### PR TITLE
ci(templates): build & publish toolchain + variant images

### DIFF
--- a/.github/workflows/toolchain-image.yml
+++ b/.github/workflows/toolchain-image.yml
@@ -1,0 +1,172 @@
+name: Toolchain image
+
+# Build & publish the sandbox-benchmarks toolchain base image and provider variants
+# (packages/templates/images). Manual, or on changes to the images on main — never on pull requests,
+# since it needs registry credentials and is slow. The version tag is immutable: bump TOOLCHAIN_VERSION
+# in packages/schema/src/toolchain.ts to publish a new toolchain.
+on:
+  workflow_dispatch:
+    inputs:
+      overwrite:
+        description: "Rebuild & push even if the version tag is already published"
+        type: boolean
+        default: false
+  push:
+    branches: [main]
+    paths:
+      - "packages/templates/**"
+      - "packages/schema/src/toolchain.ts"
+      - ".github/workflows/toolchain-image.yml"
+
+# Never run two publishes at once; don't cancel an in-flight publish (a half-pushed tag is worse).
+concurrency:
+  group: toolchain-image
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+jobs:
+  publish:
+    name: Build & publish toolchain
+    runs-on: starsling-ubuntu-24.04-2
+    permissions:
+      contents: read
+      packages: write
+    env:
+      REGISTRY: ghcr.io
+      IMAGE_OWNER: starslingdev
+    steps:
+      # Third-party actions are pinned to a commit SHA (the tag comment is for humans only).
+      - name: Checkout
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+
+      - name: Set up Bun
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
+        with:
+          bun-version: 1.3.14
+
+      # The pins source of truth (packages/templates/src/pins.ts) imports the workspace schema, so the
+      # workspace must be linked before it can run.
+      - name: Install dependencies
+        run: bun install --frozen-lockfile --ignore-scripts
+
+      # Resolve the image identity from the arktype-validated TS config. `bun pins.ts` also validates
+      # every pin (hex sha256s, non-empty versions) and exits non-zero on any unfilled/invalid pin, so
+      # this is the early fail-fast gate — no separate __TODO__ check needed.
+      - name: Resolve identity & validate pins
+        run: |
+          pins="$(bun packages/templates/src/pins.ts)"
+          name="$(echo "${pins}" | sed -n 's/^IMAGE_NAME=//p')"
+          version="$(echo "${pins}" | sed -n 's/^IMAGE_VERSION=//p')"
+          {
+            echo "IMAGE_NAME=${name}"
+            echo "IMAGE_VERSION=${version}"
+            echo "BASE_REF=${REGISTRY}/${IMAGE_OWNER}/${name}:${version}"
+          } >> "${GITHUB_ENV}"
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4.1.0
+
+      - name: Log in to the container registry
+        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      # Version guard: skip if the tag already exists, unless overwrite was requested.
+      - name: Check if already published
+        id: guard
+        run: |
+          if [ "${{ github.event.inputs.overwrite }}" = "true" ]; then
+            echo "skip=false" >> "${GITHUB_OUTPUT}"
+          elif docker manifest inspect "${BASE_REF}" >/dev/null 2>&1; then
+            echo "::notice::${BASE_REF} already published — skipping (run with overwrite to force)."
+            echo "skip=true" >> "${GITHUB_OUTPUT}"
+          else
+            echo "skip=false" >> "${GITHUB_OUTPUT}"
+          fi
+
+      # Build base + all variants via the shared build script (thin workflow, fat script). build.sh
+      # re-validates the pins and derives every --build-arg from the TS source.
+      - name: Build images
+        if: steps.guard.outputs.skip != 'true'
+        run: |
+          export BUILD_DATE="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+          export BUILD_REF="${GITHUB_SHA}"
+          export BUILD_VERSION="${IMAGE_VERSION}"
+          bash packages/templates/images/build.sh
+
+      # Smoke-test the base — fail before pushing if the baked toolchain is incomplete.
+      - name: Smoke-test base
+        if: steps.guard.outputs.skip != 'true'
+        run: |
+          docker run --rm "${BASE_REF}" bash -lc '
+            set -euo pipefail
+            bench-node --version
+            mise ls
+            test -d /var/lib/phoronix-test-suite/download-cache
+            cat /toolchain-manifest.json
+          '
+
+      # Push the base + provider variants to the registry.
+      - name: Push images
+        if: steps.guard.outputs.skip != 'true'
+        run: |
+          set -euo pipefail
+          base_repo="${REGISTRY}/${IMAGE_OWNER}/${IMAGE_NAME}"
+          docker push "${base_repo}:${IMAGE_VERSION}"
+          for provider in e2b daytona modal; do
+            docker push "${base_repo}-${provider}:${IMAGE_VERSION}"
+          done
+
+      # Register the e2b template from images/e2b (envd is injected by the e2b builder). e2b.toml was
+      # generated by build.sh from pins.ts. Guarded on the API key so the workflow stays green wherever
+      # the secret isn't configured.
+      - name: Publish e2b template
+        if: steps.guard.outputs.skip != 'true'
+        env:
+          E2B_API_KEY: ${{ secrets.E2B_API_KEY }}
+        run: |
+          set -euo pipefail
+          if [ -z "${E2B_API_KEY:-}" ]; then
+            echo "::warning::E2B_API_KEY not set — skipping e2b template build."
+            exit 0
+          fi
+          # TODO(publish): pin the e2b CLI version and confirm the build-context flags (the context
+          # must include _shared/) and template-id write-back. Reads images/e2b/e2b.toml.
+          bunx @e2b/cli template build \
+            --path packages/templates/images \
+            --dockerfile packages/templates/images/e2b/Dockerfile \
+            --config packages/templates/images/e2b/e2b.toml
+
+      # Create/refresh the daytona snapshot from the pushed base image.
+      - name: Publish daytona snapshot
+        if: steps.guard.outputs.skip != 'true'
+        env:
+          DAYTONA_API_KEY: ${{ secrets.DAYTONA_API_KEY }}
+        run: |
+          set -euo pipefail
+          if [ -z "${DAYTONA_API_KEY:-}" ]; then
+            echo "::warning::DAYTONA_API_KEY not set — skipping daytona snapshot create."
+            exit 0
+          fi
+          # TODO(publish): create snapshot "${IMAGE_NAME}-${IMAGE_VERSION}" from ${BASE_REF} via the
+          # daytona SDK (delete-if-exists, then create with TARGET_SPEC). Mirrors DAYTONA_SNAPSHOT.
+          echo "would create daytona snapshot ${IMAGE_NAME}-${IMAGE_VERSION} from ${BASE_REF}"
+
+      # Modal consumes the image via Image.fromRegistry; verify it's reachable with credentials.
+      - name: Validate modal access
+        if: steps.guard.outputs.skip != 'true'
+        env:
+          MODAL_TOKEN_ID: ${{ secrets.MODAL_TOKEN_ID }}
+          MODAL_TOKEN_SECRET: ${{ secrets.MODAL_TOKEN_SECRET }}
+        run: |
+          set -euo pipefail
+          if [ -z "${MODAL_TOKEN_ID:-}" ]; then
+            echo "::warning::MODAL_TOKEN_* not set — skipping modal validation."
+            exit 0
+          fi
+          # TODO(publish): validate ${BASE_REF} is reachable from modal via Image.fromRegistry.
+          echo "would validate modal access to ${BASE_REF}"

