### PR TITLE
feat(results,cli): public leaderboard / comparison surface (ENG-68)

### DIFF
--- a/LEADERBOARD.md
+++ b/LEADERBOARD.md
@@ -1,0 +1,22 @@
+# Sandbox provider leaderboard
+
+Run `zen5-collected-1782365479` · commit `zen5-ssh` · generated 2026-06-25T05:31:48.987Z
+
+Each table ranks the providers on that dimension's headline metric. Generated from the published Run dataset — do not edit by hand.
+
+## cpu
+
+Headline: **Node.js web tooling** (runs/s, higher is better)
+
+| Rank | Provider | Node.js web tooling (runs/s) |
+| ---: | --- | ---: |
+| 1 | Daytona | 22.77 |
+
+## economics
+
+Headline: **Hourly cost** (USD/hr, lower is better)
+
+| Rank | Provider | Hourly cost (USD/hr) |
+| ---: | --- | ---: |
+| 1 | Daytona | 0.1494 |
+

--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -13,7 +13,8 @@
     "normalize": "./src/bin/normalize.ts",
     "aggregate": "./src/bin/aggregate.ts",
     "promote": "./src/bin/promote.ts",
-    "stability": "./src/bin/stability.ts"
+    "stability": "./src/bin/stability.ts",
+    "leaderboard": "./src/bin/leaderboard.ts"
   },
   "scripts": {
     "test": "bun test",

--- a/apps/cli/src/bin/leaderboard.ts
+++ b/apps/cli/src/bin/leaderboard.ts
@@ -1,0 +1,54 @@
+#!/usr/bin/env bun
+// `leaderboard` — render a published Run document into the Markdown comparison surface (one ranked
+// table per dimension on its headline metric). Writes to <outFile> when given, else prints to stdout.
+
+import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { dirname } from "node:path";
+import { buildLeaderboard, renderLeaderboardMarkdown } from "@sandbox-benchmarks/results";
+import { parseRun } from "@sandbox-benchmarks/schema";
+import { handleDiscovery } from "../lib/discovery.ts";
+
+/** Agent-facing usage. The Run document names the providers/suites it covers, so the registry
+ *  listings are offered only as cross-CLI-consistent discovery, not the primary input. */
+export const HELP = `leaderboard — render a published Run document into the Markdown comparison surface.
+
+usage: leaderboard <run.json> [outFile.md]
+       leaderboard [--help] [--list-providers] [--list-suites] [--json]
+
+  <run.json>         Path to a normalized Run document (required).
+  [outFile.md]       Write the Markdown here; omit to print to stdout.
+  --list-providers   List the registered providers.
+  --list-suites      List the registered suites.
+  --json             Emit --list-* output as JSON instead of human-readable lines.
+  --help, -h         Show this help.
+
+examples:
+  leaderboard data/runs/local-1.json                 # print the table to stdout
+  leaderboard data/runs/local-1.json LEADERBOARD.md  # write the comparison surface to a file
+
+Next: produce a Run with  bench-suite <provider> <suite> <runId>`;
+
+if (import.meta.main) {
+	const argv = process.argv.slice(2);
+	const discovery = handleDiscovery(argv, HELP);
+	if (discovery !== null) {
+		(discovery.ok ? console.log : console.error)(discovery.text);
+		process.exit(discovery.ok ? 0 : 2);
+	}
+
+	const [runFile, outFile] = argv;
+	if (!runFile) {
+		console.error("usage: leaderboard <run.json> [outFile.md] (see --help)");
+		process.exit(1);
+	}
+	const run = parseRun(JSON.parse(readFileSync(runFile, "utf8")));
+	const markdown = renderLeaderboardMarkdown(buildLeaderboard(run));
+
+	if (outFile) {
+		mkdirSync(dirname(outFile), { recursive: true });
+		writeFileSync(outFile, markdown);
+		console.error(`Wrote leaderboard → ${outFile}`);
+	} else {
+		process.stdout.write(markdown);
+	}
+}

--- a/packages/results/src/index.ts
+++ b/packages/results/src/index.ts
@@ -6,6 +6,13 @@
 // are implementation detail. This surface exposes only the entry points consumers (the CLI) need:
 // normalize a raw tree, write the Run, and summarize it.
 export { aggregateRuns } from "./lib/aggregate.ts";
+export {
+	buildLeaderboard,
+	type Leaderboard,
+	type LeaderboardDimension,
+	type LeaderboardRow,
+	renderLeaderboardMarkdown,
+} from "./lib/leaderboard.ts";
 export { type NormalizeInput, normalizeResultsTree } from "./lib/normalize-tree.ts";
 export {
 	type CompareRunsOptions,

--- a/packages/results/src/lib/leaderboard.test.ts
+++ b/packages/results/src/lib/leaderboard.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, it } from "bun:test";
+import type { MetricResult, ProviderRun, Run } from "@sandbox-benchmarks/schema";
+import { aggregate, ECONOMICS_METRIC_IDS } from "@sandbox-benchmarks/schema";
+import { buildLeaderboard, renderLeaderboardMarkdown } from "./leaderboard.ts";
+
+function metric(metricId: string, samples: number[]): MetricResult {
+	return { metricId, samples, aggregates: aggregate(samples) };
+}
+
+function provider(providerId: string, metrics: MetricResult[]): ProviderRun {
+	return {
+		providerId,
+		validationStatus: metrics.length > 0 ? "validated" : "pending",
+		observedSpecs: {},
+		metrics,
+		skips: [],
+		uncatalogued: [],
+	};
+}
+
+function run(providers: ProviderRun[]): Run {
+	return {
+		schemaVersion: "1",
+		runId: "run-1",
+		sha: "abc123",
+		generatedAt: "2026-06-20T00:00:00.000Z",
+		targetSpec: { vcpus: 2, memoryGb: 8, diskGb: 20 },
+		providers,
+	};
+}
+
+describe("buildLeaderboard", () => {
+	it("ranks the cpu headline HIB (highest first) and includes only providers with the metric", () => {
+		const board = buildLeaderboard(
+			run([
+				provider("daytona", [metric("node_web_tooling_runs_per_s", [10])]),
+				provider("e2b", [metric("node_web_tooling_runs_per_s", [12])]),
+				provider("modal", []), // no metric → excluded from the row set
+			]),
+		);
+		const cpu = board.dimensions.find((d) => d.dimension === "cpu");
+		expect(cpu?.metric.id).toBe("node_web_tooling_runs_per_s");
+		// HIB: e2b (12) outranks daytona (10); modal absent.
+		expect(cpu?.rows.map((r) => [r.rank, r.providerId, r.value])).toEqual([
+			[1, "e2b", 12],
+			[2, "daytona", 10],
+		]);
+	});
+
+	it("ranks an economics (LIB) dimension cheapest-first and uses display names", () => {
+		const board = buildLeaderboard(
+			run([
+				provider("modal", [metric(ECONOMICS_METRIC_IDS.usdPerHour, [0.37])]),
+				provider("e2b", [metric(ECONOMICS_METRIC_IDS.usdPerHour, [0.23])]),
+			]),
+		);
+		const econ = board.dimensions.find((d) => d.dimension === "economics");
+		// LIB: cheapest first.
+		expect(econ?.rows.map((r) => r.providerId)).toEqual(["e2b", "modal"]);
+		expect(econ?.rows[0]?.displayName).toBe("E2B"); // resolved from the provider registry
+	});
+
+	it("omits dimensions with no headline value and renders Markdown tables", () => {
+		const board = buildLeaderboard(
+			run([provider("daytona", [metric("node_web_tooling_runs_per_s", [10])])]),
+		);
+		// Only cpu is populated; disk/memory/etc. are absent.
+		expect(board.dimensions.map((d) => d.dimension)).toEqual(["cpu"]);
+		const md = renderLeaderboardMarkdown(board);
+		expect(md).toContain("## cpu");
+		expect(md).toContain("Node.js web tooling");
+		expect(md).toContain("higher is better");
+		expect(md).toMatch(/\| 1 \| Daytona \| 10 \|/);
+	});
+
+	it("breaks ties on equal headline values deterministically by providerId", () => {
+		// Input order is modal-then-daytona; equal values must reorder to alphabetical providerId.
+		const board = buildLeaderboard(
+			run([
+				provider("modal", [metric("node_web_tooling_runs_per_s", [10])]),
+				provider("daytona", [metric("node_web_tooling_runs_per_s", [10])]),
+			]),
+		);
+		const cpu = board.dimensions.find((d) => d.dimension === "cpu");
+		expect(cpu?.rows.map((r) => r.providerId)).toEqual(["daytona", "modal"]);
+		expect(cpu?.rows.map((r) => r.rank)).toEqual([1, 2]);
+	});
+
+	it("renders a placeholder when nothing is ranked", () => {
+		const md = renderLeaderboardMarkdown(buildLeaderboard(run([provider("daytona", [])])));
+		expect(md).toContain("No ranked dimensions yet");
+	});
+});

--- a/packages/results/src/lib/leaderboard.ts
+++ b/packages/results/src/lib/leaderboard.ts
@@ -1,0 +1,122 @@
+/**
+ * Render a validated {@link Run} into the public comparison surface: one ranked table per Dimension,
+ * keyed on that Dimension's headline Metric, plus economics. This is the payoff the dataset exists for
+ * — a human-readable provider ranking. SDK-free: the Run model + the Catalog only.
+ *
+ * Each Dimension shows its single headline Metric (catalog.ts guarantees exactly one), every provider
+ * that produced it, ranked by the Metric's Direction (HIB → highest first, LIB → lowest first). A
+ * Dimension with no headline Metric, or no provider value, is omitted. The representative value is the
+ * Samples' p50 (median) — robust to a single slow pass.
+ */
+import type { Dimension, MetricDef, Run } from "@sandbox-benchmarks/schema";
+import { DIMENSIONS, getProvider, METRIC_CATALOG } from "@sandbox-benchmarks/schema";
+
+/** One provider's standing on a Dimension's headline Metric. */
+export interface LeaderboardRow {
+	providerId: string;
+	displayName: string;
+	/** Representative value (Samples' p50) of the headline Metric for this provider. */
+	value: number;
+	/** 1-based rank by the Metric's Direction; equal values share neither rank (deterministic tie-break). */
+	rank: number;
+}
+
+/** One Dimension's ranked comparison on its headline Metric. */
+export interface LeaderboardDimension {
+	dimension: Dimension;
+	metric: MetricDef;
+	rows: LeaderboardRow[];
+}
+
+/** The full comparison surface derived from one Run. */
+export interface Leaderboard {
+	runId: string;
+	sha: string;
+	generatedAt: string;
+	dimensions: LeaderboardDimension[];
+}
+
+/** Build the structured leaderboard from a validated Run. Pure — Run in, ranking out. */
+export function buildLeaderboard(run: Run): Leaderboard {
+	const dimensions: LeaderboardDimension[] = [];
+
+	for (const dimension of DIMENSIONS) {
+		// The headline Metric for this Dimension, if one is catalogued (else the Dimension is unpopulated).
+		// A direct lookup, not headlineMetric()+catch: an unpopulated Dimension is the expected case here,
+		// not an exceptional one, and a bare catch would also swallow real programming errors.
+		const metric: MetricDef | undefined = METRIC_CATALOG.find(
+			(m) => m.dimension === dimension && m.headline,
+		);
+		if (!metric) continue;
+
+		const rows: LeaderboardRow[] = run.providers.flatMap((provider) => {
+			const result = provider.metrics.find((m) => m.metricId === metric.id);
+			if (!result) return [];
+			return [
+				{
+					providerId: provider.providerId,
+					displayName: getProvider(provider.providerId)?.displayName ?? provider.providerId,
+					value: result.aggregates.p50,
+					rank: 0, // assigned after sort
+				},
+			];
+		});
+		if (rows.length === 0) continue;
+
+		// Rank by Direction; tie-break on providerId so the output is deterministic.
+		rows.sort((a, b) =>
+			a.value !== b.value
+				? metric.direction === "HIB"
+					? b.value - a.value
+					: a.value - b.value
+				: a.providerId.localeCompare(b.providerId),
+		);
+		rows.forEach((row, i) => {
+			row.rank = i + 1;
+		});
+
+		dimensions.push({ dimension, metric, rows });
+	}
+
+	return { runId: run.runId, sha: run.sha, generatedAt: run.generatedAt, dimensions };
+}
+
+/** Format a metric value compactly: integers as-is, otherwise up to 4 significant digits, trimmed. */
+function formatValue(value: number): string {
+	if (Number.isInteger(value)) return String(value);
+	// toPrecision(4) then strip trailing zeros / a trailing dot (e.g. 0.2304, 12.35, 1234).
+	return Number.parseFloat(value.toPrecision(4)).toString();
+}
+
+/** Render a {@link Leaderboard} as a Markdown document — the committed comparison surface. */
+export function renderLeaderboardMarkdown(board: Leaderboard): string {
+	const lines: string[] = [
+		"# Sandbox provider leaderboard",
+		"",
+		`Run \`${board.runId}\` · commit \`${board.sha}\` · generated ${board.generatedAt}`,
+		"",
+		"Each table ranks the providers on that dimension's headline metric. Generated from the published Run dataset — do not edit by hand.",
+		"",
+	];
+
+	if (board.dimensions.length === 0) {
+		lines.push("_No ranked dimensions yet (no provider produced a headline metric)._", "");
+		return `${lines.join("\n")}\n`;
+	}
+
+	for (const { dimension, metric, rows } of board.dimensions) {
+		const better = metric.direction === "HIB" ? "higher is better" : "lower is better";
+		lines.push(
+			`## ${dimension}`,
+			"",
+			`Headline: **${metric.label}** (${metric.unit}, ${better})`,
+			"",
+			`| Rank | Provider | ${metric.label} (${metric.unit}) |`,
+			"| ---: | --- | ---: |",
+			...rows.map((r) => `| ${r.rank} | ${r.displayName} | ${formatValue(r.value)} |`),
+			"",
+		);
+	}
+
+	return `${lines.join("\n")}\n`;
+}


### PR DESCRIPTION
**Sandbox Benchmark Matrix & Leaderboard — one exploration branch split into a parallel-mergeable dependency DAG.**
Every PR is green on its own (typecheck + tests) and merges bottom-up. Four independent units:

- **Standalone (off `main`):** #76 ENG-59 (lifecycle) · #77 ENG-69 (docs/ADRs)
- **Shared CLI/harness + dimensions foundation:** #67 ENG-62 → #68 ENG-60
- **CI / matrix branch:** #67 → #68 → #69 ENG-66 → #70 ci-hardening
- **Dataset / consumer branch:** #67 → #68 → #71 ENG-61 → #72 ENG-70 → #73 ENG-67 → { #74 ENG-68 ‖ #75 ENG-71 }

↑ **This PR is #74 — ENG-68**, based on #73 (ENG-67).

---

Render the validated Run dataset into a provider ranking — the repo's reason for existing. buildLeaderboard(run) produces one ranked table per Dimension keyed on its headline metric (representative value = Samples' p50, ranked by Direction with a deterministic providerId tie-break). renderLeaderboardMarkdown() emits the committed LEADERBOARD.md. leaderboard CLI reads a Run and writes markdown or stdout. Parallel tip on ENG-67; single-provider (Daytona) snapshot pending live e2b/modal (ENG-63/64).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a public provider leaderboard and a `leaderboard` CLI that generate `LEADERBOARD.md` from a Run by ranking providers on each dimension’s headline metric. Delivers ENG-68’s public comparison surface.

