### PR TITLE
feat(providers): novita compat module — the e2b wrapper re-pointed at Novita's control plane

### DIFF
--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -29,7 +29,7 @@
     "@sandbox-benchmarks/harness": "workspace:*",
     "@sandbox-benchmarks/results": "workspace:*",
     "@daytona/sdk": "catalog:computesdk",
-    "e2b": "catalog:computesdk",
+    "novita-sandbox": "catalog:computesdk",
     "dotenv": "catalog:"
   },
   "devDependencies": {

--- a/bun.lock
+++ b/bun.lock
@@ -35,7 +35,7 @@
         "@sandbox-benchmarks/schema": "workspace:*",
         "@sandbox-benchmarks/templates": "workspace:*",
         "dotenv": "catalog:",
-        "e2b": "catalog:computesdk",
+        "novita-sandbox": "catalog:computesdk",
       },
       "devDependencies": {
         "@repo/tsconfig": "workspace:*",
@@ -68,7 +68,7 @@
         "@sandbox-benchmarks/schema": "workspace:*",
         "arktype": "catalog:",
         "computesdk": "catalog:computesdk",
-        "e2b": "catalog:computesdk",
+        "novita-sandbox": "catalog:computesdk",
       },
       "devDependencies": {
         "@repo/tsconfig": "workspace:*",
@@ -167,7 +167,7 @@
       "@computesdk/provider": "2.1.3",
       "@daytona/sdk": "0.192.0",
       "computesdk": "4.1.3",
-      "e2b": "2.27.1",
+      "novita-sandbox": "2.0.6",
     },
     "xml": {
       "@nodable/compact-builder": "1.0.9",
@@ -876,6 +876,8 @@
     "node-gyp-build-optional-packages": ["node-gyp-build-optional-packages@5.1.1", "", { "dependencies": { "detect-libc": "^2.0.1" }, "bin": { "node-gyp-build-optional-packages": "bin.js", "node-gyp-build-optional-packages-test": "build-test.js", "node-gyp-build-optional-packages-optional": "optional.js" } }, "sha512-+P72GAjVAbTxjjwUmwjVrqrdZROD4nf8KgpBoDxqXXTiYZZt/ud60dE5yvCSr9lRO8e8yv6kgJIC0K0PfZFVQw=="],
 
     "normalize-path": ["normalize-path@3.0.0", "", {}, "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA=="],
+
+    "novita-sandbox": ["novita-sandbox@2.0.6", "", { "dependencies": { "@bufbuild/protobuf": "^2.6.2", "@connectrpc/connect": "2.0.0-rc.3", "@connectrpc/connect-web": "2.0.0-rc.3", "chalk": "^5.3.0", "compare-versions": "^6.1.0", "dockerfile-ast": "^0.7.1", "glob": "^11.1.0", "openapi-fetch": "^0.14.1", "platform": "^1.3.6", "tar": "^7.5.11" } }, "sha512-EkCHu4nvwCRUaYAtMas/uh+AiYLTFrk5lkbpSNmDp8+dHU/nGQ6SL6BY7VBUseUc37sVojU8rUjRKUAazq0yLA=="],
 
     "object-assign": ["object-assign@4.1.1", "", {}, "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg=="],
 

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
         "@computesdk/provider": "2.1.3",
         "@daytona/sdk": "0.192.0",
         "computesdk": "4.1.3",
-        "e2b": "2.27.1"
+        "novita-sandbox": "2.0.6"
       },
       "xml": {
         "@nodable/compact-builder": "1.0.9",

--- a/packages/providers/package.json
+++ b/packages/providers/package.json
@@ -19,7 +19,7 @@
     "@sandbox-benchmarks/schema": "workspace:*",
     "arktype": "catalog:",
     "computesdk": "catalog:computesdk",
-    "e2b": "catalog:computesdk"
+    "novita-sandbox": "catalog:computesdk"
   },
   "devDependencies": {
     "@repo/tsconfig": "workspace:*",

--- a/packages/providers/src/index.test.ts
+++ b/packages/providers/src/index.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, it } from "bun:test";
+// The stock wrapper factory, imported so the novita test can prove the connection methods were
+// actually REPLACED (identity inequality against an unpatched instance's methods table).
+import { e2b } from "@computesdk/e2b";
 import { PROVIDERS, TARGET_SPEC, VCPUS_PER_PHYSICAL_CORE } from "@sandbox-benchmarks/schema";
