### PR TITLE
fix(repo-checks): satisfy Biome and typos gates

### DIFF
--- a/tooling/repo-checks/src/boundary.test.ts
+++ b/tooling/repo-checks/src/boundary.test.ts
@@ -10,13 +10,13 @@
 import { describe, expect, it } from "bun:test";
 import { dirname } from "node:path";
 import {
-  importSpecifiers,
-  listMembers,
-  memberSourceFiles,
-  relative,
-  resolve,
-  sep,
-  stripComments,
+	importSpecifiers,
+	listMembers,
+	memberSourceFiles,
+	relative,
+	resolve,
+	sep,
+	stripComments,
 } from "./lib/workspace.ts";
 
 const allMembers = listMembers();
@@ -25,132 +25,132 @@ const srcMembers = allMembers.filter((m) => m.hasSrc);
 
 /** The workspace package an import specifier targets (by exact name or `name/...` subpath), or null if external. */
 function targetMember(spec: string): string | null {
-  for (const name of memberNames) {
-    if (spec === name || spec.startsWith(`${name}/`)) return name;
-  }
-  return null;
+	for (const name of memberNames) {
+		if (spec === name || spec.startsWith(`${name}/`)) return name;
+	}
+	return null;
 }
 
 describe("import boundaries", () => {
-  for (const member of srcMembers) {
-    it(`${member.relPath}: imports stay in-package and are declared`, () => {
-      const declared = new Set([
-        ...Object.keys(member.pkg.dependencies ?? {}),
-        ...Object.keys(member.pkg.devDependencies ?? {}),
-      ]);
-      const violations: string[] = [];
+	for (const member of srcMembers) {
+		it(`${member.relPath}: imports stay in-package and are declared`, () => {
+			const declared = new Set([
+				...Object.keys(member.pkg.dependencies ?? {}),
+				...Object.keys(member.pkg.devDependencies ?? {}),
+			]);
+			const violations: string[] = [];
 
-      for (const file of memberSourceFiles(member)) {
-        const rel = relative(process.cwd(), file);
-        for (const spec of importSpecifiers(file)) {
-          if (spec.startsWith(".")) {
-            // (a) relative import escaping the package root. Compare with a trailing
-            // separator so a sibling whose name is a prefix (foo vs foo-bar) can't slip through.
-            const target = resolve(dirname(file), spec);
-            if (target !== member.dir && !target.startsWith(member.dir + sep)) {
-              violations.push(`${rel} → "${spec}" escapes ${member.relPath}`);
-            }
-            continue;
-          }
+			for (const file of memberSourceFiles(member)) {
+				const rel = relative(process.cwd(), file);
+				for (const spec of importSpecifiers(file)) {
+					if (spec.startsWith(".")) {
+						// (a) relative import escaping the package root. Compare with a trailing
+						// separator so a sibling whose name is a prefix (foo vs foo-bar) can't slip through.
+						const target = resolve(dirname(file), spec);
+						if (target !== member.dir && !target.startsWith(member.dir + sep)) {
+							violations.push(`${rel} → "${spec}" escapes ${member.relPath}`);
+						}
+						continue;
+					}
 
-          const owner = targetMember(spec);
-          if (owner === null || owner === member.name) continue; // external dep or self-reference
+					const owner = targetMember(spec);
+					if (owner === null || owner === member.name) continue; // external dep or self-reference
 
-          // (b) reaching into another workspace package's private lib/.
-          const subpath = spec.slice(owner.length + 1);
-          if (/(^|\/)lib(\/|$)/.test(subpath)) {
-            violations.push(`${rel} → "${spec}" reaches into ${owner}'s private lib/`);
-          }
+					// (b) reaching into another workspace package's private lib/.
+					const subpath = spec.slice(owner.length + 1);
+					if (/(^|\/)lib(\/|$)/.test(subpath)) {
+						violations.push(`${rel} → "${spec}" reaches into ${owner}'s private lib/`);
+					}
 
-          // (c) the workspace package must be a declared dependency.
-          if (!declared.has(owner)) {
-            violations.push(`${rel} → imports "${owner}" but it is not a declared dependency`);
-          }
-        }
-      }
+					// (c) the workspace package must be a declared dependency.
+					if (!declared.has(owner)) {
+						violations.push(`${rel} → imports "${owner}" but it is not a declared dependency`);
+					}
+				}
+			}
 
-      expect(violations).toEqual([]);
-    });
-  }
+			expect(violations).toEqual([]);
+		});
+	}
 
-  it("found source members to scan", () => {
-    expect(srcMembers.length).toBeGreaterThan(0);
-  });
+	it("found source members to scan", () => {
+		expect(srcMembers.length).toBeGreaterThan(0);
+	});
 });
 
 /** Return a cycle (as the list of nodes on it) in a directed graph, or null if acyclic. */
 function findCycle(nodes: string[], edges: Map<string, string[]>): string[] | null {
-  const seen = new Map<string, number>(); // 0 = visiting (on stack), 1 = done
-  const stack: string[] = [];
+	const seen = new Map<string, number>(); // 0 = visiting (on stack), 1 = done
+	const stack: string[] = [];
 
-  function visit(node: string): string[] | null {
-    seen.set(node, 0);
-    stack.push(node);
-    for (const next of edges.get(node) ?? []) {
-      if (!seen.has(next)) {
-        const found = visit(next);
-        if (found) return found;
-      } else if (seen.get(next) === 0) {
-        return [...stack.slice(stack.indexOf(next)), next]; // back-edge → cycle
-      }
-    }
-    stack.pop();
-    seen.set(node, 1);
-    return null;
-  }
+	function visit(node: string): string[] | null {
+		seen.set(node, 0);
+		stack.push(node);
+		for (const next of edges.get(node) ?? []) {
+			if (!seen.has(next)) {
+				const found = visit(next);
+				if (found) return found;
+			} else if (seen.get(next) === 0) {
+				return [...stack.slice(stack.indexOf(next)), next]; // back-edge → cycle
+			}
+		}
+		stack.pop();
+		seen.set(node, 1);
+		return null;
+	}
 
-  for (const node of nodes) {
-    if (!seen.has(node)) {
-      const found = visit(node);
-      if (found) return found;
-    }
-  }
-  return null;
+	for (const node of nodes) {
+		if (!seen.has(node)) {
+			const found = visit(node);
+			if (found) return found;
+		}
+	}
+	return null;
 }
 
 describe("dependency-graph layering", () => {
-  it("the internal runtime dependency graph is acyclic", () => {
-    const nodes = allMembers.map((m) => m.name);
-    const edges = new Map<string, string[]>(
-      allMembers.map((m) => [
-        m.name,
-        Object.keys(m.pkg.dependencies ?? {}).filter((d) => memberNames.has(d)),
-      ]),
-    );
-    expect(findCycle(nodes, edges)).toBeNull();
-  });
+	it("the internal runtime dependency graph is acyclic", () => {
+		const nodes = allMembers.map((m) => m.name);
+		const edges = new Map<string, string[]>(
+			allMembers.map((m) => [
+				m.name,
+				Object.keys(m.pkg.dependencies ?? {}).filter((d) => memberNames.has(d)),
+			]),
+		);
+		expect(findCycle(nodes, edges)).toBeNull();
+	});
 
-  // Guard against a vacuous detector: it must flag a known cycle and clear a known DAG.
-  it("findCycle flags a real cycle and clears an acyclic graph", () => {
-    const cyclic = new Map([
-      ["a", ["b"]],
-      ["b", ["c"]],
-      ["c", ["a"]],
-    ]);
-    expect(findCycle(["a", "b", "c"], cyclic)).not.toBeNull();
+	// Guard against a vacuous detector: it must flag a known cycle and clear a known DAG.
+	it("findCycle flags a real cycle and clears an acyclic graph", () => {
+		const cyclic = new Map([
+			["a", ["b"]],
+			["b", ["c"]],
+			["c", ["a"]],
+		]);
+		expect(findCycle(["a", "b", "c"], cyclic)).not.toBeNull();
 
-    const acyclic = new Map([
-      ["a", ["b", "c"]],
-      ["b", ["c"]],
-      ["c", []],
-    ]);
-    expect(findCycle(["a", "b", "c"], acyclic)).toBeNull();
-  });
+		const acyclic = new Map([
+			["a", ["b", "c"]],
+			["b", ["c"]],
+			["c", []],
+		]);
+		expect(findCycle(["a", "b", "c"], acyclic)).toBeNull();
+	});
 });
 
 describe("stripComments (import-extraction pre-pass)", () => {
-  it("drops commented-out imports but keeps live imports and string contents", () => {
-    const src = [
-      'import { live } from "external-live";',
-      '// import { dead } from "external-dead";',
-      '/* import { block } from "external-block"; */',
-      'const url = "http://example.com/x";',
-    ].join("\n");
-    const cleaned = stripComments(src);
-    expect(cleaned).toContain("external-live");
-    expect(cleaned).not.toContain("external-dead");
-    expect(cleaned).not.toContain("external-block");
-    // A `//` inside a string literal is not a comment, so the URL survives.
-    expect(cleaned).toContain("http://example.com/x");
-  });
+	it("drops commented-out imports but keeps live imports and string contents", () => {
+		const src = [
+			'import { live } from "external-live";',
+			'// import { dead } from "external-dead";',
+			'/* import { block } from "external-block"; */',
+			'const url = "http://example.com/x";',
+		].join("\n");
+		const cleaned = stripComments(src);
+		expect(cleaned).toContain("external-live");
+		expect(cleaned).not.toContain("external-dead");
+		expect(cleaned).not.toContain("external-block");
+		// A `//` inside a string literal is not a comment, so the URL survives.
+		expect(cleaned).toContain("http://example.com/x");
+	});
 });

