### PR TITLE
feat(harness): step runner + timeout primitive

### DIFF
--- a/packages/harness/src/lib/execute.test.ts
+++ b/packages/harness/src/lib/execute.test.ts
@@ -1,0 +1,123 @@
+import { describe, expect, it } from "bun:test";
+import type { SandboxHandle } from "./execute.ts";
+import { PREAMBLE, StepRunner, shellQuote } from "./execute.ts";
+
+describe("shellQuote", () => {
+	it("wraps in single quotes and escapes embedded quotes", () => {
+		expect(shellQuote("echo hi")).toBe("'echo hi'");
+		expect(shellQuote("it's")).toBe(`'it'\\''s'`);
+	});
+});
+
+describe("StepRunner", () => {
+	it("runs a step through the preamble, records it, and returns the result", async () => {
+		const commands: string[] = [];
+		const sandbox: SandboxHandle = {
+			runCommand: async (command) => {
+				commands.push(command);
+				return { exitCode: 0, stdout: "ok" };
+			},
+			destroy: async () => undefined,
+		};
+		const runner = new StepRunner(sandbox);
+
+		const result = await runner.run("echo", "echo hi", 5_000);
+
+		expect(result.exitCode).toBe(0);
+		expect(runner.stepLog).toHaveLength(1);
+		expect(runner.stepLog[0]).toMatchObject({ label: "echo", phase: "setup", exitCode: 0 });
+		expect(commands[0]).toContain(PREAMBLE);
+		expect(commands[0]).toContain("echo hi");
+	});
+
+	it("throws on a non-zero exit unless allowFailure is set", async () => {
+		const sandbox: SandboxHandle = {
+			runCommand: async () => ({ exitCode: 1 }),
+			destroy: async () => undefined,
+		};
+		const runner = new StepRunner(sandbox);
+
+		await expect(runner.run("fail", "false", 5_000)).rejects.toThrow(/exit code 1/);
+		const tolerated = await runner.run("fail-ok", "false", 5_000, { allowFailure: true });
+		expect(tolerated.exitCode).toBe(1);
+	});
+});
+
+describe("StepRunner.runDetached", () => {
+	// A fake sandbox whose filesystem reports the done-file present after `readyAfter` polls and
+	// serves canned log/exit-code contents — the detached transport's two reads.
+	function detachedSandbox(opts: { readyAfter?: number; exitCode?: string; log?: string }): {
+		sandbox: SandboxHandle;
+		commands: Array<{ command: string; background?: boolean }>;
+	} {
+		const commands: Array<{ command: string; background?: boolean }> = [];
+		let polls = 0;
+		const sandbox: SandboxHandle = {
+			runCommand: async (command, options) => {
+				commands.push({ command, background: options?.background });
+				return { exitCode: 0, stdout: "" };
+			},
+			destroy: async () => undefined,
+			filesystem: {
+				exists: async (path) => path.endsWith(".done") && polls++ >= (opts.readyAfter ?? 0),
+				readFile: async (path) =>
+					path.endsWith(".done") ? (opts.exitCode ?? "0") : (opts.log ?? "benchmark output"),
+			},
+		};
+		return { sandbox, commands };
+	}
+
+	it("starts the step in the background and returns the polled log + exit code", async () => {
+		const { sandbox, commands } = detachedSandbox({ log: "ran on the host", exitCode: "0\n" });
+		const runner = new StepRunner(sandbox);
+
+		const result = await runner.runDetached("bench", "mise run benchmark", 60_000);
+
+		expect(result.exitCode).toBe(0);
+		expect(result.stdout).toBe("ran on the host");
+		// First command is the detached start, flagged background; never a synchronous foreground exec.
+		expect(commands[0]?.background).toBe(true);
+		expect(commands[0]?.command).toContain("nohup setsid");
+		expect(runner.stepLog).toHaveLength(1);
+		expect(runner.stepLog[0]).toMatchObject({ label: "bench", exitCode: 0 });
+	});
+
+	it("propagates a non-zero detached exit code as a failure", async () => {
+		const { sandbox } = detachedSandbox({ exitCode: "42" });
+		const runner = new StepRunner(sandbox);
+		await expect(runner.runDetached("bench", "false", 60_000)).rejects.toThrow(/exit code 42/);
+	});
+
+	it("times out (and best-effort kills) when the done-file never appears", async () => {
+		// exists always false → never ready; a 0ms budget trips the deadline on the first poll.
+		const commands: string[] = [];
+		const sandbox: SandboxHandle = {
+			runCommand: async (command) => {
+				commands.push(command);
+				return { exitCode: 0, stdout: "" };
+			},
+			destroy: async () => undefined,
+			filesystem: { exists: async () => false, readFile: async () => "" },
+		};
+		const runner = new StepRunner(sandbox);
+		await expect(runner.runDetached("bench", "sleep 999", 0)).rejects.toThrow(/timed out/);
+		expect(commands.some((c) => c.includes("pkill"))).toBe(true);
+	});
+
+	it("falls back to the foreground transport when the sandbox has no filesystem", async () => {
+		const commands: string[] = [];
+		const sandbox: SandboxHandle = {
+			runCommand: async (command) => {
+				commands.push(command);
+				return { exitCode: 0, stdout: "fg" };
+			},
+			destroy: async () => undefined,
+		};
+		const runner = new StepRunner(sandbox);
+		const result = await runner.runDetached("bench", "echo hi", 5_000);
+		expect(result.stdout).toBe("fg");
+		// Foreground path: a single synchronous bash -c exec, no background flag, no detach wrapper.
+		expect(commands[0]).toContain("bash -c");
+		expect(commands[0]).not.toContain("nohup setsid");
+	});
+});

