### PR TITLE
feat(schema): economics Catalog slice + pricing-driven derivation (ENG-61)

### DIFF
--- a/packages/schema/src/catalog.test.ts
+++ b/packages/schema/src/catalog.test.ts
@@ -87,7 +87,8 @@ describe("metric catalog", () => {
 	});
 
 	it("throws when a dimension has no headline metric", () => {
-		expect(() => headlineMetric("economics")).toThrow();
+		// `realworld` is the dimension still without any metrics (economics is now populated + headlined).
+		expect(() => headlineMetric("realworld")).toThrow();
 	});
 });
 

--- a/packages/schema/src/catalog.ts
+++ b/packages/schema/src/catalog.ts
@@ -10,6 +10,7 @@
 // the editorial fields the XML can't (a short `label`, the one `headline:true` per dimension, any
 // `dimension` correction). The previously hand-authored cpu entry (node-web-tooling) is now this
 // generated module's wildcard entry; its curation lives in pts-overrides.ts.
+import { economicsMetrics } from "./economics.ts";
 import { harnessMetrics } from "./harness-metrics.ts";
 import type { Dimension, MetricDef } from "./metrics.ts";
 import { metricDefSchema } from "./metrics.ts";
@@ -80,12 +81,14 @@ export const catalogSchema = metricDefSchema.array().narrow((cat, ctx) => {
  * silently broken stability contract.
  *
  * The PTS-derived slice (generated + curated) is followed by the hand-authored harness-measured
- * Metrics (lifecycle + control-plane); the latter carry no `pts` field, so the PTS-mapping invariant
- * skips them while id-uniqueness and the one-headline-per-dimension check below still cover them.
+ * Metrics (lifecycle + control-plane) and the derived economics Metrics; neither carries a `pts` field,
+ * so the PTS-mapping invariant skips them while id-uniqueness and the one-headline-per-dimension check
+ * below still cover them.
  */
 export const METRIC_CATALOG: readonly MetricDef[] = catalogSchema.assert([
 	...ptsCurated,
 	...harnessMetrics,
+	...economicsMetrics,
 ]);
 
 const byId = new Map(METRIC_CATALOG.map((metric) => [metric.id, metric]));

--- a/packages/schema/src/economics.test.ts
+++ b/packages/schema/src/economics.test.ts
@@ -1,9 +1,143 @@
 import { describe, expect, it } from "bun:test";
+import { type } from "arktype";
+import type { ProviderMeta } from "./index.ts";
 import {
 	amortizationBreakEvenRunsPerMonth,
 	amortizedCostPerRun,
 	burstCostPerRun,
+	deriveEconomics,
+	ECONOMICS_METRIC_IDS,
+	economicsMetrics,
+	getMetric,
+	getProvider,
+	HARNESS_METRIC_IDS,
+	headlineMetric,
+	hourlyCostAtTargetSpec,
+	METRIC_CATALOG,
+	metricDefSchema,
+	metricResultSchema,
+	metricsForDimension,
 } from "./index.ts";
+
+const MS_PER_HOUR = 3_600_000;
+
+describe("economics catalog slice", () => {
+	it("ECONOMICS_METRIC_IDS and economicsMetrics describe the same id set", () => {
+		const idValues = new Set(Object.values(ECONOMICS_METRIC_IDS));
+		const defIds = new Set(economicsMetrics.map((m) => m.id));
+		expect(defIds).toEqual(idValues);
+		expect(economicsMetrics.length).toBe(idValues.size);
+	});
+
+	it("registers every economics Metric as a valid, derived, non-PTS economics MetricDef", () => {
+		for (const def of economicsMetrics) {
+			expect(metricDefSchema(def)).not.toBeInstanceOf(type.errors);
+			expect(METRIC_CATALOG).toContainEqual(def);
+			expect(def.dimension).toBe("economics");
+			// Economics is computed from pricing + measured runtime, never parsed or timed.
+			expect(def.derived).toBe(true);
+			expect(def.pts).toBeUndefined();
+		}
+	});
+
+	it("headlines usd_per_hour for the economics dimension, exactly once", () => {
+		expect(headlineMetric("economics").id).toBe(ECONOMICS_METRIC_IDS.usdPerHour);
+		expect(metricsForDimension("economics").filter((m) => m.headline).length).toBe(1);
+	});
+});
+
+describe("deriveEconomics", () => {
+	it("emits usd_per_hour = hourlyCostAtTargetSpec for a vetted-rate provider with no lifecycle data", () => {
+		const meta = getProvider("e2b");
+		const measured = [{ metricId: "node_web_tooling_runs_per_s", mean: 10.5 }];
+		const econ = deriveEconomics(meta, measured);
+
+		expect(econ.map((m) => m.metricId)).toEqual([ECONOMICS_METRIC_IDS.usdPerHour]);
+		expect(econ[0]?.samples).toEqual([hourlyCostAtTargetSpec(meta) ?? Number.NaN]);
+		// Each derived result is a valid single-Sample MetricResult.
+		for (const r of econ) expect(metricResultSchema(r)).not.toBeInstanceOf(type.errors);
+	});
+
+	it("adds usd_per_lifecycle = hourly × summed lifecycle ms when lifecycle Metrics are present", () => {
+		const meta = getProvider("daytona");
+		const hourly = hourlyCostAtTargetSpec(meta) ?? Number.NaN;
+		const measured = [
+			{ metricId: HARNESS_METRIC_IDS.spawn, mean: 1000 },
+			{ metricId: HARNESS_METRIC_IDS.exec, mean: 500 },
+			// A non-lifecycle measured Metric must not feed the lifecycle sum.
+			{ metricId: "node_web_tooling_runs_per_s", mean: 10.5 },
+		];
+		const econ = deriveEconomics(meta, measured);
+
+		const lifecycle = econ.find((m) => m.metricId === ECONOMICS_METRIC_IDS.usdPerLifecycle);
+		expect(lifecycle?.samples[0]).toBeCloseTo(hourly * (1500 / 3_600_000), 12);
+		// Headline hourly cost is still present alongside it.
+		expect(econ.map((m) => m.metricId)).toContain(ECONOMICS_METRIC_IDS.usdPerHour);
+	});
+
+	it("omits usd_per_lifecycle when no lifecycle Metric was measured", () => {
+		const econ = deriveEconomics(getProvider("modal"), [
+			{ metricId: HARNESS_METRIC_IDS.controlPlaneInfo, mean: 42 },
+		]);
+		// control-plane timings are not lifecycle runtime, so no per-lifecycle cost.
+		expect(econ.map((m) => m.metricId)).toEqual([ECONOMICS_METRIC_IDS.usdPerHour]);
+	});
+
+	it("adds usd_per_compute_run = hourly × runtime when a positive runtimeMs is supplied", () => {
+		const meta = getProvider("daytona");
+		const hourly = hourlyCostAtTargetSpec(meta) ?? Number.NaN;
+		const runtimeMs = 90_000; // a 90s compute pipeline
+		const econ = deriveEconomics(
+			meta,
+			[{ metricId: "node_web_tooling_runs_per_s", mean: 10.5 }],
+			runtimeMs,
+		);
+
+		const computeRun = econ.find((m) => m.metricId === ECONOMICS_METRIC_IDS.usdPerComputeRun);
+		expect(computeRun?.samples[0]).toBeCloseTo(hourly * (runtimeMs / MS_PER_HOUR), 12);
+		// Headline hourly cost is still present; with no lifecycle Metric, per-lifecycle is omitted.
+		expect(econ.map((m) => m.metricId)).toEqual([
+			ECONOMICS_METRIC_IDS.usdPerHour,
+			ECONOMICS_METRIC_IDS.usdPerComputeRun,
+		]);
+	});
+
+	it("omits usd_per_compute_run when no runtime is supplied or it is non-positive/non-finite", () => {
+		const meta = getProvider("e2b");
+		const measured = [{ metricId: "node_web_tooling_runs_per_s", mean: 10.5 }];
+		// OURS has no realworld suite, so the normalizer passes no runtime — we never fabricate one.
+		for (const runtimeMs of [undefined, 0, -5, Number.NaN, Number.POSITIVE_INFINITY]) {
+			const econ = deriveEconomics(meta, measured, runtimeMs);
+			expect(econ.map((m) => m.metricId)).not.toContain(ECONOMICS_METRIC_IDS.usdPerComputeRun);
+		}
+	});
+
+	it("returns nothing for a provider with no vetted rate (a null rate must never read as free)", () => {
+		const unpriced: ProviderMeta = {
+			...getProvider("e2b"),
+			pricing: { model: "unknown", notes: "no vetted rate" },
+		};
+		expect(deriveEconomics(unpriced, [{ metricId: HARNESS_METRIC_IDS.spawn, mean: 1000 }])).toEqual(
+			[],
+		);
+	});
+
+	it("keeps every lifecycle harness Metric in the lifecycle sum", () => {
+		// Guards the LIFECYCLE_METRIC_IDS set: each lifecycle-dimension harness Metric contributes.
+		const meta = getProvider("daytona");
+		const hourly = hourlyCostAtTargetSpec(meta) ?? Number.NaN;
+		const lifecycleIds = Object.values(HARNESS_METRIC_IDS).filter(
+			(id) => getMetric(id)?.dimension === "lifecycle",
+		);
+		const measured = lifecycleIds.map((metricId) => ({ metricId, mean: 100 }));
+		const econ = deriveEconomics(meta, measured);
+		const lifecycle = econ.find((m) => m.metricId === ECONOMICS_METRIC_IDS.usdPerLifecycle);
+		expect(lifecycle?.samples[0]).toBeCloseTo(
+			hourly * ((100 * lifecycleIds.length) / 3_600_000),
+			12,
+		);
+	});
+});
 
 describe("cost-model helpers (burst vs fixed-infra amortization)", () => {
 	it("burstCostPerRun scales linearly with runtime", () => {

--- a/packages/schema/src/economics.ts
+++ b/packages/schema/src/economics.ts
@@ -1,14 +1,149 @@
-// Cost models for a single benchmark run: the pure pricing math the economics Dimension is built on.
-// Two models — burst (pay-per-use) and fixed-infra amortized — plus the break-even utilization between
-// them. Pure functions with no schema dependencies, so they are unit-testable in isolation. The derived
-// economics MetricDefs and the deriveEconomics() derivation that consume burstCostPerRun land in the
-// next PR up the stack.
+// The economics Dimension: the $/run comparison axis. Unlike PTS Metrics (parsed from a `<Result>`)
+// and harness Metrics (timed by the lifecycle driver), economics Metrics are DERIVED — computed from
+// a provider's published pricing ({@link hourlyCostAtTargetSpec}) and the runtime already measured on
+// the Run. Schema owns pricing, so it owns this derivation too; the results normalizer calls
+// {@link deriveEconomics} and appends the result to each validated ProviderRun.
+//
+// These MetricDefs are hand-authored (the PTS generator owns only the PTS half of the Catalog) and
+// merged into METRIC_CATALOG by catalog.ts after the harness Metrics. The drift gate diffs only the
+// generated PTS module, so editing this file never trips it.
+import { aggregate } from "./analysis.ts";
+import { harnessMetrics } from "./harness-metrics.ts";
+import type { MetricDef } from "./metrics.ts";
+import type { ProviderMeta } from "./providers.ts";
+import { hourlyCostAtTargetSpec } from "./providers.ts";
+import type { MetricResult } from "./run.ts";
 
+// The lifecycle-Dimension Metric ids, sourced from the harness slice (the sole owner of lifecycle
+// Metrics). Built here rather than via getMetric() so this module never imports catalog.ts — catalog.ts
+// imports economicsMetrics, and a back-edge would be a cycle. PTS never emits lifecycle Metrics, so the
+// harness slice is the complete set.
+const LIFECYCLE_METRIC_IDS = new Set(
+	harnessMetrics.filter((m) => m.dimension === "lifecycle").map((m) => m.id),
+);
+
+/**
+ * The stable id for each derived economics Metric — the one source of truth shared by the MetricDefs
+ * below and {@link deriveEconomics}, so the value a provider emits is always a catalogued id.
+ */
+export const ECONOMICS_METRIC_IDS = {
+	/** Hourly cost at the pinned target spec — the price/performance denominator. */
+	usdPerHour: "usd_per_hour",
+	/** Cost of one measured sandbox lifecycle (spawn→exec→snapshot→teardown) at the target spec. */
+	usdPerLifecycle: "usd_per_lifecycle",
+	/** Cost of one end-to-end compute/realworld pipeline at the target spec, from a supplied runtime. */
+	usdPerComputeRun: "usd_per_compute_run",
+} as const;
+
+/** A derived economics Metric id — a value of {@link ECONOMICS_METRIC_IDS}. */
+export type EconomicsMetricId = (typeof ECONOMICS_METRIC_IDS)[keyof typeof ECONOMICS_METRIC_IDS];
+
+const LIB = "LIB";
 const MS_PER_HOUR = 3_600_000;
 
 /**
+ * The economics Catalog slice, in display order. All three entries are `derived:true` — never parsed or
+ * timed, always computed from pricing + measured runtime. Exactly one `headline:true` (usd_per_hour),
+ * the invariant catalog.ts enforces at load. No `pts` field, so the PTS-mapping invariant skips them.
+ */
+export const economicsMetrics: MetricDef[] = [
+	{
+		id: ECONOMICS_METRIC_IDS.usdPerHour,
+		dimension: "economics",
+		unit: "USD/hr",
+		direction: LIB,
+		headline: true,
+		label: "Hourly cost",
+		description:
+			"USD per hour to run a sandbox at the pinned target spec (2 vCPU / 8 GiB), from the provider's published per-vCPU/per-GiB rates. The price/performance denominator; null-rated providers emit nothing.",
+		derived: true,
+	},
+	{
+		id: ECONOMICS_METRIC_IDS.usdPerLifecycle,
+		dimension: "economics",
+		unit: "USD",
+		direction: LIB,
+		headline: false,
+		label: "Cost per lifecycle",
+		description:
+			"USD to run one measured sandbox lifecycle (sum of the measured lifecycle timings — spawn, exec, snapshot, teardown) at the target hourly cost. Emitted only when the Run carries lifecycle timings.",
+		derived: true,
+	},
+	{
+		id: ECONOMICS_METRIC_IDS.usdPerComputeRun,
+		dimension: "economics",
+		unit: "USD",
+		direction: LIB,
+		headline: false,
+		label: "Cost per compute run",
+		description:
+			"USD to run one end-to-end compute/realworld pipeline at the target hourly cost (hourly × the pipeline's wall-clock runtime). Burst-priced: you pay only for the seconds the sandbox is alive. Emitted only when a total-runtime input is supplied; OURS has no realworld suite yet, so today's Runs omit it.",
+		derived: true,
+	},
+];
+
+/** One measured Metric's id and the mean of its Samples — the input {@link deriveEconomics} reads. */
+export interface MeasuredMetric {
+	metricId: string;
+	mean: number;
+}
+
+/**
+ * Derive a provider's economics Metrics from its pricing and the runtime already measured on the Run.
+ * Returns ready-to-embed {@link MetricResult}s (single-Sample distributions) for the normalizer to
+ * append to the ProviderRun.
+ *
+ * - `usd_per_hour` — {@link hourlyCostAtTargetSpec}; emitted whenever the provider has a vetted rate.
+ * - `usd_per_lifecycle` — the hourly cost prorated over the summed measured lifecycle timings;
+ *   emitted only when `measured` carries ≥1 lifecycle-Dimension Metric.
+ * - `usd_per_compute_run` — the hourly cost prorated over a whole compute/realworld pipeline's
+ *   wall-clock runtime, supplied via `runtimeMs`. OURS has no realworld suite yet, so this is
+ *   omitted unless a caller passes a positive runtime — we never fabricate a pipeline duration.
+ *
+ * Returns `[]` for an unknown/unpriced provider so a null rate can never read as free. Pure — `meta`,
+ * `measured`, and `runtimeMs` are the only inputs, so this is unit-testable without a Run.
+ */
+export function deriveEconomics(
+	meta: ProviderMeta,
+	measured: readonly MeasuredMetric[],
+	runtimeMs?: number,
+): MetricResult[] {
+	const hourly = hourlyCostAtTargetSpec(meta);
+	if (hourly === null) return [];
+
+	const results: MetricResult[] = [economicsResult(ECONOMICS_METRIC_IDS.usdPerHour, hourly)];
+
+	// Sum the means of every measured lifecycle-Dimension Metric (ms). Driven by the lifecycle-id set
+	// (built from the harness slice) so it stays correct as new lifecycle Metrics are added there.
+	let lifecycleMs = 0;
+	let lifecycleCount = 0;
+	for (const m of measured) {
+		if (LIFECYCLE_METRIC_IDS.has(m.metricId)) {
+			lifecycleMs += m.mean;
+			lifecycleCount += 1;
+		}
+	}
+	if (lifecycleCount > 0) {
+		results.push(
+			economicsResult(ECONOMICS_METRIC_IDS.usdPerLifecycle, burstCostPerRun(hourly, lifecycleMs)),
+		);
+	}
+
+	// usd_per_compute_run — the cost of a full compute/realworld pipeline, billed burst-style over the
+	// runtime the caller measured. Gated on a positive finite runtime so a missing suite (undefined) or
+	// a 0/NaN can never read as a free run; OURS has no realworld suite, so live Runs omit it today.
+	if (runtimeMs !== undefined && Number.isFinite(runtimeMs) && runtimeMs > 0) {
+		results.push(
+			economicsResult(ECONOMICS_METRIC_IDS.usdPerComputeRun, burstCostPerRun(hourly, runtimeMs)),
+		);
+	}
+
+	return results;
+}
+
+/**
  * Burst (pay-per-use) cost of one run: you pay only for the wall-clock the sandbox is alive, so the
- * cost scales linearly with runtime. The model behind every runtime economics Metric
+ * cost scales linearly with runtime. The model behind every runtime economics Metric here
  * (`usd_per_lifecycle`, `usd_per_compute_run`) — the serverless/per-second default.
  */
 export function burstCostPerRun(hourlyUsd: number, runtimeMs: number): number {
@@ -42,4 +177,9 @@ export function amortizationBreakEvenRunsPerMonth(
 ): number {
 	const burst = burstCostPerRun(hourlyUsd, runtimeMs);
 	return burst > 0 ? monthlyUsd / burst : Number.POSITIVE_INFINITY;
+}
+
+/** A derived economics Metric as a single-Sample MetricResult (n=1, stdev=0). */
+function economicsResult(metricId: EconomicsMetricId, value: number): MetricResult {
+	return { metricId, samples: [value], aggregates: aggregate([value]) };
 }

--- a/packages/schema/src/index.ts
+++ b/packages/schema/src/index.ts
@@ -7,7 +7,8 @@ import { rawRunSchema } from "./lib/internal.ts";
 export * from "./analysis.ts";
 // The Metric Catalog — the registry of rankable Metrics, plus lookup helpers.
 export * from "./catalog.ts";
-// The pure cost models ($/run — burst vs fixed-infra amortization) the economics Dimension builds on.
+// The derived economics Dimension ($/run): its MetricDefs, the pricing-driven derivation, and the
+// pure cost models (burst vs fixed-infra amortization) they build on.
 export * from "./economics.ts";
 // The non-PTS, harness-measured Metric slice (lifecycle + control-plane) and its operation→id contract.
 export * from "./harness-metrics.ts";


### PR DESCRIPTION
**ENG-61 economics — split into 3 focused PRs** (merge bottom-up, each independently green):
1. #80 — pure cost models
2. **#71 — economics Catalog slice + derivation** (this PR)
3. #81 — derive economics onto each Run

↑ **This PR is 2/3**, based on #80. _(Was the original #71, now narrowed to the catalog slice + derivation.)_

---
The **economics dimension**: its three MetricDefs (`usd_per_hour`/`lifecycle`/`compute_run`), `deriveEconomics()` computing them from provider pricing + measured runtime, and the catalog wiring that merges the slice into `METRIC_CATALOG`. Consumes `burstCostPerRun` from #80; the normalizer that calls `deriveEconomics` lands in #81. In-file split of `economics.ts` — confirmed byte-identical to the original.

**Validated locally:** `bun run typecheck` (0 errors); `@sandbox-benchmarks/schema` 132 tests pass; `economics.ts` verified byte-identical to the pre-split file.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a derived economics dimension to `schema` and wires it into `METRIC_CATALOG` so $ cost can rank alongside speed. Computes `usd_per_hour`, `usd_per_lifecycle`, and `usd_per_compute_run` from provider pricing and measured runtimes (ENG-61).

- **New Features**
  - Adds `economicsMetrics` (`usd_per_hour` headline, `usd_per_lifecycle`, `usd_per_compute_run`), `ECONOMICS_METRIC_IDS`, and `deriveEconomics(meta, measured, runtimeMs?)`.
  - Appends `economicsMetrics` after `harnessMetrics`; all are `derived: true` with no `pts`.
  - Derivation: emit `usd_per_hour` when a vetted rate exists; compute lifecycle cost from the sum of lifecycle means (ids sourced from `harnessMetrics`); emit compute-run cost only when `runtimeMs` is finite and >0; unpriced providers return `[]`. Each result is a single-sample `MetricResult` with aggregates.
  - Exports `burstCostPerRun`, `amortizedCostPerRun`, and `amortizationBreakEvenRunsPerMonth`.

- **Tests**
  - Validate `ECONOMICS_METRIC_IDS` ↔ `economicsMetrics` parity, catalog registration, and that `usd_per_hour` is the sole economics headline.
  - Verify lifecycle-sum behavior (includes every lifecycle harness metric), runtime gating for `usd_per_compute_run`, and that unpriced providers emit no economics.
  - Update catalog test to expect `realworld` as the only dimension without a headline.

<sup>Written for commit c300161f7f9d5c38506c95e0a3b5187866cda086. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/starslingdev/sandbox-benchmarks/pull/71?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

---
**Verification:** green on its own — affected-package typecheck clean and tests pass with 0 failures (verified across the full stack build).


