### PR TITLE
feat(harness): route long steps through capability-driven step() (ENG-62)

### DIFF
--- a/docs/pts-catalog-and-analysis-design.md
+++ b/docs/pts-catalog-and-analysis-design.md
@@ -195,6 +195,8 @@ Producer never *sets* MONITOR; the risk is **inherited env** from the image/harn
 ## 5. Transport Caveat
 
 > **Status update: the detached+poll transport described below has since been IMPLEMENTED** in the harness (`StepRunner.runDetached`, execute.ts). `SandboxHandle` now carries an optional `filesystem` slice and `runCommand` takes a `RunCommandOptions` with `background`; the benchmark, the long setup installs, and the result collection all run over it. The caveat below is retained as the rationale; the work it prescribes as a "separate stack" is no longer pending.
+>
+> **Follow-up (ENG-62): transport selection is now capability-driven, not hardcoded.** Each provider declares a `ProviderTransport` capability in the schema (`streaming`, `syncCapMs`, `detachedPoll`), and the harness picks per step via `StepRunner.step` / `selectTransport`: a step that could outlast the provider's synchronous cap detaches where supported, everything else runs directly. Daytona's HTTP 408 is one declared capability among several (E2B caps a synchronous `commands.run` at ~60s; Modal's exec is uncapped), so the long-step path is no longer Daytona-specific — it follows whichever provider is running.
 
 Per spike `bn2f5pmp4` (`docs/evidence/daytona-exec-transport.md`), Daytona itself caps a long synchronous `executeCommand` round-trip at **server-side HTTP 408** (FACT 2), and `@computesdk/daytona` does **not** stream — it ignores `onStdout`/`onStderr` and hardcodes `stderr:""` (FACT 1). So Daytona is **not** a safe direct-exec path for multi-minute suites: it is itself a **single-round-trip-capped provider**, alongside Blaxel's ~120s gateway. (`execute.ts`'s header now documents this, with the provider and exact HTTP 408 cap cited.)
 

--- a/packages/harness/README.md
+++ b/packages/harness/README.md
@@ -7,5 +7,10 @@ un-normalized timing runs.
 
 **Depends on:** `@sandbox-benchmarks/providers` (adapter type), `@sandbox-benchmarks/schema` (`RawRun`).
 
