### PR TITLE
feat(schema): Run dataset model + validators

### DIFF
--- a/packages/schema/src/index.ts
+++ b/packages/schema/src/index.ts
@@ -11,6 +11,8 @@ export * from "./catalog.ts";
 export * from "./metrics.ts";
 // Provider identity & economics registry (id, requiredEnvVars, pricing, isolation, spec-pinning).
 export * from "./providers.ts";
+// The canonical Run dataset model (Run/ProviderRun/MetricResult/…) and its validators.
+export * from "./run.ts";
 // Canonical toolchain image identity (name + version), shared by the build pins and runtime config.
 export * from "./toolchain.ts";
 

--- a/packages/schema/src/run.test.ts
+++ b/packages/schema/src/run.test.ts
@@ -1,0 +1,111 @@
+import { describe, expect, it } from "bun:test";
+import { parseRun, parseRunIndex } from "./index.ts";
+
+const validRun = {
+	schemaVersion: "1",
+	runId: "run-1",
+	sha: "deadbeef",
+	generatedAt: "2026-06-20T00:00:00.000Z",
+	targetSpec: { vcpus: 2, memoryGb: 8, diskGb: 20 },
+	providers: [
+		{
+			providerId: "daytona",
+			validationStatus: "validated",
+			observedSpecs: { vcpus: 2, memoryGb: 8 },
+			metrics: [
+				{
+					metricId: "node_web_tooling_runs_per_s",
+					samples: [16.19, 16.3, 16.08],
+					aggregates: {
+						p50: 16.19,
+						p95: 16.3,
+						mean: 16.19,
+						stdev: 0.11,
+						min: 16.08,
+						max: 16.3,
+						n: 3,
+					},
+					sourceFile: "pts_node-web-tooling.xml",
+				},
+			],
+			skips: [],
+			uncatalogued: [],
+		},
+	],
+};
+
+describe("Run schema", () => {
+	it("accepts a well-formed Run and infers through to the nested aggregates", () => {
+		const run = parseRun(validRun);
+		expect(run.providers[0]?.metrics[0]?.aggregates.n).toBe(3);
+		expect(run.providers[0]?.validationStatus).toBe("validated");
+	});
+
+	it("rejects an unknown schemaVersion", () => {
+		expect(() => parseRun({ ...validRun, schemaVersion: "2" })).toThrow();
+	});
+
+	it("rejects a non-positive target spec", () => {
+		expect(() => parseRun({ ...validRun, targetSpec: { vcpus: 0, memoryGb: 8 } })).toThrow();
+	});
+
+	it("rejects a fractional sample count in aggregates", () => {
+		const bad = structuredClone(validRun);
+		const provider = bad.providers[0];
+		const metric = provider?.metrics[0];
+		if (metric) metric.aggregates.n = 2.5;
+		expect(() => parseRun(bad)).toThrow();
+	});
+
+	it("rejects a validated ProviderRun with no metrics", () => {
+		const bad = structuredClone(validRun);
+		const provider = bad.providers[0];
+		if (provider) provider.metrics = [];
+		expect(() => parseRun(bad)).toThrow();
+	});
+
+	it("accepts a pending ProviderRun with no metrics", () => {
+		const pending = structuredClone(validRun);
+		const provider = pending.providers[0];
+		if (provider) {
+			provider.validationStatus = "pending";
+			provider.metrics = [];
+		}
+		expect(parseRun(pending).providers[0]?.validationStatus).toBe("pending");
+	});
+
+	it("rejects a non-finite sample", () => {
+		const bad = structuredClone(validRun);
+		const metric = bad.providers[0]?.metrics[0];
+		if (metric) metric.samples = [16.19, Number.POSITIVE_INFINITY, 16.08];
+		expect(() => parseRun(bad)).toThrow();
+	});
+
+	it("rejects aggregates.n disagreeing with samples.length", () => {
+		const bad = structuredClone(validRun);
+		const metric = bad.providers[0]?.metrics[0];
+		if (metric) metric.aggregates.n = 999;
+		expect(() => parseRun(bad)).toThrow();
+	});
+
+	it("round-trips a RunIndex", () => {
+		const index = parseRunIndex({
+			schemaVersion: "1",
+			runs: [{ runId: "run-1", generatedAt: "2026-06-20T00:00:00.000Z", path: "runs/run-1.json" }],
+		});
+		expect(index.runs).toHaveLength(1);
+		expect(index.runs[0]?.runId).toBe("run-1");
+	});
+
+	it("rejects a RunIndex that isn't newest-first", () => {
+		expect(() =>
+			parseRunIndex({
+				schemaVersion: "1",
+				runs: [
+					{ runId: "old", generatedAt: "2026-06-19T00:00:00.000Z", path: "runs/old.json" },
+					{ runId: "new", generatedAt: "2026-06-20T00:00:00.000Z", path: "runs/new.json" },
+				],
+			}),
+		).toThrow();
+	});
+});

