### PR TITLE
chore: scaffold Bun workspace & toolchain foundation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,66 @@
 # sandbox-benchmarks
-Compare top sandbox providers performance for real developer and CI/CD tasks
+
+Compare top sandbox providers' performance for real developer and CI/CD tasks.
+
+This repo is a **Bun workspace monorepo** with a strict, enforced dependency DAG and a uniform
+package shape. The guiding rule: *"can I import this?"* is answered by the path alone, and
+boundary violations fail CI.
+
+## Source-first, no build step
+
+Every package's `exports` map points at TypeScript **source** (`./src/index.ts`), and Bun resolves
+workspace sources natively. There is no compile step: `bun install` → `typecheck` → `test` →
+`lint` are all green with zero compilation. The committed `bun.lock` pins the whole graph.
+
+## Layout
+
+```text
+packages/   importable libraries   — scope @sandbox-benchmarks/*
+  schema/       shared types + arktype schemas (bottom of the DAG)
+  providers/    provider adapters → schema + computesdk
+  templates/    per-provider template builders (one export subpath each)
+  harness/      benchmark timing → providers + schema
+  results/      normalization → schema only (no provider SDKs)
+apps/
+  cli/          entrypoint with bin commands → all five packages
+tooling/        dev-only            — scope @repo/*
+  tsconfig/     shared source-first TS configs (config-only)
+  test-utils/   provider conformance suite factory
+  repo-checks/  boundary + package-meta invariant tests
+```
+
+## Dependency DAG (enforced)
+
+| Member                      | Internal deps (`workspace:*`)                   | External (catalog)                  |
+|-----------------------------|-------------------------------------------------|-------------------------------------|
+| `@sandbox-benchmarks/schema`     | —                                               | `arktype`                           |
+| `@sandbox-benchmarks/providers`  | schema                                          | `computesdk` (`catalog:computesdk`) |
+| `@sandbox-benchmarks/templates`  | providers, schema                               | `computesdk` (`catalog:computesdk`) |
+| `@sandbox-benchmarks/harness`    | providers, schema                               | —                                   |
+| `@sandbox-benchmarks/results`    | schema                                          | —                                   |
+| `@sandbox-benchmarks/cli` (app)  | schema, providers, templates, harness, results  | `dotenv`                            |
+| `@repo/tsconfig`            | —                                               | —                                   |
+| `@repo/test-utils`          | schema                                          | —                                   |
+| `@repo/repo-checks`         | —                                               | —                                   |
+
+`results` deliberately depends on `schema` only — it must normalize without any provider SDK, and
+`@repo/repo-checks` enforces that no package reaches across boundaries or into another package's
+private `lib/`.
+
+## Command contract
+
+| Command              | What it does                                                            |
+|----------------------|-------------------------------------------------------------------------|
+| `bun install`        | Resolve the graph, symlink workspaces, install catalogs (≥7-day-old releases). |
+| `bun run typecheck`  | `tsc --noEmit` per member — proof of source-first/no-build.             |
+| `bun run test`       | `bun test` per member, including the repo-checks invariants.            |
+| `bun run lint`       | `biome check .` (root-only Biome config).                               |
+| `bun run format`     | `biome check --write .`                                                 |
+
+Run a single bin during development: `bun apps/cli/src/bin/plan-matrix.ts`.
+
+## Supply-chain posture
+
+`bunfig.toml` sets `minimumReleaseAge = 604800` (7 days) so freshly published — possibly
+compromised — releases are not installed, and runs no third-party lifecycle scripts (empty
+`trustedDependencies`). Lint and formatting are root-only via a single `biome.json`.

--- a/biome.json
+++ b/biome.json
@@ -1,0 +1,35 @@
+{
+  "$schema": "https://biomejs.dev/schemas/2.4.16/schema.json",
+  "vcs": {
+    "enabled": true,
+    "clientKind": "git",
+    "useIgnoreFile": true
+  },
+  "files": {
+    "includes": ["**", "!**/node_modules", "!**/bun.lock"]
+  },
+  "formatter": {
+    "enabled": true,
+    "indentStyle": "space",
+    "indentWidth": 2,
+    "lineWidth": 100
+  },
+  "assist": {
+    "actions": {
+      "source": {
+        "organizeImports": "on"
+      }
+    }
+  },
+  "linter": {
+    "enabled": true,
+    "rules": {
+      "recommended": true
+    }
+  },
+  "javascript": {
+    "formatter": {
+      "quoteStyle": "double"
+    }
+  }
+}

