### PR TITLE
feat(repo-checks): workflow choice-sync drift gate (ENG-66)

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -117,7 +117,9 @@
       "version": "0.0.0",
       "devDependencies": {
         "@repo/tsconfig": "workspace:*",
+        "@sandbox-benchmarks/schema": "workspace:*",
         "@types/bun": "catalog:",
+        "arktype": "catalog:",
         "typescript": "catalog:",
       },
     },

--- a/tooling/repo-checks/package.json
+++ b/tooling/repo-checks/package.json
@@ -9,6 +9,8 @@
   },
   "devDependencies": {
     "@repo/tsconfig": "workspace:*",
+    "@sandbox-benchmarks/schema": "workspace:*",
+    "arktype": "catalog:",
     "typescript": "catalog:",
     "@types/bun": "catalog:"
   }

--- a/tooling/repo-checks/src/lib/workflow-sync.ts
+++ b/tooling/repo-checks/src/lib/workflow-sync.ts
@@ -1,0 +1,151 @@
+// Drift gate: the GitHub workflows that dispatch live benchmarks must stay in lockstep with the
+// schema registries. GHA can't import TypeScript, so the provider/suite vocabulary is re-spelled by
+// hand in the workflow files; this module re-derives the truth from PROVIDERS + SUITE_NAMES
+// (packages/schema) and compares. It mirrors runner-benchmarking's check-workflow-suite-sync.ts,
+// adapted to this repo's two workflows.
+//
+// Invariants (each maps to a real "added X, forgot the workflow" failure mode):
+//   1. bench-smoke.yml's `provider` dispatch input options == the PROVIDERS id set, and its default
+//      is one of them — a new provider must be dispatchable, a removed one must not linger.
+//   2. bench-smoke.yml's `suite` dispatch input options == SUITE_NAMES, with a valid default.
+//
+// The per-provider credential-env invariants (3 + 4) build on the same parsers and land in the next
+// PR up the stack.
+//
+// Bun.YAML.parse is built into bun >= 1.3 (no new dependency), so the parse stays dependency-light.
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { PROVIDERS, SUITE_NAMES } from "@sandbox-benchmarks/schema";
+import { type } from "arktype";
+import { findRepoRoot } from "./workspace.ts";
+
+export const SMOKE_WORKFLOW = ".github/workflows/bench-smoke.yml";
+
+// Single source of truth: this schema drives BOTH the runtime parse (coercions live in the morphs)
+// and the exported DispatchInput type (inferred below) — there is no hand-written interface or
+// typeof-narrowing that could drift from the parse. onUndeclaredKey("delete") drops the fields the
+// gate ignores (description/required/…) so the parsed value is exactly what gets compared.
+const dispatchInputSchema = type({
+	// Only `type: choice` makes GitHub enforce `options`. A non-string (malformed YAML) coerces to
+	// undefined so the invariant check reports it, rather than the parse throwing.
+	"type?": type("unknown").pipe((v) => (typeof v === "string" ? v : undefined)),
+	"default?": type("unknown").pipe((v) => (typeof v === "string" ? v : undefined)),
+	// A YAML option list may carry non-string scalars; coerce each. A non-list value is rejected.
+	"options?": type("unknown[]").pipe((arr) => arr.map((o) => String(o))),
+}).onUndeclaredKey("delete");
+
+/** A single `workflow_dispatch` input, narrowed to the fields the gate compares — inferred from
+ *  {@link dispatchInputSchema} so the type and the parser can never disagree. */
+export type DispatchInput = typeof dispatchInputSchema.infer;
+
+// The workflow envelope down to the dynamic `inputs` map: validated once, with inference, so the
+// navigation is type-safe end to end instead of a hand-rolled chain of object guards. (Bun.YAML keeps
+// the GHA `on:` key as the string "on", so the YAML 1.1 boolean gotcha does not bite here.)
+const workflowEnvelope = type({
+	on: { workflow_dispatch: { inputs: { "[string]": "unknown" } } },
+});
+
+/** Parse a workflow YAML file under `root` (Bun.YAML — built-in, no dependency). */
+export function readWorkflow(relPath: string, root: string = findRepoRoot()): unknown {
+	return Bun.YAML.parse(readFileSync(join(root, relPath), "utf8"));
+}
+
+/**
+ * The `on.workflow_dispatch.inputs.<name>` entry, parsed to its {@link DispatchInput}. Throws if the
+ * envelope is malformed or the named input is missing — a renamed/removed input must fail the gate
+ * loudly, not pass vacuously.
+ */
+export function dispatchInput(doc: unknown, name: string, label: string): DispatchInput {
+	const envelope = workflowEnvelope(doc);
+	if (envelope instanceof type.errors) {
+		throw new Error(`${label}: ${envelope.summary}`);
+	}
+	const raw = envelope.on.workflow_dispatch.inputs[name];
+	if (raw === undefined) {
+		throw new Error(`${label}: workflow_dispatch input "${name}" not found`);
+	}
+	const input = dispatchInputSchema(raw);
+	if (input instanceof type.errors) {
+		throw new Error(`${label}: workflow_dispatch input "${name}" is malformed — ${input.summary}`);
+	}
+	return input;
+}
+
+/** The canonical provider ids from the schema registry. */
+export function providerIds(): string[] {
+	return PROVIDERS.map((p) => p.id);
+}
+
+/** Pure comparison of a dispatch input's options against an expected id set. */
+function checkChoiceOptions(
+	input: DispatchInput,
+	expected: string[],
+	kind: string,
+	source: string,
+	label: string,
+): string[] {
+	const errors: string[] = [];
+	// GitHub only enforces `options` for `type: choice`; under any other type (or none, which defaults
+	// to free-text `string`) a dispatched run could pass an unlisted value, so a matching options list
+	// would be cosmetic. Check this first — it's the invariant the options/default checks rest on.
+	if (input.type !== "choice") {
+		errors.push(
+			`${label}: ${kind} input is not "type: choice" (got ${input.type ? `"${input.type}"` : "no type"}) — ` +
+				`GitHub only enforces the options list for choice inputs, so a dispatched run could pass an unlisted ${kind}`,
+		);
+	}
+	if (input.options === undefined) {
+		errors.push(
+			`${label}: ${kind} input has no options list — expected a "type: choice" listing every ${kind} from ${source}`,
+		);
+		return errors;
+	}
+	const expectedSet = new Set(expected);
+	const optionSet = new Set(input.options);
+	for (const id of expectedSet) {
+		if (!optionSet.has(id)) {
+			errors.push(
+				`${label}: ${kind} input options missing "${id}" — it is in ${source}; a dispatched run can't target it`,
+			);
+		}
+	}
+	for (const opt of optionSet) {
+		if (!expectedSet.has(opt)) {
+			errors.push(
+				`${label}: ${kind} input option "${opt}" is not in ${source} — remove it or add it to the registry`,
+			);
+		}
+	}
+	// The invariant requires a default that is one of the options. A missing default — or a malformed
+	// non-string one, which dispatchInput coerces to undefined — must fail, not pass vacuously.
+	if (input.default === undefined) {
+		errors.push(
+			`${label}: ${kind} input has no valid string default — it must default to one of ${source}`,
+		);
+	} else if (!expectedSet.has(input.default)) {
+		errors.push(`${label}: ${kind} input default "${input.default}" is not in ${source}`);
+	}
+	return errors;
+}
+
+/** Invariant 1: the provider dispatch input options == the PROVIDERS id set. */
+export function checkProviderInput(input: DispatchInput, label: string = SMOKE_WORKFLOW): string[] {
+	return checkChoiceOptions(
+		input,
+		providerIds(),
+		"provider",
+		"PROVIDERS (packages/schema/src/providers.ts)",
+		label,
+	);
+}
+
+/** Invariant 2: the suite dispatch input options == SUITE_NAMES. */
+export function checkSuiteInput(input: DispatchInput, label: string = SMOKE_WORKFLOW): string[] {
+	return checkChoiceOptions(
+		input,
+		[...SUITE_NAMES],
+		"suite",
+		"SUITE_NAMES (packages/schema/src/suites.ts)",
+		label,
+	);
+}

