### PR TITLE
chore(schema): add fetch-profiles dev script + @octokit/rest

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -88,6 +88,7 @@
         "arktype": "catalog:",
       },
       "devDependencies": {
+        "@octokit/rest": "22.0.1",
         "@repo/tsconfig": "workspace:*",
         "@types/bun": "catalog:",
         "typescript": "catalog:",
@@ -290,6 +291,30 @@
 
     "@nodelib/fs.walk": ["@nodelib/fs.walk@1.2.8", "", { "dependencies": { "@nodelib/fs.scandir": "2.1.5", "fastq": "^1.6.0" } }, "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg=="],
 
+    "@octokit/auth-token": ["@octokit/auth-token@6.0.0", "", {}, "sha512-P4YJBPdPSpWTQ1NU4XYdvHvXJJDxM6YwpS0FZHRgP7YFkdVxsWcpWGy/NVqlAA7PcPCnMacXlRm1y2PFZRWL/w=="],
+
+    "@octokit/core": ["@octokit/core@7.0.6", "", { "dependencies": { "@octokit/auth-token": "^6.0.0", "@octokit/graphql": "^9.0.3", "@octokit/request": "^10.0.6", "@octokit/request-error": "^7.0.2", "@octokit/types": "^16.0.0", "before-after-hook": "^4.0.0", "universal-user-agent": "^7.0.0" } }, "sha512-DhGl4xMVFGVIyMwswXeyzdL4uXD5OGILGX5N8Y+f6W7LhC1Ze2poSNrkF/fedpVDHEEZ+PHFW0vL14I+mm8K3Q=="],
+
+    "@octokit/endpoint": ["@octokit/endpoint@11.0.3", "", { "dependencies": { "@octokit/types": "^16.0.0", "universal-user-agent": "^7.0.2" } }, "sha512-FWFlNxghg4HrXkD3ifYbS/IdL/mDHjh9QcsNyhQjN8dplUoZbejsdpmuqdA76nxj2xoWPs7p8uX2SNr9rYu0Ag=="],
+
+    "@octokit/graphql": ["@octokit/graphql@9.0.3", "", { "dependencies": { "@octokit/request": "^10.0.6", "@octokit/types": "^16.0.0", "universal-user-agent": "^7.0.0" } }, "sha512-grAEuupr/C1rALFnXTv6ZQhFuL1D8G5y8CN04RgrO4FIPMrtm+mcZzFG7dcBm+nq+1ppNixu+Jd78aeJOYxlGA=="],
+
+    "@octokit/openapi-types": ["@octokit/openapi-types@27.0.0", "", {}, "sha512-whrdktVs1h6gtR+09+QsNk2+FO+49j6ga1c55YZudfEG+oKJVvJLQi3zkOm5JjiUXAagWK2tI2kTGKJ2Ys7MGA=="],
+
+    "@octokit/plugin-paginate-rest": ["@octokit/plugin-paginate-rest@14.0.0", "", { "dependencies": { "@octokit/types": "^16.0.0" }, "peerDependencies": { "@octokit/core": ">=6" } }, "sha512-fNVRE7ufJiAA3XUrha2omTA39M6IXIc6GIZLvlbsm8QOQCYvpq/LkMNGyFlB1d8hTDzsAXa3OKtybdMAYsV/fw=="],
+
+    "@octokit/plugin-request-log": ["@octokit/plugin-request-log@6.0.0", "", { "peerDependencies": { "@octokit/core": ">=6" } }, "sha512-UkOzeEN3W91/eBq9sPZNQ7sUBvYCqYbrrD8gTbBuGtHEuycE4/awMXcYvx6sVYo7LypPhmQwwpUe4Yyu4QZN5Q=="],
+
+    "@octokit/plugin-rest-endpoint-methods": ["@octokit/plugin-rest-endpoint-methods@17.0.0", "", { "dependencies": { "@octokit/types": "^16.0.0" }, "peerDependencies": { "@octokit/core": ">=6" } }, "sha512-B5yCyIlOJFPqUUeiD0cnBJwWJO8lkJs5d8+ze9QDP6SvfiXSz1BF+91+0MeI1d2yxgOhU/O+CvtiZ9jSkHhFAw=="],
+
+    "@octokit/request": ["@octokit/request@10.0.10", "", { "dependencies": { "@octokit/endpoint": "^11.0.3", "@octokit/request-error": "^7.0.2", "@octokit/types": "^16.0.0", "content-type": "^2.0.0", "json-with-bigint": "^3.5.3", "universal-user-agent": "^7.0.2" } }, "sha512-KxNC2pTqqhszMNrf12ZRd4PonRgyJdsM4F/jySiddQK+DsRcfBtUvqn8t7UsyZhnRJHvX46OohDt5N3VqIWC2w=="],
+
+    "@octokit/request-error": ["@octokit/request-error@7.1.0", "", { "dependencies": { "@octokit/types": "^16.0.0" } }, "sha512-KMQIfq5sOPpkQYajXHwnhjCC0slzCNScLHs9JafXc4RAJI+9f+jNDlBNaIMTvazOPLgb4BnlhGJOTbnN0wIjPw=="],
+
+    "@octokit/rest": ["@octokit/rest@22.0.1", "", { "dependencies": { "@octokit/core": "^7.0.6", "@octokit/plugin-paginate-rest": "^14.0.0", "@octokit/plugin-request-log": "^6.0.0", "@octokit/plugin-rest-endpoint-methods": "^17.0.0" } }, "sha512-Jzbhzl3CEexhnivb1iQ0KJ7s5vvjMWcmRtq5aUsKmKDrRW6z3r84ngmiFKFvpZjpiU/9/S6ITPFRpn5s/3uQJw=="],
+
+    "@octokit/types": ["@octokit/types@16.0.0", "", { "dependencies": { "@octokit/openapi-types": "^27.0.0" } }, "sha512-sKq+9r1Mm4efXW1FCk7hFSeJo4QKreL/tTbR0rz/qx/r1Oa2VV83LTA/H/MuCOX7uCIJmQVRKBcbmWoySjAnSg=="],
+
     "@opentelemetry/api": ["@opentelemetry/api@1.9.1", "", {}, "sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q=="],
 
     "@opentelemetry/api-logs": ["@opentelemetry/api-logs@0.207.0", "", { "dependencies": { "@opentelemetry/api": "^1.3.0" } }, "sha512-lAb0jQRVyleQQGiuuvCOTDVspc14nx6XJjP4FspJ1sNARo3Regq4ZZbrc3rN4b1TYSuUCvgH+UXUPug4SLOqEQ=="],
@@ -432,6 +457,8 @@
 
     "base64-js": ["base64-js@1.5.1", "", {}, "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="],
 
+    "before-after-hook": ["before-after-hook@4.0.0", "", {}, "sha512-q6tR3RPqIB1pMiTRMFcZwuG5T8vwp+vUvEG0vuI6B+Rikh5BfPp2fQ82c925FOs+b0lcFQ8CFrL+KbilfZFhOQ=="],
+
     "bowser": ["bowser@2.14.1", "", {}, "sha512-tzPjzCxygAKWFOJP011oxFHs57HzIhOEracIgAePE4pqB3LikALKnSzUyU4MGs9/iCEUuHlAJTjTc5M+u7YEGg=="],
 
     "brace-expansion": ["brace-expansion@5.0.6", "", { "dependencies": { "balanced-match": "^4.0.2" } }, "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g=="],
@@ -467,6 +494,8 @@
     "compare-versions": ["compare-versions@6.1.1", "", {}, "sha512-4hm4VPpIecmlg59CHXnRDnqGplJFrbLG4aFEl5vl6cK1u76ws3LLvX7ikFnTDl5vo39sjWD6AaDPYodJp/NNHg=="],
 
     "computesdk": ["computesdk@4.1.3", "", { "dependencies": { "@computesdk/cmd": "0.4.1", "daemond": "0.1.4" } }, "sha512-IVC7KenrhCyiGJ1FKTs7jzXTc+mJZNCljux39yzPeR2M48v6tr03YXTtiyefoJ+VZ1J/nVthrAqTF1ng+H4uOQ=="],
+
+    "content-type": ["content-type@2.0.0", "", {}, "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ=="],
 
     "cross-spawn": ["cross-spawn@7.0.6", "", { "dependencies": { "path-key": "^3.1.0", "shebang-command": "^2.0.0", "which": "^2.0.1" } }, "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA=="],
 
@@ -563,6 +592,8 @@
     "isomorphic-ws": ["isomorphic-ws@5.0.0", "", { "peerDependencies": { "ws": "*" } }, "sha512-muId7Zzn9ywDsyXgTIafTry2sV3nySZeUDe6YedVd1Hvuuep5AsIlqK+XefWpYTyJG5e503F2xIuT2lcU6rCSw=="],
 
     "jackspeak": ["jackspeak@4.2.3", "", { "dependencies": { "@isaacs/cliui": "^9.0.0" } }, "sha512-ykkVRwrYvFm1nb2AJfKKYPr0emF6IiXDYUaFx4Zn9ZuIH7MrzEZ3sD5RlqGXNRpHtvUHJyOnCEFxOlNDtGo7wg=="],
+
+    "json-with-bigint": ["json-with-bigint@3.5.8", "", {}, "sha512-eq/4KP6K34kwa7TcFdtvnftvHCD9KvHOGGICWwMFc4dOOKF5t4iYqnfLK8otCRCRv06FXOzGGyqE8h8ElMvvdw=="],
 
     "lefthook": ["lefthook@2.1.9", "", { "optionalDependencies": { "lefthook-darwin-arm64": "2.1.9", "lefthook-darwin-x64": "2.1.9", "lefthook-freebsd-arm64": "2.1.9", "lefthook-freebsd-x64": "2.1.9", "lefthook-linux-arm64": "2.1.9", "lefthook-linux-x64": "2.1.9", "lefthook-openbsd-arm64": "2.1.9", "lefthook-openbsd-x64": "2.1.9", "lefthook-windows-arm64": "2.1.9", "lefthook-windows-x64": "2.1.9" }, "bin": { "lefthook": "bin/index.js" } }, "sha512-bwDaIOViTktE8kJLf9jP0p+H2/RDTlFFlc43Am2YgUsX22hI6Sq4RbzsrecwzY5y+MHTipOH7WsmWSEniePHWQ=="],
 
@@ -693,6 +724,8 @@
     "undici": ["undici@7.27.2", "", {}, "sha512-uZsKNuzQxDMUY6M3pIMvy5tvlGmtq8XJ2oLAkfRKGNu+1VQAIvLy2xIVG5ATZl5wDXl/tddByAWCizRbOme+TA=="],
 
     "undici-types": ["undici-types@7.24.6", "", {}, "sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg=="],
+
+    "universal-user-agent": ["universal-user-agent@7.0.3", "", {}, "sha512-TmnEAEAsBJVZM/AADELsK76llnwcf9vMKuPz8JflO1frO8Lchitr0fNaN9d+Ap0BjKtqWqd/J17qeDnXh8CL2A=="],
 
     "util-deprecate": ["util-deprecate@1.0.2", "", {}, "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="],
 

--- a/packages/schema/package.json
+++ b/packages/schema/package.json
@@ -8,13 +8,15 @@
   },
   "scripts": {
     "test": "bun test",
-    "typecheck": "tsc --noEmit"
+    "typecheck": "tsc --noEmit",
+    "fetch-profiles": "bun run scripts/fetch-profiles.ts"
   },
   "dependencies": {
     "arktype": "catalog:"
   },
   "devDependencies": {
     "@repo/tsconfig": "workspace:*",
+    "@octokit/rest": "22.0.1",
     "typescript": "catalog:",
     "@types/bun": "catalog:"
   }

