### PR TITLE
fix(bench): restore hardlink-1.0.0's missing install.sh

### DIFF
--- a/packages/schema/src/pts-profiles/local/hardlink-1.0.0/install.sh
+++ b/packages/schema/src/pts-profiles/local/hardlink-1.0.0/install.sh
@@ -1,0 +1,22 @@
+#!/bin/sh
+set -eu
+# PTS local-profile install script: generates the `hardlink` executable PTS invokes at batch-run
+# time (the runtime convention — an executable named after the versionless profile dir, in the
+# install cwd). Uses the system stress-ng (apt install stress-ng); no source build. Ported from
+# runner-benchmarking, the last place this profile actually ran: sandbox-benchmarks vendored only
+# test-definition.xml/results-definition.xml, so PTS reported "No installation script found" and
+# never produced a real measurement.
+if ! command -v stress-ng >/dev/null 2>&1; then
+  echo "ERROR: stress-ng not installed (apt install stress-ng)" >&2
+  echo 1 > ~/install-exit-status
+  exit 1
+fi
+
+cat <<'EOF' > hardlink
+#!/bin/sh
+stress-ng "$@" > "$LOG_FILE" 2>&1
+echo $? > ~/test-exit-status
+EOF
+chmod +x hardlink
+
+echo 0 > ~/install-exit-status


### PR DESCRIPTION
**Goal:** make the disk suite's `hardlink` metric real. The vendored profile shipped only the two XML definitions, so PTS reported "No installation script found" at batch-run — the metric has never produced a real measurement in production.

**Approach:** port `install.sh` from runner-benchmarking (the last place this profile actually ran): use the system stress-ng (no source build) and generate the `hardlink` executable the PTS runtime convention expects (executable named after the versionless profile dir, in the install cwd).

**Precautions:** both the break and the fix were verified empirically in Docker (install + batch-run → parseable composite.xml). The script runs under `set -eu` so an unexpected failure can never fall through to a false-success `install-exit-status` write; `~/install-exit-status` and `$LOG_FILE` deliberately follow the upstream PTS profile conventions.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restore the missing install.sh for the `hardlink-1.0.0` PTS profile so the disk suite records real measurements again. The script creates the `hardlink` runner using system `stress-ng`, fixing “No installation script found” failures.

- **Bug Fixes**
  - Added `install.sh` to `packages/schema/src/pts-profiles/local/hardlink-1.0.0/`.
  - Generates the `hardlink` wrapper, logs to `$LOG_FILE`, writes PTS exit-status files, uses `set -eu`, and checks for `stress-ng` (no source build).

- **Migration**
  - Ensure `stress-ng` is installed on runners (e.g., apt install `stress-ng`).

<sup>Written for commit 6df495da9f3a86e6db6aee72092b4fe47cb58648. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/starslingdev/sandbox-benchmarks/pull/90?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