--- a/tooling/repo-checks/src/workflow-registry-sync.test.ts
+++ b/tooling/repo-checks/src/workflow-registry-sync.test.ts
@@ -1,0 +1,123 @@
+// Invariant: the GitHub workflows that dispatch live benchmarks stay in lockstep with the schema
+// registries (PROVIDERS + SUITE_NAMES). GHA can't import TypeScript, so the provider/suite choices
+// are hand-mirrored across .github/workflows/bench-*.yml; this gate re-derives the truth from the
+// registries and fails if someone adds a provider/suite without updating the workflows. Mirrors
+// runner-benchmarking's test/workflow-suite-sync.test.ts. See ./lib/workflow-sync.ts for the parsers
+// + pure checks. The per-provider credential-env coverage lands in the next PR up the stack.
+import { describe, expect, test } from "bun:test";
+import { PROVIDERS, SUITE_NAMES } from "@sandbox-benchmarks/schema";
+import {
+	checkProviderInput,
+	checkSuiteInput,
+	dispatchInput,
+	readWorkflow,
+	SMOKE_WORKFLOW,
+} from "./lib/workflow-sync.ts";
+
+const smoke = readWorkflow(SMOKE_WORKFLOW);
+const providerInput = dispatchInput(smoke, "provider", SMOKE_WORKFLOW);
+const suiteInput = dispatchInput(smoke, "suite", SMOKE_WORKFLOW);
+
+describe("parsers against the real workflow files", () => {
+	test("dispatchInput extracts the smoke provider choice (type + options + default)", () => {
+		expect(new Set(providerInput.options)).toEqual(new Set(PROVIDERS.map((p) => p.id)));
+		expect(providerInput.default).toBeDefined();
+		// `type: choice` is what makes GitHub enforce the options — assert it's captured.
+		expect(providerInput.type).toBe("choice");
+	});
+
+	test("dispatchInput extracts the smoke suite choice", () => {
+		expect(new Set(suiteInput.options)).toEqual(new Set(SUITE_NAMES));
+		expect(suiteInput.type).toBe("choice");
+	});
+
+	test("dispatchInput throws on a missing input instead of passing vacuously", () => {
+		expect(() => dispatchInput(smoke, "no-such-input", SMOKE_WORKFLOW)).toThrow(
+			'input "no-such-input" not found',
+		);
+	});
+});
+
+describe("checkProviderInput", () => {
+	test("the real provider choice is in sync", () => {
+		expect(checkProviderInput(providerInput)).toEqual([]);
+	});
+
+	test("flags a registry provider dropped from the options", () => {
+		const drifted = {
+			...providerInput,
+			options: providerInput.options?.filter((o) => o !== "modal"),
+		};
+		const errors = checkProviderInput(drifted);
+		expect(errors).toHaveLength(1);
+		expect(errors[0]).toContain('missing "modal"');
+		expect(errors[0]).toContain("PROVIDERS");
+	});
+
+	test("flags a stray option that no provider owns", () => {
+		const drifted = { ...providerInput, options: [...(providerInput.options ?? []), "fly"] };
+		const errors = checkProviderInput(drifted);
+		expect(errors).toHaveLength(1);
+		expect(errors[0]).toContain('option "fly" is not in PROVIDERS');
+	});
+
+	test("flags a default that is not a known provider", () => {
+		const errors = checkProviderInput({ ...providerInput, default: "ghost" });
+		expect(errors).toHaveLength(1);
+		expect(errors[0]).toContain('default "ghost"');
+	});
+
+	test("flags a missing options list entirely", () => {
+		const errors = checkProviderInput({ type: "choice", default: "e2b" });
+		expect(errors).toHaveLength(1);
+		expect(errors[0]).toContain("no options list");
+	});
+
+	test("flags a missing default (the invariant requires one, not a vacuous pass)", () => {
+		const errors = checkProviderInput({ type: "choice", options: providerInput.options });
+		expect(errors).toHaveLength(1);
+		expect(errors[0]).toContain("no valid string default");
+	});
+
+	test('flags a non-choice type (options are unenforced free text unless "type: choice")', () => {
+		// Registry-matching options/default, but type: string → GitHub ignores the options list.
+		const errors = checkProviderInput({ ...providerInput, type: "string" });
+		expect(errors).toHaveLength(1);
+		expect(errors[0]).toContain('not "type: choice"');
+		expect(errors[0]).toContain('"string"');
+	});
+
+	test("flags a missing type (defaults to free-text string in GHA)", () => {
+		const errors = checkProviderInput({ ...providerInput, type: undefined });
+		expect(errors).toHaveLength(1);
+		expect(errors[0]).toContain("no type");
+	});
+});
+
+describe("checkSuiteInput", () => {
+	test("the real suite choice is in sync", () => {
+		expect(checkSuiteInput(suiteInput)).toEqual([]);
+	});
+
+	test("flags a registry suite dropped from the options", () => {
+		const [first] = SUITE_NAMES;
+		const drifted = { ...suiteInput, options: suiteInput.options?.filter((o) => o !== first) };
+		const errors = checkSuiteInput(drifted);
+		expect(errors).toHaveLength(1);
+		expect(errors[0]).toContain(`missing "${first}"`);
+		expect(errors[0]).toContain("SUITE_NAMES");
+	});
+
+	test("flags a stray suite option not in the registry", () => {
+		const drifted = { ...suiteInput, options: [...(suiteInput.options ?? []), "gpu"] };
+		const errors = checkSuiteInput(drifted);
+		expect(errors).toHaveLength(1);
+		expect(errors[0]).toContain('option "gpu" is not in SUITE_NAMES');
+	});
+
+	test("flags a non-choice suite type (shared check applies on the suite axis too)", () => {
+		const errors = checkSuiteInput({ ...suiteInput, type: "string" });
+		expect(errors).toHaveLength(1);
+		expect(errors[0]).toContain('not "type: choice"');
+	});
+});


