### PR TITLE
feat(results,schema): CPU microarch fingerprint + forensics schema (ENG-70)

### DIFF
--- a/lib/bench.sh
+++ b/lib/bench.sh
@@ -242,6 +242,14 @@ run_pts_benchmark() {
 	if [ -n "$xml_found" ] && [ -f "$xml_found" ]; then
 		cp "$xml_found" "$(results_dir)/${prefix}.xml" 2>/dev/null || true
 		echo "Structured result: ${prefix}.xml (from $(dirname "$xml_found"))"
+		# Capture the whole result dir (composite.xml + installation-logs/ + test-logs/) as a forensics
+		# tarball for debugging. A .tar.gz — not a flattened copy — so its nested .xml files can't be
+		# misrouted by the extractor (the name ends --forensics.tar.gz, which isPtsResultFile never
+		# matches). `|| true` so a /var/lib perms hiccup can't abort this `set -e` measurement leaf.
+		local result_dir
+		result_dir="$(dirname "$xml_found")"
+		tar -czf "$(results_dir)/${prefix}--forensics.tar.gz" \
+			-C "$(dirname "$result_dir")" "$(basename "$result_dir")" 2>/dev/null || true
 	else
 		echo "No PTS composite.xml found under ${pts_base}/"
 		ls -la "$pts_base"/ 2>/dev/null || true

--- a/packages/results/src/lib/cpu-fingerprint.test.ts
+++ b/packages/results/src/lib/cpu-fingerprint.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it } from "bun:test";
+import { resolveCpuMicroarch } from "./cpu-fingerprint.ts";
+
+describe("resolveCpuMicroarch", () => {
+	it("resolves standard EPYC SKUs by their model number (the final digit is the generation)", () => {
+		// OURS fixtures (pts_stream/pts_hardlink) run on a bare-metal 9275F — a 9xx5 = Zen 5 (Turin).
+		expect(resolveCpuMicroarch("AMD EPYC 9275F 24-Core")).toEqual({
+			name: "Zen 5 (Turin)",
+			year: 2024,
+		});
+		// 9xx4 = Genoa (Zen 4), 7xx3 = Milan (Zen 3), 7xx2 = Rome (Zen 2).
+		expect(resolveCpuMicroarch("AMD EPYC 9654 96-Core Processor")?.name).toBe("Zen 4 (Genoa)");
+		expect(resolveCpuMicroarch("AMD EPYC 7763 64-Core Processor")?.name).toBe("Zen 3 (Milan)");
+		// High-frequency (7Fx2) and dense (7Hx2) Rome parts carry a letter in the second position but
+		// still follow the series/final-digit rule — 7xx2 = Rome (Zen 2).
+		expect(resolveCpuMicroarch("AMD EPYC 7F32 8-Core Processor")?.name).toBe("Zen 2 (Rome)");
+		expect(resolveCpuMicroarch("AMD EPYC 7F72 24-Core Processor")?.name).toBe("Zen 2 (Rome)");
+		expect(resolveCpuMicroarch("AMD EPYC 7H12 64-Core Processor")?.name).toBe("Zen 2 (Rome)");
+	});
+
+	it("resolves the cloud-masked AWS/Azure EPYC SKUs that carry a letter mid-model", () => {
+		// AWS masks the series digit ("9R14"/"9R45"); the static SKU table still nails the microarch.
+		expect(resolveCpuMicroarch("AMD EPYC 9R14")?.name).toBe("Zen 4 (Genoa)");
+		expect(resolveCpuMicroarch("AMD EPYC 9R45")?.name).toBe("Zen 5 (Turin)");
+		expect(resolveCpuMicroarch("AMD EPYC 7R13")?.name).toBe("Zen 3 (Milan)");
+		// 7R32 is the AWS custom Rome (Zen 2) part (c5a/m5a/g4ad); the letter defeats the final-digit
+		// heuristic, and it must not be confused with the Milan 7R13 above.
+		expect(resolveCpuMicroarch("AMD EPYC 7R32")?.name).toBe("Zen 2 (Rome)");
+		// Azure: 7V12 = Rome, 7V73X = Milan-X.
+		expect(resolveCpuMicroarch("AMD EPYC 7V12 64-Core Processor")?.name).toBe("Zen 2 (Rome)");
+		expect(resolveCpuMicroarch("AMD EPYC 7V73X 64-Core Processor")?.name).toBe("Zen 3 (Milan-X)");
+	});
+
+	it("resolves the Intel Xeon SKUs seen across runner composites", () => {
+		expect(resolveCpuMicroarch("Intel(R) Xeon(R) Platinum 8358 CPU @ 2.60GHz")?.name).toBe(
+			"Ice Lake-SP",
+		);
+		expect(resolveCpuMicroarch("Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz")?.name).toBe(
+			"Ice Lake-SP",
+		);
+		expect(resolveCpuMicroarch("Intel(R) Xeon(R) Platinum 8375C")?.name).toBe("Ice Lake-SP");
+		expect(resolveCpuMicroarch("Intel(R) Xeon(R) Platinum 8488C")?.name).toBe("Sapphire Rapids");
+	});
+
+	it("looks up the family/model table when ISA hints disclose them", () => {
+		expect(resolveCpuMicroarch("AMD EPYC", { family: 26, model: 2 })).toEqual({
+			name: "Zen 5 (Turin)",
+			year: 2024,
+		});
+		expect(resolveCpuMicroarch("Intel(R) Xeon(R) Processor", { family: 6, model: 143 })?.name).toBe(
+			"Sapphire Rapids",
+		);
+	});
+
+	it("infers an AMD microarch from the AVX-512 fingerprint when the SKU is masked", () => {
+		// Family 0x1A (26) + VP2INTERSECT is Zen 5-only on AMD (hypervisors expose a bare 'AMD EPYC').
+		expect(
+			resolveCpuMicroarch("AMD EPYC", { family: 26, hasAvx512Vp2intersect: true }),
+		).toMatchObject({ name: "Zen 5 (Turin, SKU masked)", inferredFrom: "ISA fingerprint" });
+		// Family 0x19 (25): AVX-512 present but no VP2INTERSECT → Zen 4; absent → Zen 3.
+		expect(resolveCpuMicroarch("AMD EPYC", { family: 25, hasAvx512f: true })?.name).toBe(
+			"Zen 4 (Genoa/Bergamo, SKU masked)",
+		);
+		expect(resolveCpuMicroarch("AMD EPYC", { family: 25, hasAvx512f: false })?.name).toBe(
+			"Zen 3 (Milan, SKU masked)",
+		);
+	});
+
+	it("returns undefined for an unrecognized model (caller leaves cpuMicroarch unset)", () => {
+		expect(resolveCpuMicroarch("Apple M2")).toBeUndefined();
+		expect(resolveCpuMicroarch("")).toBeUndefined();
+		expect(resolveCpuMicroarch("AMD EPYC")).toBeUndefined();
+	});
+});

