### PR TITLE
feat(cli,ci): provider × suite benchmark matrix + fan-out workflow (ENG-66)

### DIFF
--- a/.github/workflows/bench-matrix.yml
+++ b/.github/workflows/bench-matrix.yml
@@ -1,0 +1,153 @@
+name: Bench matrix
+
+# Fan the live benchmark out across the full provider × suite matrix: one job per (provider, suite)
+# cell, each spinning up a real sandbox, running its suite, and uploading the normalized Run as an
+# artifact. The matrix is computed from the SUITES × PROVIDERS registries by `plan-matrix` — adding a
+# provider or suite to its registry grows CI with no workflow edit. Off the PR path (real sandbox time
+# + provider credentials); dispatch on demand.
+on:
+  workflow_dispatch:
+    inputs:
+      region:
+        # Daytona only: the default org is parked, so real runs use the ZEN5-VM region. Ignored by e2b/modal.
+        description: Daytona region
+        type: choice
+        default: ZEN5-VM
+        options: [ZEN5-VM, default]
+
+# Least privilege: jobs only read the checked-out code and upload artifacts.
+permissions:
+  contents: read
+
+# Serialize matrix runs on a ref so concurrent dispatches don't contend for provider quota.
+concurrency:
+  group: bench-matrix-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  # Compute the provider × suite matrix once, as the single $GITHUB_OUTPUT contract the fan-out reads.
+  plan:
+    name: Plan matrix
+    runs-on: ubuntu-24.04
+    outputs:
+      matrix: ${{ steps.plan.outputs.matrix }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      - name: Set up Bun
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
+        with:
+          bun-version: 1.3.14
+      - name: Install dependencies
+        run: bun install --frozen-lockfile --ignore-scripts
+      # plan-matrix prints one line of compact JSON ({"include":[...]}) — the strategy.matrix contract.
+      - name: Plan
+        id: plan
+        # Capture into a variable first so a plan-matrix.ts failure aborts the step (set -e): inlining
+        # the command substitution inside `echo` would mask its exit code behind echo's 0.
+        run: |
+          matrix="$(bun apps/cli/src/bin/plan-matrix.ts)"
+          echo "matrix=$matrix" >> "$GITHUB_OUTPUT"
+
+  bench:
+    name: ${{ matrix.suite }} on ${{ matrix.provider }}
+    needs: plan
+    runs-on: starsling-ubuntu-24.04-2
+    timeout-minutes: 150
+    strategy:
+      # One cell's failure (a flaky provider) must not cancel the rest of the matrix.
+      fail-fast: false
+      matrix: ${{ fromJSON(needs.plan.outputs.matrix) }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+
+      - name: Set up Bun
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
+        with:
+          bun-version: 1.3.14
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile --ignore-scripts
+
+      # Drive the provider SDK to create a sandbox, run the suite, collect results, and normalize. The
+      # cell's provider/suite are matrix values, passed through the environment (never interpolated into
+      # the shell) so a registry value can't inject into the runner command.
+      - name: Run suite and normalize
+        env:
+          BENCH_REPO_REF: ${{ github.sha }}
+          BENCH_REPO_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          BENCH_PROVIDER: ${{ matrix.provider }}
+          BENCH_SUITE: ${{ matrix.suite }}
+          DAYTONA_REGION: ${{ inputs.region }}
+          DAYTONA_API_KEY: ${{ secrets.DAYTONA_API_KEY }}
+          DAYTONA_API_KEY_ZEN5: ${{ secrets.DAYTONA_API_KEY_ZEN5 }}
+          DAYTONA_TARGET_ZEN5: ${{ secrets.DAYTONA_TARGET_ZEN5 }}
+          E2B_API_KEY: ${{ secrets.E2B_API_KEY }}
+          MODAL_TOKEN_ID: ${{ secrets.MODAL_TOKEN_ID }}
+          MODAL_TOKEN_SECRET: ${{ secrets.MODAL_TOKEN_SECRET }}
+        run: bun apps/cli/src/bin/bench-suite.ts "$BENCH_PROVIDER" "$BENCH_SUITE" "$GITHUB_RUN_ID"
+
+      - name: Upload Run + raw results
+        if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          # Per-cell artifact name so every (provider, suite) shard uploads independently.
+          name: bench-${{ matrix.suite }}-${{ matrix.provider }}-${{ github.run_id }}
+          path: data/
+          # A successful run always writes data/runs/<id>.json (even an all-skipped Run), so an empty
+          # data/ means the job is genuinely broken — fail the upload rather than bury a warning.
+          if-no-files-found: error
+
+  # Collect every shard Run, aggregate into one candidate, gate it (promote), and commit the published
+  # dataset. candidate→promote: aggregate is the collect half, promote the validate-and-publish half.
+  publish:
+    name: Aggregate + promote dataset
+    needs: bench
+    # Run even if some matrix cells failed (fail-fast is off) so the successful shards still publish:
+    # `aggregate` exits non-zero when zero shards are found and `promote` gates on >=1 validated
+    # provider, so the quality bar is preserved. `!cancelled()` still lets an explicit cancel stop it.
+    if: ${{ !cancelled() }}
+    runs-on: ubuntu-24.04
+    # Commit the published dataset back to the branch.
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      - name: Set up Bun
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
+        with:
+          bun-version: 1.3.14
+      - name: Install dependencies
+        run: bun install --frozen-lockfile --ignore-scripts
+
+      # Pull every per-cell shard artifact into ./shards (each in its own subdir).
+      - name: Download shard artifacts
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+        with:
+          path: shards
+          pattern: bench-*-${{ github.run_id }}
+          merge-multiple: false
+
+      # Aggregate the shards' Run documents into one candidate, then promote (gate on >=1 validated
+      # provider) and publish into the committed dataset at data/dataset/. The run-id matches the shards.
+      - name: Aggregate + promote
+        run: |
+          shopt -s nullglob
+          shards=(shards/*/data/runs/*.json)
+          if [ ${#shards[@]} -eq 0 ]; then echo "no shard Run documents found" >&2; exit 1; fi
+          bun apps/cli/src/bin/aggregate.ts "$GITHUB_RUN_ID" data/candidate "${shards[@]}"
+          bun apps/cli/src/bin/promote.ts "data/candidate/runs/$GITHUB_RUN_ID.json" data/dataset
+
+      - name: Commit the published dataset
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add data/dataset
+          if git diff --cached --quiet; then
+            echo "dataset unchanged; nothing to commit"
+          else
+            git commit -m "chore(dataset): publish run ${GITHUB_RUN_ID}"
+            git push
+          fi

--- a/.github/workflows/bench-smoke.yml
+++ b/.github/workflows/bench-smoke.yml
@@ -12,8 +12,14 @@ on:
         default: daytona
         options: [daytona, e2b, modal]
       suite:
+        # Constrained to the SUITE_NAMES registry (packages/schema/src/suites.ts); the
+        # workflow-registry-sync drift gate (tooling/repo-checks) keeps this list in lockstep, so a
+        # new suite must be added here too. Still passed through the environment below (never
+        # interpolated into the shell) as defense-in-depth.
         description: Suite to run
+        type: choice
         default: cpu-node
+        options: [cpu-node, system, memory, disk]
       region:
         # Daytona only: the default org is parked, so real runs use the ZEN5-VM region (its own API key +
         # target + snapshot, keyed by the _ZEN5 env-var suffix). Ignored by e2b/modal.
@@ -61,9 +67,10 @@ jobs:
           BENCH_REPO_REF: ${{ github.sha }}
           # The sandbox clones this private repo at the run's SHA; the short-lived job token authorizes it.
           BENCH_REPO_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          # Pass the dispatch inputs through the environment, never interpolated into the `run` script:
-          # `suite` is a free-text input, so a `${{ }}` expansion straight into the shell would let a
-          # crafted value run arbitrary commands on the self-hosted runner. `$GITHUB_RUN_ID` is built-in.
+          # Pass the dispatch inputs through the environment, never interpolated into the `run` script.
+          # `provider` and `suite` are both constrained choices, but env passthrough is kept as
+          # defense-in-depth so no input value can ever expand straight into the self-hosted runner
+          # shell. `$GITHUB_RUN_ID` is built-in.
           BENCH_PROVIDER: ${{ inputs.provider }}
           BENCH_SUITE: ${{ inputs.suite }}
           # Daytona region selection (default org is parked; ZEN5-VM is the active region).

--- a/apps/cli/README.md
+++ b/apps/cli/README.md
@@ -8,7 +8,7 @@
   `--iterations N` (cold-start cycles/provider), `--control-plane-samples N`, `--no-snapshot`. Providers
   with absent creds skip; per-Metric distributions go to stdout JSON, a timing log to stderr.
 - `bench-suite` — run the full suite across the matrix.
-- `plan-matrix` — print the benchmark matrix as **single-line compact JSON** for `$GITHUB_OUTPUT`.
+- `plan-matrix` — print the **provider × suite** benchmark matrix as **single-line compact JSON** for `$GITHUB_OUTPUT` (the `bench-matrix` workflow's fan-out contract).
 - `build-template` — build a provider's sandbox template.
 - `normalize` — turn raw runs into normalized run documents.
 - `promote` — promote normalized results to the published dataset.

--- a/apps/cli/src/bin/plan-matrix.ts
+++ b/apps/cli/src/bin/plan-matrix.ts
@@ -1,12 +1,36 @@
 #!/usr/bin/env bun
 // `plan-matrix` — emit the benchmark matrix as a SINGLE LINE of compact JSON.
 // This is the $GITHUB_OUTPUT contract: `matrix=<json>` must be one line, no pretty-printing.
+import { handleDiscovery } from "../lib/discovery.ts";
 import { buildMatrix } from "../lib/matrix.ts";
 
 export function planMatrixJson(): string {
 	return JSON.stringify({ include: buildMatrix() });
 }
 
+/** Agent-facing usage; the bare invocation stays the $GITHUB_OUTPUT matrix contract. */
+export const HELP = `plan-matrix — emit the provider × suite benchmark matrix as one line of compact JSON.
+
+usage: plan-matrix [--help] [--list-providers] [--list-suites] [--json]
+
+  (no args)          Print {"include":[{provider,suite}, …]} on a single line (the GITHUB_OUTPUT contract).
+  --list-providers   List the registered providers the matrix fans out over.
+  --list-suites      List the registered suites the matrix fans out over.
+  --json             Emit --list-* output as JSON instead of human-readable lines.
+  --help, -h         Show this help.
+
+examples:
+  plan-matrix                       # the CI matrix: echo "matrix=$(plan-matrix)" >> "$GITHUB_OUTPUT"
+  plan-matrix --list-suites --json  # the suites + their dimensions/metrics as JSON
+
+Next: run one cell with  bench-suite <provider> <suite> <runId>`;
+
 if (import.meta.main) {
+	const argv = process.argv.slice(2);
+	const discovery = handleDiscovery(argv, HELP);
+	if (discovery !== null) {
+		(discovery.ok ? console.log : console.error)(discovery.text);
+		process.exit(discovery.ok ? 0 : 2);
+	}
 	console.log(planMatrixJson());
 }

--- a/apps/cli/src/lib/matrix.ts
+++ b/apps/cli/src/lib/matrix.ts
@@ -1,20 +1,30 @@
-// Private CLI helper: builds the provider × operation benchmark matrix.
-// Imports from schema + templates so the schema → cli import chain is real, not just declared.
-import type { Capability } from "@sandbox-benchmarks/schema";
-import { capabilities } from "@sandbox-benchmarks/schema";
-import { templateProviders } from "@sandbox-benchmarks/templates";
+// Private CLI helper: builds the provider × suite benchmark matrix the CI fan-out runs.
+// Imports from schema so the schema → cli import chain is real, and both registries (PROVIDERS,
+// SUITES) are the single source of truth — the matrix can never name a provider or suite that isn't
+// registered.
+import type { ProviderId, SuiteName } from "@sandbox-benchmarks/schema";
+import { PROVIDERS, SUITE_NAMES } from "@sandbox-benchmarks/schema";
 
+/** One CI cell: a single (provider, suite) benchmark run. */
 export interface MatrixEntry {
-	provider: string;
-	operation: Capability;
+	provider: ProviderId;
+	suite: SuiteName;
 }
 
-/** Build the full benchmark matrix. Stub: cross product of providers × capabilities. */
-export function buildMatrix(providers: readonly string[] = templateProviders): MatrixEntry[] {
+/**
+ * The full benchmark matrix: every provider × every registered suite. Each cell becomes one CI job
+ * (`bench-suite <provider> <suite>`), so the dataset grows by adding a provider or a suite to its
+ * registry — never by editing the workflow. Both lists are injectable for unit tests; the defaults are
+ * the real registries.
+ */
+export function buildMatrix(
+	providers: readonly ProviderId[] = PROVIDERS.map((p) => p.id),
+	suites: readonly SuiteName[] = SUITE_NAMES,
+): MatrixEntry[] {
 	const entries: MatrixEntry[] = [];
 	for (const provider of providers) {
-		for (const operation of capabilities) {
-			entries.push({ provider, operation });
+		for (const suite of suites) {
+			entries.push({ provider, suite });
 		}
 	}
 	return entries;

--- a/apps/cli/src/plan-matrix.test.ts
+++ b/apps/cli/src/plan-matrix.test.ts
@@ -1,5 +1,7 @@
 import { describe, expect, it } from "bun:test";
-import { planMatrixJson } from "./bin/plan-matrix.ts";
+import { PROVIDERS, SUITE_NAMES } from "@sandbox-benchmarks/schema";
+import { HELP, planMatrixJson } from "./bin/plan-matrix.ts";
+import { handleDiscovery } from "./lib/discovery.ts";
 
 describe("plan-matrix", () => {
 	it("emits a single line of compact JSON (the $GITHUB_OUTPUT contract)", () => {
@@ -7,10 +9,36 @@ describe("plan-matrix", () => {
 		// Single line: no embedded newlines and no pretty-print indentation.
 		expect(out).not.toContain("\n");
 		expect(out).not.toMatch(/\n\s+/);
-		// Round-trips to a non-empty matrix.
-		const parsed = JSON.parse(out) as { include: Array<{ provider: string; operation: string }> };
-		expect(parsed.include.length).toBeGreaterThan(0);
+
+		const parsed = JSON.parse(out) as { include: Array<{ provider: string; suite: string }> };
+		// Full provider × suite cross product — one CI cell each.
+		expect(parsed.include.length).toBe(PROVIDERS.length * SUITE_NAMES.length);
 		expect(parsed.include[0]).toHaveProperty("provider");
-		expect(parsed.include[0]).toHaveProperty("operation");
+		expect(parsed.include[0]).toHaveProperty("suite");
+		// Every cell names a registered provider and a registered suite.
+		const providerIds = PROVIDERS.map((p) => p.id);
+		for (const cell of parsed.include) {
+			expect(providerIds).toContain(cell.provider as (typeof PROVIDERS)[number]["id"]);
+			expect(SUITE_NAMES).toContain(cell.suite as (typeof SUITE_NAMES)[number]);
+		}
+	});
+
+	it("exposes agent-friendly discovery: --help and --list-* listings the bin wires", () => {
+		// The bin dispatches discovery through `handleDiscovery(argv, HELP)` before its matrix path, so
+		// asserting that pairing here is the bin's discovery contract (no process spawn needed).
+		expect(handleDiscovery(["--help"], HELP)).toEqual({ text: HELP, ok: true });
+		expect(HELP).toContain("plan-matrix");
+		expect(HELP).toContain("examples:");
+
+		// Every registered provider and suite is discoverable through the bin's listings.
+		const listed = handleDiscovery(["--list-providers"], HELP)?.text ?? "";
+		for (const meta of PROVIDERS) expect(listed).toContain(meta.id);
+		const suites = JSON.parse(
+			handleDiscovery(["--list-suites", "--json"], HELP)?.text ?? "[]",
+		) as Array<{ name: string }>;
+		expect(suites.map((s) => s.name)).toEqual([...SUITE_NAMES]);
+
+		// A bare invocation has no discovery flag, so the matrix path (the GITHUB_OUTPUT contract) runs.
+		expect(handleDiscovery([], HELP)).toBeNull();
 	});
 });


### PR DESCRIPTION
**ENG-66 bench matrix — split into 3 focused PRs** (merge bottom-up, each independently green):
1. **#84 — plan-matrix CLI + fan-out workflow** (this PR)
2. #85 — workflow choice-sync gate
3. #69 — workflow credential-env gate

↑ **This PR is 1/3**, based on #68.

---
The **plan-matrix CLI** (provider × suite expansion + bin) and the `bench-matrix` / `bench-smoke` GitHub workflows that fan out and publish runs. The repo-checks gate that keeps the workflows in sync with the schema registry is split across #85 (choice-sync) and #69 (credential-env).

**Validated locally:** `bun run typecheck` (8 workspaces, 0 errors); `@sandbox-benchmarks/cli` 18 tests pass.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a provider × suite benchmark matrix with a fan-out CI that runs each cell, aggregates shard runs, and commits the published dataset. Implements `plan-matrix` wired to `@sandbox-benchmarks/schema` registries so CI grows with new providers and suites (ENG-66).

- **New Features**
  - bench-matrix workflow: dispatch-only fan-out that plans once, runs `bench-suite` per (provider, suite) on self‑hosted runners, uploads artifacts, aggregates and promotes, then commits the dataset; per‑ref concurrency; `fail-fast: false`; publishes even if some cells fail; Daytona region input supported.
  - `plan-matrix` CLI: emits single‑line `{"include":[{provider,suite}]}` for `$GITHUB_OUTPUT`; adds `--list-providers`, `--list-suites`, `--json`, `--help`; matrix builds from `PROVIDERS` and `SUITE_NAMES` in `@sandbox-benchmarks/schema`; tests cover cross‑product and discovery; README updated.
  - bench-smoke workflow: `suite` is now a registry‑backed choice (cpu-node, system, memory, disk), passed via env; keeps Daytona region input and hardens runner command handling.

- **Bug Fixes**
  - `plan-matrix` exits non‑zero on bad flags and writes errors to stderr; bench-matrix captures its output into a var before writing `$GITHUB_OUTPUT` so failures abort the plan step.

<sup>Written for commit 87e60af19b6abf2b42d599cc6acff1ec993ba6f5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/starslingdev/sandbox-benchmarks/pull/84?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

