### PR TITLE
feat(bench): docker selftest for the realworld runner/PTS contract (~4 min local loop)

### DIFF
--- a/.mise/tasks/benchmark/realworld/selftest
+++ b/.mise/tasks/benchmark/realworld/selftest
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+#MISE description="Realworld runner/PTS contract selftest in a local Docker container (~3 min, no provider)"
+# Fast local iteration on the realworld machinery: runs lib/pts/realworld/selftest-payload.sh in a
+# throwaway node:22-bookworm container against a synthetic fixture repo — the full
+# run_realworld_pts -> PTS -> sentinel -> composite chain with second-scale tasks and hard
+# assertions (menu-order execution, prep-time exclusion, warm-up-once). Requires Docker.
+set -euo pipefail
+REPO_ROOT="$(git -C "$(dirname "${BASH_SOURCE[0]}")" rev-parse --show-toplevel)"
+
+command -v docker >/dev/null 2>&1 || { echo "ERROR: docker is required for the selftest" >&2; exit 1; }
+
+OUT_DIR="${REPO_ROOT}/.scratch/selftest-out"
+# Start each selftest from a clean output dir: stale artifacts from a prior run must not leak into
+# /out and mask a regression (the whole point of the selftest is a hermetic pass/fail).
+rm -rf "$OUT_DIR"
+mkdir -p "$OUT_DIR"
+exec docker run --rm \
+	-v "${REPO_ROOT}:/repo:ro" \
+	-v "${OUT_DIR}:/out" \
+	node:22-bookworm@sha256:a25c9934ff6382cd4f08b6bc26c82bf4ea69b1e6f8dabfb2ead457374127c365 \
+	bash /repo/lib/pts/realworld/selftest-payload.sh

