### PR TITLE
feat(bench): openclaw realworld mise task + realworld:all orchestrator (ENG-135/138)

### DIFF
--- a/.mise/tasks/benchmark/realworld/all
+++ b/.mise/tasks/benchmark/realworld/all
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+#MISE description="Run realworld benchmarks (better-auth, mastra, openclaw CI tasks via PTS)"
+# Orchestrator: no -e -- run_task isolates child failures and summary reports them at the end
+# (error-mode conventions: lib/bench.sh).
+set -uo pipefail
+REPO_ROOT="$(git -C "$(dirname "${BASH_SOURCE[0]}")" rev-parse --show-toplevel)"
+source "${REPO_ROOT}/lib/bench.sh"
+
+echo "========================================"
+echo "  REALWORLD BENCHMARKS"
+echo "========================================"
+
+ensure_pts || true
+
+run_task benchmark:realworld:pts:better-auth
+run_task benchmark:realworld:pts:mastra
+run_task benchmark:realworld:pts:openclaw
+
+summary

--- a/.mise/tasks/benchmark/realworld/pts/openclaw
+++ b/.mise/tasks/benchmark/realworld/pts/openclaw
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+#MISE description="PTS: openclaw CI tasks (realworld suite, repo-local profile)"
+# Measurement leaf: -e guards the scaffolding; each measured task is isolated by run_pts_benchmark.
+set -euo pipefail
+REPO_ROOT="$(git -C "$(dirname "${BASH_SOURCE[0]}")" rev-parse --show-toplevel)"
+source "${REPO_ROOT}/lib/bench.sh"
+
+run_realworld_pts openclaw


### PR DESCRIPTION
**ENG-135 — realworld runner + mise wiring (per-repo)**
Shipped as a 3-PR stack, one per repo (merge bottom-up, each independently green), on top of the profile PRs (#93/#94/#95):
1. #96 — shared lib/pts/realworld/ (runner + install.sh) + run_realworld_pts + mastra wiring
2. #97 — better-auth wiring
3. #98 — openclaw wiring + the realworld:all orchestrator

↑ **This PR is #98 (3/3)**, stacked on #97.

**Goal:** complete the family: the openclaw leaf plus the `benchmark:realworld:all` orchestrator.

**Approach:** `benchmark:realworld:pts:openclaw` delegates to `run_realworld_pts openclaw` (#96); the orchestrator follows lib/bench.sh's error-mode conventions (no `-e`; `run_task` isolates children, `summary` reports at the end).

**Precautions:** inherits #96's hardening. Validated live on a real Blaxel sandbox: 4 of 8 tasks measured; build, lint_format, test_unit_fast, shrinkwrap_check fail non-zero at this pin (repo-side).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `benchmark:realworld:pts:openclaw` and a `benchmark:realworld:all` orchestrator to run RealWorld PTS for `better-auth`, `mastra`, and `openclaw`. Completes ENG-135/ENG-138 by wiring OpenClaw to the shared runner and enabling a local all-in-one run.

- **New Features**
  - `benchmark:realworld:pts:openclaw`: delegates to `run_realworld_pts openclaw` via `lib/bench.sh` with a repo-local profile; error-safe scaffolding and isolated measurements.
  - `benchmark:realworld:all`: ensures PTS, runs the three leaves with failure isolation, then prints a summary.

<sup>Written for commit 5038f47dfa1ab0cd2c278ca2f69efd69a665bd6c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/starslingdev/sandbox-benchmarks/pull/98?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

