### PR TITLE
feat(results): effective-spec probe parser + fixtures (ENG-70)

### DIFF
--- a/packages/results/src/lib/__fixtures__/probes/cpu-info--lscpu.json
+++ b/packages/results/src/lib/__fixtures__/probes/cpu-info--lscpu.json
@@ -1,0 +1,172 @@
+{
+  "lscpu": [
+    {
+      "field": "Architecture:",
+      "data": "x86_64"
+    },
+    {
+      "field": "CPU op-mode(s):",
+      "data": "32-bit, 64-bit"
+    },
+    {
+      "field": "Address sizes:",
+      "data": "52 bits physical, 57 bits virtual"
+    },
+    {
+      "field": "Byte Order:",
+      "data": "Little Endian"
+    },
+    {
+      "field": "CPU(s):",
+      "data": "6"
+    },
+    {
+      "field": "On-line CPU(s) list:",
+      "data": "0-5"
+    },
+    {
+      "field": "Vendor ID:",
+      "data": "AuthenticAMD"
+    },
+    {
+      "field": "Model name:",
+      "data": "AMD EPYC"
+    },
+    {
+      "field": "CPU family:",
+      "data": "25"
+    },
+    {
+      "field": "Model:",
+      "data": "17"
+    },
+    {
+      "field": "Thread(s) per core:",
+      "data": "1"
+    },
+    {
+      "field": "Core(s) per socket:",
+      "data": "6"
+    },
+    {
+      "field": "Socket(s):",
+      "data": "1"
+    },
+    {
+      "field": "Stepping:",
+      "data": "1"
+    },
+    {
+      "field": "BogoMIPS:",
+      "data": "6199.99"
+    },
+    {
+      "field": "Flags:",
+      "data": "fpu vme de pse tsc msr pae mce cx8 apic sep mtrr pge mca cmov pat pse36 clflush mmx fxsr sse sse2 ht syscall nx mmxext fxsr_opt pdpe1gb rdtscp lm constant_tsc rep_good nopl xtopology nonstop_tsc cpuid tsc_known_freq pni pclmulqdq ssse3 fma cx16 pcid sse4_1 sse4_2 x2apic movbe popcnt tsc_deadline_timer aes xsave avx f16c rdrand hypervisor lahf_lm cmp_legacy svm cr8_legacy abm sse4a misalignsse 3dnowprefetch osvw topoext perfctr_core ssbd ibrs ibpb stibp vmmcall fsgsbase tsc_adjust bmi1 avx2 smep bmi2 erms invpcid avx512f avx512dq rdseed adx smap avx512ifma clflushopt clwb avx512cd sha_ni avx512bw avx512vl xsaveopt xsavec xgetbv1 xsaves avx512_bf16 clzero xsaveerptr wbnoinvd arat npt lbrv nrip_save tsc_scale vmcb_clean flushbyasid pausefilter pfthreshold v_vmsave_vmload vgif vnmi avx512vbmi umip pku ospke avx512_vbmi2 gfni vaes vpclmulqdq avx512_vnni avx512_bitalg avx512_vpopcntdq rdpid fsrm flush_l1d"
+    },
+    {
+      "field": "Virtualization:",
+      "data": "AMD-V"
+    },
+    {
+      "field": "Hypervisor vendor:",
+      "data": "KVM"
+    },
+    {
+      "field": "Virtualization type:",
+      "data": "full"
+    },
+    {
+      "field": "L1d cache:",
+      "data": "192 KiB (6 instances)"
+    },
+    {
+      "field": "L1i cache:",
+      "data": "192 KiB (6 instances)"
+    },
+    {
+      "field": "L2 cache:",
+      "data": "6 MiB (6 instances)"
+    },
+    {
+      "field": "L3 cache:",
+      "data": "32 MiB (1 instance)"
+    },
+    {
+      "field": "NUMA node(s):",
+      "data": "1"
+    },
+    {
+      "field": "NUMA node0 CPU(s):",
+      "data": "0-5"
+    },
+    {
+      "field": "Vulnerability Gather data sampling:",
+      "data": "Not affected"
+    },
+    {
+      "field": "Vulnerability Indirect target selection:",
+      "data": "Not affected"
+    },
+    {
+      "field": "Vulnerability Itlb multihit:",
+      "data": "Not affected"
+    },
+    {
+      "field": "Vulnerability L1tf:",
+      "data": "Not affected"
+    },
+    {
+      "field": "Vulnerability Mds:",
+      "data": "Not affected"
+    },
+    {
+      "field": "Vulnerability Meltdown:",
+      "data": "Not affected"
+    },
+    {
+      "field": "Vulnerability Mmio stale data:",
+      "data": "Not affected"
+    },
+    {
+      "field": "Vulnerability Reg file data sampling:",
+      "data": "Not affected"
+    },
+    {
+      "field": "Vulnerability Retbleed:",
+      "data": "Not affected"
+    },
+    {
+      "field": "Vulnerability Spec rstack overflow:",
+      "data": "Vulnerable: Safe RET, no microcode"
+    },
+    {
+      "field": "Vulnerability Spec store bypass:",
+      "data": "Mitigation; Speculative Store Bypass disabled via prctl"
+    },
+    {
+      "field": "Vulnerability Spectre v1:",
+      "data": "Mitigation; usercopy/swapgs barriers and __user pointer sanitization"
+    },
+    {
+      "field": "Vulnerability Spectre v2:",
+      "data": "Mitigation; Retpolines; IBPB conditional; IBRS_FW; STIBP disabled; RSB filling; PBRSB-eIBRS Not affected; BHI Not affected"
+    },
+    {
+      "field": "Vulnerability Srbds:",
+      "data": "Not affected"
+    },
+    {
+      "field": "Vulnerability Tsa:",
+      "data": "Vulnerable: Clear CPU buffers attempted, no microcode"
+    },
+    {
+      "field": "Vulnerability Tsx async abort:",
+      "data": "Not affected"
+    },
+    {
+      "field": "Vulnerability Vmscape:",
+      "data": "Not affected"
+    }
+  ]
+}

