### PR TITLE
fix(harness): omit diskGb when df reports gVisor's 2^63-byte sentinel

### DIFF
--- a/packages/harness/src/lib/setup.ts
+++ b/packages/harness/src/lib/setup.ts
@@ -125,7 +125,10 @@ export const OBSERVED_SPECS_SCRIPT = [
 	"if [ -f /sys/fs/cgroup/memory.max ] && grep -qv max /sys/fs/cgroup/memory.max; then",
 	`  memory_gb=$(awk '{ printf "%.2f", $1 / 1073741824 }' /sys/fs/cgroup/memory.max) && limited=1`,
 	"fi",
-	`disk_gb=$(df -Pk / | awk 'NR==2 { printf "%.1f", $2 / 1048576 }')`,
+	// gVisor (Modal) reports / as 2^63 bytes — a "no limit" sentinel, not a size. Emit diskGb only
+	// when df's answer is plausible for a sandbox (positive, < 100 TB); a sentinel, a failed df, or
+	// a non-numeric column all leave it unset as unknown.
+	`disk_gb=$(df -Pk / | awk 'NR==2 && $2 + 0 > 0 && $2 / 1048576 < 100000 { printf "%.1f", $2 / 1048576 }')`,
 	`cpu_model=$(LC_ALL=C lscpu 2>/dev/null | sed -n 's/^Model name:[[:space:]]*//p' | head -1 || true)`,
 	"kernel=$(uname -r)",
 	`os=$(sed -n 's/^PRETTY_NAME=//p' /etc/os-release 2>/dev/null | tr -d '"' || true)`,
@@ -133,7 +136,8 @@ export const OBSERVED_SPECS_SCRIPT = [
 	"user=$(id -un)",
 	String.raw`esc() { printf '%s' "$1" | sed 's/["\\]/\\&/g'; }`,
 	"{",
-	`  printf '{"vcpus":%s,"memoryGb":%s,"diskGb":%s' "$vcpus" "$memory_gb" "$disk_gb"`,
+	`  printf '{"vcpus":%s,"memoryGb":%s' "$vcpus" "$memory_gb"`,
+	`  if [ -n "$disk_gb" ]; then printf ',"diskGb":%s' "$disk_gb"; fi`,
 	`  if [ -n "$limited" ]; then printf ',"hostVcpus":%s,"hostMemoryGb":%s' "$host_vcpus" "$host_memory_gb"; fi`,
 	`  if [ -n "$cpu_model" ]; then printf ',"cpuModel":"%s"' "$(esc "$cpu_model")"; fi`,
 	String.raw`  printf ',"kernel":"%s","os":"%s","virtualization":"%s","user":"%s"}\n' "$(esc "$kernel")" "$(esc "$os")" "$(esc "$virt")" "$(esc "$user")"`,


### PR DESCRIPTION
Modal's gVisor sandbox reports / as 2^53 1K-blocks (2^63 bytes) — a
'no limit' sentinel, not a size — which landed in observed-specs.json
as diskGb 8589934592 and made the realworld disk gate treat Modal as
having unlimited space. Emit diskGb only when df's answer is plausible
for a sandbox (< 100 TB); an unknown size now stays unset, which the
spec reader already tolerates.

Claude-Session: https://claude.ai/code/session_01DWt5bJUMKni4yQE9zgiG8S

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix `packages/harness` spec script to omit `diskGb` unless `df` returns a plausible size, preventing Modal’s gVisor 2^63-byte sentinel and failed/non-numeric `df` results from writing fake values. Only include `diskGb` for positive values under 100 TB; unknown stays unset, avoiding fake “unlimited” and 0.0.

<sup>Written for commit 1861336bcbf94f88dfd2ab26e26a4b40b67f61a0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/starslingdev/sandbox-benchmarks/pull/120?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

