### PR TITLE
feat(results): typed PTS composite.xml parser + extraction

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -70,7 +70,10 @@
       "name": "@sandbox-benchmarks/results",
       "version": "0.0.0",
       "dependencies": {
+        "@nodable/compact-builder": "catalog:xml",
+        "@nodable/flexible-xml-parser": "catalog:xml",
         "@sandbox-benchmarks/schema": "workspace:*",
+        "arktype": "catalog:",
       },
       "devDependencies": {
         "@repo/tsconfig": "workspace:*",
@@ -273,7 +276,13 @@
 
     "@js-sdsl/ordered-map": ["@js-sdsl/ordered-map@4.4.2", "", {}, "sha512-iUKgm52T8HOE/makSxjqoWhe95ZJA1/G1sYsGev2JDKUSS14KAgg1LHb+Ba+IPow0xflbnSkOsZcO08C7w1gYw=="],
 
+    "@nodable/base-output-builder": ["@nodable/base-output-builder@1.0.6", "", { "dependencies": { "@nodable/entities": "^2.1.1", "strnum": "^2.2.2" } }, "sha512-gDPvbt6GVhqA4lPZayqXYvO/510kVWGBXdvZF6jUtVcssziw6o27pwq6oI9CUwMk0Oq8BcucxYYxXM5wnHUB7A=="],
+
+    "@nodable/compact-builder": ["@nodable/compact-builder@1.0.9", "", { "dependencies": { "@nodable/base-output-builder": "^1.0.6", "path-expression-matcher": "^1.5.0" } }, "sha512-90tD+khseKL+Wxf1gMiL3JsZrdevKI0g5oHbb8zqJzLsxMpwoSZu/EZDHl9I8+gmDSz7hzK1hcopC+4GnMZiKg=="],
+
     "@nodable/entities": ["@nodable/entities@2.1.1", "", {}, "sha512-Pig3HxDIoMgjdEH8OCf/dkcTmLFjJRjWuq8jSnklu284/TKOPibSRERmOykiwmyXTtv61mP+44f3GMx0tLAyjg=="],
+
+    "@nodable/flexible-xml-parser": ["@nodable/flexible-xml-parser@1.2.2", "", { "dependencies": { "@nodable/base-output-builder": "^1.0.6", "@nodable/compact-builder": "^1.0.9", "path-expression-matcher": "^1.5.0", "xml-naming": "^0.1.0" } }, "sha512-7nYGnBCN7dnF2cL1tCnA2w2HBYhHsUzCEpnJ5r4ZzKCQjB4QQcesrmgB7jibJApDe5J53fC372TVIROiAXp/tQ=="],
 
     "@nodelib/fs.scandir": ["@nodelib/fs.scandir@2.1.5", "", { "dependencies": { "@nodelib/fs.stat": "2.0.5", "run-parallel": "^1.1.9" } }, "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g=="],
 

--- a/packages/results/package.json
+++ b/packages/results/package.json
@@ -11,7 +11,10 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "@sandbox-benchmarks/schema": "workspace:*"
+    "@nodable/compact-builder": "catalog:xml",
+    "@nodable/flexible-xml-parser": "catalog:xml",
+    "@sandbox-benchmarks/schema": "workspace:*",
+    "arktype": "catalog:"
   },
   "devDependencies": {
     "@repo/tsconfig": "workspace:*",

--- a/packages/results/src/index.ts
+++ b/packages/results/src/index.ts
@@ -1,7 +1,14 @@
 // Public surface of @sandbox-benchmarks/results.
-// Normalizes raw runs into run documents using ONLY @sandbox-benchmarks/schema — never a provider SDK.
+// Normalizes raw PTS output into the schema's Run model using ONLY @sandbox-benchmarks/schema and the
+// XML parser — never a provider SDK (enforced by the package boundary).
 import type { RawRun, RunDocument } from "@sandbox-benchmarks/schema";
 import { isoNow } from "./lib/internal.ts";
+
+// Per-provider raw-directory extraction (samples, stragglers, skips).
+export * from "./lib/extract.ts";
+export * from "./lib/pts.ts";
+// Typed PTS composite.xml parsing and Catalog mapping.
+export * from "./lib/pts-schema.ts";
 
 /** Normalize a single raw run into a {@link RunDocument}. Stub logic. */
 export function normalize(raw: RawRun): RunDocument {

--- a/packages/results/src/lib/__fixtures__/daytona/pts_git--skipped.json
+++ b/packages/results/src/lib/__fixtures__/daytona/pts_git--skipped.json
@@ -1,0 +1,6 @@
+{
+  "schema_version": "1.0",
+  "benchmark": "pts_git",
+  "skipped": true,
+  "skip_reason": "phoronix-test-suite not installed"
+}

--- a/packages/results/src/lib/__fixtures__/daytona/pts_node-web-tooling.xml
+++ b/packages/results/src/lib/__fixtures__/daytona/pts_node-web-tooling.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0"?>
+<PhoronixTestSuite>
+  <Generated>
+    <Title>sandbox-bench</Title>
+    <LastModified>2026-06-09 21:14:02</LastModified>
+    <TestClient>phoronix-test-suite/10.8.4</TestClient>
+  </Generated>
+  <Result>
+    <Identifier>pts/node-web-tooling-1.0.1</Identifier>
+    <Title>Node.js V8 Web Tooling Benchmark</Title>
+    <AppVersion></AppVersion>
+    <Arguments></Arguments>
+    <Description></Description>
+    <Scale>runs/s</Scale>
+    <Proportion>HIB</Proportion>
+    <DisplayFormat>BAR_GRAPH</DisplayFormat>
+    <Data>
+      <Entry>
+        <Identifier>sandbox</Identifier>
+        <Value>16.19</Value>
+        <RawString>16.19:16.3:16.08</RawString>
+        <JSON></JSON>
+      </Entry>
+    </Data>
+  </Result>
+</PhoronixTestSuite>

--- a/packages/results/src/lib/__fixtures__/provenance/pts_node-web-tooling.xml
+++ b/packages/results/src/lib/__fixtures__/provenance/pts_node-web-tooling.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0"?>
+<PhoronixTestSuite>
+  <Generated>
+    <Title>sandbox-bench</Title>
+    <LastModified>2026-06-09 21:14:02</LastModified>
+    <TestClient>phoronix-test-suite/10.8.4</TestClient>
+  </Generated>
+  <Result>
+    <Identifier>pts/node-web-tooling-1.0.1</Identifier>
+    <Title>Node.js V8 Web Tooling Benchmark</Title>
+    <AppVersion>1.0.1</AppVersion>
+    <Arguments>Run: default</Arguments>
+    <Description></Description>
+    <Scale>runs/s</Scale>
+    <Proportion>HIB</Proportion>
+    <DisplayFormat>BAR_GRAPH</DisplayFormat>
+    <Data>
+      <Entry>
+        <Identifier>sandbox</Identifier>
+        <Value>16.19</Value>
+        <RawString>16.19:16.3:16.08</RawString>
+        <JSON></JSON>
+      </Entry>
+    </Data>
+  </Result>
+</PhoronixTestSuite>

--- a/packages/results/src/lib/extract.test.ts
+++ b/packages/results/src/lib/extract.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from "bun:test";
+import { join } from "node:path";
+import { extractProviderDir } from "./extract.ts";
+
+const daytonaDir = join(import.meta.dir, "__fixtures__/daytona");
+
+describe("extractProviderDir", () => {
+	const extraction = extractProviderDir(daytonaDir, "daytona");
+
+	it("contributes the catalogued node-web-tooling samples with provenance", () => {
+		expect(extraction.contributions).toEqual([
+			{
+				metricId: "node_web_tooling_runs_per_s",
+				samples: [16.19, 16.3, 16.08],
+				sourceFile: "pts_node-web-tooling.xml",
+			},
+		]);
+	});
+
+	it("reads the bench.sh skip marker", () => {
+		expect(extraction.skips).toEqual([
+			{ suite: "pts_git", reason: "phoronix-test-suite not installed" },
+		]);
+	});
+
+	it("finds no uncatalogued stragglers in this directory", () => {
+		expect(extraction.uncatalogued).toEqual([]);
+	});
+
+	it("carries appVersion and arguments provenance when the <Result> populates them", () => {
+		const dir = join(import.meta.dir, "__fixtures__/provenance");
+		expect(extractProviderDir(dir, "daytona").contributions).toEqual([
+			{
+				metricId: "node_web_tooling_runs_per_s",
+				samples: [16.19, 16.3, 16.08],
+				sourceFile: "pts_node-web-tooling.xml",
+				appVersion: "1.0.1",
+				arguments: "Run: default",
+			},
+		]);
+	});
+});

--- a/packages/results/src/lib/extract.ts
+++ b/packages/results/src/lib/extract.ts
@@ -1,0 +1,105 @@
+/**
+ * Walk one provider's raw result directory (`data/raw/<runId>/<provider>/`) and pull out catalogued
+ * Metric samples, uncatalogued stragglers, and skip markers. SDK-free: the filesystem and the schema
+ * contract only — never a provider SDK (enforced by the package boundary).
+ */
+import { readdirSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+import type { SkipMarker, UncataloguedResult } from "@sandbox-benchmarks/schema";
+import { isPtsResultFile, isSkipMarkerFile, parseSkipMarker } from "@sandbox-benchmarks/schema";
+import { parsePtsComposite, ptsResultToMetric } from "./pts.ts";
+
+/** One Metric's samples sourced from a single raw file — the provenance the normalizer preserves. */
+export interface SampleContribution {
+	metricId: string;
+	samples: number[];
+	sourceFile: string;
+	/** PTS profile AppVersion, when the `<Result>` reported a non-empty one. */
+	appVersion?: string;
+	/** The exact PTS option Arguments that produced these Samples, when non-empty. */
+	arguments?: string;
+}
+
+/** Everything one provider directory yields: catalogued samples, stragglers, and skips. */
+export interface ProviderExtraction {
+	contributions: SampleContribution[];
+	uncatalogued: UncataloguedResult[];
+	skips: SkipMarker[];
+}
+
+/** Parse JSON, returning undefined rather than throwing on a malformed skip marker. */
+function readJson(text: string): unknown {
+	try {
+		return JSON.parse(text);
+	} catch {
+		return undefined;
+	}
+}
+
+/** Extract every catalogued/uncatalogued result and skip marker from one provider's raw directory. */
+export function extractProviderDir(dir: string, providerId: string): ProviderExtraction {
+	const out: ProviderExtraction = { contributions: [], uncatalogued: [], skips: [] };
+
+	// `withFileTypes` so a subdirectory can't be fed to readFileSync (EISDIR); sort for determinism.
+	const entries = readdirSync(dir, { withFileTypes: true }).sort((a, b) =>
+		a.name.localeCompare(b.name),
+	);
+	for (const entry of entries) {
+		if (!entry.isFile()) continue;
+		const filename = entry.name;
+		const fullPath = join(dir, filename);
+
+		if (isPtsResultFile(filename)) {
+			const composite = parsePtsComposite(readFileSync(fullPath, "utf8"));
+			for (const result of composite.PhoronixTestSuite.Result) {
+				// A <Result> with no <Entry> carries no measurement — no sample to aggregate and no
+				// headline value to report. Skip it rather than emit a zero-sample contribution (which
+				// would throw in the normalizer's aggregate([])) or fabricate a 0-valued straggler.
+				const headEntry = result.Data.Entry[0];
+				if (!headEntry) continue;
+				const mapped = ptsResultToMetric(result);
+				switch (mapped.kind) {
+					case "matched":
+						// Carry the profile version + option arguments as provenance, but only when PTS actually
+						// populated them — node-web-tooling, e.g., emits empty <AppVersion>/<Arguments>.
+						out.contributions.push({
+							metricId: mapped.def.id,
+							samples: mapped.samples,
+							sourceFile: filename,
+							...(result.AppVersion ? { appVersion: result.AppVersion } : {}),
+							...(result.Arguments ? { arguments: result.Arguments } : {}),
+						});
+						break;
+					case "uncatalogued":
+						out.uncatalogued.push({
+							id: `${mapped.test}::${mapped.description || "default"}`,
+							// Entry[0].Value is a guaranteed number — the schema parses it and we skipped the
+							// entry-less results above.
+							value: headEntry.Value,
+							unit: result.Scale,
+							direction: result.Proportion,
+							sourceFile: filename,
+						});
+						break;
+					default: {
+						// Exhaustiveness guard: a new PtsMapping arm without a case here is a compile error.
+						const _exhaustive: never = mapped;
+						throw new Error(`unhandled PTS mapping: ${JSON.stringify(_exhaustive)}`);
+					}
+				}
+			}
+			continue;
+		}
+
+		if (isSkipMarkerFile(filename)) {
+			const marker = parseSkipMarker(
+				filename,
+				readJson(readFileSync(fullPath, "utf8")),
+				providerId,
+			);
+			if (marker) out.skips.push(marker);
+		}
+	}
+
+	return out;
+}

--- a/packages/results/src/lib/pts-schema.ts
+++ b/packages/results/src/lib/pts-schema.ts
@@ -1,0 +1,73 @@
+/**
+ * The typed schema for a PTS `composite.xml`. The XML parser (./pts.ts) is kept "dumb" — it emits
+ * raw, entity-decoded string text and natively forces the repeatable `<Result>`/`<Entry>` nodes to
+ * arrays (its `alwaysArray` option) — so this schema is the single source of truth for coercion: it
+ * parses `<Value>` to a number, and its elements validate directly without any array-shape morph.
+ */
+import { directionSchema } from "@sandbox-benchmarks/schema";
+import { type } from "arktype";
+
+/**
+ * The colon-joined per-pass samples (`<RawString>`, e.g. "16.19:16.3:16.08") parsed to a validated
+ * `number[]` AT THE SCHEMA EDGE. Parsing here (not in ./pts.ts) is the load-bearing choice: a
+ * genuinely malformed token makes `parsePtsComposite` throw rather than silently disappearing from a
+ * hand-rolled `.filter()` downstream — so "samples contain a non-number" is unrepresentable past this
+ * boundary. Empty/trailing tokens are tolerated explicitly (an absent RawString splits to `[""]`);
+ * zero is kept (a benchmark can legitimately measure 0), only non-finite and negative are rejected.
+ */
+const sampleList = type("string").pipe((raw, ctx) => {
+	const out: number[] = [];
+	for (const token of raw.split(":")) {
+		if (token.trim() === "") continue;
+		const n = Number(token);
+		if (!Number.isFinite(n) || n < 0) {
+			return ctx.error(`a colon-joined list of non-negative numbers (got "${token}")`);
+		}
+		out.push(n);
+	}
+	return out;
+});
+
+/** One `<Entry>`: a single measured value plus the per-pass samples that produced it. */
+const ptsEntry = type({
+	"Identifier?": "string",
+	// PTS writes the value as text; the schema is where it becomes a number (the parser stays dumb).
+	Value: "string.numeric.parse",
+	// Per-pass samples, parsed string → validated number[] here (see {@link sampleList}).
+	"RawString?": sampleList,
+});
+
+/** One `<Result>`: a single test profile's measurement (each Result maps to exactly one Metric). */
+const ptsResult = type({
+	Identifier: "string",
+	Title: "string",
+	"AppVersion?": "string",
+	"Arguments?": "string",
+	// Sub-result label; disambiguates multi-result tests when mapping onto the Catalog.
+	"Description?": "string",
+	Scale: "string",
+	Proportion: directionSchema,
+	Data: { Entry: ptsEntry.array() },
+});
+
+/** Provenance from the `<Generated>` header — which PTS client wrote the file, and when. */
+const ptsGenerated = type({
+	"Title?": "string",
+	"LastModified?": "string",
+	"TestClient?": "string",
+});
+
+/** A full `composite.xml`: the generator header and one-or-more test results. */
+export const ptsCompositeSchema = type({
+	PhoronixTestSuite: {
+		"Generated?": ptsGenerated,
+		Result: ptsResult.array(),
+	},
+});
+
+/** A validated PTS composite document (post-coercion: numeric values, arrays of results/entries). */
+export type PtsComposite = typeof ptsCompositeSchema.infer;
+/** A single typed `<Result>` from a parsed composite. */
+export type PtsResult = typeof ptsResult.infer;
+/** A single typed `<Entry>` from a parsed result. */
+export type PtsEntry = typeof ptsEntry.infer;

--- a/packages/results/src/lib/pts.test.ts
+++ b/packages/results/src/lib/pts.test.ts
@@ -1,0 +1,124 @@
+import { describe, expect, it } from "bun:test";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { parsePtsComposite, ptsResultToMetric, resultSamples, versionlessTest } from "./pts.ts";
+
+const realFixture = readFileSync(
+	join(import.meta.dir, "__fixtures__/daytona/pts_node-web-tooling.xml"),
+	"utf8",
+);
+
+// A two-result composite (as a batch run produces): proves Result stays an array, and exercises an
+// uncatalogued result (pts/git is not in this slice's Catalog) alongside the catalogued one.
+const multiResultXml = `<?xml version="1.0"?>
+<PhoronixTestSuite>
+  <Generated><TestClient>phoronix-test-suite/10.8.4</TestClient></Generated>
+  <Result>
+    <Identifier>pts/node-web-tooling-1.0.1</Identifier>
+    <Title>Node.js V8 Web Tooling Benchmark</Title>
+    <Scale>runs/s</Scale>
+    <Proportion>HIB</Proportion>
+    <Data><Entry><Value>20.5</Value><RawString>20.5</RawString></Entry></Data>
+  </Result>
+  <Result>
+    <Identifier>pts/git-1.1.0</Identifier>
+    <Title>Git</Title>
+    <Scale>Seconds</Scale>
+    <Proportion>LIB</Proportion>
+    <Data><Entry><Value>4.2</Value></Entry></Data>
+  </Result>
+</PhoronixTestSuite>`;
+
+describe("parsePtsComposite", () => {
+	it("parses the real single-result fixture, forcing object nodes to arrays", () => {
+		const composite = parsePtsComposite(realFixture);
+		const results = composite.PhoronixTestSuite.Result;
+		expect(Array.isArray(results)).toBe(true);
+		expect(results).toHaveLength(1);
+		const entries = results[0]?.Data.Entry;
+		expect(Array.isArray(entries)).toBe(true);
+	});
+
+	it("coerces <Value> text to a number via the schema (parser stays dumb)", () => {
+		const value = parsePtsComposite(realFixture).PhoronixTestSuite.Result[0]?.Data.Entry[0]?.Value;
+		expect(value).toBe(16.19);
+		expect(typeof value).toBe("number");
+	});
+
+	it("keeps multiple results as an array", () => {
+		expect(parsePtsComposite(multiResultXml).PhoronixTestSuite.Result).toHaveLength(2);
+	});
+
+	it("throws an arktype summary on malformed XML", () => {
+		expect(() => parsePtsComposite("<PhoronixTestSuite></PhoronixTestSuite>")).toThrow(
+			/invalid PTS composite\.xml/,
+		);
+	});
+
+	it("rejects a malformed RawString sample token at the schema boundary", () => {
+		// A non-numeric per-pass token fails the schema's sampleList morph, so the whole composite is
+		// rejected loudly here rather than the bad token silently vanishing during aggregation.
+		const xml = `<?xml version="1.0"?>
+<PhoronixTestSuite><Result>
+  <Identifier>pts/x-1.0</Identifier><Title>X</Title><Scale>runs/s</Scale><Proportion>HIB</Proportion>
+  <Data><Entry><Value>1</Value><RawString>1:notanumber:3</RawString></Entry></Data>
+</Result></PhoronixTestSuite>`;
+		expect(() => parsePtsComposite(xml)).toThrow(/invalid PTS composite\.xml/);
+	});
+});
+
+describe("resultSamples", () => {
+	it("splits the colon-joined RawString into the per-pass samples", () => {
+		const result = parsePtsComposite(realFixture).PhoronixTestSuite.Result[0];
+		expect(result && resultSamples(result)).toEqual([16.19, 16.3, 16.08]);
+	});
+
+	it("falls back to the single Value when RawString is absent", () => {
+		const git = parsePtsComposite(multiResultXml).PhoronixTestSuite.Result[1];
+		expect(git && resultSamples(git)).toEqual([4.2]);
+	});
+
+	it("retains legitimate zero-valued samples (filters non-finite/negative, not zero)", () => {
+		const xml = `<?xml version="1.0"?>
+<PhoronixTestSuite><Result>
+  <Identifier>pts/x-1.0</Identifier><Title>X</Title><Scale>errors</Scale><Proportion>LIB</Proportion>
+  <Data><Entry><Value>0</Value><RawString>0:5:0</RawString></Entry></Data>
+</Result></PhoronixTestSuite>`;
+		const result = parsePtsComposite(xml).PhoronixTestSuite.Result[0];
+		expect(result && resultSamples(result)).toEqual([0, 5, 0]);
+	});
+
+	it("returns no samples for an entry-less result (nothing to aggregate)", () => {
+		// The schema permits Data.Entry: [] (`.array()`); resultSamples reports it honestly as []
+		// rather than fabricating a value, so the extractor can skip the measurement-less result.
+		const entryless = { Data: { Entry: [] } } as unknown as Parameters<typeof resultSamples>[0];
+		expect(resultSamples(entryless)).toEqual([]);
+	});
+});
+
+describe("ptsResultToMetric", () => {
+	it("maps node-web-tooling onto its catalogued Metric", () => {
+		const result = parsePtsComposite(realFixture).PhoronixTestSuite.Result[0];
+		const mapped = result && ptsResultToMetric(result);
+		expect(mapped?.kind).toBe("matched");
+		if (mapped?.kind !== "matched") throw new Error("expected a matched mapping");
+		expect(mapped.def.id).toBe("node_web_tooling_runs_per_s");
+		expect(mapped.samples).toEqual([16.19, 16.3, 16.08]);
+	});
+
+	it("returns an uncatalogued mapping for a result with no catalogued Metric", () => {
+		const git = parsePtsComposite(multiResultXml).PhoronixTestSuite.Result[1];
+		expect(git && ptsResultToMetric(git)).toEqual({
+			kind: "uncatalogued",
+			test: "pts/git",
+			description: "",
+		});
+	});
+});
+
+describe("versionlessTest", () => {
+	it("strips the trailing version", () => {
+		expect(versionlessTest("pts/node-web-tooling-1.0.1")).toBe("pts/node-web-tooling");
+		expect(versionlessTest("pts/git-1.1.0")).toBe("pts/git");
+	});
+});

--- a/packages/results/src/lib/pts.ts
+++ b/packages/results/src/lib/pts.ts
@@ -1,0 +1,82 @@
+/**
+ * Parse a PTS `composite.xml` into the typed {@link PtsComposite}, and map its results onto the
+ * Metric Catalog. The parser is configured to emit raw, entity-decoded string text so the schema's
+ * morphs (./pts-schema.ts) do every coercion deterministically — no heuristic number/boolean parsing
+ * that could turn a version-like identifier into a number.
+ */
+import { CompactBuilderFactory } from "@nodable/compact-builder";
+import XMLParser, { type X2jOptions } from "@nodable/flexible-xml-parser";
+import type { MetricDef } from "@sandbox-benchmarks/schema";
+import { METRIC_CATALOG } from "@sandbox-benchmarks/schema";
+import { type } from "arktype";
+import type { PtsComposite, PtsResult } from "./pts-schema.ts";
+import { ptsCompositeSchema } from "./pts-schema.ts";
+
+// Entity-decode text but DON'T coerce numbers/booleans — the schema owns coercion (parse-don't-validate)
+// — and force the repeatable <Result>/<Entry> nodes to arrays so a single-test run doesn't collapse
+// them to objects (the schema then validates a clean array, no morph needed).
+// CompactBuilderFactory extends BaseOutputBuilderFactory at runtime, but compact-builder@1.0.9's types
+// declare `implements OutputBuilderFactory` and omit `resetValueParsers` — a types-only skew with the
+// parser's expected builder interface. The cast bridges it through the parser's own option type.
+const outputBuilder = new CompactBuilderFactory({
+	tags: { valueParsers: ["entity"] },
+	alwaysArray: ["..Result", "..Entry"],
+}) as unknown as X2jOptions["OutputBuilder"];
+const parser = new XMLParser({ OutputBuilder: outputBuilder });
+
+/** Parse and validate a PTS composite.xml. Throws with an arktype summary on malformed input. */
+export function parsePtsComposite(xml: string): PtsComposite {
+	const out = ptsCompositeSchema(parser.parse(xml));
+	if (out instanceof type.errors) {
+		throw new Error(`invalid PTS composite.xml: ${out.summary}`);
+	}
+	return out;
+}
+
+/** Strip a trailing version from a PTS identifier: "pts/node-web-tooling-1.0.1" → "pts/node-web-tooling". */
+export function versionlessTest(identifier: string): string {
+	return identifier.replace(/-\d+(\.\d+)*$/, "");
+}
+
+/**
+ * The per-pass samples behind a Result's headline value, falling back to the single reported value
+ * when PTS emitted no per-pass samples. `RawString` is already a validated `number[]` (parsed at the
+ * schema edge, pts-schema.ts) — a malformed token threw in `parsePtsComposite`, so nothing is
+ * silently dropped here. One `<Entry>` per run (the harness writes one), so this reads the first.
+ */
+export function resultSamples(result: PtsResult): number[] {
+	const entry = result.Data.Entry[0];
+	if (!entry) return [];
+	return entry.RawString && entry.RawString.length > 0 ? entry.RawString : [entry.Value];
+}
+
+/**
+ * The outcome of mapping a `<Result>` onto the Catalog: either a catalogued Metric (with its samples)
+ * or an explicit `uncatalogued` straggler. A discriminated union — not `… | null` — so every caller
+ * must handle both arms (an exhaustive `switch` makes a forgotten case a compile error) instead of
+ * silently dropping a `null`.
+ */
+export type PtsMapping =
+	| { kind: "matched"; def: MetricDef; samples: number[] }
+	| { kind: "uncatalogued"; test: string; description: string };
+
+/**
+ * Map a parsed Result onto the Metric Catalog by its versionless test (and `<Description>` for
+ * multi-result tests).
+ */
+export function ptsResultToMetric(result: PtsResult): PtsMapping {
+	const test = versionlessTest(result.Identifier);
+	const description = result.Description ?? "";
+	const forTest = METRIC_CATALOG.filter((metric) => metric.pts?.test === test);
+	// Prefer an exact `<Description>` match over the wildcard (description-less) entry, so a
+	// multi-result test's catalog ordering can't make the wildcard greedily shadow a specific metric.
+	// The catalog invariant (`catalogSchema` .narrow, catalog.ts) guarantees a wildcard never coexists
+	// with description-bearing entries for the same test, so the fallback can't misattribute a
+	// non-matching `<Description>`: if a wildcard matched, it is that test's only entry.
+	const def =
+		forTest.find((metric) => metric.pts?.description === description) ??
+		forTest.find((metric) => metric.pts?.description === undefined);
+	return def
+		? { kind: "matched", def, samples: resultSamples(result) }
+		: { kind: "uncatalogued", test, description };
+}

--- a/packages/schema/src/catalog.test.ts
+++ b/packages/schema/src/catalog.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "bun:test";
+import { catalogSchema } from "./catalog.ts";
 import {
 	DIMENSIONS,
 	getMetric,
@@ -41,5 +42,55 @@ describe("metric catalog", () => {
 
 	it("throws when a dimension has no headline metric", () => {
 		expect(() => headlineMetric("economics")).toThrow();
+	});
+});
+
+describe("catalogSchema PTS-mapping invariant", () => {
+	// A valid non-PTS scaffold; each case overrides only id + pts to exercise the .narrow.
+	const base = {
+		dimension: "cpu",
+		unit: "runs/s",
+		direction: "HIB",
+		headline: false,
+		label: "x",
+		description: "x",
+	} as const;
+
+	it("accepts a wildcard and a described entry for DIFFERENT tests", () => {
+		expect(() =>
+			catalogSchema.assert([
+				{ ...base, id: "a", pts: { test: "pts/a" } },
+				{ ...base, id: "b", pts: { test: "pts/b", description: "Foo" } },
+			]),
+		).not.toThrow();
+	});
+
+	it("accepts multiple described entries for the same test (the multi-result matrix)", () => {
+		expect(() =>
+			catalogSchema.assert([
+				{ ...base, id: "a", pts: { test: "pts/a", description: "Compression" } },
+				{ ...base, id: "b", pts: { test: "pts/a", description: "Decompression" } },
+			]),
+		).not.toThrow();
+	});
+
+	it("rejects two description-less wildcards for the same test", () => {
+		expect(() =>
+			catalogSchema.assert([
+				{ ...base, id: "a", pts: { test: "pts/a" } },
+				{ ...base, id: "b", pts: { test: "pts/a" } },
+			]),
+		).toThrow();
+	});
+
+	it("rejects a wildcard coexisting with a described entry for the same test", () => {
+		// This is the exact shape that would let ptsResultToMetric misattribute a non-matching
+		// <Description> to the wildcard — forbidden at load so the runtime fallback is safe.
+		expect(() =>
+			catalogSchema.assert([
+				{ ...base, id: "a", pts: { test: "pts/a" } },
+				{ ...base, id: "b", pts: { test: "pts/a", description: "Foo" } },
+			]),
+		).toThrow();
 	});
 });

--- a/packages/schema/src/catalog.ts
+++ b/packages/schema/src/catalog.ts
@@ -29,11 +29,48 @@ const ptsCpu: MetricDef[] = [
 ];
 
 /**
- * The full Catalog, validated at load. Dimensions land in display order as their Metrics are ported;
- * the runtime `.assert` turns a malformed entry (bad dimension/direction, missing field) into a
- * fail-fast at import rather than a silently broken stability contract.
+ * The Catalog schema: every entry's shape PLUS the PTS-mapping invariant the runtime relies on. The
+ * `.narrow` makes the dangerous catalog shape UNCONSTRUCTABLE so `ptsResultToMetric`'s wildcard
+ * fallback (pts.ts) is safe by construction rather than by reviewer vigilance — for any one PTS test:
+ *   1. at most one description-less wildcard entry, and
+ *   2. a wildcard never coexists with description-bearing entries.
+ * Either would let a result's `<Description>` that matches no specific entry fall to the wildcard and
+ * be misattributed; forbidding the shape at load (deterministic, CI-caught) removes that path.
+ * Exported so the invariant is unit-testable against crafted catalogs, independent of the singleton.
  */
-export const METRIC_CATALOG: readonly MetricDef[] = metricDefSchema.array().assert([...ptsCpu]);
+export const catalogSchema = metricDefSchema.array().narrow((cat, ctx) => {
+	const wildcardTests = new Set<string>();
+	const describedTests = new Set<string>();
+	for (const metric of cat) {
+		if (!metric.pts) continue;
+		if (metric.pts.description === undefined) {
+			if (wildcardTests.has(metric.pts.test)) {
+				return ctx.mustBe(
+					`at most one description-less wildcard per PTS test ("${metric.pts.test}")`,
+				);
+			}
+			wildcardTests.add(metric.pts.test);
+		} else {
+			describedTests.add(metric.pts.test);
+		}
+	}
+	for (const test of wildcardTests) {
+		if (describedTests.has(test)) {
+			return ctx.mustBe(
+				`no description-bearing entries alongside the description-less wildcard for "${test}"`,
+			);
+		}
+	}
+	return true;
+});
+
+/**
+ * The full Catalog, validated at load. Dimensions land in display order as their Metrics are ported;
+ * the runtime `.assert` turns a malformed entry (bad dimension/direction, missing field) — or a
+ * violated PTS-mapping invariant ({@link catalogSchema}) — into a fail-fast at import rather than a
+ * silently broken stability contract.
+ */
+export const METRIC_CATALOG: readonly MetricDef[] = catalogSchema.assert([...ptsCpu]);
 
 const byId = new Map(METRIC_CATALOG.map((metric) => [metric.id, metric]));
 


### PR DESCRIPTION
Replaces the prototype's regex parser with a real XML parser (@nodable/flexible-xml-parser) feeding a fully-typed arktype PtsCompositeSchema. The parser stays dumb (entity-decoded strings only); the schema owns all coercion — Value via string.numeric.parse, and a morph that forces single <Result>/<Entry> nodes to arrays. parsePtsComposite + ptsResultToMetric map onto the Metric Catalog; extractProviderDir walks a provider's raw dir into samples, stragglers and skips.

Validated against the real Daytona node-web-tooling fixture and a synthetic multi-result composite. SDK-free (schema + XML parser only), enforced by repo-checks.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaced the regex PTS parser with a typed XML parser and added provider-dir extraction to collect catalogued samples, uncatalogued results, and skip markers. Parsing and catalog mapping are hardened so malformed samples fail fast and wildcard misattribution is impossible.

- **New Features**
  - Typed PTS parsing via `@nodable/flexible-xml-parser` + `@nodable/compact-builder` with `ptsCompositeSchema` (`arktype`): forces `Result`/`Entry` arrays, parses `<Value>` to number, and validates `<RawString>` into `number[]`; exports `parsePtsComposite`, `ptsResultToMetric`, and `extractProviderDir`.
  - Safer catalog mapping: `ptsResultToMetric` returns a discriminated union; `catalogSchema` enforces one wildcard per test and forbids wildcard + described mixes; `extractProviderDir` conditionally attaches `appVersion`/`arguments` and surfaces uncatalogued stragglers.

- **Bug Fixes**
  - Skip `<Result>` with no `<Entry>` to avoid zero-sample contributions.
  - Keep zero-valued samples; reject empty, non-finite, or negative `RawString` tokens at the schema boundary.

<sup>Written for commit d5b104304fcccfcf1366259549a9684ed370c76d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/starslingdev/sandbox-benchmarks/pull/35?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

