### PR TITLE
feat(repo-checks): workflow credential-env drift gate (ENG-66)

### DIFF
--- a/tooling/repo-checks/src/lib/workflow-sync.ts
+++ b/tooling/repo-checks/src/lib/workflow-sync.ts
@@ -1,16 +1,18 @@
 // Drift gate: the GitHub workflows that dispatch live benchmarks must stay in lockstep with the
-// schema registries. GHA can't import TypeScript, so the provider/suite vocabulary is re-spelled by
-// hand in the workflow files; this module re-derives the truth from PROVIDERS + SUITE_NAMES
-// (packages/schema) and compares. It mirrors runner-benchmarking's check-workflow-suite-sync.ts,
-// adapted to this repo's two workflows.
+// schema registries. GHA can't import TypeScript, so the provider/suite vocabulary and the
+// per-provider credential wiring are re-spelled by hand in the workflow files; this module re-derives
+// the truth from PROVIDERS + SUITE_NAMES (packages/schema) and compares. It mirrors
+// runner-benchmarking's check-workflow-{env,suite}-sync.ts, adapted to this repo's two workflows.
 //
 // Invariants (each maps to a real "added X, forgot the workflow" failure mode):
 //   1. bench-smoke.yml's `provider` dispatch input options == the PROVIDERS id set, and its default
 //      is one of them — a new provider must be dispatchable, a removed one must not linger.
 //   2. bench-smoke.yml's `suite` dispatch input options == SUITE_NAMES, with a valid default.
-//
-// The per-provider credential-env invariants (3 + 4) build on the same parsers and land in the next
-// PR up the stack.
+//   3. Every provider's requiredEnvVars (schema) is present in the "Run suite and normalize" step env
+//      of BOTH bench-smoke.yml and bench-matrix.yml — the secret a new provider needs must be wired
+//      into both the smoke lane and the matrix lane, or the live run silently skips it.
+//   4. A credential key shared across the two workflows maps to the same value expression — both
+//      lanes must hand the suite the same secret, not plan one and run the other.
 //
 // Bun.YAML.parse is built into bun >= 1.3 (no new dependency), so the parse stays dependency-light.
 import { readFileSync } from "node:fs";
@@ -20,6 +22,11 @@ import { type } from "arktype";
 import { findRepoRoot } from "./workspace.ts";
 
 export const SMOKE_WORKFLOW = ".github/workflows/bench-smoke.yml";
+export const MATRIX_WORKFLOW = ".github/workflows/bench-matrix.yml";
+/** The step (in both workflows) that drives the provider SDK; it owns the credential env block. */
+export const RUN_STEP = "Run suite and normalize";
+export const SMOKE_JOB = "smoke";
+export const MATRIX_JOB = "bench";
 
 // Single source of truth: this schema drives BOTH the runtime parse (coercions live in the morphs)
 // and the exported DispatchInput type (inferred below) — there is no hand-written interface or
@@ -71,9 +78,69 @@ export function dispatchInput(doc: unknown, name: string, label: string): Dispat
 	return input;
 }
 
