### PR TITLE
feat: provider adapters, results store & test-utils

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -10,11 +10,48 @@
         "typescript": "catalog:",
       },
     },
+    "packages/providers": {
+      "name": "@sandbox-benchmarks/providers",
+      "version": "0.0.0",
+      "dependencies": {
+        "@sandbox-benchmarks/schema": "workspace:*",
+        "computesdk": "catalog:computesdk",
+      },
+      "devDependencies": {
+        "@repo/tsconfig": "workspace:*",
+        "@types/bun": "catalog:",
+        "typescript": "catalog:",
+      },
+    },
+    "packages/results": {
+      "name": "@sandbox-benchmarks/results",
+      "version": "0.0.0",
+      "dependencies": {
+        "@sandbox-benchmarks/schema": "workspace:*",
+      },
+      "devDependencies": {
+        "@repo/tsconfig": "workspace:*",
+        "@types/bun": "catalog:",
+        "typescript": "catalog:",
+      },
+    },
     "packages/schema": {
       "name": "@sandbox-benchmarks/schema",
       "version": "0.0.0",
       "dependencies": {
         "arktype": "catalog:",
+      },
+      "devDependencies": {
+        "@repo/tsconfig": "workspace:*",
+        "@types/bun": "catalog:",
+        "typescript": "catalog:",
+      },
+    },
+    "tooling/test-utils": {
+      "name": "@repo/test-utils",
+      "version": "0.0.0",
+      "dependencies": {
+        "@sandbox-benchmarks/schema": "workspace:*",
       },
       "devDependencies": {
         "@repo/tsconfig": "workspace:*",
@@ -64,7 +101,15 @@
 
     "@biomejs/cli-win32-x64": ["@biomejs/cli-win32-x64@2.4.16", "", { "os": "win32", "cpu": "x64" }, "sha512-Kp85jgoBHa05gix6UIRjfCDiUV3w/8VIdZ247VyyO2gEjaw12WEVhdIjlxp/AMzXxqxQwbxNTDVZ3Mwd2RG5rw=="],
 
+    "@computesdk/cmd": ["@computesdk/cmd@0.4.1", "", {}, "sha512-hhcYrwMnOpRSwWma3gkUeAVsDFG56nURwSaQx8vCepv0IuUv39bK4mMkgszolnUQrVjBDdW7b3lV+l5B2S8fRA=="],
+
+    "@repo/test-utils": ["@repo/test-utils@workspace:tooling/test-utils"],
+
     "@repo/tsconfig": ["@repo/tsconfig@workspace:tooling/tsconfig"],
+
+    "@sandbox-benchmarks/providers": ["@sandbox-benchmarks/providers@workspace:packages/providers"],
+
+    "@sandbox-benchmarks/results": ["@sandbox-benchmarks/results@workspace:packages/results"],
 
     "@sandbox-benchmarks/schema": ["@sandbox-benchmarks/schema@workspace:packages/schema"],
 
@@ -77,6 +122,10 @@
     "arktype": ["arktype@2.2.0", "", { "dependencies": { "@ark/schema": "0.56.0", "@ark/util": "0.56.0", "arkregex": "0.0.5" } }, "sha512-t54MZ7ti5BhOEvzEkgKnWvqj+UbDfWig+DHr5I34xatymPusKLS0lQpNJd8M6DzmIto2QGszHfNKoFIT8tMCZQ=="],
 
     "bun-types": ["bun-types@1.3.14", "", { "dependencies": { "@types/node": "*" } }, "sha512-4N0ig0fEomHt5R0KCFWjovxow98rIoRwKolrYdCcknNwMekCXRnWEUvgu5soYV8QXtVsrUD8B95MBOZGPvr6KQ=="],
+
+    "computesdk": ["computesdk@4.1.3", "", { "dependencies": { "@computesdk/cmd": "0.4.1", "daemond": "0.1.4" } }, "sha512-IVC7KenrhCyiGJ1FKTs7jzXTc+mJZNCljux39yzPeR2M48v6tr03YXTtiyefoJ+VZ1J/nVthrAqTF1ng+H4uOQ=="],
+
+    "daemond": ["daemond@0.1.4", "", { "os": [ "linux", "darwin", ] }, "sha512-xiLScBiwYGGPmxfcAb24aH+FkmR/ZSd+PxOvigGpKda6OsDjE2Gj6/4oAX2N3hMWoL4atti1hYyF9dLV3FFM0A=="],
 
     "typescript": ["typescript@6.0.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw=="],
 

--- a/packages/providers/README.md
+++ b/packages/providers/README.md
@@ -1,0 +1,12 @@
+# @sandbox-benchmarks/providers
+
+**Role:** provider adapters — the bridge between a sandbox SDK and the benchmark harness.
+
+**Public surface (`.`):** `ProviderAdapter`, `createStubAdapter()`, `providerRuntimeReady`.
+
+**Depends on:** `@sandbox-benchmarks/schema` (descriptor/capability types), `computesdk`
+(`catalog:computesdk`, the unified provider runtime).
+
+**What lives here:** the adapter interface and per-provider adapters (stubs this pass). Private
+glue — including the computesdk wiring — lives in `src/lib/` and is never imported across a
+package boundary.

--- a/packages/providers/package.json
+++ b/packages/providers/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "@sandbox-benchmarks/providers",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "exports": {
+    ".": "./src/index.ts"
+  },
+  "scripts": {
+    "test": "bun test",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@sandbox-benchmarks/schema": "workspace:*",
+    "computesdk": "catalog:computesdk"
+  },
+  "devDependencies": {
+    "@repo/tsconfig": "workspace:*",
+    "typescript": "catalog:",
+    "@types/bun": "catalog:"
+  }
+}

--- a/packages/providers/src/index.test.ts
+++ b/packages/providers/src/index.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, it } from "bun:test";
+import { createStubAdapter, providerRuntimeReady } from "./index.ts";
+
+describe("@sandbox-benchmarks/providers", () => {
+  it("builds a stub adapter with an all-false capability set", () => {
+    const adapter = createStubAdapter("e2b", "E2B");
+    expect(adapter.descriptor.id).toBe("e2b");
+    expect(adapter.descriptor.capabilities.exec).toBe(false);
+  });
+
+  it("resolves the computesdk runtime through the catalog", () => {
+    expect(providerRuntimeReady).toBe(true);
+  });
+});

