### PR TITLE
feat(config): candidate↔version naming model

### DIFF
--- a/packages/providers/src/lib/config.ts
+++ b/packages/providers/src/lib/config.ts
@@ -87,7 +87,21 @@ export function resolveDaytonaRegion(
 	};
 }
 
+// Candidate↔version naming. The public version (`:v1`, `…-v1`) is immutable and written only by
+// `promote`; iteration happens against a mutable candidate (`:v1-candidate`, `…-v1-candidate`),
+// reused every build so the public registry never accumulates versions. Bumping TOOLCHAIN_VERSION
+// then yields exactly one new public version per deliberate promote.
+const imageRepo = `ghcr.io/starslingdev/${TOOLCHAIN_IMAGE_NAME}`;
+const CANDIDATE_SUFFIX = "-candidate";
+
+const toolchainImageVersion = `${imageRepo}:${TOOLCHAIN_VERSION}`;
+const toolchainImageCandidate = `${toolchainImageVersion}${CANDIDATE_SUFFIX}`;
+// Version-scope the e2b template + daytona snapshot (parity with each other): a v2 makes a new
+// named artifact instead of overwriting v1.
+const e2bTemplateVersion = `${TOOLCHAIN_IMAGE_NAME}-${TOOLCHAIN_VERSION}`;
+const e2bTemplateCandidate = `${e2bTemplateVersion}${CANDIDATE_SUFFIX}`;
 const daytonaSnapshotDefault = `${TOOLCHAIN_IMAGE_NAME}-${TOOLCHAIN_VERSION}`;
