### PR TITLE
ci: bake-driven publish (PR gate + candidate->validate->promote)

### DIFF
--- a/.github/workflows/toolchain-image.yml
+++ b/.github/workflows/toolchain-image.yml
@@ -1,34 +1,90 @@
 name: Toolchain image
 
-# Build & publish the sandbox-benchmarks toolchain base image and provider variants
-# (packages/templates/images). Manual, or on changes to the images on main — never on pull requests,
-# since it needs registry credentials and is slow. The version tag is immutable: bump TOOLCHAIN_VERSION
-# in packages/schema/src/toolchain.ts to publish a new toolchain.
+# Build, validate, and publish the sandbox-benchmarks toolchain. Two lanes:
+#   • Pull requests — build the base (no push) and run the docker smoke. Fast gate, no credentials.
+#   • Push to main / manual dispatch — build + push the mutable CANDIDATE (:v1-candidate), bake each
+#     provider's candidate artifact and validate it by booting a sandbox and running the shared smoke
+#     spec (behind each provider's secret; missing ones skip), then promote the validated candidate to
+#     the immutable public :v1. Iteration never touches :v1; bump TOOLCHAIN_VERSION
+#     (packages/schema/src/toolchain.ts) to publish a new version.
 on:
+  # Manual re-trigger (e.g. after bumping TOOLCHAIN_VERSION). No inputs: the public version is
+  # immutable — there is no force/overwrite. To republish, bump TOOLCHAIN_VERSION; an already-published
+  # version is always skipped at the guard below.
   workflow_dispatch:
-    inputs:
-      overwrite:
-        description: "Rebuild & push even if the version tag is already published"
-        type: boolean
-        default: false
   push:
     branches: [main]
+    # The publish lane runs `bake`/`promote`, which pull in the whole provider-run + smoke + harness
+    # surface (not just packages/templates and the bake libs). Trigger on every file that can change
+    # bake/validate/promote behavior so a relevant change to main can't ship a version untested by it.
+    paths:
+      - "packages/templates/**"
+      - "packages/providers/**"
+      - "packages/harness/**"
+      - "apps/cli/src/lib/bake/**"
+      - "apps/cli/src/lib/providers-run.ts"
+      - "apps/cli/src/lib/smoke-run.ts"
+      - "apps/cli/src/bin/bake.ts"
+      - "packages/schema/src/toolchain.ts"
+      - ".github/workflows/toolchain-image.yml"
+  pull_request:
     paths:
       - "packages/templates/**"
       - "packages/schema/src/toolchain.ts"
       - ".github/workflows/toolchain-image.yml"
 
-# Never run two publishes at once; don't cancel an in-flight publish (a half-pushed tag is worse).
+# Serialize publishes by ref (NOT by event_name): a push to main and a manual workflow_dispatch on the
+# same ref must not publish concurrently and race on the version tag. PR runs key off their own head ref
+# (separate group) and may cancel superseded runs; a publish is never cancelled (a half-published
+# version is worse than a slow one).
 concurrency:
-  group: toolchain-image
-  cancel-in-progress: false
+  group: toolchain-image-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 permissions:
   contents: read
 
 jobs:
+  # Fast PR gate: prove the base image still builds and the toolchain is complete, without pushing or
+  # touching any provider. Uses the same shared smoke spec as the in-sandbox bake validation.
+  #
+  # Same-repo guard: this job checks out the PR head and runs scripts FROM that checkout (build.sh,
+  # smoke.ts) on a self-hosted runner, so a fork PR could execute arbitrary code on the runner itself.
+  # The repo is private (no untrusted forks today), but we gate on same-repo head as defense-in-depth
+  # against a compromised account / outside-collaborator fork. Branches pushed to this repo (the normal
+  # Graphite flow) satisfy it; a legitimate fork-based PR would skip the gate and need a maintainer to
+  # re-run it from an in-repo branch.
+  pr-gate:
+    name: Build base + docker smoke
+    if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: starsling-ubuntu-24.04-2
+    steps:
+      - name: Checkout
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      - name: Set up Bun
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
+        with:
+          bun-version: 1.3.14
+      - name: Install dependencies
+        run: bun install --frozen-lockfile --ignore-scripts
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4.1.0
+      - name: Build base (no push) + docker smoke
+        run: |
+          set -euo pipefail
+          name="$(bun packages/templates/src/pins.ts | sed -n 's/^IMAGE_NAME=//p')"
+          bash packages/templates/images/build.sh
+          # build.sh tags the base locally as ${name}:dev — smoke that, no registry involved. Generate
+          # the script in its own assignment first so a non-zero exit of the generator fails the job
+          # (not swallowed inside docker's command substitution, which would smoke an empty script).
+          smoke_script="$(bun packages/templates/src/smoke.ts --bash)"
+          docker run --rm "${name}:dev" bash -lc "$smoke_script"
+
+  # Publish lane: candidate → validate → promote. Thin wrapper over the bake bin (thin workflow, fat
+  # script). Provider steps are guarded by their secrets inside the bin (missing creds skip).
   publish:
