### PR TITLE
feat(cli): bake the novita template programmatically via Template.build

### DIFF
--- a/apps/cli/src/lib/bake/novita.ts
+++ b/apps/cli/src/lib/bake/novita.ts
@@ -1,0 +1,56 @@
+// Bake the novita template: the novita-sandbox SDK's Template API against Novita's
+// E2B-protocol-compatible control plane. The spawned-CLI path the e2b bake uses is a dead end for
+// Novita twice over — @e2b/cli ≥ 2.12 rejects `nvta_…` keys client-side before any request is
+// made, and Novita's control plane 404s the CLI's build route on the bare domain — so this bakes
+// programmatically via `Template.build` against the REGIONAL domain (see NOVITA_E2B_DOMAIN),
+// which serves the full v2 build surface (verified 2026-07-11: 34s remote build). novita-sandbox
+// is Novita's fork of the e2b SDK: it takes the `nvta_…` key in its own `apiKey` channel, so the
+// account credential rides control-plane requests only (see the compat module). `fromImage(baseImage)` templates straight
+// from the pushed candidate base ref; the e2b variant Dockerfile's only deltas (validate-base +
+// OCI labels) don't ride along, which is acceptable because the template still provably derives
+// from the same validated, registry-pinned bytes. The template lands in Novita's namespace
+// (independent of e2b.dev), which is why it can reuse the same version-scoped artifact name.
+import { createRequire } from "node:module";
+import { config, novitaConnection } from "@sandbox-benchmarks/providers";
+import type { Log } from "./types.ts";
+
+// CJS build on purpose — same chalk dual-format race the compat module documents
+// (packages/providers/src/lib/novita.ts): mixing novita-sandbox's ESM build with the CJS
+// wrapper chain makes Bun's require(chalk) flaky.
+const requireCjs = createRequire(import.meta.url);
+const { Template } = requireCjs("novita-sandbox") as typeof import("novita-sandbox");
+
+/** Build the novita template `name` from `baseImage` on Novita's control plane. */
+export async function bakeNovitaTemplate(name: string, baseImage: string, log: Log): Promise<void> {
+	const apiKey = config.novita.apiKey;
+	// The bake loop gates on requiredEnvVars before calling this, so a missing key here means the
+	// loop's contract broke — fail loudly rather than let the SDK fall back to an e2b.dev session.
+	if (!apiKey) throw new Error("NOVITA_API_KEY is required to bake the novita template");
+
+	const connection = novitaConnection(apiKey);
+	log(`novita Template.build ${name} via ${connection.domain} (base ${baseImage})`);
+	// Mask the PTS phoromatic units at template-build time, mirroring the base image's own mask
+	// (packages/templates/images/base/scripts/20-pts.sh). Novita boots the image with systemd as
+	// PID 1 exactly like e2b, and an unmasked phoromatic-client POWERS OFF the guest at t+300s
+	// (probed 2026-07-11 on a live Novita sandbox: dead at exactly 5:00; masked → survives).
+	// Redundant-but-idempotent once the base image ships the mask — kept so the novita template is
+	// protected even when it's rebuilt from a candidate base that predates the base-image fix.
+	const template = Template()
+		.fromImage(baseImage)
+		.runCmd(
+			// `set -e` so any failed mask fails the BUILD: without it the loop's exit status is the
+			// last ln's, and an unmasked phoromatic-client means every sandbox booted from this
+			// template powers off at t+300s — a loud bake error is infinitely cheaper than that.
+			"set -e; for unit in phoromatic-client phoromatic-server phoronix-result-server; do " +
+				'ln -sf /dev/null "/etc/systemd/system/$unit.service"; done',
+			// Build steps run as the template's default user; /etc needs root.
+			{ user: "root" },
+		);
+	const info = await Template.build(template, name, {
+		...connection,
+		cpuCount: config.targetSpec.vcpus,
+		memoryMB: config.targetSpec.memoryGb * 1024,
+		onBuildLogs: (entry) => log(String(entry)),
+	});
+	log(`novita template built: ${info.templateId} (build ${info.buildId})`);
+}


### PR DESCRIPTION
**Novita provider — full end-to-end support via Novita's E2B-compatible API**
Shipped as a 5-PR stack (merge bottom-up, each branch independently green):
1. #124 — deps: `e2b` + `@computesdk/provider` catalog additions
2. #125 — config: `NOVITA_*` env keys, template names, empty-env-as-unset hardening
3. #126 — mechanism: `novitaCompute()` compat module (e2b wrapper re-pointed at Novita)
4. #127 — mechanism: `bakeNovitaTemplate` via `Template.build` on the regional control plane
5. #128 — wiring: schema registry entry + adapter + bake/promote + CI workflows

Supersedes #122 (the same change as one monolithic PR).
↑ **This PR is #127 (4/5)**, based on #126.

---

bakeNovitaTemplate builds the toolchain template on Novita's E2B-compatible control plane via the e2b SDK's Template API. The spawned-CLI path the e2b bake uses is a dead end for Novita twice over — @e2b/cli ≥ 2.12 rejects nvta_ keys client-side, and Novita 404s the CLI's build route on the bare domain — so this builds programmatically against the regional domain (verified 2026-07-11: 34s remote build). It also masks the PTS phoromatic units at template-build time: an unmasked phoromatic-client powers off the guest at t+300s (probed on a live Novita sandbox).

Pure-additive mechanism: nothing calls bakeNovitaTemplate yet — the bake/promote wiring lands with the registry entry at the top of this stack. (An earlier revision also threaded an `envOverrides` seam through `bakeE2bTemplate`; the Template.build path made it dead code, so it was removed in review and `e2b.ts` is untouched.)

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Programmatically build the Novita toolchain template using `novita-sandbox`’s `Template.build` on Novita’s regional control plane to bypass `@e2b/cli` restrictions. Loads the SDK via CJS to avoid chalk ESM/CJS races.

- **New Features**
  - Added `bakeNovitaTemplate`: builds from `.fromImage(baseImage)` on the regional domain via `novitaConnection`, requires `NOVITA_API_KEY`, streams build logs, and sizes CPU/RAM from `config.targetSpec`.
  - Masks PTS phoromatic units during build with `set -e` to fail on any masking error.

<sup>Written for commit 580dca93a3bbad51eb7cf04e0ba0c3ab3e770052. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/starslingdev/sandbox-benchmarks/pull/127?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