--- a/lib/pts/realworld/selftest-payload.sh
+++ b/lib/pts/realworld/selftest-payload.sh
@@ -1,0 +1,93 @@
+#!/usr/bin/env bash
+# Realworld-machinery selftest — the IN-CONTAINER payload behind `mise run benchmark:realworld:selftest`.
+# Exercises the full production chain (run_realworld_pts -> install_local_pts_profile -> shared
+# install.sh -> PTS batch-install/batch-run -> realworld-runner.sh -> sentinel -> composite.xml)
+# against a tiny synthetic fixture repo with second-scale task commands, then asserts the contract:
+#   - every task produced a numeric sample in composite.xml,
+#   - tasks execute in Task-menu order (TEST_EXECUTION_SORT=none),
+#   - a TASK_PREP command's duration is EXCLUDED from its task's measured value,
+#   - the no-prep warm-up executes the command exactly once before the measured run.
+# Fixture + profile templates and the assertion script live in ./selftest/ (real .xml/.json/.mjs
+# files, not heredocs); @PIN_SHA@/@FIXTURE@ placeholders are substituted here at runtime.
+# Runs on any Docker host in ~2-4 minutes; no provider credentials, no real OSS repo.
+set -euo pipefail
+
+PTS_VERSION=10.8.4
+COUNTS=/tmp/counts
+FIXTURE=/tmp/fixture
+WORK=/work
+RESULTS=/tmp/results
+SELFTEST_SRC=/repo/lib/pts/realworld/selftest
+
+# Registered BEFORE any failable step: under set -e an early failure (PTS install, fixture build,
+# the production run itself) must still export its forensics. /out is a host mount (the mise task
+# provides it) — the only thing surviving --rm.
+export_artifacts() {
+	if [ -d /out ]; then
+		cp -r "$COUNTS" /out/counts 2>/dev/null || true
+		cp -r "$RESULTS" /out/results 2>/dev/null || true
+		cp -r /var/lib/phoronix-test-suite/test-results /out/pts-test-results 2>/dev/null || true
+	fi
+}
+trap 'export_artifacts' EXIT
+
+echo "=== [selftest] install PTS + php ==="
+export DEBIAN_FRONTEND=noninteractive
+apt-get update -qq
+apt-get install -y -qq php-cli php-xml >/dev/null
+curl -fsSL --retry 3 -o /tmp/pts.deb \
+	"https://github.com/phoronix-test-suite/phoronix-test-suite/releases/download/v${PTS_VERSION}/phoronix-test-suite_${PTS_VERSION}_all.deb"
+dpkg -i /tmp/pts.deb >/dev/null 2>&1 || apt-get install -y -qq -f >/dev/null
+phoronix-test-suite version | head -1
+
+echo "=== [selftest] build fixture repo ==="
+export COREPACK_ENABLE_DOWNLOAD_PROMPT=0
+corepack enable
+mkdir -p "$COUNTS" "$FIXTURE" "$RESULTS"
+cd "$FIXTURE"
+cp "$SELFTEST_SRC/fixture-package.json" package.json
+printf 'node_modules/\ndist/\n' > .gitignore
+pnpm install --silent
+git init -q .
+git config user.email selftest@example.com
+git config user.name selftest
+git add -A
+git commit -qm fixture
+# git_clone / install.sh fetch a bare SHA over the file:// transport; upload-pack refuses
+# unadvertised-object requests unless the serving repo opts in.
+git config uploadpack.allowAnySHA1InWant true
+PIN_SHA="$(git rev-parse HEAD)"
+
+echo "=== [selftest] assemble workspace + synthetic profile ==="
+PROFILE="$WORK/packages/schema/src/pts-profiles/local/realworld-selftest-1.0.0"
+mkdir -p "$PROFILE"
+cp -r /repo/lib "$WORK/lib"
+sed -e "s|@PIN_SHA@|${PIN_SHA}|g" "$SELFTEST_SRC/test-definition.xml" > "$PROFILE/test-definition.xml"
+sed -e "s|@PIN_SHA@|${PIN_SHA}|g" -e "s|@FIXTURE@|${FIXTURE}|g" "$SELFTEST_SRC/target.env" > "$PROFILE/target.env"
+# The REAL parser definition, not a copy — the selftest validates the sentinel against exactly what
+# production profiles ship.
+cp /repo/packages/schema/src/pts-profiles/local/realworld-mastra-1.0.0/results-definition.xml \
+	"$PROFILE/results-definition.xml"
+
+echo "=== [selftest] run the production path ==="
+export REPO_ROOT="$WORK"
+export BENCHMARK_RESULTS_DIR="$RESULTS"
+# shellcheck source=/dev/null
+source "$WORK/lib/bench.sh"
+run_realworld_pts selftest
+
+echo "=== [selftest] assertions ==="
+COMPOSITE="$RESULTS/pts_realworld-selftest.xml"
+test -f "$COMPOSITE" || { echo "FAIL: no composite.xml at $COMPOSITE" >&2; exit 1; }
+node "$SELFTEST_SRC/assert-composite.mjs" "$COMPOSITE"
+
+# Execution-count proofs (fixture scripts append one line per run to /tmp/counts/<name>):
+#   build:  Build task = warm-up + measured (2) + Prepped's prep (1)          = 3
+#   lint:   Plain task = warm-up + measured                                    = 2
+#   test:   Prepped is prep-carrying, so NO warm-up: measured only             = 1
+count() { if [ -f "$COUNTS/$1" ]; then wc -l < "$COUNTS/$1" | tr -d ' '; else echo 0; fi; }
+[ "$(count build)" = "3" ] || { echo "FAIL: build executed $(count build)x, expected 3 (warm-up+measured+prep)" >&2; exit 1; }
+[ "$(count lint)" = "2" ] || { echo "FAIL: lint executed $(count lint)x, expected 2 (warm-up+measured)" >&2; exit 1; }
+[ "$(count test)" = "1" ] || { echo "FAIL: test executed $(count test)x, expected 1 (no warm-up on prep tasks)" >&2; exit 1; }
+echo "execution-count assertions OK (build=3 lint=2 test=1)"
+echo "SELFTEST PASS"

