### PR TITLE
feat(schema): off-dimension emission check (runtime half, additive)

### DIFF
--- a/packages/schema/src/raw-files.ts
+++ b/packages/schema/src/raw-files.ts
@@ -1,8 +1,15 @@
 /**
  * The raw-file naming contract — the ONE home for how files in a Run's curated raw tree
- * (`data/raw/<runId>/<provider>/`) are named, and how skip markers are shaped. The in-sandbox
+ * (`data/raw/<runId>/<provider>/<suite>/`) are named, and how skip markers are shaped. The in-sandbox
  * producer and the harness collector (writers) and the results extractor (the single reader) all
  * route through this module, so a filename's spelling can never drift between them.
+ *
+ * Layout: a Run nests one subdirectory per provider, and under it one subdirectory per suite that ran
+ * (the harness pulls each suite's output into `<provider>/<suite>/`). Tagging the tree by suite lets
+ * the normalizer attribute every result to the suite that produced it and reject — per suite — any
+ * catalogued metric emitted on a Dimension that suite does not declare (the runtime half of the
+ * suite↔dimension↔metric contract; see suite-contract.ts). The normalizer still accepts the older
+ * un-nested `<provider>/<file>` layout (results directly under the provider dir) for back-compatibility.
  *
  * Parse, don't validate: the filename predicates and the skip-marker/artifact-name readers are arktype
  * Types — `.matching` regex narrowing plus `.pipe` morphs — so a malformed marker or off-contract name

--- a/packages/schema/src/suite-contract.test.ts
+++ b/packages/schema/src/suite-contract.test.ts
@@ -4,7 +4,9 @@ import type { Dimension, MetricDef } from "./metrics.ts";
 import type { SuiteContract } from "./suite-contract.ts";
 import {
 	assertSuiteContract,
+	describeOffDimensionEmission,
 	describeSuiteContractViolation,
+	offDimensionEmissions,
 	suiteContractViolations,
 } from "./suite-contract.ts";
 import { SUITES } from "./suites.ts";
@@ -177,5 +179,45 @@ describe("assertSuiteContract", () => {
 		expect(() =>
 			assertSuiteContract(suites({ ok: { dimensions: ["disk"], metrics: ["disk_a"] } }), catalog),
 		).not.toThrow();
+	});
+});
+
+describe("offDimensionEmissions (runtime half)", () => {
+	const reg = suites({ "cpu-suite": { dimensions: ["cpu"], metrics: ["cpu_a"] } });
+
+	it("returns nothing when every emitted metric is on a declared dimension", () => {
+		// cpu_a is declared; cpu_b is a catalogued sibling on the SAME declared axis (subset pattern) —
+		// allowed even though the suite didn't list it.
+		expect(offDimensionEmissions("cpu-suite", ["cpu_a", "cpu_b"], reg, catalog)).toEqual([]);
+	});
+
+	it("flags a catalogued metric emitted on a dimension the suite does not declare", () => {
+		expect(offDimensionEmissions("cpu-suite", ["cpu_a", "disk_a"], reg, catalog)).toEqual([
+			{ suite: "cpu-suite", metricId: "disk_a", dimension: "disk" },
+		]);
+	});
+
+	it("ignores an uncatalogued emission — that is the inert-straggler path, not a breach", () => {
+		expect(offDimensionEmissions("cpu-suite", ["ghost"], reg, catalog)).toEqual([]);
+	});
+
+	it("reports a repeated off-dimension id only once", () => {
+		expect(offDimensionEmissions("cpu-suite", ["disk_a", "disk_a"], reg, catalog)).toEqual([
+			{ suite: "cpu-suite", metricId: "disk_a", dimension: "disk" },
+		]);
+	});
+
+	it("returns nothing for an unknown suite name (caller scopes to registered suites)", () => {
+		expect(offDimensionEmissions("not-a-suite", ["disk_a"], reg, catalog)).toEqual([]);
+	});
+
+	it("defaults to the real SUITES + catalog: cpu-node's real emission is on-axis", () => {
+		expect(offDimensionEmissions("cpu-node", ["node_web_tooling_runs_per_s"])).toEqual([]);
+	});
+
+	it("renders a breach line from its structured fields", () => {
+		expect(describeOffDimensionEmission({ suite: "s", metricId: "m", dimension: "disk" })).toBe(
+			'suite "s" emitted metric "m" on dimension "disk", which it does not measure',
+		);
 	});
 });

--- a/packages/schema/src/suite-contract.ts
+++ b/packages/schema/src/suite-contract.ts
@@ -27,6 +27,13 @@
  * against crafted registries and catalogs, independent of the singletons; {@link assertSuiteContract}
  * is the load-time wrapper that throws, invoked once at module end over the real `SUITES` and
  * `METRIC_CATALOG`.
+ *
+ * The load check above guards the suite's *declaration*. The other half — guarding what a suite
+ * actually *emits* at runtime — is {@link offDimensionEmissions}: the results normalizer tags each
+ * suite's raw output by suite (`data/raw/<runId>/<provider>/<suite>/`) and, per suite, rejects any
+ * catalogued metric produced on a Dimension the suite does not declare. Together they close the gap
+ * between "what the registry says a suite measures" and "what its mise tasks really wrote", so a
+ * producer that drifts from the registry fails the run instead of landing a number under the wrong axis.
  */
 import { METRIC_CATALOG } from "./catalog.ts";
 import type { Dimension, MetricDef } from "./metrics.ts";
