### PR TITLE
feat(cli): benchmark CLI app

### DIFF
--- a/apps/cli/README.md
+++ b/apps/cli/README.md
@@ -1,0 +1,19 @@
+# @sandbox-benchmarks/cli
+
+**Role:** the entrypoint app — wires the five `@sandbox-benchmarks/*` packages into runnable commands.
+
+**Bins (`bin`, no `exports`):**
+- `bench-lifecycle` — benchmark one provider's spawn→exec→teardown lifecycle.
+- `bench-suite` — run the full suite across the matrix.
+- `plan-matrix` — print the benchmark matrix as **single-line compact JSON** for `$GITHUB_OUTPUT`.
+- `build-template` — build a provider's sandbox template.
+- `normalize` — turn raw runs into normalized run documents.
+- `promote` — promote normalized results to the published dataset.
+
+**Depends on:** all five packages (`workspace:*`) + `dotenv` (`catalog:`).
+
+**What lives here:** thin command wrappers under `src/bin/`; shared command helpers under
+`src/lib/` (never imported across a package boundary). As an app it has **no `exports`** — nothing
+imports the CLI.
+
+Run a bin directly during development: `bun apps/cli/src/bin/plan-matrix.ts`.

--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -1,0 +1,31 @@
+{
+  "name": "@sandbox-benchmarks/cli",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "bin": {
+    "bench-lifecycle": "./src/bin/bench-lifecycle.ts",
+    "bench-suite": "./src/bin/bench-suite.ts",
+    "plan-matrix": "./src/bin/plan-matrix.ts",
+    "build-template": "./src/bin/build-template.ts",
+    "normalize": "./src/bin/normalize.ts",
+    "promote": "./src/bin/promote.ts"
+  },
+  "scripts": {
+    "test": "bun test",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@sandbox-benchmarks/schema": "workspace:*",
+    "@sandbox-benchmarks/providers": "workspace:*",
+    "@sandbox-benchmarks/templates": "workspace:*",
+    "@sandbox-benchmarks/harness": "workspace:*",
+    "@sandbox-benchmarks/results": "workspace:*",
+    "dotenv": "catalog:"
+  },
+  "devDependencies": {
+    "@repo/tsconfig": "workspace:*",
+    "typescript": "catalog:",
+    "@types/bun": "catalog:"
+  }
+}

--- a/apps/cli/src/bin/bench-lifecycle.ts
+++ b/apps/cli/src/bin/bench-lifecycle.ts
@@ -1,0 +1,11 @@
+#!/usr/bin/env bun
+// `bench-lifecycle` — benchmark a single provider's spawn→exec→teardown lifecycle (stub).
+
+import { timeOperation } from "@sandbox-benchmarks/harness";
+import { createStubAdapter } from "@sandbox-benchmarks/providers";
+
+if (import.meta.main) {
+	const adapter = createStubAdapter("e2b", "E2B");
+	const run = await timeOperation(adapter, "spawn", () => {});
+	console.log(JSON.stringify(run));
+}

--- a/apps/cli/src/bin/bench-suite.ts
+++ b/apps/cli/src/bin/bench-suite.ts
@@ -1,0 +1,15 @@
+#!/usr/bin/env bun
+// `bench-suite` — run the full benchmark suite across the matrix (stub).
+
+import { timeOperation } from "@sandbox-benchmarks/harness";
+import { createStubAdapter } from "@sandbox-benchmarks/providers";
+import { buildMatrix } from "../lib/matrix.ts";
+
+if (import.meta.main) {
+	const runs = [];
+	for (const { provider, operation } of buildMatrix()) {
+		const adapter = createStubAdapter(provider, provider);
+		runs.push(await timeOperation(adapter, operation, () => {}));
+	}
+	console.log(JSON.stringify({ runs }));
+}

--- a/apps/cli/src/bin/build-template.ts
+++ b/apps/cli/src/bin/build-template.ts
@@ -1,0 +1,27 @@
+#!/usr/bin/env bun
+// `build-template` — build a provider's sandbox template (stub).
+// Usage: build-template [provider] [tag]   (defaults: e2b latest)
+import {
+	buildDaytonaTemplate,
+	buildE2bTemplate,
+	buildModalTemplate,
+} from "@sandbox-benchmarks/templates";
+
+const builders = {
+	e2b: buildE2bTemplate,
+	daytona: buildDaytonaTemplate,
+	modal: buildModalTemplate,
+} as const;
+
+if (import.meta.main) {
+	const provider = process.argv[2] ?? "e2b";
+	const tag = process.argv[3] ?? "latest";
+	if (!(provider in builders)) {
+		console.error(
+			`Unknown provider "${provider}". Expected one of: ${Object.keys(builders).join(", ")}`,
+		);
+		process.exit(1);
+	}
+	const spec = builders[provider as keyof typeof builders](tag);
+	console.log(JSON.stringify(spec));
+}

