### PR TITLE
feat(schema): pure cost models for a benchmark run (ENG-61)

### DIFF
--- a/packages/schema/src/economics.test.ts
+++ b/packages/schema/src/economics.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from "bun:test";
+import {
+	amortizationBreakEvenRunsPerMonth,
+	amortizedCostPerRun,
+	burstCostPerRun,
+} from "./index.ts";
+
+describe("cost-model helpers (burst vs fixed-infra amortization)", () => {
+	it("burstCostPerRun scales linearly with runtime", () => {
+		// $3.60/hr → $0.001/s; a 10s run costs $0.01, double the runtime → double the cost.
+		expect(burstCostPerRun(3.6, 10_000)).toBeCloseTo(0.01, 12);
+		expect(burstCostPerRun(3.6, 20_000)).toBeCloseTo(0.02, 12);
+		expect(burstCostPerRun(3.6, 0)).toBe(0);
+	});
+
+	it("amortizedCostPerRun spreads a fixed monthly bill across runs (falls as utilization rises)", () => {
+		expect(amortizedCostPerRun(300, 1000)).toBeCloseTo(0.3, 12);
+		expect(amortizedCostPerRun(300, 3000)).toBeCloseTo(0.1, 12);
+		// A reserved box that serves no runs amortizes its bill over nothing — never reads as free.
+		expect(amortizedCostPerRun(300, 0)).toBe(Number.POSITIVE_INFINITY);
+		expect(amortizedCostPerRun(300, -1)).toBe(Number.POSITIVE_INFINITY);
+	});
+
+	it("amortizationBreakEvenRunsPerMonth is where amortized cost equals burst cost", () => {
+		const monthlyUsd = 300;
+		const hourlyUsd = 3.6;
+		const runtimeMs = 60_000; // a 1-minute run → $0.06 burst
+		const breakEven = amortizationBreakEvenRunsPerMonth(monthlyUsd, hourlyUsd, runtimeMs);
+		// At break-even, the two models cost the same per run.
+		expect(amortizedCostPerRun(monthlyUsd, breakEven)).toBeCloseTo(
+			burstCostPerRun(hourlyUsd, runtimeMs),
+			12,
+		);
+		// A zero-cost run has nothing to amortize against, so break-even is unreachable.
+		expect(amortizationBreakEvenRunsPerMonth(monthlyUsd, hourlyUsd, 0)).toBe(
+			Number.POSITIVE_INFINITY,
+		);
+	});
+});

--- a/packages/schema/src/economics.ts
+++ b/packages/schema/src/economics.ts
@@ -1,0 +1,45 @@
+// Cost models for a single benchmark run: the pure pricing math the economics Dimension is built on.
+// Two models — burst (pay-per-use) and fixed-infra amortized — plus the break-even utilization between
+// them. Pure functions with no schema dependencies, so they are unit-testable in isolation. The derived
+// economics MetricDefs and the deriveEconomics() derivation that consume burstCostPerRun land in the
+// next PR up the stack.
+
+const MS_PER_HOUR = 3_600_000;
+
+/**
+ * Burst (pay-per-use) cost of one run: you pay only for the wall-clock the sandbox is alive, so the
+ * cost scales linearly with runtime. The model behind every runtime economics Metric
+ * (`usd_per_lifecycle`, `usd_per_compute_run`) — the serverless/per-second default.
+ */
+export function burstCostPerRun(hourlyUsd: number, runtimeMs: number): number {
+	return hourlyUsd * (runtimeMs / MS_PER_HOUR);
+}
+
+/**
+ * Fixed-infra amortized cost of one run: a reserved box bills `monthlyUsd` whether busy or idle, so
+ * the cost *attributable* to a single run is that fixed bill spread across the runs it serves that
+ * month. Per-run cost therefore FALLS as utilization rises — the mirror image of
+ * {@link burstCostPerRun}. `runsPerMonth <= 0` returns `Infinity` (a box that serves no runs
+ * amortizes its bill over nothing). Ported in spirit from THEIRS `compute_costs` `ec2_full`
+ * (variable per-run + a `monthly_fixed` overhead), kept as a documented helper rather than a
+ * catalogued Metric since OURS prices no reserved infra yet.
+ */
+export function amortizedCostPerRun(monthlyUsd: number, runsPerMonth: number): number {
+	return runsPerMonth > 0 ? monthlyUsd / runsPerMonth : Number.POSITIVE_INFINITY;
+}
+
+/**
+ * The break-even utilization between the two models: the runs/month at which a fixed-infra box's
+ * amortized per-run cost equals burst's. Below it burst wins (idle infra wastes the fixed bill);
+ * above it the reserved box wins. From equating the two —
+ *   monthlyUsd / runsPerMonth = hourlyUsd × runtimeHours  ⇒  runsPerMonth = monthlyUsd / burstCost.
+ * Returns `Infinity` when a run's burst cost is 0 (no per-run cost to amortize against).
+ */
+export function amortizationBreakEvenRunsPerMonth(
+	monthlyUsd: number,
+	hourlyUsd: number,
+	runtimeMs: number,
+): number {
+	const burst = burstCostPerRun(hourlyUsd, runtimeMs);
+	return burst > 0 ? monthlyUsd / burst : Number.POSITIVE_INFINITY;
+}