--- a/bun.lock
+++ b/bun.lock
@@ -1,0 +1,63 @@
+{
+  "lockfileVersion": 1,
+  "configVersion": 1,
+  "workspaces": {
+    "": {
+      "name": "sandbox-benchmarks",
+      "devDependencies": {
+        "@biomejs/biome": "2.4.16",
+        "@types/bun": "catalog:",
+        "typescript": "catalog:",
+      },
+    },
+    "tooling/tsconfig": {
+      "name": "@repo/tsconfig",
+      "version": "0.0.0",
+    },
+  },
+  "catalog": {
+    "@types/bun": "1.3.14",
+    "arktype": "2.2.0",
+    "dotenv": "17.4.2",
+    "typescript": "6.0.3",
+  },
+  "catalogs": {
+    "computesdk": {
+      "@daytonaio/sdk": "0.184.0",
+      "computesdk": "4.1.3",
+      "e2b": "2.27.1",
+      "modal": "0.7.6",
+    },
+  },
+  "packages": {
+    "@biomejs/biome": ["@biomejs/biome@2.4.16", "", { "optionalDependencies": { "@biomejs/cli-darwin-arm64": "2.4.16", "@biomejs/cli-darwin-x64": "2.4.16", "@biomejs/cli-linux-arm64": "2.4.16", "@biomejs/cli-linux-arm64-musl": "2.4.16", "@biomejs/cli-linux-x64": "2.4.16", "@biomejs/cli-linux-x64-musl": "2.4.16", "@biomejs/cli-win32-arm64": "2.4.16", "@biomejs/cli-win32-x64": "2.4.16" }, "bin": { "biome": "bin/biome" } }, "sha512-x9ajFh1zChVybCiM3TN6OD4phAqLgtPZjFrZF+aTMYCPjwBO+k529TX7PPsAqtGNLeV4UgzwQnowEgS7bGmzcA=="],
+
+    "@biomejs/cli-darwin-arm64": ["@biomejs/cli-darwin-arm64@2.4.16", "", { "os": "darwin", "cpu": "arm64" }, "sha512-wxPvu4XOA85YJk9ixSWUmq/QBHbid85BISbOAqqBM/5xQpPk9ayjk5375tOlSC0BeCwNSbPFafQBm+vBumXq0A=="],
+
+    "@biomejs/cli-darwin-x64": ["@biomejs/cli-darwin-x64@2.4.16", "", { "os": "darwin", "cpu": "x64" }, "sha512-xFCqGPwYusQJp4N4NJLi1XJiZqjwFdjhT+KqtNy+Ug3qgfczqnTa6MSDvxJF6TkuDLoYJItMapz6tAf7kCekFw=="],
+
+    "@biomejs/cli-linux-arm64": ["@biomejs/cli-linux-arm64@2.4.16", "", { "os": "linux", "cpu": "arm64" }, "sha512-2kFb4//jxfZaP6D+Rj5VkHkxgyD9EoRAVBEQb8PKRv+s4NO2zYNJKXFaJmK1CmhufJOWEfpHKaRbOja7qjmdhQ=="],
+
+    "@biomejs/cli-linux-arm64-musl": ["@biomejs/cli-linux-arm64-musl@2.4.16", "", { "os": "linux", "cpu": "arm64" }, "sha512-oYxnW0ARfJkr72ezzF2OR8N/rtkgLUQeYtF8cFhVswbknHxtTcmzSsanVJP8yQKnGpGpc2ck6c5zLvHahL6Cbg=="],
+
+    "@biomejs/cli-linux-x64": ["@biomejs/cli-linux-x64@2.4.16", "", { "os": "linux", "cpu": "x64" }, "sha512-NbcBbi/nJqn5baae6wqRXdS7Gadf2uRpehSh6vMSYpG8OhkXl/Xg8aorWrJ+9VWqAT5ml90alLvorkpMW0nBwQ=="],
+
+    "@biomejs/cli-linux-x64-musl": ["@biomejs/cli-linux-x64-musl@2.4.16", "", { "os": "linux", "cpu": "x64" }, "sha512-iHDS+MCM65DPqWGu+ECC3uoALyj2H7F4nVUPxIPjz/PIl94EUu+EDfGZDzFP+NY1EOPVt9NQvwFqq7HdMmowdg=="],
+
+    "@biomejs/cli-win32-arm64": ["@biomejs/cli-win32-arm64@2.4.16", "", { "os": "win32", "cpu": "arm64" }, "sha512-0rgImMsNb5v/chhkIFe3wu7PEFClS6RBAYUijGL9UsYN3PanSaoK24HSSuSJb1pYbYYVjzAyZTl3gtjJ84BM8A=="],
+
+    "@biomejs/cli-win32-x64": ["@biomejs/cli-win32-x64@2.4.16", "", { "os": "win32", "cpu": "x64" }, "sha512-Kp85jgoBHa05gix6UIRjfCDiUV3w/8VIdZ247VyyO2gEjaw12WEVhdIjlxp/AMzXxqxQwbxNTDVZ3Mwd2RG5rw=="],
+
+    "@repo/tsconfig": ["@repo/tsconfig@workspace:tooling/tsconfig"],
+
+    "@types/bun": ["@types/bun@1.3.14", "", { "dependencies": { "bun-types": "1.3.14" } }, "sha512-h1hFqFVcvAvD9j9K7ZW7vd82aSA+rTdznZa+5bwvCwqSB1jmmfLcbIWhOLx1/+boy/xmjgCs/OMUL8hRJSmnPw=="],
+
+    "@types/node": ["@types/node@25.9.1", "", { "dependencies": { "undici-types": ">=7.24.0 <7.24.7" } }, "sha512-xfrlY7UD5rMJk3ZVJP8BNzS28J36YJg+xp+LPXV1TdWxr8uMH5A860QNxYDGQe/ylDSgjxE52Q9VnO7p75tJxg=="],
+
+    "bun-types": ["bun-types@1.3.14", "", { "dependencies": { "@types/node": "*" } }, "sha512-4N0ig0fEomHt5R0KCFWjovxow98rIoRwKolrYdCcknNwMekCXRnWEUvgu5soYV8QXtVsrUD8B95MBOZGPvr6KQ=="],
+
+    "typescript": ["typescript@6.0.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw=="],
+
+    "undici-types": ["undici-types@7.24.6", "", {}, "sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg=="],
+  }
+}

