### PR TITLE
hotfix: fix repo-wide Biome formatting and import-type lint errors

### DIFF
--- a/packages/harness/src/index.test.ts
+++ b/packages/harness/src/index.test.ts
@@ -3,11 +3,11 @@ import { createStubAdapter } from "@sandbox-benchmarks/providers";
 import { timeOperation } from "./index.ts";
 
 describe("@sandbox-benchmarks/harness", () => {
-  it("times an operation and emits a raw run for the adapter", async () => {
-    const adapter = createStubAdapter("e2b", "E2B");
-    const run = await timeOperation(adapter, "spawn", () => {});
-    expect(run.provider).toBe("e2b");
-    expect(run.operation).toBe("spawn");
-    expect(run.durationMs).toBeGreaterThan(0);
-  });
+	it("times an operation and emits a raw run for the adapter", async () => {
+		const adapter = createStubAdapter("e2b", "E2B");
+		const run = await timeOperation(adapter, "spawn", () => {});
+		expect(run.provider).toBe("e2b");
+		expect(run.operation).toBe("spawn");
+		expect(run.durationMs).toBeGreaterThan(0);
+	});
 });

--- a/packages/harness/src/index.ts
+++ b/packages/harness/src/index.ts
@@ -5,19 +5,19 @@ import { now } from "./lib/internal.ts";
 
 /** Time a single operation against an adapter, producing a {@link RawRun}. Stub. */
 export async function timeOperation(
-  adapter: ProviderAdapter,
-  operation: string,
-  run: () => Promise<void> | void,
+	adapter: ProviderAdapter,
+	operation: string,
+	run: () => Promise<void> | void,
 ): Promise<RawRun> {
-  const start = now();
-  // NOTE: a rejected `run` currently propagates and no sample is recorded. Capturing failed-run
-  // duration as an error sample lands when `rawRunSchema` grows an error shape.
-  await run();
-  return {
-    provider: adapter.descriptor.id,
-    operation,
-    // Floor to a strictly-positive value: `rawRunSchema` requires `durationMs > 0`, and a
-    // synchronous no-op can observe two equal `now()` readings (a 0 delta).
-    durationMs: Math.max(now() - start, Number.EPSILON),
-  };
+	const start = now();
+	// NOTE: a rejected `run` currently propagates and no sample is recorded. Capturing failed-run
+	// duration as an error sample lands when `rawRunSchema` grows an error shape.
+	await run();
+	return {
+		provider: adapter.descriptor.id,
+		operation,
+		// Floor to a strictly-positive value: `rawRunSchema` requires `durationMs > 0`, and a
+		// synchronous no-op can observe two equal `now()` readings (a 0 delta).
+		durationMs: Math.max(now() - start, Number.EPSILON),
+	};
 }

--- a/packages/harness/src/lib/internal.ts
+++ b/packages/harness/src/lib/internal.ts
@@ -2,5 +2,5 @@
 
 /** Monotonic clock wrapper so timing is swappable in tests. Stub. */
 export function now(): number {
-  return performance.now();
+	return performance.now();
 }

--- a/packages/providers/src/index.test.ts
+++ b/packages/providers/src/index.test.ts
@@ -2,13 +2,13 @@ import { describe, expect, it } from "bun:test";
 import { createStubAdapter, providerRuntimeReady } from "./index.ts";
 
 describe("@sandbox-benchmarks/providers", () => {
-  it("builds a stub adapter with an all-false capability set", () => {
-    const adapter = createStubAdapter("e2b", "E2B");
-    expect(adapter.descriptor.id).toBe("e2b");
-    expect(adapter.descriptor.capabilities.exec).toBe(false);
-  });
+	it("builds a stub adapter with an all-false capability set", () => {
+		const adapter = createStubAdapter("e2b", "E2B");
+		expect(adapter.descriptor.id).toBe("e2b");
+		expect(adapter.descriptor.capabilities.exec).toBe(false);
+	});
 
-  it("resolves the computesdk runtime through the catalog", () => {
-    expect(providerRuntimeReady).toBe(true);
-  });
+	it("resolves the computesdk runtime through the catalog", () => {
+		expect(providerRuntimeReady).toBe(true);
+	});
 });

