### PR TITLE
feat(results): share a rank when providers are statistically indistinguishable (ENG-146)

### DIFF
--- a/LEADERBOARD.md
+++ b/LEADERBOARD.md
@@ -8,15 +8,33 @@ Each table ranks the providers on that dimension's headline metric. Generated fr
 
 Headline: **Node.js web tooling** (runs/s, higher is better)
 
-| Rank | Provider | Node.js web tooling (runs/s) |
-| ---: | --- | ---: |
-| 1 | Daytona | 22.77 |
+| Rank | Provider | Node.js web tooling (runs/s) | 95% CI | n | p vs. above |
+| ---: | --- | ---: | ---: | ---: | ---: |
+| 1 | Daytona | 22.77 | 22.66 – 23 | 3 | — |
 
 ## economics
 
 Headline: **Hourly cost** (USD/hr, lower is better)
 
-| Rank | Provider | Hourly cost (USD/hr) |
-| ---: | --- | ---: |
-| 1 | Daytona | 0.1494 |
+| Rank | Provider | Hourly cost (USD/hr) | 95% CI | n | p vs. above |
+| ---: | --- | ---: | ---: | ---: | ---: |
+| 1 | Daytona | 0.1494 | — | 1 | — |
+
+---
+
+**Reading this table.** The value is the median (p50) of the retained per-trial Samples, not the
+mean — a single stalled pass drags a mean far more than it moves a median. The 95% CI is a
+percentile bootstrap of that median (10,000 resamples, seeded from the Run id so the table is
+reproducible byte-for-byte), not a normal-theory interval: these Samples are neither normal nor
+independent of the host's scheduling.
+
+Rows are separated only when their full Sample distributions differ (Mann-Whitney U, two-sided, α = 0.05).
+**Providers sharing a rank are statistically indistinguishable on this Metric** — a faster median
+earned inside the noise is not a faster provider. Samples are repeated trials inside one sandbox,
+so their spread is environmental (neighbours, host contention, virtualization), and a wide CI or a
+large `n` (the harness re-runs a test that will not converge) is itself the signal that the
+provider's performance is unstable, not that the measurement is imprecise.
+
+At the small `n` this suite produces, a non-significant result means *not enough evidence to
+separate*, never *the providers are equal*.
 

