### PR TITLE
feat(schema): enforce the suite↔dimension↔metric contract

### DIFF
--- a/packages/harness/src/index.test.ts
+++ b/packages/harness/src/index.test.ts
@@ -229,6 +229,10 @@ function makeSandbox(opts: {
 const suite = (overrides: Partial<Suite>): Suite => ({
 	commandTimeoutMinutes: 1,
 	timeoutMinutes: 1,
+	// The harness never reads dimensions/metrics (those drive the results contract, not orchestration);
+	// keep the fixture empty so it stays decoupled from real catalog ids — like setup.test.ts's bare suite.
+	dimensions: [],
+	metrics: [],
 	commands: ["benchmark-cmd"],
 	...overrides,
 });

--- a/packages/harness/src/lib/setup.test.ts
+++ b/packages/harness/src/lib/setup.test.ts
@@ -21,9 +21,13 @@ describe("setupSteps", () => {
 	});
 
 	it("omits node/PTS setup for a bare suite", () => {
-		const bare = setupSteps({ commandTimeoutMinutes: 1, timeoutMinutes: 1, commands: [] }).map(
-			(step) => step.label,
-		);
+		const bare = setupSteps({
+			commandTimeoutMinutes: 1,
+			timeoutMinutes: 1,
+			dimensions: [],
+			metrics: [],
+			commands: [],
+		}).map((step) => step.label);
 		expect(bare).not.toContain("setup node 22 + pnpm 10");
 		expect(bare).not.toContain("setup phoronix-test-suite");
 	});

--- a/packages/schema/src/index.ts
+++ b/packages/schema/src/index.ts
@@ -15,6 +15,8 @@ export * from "./providers.ts";
 export * from "./raw-files.ts";
 // The canonical Run dataset model (Run/ProviderRun/MetricResult/…) and its validators.
 export * from "./run.ts";
+// The suite↔dimension↔metric contract checker (fail-fast at load) and its violation types.
+export * from "./suite-contract.ts";
 // The benchmark suite registry — shared by the harness and CI matrix planning.
 export * from "./suites.ts";
 // Canonical toolchain image identity (name + version), shared by the build pins and runtime config.

--- a/packages/schema/src/suite-contract.test.ts
+++ b/packages/schema/src/suite-contract.test.ts
@@ -1,0 +1,181 @@
+import { describe, expect, it } from "bun:test";
+import { METRIC_CATALOG } from "./catalog.ts";
+import type { Dimension, MetricDef } from "./metrics.ts";
+import type { SuiteContract } from "./suite-contract.ts";
+import {
+	assertSuiteContract,
+	describeSuiteContractViolation,
+	suiteContractViolations,
+} from "./suite-contract.ts";
+import { SUITES } from "./suites.ts";
+
+// A crafted catalog kept tiny and explicit so each case exercises one rule. Only the fields the
+// contract reads (id, dimension) matter; the rest satisfy MetricDef's shape.
+const metric = (id: string, dimension: Dimension): MetricDef => ({
+	id,
+	dimension,
+	unit: "x",
+	direction: "HIB",
+	headline: false,
+	label: id,
+	description: id,
+});
+
+const catalog: MetricDef[] = [
+	metric("cpu_a", "cpu"),
+	metric("cpu_b", "cpu"),
+	metric("disk_a", "disk"),
+];
+
+const suites = (entries: Record<string, SuiteContract>): Record<string, SuiteContract> => entries;
+
+describe("suiteContractViolations", () => {
+	it("returns no violations for a sound declaration", () => {
+		const out = suiteContractViolations(
+			suites({ "cpu-suite": { dimensions: ["cpu"], metrics: ["cpu_a", "cpu_b"] } }),
+			catalog,
+		);
+		expect(out).toEqual([]);
+	});
+
+	it("accepts a suite spanning several dimensions with a metric on each", () => {
+		const out = suiteContractViolations(
+			suites({ mixed: { dimensions: ["cpu", "disk"], metrics: ["cpu_a", "disk_a"] } }),
+			catalog,
+		);
+		expect(out).toEqual([]);
+	});
+
+	it("flags an uncatalogued metric", () => {
+		const out = suiteContractViolations(
+			suites({ "cpu-suite": { dimensions: ["cpu"], metrics: ["cpu_a", "not_a_metric"] } }),
+			catalog,
+		);
+		// The whole structured violation — uncatalogued arms carry only a metricId, never a dimension.
+		expect(out).toEqual([{ suite: "cpu-suite", kind: "uncatalogued", metricId: "not_a_metric" }]);
+	});
+
+	it("flags a catalogued metric on a dimension the suite does not declare", () => {
+		const out = suiteContractViolations(
+			// disk_a is real but sits on `disk`, which this cpu-only suite never declares.
+			suites({ "cpu-suite": { dimensions: ["cpu"], metrics: ["cpu_a", "disk_a"] } }),
+			catalog,
+		);
+		// The off-dimension arm carries both the metric and the dimension it actually sits on.
+		expect(out).toEqual([
+			{ suite: "cpu-suite", kind: "off-dimension", metricId: "disk_a", dimension: "disk" },
+		]);
+	});
+
+	it("flags a declared dimension that no declared metric covers", () => {
+		const out = suiteContractViolations(
+			suites({ "cpu-suite": { dimensions: ["cpu", "memory"], metrics: ["cpu_a"] } }),
+			catalog,
+		);
+		expect(out).toEqual([{ suite: "cpu-suite", kind: "empty-dimension", dimension: "memory" }]);
+	});
+
+	it("flags every declared dimension when the suite emits no metrics at all", () => {
+		// The metrics loop never runs, so this exercises the dangling-axis pass in isolation.
+		const out = suiteContractViolations(
+			suites({ "cpu-suite": { dimensions: ["cpu"], metrics: [] } }),
+			catalog,
+		);
+		expect(out).toEqual([{ suite: "cpu-suite", kind: "empty-dimension", dimension: "cpu" }]);
+	});
+
+	it("tolerates a metric id listed twice — the dimension is covered, not double-flagged", () => {
+		// Pins current behavior: a repeated id is not itself a contract breach (the catalog guards
+		// id-uniqueness; a suite re-listing one only covers its dimension again).
+		const out = suiteContractViolations(
+			suites({ "cpu-suite": { dimensions: ["cpu"], metrics: ["cpu_a", "cpu_a"] } }),
+			catalog,
+		);
+		expect(out).toEqual([]);
+	});
+
+	it("reports every violation across multiple suites, deterministically ordered", () => {
+		const out = suiteContractViolations(
+			suites({
+				good: { dimensions: ["cpu"], metrics: ["cpu_a"] },
+				bad: { dimensions: ["cpu"], metrics: ["ghost", "disk_a"] },
+			}),
+			catalog,
+		);
+		// `good` is clean. `bad` yields, in order: uncatalogued (ghost) and off-dimension (disk_a) over
+		// its metrics, then the dangling-axis check — `cpu` is declared but its intended metric was the
+		// misspelled `ghost`, so nothing covers it (disk_a, on `disk`, was already rejected off-dimension).
+		expect(out).toEqual([
+			{ suite: "bad", kind: "uncatalogued", metricId: "ghost" },
+			{ suite: "bad", kind: "off-dimension", metricId: "disk_a", dimension: "disk" },
+			{ suite: "bad", kind: "empty-dimension", dimension: "cpu" },
+		]);
+	});
+
+	it("defaults to the real Metric Catalog when none is passed", () => {
+		// node_web_tooling_runs_per_s is the real cpu headline; no second arg means the singleton catalog.
+		expect(
+			suiteContractViolations(
+				suites({ "cpu-node": { dimensions: ["cpu"], metrics: ["node_web_tooling_runs_per_s"] } }),
+			),
+		).toEqual([]);
+	});
+});
+
+describe("describeSuiteContractViolation", () => {
+	it("derives the line for each failure mode from its structured fields", () => {
+		expect(
+			describeSuiteContractViolation({ suite: "s", kind: "uncatalogued", metricId: "m" }),
+		).toBe('suite "s" declares metric "m", which is not in the Metric Catalog');
+		expect(
+			describeSuiteContractViolation({
+				suite: "s",
+				kind: "off-dimension",
+				metricId: "m",
+				dimension: "disk",
+			}),
+		).toBe('suite "s" declares metric "m" on undeclared dimension "disk"');
+		expect(
+			describeSuiteContractViolation({ suite: "s", kind: "empty-dimension", dimension: "memory" }),
+		).toBe('suite "s" declares dimension "memory" but emits no metric on it');
+	});
+});
+
+describe("assertSuiteContract", () => {
+	it("does not throw for the real SUITES against the real catalog", () => {
+		expect(() => assertSuiteContract()).not.toThrow();
+		expect(suiteContractViolations(SUITES, METRIC_CATALOG)).toEqual([]);
+	});
+
+	it("throws a single aggregated error listing every violation line, in order", () => {
+		let message: string | undefined;
+		try {
+			assertSuiteContract(
+				suites({
+					"cpu-suite": { dimensions: ["cpu"], metrics: ["ghost"] },
+					"disk-suite": { dimensions: ["disk"], metrics: ["cpu_a"] },
+				}),
+				catalog,
+			);
+		} catch (err) {
+			message = err instanceof Error ? err.message : String(err);
+		}
+		// One thrown error whose body carries every violation as its own `  - ` line, in suite-declaration
+		// then within-suite order — proving the "fix in one pass" aggregation, not one throw per violation.
+		expect(message).toBe(
+			[
+				"suite ↔ dimension ↔ metric contract violated:",
+				'  - suite "cpu-suite" declares metric "ghost", which is not in the Metric Catalog',
+				'  - suite "cpu-suite" declares dimension "cpu" but emits no metric on it',
+				'  - suite "disk-suite" declares metric "cpu_a" on undeclared dimension "cpu"',
+				'  - suite "disk-suite" declares dimension "disk" but emits no metric on it',
+			].join("\n"),
+		);
+	});
+
+	it("does not throw for a sound crafted registry", () => {
+		expect(() =>
+			assertSuiteContract(suites({ ok: { dimensions: ["disk"], metrics: ["disk_a"] } }), catalog),
+		).not.toThrow();
+	});
+});

--- a/packages/schema/src/suite-contract.ts
+++ b/packages/schema/src/suite-contract.ts
@@ -1,0 +1,134 @@
+/**
+ * The suite ↔ dimension ↔ metric contract: the fail-fast boundary between a benchmark suite (the
+ * producer) and the Metric Catalog (the consumer). As suites multiply, a suite emitting a metric that
+ * is not catalogued — or one catalogued on a different Dimension than the suite claims to measure —
+ * would silently corrupt the comparison: an uncatalogued result is inert (reported, never ranked) and
+ * an off-dimension metric lands under the wrong leaderboard axis. This module makes each suite's
+ * declaration explicit and checks it against the Catalog at schema load, so an incorrectly declared
+ * suite fails the build instead of shipping.
+ *
+ * Why a plain load-time check and not an arktype schema: the contract is a *cross-registry* invariant
+ * (SUITES validated against METRIC_CATALOG), and arktype's `.narrow` validates a single value in
+ * isolation — it can't reach into a second registry. So this mirrors catalog.ts's own cross-registry
+ * guards (duplicate-id, one-headline-per-dimension), which are likewise plain throws at module load
+ * over already-typed in-repo constants. The suite SHAPE is enforced at compile time by
+ * `satisfies Record<string, Suite>` (suites.ts), exactly as providers.ts pins its REGISTRY — no
+ * runtime shape validation is needed for hand-authored constants with no external provenance.
+ *
+ * A {@link SuiteContractViolation} is a discriminated union (one arm per failure mode), so each arm
+ * carries exactly the fields that mode means — an uncatalogued/off-dimension breach names a `metricId`,
+ * a dangling-axis breach names a `dimension`, and the off-dimension arm carries both. The same idiom as
+ * `ProviderPricing` and `PtsMapping`: invalid combinations (a metric id on an empty-dimension breach)
+ * are unrepresentable, and the human message is derived from the structured fields in one place
+ * ({@link describeSuiteContractViolation}) rather than hand-passed alongside `kind`, so the two can't
+ * disagree.
+ *
+ * {@link suiteContractViolations} is pure (suites + catalog in, violations out) so it is unit-testable
+ * against crafted registries and catalogs, independent of the singletons; {@link assertSuiteContract}
+ * is the load-time wrapper that throws, invoked once at module end over the real `SUITES` and
+ * `METRIC_CATALOG`.
+ */
+import { METRIC_CATALOG } from "./catalog.ts";
+import type { Dimension, MetricDef } from "./metrics.ts";
+import type { Suite } from "./suites.ts";
+import { SUITES } from "./suites.ts";
+
+/**
+ * One breach of the suite contract — a discriminated union on {@link SuiteContractViolation.kind}:
+ * - `uncatalogued`    — a declared `metricId` is not in the Metric Catalog.
+ * - `off-dimension`   — a declared `metricId` is catalogued, but on a `dimension` the suite does not
+ *   declare.
+ * - `empty-dimension` — a declared `dimension` is covered by none of the suite's declared metrics (a
+ *   dangling axis: the declaration claims an axis the suite emits nothing on).
+ *
+ * Each arm carries only the fields its mode has, so e.g. a `dimension`-less `uncatalogued` breach or a
+ * `metricId`-bearing `empty-dimension` breach cannot be constructed.
+ */
+export type SuiteContractViolation =
+	| { suite: string; kind: "uncatalogued"; metricId: string }
+	| { suite: string; kind: "off-dimension"; metricId: string; dimension: Dimension }
+	| { suite: string; kind: "empty-dimension"; dimension: Dimension };
+
+/** The slice of a {@link Suite} the contract constrains — declared axes and emitted metric ids. */
+export type SuiteContract = Pick<Suite, "dimensions" | "metrics">;
+
+/** Render a violation as a single human-readable line — the one place breach text is authored. */
+export function describeSuiteContractViolation(violation: SuiteContractViolation): string {
+	const { suite } = violation;
+	switch (violation.kind) {
+		case "uncatalogued":
+			return `suite "${suite}" declares metric "${violation.metricId}", which is not in the Metric Catalog`;
+		case "off-dimension":
+			return `suite "${suite}" declares metric "${violation.metricId}" on undeclared dimension "${violation.dimension}"`;
+		case "empty-dimension":
+			return `suite "${suite}" declares dimension "${violation.dimension}" but emits no metric on it`;
+		default: {
+			// Exhaustiveness guard: a new union arm without a case here is a compile error (the same
+			// `never` idiom as the results package's PtsMapping switch in lib/extract.ts).
+			const _exhaustive: never = violation;
+			throw new Error(`unhandled suite contract violation: ${JSON.stringify(_exhaustive)}`);
+		}
+	}
+}
+
+/**
+ * Every way the given suites breach the contract against `catalog`, in a deterministic order (suite
+ * declaration order, then each suite's declared metrics, then its dangling dimensions). Empty when the
+ * registry is sound. Pure: no module singletons unless the caller passes them.
+ */
+export function suiteContractViolations(
+	suites: Record<string, SuiteContract>,
+	catalog: readonly MetricDef[] = METRIC_CATALOG,
+): SuiteContractViolation[] {
+	// One id → dimension lookup over the catalog, reused across every suite.
+	const dimensionById = new Map<string, Dimension>(
+		catalog.map((metric) => [metric.id, metric.dimension]),
+	);
+	const violations: SuiteContractViolation[] = [];
+
+	for (const [suite, contract] of Object.entries(suites)) {
+		const declared = new Set<Dimension>(contract.dimensions);
+		// Dimensions actually backed by a catalogued, on-dimension metric — used to flag dangling axes.
+		const covered = new Set<Dimension>();
+
+		for (const metricId of contract.metrics) {
+			const dimension = dimensionById.get(metricId);
+			if (dimension === undefined) {
+				violations.push({ suite, kind: "uncatalogued", metricId });
+				continue;
+			}
+			if (!declared.has(dimension)) {
+				violations.push({ suite, kind: "off-dimension", metricId, dimension });
+				continue;
+			}
+			covered.add(dimension);
+		}
+
+		for (const dimension of declared) {
+			if (covered.has(dimension)) continue;
+			violations.push({ suite, kind: "empty-dimension", dimension });
+		}
+	}
+
+	return violations;
+}
+
+/**
+ * Throw if any suite breaches the contract; a no-op otherwise. The error lists every violation at once
+ * (not just the first) so a multi-suite mistake is fixed in one pass. Defaults to the real registry and
+ * Catalog so the bare call at module load is the production check; the arguments stay injectable for
+ * tests.
+ */
+export function assertSuiteContract(
+	suites: Record<string, SuiteContract> = SUITES,
+	catalog: readonly MetricDef[] = METRIC_CATALOG,
+): void {
+	const violations = suiteContractViolations(suites, catalog);
+	if (violations.length === 0) return;
+	const lines = violations.map((violation) => `  - ${describeSuiteContractViolation(violation)}`);
+	throw new Error(`suite ↔ dimension ↔ metric contract violated:\n${lines.join("\n")}`);
+}
+
+// Fail fast at schema load: importing @sandbox-benchmarks/schema (every consumer does) validates the
+// real registry against the real Catalog, so an off-contract suite can never reach a running benchmark.
+assertSuiteContract();

--- a/packages/schema/src/suites.test.ts
+++ b/packages/schema/src/suites.test.ts
@@ -9,6 +9,12 @@ describe("suite registry", () => {
 		expect(cpuNode.commands).toEqual(["mise run benchmark:cpu:node"]);
 	});
 
+	it("declares the cpu dimension and the node-web-tooling metric it emits", () => {
+		const cpuNode = SUITES["cpu-node"];
+		expect(cpuNode.dimensions).toEqual(["cpu"]);
+		expect(cpuNode.metrics).toEqual(["node_web_tooling_runs_per_s"]);
+	});
+
 	it("exposes the suite names", () => {
 		expect(SUITE_NAMES).toEqual(["cpu-node"]);
 	});

--- a/packages/schema/src/suites.ts
+++ b/packages/schema/src/suites.ts
@@ -1,8 +1,17 @@
+import type { Dimension } from "./metrics.ts";
+
 /**
  * The benchmark suite registry — the shared contract between the harness (which runs a suite's
  * commands inside a sandbox) and CI matrix planning (which fans suites out into jobs). Kept here in
  * schema, dependency-free, so both consumers import one source of truth and never disagree on the
  * suite list or its per-suite budgets.
+ *
+ * Each suite also declares the {@link Suite.dimensions} it measures and the catalogued
+ * {@link Suite.metrics} it emits — the producer↔catalog half of the contract. `./suite-contract.ts`
+ * checks that declaration against the Metric Catalog at schema load, so a suite emitting an
+ * uncatalogued or off-dimension metric fails fast at the boundary instead of silently corrupting the
+ * comparison once it runs. The `Dimension` import is type-only, so this module stays runtime
+ * dependency-free; the catalog coupling lives entirely in the contract checker.
  *
  * A suite's `commands` are mise tasks (e.g. `mise run benchmark:cpu:node`) implemented by the
  * in-sandbox producer under `/.mise/tasks/benchmark/**` + `/lib/bench.sh`. This slice ships a single
@@ -21,6 +30,22 @@ export interface Suite {
 	timeoutMinutes: number;
 	/** Skip (with a marker) when the sandbox has less than this much free disk, in GiB. */
 	minDiskGb?: number;
+	/**
+	 * The Dimensions this suite measures — the axes its metrics land on. Every id in {@link metrics}
+	 * must sit on one of these, and every dimension here must be covered by at least one declared
+	 * metric (both enforced by `./suite-contract.ts` at load). Declared alongside `metrics` rather than
+	 * derived from them so a metric catalogued on an unexpected dimension is rejected (off-dimension)
+	 * rather than silently widening the suite's axes; it also lets the leaderboard/matrix group suites
+	 * by axis without expanding the metric list.
+	 */
+	dimensions: readonly Dimension[];
+	/**
+	 * The catalogued Metric ids this suite emits. Each must exist in `METRIC_CATALOG` and sit on one of
+	 * {@link dimensions} — the producer↔catalog contract, checked fail-fast at schema load. A suite may
+	 * list a subset of a multi-result test's catalogued metrics when its `commands` run only some option
+	 * combinations (the unrun entries simply never receive samples).
+	 */
+	metrics: readonly string[];
 	/** Commands run sequentially in the repo checkout. Sandboxes run as root, so no `sudo` prefix. */
 	commands: string[];
 }
@@ -35,6 +60,10 @@ export const SUITES = {
 		setupNode: true,
 		commandTimeoutMinutes: 110,
 		timeoutMinutes: 120,
+		// cpu-node runs only `benchmark:cpu:node` (node-web-tooling); the catalog's c-ray entries belong
+		// to a future cpu-generic suite, so they are deliberately not declared here.
+		dimensions: ["cpu"],
+		metrics: ["node_web_tooling_runs_per_s"],
 		commands: ["mise run benchmark:cpu:node"],
 	},
 } as const satisfies Record<string, Suite>;


