### PR TITLE
fix(providers): run Modal at the 2-vCPU spec and price its cpu unit per vCPU

### DIFF
--- a/packages/providers/src/index.test.ts
+++ b/packages/providers/src/index.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from "bun:test";
 // The stock wrapper factory, imported so the novita test can prove the connection methods were
 // actually REPLACED (identity inequality against an unpatched instance's methods table).
 import { e2b } from "@computesdk/e2b";
-import { PROVIDERS, TARGET_SPEC, VCPUS_PER_PHYSICAL_CORE } from "@sandbox-benchmarks/schema";
+import { PROVIDERS, TARGET_SPEC } from "@sandbox-benchmarks/schema";
 import { config, NOVITA_E2B_DOMAIN, novitaCompute, novitaConnection, providers } from "./index.ts";
 import { assertProviderJoin } from "./lib/join.ts";
 
@@ -31,12 +31,14 @@ describe("@sandbox-benchmarks/providers", () => {
 	it("pins modal's create-time spec from the shared TARGET_SPEC", () => {
 		const modal = providers.find((p) => p.name === "modal");
 		expect(modal).toBeDefined();
-		// Modal bills/provisions in physical cores, so the pinned vCPU count is halved for cpu/cpuLimit.
+		// Modal's `cpu` unit delivers one schedulable vCPU (nproc tracks it 1:1 and throughput scales
+		// with it — measured 2026-07-10), so the pinned vCPU count passes through unhalved; halving it
+		// benchmarked Modal on half the CPU of every other provider.
 		// `memoryLimitMiB` is the hard cap (memoryMiB alone is only a reservation, and the guest then
 		// still sees the host's RAM) — assert it, or the memory fix has no regression guard at all.
 		expect(modal?.createOptions).toMatchObject({
-			cpu: TARGET_SPEC.vcpus / VCPUS_PER_PHYSICAL_CORE,
-			cpuLimit: TARGET_SPEC.vcpus / VCPUS_PER_PHYSICAL_CORE,
+			cpu: TARGET_SPEC.vcpus,
+			cpuLimit: TARGET_SPEC.vcpus,
 			memoryMiB: TARGET_SPEC.memoryGb * 1024,
 			memoryLimitMiB: TARGET_SPEC.memoryGb * 1024,
 		});

--- a/packages/providers/src/lib/adapters.ts
+++ b/packages/providers/src/lib/adapters.ts
@@ -8,7 +8,7 @@ import { daytona } from "@computesdk/daytona";
 import { e2b } from "@computesdk/e2b";
 import { modal } from "@computesdk/modal";
 import type { ProviderId } from "@sandbox-benchmarks/schema";
-import { TARGET_SPEC, VCPUS_PER_PHYSICAL_CORE } from "@sandbox-benchmarks/schema";
+import { TARGET_SPEC } from "@sandbox-benchmarks/schema";
 import { config } from "./config.ts";
 import { novitaCompute } from "./novita.ts";
 import type { ProviderAdapter } from "./types.ts";
@@ -60,12 +60,14 @@ export const adapters: Record<ProviderId, ProviderAdapter> = {
 		createCompute: () => modal({ scalableSandboxes: true, appName: MODAL_APP_NAME }),
 		createOptions: {
 			templateId: config.toolchainImage,
-			// Modal's `cpu`/`cpuLimit` are physical cores, not vCPUs ("Note that this value corresponds to
-			// physical cores, not vCPUs" — modal.com/docs/guide/resources; 1 core = 2 vCPUs), so convert
-			// from the pinned vCPU spec. Passing TARGET_SPEC.vcpus straight through would reserve 2
-			// physical cores = 4 vCPUs — double every other provider, not parity with them.
-			cpu: TARGET_SPEC.vcpus / VCPUS_PER_PHYSICAL_CORE,
-			cpuLimit: TARGET_SPEC.vcpus / VCPUS_PER_PHYSICAL_CORE,
+			// Modal's docs call `cpu` physical cores ("this value corresponds to physical cores, not
+			// vCPUs" — modal.com/docs/guide/resources), but measured behavior contradicts that reading:
+			// cpu=1/cpuLimit=1 exposes nproc=1 and delivers exactly half the dual-worker throughput of
+			// cpu=2/cpuLimit=2 (probed 2026-07-10: 264 vs 512 MB hashed/worker/8s). In practice `cpu` is
+			// the schedulable-CPU count the guest sees, so halving TARGET_SPEC.vcpus benchmarked Modal on
+			// half the CPU of every other provider (which all expose nproc=2). Pass the vCPU spec through.
+			cpu: TARGET_SPEC.vcpus,
+			cpuLimit: TARGET_SPEC.vcpus,
 			// `memoryMiB` is only a RESERVATION — on its own the guest still sees the host's RAM (a live
 			// sandbox reported 464 GB), and PTS sizes STREAM's arrays from that, so the memory suite never
 			// converged. `memoryLimitMiB` is the hard cap that makes /proc/meminfo report the target spec.

--- a/packages/schema/src/providers.test.ts
+++ b/packages/schema/src/providers.test.ts
@@ -106,7 +106,7 @@ describe("@sandbox-benchmarks/schema providers", () => {
 		// Guards the economics constants against accidental regressions (PR #15 review). Daytona's
 		// first 5 GiB of memory are free; e2b bills all memory at the same vCPU/GiB rates.
 		const expected: Record<string, number> = {
-			modal: 0.070956 * TARGET_SPEC.vcpus + 0.024192 * TARGET_SPEC.memoryGb,
+			modal: 0.141912 * TARGET_SPEC.vcpus + 0.024192 * TARGET_SPEC.memoryGb,
 			e2b: 0.0504 * TARGET_SPEC.vcpus + 0.0162 * TARGET_SPEC.memoryGb,
 			daytona: 0.0504 * TARGET_SPEC.vcpus + 0.0162 * Math.max(0, TARGET_SPEC.memoryGb - 5),
 			novita: 0.03528 * TARGET_SPEC.vcpus + 0.01152 * TARGET_SPEC.memoryGb,

--- a/packages/schema/src/providers.ts
+++ b/packages/schema/src/providers.ts
@@ -128,14 +128,6 @@ export interface ProviderMeta {
 export const TARGET_SPEC = { vcpus: 2, memoryGb: 8, diskGb: 40 } as const;
 
 /**
- * Modal provisions and prices in physical CPU cores, where 1 physical core = 2 vCPU. This is the one
- * source of that factor: the Modal pricing entry below normalizes its per-physical-core rate to
- * per-vCPU by it, and the harness adapter divides {@link TARGET_SPEC}.vcpus by it to reserve the
- * matching number of cores (Modal's `SandboxCreateParams.cpu` is physical cores, not vCPUs).
- */
-export const VCPUS_PER_PHYSICAL_CORE = 2;
-
-/**
  * The registry, keyed by {@link ProviderId} — the inspiration is the harness adapter map, which
  * keys the *behavioural* half of a provider the same way. A keyed Record (rather than an array of
  * objects each repeating its `id`) buys three things for free: ids are unique by construction, the
@@ -261,15 +253,17 @@ const REGISTRY: Record<ProviderId, Omit<ProviderMeta, "id">> = {
 		},
 		pricing: {
 			model: "per_vcpu_hour",
-			// Sandbox non-preemptible rates. CPU: $0.00003942/physical-core-s ÷ VCPUS_PER_PHYSICAL_CORE × 3600 = $0.070956/vCPU-hr.
+			// Sandbox non-preemptible rates. CPU: $0.00003942/requested-cpu-s × 3600 = $0.141912/vCPU-hr —
+			// a requested `cpu` unit delivers one schedulable vCPU (measured; see the harness adapter), so
+			// the docs' "physical core" rate is billed per vCPU-equivalent and gets no ÷2 normalization.
 			// Memory: $0.00000672/GiB-s × 3600 = $0.024192/GiB-hr.
-			usdPerVcpuHour: 0.070956,
+			usdPerVcpuHour: 0.141912,
 			usdPerGibHour: 0.024192,
 			// Volumes: 1 TiB/mo free, then $0.09/GiB/mo. The 40 GB target spec sits inside the free
 			// tier, so the marginal disk rate at TARGET_SPEC is 0 (known, not unknown).
 			usdPerGibDiskHour: 0,
 			notes:
-				"Sandbox non-preemptible rates (exact): CPU $0.00003942/physical-core-s (1 physical core = 2 vCPU), memory $0.00000672/GiB-s. Regional multipliers (1.25×–2.5×) compound. Volumes: 1 TiB/mo free, then $0.09/GiB/mo.",
+				"Sandbox non-preemptible rates (exact): CPU $0.00003942/s per requested cpu unit (observed to deliver 1 schedulable vCPU each, despite the docs calling it a physical core), memory $0.00000672/GiB-s. Regional multipliers (1.25×–2.5×) compound. Volumes: 1 TiB/mo free, then $0.09/GiB/mo.",
 			sourceUrl: "https://modal.com/pricing",
 		},
 		maturity: { status: "ga", notes: "scalableSandboxes enabled in the harness." },


### PR DESCRIPTION
Why realworld-better-auth failed everywhere but Daytona (run 29061549181):

Modal was benchmarked on HALF the CPU of every other provider. The docs call
`cpu`/`cpuLimit` physical cores (1 core = 2 vCPU), but a throughput probe
(dual-worker sha256, hard cpuLimit set) shows a requested unit delivers ONE
schedulable vCPU: cpu=1 -> nproc=1 at 264 MB/worker/8s; cpu=2 -> nproc=2 at
exactly 2x (512). Every task ran ~2x slow (lint_types 393s vs 173s after the
fix) and the suite blew its 60-min command budget at test 9/10. Pass
TARGET_SPEC.vcpus straight through, drop VCPUS_PER_PHYSICAL_CORE, and price
Modal's per-"core" rate per requested unit ($0.141912/vCPU-hr) to match what
parity actually bills. This re-lands the pass-through that #110's review
reverted, now with the limit+throughput evidence that nproc alone wasn't.

Scope note: this PR was split — it now carries ONLY the vCPU-parity and
pricing change. Its former companions are standalone PRs: the dead-sandbox
fast-fail is #132, the Modal 30-min sync-exec cap + better-auth budget bump
is #133, and the validating run's dataset/leaderboard publish is #134.

Validated in CI: dispatch run 29130741476 (providers daytona,modal) went
13/15 green with realworld-better-auth passing on BOTH providers — 17 metrics
each, all ten better-auth tasks included. The two red cells are infra, not
suites: mastra-on-modal lost its Depot runner at the ~64-min reclaim, and
openclaw-on-modal wedged inside oxlint under gVisor (tracked separately).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Run Modal at the full 2‑vCPU spec for provider parity and price its CPU per vCPU to match measured behavior. Aligns with ENG‑146.

- **Bug Fixes**
  - Provider parity: pass the 2‑vCPU target straight through to Modal `cpu`/`cpuLimit`; drop the `VCPUS_PER_PHYSICAL_CORE` factor; update adapter and `@providers` tests.
  - Pricing: set Modal to $0.141912/vCPU‑hr and update cost expectations in `@schema`.

<sup>Written for commit d56a339285e82eb1fcbe55f2ce2d1b303383cd00. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/starslingdev/sandbox-benchmarks/pull/121?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected Modal compute resource allocation so requested CPU capacity maps directly to the configured vCPU specification.
  * Updated Modal pricing calculations to accurately reflect the revised CPU capacity mapping.
  * Adjusted provider validation to match the corrected resource and cost calculations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