--- a/packages/schema/src/index.ts
+++ b/packages/schema/src/index.ts
@@ -5,6 +5,8 @@ import { rawRunSchema } from "./lib/internal.ts";
 
 // Provider identity & economics registry (id, requiredEnvVars, pricing, isolation, spec-pinning).
 export * from "./providers.ts";
+// Canonical toolchain image identity (name + version), shared by the build pins and runtime config.
+export * from "./toolchain.ts";
 
 /** The capabilities a sandbox provider may support. Stub set — expanded as providers land. */
 export const capabilities = ["spawn", "exec", "filesystem", "snapshot"] as const;

--- a/packages/schema/src/toolchain.ts
+++ b/packages/schema/src/toolchain.ts
@@ -1,0 +1,7 @@
+// Canonical identity of the shared toolchain image, in ONE place at the bottom of the dependency DAG
+// so the build pins (@sandbox-benchmarks/templates) and the runtime config
+// (@sandbox-benchmarks/providers) both derive from the same constants and cannot drift. The version
+// tag is immutable: a change to the toolchain image means bumping TOOLCHAIN_VERSION.
+
+export const TOOLCHAIN_IMAGE_NAME = "sandbox-benchmarks-toolchain";
+export const TOOLCHAIN_VERSION = "v1";

--- a/packages/templates/images/base/.dockerignore
+++ b/packages/templates/images/base/.dockerignore
@@ -1,8 +1,9 @@
-# Keep the build context minimal and reproducible: the install scripts plus the generated mise.toml
-# are the only build inputs (other pins arrive as --build-args). Everything else (the Dockerfile
-# itself, editor cruft, and — if the context is ever widened — TS sources / node_modules / configs)
-# stays out so the context can't bloat or leak unrelated files.
+# Keep the build context minimal and reproducible: the install scripts plus the generated mise.toml /
+# toolchain-manifest.json are the only build inputs (other pins arrive as --build-args). Everything else
+# (the Dockerfile itself, editor cruft, and — if the context is ever widened — TS sources /
+# node_modules / configs) stays out so the context can't bloat or leak unrelated files.
 *
 !scripts
 !scripts/**
 !mise.toml
+!toolchain-manifest.json

--- a/packages/templates/images/base/.gitignore
+++ b/packages/templates/images/base/.gitignore
@@ -1,3 +1,5 @@
-# Generated from packages/templates/src/pins.ts by build.sh (the mise tool versions); the TypeScript
-# config is its single source of truth, so the file is built, never committed.
+# Generated from packages/templates/src/pins.ts by build.sh; the TypeScript config is the single source
+# of truth, so these are built, never committed. mise.toml = the mise tool versions;
+# toolchain-manifest.json = the verification manifest (from packages/templates/src/manifest.ts).
 mise.toml
+toolchain-manifest.json

--- a/packages/templates/images/base/Dockerfile
+++ b/packages/templates/images/base/Dockerfile
@@ -72,6 +72,10 @@ SHELL ["/bin/bash", "-o", "pipefail", "-lc"]
 # > at mise's system config path so `mise install` finds it.
 COPY mise.toml /etc/mise/config.toml
 
+# > The verification manifest, generated host-side from the validated pins (single source of truth) and
+# > shipped as-is — 99-manifest.sh confirms it landed; the smoke spec verifies the runtime matches it.
+COPY toolchain-manifest.json /toolchain-manifest.json
+
 # > orchestrator.sh runs each NN-*.sh install script in order; the manifest step fails the build on
 # > any drift. Pins are passed to the orchestrator as env (from the ARGs above) for this RUN only, so
 # > versions are not baked into the final image's environment.

--- a/packages/templates/images/base/scripts/99-manifest.sh
+++ b/packages/templates/images/base/scripts/99-manifest.sh
@@ -1,66 +1,22 @@
 #!/usr/bin/env bash
-# Verification manifest — enforced, not assumed. Each probe below fails the build if its component
-# is missing or broken, and the resulting /toolchain-manifest.json lets CI diff toolchains across
-# providers and fail on drift.
+# Verification step. /toolchain-manifest.json is generated host-side from the arktype-validated pins
+# (the single source of truth — see packages/templates/src/manifest.ts) and COPY'd in by the
+# Dockerfile, so it can't drift from what `mise install` baked (both derive from the same pins). Here
+# we confirm it landed for the expected image and that the pre-seeded PTS cache is non-empty; the
+# in-sandbox smoke spec verifies the actual runtime versions match the declared manifest.
 set -Eeuxo pipefail
 
 : "${IMAGE_NAME:?}"
-: "${IMAGE_VERSION:?}"
-: "${BASE_IMAGE:?}"
-: "${PTS_INSTALL_TESTS:?}"
 
-# > Probe each component; any failure here aborts the build (set -e). Output is staged in /tmp and
-# > consumed by the python step below. node/python come from mise (10-mise); PTS from 20-pts.
-mise --version > /tmp/m.mise_version
-mise ls --json > /tmp/m.mise_ls
-bench-node --version > /tmp/m.node_version
-python3 --version > /tmp/m.python_version
-phoronix-test-suite version > /tmp/m.pts_version
-phoronix-test-suite list-installed-tests > /tmp/m.installed
-ls -1 /var/lib/phoronix-test-suite/download-cache > /tmp/m.dlcache
 # > PTS exits 0 even when downloads fail, so an empty cache would silently ship a toolchain that
-# > benchmarks nothing — fail the build instead (the whole point of baking is the pre-seeded cache).
-[ -s /tmp/m.dlcache ] || { echo "ERROR: PTS download-cache is empty (make-download-cache failed?)" >&2; exit 1; }
-# > Stable content hash of the system-wide mise tree (excluding the volatile cache) — a cheap
-# > fingerprint CI can compare across rebuilds.
-find /usr/local/share/mise -type f ! -path '*/cache/*' -print0 | sort -z \
-	| xargs -r0 sha256sum | sha256sum | cut -d' ' -f1 > /tmp/m.mise_sha
+# > benchmarks nothing — the whole point of baking is the pre-seeded cache.
+[ -n "$(ls -A /var/lib/phoronix-test-suite/download-cache 2>/dev/null)" ] \
+	|| { echo "ERROR: PTS download-cache is empty (make-download-cache failed?)" >&2; exit 1; }
 
-python3 - <<'PY'
-import json
-import os
+# > Confirm the generated manifest was COPY'd in and is for this image.
+[ -f /toolchain-manifest.json ] \
+	|| { echo "ERROR: /toolchain-manifest.json missing (Dockerfile COPY?)" >&2; exit 1; }
+grep -q "\"image_name\": \"${IMAGE_NAME}\"" /toolchain-manifest.json \
+	|| { echo "ERROR: /toolchain-manifest.json is not for ${IMAGE_NAME}" >&2; exit 1; }
 
-
-def slurp(path):
-    with open(path) as f:
-        return f.read().strip()
-
-
-manifest = {
-    "image_name": os.environ["IMAGE_NAME"],
-    "image_version": os.environ["IMAGE_VERSION"],
-    "base_image": os.environ["BASE_IMAGE"],
-    "pts_install_tests": os.environ["PTS_INSTALL_TESTS"],
-    "node_version": slurp("/tmp/m.node_version"),
-    "python_version": slurp("/tmp/m.python_version"),
-    "mise_version": slurp("/tmp/m.mise_version"),
-    "mise_ls": json.loads(slurp("/tmp/m.mise_ls")),
-    "mise_tree_sha256": slurp("/tmp/m.mise_sha"),
-    "pts_version": slurp("/tmp/m.pts_version"),
-    "pts_download_cache": sorted(slurp("/tmp/m.dlcache").splitlines()),
-    "pts_installed_tests": sorted(
-        # > Keep only the test identifier; list-installed-tests appends a volatile description that
-        # > would otherwise churn the manifest and trip CI's cross-provider drift diff.
-        line.strip().split()[0]
-        for line in slurp("/tmp/m.installed").splitlines()
-        if line.strip().startswith(("pts/", "local/"))
-    ),
-}
-with open("/toolchain-manifest.json", "w") as f:
-    json.dump(manifest, f, indent=2, sort_keys=True)
-    f.write("\n")
-PY
-
-# > Clean up the scratch probes; keep only the manifest.
-rm -f /tmp/m.*
 cat /toolchain-manifest.json

--- a/packages/templates/images/build.sh
+++ b/packages/templates/images/build.sh
@@ -1,0 +1,75 @@
+#!/usr/bin/env bash
+# Build the toolchain base image and all provider variants. The pins come from the arktype-validated
+# TypeScript source of truth (packages/templates/src/pins.ts) — there is no versions.env. This script
+# validates that config (via bun), passes the image/PTS pins to `docker build` as --build-args, and
+# generates the mise.toml (tool versions) + e2b.toml from the same source. Single source of build
+# logic for local dev and the publish workflow (the workflow stays thin by shelling out here).
+#
+# Usage: packages/templates/images/build.sh
+# Honors env overrides: REGISTRY, IMAGE_OWNER, BUILD_DATE, BUILD_REF, BUILD_VERSION.
+set -Eeuxo pipefail
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" # packages/templates/images
+PINS_TS="${HERE}/../src/pins.ts"
+
+REGISTRY="${REGISTRY:-ghcr.io}"
+IMAGE_OWNER="${IMAGE_OWNER:-starslingdev}"
+
+# > Validate the pins and collect them as KEY=VALUE lines. `bun` exits non-zero (and set -e aborts)
+# > if arktype rejects any pin, so a bad/unfilled pin fails the build before docker is even invoked.
+pins_output="$(bun "${PINS_TS}")"
+
+base_build_args=()
+image_name=""
+image_version=""
+while IFS= read -r line; do
+	[ -n "${line}" ] || continue
+	base_build_args+=(--build-arg "${line}")
+	case "${line}" in
+		IMAGE_NAME=*) image_name="${line#*=}" ;;
+		IMAGE_VERSION=*) image_version="${line#*=}" ;;
+	esac
+done <<< "${pins_output}"
+
+: "${image_name:?pins.ts did not emit IMAGE_NAME}"
+: "${image_version:?pins.ts did not emit IMAGE_VERSION}"
+
+base_repo="${REGISTRY}/${IMAGE_OWNER}/${image_name}"
+base_ref="${base_repo}:${image_version}"
+# > Local tag the variants build against (matches each variant Dockerfile's BASE_IMAGE default).
+base_dev_tag="${image_name}:dev"
+
+# > OCI label inputs — empty on local builds, real values passed by CI. Applied to every image.
+meta_args=(
+	--build-arg "BUILD_DATE=${BUILD_DATE:-}"
+	--build-arg "BUILD_REF=${BUILD_REF:-}"
+	--build-arg "BUILD_VERSION=${BUILD_VERSION:-${image_version}}"
+)
+
+# > Generate the files the images consume from the same TS source (all gitignored): mise.toml pins the
+# > base image's tool versions; e2b.toml is the e2b template manifest; toolchain-manifest.json is the
+# > verification manifest, built from the validated pins (single source of truth) and COPY'd into the
+# > base image — so it's generated + typed end-to-end instead of hand-assembled in-container.
+bun "${PINS_TS}" --mise-toml > "${HERE}/base/mise.toml"
+bun "${PINS_TS}" --e2b-toml > "${HERE}/e2b/e2b.toml"
+bun "${HERE}/../src/manifest.ts" > "${HERE}/base/toolchain-manifest.json"
+
+echo ">>> building base: ${base_dev_tag} (+ ${base_ref})"
+docker build "${base_build_args[@]}" "${meta_args[@]}" \
+	-t "${base_dev_tag}" -t "${base_ref}" \
+	"${HERE}/base"
+
+# > Each variant composes on the just-built base via --build-arg BASE_IMAGE, with the images/
+# > directory as context so it can COPY the shared _shared/validate-base.sh. Variants take only the
+# > base ref + build metadata (their Dockerfiles declare no toolchain pins).
+for provider in e2b daytona modal; do
+	ref="${base_repo}-${provider}:${image_version}"
+	echo ">>> building ${provider} variant: ${ref}"
+	docker build "${meta_args[@]}" \
+		--build-arg "BASE_IMAGE=${base_dev_tag}" \
+		-t "${ref}" \
+		-f "${HERE}/${provider}/Dockerfile" \
+		"${HERE}"
+done
+
+echo ">>> build complete"

--- a/packages/templates/package.json
+++ b/packages/templates/package.json
@@ -7,7 +7,9 @@
     ".": "./src/index.ts",
     "./e2b": "./src/e2b.ts",
     "./daytona": "./src/daytona.ts",
-    "./modal": "./src/modal.ts"
+    "./modal": "./src/modal.ts",
+    "./pins": "./src/pins.ts",
+    "./manifest": "./src/manifest.ts"
   },
   "scripts": {
     "test": "bun test",

--- a/packages/templates/src/lib/pins.ts
+++ b/packages/templates/src/lib/pins.ts
@@ -1,0 +1,68 @@
+// Private implementation detail of @sandbox-benchmarks/templates: the toolchain build pins and their
+// arktype schema. The public gatekeeper (validate, build-args, mise.toml, e2b.toml) lives in ../pins.ts.
+import { type } from "arktype";
+
+// > The PTS .deb sha256 is 64 lowercase hex chars; versions are just non-empty strings. arktype
+// > enforces this content at build time so an unfilled/garbled pin fails loudly instead of producing
+// > a broken image (the schema rejects the `__TODO__` placeholders below until they're filled).
+const sha256 = "/^[0-9a-f]{64}$/";
+const nonEmpty = "string >= 1";
+
+/** Runtime schema for the toolchain build pins. */
+export const pinsSchema = type({
+	// mise itself (release version + per-arch binary sha256) + the mise-managed tool versions
+	// (→ generated mise.toml). The mise binary is arch-specific, so its sha is pinned per arch.
+	miseVersion: nonEmpty,
+	miseSha256X64: sha256,
+	miseSha256Arm64: sha256,
+	nodeVersion: nonEmpty,
+	pythonVersion: nonEmpty,
+	pnpmVersion: nonEmpty,
+	hyperfineVersion: nonEmpty,
+	warpVersion: nonEmpty,
+	jcVersion: nonEmpty,
+	quartoVersion: nonEmpty,
+	// Phoronix Test Suite (.deb fetched + checksum-verified) + the profiles to pre-install.
+	ptsVersion: nonEmpty,
+	ptsDebSha256: sha256,
+	ptsInstallTests: nonEmpty,
+});
+
+/** The validated shape of the toolchain pins. */
+export type Pins = typeof pinsSchema.infer;
+
+/**
+ * The toolchain pins — the single source of truth (there is no versions.env or other config file).
+ * Values ship as `__TODO__` placeholders until sourced from the reference image (or current upstream
+ * releases); arktype's {@link pinsSchema} rejects them at build time (see `validatedPins`), so a
+ * forgotten pin fails the build loudly rather than silently. `satisfies` keeps every key present and
+ * typed without asserting the (not-yet-filled) runtime constraints at import time.
+ */
+export const rawPins = {
+	// > TODO(pins): mise release version, e.g. 2026.5.16 (pinned GitHub release, fetched in 00-apt.sh).
+	miseVersion: "__TODO__",
+	// > TODO(pins): per-arch sha256 of the mise release binary, from the release's SHASUMS256.txt
+	// > (lines `mise-v<ver>-linux-x64` / `-arm64`). 00-apt.sh verifies the matching arch.
+	miseSha256X64: "__TODO__",
+	miseSha256Arm64: "__TODO__",
+	// > TODO(pins): node major or exact version, e.g. 22.
+	nodeVersion: "__TODO__",
+	// > TODO(pins): python major or exact version, e.g. 3.13 (mise-managed; no longer distro python).
+	pythonVersion: "__TODO__",
+	// > TODO(pins): pnpm major or exact version, e.g. 10.
+	pnpmVersion: "__TODO__",
+	// > TODO(pins): hyperfine version, e.g. 1.20.0.
+	hyperfineVersion: "__TODO__",
+	// > TODO(pins): minio/warp version (mise ubi backend), e.g. 1.1.4.
+	warpVersion: "__TODO__",
+	// > TODO(pins): jc version, e.g. 1.25.4.
+	jcVersion: "__TODO__",
+	// > TODO(pins): quarto-cli version (mise aqua backend), e.g. 1.9.38.
+	quartoVersion: "__TODO__",
+	// > TODO(pins): PTS release version, e.g. 10.8.4.
+	ptsVersion: "__TODO__",
+	// > TODO(pins): self-computed sha256 of phoronix-test-suite_${ptsVersion}_all.deb (PTS ships none).
+	ptsDebSha256: "__TODO__",
+	// > TODO(pins): space-separated PTS profiles to pre-install, e.g. "node-web-tooling pyperformance".
+	ptsInstallTests: "__TODO__",
+} satisfies Record<keyof Pins, string>;

