### PR TITLE
feat(schema): seeded bootstrap, Mann-Whitney U and Kolmogorov-Smirnov (ENG-146)

### DIFF
--- a/packages/schema/src/analysis.test.ts
+++ b/packages/schema/src/analysis.test.ts
@@ -1,5 +1,17 @@
 import { describe, expect, it } from "bun:test";
-import { aggregate, percentileOf } from "./index.ts";
+import {
+	aggregate,
+	bootstrapMedianInterval,
+	kolmogorovSmirnov,
+	mannWhitneyU,
+	percentileOf,
+	seededRng,
+} from "./index.ts";
+
+// Real Samples from a live `memory` smoke run: modal's STREAM Copy trials (35% deviation, a noisy
+// gVisor host) against daytona's (0.14% deviation). The pair the whole inference layer exists for.
+const MODAL_COPY = [10127, 34120, 9719, 59952, 29815];
+const DAYTONA_COPY = [66500, 66510, 66495, 66505, 66502];
 
 describe("aggregate", () => {
 	it("summarises a multi-sample distribution (R-7 percentiles, n-1 stdev)", () => {
@@ -76,5 +88,209 @@ describe("percentileOf", () => {
 		expect(() => percentileOf([1, 2, 3], -0.1)).toThrow(/\[0, 1\]/);
 		expect(() => percentileOf([1, 2, 3], 1.5)).toThrow(/\[0, 1\]/);
 		expect(() => percentileOf([1, 2, 3], Number.NaN)).toThrow(/\[0, 1\]/);
+	});
+});
+
+describe("seededRng", () => {
+	it("is deterministic per seed, so a committed leaderboard never churns", () => {
+		const a = seededRng("run-1:stream_type_copy:modal");
+		const b = seededRng("run-1:stream_type_copy:modal");
+		const first = Array.from({ length: 5 }, () => a());
+		const second = Array.from({ length: 5 }, () => b());
+		expect(first).toEqual(second);
+		expect(first.every((v) => v >= 0 && v < 1)).toBe(true);
+	});
+
+	it("decorrelates different seeds", () => {
+		const a = seededRng("modal");
+		const b = seededRng("daytona");
+		expect(a()).not.toBe(b());
+	});
+});
+
+describe("bootstrapMedianInterval", () => {
+	it("brackets the median, and is wide for noisy Samples / tight for stable ones", () => {
+		const noisy = bootstrapMedianInterval(MODAL_COPY, { seed: "s" });
+		const stable = bootstrapMedianInterval(DAYTONA_COPY, { seed: "s" });
+
+		expect(noisy.median).toBe(29815);
+		expect(noisy.lo).toBeLessThanOrEqual(noisy.median);
+		expect(noisy.hi).toBeGreaterThanOrEqual(noisy.median);
+		expect(stable.lo).toBeLessThanOrEqual(stable.median);
+		expect(stable.hi).toBeGreaterThanOrEqual(stable.median);
+
+		// The whole point: the interval must expose modal's instability, not hide it behind a median.
+		expect(noisy.hi - noisy.lo).toBeGreaterThan(stable.hi - stable.lo);
+	});
+
+	it("is reproducible for a given seed, so the committed leaderboard is byte-stable", () => {
+		// Determinism is the property the committed artifact needs. Seed-SENSITIVITY is deliberately not
+		// asserted: with 5 Samples the bootstrap median can only take 5 distinct values, so two seeds
+		// landing on identical bounds is correct behaviour, not a collision.
+		expect(bootstrapMedianInterval(MODAL_COPY, { seed: "run-1" })).toEqual(
+			bootstrapMedianInterval(MODAL_COPY, { seed: "run-1" }),
+		);
+	});
+
+	it("degenerates to a point interval for a single Sample rather than inventing a bound", () => {
+		const one = bootstrapMedianInterval([42]);
+		expect(one).toEqual({ median: 42, lo: 42, hi: 42, level: 0.95, resamples: 0 });
+	});
+
+	it("collapses to the value when every Sample is identical", () => {
+		const flat = bootstrapMedianInterval([7, 7, 7, 7], { seed: "s" });
+		expect([flat.lo, flat.median, flat.hi]).toEqual([7, 7, 7]);
+	});
+
+	it("widens the interval as the coverage level rises", () => {
+		const narrow = bootstrapMedianInterval(MODAL_COPY, { seed: "s", level: 0.5 });
+		const wide = bootstrapMedianInterval(MODAL_COPY, { seed: "s", level: 0.99 });
+		expect(wide.hi - wide.lo).toBeGreaterThanOrEqual(narrow.hi - narrow.lo);
+	});
+
+	it("rejects an empty set, a non-finite Sample, and a level outside (0, 1)", () => {
+		expect(() => bootstrapMedianInterval([])).toThrow(/at least one sample/);
+		expect(() => bootstrapMedianInterval([1, Number.NaN])).toThrow(/finite/);
+		expect(() => bootstrapMedianInterval([1, 2], { level: 0 })).toThrow(/level/);
+		expect(() => bootstrapMedianInterval([1, 2], { level: 1 })).toThrow(/level/);
+	});
+
+	it("rejects a resample count that would yield NaN bounds instead of an error", () => {
+		// `0`/`NaN` built an empty Float64Array, skipped the loop, and returned lo/hi = NaN — which
+		// serialize into the committed leaderboard as `null` rather than failing. `-1` threw a bare
+		// RangeError from the typed array, naming neither the caller nor the value.
+		expect(() => bootstrapMedianInterval([1, 2], { resamples: 0 })).toThrow(/positive integer/);
+		expect(() => bootstrapMedianInterval([1, 2], { resamples: Number.NaN })).toThrow(
+			/positive integer/,
+		);
+		expect(() => bootstrapMedianInterval([1, 2], { resamples: -5 })).toThrow(/positive integer/);
+		expect(() => bootstrapMedianInterval([1, 2], { resamples: 1.5 })).toThrow(/positive integer/);
+	});
+
+	it("validates options even at n = 1, where the early return used to skip the check", () => {
+		// The n=1 point-interval path returned before the resamples guard, so a misconfigured call passed
+		// silently — while `level`, validated earlier, threw. Options are now checked regardless of how
+		// many Samples the call happens to carry.
+		expect(() => bootstrapMedianInterval([42], { resamples: 0 })).toThrow(/positive integer/);
+		expect(() => bootstrapMedianInterval([42], { resamples: -1 })).toThrow(/positive integer/);
+		expect(() => bootstrapMedianInterval([42], { level: 0 })).toThrow(/level/);
+		// …and a well-formed n=1 call still degenerates to a point interval.
+		expect(bootstrapMedianInterval([42])).toEqual({
+			median: 42,
+			lo: 42,
+			hi: 42,
+			level: 0.95,
+			resamples: 0,
+		});
+	});
+});
+
+describe("mannWhitneyU", () => {
+	// Values cross-checked against an independent implementation of the same normal approximation
+	// (tie- and continuity-corrected) and against exact enumeration of the permutation null.
+	it("separates disjoint samples (exact p = 0.0079; the normal approximation is conservative)", () => {
+		const r = mannWhitneyU([1, 2, 3, 4, 5], [6, 7, 8, 9, 10]);
+		expect(r.statistic).toBe(0);
+		expect(r.pValue).toBeCloseTo(0.012186, 5);
+		// Conservative: the approximation never claims MORE significance than exact enumeration.
+		expect(r.pValue).toBeGreaterThan(0.007937);
+		expect(r.pValue).toBeLessThan(0.05);
+	});
+
+	it("finds no evidence of difference between identical samples", () => {
+		expect(mannWhitneyU([5, 5, 5, 5, 5], [5, 5, 5, 5, 5]).pValue).toBe(1);
+	});
+
+	it("applies the tie correction", () => {
+		const r = mannWhitneyU([1, 2, 2, 3, 3], [2, 3, 3, 4, 5]);
+		expect(r.statistic).toBe(5);
+		expect(r.pValue).toBeCloseTo(0.126379, 5);
+	});
+
+	it("is symmetric in its arguments (U is the min of the two rank sums)", () => {
+		const a = mannWhitneyU(MODAL_COPY, DAYTONA_COPY);
+		const b = mannWhitneyU(DAYTONA_COPY, MODAL_COPY);
+		expect(a.statistic).toBe(b.statistic);
+		expect(a.pValue).toBeCloseTo(b.pValue, 12);
+	});
+
+	it("separates the real modal/daytona STREAM Copy distributions", () => {
+		expect(mannWhitneyU(MODAL_COPY, DAYTONA_COPY).pValue).toBeLessThan(0.05);
+	});
+
+	it("cannot separate overlapping noise (the false-ranking case it exists to prevent)", () => {
+		expect(mannWhitneyU([10, 12, 11, 13, 9], [11, 12, 10, 14, 13]).pValue).toBeGreaterThan(0.05);
+	});
+
+	it("requires a non-empty sample on both sides", () => {
+		expect(() => mannWhitneyU([], [1])).toThrow(/non-empty/);
+		expect(() => mannWhitneyU([1], [])).toThrow(/non-empty/);
+	});
+
+	it("rejects a non-finite sample rather than returning a plausible, meaningless p-value", () => {
+		// NaN has no order, so it corrupts the sort-based midranks silently: before this guard,
+		// mannWhitneyU([NaN, 1, 2], [3, 4, 5]) happily returned p ≈ 0.081.
+		expect(() => mannWhitneyU([Number.NaN, 1], [2, 3])).toThrow(/finite samples/);
+		expect(() => mannWhitneyU([1, 2], [Number.POSITIVE_INFINITY, 3])).toThrow(/finite samples/);
+	});
+});
+
+describe("kolmogorovSmirnov", () => {
+	it("reports D = 1 and a significant p for disjoint samples", () => {
+		const r = kolmogorovSmirnov([1, 2, 3, 4, 5], [6, 7, 8, 9, 10]);
+		expect(r.statistic).toBe(1);
+		expect(r.pValue).toBeCloseTo(0.003781, 5);
+	});
+
+	it("returns p = 1 for identical samples (D = 0)", () => {
+		// Regression: the naive fixed-term series alternates 1-1+1-1..., truncating to ~0, which would
+		// report two IDENTICAL providers as certainly different. The convergence guard returns the limit.
+		const r = kolmogorovSmirnov([5, 5, 5, 5, 5], [5, 5, 5, 5, 5]);
+		expect(r.statistic).toBe(0);
+		expect(r.pValue).toBe(1);
+	});
+
+	it("handles ties without reporting a spurious step", () => {
+		const r = kolmogorovSmirnov([1, 2, 2, 3, 3], [2, 3, 3, 4, 5]);
+		expect(r.statistic).toBeCloseTo(0.4, 10);
+		expect(r.pValue).toBeCloseTo(0.697405, 5);
+	});
+
+	it("is symmetric in its arguments", () => {
+		const a = kolmogorovSmirnov(MODAL_COPY, DAYTONA_COPY);
+		const b = kolmogorovSmirnov(DAYTONA_COPY, MODAL_COPY);
+		expect(a.statistic).toBeCloseTo(b.statistic, 12);
+		expect(a.pValue).toBeCloseTo(b.pValue, 12);
+	});
+
+	it("catches a shape difference that a median comparison would miss", () => {
+		// IDENTICAL medians (50), wildly different distributions: one stable, one bimodal — the signature
+		// of a provider alternating between fast and stalled passes. Mann-Whitney tests central tendency
+		// and sees no shift; KS compares the whole ECDF and separates them decisively. This is precisely
+		// why both are reported: a leaderboard that only asked "is the median different?" would call
+		// these two providers equivalent.
+		const stable = [...Array(10).fill(50), 49, 49, 49, 49, 49, 51, 51, 51, 51, 51];
+		const bimodal = [...Array(10).fill(1), ...Array(10).fill(99)];
+		expect(percentileOf(stable, 0.5)).toBe(50);
+		expect(percentileOf(bimodal, 0.5)).toBe(50);
+
+		expect(mannWhitneyU(stable, bimodal).pValue).toBeGreaterThan(0.05);
+
+		const ks = kolmogorovSmirnov(stable, bimodal);
+		expect(ks.statistic).toBeCloseTo(0.5, 10);
+		expect(ks.pValue).toBeLessThan(0.05);
+	});
+
+	it("requires a non-empty sample on both sides", () => {
+		expect(() => kolmogorovSmirnov([], [1])).toThrow(/non-empty/);
+		expect(() => kolmogorovSmirnov([1], [])).toThrow(/non-empty/);
+	});
+
+	it("rejects a non-finite sample instead of hanging the ECDF sweep forever", () => {
+		// The two-pointer sweep advances on `x <= y` / `y <= x`; against NaN both are false, so neither
+		// index moves and the loop never terminates. This test HANGS without the guard — it is the
+		// reason the guard exists, not a style check. (Verified: the pre-guard call had to be killed.)
+		expect(() => kolmogorovSmirnov([Number.NaN, 1], [1, 2])).toThrow(/finite samples/);
+		expect(() => kolmogorovSmirnov([1, 2], [Number.NaN])).toThrow(/finite samples/);
 	});
 });

--- a/packages/schema/src/analysis.ts
+++ b/packages/schema/src/analysis.ts
@@ -104,3 +104,310 @@ export function aggregate(samples: number[]): Aggregates {
 		n,
 	};
 }
+
+// ---------------------------------------------------------------------------------------------
+// Inference. A provider's Samples are repeated trials inside ONE sandbox, so the spread across them
+// is environmental noise (neighbours, host contention, gVisor), not measurement error that shrinks
+// with more trials. Reporting a bare p50 therefore invites a false ranking: a provider whose trials
+// span 9.7k–65k MB/s can out-rank a provider pinned at 66.5k ±0.14% on a lucky median. The tools
+// below quantify that — an interval around the median, and a test for whether two providers'
+// distributions differ at all.
+// ---------------------------------------------------------------------------------------------
+
+/** Bootstrap resamples per interval. 10k puts the Monte-Carlo error on a 95% bound well under the
+ *  precision the leaderboard prints (4 significant digits). */
+const DEFAULT_RESAMPLES = 10_000;
+/** Two-sided significance level for "are these two providers actually different?". */
+export const DEFAULT_ALPHA = 0.05;
+
+/**
+ * Reject an empty or non-finite sample set at the boundary, naming the caller and the bad value.
+ *
+ * Every function below consumes Samples by ORDER (sorting, ranking, ECDF sweeps), and `NaN` has no
+ * order: every comparison against it is `false`. That is not a cosmetic problem. In
+ * {@link kolmogorovSmirnov}'s two-pointer sweep neither index advances past a `NaN`, so the loop
+ * never terminates; in {@link mannWhitneyU} it silently corrupts the midranks and yields a plausible
+ * but meaningless p-value. Fail fast instead, exactly as `aggregate`/`percentileOf` already do.
+ */
+function assertFiniteSamples(fn: string, samples: readonly number[]): void {
+	if (samples.length === 0) {
+		throw new Error(`${fn}() requires at least one sample`);
+	}
+	for (const sample of samples) {
+		if (!Number.isFinite(sample)) {
+			throw new Error(`${fn}() requires finite samples; got ${sample}`);
+		}
+	}
+}
+
+/**
+ * A deterministic PRNG (mulberry32) seeded by hashing `seed`. The leaderboard is a COMMITTED
+ * artifact, so a `Math.random()`-driven bootstrap would rewrite every confidence bound on each
+ * regeneration and make the diff meaningless. Seeding from stable Run/Metric/provider identity keeps
+ * a given Run's leaderboard byte-identical across machines and reruns.
+ */
+export function seededRng(seed: string): () => number {
+	// An FNV-1a *variant*: it mixes UTF-16 code units, not UTF-8 bytes, because `charCodeAt` yields a
+	// 16-bit unit. For the ASCII seeds this is called with (`<runId>:<metricId>:<providerId>`) that is
+	// identical to textbook FNV-1a; above U+007F it diverges from the reference algorithm. We keep it
+	// rather than encoding to bytes first: nothing depends on interoperating with another FNV-1a
+	// implementation, only on being a stable, well-mixed 32-bit seed — and changing the hash would
+	// silently rewrite every confidence bound in the committed leaderboard.
+	let h = 2166136261;
+	for (let i = 0; i < seed.length; i++) {
+		h ^= seed.charCodeAt(i);
+		h = Math.imul(h, 16777619);
+	}
+	let state = h >>> 0;
+	return () => {
+		state = (state + 0x6d2b79f5) >>> 0;
+		let t = state;
+		t = Math.imul(t ^ (t >>> 15), t | 1);
+		t ^= t + Math.imul(t ^ (t >>> 7), t | 61);
+		return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+	};
+}
+
+/** A bootstrapped interval around a Metric's median. */
+export interface MedianInterval {
+	/** The observed median (identical to `Aggregates.p50`). */
+	median: number;
+	/** Lower/upper bound of the percentile-bootstrap interval at {@link level}. */
+	lo: number;
+	hi: number;
+	/** Coverage, e.g. 0.95. */
+	level: number;
+	/** Resamples drawn. 0 when n === 1 (no interval is estimable; lo === hi === median). */
+	resamples: number;
+}
+
+/**
+ * Percentile bootstrap of the median: draw `resamples` resamples of size n with replacement, take each
+ * one's median, and report the empirical [α/2, 1−α/2] quantiles of that distribution.
+ *
+ * The median — not the mean — because a single stalled pass (STREAM under a noisy neighbour) drags a
+ * mean far more than it moves a median, and we want the provider's typical throughput, not its
+ * average-including-the-stall. The bootstrap — not a normal-theory `±1.96·stdev/√n` — because these
+ * Samples are neither normal nor independent of the host's scheduling, and a closed-form interval on
+ * the median would assume a symmetry the data plainly lacks (modal's Copy: 9.7k…65k MB/s).
+ *
+ * Note the interval narrows as PTS re-runs a noisy test (n grows), which is honest about the median's
+ * precision but says nothing about the underlying instability — read it alongside `Aggregates.stdev`.
+ */
+export function bootstrapMedianInterval(
+	samples: readonly number[],
+	options: { resamples?: number; level?: number; seed?: string } = {},
+): MedianInterval {
+	assertFiniteSamples("bootstrapMedianInterval", samples);
+	const level = options.level ?? 0.95;
+	if (!(level > 0 && level < 1)) {
+		throw new Error(`bootstrapMedianInterval() requires level in (0, 1); got ${level}`);
+	}
+	// Validate EVERY option before the n=1 early return, so a misconfigured call is rejected regardless
+	// of how many Samples it happens to carry. `0`/`NaN` would otherwise build an empty Float64Array,
+	// skip the resampling loop, and hand back NaN bounds — which serialize into the committed leaderboard
+	// as `null` rather than failing; a negative count throws a bare RangeError from the typed array,
+	// naming neither the caller nor the offending value. (Guarding after the early return would let
+	// `bootstrapMedianInterval([42], { resamples: -1 })` pass silently while `{ level: 0 }` threw.)
+	const resamples = options.resamples ?? DEFAULT_RESAMPLES;
+	if (!Number.isInteger(resamples) || resamples < 1) {
+		throw new Error(
+			`bootstrapMedianInterval() requires resamples to be a positive integer; got ${resamples}`,
+		);
+	}
+
+	const median = percentileOf(samples, 0.5);
+	// A single Sample carries no information about its own spread — degenerate to a point interval
+	// rather than fabricating a bound by resampling the one value n times (which would always give it).
+	// Reached only once the options above are known good.
+	if (samples.length === 1) return { median, lo: median, hi: median, level, resamples: 0 };
+
+	const rng = seededRng(options.seed ?? "sandbox-benchmarks");
+	const n = samples.length;
+	const medians = new Float64Array(resamples);
+	const draw = new Array<number>(n);
+	for (let b = 0; b < resamples; b++) {
+		for (let i = 0; i < n; i++) draw[i] = samples[Math.floor(rng() * n)] as number;
+		draw.sort((x, y) => x - y);
+		medians[b] = percentile(draw, 0.5);
+	}
+	const sorted = Array.from(medians).sort((a, b) => a - b);
+	const tail = (1 - level) / 2;
+	return {
+		median,
+		lo: percentile(sorted, tail),
+		hi: percentile(sorted, 1 - tail),
+		level,
+		resamples,
+	};
+}
+
+/** Standard normal CDF, via a rational approximation to erfc (Numerical Recipes `erfcc`,
+ *  |ε| < 1.2e-7 — far finer than any p-value we act on). */
+function normalCdf(z: number): number {
+	const x = Math.abs(z) / Math.SQRT2;
+	const t = 1 / (1 + 0.5 * x);
+	const tau =
+		t *
+		Math.exp(
+			-x * x -
+				1.26551223 +
+				t *
+					(1.00002368 +
+						t *
+							(0.37409196 +
+								t *
+									(0.09678418 +
+										t *
+											(-0.18628806 +
+												t *
+													(0.27886807 +
+														t *
+															(-1.13520398 +
+																t * (1.48851587 + t * (-0.82215223 + t * 0.17087277)))))))),
+		);
+	const erfc = z >= 0 ? tau : 2 - tau;
+	return 1 - erfc / 2;
+}
+
+/** Midranks of the pooled samples (ties share their average rank), plus Σ(t³−t) over tie groups. */
+function midranks(pooled: readonly number[]): { ranks: number[]; tieCorrection: number } {
+	const order = pooled.map((value, index) => ({ value, index })).sort((a, b) => a.value - b.value);
+	const ranks = new Array<number>(pooled.length);
+	let tieCorrection = 0;
+	for (let i = 0; i < order.length; ) {
+		let j = i;
+		while (j + 1 < order.length && order[j + 1]?.value === order[i]?.value) j++;
+		// Ranks are 1-based; a tie group spanning [i, j] shares their mean rank.
+		const mean = (i + j + 2) / 2;
+		const t = j - i + 1;
+		tieCorrection += t ** 3 - t;
+		for (let k = i; k <= j; k++) ranks[(order[k] as { index: number }).index] = mean;
+		i = j + 1;
+	}
+	return { ranks, tieCorrection };
+}
+
+/** The outcome of a two-sample test on full distributions. */
+export interface DistributionTest {
+	/** The test statistic (U for Mann-Whitney, D for Kolmogorov-Smirnov). */
+	statistic: number;
+	/** Two-sided p-value: P(a difference this extreme | the two samples came from one distribution). */
+	pValue: number;
+	nA: number;
+	nB: number;
+}
+
+/**
+ * Mann-Whitney U (two-sided), normal approximation with tie and continuity corrections.
+ *
+ * The question it answers is exactly the one a leaderboard needs: are these two providers' Samples
+ * drawn from the same distribution, or does one genuinely tend to be faster? It's rank-based, so it
+ * assumes neither normality nor equal variance — both of which these Samples violate — and a single
+ * catastrophic pass moves a rank by one position instead of dragging a mean.
+ *
+ * The normal approximation is used at every n (exact enumeration is not implemented). At the n≈5 this
+ * suite produces, the smallest attainable two-sided p is ~0.008, so a genuine difference between two
+ * five-trial providers can be detected, but only a large one — treat a non-significant result at small
+ * n as "not enough evidence", never as "the providers are equal".
+ */
+export function mannWhitneyU(a: readonly number[], b: readonly number[]): DistributionTest {
+	if (a.length === 0 || b.length === 0) {
+		throw new Error("mannWhitneyU() requires a non-empty sample on both sides");
+	}
+	// A NaN silently corrupts the sort-based midranks and returns a plausible p-value.
+	assertFiniteSamples("mannWhitneyU", a);
+	assertFiniteSamples("mannWhitneyU", b);
+	const nA = a.length;
+	const nB = b.length;
+	const { ranks, tieCorrection } = midranks([...a, ...b]);
+	let rankSumA = 0;
+	for (let i = 0; i < nA; i++) rankSumA += ranks[i] as number;
+
+	const uA = rankSumA - (nA * (nA + 1)) / 2;
+	const uB = nA * nB - uA;
+	const statistic = Math.min(uA, uB);
+
+	const N = nA + nB;
+	const mu = (nA * nB) / 2;
+	// Tie-corrected variance; collapses to nA*nB*(N+1)/12 when there are no ties.
+	const variance = ((nA * nB) / 12) * (N + 1 - tieCorrection / (N * (N - 1)));
+	// Every pooled value identical → no variance, no evidence of any difference.
+	if (variance <= 0) return { statistic, pValue: 1, nA, nB };
+
+	// Continuity correction: |U − μ| is discrete, so shave half a step before the normal tail.
+	const z = Math.max(0, Math.abs(statistic - mu) - 0.5) / Math.sqrt(variance);
+	return { statistic, pValue: Math.min(1, 2 * (1 - normalCdf(z))), nA, nB };
+}
+
+/**
+ * Two-sample Kolmogorov-Smirnov (two-sided), asymptotic p-value.
+ *
+ * Complements Mann-Whitney: where U tests for a shift in central tendency, D is the largest gap
+ * between the two empirical CDFs, so it also catches providers whose medians coincide but whose
+ * *shapes* differ — a stable provider vs a bimodal one that alternates between fast and stalled
+ * passes. That bimodality is precisely what environmental noise looks like.
+ *
+ * The tail is the asymptotic (Numerical Recipes) approximation at every n; exact enumeration is not
+ * implemented. At the n≈5 this suite produces it is anti-conservative — e.g. `[1,2,3]` vs `[4,5,6]`
+ * returns p≈0.033 where the exact two-sided p is 2/C(6,3)=0.1 — so, as with {@link mannWhitneyU},
+ * treat a small-n result as directional evidence and never read a sub-α p at tiny n as hard proof.
+ */
+export function kolmogorovSmirnov(a: readonly number[], b: readonly number[]): DistributionTest {
+	if (a.length === 0 || b.length === 0) {
+		throw new Error("kolmogorovSmirnov() requires a non-empty sample on both sides");
+	}
+	// Critical: a NaN stalls the ECDF sweep below forever — `x <= y` and `y <= x` are both false, so
+	// neither index advances. Reject it here rather than hanging the leaderboard build.
+	assertFiniteSamples("kolmogorovSmirnov", a);
+	assertFiniteSamples("kolmogorovSmirnov", b);
+	const nA = a.length;
+	const nB = b.length;
+	const sortedA = [...a].sort((x, y) => x - y);
+	const sortedB = [...b].sort((x, y) => x - y);
+
+	// Sweep both ECDFs together, stepping whichever is behind; D is the largest gap seen.
+	let i = 0;
+	let j = 0;
+	let statistic = 0;
+	while (i < nA && j < nB) {
+		const x = sortedA[i] as number;
+		const y = sortedB[j] as number;
+		// Advance past every copy of the smaller value (both, when equal) before measuring the gap, so
+		// ties can't report a spurious step.
+		if (x <= y) while (i < nA && sortedA[i] === x) i++;
+		if (y <= x) while (j < nB && sortedB[j] === y) j++;
+		statistic = Math.max(statistic, Math.abs(i / nA - j / nB));
+	}
+
+	const en = Math.sqrt((nA * nB) / (nA + nB));
+	return { statistic, pValue: kolmogorovQ((en + 0.12 + 0.11 / en) * statistic), nA, nB };
+}
+
+/**
+ * Q_KS(λ) = 2 Σ_{j≥1} (−1)^{j−1} e^{−2j²λ²}, the asymptotic KS tail (Numerical Recipes `probks`).
+ *
+ * Summing a fixed number of terms is WRONG at small λ: the series alternates 1−1+1−1…, so a truncated
+ * sum collapses toward 0 and reports p≈0 — i.e. "certainly different" — for two IDENTICAL samples
+ * (λ = 0). Iterate until the terms actually converge, and treat non-convergence (only λ→0 does that)
+ * as p = 1, which is the limit.
+ */
+function kolmogorovQ(lambda: number): number {
+	const EPS1 = 1e-6;
+	const EPS2 = 1e-16;
+	const a2 = -2 * lambda * lambda;
+	let fac = 2;
+	let sum = 0;
+	let termPrev = 0;
+	for (let j = 1; j <= 100; j++) {
+		const term = fac * Math.exp(a2 * j * j);
+		sum += term;
+		if (Math.abs(term) <= EPS1 * termPrev || Math.abs(term) <= EPS2 * sum) {
+			return Math.max(0, Math.min(1, sum));
+		}
+		fac = -fac;
+		termPrev = Math.abs(term);
+	}
+	// Failed to converge — only happens as λ → 0, where the true value is 1 (no evidence of difference).
+	return 1;
+}


### PR DESCRIPTION
**ENG-146 — rank the leaderboard inferentially, not on a bare median.**
Split into a 6-PR stack (merge bottom-up, each branch independently green on its own):

1. #116 — ci: dispatch `bench-matrix` per-provider + fix two runner-cache/publish bugs
2. **#114 — schema:** seeded bootstrap, Mann-Whitney U, Kolmogorov-Smirnov (pure-additive toolkit) ← _you are here_
3. #115 — results: share a rank on statistical ties; create the `LEADERBOARD.md` drift gate
4. #117 — repo-checks: render the leaderboard from the committed dataset, not the raw tree
5. #118 — results: render the `p (KS)` column; stop the gate silencing its own guard
6. #119 — dataset: publish run `29061549181` + the regenerated leaderboard

↑ **This PR is #114 (2/6)**, based on #116. Nothing here consumes the toolkit yet — the wiring lands in #115.

---

## Why the leaderboard needs statistics at all

A provider's `Samples` are repeated trials **inside one sandbox**. Their spread is therefore *environmental* — noisy neighbours, host contention, virtualization overhead — not measurement error that shrinks as we collect more trials. Two consequences follow, and both are load-bearing:

- The spread does **not** vanish with more trials, so a bare [median](https://en.wikipedia.org/wiki/Median) is a point estimate carrying real, unreported uncertainty.
- Ranking on that bare median lets a lucky draw buy a position. In a live run modal's STREAM `Copy` spanned **9.7k–65k MB/s** while daytona sat at **66.5k ±0.14%**. Sorting on the median alone can put either one first.

This PR adds the tools to say *how confident* a ranking is. Nothing consumes them yet — the wiring lands in #115 — so each is unit-tested directly.

## What's added, and why each choice

### `bootstrapMedianInterval` — a [confidence interval](https://en.wikipedia.org/wiki/Confidence_interval) around the median

A [percentile bootstrap](https://en.wikipedia.org/wiki/Bootstrapping_(statistics)#Methods_for_bootstrap_confidence_intervals): resample the trials with replacement 10,000 times, take each resample's median, and report the empirical 2.5th/97.5th percentiles of that distribution.

- **The median, not the mean** — it is [robust](https://en.wikipedia.org/wiki/Robust_statistics): one stalled pass drags a mean far more than it moves a median, and we want the provider's *typical* throughput, not its average-including-the-stall.
- **The [bootstrap](https://en.wikipedia.org/wiki/Bootstrapping_(statistics)), not a normal-theory `±1.96·σ/√n`** — that closed form assumes a symmetry the data plainly lacks (see modal's 9.7k…65k range) and independence from the host's scheduler, which is exactly what these samples violate.
- At `n = 1` it degenerates to a point interval rather than fabricating a bound by resampling one value.

### `mannWhitneyU` — are two providers actually different?

The [Mann–Whitney U test](https://en.wikipedia.org/wiki/Mann%E2%80%93Whitney_U_test) (two-sided, normal approximation with tie and [continuity](https://en.wikipedia.org/wiki/Continuity_correction) corrections) asks precisely the leaderboard's question: do these two samples come from one distribution, or does one genuinely tend to be faster?

It is [non-parametric](https://en.wikipedia.org/wiki/Nonparametric_statistics) and rank-based, so it assumes neither normality nor equal variance — both violated here — and a single catastrophic pass moves a rank by one position instead of dragging a mean.

⚠️ At this suite's `n ≈ 5` the smallest attainable two-sided [p-value](https://en.wikipedia.org/wiki/P-value) is ≈ 0.008. A real difference is detectable, but only a large one. **A non-significant result means "not enough evidence", never "the providers are equal"** — the classic [type II error](https://en.wikipedia.org/wiki/Type_I_and_type_II_errors).

### `kolmogorovSmirnov` — do the *shapes* differ?

The [two-sample Kolmogorov–Smirnov test](https://en.wikipedia.org/wiki/Kolmogorov%E2%80%93Smirnov_test) reports the largest gap between the two [empirical CDFs](https://en.wikipedia.org/wiki/Empirical_distribution_function). Where U tests a shift in central tendency, D also catches a provider whose median coincides with another's but whose distribution is [bimodal](https://en.wikipedia.org/wiki/Multimodal_distribution) — alternating between fast and stalled passes. **That bimodality is exactly what environmental noise looks like**, so it is reported alongside U rather than driving the ranking.

`kolmogorovQ` sums the asymptotic tail series *to convergence*. The series alternates (`1 − 1 + 1 − 1 …`), so a fixed-term truncation collapses toward 0 at small λ and would report p ≈ 0 — "certainly different" — for two **identical** samples.

### `seededRng` — because the leaderboard is a committed artifact

`LEADERBOARD.md` is checked into the repo. A `Math.random()`-driven bootstrap would rewrite every confidence bound on each regeneration, making the diff meaningless and the artifact non-[reproducible](https://en.wikipedia.org/wiki/Reproducibility).

So the [PRNG](https://en.wikipedia.org/wiki/Pseudorandom_number_generator) (mulberry32) is seeded by hashing stable Run/Metric/provider identity with [FNV-1a](https://en.wikipedia.org/wiki/Fowler%E2%80%93Noll%E2%80%93Vo_hash_function). A given Run renders byte-identically on every machine and every rerun — which is also what makes #115's drift gate sound rather than flaky.

## Correctness

Two defects found in review, both verified against the code rather than taken on report:

| | Symptom | Cause |
|---|---|---|
| **P1** | `kolmogorovSmirnov([NaN, 1], [1, 2])` **never returns** (had to be `SIGKILL`ed) | the two-pointer ECDF sweep advances on `x <= y` / `y <= x`; both are `false` against `NaN`, so neither index moves |
| **P1** | `mannWhitneyU([NaN, 1, 2], [3, 4, 5])` returned a plausible `p ≈ 0.081` | `NaN` has no order, silently corrupting the sort-based midranks |

Both consume samples *by order*, and `NaN` has no order. Rather than adding a fourth copy of the guard, the one `aggregate`/`percentileOf`/`bootstrapMedianInterval` each already spelled out was extracted into `assertFiniteSamples`. `options.resamples` is guarded too: `0`/`NaN` previously produced `lo`/`hi` of `NaN`, which serialize into the committed leaderboard as `null` instead of failing.

The KS test added here **hangs without the fix** — a real regression guard, not a style check.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds seeded bootstrap and two nonparametric tests to quantify sample noise and avoid lucky median rankings. Preps leaderboard inference for ENG-146; pure additive utilities, not wired yet.

- **New Features**
  - `seededRng`: deterministic mulberry32 seeded by an FNV-1a (UTF-16) variant to keep the committed leaderboard stable.
  - `bootstrapMedianInterval`: percentile bootstrap of the median (10k resamples; supports `level`, `seed`; point interval at n=1).
  - `mannWhitneyU` and `kolmogorovSmirnov`: two-sample tests with tie/continuity corrections; KS tail converges and is anti-conservative at tiny n; return statistic and two-sided p-value.
  - `DEFAULT_ALPHA = 0.05`: exported default two-sided significance level for tests.

- **Bug Fixes**
  - Reject non-finite samples, empty inputs, and invalid `resamples`; options validated even at n=1.
  - Prevent KS hangs on `NaN` and MWU from returning misleading p-values; identical samples correctly yield p = 1 via a convergent KS series.

<sup>Written for commit cf186a040578dda10d52d3eb634e4fcd69c27ac0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/starslingdev/sandbox-benchmarks/pull/114?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added statistical inference utilities for comparing repeated measurements, including deterministic seeded bootstrapped median confidence intervals.
  * Added two-sample distribution tests (Mann–Whitney U and Kolmogorov–Smirnov) with configurable confidence level and default two-sided significance.
* **Bug Fixes**
  * Improved robustness by validating inputs and rejecting empty or non-finite samples to avoid incorrect results and potential hangs.
* **Tests**
  * Expanded coverage for seeded determinism, interval edge cases, tie/identical-sample handling, symmetry, and p-value/behavior expectations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