+/**
+ * Assert `value` is a non-null, non-array object, or throw `message`. A lazy per-node guard for the
+ * {@link stepEnv} navigation below: unlike the fixed `on.workflow_dispatch` path (an arktype envelope),
+ * step-env walks to one *named* job/step, so validating the whole `jobs` map with a schema would
+ * over-reject sibling jobs the gate doesn't care about.
+ */
+function asRecord(value: unknown, message: string): Record<string, unknown> {
+	if (value === null || typeof value !== "object" || Array.isArray(value)) {
+		throw new Error(message);
+	}
+	return value as Record<string, unknown>;
+}
+
+/**
+ * The `env` mapping of a named step inside a job, as key -> value-expression entries. Throws if the
+ * job, the step, or its env block is missing, or an env value is not a string — a renamed job/step
+ * must fail the gate, not silently match nothing.
+ */
+export function stepEnv(
+	doc: unknown,
+	jobId: string,
+	stepName: string,
+	label: string,
+): Record<string, string> {
+	const root = asRecord(doc, `${label}: not a YAML mapping`);
+	const jobs = asRecord(root.jobs, `${label}: no jobs mapping`);
+	const job = asRecord(jobs[jobId], `${label}: job "${jobId}" not found`);
+	const steps = job.steps;
+	if (!Array.isArray(steps)) throw new Error(`${label}: job "${jobId}" has no steps list`);
+	const step = steps.find((s) => asRecord(s, `${label}: malformed step`).name === stepName);
+	if (step === undefined) {
+		throw new Error(`${label}: job "${jobId}" has no step named "${stepName}"`);
+	}
+	const env = asRecord(
+		(step as Record<string, unknown>).env,
+		`${label}: step "${stepName}" has no env mapping`,
+	);
+	const entries: Record<string, string> = {};
+	for (const [key, value] of Object.entries(env)) {
+		if (typeof value !== "string") {
+			throw new Error(`${label}: step "${stepName}" env.${key} is not a string value`);
+		}
+		entries[key] = value;
+	}
+	return entries;
+}
+
 /** The canonical provider ids from the schema registry. */
 export function providerIds(): string[] {
 	return PROVIDERS.map((p) => p.id);
+}
+
+/** Every requiredEnvVars entry across the Provider registry, with provenance (key -> owning ids). */
+export function requiredCredentialKeys(): Map<string, string[]> {
+	const byKey = new Map<string, string[]>();
+	for (const provider of PROVIDERS) {
+		for (const key of provider.requiredEnvVars) {
+			const owners = byKey.get(key) ?? [];
+			owners.push(provider.id);
+			byKey.set(key, owners);
+		}
+	}
+	return byKey;
 }
 
 /** Pure comparison of a dispatch input's options against an expected id set. */
@@ -148,4 +215,53 @@ export function checkSuiteInput(input: DispatchInput, label: string = SMOKE_WORK
 		"SUITE_NAMES (packages/schema/src/suites.ts)",
 		label,
 	);
+}
+
+/**
+ * Invariants 3 + 4: every provider requiredEnvVar is present in the run-step env of every workflow,
+ * and a key shared across them maps to the same value expression. `envByWorkflow` keys are workflow
+ * paths so error messages name the offending file.
+ */
+export function checkCredentialEnv(
+	envByWorkflow: Record<string, Record<string, string>>,
+): string[] {
+	const errors: string[] = [];
+	const workflows = Object.keys(envByWorkflow);
+	for (const [key, owners] of requiredCredentialKeys()) {
+		// biome-ignore lint/style/noNonNullAssertion: keys come from Object.keys(envByWorkflow).
+		const missing = workflows.filter((wf) => !(key in envByWorkflow[wf]!));
+		if (missing.length > 0) {
+			errors.push(
+				`${key}: required by provider ${owners.join(", ")} (packages/schema/src/providers.ts ` +
+					`requiredEnvVars) but missing from the "${RUN_STEP}" step env of ${missing.join(" and ")}`,
+			);
+			continue;
+		}
+		// biome-ignore lint/style/noNonNullAssertion: presence checked above.
+		const values = new Set(workflows.map((wf) => envByWorkflow[wf]![key]!));
+		if (values.size > 1) {
+			errors.push(
+				`${key}: maps to different value expressions across workflows ` +
+					`(${[...values].map((v) => `"${v}"`).join(" vs ")}) — every lane must hand the suite the same secret`,
+			);
+		}
+	}
+	return errors;
+}
+
+/**
+ * The whole gate against the real workflow files under `root` — the single owner of which files feed
+ * the gate, used by the real-file test in workflow-registry-sync.test.ts.
+ */
+export function runCheck(root: string = findRepoRoot()): string[] {
+	const smoke = readWorkflow(SMOKE_WORKFLOW, root);
+	const matrix = readWorkflow(MATRIX_WORKFLOW, root);
+	return [
+		...checkProviderInput(dispatchInput(smoke, "provider", SMOKE_WORKFLOW)),
+		...checkSuiteInput(dispatchInput(smoke, "suite", SMOKE_WORKFLOW)),
+		...checkCredentialEnv({
+			[SMOKE_WORKFLOW]: stepEnv(smoke, SMOKE_JOB, RUN_STEP, SMOKE_WORKFLOW),
+			[MATRIX_WORKFLOW]: stepEnv(matrix, MATRIX_JOB, RUN_STEP, MATRIX_WORKFLOW),
+		}),
+	];
 }