-    name: Build & publish toolchain
+    name: Bake, validate & promote toolchain
+    if: github.event_name != 'pull_request'
     runs-on: starsling-ubuntu-24.04-2
     permissions:
       contents: read
@@ -37,37 +93,16 @@ jobs:
       REGISTRY: ghcr.io
       IMAGE_OWNER: starslingdev
     steps:
-      # Third-party actions are pinned to a commit SHA (the tag comment is for humans only).
       - name: Checkout
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
-
       - name: Set up Bun
         uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
         with:
           bun-version: 1.3.14
-
-      # The pins source of truth (packages/templates/src/pins.ts) imports the workspace schema, so the
-      # workspace must be linked before it can run.
       - name: Install dependencies
         run: bun install --frozen-lockfile --ignore-scripts
-
-      # Resolve the image identity from the arktype-validated TS config. `bun pins.ts` also validates
-      # every pin (hex sha256s, non-empty versions) and exits non-zero on any unfilled/invalid pin, so
-      # this is the early fail-fast gate — no separate __TODO__ check needed.
-      - name: Resolve identity & validate pins
-        run: |
-          pins="$(bun packages/templates/src/pins.ts)"
-          name="$(echo "${pins}" | sed -n 's/^IMAGE_NAME=//p')"
-          version="$(echo "${pins}" | sed -n 's/^IMAGE_VERSION=//p')"
-          {
-            echo "IMAGE_NAME=${name}"
-            echo "IMAGE_VERSION=${version}"
-            echo "BASE_REF=${REGISTRY}/${IMAGE_OWNER}/${name}:${version}"
-          } >> "${GITHUB_ENV}"
-
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4.1.0
-
       - name: Log in to the container registry
         uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
         with:
@@ -75,98 +110,96 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      # Version guard: skip if the tag already exists, unless overwrite was requested.
-      - name: Check if already published
+      # Resolve identity from the arktype-validated TS config; `bun pins.ts` also validates every pin
+      # and exits non-zero on any unfilled/invalid one (the early fail-fast gate).
+      - name: Resolve identity & validate pins
+        run: |
+          set -euo pipefail
+          pins="$(bun packages/templates/src/pins.ts)"
+          name="$(echo "${pins}" | sed -n 's/^IMAGE_NAME=//p')"
+          version="$(echo "${pins}" | sed -n 's/^IMAGE_VERSION=//p')"
+          {
+            echo "IMAGE_NAME=${name}"
+            echo "IMAGE_VERSION=${version}"
+            echo "VERSION_REF=${REGISTRY}/${IMAGE_OWNER}/${name}:${version}"
+          } >> "${GITHUB_ENV}"
+
+      # Guard the immutable public version: skip the whole publish if :v1 already exists. The version is
+      # immutable (promote refuses to overwrite it), so a published version is never re-promoted — bump
+      # TOOLCHAIN_VERSION to publish a new one. The candidate is mutable and always rebuilt within a run.
+      - name: Check if version already published
         id: guard
         run: |
-          if [ "${{ github.event.inputs.overwrite }}" = "true" ]; then
-            echo "skip=false" >> "${GITHUB_OUTPUT}"
-          elif docker manifest inspect "${BASE_REF}" >/dev/null 2>&1; then
-            echo "::notice::${BASE_REF} already published — skipping (run with overwrite to force)."
+          if docker manifest inspect "${VERSION_REF}" >/dev/null 2>&1; then
+            echo "::notice::${VERSION_REF} already published — skipping (bump TOOLCHAIN_VERSION to publish a new version)."
             echo "skip=true" >> "${GITHUB_OUTPUT}"
           else
             echo "skip=false" >> "${GITHUB_OUTPUT}"
           fi
 
