### PR TITLE
test: workspace boundary & package-meta enforcement

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -100,6 +100,15 @@
         "typescript": "catalog:",
       },
     },
+    "tooling/repo-checks": {
+      "name": "@repo/repo-checks",
+      "version": "0.0.0",
+      "devDependencies": {
+        "@repo/tsconfig": "workspace:*",
+        "@types/bun": "catalog:",
+        "typescript": "catalog:",
+      },
+    },
     "tooling/test-utils": {
       "name": "@repo/test-utils",
       "version": "0.0.0",
@@ -155,6 +164,8 @@
     "@biomejs/cli-win32-x64": ["@biomejs/cli-win32-x64@2.4.16", "", { "os": "win32", "cpu": "x64" }, "sha512-Kp85jgoBHa05gix6UIRjfCDiUV3w/8VIdZ247VyyO2gEjaw12WEVhdIjlxp/AMzXxqxQwbxNTDVZ3Mwd2RG5rw=="],
 
     "@computesdk/cmd": ["@computesdk/cmd@0.4.1", "", {}, "sha512-hhcYrwMnOpRSwWma3gkUeAVsDFG56nURwSaQx8vCepv0IuUv39bK4mMkgszolnUQrVjBDdW7b3lV+l5B2S8fRA=="],
+
+    "@repo/repo-checks": ["@repo/repo-checks@workspace:tooling/repo-checks"],
 
     "@repo/test-utils": ["@repo/test-utils@workspace:tooling/test-utils"],
 

--- a/tooling/repo-checks/README.md
+++ b/tooling/repo-checks/README.md
@@ -1,0 +1,20 @@
+# @repo/repo-checks
+
+**Role:** runnable invariant tests that keep the monorepo structure honest. They run under
+`bun --filter '*' test` like any other member, so a structural violation fails CI.
+
+**Public surface:** none — this package is not imported (no `exports`, no `bin`). It only ships
+`bun:test` files.
+
+**What lives here:**
+- `src/boundary.test.ts` — scans every source member's `src/**/*.ts` imports and fails on
+  (a) relative imports that escape the package root and (b) imports reaching another package's
+  private `lib/`.
+- `src/package-meta.test.ts` — asserts the uniform `package.json` shape across all members:
+  identity fields, the test/typecheck script contract (source members) vs. a `files` array
+  (config-only members), `exports`/`bin` rules, and that internal deps use `workspace:*` while
+  cataloged externals use `catalog:` / `catalog:<name>`.
+- `src/lib/workspace.ts` — repo-root resolution + member enumeration via `Bun.Glob` (private).
+
+To prove enforcement works, temporarily add an import like `import "../../providers/src/index.ts"`
+to any stub and watch `boundary.test.ts` fail; then revert.

--- a/tooling/repo-checks/package.json
+++ b/tooling/repo-checks/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "@repo/repo-checks",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "test": "bun test",
+    "typecheck": "tsc --noEmit"
+  },
+  "devDependencies": {
+    "@repo/tsconfig": "workspace:*",
+    "typescript": "catalog:",
+    "@types/bun": "catalog:"
+  }
+}