--- a/packages/schema/src/run.ts
+++ b/packages/schema/src/run.ts
@@ -1,0 +1,175 @@
+/**
+ * The canonical result model for the sandbox comparison dataset. These arktype
+ * schemas are the producer/consumer contract: the harness validates every Run it emits, and every
+ * consumer validates a dataset at its fetch boundary. The measurement model nests Sample → Metric →
+ * Run: `MetricResult.samples` holds the retained Samples, `aggregates` their distribution.
+ *
+ * Schemas compose by embedding one another (arktype accepts a `Type` as a property value), so the
+ * TypeScript types stay inferred from the single runtime source — no hand-written interface to drift.
+ */
+import { type } from "arktype";
+import { aggregatesSchema } from "./analysis.ts";
+import { directionSchema } from "./metrics.ts";
+
+/** Whether a ProviderRun carries at least one catalogued Metric (validated) or none yet (pending). */
+export const validationStatusSchema = type("'validated' | 'pending'");
+export type ValidationStatus = typeof validationStatusSchema.infer;
+
+/** One catalogued Metric's result: the retained Samples and their distribution, with provenance. */
+export const metricResultSchema = type({
+	metricId: "string",
+	// At least one retained Sample — a MetricResult with `samples: []` but `aggregates.n > 0` would be
+	// internally inconsistent, so reject it at the boundary.
+	samples: "number[] >= 1",
+	aggregates: aggregatesSchema,
+	// Which raw file the Samples came from — provenance for debugging a Run.
+	"sourceFile?": "string",
+	// Test-profile provenance carried from the PTS `<Result>`: the profile's AppVersion and the exact
+	// option Arguments that produced these Samples. Pins each Metric to the version + argument matrix it
+	// was measured under, so a profile/option bump can't silently shift numbers across Runs.
+	"appVersion?": "string",
+	"arguments?": "string",
+}).narrow((metric, ctx) => {
+	// `aggregate()` already guarantees these at the producer; enforce them at the dataset boundary too,
+	// so a hand-edited/corrupt persisted Run can't carry NaN/Infinity samples or a sample count that
+	// disagrees with `aggregates.n`.
+	if (!metric.samples.every((s) => Number.isFinite(s))) {
+		return ctx.mustBe("a MetricResult whose samples are all finite");
+	}
+	if (metric.aggregates.n !== metric.samples.length) {
+		return ctx.mustBe("a MetricResult whose aggregates.n equals samples.length");
+	}
+	return true;
+});
+export type MetricResult = typeof metricResultSchema.infer;
+
+/**
+ * A parsed result whose id is not in the Metric Catalog — reported for visibility but inert: it
+ * never feeds rankings until someone adds a matching Catalog entry.
+ */
+export const uncataloguedResultSchema = type({
+	id: "string",
+	value: "number",
+	"unit?": "string",
+	"direction?": directionSchema,
+	sourceFile: "string",
+});
+export type UncataloguedResult = typeof uncataloguedResultSchema.infer;
+
+/**
+ * Observed actuals recorded per Run — what in-sandbox probes actually saw, versus the requested
+ * {@link TargetSpec}. All optional: providers differ in what in-sandbox
+ * probes can see. `vcpus`/`memoryGb` are the EFFECTIVE Sandbox size (cgroup quota where enforced);
+ * `hostVcpus`/`hostMemoryGb` disclose the underlying machine when probes see through the container
+ * boundary (e.g. Daytona: a 4-vCPU quota on a 48-thread host).
+ */
+export const observedSpecsSchema = type({
+	"vcpus?": "number",
+	"memoryGb?": "number",
+	"diskGb?": "number",
+	"hostVcpus?": "number",
+	"hostMemoryGb?": "number",
+	"cpuModel?": "string",
+	"cpuMhz?": "number",
+	"kernel?": "string",
+	"os?": "string",
+	"virtualization?": "string",
+	"user?": "string",
+});
+export type ObservedSpecs = typeof observedSpecsSchema.infer;
+
+/** The pinned size every provider is asked to match; compared against each provider's {@link ObservedSpecs}. */
+export const targetSpecSchema = type({
+	vcpus: "number > 0",
+	memoryGb: "number > 0",
+	"diskGb?": "number > 0",
+});
+export type TargetSpec = typeof targetSpecSchema.infer;
+
+/** A benchmark that was deliberately not run, and why. */
+export const skipMarkerSchema = type({
+	suite: "string",
+	reason: "string",
+});
+export type SkipMarker = typeof skipMarkerSchema.infer;
+
+/**
+ * One provider's slice of a Run: its catalogued Metrics, observed specs, skips and stragglers. The
+ * `.narrow` enforces the cross-field invariant documented on {@link validationStatusSchema}: a
+ * `validated` ProviderRun must carry at least one Metric, so `{ validationStatus: "validated",
+ * metrics: [] }` is rejected at the boundary rather than reaching a consumer that branches on it.
+ */
+export const providerRunSchema = type({
+	providerId: "string",
+	validationStatus: validationStatusSchema,
+	// Whether observed specs honored the pinned target spec; absent when probes saw too little to judge.
+	"specMatched?": "boolean",
+	observedSpecs: observedSpecsSchema,
+	metrics: metricResultSchema.array(),
+	skips: skipMarkerSchema.array(),
+	uncatalogued: uncataloguedResultSchema.array(),
+}).narrow(
+	(run, ctx) =>
+		run.validationStatus !== "validated" ||
+		run.metrics.length > 0 ||
+		ctx.mustBe('a ProviderRun with at least one metric when validationStatus is "validated"'),
+);
+export type ProviderRun = typeof providerRunSchema.infer;
+
+/** A full benchmark Run: every provider measured against one pinned target spec at one SHA. */
+export const runSchema = type({
+	schemaVersion: "'1'",
+	runId: "string",
+	sha: "string",
+	// ISO-8601 timestamp the Run was generated at — validated so the RunIndex sort key can't be a
+	// free-form string ("tomorrow") that silently breaks newest-first ordering.
+	generatedAt: "string.date.iso",
+	"sourceRunUrl?": "string",
+	targetSpec: targetSpecSchema,
+	providers: providerRunSchema.array(),
+});
+export type Run = typeof runSchema.infer;
+
+/**
+ * Index of committed Runs, newest first — the time series the trends view reads. The `.narrow`
+ * enforces the newest-first ordering the doc promises (ISO-8601 sorts lexicographically), so a
+ * consumer can trust `runs[0]` is the latest without re-sorting.
+ */
+export const runIndexSchema = type({
+	schemaVersion: "'1'",
+	runs: type({
+		runId: "string",
+		// ISO-8601 — the sort key for the newest-first time series, validated like runSchema's.
+		generatedAt: "string.date.iso",
+		// Path to the Run document, relative to the index file.
+		path: "string",
+	}).array(),
+}).narrow((index, ctx) => {
+	for (let i = 1; i < index.runs.length; i++) {
+		const prev = index.runs[i - 1];
+		const curr = index.runs[i];
+		if (prev && curr && prev.generatedAt < curr.generatedAt) {
+			return ctx.mustBe("a RunIndex whose runs are ordered newest-first by generatedAt");
+		}
+	}
+	return true;
+});
+export type RunIndex = typeof runIndexSchema.infer;
+
+/** Validate an unknown value as a {@link Run}. */
+export function parseRun(value: unknown): Run {
+	const out = runSchema(value);
+	if (out instanceof type.errors) {
+		throw new Error(`invalid Run: ${out.summary}`);
+	}
+	return out;
+}
+
+/** Validate an unknown value as a {@link RunIndex}. */
+export function parseRunIndex(value: unknown): RunIndex {
+	const out = runIndexSchema(value);
+	if (out instanceof type.errors) {
+		throw new Error(`invalid RunIndex: ${out.summary}`);
+	}
+	return out;
+}

