### PR TITLE
feat(schema): realworld suite registry + CI wiring + docs (ENG-135)

### DIFF
--- a/.github/workflows/bench-smoke.yml
+++ b/.github/workflows/bench-smoke.yml
@@ -19,7 +19,16 @@ on:
         description: Suite to run
         type: choice
         default: cpu-node
-        options: [cpu-node, system, memory, disk]
+        options:
+          [
+            cpu-node,
+            system,
+            memory,
+            disk,
+            realworld-mastra,
+            realworld-better-auth,
+            realworld-openclaw,
+          ]
       region:
         # Daytona only: the default org is parked, so real runs use the ZEN5-VM region (its own API key +
         # target + snapshot, keyed by the _ZEN5 env-var suffix). Ignored by e2b/modal.

--- a/docs/pts-catalog-and-analysis-design.md
+++ b/docs/pts-catalog-and-analysis-design.md
@@ -250,3 +250,49 @@ Detached+poll transport (§5) is a **third, independent stack**, prerequisite fo
 - **Transport blocks heavier suites.** On single-round-trip-capped providers (e.g. Daytona's HTTP 408, confirmed via spike `bn2f5pmp4`; Blaxel ~120s) only short suites complete until detached+poll lands; a capped round-trip can yield a misleading "green" while the process keeps running. **Open:** does a capped/aborted round-trip leave a partial/locked result dir that corrupts the next run's scoped find?
 - **`/var/lib` perms if a non-root path is introduced.** Sandboxes run as root today (suites.ts:24); `cp`/`tar` reads assume root. Documentation note; keep `|| true` on the tar.
 - **Headline selection at scale.** `headlineMetric` (catalog.ts:57-63) throws if a dimension has metrics but none headline. Every populated dimension needs exactly one curated `headline:true` in `pts-overrides.ts`. **Open:** add a catalog-completeness lint (every dimension with ≥1 metric has exactly one headline)?
+
+---
+
+## 8. Realworld Profile Pattern (ENG-135/136/137/138)
+
+Real OSS repos (Mastra, Better-Auth, OpenClaw) run through the CI tasks their own pipelines run —
+clone, cold install, lints, typecheck, build, test — each as a **repo-local PTS profile**
+(`packages/schema/src/pts-profiles/local/realworld-<repo>-1.0.0/`), reusing the whole existing
+pipeline (`run_pts_benchmark` → `composite.xml` → `parsePtsComposite` → generated catalog → suite
+contract → CI matrix → dataset) with zero new consumer code. Granularity comes from a single `Task`
+`<Option>` axis: one `<Entry>` per CI task, one catalogued metric per task
+(`realworld_<repo>_task_<slug>`), one `batch-run` measuring every task as a separate `<Result>`.
+
+**The PTS local-profile contract** (confirmed empirically, not documented upstream): `install.sh`
+runs with its working directory set to PTS's `installed-tests/local/<name>/` dir, but `$0` still
+resolves to its own source location under `test-profiles/local/<name>/` — so `$(dirname "$0")` reads
+install-time siblings (`target.env`, the shared runner) while relative writes (the generated
+executable) land in the persistent install dir. The executable PTS looks for at `batch-run` is named
+after the **versionless** profile dir (`realworld-better-auth`, not `-1.0.0`); it receives the
+selected `<Entry>/<Value>` as `$1` and must pipe its own stdout/stderr to `$LOG_FILE`.
+
+**One trap this pattern must avoid:** PTS truncates a Menu `<Entry>/<Name>` at its first `(`
+character when building the runtime `<Description>` — dropping the parenthetical *and everything
+after it* — but the offline description predictor (`synthesizeDescriptions`, §3.3) has no way to
+know this and predicts the literal Name. A parenthesized Entry Name (`"Lint (Biome)"`) therefore
+byte-mismatches at runtime (`"Task: Lint"` vs. the predicted `"Task: Lint (Biome)"`), routing that
+task to `uncatalogued` in production despite the golden gate (§3.7) looking clean against a
+hand-authored fixture. **Every realworld Entry Name must avoid parentheses** (`"Lint Biome"`, not
+`"Lint (Biome)"`); the `pts-profiles.test.ts` consistency test and the golden gate together catch a
+regression, but neither can catch it from XML alone without a real recorded composite exercising the
+name.
+
+**`target.env` is the per-repo config seam**, adjacent to the XML: `REPO_URL`, `PIN_SHA`,
+`NODE_VERSION`, and one `TASK_CMD_<value>` per `<Option>` `Entry`/`Value` (asserted 1:1 by
+`pts-profiles.test.ts`, both directions). `lib/pts/realworld/realworld-runner.sh` is the one shared runner
+script for all three repos — byte-identical, no per-repo branching beyond reading `target.env` — so
+a repo's *quirks* (its exact CI install invocation, which lint/build/test scripts it exposes) live
+entirely in that repo's `target.env`, never in the runner or `install.sh`.
+
+**Pin bump = profile-version bump.** `AppVersion` in `test-definition.xml` is pinned to the exact
+commit SHA `target.env`'s `PIN_SHA` checks out (cross-checked by `pts-profiles.test.ts`), which PTS
+echoes into `composite.xml`'s `<Result><AppVersion>` and `extract.ts` already carries through as
+`MetricResult.appVersion` provenance (§4.2) — for free, no extraction change needed. Moving a pin
+forward is a content change to an already-versioned profile dir (`realworld-<repo>-1.0.0`), not a new
+profile version: the versionless `pts.test` join key and every metric id stay stable across a pin
+bump, only `AppVersion` (and whatever task set/commands changed upstream) moves.

--- a/packages/results/src/lib/__fixtures__/realworld-smoke/pts_realworld-better-auth.xml
+++ b/packages/results/src/lib/__fixtures__/realworld-smoke/pts_realworld-better-auth.xml
@@ -1,0 +1,227 @@
+<?xml version="1.0"?>
+<!--Phoronix Test Suite v10.8.4-->
+<!--Captured from a real end-to-end Docker run of the real install.sh + realworld-runner.sh + the
+real realworld-better-auth-1.0.0 profile, via the actual mise leaf task, through actual PTS
+batch-install/batch-run -- proves the full producer chain and the extraction/catalog mapping, not
+performance numbers: target.env's REPO_URL/PIN_SHA pointed at a throwaway local fixture repo (a
+package.json with build/test echo scripts) instead of the real better-auth checkout, and the lint/
+typecheck TASK_CMD_* entries were swapped for `false` to also exercise the partial-failure path
+(empty <Value>, see pts.test.ts) end to end against real PTS output. Every <Result> here maps to a
+catalogued realworld_better_auth_task_* metric -- the extraction fixture test asserts zero
+uncatalogued and confirms the Entry-Name-parentheses fix (docs/pts-catalog-and-analysis-design.md).-->
+<PhoronixTestSuite>
+  <Generated>
+    <Title>benchmark</Title>
+    <LastModified>2026-07-07 20:45:02</LastModified>
+    <TestClient>Phoronix Test Suite v10.8.4</TestClient>
+    <Description>Docker testing on Ubuntu 24.04.4 LTS via the Phoronix Test Suite.</Description>
+  </Generated>
+  <System>
+    <Identifier>ci</Identifier>
+    <Hardware>Processor: Apple (14 Cores), Memory: 8GB, Disk: 1007GB</Hardware>
+    <Software>OS: Ubuntu 24.04.4 LTS, Kernel: 6.12.76-linuxkit (aarch64), Compiler: GCC 13.3.0, File-System: overlayfs, System Layer: Docker</Software>
+    <User>root</User>
+    <TimeStamp>2026-07-07 20:43:14</TimeStamp>
+    <TestClientVersion>10.8.4</TestClientVersion>
+    <Notes></Notes>
+    <JSON>{"kernel-extra-details":"Transparent Huge Pages: always","security":"gather_data_sampling: Not affected + indirect_target_selection: Not affected + itlb_multihit: Not affected + l1tf: Not affected + mds: Not affected + meltdown: Not affected + mmio_stale_data: Not affected + reg_file_data_sampling: Not affected + retbleed: Not affected + spec_rstack_overflow: Not affected + spec_store_bypass: Vulnerable + spectre_v1: Mitigation of __user pointer sanitization + spectre_v2: Mitigation of CSV2 but not BHB + srbds: Not affected + tsa: Not affected + tsx_async_abort: Not affected + vmscape: Not affected"}</JSON>
+  </System>
+  <Result>
+    <Identifier>local/realworld-better-auth-1.0.0</Identifier>
+    <Title>Better-Auth CI Tasks</Title>
+    <AppVersion>6f3ba45639579da152b69e8e5342e02f28288670</AppVersion>
+    <Arguments>test</Arguments>
+    <Description>Task: Test</Description>
+    <Scale>Seconds</Scale>
+    <Proportion>LIB</Proportion>
+    <DisplayFormat>BAR_GRAPH</DisplayFormat>
+    <Data>
+      <Entry>
+        <Identifier>ci</Identifier>
+        <Value>0.142</Value>
+        <RawString></RawString>
+        <JSON>{"test-run-times":"1.32"}</JSON>
+      </Entry>
+    </Data>
+  </Result>
+  <Result>
+    <Identifier>local/realworld-better-auth-1.0.0</Identifier>
+    <Title>Better-Auth CI Tasks</Title>
+    <AppVersion>6f3ba45639579da152b69e8e5342e02f28288670</AppVersion>
+    <Arguments>build</Arguments>
+    <Description>Task: Build</Description>
+    <Scale>Seconds</Scale>
+    <Proportion>LIB</Proportion>
+    <DisplayFormat>BAR_GRAPH</DisplayFormat>
+    <Data>
+      <Entry>
+        <Identifier>ci</Identifier>
+        <Value>0.2</Value>
+        <RawString></RawString>
+        <JSON>{"test-run-times":"0.43"}</JSON>
+      </Entry>
+    </Data>
+  </Result>
+  <Result>
+    <Identifier>local/realworld-better-auth-1.0.0</Identifier>
+    <Title>Better-Auth CI Tasks</Title>
+    <AppVersion>6f3ba45639579da152b69e8e5342e02f28288670</AppVersion>
+    <Arguments>git_clone</Arguments>
+    <Description>Task: Git Clone</Description>
+    <Scale>Seconds</Scale>
+    <Proportion>LIB</Proportion>
+    <DisplayFormat>BAR_GRAPH</DisplayFormat>
+    <Data>
+      <Entry>
+        <Identifier>ci</Identifier>
+        <Value>0.038</Value>
+        <RawString></RawString>
+        <JSON>{"test-run-times":"0.06"}</JSON>
+      </Entry>
+    </Data>
+  </Result>
+  <Result>
+    <Identifier>local/realworld-better-auth-1.0.0</Identifier>
+    <Title>Better-Auth CI Tasks</Title>
+    <AppVersion>6f3ba45639579da152b69e8e5342e02f28288670</AppVersion>
+    <Arguments>typecheck</Arguments>
+    <Description>Task: Typecheck</Description>
+    <Scale>Seconds</Scale>
+    <Proportion>LIB</Proportion>
+    <DisplayFormat>BAR_GRAPH</DisplayFormat>
+    <Data>
+      <Entry>
+        <Identifier>ci</Identifier>
+        <Value></Value>
+        <RawString></RawString>
+        <JSON>{"test-run-times":"0.24","error":"The test quit with a non-zero exit status."}</JSON>
+      </Entry>
+    </Data>
+  </Result>
+  <Result>
+    <Identifier>local/realworld-better-auth-1.0.0</Identifier>
+    <Title>Better-Auth CI Tasks</Title>
+    <AppVersion>6f3ba45639579da152b69e8e5342e02f28288670</AppVersion>
+    <Arguments>lint_biome</Arguments>
+    <Description>Task: Lint Biome</Description>
+    <Scale>Seconds</Scale>
+    <Proportion>LIB</Proportion>
+    <DisplayFormat>BAR_GRAPH</DisplayFormat>
+    <Data>
+      <Entry>
+        <Identifier>ci</Identifier>
+        <Value></Value>
+        <RawString></RawString>
+        <JSON>{"test-run-times":"0.21","error":"The test quit with a non-zero exit status."}</JSON>
+      </Entry>
+    </Data>
+  </Result>
+  <Result>
+    <Identifier>local/realworld-better-auth-1.0.0</Identifier>
+    <Title>Better-Auth CI Tasks</Title>
+    <AppVersion>6f3ba45639579da152b69e8e5342e02f28288670</AppVersion>
+    <Arguments>lint_spell</Arguments>
+    <Description>Task: Lint Spell</Description>
+    <Scale>Seconds</Scale>
+    <Proportion>LIB</Proportion>
+    <DisplayFormat>BAR_GRAPH</DisplayFormat>
+    <Data>
+      <Entry>
+        <Identifier>ci</Identifier>
+        <Value></Value>
+        <RawString></RawString>
+        <JSON>{"test-run-times":"0.20","error":"The test quit with a non-zero exit status."}</JSON>
+      </Entry>
+    </Data>
+  </Result>
+  <Result>
+    <Identifier>local/realworld-better-auth-1.0.0</Identifier>
+    <Title>Better-Auth CI Tasks</Title>
+    <AppVersion>6f3ba45639579da152b69e8e5342e02f28288670</AppVersion>
+    <Arguments>lint_types</Arguments>
+    <Description>Task: Lint Types</Description>
+    <Scale>Seconds</Scale>
+    <Proportion>LIB</Proportion>
+    <DisplayFormat>BAR_GRAPH</DisplayFormat>
+    <Data>
+      <Entry>
+        <Identifier>ci</Identifier>
+        <Value></Value>
+        <RawString></RawString>
+        <JSON>{"test-run-times":"0.21","error":"The test quit with a non-zero exit status."}</JSON>
+      </Entry>
+    </Data>
+  </Result>
+  <Result>
+    <Identifier>local/realworld-better-auth-1.0.0</Identifier>
+    <Title>Better-Auth CI Tasks</Title>
+    <AppVersion>6f3ba45639579da152b69e8e5342e02f28288670</AppVersion>
+    <Arguments>lint_format</Arguments>
+    <Description>Task: Lint Format</Description>
+    <Scale>Seconds</Scale>
+    <Proportion>LIB</Proportion>
+    <DisplayFormat>BAR_GRAPH</DisplayFormat>
+    <Data>
+      <Entry>
+        <Identifier>ci</Identifier>
+        <Value></Value>
+        <RawString></RawString>
+        <JSON>{"test-run-times":"0.29","error":"The test quit with a non-zero exit status."}</JSON>
+      </Entry>
+    </Data>
+  </Result>
+  <Result>
+    <Identifier>local/realworld-better-auth-1.0.0</Identifier>
+    <Title>Better-Auth CI Tasks</Title>
+    <AppVersion>6f3ba45639579da152b69e8e5342e02f28288670</AppVersion>
+    <Arguments>cold_install</Arguments>
+    <Description>Task: Cold Install</Description>
+    <Scale>Seconds</Scale>
+    <Proportion>LIB</Proportion>
+    <DisplayFormat>BAR_GRAPH</DisplayFormat>
+    <Data>
+      <Entry>
+        <Identifier>ci</Identifier>
+        <Value>0.215</Value>
+        <RawString></RawString>
+        <JSON>{"test-run-times":"0.30"}</JSON>
+      </Entry>
+    </Data>
+  </Result>
+  <Result>
+    <Identifier>local/realworld-better-auth-1.0.0</Identifier>
+    <Title>Better-Auth CI Tasks</Title>
+    <AppVersion>6f3ba45639579da152b69e8e5342e02f28288670</AppVersion>
+    <Arguments>lint_packages</Arguments>
+    <Description>Task: Lint Packages</Description>
+    <Scale>Seconds</Scale>
+    <Proportion>LIB</Proportion>
+    <DisplayFormat>BAR_GRAPH</DisplayFormat>
+    <Data>
+      <Entry>
+        <Identifier>ci</Identifier>
+        <Value></Value>
+        <RawString></RawString>
+        <JSON>{"test-run-times":"0.24","error":"The test quit with a non-zero exit status."}</JSON>
+      </Entry>
+    </Data>
+  </Result>
+  <Result>
+    <Identifier>local/realworld-better-auth-1.0.0</Identifier>
+    <Title>Better-Auth CI Tasks</Title>
+    <AppVersion>6f3ba45639579da152b69e8e5342e02f28288670</AppVersion>
+    <Arguments>lint_deps</Arguments>
+    <Description>Task: Lint Deps Knip</Description>
+    <Scale>Seconds</Scale>
+    <Proportion>LIB</Proportion>
+    <DisplayFormat>BAR_GRAPH</DisplayFormat>
+    <Data>
+      <Entry>
+        <Identifier>ci</Identifier>
+        <Value></Value>
+        <RawString></RawString>
+        <JSON>{"test-run-times":"0.25","error":"The test quit with a non-zero exit status."}</JSON>
+      </Entry>
+    </Data>
+  </Result>
+</PhoronixTestSuite>