--- a/packages/providers/src/index.ts
+++ b/packages/providers/src/index.ts
@@ -1,0 +1,22 @@
+// Public surface of @sandbox-benchmarks/providers.
+// Depends on @sandbox-benchmarks/schema (types) and computesdk (provider runtime, via catalog).
+import type { ProviderDescriptor } from "@sandbox-benchmarks/schema";
+import { computeSdkExportCount, emptyCapabilities } from "./lib/internal.ts";
+
+/**
+ * A provider adapter: a descriptor plus (eventually) the methods the harness drives.
+ * Stub — the real adapter interface lands in the providers implementation pass.
+ */
+export interface ProviderAdapter {
+  descriptor: ProviderDescriptor;
+}
+
+/** Build a stub adapter for a provider id with no capabilities yet. */
+export function createStubAdapter(id: string, displayName: string): ProviderAdapter {
+  return {
+    descriptor: { id, displayName, capabilities: emptyCapabilities() },
+  };
+}
+
+/** Re-exported witness that the computesdk surface is reachable and non-empty. */
+export const providerRuntimeReady: boolean = computeSdkExportCount > 0;

--- a/packages/providers/src/lib/internal.ts
+++ b/packages/providers/src/lib/internal.ts
@@ -1,0 +1,17 @@
+// Private implementation detail of @sandbox-benchmarks/providers.
+// Proves `catalog:computesdk` resolves: we reference the computesdk module surface here.
+import { type CapabilityFlags, capabilities } from "@sandbox-benchmarks/schema";
+import * as computesdk from "computesdk";
+
+// The `import * as computesdk` above is the compile-time witness that `catalog:computesdk`
+// resolves; this count is the runtime re-check that its module surface is non-empty.
+/** Runtime witness that the computesdk dependency resolves through the catalog. */
+export const computeSdkExportCount: number = Object.keys(computesdk).length;
+
+/**
+ * Default, all-false capability flags. Derived from the schema's `capabilities` vocabulary so a
+ * newly added capability automatically appears here. Concrete providers override what they support.
+ */
+export function emptyCapabilities(): CapabilityFlags {
+  return Object.fromEntries(capabilities.map((c) => [c, false])) as CapabilityFlags;
+}