--- a/packages/results/src/lib/cpu-fingerprint.ts
+++ b/packages/results/src/lib/cpu-fingerprint.ts
@@ -1,0 +1,151 @@
+/**
+ * Resolve a CPU brand string into a microarchitecture/generation label — a pure helper, ported from
+ * THEIRS `scripts/lib/analyze.py` (`resolve_cpu_gen`, the `cpu_generations` table, and
+ * `_infer_amd_microarch_from_isa`). Used HOST-side only: the brand string always describes the
+ * physical machine, so the label this returns is a host fingerprint and must never decorate an
+ * effective (cgroup-quota) spec.
+ *
+ * Resolution order, most-authoritative first: (1) the static `cpu_family/cpu_model_id` table when ISA
+ * hints disclose them, (2) the brand-string SKU table (handles the cloud-masked AWS/Azure SKUs whose
+ * series digit is replaced by a letter), and (3) an AVX-512 fingerprint inference for AMD when only a
+ * bare 'AMD EPYC' brand survives (hypervisors like Novita strip the model). Anything unresolved
+ * returns `undefined`, mirroring `parseSystemHost`'s "leave it unset" tolerance.
+ */
+
+/** A resolved generation/microarch label, with the launch year and (when inferred) its provenance. */
+export interface CpuFingerprint {
+	name: string;
+	year?: number;
+	inferredFrom?: string;
+}
+
+/** Optional ISA hints a probe may disclose; absent under PTS, which only exposes the brand string. */
+export interface CpuIsaHints {
+	family?: number;
+	model?: number;
+	hasAvx512f?: boolean;
+	hasAvx512Vp2intersect?: boolean;
+}
+
+/**
+ * `cpu_family/cpu_model_id -> {name, year}`, ported verbatim from THEIRS runner_config.yaml. The
+ * primary, most-reliable lookup when a probe discloses the raw family/model (cpuid leaf 1).
+ */
+const CPU_GENERATIONS: Record<string, CpuFingerprint> = {
+	"6/85": { name: "Skylake-SP", year: 2017 },
+	"6/106": { name: "Ice Lake-SP", year: 2021 },
+	"25/1": { name: "Zen 3 (Milan)", year: 2021 },
+	"25/97": { name: "Zen 3 (Milan)", year: 2021 },
+	"25/17": { name: "Zen 4 (Genoa)", year: 2022 },
+	"26/2": { name: "Zen 5 (Turin)", year: 2024 },
+	"26/68": { name: "Zen 5 (Turin Dense)", year: 2024 },
+	"23/49": { name: "Zen 2 (Rome)", year: 2019 },
+	"6/143": { name: "Sapphire Rapids", year: 2023 },
+	"6/173": { name: "Granite Rapids", year: 2024 },
+	"6/79": { name: "Broadwell-EP", year: 2015 },
+	"6/63": { name: "Haswell-EP", year: 2014 },
+	"6/142": { name: "Kaby Lake", year: 2017 },
+	"6/158": { name: "Coffee Lake", year: 2018 },
+};
+
+/** Map an AMD EPYC brand string to a generation, handling the cloud-masked SKUs first. */
+function resolveEpyc(brand: string): CpuFingerprint | undefined {
+	// Cloud-masked AWS/Azure SKUs carry a letter where the series digit would be, so the
+	// general "final digit = generation" rule below can't read them — match them explicitly.
+	if (/\b7(R13|763|B13)\b/.test(brand)) return { name: "Zen 3 (Milan)", year: 2021 };
+	if (/\b7V73X\b/.test(brand)) return { name: "Zen 3 (Milan-X)", year: 2022 };
+	// 7R32 is the AWS custom Rome (Zen 2) part (c5a/m5a/r5a/g4ad); 7R13 above is the Milan (Zen 3) part.
+	if (/\b7(V12|R32)\b/.test(brand)) return { name: "Zen 2 (Rome)", year: 2019 };
+	if (/\b9R45\b/.test(brand)) return { name: "Zen 5 (Turin)", year: 2024 };
+	if (/\b9R14\b/.test(brand)) return { name: "Zen 4 (Genoa)", year: 2022 };
+	// Standard 4-symbol EPYC numbering: the series digit and the final digit name the generation —
+	// 9xx5 = Turin (Zen 5), 9xx4 = Genoa/Bergamo (Zen 4), 7xx3 = Milan (Zen 3), 7xx2 = Rome (Zen 2).
+	// The second symbol may be a letter on high-frequency / dense parts (7F32, 7H12 → Rome), so match
+	// a letter-or-digit there rather than requiring four digits.
+	const m = brand.match(/EPYC\s+(\d)[A-Z\d]\d(\d)/);
+	if (m) {
+		const series = m[1];
+		const gen = m[2];
+		if (series === "9" && gen === "5") return { name: "Zen 5 (Turin)", year: 2024 };
+		if (series === "9" && gen === "4") return { name: "Zen 4 (Genoa)", year: 2022 };
+		if (series === "7" && gen === "3") return { name: "Zen 3 (Milan)", year: 2021 };
+		if (series === "7" && gen === "2") return { name: "Zen 2 (Rome)", year: 2019 };
+	}
+	return undefined;
+}
+
+/** Map an Intel Xeon brand string to a microarch via the SKUs seen across the runner composites. */
+function resolveXeon(brand: string): CpuFingerprint | undefined {
+	if (/Platinum 8488C/.test(brand)) return { name: "Sapphire Rapids", year: 2023 };
+	if (/Platinum 8375C/.test(brand)) return { name: "Ice Lake-SP", year: 2021 };
+	if (/Platinum 8358/.test(brand) || /Platinum 8370C/.test(brand)) {
+		return { name: "Ice Lake-SP", year: 2021 };
+	}
+	return undefined;
+}
+
+/**
+ * Infer an AMD microarch from the family number + AVX-512 fingerprint, ported from THEIRS
+ * `_infer_amd_microarch_from_isa`. The last resort when the SKU/brand is masked (e.g. a bare
+ * 'AMD EPYC' with family=25/26 and a disclosed AVX-512 feature set).
+ */
+function inferAmdFromIsa(brand: string, isa: CpuIsaHints): CpuFingerprint | undefined {
+	const upper = brand.toUpperCase();
+	if (!["AMD", "EPYC", "RYZEN", "THREADRIPPER"].some((t) => upper.includes(t))) return undefined;
+	const fam = isa.family;
+	if (fam === 25) {
+		// Family 0x19 = Zen 3 / Zen 4. AVX-512 was added in Zen 4.
+		if (isa.hasAvx512f && !isa.hasAvx512Vp2intersect) {
+			return {
+				name: "Zen 4 (Genoa/Bergamo, SKU masked)",
+				year: 2022,
+				inferredFrom: "ISA fingerprint",
+			};
+		}
+		// Only conclude Zen 3 when AVX-512 is explicitly absent — an unknown (undefined) flag must not
+		// be read as "no AVX-512" and guess Milan.
+		if (isa.hasAvx512f === false) {
+			return { name: "Zen 3 (Milan, SKU masked)", year: 2021, inferredFrom: "ISA fingerprint" };
+		}
+	}
+	if (fam === 26) {
+		// Family 0x1A is unambiguously Zen 5 on AMD (unlike family 25, which spans Zen 3 and Zen 4), so
+		// bare family 26 resolves even when a guest strips the AVX-512 VP2INTERSECT confirmation flag.
+		return { name: "Zen 5 (Turin, SKU masked)", year: 2024, inferredFrom: "ISA fingerprint" };
+	}
+	return undefined;
+}
+
+/**
+ * Resolve a CPU `cpuModel` brand string (and optional ISA hints) to a {@link CpuFingerprint}, or
+ * `undefined` when nothing matches. See the file header for the resolution order and the host-only rule.
+ */
+export function resolveCpuMicroarch(
+	cpuModel: string,
+	isa?: CpuIsaHints,
+): CpuFingerprint | undefined {
+	// 1. Family/model table — the most reliable signal when a probe discloses them.
+	if (isa?.family !== undefined && isa?.model !== undefined) {
+		const hit = CPU_GENERATIONS[`${isa.family}/${isa.model}`];
+		if (hit) return hit;
+	}
+
+	const brand = cpuModel ?? "";
+	// 2. Brand-string SKU tables.
+	if (brand.includes("EPYC")) {
+		const hit = resolveEpyc(brand);
+		if (hit) return hit;
+	}
+	if (brand.includes("Xeon")) {
+		const hit = resolveXeon(brand);
+		if (hit) return hit;
+	}
+
+	// 3. Last-resort AVX-512 fingerprint inference for a masked AMD SKU.
+	if (isa) {
+		const hit = inferAmdFromIsa(brand, isa);
+		if (hit) return hit;
+	}
+
+	return undefined;
+}