--- a/lib/pts/realworld/selftest/assert-composite.mjs
+++ b/lib/pts/realworld/selftest/assert-composite.mjs
@@ -1,0 +1,47 @@
+// Composite assertions for the realworld selftest (invoked by selftest-payload.sh with the
+// composite.xml path). Fails loudly with a FAIL: line and exit 1 on any contract violation.
+import { readFileSync } from "node:fs";
+
+const xml = readFileSync(process.argv[2], "utf8");
+// Scope to <Result> blocks: the composite header carries its own <Description> which must not
+// shift the pairing, and a failed task's <Value> is empty.
+const results = [...xml.matchAll(/<Result>[\s\S]*?<\/Result>/g)].map(([block]) => {
+	const desc = block.match(/<Description>([^<]*)<\/Description>/)?.[1];
+	const value = block.match(/<Value>([^<]*)<\/Value>/)?.[1] ?? "";
+	return [desc, Number(value)];
+});
+const byDesc = Object.fromEntries(results);
+const fail = (msg) => {
+	console.error("FAIL:", msg);
+	process.exit(1);
+};
+
+const expected = [
+	"Task: Git Clone",
+	"Task: Cold Install",
+	"Task: Build",
+	"Task: Plain",
+	"Task: Prepped",
+];
+for (const d of expected) {
+	if (!(d in byDesc)) fail(`missing result for "${d}"`);
+	if (!Number.isFinite(byDesc[d]) || byDesc[d] <= 0)
+		fail(`non-numeric value for "${d}": ${byDesc[d]}`);
+}
+// Execution order == menu order (TEST_EXECUTION_SORT=none). The composite preserves run order.
+const order = results.map(([d]) => d).filter((d) => expected.includes(d));
+if (JSON.stringify(order) !== JSON.stringify(expected))
+	fail(`execution order ${order} != menu order`);
+// Timing windows. build sleeps 2s, lint 0.5s, test 1s. Lower bounds are hard (a too-fast sample
+// means the command didn't really run); upper bounds are loose for loaded hosts — EXCEPT Prepped's,
+// which must stay below the 3.0s leak floor (2s prep + 1s test) to keep the core assertion sound.
+const inWindow = (d, lo, hi) => byDesc[d] >= lo && byDesc[d] <= hi;
+if (!inWindow("Task: Build", 1.9, 6.0)) fail(`Build ${byDesc["Task: Build"]}s outside [1.9, 6.0]`);
+if (!inWindow("Task: Plain", 0.4, 2.5)) fail(`Plain ${byDesc["Task: Plain"]}s outside [0.4, 2.5]`);
+// THE core assertion: Prepped measures only its 1s test — the 2s prep must be excluded. A leak
+// lands at >= 3.0s, so the ceiling stays strictly below that.
+if (!inWindow("Task: Prepped", 0.9, 2.7))
+	fail(
+		`Prepped ${byDesc["Task: Prepped"]}s outside [0.9, 2.7] — prep time leaked into the measured window?`,
+	);
+console.log("composite assertions OK:", JSON.stringify(byDesc));

--- a/lib/pts/realworld/selftest/fixture-package.json
+++ b/lib/pts/realworld/selftest/fixture-package.json
@@ -1,0 +1,10 @@
+{
+  "name": "selftest-fixture",
+  "private": true,
+  "packageManager": "pnpm@10.12.1",
+  "scripts": {
+    "build": "mkdir -p dist && echo ok > dist/out.txt && echo x >> /tmp/counts/build && sleep 2",
+    "lint": "echo x >> /tmp/counts/lint && sleep 0.5",
+    "test": "test -f dist/out.txt && echo x >> /tmp/counts/test && sleep 1"
+  }
+}

--- a/lib/pts/realworld/selftest/target.env
+++ b/lib/pts/realworld/selftest/target.env
@@ -1,0 +1,12 @@
+# Synthetic selftest target.env TEMPLATE -- @PIN_SHA@ and @FIXTURE@ substituted at runtime by
+# selftest-payload.sh. Task commands are second-scale with execution counters (see
+# fixture-package.json); Prepped declares a TASK_PREP so the prep-exclusion contract is asserted.
+REPO_URL="file://@FIXTURE@"
+PIN_SHA="@PIN_SHA@"
+NODE_VERSION="22"
+TASK_CMD_git_clone=""
+TASK_CMD_cold_install="pnpm install --frozen-lockfile"
+TASK_CMD_build="pnpm run build"
+TASK_CMD_plain="pnpm run lint"
+TASK_PREP_prepped="pnpm run build"
+TASK_CMD_prepped="pnpm run test"

--- a/lib/pts/realworld/selftest/test-definition.xml
+++ b/lib/pts/realworld/selftest/test-definition.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0"?>
+<!--Synthetic realworld-selftest profile TEMPLATE (never vendored into packages/schema): the
+selftest payload substitutes @PIN_SHA@ at runtime and installs it via the production
+install_local_pts_profile path. results-definition.xml is deliberately absent here — the payload
+copies a real profile's, so the selftest exercises the actual parser definition.-->
+<PhoronixTestSuite>
+  <TestInformation>
+    <Title>Realworld Selftest</Title>
+    <AppVersion>@PIN_SHA@</AppVersion>
+    <Description>Synthetic fixture exercising the realworld runner contract.</Description>
+    <Executable>realworld-run</Executable>
+    <ResultScale>Seconds</ResultScale>
+    <Proportion>LIB</Proportion>
+    <TimesToRun>1</TimesToRun>
+  </TestInformation>
+  <TestProfile>
+    <Version>1.0.0</Version>
+    <SupportedPlatforms>Linux</SupportedPlatforms>
+    <SoftwareType>Benchmark</SoftwareType>
+    <TestType>System</TestType>
+    <License>Free</License>
+    <Status>Verified</Status>
+    <EnvironmentSize>1</EnvironmentSize>
+    <ProjectURL>https://example.com</ProjectURL>
+    <Maintainer>StarSling</Maintainer>
+  </TestProfile>
+  <TestSettings>
+    <Option>
+      <DisplayName>Task</DisplayName>
+      <Identifier>task</Identifier>
+      <Menu>
+        <Entry><Name>Git Clone</Name><Value>git_clone</Value></Entry>
+        <Entry><Name>Cold Install</Name><Value>cold_install</Value></Entry>
+        <Entry><Name>Build</Name><Value>build</Value></Entry>
+        <Entry><Name>Plain</Name><Value>plain</Value></Entry>
+        <Entry><Name>Prepped</Name><Value>prepped</Value></Entry>
+      </Menu>
+    </Option>
+  </TestSettings>
+</PhoronixTestSuite>


