### PR TITLE
feat: templates & harness orchestration layer

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -10,6 +10,19 @@
         "typescript": "catalog:",
       },
     },
+    "packages/harness": {
+      "name": "@sandbox-benchmarks/harness",
+      "version": "0.0.0",
+      "dependencies": {
+        "@sandbox-benchmarks/providers": "workspace:*",
+        "@sandbox-benchmarks/schema": "workspace:*",
+      },
+      "devDependencies": {
+        "@repo/tsconfig": "workspace:*",
+        "@types/bun": "catalog:",
+        "typescript": "catalog:",
+      },
+    },
     "packages/providers": {
       "name": "@sandbox-benchmarks/providers",
       "version": "0.0.0",
@@ -40,6 +53,20 @@
       "version": "0.0.0",
       "dependencies": {
         "arktype": "catalog:",
+      },
+      "devDependencies": {
+        "@repo/tsconfig": "workspace:*",
+        "@types/bun": "catalog:",
+        "typescript": "catalog:",
+      },
+    },
+    "packages/templates": {
+      "name": "@sandbox-benchmarks/templates",
+      "version": "0.0.0",
+      "dependencies": {
+        "@sandbox-benchmarks/providers": "workspace:*",
+        "@sandbox-benchmarks/schema": "workspace:*",
+        "computesdk": "catalog:computesdk",
       },
       "devDependencies": {
         "@repo/tsconfig": "workspace:*",
@@ -107,11 +134,15 @@
 
     "@repo/tsconfig": ["@repo/tsconfig@workspace:tooling/tsconfig"],
 
+    "@sandbox-benchmarks/harness": ["@sandbox-benchmarks/harness@workspace:packages/harness"],
+
     "@sandbox-benchmarks/providers": ["@sandbox-benchmarks/providers@workspace:packages/providers"],
 
     "@sandbox-benchmarks/results": ["@sandbox-benchmarks/results@workspace:packages/results"],
 
     "@sandbox-benchmarks/schema": ["@sandbox-benchmarks/schema@workspace:packages/schema"],
+
+    "@sandbox-benchmarks/templates": ["@sandbox-benchmarks/templates@workspace:packages/templates"],
 
     "@types/bun": ["@types/bun@1.3.14", "", { "dependencies": { "bun-types": "1.3.14" } }, "sha512-h1hFqFVcvAvD9j9K7ZW7vd82aSA+rTdznZa+5bwvCwqSB1jmmfLcbIWhOLx1/+boy/xmjgCs/OMUL8hRJSmnPw=="],
 

--- a/packages/harness/README.md
+++ b/packages/harness/README.md
@@ -1,0 +1,11 @@
+# @sandbox-benchmarks/harness
+
+**Role:** the benchmark harness — drives a provider adapter through operations and emits raw,
+un-normalized timing runs.
+
+**Public surface (`.`):** `timeOperation()`.
+
+**Depends on:** `@sandbox-benchmarks/providers` (adapter type), `@sandbox-benchmarks/schema` (`RawRun`).
+
+**What lives here:** operation timing and (later) suite orchestration. The clock and other timing
+internals live in `src/lib/` and are never imported across a package boundary.

--- a/packages/harness/package.json
+++ b/packages/harness/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "@sandbox-benchmarks/harness",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "exports": {
+    ".": "./src/index.ts"
+  },
+  "scripts": {
+    "test": "bun test",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@sandbox-benchmarks/providers": "workspace:*",
+    "@sandbox-benchmarks/schema": "workspace:*"
+  },
+  "devDependencies": {
+    "@repo/tsconfig": "workspace:*",
+    "typescript": "catalog:",
+    "@types/bun": "catalog:"
+  }
+}

--- a/packages/harness/src/index.test.ts
+++ b/packages/harness/src/index.test.ts
@@ -1,0 +1,13 @@
+import { describe, expect, it } from "bun:test";
+import { createStubAdapter } from "@sandbox-benchmarks/providers";
+import { timeOperation } from "./index.ts";
+
+describe("@sandbox-benchmarks/harness", () => {
+  it("times an operation and emits a raw run for the adapter", async () => {
+    const adapter = createStubAdapter("e2b", "E2B");
+    const run = await timeOperation(adapter, "spawn", () => {});
+    expect(run.provider).toBe("e2b");
+    expect(run.operation).toBe("spawn");
+    expect(run.durationMs).toBeGreaterThan(0);
+  });
+});

--- a/packages/harness/src/index.ts
+++ b/packages/harness/src/index.ts
@@ -1,0 +1,23 @@
+// Public surface of @sandbox-benchmarks/harness — drives an adapter and emits raw runs.
+import type { ProviderAdapter } from "@sandbox-benchmarks/providers";
+import type { RawRun } from "@sandbox-benchmarks/schema";
+import { now } from "./lib/internal.ts";
+
+/** Time a single operation against an adapter, producing a {@link RawRun}. Stub. */
+export async function timeOperation(
+  adapter: ProviderAdapter,
+  operation: string,
+  run: () => Promise<void> | void,
+): Promise<RawRun> {
+  const start = now();
+  // NOTE: a rejected `run` currently propagates and no sample is recorded. Capturing failed-run
+  // duration as an error sample lands when `rawRunSchema` grows an error shape.
+  await run();
+  return {
+    provider: adapter.descriptor.id,
+    operation,
+    // Floor to a strictly-positive value: `rawRunSchema` requires `durationMs > 0`, and a
+    // synchronous no-op can observe two equal `now()` readings (a 0 delta).
+    durationMs: Math.max(now() - start, Number.EPSILON),
+  };
+}

--- a/packages/harness/src/lib/internal.ts
+++ b/packages/harness/src/lib/internal.ts
@@ -1,0 +1,6 @@
+// Private implementation detail of @sandbox-benchmarks/harness.
+
+/** Monotonic clock wrapper so timing is swappable in tests. Stub. */
+export function now(): number {
+  return performance.now();
+}

--- a/packages/harness/tsconfig.json
+++ b/packages/harness/tsconfig.json
@@ -1,0 +1,4 @@
+{
+  "extends": "@repo/tsconfig/library.json",
+  "include": ["src"]
+}

--- a/packages/templates/README.md
+++ b/packages/templates/README.md
@@ -1,0 +1,16 @@
+# @sandbox-benchmarks/templates
+
+**Role:** per-provider sandbox template builders.
+
+**Public surface:**
+- `.` — `TemplateSpec`, the three `build*Template()` functions, `templateProviders`.
+- `./e2b` — `buildE2bTemplate()`
+- `./daytona` — `buildDaytonaTemplate()`
+- `./modal` — `buildModalTemplate()`
+
+**Depends on:** `@sandbox-benchmarks/providers`, `@sandbox-benchmarks/schema`, `computesdk`
+(`catalog:computesdk`).
+
+**What lives here:** one module per provider, exposed at its own export subpath — the
+**one-subpath-one-module** policy, so importing `@sandbox-benchmarks/templates/e2b` pulls in only the
+E2B builder. Shared helpers live in `src/lib/` and are never imported across a package boundary.

--- a/packages/templates/package.json
+++ b/packages/templates/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "@sandbox-benchmarks/templates",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "exports": {
+    ".": "./src/index.ts",
+    "./e2b": "./src/e2b.ts",
+    "./daytona": "./src/daytona.ts",
+    "./modal": "./src/modal.ts"
+  },
+  "scripts": {
+    "test": "bun test",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@sandbox-benchmarks/providers": "workspace:*",
+    "@sandbox-benchmarks/schema": "workspace:*",
+    "computesdk": "catalog:computesdk"
+  },
+  "devDependencies": {
+    "@repo/tsconfig": "workspace:*",
+    "typescript": "catalog:",
+    "@types/bun": "catalog:"
+  }
+}

