### PR TITLE
feat(results): host-fingerprint enrichment onto the normalized tree (ENG-70)

### DIFF
--- a/packages/results/src/lib/extract.ts
+++ b/packages/results/src/lib/extract.ts
@@ -5,9 +5,10 @@
  */
 import { readdirSync, readFileSync } from "node:fs";
 import { join } from "node:path";
-import type { SkipMarker, UncataloguedResult } from "@sandbox-benchmarks/schema";
+import type { ObservedSpecs, SkipMarker, UncataloguedResult } from "@sandbox-benchmarks/schema";
 import { isPtsResultFile, isSkipMarkerFile, parseSkipMarker } from "@sandbox-benchmarks/schema";
 import { parsePtsComposite, ptsResultToMetric } from "./pts.ts";
+import { parseSystemHost } from "./system-specs.ts";
 
 /** One Metric's samples sourced from a single raw file — the provenance the normalizer preserves. */
 export interface SampleContribution {
@@ -25,6 +26,13 @@ export interface ProviderExtraction {
 	contributions: SampleContribution[];
 	uncatalogued: UncataloguedResult[];
 	skips: SkipMarker[];
+	/**
+	 * HOST-side specs read from a composite's `<System>` fingerprint (the underlying machine, not the
+	 * sandbox quota), when any composite in this directory carried one. The first composite with a
+	 * non-empty `<System>` wins (all files come from one sandbox). The run-writer layer merges this UNDER
+	 * the in-sandbox spec probe, so the dedicated probe always wins on the effective fields.
+	 */
+	observedHost?: ObservedSpecs;
 }
 
 /** Parse JSON, returning undefined rather than throwing on a malformed skip marker. */
@@ -51,6 +59,12 @@ export function extractProviderDir(dir: string, providerId: string): ProviderExt
 
 		if (isPtsResultFile(filename)) {
 			const composite = parsePtsComposite(readFileSync(fullPath, "utf8"));
+			// Capture the host fingerprint from the first composite that carries a non-empty <System>.
+			// Host-only (never effective): merged under the in-sandbox spec probe at the run-writer layer.
+			if (!out.observedHost && composite.PhoronixTestSuite.System) {
+				const host = parseSystemHost(composite.PhoronixTestSuite.System);
+				if (Object.keys(host).length > 0) out.observedHost = host;
+			}
 			for (const result of composite.PhoronixTestSuite.Result) {
 				// A <Result> with no <Entry> carries no measurement — no sample to aggregate and no
 				// headline value to report. Skip it rather than emit a zero-sample contribution (which

--- a/packages/results/src/lib/normalize-tree.test.ts
+++ b/packages/results/src/lib/normalize-tree.test.ts
@@ -121,6 +121,43 @@ describe("normalizeProviderDir reads the suite-tagged layout", () => {
 		);
 	});
 
+	it("maps the composite <System> to host specs while the probe owns the effective specs", () => {
+		const suiteDir = join(providerDir, "cpu-node");
+		mkdirSync(suiteDir);
+		// A composite that discloses a 48-thread host through <System>, plus a node-web-tooling result.
+		writeFileSync(
+			join(suiteDir, "pts_node-web-tooling.xml"),
+			`<?xml version="1.0"?>
+<PhoronixTestSuite>
+  <System>
+    <Identifier>sandbox</Identifier>
+    <Hardware>Processor: AMD EPYC 9R14 96-Core Processor (48 Cores), Memory: 4 x 16 GB</Hardware>
+    <Software>OS: Ubuntu 24.04, Kernel: 6.8.0-1014-aws (x86_64)</Software>
+    <User>root</User>
+  </System>
+  <Result>
+    <Identifier>pts/node-web-tooling-1.0.1</Identifier>
+    <Title>Node.js V8 Web Tooling Benchmark</Title>
+    <Scale>runs/s</Scale><Proportion>HIB</Proportion>
+    <Data><Entry><Value>10.5</Value><RawString>10.5:10.6</RawString></Entry></Data>
+  </Result>
+</PhoronixTestSuite>`,
+		);
+		// The in-sandbox probe reports the EFFECTIVE 2-vCPU cgroup quota.
+		writeFileSync(join(suiteDir, "observed-specs.json"), JSON.stringify({ vcpus: 2, memoryGb: 8 }));
+
+		const run = normalizeProviderDir(root, "daytona");
+		// Host disclosure from <System> lands on the host side…
+		expect(run.observedSpecs.hostVcpus).toBe(48);
+		expect(run.observedSpecs.hostMemoryGb).toBe(64);
+		expect(run.observedSpecs.cpuModel).toBe("AMD EPYC 9R14 96-Core Processor");
+		expect(run.observedSpecs.cpuMicroarch).toBe("Zen 4 (Genoa)");
+		expect(run.observedSpecs.os).toBe("Ubuntu 24.04");
+		// …while the probe still owns the effective fields (the host count never masquerades as effective).
+		expect(run.observedSpecs.vcpus).toBe(2);
+		expect(run.observedSpecs.memoryGb).toBe(8);
+	});
+
 	it("does NOT attach economics to a pending provider (no measured metrics)", () => {
 		// Empty provider dir → pending; economics must not promote it or appear.
 		const run = normalizeProviderDir(root, "daytona");

--- a/packages/results/src/lib/normalize-tree.ts
+++ b/packages/results/src/lib/normalize-tree.ts
@@ -8,6 +8,7 @@ import { readdirSync, readFileSync, statSync } from "node:fs";
 import { join } from "node:path";
 import type {
 	MetricResult,
+	ObservedSpecs,
 	OffDimensionEmission,
 	ProviderRun,
 	Run,
@@ -127,9 +128,13 @@ export function normalizeProviderDir(rawRoot: string, providerId: string): Provi
 	const rawUncatalogued: UncataloguedResult[] = [];
 	const skips: SkipMarker[] = [];
 	const offDimension: OffDimensionEmission[] = [];
+	// Host fingerprint from a composite's <System>, first non-empty across the read order (all suites of
+	// one provider ran on the same machine). Merged UNDER the spec probe below so the probe always wins.
+	let systemHost: ObservedSpecs | undefined;
 
 	for (const suite of suiteDirs) {
 		const ext = extractProviderDir(join(dir, suite), providerId);
+		if (!systemHost && ext.observedHost) systemHost = ext.observedHost;
 		// Runtime half of the contract: collect any catalogued metric this suite emitted on a Dimension it
 		// does not declare. (Uncatalogued emissions are NOT breaches — they stay inert stragglers below.)
 		offDimension.push(
@@ -161,6 +166,7 @@ export function normalizeProviderDir(rawRoot: string, providerId: string): Provi
 	contributions.push(...flat.contributions);
 	rawUncatalogued.push(...flat.uncatalogued);
 	skips.push(...flat.skips);
+	if (!systemHost && flat.observedHost) systemHost = flat.observedHost;
 
 	// De-dupe catalogued metrics by metricId across source files — keep the FIRST (deterministic file
 	// order). In our model one <Result> owns a metric's per-pass samples, so the same metricId in two
@@ -241,13 +247,17 @@ export function normalizeProviderDir(rawRoot: string, providerId: string): Provi
 	// `suiteDirs` is sorted, so when several suites carry one the alphabetically-first wins — an arbitrary
 	// but deterministic tie-break, fine while suites share a provider's spec; revisit if tiers diverge.
 	const specSources = [...suiteDirs, ""];
-	const observedSpecs = readObservedSpecs((name) => {
+	const probeSpecs = readObservedSpecs((name) => {
 		for (const sub of specSources) {
 			const parsed = readJsonFile(join(dir, sub, name));
 			if (parsed !== undefined) return parsed;
 		}
 		return undefined;
 	});
+	// Merge the <System> host fingerprint UNDER the in-sandbox spec probe: the probe owns the effective
+	// fields (vcpus/memoryGb), and <System> only ever fills host-side fields, so the probe always wins on
+	// overlap and a host disclosure can never masquerade as the sandbox's effective size.
+	const observedSpecs: ObservedSpecs = { ...(systemHost ?? {}), ...probeSpecs };
 	const specMatched = computeSpecMatched(observedSpecs);
 
 	return {

--- a/packages/results/src/lib/system-specs.test.ts
+++ b/packages/results/src/lib/system-specs.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from "bun:test";
+import { parseSystemHost } from "./system-specs.ts";
+
+describe("parseSystemHost", () => {
+	it("extracts host CPU/memory/OS from a real PTS <System> Hardware/Software block", () => {
+		const host = parseSystemHost({
+			Identifier: "sandbox",
+			Hardware:
+				"Processor: AMD EPYC 9R14 96-Core Processor (48 Cores), Motherboard: Amazon EC2, Memory: 4 x 16 GB DDR5-4800MT/s, Disk: 322GB Amazon Elastic Block Store",
+			Software:
+				"OS: Ubuntu 24.04, Kernel: 6.8.0-1014-aws (x86_64), Compiler: GCC 13.2.0, System Layer: amazon",
+			User: "root",
+		});
+		expect(host.cpuModel).toBe("AMD EPYC 9R14 96-Core Processor");
+		// Host-side microarch fingerprint derived from the brand string (9R14 = AWS-masked Genoa).
+		expect(host.cpuMicroarch).toBe("Zen 4 (Genoa)");
+		expect(host.hostVcpus).toBe(48);
+		expect(host.hostMemoryGb).toBe(64); // 4 x 16 GB
+		expect(host.os).toBe("Ubuntu 24.04");
+		expect(host.kernel).toBe("6.8.0-1014-aws");
+		expect(host.virtualization).toBe("amazon");
+		expect(host.user).toBe("root");
+		// CRITICAL: never sets effective fields — those come only from the in-sandbox probe.
+		expect(host.vcpus).toBeUndefined();
+		expect(host.memoryGb).toBeUndefined();
+	});
+
+	it("prefers the thread count over the core count for host vCPUs, and parses clock + single-stick memory", () => {
+		const host = parseSystemHost({
+			Hardware: "Processor: Intel Xeon (24 Cores / 48 Threads) @ 3.70GHz, Memory: 64 GB",
+		});
+		expect(host.hostVcpus).toBe(48);
+		expect(host.cpuMhz).toBe(3700);
+		expect(host.hostMemoryGb).toBe(64);
+	});
+
+	it("captures a processor model even when no core-count parenthetical is present", () => {
+		const host = parseSystemHost({ Hardware: "Processor: Apple M2, Memory: 16 GB" });
+		expect(host.cpuModel).toBe("Apple M2");
+		expect(host.hostVcpus).toBeUndefined();
+		expect(host.hostMemoryGb).toBe(16);
+	});
+
+	it("returns an empty object for an empty/unrecognized <System>", () => {
+		expect(parseSystemHost({})).toEqual({});
+		expect(parseSystemHost({ Hardware: "nothing parseable here" })).toEqual({});
+	});
+});

--- a/packages/results/src/lib/system-specs.ts
+++ b/packages/results/src/lib/system-specs.ts
@@ -1,0 +1,67 @@
+/**
+ * Parse a PTS `<System>` block into HOST-side {@link ObservedSpecs}. PTS's Hardware/Software fields are
+ * free-text human descriptions ("Processor: AMD EPYC … (48 Cores), Memory: 4 x 16 GB, …"), so this is
+ * deliberately a set of tolerant regexes: anything that doesn't match is simply left unset.
+ *
+ * CRITICAL host-vs-effective rule: inside a container `<System>` reports the underlying machine (a
+ * 48-thread EPYC), not the sandbox's 2-vCPU cgroup quota. So this only ever sets the HOST fields
+ * (`hostVcpus`/`hostMemoryGb`/`cpuModel`/`cpuMhz`/`kernel`/`os`/`virtualization`/`user`) and NEVER the
+ * effective `vcpus`/`memoryGb`/`diskGb` — those come solely from the in-sandbox spec probe.
+ */
+import type { ObservedSpecs } from "@sandbox-benchmarks/schema";
+import { resolveCpuMicroarch } from "./cpu-fingerprint.ts";
+import type { PtsSystem } from "./pts-schema.ts";
+
+export function parseSystemHost(system: PtsSystem): ObservedSpecs {
+	const specs: ObservedSpecs = {};
+	const hw = system.Hardware ?? "";
+	const sw = system.Software ?? "";
+
+	// "Processor: <model> (N Cores[ / M Threads][, …])". Host logical CPUs = threads when disclosed,
+	// else cores. The model is everything between "Processor:" and the core-count parenthetical.
+	const cpu = hw.match(/Processor:\s*(.+?)\s*\((\d+)\s*Cores(?:\s*\/\s*(\d+)\s*Threads)?/i);
+	if (cpu?.[1]) {
+		specs.cpuModel = cpu[1].trim();
+		const logical = Number(cpu[3] ?? cpu[2]);
+		if (Number.isFinite(logical) && logical > 0) specs.hostVcpus = logical;
+	} else {
+		// No core count — still capture the model up to the first comma/parenthesis.
+		const model = hw.match(/Processor:\s*([^,(]+)/i);
+		if (model?.[1]?.trim()) specs.cpuModel = model[1].trim();
+	}
+
+	// Clock, when PTS appends it ("… @ 3.7GHz"). Stored as MHz to match ObservedSpecs.cpuMhz.
+	const ghz = hw.match(/@\s*([\d.]+)\s*GHz/i);
+	if (ghz?.[1]) {
+		const mhz = Math.round(Number(ghz[1]) * 1000);
+		if (Number.isFinite(mhz) && mhz > 0) specs.cpuMhz = mhz;
+	}
+
+	// "Memory: [K x ]S GB" → total GiB (K defaults to 1 for a single-stick "S GB"/"SGB").
+	const mem = hw.match(/Memory:\s*(?:(\d+)\s*x\s*)?(\d+)\s*GB/i);
+	if (mem?.[2]) {
+		const total = (mem[1] ? Number(mem[1]) : 1) * Number(mem[2]);
+		if (Number.isFinite(total) && total > 0) specs.hostMemoryGb = total;
+	}
+
+	const os = sw.match(/OS:\s*([^,]+)/i);
+	if (os?.[1]?.trim()) specs.os = os[1].trim();
+	const kernel = sw.match(/Kernel:\s*([^\s,]+)/i);
+	if (kernel?.[1]) specs.kernel = kernel[1];
+	// PTS's "System Layer" names the virtualization/containerization layer (kvm, amazon, docker, …).
+	const layer = sw.match(/System Layer:\s*([^,]+)/i);
+	if (layer?.[1]?.trim()) specs.virtualization = layer[1].trim();
+
+	const user = (system.User ?? "").trim();
+	if (user) specs.user = user;
+
+	// Host-side microarch fingerprint, derived purely from the disclosed CPU model. Host-only by
+	// construction: cpuModel here is always the <System> brand string (the physical machine), so the
+	// label can never masquerade as the effective spec.
+	if (specs.cpuModel) {
+		const fp = resolveCpuMicroarch(specs.cpuModel);
+		if (fp) specs.cpuMicroarch = fp.name;
+	}
+
+	return specs;
+}


### PR DESCRIPTION
**ENG-70 host fingerprint — split into 3 focused PRs** (merge bottom-up, each independently green):
1. #82 — CPU microarch fingerprint + forensics schema
2. #83 — effective-spec probe parser + fixtures
3. **#72 — host-fingerprint enrichment onto the tree** (this PR)

↑ **This PR is 3/3**, based on #83. _(Was the original #72, now narrowed to the enrichment wiring.)_

---
The **enrichment wiring**: `system-specs` joins the CPU microarch fingerprint with the parsed PTS `System` host into an observed-host record, `extract` surfaces it, and the normalizer attaches it to each Run — the top layer consuming the fingerprint core (#82) + probe parser (#83).

**Validated locally:** `bun run typecheck` (0 errors); `@sandbox-benchmarks/results` 64 tests pass; tree byte-identical to the pre-split #72.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds host fingerprints from PTS `<System>` into normalized `observedSpecs` (ENG-70). Host-only fields are merged under the in-sandbox probe so effective `vcpus`/`memoryGb` never change.

- **New Features**
  - Added `system-specs` parser for host-only fields: `hostVcpus` (prefers threads), `hostMemoryGb` (“K x S GB” or single-stick), `cpuModel`, `cpuMhz` (from “@ N GHz”), `kernel`, `os`, `virtualization` (“System Layer”), `user`; derives `cpuMicroarch` from `cpuModel`; never sets effective fields; returns `{}` for unrecognized input.
  - `extractProviderDir` captures the first non-empty `<System>` as `observedHost`; `normalizeProviderDir` picks the first across suites and merges it under the probe into `run.observedSpecs`. Tests cover parsing, microarch labeling, and the non-overwrite guarantee.

<sup>Written for commit 03aab666c4479078625b5e55be5e6a954bf9a5db. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/starslingdev/sandbox-benchmarks/pull/72?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

---

**Verification:** green on its own — affected-package typecheck clean and tests pass with 0 failures (verified across the full stack build).

