### PR TITLE
ci: actionlint + zizmor lint workflow + persist-credentials hardening

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -1,0 +1,7 @@
+# actionlint configuration. The only custom entry is the self-hosted runner label every CI job
+# targets: `starsling-ubuntu-24.04-2` is registered at the org (starslingdev) level, not in
+# actionlint's built-in label set, so without this entry actionlint flags every `runs-on:` as an
+# unknown label. Keep this list in sync with the labels used across .github/workflows/.
+self-hosted-runner:
+  labels:
+    - starsling-ubuntu-24.04-2

--- a/.github/workflows/bench-matrix.yml
+++ b/.github/workflows/bench-matrix.yml
@@ -34,6 +34,9 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          # Planning only reads code; don't persist the job token in .git/config.
+          persist-credentials: false
       - name: Set up Bun
         uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
         with:
@@ -61,6 +64,10 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          # This cell only reads code (the sandbox clones via BENCH_REPO_TOKEN, not the checkout's
+          # credentials), so don't persist the job token in .git/config.
+          persist-credentials: false
 
       - name: Set up Bun
         uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
@@ -113,6 +120,9 @@ jobs:
     permissions:
       contents: write
     steps:
+      # Unlike the read-only jobs above, this one commits + `git push`es the published dataset, so it
+      # keeps the default persisted job token (contents: write above authorizes it). Don't add
+      # persist-credentials: false here or the push at the end of the job loses its credentials.
       - name: Checkout
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       - name: Set up Bun

--- a/.github/workflows/bench-smoke.yml
+++ b/.github/workflows/bench-smoke.yml
@@ -47,6 +47,10 @@ jobs:
       # moved/compromised tag can't silently change what runs.
       - name: Checkout
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          # The job only reads code (the sandbox clones via BENCH_REPO_TOKEN, not the checkout's
+          # credentials), so don't persist the job token in .git/config.
+          persist-credentials: false
 
       - name: Set up Bun
         uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0

--- a/.github/workflows/ci-lint.yml
+++ b/.github/workflows/ci-lint.yml
@@ -1,0 +1,95 @@
+name: CI Lint
+
+# Lints the GitHub Actions layer itself — the workflows under .github/workflows:
+#   - actionlint: workflow syntax, expressions, runner labels (via the .github/actionlint.yaml
+#     self-hosted-runner registry) and the shell embedded in `run:` steps (embedded shellcheck).
+#   - zizmor: workflow security audits (template injection, credential persistence, excessive
+#     permissions, ...). Accepted findings live in .github/zizmor.yml.
+# Both linters are version-pinned in mise.toml (aqua backend, checksum + attestation verified) and
+# installed by the mise step below — the same supply-chain posture as the rest of the repo's tooling.
+on:
+  push:
+    branches: [main]
+    paths:
+      - ".github/**"
+      - "mise.toml"
+  pull_request:
+    paths:
+      - ".github/**"
+      - "mise.toml"
+
+# One in-flight run per ref — a new push cancels the previous, still-running lint for that branch.
+concurrency:
+  group: ci-lint-${{ github.ref }}
+  cancel-in-progress: true
+
+# Least privilege: the linters only read the checked-out workflows (zizmor's online audits use the
+# read-only job token).
+permissions:
+  contents: read
+
+jobs:
+  actionlint:
+    name: Lint workflows (actionlint)
+    runs-on: starsling-ubuntu-24.04-2
+    timeout-minutes: 10
+    # The runner is self-hosted, so never execute untrusted fork-PR code on it: run only for pushes
+    # and pull requests whose head is this same repository (fork PRs are skipped).
+    if: >-
+      github.event_name == 'push' ||
+      github.event.pull_request.head.repo.full_name == github.repository
+    steps:
+      # Third-party actions are pinned to a commit SHA (the tag comment is for humans only) so a
+      # moved/compromised tag can't silently change what runs.
+      - name: Checkout
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          # The linter only reads the workflows; never persist the job token in .git/config.
+          persist-credentials: false
+
+      # Installs the version-pinned tools from mise.toml (actionlint + shellcheck for actionlint's
+      # embedded shell check) with checksum verification, and caches them.
+      - name: Set up mise tools
+        uses: jdx/mise-action@dba19683ed58901619b14f395a24841710cb4925 # v4.1.0
+        with:
+          version: 2026.5.16
+          install: true
+          cache: true
+
+      # With no path args actionlint scans .github/workflows automatically; .github/actionlint.yaml
+      # (the self-hosted runner registry) is picked up from the repo root. shellcheck comes from mise,
+      # so actionlint's embedded shell linting runs against the same pinned version as `lint:shell`.
+      - name: Run actionlint
+        run: mise exec -- actionlint -no-color
+
+  zizmor:
+    name: Audit workflows (zizmor)
+    runs-on: starsling-ubuntu-24.04-2
+    timeout-minutes: 10
+    if: >-
+      github.event_name == 'push' ||
+      github.event.pull_request.head.repo.full_name == github.repository
+    steps:
+      - name: Checkout
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
+
+      - name: Set up mise tools
+        uses: jdx/mise-action@dba19683ed58901619b14f395a24841710cb4925 # v4.1.0
+        with:
+          version: 2026.5.16
+          install: true
+          cache: true
+
+      # Gate on findings zizmor is confident about (medium+ severity at high confidence) so the job
+      # fails only on real, actionable findings; lower-confidence audits stay visible locally without
+      # blocking CI. Accepted findings: .github/zizmor.yml. github.token enables the online audits
+      # (known-vulnerable-actions, impostor-commit, ref-confusion) zizmor skips when offline.
+      - name: Run zizmor
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          mise exec -- zizmor --no-progress --persona regular \
+            --min-severity medium --min-confidence high \
+            .github/workflows/

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,6 +30,9 @@ jobs:
       # moved/compromised tag can't silently change what runs in CI.
       - name: Checkout
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          # The gate only reads code (it never pushes), so don't leave the job token in .git/config.
+          persist-credentials: false
 
       - name: Set up Bun
         uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0