--- a/packages/templates/src/daytona.ts
+++ b/packages/templates/src/daytona.ts
@@ -1,0 +1,9 @@
+// `@sandbox-benchmarks/templates/daytona` — one subpath, one module (the template policy).
+import { createStubAdapter } from "@sandbox-benchmarks/providers";
+import { makeTemplateSpec, type TemplateSpec } from "./lib/internal.ts";
+
+/** Build the Daytona sandbox template (stub). */
+export function buildDaytonaTemplate(tag = "latest"): TemplateSpec {
+  const { descriptor } = createStubAdapter("daytona", "Daytona");
+  return makeTemplateSpec(descriptor.id, tag);
+}

--- a/packages/templates/src/e2b.ts
+++ b/packages/templates/src/e2b.ts
@@ -1,0 +1,9 @@
+// `@sandbox-benchmarks/templates/e2b` — one subpath, one module (the template policy).
+import { createStubAdapter } from "@sandbox-benchmarks/providers";
+import { makeTemplateSpec, type TemplateSpec } from "./lib/internal.ts";
+
+/** Build the E2B sandbox template (stub). */
+export function buildE2bTemplate(tag = "latest"): TemplateSpec {
+  const { descriptor } = createStubAdapter("e2b", "E2B");
+  return makeTemplateSpec(descriptor.id, tag);
+}

