### PR TITLE
feat(results): tag the raw tree by suite and enforce emissions

### DIFF
--- a/apps/cli/src/bin/bench-suite.ts
+++ b/apps/cli/src/bin/bench-suite.ts
@@ -21,7 +21,10 @@ if (import.meta.main) {
 		await runSuite({
 			providerName: provider,
 			suiteName: suite,
-			resultsDir: join(rawRoot, provider),
+			// Tag the raw tree by suite: `<rawRoot>/<provider>/<suite>/`. The normalizer reads each suite
+			// subdirectory independently and rejects any catalogued metric a suite emits off its declared
+			// Dimensions (the runtime half of the suite↔dimension↔metric contract).
+			resultsDir: join(rawRoot, provider, suite),
 		});
 	} catch (err) {
 		if (err instanceof SuiteUsageError) {

--- a/packages/results/src/lib/normalize-tree.test.ts
+++ b/packages/results/src/lib/normalize-tree.test.ts
@@ -65,3 +65,52 @@ describe("normalizeProviderDir de-dupes a metric leaked into two composites", ()
 		}
 	});
 });
+
+describe("normalizeProviderDir reads the suite-tagged layout", () => {
+	let root: string;
+	let providerDir: string;
+	beforeEach(() => {
+		root = mkdtempSync(join(tmpdir(), "norm-tagged-"));
+		providerDir = join(root, "daytona");
+		mkdirSync(providerDir);
+	});
+	afterEach(() => {
+		rmSync(root, { recursive: true, force: true });
+	});
+
+	it("attributes a suite subdirectory's metric and stamps its provenance with the suite", () => {
+		const suiteDir = join(providerDir, "cpu-node");
+		mkdirSync(suiteDir);
+		writeFileSync(join(suiteDir, "pts_node-web-tooling.xml"), composite("16.1:16.3:16.0"));
+		writeFileSync(join(suiteDir, "observed-specs.json"), JSON.stringify({ vcpus: 4, memoryGb: 8 }));
+
+		const run = normalizeProviderDir(root, "daytona");
+		expect(run.validationStatus).toBe("validated");
+		const metric = run.metrics.find((m) => m.metricId === "node_web_tooling_runs_per_s");
+		// sourceFile is prefixed with the suite so a number stays traceable to the suite that wrote it.
+		expect(metric?.sourceFile).toBe("cpu-node/pts_node-web-tooling.xml");
+		// The git result is still an inert straggler, also suite-tagged.
+		expect(run.uncatalogued.map((u) => u.sourceFile)).toEqual([
+			"cpu-node/pts_node-web-tooling.xml",
+		]);
+		// observed-specs.json is read from the suite subdirectory (per-sandbox), not just the provider dir.
+		expect(run.observedSpecs.vcpus).toBe(4);
+	});
+
+	it("ignores (with a warning) a subdirectory that is not a registered suite", () => {
+		const warn = spyOn(console, "warn").mockImplementation(() => {});
+		try {
+			const bogusDir = join(providerDir, "not-a-suite");
+			mkdirSync(bogusDir);
+			writeFileSync(join(bogusDir, "pts_node-web-tooling.xml"), composite("16.1:16.3:16.0"));
+
+			const run = normalizeProviderDir(root, "daytona");
+			// The unknown subdir is skipped, so nothing is attributed and the provider stays pending.
+			expect(run.metrics).toEqual([]);
+			expect(run.validationStatus).toBe("pending");
+			expect(warn.mock.calls.flat().join("\n")).toMatch(/not a registered suite/);
+		} finally {
+			warn.mockRestore();
+		}
+	});
+});

--- a/packages/results/src/lib/normalize-tree.ts
+++ b/packages/results/src/lib/normalize-tree.ts
@@ -4,15 +4,26 @@
  * validated against the shared schema before it leaves this module — validation happens at the
  * producer boundary, so no malformed Run can reach a consumer. SDK-free — filesystem + schema only.
  */
-import { readFileSync, statSync } from "node:fs";
+import { readdirSync, readFileSync, statSync } from "node:fs";
 import { join } from "node:path";
 import type {
 	MetricResult,
+	OffDimensionEmission,
 	ProviderRun,
 	Run,
+	SkipMarker,
 	UncataloguedResult,
 } from "@sandbox-benchmarks/schema";
-import { aggregate, PROVIDERS, parseRun, TARGET_SPEC } from "@sandbox-benchmarks/schema";
+import {
+	aggregate,
+	describeOffDimensionEmission,
+	offDimensionEmissions,
+	PROVIDERS,
+	parseRun,
+	SUITE_NAMES,
+	TARGET_SPEC,
+} from "@sandbox-benchmarks/schema";
+import type { SampleContribution } from "./extract.ts";
 import { extractProviderDir } from "./extract.ts";
 import { computeSpecMatched, readObservedSpecs } from "./specs.ts";
 
