### PR TITLE
chore: set up Biome formatting & linting for the Bun workspace

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,8 +54,10 @@ private `lib/`.
 | `bun install`        | Resolve the graph, symlink workspaces, install catalogs (≥7-day-old releases). |
 | `bun run typecheck`  | `tsc --noEmit` per member — proof of source-first/no-build.             |
 | `bun run test`       | `bun test` per member, including the repo-checks invariants.            |
-| `bun run lint`       | `biome check .` (root-only Biome config).                               |
-| `bun run format`     | `biome check --write .`                                                 |
+| `bun run lint`       | `biome check . --error-on-warnings` — CI gate; warnings fail (root-only Biome config). |
+| `bun run format`     | `biome format . --write` — formatting only (no import sorting / lint fixes). |
+| `bun run lint:fix`   | `biome check . --write` — formatting + import sorting + safe lint fixes. |
+| `bun run lint:fix:unsafe` | `biome check . --fix --unsafe` — also applies behavior-changing fixes; review the diff. |
 
 Run a single bin during development: `bun apps/cli/src/bin/plan-matrix.ts`.
 

--- a/biome.json
+++ b/biome.json
@@ -1,20 +1,26 @@
 {
   "$schema": "https://biomejs.dev/schemas/2.4.16/schema.json",
+  "root": true,
   "vcs": {
     "enabled": true,
     "clientKind": "git",
     "useIgnoreFile": true
   },
   "files": {
-    "includes": ["**", "!**/node_modules", "!**/bun.lock"]
+    "ignoreUnknown": true
   },
   "formatter": {
     "enabled": true,
-    "indentStyle": "space",
-    "indentWidth": 2,
+    "indentStyle": "tab",
     "lineWidth": 100
   },
+  "javascript": {
+    "formatter": {
+      "quoteStyle": "double"
+    }
+  },
   "assist": {
+    "enabled": true,
     "actions": {
       "source": {
         "organizeImports": "on"
@@ -24,12 +30,83 @@
   "linter": {
     "enabled": true,
     "rules": {
-      "recommended": true
+      "recommended": true,
+      "style": {
+        "useImportType": {
+          "level": "error",
+          "options": {
+            "style": "separatedType"
+          }
+        },
+        "useNodejsImportProtocol": "error",
+        "useConst": "error"
+      },
+      "suspicious": {
+        "noTsIgnore": "error",
+        "noDebugger": "error"
+      },
+      "performance": {
+        "noDelete": "error"
+      },
+      "complexity": {
+        "useDateNow": "error"
+      },
+      "correctness": {
+        "noUnusedImports": "warn",
+        "noUnusedVariables": "warn"
+      },
+      "nursery": {
+        "noFloatingPromises": "warn",
+        "noMisusedPromises": "warn"
+      }
     }
   },
-  "javascript": {
-    "formatter": {
-      "quoteStyle": "double"
+  "overrides": [
+    {
+      "includes": ["**/*.json"],
+      "formatter": {
+        "indentStyle": "space",
+        "indentWidth": 2
+      }
+    },
+    {
+      "includes": ["packages/**/src/**"],
+      "linter": {
+        "rules": {
+          "style": {
+            "noRestrictedTypes": {
+              "level": "error",
+              "options": {
+                "types": {
+                  "Buffer": {
+                    "message": "Buffer is Node-specific. Use `Uint8Array` for cross-runtime code.",
+                    "use": "Uint8Array"
+                  }
+                }
+              }
+            },
+            "noRestrictedGlobals": {
+              "level": "error",
+              "options": {
+                "deniedGlobals": {
+                  "Buffer": "Buffer is Node-specific. Use `Uint8Array` for cross-runtime code."
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    {
+      "includes": ["**/*.test.*", "**/*.spec.*", "**/test/**", "**/__tests__/**"],
+      "linter": {
+        "rules": {
+          "style": {
+            "noRestrictedTypes": "off",
+            "noRestrictedGlobals": "off"
+          }
+        }
+      }
     }
-  }
+  ]
 }

--- a/package.json
+++ b/package.json
@@ -26,8 +26,10 @@
   "scripts": {
     "typecheck": "bun --filter '!./' --filter '*' --if-present typecheck",
     "test": "bun --filter '!./' --filter '*' --if-present test",
-    "lint": "biome check .",
-    "format": "biome check --write ."
+    "format": "biome format . --write",
+    "lint": "biome check . --error-on-warnings",
+    "lint:fix": "biome check . --write",
+    "lint:fix:unsafe": "biome check . --fix --unsafe"
   },
   "devDependencies": {
     "@biomejs/biome": "2.4.16",

--- a/packages/schema/src/index.test.ts
+++ b/packages/schema/src/index.test.ts
@@ -1,26 +1,27 @@
 import { describe, expect, it } from "bun:test";
-import { type CapabilityFlags, capabilities, parseRawRun } from "./index.ts";
+import type { CapabilityFlags } from "./index.ts";
+import { capabilities, parseRawRun } from "./index.ts";
 
 describe("@sandbox-benchmarks/schema", () => {
-  it("exposes the capability vocabulary", () => {
-    expect(capabilities).toContain("exec");
-    const flags: CapabilityFlags = {
-      spawn: true,
-      exec: true,
-      filesystem: false,
-      snapshot: false,
-    };
-    expect(flags.exec).toBe(true);
-  });
+	it("exposes the capability vocabulary", () => {
+		expect(capabilities).toContain("exec");
+		const flags: CapabilityFlags = {
+			spawn: true,
+			exec: true,
+			filesystem: false,
+			snapshot: false,
+		};
+		expect(flags.exec).toBe(true);
+	});
 
-  it("parses a valid raw run via arktype", () => {
-    const run = parseRawRun({ provider: "e2b", operation: "spawn", durationMs: 12 });
-    expect(run.provider).toBe("e2b");
-  });
+	it("parses a valid raw run via arktype", () => {
+		const run = parseRawRun({ provider: "e2b", operation: "spawn", durationMs: 12 });
+		expect(run.provider).toBe("e2b");
+	});
 
-  it("rejects an invalid raw run", () => {
-    expect(() => parseRawRun({ provider: "e2b", operation: "spawn", durationMs: -1 })).toThrow();
-    // durationMs must be strictly positive — a 0ms run is a timing error, not a real result.
-    expect(() => parseRawRun({ provider: "e2b", operation: "spawn", durationMs: 0 })).toThrow();
-  });
+	it("rejects an invalid raw run", () => {
+		expect(() => parseRawRun({ provider: "e2b", operation: "spawn", durationMs: -1 })).toThrow();
+		// durationMs must be strictly positive — a 0ms run is a timing error, not a real result.
+		expect(() => parseRawRun({ provider: "e2b", operation: "spawn", durationMs: 0 })).toThrow();
+	});
 });

--- a/packages/schema/src/index.ts
+++ b/packages/schema/src/index.ts
@@ -12,12 +12,12 @@ export type CapabilityFlags = Record<Capability, boolean>;
 
 /** Static description of a sandbox provider. */
 export interface ProviderDescriptor {
-  /** Stable identifier, e.g. "e2b", "daytona", "modal". */
-  id: string;
-  /** Human-readable name. */
-  displayName: string;
-  /** Capabilities the provider supports. */
-  capabilities: CapabilityFlags;
+	/** Stable identifier, e.g. "e2b", "daytona", "modal". */
+	id: string;
+	/** Human-readable name. */
+	displayName: string;
+	/** Capabilities the provider supports. */
+	capabilities: CapabilityFlags;
 }
 
 /**
@@ -28,18 +28,18 @@ export type RawRun = typeof rawRunSchema.infer;
 
 /** A normalized run document, as produced by @sandbox-benchmarks/results. */
 export interface RunDocument {
-  provider: string;
-  operation: string;
-  durationMs: number;
-  /** ISO-8601 timestamp the document was normalized at. */
-  normalizedAt: string;
+	provider: string;
+	operation: string;
+	durationMs: number;
+	/** ISO-8601 timestamp the document was normalized at. */
+	normalizedAt: string;
 }
 
 /** Validate an unknown value as a {@link RawRun} using the arktype schema. */
 export function parseRawRun(value: unknown): RawRun {
-  const out = rawRunSchema(value);
-  if (out instanceof type.errors) {
-    throw new Error(`invalid RawRun: ${out.summary}`);
-  }
-  return out;
+	const out = rawRunSchema(value);
+	if (out instanceof type.errors) {
+		throw new Error(`invalid RawRun: ${out.summary}`);
+	}
+	return out;
 }

--- a/packages/schema/src/lib/internal.ts
+++ b/packages/schema/src/lib/internal.ts
@@ -7,9 +7,9 @@ import { type } from "arktype";
  * Stub shape — real fields land in the schema implementation pass.
  */
 export const rawRunSchema = type({
-  provider: "string",
-  operation: "string",
-  // A real benchmarked operation always takes measurable wall-clock time; a 0ms (or negative)
-  // duration is a timing error or dropped observation, so reject it at the boundary.
-  durationMs: "number>0",
+	provider: "string",
+	operation: "string",
+	// A real benchmarked operation always takes measurable wall-clock time; a 0ms (or negative)
+	// duration is a timing error or dropped observation, so reject it at the boundary.
+	durationMs: "number>0",
 });


### PR DESCRIPTION
## Summary

Sets up [Biome](https://biomejs.dev/) v2 as the single formatter + linter for the Bun monorepo, with a root `biome.json` (the [big-projects](https://biomejs.dev/guides/big-projects/) single-root pattern) and enforcement wired into `package.json` scripts.

## What changed

**`biome.json`** — regenerated from `biome init`, then layered with config justified by this codebase:
- **Tab indentation** globally, with a `**/*.json` override keeping JSON at 2-space; `lineWidth: 100`, double quotes, `organizeImports`.
- **Stricter rules on top of `recommended`:**
  - Import hygiene — `useImportType` (separatedType), `useNodejsImportProtocol`, `useConst`
  - Safety/correctness — `noTsIgnore`, `noDebugger`, `noDelete`, `useDateNow`, `noUnusedImports`/`noUnusedVariables` (warn)
  - Type-aware async — `noFloatingPromises` / `noMisusedPromises` (nursery, `error`; risk contained by the exact-pinned Biome version)
  - **Cross-runtime guard** — bans `Buffer` (type + global) in `packages/**/src/**` in favor of `Uint8Array`; relaxed in test files. Scoped to `packages/` (not `apps/`), since apps are the runtime-specific layer.
- `root: true` marks the monorepo root config.

**`package.json`** — enforcement scripts:
```jsonc
"format":          "biome format . --write",          // formatting only
"lint":            "biome check . --error-on-warnings", // CI gate — warnings fail
"lint:fix":        "biome check . --write",            // formatting + import sorting + safe lint fixes
"lint:fix:unsafe": "biome check . --fix --unsafe"      // also applies behavior-changing fixes
```
`lint:fix` is safe by default; behavior-changing (`--unsafe`) fixes live in the separate `lint:fix:unsafe` script.

**Source** — reformatted to tabs; the test's mixed import was split into a dedicated `import type` by the new rule.

**`README.md`** — scripts table updated to document the four commands and the `format` (formatting only) vs `lint:fix` (formatting + imports + safe fixes) distinction.

## Notably skipped (vs. the reference config that inspired this)
- zod `noRestrictedImports` — this repo uses **arktype**
- Tailwind CSS parser — no CSS here
- The long `files.includes` build-dir excludes — already covered by `.gitignore` via `vcs.useIgnoreFile`

## Verification
- `bun run lint` (`biome check . --error-on-warnings`) → clean
- `bun run typecheck` → passes
- `bun run test` → 3 pass, 0 fail

https://claude.ai/code/session_01Tz4pSpYkRUgCugA6P5zd5c

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added lint:fix (safe fixes + import sorting) and lint:fix:unsafe (behavior-changing fixes) commands.

* **Chores**
  * Standardized lint/format scripts to Biome and made warnings fail CI.
  * Expanded linter rules with stricter error/warn levels.
  * Switched formatter indentation from spaces to tabs (JSON override keeps spaces).
  * Updated docs to reflect new lint/format commands.
  * File discovery behavior adjusted to ignore unknown globs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->