### PR TITLE
feat(harness): surface a timed-out step's log tail before killing it (ENG-64)

### DIFF
--- a/packages/harness/src/lib/execute.test.ts
+++ b/packages/harness/src/lib/execute.test.ts
@@ -140,6 +140,58 @@ describe("StepRunner.runDetached", () => {
 		expect(commands.some((c) => c.includes("pkill"))).toBe(true);
 	});
 
+	it("surfaces the detached log's tail on timeout, before the kill discards the sandbox", async () => {
+		// Regression: the timeout path used to pkill and throw without ever reading logPath, so a hung
+		// step (the one whose output matters most) was a black box in CI.
+		const reads: string[] = [];
+		const sandbox: SandboxHandle = {
+			runCommand: async () => ({ exitCode: 0, stdout: "" }),
+			destroy: async () => undefined,
+			filesystem: {
+				exists: async () => false,
+				readFile: async (path) => {
+					reads.push(path);
+					return "line one\nStarted Run 18 @ 04:10:59 *";
+				},
+			},
+		};
+		const logged: string[] = [];
+		const spy = console.log;
+		console.log = (msg: string) => void logged.push(String(msg));
+		try {
+			const runner = new StepRunner(sandbox);
+			await expect(runner.runDetached("bench", "sleep 999", 0)).rejects.toThrow(/timed out/);
+		} finally {
+			console.log = spy;
+		}
+		expect(reads.some((p) => p.endsWith(".log"))).toBe(true);
+		expect(logged.join("\n")).toContain("Started Run 18");
+	});
+
+	it("distinguishes an unreadable log (wedged sandbox) from a quiet one", async () => {
+		// A read that never resolves means the sandbox stopped answering — not that the step was silent.
+		const sandbox: SandboxHandle = {
+			runCommand: async () => ({ exitCode: 0, stdout: "" }),
+			destroy: async () => undefined,
+			filesystem: {
+				exists: async () => false,
+				readFile: async () => {
+					throw new Error("sandbox unresponsive");
+				},
+			},
+		};
+		const logged: string[] = [];
+		const spy = console.log;
+		console.log = (msg: string) => void logged.push(String(msg));
+		try {
+			const runner = new StepRunner(sandbox);
+			await expect(runner.runDetached("bench", "sleep 999", 0)).rejects.toThrow(/timed out/);
+		} finally {
+			console.log = spy;
+		}
+		expect(logged.join("\n")).toContain("stopped responding");
+	});
+
 	// A sandbox with NO filesystem API: the detached transport must still detach (double-fork) and
 	// observe completion by `cat`-ing the done-file over exec. runCommand answers each command shape —
 	// the launch (contains nohup), the done-file probe (`cat …done`), and the log read (`cat …log`).