--- a/packages/results/src/lib/extract.test.ts
+++ b/packages/results/src/lib/extract.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, it } from "bun:test";
+import { readFileSync } from "node:fs";
 import { join } from "node:path";
 import { extractProviderDir } from "./extract.ts";
+import { parsePtsComposite, ptsResultToMetric } from "./pts.ts";
 
 const daytonaDir = join(import.meta.dir, "__fixtures__/daytona");
 
@@ -49,6 +51,51 @@ describe("extractProviderDir", () => {
 				sourceFile: "pts_node-web-tooling.xml",
 				arguments: "ok",
 			},
+		]);
+	});
+
+	it("extracts every realworld task from a real end-to-end smoke composite.xml, none uncatalogued", () => {
+		// Captured from a real Docker run of the actual install.sh + realworld-runner.sh + mise task
+		// (packages/results/src/lib/__fixtures__/realworld-smoke/ -- see its header comment for
+		// provenance); 7 of the 11 better-auth tasks were deliberately pointed at `false` to also
+		// exercise the partial-failure path end to end against real PTS output.
+		const dir = join(import.meta.dir, "__fixtures__/realworld-smoke");
+		const extraction = extractProviderDir(dir, "daytona");
+		// The fixture predates the deliberate drop of better-auth's `test` task (needs docker-compose
+		// DB services no sandbox provides); its measured <Result> now routes to `uncatalogued` -- the
+		// designed straggler path, pinned here so an ACCIDENTAL catalog miss can't hide behind it.
+		expect(extraction.uncatalogued.map((u) => u.id)).toEqual([
+			"local/realworld-better-auth::Task: Test",
+		]);
+		expect(extraction.contributions.map((c) => c.metricId).sort()).toEqual(
+			[
+				"realworld_better_auth_task_git_clone",
+				"realworld_better_auth_task_cold_install",
+				"realworld_better_auth_task_build",
+			].sort(),
+		);
+		for (const contribution of extraction.contributions) {
+			expect(contribution.appVersion).toBe("6f3ba45639579da152b69e8e5342e02f28288670");
+			expect(contribution.samples.length).toBeGreaterThan(0);
+			for (const sample of contribution.samples) expect(sample).toBeGreaterThan(0);
+		}
+	});
+
+	it("maps every realworld <Result> onto the catalog, including the 7 all-passes-failed ones", () => {
+		// extractProviderDir drops a valueless (all-passes-failed) <Result> before the catalog router,
+		// so the extraction-level `uncatalogued: []` above can't vouch for the 7 deliberately-failed
+		// tasks. Route every raw <Result> through ptsResultToMetric directly: a drifted <Description>
+		// on ANY of the 11 must surface here, measured or not.
+		const xml = readFileSync(
+			join(import.meta.dir, "__fixtures__/realworld-smoke/pts_realworld-better-auth.xml"),
+			"utf8",
+		);
+		const results = parsePtsComposite(xml).PhoronixTestSuite.Result;
+		expect(results).toHaveLength(11);
+		const kinds = results.map((r) => [r.Description, ptsResultToMetric(r).kind]);
+		// 10 of 11 map; the dropped `test` task is the one expected uncatalogued straggler.
+		expect(kinds.filter(([, kind]) => kind !== "matched")).toEqual([
+			["Task: Test", "uncatalogued"],
 		]);
 	});
 });