--- a/packages/results/src/lib/pts-schema.ts
+++ b/packages/results/src/lib/pts-schema.ts
@@ -57,10 +57,25 @@ const ptsGenerated = type({
 	"TestClient?": "string",
 });
 
-/** A full `composite.xml`: the generator header and one-or-more test results. */
+/**
+ * The host fingerprint PTS embeds in `<System>`: free-text Hardware/Software description strings plus
+ * the run user. Inside a container these disclose the HOST machine (e.g. a 48-thread EPYC), never the
+ * sandbox's effective cgroup quota — so the reader (./system-specs.ts) maps them ONLY to the host side
+ * of ObservedSpecs (`hostVcpus`/`hostMemoryGb`/…), never the effective `vcpus`/`memoryGb`. Optional:
+ * PTS writes `<System>` into composite.xml, but older/partial trees may omit it.
+ */
+const ptsSystem = type({
+	"Identifier?": "string",
+	"Hardware?": "string",
+	"Software?": "string",
+	"User?": "string",
+});
+
+/** A full `composite.xml`: the generator header, the host `<System>` fingerprint, and the results. */
 export const ptsCompositeSchema = type({
 	PhoronixTestSuite: {
 		"Generated?": ptsGenerated,
+		"System?": ptsSystem,
 		Result: ptsResult.array(),
 	},
 });