--- a/packages/schema/src/index.ts
+++ b/packages/schema/src/index.ts
@@ -7,6 +7,8 @@ import { rawRunSchema } from "./lib/internal.ts";
 export * from "./analysis.ts";
 // The Metric Catalog — the registry of rankable Metrics, plus lookup helpers.
 export * from "./catalog.ts";
+// The pure cost models ($/run — burst vs fixed-infra amortization) the economics Dimension builds on.
+export * from "./economics.ts";
 // The non-PTS, harness-measured Metric slice (lifecycle + control-plane) and its operation→id contract.
 export * from "./harness-metrics.ts";
 // Metric vocabulary: Dimension, Direction and the MetricDef shape every Metric declares.


### PR DESCRIPTION
**ENG-61 economics — split into 3 focused PRs** (merge bottom-up, each independently green):
1. **#80 — pure cost models** (this PR)
2. #71 — economics Catalog slice + derivation
3. #81 — derive economics onto each Run

↑ **This PR is 1/3**, based on #68.

---
The **pure pricing math** the economics dimension rests on — burst (pay-per-use) and fixed-infra amortized cost models, plus their break-even utilization. Zero schema dependencies; unit-tested in isolation. The MetricDefs + `deriveEconomics()` that consume `burstCostPerRun` land in #71.

**Validated locally:** `bun run typecheck` (8 workspaces, 0 errors); `@sandbox-benchmarks/schema` 122 tests pass.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds pure per-run cost models for the economics dimension: burst (pay-per-use), fixed-infra amortization, and a break-even runs/month helper. Exported from `index.ts`; supports ENG-61.

- **New Features**
  - Helpers: `burstCostPerRun(hourlyUsd, runtimeMs)`, `amortizedCostPerRun(monthlyUsd, runsPerMonth)` (`Infinity` when runs/month ≤ 0), `amortizationBreakEvenRunsPerMonth(monthlyUsd, hourlyUsd, runtimeMs)` (`Infinity` when burst cost is 0).
  - Unit tests in `economics.test.ts`.

<sup>Written for commit 6f5a6a3b7ba58d58bb319289b01f6211a57f9f29. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/starslingdev/sandbox-benchmarks/pull/80?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added economics cost utilities to estimate burst per-run costs, amortized per-run costs (with `Infinity` for zero/negative usage), and the monthly runs-per-month break-even point.
  * Re-exported these new pricing helpers as part of the public schema API.
* **Tests**
  * Added Bun-based unit tests covering burst, amortized, and break-even calculations, including edge cases like zero runtime and zero usage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->