### PR TITLE
feat(ci): require providers in bench-smoke, and allow a forced republish (ENG-145)

### DIFF
--- a/.github/workflows/bench-smoke.yml
+++ b/.github/workflows/bench-smoke.yml
@@ -16,9 +16,11 @@ on:
         # workflow-registry-sync drift gate (tooling/repo-checks) keeps this list in lockstep, so a
         # new suite must be added here too. Still passed through the environment below (never
         # interpolated into the shell) as defense-in-depth.
+        # Defaults to `memory` (STREAM): the fastest suite in the registry — a couple of minutes of
+        # benchmark on top of setup — which makes it the cheapest end-to-end validation of the lane.
         description: Suite to run
         type: choice
-        default: cpu-node
+        default: memory
         options:
           [
             cpu-node,
@@ -79,6 +81,10 @@ jobs:
           # shell. `$GITHUB_RUN_ID` is built-in.
           BENCH_PROVIDER: ${{ inputs.provider }}
           BENCH_SUITE: ${{ inputs.suite }}
+          # The point of a smoke run is to prove the lane end to end. Without this, a missing or
+          # misnamed provider secret is recorded as a skip and the job still exits 0 having
+          # benchmarked nothing — assert the dispatched provider actually reached "validated".
+          REQUIRE_PROVIDERS: ${{ inputs.provider }}
           DAYTONA_API_KEY: ${{ secrets.DAYTONA_API_KEY }}
           # Boot daytona sandboxes in the active region (us-west-2). Defaulted so an unsynced secret
           # can't fail the config gatekeeper at module load.

--- a/.github/workflows/toolchain-image.yml
+++ b/.github/workflows/toolchain-image.yml
@@ -8,10 +8,16 @@ name: Toolchain image
 #     the immutable public :v1. Iteration never touches :v1; bump TOOLCHAIN_VERSION
 #     (packages/schema/src/toolchain.ts) to publish a new version.
 on:
-  # Manual re-trigger (e.g. after bumping TOOLCHAIN_VERSION). No inputs: the public version is
-  # immutable — there is no force/overwrite. To republish, bump TOOLCHAIN_VERSION; an already-published
-  # version is always skipped at the guard below.
+  # Manual re-trigger (e.g. after bumping TOOLCHAIN_VERSION). The public version is immutable on the
+  # automated push path; `force_republish` (manual dispatch only) deliberately regenerates it over an
+  # existing version for fast dev iteration. Normally, to republish you bump TOOLCHAIN_VERSION; an
+  # already-published version is skipped at the guard below unless force_republish is set.
   workflow_dispatch:
+    inputs:
+      force_republish:
+        description: "Regenerate the current version, overwriting it if already published (dev only)"
+        type: boolean
+        default: false
   push:
     branches: [main]
     # The publish lane runs `bake`/`promote`, which pull in the whole provider-run + smoke + harness
@@ -140,11 +146,17 @@ jobs:
       # Guard the immutable public version: skip the whole publish if :v1 already exists. The version is
       # immutable (promote refuses to overwrite it), so a published version is never re-promoted — bump
       # TOOLCHAIN_VERSION to publish a new one. The candidate is mutable and always rebuilt within a run.
+      # `force_republish` (manual dispatch only) overrides the skip to regenerate the version in place.
       - name: Check if version already published
         id: guard
+        env:
+          FORCE_REPUBLISH: ${{ inputs.force_republish }}
         run: |
-          if docker manifest inspect "${VERSION_REF}" >/dev/null 2>&1; then
-            echo "::notice::${VERSION_REF} already published — skipping (bump TOOLCHAIN_VERSION to publish a new version)."
+          if [ "${FORCE_REPUBLISH}" = "true" ]; then
+            echo "::notice::force_republish set — regenerating ${VERSION_REF} even though it may already exist."
+            echo "skip=false" >> "${GITHUB_OUTPUT}"
+          elif docker manifest inspect "${VERSION_REF}" >/dev/null 2>&1; then
+            echo "::notice::${VERSION_REF} already published — skipping (bump TOOLCHAIN_VERSION, or dispatch with force_republish, to publish again)."
             echo "skip=true" >> "${GITHUB_OUTPUT}"
           else
             echo "skip=false" >> "${GITHUB_OUTPUT}"
@@ -228,8 +240,14 @@ jobs:
           DAYTONA_TARGET: ${{ secrets.DAYTONA_TARGET || 'us-west-2' }}
           MODAL_TOKEN_ID: ${{ secrets.MODAL_TOKEN_ID }}
           MODAL_TOKEN_SECRET: ${{ secrets.MODAL_TOKEN_SECRET }}
+          FORCE_REPUBLISH: ${{ inputs.force_republish }}
         # --require fails promote loudly if a required provider's secret is missing/misnamed, so the
         # public version is never published while a required provider's version artifact was silently
         # skipped. modal is required (validated via its fromRegistry boot); MODAL_TOKEN_* must be synced.
-        # (blaxel is excluded — its bake is a no-op.)
-        run: bun apps/cli/src/bin/bake.ts --promote --require e2b,daytona,modal
+        # (blaxel is excluded — its bake is a no-op.) `--force` (manual force_republish dispatch only)
+        # republishes over an existing immutable version; never set on the automated push path.
+        run: |
+          set -euo pipefail
+          args=(--promote --require "e2b,daytona,modal")
+          if [ "${FORCE_REPUBLISH}" = "true" ]; then args+=(--force); fi
+          bun apps/cli/src/bin/bake.ts "${args[@]}"

--- a/apps/cli/src/bin/bake.ts
+++ b/apps/cli/src/bin/bake.ts
@@ -45,7 +45,9 @@ if (import.meta.main) {
 
 	// Promote is the release step: publish the already-validated candidate as the public version.
 	if (process.argv.includes("--promote")) {
-		const promoted = await promoteAll(log);
+		// `--force` republishes over an existing (immutable) version — dev regeneration, set only by a
+		// manual toolchain-image.yml dispatch. Automated pushes never pass it, so :v1 stays immutable there.
+		const promoted = await promoteAll(log, process.argv.includes("--force"));
 		console.log(
 			JSON.stringify(
 				{

--- a/apps/cli/src/bin/bench-suite.ts
+++ b/apps/cli/src/bin/bench-suite.ts
@@ -4,7 +4,12 @@
 // recorded as a skip (the provider stays `pending` in the Run), so this is runnable without secrets.
 
 import { join } from "node:path";
-import { runSuite, SuiteUsageError } from "@sandbox-benchmarks/harness";
+import {
+	requiredProviders,
+	runSuite,
+	SuiteUsageError,
+	unmetRequirements,
+} from "@sandbox-benchmarks/harness";
 import { summarizeRun, writeNormalizedRun } from "@sandbox-benchmarks/results";
 import { handleDiscovery } from "../lib/discovery.ts";
 
@@ -17,6 +22,8 @@ usage: bench-suite [provider] [suite] [runId]
   provider           Provider to run on (default: daytona). See --list-providers.
   suite              Suite to run (default: cpu-node). See --list-suites.
   runId              Run identifier for the data/ tree (default: local-<timestamp>).
+  --require <ids>    Comma-separated providers that MUST reach "validated"; exit 1 otherwise.
+                     Also read from REQUIRE_PROVIDERS. CI sets this so a missing secret fails loudly.
   --list-providers   List the registered providers.
   --list-suites      List the registered suites and their dimensions/metrics.
   --json             Emit --list-* output as JSON instead of human-readable lines.
@@ -28,21 +35,36 @@ runnable without secrets. Writes data/runs/<runId>.json and updates data/runs/in
 examples:
   bench-suite daytona cpu-node            # one suite locally, auto runId
   bench-suite modal memory ci-1234        # a specific cell + runId
+  bench-suite e2b memory --require e2b    # fail (don't skip) if E2B_API_KEY is absent
   bench-suite --list-suites               # discover the suite names first
 
 Next: render the Run with \`leaderboard data/runs/<runId>.json\`.`;
 
 if (import.meta.main) {
 	const argv = process.argv.slice(2);
-	const discovery = handleDiscovery(argv, HELP);
+	const discovery = handleDiscovery(argv, HELP, ["--require"]);
 	if (discovery !== null) {
 		(discovery.ok ? console.log : console.error)(discovery.text);
 		process.exit(discovery.ok ? 0 : 2);
 	}
 
 	// Filter flags out before positional resolution so a trailing/misplaced flag (e.g.
-	// `bench-suite daytona cpu-node --json`) never gets captured as the runId.
-	const positionals = argv.filter((a) => !a.startsWith("-"));
+	// `bench-suite daytona cpu-node --json`) never gets captured as the runId. `--require` is the one
+	// flag that takes a separate operand, so consume that operand too — otherwise `--require daytona`
+	// would leave `daytona` behind to be read as the runId.
+	const positionals: string[] = [];
+	for (let i = 0; i < argv.length; i++) {
+		const arg = argv[i];
+		if (arg === undefined) continue;
+		// Only the space-separated spelling needs the skip: `--require=<ids>` is a single token and is
+		// already dropped by the leading-`-` guard below.
+		if (arg === "--require") {
+			i++;
+			continue;
+		}
+		if (arg.startsWith("-")) continue;
+		positionals.push(arg);
+	}
 	const provider = positionals[0] ?? "daytona";
 	const suite = positionals[1] ?? "cpu-node";
 	const runId = positionals[2] ?? `local-${Date.now()}`;
@@ -72,4 +94,29 @@ if (import.meta.main) {
 	const run = writeNormalizedRun({ rawRoot, runId, sha, outFile, updateIndexFile: indexFile });
 	console.log(`\nNormalized Run ${runId} → ${outFile}`);
 	for (const line of summarizeRun(run)) console.log(line);
+
+	// Missing credentials (and an unusable sandbox) are recorded as a skip, not a throw — the lenient
+	// local-dev default. That would make a smoke run whose secret is missing/misnamed exit 0 having
+	// benchmarked nothing, so CI passes `--require <provider>` (or REQUIRE_PROVIDERS) to assert the
+	// provider actually reached `validated` — i.e. produced at least one catalogued metric.
+	// Pass the sliced argv explicitly rather than letting it default to `process.argv` (which also
+	// carries the bun executable and script path), so the flag this bin parses is the flag this gate reads.
+	const required = requiredProviders(argv);
+	if (required.length > 0) {
+		const reports = run.providers.map((p) => ({
+			provider: p.providerId,
+			status: p.validationStatus === "validated" ? "ok" : p.validationStatus,
+		}));
+		const unmet = unmetRequirements(reports, required);
+		if (unmet.length > 0) {
+			for (const providerId of unmet) {
+				const skips = run.providers.find((p) => p.providerId === providerId)?.skips ?? [];
+				const detail = skips.map((s) => `${s.suite}: ${s.reason}`).join("; ");
+				console.error(
+					`Required provider "${providerId}" produced no metrics${detail ? ` — ${detail}` : " and was absent from the Run"}`,
+				);
+			}
+			process.exit(1);
+		}
+	}
 }

--- a/apps/cli/src/lib/bake/daytona.test.ts
+++ b/apps/cli/src/lib/bake/daytona.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from "bun:test";
+import { snapshotDestroyedMessage } from "./daytona.ts";
+
+// The published snapshot name a `promote --force` regenerates in place — the case where a create that
+// fails after the delete leaves a *public* artifact absent rather than stale.
+const PUBLISHED = "sandbox-benchmarks-toolchain-v1";
+
+describe("snapshotDestroyedMessage", () => {
+	it("names the snapshot that no longer exists, so a report reader can't mistake it for untouched", () => {
+		const message = snapshotDestroyedMessage(PUBLISHED, 1, "runner out of capacity");
+
+		// The whole point of the annotation: the name is gone, not merely un-updated. A reader of the
+		// promote report sees the destroyed artifact without knowing daytona deletes before it creates.
+		expect(message).toContain(`no snapshot named ${PUBLISHED} now exists`);
+		expect(message).toContain("rerun the bake to recreate it");
+	});
+
+	it("preserves the underlying create failure, so the root cause survives the annotation", () => {
+		const message = snapshotDestroyedMessage(PUBLISHED, 1, "runner out of capacity");
+
+		expect(message).toContain("runner out of capacity");
+	});
+
+	it("reports how many snapshots the delete swept, since a stuck bake can leave several of one name", () => {
+		// listSnapshotsByName sweeps every snapshot of the name in any state (a failed mid-create leaves
+		// one `get` won't return), so the count is genuinely unbounded above 1 — don't hardcode "1".
+		expect(snapshotDestroyedMessage(PUBLISHED, 3, "boom")).toContain("deleting 3 pre-existing");
+	});
+});

--- a/apps/cli/src/lib/bake/daytona.ts
+++ b/apps/cli/src/lib/bake/daytona.ts
@@ -3,6 +3,13 @@
 // snapshot of that name, then recreate. The API key + runner target come from config.daytona
 // (single-region: DAYTONA_API_KEY + DAYTONA_TARGET, e.g. us-west-2).
 //
+// Delete-then-create is idempotent but NOT atomic: the SDK exposes no snapshot rename or overwrite,
+// so the name is unavoidably ABSENT between the delete and a successful create. Reruns converge, but
+// a create that fails leaves no snapshot of that name at all. That is harmless for the candidate
+// (nothing consumes it) and destructive for a name already in public use — see `promote --force`,
+// which is the only caller that hands us a published name. `bakeDaytonaSnapshot` therefore reports
+// which side of the delete it failed on, so callers never have to guess whether the name survived.
+//
 // Iteration surface: a snapshot's region must match where sandboxes boot. We pass the client `target`;
 // if the target also needs an explicit snapshot `regionId`, add it to CreateSnapshotParams here.
 //
@@ -54,8 +61,13 @@ async function listSnapshotsByName(
  *  asynchronous (active → `removing` → gone), and `create` rejects the name while ANY snapshot of it
  *  still exists — so returning right after issuing the delete races the not-yet-completed removal
  *  ("already exists for this organization"). Poll `list()` until no match remains, bounded by a
- *  deadline so a stuck removal fails loudly instead of hanging. */
-async function deleteExistingSnapshots(daytona: Daytona, name: string, log: Log): Promise<void> {
+ *  deadline so a stuck removal fails loudly instead of hanging.
+ *
+ *  Returns how many snapshots it removed. A non-zero return means the name is now free BECAUSE we
+ *  destroyed what held it: from here to a successful `create`, `name` does not resolve. Callers use
+ *  this to distinguish "create failed, nothing was there anyway" from "create failed and the
+ *  pre-existing snapshot is gone". Throwing leaves the name intact (the delete never completed). */
+async function deleteExistingSnapshots(daytona: Daytona, name: string, log: Log): Promise<number> {
 	const matches = await listSnapshotsByName(daytona, name);
 	for (const snap of matches) {
 		// A snapshot already mid-removal (a cancelled or concurrent bake) needs no second delete, and
@@ -74,7 +86,7 @@ async function deleteExistingSnapshots(daytona: Daytona, name: string, log: Log)
 			if (!isNotFound(err)) throw err;
 		}
 	}
-	if (matches.length === 0) return;
+	if (matches.length === 0) return 0;
 
 	const DEADLINE_MS = 180_000;
 	const POLL_MS = 3_000;
@@ -97,7 +109,7 @@ async function deleteExistingSnapshots(daytona: Daytona, name: string, log: Log)
 			continue;
 		}
 
-		if (remaining.length === 0) return;
+		if (remaining.length === 0) return matches.length;
 		if (performance.now() - start > DEADLINE_MS) {
 			throw new Error(
 				`daytona snapshot ${name} still present after ${DEADLINE_MS}ms (states: ${remaining
@@ -112,8 +124,26 @@ async function deleteExistingSnapshots(daytona: Daytona, name: string, log: Log)
 	}
 }
 
+/** The message for a create that failed after `deleted` (> 0) pre-existing snapshots of `name` were
+ *  removed to free the name: `name` now resolves to nothing. Stated plainly because the caller that
+ *  passes a published name (promote `--force`) surfaces this as the report's `reason`, where "failed"
+ *  otherwise reads as "nothing changed". Pure (strings in, string out) so it is unit-testable without
+ *  standing up the SDK. */
+export function snapshotDestroyedMessage(name: string, deleted: number, reason: string): string {
+	return (
+		`daytona snapshot ${name}: create failed after deleting ${deleted} pre-existing snapshot(s) of ` +
+		`that name — no snapshot named ${name} now exists; rerun the bake to recreate it: ${reason}`
+	);
+}
+
 /** Create the daytona snapshot `name` from `image` (candidate while iterating, version on promote).
- *  Idempotent: delete any existing snapshot of that name first. */
+ *  Idempotent: delete any existing snapshot of that name first.
+ *
+ *  If the create fails AFTER a pre-existing snapshot was deleted, the thrown error says so — `name`
+ *  now resolves to nothing, and for a published name (promote `--force`) that is a public artifact
+ *  the caller must report as destroyed rather than merely "not written". A create that fails with
+ *  nothing deleted, or a delete that fails outright, leaves the prior snapshot intact and rethrows
+ *  unchanged. */
 export async function bakeDaytonaSnapshot(name: string, image: string, log: Log): Promise<void> {
 	const { daytona: daytonaCfg, targetSpec } = config;
 	const daytona = new Daytona({
@@ -121,17 +151,25 @@ export async function bakeDaytonaSnapshot(name: string, image: string, log: Log)
 		...(daytonaCfg.target ? { target: daytonaCfg.target } : {}),
 	});
 
-	await deleteExistingSnapshots(daytona, name, log);
+	const deleted = await deleteExistingSnapshots(daytona, name, log);
 
 	log(`creating snapshot ${name} from ${image} (target ${daytonaCfg.target ?? "default"})`);
-	await daytona.snapshot.create(
-		{
-			name,
-			image,
-			resources: { cpu: targetSpec.vcpus, memory: targetSpec.memoryGb, disk: targetSpec.diskGb },
-			// Pin to microVM runners (never the `container` default) — the fleet's hard constraint.
-			sandboxClass: SandboxClass.LINUX_VM,
-		},
-		{ onLogs: log },
-	);
+	try {
+		await daytona.snapshot.create(
+			{
+				name,
+				image,
+				resources: { cpu: targetSpec.vcpus, memory: targetSpec.memoryGb, disk: targetSpec.diskGb },
+				// Pin to microVM runners (never the `container` default) — the fleet's hard constraint.
+				sandboxClass: SandboxClass.LINUX_VM,
+			},
+			{ onLogs: log },
+		);
+	} catch (err) {
+		// Nothing was deleted → the name was already free, so the prior state (none) is intact: rethrow
+		// verbatim rather than dress up an ordinary create failure as a destroyed artifact.
+		if (deleted === 0) throw err;
+		const reason = err instanceof Error ? err.message : String(err);
+		throw new Error(snapshotDestroyedMessage(name, deleted, reason), { cause: err });
+	}
 }

--- a/apps/cli/src/lib/bake/promote.ts
+++ b/apps/cli/src/lib/bake/promote.ts
@@ -1,8 +1,10 @@
 // Promote the validated candidate to the immutable public version — the ONLY step that writes
 // public-facing artifacts. Run after `bake` validates the candidate.
 //
-// The order makes the immutable base tag the COMMIT POINT, so a mid-promote failure is always clean:
-//   1. Refuse if the public version tag already exists — it is immutable (no --force; bump to republish).
+// The order makes the immutable base tag the COMMIT POINT, so a mid-promote failure is clean — with one
+// documented exception under `--force`, called out at step 3 and in the step-3 abort:
+//   1. Refuse if the public version tag already exists — it is immutable; bump to republish (or pass
+//      `--force`, wired only to a manual force_republish dispatch, to deliberately regenerate in place).
 //   2. Re-validate the candidate (boot + smoke) right now, so the bytes we publish are verified again
 //      (the candidate tag is mutable and may have changed since `bake`). Abort on any failure.
 //   3. Build each provider's version-named artifact FROM the candidate base (the just-revalidated
@@ -13,7 +15,12 @@
 //   4. LAST: retag the candidate base → the public version (registry-side). Reached only when every
 //      prior step succeeded, so a failure never leaves a published version with missing/stale artifacts.
 // A rerun after a mid-promote failure is clean (the version tag was never written); once published it
-// is refused at step 1 — bump the version to publish again.
+// is refused at step 1 — bump the version, or force_republish, to publish again. Under `--force` the
+// version's artifacts already exist, and step 3 regenerates them in place: the image retag and e2b
+// `template create` publish a new artifact over the old name (the prior one stands until the new one
+// lands), but daytona has no snapshot overwrite — it deletes, then creates. So a forced republish whose
+// daytona create fails leaves that snapshot ABSENT, not stale. Recovery is a rerun with force_republish
+// (a plain rerun is refused at step 1, since the base image is still there).
 import { requiredProviders, unmetRequirements } from "@sandbox-benchmarks/harness";
 import { config } from "@sandbox-benchmarks/providers";
 import { forEachProviderWithCreds } from "../providers-run.ts";
@@ -24,26 +31,40 @@ import type { BakeReport, Log } from "./types.ts";
 import type { CandidateRefs } from "./validate.ts";
 import { validateCandidates } from "./validate-run.ts";
 
-export async function promoteAll(log: Log): Promise<BakeReport[]> {
+export async function promoteAll(log: Log, force = false): Promise<BakeReport[]> {
 	const reports: BakeReport[] = [];
 
 	// 1. Refuse to overwrite the immutable public version (D2b). Checked first, before any mutation, so
 	//    a refused promote leaves everything untouched. A registry error here (auth/network) is NOT
 	//    "not published" — refuse rather than risk overwriting an existing :v1 we couldn't see.
-	let alreadyPublished: boolean;
-	try {
-		alreadyPublished = await imageExistsInRegistry(config.toolchainImageVersion);
-	} catch (err) {
-		const reason = `could not verify whether ${config.toolchainImageVersion} is already published, so refusing to publish: ${err instanceof Error ? err.message : String(err)}`;
-		log(`<<< promote refused — ${reason}`);
-		reports.push({ provider: "image", status: "failed", reason });
-		return reports;
-	}
-	if (alreadyPublished) {
-		const reason = `${config.toolchainImageVersion} already exists — the public version is immutable; bump the version to publish again`;
-		log(`<<< promote refused — ${reason}`);
-		reports.push({ provider: "image", status: "failed", reason });
-		return reports;
+	//    `force` (manual dispatch only — see toolchain-image.yml) deliberately republishes over an
+	//    existing version for dev iteration; automated push-to-main never sets it, so the invariant
+	//    holds in production. The image retag and e2b `template create` overwrite by name, replacing
+	//    the artifact only once the new one is built. Daytona does NOT: it deletes the existing
+	//    snapshot before creating, so a forced republish drops the published snapshot for the length
+	//    of the rebuild, and leaves it absent if the rebuild fails. Forced republish is therefore a
+	//    destructive regenerate, and is why `force` is manual-dispatch-only.
+	if (force) {
+		log(
+			`>>> force-republish: regenerating ${config.toolchainImageVersion}, overwriting if present ` +
+				`(daytona: ${config.daytonaSnapshotDefault} is deleted and rebuilt, so it is briefly absent)`,
+		);
+	} else {
+		let alreadyPublished: boolean;
+		try {
+			alreadyPublished = await imageExistsInRegistry(config.toolchainImageVersion);
+		} catch (err) {
+			const reason = `could not verify whether ${config.toolchainImageVersion} is already published, so refusing to publish: ${err instanceof Error ? err.message : String(err)}`;
+			log(`<<< promote refused — ${reason}`);
+			reports.push({ provider: "image", status: "failed", reason });
+			return reports;
+		}
+		if (alreadyPublished) {
+			const reason = `${config.toolchainImageVersion} already exists — the public version is immutable; bump the version or dispatch with force_republish to publish again`;
+			log(`<<< promote refused — ${reason}`);
+			reports.push({ provider: "image", status: "failed", reason });
+			return reports;
+		}
 	}
 
 	// 2. Re-validate the candidate immediately before publishing, so the bytes we promote are verified
@@ -72,6 +93,10 @@ export async function promoteAll(log: Log): Promise<BakeReport[]> {
 	// 3. Build each provider's version-named artifact FROM the candidate base (the bytes we just
 	//    revalidated). Built BEFORE the base retag, so a failure here leaves the version base unwritten
 	//    and a rerun is clean. Shares the skip-vs-fail loop with bake.
+	//    Under `--force` these names already exist and are live. e2b/image replace on success; daytona
+	//    deletes first (no snapshot overwrite in the SDK), so a failed daytona create removes the
+	//    published snapshot — `bakeDaytonaSnapshot` says so in its error, which lands in the report's
+	//    `reason`. The base is still never written, so the version tag itself stays consistent.
 	const runs = await forEachProviderWithCreds(
 		async (provider) => {
 			log(`>>> ${provider.name}: building version artifact from candidate…`);
@@ -119,12 +144,25 @@ export async function promoteAll(log: Log): Promise<BakeReport[]> {
 		});
 	}
 
+	// After a forced republish aborts, the previous version's base image is still tagged, so step 1 would
+	// refuse a plain rerun — recovery has to re-force. Shared by both pre-publish aborts below.
+	const rerunHint = force
+		? "Fix the cause and rerun with force_republish — a plain rerun is refused because the base image already exists."
+		: "Fix the cause and rerun `bake --promote`.";
+
 	// A provider artifact failed → do NOT publish the base. The version tag stays unwritten, so a rerun
-	// (after fixing the cause) reconciles cleanly — nothing public was half-written.
+	// (after fixing the cause) reconciles cleanly. Nothing public was half-written — EXCEPT under
+	// `--force`, where step 3 regenerates already-published artifacts in place and daytona's
+	// delete-then-create can leave its published snapshot absent (the report's `reason` says so).
 	if (reports.some((r) => r.status === "failed")) {
 		log(
 			`!!! promote aborted before publish: a ${config.toolchainImageVersion} provider artifact failed; ` +
-				"the public base was NOT written. Fix the cause and rerun `bake --promote`.",
+				"the public base was NOT written. " +
+				(force
+					? "This was a forced republish, so the failed provider's already-published artifact may have " +
+						"been regenerated — or, for daytona, deleted and not recreated (see its reason above). "
+					: "") +
+				rerunHint,
 		);
 		return reports;
 	}
@@ -140,9 +178,10 @@ export async function promoteAll(log: Log): Promise<BakeReport[]> {
 	const unmet = unmetRequirements(reports, required);
 	if (required.length > 0 && unmet.length > 0) {
 		const reason = `required providers did not promote: ${unmet.join(", ")} (--require / REQUIRE_PROVIDERS)`;
+		// A required provider that merely *skipped* never built anything, so unlike the artifact-failed
+		// abort above there is no half-regenerated artifact to warn about — only the rerun differs.
 		log(
-			`!!! promote aborted before publish: ${reason}; the public base was NOT written. ` +
-				"Fix the cause and rerun `bake --promote`.",
+			`!!! promote aborted before publish: ${reason}; the public base was NOT written. ${rerunHint}`,
 		);
 		// Push a structured failure (like the step-1 and step-4 aborts) so the emitted JSON is
 		// self-describing — a consumer sees the failed promote without re-deriving it from `--require`.

--- a/apps/cli/src/lib/discovery.test.ts
+++ b/apps/cli/src/lib/discovery.test.ts
@@ -84,6 +84,25 @@ describe("handleDiscovery", () => {
 		expect(suites?.text).toContain("Unknown flag: --nope");
 	});
 
+	it("accepts a bin's declared value flag in both the space and equals spellings", () => {
+		// bench-suite declares `--require`; it must fall through to the bin's own parsing, not error.
+		expect(handleDiscovery(["e2b", "memory", "--require", "e2b"], HELP, ["--require"])).toBeNull();
+		expect(handleDiscovery(["e2b", "memory", "--require=e2b"], HELP, ["--require"])).toBeNull();
+	});
+
+	it("keeps the flag set closed for bins that don't declare the value flag", () => {
+		// The closed set must not grow a union of every bin's private vocabulary.
+		const res = handleDiscovery(["--require", "e2b"], HELP);
+		expect(res?.ok).toBe(false);
+		expect(res?.text).toContain("Unknown flag: --require");
+	});
+
+	it("still rejects an undeclared flag alongside a declared value flag", () => {
+		const res = handleDiscovery(["--require=e2b", "--bogus"], HELP, ["--require"]);
+		expect(res?.ok).toBe(false);
+		expect(res?.text).toContain("Unknown flag: --bogus");
+	});
+
 	it("lets --help win over an unknown flag, as a safe escape hatch", () => {
 		expect(handleDiscovery(["--help", "--bogus"], HELP)).toEqual({ text: HELP, ok: true });
 	});

--- a/apps/cli/src/lib/discovery.ts
+++ b/apps/cli/src/lib/discovery.ts
@@ -85,19 +85,31 @@ export interface DiscoveryResult {
  *   - `--list-suites`    → the registered suites
  *   - any other `-…`     → an "Unknown flag" error (`!ok`) so the caller exits non-zero, even when
  *                          paired with a valid action (the unknown flag is never silently dropped)
+ * A bin with its own value-taking flag (e.g. bench-suite's `--require <ids>`) declares it in
+ * `valueFlags` so the closed set stays closed for every other bin rather than growing a union of
+ * every bin's private vocabulary. Both `--flag <v>` and `--flag=<v>` spellings are accepted.
  * Centralising the dispatch keeps the flag vocabulary consistent and makes a bin's discovery output
  * unit-testable without spawning a process.
  */
 /** The closed set of flags any bin's discovery layer accepts; anything else `-…` is an error. */
 const RECOGNISED_FLAGS = new Set(["--help", "-h", "--list-providers", "--list-suites", "--json"]);
-export function handleDiscovery(argv: readonly string[], help: string): DiscoveryResult | null {
+export function handleDiscovery(
+	argv: readonly string[],
+	help: string,
+	valueFlags: readonly string[] = [],
+): DiscoveryResult | null {
 	// `--help` is the escape hatch: it wins even alongside other flags, so `--help --anything` prints
 	// usage rather than an error.
 	if (hasFlag(argv, "--help", "-h")) return { text: help, ok: true };
 	// Reject any unrecognized flag BEFORE dispatching an action, so a bogus flag paired with a valid
 	// action (e.g. `--list-providers --bogus`) is surfaced rather than silently ignored — matching the
 	// bare `--bogus` path. Positional args (no leading `-`) fall through to the bin's own parsing.
-	const unknown = argv.find((a) => a.startsWith("-") && !RECOGNISED_FLAGS.has(a));
+	const unknown = argv.find(
+		(a) =>
+			a.startsWith("-") &&
+			!RECOGNISED_FLAGS.has(a) &&
+			!valueFlags.some((f) => a === f || a.startsWith(`${f}=`)),
+	);
 	if (unknown) return { text: `Unknown flag: ${unknown}\n\n${help}`, ok: false };
 	const json = hasFlag(argv, "--json");
 	if (hasFlag(argv, "--list-providers")) return { text: renderProviders(json), ok: true };


### PR DESCRIPTION
**Daytona microVM bake + provider-spec correctness** — the `claude/daytona-microvm-class` branch, decomposed.
Shipped as a 7-PR stack (merge bottom-up, each branch independently green):

1. #107 — deps: `@daytonaio/sdk` → `@daytona/sdk` 0.192 (unlocks the `sandboxClass` selector) · ENG-145
2. #108 — refactor: retire the `DAYTONA_REGION`/ZEN5-VM selector · ENG-145
3. #109 — fix: pin snapshots to `LINUX_VM`; wait for snapshot deletion · ENG-145
4. #110 — fix: give modal a hard memory cap · ENG-64
5. #111 — fix: pin STREAM's array size so providers measure one working set · ENG-64
6. #112 — feat: surface a timed-out step's log tail · ENG-64
7. #113 — feat: `--require` in bench-smoke + `force_republish` · ENG-145

↑ **This PR is #113 (7/7)**, based on #112.

---

Two CI-lane hardening changes.

1. bench-suite --require. Missing credentials are recorded as a skip, not a throw — the lenient
   local-dev default. That made a smoke run whose secret was missing or misnamed exit 0 having
   benchmarked nothing, which defeats the entire point of a smoke run. bench-suite now accepts
   `--require <ids>` (and REQUIRE_PROVIDERS), asserting each named provider actually reached
   `validated` — i.e. produced at least one catalogued metric — and exits 1 with the skip reasons
   otherwise. bench-smoke.yml passes the dispatched provider. Its default suite moves cpu-node ->
   memory: STREAM is the registry's fastest suite, so it's the cheapest end-to-end lane check.

   `--require` is the first bin flag that takes a separate operand, which touches two parsers.
   `handleDiscovery` grew a `valueFlags` parameter so a bin declares its own value-taking flags
   rather than the shared closed set growing a union of every bin's private vocabulary (both
   `--flag v` and `--flag=v` spellings). bench-suite's positional scan consumes the operand too,
   so `--require daytona` no longer leaves `daytona` behind to be captured as the runId.

2. force_republish. The public version is immutable and promote refuses to overwrite it, so dev
   iteration on a published version required a TOOLCHAIN_VERSION bump. `promoteAll(log, force)` —
   reached only via `bake.ts --force`, wired only to toolchain-image.yml's manual
   `force_republish` dispatch input — skips the already-published guard and regenerates in place.
   The automated push-to-main path never sets it, so :v1 stays immutable in production. This is a
   clean regenerate: the image retag, e2b `template create`, and the daytona list-sweep all
   overwrite by name.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardens CI by failing bench-smoke when the dispatched provider produces no metrics and by enforcing required providers during `toolchain-image` promote. Adds a manual, dev-only force-republish and clearly reports when a forced daytona republish deletes but can’t recreate its snapshot; smoke now defaults to the `memory` suite. (ENG-145)

- **New Features**
  - `bench-suite`: add `--require <ids>` and `REQUIRE_PROVIDERS`; exit non-zero if required providers didn’t reach validated. Supports both `--require <ids>` and `--require=<ids>`.
  - `bench-smoke`: default suite set to `memory` (STREAM); sets `REQUIRE_PROVIDERS` to the dispatched provider.
  - `toolchain-image`: manual `force_republish` input wires to `bake.ts --force` and `promoteAll(log, true)`; promote runs with `--require e2b,daytona,modal`. Automated pushes never set `force_republish`. Forced republish now reports when a daytona snapshot was deleted and not recreated.

- **Refactors**
  - Discovery: bins can declare value-taking flags; supports `--flag v` and `--flag=v`. Tests added.
  - Daytona bake: `deleteExistingSnapshots` returns a count; `bakeDaytonaSnapshot` surfaces destructive failure; pure `snapshotDestroyedMessage()` added and tested.
  - `bench-suite`: consumes the `--require` operand and passes sliced argv to `requiredProviders`.

<sup>Written for commit e1614c1d872a87b9de6319cf8251fe2b69b892bb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/starslingdev/sandbox-benchmarks/pull/113?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added required-provider validation for benchmark runs, with clear failure details when providers are unavailable or unvalidated.
  * Added manual force-republish support for regenerating existing published versions.
  * Improved CLI help and flag handling for provider requirements.

* **Bug Fixes**
  * Improved snapshot bake failures with clearer recovery guidance when existing snapshots are removed.
  * Enhanced promotion error messages and rerun instructions.
  * Added validation for value-based command-line flags.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->