--- a/.github/workflows/toolchain-image.yml
+++ b/.github/workflows/toolchain-image.yml
@@ -61,6 +61,9 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          # Builds and smokes the image locally — no git push, so don't persist the job token.
+          persist-credentials: false
       - name: Set up Bun
         uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
         with:
@@ -98,6 +101,10 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          # Publishes to GHCR via docker/login-action (the GITHUB_TOKEN below), never `git push`, so
+          # the checkout's own credentials aren't needed — don't persist the job token.
+          persist-credentials: false
       - name: Set up Bun
         uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
         with:
@@ -193,7 +200,9 @@ jobs:
           MODAL_TOKEN_SECRET: ${{ secrets.MODAL_TOKEN_SECRET }}
         run: |
           set -euo pipefail
-          export BUILD_DATE="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+          # Declare then assign so the command substitution's exit status isn't masked (SC2155).
+          BUILD_DATE="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+          export BUILD_DATE
           # --require fails the publish loudly if any provider's secret is missing/misnamed, so a merge
           # can't bless a candidate while a provider was silently skipped (never built or validated).
           bun apps/cli/src/bin/bake.ts --build-push --require e2b,daytona,modal

--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -1,0 +1,12 @@
+# ci-lint.yml runs zizmor with `--min-severity medium --min-confidence high`; only findings zizmor is
+# confident about block CI. The ignores below accept specific findings — never blanket-disable an audit
+# repo-wide, and always record why the finding is accepted.
+rules:
+  artipacked:
+    ignore:
+      # bench-matrix.yml's `publish` job is the one checkout that must keep its persisted job token:
+      # it commits the promoted dataset and `git push`es it back to the branch (the job grants
+      # `contents: write` for exactly this). Every other checkout in the repo sets
+      # persist-credentials: false; this one can't, by design. (Filename-scoped, not repo-wide — the
+      # other checkouts in this file already opt out, so only the publish-job finding is accepted.)
+      - bench-matrix.yml

--- a/.gitignore
+++ b/.gitignore
@@ -112,6 +112,14 @@ dist
 # TernJS port file
 .tern-port
 
+# Claude Code agent/harness state (skills, workflows, settings) — machine-local, not repo source.
+.claude/
+
+# Local benchmark outputs are transient (per-run raw trees + the local run index). The PUBLISHED
+# dataset lives under data/dataset/ and is committed by the promote step, so it is NOT ignored.
+data/raw/
+data/runs/
+
 # Generated from packages/templates/src/pins.ts by build.sh / the publish workflow (the
 # e2b CLI requires this file on disk; the TypeScript config is its single source of truth).
 packages/templates/images/e2b/e2b.toml

--- a/mise.toml
+++ b/mise.toml
@@ -10,3 +10,9 @@ typos = "1.47.2"
 # so nothing runs a postinstall or needs Bun `trustedDependencies`.
 "aqua:koalaman/shellcheck" = "0.11.0"
 "aqua:hadolint/hadolint" = "2.14.0"
+# GitHub Actions linters for the ci-lint workflow: actionlint checks workflow syntax, expressions and
+# runner labels (via .github/actionlint.yaml) plus embedded shellcheck; zizmor security-audits the
+# workflows (template injection, excessive permissions, ...). aqua backend with checksum + attestation
+# verification — same posture as the tools above, so nothing runs a postinstall.
+"aqua:rhysd/actionlint" = "1.7.12"
+"aqua:zizmorcore/zizmor" = "1.26.1"


### PR DESCRIPTION
**CI hardening — split into 3 focused PRs** (merge bottom-up, each independently green):
1. **#86 — ci-lint workflow + persist-credentials hardening** (this PR)
2. #87 — persist-credentials gate
3. #70 — ci-lint threshold gate

↑ **This PR is 1/3**, based on #69.

---
The **ci-lint workflow** (actionlint + zizmor at the agreed threshold), its config (`zizmor.yml`, `actionlint.yaml`, `mise.toml`), and the `persist-credentials: false` opt-outs across the existing workflows. The repo-checks gates that enforce these land in #87 and #70.

**Validated locally:** `bun run typecheck` (0 errors). Config/YAML only — no test surface; enforced by the gates above it.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a `ci-lint` workflow that runs `actionlint` and `zizmor` on our GitHub workflows, and hardens CI by disabling credential persistence on read‑only jobs. Only the `bench-matrix` publish step keeps push credentials.

- **New Features**
  - Add `ci-lint.yml` to lint `.github/workflows/` with `contents: read`, concurrency, and same‑repo PR gating on self‑hosted runners; `zizmor` fails only on medium+ severity at high confidence and uses `GH_TOKEN` for online audits.
  - Pin `actionlint`, `zizmor`, and `shellcheck` in `mise.toml` via `jdx/mise-action`. Add `.github/actionlint.yaml` with `starsling-ubuntu-24.04-2` and `.github/zizmor.yml` to accept the `bench-matrix` publish checkout.

- **Refactors**
  - Set `persist-credentials: false` for read‑only `actions/checkout` in `bench-matrix`, `bench-smoke`, `ci`, and `toolchain-image`; leave it enabled only for `bench-matrix` publish.
  - Fix `BUILD_DATE` export in `toolchain-image.yml`; ignore `.claude/`, `data/raw/`, and `data/runs/` in `.gitignore`.

<sup>Written for commit 1ebc517cf12a602685f1a5d1a325c88d522efd15. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/starslingdev/sandbox-benchmarks/pull/86?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

