### PR TITLE
feat(schema): raw-file naming contract

### DIFF
--- a/packages/schema/src/index.ts
+++ b/packages/schema/src/index.ts
@@ -11,6 +11,8 @@ export * from "./catalog.ts";
 export * from "./metrics.ts";
 // Provider identity & economics registry (id, requiredEnvVars, pricing, isolation, spec-pinning).
 export * from "./providers.ts";
+// The raw-file naming contract shared by the producers and the results extractor.
+export * from "./raw-files.ts";
 // The canonical Run dataset model (Run/ProviderRun/MetricResult/…) and its validators.
 export * from "./run.ts";
 // Canonical toolchain image identity (name + version), shared by the build pins and runtime config.

--- a/packages/schema/src/raw-files.test.ts
+++ b/packages/schema/src/raw-files.test.ts
@@ -1,0 +1,114 @@
+import { describe, expect, it } from "bun:test";
+import {
+	harnessSkipMarkerJson,
+	isPtsResultFile,
+	isSkipMarkerFile,
+	parseResultsArtifactName,
+	parseSkipMarker,
+	resultsArtifactName,
+	sandboxSkipMarkerFile,
+} from "./index.ts";
+
+describe("raw-file naming", () => {
+	it("recognises PTS result XML by prefix and extension", () => {
+		expect(isPtsResultFile("pts_node-web-tooling.xml")).toBe(true);
+		expect(isPtsResultFile("pts_node-web-tooling.log")).toBe(false);
+		expect(isPtsResultFile("observed-specs.json")).toBe(false);
+	});
+
+	it("names and detects suite skip markers", () => {
+		const file = sandboxSkipMarkerFile("daytona", "cpu-node");
+		expect(file).toBe("sandbox-daytona-cpu-node--skipped.json");
+		expect(isSkipMarkerFile(file)).toBe(true);
+	});
+
+	it("pins the exact harness skip-marker bytes (the producer/harness/normalizer contract)", () => {
+		// harnessSkipMarkerJson is the single source of truth for the on-disk skip-marker body. Pin the
+		// exact spelling — fixed key order, two-space indent, trailing newline — so a drift here can't
+		// silently break the producer↔harness↔normalizer round-trip.
+		const bytes = harnessSkipMarkerJson("daytona", "cpu-node", "Missing credentials");
+		expect(bytes).toBe(
+			'{\n  "provider": "daytona",\n  "suite": "cpu-node",\n  "skipped": true,\n  "reason": "Missing credentials"\n}\n',
+		);
+		// And it round-trips through the reader to the suite + reason it encoded.
+		expect(
+			parseSkipMarker(sandboxSkipMarkerFile("daytona", "cpu-node"), JSON.parse(bytes), "daytona"),
+		).toEqual({ suite: "cpu-node", reason: "Missing credentials" });
+	});
+
+	it("round-trips a results artifact name, splitting on the first -sandbox-", () => {
+		const name = resultsArtifactName("cpu-node", "daytona");
+		expect(name).toBe("benchmark-results-cpu-node-sandbox-daytona");
+		expect(parseResultsArtifactName(name)).toEqual({ suite: "cpu-node", provider: "daytona" });
+		// Suite is lazy, so a name with a stray `-sandbox-` splits on the FIRST one (suite stays
+		// minimal); the provider tail keeps the remainder verbatim.
+		expect(parseResultsArtifactName("benchmark-results-cpu-sandbox-node-sandbox-daytona")).toEqual({
+			suite: "cpu",
+			provider: "node-sandbox-daytona",
+		});
+	});
+
+	it("returns undefined for an artifact name that doesn't match the grammar", () => {
+		expect(parseResultsArtifactName("benchmark-results-cpu-node")).toBeUndefined();
+	});
+});
+
+describe("parseSkipMarker", () => {
+	it("reads the harness shape", () => {
+		const marker = parseSkipMarker(
+			"sandbox-daytona-cpu-node--skipped.json",
+			{ provider: "daytona", suite: "cpu-node", skipped: true, reason: "insufficient disk" },
+			"daytona",
+		);
+		expect(marker).toEqual({ suite: "cpu-node", reason: "insufficient disk" });
+	});
+
+	it("reads the bench.sh shape", () => {
+		const marker = parseSkipMarker(
+			"pts_git--skipped.json",
+			{
+				schema_version: "1.0",
+				benchmark: "pts_git",
+				skipped: true,
+				skip_reason: "PTS unavailable",
+			},
+			"daytona",
+		);
+		expect(marker).toEqual({ suite: "pts_git", reason: "PTS unavailable" });
+	});
+
+	it("re-derives the suite from the filename when the body omits it", () => {
+		const marker = parseSkipMarker(
+			"sandbox-daytona-cpu-node--skipped.json",
+			{ skipped: true },
+			"daytona",
+		);
+		expect(marker).toEqual({ suite: "cpu-node", reason: "unknown" });
+	});
+
+	it("treats an empty-string body suite as absent and re-derives from the filename", () => {
+		// suite is a downstream identifier; an explicit `suite: ""` must not slip through as an empty
+		// name — it falls through to the filename derivation just like a missing field does.
+		const marker = parseSkipMarker(
+			"sandbox-daytona-cpu-node--skipped.json",
+			{ skipped: true, suite: "" },
+			"daytona",
+		);
+		expect(marker).toEqual({ suite: "cpu-node", reason: "unknown" });
+	});
+
+	it("falls back to the filename when the suite portion is empty", () => {
+		const marker = parseSkipMarker("sandbox-daytona---skipped.json", { skipped: true }, "daytona");
+		expect(marker).toEqual({ suite: "sandbox-daytona---skipped.json", reason: "unknown" });
+	});
+
+	it("rejects a marker-named file whose body isn't skipped (literal trap)", () => {
+		expect(
+			parseSkipMarker("sandbox-daytona-cpu-node--skipped.json", { skipped: false }, "daytona"),
+		).toBeUndefined();
+	});
+
+	it("returns undefined when the filename is not a skip marker", () => {
+		expect(parseSkipMarker("results.json", { skipped: true }, "daytona")).toBeUndefined();
+	});
+});