--- a/packages/results/src/lib/pts-golden.test.ts
+++ b/packages/results/src/lib/pts-golden.test.ts
@@ -49,6 +49,18 @@ function discoverComposites(): [string, string][] {
 
 const composites = discoverComposites();
 
+/**
+ * Tasks deliberately removed from a profile AFTER its composite was recorded. Recorded fixtures are
+ * never hand-edited (they prove the byte-match against real PTS output), so a dropped task's
+ * `<Result>` now legitimately routes to `uncatalogued`. Every entry documents a deliberate drop;
+ * anything not listed here must still resolve.
+ */
+const DROPPED_RESULTS = new Set([
+	// better-auth's `test` needs docker-compose DB services (postgres, mongodb) no provider sandbox
+	// provides -- removed from the profile in the ENG-136 review; the fixture predates the drop.
+	'local/realworld-better-auth | "Task: Test"',
+]);
+
 describe("golden composite byte-match (design §3.7)", () => {
 	it("discovers at least one recorded composite fixture", () => {
 		// A zero-fixture run would make every per-fixture assertion below vacuously pass — fail loudly
@@ -68,7 +80,7 @@ describe("golden composite byte-match (design §3.7)", () => {
 					? [`${mapping.test} | "${mapping.description}"`]
 					: [];
 			});
-			expect(uncatalogued).toEqual([]);
+			expect(uncatalogued.filter((id) => !DROPPED_RESULTS.has(id))).toEqual([]);
 		});
 	}
 });