--- a/packages/providers/src/index.ts
+++ b/packages/providers/src/index.ts
@@ -8,14 +8,14 @@ import { computeSdkExportCount, emptyCapabilities } from "./lib/internal.ts";
  * Stub — the real adapter interface lands in the providers implementation pass.
  */
 export interface ProviderAdapter {
-  descriptor: ProviderDescriptor;
+	descriptor: ProviderDescriptor;
 }
 
 /** Build a stub adapter for a provider id with no capabilities yet. */
 export function createStubAdapter(id: string, displayName: string): ProviderAdapter {
-  return {
-    descriptor: { id, displayName, capabilities: emptyCapabilities() },
-  };
+	return {
+		descriptor: { id, displayName, capabilities: emptyCapabilities() },
+	};
 }
 
 /** Re-exported witness that the computesdk surface is reachable and non-empty. */

--- a/packages/providers/src/lib/internal.ts
+++ b/packages/providers/src/lib/internal.ts
@@ -1,6 +1,7 @@
 // Private implementation detail of @sandbox-benchmarks/providers.
 // Proves `catalog:computesdk` resolves: we reference the computesdk module surface here.
-import { type CapabilityFlags, capabilities } from "@sandbox-benchmarks/schema";
+import type { CapabilityFlags } from "@sandbox-benchmarks/schema";
+import { capabilities } from "@sandbox-benchmarks/schema";
 import * as computesdk from "computesdk";
 
 // The `import * as computesdk` above is the compile-time witness that `catalog:computesdk`
@@ -13,5 +14,5 @@ export const computeSdkExportCount: number = Object.keys(computesdk).length;
  * newly added capability automatically appears here. Concrete providers override what they support.
  */
 export function emptyCapabilities(): CapabilityFlags {
-  return Object.fromEntries(capabilities.map((c) => [c, false])) as CapabilityFlags;
+	return Object.fromEntries(capabilities.map((c) => [c, false])) as CapabilityFlags;
 }

--- a/packages/results/src/index.test.ts
+++ b/packages/results/src/index.test.ts
@@ -3,12 +3,12 @@ import type { RawRun } from "@sandbox-benchmarks/schema";
 import { normalize } from "./index.ts";
 
 describe("@sandbox-benchmarks/results", () => {
-  it("normalizes a raw run into a run document", () => {
-    const raw: RawRun = { provider: "modal", operation: "exec", durationMs: 42 };
-    const doc = normalize(raw);
-    expect(doc.provider).toBe("modal");
-    expect(doc.operation).toBe("exec");
-    expect(doc.durationMs).toBe(42);
-    expect(() => new Date(doc.normalizedAt).toISOString()).not.toThrow();
-  });
+	it("normalizes a raw run into a run document", () => {
+		const raw: RawRun = { provider: "modal", operation: "exec", durationMs: 42 };
+		const doc = normalize(raw);
+		expect(doc.provider).toBe("modal");
+		expect(doc.operation).toBe("exec");
+		expect(doc.durationMs).toBe(42);
+		expect(() => new Date(doc.normalizedAt).toISOString()).not.toThrow();
+	});
 });

--- a/packages/results/src/index.ts
+++ b/packages/results/src/index.ts
@@ -5,10 +5,10 @@ import { isoNow } from "./lib/internal.ts";
 
 /** Normalize a single raw run into a {@link RunDocument}. Stub logic. */
 export function normalize(raw: RawRun): RunDocument {
-  return {
-    provider: raw.provider,
-    operation: raw.operation,
-    durationMs: raw.durationMs,
-    normalizedAt: isoNow(),
-  };
+	return {
+		provider: raw.provider,
+		operation: raw.operation,
+		durationMs: raw.durationMs,
+		normalizedAt: isoNow(),
+	};
 }

