### PR TITLE
chore(schema): vendor pts-profiles (generated by `bun run fetch-profiles`)

### DIFF
--- a/packages/schema/README.md
+++ b/packages/schema/README.md
@@ -14,3 +14,9 @@ vocabulary + Catalog (`MetricDef`, `METRIC_CATALOG`, `aggregate()`), the Run dat
 builds on — providers, metrics, the normalized Run model, and how raw result files are named.
 Private validation internals live in `src/lib/` and must never be imported across a package
 boundary — import from `@sandbox-benchmarks/schema` instead.
+
+**Vendored PTS profiles (`src/pts-profiles/<name>-<ver>/`):** the upstream PTS
+`test-definition.xml` / `results-definition.xml` for each suite we run, pinned by exact version (the
+dir name is the pin). The forthcoming Metric Catalog generator reads these committed copies — the
+build never hits the network. Re-pull or add a profile with `bun run fetch-profiles` (a non-build
+dev tool; nothing imports it).

--- a/packages/schema/src/pts-profiles/c-ray-2.0.0/results-definition.xml
+++ b/packages/schema/src/pts-profiles/c-ray-2.0.0/results-definition.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0"?>
+<!--Phoronix Test Suite v10.8.5-->
+<PhoronixTestSuite>
+  <ResultsParser>
+    <OutputTemplate>Rendering took: 86 seconds (#_RESULT_# milliseconds)</OutputTemplate>
+    <DivideResultBy>1000</DivideResultBy>
+  </ResultsParser>
+</PhoronixTestSuite>

--- a/packages/schema/src/pts-profiles/c-ray-2.0.0/test-definition.xml
+++ b/packages/schema/src/pts-profiles/c-ray-2.0.0/test-definition.xml
@@ -1,0 +1,60 @@
+<?xml version="1.0"?>
+<!--Phoronix Test Suite v10.8.5-->
+<PhoronixTestSuite>
+  <TestInformation>
+    <Title>C-Ray</Title>
+    <AppVersion>2.0</AppVersion>
+    <Description>This is a test of C-Ray, a simple multi-threaded raytracer designed to test the floating-point CPU performance.</Description>
+    <ResultScale>Seconds</ResultScale>
+    <Proportion>LIB</Proportion>
+    <SubTitle>Total Time - 4K, 16 Rays Per Pixel</SubTitle>
+    <TimesToRun>3</TimesToRun>
+  </TestInformation>
+  <TestProfile>
+    <Version>2.0.0</Version>
+    <SupportedPlatforms>Linux, Solaris, MacOSX, BSD</SupportedPlatforms>
+    <SoftwareType>Utility</SoftwareType>
+    <TestType>Processor</TestType>
+    <License>Free</License>
+    <Status>Verified</Status>
+    <ExternalDependencies>build-utilities</ExternalDependencies>
+    <EnvironmentSize>6.0</EnvironmentSize>
+    <ProjectURL>http://nuclear.mutantstargoat.com/sw/c-ray/</ProjectURL>
+    <RepositoryURL>https://github.com/jtsiomb/c-ray</RepositoryURL>
+    <InternalTags>SMP</InternalTags>
+    <Maintainer>Michael Larabel</Maintainer>
+  </TestProfile>
+  <TestSettings>
+    <Option>
+      <DisplayName>Resolution</DisplayName>
+      <Identifier>resolution</Identifier>
+      <ArgumentPrefix>-s </ArgumentPrefix>
+      <Menu>
+        <Entry>
+          <Name>1080p</Name>
+          <Value>1920x1080</Value>
+        </Entry>
+        <Entry>
+          <Name>4K</Name>
+          <Value>3840x2160</Value>
+        </Entry>
+        <Entry>
+          <Name>5K</Name>
+          <Value>5120x2880</Value>
+          <Message>Practical for high core count systems.</Message>
+        </Entry>
+      </Menu>
+    </Option>
+    <Option>
+      <DisplayName>Rays Per Pixel</DisplayName>
+      <Identifier>rays</Identifier>
+      <ArgumentPrefix>-r </ArgumentPrefix>
+      <Menu>
+        <Entry>
+          <Name>16</Name>
+          <Value>16</Value>
+        </Entry>
+      </Menu>
+    </Option>
+  </TestSettings>
+</PhoronixTestSuite>

--- a/packages/schema/src/pts-profiles/node-web-tooling-1.0.1/results-definition.xml
+++ b/packages/schema/src/pts-profiles/node-web-tooling-1.0.1/results-definition.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0"?>
+<!--Phoronix Test Suite v10.8.4-->
+<PhoronixTestSuite>
+  <ResultsParser>
+    <OutputTemplate>Geometric mean:  #_RESULT_# runs/s</OutputTemplate>
+    <LineHint>Geometric mean</LineHint>
+  </ResultsParser>
+</PhoronixTestSuite>

--- a/packages/schema/src/pts-profiles/node-web-tooling-1.0.1/test-definition.xml
+++ b/packages/schema/src/pts-profiles/node-web-tooling-1.0.1/test-definition.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0"?>
+<!--Phoronix Test Suite v10.8.4-->
+<PhoronixTestSuite>
+  <TestInformation>
+    <Title>Node.js V8 Web Tooling Benchmark</Title>
+    <Description>Running the V8 project's Web-Tooling-Benchmark under Node.js. The Web-Tooling-Benchmark stresses JavaScript-related workloads common to web developers like Babel and TypeScript and Babylon. This test profile can test the system's JavaScript performance with Node.js.</Description>
+    <ResultScale>runs/s</ResultScale>
+    <Proportion>HIB</Proportion>
+    <TimesToRun>3</TimesToRun>
+  </TestInformation>
+  <TestProfile>
+    <Version>1.0.1</Version>
+    <SupportedPlatforms>Linux, BSD, Solaris, MacOSX</SupportedPlatforms>
+    <SoftwareType>Utility</SoftwareType>
+    <TestType>Processor</TestType>
+    <License>Free</License>
+    <Status>Verified</Status>
+    <ExternalDependencies>node-npm</ExternalDependencies>
+    <EnvironmentSize>236</EnvironmentSize>
+    <ProjectURL>https://v8.github.io/web-tooling-benchmark/</ProjectURL>
+    <RepositoryURL>https://github.com/v8/web-tooling-benchmark</RepositoryURL>
+    <Maintainer>Michael Larabel</Maintainer>
+    <SystemDependencies>webpack</SystemDependencies>
+  </TestProfile>
+</PhoronixTestSuite>

--- a/typos.toml
+++ b/typos.toml
@@ -3,8 +3,10 @@
 # intentional identifier, add it under [default.extend-words] rather than rewording the code.
 
 [files]
-# The lockfile is generated and full of hashes/identifiers — don't spell-check it.
-extend-exclude = ["bun.lock"]
+# The lockfile is generated and full of hashes/identifiers — don't spell-check it. The pts-profiles
+# are vendored verbatim from upstream PTS (fetch-profiles dev script) — we must not reword them, so
+# any typo in the upstream prose is theirs to keep, not ours to "fix".
+extend-exclude = ["bun.lock", "packages/schema/src/pts-profiles/**"]
 
 [default.extend-words]
 # Domain term: a parsed result not (yet) in the Metric Catalog. International spelling, used as the


### PR DESCRIPTION
Autogenerated output of the fetch-profiles dev tool added in the PR below
this one. Do not hand-edit these files; re-run the tool to refresh them.

Generated with (from packages/schema):

    $ bun run fetch-profiles
    pinned phoronix-test-suite/test-profiles@master -> d2f1a150d388bd062737b445891edda0780f7e25
    ✓ node-web-tooling-1.0.1/test-definition.xml
    ✓ node-web-tooling-1.0.1/results-definition.xml
    ✓ c-ray-2.0.0/test-definition.xml
    ✓ c-ray-2.0.0/results-definition.xml

Vendors test-definition.xml / results-definition.xml for node-web-tooling-1.0.1
and c-ray-2.0.0 under packages/schema/src/pts-profiles/, pinned by exact
version (the dir name is the pin). typos.toml excludes the dir so the upstream
prose isn't spell-checked; README documents the dir.

Refs ENG-74.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Vendor PTS profile XMLs for `node-web-tooling-1.0.1` and `c-ray-2.0.0` into `packages/schema` so the Metric Catalog generator uses pinned inputs and runs offline. Profiles are generated by `bun run fetch-profiles`. Supports ENG-74.

- **New Features**
  - Added `test-definition.xml` and `results-definition.xml` under `packages/schema/src/pts-profiles/<name>-<ver>/`.
  - Documented vendored profiles and refresh steps in `packages/schema/README.md` (build never hits the network).
  - Excluded `packages/schema/src/pts-profiles/**` from `typos.toml` spell-check.

<sup>Written for commit c8beac85e7f1ea98947a482414e6257bae636552. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/starslingdev/sandbox-benchmarks/pull/46?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added C-Ray 2.0.0 benchmark profile with configurable resolution and rendering options.
  * Added Node.js V8 Web Tooling Benchmark (v1.0.1) profile.

* **Documentation**
  * Updated README to clarify how test profiles are vendored and managed.

* **Chores**
  * Updated spell-check configuration to exclude vendored profile directories.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->