--- a/packages/templates/src/index.test.ts
+++ b/packages/templates/src/index.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from "bun:test";
+import { buildDaytonaTemplate } from "./daytona.ts";
+import { buildE2bTemplate } from "./e2b.ts";
+import { templateProviders } from "./index.ts";
+import { buildModalTemplate } from "./modal.ts";
+
+describe("@sandbox-benchmarks/templates", () => {
+  it("builds one template spec per provider subpath", () => {
+    expect(buildE2bTemplate("v1").provider).toBe("e2b");
+    expect(buildDaytonaTemplate("v1").provider).toBe("daytona");
+    expect(buildModalTemplate("v1").provider).toBe("modal");
+  });
+
+  it("lists every provider that has a builder", () => {
+    expect([...templateProviders]).toEqual(["e2b", "daytona", "modal"]);
+  });
+});

--- a/packages/templates/src/index.ts
+++ b/packages/templates/src/index.ts
@@ -1,0 +1,20 @@
+// Public surface of @sandbox-benchmarks/templates (the "." subpath).
+// Per-provider builders live at their own subpaths: ./e2b, ./daytona, ./modal.
+import { buildDaytonaTemplate } from "./daytona.ts";
+import { buildE2bTemplate } from "./e2b.ts";
+import type { TemplateSpec } from "./lib/internal.ts";
+import { buildModalTemplate } from "./modal.ts";
+
+export type { TemplateSpec };
+export { buildDaytonaTemplate, buildE2bTemplate, buildModalTemplate };
+
+/** Each provider id mapped to its template builder. `templateProviders` is derived from these
+ *  keys, so the published id list can't drift from the builders that actually exist. */
+const templateBuilders = {
+  e2b: buildE2bTemplate,
+  daytona: buildDaytonaTemplate,
+  modal: buildModalTemplate,
+} satisfies Record<string, (tag?: string) => TemplateSpec>;
+
+/** All provider ids that ship a template builder this pass. */
+export const templateProviders = Object.keys(templateBuilders) as (keyof typeof templateBuilders)[];

--- a/packages/templates/src/lib/internal.ts
+++ b/packages/templates/src/lib/internal.ts
@@ -1,0 +1,15 @@
+// Private implementation detail of @sandbox-benchmarks/templates.
+import type { ProviderDescriptor } from "@sandbox-benchmarks/schema";
+
+/** A built sandbox template descriptor. Stub shape — real build metadata lands later. */
+export interface TemplateSpec {
+  /** The provider this template targets. */
+  provider: ProviderDescriptor["id"];
+  /** Opaque template tag/id the build step would produce. */
+  tag: string;
+}
+
+/** Shared helper used by every per-provider builder module. */
+export function makeTemplateSpec(provider: string, tag: string): TemplateSpec {
+  return { provider, tag };
+}

--- a/packages/templates/src/modal.ts
+++ b/packages/templates/src/modal.ts
@@ -1,0 +1,9 @@
+// `@sandbox-benchmarks/templates/modal` — one subpath, one module (the template policy).
+import { createStubAdapter } from "@sandbox-benchmarks/providers";
+import { makeTemplateSpec, type TemplateSpec } from "./lib/internal.ts";
+
+/** Build the Modal sandbox template (stub). */
+export function buildModalTemplate(tag = "latest"): TemplateSpec {
+  const { descriptor } = createStubAdapter("modal", "Modal");
+  return makeTemplateSpec(descriptor.id, tag);
+}

--- a/packages/templates/tsconfig.json
+++ b/packages/templates/tsconfig.json
@@ -1,0 +1,4 @@
+{
+  "extends": "@repo/tsconfig/library.json",
+  "include": ["src"]
+}


### PR DESCRIPTION
- @sandbox-benchmarks/templates: per-provider sandbox template builders (e2b, Daytona, Modal)
- @sandbox-benchmarks/harness: benchmark execution harness wiring providers + schema

Both build on the @sandbox-benchmarks/providers layer.