### PR TITLE
chore: enforce Biome and the lockfile at commit time with lefthook

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,8 +68,21 @@ Run a single bin during development: `bun apps/cli/src/bin/plan-matrix.ts`.
 `bun run typecheck` → `bun run test`. The same checks run locally, so green-on-your-machine means
 green-in-CI.
 
+## Git hooks (pre-commit)
+
+[Lefthook](https://lefthook.dev) runs a fast local mirror of CI on every commit, configured in
+`lefthook.yml`. On staged files it runs Biome (`biome check --write`, restaging any auto-fixes;
+unfixable issues or warnings block the commit) and, when a manifest or the lockfile is touched,
+re-checks `bun install --frozen-lockfile` so `package.json` and `bun.lock` can't drift apart.
+
+`bun install` wires the hooks automatically via the project's own `prepare` script
+(`lefthook install`) — no third-party postinstall runs. Re-install them with `bunx lefthook
+install`, and bypass a single commit with `LEFTHOOK=0 git commit`.
+
 ## Supply-chain posture
 
 `bunfig.toml` sets `minimumReleaseAge = 604800` (7 days) so freshly published — possibly
-compromised — releases are not installed, and runs no third-party lifecycle scripts (empty
-`trustedDependencies`). Lint and formatting are root-only via a single `biome.json`.
+compromised — releases are not installed, and **no third-party lifecycle scripts run** (empty
+`trustedDependencies`). The git hooks above are wired by the project's own first-party `prepare`
+script, not a dependency's postinstall, and CI installs with `--ignore-scripts` so it runs none
+either. Lint and formatting are root-only via a single `biome.json`.

--- a/bun.lock
+++ b/bun.lock
@@ -7,6 +7,7 @@
       "devDependencies": {
         "@biomejs/biome": "2.4.16",
         "@types/bun": "catalog:",
+        "lefthook": "2.1.9",
         "typescript": "catalog:",
       },
     },
@@ -157,6 +158,28 @@
     "computesdk": ["computesdk@4.1.3", "", { "dependencies": { "@computesdk/cmd": "0.4.1", "daemond": "0.1.4" } }, "sha512-IVC7KenrhCyiGJ1FKTs7jzXTc+mJZNCljux39yzPeR2M48v6tr03YXTtiyefoJ+VZ1J/nVthrAqTF1ng+H4uOQ=="],
 
     "daemond": ["daemond@0.1.4", "", { "os": [ "linux", "darwin", ] }, "sha512-xiLScBiwYGGPmxfcAb24aH+FkmR/ZSd+PxOvigGpKda6OsDjE2Gj6/4oAX2N3hMWoL4atti1hYyF9dLV3FFM0A=="],
