### PR TITLE
feat(results): raw-tree normalization, Run writer, wired CLI

### DIFF
--- a/apps/cli/src/bin/normalize.ts
+++ b/apps/cli/src/bin/normalize.ts
@@ -1,10 +1,21 @@
 #!/usr/bin/env bun
-// `normalize` — read raw runs and emit normalized run documents (stub).
+// `normalize` — read a raw results tree (`data/raw/<runId>/<provider>/`) and emit a validated Run
+// document, optionally appending it to a Run index.
 
-import { normalize } from "@sandbox-benchmarks/results";
-import { parseRawRun } from "@sandbox-benchmarks/schema";
+import { summarizeRun, writeNormalizedRun } from "@sandbox-benchmarks/results";
 
 if (import.meta.main) {
-	const raw = parseRawRun({ provider: "e2b", operation: "spawn", durationMs: 1280 });
-	console.log(JSON.stringify(normalize(raw)));
+	const [rawRoot, runId, sha, outFile, indexFile] = process.argv.slice(2);
+	if (!rawRoot || !runId || !sha || !outFile) {
+		console.error("usage: normalize <rawRoot> <runId> <sha> <outFile> [indexFile]");
+		process.exit(1);
+	}
+	const run = writeNormalizedRun({
+		rawRoot,
+		runId,
+		sha,
+		outFile,
+		...(indexFile ? { updateIndexFile: indexFile } : {}),
+	});
+	for (const line of summarizeRun(run)) console.log(line);
 }

--- a/apps/cli/src/bin/promote.ts
+++ b/apps/cli/src/bin/promote.ts
@@ -1,10 +1,26 @@
 #!/usr/bin/env bun
-// `promote` — promote normalized results to the published dataset (stub).
+// `promote` — validate a normalized Run document and stage it for the published dataset. Publishing
+// to the public dataset lands with the dataset/web slice; for now this is the validation gate.
 
-import { normalize } from "@sandbox-benchmarks/results";
-import type { RunDocument } from "@sandbox-benchmarks/schema";
+import { readFileSync } from "node:fs";
+import { summarizeRun } from "@sandbox-benchmarks/results";
+import { parseRun } from "@sandbox-benchmarks/schema";
 
 if (import.meta.main) {
-	const doc: RunDocument = normalize({ provider: "modal", operation: "exec", durationMs: 64 });
-	console.log(JSON.stringify({ promoted: [doc] }));
+	const [runFile] = process.argv.slice(2);
+	if (!runFile) {
+		console.error("usage: promote <run.json>");
+		process.exit(1);
+	}
+	const run = parseRun(JSON.parse(readFileSync(runFile, "utf8")));
+	const validated = run.providers.filter((p) => p.validationStatus === "validated").length;
+	for (const line of summarizeRun(run)) console.log(line);
+	console.log(JSON.stringify({ promoted: run.runId, validatedProviders: validated }));
+
+	// Gate on the exit code: a Run with nothing validated (e.g. a partial collection with no PTS XML)
+	// must fail so a CI promote step can't silently publish an empty run.
+	if (validated === 0) {
+		console.error("promote: refusing to promote a Run with zero validated providers");
+		process.exit(1);
+	}
 }

--- a/packages/results/README.md
+++ b/packages/results/README.md
@@ -1,12 +1,16 @@
 # @sandbox-benchmarks/results
 
-**Role:** normalize raw benchmark runs into stable run documents for reporting/promotion.
+**Role:** normalize a raw benchmark results tree (`data/raw/<runId>/<provider>/`) into validated `Run`
+documents for reporting/promotion.
 
-**Public surface (`.`):** `normalize()`.
+**Public surface (`.`):** `normalizeResultsTree()`, `writeNormalizedRun()`, `updateRunIndex()`,
+`summarizeRun()` (+ their input types). The PTS XML parser, per-file extraction, and observed-spec
+reading are package-internal under `src/lib/`.
 
-**Depends on:** `@sandbox-benchmarks/schema` **only**. By design this package must normalize results
-*without* any provider SDK — the boundary test enforces that it never reaches into
-`@sandbox-benchmarks/providers` or a vendor SDK.
+**Depends on:** `@sandbox-benchmarks/schema` and an XML parser (`@nodable/*`) **only**. By design this
+package must normalize results *without* any provider SDK — the boundary test enforces that it never
+reaches into `@sandbox-benchmarks/providers` or a vendor SDK.
 
