### PR TITLE
feat(harness,cli): live suite runner wiring

### DIFF
--- a/apps/cli/src/bin/bench-suite.ts
+++ b/apps/cli/src/bin/bench-suite.ts
@@ -1,20 +1,37 @@
 #!/usr/bin/env bun
-// `bench-suite` — run the full benchmark suite across the matrix (stub).
+// `bench-suite` — run a benchmark suite on a provider sandbox, collect the raw results into a
+// data/raw tree, and normalize them into a validated Run document. Missing provider credentials are
+// recorded as a skip (the provider stays `pending` in the Run), so this is runnable without secrets.
 
-import { timeOperation } from "@sandbox-benchmarks/harness";
-import type { ProviderConfig } from "@sandbox-benchmarks/providers";
-import { providers } from "@sandbox-benchmarks/providers";
-import { buildMatrix } from "../lib/matrix.ts";
+import { join } from "node:path";
+import { runSuite, SuiteUsageError } from "@sandbox-benchmarks/harness";
+import { summarizeRun, writeNormalizedRun } from "@sandbox-benchmarks/results";
 
 if (import.meta.main) {
-	// Keyed by string: the matrix yields arbitrary provider names, and the guard below rejects any
-	// that isn't registered (the providers list is keyed by ProviderId, the matrix is not).
-	const byName = new Map<string, ProviderConfig>(providers.map((p) => [p.name, p]));
-	const runs = [];
-	for (const { provider, operation } of buildMatrix()) {
-		const config = byName.get(provider);
-		if (!config) throw new Error(`provider "${provider}" is not registered`);
-		runs.push(await timeOperation(config, operation, () => {}));
+	const provider = process.argv[2] ?? "daytona";
+	const suite = process.argv[3] ?? "cpu-node";
+	const runId = process.argv[4] ?? `local-${Date.now()}`;
+	const sha = process.env.GITHUB_SHA ?? "local";
+
+	const rawRoot = join("data", "raw", runId);
+	const outFile = join("data", "runs", `${runId}.json`);
+	const indexFile = join("data", "runs", "index.json");
+
+	try {
+		await runSuite({
+			providerName: provider,
+			suiteName: suite,
+			resultsDir: join(rawRoot, provider),
+		});
+	} catch (err) {
+		if (err instanceof SuiteUsageError) {
+			console.error(err.message);
+			process.exit(1);
+		}
+		throw err;
 	}
-	console.log(JSON.stringify({ runs }));
+
+	const run = writeNormalizedRun({ rawRoot, runId, sha, outFile, updateIndexFile: indexFile });
+	console.log(`\nNormalized Run ${runId} → ${outFile}`);
+	for (const line of summarizeRun(run)) console.log(line);
 }

--- a/packages/harness/src/index.test.ts
+++ b/packages/harness/src/index.test.ts
@@ -1,6 +1,12 @@
-import { describe, expect, it } from "bun:test";
+import { afterAll, describe, expect, it } from "bun:test";
+import { execFileSync } from "node:child_process";
+import { existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import type { ProviderConfig } from "@sandbox-benchmarks/providers";
-import { timeOperation } from "./index.ts";
+import type { Suite } from "@sandbox-benchmarks/schema";
+import { runSuite, runSuiteOnSandbox, SuiteUsageError, timeOperation } from "./index.ts";
+import type { SandboxHandle } from "./lib/execute.ts";
 
 // timeOperation only reads identity, never calls createCompute — a throwing stub keeps this unit
 // test free of any real SDK while staying fully typed.
@@ -18,5 +24,157 @@ describe("@sandbox-benchmarks/harness", () => {
 		expect(run.provider).toBe("e2b");
 		expect(run.operation).toBe("spawn");
 		expect(run.durationMs).toBeGreaterThan(0);
+	});
+});
+
+const work = mkdtempSync(join(tmpdir(), "harness-runsuite-"));
+afterAll(() => rmSync(work, { recursive: true, force: true }));
+
+let dirSeq = 0;
+const freshDir = (): string => join(work, `r${dirSeq++}`);
+
+// Build the stdout the in-sandbox collect command emits: BEGIN/END markers around a base64'd tar of a
+// benchmark-results/ directory holding the given files — what runSuiteOnSandbox extracts.
+function collectPayload(files: Record<string, string>): string {
+	const src = mkdtempSync(join(tmpdir(), "harness-collect-src-"));
+	mkdirSync(join(src, "benchmark-results"), { recursive: true });
+	for (const [name, contents] of Object.entries(files)) {
+		writeFileSync(join(src, "benchmark-results", name), contents);
+	}
+	const b64 = execFileSync("bash", ["-c", "tar -czf - benchmark-results | base64 | tr -d '\\n'"], {
+		cwd: src,
+		encoding: "utf8",
+	});
+	rmSync(src, { recursive: true, force: true });
+	return `__BENCH_RESULTS_TGZ_BEGIN__\n${b64}\n__BENCH_RESULTS_TGZ_END__\n`;
+}
+
+// A fake sandbox that dispatches on command content: the disk probe, the benchmark command (token
+// `benchmark-cmd`), and the base64 collect stream. No filesystem, so runDetached uses the foreground
+// path. `destroyed` flips when teardown runs.
+function makeSandbox(opts: {
+	freeKb?: string;
+	benchmarkFails?: boolean;
+	collectFails?: boolean;
+	collectFiles?: Record<string, string>;
+	destroyed: { hit: boolean };
+}): SandboxHandle {
+	return {
+		async runCommand(command) {
+			if (command.includes("df -Pk")) return { exitCode: 0, stdout: opts.freeKb ?? "999999999" };
+			if (command.includes("base64")) {
+				if (opts.collectFails) return { exitCode: 1, stderr: "collect boom" };
+				const files = opts.collectFiles ?? { "pts_node-web-tooling.xml": "<xml/>" };
+				return { exitCode: 0, stdout: collectPayload(files) };
+			}
+			if (command.includes("benchmark-cmd")) {
+				return opts.benchmarkFails ? { exitCode: 1, stderr: "bench boom" } : { exitCode: 0 };
+			}
+			return { exitCode: 0, stdout: "" };
+		},
+		async destroy() {
+			opts.destroyed.hit = true;
+			return undefined;
+		},
+	};
+}
+
+const suite = (overrides: Partial<Suite>): Suite => ({
+	commandTimeoutMinutes: 1,
+	timeoutMinutes: 1,
+	commands: ["benchmark-cmd"],
+	...overrides,
+});
+
+const ctx = (s: Suite, resultsDir: string) => ({
+	suite: s,
+	suiteName: "cpu-node",
+	providerName: "daytona",
+	resultsDir,
+});
+
+describe("runSuite (resolution + credential gate)", () => {
+	it("rejects an unknown suite as a usage error", async () => {
+		await expect(
+			runSuite({ providerName: "daytona", suiteName: "nope", resultsDir: freshDir() }),
+		).rejects.toBeInstanceOf(SuiteUsageError);
+	});
+
+	it("rejects an unknown provider as a usage error", async () => {
+		await expect(
+			runSuite({ providerName: "nope", suiteName: "cpu-node", resultsDir: freshDir() }),
+		).rejects.toBeInstanceOf(SuiteUsageError);
+	});
+
+	it("records a skip marker (not a failure) when credentials are missing", async () => {
+		const resultsDir = freshDir();
+		// Empty env → daytona's required key is absent, so the suite skips before any sandbox is created.
+		await runSuite({ providerName: "daytona", suiteName: "cpu-node", resultsDir, env: {} });
+		expect(existsSync(join(resultsDir, "sandbox-daytona-cpu-node--skipped.json"))).toBe(true);
+	});
+});
+
+describe("runSuiteOnSandbox (orchestration + teardown)", () => {
+	it("runs the suite, collects results, and tears the sandbox down", async () => {
+		const resultsDir = freshDir();
+		const destroyed = { hit: false };
+		const sandbox = makeSandbox({
+			destroyed,
+			collectFiles: { "pts_node-web-tooling.xml": "<x/>" },
+		});
+		await runSuiteOnSandbox(sandbox, ctx(suite({ setupPts: true }), resultsDir));
+		expect(existsSync(join(resultsDir, "pts_node-web-tooling.xml"))).toBe(true);
+		expect(destroyed.hit).toBe(true);
+	});
+
+	it("tears the sandbox down even when the benchmark fails, and propagates the error", async () => {
+		const destroyed = { hit: false };
+		const sandbox = makeSandbox({ destroyed, benchmarkFails: true });
+		await expect(runSuiteOnSandbox(sandbox, ctx(suite({}), freshDir()))).rejects.toThrow(
+			/exit code 1/,
+		);
+		expect(destroyed.hit).toBe(true);
+	});
+
+	it("prefers the benchmark error over a later collect failure", async () => {
+		const destroyed = { hit: false };
+		const sandbox = makeSandbox({ destroyed, benchmarkFails: true, collectFails: true });
+		// The in-flight benchmark error wins; the collect failure is logged, not thrown.
+		await expect(runSuiteOnSandbox(sandbox, ctx(suite({}), freshDir()))).rejects.toThrow(
+			/bench boom|exit code 1/,
+		);
+		expect(destroyed.hit).toBe(true);
+	});
+
+	it("surfaces a collect failure when the benchmark succeeded", async () => {
+		const destroyed = { hit: false };
+		const sandbox = makeSandbox({ destroyed, collectFails: true });
+		await expect(runSuiteOnSandbox(sandbox, ctx(suite({}), freshDir()))).rejects.toThrow(
+			/exit code 1/,
+		);
+		expect(destroyed.hit).toBe(true);
+	});
+
+	it("skips (marker, no throw) and tears down when free disk is below the suite minimum", async () => {
+		const resultsDir = freshDir();
+		const destroyed = { hit: false };
+		// 1 KiB free, suite needs 50 GiB.
+		const sandbox = makeSandbox({ destroyed, freeKb: "1" });
+		await runSuiteOnSandbox(sandbox, ctx(suite({ minDiskGb: 50 }), resultsDir));
+		expect(existsSync(join(resultsDir, "sandbox-daytona-cpu-node--skipped.json"))).toBe(true);
+		expect(destroyed.hit).toBe(true);
+	});
+
+	it("fails a PTS suite that collected no pts_*.xml (silent PTS failure)", async () => {
+		const destroyed = { hit: false };
+		// Collect succeeds (a skip marker satisfies collection) but yields no pts_*.xml.
+		const sandbox = makeSandbox({
+			destroyed,
+			collectFiles: { "sandbox-daytona-cpu-node--skipped.json": '{"skipped":true}' },
+		});
+		await expect(
+			runSuiteOnSandbox(sandbox, ctx(suite({ setupPts: true }), freshDir())),
+		).rejects.toThrow(/no pts_\*\.xml/);
+		expect(destroyed.hit).toBe(true);
 	});
 });