@@ -194,6 +246,31 @@ describe("StepRunner.runDetached", () => {
 		const { sandbox } = catPollSandbox({ exitCode: "42" });
 		const runner = new StepRunner(sandbox, CAPPED, async () => undefined);
 		await expect(runner.runDetached("bench", "false", 60_000)).rejects.toThrow(/exit code 42/);
+	});
+
+	it("distinguishes a wedged from a quiet sandbox on the no-filesystem path too", async () => {
+		// Regression: readLogTail read the log via catFile, which folds every failure into "". On a
+		// provider with no filesystem API the `.catch(() => null)` could therefore never fire, so a
+		// wedged sandbox was reported as a step that ran quietly — the exact diagnosis this is meant to
+		// tell apart. Only the fs path was covered before, which is how it shipped.
+		const sandbox: SandboxHandle = {
+			runCommand: async (command) => {
+				if (command.includes("nohup")) return { exitCode: 0, stdout: "launched" };
+				if (command.includes(".done")) return { exitCode: 0, stdout: "__RUNNING__" };
+				throw new Error("sandbox unresponsive"); // the `.log` read
+			},
+			destroy: async () => undefined,
+		};
+		const logged: string[] = [];
+		const spy = console.log;
+		console.log = (msg: string) => void logged.push(String(msg));
+		try {
+			const runner = new StepRunner(sandbox, CAPPED, async () => undefined);
+			await expect(runner.runDetached("bench", "sleep 999", 0)).rejects.toThrow(/timed out/);
+		} finally {
+			console.log = spy;
+		}
+		expect(logged.join("\n")).toContain("stopped responding");
 	});
 
 	it("backs off the poll interval geometrically up to the cap", async () => {

--- a/packages/harness/src/lib/execute.ts
+++ b/packages/harness/src/lib/execute.ts
@@ -36,6 +36,8 @@ export const MIN = 60_000;
 const POLL_START_MS = 1_500;
 const POLL_BACKOFF = 1.5;
 const POLL_CAP_MS = 10_000;
+/** How much of a timed-out detached step's log to surface — enough to diagnose, not enough to flood. */
+const TIMEOUT_LOG_TAIL_LINES = 50;
 /** Done-file sentinel for the no-filesystem cat-poll fallback: printed while the file isn't there yet. */
 const RUNNING_SENTINEL = "__RUNNING__";
 const delay = (ms: number): Promise<void> => new Promise((resolve) => setTimeout(resolve, ms));
@@ -309,10 +311,23 @@ export class StepRunner {
 					return this.finishStep(label, started, { exitCode, stdout }, opts);
 				}
 				if (performance.now() > deadline) {
+					// Recover the detached job's own output BEFORE killing it and tearing the sandbox down.
+					// A timed-out step is otherwise a black box: the log lives only inside the sandbox, and
+					// a step that hangs is exactly the one whose output we need. Best-effort — a failed read
+					// must not mask the timeout.
+					const tail = await this.readLogTail(fs, logPath);
 					// Best-effort stop the detached job; don't let a failing kill mask the timeout.
 					await this.sandbox
 						.runCommand(`pkill -f ${shellQuote(tag)} || true`)
 						.catch(() => undefined);
+					if (tail === null) {
+						console.log(
+							`--- "${label}" timed out and its log could not be read: the sandbox stopped ` +
+								`responding (memory exhaustion or a dead agent), rather than running quietly ---`,
+						);
+					} else if (tail) {
+						console.log(`--- last output from "${label}" before timeout ---\n${tail}`);
+					}
 					throw new Error(`Step "${label}" timed out after ${Math.round(timeoutMs / 1000)}s`);
 				}
 				await this.sleep(pollDelayMs);
@@ -362,6 +377,37 @@ export class StepRunner {
 		const out = (probe?.stdout ?? "").trim();
 		if (out === "" || out === RUNNING_SENTINEL) return undefined;
 		return parseExitCode(out);
+	}
+
+	/** The last {@link TIMEOUT_LOG_TAIL_LINES} lines of a detached step's log, or `null` when the log
+	 *  could not be read at all. The distinction matters: an empty tail means the step ran quietly,
+	 *  whereas an unreadable one means the sandbox stopped answering — a very different diagnosis, and
+	 *  collapsing both to "" once sent us hunting a detach bug that was really memory exhaustion.
+	 *  Bounded so a runaway log can't flood the CI transcript; never throws. */
+	private async readLogTail(
+		fs: SandboxFilesystem | undefined,
+		logPath: string,
+	): Promise<string | null> {
+		const text = fs
+			? await withTimeout(fs.readFile(logPath), POLL_CAP_MS, "log fs read").catch(() => null)
+			: await this.catLogOrNull(logPath);
+		if (text === null) return null;
+		const lines = text.trimEnd().split("\n");
+		return lines.slice(-TIMEOUT_LOG_TAIL_LINES).join("\n");
+	}
+
+	/** `cat` the log for {@link readLogTail}, preserving a read failure as `null`. Deliberately NOT
+	 *  {@link catFile}: that one folds every failure into `""`, which is right for the poll loop (an
+	 *  absent done-file is not an error) but would make a wedged sandbox indistinguishable from a step
+	 *  that simply printed nothing — the one distinction this diagnostic exists to draw. */
+	private async catLogOrNull(logPath: string): Promise<string | null> {
+		return withTimeout(
+			this.sandbox.runCommand(`bash -c ${shellQuote(`cat ${logPath} 2>/dev/null || true`)}`),
+			POLL_CAP_MS,
+			"log cat read",
+		)
+			.then((res) => res.stdout ?? "")
+			.catch(() => null);
 	}
 
 	/** Read the detached step's log over `exec` — the output transport for the no-filesystem path. */


### PR DESCRIPTION
**Daytona microVM bake + provider-spec correctness** — the `claude/daytona-microvm-class` branch, decomposed.
Shipped as a 7-PR stack (merge bottom-up, each branch independently green):

1. #107 — deps: `@daytonaio/sdk` → `@daytona/sdk` 0.192 (unlocks the `sandboxClass` selector) · ENG-145
2. #108 — refactor: retire the `DAYTONA_REGION`/ZEN5-VM selector · ENG-145
3. #109 — fix: pin snapshots to `LINUX_VM`; wait for snapshot deletion · ENG-145
4. #110 — fix: give modal a hard memory cap · ENG-64
5. #111 — fix: pin STREAM's array size so providers measure one working set · ENG-64
6. #112 — feat: surface a timed-out step's log tail · ENG-64
7. #113 — feat: `--require` in bench-smoke + `force_republish` · ENG-145

↑ **This PR is #112 (6/7)**, based on #111.

---

A detached step that times out was a black box. Its log lives only inside the sandbox, and
the timeout path killed the job and tore the sandbox down without ever reading it — so the one
step whose output we most need is the one whose output we threw away.

`readLogTail()` recovers the last 50 lines over whichever transport the step used (fs read, or
the cat-poll fallback) BEFORE the pkill, bounded so a runaway log can't flood the CI transcript.
It is best-effort and never throws: a failed read must not mask the timeout itself.

It returns `null` (unreadable) distinctly from `""` (read fine, step was quiet). That distinction
is the whole point — collapsing both to "" once sent us hunting a detach bug that was really
memory exhaustion, because a wedged sandbox and a quiet step looked identical. The two cases now
print different diagnoses.

Pure-additive: nothing else changes behavior, and the two new unit tests drive the method directly.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Print the last 50 lines of a timed-out detached step’s log before killing it, so timeouts are diagnosable. Addresses ENG-64 in `packages/harness`; works on both filesystem and cat-poll paths and distinguishes a wedged sandbox from a quiet step.

- **New Features**
  - Added `readLogTail()` to surface up to 50 lines before `pkill`; bounded, best-effort, never throws.
  - Prints either the tail or a clear “sandbox stopped responding” message; stays quiet if the tail is empty.

- **Bug Fixes**
  - No-filesystem path reads via `catLogOrNull` so failures return `null`, preserving wedged-vs-quiet behavior; added tests for filesystem and no-filesystem paths.

<sup>Written for commit 27c17232bddd265c763af6781645defb3f316d80. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/starslingdev/sandbox-benchmarks/pull/112?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

