### PR TITLE
chore(deps): add @daytonaio/sdk for the daytona bake

### DIFF
--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -23,6 +23,7 @@
     "@sandbox-benchmarks/templates": "workspace:*",
     "@sandbox-benchmarks/harness": "workspace:*",
     "@sandbox-benchmarks/results": "workspace:*",
+    "@daytonaio/sdk": "catalog:computesdk",
     "dotenv": "catalog:"
   },
   "devDependencies": {

--- a/bun.lock
+++ b/bun.lock
@@ -17,12 +17,14 @@
       "bin": {
         "bench-lifecycle": "./src/bin/bench-lifecycle.ts",
         "bench-suite": "./src/bin/bench-suite.ts",
+        "bench-smoke": "./src/bin/bench-smoke.ts",
         "plan-matrix": "./src/bin/plan-matrix.ts",
         "build-template": "./src/bin/build-template.ts",
         "normalize": "./src/bin/normalize.ts",
         "promote": "./src/bin/promote.ts",
       },
       "dependencies": {
+        "@daytonaio/sdk": "catalog:computesdk",
         "@sandbox-benchmarks/harness": "workspace:*",
         "@sandbox-benchmarks/providers": "workspace:*",
         "@sandbox-benchmarks/results": "workspace:*",
@@ -145,6 +147,7 @@
       "@computesdk/daytona": "1.7.30",
       "@computesdk/e2b": "1.7.51",
       "@computesdk/modal": "1.9.3",
+      "@daytonaio/sdk": "0.143.0",
       "computesdk": "4.1.3",
     },
     "xml": {

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
         "@computesdk/daytona": "1.7.30",
         "@computesdk/e2b": "1.7.51",
         "@computesdk/modal": "1.9.3",
+        "@daytonaio/sdk": "0.143.0",
         "computesdk": "4.1.3"
       },
       "xml": {


### PR DESCRIPTION
Land the daytona SDK dependency ahead of its consumer (the repo's deps-in-a-chore-PR convention), so the bake PR stays focused on logic.

### Changes
- Catalog-pin `@daytonaio/sdk` (0.143.0) and add it to `apps/cli`; lockfile updated. Nothing imports it yet.

### Validation
- `bun install --frozen-lockfile` green; lockfile committed.
- Consumed by the daytona bake (#29) and **exercised live** in the green daytona ZEN5 e2e (raw SDK `snapshot.get/delete/create`).

---
Toolchain *bake* stack. Parent: #26.