--- a/packages/templates/src/manifest.test.ts
+++ b/packages/templates/src/manifest.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from "bun:test";
+import { type } from "arktype";
+import { buildManifest, manifestSchema } from "./manifest.ts";
+
+// A synthetic, fully-specified pin set (matches pins.test.ts) so these tests exercise buildManifest
+// independently of the real pins, which ship as TODO placeholders until filled in a later PR.
+const validSample = {
+	miseVersion: "2026.6.1",
+	miseSha256X64: "a".repeat(64),
+	miseSha256Arm64: "c".repeat(64),
+	nodeVersion: "22.22.3",
+	pythonVersion: "3.13.14",
+	pnpmVersion: "10.34.3",
+	hyperfineVersion: "1.20.0",
+	warpVersion: "1.3.1",
+	jcVersion: "1.25.6",
+	quartoVersion: "1.9.38",
+	ptsVersion: "10.8.4",
+	ptsDebSha256: "b".repeat(64),
+	ptsInstallTests: "pyperformance node-web-tooling",
+};
+
+describe("@sandbox-benchmarks/templates manifest", () => {
+	it("builds a manifest that satisfies the schema (the pre-bake gate)", () => {
+		expect(manifestSchema(buildManifest(validSample)) instanceof type.errors).toBe(false);
+	});
+
+	it("derives tool + PTS versions from the pins (single source of truth)", () => {
+		const m = buildManifest(validSample);
+		expect(m.tools.node).toBe(validSample.nodeVersion);
+		expect(m.tools.warp).toBe(validSample.warpVersion);
+		expect(m.tools.mise).toBe(validSample.miseVersion);
+		expect(m.pts.version).toBe(validSample.ptsVersion);
+	});
+
+	it("normalizes install_tests to a sorted list (stable across rebuilds)", () => {
+		expect(buildManifest(validSample).pts.install_tests).toEqual([
+			"node-web-tooling",
+			"pyperformance",
+		]);
+	});
+
+	it("carries the canonical image identity", () => {
+		const m = buildManifest(validSample);
+		expect(m.image_name.length).toBeGreaterThan(0);
+		expect(m.image_version.length).toBeGreaterThan(0);
+	});
+});

