### PR TITLE
ci: disable setup-bun cache (restores without a working bun binary)

### DIFF
--- a/.github/workflows/bench-smoke.yml
+++ b/.github/workflows/bench-smoke.yml
@@ -46,6 +46,9 @@ jobs:
         uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
         with:
           bun-version: 1.3.14
+          # This runner's setup-bun cache restores without a working ~/.bun/bin/bun, so a cache hit
+          # fails the "Set up Bun" step. Always download bun fresh instead of restoring the cache.
+          no-cache: true
 
       # Frozen lockfile + no lifecycle scripts, matching bunfig.toml's supply-chain posture.
       - name: Install dependencies

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,6 +36,9 @@ jobs:
         with:
           # Pinned to the toolchain version the repo develops against.
           bun-version: 1.3.14
+          # This runner's setup-bun cache restores without a working ~/.bun/bin/bun, so a cache hit
+          # fails the "Set up Bun" step. Always download bun fresh instead of restoring the cache.
+          no-cache: true
 
       # Installs the version-pinned tools from mise.toml (typos) with checksum verification, and
       # caches them. mise itself is version-pinned for reproducibility.

--- a/.github/workflows/toolchain-image.yml
+++ b/.github/workflows/toolchain-image.yml
@@ -65,6 +65,9 @@ jobs:
         uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
         with:
           bun-version: 1.3.14
+          # This runner's setup-bun cache restores without a working ~/.bun/bin/bun, so a cache hit
+          # fails the "Set up Bun" step. Always download bun fresh instead of restoring the cache.
+          no-cache: true
       - name: Install dependencies
         run: bun install --frozen-lockfile --ignore-scripts
       - name: Set up Docker Buildx
@@ -99,6 +102,9 @@ jobs:
         uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
         with:
           bun-version: 1.3.14
+          # This runner's setup-bun cache restores without a working ~/.bun/bin/bun, so a cache hit
+          # fails the "Set up Bun" step. Always download bun fresh instead of restoring the cache.
+          no-cache: true
       - name: Install dependencies
         run: bun install --frozen-lockfile --ignore-scripts
       - name: Set up Docker Buildx


### PR DESCRIPTION
The starsling-ubuntu-24.04-2 runner's oven-sh/setup-bun cache restores a tarball that lacks ~/.bun/bin/bun, so any cache *hit* fails the 'Set up Bun' step with 'Unable to locate executable file'. A cache *miss* passes (fresh download) but then re-saves the same broken cache, so the failure recurs for every subsequent run. Set no-cache: true on all four setup-bun steps (ci, bench-smoke, toolchain-image ×2) to always download bun fresh. Sits at the base of the stack so every branch's CI inherits it.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Disable `oven-sh/setup-bun` cache to avoid restoring a broken tarball that lacks `~/.bun/bin/bun`. Always download Bun fresh to prevent "Unable to locate executable file" failures.

- **Bug Fixes**
  - Set `no-cache: true` for all `setup-bun` steps in `.github/workflows/ci.yml`, `.github/workflows/bench-smoke.yml`, and both jobs in `.github/workflows/toolchain-image.yml`.

<sup>Written for commit 3233984511d3f61f771cd0529ec372c1e08146da. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/starslingdev/sandbox-benchmarks/pull/88?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved workflow reliability by ensuring Bun is downloaded fresh during setup, avoiding failures from incomplete cache restores.
  * Applied the fix consistently across benchmark, CI, and toolchain image workflows to reduce setup-related job interruptions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->