### PR TITLE
fix(harness): fail fast when a sandbox dies mid-suite instead of burning the command budget

### DIFF
--- a/packages/harness/src/lib/execute.test.ts
+++ b/packages/harness/src/lib/execute.test.ts
@@ -248,6 +248,80 @@ describe("StepRunner.runDetached", () => {
 		await expect(runner.runDetached("bench", "false", 60_000)).rejects.toThrow(/exit code 42/);
 	});
 
+	it("fails fast when the cat poll returns a non-zero exit — a wedged shell, not still-running", async () => {
+		// Regression: the `|| echo __RUNNING__` guard makes bash exit 0 for both a present and an absent
+		// done-file, so a non-zero exit means the shell itself couldn't run. runCommand RESOLVES with
+		// that code rather than rejecting, so it slipped past the throw-based fast-fail and read as
+		// "still running" — sitting on a wedged sandbox for the whole budget.
+		let launched = false;
+		const sandbox: SandboxHandle = {
+			runCommand: async (command) => {
+				if (!launched && command.includes("nohup")) {
+					launched = true;
+					return { exitCode: 0, stdout: "launched" };
+				}
+				return { exitCode: 137, stdout: "" }; // shell couldn't run: no reject, just a bad code
+			},
+			destroy: async () => undefined,
+		};
+		const runner = new StepRunner(sandbox, CAPPED, async () => undefined);
+		await expect(runner.runDetached("bench", "mise run benchmark", 60 * 60_000)).rejects.toThrow(
+			/lost its sandbox.*stopped responding/,
+		);
+	});
+
+	it("fails fast when every detached poll throws — a dead sandbox, not a quiet step", async () => {
+		// Regression: poll failures were swallowed as "not done yet", so a sandbox killed mid-step
+		// (e2b orchestrator-stops, 2026-07-10) looked like a quietly-running benchmark for the WHOLE
+		// command budget — CI cells sat on a corpse for 60+ minutes until the runner was reclaimed.
+		let launched = false;
+		const sandbox: SandboxHandle = {
+			runCommand: async (command) => {
+				if (!launched && command.includes("nohup")) {
+					launched = true;
+					return { exitCode: 0, stdout: "launched" };
+				}
+				throw new Error("sandbox is probably not running anymore");
+			},
+			destroy: async () => undefined,
+			filesystem: {
+				exists: async () => {
+					throw new Error("sandbox is probably not running anymore");
+				},
+				readFile: async () => {
+					throw new Error("sandbox is probably not running anymore");
+				},
+			},
+		};
+		const runner = new StepRunner(sandbox, CAPPED, async () => undefined);
+		// Budget far above the poll-failure threshold: the fast-fail, not the deadline, must trip.
+		await expect(runner.runDetached("bench", "mise run benchmark", 60 * 60_000)).rejects.toThrow(
+			/lost its sandbox.*stopped responding/,
+		);
+	});
+
+	it("tolerates a transient poll blip when later polls succeed", async () => {
+		// One flaky poll must not kill an hour-long benchmark — only a consecutive run of failures may.
+		let polls = 0;
+		const sandbox: SandboxHandle = {
+			runCommand: async () => ({ exitCode: 0, stdout: "launched" }),
+			destroy: async () => undefined,
+			filesystem: {
+				exists: async (path) => {
+					if (!path.endsWith(".done")) return false;
+					polls++;
+					if (polls === 1) throw new Error("transient fs blip");
+					return polls >= 3;
+				},
+				readFile: async (path) => (path.endsWith(".done") ? "0" : "recovered fine"),
+			},
+		};
+		const runner = new StepRunner(sandbox, CAPPED, async () => undefined);
+		const result = await runner.runDetached("bench", "mise run benchmark", 60_000);
+		expect(result.exitCode).toBe(0);
+		expect(result.stdout).toBe("recovered fine");
+	});
+
 	it("distinguishes a wedged from a quiet sandbox on the no-filesystem path too", async () => {
 		// Regression: readLogTail read the log via catFile, which folds every failure into "". On a
 		// provider with no filesystem API the `.catch(() => null)` could therefore never fire, so a

--- a/packages/harness/src/lib/execute.ts
+++ b/packages/harness/src/lib/execute.ts
@@ -36,6 +36,13 @@ export const MIN = 60_000;
 const POLL_START_MS = 1_500;
 const POLL_BACKOFF = 1.5;
 const POLL_CAP_MS = 10_000;
+/** Consecutive failed detached polls before concluding the sandbox itself is gone. One transient
+ *  blip must not kill an hour-long benchmark, but a sandbox that stops answering EVERY poll is dead
+ *  (e2b was observed orchestrator-stopping sandboxes ~4.5 min in, 2026-07-10), and treating that as
+ *  "still running" burned the full command budget — CI cells then sat on a corpse for 60+ minutes
+ *  until the runner itself was reclaimed. 12 failures ≈ 2–4 min of continuous unreachability at the
+ *  capped poll interval. */
+const MAX_CONSECUTIVE_POLL_FAILURES = 12;
 /** How much of a timed-out detached step's log to surface — enough to diagnose, not enough to flood. */
 const TIMEOUT_LOG_TAIL_LINES = 50;
 /** Done-file sentinel for the no-filesystem cat-poll fallback: printed while the file isn't there yet. */
@@ -300,10 +307,27 @@ export class StepRunner {
 			// Poll for the done-file, backing off adaptively so a quick step isn't over-charged for polls.
 			const deadline = started + timeoutMs;
 			let pollDelayMs = POLL_START_MS;
+			let consecutivePollFailures = 0;
 			for (;;) {
-				const exitCode = fs
-					? await this.pollDoneViaFs(fs, donePath)
-					: await this.pollDoneViaCat(donePath);
+				// A poll that THROWS is different from "not done yet": one blip is transient, but a run of
+				// them means the sandbox stopped answering — fail fast instead of sitting on a dead sandbox
+				// for the rest of the command budget (see MAX_CONSECUTIVE_POLL_FAILURES).
+				let exitCode: number | undefined;
+				try {
+					exitCode = fs
+						? await this.pollDoneViaFs(fs, donePath)
+						: await this.pollDoneViaCat(donePath);
+					consecutivePollFailures = 0;
+				} catch (err) {
+					consecutivePollFailures++;
+					if (consecutivePollFailures >= MAX_CONSECUTIVE_POLL_FAILURES) {
+						const reason = err instanceof Error ? err.message : String(err);
+						throw new Error(
+							`Step "${label}" lost its sandbox: ${consecutivePollFailures} consecutive detached ` +
+								`polls failed (last: ${reason}) — the sandbox stopped responding, not a quiet long step`,
+						);
+					}
+				}
 				if (exitCode !== undefined) {
 					const stdout = fs
 						? await withTimeout(fs.readFile(logPath), POLL_CAP_MS, "log fs read").catch(() => "")
@@ -344,37 +368,44 @@ export class StepRunner {
 		fs: SandboxFilesystem,
 		donePath: string,
 	): Promise<number | undefined> {
-		try {
-			// Bound both fs calls so a hung filesystem API (some adapters go over the network) can't
-			// stall the poll loop indefinitely — the outer deadline only advances between iterations.
-			if (!(await withTimeout(fs.exists(donePath), POLL_CAP_MS, "done-file fs exists"))) {
-				return undefined;
-			}
-			// The background script writes the done-file non-atomically (truncate, then echo the code),
-			// so an empty read means "created but not yet written" — still running, not exit 0.
-			const raw = (
-				await withTimeout(fs.readFile(donePath), POLL_CAP_MS, "done-file fs read")
-			).trim();
-			return raw === "" ? undefined : parseExitCode(raw);
-		} catch {
-			// A transient fs blip counts as not-yet-done; the caller's deadline bounds total retry time.
+		// Bound both fs calls so a hung filesystem API (some adapters go over the network) can't
+		// stall the poll loop indefinitely — the outer deadline only advances between iterations.
+		// A timeout or fs error THROWS to the poll loop, which tolerates a transient blip but fails
+		// fast on a run of them (a dead sandbox); swallowing errors here once made a killed sandbox
+		// indistinguishable from a quietly-running step for the entire command budget.
+		if (!(await withTimeout(fs.exists(donePath), POLL_CAP_MS, "done-file fs exists"))) {
 			return undefined;
 		}
+		// The background script writes the done-file non-atomically (truncate, then echo the code),
+		// so an empty read means "created but not yet written" — still running, not exit 0.
+		const raw = (await withTimeout(fs.readFile(donePath), POLL_CAP_MS, "done-file fs read")).trim();
+		return raw === "" ? undefined : parseExitCode(raw);
 	}
 
 	/** Poll fallback for providers whose adapter exposes no filesystem API: read the done-file with a
 	 *  `cat` exec, treating the {@link RUNNING_SENTINEL} (or empty output) as not-done-yet. */
 	private async pollDoneViaCat(donePath: string): Promise<number | undefined> {
-		// Bound the exec so a hung `cat` can't outlast the step budget, and treat any transient
-		// exec error as not-yet-done (the caller's deadline bounds total retry time).
+		// Bound the exec so a hung `cat` can't outlast the step budget. An exec failure or timeout
+		// THROWS to the poll loop (which tolerates transient blips but fails fast on a dead sandbox);
+		// an absent done-file is the RUNNING_SENTINEL, not an error.
 		const probe = await withTimeout(
 			this.sandbox.runCommand(
 				`bash -c ${shellQuote(`cat ${donePath} 2>/dev/null || echo ${RUNNING_SENTINEL}`)}`,
 			),
 			POLL_CAP_MS,
 			"done-file cat poll",
-		).catch(() => undefined);
-		const out = (probe?.stdout ?? "").trim();
+		);
+		// The `|| echo RUNNING_SENTINEL` guard makes bash exit 0 whether the done-file is present or
+		// absent, so a non-zero code means the shell itself couldn't run — a wedged sandbox, not a
+		// missing done-file. THROW so the poll loop's consecutive-failure fast-fail engages, matching
+		// pollDoneViaFs; swallowing it as "still running" would sit on a dead sandbox for the whole
+		// step budget — the exact failure this detached path exists to catch.
+		if (probe.exitCode !== 0) {
+			throw new Error(
+				`done-file cat poll returned exit ${probe.exitCode} — sandbox not responding`,
+			);
+		}
+		const out = (probe.stdout ?? "").trim();
 		if (out === "" || out === RUNNING_SENTINEL) return undefined;
 		return parseExitCode(out);
 	}


### PR DESCRIPTION
Detached polling treated EVERY poll error as "not done yet", so a sandbox that
died mid-step was indistinguishable from a quiet long step for the whole command
budget — e2b's orchestrator stops toolchain-template sandboxes ~4.5 min in
(fresh trivial 2cpu/8GB templates survive; tracked separately), and CI cells sat
on the corpse until the Depot runner was reclaimed at ~64-70 min. Poll helpers
now throw and the loop fails the step after 12 consecutive failures (~2-4 min)
instead of burning the budget.

The cat-poll fallback also masked a wedged sandbox: its `|| echo RUNNING_SENTINEL`
guard makes bash exit 0 whether the done-file exists or not, so a non-zero exit
means the shell itself couldn't run. Treat that as a poll failure too, matching
pollDoneViaFs.

Claude-Session: https://claude.ai/code/session_01DWt5bJUMKni4yQE9zgiG8S

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fail fast when a detached sandbox stops responding, instead of waiting out the full command budget. Addresses ENG-146 by preventing 60+ minute CI hangs when e2b kills a sandbox mid-step.

- **Bug Fixes**
  - Abort after 12 consecutive detached poll failures (~2–4 min at cap) instead of treating errors as “still running”.
  - Make both fs- and cat-based polls surface failures to the loop; treat non-zero `cat` exit as a wedged shell.
  - Keep transient tolerance: reset the counter on success; bound all poll execs and fs calls by `POLL_CAP_MS`.
  - Added tests for dead sandbox, wedged shell, and transient blips in `packages/harness`.

<sup>Written for commit c99330b695ce74cc5bbb1bde3560605b8fea0952. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/starslingdev/sandbox-benchmarks/pull/132?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