--- a/packages/schema/scripts/fetch-profiles.ts
+++ b/packages/schema/scripts/fetch-profiles.ts
@@ -1,0 +1,121 @@
+#!/usr/bin/env bun
+// `fetch-profiles` — a non-build dev tool that vendors the upstream PTS profile definitions the
+// Metric Catalog generator reads (see docs/pts-catalog-and-analysis-design.md §3.1). It writes
+// `test-definition.xml` + `results-definition.xml` for each pinned `<name>-<ver>` into
+// `src/pts-profiles/`, co-located with the catalog so the vendored file IS the version pin.
+//
+// This is NOT part of the build: nothing imports it, `typecheck`/`test` never run it, and the
+// generator only ever reads the committed local copies. Re-run it by hand to vendor a new profile
+// or re-pull an existing one (`bun run fetch-profiles`). It is idempotent: every run overwrites the
+// vendored copies in place from the pinned upstream blobs, so re-running against unchanged upstream
+// leaves git clean.
+//
+// Two distinct repos, do not conflate (design doc §3.1): the XML is fetched from
+// `phoronix-test-suite/test-profiles` under `pts/`; the catalog's `sourceUrl` provenance points at
+// the *other* repo (`phoronix-test-suite/phoronix-test-suite`, `ob-cache/test-profiles/pts/...`),
+// which 404s here. The GitHub Contents API truncates `pts/` (thousands of entries), so we read a
+// single profile dir via the git-trees API and pull each definition by its exact blob SHA — both
+// through Octokit rather than hand-built REST calls, so responses stay typed against the GitHub
+// OpenAPI schema.
+//
+// The dir name pins the profile *version*; `REF` pins the exact upstream *commit* the definitions
+// are vendored from — a fixed revision, never a moving branch — so every run reproduces
+// byte-identical output and the source is auditable. Blobs are read under that commit and pulled by
+// their per-file SHAs. Bump `REF` and re-run to vendor an updated upstream.
+import { Octokit } from "@octokit/rest";
+
+// Upstream repo and the profile dirs we vendor, pinned by exact `<name>-<ver>` — the suites we run
+// (node-web-tooling-1.0.1, c-ray-2.0.0). Version suffixes are mandatory and non-uniform upstream, so
+// the dir name is the pin; add a profile by appending its versioned dir here.
+const OWNER = "phoronix-test-suite";
+const REPO = "test-profiles";
+// The exact upstream commit we vendor from — a fixed revision, not a moving branch, so the same
+// `REF` always yields the same blobs (reproducible vendoring). To update, bump this to a newer
+// `phoronix-test-suite/test-profiles` commit SHA and re-run. Latest on master:
+//   gh api repos/phoronix-test-suite/test-profiles/commits/master --jq .sha
+const REF = "d2f1a150d388bd062737b445891edda0780f7e25";
+const PROFILES = ["node-web-tooling-1.0.1", "c-ray-2.0.0"] as const;
+
+// Only these definition files feed the generator; siblings (downloads.xml, install.sh) are ignored.
+// `required` distinguishes the essential `test-definition.xml` (a missing one is a hard failure, not
+// a warn-and-skip that would look like success) from the optional `results-definition.xml`.
+const VENDORED_FILES = [
+	{ name: "test-definition.xml", required: true },
+	{ name: "results-definition.xml", required: false },
+] as const;
+
+// Bun normalizes the `..` and forward slashes here (every platform, Windows included) when this
+// reaches `Bun.write`, so a plain template literal needs no `node:path` join.
+const OUT_DIR = `${import.meta.dir}/../src/pts-profiles`;
+
+// Optional auth lifts the unauthenticated rate limit; the script still works without it for the
+// handful of blobs we pull. Read via `Bun.env` so a re-run under a token "just works", no code edit.
+const octokit = new Octokit({ auth: Bun.env.GITHUB_TOKEN });
+
+// Map each blob file name in a profile dir to its content SHA, reading the dir under the pinned
+// commit `commitSha`. Listing via the git-trees API sidesteps Contents-API truncation and fails loudly
+// (Octokit throws on 404) if a pinned profile is gone. A profile dir is tiny, but the trees API can
+// still set `truncated`, so we reject a partial response rather than vendor an incomplete dir. Each
+// entry carries its blob SHA, so this one response also pins exactly which content we later fetch.
+async function listProfileBlobs(commitSha: string, profile: string): Promise<Map<string, string>> {
+	const { data } = await octokit.rest.git.getTree({
+		owner: OWNER,
+		repo: REPO,
+		tree_sha: `${commitSha}:pts/${profile}`,
+	});
+	if (data.truncated) {
+		throw new Error(`tree for pts/${profile} was truncated; refusing to vendor a partial dir`);
+	}
+	return new Map(
+		data.tree.flatMap((entry) =>
+			entry.type === "blob" && entry.path && entry.sha ? [[entry.path, entry.sha]] : [],
+		),
+	);
+}
+
+// Fetch one blob by SHA and decode it to text. getBlob returns base64-encoded content; assert the
+// encoding instead of trusting it blindly, so an upstream API change can't silently vendor garbage.
+async function fetchBlobText(file_sha: string): Promise<string> {
+	const { data } = await octokit.rest.git.getBlob({ owner: OWNER, repo: REPO, file_sha });
+	if (data.encoding !== "base64") {
+		throw new Error(`blob ${file_sha} -> unexpected encoding ${data.encoding}`);
+	}
+	return Buffer.from(data.content, "base64").toString("utf8");
+}
+
+async function vendorProfile(commitSha: string, profile: string): Promise<void> {
+	const blobs = await listProfileBlobs(commitSha, profile);
+	// Fetch + write this profile's definitions concurrently — they're independent I/O-bound GitHub
+	// calls. A rejected required-file fetch propagates out of Promise.all to the top-level boundary.
+	await Promise.all(
+		VENDORED_FILES.map(async ({ name, required }) => {
+			const sha = blobs.get(name);
+			if (!sha) {
+				if (required) {
+					// A missing essential definition must abort: warn-and-skip here would exit 0 and read as
+					// success while silently vendoring nothing the generator can use.
+					throw new Error(`${profile}/${name} is required but was not found upstream`);
+				}
+				// Optional sibling (e.g. results-definition.xml): warn rather than abort so a profile that
+				// ships only its test-definition.xml still vendors cleanly.
+				console.warn(`! ${profile}/${name} not found upstream, skipping`);
+				return;
+			}
+			// Bun.write creates parent dirs, normalizes the path, and overwrites in place — no node:path
+			// join or mkdir + writeFile dance needed.
+			await Bun.write(`${OUT_DIR}/${profile}/${name}`, await fetchBlobText(sha));
+			console.log(`✓ ${profile}/${name}`);
+		}),
+	);
+}
+
+if (import.meta.main) {
+	try {
+		console.log(`pinned ${OWNER}/${REPO}@${REF}`);
+		// Fan out across all profiles too — the whole vendor is one big batch of independent API reads.
+		await Promise.all(PROFILES.map((profile) => vendorProfile(REF, profile)));
+	} catch (err) {
+		console.error(`fetch-profiles failed: ${err instanceof Error ? err.message : err}`);
+		process.exit(1);
+	}
+}

