### PR TITLE
fix(results): tolerate a fully-failed PTS Result instead of throwing

### DIFF
--- a/packages/results/src/lib/__fixtures__/partial-failure/pts_node-web-tooling.xml
+++ b/packages/results/src/lib/__fixtures__/partial-failure/pts_node-web-tooling.xml
@@ -1,0 +1,43 @@
+<?xml version="1.0"?>
+<!--Captured from a Docker PTS smoke test: a two-Option batch-run where one Option's every pass
+failed. PTS still emits a <Result> for the failed Option, with an empty <Value>/<RawString> and a
+JSON error field, rather than omitting it -- the shape parsePtsComposite (pts-schema.ts) must
+tolerate instead of throwing on. See extract.test.ts "skips a Result whose every pass failed".-->
+<PhoronixTestSuite>
+  <Generated>
+    <TestClient>Phoronix Test Suite v10.8.4</TestClient>
+  </Generated>
+  <Result>
+    <Identifier>pts/node-web-tooling-1.0.1</Identifier>
+    <Title>Node.js V8 Web Tooling Benchmark</Title>
+    <AppVersion></AppVersion>
+    <Arguments>ok</Arguments>
+    <Description>Task: OK Task</Description>
+    <Scale>runs/s</Scale>
+    <Proportion>HIB</Proportion>
+    <Data>
+      <Entry>
+        <Identifier>ci</Identifier>
+        <Value>20.5</Value>
+        <RawString>20.5</RawString>
+      </Entry>
+    </Data>
+  </Result>
+  <Result>
+    <Identifier>pts/node-web-tooling-1.0.1</Identifier>
+    <Title>Node.js V8 Web Tooling Benchmark</Title>
+    <AppVersion></AppVersion>
+    <Arguments>fail</Arguments>
+    <Description>Task: Fail Task</Description>
+    <Scale>runs/s</Scale>
+    <Proportion>HIB</Proportion>
+    <Data>
+      <Entry>
+        <Identifier>ci</Identifier>
+        <Value></Value>
+        <RawString></RawString>
+        <JSON>{"error":"The test quit with a non-zero exit status."}</JSON>
+      </Entry>
+    </Data>
+  </Result>
+</PhoronixTestSuite>

--- a/packages/results/src/lib/extract.test.ts
+++ b/packages/results/src/lib/extract.test.ts
@@ -39,4 +39,16 @@ describe("extractProviderDir", () => {
 			},
 		]);
 	});
+
+	it("skips a Result whose every pass failed instead of throwing, keeping the successful one", () => {
+		const dir = join(import.meta.dir, "__fixtures__/partial-failure");
+		expect(extractProviderDir(dir, "daytona").contributions).toEqual([
+			{
+				metricId: "node_web_tooling_runs_per_s",
+				samples: [20.5],
+				sourceFile: "pts_node-web-tooling.xml",
+				arguments: "ok",
+			},
+		]);
+	});
 });

