### PR TITLE
feat(novita): register the novita provider and wire it through the harness, bake, and CI

### DIFF
--- a/.github/workflows/bench-matrix.yml
+++ b/.github/workflows/bench-matrix.yml
@@ -113,6 +113,7 @@ jobs:
           MODAL_TOKEN_SECRET: ${{ secrets.MODAL_TOKEN_SECRET }}
           BL_API_KEY: ${{ secrets.BL_API_KEY }}
           BL_WORKSPACE: ${{ secrets.BL_WORKSPACE }}
+          NOVITA_API_KEY: ${{ secrets.NOVITA_API_KEY }}
         run: bun apps/cli/src/bin/bench-suite.ts "$BENCH_PROVIDER" "$BENCH_SUITE" "$GITHUB_RUN_ID"
 
       - name: Upload Run + raw results

--- a/.github/workflows/bench-smoke.yml
+++ b/.github/workflows/bench-smoke.yml
@@ -10,7 +10,7 @@ on:
         description: Provider to benchmark
         type: choice
         default: daytona
-        options: [daytona, e2b, modal, blaxel]
+        options: [daytona, e2b, modal, blaxel, novita]
       suite:
         # Constrained to the SUITE_NAMES registry (packages/schema/src/suites.ts); the
         # workflow-registry-sync drift gate (tooling/repo-checks) keeps this list in lockstep, so a
@@ -94,6 +94,7 @@ jobs:
           MODAL_TOKEN_SECRET: ${{ secrets.MODAL_TOKEN_SECRET }}
           BL_API_KEY: ${{ secrets.BL_API_KEY }}
           BL_WORKSPACE: ${{ secrets.BL_WORKSPACE }}
+          NOVITA_API_KEY: ${{ secrets.NOVITA_API_KEY }}
         run: bun apps/cli/src/bin/bench-suite.ts "$BENCH_PROVIDER" "$BENCH_SUITE" "$GITHUB_RUN_ID"
 
       - name: Upload Run + raw results

--- a/.github/workflows/toolchain-image.yml
+++ b/.github/workflows/toolchain-image.yml
@@ -215,6 +215,9 @@ jobs:
           DAYTONA_TARGET: ${{ secrets.DAYTONA_TARGET || 'us-west-2' }}
           MODAL_TOKEN_ID: ${{ secrets.MODAL_TOKEN_ID }}
           MODAL_TOKEN_SECRET: ${{ secrets.MODAL_TOKEN_SECRET }}
+          # Bake the novita template on Novita's E2B-compatible control plane. Optional: a missing
+          # secret skips the novita bake (it is not in --require) without failing the publish.
+          NOVITA_API_KEY: ${{ secrets.NOVITA_API_KEY }}
         run: |
           set -euo pipefail
           # Declare then assign so the command substitution's exit status isn't masked (SC2155).
@@ -240,6 +243,9 @@ jobs:
           DAYTONA_TARGET: ${{ secrets.DAYTONA_TARGET || 'us-west-2' }}
           MODAL_TOKEN_ID: ${{ secrets.MODAL_TOKEN_ID }}
           MODAL_TOKEN_SECRET: ${{ secrets.MODAL_TOKEN_SECRET }}
+          # Bake the novita template on Novita's E2B-compatible control plane. Optional: a missing
+          # secret skips the novita bake (it is not in --require) without failing the publish.
+          NOVITA_API_KEY: ${{ secrets.NOVITA_API_KEY }}
           FORCE_REPUBLISH: ${{ inputs.force_republish }}
         # --require fails promote loudly if a required provider's secret is missing/misnamed, so the
         # public version is never published while a required provider's version artifact was silently

--- a/apps/cli/src/bin/bake.ts
+++ b/apps/cli/src/bin/bake.ts
@@ -16,6 +16,7 @@ import { bakeDaytonaSnapshot } from "../lib/bake/daytona.ts";
 import { bakeE2bTemplate } from "../lib/bake/e2b.ts";
 import { buildAndPushCandidate } from "../lib/bake/image.ts";
 import { bakeModalImage } from "../lib/bake/modal.ts";
+import { bakeNovitaTemplate } from "../lib/bake/novita.ts";
 import { promoteAll } from "../lib/bake/promote.ts";
 import type { BakeReport, Log } from "../lib/bake/types.ts";
 import { candidateCreateOptions } from "../lib/bake/validate.ts";
