### PR TITLE
feat(harness): lifecycle & control-plane measurement driver (ENG-59)

### DIFF
--- a/packages/harness/src/lib/internal.ts
+++ b/packages/harness/src/lib/internal.ts
@@ -4,3 +4,20 @@
 export function now(): number {
 	return performance.now();
 }
+
+/** A measured operation: its return value paired with the elapsed wall time. */
+export interface Timed<T> {
+	value: T;
+	ms: number;
+}
+
+/**
+ * Time an async (or sync) operation, flooring to a strictly-positive duration. `rawRunSchema` requires
+ * `durationMs > 0`, and a sub-tick op can observe two equal `now()` readings (a 0 delta) — so the floor
+ * to EPSILON lives here, the single home for the contract `timeOperation` and the lifecycle driver share.
+ */
+export async function time<T>(run: () => Promise<T> | T): Promise<Timed<T>> {
+	const start = now();
+	const value = await run();
+	return { value, ms: Math.max(now() - start, Number.EPSILON) };
+}

--- a/packages/harness/src/lib/lifecycle.test.ts
+++ b/packages/harness/src/lib/lifecycle.test.ts
@@ -1,0 +1,231 @@
+import { describe, expect, it } from "bun:test";
+import type { RawRun } from "@sandbox-benchmarks/schema";
+import { HARNESS_METRIC_IDS } from "@sandbox-benchmarks/schema";
+import type { LifecycleCompute, LifecycleSandbox } from "./lifecycle.ts";
+import { aggregateLifecycle, measureLifecycle } from "./lifecycle.ts";
+
+interface FakeCalls {
+	order: string[];
+	deletedSnapshots: string[];
+}
+
+interface FakeOptions {
+	withSnapshot?: boolean;
+	withList?: boolean;
+	failCreate?: boolean;
+	failExec?: boolean;
+	failInfo?: boolean;
+	failDestroy?: boolean;
+	failSnapshotCreate?: boolean;
+}
+
+/** A fake compute that records its call order, so the driver's chain is checkable without a real SDK. */
+function fakeCompute(opts: FakeOptions = {}): { compute: LifecycleCompute; calls: FakeCalls } {
+	const calls: FakeCalls = { order: [], deletedSnapshots: [] };
+	const sandbox: LifecycleSandbox = {
+		sandboxId: "sb-1",
+		async runCommand(command) {
+			calls.order.push(`exec:${command}`);
+			if (opts.failExec) throw new Error("exec boom");
+			return { exitCode: 0 };
+		},
+		async getInfo() {
+			calls.order.push("getInfo");
+			if (opts.failInfo) throw new Error("info boom");
+			return { status: "running" };
+		},
+		async destroy() {
+			calls.order.push("destroy");
+			if (opts.failDestroy) throw new Error("destroy boom");
+			return undefined;
+		},
+	};
+	const sandboxManager: LifecycleCompute["sandbox"] = {
+		async create() {
+			calls.order.push("create");
+			if (opts.failCreate) throw new Error("create boom");
+			return sandbox;
+		},
+	};
+	if (opts.withList) {
+		sandboxManager.list = async () => {
+			calls.order.push("list");
+			return [sandbox];
+		};
+	}
+	const compute: LifecycleCompute = { sandbox: sandboxManager };
+	if (opts.withSnapshot) {
+		compute.snapshot = {
+			async create(sandboxId) {
+				calls.order.push(`snapshot:${sandboxId}`);
+				if (opts.failSnapshotCreate) throw new Error("snapshot boom");
+				return { id: "snap-1" };
+			},
+			async delete(snapshotId) {
+				calls.deletedSnapshots.push(snapshotId);
+				return undefined;
+			},
+		};
+	}
+	return { compute, calls };
+}
+
+/** Map of Metric id → number of Samples that carry it. */
+function countByOp(samples: RawRun[]): Record<string, number> {
+	const counts: Record<string, number> = {};
+	for (const s of samples) counts[s.operation] = (counts[s.operation] ?? 0) + 1;
+	return counts;
+}
+
+const reasonFor = (skips: { suite: string; reason: string }[], op: string): string | undefined =>
+	skips.find((s) => s.suite === op)?.reason;
+
+describe("measureLifecycle", () => {
+	it("times the full spawn→exec→info→list→snapshot→teardown chain in order", async () => {
+		const { compute, calls } = fakeCompute({ withSnapshot: true, withList: true });
+		const { samples, skips } = await measureLifecycle(compute, {
+			provider: "e2b",
+			controlPlaneSamples: 2,
+		});
+
+		expect(calls.order).toEqual([
+			"create",
+			"exec:true",
+			"getInfo",
+			"getInfo",
+			"list",
+			"list",
+			"snapshot:sb-1",
+			"destroy",
+		]);
+		// controlPlaneSamples:2 governs BOTH control-plane reads — getInfo and list each probed twice.
+		expect(countByOp(samples)).toEqual({
+			[HARNESS_METRIC_IDS.spawn]: 1,
+			[HARNESS_METRIC_IDS.exec]: 1,
+			[HARNESS_METRIC_IDS.controlPlaneInfo]: 2,
+			[HARNESS_METRIC_IDS.controlPlaneList]: 2,
+			[HARNESS_METRIC_IDS.snapshot]: 1,
+			[HARNESS_METRIC_IDS.teardown]: 1,
+		});
+		// Every Sample carries the provider and a strictly-positive duration (the RawRun contract).
+		expect(samples.every((s) => s.provider === "e2b" && s.durationMs > 0)).toBe(true);
+		expect(skips).toEqual([]);
+		// The measured snapshot is cleaned up, never leaked.
+		expect(calls.deletedSnapshots).toEqual(["snap-1"]);
+	});
+
+	it("honors a custom exec command", async () => {
+		const { compute, calls } = fakeCompute();
+		await measureLifecycle(compute, { provider: "e2b", execCommand: "uname -a" });
+		expect(calls.order).toContain("exec:uname -a");
+	});
+
+	it("records a skip (not a sample) when the SDK exposes no snapshot or list operation", async () => {
+		const { compute } = fakeCompute(); // no snapshot manager, no list
+		const { samples, skips } = await measureLifecycle(compute, { provider: "modal" });
+
+		const ops = countByOp(samples);
+		expect(ops[HARNESS_METRIC_IDS.snapshot]).toBeUndefined();
+		expect(ops[HARNESS_METRIC_IDS.controlPlaneList]).toBeUndefined();
+		// Spawn/exec/info/teardown still measured.
+		expect(ops[HARNESS_METRIC_IDS.spawn]).toBe(1);
+		expect(ops[HARNESS_METRIC_IDS.teardown]).toBe(1);
+		expect(reasonFor(skips, HARNESS_METRIC_IDS.snapshot)).toMatch(/no snapshot operation/);
+		expect(reasonFor(skips, HARNESS_METRIC_IDS.controlPlaneList)).toMatch(
+			/no sandbox list operation/,
+		);
+	});
+
+	it("records a skip when snapshot measurement is disabled, without calling the SDK", async () => {
+		const { compute, calls } = fakeCompute({ withSnapshot: true });
+		const { samples, skips } = await measureLifecycle(compute, {
+			provider: "e2b",
+			snapshot: false,
+		});
+		expect(calls.order.some((c) => c.startsWith("snapshot:"))).toBe(false);
+		expect(countByOp(samples)[HARNESS_METRIC_IDS.snapshot]).toBeUndefined();
+		expect(reasonFor(skips, HARNESS_METRIC_IDS.snapshot)).toMatch(/disabled/);
+	});
+
+	it("turns a mid-chain exec failure into a skip and still tears down", async () => {
+		const { compute, calls } = fakeCompute({ failExec: true });
+		const { samples, skips } = await measureLifecycle(compute, { provider: "e2b" });
+		// exec failed → no exec sample, but a skip carrying the error message.
+		expect(countByOp(samples)[HARNESS_METRIC_IDS.exec]).toBeUndefined();
+		expect(reasonFor(skips, HARNESS_METRIC_IDS.exec)).toBe("exec boom");
+		// Teardown still ran and was sampled.
+		expect(calls.order).toContain("destroy");
+		expect(countByOp(samples)[HARNESS_METRIC_IDS.teardown]).toBe(1);
+	});
+
+	it("skips every failed control-plane probe but keeps measuring", async () => {
+		const { compute } = fakeCompute({ failInfo: true });
+		const { samples, skips } = await measureLifecycle(compute, {
+			provider: "e2b",
+			controlPlaneSamples: 3,
+		});
+		expect(countByOp(samples)[HARNESS_METRIC_IDS.controlPlaneInfo]).toBeUndefined();
+		// Each failed probe records its own skip.
+		expect(skips.filter((s) => s.suite === HARNESS_METRIC_IDS.controlPlaneInfo).length).toBe(3);
+		expect(countByOp(samples)[HARNESS_METRIC_IDS.spawn]).toBe(1);
+	});
+
+	it("rejects when spawn fails — there is no sandbox to tear down", async () => {
+		const { compute, calls } = fakeCompute({ failCreate: true });
+		await expect(measureLifecycle(compute, { provider: "e2b" })).rejects.toThrow("create boom");
+		expect(calls.order).toEqual(["create"]);
+	});
+
+	it("records a teardown failure as a skip rather than throwing out of finally", async () => {
+		const { compute } = fakeCompute({ failDestroy: true });
+		const { samples, skips } = await measureLifecycle(compute, { provider: "e2b" });
+		expect(countByOp(samples)[HARNESS_METRIC_IDS.spawn]).toBe(1);
+		expect(countByOp(samples)[HARNESS_METRIC_IDS.teardown]).toBeUndefined();
+		expect(reasonFor(skips, HARNESS_METRIC_IDS.teardown)).toBe("destroy boom");
+	});
+
+	it("records a snapshot-create failure as a skip", async () => {
+		const { compute } = fakeCompute({ withSnapshot: true, failSnapshotCreate: true });
+		const { samples, skips } = await measureLifecycle(compute, { provider: "e2b" });
+		expect(countByOp(samples)[HARNESS_METRIC_IDS.snapshot]).toBeUndefined();
+		expect(reasonFor(skips, HARNESS_METRIC_IDS.snapshot)).toBe("snapshot boom");
+	});
+});
+
+describe("aggregateLifecycle", () => {
+	const raw = (operation: string, durationMs: number): RawRun => ({
+		provider: "e2b",
+		operation,
+		durationMs,
+	});
+
+	it("groups Samples by Metric id and aggregates, in HARNESS_METRIC_IDS order", () => {
+		const aggregates = aggregateLifecycle([
+			raw(HARNESS_METRIC_IDS.controlPlaneInfo, 10),
+			raw(HARNESS_METRIC_IDS.spawn, 200),
+			raw(HARNESS_METRIC_IDS.controlPlaneInfo, 20),
+			raw(HARNESS_METRIC_IDS.spawn, 100),
+			raw(HARNESS_METRIC_IDS.controlPlaneInfo, 30),
+		]);
+		// spawn precedes control-plane info (declaration order), regardless of Sample order.
+		expect(aggregates.map((a) => a.metricId)).toEqual([
+			HARNESS_METRIC_IDS.spawn,
+			HARNESS_METRIC_IDS.controlPlaneInfo,
+		]);
+		const spawn = aggregates[0];
+		const info = aggregates[1];
+		expect(spawn?.aggregates.n).toBe(2);
+		expect(spawn?.aggregates.p50).toBe(150);
+		expect(info?.aggregates.n).toBe(3);
+		expect(info?.aggregates.p50).toBe(20);
+	});
+
+	it("omits operations with no Samples", () => {
+		const aggregates = aggregateLifecycle([raw(HARNESS_METRIC_IDS.teardown, 5)]);
+		expect(aggregates.map((a) => a.metricId)).toEqual([HARNESS_METRIC_IDS.teardown]);
+	});
+
+	it("returns an empty list for no Samples", () => {
+		expect(aggregateLifecycle([])).toEqual([]);
+	});
+});

