### PR TITLE
docs(adr,schema): methodology + ADR log + add-a-provider/suite/metric guide (ENG-69)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,82 @@
+# Contributing
+
+This repo is a Bun workspace monorepo with a strict, enforced dependency DAG (see the
+[README](./README.md)) and a source-first, no-build layout. Read the [methodology](./docs/methodology.md)
+for how a measurement is produced before extending the matrix.
+
+## Local checks (the gate)
+
+Green-on-your-machine means green-in-CI — the same command contract runs in both:
+
+```sh
+bun install          # resolve the graph (frozen lockfile in CI)
+bun run typecheck    # tsc --noEmit per member
+bun run test         # bun test per member, incl. repo-checks invariants
+bun run lint         # biome check; warnings fail
+bun run spell        # typos (via mise)
+```
+
+PTS-catalog changes also have a drift gate:
+
+```sh
+bun run --filter @sandbox-benchmarks/schema generate-catalog   # regenerate from vendored profiles
+bun run check:catalog-drift                                    # fail if the committed draft drifted
+```
+
+## Add a provider
+
+1. **Identity & economics** — add the id to `ProviderId` and a `REGISTRY` entry in
+   [`packages/schema/src/providers.ts`](./packages/schema/src/providers.ts): `displayName`, `website`,
+   `sdkPackage`, `requiredEnvVars`, `isolation`, vetted `pricing` (per-vCPU/per-GiB, normalized to USD),
+   `maturity`, `specPinning`, and the `transport` capability (`streaming`/`syncCapMs`/`detachedPoll`).
+   The `Record<ProviderId, …>` type makes a missing entry a compile error.
+2. **Adapter** — add a matching entry to the adapter map in
+   [`packages/providers`](./packages/providers): how to `createCompute()` and the create-time
+   `createOptions` (the pinned target spec + toolchain image). The two registries are joined by id, so a
+   one-sided provider is a compile error.
+3. **Template** — add a template builder under [`packages/templates`](./packages/templates) so the
+   provider can be baked with the toolchain image.
+4. The provider now flows through the matrix, normalizer, leaderboard, and economics automatically — no
+   consumer edits. Bring it up live per the provider end-to-end issues (E2B/Modal/Daytona).
+
+## Add a suite
+
+1. **Register it** in [`SUITES`](./packages/schema/src/suites.ts): the `dimensions` it measures, the
+   catalogued `metrics` it emits, its `commands` (mise tasks), and the timeouts. The
+   [suite↔dimension↔metric contract](./packages/schema/src/suite-contract.ts) fails at load if a metric
+   is uncatalogued or off-dimension, or a declared dimension has no metric.
+2. **Producer tasks** — add the mise task(s) under `.mise/tasks/benchmark/**` that the `commands` name,
+   driving the benchmark via the helpers in [`lib/bench.sh`](./lib/bench.sh) (e.g. `run_pts_benchmark`).
+   An orchestrator is a task *file*; its leaves live in a sibling *directory* (a task path can't be both).
+3. The CI matrix picks the suite up automatically (`plan-matrix` crosses `PROVIDERS × SUITE_NAMES`).
+
+## Add a metric
+
+**PTS-backed metric** (preferred — generated, not hand-written):
+
+1. Add the profile's exact `<name>-<ver>` dir to `PROFILES` in
+   [`fetch-profiles.ts`](./packages/schema/scripts/fetch-profiles.ts) and run
+   `bun run --filter @sandbox-benchmarks/schema fetch-profiles` to vendor its
+   `test-definition.xml` / `results-definition.xml`.
+2. Run `generate-catalog` to regenerate `pts-generated.ts`. A **single-result** profile yields one
+   description-less wildcard entry (no byte-match risk). A **multi-result** profile yields one entry per
+   option combination — its synthesized `pts.description` must byte-match real PTS output, so commit a
+   recorded `composite.xml` fixture under `packages/results/src/lib/__fixtures__/` (the
+   [golden gate](./packages/results/src/lib/pts-golden.test.ts) proves it).
+3. Curate editorial fields in [`pts-overrides.ts`](./packages/schema/src/pts-overrides.ts): a short
+   `label`, any `dimension` correction, and exactly one `headline: true` per dimension.
+4. Commit the regenerated `pts-generated.ts` (the drift gate diffs it; overrides are excluded).
+
+**Non-PTS metric** (harness-measured or derived): add the `MetricDef` to the relevant hand-authored
+slice (`harness-metrics.ts` for timings, `economics.ts` for derived) and wire its producer — the
+lifecycle driver for a timing, `deriveEconomics` for a derived metric. These carry no `pts` field and
+don't trip the drift gate.
+
+## Conventions
+
+- **Parse, don't validate**: arktype schemas at every boundary; the TypeScript types are inferred from
+  the runtime schema, never hand-written twice.
+- **Cross-registry invariants** (id-uniqueness, one-headline-per-dimension, the suite contract) are
+  plain throws at module load over typed in-repo constants — fail fast at import.
+- Keep packages within the [dependency DAG](./README.md#dependency-dag-enforced); `@repo/repo-checks`
+  fails CI on a boundary violation.

--- a/README.md
+++ b/README.md
@@ -2,6 +2,11 @@
 
 Compare top sandbox providers' performance for real developer and CI/CD tasks.
 
+> **Docs:** [Methodology](./docs/methodology.md) — how a measurement is produced (target spec,
+> dimensions, economics, host-vs-effective specs, transport model, the dataset pipeline). ·
+> [ADRs](./docs/adr/README.md) — the load-bearing architecture decisions and why. ·
+> [Contributing](./CONTRIBUTING.md) — the local gate and how to add a provider, suite, or metric.
+
 This repo is a **Bun workspace monorepo** with a strict, enforced dependency DAG and a uniform
 package shape. The guiding rule: *"can I import this?"* is answered by the path alone, and
 boundary violations fail CI.

--- a/docs/adr/0001-arktype-parse-dont-validate-boundary.md
+++ b/docs/adr/0001-arktype-parse-dont-validate-boundary.md
@@ -1,0 +1,36 @@
+---
+status: accepted
+---
+
+# arktype parse-don't-validate boundary
+
+## Context
+
+The repo ingests data from outside its own types at several edges: harness `RawRun` output, vendored
+PTS `<Result>` XML, jc/fio/free probe JSON, `observed-specs.json`, per-shard Run documents merged at
+aggregation, and the committed dataset itself. A `RawRun | Run` JSON file on disk is `unknown` until
+something checks it. Hand-written TypeScript interfaces describe the *intended* shape but enforce
+nothing at runtime — a malformed artifact would flow deep into normalization before failing (or
+worse, succeed and publish a corrupt number), and the interface and any ad-hoc validator would drift.
+
+## Decision
+
+Every external boundary is an **arktype schema, and the TypeScript type is inferred from it** — one
+source of truth for shape *and* runtime check. The schema is the gate: a value is *parsed* into a
+typed value at the boundary (`parseRawRun`, `parseRun`, `aggregatesSchema`, `metricDefSchema`,
+`observedSpecsSchema`, …), and code past that point receives an already-validated value, never an
+`unknown`. Schemas also carry invariants the type system can't: `finiteNumber` narrows reject
+NaN/Infinity, `catalogSchema.narrow` makes the dangerous wildcard catalog shape unconstructable, and
+the Catalog `.assert`s at module load so a malformed `MetricDef` is a fail-fast at import.
+
+## Consequences
+
+- No interface/validator drift: there is exactly one declaration of each boundary shape, and `infer`
+  keeps the static type honest to the runtime check.
+- Failures are loud and early — a bad artifact fails *at the boundary* with an arktype summary, not
+  three layers deep in aggregation. The promote gate relies on this: a Run that can't parse can't be
+  published.
+- arktype is the schema package's only external dependency (bottom of the DAG, ADR-0002), so the
+  whole repo shares one validation vocabulary and adds no other runtime dep to get it.
+- Validation is paid at every boundary crossing. For repo-scale data (hundreds of KB per Run) this is
+  negligible, and the alternative — trusting `unknown` — is what we are explicitly buying out of.

--- a/docs/adr/0002-enforced-dependency-dag.md
+++ b/docs/adr/0002-enforced-dependency-dag.md
@@ -1,0 +1,35 @@
+---
+status: accepted
+---
+
+# Enforced dependency DAG with a uniform package shape
+
+## Context
+
+This is a Bun workspace monorepo: `schema`, `providers`, `templates`, `harness`, `results`, the `cli`
+app, and dev-only `@repo/*` tooling. Left unconstrained, monorepos rot into a tangle — `results`
+reaching into a provider SDK, a package importing another's private `lib/`, a cycle between two
+peers — and the rot is invisible until something breaks. We wanted "can I import this?" answerable
+from the path alone, and the answer enforced rather than documented.
+
+## Decision
+
+A **strict, acyclic dependency DAG** with a uniform package shape, **enforced in CI** by
+`@repo/repo-checks`, not just written down. `schema` sits at the bottom (only external dep: arktype,
+ADR-0001); each member declares its internal `workspace:*` deps explicitly; and the layering is a
+deliberate contract — e.g. `results` depends on `schema` **only**, so it can normalize without any
+provider SDK. Every package's `exports` points at TypeScript **source** (`./src/index.ts`) with no
+build step, and only a package's public entry is importable — its private `lib/` is off-limits across
+boundaries. The boundary + package-meta invariants run as ordinary `bun test` checks.
+
+## Consequences
+
+- Boundary violations (a cross-package `lib/` reach, an undeclared dep, a cycle, a stray SDK import in
+  `results`) fail CI as a red test, so the architecture can't silently erode.
+- Source-first + no build means `bun install → typecheck → test → lint` are green with zero
+  compilation, and the committed `bun.lock` pins the whole graph.
+- New packages must adopt the uniform shape (public `src/index.ts`, declared deps, `@repo/tsconfig`)
+  to pass the invariants — slightly more ceremony per package, bought deliberately for the guarantee.
+- The DAG dictates where new code lives: a helper two packages need moves *down* toward `schema`
+  rather than sideways, which is why pricing/economics derivation and the Metric Catalog live in
+  `schema`.

--- a/docs/adr/0003-generated-pts-catalog-and-drift-gate.md
+++ b/docs/adr/0003-generated-pts-catalog-and-drift-gate.md
@@ -1,0 +1,37 @@
+---
+status: accepted
+---
+
+# Generated PTS catalog behind a drift gate
+
+## Context
+
+Most catalogued Metrics come from the Phoronix Test Suite: their id, unit, direction, and the
+`<Description>` that maps a parsed `<Result>` onto a Metric all live in upstream `test-definition.xml`
+profiles we vendor verbatim. Hand-transcribing those into `MetricDef`s is error-prone (a wrong unit
+or a typo'd description silently routes results to `uncatalogued`) and goes stale the moment a profile
+is re-fetched. But the Catalog is also a **stability contract** — ids/units/directions are the keys
+that keep historical Runs comparable — so it can't be free to change on a whim either.
+
+## Decision
+
+**Generate the PTS half of the Catalog from the vendored profiles, and hold it byte-stable with a
+drift gate.** `generate-catalog` derives `pts-generated.ts` (the XML-owned fields: id, unit,
+direction, `pts` provenance, and id-uniqueness) from `test-definition.xml`; a hand-authored
+`pts-overrides.ts` supplies only the editorial fields XML can't express (short `label`, the one
+`headline:true` per dimension, dimension corrections), merged `{ ...generated, ...override }`.
+`check:catalog-drift` fails CI if the committed generated module doesn't match a fresh regeneration,
+so the generated file can't drift from its source. The hand-authored harness and economics slices are
+appended separately and carry no `pts`, so the generator never touches them.
+
+## Consequences
+
+- Catalog changes are deliberate: editorial tweaks go in the override map (drift gate untouched);
+  profile changes require a regenerate-and-commit, which review sees as a data diff.
+- The generator owns id-uniqueness and the XML-derived fields; an orphaned override key (a profile
+  regen renamed a slug) fails fast at load rather than silently shipping a verbose generated label.
+- Adding a PTS suite means vendoring its profile and regenerating — no hand-transcription — at the
+  cost of one more generator input to keep correct. `bun run --filter @sandbox-benchmarks/schema
+  generate-catalog` then `bun run check:catalog-drift` is part of the gate for catalog changes.
+- A synthesized `pts.description` that drifts from real PTS output turns the results golden gate red
+  rather than silently misrouting a `<Result>` to `uncatalogued`.

--- a/docs/adr/0004-consumption-layer-aggregation.md
+++ b/docs/adr/0004-consumption-layer-aggregation.md
@@ -1,0 +1,36 @@
+---
+status: accepted
+---
+
+# Raw-first history, consumption-layer candidate→promote
+
+## Context
+
+A benchmark run is produced by the CI matrix as one Run document per `(provider, suite)` shard. Those
+shards have to become a single comparable Run in the committed dataset. Two failure modes to avoid:
+baking parser bugs into frozen committed numbers (a unit fix would never reach old Runs), and
+publishing a half-collected run (a shard that produced no real metrics reading as a valid provider
+result). GHA artifacts also expire, so the durable evidence can't live only there.
+
+## Decision
+
+**Commit the curated raw tool output as the durable source of truth, and aggregate at the consumption
+layer through an explicit candidate→promote pipeline.** `aggregate` (the collect half) merges the
+per-shard Run documents into a single **candidate** Run written to a candidate dataset; `promote`
+(the publish half) re-validates the candidate against the current schema + Catalog, **gates on at
+least one `validated` provider**, and only then writes it into the committed dataset + newest-first
+index. Normalization is re-runnable from raw with the current parsers, so a parser fix applies to all
+history rather than being frozen at collection time. Every shard is parsed at the boundary on the way
+in (ADR-0001), so a malformed artifact fails loudly at aggregation, not mid-merge.
+
+## Consequences
+
+- Parser/Catalog fixes apply retroactively — committed raw is immutable, the canonical Run is
+  re-derived, so a bad unit conversion doesn't become permanent history.
+- A partial collection with zero validated providers **cannot** be published: the promote gate refuses
+  it, so the dataset never shows an empty or unvalidated run.
+- The dataset is two-staged (candidate, then promoted): more moving parts than committing one blob,
+  bought for the validation gate and the retroactive-fix property. A bad published Run is removed by
+  reverting its dataset commit.
+- Aggregation is pure over parsed shards and unit-tested without live providers, so the merge logic is
+  verifiable from fixtures alone.

--- a/docs/adr/0005-host-vs-effective-spec-split.md
+++ b/docs/adr/0005-host-vs-effective-spec-split.md
@@ -1,0 +1,38 @@
+---
+status: accepted
+---
+
+# Host-vs-effective spec split
+
+## Context
+
+Every provider is created at one pinned [`TARGET_SPEC`](../../packages/schema/src/providers.ts)
+(2 vCPU / 8 GiB) for fairness, but what an in-sandbox probe *sees* varies by provider. Some enforce a
+cgroup quota so the sandbox really is 2 vCPU; others run that 2-vCPU sandbox on a large shared host
+(e.g. Daytona: a 4-vCPU quota on a 48-thread machine) and the probe can see straight through the
+container boundary. If we recorded a single "observed CPU model / vcpu count," a comparison would
+silently mix "the sandbox you were sold" with "the box it happened to land on" — and an aggregate over
+shards scheduled on different hosts would average across hardware without anyone noticing.
+
+## Decision
+
+**Record observed specs as two explicit sides — effective and host — in one
+[`ObservedSpecs`](../../packages/schema/src/run.ts).** `vcpus`/`memoryGb`/`diskGb` are the EFFECTIVE
+sandbox size (the cgroup quota where enforced); `hostVcpus`/`hostMemoryGb` disclose the underlying
+machine when probes see through the boundary. `cpuModel`/`cpuMicroarch`/`cpuMhz` and friends are
+HOST-side by construction — `cpuMicroarch` is a generation label derived from the host `cpuModel`,
+and **never reflects the effective spec**. The aggregate path sets `hostCpuModels` — the distinct host
+CPU models — when a provider's merged shards disclosed more than one, naming the scheduling confound the
+published Run must own. Every field is optional because providers differ in what their probes expose,
+and `specMatched` records whether the effective side honored the target.
+
+## Consequences
+
+- A reader can always tell the sold size from the silicon it ran on; price/performance uses the
+  effective spec, while the host side explains a fast or noisy number.
+- Heterogeneous scheduling is disclosed, not hidden: `hostCpuModels` names the distinct CPUs when a
+  provider's shards didn't all land on the same hardware, so the comparison stays honest about that confound.
+- More fields to populate, and probes that can't see the host simply leave the host side absent (the
+  effective side stands alone) — accepted in exchange for never conflating the two axes.
+- The split is encoded in the schema and documented field-by-field, so a new probe/provider must
+  decide *which side* a value belongs to rather than dumping it into one ambiguous bucket.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -1,0 +1,17 @@
+# Architecture Decision Records
+
+Short records of the load-bearing decisions in this repo — the ones that shape what you can import,
+how a measurement becomes a published number, and why the gates are where they are. Each ADR is
+**Context / Decision / Consequences**: the problem, the choice, and what we accept by making it.
+
+These describe *why the code is the way it is*; the [methodology](../methodology.md) describes *how a
+measurement is produced* and [CONTRIBUTING](../../CONTRIBUTING.md) the local gate. When a decision
+here changes, supersede the ADR (leave it in place, note what replaced it) rather than deleting it.
+
+| ADR | Decision |
+|-----|----------|
+| [0001](./0001-arktype-parse-dont-validate-boundary.md) | arktype parse-don't-validate boundary |
+| [0002](./0002-enforced-dependency-dag.md) | Enforced dependency DAG with a uniform package shape |
+| [0003](./0003-generated-pts-catalog-and-drift-gate.md) | Generated PTS catalog behind a drift gate |
+| [0004](./0004-consumption-layer-aggregation.md) | Raw-first history, consumption-layer candidate→promote |
+| [0005](./0005-host-vs-effective-spec-split.md) | Host-vs-effective spec split |

--- a/docs/methodology.md
+++ b/docs/methodology.md
@@ -1,0 +1,92 @@
+# Methodology
+
+How a number in this repo's dataset is produced, and the caveats that keep it comparable across
+providers and over time.
+
+## North star
+
+Compare sandbox **providers** (`e2b` / `daytona` / `modal`), not bare-metal hardware. Every provider
+is asked to run the same workloads on the same pinned spec, and the results are normalized into one
+schema-validated dataset.
+
+## Target spec
+
+Every provider is created at one pinned [`TARGET_SPEC`](../packages/schema/src/providers.ts): **2 vCPU,
+8 GiB RAM, 20 GB disk**. It's sized to fit inside every provider's reproducible envelope (E2B caps
+sandbox RAM at 8 GiB), so anyone can rerun on the same shape. A provider that can't express a dimension
+runs with its actuals recorded and the mismatch disclosed (`specMatched`).
+
+## Dimensions and metrics
+
+Results land on a closed, ordered set of [`DIMENSIONS`](../packages/schema/src/metrics.ts): `lifecycle`,
+`control-plane`, `cpu`, `disk`, `memory`, `network`, `system`, `realworld`, `economics`. Each catalogued
+[`MetricDef`](../packages/schema/src/metrics.ts) declares its `dimension`, `unit`, `direction` (HIB =
+higher-is-better, LIB = lower-is-better), and whether it `headline`s its dimension. The leaderboard
+shows exactly one headline metric per dimension (enforced at catalog load).
+
+Metrics come from three sources:
+
+- **PTS-derived** — generated from vendored Phoronix Test Suite profiles (see the
+  [ADR-0003](./adr/0003-generated-pts-catalog-and-drift-gate.md)). The generator owns the
+  XML-derived fields and id-uniqueness; a hand-authored override map supplies editorial fields.
+- **Harness-measured** — lifecycle (spawn/exec/snapshot/teardown) and control-plane (info/list)
+  timings PTS can't see, measured directly around the provider SDK calls.
+- **Derived (economics)** — never measured; computed from pricing + measured runtime (below).
+
+## Economics ($/run)
+
+The `economics` dimension is the price/performance axis. It's `derived` — computed at normalization
+from each provider's published, vetted pricing
+([`hourlyCostAtTargetSpec`](../packages/schema/src/providers.ts)) plus the runtime already on the Run:
+
+- `usd_per_hour` (headline) — hourly cost at the target spec; the comparison denominator.
+- `usd_per_lifecycle` — hourly cost × the summed measured lifecycle timings; emitted only when a Run
+  carries lifecycle metrics.
+
+A provider with no vetted rate emits no economics (a null rate must never read as free). Economics
+enriches a provider that already produced ≥1 measured metric — it never promotes a `pending` provider.
+
+## Host vs. effective specs (the host-fingerprint caveat)
+
+`ObservedSpecs` splits what a Run saw into two sides:
+
+- **Effective** (`vcpus`/`memoryGb`/`diskGb`) — the sandbox's actual size (cgroup quota where enforced),
+  from the in-sandbox spec probe.
+- **Host** (`hostVcpus`/`hostMemoryGb`/`cpuModel`/…) — the underlying machine, parsed from the PTS
+  composite's `<System>` block.
+
+In a container `<System>` discloses the **host** (e.g. a 48-thread EPYC), not the 2-vCPU sandbox quota.
+The normalizer therefore maps `<System>` only to the host side and merges it **under** the spec probe,
+so a host disclosure can never masquerade as the sandbox's effective size. Forensic logs are captured as
+a `*--forensics.tar.gz` tarball (a tarball, not loose files, so nested `.xml` can't be misrouted).
+
+PTS `MONITOR`/sensor data is deliberately **not** collected: it's host-level (unattributable per
+provider) and its empty-`<Identifier>` `<Result>` nodes would abort extraction — the producer unsets
+`MONITOR`.
+
+## Transport model
+
+Providers differ in how their `@computesdk/*` adapter executes a command. Each declares a
+[`ProviderTransport`](../packages/schema/src/providers.ts) capability (`streaming`, `syncCapMs`,
+`detachedPoll`), and the harness selects a transport per step: a step that could outlast the provider's
+synchronous cap runs **detached + poll** where supported, everything else runs directly. This is why a
+multi-minute suite completes on a single-round-trip-capped provider (e.g. Daytona's server-side HTTP 408)
+without being Daytona-specific.
+
+## The dataset pipeline
+
+1. **Run** — `bench-suite <provider> <suite>` boots a sandbox, runs the suite's mise tasks, pulls the
+   raw tree (`data/raw/<runId>/<provider>/<suite>/`), and normalizes it into a Run document.
+2. **Matrix** — the `bench-matrix` workflow fans `plan-matrix` (provider × suite) out into one job per
+   cell, each uploading its shard Run as an artifact.
+3. **Aggregate → promote** — the `publish` job collects every shard, `aggregate`s them into one
+   candidate Run (measured metrics unioned, economics re-derived from the merged set), then `promote`s
+   it (gate: ≥1 validated provider) into the committed dataset at `data/dataset/` with a newest-first
+   index.
+4. **Leaderboard** — `leaderboard` renders the published Run into a ranked Markdown table per dimension.
+5. **Stability gate** — `stability <prev> <cur>` flags any provider metric that shifted beyond the noise
+   threshold across Runs, comparing only provenance-matched (same `appVersion` + `arguments`) metrics.
+
+Every Run is validated against the schema at the producer boundary, so no malformed Run reaches a
+consumer. The whole pipeline is reproducible: a committed `bun.lock`, vendored PTS profiles, and a
+byte-stable catalog held by the drift gate.

--- a/packages/schema/src/analysis.test.ts
+++ b/packages/schema/src/analysis.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "bun:test";
-import { aggregate } from "./index.ts";
+import { aggregate, percentileOf } from "./index.ts";
 
 describe("aggregate", () => {
 	it("summarises a multi-sample distribution (R-7 percentiles, n-1 stdev)", () => {
@@ -46,5 +46,35 @@ describe("aggregate", () => {
 		const a = aggregate([100_000_001, 100_000_002, 100_000_003]);
 		expect(a.mean).toBe(100_000_002);
 		expect(a.stdev).toBeCloseTo(1, 10);
+	});
+});
+
+describe("percentileOf", () => {
+	it("matches aggregate's percentiles on the same unsorted samples", () => {
+		// Same samples, same R-7 interpolation: the public helper and aggregate() share one code path,
+		// so a one-off percentile can never diverge from the catalogued distribution.
+		const samples = [16.3, 16.08, 16.19];
+		const a = aggregate(samples);
+		expect(percentileOf(samples, 0.5)).toBeCloseTo(a.p50, 10);
+		expect(percentileOf(samples, 0.95)).toBeCloseTo(a.p95, 10);
+	});
+
+	it("resolves p=0 to the min and p=1 to the max", () => {
+		expect(percentileOf([3, 1, 2], 0)).toBe(1);
+		expect(percentileOf([3, 1, 2], 1)).toBe(3);
+	});
+
+	it("rejects an empty sample set", () => {
+		expect(() => percentileOf([], 0.5)).toThrow();
+	});
+
+	it("rejects a non-finite sample", () => {
+		expect(() => percentileOf([1, Number.NaN], 0.5)).toThrow(/finite/);
+	});
+
+	it("rejects a p outside [0, 1]", () => {
+		expect(() => percentileOf([1, 2, 3], -0.1)).toThrow(/\[0, 1\]/);
+		expect(() => percentileOf([1, 2, 3], 1.5)).toThrow(/\[0, 1\]/);
+		expect(() => percentileOf([1, 2, 3], Number.NaN)).toThrow(/\[0, 1\]/);
 	});
 });

--- a/packages/schema/src/analysis.ts
+++ b/packages/schema/src/analysis.ts
@@ -39,6 +39,32 @@ function percentile(sorted: readonly number[], p: number): number {
 	return loValue + (h - lo) * (hiValue - loValue);
 }
 
+/**
+ * Percentile `p` (0–1) of an unsorted, non-empty Sample set — the public entry point to the same R-7
+ * interpolation {@link aggregate} computes its p50/p95 with. Sorts a copy and defers to the private
+ * {@link percentile} order-statistic helper, so a one-off percentile and the Aggregates distribution
+ * share one code path and can never diverge. Throws on an empty set, a non-finite Sample, or a `p`
+ * outside [0, 1] (same fail-fast posture as {@link aggregate}); `p` of 0 and 1 resolve to min and max.
+ */
+export function percentileOf(samples: readonly number[], p: number): number {
+	if (samples.length === 0) {
+		throw new Error("percentileOf() requires at least one sample");
+	}
+	// `!(0 <= p <= 1)` rather than `p < 0 || p > 1` so a NaN `p` is rejected too.
+	if (!(p >= 0 && p <= 1)) {
+		throw new Error(`percentileOf() requires p in [0, 1]; got ${p}`);
+	}
+	for (const sample of samples) {
+		if (!Number.isFinite(sample)) {
+			throw new Error(`percentileOf() requires finite samples; got ${sample}`);
+		}
+	}
+	return percentile(
+		[...samples].sort((a, b) => a - b),
+		p,
+	);
+}
+
 /** Aggregate Samples into the canonical distribution. Throws on an empty Sample set. */
 export function aggregate(samples: number[]): Aggregates {
 	if (samples.length === 0) {

--- a/packages/schema/src/catalog.test.ts
+++ b/packages/schema/src/catalog.test.ts
@@ -21,6 +21,26 @@ describe("metric catalog", () => {
 		}
 	});
 
+	it("uses snake_case slugs for every metric id", () => {
+		// The id is a stability-contract key and shows up in URLs/filenames/JSON, so it must be a plain
+		// lowercase snake_case slug — no uppercase, leading/trailing/doubled underscores, or punctuation.
+		// A generated PTS slug or a hand-authored harness/economics id that drifts off this shape fails
+		// here rather than shipping an un-greppable id.
+		const slug = /^[a-z0-9]+(_[a-z0-9]+)*$/;
+		for (const metric of METRIC_CATALOG) {
+			expect(metric.id).toMatch(slug);
+		}
+	});
+
+	it("never gives a derived metric a pts source", () => {
+		// `derived` (economics) and `pts` (parsed from a PTS <Result>) are mutually exclusive provenances:
+		// a derived metric is computed from pricing + measured runtime, never parsed. A derived entry that
+		// also carried `pts` would make ptsResultToMetric try to route a parsed result onto it.
+		for (const metric of METRIC_CATALOG) {
+			if (metric.derived) expect(metric.pts).toBeUndefined();
+		}
+	});
+
 	it("has at most one headline metric per dimension", () => {
 		for (const dimension of DIMENSIONS) {
 			const headlines = metricsForDimension(dimension).filter((metric) => metric.headline);


### PR DESCRIPTION
**Sandbox Benchmark Matrix & Leaderboard — one exploration branch split into a parallel-mergeable dependency DAG.**
Every PR is green on its own (typecheck + tests) and merges bottom-up. Four independent units:

- **Standalone (off `main`):** #76 ENG-59 (lifecycle) · #77 ENG-69 (docs/ADRs)
- **Shared CLI/harness + dimensions foundation:** #67 ENG-62 → #68 ENG-60
- **CI / matrix branch:** #67 → #68 → #69 ENG-66 → #70 ci-hardening
- **Dataset / consumer branch:** #67 → #68 → #71 ENG-61 → #72 ENG-70 → #73 ENG-67 → { #74 ENG-68 ‖ #75 ENG-71 }

↑ **This PR is #77 — ENG-69**, based on `main`.

---

Document how a Run is produced and how to extend the matrix so the comparison is reproducible and extensible by outsiders. Adds docs/methodology.md, CONTRIBUTING.md (local gate commands + add-a-provider/suite/metric walkthroughs), and a 5-record ADR log with index. Schema-side (additive on main): catalog asserts snake_case ids and that no derived metric carries a pts source; analysis exports percentileOf() sharing the R-7 helper the aggregator uses. Independent stack — off main.

Also fixes two authoring defects: strips stray closing tags accidentally committed into all five ADRs plus the ADR index, and repoints a dangling methodology link to ADR-0003.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds methodology and ADR docs, plus a contributor guide for adding providers/suites/metrics, and tightens the schema with a public `percentileOf()` helper and new catalog invariants. Addresses ENG-69 by documenting how a Run is produced, how to extend the matrix safely, and updating ADR-0005 to disclose `hostCpuModels`.

- **New Features**
  - Docs: `docs/methodology.md`, ADR log (0001–0005 + index), and `CONTRIBUTING.md` with local gate and add-a-provider/suite/metric guides; README links added.
  - Schema (`@sandbox-benchmarks/schema`): exports `percentileOf()` using the same R-7 interpolation as `aggregate`; validates `p` in [0,1] and finite samples; tests cover parity and edge cases.
  - Catalog: enforces snake_case metric ids and forbids `pts` on `derived` metrics; tests added.

- **Bug Fixes**
  - Removed stray closing tags from all ADRs and the ADR index.
  - Fixed a broken methodology link to ADR-0003.

<sup>Written for commit 47043650ccd7327f60c22017c3883539fdfd41a9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/starslingdev/sandbox-benchmarks/pull/77?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

---

**Verification:** green on its own — affected-package typecheck clean and tests pass with 0 failures (verified across the full stack build).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a percentile calculation helper (`percentileOf`) with R-7 behavior and strict input validation.

* **Documentation**
  * Added a short documentation index in the README.
  * Added contribution guidance for the Bun workspace monorepo.
  * Added methodology documentation for dataset generation and reproducibility.
  * Added/expanded ADRs covering boundary parsing, enforced dependency DAG, PTS catalog drift gating, aggregation/promotion pipeline, and host vs effective spec handling.

* **Tests**
  * Extended tests for percentile edge cases and metric catalog invariants (ID format and derived-metric provenance).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->