### PR DESCRIPTION
**ENG-58 — enforce the suite ↔ dimension ↔ metric contract**

Shipped as a 3-PR stack (merge bottom-up; each branch is independently green):
1. **#59** — contract: each suite declares the Dimensions it measures + the catalogued Metric ids it emits; a load-time check rejects an uncatalogued/off-dimension declaration.
2. **#60** — mechanism: `offDimensionEmissions`, the runtime mirror of that check (pure-additive, unit-tested directly).
3. **#61** — wiring: tag the raw tree by suite and enforce emissions in the normalizer.

↑ **This PR is #59 (1/3)** — base `main`.

---

Extend the suites registry so each suite declares the Dimensions it measures and the catalogued Metric ids it emits, and add a fail-fast checker that rejects, at schema load, any suite declaring an uncatalogued or off-dimension metric.

A suite emitting a metric that is not catalogued (it would fall to the inert uncatalogued path) or one catalogued on the wrong Dimension (wrong leaderboard axis) would silently corrupt the comparison. Making the producer↔catalog declaration explicit and checking it at the registry boundary lets new suites be added safely: a misdeclared suite fails the build instead of shipping.

- suites.ts: Suite gains required dimensions + metrics (type-only Dimension import keeps the module runtime dependency-free); cpu-node declares [cpu] / [node_web_tooling_runs_per_s].
- suite-contract.ts: SuiteContractViolation is a discriminated union (uncatalogued / off-dimension / empty-dimension), pure suiteContractViolations + load-time assertSuiteContract over the real SUITES × METRIC_CATALOG; message text derived in one place via describeSuiteContractViolation.
- Blast radius: making dimensions/metrics required breaks the two harness test fixtures that construct Suite objects (index.test.ts factory, setup.test.ts bare suite) — updated here purely to keep the harness compiling; the harness does not consume the fields.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enforces the suite↔dimension↔metric contract in `schema` with a load‑time checker so suites must declare their dimensions and emitted metric ids; misdeclared suites fail fast instead of corrupting leaderboards. Addresses ENG-58.

