### PR TITLE
feat(templates): fill toolchain pins with real sourced versions

### DIFF
--- a/packages/templates/src/lib/pins.ts
+++ b/packages/templates/src/lib/pins.ts
@@ -2,30 +2,35 @@
 // arktype schema. The public gatekeeper (validate, build-args, mise.toml, e2b.toml) lives in ../pins.ts.
 import { type } from "arktype";
 
-// > The PTS .deb sha256 is 64 lowercase hex chars; versions are just non-empty strings. arktype
-// > enforces this content at build time so an unfilled/garbled pin fails loudly instead of producing
-// > a broken image (the schema rejects the `__TODO__` placeholders below until they're filled).
+// > The PTS .deb sha256 is 64 lowercase hex chars; every other pin is a non-empty string that is not
+// > the `__TODO__` sentinel. arktype enforces this at build time so a forgotten/garbled pin fails
+// > loudly here (and in `bun test`) rather than producing a broken image.
 const sha256 = "/^[0-9a-f]{64}$/";
-const nonEmpty = "string >= 1";
+// > Non-empty AND not the unfilled-pin sentinel: plain `string >= 1` accepts the 8-char "__TODO__",
+// > which would defer the failure to docker build — this rejects it at validation time. The pattern
+// > also rejects whitespace-only values and a `__TODO__` padded with surrounding whitespace, so only
+// > a genuinely-filled pin (>=1 non-whitespace char) passes. (`\\s`/`\\S` are escaped so the string
+// > literal carries real backslashes into the arktype regex.)
+const filled = "/^(?!\\s*__TODO__\\s*$).*\\S.*$/";
 
 /** Runtime schema for the toolchain build pins. */
 export const pinsSchema = type({
 	// mise itself (release version + per-arch binary sha256) + the mise-managed tool versions
 	// (→ generated mise.toml). The mise binary is arch-specific, so its sha is pinned per arch.
-	miseVersion: nonEmpty,
+	miseVersion: filled,
 	miseSha256X64: sha256,
 	miseSha256Arm64: sha256,
-	nodeVersion: nonEmpty,
-	pythonVersion: nonEmpty,
-	pnpmVersion: nonEmpty,
-	hyperfineVersion: nonEmpty,
-	warpVersion: nonEmpty,
-	jcVersion: nonEmpty,
-	quartoVersion: nonEmpty,
+	nodeVersion: filled,
+	pythonVersion: filled,
+	pnpmVersion: filled,
+	hyperfineVersion: filled,
+	warpVersion: filled,
+	jcVersion: filled,
+	quartoVersion: filled,
 	// Phoronix Test Suite (.deb fetched + checksum-verified) + the profiles to pre-install.
-	ptsVersion: nonEmpty,
+	ptsVersion: filled,
 	ptsDebSha256: sha256,
-	ptsInstallTests: nonEmpty,
+	ptsInstallTests: filled,
 });
 
 /** The validated shape of the toolchain pins. */