+
+    "lefthook": ["lefthook@2.1.9", "", { "optionalDependencies": { "lefthook-darwin-arm64": "2.1.9", "lefthook-darwin-x64": "2.1.9", "lefthook-freebsd-arm64": "2.1.9", "lefthook-freebsd-x64": "2.1.9", "lefthook-linux-arm64": "2.1.9", "lefthook-linux-x64": "2.1.9", "lefthook-openbsd-arm64": "2.1.9", "lefthook-openbsd-x64": "2.1.9", "lefthook-windows-arm64": "2.1.9", "lefthook-windows-x64": "2.1.9" }, "bin": { "lefthook": "bin/index.js" } }, "sha512-bwDaIOViTktE8kJLf9jP0p+H2/RDTlFFlc43Am2YgUsX22hI6Sq4RbzsrecwzY5y+MHTipOH7WsmWSEniePHWQ=="],
+
+    "lefthook-darwin-arm64": ["lefthook-darwin-arm64@2.1.9", "", { "os": "darwin", "cpu": "arm64" }, "sha512-119HryNcvr4nqn0wUIrNPgpMEPn9yMQzEcW/lezRsnb56PCJriJB92+MCySPVcWDxJnZef7o0T3jdnPNiSH7Qg=="],
+
+    "lefthook-darwin-x64": ["lefthook-darwin-x64@2.1.9", "", { "os": "darwin", "cpu": "x64" }, "sha512-dwo5Tke2XcQCM56DGHgFKBfRbJIL6xs2wZ0zG1TUVZgl4t4mQUt6LiZ4V/ZQfYHTZF9qywvXoIlR5N35qOaiVQ=="],
+
+    "lefthook-freebsd-arm64": ["lefthook-freebsd-arm64@2.1.9", "", { "os": "freebsd", "cpu": "arm64" }, "sha512-+09PVap6nl6xsaHch5JLtq7WvIR++U1Q2MzA2ai0M4uB/VP3AqrvKqHw6+9hjyKnIH+HHL83uqi77EAY+LaxLA=="],
+
+    "lefthook-freebsd-x64": ["lefthook-freebsd-x64@2.1.9", "", { "os": "freebsd", "cpu": "x64" }, "sha512-8XresjKIYpkE9ARgCtBEZgJZxAU3T4MIqzj4zNy15XRT59I1Us+QdqXTNm+pkZ41Yd2X/nxs2Pkvbq3NWWlIGw=="],
+
+    "lefthook-linux-arm64": ["lefthook-linux-arm64@2.1.9", "", { "os": "linux", "cpu": "arm64" }, "sha512-1oNIQfwrPe6rgU2KcDM3aF6+hpZDCKx1TmawQKpXUY5gVsbZ7MqX0Sk/1lnnWxqPm+kQQ5f6J2dpFWd+4xH8jg=="],
+
+    "lefthook-linux-x64": ["lefthook-linux-x64@2.1.9", "", { "os": "linux", "cpu": "x64" }, "sha512-fT+7Q+BJyGp+CslFQkNXmdFRgyVXsPHPi9NAsDX0a6QOyNnoORByAsvx6zeAKuF5rL3BBgNfho1/v2RuGxGy9w=="],
+
+    "lefthook-openbsd-arm64": ["lefthook-openbsd-arm64@2.1.9", "", { "os": "openbsd", "cpu": "arm64" }, "sha512-4bVuafBk3dddVNo0+3hMbjcJs4mqYAstxpPMmX2ufkudSTYFNIhWoqwuGVQV/SS/xdcOKJAldW4qayAzed2ysw=="],
+
+    "lefthook-openbsd-x64": ["lefthook-openbsd-x64@2.1.9", "", { "os": "openbsd", "cpu": "x64" }, "sha512-PmPoMmLP/wQQWcQ9u2YH86bTZ3UCfBsxuEmVTEyPU2U8R1qSTp5r/Gs3G8cN5Mxo91XB9oBERtF1n+xD3W6aVA=="],
+
+    "lefthook-windows-arm64": ["lefthook-windows-arm64@2.1.9", "", { "os": "win32", "cpu": "arm64" }, "sha512-KphfkBKmwBnmolyrdhIl3lrBaOyTcCgXBT2AB/9OHnEXhOLvv5uTCUkrD4YRAxXPtFKq6UvnapIeoL3GZq0bdA=="],
+
+    "lefthook-windows-x64": ["lefthook-windows-x64@2.1.9", "", { "os": "win32", "cpu": "x64" }, "sha512-2qlUtkJHZ3MyUxgV5XTEmcrIoNZA07iwaquoswAcqv/1MeBFXlD+O+koFRfrzWng2O5WYEbpJnd8tvaYnV8fTA=="],
 
     "typescript": ["typescript@6.0.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw=="],
 

--- a/bunfig.toml
+++ b/bunfig.toml
@@ -4,9 +4,10 @@
 linker = "hoisted"
 
 # Supply-chain posture (PRD): no third-party lifecycle scripts run.
