### PR TITLE
feat(bench): better-auth realworld mise task (ENG-135/136)

### DIFF
--- a/.mise/tasks/benchmark/realworld/pts/better-auth
+++ b/.mise/tasks/benchmark/realworld/pts/better-auth
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+#MISE description="PTS: better-auth CI tasks (realworld suite, repo-local profile)"
+# Measurement leaf: -e guards the scaffolding; each measured task is isolated by run_pts_benchmark.
+set -euo pipefail
+REPO_ROOT="$(git -C "$(dirname "${BASH_SOURCE[0]}")" rev-parse --show-toplevel)"
+source "${REPO_ROOT}/lib/bench.sh"
+
+run_realworld_pts better-auth


### PR DESCRIPTION
**ENG-135 — realworld runner + mise wiring (per-repo)**
Stack: #96 (shared runner/install + mastra) → #97 (better-auth) → #98 (openclaw + orchestrator), on the profile PRs.

↑ **This PR is #97 (2/3)**, stacked on #96.

**Goal:** wire the better-auth profile onto the shared machinery.

**Approach:** one mise leaf, `benchmark:realworld:pts:better-auth`, delegating to `run_realworld_pts better-auth` (#96). Everything repo-specific lives in the profile's target.env (#94).

**Validated live (Blaxel, final architecture):** the full 10-task matrix measured with 0 uncatalogued — build 9.92s ±1.0%, cold_install 15.8s ±2.5%, all six lint tasks green including lint_types/lint_packages via FULL-TURBO prep replays (~0.2s unmeasured) feeding genuinely-executed `--only` measurements.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a `.mise` task to run the RealWorld PTS for `better-auth`, sourcing `lib/bench.sh` and delegating to `run_realworld_pts better-auth` (ENG-135/136).

<sup>Written for commit ad7d7718d5bb83b00cbbf00c12e3789df7ce435a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/starslingdev/sandbox-benchmarks/pull/97?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