--- a/typos.toml
+++ b/typos.toml
@@ -7,3 +7,6 @@
 extend-exclude = ["bun.lock"]
 
 [default.extend-words]
+# Domain term: a parsed result not (yet) in the Metric Catalog. International spelling, used as the
+# `uncatalogued` field name and `UncataloguedResult` type throughout the dataset model.
+uncatalogued = "uncatalogued"


### PR DESCRIPTION
Adds the canonical Run model (Run/ProviderRun/MetricResult/ObservedSpecs/RunIndex) as composable arktype schemas with parseRun/parseRunIndex validators, and the raw-file naming contract (PTS result files, skip markers in both legacy shapes, results-artifact names) shared by the producers and the results extractor.

Additive only: the placeholder RunDocument is removed in the results rewrite (PR 4) where its consumers move to the tree normalizer, avoiding throwaway repointing. Allowlists the intentional 'uncatalogued' spelling per typos.toml guidance.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds the canonical Run dataset model with `arktype` schemas and `parseRun`/`parseRunIndex` validators, exported from `packages/schema`. Standardizes Run validation across producers and consumers with tests for key invariants.

- **New Features**
  - Schemas: `Run`, `ProviderRun`, `MetricResult`, `SkipMarker`, `ObservedSpecs`, `TargetSpec`, `UncataloguedResult`, `RunIndex`. Includes provider `validationStatus` (`validated`/`pending`), optional `specMatched`, `uncatalogued`, `sourceRunUrl`, and metric provenance (`sourceFile`, optional `appVersion`/`arguments`).
  - Validation: `schemaVersion` = "1"; ISO-8601 `generatedAt`; positive `targetSpec`; metric `samples` non-empty and finite; `aggregates.n` is an integer equal to `samples.length`; `validated` providers must have ≥1 metric (empty only when `pending`); `RunIndex` must be newest-first. Also allowlists `uncatalogued` in `typos.toml`.

<sup>Written for commit 00aacbabe23dd88a64c609ba07d41384c4c5434c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/starslingdev/sandbox-benchmarks/pull/34?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

