### PR TITLE
feat(schema): metric catalog + sample aggregation

### DIFF
--- a/packages/schema/src/analysis.test.ts
+++ b/packages/schema/src/analysis.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from "bun:test";
+import { aggregate } from "./index.ts";
+
+describe("aggregate", () => {
+	it("summarises a multi-sample distribution (R-7 percentiles, n-1 stdev)", () => {
+		// The three real per-run samples from a Daytona node-web-tooling run.
+		const a = aggregate([16.19, 16.3, 16.08]);
+		expect(a.n).toBe(3);
+		expect(a.min).toBe(16.08);
+		expect(a.max).toBe(16.3);
+		expect(a.p50).toBeCloseTo(16.19, 5);
+		// R-7 interpolation for p95 over [16.08, 16.19, 16.3]: 16.19 + 0.9 * (16.3 - 16.19).
+		expect(a.p95).toBeCloseTo(16.289, 3);
+		expect(a.mean).toBeCloseTo(16.19, 2);
+		expect(a.stdev).toBeCloseTo(0.11, 2);
+	});
+
+	it("rejects a non-finite sample", () => {
+		expect(() => aggregate([1, Number.POSITIVE_INFINITY])).toThrow(/finite/);
+		expect(() => aggregate([Number.NaN])).toThrow(/finite/);
+	});
+
+	it("is order-independent", () => {
+		expect(aggregate([16.08, 16.19, 16.3])).toEqual(aggregate([16.3, 16.08, 16.19]));
+	});
+
+	it("reports a single sample with zero spread", () => {
+		expect(aggregate([42])).toMatchObject({
+			p50: 42,
+			p95: 42,
+			mean: 42,
+			stdev: 0,
+			min: 42,
+			max: 42,
+			n: 1,
+		});
+	});
+
+	it("rejects an empty sample set", () => {
+		expect(() => aggregate([])).toThrow();
+	});
+
+	it("computes a stable stdev for large-magnitude samples (Welford)", () => {
+		// Values near 1e8 whose true stdev is exactly 1; a naive Σx² accumulator loses this signal to
+		// float64 cancellation, Welford does not.
+		const a = aggregate([100_000_001, 100_000_002, 100_000_003]);
+		expect(a.mean).toBe(100_000_002);
+		expect(a.stdev).toBeCloseTo(1, 10);
+	});
+});

--- a/packages/schema/src/analysis.ts
+++ b/packages/schema/src/analysis.ts
@@ -1,0 +1,80 @@
+// Pure analysis over the Samples a Metric retains. Percentiles use linear interpolation between
+// order statistics (R-7, the numpy/Excel default) so Aggregates are stable across toolchains.
+import { type } from "arktype";
+
+// Plain `"number"` accepts NaN/Infinity; the distribution fields must be finite, so a corrupt
+// Aggregates can't pass validation undetected. `n`'s `number.integer` already excludes both; `stdev`
+// composes `finiteNumber` with `>= 0` (a bare `number >= 0` would still admit `Infinity`).
+const finiteNumber = type("number").narrow((value) => Number.isFinite(value));
+const finiteNonNegative = finiteNumber.narrow((value) => value >= 0);
+
+/**
+ * The canonical distribution retained for every MetricResult: percentiles, mean, spread and Sample
+ * count. An arktype schema so the Run model (./run.ts) can validate it at the dataset boundary, with
+ * the TypeScript {@link Aggregates} type inferred from it — one source of truth for the shape.
+ */
+export const aggregatesSchema = type({
+	p50: finiteNumber,
+	p95: finiteNumber,
+	mean: finiteNumber,
+	stdev: finiteNonNegative,
+	min: finiteNumber,
+	max: finiteNumber,
+	n: "number.integer > 0",
+});
+
+export type Aggregates = typeof aggregatesSchema.infer;
+
+/**
+ * Percentile of a pre-sorted, non-empty Sample set (R-7 linear interpolation). Private: callers go
+ * through {@link aggregate}, which establishes the sorted/non-empty precondition. `p` of 0 and 1
+ * resolve to the min and max, so {@link aggregate} reuses this for both.
+ */
+function percentile(sorted: readonly number[], p: number): number {
+	const h = (sorted.length - 1) * p;
+	const lo = Math.floor(h);
+	const hi = Math.ceil(h);
+	const loValue = sorted[lo] ?? Number.NaN;
+	const hiValue = sorted[hi] ?? loValue;
+	return loValue + (h - lo) * (hiValue - loValue);
+}
+
+/** Aggregate Samples into the canonical distribution. Throws on an empty Sample set. */
+export function aggregate(samples: number[]): Aggregates {
+	if (samples.length === 0) {
+		throw new Error("aggregate() requires at least one sample");
+	}
+	for (const sample of samples) {
+		// Reject non-finite samples at the source so NaN/Infinity can never propagate into a Run.
+		if (!Number.isFinite(sample)) {
+			throw new Error(`aggregate() requires finite samples; got ${sample}`);
+		}
+	}
+	const sorted = [...samples].sort((a, b) => a - b);
+
+	// Welford's online algorithm over the sorted samples: mean and the sum of squared deviations (M2)
+	// in one pass. Numerically stable — accumulating deviations from the running mean avoids the
+	// catastrophic cancellation a naive Σx² accumulator suffers on large-magnitude samples — and
+	// deterministic regardless of input order (we iterate the canonical sorted order, not the raw
+	// input). The percentiles already require the sort, so aggregate() is O(n log n) overall.
+	let mean = 0;
+	let m2 = 0;
+	let n = 0;
+	for (const sample of sorted) {
+		n += 1;
+		const delta = sample - mean;
+		mean += delta / n;
+		m2 += delta * (sample - mean);
+	}
+
+	return {
+		p50: percentile(sorted, 0.5),
+		p95: percentile(sorted, 0.95),
+		mean,
+		// Sample standard deviation (n-1); 0 for a single Sample.
+		stdev: Math.sqrt(n > 1 ? m2 / (n - 1) : 0),
+		min: percentile(sorted, 0),
+		max: percentile(sorted, 1),
+		n,
+	};
+}