--- a/packages/templates/src/manifest.ts
+++ b/packages/templates/src/manifest.ts
@@ -1,0 +1,75 @@
+// `@sandbox-benchmarks/templates/manifest` — the toolchain verification manifest, derived from the
+// arktype-validated pins (the single source of truth) so `/toolchain-manifest.json` is generated +
+// typed end-to-end rather than hand-assembled in-container. build.sh writes it into the base build
+// context (like mise.toml / e2b.toml); the Dockerfile COPYs it to `/toolchain-manifest.json`; the
+// 99-manifest.sh step confirms it landed. The in-sandbox smoke spec verifies the running toolchain
+// actually matches these declared versions, so the manifest can't quietly diverge from reality.
+//
+// Run directly to emit the manifest JSON:
+//   bun packages/templates/src/manifest.ts
+import { TOOLCHAIN_IMAGE_NAME, TOOLCHAIN_VERSION } from "@sandbox-benchmarks/schema";
+import { type } from "arktype";
+import type { Pins } from "./lib/pins.ts";
+import { validatedPins } from "./pins.ts";
+
+const nonEmpty = "string >= 1";
+
+/** Runtime schema for `/toolchain-manifest.json` — the typed shape every producer/consumer shares. */
+export const manifestSchema = type({
+	image_name: nonEmpty,
+	image_version: nonEmpty,
+	// The mise-managed toolchain, keyed by tool → exact pinned version.
+	tools: {
+		node: nonEmpty,
+		python: nonEmpty,
+		pnpm: nonEmpty,
+		hyperfine: nonEmpty,
+		jc: nonEmpty,
+		quarto: nonEmpty,
+		warp: nonEmpty,
+		mise: nonEmpty,
+	},
+	pts: {
+		version: nonEmpty,
+		// Profiles pre-installed into the image (sorted, so the manifest is stable across rebuilds).
+		install_tests: "string[]",
+	},
+});
+
+/** The validated toolchain manifest shape (single source of truth for producers + consumers). */
+export type ToolchainManifest = typeof manifestSchema.infer;
+
+/**
+ * Build the toolchain manifest from the validated pins and validate it against {@link manifestSchema}.
+ * Throws on any invalid pin or shape mismatch, so a drift fails before the image is built. `pins` is
+ * injectable so the manifest can be unit-tested without the (placeholder-until-filled) real pins.
+ */
+export function buildManifest(pins: Pins = validatedPins()): ToolchainManifest {
+	const manifest = {
+		image_name: TOOLCHAIN_IMAGE_NAME,
+		image_version: TOOLCHAIN_VERSION,
+		tools: {
+			node: pins.nodeVersion,
+			python: pins.pythonVersion,
+			pnpm: pins.pnpmVersion,
+			hyperfine: pins.hyperfineVersion,
+			jc: pins.jcVersion,
+			quarto: pins.quartoVersion,
+			warp: pins.warpVersion,
+			mise: pins.miseVersion,
+		},
+		pts: {
+			version: pins.ptsVersion,
+			install_tests: pins.ptsInstallTests.split(/\s+/).filter(Boolean).sort(),
+		},
+	};
+	const out = manifestSchema(manifest);
+	if (out instanceof type.errors) {
+		throw new Error(`Invalid toolchain manifest: ${out.summary}`);
+	}
+	return out;
+}
+
+if (import.meta.main) {
+	process.stdout.write(`${JSON.stringify(buildManifest(), null, 2)}\n`);
+}

