### PR TITLE
fix(bake): make the toolchain bake succeed for daytona + e2b

### DIFF
--- a/.github/workflows/toolchain-image.yml
+++ b/.github/workflows/toolchain-image.yml
@@ -196,6 +196,11 @@ jobs:
           BUILD_VERSION: ${{ env.IMAGE_VERSION }}
           E2B_API_KEY: ${{ secrets.E2B_API_KEY }}
           DAYTONA_API_KEY: ${{ secrets.DAYTONA_API_KEY }}
+          # Bake/validate the daytona snapshot in the active region. Without a target the snapshot lands
+          # in the account's default region (which has no `container` runners) and the bake fails at
+          # snapshot creation. Defaulted to the active target so an unsynced secret can't break the
+          # publish at module load (parity with bench-matrix.yml / bench-smoke.yml).
+          DAYTONA_TARGET: ${{ secrets.DAYTONA_TARGET || 'us-west-2' }}
           MODAL_TOKEN_ID: ${{ secrets.MODAL_TOKEN_ID }}
           MODAL_TOKEN_SECRET: ${{ secrets.MODAL_TOKEN_SECRET }}
         run: |
@@ -203,9 +208,12 @@ jobs:
           # Declare then assign so the command substitution's exit status isn't masked (SC2155).
           BUILD_DATE="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
           export BUILD_DATE
-          # --require fails the publish loudly if any provider's secret is missing/misnamed, so a merge
-          # can't bless a candidate while a provider was silently skipped (never built or validated).
-          bun apps/cli/src/bin/bake.ts --build-push --require e2b,daytona,modal
+          # --require fails the publish loudly if a required provider's secret is missing/misnamed, so a
+          # merge can't bless a candidate while a required provider was silently skipped (never built or
+          # validated). modal is intentionally NOT required here: its creds aren't synced yet, so a
+          # required modal would skip and fail the publish; add it back once MODAL_TOKEN_* land. (blaxel
+          # is likewise excluded — its bake is a no-op.)
+          bun apps/cli/src/bin/bake.ts --build-push --require e2b,daytona
 
       # Promote the validated candidate to the immutable public version (+ version-named artifacts).
       - name: Promote candidate → version
@@ -213,8 +221,15 @@ jobs:
         env:
           E2B_API_KEY: ${{ secrets.E2B_API_KEY }}
           DAYTONA_API_KEY: ${{ secrets.DAYTONA_API_KEY }}
+          # Bake/validate the daytona snapshot in the active region. Without a target the snapshot lands
+          # in the account's default region (which has no `container` runners) and the bake fails at
+          # snapshot creation. Defaulted to the active target so an unsynced secret can't break the
+          # publish at module load (parity with bench-matrix.yml / bench-smoke.yml).
+          DAYTONA_TARGET: ${{ secrets.DAYTONA_TARGET || 'us-west-2' }}
           MODAL_TOKEN_ID: ${{ secrets.MODAL_TOKEN_ID }}
           MODAL_TOKEN_SECRET: ${{ secrets.MODAL_TOKEN_SECRET }}
         # --require fails promote loudly if a required provider's secret is missing/misnamed, so the
-        # public version is never published while a provider's version artifact was silently skipped.
-        run: bun apps/cli/src/bin/bake.ts --promote --require e2b,daytona,modal
+        # public version is never published while a required provider's version artifact was silently
+        # skipped. modal is intentionally NOT required here (creds not synced yet); add it back once
+        # MODAL_TOKEN_* land. (blaxel is likewise excluded — its bake is a no-op.)
+        run: bun apps/cli/src/bin/bake.ts --promote --require e2b,daytona

--- a/apps/cli/src/bin/bake.ts
+++ b/apps/cli/src/bin/bake.ts
@@ -60,7 +60,7 @@ if (import.meta.main) {
 				2,
 			),
 		);
-		// promoteAll is self-gating: the D1 required-providers gate (CI passes `--require e2b,daytona,modal`)
+		// promoteAll is self-gating: the D1 required-providers gate (CI passes `--require e2b,daytona`)
 		// runs INSIDE promoteAll before the immutable base is written, and every abort path (version already
 		// published, candidate re-validation failed, artifact failed, unmet requirements) pushes a structured
 		// `{ status: "failed" }` report. So a single `some(failed)` is the whole exit contract — re-deriving
