### PR TITLE
ci(harness): bench-smoke workflow (Daytona)

### DIFF
--- a/.github/workflows/bench-smoke.yml
+++ b/.github/workflows/bench-smoke.yml
@@ -1,0 +1,84 @@
+name: Bench smoke
+
+# Manually-dispatched live benchmark: spins up a real provider sandbox, runs one suite, normalizes
+# the result into a Run document, and uploads it as an artifact. Off the PR path (it costs real
+# sandbox time and needs provider credentials) — run it on demand to validate the end-to-end lane.
+on:
+  workflow_dispatch:
+    inputs:
+      provider:
+        description: Provider to benchmark
+        type: choice
+        default: daytona
+        options: [daytona, e2b, modal]
+      suite:
+        description: Suite to run
+        default: cpu-node
+      region:
+        # Daytona only: the default org is parked, so real runs use the ZEN5 region (its own API key +
+        # target + snapshot). Ignored by e2b/modal.
+        description: Daytona region
+        type: choice
+        default: zen5
+        options: [zen5, default]
+
+# Least privilege: the job only reads the checked-out code and uploads an artifact.
+permissions:
+  contents: read
+
+concurrency:
+  group: bench-smoke-${{ github.ref }}-${{ inputs.provider }}-${{ inputs.suite }}
+  cancel-in-progress: false
+
+jobs:
+  smoke:
+    name: ${{ inputs.suite }} on ${{ inputs.provider }}
+    runs-on: starsling-ubuntu-24.04-2
+    # The suite itself runs for many minutes inside the sandbox; give the host job ample headroom.
+    timeout-minutes: 150
+    steps:
+      # Third-party actions are pinned to a commit SHA (the tag comment is for humans) so a
+      # moved/compromised tag can't silently change what runs.
+      - name: Checkout
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+
+      - name: Set up Bun
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
+        with:
+          bun-version: 1.3.14
+
+      # Frozen lockfile + no lifecycle scripts, matching bunfig.toml's supply-chain posture.
+      - name: Install dependencies
+        run: bun install --frozen-lockfile --ignore-scripts
+
+      # Drives the provider SDK to create a sandbox, run the suite, collect results, and normalize.
+      # The sandbox clones THIS repo at the run's SHA so the in-sandbox producer matches the harness.
+      - name: Run suite and normalize
+        env:
+          BENCH_REPO_REF: ${{ github.sha }}
+          # The sandbox clones this private repo at the run's SHA; the short-lived job token authorizes it.
+          BENCH_REPO_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # Pass the dispatch inputs through the environment, never interpolated into the `run` script:
+          # `suite` is a free-text input, so a `${{ }}` expansion straight into the shell would let a
+          # crafted value run arbitrary commands on the self-hosted runner. `$GITHUB_RUN_ID` is built-in.
+          BENCH_PROVIDER: ${{ inputs.provider }}
+          BENCH_SUITE: ${{ inputs.suite }}
+          # Daytona region selection (default org is parked; ZEN5 is the active region).
+          DAYTONA_REGION: ${{ inputs.region }}
+          DAYTONA_API_KEY: ${{ secrets.DAYTONA_API_KEY }}
+          DAYTONA_API_KEY_ZEN5: ${{ secrets.DAYTONA_API_KEY_ZEN5 }}
+          DAYTONA_TARGET_ZEN5: ${{ secrets.DAYTONA_TARGET_ZEN5 }}
+          E2B_API_KEY: ${{ secrets.E2B_API_KEY }}
+          MODAL_TOKEN_ID: ${{ secrets.MODAL_TOKEN_ID }}
+          MODAL_TOKEN_SECRET: ${{ secrets.MODAL_TOKEN_SECRET }}
+        run: bun apps/cli/src/bin/bench-suite.ts "$BENCH_PROVIDER" "$BENCH_SUITE" "$GITHUB_RUN_ID"
+
+      - name: Upload Run + raw results
+        if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: bench-${{ inputs.suite }}-${{ inputs.provider }}-${{ github.run_id }}
+          path: data/
+          # A successful run always writes data/runs/<id>.json (even an all-skipped Run), so an empty
+          # data/ means the job is genuinely broken — fail the upload rather than bury a warning.
+          if-no-files-found: error