@@ -31,11 +32,14 @@ const bakers: Record<ProviderId, (log: Log) => Promise<void>> = {
 	blaxel: async (log) => {
 		log("blaxel boots the stock base image — no candidate artifact to bake");
 	},
+	novita: (log) =>
+		bakeNovitaTemplate(config.novitaTemplateCandidate, config.toolchainImageCandidate, log),
 };
 
 const candidateRefs = {
 	e2bTemplateCandidate: config.e2bTemplateCandidate,
 	daytonaSnapshotCandidate: config.daytonaSnapshotCandidate,
+	novitaTemplateCandidate: config.novitaTemplateCandidate,
 	toolchainImageCandidate: config.toolchainImageCandidate,
 	daytonaTarget: config.daytona.target,
 };
@@ -55,6 +59,7 @@ if (import.meta.main) {
 						image: config.toolchainImageVersion,
 						e2bTemplate: config.e2bTemplateVersion,
 						daytonaSnapshot: config.daytonaSnapshotDefault,
+						novitaTemplate: config.novitaTemplateVersion,
 					},
 					reports: promoted,
 				},
@@ -130,6 +135,7 @@ if (import.meta.main) {
 					image: config.toolchainImageCandidate,
 					e2bTemplate: config.e2bTemplateCandidate,
 					daytonaSnapshot: config.daytonaSnapshotCandidate,
+					novitaTemplate: config.novitaTemplateCandidate,
 				},
 				reports,
 			},

--- a/apps/cli/src/lib/bake/promote.ts
+++ b/apps/cli/src/lib/bake/promote.ts
@@ -27,6 +27,7 @@ import { forEachProviderWithCreds } from "../providers-run.ts";
 import { bakeDaytonaSnapshot } from "./daytona.ts";
 import { bakeE2bTemplate } from "./e2b.ts";
 import { imageExistsInRegistry, promoteImage } from "./image.ts";
+import { bakeNovitaTemplate } from "./novita.ts";
 import type { BakeReport, Log } from "./types.ts";
 import type { CandidateRefs } from "./validate.ts";
 import { validateCandidates } from "./validate-run.ts";
@@ -72,6 +73,7 @@ export async function promoteAll(log: Log, force = false): Promise<BakeReport[]>
 	const candidateRefs: CandidateRefs = {
 		e2bTemplateCandidate: config.e2bTemplateCandidate,
 		daytonaSnapshotCandidate: config.daytonaSnapshotCandidate,
+		novitaTemplateCandidate: config.novitaTemplateCandidate,
 		toolchainImageCandidate: config.toolchainImageCandidate,
 		daytonaTarget: config.daytona.target,
 	};
@@ -118,6 +120,13 @@ export async function promoteAll(log: Log, force = false): Promise<BakeReport[]>
 					break;
 				case "blaxel":
 					log("    blaxel boots the stock base image — nothing to promote");