--- a/packages/results/src/lib/internal.ts
+++ b/packages/results/src/lib/internal.ts
@@ -2,5 +2,5 @@
 
 /** Current time as an ISO-8601 string. Wrapped so it can be stubbed in tests. */
 export function isoNow(): string {
-  return new Date().toISOString();
+	return new Date().toISOString();
 }

--- a/packages/templates/src/daytona.ts
+++ b/packages/templates/src/daytona.ts
@@ -1,9 +1,10 @@
 // `@sandbox-benchmarks/templates/daytona` — one subpath, one module (the template policy).
 import { createStubAdapter } from "@sandbox-benchmarks/providers";
-import { makeTemplateSpec, type TemplateSpec } from "./lib/internal.ts";
+import type { TemplateSpec } from "./lib/internal.ts";
+import { makeTemplateSpec } from "./lib/internal.ts";
 
 /** Build the Daytona sandbox template (stub). */
 export function buildDaytonaTemplate(tag = "latest"): TemplateSpec {
-  const { descriptor } = createStubAdapter("daytona", "Daytona");
-  return makeTemplateSpec(descriptor.id, tag);
+	const { descriptor } = createStubAdapter("daytona", "Daytona");
+	return makeTemplateSpec(descriptor.id, tag);
 }

--- a/packages/templates/src/e2b.ts
+++ b/packages/templates/src/e2b.ts
@@ -1,9 +1,10 @@
 // `@sandbox-benchmarks/templates/e2b` — one subpath, one module (the template policy).
 import { createStubAdapter } from "@sandbox-benchmarks/providers";
-import { makeTemplateSpec, type TemplateSpec } from "./lib/internal.ts";
+import type { TemplateSpec } from "./lib/internal.ts";
+import { makeTemplateSpec } from "./lib/internal.ts";
 
 /** Build the E2B sandbox template (stub). */
 export function buildE2bTemplate(tag = "latest"): TemplateSpec {
-  const { descriptor } = createStubAdapter("e2b", "E2B");
-  return makeTemplateSpec(descriptor.id, tag);
+	const { descriptor } = createStubAdapter("e2b", "E2B");
+	return makeTemplateSpec(descriptor.id, tag);
 }

--- a/packages/templates/src/index.test.ts
+++ b/packages/templates/src/index.test.ts
@@ -5,13 +5,13 @@ import { templateProviders } from "./index.ts";
 import { buildModalTemplate } from "./modal.ts";
 
 describe("@sandbox-benchmarks/templates", () => {
-  it("builds one template spec per provider subpath", () => {
-    expect(buildE2bTemplate("v1").provider).toBe("e2b");
-    expect(buildDaytonaTemplate("v1").provider).toBe("daytona");
-    expect(buildModalTemplate("v1").provider).toBe("modal");
-  });
+	it("builds one template spec per provider subpath", () => {
+		expect(buildE2bTemplate("v1").provider).toBe("e2b");
+		expect(buildDaytonaTemplate("v1").provider).toBe("daytona");
+		expect(buildModalTemplate("v1").provider).toBe("modal");
+	});
 
-  it("lists every provider that has a builder", () => {
-    expect([...templateProviders]).toEqual(["e2b", "daytona", "modal"]);
-  });
+	it("lists every provider that has a builder", () => {
+		expect([...templateProviders]).toEqual(["e2b", "daytona", "modal"]);
+	});
 });

--- a/packages/templates/src/index.ts
+++ b/packages/templates/src/index.ts
@@ -11,9 +11,9 @@ export { buildDaytonaTemplate, buildE2bTemplate, buildModalTemplate };
 /** Each provider id mapped to its template builder. `templateProviders` is derived from these
  *  keys, so the published id list can't drift from the builders that actually exist. */
 const templateBuilders = {
-  e2b: buildE2bTemplate,
-  daytona: buildDaytonaTemplate,
-  modal: buildModalTemplate,
+	e2b: buildE2bTemplate,
+	daytona: buildDaytonaTemplate,
+	modal: buildModalTemplate,
 } satisfies Record<string, (tag?: string) => TemplateSpec>;
 
 /** All provider ids that ship a template builder this pass. */

