### PR TITLE
feat(providers): wire the blaxel provider (schema meta + adapter + CI options)

### DIFF
--- a/.github/workflows/bench-matrix.yml
+++ b/.github/workflows/bench-matrix.yml
@@ -93,6 +93,8 @@ jobs:
           E2B_API_KEY: ${{ secrets.E2B_API_KEY }}
           MODAL_TOKEN_ID: ${{ secrets.MODAL_TOKEN_ID }}
           MODAL_TOKEN_SECRET: ${{ secrets.MODAL_TOKEN_SECRET }}
+          BL_API_KEY: ${{ secrets.BL_API_KEY }}
+          BL_WORKSPACE: ${{ secrets.BL_WORKSPACE }}
         run: bun apps/cli/src/bin/bench-suite.ts "$BENCH_PROVIDER" "$BENCH_SUITE" "$GITHUB_RUN_ID"
 
       - name: Upload Run + raw results

--- a/.github/workflows/bench-smoke.yml
+++ b/.github/workflows/bench-smoke.yml
@@ -10,7 +10,7 @@ on:
         description: Provider to benchmark
         type: choice
         default: daytona
-        options: [daytona, e2b, modal]
+        options: [daytona, e2b, modal, blaxel]
       suite:
         # Constrained to the SUITE_NAMES registry (packages/schema/src/suites.ts); the
         # workflow-registry-sync drift gate (tooling/repo-checks) keeps this list in lockstep, so a
@@ -94,6 +94,8 @@ jobs:
           E2B_API_KEY: ${{ secrets.E2B_API_KEY }}
           MODAL_TOKEN_ID: ${{ secrets.MODAL_TOKEN_ID }}
           MODAL_TOKEN_SECRET: ${{ secrets.MODAL_TOKEN_SECRET }}
+          BL_API_KEY: ${{ secrets.BL_API_KEY }}
+          BL_WORKSPACE: ${{ secrets.BL_WORKSPACE }}
         run: bun apps/cli/src/bin/bench-suite.ts "$BENCH_PROVIDER" "$BENCH_SUITE" "$GITHUB_RUN_ID"
 
       - name: Upload Run + raw results