--- a/packages/schema/tsconfig.json
+++ b/packages/schema/tsconfig.json
@@ -1,4 +1,4 @@
 {
   "extends": "@repo/tsconfig/library.json",
-  "include": ["src"]
+  "include": ["src", "scripts"]
 }


### PR DESCRIPTION
**Bottom of a 2-PR stack splitting ENG-74** into the tool and its generated output. This PR adds only the `fetch-profiles` dev tool; the vendored XML it produces lands in #46, stacked on top. No catalog change.

- Adds a **non-build** `fetch-profiles` dev script (`bun run fetch-profiles`, `packages/schema/scripts/fetch-profiles.ts`) that vendors the upstream PTS profile definitions the Metric Catalog generator (ENG-57) will read, so the build stays hermetic — no network at generate time.
  - Resolves `master` to a commit SHA once and logs it (auditable pin), lists each pinned profile dir via the git-trees API (truncation-guarded; the Contents API truncates `pts/`), and pulls each definition by exact blob SHA via Octokit.
  - A missing required `test-definition.xml` is a hard failure; an optional `results-definition.xml` warns and skips; a top-level error boundary exits non-zero. Idempotent; Bun-native I/O.
- Adds `@octokit/rest` (devDep) + the `fetch-profiles` package script.
- Includes `scripts/` in the schema `typecheck`.

