### PR TITLE
feat(templates): provider variant images (e2b, daytona, modal)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -111,3 +111,7 @@ dist
 
 # TernJS port file
 .tern-port
+
+# Generated from packages/templates/src/pins.ts by build.sh / the publish workflow (the
+# e2b CLI requires this file on disk; the TypeScript config is its single source of truth).
+packages/templates/images/e2b/e2b.toml

--- a/packages/templates/images/.dockerignore
+++ b/packages/templates/images/.dockerignore
@@ -1,0 +1,6 @@
+# Build context for the provider variants is this images/ directory (so they can COPY the shared
+# _shared/validate-base.sh). Keep that context lean: the base build inputs and docs are not variant
+# build inputs. (The base image builds from images/base/ with its own .dockerignore.)
+base/
+README.md
+**/*.md

--- a/packages/templates/images/_shared/validate-base.sh
+++ b/packages/templates/images/_shared/validate-base.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+# Shared base-validation run by every provider variant right after `FROM ${BASE_IMAGE}`. Asserts the
+# base actually is the sandbox-benchmarks toolchain — failing the build with a clear, actionable
+# message rather than letting a wrong/stale BASE_IMAGE fail opaquely at benchmark time.
+set -Eeuxo pipefail
+
+fail() {
+	echo "ERROR: $* — BASE_IMAGE is not a current sandbox-benchmarks toolchain base." >&2
+	echo "       Rebuild the base first (images/base) and pass its tag via --build-arg BASE_IMAGE=." >&2
+	exit 1
+}
+
+# > mise + the pinned toolchain.
+command -v mise >/dev/null 2>&1 || fail "mise not found on PATH"
+
+# > The stable node path the base resolves once; consumers depend on it, not a versioned path.
+[[ -x /usr/local/bin/bench-node ]] || fail "stable node symlink /usr/local/bin/bench-node missing"
+bench-node --version >/dev/null 2>&1 || fail "/usr/local/bin/bench-node is not runnable"
+
+# > Phoronix Test Suite + its pre-seeded offline caches (the whole point of baking the base).
+command -v phoronix-test-suite >/dev/null 2>&1 || fail "phoronix-test-suite not found on PATH"
+[[ -d /var/lib/phoronix-test-suite/download-cache ]] || fail "PTS download cache missing"
+
+# > The base's enforced manifest — present iff the base build's verification step ran.
+[[ -f /toolchain-manifest.json ]] || fail "/toolchain-manifest.json missing"
+
+echo "validate-base: ok"

--- a/packages/templates/images/daytona/Dockerfile
+++ b/packages/templates/images/daytona/Dockerfile
@@ -1,0 +1,31 @@
+# syntax=docker/dockerfile:1
+
+# daytona snapshot source: the publish workflow (PR3) creates a daytona snapshot from this image.
+# daytona injects its agent at snapshot/runtime, so the only delta here is base validation + labels.
+# Built with the images/ directory as context (to reach _shared/), e.g.:
+#   docker build -f packages/templates/images/daytona/Dockerfile \
+#     --build-arg BASE_IMAGE=sandbox-benchmarks-toolchain:dev packages/templates/images
+
+ARG BASE_IMAGE=sandbox-benchmarks-toolchain:dev
+
+FROM ${BASE_IMAGE}
+
+ARG BASE_IMAGE
+ARG BUILD_DATE=""
+ARG BUILD_REF=""
+ARG BUILD_VERSION=""
+
+SHELL ["/bin/bash", "-o", "pipefail", "-lc"]
+
+COPY _shared/validate-base.sh /tmp/validate-base.sh
+RUN bash /tmp/validate-base.sh && rm -f /tmp/validate-base.sh
+
+LABEL org.opencontainers.image.title="sandbox-benchmarks-toolchain-daytona" \
+      org.opencontainers.image.description="daytona snapshot source for the sandbox-benchmarks toolchain." \
+      org.opencontainers.image.source="https://github.com/starslingdev/sandbox-benchmarks" \
+      org.opencontainers.image.base.name="${BASE_IMAGE}" \
+      org.opencontainers.image.created="${BUILD_DATE}" \
+      org.opencontainers.image.revision="${BUILD_REF}" \
+      org.opencontainers.image.version="${BUILD_VERSION}"
+
+# > No ENTRYPOINT/CMD: daytona wraps this image in a snapshot and injects its own agent.

--- a/packages/templates/images/e2b/Dockerfile
+++ b/packages/templates/images/e2b/Dockerfile
@@ -1,0 +1,35 @@
+# syntax=docker/dockerfile:1
+
+# e2b template variant of the shared toolchain. e2b builds templates from a Dockerfile and injects
+# its own `envd` daemon during `e2b template build`, so the only delta here is validating the base
+# and stamping labels. Built with the images/ directory as context (to reach _shared/), e.g.:
+#   docker build -f packages/templates/images/e2b/Dockerfile \
+#     --build-arg BASE_IMAGE=sandbox-benchmarks-toolchain:dev packages/templates/images
+
+# > ARG BASE_IMAGE before FROM: default is the local base build tag; CI overrides with the registry
+# > URI. The variant's base is the base image's output — declared here, never duplicated.
+ARG BASE_IMAGE=sandbox-benchmarks-toolchain:dev
+
+FROM ${BASE_IMAGE}
+
+ARG BASE_IMAGE
+ARG BUILD_DATE=""
+ARG BUILD_REF=""
+ARG BUILD_VERSION=""
+
+SHELL ["/bin/bash", "-o", "pipefail", "-lc"]
+
+# > Validate the base before doing anything provider-specific (catches base/variant skew at build
+# > time). Shared across all three variants.
+COPY _shared/validate-base.sh /tmp/validate-base.sh
+RUN bash /tmp/validate-base.sh && rm -f /tmp/validate-base.sh
+
+LABEL org.opencontainers.image.title="sandbox-benchmarks-toolchain-e2b" \
+      org.opencontainers.image.description="e2b template variant of the sandbox-benchmarks toolchain." \
+      org.opencontainers.image.source="https://github.com/starslingdev/sandbox-benchmarks" \
+      org.opencontainers.image.base.name="${BASE_IMAGE}" \
+      org.opencontainers.image.created="${BUILD_DATE}" \
+      org.opencontainers.image.revision="${BUILD_REF}" \
+      org.opencontainers.image.version="${BUILD_VERSION}"
+
+# > No ENTRYPOINT/CMD: `e2b template build` injects envd and owns the sandbox lifecycle.

--- a/packages/templates/images/modal/Dockerfile
+++ b/packages/templates/images/modal/Dockerfile
@@ -1,0 +1,31 @@
+# syntax=docker/dockerfile:1
+
+# modal variant: modal consumes this image directly via Image.fromRegistry at runtime, so the only
+# delta here is base validation + labels. Built with the images/ directory as context (to reach
+# _shared/), e.g.:
+#   docker build -f packages/templates/images/modal/Dockerfile \
+#     --build-arg BASE_IMAGE=sandbox-benchmarks-toolchain:dev packages/templates/images
+
+ARG BASE_IMAGE=sandbox-benchmarks-toolchain:dev
+
+FROM ${BASE_IMAGE}
+
+ARG BASE_IMAGE
+ARG BUILD_DATE=""
+ARG BUILD_REF=""
+ARG BUILD_VERSION=""
+
+SHELL ["/bin/bash", "-o", "pipefail", "-lc"]
+
+COPY _shared/validate-base.sh /tmp/validate-base.sh
+RUN bash /tmp/validate-base.sh && rm -f /tmp/validate-base.sh
+
+LABEL org.opencontainers.image.title="sandbox-benchmarks-toolchain-modal" \
+      org.opencontainers.image.description="modal variant of the sandbox-benchmarks toolchain (consumed via Image.fromRegistry)." \
+      org.opencontainers.image.source="https://github.com/starslingdev/sandbox-benchmarks" \
+      org.opencontainers.image.base.name="${BASE_IMAGE}" \
+      org.opencontainers.image.created="${BUILD_DATE}" \
+      org.opencontainers.image.revision="${BUILD_REF}" \
+      org.opencontainers.image.version="${BUILD_VERSION}"
+
+# > No ENTRYPOINT/CMD: modal manages the sandbox lifecycle around this image at runtime.


### PR DESCRIPTION
Thin per-provider variant Dockerfiles (`FROM` the base) that add only each provider's delta — a shared base-validation step + OCI labels — so the toolchain layers stay byte-identical across providers (registry dedupe).

### Changes
- `e2b/`, `daytona/`, `modal/` Dockerfiles — `ARG BASE_IMAGE` + `FROM`, then `COPY`/run `_shared/validate-base.sh` and stamp labels. No toolchain logic (it lives in the base).
- `_shared/validate-base.sh` — asserts the base really is the toolchain (mise, `bench-node`, PTS download cache, manifest) so a wrong/stale `BASE_IMAGE` fails the build with a clear message instead of at benchmark time.
- `.dockerignore`/`.gitignore` — keep the variant build context lean.

### Validation
- All three variants build in the **amd64 build**; `validate-base.sh` passes, proving the base wiring is intact end-to-end.

---
Toolchain *bake* stack. Parent: #23.