--- a/apps/cli/src/bin/bake.ts
+++ b/apps/cli/src/bin/bake.ts
@@ -28,6 +28,9 @@ const bakers: Record<ProviderId, (log: Log) => Promise<void>> = {
 	daytona: (log) =>
 		bakeDaytonaSnapshot(config.daytonaSnapshotCandidate, config.toolchainImageCandidate, log),
 	modal: bakeModalImage,
+	blaxel: async (log) => {
+		log("blaxel boots the stock base image — no candidate artifact to bake");
+	},
 };
 
 const candidateRefs = {

--- a/apps/cli/src/lib/bake/promote.ts
+++ b/apps/cli/src/lib/bake/promote.ts
@@ -91,6 +91,9 @@ export async function promoteAll(log: Log): Promise<BakeReport[]> {
 				case "modal":
 					log("    modal boots the published version image — nothing to build");
 					break;
+				case "blaxel":
+					log("    blaxel boots the stock base image — nothing to promote");
+					break;
 				default: {
 					// Exhaustiveness: a new ProviderId must add a promote branch above (compile error here).
 					const unhandled: never = provider.name;

--- a/apps/cli/src/lib/bake/validate.ts
+++ b/apps/cli/src/lib/bake/validate.ts
@@ -27,5 +27,8 @@ export function candidateCreateOptions(
 			};
 		case "modal":
 			return { templateId: refs.toolchainImageCandidate };
+		case "blaxel":
+			// Stock base image — no candidate artifact to point at.
+			return {};
 	}
 }

--- a/packages/providers/src/lib/adapters.ts
+++ b/packages/providers/src/lib/adapters.ts
@@ -3,6 +3,7 @@
 // computesdk's universal sandbox (runCommand with daemon-backed streaming, filesystem, destroy), so
 // nothing here re-wraps an SDK — these are pure config. Credentials are read from each provider's
 // env vars by its factory.
+import { blaxel } from "@computesdk/blaxel";
 import { daytona } from "@computesdk/daytona";
 import { e2b } from "@computesdk/e2b";
 import { modal } from "@computesdk/modal";
@@ -39,6 +40,15 @@ export const adapters: Record<ProviderId, ProviderAdapter> = {
 			...(daytonaRegion.target ? { target: daytonaRegion.target } : {}),
 		},
 		requiredEnvVars: [daytonaRegion.apiKeyVar],
+	},
+	blaxel: {
+		// Credentials come from BL_API_KEY/BL_WORKSPACE (the factory's env fallback). The stock
+		// base-image is Alpine (no apt — PTS uninstallable) and disk is a tmpfs overlay carved from VM
+		// RAM (~78%), so boot the Debian ts-app image and buy disk with memory: 16384 MB ≈ 12.5 GiB
+		// disk. No pre-baked toolchain snapshot yet — setup steps run their fallback paths.
+		createCompute: () =>
+			blaxel({ image: "blaxel/ts-app:latest", memory: 16384, region: "us-pdx-1" }),
+		createOptions: {},
 	},
 	modal: {
 		createCompute: () => modal({ scalableSandboxes: true }),

--- a/packages/results/src/index.test.ts
+++ b/packages/results/src/index.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "bun:test";
 import { join } from "node:path";
+import { PROVIDERS } from "@sandbox-benchmarks/schema";
 import { normalizeResultsTree, summarizeRun } from "./index.ts";
 
 // The committed fixture tree has one provider directory (daytona) holding a real node-web-tooling
@@ -16,11 +17,9 @@ describe("normalizeResultsTree", () => {
 
 	it("validates as a Run and includes every known provider", () => {
 		expect(run.schemaVersion).toBe("1");
-		expect(run.providers.map((provider) => provider.providerId).sort()).toEqual([
-			"daytona",
-			"e2b",
-			"modal",
-		]);
+		expect(run.providers.map((provider) => provider.providerId).sort()).toEqual(
+			PROVIDERS.map((provider) => provider.id).sort(),
+		);
 	});
 
 	it("normalizes daytona's node-web-tooling into an aggregated, validated metric", () => {
@@ -49,6 +48,6 @@ describe("normalizeResultsTree", () => {
 	});
 
 	it("summarizes one line per provider", () => {
-		expect(summarizeRun(run)).toHaveLength(3);
+		expect(summarizeRun(run)).toHaveLength(PROVIDERS.length);
 	});
 });

--- a/packages/schema/src/providers.test.ts
+++ b/packages/schema/src/providers.test.ts
@@ -18,6 +18,12 @@ const fixture: ProviderMeta = {
 };
 
 describe("@sandbox-benchmarks/schema providers", () => {
+	it("pins the registered provider id set (the independent oracle downstream joins derive from)", () => {
+		// Deliberately hardcoded: downstream tests (e.g. results' normalizeResultsTree) assert their
+		// output against PROVIDERS, so this pin is what makes an accidental registry removal loud.
+		expect(PROVIDERS.map((p) => p.id).sort()).toEqual(["blaxel", "daytona", "e2b", "modal"]);
+	});
+
 	it("keeps the registry well-formed (unique ids, non-empty required env vars)", () => {
 		const ids = PROVIDERS.map((p) => p.id);
 		expect(new Set(ids).size).toBe(ids.length);

--- a/packages/schema/src/providers.ts
+++ b/packages/schema/src/providers.ts
@@ -11,7 +11,7 @@
  * matching {@link REGISTRY} entry (the Record type below makes a missing or extra id a compile
  * error) and, downstream, a harness adapter in @sandbox-benchmarks/providers.
  */
-export type ProviderId = "e2b" | "daytona" | "modal";
+export type ProviderId = "e2b" | "daytona" | "modal" | "blaxel";
 
 /** Can the SDK request a pinned target spec (vCPU / memory) at create() time? */
 export type SpecPinning = "settable" | "fixed" | "unknown";
@@ -204,6 +204,38 @@ const REGISTRY: Record<ProviderId, Omit<ProviderMeta, "id">> = {
 			// server threshold is unmeasured (sub-second probes succeed; multi-minute execs 408), so the
 			// bound is a conservative 60s policy: budget anything longer to the detached+poll path
 			// (`background` via nohup + the pollable filesystem).
+			streaming: false,
+			syncCapMs: 60_000,
+			detachedPoll: true,
+		},
+	},
+	blaxel: {
+		displayName: "Blaxel",
+		website: "https://blaxel.ai",
+		sdkPackage: "@computesdk/blaxel",
+		requiredEnvVars: ["BL_API_KEY", "BL_WORKSPACE"],
+		isolation: {
+			technology: "microVM",
+			notes:
+				"Blaxel sandboxes (sub-25ms boot claim). Spec dimensions are COUPLED: CPU cores = memory MB / 2048 and disk is a tmpfs overlay at ~78% of memory, so the 2 vCPU / 8 GiB / 20 GB target spec is inexpressible -- the adapter runs oversized (16 GiB => 8-core allocation, ~12.5 GiB disk) and relies on observed-specs disclosure (specMatched=false) downstream.",
+		},
+		pricing: {
+			model: "unknown",
+			notes: "Not yet vetted against a published per-second rate.",
+			sourceUrl: "https://blaxel.ai/pricing",
+		},
+		maturity: {
+			status: "beta",
+			notes:
+				"Local e2e validation wiring; not yet a committed run. Realworld suites with minDiskGb > ~12.5 (mastra 30, openclaw 25) skip on the harness disk gate until Blaxel exposes disk independently of memory.",
+		},
+		// Values ARE settable, but the CPU/disk coupling makes the shared target spec unreachable --
+		// "fixed" is the honest capability for cross-provider comparability purposes.
+		specPinning: "fixed",
+		transport: {
+			// `@computesdk/blaxel` execs through the sandbox gateway; long synchronous execs are not
+			// validated, so apply the conservative 60s policy bound and use the detached+poll path
+			// (background nohup + pollable filesystem, both supported by the wrapper) for long steps.
 			streaming: false,
 			syncCapMs: 60_000,
 			detachedPoll: true,


### PR DESCRIPTION
**Goal:** register Blaxel as the fourth sandbox provider so every suite — including the realworld family below this stack — can run on it via `bench-suite` and the CI dispatch workflows.

**Approach (stacked on #100, the deps chore):**
- **Schema** `ProviderMeta`: credentials `BL_API_KEY`/`BL_WORKSPACE`, pricing `unknown` (no vetted rate yet), and a conservative transport — 60s sync-cap policy bound with detached+poll, since long synchronous execs through the wrapper are unvalidated.
- **Adapter**: boots the Debian `blaxel/ts-app` image — the Alpine `base-image` has no apt, so PTS can't install — with `memory: 16384`, because Blaxel's sandbox disk is a tmpfs overlay carved from VM RAM (~78%): 16 GiB RAM ≈ 12.5 GiB disk. No pre-baked toolchain artifact yet; setup steps run their fallback paths (bake CLI gets explicit no-op stubs).
- **CI**: blaxel added to bench-smoke's provider options; `BL_API_KEY`/`BL_WORKSPACE` wired into both bench-smoke and bench-matrix run-step envs (the workflow-registry drift gate enforces exactly this).

**Precautions:** validated live before landing — all three realworld suites ran end-to-end on real Blaxel sandboxes (fallback setup path, PTS batch runs, results collected + normalized; blaxel reported `validated` with real metrics in all three Runs), plus four further verification runs during the measurement-architecture hardening, the final one clean: 10/10 metrics, build 9.9s ±1.0%, FULL-TURBO prep replays (see #96). The provider id set is pinned as an independent oracle in schema tests; results tests assert the registry join rather than duplicating the list.

⚠️ **Post-merge setup:** the `BL_API_KEY` and `BL_WORKSPACE` repo secrets must be added in GitHub settings before a blaxel CI dispatch will pass its credential gate (missing creds record a skip, not a failure).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds Blaxel as a provider across schema, adapter, CLI, and CI so benches can run on Blaxel via `@computesdk/blaxel`. Spec coupling sets `specPinning: fixed` and uses a 16 GiB shape (~12.5 GiB disk); validated end-to-end on a real sandbox.

- **New Features**
  - Schema: adds `blaxel` with `BL_API_KEY`/`BL_WORKSPACE`, 60s sync cap + detached/poll; documents CPU/disk coupling, oversize, and disk-gate skips.
  - Adapter: uses `blaxel/ts-app:latest` (Debian) with `memory: 16384`, region `us-pdx-1`.
  - CLI/CI: bake/promote are no-ops; validate uses the stock base image. Adds `blaxel` to `bench-smoke` options and passes `BL_API_KEY`/`BL_WORKSPACE` in both `bench-smoke` and `bench-matrix`.
  - Tests: schema pins the provider id set; results derive expected providers from `PROVIDERS`.

- **Migration**
  - Add GitHub secrets `BL_API_KEY` and `BL_WORKSPACE`.
  - Select provider `blaxel` when running `bench-smoke` or `bench-matrix`.

<sup>Written for commit 4556a2e27cf5556eb7d7abc1648901146301f920. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/starslingdev/sandbox-benchmarks/pull/101?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