-**What lives here:** normalization logic. Timestamp/formatting internals live in `src/lib/` and are
-never imported across a package boundary.
+**What lives here:** the typed `composite.xml` parser, the raw-directory extractor, sample
+aggregation into the `Run` model, and the Run writer/index. Implementation modules live in `src/lib/`
+and are never imported across a package boundary — import from `@sandbox-benchmarks/results` instead.

--- a/packages/results/src/index.test.ts
+++ b/packages/results/src/index.test.ts
@@ -1,14 +1,54 @@
 import { describe, expect, it } from "bun:test";
-import type { RawRun } from "@sandbox-benchmarks/schema";
-import { normalize } from "./index.ts";
+import { join } from "node:path";
+import { normalizeResultsTree, summarizeRun } from "./index.ts";
 
-describe("@sandbox-benchmarks/results", () => {
-	it("normalizes a raw run into a run document", () => {
-		const raw: RawRun = { provider: "modal", operation: "exec", durationMs: 42 };
-		const doc = normalize(raw);
-		expect(doc.provider).toBe("modal");
-		expect(doc.operation).toBe("exec");
-		expect(doc.durationMs).toBe(42);
-		expect(() => new Date(doc.normalizedAt).toISOString()).not.toThrow();
+// The committed fixture tree has one provider directory (daytona) holding a real node-web-tooling
+// composite, a bench.sh skip marker, and observed specs. This is the offline end-to-end proof.
+const rawRoot = join(import.meta.dir, "lib/__fixtures__");
+
+describe("normalizeResultsTree", () => {
+	const run = normalizeResultsTree({
+		rawRoot,
+		runId: "run-test",
+		sha: "abc123",
+		generatedAt: "2026-06-20T00:00:00.000Z",
+	});
+
+	it("validates as a Run and includes every known provider", () => {
+		expect(run.schemaVersion).toBe("1");
+		expect(run.providers.map((provider) => provider.providerId).sort()).toEqual([
+			"daytona",
+			"e2b",
+			"modal",
+		]);
+	});
+
+	it("normalizes daytona's node-web-tooling into an aggregated, validated metric", () => {
+		const daytona = run.providers.find((provider) => provider.providerId === "daytona");
+		expect(daytona?.validationStatus).toBe("validated");
+		const metric = daytona?.metrics.find((m) => m.metricId === "node_web_tooling_runs_per_s");
+		expect(metric?.samples).toEqual([16.19, 16.3, 16.08]);
+		expect(metric?.aggregates.n).toBe(3);
+		expect(metric?.aggregates.p50).toBeCloseTo(16.19, 5);
+		expect(metric?.sourceFile).toBe("pts_node-web-tooling.xml");
+	});
+
+	it("records the bench.sh skip and matches the pinned target spec", () => {
+		const daytona = run.providers.find((provider) => provider.providerId === "daytona");
+		expect(daytona?.skips).toEqual([
+			{ suite: "pts_git", reason: "phoronix-test-suite not installed" },
+		]);
+		expect(daytona?.specMatched).toBe(true);
+		expect(daytona?.observedSpecs.hostVcpus).toBe(48);
+	});
+
+	it("leaves providers without a raw directory pending", () => {
+		const e2b = run.providers.find((provider) => provider.providerId === "e2b");
+		expect(e2b?.validationStatus).toBe("pending");
+		expect(e2b?.metrics).toEqual([]);
+	});
+
+	it("summarizes one line per provider", () => {
+		expect(summarizeRun(run)).toHaveLength(3);
 	});
 });

--- a/packages/results/src/index.ts
+++ b/packages/results/src/index.ts
@@ -1,21 +1,14 @@
 // Public surface of @sandbox-benchmarks/results.
-// Normalizes raw PTS output into the schema's Run model using ONLY @sandbox-benchmarks/schema and the
-// XML parser — never a provider SDK (enforced by the package boundary).
-import type { RawRun, RunDocument } from "@sandbox-benchmarks/schema";
-import { isoNow } from "./lib/internal.ts";
-
-// Per-provider raw-directory extraction (samples, stragglers, skips).
-export * from "./lib/extract.ts";
-export * from "./lib/pts.ts";
-// Typed PTS composite.xml parsing and Catalog mapping.
-export * from "./lib/pts-schema.ts";
-
-/** Normalize a single raw run into a {@link RunDocument}. Stub logic. */
-export function normalize(raw: RawRun): RunDocument {
-	return {
-		provider: raw.provider,
-		operation: raw.operation,
-		durationMs: raw.durationMs,
-		normalizedAt: isoNow(),
-	};
-}
+// Turns a provider's raw PTS output into the schema's Run model using ONLY @sandbox-benchmarks/schema
+// and the XML parser — never a provider SDK (enforced by the package boundary).
+//
+// The PTS parser, per-file extraction, observed-spec reading, and Run writer all live under ./lib and
+// are implementation detail. This surface exposes only the entry points consumers (the CLI) need:
+// normalize a raw tree, write the Run, and summarize it.
+export { type NormalizeInput, normalizeResultsTree } from "./lib/normalize-tree.ts";
+export {
+	summarizeRun,
+	updateRunIndex,
+	type WriteNormalizedRunInput,
+	writeNormalizedRun,
+} from "./lib/write-run.ts";

--- a/packages/results/src/lib/__fixtures__/daytona/observed-specs.json
+++ b/packages/results/src/lib/__fixtures__/daytona/observed-specs.json
@@ -1,0 +1,11 @@
+{
+  "vcpus": 2,
+  "memoryGb": 8,
+  "diskGb": 20,
+  "hostVcpus": 48,
+  "hostMemoryGb": 377,
+  "kernel": "6.8.0-generic",
+  "os": "Debian GNU/Linux 13",
+  "virtualization": "kvm",
+  "user": "daytona"
+}

--- a/packages/results/src/lib/internal.ts
+++ b/packages/results/src/lib/internal.ts
@@ -1,6 +1,0 @@
-// Private implementation detail of @sandbox-benchmarks/results.
-
-/** Current time as an ISO-8601 string. Wrapped so it can be stubbed in tests. */
-export function isoNow(): string {
-	return new Date().toISOString();
-}

--- a/packages/results/src/lib/normalize-tree.test.ts
+++ b/packages/results/src/lib/normalize-tree.test.ts
@@ -1,0 +1,67 @@
+import { afterEach, beforeEach, describe, expect, it, spyOn } from "bun:test";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { normalizeProviderDir } from "./normalize-tree.ts";
+
+// A composite carrying a catalogued node-web-tooling result plus an uncatalogued pts/git result.
+// `samples` lets a second file diverge so we can prove the contamination-vs-benign distinction.
+function composite(samples: string): string {
+	return `<?xml version="1.0"?>
+<PhoronixTestSuite>
+  <Generated><TestClient>pts/10.8.4</TestClient></Generated>
+  <Result>
+    <Identifier>pts/node-web-tooling-1.0.1</Identifier>
+    <Title>Node.js V8 Web Tooling Benchmark</Title>
+    <Scale>runs/s</Scale><Proportion>HIB</Proportion>
+    <Data><Entry><Value>10.5</Value><RawString>${samples}</RawString></Entry></Data>
+  </Result>
+  <Result>
+    <Identifier>pts/git-1.1.0</Identifier>
+    <Title>Git</Title>
+    <Scale>Seconds</Scale><Proportion>LIB</Proportion>
+    <Data><Entry><Value>54.27</Value></Entry></Data>
+  </Result>
+</PhoronixTestSuite>`;
+}
+
+describe("normalizeProviderDir de-dupes a metric leaked into two composites", () => {
+	// normalizeProviderDir joins rawRoot/providerId, so results live in a provider subdirectory.
+	let root: string;
+	let providerDir: string;
+	beforeEach(() => {
+		root = mkdtempSync(join(tmpdir(), "norm-dedupe-"));
+		providerDir = join(root, "daytona");
+		mkdirSync(providerDir);
+	});
+	afterEach(() => {
+		rmSync(root, { recursive: true, force: true });
+	});
+
+	it("keeps one copy and does NOT pool samples across files (no inflated n)", () => {
+		// Both files carry the same node-web-tooling + git result — the exact TEST_RESULTS_NAME-reuse
+		// contamination seen in real PTS output. Pooling would give n=6 and a fabricated stddev.
+		writeFileSync(join(providerDir, "pts_compress_zstd.xml"), composite("10.5:10.6:10.4"));
+		writeFileSync(join(providerDir, "pts_node-web-tooling.xml"), composite("10.5:10.6:10.4"));
+
+		const run = normalizeProviderDir(root, "daytona");
+		const metric = run.metrics.find((m) => m.metricId === "node_web_tooling_runs_per_s");
+		expect(run.metrics).toHaveLength(1);
+		expect(metric?.samples).toEqual([10.5, 10.6, 10.4]);
+		expect(metric?.aggregates.n).toBe(3);
+		// The uncatalogued git straggler is collapsed to a single entry too.
+		expect(run.uncatalogued.filter((u) => u.id.startsWith("pts/git"))).toHaveLength(1);
+	});
+
+	it("warns loudly when the duplicate's samples diverge (real contamination, not a rewrite)", () => {
+		const warn = spyOn(console, "warn").mockImplementation(() => {});
+		try {
+			writeFileSync(join(providerDir, "pts_compress_zstd.xml"), composite("10.5:10.6:10.4"));
+			writeFileSync(join(providerDir, "pts_node-web-tooling.xml"), composite("99.9:99.8"));
+			normalizeProviderDir(root, "daytona");
+			expect(warn.mock.calls.flat().join("\n")).toMatch(/DIFFERENT samples/);
+		} finally {
+			warn.mockRestore();
+		}
+	});
+});

--- a/packages/results/src/lib/normalize-tree.ts
+++ b/packages/results/src/lib/normalize-tree.ts
@@ -1,0 +1,159 @@
+/**
+ * Normalization pipeline: a raw `data/raw/<runId>/` tree → one validated {@link Run}. The tree has
+ * one subdirectory per provider id; every file inside is routed through ./extract.ts. The output is
+ * validated against the shared schema before it leaves this module — validation happens at the
+ * producer boundary, so no malformed Run can reach a consumer. SDK-free — filesystem + schema only.
+ */
+import { readFileSync, statSync } from "node:fs";
+import { join } from "node:path";
+import type {
+	MetricResult,
+	ProviderRun,
+	Run,
+	UncataloguedResult,
+} from "@sandbox-benchmarks/schema";
+import { aggregate, PROVIDERS, parseRun, TARGET_SPEC } from "@sandbox-benchmarks/schema";
+import { extractProviderDir } from "./extract.ts";
+import { computeSpecMatched, readObservedSpecs } from "./specs.ts";
+
+export interface NormalizeInput {
+	rawRoot: string;
+	runId: string;
+	sha: string;
+	generatedAt: string;
+	sourceRunUrl?: string;
+}
+
+/** Normalize a whole raw tree into one validated Run — every known provider appears in every Run. */
+export function normalizeResultsTree(input: NormalizeInput): Run {
+	// Providers without results stay `pending`, which is itself a first-class fact the tool surfaces.
+	const providers = [...PROVIDERS]
+		.sort((a, b) => a.id.localeCompare(b.id))
+		.map((meta) => normalizeProviderDir(input.rawRoot, meta.id));
+
+	const candidate = {
+		schemaVersion: "1" as const,
+		runId: input.runId,
+		sha: input.sha,
+		generatedAt: input.generatedAt,
+		...(input.sourceRunUrl !== undefined ? { sourceRunUrl: input.sourceRunUrl } : {}),
+		targetSpec: { ...TARGET_SPEC },
+		providers,
+	};
+
+	try {
+		return parseRun(candidate);
+	} catch (err) {
+		throw new Error(
+			`Normalized Run for ${input.runId} failed schema validation: ${
+				err instanceof Error ? err.message : String(err)
+			}`,
+		);
+	}
+}
+
+/** Element-wise sample equality — used to tell a benign duplicate from divergent contamination. */
+function sameSamples(a: readonly number[], b: readonly number[]): boolean {
+	return a.length === b.length && a.every((value, i) => value === b[i]);
+}
+
+/** Normalize one provider's raw directory into a ProviderRun (pending when the directory is absent). */
+export function normalizeProviderDir(rawRoot: string, providerId: string): ProviderRun {
+	const dir = join(rawRoot, providerId);
+	// Single stat (not existsSync + statSync) so a directory removed between the two calls degrades to
+	// `pending` instead of throwing ENOENT mid-normalization.
+	let dirStat: ReturnType<typeof statSync> | undefined;
+	try {
+		dirStat = statSync(dir);
+	} catch {
+		dirStat = undefined;
+	}
+	if (!dirStat?.isDirectory()) {
+		return {
+			providerId,
+			validationStatus: "pending",
+			observedSpecs: {},
+			metrics: [],
+			skips: [],
+			uncatalogued: [],
+		};
+	}
+
+	const extraction = extractProviderDir(dir, providerId);
+
+	// De-dupe catalogued metrics by metricId across source files — keep the FIRST (deterministic file
+	// order). In our model one <Result> owns a metric's per-pass samples, so the same metricId in two
+	// files is a duplicate, not extra passes: real PTS producers that reuse TEST_RESULTS_NAME write the
+	// same result into more than one composite (observed in runner-benchmarking's pts_git result, which
+	// landed in both pts_git.xml and pts_compress_zstd.xml). Pooling the samples would inflate n and
+	// distort the stddev, so drop the later copy and warn — louder when the samples diverge, which
+	// signals genuine result-name contamination rather than a benign rewrite.
+	const merged = new Map<
+		string,
+		{ samples: number[]; sourceFile: string; appVersion?: string; arguments?: string }
+	>();
+	for (const contribution of extraction.contributions) {
+		const existing = merged.get(contribution.metricId);
+		if (existing) {
+			const diverged = !sameSamples(existing.samples, contribution.samples);
+			console.warn(
+				`[normalize] ${providerId}: metric "${contribution.metricId}" appears in both ` +
+					`${existing.sourceFile} and ${contribution.sourceFile}` +
+					(diverged
+						? " with DIFFERENT samples — keeping the first (check for result-name contamination)"
+						: " — keeping the first"),
+			);
+			continue;
+		}
+		merged.set(contribution.metricId, {
+			samples: [...contribution.samples],
+			sourceFile: contribution.sourceFile,
+			appVersion: contribution.appVersion,
+			arguments: contribution.arguments,
+		});
+	}
+	const metrics: MetricResult[] = [...merged.entries()]
+		// A metric must carry >=1 sample to aggregate (and to satisfy the schema). The extractor no
+		// longer emits empty-sample contributions, but guard here too so a zero-sample metric is
+		// dropped rather than throwing out of aggregate() before parseRun's try/catch can frame it.
+		.filter(([, { samples }]) => samples.length > 0)
+		.map(([metricId, { samples, sourceFile, appVersion, arguments: args }]) => ({
+			metricId,
+			samples,
+			aggregates: aggregate(samples),
+			sourceFile,
+			...(appVersion !== undefined ? { appVersion } : {}),
+			...(args !== undefined ? { arguments: args } : {}),
+		}))
+		.sort((a, b) => a.metricId.localeCompare(b.metricId));
+
+	// De-dupe uncatalogued stragglers by id for the same reason (a contaminating result leaks into every
+	// composite it lands in); keep the first occurrence and preserve extraction order.
+	const seenUncatalogued = new Set<string>();
+	const uncatalogued: UncataloguedResult[] = [];
+	for (const straggler of extraction.uncatalogued) {
+		if (seenUncatalogued.has(straggler.id)) continue;
+		seenUncatalogued.add(straggler.id);
+		uncatalogued.push(straggler);
+	}
+
+	const observedSpecs = readObservedSpecs((name) => {
+		try {
+			return JSON.parse(readFileSync(join(dir, name), "utf8"));
+		} catch {
+			return undefined;
+		}
+	});
+	const specMatched = computeSpecMatched(observedSpecs);
+
+	return {
+		providerId,
+		// A provider is validated exactly when it produced ≥1 catalogued Metric.
+		validationStatus: metrics.length > 0 ? "validated" : "pending",
+		...(specMatched !== undefined ? { specMatched } : {}),
+		observedSpecs,
+		metrics,
+		skips: extraction.skips,
+		uncatalogued,
+	};
+}

--- a/packages/results/src/lib/specs.ts
+++ b/packages/results/src/lib/specs.ts
@@ -1,0 +1,58 @@
+/**
+ * Observed specs per ProviderRun: the harness pins a target spec at create() and records
+ * what the sandbox actually delivered into `observed-specs.json`. This slice reads that file; the jc
+ * probe-file fallback (lscpu/free/uname/df) lands with the lifecycle path.
+ */
+import type { ObservedSpecs } from "@sandbox-benchmarks/schema";
+import { TARGET_SPEC } from "@sandbox-benchmarks/schema";
+
+/** Reads a named JSON file from a provider's raw directory, or undefined when absent/unparseable. */
+export type JsonReader = (name: string) => unknown;
+
+const num = (value: unknown): number | undefined =>
+	typeof value === "number" && Number.isFinite(value) ? value : undefined;
+const str = (value: unknown): string | undefined =>
+	typeof value === "string" && value.length > 0 ? value : undefined;
+
+const NUMERIC_FIELDS = [
+	"vcpus",
+	"memoryGb",
+	"diskGb",
+	"hostVcpus",
+	"hostMemoryGb",
+	"cpuMhz",
+] as const;
+const STRING_FIELDS = ["cpuModel", "kernel", "os", "virtualization", "user"] as const;
+
+function fromObservedSpecsFile(raw: Record<string, unknown>): ObservedSpecs {
+	const specs: ObservedSpecs = {};
+	for (const key of NUMERIC_FIELDS) {
+		const value = num(raw[key]);
+		if (value !== undefined) specs[key] = value;
+	}
+	for (const key of STRING_FIELDS) {
+		const value = str(raw[key]);
+		if (value !== undefined) specs[key] = value;
+	}
+	return specs;
+}
+
+/** Read the harness-written observed-specs.json, tolerating its absence (returns `{}`). */
+export function readObservedSpecs(readJson: JsonReader): ObservedSpecs {
+	const direct = readJson("observed-specs.json");
+	if (direct && typeof direct === "object" && !Array.isArray(direct)) {
+		return fromObservedSpecsFile(direct as Record<string, unknown>);
+	}
+	return {};
+}
+
+/**
+ * Did the sandbox honor the pinned target spec? vCPUs must match exactly; memory within ±10%
+ * (kernels reserve some). Undefined when either observation is missing — we refuse to judge on
+ * partial evidence.
+ */
+export function computeSpecMatched(specs: ObservedSpecs): boolean | undefined {
+	if (specs.vcpus === undefined || specs.memoryGb === undefined) return undefined;
+	const memoryOk = Math.abs(specs.memoryGb - TARGET_SPEC.memoryGb) <= TARGET_SPEC.memoryGb * 0.1;
+	return specs.vcpus === TARGET_SPEC.vcpus && memoryOk;
+}

--- a/packages/results/src/lib/write-run.test.ts
+++ b/packages/results/src/lib/write-run.test.ts
@@ -1,0 +1,37 @@
+import { afterAll, describe, expect, it } from "bun:test";
+import { mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { parseRun, parseRunIndex } from "@sandbox-benchmarks/schema";
+import { writeNormalizedRun } from "./write-run.ts";
+
+const rawRoot = join(import.meta.dir, "__fixtures__");
+const outDir = mkdtempSync(join(tmpdir(), "sandbox-bench-write-run-"));
+
+afterAll(() => rmSync(outDir, { recursive: true, force: true }));
+
+describe("writeNormalizedRun", () => {
+	const outFile = join(outDir, "runs", "run-1.json");
+	const indexFile = join(outDir, "index.json");
+	const run = writeNormalizedRun({
+		rawRoot,
+		runId: "run-1",
+		sha: "abc123",
+		generatedAt: "2026-06-20T00:00:00.000Z",
+		outFile,
+		updateIndexFile: indexFile,
+	});
+
+	it("writes a Run document that re-parses against the schema", () => {
+		const written = parseRun(JSON.parse(readFileSync(outFile, "utf8")));
+		expect(written.runId).toBe("run-1");
+		expect(written).toEqual(run);
+	});
+
+	it("records the run in the index with a path relative to the index file", () => {
+		const index = parseRunIndex(JSON.parse(readFileSync(indexFile, "utf8")));
+		expect(index.runs).toEqual([
+			{ runId: "run-1", generatedAt: "2026-06-20T00:00:00.000Z", path: "runs/run-1.json" },
+		]);
+	});
+});

--- a/packages/results/src/lib/write-run.ts
+++ b/packages/results/src/lib/write-run.ts
@@ -1,0 +1,87 @@
+/**
+ * Write a normalized {@link Run} to disk and maintain the newest-first Run index. SDK-free —
+ * filesystem + schema only. Timestamps default to now; pass `generatedAt` for reproducible output.
+ */
+import { mkdirSync, readFileSync, renameSync, writeFileSync } from "node:fs";
+import { dirname, relative, resolve } from "node:path";
+import type { Run, RunIndex } from "@sandbox-benchmarks/schema";
+import { parseRunIndex } from "@sandbox-benchmarks/schema";
+import { normalizeResultsTree } from "./normalize-tree.ts";
+
+/**
+ * Write a file atomically: serialize to a sibling temp file, then rename over the target. rename(2) is
+ * atomic within a filesystem, so a crash mid-write can never leave a half-written Run/index on disk —
+ * a reader sees either the old file or the complete new one.
+ */
+function atomicWriteFileSync(path: string, contents: string): void {
+	mkdirSync(dirname(path), { recursive: true });
+	const tmp = `${path}.${process.pid}.tmp`;
+	writeFileSync(tmp, contents);
+	renameSync(tmp, path);
+}
+
+export interface WriteNormalizedRunInput {
+	rawRoot: string;
+	runId: string;
+	sha: string;
+	outFile: string;
+	generatedAt?: string;
+	sourceRunUrl?: string;
+	updateIndexFile?: string;
+}
+
+/** Insert a Run into the index (newest first, de-duplicated by runId) and rewrite the index file. */
+export function updateRunIndex(indexPath: string, run: Run, runFilePath: string): RunIndex {
+	// Read-and-parse directly rather than existsSync-then-read: a TOCTOU gap there could throw ENOENT
+	// after the Run JSON was already written, orphaning it from the index. A missing index is the
+	// first-run case; a corrupt/unreadable one must still surface (don't silently overwrite it).
+	let existing: RunIndex;
+	try {
+		existing = parseRunIndex(JSON.parse(readFileSync(indexPath, "utf8")));
+	} catch (err) {
+		if (!(err && typeof err === "object" && "code" in err && err.code === "ENOENT")) throw err;
+		existing = { schemaVersion: "1", runs: [] };
+	}
+
+	const entry = {
+		runId: run.runId,
+		generatedAt: run.generatedAt,
+		// Forward slashes so the index stays portable (relative() yields backslashes on Windows).
+		path: relative(dirname(indexPath), runFilePath).replaceAll("\\", "/"),
+	};
+	// Fixed "en" locale: ISO-8601 strings sort lexicographically === chronologically, regardless of
+	// the runtime's default collation.
+	const runs = [entry, ...existing.runs.filter((r) => r.runId !== run.runId)].sort((a, b) =>
+		b.generatedAt.localeCompare(a.generatedAt, "en"),
+	);
+	const index = parseRunIndex({ schemaVersion: "1", runs });
+	atomicWriteFileSync(indexPath, `${JSON.stringify(index, null, 2)}\n`);
+	return index;
+}
+
+/** Normalize a raw tree and write the validated Run JSON (optionally updating a Run index). */
+export function writeNormalizedRun(input: WriteNormalizedRunInput): Run {
+	const run = normalizeResultsTree({
+		rawRoot: resolve(input.rawRoot),
+		runId: input.runId,
+		sha: input.sha,
+		generatedAt: input.generatedAt ?? new Date().toISOString(),
+		...(input.sourceRunUrl !== undefined ? { sourceRunUrl: input.sourceRunUrl } : {}),
+	});
+
+	const outPath = resolve(input.outFile);
+	atomicWriteFileSync(outPath, `${JSON.stringify(run, null, 2)}\n`);
+
+	if (input.updateIndexFile) updateRunIndex(resolve(input.updateIndexFile), run, outPath);
+	return run;
+}
+
+/** One human-readable status line per provider, for CLI/CI logs. */
+export function summarizeRun(run: Run): string[] {
+	return run.providers.map(
+		(provider) =>
+			`${provider.providerId.padEnd(12)} ${provider.validationStatus.padEnd(10)} ` +
+			`metrics=${provider.metrics.length} skips=${provider.skips.length} ` +
+			`uncatalogued=${provider.uncatalogued.length}`,
+	);
+}

--- a/packages/schema/README.md
+++ b/packages/schema/README.md
@@ -3,11 +3,14 @@
 **Role:** the bottom of the dependency DAG — shared types and runtime schemas every other member
 builds on.
 
-**Public surface (`.`):** `Capability` / `capabilities`, `CapabilityFlags`, `ProviderDescriptor`,
-`RawRun`, `RunDocument`, `parseRawRun()`.
+**Public surface (`.`):** the provider registry and economics, the toolchain identity, the Metric
+vocabulary + Catalog (`MetricDef`, `METRIC_CATALOG`, `aggregate()`), the Run dataset model (`Run`,
+`ProviderRun`, `MetricResult`, `parseRun()`), the raw-file naming contract, and `RawRun` /
+`parseRawRun()`.
 
 **Depends on:** `arktype` only (no internal deps).
 
-**What lives here:** the canonical type vocabulary for providers, raw runs, and normalized run
-documents, plus arktype runtime validators. Private validation internals live in `src/lib/` and
-must never be imported across a package boundary — import from `@sandbox-benchmarks/schema` instead.
+**What lives here:** the canonical type vocabulary and arktype runtime schemas every other member
+builds on — providers, metrics, the normalized Run model, and how raw result files are named.
+Private validation internals live in `src/lib/` and must never be imported across a package
+boundary — import from `@sandbox-benchmarks/schema` instead.

--- a/packages/schema/src/index.ts
+++ b/packages/schema/src/index.ts
@@ -45,15 +45,6 @@ export interface ProviderDescriptor {
  */
 export type RawRun = typeof rawRunSchema.infer;
 
-/** A normalized run document, as produced by @sandbox-benchmarks/results. */
-export interface RunDocument {
-	provider: string;
-	operation: string;
-	durationMs: number;
-	/** ISO-8601 timestamp the document was normalized at. */
-	normalizedAt: string;
-}
-
 /** Validate an unknown value as a {@link RawRun} using the arktype schema. */
 export function parseRawRun(value: unknown): RawRun {
 	const out = rawRunSchema(value);


### PR DESCRIPTION
Normalizes a data/raw tree into a validated Run: per-provider extraction merges samples per metric, aggregates them, reads observed specs, and computes spec-match. writeNormalizedRun emits the Run JSON and maintains the newest-first index. The normalize and promote CLI bins now do real work; the offline end-to-end (real Daytona fixture -> Run with node_web_tooling_runs_per_s) is proven by tests.

Removes the placeholder RunDocument and its consumers (the deferred PR 2 supersession), now that the real Run model is wired. SDK-free; boundary tests stay green.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Normalizes a raw `data/raw/<runId>/` tree into a validated `Run`, writes it atomically, and maintains a newest-first index. The `normalize` and `promote` CLIs run the full flow with per-provider summaries and a CI-safe validation gate; the old `RunDocument` stub is removed.

- **New Features**
  - `normalizeResultsTree`: de-dupes per-metric contributions across files (keep first, no sample pooling), aggregates samples, reads `observed-specs.json`, sets `specMatched`, includes all providers (`pending` when missing), and supports optional `sourceRunUrl`/`generatedAt`.
  - `writeNormalizedRun`, `updateRunIndex` (newest-first, de-duped by `runId`, portable relative paths, atomic writes), and `summarizeRun` in `@sandbox-benchmarks/results`.
  - Wired CLI: `normalize <rawRoot> <runId> <sha> <outFile> [indexFile]` writes the run and optional index, then prints one summary per provider; `promote <run.json>` re-validates via `@sandbox-benchmarks/schema`, prints summaries, outputs `validatedProviders`, and exits non-zero if none are validated.

- **Bug Fixes**
  - De-duped metrics appearing in multiple composites (warn when samples differ) and de-duped uncatalogued stragglers to prevent inflated `n`/stddev.
  - Dropped zero-sample metrics before aggregation and made Run/index writes atomic (temp file + rename).

<sup>Written for commit 5ae5705410b24ce75d624c9bf15d8beaacc87559. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/starslingdev/sandbox-benchmarks/pull/36?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

