### PR TITLE
ci: run Biome lint, typecheck and tests in GitHub Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,54 @@
+name: CI
+
+# Runs the README's "command contract" on every PR (and every push to main): the same Biome
+# lint, typecheck, and tests a developer runs locally must pass before code can merge.
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+# One in-flight run per ref — a new push cancels the previous, still-running CI for that branch.
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+# Least privilege: the gate only reads the checked-out code.
+permissions:
+  contents: read
+
+jobs:
+  check:
+    name: Lint, typecheck & test
+    runs-on: starsling-ubuntu-24.04-2
+    # The runner is self-hosted, so never execute untrusted fork-PR code on it: run only for
+    # pushes and pull requests whose head is this same repository (fork PRs are skipped).
+    if: >-
+      github.event_name == 'push' ||
+      github.event.pull_request.head.repo.full_name == github.repository
+    steps:
+      # Third-party actions are pinned to a commit SHA (the tag comment is for humans only) so a
+      # moved/compromised tag can't silently change what runs in CI.
+      - name: Checkout
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+
+      - name: Set up Bun
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
+        with:
+          # Pinned to the toolchain version the repo develops against.
+          bun-version: 1.3.14
+
+      # Frozen lockfile: fail if package.json and bun.lock have drifted. --ignore-scripts so CI
+      # runs zero lifecycle scripts, matching bunfig.toml's supply-chain posture (minimumReleaseAge,
+      # no third-party postinstalls).
+      - name: Install dependencies
+        run: bun install --frozen-lockfile --ignore-scripts
+
+      # Biome gate — `biome check . --error-on-warnings`; warnings fail the build.
+      - name: Lint (Biome)
+        run: bun run lint
+
+      - name: Typecheck
+        run: bun run typecheck
+
+      - name: Test
+        run: bun run test

--- a/README.md
+++ b/README.md
@@ -61,6 +61,13 @@ private `lib/`.
 
 Run a single bin during development: `bun apps/cli/src/bin/plan-matrix.ts`.
 
+## Continuous integration
+
+`.github/workflows/ci.yml` runs the command contract on every pull request and every push to
+`main`: `bun install --frozen-lockfile --ignore-scripts` → `bun run lint` (the Biome gate) →
+`bun run typecheck` → `bun run test`. The same checks run locally, so green-on-your-machine means
+green-in-CI.
+
 ## Supply-chain posture
 
 `bunfig.toml` sets `minimumReleaseAge = 604800` (7 days) so freshly published — possibly


### PR DESCRIPTION
Add .github/workflows/ci.yml running the README's command contract on every
pull request and every push to main: bun install --frozen-lockfile, then the
Biome lint (bun run lint, warnings fail), typecheck, and test.

This makes good on the README's existing CI claims, which until now had no
workflow behind them. Concurrency cancels superseded runs per ref and the job
has read-only permissions.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a GitHub Actions CI workflow that runs Biome lint, typecheck, and tests with `bun` on every PR and push to `main`. Runs on a self-hosted runner with pinned actions and least-privilege settings.

- **New Features**
  - Add `.github/workflows/ci.yml`: `bun install --frozen-lockfile --ignore-scripts` → `bun run lint` (warnings fail) → `bun run typecheck` → `bun run test`; triggers on PRs and pushes; cancels superseded runs; README documents the steps.
  - Hardening: SHA-pinned `actions/checkout` and `oven-sh/setup-bun`; `permissions: contents: read`; Bun `1.3.14`; skip untrusted fork PRs on `starsling-ubuntu-24.04-2`.

<sup>Written for commit 0e7dcc8613532678173c04b26250b7adbfad2752. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/starslingdev/sandbox-benchmarks/pull/9?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