--- a/packages/results/src/lib/__fixtures__/probes/disk-layout--df.json
+++ b/packages/results/src/lib/__fixtures__/probes/disk-layout--df.json
@@ -1,0 +1,38 @@
+[
+  {
+    "filesystem": "overlay",
+    "type": "overlay",
+    "size": 8482560409,
+    "used": 15728640,
+    "mounted_on": "/",
+    "available": 8482560409,
+    "use_percent": 1
+  },
+  {
+    "filesystem": "devtmpfs",
+    "type": "devtmpfs",
+    "size": 8482560409,
+    "used": 0,
+    "mounted_on": "/dev",
+    "available": 8482560409,
+    "use_percent": 0
+  },
+  {
+    "filesystem": "tmpfs",
+    "type": "tmpfs",
+    "size": 8482560409,
+    "used": 0,
+    "mounted_on": "/dev/shm",
+    "available": 8482560409,
+    "use_percent": 0
+  },
+  {
+    "filesystem": "fs0",
+    "type": "virtiofs",
+    "size": 1048576,
+    "used": 4096,
+    "mounted_on": "/run/secrets/blaxel.ai/identity",
+    "available": 1044480,
+    "use_percent": 1
+  }
+]

--- a/packages/results/src/lib/__fixtures__/probes/memory-info--free.json
+++ b/packages/results/src/lib/__fixtures__/probes/memory-info--free.json
@@ -1,0 +1,12 @@
+[
+  {
+    "type": "Mem",
+    "total": 16787812352,
+    "used": 368668672,
+    "free": 16586633216,
+    "shared": 15568896,
+    "buff_cache": 24076288,
+    "available": 16419143680
+  },
+  { "type": "Swap", "total": 0, "used": 0, "free": 0 }
+]

--- a/packages/results/src/lib/__fixtures__/probes/system-os--uname.json
+++ b/packages/results/src/lib/__fixtures__/probes/system-os--uname.json
@@ -1,0 +1,7 @@
+{
+  "kernel_name": "Linux",
+  "node_name": "sandbox",
+  "kernel_release": "6.8.0-45-generic",
+  "kernel_version": "#45-Ubuntu SMP PREEMPT_DYNAMIC",
+  "machine": "x86_64"
+}