--- a/packages/schema/src/suites.test.ts
+++ b/packages/schema/src/suites.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "bun:test";
-import { paddedSuiteToken, padSuiteList, SUITE_NAMES, SUITES } from "./index.ts";
+import { METRIC_CATALOG, paddedSuiteToken, padSuiteList, SUITE_NAMES, SUITES } from "./index.ts";
 
 describe("suite registry", () => {
 	it("registers cpu-node as a PTS- and Node-backed suite", () => {
@@ -16,7 +16,35 @@ describe("suite registry", () => {
 	});
 
 	it("exposes the suite names", () => {
-		expect(SUITE_NAMES).toEqual(["cpu-node", "system", "memory", "disk"]);
+		expect(SUITE_NAMES).toEqual([
+			"cpu-node",
+			"system",
+			"memory",
+			"disk",
+			"realworld-mastra",
+			"realworld-better-auth",
+			"realworld-openclaw",
+		]);
+	});
+
+	it("mirrors each realworld suite's metrics from the generated catalog (no hand-drift)", () => {
+		// The task set already lives in test-definition.xml, target.env, and the generated catalog;
+		// this pins the fourth (hand-maintained) copy in SUITES to the catalog in BOTH directions, so
+		// an added/removed/renamed task can't leave a suite emitting an undeclared metric or
+		// declaring a metric its profile no longer produces.
+		const profileOf = {
+			"realworld-mastra": "local/realworld-mastra",
+			"realworld-better-auth": "local/realworld-better-auth",
+			"realworld-openclaw": "local/realworld-openclaw",
+		} as const;
+		for (const [suiteName, ptsTest] of Object.entries(profileOf)) {
+			const fromCatalog = METRIC_CATALOG.filter((m) => m.pts?.test === ptsTest)
+				.map((m) => m.id)
+				.sort();
+			expect(fromCatalog.length).toBeGreaterThan(0);
+			const declared: string[] = [...SUITES[suiteName as keyof typeof SUITES].metrics];
+			expect(declared.sort()).toEqual(fromCatalog);
+		}
 	});
 
 	it("keeps command timeouts within the requested sandbox lifetime", () => {

--- a/packages/schema/src/suites.ts
+++ b/packages/schema/src/suites.ts
@@ -96,6 +96,67 @@ export const SUITES = {
 		metrics: ["hardlink_bogo_ops_per_s"],
 		commands: ["mise run benchmark:disk:all"],
 	},
+	// The realworld dimension (ENG-135/136/137/138): real OSS repos run through their own CI tasks,
+	// each a repo-local PTS profile with a Task option axis. Budgets are starting points (tuned from
+	// smoke); mastra's task matrix is the narrowest (scoped to packages/core) but its monorepo has
+	// the largest install/build footprint — hence the biggest minDiskGb. better-auth and openclaw
+	// run their full task matrices including a cold pnpm install and a full build.
+	"realworld-mastra": {
+		setupPts: true,
+		setupNode: true,
+		commandTimeoutMinutes: 90,
+		timeoutMinutes: 105,
+		minDiskGb: 30,
+		dimensions: ["realworld"],
+		metrics: [
+			"realworld_mastra_task_git_clone",
+			"realworld_mastra_task_cold_install",
+			"realworld_mastra_task_lint_format",
+			"realworld_mastra_task_build_core",
+			"realworld_mastra_task_test_core",
+		],
+		commands: ["mise run benchmark:realworld:pts:mastra"],
+	},
+	"realworld-better-auth": {
+		setupPts: true,
+		setupNode: true,
+		commandTimeoutMinutes: 60,
+		timeoutMinutes: 75,
+		minDiskGb: 10,
+		dimensions: ["realworld"],
+		metrics: [
+			"realworld_better_auth_task_git_clone",
+			"realworld_better_auth_task_cold_install",
+			"realworld_better_auth_task_lint_biome",
+			"realworld_better_auth_task_lint_deps_knip",
+			"realworld_better_auth_task_lint_format",
+			"realworld_better_auth_task_lint_spell",
+			"realworld_better_auth_task_lint_types",
+			"realworld_better_auth_task_lint_packages",
+			"realworld_better_auth_task_typecheck",
+			"realworld_better_auth_task_build",
+		],
+		commands: ["mise run benchmark:realworld:pts:better-auth"],
+	},
+	"realworld-openclaw": {
+		setupPts: true,
+		setupNode: true,
+		commandTimeoutMinutes: 90,
+		timeoutMinutes: 105,
+		minDiskGb: 25,
+		dimensions: ["realworld"],
+		metrics: [
+			"realworld_openclaw_task_git_clone",
+			"realworld_openclaw_task_cold_install",
+			"realworld_openclaw_task_lint_oxlint",
+			"realworld_openclaw_task_lint_format",
+			"realworld_openclaw_task_typecheck",
+			"realworld_openclaw_task_shrinkwrap_check",
+			"realworld_openclaw_task_test_unit_fast",
+			"realworld_openclaw_task_build",
+		],
+		commands: ["mise run benchmark:realworld:pts:openclaw"],
+	},
 } as const satisfies Record<string, Suite>;
 
 /** A registered suite name. */


### PR DESCRIPTION
**ENG-135/136/137/138 — realworld PTS profiles as suites (final PR)**
Top of the ENG-135 stack: profile PRs (#93/#94/#95) → wiring PRs (#96/#97/#98) → this PR.

↑ **This PR is #99**, stacked on #98.

**Goal:** make the three realworld suites first-class: registered in the SUITES registry (so bench-suite, the CI matrix, and the normalizer all see them), dispatchable from bench-smoke, and documented.

**Approach:** three `Suite` entries (dimensions, metric lists, per-suite time/disk budgets, `mise run` commands), the bench-smoke.yml suite options refresh, a real end-to-end extraction fixture, and docs for the pattern.

**Precautions:** the workflow-registry drift gate keeps bench-smoke's options in lockstep with the registry — a new suite that skips the workflow edit fails CI. The fixture is a real composite.xml from a Docker run of the actual scripts (7 of 11 tasks deliberately failed to exercise the partial-failure path); a catalog-matcher test routes all 11 `<Result>`s — including the valueless failed ones extraction drops pre-router — so a drifted `<Description>` fails even on unmeasured tasks. Budgets are starting points tuned from smoke; mastra's task matrix is the narrowest but its monorepo install footprint needs the largest disk budget.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Registers three realworld suites, syncs them to CI smoke options, and adds a real end-to-end PTS fixture. Completes ENG-135 and removes manual matrix/workflow wiring via the `SUITES`-derived plan matrix.

- **New Features**
  - Added `realworld-mastra`, `realworld-better-auth`, and `realworld-openclaw` to `SUITES` with `setupPts` + `setupNode`, dimension `["realworld"]`, explicit metrics, and single `mise` commands. Budgets: mastra 90/105 min & 30 GB; better-auth 60/75 min & 10 GB; openclaw 90/105 min & 25 GB. Synced and drift-gated `SUITE_NAMES` with `.github/workflows/bench-smoke.yml` so smoke runs can target them.
  - Catalog gate mirrors each realworld suite’s metrics to `METRIC_CATALOG` (both directions). Dropped `realworld_better_auth_task_test` (needs docker-compose DBs). Tests route all 11 `<Result>`s through `ptsResultToMetric`; the fixture’s “Task: Test” is expected `uncatalogued` and allowlisted in the golden check. Extraction asserts mapped contributions and `AppVersion`.
  - Docs: added the realworld profile pattern, the local-profile contract, `target.env` as the config seam, avoiding parentheses in Entry names, and the runner path `lib/pts/realworld/`.

<sup>Written for commit e9395a5b21b73ea902f152d494ab085ca24fe7a4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/starslingdev/sandbox-benchmarks/pull/99?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