--- a/packages/harness/src/lib/lifecycle.ts
+++ b/packages/harness/src/lib/lifecycle.ts
@@ -1,0 +1,182 @@
+/**
+ * Lifecycle & control-plane measurement — the harness-measured Dimensions PTS cannot see.
+ *
+ * A PTS profile times work done INSIDE an already-running sandbox; it is blind to how fast a provider
+ * spawns, execs, snapshots, and tears a sandbox down, and to how quickly its control-plane API answers.
+ * This module times those provider SDK calls directly and labels each timing with the matching
+ * {@link HARNESS_METRIC_IDS} id, so a {@link RawRun}'s `operation` is a catalogued Metric id by
+ * construction — the harness-side analogue of the PTS `<Result>`→id mapping.
+ *
+ * {@link measureLifecycle} drives ONE cold-start cycle (spawn → exec → control-plane probes → snapshot
+ * → teardown) against a structural {@link LifecycleCompute}, so it is unit-testable against a fake with
+ * no real SDK. Spawn is the bookend that must succeed (a failure has nothing to tear down, so it
+ * rejects); every middle step is best-effort (a flaky exec/probe records a skip, never losing the
+ * spawn/teardown samples); teardown always runs in `finally` and never throws out of it. Repeat the
+ * cycle for a cold-start distribution — that is what {@link benchmarkLifecycle} (in index.ts) does.
+ */
+import type { Aggregates, HarnessMetricId, RawRun, SkipMarker } from "@sandbox-benchmarks/schema";
+import { aggregate, HARNESS_METRIC_IDS } from "@sandbox-benchmarks/schema";
+import { time } from "./internal.ts";
+
+/** The slice of a computesdk sandbox the lifecycle driver times (its `Sandbox` satisfies this). */
+export interface LifecycleSandbox {
+	readonly sandboxId: string;
+	runCommand(command: string, options?: { background?: boolean }): Promise<{ exitCode: number }>;
+	getInfo(): Promise<unknown>;
+	destroy(): Promise<unknown>;
+}
+
+/** The slice of a computesdk snapshot manager the driver times (its `ProviderSnapshotManager` satisfies this). */
+export interface LifecycleSnapshots {
+	create(sandboxId: string, options?: { name?: string }): Promise<{ id: string }>;
+	delete(snapshotId: string): Promise<unknown>;
+}
+
+/** The slice of a computesdk provider the driver needs (its `DirectProvider` satisfies this). */
+export interface LifecycleCompute {
+	sandbox: {
+		create(options?: unknown): Promise<LifecycleSandbox>;
+		/** Present on providers whose SDK can enumerate sandboxes — the control-plane list probe. */
+		list?(): Promise<unknown[]>;
+	};
+	/** Present on providers whose SDK exposes snapshots — the lifecycle snapshot probe. */
+	snapshot?: LifecycleSnapshots;
+}
+
+export interface MeasureLifecycleOptions {
+	/** Provider id stamped onto every emitted {@link RawRun}. */
+	provider: string;
+	/** Create-time options forwarded verbatim to `sandbox.create` (the pinned spec/image). */
+	createOptions?: unknown;
+	/** Trivial command timed for the exec round-trip floor. Default `"true"`. */
+	execCommand?: string;
+	/** How many times to probe each control-plane read within the one sandbox. Default `1`. */
+	controlPlaneSamples?: number;
+	/** Attempt a snapshot (recorded as a skip when the SDK exposes none, or when false). Default `true`. */
+	snapshot?: boolean;
+}
+
+/** One cold-start cycle's output: a timing Sample per measured op, a skip per op that couldn't run. */
+export interface LifecycleMeasurement {
+	samples: RawRun[];
+	skips: SkipMarker[];
+}
+
+/** A measured operation's distribution, keyed by the catalogued Metric id its Samples belong to. */
+export interface LifecycleAggregate {
+	metricId: HarnessMetricId;
+	aggregates: Aggregates;
+}
+
+const reasonOf = (err: unknown): string => (err instanceof Error ? err.message : String(err));
+
+/**
+ * Measure one full lifecycle cycle against `compute`, returning a timing Sample per op and a skip per op
+ * that was unsupported or failed. See the module header for the spawn-rejects / middle-best-effort /
+ * teardown-always-runs contract.
+ */
+export async function measureLifecycle(
+	compute: LifecycleCompute,
+	options: MeasureLifecycleOptions,
+): Promise<LifecycleMeasurement> {
+	const { provider } = options;
+	const execCommand = options.execCommand ?? "true";
+	// `?? 1` only catches undefined; a NaN/Infinity slipping through would make `i < samples` never
+	// run (or never stop), so a non-finite value falls back to a single probe.
+	const rawSamples = options.controlPlaneSamples ?? 1;
+	const controlPlaneSamples = Number.isFinite(rawSamples) ? Math.max(1, Math.floor(rawSamples)) : 1;
+	const wantSnapshot = options.snapshot ?? true;
+
+	const samples: RawRun[] = [];
+	const skips: SkipMarker[] = [];
+	const sample = (operation: HarnessMetricId, ms: number): void => {
+		samples.push({ provider, operation, durationMs: ms });
+	};
+	// Reuse SkipMarker's `suite` slot for the skipped op's Metric id — it identifies what didn't run.
+	const skip = (operation: HarnessMetricId, reason: string): void => {
+		skips.push({ suite: operation, reason });
+	};
+	// A timed step that records a Sample on success and a skip (never a throw) on failure.
+	const step = async (operation: HarnessMetricId, run: () => Promise<unknown>): Promise<void> => {
+		try {
+			sample(operation, (await time(run)).ms);
+		} catch (err) {
+			skip(operation, reasonOf(err));
+		}
+	};
+
+	// Spawn: the opening bookend. A failure has no sandbox to tear down, so it rejects and the caller
+	// records the failed cold-start cycle.
+	const spawned = await time(() => compute.sandbox.create(options.createOptions));
+	sample(HARNESS_METRIC_IDS.spawn, spawned.ms);
+	const sandbox = spawned.value;
+
+	try {
+		// Exec: a trivial command round-trip — the exec-path latency floor, independent of the work done.
+		await step(HARNESS_METRIC_IDS.exec, () => sandbox.runCommand(execCommand));
+
+		// Control-plane read: getInfo, sampled within this one (cheap) sandbox to build a distribution
+		// without paying a fresh spawn/teardown per Sample.
+		for (let i = 0; i < controlPlaneSamples; i++) {
+			await step(HARNESS_METRIC_IDS.controlPlaneInfo, () => sandbox.getInfo());
+		}
+
+		// Control-plane enumeration: list, when the SDK exposes it. Bind `this` so the captured method
+		// keeps its receiver, and narrow on a const (property narrowing wouldn't survive the closure).
+		const listSandboxes = compute.sandbox.list?.bind(compute.sandbox);
+		if (listSandboxes) {
+			// Sampled `controlPlaneSamples` times like getInfo — list is a control-plane read too, so the
+			// configured probe depth governs both reads, not just info.
+			for (let i = 0; i < controlPlaneSamples; i++) {
+				await step(HARNESS_METRIC_IDS.controlPlaneList, () => listSandboxes());
+			}
+		} else {
+			skip(HARNESS_METRIC_IDS.controlPlaneList, "provider SDK exposes no sandbox list operation");
+		}
+
+		// Snapshot: when requested and the SDK exposes a snapshot manager. Best-effort delete afterwards
+		// so a measured snapshot never leaks into the account.
+		const snapshots = compute.snapshot;
+		if (!wantSnapshot) {
+			skip(HARNESS_METRIC_IDS.snapshot, "snapshot measurement disabled for this run");
+		} else if (!snapshots) {
+			skip(HARNESS_METRIC_IDS.snapshot, "provider SDK exposes no snapshot operation");
+		} else {
+			try {
+				const snap = await time(() => snapshots.create(sandbox.sandboxId));
+				sample(HARNESS_METRIC_IDS.snapshot, snap.ms);
+				// Best-effort cleanup: a failed delete shouldn't fail the cycle, but it can leak a snapshot,
+				// so surface it (mirrors the destroy-failure warning) instead of swallowing it silently.
+				await snapshots.delete(snap.value.id).catch((err) => {
+					console.warn(`[lifecycle] snapshot cleanup failed (${snap.value.id}): ${reasonOf(err)}`);
+				});
+			} catch (err) {
+				skip(HARNESS_METRIC_IDS.snapshot, reasonOf(err));
+			}
+		}
+	} finally {
+		// Teardown: the closing bookend — always attempted. A throw out of `finally` would mask an
+		// in-flight error, so a failed destroy is a skip, not a throw; the leak is the caller's to notice.
+		try {
+			sample(HARNESS_METRIC_IDS.teardown, (await time(() => sandbox.destroy())).ms);
+		} catch (err) {
+			skip(HARNESS_METRIC_IDS.teardown, reasonOf(err));
+		}
+	}
+
+	return { samples, skips };
+}
+
+/**
+ * Group {@link RawRun} Samples by their Metric id and aggregate each into the canonical distribution,
+ * in {@link HARNESS_METRIC_IDS} declaration order. Operations with no Samples (all skipped) are omitted
+ * rather than aggregated — `aggregate()` requires at least one Sample.
+ */
+export function aggregateLifecycle(samples: readonly RawRun[]): LifecycleAggregate[] {
+	const out: LifecycleAggregate[] = [];
+	for (const metricId of Object.values(HARNESS_METRIC_IDS)) {
+		const durations = samples.filter((s) => s.operation === metricId).map((s) => s.durationMs);
+		if (durations.length > 0) out.push({ metricId, aggregates: aggregate(durations) });
+	}
+	return out;
+}


