### PR TITLE
test(results): golden composite.xml byte-match gate (§3.7)

### DIFF
--- a/packages/results/src/lib/pts-golden.test.ts
+++ b/packages/results/src/lib/pts-golden.test.ts
@@ -1,0 +1,74 @@
+// Golden byte-match gate (design §3.7): for every committed recorded `composite.xml` fixture, assert
+// each `<Result>` resolves to a Catalog Metric via `ptsResultToMetric` — i.e. the synthesized
+// `pts.description` byte-matches the runtime `<Description>` (separators, spacing, `" - "` joins). This
+// is the highest-risk correctness item: a one-character drift (c-ray's "Resolution: 1080p - Rays Per
+// Pixel: 16" is the canonical break point) silently routes a result to `uncatalogued` instead of
+// ranking it. Recorded composites are REAL PTS output, never hand-written — they prove the byte-match
+// against reality, so dropping a new suite's recorded composite here automatically extends the gate.
+import { describe, expect, it } from "bun:test";
+import { readdirSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+import { isPtsResultFile } from "@sandbox-benchmarks/schema";
+import { parsePtsComposite, ptsResultToMetric } from "./pts.ts";
+
+const FIXTURES_DIR = join(import.meta.dir, "__fixtures__");
+
+/**
+ * Every recorded composite under `__fixtures__`, recursively. Scoped to the SAME `pts_*.xml` naming
+ * contract the production extractor routes through ({@link isPtsResultFile}, raw-files.ts) — not a
+ * looser `.endsWith(".xml")` — so the gate validates exactly the files the real reader parses, and an
+ * unrelated `.xml` (or an inline non-composite fixture) can't drag the gate red.
+ */
+function recordedCompositesUnder(dir: string): string[] {
+	return readdirSync(dir, { withFileTypes: true }).flatMap((entry) => {
+		const full = join(dir, entry.name);
+		if (entry.isDirectory()) return recordedCompositesUnder(full);
+		return isPtsResultFile(entry.name) ? [full] : [];
+	});
+}
+
+/**
+ * Discover fixtures at collection time. A missing/renamed `__fixtures__` ROOT must surface as the
+ * clean "discovers at least one fixture" assertion below — NOT an opaque ENOENT thrown during module
+ * import that takes down every co-located suite in this file.
+ */
+function discoverComposites(): [string, string][] {
+	let paths: string[];
+	try {
+		paths = recordedCompositesUnder(FIXTURES_DIR);
+	} catch (err) {
+		// Tolerate ONLY a missing fixtures root. An ENOENT whose path is a sub-directory means one
+		// vanished mid-walk — a real partial-read error to surface, not mask as "no fixtures". Typed
+		// structurally (not NodeJS.ErrnoException) since this is a Bun-runtime package with no @types/node.
+		const e = err as { code?: string; path?: string };
+		if (e.code === "ENOENT" && e.path === FIXTURES_DIR) return [];
+		throw err;
+	}
+	return paths.map((path) => [path.slice(FIXTURES_DIR.length + 1), readFileSync(path, "utf8")]);
+}
+
+const composites = discoverComposites();
+
+describe("golden composite byte-match (design §3.7)", () => {
+	it("discovers at least one recorded composite fixture", () => {
+		// A zero-fixture run would make every per-fixture assertion below vacuously pass — fail loudly
+		// instead, so a moved/renamed __fixtures__ dir can't silently disable the whole gate.
+		expect(composites.length).toBeGreaterThan(0);
+	});
+
+	for (const [name, xml] of composites) {
+		it(`every <Result> in ${name} resolves to a catalogued Metric`, () => {
+			const results = parsePtsComposite(xml).PhoronixTestSuite.Result;
+			expect(results.length).toBeGreaterThan(0);
+			// Surface the offending test+description (not just a count) so a byte-mismatch points straight
+			// at the synthesized id that drifted from the recorded <Description>.
+			const uncatalogued = results.flatMap((result) => {
+				const mapping = ptsResultToMetric(result);
+				return mapping.kind === "uncatalogued"
+					? [`${mapping.test} | "${mapping.description}"`]
+					: [];
+			});
+			expect(uncatalogued).toEqual([]);
+		});
+	}
+});

--- a/packages/results/src/lib/pts.ts
+++ b/packages/results/src/lib/pts.ts
@@ -60,6 +60,18 @@ export type PtsMapping =
 	| { kind: "matched"; def: MetricDef; samples: number[] }
 	| { kind: "uncatalogued"; test: string; description: string };
 
+// Index the catalog by versionless test once at module load. `ptsResultToMetric` runs per `<Result>`
+// — the golden gate alone calls it across every result of every recorded composite — so a per-call
+// linear `METRIC_CATALOG.filter` is O(results × catalog); the prebuilt map makes each lookup O(1).
+// Insertion order follows catalog order, so the wildcard-vs-description preference below is unchanged.
+const catalogByTest = new Map<string, MetricDef[]>();
+for (const metric of METRIC_CATALOG) {
+	if (!metric.pts) continue;
+	const forTest = catalogByTest.get(metric.pts.test);
+	if (forTest) forTest.push(metric);
+	else catalogByTest.set(metric.pts.test, [metric]);
+}
+
 /**
  * Map a parsed Result onto the Metric Catalog by its versionless test (and `<Description>` for
  * multi-result tests).
@@ -67,7 +79,7 @@ export type PtsMapping =
 export function ptsResultToMetric(result: PtsResult): PtsMapping {
 	const test = versionlessTest(result.Identifier);
 	const description = result.Description ?? "";
-	const forTest = METRIC_CATALOG.filter((metric) => metric.pts?.test === test);
+	const forTest = catalogByTest.get(test) ?? [];
 	// Prefer an exact `<Description>` match over the wildcard (description-less) entry, so a
 	// multi-result test's catalog ordering can't make the wildcard greedily shadow a specific metric.
 	// The catalog invariant (`catalogSchema` .narrow, catalog.ts) guarantees a wildcard never coexists


### PR DESCRIPTION
**Stack 1/2 — the byte-match gate.** Lands the §3.7 golden gate that the seam PR (#53) builds on.

Adds a data-driven test that, for every committed recorded `composite.xml` under `__fixtures__`, asserts each `<Result>` resolves to a Catalog Metric via `ptsResultToMetric` — i.e. the synthesized `pts.description` byte-matches the real recorded `<Description>`. An uncatalogued result names the offending `test | "description"` so a byte-drift is pinpointed, not just counted.

- Discovers fixtures recursively, scoped to the production `pts_*.xml` contract (`isPtsResultFile`), and tolerates a missing `__fixtures__` dir as a clean assertion failure rather than an import-time crash.
- Indexes the catalog by test once (`catalogByTest`) so `ptsResultToMetric` is O(1) per result instead of a full catalog scan — the gate calls it across every result of every composite.

Covers the node-web-tooling recorded composites (provenance + daytona); the c-ray composite rides on #53, where c-ray is catalogued. Recorded composites are real PTS output, so dropping a new suite's composite here extends the gate automatically.

Refs ENG-57.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a golden test for recorded `composite.xml` fixtures that ensures each `<Result>` maps to a catalog metric via `ptsResultToMetric` by byte-matching the synthesized `pts.description` to the runtime `<Description>`. Adds a module-level catalog index for O(1) lookups and flags any description drift; dropping new composites in `__fixtures__` extends coverage automatically.

- **New Features**
  - Recursively discovers only `pts_*.xml` via `isPtsResultFile`; tolerates a missing `__fixtures__` root and asserts at least one fixture.
  - On mismatch, reports offending `test | "description"` to pinpoint byte drift.

<sup>Written for commit 26cdbe0b3f4005f63c4efb1b4ee1af5046ef7c00. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/starslingdev/sandbox-benchmarks/pull/52?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability when translating recorded PTS results into metrics, reducing the chance of unmatched results slipping through.
  * Added a safeguard to catch missing or renamed fixture sets so validation won’t pass accidentally.

* **Tests**
  * Added stronger golden-file checks to verify recorded result files still map cleanly to known metrics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->