### PR TITLE
feat(repo-checks): ci-lint threshold hardening gate

### DIFF
--- a/tooling/repo-checks/src/lib/workflow-hardening.ts
+++ b/tooling/repo-checks/src/lib/workflow-hardening.ts
@@ -1,14 +1,14 @@
-// Drift gate: the security posture of the GitHub Actions layer. The persist-credentials invariant the
-// .github/ files must hold, which the type system can't enforce (GHA is YAML):
+// Drift gate: the security posture of the GitHub Actions layer. Two invariants the .github/ files
+// must hold, neither of which the type system can enforce (GHA is YAML):
 //
 //   1. persist-credentials hygiene — every `actions/checkout` step sets `persist-credentials: false`
 //      UNLESS it is one of the few jobs that later `git push`es (it needs the persisted job token).
 //      The pushing checkouts are enumerated in CREDENTIALED_CHECKOUTS with provenance; the gate fails
 //      both when a read-only checkout forgets the opt-out AND when a pushing checkout is in the
 //      allowlist but no longer exists / no longer keeps its token (so the allowlist can't rot).
-//
-// The ci-lint threshold invariant (ci-lint.yml runs actionlint + zizmor at the agreed gate) builds on
-// the same parse core and lands in the next PR up the stack.
+//   2. The ci-lint workflow actually runs the two linters at the agreed gate threshold — an actionlint
+//      job and a zizmor job invoked with `--min-severity medium --min-confidence high`. A renamed job
+//      or a loosened threshold (e.g. someone dropping --min-confidence) must fail this gate.
 //
 // Mirrors runner-benchmarking's ci-lint.yml + zizmor.yml hardening, adapted to this repo's workflows.
 // Bun.YAML.parse is built into bun >= 1.3 (no new dependency).
@@ -18,6 +18,7 @@ import { Glob } from "bun";
 import { findRepoRoot } from "./workspace.ts";
 
 export const WORKFLOWS_DIR = ".github/workflows";
+export const CI_LINT_WORKFLOW = ".github/workflows/ci-lint.yml";
 
 /** Checkout steps that intentionally keep the persisted job token, keyed "<file>::<jobId>", with the
  *  reason they push. Every other `actions/checkout` must set persist-credentials: false. */
@@ -125,4 +126,55 @@ export function checkPersistCredentials(
 		}
 	}
 	return errors;
+}
+
+/** Invariant 2: ci-lint.yml runs actionlint + zizmor, and zizmor at the agreed gate threshold. */
+export function checkCiLintGate(doc: unknown, label: string = CI_LINT_WORKFLOW): string[] {
+	const errors: string[] = [];
+	const root = asRecord(doc, `${label}: not a YAML mapping`);
+	const jobs = asRecord(root.jobs, `${label}: no jobs mapping`);
+	// The joined `run:` text of a job's steps — used to confirm the job actually invokes its tool.
+	const jobRun = (jobId: string): string => {
+		const job = asRecord(jobs[jobId], `${label}: "${jobId}" job is not a mapping`);
+		const steps = Array.isArray(job.steps) ? job.steps : [];
+		return steps
+			.map((s) => asRecord(s, `${label}: malformed "${jobId}" step`).run)
+			.filter((r): r is string => typeof r === "string")
+			.join("\n");
+	};
+	for (const tool of ["actionlint", "zizmor"]) {
+		if (!(tool in jobs)) {
+			errors.push(`${label}: missing the "${tool}" job — the ${tool} linter is the gate`);
+			continue;
+		}
+		// Job existence isn't enough: it must actually invoke the tool, or the gate false-passes if
+		// the real invocation is renamed/removed while an empty job shell survives.
+		if (!jobRun(tool).includes(tool)) {
+			errors.push(
+				`${label}: the "${tool}" job must actually run \`${tool}\` — the gate must not pass on a job that no longer invokes it`,
+			);
+		}
+	}
+	if ("zizmor" in jobs) {
+		const run = jobRun("zizmor");
+		for (const flag of ["--min-severity medium", "--min-confidence high"]) {
+			if (!run.includes(flag)) {
+				errors.push(
+					`${label}: the zizmor job must invoke zizmor with \`${flag}\` — the gate threshold can't be loosened`,
+				);
+			}
+		}
+	}
+	return errors;
+}
+
+/** The whole gate against the real .github files under `root`. */
+export function runHardeningCheck(root: string = findRepoRoot()): string[] {
+	const steps = listWorkflowFiles(root).flatMap((file) =>
+		checkoutSteps(readWorkflow(`${WORKFLOWS_DIR}/${file}`, root), file),
+	);
+	return [
+		...checkPersistCredentials(steps),
+		...checkCiLintGate(readWorkflow(CI_LINT_WORKFLOW, root)),
+	];
 }

