### PR TITLE
build: adopt mise for non-Bun tooling and pin the typos spell checker

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,8 +58,19 @@ private `lib/`.
 | `bun run format`     | `biome format . --write` — formatting only (no import sorting / lint fixes). |
 | `bun run lint:fix`   | `biome check . --write` — formatting + import sorting + safe lint fixes. |
 | `bun run lint:fix:unsafe` | `biome check . --fix --unsafe` — also applies behavior-changing fixes; review the diff. |
+| `bun run spell`      | `typos` — source-code spell check (run it before pushing).              |
+| `bun run spell:fix`  | `typos --write-changes` — apply typos' suggested corrections.            |
 
 Run a single bin during development: `bun apps/cli/src/bin/plan-matrix.ts`.
+
+## Toolchain (mise)
+
+Non-Bun tools are version-pinned in [`mise.toml`](mise.toml) and managed with
+[mise](https://mise.jdx.dev). Today that's [`typos`](https://github.com/crate-ci/typos), the
+spell checker behind `bun run spell`. After cloning, run `mise install` (and `mise trust` once) so
+the pinned binaries are available; `bun run spell` invokes typos through `mise exec`, so it always
+uses the pinned version. mise fetches from official release sources with checksum verification — no
+npm republisher and no install-time postinstall.
 
 ## Continuous integration
 

--- a/mise.toml
+++ b/mise.toml
@@ -1,0 +1,7 @@
+# Non-Bun developer tools, version-pinned and installed by `mise install` (or on demand via
+# `mise exec`). mise fetches from official sources with checksum verification — `typos` resolves
+# to the official `aqua:crate-ci/typos` release, not an npm republisher, so nothing here runs a
+# postinstall or needs Bun `trustedDependencies`. Run `mise trust` once after cloning.
+
+[tools]
+typos = "1.47.2"

--- a/package.json
+++ b/package.json
@@ -30,6 +30,8 @@
     "lint": "biome check . --error-on-warnings",
     "lint:fix": "biome check . --write",
     "lint:fix:unsafe": "biome check . --fix --unsafe",
+    "spell": "mise exec -- typos",
+    "spell:fix": "mise exec -- typos --write-changes",
     "prepare": "lefthook install"
   },
   "devDependencies": {

--- a/typos.toml
+++ b/typos.toml
@@ -1,0 +1,9 @@
+# typos (https://github.com/crate-ci/typos) config. The checker is pinned in mise.toml and run
+# via `bun run spell` / `bun run spell:fix`, locally (pre-commit) and in CI. When typos flags an
+# intentional identifier, add it under [default.extend-words] rather than rewording the code.
+
+[files]
+# The lockfile is generated and full of hashes/identifiers — don't spell-check it.
+extend-exclude = ["bun.lock"]
+
+[default.extend-words]


### PR DESCRIPTION
Introduce mise (mise.toml) to manage version-pinned non-Bun tools, starting
with typos 1.47.2 -- the official aqua:crate-ci/typos release, checksum-verified
by mise. No npm republisher, no postinstall, no Bun trustedDependencies.

Add `bun run spell` (typos) and `bun run spell:fix` (typos --write-changes),
both invoking typos through `mise exec` so the pinned version is always used.
typos config lives in typos.toml (the generated lockfile is excluded). README
documents the mise prerequisite and the new commands.

No enforcement yet -- CI and pre-commit wiring follow in the next two PRs.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adopted `mise` to pin non-Bun tools and added `typos` 1.47.2 as the spell checker, fetched from `aqua:crate-ci/typos` with checksum verification (no npm republisher or postinstall). Added `bun run spell` and `bun run spell:fix` via `mise exec`, with config in `typos.toml` (excludes `bun.lock`) and the version pinned in `mise.toml`.

- **Migration**
  - Install `mise`, then run `mise trust` once.
  - Run `mise install` to fetch the pinned tools.
  - Use `bun run spell` and `bun run spell:fix`. No CI or pre-commit enforcement yet.

<sup>Written for commit 76396fd75f721f412b2caa01e2e28c2199a7df40. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/starslingdev/sandbox-benchmarks/pull/11?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

