### PR TITLE
feat(results): derive economics onto each validated ProviderRun (ENG-61)

### DIFF
--- a/packages/results/src/lib/normalize-tree.test.ts
+++ b/packages/results/src/lib/normalize-tree.test.ts
@@ -2,6 +2,11 @@ import { afterEach, beforeEach, describe, expect, it, spyOn } from "bun:test";
 import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import {
+	ECONOMICS_METRIC_IDS,
+	getProvider,
+	hourlyCostAtTargetSpec,
+} from "@sandbox-benchmarks/schema";
 import { normalizeProviderDir } from "./normalize-tree.ts";
 
 // A composite carrying a catalogued node-web-tooling result plus an uncatalogued pts/git result.
@@ -45,8 +50,11 @@ describe("normalizeProviderDir de-dupes a metric leaked into two composites", ()
 		writeFileSync(join(providerDir, "pts_node-web-tooling.xml"), composite("10.5:10.6:10.4"));
 
 		const run = normalizeProviderDir(root, "daytona");
-		const metric = run.metrics.find((m) => m.metricId === "node_web_tooling_runs_per_s");
-		expect(run.metrics).toHaveLength(1);
+		const matches = run.metrics.filter((m) => m.metricId === "node_web_tooling_runs_per_s");
+		// The leaked metric is kept exactly once (other catalogued metrics — e.g. derived economics — may
+		// also be present; this asserts the de-dup, not the total count).
+		expect(matches).toHaveLength(1);
+		const metric = matches[0];
 		expect(metric?.samples).toEqual([10.5, 10.6, 10.4]);
 		expect(metric?.aggregates.n).toBe(3);
 		// The uncatalogued git straggler is collapsed to a single entry too.
@@ -95,6 +103,29 @@ describe("normalizeProviderDir reads the suite-tagged layout", () => {
 		]);
 		// observed-specs.json is read from the suite subdirectory (per-sandbox), not just the provider dir.
 		expect(run.observedSpecs.vcpus).toBe(4);
+	});
+
+	it("appends derived economics ($/hr) to a validated provider", () => {
+		const suiteDir = join(providerDir, "cpu-node");
+		mkdirSync(suiteDir);
+		writeFileSync(join(suiteDir, "pts_node-web-tooling.xml"), composite("16.1:16.3:16.0"));
+
+		const run = normalizeProviderDir(root, "daytona");
+		const usdPerHour = run.metrics.find((m) => m.metricId === ECONOMICS_METRIC_IDS.usdPerHour);
+		expect(usdPerHour?.samples).toEqual([
+			hourlyCostAtTargetSpec(getProvider("daytona")) ?? Number.NaN,
+		]);
+		// No lifecycle timings in a PTS-only run, so no per-lifecycle cost.
+		expect(run.metrics.some((m) => m.metricId === ECONOMICS_METRIC_IDS.usdPerLifecycle)).toBe(
+			false,
+		);
+	});
+
+	it("does NOT attach economics to a pending provider (no measured metrics)", () => {
+		// Empty provider dir → pending; economics must not promote it or appear.
+		const run = normalizeProviderDir(root, "daytona");
+		expect(run.validationStatus).toBe("pending");
+		expect(run.metrics).toEqual([]);
 	});
 
 	it("ignores (with a warning) a subdirectory that is not a registered suite", () => {

--- a/packages/results/src/lib/normalize-tree.ts
+++ b/packages/results/src/lib/normalize-tree.ts
@@ -16,7 +16,9 @@ import type {
 } from "@sandbox-benchmarks/schema";
 import {
 	aggregate,
+	deriveEconomics,
 	describeOffDimensionEmission,
+	getProvider,
 	offDimensionEmissions,
 	PROVIDERS,
 	parseRun,
@@ -205,6 +207,23 @@ export function normalizeProviderDir(rawRoot: string, providerId: string): Provi
 			...(args !== undefined ? { arguments: args } : {}),
 		}))
 		.sort((a, b) => a.metricId.localeCompare(b.metricId));
+
+	// Enrich a measured provider with derived economics ($/run): pricing × the runtime already on the
+	// Run. Done here, AFTER the off-dimension contract check above, because economics is derived and
+	// declared by no suite — running it through that check would flag it as off-contract. Gated on ≥1
+	// measured Metric so economics enriches a `validated` provider and never promotes a `pending` one
+	// (a provider with no real measurements has no economics either). An unknown/unpriced provider
+	// yields no economics, so a null rate can never read as free.
+	const meta = getProvider(providerId);
+	if (meta && metrics.length > 0) {
+		metrics.push(
+			...deriveEconomics(
+				meta,
+				metrics.map((m) => ({ metricId: m.metricId, mean: m.aggregates.mean })),
+			),
+		);
+		metrics.sort((a, b) => a.metricId.localeCompare(b.metricId));
+	}
 
 	// De-dupe uncatalogued stragglers by id for the same reason (a contaminating result leaks into every
 	// composite it lands in); keep the first occurrence and preserve extraction order.


### PR DESCRIPTION
**ENG-61 economics — split into 3 focused PRs** (merge bottom-up, each independently green):
1. #80 — pure cost models
2. #71 — economics Catalog slice + derivation
3. **#81 — derive economics onto each Run** (this PR)

↑ **This PR is 3/3**, based on #71.

---
The **consumption layer**: the results normalizer now calls `deriveEconomics` and appends the derived economics MetricResults to each validated ProviderRun.

**Validated locally:** `bun run typecheck` (0 errors); `@sandbox-benchmarks/results` 35 tests pass; this branch's tree reproduces the original #71 byte-for-byte.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds derived provider economics to each validated ProviderRun during normalization. Satisfies ENG-61 by using `@sandbox-benchmarks/schema` pricing to add $/hour and, when timing data exists, $/lifecycle.

- **New Features**
  - Calls `deriveEconomics` after contract checks; only when the run has ≥1 measured metric and `getProvider` pricing; unknown/unpriced add nothing; pending stays pending.
  - Tests cover $/hour via `hourlyCostAtTargetSpec(getProvider(...))`, omission of $/lifecycle without timings, and de-dupe keeps one real metric while allowing derived ones.

<sup>Written for commit 3794bfe66f9c62f890f385187e80e21ce5ca6cfd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/starslingdev/sandbox-benchmarks/pull/81?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

