### PR TITLE
fix(bench): route Modal suite-length steps over detached poll and raise better-auth budgets

### DIFF
--- a/packages/schema/src/providers.ts
+++ b/packages/schema/src/providers.ts
@@ -270,13 +270,14 @@ const REGISTRY: Record<ProviderId, Omit<ProviderMeta, "id">> = {
 		specPinning: "settable",
 		transport: {
 			// `@computesdk/modal` runs `sandbox.exec([...])` and `process.wait()`s the result, with no
-			// separate per-exec timeout — a synchronous exec is bounded only by the create-time sandbox
-			// lifetime, not a server gateway cap (`syncCapMs: null`). It still doesn't surface
-			// onStdout/onStderr (it reads the piped streams to completion), and `background` + filesystem
-			// are available, so detached+poll remains an option even though direct exec is the default.
-			// ENG-64 validates this end-to-end against a live multi-minute suite.
+			// separate per-exec timeout. There is no hard server gateway cap, but the exec stdio stream
+			// is not reliable over benchmark-length execs: a ~66-minute better-auth run completed
+			// in-sandbox (manifest exit_code 0) while the harness-side stream died with gRPC INTERNAL
+			// "Failed to read exec stdio stream" (ZEHA3277, 2026-07-10), losing the step result. Cap
+			// synchronous execs at 30 minutes so suite-length steps take the detached+poll path, which
+			// survives a dropped stream; short setup steps keep the cheaper direct exec.
 			streaming: false,
-			syncCapMs: null,
+			syncCapMs: 30 * 60_000,
 			detachedPoll: true,
 		},
 	},

--- a/packages/schema/src/suites.ts
+++ b/packages/schema/src/suites.ts
@@ -117,11 +117,17 @@ export const SUITES = {
 		],
 		commands: ["mise run benchmark:realworld:pts:mastra"],
 	},
+	// Budgets from measured 2026-07-10 runs at the 2-vCPU spec: daytona ~18 min, modal ~67 min (gVisor
+	// syscall overhead on the per-run git-clean/install resets; measured via a complete local run —
+	// the old 60-min command budget killed modal at test 9/10). 90 covers modal plus variance without
+	// letting a wedged provider eat the whole runner. e2b currently never gets past ~4.5 min: its
+	// sandboxes from our template are orchestrator-stopped regardless of requested lifetime (platform
+	// issue, tracked separately) — no budget fixes that.
 	"realworld-better-auth": {
 		setupPts: true,
 		setupNode: true,
-		commandTimeoutMinutes: 60,
-		timeoutMinutes: 75,
+		commandTimeoutMinutes: 90,
+		timeoutMinutes: 105,
 		minDiskGb: 10,
 		dimensions: ["realworld"],
 		metrics: [


### PR DESCRIPTION
Modal's exec stdio stream is not benchmark-durable: a complete ~66-min suite
finished in-sandbox (manifest exit 0) while the synchronous exec died with gRPC
INTERNAL "Failed to read exec stdio stream" (ZEHA3277), losing the step. Cap
Modal's synchronous execs at 30 min so suite-length steps take the detached+poll
transport — a full better-auth run validated end-to-end through that path
(32.8-min PTS phase, 10/10 tasks, provider validated).

better-auth budgets move to 90/105 min: measured full runs at the 2-vCPU spec
are ~18 min (daytona) and 33-67 min (modal, high host variance).

Claude-Session: https://claude.ai/code/session_01DWt5bJUMKni4yQE9zgiG8S

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Cap Modal synchronous execs at 30 minutes to route long benchmark steps over detached+poll and avoid dropped stdio streams. Increase better-auth budgets to 90/105 minutes to handle provider variance and prevent premature timeouts (ENG-146).

- **Bug Fixes**
  - `@computesdk/modal`: set `syncCapMs` to 30 min; long steps use detached+poll, short setup stays direct exec.
  - realworld-better-auth: command timeout 90 min (was 60); suite timeout 105 min (was 75) for 2‑vCPU runs.

<sup>Written for commit e05831f714b2c1968c44bb0419d5a425468c984b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/starslingdev/sandbox-benchmarks/pull/133?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

