### PR TITLE
fix(templates): mask the PTS phoromatic units that power off e2b sandboxes at 5 min

### DIFF
--- a/packages/templates/images/base/scripts/20-pts.sh
+++ b/packages/templates/images/base/scripts/20-pts.sh
@@ -20,6 +20,19 @@ dpkg -i /tmp/pts.deb || apt-get install -y --no-install-recommends -f
 rm -rf /tmp/pts.deb /var/lib/apt/lists/*
 phoronix-test-suite version
 
+# > The PTS deb ships phoromatic + result-viewer systemd units, and its postinst ENABLES them via
+# > deb-systemd-helper (no running systemd needed). Providers that boot this image with systemd as
+# > PID 1 (e2b microVMs — e2b's template build injects systemd; daytona/modal never run it) then
+# > start phoromatic-client at boot, and a phoromatic client with no server POWERS OFF the guest
+# > ~5 min in — every e2b sandbox died at exactly t+300s until this mask (probed 2026-07-10:
+# > masked → survives; unmasked → dead at 5:00, guest healthy, orchestrator logs a bare "Sandbox
+# > stopped"). Mask by symlinking the unit names to /dev/null — exactly what `systemctl mask`
+# > writes, done by hand because this slim build stage has no systemctl binary; a mask (vs
+# > removing the wants/ symlinks) also defeats the deb's enable-on-upgrade.
+for unit in phoromatic-client phoromatic-server phoronix-result-server; do
+	ln -sf /dev/null "/etc/systemd/system/${unit}.service"
+done
+
 # > Non-interactive batch config + offline download caches for the cpu-suite profiles. Build and
 # > sandboxes both run as root, so PTS state under /var/lib/phoronix-test-suite lines up at runtime.
 printf 'y\nn\nn\nn\nn\nn\ny\n' | phoronix-test-suite batch-setup


### PR DESCRIPTION
Every e2b sandbox booted from the toolchain template died exactly 300s after
create — idle or loaded, timeoutMs honored by the control plane (endAt +30m,
`e2b sandbox logs` shows a bare orchestrator "Sandbox stopped", guest healthy:
321MB/8GB used, load 0.02, clean dmesg). Stock `base` and a trivial 2cpu/8GB
template survive; the toolchain image dies on both CLI 2.12.0 and 2.13.1
builds — so the trigger is image content.

It's phoromatic: the phoronix-test-suite deb ships phoromatic-client,
phoromatic-server, and phoronix-result-server units ENABLED. e2b microVMs
boot the image with systemd as PID 1 (daytona/modal never run systemd, which
is why only e2b died), so phoromatic-client starts at boot — and a phoromatic
client with no server powers off the guest ~5 minutes in. Probed live
2026-07-10: `systemctl mask --now` on those three units → the same template
survives past 8 minutes; five unmasked controls all died at 5:00.

This explains every e2b mystery in run 29061549181: cpu-node/better-auth
cells whose sandboxes silently died minutes in while the harness polled the
corpse until the runner was reclaimed, and the memory cell's 1800s "stopped
responding" step timeout.

Mask (not disable) so a deb upgrade can't re-enable them. The mask is
written as plain `/dev/null` unit symlinks — byte-for-byte what
`systemctl mask` creates — because the slim build stage ships no systemctl
binary (the deb's postinst enables the units via deb-systemd-helper, which
also needs no running systemd). Takes effect on the next bake + promote of
the e2b template. Novita shares the e2b machinery and boots systemd the same
way — confirmed live 2026-07-11: an unmasked Novita sandbox died at exactly
t+300s, and the same template with these units masked survived the full
8-minute probe (#122 also masks at novita-template build time as
defense-in-depth until this base-image fix ships).

Claude-Session: https://claude.ai/code/session_01DWt5bJUMKni4yQE9zgiG8S

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Masks the `phoronix-test-suite` phoromatic systemd units to stop e2b microVM sandboxes from powering off ~5 minutes after boot. Fixes ENG-146 by preventing unexpected shutdowns.

- **Bug Fixes**
  - During base image build, symlink `/etc/systemd/system/{phoromatic-client,phoromatic-server,phoronix-result-server}.service` to `/dev/null` (equivalent to `systemctl mask`; no `systemctl` in the slim stage).
  - Masks persist across package upgrades and do not require a running systemd.

- **Migration**
  - Re-bake and promote the e2b and Novita templates.

<sup>Written for commit 8e991a920f21a5ecfaf2145f88964c5ed94d9ea3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/starslingdev/sandbox-benchmarks/pull/123?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented Phoronix Test Suite services from starting automatically in systemd-based images.
  * Improved image stability by avoiding unexpected service failures during operation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->