--- a/apps/cli/src/bin/normalize.ts
+++ b/apps/cli/src/bin/normalize.ts
@@ -1,0 +1,10 @@
+#!/usr/bin/env bun
+// `normalize` — read raw runs and emit normalized run documents (stub).
+
+import { normalize } from "@sandbox-benchmarks/results";
+import { parseRawRun } from "@sandbox-benchmarks/schema";
+
+if (import.meta.main) {
+	const raw = parseRawRun({ provider: "e2b", operation: "spawn", durationMs: 1280 });
+	console.log(JSON.stringify(normalize(raw)));
+}

--- a/apps/cli/src/bin/plan-matrix.ts
+++ b/apps/cli/src/bin/plan-matrix.ts
@@ -1,0 +1,12 @@
+#!/usr/bin/env bun
+// `plan-matrix` — emit the benchmark matrix as a SINGLE LINE of compact JSON.
+// This is the $GITHUB_OUTPUT contract: `matrix=<json>` must be one line, no pretty-printing.
+import { buildMatrix } from "../lib/matrix.ts";
+
+export function planMatrixJson(): string {
+	return JSON.stringify({ include: buildMatrix() });
+}
+
+if (import.meta.main) {
+	console.log(planMatrixJson());
+}

--- a/apps/cli/src/bin/promote.ts
+++ b/apps/cli/src/bin/promote.ts
@@ -1,0 +1,10 @@
+#!/usr/bin/env bun
+// `promote` — promote normalized results to the published dataset (stub).
+
+import { normalize } from "@sandbox-benchmarks/results";
+import type { RunDocument } from "@sandbox-benchmarks/schema";
+
+if (import.meta.main) {
+	const doc: RunDocument = normalize({ provider: "modal", operation: "exec", durationMs: 64 });
+	console.log(JSON.stringify({ promoted: [doc] }));
+}

--- a/apps/cli/src/lib/matrix.ts
+++ b/apps/cli/src/lib/matrix.ts
@@ -1,0 +1,21 @@
+// Private CLI helper: builds the provider × operation benchmark matrix.
+// Imports from schema + templates so the schema → cli import chain is real, not just declared.
+import type { Capability } from "@sandbox-benchmarks/schema";
+import { capabilities } from "@sandbox-benchmarks/schema";
+import { templateProviders } from "@sandbox-benchmarks/templates";
+
+export interface MatrixEntry {
+	provider: string;
+	operation: Capability;
+}
+
+/** Build the full benchmark matrix. Stub: cross product of providers × capabilities. */
+export function buildMatrix(providers: readonly string[] = templateProviders): MatrixEntry[] {
+	const entries: MatrixEntry[] = [];
+	for (const provider of providers) {
+		for (const operation of capabilities) {
+			entries.push({ provider, operation });
+		}
+	}
+	return entries;
+}

--- a/apps/cli/src/plan-matrix.test.ts
+++ b/apps/cli/src/plan-matrix.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from "bun:test";
+import { planMatrixJson } from "./bin/plan-matrix.ts";
+
+describe("plan-matrix", () => {
+	it("emits a single line of compact JSON (the $GITHUB_OUTPUT contract)", () => {
+		const out = planMatrixJson();
+		// Single line: no embedded newlines and no pretty-print indentation.
+		expect(out).not.toContain("\n");
+		expect(out).not.toMatch(/\n\s+/);
+		// Round-trips to a non-empty matrix.
+		const parsed = JSON.parse(out) as { include: Array<{ provider: string; operation: string }> };
+		expect(parsed.include.length).toBeGreaterThan(0);
+		expect(parsed.include[0]).toHaveProperty("provider");
+		expect(parsed.include[0]).toHaveProperty("operation");
+	});
+});

--- a/apps/cli/tsconfig.json
+++ b/apps/cli/tsconfig.json
@@ -1,0 +1,4 @@
+{
+  "extends": "@repo/tsconfig/base.json",
+  "include": ["src"]
+}

--- a/bun.lock
+++ b/bun.lock
@@ -11,6 +11,31 @@
         "typescript": "catalog:",
       },
     },