--- a/packages/results/src/lib/specs.test.ts
+++ b/packages/results/src/lib/specs.test.ts
@@ -1,0 +1,214 @@
+/**
+ * Unit tests for specs.ts: observed-specs.json (primary) merged with the jc probe-file fallback
+ * (lscpu/free/uname/df), plus the target-spec match.
+ *
+ * The probe-file cases load real captures under __fixtures__/probes/ (copied from a Blaxel run), so the
+ * shapes mirror what the producer's `*--lscpu.json` / `*--free.json` / `*--df.json` actually carry.
+ */
+import { describe, expect, it } from "bun:test";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import type { JsonReader } from "./specs.ts";
+import { computeSpecMatched, readObservedSpecs } from "./specs.ts";
+
+const probesDir = join(import.meta.dir, "__fixtures__/probes");
+
+/** Reader over an in-memory map — undefined for any name not present (mirrors an absent file). */
+function reader(files: Record<string, unknown>): JsonReader {
+	return (name) => files[name];
+}
+
+/** Reader over the real fixture probe files on disk; `undefined` when the fixture is omitted/absent. */
+function fixtureReader(names: readonly string[]): JsonReader {
+	const present = new Set(names);
+	return (name) =>
+		present.has(name) ? JSON.parse(readFileSync(join(probesDir, name), "utf8")) : undefined;
+}
+
+const PROBE_FILES = [
+	"cpu-info--lscpu.json",
+	"memory-info--free.json",
+	"system-os--uname.json",
+	"disk-layout--df.json",
+] as const;
+
+describe("readObservedSpecs: observed-specs.json (harness-written, primary)", () => {
+	it("carries all known numeric and string fields verbatim", () => {
+		const specs = readObservedSpecs(
+			reader({
+				"observed-specs.json": {
+					vcpus: 4,
+					memoryGb: 16,
+					diskGb: 20,
+					hostVcpus: 48,
+					hostMemoryGb: 755.1,
+					cpuMhz: 2750,
+					cpuModel: "AMD EPYC 9275F 24-Core Processor",
+					kernel: "6.17.0-22-generic",
+					os: "Debian GNU/Linux 13 (trixie)",
+					virtualization: "kvm",
+					user: "root",
+				},
+			}),
+		);
+		expect(specs).toEqual({
+			vcpus: 4,
+			memoryGb: 16,
+			diskGb: 20,
+			hostVcpus: 48,
+			hostMemoryGb: 755.1,
+			cpuMhz: 2750,
+			cpuModel: "AMD EPYC 9275F 24-Core Processor",
+			kernel: "6.17.0-22-generic",
+			os: "Debian GNU/Linux 13 (trixie)",
+			virtualization: "kvm",
+			user: "root",
+		});
+	});
+
+	it("drops wrong-typed, empty-string, and unknown fields", () => {
+		const specs = readObservedSpecs(
+			reader({
+				"observed-specs.json": {
+					vcpus: "4", // numeric fields must be numbers
+					memoryGb: Number.NaN, // non-finite dropped
+					cpuModel: "", // empty strings dropped
+					kernel: 6.17, // string fields must be strings
+					os: "Ubuntu 24.04.2 LTS",
+					bogusField: 123, // unknown keys never pass through
+				},
+			}),
+		);
+		expect(specs).toEqual({ os: "Ubuntu 24.04.2 LTS" });
+	});
+
+	it("wins on overlap but lets the probes backfill the fields it didn't record", () => {
+		// observed-specs.json owns vcpus; the free probe fills the missing memoryGb instead of being ignored.
+		const specs = readObservedSpecs(
+			reader({
+				"observed-specs.json": { vcpus: 4 },
+				"memory-info--free.json": [{ type: "Mem", total: 16 * 1024 ** 3 }],
+			}),
+		);
+		expect(specs).toEqual({ vcpus: 4, memoryGb: 16 });
+	});
+
+	it("an array (or other non-object) observed-specs.json falls back to probes", () => {
+		const specs = readObservedSpecs(
+			reader({
+				"observed-specs.json": [{ vcpus: 4 }],
+				"system-os--uname.json": { kernel_release: "6.8.0-45-generic" },
+			}),
+		);
+		expect(specs).toEqual({ kernel: "6.8.0-45-generic" });
+	});
+});
+
+describe("readObservedSpecs: jc probe fallback (real fixtures)", () => {
+	it("assembles vcpus/cpuModel/virtualization, memoryGb, kernel and diskGb from the four probes", () => {
+		const specs = readObservedSpecs(fixtureReader(PROBE_FILES));
+		expect(specs.vcpus).toBe(6);
+		expect(specs.cpuModel).toBe("AMD EPYC");
+		expect(specs.virtualization).toBe("KVM");
+		expect(specs.kernel).toBe("6.8.0-45-generic");
+		expect(specs.memoryGb).toBeCloseTo(15.63, 2); // 16787812352 B → GiB
+		expect(specs.diskGb).toBeCloseTo(7.9, 2); // root "size" 8482560409 B → GiB
+	});
+
+	it("tolerates any subset of the probes being absent", () => {
+		const specs = readObservedSpecs(fixtureReader(["cpu-info--lscpu.json"]));
+		expect(specs).toEqual({ vcpus: 6, cpuModel: "AMD EPYC", virtualization: "KVM" });
+	});
+
+	it("all probes absent → empty specs (every field optional)", () => {
+		expect(readObservedSpecs(reader({}))).toEqual({});
+	});
+});
+
+describe("readObservedSpecs: jc probe fallback (edge shapes)", () => {
+	it("lscpu without CPU(s) / with zero or non-numeric counts sets no vcpus", () => {
+		for (const data of [undefined, "0", "many"]) {
+			const entries = [{ field: "Model name:", data: "Intel Xeon" }];
+			if (data !== undefined) entries.push({ field: "CPU(s):", data });
+			const specs = readObservedSpecs(reader({ "cpu-info--lscpu.json": { lscpu: entries } }));
+			expect(specs.vcpus).toBeUndefined();
+			expect(specs.cpuModel).toBe("Intel Xeon");
+		}
+	});
+
+	it("malformed lscpu payloads are tolerated", () => {
+		expect(readObservedSpecs(reader({ "cpu-info--lscpu.json": { lscpu: "x" } }))).toEqual({});
+		expect(readObservedSpecs(reader({ "cpu-info--lscpu.json": [] }))).toEqual({});
+	});
+
+	it("free without a Mem row, or non-array free, sets no memoryGb", () => {
+		expect(
+			readObservedSpecs(reader({ "memory-info--free.json": [{ type: "Swap", total: 9 }] })),
+		).toEqual({});
+		expect(
+			readObservedSpecs(reader({ "memory-info--free.json": { type: "Mem", total: 9 } })),
+		).toEqual({});
+	});
+
+	it("free Mem total converts bytes → GiB", () => {
+		const specs = readObservedSpecs(
+			reader({ "memory-info--free.json": [{ type: "Mem", total: 8322400256 }] }),
+		);
+		expect(specs.memoryGb).toBeCloseTo(7.75, 2);
+	});
+
+	it("df root mount: bytes 'size' wins, legacy KiB '1k_blocks' is the fallback, no root → no diskGb", () => {
+		// No root mount.
+		expect(
+			readObservedSpecs(reader({ "disk-layout--df.json": [{ mounted_on: "/home", size: 5 }] })),
+		).toEqual({});
+		// Modern jc df: bytes in "size".
+		expect(
+			readObservedSpecs(
+				reader({ "disk-layout--df.json": [{ mounted_on: "/", size: 20 * 1024 ** 3 }] }),
+			).diskGb,
+		).toBeCloseTo(20, 3);
+		// Legacy jc df: KiB in "1k_blocks".
+		expect(
+			readObservedSpecs(
+				reader({ "disk-layout--df.json": [{ mounted_on: "/", "1k_blocks": 10066329.6 }] }),
+			).diskGb,
+		).toBeCloseTo(9.6, 3);
+	});
+
+	it("uname without kernel_release sets no kernel", () => {
+		expect(readObservedSpecs(reader({ "system-os--uname.json": {} }))).toEqual({});
+		expect(readObservedSpecs(reader({ "system-os--uname.json": { kernel_release: "" } }))).toEqual(
+			{},
+		);
+	});
+});
+
+describe("computeSpecMatched (target: 2 vCPU / 8 GB ±10%)", () => {
+	it("undefined when vcpus or memoryGb is unobserved — no judging partial evidence", () => {
+		expect(computeSpecMatched({})).toBeUndefined();
+		expect(computeSpecMatched({ vcpus: 2 })).toBeUndefined();
+		expect(computeSpecMatched({ memoryGb: 8 })).toBeUndefined();
+		// Other fields don't substitute for the required pair.
+		expect(computeSpecMatched({ hostVcpus: 2, hostMemoryGb: 8 })).toBeUndefined();
+	});
+
+	it("exact target matches", () => {
+		expect(computeSpecMatched({ vcpus: 2, memoryGb: 8 })).toBe(true);
+	});
+
+	it("memory within ±10% still matches (kernels reserve some)", () => {
+		expect(computeSpecMatched({ vcpus: 2, memoryGb: 7.5 })).toBe(true);
+		expect(computeSpecMatched({ vcpus: 2, memoryGb: 8.5 })).toBe(true);
+	});
+
+	it("memory beyond the tolerance fails", () => {
+		expect(computeSpecMatched({ vcpus: 2, memoryGb: 4 })).toBe(false);
+		expect(computeSpecMatched({ vcpus: 2, memoryGb: 16 })).toBe(false);
+	});
+
+	it("vCPUs must match exactly", () => {
+		expect(computeSpecMatched({ vcpus: 4, memoryGb: 8 })).toBe(false);
+		expect(computeSpecMatched({ vcpus: 1, memoryGb: 8 })).toBe(false);
+	});
+});

