### PR TITLE
ci: catalog drift gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,6 +70,12 @@ jobs:
       - name: Test
         run: bun run test
 
+      # Catalog drift gate — re-run the PTS catalog generator against the vendored profiles and fail
+      # if the committed pts-generated.ts drifts (un-regenerated profile bump or a hand edit). Diffs
+      # pts-generated.ts only; pts-overrides.ts curation is excluded.
+      - name: Catalog drift
+        run: bun run check:catalog-drift
+
       # Spelling gate — typos (pinned in mise.toml); misspellings fail the build.
       - name: Spell (typos)
         run: bun run spell

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "lint:docker": "find packages/templates/images -name 'Dockerfile' -exec mise exec -- hadolint {} +",
     "spell": "mise exec -- typos",
     "spell:fix": "mise exec -- typos --write-changes",
+    "check:catalog-drift": "bun --filter '@sandbox-benchmarks/schema' check:catalog-drift",
     "prepare": "lefthook install"
   },
   "devDependencies": {

--- a/packages/schema/package.json
+++ b/packages/schema/package.json
@@ -10,7 +10,8 @@
     "test": "bun test",
     "typecheck": "tsc --noEmit",
     "fetch-profiles": "bun run scripts/fetch-profiles.ts",
-    "generate-catalog": "bun run scripts/generate-catalog.ts"
+    "generate-catalog": "bun run scripts/generate-catalog.ts",
+    "check:catalog-drift": "bun run scripts/check-catalog-drift.ts"
   },
   "dependencies": {
     "arktype": "catalog:"

--- a/packages/schema/scripts/check-catalog-drift.ts
+++ b/packages/schema/scripts/check-catalog-drift.ts
@@ -1,0 +1,40 @@
+#!/usr/bin/env bun
+// Catalog drift gate (CI): regenerate the catalog from the vendored profiles and fail if the
+// committed src/pts-generated.ts differs from a fresh run — catching an un-regenerated profile bump
+// or a hand edit of the generated file. Only pts-generated.ts is diffed; pts-overrides.ts is curation
+// and is intentionally out of the gate, so curating labels/headlines never trips it.
+import { generateCatalogFile } from "./generate-catalog.ts";
+
+// The path is repo-relative; we run git from the repo root so the gate is cwd-independent.
+const REPO_ROOT = `${import.meta.dir}/../../..`;
+const GENERATED = "packages/schema/src/pts-generated.ts";
+
+async function main(): Promise<void> {
+	await generateCatalogFile();
+
+	const diff = Bun.spawn(["git", "diff", "--exit-code", "--", GENERATED], {
+		cwd: REPO_ROOT,
+		stdout: "inherit",
+		stderr: "inherit",
+	});
+	// `git diff --exit-code` returns 1 for drift specifically; 128 (and other non-zero) means git
+	// itself failed (not a repo, missing binary). Don't report a git failure as "out of date".
+	const exitCode = await diff.exited;
+	if (exitCode === 1) {
+		throw new Error(
+			`${GENERATED} is out of date — run \`bun run --filter @sandbox-benchmarks/schema generate-catalog\` and commit the result`,
+		);
+	}
+	if (exitCode !== 0) {
+		throw new Error(`git diff failed with exit code ${exitCode}`);
+	}
+	console.log(`✓ ${GENERATED} matches a fresh generator run`);
+}
+
+try {
+	await main();
+} catch (err) {
+	// Log the whole error (preserves the stack) so a CI failure is debuggable, not just its message.
+	console.error("catalog drift check failed:", err);
+	process.exit(1);
+}

--- a/packages/schema/scripts/generate-catalog.ts
+++ b/packages/schema/scripts/generate-catalog.ts
@@ -18,7 +18,8 @@ async function readXml(path: string): Promise<string> {
 	return (await file.exists()) ? file.text() : "";
 }
 
-async function main(): Promise<void> {
+/** Regenerate `src/pts-generated.ts` in place. Exported so the drift gate can re-run it directly. */
+export async function generateCatalogFile(): Promise<void> {
 	// Sort the profile dirs so generation order — and thus output — is independent of readdir order.
 	const dirs = (await readdir(PROFILES_DIR, { withFileTypes: true }))
 		.filter((d) => d.isDirectory())
@@ -50,9 +51,10 @@ async function main(): Promise<void> {
 
 if (import.meta.main) {
 	try {
-		await main();
+		await generateCatalogFile();
 	} catch (err) {
-		console.error(`generate-catalog failed: ${err instanceof Error ? err.message : err}`);
+		// Log the whole error (preserves the stack) so a failure is debuggable, not just its message.
+		console.error("generate-catalog failed:", err);
 		process.exit(1);
 	}
 }


### PR DESCRIPTION
Re-run the PTS catalog generator in CI and fail if the committed
src/pts-generated.ts drifts from a fresh run — catching an un-regenerated
profile bump or a hand edit of the generated file. Design §3.6. Completes
ENG-57 up to the drift gate (the catalog seam stays unwired).

- scripts/check-catalog-drift.ts: regenerate, then `git diff --exit-code`
  pts-generated.ts only (pts-overrides.ts curation is excluded, so editing
  labels/headlines never trips the gate); actionable error on drift.
- generate-catalog.ts: export generateCatalogFile() so the gate re-runs it directly.
- check:catalog-drift script (schema + root); new CI step after Test.

Gate verified both ways: clean on the committed catalog, and fails with a fix
hint when the generated file is stale.

Refs ENG-57.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a CI drift gate that re-runs the PTS catalog generator and fails if `packages/schema/src/pts-generated.ts` differs from a fresh run. Implements Design §3.6 for ENG-57.

- **New Features**
  - Adds `check:catalog-drift` at root and in `@sandbox-benchmarks/schema`; CI runs it after tests.
  - Gate regenerates and diffs `pts-generated.ts` only (excludes `pts-overrides.ts`), treats git exit 1 as drift, surfaces other git failures; exports `generateCatalogFile()` and logs full error objects.

<sup>Written for commit 5e37a8cfda8dfd9e42764942c67655ad653fe88f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/starslingdev/sandbox-benchmarks/pull/50?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