--- a/packages/schema/src/catalog.test.ts
+++ b/packages/schema/src/catalog.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from "bun:test";
+import {
+	DIMENSIONS,
+	getMetric,
+	headlineMetric,
+	METRIC_CATALOG,
+	metricsForDimension,
+} from "./index.ts";
+
+describe("metric catalog", () => {
+	it("has unique metric ids", () => {
+		const ids = METRIC_CATALOG.map((metric) => metric.id);
+		expect(new Set(ids).size).toBe(ids.length);
+	});
+
+	it("places every metric in a known dimension and gives PTS metrics a test profile", () => {
+		for (const metric of METRIC_CATALOG) {
+			expect(DIMENSIONS).toContain(metric.dimension);
+			if (metric.pts) expect(metric.pts.test.length).toBeGreaterThan(0);
+		}
+	});
+
+	it("has at most one headline metric per dimension", () => {
+		for (const dimension of DIMENSIONS) {
+			const headlines = metricsForDimension(dimension).filter((metric) => metric.headline);
+			expect(headlines.length).toBeLessThanOrEqual(1);
+		}
+	});
+
+	it("resolves the node-web-tooling headline for cpu", () => {
+		const metric = headlineMetric("cpu");
+		expect(metric.id).toBe("node_web_tooling_runs_per_s");
+		expect(metric.direction).toBe("HIB");
+		expect(metric.pts?.test).toBe("pts/node-web-tooling");
+		expect(getMetric(metric.id)).toBe(metric);
+	});
+
+	it("returns undefined for an unknown metric id", () => {
+		expect(getMetric("not_a_metric")).toBeUndefined();
+	});
+
+	it("throws when a dimension has no headline metric", () => {
+		expect(() => headlineMetric("economics")).toThrow();
+	});
+});

