### PR TITLE
chore(bench): extract install_local_pts_profile helper

### DIFF
--- a/.mise/tasks/benchmark/disk/pts/hardlink
+++ b/.mise/tasks/benchmark/disk/pts/hardlink
@@ -15,18 +15,7 @@ if ! command -v stress-ng &>/dev/null; then
 fi
 
 # hardlink is a REPO-LOCAL PTS profile (Identifier local/hardlink-1.0.0), so PTS won't download it —
-# install our vendored copy into PTS's local-profile dir first. The dir depends on the run user
-# ($HOME/.phoronix-test-suite vs /var/lib/... for root); pts_init creates it and pts_user_dir locates
-# it, so installing elsewhere makes PTS reject it with "Invalid Argument: local/hardlink-1.0.0".
-PROFILE_NAME="hardlink-1.0.0"
-SRC="${REPO_ROOT}/packages/schema/src/pts-profiles/local/${PROFILE_NAME}"
-
-pts_init
-PTS_DIR="$(pts_user_dir)"
-DST="${PTS_DIR}/test-profiles/local/${PROFILE_NAME}"
-mkdir -p "$(dirname "$DST")"
-rm -rf "$DST"
-cp -r "$SRC" "$DST"
-echo "Installed local PTS profile: ${DST} (PTS data dir: ${PTS_DIR})"
+# install our vendored copy into PTS's local-profile dir first.
+install_local_pts_profile "hardlink-1.0.0"
 
 run_pts_benchmark "local/hardlink-1.0.0" "pts_hardlink"

--- a/lib/bench.sh
+++ b/lib/bench.sh
@@ -211,6 +211,46 @@ ensure_pts() {
 	return 0
 }
 
+# Install a repo-local PTS profile (packages/schema/src/pts-profiles/local/<name>) into PTS's
+# local-profile dir, so `phoronix-test-suite batch-install local/<name>` can find it — PTS won't fetch
+# a repo-local profile itself. The dir depends on the run user ($HOME/.phoronix-test-suite vs
+# /var/lib/... for root); pts_init creates it and pts_user_dir locates it, so installing elsewhere
+# makes PTS reject it with "Invalid Argument: local/<name>". Any `overlay-file` args are copied into
+# the installed dir alongside the vendored XML+install.sh — for a runner script shared across several
+# profiles (kept once with the rest of the producer bash, not duplicated per-profile in schema).
+# Usage: install_local_pts_profile <name> [overlay-file...]
+install_local_pts_profile() {
+	# Empty name would make dst the whole local-profile dir — which rm -rf below would wipe.
+	local name="${1:-}"
+	if [ -z "$name" ]; then
+		echo "ERROR: install_local_pts_profile requires a profile name" >&2
+		return 1
+	fi
+	shift
+	local src="${REPO_ROOT}/packages/schema/src/pts-profiles/local/${name}"
+	# Fail before the rm -rf below: a missing source (typo'd name, wrong REPO_ROOT) must not delete
+	# the previously-installed copy.
+	if [ ! -d "$src" ]; then
+		echo "ERROR: install_local_pts_profile: source profile not found: ${src}" >&2
+		return 1
+	fi
+
+	pts_init
+	local pts_dir dst
+	pts_dir="$(pts_user_dir)"
+	dst="${pts_dir}/test-profiles/local/${name}"
+	mkdir -p "$(dirname "$dst")"
+	rm -rf "$dst"
+	cp -r "$src" "$dst"
+
+	local overlay
+	for overlay in "$@"; do
+		cp "$overlay" "$dst/"
+	done
+
+	echo "Installed local PTS profile: ${dst} (PTS data dir: ${pts_dir})"
+}
+
 # Install and run one PTS test, capturing timing via bench_cmd and copying the result XML to
 # benchmark-results/<prefix>.xml (the contract the results extractor reads).
 # Usage: run_pts_benchmark <test-name> <results-prefix>


### PR DESCRIPTION
**Goal:** the three realworld profiles upstack all need to install a repo-local PTS profile; extract that logic once instead of duplicating it per task.

**Approach:** pull the `pts_init` + `pts_user_dir` + rm/cp install sequence out of the hardlink task into a shared `install_local_pts_profile` helper in `lib/bench.sh`, with an overlay-file mechanism for a runner script shared across profiles, and refactor the hardlink task onto it.

**Precautions:** two guards protect the destructive step — an empty profile name is rejected before `rm -rf` (an empty `name` would resolve `dst` to the whole `test-profiles/local/` dir), and a missing source dir fails before the previously-installed copy is deleted. Otherwise a pure refactor, re-verified end-to-end in Docker (install + batch-run produces a real, parseable composite.xml).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Extracted a shared `install_local_pts_profile` helper to install repo-local PTS profiles and refactored the hardlink task to use it. Adds guards and optional overlay-file support; behavior unchanged.

- **Refactors**
  - Added `install_local_pts_profile` in `lib/bench.sh`; hardlink task now uses it.

- **Bug Fixes**
  - Reject empty profile names and missing source directories before deletion.

<sup>Written for commit 225be75e2ed76829f9177eed45544c9e1b24107f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/starslingdev/sandbox-benchmarks/pull/91?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for installing local benchmark profiles automatically before running PTS-based benchmarks.
  * Benchmark runs can now include optional overlay files applied during profile installation.

* **Bug Fixes**
  * Simplified benchmark setup so local profile preparation is handled consistently, reducing manual setup steps and the chance of stale profile data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->