### PR TITLE
feat(bench): mastra realworld runner + mise task (ENG-135/137)

### DIFF
--- a/.mise/tasks/benchmark/realworld/pts/mastra
+++ b/.mise/tasks/benchmark/realworld/pts/mastra
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+#MISE description="PTS: mastra CI tasks (realworld suite, repo-local profile)"
+# Measurement leaf: -e guards the scaffolding; each measured task is isolated by run_pts_benchmark.
+set -euo pipefail
+REPO_ROOT="$(git -C "$(dirname "${BASH_SOURCE[0]}")" rev-parse --show-toplevel)"
+source "${REPO_ROOT}/lib/bench.sh"
+
+run_realworld_pts mastra

--- a/lib/bench.sh
+++ b/lib/bench.sh
@@ -168,6 +168,11 @@ _configure_pts_batch() {
 	# The readings are host-level sensors anyway (unattributable for provider comparison). Unset any
 	# value inherited from the image/harness env defensively — the producer never sets it.
 	unset MONITOR PERFORMANCE_PER_WATT
+	# Pin the batch run queue to each profile's natural (menu) order. PTS's AutoSortRunQueue
+	# otherwise usort()s the queue (pts_test_run_manager.php) — effectively arbitrary within one
+	# test's option matrix — which would run build-dependent tasks before the measured `build`
+	# their unmeasured prep replays (correct either way, but the prep then pays a full rebuild).
+	export TEST_EXECUTION_SORT=none
 	export TEST_RESULTS_NAME=benchmark
 	export TEST_RESULTS_DESCRIPTION=ci
 	export TEST_RESULTS_IDENTIFIER=ci
@@ -299,6 +304,32 @@ run_pts_benchmark() {
 		skip_result "PTS batch-run of ${test_name} produced no composite.xml" "$prefix"
 	fi
 	return 0
+}
+
+# Run one realworld suite end to end: gate on the toolchain, install the repo-local profile with
+# the SHARED install.sh + runner overlaid from lib/pts/realworld/ (the profiles vendor only
+# XML + target.env — no per-profile scripts to drift), then batch-run it. The single body behind
+# every benchmark:realworld:pts:<repo> mise leaf.
+# Usage: run_realworld_pts <repo>   (repo = mastra | better-auth | openclaw)
+run_realworld_pts() {
+	local repo="$1"
+	local profile="realworld-${repo}-1.0.0"
+	local prefix="pts_realworld-${repo}"
+
+	if ! command -v phoronix-test-suite &>/dev/null; then
+		skip_result "phoronix-test-suite not installed" "$prefix"
+		return 0
+	fi
+	if ! command -v node &>/dev/null; then
+		skip_result "node not installed" "$prefix"
+		return 0
+	fi
+
+	install_local_pts_profile "$profile" \
+		"${REPO_ROOT}/lib/pts/realworld/install.sh" \
+		"${REPO_ROOT}/lib/pts/realworld/realworld-runner.sh"
+
+	run_pts_benchmark "local/${profile}" "$prefix"
 }
 
 # --- Orchestrator helpers ---

--- a/lib/pts/realworld/install.sh
+++ b/lib/pts/realworld/install.sh
@@ -1,0 +1,89 @@
+#!/bin/sh
+# PTS local-profile install script (ENG-135/136/137/138), SHARED by every realworld-<repo>-1.0.0
+# profile: the profiles vendor only XML + target.env, and run_realworld_pts (lib/bench.sh) overlays
+# this file (and realworld-runner.sh, adjacent here) into the installed profile dir, where PTS
+# executes it as the profile's install.sh. All per-repo config lives in target.env. Copies
+# target.env + the runner from $(dirname "$0") into the install dir, writes the PTS executable
+# wrapper each profile declares via <Executable>realworld-run</Executable> (receiving the selected
+# Task Option's Value as $1, stdout/stderr piped to $LOG_FILE), then does
+# the UNMEASURED provisioning: pin the toolchain, shallow-fetch the pinned SHA into work/, one warm
+# install -- so every measured task starts from a deps-ready workspace. See realworld-runner.sh for
+# the per-task measured logic the wrapper invokes at batch-run.
+set -eu
+
+# shellcheck disable=SC1007 # CDPATH= (no value) is the idiom that disables CDPATH's cd-echoes-a-path
+# behavior for this one invocation; shellcheck misreads it as a mistyped assignment.
+SRC_DIR="$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)"
+# Every profile declares <Executable>realworld-run</Executable> (test-definition.xml), so the
+# wrapper name is a fixed constant -- no versionless-dir derivation.
+EXE_NAME="realworld-run"
+
+if [ ! -f "${SRC_DIR}/target.env" ] || [ ! -f "${SRC_DIR}/realworld-runner.sh" ]; then
+	echo "ERROR: target.env or realworld-runner.sh missing next to install.sh (${SRC_DIR})" >&2
+	echo 1 > ~/install-exit-status
+	exit 1
+fi
+cp "${SRC_DIR}/target.env" .
+cp "${SRC_DIR}/realworld-runner.sh" .
+chmod +x realworld-runner.sh
+
+cat <<EOF > "$EXE_NAME"
+#!/bin/sh
+"\$(dirname "\$0")/realworld-runner.sh" "\$1" > "\$LOG_FILE" 2>&1
+echo \$? > ~/test-exit-status
+EOF
+chmod +x "$EXE_NAME"
+
+# shellcheck source=/dev/null
+. ./target.env
+
+# Warm the SAME cache locations realworld-runner.sh pins at run time (relative to this install
+# dir, which is the runner's SCRIPT_DIR), so the unmeasured provisioning below populates exactly
+# what the runner reads: a fresh COREPACK_HOME would otherwise make the first measured pnpm task
+# of a batch pay a pnpm-toolchain download inside its sample. The runner's cold_install branch
+# still wipes the store + XDG cache before measuring, so this never warms a cold-install sample.
+export XDG_CACHE_HOME="${PWD}/.cache"
+export COREPACK_HOME="${PWD}/.corepack"
+export npm_config_store_dir="${PWD}/.pnpm-store"
+
+if ! command -v node >/dev/null 2>&1; then
+	echo "ERROR: node not found (the sandbox harness's setupNode step provisions it)" >&2
+	echo 1 > ~/install-exit-status
+	exit 1
+fi
+node_have="$(node --version | sed 's/^v//')"
+if [ "$(printf '%s\n%s\n' "$NODE_VERSION" "$node_have" | sort -V | head -1)" != "$NODE_VERSION" ]; then
+	echo "ERROR: node ${node_have} does not satisfy this profile's required >= ${NODE_VERSION}" >&2
+	echo 1 > ~/install-exit-status
+	exit 1
+fi
+corepack enable >/dev/null 2>&1 || true
+
+rm -rf work
+mkdir -p work
+# Pessimistic status: POSIX suspends `set -e` inside any compound run as an `if !` condition, so
+# wrapping the subshell that way would let an intermediate failure (e.g. `git fetch`) fall through
+# to the next command. Written as a plain subshell, -e stays live inside it and any failure aborts
+# the whole script (outer -e) with the 1 already on disk; only full success overwrites it below.
+echo 1 > ~/install-exit-status
+(
+	cd work
+	git init -q .
+	git remote add origin "$REPO_URL"
+	git fetch --depth 1 origin "$PIN_SHA"
+	git checkout -q FETCH_HEAD
+	head_sha="$(git rev-parse HEAD)"
+	if [ "$head_sha" != "$PIN_SHA" ]; then
+		echo "install: cloned HEAD ${head_sha} != PIN_SHA ${PIN_SHA}" >&2
+		exit 1
+	fi
+	corepack install >/dev/null 2>&1 || true
+	# The warm install IS the profile's cold_install command (single source of truth in target.env) —
+	# no un-frozen fallback: a lockfile that can't install frozen at PIN_SHA must fail HERE, loudly,
+	# not provision warm node_modules from a regenerated (unpinned) package set while every measured
+	# cold_install sample fails against the restored lockfile.
+	# shellcheck disable=SC2154 # sourced from target.env above.
+	eval "$TASK_CMD_cold_install"
+)
+
+echo 0 > ~/install-exit-status

--- a/lib/pts/realworld/realworld-runner.sh
+++ b/lib/pts/realworld/realworld-runner.sh
@@ -1,0 +1,138 @@
+#!/bin/sh
+# Shared realworld-suite runner (ENG-135/136/137/138), one copy for every realworld-<repo>-1.0.0
+# profile. run_realworld_pts (lib/bench.sh) overlays this script and the adjacent install.sh into
+# the installed profile dir next to the profile's vendored target.env; the generated PTS executable
+# wrapper invokes it as `realworld-runner.sh <task-value>`, with stdout/stderr already
+# redirected to $LOG_FILE by that wrapper. One measured task per invocation -- the unmeasured
+# "prepare" step below runs first on every invocation so every sample starts from the same state
+# regardless of what task ran before it.
+set -eu
+
+TASK="${1:?usage: realworld-runner.sh <task-value>}"
+# shellcheck disable=SC1007 # CDPATH= (no value) is the idiom that disables CDPATH's cd-echoes-a-path
+# behavior for this one invocation; shellcheck misreads it as a mistyped assignment.
+SCRIPT_DIR="$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)"
+# shellcheck source=/dev/null
+. "${SCRIPT_DIR}/target.env"
+
+WORK_DIR="${SCRIPT_DIR}/work"
+
+# Fixed env, never ambient-HOME-dependent, so PTS's env quirks (it runs tests under varying HOME
+# handling) can't leak cache state across runs or providers.
+export XDG_CACHE_HOME="${SCRIPT_DIR}/.cache"
+export COREPACK_HOME="${SCRIPT_DIR}/.corepack"
+export npm_config_store_dir="${SCRIPT_DIR}/.pnpm-store"
+export CI=true
+export TZ=UTC
+export LC_ALL=C.UTF-8
+export GIT_TERMINAL_PROMPT=0
+export DO_NOT_TRACK=1
+export TURBO_TELEMETRY_DISABLED=1
+export TURBO_FORCE=true
+export COREPACK_ENABLE_DOWNLOAD_PROMPT=0
+
+start_ns=""
+end_ns=""
+
+case "$TASK" in
+git_clone)
+	# Measured clone: what actions/checkout does -- deterministic content, network-inclusive on
+	# purpose. Every iteration fully cold by construction (rm -rf first).
+	rm -rf "$WORK_DIR"
+	mkdir -p "$WORK_DIR"
+	cd "$WORK_DIR"
+	start_ns=$(date +%s%N)
+	git init -q .
+	git remote add origin "$REPO_URL"
+	git fetch --depth 1 origin "$PIN_SHA"
+	git checkout -q FETCH_HEAD
+	end_ns=$(date +%s%N)
+	head_sha="$(git rev-parse HEAD)"
+	if [ "$head_sha" != "$PIN_SHA" ]; then
+		echo "git_clone: HEAD $head_sha != PIN_SHA $PIN_SHA" >&2
+		exit 1
+	fi
+	;;
+cold_install)
+	# Workspace reset: full node_modules removal + store/cache wipe, then assert cold before
+	# measuring -- provably cold, not just "probably cold".
+	cd "$WORK_DIR"
+	git checkout -f -q "$PIN_SHA"
+	git clean -xdff
+	rm -rf "$npm_config_store_dir" "$XDG_CACHE_HOME"
+	if [ -d node_modules ]; then
+		echo "cold_install: node_modules survived the cold reset" >&2
+		exit 1
+	fi
+	start_ns=$(date +%s%N)
+	# shellcheck disable=SC2154 # sourced dynamically from target.env (per-profile config, not
+	# assigned in this file).
+	eval "$TASK_CMD_cold_install"
+	end_ns=$(date +%s%N)
+	;;
+*)
+	# lint/typecheck/build/test: reset build artifacts but keep node_modules (gitignore-pattern
+	# exclude), then ensure deps exist so tasks are order-independent regardless of whether
+	# cold_install has run yet in this batch.
+	cd "$WORK_DIR"
+	prep_var="TASK_PREP_${TASK}"
+	eval "prep=\"\${${prep_var}:-}\""
+	if [ -n "$prep" ]; then
+		# Build-dependent task (declared via TASK_PREP_<value>): keep dist + node_modules + .turbo
+		# (turbo 2's local cache dir) through the reset, so the UNMEASURED prep below is a
+		# near-instant turbo cache REPLAY of the build the Task menu already measured earlier in the
+		# batch — never a duplicate slow build (a full build happens only when the task runs
+		# standalone). TURBO_FORCE is lifted for the prep only; the measured command keeps
+		# TURBO_FORCE=true so it is always a genuine execution, never a cache replay.
+		git clean -xdff -e node_modules -e dist -e .turbo
+		if [ ! -d node_modules ]; then
+			eval "$TASK_CMD_cold_install"
+		fi
+		(unset TURBO_FORCE && eval "$prep")
+	else
+		# Turbo's cache dirs (.turbo/ at the root, node_modules/.cache/turbo) survive EVERY generic
+		# reset — not just prep tasks' — so the cache the measured build wrote is still there when a
+		# later prep replays it, regardless of which tasks ran in between. Measurement-safe: every
+		# measured turbo command runs with TURBO_FORCE=true, so preserved cache is never read inside
+		# a timed window; all other tool caches in node_modules/.cache are still wiped.
+		git clean -xdff -e node_modules -e .turbo
+		if [ -d node_modules/.cache ]; then
+			find node_modules/.cache -mindepth 1 -maxdepth 1 ! -name turbo -exec rm -rf {} +
+		fi
+		if [ ! -d node_modules ]; then
+			# Recovery install: output stays on the (already-redirected) log — discarding it would
+			# hide the one diagnostic that explains a subsequent task failure.
+			eval "$TASK_CMD_cold_install"
+		fi
+	fi
+	cmd_var="TASK_CMD_${TASK}"
+	eval "cmd=\"\${${cmd_var}:-}\""
+	if [ -z "$cmd" ]; then
+		echo "no ${cmd_var} in target.env for task '${TASK}'" >&2
+		exit 1
+	fi
+	if [ -z "$prep" ]; then
+		# Steady-state warm-up (fio's ramp_time, adapted): the FIRST execution of a JS toolchain in a
+		# fresh sandbox pays one-time JIT/compile-cache costs that live outside work/ and survive the
+		# per-pass reset — observed 75s vs ~10s on an identical better-auth build, an asymmetry that
+		# poisons the sample set and trips PTS's dynamic run count. One unmeasured execution, then
+		# the same reset again, so the measured run is warm-toolchain + cold-artifact on every pass.
+		# Prep-carrying tasks skip this: their prep already exercised the toolchain.
+		eval "$cmd"
+		# Same PRESERVING reset as above — the old destructive form here wiped the turbo cache the
+		# measured build had written, killing the replay for any prep task downstream of a no-prep
+		# task's warm-up cycle.
+		git clean -xdff -e node_modules -e .turbo
+		if [ -d node_modules/.cache ]; then
+			find node_modules/.cache -mindepth 1 -maxdepth 1 ! -name turbo -exec rm -rf {} +
+		fi
+	fi
+	start_ns=$(date +%s%N)
+	eval "$cmd"
+	end_ns=$(date +%s%N)
+	;;
+esac
+
+# A failing measured command aborts above (set -e) before this prints -- no sentinel, non-zero exit,
+# so PTS records a missing sample for that option while the remaining options continue.
+awk -v ns="$((end_ns - start_ns))" 'BEGIN { printf "REALWORLD_RESULT_SECONDS: %.3f\n", ns / 1000000000 }'

