### PR TITLE
feat(cli): bench-lifecycle measures provider lifecycle & control-plane (ENG-59)

### DIFF
--- a/apps/cli/README.md
+++ b/apps/cli/README.md
@@ -3,7 +3,10 @@
 **Role:** the entrypoint app — wires the five `@sandbox-benchmarks/*` packages into runnable commands.
 
 **Bins (`bin`, no `exports`):**
-- `bench-lifecycle` — benchmark one provider's spawn→exec→teardown lifecycle.
+- `bench-lifecycle` — measure each provider's lifecycle (spawn→exec→snapshot→teardown) and
+  control-plane (sandbox info/list) timings directly in the harness, the axes PTS cannot see. Flags:
+  `--iterations N` (cold-start cycles/provider), `--control-plane-samples N`, `--no-snapshot`. Providers
+  with absent creds skip; per-Metric distributions go to stdout JSON, a timing log to stderr.
 - `bench-suite` — run the full suite across the matrix.
 - `plan-matrix` — print the benchmark matrix as **single-line compact JSON** for `$GITHUB_OUTPUT`.
 - `build-template` — build a provider's sandbox template.

--- a/apps/cli/src/bin/bench-lifecycle.ts
+++ b/apps/cli/src/bin/bench-lifecycle.ts
@@ -1,12 +1,92 @@
 #!/usr/bin/env bun
-// `bench-lifecycle` — benchmark a single provider's spawn→exec→teardown lifecycle (stub).
+// `bench-lifecycle` — measure each provider's lifecycle (spawn→exec→snapshot→teardown) and
+// control-plane (sandbox info/list) timings directly in the harness, the axes PTS cannot see. Each
+// provider runs `--iterations` cold-start cycles; per-Metric distributions are aggregated and reported.
+//
+// Providers whose credentials are absent are SKIPPED, not failed (the e2e surface is CI-with-secrets);
+// a provider that can't even spawn FAILS. Exits non-zero iff a provider that ran failed, or a
+// `--require`d provider didn't run-and-pass — mirroring `bench-smoke`.
+//
+// Observability: a per-provider timing log goes to stderr; the machine-readable summary is JSON on
+// stdout. bun auto-loads .env, so local creds in a .env file are picked up.
+import {
+	benchmarkLifecycle,
+	requiredProviders,
+	unmetRequirements,
+} from "@sandbox-benchmarks/harness";
+import type { LifecycleMetricSummary } from "../lib/lifecycle-summary.ts";
+import { formatLifecycleLines, summarizeLifecycleAggregates } from "../lib/lifecycle-summary.ts";
+import { anyFailed, forEachProviderWithCreds } from "../lib/providers-run.ts";
 
-import { timeOperation } from "@sandbox-benchmarks/harness";
-import { providers } from "@sandbox-benchmarks/providers";
+/** A positive integer flag (`--flag N`), falling back when absent or malformed. */
+function intFlag(argv: string[], flag: string, fallback: number): number {
+	const i = argv.indexOf(flag);
+	const raw = i === -1 ? undefined : argv[i + 1];
+	// parseInt yields NaN for absent/garbage input, and `NaN > 0` is false — so this also rejects those.
+	const value = raw === undefined ? Number.NaN : Number.parseInt(raw, 10);
+	return value > 0 ? value : fallback;
+}
 
 if (import.meta.main) {
-	const config = providers.find((p) => p.name === "e2b");
-	if (!config) throw new Error('provider "e2b" is not registered');
-	const run = await timeOperation(config, "spawn", () => {});
-	console.log(JSON.stringify(run));
+	const log = (m: string) => console.error(m);
+
+	const iterations = intFlag(process.argv, "--iterations", 3);
+	const controlPlaneSamples = intFlag(process.argv, "--control-plane-samples", 5);
+	const snapshot = !process.argv.includes("--no-snapshot");
+
+	log(
+		`>>> lifecycle: ${iterations} cold-start cycle(s)/provider, ` +
+			`${controlPlaneSamples} control-plane probe(s)/cycle, snapshot=${snapshot}`,
+	);
+
+	// Summarize each provider's aggregates once, as it settles, then reuse for both the stderr log and the
+	// stdout JSON below. Skipped providers never settle through onComplete and carry no metrics.
+	const metricsByProvider = new Map<string, LifecycleMetricSummary[]>();
+	const runs = await forEachProviderWithCreds(
+		(provider) => {
+			log(`>>> ${provider.name}: measuring lifecycle…`);
+			return benchmarkLifecycle(provider, { iterations, controlPlaneSamples, snapshot });
+		},
+		{
+			log,
+			onComplete: (run) => {
+				if (run.value) {
+					const metrics = summarizeLifecycleAggregates(run.value.aggregates);
+					metricsByProvider.set(run.provider, metrics);
+					for (const line of formatLifecycleLines(metrics)) log(line);
+					for (const skip of run.value.skips) log(`    [skip] ${skip.suite}: ${skip.reason}`);
+				}
+				const time = run.durationMs ? `${run.durationMs.toFixed(0)}ms` : "";
+				log(`<<< ${run.provider}: ${run.status}${time ? ` (${time})` : ""}`);
+			},
+		},
+	);
+
+	const summary = runs.map((run) => ({
+		provider: run.provider,
+		status: run.status,
+		...(run.reason ? { reason: run.reason } : {}),
+		...(run.durationMs !== undefined ? { durationMs: run.durationMs } : {}),
+		...(run.value
+			? {
+					metrics: metricsByProvider.get(run.provider) ?? [],
+					skips: run.value.skips,
+				}
+			: {}),
+	}));
+	console.log(JSON.stringify({ summary }, null, 2));
+
+	// Skips (missing creds) never fail the run; only a provider that ran and broke does.
+	if (anyFailed(runs)) process.exit(1);
+
+	// At the CI/publish boundary a *required* provider that didn't run-and-pass must fail the lane loudly,
+	// so a green run can't hide that a provider was never actually measured.
+	const required = requiredProviders();
+	const unmet = unmetRequirements(runs, required);
+	if (required.length > 0 && unmet.length > 0) {
+		log(
+			`error: required providers did not pass: ${unmet.join(", ")} (--require / REQUIRE_PROVIDERS)`,
+		);
+		process.exit(1);
+	}
 }