-      # Build base + all variants via the shared build script (thin workflow, fat script). build.sh
-      # re-validates the pins and derives every --build-arg from the TS source.
-      - name: Build images
-        if: steps.guard.outputs.skip != 'true'
-        run: |
-          export BUILD_DATE="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
-          export BUILD_REF="${GITHUB_SHA}"
-          export BUILD_VERSION="${IMAGE_VERSION}"
-          bash packages/templates/images/build.sh
-
-      # Smoke-test the base — fail before pushing if the baked toolchain is incomplete. The probes
-      # come from the single shared spec (packages/templates/src/smoke.ts) so this docker check and
-      # the in-sandbox bench-smoke check can't drift; --bash emits a self-logging assertion script.
-      - name: Smoke-test base
+      # The candidate base image must be PUBLIC so providers can pull it anonymously: e2b builds the
+      # template on its REMOTE builder (FROM the ghcr candidate base) and daytona/modal pull it to
+      # snapshot/boot — none are handed ghcr pull credentials. GHCR packages are created PRIVATE on
+      # first push and GitHub exposes no API to flip visibility, so making it public is a one-time
+      # manual bootstrap (Org → Packages → this package → Package settings → Change visibility → Public,
+      # or link the package to this public repo). This guard fails fast with that instruction instead of
+      # letting an opaque provider "unauthorized/not found" pull error surface mid-bake.
+      - name: Ensure candidate package is public
         if: steps.guard.outputs.skip != 'true'
         run: |
           set -euo pipefail
-          # Generate the script in its own step first: a non-zero exit of the generator must fail the
-          # job, not get swallowed inside docker's command substitution (which would smoke an empty script).
-          smoke_script="$(bun packages/templates/src/smoke.ts --bash)"
-          docker run --rm "${BASE_REF}" bash -lc "$smoke_script"
+          # > Capture the HTTP status separately so a real "absent" (404) is distinguished from auth/scope
+          # > failures (403 SSO/token gap) and transport errors — `curl -f ... || echo '{}'` would collapse
+          # > all of them into the same empty fallback and let the publish proceed on a false "not found".
+          api="https://api.github.com/orgs/${IMAGE_OWNER}/packages/container/${IMAGE_NAME}"
+          code="$(curl -sS -m 30 -o /tmp/ghcr-pkg.json -w '%{http_code}' \
+            -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
+            -H "Accept: application/vnd.github+json" \
+            "${api}")" || { echo "::error::Could not reach the GHCR package API (network/transport error) — refusing to publish blind."; exit 1; }
+          case "${code}" in
+            200)
+              if grep -qE '"visibility"[[:space:]]*:[[:space:]]*"public"' /tmp/ghcr-pkg.json; then
+                echo "GHCR package ${IMAGE_OWNER}/${IMAGE_NAME} is public — providers can pull the candidate."
+              else
+                echo "::error::GHCR package ${IMAGE_OWNER}/${IMAGE_NAME} is not public. e2b/daytona/modal pull the candidate base anonymously, so set it Public once (org package settings or link it to this repo), then re-run."
+                exit 1
+              fi
+              ;;
+            404)
+              echo "::warning::GHCR package ${IMAGE_OWNER}/${IMAGE_NAME} not found yet — the push below creates it PRIVATE. After this run, set it Public once so the candidate validate and the providers can pull it; this run's validate will fail until then."
+              ;;
+            *)
+              echo "::error::GHCR package API returned HTTP ${code} (expected 200 or 404) — likely a token-scope gap or org SSO enforcement, not a missing package. Resolve and re-run instead of publishing blind."
+              exit 1
+              ;;
+          esac
 
-      # Push the base + provider variants to the registry.
-      - name: Push images
-        if: steps.guard.outputs.skip != 'true'
-        run: |
-          set -euo pipefail
-          base_repo="${REGISTRY}/${IMAGE_OWNER}/${IMAGE_NAME}"
-          docker push "${base_repo}:${IMAGE_VERSION}"
-          for provider in e2b daytona modal; do
-            docker push "${base_repo}-${provider}:${IMAGE_VERSION}"
-          done
-
-      # Register the e2b template from images/e2b (envd is injected by the e2b builder). e2b.toml was
-      # generated by build.sh from pins.ts. Guarded on the API key so the workflow stays green wherever
-      # the secret isn't configured.
-      - name: Publish e2b template
+      # Build + push the candidate, then bake each provider's candidate artifact and validate it by
+      # booting a sandbox (skip-on-missing-creds). Fails the job if any baked provider fails to validate.
+      - name: Bake + validate candidate
         if: steps.guard.outputs.skip != 'true'
         env:
+          BUILD_REF: ${{ github.sha }}
+          BUILD_VERSION: ${{ env.IMAGE_VERSION }}
           E2B_API_KEY: ${{ secrets.E2B_API_KEY }}
