### PR TITLE
refactor(providers): retire the DAYTONA_REGION selector (ENG-145)

### DIFF
--- a/.github/workflows/bench-matrix.yml
+++ b/.github/workflows/bench-matrix.yml
@@ -7,13 +7,6 @@ name: Bench matrix
 # + provider credentials); dispatch on demand.
 on:
   workflow_dispatch:
-    inputs:
-      region:
-        # Daytona only: the default org is parked, so real runs use the ZEN5-VM region. Ignored by e2b/modal.
-        description: Daytona region
-        type: choice
-        default: ZEN5-VM
-        options: [ZEN5-VM, default]
 
 # Least privilege: jobs only read the checked-out code and upload artifacts.
 permissions:
@@ -86,10 +79,10 @@ jobs:
           BENCH_REPO_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           BENCH_PROVIDER: ${{ matrix.provider }}
           BENCH_SUITE: ${{ matrix.suite }}
-          DAYTONA_REGION: ${{ inputs.region }}
           DAYTONA_API_KEY: ${{ secrets.DAYTONA_API_KEY }}
-          DAYTONA_API_KEY_ZEN5: ${{ secrets.DAYTONA_API_KEY_ZEN5 }}
-          DAYTONA_TARGET_ZEN5: ${{ secrets.DAYTONA_TARGET_ZEN5 }}
+          # Boot daytona sandboxes in the active region (us-west-2). Defaulted so an unsynced secret
+          # can't fail the config gatekeeper at module load.
+          DAYTONA_TARGET: ${{ secrets.DAYTONA_TARGET || 'us-west-2' }}
           E2B_API_KEY: ${{ secrets.E2B_API_KEY }}
           MODAL_TOKEN_ID: ${{ secrets.MODAL_TOKEN_ID }}
           MODAL_TOKEN_SECRET: ${{ secrets.MODAL_TOKEN_SECRET }}

--- a/.github/workflows/bench-smoke.yml
+++ b/.github/workflows/bench-smoke.yml
@@ -29,13 +29,6 @@ on:
             realworld-better-auth,
             realworld-openclaw,
           ]
-      region:
-        # Daytona only: the default org is parked, so real runs use the ZEN5-VM region (its own API key +
-        # target + snapshot, keyed by the _ZEN5 env-var suffix). Ignored by e2b/modal.
-        description: Daytona region
-        type: choice
-        default: ZEN5-VM
-        options: [ZEN5-VM, default]
 
 # Least privilege: the job only reads the checked-out code and uploads an artifact.
 permissions:
@@ -86,11 +79,10 @@ jobs:
           # shell. `$GITHUB_RUN_ID` is built-in.
           BENCH_PROVIDER: ${{ inputs.provider }}
           BENCH_SUITE: ${{ inputs.suite }}
-          # Daytona region selection (default org is parked; ZEN5-VM is the active region).
-          DAYTONA_REGION: ${{ inputs.region }}
           DAYTONA_API_KEY: ${{ secrets.DAYTONA_API_KEY }}
-          DAYTONA_API_KEY_ZEN5: ${{ secrets.DAYTONA_API_KEY_ZEN5 }}
-          DAYTONA_TARGET_ZEN5: ${{ secrets.DAYTONA_TARGET_ZEN5 }}
+          # Boot daytona sandboxes in the active region (us-west-2). Defaulted so an unsynced secret
+          # can't fail the config gatekeeper at module load.
+          DAYTONA_TARGET: ${{ secrets.DAYTONA_TARGET || 'us-west-2' }}
           E2B_API_KEY: ${{ secrets.E2B_API_KEY }}
           MODAL_TOKEN_ID: ${{ secrets.MODAL_TOKEN_ID }}
           MODAL_TOKEN_SECRET: ${{ secrets.MODAL_TOKEN_SECRET }}

