### PR TITLE
chore: run typos in the pre-commit hook

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,9 +83,13 @@ green-in-CI.
 ## Git hooks (pre-commit)
 
 [Lefthook](https://lefthook.dev) runs a fast local mirror of CI on every commit, configured in
-`lefthook.yml`. On staged files it runs Biome (`biome check --write`, restaging any auto-fixes;
-unfixable issues or warnings block the commit) and, when a manifest or the lockfile is touched,
-re-checks `bun install --frozen-lockfile` so `package.json` and `bun.lock` can't drift apart.
+`lefthook.yml`:
+
+- **Biome** on staged files (`biome check --write`, restaging any auto-fixes; unfixable issues or
+  warnings block the commit).
+- **Typos** repo-wide (`bun run spell`) — read-only, so run `bun run spell:fix` to apply corrections.
+- **Lockfile** check (`bun install --frozen-lockfile`) when a manifest or `bun.lock` is staged, so
+  `package.json` and `bun.lock` can't drift apart.
 
 `bun install` wires the hooks automatically via the project's own `prepare` script
 (`lefthook install`) — no third-party postinstall runs. Re-install them with `bunx lefthook

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -15,6 +15,12 @@ pre-commit:
     biome:
       run: bun biome check --write --error-on-warnings --no-errors-on-unmatched --files-ignore-unknown=true --colors=off {staged_files}
       stage_fixed: true
+    # Spell-check with typos (pinned in mise.toml), repo-wide so its config excludes (e.g. the
+    # generated lockfile) apply — typos ignores excludes when handed explicit file paths. Repo-wide
+    # means a typo anywhere (not only in staged files) blocks the commit. Read-only: run
+    # `bun run spell:fix` to apply corrections (it can rename identifiers, so review them).
+    typos:
+      run: bun run spell
     # Touch a manifest or the lockfile and the two must agree (--frozen-lockfile fails on drift).
     lockfile:
       glob: "{package.json,bun.lock,packages/*/package.json,apps/*/package.json,tooling/*/package.json}"


### PR DESCRIPTION
Add a typos command to the lefthook pre-commit hook, in parallel with the Biome
and lockfile checks. It runs `bun run spell` repo-wide so typos.toml excludes
(the generated lockfile) apply -- typos ignores excludes when handed explicit
file paths. Repo-wide means a typo anywhere blocks the commit. Read-only: it
blocks on misspellings; run `bun run spell:fix` to apply corrections (which can
rename identifiers, so review them). README updated.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add `typos` spell-check to the pre-commit hook in `lefthook.yml`, running in parallel with Biome and lockfile checks. It runs `bun run spell` repo-wide so `typos.toml` excludes (e.g., `bun.lock`) apply; any typo blocks the commit; read-only—use `bun run spell:fix` to apply corrections; `README` updated.

<sup>Written for commit 3733ec7e02a3316865ea989f94dd8a203cfaca54. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/starslingdev/sandbox-benchmarks/pull/13?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