+    "apps/cli": {
+      "name": "@sandbox-benchmarks/cli",
+      "version": "0.0.0",
+      "bin": {
+        "bench-lifecycle": "./src/bin/bench-lifecycle.ts",
+        "bench-suite": "./src/bin/bench-suite.ts",
+        "plan-matrix": "./src/bin/plan-matrix.ts",
+        "build-template": "./src/bin/build-template.ts",
+        "normalize": "./src/bin/normalize.ts",
+        "promote": "./src/bin/promote.ts",
+      },
+      "dependencies": {
+        "@sandbox-benchmarks/harness": "workspace:*",
+        "@sandbox-benchmarks/providers": "workspace:*",
+        "@sandbox-benchmarks/results": "workspace:*",
+        "@sandbox-benchmarks/schema": "workspace:*",
+        "@sandbox-benchmarks/templates": "workspace:*",
+        "dotenv": "catalog:",
+      },
+      "devDependencies": {
+        "@repo/tsconfig": "workspace:*",
+        "@types/bun": "catalog:",
+        "typescript": "catalog:",
+      },
+    },
     "packages/harness": {
       "name": "@sandbox-benchmarks/harness",
       "version": "0.0.0",
@@ -135,6 +160,8 @@
 
     "@repo/tsconfig": ["@repo/tsconfig@workspace:tooling/tsconfig"],
 
+    "@sandbox-benchmarks/cli": ["@sandbox-benchmarks/cli@workspace:apps/cli"],
+
     "@sandbox-benchmarks/harness": ["@sandbox-benchmarks/harness@workspace:packages/harness"],
 
     "@sandbox-benchmarks/providers": ["@sandbox-benchmarks/providers@workspace:packages/providers"],
@@ -158,6 +185,8 @@
     "computesdk": ["computesdk@4.1.3", "", { "dependencies": { "@computesdk/cmd": "0.4.1", "daemond": "0.1.4" } }, "sha512-IVC7KenrhCyiGJ1FKTs7jzXTc+mJZNCljux39yzPeR2M48v6tr03YXTtiyefoJ+VZ1J/nVthrAqTF1ng+H4uOQ=="],
 
     "daemond": ["daemond@0.1.4", "", { "os": [ "linux", "darwin", ] }, "sha512-xiLScBiwYGGPmxfcAb24aH+FkmR/ZSd+PxOvigGpKda6OsDjE2Gj6/4oAX2N3hMWoL4atti1hYyF9dLV3FFM0A=="],
+
+    "dotenv": ["dotenv@17.4.2", "", {}, "sha512-nI4U3TottKAcAD9LLud4Cb7b2QztQMUEfHbvhTH09bqXTxnSie8WnjPALV/WMCrJZ6UV/qHJ6L03OqO3LcdYZw=="],
 
     "lefthook": ["lefthook@2.1.9", "", { "optionalDependencies": { "lefthook-darwin-arm64": "2.1.9", "lefthook-darwin-x64": "2.1.9", "lefthook-freebsd-arm64": "2.1.9", "lefthook-freebsd-x64": "2.1.9", "lefthook-linux-arm64": "2.1.9", "lefthook-linux-x64": "2.1.9", "lefthook-openbsd-arm64": "2.1.9", "lefthook-openbsd-x64": "2.1.9", "lefthook-windows-arm64": "2.1.9", "lefthook-windows-x64": "2.1.9" }, "bin": { "lefthook": "bin/index.js" } }, "sha512-bwDaIOViTktE8kJLf9jP0p+H2/RDTlFFlc43Am2YgUsX22hI6Sq4RbzsrecwzY5y+MHTipOH7WsmWSEniePHWQ=="],
 


### PR DESCRIPTION
## Add `@sandbox-benchmarks/cli` app

Top-level `@sandbox-benchmarks/cli` that wires the full stack into runnable bins (`bench-suite`, `bench-lifecycle`, `plan-matrix`, `build-template`, `normalize`, `promote`). Depends on `schema`, `providers`, `templates`, `harness`, `results`, and `dotenv`.

### Bins

- **`bench-lifecycle`** — benchmarks a single provider's spawn→exec→teardown lifecycle.
- **`bench-suite`** — runs the full benchmark suite across the provider × operation matrix.
- **`plan-matrix`** — emits the benchmark matrix as single-line compact JSON for `$GITHUB_OUTPUT`.
- **`build-template`** — builds a provider's sandbox template.
- **`normalize`** — reads raw runs and emits normalized run documents.
- **`promote`** — promotes normalized results to the published dataset.

### Notes

- Thin command wrappers live under `src/bin/`; shared CLI helpers under `src/lib/` (not exported across package boundaries).
- `plan-matrix` is tested to enforce the single-line `$GITHUB_OUTPUT` contract.
- No `exports` field — nothing imports this package.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a CLI app exposing multiple commands for benchmarking, suites, template building (provider/tag), normalization, matrix planning, and promoting runs; includes a provider×operation matrix helper.

* **Documentation**
  * Added a README describing the CLI commands, binaries, structure, dependencies, and a developer tip for running the matrix command directly.

* **Tests**
  * Added a test ensuring the matrix planner emits single-line compact JSON.

* **Chores**
  * Added CLI package metadata, test/typecheck scripts, and a minimal TypeScript config.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->