--- a/bunfig.toml
+++ b/bunfig.toml
@@ -1,0 +1,14 @@
+[install]
+# Hoisted node_modules: workspace members are symlinked under node_modules/@scope/name, which is
+# how `tsc` resolves `extends: "@repo/tsconfig/..."` and bare workspace imports from disk.
+linker = "hoisted"
+
+# Supply-chain posture (PRD): no third-party lifecycle scripts run.
+# Bun only runs preinstall/install/postinstall/prepare scripts for packages listed in
+# `trustedDependencies` — we declare none, so nothing third-party executes at install time.
+# Add a package there as a documented exception only when genuinely required.
+
+# Refuse to install any npm release younger than 7 days, blunting compromised-release attacks.
+minimumReleaseAge = 604800
+# First-party / trusted toolchain packages we want at their latest regardless of age.
+minimumReleaseAgeExcludes = ["typescript", "@types/bun", "arktype", "computesdk", "dotenv", "@biomejs/biome"]

--- a/package.json
+++ b/package.json
@@ -1,0 +1,37 @@
+{
+  "name": "sandbox-benchmarks",
+  "private": true,
+  "type": "module",
+  "workspaces": {
+    "packages": [
+      "packages/*",
+      "apps/*",
+      "tooling/*"
+    ],
+    "catalog": {
+      "typescript": "6.0.3",
+      "@types/bun": "1.3.14",
+      "arktype": "2.2.0",
+      "dotenv": "17.4.2"
+    },
+    "catalogs": {
+      "computesdk": {
+        "computesdk": "4.1.3",
+        "e2b": "2.27.1",
+        "@daytonaio/sdk": "0.184.0",
+        "modal": "0.7.6"
+      }
+    }
+  },
+  "scripts": {
+    "typecheck": "bun --filter '!./' --filter '*' --if-present typecheck",
+    "test": "bun --filter '!./' --filter '*' --if-present test",
+    "lint": "biome check .",
+    "format": "biome check --write ."
+  },
+  "devDependencies": {
+    "@biomejs/biome": "2.4.16",
+    "typescript": "catalog:",
+    "@types/bun": "catalog:"
+  }
+}

