### PR TITLE
feat(results,cli): cross-run stability / regression gate (ENG-71)

### DIFF
--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -12,7 +12,8 @@
     "build-template": "./src/bin/build-template.ts",
     "normalize": "./src/bin/normalize.ts",
     "aggregate": "./src/bin/aggregate.ts",
-    "promote": "./src/bin/promote.ts"
+    "promote": "./src/bin/promote.ts",
+    "stability": "./src/bin/stability.ts"
   },
   "scripts": {
     "test": "bun test",

--- a/apps/cli/src/bin/stability.ts
+++ b/apps/cli/src/bin/stability.ts
@@ -1,0 +1,55 @@
+#!/usr/bin/env bun
+// `stability` — compare two Run documents and report cross-run metric shifts, exiting non-zero when a
+// provider's metric regressed beyond the noise threshold. A CI gate against silent provider drift; only
+// provenance-matched (same appVersion + arguments) measured metrics are compared.
+
+import { readFileSync } from "node:fs";
+import { compareRuns, describeShift, regressions } from "@sandbox-benchmarks/results";
+import { parseRun } from "@sandbox-benchmarks/schema";
+
+if (import.meta.main) {
+	const [previousFile, currentFile, thresholdArg] = process.argv.slice(2);
+	if (!previousFile || !currentFile) {
+		console.error(
+			"usage: stability <previousRun.json> <currentRun.json> [threshold]\n" +
+				"  threshold: relative decimal fraction, e.g. 0.05 = 5% (default 0.10)",
+		);
+		process.exit(1);
+	}
+	const previous = parseRun(JSON.parse(readFileSync(previousFile, "utf8")));
+	const current = parseRun(JSON.parse(readFileSync(currentFile, "utf8")));
+	const threshold = thresholdArg ? Number(thresholdArg) : undefined;
+	if (threshold !== undefined && (!Number.isFinite(threshold) || threshold < 0)) {
+		// A negative noise margin would reclassify every metric as regression/improvement.
+		console.error(
+			`stability: invalid threshold "${thresholdArg}" (must be a non-negative decimal fraction, e.g. 0.1 for 10%)`,
+		);
+		process.exit(1);
+	}
+	// A threshold ≥ 1 (100%) is almost always a percentage typo (e.g. `10` meant as "10%"), which would
+	// silently mark every metric stable and neuter the gate. It's a legal value, so warn loudly on stderr
+	// rather than fail — the operator sees the mistake without a rare wide-margin run being rejected.
+	if (threshold !== undefined && threshold >= 1) {
+		console.error(
+			`stability: warning — threshold ${threshold} is a ${threshold * 100}% margin (thresholds are decimal fractions); did you mean ${threshold / 100}?`,
+		);
+	}
+
+	const shifts = compareRuns(
+		previous,
+		current,
+		threshold !== undefined ? { threshold } : undefined,
+	);
+	for (const shift of shifts) console.log(describeShift(shift));
+
+	const regressed = regressions(shifts);
+	const incomparable = shifts.filter((s) => s.classification === "incomparable").length;
+	const compared = shifts.length - incomparable;
+	console.log(
+		`\n${regressed.length} regression(s) across ${compared} compared metric(s)` +
+			`${incomparable > 0 ? ` (${incomparable} incomparable)` : ""} ` +
+			`(${current.runId} vs ${previous.runId}).`,
+	);
+	// Gate: any regression fails the run so CI surfaces the drift.
+	if (regressed.length > 0) process.exit(1);
+}

--- a/packages/results/src/index.ts
+++ b/packages/results/src/index.ts
@@ -8,6 +8,14 @@
 export { aggregateRuns } from "./lib/aggregate.ts";
 export { type NormalizeInput, normalizeResultsTree } from "./lib/normalize-tree.ts";
 export {
+	type CompareRunsOptions,
+	compareRuns,
+	DEFAULT_THRESHOLD,
+	describeShift,
+	type MetricShift,
+	regressions,
+} from "./lib/stability.ts";
+export {
 	summarizeRun,
 	updateRunIndex,
 	type WriteNormalizedRunInput,

--- a/packages/results/src/lib/stability.test.ts
+++ b/packages/results/src/lib/stability.test.ts
@@ -1,0 +1,121 @@
+import { describe, expect, it } from "bun:test";
+import type { MetricResult, ProviderRun, Run } from "@sandbox-benchmarks/schema";
+import { aggregate } from "@sandbox-benchmarks/schema";
+import { compareRuns, regressions } from "./stability.ts";
+
+function metric(
+	metricId: string,
+	value: number,
+	provenance?: { appVersion?: string; arguments?: string },
+): MetricResult {
+	return {
+		metricId,
+		samples: [value],
+		aggregates: aggregate([value]),
+		...(provenance?.appVersion !== undefined ? { appVersion: provenance.appVersion } : {}),
+		...(provenance?.arguments !== undefined ? { arguments: provenance.arguments } : {}),
+	};
+}
+
+function run(providerId: string, metrics: MetricResult[]): Run {
+	const provider: ProviderRun = {
+		providerId,
+		validationStatus: "validated",
+		observedSpecs: {},
+		metrics,
+		skips: [],
+		uncatalogued: [],
+	};
+	return {
+		schemaVersion: "1",
+		runId: "r",
+		sha: "s",
+		generatedAt: "2026-06-20T00:00:00.000Z",
+		targetSpec: { vcpus: 2, memoryGb: 8, diskGb: 20 },
+		providers: [provider],
+	};
+}
+
+describe("compareRuns", () => {
+	it("flags a HIB drop beyond threshold as a regression", () => {
+		// node-web-tooling is HIB: 10 → 8 is a 20% drop.
+		const shifts = compareRuns(
+			run("daytona", [metric("node_web_tooling_runs_per_s", 10)]),
+			run("daytona", [metric("node_web_tooling_runs_per_s", 8)]),
+		);
+		expect(shifts).toHaveLength(1);
+		expect(shifts[0]?.classification).toBe("regression");
+		expect(regressions(shifts)).toHaveLength(1);
+	});
+
+	it("treats a HIB rise as an improvement and a small move as stable", () => {
+		expect(
+			compareRuns(
+				run("daytona", [metric("node_web_tooling_runs_per_s", 10)]),
+				run("daytona", [metric("node_web_tooling_runs_per_s", 12)]),
+			)[0]?.classification,
+		).toBe("improvement");
+		// 10 → 10.5 is 5%, within the default 10% threshold.
+		expect(
+			compareRuns(
+				run("daytona", [metric("node_web_tooling_runs_per_s", 10)]),
+				run("daytona", [metric("node_web_tooling_runs_per_s", 10.5)]),
+			)[0]?.classification,
+		).toBe("stable");
+	});
+
+	it("flags a LIB rise as a regression (pybench is lower-is-better)", () => {
+		const shifts = compareRuns(
+			run("daytona", [metric("pybench_milliseconds", 900)]),
+			run("daytona", [metric("pybench_milliseconds", 1100)]),
+		);
+		expect(shifts[0]?.classification).toBe("regression");
+	});
+
+	it("classifies a provenance change as incomparable, never a regression", () => {
+		const shifts = compareRuns(
+			run("daytona", [metric("node_web_tooling_runs_per_s", 10, { appVersion: "1.0" })]),
+			run("daytona", [metric("node_web_tooling_runs_per_s", 5, { appVersion: "2.0" })]),
+		);
+		expect(shifts[0]?.classification).toBe("incomparable");
+		expect(shifts[0]?.note).toMatch(/appVersion 1.0→2.0/);
+		expect(regressions(shifts)).toHaveLength(0);
+	});
+
+	it("excludes derived economics metrics from the comparison", () => {
+		const shifts = compareRuns(
+			run("daytona", [metric("usd_per_hour", 0.2)]),
+			run("daytona", [metric("usd_per_hour", 0.9)]),
+		);
+		expect(shifts).toHaveLength(0);
+	});
+
+	it("reports a zero-baseline metric as incomparable, not an Infinity regression", () => {
+		// Previous p50 of 0 has no ratio; the pair is surfaced but never gates.
+		const shifts = compareRuns(
+			run("daytona", [metric("node_web_tooling_runs_per_s", 0)]),
+			run("daytona", [metric("node_web_tooling_runs_per_s", 10)]),
+		);
+		expect(shifts[0]?.classification).toBe("incomparable");
+		expect(shifts[0]?.relativeChange).toBeNaN();
+		expect(shifts[0]?.note).toMatch(/no baseline/);
+		expect(regressions(shifts)).toHaveLength(0);
+	});
+
+	it("treats an unchanged zero metric as stable", () => {
+		const shifts = compareRuns(
+			run("daytona", [metric("node_web_tooling_runs_per_s", 0)]),
+			run("daytona", [metric("node_web_tooling_runs_per_s", 0)]),
+		);
+		expect(shifts[0]?.classification).toBe("stable");
+		expect(shifts[0]?.relativeChange).toBe(0);
+	});
+
+	it("honors a custom threshold", () => {
+		// 10 → 9 is a 10% drop: stable at the default, a regression at a 5% threshold.
+		const a = run("daytona", [metric("node_web_tooling_runs_per_s", 10)]);
+		const b = run("daytona", [metric("node_web_tooling_runs_per_s", 9)]);
+		expect(compareRuns(a, b)[0]?.classification).toBe("stable");
+		expect(compareRuns(a, b, { threshold: 0.05 })[0]?.classification).toBe("regression");
+	});
+});

--- a/packages/results/src/lib/stability.ts
+++ b/packages/results/src/lib/stability.ts
@@ -1,0 +1,177 @@
+/**
+ * Cross-run stability gate: compare a provider's metrics between two {@link Run}s and flag movements
+ * beyond a noise threshold. Provider performance drifts and PTS profiles get re-versioned, so a silent
+ * shift would erode trust in the dataset.
+ *
+ * Provenance is load-bearing. A metric is only comparable when its `appVersion` AND `arguments` match
+ * across the two Runs — otherwise the profile/option matrix changed and a value move is expected, not a
+ * regression. Such pairs are classified `incomparable` (reported, never a gate failure). Derived metrics
+ * (economics) are excluded: they carry no measurement provenance and would double-count the measured
+ * shift they're computed from.
+ *
+ * SDK-free: the Run model + the Catalog (for each metric's Direction) only.
+ */
+import type { Direction, Run } from "@sandbox-benchmarks/schema";
+import { getMetric } from "@sandbox-benchmarks/schema";
+import { type } from "arktype";
+
+/** The default noise threshold (relative): movements within ±10% are treated as stable. */
+export const DEFAULT_THRESHOLD = 0.1;
+
+/**
+ * How a current p50 relates to the previous one, as an explicit state rather than a sentinel number.
+ * A previous value of 0 has no ratio, so that case is its own arm — Infinity never leaks into the
+ * reported percentage or the gate decision. arktype is the single source of truth for the shape (the
+ * {@link Comparison} type is inferred from it).
+ */
+const comparisonSchema = type({
+	status: "'comparable'",
+	/** Signed relative change `(current - previous) / previous`. */
+	relativeChange: "number",
+})
+	.or({
+		// Previous and current p50 are both 0 — identical, no movement.
+		status: "'unchanged'",
+	})
+	.or({
+		// Previous p50 was 0 while current is not — no ratio exists; only the absolute current is meaningful.
+		status: "'no-baseline'",
+		current: "number",
+	});
+
+/** One of the three comparison states — see {@link comparisonSchema}. */
+type Comparison = typeof comparisonSchema.infer;
+
+/** Relate a current p50 to a previous one without ever producing a non-finite `relativeChange`. */
+function compareP50(previous: number, current: number): Comparison {
+	if (previous !== 0) {
+		return { status: "comparable", relativeChange: (current - previous) / previous };
+	}
+	return current === 0 ? { status: "unchanged" } : { status: "no-baseline", current };
+}
+
+/** How a metric moved between two Runs for one provider. */
+export interface MetricShift {
+	providerId: string;
+	metricId: string;
+	direction: Direction;
+	/** Representative (p50) values in the previous and current Run. */
+	previous: number;
+	current: number;
+	/** Signed relative change `(current - previous) / previous`; `NaN` when the pair is incomparable. */
+	relativeChange: number;
+	classification: "regression" | "improvement" | "stable" | "incomparable";
+	/** Why a pair is `incomparable` — the provenance that changed. */
+	note?: string;
+}
+
+export interface CompareRunsOptions {
+	/** Relative movement (e.g. 0.1 = 10%) under which a change is `stable`. Defaults to {@link DEFAULT_THRESHOLD}. */
+	threshold?: number;
+}
+
+/**
+ * Compare every measured metric present for the same provider in both Runs. Returns one
+ * {@link MetricShift} per comparable (and per incomparable) metric, in provider-then-metric order.
+ */
+export function compareRuns(
+	previous: Run,
+	current: Run,
+	options?: CompareRunsOptions,
+): MetricShift[] {
+	const threshold = options?.threshold ?? DEFAULT_THRESHOLD;
+	const prevByProvider = new Map(previous.providers.map((p) => [p.providerId, p]));
+	const shifts: MetricShift[] = [];
+
+	for (const cur of current.providers) {
+		const prev = prevByProvider.get(cur.providerId);
+		if (!prev) continue;
+		const prevMetrics = new Map(prev.metrics.map((m) => [m.metricId, m]));
+
+		for (const curMetric of cur.metrics) {
+			const def = getMetric(curMetric.metricId);
+			// Derived metrics (economics) carry no provenance and mirror a measured shift — skip them.
+			if (def?.derived === true) continue;
+			const prevMetric = prevMetrics.get(curMetric.metricId);
+			if (!prevMetric) continue;
+
+			const direction: Direction = def?.direction ?? "HIB";
+			const base = {
+				providerId: cur.providerId,
+				metricId: curMetric.metricId,
+				direction,
+				previous: prevMetric.aggregates.p50,
+				current: curMetric.aggregates.p50,
+			};
+
+			// Apples-to-apples only when the profile version AND option arguments are unchanged.
+			const provenanceParts: string[] = [];
+			if (prevMetric.appVersion !== curMetric.appVersion) {
+				provenanceParts.push(
+					`appVersion ${prevMetric.appVersion ?? "-"}→${curMetric.appVersion ?? "-"}`,
+				);
+			}
+			if (prevMetric.arguments !== curMetric.arguments) {
+				provenanceParts.push(
+					`arguments ${prevMetric.arguments ?? "-"}→${curMetric.arguments ?? "-"}`,
+				);
+			}
+			if (provenanceParts.length > 0) {
+				shifts.push({
+					...base,
+					relativeChange: Number.NaN,
+					classification: "incomparable",
+					// Only name the field(s) that actually changed, so an unchanged field isn't implied to differ.
+					note: `provenance changed (${provenanceParts.join(", ")})`,
+				});
+				continue;
+			}
+
+			const { previous: p, current: c } = base;
+			const comparison = compareP50(p, c);
+			if (comparison.status === "no-baseline") {
+				// Previous p50 was 0: with no baseline there is no ratio to threshold, so surface it as
+				// incomparable (reported, never a gate failure) rather than inventing an Infinity regression.
+				shifts.push({
+					...base,
+					relativeChange: Number.NaN,
+					classification: "incomparable",
+					note: `no baseline (previous p50 was 0, current ${c})`,
+				});
+				continue;
+			}
+			const relativeChange = comparison.status === "comparable" ? comparison.relativeChange : 0;
+			let classification: MetricShift["classification"];
+			if (Math.abs(relativeChange) <= threshold) {
+				classification = "stable";
+			} else {
+				// "Worse" depends on Direction: HIB regresses when it falls, LIB when it rises.
+				const worse = direction === "HIB" ? c < p : c > p;
+				classification = worse ? "regression" : "improvement";
+			}
+			shifts.push({ ...base, relativeChange, classification });
+		}
+	}
+
+	return shifts;
+}
+
+/** Only the regressions from {@link compareRuns} — what a CI gate fails on. */
+export function regressions(shifts: readonly MetricShift[]): MetricShift[] {
+	return shifts.filter((s) => s.classification === "regression");
+}
+
+/** One human-readable line per shift, for CLI/CI logs. */
+export function describeShift(shift: MetricShift): string {
+	if (shift.classification === "incomparable") {
+		return `~ ${shift.providerId}/${shift.metricId}: incomparable — ${shift.note}`;
+	}
+	const pct = `${(shift.relativeChange * 100).toFixed(1)}%`;
+	const mark =
+		shift.classification === "regression"
+			? "✗"
+			: shift.classification === "improvement"
+				? "✓"
+				: "·";
+	return `${mark} ${shift.providerId}/${shift.metricId}: ${shift.previous} → ${shift.current} (${pct}, ${shift.classification})`;
+}


### PR DESCRIPTION
**Sandbox Benchmark Matrix & Leaderboard — one exploration branch split into a parallel-mergeable dependency DAG.**
Every PR is green on its own (typecheck + tests) and merges bottom-up. Four independent units:

- **Standalone (off `main`):** #76 ENG-59 (lifecycle) · #77 ENG-69 (docs/ADRs)
- **Shared CLI/harness + dimensions foundation:** #67 ENG-62 → #68 ENG-60
- **CI / matrix branch:** #67 → #68 → #69 ENG-66 → #70 ci-hardening
- **Dataset / consumer branch:** #67 → #68 → #71 ENG-61 → #72 ENG-70 → #73 ENG-67 → { #74 ENG-68 ‖ #75 ENG-71 }

↑ **This PR is #75 — ENG-71**, based on #73 (ENG-67).

---

Flag when a provider's metric shifts beyond a noise threshold across Runs, using the retained appVersion and arguments provenance. compareRuns() compares per-provider p50 for metrics present in both runs; a metric is only comparable when appVersion AND arguments match (else incomparable — reported, never a gate failure), derived economics metrics are excluded, and regression/improvement/stable is direction-aware. The stability CLI exits 1 on any regression so CI can gate the committed dataset against silent drift. Parallel tip on ENG-67.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds the ENG-71 stability gate to catch cross-run regressions and fail CI on silent drift. Adds a `stability` CLI and helpers in `@sandbox-benchmarks/results` with provenance checks and correct zero-baseline handling.

- **New Features**
  - `@sandbox-benchmarks/results`: `compareRuns`, `regressions`, `describeShift`, `DEFAULT_THRESHOLD` (10%), plus `MetricShift` and `CompareRunsOptions`.
  - Compares per-provider p50; direction-aware (HIB/LIB). Only compares when `appVersion` and `arguments` match; skips derived economics.
  - `apps/cli`: `stability <previousRun.json> <currentRun.json> [threshold]`; prints shifts and a summary; exits 1 on any regression.

- **Bug Fixes**
  - Threshold guardrails: reject negative/invalid values; warn when threshold ≥ 1; usage clarifies decimal-fraction input.
  - Summary reports compared vs `incomparable` counts and run IDs; notes list only the provenance fields that changed.
  - Zero-baseline: 0→X is `incomparable`; 0→0 is `stable` (no Infinity%).

<sup>Written for commit a74e9e68776d6e82c20a676ce5819e08f1c17273. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/starslingdev/sandbox-benchmarks/pull/75?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

---

**Verification:** green on its own — affected-package typecheck clean and tests pass with 0 failures (verified across the full stack build).