--- a/packages/templates/src/lib/internal.ts
+++ b/packages/templates/src/lib/internal.ts
@@ -3,13 +3,13 @@ import type { ProviderDescriptor } from "@sandbox-benchmarks/schema";
 
 /** A built sandbox template descriptor. Stub shape — real build metadata lands later. */
 export interface TemplateSpec {
-  /** The provider this template targets. */
-  provider: ProviderDescriptor["id"];
-  /** Opaque template tag/id the build step would produce. */
-  tag: string;
+	/** The provider this template targets. */
+	provider: ProviderDescriptor["id"];
+	/** Opaque template tag/id the build step would produce. */
+	tag: string;
 }
 
 /** Shared helper used by every per-provider builder module. */
 export function makeTemplateSpec(provider: string, tag: string): TemplateSpec {
-  return { provider, tag };
+	return { provider, tag };
 }

--- a/packages/templates/src/modal.ts
+++ b/packages/templates/src/modal.ts
@@ -1,9 +1,10 @@
 // `@sandbox-benchmarks/templates/modal` — one subpath, one module (the template policy).
 import { createStubAdapter } from "@sandbox-benchmarks/providers";
-import { makeTemplateSpec, type TemplateSpec } from "./lib/internal.ts";
+import type { TemplateSpec } from "./lib/internal.ts";
+import { makeTemplateSpec } from "./lib/internal.ts";
 
 /** Build the Modal sandbox template (stub). */
 export function buildModalTemplate(tag = "latest"): TemplateSpec {
-  const { descriptor } = createStubAdapter("modal", "Modal");
-  return makeTemplateSpec(descriptor.id, tag);
+	const { descriptor } = createStubAdapter("modal", "Modal");
+	return makeTemplateSpec(descriptor.id, tag);
 }

--- a/tooling/test-utils/src/index.test.ts
+++ b/tooling/test-utils/src/index.test.ts
@@ -3,11 +3,11 @@ import type { CapabilityFlags } from "@sandbox-benchmarks/schema";
 import { createProviderConformanceSuite } from "./index.ts";
 
 describe("@repo/test-utils", () => {
-  it("scopes a conformance suite to the capabilities the adapter claims", () => {
-    const flags: CapabilityFlags = { spawn: true, exec: true, filesystem: false, snapshot: false };
-    const suite = createProviderConformanceSuite({ id: "e2b" }, flags);
-    expect(suite.name).toBe("conformance: e2b");
-    expect(suite.covers.sort()).toEqual(["exec", "spawn"]);
-    expect(() => suite.run()).not.toThrow();
-  });
+	it("scopes a conformance suite to the capabilities the adapter claims", () => {
+		const flags: CapabilityFlags = { spawn: true, exec: true, filesystem: false, snapshot: false };
+		const suite = createProviderConformanceSuite({ id: "e2b" }, flags);
+		expect(suite.name).toBe("conformance: e2b");
+		expect(suite.covers.sort()).toEqual(["exec", "spawn"]);
+		expect(() => suite.run()).not.toThrow();
+	});
 });