--- a/packages/results/src/lib/extract.ts
+++ b/packages/results/src/lib/extract.ts
@@ -66,11 +66,12 @@ export function extractProviderDir(dir: string, providerId: string): ProviderExt
 				if (Object.keys(host).length > 0) out.observedHost = host;
 			}
 			for (const result of composite.PhoronixTestSuite.Result) {
-				// A <Result> with no <Entry> carries no measurement — no sample to aggregate and no
-				// headline value to report. Skip it rather than emit a zero-sample contribution (which
-				// would throw in the normalizer's aggregate([])) or fabricate a 0-valued straggler.
+				// A <Result> with no <Entry>, or one whose every pass failed (empty <Value> — pts-schema.ts
+				// treats that as "no measurement", not a parse error), carries no sample to aggregate and no
+				// headline value to report. Skip it rather than emit a zero-sample contribution (which would
+				// throw in the normalizer's aggregate([])) or fabricate a 0-valued straggler.
 				const headEntry = result.Data.Entry[0];
-				if (!headEntry) continue;
+				if (!headEntry || headEntry.Value === undefined) continue;
 				const mapped = ptsResultToMetric(result);
 				switch (mapped.kind) {
 					case "matched":

--- a/packages/results/src/lib/pts-schema.ts
+++ b/packages/results/src/lib/pts-schema.ts
@@ -28,11 +28,23 @@ const sampleList = type("string").pipe((raw, ctx) => {
 	return out;
 });
 
+// PTS writes the value as text; the schema is where it becomes a number (the parser stays dumb). When
+// every pass of a `<Result>` fails (a real command erroring — expected for realworld CI tasks, not
+// just synthetic PTS microbenchmarks), PTS still emits the `<Result>` but with an empty `<Value>`
+// rather than omitting it. Treated as "no measurement" (undefined), not a parse failure, so one failed
+// option can't throw away every other `<Result>` in the same composite.xml.
+const numericParse = type("string.numeric.parse");
+const entryValue = type("string").pipe((raw, ctx) => {
+	if (raw.trim() === "") return undefined;
+	const parsed = numericParse(raw);
+	if (parsed instanceof type.errors) return ctx.error("a well-formed numeric string");
+	return parsed;
+});
+
 /** One `<Entry>`: a single measured value plus the per-pass samples that produced it. */
 const ptsEntry = type({
 	"Identifier?": "string",
-	// PTS writes the value as text; the schema is where it becomes a number (the parser stays dumb).
-	Value: "string.numeric.parse",
+	Value: entryValue,
 	// Per-pass samples, parsed string → validated number[] here (see {@link sampleList}).
 	"RawString?": sampleList,
 });

--- a/packages/results/src/lib/pts.test.ts
+++ b/packages/results/src/lib/pts.test.ts
@@ -55,6 +55,19 @@ describe("parsePtsComposite", () => {
 		);
 	});
 
+	it("tolerates a Result whose every pass failed (empty <Value>) instead of throwing", () => {
+		// PTS doesn't omit a fully-failed option's <Result> — it emits one with an empty <Value>. A
+		// composite carrying one alongside a successful Result must still parse (captured shape: a Docker
+		// smoke test of a two-Option batch-run where one Option's every pass failed).
+		const xml = `<?xml version="1.0"?>
+<PhoronixTestSuite><Result>
+  <Identifier>pts/x-1.0</Identifier><Title>X</Title><Scale>Seconds</Scale><Proportion>LIB</Proportion>
+  <Data><Entry><Value></Value><RawString></RawString></Entry></Data>
+</Result></PhoronixTestSuite>`;
+		const result = parsePtsComposite(xml).PhoronixTestSuite.Result[0];
+		expect(result?.Data.Entry[0]?.Value).toBeUndefined();
+	});
+
 	it("rejects a malformed RawString sample token at the schema boundary", () => {
 		// A non-numeric per-pass token fails the schema's sampleList morph, so the whole composite is
 		// rejected loudly here rather than the bad token silently vanishing during aggregation.
@@ -86,6 +99,16 @@ describe("resultSamples", () => {
 </Result></PhoronixTestSuite>`;
 		const result = parsePtsComposite(xml).PhoronixTestSuite.Result[0];
 		expect(result && resultSamples(result)).toEqual([0, 5, 0]);
+	});
+
+	it("returns no samples for a Result whose every pass failed (empty <Value>)", () => {
+		const xml = `<?xml version="1.0"?>
+<PhoronixTestSuite><Result>
+  <Identifier>pts/x-1.0</Identifier><Title>X</Title><Scale>Seconds</Scale><Proportion>LIB</Proportion>
+  <Data><Entry><Value></Value><RawString></RawString></Entry></Data>
+</Result></PhoronixTestSuite>`;
+		const result = parsePtsComposite(xml).PhoronixTestSuite.Result[0];
+		expect(result && resultSamples(result)).toEqual([]);
 	});
 
 	it("returns no samples for an entry-less result (nothing to aggregate)", () => {

--- a/packages/results/src/lib/pts.ts
+++ b/packages/results/src/lib/pts.ts
@@ -43,10 +43,12 @@ export function versionlessTest(identifier: string): string {
  * when PTS emitted no per-pass samples. `RawString` is already a validated `number[]` (parsed at the
  * schema edge, pts-schema.ts) — a malformed token threw in `parsePtsComposite`, so nothing is
  * silently dropped here. One `<Entry>` per run (the harness writes one), so this reads the first.
+ * `[]` when the option's every pass failed (`Value` undefined, pts-schema.ts) — no measurement, not
+ * an error.
  */
 export function resultSamples(result: PtsResult): number[] {
 	const entry = result.Data.Entry[0];
-	if (!entry) return [];
+	if (!entry || entry.Value === undefined) return [];
 	return entry.RawString && entry.RawString.length > 0 ? entry.RawString : [entry.Value];
 }
 


### PR DESCRIPTION
**Goal:** one failed option in a PTS batch-run must not throw away every other option's successful result. PTS doesn't omit a `<Result>` whose every pass failed — it emits one with an empty `<Value>`, which the parser rejected as malformed, aborting extraction of the whole composite.xml.

**Approach:** treat an empty `<Value>` as "no measurement" (`undefined`) in the arktype schema and skip the valueless `<Result>` at extraction — the same path as an entry-less Result. The numeric-string parser is compiled once at module scope, not per-`<Value>`.

**Precautions:** PTS's empty-`<Value>` emission was confirmed empirically in a Docker PTS smoke run (not assumed from docs); a partial-failure fixture pins the behavior — the failed Result is skipped, the successful sibling survives.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Handle fully failed PTS results without throwing, so batch runs keep successful measurements. Empty <Value> is treated as no measurement and skipped during extraction; includes a small parse-time perf win. Addresses ENG-135.

- **Bug Fixes**
  - `pts-schema.ts`: parse empty `<Value>` as undefined, not an error.
  - `extract.ts`: skip results with undefined `Value` to avoid zero-sample aggregation.
  - `pts.ts`: `resultSamples` returns `[]` when `Value` is undefined.
  - Added a real-world fixture and tests to pin the behavior.

- **Refactors**
  - `pts-schema.ts`: compile the numeric-string parser once at module scope.

<sup>Written for commit 0a57b1595c198e3bf96dc5a5c347eb0233bac76e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/starslingdev/sandbox-benchmarks/pull/89?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved PTS parsing so “every pass failed” cases don’t break when result entries contain empty measurement values.
  * Empty/whitespace result values are now treated as missing data, preventing invalid or undefined measurements from appearing in extracted output.
  * Sample extraction now returns no samples for entries without a measurement.
* **Tests**
  * Added coverage for composite/result parsing and sample extraction when entries have empty values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
