### PR TITLE
chore(deps): add e2b and @computesdk/provider to the computesdk catalog

### DIFF
--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -29,6 +29,7 @@
     "@sandbox-benchmarks/harness": "workspace:*",
     "@sandbox-benchmarks/results": "workspace:*",
     "@daytona/sdk": "catalog:computesdk",
+    "e2b": "catalog:computesdk",
     "dotenv": "catalog:"
   },
   "devDependencies": {

--- a/bun.lock
+++ b/bun.lock
@@ -35,6 +35,7 @@
         "@sandbox-benchmarks/schema": "workspace:*",
         "@sandbox-benchmarks/templates": "workspace:*",
         "dotenv": "catalog:",
+        "e2b": "catalog:computesdk",
       },
       "devDependencies": {
         "@repo/tsconfig": "workspace:*",
@@ -63,9 +64,11 @@
         "@computesdk/daytona": "catalog:computesdk",
         "@computesdk/e2b": "catalog:computesdk",
         "@computesdk/modal": "catalog:computesdk",
+        "@computesdk/provider": "catalog:computesdk",
         "@sandbox-benchmarks/schema": "workspace:*",
         "arktype": "catalog:",
         "computesdk": "catalog:computesdk",
+        "e2b": "catalog:computesdk",
       },
       "devDependencies": {
         "@repo/tsconfig": "workspace:*",
@@ -161,8 +164,10 @@
       "@computesdk/daytona": "1.7.31",
       "@computesdk/e2b": "1.7.51",
       "@computesdk/modal": "1.9.3",
+      "@computesdk/provider": "2.1.3",
       "@daytona/sdk": "0.192.0",
       "computesdk": "4.1.3",
+      "e2b": "2.27.1",
     },
     "xml": {
       "@nodable/compact-builder": "1.0.9",

--- a/package.json
+++ b/package.json
@@ -20,8 +20,10 @@
         "@computesdk/daytona": "1.7.31",
         "@computesdk/e2b": "1.7.51",
         "@computesdk/modal": "1.9.3",
+        "@computesdk/provider": "2.1.3",
         "@daytona/sdk": "0.192.0",
-        "computesdk": "4.1.3"
+        "computesdk": "4.1.3",
+        "e2b": "2.27.1"
       },
       "xml": {
         "@nodable/compact-builder": "1.0.9",

--- a/packages/providers/package.json
+++ b/packages/providers/package.json
@@ -15,9 +15,11 @@
     "@computesdk/daytona": "catalog:computesdk",
     "@computesdk/e2b": "catalog:computesdk",
     "@computesdk/modal": "catalog:computesdk",
+    "@computesdk/provider": "catalog:computesdk",
     "@sandbox-benchmarks/schema": "workspace:*",
     "arktype": "catalog:",
-    "computesdk": "catalog:computesdk"
+    "computesdk": "catalog:computesdk",
+    "e2b": "catalog:computesdk"
   },
   "devDependencies": {
     "@repo/tsconfig": "workspace:*",


### PR DESCRIPTION
**Novita provider — full end-to-end support via Novita's E2B-compatible API**
Shipped as a 5-PR stack (merge bottom-up, each branch independently green):
1. #124 — deps: `e2b` + `@computesdk/provider` catalog additions
2. #125 — config: `NOVITA_*` env keys, template names, empty-env-as-unset hardening
3. #126 — mechanism: `novitaCompute()` compat module (e2b wrapper re-pointed at Novita)
4. #127 — mechanism: `bakeNovitaTemplate` via `Template.build` on the regional control plane
5. #128 — wiring: schema registry entry + adapter + bake/promote + CI workflows

Supersedes #122 (the same change as one monolithic PR).
↑ **This PR is #124 (1/5)**, based on main.

---

The upcoming Novita provider drives Novita's E2B-protocol-compatible control plane through the raw e2b SDK (@computesdk/e2b re-exports it in types only, not at runtime) and types its method-table patch against @computesdk/provider's SandboxMethods contract. Pure dependency additions; nothing imports them yet — the consumers land in the next PRs of this stack.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add `e2b` and `@computesdk/provider` to the `computesdk` catalog to prep the Novita provider. Dependency-only change; no runtime usage yet.

- **Dependencies**
  - Added `e2b` (runtime SDK; `@computesdk/e2b` is types-only) and `@computesdk/provider` (`SandboxMethods` contract) to the catalog.
  - Wired into `packages/providers`; added `e2b` to `apps/cli`.
  - Pinned versions in the root catalog and updated `bun.lock`.

<sup>Written for commit 529be8a72fae17007dbfc3ed648e93fd9aa49f27. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/starslingdev/sandbox-benchmarks/pull/124?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added support for the E2B compute provider across the CLI and provider packages.
  * Updated dependency configuration to include the Compute SDK provider package and E2B integration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->