- **New Features**
  - `Suite` now requires `dimensions` and `metrics`; `cpu-node` declares `["cpu"]` and `["node_web_tooling_runs_per_s"]`.
  - Added a load‑time contract checker (`suiteContractViolations`, `assertSuiteContract`, `describeSuiteContractViolation`), exported via `index.ts`; validates uncatalogued, off‑dimension (“on undeclared dimension D”), and empty‑dimension cases, aggregating all violations over `SUITES` × `METRIC_CATALOG`.
  - Updated tests and harness fixtures to reflect required fields; fixtures use empty arrays where the harness doesn’t consume them.

- **Migration**
  - When adding or editing a suite, set:
    - `dimensions`: the axes it measures.
    - `metrics`: catalogued metric ids on those dimensions.
  - For test/mocked suites, use `dimensions: []` and `metrics: []`.
  - Importing the schema (or running CI) now fails on any uncatalogued, off‑dimension, or empty‑dimension declaration.

<sup>Written for commit 46aa82f76eae4a06edfe64f8ea89d9c86a30c7c3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/starslingdev/sandbox-benchmarks/pull/59?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added explicit `dimensions` and `metrics` declarations to benchmark suite definitions and tightened the suite registry contract.
  * Introduced schema-level validation to ensure suites correctly align with the metric catalog, including human-readable violation descriptions.

* **Bug Fixes**
  * Contract checks now aggregate and report all detected issues in a single error message.

* **Tests**
  * Expanded coverage for contract violations, deterministic ordering, and message formatting, along with updates to related harness and suite registry tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->