### PR TITLE
Add Novita provider support via E2B-compatible API

### DIFF
--- a/.github/workflows/bench-matrix.yml
+++ b/.github/workflows/bench-matrix.yml
@@ -113,6 +113,7 @@ jobs:
           MODAL_TOKEN_SECRET: ${{ secrets.MODAL_TOKEN_SECRET }}
           BL_API_KEY: ${{ secrets.BL_API_KEY }}
           BL_WORKSPACE: ${{ secrets.BL_WORKSPACE }}
+          NOVITA_API_KEY: ${{ secrets.NOVITA_API_KEY }}
         run: bun apps/cli/src/bin/bench-suite.ts "$BENCH_PROVIDER" "$BENCH_SUITE" "$GITHUB_RUN_ID"
 
       - name: Upload Run + raw results

--- a/.github/workflows/bench-smoke.yml
+++ b/.github/workflows/bench-smoke.yml
@@ -10,7 +10,7 @@ on:
         description: Provider to benchmark
         type: choice
         default: daytona
-        options: [daytona, e2b, modal, blaxel]
+        options: [daytona, e2b, modal, blaxel, novita]
       suite:
         # Constrained to the SUITE_NAMES registry (packages/schema/src/suites.ts); the
         # workflow-registry-sync drift gate (tooling/repo-checks) keeps this list in lockstep, so a
@@ -94,6 +94,7 @@ jobs:
           MODAL_TOKEN_SECRET: ${{ secrets.MODAL_TOKEN_SECRET }}
           BL_API_KEY: ${{ secrets.BL_API_KEY }}
           BL_WORKSPACE: ${{ secrets.BL_WORKSPACE }}
+          NOVITA_API_KEY: ${{ secrets.NOVITA_API_KEY }}
         run: bun apps/cli/src/bin/bench-suite.ts "$BENCH_PROVIDER" "$BENCH_SUITE" "$GITHUB_RUN_ID"
 
       - name: Upload Run + raw results

--- a/.github/workflows/toolchain-image.yml
+++ b/.github/workflows/toolchain-image.yml
@@ -215,6 +215,9 @@ jobs:
           DAYTONA_TARGET: ${{ secrets.DAYTONA_TARGET || 'us-west-2' }}
           MODAL_TOKEN_ID: ${{ secrets.MODAL_TOKEN_ID }}
           MODAL_TOKEN_SECRET: ${{ secrets.MODAL_TOKEN_SECRET }}
+          # Bake the novita template on Novita's E2B-compatible control plane. Optional: a missing
+          # secret skips the novita bake (it is not in --require) without failing the publish.
+          NOVITA_API_KEY: ${{ secrets.NOVITA_API_KEY }}
         run: |
           set -euo pipefail
           # Declare then assign so the command substitution's exit status isn't masked (SC2155).
@@ -240,6 +243,9 @@ jobs:
           DAYTONA_TARGET: ${{ secrets.DAYTONA_TARGET || 'us-west-2' }}
           MODAL_TOKEN_ID: ${{ secrets.MODAL_TOKEN_ID }}
           MODAL_TOKEN_SECRET: ${{ secrets.MODAL_TOKEN_SECRET }}
+          # Bake the novita template on Novita's E2B-compatible control plane. Optional: a missing
+          # secret skips the novita bake (it is not in --require) without failing the publish.
+          NOVITA_API_KEY: ${{ secrets.NOVITA_API_KEY }}
           FORCE_REPUBLISH: ${{ inputs.force_republish }}
         # --require fails promote loudly if a required provider's secret is missing/misnamed, so the
         # public version is never published while a required provider's version artifact was silently

--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -29,6 +29,7 @@
     "@sandbox-benchmarks/harness": "workspace:*",
     "@sandbox-benchmarks/results": "workspace:*",
     "@daytona/sdk": "catalog:computesdk",
+    "e2b": "catalog:computesdk",
     "dotenv": "catalog:"
   },
   "devDependencies": {

--- a/apps/cli/src/bin/bake.ts
+++ b/apps/cli/src/bin/bake.ts
@@ -16,6 +16,7 @@ import { bakeDaytonaSnapshot } from "../lib/bake/daytona.ts";
 import { bakeE2bTemplate } from "../lib/bake/e2b.ts";
 import { buildAndPushCandidate } from "../lib/bake/image.ts";
 import { bakeModalImage } from "../lib/bake/modal.ts";
+import { bakeNovitaTemplate } from "../lib/bake/novita.ts";
 import { promoteAll } from "../lib/bake/promote.ts";
 import type { BakeReport, Log } from "../lib/bake/types.ts";
 import { candidateCreateOptions } from "../lib/bake/validate.ts";
@@ -31,11 +32,14 @@ const bakers: Record<ProviderId, (log: Log) => Promise<void>> = {
 	blaxel: async (log) => {
 		log("blaxel boots the stock base image — no candidate artifact to bake");
 	},
+	novita: (log) =>
+		bakeNovitaTemplate(config.novitaTemplateCandidate, config.toolchainImageCandidate, log),
 };
 
 const candidateRefs = {
 	e2bTemplateCandidate: config.e2bTemplateCandidate,
 	daytonaSnapshotCandidate: config.daytonaSnapshotCandidate,
+	novitaTemplateCandidate: config.novitaTemplateCandidate,
 	toolchainImageCandidate: config.toolchainImageCandidate,
 	daytonaTarget: config.daytona.target,
 };
@@ -55,6 +59,7 @@ if (import.meta.main) {
 						image: config.toolchainImageVersion,
 						e2bTemplate: config.e2bTemplateVersion,
 						daytonaSnapshot: config.daytonaSnapshotDefault,
+						novitaTemplate: config.novitaTemplateVersion,
 					},
 					reports: promoted,
 				},
@@ -130,6 +135,7 @@ if (import.meta.main) {
 					image: config.toolchainImageCandidate,
 					e2bTemplate: config.e2bTemplateCandidate,
 					daytonaSnapshot: config.daytonaSnapshotCandidate,
+					novitaTemplate: config.novitaTemplateCandidate,
 				},
 				reports,
 			},

--- a/apps/cli/src/lib/bake/e2b.ts
+++ b/apps/cli/src/lib/bake/e2b.ts
@@ -67,8 +67,17 @@ function writeE2bDockerfile(baseImage: string): void {
 }
 
 /** Build the e2b template `name` from `baseImage` (the candidate base while iterating, the published
- *  version base on promote — so the template provably derives from the validated bytes). */
-export async function bakeE2bTemplate(name: string, baseImage: string, log: Log): Promise<void> {
+ *  version base on promote — so the template provably derives from the validated bytes).
+ *
+ *  `envOverrides` re-points the CLI at an E2B-protocol-compatible control plane: the e2b CLI reads
+ *  E2B_API_KEY and E2B_DOMAIN from the environment, so the novita bake reuses this whole path (same
+ *  Dockerfile, same toml, same remote builder protocol) with only the credentials/domain swapped. */
+export async function bakeE2bTemplate(
+	name: string,
+	baseImage: string,
+	log: Log,
+	envOverrides: Record<string, string> = {},
+): Promise<void> {
 	// Keep the on-disk manifest's template_name in sync with the name we create, and pin the base.
 	writeFileSync(`${E2B_CONTEXT}/${E2B_TOML}`, e2bToml(name));
 	writeE2bDockerfile(baseImage);
@@ -90,7 +99,7 @@ export async function bakeE2bTemplate(name: string, baseImage: string, log: Log)
 			"--memory-mb",
 			String(config.targetSpec.memoryGb * 1024),
 		],
