### PR TITLE
feat(harness): result collection + skip markers

### DIFF
--- a/packages/harness/src/lib/collect.test.ts
+++ b/packages/harness/src/lib/collect.test.ts
@@ -1,0 +1,88 @@
+import { afterAll, describe, expect, it } from "bun:test";
+import { execFileSync } from "node:child_process";
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { harnessSkipMarkerJson } from "@sandbox-benchmarks/schema";
+import { collectResults, writeSkipMarker } from "./collect.ts";
+import type { SandboxHandle } from "./execute.ts";
+import { StepRunner } from "./execute.ts";
+
+const work = mkdtempSync(join(tmpdir(), "harness-collect-"));
+afterAll(() => rmSync(work, { recursive: true, force: true }));
+
+// Build the exact stdout the in-sandbox collect command emits: markers around a base64'd tar of a
+// benchmark-results/ directory holding the given files (name → contents).
+function collectPayload(files: Record<string, string>): string {
+	const src = mkdtempSync(join(tmpdir(), "harness-src-"));
+	mkdirSync(join(src, "benchmark-results"), { recursive: true });
+	for (const [name, contents] of Object.entries(files)) {
+		writeFileSync(join(src, "benchmark-results", name), contents);
+	}
+	const b64 = execFileSync("bash", ["-c", "tar -czf - benchmark-results | base64 | tr -d '\\n'"], {
+		cwd: src,
+		encoding: "utf8",
+	});
+	rmSync(src, { recursive: true, force: true });
+	return `noise\n__BENCH_RESULTS_TGZ_BEGIN__\n${b64}\n__BENCH_RESULTS_TGZ_END__\ntrailing\n`;
+}
+
+function payloadSandbox(files: Record<string, string>): SandboxHandle {
+	return {
+		runCommand: async () => ({ exitCode: 0, stdout: collectPayload(files) }),
+		destroy: async () => undefined,
+	};
+}
+
+const sandbox = payloadSandbox({ "pts_node-web-tooling.xml": "<xml/>" });
+
+describe("collectResults", () => {
+	it("extracts the base64 tar stream into the results directory", async () => {
+		const resultsDir = join(work, "daytona");
+		await collectResults(new StepRunner(sandbox), resultsDir);
+		expect(existsSync(join(resultsDir, "pts_node-web-tooling.xml"))).toBe(true);
+		expect(readFileSync(join(resultsDir, "pts_node-web-tooling.xml"), "utf8")).toBe("<xml/>");
+	});
+
+	it("accepts a results tree whose only signal is a skip marker", async () => {
+		const resultsDir = join(work, "skip-only");
+		const skipped = payloadSandbox({
+			"pts_node-web-tooling--skipped.json": '{"skipped":true,"benchmark":"pts_node-web-tooling"}',
+			"manifest.ndjson": "{}\n",
+		});
+		await collectResults(new StepRunner(skipped), resultsDir);
+		expect(existsSync(join(resultsDir, "pts_node-web-tooling--skipped.json"))).toBe(true);
+	});
+
+	it("throws when the collected tree has no PTS result or skip marker (silent data loss)", async () => {
+		// A suite that produced only provenance/timing files and neither a result nor a marker must
+		// fail collection, not upload an empty-of-signal directory as a green run.
+		const empty = payloadSandbox({ "manifest.ndjson": "{}\n", "cpu-info.json": "{}" });
+		await expect(collectResults(new StepRunner(empty), join(work, "no-signal"))).rejects.toThrow(
+			/no PTS result or skip marker/,
+		);
+	});
+
+	it("throws when the payload markers are missing", async () => {
+		const noMarkers: SandboxHandle = {
+			runCommand: async () => ({ exitCode: 0, stdout: "no markers here" }),
+			destroy: async () => undefined,
+		};
+		await expect(collectResults(new StepRunner(noMarkers), join(work, "x"))).rejects.toThrow(
+			/markers/,
+		);
+	});
+});
+
+describe("writeSkipMarker", () => {
+	it("writes the harness skip marker the normalizer reads", () => {
+		const dir = join(work, "skip");
+		writeSkipMarker(dir, "daytona", "cpu-node", "Missing credentials");
+		// Pin the exact bytes, not just a shape: the producer/harness/normalizer share
+		// harnessSkipMarkerJson as the single source of truth, so a key-order or newline drift here
+		// would silently break the cross-package contract.
+		expect(readFileSync(join(dir, "sandbox-daytona-cpu-node--skipped.json"), "utf8")).toBe(
+			harnessSkipMarkerJson("daytona", "cpu-node", "Missing credentials"),
+		);
+	});
+});