--- a/packages/templates/src/pins.test.ts
+++ b/packages/templates/src/pins.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from "bun:test";
+import { type } from "arktype";
+import { pinsSchema } from "./lib/pins.ts";
+import { e2bToml, miseToml, pins } from "./pins.ts";
+
+// A synthetic, fully-specified pin set — exercises the schema independently of the (TODO-placeholder)
+// real pins, so these tests don't break when the real pins get filled in.
+const validSample = {
+	miseVersion: "2026.6.1",
+	miseSha256X64: "a".repeat(64),
+	miseSha256Arm64: "c".repeat(64),
+	nodeVersion: "22",
+	pythonVersion: "3.13",
+	pnpmVersion: "10",
+	hyperfineVersion: "1.20.0",
+	warpVersion: "1.1.4",
+	jcVersion: "1.25.4",
+	quartoVersion: "1.9.38",
+	ptsVersion: "10.8.4",
+	ptsDebSha256: "b".repeat(64),
+	ptsInstallTests: "node-web-tooling pyperformance",
+};
+
+describe("@sandbox-benchmarks/templates pins", () => {
+	it("accepts fully-specified pins", () => {
+		expect(pinsSchema(validSample) instanceof type.errors).toBe(false);
+	});
+
+	it("rejects a non-hex sha256 (so a garbled or unfilled pin fails loudly)", () => {
+		expect(pinsSchema({ ...validSample, ptsDebSha256: "nope" }) instanceof type.errors).toBe(true);
+	});
+
+	it("rejects an empty version", () => {
+		expect(pinsSchema({ ...validSample, nodeVersion: "" }) instanceof type.errors).toBe(true);
+	});
+
+	it("exposes every pin key as the single source of truth", () => {
+		expect(Object.keys(pins).sort()).toEqual(Object.keys(validSample).sort());
+	});
+
+	it("generates a mise.toml from the tool pins", () => {
+		const toml = miseToml(validSample);
+		expect(toml).toContain("[tools]");
+		expect(toml).toContain('node = "22"');
+		expect(toml).toContain('python = "3.13"');
+	});
+
+	it("generates an e2b manifest from the image identity and TARGET_SPEC", () => {
+		const toml = e2bToml();
+		expect(toml).toContain('template_name = "sandbox-benchmarks-toolchain"');
+		expect(toml).toContain("cpu_count = 2");
+		expect(toml).toContain("memory_mb = 8192");
+	});
+});

