### PR TITLE
ci: enforce spelling with typos

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,7 +1,7 @@
 name: CI
 
 # Runs the README's "command contract" on every PR (and every push to main): the same Biome
-# lint, typecheck, and tests a developer runs locally must pass before code can merge.
+# lint, typecheck, tests, and spell check a developer runs locally must pass before code can merge.
 on:
   push:
     branches: [main]
@@ -18,7 +18,7 @@ permissions:
 
 jobs:
   check:
-    name: Lint, typecheck & test
+    name: Lint, typecheck, test & spell
     runs-on: starsling-ubuntu-24.04-2
     # The runner is self-hosted, so never execute untrusted fork-PR code on it: run only for
     # pushes and pull requests whose head is this same repository (fork PRs are skipped).
@@ -37,6 +37,15 @@ jobs:
           # Pinned to the toolchain version the repo develops against.
           bun-version: 1.3.14
 
+      # Installs the version-pinned tools from mise.toml (typos) with checksum verification, and
+      # caches them. mise itself is version-pinned for reproducibility.
+      - name: Set up mise tools
+        uses: jdx/mise-action@dba19683ed58901619b14f395a24841710cb4925 # v4.1.0
+        with:
+          version: 2026.5.16
+          install: true
+          cache: true
+
       # Frozen lockfile: fail if package.json and bun.lock have drifted. --ignore-scripts so CI
       # runs zero lifecycle scripts, matching bunfig.toml's supply-chain posture (minimumReleaseAge,
       # no third-party postinstalls).
@@ -52,3 +61,7 @@ jobs:
 
       - name: Test
         run: bun run test
+
+      # Spelling gate — typos (pinned in mise.toml); misspellings fail the build.
+      - name: Spell (typos)
+        run: bun run spell

--- a/README.md
+++ b/README.md
@@ -76,7 +76,8 @@ npm republisher and no install-time postinstall.
 
 `.github/workflows/ci.yml` runs the command contract on every pull request and every push to
 `main`: `bun install --frozen-lockfile --ignore-scripts` → `bun run lint` (the Biome gate) →
-`bun run typecheck` → `bun run test`. The same checks run locally, so green-on-your-machine means
+`bun run typecheck` → `bun run test` → `bun run spell` (typos, set up via
+[mise](https://mise.jdx.dev)). The same checks run locally, so green-on-your-machine means
 green-in-CI.
 
 ## Git hooks (pre-commit)


### PR DESCRIPTION
Add a spell gate to the CI workflow. A new step sets up mise (jdx/mise-action,
pinned to a commit SHA and a pinned mise version) which installs the typos
version from mise.toml with checksum verification, then runs `bun run spell`.
Misspellings fail the build, exactly as they do locally and at pre-commit.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enforces spelling in CI using `typos` installed via `mise`. Misspellings now fail the build, matching local and pre-commit behavior.

- **New Features**
  - Pinned `jdx/mise-action` and `mise`; installs `typos` from `mise.toml` with checksum verification and caching.
  - Added a "Spell (typos)" CI step (`bun run spell`) and updated the job name and README to include the new gate.

<sup>Written for commit 88e3f3b2dbb8d34768175e6c89f161d9fb0ea599. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/starslingdev/sandbox-benchmarks/pull/12?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