### PR DESCRIPTION
The on-demand CI lane: a `workflow_dispatch` `bench-smoke.yml` that spins up a real provider sandbox, runs one suite end-to-end via the `bench-suite` CLI (#43), normalizes the raw output into a Run, and uploads `data/` (raw + Run) as an artifact. This is the final de-risking step — it proves the whole slice (#35–#43) runs against a live provider, not just in unit tests.

Least-privilege (`contents: read`), SHA-pinned actions, and Daytona/e2b/modal creds via `secrets.*`. The free-text dispatch inputs are passed through the environment (never interpolated into the `run` shell) to avoid command injection on the self-hosted runner, and `if-no-files-found: error` fails a genuinely empty run rather than burying a warning.

The harness internals this drives — `StepRunner`/`runDetached`, `setupSteps`, the collector, and `runSuite` — live in #40–#43. The durable detached+poll transport for multi-minute suites has landed (#40), so this lane now covers the real `cpu-node` run, not only a short smoke.

---

## Post-merge setup (required to run this workflow)

GitHub → **Settings → Secrets and variables → Actions → Secrets**. No repository *Variables* are used.

**Secrets**

| Secret | For | Required |
|---|---|---|
| `DAYTONA_API_KEY_ZEN5` | Daytona `zen5` (the default `region` input) — the provider credential gate | ✅ for the default dispatch |
| `DAYTONA_TARGET_ZEN5` | Routes the sandbox to the ZEN5 runner/region | ✅ for `zen5` |
| `DAYTONA_API_KEY` | Daytona `region: default` only (that org is parked) | only if dispatching `region=default` |
| `E2B_API_KEY` | `provider: e2b` | only for e2b |
| `MODAL_TOKEN_ID` + `MODAL_TOKEN_SECRET` | `provider: modal` | only for modal |
| `GITHUB_TOKEN` | clones this repo into the sandbox (`BENCH_REPO_TOKEN`) | auto-provided — **no action** |

**Operational prerequisites (not secrets, but a run fails without them)**

- **Daytona snapshot** must already be baked under the default name `<toolchain-image>-<version>` in the ZEN5 account — the workflow does not pass `DAYTONA_SNAPSHOT_ZEN5`, so it can't override a custom name yet.
- **e2b template** (`E2B_TEMPLATE`, defaults to the toolchain image name) must be built/published in the e2b account.
- **modal** boots from `ghcr.io/starslingdev/<toolchain>:<version>` — that package must be public.
- The self-hosted runner **`starsling-ubuntu-24.04-2`** must be online.

Minimum to run the default dispatch (`provider: daytona`, `region: zen5`, `suite: cpu-node`): set `DAYTONA_API_KEY_ZEN5` + `DAYTONA_TARGET_ZEN5`, ensure the ZEN5 snapshot exists, then **Actions → Bench smoke → Run workflow**.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a manual bench-smoke GitHub Actions workflow that spins up a real provider sandbox, runs one suite end to end via the `bench-suite` CLI, normalizes results, and uploads raw + Run artifacts. Supports `daytona` (ZEN5 default), `e2b`, and `modal`, with inputs passed via env to avoid shell injection.

- **New Features**
  - Inputs: `provider` (`daytona`/`e2b`/`modal`, default `daytona`), `suite` (default `cpu-node`), Daytona `region` (`zen5` default).
  - Safety: `contents: read`; SHA-pinned actions; clone via `GITHUB_TOKEN`; concurrency by `ref/provider/suite` (no auto-cancel).
  - Run/tooling: self-hosted `starsling-ubuntu-24.04-2`, 150‑min timeout; Bun 1.3.14 with `--frozen-lockfile --ignore-scripts`; runs `apps/cli/src/bin/bench-suite.ts` with `BENCH_REPO_REF`/`BENCH_REPO_TOKEN`; Daytona `region` via `DAYTONA_REGION`; provider creds via secrets.
  - Artifacts: always upload `data/` (raw + Run); `if-no-files-found: error`.

<sup>Written for commit 45f09700c20935ace4f1c89fa20cc7f2aed91a4e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/starslingdev/sandbox-benchmarks/pull/38?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

