### PR TITLE
feat(harness): harden detached+poll execute transport (ENG-62)

### DIFF
--- a/packages/harness/src/index.test.ts
+++ b/packages/harness/src/index.test.ts
@@ -17,7 +17,7 @@ import {
 	unmetRequirements,
 	withSandbox,
 } from "./index.ts";
-import type { SandboxHandle } from "./lib/execute.ts";
+import type { CommandResult, SandboxHandle } from "./lib/execute.ts";
 import type { LifecycleCompute } from "./lib/lifecycle.ts";
 
 // A transport capability for the test fixtures — capped-with-detach, matching a single-round-trip
@@ -287,8 +287,10 @@ function collectPayload(files: Record<string, string>): string {
 }
 
 // A fake sandbox that dispatches on command content: the disk probe, the benchmark command (token
-// `benchmark-cmd`), and the base64 collect stream. No filesystem, so runDetached uses the foreground
-// path. `destroyed` flips when teardown runs.
+// `benchmark-cmd`), and the base64 collect stream. No filesystem, so a detached step uses the
+// cat-poll fallback — the detached launch wraps the real script (so the step's result is computed
+// from the launch command) and is stashed under the step's tag for the done-file/log `cat` polls to
+// read back, exercising the no-filesystem transport end-to-end. `destroyed` flips when teardown runs.
 function makeSandbox(opts: {
 	freeKb?: string;
 	benchmarkFails?: boolean;
@@ -296,18 +298,45 @@ function makeSandbox(opts: {
 	collectFiles?: Record<string, string>;
 	destroyed: { hit: boolean };
 }): SandboxHandle {
+	// Results of detached steps, keyed by their /tmp/<tag> so the cat-polls can read them back.
+	const detached = new Map<string, { exit: number; out: string }>();
+	const resultFor = (command: string): CommandResult => {
+		if (command.includes("df -Pk")) return { exitCode: 0, stdout: opts.freeKb ?? "999999999" };
+		if (command.includes("base64")) {
+			if (opts.collectFails) return { exitCode: 1, stderr: "collect boom" };
+			const files = opts.collectFiles ?? { "pts_node-web-tooling.xml": "<xml/>" };
+			return { exitCode: 0, stdout: collectPayload(files) };
+		}
+		if (command.includes("benchmark-cmd")) {
+			return opts.benchmarkFails ? { exitCode: 1, stderr: "bench boom" } : { exitCode: 0 };
+		}
+		return { exitCode: 0, stdout: "" };
+	};
+	const tagOf = (command: string, ext: string): string | undefined =>
+		command.match(new RegExp(`/tmp/(bench-[0-9a-f-]+)\\.${ext}`))?.[1];
 	return {
 		async runCommand(command) {
-			if (command.includes("df -Pk")) return { exitCode: 0, stdout: opts.freeKb ?? "999999999" };
-			if (command.includes("base64")) {
-				if (opts.collectFails) return { exitCode: 1, stderr: "collect boom" };
-				const files = opts.collectFiles ?? { "pts_node-web-tooling.xml": "<xml/>" };
-				return { exitCode: 0, stdout: collectPayload(files) };
+			// Detached launch (double-fork, so it carries nohup): compute the wrapped step's result and
+			// stash it under its tag for the cat-polls. The launch itself just acknowledges.
+			if (command.includes("nohup")) {
+				const tag = tagOf(command, "log");
+				if (tag) {
+					const r = resultFor(command);
+					detached.set(tag, { exit: r.exitCode, out: r.stdout ?? r.stderr ?? "" });
+				}
+				return { exitCode: 0, stdout: "launched" };
 			}
-			if (command.includes("benchmark-cmd")) {
-				return opts.benchmarkFails ? { exitCode: 1, stderr: "bench boom" } : { exitCode: 0 };
+			// Cat-poll of the done-file: the stashed exit code (present from launch), else still-running.
+			const doneTag = tagOf(command, "done");
+			if (doneTag) {
+				const d = detached.get(doneTag);
+				return { exitCode: 0, stdout: d ? String(d.exit) : "__RUNNING__" };
 			}
-			return { exitCode: 0, stdout: "" };
+			// Cat-read of the log: the stashed output (stderr merged into stdout, mirroring live 2>&1).
+			const logTag = tagOf(command, "log");
+			if (logTag) return { exitCode: 0, stdout: detached.get(logTag)?.out ?? "" };
+			// Synchronous foreground exec (short steps: the disk probe, observed-specs).
+			return resultFor(command);
 		},
 		async destroy() {
 			opts.destroyed.hit = true;
@@ -333,7 +362,7 @@ const ctx = (s: Suite, resultsDir: string) => ({
 	providerName: "daytona",
 	resultsDir,
 	// Daytona-shaped: synchronous execs capped, detached+poll available. The fake sandbox has no
-	// filesystem, so a detached selection falls back to the foreground path — behavior is unchanged.
+	// filesystem, so a detached selection drives the cat-poll fallback (done-file read over exec).
 	transport: fixtureTransport,
 });
 

--- a/packages/harness/src/lib/collect.test.ts
+++ b/packages/harness/src/lib/collect.test.ts
@@ -3,6 +3,7 @@ import { execFileSync } from "node:child_process";
 import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import type { ProviderTransport } from "@sandbox-benchmarks/schema";
 import { harnessSkipMarkerJson } from "@sandbox-benchmarks/schema";
 import { collectResults, writeSkipMarker } from "./collect.ts";
 import type { SandboxHandle } from "./execute.ts";
@@ -10,6 +11,11 @@ import { StepRunner } from "./execute.ts";
 
 const work = mkdtempSync(join(tmpdir(), "harness-collect-"));
 afterAll(() => rmSync(work, { recursive: true, force: true }));
+
+// Marker extraction is transport-agnostic, so run collect synchronously (uncapped) — the dumb payload
+// fakes return their stdout for every command, which the detached cat-poll would misread as a done-file.
+// The detached collect path is covered by execute.test.ts and end-to-end in index.test.ts.
+const UNCAPPED: ProviderTransport = { streaming: false, syncCapMs: null, detachedPoll: false };
 
 // Build the exact stdout the in-sandbox collect command emits: markers around a base64'd tar of a
 // benchmark-results/ directory holding the given files (name → contents).
@@ -39,7 +45,7 @@ const sandbox = payloadSandbox({ "pts_node-web-tooling.xml": "<xml/>" });
 describe("collectResults", () => {
 	it("extracts the base64 tar stream into the results directory", async () => {
 		const resultsDir = join(work, "daytona");
-		await collectResults(new StepRunner(sandbox), resultsDir);
+		await collectResults(new StepRunner(sandbox, UNCAPPED), resultsDir);
 		expect(existsSync(join(resultsDir, "pts_node-web-tooling.xml"))).toBe(true);
 		expect(readFileSync(join(resultsDir, "pts_node-web-tooling.xml"), "utf8")).toBe("<xml/>");
 	});
@@ -50,7 +56,7 @@ describe("collectResults", () => {
 			"pts_node-web-tooling--skipped.json": '{"skipped":true,"benchmark":"pts_node-web-tooling"}',
 			"manifest.ndjson": "{}\n",
 		});
-		await collectResults(new StepRunner(skipped), resultsDir);
+		await collectResults(new StepRunner(skipped, UNCAPPED), resultsDir);
 		expect(existsSync(join(resultsDir, "pts_node-web-tooling--skipped.json"))).toBe(true);
 	});
 
@@ -58,9 +64,9 @@ describe("collectResults", () => {
 		// A suite that produced only provenance/timing files and neither a result nor a marker must
 		// fail collection, not upload an empty-of-signal directory as a green run.
 		const empty = payloadSandbox({ "manifest.ndjson": "{}\n", "cpu-info.json": "{}" });
-		await expect(collectResults(new StepRunner(empty), join(work, "no-signal"))).rejects.toThrow(
-			/no PTS result or skip marker/,
-		);
+		await expect(
+			collectResults(new StepRunner(empty, UNCAPPED), join(work, "no-signal")),
+		).rejects.toThrow(/no PTS result or skip marker/);
 	});
 
 	it("throws when the payload markers are missing", async () => {
@@ -68,9 +74,9 @@ describe("collectResults", () => {
 			runCommand: async () => ({ exitCode: 0, stdout: "no markers here" }),
 			destroy: async () => undefined,
 		};
-		await expect(collectResults(new StepRunner(noMarkers), join(work, "x"))).rejects.toThrow(
-			/markers/,
-		);
+		await expect(
+			collectResults(new StepRunner(noMarkers, UNCAPPED), join(work, "x")),
+		).rejects.toThrow(/markers/);
 	});
 });
 

--- a/packages/harness/src/lib/execute.test.ts
+++ b/packages/harness/src/lib/execute.test.ts
@@ -111,7 +111,9 @@ describe("StepRunner.runDetached", () => {
 		expect(result.stdout).toBe("ran on the host");
 		// First command is the detached start, flagged background; never a synchronous foreground exec.
 		expect(commands[0]?.background).toBe(true);
-		expect(commands[0]?.command).toContain("nohup setsid");
+		// Double-fork daemonization: an outer nohup launches an inner nohup, not a single setsid.
+		expect(commands[0]?.command).toContain("nohup");
+		expect(commands[0]?.command).not.toContain("setsid");
 		expect(runner.stepLog).toHaveLength(1);
 		expect(runner.stepLog[0]).toMatchObject({ label: "bench", exitCode: 0 });
 	});
@@ -138,21 +140,74 @@ describe("StepRunner.runDetached", () => {
 		expect(commands.some((c) => c.includes("pkill"))).toBe(true);
 	});
 
-	it("falls back to the foreground transport when the sandbox has no filesystem", async () => {
-		const commands: string[] = [];
+	// A sandbox with NO filesystem API: the detached transport must still detach (double-fork) and
+	// observe completion by `cat`-ing the done-file over exec. runCommand answers each command shape —
+	// the launch (contains nohup), the done-file probe (`cat …done`), and the log read (`cat …log`).
+	function catPollSandbox(opts: { readyAfter?: number; exitCode?: string; log?: string }): {
+		sandbox: SandboxHandle;
+		commands: Array<{ command: string; background?: boolean }>;
+	} {
+		const commands: Array<{ command: string; background?: boolean }> = [];
+		const readyAfter = opts.readyAfter ?? 0;
+		let probes = 0;
 		const sandbox: SandboxHandle = {
-			runCommand: async (command) => {
-				commands.push(command);
-				return { exitCode: 0, stdout: "fg" };
+			runCommand: async (command, options) => {
+				commands.push({ command, background: options?.background });
+				if (command.includes("nohup")) return { exitCode: 0, stdout: "launched" };
+				if (command.includes(".done")) {
+					const ready = probes++ >= readyAfter;
+					return { exitCode: 0, stdout: ready ? (opts.exitCode ?? "0") : "__RUNNING__" };
+				}
+				return { exitCode: 0, stdout: opts.log ?? "cat output" }; // the `.log` read
 			},
 			destroy: async () => undefined,
 		};
-		const runner = new StepRunner(sandbox);
-		const result = await runner.runDetached("bench", "echo hi", 5_000);
-		expect(result.stdout).toBe("fg");
-		// Foreground path: a single synchronous bash -c exec, no background flag, no detach wrapper.
-		expect(commands[0]).toContain("bash -c");
-		expect(commands[0]).not.toContain("nohup setsid");
+		return { sandbox, commands };
+	}
+
+	it("polls the done-file over exec when the sandbox has no filesystem", async () => {
+		const { sandbox, commands } = catPollSandbox({
+			readyAfter: 2,
+			log: "ran via cat",
+			exitCode: "0",
+		});
+		// Inject a no-op sleep so the two not-ready polls don't actually wait.
+		const runner = new StepRunner(sandbox, CAPPED, async () => undefined);
+
+		const result = await runner.runDetached("bench", "mise run benchmark", 60_000);
+
+		expect(result.exitCode).toBe(0);
+		expect(result.stdout).toBe("ran via cat");
+		// Still a real detach: the launch is backgrounded and double-fork daemonized, not a foreground run.
+		expect(commands[0]?.background).toBe(true);
+		expect(commands[0]?.command).toContain("nohup");
+		// Completion is observed by cat-ing the done-file (the no-filesystem fallback), then the log.
+		expect(commands.some((c) => c.command.includes("cat") && c.command.includes(".done"))).toBe(
+			true,
+		);
+		expect(commands.some((c) => c.command.includes("cat") && c.command.includes(".log"))).toBe(
+			true,
+		);
+	});
+
+	it("propagates a non-zero exit from the cat-polled done-file", async () => {
+		const { sandbox } = catPollSandbox({ exitCode: "42" });
+		const runner = new StepRunner(sandbox, CAPPED, async () => undefined);
+		await expect(runner.runDetached("bench", "false", 60_000)).rejects.toThrow(/exit code 42/);
+	});
+
+	it("backs off the poll interval geometrically up to the cap", async () => {
+		// Done only after 7 not-ready polls → 7 inter-poll sleeps, exercising the geometric ramp + cap.
+		const { sandbox } = detachedSandbox({ readyAfter: 7, exitCode: "0", log: "done" });
+		const slept: number[] = [];
+		const runner = new StepRunner(sandbox, CAPPED, async (ms) => {
+			slept.push(ms);
+		});
+
+		await runner.runDetached("bench", "mise install", 60 * MIN);
+
+		// 1.5s start, ×1.5 each poll, capped at 10s: 1500, 2250, 3375, 5062.5, 7593.75, 10000, 10000.
+		expect(slept).toEqual([1_500, 2_250, 3_375, 5_062.5, 7_593.75, 10_000, 10_000]);
 	});
 });
 
@@ -182,9 +237,9 @@ describe("StepRunner.step (capability-driven transport)", () => {
 		const { sandbox, commands } = fsSandbox();
 		const runner = new StepRunner(sandbox, CAPPED);
 		await runner.step("long", "mise install", 20 * MIN);
-		// Detached start: backgrounded, wrapped in nohup setsid.
+		// Detached start: backgrounded, double-fork daemonized (nohup).
 		expect(commands[0]?.background).toBe(true);
-		expect(commands[0]?.command).toContain("nohup setsid");
+		expect(commands[0]?.command).toContain("nohup");
 	});
 
 	it("runs a short step synchronously on a capped provider", async () => {
@@ -195,7 +250,7 @@ describe("StepRunner.step (capability-driven transport)", () => {
 		// Direct exec: a single bash -c, no background flag, no detach wrapper.
 		expect(commands[0]?.background).toBeUndefined();
 		expect(commands[0]?.command).toContain("bash -c");
-		expect(commands[0]?.command).not.toContain("nohup setsid");
+		expect(commands[0]?.command).not.toContain("nohup");
 	});
 
 	it("stays synchronous past the cap on a provider that can't detach", async () => {
@@ -207,7 +262,7 @@ describe("StepRunner.step (capability-driven transport)", () => {
 		await runner.step("long", "mise install", 5 * MIN);
 		expect(commands[0]?.background).toBeUndefined();
 		expect(commands[0]?.command).toContain("bash -c");
-		expect(commands[0]?.command).not.toContain("nohup setsid");
+		expect(commands[0]?.command).not.toContain("nohup");
 	});
 
 	it("runs a long step synchronously on an uncapped provider", async () => {
@@ -216,7 +271,7 @@ describe("StepRunner.step (capability-driven transport)", () => {
 		await runner.step("long", "mise run benchmark", 110 * MIN);
 		// No cap → direct exec even for a multi-minute step; the filesystem is never polled.
 		expect(commands[0]?.background).toBeUndefined();
-		expect(commands[0]?.command).not.toContain("nohup setsid");
+		expect(commands[0]?.command).not.toContain("nohup");
 	});
 
 	it("defaults to a capped profile when constructed without a transport", async () => {

--- a/packages/harness/src/lib/execute.ts
+++ b/packages/harness/src/lib/execute.ts
@@ -9,10 +9,11 @@
  *     multi-minute commands while the process keeps running server-side, and computesdk's Daytona
  *     adapter doesn't stream (it ignores onStdout/onStderr).
  *   - {@link StepRunner.runDetached}: starts the step in the background (computesdk's `background:true`,
- *     fully detached with nohup+setsid) writing its output to a log file and its exit code to a
- *     done-file, then polls the sandbox filesystem until the done-file appears. This survives the
- *     408-prone exec round-trip, so multi-minute benchmarks complete. Falls back to `run` when the
- *     sandbox exposes no filesystem (the unit-test fakes) — correctness is unchanged, only durability.
+ *     double-fork daemonized so it detaches even on e2b's envd) writing its output to a log file and
+ *     its exit code to a done-file, then polls until the done-file appears — via the sandbox filesystem
+ *     when one is exposed, else by `cat`-ing the done-file over `exec`. The poll interval backs off
+ *     adaptively so a short step isn't over-charged for polling. This survives the 408-prone exec
+ *     round-trip, so multi-minute benchmarks complete on every provider.
  *
  * {@link StepRunner.step} reads the provider's declared {@link ProviderTransport} (via
  * {@link selectTransport}) and dispatches: a step that could outlast the provider's synchronous cap
@@ -26,8 +27,17 @@ import type { ProviderTransport } from "@sandbox-benchmarks/schema";
 
 export const MIN = 60_000;
 
-/** Poll cadence for {@link StepRunner.runDetached} while it waits on a detached step's done-file. */
-const POLL_MS = 10_000;
+/**
+ * Adaptive poll backoff for {@link StepRunner.runDetached} while it waits on a detached step's
+ * done-file. Setup steps no-op in ~1s on a pre-baked image, so a fixed quantum charged most of a
+ * short run to pure polling overhead (~44% of one measured suite). Start tight, grow geometrically,
+ * and cap so a multi-minute benchmark still settles at a cheap steady cadence.
+ */
+const POLL_START_MS = 1_500;
+const POLL_BACKOFF = 1.5;
+const POLL_CAP_MS = 10_000;
+/** Done-file sentinel for the no-filesystem cat-poll fallback: printed while the file isn't there yet. */
+const RUNNING_SENTINEL = "__RUNNING__";
 const delay = (ms: number): Promise<void> => new Promise((resolve) => setTimeout(resolve, ms));
 
 export type Phase = "create" | "setup" | "benchmark" | "collect";
@@ -128,6 +138,12 @@ export function shellQuote(script: string): string {
 	return `'${script.replace(/'/g, `'\\''`)}'`;
 }
 
+/** Parse a done-file's exit-code contents, defaulting a malformed value to a failure (1). */
+function parseExitCode(raw: string): number {
+	const code = Number.parseInt(raw, 10);
+	return Number.isFinite(code) ? code : 1;
+}
+
 /**
  * Re-establish env + PATH on every step (each runCommand is a fresh shell). `$SUDO` covers both root
  * images (no prefix) and non-root images with sudo. The toolchain image (packages/templates/images)
@@ -179,6 +195,9 @@ export class StepRunner {
 		private readonly sandbox: SandboxHandle,
 		/** The provider's exec transport capability — {@link step} selects sync vs detached from it. */
 		private readonly transport: ProviderTransport = DEFAULT_TRANSPORT,
+		/** The inter-poll sleep used by {@link runDetached}; injectable so tests can assert the backoff
+		 *  schedule without real waiting. */
+		private readonly sleep: (ms: number) => Promise<void> = delay,
 	) {}
 
 	/**
@@ -230,12 +249,18 @@ export class StepRunner {
 
 	/**
 	 * Run a long step on the durable detached transport: start it in the background (output → log
-	 * file, exit code → done-file), then poll the sandbox filesystem until the done-file appears and
-	 * read both back. Survives Daytona's 408 on multi-minute synchronous execs. On timeout the
-	 * detached job is best-effort killed; the job teardown's `destroy()` is the backstop either way.
+	 * file, exit code → done-file), then poll until the done-file appears and read both back. Survives
+	 * Daytona's 408 on multi-minute synchronous execs. On timeout the detached job is best-effort
+	 * killed; the job teardown's `destroy()` is the backstop either way.
 	 *
-	 * Requires a sandbox filesystem; without one (the unit-test fakes) it transparently delegates to
-	 * {@link run}, so behavior is identical save for durability.
+	 * The background launch is double-fork daemonized: a single nohup/setsid still blocks e2b's envd,
+	 * which holds the exec open for as long as its direct child lives (probed live), so the direct
+	 * child backgrounds the real job via a second nohup and exits at once — the step truly detaches
+	 * across providers. Completion is observed through the sandbox filesystem when one is exposed;
+	 * otherwise (providers whose adapter has no filesystem API, and the unit-test fakes) it falls back
+	 * to reading the done-file with a `cat` exec. The poll interval backs off adaptively
+	 * ({@link POLL_START_MS} → ×{@link POLL_BACKOFF}, capped at {@link POLL_CAP_MS}) so a step that
+	 * finishes quickly isn't over-charged for polling.
 	 */
 	async runDetached(
 		label: string,
@@ -243,10 +268,8 @@ export class StepRunner {
 		timeoutMs: number,
 		opts: StepOptions = {},
 	): Promise<CommandResult> {
-		const fs = this.sandbox.filesystem;
-		if (!fs) return this.run(label, script, timeoutMs, opts);
-
 		console.log(`\n=== [${label}] (detached) ===`);
+		const fs = this.sandbox.filesystem;
 		const started = performance.now();
 		const stopHeartbeat = startHeartbeat(label, started, timeoutMs);
 		const tag = `bench-${randomUUID()}`;
@@ -254,20 +277,35 @@ export class StepRunner {
 		const donePath = `/tmp/${tag}.done`;
 		try {
 			// Start fully detached so the job outlives the (short-lived, 408-prone) exec round-trip.
-			// The `&&/||` capture keeps the script's exit code without letting the preamble's `set -e`
-			// abort before the done-file is written — success writes 0, failure writes the real code.
+			// Run preamble+script in a nested `bash -c` so `set -eo pipefail` governs the inner shell:
+			// as part of the outer `&&/||` list a `{ … }` group has `set -e` suspended, so a mid-script
+			// failure followed by a passing command would exit 0 and be recorded as success. The inner
+			// shell aborts on first failure and its real exit code flows through the `&&/||` capture —
+			// success writes 0, failure writes the real code.
 			const wrapped =
-				`${PREAMBLE}; { ${script}; } > ${logPath} 2>&1 ` +
+				`bash -c ${shellQuote(`${PREAMBLE}; ${script}`)} > ${logPath} 2>&1 ` +
 				`&& echo 0 > ${donePath} || echo $? > ${donePath}`;
-			await this.sandbox.runCommand(
-				`nohup setsid bash -c ${shellQuote(wrapped)} >/dev/null 2>&1 &`,
-				{
-					background: true,
-				},
-			);
+			// Double-fork daemonization: a single nohup/setsid still blocks e2b's envd, which holds the
+			// exec open for as long as its DIRECT child lives (probed live: even `nohup ... &` pins the
+			// exec for the child's whole life; setsid doesn't help). So the direct child backgrounds the
+			// real job via a second nohup and exits at once — Daytona/Blaxel detach fine either way.
+			const daemonized = `nohup bash -c ${shellQuote(wrapped)} </dev/null >/dev/null 2>&1 &`;
+			const launch = `nohup bash -c ${shellQuote(daemonized)} </dev/null >/dev/null 2>&1 & echo launched`;
+			await this.sandbox.runCommand(`bash -c ${shellQuote(launch)}`, { background: true });
 
+			// Poll for the done-file, backing off adaptively so a quick step isn't over-charged for polls.
 			const deadline = started + timeoutMs;
-			while (!(await fs.exists(donePath))) {
+			let pollDelayMs = POLL_START_MS;
+			for (;;) {
+				const exitCode = fs
+					? await this.pollDoneViaFs(fs, donePath)
+					: await this.pollDoneViaCat(donePath);
+				if (exitCode !== undefined) {
+					const stdout = fs
+						? await withTimeout(fs.readFile(logPath), POLL_CAP_MS, "log fs read").catch(() => "")
+						: await this.catFile(logPath);
+					return this.finishStep(label, started, { exitCode, stdout }, opts);
+				}
 				if (performance.now() > deadline) {
 					// Best-effort stop the detached job; don't let a failing kill mask the timeout.
 					await this.sandbox
@@ -275,16 +313,63 @@ export class StepRunner {
 						.catch(() => undefined);
 					throw new Error(`Step "${label}" timed out after ${Math.round(timeoutMs / 1000)}s`);
 				}
-				await delay(POLL_MS);
+				await this.sleep(pollDelayMs);
+				pollDelayMs = Math.min(pollDelayMs * POLL_BACKOFF, POLL_CAP_MS);
 			}
-
-			const exitCode = Number.parseInt((await fs.readFile(donePath)).trim(), 10);
-			const stdout = await fs.readFile(logPath).catch(() => "");
-			const result: CommandResult = { exitCode: Number.isFinite(exitCode) ? exitCode : 1, stdout };
-			return this.finishStep(label, started, result, opts);
 		} finally {
 			stopHeartbeat();
 		}
+	}
+
+	/** Check the filesystem-backed done-file: its trimmed contents are the exit code, or `undefined`
+	 *  while the detached step is still running. */
+	private async pollDoneViaFs(
+		fs: SandboxFilesystem,
+		donePath: string,
+	): Promise<number | undefined> {
+		try {
+			// Bound both fs calls so a hung filesystem API (some adapters go over the network) can't
+			// stall the poll loop indefinitely — the outer deadline only advances between iterations.
+			if (!(await withTimeout(fs.exists(donePath), POLL_CAP_MS, "done-file fs exists"))) {
+				return undefined;
+			}
+			// The background script writes the done-file non-atomically (truncate, then echo the code),
+			// so an empty read means "created but not yet written" — still running, not exit 0.
+			const raw = (
+				await withTimeout(fs.readFile(donePath), POLL_CAP_MS, "done-file fs read")
+			).trim();
+			return raw === "" ? undefined : parseExitCode(raw);
+		} catch {
+			// A transient fs blip counts as not-yet-done; the caller's deadline bounds total retry time.
+			return undefined;
+		}
+	}
+
+	/** Poll fallback for providers whose adapter exposes no filesystem API: read the done-file with a
+	 *  `cat` exec, treating the {@link RUNNING_SENTINEL} (or empty output) as not-done-yet. */
+	private async pollDoneViaCat(donePath: string): Promise<number | undefined> {
+		// Bound the exec so a hung `cat` can't outlast the step budget, and treat any transient
+		// exec error as not-yet-done (the caller's deadline bounds total retry time).
+		const probe = await withTimeout(
+			this.sandbox.runCommand(
+				`bash -c ${shellQuote(`cat ${donePath} 2>/dev/null || echo ${RUNNING_SENTINEL}`)}`,
+			),
+			POLL_CAP_MS,
+			"done-file cat poll",
+		).catch(() => undefined);
+		const out = (probe?.stdout ?? "").trim();
+		if (out === "" || out === RUNNING_SENTINEL) return undefined;
+		return parseExitCode(out);
+	}
+
+	/** Read the detached step's log over `exec` — the output transport for the no-filesystem path. */
+	private async catFile(logPath: string): Promise<string> {
+		const res = await withTimeout(
+			this.sandbox.runCommand(`bash -c ${shellQuote(`cat ${logPath} 2>/dev/null || true`)}`),
+			POLL_CAP_MS,
+			"log cat read",
+		).catch(() => undefined);
+		return res?.stdout ?? "";
 	}
 
 	/** Shared post-step bookkeeping: record the step, echo output (unless silent), enforce exit code. */


### PR DESCRIPTION
**ENG-62 transport hardening — split into 2 focused PRs** (merge bottom-up, each independently green):
1. **#78 — harness execute transport** (this PR)
2. #67 — provider-join assert + agent CLI discovery

↑ **This PR is 1/2**, based on `main`.

---
The harness **execute engine**: detached-poll transport with race & robustness fixes to `StepRunner` (which gains a transport arg). Pure-additive — imports only `node:crypto` and the existing `ProviderTransport` schema type, so it compiles on `main` alone.

**Validated locally:** `bun run typecheck` across all 8 workspaces (0 errors); `@sandbox-benchmarks/harness` 60 tests pass; full-workspace typecheck confirms no consumer breaks on the changed `StepRunner` signature.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardened the harness execute transport so detached steps fully detach across providers and long runs finish reliably. Implements ENG-62 with double-fork detaching, fs/exec-based polling with timeouts, and adaptive backoff to cut overhead.

- **New Features**
  - Double-fork daemonization in `StepRunner.runDetached` (nested `nohup`) to fully detach across providers.
  - Polls the done-file via filesystem when available, else by `cat` over `exec`; reads logs the same way.
  - Adaptive poll backoff (start 1.5s, ×1.5, cap 10s); `StepRunner` accepts injectable sleep for tests.

- **Bug Fixes**
  - Runs preamble+script in a nested `bash -c` so `set -eo pipefail` applies and real exit codes are captured.
  - Bounds per-poll filesystem reads and `cat` execs with timeouts; best-effort kill on step timeout to prevent hangs.
  - Robust exit parsing: empty/missing done-file = running; malformed exit code = failure.

<sup>Written for commit 2623f40be277b8a8b0d9b970eea1f0856872d06e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/starslingdev/sandbox-benchmarks/pull/78?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved detached task handling, including better progress polling and completion detection.
  * Added support for environments without filesystem access during detached execution.

* **Bug Fixes**
  * More reliably captures exit codes and output from completed detached steps.
  * Improves handling of malformed completion data and non-zero completion results.
  * Refines polling behavior to back off gradually and stop safely on timeout.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

