### PR TITLE
feat(cli): bake provider artifacts + validate end-to-end

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -115,3 +115,6 @@ dist
 # Generated from packages/templates/src/pins.ts by build.sh / the publish workflow (the
 # e2b CLI requires this file on disk; the TypeScript config is its single source of truth).
 packages/templates/images/e2b/e2b.toml
+# Generated per-bake by `bake` (apps/cli/src/lib/bake/e2b.ts): the committed e2b/Dockerfile with its
+# base pinned to the candidate/version registry ref, since e2b CLI 2.x can't inject a build-arg.
+packages/templates/images/e2b/Dockerfile.generated

--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -7,6 +7,7 @@
     "bench-lifecycle": "./src/bin/bench-lifecycle.ts",
     "bench-suite": "./src/bin/bench-suite.ts",
     "bench-smoke": "./src/bin/bench-smoke.ts",
+    "bake": "./src/bin/bake.ts",
     "plan-matrix": "./src/bin/plan-matrix.ts",
     "build-template": "./src/bin/build-template.ts",
     "normalize": "./src/bin/normalize.ts",
@@ -15,7 +16,8 @@
   "scripts": {
     "test": "bun test",
     "typecheck": "tsc --noEmit",
-    "smoke": "bun src/bin/bench-smoke.ts"
+    "smoke": "bun src/bin/bench-smoke.ts",
+    "bake": "bun src/bin/bake.ts"
   },
   "dependencies": {
     "@sandbox-benchmarks/schema": "workspace:*",

--- a/apps/cli/src/bin/bake.ts
+++ b/apps/cli/src/bin/bake.ts
@@ -1,0 +1,122 @@
+#!/usr/bin/env bun
+// `bake` — create each provider's CANDIDATE toolchain artifact and immediately validate it end-to-end
+// by booting a sandbox from the just-baked artifact and running the shared smoke spec. This is the
+// iteration loop: edit Dockerfile/templates → `bake --build-push` → `bake` → repeat. Everything hits
+// the mutable candidate (`:v1-candidate`, `…-v1-candidate`); the public `:v1` is untouched until
+// `promote` (next PR). Providers without credentials are skipped; exits non-zero iff a baked provider
+// failed to validate. bun auto-loads .env, so local creds are picked up.
+//
+// The provider loop + skip-vs-fail contract is shared with bench-smoke/promote (providers-run.ts);
+// the boot+smoke lifecycle (probe results captured before teardown) is shared too (smoke-run.ts).
+import { requiredProviders, unmetRequirements } from "@sandbox-benchmarks/harness";
+import type { ProviderConfig } from "@sandbox-benchmarks/providers";
+import { config } from "@sandbox-benchmarks/providers";
+import type { ProviderId } from "@sandbox-benchmarks/schema";
+import { bakeDaytonaSnapshot } from "../lib/bake/daytona.ts";
+import { bakeE2bTemplate } from "../lib/bake/e2b.ts";
+import { buildAndPushCandidate } from "../lib/bake/image.ts";
+import { bakeModalImage } from "../lib/bake/modal.ts";
+import type { BakeReport, Log } from "../lib/bake/types.ts";
+import { candidateCreateOptions } from "../lib/bake/validate.ts";
+import { anyFailed, forEachProviderWithCreds } from "../lib/providers-run.ts";
+import { bootAndSmoke, logChecks, smokeFailureReason, smokeOk } from "../lib/smoke-run.ts";
+
+// Each provider's candidate bake, bound to the candidate names + base ref from config.
+const bakers: Record<ProviderId, (log: Log) => Promise<void>> = {
+	e2b: (log) => bakeE2bTemplate(config.e2bTemplateCandidate, config.toolchainImageCandidate, log),
+	daytona: (log) =>
+		bakeDaytonaSnapshot(config.daytonaSnapshotCandidate, config.toolchainImageCandidate, log),
+	modal: bakeModalImage,
+};
+
+const candidateRefs = {
+	e2bTemplateCandidate: config.e2bTemplateCandidate,
+	daytonaSnapshotCandidate: config.daytonaSnapshotCandidate,
+	toolchainImageCandidate: config.toolchainImageCandidate,
+	daytonaTarget: config.daytonaRegion.target,
+};
+
+if (import.meta.main) {
+	const log: Log = (m) => console.error(m);
+
+	if (process.argv.includes("--build-push")) {
+		log(">>> building + pushing candidate image…");
+		try {
+			await buildAndPushCandidate(log);
+		} catch (err) {
+			log(`<<< build/push failed — ${err instanceof Error ? err.message : String(err)}`);
+			process.exit(1);
+		}
+	}
+
+	const runs = await forEachProviderWithCreds(
+		async (provider) => {
+			log(`>>> ${provider.name}: baking candidate…`);
+			await bakers[provider.name]((m) => log(`    ${m}`));
+
+			log(`>>> ${provider.name}: validating (boot + smoke)…`);
+			// Boot the just-baked candidate (override the registry adapter's version create-options).
+			const validateConfig: ProviderConfig = {
+				...provider,
+				createOptions: {
+					...provider.createOptions,
+					...candidateCreateOptions(provider.name, candidateRefs),
+				},
+			};
+			return bootAndSmoke(validateConfig);
+		},
+		{
+			log,
+			ok: smokeOk,
+			failureReason: smokeFailureReason,
+			onComplete: (run) => {
+				if (run.value) logChecks(run.provider, run.value.checks, log);
+				const time = run.durationMs !== undefined ? `${run.durationMs.toFixed(0)}ms` : "";
+				const counts = run.value
+					? `${run.value.checks.filter((c) => c.ok).length}/${run.value.checks.length} checks`
+					: "";
+				const meta = [time, counts].filter(Boolean).join(", ");
+				log(
+					`<<< ${run.provider}: ${run.status}${meta ? ` (${meta})` : ""}${run.reason ? ` — ${run.reason}` : ""}`,
+				);
+			},
+		},
+	);
+
+	const reports: BakeReport[] = runs.map((run) => ({
+		provider: run.provider,
+		status: run.status,
+		...(run.reason ? { reason: run.reason } : {}),
+		...(run.durationMs !== undefined ? { durationMs: run.durationMs } : {}),
+		...(run.value && run.value.checks.length > 0 ? { checks: run.value.checks } : {}),
+	}));
+
+	console.log(
+		JSON.stringify(
+			{
+				candidate: {
+					image: config.toolchainImageCandidate,
+					e2bTemplate: config.e2bTemplateCandidate,
+					daytonaSnapshot: config.daytonaSnapshotCandidate,
+				},
+				reports,
+			},
+			null,
+			2,
+		),
+	);
+
+	if (anyFailed(runs)) process.exit(1);
+
+	// D1: at the publish boundary (CI passes `--require e2b,daytona,modal`) a required provider that was
+	// skipped for a missing/misnamed secret — or failed to validate — must fail the bake loudly, so a
+	// candidate is never blessed while a provider was silently never built. Lenient locally (none required).
+	const required = requiredProviders();
+	const unmet = unmetRequirements(reports, required);
+	if (required.length > 0 && unmet.length > 0) {
+		log(
+			`error: required providers did not pass: ${unmet.join(", ")} (--require / REQUIRE_PROVIDERS)`,
+		);
+		process.exit(1);
+	}
+}

--- a/apps/cli/src/lib/bake/daytona.ts
+++ b/apps/cli/src/lib/bake/daytona.ts
@@ -1,0 +1,57 @@
+// Bake a daytona snapshot directly from a pushed toolchain image, via the raw Daytona SDK (the
+// @computesdk/daytona wrapper only snapshots a running sandbox). Idempotent: delete an existing
+// snapshot of that name, then recreate. Region-aware: the active region's API key + target come from
+// config.daytonaRegion (ZEN5 supported).
+//
+// Iteration surface: a snapshot's region must match where sandboxes boot. We pass the region's
+// `target` to the client; if a beta region (ZEN5) also needs an explicit snapshot `regionId`, add it
+// to CreateSnapshotParams here.
+import { Daytona } from "@daytonaio/sdk";
+import { config } from "@sandbox-benchmarks/providers";
+import type { Log } from "./types.ts";
+
+/** Whether a snapshot.get/delete error is a genuine "no such snapshot" (so the idempotent path may
+ *  swallow it) — as opposed to auth/network/in-use failures, which must surface their root cause
+ *  instead of being masked into a confusing create-time error. */
+function isNotFound(err: unknown): boolean {
+	if (typeof err !== "object" || err === null) return false;
+	const e = err as {
+		statusCode?: number;
+		status?: number;
+		response?: { status?: number };
+		message?: string;
+	};
+	const status = e.statusCode ?? e.status ?? e.response?.status;
+	if (status === 404) return true;
+	return typeof e.message === "string" && /not found|does not exist|404/i.test(e.message);
+}
+
+/** Create the daytona snapshot `name` from `image` (candidate while iterating, version on promote),
+ *  in the active region. Idempotent: delete an existing snapshot of that name first. */
+export async function bakeDaytonaSnapshot(name: string, image: string, log: Log): Promise<void> {
+	const { daytonaRegion, targetSpec } = config;
+	const daytona = new Daytona({
+		apiKey: daytonaRegion.apiKey,
+		...(daytonaRegion.target ? { target: daytonaRegion.target } : {}),
+	});
+
+	try {
+		const existing = await daytona.snapshot.get(name);
+		log(`deleting existing snapshot ${name}`);
+		await daytona.snapshot.delete(existing);
+	} catch (err) {
+		// Only "no such snapshot" is expected here; rethrow auth/network/in-use so the real failure
+		// isn't masked by a downstream "already exists"/permission error from create.
+		if (!isNotFound(err)) throw err;
+	}
+
+	log(`creating snapshot ${name} from ${image} (target ${daytonaRegion.target ?? "default"})`);
+	await daytona.snapshot.create(
+		{
+			name,
+			image,
+			resources: { cpu: targetSpec.vcpus, memory: targetSpec.memoryGb, disk: targetSpec.diskGb },
+		},
+		{ onLogs: log },
+	);
+}

--- a/apps/cli/src/lib/bake/e2b.ts
+++ b/apps/cli/src/lib/bake/e2b.ts
@@ -1,0 +1,76 @@
+// Bake the e2b template from the e2b variant Dockerfile via the pinned e2b CLI.
+//
+// Two things the e2b path forces (verified against @e2b/cli@2.12.0):
+//  1. `template create` builds the Dockerfile on E2B's REMOTE builder — it cannot see the local
+//     `:dev` tag build.sh produces, and CLI 2.x dropped `--build-arg`, so the base CANNOT be a local
+//     tag nor injected at build time. We pin `FROM` to a concrete, registry-pullable ref by generating
+//     a Dockerfile per bake (the candidate ref while iterating, the published `:v1` on promote) — the
+//     same single-source way e2b.toml / mise.toml are generated, so the committed Dockerfile stays the
+//     one source of the variant body. The pinned base image must be pushed AND pullable by the remote
+//     builder (public package, or registry auth) before this runs.
+//  2. `--path` is the build context root and `--dockerfile` is resolved RELATIVE to it (the CLI joins
+//     them), so the Dockerfile arg must be context-relative, not repo-relative.
+
+import { readFileSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { config } from "@sandbox-benchmarks/providers";
+import { e2bToml } from "@sandbox-benchmarks/templates/pins";
+import type { Log } from "./types.ts";
+
+/** Pinned so the build is reproducible (every other tool in the toolchain is version-pinned). */
+export const E2B_CLI_VERSION = "2.12.0";
+
+// Context root the e2b CLI uploads (so the Dockerfile can COPY the shared _shared/validate-base.sh).
+// Anchored to this file (not cwd): the `bake` package script runs from apps/cli, where a repo-relative
+// path would resolve under apps/cli/ and every readFileSync/writeFileSync/--path here would be wrong.
+const E2B_CONTEXT = join(import.meta.dir, "../../../../../packages/templates/images");
+// Paths RELATIVE to E2B_CONTEXT (the CLI joins --dockerfile onto --path).
+const E2B_DOCKERFILE = "e2b/Dockerfile"; // committed template: ARG BASE_IMAGE default + validate + labels
+const E2B_DOCKERFILE_GENERATED = "e2b/Dockerfile.generated"; // base pinned to a registry ref per bake
+const E2B_TOML = "e2b/e2b.toml"; // generated manifest (record + parity)
+
+/** Generate the per-bake e2b Dockerfile: the committed variant Dockerfile with its `ARG BASE_IMAGE`
+ *  default rewritten to a concrete, registry-pullable `baseImage`. Throws if the anchor is missing so
+ *  a Dockerfile refactor can't silently ship the wrong (local `:dev`) base. */
+function writeE2bDockerfile(baseImage: string): void {
+	const anchor = /^ARG BASE_IMAGE=.*$/m;
+	const template = readFileSync(`${E2B_CONTEXT}/${E2B_DOCKERFILE}`, "utf8");
+	// Test the regex matched (not `pinned !== template`): a base that already equals the committed
+	// default would otherwise be misread as a missing anchor.
+	if (!anchor.test(template)) {
+		throw new Error(`e2b Dockerfile has no 'ARG BASE_IMAGE=' default to pin (${E2B_DOCKERFILE})`);
+	}
+	// Function replacement so a `$` in `baseImage` (e.g. `$&`) isn't interpreted as a replacement pattern.
+	const pinned = template.replace(anchor, () => `ARG BASE_IMAGE=${baseImage}`);
+	writeFileSync(`${E2B_CONTEXT}/${E2B_DOCKERFILE_GENERATED}`, pinned);
+}
+
+/** Build the e2b template `name` from `baseImage` (the candidate base while iterating, the published
+ *  version base on promote — so the template provably derives from the validated bytes). */
+export async function bakeE2bTemplate(name: string, baseImage: string, log: Log): Promise<void> {
+	// Keep the on-disk manifest's template_name in sync with the name we create, and pin the base.
+	writeFileSync(`${E2B_CONTEXT}/${E2B_TOML}`, e2bToml(name));
+	writeE2bDockerfile(baseImage);
+
+	log(`e2b template create ${name} (base ${baseImage})`);
+	const proc = Bun.spawn(
+		[
+			"bunx",
+			`@e2b/cli@${E2B_CLI_VERSION}`,
+			"template",
+			"create",
+			name,
+			"--path",
+			E2B_CONTEXT,
+			"--dockerfile",
+			E2B_DOCKERFILE_GENERATED,
+			"--cpu-count",
+			String(config.targetSpec.vcpus),
+			"--memory-mb",
+			String(config.targetSpec.memoryGb * 1024),
+		],
+		{ stdout: "inherit", stderr: "inherit", env: process.env },
+	);
+	const code = await proc.exited;
+	if (code !== 0) throw new Error(`e2b template create exited ${code}`);
+}

--- a/apps/cli/src/lib/bake/image.ts
+++ b/apps/cli/src/lib/bake/image.ts
@@ -1,0 +1,26 @@
+// Build the toolchain images and push the *candidate* base to GHCR. daytona (snapshot source) and
+// modal (Image.fromRegistry) boot the base image by ref, so the candidate base must be pushed;
+// e2b builds its template from the local `:dev` base that build.sh produces, so it needs no push.
+// The public `:v1` is never pushed here — that is promote's job.
+import { join } from "node:path";
+import { config } from "@sandbox-benchmarks/providers";
+import type { Log } from "./types.ts";
+
+// Anchored to this file (not cwd): the `bake` package script runs from apps/cli, where a
+// repo-relative path would resolve to the non-existent apps/cli/packages/... and fail in bash.
+const BUILD_SH = join(import.meta.dir, "../../../../../packages/templates/images/build.sh");
+
+async function run(cmd: string[], log: Log): Promise<void> {
+	log(`$ ${cmd.join(" ")}`);
+	const proc = Bun.spawn(cmd, { stdout: "inherit", stderr: "inherit", env: process.env });
+	const code = await proc.exited;
+	if (code !== 0) throw new Error(`${cmd[0]} exited ${code}`);
+}
+
+/** build.sh (base + variants, tagged `:dev` and `:v1`) → retag base `:v1`→`:v1-candidate` → push the
+ *  candidate. Idempotent: the candidate tag is mutable and simply overwritten each run. */
+export async function buildAndPushCandidate(log: Log): Promise<void> {
+	await run(["bash", BUILD_SH], log);
+	await run(["docker", "tag", config.toolchainImageVersion, config.toolchainImageCandidate], log);
+	await run(["docker", "push", config.toolchainImageCandidate], log);
+}

--- a/apps/cli/src/lib/bake/modal.ts
+++ b/apps/cli/src/lib/bake/modal.ts
@@ -1,0 +1,13 @@
+// "Bake" for modal: there is no separate artifact — modal boots the image directly via
+// Image.fromRegistry at create time. The candidate image just needs to be pushed (buildAndPushCandidate
+// / `--build-push`); reachability with credentials is proven by the validate boot that follows.
+import { config } from "@sandbox-benchmarks/providers";
+import type { Log } from "./types.ts";
+
+export function bakeModalImage(log: Log): Promise<void> {
+	log(
+		`modal boots ${config.toolchainImageCandidate} via fromRegistry — no artifact to bake; ` +
+			`the candidate image must be pushed and reachability is the validate boot`,
+	);
+	return Promise.resolve();
+}

--- a/apps/cli/src/lib/bake/types.ts
+++ b/apps/cli/src/lib/bake/types.ts
@@ -1,0 +1,19 @@
+// Shared types for the provider bake. A `Log` sink keeps the per-provider bake modules free of
+// console wiring (the bin passes an indenting logger).
+import type { SmokeResult } from "@sandbox-benchmarks/templates/smoke";
+
+export type Log = (message: string) => void;
+
+export type BakeStatus = "ok" | "skipped" | "failed";
+
+/** The per-provider outcome the bake emits — bake + immediate boot/smoke validation. */
+export interface BakeReport {
+	provider: string;
+	status: BakeStatus;
+	/** Why it skipped or failed (absent when it baked + validated clean). */
+	reason?: string;
+	/** Bake + validate wall time, when it ran. */
+	durationMs?: number;
+	/** Smoke results from booting the just-baked candidate artifact. */
+	checks?: SmokeResult[];
+}

--- a/apps/cli/src/lib/bake/validate.test.ts
+++ b/apps/cli/src/lib/bake/validate.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from "bun:test";
+import type { CandidateRefs } from "./validate.ts";
+import { candidateCreateOptions } from "./validate.ts";
+
+const refs: CandidateRefs = {
+	e2bTemplateCandidate: "tc-v1-candidate",
+	daytonaSnapshotCandidate: "snap-v1-candidate",
+	toolchainImageCandidate: "ghcr.io/o/tc:v1-candidate",
+	daytonaTarget: "zen5",
+};
+
+describe("candidateCreateOptions", () => {
+	it("points e2b at the candidate template via snapshotId", () => {
+		expect(candidateCreateOptions("e2b", refs)).toEqual({ snapshotId: "tc-v1-candidate" });
+	});
+
+	it("points daytona at the candidate snapshot + region target", () => {
+		expect(candidateCreateOptions("daytona", refs)).toEqual({
+			snapshotId: "snap-v1-candidate",
+			target: "zen5",
+		});
+	});
+
+	it("omits the daytona target when the region has none (account default)", () => {
+		expect(candidateCreateOptions("daytona", { ...refs, daytonaTarget: undefined })).toEqual({
+			snapshotId: "snap-v1-candidate",
+		});
+	});
+
+	it("points modal at the candidate image via templateId", () => {
+		expect(candidateCreateOptions("modal", refs)).toEqual({
+			templateId: "ghcr.io/o/tc:v1-candidate",
+		});
+	});
+});

--- a/apps/cli/src/lib/bake/validate.ts
+++ b/apps/cli/src/lib/bake/validate.ts
@@ -1,0 +1,31 @@
+// Pure mapping from a provider id to the create-options that boot its *candidate* artifact, so the
+// bake can validate exactly what it just built (not the public version). Kept pure + injectable so
+// it's unit-testable without the env-backed config.
+import type { ProviderId } from "@sandbox-benchmarks/schema";
+
+export interface CandidateRefs {
+	e2bTemplateCandidate: string;
+	daytonaSnapshotCandidate: string;
+	toolchainImageCandidate: string;
+	/** Daytona runner target for the active region (undefined → account default). */
+	daytonaTarget?: string;
+}
+
+/** Create-options overrides that point a provider at its candidate artifact for the validate boot. */
+export function candidateCreateOptions(
+	id: ProviderId,
+	refs: CandidateRefs,
+): Record<string, unknown> {
+	switch (id) {
+		case "e2b":
+			// computesdk maps snapshotId → the e2b template id/name.
+			return { snapshotId: refs.e2bTemplateCandidate };
+		case "daytona":
+			return {
+				snapshotId: refs.daytonaSnapshotCandidate,
+				...(refs.daytonaTarget ? { target: refs.daytonaTarget } : {}),
+			};
+		case "modal":
+			return { templateId: refs.toolchainImageCandidate };
+	}
+}


### PR DESCRIPTION
The iteration tool: create each provider's **candidate** artifact and immediately validate it end-to-end by booting a sandbox from the just-baked artifact and running the shared smoke spec. Everything targets the mutable candidate; public `:v1` is untouched until `promote` (#30).

### Changes
- `bake.ts` (thin) + `lib/bake/{image,e2b,daytona,modal,validate}.ts` (fat); reuses the shared provider runner + `bootAndSmoke` (#26).
- `--build-push` — `build.sh`, then retag base `:v1` → `:v1-candidate` and push (daytona snapshot source + modal `fromRegistry` boot the base by ref).
- **e2b** — `bunx @e2b/cli@2.12.0 template create`; generates a base-pinned Dockerfile (`ARG BASE_IMAGE`=the candidate ref) because CLI 2.x dropped `--build-arg` **and** builds on E2B's remote builder, so the base must be a registry-pullable ref, not a local `:dev` tag; `--dockerfile` is passed context-relative (CLI joins it onto `--path`).
- **daytona** — raw `@daytonaio/sdk` idempotent get→delete→create snapshot from the candidate image; region-aware (key + target from `daytonaRegion`, ZEN5 supported); the not-found-only catch surfaces real auth/network errors.
- **validate** — boot the candidate (via `candidateCreateOptions` overrides) and run `runSmoke`; skip-on-missing-creds; structured JSON + per-step logs; non-zero exit iff a baked provider fails.

### Validation — **daytona ZEN5 end-to-end: GREEN** ✅
```
>>> daytona: baking candidate…
>>> daytona: validating (boot + smoke)…
    [ok] daytona/node (467ms)
    [ok] daytona/python (137ms)
    [ok] daytona/mise (135ms)
    [ok] daytona/pts-download-cache (123ms)
    [ok] daytona/manifest (119ms)
<<< daytona: ok (113312ms, 5/5 checks)
```
`bake --build-push` pushed the candidate base to GHCR; `bake` created the daytona snapshot from it (ZEN5 pulled it via the org's registry credential), booted a **real sandbox**, and passed **5/5** smoke. The e2b path is validated structurally (CLI flags + remote-build base resolution, verified against the pinned CLI bundle); **live e2b is pending the candidate package being made public** (e2b's remote builder pulls anonymously). `candidateCreateOptions` unit-tested.

---
Toolchain *bake* stack. Parent: #28.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added a `bake` CLI command to generate and validate provider-specific toolchains for E2B, Daytona, and Modal.
  * Runs end-to-end verification by booting sandboxes from the freshly prepared artifacts and executing smoke checks.
  * Optional build-and-push mode now builds and publishes candidate toolchain images to the container registry.

* **Tests**
  * Added unit tests to verify correct candidate artifact/reference mapping across providers.

* **Chores**
  * Updated ignore rules to exclude generated E2B Dockerfile artifacts from version control.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->