--- a/tooling/repo-checks/src/lib/workspace.ts
+++ b/tooling/repo-checks/src/lib/workspace.ts
@@ -5,117 +5,117 @@ import { dirname, join, relative, resolve, sep } from "node:path";
 import { Glob } from "bun";
 
 export interface PackageJson {
-  name?: string;
-  version?: string;
-  private?: boolean;
-  type?: string;
-  exports?: Record<string, unknown>;
-  bin?: Record<string, string> | string;
-  files?: string[];
-  scripts?: Record<string, string>;
-  dependencies?: Record<string, string>;
-  devDependencies?: Record<string, string>;
-  workspaces?:
-    | string[]
-    | {
-        packages?: string[];
-        catalog?: Record<string, string>;
-        catalogs?: Record<string, Record<string, string>>;
-      };
+	name?: string;
+	version?: string;
+	private?: boolean;
+	type?: string;
+	exports?: Record<string, unknown>;
+	bin?: Record<string, string> | string;
+	files?: string[];
+	scripts?: Record<string, string>;
+	dependencies?: Record<string, string>;
+	devDependencies?: Record<string, string>;
+	workspaces?:
+		| string[]
+		| {
+				packages?: string[];
+				catalog?: Record<string, string>;
+				catalogs?: Record<string, Record<string, string>>;
+		  };
 }
 
 export interface Member {
-  /** Declared package name. */
-  name: string;
-  /** Absolute path to the member directory. */
-  dir: string;
-  /** Path of the member directory relative to the repo root, e.g. "packages/schema". */
-  relPath: string;
-  /** Whether the member has a `src/` directory (a "source member"). */
-  hasSrc: boolean;
-  /** Parsed package.json. */
-  pkg: PackageJson;
+	/** Declared package name. */
+	name: string;
+	/** Absolute path to the member directory. */
+	dir: string;
+	/** Path of the member directory relative to the repo root, e.g. "packages/schema". */
+	relPath: string;
+	/** Whether the member has a `src/` directory (a "source member"). */
+	hasSrc: boolean;
+	/** Parsed package.json. */
+	pkg: PackageJson;
 }
 
 function readJson(path: string): PackageJson {
-  return JSON.parse(readFileSync(path, "utf8")) as PackageJson;
+	return JSON.parse(readFileSync(path, "utf8")) as PackageJson;
 }
 
 /** Walk up from `start` until we find the package.json that declares `workspaces`. */
 export function findRepoRoot(start: string = import.meta.dir): string {
-  let dir = start;
-  for (;;) {
-    const pj = join(dir, "package.json");
-    if (existsSync(pj) && readJson(pj).workspaces) return dir;
-    const parent = dirname(dir);
-    if (parent === dir)
-      throw new Error("could not locate repo root (no package.json with workspaces)");
-    dir = parent;
-  }
+	let dir = start;
+	for (;;) {
+		const pj = join(dir, "package.json");
+		if (existsSync(pj) && readJson(pj).workspaces) return dir;
+		const parent = dirname(dir);
+		if (parent === dir)
+			throw new Error("could not locate repo root (no package.json with workspaces)");
+		dir = parent;
+	}
 }
 
 /** The workspace package globs from the root package.json (object or array form). */
 export function workspaceGlobs(root: string = findRepoRoot()): string[] {
-  const ws = readJson(join(root, "package.json")).workspaces;
-  if (!ws) return [];
-  return Array.isArray(ws) ? ws : (ws.packages ?? []);
+	const ws = readJson(join(root, "package.json")).workspaces;
+	if (!ws) return [];
+	return Array.isArray(ws) ? ws : (ws.packages ?? []);
 }
 
 /** Enumerate every workspace member by expanding the workspace globs. */
 export function listMembers(root: string = findRepoRoot()): Member[] {
-  const members: Member[] = [];
-  for (const g of workspaceGlobs(root)) {
-    const glob = new Glob(`${g}/package.json`);
-    for (const rel of glob.scanSync({ cwd: root, onlyFiles: true })) {
-      const dir = dirname(join(root, rel));
-      const pkg = readJson(join(dir, "package.json"));
-      members.push({
-        name: pkg.name ?? "<unnamed>",
-        dir,
-        relPath: dirname(rel),
-        hasSrc: existsSync(join(dir, "src")),
-        pkg,
-      });
-    }
-  }
-  return members.sort((a, b) => a.relPath.localeCompare(b.relPath));
+	const members: Member[] = [];
+	for (const g of workspaceGlobs(root)) {
+		const glob = new Glob(`${g}/package.json`);
+		for (const rel of glob.scanSync({ cwd: root, onlyFiles: true })) {
+			const dir = dirname(join(root, rel));
+			const pkg = readJson(join(dir, "package.json"));
+			members.push({
+				name: pkg.name ?? "<unnamed>",
+				dir,
+				relPath: dirname(rel),
+				hasSrc: existsSync(join(dir, "src")),
+				pkg,
+			});
+		}
+	}
+	return members.sort((a, b) => a.relPath.localeCompare(b.relPath));
 }
 
 /** Every `.ts` file under a member's `src/`, as absolute paths. */
 export function memberSourceFiles(member: Member): string[] {
-  const glob = new Glob("**/*.ts");
-  return [...glob.scanSync({ cwd: join(member.dir, "src"), onlyFiles: true })].map((rel) =>
-    join(member.dir, "src", rel),
-  );
+	const glob = new Glob("**/*.ts");
+	return [...glob.scanSync({ cwd: join(member.dir, "src"), onlyFiles: true })].map((rel) =>
+		join(member.dir, "src", rel),
+	);
 }
 
 // Matches a string/template literal (capture group 1) OR a line/block comment. Echoing the
 // string back while replacing comments with "" strips comments without tripping on a `//`
 // that lives inside a string (e.g. "http://…").
 const STRING_OR_COMMENT =
