### PR TITLE
feat(schema): non-PTS lifecycle & control-plane MetricDefs (ENG-59)

### DIFF
--- a/packages/schema/README.md
+++ b/packages/schema/README.md
@@ -4,7 +4,8 @@
 builds on.
 
 **Public surface (`.`):** the provider registry and economics, the toolchain identity, the Metric
-vocabulary + Catalog (`MetricDef`, `METRIC_CATALOG`, `aggregate()`), the Run dataset model (`Run`,
+vocabulary + Catalog (`MetricDef`, `METRIC_CATALOG`, `aggregate()`), the harness-measured Metric slice
+and its operation→id contract (`harnessMetrics`, `HARNESS_METRIC_IDS`), the Run dataset model (`Run`,
 `ProviderRun`, `MetricResult`, `parseRun()`), the raw-file naming contract, and `RawRun` /
 `parseRawRun()`.
 

--- a/packages/schema/src/catalog.ts
+++ b/packages/schema/src/catalog.ts
@@ -10,6 +10,7 @@
 // the editorial fields the XML can't (a short `label`, the one `headline:true` per dimension, any
 // `dimension` correction). The previously hand-authored cpu entry (node-web-tooling) is now this
 // generated module's wildcard entry; its curation lives in pts-overrides.ts.
+import { harnessMetrics } from "./harness-metrics.ts";
 import type { Dimension, MetricDef } from "./metrics.ts";
 import { metricDefSchema } from "./metrics.ts";
 import { ptsGenerated } from "./pts-generated.ts";
@@ -77,8 +78,15 @@ export const catalogSchema = metricDefSchema.array().narrow((cat, ctx) => {
  * the runtime `.assert` turns a malformed entry (bad dimension/direction, missing field) — or a
  * violated PTS-mapping invariant ({@link catalogSchema}) — into a fail-fast at import rather than a
  * silently broken stability contract.
+ *
+ * The PTS-derived slice (generated + curated) is followed by the hand-authored harness-measured
+ * Metrics (lifecycle + control-plane); the latter carry no `pts` field, so the PTS-mapping invariant
+ * skips them while id-uniqueness and the one-headline-per-dimension check below still cover them.
  */
-export const METRIC_CATALOG: readonly MetricDef[] = catalogSchema.assert(ptsCurated);
+export const METRIC_CATALOG: readonly MetricDef[] = catalogSchema.assert([
+	...ptsCurated,
+	...harnessMetrics,
+]);
 
 const byId = new Map(METRIC_CATALOG.map((metric) => [metric.id, metric]));
 

--- a/packages/schema/src/harness-metrics.test.ts
+++ b/packages/schema/src/harness-metrics.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from "bun:test";
+import { type } from "arktype";
+import {
+	getMetric,
+	HARNESS_METRIC_IDS,
+	harnessMetrics,
+	headlineMetric,
+	METRIC_CATALOG,
+	metricDefSchema,
+	metricsForDimension,
+} from "./index.ts";
+
+describe("harness-measured metrics", () => {
+	it("every HARNESS_METRIC_IDS value resolves to a catalogued, non-PTS, lower-is-better ms Metric", () => {
+		for (const id of Object.values(HARNESS_METRIC_IDS)) {
+			const metric = getMetric(id);
+			expect(metric, `catalog is missing ${id}`).toBeDefined();
+			// Harness Metrics are populated from timings, never a parsed PTS <Result>.
+			expect(metric?.pts).toBeUndefined();
+			expect(metric?.unit).toBe("ms");
+			expect(metric?.direction).toBe("LIB");
+		}
+	});
+
+	it("HARNESS_METRIC_IDS and harnessMetrics describe the same id set", () => {
+		const idValues = new Set(Object.values(HARNESS_METRIC_IDS));
+		const defIds = new Set(harnessMetrics.map((m) => m.id));
+		expect(defIds).toEqual(idValues);
+		// No stray non-harness id slipped into the array.
+		expect(harnessMetrics.length).toBe(idValues.size);
+	});
+
+	it("places the lifecycle ops in the lifecycle dimension and the control-plane ops in control-plane", () => {
+		expect(getMetric(HARNESS_METRIC_IDS.spawn)?.dimension).toBe("lifecycle");
+		expect(getMetric(HARNESS_METRIC_IDS.exec)?.dimension).toBe("lifecycle");
+		expect(getMetric(HARNESS_METRIC_IDS.snapshot)?.dimension).toBe("lifecycle");
+		expect(getMetric(HARNESS_METRIC_IDS.teardown)?.dimension).toBe("lifecycle");
+		expect(getMetric(HARNESS_METRIC_IDS.controlPlaneInfo)?.dimension).toBe("control-plane");
+		expect(getMetric(HARNESS_METRIC_IDS.controlPlaneList)?.dimension).toBe("control-plane");
+	});
+
+	it("headlines spawn for lifecycle and sandbox-info for control-plane", () => {
+		expect(headlineMetric("lifecycle").id).toBe(HARNESS_METRIC_IDS.spawn);
+		expect(headlineMetric("control-plane").id).toBe(HARNESS_METRIC_IDS.controlPlaneInfo);
+		// Exactly one headline per harness dimension (catalog.ts also fails fast on a second).
+		for (const dimension of ["lifecycle", "control-plane"] as const) {
+			const headlines = metricsForDimension(dimension).filter((m) => m.headline);
+			expect(headlines.length).toBe(1);
+		}
+	});
+
+	it("registers every harness Metric in the singleton catalog as a valid MetricDef", () => {
+		for (const def of harnessMetrics) {
+			// not.toBeInstanceOf prints the arktype error summary on failure, unlike toBe(false).
+			expect(metricDefSchema(def)).not.toBeInstanceOf(type.errors);
+			expect(METRIC_CATALOG).toContainEqual(def);
+		}
+	});
+});

--- a/packages/schema/src/harness-metrics.ts
+++ b/packages/schema/src/harness-metrics.ts
@@ -1,0 +1,118 @@
+// The harness-measured Metrics: the lifecycle and control-plane Dimensions PTS cannot see.
+//
+// Phoronix profiles measure work done INSIDE an already-running sandbox; they are blind to how fast a
+// provider spawns, execs, snapshots, and tears a sandbox down, and to how quickly its control-plane
+// API answers. Those axes are measured directly by the harness lifecycle driver
+// (@sandbox-benchmarks/harness), which times each provider SDK call and labels every timing Sample
+// with one of the {@link HARNESS_METRIC_IDS} below — exactly as the PTS parser maps a `<Result>` onto
+// a catalogued id. So these MetricDefs carry NO `pts` provenance: they are populated from harness
+// timings, never from a parsed profile.
+//
+// These entries are hand-authored (the XML generator owns only the PTS half of the Catalog) and merged
+// into METRIC_CATALOG by catalog.ts. The catalog drift gate diffs only the generated PTS module, so
+// editing this file never trips it.
+import type { MetricDef } from "./metrics.ts";
+
+/**
+ * The stable Metric id the harness emits for each timed lifecycle/control-plane operation — the one
+ * source of truth both sides share. The harness imports this map to label each {@link RawRun} it
+ * produces, and {@link harnessMetrics} keys its MetricDefs off the same values, so a `RawRun.operation`
+ * is a catalogued Metric id by construction (the harness-side analogue of the PTS test→id mapping).
+ *
+ * Keyed by the operation the driver performs, not by the id, so the harness reads
+ * `HARNESS_METRIC_IDS.spawn` rather than repeating the string literal.
+ */
+export const HARNESS_METRIC_IDS = {
+	/** Cold start: `sandbox.create()` returns a usable handle. */
+	spawn: "lifecycle_spawn_ms",
+	/** A trivial in-sandbox command round-trip — the exec-path latency floor. */
+	exec: "lifecycle_exec_ms",
+	/** Capturing a snapshot/image from a running sandbox. */
+	snapshot: "lifecycle_snapshot_ms",
+	/** `sandbox.destroy()` releases the sandbox. */
+	teardown: "lifecycle_teardown_ms",
+	/** Control-plane read: a sandbox status/metadata lookup (`getInfo`). */
+	controlPlaneInfo: "control_plane_info_ms",
+	/** Control-plane enumeration: listing the account's sandboxes. */
+	controlPlaneList: "control_plane_list_ms",
+} as const;
+
+/** The operations the lifecycle driver times — the keys of {@link HARNESS_METRIC_IDS}. */
+export type HarnessOperation = keyof typeof HARNESS_METRIC_IDS;
+
+/** A Metric id the harness emits — a value of {@link HARNESS_METRIC_IDS}. */
+export type HarnessMetricId = (typeof HARNESS_METRIC_IDS)[HarnessOperation];
+
+// Every harness Metric is a latency in milliseconds where lower is better; spelled once here so the
+// table below stays a list of the editorial fields (id/label/description/headline) that actually differ.
+const MS = "ms";
+const LIB = "LIB";
+
+/**
+ * The non-PTS Metric Catalog slice: the lifecycle and control-plane Metrics, in display order. Exactly
+ * one `headline:true` per Dimension (spawn for lifecycle, sandbox-info for control-plane), the
+ * invariant catalog.ts enforces at load and harness-metrics.test asserts here. No `pts` field — these
+ * are populated from harness timings, so the catalogSchema PTS-mapping invariant skips them.
+ */
+export const harnessMetrics: MetricDef[] = [
+	{
+		id: HARNESS_METRIC_IDS.spawn,
+		dimension: "lifecycle",
+		unit: MS,
+		direction: LIB,
+		headline: true,
+		label: "Spawn",
+		description:
+			"Wall time for the provider to create a sandbox and return a usable handle (cold start), measured by the harness around the SDK create() call.",
+	},
+	{
+		id: HARNESS_METRIC_IDS.exec,
+		dimension: "lifecycle",
+		unit: MS,
+		direction: LIB,
+		headline: false,
+		label: "Exec round-trip",
+		description:
+			"Wall time of a trivial in-sandbox command round-trip — the exec-path latency floor, independent of the work the command does.",
+	},
+	{
+		id: HARNESS_METRIC_IDS.snapshot,
+		dimension: "lifecycle",
+		unit: MS,
+		direction: LIB,
+		headline: false,
+		label: "Snapshot",
+		description:
+			"Wall time to capture a snapshot/image from a running sandbox. Recorded as a skip for providers whose SDK exposes no snapshot operation.",
+	},
+	{
+		id: HARNESS_METRIC_IDS.teardown,
+		dimension: "lifecycle",
+		unit: MS,
+		direction: LIB,
+		headline: false,
+		label: "Teardown",
+		description:
+			"Wall time for the provider to destroy a sandbox and release its resources, measured by the harness around the SDK destroy() call.",
+	},
+	{
+		id: HARNESS_METRIC_IDS.controlPlaneInfo,
+		dimension: "control-plane",
+		unit: MS,
+		direction: LIB,
+		headline: true,
+		label: "Sandbox info",
+		description:
+			"Round-trip latency of a sandbox status/metadata lookup (getInfo) — the control-plane read path.",
+	},
+	{
+		id: HARNESS_METRIC_IDS.controlPlaneList,
+		dimension: "control-plane",
+		unit: MS,
+		direction: LIB,
+		headline: false,
+		label: "List sandboxes",
+		description:
+			"Round-trip latency of listing the account's sandboxes — the control-plane enumeration path. Recorded as a skip for providers whose SDK exposes no list operation.",
+	},
+];

--- a/packages/schema/src/index.ts
+++ b/packages/schema/src/index.ts
@@ -7,6 +7,8 @@ import { rawRunSchema } from "./lib/internal.ts";
 export * from "./analysis.ts";
 // The Metric Catalog — the registry of rankable Metrics, plus lookup helpers.
 export * from "./catalog.ts";
+// The non-PTS, harness-measured Metric slice (lifecycle + control-plane) and its operation→id contract.
+export * from "./harness-metrics.ts";
 // Metric vocabulary: Dimension, Direction and the MetricDef shape every Metric declares.
 export * from "./metrics.ts";
 // Provider identity & economics registry (id, requiredEnvVars, pricing, isolation, spec-pinning).


### PR DESCRIPTION
**ENG-59 — Lifecycle & control-plane dimensions (harness-measured)**

Shipped as a 4-PR stack (merge bottom-up, each branch is independently green):
1. **#62 — schema:** non-PTS lifecycle & control-plane `MetricDef`s ← _you are here_
2. #63 — harness: lifecycle & control-plane measurement driver
3. #64 — harness: `benchmarkLifecycle` public surface + re-exports
4. #65 — cli: `bench-lifecycle` measures provider lifecycle & control-plane

↑ **This PR is #62 (1/4)**, based on `main`.

Linear: ENG-59

---

Define the harness-measured Metric vocabulary PTS cannot supply: the lifecycle (spawn/exec/snapshot/teardown) and control-plane (sandbox info/list) `MetricDef`s, plus the `HARNESS_METRIC_IDS` operation→id contract the harness and catalog share. Merge them into `METRIC_CATALOG` after the PTS-derived slice; the existing id-uniqueness, one-headline-per-dimension, and PTS-mapping invariants now cover them, and the drift gate (which diffs only the generated PTS module) is unaffected.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds harness‑measured lifecycle and control‑plane metrics to the schema and merges them into the catalog with a stable operation→id contract. Completes ENG‑59 by covering metrics PTS cannot provide without changing the drift gate.

- **New Features**
  - Added `HARNESS_METRIC_IDS` and `harnessMetrics` for lifecycle (spawn/exec/snapshot/teardown) and control‑plane (info/list); all are `ms`, `LIB`; headlines are spawn and sandbox info.
  - Appended `harnessMetrics` to `METRIC_CATALOG` after the PTS slice; PTS-mapping checks skip them, while id uniqueness and one‑headline‑per‑dimension still apply.
  - Re-exported from `packages/schema` and documented in README.
  - Added tests to verify contract parity, dimensions, headlines, schema validity, and catalog inclusion.

<sup>Written for commit 909e62548d60d369ba1a0ad11707866099b374a0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/starslingdev/sandbox-benchmarks/pull/62?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Expanded the schema package’s public API with harness-related metrics and stable operation-to-metric mappings.
  * Added lifecycle and control-plane metrics to the shared metric catalog (with consistent units/directions and headline selection).
* **Documentation**
  * Improved schema documentation formatting to more clearly enumerate exported schema elements and metric groupings.
* **Tests**
  * Added a test suite to verify harness metric completeness, correct attributes, headline behavior, and catalog/schema integration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->