### PR TITLE
feat(mise): memory/disk/system PTS benchmark task definitions (ENG-60)

### DIFF
--- a/.mise/tasks/benchmark/disk/all
+++ b/.mise/tasks/benchmark/disk/all
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+#MISE description="Run disk benchmarks (PTS hardlink throughput)"
+# Orchestrator: no -e — run_task isolates child failures and summary reports them at the end
+# (error-mode conventions: lib/bench.sh).
+set -uo pipefail
+REPO_ROOT="$(git -C "$(dirname "${BASH_SOURCE[0]}")" rev-parse --show-toplevel)"
+source "${REPO_ROOT}/lib/bench.sh"
+
+echo "========================================"
+echo "  DISK BENCHMARKS"
+echo "========================================"
+
+ensure_pts || true
+
+run_task benchmark:disk:pts:hardlink
+
+summary

--- a/.mise/tasks/benchmark/disk/pts/hardlink
+++ b/.mise/tasks/benchmark/disk/pts/hardlink
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+#MISE description="PTS: hardlink throughput (stress-ng --link, repo-local profile)"
+# Measurement leaf: -e guards the scaffolding; the measured run is isolated by run_pts_benchmark.
+set -euo pipefail
+REPO_ROOT="$(git -C "$(dirname "${BASH_SOURCE[0]}")" rev-parse --show-toplevel)"
+source "${REPO_ROOT}/lib/bench.sh"
+
+if ! command -v phoronix-test-suite &>/dev/null; then
+	skip_result "phoronix-test-suite not installed" "pts_hardlink"
+	exit 0
+fi
+if ! command -v stress-ng &>/dev/null; then
+	skip_result "stress-ng not installed (apt-get install -y stress-ng)" "pts_hardlink"
+	exit 0
+fi
+
+# hardlink is a REPO-LOCAL PTS profile (Identifier local/hardlink-1.0.0), so PTS won't download it —
+# install our vendored copy into PTS's local-profile dir first. The dir depends on the run user
+# ($HOME/.phoronix-test-suite vs /var/lib/... for root); pts_init creates it and pts_user_dir locates
+# it, so installing elsewhere makes PTS reject it with "Invalid Argument: local/hardlink-1.0.0".
+PROFILE_NAME="hardlink-1.0.0"
+SRC="${REPO_ROOT}/packages/schema/src/pts-profiles/local/${PROFILE_NAME}"
+
+pts_init
+PTS_DIR="$(pts_user_dir)"
+DST="${PTS_DIR}/test-profiles/local/${PROFILE_NAME}"
+mkdir -p "$(dirname "$DST")"
+rm -rf "$DST"
+cp -r "$SRC" "$DST"
+echo "Installed local PTS profile: ${DST} (PTS data dir: ${PTS_DIR})"
+
+run_pts_benchmark "local/hardlink-1.0.0" "pts_hardlink"

--- a/.mise/tasks/benchmark/memory/all
+++ b/.mise/tasks/benchmark/memory/all
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+#MISE description="Run memory benchmarks (PTS STREAM)"
+# Orchestrator: no -e — run_task isolates child failures and summary reports them at the end
+# (error-mode conventions: lib/bench.sh).
+set -uo pipefail
+REPO_ROOT="$(git -C "$(dirname "${BASH_SOURCE[0]}")" rev-parse --show-toplevel)"
+source "${REPO_ROOT}/lib/bench.sh"
+
+echo "========================================"
+echo "  MEMORY BENCHMARKS"
+echo "========================================"
+
+ensure_pts || true
+
+run_task benchmark:memory:pts:stream
+
+summary

--- a/.mise/tasks/benchmark/memory/pts/stream
+++ b/.mise/tasks/benchmark/memory/pts/stream
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+#MISE description="PTS: STREAM memory bandwidth (Copy/Scale/Add/Triad)"
+# Measurement leaf: -e guards the scaffolding; the measured run is isolated by run_pts_benchmark.
+set -euo pipefail
+REPO_ROOT="$(git -C "$(dirname "${BASH_SOURCE[0]}")" rev-parse --show-toplevel)"
+source "${REPO_ROOT}/lib/bench.sh"
+
+if ! command -v phoronix-test-suite &>/dev/null; then
+	skip_result "phoronix-test-suite not installed" "pts_stream"
+	exit 0
+fi
+
+run_pts_benchmark "pts/stream" "pts_stream"