--- a/packages/harness/src/lib/execute.ts
+++ b/packages/harness/src/lib/execute.ts
@@ -165,7 +165,9 @@ export const PREAMBLE = [
 	"export PIP_BREAK_SYSTEM_PACKAGES=1",
 	// Honour each PTS profile's TimesToRun (lib/bench.sh otherwise forces a single pass). The sandbox
 	// is the statistical-confidence path: the in-sandbox repeats give p50/stdev per Metric.
-	"export PTS_RESPECT_TIMES_TO_RUN=1",
+	// BENCH_PASSES=1 (host env) opts a run out for fast contract-verification iteration -- one pass
+	// per task, ~3x faster on multi-pass suites; never set it for a run whose numbers you publish.
+	...(process.env.BENCH_PASSES === "1" ? [] : ["export PTS_RESPECT_TIMES_TO_RUN=1"]),
 	'if [ "$(id -u)" = 0 ]; then SUDO=""; elif command -v sudo >/dev/null 2>&1; then SUDO="sudo -E"; else SUDO=""; fi',
 ].join("; ");
 

--- a/packages/schema/src/pts-profiles.test.ts
+++ b/packages/schema/src/pts-profiles.test.ts
@@ -1,7 +1,7 @@
 /**
  * Consistency gate for the realworld PTS profiles (ENG-135/136/137/138): each profile's `Task` Option
  * (test-definition.xml) and its `target.env` sibling are two hand-authored, unrelated-by-construction
- * files that must stay in lockstep -- lib/pts/realworld-runner.sh looks up `TASK_CMD_<value>` for
+ * files that must stay in lockstep -- lib/pts/realworld/realworld-runner.sh looks up `TASK_CMD_<value>` for
  * whichever Option Value PTS invokes it with, so a Value with no matching key would fail at runtime
  * with no compile-time signal. Checked here instead: every Entry's Value has exactly one
  * `TASK_CMD_<value>` key, and vice versa (no orphaned key). Also cross-checks target.env's PIN_SHA
@@ -10,7 +10,7 @@
  */
 
 import { describe, expect, it } from "bun:test";