@@ -138,7 +138,7 @@ if (import.meta.main) {
 
 	if (anyFailed(runs)) process.exit(1);
 
-	// D1: at the publish boundary (CI passes `--require e2b,daytona,modal`) a required provider that was
+	// D1: at the publish boundary (CI passes `--require e2b,daytona`) a required provider that was
 	// skipped for a missing/misnamed secret — or failed to validate — must fail the bake loudly, so a
 	// candidate is never blessed while a provider was silently never built. Lenient locally (none required).
 	const required = requiredProviders();

--- a/apps/cli/src/lib/bake/e2b.test.ts
+++ b/apps/cli/src/lib/bake/e2b.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, it } from "bun:test";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { pinE2bBaseImage } from "./e2b.ts";
+
+// The concrete registry ref a bake pins the e2b template's base to.
+const BASE = "ghcr.io/starslingdev/sandbox-benchmarks-toolchain:v1-candidate";
+
+// The literal Dockerfile placeholder `${BASE_IMAGE}` — a Dockerfile ARG reference, NOT a JS template
+// placeholder. Kept in one constant so the biome ignore lives once; template strings below compose it
+// (`FROM ${VAR}` → the string "FROM ${BASE_IMAGE}") without tripping the lint again.
+// biome-ignore lint/suspicious/noTemplateCurlyInString: literal Dockerfile ARG reference, not a JS placeholder.
+const VAR = "${BASE_IMAGE}";
+
+// A minimal stand-in for the committed variant Dockerfile: the two anchors plus a `${BASE_IMAGE}`
+// label reference that must survive (E2B *does* expand ARGs after FROM, only the pre-FROM one breaks).
+const TEMPLATE = [
+	"# syntax=docker/dockerfile:1",
+	"ARG BASE_IMAGE=sandbox-benchmarks-toolchain:dev",
+	"",
+	`FROM ${VAR}`,
+	"",
+	"ARG BASE_IMAGE",
+	`LABEL org.opencontainers.image.base.name="${VAR}"`,
+].join("\n");
+
+describe("pinE2bBaseImage", () => {
+	it("concretes the FROM line — E2B's builder doesn't expand a pre-FROM ARG BASE_IMAGE", () => {
+		const out = pinE2bBaseImage(TEMPLATE, BASE);
+		expect(out).toContain(`FROM ${BASE}`);
+		expect(out).not.toContain(`FROM ${VAR}`);
+	});
+
+	it("also pins the ARG BASE_IMAGE default, leaving the post-FROM ARG + label intact", () => {
+		const out = pinE2bBaseImage(TEMPLATE, BASE);
+		expect(out).toContain(`ARG BASE_IMAGE=${BASE}`);
+		// The bare post-FROM `ARG BASE_IMAGE` and the label reference stay as-is (ARGs work there).
+		expect(out).toContain("\nARG BASE_IMAGE\n");
+		expect(out).toContain(`LABEL org.opencontainers.image.base.name="${VAR}"`);
+	});
+
+	it("preserves CRLF line endings — the FROM anchor's whitespace class excludes `\\r`", () => {
+		const crlf = TEMPLATE.replace(/\n/g, "\r\n");
+		const out = pinE2bBaseImage(crlf, BASE);
+		// The rewritten FROM keeps its `\r` (no LF/CRLF mix vs the untouched ARG line above it).
+		expect(out).toContain(`FROM ${BASE}\r\n`);
+		expect(out).toContain(`ARG BASE_IMAGE=${BASE}\r\n`);
+		// ...and did NOT collapse to a bare-LF FROM line (the `\r`-consuming bug).
+		expect(out).not.toContain(`FROM ${BASE}\n`);
+	});
+
+	it("does not misinterpret a `$` in the base ref as a regex replacement pattern", () => {
+		const weird = "registry.example.com/img:$&-$1";
+		const out = pinE2bBaseImage(TEMPLATE, weird);
+		expect(out).toContain(`FROM ${weird}`);
+		expect(out).toContain(`ARG BASE_IMAGE=${weird}`);
+	});
+
+	it("throws if the placeholder FROM line is missing (a refactor must fail loudly)", () => {
+		const noFrom = "ARG BASE_IMAGE=x\nFROM debian:13-slim\n";
+		expect(() => pinE2bBaseImage(noFrom, BASE)).toThrow(/FROM \$\{BASE_IMAGE\}/);
+	});
+
+	it("throws if the ARG BASE_IMAGE default is missing", () => {
+		const noArg = `FROM ${VAR}\n`;
+		expect(() => pinE2bBaseImage(noArg, BASE)).toThrow(/ARG BASE_IMAGE=/);
+	});
+
+	it("pins the real committed e2b Dockerfile — catches a FROM/ARG refactor", () => {
+		// Path mirrors E2B_CONTEXT in e2b.ts (anchored to this file, not cwd).
+		const real = readFileSync(
+			join(import.meta.dir, "../../../../../packages/templates/images/e2b/Dockerfile"),
+			"utf8",
+		);
+		const out = pinE2bBaseImage(real, BASE);
+		expect(out).toContain(`FROM ${BASE}`);
+		expect(out).not.toContain(`FROM ${VAR}`);
+		expect(out).toContain(`ARG BASE_IMAGE=${BASE}`);
+	});
+});