### PR DESCRIPTION
**Goal:** a ~4-minute, credential-free local iteration loop for the realworld benchmark machinery — the full production chain, not a unit-level approximation. Contract changes to the runner/install/PTS path get proven here in minutes before any provider spend.

**Approach:** `mise run benchmark:realworld:selftest` runs `lib/pts/realworld/selftest-payload.sh` in a throwaway, digest-pinned `node:22-bookworm` container: it installs PTS, builds a tiny synthetic fixture repo (second-scale `build`/`lint`/`test` scripts that append to execution counters), and drives the real `run_realworld_pts` → shared `install.sh` → PTS batch-install/run → `realworld-runner.sh` → sentinel → composite.xml path. Fixtures are real files under `lib/pts/realworld/selftest/` (XML template with `@PIN_SHA@` substitution, `target.env` template, `fixture-package.json`, `assert-composite.mjs`) — no heredocs. The profile is generated at runtime, never vendored: schema registry, catalog, and consistency gates stay untouched. `results-definition.xml` is deliberately not duplicated — the payload copies the real mastra profile's at runtime, so the selftest validates the sentinel against exactly the parser definition production ships.

**Hard assertions (all verified in the shipped run):**
- every task yields a numeric sample in composite.xml; execution order == Task-menu order (`TEST_EXECUTION_SORT=none`)
- **prep-time exclusion** — `Prepped` (2s `TASK_PREP` + 1s command) measures ~1.2s; its ceiling (2.7s) sits strictly below the 3.0s leak floor, so a regression cannot hide
- **warm-up-exactly-once** — counter-proven executions: build=3 (warm-up + measured + prep), lint=2, test=1 (prep tasks skip warm-up)
- timing lower bounds are hard (a too-fast sample means the command didn't run); upper bounds tolerate loaded hosts

**Validation record.** The selftest passed end-to-end on every iteration of this PR (final: `Git Clone 0.02s, Cold Install 0.42s, Build 2.17s, Plain 0.68s, Prepped 1.19s` — `SELFTEST PASS`). Building it caught three real defects before any sandbox spend: `file://` SHA fetches need `uploadpack.allowAnySHA1InWant`; a fixture without `.gitignore` commits `node_modules` and breaks the runner's cold-reset assertion; and a composite parser that pairs the header `<Description>` with result values. It cross-checks the same contract the live Blaxel verification runs proved at full scale (better-auth 10/10 metrics, build 9.9s ±1.0%, `FULL TURBO` prep replays — see #96).

**Precautions:** composite + PTS logs + counters export to `.scratch/selftest-out/` via an EXIT trap registered before any failable step (review fix — early failures keep their forensics); requires Docker; network only for the apt/PTS/pnpm bootstrap.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a Docker selftest to validate the realworld runner ↔ PTS contract end to end with a hermetic pass/fail. Runs in ~3–4 minutes against a tiny fixture repo and starts from a clean `.scratch/selftest-out` each time.

- **New Features**
  - Adds `mise run benchmark:realworld:selftest` to execute the full path (`run_realworld_pts -> PTS -> runner -> sentinel -> composite.xml`) in a digest‑pinned `node:22-bookworm` container, installing `phoronix-test-suite` v10.8.4 and `pnpm`.
  - Uses the production `results-definition.xml`; asserts numeric samples and menu‑order; enforces prep‑time exclusion and warm‑up‑exactly‑once (build=3, lint=2, test=1); checks Docker is available; exports composite, PTS logs, and counters for forensics.

<sup>Written for commit 03775b86152c9a38c50f6d31bd8026e2eb120214. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/starslingdev/sandbox-benchmarks/pull/103?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added a new containerized self-test flow for the real-world benchmark, including hermetic scratch output handling.
  * Introduced a synthetic fixture and a generated Realworld selftest profile to validate end-to-end execution.
  * Improved validation of benchmark output structure, execution order, and measured vs. prep timing behavior.
  * Added safeguards for required tooling availability and automatic diagnostic export on failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->