@@ -57,6 +68,15 @@ function sameSamples(a: readonly number[], b: readonly number[]): boolean {
 	return a.length === b.length && a.every((value, i) => value === b[i]);
 }
 
+/** Parse a JSON file, returning undefined (never throwing) when it's absent or malformed. */
+function readJsonFile(path: string): unknown {
+	try {
+		return JSON.parse(readFileSync(path, "utf8"));
+	} catch {
+		return undefined;
+	}
+}
+
 /** Normalize one provider's raw directory into a ProviderRun (pending when the directory is absent). */
 export function normalizeProviderDir(rawRoot: string, providerId: string): ProviderRun {
 	const dir = join(rawRoot, providerId);
@@ -79,7 +99,66 @@ export function normalizeProviderDir(rawRoot: string, providerId: string): Provi
 		};
 	}
 
-	const extraction = extractProviderDir(dir, providerId);
+	// The raw tree tags results by suite (`<provider>/<suite>/`). Read each registered-suite
+	// subdirectory on its own, so every produced metric can be attributed to — and contract-checked
+	// against — the suite that wrote it. Also read any files directly under the provider dir: the older
+	// un-nested layout, kept working for back-compat. extractProviderDir only reads files (it skips
+	// subdirectories), so the flat read never double-counts a suite subdir's contents.
+	const registered = new Set<string>(SUITE_NAMES);
+	const suiteDirs: string[] = [];
+	for (const entry of readdirSync(dir, { withFileTypes: true }).sort((a, b) =>
+		a.name.localeCompare(b.name),
+	)) {
+		if (!entry.isDirectory()) continue;
+		if (registered.has(entry.name)) {
+			suiteDirs.push(entry.name);
+			continue;
+		}
+		// An unexpected subdirectory can't be attributed to a suite, so it can't be contract-checked;
+		// skip it loudly rather than silently fold its results into the provider untagged.
+		console.warn(
+			`[normalize] ${providerId}: ignoring subdirectory "${entry.name}" — not a registered suite`,
+		);
+	}
+
+	const contributions: SampleContribution[] = [];
+	const rawUncatalogued: UncataloguedResult[] = [];
+	const skips: SkipMarker[] = [];
+	const offDimension: OffDimensionEmission[] = [];
+
+	for (const suite of suiteDirs) {
+		const ext = extractProviderDir(join(dir, suite), providerId);
+		// Runtime half of the contract: collect any catalogued metric this suite emitted on a Dimension it
+		// does not declare. (Uncatalogued emissions are NOT breaches — they stay inert stragglers below.)
+		offDimension.push(
+			...offDimensionEmissions(
+				suite,
+				ext.contributions.map((c) => c.metricId),
+			),
+		);
+		// Carry the suite in each result's provenance so a metric/straggler stays traceable to its source.
+		for (const c of ext.contributions)
+			contributions.push({ ...c, sourceFile: `${suite}/${c.sourceFile}` });
+		for (const u of ext.uncatalogued)
+			rawUncatalogued.push({ ...u, sourceFile: `${suite}/${u.sourceFile}` });
+		skips.push(...ext.skips);
+	}
+	// Reject at the boundary before any further work: a suite emitting a catalogued metric off its
+	// declared Dimensions is a producer/registry drift that would land a number under the wrong
+	// leaderboard axis. Fail the run with every such emission listed at once, rather than silently
+	// ranking it — and before the flat read below, so the error path does no extra I/O.
+	if (offDimension.length > 0) {
+		const lines = offDimension.map((e) => `  - ${describeOffDimensionEmission(e)}`);
+		throw new Error(
+			`provider "${providerId}" emitted off-contract metrics (suite ↔ dimension ↔ metric contract):\n${lines.join("\n")}`,
+		);
+	}
+
+	// Legacy flat files (no suite subdir): no suite to attribute to, so they can't be contract-checked.
+	const flat = extractProviderDir(dir, providerId);
+	contributions.push(...flat.contributions);
+	rawUncatalogued.push(...flat.uncatalogued);
+	skips.push(...flat.skips);
 
 	// De-dupe catalogued metrics by metricId across source files — keep the FIRST (deterministic file
 	// order). In our model one <Result> owns a metric's per-pass samples, so the same metricId in two
@@ -92,7 +171,7 @@ export function normalizeProviderDir(rawRoot: string, providerId: string): Provi
 		string,
 		{ samples: number[]; sourceFile: string; appVersion?: string; arguments?: string }
 	>();