--- a/tooling/test-utils/src/index.ts
+++ b/tooling/test-utils/src/index.ts
@@ -6,16 +6,16 @@ import { supportedCapabilities } from "./lib/internal.ts";
 
 /** Minimal adapter shape the conformance suite drives. Stub — widened as the harness grows. */
 export interface ConformanceAdapter {
-  id: string;
+	id: string;
 }
 
 /** A registered conformance suite: its name and the assertions it would run. Stub. */
 export interface ConformanceSuite {
-  name: string;
-  /** Capabilities this suite will exercise, derived from the declared flags. */
-  covers: Capability[];
-  /** Run the suite. Stub: a real suite would register `bun:test` cases per capability. */
-  run(): void;
+	name: string;
+	/** Capabilities this suite will exercise, derived from the declared flags. */
+	covers: Capability[];
+	/** Run the suite. Stub: a real suite would register `bun:test` cases per capability. */
+	run(): void;
 }
 
 /**
@@ -23,15 +23,15 @@ export interface ConformanceSuite {
  * Typed against schema's {@link CapabilityFlags} so capability drift is a type error.
  */
 export function createProviderConformanceSuite(
-  adapter: ConformanceAdapter,
-  capabilities: CapabilityFlags,
+	adapter: ConformanceAdapter,
+	capabilities: CapabilityFlags,
 ): ConformanceSuite {
-  const covers = supportedCapabilities(capabilities);
-  return {
-    name: `conformance: ${adapter.id}`,
-    covers,
-    run() {
-      // Stub: real implementation registers one bun:test block per covered capability.
-    },
-  };
+	const covers = supportedCapabilities(capabilities);
+	return {
+		name: `conformance: ${adapter.id}`,
+		covers,
+		run() {
+			// Stub: real implementation registers one bun:test block per covered capability.
+		},
+	};
 }

--- a/tooling/test-utils/src/lib/internal.ts
+++ b/tooling/test-utils/src/lib/internal.ts
@@ -3,5 +3,5 @@ import type { Capability, CapabilityFlags } from "@sandbox-benchmarks/schema";
 
 /** The capabilities a descriptor claims, as a list (derived from its flags). */
 export function supportedCapabilities(flags: CapabilityFlags): Capability[] {
-  return (Object.keys(flags) as Capability[]).filter((c) => flags[c]);
+	return (Object.keys(flags) as Capability[]).filter((c) => flags[c]);
 }


### PR DESCRIPTION
## What

The repo-wide Biome lint reported 31 errors, including ones in pre-existing files (`packages/templates`, `tooling/test-utils`). This fixes all of them so `lint`, `format`, and `spell` run clean.

Two categories, both safe-fixable:
- **Formatting** — files used 2-space indentation, but `biome.json` mandates `indentStyle: "tab"`. Most of the errors.
- **Lint (`useImportType`)** — files mixed type and value imports on one line (e.g. `import { type TemplateSpec, makeTemplateSpec }`); config requires `separatedType`, so each was split into a dedicated `import type { … }`.

Applied via `biome check . --write` using the project's pinned Biome **2.4.16**. No source logic changed — formatting and import-grouping only.

## Verification

| Command | Result |
|---|---|
| `bun run lint` | ✅ 0 errors |
| `bun run format` | ✅ no changes needed |
| `typos` (spell) | ✅ no misspellings |
| `bun run typecheck` | ✅ all packages pass |
| `bun run test` | ✅ all suites pass |

The spelling category was already clean — the 31 errors were entirely Biome formatting + import-type lint.

https://claude.ai/code/session_01BqoaBfJQ4FunBxxZ5dwU7W

---
_Generated by [Claude Code](https://claude.ai/code/session_01BqoaBfJQ4FunBxxZ5dwU7W)_

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Standardizes formatting and imports across the repo to match Biome rules so `bun run lint`, `bun run format`, and `typos` all pass. No logic or behavior changes.

- **Refactors**
  - Switch to tab indentation per `indentStyle: "tab"`.
  - Split mixed type/value imports into `import type { … }` and value imports to satisfy `useImportType` with `separatedType` (applied via `biome check . --write` using Biome 2.4.16).

<sup>Written for commit 831a4448a0c781a863cac54e46924e8dfeb19fe1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/starslingdev/sandbox-benchmarks/pull/14?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved code formatting and indentation across the codebase for consistency.
  * Reorganized imports to use type-only declarations where applicable for better tree-shaking and clarity.
  * Streamlined internal utility implementations for maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->