-  /("(?:[^"\\]|\\.)*"|'(?:[^'\\]|\\.)*'|`(?:[^`\\]|\\.)*`)|\/\/[^\n]*|\/\*[\s\S]*?\*\//g;
+	/("(?:[^"\\]|\\.)*"|'(?:[^'\\]|\\.)*'|`(?:[^`\\]|\\.)*`)|\/\/[^\n]*|\/\*[\s\S]*?\*\//g;
 
 /**
  * Strip `//` line and block comments from TS/JS source while preserving string and template
  * literals. Import extraction runs on the result, so a commented-out import never registers as a
- * real one — a regex over raw source text would mis-read it and fire a false boundary violation.
+ * real one — a regex over raw source text would misread it and fire a false boundary violation.
  */
 export function stripComments(src: string): string {
-  return src.replace(STRING_OR_COMMENT, (_match, stringLiteral) => stringLiteral ?? "");
+	return src.replace(STRING_OR_COMMENT, (_match, stringLiteral) => stringLiteral ?? "");
 }
 
 const IMPORT_SPECIFIER =
-  /(?:import|export)\b[^'"]*?\bfrom\s*['"]([^'"]+)['"]|import\s*\(\s*['"]([^'"]+)['"]\s*\)|import\s+['"]([^'"]+)['"]/g;
+	/(?:import|export)\b[^'"]*?\bfrom\s*['"]([^'"]+)['"]|import\s*\(\s*['"]([^'"]+)['"]\s*\)|import\s+['"]([^'"]+)['"]/g;
 
 /** Extract every module specifier referenced by a source file (comments stripped first). */
 export function importSpecifiers(filePath: string): string[] {
-  const src = stripComments(readFileSync(filePath, "utf8"));
-  const specs: string[] = [];
-  for (const m of src.matchAll(IMPORT_SPECIFIER)) {
-    const spec = m[1] ?? m[2] ?? m[3];
-    if (spec) specs.push(spec);
-  }
-  return specs;
+	const src = stripComments(readFileSync(filePath, "utf8"));
+	const specs: string[] = [];
+	for (const m of src.matchAll(IMPORT_SPECIFIER)) {
+		const spec = m[1] ?? m[2] ?? m[3];
+		if (spec) specs.push(spec);
+	}
+	return specs;
 }
 
 export { relative, resolve, sep };

--- a/tooling/repo-checks/src/package-meta.test.ts
+++ b/tooling/repo-checks/src/package-meta.test.ts
@@ -4,7 +4,8 @@ import { describe, expect, it } from "bun:test";
 import { readFileSync } from "node:fs";
 import { join } from "node:path";
 import { Glob } from "bun";
-import { findRepoRoot, listMembers, type PackageJson, workspaceGlobs } from "./lib/workspace.ts";
+import type { PackageJson } from "./lib/workspace.ts";
+import { findRepoRoot, listMembers, workspaceGlobs } from "./lib/workspace.ts";
 
 const root = findRepoRoot();
 const members = listMembers(root);
@@ -14,80 +15,80 @@ const rootPkg = JSON.parse(readFileSync(join(root, "package.json"), "utf8")) as 
 const ws = rootPkg.workspaces;
 const catalogExpectation = new Map<string, string>();
 if (ws && !Array.isArray(ws)) {
-  for (const name of Object.keys(ws.catalog ?? {})) catalogExpectation.set(name, "catalog:");
-  for (const [catName, entries] of Object.entries(ws.catalogs ?? {})) {
-    for (const name of Object.keys(entries)) catalogExpectation.set(name, `catalog:${catName}`);
-  }
+	for (const name of Object.keys(ws.catalog ?? {})) catalogExpectation.set(name, "catalog:");
+	for (const [catName, entries] of Object.entries(ws.catalogs ?? {})) {
+		for (const name of Object.keys(entries)) catalogExpectation.set(name, `catalog:${catName}`);
+	}
 }
 
 function isInternal(depName: string): boolean {
-  return depName.startsWith("@sandbox-benchmarks/") || depName.startsWith("@repo/");
+	return depName.startsWith("@sandbox-benchmarks/") || depName.startsWith("@repo/");
 }
 
 function allDeps(pkg: PackageJson): Record<string, string> {
-  return { ...(pkg.dependencies ?? {}), ...(pkg.devDependencies ?? {}) };
+	return { ...(pkg.dependencies ?? {}), ...(pkg.devDependencies ?? {}) };
 }
 
 describe("package metadata invariants", () => {
-  it("enumerates one member per workspace package.json (no silent drops)", () => {
-    // Cross-check listMembers against an independent glob of the workspace, so adding a package
-    // never requires bumping a magic number, while a regression that drops members still fails.
-    const onDisk = workspaceGlobs(root).flatMap((g) =>
-      Array.from(new Glob(`${g}/package.json`).scanSync({ cwd: root, onlyFiles: true })),
-    ).length;
-    expect(members.length).toBe(onDisk);
-    expect(members.length).toBeGreaterThan(0);
-  });
+	it("enumerates one member per workspace package.json (no silent drops)", () => {
+		// Cross-check listMembers against an independent glob of the workspace, so adding a package
+		// never requires bumping a magic number, while a regression that drops members still fails.
+		const onDisk = workspaceGlobs(root).flatMap((g) =>
+			Array.from(new Glob(`${g}/package.json`).scanSync({ cwd: root, onlyFiles: true })),
+		).length;
+		expect(members.length).toBe(onDisk);
+		expect(members.length).toBeGreaterThan(0);
+	});
 
-  for (const member of members) {
-    describe(member.relPath, () => {
-      const { pkg } = member;
+	for (const member of members) {
+		describe(member.relPath, () => {
+			const { pkg } = member;
 
-      it("has name / version / private:true / type:module", () => {
-        expect(typeof pkg.name).toBe("string");
-        expect(typeof pkg.version).toBe("string");
-        expect(pkg.private).toBe(true);
-        expect(pkg.type).toBe("module");
-      });
+			it("has name / version / private:true / type:module", () => {
+				expect(typeof pkg.name).toBe("string");
+				expect(typeof pkg.version).toBe("string");
+				expect(pkg.private).toBe(true);
+				expect(pkg.type).toBe("module");
+			});
 
-      if (member.hasSrc) {
-        it("source member defines test + typecheck scripts", () => {
-          expect(pkg.scripts?.test).toBeDefined();
-          expect(pkg.scripts?.typecheck).toBeDefined();
-        });
-      } else {
-        it("config-only member declares a non-empty files array", () => {
-          expect(Array.isArray(pkg.files)).toBe(true);
-          expect((pkg.files ?? []).length).toBeGreaterThan(0);
-        });
-      }
+			if (member.hasSrc) {
+				it("source member defines test + typecheck scripts", () => {
+					expect(pkg.scripts?.test).toBeDefined();
+					expect(pkg.scripts?.typecheck).toBeDefined();
+				});
+			} else {
+				it("config-only member declares a non-empty files array", () => {
+					expect(Array.isArray(pkg.files)).toBe(true);
+					expect((pkg.files ?? []).length).toBeGreaterThan(0);
+				});
+			}
 
-      const isLibraryPackage = member.relPath.startsWith("packages/");
-      const isApp = member.relPath.startsWith("apps/");
+			const isLibraryPackage = member.relPath.startsWith("packages/");
+			const isApp = member.relPath.startsWith("apps/");
 
-      if (isLibraryPackage || member.name === "@repo/test-utils") {
-        it("exposes an exports map", () => {
-          expect(pkg.exports).toBeDefined();
-        });
-      }
+			if (isLibraryPackage || member.name === "@repo/test-utils") {
+				it("exposes an exports map", () => {
+					expect(pkg.exports).toBeDefined();
+				});
+			}
 
-      if (isApp) {
-        it("app declares bin and has no exports", () => {
-          expect(pkg.bin).toBeDefined();
-          expect(pkg.exports).toBeUndefined();
-        });
-      }
+			if (isApp) {
+				it("app declares bin and has no exports", () => {
+					expect(pkg.bin).toBeDefined();
+					expect(pkg.exports).toBeUndefined();
+				});
+			}
 
-      it("internal deps use workspace:* and cataloged externals use catalog:", () => {
-        for (const [dep, version] of Object.entries(allDeps(pkg))) {
-          const expected = catalogExpectation.get(dep);
-          if (isInternal(dep)) {
-            expect(version).toBe("workspace:*");
-          } else if (expected) {
-            expect(version).toBe(expected);
-          }
-        }
-      });
-    });
-  }
+			it("internal deps use workspace:* and cataloged externals use catalog:", () => {
+				for (const [dep, version] of Object.entries(allDeps(pkg))) {
+					const expected = catalogExpectation.get(dep);
+					if (isInternal(dep)) {
+						expect(version).toBe("workspace:*");
+					} else if (expected) {
+						expect(version).toBe(expected);
+					}
+				}
+			});
+		});
+	}
 });


### PR DESCRIPTION
PR #7 landed tooling/repo-checks with violations that fail the repo-wide
gates (bun run lint / bun run spell) and block every commit via the
lefthook pre-commit:

- Biome format drift in boundary.test.ts, lib/workspace.ts, package-meta.test.ts
- a useImportType (separatedType) violation in package-meta.test.ts
- a typos false positive ("mis-read") in lib/workspace.ts

Auto-fixed with `biome check --write`; reworded the comment to "misread".
No behavior change; repo-checks still typechecks and its 47 tests pass.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Biome formatting, type-import, and spelling-gate issues in repo-checks to unblock `lefthook` pre-commit and `bun run lint`/`bun run spell`. No behavior changes; all 47 tests still pass.

- **Bug Fixes**
  - Reformatted `boundary.test.ts`, `lib/workspace.ts`, and `package-meta.test.ts` via `biome check --write`.
  - Switched to `import type` in `package-meta.test.ts` to satisfy `useImportType` (separatedType).
  - Reworded a comment in `lib/workspace.ts` (“mis-read” → “misread”) to silence a typos false positive.

<sup>Written for commit 14ecdb49bf76dd5fe071cd8898ad20e47fcb28f1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/starslingdev/sandbox-benchmarks/pull/18?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Code structure and formatting improvements in repository testing and workspace configuration utilities.

* **Tests**
  * Updated test initialization with improved type handling in workspace catalog setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->