-        run: |
-          set -euo pipefail
-          if [ -z "${E2B_API_KEY:-}" ]; then
-            echo "::warning::E2B_API_KEY not set — skipping e2b template build."
-            exit 0
-          fi
-          # TODO(publish): pin the e2b CLI version and confirm the build-context flags (the context
-          # must include _shared/) and template-id write-back. Reads images/e2b/e2b.toml.
-          bunx @e2b/cli template build \
-            --path packages/templates/images \
-            --dockerfile packages/templates/images/e2b/Dockerfile \
-            --config packages/templates/images/e2b/e2b.toml
-
-      # Create/refresh the daytona snapshot from the pushed base image.
-      - name: Publish daytona snapshot
-        if: steps.guard.outputs.skip != 'true'
-        env:
           DAYTONA_API_KEY: ${{ secrets.DAYTONA_API_KEY }}
-        run: |
-          set -euo pipefail
-          if [ -z "${DAYTONA_API_KEY:-}" ]; then
-            echo "::warning::DAYTONA_API_KEY not set — skipping daytona snapshot create."
-            exit 0
-          fi
-          # TODO(publish): create snapshot "${IMAGE_NAME}-${IMAGE_VERSION}" from ${BASE_REF} via the
-          # daytona SDK (delete-if-exists, then create with TARGET_SPEC). Mirrors DAYTONA_SNAPSHOT.
-          echo "would create daytona snapshot ${IMAGE_NAME}-${IMAGE_VERSION} from ${BASE_REF}"
-
-      # Modal consumes the image via Image.fromRegistry; verify it's reachable with credentials.
-      - name: Validate modal access
-        if: steps.guard.outputs.skip != 'true'
-        env:
           MODAL_TOKEN_ID: ${{ secrets.MODAL_TOKEN_ID }}
           MODAL_TOKEN_SECRET: ${{ secrets.MODAL_TOKEN_SECRET }}
         run: |
           set -euo pipefail
-          if [ -z "${MODAL_TOKEN_ID:-}" ]; then
-            echo "::warning::MODAL_TOKEN_* not set — skipping modal validation."
-            exit 0
-          fi
-          # TODO(publish): validate ${BASE_REF} is reachable from modal via Image.fromRegistry.
-          echo "would validate modal access to ${BASE_REF}"
+          export BUILD_DATE="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+          # --require fails the publish loudly if any provider's secret is missing/misnamed, so a merge
+          # can't bless a candidate while a provider was silently skipped (never built or validated).
+          bun apps/cli/src/bin/bake.ts --build-push --require e2b,daytona,modal
+
+      # Promote the validated candidate to the immutable public version (+ version-named artifacts).
+      - name: Promote candidate → version
+        if: steps.guard.outputs.skip != 'true'
+        env:
+          E2B_API_KEY: ${{ secrets.E2B_API_KEY }}
+          DAYTONA_API_KEY: ${{ secrets.DAYTONA_API_KEY }}
+          MODAL_TOKEN_ID: ${{ secrets.MODAL_TOKEN_ID }}
+          MODAL_TOKEN_SECRET: ${{ secrets.MODAL_TOKEN_SECRET }}
+        # --require fails promote loudly if a required provider's secret is missing/misnamed, so the
+        # public version is never published while a provider's version artifact was silently skipped.
+        run: bun apps/cli/src/bin/bake.ts --promote --require e2b,daytona,modal


### PR DESCRIPTION
Rewrite the toolchain workflow as a thin wrapper over the validated `bake` bin (thin workflow, fat script).

### Changes
- **PR gate** (`pull_request`) — build the base (no push) + run the docker smoke from the shared spec. Fast, no credentials.
- **Publish** (`push: main` / dispatch) — resolve + validate pins → guard the immutable version tag (skip `:v1` if already published, unless `overwrite`) → **ensure the candidate package is public** (fail-fast guard with actionable message) → `bake --build-push` (bake + validate every provider behind its secret; missing creds skip) → `bake --promote`.
- Never cancels an in-flight publish; PR runs cancel superseded runs.

### Validation
- The bin this calls is validated **locally** (amd64 build + 5/5 docker smoke) and **live** (daytona ZEN5 e2e, 5/5); the PR-gate docker smoke mirrors that local 5/5.
- The publish job runs on merge to `main`. **One-time bootstrap:** the GHCR package must be made Public (GitHub has no API to flip visibility) — the new guard surfaces this clearly rather than letting a provider pull fail opaquely.

---
Top of the toolchain *bake* stack. Parent: #30.
