### PR TITLE
feat(providers): add Novita config (NOVITA_API_KEY/NOVITA_TEMPLATE) and treat empty env vars as unset

### DIFF
--- a/packages/providers/src/lib/config.ts
+++ b/packages/providers/src/lib/config.ts
@@ -15,6 +15,8 @@ const envSchema = type({
 	"DAYTONA_API_KEY?": "string >= 1",
 	"DAYTONA_TARGET?": "string >= 1",
 	"DAYTONA_SNAPSHOT?": "string >= 1",
+	"NOVITA_API_KEY?": "string >= 1",
+	"NOVITA_TEMPLATE?": "string >= 1",
 });
 
 const ENV_KEYS = [
@@ -23,18 +25,32 @@ const ENV_KEYS = [
 	"DAYTONA_API_KEY",
 	"DAYTONA_TARGET",
 	"DAYTONA_SNAPSHOT",
+	"NOVITA_API_KEY",
+	"NOVITA_TEMPLATE",
 ] as const;
 
 // 2. Startup gatekeeper — validate the environment once, fail fast with a clear message. Only the
-//    keys we declare are forwarded (process.env carries hundreds of unrelated ones).
+//    keys we declare are forwarded (process.env carries hundreds of unrelated ones). A set-but-EMPTY
+//    value is treated as unset, not a misconfiguration: GitHub Actions materializes an unconfigured
+//    secret as an empty-string env var (`FOO: ${{ secrets.MISSING }}` sets FOO=""), so throwing here
+//    would crash EVERY provider's bench job at module load the moment one optional secret is
+//    unsynced — the exact hazard the workflows' `DAYTONA_TARGET || 'us-west-2'` default papered
+//    over. Empty ⇒ unset keeps a missing credential what it is everywhere else in the harness
+//    (missingCreds treats "" as missing): a downstream skip decision, never an import-time crash.
 const rawEnv: Record<string, string> = {};
 for (const key of ENV_KEYS) {
 	const value = process.env[key];
-	if (value !== undefined) rawEnv[key] = value;
+	if (value !== undefined && value !== "") rawEnv[key] = value;
 }
 const env = envSchema(rawEnv);
 if (env instanceof type.errors) {
 	throw new Error(`Invalid configuration: ${env.summary}`);
+}
+
+/** The Novita account the novita adapter boots from (via the E2B-compatible API). */
+export interface NovitaConfig {
+	/** Novita API key (`nvta_…`), sent to Novita's E2B-compatible API at sandbox.novita.ai. */
+	apiKey?: string;
 }
 
 /** The daytona account/target the adapter boots from. Single-region: the base DAYTONA_* env vars. */
@@ -61,6 +77,11 @@ const e2bTemplateVersion = `${TOOLCHAIN_IMAGE_NAME}-${TOOLCHAIN_VERSION}`;
 const e2bTemplateCandidate = `${e2bTemplateVersion}${CANDIDATE_SUFFIX}`;
 const daytonaSnapshotDefault = `${TOOLCHAIN_IMAGE_NAME}-${TOOLCHAIN_VERSION}`;
 const daytonaSnapshotCandidate = `${daytonaSnapshotDefault}${CANDIDATE_SUFFIX}`;
+// The novita template lives on Novita's E2B-compatible control plane (a separate namespace from
+// e2b.dev), so it reuses the same version-scoped artifact name as the e2b template — aliased, not
+// recomputed, so a change to the e2b naming formula can't silently break the shared-name invariant.
+const novitaTemplateVersion = e2bTemplateVersion;
+const novitaTemplateCandidate = e2bTemplateCandidate;
 
 // 3. The single, fully-typed config object. Everything that needs config imports THIS.
 export const config = {
@@ -94,4 +115,15 @@ export const config = {
 		target: env.DAYTONA_TARGET,
 		snapshot: env.DAYTONA_SNAPSHOT ?? daytonaSnapshotDefault,
 	} satisfies DaytonaConfig,
+	/** The novita template the sandbox boots from (on Novita's control plane); `NOVITA_TEMPLATE`
+	 *  override, else the version-scoped public template. */
+	novitaTemplate: env.NOVITA_TEMPLATE ?? novitaTemplateVersion,
+	/** Public (version-scoped) novita template name; the promote target. */
+	novitaTemplateVersion,
+	/** Candidate novita template name the bake builds while iterating. */
+	novitaTemplateCandidate,
+	/** The Novita account the adapter and bake boot from (E2B-protocol-compatible control plane). */
+	novita: {
+		apiKey: env.NOVITA_API_KEY,
+	} satisfies NovitaConfig,
 } as const;


### PR DESCRIPTION
**Novita provider — full end-to-end support via Novita's E2B-compatible API**
Shipped as a 5-PR stack (merge bottom-up, each branch independently green):
1. #124 — deps: `e2b` + `@computesdk/provider` catalog additions
2. #125 — config: `NOVITA_*` env keys, template names, empty-env-as-unset hardening
3. #126 — mechanism: `novitaCompute()` compat module (e2b wrapper re-pointed at Novita)
4. #127 — mechanism: `bakeNovitaTemplate` via `Template.build` on the regional control plane
5. #128 — wiring: schema registry entry + adapter + bake/promote + CI workflows

Supersedes #122 (the same change as one monolithic PR).
↑ **This PR is #125 (2/5)**, based on #124.

---

Declares the NOVITA_* env keys, the NovitaConfig account slot, and the version-scoped novita template names (aliased from the e2b naming formula, since Novita's E2B-compatible control plane is a separate namespace that can safely reuse the artifact name).

Also hardens the env gatekeeper: a set-but-empty value is now treated as unset, not a misconfiguration. GitHub Actions materializes an unconfigured secret as an empty-string env var, so throwing at module load would crash every provider's bench job the moment one optional secret is unsynced — empty ⇒ unset keeps a missing credential a downstream skip decision.

Nothing consumes the new config fields yet; the adapter and bake land next in this stack.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add Novita config support with `NOVITA_API_KEY` and `NOVITA_TEMPLATE`, exposing `config.novita.apiKey` and novita template names that alias the E2B versions. Empty env vars are treated as unset to prevent CI crashes.

- **New Features**
  - Added `NOVITA_API_KEY` and `NOVITA_TEMPLATE` to the env schema and allowlist.
  - Exposed `NovitaConfig` (`novita.apiKey`) and `novitaTemplate`, `novitaTemplateVersion`, `novitaTemplateCandidate` (aliased to the E2B names).

- **Bug Fixes**
  - Env gatekeeper ignores empty-string values so missing GitHub Actions secrets don’t throw at module load.

<sup>Written for commit 618f0ed364f13043d42f6b3b13cef8cd731850d6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/starslingdev/sandbox-benchmarks/pull/125?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