@@ -132,3 +139,57 @@ export function assertSuiteContract(
 // Fail fast at schema load: importing @sandbox-benchmarks/schema (every consumer does) validates the
 // real registry against the real Catalog, so an off-contract suite can never reach a running benchmark.
 assertSuiteContract();
+
+/**
+ * A catalogued metric a suite EMITTED at runtime on a Dimension it does not declare — the runtime half
+ * of the contract, the mirror of the declaration-time `off-dimension` {@link SuiteContractViolation}.
+ * The declaration check proves a suite's *declared* metrics are catalogued and on-axis; this proves a
+ * suite's *produced* results stay on the axes it measures. Only off-dimension emissions are breaches:
+ * an uncatalogued emission is the normalizer's inert straggler (reported, never ranked), and a
+ * catalogued metric on a Dimension the suite DOES declare is fine even if the suite didn't list that
+ * exact id — a suite may run a subset of a multi-result test's combinations, and the unlisted siblings
+ * are still correctly-dimensioned (design §"which combination runs").
+ */
+export interface OffDimensionEmission {
+	suite: string;
+	metricId: string;
+	/** The metric's catalog Dimension — the axis the suite does not declare. */
+	dimension: Dimension;
+}
+
+/**
+ * Which of `emittedMetricIds` a suite produced on a Dimension outside its declared `dimensions`,
+ * resolved against the Catalog. Ids absent from the Catalog are skipped (inert stragglers, not
+ * breaches); a repeated id is reported once (a metric can land in several of a suite's raw files). An
+ * unknown suite name yields none — the caller scopes to registered suites. Pure / injectable like
+ * {@link suiteContractViolations}, so it is testable against crafted suites and catalogs.
+ */
+export function offDimensionEmissions(
+	suite: string,
+	emittedMetricIds: Iterable<string>,
+	suites: Record<string, SuiteContract> = SUITES,
+	catalog: readonly MetricDef[] = METRIC_CATALOG,
+): OffDimensionEmission[] {
+	const contract = suites[suite];
+	if (!contract) return [];
+	const declared = new Set<Dimension>(contract.dimensions);
+	const dimensionById = new Map<string, Dimension>(
+		catalog.map((metric) => [metric.id, metric.dimension]),
+	);
+	const out: OffDimensionEmission[] = [];
+	const seen = new Set<string>();
+	for (const metricId of emittedMetricIds) {
+		if (seen.has(metricId)) continue;
+		seen.add(metricId);
+		const dimension = dimensionById.get(metricId);
+		if (dimension === undefined) continue; // uncatalogued → inert straggler, not this check's job
+		if (declared.has(dimension)) continue; // on a measured axis → fine (declared id or subset sibling)
+		out.push({ suite, metricId, dimension });
+	}
+	return out;
+}
+
+/** Render an off-dimension emission as one line — the single owner of this breach's text. */
+export function describeOffDimensionEmission(emission: OffDimensionEmission): string {
+	return `suite "${emission.suite}" emitted metric "${emission.metricId}" on dimension "${emission.dimension}", which it does not measure`;
+}


### PR DESCRIPTION
**ENG-58 — enforce the suite ↔ dimension ↔ metric contract**

Shipped as a 3-PR stack (merge bottom-up; each branch is independently green):
1. **#59** — contract: each suite declares the Dimensions it measures + the catalogued Metric ids it emits; a load-time check rejects an uncatalogued/off-dimension declaration.
2. **#60** — mechanism: `offDimensionEmissions`, the runtime mirror of that check (pure-additive, unit-tested directly).
3. **#61** — wiring: tag the raw tree by suite and enforce emissions in the normalizer.

↑ **This PR is #60 (2/3)** — based on #59.

---

Add the runtime mirror of the declaration-time off-dimension check: offDimensionEmissions resolves a suite's PRODUCED metric ids against the Catalog and returns the ones emitted on a Dimension the suite does not declare. Pure-additive — nothing consumes it yet; the results normalizer wires it in the next PR.

- suite-contract.ts: offDimensionEmissions (+ OffDimensionEmission, describeOffDimensionEmission). Uncatalogued emissions are NOT breaches (they stay inert stragglers); a catalogued metric on a DECLARED dimension is fine even if the suite didn't list that exact id (a suite may run a subset of a multi-result test's combinations, and the unlisted siblings are still correctly-dimensioned).
- raw-files.ts: document the per-suite raw-tree layout (data/raw/<runId>/<provider>/<suite>/) that the check operates over, as the naming-contract owner.
- Unit tests cover off-dimension, uncatalogued-ignored, subset-sibling-allowed, repeated-id dedup, and unknown-suite.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds the runtime off-dimension emission check to enforce the suite↔dimension↔metric contract by flagging catalogued metrics a suite emits on undeclared dimensions. Pure additive; wiring into the normalizer lands next (ENG-58).

- **New Features**
  - Add `offDimensionEmissions` (+ `OffDimensionEmission`) and `describeOffDimensionEmission`; dedups ids, skips uncatalogued, allows catalogued siblings on declared axes, returns none for unknown suites.
  - Document per-suite raw path `data/raw/<runId>/<provider>/<suite>/` in `raw-files.ts` with back-compat for the older provider-root layout.

<sup>Written for commit 4d8cac752724b55ef6df2a0d17c78f26d1a5c309. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/starslingdev/sandbox-benchmarks/pull/60?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

