### PR TITLE
chore(deps): catalog @nodable XML parser for PTS schema

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -143,6 +143,10 @@
       "@computesdk/modal": "1.9.3",
       "computesdk": "4.1.3",
     },
+    "xml": {
+      "@nodable/compact-builder": "1.0.9",
+      "@nodable/flexible-xml-parser": "1.2.2",
+    },
   },
   "packages": {
     "@ark/schema": ["@ark/schema@0.56.0", "", { "dependencies": { "@ark/util": "0.56.0" } }, "sha512-ECg3hox/6Z/nLajxXqNhgPtNdHWC9zNsDyskwO28WinoFEnWow4IsERNz9AnXRhTZJnYIlAJ4uGn3nlLk65vZA=="],

--- a/package.json
+++ b/package.json
@@ -20,6 +20,10 @@
         "@computesdk/e2b": "1.7.51",
         "@computesdk/modal": "1.9.3",
         "computesdk": "4.1.3"
+      },
+      "xml": {
+        "@nodable/compact-builder": "1.0.9",
+        "@nodable/flexible-xml-parser": "1.2.2"
       }
     }
   },


### PR DESCRIPTION
I'm doing the implementation of the benchmarking mise tasks in vertical slices rather than just copying over from the runner-benchmarking repo. This PR stack is the full end to end scope run the node pts test suite and analyze it  
  
This PR adds an `xml` catalog (@nodable/flexible-xml-parser + @nodable/compact-builder)
pinned for the typed PTS composite.xml parser landing in the results package.
Deps-only; no consumer yet, so the lockfile records the pins in isolation.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an `xml` catalog with pinned parser deps to prepare the typed PTS `composite.xml` parser in the results package. Deps-only; no consumers or runtime changes.

- **Dependencies**
  - Added `@nodable/flexible-xml-parser@1.2.2`
  - Added `@nodable/compact-builder@1.0.9`

<sup>Written for commit 4933aa3a9dc690dfb07e841bb1e88bd16678c62e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/starslingdev/sandbox-benchmarks/pull/32?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Added XML parsing capabilities to the project by updating the workspace catalog configuration to include XML-related dependencies.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->