@@ -33,36 +38,41 @@ export type Pins = typeof pinsSchema.infer;
 
 /**
  * The toolchain pins — the single source of truth (there is no versions.env or other config file).
- * Values ship as `__TODO__` placeholders until sourced from the reference image (or current upstream
- * releases); arktype's {@link pinsSchema} rejects them at build time (see `validatedPins`), so a
+ * arktype's {@link pinsSchema} validates them at build time (see `validatedPins`), so a garbled or
  * forgotten pin fails the build loudly rather than silently. `satisfies` keeps every key present and
- * typed without asserting the (not-yet-filled) runtime constraints at import time.
+ * typed.
+ *
+ * Sourced 2026-06-17 from current upstream releases (`mise latest <tool>` for the mise-managed tools;
+ * the PTS .deb sha256 self-computed — PTS ships none). To refresh: bump the version, and for PTS
+ * re-run `curl -fsSL .../phoronix-test-suite_<ver>_all.deb | sha256sum`; for mise pull the per-arch
+ * lines from `.../releases/download/v<ver>/SHASUMS256.txt`. Tool versions are exact (not floating
+ * majors) so two builds of the same image tag resolve byte-identically.
  */
 export const rawPins = {
-	// > TODO(pins): mise release version, e.g. 2026.5.16 (pinned GitHub release, fetched in 00-apt.sh).
-	miseVersion: "__TODO__",
-	// > TODO(pins): per-arch sha256 of the mise release binary, from the release's SHASUMS256.txt
-	// > (lines `mise-v<ver>-linux-x64` / `-arm64`). 00-apt.sh verifies the matching arch.
-	miseSha256X64: "__TODO__",
-	miseSha256Arm64: "__TODO__",
-	// > TODO(pins): node major or exact version, e.g. 22.
-	nodeVersion: "__TODO__",
-	// > TODO(pins): python major or exact version, e.g. 3.13 (mise-managed; no longer distro python).
-	pythonVersion: "__TODO__",
-	// > TODO(pins): pnpm major or exact version, e.g. 10.
-	pnpmVersion: "__TODO__",
-	// > TODO(pins): hyperfine version, e.g. 1.20.0.
-	hyperfineVersion: "__TODO__",
-	// > TODO(pins): minio/warp version (mise ubi backend), e.g. 1.1.4.
-	warpVersion: "__TODO__",
-	// > TODO(pins): jc version, e.g. 1.25.4.
-	jcVersion: "__TODO__",
-	// > TODO(pins): quarto-cli version (mise aqua backend), e.g. 1.9.38.
-	quartoVersion: "__TODO__",
-	// > TODO(pins): PTS release version, e.g. 10.8.4.
-	ptsVersion: "__TODO__",
-	// > TODO(pins): self-computed sha256 of phoronix-test-suite_${ptsVersion}_all.deb (PTS ships none).
-	ptsDebSha256: "__TODO__",
-	// > TODO(pins): space-separated PTS profiles to pre-install, e.g. "node-web-tooling pyperformance".
-	ptsInstallTests: "__TODO__",
+	// > mise release version (installed from its immutable GitHub release in 00-apt.sh — mise's apt
+	// > repo is rolling and only serves the latest, so we pin the release). Matches the CI mise-action
+	// > pin for a single mise across build + checks.
+	miseVersion: "2026.5.16",
+	// > sha256 of the mise release binary per arch (from the release's SHASUMS256.txt): the asset is
+	// > arch-specific, so 00-apt.sh verifies the download against the line matching the build arch.
+	miseSha256X64: "fb2d7bf1a3751398a5c336a3565cd3c60af9b41952abe6fd62e2f2f0d5f06b60",
+	miseSha256Arm64: "a068f29d8821ab0707f1a006721b5ab0baa80acaafc5a7b71e04371287108b92",
+	// > node 22 LTS (exact).
+	nodeVersion: "22.22.3",
+	// > python 3.13 (exact; mise-managed standalone build, not distro python).
+	pythonVersion: "3.13.14",
+	// > pnpm 10 (exact).
+	pnpmVersion: "10.34.3",
+	hyperfineVersion: "1.20.0",
+	// > minio/warp (mise ubi backend → github releases). Pinned to 1.3.1: minio stopped attaching
+	// > binaries to warp's GitHub releases at 1.4.0+, so newer tags have no asset ubi can install.
+	warpVersion: "1.3.1",
+	jcVersion: "1.25.6",
+	// > quarto-cli (mise aqua backend).
+	quartoVersion: "1.9.38",
+	// > Phoronix Test Suite release + self-computed sha256 of phoronix-test-suite_10.8.4_all.deb.
+	ptsVersion: "10.8.4",
+	ptsDebSha256: "be81f71fc0382a7725dc88f4a18f013d1c3f6939d440629231d392a11816feca",
+	// > Small node + python profiles pre-installed so sandbox wall time goes to benchmarks, not setup.
+	ptsInstallTests: "node-web-tooling pyperformance",
 } satisfies Record<keyof Pins, string>;

