### PR TITLE
fix(providers): provision 40 GiB disk so realworld suites stop skipping

### DIFF
--- a/apps/cli/src/lib/bake/e2b.ts
+++ b/apps/cli/src/lib/bake/e2b.ts
@@ -85,6 +85,10 @@ export async function bakeE2bTemplate(name: string, baseImage: string, log: Log)
 			E2B_CONTEXT,
 			"--dockerfile",
 			E2B_DOCKERFILE_GENERATED,
+			// No --disk-size-mb: @e2b/cli template create exposes only --cpu-count/--memory-mb (checked on
+			// the pinned 2.12.0), so e2b/novita disk is platform-fixed and can't be raised to
+			// TARGET_SPEC.diskGb the way Daytona's snapshot resources.disk is. The heavy realworld suites
+			// that need the disk therefore skip on e2b/novita — surfaced as a leaderboard coverage gap.
 			"--cpu-count",
 			String(config.targetSpec.vcpus),
 			"--memory-mb",

--- a/packages/providers/src/lib/config.ts
+++ b/packages/providers/src/lib/config.ts
@@ -85,7 +85,7 @@ const novitaTemplateCandidate = e2bTemplateCandidate;
 
 // 3. The single, fully-typed config object. Everything that needs config imports THIS.
 export const config = {
-	/** Pinned cross-provider target spec (2 vCPU / 8 GiB / 20 GB). */
+	/** Pinned cross-provider target spec — see {@link TARGET_SPEC} for the dimensions and sizing rationale. */
 	targetSpec: TARGET_SPEC,
 	/** Immutable toolchain image version tag. */
 	toolchainVersion: TOOLCHAIN_VERSION,

--- a/packages/results/src/lib/specs.ts
+++ b/packages/results/src/lib/specs.ts
@@ -109,6 +109,14 @@ export function readObservedSpecs(readJson: JsonReader): ObservedSpecs {
  * Did the sandbox honor the pinned target spec? vCPUs must match exactly; memory within ±10%
  * (kernels reserve some). Undefined when either observation is missing — we refuse to judge on
  * partial evidence.
+ *
+ * Deliberately covers the COMPARABILITY dimensions only — the two that decide whether two providers'
+ * numbers may be put side by side. {@link TARGET_SPEC}.diskGb is excluded even though it is part of
+ * the spec: disk is a gate on whether a suite can run at all, not an axis anyone is ranked on (it is
+ * excluded from `hourlyCostAtTargetSpec` for the same reason), and providers that cannot express disk
+ * would otherwise all report `specMatched: false` for a dimension that never touched their results.
+ * A disk shortfall is not silently absorbed here — it surfaces as a skip with an "Insufficient disk"
+ * reason and is rendered as an explicit leaderboard coverage gap.
  */
 export function computeSpecMatched(specs: ObservedSpecs): boolean | undefined {
 	if (specs.vcpus === undefined || specs.memoryGb === undefined) return undefined;

--- a/packages/schema/src/providers.ts
+++ b/packages/schema/src/providers.ts
@@ -111,12 +111,21 @@ export interface ProviderMeta {
 }
 
 /**
- * The pinned cross-provider target spec: 2 vCPU, 8 GiB RAM, 20 GB disk. Sized to fit inside every
- * provider's reproducible envelope — E2B caps sandbox RAM at 8 GiB — so anyone can rerun the
- * benchmark on the same shape. Providers that can't express a dimension run with actuals recorded
- * and the mismatch disclosed downstream.
+ * The pinned cross-provider target spec: 2 vCPU, 8 GiB RAM, 40 GB disk. vCPU/RAM are sized to fit
+ * inside every provider's reproducible envelope — E2B caps sandbox RAM at 8 GiB — so anyone can rerun
+ * the benchmark on the same shape. Disk is sized for the realworld suites' working set instead: a
+ * cold monorepo install + full build needs ~30 GiB free (mastra's `minDiskGb`), and at 20 GB a
+ * Daytona sandbox had only 16.7 GiB free, silently skipping mastra/openclaw. Disk is NOT a comparison
+ * axis and is excluded from {@link hourlyCostAtTargetSpec}, so a larger disk can't bias the ranking.
+ *
+ * Providers that expose a per-sandbox/snapshot disk get 40 GiB (Daytona, via the snapshot's
+ * `resources.disk`); Modal has no disk knob but its gVisor root reports effectively unbounded disk,
+ * so it clears the gate anyway. Providers that CANNOT express disk — e2b/novita (the `@e2b/cli`
+ * `template create` takes only `--cpu-count`/`--memory-mb`) and blaxel (disk is a RAM-derived tmpfs)
+ * — run with actuals recorded, and the heavy suites that need the disk skip there. Those skips are
+ * surfaced as an explicit coverage gap in the leaderboard, never silently dropped.
  */
-export const TARGET_SPEC = { vcpus: 2, memoryGb: 8, diskGb: 20 } as const;
+export const TARGET_SPEC = { vcpus: 2, memoryGb: 8, diskGb: 40 } as const;
 
 /**
  * Modal provisions and prices in physical CPU cores, where 1 physical core = 2 vCPU. This is the one
@@ -217,7 +226,7 @@ const REGISTRY: Record<ProviderId, Omit<ProviderMeta, "id">> = {
 		isolation: {
 			technology: "microVM",
 			notes:
-				"Blaxel sandboxes (sub-25ms boot claim). Spec dimensions are COUPLED: CPU cores = memory MB / 2048 and disk is a tmpfs overlay at ~78% of memory, so the 2 vCPU / 8 GiB / 20 GB target spec is inexpressible -- the adapter runs oversized (16 GiB => 8-core allocation, ~12.5 GiB disk) and relies on observed-specs disclosure (specMatched=false) downstream.",
+				"Blaxel sandboxes (sub-25ms boot claim). Spec dimensions are COUPLED: CPU cores = memory MB / 2048 and disk is a tmpfs overlay at ~78% of memory, so the 2 vCPU / 8 GiB / 40 GB target spec is inexpressible -- the adapter runs oversized (16 GiB => 8-core allocation, ~12.5 GiB disk) and relies on observed-specs disclosure (specMatched=false) downstream.",
 		},
 		pricing: {
 			model: "unknown",
@@ -256,7 +265,7 @@ const REGISTRY: Record<ProviderId, Omit<ProviderMeta, "id">> = {
 			// Memory: $0.00000672/GiB-s × 3600 = $0.024192/GiB-hr.
 			usdPerVcpuHour: 0.070956,
 			usdPerGibHour: 0.024192,
-			// Volumes: 1 TiB/mo free, then $0.09/GiB/mo. The 20 GB target spec sits inside the free
+			// Volumes: 1 TiB/mo free, then $0.09/GiB/mo. The 40 GB target spec sits inside the free
 			// tier, so the marginal disk rate at TARGET_SPEC is 0 (known, not unknown).
 			usdPerGibDiskHour: 0,
 			notes:
@@ -295,7 +304,7 @@ const REGISTRY: Record<ProviderId, Omit<ProviderMeta, "id">> = {
 			// $0.0000098/vCPU-s × 3600 = $0.03528/vCPU-hr; $0.0000032/GiB-s × 3600 = $0.01152/GiB-hr.
 			usdPerVcpuHour: 0.03528,
 			usdPerGibHour: 0.01152,
-			// Storage $0.00009/GB-hr with the first 60 GB free — the 20 GB target spec sits inside the
+			// Storage $0.00009/GB-hr with the first 60 GB free — the 40 GB target spec sits inside the
 			// free tier, so the marginal disk rate at TARGET_SPEC is 0 (known, not unknown).
 			usdPerGibDiskHour: 0,
 			notes:


### PR DESCRIPTION
Raise TARGET_SPEC.diskGb from 20 to 40. At 20 GB a Daytona sandbox had only
16.7 GiB free, so realworld-mastra (minDiskGb 30) and realworld-openclaw (25)
silently skipped there; 40 GiB provisioned leaves ~36.7 GiB free, clearing both.

Disk flows to each provider by whatever knob it exposes:
  - Daytona: the snapshot bake already passes resources.disk = targetSpec.diskGb,
    so the snapshot is now cut at 40 GiB (takes effect on the next bake).
  - Modal: no disk knob, but its gVisor root reports effectively unbounded disk,
    so it already clears the gate and runs the heavy suites.
  - e2b/novita: @e2b/cli template create exposes only --cpu-count/--memory-mb
    (verified on the pinned 2.12.0) — disk is platform-fixed and cannot be
    raised, so the heavy suites keep skipping there (surfaced as a leaderboard
    coverage gap in the next PR).
  - blaxel: disk is a RAM-derived tmpfs; excluded from the default matrix.

Disk is NOT a comparison axis and is excluded from hourlyCostAtTargetSpec, so a
larger disk can't bias the ranking; the 40 GB still sits inside every provider's
disk free tier, so no cost figure changes. Only descriptive '20 GB target spec'
strings were synced to 40 GB. No test pins the spec value.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Increase `TARGET_SPEC.diskGb` from 20 to 40 GiB to stop heavy realworld suites from skipping and restore accurate coverage. Aligns with ENG-146.

- **Bug Fixes**
  - Daytona snapshots now bake at 40 GiB, clearing `realworld-mastra` (30 GiB min) and `realworld-openclaw` (25 GiB).
  - Modal unchanged (no disk knob; effectively unbounded). `e2b/novita` unchanged (`@e2b/cli` only sets CPU/RAM), so heavy suites still skip. Blaxel excluded (tmpfs).
  - No ranking/cost impact: disk not in `hourlyCostAtTargetSpec`; 40 GiB stays inside free tiers. Docs updated: provider notes and JSDoc reference `TARGET_SPEC`; results clarify `specMatched` checks vCPU/memory only, and disk shortfalls surface as "Insufficient disk" skips.

<sup>Written for commit 2644cfdce2b5708da15d647230413a945ad6993c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/starslingdev/sandbox-benchmarks/pull/130?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Configuration**
  - Increased the cross-provider target specification from 20 GB to 40 GB of disk space.
  - Updated provider guidance and pricing notes to reflect the new target.

- **Documentation**
  - Clarified how provider specifications are compared, including that disk capacity is treated as a requirement rather than a ranking dimension.
  - Documented cases where providers cannot meet the disk requirement and may be excluded from coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->