-# Bun only runs preinstall/install/postinstall/prepare scripts for packages listed in
-# `trustedDependencies` — we declare none, so nothing third-party executes at install time.
-# Add a package there as a documented exception only when genuinely required.
+# Bun runs preinstall/install/postinstall/prepare scripts for a *dependency* only when it is listed
+# in `trustedDependencies` — we declare none, so nothing third-party executes at install time.
+# (The root package's OWN scripts still run; that's how `prepare: lefthook install` wires git hooks.)
+# Add a package to trustedDependencies as a documented exception only when genuinely required.
 
 # Refuse to install any npm release younger than 7 days, blunting compromised-release attacks.
 minimumReleaseAge = 604800

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -1,0 +1,21 @@
+# Local mirror of the CI checks (.github/workflows/ci.yml): every commit must leave its staged
+# changes Biome-clean and the bun lockfile in sync with the package manifests.
+#
+# Installed automatically by `bun install` via the project's own `prepare` script, which runs
+# `lefthook install` to wire the .git hooks — no third-party postinstall (trustedDependencies
+# stays empty). Re-wire with `bunx lefthook install`; skip a one-off commit with `LEFTHOOK=0 git commit`.
+
+pre-commit:
+  # Sequential (no `parallel`): Biome's stage_fixed (`git add`) finishes before the lockfile check
+  # shells out to `bun install`, so there's no concurrent git-index or manifest access.
+  commands:
+    # Format + lint + organize imports on staged files, restaging whatever Biome auto-fixes.
+    # Anything Biome can't fix — and any warning — blocks the commit, matching `bun run lint`.
+    # `bun biome` runs the local binary directly (no bunx resolution overhead).
+    biome:
+      run: bun biome check --write --error-on-warnings --no-errors-on-unmatched --files-ignore-unknown=true --colors=off {staged_files}
+      stage_fixed: true
+    # Touch a manifest or the lockfile and the two must agree (--frozen-lockfile fails on drift).
+    lockfile:
+      glob: "{package.json,bun.lock,packages/*/package.json,apps/*/package.json,tooling/*/package.json}"
+      run: bun install --frozen-lockfile --ignore-scripts

--- a/package.json
+++ b/package.json
@@ -29,10 +29,12 @@
     "format": "biome format . --write",
     "lint": "biome check . --error-on-warnings",
     "lint:fix": "biome check . --write",
-    "lint:fix:unsafe": "biome check . --fix --unsafe"
+    "lint:fix:unsafe": "biome check . --fix --unsafe",
+    "prepare": "lefthook install"
   },
   "devDependencies": {
     "@biomejs/biome": "2.4.16",
+    "lefthook": "2.1.9",
     "typescript": "catalog:",
     "@types/bun": "catalog:"
   }


### PR DESCRIPTION
Add lefthook (pinned 2.1.9) as the pre-commit hook manager, configured in
lefthook.yml to mirror CI locally on staged files:

- biome check --write --error-on-warnings: restages auto-fixes; anything
  unfixable or any warning blocks the commit (same strictness as bun run lint).
- bun install --frozen-lockfile when a manifest or bun.lock is staged, so
  package.json and the lockfile can't drift apart.

lefthook is listed in package.json trustedDependencies so bun install runs its
postinstall and wires .git/hooks automatically -- the single documented
exception to the repo's no-lifecycle-scripts posture (a pinned, >7-day-old
release). README documents the hook and the exception.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add `lefthook` pre-commit hooks to mirror CI on staged changes: `bun biome check --write --error-on-warnings` restages fixes and blocks warnings; touching manifests or `bun.lock` triggers `bun install --frozen-lockfile --ignore-scripts` to prevent drift. Commands run sequentially to avoid git-index conflicts; hooks are wired by our own `prepare` script (no third-party lifecycle scripts).

- **Dependencies**
  - Add `lefthook@2.1.9` (pinned) as a dev dependency.

- **Migration**
  - Hooks install automatically on `bun install` via `prepare` (`lefthook install`); re-install with `bunx lefthook install`.
  - Bypass once with `LEFTHOOK=0 git commit`.

<sup>Written for commit 21d3105fc3fc11ccd2fff9458265d57166f1fcc5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/starslingdev/sandbox-benchmarks/pull/10?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