-import { config, providers } from "./index.ts";
+import { config, NOVITA_E2B_DOMAIN, novitaCompute, novitaConnection, providers } from "./index.ts";
 import { assertProviderJoin } from "./lib/join.ts";
 
 describe("@sandbox-benchmarks/providers", () => {
@@ -37,6 +40,58 @@ describe("@sandbox-benchmarks/providers", () => {
 			memoryMiB: TARGET_SPEC.memoryGb * 1024,
 			memoryLimitMiB: TARGET_SPEC.memoryGb * 1024,
 		});
+	});
+
+	it("re-points the e2b wrapper at Novita without the e2b_ key-format guard", () => {
+		// Construction must accept an nvta_-prefixed key and still expose the universal manager surface
+		// the harness drives, with the mispointed snapshot/template managers removed (their every call
+		// would reconnect to e2b.dev). This also exercises the patch's runtime shape assertion, so a
+		// wrapper upgrade that moves the internal methods table fails here instead of mid-run.
+		const compute = novitaCompute("nvta_unit-test-key");
+		expect(typeof compute.sandbox.create).toBe("function");
+		expect(typeof compute.sandbox.destroy).toBe("function");
+		expect(typeof compute.sandbox.list).toBe("function");
+		// The stock wrapper's connection methods (whose create() enforces the e2b_ prefix and whose
+		// every call omits the domain) must have been REPLACED, not just still-callable — a stock
+		// `create` is also `typeof "function"`, so compare the internal methods table against an
+		// unpatched wrapper's by identity. Reaches the same internal seam the patch itself asserts.
+		const methodsOf = (p: unknown) =>
+			(p as { sandbox: { methods: Record<string, unknown> } }).sandbox.methods;
+		const stock = methodsOf(e2b({ apiKey: "e2b_unit-test-key" }));
+		const patched = methodsOf(compute);
+		for (const method of ["create", "getById", "destroy", "list"] as const) {
+			// Precondition that makes the inequality below meaningful: the wrapper hands every instance
+			// the SAME module-level methods object (defineProvider passes it by reference). If an upgrade
+			// switches to per-instance closures, this fails loudly instead of the patch check passing
+			// vacuously against a never-shared function.
+			expect(methodsOf(e2b({ apiKey: "e2b_unit-test-key" }))[method]).toBe(stock[method]);
+			expect(patched[method]).not.toBe(stock[method]);
+		}
+		expect(compute.snapshot).toBeUndefined();
+		// `template` is a runtime property of the generated provider (computesdk's type doesn't model
+		// it), so reach through a structural cast to pin its removal too.
+		expect((compute as { template?: unknown }).template).toBeUndefined();
+	});
+
+	it("refuses construction without a key, unconditionally", () => {
+		// The factory (not env state) owns the missing-credential error, so this holds even in an
+		// environment where NOVITA_API_KEY is set.
+		expect(() => novitaCompute(undefined)).toThrow(/NOVITA_API_KEY/);
+	});
+
+	it("keeps the account key in the SDK's apiKey channel — never in connection headers", () => {
+		// SECURITY PIN: the SDK replays connection `headers` into the envd RPC transport, so a
+		// credential riding `headers` is delivered to the daemon INSIDE the guest on every
+		// command/filesystem call — where TLS has already terminated and any root process (including
+		// a supply-chain-compromised benchmark suite) can read it. `apiKey` becomes an X-API-KEY
+		// header inside the control-plane ApiClient only. If a future revision reintroduces a headers
+		// override (e.g. to dodge a key-format guard again), this must fail.
+		const connection = novitaConnection("nvta_unit-test-key");
+		expect(connection).toEqual({
+			apiKey: "nvta_unit-test-key",
+			domain: NOVITA_E2B_DOMAIN,
+		});
+		expect(connection).not.toHaveProperty("headers");
 	});
 
 	it("boots e2b from the configured template and daytona from the configured snapshot", () => {

--- a/packages/providers/src/index.ts
+++ b/packages/providers/src/index.ts
@@ -9,6 +9,9 @@ import type { ProviderConfig } from "./lib/types.ts";
 
 // The runtime configuration gatekeeper — the single validated config object consumers import.
 export { config } from "./lib/config.ts";
+// Novita's E2B-compat surface: the pinned regional domain + connection the bake pipeline reuses,
+// and the compat factory (exported for tests and for anyone driving Novita outside the harness join).
+export { NOVITA_E2B_DOMAIN, novitaCompute, novitaConnection } from "./lib/novita.ts";
 export type { DirectProvider, ProviderAdapter, ProviderConfig } from "./lib/types.ts";
 
 /**

--- a/packages/providers/src/lib/novita.ts
+++ b/packages/providers/src/lib/novita.ts
@@ -1,0 +1,188 @@
+// Novita's control plane speaks the E2B protocol, so the harness reuses the whole
+// `@computesdk/e2b` wrapper — runCommand with daemon-backed streaming, filesystem, the lot —
+// rather than growing a parallel adapter. But the wrapper's config-taking connection methods are
+// hard-wired to e2b.dev twice over: both the wrapper's `create()` and the raw e2b SDK's ApiClient
+// reject any key that doesn't match `e2b_<hex>` (Novita keys are `nvta_…`-prefixed), and every
+// other connection method reaches the control plane via `{ apiKey }` with no `domain`.
+//
+// So the connection methods are driven through `novita-sandbox` — Novita's own fork of the e2b
+// SDK — instead. The fork accepts `nvta_…` keys natively and defaults to Novita's regional
+// control plane, which means the credential rides the SDK's own `apiKey` channel: it becomes an
+// `X-API-KEY` header inside the control-plane ApiClient ONLY, and never reaches the data plane.
+// (An earlier revision cleared the stock SDK's key-format guard with a placeholder `apiKey` plus a
+// real-key `headers` override — but the SDK spreads connection `headers` into the envd RPC
+// transport too, so every command/filesystem call delivered the ACCOUNT-level key to the envd
+// daemon inside the guest, where TLS has already terminated and any root process — including a
+// supply-chain-compromised benchmark — could read it. The fork makes that whole hack unnecessary;
+// see the no-headers pin in index.test.ts.)
+//
+// Everything else the harness touches (runCommand, filesystem, getInfo) operates on the live
+// sandbox INSTANCE returned by create — a fork instance already carrying Novita's domain and
+// properly-channelled credential — so this module swaps the config-taking connection methods
+// (create/getById/destroy/list) for fork-backed equivalents typed against the wrapper framework's
+// own `SandboxMethods` contract, and removes the snapshot/template managers outright: their every
+// method reconnects to e2b.dev with the stock SDK, and absent managers read downstream as a clean
+// "provider exposes no snapshot operation" skip instead of a misleading failure against the wrong
+// control plane.
+import { createRequire } from "node:module";
+import { e2b } from "@computesdk/e2b";
+import type { SandboxMethods } from "@computesdk/provider";
+import type { CreateSandboxOptions } from "computesdk";
+import type {
+	Sandbox as NovitaSandboxInstance,
+	SandboxConnectOpts,
+	SandboxOpts,
+} from "novita-sandbox";
+import type { DirectProvider } from "./types.ts";
+
+// Loaded through the package's `require` (CJS) build, NOT an import: `@computesdk/e2b` is CJS and
+// `require()`s chalk, while novita-sandbox's ESM build `import`s it — and Bun's require() of an
+// ESM module throws "require() async module is unsupported" whenever that ESM load is still
+// in-flight, which the two-format mix makes a load-order race (flaky test failures, not a
+// deterministic break). One format for both SDKs removes the race; the type-only imports above
+// still come from the package's type declarations and erase at compile time.
+const requireCjs = createRequire(import.meta.url);
+const { Sandbox: NovitaSandbox, SandboxNotFoundError } = requireCjs(
+	"novita-sandbox",
+) as typeof import("novita-sandbox");
+
+/** Novita's E2B-compatible control-plane domain. REGIONAL, not the bare `sandbox.novita.ai` their
+ *  docs open with: the bare domain serves only a legacy slice of the API (template list works; the
+ *  v2 template-build routes 404 with "no matching operation was found"), while the regional domain
+ *  serves the full surface (probed 2026-07-11; the novita-sandbox SDK's own default agrees, and
+ *  names the bare domain legacy). Pinned explicitly rather than trusting the SDK default so a
+ *  NOVITA_DOMAIN env var or an SDK-default change can't silently split the bake and the harness
+ *  across regions — templates and sandboxes are region-scoped, so the two must agree. */
+export const NOVITA_E2B_DOMAIN = "us-phx-1.sandbox.novita.ai";
+
+/** The connection options every Novita control-plane call rides: the real key in the SDK's own
+ *  `apiKey` channel (control-plane `X-API-KEY` only — NEVER a custom `headers` entry, which the
+ *  SDK would replay to the envd daemon inside the guest on every data-plane call), and the region
+ *  pinned. */
+export function novitaConnection(apiKey: string): SandboxConnectOpts {
+	return {
+		apiKey,
+		domain: NOVITA_E2B_DOMAIN,
+	};
+}
+
+/** The connection-method half of the wrapper framework's sandbox method table — the exact slice
+ *  this module replaces, typed by the framework so a wrapper upgrade that changes a signature is a
+ *  compile error here, not a runtime surprise. (The sandbox generic is the fork's class: the fork
+ *  is protocol- and surface-identical to the stock SDK, so the wrapper's instance methods —
+ *  `sandbox.commands.run`, `sandbox.files.*` — drive it unchanged.) */
+type ConnectionMethods = Pick<
+	SandboxMethods<NovitaSandboxInstance>,
+	"create" | "getById" | "destroy" | "list"
+>;
+
+/** The internal seam the patch reaches through: the generated sandbox manager dispatches every call
+ *  via its `methods` table. Internal to @computesdk/provider, so asserted at runtime
+ *  ({@link assertPatchable}) rather than trusted blindly across upgrades. */
+interface PatchableManager {
+	methods: ConnectionMethods & Record<string, unknown>;
+}
+
+function assertPatchable(manager: unknown): asserts manager is PatchableManager {
+	const methods = (manager as { methods?: Record<string, unknown> })?.methods;
+	for (const method of ["create", "getById", "destroy", "list"] as const) {
+		if (typeof methods?.[method] !== "function") {
+			throw new Error(
+				"@computesdk/e2b provider internals changed shape (sandbox manager has no patchable " +
+					`${method} method); revisit the novita adapter against the upgraded wrapper`,
+			);
+		}
+	}
+}
+
+/**
+ * A computesdk provider for Novita: the `@computesdk/e2b` provider with its config-taking
+ * connection methods re-pointed at Novita's control plane via the novita-sandbox SDK.
+ * Construction is lazy-credentialed like every other factory — the missing-key error only fires
+ * when the harness actually selects the provider (it gates on NOVITA_API_KEY before that).
+ */
+export function novitaCompute(apiKey: string | undefined): DirectProvider {
+	if (!apiKey) {
+		throw new Error("NOVITA_API_KEY is required to construct the novita provider");
+	}
+	const connection: SandboxConnectOpts = novitaConnection(apiKey);
+
+	const overrides: ConnectionMethods = {
+		// The wrapper's create against the fork, with Novita's domain pinned. Mirrors the wrapper's
+		// option handling — including the open `...providerOptions` passthrough that computesdk's
+		// CreateSandboxOptions models with its index signature — but spreads the connection LAST, so
+		// no stray `domain`/`apiKey` riding providerOptions can silently re-point creation at another
+		// control plane. An undefined `timeoutMs` defers to the SDK's own default.
+		create: async (_config, options?: CreateSandboxOptions) => {
+			const {
+				timeout,
+				envs,
+				metadata,
+				templateId,
+				snapshotId,
+				sandboxId: _sandboxId,
+				name: _name,
+				namespace: _namespace,
+				directory: _directory,
+				...providerOptions
+			} = options ?? {};
+			const createOpts: SandboxOpts = {
+				timeoutMs: timeout,
+				envs,
+				metadata,
+				...providerOptions,
+				...connection,
+			};
+			const template = templateId ?? snapshotId;
+			const sandbox = template
+				? await NovitaSandbox.create(template, createOpts)
+				: await NovitaSandbox.create(createOpts);
+			if (!sandbox.sandboxId) throw new Error("Novita create() returned sandbox without an ID");
+			return { sandbox, sandboxId: sandbox.sandboxId };
+		},
+		getById: async (_config, sandboxId) => {
+			// Only a genuinely missing sandbox is the contract's `null`; anything else (auth, network)
+			// propagates — folding those into null would mask an invalid key or an outage as "not found".
+			try {
+				const sandbox = await NovitaSandbox.connect(sandboxId, connection);
+				return { sandbox, sandboxId };
+			} catch (error) {
+				if (error instanceof SandboxNotFoundError) return null;
+				throw error;
+			}
+		},
+		// One domain-aware DELETE via the SDK's static kill — no connect round-trip first (connect
+		// also re-extends the sandbox timeout as a side effect, pure waste on a teardown path the
+		// lifecycle benchmark TIMES). `kill` resolves false when the sandbox is already gone (the
+		// legitimate best-effort case); a real control-plane failure REJECTS and propagates, so the
+		// harness records a teardown failure instead of a fake success over a leaked, billing sandbox.
+		destroy: async (_config, sandboxId) => {
+			await NovitaSandbox.kill(sandboxId, connection);
+		},
+		// The fork's list with the domain pinned — the harness's control-plane probe rides this.
+		// Deliberately NOT swallowing errors into [] (the stock wrapper does): a failed enumeration
+		// must surface as a probe skip, not publish a fast fake "success" sample. Single page on
+		// purpose, too: the lifecycle benchmark times ONE list round-trip as the control-plane-read
+		// metric — draining the paginator would time N requests and skew the sample (and nothing
+		// downstream enumerates sandboxes for cleanup; teardown works by id).
+		list: async (_config) => {
+			const paginator = NovitaSandbox.list(connection);
+			const items = await paginator.nextItems();
+			return items.map((info) => ({
+				sandbox: info as unknown as NovitaSandboxInstance,
+				sandboxId: info.sandboxId,
+			}));
+		},
+	};
+
+	const compute = e2b({ apiKey });
+	const manager: unknown = compute.sandbox;
+	assertPatchable(manager);
+	manager.methods = { ...manager.methods, ...overrides };
+	// Absent managers make the harness's snapshot/template probes record a clean capability skip
+	// (the probe's `!snapshots` guard treats undefined as not-exposed) — the wrapper's own managers
+	// reconnect without a domain, i.e. against the wrong control plane.
+	(compute as { snapshot?: unknown }).snapshot = undefined;
+	(compute as { template?: unknown }).template = undefined;
+	return compute;
+}


### PR DESCRIPTION
**Novita provider — full end-to-end support via Novita's E2B-compatible API**
Shipped as a 5-PR stack (merge bottom-up, each branch independently green):
1. #124 — deps: `e2b` + `@computesdk/provider` catalog additions
2. #125 — config: `NOVITA_*` env keys, template names, empty-env-as-unset hardening
3. #126 — mechanism: `novitaCompute()` compat module (e2b wrapper re-pointed at Novita)
4. #127 — mechanism: `bakeNovitaTemplate` via `Template.build` on the regional control plane
5. #128 — wiring: schema registry entry + adapter + bake/promote + CI workflows

Supersedes #122 (the same change as one monolithic PR).
↑ **This PR is #126 (3/5)**, based on #125.

---

Novita's control plane speaks the E2B protocol (E2B_DOMAIN=sandbox.novita.ai), so the harness reuses the whole @computesdk/e2b wrapper rather than growing a parallel adapter. Two wrapper behaviours stand in the way, both confined to the config-taking connection methods: the e2b_ key-format guard (Novita keys are nvta_-prefixed) and the missing domain on every reconnect. novitaCompute() swaps create/getById/destroy/list for domain-aware, guard-free equivalents typed against @computesdk/provider's SandboxMethods contract, and removes the snapshot/template managers outright (their every call would reconnect to e2b.dev).

The domain is the REGIONAL us-phx-1.sandbox.novita.ai — the bare domain serves only a legacy API slice (v2 template-build routes 404; probed 2026-07-11).

Pure-additive: exported and unit-tested directly, but no ProviderId/registry entry consumes it yet — that wiring lands at the top of this stack.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a Novita-compatible compute provider by re-pointing the `@computesdk/e2b` wrapper to `novita-sandbox` for connection methods. Pins the region to `us-phx-1.sandbox.novita.ai` and keeps `nvta_` keys on the control plane only. Exposes `novitaCompute()`, `novitaConnection()`, and `NOVITA_E2B_DOMAIN`; not registered in the provider registry yet.

- **New Features**
  - Replace `create/getById/destroy/list` with `novita-sandbox` equivalents; domain pinned; keys ride the `apiKey` channel (no custom headers).
  - Remove `snapshot`/`template` managers to prevent reconnects to `e2b.dev`.
  - Export `NOVITA_E2B_DOMAIN`, `novitaCompute`, and `novitaConnection`; tests cover method replacement (identity check), missing-key error, and the “no headers” security pin.

- **Dependencies**
  - Swap `e2b` → `novita-sandbox` in catalogs and load via CJS to avoid a `chalk` dual-format race.

<sup>Written for commit 9e8b1cef06395d5fd233890a3d859f3ab41f5f98. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/starslingdev/sandbox-benchmarks/pull/126?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

