### PR TITLE
feat(repo-checks): persist-credentials hardening gate (ENG)

### DIFF
--- a/tooling/repo-checks/src/lib/workflow-hardening.ts
+++ b/tooling/repo-checks/src/lib/workflow-hardening.ts
@@ -1,0 +1,128 @@
+// Drift gate: the security posture of the GitHub Actions layer. The persist-credentials invariant the
+// .github/ files must hold, which the type system can't enforce (GHA is YAML):
+//
+//   1. persist-credentials hygiene — every `actions/checkout` step sets `persist-credentials: false`
+//      UNLESS it is one of the few jobs that later `git push`es (it needs the persisted job token).
+//      The pushing checkouts are enumerated in CREDENTIALED_CHECKOUTS with provenance; the gate fails
+//      both when a read-only checkout forgets the opt-out AND when a pushing checkout is in the
+//      allowlist but no longer exists / no longer keeps its token (so the allowlist can't rot).
+//
+// The ci-lint threshold invariant (ci-lint.yml runs actionlint + zizmor at the agreed gate) builds on
+// the same parse core and lands in the next PR up the stack.
+//
+// Mirrors runner-benchmarking's ci-lint.yml + zizmor.yml hardening, adapted to this repo's workflows.
+// Bun.YAML.parse is built into bun >= 1.3 (no new dependency).
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { Glob } from "bun";
+import { findRepoRoot } from "./workspace.ts";
+
+export const WORKFLOWS_DIR = ".github/workflows";
+
+/** Checkout steps that intentionally keep the persisted job token, keyed "<file>::<jobId>", with the
+ *  reason they push. Every other `actions/checkout` must set persist-credentials: false. */
+export const CREDENTIALED_CHECKOUTS: Readonly<Record<string, string>> = {
+	// bench-matrix.yml's publish job commits the promoted dataset and `git push`es it back to the
+	// branch (it grants `contents: write` for exactly this), so it must keep the persisted token.
+	"bench-matrix.yml::publish": "commits + pushes the promoted dataset back to the branch",
+};
+
+function asRecord(value: unknown, message: string): Record<string, unknown> {
+	if (value === null || typeof value !== "object" || Array.isArray(value)) {
+		throw new Error(message);
+	}
+	return value as Record<string, unknown>;
+}
+
+/** Parse a workflow YAML file under `root` (Bun.YAML — built-in, no dependency). */
+export function readWorkflow(relPath: string, root: string = findRepoRoot()): unknown {
+	return Bun.YAML.parse(readFileSync(join(root, relPath), "utf8"));
+}
+
+/** The workflow file names (e.g. "ci.yml") under .github/workflows, sorted. */
+export function listWorkflowFiles(root: string = findRepoRoot()): string[] {
+	const glob = new Glob("*.{yml,yaml}");
+	return [...glob.scanSync({ cwd: join(root, WORKFLOWS_DIR), onlyFiles: true })].sort();
+}
+
+/** One `actions/checkout` step found while walking a workflow's jobs. */
+export interface CheckoutStep {
+	/** Workflow file name, e.g. "ci.yml". */
+	file: string;
+	/** The job the step lives in. */
+	jobId: string;
+	/** The step's `with.persist-credentials` value (undefined if no `with`/key). */
+	persistCredentials: boolean | undefined;
+}
+
+/** Every `actions/checkout` step in a parsed workflow, with its persist-credentials setting. */
+export function checkoutSteps(doc: unknown, file: string): CheckoutStep[] {
+	const root = asRecord(doc, `${file}: not a YAML mapping`);
+	const jobs = asRecord(root.jobs, `${file}: no jobs mapping`);
+	const found: CheckoutStep[] = [];
+	for (const [jobId, jobValue] of Object.entries(jobs)) {
+		const job = asRecord(jobValue, `${file}: job "${jobId}" is not a mapping`);
+		const steps = job.steps;
+		if (!Array.isArray(steps)) continue;
+		for (const stepValue of steps) {
+			const step = asRecord(stepValue, `${file}: job "${jobId}" has a malformed step`);
+			const uses = step.uses;
+			if (typeof uses !== "string" || !uses.startsWith("actions/checkout@")) continue;
+			// An empty `with:` block parses as null (not undefined); treat both as "no inputs" so a
+			// valid workflow with a bare `with:` doesn't crash the gate in asRecord.
+			const withBlock =
+				step.with === undefined || step.with === null
+					? {}
+					: asRecord(step.with, `${file}: malformed with`);
+			// YAML may carry the value as a boolean (`false`) or a quoted string (`"false"`); accept both
+			// so a string-typed opt-out isn't misread as "unset" and wrongly flagged by the gate.
+			const pc = withBlock["persist-credentials"];
+			const persistCredentials =
+				typeof pc === "boolean" ? pc : pc === "true" ? true : pc === "false" ? false : undefined;
+			found.push({ file, jobId, persistCredentials });
+		}
+	}
+	return found;
+}
+
+/**
+ * Invariant 1: read-only checkouts opt out of credential persistence; pushing checkouts (the
+ * allowlist) keep it. `steps` is the flattened list across all workflows; `allowlist` maps
+ * "<file>::<jobId>" to the reason it pushes.
+ */
+export function checkPersistCredentials(
+	steps: CheckoutStep[],
+	allowlist: Readonly<Record<string, string>> = CREDENTIALED_CHECKOUTS,
+): string[] {
+	const errors: string[] = [];
+	const seen = new Set<string>();
+	for (const step of steps) {
+		const key = `${step.file}::${step.jobId}`;
+		seen.add(key);
+		if (key in allowlist) {
+			// A pushing checkout must NOT opt out, or its later `git push` loses its credentials.
+			if (step.persistCredentials === false) {
+				errors.push(
+					`${key}: sets persist-credentials: false but is allowlisted as a pushing checkout ` +
+						`(${allowlist[key]}) — the push would lose its token; remove it from the allowlist or the opt-out`,
+				);
+			}
+			continue;
+		}
+		if (step.persistCredentials !== false) {
+			errors.push(
+				`${key}: actions/checkout must set persist-credentials: false (it does not push) — ` +
+					`add it under \`with:\`, or list "${key}" in CREDENTIALED_CHECKOUTS if it pushes`,
+			);
+		}
+	}
+	// The allowlist can't rot: every entry must name a checkout that still exists.
+	for (const key of Object.keys(allowlist)) {
+		if (!seen.has(key)) {
+			errors.push(
+				`${key}: listed in CREDENTIALED_CHECKOUTS but no such checkout step exists — remove the stale entry`,
+			);
+		}
+	}
+	return errors;
+}