--- a/apps/cli/src/lib/bake/e2b.ts
+++ b/apps/cli/src/lib/bake/e2b.ts
@@ -29,20 +29,41 @@ const E2B_DOCKERFILE = "e2b/Dockerfile"; // committed template: ARG BASE_IMAGE d
 const E2B_DOCKERFILE_GENERATED = "e2b/Dockerfile.generated"; // base pinned to a registry ref per bake
 const E2B_TOML = "e2b/e2b.toml"; // generated manifest (record + parity)
 
-/** Generate the per-bake e2b Dockerfile: the committed variant Dockerfile with its `ARG BASE_IMAGE`
- *  default rewritten to a concrete, registry-pullable `baseImage`. Throws if the anchor is missing so
- *  a Dockerfile refactor can't silently ship the wrong (local `:dev`) base. */
-function writeE2bDockerfile(baseImage: string): void {
-	const anchor = /^ARG BASE_IMAGE=.*$/m;
-	const template = readFileSync(`${E2B_CONTEXT}/${E2B_DOCKERFILE}`, "utf8");
-	// Test the regex matched (not `pinned !== template`): a base that already equals the committed
+/**
+ * Pin the e2b variant Dockerfile's base to a concrete, registry-pullable `baseImage`. Unlike
+ * `docker build` (used for the daytona/modal variants), E2B's remote builder does NOT expand a
+ * pre-`FROM` `ARG BASE_IMAGE`, so a `FROM ${BASE_IMAGE}` reaches it verbatim and fails with
+ * "invalid image reference '${BASE_IMAGE}'". So rewrite the `FROM` line itself to the concrete ref;
+ * the `ARG BASE_IMAGE=` default is pinned too so the `${BASE_IMAGE}` labels still record the real base.
+ * Throws if either anchor is missing so a Dockerfile refactor can't silently ship the wrong (local
+ * `:dev`) base. Pure (string in, string out) so the substitution is unit-testable without file I/O.
+ */
+export function pinE2bBaseImage(template: string, baseImage: string): string {
+	const argAnchor = /^ARG BASE_IMAGE=.*$/m;
+	// Only the pre-FROM `FROM ${BASE_IMAGE}` needs concreting; trailing horizontal whitespace is
+	// tolerated, but not a newline (so the anchor can't swallow following lines). `[^\S\r\n]` is
+	// horizontal-whitespace-only: excluding `\r` too keeps a CRLF source Dockerfile's line endings
+	// intact (a `\r`-consuming match would rewrite FROM as LF while ARG stays CRLF → mixed endings).
+	const fromAnchor = /^FROM \$\{BASE_IMAGE\}[^\S\r\n]*$/m;
+	// Test each regex matched (not `pinned !== template`): a base that already equals the committed
 	// default would otherwise be misread as a missing anchor.
-	if (!anchor.test(template)) {
+	if (!argAnchor.test(template)) {
 		throw new Error(`e2b Dockerfile has no 'ARG BASE_IMAGE=' default to pin (${E2B_DOCKERFILE})`);
 	}
-	// Function replacement so a `$` in `baseImage` (e.g. `$&`) isn't interpreted as a replacement pattern.
-	const pinned = template.replace(anchor, () => `ARG BASE_IMAGE=${baseImage}`);
-	writeFileSync(`${E2B_CONTEXT}/${E2B_DOCKERFILE_GENERATED}`, pinned);
+	if (!fromAnchor.test(template)) {
+		throw new Error(`e2b Dockerfile has no 'FROM \${BASE_IMAGE}' line to pin (${E2B_DOCKERFILE})`);
+	}
+	// Function replacements so a `$` in `baseImage` (e.g. `$&`) isn't interpreted as a replacement pattern.
+	return template
+		.replace(argAnchor, () => `ARG BASE_IMAGE=${baseImage}`)
+		.replace(fromAnchor, () => `FROM ${baseImage}`);
+}
+
+/** Generate the per-bake e2b Dockerfile: the committed variant Dockerfile with its base pinned to a
+ *  concrete, registry-pullable `baseImage` (see {@link pinE2bBaseImage}). */
+function writeE2bDockerfile(baseImage: string): void {
+	const template = readFileSync(`${E2B_CONTEXT}/${E2B_DOCKERFILE}`, "utf8");
+	writeFileSync(`${E2B_CONTEXT}/${E2B_DOCKERFILE_GENERATED}`, pinE2bBaseImage(template, baseImage));
 }
 
 /** Build the e2b template `name` from `baseImage` (the candidate base while iterating, the published

--- a/apps/cli/src/lib/bake/promote.ts
+++ b/apps/cli/src/lib/bake/promote.ts
@@ -130,7 +130,7 @@ export async function promoteAll(log: Log): Promise<BakeReport[]> {
 	}
 
 	// Required-providers gate (D1), enforced HERE — before step 4 writes the immutable base — not
-	// post-hoc in bake.ts. At the publish boundary CI passes `--require e2b,daytona,modal`; a required
+	// post-hoc in bake.ts. At the publish boundary CI passes `--require e2b,daytona`; a required
 	// provider whose version artifact was skipped (missing/misnamed secret) or failed is `skipped`/
 	// `failed`, so `reports.some(failed)` above does NOT catch a pure skip. Were the base published
 	// first and the gap detected only in bake.ts, the immutable `:v1` would already be tagged and a


### PR DESCRIPTION
## Goal

Make the toolchain publish lane actually **bake + validate** the Daytona snapshot and E2B template. Two provider-side bake bugs (surfaced by a real dispatch — run #75) broke it. First PR of a 3-PR stack: **#104 → #105 → #106**.

## Fixes

**1. daytona — bake in the active region** (`ci`: `toolchain-image.yml`)
The bake passed `DAYTONA_API_KEY` but no target, so `bakeDaytonaSnapshot` created the snapshot in the account's default region (no matching runners) and failed at create. Pass `DAYTONA_TARGET` (defaulted to `us-west-2`) in **both** the bake and promote step envs.

**2. e2b — pin the template `FROM` to a concrete base** (`apps/cli/src/lib/bake/e2b.ts`)
E2B's remote builder does **not** expand a pre-`FROM` `ARG BASE_IMAGE` (unlike `docker build`), so `FROM ${BASE_IMAGE}` reached it verbatim → `invalid image reference '${BASE_IMAGE}'`. Extracted a pure, exported `pinE2bBaseImage()` that rewrites the **`FROM` line** to the concrete registry ref (keeping the `ARG` default pinned so the `${BASE_IMAGE}` labels still record the real base). Hardened to preserve CRLF line endings (`[^\S\r\n]`), and covered with unit tests including a **real-committed-Dockerfile** regression guard.

**3. drop `modal` from the publish `--require` gate** (`ci`: `toolchain-image.yml`)
The D1 gate fails the publish if a required provider is skipped; modal's creds weren't synced when this landed, so both steps require only `e2b,daytona` here. (#105 re-adds `modal` once its Modal app + secrets land.)

## Verification

- `bun run typecheck` (exit 0); `bun run test` — cli green, incl. the new `pinE2bBaseImage` tests (happy path, ARG preservation, `$`-in-ref safety, both error paths, CRLF, and the real-Dockerfile guard).
- `actionlint` clean on `toolchain-image.yml`.
- Proven end-to-end at the top of the stack: a force-republish dispatch published `:v1` with e2b + daytona + modal all validating 11/11.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the toolchain bake so the publish lane builds and validates Daytona and E2B. Sets the active Daytona region and pins E2B’s base image; CI no longer requires `modal` until creds land.

- **Bug Fixes**
  - Daytona: Pass `DAYTONA_TARGET` (default `us-west-2`) in bake and promote so snapshots build in the active region.
  - E2B: Export `pinE2bBaseImage()` to rewrite `FROM ${BASE_IMAGE}` and pin the `ARG` default; preserve CRLF line endings; add tests (real Dockerfile, CRLF, `$` in refs, error paths). Fixes the `@e2b/cli` “invalid image reference '${BASE_IMAGE}'” error.

- **Migration**
  - CI requires only `e2b,daytona`. Re-add `modal` once `MODAL_TOKEN_ID` and `MODAL_TOKEN_SECRET` are available.

<sup>Written for commit c7f261ade90fde991775083dde10e821b4d742c1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/starslingdev/sandbox-benchmarks/pull/104?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the toolchain image publish workflow to default to a valid Daytona region when no target is set, improving snapshot bake/validation reliability.
  * Adjusted bake/validation and promotion required-provider checks to use only `e2b,daytona`, so promotion no longer depends on `modal`.
  * Improved E2B Dockerfile generation by validating required template anchors and pinning the base image deterministically, preserving formatting and failing with clearer errors when markers are missing.
* **Tests**
  * Added Bun tests covering E2B base image pinning, including literal handling of `$` in refs, CRLF preservation, and negative/anchor-missing cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