--- a/packages/harness/src/lib/execute.ts
+++ b/packages/harness/src/lib/execute.ts
@@ -1,0 +1,258 @@
+/**
+ * Suite-step execution against a live sandbox: the in-sandbox shell preamble, a liveness heartbeat,
+ * a per-step timeout, and per-phase wall-time accounting. Two transports:
+ *
+ *   - {@link StepRunner.run}: a direct synchronous exec. Fine for short steps, but NOT durable for
+ *     long ones: Daytona's synchronous executeCommand returns HTTP 408 on multi-minute commands
+ *     while the process keeps running server-side, and computesdk's Daytona adapter doesn't stream
+ *     (it ignores onStdout/onStderr).
+ *   - {@link StepRunner.runDetached}: starts the step in the background (computesdk's `background:true`,
+ *     fully detached with nohup+setsid) writing its output to a log file and its exit code to a
+ *     done-file, then polls the sandbox filesystem until the done-file appears. This survives the
+ *     408-prone exec round-trip, so multi-minute benchmarks complete. Falls back to `run` when the
+ *     sandbox exposes no filesystem (the unit-test fakes) — correctness is unchanged, only durability.
+ */
+
+import { randomUUID } from "node:crypto";
+
+export const MIN = 60_000;
+
+/** Poll cadence for {@link StepRunner.runDetached} while it waits on a detached step's done-file. */
+const POLL_MS = 10_000;
+const delay = (ms: number): Promise<void> => new Promise((resolve) => setTimeout(resolve, ms));
+
+export type Phase = "create" | "setup" | "benchmark" | "collect";
+
+export interface StepLogEntry {
+	phase: Phase;
+	label: string;
+	ms: number;
+	exitCode: number | null;
+}
+
+/** The result of one in-sandbox command. */
+export interface CommandResult {
+	exitCode: number;
+	stdout?: string;
+	stderr?: string;
+}
+
+/** Options for one in-sandbox command (a subset of computesdk's RunCommandOptions). */
+export interface RunCommandOptions {
+	/** Start detached and return immediately, rather than waiting for the command to finish. */
+	background?: boolean;
+}
+
+/** The slice of a computesdk sandbox filesystem the detached transport polls (its `filesystem` satisfies this). */
+export interface SandboxFilesystem {
+	readFile(path: string): Promise<string>;
+	exists(path: string): Promise<boolean>;
+}
+
+/** The slice of a computesdk sandbox the suite runner needs (its `Sandbox` satisfies this). */
+export interface SandboxHandle {
+	runCommand(command: string, options?: RunCommandOptions): Promise<CommandResult>;
+	destroy(): Promise<unknown>;
+	/** Present on real computesdk sandboxes; enables the durable detached transport for long steps. */
+	filesystem?: SandboxFilesystem;
+}
+
+export interface StepOptions {
+	allowFailure?: boolean;
+	/** Suppress echoing stdout/stderr (for steps that emit bulk data, e.g. the base64 results tar).
+	 *  A silent step that fails still emits its stderr, so failures stay debuggable. */
+	silent?: boolean;
+}
+
+/** Race a promise against a timeout, clearing the timer either way. */
+export async function withTimeout<T>(promise: Promise<T>, ms: number, message: string): Promise<T> {
+	let timer: ReturnType<typeof setTimeout> | undefined;
+	try {
+		return await Promise.race([
+			promise,
+			new Promise<never>((_, reject) => {
+				timer = setTimeout(() => reject(new Error(message)), ms);
+			}),
+		]);
+	} finally {
+		if (timer) clearTimeout(timer);
+	}
+}
+
+/** Single-quote a script for safe embedding in `bash -c '<script>'`. */
+export function shellQuote(script: string): string {
+	return `'${script.replace(/'/g, `'\\''`)}'`;
+}
+
+/**
+ * Re-establish env + PATH on every step (each runCommand is a fresh shell). `$SUDO` covers both root
+ * images (no prefix) and non-root images with sudo. The toolchain image (packages/templates/images)
+ * installs mise globally under /mise, so prefer it when present.
+ */
+export const PREAMBLE = [
+	"set -eo pipefail",
+	"export DEBIAN_FRONTEND=noninteractive",
+	// biome-ignore lint/suspicious/noTemplateCurlyInString: bash expansion, not a JS template
+	'export HOME="${HOME:-/root}"',
+	'export PATH="$HOME/.local/bin:$HOME/.local/share/mise/shims:$PATH"',
+	'if [ -d /mise ]; then export MISE_DATA_DIR=/mise MISE_CONFIG_DIR=/mise MISE_CACHE_DIR=/mise/cache PATH="/mise/shims:$PATH"; fi',
+	// Some sandbox networks reset connections to *.jdx.dev — fetch versions/tools from GitHub instead.
+	"export MISE_USE_VERSIONS_HOST=0",
+	// The precompiled-python index is jdx.dev-only (no GitHub fallback) — use the distro python3.
+	"export MISE_DISABLE_TOOLS=python",
+	// Distro pythons are PEP 668 externally-managed, but PTS profiles pip-install their harness —
+	// fine in a throwaway sandbox; the baked image sets the same.
+	"export PIP_BREAK_SYSTEM_PACKAGES=1",
+	// Honour each PTS profile's TimesToRun (lib/bench.sh otherwise forces a single pass). The sandbox
+	// is the statistical-confidence path: the in-sandbox repeats give p50/stdev per Metric.
+	"export PTS_RESPECT_TIMES_TO_RUN=1",
+	'if [ "$(id -u)" = 0 ]; then SUDO=""; elif command -v sudo >/dev/null 2>&1; then SUDO="sudo -E"; else SUDO=""; fi',
+].join("; ");
+
+/** Print liveness every 2 min while a long step runs — exec transports buffer output, so without
+ *  this a healthy multi-minute benchmark looks hung in the CI log. */
+const HEARTBEAT_MS = 2 * MIN;
+function startHeartbeat(label: string, startedAt: number, timeoutMs: number): () => void {
+	const timer = setInterval(() => {
+		const elapsedMin = Math.round((performance.now() - startedAt) / MIN);
+		console.log(`    [${label}] still running (${elapsedMin}m of ${Math.round(timeoutMs / MIN)}m)`);
+	}, HEARTBEAT_MS);
+	timer.unref?.();
+	return () => clearInterval(timer);
+}
+
+/**
+ * Runs suite steps against one sandbox, charging each step's elapsed wall time to the current Phase
+ * (`phase` is mutated by the orchestrator as the job progresses). One instance per sandbox/suite job.
+ */
+export class StepRunner {
+	/** The phase subsequent steps are charged to. */
+	phase: Phase = "setup";
+	/** Every executed step with its phase, elapsed ms, and exit code. */
+	readonly stepLog: StepLogEntry[] = [];
+
+	constructor(private readonly sandbox: SandboxHandle) {}
+
+	/**
+	 * Synchronous foreground exec — for short steps. The timeout is a wait-cap, not a kill: on timeout
+	 * the host stops waiting but the in-sandbox process keeps running server-side until job teardown
+	 * destroys the sandbox. Use {@link runDetached} for long steps, which can 408 here and which it
+	 * best-effort kills on timeout.
+	 */
+	async run(
+		label: string,
+		script: string,
+		timeoutMs: number,
+		opts: StepOptions = {},
+	): Promise<CommandResult> {
+		console.log(`\n=== [${label}] ===`);
+		const started = performance.now();
+		const stopHeartbeat = startHeartbeat(label, started, timeoutMs);
+		let result: CommandResult;
+		try {
+			result = await withTimeout(
+				this.sandbox.runCommand(`bash -c ${shellQuote(`${PREAMBLE}; ${script}`)}`),
+				timeoutMs,
+				`Step "${label}" timed out after ${Math.round(timeoutMs / 1000)}s`,
+			);
+		} finally {
+			stopHeartbeat();
+		}
+		return this.finishStep(label, started, result, opts);
+	}
+
+	/**
+	 * Run a long step on the durable detached transport: start it in the background (output → log
+	 * file, exit code → done-file), then poll the sandbox filesystem until the done-file appears and
+	 * read both back. Survives Daytona's 408 on multi-minute synchronous execs. On timeout the
+	 * detached job is best-effort killed; the job teardown's `destroy()` is the backstop either way.
+	 *
+	 * Requires a sandbox filesystem; without one (the unit-test fakes) it transparently delegates to
+	 * {@link run}, so behavior is identical save for durability.
+	 */
+	async runDetached(
+		label: string,
+		script: string,
+		timeoutMs: number,
+		opts: StepOptions = {},
+	): Promise<CommandResult> {
+		const fs = this.sandbox.filesystem;
+		if (!fs) return this.run(label, script, timeoutMs, opts);
+
+		console.log(`\n=== [${label}] (detached) ===`);
+		const started = performance.now();
+		const stopHeartbeat = startHeartbeat(label, started, timeoutMs);
+		const tag = `bench-${randomUUID()}`;
+		const logPath = `/tmp/${tag}.log`;
+		const donePath = `/tmp/${tag}.done`;
+		try {
+			// Start fully detached so the job outlives the (short-lived, 408-prone) exec round-trip.
+			// The `&&/||` capture keeps the script's exit code without letting the preamble's `set -e`
+			// abort before the done-file is written — success writes 0, failure writes the real code.
+			const wrapped =
+				`${PREAMBLE}; { ${script}; } > ${logPath} 2>&1 ` +
+				`&& echo 0 > ${donePath} || echo $? > ${donePath}`;
+			await this.sandbox.runCommand(
+				`nohup setsid bash -c ${shellQuote(wrapped)} >/dev/null 2>&1 &`,
+				{
+					background: true,
+				},
+			);
+
+			const deadline = started + timeoutMs;
+			while (!(await fs.exists(donePath))) {
+				if (performance.now() > deadline) {
+					// Best-effort stop the detached job; don't let a failing kill mask the timeout.
+					await this.sandbox
+						.runCommand(`pkill -f ${shellQuote(tag)} || true`)
+						.catch(() => undefined);
+					throw new Error(`Step "${label}" timed out after ${Math.round(timeoutMs / 1000)}s`);
+				}
+				await delay(POLL_MS);
+			}
+
+			const exitCode = Number.parseInt((await fs.readFile(donePath)).trim(), 10);
+			const stdout = await fs.readFile(logPath).catch(() => "");
+			const result: CommandResult = { exitCode: Number.isFinite(exitCode) ? exitCode : 1, stdout };
+			return this.finishStep(label, started, result, opts);
+		} finally {
+			stopHeartbeat();
+		}
+	}
+
+	/** Shared post-step bookkeeping: record the step, echo output (unless silent), enforce exit code. */
+	private finishStep(
+		label: string,
+		started: number,
+		result: CommandResult,
+		opts: StepOptions,
+	): CommandResult {
+		const elapsedMs = Math.round(performance.now() - started);
+		const elapsedS = (elapsedMs / 1000).toFixed(1);
+		this.stepLog.push({
+			phase: this.phase,
+			label,
+			ms: elapsedMs,
+			exitCode: result.exitCode,
+		});
+
+		if (result.stdout && !opts.silent) {
+			process.stdout.write(result.stdout.endsWith("\n") ? result.stdout : `${result.stdout}\n`);
+		}
+		if (result.stderr && !opts.silent) {
+			process.stderr.write(result.stderr.endsWith("\n") ? result.stderr : `${result.stderr}\n`);
+		}
+		console.log(`=== [${label}] exit ${result.exitCode} in ${elapsedS}s ===`);
+
+		if (result.exitCode !== 0 && !opts.allowFailure) {
+			// A silent step withheld its output above; surface it now so the failure is debuggable. The
+			// detached transport merges stderr into stdout (2>&1), so fall back to stdout when no stderr.
+			if (opts.silent) {
+				const tail = result.stderr || result.stdout;
+				if (tail) process.stderr.write(tail.endsWith("\n") ? tail : `${tail}\n`);
+			}
+			throw new Error(`Step "${label}" failed with exit code ${result.exitCode}`);
+		}
+		return result;
+	}
+}


### PR DESCRIPTION
The harness execution layer: `StepRunner`, `withTimeout`, `shellQuote`/`PREAMBLE`, and the `MIN` unit — the primitive every later stage (setup, collect, runner) builds on. Two transports:

- `run()` — synchronous foreground exec for short steps. Its timeout is a wait-cap, not a kill.
- `runDetached()` — the **durable transport that unblocks the live path**. It starts a step fully detached (`nohup setsid`, computesdk `background:true`), redirects output to a log file and the exit code to a done-file, then polls the sandbox filesystem until completion. This is what lets a multi-minute benchmark survive Daytona's synchronous-exec **HTTP 408** (the process keeps running server-side while the foreground round-trip dies). Falls back to `run()` when the sandbox exposes no filesystem.

`SandboxHandle` gains an optional `filesystem` slice and `runCommand(..., { background })`. This is the keystone that de-risks "node benchmarking runs end-to-end on the primary provider": #42 (collect) and #43 (benchmark + long setup installs) all execute over it. No local deps.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a sandbox step runner with per-step timeouts, 2‑minute heartbeats, and phase tracking. Adds a durable detached transport for long steps that survives multi‑minute runs and best‑effort kills on timeout; no new dependencies.

- **New Features**
  - Step runner: runs via bash with a `PREAMBLE`, records phase/label/ms/exitCode, echoes stdout/stderr (optional `silent`), supports `allowFailure`. Foreground `run()` timeout is a wait-cap, not a kill.
  - Detached transport: starts fully detached (`nohup` + `setsid`, `{ background:true }`), writes `/tmp/<tag>.log` and `/tmp/<tag>.done`, polls every 10s, reads log/exit code; uses `&&/||` to capture exit despite `set -e`; best‑effort `pkill` on timeout; falls back to `run()` if no filesystem.
  - API/utilities: `withTimeout`, `shellQuote`, `MIN`. `SandboxHandle` adds optional `filesystem` and `runCommand(..., { background })`.

- **Tests**
  - Validates quoting/`PREAMBLE` and non‑zero propagation with `allowFailure`.
  - Covers detached start + poll + read, timeout + kill, and foreground fallback.

<sup>Written for commit 24642ab00f8b9938a95627387b7d675e905bd31f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/starslingdev/sandbox-benchmarks/pull/40?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

