### PR TITLE
feat(schema): model provider exec transport capability (ENG-62)

### DIFF
--- a/packages/schema/src/providers.test.ts
+++ b/packages/schema/src/providers.test.ts
@@ -14,6 +14,7 @@ const fixture: ProviderMeta = {
 	pricing: { model: "per_vcpu_hour", usdPerVcpuHour: 0.05, usdPerGibHour: 0.01, notes: "fixture" },
 	maturity: { status: "ga" },
 	specPinning: "settable",
+	transport: { streaming: false, syncCapMs: 60_000, detachedPoll: true },
 };
 
 describe("@sandbox-benchmarks/schema providers", () => {
@@ -22,6 +23,30 @@ describe("@sandbox-benchmarks/schema providers", () => {
 		expect(new Set(ids).size).toBe(ids.length);
 		for (const p of PROVIDERS) {
 			expect(p.requiredEnvVars.length).toBeGreaterThan(0);
+		}
+	});
+
+	it("declares a well-formed exec transport for every provider", () => {
+		for (const p of PROVIDERS) {
+			const t = p.transport;
+			expect(typeof t.streaming).toBe("boolean");
+			expect(typeof t.detachedPoll).toBe("boolean");
+			// A cap is either "uncapped" (null) or a strictly-positive, *finite* duration — a 0/negative
+			// cap would force every step past it (always detached) and is never a real bound, and a
+			// non-finite cap (`Infinity`) is "uncapped" smuggled in as a number instead of `null`.
+			// Split into explicit branches so a failure says which rule broke, not "expected false".
+			if (t.syncCapMs === null) {
+				expect(t.syncCapMs).toBeNull();
+			} else {
+				expect(typeof t.syncCapMs).toBe("number");
+				expect(Number.isFinite(t.syncCapMs)).toBe(true);
+				expect(t.syncCapMs).toBeGreaterThan(0);
+				// A bounded cap is only honourable if there's a detached path to fall back to: the harness
+				// routes steps past the cap to detached+poll. A finite cap with `detachedPoll: false` would
+				// silently strand capped steps in synchronous best-effort mode — the exact failure this
+				// schema exists to prevent — so assert the invariant the type alone can't.
+				expect(t.detachedPoll).toBe(true);
+			}
 		}
 	});
 

--- a/packages/schema/src/providers.ts
+++ b/packages/schema/src/providers.ts
@@ -17,6 +17,39 @@ export type ProviderId = "e2b" | "daytona" | "modal";
 export type SpecPinning = "settable" | "fixed" | "unknown";
 
 /**
+ * How a provider's command-exec transport behaves *through its `@computesdk/*` adapter* — the facts the
+ * harness needs to pick a per-step transport instead of hardcoding one provider's quirks (the original
+ * sin this models away: the harness forced Daytona's detached+poll on every provider). Owned here
+ * alongside the other declared capabilities ({@link SpecPinning}, isolation, maturity) because it is a
+ * static, comparable property of the integration, and the schema already names the `@computesdk/*`
+ * adapter via {@link ProviderMeta.sdkPackage}.
+ *
+ * Three independent capabilities, each load-bearing for transport selection:
+ *
+ *   - `streaming` — does the adapter deliver stdout/stderr incrementally (computesdk's
+ *     `onStdout`/`onStderr`)? All three shipped adapters drop those callbacks, so a long synchronous
+ *     exec buffers silently. Modeled because a streaming path keeps a connection productive past an
+ *     idle gateway cap; today it is uniformly `false`, so it does not yet tip the harness's choice.
+ *   - `syncCapMs` — the longest a single *synchronous* exec round-trip is safe before the provider
+ *     caps it, or `null` when uncapped. The conservative policy bound the harness compares a step's
+ *     timeout budget against: a step that could run past it must not go synchronous. Daytona returns a
+ *     server-side HTTP 408 on multi-minute synchronous execs while the process keeps running
+ *     (`docs/evidence/daytona-exec-transport.md`); E2B's `commands.run` defaults to a 60s command
+ *     timeout the computesdk wrapper never overrides.
+ *   - `detachedPoll` — can the provider run a step fully detached (background exec + a pollable
+ *     filesystem), the durable path for steps that would outlast `syncCapMs`? Without it there is no
+ *     alternative, so such a step stays synchronous and best-effort.
+ */
+export interface ProviderTransport {
+	/** Does the `@computesdk/*` adapter stream stdout/stderr chunks (`onStdout`/`onStderr`)? */
+	streaming: boolean;
+	/** Conservative bound (ms) on a safe single synchronous exec round-trip; `null` when uncapped. */
+	syncCapMs: number | null;
+	/** Can a step run detached (background exec + filesystem poll), the durable long-step path? */
+	detachedPoll: boolean;
+}
+
+/**
  * How a provider bills. A discriminated union so a vetted `per_vcpu_hour` rate cannot be declared
  * without its `usdPerVcpuHour` — the missing-rate case is a compile error, not a silent `null`.
  */
@@ -73,6 +106,8 @@ export interface ProviderMeta {
 	pricing: ProviderPricing;
 	maturity: ProviderMaturity;
 	specPinning: SpecPinning;
+	/** How the provider's exec transport behaves — the harness selects sync vs detached from this. */
+	transport: ProviderTransport;
 }
 
 /**
@@ -123,6 +158,15 @@ const REGISTRY: Record<ProviderId, Omit<ProviderMeta, "id">> = {
 		},
 		maturity: { status: "ga", notes: "Custom images via e2b template build." },
 		specPinning: "fixed",
+		transport: {
+			// `@computesdk/e2b` calls `sandbox.commands.run(cmd)` with no options, so the E2B SDK applies
+			// its default 60s command timeout (`Commands.defaultProcessConnectionTimeout = 6e4`) and the
+			// onStdout/onStderr callbacks are never passed through. A step budgeted past ~60s must detach;
+			// E2B exposes a filesystem + `background`, so detached+poll is available.
+			streaming: false,
+			syncCapMs: 60_000,
+			detachedPoll: true,
+		},
 	},
 	daytona: {
 		displayName: "Daytona",
@@ -152,6 +196,18 @@ const REGISTRY: Record<ProviderId, Omit<ProviderMeta, "id">> = {
 			notes: "The validated reference provider for this harness (pre-baked toolchain snapshot).",
 		},
 		specPinning: "settable",
+		transport: {
+			// The single-round-trip-capped reference case: the Daytona server returns HTTP 408 on a
+			// multi-minute synchronous `executeCommand` while the process keeps running server-side, and
+			// `@computesdk/daytona` ignores onStdout/onStderr (hardcoding `stderr:""`) — no streaming to
+			// keep the connection productive. See docs/evidence/daytona-exec-transport.md. The exact
+			// server threshold is unmeasured (sub-second probes succeed; multi-minute execs 408), so the
+			// bound is a conservative 60s policy: budget anything longer to the detached+poll path
+			// (`background` via nohup + the pollable filesystem).
+			streaming: false,
+			syncCapMs: 60_000,
+			detachedPoll: true,
+		},
 	},
 	modal: {
 		displayName: "Modal",
@@ -177,6 +233,17 @@ const REGISTRY: Record<ProviderId, Omit<ProviderMeta, "id">> = {
 		},
 		maturity: { status: "ga", notes: "scalableSandboxes enabled in the harness." },
 		specPinning: "settable",
+		transport: {
+			// `@computesdk/modal` runs `sandbox.exec([...])` and `process.wait()`s the result, with no
+			// separate per-exec timeout — a synchronous exec is bounded only by the create-time sandbox
+			// lifetime, not a server gateway cap (`syncCapMs: null`). It still doesn't surface
+			// onStdout/onStderr (it reads the piped streams to completion), and `background` + filesystem
+			// are available, so detached+poll remains an option even though direct exec is the default.
+			// ENG-64 validates this end-to-end against a live multi-minute suite.
+			streaming: false,
+			syncCapMs: null,
+			detachedPoll: true,
+		},
 	},
 };
 


### PR DESCRIPTION
**ENG-62 — Provider transport capability model**

Generalize transport selection so the harness adapts per provider instead of hardcoding Daytona's detached+poll on every provider. Shipped as a 4-PR stack — merge bottom-up, each branch independently green:

1. #54 — **schema**: declare each provider's `ProviderTransport` capability
2. #55 — **providers**: carry it onto `ProviderConfig`
3. #56 — **harness**: `selectTransport()` + `StepRunner.step()` selector
4. #57 — **harness**: route the long steps through `step()`

↑ **This PR is #54 (1/4)**, based on `main`.

---

Add a `ProviderTransport` capability (`streaming`, `syncCapMs`, `detachedPoll`) to `ProviderMeta`, declared per provider from its `@computesdk/*` adapter behavior: daytona caps synchronous execs server-side (HTTP 408 on multi-minute commands); e2b's `commands.run()` applies the SDK's default 60s command timeout; modal's exec is uncapped (`syncCapMs: null`). All three support detached+poll.

This is the single owner of each provider's transport facts — the foundation the harness selects a per-step transport from instead of hardcoding one provider's quirks.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_0144qfjJyyjAesfj3FCHrvJ2


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added validation for provider execution transport settings to catch misconfigured provider definitions earlier.
  * Ensured provider capability data is consistently defined, including synchronous execution limits and polling behavior.

* **Tests**
  * Expanded coverage to verify that every provider includes a valid transport configuration and that related limits are correctly shaped.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->