--- a/packages/templates/src/pins.test.ts
+++ b/packages/templates/src/pins.test.ts
@@ -1,10 +1,10 @@
 import { describe, expect, it } from "bun:test";
 import { type } from "arktype";
 import { pinsSchema } from "./lib/pins.ts";
-import { e2bToml, miseToml, pins } from "./pins.ts";
+import { e2bToml, miseToml, pins, validatedPins } from "./pins.ts";
 
-// A synthetic, fully-specified pin set — exercises the schema independently of the (TODO-placeholder)
-// real pins, so these tests don't break when the real pins get filled in.
+// A synthetic, fully-specified pin set — exercises the schema independently of the real pins, so
+// these schema-level tests stay stable across future pin updates.
 const validSample = {
 	miseVersion: "2026.6.1",
 	miseSha256X64: "a".repeat(64),
@@ -34,8 +34,30 @@ describe("@sandbox-benchmarks/templates pins", () => {
 		expect(pinsSchema({ ...validSample, nodeVersion: "" }) instanceof type.errors).toBe(true);
 	});
 
+	it("rejects the __TODO__ placeholder so an unfilled version pin fails loudly", () => {
+		expect(pinsSchema({ ...validSample, nodeVersion: "__TODO__" }) instanceof type.errors).toBe(
+			true,
+		);
+	});
+
+	it("rejects a whitespace-only version (no non-whitespace content)", () => {
+		expect(pinsSchema({ ...validSample, nodeVersion: "   " }) instanceof type.errors).toBe(true);
+	});
+
+	it("rejects a __TODO__ padded with surrounding whitespace", () => {
+		expect(pinsSchema({ ...validSample, nodeVersion: "  __TODO__  " }) instanceof type.errors).toBe(
+			true,
+		);
+	});
+
 	it("exposes every pin key as the single source of truth", () => {
 		expect(Object.keys(pins).sort()).toEqual(Object.keys(validSample).sort());
+	});
+
+	it("ships real, valid pins (no unfilled/garbled placeholder survives)", () => {
+		// validatedPins() throws if any real pin fails the schema — this guards against a future
+		// edit leaving a TODO/typo'd value, which would otherwise only surface at docker build time.
+		expect(() => validatedPins()).not.toThrow();
 	});
 
 	it("generates a mise.toml from the tool pins", () => {


### PR DESCRIPTION
Replace placeholder pins with real, sourced versions — each verified to actually install.

### Changes
- Exact pins: node 22.22.3, python 3.13.14, pnpm 10.34.3, hyperfine 1.20.0, jc 1.25.6, quarto 1.9.38, mise 2026.5.16, PTS 10.8.4 (+ self-computed `.deb` sha256).
- **warp pinned to 1.3.1** — minio stopped attaching prebuilt binaries to warp's GitHub releases at **v1.4.0+** (verified via the releases API and direct download-URL probes: v1.4.0/v1.4.1/v1.5.0 → 404, v1.3.1 → present), so `ubi:minio/warp` can only install ≤ 1.3.1.

### Validation
- Every pin installs cleanly in the **green amd64 build**.
- **Live daytona ZEN5 smoke** confirms the running toolchain matches the pins exactly — `node v22.22.3`, `Python 3.13.14`, and the manifest's `mise_ls` (incl. `ubi:minio/warp 1.3.1`).

---
Toolchain *bake* stack. Parent: #22.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Strengthened build-time toolchain pin validation to reject placeholder values and whitespace-only entries.
  * Updated the shipped toolchain pin set to concrete pinned releases (including related utilities and test-suite artifacts).
* **Tests**
  * Expanded schema validation coverage for invalid `nodeVersion` values, including placeholder and whitespace-padded variants.
  * Added a regression check that the shipped real pins validate successfully without throwing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->