-**What lives here:** operation timing and (later) suite orchestration. The clock and other timing
-internals live in `src/lib/` and are never imported across a package boundary.
+**What lives here:** operation timing and suite orchestration. Suite steps run through `StepRunner`,
+which exposes two transports — a direct synchronous exec (`run`) and a durable detached+poll exec
+(`runDetached`) — and a capability-driven selector (`step`). `step` reads the provider's declared
+`ProviderTransport` (`selectTransport`) and detaches a step only when it could outlast the provider's
+synchronous cap and the provider supports detached+poll, so a single-round-trip-capped provider
+(Daytona's HTTP 408) keeps its detached path while an uncapped one runs the same step directly. The
+clock and other timing internals live in `src/lib/` and are never imported across a package boundary.

--- a/packages/harness/src/index.test.ts
+++ b/packages/harness/src/index.test.ts
@@ -238,6 +238,9 @@ const ctx = (s: Suite, resultsDir: string) => ({
 	suiteName: "cpu-node",
 	providerName: "daytona",
 	resultsDir,
+	// Daytona-shaped: synchronous execs capped, detached+poll available. The fake sandbox has no
+	// filesystem, so a detached selection falls back to the foreground path — behavior is unchanged.
+	transport: fixtureTransport,
 });
 
 describe("runSuite (resolution + credential gate)", () => {

--- a/packages/harness/src/index.ts
+++ b/packages/harness/src/index.ts
@@ -3,7 +3,7 @@ import { readdirSync } from "node:fs";
 import { resolve } from "node:path";
 import type { DirectProvider, ProviderConfig } from "@sandbox-benchmarks/providers";
 import { providers } from "@sandbox-benchmarks/providers";
-import type { RawRun, Suite } from "@sandbox-benchmarks/schema";
+import type { ProviderTransport, RawRun, Suite } from "@sandbox-benchmarks/schema";
 import { isPtsResultFile, SUITES } from "@sandbox-benchmarks/schema";
 import { collectResults, writeSkipMarker } from "./lib/collect.ts";
 import type { SandboxHandle } from "./lib/execute.ts";
@@ -128,7 +128,13 @@ export async function runSuite(options: RunSuiteOptions): Promise<void> {
 		}
 	}
 
-	await runSuiteOnSandbox(sandbox, { suite, suiteName, providerName, resultsDir });
+	await runSuiteOnSandbox(sandbox, {
+		suite,
+		suiteName,
+		providerName,
+		resultsDir,
+		transport: config.transport,
+	});
 }
 
 /** The already-resolved context {@link runSuiteOnSandbox} runs against. */
@@ -137,21 +143,25 @@ export interface SuiteRunContext {
 	suiteName: string;
 	providerName: string;
 	resultsDir: string;
+	/** The provider's exec transport capability — drives the per-step sync/detached choice. */
+	transport: ProviderTransport;
 }
 
 /**
  * Run a suite against an already-created sandbox, then tear it down (run-and-dispose). Split from
  * {@link runSuite} so the orchestration — disk gate, setup, benchmark, result collection, the
  * benchmark-vs-collect error precedence, and the always-runs teardown — is testable against a fake
- * sandbox without provisioning a real one. Long steps (setup installs, the benchmark) run on the
- * durable detached transport so Daytona's 408 on multi-minute synchronous execs can't truncate them.
+ * sandbox without provisioning a real one. Long steps (setup installs, the benchmark, result
+ * collection) run through the capability-driven {@link StepRunner.step}, which picks the detached
+ * transport for a provider whose synchronous exec is capped (e.g. Daytona's 408 on multi-minute
+ * commands) and a direct exec for an uncapped one.
  */
 export async function runSuiteOnSandbox(
 	sandbox: SandboxHandle,
 	ctx: SuiteRunContext,
 ): Promise<void> {
-	const { suite, suiteName, providerName, resultsDir } = ctx;
-	const runner = new StepRunner(sandbox);
+	const { suite, suiteName, providerName, resultsDir, transport } = ctx;
+	const runner = new StepRunner(sandbox, transport);
 	let suiteError: unknown;
 	try {
 		runner.phase = "setup";
@@ -172,8 +182,9 @@ export async function runSuiteOnSandbox(
 			const attempts = (step.retries ?? 0) + 1;
 			for (let attempt = 1; ; attempt++) {
 				try {
-					// Detached: a multi-minute install (mise/PTS/apt) would 408 a synchronous exec.
-					await runner.runDetached(step.label, step.script, step.timeoutMs);
+					// A multi-minute install (mise/PTS/apt) would 408 a synchronous exec on a capped
+					// provider — step() detaches it there and runs it directly on an uncapped one.
+					await runner.step(step.label, step.script, step.timeoutMs);
 					break;
 				} catch (err) {
 					if (attempt >= attempts) throw err;
@@ -188,12 +199,9 @@ export async function runSuiteOnSandbox(
 		try {
 			runner.phase = "benchmark";
 			for (const command of suite.commands) {
-				// Detached: the cpu-node command budgets 110 min — far past Daytona's synchronous-exec 408.
-				await runner.runDetached(
-					command,
-					`cd ${DIR} && ${command}`,
-					suite.commandTimeoutMinutes * MIN,
-				);
+				// The cpu-node command budgets 110 min — far past a capped provider's synchronous-exec
+				// limit (Daytona's 408), so step() detaches there; an uncapped provider runs it directly.
+				await runner.step(command, `cd ${DIR} && ${command}`, suite.commandTimeoutMinutes * MIN);
 			}
 		} catch (err) {
 			// Still pull whatever results were produced before failing the job.

--- a/packages/harness/src/lib/collect.ts
+++ b/packages/harness/src/lib/collect.ts
@@ -25,10 +25,11 @@ const RESULTS_END = "__BENCH_RESULTS_TGZ_END__";
 /** Pull the sandbox's benchmark-results/ into `resultsDir` on the host. */
 export async function collectResults(runner: StepRunner, resultsDir: string): Promise<void> {
 	runner.phase = "collect";
-	// Detached transport: the tar|base64 payload lands in the step's log file and is read back, so a
-	// large or slow collect can't 408 the synchronous exec mid-stream (the path long steps use). The
-	// BEGIN/END markers still bound the base64 within that captured output.
-	const result = await runner.runDetached(
+	// Capability-driven transport: on a capped provider the tar|base64 payload lands in the step's log
+	// file and is read back, so a large or slow collect can't 408 the synchronous exec mid-stream; on an
+	// uncapped provider it streams straight back over a direct exec. Both populate `result.stdout`, and
+	// the BEGIN/END markers bound the base64 within that captured output either way.
+	const result = await runner.step(
 		"collect benchmark-results",
 		`cd ${DIR} && mkdir -p benchmark-results && ` +
 			`echo ${RESULTS_BEGIN} && tar -czf - benchmark-results | base64 | tr -d '\\n' && echo && echo ${RESULTS_END}`,


### PR DESCRIPTION
**ENG-62 — Provider transport capability model**

Generalize transport selection so the harness adapts per provider instead of hardcoding Daytona's detached+poll on every provider. Shipped as a 4-PR stack — merge bottom-up, each branch independently green:

1. #54 — **schema**: declare each provider's `ProviderTransport` capability
2. #55 — **providers**: carry it onto `ProviderConfig`
3. #56 — **harness**: `selectTransport()` + `StepRunner.step()` selector
4. #57 — **harness**: route the long steps through `step()`

↑ **This PR is #57 (4/4 — keystone)**, based on #56.

---

`runSuiteOnSandbox` now builds its `StepRunner` from the provider's transport (threaded via `SuiteRunContext.transport`) and routes the long steps — setup installs, the benchmark, result collection — through `StepRunner.step()` instead of the hardcoded `runDetached`. So a capped provider (Daytona's HTTP 408) keeps detached+poll while an uncapped one (Modal) runs the same step directly; trivial sub-second probes stay on the direct path.

Completes ENG-62 and unblocks the per-provider live transport validation in ENG-63 / ENG-64 / ENG-65. Updates the harness README and the transport caveat in the PTS design doc.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_0144qfjJyyjAesfj3FCHrvJ2
