### PR TITLE
feat(harness): selectTransport + StepRunner.step capability selector (ENG-62)

### DIFF
--- a/packages/harness/src/lib/execute.test.ts
+++ b/packages/harness/src/lib/execute.test.ts
@@ -1,6 +1,40 @@
 import { describe, expect, it } from "bun:test";
+import type { ProviderTransport } from "@sandbox-benchmarks/schema";
 import type { SandboxHandle } from "./execute.ts";
-import { PREAMBLE, StepRunner, shellQuote } from "./execute.ts";
+import { MIN, PREAMBLE, StepRunner, selectTransport, shellQuote } from "./execute.ts";
+
+const CAPPED: ProviderTransport = { streaming: false, syncCapMs: MIN, detachedPoll: true };
+const UNCAPPED: ProviderTransport = { streaming: false, syncCapMs: null, detachedPoll: true };
+const CAPPED_NO_DETACH: ProviderTransport = {
+	streaming: false,
+	syncCapMs: MIN,
+	detachedPoll: false,
+};
+
+describe("selectTransport", () => {
+	it("detaches a step that could reach or outlast a capped provider's synchronous limit", () => {
+		// Budget past the cap, and the provider supports detached+poll → detached.
+		expect(selectTransport(CAPPED, 2 * MIN)).toBe("detached");
+		// Budget exactly at the cap could run right up to a hard limit with no margin (E2B's cap *is*
+		// its SDK connection timeout) → detached, not sync. The boundary is inclusive of detach.
+		expect(selectTransport(CAPPED, MIN)).toBe("detached");
+	});
+
+	it("keeps a step safely within the cap synchronous", () => {
+		// Strictly under the cap → direct exec.
+		expect(selectTransport(CAPPED, MIN - 1)).toBe("sync");
+		expect(selectTransport(CAPPED, MIN / 2)).toBe("sync");
+	});
+
+	it("keeps every step synchronous on an uncapped provider", () => {
+		// No cap → a synchronous exec is always safe, even for a long step.
+		expect(selectTransport(UNCAPPED, 200 * MIN)).toBe("sync");
+	});
+
+	it("stays synchronous past the cap when the provider can't detach (no durable alternative)", () => {
+		expect(selectTransport(CAPPED_NO_DETACH, 5 * MIN)).toBe("sync");
+	});
+});
 
 describe("shellQuote", () => {
 	it("wraps in single quotes and escapes embedded quotes", () => {
@@ -119,5 +153,77 @@ describe("StepRunner.runDetached", () => {
 		// Foreground path: a single synchronous bash -c exec, no background flag, no detach wrapper.
 		expect(commands[0]).toContain("bash -c");
 		expect(commands[0]).not.toContain("nohup setsid");
+	});
+});
+
+describe("StepRunner.step (capability-driven transport)", () => {
+	// A sandbox WITH a filesystem (so a detached selection truly detaches rather than falling back),
+	// recording each command and its background flag. The done-file is present from the first poll.
+	function fsSandbox(): {
+		sandbox: SandboxHandle;
+		commands: Array<{ command: string; background?: boolean }>;
+	} {
+		const commands: Array<{ command: string; background?: boolean }> = [];
+		const sandbox: SandboxHandle = {
+			runCommand: async (command, options) => {
+				commands.push({ command, background: options?.background });
+				return { exitCode: 0, stdout: "" };
+			},
+			destroy: async () => undefined,
+			filesystem: {
+				exists: async (path) => path.endsWith(".done"),
+				readFile: async (path) => (path.endsWith(".done") ? "0" : "out"),
+			},
+		};
+		return { sandbox, commands };
+	}
+
+	it("detaches a long step on a capped provider", async () => {
+		const { sandbox, commands } = fsSandbox();
+		const runner = new StepRunner(sandbox, CAPPED);
+		await runner.step("long", "mise install", 20 * MIN);
+		// Detached start: backgrounded, wrapped in nohup setsid.
+		expect(commands[0]?.background).toBe(true);
+		expect(commands[0]?.command).toContain("nohup setsid");
+	});
+
+	it("runs a short step synchronously on a capped provider", async () => {
+		const { sandbox, commands } = fsSandbox();
+		const runner = new StepRunner(sandbox, CAPPED);
+		// Budget strictly under the cap → direct exec.
+		await runner.step("short", "df -Pk /", MIN / 2);
+		// Direct exec: a single bash -c, no background flag, no detach wrapper.
+		expect(commands[0]?.background).toBeUndefined();
+		expect(commands[0]?.command).toContain("bash -c");
+		expect(commands[0]?.command).not.toContain("nohup setsid");
+	});
+
+	it("stays synchronous past the cap on a provider that can't detach", async () => {
+		// CAPPED_NO_DETACH exercises step()'s wiring end-to-end (selectTransport via the constructor):
+		// even a long budget has no durable alternative, so it must stay a direct foreground exec and
+		// never background. Guards the no-detach fallback against a future regression in step()'s wiring.
+		const { sandbox, commands } = fsSandbox();
+		const runner = new StepRunner(sandbox, CAPPED_NO_DETACH);
+		await runner.step("long", "mise install", 5 * MIN);
+		expect(commands[0]?.background).toBeUndefined();
+		expect(commands[0]?.command).toContain("bash -c");
+		expect(commands[0]?.command).not.toContain("nohup setsid");
+	});
+
+	it("runs a long step synchronously on an uncapped provider", async () => {
+		const { sandbox, commands } = fsSandbox();
+		const runner = new StepRunner(sandbox, UNCAPPED);
+		await runner.step("long", "mise run benchmark", 110 * MIN);
+		// No cap → direct exec even for a multi-minute step; the filesystem is never polled.
+		expect(commands[0]?.background).toBeUndefined();
+		expect(commands[0]?.command).not.toContain("nohup setsid");
+	});
+
+	it("defaults to a capped profile when constructed without a transport", async () => {
+		// The no-transport constructor (used by the unit-test fakes) detaches a long step by default.
+		const { sandbox, commands } = fsSandbox();
+		const runner = new StepRunner(sandbox);
+		await runner.step("long", "mise install", 20 * MIN);
+		expect(commands[0]?.background).toBe(true);
 	});
 });

--- a/packages/harness/src/lib/execute.ts
+++ b/packages/harness/src/lib/execute.ts
@@ -1,19 +1,28 @@
 /**
  * Suite-step execution against a live sandbox: the in-sandbox shell preamble, a liveness heartbeat,
- * a per-step timeout, and per-phase wall-time accounting. Two transports:
+ * a per-step timeout, and per-phase wall-time accounting. Two transports, and a capability-driven
+ * selector ({@link StepRunner.step}) that picks between them per provider instead of hardcoding one
+ * provider's quirks:
  *
  *   - {@link StepRunner.run}: a direct synchronous exec. Fine for short steps, but NOT durable for
- *     long ones: Daytona's synchronous executeCommand returns HTTP 408 on multi-minute commands
- *     while the process keeps running server-side, and computesdk's Daytona adapter doesn't stream
- *     (it ignores onStdout/onStderr).
+ *     long ones on a capped provider: Daytona's synchronous executeCommand returns HTTP 408 on
+ *     multi-minute commands while the process keeps running server-side, and computesdk's Daytona
+ *     adapter doesn't stream (it ignores onStdout/onStderr).
  *   - {@link StepRunner.runDetached}: starts the step in the background (computesdk's `background:true`,
  *     fully detached with nohup+setsid) writing its output to a log file and its exit code to a
  *     done-file, then polls the sandbox filesystem until the done-file appears. This survives the
  *     408-prone exec round-trip, so multi-minute benchmarks complete. Falls back to `run` when the
  *     sandbox exposes no filesystem (the unit-test fakes) — correctness is unchanged, only durability.
+ *
+ * {@link StepRunner.step} reads the provider's declared {@link ProviderTransport} (via
+ * {@link selectTransport}) and dispatches: a step that could outlast the provider's synchronous cap
+ * runs detached where the provider supports it; everything else runs synchronously. So Daytona keeps
+ * its detached+poll path while an uncapped provider (e.g. Modal) runs the same step directly — the
+ * harness adapts to the capability rather than hardcoding one provider's transport.
  */
 
 import { randomUUID } from "node:crypto";
+import type { ProviderTransport } from "@sandbox-benchmarks/schema";
 
 export const MIN = 60_000;
 
@@ -41,6 +50,41 @@ export interface CommandResult {
 export interface RunCommandOptions {
 	/** Start detached and return immediately, rather than waiting for the command to finish. */
 	background?: boolean;
+}
+
+/** Which transport {@link StepRunner.step} chose for a step. */
+export type TransportKind = "sync" | "detached";
+
+/**
+ * Conservative transport profile used when a {@link StepRunner} is built without a declared one (the
+ * unit-test fakes). Mirrors a single-round-trip-capped provider: short execs go direct, anything
+ * budgeted past ~1 minute detaches — the safe default when a provider's real capability is unknown.
+ */
+export const DEFAULT_TRANSPORT: ProviderTransport = Object.freeze({
+	streaming: false,
+	syncCapMs: MIN,
+	detachedPoll: true,
+});
+
+/**
+ * Pick the exec transport for a step from the provider's declared {@link ProviderTransport} and the
+ * step's timeout budget. A step runs detached when it could reach or outlast the provider's synchronous
+ * cap (`syncCapMs`) AND the provider supports detached+poll; otherwise it runs as a direct synchronous
+ * exec. A `null` cap (uncapped) always stays synchronous; a provider without `detachedPoll` has no
+ * durable alternative, so it stays synchronous and best-effort even past its cap.
+ *
+ * The budget is the comparison key (worst case = a step that runs its full timeout), so the choice is
+ * deterministic and provider-driven, not a guess about a step's actual runtime. The comparison is `>=`,
+ * not `>`: when `syncCapMs` equals a provider's hard limit (E2B's `syncCapMs` *is* its SDK
+ * `defaultProcessConnectionTimeout`), a step budgeted at exactly the cap could run right up to it and
+ * drop the connection with no margin — so a budget that *reaches* the cap detaches, not just one that
+ * exceeds it. `streaming` is modeled on the capability but does not tip this decision today: no shipped
+ * `@computesdk/*` adapter delivers incremental output, so there is no streaming transport to prefer —
+ * when one lands, it is selected here.
+ */
+export function selectTransport(transport: ProviderTransport, timeoutMs: number): TransportKind {
+	const couldExceedSyncCap = transport.syncCapMs !== null && timeoutMs >= transport.syncCapMs;
+	return couldExceedSyncCap && transport.detachedPoll ? "detached" : "sync";
 }
 
 /** The slice of a computesdk sandbox filesystem the detached transport polls (its `filesystem` satisfies this). */
@@ -131,7 +175,30 @@ export class StepRunner {
 	/** Every executed step with its phase, elapsed ms, and exit code. */
 	readonly stepLog: StepLogEntry[] = [];
 
-	constructor(private readonly sandbox: SandboxHandle) {}
+	constructor(
+		private readonly sandbox: SandboxHandle,
+		/** The provider's exec transport capability — {@link step} selects sync vs detached from it. */
+		private readonly transport: ProviderTransport = DEFAULT_TRANSPORT,
+	) {}
+
+	/**
+	 * Run a step on the transport the provider's {@link ProviderTransport} calls for: detached+poll when
+	 * the step's budget could outlast the provider's synchronous cap and the provider supports it,
+	 * otherwise a direct synchronous exec (see {@link selectTransport}). This is the capability-driven
+	 * entry point the orchestrator uses for every step whose runtime can reach into the minutes (setup
+	 * installs, the benchmark, result collection); trivial sub-second probes can call {@link run}
+	 * directly. Both underlying transports populate `result.stdout`, so callers read it identically.
+	 */
+	async step(
+		label: string,
+		script: string,
+		timeoutMs: number,
+		opts: StepOptions = {},
+	): Promise<CommandResult> {
+		return selectTransport(this.transport, timeoutMs) === "detached"
+			? this.runDetached(label, script, timeoutMs, opts)
+			: this.run(label, script, timeoutMs, opts);
+	}
 
 	/**
 	 * Synchronous foreground exec — for short steps. The timeout is a wait-cap, not a kill: on timeout


### PR DESCRIPTION
**ENG-62 — Provider transport capability model**

Generalize transport selection so the harness adapts per provider instead of hardcoding Daytona's detached+poll on every provider. Shipped as a 4-PR stack — merge bottom-up, each branch independently green:

1. #54 — **schema**: declare each provider's `ProviderTransport` capability
2. #55 — **providers**: carry it onto `ProviderConfig`
3. #56 — **harness**: `selectTransport()` + `StepRunner.step()` selector
4. #57 — **harness**: route the long steps through `step()`

↑ **This PR is #56 (3/4)**, based on #55.

---

Add `selectTransport()`, `DEFAULT_TRANSPORT`, and `StepRunner.step()`: a capability-driven entry point that detaches a step only when its timeout budget could outlast the provider's synchronous cap (`syncCapMs`) **and** the provider supports detached+poll, otherwise a direct synchronous exec. The `StepRunner` constructor takes an optional `ProviderTransport` (defaulting to a conservative capped profile), so existing single-arg construction stays valid.

Pure additive mechanism: nothing routes through `step()` yet, but `selectTransport` and `step()` are unit-tested directly (boundary cases, uncapped, no-detach fallback). The orchestrator adopts it in #57.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_0144qfjJyyjAesfj3FCHrvJ2
