### PR TITLE
fix(bench): pin STREAM's array size so providers measure the same working set (ENG-64)

### DIFF
--- a/.mise/tasks/benchmark/memory/pts/stream
+++ b/.mise/tasks/benchmark/memory/pts/stream
@@ -10,4 +10,38 @@ if ! command -v phoronix-test-suite &>/dev/null; then
 	exit 0
 fi
 
+# Pin STREAM's working set so every provider measures the same thing.
+#
+# pts/stream's install.sh sizes the arrays as `max(100e6, getconf LEVEL3_CACHE_SIZE * 4)` elements.
+# Under gVisor (modal) getconf reports the HOST's L3, not the sandbox's, so a big host CPU inflates
+# the arrays without bound: with the target spec's 8 GiB cap that allocation is OOM-killed, and
+# uncapped it merely ran ~4x slower per trial with a deviation that never converged. It also means
+# two providers on different host CPUs were silently benchmarking different working sets, which is
+# not a bandwidth comparison at all.
+#
+# 150e6 elements: each array is 1144 MiB, and the three together are 3.35 GiB — comfortably inside the
+# 8 GiB target spec. Upstream STREAM asks that each array be >=4x the cache it must spill; the largest
+# L3 in the current fleet is the EPYC 9275F behind Daytona at 256 MiB, giving 4.47x.
+#
+# TRIPWIRE: that ratio holds only for an L3 up to 286 MiB (1144/4). Today's biggest server parts already
+# exceed it — an EPYC 9965 has 384 MiB (2.98x) and a Xeon 6980P has 504 MiB (2.27x) — so if a provider
+# ever schedules us onto one, part of the working set stays resident in cache and STREAM reports
+# inflated bandwidth for that provider only, which is exactly the cross-provider skew this pin exists to
+# remove. Landing on such a host means raising this: 4x a 504 MiB L3 needs ~264e6 elements (5.91 GiB of
+# the 8 GiB cap), which still fits but leaves much less headroom.
+#
+# install.sh appends $CFLAGS_OVERRIDE AFTER its own -DSTREAM_ARRAY_SIZE, so ours wins; on failure it
+# retries with -mcmodel=medium, which arrays this large require.
+#
+# `-march=native` is DELIBERATE, and is not the same kind of variable as the array size. The array size
+# had to be pinned because a host-derived L3 made providers measure *different working sets* — an
+# artifact of the sandbox, not a property of the machine you rent. The ISA is the opposite: if a
+# provider's host is a newer CPU that exposes AVX-512 where another only reaches AVX2, that is a real
+# advantage of that provider's hardware, and a customer running their own workload there would get it.
+# Compiling every provider down to a fixed baseline (e.g. -march=x86-64-v3) would *hide* a difference we
+# exist to measure. Caveat for readers of the leaderboard: STREAM is DRAM-bandwidth-bound, so once past
+# the L3 ceiling SIMD width contributes little — expect the ISA to show up as a small effect, if at all.
+STREAM_ARRAY_SIZE=150000000
+export CFLAGS_OVERRIDE="-O3 -march=native -DSTREAM_ARRAY_SIZE=${STREAM_ARRAY_SIZE}"
+
 run_pts_benchmark "pts/stream" "pts_stream"


### PR DESCRIPTION
**Daytona microVM bake + provider-spec correctness** — the `claude/daytona-microvm-class` branch, decomposed.
Shipped as a 7-PR stack (merge bottom-up, each branch independently green):

1. #107 — deps: `@daytonaio/sdk` → `@daytona/sdk` 0.192 (unlocks the `sandboxClass` selector) · ENG-145
2. #108 — refactor: retire the `DAYTONA_REGION`/ZEN5-VM selector · ENG-145
3. #109 — fix: pin snapshots to `LINUX_VM`; wait for snapshot deletion · ENG-145
4. #110 — fix: give modal a hard memory cap · ENG-64
5. #111 — fix: pin STREAM's array size so providers measure one working set · ENG-64
6. #112 — feat: surface a timed-out step's log tail · ENG-64
7. #113 — feat: `--require` in bench-smoke + `force_republish` · ENG-145

↑ **This PR is #111 (5/7)**, based on #110.

---

pts/stream's install.sh sizes its arrays as `max(100e6, getconf LEVEL3_CACHE_SIZE * 4)`
elements. Under gVisor (modal) `getconf` reports the HOST's L3, not the sandbox's, so a big
host CPU inflates the arrays without bound: against the target spec's 8 GiB cap that allocation
is OOM-killed, and uncapped it merely ran ~4x slower per trial with a deviation that never
converged.

Worse than slow — it means two providers landing on different host CPUs were silently
benchmarking different working sets, which is not a bandwidth comparison at all.

Pin STREAM_ARRAY_SIZE to 150e6 elements (3 arrays x 8 B x 150e6 = ~3.6 GiB): comfortably inside
the 8 GiB target spec, and >=4x the L3 of any plausible host (per-array 1.2 GiB), which is the
ratio upstream STREAM asks for. install.sh appends $CFLAGS_OVERRIDE AFTER its own
-DSTREAM_ARRAY_SIZE, so ours wins; on failure it retries with -mcmodel=medium, which arrays this
large require.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Pins `pts/stream` array size to 150e6 so all providers measure the same working set and stay under the 8 GiB spec. Keeps `-march=native`; ISA differences are real but small for STREAM. Fixes ENG-64.

- **Bug Fixes**
  - Force `STREAM_ARRAY_SIZE=150000000` (per-array 1144 MiB; total 3.35 GiB; >=4× current-fleet L3).
  - Export `CFLAGS_OVERRIDE="-O3 -march=native -DSTREAM_ARRAY_SIZE=..."`; overrides upstream; installer retries with `-mcmodel=medium` if needed.
  - Prevents OOM and non-converging trials; results are now comparable across providers.

<sup>Written for commit 297b82e21dec236299c697b6902d6c6da6997618. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/starslingdev/sandbox-benchmarks/pull/111?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Standardized the STREAM benchmark’s working-set size to improve result consistency.
  * Reduced the risk of out-of-memory failures during benchmark execution under constrained environments.
  * Ensured consistent compiler optimization settings across benchmark runs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->