--- a/packages/templates/src/pins.ts
+++ b/packages/templates/src/pins.ts
@@ -1,0 +1,98 @@
+// `@sandbox-benchmarks/templates/pins` — the build-time configuration gatekeeper for the toolchain
+// images. The arktype-validated TypeScript here is the single source of truth: nothing parses a
+// versions.env or other config file. build.sh (and the publish workflow) import this to validate the
+// pins and feed `docker build` / the e2b CLI; an unfilled or invalid pin is rejected before any image
+// is built.
+//
+// Run directly to emit the build inputs:
+//   bun packages/templates/src/pins.ts              # KEY=VALUE --build-arg lines
+//   bun packages/templates/src/pins.ts --mise-toml  # the mise tool config (node, python, ...)
+//   bun packages/templates/src/pins.ts --e2b-toml   # the e2b template manifest
+
+import { TARGET_SPEC, TOOLCHAIN_IMAGE_NAME, TOOLCHAIN_VERSION } from "@sandbox-benchmarks/schema";
+import { type } from "arktype";
+import type { Pins } from "./lib/pins.ts";
+import { pinsSchema, rawPins } from "./lib/pins.ts";
+
+export type { Pins };
+/** The raw toolchain pins (single source of truth). Validate with {@link validatedPins} before use. */
+export { rawPins as pins };
+
+/**
+ * Validate the pins (content included — hex sha256s, non-empty versions) and return the typed object.
+ * Throws with a clear summary on any unfilled/invalid pin, so the build fails loudly. This is the
+ * gatekeeper every build input below passes through.
+ */
+export function validatedPins(): Pins {
+	const out = pinsSchema(rawPins);
+	if (out instanceof type.errors) {
+		throw new Error(`Invalid toolchain pins (packages/templates/src/lib/pins.ts): ${out.summary}`);
+	}
+	return out;
+}
+
+/**
+ * The `--build-arg` set for the toolchain base image: the shared image identity, the mise release
+ * version + per-arch binary sha256, and the PTS pins, keyed in SCREAMING_SNAKE to match the
+ * Dockerfile's `ARG`s. The mise *tool* versions are NOT here — they flow through the generated
+ * mise.toml ({@link miseToml}).
+ */
+export function toolchainBuildArgs(pins: Pins = validatedPins()): Record<string, string> {
+	return {
+		IMAGE_NAME: TOOLCHAIN_IMAGE_NAME,
+		IMAGE_VERSION: TOOLCHAIN_VERSION,
+		MISE_VERSION: pins.miseVersion,
+		MISE_SHA256_X64: pins.miseSha256X64,
+		MISE_SHA256_ARM64: pins.miseSha256Arm64,
+		PTS_VERSION: pins.ptsVersion,
+		PTS_DEB_SHA256: pins.ptsDebSha256,
+		PTS_INSTALL_TESTS: pins.ptsInstallTests,
+	};
+}
+
+/**
+ * The mise config (`mise.toml`) pinning the language/CLI toolchain. build.sh writes this into the
+ * base build context; the Dockerfile COPYs it and `mise install` consumes it. Generated from the same
+ * validated pins, so the tool versions live only here — never hand-maintained.
+ */
+export function miseToml(pins: Pins = validatedPins()): string {
+	return `${[
+		"# Generated from packages/templates/src/pins.ts — do not edit by hand.",
+		"[tools]",
+		`node = "${pins.nodeVersion}"`,
+		`python = "${pins.pythonVersion}"`,
+		`pnpm = "${pins.pnpmVersion}"`,
+		`hyperfine = "${pins.hyperfineVersion}"`,
+		`"ubi:minio/warp" = "${pins.warpVersion}"`,
+		`jc = "${pins.jcVersion}"`,
+		`"aqua:quarto-dev/quarto-cli" = "${pins.quartoVersion}"`,
+	].join("\n")}\n`;
+}
+
+/**
+ * The e2b template manifest. The e2b CLI requires an `e2b.toml` on disk; this TypeScript config is
+ * its source of truth, so the file is generated, never hand-edited. cpu/memory come from the
+ * benchmark {@link TARGET_SPEC}.
+ */
+export function e2bToml(): string {
+	return `${[
+		"# Generated from packages/templates/src/pins.ts — do not edit by hand.",
+		'dockerfile = "Dockerfile"',
+		`template_name = "${TOOLCHAIN_IMAGE_NAME}"`,
+		`cpu_count = ${TARGET_SPEC.vcpus}`,
+		`memory_mb = ${TARGET_SPEC.memoryGb * 1024}`,
+	].join("\n")}\n`;
+}
+
+if (import.meta.main) {
+	const mode = process.argv[2];
+	if (mode === "--mise-toml") {
+		process.stdout.write(miseToml());
+	} else if (mode === "--e2b-toml") {
+		process.stdout.write(e2bToml());
+	} else {
+		for (const [key, value] of Object.entries(toolchainBuildArgs())) {
+			console.log(`${key}=${value}`);
+		}
+	}
+}


