### PR TITLE
feat(schema): core arktype domain schema

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -10,6 +10,18 @@
         "typescript": "catalog:",
       },
     },
+    "packages/schema": {
+      "name": "@sandbox-benchmarks/schema",
+      "version": "0.0.0",
+      "dependencies": {
+        "arktype": "catalog:",
+      },
+      "devDependencies": {
+        "@repo/tsconfig": "workspace:*",
+        "@types/bun": "catalog:",
+        "typescript": "catalog:",
+      },
+    },
     "tooling/tsconfig": {
       "name": "@repo/tsconfig",
       "version": "0.0.0",
@@ -30,6 +42,10 @@
     },
   },
   "packages": {
+    "@ark/schema": ["@ark/schema@0.56.0", "", { "dependencies": { "@ark/util": "0.56.0" } }, "sha512-ECg3hox/6Z/nLajxXqNhgPtNdHWC9zNsDyskwO28WinoFEnWow4IsERNz9AnXRhTZJnYIlAJ4uGn3nlLk65vZA=="],
+
+    "@ark/util": ["@ark/util@0.56.0", "", {}, "sha512-BghfRC8b9pNs3vBoDJhcta0/c1J1rsoS1+HgVUreMFPdhz/CRAKReAu57YEllNaSy98rWAdY1gE+gFup7OXpgA=="],
+
     "@biomejs/biome": ["@biomejs/biome@2.4.16", "", { "optionalDependencies": { "@biomejs/cli-darwin-arm64": "2.4.16", "@biomejs/cli-darwin-x64": "2.4.16", "@biomejs/cli-linux-arm64": "2.4.16", "@biomejs/cli-linux-arm64-musl": "2.4.16", "@biomejs/cli-linux-x64": "2.4.16", "@biomejs/cli-linux-x64-musl": "2.4.16", "@biomejs/cli-win32-arm64": "2.4.16", "@biomejs/cli-win32-x64": "2.4.16" }, "bin": { "biome": "bin/biome" } }, "sha512-x9ajFh1zChVybCiM3TN6OD4phAqLgtPZjFrZF+aTMYCPjwBO+k529TX7PPsAqtGNLeV4UgzwQnowEgS7bGmzcA=="],
 
     "@biomejs/cli-darwin-arm64": ["@biomejs/cli-darwin-arm64@2.4.16", "", { "os": "darwin", "cpu": "arm64" }, "sha512-wxPvu4XOA85YJk9ixSWUmq/QBHbid85BISbOAqqBM/5xQpPk9ayjk5375tOlSC0BeCwNSbPFafQBm+vBumXq0A=="],
@@ -50,9 +66,15 @@
 
     "@repo/tsconfig": ["@repo/tsconfig@workspace:tooling/tsconfig"],
 
+    "@sandbox-benchmarks/schema": ["@sandbox-benchmarks/schema@workspace:packages/schema"],
+
     "@types/bun": ["@types/bun@1.3.14", "", { "dependencies": { "bun-types": "1.3.14" } }, "sha512-h1hFqFVcvAvD9j9K7ZW7vd82aSA+rTdznZa+5bwvCwqSB1jmmfLcbIWhOLx1/+boy/xmjgCs/OMUL8hRJSmnPw=="],
 
     "@types/node": ["@types/node@25.9.1", "", { "dependencies": { "undici-types": ">=7.24.0 <7.24.7" } }, "sha512-xfrlY7UD5rMJk3ZVJP8BNzS28J36YJg+xp+LPXV1TdWxr8uMH5A860QNxYDGQe/ylDSgjxE52Q9VnO7p75tJxg=="],
+
+    "arkregex": ["arkregex@0.0.5", "", { "dependencies": { "@ark/util": "0.56.0" } }, "sha512-ncYjBdLlh5/QnVsAA8De16Tc9EqmYM7y/WU9j+236KcyYNUXogpz3sC4ATIZYzzLxwI+0sEOaQLEmLmRleaEXw=="],
+
+    "arktype": ["arktype@2.2.0", "", { "dependencies": { "@ark/schema": "0.56.0", "@ark/util": "0.56.0", "arkregex": "0.0.5" } }, "sha512-t54MZ7ti5BhOEvzEkgKnWvqj+UbDfWig+DHr5I34xatymPusKLS0lQpNJd8M6DzmIto2QGszHfNKoFIT8tMCZQ=="],
 
     "bun-types": ["bun-types@1.3.14", "", { "dependencies": { "@types/node": "*" } }, "sha512-4N0ig0fEomHt5R0KCFWjovxow98rIoRwKolrYdCcknNwMekCXRnWEUvgu5soYV8QXtVsrUD8B95MBOZGPvr6KQ=="],
 

--- a/packages/schema/README.md
+++ b/packages/schema/README.md
@@ -1,0 +1,13 @@
+# @sandbox-benchmarks/schema
+
+**Role:** the bottom of the dependency DAG — shared types and runtime schemas every other member
+builds on.
+
+**Public surface (`.`):** `Capability` / `capabilities`, `CapabilityFlags`, `ProviderDescriptor`,
+`RawRun`, `RunDocument`, `parseRawRun()`.
+
+**Depends on:** `arktype` only (no internal deps).
+
+**What lives here:** the canonical type vocabulary for providers, raw runs, and normalized run
+documents, plus arktype runtime validators. Private validation internals live in `src/lib/` and
+must never be imported across a package boundary — import from `@sandbox-benchmarks/schema` instead.

--- a/packages/schema/package.json
+++ b/packages/schema/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "@sandbox-benchmarks/schema",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "exports": {
+    ".": "./src/index.ts"
+  },
+  "scripts": {
+    "test": "bun test",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "arktype": "catalog:"
+  },
+  "devDependencies": {
+    "@repo/tsconfig": "workspace:*",
+    "typescript": "catalog:",
+    "@types/bun": "catalog:"
+  }
+}