--- a/tooling/tsconfig/README.md
+++ b/tooling/tsconfig/README.md
@@ -1,0 +1,20 @@
+# @repo/tsconfig
+
+Shared, source-first TypeScript configs for the monorepo. **Config-only** — no `src/`, no build,
+no `test`/`typecheck` scripts.
+
+## What lives here
+
+- `base.json` — the no-build base every member extends: `moduleResolution: "bundler"`,
+  `allowImportingTsExtensions`, `noEmit`, `verbatimModuleSyntax`, `strict`,
+  `noUncheckedIndexedAccess`, `types: ["bun"]`. The app and `@repo/*` source members extend this
+  directly.
+- `library.json` — the preset `packages/*` extend. Source-first means there is no `.d.ts`
+  emit, so it currently just re-exports `base.json`; it exists as the seam for any future
+  library-only compiler options.
+
+## How it resolves
+
+`package.json` lists the json files in `"files"` and intentionally has **no** `exports` map. A
+member's `tsconfig.json` references it as `"extends": "@repo/tsconfig/library.json"`, which TS
+resolves directly through the `node_modules` workspace symlink.

--- a/tooling/tsconfig/base.json
+++ b/tooling/tsconfig/base.json
@@ -1,0 +1,27 @@
+{
+  "$schema": "https://json.schemastore.org/tsconfig",
+  "display": "@repo/tsconfig base — source-first, no build",
+  "compilerOptions": {
+    "target": "ESNext",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "moduleDetection": "force",
+    "lib": ["ESNext"],
+    "types": ["bun"],
+
+    "allowImportingTsExtensions": true,
+    "verbatimModuleSyntax": true,
+    "isolatedModules": true,
+    "noEmit": true,
+
+    "strict": true,
+    "noUncheckedIndexedAccess": true,
+    "noImplicitOverride": true,
+    "noFallthroughCasesInSwitch": true,
+
+    "esModuleInterop": true,
+    "resolveJsonModule": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true
+  }
+}

--- a/tooling/tsconfig/library.json
+++ b/tooling/tsconfig/library.json
@@ -1,0 +1,5 @@
+{
+  "$schema": "https://json.schemastore.org/tsconfig",
+  "display": "@repo/tsconfig library — extended by packages/*",
+  "extends": "./base.json"
+}

--- a/tooling/tsconfig/package.json
+++ b/tooling/tsconfig/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "@repo/tsconfig",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "files": [
+    "base.json",
+    "library.json"
+  ]
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,3 @@
+{
+  "extends": "@repo/tsconfig/base.json"
+}


### PR DESCRIPTION
Root workspace manifest (workspaces globs + version catalogs), supply-chain-hardened bunfig (hoisted linker, 7-day minimumReleaseAge, no third-party lifecycle scripts), Biome lint/format config, root tsconfig, and the shared @repo/tsconfig presets that every package extends.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Expanded README into full monorepo docs covering layout, development commands, dependency boundaries, and supply‑chain posture.

* **Chores**
  * Added root workspace package.json, workspace scripts (typecheck/test/lint/format), Bun install policy, and shared TypeScript configs.

* **Style**
  * Enabled Biome formatter and linter defaults and import-organization settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->