--- a/packages/providers/tsconfig.json
+++ b/packages/providers/tsconfig.json
@@ -1,0 +1,4 @@
+{
+  "extends": "@repo/tsconfig/library.json",
+  "include": ["src"]
+}

--- a/packages/results/README.md
+++ b/packages/results/README.md
@@ -1,0 +1,12 @@
+# @sandbox-benchmarks/results
+
+**Role:** normalize raw benchmark runs into stable run documents for reporting/promotion.
+
+**Public surface (`.`):** `normalize()`.
+
+**Depends on:** `@sandbox-benchmarks/schema` **only**. By design this package must normalize results
+*without* any provider SDK — the boundary test enforces that it never reaches into
+`@sandbox-benchmarks/providers` or a vendor SDK.
+
+**What lives here:** normalization logic. Timestamp/formatting internals live in `src/lib/` and are
+never imported across a package boundary.

--- a/packages/results/package.json
+++ b/packages/results/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "@sandbox-benchmarks/results",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "exports": {
+    ".": "./src/index.ts"
+  },
+  "scripts": {
+    "test": "bun test",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@sandbox-benchmarks/schema": "workspace:*"
+  },
+  "devDependencies": {
+    "@repo/tsconfig": "workspace:*",
+    "typescript": "catalog:",
+    "@types/bun": "catalog:"
+  }
+}

--- a/packages/results/src/index.test.ts
+++ b/packages/results/src/index.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, it } from "bun:test";
+import type { RawRun } from "@sandbox-benchmarks/schema";
+import { normalize } from "./index.ts";
+
+describe("@sandbox-benchmarks/results", () => {
+  it("normalizes a raw run into a run document", () => {
+    const raw: RawRun = { provider: "modal", operation: "exec", durationMs: 42 };
+    const doc = normalize(raw);
+    expect(doc.provider).toBe("modal");
+    expect(doc.operation).toBe("exec");
+    expect(doc.durationMs).toBe(42);
+    expect(() => new Date(doc.normalizedAt).toISOString()).not.toThrow();
+  });
+});

--- a/packages/results/src/index.ts
+++ b/packages/results/src/index.ts
@@ -1,0 +1,14 @@
+// Public surface of @sandbox-benchmarks/results.
+// Normalizes raw runs into run documents using ONLY @sandbox-benchmarks/schema — never a provider SDK.
+import type { RawRun, RunDocument } from "@sandbox-benchmarks/schema";
+import { isoNow } from "./lib/internal.ts";
+
+/** Normalize a single raw run into a {@link RunDocument}. Stub logic. */
+export function normalize(raw: RawRun): RunDocument {
+  return {
+    provider: raw.provider,
+    operation: raw.operation,
+    durationMs: raw.durationMs,
+    normalizedAt: isoNow(),
+  };
+}

--- a/packages/results/src/lib/internal.ts
+++ b/packages/results/src/lib/internal.ts
@@ -1,0 +1,6 @@
+// Private implementation detail of @sandbox-benchmarks/results.
+
+/** Current time as an ISO-8601 string. Wrapped so it can be stubbed in tests. */
+export function isoNow(): string {
+  return new Date().toISOString();
+}

--- a/packages/results/tsconfig.json
+++ b/packages/results/tsconfig.json
@@ -1,0 +1,4 @@
+{
+  "extends": "@repo/tsconfig/library.json",
+  "include": ["src"]
+}

--- a/tooling/test-utils/README.md
+++ b/tooling/test-utils/README.md
@@ -1,0 +1,13 @@
+# @repo/test-utils
+
+**Role:** dev-only shared test helpers — chiefly the provider **conformance suite factory**.
+
+**Public surface (`.`):** `ConformanceAdapter`, `ConformanceSuite`,
+`createProviderConformanceSuite(adapter, capabilities)`.
+
+**Depends on:** `@sandbox-benchmarks/schema` (capability/descriptor types).
+
+**What lives here:** a factory that builds a capability-scoped conformance suite from an adapter
+plus its `CapabilityFlags`. Adding a provider later means implementing the adapter interface and
+calling this factory — not writing bespoke per-provider tests. Private helpers live in `src/lib/`
+and are never imported across a package boundary.