@@ -71,3 +86,5 @@ export type PtsComposite = typeof ptsCompositeSchema.infer;
 export type PtsResult = typeof ptsResult.infer;
 /** A single typed `<Entry>` from a parsed result. */
 export type PtsEntry = typeof ptsEntry.infer;
+/** The typed `<System>` host fingerprint from a parsed composite. */
+export type PtsSystem = typeof ptsSystem.infer;

--- a/packages/schema/src/raw-files.test.ts
+++ b/packages/schema/src/raw-files.test.ts
@@ -1,10 +1,12 @@
 import { describe, expect, it } from "bun:test";
 import {
 	harnessSkipMarkerJson,
+	isPtsForensicsFile,
 	isPtsResultFile,
 	isSkipMarkerFile,
 	parseResultsArtifactName,
 	parseSkipMarker,
+	ptsForensicsFile,
 	resultsArtifactName,
 	sandboxSkipMarkerFile,
 } from "./index.ts";
@@ -14,6 +16,18 @@ describe("raw-file naming", () => {
 		expect(isPtsResultFile("pts_node-web-tooling.xml")).toBe(true);
 		expect(isPtsResultFile("pts_node-web-tooling.log")).toBe(false);
 		expect(isPtsResultFile("observed-specs.json")).toBe(false);
+	});
+
+	it("names a forensics tarball and keeps it disjoint from the PTS result predicate", () => {
+		const file = ptsForensicsFile("pts_node-web-tooling");
+		expect(file).toBe("pts_node-web-tooling--forensics.tar.gz");
+		expect(isPtsForensicsFile(file)).toBe(true);
+		// Provably disjoint: the tarball starts pts_ but must NEVER route through the .xml extractor.
+		expect(isPtsResultFile(file)).toBe(false);
+		// And a real result XML is not a forensics tarball.
+		expect(isPtsForensicsFile("pts_node-web-tooling.xml")).toBe(false);
+		// The profile segment must be non-empty — a bare `pts_--forensics.tar.gz` is not a valid name.
+		expect(isPtsForensicsFile("pts_--forensics.tar.gz")).toBe(false);
 	});
 
 	it("names and detects suite skip markers", () => {

--- a/packages/schema/src/raw-files.ts
+++ b/packages/schema/src/raw-files.ts
@@ -28,11 +28,29 @@ const SKIP_SUFFIX = "--skipped.json";
 
 /**
  * A PTS structured result, e.g. `pts_node-web-tooling.xml`. The producer writes one per test under a
- * `pts_` prefix; the extractor keys on this to route XML through the PTS parser. The `.json`/`.log`
- * siblings are provenance, not metrics, so they deliberately don't match.
+ * `pts_` prefix; the extractor keys on this to route XML through the PTS parser. Most `pts_*` siblings
+ * (`.json`/`.log`) are provenance, not metrics, so they don't match — with one intentional exception:
+ * the forensics tarball ({@link isPtsForensicsFile}), a recognized provenance name that is provably
+ * disjoint from this predicate (it ends `--forensics.tar.gz`, never `.xml`).
  */
 const ptsResultFile = type("string").matching("^pts_.*\\.xml$");
 export const isPtsResultFile = (filename: string): boolean => ptsResultFile.allows(filename);
+
+const FORENSICS_SUFFIX = "--forensics.tar.gz";
+
+/**
+ * `pts_<test>--forensics.tar.gz` — the full PTS result directory (composite.xml + installation-logs/ +
+ * test-logs/) captured as a tarball for post-hoc debugging. A tarball, not a flattened copy, so its
+ * nested `.xml` files can't be misrouted by {@link isPtsResultFile}: it `startsWith("pts_")` yet ends
+ * `--forensics.tar.gz`, so it is provably disjoint from the `.xml` result predicate.
+ */
+export function ptsForensicsFile(prefix: string): string {
+	return `${prefix}${FORENSICS_SUFFIX}`;
+}
+
+const ptsForensicsFileName = type("string").matching("^pts_.+--forensics\\.tar\\.gz$");
+export const isPtsForensicsFile = (filename: string): boolean =>
+	ptsForensicsFileName.allows(filename);
 
 const skipMarkerFileName = type("string").matching("--skipped\\.json$");
 export const isSkipMarkerFile = (filename: string): boolean => skipMarkerFileName.allows(filename);

--- a/packages/schema/src/run.ts
+++ b/packages/schema/src/run.ts
@@ -61,7 +61,10 @@ export type UncataloguedResult = typeof uncataloguedResultSchema.infer;
  * {@link TargetSpec}. All optional: providers differ in what in-sandbox
  * probes can see. `vcpus`/`memoryGb` are the EFFECTIVE Sandbox size (cgroup quota where enforced);
  * `hostVcpus`/`hostMemoryGb` disclose the underlying machine when probes see through the container
- * boundary (e.g. Daytona: a 4-vCPU quota on a 48-thread host).
+ * boundary (e.g. Daytona: a 4-vCPU quota on a 48-thread host). `cpuMicroarch` is a HOST-side
+ * generation/microarch label derived from `cpuModel` (e.g. "Zen 5 (Turin)"). `hostCpuModels` is set
+ * only by the aggregate path — the distinct host CPU models a provider's shards disclosed, present
+ * only when there was more than one (a scheduling confound the published Run names rather than hides).
  */
 export const observedSpecsSchema = type({
 	"vcpus?": "number",
@@ -70,11 +73,16 @@ export const observedSpecsSchema = type({
 	"hostVcpus?": "number",
 	"hostMemoryGb?": "number",
 	"cpuModel?": "string",
+	// Host-side generation/microarch label derived from cpuModel; never reflects the effective spec.
+	"cpuMicroarch?": "string",
 	"cpuMhz?": "number",
 	"kernel?": "string",
 	"os?": "string",
 	"virtualization?": "string",
 	"user?": "string",
+	// The distinct host CPU models when merged shards of one provider disclosed more than one — the
+	// aggregate-only heterogeneity disclosure (cpuModel is the key; cpuMicroarch is derived from it).
+	"hostCpuModels?": "string[]",
 });
 export type ObservedSpecs = typeof observedSpecsSchema.infer;
 


### PR DESCRIPTION
**ENG-70 host fingerprint — split into 3 focused PRs** (merge bottom-up, each independently green):
1. **#82 — CPU microarch fingerprint + forensics schema** (this PR)
2. #83 — effective-spec probe parser + fixtures
3. #72 — host-fingerprint enrichment onto the tree

↑ **This PR is 1/3**, based on #81.

---
**Leaves + schema plumbing**: the pure CPU-microarch fingerprint resolver, the PTS `System` type, the observedSpecs `cpuMicroarch`/`hostHeterogeneous` schema fields, the `ptsForensics` raw-file recognizer, and the `bench.sh` forensics-tarball step. All pure-additive; the probe parser and wiring that consume them land in #83 and #72.

**Validated locally:** `bun run typecheck` (8 workspaces, 0 errors); `@sandbox-benchmarks/results` 41 and `@sandbox-benchmarks/schema` 133 tests pass.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a host CPU microarchitecture fingerprint resolver, PTS `<System>` parsing, and a `pts_<test>--forensics.tar.gz` artifact for ENG-70. Host-only leaves; probe parsing and wiring land in follow-ups.

- **New Features**
  - `packages/results`: `resolveCpuMicroarch` resolves via family/model table, EPYC/Xeon SKU tables (incl. AWS/Azure masked SKUs), and AMD AVX‑512 inference.
  - `packages/results`: Parse PTS `<System>` in `ptsCompositeSchema`; export `PtsSystem`.
  - `packages/schema`: `ObservedSpecs` adds `cpuMicroarch?` (host-only) and `hostCpuModels?` (aggregate-only distinct host CPU models).
  - `lib/bench.sh` + `packages/schema`: Emit `pts_<test>--forensics.tar.gz`; add `isPtsForensicsFile`/`ptsForensicsFile`.

- **Bug Fixes**
  - Forensics tarball creation is best-effort (`|| true`) and won’t fail a run.
  - Forensics tarball names never match `.xml` and require a non-empty `<test>` segment.

<sup>Written for commit e7ed6c1a79b3cecf6cf795bcd5272d9dca00d9e1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/starslingdev/sandbox-benchmarks/pull/82?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added host CPU microarchitecture and heterogeneous-host signaling to observed benchmark specs.
  * Added host CPU fingerprint resolution for more AMD EPYC and Intel Xeon formats, including inference from ISA hints.
  * Parse optional host `<System>` data from PTS composite results and expose it in public types.
  * Benchmarks now generate per-run `--forensics.tar.gz` archives; raw artifact detection supports them.
* **Bug Fixes**
  * Forensics archive creation failures no longer break benchmarks.
* **Tests**
  * Added coverage for CPU resolution and PTS forensics raw-file naming edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->