### PR TITLE
feat(harness,cli): sandbox lifecycle + bench-smoke e2e lane

### DIFF
--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -6,6 +6,7 @@
   "bin": {
     "bench-lifecycle": "./src/bin/bench-lifecycle.ts",
     "bench-suite": "./src/bin/bench-suite.ts",
+    "bench-smoke": "./src/bin/bench-smoke.ts",
     "plan-matrix": "./src/bin/plan-matrix.ts",
     "build-template": "./src/bin/build-template.ts",
     "normalize": "./src/bin/normalize.ts",
@@ -13,7 +14,8 @@
   },
   "scripts": {
     "test": "bun test",
-    "typecheck": "tsc --noEmit"
+    "typecheck": "tsc --noEmit",
+    "smoke": "bun src/bin/bench-smoke.ts"
   },
   "dependencies": {
     "@sandbox-benchmarks/schema": "workspace:*",

--- a/apps/cli/src/bin/bench-smoke.ts
+++ b/apps/cli/src/bin/bench-smoke.ts
@@ -1,0 +1,63 @@
+#!/usr/bin/env bun
+// `bench-smoke` — boot each provider's sandbox from the baked toolchain image, run the shared smoke
+// spec inside it, and assert the toolchain survived that provider's packaging (e2b envd injection,
+// daytona snapshot, modal fromRegistry). Providers whose credentials are absent are SKIPPED, not
+// failed — the e2e surface is CI-with-secrets. Exits non-zero iff a provider that actually ran failed.
+//
+// The provider loop, skip-vs-fail contract, and boot+smoke lifecycle are shared with `bake` (see
+// providers-run.ts / smoke-run.ts); this bin only wires logging + the JSON summary.
+//
+// Observability: a per-provider/per-check log goes to stderr (with durations and, on failure, the
+// captured output); the machine-readable summary is the JSON on stdout. bun auto-loads .env, so
+// local creds in a .env file are picked up.
+import { requiredProviders, unmetRequirements } from "@sandbox-benchmarks/harness";
+import { anyFailed, forEachProviderWithCreds } from "../lib/providers-run.ts";
+import { bootAndSmoke, logChecks, smokeFailureReason, smokeOk } from "../lib/smoke-run.ts";
+
+if (import.meta.main) {
+	const log = (m: string) => console.error(m);
+
+	const runs = await forEachProviderWithCreds(
+		(provider) => {
+			log(`>>> ${provider.name}: booting sandbox…`);
+			return bootAndSmoke(provider);
+		},
+		{
+			log,
+			ok: smokeOk,
+			failureReason: smokeFailureReason,
+			// Log each provider's checks + result as it settles, so output stays interleaved with boots.
+			onComplete: (run) => {
+				if (run.value) logChecks(run.provider, run.value.checks, log);
+				const passed = run.value ? run.value.checks.filter((c) => c.ok).length : 0;
+				const total = run.value?.checks.length ?? 0;
+				const time = run.durationMs ? `${run.durationMs.toFixed(0)}ms, ` : "";
+				log(`<<< ${run.provider}: ${run.status} (${time}${passed}/${total} checks)`);
+			},
+		},
+	);
+
+	const summary = runs.map((run) => ({
+		provider: run.provider,
+		status: run.status,
+		...(run.reason ? { reason: run.reason } : {}),
+		...(run.durationMs !== undefined ? { durationMs: run.durationMs } : {}),
+		...(run.value && run.value.checks.length > 0 ? { checks: run.value.checks } : {}),
+	}));
+	console.log(JSON.stringify({ summary }, null, 2));
+
+	// Skips never fail the run; only a provider that ran and broke does.
+	if (anyFailed(runs)) process.exit(1);
+
+	// D1: at the CI/publish boundary a *required* provider that didn't run-and-pass — skipped for a
+	// missing/misnamed secret, or failed — must fail the lane loudly, so a green run can't hide that
+	// a provider was never actually smoked. Locally, with nothing required, skips stay green.
+	const required = requiredProviders();
+	const unmet = unmetRequirements(runs, required);
+	if (required.length > 0 && unmet.length > 0) {
+		log(
+			`error: required providers did not pass: ${unmet.join(", ")} (--require / REQUIRE_PROVIDERS)`,
+		);
+		process.exit(1);
+	}
+}

--- a/apps/cli/src/lib/providers-run.ts
+++ b/apps/cli/src/lib/providers-run.ts
@@ -1,0 +1,96 @@
+// The one place the "for each provider, skip if its creds are missing, otherwise time the work and
+// collect a structured result" loop lives. bench-smoke, bake, and promote all drive providers the
+// same way; before this they each re-implemented the skeleton and had already drifted (performance.now
+// vs timeOperation, "ok" vs "ran"). Keeping it here makes the skip-vs-fail contract single-sourced:
+// a provider with no creds SKIPS (never fails the run); a provider that runs and throws — or whose
+// result `ok()` rejects — FAILS.
+import { missingCreds } from "@sandbox-benchmarks/harness";
+import type { ProviderConfig } from "@sandbox-benchmarks/providers";
+import { providers } from "@sandbox-benchmarks/providers";
+import type { ProviderId } from "@sandbox-benchmarks/schema";
+
+export type ProviderRunStatus = "ok" | "skipped" | "failed";
+
+/** The outcome of driving one provider: status plus (when it ran) the body's value and wall time. */
+export interface ProviderRun<T> {
+	provider: ProviderId;
+	status: ProviderRunStatus;
+	/** Why it skipped or failed (absent when it ran ok). */
+	reason?: string;
+	/** Body wall time (ms) when it ran. */
+	durationMs?: number;
+	/** The body's return value when it ran without throwing (carries e.g. smoke checks). */
+	value?: T;
+}
+
+export interface ForEachProviderOptions<T> {
+	/** Progress sink (stderr). Skips are logged here; per-result detail is left to `onComplete`. */
+	log?: (message: string) => void;
+	/** Env for the missing-creds check (defaults to process.env via the harness). */
+	env?: Record<string, string | undefined>;
+	/** Mark a non-throwing run failed when this returns false (e.g. a smoke probe failed). Default: ok. */
+	ok?: (value: T) => boolean;
+	/** Reason recorded for a non-throwing failure (when `ok` returns false). */
+	failureReason?: (value: T) => string;
+	/** Called right after each provider settles (ok/failed), so callers can log results in order. */
+	onComplete?: (run: ProviderRun<T>) => void;
+}
+
+const noop = () => {};
+
+/**
+ * Run `body` against every provider whose credentials are present, in registry order, collecting a
+ * {@link ProviderRun} per provider. Never throws: a body that throws becomes a `failed` run carrying
+ * the coerced error message; a provider with missing creds becomes a `skipped` run.
+ */
+export async function forEachProviderWithCreds<T>(
+	body: (provider: ProviderConfig) => Promise<T>,
+	options: ForEachProviderOptions<T> = {},
+): Promise<ProviderRun<T>[]> {
+	const log = options.log ?? noop;
+	const runs: ProviderRun<T>[] = [];
+
+	for (const provider of providers) {
+		const missing = missingCreds(provider, options.env);
+		if (missing.length > 0) {
+			log(`skip: ${provider.name} (missing ${missing.join(", ")})`);
+			const skipped: ProviderRun<T> = {
+				provider: provider.name,
+				status: "skipped",
+				reason: `missing ${missing.join(", ")}`,
+			};
+			runs.push(skipped);
+			continue;
+		}
+
+		const start = performance.now();
+		let run: ProviderRun<T>;
+		try {
+			const value = await body(provider);
+			const ok = options.ok?.(value) ?? true;
+			run = {
+				provider: provider.name,
+				status: ok ? "ok" : "failed",
+				durationMs: performance.now() - start,
+				value,
+				...(ok ? {} : { reason: options.failureReason?.(value) }),
+			};
+		} catch (err) {
+			run = {
+				provider: provider.name,
+				status: "failed",
+				reason: err instanceof Error ? err.message : String(err),
+				durationMs: performance.now() - start,
+			};
+		}
+		runs.push(run);
+		options.onComplete?.(run);
+	}
+
+	return runs;
+}
+
+/** True iff any provider that actually ran failed (skips never fail the run). For the process exit code. */
+export function anyFailed(runs: ProviderRun<unknown>[]): boolean {
+	return runs.some((run) => run.status === "failed");
+}

--- a/apps/cli/src/lib/smoke-run.ts
+++ b/apps/cli/src/lib/smoke-run.ts
@@ -1,0 +1,59 @@
+// Boot a provider's sandbox, run the shared smoke spec inside it, and present the results — the
+// body that both `bench-smoke` (boot the published image) and `bake` (boot the just-baked candidate)
+// feed to {@link forEachProviderWithCreds}. The probe results are captured INSIDE the lifecycle so a
+// teardown-only failure still reports which probes passed instead of looking like nothing ran.
+import { withSandbox } from "@sandbox-benchmarks/harness";
+import type { ProviderConfig } from "@sandbox-benchmarks/providers";
+import type { SmokeResult } from "@sandbox-benchmarks/templates/smoke";
+import { runSmoke } from "@sandbox-benchmarks/templates/smoke";
+
+/** A smoke run's outcome: the probe results, plus the lifecycle error if boot/teardown threw. */
+export interface SmokeOutcome {
+	checks: SmokeResult[];
+	/** Set iff the boot→smoke→teardown lifecycle threw (bad creds, unreachable image, flaky destroy). */
+	error?: unknown;
+}
+
+/**
+ * Boot a sandbox from `config`, run the smoke spec, and tear it down. Never throws: `checks` are
+ * captured before teardown so they survive a destroy failure, and any lifecycle error is returned in
+ * `error` rather than thrown — the caller (via {@link smokeOk}) decides pass/fail.
+ */
+export async function bootAndSmoke(config: ProviderConfig): Promise<SmokeOutcome> {
+	let checks: SmokeResult[] = [];
+	try {
+		await withSandbox(config, async (sandbox) => {
+			checks = await runSmoke((cmd) => sandbox.runCommand(cmd));
+		});
+		return { checks };
+	} catch (error) {
+		return { checks, error };
+	}
+}
+
+/** A smoke run passed iff it didn't throw and every probe (at least one) passed. */
+export function smokeOk(outcome: SmokeOutcome): boolean {
+	return !outcome.error && outcome.checks.length > 0 && outcome.checks.every((c) => c.ok);
+}
+
+/** A human reason for a failed smoke run: the lifecycle error, else the failed-probe count. */
+export function smokeFailureReason(outcome: SmokeOutcome): string {
+	if (outcome.error) {
+		return outcome.error instanceof Error ? outcome.error.message : String(outcome.error);
+	}
+	const failed = outcome.checks.filter((c) => !c.ok).length;
+	return `${failed}/${outcome.checks.length} checks failed`;
+}
+
+/** Last `lines` lines of captured output, indented for the per-check failure detail. */
+export function tail(output: string, lines = 5): string {
+	return output.trim().split("\n").slice(-lines).join("\n             ");
+}
+
+/** Print each probe's pass/fail (with duration) to `log`, and the cmd+output tail on failure. */
+export function logChecks(provider: string, checks: SmokeResult[], log: (m: string) => void): void {
+	for (const c of checks) {
+		log(`    [${c.ok ? "ok" : "FAIL"}] ${provider}/${c.name} (${c.durationMs.toFixed(0)}ms)`);
+		if (!c.ok) log(`        cmd: ${c.cmd}\n        out: ${tail(c.output)}`);
+	}
+}

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
   "scripts": {
     "typecheck": "bun --filter '!./' --filter '*' --if-present typecheck",
     "test": "bun --filter '!./' --filter '*' --if-present test",
+    "smoke": "bun --filter @sandbox-benchmarks/cli smoke",
     "format": "biome format . --write",
     "lint": "biome check . --error-on-warnings",
     "lint:fix": "biome check . --write",

--- a/packages/harness/src/index.test.ts
+++ b/packages/harness/src/index.test.ts
@@ -3,9 +3,19 @@ import { execFileSync } from "node:child_process";
 import { existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import type { ProviderConfig } from "@sandbox-benchmarks/providers";
+import type { DirectProvider, ProviderConfig } from "@sandbox-benchmarks/providers";
 import type { Suite } from "@sandbox-benchmarks/schema";
-import { runSuite, runSuiteOnSandbox, SuiteUsageError, timeOperation } from "./index.ts";
+import {
+	hasRequiredCreds,
+	missingCreds,
+	requiredProviders,
+	runSuite,
+	runSuiteOnSandbox,
+	SuiteUsageError,
+	timeOperation,
+	unmetRequirements,
+	withSandbox,
+} from "./index.ts";
 import type { SandboxHandle } from "./lib/execute.ts";
 
 // timeOperation only reads identity, never calls createCompute — a throwing stub keeps this unit
@@ -18,12 +28,134 @@ const config: ProviderConfig = {
 	},
 };
 
+// A fake provider that records its lifecycle calls, so withSandbox can be exercised offline with no
+// real SDK. Only the methods withSandbox touches are implemented; the cast recovers the full type.
+function fakeProvider(calls: string[], opts: { destroyFails?: boolean } = {}): ProviderConfig {
+	const sandbox = {
+		sandboxId: "sb-1",
+		provider: "e2b",
+		runCommand: (cmd: string) => {
+			calls.push(`run:${cmd}`);
+			return Promise.resolve({ stdout: "", stderr: "", exitCode: 0 });
+		},
+		destroy: () => {
+			calls.push("destroy");
+			return opts.destroyFails ? Promise.reject(new Error("destroy failed")) : Promise.resolve();
+		},
+	};
+	const compute = {
+		sandbox: {
+			create: () => {
+				calls.push("create");
+				return Promise.resolve(sandbox);
+			},
+		},
+	} as unknown as DirectProvider;
+	return { name: "e2b", requiredEnvVars: [], createCompute: () => compute };
+}
+
 describe("@sandbox-benchmarks/harness", () => {
 	it("times an operation and emits a raw run for the provider", async () => {
 		const run = await timeOperation(config, "spawn", () => {});
 		expect(run.provider).toBe("e2b");
 		expect(run.operation).toBe("spawn");
 		expect(run.durationMs).toBeGreaterThan(0);
+	});
+
+	it("withSandbox creates, runs the body, then destroys", async () => {
+		const calls: string[] = [];
+		const out = await withSandbox(fakeProvider(calls), async (sb) => {
+			await sb.runCommand("echo hi");
+			return "result";
+		});
+		expect(out).toBe("result");
+		expect(calls).toEqual(["create", "run:echo hi", "destroy"]);
+	});
+
+	it("withSandbox destroys even when the body throws", async () => {
+		const calls: string[] = [];
+		await expect(
+			withSandbox(fakeProvider(calls), async () => {
+				throw new Error("boom");
+			}),
+		).rejects.toThrow("boom");
+		expect(calls).toEqual(["create", "destroy"]);
+	});
+
+	it("withSandbox surfaces the body error, not a teardown error, when both fail", async () => {
+		const calls: string[] = [];
+		// destroy also rejects — the original "boom" must win so the root cause isn't masked, and
+		// destroy must be attempted exactly once (no double-teardown).
+		await expect(
+			withSandbox(fakeProvider(calls, { destroyFails: true }), async () => {
+				throw new Error("boom");
+			}),
+		).rejects.toThrow("boom");
+		expect(calls).toEqual(["create", "destroy"]);
+	});
+
+	it("withSandbox surfaces a teardown failure on the success path", async () => {
+		const calls: string[] = [];
+		// fn succeeded but destroy fails — a leaked sandbox is worth failing on, so it surfaces.
+		await expect(
+			withSandbox(fakeProvider(calls, { destroyFails: true }), async () => "ok"),
+		).rejects.toThrow("destroy failed");
+		expect(calls).toEqual(["create", "destroy"]);
+	});
+
+	const credsCfg: ProviderConfig = {
+		name: "modal",
+		requiredEnvVars: ["A", "B"],
+		createCompute: () => {
+			throw new Error("not exercised");
+		},
+	};
+
+	it("missingCreds lists the required vars that are unset or empty", () => {
+		expect(missingCreds(credsCfg, { A: "1", B: "2" })).toEqual([]);
+		expect(missingCreds(credsCfg, { A: "1", B: "" })).toEqual(["B"]);
+		expect(missingCreds(credsCfg, {})).toEqual(["A", "B"]);
+	});
+
+	it("hasRequiredCreds is true only when every required var is present and non-empty", () => {
+		expect(hasRequiredCreds(credsCfg, { A: "1", B: "2" })).toBe(true);
+		expect(hasRequiredCreds(credsCfg, { A: "1", B: "" })).toBe(false);
+		expect(hasRequiredCreds(credsCfg, { A: "1" })).toBe(false);
+		expect(hasRequiredCreds({ ...credsCfg, requiredEnvVars: [] }, {})).toBe(true);
+	});
+
+	it("requiredProviders parses --require, --require=, and the env fallback (empty by default)", () => {
+		expect(requiredProviders([], {})).toEqual([]);
+		expect(requiredProviders(["--require", "e2b,daytona,modal"], {})).toEqual([
+			"e2b",
+			"daytona",
+			"modal",
+		]);
+		expect(requiredProviders(["--require=e2b, daytona"], {})).toEqual(["e2b", "daytona"]);
+		// A bare --require with no value falls through to the env var rather than swallowing the next flag.
+		expect(requiredProviders(["--require", "--other"], { REQUIRE_PROVIDERS: "modal" })).toEqual([
+			"modal",
+		]);
+		// CLI takes precedence over env.
+		expect(requiredProviders(["--require", "e2b"], { REQUIRE_PROVIDERS: "modal" })).toEqual([
+			"e2b",
+		]);
+	});
+
+	it("unmetRequirements flags required providers that did not run-and-pass", () => {
+		const reports = [
+			{ provider: "e2b", status: "ok" },
+			{ provider: "daytona", status: "skipped" },
+			{ provider: "modal", status: "failed" },
+		];
+		expect(unmetRequirements(reports, [])).toEqual([]);
+		expect(unmetRequirements(reports, ["e2b"])).toEqual([]);
+		// skipped, failed, and entirely-absent (a typo'd id) all count as unmet.
+		expect(unmetRequirements(reports, ["e2b", "daytona", "modal", "typo"])).toEqual([
+			"daytona",
+			"modal",
+			"typo",
+		]);
 	});
 });
 

--- a/packages/harness/src/index.ts
+++ b/packages/harness/src/index.ts
@@ -1,7 +1,7 @@
 // Public surface of @sandbox-benchmarks/harness — drives a provider to produce raw benchmark output.
 import { readdirSync } from "node:fs";
 import { resolve } from "node:path";
-import type { ProviderConfig } from "@sandbox-benchmarks/providers";
+import type { DirectProvider, ProviderConfig } from "@sandbox-benchmarks/providers";
 import { providers } from "@sandbox-benchmarks/providers";
 import type { RawRun, Suite } from "@sandbox-benchmarks/schema";
 import { isPtsResultFile, SUITES } from "@sandbox-benchmarks/schema";
@@ -11,7 +11,14 @@ import { MIN, StepRunner, withTimeout } from "./lib/execute.ts";
 import { now } from "./lib/internal.ts";
 import { DIR, OBSERVED_SPECS_SCRIPT, REPO_REF, REPO_URL, setupSteps } from "./lib/setup.ts";
 
-/** Time a single operation against a provider, producing a {@link RawRun}. Stub (lifecycle path). */
+/**
+ * The universal sandbox a provider's `sandbox.create` returns (computesdk's `Sandbox`). Derived from
+ * {@link DirectProvider} so the harness depends only on providers — it never imports computesdk
+ * directly — while still being exactly typed (runCommand/destroy/filesystem).
+ */
+export type Sandbox = Awaited<ReturnType<DirectProvider["sandbox"]["create"]>>;
+
+/** Time a single operation against a provider, producing a {@link RawRun}. */
 export async function timeOperation(
 	config: ProviderConfig,
 	operation: string,
@@ -216,4 +223,102 @@ export async function runSuiteOnSandbox(
 
 	if (suiteError) throw suiteError;
 	console.log(`\nDone: ${suiteName} on ${providerName}`);
+}
+
+/**
+ * Run `fn` against a freshly created sandbox and guarantee teardown. Constructs the provider lazily
+ * (so importing the registry needs no credentials), creates a sandbox with the adapter's pinned
+ * {@link ProviderConfig.createOptions}, and always destroys it — even if `fn` throws. This is the
+ * boot→exec→teardown chain the benchmarks and bench-smoke drive.
+ */
+export async function withSandbox<T>(
+	config: ProviderConfig,
+	fn: (sandbox: Sandbox) => Promise<T>,
+): Promise<T> {
+	const compute = config.createCompute();
+	const sandbox = await compute.sandbox.create(config.createOptions);
+	let result: T;
+	try {
+		result = await fn(sandbox);
+	} catch (err) {
+		// fn failed: tear down once, but never let a destroy error mask the root cause (a
+		// `finally { await destroy() }` would swallow it). Log the secondary failure and rethrow fn's.
+		try {
+			await sandbox.destroy();
+		} catch (destroyErr) {
+			console.error(
+				`withSandbox: destroy failed after an error in fn (${config.name}):`,
+				destroyErr,
+			);
+		}
+		throw err;
+	}
+	// fn succeeded: tear down once. A teardown failure here is the only error, so let it surface
+	// (a leaked sandbox is worth failing on) — the result is already captured by the caller's fn.
+	await sandbox.destroy();
+	return result;
+}
+
+/**
+ * The credentials a provider needs that are missing (unset/empty) from `env`. A runner can both
+ * decide to skip and report exactly which vars are absent from this one list — the e2e surface is
+ * CI-with-secrets. `env` is injectable so this stays unit-testable without touching `process.env`.
+ */
+export function missingCreds(
+	config: ProviderConfig,
+	env: Record<string, string | undefined> = process.env,
+): string[] {
+	return config.requiredEnvVars.filter((name) => (env[name]?.length ?? 0) === 0);
+}
+
+/** Whether every credential a provider needs is present (non-empty) in `env`. */
+export function hasRequiredCreds(
+	config: ProviderConfig,
+	env: Record<string, string | undefined> = process.env,
+): boolean {
+	return missingCreds(config, env).length === 0;
+}
+
+/**
+ * The providers a run is *required* to exercise — parsed from `--require <ids>` (or `--require=<ids>`)
+ * in `argv`, falling back to the `REQUIRE_PROVIDERS` env var; both a comma-separated id list. Empty
+ * when neither is set, which is the lenient local-dev default (missing creds simply skip). CI passes
+ * `--require e2b,daytona,modal` at the publish boundary so a missing/misnamed secret fails loudly
+ * instead of silently shipping a version whose provider artifacts were never built/validated. Tokens
+ * are returned verbatim (not filtered to known ids) so a typo'd id surfaces as unmet rather than being
+ * dropped. `argv`/`env` are injectable to keep this unit-testable.
+ */
+export function requiredProviders(
+	argv: string[] = process.argv,
+	env: Record<string, string | undefined> = process.env,
+): string[] {
+	let raw = "";
+	const eq = argv.find((a) => a.startsWith("--require="));
+	if (eq) {
+		raw = eq.slice("--require=".length);
+	} else {
+		const i = argv.indexOf("--require");
+		const next = i === -1 ? undefined : argv[i + 1];
+		if (next !== undefined && !next.startsWith("-")) raw = next;
+	}
+	if (!raw) raw = env.REQUIRE_PROVIDERS ?? "";
+	return raw
+		.split(",")
+		.map((s) => s.trim())
+		.filter(Boolean);
+}
+
+/**
+ * Of the `required` providers, those NOT satisfied by `reports` — i.e. no report with status `"ok"`.
+ * Skipped, failed, and entirely-absent providers all count as unmet. `reports` is typed structurally
+ * (`provider`/`status`) so both a {@link ProviderRun} list and a bake/promote report list fit without
+ * coupling the harness to either shape. A caller enforces the requirement by exiting non-zero when the
+ * result is non-empty (and `required` was non-empty).
+ */
+export function unmetRequirements(
+	reports: ReadonlyArray<{ provider: string; status: string }>,
+	required: readonly string[],
+): string[] {
+	const passed = new Set(reports.filter((r) => r.status === "ok").map((r) => r.provider));
+	return required.filter((id) => !passed.has(id));
 }


### PR DESCRIPTION
The boot→exec→assert→teardown chain the benchmarks were missing, plus a credential-aware provider runner shared across `bench-smoke`/`bake`/`promote` (DRY — this skeleton was about to be triplicated).

### Changes
- **harness** — `withSandbox(config, fn)`: create → run → guaranteed teardown, preserving the root cause if teardown *also* throws (no `finally`-swallow); `missingCreds`/`hasRequiredCreds` (env injectable for offline tests). `Sandbox` type derived from the provider so harness keeps depending only on `providers`.
- **cli lib** — `forEachProviderWithCreds` (one place for "for each provider, skip-on-missing-creds, time it, collect a structured result"); `bootAndSmoke`/`smokeOk`/`logChecks` that capture probe results **inside** the lifecycle, so a teardown-only failure still reports which probes passed.
- `bench-smoke` bin adopts both.

### Validation
- harness offline tests (7) — `withSandbox` order + destroy-on-throw + root-cause preservation; `missingCreds` truth table.
- **Live:** the green daytona ZEN5 e2e (#29) runs through exactly this lifecycle — boot → 5/5 smoke → clean teardown.

---
Toolchain *bake* stack. Parent: #25.