-	for (const contribution of extraction.contributions) {
+	for (const contribution of contributions) {
 		const existing = merged.get(contribution.metricId);
 		if (existing) {
 			const diverged = !sameSamples(existing.samples, contribution.samples);
@@ -131,18 +210,24 @@ export function normalizeProviderDir(rawRoot: string, providerId: string): Provi
 	// composite it lands in); keep the first occurrence and preserve extraction order.
 	const seenUncatalogued = new Set<string>();
 	const uncatalogued: UncataloguedResult[] = [];
-	for (const straggler of extraction.uncatalogued) {
+	for (const straggler of rawUncatalogued) {
 		if (seenUncatalogued.has(straggler.id)) continue;
 		seenUncatalogued.add(straggler.id);
 		uncatalogued.push(straggler);
 	}
 
+	// Observed specs are per-sandbox; each suite ran in its own sandbox of the same provider, so the
+	// readings describe the same machine. Prefer a suite subdirectory's file (the suite-scoped, current
+	// layout) over a provider-dir file (legacy flat), so a stray legacy file can't shadow the tagged one.
+	// `suiteDirs` is sorted, so when several suites carry one the alphabetically-first wins — an arbitrary
+	// but deterministic tie-break, fine while suites share a provider's spec; revisit if tiers diverge.
+	const specSources = [...suiteDirs, ""];
 	const observedSpecs = readObservedSpecs((name) => {
-		try {
-			return JSON.parse(readFileSync(join(dir, name), "utf8"));
-		} catch {
-			return undefined;
+		for (const sub of specSources) {
+			const parsed = readJsonFile(join(dir, sub, name));
+			if (parsed !== undefined) return parsed;
 		}
+		return undefined;
 	});
 	const specMatched = computeSpecMatched(observedSpecs);
 
@@ -153,7 +238,7 @@ export function normalizeProviderDir(rawRoot: string, providerId: string): Provi
 		...(specMatched !== undefined ? { specMatched } : {}),
 		observedSpecs,
 		metrics,
-		skips: extraction.skips,
+		skips,
 		uncatalogued,
 	};
 }


### PR DESCRIPTION
**ENG-58 — enforce the suite ↔ dimension ↔ metric contract**

Shipped as a 3-PR stack (merge bottom-up; each branch is independently green):
1. **#59** — contract: each suite declares the Dimensions it measures + the catalogued Metric ids it emits; a load-time check rejects an uncatalogued/off-dimension declaration.
2. **#60** — mechanism: `offDimensionEmissions`, the runtime mirror of that check (pure-additive, unit-tested directly).
3. **#61** — wiring: tag the raw tree by suite and enforce emissions in the normalizer.

↑ **This PR is #61 (3/3)** — based on #60.

---

Wire the runtime half end-to-end. The harness writes each suite's pulled output to data/raw/<runId>/<provider>/<suite>/; the normalizer reads each registered-suite subdirectory on its own, attributes + contract-checks its emissions, and rejects (fails the run, listing every breach) any catalogued metric a suite emitted off its declared Dimensions — closing the gap between what the registry says a suite measures and what its mise tasks actually wrote.

- bench-suite.ts: resultsDir nests the suite (<provider>/<suite>/).
- normalize-tree.ts: read each suite subdir, call offDimensionEmissions, throw on off-contract; stamp provenance with the suite; skip unknown subdirs with a warning; read observed-specs from the suite subdir then the provider dir. The older flat <provider>/<file> layout still normalizes (no per-suite check — no suite to attribute to), so existing fixtures/history are untouched.
- Integration tests cover the tagged-layout happy path (provenance, suite-scoped observed-specs) and the unknown-subdir warning; flat-layout tests unchanged.

The off-dimension throw is dormant until a non-cpu dimension is catalogued (every current metric is cpu, which cpu-node declares); the L2 unit tests exercise the logic directly.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Tags raw results by suite and enforces the suite ↔ dimension ↔ metric contract during normalization, rejecting off-dimension catalogued metrics. Keeps the legacy flat layout working; addresses Linear ENG-58.

- **New Features**
  - CLI writes results to `<rawRoot>/<provider>/<suite>/`; normalizer reads each suite independently.
  - Fails the run on off-dimension catalogued metrics; provenance now includes the suite.
  - Warns and skips unknown subdirectories.
  - Observed specs: prefer a suite’s file; fallback to provider-level; deterministic alphabetical tie-break across suites.
  - Legacy flat files still normalize (no per-suite checks).

- **Refactors**
  - Classifies suite subdirectories in one pass.
  - Fails fast before the legacy flat read to avoid extra I/O when a breach is detected.

<sup>Written for commit 16146e538bc095835f1add52b4dff0ff98f21711. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/starslingdev/sandbox-benchmarks/pull/61?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