--- a/tooling/repo-checks/src/workflow-hardening.test.ts
+++ b/tooling/repo-checks/src/workflow-hardening.test.ts
@@ -1,15 +1,20 @@
-// Invariant: the GitHub Actions layer stays hardened — every actions/checkout opts out of credential
-// persistence unless it is an allowlisted pushing checkout. This is unit coverage of the pure checks
-// on synthetic drift (so a regression names the offender) plus a sanity read of the real workflows.
-// The ci-lint threshold coverage and the runHardeningCheck() real-file gate land in the next PR up the
-// stack. See ./lib/workflow-hardening.ts.
+// Invariant: the GitHub Actions layer stays hardened. (1) every actions/checkout opts out of
+// credential persistence unless it is an allowlisted pushing checkout, and (2) ci-lint.yml runs
+// actionlint + zizmor at the agreed gate threshold. The runHardeningCheck() test against the real
+// .github files IS the gate's CI enforcement point (same precedent as workflow-registry-sync.test.ts);
+// the rest is unit coverage of the pure checks on synthetic drift so a regression names the offender.
+// See ./lib/workflow-hardening.ts.
 import { describe, expect, test } from "bun:test";
 import type { CheckoutStep } from "./lib/workflow-hardening.ts";
 import {
+	CI_LINT_WORKFLOW,
+	CREDENTIALED_CHECKOUTS,
+	checkCiLintGate,
 	checkoutSteps,
 	checkPersistCredentials,
 	listWorkflowFiles,
 	readWorkflow,
+	runHardeningCheck,
 	WORKFLOWS_DIR,
 } from "./lib/workflow-hardening.ts";
 
@@ -87,5 +92,61 @@ describe("checkPersistCredentials", () => {
 		const errors = checkPersistCredentials([], allowlist);
 		expect(errors).toHaveLength(1);
 		expect(errors[0]).toContain("no such checkout step exists");
+	});
+});
+
+describe("checkCiLintGate", () => {
+	const good = {
+		jobs: {
+			actionlint: { steps: [{ run: "mise exec -- actionlint -no-color" }] },
+			zizmor: {
+				steps: [
+					{
+						run: "mise exec -- zizmor --min-severity medium --min-confidence high .github/workflows/",
+					},
+				],
+			},
+		},
+	};
+
+	test("passes the real ci-lint.yml", () => {
+		expect(checkCiLintGate(readWorkflow(CI_LINT_WORKFLOW, undefined))).toEqual([]);
+	});
+
+	test("passes a well-formed synthetic gate", () => {
+		expect(checkCiLintGate(good)).toEqual([]);
+	});
+
+	test("flags a missing zizmor job", () => {
+		const errors = checkCiLintGate({ jobs: { actionlint: good.jobs.actionlint } });
+		expect(errors).toHaveLength(1);
+		expect(errors[0]).toContain('missing the "zizmor" job');
+	});
+
+	test("flags a loosened zizmor threshold (dropped --min-confidence)", () => {
+		const loosened = {
+			jobs: {
+				actionlint: good.jobs.actionlint,
+				zizmor: {
+					steps: [{ run: "mise exec -- zizmor --min-severity medium .github/workflows/" }],
+				},
+			},
+		};
+		const errors = checkCiLintGate(loosened);
+		expect(errors).toHaveLength(1);
+		expect(errors[0]).toContain("--min-confidence high");
+	});
+});
+
+describe("the gate itself", () => {
+	test("the real .github layer is hardened", () => {
+		expect(runHardeningCheck()).toEqual([]);
+	});
+
+	test("the allowlist documents a reason for every entry", () => {
+		for (const [key, reason] of Object.entries(CREDENTIALED_CHECKOUTS)) {
+			expect(key).toContain("::");
+			expect(reason.length).toBeGreaterThan(0);
+		}
 	});
 });


### PR DESCRIPTION
**CI hardening — split into 3 focused PRs** (merge bottom-up, each independently green):
1. #86 — ci-lint workflow + persist-credentials hardening
2. #87 — persist-credentials gate
3. **#70 — ci-lint threshold gate** (this PR)

↑ **This PR is 3/3**, based on #87. _(Was the original #70, now narrowed to the ci-lint threshold gate.)_

---
Completes the workflow-hardening gate with **invariant 2** — ci-lint.yml must run actionlint + zizmor and invoke zizmor at `--min-severity medium --min-confidence high` — plus `runHardeningCheck`, the real-file CI enforcement point. In-file split of `workflow-hardening.ts`: byte-identical to the pre-split #70.

**Validated locally:** `bun run typecheck` (0 errors); `@repo/repo-checks` 77 tests pass.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a hardened repo check that enforces two CI invariants: `actions/checkout` must not persist credentials unless allowlisted, and `.github/workflows/ci-lint.yml` must run `actionlint` and `zizmor` with `--min-severity medium --min-confidence high`. It reads the real workflows and fails on missing/renamed/empty jobs or loosened flags; enforced via `runHardeningCheck`.

- **New Features**
  - `checkCiLintGate`: verifies `actionlint` and `zizmor` jobs exist, actually invoke their tools, and require `zizmor` flags `--min-severity medium --min-confidence high`.
  - `runHardeningCheck`: scans `.github/workflows` for checkout steps and validates `.github/workflows/ci-lint.yml`, applying both gates against the repo’s real files.

<sup>Written for commit 46d1c2d7a78971b78b9d8ce08152d2c61a112b1d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/starslingdev/sandbox-benchmarks/pull/70?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

---

**Verification:** green on its own — affected-package typecheck clean and tests pass with 0 failures (verified across the full stack build).