--- a/packages/harness/src/index.ts
+++ b/packages/harness/src/index.ts
@@ -1,9 +1,17 @@
-// Public surface of @sandbox-benchmarks/harness — drives a provider and emits raw runs.
+// Public surface of @sandbox-benchmarks/harness — drives a provider to produce raw benchmark output.
+import { readdirSync } from "node:fs";
+import { resolve } from "node:path";
 import type { ProviderConfig } from "@sandbox-benchmarks/providers";
-import type { RawRun } from "@sandbox-benchmarks/schema";
+import { providers } from "@sandbox-benchmarks/providers";
+import type { RawRun, Suite } from "@sandbox-benchmarks/schema";
+import { isPtsResultFile, SUITES } from "@sandbox-benchmarks/schema";
+import { collectResults, writeSkipMarker } from "./lib/collect.ts";
+import type { SandboxHandle } from "./lib/execute.ts";
+import { MIN, StepRunner, withTimeout } from "./lib/execute.ts";
 import { now } from "./lib/internal.ts";
+import { DIR, OBSERVED_SPECS_SCRIPT, REPO_REF, REPO_URL, setupSteps } from "./lib/setup.ts";
 
-/** Time a single operation against a provider, producing a {@link RawRun}. Stub. */
+/** Time a single operation against a provider, producing a {@link RawRun}. Stub (lifecycle path). */
 export async function timeOperation(
 	config: ProviderConfig,
 	operation: string,
@@ -20,4 +28,192 @@ export async function timeOperation(
 		// synchronous no-op can observe two equal `now()` readings (a 0 delta).
 		durationMs: Math.max(now() - start, Number.EPSILON),
 	};
+}
+
+/** An unknown provider or suite is a usage error, distinct from an operational failure mid-run. */
+export class SuiteUsageError extends Error {}
+
+export interface RunSuiteOptions {
+	/** Provider to create the sandbox on — must be in the provider registry. */
+	providerName: string;
+	/** Suite to run — must be a key of SUITES. */
+	suiteName: string;
+	/** Host directory to extract results into (e.g. `data/raw/<runId>/<provider>`). */
+	resultsDir: string;
+	/** Credential source for the provider's required env vars (default: process.env). */
+	env?: Record<string, string | undefined>;
+}
+
+async function destroySandbox(sandbox: SandboxHandle | undefined): Promise<void> {
+	if (!sandbox) return;
+	try {
+		await withTimeout(Promise.resolve(sandbox.destroy()), 15_000, "Destroy timeout");
+	} catch (err) {
+		console.warn(`[cleanup] destroy failed: ${err instanceof Error ? err.message : String(err)}`);
+	}
+}
+
+/**
+ * Run a benchmark suite inside a provider sandbox: clone the repo (carrying the in-sandbox producer),
+ * run the suite's mise commands, and pull benchmark-results/ back to `resultsDir`. Uses the sandbox
+ * as a CI runner — it does NOT measure the sandbox lifecycle itself (that's the lifecycle path).
+ * Missing credentials or insufficient disk are recorded as skip markers, not failures.
+ */
+export async function runSuite(options: RunSuiteOptions): Promise<void> {
+	const { providerName, suiteName, env = process.env } = options;
+	const resultsDir = resolve(options.resultsDir);
+
+	const suite: Suite | undefined = (SUITES as Record<string, Suite>)[suiteName];
+	if (!suite) {
+		throw new SuiteUsageError(
+			`Unknown suite "${suiteName}". Known suites: ${Object.keys(SUITES).join(", ")}`,
+		);
+	}
+
+	const config = providers.find((p) => p.name === providerName);
+	if (!config) {
+		throw new SuiteUsageError(
+			`Unknown provider "${providerName}". Known providers: ${providers.map((p) => p.name).join(", ")}`,
+		);
+	}
+
+	const missingVars = config.requiredEnvVars.filter((v) => !env[v]);
+	if (missingVars.length > 0) {
+		const reason = `Missing credentials: ${missingVars.join(", ")}`;
+		console.log(`SKIPPED ${providerName}/${suiteName}: ${reason}`);
+		writeSkipMarker(resultsDir, providerName, suiteName, reason);
+		return;
+	}
+
+	console.log(`\n--- Sandbox suite: ${suiteName} on ${providerName} (${REPO_URL}@${REPO_REF}) ---`);
+
+	const compute = config.createCompute();
+
+	// Concurrent jobs share one provider account; quota/capacity errors mean "no slot right now", not
+	// "broken" — retry patiently so jobs self-serialize as earlier sandboxes are destroyed.
+	const CREATE_RETRY_BUDGET_MS = 60 * MIN;
+	const CREATE_RETRY_DELAY_MS = 2 * MIN;
+	const createDeadline = Date.now() + CREATE_RETRY_BUDGET_MS;
+	let sandbox: SandboxHandle | undefined;
+	for (let attempt = 1; ; attempt++) {
+		try {
+			sandbox = await withTimeout(
+				Promise.resolve(
+					compute.sandbox.create({
+						...config.createOptions,
+						// Ask for a sandbox lifetime covering setup + the suite, where supported.
+						timeout: suite.timeoutMinutes * MIN,
+					}),
+				),
+				5 * MIN,
+				"Sandbox creation timed out",
+			);
+			break;
+		} catch (err) {
+			const message = err instanceof Error ? err.message : String(err);
+			const capacity = /quota|rate.?limit|too many|capacity|429/i.test(message);
+			if (!capacity || Date.now() + CREATE_RETRY_DELAY_MS > createDeadline) throw err;
+			console.log(
+				`Sandbox create attempt ${attempt} hit a capacity limit (${message.slice(0, 140)}); ` +
+					`retrying in ${CREATE_RETRY_DELAY_MS / 1000}s...`,
+			);
+			await new Promise((r) => setTimeout(r, CREATE_RETRY_DELAY_MS));
+		}
+	}
+
+	await runSuiteOnSandbox(sandbox, { suite, suiteName, providerName, resultsDir });
+}
+
+/** The already-resolved context {@link runSuiteOnSandbox} runs against. */
+export interface SuiteRunContext {
+	suite: Suite;
+	suiteName: string;
+	providerName: string;
+	resultsDir: string;
+}
+
+/**
+ * Run a suite against an already-created sandbox, then tear it down (run-and-dispose). Split from
+ * {@link runSuite} so the orchestration — disk gate, setup, benchmark, result collection, the
+ * benchmark-vs-collect error precedence, and the always-runs teardown — is testable against a fake
+ * sandbox without provisioning a real one. Long steps (setup installs, the benchmark) run on the
+ * durable detached transport so Daytona's 408 on multi-minute synchronous execs can't truncate them.
+ */
+export async function runSuiteOnSandbox(
+	sandbox: SandboxHandle,
+	ctx: SuiteRunContext,
+): Promise<void> {
+	const { suite, suiteName, providerName, resultsDir } = ctx;
+	const runner = new StepRunner(sandbox);
+	let suiteError: unknown;
+	try {
+		runner.phase = "setup";
+		if (suite.minDiskGb) {
+			const df = await runner.run("check free disk", "df -Pk / | awk 'NR==2 {print $4}'", MIN);
+			// Treat non-numeric df output as 0 free (skip) — a NaN comparison would silently pass the check.
+			const freeKb = Number.parseInt((df.stdout || "").trim(), 10);
+			const freeGb = Number.isNaN(freeKb) ? 0 : freeKb / 1024 / 1024;
+			if (freeGb < suite.minDiskGb) {
+				const reason = `Insufficient disk: ${freeGb.toFixed(1)} GiB free, suite needs ${suite.minDiskGb} GiB`;
+				console.log(`SKIPPED ${providerName}/${suiteName}: ${reason}`);
+				writeSkipMarker(resultsDir, providerName, suiteName, reason);
+				return;
+			}
+		}
+
+		for (const step of setupSteps(suite)) {
+			const attempts = (step.retries ?? 0) + 1;
+			for (let attempt = 1; ; attempt++) {
+				try {
+					// Detached: a multi-minute install (mise/PTS/apt) would 408 a synchronous exec.
+					await runner.runDetached(step.label, step.script, step.timeoutMs);
+					break;
+				} catch (err) {
+					if (attempt >= attempts) throw err;
+					console.log(`Step "${step.label}" failed, retrying (${attempt + 1}/${attempts})...`);
+				}
+			}
+		}
+
+		// Observed specs are best-effort: a spec probe must never fail a Run (hence allowFailure below).
+		await runner.run("capture observed specs", OBSERVED_SPECS_SCRIPT, MIN, { allowFailure: true });
+
+		try {
+			runner.phase = "benchmark";
+			for (const command of suite.commands) {
+				// Detached: the cpu-node command budgets 110 min — far past Daytona's synchronous-exec 408.
+				await runner.runDetached(
+					command,
+					`cd ${DIR} && ${command}`,
+					suite.commandTimeoutMinutes * MIN,
+				);
+			}
+		} catch (err) {
+			// Still pull whatever results were produced before failing the job.
+			suiteError = err;
+		}
+
+		try {
+			await collectResults(runner, resultsDir);
+		} catch (collectErr) {
+			// A failed result-pull must not mask an in-flight benchmark error.
+			if (!suiteError) throw collectErr;
+			console.warn(
+				`[collect] failed after benchmark error: ${collectErr instanceof Error ? collectErr.message : String(collectErr)}`,
+			);
+		}
+
+		// PTS exits 0 even when a profile fails to install, so a broken environment yields a green job
+		// with an empty artifact — treat "no pts_*.xml from a PTS suite" as a failure.
+		if (!suiteError && suite.setupPts && !readdirSync(resultsDir).some(isPtsResultFile)) {
+			suiteError = new Error(
+				`Suite "${suiteName}" on ${providerName} produced no pts_*.xml — PTS likely failed silently`,
+			);
+		}
+	} finally {
+		await destroySandbox(sandbox);
+	}
+
+	if (suiteError) throw suiteError;
+	console.log(`\nDone: ${suiteName} on ${providerName}`);
 }


