### PR TITLE
fix(providers): accept Daytona ZEN5-VM region, decouple identifier from env-var suffix (ENG-62)

### DIFF
--- a/.github/workflows/bench-smoke.yml
+++ b/.github/workflows/bench-smoke.yml
@@ -15,12 +15,12 @@ on:
         description: Suite to run
         default: cpu-node
       region:
-        # Daytona only: the default org is parked, so real runs use the ZEN5 region (its own API key +
-        # target + snapshot). Ignored by e2b/modal.
+        # Daytona only: the default org is parked, so real runs use the ZEN5-VM region (its own API key +
+        # target + snapshot, keyed by the _ZEN5 env-var suffix). Ignored by e2b/modal.
         description: Daytona region
         type: choice
-        default: zen5
-        options: [zen5, default]
+        default: ZEN5-VM
+        options: [ZEN5-VM, default]
 
 # Least privilege: the job only reads the checked-out code and uploads an artifact.
 permissions:
@@ -63,7 +63,7 @@ jobs:
           # crafted value run arbitrary commands on the self-hosted runner. `$GITHUB_RUN_ID` is built-in.
           BENCH_PROVIDER: ${{ inputs.provider }}
           BENCH_SUITE: ${{ inputs.suite }}
-          # Daytona region selection (default org is parked; ZEN5 is the active region).
+          # Daytona region selection (default org is parked; ZEN5-VM is the active region).
           DAYTONA_REGION: ${{ inputs.region }}
           DAYTONA_API_KEY: ${{ secrets.DAYTONA_API_KEY }}
           DAYTONA_API_KEY_ZEN5: ${{ secrets.DAYTONA_API_KEY_ZEN5 }}

--- a/packages/providers/src/index.test.ts
+++ b/packages/providers/src/index.test.ts
@@ -60,17 +60,27 @@ describe("resolveDaytonaRegion", () => {
 		});
 	});
 
