### PR TITLE
fix(bake): pin daytona snapshots to the microVM (LINUX_VM) class, and wait for deletion (ENG-145)

### DIFF
--- a/apps/cli/src/lib/bake/daytona.ts
+++ b/apps/cli/src/lib/bake/daytona.ts
@@ -5,13 +5,19 @@
 //
 // Iteration surface: a snapshot's region must match where sandboxes boot. We pass the client `target`;
 // if the target also needs an explicit snapshot `regionId`, add it to CreateSnapshotParams here.
-import { Daytona } from "@daytona/sdk";
+//
+// microVM-only: the fleet is Firecracker microVMs, never containers. We pin the snapshot's
+// `sandboxClass` to LINUX_VM so its create — and every sandbox booted from it — routes to microVM
+// runners. Without it Daytona defaults to the `container` class, which fails on a region that only has
+// microVM runners with "No runners are configured … for sandbox class 'container'". (Needs
+// @daytona/sdk ≥ 0.192, which first exposed the selector.)
+import { Daytona, SandboxClass } from "@daytona/sdk";
 import { config } from "@sandbox-benchmarks/providers";
 import type { Log } from "./types.ts";
 
-/** Whether a snapshot.get/delete error is a genuine "no such snapshot" (so the idempotent path may
- *  swallow it) — as opposed to auth/network/in-use failures, which must surface their root cause
- *  instead of being masked into a confusing create-time error. */
+/** Whether a snapshot delete error is a genuine "no such snapshot" (so the idempotent path may
+ *  swallow it — e.g. a snapshot deleted out from under us between the list and the delete) — as
+ *  opposed to auth/network/in-use failures, which must surface their root cause. */
 function isNotFound(err: unknown): boolean {
 	if (typeof err !== "object" || err === null) return false;
 	const e = err as {
@@ -25,8 +31,89 @@ function isNotFound(err: unknown): boolean {
 	return typeof e.message === "string" && /not found|does not exist|404/i.test(e.message);
 }
 
-/** Create the daytona snapshot `name` from `image` (candidate while iterating, version on promote),
- *  in the active region. Idempotent: delete an existing snapshot of that name first. */
+/** Every snapshot named `name`, in any state, across all pages. We sweep `list()` rather than
+ *  `get(name)`: a snapshot stuck in a failed/error state — a prior bake that died mid-create — is NOT
+ *  returned by `get`, yet still makes `create` reject the name as "already exists for this
+ *  organization". Pagination advances on a short page rather than on a page count derived from
+ *  `total`: an absent or mid-iteration-changed `total` would make `Math.ceil(total / LIMIT)` NaN, and
+ *  the loop would silently scan only the first page — the exact failure this sweep exists to avoid. */
+async function listSnapshotsByName(
+	daytona: Daytona,
+	name: string,
+): Promise<Awaited<ReturnType<Daytona["snapshot"]["list"]>>["items"]> {
+	const LIMIT = 100;
+	const matches: Awaited<ReturnType<Daytona["snapshot"]["list"]>>["items"] = [];
+	for (let page = 1; ; page++) {
+		const { items } = await daytona.snapshot.list(page, LIMIT);
+		matches.push(...items.filter((s) => s.name === name));
+		if (items.length < LIMIT) return matches;
+	}
+}
+
+/** Delete every existing snapshot named `name` and WAIT until it's fully gone. `snapshot.delete` is
+ *  asynchronous (active → `removing` → gone), and `create` rejects the name while ANY snapshot of it
+ *  still exists — so returning right after issuing the delete races the not-yet-completed removal
+ *  ("already exists for this organization"). Poll `list()` until no match remains, bounded by a
+ *  deadline so a stuck removal fails loudly instead of hanging. */
+async function deleteExistingSnapshots(daytona: Daytona, name: string, log: Log): Promise<void> {
+	const matches = await listSnapshotsByName(daytona, name);
+	for (const snap of matches) {
+		// A snapshot already mid-removal (a cancelled or concurrent bake) needs no second delete, and
+		// issuing one can reject with a state-transition conflict — which `isNotFound` would NOT swallow,
+		// failing the bake over a snapshot that was on its way out anyway. Let the poll below wait it out.
+		if (snap.state === "removing") {
+			log(`snapshot ${name} is already being deleted (state ${snap.state})`);
+			continue;
+		}
+		log(`deleting existing snapshot ${name} (state ${snap.state})`);
+		try {
+			await daytona.snapshot.delete(snap);
+		} catch (err) {
+			// A snapshot already gone (concurrent delete) is fine; rethrow auth/network/in-use so the
+			// real failure isn't masked by a downstream "already exists" from create.
+			if (!isNotFound(err)) throw err;
+		}
+	}
+	if (matches.length === 0) return;
+
+	const DEADLINE_MS = 180_000;
+	const POLL_MS = 3_000;
+	const start = performance.now();
+	for (;;) {
+		// A transient network/API blip over a 3-minute window must not abort the bake. Retry until the
+		// deadline; only then surface the error, so a genuinely unreachable API still fails loudly.
+		let remaining: Awaited<ReturnType<typeof listSnapshotsByName>>;
+		try {
+			remaining = await listSnapshotsByName(daytona, name);
+		} catch (err) {
+			const reason = err instanceof Error ? err.message : String(err);
+			if (performance.now() - start > DEADLINE_MS) {
+				throw new Error(
+					`daytona snapshot ${name}: deletion poll failed after ${DEADLINE_MS}ms — ${reason}`,
+				);
+			}
+			log(`transient error listing snapshots while waiting for ${name} deletion — ${reason}`);
+			await new Promise((resolve) => setTimeout(resolve, POLL_MS));
+			continue;
+		}
+
+		if (remaining.length === 0) return;
+		if (performance.now() - start > DEADLINE_MS) {
+			throw new Error(
+				`daytona snapshot ${name} still present after ${DEADLINE_MS}ms (states: ${remaining
+					.map((s) => s.state)
+					.join(", ")}) — deletion did not complete`,
+			);
+		}
+		log(
+			`waiting for snapshot ${name} deletion (states: ${remaining.map((s) => s.state).join(", ")})…`,
+		);
+		await new Promise((resolve) => setTimeout(resolve, POLL_MS));
+	}
+}
+
+/** Create the daytona snapshot `name` from `image` (candidate while iterating, version on promote).
+ *  Idempotent: delete any existing snapshot of that name first. */
 export async function bakeDaytonaSnapshot(name: string, image: string, log: Log): Promise<void> {
 	const { daytona: daytonaCfg, targetSpec } = config;
 	const daytona = new Daytona({
@@ -34,15 +121,7 @@ export async function bakeDaytonaSnapshot(name: string, image: string, log: Log)
 		...(daytonaCfg.target ? { target: daytonaCfg.target } : {}),
 	});
 
-	try {
-		const existing = await daytona.snapshot.get(name);
-		log(`deleting existing snapshot ${name}`);
-		await daytona.snapshot.delete(existing);
-	} catch (err) {
-		// Only "no such snapshot" is expected here; rethrow auth/network/in-use so the real failure
-		// isn't masked by a downstream "already exists"/permission error from create.
-		if (!isNotFound(err)) throw err;
-	}
+	await deleteExistingSnapshots(daytona, name, log);
 
 	log(`creating snapshot ${name} from ${image} (target ${daytonaCfg.target ?? "default"})`);
 	await daytona.snapshot.create(
@@ -50,6 +129,8 @@ export async function bakeDaytonaSnapshot(name: string, image: string, log: Log)
 			name,
 			image,
 			resources: { cpu: targetSpec.vcpus, memory: targetSpec.memoryGb, disk: targetSpec.diskGb },
+			// Pin to microVM runners (never the `container` default) — the fleet's hard constraint.
+			sandboxClass: SandboxClass.LINUX_VM,
 		},
 		{ onLogs: log },
 	);


### PR DESCRIPTION
**Daytona microVM bake + provider-spec correctness** — the `claude/daytona-microvm-class` branch, decomposed.
Shipped as a 7-PR stack (merge bottom-up, each branch independently green):

1. #107 — deps: `@daytonaio/sdk` → `@daytona/sdk` 0.192 (unlocks the `sandboxClass` selector) · ENG-145
2. #108 — refactor: retire the `DAYTONA_REGION`/ZEN5-VM selector · ENG-145
3. #109 — fix: pin snapshots to `LINUX_VM`; wait for snapshot deletion · ENG-145
4. #110 — fix: give modal a hard memory cap · ENG-64
5. #111 — fix: pin STREAM's array size so providers measure one working set · ENG-64
6. #112 — feat: surface a timed-out step's log tail · ENG-64
7. #113 — feat: `--require` in bench-smoke + `force_republish` · ENG-145

↑ **This PR is #109 (3/7)**, based on #108.

---

Two bake bugs, both surfaced by a real publish dispatch.

1. sandbox class. Daytona defaults a new snapshot to the `container` class, and a sandbox
   inherits its class from the snapshot it boots from. Against our microVM-only fleet that
   fails at create with 'No runners are configured in region … for sandbox class container'.
   Pin `sandboxClass: SandboxClass.LINUX_VM` so the snapshot's create — and every sandbox
   booted from it — routes to Firecracker runners. The selector needs @daytona/sdk >= 0.192.

2. deletion race. The idempotent path used `snapshot.get(name)` then `delete`, which is wrong
   twice over. `get` does NOT return a snapshot stuck in a failed/error state (a prior bake
   that died mid-create), yet such a snapshot still makes `create` reject the name as 'already
   exists for this organization'. And `delete` is asynchronous (active -> removing -> gone), so
   returning as soon as it's issued races the not-yet-finished removal. Now: sweep `list()` by
   name across all pages, delete every match, and poll until none remain — bounded by a 180s
   deadline so a stuck removal fails loudly instead of hanging forever.

Verified live against us-west-2: daytona ok, 11/11 smoke checks (was: create failed instantly).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Pin Daytona snapshots to the `LINUX_VM` class and make snapshot deletion truly idempotent. Prevents “No runners…” and “already exists” bake failures in a microVM-only fleet (ENG-145).

- **Bug Fixes**
  - Set `sandboxClass: SandboxClass.LINUX_VM` on `snapshot.create` so snapshots and sandboxes run on microVM runners; avoids default `container` class failures. Requires `@daytona/sdk` >= 0.192.
  - Replace `get`/`delete` with sweep-and-wait: list snapshots by name across pages, delete all matches, then poll until none remain (180s timeout). Only not-found is ignored; other errors surface.
  - Harden deletion sweep: advance pagination on short pages (don’t trust `total`), skip snapshots already in `removing`, and retry transient list errors during the poll until the deadline.

<sup>Written for commit 5c60ba5b20563854dbbca2baeeb489bf30b599be. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/starslingdev/sandbox-benchmarks/pull/109?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