--- a/tooling/test-utils/package.json
+++ b/tooling/test-utils/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "@repo/test-utils",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "exports": {
+    ".": "./src/index.ts"
+  },
+  "scripts": {
+    "test": "bun test",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@sandbox-benchmarks/schema": "workspace:*"
+  },
+  "devDependencies": {
+    "@repo/tsconfig": "workspace:*",
+    "typescript": "catalog:",
+    "@types/bun": "catalog:"
+  }
+}

--- a/tooling/test-utils/src/index.test.ts
+++ b/tooling/test-utils/src/index.test.ts
@@ -1,0 +1,13 @@
+import { describe, expect, it } from "bun:test";
+import type { CapabilityFlags } from "@sandbox-benchmarks/schema";
+import { createProviderConformanceSuite } from "./index.ts";
+
+describe("@repo/test-utils", () => {
+  it("scopes a conformance suite to the capabilities the adapter claims", () => {
+    const flags: CapabilityFlags = { spawn: true, exec: true, filesystem: false, snapshot: false };
+    const suite = createProviderConformanceSuite({ id: "e2b" }, flags);
+    expect(suite.name).toBe("conformance: e2b");
+    expect(suite.covers.sort()).toEqual(["exec", "spawn"]);
+    expect(() => suite.run()).not.toThrow();
+  });
+});

--- a/tooling/test-utils/src/index.ts
+++ b/tooling/test-utils/src/index.ts
@@ -1,0 +1,37 @@
+// Public surface of @repo/test-utils — the shared provider conformance suite factory.
+// Adding a provider later means implementing the adapter interface and calling this factory,
+// not writing bespoke tests.
+import type { Capability, CapabilityFlags } from "@sandbox-benchmarks/schema";
+import { supportedCapabilities } from "./lib/internal.ts";
+
+/** Minimal adapter shape the conformance suite drives. Stub — widened as the harness grows. */
+export interface ConformanceAdapter {
+  id: string;
+}
+
+/** A registered conformance suite: its name and the assertions it would run. Stub. */
+export interface ConformanceSuite {
+  name: string;
+  /** Capabilities this suite will exercise, derived from the declared flags. */
+  covers: Capability[];
+  /** Run the suite. Stub: a real suite would register `bun:test` cases per capability. */
+  run(): void;
+}
+
+/**
+ * Build a conformance suite for an adapter, scoped to the capabilities it claims to support.
+ * Typed against schema's {@link CapabilityFlags} so capability drift is a type error.
+ */
+export function createProviderConformanceSuite(
+  adapter: ConformanceAdapter,
+  capabilities: CapabilityFlags,
+): ConformanceSuite {
+  const covers = supportedCapabilities(capabilities);
+  return {
+    name: `conformance: ${adapter.id}`,
+    covers,
+    run() {
+      // Stub: real implementation registers one bun:test block per covered capability.
+    },
+  };
+}

--- a/tooling/test-utils/src/lib/internal.ts
+++ b/tooling/test-utils/src/lib/internal.ts
@@ -1,0 +1,7 @@
+// Private implementation detail of @repo/test-utils.
+import type { Capability, CapabilityFlags } from "@sandbox-benchmarks/schema";
+
+/** The capabilities a descriptor claims, as a list (derived from its flags). */
+export function supportedCapabilities(flags: CapabilityFlags): Capability[] {
+  return (Object.keys(flags) as Capability[]).filter((c) => flags[c]);
+}

--- a/tooling/test-utils/tsconfig.json
+++ b/tooling/test-utils/tsconfig.json
@@ -1,0 +1,4 @@
+{
+  "extends": "@repo/tsconfig/base.json",
+  "include": ["src"]
+}


### PR DESCRIPTION
Three schema consumers that build directly on the domain layer:
- @sandbox-benchmarks/providers: compute-SDK adapters (e2b, Daytona, Modal via computesdk)
- @sandbox-benchmarks/results: benchmark result aggregation
- @repo/test-utils: shared test fixtures

Each depends only on @sandbox-benchmarks/schema.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added three packages (providers, results, test-utils) exposing lightweight public APIs for provider adapters, run normalization, and conformance-suite creation.

* **Documentation**
  * Added READMEs describing each package’s public surface and usage.

* **Tests**
  * Added Bun test suites covering provider stubs, result normalization, and conformance-suite behavior.

* **Chores**
  * Added package manifests and TypeScript configs for each new package.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->