--- a/apps/cli/src/lib/lifecycle-summary.test.ts
+++ b/apps/cli/src/lib/lifecycle-summary.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from "bun:test";
+import type { LifecycleAggregate } from "@sandbox-benchmarks/harness";
+import { HARNESS_METRIC_IDS } from "@sandbox-benchmarks/schema";
+import { formatLifecycleLines, summarizeLifecycleAggregates } from "./lifecycle-summary.ts";
+
+// `metricId` is typed wider than HarnessMetricId so the uncatalogued-fallback case can pass an
+// off-catalog id; the cast recovers the aggregate shape the summarizer consumes.
+const agg = (metricId: string, p50: number, p95: number, n: number): LifecycleAggregate =>
+	({
+		metricId,
+		aggregates: { p50, p95, mean: p50, stdev: 0, min: p50, max: p95, n },
+	}) as unknown as LifecycleAggregate;
+
+describe("summarizeLifecycleAggregates", () => {
+	it("resolves catalog labels/units and rounds p50/p95 to one decimal", () => {
+		const [spawn] = summarizeLifecycleAggregates([
+			agg(HARNESS_METRIC_IDS.spawn, 812.37, 998.61, 3),
+		]);
+		expect(spawn).toEqual({
+			metricId: HARNESS_METRIC_IDS.spawn,
+			label: "Spawn",
+			unit: "ms",
+			p50: 812.4,
+			p95: 998.6,
+			n: 3,
+		});
+	});
+
+	it("falls back to the raw id and ms for an uncatalogued id", () => {
+		const [summary] = summarizeLifecycleAggregates([agg("not_a_metric", 1, 2, 1)]);
+		expect(summary?.label).toBe("not_a_metric");
+		expect(summary?.unit).toBe("ms");
+	});
+
+	it("preserves aggregate order (one summary per aggregate)", () => {
+		const summaries = summarizeLifecycleAggregates([
+			agg(HARNESS_METRIC_IDS.spawn, 800, 900, 3),
+			agg(HARNESS_METRIC_IDS.controlPlaneInfo, 12, 20, 15),
+		]);
+		expect(summaries.map((s) => s.metricId)).toEqual([
+			HARNESS_METRIC_IDS.spawn,
+			HARNESS_METRIC_IDS.controlPlaneInfo,
+		]);
+	});
+});
+
+describe("formatLifecycleLines", () => {
+	it("formats one aligned line per Metric with p50/p95/n", () => {
+		const lines = formatLifecycleLines(
+			summarizeLifecycleAggregates([agg(HARNESS_METRIC_IDS.controlPlaneInfo, 12.5, 19.9, 15)]),
+		);
+		expect(lines).toHaveLength(1);
+		// 4-space indent, the catalog label, then the rounded p50/p95/n (padding between is alignment).
+		expect(lines[0]).toMatch(/^ {4}Sandbox info\s+p50=12\.5ms p95=19\.9ms \(n=15\)$/);
+	});
+});