### PR DESCRIPTION
Single source of build logic + identity: `build.sh` builds the base + variants from the **arktype-validated `pins.ts`** (no `versions.env`), generating every file the images consume from that one source — `mise.toml`, `e2b.toml`, and the toolchain **verification manifest**. Plus the toolchain identity in `schema` and the initial publish workflow.

### Changes
- `templates/src/pins.ts` + `lib/pins.ts` — the pin gatekeeper: arktype validates every pin (rejects unfilled/invalid) and emits the `--build-arg` set + `mise.toml` + `e2b.toml`.
- `templates/src/manifest.ts` (+ `manifest.test.ts`) — **NEW:** an arktype `manifestSchema` + `buildManifest(pins)` that derives `/toolchain-manifest.json` from the validated pins and validates it. This makes the manifest **generated + typed end-to-end** (single source of truth) instead of the hand-assembled in-container Python from #23 — which this supersedes. `build.sh` writes it to the base context, the base Dockerfile `COPY`s it, and `99-manifest.sh` shrinks to verifying it landed (the in-sandbox smoke spec verifies the runtime matches it).
- `images/build.sh` — validates pins, generates `mise.toml`/`e2b.toml`/`toolchain-manifest.json`, then `docker build` base + variants with pinned build-args; single build path for local dev + CI.
- `schema/toolchain.ts` — shared `TOOLCHAIN_IMAGE_NAME`/`VERSION`/`TARGET_SPEC`.
- `toolchain-image.yml` — initial build+publish workflow (rewritten to the bake-driven flow in #31).

### Validation
- Offline: `bun pins.ts` / `bun manifest.ts` validate + emit; `pins.test.ts` + `manifest.test.ts` (the pre-bake gate — `buildManifest()` validates against the schema, versions derive from the pins).
- **amd64 image build (production arch): clean**, and the generated manifest flows through correctly — `build.sh` produced it, the Dockerfile `COPY`'d it, `99-manifest.sh` verified it, and the in-image `/toolchain-manifest.json` is the typed declared manifest (image identity + tool versions + PTS). Smoke **5/5** (incl. the `manifest` probe).

> Note: the manifest is now *declared from pins* (tool versions, PTS version, install-tests) rather than *measured in-container*; the in-container measured-only fields (mise-tree sha, actual download-cache filenames) are dropped — runtime correctness is enforced by the smoke spec, which is pinned to the same pins.

---
Toolchain *bake* stack. Parent: #20.