-	it("selects the ZEN5 region's suffixed key + target", () => {
+	it("maps the hyphenated ZEN5-VM region to its _ZEN5 suffixed key + target", () => {
+		// The region identifier (`ZEN5-VM`, with a hyphen) is decoupled from the env-var suffix
+		// (`ZEN5`), so the per-region vars resolve to valid names despite the illegal-in-env hyphen.
 		const r = resolveDaytonaRegion(
-			{ DAYTONA_REGION: "zen5", DAYTONA_API_KEY_ZEN5: "kz", DAYTONA_TARGET_ZEN5: "zen5-rgn" },
+			{
+				DAYTONA_REGION: "ZEN5-VM",
+				DAYTONA_API_KEY_ZEN5: "kz",
+				DAYTONA_TARGET_ZEN5: "zen5-rgn",
+				DAYTONA_SNAPSHOT_ZEN5: "zen5-snap",
+			},
 			SNAP,
 		);
-		expect(r).toMatchObject({
-			region: "zen5",
+		// The suffix applies to every per-region var, including the snapshot — `DAYTONA_SNAPSHOT_ZEN5`
+		// wins over the default snapshot, so a regression that wrongly applied the suffix to the snapshot
+		// var (or fell back to SNAP) would be caught here.
+		expect(r).toEqual({
+			region: "ZEN5-VM",
 			apiKeyVar: "DAYTONA_API_KEY_ZEN5",
 			apiKey: "kz",
 			target: "zen5-rgn",
-			snapshot: SNAP,
+			snapshot: "zen5-snap",
 		});
 	});
 

--- a/packages/providers/src/lib/config.ts
+++ b/packages/providers/src/lib/config.ts
@@ -7,11 +7,23 @@ import { type } from "arktype";
 
 /**
  * Daytona regions the harness knows about. `default` uses the base env vars (DAYTONA_API_KEY, …); a
- * named region uses an UPPERCASE-suffixed set (e.g. `zen5` → DAYTONA_API_KEY_ZEN5, DAYTONA_TARGET_ZEN5,
- * DAYTONA_SNAPSHOT_ZEN5). Daytona's ZEN5 is a beta region with faster machines and its own API key.
+ * named region uses an UPPERCASE-suffixed set (e.g. DAYTONA_API_KEY_ZEN5, DAYTONA_TARGET_ZEN5,
+ * DAYTONA_SNAPSHOT_ZEN5). Daytona's `ZEN5-VM` is a beta region with faster machines and its own API key.
+ *
+ * `region` is Daytona's own region identifier, set verbatim in `DAYTONA_REGION` — it can contain
+ * characters that aren't legal in an env-var name (the beta fast-machine region is `ZEN5-VM`). `suffix`
+ * is the short key the per-region env vars are keyed by, kept *decoupled* from the identifier so a
+ * hyphenated region name still resolves to a valid `DAYTONA_API_KEY_ZEN5` rather than the impossible
+ * `DAYTONA_API_KEY_ZEN5-VM`.
  */
-export const DAYTONA_REGIONS = ["default", "zen5"] as const;
-export type DaytonaRegion = (typeof DAYTONA_REGIONS)[number];
+export const DAYTONA_REGIONS = [
+	{ region: "default", suffix: "" },
+	{ region: "ZEN5-VM", suffix: "ZEN5" },
+] as const;
+export type DaytonaRegion = (typeof DAYTONA_REGIONS)[number]["region"];
+
+/** Region identifier → its env-var suffix, for resolving the per-region key/target/snapshot vars. */
+const SUFFIX_BY_REGION = new Map<string, string>(DAYTONA_REGIONS.map((r) => [r.region, r.suffix]));
 
 // 1. Env schema — only the variables this app reads, validated at the boundary. All optional; an
 //    explicitly-set but empty value is a misconfiguration and is rejected. DAYTONA_REGION must be a
@@ -20,7 +32,8 @@ export type DaytonaRegion = (typeof DAYTONA_REGIONS)[number];
 const envSchema = type({
 	"BENCH_TOOLCHAIN_IMAGE?": "string >= 1",
 	"E2B_TEMPLATE?": "string >= 1",
-	"DAYTONA_REGION?": "'default' | 'zen5'",
+	// Derived from DAYTONA_REGIONS so the accepted values can't drift from the resolver's known set.
+	"DAYTONA_REGION?": type.enumerated(...DAYTONA_REGIONS.map((r) => r.region)),
 	"DAYTONA_API_KEY?": "string >= 1",
 	"DAYTONA_TARGET?": "string >= 1",
 	"DAYTONA_SNAPSHOT?": "string >= 1",
@@ -76,7 +89,11 @@ export function resolveDaytonaRegion(
 	snapshotDefault: string,
 ): DaytonaRegionConfig {
 	const region = (env.DAYTONA_REGION ?? "default") as DaytonaRegion;
-	const suffix = region === "default" ? "" : `_${region.toUpperCase()}`;
+	// The env-var suffix is looked up from the registry, not derived from the identifier, so a region
+	// name with characters illegal in an env-var (e.g. `ZEN5-VM`) still maps to `_ZEN5`. An unknown
+	// region falls back to the base vars rather than synthesizing a bogus suffix.
+	const key = SUFFIX_BY_REGION.get(region) ?? "";
+	const suffix = key ? `_${key}` : "";
 	const apiKeyVar = `DAYTONA_API_KEY${suffix}`;
 	return {
 		region,
@@ -128,6 +145,6 @@ export const config = {
 	/** Candidate daytona snapshot name the bake creates while iterating. */
 	daytonaSnapshotCandidate,
 	/** The active daytona region profile (key var, key, target, snapshot), selected by
-	 *  `DAYTONA_REGION` (`default` | `zen5`). */
+	 *  `DAYTONA_REGION` (`default` | `ZEN5-VM`). */
 	daytonaRegion: resolveDaytonaRegion(rawEnv, daytonaSnapshotDefault),
 } as const;


### PR DESCRIPTION
Daytona renamed its beta fast-machine region from `ZEN5` to `ZEN5-VM`, so `DAYTONA_REGION=ZEN5-VM` is now the valid value and the old `zen5` is rejected upstream. The config gatekeeper still only accepted `'default' | 'zen5'`, so a correctly-configured `.env`/CI run failed validation at module load.

This decouples the **region identifier** (Daytona's own string, which can contain characters illegal in an env-var name — `ZEN5-VM` has a hyphen) from the **env-var suffix** the per-region credentials are keyed by (`ZEN5`, giving `DAYTONA_API_KEY_ZEN5` / `DAYTONA_TARGET_ZEN5` / `DAYTONA_SNAPSHOT_ZEN5`):

- `DAYTONA_REGIONS` becomes a `{ region, suffix }` registry; `resolveDaytonaRegion` looks the suffix up instead of deriving it via `region.toUpperCase()` (which would have produced the impossible `DAYTONA_API_KEY_ZEN5-VM`).
- The `DAYTONA_REGION` arktype validator is derived from that registry, so the accepted values can't drift from the resolver's known set.
- The `bench-smoke` workflow's region input (default + options) moves to `ZEN5-VM`; the `_ZEN5`-suffixed secret names are unchanged.

Not part of the ENG-62 transport stack (#54–#57) — branched off `main` since it touches none of that work.

Test: `resolveDaytonaRegion` now asserts the hyphenated `ZEN5-VM` identifier maps to the `_ZEN5` suffix; full suite green (235 pass).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Support the Daytona `ZEN5-VM` region by mapping it to the existing `_ZEN5` env vars and decoupling the region identifier from env-var suffixes (ENG-62). Updates the resolver, schema, tests, and the bench-smoke workflow default.

- **Bug Fixes**
  - Accept `DAYTONA_REGION=ZEN5-VM` and map to `DAYTONA_API_KEY_ZEN5` / `DAYTONA_TARGET_ZEN5` / `DAYTONA_SNAPSHOT_ZEN5` via a region→suffix registry; unknown regions fall back to base vars. The schema derives accepted values (`default`, `ZEN5-VM`) from the same registry.
  - Update bench-smoke default/options and help text to `ZEN5-VM`. Tests use `ZEN5-VM`, assert per-region snapshot override, switch to strict equality, and tidy a comment for typos CI.

<sup>Written for commit 8dd8dbe6e01aa0f0f8721bb49e1e6536a624ab05. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/starslingdev/sandbox-benchmarks/pull/58?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Expanded support for Daytona region selection to include a hyphenated region option.
  * Region-specific environment values are now mapped more reliably for Daytona-based setups.

* **Bug Fixes**
  * Improved handling of Daytona region detection so related environment variables and snapshots resolve correctly when the new region format is used.
  * Updated the manual smoke workflow to use the new region value by default.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->