### PR TITLE
feat(providers,cli): provider-join assert + agent CLI discovery (ENG-62)

### DIFF
--- a/apps/cli/src/bin/bench-suite.ts
+++ b/apps/cli/src/bin/bench-suite.ts
@@ -6,11 +6,46 @@
 import { join } from "node:path";
 import { runSuite, SuiteUsageError } from "@sandbox-benchmarks/harness";
 import { summarizeRun, writeNormalizedRun } from "@sandbox-benchmarks/results";
+import { handleDiscovery } from "../lib/discovery.ts";
+
+/** Agent-facing usage; bare invocation keeps the daytona/cpu-node local-dev default. */
+export const HELP = `bench-suite — run a benchmark suite on a provider sandbox and normalize it into a Run document.
+
+usage: bench-suite [provider] [suite] [runId]
+       bench-suite [--help] [--list-providers] [--list-suites] [--json]
+
+  provider           Provider to run on (default: daytona). See --list-providers.
+  suite              Suite to run (default: cpu-node). See --list-suites.
+  runId              Run identifier for the data/ tree (default: local-<timestamp>).
+  --list-providers   List the registered providers.
+  --list-suites      List the registered suites and their dimensions/metrics.
+  --json             Emit --list-* output as JSON instead of human-readable lines.
+  --help, -h         Show this help.
+
+Missing provider credentials are recorded as a skip (the provider stays "pending"), so this is
+runnable without secrets. Writes data/runs/<runId>.json and updates data/runs/index.json.
+
+examples:
+  bench-suite daytona cpu-node            # one suite locally, auto runId
+  bench-suite modal memory ci-1234        # a specific cell + runId
+  bench-suite --list-suites               # discover the suite names first
+
+Next: render the Run with \`leaderboard data/runs/<runId>.json\`.`;
 
 if (import.meta.main) {
-	const provider = process.argv[2] ?? "daytona";
-	const suite = process.argv[3] ?? "cpu-node";
-	const runId = process.argv[4] ?? `local-${Date.now()}`;
+	const argv = process.argv.slice(2);
+	const discovery = handleDiscovery(argv, HELP);
+	if (discovery !== null) {
+		(discovery.ok ? console.log : console.error)(discovery.text);
+		process.exit(discovery.ok ? 0 : 2);
+	}
+
+	// Filter flags out before positional resolution so a trailing/misplaced flag (e.g.
+	// `bench-suite daytona cpu-node --json`) never gets captured as the runId.
+	const positionals = argv.filter((a) => !a.startsWith("-"));
+	const provider = positionals[0] ?? "daytona";
+	const suite = positionals[1] ?? "cpu-node";
+	const runId = positionals[2] ?? `local-${Date.now()}`;
 	const sha = process.env.GITHUB_SHA ?? "local";
 
 	const rawRoot = join("data", "raw", runId);

--- a/apps/cli/src/lib/discovery.test.ts
+++ b/apps/cli/src/lib/discovery.test.ts
@@ -1,0 +1,95 @@
+import { describe, expect, it } from "bun:test";
+import { PROVIDERS, SUITE_NAMES } from "@sandbox-benchmarks/schema";
+import {
+	handleDiscovery,
+	hasFlag,
+	providerListing,
+	renderProviders,
+	renderSuites,
+	suiteListing,
+} from "./discovery.ts";
+
+describe("hasFlag", () => {
+	it("matches any of the supplied flag spellings, and ignores unrelated args", () => {
+		expect(hasFlag(["a", "--help"], "--help", "-h")).toBe(true);
+		expect(hasFlag(["-h"], "--help", "-h")).toBe(true);
+		expect(hasFlag(["daytona", "cpu-node"], "--help", "-h")).toBe(false);
+	});
+});
+
+describe("provider/suite listings", () => {
+	it("advertise exactly the registered providers and suites (single source of truth)", () => {
+		expect(providerListing().map((p) => p.id)).toEqual(PROVIDERS.map((m) => m.id));
+		expect(suiteListing().map((s) => s.name)).toEqual([...SUITE_NAMES]);
+	});
+});
+
+describe("renderProviders / renderSuites", () => {
+	it("emit parseable JSON under --json that round-trips to the registry ids", () => {
+		const providers = JSON.parse(renderProviders(true)) as Array<{ id: string }>;
+		expect(providers.map((p) => p.id)).toEqual(PROVIDERS.map((m) => m.id));
+
+		const suites = JSON.parse(renderSuites(true)) as Array<{ name: string }>;
+		expect(suites.map((s) => s.name)).toEqual([...SUITE_NAMES]);
+	});
+
+	it("emit one human line per row by default, naming every registered id", () => {
+		const providerLines = renderProviders(false).split("\n");
+		expect(providerLines.length).toBe(PROVIDERS.length);
+		for (const meta of PROVIDERS) expect(renderProviders(false)).toContain(meta.id);
+
+		const suiteLines = renderSuites(false).split("\n");
+		expect(suiteLines.length).toBe(SUITE_NAMES.length);
+		for (const name of SUITE_NAMES) expect(renderSuites(false)).toContain(name);
+	});
+});
+
+describe("handleDiscovery", () => {
+	const HELP = "USAGE TEXT";
+
+	it("returns the bin's help for --help / -h, as an ok result", () => {
+		expect(handleDiscovery(["--help"], HELP)).toEqual({ text: HELP, ok: true });
+		expect(handleDiscovery(["-h"], HELP)).toEqual({ text: HELP, ok: true });
+	});
+
+	it("returns the provider/suite listings, honoring --json", () => {
+		expect(handleDiscovery(["--list-providers"], HELP)).toEqual({
+			text: renderProviders(false),
+			ok: true,
+		});
+		expect(handleDiscovery(["--list-providers", "--json"], HELP)).toEqual({
+			text: renderProviders(true),
+			ok: true,
+		});
+		expect(handleDiscovery(["--list-suites", "--json"], HELP)).toEqual({
+			text: renderSuites(true),
+			ok: true,
+		});
+	});
+
+	it("flags an unrecognized flag as a not-ok result (caller exits non-zero, not exit 0)", () => {
+		const res = handleDiscovery(["--bogus"], HELP);
+		expect(res?.ok).toBe(false);
+		expect(res?.text).toContain("Unknown flag: --bogus");
+	});
+
+	it("rejects an unknown flag even when paired with a valid action (never silently dropped)", () => {
+		// A bogus flag alongside --list-providers must not be swallowed by the action dispatch.
+		const providers = handleDiscovery(["--list-providers", "--bogus"], HELP);
+		expect(providers?.ok).toBe(false);
+		expect(providers?.text).toContain("Unknown flag: --bogus");
+
+		const suites = handleDiscovery(["--list-suites", "--json", "--nope"], HELP);
+		expect(suites?.ok).toBe(false);
+		expect(suites?.text).toContain("Unknown flag: --nope");
+	});
+
+	it("lets --help win over an unknown flag, as a safe escape hatch", () => {
+		expect(handleDiscovery(["--help", "--bogus"], HELP)).toEqual({ text: HELP, ok: true });
+	});
+
+	it("returns null when no discovery flag is present, so the bin runs its positional path", () => {
+		expect(handleDiscovery([], HELP)).toBeNull();
+		expect(handleDiscovery(["daytona", "cpu-node"], HELP)).toBeNull();
+	});
+});

--- a/apps/cli/src/lib/discovery.ts
+++ b/apps/cli/src/lib/discovery.ts
@@ -1,0 +1,106 @@
+// Shared, agent-facing discovery for the CLI bins: a `--help`/`--list-*` flag detector and the
+// provider/suite listings the bins advertise. Both listings read the schema registries directly, so a
+// bin can never advertise a provider or suite that isn't registered. Kept here rather than per-bin so
+// every bin spells the flags and renders the listings the same way (one vocabulary across the CLI).
+import { PROVIDERS, SUITE_NAMES, SUITES } from "@sandbox-benchmarks/schema";
+
+/**
+ * Whether `argv` contains any of `names`. Callers pass the long flags (e.g. `--help`, `--json`) — the
+ * stable handle an agent should prefer — alongside any short alias (`-h`).
+ */
+export function hasFlag(argv: readonly string[], ...names: string[]): boolean {
+	return argv.some((arg) => names.includes(arg));
+}
+
+/** One registered provider, as the discovery surface advertises it. */
+export interface ProviderListing {
+	id: string;
+	displayName: string;
+	requiredEnvVars: string[];
+}
+
+/** One registered suite, as the discovery surface advertises it. */
+export interface SuiteListing {
+	name: string;
+	dimensions: string[];
+	metrics: string[];
+}
+
+/** The registered providers, in schema declaration order — the join's schema half. */
+export function providerListing(): ProviderListing[] {
+	return PROVIDERS.map((p) => ({
+		id: p.id,
+		displayName: p.displayName,
+		requiredEnvVars: [...p.requiredEnvVars],
+	}));
+}
+
+/** The registered suites, in registry order, with the dimensions/metrics each emits. */
+export function suiteListing(): SuiteListing[] {
+	return SUITE_NAMES.map((name) => ({
+		name,
+		dimensions: [...SUITES[name].dimensions],
+		metrics: [...SUITES[name].metrics],
+	}));
+}
+
+/**
+ * Render the provider listing: pretty JSON under `--json` (the machine surface), else one
+ * `id<TAB>displayName (env vars)` line per provider for a human skimming `--help`.
+ */
+export function renderProviders(json: boolean): string {
+	const rows = providerListing();
+	if (json) return JSON.stringify(rows, null, 2);
+	return rows.map((p) => `${p.id}\t${p.displayName} (${p.requiredEnvVars.join(", ")})`).join("\n");
+}
+
+/**
+ * Render the suite listing: pretty JSON under `--json`, else one `name<TAB>[dimensions]` line per
+ * suite.
+ */
+export function renderSuites(json: boolean): string {
+	const rows = suiteListing();
+	if (json) return JSON.stringify(rows, null, 2);
+	return rows.map((s) => `${s.name}\t[${s.dimensions.join(", ")}]`).join("\n");
+}
+
+/**
+ * The outcome of {@link handleDiscovery}: `text` is what the bin prints, `ok` distinguishes a
+ * requested listing/help (stdout, exit 0) from an unrecognized-flag error (stderr, non-zero exit) so
+ * a bin whose real output is machine-consumed — e.g. `plan-matrix`'s single-line JSON to
+ * `$GITHUB_OUTPUT` — never emits an error message as success.
+ */
+export interface DiscoveryResult {
+	text: string;
+	ok: boolean;
+}
+
+/**
+ * The discovery dispatch every bin shares. Given the bin's `argv` (already sliced past the runtime +
+ * script) and its `--help` text, return the {@link DiscoveryResult} the bin should print, or `null`
+ * when no discovery flag is present and the bin should fall through to its real positional behaviour.
+ * Recognised flags, identical across every bin:
+ *   - `--help` / `-h`    → the bin's usage text (`ok`)
+ *   - `--list-providers` → the registered providers (pretty JSON under `--json`, else human lines)
+ *   - `--list-suites`    → the registered suites
+ *   - any other `-…`     → an "Unknown flag" error (`!ok`) so the caller exits non-zero, even when
+ *                          paired with a valid action (the unknown flag is never silently dropped)
+ * Centralising the dispatch keeps the flag vocabulary consistent and makes a bin's discovery output
+ * unit-testable without spawning a process.
+ */
+/** The closed set of flags any bin's discovery layer accepts; anything else `-…` is an error. */
+const RECOGNISED_FLAGS = new Set(["--help", "-h", "--list-providers", "--list-suites", "--json"]);
+export function handleDiscovery(argv: readonly string[], help: string): DiscoveryResult | null {
+	// `--help` is the escape hatch: it wins even alongside other flags, so `--help --anything` prints
+	// usage rather than an error.
+	if (hasFlag(argv, "--help", "-h")) return { text: help, ok: true };
+	// Reject any unrecognized flag BEFORE dispatching an action, so a bogus flag paired with a valid
+	// action (e.g. `--list-providers --bogus`) is surfaced rather than silently ignored — matching the
+	// bare `--bogus` path. Positional args (no leading `-`) fall through to the bin's own parsing.
+	const unknown = argv.find((a) => a.startsWith("-") && !RECOGNISED_FLAGS.has(a));
+	if (unknown) return { text: `Unknown flag: ${unknown}\n\n${help}`, ok: false };
+	const json = hasFlag(argv, "--json");
+	if (hasFlag(argv, "--list-providers")) return { text: renderProviders(json), ok: true };
+	if (hasFlag(argv, "--list-suites")) return { text: renderSuites(json), ok: true };
+	return null;
+}

--- a/packages/providers/src/index.test.ts
+++ b/packages/providers/src/index.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "bun:test";
 import { PROVIDERS, TARGET_SPEC, VCPUS_PER_PHYSICAL_CORE } from "@sandbox-benchmarks/schema";
 import { config, providers } from "./index.ts";
 import { resolveDaytonaRegion } from "./lib/config.ts";
+import { assertProviderJoin } from "./lib/join.ts";
 
 describe("@sandbox-benchmarks/providers", () => {
 	it("wires every schema provider through to a computesdk factory", () => {
@@ -43,6 +44,48 @@ describe("@sandbox-benchmarks/providers", () => {
 		expect(daytona?.createOptions?.snapshotId).toBe(config.daytonaRegion.snapshot);
 		// requiredEnvVars tracks the active region's key var (the schema default for the default region).
 		expect(daytona?.requiredEnvVars).toEqual([config.daytonaRegion.apiKeyVar]);
+	});
+});
+
+describe("assertProviderJoin", () => {
+	it("passes silently when the schema ids and the adapter ids are the same set", () => {
+		// The real registries are already index-aligned, so the live module load (above) exercises the
+		// happy path; assert it explicitly here too, including when order differs between the two sides.
+		expect(() =>
+			assertProviderJoin(["e2b", "daytona", "modal"], ["modal", "e2b", "daytona"]),
+		).not.toThrow();
+		expect(() =>
+			assertProviderJoin(
+				PROVIDERS.map((m) => m.id),
+				providers.map((p) => p.name),
+			),
+		).not.toThrow();
+	});
+
+	it("throws naming a provider that's in the schema but missing an adapter", () => {
+		// A provider added to the schema registry without a matching harness adapter — the compile-time
+		// Record can't catch this across a version drift, so the runtime guard must.
+		expect(() => assertProviderJoin(["e2b", "daytona", "modal"], ["e2b", "daytona"])).toThrow(
+			/missing a harness adapter: modal/,
+		);
+	});
+
+	it("throws naming an adapter that has no schema entry", () => {
+		expect(() => assertProviderJoin(["e2b", "daytona"], ["e2b", "daytona", "modal"])).toThrow(
+			/no schema PROVIDERS entry: modal/,
+		);
+	});
+
+	it("reports both one-sided directions at once", () => {
+		const err = (() => {
+			try {
+				assertProviderJoin(["e2b", "ghost"], ["e2b", "modal"]);
+			} catch (e) {
+				return e as Error;
+			}
+		})();
+		expect(err?.message).toContain("missing a harness adapter: ghost");
+		expect(err?.message).toContain("no schema PROVIDERS entry: modal");
 	});
 });
 

--- a/packages/providers/src/index.ts
+++ b/packages/providers/src/index.ts
@@ -4,6 +4,7 @@
 // `providers` is the schema identity joined with those adapters.
 import { PROVIDERS } from "@sandbox-benchmarks/schema";
 import { adapters } from "./lib/adapters.ts";
+import { assertProviderJoin } from "./lib/join.ts";
 import type { ProviderConfig } from "./lib/types.ts";
 
 // The runtime configuration gatekeeper — the single validated config object consumers import.
@@ -18,7 +19,17 @@ export type { DirectProvider, ProviderAdapter, ProviderConfig } from "./lib/type
  * `PROVIDERS` is derived from the schema's `Record<ProviderId, …>` registry and `adapters` is a
  * `Record<ProviderId, ProviderAdapter>`, so every `meta.id` indexes exactly one adapter and the two
  * registries are provably the same set at compile time.
+ *
+ * The runtime {@link assertProviderJoin} below backs that compile-time guarantee for any path the
+ * type-checker never saw — a published/installed build or a cross-version schema/providers drift —
+ * failing loudly at module load rather than letting a one-sided provider surface as an `undefined`
+ * adapter mid-run.
  */
+assertProviderJoin(
+	PROVIDERS.map((meta) => meta.id),
+	Object.keys(adapters),
+);
+
 export const providers: ProviderConfig[] = PROVIDERS.map((meta) => {
 	const adapter = adapters[meta.id];
 	return {

--- a/packages/providers/src/lib/join.ts
+++ b/packages/providers/src/lib/join.ts
@@ -1,0 +1,36 @@
+// The runtime half of the PROVIDERS × adapters join guarantee. The `Record<ProviderId, …>` type on
+// both registries already makes a one-sided provider a *compile* error, but a compile error only
+// protects an in-repo edit: a published/installed build, a downstream consumer, or any path where the
+// schema and providers packages drift to different versions can present a registry pair the compiler
+// never type-checked together. This asserts the two id sets are identical at load and throws naming
+// the exact offenders, so a one-sided provider fails loudly here instead of surfacing as an
+// `undefined` adapter deep inside a benchmark run.
+
+/**
+ * Assert that the schema provider ids and the harness adapter ids are exactly the same set.
+ * Throws an {@link Error} naming every one-sided id (in the schema but missing an adapter, or with an
+ * adapter but no schema entry) when they disagree; returns silently when they match. Both id lists
+ * are passed in (rather than read from the modules) so the guard stays a pure, unit-testable function
+ * the caller wires to the real registries.
+ */
+export function assertProviderJoin(
+	schemaIds: readonly string[],
+	adapterIds: readonly string[],
+): void {
+	const schema = new Set(schemaIds);
+	const adapter = new Set(adapterIds);
+	const missingAdapter = schemaIds.filter((id) => !adapter.has(id));
+	const missingSchema = adapterIds.filter((id) => !schema.has(id));
+	if (missingAdapter.length === 0 && missingSchema.length === 0) return;
+
+	const parts: string[] = [];
+	if (missingAdapter.length > 0) {
+		parts.push(
+			`in the schema PROVIDERS registry but missing a harness adapter: ${missingAdapter.join(", ")}`,
+		);
+	}
+	if (missingSchema.length > 0) {
+		parts.push(`have a harness adapter but no schema PROVIDERS entry: ${missingSchema.join(", ")}`);
+	}
+	throw new Error(`Provider registry mismatch — ${parts.join("; ")}`);
+}


### PR DESCRIPTION
**ENG-62 transport hardening — split into 2 focused PRs** (merge bottom-up, each independently green):
1. #78 — harness execute transport
2. **#67 — provider-join assert + agent CLI discovery** (this PR)

↑ **This PR is 2/2**, based on #78. _(Was the original #67, now narrowed to this layer.)_

---
The provider-**join transport assertion** plus the agent-facing **CLI discovery** surface (`discovery.ts`) with `bench-suite` flag wiring. Sits on top of the harness execute engine in #78; depends only on schema + the unchanged `runSuite` API.

**Validated locally:** `bun run typecheck` (8 workspaces, 0 errors); full suite green end-to-end — providers 11, cli 17, harness 60, results 31, schema 115.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a runtime join check between schema providers and harness adapters, plus a shared, registry-backed CLI discovery used by `bench-suite`. Agents can list providers and suites with parseable JSON, and bad flags fail fast. Aligns with ENG-62.

- **New Features**
  - `@sandbox-benchmarks/providers`: Added `assertProviderJoin()` (runs at module load) to ensure schema provider ids match adapter ids; throws with the missing ids.
  - `apps/cli`: Introduced shared discovery (`--help`, `--list-providers`, `--list-suites`, `--json`) sourced from registries and used by `bench-suite`; provider rows include `id`, `displayName`, `requiredEnvVars`; suite rows include `name`, `dimensions`, `metrics`.

- **Bug Fixes**
  - `apps/cli`: `handleDiscovery()` returns `{ text, ok }`; ok prints to stdout/exit 0; unknown flags print to stderr/exit 2 and are rejected before action dispatch; `--help` wins.
  - `bench-suite`: Filters flags before positionals so trailing flags don’t become `runId`.

<sup>Written for commit e437a3dd2b265b15725bda77fd341345d45324dd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/starslingdev/sandbox-benchmarks/pull/67?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

---

**Verification:** green on its own — affected-package typecheck clean and tests pass with 0 failures (verified across the full stack build).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced CLI discovery handling for `--help`, provider/suite listing, and `--json` output formatting
  * Improved detached-step completion monitoring with adaptive polling backoff
  * Added exec-based (cat) polling fallback when no filesystem API is available
  * Added runtime validation to ensure providers and schema stay consistent
* **Bug Fixes**
  * Updated detached process daemonization to use a double-fork style
* **Tests**
  * Expanded CLI discovery, detached execution (including no-filesystem), and provider validation coverage
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