--- a/tooling/repo-checks/src/workflow-hardening.test.ts
+++ b/tooling/repo-checks/src/workflow-hardening.test.ts
@@ -1,0 +1,91 @@
+// Invariant: the GitHub Actions layer stays hardened — every actions/checkout opts out of credential
+// persistence unless it is an allowlisted pushing checkout. This is unit coverage of the pure checks
+// on synthetic drift (so a regression names the offender) plus a sanity read of the real workflows.
+// The ci-lint threshold coverage and the runHardeningCheck() real-file gate land in the next PR up the
+// stack. See ./lib/workflow-hardening.ts.
+import { describe, expect, test } from "bun:test";
+import type { CheckoutStep } from "./lib/workflow-hardening.ts";
+import {
+	checkoutSteps,
+	checkPersistCredentials,
+	listWorkflowFiles,
+	readWorkflow,
+	WORKFLOWS_DIR,
+} from "./lib/workflow-hardening.ts";
+
+describe("checkoutSteps against the real workflows", () => {
+	test("every workflow's checkouts are extracted with a persist-credentials reading", () => {
+		const files = listWorkflowFiles();
+		expect(files).toContain("ci.yml");
+		expect(files).toContain("ci-lint.yml");
+		const steps = files.flatMap((file) =>
+			checkoutSteps(readWorkflow(`${WORKFLOWS_DIR}/${file}`, undefined), file),
+		);
+		// Sanity: there are several checkouts and ci.yml's reads false.
+		expect(steps.length).toBeGreaterThanOrEqual(5);
+		const ci = steps.find((s) => s.file === "ci.yml");
+		expect(ci?.persistCredentials).toBe(false);
+	});
+
+	test("reads persist-credentials whether YAML types it as a boolean or a quoted string", () => {
+		const doc = {
+			jobs: {
+				j: {
+					steps: [
+						{ uses: "actions/checkout@v4", with: { "persist-credentials": false } },
+						{ uses: "actions/checkout@v4", with: { "persist-credentials": "false" } },
+						{ uses: "actions/checkout@v4", with: { "persist-credentials": "true" } },
+					],
+				},
+			},
+		};
+		expect(checkoutSteps(doc, "synthetic.yml").map((s) => s.persistCredentials)).toEqual([
+			false,
+			false,
+			true,
+		]);
+	});
+});
+
+describe("checkPersistCredentials", () => {
+	const allowlist = { "bench-matrix.yml::publish": "pushes the dataset" };
+
+	test("passes when read-only checkouts opt out and the pushing one keeps its token", () => {
+		const steps: CheckoutStep[] = [
+			{ file: "ci.yml", jobId: "check", persistCredentials: false },
+			{ file: "bench-matrix.yml", jobId: "plan", persistCredentials: false },
+			{ file: "bench-matrix.yml", jobId: "publish", persistCredentials: undefined },
+		];
+		expect(checkPersistCredentials(steps, allowlist)).toEqual([]);
+	});
+
+	test("flags a read-only checkout that forgot persist-credentials: false", () => {
+		const steps: CheckoutStep[] = [
+			{ file: "ci.yml", jobId: "check", persistCredentials: undefined },
+		];
+		const errors = checkPersistCredentials(steps, {});
+		expect(errors).toHaveLength(1);
+		expect(errors[0]).toContain("ci.yml::check");
+		expect(errors[0]).toContain("persist-credentials: false");
+	});
+
+	test("flags a checkout that sets persist-credentials: true explicitly", () => {
+		const steps: CheckoutStep[] = [{ file: "ci.yml", jobId: "check", persistCredentials: true }];
+		expect(checkPersistCredentials(steps, {})).toHaveLength(1);
+	});
+
+	test("flags an allowlisted pushing checkout that opted out (its push would break)", () => {
+		const steps: CheckoutStep[] = [
+			{ file: "bench-matrix.yml", jobId: "publish", persistCredentials: false },
+		];
+		const errors = checkPersistCredentials(steps, allowlist);
+		expect(errors).toHaveLength(1);
+		expect(errors[0]).toContain("allowlisted as a pushing checkout");
+	});
+
+	test("flags a stale allowlist entry with no matching checkout", () => {
+		const errors = checkPersistCredentials([], allowlist);
+		expect(errors).toHaveLength(1);
+		expect(errors[0]).toContain("no such checkout step exists");
+	});
+});


