### PR TITLE
feat(cli): promote validated candidate → public version

### DIFF
--- a/apps/cli/src/bin/bake.ts
+++ b/apps/cli/src/bin/bake.ts
@@ -16,6 +16,7 @@ import { bakeDaytonaSnapshot } from "../lib/bake/daytona.ts";
 import { bakeE2bTemplate } from "../lib/bake/e2b.ts";
 import { buildAndPushCandidate } from "../lib/bake/image.ts";
 import { bakeModalImage } from "../lib/bake/modal.ts";
+import { promoteAll } from "../lib/bake/promote.ts";
 import type { BakeReport, Log } from "../lib/bake/types.ts";
 import { candidateCreateOptions } from "../lib/bake/validate.ts";
 import { anyFailed, forEachProviderWithCreds } from "../lib/providers-run.ts";
@@ -38,6 +39,32 @@ const candidateRefs = {
 
 if (import.meta.main) {
 	const log: Log = (m) => console.error(m);
+
+	// Promote is the release step: publish the already-validated candidate as the public version.
+	if (process.argv.includes("--promote")) {
+		const promoted = await promoteAll(log);
+		console.log(
+			JSON.stringify(
+				{
+					version: {
+						image: config.toolchainImageVersion,
+						e2bTemplate: config.e2bTemplateVersion,
+						daytonaSnapshot: config.daytonaSnapshotDefault,
+					},
+					reports: promoted,
+				},
+				null,
+				2,
+			),
+		);
+		// promoteAll is self-gating: the D1 required-providers gate (CI passes `--require e2b,daytona,modal`)
+		// runs INSIDE promoteAll before the immutable base is written, and every abort path (version already
+		// published, candidate re-validation failed, artifact failed, unmet requirements) pushes a structured
+		// `{ status: "failed" }` report. So a single `some(failed)` is the whole exit contract — re-deriving
+		// `unmet` here would mislabel an early abort (e.g. "version already exists") as a provider-credentials
+		// failure, since the early `reports` carry no provider "ok" entries.
+		process.exit(promoted.some((r) => r.status === "failed") ? 1 : 0);
+	}
 
 	if (process.argv.includes("--build-push")) {
 		log(">>> building + pushing candidate image…");

--- a/apps/cli/src/lib/bake/image.test.ts
+++ b/apps/cli/src/lib/bake/image.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from "bun:test";
+import { imagetoolsRetagCmd } from "./image.ts";
+
+describe("imagetoolsRetagCmd", () => {
+	it("builds a registry-side retag (candidate → version) with no pull", () => {
+		expect(imagetoolsRetagCmd("ghcr.io/o/tc:v1-candidate", "ghcr.io/o/tc:v1")).toEqual([
+			"docker",
+			"buildx",
+			"imagetools",
+			"create",
+			"-t",
+			"ghcr.io/o/tc:v1",
+			"ghcr.io/o/tc:v1-candidate",
+		]);
+	});
+});

--- a/apps/cli/src/lib/bake/image.ts
+++ b/apps/cli/src/lib/bake/image.ts
@@ -24,3 +24,36 @@ export async function buildAndPushCandidate(log: Log): Promise<void> {
 	await run(["docker", "tag", config.toolchainImageVersion, config.toolchainImageCandidate], log);
 	await run(["docker", "push", config.toolchainImageCandidate], log);
 }
+
+/** Pure: the buildx command that retags one pushed image ref to another registry-side (no pull). */
+export function imagetoolsRetagCmd(from: string, to: string): string[] {
+	return ["docker", "buildx", "imagetools", "create", "-t", to, from];
+}
+
+/** Whether `ref` already exists in the registry — a successful `docker manifest inspect`. Queries the
+ *  registry (not local images), so a locally-built `:v1` tag never reads as published. promote uses
+ *  this to REFUSE overwriting the immutable public version.
+ *
+ *  Only a genuine "manifest not found" reads as absent. An auth, rate-limit, or network failure also
+ *  exits non-zero, but must NOT be mistaken for "not published" — that would bypass the immutability
+ *  guard and let promote overwrite an existing `:v1`. So those throw, and the caller refuses to publish
+ *  on an uncertain check rather than risk clobbering. */
+export async function imageExistsInRegistry(ref: string): Promise<boolean> {
+	const proc = Bun.spawn(["docker", "manifest", "inspect", ref], {
+		stdout: "ignore",
+		stderr: "pipe",
+		env: process.env,
+	});
+	const [code, stderr] = await Promise.all([proc.exited, new Response(proc.stderr).text()]);
+	if (code === 0) return true;
+	if (/no such manifest|manifest unknown|not found/i.test(stderr)) return false;
+	throw new Error(
+		`docker manifest inspect ${ref} failed (exit ${code}): ${stderr.trim() || "unknown error"}`,
+	);
+}
+
+/** Publish the validated candidate base as the immutable public version — a registry-side retag of
+ *  the exact validated bytes, so `:v1` is the same image the candidate validate booted. */
+export async function promoteImage(log: Log): Promise<void> {
+	await run(imagetoolsRetagCmd(config.toolchainImageCandidate, config.toolchainImageVersion), log);
+}

--- a/apps/cli/src/lib/bake/promote.ts
+++ b/apps/cli/src/lib/bake/promote.ts
@@ -1,0 +1,168 @@
+// Promote the validated candidate to the immutable public version — the ONLY step that writes
+// public-facing artifacts. Run after `bake` validates the candidate.
+//
+// The order makes the immutable base tag the COMMIT POINT, so a mid-promote failure is always clean:
+//   1. Refuse if the public version tag already exists — it is immutable (no --force; bump to republish).
+//   2. Re-validate the candidate (boot + smoke) right now, so the bytes we publish are verified again
+//      (the candidate tag is mutable and may have changed since `bake`). Abort on any failure.
+//   3. Build each provider's version-named artifact FROM the candidate base (the just-revalidated
+//      bytes), so the public artifact provably derives from validated bytes — BEFORE touching the base.
+//   3b. Required-providers gate: if `--require`/`REQUIRE_PROVIDERS` names providers a skipped one
+//      did not promote (a pure skip is not a `failed`), abort BEFORE the base is written — so the
+//      gap can't be detected only post-hoc in bake.ts after the immutable base is already tagged.
+//   4. LAST: retag the candidate base → the public version (registry-side). Reached only when every
+//      prior step succeeded, so a failure never leaves a published version with missing/stale artifacts.
+// A rerun after a mid-promote failure is clean (the version tag was never written); once published it
+// is refused at step 1 — bump the version to publish again.
+import { requiredProviders, unmetRequirements } from "@sandbox-benchmarks/harness";
+import { config } from "@sandbox-benchmarks/providers";
+import { forEachProviderWithCreds } from "../providers-run.ts";
+import { bakeDaytonaSnapshot } from "./daytona.ts";
+import { bakeE2bTemplate } from "./e2b.ts";
+import { imageExistsInRegistry, promoteImage } from "./image.ts";
+import type { BakeReport, Log } from "./types.ts";
+import type { CandidateRefs } from "./validate.ts";
+import { validateCandidates } from "./validate-run.ts";
+
+export async function promoteAll(log: Log): Promise<BakeReport[]> {
+	const reports: BakeReport[] = [];
+
+	// 1. Refuse to overwrite the immutable public version (D2b). Checked first, before any mutation, so
+	//    a refused promote leaves everything untouched. A registry error here (auth/network) is NOT
+	//    "not published" — refuse rather than risk overwriting an existing :v1 we couldn't see.
+	let alreadyPublished: boolean;
+	try {
+		alreadyPublished = await imageExistsInRegistry(config.toolchainImageVersion);
+	} catch (err) {
+		const reason = `could not verify whether ${config.toolchainImageVersion} is already published, so refusing to publish: ${err instanceof Error ? err.message : String(err)}`;
+		log(`<<< promote refused — ${reason}`);
+		reports.push({ provider: "image", status: "failed", reason });
+		return reports;
+	}
+	if (alreadyPublished) {
+		const reason = `${config.toolchainImageVersion} already exists — the public version is immutable; bump the version to publish again`;
+		log(`<<< promote refused — ${reason}`);
+		reports.push({ provider: "image", status: "failed", reason });
+		return reports;
+	}
+
+	// 2. Re-validate the candidate immediately before publishing, so the bytes we promote are verified
+	//    again (the candidate tag is mutable). Abort the whole promote if any provider fails to validate.
+	const candidateRefs: CandidateRefs = {
+		e2bTemplateCandidate: config.e2bTemplateCandidate,
+		daytonaSnapshotCandidate: config.daytonaSnapshotCandidate,
+		toolchainImageCandidate: config.toolchainImageCandidate,
+		daytonaTarget: config.daytonaRegion.target,
+	};
+	log(`>>> re-validating candidate ${config.toolchainImageCandidate} before promote…`);
+	const validateRuns = await validateCandidates(candidateRefs, log);
+	if (validateRuns.some((r) => r.status === "failed")) {
+		log("<<< promote aborted — candidate re-validation failed (nothing published)");
+		for (const run of validateRuns) {
+			reports.push({
+				provider: run.provider,
+				status: run.status,
+				...(run.reason ? { reason: run.reason } : {}),
+				...(run.durationMs !== undefined ? { durationMs: run.durationMs } : {}),
+			});
+		}
+		return reports;
+	}
+
+	// 3. Build each provider's version-named artifact FROM the candidate base (the bytes we just
+	//    revalidated). Built BEFORE the base retag, so a failure here leaves the version base unwritten
+	//    and a rerun is clean. Shares the skip-vs-fail loop with bake.
+	const runs = await forEachProviderWithCreds(
+		async (provider) => {
+			log(`>>> ${provider.name}: building version artifact from candidate…`);
+			switch (provider.name) {
+				case "e2b":
+					await bakeE2bTemplate(config.e2bTemplateVersion, config.toolchainImageCandidate, (m) =>
+						log(`    ${m}`),
+					);
+					break;
+				case "daytona":
+					await bakeDaytonaSnapshot(
+						config.daytonaSnapshotDefault,
+						config.toolchainImageCandidate,
+						(m) => log(`    ${m}`),
+					);
+					break;
+				case "modal":
+					log("    modal boots the published version image — nothing to build");
+					break;
+				default: {
+					// Exhaustiveness: a new ProviderId must add a promote branch above (compile error here).
+					const unhandled: never = provider.name;
+					throw new Error(`unhandled provider: ${String(unhandled)}`);
+				}
+			}
+		},
+		{
+			log,
+			onComplete: (run) => {
+				const time = run.durationMs !== undefined ? ` (${run.durationMs.toFixed(0)}ms)` : "";
+				log(`<<< ${run.provider}: ${run.status}${time}${run.reason ? ` — ${run.reason}` : ""}`);
+			},
+		},
+	);
+
+	for (const run of runs) {
+		reports.push({
+			provider: run.provider,
+			status: run.status,
+			...(run.reason ? { reason: run.reason } : {}),
+			...(run.durationMs !== undefined ? { durationMs: run.durationMs } : {}),
+		});
+	}
+
+	// A provider artifact failed → do NOT publish the base. The version tag stays unwritten, so a rerun
+	// (after fixing the cause) reconciles cleanly — nothing public was half-written.
+	if (reports.some((r) => r.status === "failed")) {
+		log(
+			`!!! promote aborted before publish: a ${config.toolchainImageVersion} provider artifact failed; ` +
+				"the public base was NOT written. Fix the cause and rerun `bake --promote`.",
+		);
+		return reports;
+	}
+
+	// Required-providers gate (D1), enforced HERE — before step 4 writes the immutable base — not
+	// post-hoc in bake.ts. At the publish boundary CI passes `--require e2b,daytona,modal`; a required
+	// provider whose version artifact was skipped (missing/misnamed secret) or failed is `skipped`/
+	// `failed`, so `reports.some(failed)` above does NOT catch a pure skip. Were the base published
+	// first and the gap detected only in bake.ts, the immutable `:v1` would already be tagged and a
+	// fixed rerun would be refused at step 1 — forcing a version bump to recover. Gating before publish
+	// keeps the base unwritten so a rerun reconciles cleanly. (Lenient locally: nothing required.)
+	const required = requiredProviders();
+	const unmet = unmetRequirements(reports, required);
+	if (required.length > 0 && unmet.length > 0) {
+		const reason = `required providers did not promote: ${unmet.join(", ")} (--require / REQUIRE_PROVIDERS)`;
+		log(
+			`!!! promote aborted before publish: ${reason}; the public base was NOT written. ` +
+				"Fix the cause and rerun `bake --promote`.",
+		);
+		// Push a structured failure (like the step-1 and step-4 aborts) so the emitted JSON is
+		// self-describing — a consumer sees the failed promote without re-deriving it from `--require`.
+		reports.push({ provider: "image", status: "failed", reason });
+		return reports;
+	}
+
+	// 4. LAST: publish the candidate base as the immutable public version — the commit point.
+	log(`>>> promoting image ${config.toolchainImageCandidate} → ${config.toolchainImageVersion}…`);
+	const imageStart = performance.now();
+	try {
+		await promoteImage(log);
+		reports.push({ provider: "image", status: "ok", durationMs: performance.now() - imageStart });
+	} catch (err) {
+		const reason = err instanceof Error ? err.message : String(err);
+		log(`<<< image: promote failed — ${reason}`);
+		reports.push({
+			provider: "image",
+			status: "failed",
+			reason,
+			durationMs: performance.now() - imageStart,
+		});
+	}
+
+	return reports;
+}

--- a/apps/cli/src/lib/bake/validate-run.ts
+++ b/apps/cli/src/lib/bake/validate-run.ts
@@ -1,0 +1,51 @@
+// Boot each provider's CANDIDATE artifact and run the shared smoke spec against it — the validate-only
+// pass. `promote` runs this immediately before the immutable base retag so the published version
+// derives from bytes verified again, closing the validate→promote drift window (the candidate tag is
+// mutable, so it could have changed since `bake` last validated it). Distinct from `bake`'s loop,
+// which bakes AND validates each candidate in one pass; this only validates an already-baked candidate.
+import type { ProviderConfig } from "@sandbox-benchmarks/providers";
+import type { ProviderRun } from "../providers-run.ts";
+import { forEachProviderWithCreds } from "../providers-run.ts";
+import type { SmokeOutcome } from "../smoke-run.ts";
+import { bootAndSmoke, logChecks, smokeFailureReason, smokeOk } from "../smoke-run.ts";
+import type { Log } from "./types.ts";
+import type { CandidateRefs } from "./validate.ts";
+import { candidateCreateOptions } from "./validate.ts";
+
+/** Validate every provider's candidate artifact (boot + smoke), sharing the skip-vs-fail contract. A
+ *  provider with no creds skips; one that boots and fails its smoke is `failed`. Never throws. */
+export function validateCandidates(
+	refs: CandidateRefs,
+	log: Log,
+): Promise<ProviderRun<SmokeOutcome>[]> {
+	return forEachProviderWithCreds(
+		(provider) => {
+			log(`>>> ${provider.name}: validating candidate (boot + smoke)…`);
+			// Boot the candidate artifact (override the registry adapter's version create-options).
+			const validateConfig: ProviderConfig = {
+				...provider,
+				createOptions: {
+					...provider.createOptions,
+					...candidateCreateOptions(provider.name, refs),
+				},
+			};
+			return bootAndSmoke(validateConfig);
+		},
+		{
+			log,
+			ok: smokeOk,
+			failureReason: smokeFailureReason,
+			onComplete: (run) => {
+				if (run.value) logChecks(run.provider, run.value.checks, log);
+				const time = run.durationMs !== undefined ? `${run.durationMs.toFixed(0)}ms` : "";
+				const counts = run.value
+					? `${run.value.checks.filter((c) => c.ok).length}/${run.value.checks.length} checks`
+					: "";
+				const meta = [time, counts].filter(Boolean).join(", ");
+				log(
+					`<<< ${run.provider}: ${run.status}${meta ? ` (${meta})` : ""}${run.reason ? ` — ${run.reason}` : ""}`,
+				);
+			},
+		},
+	);
+}


### PR DESCRIPTION
The release step: publish the validated candidate as the immutable public version — the only step that writes public-facing artifacts. Idempotent; run after `bake` validates.

### Changes
- `bake --promote` — registry-side retag of the candidate base → `:v1` (`docker buildx imagetools create`, no pull, so `:v1` is the exact validated bytes), then create the version-named e2b template + daytona snapshot **from the published `:v1`** (so public artifacts provably derive from the validated image).
- Atomicity — the base retag is wrapped so a failure yields a structured report instead of an unhandled rejection; a partial provider failure is flagged as an inconsistent public set with a "rerun promote" message (promote is idempotent).
- Reuses the shared provider runner (#26).

### Validation
- Unit test for the retag command builder (`imagetoolsRetagCmd`).
- The candidate-push + registry-retag mechanics were exercised during the live daytona run (the candidate base is on GHCR).
- **`--promote` (writing the public `:v1`) is intentionally not yet executed** — it's the deliberate release, best run once e2b is also green so the version ships validated on both providers.

---
Toolchain *bake* stack. Parent: #29.