### PR DESCRIPTION
**ENG-59 — Lifecycle & control-plane dimensions (harness-measured)**

Shipped as a 4-PR stack (merge bottom-up, each branch is independently green):
1. #62 — schema: non-PTS lifecycle & control-plane `MetricDef`s
2. **#63 — harness:** lifecycle & control-plane measurement driver ← _you are here_
3. #64 — harness: `benchmarkLifecycle` public surface + re-exports
4. #65 — cli: `bench-lifecycle` measures provider lifecycle & control-plane

↑ **This PR is #63 (2/4)**, based on #62.

Linear: ENG-59

---

Add the harness-side mechanism that times each provider SDK call — spawn → exec → snapshot → teardown plus the control-plane reads (`getInfo`, `list`) — and labels every timing with the matching `HARNESS_METRIC_IDS` id, so a `RawRun.operation` is a catalogued Metric id by construction. `measureLifecycle` drives one cold-start cycle against a structural `LifecycleCompute` (unit-testable with no real SDK): spawn must succeed, every middle step is best-effort (a flaky probe records a skip), teardown always runs in `finally`. `aggregateLifecycle` groups Samples per Metric. Pure-additive — nothing in the public surface calls it yet (that wiring lands in #64); the shared floor-to-EPSILON timer moves into `lib/internal.ts` as `time()`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a harness-side lifecycle and control‑plane measurement driver that times provider SDK calls (spawn → exec → info/list → snapshot → teardown) and labels each timing with `HARNESS_METRIC_IDS` to produce `RawRun` data. Addresses ENG-59 and is additive only (not wired to the public flow yet).

- **New Features**
  - `measureLifecycle(compute, options)`: measures spawn, exec, control‑plane `getInfo`/`list`, snapshot (with cleanup), and teardown; emits `RawRun` samples labeled by `HARNESS_METRIC_IDS` from `@sandbox-benchmarks/schema`.
  - Fault-tolerant flow: spawn must succeed; mid‑chain errors record skips; teardown always runs. Options include `execCommand`, `controlPlaneSamples` (applies to both info and list), and a `snapshot` toggle.
  - `aggregateLifecycle(samples)`: groups by metric id and returns `Aggregates` in declaration order. Shared `time()` in `lib/internal.ts` floors ms to >0. Unit tests with a fake compute.

- **Bug Fixes**
  - Apply `controlPlaneSamples` to both `getInfo` and `list`.
  - Fallback to 1 when `controlPlaneSamples` is non‑finite.
  - Warn when snapshot cleanup delete fails instead of swallowing the error.

<sup>Written for commit 1bad1e9daad94b3962e629ac7aa5bc5ff2dd2cbb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/starslingdev/sandbox-benchmarks/pull/63?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

