### PR TITLE
perf(bench): lower PTS TimesToRun from 3 to 2

### DIFF
--- a/lib/bench.sh
+++ b/lib/bench.sh
@@ -178,8 +178,9 @@ _configure_pts_batch() {
 	export TEST_RESULTS_IDENTIFIER=ci
 	# FORCE_TIMES_TO_RUN=1 pins every test to a single pass (fast, but no in-sandbox repeats to
 	# aggregate). The sandbox harness sets PTS_RESPECT_TIMES_TO_RUN=1 to opt out, so PTS honours each
-	# profile's TimesToRun (3 by default) and writes the repeated samples our normalizer reads from
-	# RawString — the statistical confidence we want there.
+	# profile's TimesToRun (our profiles pin 2 — the floor; PTS re-runs beyond it when a test's
+	# stddev stays high) and writes the repeated samples our normalizer reads from RawString — the
+	# statistical confidence we want there.
 	if [ -z "${PTS_RESPECT_TIMES_TO_RUN:-}" ]; then
 		export FORCE_TIMES_TO_RUN=1
 	fi

--- a/packages/harness/src/lib/execute.ts
+++ b/packages/harness/src/lib/execute.ts
@@ -175,7 +175,8 @@ export const PREAMBLE = [
 	// Honour each PTS profile's TimesToRun (lib/bench.sh otherwise forces a single pass). The sandbox
 	// is the statistical-confidence path: the in-sandbox repeats give p50/stdev per Metric.
 	// BENCH_PASSES=1 (host env) opts a run out for fast contract-verification iteration -- one pass
-	// per task, ~3x faster on multi-pass suites; never set it for a run whose numbers you publish.
+	// per task, ~2x faster on multi-pass suites (profiles pin TimesToRun=2); never set it for a run
+	// whose numbers you publish.
 	...(process.env.BENCH_PASSES === "1" ? [] : ["export PTS_RESPECT_TIMES_TO_RUN=1"]),
 	'if [ "$(id -u)" = 0 ]; then SUDO=""; elif command -v sudo >/dev/null 2>&1; then SUDO="sudo -E"; else SUDO=""; fi',
 ].join("; ");

--- a/packages/schema/src/pts-profiles/c-ray-2.0.0/test-definition.xml
+++ b/packages/schema/src/pts-profiles/c-ray-2.0.0/test-definition.xml
@@ -8,7 +8,7 @@
     <ResultScale>Seconds</ResultScale>
     <Proportion>LIB</Proportion>
     <SubTitle>Total Time - 4K, 16 Rays Per Pixel</SubTitle>
-    <TimesToRun>3</TimesToRun>
+    <TimesToRun>2</TimesToRun>
   </TestInformation>
   <TestProfile>
     <Version>2.0.0</Version>

--- a/packages/schema/src/pts-profiles/local/hardlink-1.0.0/test-definition.xml
+++ b/packages/schema/src/pts-profiles/local/hardlink-1.0.0/test-definition.xml
@@ -7,7 +7,7 @@
     <Description>Measures hardlink() syscall throughput using the stress-ng --link stressor. Mirrors the per-syscall pattern that pnpm install hits when materialising thousands of node_modules entries from a content-addressable store. Reports bogo ops/sec (real time) — one bogo op = one create+unlink hardlink cycle.</Description>
     <ResultScale>bogo ops/s</ResultScale>
     <Proportion>HIB</Proportion>
-    <TimesToRun>3</TimesToRun>
+    <TimesToRun>2</TimesToRun>
   </TestInformation>
   <TestProfile>
     <Version>1.0.0</Version>

--- a/packages/schema/src/pts-profiles/local/realworld-better-auth-1.0.0/test-definition.xml
+++ b/packages/schema/src/pts-profiles/local/realworld-better-auth-1.0.0/test-definition.xml
@@ -8,7 +8,7 @@
     <ResultScale>Seconds</ResultScale>
     <Proportion>LIB</Proportion>
     <Executable>realworld-run</Executable>
-    <TimesToRun>3</TimesToRun>
+    <TimesToRun>2</TimesToRun>
   </TestInformation>
   <TestProfile>
     <Version>1.0.0</Version>

--- a/packages/schema/src/pts-profiles/local/realworld-mastra-1.0.0/test-definition.xml
+++ b/packages/schema/src/pts-profiles/local/realworld-mastra-1.0.0/test-definition.xml
@@ -8,7 +8,7 @@
     <ResultScale>Seconds</ResultScale>
     <Proportion>LIB</Proportion>
     <Executable>realworld-run</Executable>
-    <TimesToRun>3</TimesToRun>
+    <TimesToRun>2</TimesToRun>
   </TestInformation>
   <TestProfile>
     <Version>1.0.0</Version>

--- a/packages/schema/src/pts-profiles/local/realworld-openclaw-1.0.0/test-definition.xml
+++ b/packages/schema/src/pts-profiles/local/realworld-openclaw-1.0.0/test-definition.xml
@@ -8,7 +8,7 @@
     <ResultScale>Seconds</ResultScale>
     <Proportion>LIB</Proportion>
     <Executable>realworld-run</Executable>
-    <TimesToRun>3</TimesToRun>
+    <TimesToRun>2</TimesToRun>
   </TestInformation>
   <TestProfile>
     <Version>1.0.0</Version>

--- a/packages/schema/src/pts-profiles/node-web-tooling-1.0.1/test-definition.xml
+++ b/packages/schema/src/pts-profiles/node-web-tooling-1.0.1/test-definition.xml
@@ -6,7 +6,7 @@
     <Description>Running the V8 project's Web-Tooling-Benchmark under Node.js. The Web-Tooling-Benchmark stresses JavaScript-related workloads common to web developers like Babel and TypeScript and Babylon. This test profile can test the system's JavaScript performance with Node.js.</Description>
     <ResultScale>runs/s</ResultScale>
     <Proportion>HIB</Proportion>
-    <TimesToRun>3</TimesToRun>
+    <TimesToRun>2</TimesToRun>
   </TestInformation>
   <TestProfile>
     <Version>1.0.1</Version>

--- a/packages/schema/src/pts-profiles/pybench-1.1.3/test-definition.xml
+++ b/packages/schema/src/pts-profiles/pybench-1.1.3/test-definition.xml
@@ -8,7 +8,7 @@
     <ResultScale>Milliseconds</ResultScale>
     <Proportion>LIB</Proportion>
     <SubTitle>Total For Average Test Times</SubTitle>
-    <TimesToRun>3</TimesToRun>
+    <TimesToRun>2</TimesToRun>
   </TestInformation>
   <TestProfile>
     <Version>1.1.3</Version>

--- a/packages/schema/src/pts-profiles/sqlite-speedtest-1.0.1/test-definition.xml
+++ b/packages/schema/src/pts-profiles/sqlite-speedtest-1.0.1/test-definition.xml
@@ -8,7 +8,7 @@
     <ResultScale>Seconds</ResultScale>
     <Proportion>LIB</Proportion>
     <SubTitle>Timed Time - Size 1,000</SubTitle>
-    <TimesToRun>3</TimesToRun>
+    <TimesToRun>2</TimesToRun>
   </TestInformation>
   <TestProfile>
     <Version>1.0.1</Version>


### PR DESCRIPTION
Drop the in-sandbox repeat floor from 3 to 2 on every profile that pinned 3
(realworld better-auth/mastra/openclaw plus the micro-benchmarks node-web-tooling,
c-ray, sqlite-speedtest, pybench, hardlink). STREAM (5) and the selftest (1) are
left as-is.

Two passes is still a floor, not a cap: PTS_RESPECT_TIMES_TO_RUN keeps
DynamicRunCount on, so PTS re-runs a test beyond TimesToRun whenever its stddev
stays above threshold — we let PTS spend extra passes only where variance
actually needs them, instead of paying a fixed third pass on every task. On the
realworld suites (each task serial, cold install + build multi-minute) that
removes ~1/3 of the per-cell wall clock; the micro-benchmarks keep their two-pass
p50/stddev.

TimesToRun is not read by the catalog parser (parse.ts ignores it) and no test
asserts its value, so this is a pure runtime-budget change.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Lowered PTS `TimesToRun` floor from 3 to 2 across realworld profiles (`better-auth`, `mastra`, `openclaw`) and micro-benchmarks (`node-web-tooling`, `c-ray`, `sqlite-speedtest`, `pybench`, `hardlink`) to cut runtime; `STREAM` (5) and selftest (1) unchanged.
Sandbox runs honor `TimesToRun` via `PTS_RESPECT_TIMES_TO_RUN` (DynamicRunCount on) so extra passes run only when variance is high; realworld cells are ~1/3 faster, micro-benchmark p50/stdev unchanged; updated harness comments and noted `BENCH_PASSES=1` is now ~2x faster on multi-pass suites.

<sup>Written for commit 7c6562aa647aa865fce15980e266f4f947610729. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/starslingdev/sandbox-benchmarks/pull/129?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