### PR DESCRIPTION
The live suite orchestrator (`runSuite` / `runSuiteOnSandbox` in the harness index) that sequences create → setup → benchmark → collect → normalize across a provider, plus the `bench-suite` CLI entrypoint that drives it.

`runSuite` resolves the provider/suite, records missing creds or low disk as skips, and retries capacity-limited sandbox creation. `runSuiteOnSandbox` runs the suite against the sandbox and always tears it down (run-and-dispose), executing the long setup installs and the benchmark over the **detached transport** (#40) so the 110-minute `cpu-node` run survives Daytona's 408. It collects results, fails a PTS suite that produced no `pts_*.xml`, and gives an in-flight benchmark error precedence over a later collect failure. Builds on #40/#41/#42.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a live suite runner to `@sandbox-benchmarks/harness` and wires the `bench-suite` CLI to run suites on provider sandboxes, collect raw results, and write a normalized Run. Long installs and benchmarks run detached to survive provider exec timeouts; capacity-limited sandbox creation is retried, and missing credentials or low disk are recorded as skips.

- **New Features**
  - `runSuite` + `runSuiteOnSandbox`: validate provider/suite (`SuiteUsageError`); write a skip marker when credentials are missing or free disk is below the suite minimum; retry sandbox creation on capacity limits; run setup steps detached with per-step timeouts and retries; capture observed specs (non-fatal); run benchmark commands detached; collect artifacts; fail PTS suites that produce no `pts_*.xml`; prefer an in-flight benchmark error over a later collect failure; always tear down the sandbox.
  - CLI `bench-suite`: args `provider` `suite` `[runId]` (defaults: `daytona`, `cpu-node`, `local-<ts>`); uses `GITHUB_SHA` when available; writes raw to `data/raw/<runId>/<provider>`, normalizes to `data/runs/<runId>.json` via `@sandbox-benchmarks/results`, updates `data/runs/index.json`, prints a summary and output path, and exits 1 on usage errors.

<sup>Written for commit 148406b552fc484b7adeccc711ff648c58c4aa15. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/starslingdev/sandbox-benchmarks/pull/43?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