+const daytonaSnapshotCandidate = `${daytonaSnapshotDefault}${CANDIDATE_SUFFIX}`;
 
 // 3. The single, fully-typed config object. Everything that needs config imports THIS.
 export const config = {
@@ -95,16 +109,24 @@ export const config = {
 	targetSpec: TARGET_SPEC,
 	/** Immutable toolchain image version tag. */
 	toolchainVersion: TOOLCHAIN_VERSION,
-	/** Full registry ref of the toolchain image: the `BENCH_TOOLCHAIN_IMAGE` override, else the
-	 *  canonical public image. modal boots from this; the daytona snapshot is built from it. */
-	toolchainImage:
-		env.BENCH_TOOLCHAIN_IMAGE ??
-		`ghcr.io/starslingdev/${TOOLCHAIN_IMAGE_NAME}:${TOOLCHAIN_VERSION}`,
-	/** The e2b template the sandbox boots from (built by `e2b template build` from the toolchain
-	 *  image, name = e2b.toml `template_name`). Override with `E2B_TEMPLATE`. */
-	e2bTemplate: env.E2B_TEMPLATE ?? TOOLCHAIN_IMAGE_NAME,
-	/** Canonical daytona snapshot name baked from the toolchain image. */
+	/** Active toolchain image ref the adapters boot from: the `BENCH_TOOLCHAIN_IMAGE` override (CI
+	 *  points this at the candidate during iteration), else the canonical public version. */
+	toolchainImage: env.BENCH_TOOLCHAIN_IMAGE ?? toolchainImageVersion,
+	/** Immutable public image ref (`:v1`); the promote target. */
+	toolchainImageVersion,
+	/** Mutable candidate image ref (`:v1-candidate`); what the bake builds/pushes while iterating. */
+	toolchainImageCandidate,
+	/** The e2b template the sandbox boots from (name = e2b.toml `template_name`); `E2B_TEMPLATE`
+	 *  override, else the version-scoped public template. */
+	e2bTemplate: env.E2B_TEMPLATE ?? e2bTemplateVersion,
+	/** Public (version-scoped) e2b template name; the promote target. */
+	e2bTemplateVersion,
+	/** Candidate e2b template name the bake builds while iterating. */
+	e2bTemplateCandidate,
+	/** Canonical (version-scoped) daytona snapshot name; the promote target. */
 	daytonaSnapshotDefault,
+	/** Candidate daytona snapshot name the bake creates while iterating. */
+	daytonaSnapshotCandidate,
 	/** The active daytona region profile (key var, key, target, snapshot), selected by
 	 *  `DAYTONA_REGION` (`default` | `zen5`). */
 	daytonaRegion: resolveDaytonaRegion(rawEnv, daytonaSnapshotDefault),

--- a/packages/templates/src/pins.test.ts
+++ b/packages/templates/src/pins.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "bun:test";
+import { TOOLCHAIN_IMAGE_NAME, TOOLCHAIN_VERSION } from "@sandbox-benchmarks/schema";
 import { type } from "arktype";
 import { pinsSchema } from "./lib/pins.ts";
 import { e2bToml, miseToml, pins, validatedPins } from "./pins.ts";
@@ -67,10 +68,15 @@ describe("@sandbox-benchmarks/templates pins", () => {
 		expect(toml).toContain('python = "3.13"');
 	});
 
-	it("generates an e2b manifest from the image identity and TARGET_SPEC", () => {
+	it("generates an e2b manifest with the version-scoped template name and TARGET_SPEC", () => {
 		const toml = e2bToml();
-		expect(toml).toContain('template_name = "sandbox-benchmarks-toolchain"');
+		expect(toml).toContain(`template_name = "${TOOLCHAIN_IMAGE_NAME}-${TOOLCHAIN_VERSION}"`);
 		expect(toml).toContain("cpu_count = 2");
 		expect(toml).toContain("memory_mb = 8192");
+	});
+
+	it("accepts a custom template name (the bake passes the candidate name)", () => {
+		const candidate = `${TOOLCHAIN_IMAGE_NAME}-${TOOLCHAIN_VERSION}-candidate`;
+		expect(e2bToml(candidate)).toContain(`template_name = "${candidate}"`);
 	});
 });

--- a/packages/templates/src/pins.ts
+++ b/packages/templates/src/pins.ts
@@ -74,11 +74,13 @@ export function miseToml(pins: Pins = validatedPins()): string {
  * its source of truth, so the file is generated, never hand-edited. cpu/memory come from the
  * benchmark {@link TARGET_SPEC}.
  */
-export function e2bToml(): string {
+export function e2bToml(
+	templateName: string = `${TOOLCHAIN_IMAGE_NAME}-${TOOLCHAIN_VERSION}`,
+): string {
 	return `${[
 		"# Generated from packages/templates/src/pins.ts — do not edit by hand.",
 		'dockerfile = "Dockerfile"',
-		`template_name = "${TOOLCHAIN_IMAGE_NAME}"`,
+		`template_name = "${templateName}"`,
 		`cpu_count = ${TARGET_SPEC.vcpus}`,
 		`memory_mb = ${TARGET_SPEC.memoryGb * 1024}`,
 	].join("\n")}\n`;


### PR DESCRIPTION
Introduce the mutable-**candidate** / immutable-**version** split so iteration never bloats the public registry: everything builds against `:v1-candidate` (+ `…-v1-candidate` artifacts), and the public `:v1` is written only by `promote`.

### Changes
- `config.ts` — `toolchainImageVersion` (`:v1`) / `toolchainImageCandidate` (`:v1-candidate`); version-scope the e2b template + daytona snapshot and add their `…-candidate` names. Keeps `toolchainImage` as the active boot ref (`BENCH_TOOLCHAIN_IMAGE` override).
- `pins.ts` — parameterize `e2bToml(templateName)` so the bake can stamp the candidate vs version template name.

### Validation
- Offline config/pins tests.
- **Live:** the daytona ZEN5 e2e baked `sandbox-benchmarks-toolchain-v1-candidate` from `ghcr.io/…:v1-candidate` — exactly this naming model, with the public `:v1` left untouched.

---
Toolchain *bake* stack. Parent: #27.