--- a/.mise/tasks/benchmark/system/all
+++ b/.mise/tasks/benchmark/system/all
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+#MISE description="Run system benchmarks (PTS PyBench + SQLite Speedtest)"
+# Orchestrator: no -e — run_task isolates child failures and summary reports them at the end
+# (error-mode conventions: lib/bench.sh).
+set -uo pipefail
+REPO_ROOT="$(git -C "$(dirname "${BASH_SOURCE[0]}")" rev-parse --show-toplevel)"
+source "${REPO_ROOT}/lib/bench.sh"
+
+echo "========================================"
+echo "  SYSTEM BENCHMARKS"
+echo "========================================"
+
+# One install/configure attempt for the PTS children; each leaf skips fast via its own `command -v`
+# guard and writes a skip record if PTS is still unavailable.
+ensure_pts || true
+
+run_task benchmark:system:pts:pybench
+run_task benchmark:system:pts:sqlite-speedtest
+
+summary

--- a/.mise/tasks/benchmark/system/pts/pybench
+++ b/.mise/tasks/benchmark/system/pts/pybench
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+#MISE description="PTS: PyBench Python interpreter benchmark"
+# Measurement leaf: -e guards the scaffolding; the measured run is isolated by run_pts_benchmark.
+set -euo pipefail
+REPO_ROOT="$(git -C "$(dirname "${BASH_SOURCE[0]}")" rev-parse --show-toplevel)"
+source "${REPO_ROOT}/lib/bench.sh"
+
+if ! command -v phoronix-test-suite &>/dev/null; then
+	skip_result "phoronix-test-suite not installed" "pts_pybench"
+	exit 0
+fi
+
+run_pts_benchmark "pts/pybench" "pts_pybench"

--- a/.mise/tasks/benchmark/system/pts/sqlite-speedtest
+++ b/.mise/tasks/benchmark/system/pts/sqlite-speedtest
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+#MISE description="PTS: SQLite speedtest1 benchmark"
+# Measurement leaf: -e guards the scaffolding; the measured run is isolated by run_pts_benchmark.
+set -euo pipefail
+REPO_ROOT="$(git -C "$(dirname "${BASH_SOURCE[0]}")" rev-parse --show-toplevel)"
+source "${REPO_ROOT}/lib/bench.sh"
+
+if ! command -v phoronix-test-suite &>/dev/null; then
+	skip_result "phoronix-test-suite not installed" "pts_sqlite-speedtest"
+	exit 0
+fi
+
+run_pts_benchmark "pts/sqlite-speedtest" "pts_sqlite-speedtest"


### PR DESCRIPTION
**ENG-60 PTS dimensions — split into 2 focused PRs** (merge bottom-up, each independently green):
1. #79 — generated PTS catalog + drift gate
2. **#68 — memory/disk/system bench task definitions** (this PR)

↑ **This PR is 2/2**, based on #79. _(Was the original #68, now narrowed to the task definitions.)_

---
The **mise bench-task runners** for the memory / disk / system dimensions — leaf tasks plus per-dimension aggregators, pure-bash orchestration invoking each other by task name, on top of the generated catalog in #79.

**Validated locally:** `bun run typecheck` (0 errors); full-workspace tests green; tree byte-identical to the pre-split #68.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `mise` PTS benchmark tasks for memory, disk, and system with per-dimension aggregators and skip-safe leaves. Aligns with ENG-60.

- **New Features**
  - Aggregators: `benchmark:memory:all`, `benchmark:disk:all`, `benchmark:system:all` run child tasks, call `ensure_pts` once, and print a summary.
  - Leaves: `benchmark:memory:pts:stream` (`pts/stream`), `benchmark:system:pts:pybench` (`pts/pybench`), `benchmark:system:pts:sqlite-speedtest` (`pts/sqlite-speedtest`), `benchmark:disk:pts:hardlink` (`local/hardlink-1.0.0`).
  - Hardlink: installs a repo-local profile into the PTS user dir via `pts_init`/`pts_user_dir`; requires `stress-ng`. Leaves check for `phoronix-test-suite` (and `stress-ng` where needed) and write a skip record.

<sup>Written for commit 29a50f555d9ffd0a22affed9814e89d2ca954290. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/starslingdev/sandbox-benchmarks/pull/68?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

---

**Verification:** green on its own — affected-package typecheck clean and tests pass with 0 failures (verified across the full stack build).