--- a/packages/schema/src/catalog.ts
+++ b/packages/schema/src/catalog.ts
@@ -1,0 +1,63 @@
+// The Metric Catalog: the single registry of every Metric the dataset can rank or chart, and the
+// stability contract for the comparison dataset — entries change only by deliberate schema revision,
+// so historical Runs stay comparable. A parsed result whose id isn't here is inert: it's reported
+// separately for visibility, never ranked, until someone adds a matching entry.
+//
+// This slice populates only the cpu Dimension's single headline Metric (PTS node-web-tooling). The
+// per-Dimension assembly seam below is retained so the remaining Metrics slot in without reshaping
+// the Catalog or its consumers. As more PTS dimensions land, prefer GENERATING the cpu/pts entries by
+// parsing the upstream PTS `test-definition.xml` over hand-authoring multi-result option matrices —
+// the `...ptsCpu` seam accepts such a generated module unchanged.
+import type { Dimension, MetricDef } from "./metrics.ts";
+import { metricDefSchema } from "./metrics.ts";
+
+// The cpu Dimension is PTS-backed; node-web-tooling is its headline (V8 Web Tooling under Node.js).
+const ptsCpu: MetricDef[] = [
+	{
+		id: "node_web_tooling_runs_per_s",
+		dimension: "cpu",
+		unit: "runs/s",
+		direction: "HIB",
+		headline: true,
+		label: "Node.js web tooling",
+		description:
+			"Node.js V8 Web Tooling Benchmark (PTS pts/node-web-tooling). Running the V8 project's Web-Tooling-Benchmark under Node.js. The Web-Tooling-Benchmark stresses JavaScript-related workloads common to web developers like Babel and TypeScript and Babylon. This test profile can test the system's JavaScript performance with Node.js.",
+		pts: { test: "pts/node-web-tooling" },
+		sourceUrl:
+			"https://github.com/phoronix-test-suite/phoronix-test-suite/tree/master/ob-cache/test-profiles/pts/node-web-tooling-1.0.1",
+	},
+];
+
+/**
+ * The full Catalog, validated at load. Dimensions land in display order as their Metrics are ported;
+ * the runtime `.assert` turns a malformed entry (bad dimension/direction, missing field) into a
+ * fail-fast at import rather than a silently broken stability contract.
+ */
+export const METRIC_CATALOG: readonly MetricDef[] = metricDefSchema.array().assert([...ptsCpu]);
+
+const byId = new Map(METRIC_CATALOG.map((metric) => [metric.id, metric]));
+
+// Two Metrics sharing an id would silently collapse in `byId` (and corrupt getMetric); fail fast at
+// import — the schema validates each entry's shape but not id-uniqueness across the registry.
+if (byId.size !== METRIC_CATALOG.length) {
+	throw new Error("METRIC_CATALOG contains duplicate metric ids");
+}
+
+/** Look up a Metric by id; undefined for ids not in the Catalog. */
+export function getMetric(id: string): MetricDef | undefined {
+	return byId.get(id);
+}
+
+/** Every Metric belonging to a Dimension, in Catalog order. */
+export function metricsForDimension(dimension: Dimension): MetricDef[] {
+	return METRIC_CATALOG.filter((metric) => metric.dimension === dimension);
+}
+
+/** The first headline Metric of a Dimension — what the leaderboard shows. Throws if none exists. */
+export function headlineMetric(dimension: Dimension): MetricDef {
+	const headline = METRIC_CATALOG.find(
+		(metric) => metric.dimension === dimension && metric.headline,
+	);
+	if (!headline) throw new Error(`Dimension ${dimension} has no headline Metric`);
+	return headline;
+}

--- a/packages/schema/src/index.ts
+++ b/packages/schema/src/index.ts
@@ -3,6 +3,12 @@
 import { type } from "arktype";
 import { rawRunSchema } from "./lib/internal.ts";
 
+// Pure analysis over retained Samples: the Aggregates distribution and how it's computed.
+export * from "./analysis.ts";
+// The Metric Catalog — the registry of rankable Metrics, plus lookup helpers.
+export * from "./catalog.ts";
+// Metric vocabulary: Dimension, Direction and the MetricDef shape every Metric declares.
+export * from "./metrics.ts";
 // Provider identity & economics registry (id, requiredEnvVars, pricing, isolation, spec-pinning).
 export * from "./providers.ts";
 // Canonical toolchain image identity (name + version), shared by the build pins and runtime config.