--- a/packages/schema/src/raw-files.ts
+++ b/packages/schema/src/raw-files.ts
@@ -1,0 +1,143 @@
+/**
+ * The raw-file naming contract — the ONE home for how files in a Run's curated raw tree
+ * (`data/raw/<runId>/<provider>/`) are named, and how skip markers are shaped. The in-sandbox
+ * producer and the harness collector (writers) and the results extractor (the single reader) all
+ * route through this module, so a filename's spelling can never drift between them.
+ *
+ * Parse, don't validate: the filename predicates and the skip-marker/artifact-name readers are arktype
+ * Types — `.matching` regex narrowing plus `.pipe` morphs — so a malformed marker or off-contract name
+ * can never produce a half-resolved value. A morph either yields a fully-formed result or `type.errors`.
+ *
+ * This slice covers the PTS result files and skip markers the node-web-tooling path needs. The
+ * lifecycle timing files (`<name>_ms.txt`, `<name>-exit-code.txt`) land with the lifecycle path.
+ */
+import { type } from "arktype";
+import type { SkipMarker } from "./run.ts";
+
+const SKIP_SUFFIX = "--skipped.json";
+
+// Filename predicates: regex-narrowed string Types. Wrapped (not point-free `T.allows`) so the bound
+// receiver is never lost.
+
+/**
+ * A PTS structured result, e.g. `pts_node-web-tooling.xml`. The producer writes one per test under a
+ * `pts_` prefix; the extractor keys on this to route XML through the PTS parser. The `.json`/`.log`
+ * siblings are provenance, not metrics, so they deliberately don't match.
+ */
+const ptsResultFile = type("string").matching("^pts_.*\\.xml$");
+export const isPtsResultFile = (filename: string): boolean => ptsResultFile.allows(filename);
+
+const skipMarkerFileName = type("string").matching("--skipped\\.json$");
+export const isSkipMarkerFile = (filename: string): boolean => skipMarkerFileName.allows(filename);
+
+// Name builders (the writer side of the contract).
+
+/** `<name>--skipped.json` — the benchmark was deliberately not run. */
+export function skipMarkerFile(name: string): string {
+	return `${name}${SKIP_SUFFIX}`;
+}
+
+/** Composite name for harness-level (whole suite × provider) files. */
+export function sandboxResultName(provider: string, suite: string): string {
+	return `sandbox-${provider}-${suite}`;
+}
+
+/** `sandbox-<provider>-<suite>--skipped.json` — the whole suite never ran. */
+export function sandboxSkipMarkerFile(provider: string, suite: string): string {
+	return skipMarkerFile(sandboxResultName(provider, suite));
+}
+
+/**
+ * Serialized harness skip marker — the exact bytes the harness writes into a `*--skipped.json`
+ * (pretty-printed, trailing newline, fixed key order) so the producer side has one source of truth.
+ */
+export function harnessSkipMarkerJson(provider: string, suite: string, reason: string): string {
+	return `${JSON.stringify({ provider, suite, skipped: true, reason }, null, 2)}\n`;
+}
+
+/**
+ * Suite re-derived from a `sandbox-<provider>-<suite>--skipped.json` filename — the fallback when a
+ * marker body carries no suite field. Undefined for filenames that are not skip markers, and for an
+ * empty suite portion (e.g. `sandbox-daytona---skipped.json`), so the caller's `?? filename` fallback
+ * still fires instead of yielding an empty suite name.
+ */
+export function suiteFromSkipMarkerFilename(
+	filename: string,
+	providerId: string,
+): string | undefined {
+	if (!isSkipMarkerFile(filename)) return undefined;
+	let base = filename.slice(0, -SKIP_SUFFIX.length);
+	const prefix = `sandbox-${providerId}-`;
+	if (base.startsWith(prefix)) base = base.slice(prefix.length);
+	return base || undefined;
+}
+
+/**
+ * The two legacy on-disk skip-marker body shapes, unified at the type boundary. BOTH must stay
+ * accepted — the committed raw tree is the source of truth and is re-normalized retroactively, so
+ * dropping either would silently rewrite history:
+ *
+ *   1. Harness shape:     `{ provider, suite, skipped: true, reason }`
+ *   2. bash skip_result:  `{ schema_version, benchmark, skipped: true, skip_reason }`
+ *
+ * `skipped: "true"` is a literal trap: a body with `skipped: false` (or no `skipped`) fails the morph,
+ * so the old `!json.skipped` check disappears. The morph normalizes the divergent field spellings into
+ * `{ suite?, reason }`; the filename fallback for `suite` is applied by {@link parseSkipMarker}.
+ */
+const skipMarkerBody = type({
+	skipped: "true",
+	"suite?": "string",
+	"benchmark?": "string",
+	"reason?": "string",
+	"skip_reason?": "string",
+}).pipe((d) => ({
+	// `|| undefined` (not `??`) so an empty-string `suite`/`benchmark` is treated as absent — suite is
+	// a downstream identifier, and an explicit `""` must fall through to the filename derivation in
+	// `parseSkipMarker`, exactly as a missing field does (mirrors `suiteFromSkipMarkerFilename`).
+	suite: d.suite || d.benchmark || undefined,
+	reason: d.reason ?? d.skip_reason ?? "unknown",
+}));
+
+/**
+ * Parse a `*--skipped.json` body into a {@link SkipMarker}. Guards the filename naming contract first
+ * (a non-marker filename is never a skip marker, even if its JSON happens to carry `skipped: true`),
+ * then morphs the body and re-derives the suite from the filename when the body omits it.
+ */
+export function parseSkipMarker(
+	filename: string,
+	data: unknown,
+	providerId: string,
+): SkipMarker | undefined {
+	if (!isSkipMarkerFile(filename)) return undefined;
+	const body = skipMarkerBody(data);
+	if (body instanceof type.errors) return undefined;
+	return {
+		suite: body.suite ?? suiteFromSkipMarkerFilename(filename, providerId) ?? filename,
+		reason: body.reason,
+	};
+}
+
+/** GHA artifact name for one suite × provider results upload: `benchmark-results-<suite>-sandbox-<provider>`. */
+export function resultsArtifactName(suite: string, provider: string): string {
+	return `benchmark-results-${suite}-sandbox-${provider}`;
+}
+
+// Suite is matched non-greedily, so the name splits on the FIRST `-sandbox-` (suite names never
+// contain `-sandbox-`). One regex, reused by `.matching` (narrow) and the morph (named-group extract).
+const ARTIFACT_RE = /^benchmark-results-(?<suite>.+?)-sandbox-(?<provider>.+)$/;
+const artifactName = type("string")
+	.matching(ARTIFACT_RE.source)
+	.pipe((name) => {
+		// `.matching` already proved the pattern (with both named groups) matched, so `groups` is
+		// always present; the `?? ""` only satisfies the type-checker for the unreachable miss.
+		const groups = name.match(ARTIFACT_RE)?.groups;
+		return { suite: groups?.suite ?? "", provider: groups?.provider ?? "" };
+	});
+
+/** Inverse of {@link resultsArtifactName}; undefined when the name doesn't match the contract. */
+export function parseResultsArtifactName(
+	name: string,
+): { suite: string; provider: string } | undefined {
+	const out = artifactName(name);
+	return out instanceof type.errors ? undefined : out;
+}