Nothing imports the script; `typecheck`/`test` never run it. The vendored output, the `typos` exclusion for it, and the README note all live in #46.

Refs ENG-74.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a non-build `fetch-profiles` dev script that vendors PTS profile XML for `node-web-tooling-1.0.1` and `c-ray-2.0.0` into `src/pts-profiles`, pinning to a fixed upstream commit to keep the Metric Catalog build hermetic. Tooling only; no catalog changes; addresses ENG-74.

- **New Features**
  - `bun run fetch-profiles`: vendors `test-definition.xml` and optional `results-definition.xml` for each pinned profile from `phoronix-test-suite/test-profiles` at a fixed commit; lists `pts/<name>-<ver>` via git-trees (rejects truncated) and fetches by blob SHA with Octokit; idempotent; supports `GITHUB_TOKEN`; fails on missing `test-definition.xml` and warns on missing `results-definition.xml`.
  - Adds `@octokit/rest` (dev), registers the `fetch-profiles` script, and includes `scripts/` in `typecheck`.

<sup>Written for commit 3b4df06c96a06219064711aa7f757a9bdd57ed79. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/starslingdev/sandbox-benchmarks/pull/45?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a command/script to fetch and vendor upstream PTS profile XML definitions into the local repository, updating the corresponding XML files automatically.

* **Chores**
  * Expanded TypeScript checking to also cover the added script files.
  * Added the required tooling dependency and a dedicated run script to support the profile fetching workflow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