-		{ stdout: "inherit", stderr: "inherit", env: process.env },
+		{ stdout: "inherit", stderr: "inherit", env: { ...process.env, ...envOverrides } },
 	);
 	const code = await proc.exited;
 	if (code !== 0) throw new Error(`e2b template create exited ${code}`);

--- a/apps/cli/src/lib/bake/novita.ts
+++ b/apps/cli/src/lib/bake/novita.ts
@@ -1,23 +1,45 @@
-// Bake the novita template: the e2b bake pointed at Novita's E2B-protocol-compatible control plane.
-// Novita's compatibility API accepts the stock e2b CLI (their docs: set E2B_DOMAIN=sandbox.novita.ai
-// and E2B_API_KEY=<Novita key>), so template creation is bakeE2bTemplate verbatim — same committed
-// Dockerfile, same generated e2b.toml, same remote-builder protocol — with only the domain and
-// credentials swapped for the spawned CLI. The template lands in Novita's namespace (independent of
-// e2b.dev), which is why it can reuse the same version-scoped artifact name.
-import { config, NOVITA_E2B_DOMAIN } from "@sandbox-benchmarks/providers";
-import { bakeE2bTemplate } from "./e2b.ts";
+// Bake the novita template: the e2b SDK's Template API pointed at Novita's E2B-protocol-compatible
+// control plane. The spawned-CLI path the e2b bake uses is a dead end for Novita twice over —
+// @e2b/cli ≥ 2.12 rejects `nvta_…` keys client-side before any request is made, and Novita's
+// control plane 404s the CLI's build route on the bare domain — so this bakes programmatically via
+// `Template.build` against the REGIONAL domain (see NOVITA_E2B_DOMAIN), which serves the full v2
+// build surface (verified 2026-07-11: 34s remote build). `fromImage(baseImage)` templates straight
+// from the pushed candidate base ref; the e2b variant Dockerfile's only deltas (validate-base +
+// OCI labels) don't ride along, which is acceptable because the template still provably derives
+// from the same validated, registry-pinned bytes. The template lands in Novita's namespace
+// (independent of e2b.dev), which is why it can reuse the same version-scoped artifact name.
+import { config, novitaConnection } from "@sandbox-benchmarks/providers";
+import { Template } from "e2b";
 import type { Log } from "./types.ts";
 
 /** Build the novita template `name` from `baseImage` on Novita's control plane. */
 export async function bakeNovitaTemplate(name: string, baseImage: string, log: Log): Promise<void> {
 	const apiKey = config.novita.apiKey;
 	// The bake loop gates on requiredEnvVars before calling this, so a missing key here means the
-	// loop's contract broke — fail loudly rather than let the CLI fall back to an e2b.dev session.
+	// loop's contract broke — fail loudly rather than let the SDK fall back to an e2b.dev session.
 	if (!apiKey) throw new Error("NOVITA_API_KEY is required to bake the novita template");
 
-	log(`novita template create ${name} via ${NOVITA_E2B_DOMAIN} (base ${baseImage})`);
-	await bakeE2bTemplate(name, baseImage, log, {
-		E2B_DOMAIN: NOVITA_E2B_DOMAIN,
-		E2B_API_KEY: apiKey,
+	const connection = novitaConnection(apiKey);
+	log(`novita Template.build ${name} via ${connection.domain} (base ${baseImage})`);
+	// Mask the PTS phoromatic units at template-build time, mirroring the base image's own mask
+	// (packages/templates/images/base/scripts/20-pts.sh). Novita boots the image with systemd as
+	// PID 1 exactly like e2b, and an unmasked phoromatic-client POWERS OFF the guest at t+300s
+	// (probed 2026-07-11 on a live Novita sandbox: dead at exactly 5:00; masked → survives).
+	// Redundant-but-idempotent once the base image ships the mask — kept so the novita template is
+	// protected even when it's rebuilt from a candidate base that predates the base-image fix.
+	const template = Template()
+		.fromImage(baseImage)
+		.runCmd(
+			"for unit in phoromatic-client phoromatic-server phoronix-result-server; do " +
+				'ln -sf /dev/null "/etc/systemd/system/$unit.service"; done',
+			// Build steps run as the template's default user; /etc needs root.
+			{ user: "root" },
+		);
+	const info = await Template.build(template, name, {
+		...connection,
+		cpuCount: config.targetSpec.vcpus,
+		memoryMB: config.targetSpec.memoryGb * 1024,
+		onBuildLogs: (entry) => log(String(entry)),
 	});
+	log(`novita template built: ${info.templateId} (build ${info.buildId})`);
 }

--- a/apps/cli/src/lib/bake/novita.ts
+++ b/apps/cli/src/lib/bake/novita.ts
@@ -1,0 +1,23 @@
+// Bake the novita template: the e2b bake pointed at Novita's E2B-protocol-compatible control plane.
+// Novita's compatibility API accepts the stock e2b CLI (their docs: set E2B_DOMAIN=sandbox.novita.ai
+// and E2B_API_KEY=<Novita key>), so template creation is bakeE2bTemplate verbatim — same committed
+// Dockerfile, same generated e2b.toml, same remote-builder protocol — with only the domain and
+// credentials swapped for the spawned CLI. The template lands in Novita's namespace (independent of
+// e2b.dev), which is why it can reuse the same version-scoped artifact name.
+import { config, NOVITA_E2B_DOMAIN } from "@sandbox-benchmarks/providers";
+import { bakeE2bTemplate } from "./e2b.ts";
+import type { Log } from "./types.ts";
+
+/** Build the novita template `name` from `baseImage` on Novita's control plane. */
+export async function bakeNovitaTemplate(name: string, baseImage: string, log: Log): Promise<void> {
+	const apiKey = config.novita.apiKey;
+	// The bake loop gates on requiredEnvVars before calling this, so a missing key here means the
+	// loop's contract broke — fail loudly rather than let the CLI fall back to an e2b.dev session.
+	if (!apiKey) throw new Error("NOVITA_API_KEY is required to bake the novita template");
+
+	log(`novita template create ${name} via ${NOVITA_E2B_DOMAIN} (base ${baseImage})`);
+	await bakeE2bTemplate(name, baseImage, log, {
+		E2B_DOMAIN: NOVITA_E2B_DOMAIN,
+		E2B_API_KEY: apiKey,
+	});
+}

--- a/apps/cli/src/lib/bake/promote.ts
+++ b/apps/cli/src/lib/bake/promote.ts
@@ -27,6 +27,7 @@ import { forEachProviderWithCreds } from "../providers-run.ts";
 import { bakeDaytonaSnapshot } from "./daytona.ts";
 import { bakeE2bTemplate } from "./e2b.ts";
 import { imageExistsInRegistry, promoteImage } from "./image.ts";
+import { bakeNovitaTemplate } from "./novita.ts";
 import type { BakeReport, Log } from "./types.ts";
 import type { CandidateRefs } from "./validate.ts";
 import { validateCandidates } from "./validate-run.ts";
@@ -72,6 +73,7 @@ export async function promoteAll(log: Log, force = false): Promise<BakeReport[]>
 	const candidateRefs: CandidateRefs = {
 		e2bTemplateCandidate: config.e2bTemplateCandidate,
 		daytonaSnapshotCandidate: config.daytonaSnapshotCandidate,
+		novitaTemplateCandidate: config.novitaTemplateCandidate,
 		toolchainImageCandidate: config.toolchainImageCandidate,
 		daytonaTarget: config.daytona.target,
 	};
@@ -118,6 +120,13 @@ export async function promoteAll(log: Log, force = false): Promise<BakeReport[]>
 					break;
 				case "blaxel":
 					log("    blaxel boots the stock base image — nothing to promote");
+					break;
+				case "novita":
+					await bakeNovitaTemplate(
+						config.novitaTemplateVersion,
+						config.toolchainImageCandidate,
+						(m) => log(`    ${m}`),
+					);
 					break;
 				default: {
 					// Exhaustiveness: a new ProviderId must add a promote branch above (compile error here).

--- a/apps/cli/src/lib/bake/validate.test.ts
+++ b/apps/cli/src/lib/bake/validate.test.ts
@@ -5,7 +5,8 @@ import { candidateCreateOptions } from "./validate.ts";
 const refs: CandidateRefs = {
 	e2bTemplateCandidate: "tc-v1-candidate",
 	daytonaSnapshotCandidate: "snap-v1-candidate",
-	novitaTemplateCandidate: "tc-v1-candidate",
+	// Distinct from the e2b value so the novita case fails if it ever reads the e2b field.
+	novitaTemplateCandidate: "tc-v1-novita-candidate",
 	toolchainImageCandidate: "ghcr.io/o/tc:v1-candidate",
 	daytonaTarget: "zen5",
 };
@@ -29,7 +30,9 @@ describe("candidateCreateOptions", () => {
 	});
 
 	it("points novita at its candidate template via snapshotId (e2b mapping, Novita's control plane)", () => {
-		expect(candidateCreateOptions("novita", refs)).toEqual({ snapshotId: "tc-v1-candidate" });
+		expect(candidateCreateOptions("novita", refs)).toEqual({
+			snapshotId: "tc-v1-novita-candidate",
+		});
 	});
 
 	it("points modal at the candidate image via templateId", () => {

--- a/apps/cli/src/lib/bake/validate.test.ts
+++ b/apps/cli/src/lib/bake/validate.test.ts
@@ -5,6 +5,7 @@ import { candidateCreateOptions } from "./validate.ts";
 const refs: CandidateRefs = {
 	e2bTemplateCandidate: "tc-v1-candidate",
 	daytonaSnapshotCandidate: "snap-v1-candidate",
+	novitaTemplateCandidate: "tc-v1-candidate",
 	toolchainImageCandidate: "ghcr.io/o/tc:v1-candidate",
 	daytonaTarget: "zen5",
 };
@@ -25,6 +26,10 @@ describe("candidateCreateOptions", () => {
 		expect(candidateCreateOptions("daytona", { ...refs, daytonaTarget: undefined })).toEqual({
 			snapshotId: "snap-v1-candidate",
 		});
+	});
+
+	it("points novita at its candidate template via snapshotId (e2b mapping, Novita's control plane)", () => {
+		expect(candidateCreateOptions("novita", refs)).toEqual({ snapshotId: "tc-v1-candidate" });
 	});
 
 	it("points modal at the candidate image via templateId", () => {

--- a/apps/cli/src/lib/bake/validate.ts
+++ b/apps/cli/src/lib/bake/validate.ts
@@ -6,6 +6,8 @@ import type { ProviderId } from "@sandbox-benchmarks/schema";
 export interface CandidateRefs {
 	e2bTemplateCandidate: string;
 	daytonaSnapshotCandidate: string;
+	/** Candidate template on Novita's E2B-compatible control plane (its own namespace). */
+	novitaTemplateCandidate: string;
 	toolchainImageCandidate: string;
 	/** Daytona runner target for the active region (undefined → account default). */
 	daytonaTarget?: string;
@@ -30,5 +32,8 @@ export function candidateCreateOptions(
 		case "blaxel":
 			// Stock base image — no candidate artifact to point at.
 			return {};
+		case "novita":
+			// Same mapping as e2b (snapshotId → template name), against Novita's control plane.
+			return { snapshotId: refs.novitaTemplateCandidate };
 	}
 }

--- a/bun.lock
+++ b/bun.lock
@@ -35,6 +35,7 @@
         "@sandbox-benchmarks/schema": "workspace:*",
         "@sandbox-benchmarks/templates": "workspace:*",
         "dotenv": "catalog:",
+        "e2b": "catalog:computesdk",
       },
       "devDependencies": {
         "@repo/tsconfig": "workspace:*",

--- a/bun.lock
+++ b/bun.lock
@@ -63,9 +63,11 @@
         "@computesdk/daytona": "catalog:computesdk",
         "@computesdk/e2b": "catalog:computesdk",
         "@computesdk/modal": "catalog:computesdk",
+        "@computesdk/provider": "catalog:computesdk",
         "@sandbox-benchmarks/schema": "workspace:*",
         "arktype": "catalog:",
         "computesdk": "catalog:computesdk",
+        "e2b": "catalog:computesdk",
       },
       "devDependencies": {
         "@repo/tsconfig": "workspace:*",
@@ -161,8 +163,10 @@
       "@computesdk/daytona": "1.7.31",
       "@computesdk/e2b": "1.7.51",
       "@computesdk/modal": "1.9.3",
+      "@computesdk/provider": "2.1.3",
       "@daytona/sdk": "0.192.0",
       "computesdk": "4.1.3",
+      "e2b": "2.27.1",
     },
     "xml": {
       "@nodable/compact-builder": "1.0.9",

--- a/package.json
+++ b/package.json
@@ -20,8 +20,10 @@
         "@computesdk/daytona": "1.7.31",
         "@computesdk/e2b": "1.7.51",
         "@computesdk/modal": "1.9.3",
+        "@computesdk/provider": "2.1.3",
         "@daytona/sdk": "0.192.0",
-        "computesdk": "4.1.3"
+        "computesdk": "4.1.3",
+        "e2b": "2.27.1"
       },
       "xml": {
         "@nodable/compact-builder": "1.0.9",

--- a/packages/providers/package.json
+++ b/packages/providers/package.json
@@ -15,9 +15,11 @@
     "@computesdk/daytona": "catalog:computesdk",
     "@computesdk/e2b": "catalog:computesdk",
     "@computesdk/modal": "catalog:computesdk",
+    "@computesdk/provider": "catalog:computesdk",
     "@sandbox-benchmarks/schema": "workspace:*",
     "arktype": "catalog:",
-    "computesdk": "catalog:computesdk"
+    "computesdk": "catalog:computesdk",
+    "e2b": "catalog:computesdk"
   },
   "devDependencies": {
     "@repo/tsconfig": "workspace:*",

--- a/packages/providers/src/index.test.ts
+++ b/packages/providers/src/index.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "bun:test";
 import { PROVIDERS, TARGET_SPEC, VCPUS_PER_PHYSICAL_CORE } from "@sandbox-benchmarks/schema";
-import { config, providers } from "./index.ts";
+import { config, novitaCompute, providers } from "./index.ts";
 import { assertProviderJoin } from "./lib/join.ts";
 
 describe("@sandbox-benchmarks/providers", () => {
@@ -37,6 +37,34 @@ describe("@sandbox-benchmarks/providers", () => {
 			memoryMiB: TARGET_SPEC.memoryGb * 1024,
 			memoryLimitMiB: TARGET_SPEC.memoryGb * 1024,
 		});
+	});
+
+	it("re-points the e2b wrapper at Novita without the e2b_ key-format guard", () => {
+		// Construction must accept an nvta_-prefixed key (the stock wrapper's create() rejects those)
+		// and still expose the universal manager surface the harness drives, with the mispointed
+		// snapshot/template managers removed (their every call would reconnect to e2b.dev). This also
+		// exercises the patch's runtime shape assertion, so a wrapper upgrade that moves the internal
+		// methods table fails here instead of mid-run.
+		const compute = novitaCompute("nvta_unit-test-key");
+		expect(typeof compute.sandbox.create).toBe("function");
+		expect(typeof compute.sandbox.destroy).toBe("function");
+		expect(typeof compute.sandbox.list).toBe("function");
+		expect(compute.snapshot).toBeUndefined();
+		// `template` is a runtime property of the generated provider (computesdk's type doesn't model
+		// it), so reach through a structural cast to pin its removal too.
+		expect((compute as { template?: unknown }).template).toBeUndefined();
+	});
+
+	it("boots novita from the configured template, erroring on use — not import — without a key", () => {
+		const novita = providers.find((p) => p.name === "novita");
+		expect(novita).toBeDefined();
+		expect(novita?.requiredEnvVars).toEqual(["NOVITA_API_KEY"]);
+		expect(novita?.createOptions?.snapshotId).toBe(config.novitaTemplate);
+		// The registry module must stay importable without credentials; the factory throws only when
+		// the harness actually selects the provider (after its requiredEnvVars gate).
+		if (!process.env.NOVITA_API_KEY) {
+			expect(() => novita?.createCompute()).toThrow(/NOVITA_API_KEY/);
+		}
 	});
 
 	it("boots e2b from the configured template and daytona from the configured snapshot", () => {

--- a/packages/providers/src/index.test.ts
+++ b/packages/providers/src/index.test.ts
@@ -1,4 +1,7 @@
 import { describe, expect, it } from "bun:test";
+// The stock wrapper factory, imported so the novita test can prove the connection methods were
+// actually REPLACED (identity inequality against an unpatched instance's methods table).
+import { e2b } from "@computesdk/e2b";
 import { PROVIDERS, TARGET_SPEC, VCPUS_PER_PHYSICAL_CORE } from "@sandbox-benchmarks/schema";
 import { config, novitaCompute, providers } from "./index.ts";
 import { assertProviderJoin } from "./lib/join.ts";
@@ -40,15 +43,25 @@ describe("@sandbox-benchmarks/providers", () => {
 	});
 
 	it("re-points the e2b wrapper at Novita without the e2b_ key-format guard", () => {
-		// Construction must accept an nvta_-prefixed key (the stock wrapper's create() rejects those)
-		// and still expose the universal manager surface the harness drives, with the mispointed
-		// snapshot/template managers removed (their every call would reconnect to e2b.dev). This also
-		// exercises the patch's runtime shape assertion, so a wrapper upgrade that moves the internal
-		// methods table fails here instead of mid-run.
+		// Construction must accept an nvta_-prefixed key and still expose the universal manager surface
+		// the harness drives, with the mispointed snapshot/template managers removed (their every call
+		// would reconnect to e2b.dev). This also exercises the patch's runtime shape assertion, so a
+		// wrapper upgrade that moves the internal methods table fails here instead of mid-run.
 		const compute = novitaCompute("nvta_unit-test-key");
 		expect(typeof compute.sandbox.create).toBe("function");
 		expect(typeof compute.sandbox.destroy).toBe("function");
 		expect(typeof compute.sandbox.list).toBe("function");
+		// The stock wrapper's connection methods (whose create() enforces the e2b_ prefix and whose
+		// every call omits the domain) must have been REPLACED, not just still-callable — a stock
+		// `create` is also `typeof "function"`, so compare the internal methods table against an
+		// unpatched wrapper's by identity. Reaches the same internal seam the patch itself asserts.
+		const methodsOf = (p: unknown) =>
+			(p as { sandbox: { methods: Record<string, unknown> } }).sandbox.methods;
+		const stock = methodsOf(e2b({ apiKey: "e2b_unit-test-key" }));
+		const patched = methodsOf(compute);
+		for (const method of ["create", "getById", "destroy", "list"] as const) {
+			expect(patched[method]).not.toBe(stock[method]);
+		}
 		expect(compute.snapshot).toBeUndefined();
 		// `template` is a runtime property of the generated provider (computesdk's type doesn't model
 		// it), so reach through a structural cast to pin its removal too.

--- a/packages/providers/src/index.ts
+++ b/packages/providers/src/index.ts
@@ -11,7 +11,7 @@ import type { ProviderConfig } from "./lib/types.ts";
 export { config } from "./lib/config.ts";
 // Novita's E2B-compat surface: the domain the bake pipeline points the e2b CLI at, and the compat
 // factory (exported for tests and for anyone driving Novita outside the harness join).
-export { NOVITA_E2B_DOMAIN, novitaCompute } from "./lib/novita.ts";
+export { NOVITA_E2B_DOMAIN, novitaCompute, novitaConnection } from "./lib/novita.ts";
 export type { DirectProvider, ProviderAdapter, ProviderConfig } from "./lib/types.ts";
 
 /**

--- a/packages/providers/src/index.ts
+++ b/packages/providers/src/index.ts
@@ -9,6 +9,9 @@ import type { ProviderConfig } from "./lib/types.ts";
 
 // The runtime configuration gatekeeper — the single validated config object consumers import.
 export { config } from "./lib/config.ts";
+// Novita's E2B-compat surface: the domain the bake pipeline points the e2b CLI at, and the compat
+// factory (exported for tests and for anyone driving Novita outside the harness join).
+export { NOVITA_E2B_DOMAIN, novitaCompute } from "./lib/novita.ts";
 export type { DirectProvider, ProviderAdapter, ProviderConfig } from "./lib/types.ts";
 
 /**

--- a/packages/providers/src/lib/adapters.ts
+++ b/packages/providers/src/lib/adapters.ts
@@ -10,6 +10,7 @@ import { modal } from "@computesdk/modal";
 import type { ProviderId } from "@sandbox-benchmarks/schema";
 import { TARGET_SPEC, VCPUS_PER_PHYSICAL_CORE } from "@sandbox-benchmarks/schema";
 import { config } from "./config.ts";
+import { novitaCompute } from "./novita.ts";
 import type { ProviderAdapter } from "./types.ts";
 
 // The daytona account/target (key/target/snapshot), resolved by the config gatekeeper. Named
@@ -71,5 +72,13 @@ export const adapters: Record<ProviderId, ProviderAdapter> = {
 			memoryMiB: TARGET_SPEC.memoryGb * 1024,
 			memoryLimitMiB: TARGET_SPEC.memoryGb * 1024,
 		},
+	},
+	novita: {
+		// The e2b wrapper re-pointed at Novita's E2B-compatible control plane (sandbox.novita.ai) —
+		// see novita.ts for exactly what is swapped and why. Boots the pre-baked toolchain template
+		// the bake pipeline creates on Novita via the same e2b CLI (computesdk maps snapshotId → the
+		// template name); cpu/memory are pinned at template create, not per-sandbox.
+		createCompute: () => novitaCompute(config.novita.apiKey),
+		createOptions: { snapshotId: config.novitaTemplate },
 	},
 };

--- a/packages/providers/src/lib/config.ts
+++ b/packages/providers/src/lib/config.ts
@@ -15,6 +15,8 @@ const envSchema = type({
 	"DAYTONA_API_KEY?": "string >= 1",
 	"DAYTONA_TARGET?": "string >= 1",
 	"DAYTONA_SNAPSHOT?": "string >= 1",
+	"NOVITA_API_KEY?": "string >= 1",
+	"NOVITA_TEMPLATE?": "string >= 1",
 });
 
 const ENV_KEYS = [
@@ -23,18 +25,32 @@ const ENV_KEYS = [
 	"DAYTONA_API_KEY",
 	"DAYTONA_TARGET",
 	"DAYTONA_SNAPSHOT",
+	"NOVITA_API_KEY",
+	"NOVITA_TEMPLATE",
 ] as const;
 
 // 2. Startup gatekeeper — validate the environment once, fail fast with a clear message. Only the
-//    keys we declare are forwarded (process.env carries hundreds of unrelated ones).
+//    keys we declare are forwarded (process.env carries hundreds of unrelated ones). A set-but-EMPTY
+//    value is treated as unset, not a misconfiguration: GitHub Actions materializes an unconfigured
+//    secret as an empty-string env var (`FOO: ${{ secrets.MISSING }}` sets FOO=""), so throwing here
+//    would crash EVERY provider's bench job at module load the moment one optional secret is
+//    unsynced — the exact hazard the workflows' `DAYTONA_TARGET || 'us-west-2'` default papered
+//    over. Empty ⇒ unset keeps a missing credential what it is everywhere else in the harness
+//    (missingCreds treats "" as missing): a downstream skip decision, never an import-time crash.
 const rawEnv: Record<string, string> = {};
 for (const key of ENV_KEYS) {
 	const value = process.env[key];
-	if (value !== undefined) rawEnv[key] = value;
+	if (value !== undefined && value !== "") rawEnv[key] = value;
 }
 const env = envSchema(rawEnv);
 if (env instanceof type.errors) {
 	throw new Error(`Invalid configuration: ${env.summary}`);
+}
+
+/** The Novita account the novita adapter boots from (via the E2B-compatible API). */
+export interface NovitaConfig {
+	/** Novita API key (`nvta_…`), sent to Novita's E2B-compatible API at sandbox.novita.ai. */
+	apiKey?: string;
 }
 
 /** The daytona account/target the adapter boots from. Single-region: the base DAYTONA_* env vars. */
@@ -61,6 +77,10 @@ const e2bTemplateVersion = `${TOOLCHAIN_IMAGE_NAME}-${TOOLCHAIN_VERSION}`;
 const e2bTemplateCandidate = `${e2bTemplateVersion}${CANDIDATE_SUFFIX}`;
 const daytonaSnapshotDefault = `${TOOLCHAIN_IMAGE_NAME}-${TOOLCHAIN_VERSION}`;
 const daytonaSnapshotCandidate = `${daytonaSnapshotDefault}${CANDIDATE_SUFFIX}`;
+// The novita template lives on Novita's E2B-compatible control plane (a separate namespace from
+// e2b.dev), so it reuses the same version-scoped artifact name as the e2b template.
+const novitaTemplateVersion = `${TOOLCHAIN_IMAGE_NAME}-${TOOLCHAIN_VERSION}`;
+const novitaTemplateCandidate = `${novitaTemplateVersion}${CANDIDATE_SUFFIX}`;
 
 // 3. The single, fully-typed config object. Everything that needs config imports THIS.
 export const config = {
@@ -94,4 +114,15 @@ export const config = {
 		target: env.DAYTONA_TARGET,
 		snapshot: env.DAYTONA_SNAPSHOT ?? daytonaSnapshotDefault,
 	} satisfies DaytonaConfig,
+	/** The novita template the sandbox boots from (on Novita's control plane); `NOVITA_TEMPLATE`
+	 *  override, else the version-scoped public template. */
+	novitaTemplate: env.NOVITA_TEMPLATE ?? novitaTemplateVersion,
+	/** Public (version-scoped) novita template name; the promote target. */
+	novitaTemplateVersion,
+	/** Candidate novita template name the bake builds while iterating. */
+	novitaTemplateCandidate,
+	/** The Novita account the adapter and bake boot from (E2B-protocol-compatible control plane). */
+	novita: {
+		apiKey: env.NOVITA_API_KEY,
+	} satisfies NovitaConfig,
 } as const;

--- a/packages/providers/src/lib/config.ts
+++ b/packages/providers/src/lib/config.ts
@@ -78,8 +78,9 @@ const e2bTemplateCandidate = `${e2bTemplateVersion}${CANDIDATE_SUFFIX}`;
 const daytonaSnapshotDefault = `${TOOLCHAIN_IMAGE_NAME}-${TOOLCHAIN_VERSION}`;
 const daytonaSnapshotCandidate = `${daytonaSnapshotDefault}${CANDIDATE_SUFFIX}`;
 // The novita template lives on Novita's E2B-compatible control plane (a separate namespace from
-// e2b.dev), so it reuses the same version-scoped artifact name as the e2b template.
-const novitaTemplateVersion = `${TOOLCHAIN_IMAGE_NAME}-${TOOLCHAIN_VERSION}`;
+// e2b.dev), so it reuses the same version-scoped artifact name as the e2b template — aliased, not
+// recomputed, so a change to the e2b naming formula can't silently break the shared-name invariant.
+const novitaTemplateVersion = e2bTemplateVersion;
 const novitaTemplateCandidate = `${novitaTemplateVersion}${CANDIDATE_SUFFIX}`;
 
 // 3. The single, fully-typed config object. Everything that needs config imports THIS.

--- a/packages/providers/src/lib/novita.ts
+++ b/packages/providers/src/lib/novita.ts
@@ -24,7 +24,7 @@ import type { CreateSandboxOptions } from "computesdk";
 // The raw e2b SDK, depended on directly: `@computesdk/e2b` re-exports it as `E2BSandbox` in its type
 // declarations only — the runtime ESM build ships just the factory — so the re-export can't be used.
 import type { SandboxConnectOpts, SandboxOpts } from "e2b";
-import { Sandbox as E2BSandbox } from "e2b";
+import { Sandbox as E2BSandbox, SandboxNotFoundError } from "e2b";
 import type { DirectProvider } from "./types.ts";
 
 /** Novita's E2B-compatible control-plane domain (what their docs set E2B_DOMAIN to). The bake
@@ -105,12 +105,14 @@ export function novitaCompute(apiKey: string | undefined): DirectProvider {
 			return { sandbox, sandboxId: sandbox.sandboxId };
 		},
 		getById: async (_config, sandboxId) => {
-			// "Not found" is a legitimate null; anything else (network, auth) propagates.
+			// Only a genuinely missing sandbox is the contract's `null`; anything else (auth, network)
+			// propagates — folding those into null would mask an invalid key or an outage as "not found".
 			try {
 				const sandbox = await E2BSandbox.connect(sandboxId, connection);
 				return { sandbox, sandboxId };
-			} catch {
-				return null;
+			} catch (error) {
+				if (error instanceof SandboxNotFoundError) return null;
+				throw error;
 			}
 		},
 		// One domain-aware DELETE via the SDK's static kill — no connect round-trip first (connect

--- a/packages/providers/src/lib/novita.ts
+++ b/packages/providers/src/lib/novita.ts
@@ -4,8 +4,9 @@
 //
 // Two wrapper behaviours stand in the way, both confined to the config-taking connection methods:
 //
-//   1. `create()` rejects any key that doesn't start with `e2b_` (a client-side format guard), and
-//      Novita keys are `nvta_…`-prefixed.
+//   1. Both the wrapper's `create()` AND the raw e2b SDK's ApiClient reject any key that doesn't
+//      match `e2b_<hex>` (client-side format guards), and Novita keys are `nvta_…`-prefixed — see
+//      {@link novitaConnection} for the placeholder-plus-header-override that clears both.
 //   2. Every other connection method reaches the control plane via `{ apiKey }` with no `domain`,
 //      so it would hit e2b.dev instead of Novita (the e2b SDK only falls back to the E2B_DOMAIN env
 //      var, and mutating process-wide env from one provider's adapter would leak into a
@@ -27,9 +28,29 @@ import type { SandboxConnectOpts, SandboxOpts } from "e2b";
 import { Sandbox as E2BSandbox, SandboxNotFoundError } from "e2b";
 import type { DirectProvider } from "./types.ts";
 
-/** Novita's E2B-compatible control-plane domain (what their docs set E2B_DOMAIN to). The bake
- *  pipeline points the e2b CLI at the same domain to create the toolchain template there. */
-export const NOVITA_E2B_DOMAIN = "sandbox.novita.ai";
+/** Novita's E2B-compatible control-plane domain. REGIONAL, not the bare `sandbox.novita.ai` their
+ *  docs open with: the bare domain serves only a legacy slice of the API (template list works; the
+ *  v2 template-build routes 404 with "no matching operation was found"), while the regional domain
+ *  serves the full surface (probed 2026-07-11: an identical Template.build 404s on the bare domain
+ *  and succeeds on us-phx-1). Templates and sandboxes are region-scoped, so the bake and the
+ *  harness must agree on this value. */
+export const NOVITA_E2B_DOMAIN = "us-phx-1.sandbox.novita.ai";
+
+/** A dummy key matching the e2b SDK's client-side `e2b_<hex>` format check. The SDK validates
+ *  `apiKey`'s SHAPE before any request (ApiClient), so Novita's `nvta_…` keys throw locally — but
+ *  it spreads `headers` AFTER the `X-API-KEY` header it derives from `apiKey`, so the real Novita
+ *  credential rides a header override while this placeholder satisfies the format guard. */
+export const E2B_KEY_FORMAT_PLACEHOLDER = `e2b_${"0".repeat(40)}`;
+
+/** The connection options that authenticate against Novita despite the e2b SDK's key-shape guard:
+ *  placeholder `apiKey` for the client-side check, real key via the `X-API-KEY` header override. */
+export function novitaConnection(apiKey: string): SandboxConnectOpts {
+	return {
+		apiKey: E2B_KEY_FORMAT_PLACEHOLDER,
+		headers: { "X-API-KEY": apiKey },
+		domain: NOVITA_E2B_DOMAIN,
+	};
+}
 
 /** The connection-method half of the wrapper framework's sandbox method table — the exact slice
  *  this module replaces, typed by the framework so a wrapper upgrade that changes a signature is a
@@ -68,7 +89,7 @@ export function novitaCompute(apiKey: string | undefined): DirectProvider {
 	if (!apiKey) {
 		throw new Error("NOVITA_API_KEY is required to construct the novita provider");
 	}
-	const connection: SandboxConnectOpts = { apiKey, domain: NOVITA_E2B_DOMAIN };
+	const connection: SandboxConnectOpts = novitaConnection(apiKey);
 
 	const overrides: ConnectionMethods = {
 		// The wrapper's create minus the `e2b_` prefix guard, with Novita's domain pinned. Mirrors the
@@ -125,7 +146,10 @@ export function novitaCompute(apiKey: string | undefined): DirectProvider {
 		},
 		// The wrapper's list with the domain pinned — the harness's control-plane probe rides this.
 		// Deliberately NOT swallowing errors into [] (the stock wrapper does): a failed enumeration
-		// must surface as a probe skip, not publish a fast fake "success" sample.
+		// must surface as a probe skip, not publish a fast fake "success" sample. Single page on
+		// purpose, too: the lifecycle benchmark times ONE list round-trip as the control-plane-read
+		// metric — draining the paginator would time N requests and skew the sample (and nothing
+		// downstream enumerates sandboxes for cleanup; teardown works by id).
 		list: async (_config) => {
 			const paginator = E2BSandbox.list(connection);
 			const items = await paginator.nextItems();

--- a/packages/providers/src/lib/novita.ts
+++ b/packages/providers/src/lib/novita.ts
@@ -1,0 +1,147 @@
+// Novita's control plane speaks the E2B protocol (their docs: E2B_DOMAIN=sandbox.novita.ai +
+// E2B_API_KEY=<Novita key>), so the harness reuses the whole `@computesdk/e2b` wrapper — runCommand
+// with daemon-backed streaming, filesystem, the lot — rather than growing a parallel adapter.
+//
+// Two wrapper behaviours stand in the way, both confined to the config-taking connection methods:
+//
+//   1. `create()` rejects any key that doesn't start with `e2b_` (a client-side format guard), and
+//      Novita keys are `nvta_…`-prefixed.
+//   2. Every other connection method reaches the control plane via `{ apiKey }` with no `domain`,
+//      so it would hit e2b.dev instead of Novita (the e2b SDK only falls back to the E2B_DOMAIN env
+//      var, and mutating process-wide env from one provider's adapter would leak into a
+//      same-process e2b run).
+//
+// Everything else the harness touches (runCommand, filesystem, getInfo) operates on the live sandbox
+// INSTANCE returned by create — which already carries Novita's domain — so this module swaps the
+// config-taking connection methods (create/getById/destroy/list) for domain-aware, guard-free
+// equivalents typed against the wrapper framework's own `SandboxMethods` contract, and removes the
+// snapshot/template managers outright: their every method reconnects without a domain, and absent
+// managers read downstream as a clean "provider exposes no snapshot operation" skip instead of a
+// misleading failure against the wrong control plane.
+import { e2b } from "@computesdk/e2b";
+import type { SandboxMethods } from "@computesdk/provider";
+import type { CreateSandboxOptions } from "computesdk";
+// The raw e2b SDK, depended on directly: `@computesdk/e2b` re-exports it as `E2BSandbox` in its type
+// declarations only — the runtime ESM build ships just the factory — so the re-export can't be used.
+import type { SandboxConnectOpts, SandboxOpts } from "e2b";
+import { Sandbox as E2BSandbox } from "e2b";
+import type { DirectProvider } from "./types.ts";
+
+/** Novita's E2B-compatible control-plane domain (what their docs set E2B_DOMAIN to). The bake
+ *  pipeline points the e2b CLI at the same domain to create the toolchain template there. */
+export const NOVITA_E2B_DOMAIN = "sandbox.novita.ai";
+
+/** The connection-method half of the wrapper framework's sandbox method table — the exact slice
+ *  this module replaces, typed by the framework so a wrapper upgrade that changes a signature is a
+ *  compile error here, not a runtime surprise. */
+type ConnectionMethods = Pick<
+	SandboxMethods<E2BSandbox>,
+	"create" | "getById" | "destroy" | "list"
+>;
+
+/** The internal seam the patch reaches through: the generated sandbox manager dispatches every call
+ *  via its `methods` table. Internal to @computesdk/provider, so asserted at runtime
+ *  ({@link assertPatchable}) rather than trusted blindly across upgrades. */
+interface PatchableManager {
+	methods: ConnectionMethods & Record<string, unknown>;
+}
+
+function assertPatchable(manager: unknown): asserts manager is PatchableManager {
+	const methods = (manager as { methods?: Record<string, unknown> })?.methods;
+	for (const method of ["create", "getById", "destroy", "list"] as const) {
+		if (typeof methods?.[method] !== "function") {
+			throw new Error(
+				"@computesdk/e2b provider internals changed shape (sandbox manager has no patchable " +
+					`${method} method); revisit the novita adapter against the upgraded wrapper`,
+			);
+		}
+	}
+}
+
+/**
+ * A computesdk provider for Novita: the `@computesdk/e2b` provider with its config-taking
+ * connection methods re-pointed at Novita's domain and freed of the `e2b_` key-format guard.
+ * Construction is lazy-credentialed like every other factory — the missing-key error only fires
+ * when the harness actually selects the provider (it gates on NOVITA_API_KEY before that).
+ */
+export function novitaCompute(apiKey: string | undefined): DirectProvider {
+	if (!apiKey) {
+		throw new Error("NOVITA_API_KEY is required to construct the novita provider");
+	}
+	const connection: SandboxConnectOpts = { apiKey, domain: NOVITA_E2B_DOMAIN };
+
+	const overrides: ConnectionMethods = {
+		// The wrapper's create minus the `e2b_` prefix guard, with Novita's domain pinned. Mirrors the
+		// wrapper's option handling — including the open `...providerOptions` passthrough that
+		// computesdk's CreateSandboxOptions models with its index signature — but spreads the
+		// connection LAST, so no stray `domain`/`apiKey` riding providerOptions can silently re-point
+		// creation at e2b.dev with the nvta_ key. An undefined `timeoutMs` defers to the SDK's own
+		// default.
+		create: async (_config, options?: CreateSandboxOptions) => {
+			const {
+				timeout,
+				envs,
+				metadata,
+				templateId,
+				snapshotId,
+				sandboxId: _sandboxId,
+				name: _name,
+				namespace: _namespace,
+				directory: _directory,
+				...providerOptions
+			} = options ?? {};
+			const createOpts: SandboxOpts = {
+				timeoutMs: timeout,
+				envs,
+				metadata,
+				...providerOptions,
+				...connection,
+			};
+			const template = templateId ?? snapshotId;
+			const sandbox = template
+				? await E2BSandbox.create(template, createOpts)
+				: await E2BSandbox.create(createOpts);
+			if (!sandbox.sandboxId) throw new Error("Novita create() returned sandbox without an ID");
+			return { sandbox, sandboxId: sandbox.sandboxId };
+		},
+		getById: async (_config, sandboxId) => {
+			// "Not found" is a legitimate null; anything else (network, auth) propagates.
+			try {
+				const sandbox = await E2BSandbox.connect(sandboxId, connection);
+				return { sandbox, sandboxId };
+			} catch {
+				return null;
+			}
+		},
+		// One domain-aware DELETE via the SDK's static kill — no connect round-trip first (connect
+		// also re-extends the sandbox timeout as a side effect, pure waste on a teardown path the
+		// lifecycle benchmark TIMES). `kill` resolves false when the sandbox is already gone (the
+		// legitimate best-effort case); a real control-plane failure REJECTS and propagates, so the
+		// harness records a teardown failure instead of a fake success over a leaked, billing sandbox.
+		destroy: async (_config, sandboxId) => {
+			await E2BSandbox.kill(sandboxId, connection);
+		},
+		// The wrapper's list with the domain pinned — the harness's control-plane probe rides this.
+		// Deliberately NOT swallowing errors into [] (the stock wrapper does): a failed enumeration
+		// must surface as a probe skip, not publish a fast fake "success" sample.
+		list: async (_config) => {
+			const paginator = E2BSandbox.list(connection);
+			const items = await paginator.nextItems();
+			return items.map((info) => ({
+				sandbox: info as unknown as E2BSandbox,
+				sandboxId: info.sandboxId,
+			}));
+		},
+	};
+
+	const compute = e2b({ apiKey });
+	const manager: unknown = compute.sandbox;
+	assertPatchable(manager);
+	manager.methods = { ...manager.methods, ...overrides };
+	// Absent managers make the harness's snapshot/template probes record a clean capability skip
+	// (the probe's `!snapshots` guard treats undefined as not-exposed) — the wrapper's own managers
+	// reconnect without a domain, i.e. against the wrong control plane.
+	(compute as { snapshot?: unknown }).snapshot = undefined;
+	(compute as { template?: unknown }).template = undefined;
+	return compute;
+}

--- a/packages/schema/src/providers.test.ts
+++ b/packages/schema/src/providers.test.ts
@@ -21,7 +21,13 @@ describe("@sandbox-benchmarks/schema providers", () => {
 	it("pins the registered provider id set (the independent oracle downstream joins derive from)", () => {
 		// Deliberately hardcoded: downstream tests (e.g. results' normalizeResultsTree) assert their
 		// output against PROVIDERS, so this pin is what makes an accidental registry removal loud.
-		expect(PROVIDERS.map((p) => p.id).sort()).toEqual(["blaxel", "daytona", "e2b", "modal"]);
+		expect(PROVIDERS.map((p) => p.id).sort()).toEqual([
+			"blaxel",
+			"daytona",
+			"e2b",
+			"modal",
+			"novita",
+		]);
 	});
 
 	it("keeps the registry well-formed (unique ids, non-empty required env vars)", () => {
@@ -103,6 +109,7 @@ describe("@sandbox-benchmarks/schema providers", () => {
 			modal: 0.070956 * TARGET_SPEC.vcpus + 0.024192 * TARGET_SPEC.memoryGb,
 			e2b: 0.0504 * TARGET_SPEC.vcpus + 0.0162 * TARGET_SPEC.memoryGb,
 			daytona: 0.0504 * TARGET_SPEC.vcpus + 0.0162 * Math.max(0, TARGET_SPEC.memoryGb - 5),
+			novita: 0.03528 * TARGET_SPEC.vcpus + 0.01152 * TARGET_SPEC.memoryGb,
 		};
 		for (const [id, cost] of Object.entries(expected)) {
 			const meta = getProvider(id);
@@ -120,6 +127,7 @@ describe("@sandbox-benchmarks/schema providers", () => {
 		expect(diskRate("daytona")).toBeCloseTo(0.000108); // $0.00000003/GiB-s × 3600
 		expect(diskRate("modal")).toBe(0); // volumes free under the 1 TiB/mo tier
 		expect(diskRate("e2b")).toBeUndefined(); // no published overage rate
+		expect(diskRate("novita")).toBe(0); // 20 GB target spec inside the 60 GB free tier
 	});
 
 	it("returns null when a provider has no vetted rate", () => {

--- a/packages/schema/src/providers.ts
+++ b/packages/schema/src/providers.ts
@@ -11,7 +11,7 @@
  * matching {@link REGISTRY} entry (the Record type below makes a missing or extra id a compile
  * error) and, downstream, a harness adapter in @sandbox-benchmarks/providers.
  */
-export type ProviderId = "e2b" | "daytona" | "modal" | "blaxel";
+export type ProviderId = "e2b" | "daytona" | "modal" | "blaxel" | "novita";
 
 /** Can the SDK request a pinned target spec (vCPU / memory) at create() time? */
 export type SpecPinning = "settable" | "fixed" | "unknown";
@@ -274,6 +274,48 @@ const REGISTRY: Record<ProviderId, Omit<ProviderMeta, "id">> = {
 			// ENG-64 validates this end-to-end against a live multi-minute suite.
 			streaming: false,
 			syncCapMs: null,
+			detachedPoll: true,
+		},
+	},
+	novita: {
+		displayName: "Novita",
+		website: "https://novita.ai/sandbox",
+		// Novita's control plane speaks the E2B protocol (their docs: E2B_DOMAIN=sandbox.novita.ai),
+		// so the harness drives it through the e2b wrapper — see the novita adapter's compat module.
+		sdkPackage: "@computesdk/e2b",
+		requiredEnvVars: ["NOVITA_API_KEY"],
+		isolation: {
+			technology: "microVM",
+			notes:
+				"Dedicated microVM per sandbox; E2B-protocol-compatible control plane (sandbox.novita.ai) driven through @computesdk/e2b pointed at Novita's domain.",
+		},
+		pricing: {
+			model: "per_vcpu_hour",
+			// $0.0000098/vCPU-s × 3600 = $0.03528/vCPU-hr; $0.0000032/GiB-s × 3600 = $0.01152/GiB-hr.
+			usdPerVcpuHour: 0.03528,
+			usdPerGibHour: 0.01152,
+			// Storage $0.00009/GB-hr with the first 60 GB free — the 20 GB target spec sits inside the
+			// free tier, so the marginal disk rate at TARGET_SPEC is 0 (known, not unknown).
+			usdPerGibDiskHour: 0,
+			notes:
+				"Published per-second rates (exact): $0.0000098/vCPU-s, $0.0000032/GiB-s. Storage $0.00009/GB-hr (first 60 GB free).",
+			sourceUrl: "https://novita.ai/sandbox",
+		},
+		maturity: {
+			status: "beta",
+			notes:
+				"E2B-compatible API; boots the pre-baked toolchain template created on Novita's control plane by the bake pipeline (same e2b CLI, Novita domain). Pay-as-you-go caps sandboxes at 8 vCPU / 8 GB RAM. Not yet a committed run.",
+		},
+		// E2B protocol: resources come from the template (cpu/memory pinned at template create), not
+		// the per-sandbox create() call.
+		specPinning: "fixed",
+		transport: {
+			// Same wrapper (and therefore the same caps) as e2b: `sandbox.commands.run(cmd)` with no
+			// options applies the E2B SDK's default 60s command timeout, and onStdout/onStderr are never
+			// passed through. The compat API exposes the same filesystem + `background`, so detached+poll
+			// is the long-step path.
+			streaming: false,
+			syncCapMs: 60_000,
 			detachedPoll: true,
 		},
 	},


### PR DESCRIPTION
## Summary
Adds support for Novita as a compute provider by leveraging its E2B-protocol-compatible control plane. Rather than building a separate adapter, this implementation re-points the existing `@computesdk/e2b` wrapper at Novita's **regional** control plane (`us-phx-1.sandbox.novita.ai`) while removing incompatible features.

Validated end-to-end 2026-07-11 against a real `nvta_` key: `Template.build` on Novita's remote builder (34–46s), boot from the candidate through the adapter, 11/11 smoke checks green, sandbox survival past the phoromatic window, and a full `realworld-better-auth` suite run.

## Key Changes

- **New Novita adapter** (`packages/providers/src/lib/novita.ts`):
  - Wraps the e2b provider and overrides its config-taking connection methods (`create`, `getById`, `destroy`, `list`) to use Novita's domain and accept `nvta_`-prefixed API keys
  - **Regional domain is mandatory**: the bare `sandbox.novita.ai` serves only a legacy API slice (template list answers; the v2 template-build routes 404 with "no matching operation was found"). `NOVITA_E2B_DOMAIN` is `us-phx-1.sandbox.novita.ai`, and templates/sandboxes are region-scoped so bake + harness must agree on it
  - **Key-format guard bypass** (`novitaConnection()`): both the computesdk wrapper *and* the raw e2b SDK's `ApiClient` client-side reject any key not matching `e2b_<hex>` before a request is made. The connection passes a placeholder key that satisfies the shape check and carries the real credential via an `X-API-KEY` header override (which `ApiClient` spreads after its derived header)
  - Removes snapshot/template managers entirely since they would reconnect without a domain, hitting e2b.dev instead of Novita
  - Includes runtime shape assertions to catch wrapper upgrades that change internal structure

- **Provider registry** (`packages/schema/src/providers.ts`):
  - Added "novita" to `ProviderId` type
  - Registered Novita in the provider metadata with pricing ($0.03528/vCPU-hr, $0.01152/GiB-hr), isolation details, and transport capabilities
  - Marked as beta maturity with E2B-compatible API notes

- **Configuration** (`packages/providers/src/lib/config.ts`):
  - Added `NOVITA_API_KEY` and `NOVITA_TEMPLATE` environment variables
  - Treats empty-string env vars as unset (handles GitHub Actions secrets materialization)
  - Exports `NovitaConfig` interface

- **Bake pipeline** (`apps/cli/src/lib/bake/novita.ts`):
  - Bakes programmatically via the e2b SDK's `Template.build` against the regional domain — the spawned-CLI path is a dead end for Novita (`@e2b/cli ≥ 2.12` rejects `nvta_` keys client-side, and the CLI build route 404s)
  - Masks the PTS phoromatic units as a template build step (`{ user: "root" }`): Novita boots the image with systemd as PID 1 exactly like e2b, and an unmasked phoromatic-client powers the guest off at t+300s (probed live: unmasked died at exactly 5:00, masked survived). Redundant-but-idempotent once the base image ships the mask (#123)

- **Adapter registration** (`packages/providers/src/lib/adapters.ts`):
  - Registered novita adapter with `novitaCompute` factory and template-based create options

- **Workflow updates** (`.github/workflows/`):
  - Added `NOVITA_API_KEY` secret to toolchain-image, bench-matrix, and bench-smoke workflows
  - Added novita to provider choice options in bench-smoke

- **Tests**:
  - Added unit test verifying the adapter accepts `nvta_` keys and removes snapshot/template managers
  - Added integration test confirming lazy credential validation and template configuration
  - Updated provider registry test to include novita in expected provider list
  - Updated pricing calculation test with novita rates
  - Updated bake validation tests for novita template candidate mapping

## Implementation Details

The key insight is that Novita's E2B-compatible API means the e2b wrapper and SDK can be reused with only the connection swapped: the adapter patches the wrapper's internal `methods` table at runtime, replacing only the connection methods that take config parameters, and the bake drives the SDK's own Template API. This avoids code duplication while maintaining type safety through the `SandboxMethods` contract.

The adapter validates the wrapper's internal shape at runtime to ensure compatibility across upgrades, failing fast with a clear error if the framework changes.

https://claude.ai/code/session_01Ev54L6Q22HhEeXoMbCaTKF
Claude-Session: https://claude.ai/code/session_01DWt5bJUMKni4yQE9zgiG8S

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds Novita as a compute provider via its E2B‑compatible API. Uses SDK-based template builds on Novita’s regional control plane and wires Novita into bake, promote, and CI.

- **New Features**
  - Novita adapter: re-points `@computesdk/e2b` to `us-phx-1.sandbox.novita.ai`, bypasses the `e2b_` key guard via placeholder+`X-API-KEY`, replaces `create/getById/destroy/list`, removes snapshot/template managers; exports `NOVITA_E2B_DOMAIN`, `novitaCompute`, and `novitaConnection`.
  - Bake/Promote/CLI: `bakeNovitaTemplate` builds via `e2b` SDK `Template.build` (CLI rejects `nvta_` keys; regional API required), wired into `bake`, `promote`, and candidate mapping; `bakeE2bTemplate` accepts env overrides; `NOVITA_TEMPLATE` override supported.
  - Registry/Adapter: adds `novita` with vetted per-second pricing, microVM isolation, E2B‑equivalent transport, fixed spec pinning; adapter boots the pre-baked Novita template via `snapshotId`.
  - CI: `bench-smoke`, `bench-matrix`, and `toolchain-image` pass `NOVITA_API_KEY`; Novita added as a bench option.
  - Dependencies: add `e2b` and `@computesdk/provider`.

- **Bug Fixes**
  - `getById` returns null only for missing sandboxes and propagates auth/network errors.
  - Config gatekeeper treats empty-string env vars as unset to avoid import-time crashes when optional secrets are missing.

<sup>Written for commit 7f09786eae9784e42ef0c74849a269abd0dfb7f0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/starslingdev/sandbox-benchmarks/pull/122?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added **Novita** as a supported compute provider (provider registration, auth via `NOVITA_API_KEY`, and sandbox lifecycle support).
  * Extended the CLI baking pipeline to **bake, validate, and promote** Novita templates and include them in reports.
  * Updated benchmark workflows to support the **Novita** provider option.
  * Enhanced E2B template baking to allow **environment variable overrides**.
* **Bug Fixes**
  * Treat empty environment variable values as **unset**, so optional configuration behaves correctly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
