### PR TITLE
feat(ci): let a bench-matrix dispatch choose which providers to fan out over

### DIFF
--- a/.github/workflows/bench-matrix.yml
+++ b/.github/workflows/bench-matrix.yml
@@ -7,6 +7,16 @@ name: Bench matrix
 # + provider credentials); dispatch on demand.
 on:
   workflow_dispatch:
+    inputs:
+      providers:
+        description: 'Comma-separated providers to benchmark (blank = every registered provider).'
+        required: false
+        type: string
+        # The providers with a baked toolchain artifact and credentials in CI. blaxel boots the stock
+        # base image (nothing baked for it), so it is excluded by default rather than burning ~150min
+        # of runner time per suite on cells that cannot produce a comparable result. Pass it explicitly
+        # to include it; `plan-matrix` rejects any name that is not in the registry.
+        default: e2b,daytona,modal
 
 # Least privilege: jobs only read the checked-out code and upload artifacts.
 permissions:
@@ -39,8 +49,14 @@ jobs:
       # plan-matrix prints one line of compact JSON ({"include":[...]}) — the strategy.matrix contract.
       - name: Plan
         id: plan
+        # The dispatch input reaches plan-matrix through the environment, never interpolated into the
+        # shell, so a crafted input can't inject into the runner command.
+        env:
+          BENCH_PROVIDERS: ${{ inputs.providers }}
         # Capture into a variable first so a plan-matrix.ts failure aborts the step (set -e): inlining
-        # the command substitution inside `echo` would mask its exit code behind echo's 0.
+        # the command substitution inside `echo` would mask its exit code behind echo's 0. An
+        # unregistered provider name exits 2 here, so a typo fails the plan instead of quietly
+        # publishing a dataset with that provider missing.
         run: |
           matrix="$(bun apps/cli/src/bin/plan-matrix.ts)"
           echo "matrix=$matrix" >> "$GITHUB_OUTPUT"
@@ -62,10 +78,19 @@ jobs:
           # credentials), so don't persist the job token in .git/config.
           persist-credentials: false
 
+      # `no-cache` is REQUIRED on this label, unlike the hosted-runner jobs above/below. Two runner
+      # images answer to `starsling-ubuntu-24.04-2` and they root the workspace at different depths
+      # (`/home/runner/_work/…` vs `/home/runner/actions-runner/_work/…`), yet setup-bun keys its cache
+      # only on the bun version. The cached `~/.bun` is stored relative to the save-time workspace and
+      # extracted with `-C <workspace>`, so an entry saved on one image unpacks to
+      # `/home/runner/actions-runner/.bun` on the other — the cache reports "restored successfully" and
+      # the next line dies with "Unable to locate executable file: /home/runner/.bun/bin/bun". Downloading
+      # bun (~32 MB) costs a couple of seconds; restoring a cache built for the other image costs the cell.
       - name: Set up Bun
         uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
         with:
           bun-version: 1.3.14
+          no-cache: true
 
       - name: Install dependencies
         run: bun install --frozen-lockfile --ignore-scripts
@@ -137,10 +162,17 @@ jobs:
 
       # Aggregate the shards' Run documents into one candidate, then promote (gate on >=1 validated
       # provider) and publish into the committed dataset at data/dataset/. The run-id matches the shards.
+      #
+      # The glob names the Run document EXACTLY, `<runId>.json`, and must not gain a `data/` segment:
+      # the bench cell uploads `path: data/`, and upload-artifact roots the artifact at the least common
+      # ancestor of the matched files — so a shard unpacks as `shards/<artifact>/runs/<runId>.json`, with
+      # no `data/` prefix. Two decoys sit next to it that a `runs/*.json` wildcard would sweep in: the
+      # sibling `runs/index.json` (an index, not a Run), and `dataset/runs/<oldRunId>.json` (the committed
+      # dataset, which rides along because it lives under data/). Both would poison the aggregate.
       - name: Aggregate + promote
         run: |
           shopt -s nullglob