--- a/tooling/repo-checks/src/workflow-registry-sync.test.ts
+++ b/tooling/repo-checks/src/workflow-registry-sync.test.ts
@@ -1,22 +1,37 @@
 // Invariant: the GitHub workflows that dispatch live benchmarks stay in lockstep with the schema
 // registries (PROVIDERS + SUITE_NAMES). GHA can't import TypeScript, so the provider/suite choices
-// are hand-mirrored across .github/workflows/bench-*.yml; this gate re-derives the truth from the
-// registries and fails if someone adds a provider/suite without updating the workflows. Mirrors
-// runner-benchmarking's test/workflow-suite-sync.test.ts. See ./lib/workflow-sync.ts for the parsers
-// + pure checks. The per-provider credential-env coverage lands in the next PR up the stack.
+// and the per-provider credential env block are hand-mirrored across .github/workflows/bench-*.yml;
+// this gate re-derives the truth from the registries and fails if someone adds a provider/suite (or
+// its required secret) without updating the workflows. Mirrors runner-benchmarking's
+// test/workflow-{env,suite}-sync.test.ts. See ./lib/workflow-sync.ts for the parsers + pure checks.
+//
+// The runCheck() test against the real workflow files IS the gate's CI enforcement point (it runs
+// under `bun test`, same precedent as boundary.test.ts); the rest is unit coverage of the parsers and
+// the failure messages on synthetic drift, so a future regression names the offending file + key.
 import { describe, expect, test } from "bun:test";
 import { PROVIDERS, SUITE_NAMES } from "@sandbox-benchmarks/schema";
 import {
+	checkCredentialEnv,
 	checkProviderInput,
 	checkSuiteInput,
 	dispatchInput,
+	MATRIX_JOB,
+	MATRIX_WORKFLOW,
+	RUN_STEP,
 	readWorkflow,
+	requiredCredentialKeys,
+	runCheck,
+	SMOKE_JOB,
 	SMOKE_WORKFLOW,
+	stepEnv,
 } from "./lib/workflow-sync.ts";
 
 const smoke = readWorkflow(SMOKE_WORKFLOW);
+const matrix = readWorkflow(MATRIX_WORKFLOW);
 const providerInput = dispatchInput(smoke, "provider", SMOKE_WORKFLOW);
 const suiteInput = dispatchInput(smoke, "suite", SMOKE_WORKFLOW);