--- a/apps/cli/src/bin/bake.ts
+++ b/apps/cli/src/bin/bake.ts
@@ -37,7 +37,7 @@ const candidateRefs = {
 	e2bTemplateCandidate: config.e2bTemplateCandidate,
 	daytonaSnapshotCandidate: config.daytonaSnapshotCandidate,
 	toolchainImageCandidate: config.toolchainImageCandidate,
-	daytonaTarget: config.daytonaRegion.target,
+	daytonaTarget: config.daytona.target,
 };
 
 if (import.meta.main) {

--- a/apps/cli/src/lib/bake/daytona.ts
+++ b/apps/cli/src/lib/bake/daytona.ts
@@ -1,11 +1,10 @@
 // Bake a daytona snapshot directly from a pushed toolchain image, via the raw Daytona SDK (the
 // @computesdk/daytona wrapper only snapshots a running sandbox). Idempotent: delete an existing
-// snapshot of that name, then recreate. Region-aware: the active region's API key + target come from
-// config.daytonaRegion (ZEN5 supported).
+// snapshot of that name, then recreate. The API key + runner target come from config.daytona
+// (single-region: DAYTONA_API_KEY + DAYTONA_TARGET, e.g. us-west-2).
 //
-// Iteration surface: a snapshot's region must match where sandboxes boot. We pass the region's
-// `target` to the client; if a beta region (ZEN5) also needs an explicit snapshot `regionId`, add it
-// to CreateSnapshotParams here.
+// Iteration surface: a snapshot's region must match where sandboxes boot. We pass the client `target`;
+// if the target also needs an explicit snapshot `regionId`, add it to CreateSnapshotParams here.
 import { Daytona } from "@daytona/sdk";
 import { config } from "@sandbox-benchmarks/providers";
 import type { Log } from "./types.ts";
@@ -29,10 +28,10 @@ function isNotFound(err: unknown): boolean {
 /** Create the daytona snapshot `name` from `image` (candidate while iterating, version on promote),
  *  in the active region. Idempotent: delete an existing snapshot of that name first. */
 export async function bakeDaytonaSnapshot(name: string, image: string, log: Log): Promise<void> {
-	const { daytonaRegion, targetSpec } = config;
+	const { daytona: daytonaCfg, targetSpec } = config;
 	const daytona = new Daytona({
-		apiKey: daytonaRegion.apiKey,
-		...(daytonaRegion.target ? { target: daytonaRegion.target } : {}),
+		apiKey: daytonaCfg.apiKey,
+		...(daytonaCfg.target ? { target: daytonaCfg.target } : {}),
 	});
 
 	try {
@@ -45,7 +44,7 @@ export async function bakeDaytonaSnapshot(name: string, image: string, log: Log)
 		if (!isNotFound(err)) throw err;
 	}
 
-	log(`creating snapshot ${name} from ${image} (target ${daytonaRegion.target ?? "default"})`);
+	log(`creating snapshot ${name} from ${image} (target ${daytonaCfg.target ?? "default"})`);
 	await daytona.snapshot.create(
 		{
 			name,

--- a/apps/cli/src/lib/bake/promote.ts
+++ b/apps/cli/src/lib/bake/promote.ts
@@ -52,7 +52,7 @@ export async function promoteAll(log: Log): Promise<BakeReport[]> {
 		e2bTemplateCandidate: config.e2bTemplateCandidate,
 		daytonaSnapshotCandidate: config.daytonaSnapshotCandidate,
 		toolchainImageCandidate: config.toolchainImageCandidate,
-		daytonaTarget: config.daytonaRegion.target,
+		daytonaTarget: config.daytona.target,
 	};
 	log(`>>> re-validating candidate ${config.toolchainImageCandidate} before promote…`);
 	const validateRuns = await validateCandidates(candidateRefs, log);

--- a/packages/providers/src/index.test.ts
+++ b/packages/providers/src/index.test.ts
@@ -1,7 +1,6 @@
 import { describe, expect, it } from "bun:test";
 import { PROVIDERS, TARGET_SPEC, VCPUS_PER_PHYSICAL_CORE } from "@sandbox-benchmarks/schema";
 import { config, providers } from "./index.ts";
-import { resolveDaytonaRegion } from "./lib/config.ts";
 import { assertProviderJoin } from "./lib/join.ts";
 
 describe("@sandbox-benchmarks/providers", () => {
@@ -36,14 +35,20 @@ describe("@sandbox-benchmarks/providers", () => {
 		});
 	});
 
-	it("boots e2b from the configured template and daytona from the region snapshot", () => {
+	it("boots e2b from the configured template and daytona from the configured snapshot", () => {
 		const e2b = providers.find((p) => p.name === "e2b");
 		expect(e2b?.createOptions?.snapshotId).toBe(config.e2bTemplate);
 
 		const daytona = providers.find((p) => p.name === "daytona");
-		expect(daytona?.createOptions?.snapshotId).toBe(config.daytonaRegion.snapshot);
-		// requiredEnvVars tracks the active region's key var (the schema default for the default region).
-		expect(daytona?.requiredEnvVars).toEqual([config.daytonaRegion.apiKeyVar]);
+		expect(daytona).toBeDefined();
+		expect(daytona?.createOptions?.snapshotId).toBe(config.daytona.snapshot);
+
+		// No adapter override — requiredEnvVars falls back to the schema meta's static list. Pin the
+		// concrete value rather than only comparing the two lookups against each other: if both `find`s
+		// missed (provider renamed on one side), `undefined === undefined` would pass — a false green.
+		const daytonaMeta = PROVIDERS.find((m) => m.id === "daytona");
+		expect(daytonaMeta?.requiredEnvVars).toEqual(["DAYTONA_API_KEY"]);
+		expect(daytona?.requiredEnvVars).toEqual(daytonaMeta?.requiredEnvVars);
 	});
 });
 
@@ -86,49 +91,5 @@ describe("assertProviderJoin", () => {
 		})();
 		expect(err?.message).toContain("missing a harness adapter: ghost");
 		expect(err?.message).toContain("no schema PROVIDERS entry: modal");
-	});
-});
-
-describe("resolveDaytonaRegion", () => {
-	const SNAP = "sandbox-benchmarks-toolchain-v1";
-
-	it("defaults to the base env vars and the default snapshot", () => {
-		const r = resolveDaytonaRegion({ DAYTONA_API_KEY: "k", DAYTONA_TARGET: "us" }, SNAP);
-		expect(r).toEqual({
-			region: "default",
-			apiKeyVar: "DAYTONA_API_KEY",
-			apiKey: "k",
-			target: "us",
-			snapshot: SNAP,
-		});
-	});
-
-	it("maps the hyphenated ZEN5-VM region to its _ZEN5 suffixed key + target", () => {
-		// The region identifier (`ZEN5-VM`, with a hyphen) is decoupled from the env-var suffix
-		// (`ZEN5`), so the per-region vars resolve to valid names despite the illegal-in-env hyphen.
-		const r = resolveDaytonaRegion(
-			{
-				DAYTONA_REGION: "ZEN5-VM",
-				DAYTONA_API_KEY_ZEN5: "kz",
-				DAYTONA_TARGET_ZEN5: "zen5-rgn",
-				DAYTONA_SNAPSHOT_ZEN5: "zen5-snap",
-			},
-			SNAP,
-		);
-		// The suffix applies to every per-region var, including the snapshot — `DAYTONA_SNAPSHOT_ZEN5`
-		// wins over the default snapshot, so a regression that wrongly applied the suffix to the snapshot
-		// var (or fell back to SNAP) would be caught here.
-		expect(r).toEqual({
-			region: "ZEN5-VM",
-			apiKeyVar: "DAYTONA_API_KEY_ZEN5",
-			apiKey: "kz",
-			target: "zen5-rgn",
-			snapshot: "zen5-snap",
-		});
-	});
-
-	it("honors a per-region snapshot override and leaves a missing key undefined", () => {
-		expect(resolveDaytonaRegion({ DAYTONA_SNAPSHOT: "snap" }, SNAP).snapshot).toBe("snap");
-		expect(resolveDaytonaRegion({}, SNAP).apiKey).toBeUndefined();
 	});
 });

--- a/packages/providers/src/lib/adapters.ts
+++ b/packages/providers/src/lib/adapters.ts
@@ -12,9 +12,9 @@ import { TARGET_SPEC, VCPUS_PER_PHYSICAL_CORE } from "@sandbox-benchmarks/schema
 import { config } from "./config.ts";
 import type { ProviderAdapter } from "./types.ts";
 
-// The active Daytona region profile (key/target/snapshot), resolved by the config gatekeeper from
-// DAYTONA_REGION. Never read process.env directly here.
-const { daytonaRegion } = config;
+// The daytona account/target (key/target/snapshot), resolved by the config gatekeeper. Named
+// `daytonaCfg` to avoid shadowing the `daytona` factory imported above. Never read process.env here.
+const daytonaCfg = config.daytona;
 
 // This project's dedicated Modal app — the namespace all sandbox-benchmarks sandboxes boot under.
 const MODAL_APP_NAME = "sandbox-benchmarks";
@@ -33,16 +33,15 @@ export const adapters: Record<ProviderId, ProviderAdapter> = {
 		createOptions: { snapshotId: config.e2bTemplate },
 	},
 	daytona: {
-		// The region's API key (beta regions like ZEN5 use a separate key); the toolchain snapshot and
-		// runner target are pinned per-create. `target` rides the wrapper's create-options passthrough
-		// into Daytona's createParams. requiredEnvVars tracks the active region's key var so a missing
+		// The account API key; the toolchain snapshot and runner target are pinned per-create. `target`
+		// rides the wrapper's create-options passthrough into Daytona's createParams. No requiredEnvVars
+		// override needed — it falls back to the schema meta's static ["DAYTONA_API_KEY"], so a missing
 		// credential skips (not errors).
-		createCompute: () => daytona({ apiKey: daytonaRegion.apiKey }),
+		createCompute: () => daytona({ apiKey: daytonaCfg.apiKey }),
 		createOptions: {
-			snapshotId: daytonaRegion.snapshot,
-			...(daytonaRegion.target ? { target: daytonaRegion.target } : {}),
+			snapshotId: daytonaCfg.snapshot,
+			...(daytonaCfg.target ? { target: daytonaCfg.target } : {}),
 		},
-		requiredEnvVars: [daytonaRegion.apiKeyVar],
 	},
 	blaxel: {
 		// Credentials come from BL_API_KEY/BL_WORKSPACE (the factory's env fallback). The stock

--- a/packages/providers/src/lib/config.ts
+++ b/packages/providers/src/lib/config.ts
@@ -5,53 +5,24 @@
 import { TARGET_SPEC, TOOLCHAIN_IMAGE_NAME, TOOLCHAIN_VERSION } from "@sandbox-benchmarks/schema";
 import { type } from "arktype";
 
-/**
- * Daytona regions the harness knows about. `default` uses the base env vars (DAYTONA_API_KEY, …); a
- * named region uses an UPPERCASE-suffixed set (e.g. DAYTONA_API_KEY_ZEN5, DAYTONA_TARGET_ZEN5,
- * DAYTONA_SNAPSHOT_ZEN5). Daytona's `ZEN5-VM` is a beta region with faster machines and its own API key.
- *
- * `region` is Daytona's own region identifier, set verbatim in `DAYTONA_REGION` — it can contain
- * characters that aren't legal in an env-var name (the beta fast-machine region is `ZEN5-VM`). `suffix`
- * is the short key the per-region env vars are keyed by, kept *decoupled* from the identifier so a
- * hyphenated region name still resolves to a valid `DAYTONA_API_KEY_ZEN5` rather than the impossible
- * `DAYTONA_API_KEY_ZEN5-VM`.
- */
-export const DAYTONA_REGIONS = [
-	{ region: "default", suffix: "" },
-	{ region: "ZEN5-VM", suffix: "ZEN5" },
-] as const;
-export type DaytonaRegion = (typeof DAYTONA_REGIONS)[number]["region"];
-
-/** Region identifier → its env-var suffix, for resolving the per-region key/target/snapshot vars. */
-const SUFFIX_BY_REGION = new Map<string, string>(DAYTONA_REGIONS.map((r) => [r.region, r.suffix]));
-
 // 1. Env schema — only the variables this app reads, validated at the boundary. All optional; an
-//    explicitly-set but empty value is a misconfiguration and is rejected. DAYTONA_REGION must be a
-//    known region. The per-region key/target/snapshot vars are declared for both regions so they pass
-//    through the same validation as everything else.
+//    explicitly-set but empty value is a misconfiguration and is rejected. Daytona is single-region
+//    (the base DAYTONA_* vars): the beta `ZEN5-VM` region and its `_ZEN5`-suffixed vars were retired
+//    in favor of `us-west-2` (set via DAYTONA_TARGET), so there's no region selector any more.
 const envSchema = type({
 	"BENCH_TOOLCHAIN_IMAGE?": "string >= 1",
 	"E2B_TEMPLATE?": "string >= 1",
-	// Derived from DAYTONA_REGIONS so the accepted values can't drift from the resolver's known set.
-	"DAYTONA_REGION?": type.enumerated(...DAYTONA_REGIONS.map((r) => r.region)),
 	"DAYTONA_API_KEY?": "string >= 1",
 	"DAYTONA_TARGET?": "string >= 1",
 	"DAYTONA_SNAPSHOT?": "string >= 1",
-	"DAYTONA_API_KEY_ZEN5?": "string >= 1",
-	"DAYTONA_TARGET_ZEN5?": "string >= 1",
-	"DAYTONA_SNAPSHOT_ZEN5?": "string >= 1",
 });
 
 const ENV_KEYS = [
 	"BENCH_TOOLCHAIN_IMAGE",
 	"E2B_TEMPLATE",
-	"DAYTONA_REGION",
 	"DAYTONA_API_KEY",
 	"DAYTONA_TARGET",
 	"DAYTONA_SNAPSHOT",
-	"DAYTONA_API_KEY_ZEN5",
-	"DAYTONA_TARGET_ZEN5",
-	"DAYTONA_SNAPSHOT_ZEN5",
 ] as const;
 
 // 2. Startup gatekeeper — validate the environment once, fail fast with a clear message. Only the
@@ -66,42 +37,13 @@ if (env instanceof type.errors) {
 	throw new Error(`Invalid configuration: ${env.summary}`);
 }
 
-/** The resolved Daytona region profile the adapter boots: which key var to require, that key's value,
- *  and the per-region target + snapshot. */
-export interface DaytonaRegionConfig {
-	region: DaytonaRegion;
-	/** Name of the env var that holds this region's API key (so a runner can report what's missing). */
-	apiKeyVar: string;
+/** The daytona account/target the adapter boots from. Single-region: the base DAYTONA_* env vars. */
+export interface DaytonaConfig {
 	apiKey?: string;
-	/** Daytona runner target/region; undefined uses the account default. */
+	/** Daytona runner target/region (e.g. `us-west-2`); undefined uses the account default. */
 	target?: string;
 	/** Snapshot to boot from (the pre-baked toolchain snapshot). */
 	snapshot: string;
-}
-
-/**
- * Resolve the active Daytona region from `env`: the key/target/snapshot come from the region's
- * (suffixed) env vars, with the snapshot falling back to `snapshotDefault`. Pure + injectable so the
- * region wiring is unit-testable without touching process.env.
- */
-export function resolveDaytonaRegion(
-	env: Record<string, string | undefined>,
-	snapshotDefault: string,
-): DaytonaRegionConfig {
-	const region = (env.DAYTONA_REGION ?? "default") as DaytonaRegion;
-	// The env-var suffix is looked up from the registry, not derived from the identifier, so a region
-	// name with characters illegal in an env-var (e.g. `ZEN5-VM`) still maps to `_ZEN5`. An unknown
-	// region falls back to the base vars rather than synthesizing a bogus suffix.
-	const key = SUFFIX_BY_REGION.get(region) ?? "";
-	const suffix = key ? `_${key}` : "";
-	const apiKeyVar = `DAYTONA_API_KEY${suffix}`;
-	return {
-		region,
-		apiKeyVar,
-		apiKey: env[apiKeyVar],
-		target: env[`DAYTONA_TARGET${suffix}`],
-		snapshot: env[`DAYTONA_SNAPSHOT${suffix}`] ?? snapshotDefault,
-	};
 }
 
 // Candidate↔version naming. The public version (`:v1`, `…-v1`) is immutable and written only by
@@ -144,7 +86,12 @@ export const config = {
 	daytonaSnapshotDefault,
 	/** Candidate daytona snapshot name the bake creates while iterating. */
 	daytonaSnapshotCandidate,
-	/** The active daytona region profile (key var, key, target, snapshot), selected by
-	 *  `DAYTONA_REGION` (`default` | `ZEN5-VM`). */
-	daytonaRegion: resolveDaytonaRegion(rawEnv, daytonaSnapshotDefault),
+	/** The daytona account/target the adapter boots from: API key, runner target (`DAYTONA_TARGET`,
+	 *  e.g. `us-west-2`), and the snapshot to boot (`DAYTONA_SNAPSHOT` override, else the version-scoped
+	 *  default). */
+	daytona: {
+		apiKey: env.DAYTONA_API_KEY,
+		target: env.DAYTONA_TARGET,
+		snapshot: env.DAYTONA_SNAPSHOT ?? daytonaSnapshotDefault,
+	} satisfies DaytonaConfig,
 } as const;


### PR DESCRIPTION
**Daytona microVM bake + provider-spec correctness** — the `claude/daytona-microvm-class` branch, decomposed.
Shipped as a 7-PR stack (merge bottom-up, each branch independently green):

1. #107 — deps: `@daytonaio/sdk` → `@daytona/sdk` 0.192 (unlocks the `sandboxClass` selector) · ENG-145
2. #108 — refactor: retire the `DAYTONA_REGION`/ZEN5-VM selector · ENG-145
3. #109 — fix: pin snapshots to `LINUX_VM`; wait for snapshot deletion · ENG-145
4. #110 — fix: give modal a hard memory cap · ENG-64
5. #111 — fix: pin STREAM's array size so providers measure one working set · ENG-64
6. #112 — feat: surface a timed-out step's log tail · ENG-64
7. #113 — feat: `--require` in bench-smoke + `force_republish` · ENG-145

↑ **This PR is #108 (2/7)**, based on #107.

---

Daytona is single-region again. The beta `ZEN5-VM` region — and the `_ZEN5`-suffixed
env-var set it needed (`DAYTONA_API_KEY_ZEN5`, `DAYTONA_TARGET_ZEN5`, `DAYTONA_SNAPSHOT_ZEN5`)
— are retired in favor of `us-west-2`, selected with the base `DAYTONA_TARGET`.

Drops `DAYTONA_REGIONS`, `resolveDaytonaRegion()` and the `DaytonaRegionConfig` type, replacing
`config.daytonaRegion` with a plain `config.daytona` (apiKey / target / snapshot). The daytona
adapter no longer needs a `requiredEnvVars` override either: with no per-region key var to track,
it falls back to the schema meta's static ["DAYTONA_API_KEY"], so a missing credential still
skips rather than errors.

Blast radius — everything that read `config.daytonaRegion` had to move in this commit or the
branch is red: the adapter, `bake.ts`, `promote.ts` and `bake/daytona.ts`. The two workflows lose
their `region` dispatch input and the `_ZEN5` secret passthrough, gaining
`DAYTONA_TARGET: ${{ secrets.DAYTONA_TARGET || 'us-west-2' }}` (defaulted so an unsynced secret
can't fail the config gatekeeper at module load). `resolveDaytonaRegion`'s unit tests are deleted
with the function they covered.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make Daytona single‑region by removing `DAYTONA_REGION` and all `_ZEN5` env vars. Replace `config.daytonaRegion` with `config.daytona`; CI now defaults `DAYTONA_TARGET` to `us-west-2`. Aligns with ENG-145.

- **Refactors**
  - Replace `config.daytonaRegion` with `config.daytona` (apiKey/target/snapshot); remove `DAYTONA_REGIONS`, `resolveDaytonaRegion()`, and related types.
  - Update the daytona adapter to read `config.daytona` and drop the `requiredEnvVars` override (falls back to `["DAYTONA_API_KEY"]`); update tests to assert parity with the schema meta.
  - Update CLI (`bake.ts`, `promote.ts`, `bake/daytona.ts`) to use `config.daytona`.
  - Workflows: remove `region` input and ZEN5 secrets; set `DAYTONA_TARGET: ${{ secrets.DAYTONA_TARGET || 'us-west-2' }}`.

- **Migration**
  - Stop using `DAYTONA_REGION` and all `*_ZEN5` vars. Use `DAYTONA_API_KEY`, `DAYTONA_TARGET` (e.g. `us-west-2`), and optional `DAYTONA_SNAPSHOT`.
  - Update any code that referenced `config.daytonaRegion` to `config.daytona`.

<sup>Written for commit 19d3beff34f6c592b6c1bbe57b041d08d46c5fc8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/starslingdev/sandbox-benchmarks/pull/108?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