-          shards=(shards/*/data/runs/*.json)
+          shards=(shards/*/runs/"$GITHUB_RUN_ID".json)
           if [ ${#shards[@]} -eq 0 ]; then echo "no shard Run documents found" >&2; exit 1; fi
           bun apps/cli/src/bin/aggregate.ts "$GITHUB_RUN_ID" data/candidate "${shards[@]}"
           bun apps/cli/src/bin/promote.ts "data/candidate/runs/$GITHUB_RUN_ID.json" data/dataset

--- a/apps/cli/src/bin/plan-matrix.ts
+++ b/apps/cli/src/bin/plan-matrix.ts
@@ -2,10 +2,13 @@
 // `plan-matrix` — emit the benchmark matrix as a SINGLE LINE of compact JSON.
 // This is the $GITHUB_OUTPUT contract: `matrix=<json>` must be one line, no pretty-printing.
 import { handleDiscovery } from "../lib/discovery.ts";
-import { buildMatrix } from "../lib/matrix.ts";
+import { buildMatrix, selectProviders } from "../lib/matrix.ts";
 
-export function planMatrixJson(): string {
-	return JSON.stringify({ include: buildMatrix() });
+/** The matrix JSON for `providersRaw` (a comma-separated `BENCH_PROVIDERS` value; blank/undefined =
+ *  every registered provider). Takes the raw string rather than reading `process.env` itself, so it
+ *  stays pure — the bin owns the env read, and a test can't be perturbed by an ambient value. */
+export function planMatrixJson(providersRaw?: string): string {
+	return JSON.stringify({ include: buildMatrix(selectProviders(providersRaw)) });
 }
 
 /** Agent-facing usage; the bare invocation stays the $GITHUB_OUTPUT matrix contract. */
@@ -19,9 +22,15 @@ usage: plan-matrix [--help] [--list-providers] [--list-suites] [--json]
   --json             Emit --list-* output as JSON instead of human-readable lines.
   --help, -h         Show this help.
 
+environment:
+  BENCH_PROVIDERS    Comma-separated providers to fan out over (e.g. "e2b,daytona,modal"). Unset or
+                     blank fans out over every registered provider. An unregistered name is an error,
+                     never a silently smaller matrix.
+
 examples:
-  plan-matrix                       # the CI matrix: echo "matrix=$(plan-matrix)" >> "$GITHUB_OUTPUT"
-  plan-matrix --list-suites --json  # the suites + their dimensions/metrics as JSON
+  plan-matrix                                  # the CI matrix: echo "matrix=$(plan-matrix)" >> "$GITHUB_OUTPUT"
+  BENCH_PROVIDERS=e2b,daytona plan-matrix      # only those two providers' cells
+  plan-matrix --list-suites --json             # the suites + their dimensions/metrics as JSON
 
 Next: run one cell with  bench-suite <provider> <suite> <runId>`;
 
@@ -32,5 +41,12 @@ if (import.meta.main) {
 		(discovery.ok ? console.log : console.error)(discovery.text);
 		process.exit(discovery.ok ? 0 : 2);
 	}
-	console.log(planMatrixJson());
+	// A bad BENCH_PROVIDERS must fail the step, not print a diagnostic onto stdout: stdout here IS the
+	// `matrix=` value CI captures, so an error message there would be parsed as the matrix.
+	try {
+		console.log(planMatrixJson(process.env.BENCH_PROVIDERS));
+	} catch (err) {
+		console.error(`plan-matrix: ${err instanceof Error ? err.message : String(err)}`);
+		process.exit(2);
+	}
 }

--- a/apps/cli/src/lib/matrix.ts
+++ b/apps/cli/src/lib/matrix.ts
@@ -12,6 +12,37 @@ export interface MatrixEntry {
 }
 
 /**
+ * The providers a dispatch asks the matrix to fan out over, parsed from a comma-separated list (the
+ * `BENCH_PROVIDERS` dispatch input). Absent or blank → every registered provider, so the default CI
+ * matrix is unchanged and the registry stays the source of truth.
+ *
+ * An unregistered name THROWS rather than being dropped: a typo'd `--providers e2b,dayton` would
+ * otherwise silently shrink the matrix and publish a dataset missing that provider, which reads
+ * downstream as "daytona had no results" instead of "you misspelled it". Duplicates collapse, and the
+ * result is ordered by the registry, so a dispatch can't reorder or double-run a cell. Matching is
+ * case-insensitive (every registered id is lowercase), so a hand-typed `E2B` still selects `e2b`.
+ */
+export function selectProviders(raw: string | undefined): ProviderId[] {
+	const registered = PROVIDERS.map((p) => p.id);
+	const requested = (raw ?? "")
+		.toLowerCase()
+		.split(",")
+		.map((name) => name.trim())
+		.filter((name) => name.length > 0);
+	if (requested.length === 0) return registered;
+
+	const unknown = requested.filter((name) => !registered.includes(name as ProviderId));
+	if (unknown.length > 0) {
+		throw new Error(
+			`unknown provider(s): ${unknown.join(", ")} — registered providers are ${registered.join(", ")}`,
+		);
+	}
+	// Registry order, not request order: the matrix is a set of cells, and a stable order keeps the CI
+	// job list (and any diff of it) from churning with the way a dispatch happened to spell the list.
+	return registered.filter((id) => requested.includes(id));
+}
+
+/**
  * The full benchmark matrix: every provider × every registered suite. Each cell becomes one CI job
  * (`bench-suite <provider> <suite>`), so the dataset grows by adding a provider or a suite to its
  * registry — never by editing the workflow. Both lists are injectable for unit tests; the defaults are

--- a/apps/cli/src/plan-matrix.test.ts
+++ b/apps/cli/src/plan-matrix.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "bun:test";
 import { PROVIDERS, SUITE_NAMES } from "@sandbox-benchmarks/schema";
 import { HELP, planMatrixJson } from "./bin/plan-matrix.ts";
 import { handleDiscovery } from "./lib/discovery.ts";
+import { selectProviders } from "./lib/matrix.ts";
 
 describe("plan-matrix", () => {
 	it("emits a single line of compact JSON (the $GITHUB_OUTPUT contract)", () => {
@@ -40,5 +41,42 @@ describe("plan-matrix", () => {
 
 		// A bare invocation has no discovery flag, so the matrix path (the GITHUB_OUTPUT contract) runs.
 		expect(handleDiscovery([], HELP)).toBeNull();
+	});
+
+	it("narrows the matrix to the providers a dispatch names, still one line of JSON", () => {
+		const out = planMatrixJson("e2b,daytona");
+		expect(out).not.toContain("\n");
+
+		const parsed = JSON.parse(out) as { include: Array<{ provider: string }> };
+		expect(parsed.include.length).toBe(2 * SUITE_NAMES.length);
+		expect([...new Set(parsed.include.map((c) => c.provider))]).toEqual(["e2b", "daytona"]);
+	});
+});
+
+describe("selectProviders", () => {
+	const registered = PROVIDERS.map((p) => p.id);
+
+	it("defaults to every registered provider when unset or blank", () => {
+		// Blank is the workflow's "no filter" value (an empty dispatch input arrives as ""), so it must
+		// mean the full matrix — not an empty one, which would silently benchmark nothing.
+		expect(selectProviders(undefined)).toEqual(registered);
+		expect(selectProviders("")).toEqual(registered);
+		expect(selectProviders("  , ,")).toEqual(registered);
+	});
+
+	it("throws on an unregistered name rather than shrinking the matrix", () => {
+		// The failure this guards: `dayton` silently drops daytona's cells, and the published dataset
+		// then reads as "daytona produced no results" instead of "the dispatch was misspelled".
+		expect(() => selectProviders("e2b,dayton")).toThrow(/unknown provider\(s\): dayton/);
+		expect(() => selectProviders("e2b,dayton")).toThrow(/registered providers are/);
+	});
+
+	it("collapses duplicates and orders by the registry, not by the request", () => {
+		// Cells are a set: a dispatch can neither double-run one nor reorder the CI job list.
+		expect(selectProviders("modal,e2b,modal")).toEqual(["e2b", "modal"]);
+	});
+
+	it("tolerates whitespace and mixed casing around names, as a hand-typed dispatch input has", () => {
+		expect(selectProviders(" E2b , Modal ")).toEqual(["e2b", "modal"]);
 	});
 });


### PR DESCRIPTION
**CI — make the benchmark matrix dispatchable per-provider and reliable on the custom runner.**
Sits at the **base** of the ENG-146 leaderboard stack. It is pure CI infrastructure and does not depend on the statistics work above it — it lives here only because that work needs a matrix that actually publishes a dataset.

Split into a 6-PR stack (merge bottom-up, each branch independently green on its own):

1. **#116 — ci:** dispatch `bench-matrix` per-provider + fix two runner-cache/publish bugs ← _you are here_
2. #114 — schema: seeded bootstrap, Mann-Whitney U, Kolmogorov-Smirnov (pure-additive toolkit)
3. #115 — results: share a rank on statistical ties; create the `LEADERBOARD.md` drift gate
4. #117 — repo-checks: render the leaderboard from the committed dataset, not the raw tree
5. #118 — results: render the `p (KS)` column; stop the gate silencing its own guard
6. #119 — dataset: publish run `29061549181` + the regenerated leaderboard

↑ **This PR is #116 (1/6)**, based on `main`.

---

Three independent bench-matrix changes, all discovered while trying to produce the dataset #119 publishes.

### Dispatch a subset of providers

`bench-matrix` planned every registered provider, so a dispatch could not skip `blaxel` — which boots the stock base image with nothing baked for it, and burned a ~150-minute runner slot per suite on cells that cannot produce a comparable result. A new `providers` dispatch input (default `e2b,daytona,modal`) drives a pure `selectProviders` over the schema registry:

- blank/unset ⇒ every registered provider, so the default matrix and the `$GITHUB_OUTPUT` contract are unchanged;
- an unregistered name **throws** — a typo'd `dayton` would otherwise silently drop daytona's cells, and the published dataset would then read as "daytona produced no results" rather than "the dispatch was misspelled";
- duplicates collapse and the result is registry-ordered, so a dispatch can neither double-run a cell nor churn the CI job list.

The value reaches `plan-matrix` through the environment, not the shell, and a bad value exits 2 on stderr — stdout **is** the `matrix=` value CI captures.

### Two reliability bugs this dispatch surfaced

- **Cross-image bun cache.** Two runner images answer to `starsling-ubuntu-24.04-2` and root the workspace at different depths, but `setup-bun` keys its cache on the bun version alone. The cached `~/.bun` unpacks to the wrong path on the other image; the restore logs success and the next line dies with `Unable to locate executable file: /home/runner/.bun/bin/bun`. It killed 10 of 21 cells before they touched a provider. Fixed with `no-cache: true` on the bench job only, leaving the hosted jobs as the cache's sole writers.
- **Publish glob.** The publish job globbed `shards/*/data/runs/*.json` and matched nothing, so every dispatch aborted at `no shard Run documents found` — no dataset was ever committed. `upload-artifact` strips the `data/` prefix; the exact glob is `shards/*/runs/$GITHUB_RUN_ID.json`, which also dodges the `runs/index.json` and committed-dataset decoys. Verified against a real 21-artifact tree.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a provider filter to the bench matrix and fixes CI setup/publish issues so runs are correct and faster. Dispatches can target providers by name and avoid silent data gaps.

- New Features
  - Added `providers` dispatch input (default: e2b, daytona, modal) to select which providers to benchmark.
  - `plan-matrix` reads `BENCH_PROVIDERS` and uses `selectProviders` (blank=all; case-insensitive; deduped; registry order; unknown names fail with exit 2 on stderr).

- Bug Fixes
  - Set `no-cache: true` for `oven-sh/setup-bun` on the custom bench runner to avoid cross-image cache issues.
  - Fixed publish glob to `shards/*/runs/$GITHUB_RUN_ID.json` so only this run’s Run docs are aggregated.

<sup>Written for commit 43bcb97eb0a4a8958814d5bbfc2ace7866c7f5c8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/starslingdev/sandbox-benchmarks/pull/116?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Benchmark runs can now be limited to selected providers through workflow dispatch input.
  * Provider selection supports comma-separated names, flexible casing and spacing, and removes duplicates.
  * Blank selections continue to run benchmarks across all available providers.

* **Bug Fixes**
  * Invalid provider names now fail clearly before benchmark execution.
  * Dataset publishing now aggregates only results from the current workflow run.
  * Benchmark setup avoids using potentially inconsistent runner caches.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->