### PR TITLE
feat(modal): boot sandboxes under a dedicated 'sandbox-benchmarks' app

### DIFF
--- a/.github/workflows/toolchain-image.yml
+++ b/.github/workflows/toolchain-image.yml
@@ -210,10 +210,10 @@ jobs:
           export BUILD_DATE
           # --require fails the publish loudly if a required provider's secret is missing/misnamed, so a
           # merge can't bless a candidate while a required provider was silently skipped (never built or
-          # validated). modal is intentionally NOT required here: its creds aren't synced yet, so a
-          # required modal would skip and fail the publish; add it back once MODAL_TOKEN_* land. (blaxel
-          # is likewise excluded — its bake is a no-op.)
-          bun apps/cli/src/bin/bake.ts --build-push --require e2b,daytona
+          # validated). modal boots the toolchain image via fromRegistry under this project's Modal app
+          # and is validated the same as e2b/daytona, so it's required — MODAL_TOKEN_* must be synced.
+          # (blaxel is excluded — its bake is a no-op.)
+          bun apps/cli/src/bin/bake.ts --build-push --require e2b,daytona,modal
 
       # Promote the validated candidate to the immutable public version (+ version-named artifacts).
       - name: Promote candidate → version
@@ -230,6 +230,6 @@ jobs:
           MODAL_TOKEN_SECRET: ${{ secrets.MODAL_TOKEN_SECRET }}
         # --require fails promote loudly if a required provider's secret is missing/misnamed, so the
         # public version is never published while a required provider's version artifact was silently
-        # skipped. modal is intentionally NOT required here (creds not synced yet); add it back once
-        # MODAL_TOKEN_* land. (blaxel is likewise excluded — its bake is a no-op.)
-        run: bun apps/cli/src/bin/bake.ts --promote --require e2b,daytona
+        # skipped. modal is required (validated via its fromRegistry boot); MODAL_TOKEN_* must be synced.
+        # (blaxel is excluded — its bake is a no-op.)
+        run: bun apps/cli/src/bin/bake.ts --promote --require e2b,daytona,modal

--- a/apps/cli/src/bin/bake.ts
+++ b/apps/cli/src/bin/bake.ts
@@ -60,7 +60,7 @@ if (import.meta.main) {
 				2,
 			),
 		);
-		// promoteAll is self-gating: the D1 required-providers gate (CI passes `--require e2b,daytona`)
+		// promoteAll is self-gating: the D1 required-providers gate (CI passes `--require e2b,daytona,modal`)
 		// runs INSIDE promoteAll before the immutable base is written, and every abort path (version already
 		// published, candidate re-validation failed, artifact failed, unmet requirements) pushes a structured
 		// `{ status: "failed" }` report. So a single `some(failed)` is the whole exit contract — re-deriving
@@ -138,7 +138,7 @@ if (import.meta.main) {
 
 	if (anyFailed(runs)) process.exit(1);
 
-	// D1: at the publish boundary (CI passes `--require e2b,daytona`) a required provider that was
+	// D1: at the publish boundary (CI passes `--require e2b,daytona,modal`) a required provider that was
 	// skipped for a missing/misnamed secret — or failed to validate — must fail the bake loudly, so a
 	// candidate is never blessed while a provider was silently never built. Lenient locally (none required).
 	const required = requiredProviders();

--- a/apps/cli/src/lib/bake/promote.ts
+++ b/apps/cli/src/lib/bake/promote.ts
@@ -130,7 +130,7 @@ export async function promoteAll(log: Log): Promise<BakeReport[]> {
 	}
 
 	// Required-providers gate (D1), enforced HERE — before step 4 writes the immutable base — not
-	// post-hoc in bake.ts. At the publish boundary CI passes `--require e2b,daytona`; a required
+	// post-hoc in bake.ts. At the publish boundary CI passes `--require e2b,daytona,modal`; a required
 	// provider whose version artifact was skipped (missing/misnamed secret) or failed is `skipped`/
 	// `failed`, so `reports.some(failed)` above does NOT catch a pure skip. Were the base published
 	// first and the gap detected only in bake.ts, the immutable `:v1` would already be tagged and a

--- a/packages/providers/src/lib/adapters.ts
+++ b/packages/providers/src/lib/adapters.ts
@@ -16,6 +16,9 @@ import type { ProviderAdapter } from "./types.ts";
 // DAYTONA_REGION. Never read process.env directly here.
 const { daytonaRegion } = config;
 
+// This project's dedicated Modal app — the namespace all sandbox-benchmarks sandboxes boot under.
+const MODAL_APP_NAME = "sandbox-benchmarks";
+
 /**
  * Harness adapters, keyed by the schema {@link ProviderId}. The `Record<ProviderId, …>` type is what
  * keeps the two registries honest: it forces exactly one adapter per schema provider, so a provider
@@ -51,7 +54,10 @@ export const adapters: Record<ProviderId, ProviderAdapter> = {
 		createOptions: {},
 	},
 	modal: {
-		createCompute: () => modal({ scalableSandboxes: true }),
+		// Boot sandboxes under this project's own Modal app (auto-created via apps.fromName on first
+		// create), not the wrapper's generic `computesdk-modal` default — so this project's sandboxes
+		// are namespaced/attributable in the Modal dashboard, separate from any other computesdk usage.
+		createCompute: () => modal({ scalableSandboxes: true, appName: MODAL_APP_NAME }),
 		createOptions: {
 			templateId: config.toolchainImage,
 			// Modal's `cpu`/`cpuLimit` are physical cores, not vCPUs — convert from the pinned vCPU spec.


### PR DESCRIPTION
## Goal

Make **modal** a first-class provider in the toolchain publish lane. Modal has no artifact to bake — it boots the toolchain image directly via `Image.fromRegistry` at sandbox-create time — so "supporting modal" means booting it under a dedicated app and validating it the same as e2b/daytona. Stacked on #104 (which dropped modal from the `--require` gate while its creds were unsynced).

## Changes

**1. boot under a dedicated Modal app** (`packages/providers/src/lib/adapters.ts`)
The adapter passed no `appName`, so modal sandboxes landed in `@computesdk/modal`'s generic `computesdk-modal` app. Now boots under `appName: "sandbox-benchmarks"` (auto-created via `apps.fromName(createIfMissing)` on first boot), so this project's sandboxes are namespaced in the Modal dashboard.

**2. require modal in the publish gate** (`ci`: `toolchain-image.yml`; comments in `bake.ts`, `promote.ts`)
Re-add `modal` to `--require e2b,daytona,modal` in **both** the bake and promote steps (reverting #104's temporary drop) now that modal validates end-to-end. `MODAL_TOKEN_ID` / `MODAL_TOKEN_SECRET` are synced as GitHub secrets. modal already inherits `requiredEnvVars` from the schema meta, so it skips cleanly when creds are absent locally.

## Verification

Live: the `sandbox-benchmarks` Modal app was created and modal booted the toolchain candidate via `fromRegistry`, passing **11/11 smoke checks** — confirmed both in a local run and in the green publish dispatch at the top of the stack.

`bun run typecheck` (exit 0); providers + cli tests green; `actionlint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Modal support to the release validation and publish flow, so required checks now cover all expected providers.
  * Updated Modal sandbox setup to use a dedicated project name for cleaner isolation.

* **Bug Fixes**
  * Improved publish gating so releases won’t proceed when Modal credentials or validation are missing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->