--- a/apps/cli/src/lib/lifecycle-summary.ts
+++ b/apps/cli/src/lib/lifecycle-summary.ts
@@ -1,0 +1,56 @@
+// Present a provider's harness-measured lifecycle/control-plane timings — the formatting `bench-lifecycle`
+// feeds to its stderr logs and stdout JSON. Kept out of the bin so the catalog-label lookup and rounding
+// are unit-testable without driving a real provider. SDK-free: the schema Catalog + the harness result
+// shape only.
+import type { LifecycleAggregate } from "@sandbox-benchmarks/harness";
+import { getMetric } from "@sandbox-benchmarks/schema";
+
+/** One Metric's distribution, resolved to its catalog label/unit and rounded for display. */
+export interface LifecycleMetricSummary {
+	metricId: string;
+	label: string;
+	unit: string;
+	p50: number;
+	p95: number;
+	n: number;
+}
+
+/**
+ * Round to at most one decimal place so millisecond timings read cleanly without losing sub-ms signal
+ * entirely. Stays a `number` (not a fixed-decimal string) so the JSON emit is numeric — a whole value
+ * therefore renders as `12`, not `12.0`; the cap is on precision, not on a forced trailing zero.
+ */
+function round1(value: number): number {
+	return Math.round(value * 10) / 10;
+}
+
+/**
+ * Resolve each aggregated Metric against the Catalog for its display label/unit, rounding p50/p95.
+ * Falls back to the raw id/`ms` for an id not in the Catalog — a defensive default; in practice every
+ * {@link HARNESS_METRIC_IDS} value is catalogued (the schema contract test proves it).
+ */
+export function summarizeLifecycleAggregates(
+	aggregates: readonly LifecycleAggregate[],
+): LifecycleMetricSummary[] {
+	return aggregates.map((a) => {
+		const def = getMetric(a.metricId);
+		return {
+			metricId: a.metricId,
+			label: def?.label ?? a.metricId,
+			unit: def?.unit ?? "ms",
+			p50: round1(a.aggregates.p50),
+			p95: round1(a.aggregates.p95),
+			n: a.aggregates.n,
+		};
+	});
+}
+
+/** Human-readable, aligned timing lines (one per Metric) for the per-provider stderr log. */
+export function formatLifecycleLines(summaries: readonly LifecycleMetricSummary[]): string[] {
+	// Size the label column to the widest label present (floor 16) so alignment survives a future
+	// catalog label longer than today's "Exec round-trip" instead of silently breaking.
+	const width = Math.max(16, ...summaries.map((s) => s.label.length));
+	return summaries.map(
+		(s) => `    ${s.label.padEnd(width)} p50=${s.p50}${s.unit} p95=${s.p95}${s.unit} (n=${s.n})`,
+	);
+}


### PR DESCRIPTION
**ENG-59 — Lifecycle & control-plane dimensions (harness-measured)**

Shipped as a 4-PR stack (merge bottom-up, each branch is independently green):
1. #62 — schema: non-PTS lifecycle & control-plane `MetricDef`s
2. #63 — harness: lifecycle & control-plane measurement driver
3. #64 — harness: `benchmarkLifecycle` public surface + re-exports
4. **#65 — cli:** `bench-lifecycle` measures provider lifecycle & control-plane ← _you are here_

↑ **This PR is #65 (4/4)**, based on #64.

Linear: ENG-59

---

Flesh out the `bench-lifecycle` bin to drive `benchmarkLifecycle` across providers-with-creds (`--iterations` / `--control-plane-samples` / `--no-snapshot`), emitting a catalog-aligned timing summary on stdout JSON + stderr logs and mirroring `bench-smoke`'s skip-vs-fail and `--require` contract. The summary helper resolves each aggregate to its catalog label/unit via `getMetric`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a finished `bench-lifecycle` that measures each provider’s lifecycle (spawn→exec→snapshot→teardown) and control-plane (sandbox info/list) timings in the harness. Implements ENG-59 by emitting a catalog-aligned JSON summary to stdout and aligned timing logs to stderr, with proper skip/fail and --require handling.

- New Features
  - Runs across providers with creds; supports `--iterations`, `--control-plane-samples`, and `--no-snapshot`.
  - Aggregates per-metric distributions and resolves label/unit via `@sandbox-benchmarks/schema` `getMetric` (p50/p95 rounded for display).
  - Outputs JSON with provider status/reason/duration, metrics, and skips to stdout; aligned per-provider timing lines to stderr. Exit rules mirror `bench-smoke`, including `--require`/`REQUIRE_PROVIDERS`.
  - Adds `lifecycle-summary` (formatting + rounding) with unit tests; updates CLI README.

- Bug Fixes
  - Align timing log columns by padding the label to the widest present (min 16), and keep p50/p95 numeric with up to one decimal so JSON emits numbers (e.g., 12, not "12.0").

<sup>Written for commit 1da86a4f053ccb2b77a692ab2425b8cafc4fc480. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/starslingdev/sandbox-benchmarks/pull/65?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