-import { readdirSync, readFileSync } from "node:fs";
+import { existsSync, readdirSync, readFileSync } from "node:fs";
 import { join } from "node:path";
 import { parseProfile } from "../scripts/catalog/parse.ts";
 
@@ -72,6 +72,26 @@ describe("realworld profiles: Task Option <-> target.env consistency", () => {
 						.map((key) => key.slice("TASK_CMD_".length)),
 				);
 				expect(taskCmdKeys).toEqual(values);
+			});
+
+			it("stays data-only: no per-profile install.sh (the shared lib/pts/realworld/ copy is overlaid)", () => {
+				expect(existsSync(join(base, "install.sh"))).toBe(false);
+			});
+
+			it("anchors every TASK_PREP_<value> to a declared Task Value (no orphaned prep)", () => {
+				// TASK_PREP_<value> runs unmeasured before the timed TASK_CMD_<value> (realworld-runner.sh);
+				// a prep keyed to a renamed/removed Value would silently stop running.
+				const values = new Set(
+					profile.settings
+						.find((option) => option.DisplayName === "Task")
+						?.Menu.Entry.map((e) => e.Value) ?? [],
+				);
+				const prepKeys = Object.keys(env)
+					.filter((key) => key.startsWith("TASK_PREP_"))
+					.map((key) => key.slice("TASK_PREP_".length));
+				for (const key of prepKeys) {
+					expect(values).toContain(key);
+				}
 			});
 
 			it("declares REPO_URL, PIN_SHA and NODE_VERSION", () => {

--- a/packages/schema/src/pts-profiles/local/realworld-mastra-1.0.0/results-definition.xml
+++ b/packages/schema/src/pts-profiles/local/realworld-mastra-1.0.0/results-definition.xml
@@ -3,6 +3,7 @@
   <ResultsParser>
     <!-- lib/pts/realworld-runner.sh prints exactly one sentinel line per measured task run. -->
     <OutputTemplate>REALWORLD_RESULT_SECONDS: #_RESULT_#</OutputTemplate>
+    <LineHint>REALWORLD_RESULT_SECONDS:</LineHint>
     <ResultScale>Seconds</ResultScale>
     <ResultProportion>LIB</ResultProportion>
   </ResultsParser>

--- a/packages/schema/src/pts-profiles/local/realworld-mastra-1.0.0/target.env
+++ b/packages/schema/src/pts-profiles/local/realworld-mastra-1.0.0/target.env
@@ -11,4 +11,10 @@ TASK_CMD_git_clone=""
 TASK_CMD_cold_install="pnpm install --frozen-lockfile"
 TASK_CMD_lint_format="pnpm lint:format"
 TASK_CMD_build_core="pnpm build:core"
+# test:core is plain `pnpm --filter ./packages/core test` upstream -- no turbo graph, so it needs
+# core's workspace deps' dist/. Upstream CI builds before unit tests; the Task menu measures
+# build_core first, and this prep (upstream's own build:core) then replays it from the preserved
+# turbo cache (see realworld-runner.sh's prep reset), leaving the timed command exactly the
+# vitest run.
+TASK_PREP_test_core="pnpm build:core"
 TASK_CMD_test_core="pnpm test:core"

--- a/packages/schema/src/pts-profiles/local/realworld-mastra-1.0.0/test-definition.xml
+++ b/packages/schema/src/pts-profiles/local/realworld-mastra-1.0.0/test-definition.xml
@@ -7,6 +7,7 @@
     <Description>Runs a scoped slice of mastra-ai/mastra's own CI tasks -- clone, cold install, lint:format, build:core, test:core -- against a pinned main-HEAD checkout, timing each phase per sandbox provider.</Description>
     <ResultScale>Seconds</ResultScale>
     <Proportion>LIB</Proportion>
+    <Executable>realworld-run</Executable>
     <TimesToRun>3</TimesToRun>
   </TestInformation>
   <TestProfile>
@@ -18,6 +19,7 @@
     <Status>Verified</Status>
     <EnvironmentSize>3</EnvironmentSize>
     <ProjectURL>https://github.com/mastra-ai/mastra</ProjectURL>
+    <RepositoryURL>https://github.com/mastra-ai/mastra</RepositoryURL>
     <Maintainer>StarSling</Maintainer>
   </TestProfile>
   <TestSettings>


### PR DESCRIPTION
**ENG-135 — realworld runner + mise wiring (per-repo)**
Stack: #96 (shared runner/install + mastra) → #97 (better-auth) → #98 (openclaw + orchestrator), on the profile PRs.

↑ **This PR is #96 (1/3)**, stacked on #95.

**Goal:** make the realworld profiles executable end-to-end with zero per-repo script duplication and phase-exact measurement: everything shared lives once under `lib/pts/realworld/`, and each repo's wiring is a one-line mise leaf.

**Approach:**
- `realworld-runner.sh`: one measured task per invocation with fixed env and cold-by-construction resets. Two measurement mechanisms shaped by live verification: (1) **steady-state warm-up** — no-prep tasks run once unmeasured then reset (fio's ramp_time adapted), because a fresh sandbox's first JS-toolchain execution pays one-time JIT/compile costs (observed 75s vs ~10s for an identical build) that poison deviation and trip PTS's dynamic run count; (2) **TASK_PREP replay** — build-dependent tasks keep dist + turbo caches through their reset and replay the menu's already-measured build unmeasured, then time the `--only` command (TURBO_FORCE=true keeps every measured run a genuine execution). Turbo caches survive all generic resets (including warm-up cycles) so the replay works regardless of task interleaving.
- `install.sh` (shared, overlaid per profile): unmeasured provisioning — pin-verified shallow fetch, warm install via the profile's own TASK_CMD_cold_install, cache locations aligned with the runner's.
- `run_realworld_pts <repo>` (lib/bench.sh): the single body behind every leaf; PTS batch queue pinned to menu order (TEST_EXECUTION_SORT=none — AutoSortRunQueue otherwise shuffles it). Plus BENCH_PASSES=1 (harness) for fast single-pass verification runs.

**Validated live (Blaxel sandboxes, three iterations to converge):** better-auth 10/10 metrics, 0 uncatalogued; build 9.92s ±1.03% over 3 passes with exactly 3 samples (previously 74.9s/9.8s/… with PTS inflating to 6); preps replay as `20 cached, 20 total >>> FULL TURBO` (~0.2s) with measured commands executing genuinely (`0 cached`); execution order == menu order. The Docker selftest (#103) pins the same contract locally with execution-counter proofs.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a shared RealWorld PTS runner and a single `run_realworld_pts` helper, wiring the repo‑local `mastra` profile to a `.mise` task for cold, repeatable CI benchmarks (ENG-135/137). Pins queue order, improves sample quality with an unmeasured prep hook and steady‑state warm‑up, and supports single‑pass verification.

- **New Features**
  - Shared runner `lib/pts/realworld/realworld-runner.sh`: fixed env, per‑task cold resets, `REALWORLD_RESULT_SECONDS` output, optional `TASK_PREP_<value>`, and warm‑up for no‑prep tasks.
  - Shared installer `lib/pts/realworld/install.sh`: copies `target.env` + runner, writes constant `realworld-run` wrapper, warms caches, asserts `node` ≥ `NODE_VERSION`, shallow‑fetches `PIN_SHA`, and runs `TASK_CMD_cold_install`.
  - New `run_realworld_pts` in `lib/bench.sh`: overlays shared scripts, gates on `phoronix-test-suite` and `node`, pins PTS order with `TEST_EXECUTION_SORT=none`, and runs `local/realworld-mastra-1.0.0`; `.mise` leaf calls it.
  - Schema/harness polish: `<Executable>realworld-run</Executable>`, `LineHint`, `RepositoryURL`; tests enforce data‑only profiles and `TASK_PREP_*` match Task Values; `BENCH_PASSES=1` opts out of multi‑pass.

- **Bug Fixes**
  - Preserve turbo caches across all resets (including post‑warm‑up) so prep tasks replay the measured build; measured commands still force execution (`TURBO_FORCE=true`).
  - Keep `set -e` live in the install subshell; make the `.mise` task executable and remove the unfrozen `pnpm install` fallback.

<sup>Written for commit 37932e263208ee2555a4e41386c534e9bfafad1d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/starslingdev/sandbox-benchmarks/pull/96?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

