### PR TITLE
feat(providers): carry transport capability onto ProviderConfig (ENG-62)

### DIFF
--- a/packages/harness/src/index.test.ts
+++ b/packages/harness/src/index.test.ts
@@ -18,11 +18,16 @@ import {
 } from "./index.ts";
 import type { SandboxHandle } from "./lib/execute.ts";
 
+// A transport capability for the test fixtures — capped-with-detach, matching a single-round-trip
+// provider; none of these tests exercise real exec, so the exact values are inert here.
+const fixtureTransport = { streaming: false, syncCapMs: 60_000, detachedPoll: true } as const;
+
 // timeOperation only reads identity, never calls createCompute — a throwing stub keeps this unit
 // test free of any real SDK while staying fully typed.
 const config: ProviderConfig = {
 	name: "e2b",
 	requiredEnvVars: [],
+	transport: fixtureTransport,
 	createCompute: () => {
 		throw new Error("not exercised");
 	},
@@ -51,7 +56,12 @@ function fakeProvider(calls: string[], opts: { destroyFails?: boolean } = {}): P
 			},
 		},
 	} as unknown as DirectProvider;
-	return { name: "e2b", requiredEnvVars: [], createCompute: () => compute };
+	return {
+		name: "e2b",
+		requiredEnvVars: [],
+		transport: fixtureTransport,
+		createCompute: () => compute,
+	};
 }
 
 describe("@sandbox-benchmarks/harness", () => {
@@ -103,9 +113,14 @@ describe("@sandbox-benchmarks/harness", () => {
 		expect(calls).toEqual(["create", "destroy"]);
 	});
 
+	// Named "modal", so it carries modal's real (uncapped) transport rather than the capped
+	// fixtureTransport — these creds tests never read transport, but keeping the fixture faithful to
+	// the name stops a future transport-aware test from exercising E2B/Daytona semantics under a
+	// modal-named config.
 	const credsCfg: ProviderConfig = {
 		name: "modal",
 		requiredEnvVars: ["A", "B"],
+		transport: { streaming: false, syncCapMs: null, detachedPoll: true },
 		createCompute: () => {
 			throw new Error("not exercised");
 		},

--- a/packages/providers/README.md
+++ b/packages/providers/README.md
@@ -17,3 +17,7 @@ provider, and the benchmark's create-time policy — the pinned `TARGET_SPEC` an
 (ADR-0003). The assembled `providers` registry joins the schema `PROVIDERS` metadata with the adapter
 map by id; both are keyed by `ProviderId`, so a one-sided provider is a compile error rather than a
 runtime check. Private glue lives in `src/lib/` and is never imported across a package boundary.
+
+The join also carries each provider's schema-owned `transport` capability (`ProviderTransport`:
+streaming, synchronous cap, detached+poll) onto the `ProviderConfig`, so the harness selects a
+per-step exec transport from the declared capability instead of hardcoding one provider's quirks.

--- a/packages/providers/src/index.test.ts
+++ b/packages/providers/src/index.test.ts
@@ -14,6 +14,17 @@ describe("@sandbox-benchmarks/providers", () => {
 		}
 	});
 
+	it("carries each provider's schema-owned transport capability through to the config", () => {
+		// The join must surface the same transport the schema declares, so the harness selects a
+		// transport from the provider's real capability rather than a hardcoded default. `providers` is
+		// `PROVIDERS.map(...)`, so the two are index-aligned by construction — assert positionally
+		// instead of an O(N²) `.find`, which also keeps the failure message pointing at the drift.
+		expect(providers.length).toBe(PROVIDERS.length);
+		for (let i = 0; i < providers.length; i++) {
+			expect(providers[i]?.transport).toEqual(PROVIDERS[i]?.transport);
+		}
+	});
+
 	it("pins modal's create-time spec from the shared TARGET_SPEC", () => {
 		const modal = providers.find((p) => p.name === "modal");
 		// Modal bills/provisions in physical cores, so the pinned vCPU count is halved for cpu/cpuLimit.

--- a/packages/providers/src/index.ts
+++ b/packages/providers/src/index.ts
@@ -27,5 +27,8 @@ export const providers: ProviderConfig[] = PROVIDERS.map((meta) => {
 		// The adapter may refine the required credentials at runtime (daytona's per-region key var);
 		// otherwise the schema ProviderMeta's static list stands.
 		requiredEnvVars: adapter.requiredEnvVars ?? meta.requiredEnvVars,
+		// Transport capability is schema-owned (a static fact of the @computesdk/* integration), so it
+		// rides the same id-keyed join — the harness reads it to pick sync vs detached per step.
+		transport: meta.transport,
 	};
 });

--- a/packages/providers/src/lib/types.ts
+++ b/packages/providers/src/lib/types.ts
@@ -1,7 +1,7 @@
 // The harness-facing adapter contract. Identity (`name`, `requiredEnvVars`) is owned by the schema's
 // ProviderMeta; this module owns only how to construct a provider and the benchmark's create-time
 // policy. `index.ts` joins the two registries by id (PROVIDERS × adapters, both keyed by ProviderId).
-import type { ProviderId } from "@sandbox-benchmarks/schema";
+import type { ProviderId, ProviderTransport } from "@sandbox-benchmarks/schema";
 import type { CreateSandboxOptions, ExplicitComputeConfig } from "computesdk";
 
 /**
@@ -39,4 +39,6 @@ export interface ProviderConfig extends ProviderAdapter {
 	name: ProviderId;
 	/** Env vars that must all be set to run (mirrored from the schema ProviderMeta). */
 	requiredEnvVars: string[];
+	/** Exec transport capability (schema-owned), from which the harness picks a per-step transport. */
+	transport: ProviderTransport;
 }


### PR DESCRIPTION
**ENG-62 — Provider transport capability model**

Generalize transport selection so the harness adapts per provider instead of hardcoding Daytona's detached+poll on every provider. Shipped as a 4-PR stack — merge bottom-up, each branch independently green:

1. #54 — **schema**: declare each provider's `ProviderTransport` capability
2. #55 — **providers**: carry it onto `ProviderConfig`
3. #56 — **harness**: `selectTransport()` + `StepRunner.step()` selector
4. #57 — **harness**: route the long steps through `step()`

↑ **This PR is #55 (2/4)**, based on #54.

---

The id-keyed `PROVIDERS × adapters` join now surfaces each provider's schema-owned `ProviderTransport` onto `ProviderConfig` (required field), so the harness reads the real capability rather than a hardcoded default.

Making the field required pulls in the immediate blast radius: the harness unit-test `ProviderConfig` fixtures gain a transport value to keep that package compiling. The harness itself starts consuming the field in #56/#57.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_0144qfjJyyjAesfj3FCHrvJ2
