### PR TITLE
fix(results,repo-checks): render the KS p-value, and stop the gate silencing its own guard

### DIFF
--- a/LEADERBOARD.md
+++ b/LEADERBOARD.md
@@ -8,17 +8,17 @@ Each table ranks the providers on that dimension's headline metric. Generated fr
 
 Headline: **Node.js web tooling** (runs/s, higher is better)
 
-| Rank | Provider | Node.js web tooling (runs/s) | 95% CI | n | p vs. above |
-| ---: | --- | ---: | ---: | ---: | ---: |
-| 1 | Daytona | 22.77 | 22.66 – 23 | 3 | — |
+| Rank | Provider | Node.js web tooling (runs/s) | 95% CI | n | p vs. above | p (KS) |
+| ---: | --- | ---: | ---: | ---: | ---: | ---: |
+| 1 | Daytona | 22.77 | 22.66 – 23 | 3 | — | — |
 
 ## economics
 
 Headline: **Hourly cost** (USD/hr, lower is better)
 
-| Rank | Provider | Hourly cost (USD/hr) | 95% CI | n | p vs. above |
-| ---: | --- | ---: | ---: | ---: | ---: |
-| 1 | Daytona | 0.1494 | — | 1 | — |
+| Rank | Provider | Hourly cost (USD/hr) | 95% CI | n | p vs. above | p (KS) |
+| ---: | --- | ---: | ---: | ---: | ---: | ---: |
+| 1 | Daytona | 0.1494 | — | 1 | — | — |
 
 ---
 
@@ -34,6 +34,13 @@ earned inside the noise is not a faster provider. Samples are repeated trials in
 so their spread is environmental (neighbours, host contention, virtualization), and a wide CI or a
 large `n` (the harness re-runs a test that will not converge) is itself the signal that the
 provider's performance is unstable, not that the measurement is imprecise.
+
+`p (KS)` is a two-sample Kolmogorov-Smirnov test against the same row above. It does **not** drive
+the ranking — it compares the two empirical distributions' *shapes* rather than their central
+tendency. Read it where it disagrees with `p vs. above`: a tied rank (large Mann-Whitney p) beside a
+small `p (KS)` means two providers with the same typical speed but different behaviour — usually one
+of them alternating between fast and stalled passes. That bimodality is what environmental noise
+looks like, and it is the reason a median alone cannot rank these providers.
 
 At the small `n` this suite produces, a non-significant result means *not enough evidence to
 separate*, never *the providers are equal*.

--- a/packages/results/src/lib/leaderboard.test.ts
+++ b/packages/results/src/lib/leaderboard.test.ts
@@ -218,12 +218,47 @@ describe("renderLeaderboardMarkdown statistics", () => {
 		expect(md).toContain("Mann-Whitney");
 	});
 