--- a/packages/results/src/lib/specs.ts
+++ b/packages/results/src/lib/specs.ts
@@ -1,7 +1,8 @@
 /**
  * Observed specs per ProviderRun: the harness pins a target spec at create() and records
- * what the sandbox actually delivered into `observed-specs.json`. This slice reads that file; the jc
- * probe-file fallback (lscpu/free/uname/df) lands with the lifecycle path.
+ * what the sandbox actually delivered into `observed-specs.json`. That file is primary; when it is
+ * absent — or omits a field — the in-sandbox jc probe files the producer writes (lscpu/free/uname/df)
+ * backfill the EFFECTIVE side (vcpus/memoryGb/diskGb/cpuModel/kernel/virtualization).
  */
 import type { ObservedSpecs } from "@sandbox-benchmarks/schema";
 import { TARGET_SPEC } from "@sandbox-benchmarks/schema";
@@ -37,13 +38,71 @@ function fromObservedSpecsFile(raw: Record<string, unknown>): ObservedSpecs {
 	return specs;
 }
 
-/** Read the harness-written observed-specs.json, tolerating its absence (returns `{}`). */
+/**
+ * Derive the EFFECTIVE specs from the individual jc probe files (the producer's `*--lscpu.json` /
+ * `*--free.json` / `*--uname.json` / `*--df.json`). Each file is independent and optional — anything
+ * missing or malformed is simply left unset. Only the in-sandbox effective fields are filled here; the
+ * host-side fingerprint comes from the PTS `<System>` block.
+ */
+function fromProbeFiles(readJson: JsonReader): ObservedSpecs {
+	const specs: ObservedSpecs = {};
+
+	// jc lscpu: { lscpu: [{ field, data }, …] }. `CPU(s):` is the effective vCPU count inside the sandbox.
+	const lscpu = readJson("cpu-info--lscpu.json") as
+		| { lscpu?: Array<{ field?: string; data?: string }> }
+		| undefined;
+	if (Array.isArray(lscpu?.lscpu)) {
+		const field = (name: string) => lscpu.lscpu?.find((e) => e?.field === name)?.data;
+		const vcpus = Number(field("CPU(s):"));
+		if (Number.isFinite(vcpus) && vcpus > 0) specs.vcpus = vcpus;
+		const model = str(field("Model name:"));
+		if (model) specs.cpuModel = model;
+		const hypervisor = str(field("Hypervisor vendor:"));
+		if (hypervisor) specs.virtualization = hypervisor;
+	}
+
+	// jc free: array of rows; the "Mem" row's `total` is bytes → GiB.
+	const free = readJson("memory-info--free.json");
+	if (Array.isArray(free)) {
+		const mem = free.find(
+			(e) => e && typeof e === "object" && (e as { type?: unknown }).type === "Mem",
+		) as { total?: unknown } | undefined;
+		const total = num(mem?.total);
+		if (total !== undefined) specs.memoryGb = total / 1024 ** 3;
+	}
+
+	// jc uname: { kernel_release }.
+	const uname = readJson("system-os--uname.json") as { kernel_release?: unknown } | undefined;
+	const kernel = str(uname?.kernel_release);
+	if (kernel) specs.kernel = kernel;
+
+	// jc df: array; the root filesystem's size in bytes (`size`, modern jc) or KiB (`1k_blocks`, legacy) → GiB.
+	const df = readJson("disk-layout--df.json");
+	if (Array.isArray(df)) {
+		const root = df.find(
+			(e) => e && typeof e === "object" && (e as { mounted_on?: unknown }).mounted_on === "/",
+		) as Record<string, unknown> | undefined;
+		const bytes = num(root?.size);
+		const kib = num(root?.["1k_blocks"]);
+		if (bytes !== undefined) specs.diskGb = bytes / 1024 ** 3;
+		else if (kib !== undefined) specs.diskGb = (kib * 1024) / 1024 ** 3;
+	}
+
+	return specs;
+}
+
+/**
+ * Read the harness-written observed-specs.json (primary), backfilling any field it omits from the jc
+ * probe files. observed-specs.json always wins on overlap; with no usable observed-specs.json the probes
+ * stand alone. Tolerates everything being absent (returns `{}`). Signature is stable for normalize-tree.
+ */
 export function readObservedSpecs(readJson: JsonReader): ObservedSpecs {
+	const probes = fromProbeFiles(readJson);
 	const direct = readJson("observed-specs.json");
 	if (direct && typeof direct === "object" && !Array.isArray(direct)) {
-		return fromObservedSpecsFile(direct as Record<string, unknown>);
+		return { ...probes, ...fromObservedSpecsFile(direct as Record<string, unknown>) };
 	}
-	return {};
+	return probes;
 }
 
 /**


### PR DESCRIPTION
**ENG-70 host fingerprint — split into 3 focused PRs** (merge bottom-up, each independently green):
1. #82 — CPU microarch fingerprint + forensics schema
2. **#83 — effective-spec probe parser + fixtures** (this PR)
3. #72 — host-fingerprint enrichment onto the tree

↑ **This PR is 2/3**, based on #82.

---
The **effective-spec probe parser**: `specs.ts` gains `fromProbeFiles`, reading the collected host probe files (`lscpu`/`free`/`uname`/`df`) into an `ObservedSpecs`, with recorded-probe fixtures covering it. **~278 hand-written LOC** — the remaining ~229 are exempt JSON probe fixtures. The system-host wiring that joins this with the CPU fingerprint lands in #72.

**Validated locally:** `bun run typecheck` (0 errors); `@sandbox-benchmarks/results` 59 tests pass.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Merges effective sandbox specs from jc probe files with `observed-specs.json`, backfilling vCPUs, memory, disk, CPU model, kernel, and virtualization when the primary file is missing or partial. Implements ENG-70.

- **New Features**
  - Added `fromProbeFiles`; `readObservedSpecs` now merges with precedence — `observed-specs.json` wins, probes fill gaps, and probes stand alone if the file is absent or non-object.
  - Probe mapping: `lscpu` (CPU(s)→vcpus, Model name→cpuModel, Hypervisor vendor→virtualization), `free` (Mem.total bytes→GiB), `uname.kernel_release`→kernel, `df` root size (bytes `size` or KiB `1k_blocks`)→GiB.
  - Sanitizes `observed-specs.json` (drops wrong-typed/empty-string/unknown fields) and tolerates missing/malformed probe files. Adds recorded probe fixtures and edge-case tests.
  - `computeSpecMatched`: exact vCPU match; memory within ±10%; returns `undefined` if either is missing.

<sup>Written for commit 179a74beec25527a7f67c16243aa01edcc80da4f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/starslingdev/sandbox-benchmarks/pull/83?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

