### PR TITLE
fix(providers): give modal a hard memory cap (ENG-64)

### DIFF
--- a/packages/providers/src/index.test.ts
+++ b/packages/providers/src/index.test.ts
@@ -27,11 +27,15 @@ describe("@sandbox-benchmarks/providers", () => {
 
 	it("pins modal's create-time spec from the shared TARGET_SPEC", () => {
 		const modal = providers.find((p) => p.name === "modal");
+		expect(modal).toBeDefined();
 		// Modal bills/provisions in physical cores, so the pinned vCPU count is halved for cpu/cpuLimit.
+		// `memoryLimitMiB` is the hard cap (memoryMiB alone is only a reservation, and the guest then
+		// still sees the host's RAM) — assert it, or the memory fix has no regression guard at all.
 		expect(modal?.createOptions).toMatchObject({
 			cpu: TARGET_SPEC.vcpus / VCPUS_PER_PHYSICAL_CORE,
 			cpuLimit: TARGET_SPEC.vcpus / VCPUS_PER_PHYSICAL_CORE,
 			memoryMiB: TARGET_SPEC.memoryGb * 1024,
+			memoryLimitMiB: TARGET_SPEC.memoryGb * 1024,
 		});
 	});
 

--- a/packages/providers/src/lib/adapters.ts
+++ b/packages/providers/src/lib/adapters.ts
@@ -59,10 +59,17 @@ export const adapters: Record<ProviderId, ProviderAdapter> = {
 		createCompute: () => modal({ scalableSandboxes: true, appName: MODAL_APP_NAME }),
 		createOptions: {
 			templateId: config.toolchainImage,
-			// Modal's `cpu`/`cpuLimit` are physical cores, not vCPUs — convert from the pinned vCPU spec.
+			// Modal's `cpu`/`cpuLimit` are physical cores, not vCPUs ("Note that this value corresponds to
+			// physical cores, not vCPUs" — modal.com/docs/guide/resources; 1 core = 2 vCPUs), so convert
+			// from the pinned vCPU spec. Passing TARGET_SPEC.vcpus straight through would reserve 2
+			// physical cores = 4 vCPUs — double every other provider, not parity with them.
 			cpu: TARGET_SPEC.vcpus / VCPUS_PER_PHYSICAL_CORE,
 			cpuLimit: TARGET_SPEC.vcpus / VCPUS_PER_PHYSICAL_CORE,
+			// `memoryMiB` is only a RESERVATION — on its own the guest still sees the host's RAM (a live
+			// sandbox reported 464 GB), and PTS sizes STREAM's arrays from that, so the memory suite never
+			// converged. `memoryLimitMiB` is the hard cap that makes /proc/meminfo report the target spec.
 			memoryMiB: TARGET_SPEC.memoryGb * 1024,
+			memoryLimitMiB: TARGET_SPEC.memoryGb * 1024,
 		},
 	},
 };


### PR DESCRIPTION
**Daytona microVM bake + provider-spec correctness** — the `claude/daytona-microvm-class` branch, decomposed.
Shipped as a 7-PR stack (merge bottom-up, each branch independently green):

1. #107 — deps: `@daytonaio/sdk` → `@daytona/sdk` 0.192 (unlocks the `sandboxClass` selector) · ENG-145
2. #108 — refactor: retire the `DAYTONA_REGION`/ZEN5-VM selector · ENG-145
3. #109 — fix: pin snapshots to `LINUX_VM`; wait for snapshot deletion · ENG-145
4. #110 — fix: give modal a hard memory cap · ENG-64
5. #111 — fix: pin STREAM's array size so providers measure one working set · ENG-64
6. #112 — feat: surface a timed-out step's log tail · ENG-64
7. #113 — feat: `--require` in bench-smoke + `force_republish` · ENG-145

↑ **This PR is #110 (4/7)**, based on #109.

---

## What this fixes

`memoryMiB` is only a **reservation**. On its own the guest still sees the host's RAM — a live sandbox
reported **464 GB** — and PTS sizes STREAM's arrays from what the guest reports, so the memory suite
never converged. `memoryLimitMiB` is the hard cap that makes `/proc/meminfo` report the target spec.

## What this PR no longer does (reverted during review)

It originally also passed `TARGET_SPEC.vcpus` straight into `cpu`/`cpuLimit`, on the claim that a Modal
sandbox sees the requested `cpu` 1:1. **That was wrong.** Modal's docs are explicit — *"Note that this
value corresponds to physical cores, not vCPUs"* ([resources](https://modal.com/docs/guide/resources)),
where 1 core = 2 vCPUs. So the pre-existing `TARGET_SPEC.vcpus / VCPUS_PER_PHYSICAL_CORE` = 1 physical
core = **2 vCPU, which is exactly the target spec**. Passing the vCPU count through would have reserved
2 physical cores = **4 vCPUs — double every other provider**.

The `nproc == 1` observation the change rested on was never verified, and a *reservation* need not
change what `nproc` reports — precisely as `memoryMiB` doesn't change `/proc/meminfo`, which is this
PR's own thesis. The halving and `VCPUS_PER_PHYSICAL_CORE`'s original doc comment are restored.

## Test

Now asserts `memoryLimitMiB` — previously absent, which left the actual fix with no regression guard
(caught in review). Drops the `not.toBe` guard, logically implied by the `toMatchObject` above it.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Modal resource pinning by converting target vCPUs to physical cores for `cpu`/`cpuLimit` and enforcing a hard memory cap so the guest reports the correct RAM. Addresses ENG-64.

- **Bug Fixes**
  - Set `cpu` and `cpuLimit` to `TARGET_SPEC.vcpus / VCPUS_PER_PHYSICAL_CORE` (Modal uses physical cores; 1 core = 2 vCPUs).
  - Add `memoryLimitMiB` alongside `memoryMiB` to hard-cap guest RAM to the target spec.
  - Update tests to assert the core conversion and `memoryLimitMiB`.

<sup>Written for commit b19348e48fdd2bb610d8f510acf4ffc3c1d3dc45. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/starslingdev/sandbox-benchmarks/pull/110?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