+	it("surfaces the KS p-value in the table, not only on the row object", () => {
+		// Regression: `ks` was computed and stored on every LeaderboardRow, documented as the way to spot
+		// a bimodal provider, and then never rendered — so no reader of LEADERBOARD.md could ever see it.
+		const board = buildLeaderboard(
+			run([
+				provider("daytona", [metric(HEADLINE, [10, 12, 11, 13, 9])]),
+				provider("e2b", [metric(HEADLINE, [11, 12, 10, 14, 13])]),
+			]),
+		);
+		const md = renderLeaderboardMarkdown(board);
+
+		expect(md).toContain("p (KS)");
+		// The note must explain the column, since a second p-value is otherwise cryptic.
+		expect(md).toContain("Kolmogorov-Smirnov");
+
+		// The second row carries both p-values (rank 1 has no predecessor, so both cells are em-dashes).
+		expect(board.dimensions[0]?.rows[1]?.pVsPrevious).not.toBeNull();
+
+		// Assert the SHAPE of the rendered rows, not a re-derived format string: duplicating
+		// `formatPValue`'s rule here would let the test agree with itself and drift from the renderer
+		// (`toPrecision(2)` keeps a trailing zero — "0.0080" — which a `Number(...)` round-trip drops).
+		const rows = md.split("\n").filter((l) => /^\| \d+ \| (Daytona|E2B) \|/.test(l));
+		expect(rows).toHaveLength(2);
+		for (const row of rows) {
+			// 7 columns: rank, provider, value, CI, n, p vs. above, p (KS).
+			expect(row.split("|").filter((c) => c.trim() !== "")).toHaveLength(7);
+		}
+		const [first, second] = rows as [string, string];
+		expect(first.trimEnd().endsWith("| — |")).toBe(true); // no predecessor → no KS
+		const secondKs = second.trimEnd().split("|").at(-2)?.trim() as string;
+		expect(secondKs).not.toBe("—");
+		expect(secondKs).toMatch(/^(<0\.001|\d+(\.\d+)?(e[+-]?\d+)?)$/);
+	});
+
 	it("renders a point value with no interval for a single-Sample Metric", () => {
 		const md = renderLeaderboardMarkdown(
 			buildLeaderboard(run([provider("daytona", [metric(HEADLINE, [10])])])),
 		);
-		// n=1 → em-dash for both CI and p, never a fabricated bound.
-		expect(md).toMatch(/\| 1 \| Daytona \| 10 \| — \| 1 \| — \|/);
+		// n=1 → em-dash for the CI and BOTH p-values, never a fabricated bound. Anchored to the row end so
+		// a future column can't be silently dropped from the assertion.
+		expect(md).toMatch(/\| 1 \| Daytona \| 10 \| — \| 1 \| — \| — \|\n/);
 	});
 
 	it("never prints a p-value as a misleading 0", () => {

--- a/packages/results/src/lib/leaderboard.ts
+++ b/packages/results/src/lib/leaderboard.ts
@@ -48,6 +48,9 @@ export interface LeaderboardRow {
 	 * `mannWhitney` tests a shift in central tendency and drives the tie grouping; `ks` compares the full
 	 * empirical CDFs, catching a provider whose median matches but whose distribution is bimodal — the
 	 * signature of environmental noise rather than a real difference.
+	 *
+	 * Both are rendered: `mannWhitney` as `p vs. above`, `ks` as `p (KS)`. Only `mannWhitney` decides the
+	 * rank; `ks` is shown so a reader can see the two disagree.
 	 */
 	pVsPrevious: { mannWhitney: number; ks: number } | null;
 	/** Whether this row is statistically separable from the one above it. `null` for rank 1. */
@@ -192,8 +195,8 @@ export function renderLeaderboardMarkdown(board: Leaderboard): string {
 			"",
 			`Headline: **${metric.label}** (${metric.unit}, ${better})`,
 			"",
-			`| Rank | Provider | ${metric.label} (${metric.unit}) | 95% CI | n | p vs. above |`,
-			"| ---: | --- | ---: | ---: | ---: | ---: |",
+			`| Rank | Provider | ${metric.label} (${metric.unit}) | 95% CI | n | p vs. above | p (KS) |`,
+			"| ---: | --- | ---: | ---: | ---: | ---: | ---: |",
 			...rows.map((r) => {
 				const ci =
 					r.interval.resamples === 0
@@ -207,7 +210,11 @@ export function renderLeaderboardMarkdown(board: Leaderboard): string {
 						: r.separated
 							? formatPValue(r.pVsPrevious.mannWhitney)
 							: `${formatPValue(r.pVsPrevious.mannWhitney)} (tied)`;
-				return `| ${r.rank} | ${r.displayName} | ${formatValue(r.value)} | ${ci} | ${r.n} | ${p} |`;
+				// KS is rendered, not just stored: it is the only column that exposes a provider whose
+				// median matches its neighbour's while its distribution is bimodal. A small `p (KS)` beside
+				// a large, tied `p vs. above` is exactly that case — same typical speed, different machine.
+				const ks = r.pVsPrevious === null ? "—" : formatPValue(r.pVsPrevious.ks);
+				return `| ${r.rank} | ${r.displayName} | ${formatValue(r.value)} | ${ci} | ${r.n} | ${p} | ${ks} |`;
 			}),
 			"",
 		);
@@ -228,6 +235,13 @@ export function renderLeaderboardMarkdown(board: Leaderboard): string {
 		"so their spread is environmental (neighbours, host contention, virtualization), and a wide CI or a",
 		"large `n` (the harness re-runs a test that will not converge) is itself the signal that the",
 		"provider's performance is unstable, not that the measurement is imprecise.",
+		"",
+		"`p (KS)` is a two-sample Kolmogorov-Smirnov test against the same row above. It does **not** drive",
+		"the ranking — it compares the two empirical distributions' *shapes* rather than their central",
+		"tendency. Read it where it disagrees with `p vs. above`: a tied rank (large Mann-Whitney p) beside a",
+		"small `p (KS)` means two providers with the same typical speed but different behaviour — usually one",
+		"of them alternating between fast and stalled passes. That bimodality is what environmental noise",
+		"looks like, and it is the reason a median alone cannot rank these providers.",
 		"",
 		"At the small `n` this suite produces, a non-significant result means *not enough evidence to",
 		"separate*, never *the providers are equal*.",

--- a/tooling/repo-checks/src/leaderboard-artifact-sync.test.ts
+++ b/tooling/repo-checks/src/leaderboard-artifact-sync.test.ts
@@ -35,18 +35,27 @@ function runIdOf(markdown: string): string {
 	return match[1];
 }
 
-const committed = readFileSync(ARTIFACT, "utf8");
-const runId = runIdOf(committed);
-const source = runFile(runId);
-
-/** Read and parse the source Run, translating a bare ENOENT into the diagnosis that matters here:
- *  a named Run missing from the committed dataset means the artifact was rendered from the
- *  gitignored raw tree. try/catch rather than an existsSync pre-check, so there is no TOCTOU gap. */
-function readCommittedRun(): ReturnType<typeof parseRun> {
+/**
+ * Load the Run the committed artifact names. Called INSIDE each test, never at module scope: a throw
+ * during module initialisation aborts the whole file before Bun collects any test, so a missing source
+ * Run would take the determinism test below down with it — silencing the check precisely in the
+ * scenario it exists to catch (an artifact rendered from the gitignored `data/runs/`).
+ */
+function loadCommittedRun(): {
+	committed: string;
+	runId: string;
+	run: ReturnType<typeof parseRun>;
+} {
+	const committed = readFileSync(ARTIFACT, "utf8");
+	const runId = runIdOf(committed);
+	const source = runFile(runId);
 	try {
-		return parseRun(JSON.parse(readFileSync(source, "utf8")));
+		return { committed, runId, run: parseRun(JSON.parse(readFileSync(source, "utf8"))) };
 	} catch (error) {
 		if ((error as NodeJS.ErrnoException).code === "ENOENT") {
+			// A named Run that isn't in the committed dataset means the artifact was rendered from the
+			// gitignored raw tree — say so, rather than failing later with a bare ENOENT. try/catch
+			// rather than an existsSync pre-check, so there is no TOCTOU gap.
 			throw new Error(
 				`LEADERBOARD.md names Run "${runId}", but ${source} is not committed. The artifact must be ` +
 					`rendered from the published dataset (data/dataset/runs/), not the gitignored data/runs/.`,
@@ -55,10 +64,10 @@ function readCommittedRun(): ReturnType<typeof parseRun> {
 		throw error;
 	}
 }
-const run = readCommittedRun();
 
 describe("LEADERBOARD.md stays in sync with the renderer", () => {
 	it("is byte-identical to a fresh render of the Run it names", () => {
+		const { committed, runId, run } = loadCommittedRun();
 		const rendered = renderLeaderboardMarkdown(buildLeaderboard(run));
 		if (committed !== rendered) {
 			// Name the remedy in the failure, rather than leaving whoever hits this to work it out.
@@ -71,6 +80,9 @@ describe("LEADERBOARD.md stays in sync with the renderer", () => {
 	});
 
 	it("renders the same bytes twice, so this gate can't flake on an unseeded bootstrap", () => {
+		// Loads independently of the test above: each resolves the Run itself, so one failing reports
+		// its own diagnosis instead of aborting the file and taking the other down with it.
+		const { run } = loadCommittedRun();
 		expect(renderLeaderboardMarkdown(buildLeaderboard(run))).toBe(
 			renderLeaderboardMarkdown(buildLeaderboard(run)),
 		);


### PR DESCRIPTION
**ENG-146 — rank the leaderboard inferentially, not on a bare median.**
Split into a 6-PR stack (merge bottom-up, each branch independently green on its own):

1. #116 — ci: dispatch `bench-matrix` per-provider + fix two runner-cache/publish bugs
2. #114 — schema: seeded bootstrap, Mann-Whitney U, Kolmogorov-Smirnov (pure-additive toolkit)
3. #115 — results: share a rank on statistical ties; create the `LEADERBOARD.md` drift gate
4. #117 — repo-checks: render the leaderboard from the committed dataset, not the raw tree
5. **#118 — results:** render the `p (KS)` column; stop the gate silencing its own guard ← _you are here_
6. #119 — dataset: publish run `29061549181` + the regenerated leaderboard

↑ **This PR is #118 (5/6)**, based on #117.

---

Two changes to the same renderer + gate, plus a test that pins the row shape.

### Render the `p (KS)` column

#114 computes the [Kolmogorov–Smirnov](https://en.wikipedia.org/wiki/Kolmogorov%E2%80%93Smirnov_test) statistic but #115 didn't surface it. This adds it as its own `p (KS)` column, which **does not drive the grouping** — it compares the two [empirical CDFs](https://en.wikipedia.org/wiki/Empirical_distribution_function), so it catches a provider whose median matches another's while its distribution is [bimodal](https://en.wikipedia.org/wiki/Multimodal_distribution) (fast passes alternating with stalled ones). That shape *is* the signature of environmental noise, so it is shown to the reader rather than folded into the rank. **Read `p (KS)` where it disagrees with `p vs. above`:** a tied rank beside a small `p (KS)` means two providers with the same typical speed but different behaviour.

### Stop the gate silencing its own guard

The drift gate resolved its source Run at **module scope**. A missing Run then threw before bun collected any test — aborting the whole file and silencing the determinism check in exactly the scenario the gate exists to catch. Both tests now resolve the Run **inside** the test body, so each runs and reports its own diagnosis.

### Test the rendered row, not the formatter

The row-shape test now asserts the **rendered** cell values instead of re-deriving them through `formatPValue` — so a change to the formatter can't make the test agree with a wrong render by construction.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a `p (KS)` column to the leaderboard and explains it in the note. Fixes the repo-check gate so a missing source Run doesn’t abort the file. Supports ENG-146 by surfacing KS while ranks still use Mann–Whitney.

- **Bug Fixes**
  - Render `p (KS)` in the table; note now explains Kolmogorov–Smirnov; JSDoc updated; regenerated `LEADERBOARD.md`.
  - Resolve the source Run inside each repo-check test so both tests run; clearer error when the Run isn’t in the committed dataset.

- **Tests**
  - Assert rendered cells and the 7-column shape; rank‑1 and `n=1` rows show em-dashes for both p-values.
  - Avoid re-deriving `formatPValue`; anchor the `n=1` check to the row end.

<sup>Written for commit 57716148a1036085049db9cc816e1c46678449b6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/starslingdev/sandbox-benchmarks/pull/118?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