--- a/tooling/repo-checks/src/boundary.test.ts
+++ b/tooling/repo-checks/src/boundary.test.ts
@@ -1,0 +1,156 @@
+// Invariant: imports respect package boundaries AND the dependency graph respects layering.
+// (a) No relative import may climb above its own package root (into a sibling package).
+// (b) No import may reach another workspace package's private `lib/`.
+// (c) Every cross-package (workspace) import in a member's src MUST be declared in that
+//     member's package.json dependencies/devDependencies. An undeclared workspace import
+//     (e.g. a backward/illegal edge such as `schema` importing `cli`) is a violation — this
+//     is the gap a name/relative-only check misses.
+// (d) The internal runtime-dependency graph (package.json `dependencies` among workspace
+//     members) MUST be acyclic. Layer inversions show up here as cycles.
+import { describe, expect, it } from "bun:test";
+import { dirname } from "node:path";
+import {
+  importSpecifiers,
+  listMembers,
+  memberSourceFiles,
+  relative,
+  resolve,
+  sep,
+  stripComments,
+} from "./lib/workspace.ts";
+
+const allMembers = listMembers();
+const memberNames = new Set(allMembers.map((m) => m.name));
+const srcMembers = allMembers.filter((m) => m.hasSrc);
+
+/** The workspace package an import specifier targets (by exact name or `name/...` subpath), or null if external. */
+function targetMember(spec: string): string | null {
+  for (const name of memberNames) {
+    if (spec === name || spec.startsWith(`${name}/`)) return name;
+  }
+  return null;
+}
+
+describe("import boundaries", () => {
+  for (const member of srcMembers) {
+    it(`${member.relPath}: imports stay in-package and are declared`, () => {
+      const declared = new Set([
+        ...Object.keys(member.pkg.dependencies ?? {}),
+        ...Object.keys(member.pkg.devDependencies ?? {}),
+      ]);
+      const violations: string[] = [];
+
+      for (const file of memberSourceFiles(member)) {
+        const rel = relative(process.cwd(), file);
+        for (const spec of importSpecifiers(file)) {
+          if (spec.startsWith(".")) {
+            // (a) relative import escaping the package root. Compare with a trailing
+            // separator so a sibling whose name is a prefix (foo vs foo-bar) can't slip through.
+            const target = resolve(dirname(file), spec);
+            if (target !== member.dir && !target.startsWith(member.dir + sep)) {
+              violations.push(`${rel} → "${spec}" escapes ${member.relPath}`);
+            }
+            continue;
+          }
+
+          const owner = targetMember(spec);
+          if (owner === null || owner === member.name) continue; // external dep or self-reference
+
+          // (b) reaching into another workspace package's private lib/.
+          const subpath = spec.slice(owner.length + 1);
+          if (/(^|\/)lib(\/|$)/.test(subpath)) {
+            violations.push(`${rel} → "${spec}" reaches into ${owner}'s private lib/`);
+          }
+
+          // (c) the workspace package must be a declared dependency.
+          if (!declared.has(owner)) {
+            violations.push(`${rel} → imports "${owner}" but it is not a declared dependency`);
+          }
+        }
+      }
+
+      expect(violations).toEqual([]);
+    });
+  }
+
+  it("found source members to scan", () => {
+    expect(srcMembers.length).toBeGreaterThan(0);
+  });
+});
+
+/** Return a cycle (as the list of nodes on it) in a directed graph, or null if acyclic. */
+function findCycle(nodes: string[], edges: Map<string, string[]>): string[] | null {
+  const seen = new Map<string, number>(); // 0 = visiting (on stack), 1 = done
+  const stack: string[] = [];
+
+  function visit(node: string): string[] | null {
+    seen.set(node, 0);
+    stack.push(node);
+    for (const next of edges.get(node) ?? []) {
+      if (!seen.has(next)) {
+        const found = visit(next);
+        if (found) return found;
+      } else if (seen.get(next) === 0) {
+        return [...stack.slice(stack.indexOf(next)), next]; // back-edge → cycle
+      }
+    }
+    stack.pop();
+    seen.set(node, 1);
+    return null;
+  }
+
+  for (const node of nodes) {
+    if (!seen.has(node)) {
+      const found = visit(node);
+      if (found) return found;
+    }
+  }
+  return null;
+}
+
+describe("dependency-graph layering", () => {
+  it("the internal runtime dependency graph is acyclic", () => {
+    const nodes = allMembers.map((m) => m.name);
+    const edges = new Map<string, string[]>(
+      allMembers.map((m) => [
+        m.name,
+        Object.keys(m.pkg.dependencies ?? {}).filter((d) => memberNames.has(d)),
+      ]),
+    );
+    expect(findCycle(nodes, edges)).toBeNull();
+  });
+
+  // Guard against a vacuous detector: it must flag a known cycle and clear a known DAG.
+  it("findCycle flags a real cycle and clears an acyclic graph", () => {
+    const cyclic = new Map([
+      ["a", ["b"]],
+      ["b", ["c"]],
+      ["c", ["a"]],
+    ]);
+    expect(findCycle(["a", "b", "c"], cyclic)).not.toBeNull();
+
+    const acyclic = new Map([
+      ["a", ["b", "c"]],
+      ["b", ["c"]],
+      ["c", []],
+    ]);
+    expect(findCycle(["a", "b", "c"], acyclic)).toBeNull();
+  });
+});
+
+describe("stripComments (import-extraction pre-pass)", () => {
+  it("drops commented-out imports but keeps live imports and string contents", () => {
+    const src = [
+      'import { live } from "external-live";',
+      '// import { dead } from "external-dead";',
+      '/* import { block } from "external-block"; */',
+      'const url = "http://example.com/x";',
+    ].join("\n");
+    const cleaned = stripComments(src);
+    expect(cleaned).toContain("external-live");
+    expect(cleaned).not.toContain("external-dead");
+    expect(cleaned).not.toContain("external-block");
+    // A `//` inside a string literal is not a comment, so the URL survives.
+    expect(cleaned).toContain("http://example.com/x");
+  });
+});