+					break;
+				case "novita":
+					await bakeNovitaTemplate(
+						config.novitaTemplateVersion,
+						config.toolchainImageCandidate,
+						(m) => log(`    ${m}`),
+					);
 					break;
 				default: {
 					// Exhaustiveness: a new ProviderId must add a promote branch above (compile error here).

--- a/apps/cli/src/lib/bake/validate.test.ts
+++ b/apps/cli/src/lib/bake/validate.test.ts
@@ -5,6 +5,8 @@ import { candidateCreateOptions } from "./validate.ts";
 const refs: CandidateRefs = {
 	e2bTemplateCandidate: "tc-v1-candidate",
 	daytonaSnapshotCandidate: "snap-v1-candidate",
+	// Distinct from the e2b value so the novita case fails if it ever reads the e2b field.
+	novitaTemplateCandidate: "tc-v1-novita-candidate",
 	toolchainImageCandidate: "ghcr.io/o/tc:v1-candidate",
 	daytonaTarget: "zen5",
 };
@@ -24,6 +26,12 @@ describe("candidateCreateOptions", () => {
 	it("omits the daytona target when the region has none (account default)", () => {
 		expect(candidateCreateOptions("daytona", { ...refs, daytonaTarget: undefined })).toEqual({
 			snapshotId: "snap-v1-candidate",
+		});
+	});
+
+	it("points novita at its candidate template via snapshotId (e2b mapping, Novita's control plane)", () => {
+		expect(candidateCreateOptions("novita", refs)).toEqual({
+			snapshotId: "tc-v1-novita-candidate",
 		});
 	});
 

--- a/apps/cli/src/lib/bake/validate.ts
+++ b/apps/cli/src/lib/bake/validate.ts
@@ -6,6 +6,8 @@ import type { ProviderId } from "@sandbox-benchmarks/schema";
 export interface CandidateRefs {
 	e2bTemplateCandidate: string;
 	daytonaSnapshotCandidate: string;
+	/** Candidate template on Novita's E2B-compatible control plane (its own namespace). */
+	novitaTemplateCandidate: string;
 	toolchainImageCandidate: string;
 	/** Daytona runner target for the active region (undefined → account default). */
 	daytonaTarget?: string;
@@ -30,5 +32,8 @@ export function candidateCreateOptions(
 		case "blaxel":
 			// Stock base image — no candidate artifact to point at.
 			return {};
+		case "novita":
+			// Same mapping as e2b (snapshotId → template name), against Novita's control plane.
+			return { snapshotId: refs.novitaTemplateCandidate };
 	}
 }

--- a/packages/providers/src/index.test.ts
+++ b/packages/providers/src/index.test.ts
@@ -94,6 +94,18 @@ describe("@sandbox-benchmarks/providers", () => {
 		expect(connection).not.toHaveProperty("headers");
 	});
 
+	it("boots novita from the configured template, erroring on use — not import — without a key", () => {
+		const novita = providers.find((p) => p.name === "novita");
+		expect(novita).toBeDefined();
+		expect(novita?.requiredEnvVars).toEqual(["NOVITA_API_KEY"]);
+		expect(novita?.createOptions?.snapshotId).toBe(config.novitaTemplate);
+		// The registry module must stay importable without credentials; the factory throws only when
+		// the harness actually selects the provider (after its requiredEnvVars gate).
+		if (!process.env.NOVITA_API_KEY) {
+			expect(() => novita?.createCompute()).toThrow(/NOVITA_API_KEY/);
+		}
+	});
+
 	it("boots e2b from the configured template and daytona from the configured snapshot", () => {
 		const e2b = providers.find((p) => p.name === "e2b");
 		expect(e2b?.createOptions?.snapshotId).toBe(config.e2bTemplate);

--- a/packages/providers/src/lib/adapters.ts
+++ b/packages/providers/src/lib/adapters.ts
@@ -10,6 +10,7 @@ import { modal } from "@computesdk/modal";
 import type { ProviderId } from "@sandbox-benchmarks/schema";
 import { TARGET_SPEC, VCPUS_PER_PHYSICAL_CORE } from "@sandbox-benchmarks/schema";
 import { config } from "./config.ts";
+import { novitaCompute } from "./novita.ts";
 import type { ProviderAdapter } from "./types.ts";
 
 // The daytona account/target (key/target/snapshot), resolved by the config gatekeeper. Named
@@ -71,5 +72,13 @@ export const adapters: Record<ProviderId, ProviderAdapter> = {
 			memoryMiB: TARGET_SPEC.memoryGb * 1024,
 			memoryLimitMiB: TARGET_SPEC.memoryGb * 1024,
 		},
+	},
+	novita: {
+		// The e2b wrapper re-pointed at Novita's E2B-compatible control plane (sandbox.novita.ai) —
+		// see novita.ts for exactly what is swapped and why. Boots the pre-baked toolchain template
+		// the bake pipeline creates on Novita via the same e2b CLI (computesdk maps snapshotId → the
+		// template name); cpu/memory are pinned at template create, not per-sandbox.
+		createCompute: () => novitaCompute(config.novita.apiKey),
+		createOptions: { snapshotId: config.novitaTemplate },
 	},
 };

--- a/packages/schema/src/providers.test.ts
+++ b/packages/schema/src/providers.test.ts
@@ -21,7 +21,13 @@ describe("@sandbox-benchmarks/schema providers", () => {
 	it("pins the registered provider id set (the independent oracle downstream joins derive from)", () => {
 		// Deliberately hardcoded: downstream tests (e.g. results' normalizeResultsTree) assert their
 		// output against PROVIDERS, so this pin is what makes an accidental registry removal loud.
-		expect(PROVIDERS.map((p) => p.id).sort()).toEqual(["blaxel", "daytona", "e2b", "modal"]);
+		expect(PROVIDERS.map((p) => p.id).sort()).toEqual([
+			"blaxel",
+			"daytona",
+			"e2b",
+			"modal",
+			"novita",
+		]);
 	});
 
 	it("keeps the registry well-formed (unique ids, non-empty required env vars)", () => {
@@ -103,6 +109,7 @@ describe("@sandbox-benchmarks/schema providers", () => {
 			modal: 0.070956 * TARGET_SPEC.vcpus + 0.024192 * TARGET_SPEC.memoryGb,
 			e2b: 0.0504 * TARGET_SPEC.vcpus + 0.0162 * TARGET_SPEC.memoryGb,
 			daytona: 0.0504 * TARGET_SPEC.vcpus + 0.0162 * Math.max(0, TARGET_SPEC.memoryGb - 5),
+			novita: 0.03528 * TARGET_SPEC.vcpus + 0.01152 * TARGET_SPEC.memoryGb,
 		};
 		for (const [id, cost] of Object.entries(expected)) {
 			const meta = getProvider(id);
@@ -120,6 +127,7 @@ describe("@sandbox-benchmarks/schema providers", () => {
 		expect(diskRate("daytona")).toBeCloseTo(0.000108); // $0.00000003/GiB-s × 3600
 		expect(diskRate("modal")).toBe(0); // volumes free under the 1 TiB/mo tier
 		expect(diskRate("e2b")).toBeUndefined(); // no published overage rate
+		expect(diskRate("novita")).toBe(0); // 20 GB target spec inside the 60 GB free tier
 	});
 
 	it("returns null when a provider has no vetted rate", () => {

--- a/packages/schema/src/providers.ts
+++ b/packages/schema/src/providers.ts
@@ -11,7 +11,7 @@
  * matching {@link REGISTRY} entry (the Record type below makes a missing or extra id a compile
  * error) and, downstream, a harness adapter in @sandbox-benchmarks/providers.
  */
-export type ProviderId = "e2b" | "daytona" | "modal" | "blaxel";
+export type ProviderId = "e2b" | "daytona" | "modal" | "blaxel" | "novita";
 
 /** Can the SDK request a pinned target spec (vCPU / memory) at create() time? */
 export type SpecPinning = "settable" | "fixed" | "unknown";
@@ -274,6 +274,49 @@ const REGISTRY: Record<ProviderId, Omit<ProviderMeta, "id">> = {
 			// ENG-64 validates this end-to-end against a live multi-minute suite.
 			streaming: false,
 			syncCapMs: null,
+			detachedPoll: true,
+		},
+	},
+	novita: {
+		displayName: "Novita",
+		website: "https://novita.ai/sandbox",
+		// Novita's control plane speaks the E2B protocol, so the harness drives it through the e2b
+		// wrapper with its connection methods backed by novita-sandbox (Novita's fork of the e2b SDK)
+		// — see the novita adapter's compat module.
+		sdkPackage: "@computesdk/e2b",
+		requiredEnvVars: ["NOVITA_API_KEY"],
+		isolation: {
+			technology: "microVM",
+			notes:
+				"Dedicated microVM per sandbox; E2B-protocol-compatible control plane (us-phx-1.sandbox.novita.ai) driven through @computesdk/e2b with novita-sandbox-backed connection methods.",
+		},
+		pricing: {
+			model: "per_vcpu_hour",
+			// $0.0000098/vCPU-s × 3600 = $0.03528/vCPU-hr; $0.0000032/GiB-s × 3600 = $0.01152/GiB-hr.
+			usdPerVcpuHour: 0.03528,
+			usdPerGibHour: 0.01152,
+			// Storage $0.00009/GB-hr with the first 60 GB free — the 20 GB target spec sits inside the
+			// free tier, so the marginal disk rate at TARGET_SPEC is 0 (known, not unknown).
+			usdPerGibDiskHour: 0,
+			notes:
+				"Published per-second rates (exact): $0.0000098/vCPU-s, $0.0000032/GiB-s. Storage $0.00009/GB-hr (first 60 GB free).",
+			sourceUrl: "https://novita.ai/sandbox",
+		},
+		maturity: {
+			status: "beta",
+			notes:
+				"E2B-compatible API; boots the pre-baked toolchain template created on Novita's control plane by the bake pipeline (novita-sandbox Template.build). Pay-as-you-go caps sandboxes at 8 vCPU / 8 GB RAM. Not yet a committed run.",
+		},
+		// E2B protocol: resources come from the template (cpu/memory pinned at template create), not
+		// the per-sandbox create() call.
+		specPinning: "fixed",
+		transport: {
+			// Same wrapper (and therefore the same caps) as e2b: `sandbox.commands.run(cmd)` with no
+			// options applies the E2B SDK's default 60s command timeout, and onStdout/onStderr are never
+			// passed through. The compat API exposes the same filesystem + `background`, so detached+poll
+			// is the long-step path.
+			streaming: false,
+			syncCapMs: 60_000,
 			detachedPoll: true,
 		},
 	},


### PR DESCRIPTION
**Novita provider — full end-to-end support via Novita's E2B-compatible API**
Shipped as a 5-PR stack (merge bottom-up, each branch independently green):
1. #124 — deps: `e2b` + `@computesdk/provider` catalog additions
2. #125 — config: `NOVITA_*` env keys, template names, empty-env-as-unset hardening
3. #126 — mechanism: `novitaCompute()` compat module (e2b wrapper re-pointed at Novita)
4. #127 — mechanism: `bakeNovitaTemplate` via `Template.build` on the regional control plane
5. #128 — wiring: schema registry entry + adapter + bake/promote + CI workflows

Supersedes #122 (the same change as one monolithic PR).
↑ **This PR is #128 (5/5)**, based on #127.

---

Adds novita to the ProviderId union and the schema REGISTRY (microVM isolation, published per-second pricing, fixed spec pinning at template create, e2b-transport caps), and everything the type change compile-forces in one green unit: the harness adapter (novitaCompute + snapshotId → configured template), the bake loop and promote path (bakeNovitaTemplate for candidate and public names), and candidateCreateOptions' exhaustive switch.

The workflow updates ride here for the same reason: the workflow-registry-sync drift gate pins bench-smoke.yml's provider options to the PROVIDERS id set, so the registry change and the options list must land together. bench-matrix and toolchain-image just pass NOVITA_API_KEY through (optional — a missing secret skips the novita bake without failing the publish).

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds the `novita` provider end to end: registered in `@sandbox-benchmarks/schema`, wired into `@sandbox-benchmarks/providers`, and enabled across bake/promote and CI. Runs via Novita’s E2B‑compatible control plane using `@computesdk/e2b` to boot a pre‑baked template.

- **New Features**
  - Schema: added `novita` to `ProviderId`/REGISTRY with microVM isolation, fixed spec pinning, and E2B transport caps; pricing $0.03528/vCPU‑hr + $0.01152/GiB‑hr; disk $0 at target (60 GB free); maturity: beta (8 vCPU/8 GB cap); notes updated for the novita‑sandbox path.
  - Adapter: implemented `novitaCompute` via `@computesdk/e2b` with novita‑sandbox connection methods; `createOptions` uses `{ snapshotId: config.novitaTemplate }`; gated by `NOVITA_API_KEY`.
  - Bake/Promote: wired `bakeNovitaTemplate` for candidate and public names; `candidateCreateOptions("novita")` → `{ snapshotId: <novitaTemplateCandidate> }`; reports include `novitaTemplate`.
  - CI/Tests: added `novita` to bench‑smoke provider options and pass `NOVITA_API_KEY`; bench‑matrix/toolchain‑image also pass it; tests pin the provider set and validate costs, disk rate, and credential gating.

- **Migration**
  - Add `NOVITA_API_KEY` to GitHub secrets; workflows pass it through. Missing `NOVITA_API_KEY` skips the Novita bake without failing publish.

<sup>Written for commit 5d8e701b129e4a5ff186356a8438b91f7fe1d4fc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/starslingdev/sandbox-benchmarks/pull/128?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