- **New Features**
  - `@sandbox-benchmarks/results`: `buildLeaderboard(run)` ranks by headline p50, respects HIB/LIB, skips empty dimensions, uses registry display names, and tie-breaks by `providerId`.
  - `renderLeaderboardMarkdown(board)` outputs Markdown tables with compact number formatting, an empty state, and a run metadata header (runId, sha, generatedAt).
  - CLI `leaderboard <run.json> [outFile.md]` writes to file or stdout; supports `--list-providers`, `--list-suites`, `--json`; exports leaderboard APIs/types with tests and an example `LEADERBOARD.md`.

<sup>Written for commit 98b8c0af2a2651e18c231930b9e39c846815f7d3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/starslingdev/sandbox-benchmarks/pull/74?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

---

**Verification:** green on its own — affected-package typecheck clean and tests pass with 0 failures (verified across the full stack build).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a leaderboard view for benchmark runs with ranked metric and cost summaries.
  * Added a new CLI command to generate leaderboard Markdown from a run JSON file.
  * Exposed leaderboard building and Markdown rendering utilities through the results package API.
* **Tests**
  * Added tests covering ranking direction, deterministic tie-breaking, omitted missing dimensions, and empty-state Markdown output.
* **Documentation**
  * Updated/added a generated leaderboard document with run metadata and metric rankings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->