--- a/packages/harness/src/lib/collect.ts
+++ b/packages/harness/src/lib/collect.ts
@@ -1,0 +1,96 @@
+/**
+ * Results collection for a suite run: pulls benchmark-results/ back to the host via a base64 tar
+ * stream over stdout (no temp file in the sandbox, so it works even when the sandbox disk is full —
+ * exactly when partial results matter), and writes harness skip markers. The pulled files are the
+ * raw inputs the normalizer consumes — the committed raw tool output is the dataset's source of truth.
+ */
+import { execFileSync } from "node:child_process";
+import { randomUUID } from "node:crypto";
+import { cpSync, mkdirSync, readdirSync, rmSync, statSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import {
+	harnessSkipMarkerJson,
+	isPtsResultFile,
+	isSkipMarkerFile,
+	sandboxSkipMarkerFile,
+} from "@sandbox-benchmarks/schema";
+import type { StepRunner } from "./execute.ts";
+import { MIN } from "./execute.ts";
+import { DIR } from "./setup.ts";
+
+const RESULTS_BEGIN = "__BENCH_RESULTS_TGZ_BEGIN__";
+const RESULTS_END = "__BENCH_RESULTS_TGZ_END__";
+
+/** Pull the sandbox's benchmark-results/ into `resultsDir` on the host. */
+export async function collectResults(runner: StepRunner, resultsDir: string): Promise<void> {
+	runner.phase = "collect";
+	// Detached transport: the tar|base64 payload lands in the step's log file and is read back, so a
+	// large or slow collect can't 408 the synchronous exec mid-stream (the path long steps use). The
+	// BEGIN/END markers still bound the base64 within that captured output.
+	const result = await runner.runDetached(
+		"collect benchmark-results",
+		`cd ${DIR} && mkdir -p benchmark-results && ` +
+			`echo ${RESULTS_BEGIN} && tar -czf - benchmark-results | base64 | tr -d '\\n' && echo && echo ${RESULTS_END}`,
+		5 * MIN,
+		// Silent: the step's stdout IS the base64 tarball — echoing it would flood the CI log.
+		{ silent: true },
+	);
+
+	const stdout = result.stdout || "";
+	const begin = stdout.indexOf(RESULTS_BEGIN);
+	const end = stdout.indexOf(RESULTS_END);
+	if (begin === -1 || end === -1 || end <= begin) {
+		throw new Error("Could not locate results payload markers in sandbox output");
+	}
+	const base64 = stdout.slice(begin + RESULTS_BEGIN.length, end).trim();
+
+	// Decode straight to disk via the "base64" write encoding — avoids a Node-only Buffer in the
+	// cross-runtime package code. A random suffix keeps concurrent collects from colliding.
+	const archive = join(tmpdir(), `bench-results-${process.pid}-${randomUUID()}.tgz`);
+	try {
+		writeFileSync(archive, base64, "base64");
+		const target = resolve(resultsDir);
+		// The tarball holds a top-level benchmark-results/ directory. Extract into a unique staging
+		// dir (not `parent`, which is shared across providers) so concurrent collects can't clobber
+		// each other, then copy its contents into the target (`<provider>`, not `benchmark-results`).
+		const stage = join(tmpdir(), `bench-extract-${process.pid}-${randomUUID()}`);
+		mkdirSync(stage, { recursive: true });
+		try {
+			execFileSync("tar", ["-xzf", archive, "-C", stage]);
+			cpSync(join(stage, "benchmark-results"), target, { recursive: true });
+		} finally {
+			rmSync(stage, { recursive: true, force: true });
+		}
+		// Validate the collected tree carries real signal: at least one PTS result or skip marker
+		// (the #39 naming contract). A suite that produced neither — the benchmark crashed before
+		// writing anything AND no marker was recorded — is silent data loss; fail loudly here rather
+		// than let an empty results directory upload and report as a green run.
+		const collected = readdirSync(target);
+		if (!collected.some((name) => isPtsResultFile(name) || isSkipMarkerFile(name))) {
+			throw new Error(
+				`Collected results for ${resultsDir} contain no PTS result or skip marker ` +
+					`(found: ${collected.join(", ") || "nothing"}); the suite produced no usable output`,
+			);
+		}
+		console.log(
+			`Results extracted to ${resultsDir} (${(statSync(archive).size / 1024).toFixed(1)} KiB archive)`,
+		);
+	} finally {
+		rmSync(archive, { force: true });
+	}
+}
+
+/** Write a harness skip marker (whole suite × provider never ran) into the results directory. */
+export function writeSkipMarker(
+	resultsDir: string,
+	provider: string,
+	suite: string,
+	reason: string,
+): void {
+	mkdirSync(resultsDir, { recursive: true });
+	writeFileSync(
+		join(resultsDir, sandboxSkipMarkerFile(provider, suite)),
+		harnessSkipMarkerJson(provider, suite, reason),
+	);
+}


### PR DESCRIPTION
`collectResults` and `writeSkipMarker` — pull the sandbox's `benchmark-results/` back to the host and record suite-level skips. Builds on #40 (`StepRunner`, `runDetached`, `MIN`) and #41 (`DIR`).

Two things make this a de-risking step, not just a copy:
- It runs over the **durable detached transport** (#40), so a large or slow result pull can't 408 mid-stream the way a synchronous exec would.
- After extracting the tarball it **validates the tree against the #39 naming contract** — at least one `pts_*.xml` result or a `*--skipped.json` marker — and fails otherwise. A benchmark that produced nothing can no longer upload an empty results dir and report green.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Collect sandbox `benchmark-results/` via a durable detached base64 tgz stream and extract on the host. Validates payload markers and requires at least one PTS result or skip marker to prevent empty green runs.

- **New Features**
  - `collectResults`: uses `runDetached` with BEGIN/END markers; decodes base64 to a temp archive, extracts to a per-run staging dir, copies into `resultsDir`, cleans up; enforces at least one `isPtsResultFile` or `isSkipMarkerFile`; silent to avoid log spam; resilient to disk pressure and concurrent runs; logs archive size.
  - `writeSkipMarker`: writes `sandbox-<provider>-<suite>--skipped.json` using `harnessSkipMarkerJson` and `sandboxSkipMarkerFile` from `@sandbox-benchmarks/schema`.

<sup>Written for commit 512fc7dfce1f635115c1eb2eac747ee940ca76d2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/starslingdev/sandbox-benchmarks/pull/42?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