--- a/tooling/repo-checks/src/lib/workspace.ts
+++ b/tooling/repo-checks/src/lib/workspace.ts
@@ -1,0 +1,121 @@
+// Private helper: locate the repo root and enumerate workspace members from the workspace globs.
+// Used by the boundary + package-meta invariant tests.
+import { existsSync, readFileSync } from "node:fs";
+import { dirname, join, relative, resolve, sep } from "node:path";
+import { Glob } from "bun";
+
+export interface PackageJson {
+  name?: string;
+  version?: string;
+  private?: boolean;
+  type?: string;
+  exports?: Record<string, unknown>;
+  bin?: Record<string, string> | string;
+  files?: string[];
+  scripts?: Record<string, string>;
+  dependencies?: Record<string, string>;
+  devDependencies?: Record<string, string>;
+  workspaces?:
+    | string[]
+    | {
+        packages?: string[];
+        catalog?: Record<string, string>;
+        catalogs?: Record<string, Record<string, string>>;
+      };
+}
+
+export interface Member {
+  /** Declared package name. */
+  name: string;
+  /** Absolute path to the member directory. */
+  dir: string;
+  /** Path of the member directory relative to the repo root, e.g. "packages/schema". */
+  relPath: string;
+  /** Whether the member has a `src/` directory (a "source member"). */
+  hasSrc: boolean;
+  /** Parsed package.json. */
+  pkg: PackageJson;
+}
+
+function readJson(path: string): PackageJson {
+  return JSON.parse(readFileSync(path, "utf8")) as PackageJson;
+}
+
+/** Walk up from `start` until we find the package.json that declares `workspaces`. */
+export function findRepoRoot(start: string = import.meta.dir): string {
+  let dir = start;
+  for (;;) {
+    const pj = join(dir, "package.json");
+    if (existsSync(pj) && readJson(pj).workspaces) return dir;
+    const parent = dirname(dir);
+    if (parent === dir)
+      throw new Error("could not locate repo root (no package.json with workspaces)");
+    dir = parent;
+  }
+}
+
+/** The workspace package globs from the root package.json (object or array form). */
+export function workspaceGlobs(root: string = findRepoRoot()): string[] {
+  const ws = readJson(join(root, "package.json")).workspaces;
+  if (!ws) return [];
+  return Array.isArray(ws) ? ws : (ws.packages ?? []);
+}
+
+/** Enumerate every workspace member by expanding the workspace globs. */
+export function listMembers(root: string = findRepoRoot()): Member[] {
+  const members: Member[] = [];
+  for (const g of workspaceGlobs(root)) {
+    const glob = new Glob(`${g}/package.json`);
+    for (const rel of glob.scanSync({ cwd: root, onlyFiles: true })) {
+      const dir = dirname(join(root, rel));
+      const pkg = readJson(join(dir, "package.json"));
+      members.push({
+        name: pkg.name ?? "<unnamed>",
+        dir,
+        relPath: dirname(rel),
+        hasSrc: existsSync(join(dir, "src")),
+        pkg,
+      });
+    }
+  }
+  return members.sort((a, b) => a.relPath.localeCompare(b.relPath));
+}
+
+/** Every `.ts` file under a member's `src/`, as absolute paths. */
+export function memberSourceFiles(member: Member): string[] {
+  const glob = new Glob("**/*.ts");
+  return [...glob.scanSync({ cwd: join(member.dir, "src"), onlyFiles: true })].map((rel) =>
+    join(member.dir, "src", rel),
+  );
+}
+
+// Matches a string/template literal (capture group 1) OR a line/block comment. Echoing the
+// string back while replacing comments with "" strips comments without tripping on a `//`
+// that lives inside a string (e.g. "http://…").
+const STRING_OR_COMMENT =
+  /("(?:[^"\\]|\\.)*"|'(?:[^'\\]|\\.)*'|`(?:[^`\\]|\\.)*`)|\/\/[^\n]*|\/\*[\s\S]*?\*\//g;
+
+/**
+ * Strip `//` line and block comments from TS/JS source while preserving string and template
+ * literals. Import extraction runs on the result, so a commented-out import never registers as a
+ * real one — a regex over raw source text would mis-read it and fire a false boundary violation.
+ */
+export function stripComments(src: string): string {
+  return src.replace(STRING_OR_COMMENT, (_match, stringLiteral) => stringLiteral ?? "");
+}
+
+const IMPORT_SPECIFIER =
+  /(?:import|export)\b[^'"]*?\bfrom\s*['"]([^'"]+)['"]|import\s*\(\s*['"]([^'"]+)['"]\s*\)|import\s+['"]([^'"]+)['"]/g;
+
+/** Extract every module specifier referenced by a source file (comments stripped first). */
+export function importSpecifiers(filePath: string): string[] {
+  const src = stripComments(readFileSync(filePath, "utf8"));
+  const specs: string[] = [];
+  for (const m of src.matchAll(IMPORT_SPECIFIER)) {
+    const spec = m[1] ?? m[2] ?? m[3];
+    if (spec) specs.push(spec);
+  }
+  return specs;
+}
+
+export { relative, resolve, sep };

--- a/tooling/repo-checks/src/package-meta.test.ts
+++ b/tooling/repo-checks/src/package-meta.test.ts
@@ -1,0 +1,93 @@
+// Invariant: every workspace member has the uniform package.json shape.
+
+import { describe, expect, it } from "bun:test";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { Glob } from "bun";
+import { findRepoRoot, listMembers, type PackageJson, workspaceGlobs } from "./lib/workspace.ts";
+
+const root = findRepoRoot();
+const members = listMembers(root);
+
+// Build the catalog expectation map: dep name → required version string ("catalog:" / "catalog:<name>").
+const rootPkg = JSON.parse(readFileSync(join(root, "package.json"), "utf8")) as PackageJson;
+const ws = rootPkg.workspaces;
+const catalogExpectation = new Map<string, string>();
+if (ws && !Array.isArray(ws)) {
+  for (const name of Object.keys(ws.catalog ?? {})) catalogExpectation.set(name, "catalog:");
+  for (const [catName, entries] of Object.entries(ws.catalogs ?? {})) {
+    for (const name of Object.keys(entries)) catalogExpectation.set(name, `catalog:${catName}`);
+  }
+}
+
+function isInternal(depName: string): boolean {
+  return depName.startsWith("@sandbox-benchmarks/") || depName.startsWith("@repo/");
+}
+
+function allDeps(pkg: PackageJson): Record<string, string> {
+  return { ...(pkg.dependencies ?? {}), ...(pkg.devDependencies ?? {}) };
+}
+
+describe("package metadata invariants", () => {
+  it("enumerates one member per workspace package.json (no silent drops)", () => {
+    // Cross-check listMembers against an independent glob of the workspace, so adding a package
+    // never requires bumping a magic number, while a regression that drops members still fails.
+    const onDisk = workspaceGlobs(root).flatMap((g) =>
+      Array.from(new Glob(`${g}/package.json`).scanSync({ cwd: root, onlyFiles: true })),
+    ).length;
+    expect(members.length).toBe(onDisk);
+    expect(members.length).toBeGreaterThan(0);
+  });
+
+  for (const member of members) {
+    describe(member.relPath, () => {
+      const { pkg } = member;
+
+      it("has name / version / private:true / type:module", () => {
+        expect(typeof pkg.name).toBe("string");
+        expect(typeof pkg.version).toBe("string");
+        expect(pkg.private).toBe(true);
+        expect(pkg.type).toBe("module");
+      });
+
+      if (member.hasSrc) {
+        it("source member defines test + typecheck scripts", () => {
+          expect(pkg.scripts?.test).toBeDefined();
+          expect(pkg.scripts?.typecheck).toBeDefined();
+        });
+      } else {
+        it("config-only member declares a non-empty files array", () => {
+          expect(Array.isArray(pkg.files)).toBe(true);
+          expect((pkg.files ?? []).length).toBeGreaterThan(0);
+        });
+      }
+
+      const isLibraryPackage = member.relPath.startsWith("packages/");
+      const isApp = member.relPath.startsWith("apps/");
+
+      if (isLibraryPackage || member.name === "@repo/test-utils") {
+        it("exposes an exports map", () => {
+          expect(pkg.exports).toBeDefined();
+        });
+      }
+
+      if (isApp) {
+        it("app declares bin and has no exports", () => {
+          expect(pkg.bin).toBeDefined();
+          expect(pkg.exports).toBeUndefined();
+        });
+      }
+
+      it("internal deps use workspace:* and cataloged externals use catalog:", () => {
+        for (const [dep, version] of Object.entries(allDeps(pkg))) {
+          const expected = catalogExpectation.get(dep);
+          if (isInternal(dep)) {
+            expect(version).toBe("workspace:*");
+          } else if (expected) {
+            expect(version).toBe(expected);
+          }
+        }
+      });
+    });
+  }
+});

--- a/tooling/repo-checks/tsconfig.json
+++ b/tooling/repo-checks/tsconfig.json
@@ -1,0 +1,4 @@
+{
+  "extends": "@repo/tsconfig/base.json",
+  "include": ["src"]
+}


### PR DESCRIPTION
## `@repo/repo-checks`: Monorepo Structural Invariant Tests

Adds a new `@repo/repo-checks` workspace package under `tooling/` that runs as a standard `bun:test` member, so structural violations fail CI automatically.

### Boundary Enforcement (`src/boundary.test.ts`)

Scans every source member's `src/**/*.ts` imports and enforces four invariants:

- **(a)** No relative import may escape its package root into a sibling package.
- **(b)** No import may reach into another workspace package's private `lib/`.
- **(c)** Every cross-package workspace import must be a declared `dependency` or `devDependency` — catching illegal or backward edges (e.g. `schema` importing `cli`) that a name/relative-only check would miss.
- **(d)** The internal runtime dependency graph (workspace `dependencies` in `package.json`) must be acyclic — layer inversions surface here as cycles.

Includes a non-vacuous self-test of the cycle detector that both flags a known cycle and clears a known DAG.

### Package Metadata Enforcement (`src/package-meta.test.ts`)

Asserts a uniform `package.json` shape across all workspace members:

- Every member declares `name`, `version`, `private: true`, and `type: "module"`.
- Source members define `test` and `typecheck` scripts; config-only members declare a non-empty `files` array.
- Library packages expose an `exports` map; app packages declare `bin` and omit `exports`.
- Internal deps use `workspace:*`; cataloged externals use `catalog:` or `catalog:<name>`.
- Member count is cross-checked against an independent glob scan so a silent drop still fails.

### Workspace Utilities (`src/lib/workspace.ts`)

Private helpers for repo-root resolution and member enumeration via `Bun.Glob`, plus comment-stripping logic that preserves string literals so a `//` inside a URL (e.g. `"http://..."`) is never misread as a comment, preventing false boundary violations.