### PR DESCRIPTION
The raw-file naming contract (UncataloguedResult, skip-marker file names)
shared by the producers and the results extractor. Imports SkipMarker from
the Run dataset model below it.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a single source of truth for raw-file naming and skip-marker shapes in `packages/schema`. Exposes helpers for PTS result detection, skip-marker naming/JSON, and suite/provider artifact names with robust parsers; tests pin exact bytes and split behavior.

- **New Features**
  - Added `packages/schema/src/raw-files.ts` and exported from `packages/schema/src/index.ts`. Includes `isPtsResultFile`, `isSkipMarkerFile`, `skipMarkerFile`, `sandboxSkipMarkerFile`, `harnessSkipMarkerJson`, `resultsArtifactName`, `parseResultsArtifactName`, `suiteFromSkipMarkerFilename`, and `parseSkipMarker`.
  - `parseSkipMarker` accepts harness and legacy bash shapes, requires `skipped: true`, and derives the suite from `sandbox-<provider>-<suite>--skipped.json` (falls back to the filename). Artifact parsing splits on the first `-sandbox-`. Tests pin the exact harness JSON bytes and round-trip behavior.

- **Bug Fixes**
  - Treat empty-string `suite`/`benchmark` in skip-marker bodies as absent so filename fallback applies; added a multi-token artifact case to confirm first `-sandbox-` splitting.

<sup>Written for commit d9d63b0061db4b8da7a49d5f0053449e8e77fc30. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/starslingdev/sandbox-benchmarks/pull/39?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a raw-file naming contract to the schema package, including helpers to detect PTS result files, generate skip-marker filenames, serialize harness skip-marker JSON, and parse skip markers into `{ suite, reason }`.
  * Added suite×provider artifact name helpers with round-trip parsing.
  * Exposed the contract via the schema package public exports.

* **Tests**
  * Added Bun tests validating skip-marker parsing/generation across legacy formats and invalid inputs, plus artifact-name round-tripping.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->