--- a/packages/schema/src/metrics.ts
+++ b/packages/schema/src/metrics.ts
@@ -1,0 +1,65 @@
+// The Metric vocabulary: the Dimensions a Sandbox is measured across, the Direction a Metric
+// improves in, and the MetricDef shape every catalogued Metric declares — all arktype-first, so the
+// Catalog (./catalog.ts), the Run model (./run.ts) and the PTS parser share one validated source of
+// truth for these and the TypeScript types are inferred, never hand-written twice.
+import { type } from "arktype";
+
+/** Whether a higher or lower value is better. HIB = higher-is-better, LIB = lower-is-better. */
+export const directionSchema = type("'HIB' | 'LIB'");
+export type Direction = typeof directionSchema.infer;
+
+/**
+ * The axes a Sandbox provider is measured across — a closed, ordered vocabulary. A
+ * Metric's Dimension is part of its stability contract, so this set changes only by deliberate
+ * schema revision. The tuple is the ordering source; {@link dimensionSchema} validates it at runtime.
+ * Landed in full even though this slice populates only `cpu`: the vocabulary is cheap, and downstream
+ * code switches over it exhaustively.
+ */
+export const DIMENSIONS = [
+	"lifecycle",
+	"control-plane",
+	"cpu",
+	"disk",
+	"memory",
+	"network",
+	"system",
+	"realworld",
+	"economics",
+] as const;
+
+export const dimensionSchema = type.enumerated(...DIMENSIONS);
+export type Dimension = typeof dimensionSchema.infer;
+
+/**
+ * One Metric's definition: its stable id, the Dimension it belongs to, unit, Direction, and whether
+ * it headlines that Dimension on the leaderboard. PTS-derived Metrics also carry the `pts` provenance
+ * the results normalizer uses to map a parsed `<Result>` onto the Catalog.
+ *
+ * An arktype schema, not a hand-written interface, so the Metric Catalog — itself a stability
+ * contract whose ids, units and directions are the keys that keep Runs comparable across history — is
+ * validated at load, with the TypeScript {@link MetricDef} type inferred from the same source.
+ */
+export const metricDefSchema = type({
+	// Stable, unique identifier, e.g. "node_web_tooling_runs_per_s". Non-empty: an empty id would
+	// silently collapse the byId registry (catalog.ts) and is always an authoring/generator bug.
+	id: "string >= 1",
+	dimension: dimensionSchema,
+	// Display unit, e.g. "runs/s", "ms", "MB/s".
+	unit: "string >= 1",
+	direction: directionSchema,
+	// Shown on the leaderboard/summary for its Dimension.
+	headline: "boolean",
+	label: "string >= 1",
+	description: "string >= 1",
+	// For Metrics parsed from a PTS `<Result>`: the versionless test profile (e.g.
+	// "pts/node-web-tooling") and — for multi-result tests — the exact `<Description>` this Metric maps
+	// to. Each PTS `<Result>` maps to exactly one Metric. Both non-empty when present (an empty
+	// `test`/`description` would never match a real `<Result>`).
+	"pts?": { test: "string >= 1", "description?": "string >= 1" },
+	// Primary-source definition (upstream PTS profile, methodology doc, …).
+	"sourceUrl?": "string",
+	// Economics Metrics derived from other Metrics + pricing, never parsed.
+	"derived?": "boolean",
+});
+
+export type MetricDef = typeof metricDefSchema.infer;


### PR DESCRIPTION
Adds the Metric vocabulary (Dimension, Direction, MetricDef), the Metric Catalog seeded with the cpu headline metric node_web_tooling_runs_per_s, and pure Sample analysis (Aggregates schema + R-7 aggregate()).

metrics.ts: closed Dimension vocabulary plus MetricDef shape. catalog.ts: METRIC_CATALOG with getMetric/metricsForDimension/headlineMetric. analysis.ts: aggregatesSchema (arktype) plus aggregate()/percentile (R-7).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds the Metric vocabulary and a seeded Metric Catalog, plus pure sample aggregation with stable percentiles and spread. Enables a CPU headline metric and simple metric lookups for ranking.

- **New Features**
  - Metric model: closed `DIMENSIONS`, `Direction`, and `MetricDef` schema (`arktype`).
  - Catalog: CPU headline `node_web_tooling_runs_per_s` (`runs/s`, HIB) from PTS `pts/node-web-tooling`; helpers `getMetric`, `metricsForDimension`, `headlineMetric`; runtime schema validation and duplicate-id guard.
  - Analysis: `aggregate()` over finite samples returns p50/p95 (R-7), mean, n−1 stdev (Welford), min/max, and `n`; `aggregatesSchema` (`arktype`).
  - Index/tests: exports re-exported via the package index; tests cover catalog invariants, order independence, single/empty cases, and numeric stability.

<sup>Written for commit 2d647f79b0f3b23a53844dc1b0e2b047bc82c577. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/starslingdev/sandbox-benchmarks/pull/33?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