+const smokeEnv = stepEnv(smoke, SMOKE_JOB, RUN_STEP, SMOKE_WORKFLOW);
+const matrixEnv = stepEnv(matrix, MATRIX_JOB, RUN_STEP, MATRIX_WORKFLOW);
 
 describe("parsers against the real workflow files", () => {
 	test("dispatchInput extracts the smoke provider choice (type + options + default)", () => {
@@ -31,9 +46,29 @@ describe("parsers against the real workflow files", () => {
 		expect(suiteInput.type).toBe("choice");
 	});
 
+	test("stepEnv extracts a realistic credential block from both workflows", () => {
+		expect(smokeEnv).toContainKey("DAYTONA_API_KEY");
+		expect(matrixEnv).toContainKey("E2B_API_KEY");
+		// A real block (credentials + runtime context), not a parse fragment.
+		expect(Object.keys(smokeEnv).length).toBeGreaterThanOrEqual(8);
+	});
+
 	test("dispatchInput throws on a missing input instead of passing vacuously", () => {
 		expect(() => dispatchInput(smoke, "no-such-input", SMOKE_WORKFLOW)).toThrow(
 			'input "no-such-input" not found',
+		);
+	});
+
+	test("stepEnv throws on a missing job, step, or env mapping", () => {
+		expect(() => stepEnv(smoke, "no-such-job", RUN_STEP, SMOKE_WORKFLOW)).toThrow(
+			'job "no-such-job" not found',
+		);
+		expect(() => stepEnv(smoke, SMOKE_JOB, "No Such Step", SMOKE_WORKFLOW)).toThrow(
+			'has no step named "No Such Step"',
+		);
+		const yaml = Bun.YAML.stringify({ jobs: { j: { steps: [{ name: "bare" }] } } });
+		expect(() => stepEnv(Bun.YAML.parse(yaml), "j", "bare", "synthetic.yml")).toThrow(
+			"has no env mapping",
 		);
 	});
 });
@@ -119,5 +154,52 @@ describe("checkSuiteInput", () => {
 		const errors = checkSuiteInput({ ...suiteInput, type: "string" });
 		expect(errors).toHaveLength(1);
 		expect(errors[0]).toContain('not "type: choice"');
+	});
+});
+
+describe("checkCredentialEnv", () => {
+	test("requiredCredentialKeys records provenance per provider", () => {
+		const required = requiredCredentialKeys();
+		expect(required.get("E2B_API_KEY")).toEqual(["e2b"]);
+		expect(required.get("MODAL_TOKEN_ID")).toEqual(["modal"]);
+	});
+
+	test("flags a required key dropped from the matrix block, naming key and file", () => {
+		const { E2B_API_KEY: _, ...drifted } = matrixEnv;
+		const errors = checkCredentialEnv({
+			[SMOKE_WORKFLOW]: smokeEnv,
+			[MATRIX_WORKFLOW]: drifted,
+		});
+		expect(errors).toHaveLength(1);
+		expect(errors[0]).toContain("E2B_API_KEY");
+		expect(errors[0]).toContain("required by provider e2b");
+		expect(errors[0]).toContain(MATRIX_WORKFLOW);
+		expect(errors[0]).not.toContain(SMOKE_WORKFLOW);
+	});
+
+	test("flags a shared key whose value expression differs across the two lanes", () => {
+		const drifted = { ...matrixEnv, DAYTONA_API_KEY: `\${{ secrets.DAYTONA_API_KEY_OTHER }}` };
+		const errors = checkCredentialEnv({
+			[SMOKE_WORKFLOW]: smokeEnv,
+			[MATRIX_WORKFLOW]: drifted,
+		});
+		expect(errors).toHaveLength(1);
+		expect(errors[0]).toContain("DAYTONA_API_KEY:");
+		expect(errors[0]).toContain(smokeEnv.DAYTONA_API_KEY);
+		expect(errors[0]).toContain("DAYTONA_API_KEY_OTHER");
+	});
+
+	test("tolerates extra runtime-context vars beyond the required credentials", () => {
+		const errors = checkCredentialEnv({
+			[SMOKE_WORKFLOW]: { ...smokeEnv, SOME_RUNTIME_CONTEXT: "x" },
+			[MATRIX_WORKFLOW]: matrixEnv,
+		});
+		expect(errors).toEqual([]);
+	});
+});
+
+describe("the gate itself", () => {
+	test("the real workflows are in lockstep with the registries", () => {
+		expect(runCheck()).toEqual([]);
 	});
 });


### PR DESCRIPTION
**ENG-66 bench matrix — split into 3 focused PRs** (merge bottom-up, each independently green):
1. #84 — plan-matrix CLI + fan-out workflow
2. #85 — workflow choice-sync gate
3. **#69 — workflow credential-env gate** (this PR)

↑ **This PR is 3/3**, based on #85. _(Was the original #69, now narrowed to the credential-env gate.)_

---
Completes the workflow-sync gate with **invariants 3–4** — every provider's `requiredEnvVars` wired into the run-step env of both workflow lanes, and a shared key mapping to the same value expression across lanes — plus `runCheck`, the real-file CI enforcement point. In-file split of `workflow-sync.ts`: the final file is byte-identical to the pre-split #69.

**Validated locally:** `bun run typecheck` (0 errors); `@repo/repo-checks` 65 tests pass.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a workflow↔registry credential-env drift gate to keep `bench-smoke.yml` and `bench-matrix.yml` aligned with `@sandbox-benchmarks/schema` (ENG-66). Checks each provider’s `requiredEnvVars` in the “Run suite and normalize” step in both workflows and ensures shared keys use the same value expression.

- **New Features**
  - Repo checks: `stepEnv`, `requiredCredentialKeys`, and `checkCredentialEnv` to parse step env and enforce credential invariants alongside provider/suite checks.
  - CI: `runCheck()` validates the real workflow files and reports missing or mismatched keys with file names.
  - Tests: coverage for `stepEnv` parsing and errors, provenance via `requiredCredentialKeys`, drift cases (missing key, value mismatch), tolerance of extra runtime vars, and the real-file gate.

- **Bug Fixes**
  - Restored `asRecord` guard used by `stepEnv` to fix a typecheck failure and ensure reliable YAML navigation.

<sup>Written for commit 3f81c138131023c8720f6abfc50d405122589709. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/starslingdev/sandbox-benchmarks/pull/69?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

---

**Verification:** green on its own — affected-package typecheck clean and tests pass with 0 failures (verified across the full stack build).