### PR DESCRIPTION
**ENG-66 bench matrix — split into 3 focused PRs** (merge bottom-up, each independently green):
1. #84 — plan-matrix CLI + fan-out workflow
2. **#85 — workflow choice-sync gate** (this PR)
3. #69 — workflow credential-env gate

↑ **This PR is 2/3**, based on #84.

---
A repo-checks **drift gate** keeping the workflows' provider/suite dispatch choices in lockstep with the `PROVIDERS` + `SUITE_NAMES` registries (invariants 1–2), plus the YAML parse core shared with the credential-env gate in #69. Adds the schema workspace dep the gate resolves against.

**Validated locally:** `bun run typecheck` (0 errors); `@repo/repo-checks` 58 tests pass.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a repo-check that fails CI if `.github/workflows/bench-smoke.yml` provider or suite choices drift from `@sandbox-benchmarks/schema`, and enforces `type: choice` with valid defaults. Keeps `workflow_dispatch` options aligned with `PROVIDERS` and `SUITE_NAMES` (ENG-66).

- **New Features**
  - Adds `workflow-sync` core: `readWorkflow`, `dispatchInput`, `checkProviderInput`, `checkSuiteInput`; parses with Bun YAML and `arktype`-typed schema.
  - Compares workflow options to registry data; reports missing/extra options and throws on missing inputs.

- **Bug Fixes**
  - Fails when inputs aren’t `type: choice`, lack an options list, or have an invalid/missing default.

<sup>Written for commit 03fb6df71a29d3101c6035e802230bef8cfbea46. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/starslingdev/sandbox-benchmarks/pull/85?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added workflow synchronization validation for smoke workflows, ensuring `workflow_dispatch` provider/suite inputs stay aligned with the current registry of providers and suite names.
* **Tests**
  * Introduced a Bun test suite that parses real workflow YAML and verifies both option lists and required `choice`/default invariants, including drift and misconfiguration cases.
* **Chores**
  * Updated tooling dependencies to support schema-driven workflow validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->