### PR DESCRIPTION
**CI hardening — split into 3 focused PRs** (merge bottom-up, each independently green):
1. #86 — ci-lint workflow + persist-credentials hardening
2. **#87 — persist-credentials gate** (this PR)
3. #70 — ci-lint threshold gate

↑ **This PR is 2/3**, based on #86.

---
A repo-checks gate enforcing **persist-credentials hygiene** — every `actions/checkout` opts out of credential persistence unless it is an allowlisted pushing checkout, with an anti-rot check so the allowlist can't reference a vanished step. The ci-lint threshold invariant builds on the same parse core in #70.

**Validated locally:** `bun run typecheck` (0 errors); `@repo/repo-checks` 71 tests pass.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a repo-checks gate that enforces `persist-credentials` hygiene in GitHub Actions. It scans `.github/workflows` for `actions/checkout`, blocks unsafe uses, and catches stale allowlist entries.

- **New Features**
  - Parse workflows with `Bun.YAML` to read each checkout’s `with.persist-credentials`, and enforce: non-pushing checkouts set `false`; allowlisted pushing jobs keep it and must exist.

- **Bug Fixes**
  - Read `persist-credentials` when YAML types it as a boolean or a string, and handle an empty `with:` block.
  - Make `CREDENTIALED_CHECKOUTS` and the allowlist arg `Readonly` to prevent mutation.

<sup>Written for commit cf2077ad399b7b666d0d3336ee88bd7060fdab91. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/starslingdev/sandbox-benchmarks/pull/87?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