--- a/packages/schema/src/index.test.ts
+++ b/packages/schema/src/index.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from "bun:test";
+import { type CapabilityFlags, capabilities, parseRawRun } from "./index.ts";
+
+describe("@sandbox-benchmarks/schema", () => {
+  it("exposes the capability vocabulary", () => {
+    expect(capabilities).toContain("exec");
+    const flags: CapabilityFlags = {
+      spawn: true,
+      exec: true,
+      filesystem: false,
+      snapshot: false,
+    };
+    expect(flags.exec).toBe(true);
+  });
+
+  it("parses a valid raw run via arktype", () => {
+    const run = parseRawRun({ provider: "e2b", operation: "spawn", durationMs: 12 });
+    expect(run.provider).toBe("e2b");
+  });
+
+  it("rejects an invalid raw run", () => {
+    expect(() => parseRawRun({ provider: "e2b", operation: "spawn", durationMs: -1 })).toThrow();
+    // durationMs must be strictly positive — a 0ms run is a timing error, not a real result.
+    expect(() => parseRawRun({ provider: "e2b", operation: "spawn", durationMs: 0 })).toThrow();
+  });
+});

--- a/packages/schema/src/index.ts
+++ b/packages/schema/src/index.ts
@@ -1,0 +1,45 @@
+// Public surface of @sandbox-benchmarks/schema — the bottom of the dependency DAG.
+// Depends only on arktype. Every other package imports its shared types from here.
+import { type } from "arktype";
+import { rawRunSchema } from "./lib/internal.ts";
+
+/** The capabilities a sandbox provider may support. Stub set — expanded as providers land. */
+export const capabilities = ["spawn", "exec", "filesystem", "snapshot"] as const;
+export type Capability = (typeof capabilities)[number];
+
+/** Which capabilities a given provider supports. */
+export type CapabilityFlags = Record<Capability, boolean>;
+
+/** Static description of a sandbox provider. */
+export interface ProviderDescriptor {
+  /** Stable identifier, e.g. "e2b", "daytona", "modal". */
+  id: string;
+  /** Human-readable name. */
+  displayName: string;
+  /** Capabilities the provider supports. */
+  capabilities: CapabilityFlags;
+}
+
+/**
+ * A single raw, un-normalized benchmark run as emitted by the harness.
+ * Inferred from {@link rawRunSchema} so the runtime schema stays the single source of truth.
+ */
+export type RawRun = typeof rawRunSchema.infer;
+
+/** A normalized run document, as produced by @sandbox-benchmarks/results. */
+export interface RunDocument {
+  provider: string;
+  operation: string;
+  durationMs: number;
+  /** ISO-8601 timestamp the document was normalized at. */
+  normalizedAt: string;
+}
+
+/** Validate an unknown value as a {@link RawRun} using the arktype schema. */
+export function parseRawRun(value: unknown): RawRun {
+  const out = rawRunSchema(value);
+  if (out instanceof type.errors) {
+    throw new Error(`invalid RawRun: ${out.summary}`);
+  }
+  return out;
+}

--- a/packages/schema/src/lib/internal.ts
+++ b/packages/schema/src/lib/internal.ts
@@ -1,0 +1,15 @@
+// Private implementation detail of @sandbox-benchmarks/schema.
+// Never import this module across a package boundary — go through the package's public index.
+import { type } from "arktype";
+
+/**
+ * Runtime schema for a single raw benchmark run, validated with arktype.
+ * Stub shape — real fields land in the schema implementation pass.
+ */
+export const rawRunSchema = type({
+  provider: "string",
+  operation: "string",
+  // A real benchmarked operation always takes measurable wall-clock time; a 0ms (or negative)
+  // duration is a timing error or dropped observation, so reject it at the boundary.
+  durationMs: "number>0",
+});

--- a/packages/schema/tsconfig.json
+++ b/packages/schema/tsconfig.json
@@ -1,0 +1,4 @@
+{
+  "extends": "@repo/tsconfig/library.json",
+  "include": ["src"]
+}


### PR DESCRIPTION
Typed domain model for the benchmark suite built on arktype runtime schemas with inferred static types. The foundational data layer every other workspace package imports; depends only on arktype. Package scope is @sandbox-benchmarks/*.