--- a/bun.lock
+++ b/bun.lock
@@ -122,6 +122,7 @@
       "version": "0.0.0",
       "devDependencies": {
         "@repo/tsconfig": "workspace:*",
+        "@sandbox-benchmarks/results": "workspace:*",
         "@sandbox-benchmarks/schema": "workspace:*",
         "@types/bun": "catalog:",
         "arktype": "catalog:",

--- a/packages/results/src/lib/leaderboard.test.ts
+++ b/packages/results/src/lib/leaderboard.test.ts
@@ -73,8 +73,9 @@ describe("buildLeaderboard", () => {
 		expect(md).toMatch(/\| 1 \| Daytona \| 10 \|/);
 	});
 
-	it("breaks ties on equal headline values deterministically by providerId", () => {
-		// Input order is modal-then-daytona; equal values must reorder to alphabetical providerId.
+	it("orders equal headline values deterministically by providerId and shares their rank", () => {
+		// Input order is modal-then-daytona; equal values must reorder to alphabetical providerId AND
+		// share a rank — an exact tie is not a ranking win for whoever sorts first.
 		const board = buildLeaderboard(
 			run([
 				provider("modal", [metric("node_web_tooling_runs_per_s", [10])]),
@@ -83,11 +84,157 @@ describe("buildLeaderboard", () => {
 		);
 		const cpu = board.dimensions.find((d) => d.dimension === "cpu");
 		expect(cpu?.rows.map((r) => r.providerId)).toEqual(["daytona", "modal"]);
-		expect(cpu?.rows.map((r) => r.rank)).toEqual([1, 2]);
+		expect(cpu?.rows.map((r) => r.rank)).toEqual([1, 1]);
 	});
 
 	it("renders a placeholder when nothing is ranked", () => {
 		const md = renderLeaderboardMarkdown(buildLeaderboard(run([provider("daytona", [])])));
 		expect(md).toContain("No ranked dimensions yet");
+	});
+});
+
+describe("buildLeaderboard statistical ranking", () => {
+	// Real Samples from a live `memory` smoke run: modal's noisy gVisor STREAM Copy trials vs daytona's.
+	const MODAL_COPY = [10127, 34120, 9719, 59952, 29815];
+	const DAYTONA_COPY = [66500, 66510, 66495, 66505, 66502];
+	const HEADLINE = "node_web_tooling_runs_per_s";
+
+	it("attaches a bootstrapped interval that is wider for the noisier provider", () => {
+		const board = buildLeaderboard(
+			run([
+				provider("daytona", [metric(HEADLINE, DAYTONA_COPY)]),
+				provider("modal", [metric(HEADLINE, MODAL_COPY)]),
+			]),
+		);
+		const rows = board.dimensions.find((d) => d.dimension === "cpu")?.rows ?? [];
+		const daytona = rows.find((r) => r.providerId === "daytona");
+		const modal = rows.find((r) => r.providerId === "modal");
+
+		expect(daytona?.interval.level).toBe(0.95);
+		expect(daytona?.interval.resamples).toBeGreaterThan(0);
+		expect(daytona?.n).toBe(5);
+		// The interval must expose modal's instability rather than hide it behind a median.
+		const width = (r?: (typeof rows)[number]) => (r ? r.interval.hi - r.interval.lo : 0);
+		expect(width(modal)).toBeGreaterThan(width(daytona));
+	});
+
+	it("is deterministic: the same Run yields byte-identical markdown", () => {
+		const build = () =>
+			renderLeaderboardMarkdown(
+				buildLeaderboard(
+					run([
+						provider("daytona", [metric(HEADLINE, DAYTONA_COPY)]),
+						provider("modal", [metric(HEADLINE, MODAL_COPY)]),
+					]),
+				),
+			);
+		expect(build()).toBe(build());
+	});
+
+	it("separates providers whose distributions genuinely differ", () => {
+		const board = buildLeaderboard(
+			run([
+				provider("daytona", [metric(HEADLINE, DAYTONA_COPY)]),
+				provider("modal", [metric(HEADLINE, MODAL_COPY)]),
+			]),
+		);
+		const rows = board.dimensions.find((d) => d.dimension === "cpu")?.rows ?? [];
+		expect(rows.map((r) => [r.rank, r.providerId])).toEqual([
+			[1, "daytona"],
+			[2, "modal"],
+		]);
+		const modal = rows[1];
+		expect(modal?.separated).toBe(true);
+		expect(modal?.pVsPrevious?.mannWhitney).toBeLessThan(0.05);
+		expect(modal?.pVsPrevious?.ks).toBeLessThan(0.05);
+	});
+
+	it("SHARES a rank when the difference is environmental noise, not a faster provider", () => {
+		// Overlapping distributions: e2b's median edges daytona's, but the samples interleave. Ranking on
+		// p50 alone would crown e2b; the U test refuses to.
+		const board = buildLeaderboard(
+			run([
+				provider("daytona", [metric(HEADLINE, [10, 12, 11, 13, 9])]),
+				provider("e2b", [metric(HEADLINE, [11, 12, 10, 14, 13])]),
+			]),
+		);
+		const rows = board.dimensions.find((d) => d.dimension === "cpu")?.rows ?? [];
+		// e2b sorts first on the median, but cannot be separated → both hold rank 1.
+		expect(rows.map((r) => r.rank)).toEqual([1, 1]);
+		expect(rows[1]?.separated).toBe(false);
+		expect(rows[1]?.pVsPrevious?.mannWhitney).toBeGreaterThan(0.05);
+	});
+
+	it("leaves a single-Sample Metric untested and ranked on its exact value", () => {
+		// `usd_per_hour` is a published price, not a trial: one Sample, no distribution to test. Ranking
+		// must NOT collapse every provider into a tie just because n=1 can never reach significance.
+		const board = buildLeaderboard(
+			run([
+				provider("daytona", [metric(ECONOMICS_METRIC_IDS.usdPerHour, [0.2])]),
+				provider("modal", [metric(ECONOMICS_METRIC_IDS.usdPerHour, [0.1])]),
+			]),
+		);
+		const rows = board.dimensions.find((d) => d.dimension === "economics")?.rows ?? [];
+		expect(rows.map((r) => [r.rank, r.providerId])).toEqual([
+			[1, "modal"],
+			[2, "daytona"],
+		]);
+		expect(rows[1]?.separated).toBeNull();
+		expect(rows[1]?.pVsPrevious).toBeNull();
+		expect(rows[0]?.interval.resamples).toBe(0);
+	});
+
+	it("SHARES a rank between single-Sample Metrics with exactly equal values", () => {
+		// Two providers publishing the same price are a genuine tie: they must share a rank rather
+		// than being split by the providerId sort tie-break alone.
+		const board = buildLeaderboard(
+			run([
+				provider("daytona", [metric(ECONOMICS_METRIC_IDS.usdPerHour, [0.1])]),
+				provider("modal", [metric(ECONOMICS_METRIC_IDS.usdPerHour, [0.1])]),
+			]),
+		);
+		const rows = board.dimensions.find((d) => d.dimension === "economics")?.rows ?? [];
+		expect(rows.map((r) => r.rank)).toEqual([1, 1]);
+	});
+});
+
+describe("renderLeaderboardMarkdown statistics", () => {
+	const HEADLINE = "node_web_tooling_runs_per_s";
+
+	it("renders CI, n and the p-value, and marks a statistical tie", () => {
+		const md = renderLeaderboardMarkdown(
+			buildLeaderboard(
+				run([
+					provider("daytona", [metric(HEADLINE, [10, 12, 11, 13, 9])]),
+					provider("e2b", [metric(HEADLINE, [11, 12, 10, 14, 13])]),
+				]),
+			),
+		);
+		expect(md).toContain("95% CI");
+		expect(md).toContain("p vs. above");
+		expect(md).toContain("(tied)");
+		// The reader must be told what a shared rank means, not left to infer it.
+		expect(md).toContain("statistically indistinguishable");
+		expect(md).toContain("Mann-Whitney");
+	});
+
+	it("renders a point value with no interval for a single-Sample Metric", () => {
+		const md = renderLeaderboardMarkdown(
+			buildLeaderboard(run([provider("daytona", [metric(HEADLINE, [10])])])),
+		);
+		// n=1 → em-dash for both CI and p, never a fabricated bound.
+		expect(md).toMatch(/\| 1 \| Daytona \| 10 \| — \| 1 \| — \|/);
+	});
+
+	it("never prints a p-value as a misleading 0", () => {
+		const md = renderLeaderboardMarkdown(
+			buildLeaderboard(
+				run([
+					provider("daytona", [metric(HEADLINE, [1, 2, 3, 4, 5, 6, 7, 8])]),
+					provider("modal", [metric(HEADLINE, [90, 91, 92, 93, 94, 95, 96, 97])]),
+				]),
+			),
+		);
+		expect(md).toContain("<0.001");
 	});
 });

--- a/packages/results/src/lib/leaderboard.ts
+++ b/packages/results/src/lib/leaderboard.ts
@@ -7,9 +7,24 @@
  * that produced it, ranked by the Metric's Direction (HIB → highest first, LIB → lowest first). A
  * Dimension with no headline Metric, or no provider value, is omitted. The representative value is the
  * Samples' p50 (median) — robust to a single slow pass.
+ *
+ * Ranking is INFERENTIAL, not a bare sort. A provider's Samples are repeated trials inside one sandbox,
+ * so their spread is environmental noise, and ordering on the median alone would let a lucky draw buy a
+ * position: a live run had modal's STREAM Copy span 9.7k–65k MB/s against daytona's 66.5k ±0.14%. Each
+ * row therefore carries a bootstrapped interval around its median, and two rows share a rank unless
+ * their full distributions separate under Mann-Whitney U (with Kolmogorov-Smirnov reported alongside,
+ * since a bimodal provider can match another's median while behaving nothing like it).
  */
-import type { Dimension, MetricDef, Run } from "@sandbox-benchmarks/schema";
-import { DIMENSIONS, getProvider, METRIC_CATALOG } from "@sandbox-benchmarks/schema";
+import type { Dimension, MedianInterval, MetricDef, Run } from "@sandbox-benchmarks/schema";
+import {
+	bootstrapMedianInterval,
+	DEFAULT_ALPHA,
+	DIMENSIONS,
+	getProvider,
+	kolmogorovSmirnov,
+	METRIC_CATALOG,
+	mannWhitneyU,
+} from "@sandbox-benchmarks/schema";
 
 /** One provider's standing on a Dimension's headline Metric. */
 export interface LeaderboardRow {
@@ -17,8 +32,26 @@ export interface LeaderboardRow {
 	displayName: string;
 	/** Representative value (Samples' p50) of the headline Metric for this provider. */
 	value: number;
-	/** 1-based rank by the Metric's Direction; equal values share neither rank (deterministic tie-break). */
+	/**
+	 * 1-based rank by the Metric's Direction. Providers whose Sample distributions are NOT
+	 * distinguishable (Mann-Whitney U, two-sided, α = {@link DEFAULT_ALPHA}) share a rank: a faster
+	 * median earned inside the noise is not a faster provider.
+	 */
 	rank: number;
+	/** Bootstrapped interval around {@link value} — the honest precision of the median. */
+	interval: MedianInterval;
+	/** Retained Sample count and their spread, so a wide/unstable row is legible at a glance. */
+	n: number;
+	stdev: number;
+	/**
+	 * Two-sided p-values against the row immediately above (`null` for rank 1, which has no predecessor).
+	 * `mannWhitney` tests a shift in central tendency and drives the tie grouping; `ks` compares the full
+	 * empirical CDFs, catching a provider whose median matches but whose distribution is bimodal — the
+	 * signature of environmental noise rather than a real difference.
+	 */
+	pVsPrevious: { mannWhitney: number; ks: number } | null;
+	/** Whether this row is statistically separable from the one above it. `null` for rank 1. */
+	separated: boolean | null;
 }
 
 /** One Dimension's ranked comparison on its headline Metric. */
@@ -49,33 +82,75 @@ export function buildLeaderboard(run: Run): Leaderboard {
 		);
 		if (!metric) continue;
 
-		const rows: LeaderboardRow[] = run.providers.flatMap((provider) => {
+		// Carry each provider's raw Samples alongside its row: the ranking needs the full distributions,
+		// not just their medians, to tell a real difference from environmental noise.
+		const candidates = run.providers.flatMap((provider) => {
 			const result = provider.metrics.find((m) => m.metricId === metric.id);
 			if (!result) return [];
-			return [
-				{
-					providerId: provider.providerId,
-					displayName: getProvider(provider.providerId)?.displayName ?? provider.providerId,
-					value: result.aggregates.p50,
-					rank: 0, // assigned after sort
-				},
-			];
+			const row: LeaderboardRow = {
+				providerId: provider.providerId,
+				displayName: getProvider(provider.providerId)?.displayName ?? provider.providerId,
+				value: result.aggregates.p50,
+				rank: 0, // assigned after sort
+				// Seed from stable identity so a committed leaderboard is byte-identical on every
+				// regeneration — a Math.random() bootstrap would churn the diff on every run.
+				interval: bootstrapMedianInterval(result.samples, {
+					seed: `${run.runId}:${metric.id}:${provider.providerId}`,
+				}),
+				n: result.aggregates.n,
+				stdev: result.aggregates.stdev,
+				pVsPrevious: null,
+				separated: null,
+			};
+			return [{ samples: result.samples, row }];
 		});
-		if (rows.length === 0) continue;
+		if (candidates.length === 0) continue;
 
-		// Rank by Direction; tie-break on providerId so the output is deterministic.
-		rows.sort((a, b) =>
-			a.value !== b.value
+		// Order by Direction; tie-break on providerId so the output is deterministic.
+		candidates.sort((a, b) =>
+			a.row.value !== b.row.value
 				? metric.direction === "HIB"
-					? b.value - a.value
-					: a.value - b.value
-				: a.providerId.localeCompare(b.providerId),
+					? b.row.value - a.row.value
+					: a.row.value - b.row.value
+				: a.row.providerId.localeCompare(b.row.providerId),
 		);
-		rows.forEach((row, i) => {
-			row.rank = i + 1;
+
+		// Competition ranking with STATISTICAL ties. Walk the ordered rows and test each against the one
+		// above: when Mann-Whitney can't separate them, they share a rank rather than letting a median
+		// won inside the noise buy a position. `separated` carries the verdict; `ks` is reported beside
+		// it because two providers can share a median while differing in distribution shape.
+		//
+		// Only ADJACENT rows are tested, which is deliberate: a leaderboard is a linear order, and the
+		// pairwise "which providers are mutually indistinguishable" relation is not transitive (A~B and
+		// B~C does not give A~C). Testing the chain keeps the table honest about the one comparison it
+		// actually renders — each row against the row above it — instead of implying a grouping the
+		// tests don't support. It also keeps this to k−1 tests, so no multiplicity correction is owed.
+		candidates.forEach((candidate, i) => {
+			const previous = candidates[i - 1];
+			if (!previous) {
+				candidate.row.rank = 1;
+				return;
+			}
+			// A single Sample is not a distribution: there is nothing to test, and the value is typically
+			// exact rather than measured (a Metric like `usd_per_hour` is a published price, not a trial).
+			// Rank such rows on the value and mark them untested, rather than declaring every provider
+			// "indistinguishable" because a one-trial comparison can never reach significance. Exactly
+			// equal values are a genuine tie, though, and must share a rank — otherwise two providers
+			// with an identical published price would be split by the providerId sort tie-break alone.
+			if (previous.samples.length < 2 || candidate.samples.length < 2) {
+				candidate.row.rank = candidate.row.value === previous.row.value ? previous.row.rank : i + 1;
+				return;
+			}
+			const mw = mannWhitneyU(previous.samples, candidate.samples);
+			const ks = kolmogorovSmirnov(previous.samples, candidate.samples);
+			const separated = mw.pValue < DEFAULT_ALPHA;
+			candidate.row.pVsPrevious = { mannWhitney: mw.pValue, ks: ks.pValue };
+			candidate.row.separated = separated;
+			// Not separable → inherit the rank above. Separable → this row's ordinal position.
+			candidate.row.rank = separated ? i + 1 : previous.row.rank;
 		});
 
-		dimensions.push({ dimension, metric, rows });
+		dimensions.push({ dimension, metric, rows: candidates.map((c) => c.row) });
 	}
 
 	return { runId: run.runId, sha: run.sha, generatedAt: run.generatedAt, dimensions };
@@ -86,6 +161,12 @@ function formatValue(value: number): string {
 	if (Number.isInteger(value)) return String(value);
 	// toPrecision(4) then strip trailing zeros / a trailing dot (e.g. 0.2304, 12.35, 1234).
 	return Number.parseFloat(value.toPrecision(4)).toString();
+}
+
+/** Format a p-value for the table: tiny values as a bound, never as a misleading `0`. */
+function formatPValue(p: number): string {
+	if (p < 0.001) return "<0.001";
+	return p.toPrecision(2);
 }
 
 /** Render a {@link Leaderboard} as a Markdown document — the committed comparison surface. */
@@ -111,12 +192,47 @@ export function renderLeaderboardMarkdown(board: Leaderboard): string {
 			"",
 			`Headline: **${metric.label}** (${metric.unit}, ${better})`,
 			"",
-			`| Rank | Provider | ${metric.label} (${metric.unit}) |`,
-			"| ---: | --- | ---: |",
-			...rows.map((r) => `| ${r.rank} | ${r.displayName} | ${formatValue(r.value)} |`),
+			`| Rank | Provider | ${metric.label} (${metric.unit}) | 95% CI | n | p vs. above |`,
+			"| ---: | --- | ---: | ---: | ---: | ---: |",
+			...rows.map((r) => {
+				const ci =
+					r.interval.resamples === 0
+						? "—"
+						: `${formatValue(r.interval.lo)} – ${formatValue(r.interval.hi)}`;
+				// A tied rank is the interesting case: say so in the cell rather than leaving the reader
+				// to infer it from two rows sharing a number.
+				const p =
+					r.pVsPrevious === null
+						? "—"
+						: r.separated
+							? formatPValue(r.pVsPrevious.mannWhitney)
+							: `${formatPValue(r.pVsPrevious.mannWhitney)} (tied)`;
+				return `| ${r.rank} | ${r.displayName} | ${formatValue(r.value)} | ${ci} | ${r.n} | ${p} |`;
+			}),
 			"",
 		);
 	}
+
+	lines.push(
+		"---",
+		"",
+		"**Reading this table.** The value is the median (p50) of the retained per-trial Samples, not the",
+		"mean — a single stalled pass drags a mean far more than it moves a median. The 95% CI is a",
+		"percentile bootstrap of that median (10,000 resamples, seeded from the Run id so the table is",
+		"reproducible byte-for-byte), not a normal-theory interval: these Samples are neither normal nor",
+		"independent of the host's scheduling.",
+		"",
+		`Rows are separated only when their full Sample distributions differ (Mann-Whitney U, two-sided, α = ${DEFAULT_ALPHA}).`,
+		"**Providers sharing a rank are statistically indistinguishable on this Metric** — a faster median",
+		"earned inside the noise is not a faster provider. Samples are repeated trials inside one sandbox,",
+		"so their spread is environmental (neighbours, host contention, virtualization), and a wide CI or a",
+		"large `n` (the harness re-runs a test that will not converge) is itself the signal that the",
+		"provider's performance is unstable, not that the measurement is imprecise.",
+		"",
+		"At the small `n` this suite produces, a non-significant result means *not enough evidence to",
+		"separate*, never *the providers are equal*.",
+		"",
+	);
 
 	return `${lines.join("\n")}\n`;
 }

--- a/tooling/repo-checks/package.json
+++ b/tooling/repo-checks/package.json
@@ -9,6 +9,7 @@
   },
   "devDependencies": {
     "@repo/tsconfig": "workspace:*",
+    "@sandbox-benchmarks/results": "workspace:*",
     "@sandbox-benchmarks/schema": "workspace:*",
     "arktype": "catalog:",
     "typescript": "catalog:",

--- a/tooling/repo-checks/src/leaderboard-artifact-sync.test.ts
+++ b/tooling/repo-checks/src/leaderboard-artifact-sync.test.ts
@@ -1,0 +1,55 @@
+// Invariant: the committed LEADERBOARD.md is exactly what the current renderer produces from the Run
+// it names. The file is generated ("do not edit by hand") but nothing re-generated it in CI, so a
+// change to `renderLeaderboardMarkdown` or to the ranking silently left the published comparison
+// surface stale — showing readers an old table while the code computed a new one. This gate closes
+// that gap the same way workflow-registry-sync does: re-derive the truth and diff.
+//
+// This is only sound because the leaderboard is deterministic: the bootstrap is seeded from stable
+// Run/Metric/provider identity (see schema/analysis.ts `seededRng`), and `generatedAt` is read from the
+// Run document rather than the clock. A Math.random() bootstrap would make this gate flake on every run.
+import { describe, expect, it } from "bun:test";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { buildLeaderboard, renderLeaderboardMarkdown } from "@sandbox-benchmarks/results";
+import { parseRun } from "@sandbox-benchmarks/schema";
+import { findRepoRoot } from "./lib/workspace.ts";
+
+const ROOT = findRepoRoot();
+const ARTIFACT = join(ROOT, "LEADERBOARD.md");
+
+/** The Run id the committed artifact was generated from, read out of its own header line:
+ *  "Run `<id>` · commit `<sha>` · generated <iso>". Parsed rather than hardcoded so regenerating the
+ *  leaderboard from a newer Run doesn't require editing this gate too. */
+function runIdOf(markdown: string): string {
+	const match = markdown.match(/^Run `([^`]+)`/m);
+	if (!match?.[1]) {
+		throw new Error("LEADERBOARD.md has no `Run <id>` header line — cannot locate its source Run");
+	}
+	return match[1];
+}
+
+const committed = readFileSync(ARTIFACT, "utf8");
+const runId = runIdOf(committed);
+const run = parseRun(
+	JSON.parse(readFileSync(join(ROOT, "data", "dataset", "runs", `${runId}.json`), "utf8")),
+);
+
+describe("LEADERBOARD.md stays in sync with the renderer", () => {
+	it("is byte-identical to a fresh render of the Run it names", () => {
+		const rendered = renderLeaderboardMarkdown(buildLeaderboard(run));
+		if (committed !== rendered) {
+			// Name the remedy in the failure, rather than leaving whoever hits this to work it out.
+			throw new Error(
+				`LEADERBOARD.md is stale — the renderer no longer produces the committed file.\n` +
+					`Regenerate it:\n  bun apps/cli/src/bin/leaderboard.ts data/dataset/runs/${runId}.json LEADERBOARD.md`,
+			);
+		}
+		expect(committed).toBe(rendered);
+	});
+
+	it("renders the same bytes twice, so this gate can't flake on an unseeded bootstrap", () => {
+		expect(renderLeaderboardMarkdown(buildLeaderboard(run))).toBe(
+			renderLeaderboardMarkdown(buildLeaderboard(run)),
+		);
+	});
+});


### PR DESCRIPTION
**ENG-146 — rank the leaderboard inferentially, not on a bare median.**
Split into a 6-PR stack (merge bottom-up, each branch independently green on its own):

1. #116 — ci: dispatch `bench-matrix` per-provider + fix two runner-cache/publish bugs
2. #114 — schema: seeded bootstrap, Mann-Whitney U, Kolmogorov-Smirnov (pure-additive toolkit)
3. **#115 — results:** share a rank on statistical ties; create the `LEADERBOARD.md` drift gate ← _you are here_
4. #117 — repo-checks: render the leaderboard from the committed dataset, not the raw tree
5. #118 — results: render the `p (KS)` column; stop the gate silencing its own guard
6. #119 — dataset: publish run `29061549181` + the regenerated leaderboard

↑ **This PR is #115 (3/6)**, based on #114. It is the wiring that consumes #114's toolkit; the `p (KS)` column and the dataset-source fix are split out into #118 and #117.

---

## What changes for a reader of the leaderboard

Ranking stops being a sort and becomes an inference. Each row carries a bootstrapped [confidence interval](https://en.wikipedia.org/wiki/Confidence_interval) around its [median](https://en.wikipedia.org/wiki/Median), its retained sample count `n`, and the [p-value](https://en.wikipedia.org/wiki/P-value) against the row above it.

**Two rows share a rank unless their full distributions separate** under the [Mann–Whitney U test](https://en.wikipedia.org/wiki/Mann%E2%80%93Whitney_U_test) (two-sided, α = 0.05) — [standard competition ranking](https://en.wikipedia.org/wiki/Ranking) ("1224"), except the ties are *statistical* rather than exact-value ties. The rule it enforces:

> A faster median earned inside the noise is not a faster provider.

Why these tests and not a t-test: the samples are repeated trials inside **one sandbox**, so their spread is environmental, not normal, and not independent of the host's scheduler. Mann–Whitney is [non-parametric](https://en.wikipedia.org/wiki/Nonparametric_statistics) and rank-based; the interval is a [percentile bootstrap](https://en.wikipedia.org/wiki/Bootstrapping_(statistics)#Methods_for_bootstrap_confidence_intervals) rather than a normal-theory `±1.96·σ/√n`, which would assume a symmetry the data lacks. The median is used because it is [robust](https://en.wikipedia.org/wiki/Robust_statistics) to a single stalled pass. Full reasoning in #114.

The rendered table gains `95% CI` / `n` / `p vs. above` columns and a **"Reading this table"** note stating plainly that at this suite's small `n`, a non-significant result means *not enough evidence to separate* — never *the providers are equal* ([type II error](https://en.wikipedia.org/wiki/Type_I_and_type_II_errors)). (The fourth column, `p (KS)`, is added on top in #118.)

## `LEADERBOARD.md` becomes a gated artifact

`LEADERBOARD.md` is a committed, generated artifact ("do not edit by hand"). A renderer change would otherwise leave it stale — readers seeing the old three-column table while the code computed a new one — and **nothing gated that.** This PR adds `tooling/repo-checks/src/leaderboard-artifact-sync.test.ts`, which re-renders the Run the artifact names (parsed from its own header line) and fails on any difference, naming the regeneration command.

The gate is only sound because the render is deterministic: the bootstrap is seeded from stable Run/Metric/provider identity, and `generatedAt` is read from the Run document rather than the clock, so the output is [reproducible](https://en.wikipedia.org/wiki/Reproducibility). A second test asserts that determinism directly, so an unseeded bootstrap can never make the gate flake.

Two follow-ups harden this gate and are split out to keep this PR to one concept: **#117** points it at the committed dataset (rather than a gitignored raw tree), and **#118** stops a module-scope resolve from silencing the determinism check.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Share leaderboard ranks when providers are statistically indistinguishable so noise doesn’t pick winners. Adds inferential ranking with seeded CIs, n, and p-values, makes the render deterministic, and gates `LEADERBOARD.md` by re-rendering from the committed dataset. (ENG-146)

- **New Features**
  - Inferential ranking using Mann–Whitney U (two-sided, alpha=0.05); adjacent rows share a rank when not separable. Single-sample metrics rank by value; exact ties share a rank. KS p-value is computed for distribution shape but does not drive grouping.
  - Deterministic ordering: tie-break on providerId; equal headline values share rank rather than winning by sort.
  - Table adds 95% CI (seeded bootstrap), n, and “p vs. above” with a "<0.001" floor, and marks ties as "(tied)". Adds a short “Reading this table” note.

- **Dependencies**
  - Add `@sandbox-benchmarks/results` to `tooling/repo-checks`; repo-check re-renders the named Run from `data/dataset/runs` and fails on drift, with deterministic output and a clear regen command.

<sup>Written for commit e2e2a2354b2b181b03d63966e3c1440643045126. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/starslingdev/sandbox-benchmarks/pull/115?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

