### PR TITLE
feat(schema): scale-aware PTS metric identity (pts.scale) + O(1) result lookup

### DIFF
--- a/packages/results/src/lib/extract.test.ts
+++ b/packages/results/src/lib/extract.test.ts
@@ -65,7 +65,7 @@ describe("extractProviderDir", () => {
 		// DB services no sandbox provides); its measured <Result> now routes to `uncatalogued` -- the
 		// designed straggler path, pinned here so an ACCIDENTAL catalog miss can't hide behind it.
 		expect(extraction.uncatalogued.map((u) => u.id)).toEqual([
-			"local/realworld-better-auth::Task: Test",
+			"local/realworld-better-auth::Task: Test::Seconds",
 		]);
 		expect(extraction.contributions.map((c) => c.metricId).sort()).toEqual(
 			[

--- a/packages/results/src/lib/extract.ts
+++ b/packages/results/src/lib/extract.ts
@@ -87,7 +87,11 @@ export function extractProviderDir(dir: string, providerId: string): ProviderExt
 						break;
 					case "uncatalogued":
 						out.uncatalogued.push({
-							id: `${mapped.test}::${mapped.description || "default"}`,
+							// Scale is part of the id: scale-pinned twins (fio posts MB/s and IOPS under one
+							// description) share a test+description, so without it two stragglers whose
+							// `<Scale>` matched no pin collapse onto one id and the dedupe downstream
+							// (normalize-tree) silently drops the second measurement.
+							id: `${mapped.test}::${mapped.description || "default"}::${mapped.scale}`,
 							// Entry[0].Value is a guaranteed number — the schema parses it and we skipped the
 							// entry-less results above.
 							value: headEntry.Value,

--- a/packages/results/src/lib/pts.test.ts
+++ b/packages/results/src/lib/pts.test.ts
@@ -1,7 +1,15 @@
 import { describe, expect, it } from "bun:test";
 import { readFileSync } from "node:fs";
 import { join } from "node:path";
-import { parsePtsComposite, ptsResultToMetric, resultSamples, versionlessTest } from "./pts.ts";
+import type { MetricDef } from "@sandbox-benchmarks/schema";
+import {
+	buildPtsIndex,
+	parsePtsComposite,
+	ptsResultToMetric,
+	resultSamples,
+	versionlessTest,
+} from "./pts.ts";
+import type { PtsResult } from "./pts-schema.ts";
 
 const realFixture = readFileSync(
 	join(import.meta.dir, "__fixtures__/daytona/pts_node-web-tooling.xml"),
@@ -135,7 +143,78 @@ describe("ptsResultToMetric", () => {
 			kind: "uncatalogued",
 			test: "pts/git",
 			description: "",
+			scale: "Seconds",
 		});
+	});
+});
+
+// The scale-pinned arm has no coverage through the real catalog: no METRIC_CATALOG entry carries a
+// `pts.scale` pin until fio is vendored two branches up, so the precedence order and — critically —
+// the BUILD/LOOKUP key-shape agreement would ship unexecuted. `buildPtsIndex` is the same seam
+// `catalogSchema` already offers: drive it with a crafted catalog rather than waiting for the pins.
+describe("buildPtsIndex scale-pinned routing", () => {
+	const base = {
+		dimension: "disk",
+		direction: "HIB",
+		headline: false,
+		label: "l",
+		description: "d",
+	} as const;
+	const catalog: MetricDef[] = [
+		{
+			...base,
+			id: "twin_mb_per_s",
+			unit: "MB/s",
+			pts: { test: "pts/fio", description: "4K", scale: "MB/s" },
+		},
+		{
+			...base,
+			id: "twin_iops",
+			unit: "IOPS",
+			pts: { test: "pts/fio", description: "4K", scale: "IOPS" },
+		},
+		{ ...base, id: "described", unit: "s", pts: { test: "pts/other", description: "Only" } },
+		{ ...base, id: "wild", unit: "s", pts: { test: "pts/wild" } },
+	];
+	const match = buildPtsIndex(catalog);
+	const result = (identifier: string, description: string, scale: string): PtsResult =>
+		({
+			Identifier: identifier,
+			Description: description,
+			Scale: scale,
+			Data: { Entry: [{ Value: 1 }] },
+		}) as PtsResult;
+
+	it("routes each scale twin to ITS OWN entry (a swap is what this catches)", () => {
+		const mb = match(result("pts/fio-2.1.0", "4K", "MB/s"));
+		const iops = match(result("pts/fio-2.1.0", "4K", "IOPS"));
+		if (mb.kind !== "matched" || iops.kind !== "matched") throw new Error("expected matches");
+		expect(mb.def.id).toBe("twin_mb_per_s");
+		expect(iops.def.id).toBe("twin_iops");
+	});
+
+	it("falls to uncatalogued (never the nearest twin) when <Scale> matches no pin", () => {
+		expect(match(result("pts/fio-2.1.0", "4K", "GB/s"))).toEqual({
+			kind: "uncatalogued",
+			test: "pts/fio",
+			description: "4K",
+			scale: "GB/s",
+		});
+	});
+
+	it("still matches an unpinned description, and the wildcard, on any scale", () => {
+		const described = match(result("pts/other-1.0.0", "Only", "anything"));
+		const wild = match(result("pts/wild-1.0.0", "whatever", "anything"));
+		if (described.kind !== "matched" || wild.kind !== "matched")
+			throw new Error("expected matches");
+		expect(described.def.id).toBe("described");
+		expect(wild.def.id).toBe("wild");
+	});
+
+	it("throws at build on a key collision (the catalogSchema invariants regressed)", () => {
+		expect(() => buildPtsIndex([catalog[0] as MetricDef, catalog[0] as MetricDef])).toThrow(
+			/collide on PTS match key/,
+		);
 	});
 });
 

--- a/packages/results/src/lib/pts.ts
+++ b/packages/results/src/lib/pts.ts
@@ -7,7 +7,7 @@
 import { CompactBuilderFactory } from "@nodable/compact-builder";
 import XMLParser, { type X2jOptions } from "@nodable/flexible-xml-parser";
 import type { MetricDef } from "@sandbox-benchmarks/schema";
-import { METRIC_CATALOG } from "@sandbox-benchmarks/schema";
+import { METRIC_CATALOG, ptsKey } from "@sandbox-benchmarks/schema";
 import { type } from "arktype";
 import type { PtsComposite, PtsResult } from "./pts-schema.ts";
 import { ptsCompositeSchema } from "./pts-schema.ts";
@@ -60,37 +60,81 @@ export function resultSamples(result: PtsResult): number[] {
  */
 export type PtsMapping =
 	| { kind: "matched"; def: MetricDef; samples: number[] }
-	| { kind: "uncatalogued"; test: string; description: string };
+	| { kind: "uncatalogued"; test: string; description: string; scale: string };
 
-// Index the catalog by versionless test once at module load. `ptsResultToMetric` runs per `<Result>`
-// — the golden gate alone calls it across every result of every recorded composite — so a per-call
-// linear `METRIC_CATALOG.filter` is O(results × catalog); the prebuilt map makes each lookup O(1).
-// Insertion order follows catalog order, so the wildcard-vs-description preference below is unchanged.
-const catalogByTest = new Map<string, MetricDef[]>();
-for (const metric of METRIC_CATALOG) {
-	if (!metric.pts) continue;
-	const forTest = catalogByTest.get(metric.pts.test);
-	if (forTest) forTest.push(metric);
-	else catalogByTest.set(metric.pts.test, [metric]);
+/**
+ * Index a catalog by match precedence and return the per-`<Result>` matcher over it.
+ *
+ * A factory, not three module-scope maps: the singleton below is one instance, but the scale-pinned
+ * arm and the build/lookup key-shape agreement are otherwise unexercisable until real pins land in
+ * the generated catalog — the exact drift a routing bug would hide behind. Tests build crafted
+ * catalogs through the same seam `catalogSchema` already offers.
+ *
+ * Indexing once matters: the matcher runs per `<Result>` — the golden gate alone calls it across
+ * every result of every recorded composite — and a per-call linear scan is O(results × per-test
+ * entries), which stopped being hypothetical when fio put 960 entries under one test key. Three
+ * maps, one per precedence arm, make each lookup O(1). The catalogSchema invariants (catalog.ts)
+ * make a key collision unconstructable; a collision here means those invariants regressed, so it
+ * throws at build — matching every other catalog-integrity breach (duplicate ids, duplicate
+ * headlines) — rather than silently letting first-wins route every result for the shadowed metric
+ * onto the wrong entry.
+ */
+export function buildPtsIndex(catalog: readonly MetricDef[]): (result: PtsResult) => PtsMapping {
+	const byTestDescriptionScale = new Map<string, MetricDef>();
+	const byTestDescription = new Map<string, MetricDef>();
+	const byTestWildcard = new Map<string, MetricDef>();
+	const indexInto = (map: Map<string, MetricDef>, key: string, metric: MetricDef): void => {
+		const existing = map.get(key);
+		if (existing) {
+			throw new Error(
+				`catalog integrity: "${metric.id}" and "${existing.id}" collide on PTS match key ${key} — the catalogSchema invariants should have rejected this at load`,
+			);
+		}
+		map.set(key, metric);
+	};
+	for (const metric of catalog) {
+		if (!metric.pts) continue;
+		const { test, description, scale } = metric.pts;
+		if (description === undefined) {
+			indexInto(byTestWildcard, ptsKey(test), metric);
+		} else if (scale !== undefined) {
+			indexInto(byTestDescriptionScale, ptsKey(test, description, scale), metric);
+		} else {
+			indexInto(byTestDescription, ptsKey(test, description), metric);
+		}
+	}
+
+	return (result: PtsResult): PtsMapping => {
+		const test = versionlessTest(result.Identifier);
+		const description = result.Description ?? "";
+		// Prefer an exact `<Description>` match over the wildcard (description-less) entry, so a
+		// multi-result test's catalog ordering can't make the wildcard greedily shadow a specific
+		// metric. The catalog invariant (`catalogSchema` .narrow, catalog.ts) guarantees a wildcard
+		// never coexists with description-bearing entries for the same test, so the fallback can't
+		// misattribute a non-matching `<Description>`: if a wildcard matched, it is that test's only
+		// entry.
+		//
+		// Scale-pinned entries (fio: one run posts bandwidth AND IOPS `<Result>`s under one
+		// description) additionally require `<Scale>` to byte-match their pin. The same invariant
+		// guarantees a pinned description never coexists with an unpinned twin, so the
+		// description-only arm below can't steal a result that belongs to a pinned entry — and a
+		// pinned description whose `<Scale>` matches no pin falls through to `uncatalogued` (an
+		// honest straggler) rather than the nearest twin.
+		const def =
+			byTestDescriptionScale.get(ptsKey(test, description, result.Scale)) ??
+			byTestDescription.get(ptsKey(test, description)) ??
+			byTestWildcard.get(ptsKey(test));
+		return def
+			? { kind: "matched", def, samples: resultSamples(result) }
+			: // `scale` rides along: scale-pinned twins share a description, so (test, description)
+				// alone no longer identifies a straggler — two twins whose `<Scale>` matched no pin
+				// would collapse onto one id downstream, silently dropping one measurement.
+				{ kind: "uncatalogued", test, description, scale: result.Scale };
+	};
 }
 
 /**
  * Map a parsed Result onto the Metric Catalog by its versionless test (and `<Description>` for
- * multi-result tests).
+ * multi-result tests, plus `<Scale>` where the catalog pins one).
  */
-export function ptsResultToMetric(result: PtsResult): PtsMapping {
-	const test = versionlessTest(result.Identifier);
-	const description = result.Description ?? "";
-	const forTest = catalogByTest.get(test) ?? [];
-	// Prefer an exact `<Description>` match over the wildcard (description-less) entry, so a
-	// multi-result test's catalog ordering can't make the wildcard greedily shadow a specific metric.
-	// The catalog invariant (`catalogSchema` .narrow, catalog.ts) guarantees a wildcard never coexists
-	// with description-bearing entries for the same test, so the fallback can't misattribute a
-	// non-matching `<Description>`: if a wildcard matched, it is that test's only entry.
-	const def =
-		forTest.find((metric) => metric.pts?.description === description) ??
-		forTest.find((metric) => metric.pts?.description === undefined);
-	return def
-		? { kind: "matched", def, samples: resultSamples(result) }
-		: { kind: "uncatalogued", test, description };
-}
+export const ptsResultToMetric = buildPtsIndex(METRIC_CATALOG);

--- a/packages/schema/src/catalog.test.ts
+++ b/packages/schema/src/catalog.test.ts
@@ -142,6 +142,35 @@ describe("catalogSchema PTS-mapping invariant", () => {
 		).not.toThrow();
 	});
 
+	it("scopes the twin-description invariant PER TEST (same description, different tests)", () => {
+		// The invariant keys on (test, description), not description alone. Nothing else pins that
+		// scoping: every other twin case here uses one test, so re-keying the narrow by description
+		// only would still pass them — and would then reject this legal catalog, where two unrelated
+		// profiles happen to share a <Description> string.
+		expect(() =>
+			catalogSchema.assert([
+				{
+					...base,
+					id: "a",
+					unit: "MB/s",
+					pts: { test: "pts/fio", description: "Task: X", scale: "MB/s" },
+				},
+				{ ...base, id: "b", pts: { test: "pts/other", description: "Task: X" } },
+			]),
+		).not.toThrow();
+	});
+
+	it("rejects an undeclared key inside the pts pin (a typo'd pin silently unpins the entry)", () => {
+		// arktype keeps undeclared keys by default, so `scael` would validate, survive, and degrade the
+		// entry to UNPINNED — which the matcher then resolves by description alone, i.e. arbitrarily
+		// between a twin pair. onUndeclaredKey("reject") makes it a loud generator/authoring bug.
+		expect(() =>
+			catalogSchema.assert([
+				{ ...base, id: "a", pts: { test: "pts/a", description: "Foo", scael: "MB/s" } },
+			]),
+		).toThrow();
+	});
+
 	it("rejects two description-less wildcards for the same test", () => {
 		expect(() =>
 			catalogSchema.assert([
@@ -158,6 +187,85 @@ describe("catalogSchema PTS-mapping invariant", () => {
 			catalogSchema.assert([
 				{ ...base, id: "a", pts: { test: "pts/a" } },
 				{ ...base, id: "b", pts: { test: "pts/a", description: "Foo" } },
+			]),
+		).toThrow();
+	});
+
+	it("accepts twin descriptions disambiguated by distinct pts.scale pins (fio)", () => {
+		expect(() =>
+			catalogSchema.assert([
+				{
+					...base,
+					id: "a",
+					unit: "MB/s",
+					pts: { test: "pts/fio", description: "Type: Random Read", scale: "MB/s" },
+				},
+				{
+					...base,
+					id: "b",
+					unit: "IOPS",
+					pts: { test: "pts/fio", description: "Type: Random Read", scale: "IOPS" },
+				},
+			]),
+		).not.toThrow();
+	});
+
+	it("rejects twin descriptions when one lacks a pts.scale pin", () => {
+		// The description-only matcher arm would resolve a result to the unpinned twin arbitrarily.
+		expect(() =>
+			catalogSchema.assert([
+				{
+					...base,
+					id: "a",
+					unit: "MB/s",
+					pts: { test: "pts/fio", description: "Type: Random Read", scale: "MB/s" },
+				},
+				{ ...base, id: "b", pts: { test: "pts/fio", description: "Type: Random Read" } },
+			]),
+		).toThrow();
+	});
+
+	it("rejects twin descriptions carrying the SAME pts.scale pin", () => {
+		expect(() =>
+			catalogSchema.assert([
+				{
+					...base,
+					id: "a",
+					unit: "MB/s",
+					pts: { test: "pts/fio", description: "Type: Random Read", scale: "MB/s" },
+				},
+				{
+					...base,
+					id: "b",
+					unit: "MB/s",
+					pts: { test: "pts/fio", description: "Type: Random Read", scale: "MB/s" },
+				},
+			]),
+		).toThrow();
+	});
+
+	it("rejects a pts.scale pin on a description-less wildcard", () => {
+		// The wildcard matcher arm never compares <Scale>, so the pin would be silently ignored and a
+		// fio-style test posting two description-less results (MB/s + IOPS) would collapse both onto
+		// this one metric — the exact cross-scale misattribution pinning exists to prevent.
+		expect(() =>
+			catalogSchema.assert([
+				{ ...base, id: "a", unit: "IOPS", pts: { test: "pts/fio", scale: "IOPS" } },
+			]),
+		).toThrow();
+	});
+
+	it("rejects a pinned entry whose unit differs from its pts.scale (crossed pins)", () => {
+		// unit and pts.scale both name the runtime <Scale> string; crossed values would rank one
+		// scale's samples under the other's unit label.
+		expect(() =>
+			catalogSchema.assert([
+				{
+					...base,
+					id: "a",
+					unit: "MB/s",
+					pts: { test: "pts/fio", description: "Type: Random Read", scale: "IOPS" },
+				},
 			]),
 		).toThrow();
 	});

--- a/packages/schema/src/catalog.ts
+++ b/packages/schema/src/catalog.ts
@@ -13,7 +13,7 @@
 import { economicsMetrics } from "./economics.ts";
 import { harnessMetrics } from "./harness-metrics.ts";
 import type { Dimension, MetricDef } from "./metrics.ts";
-import { metricDefSchema } from "./metrics.ts";
+import { metricDefSchema, ptsKey } from "./metrics.ts";
 import { ptsGenerated } from "./pts-generated.ts";
 import { ptsOverrides } from "./pts-overrides.ts";
 
@@ -42,33 +42,71 @@ if (orphanedOverrides.length > 0) {
  * The Catalog schema: every entry's shape PLUS the PTS-mapping invariant the runtime relies on. The
  * `.narrow` makes the dangerous catalog shape UNCONSTRUCTABLE so `ptsResultToMetric`'s wildcard
  * fallback (pts.ts) is safe by construction rather than by reviewer vigilance — for any one PTS test:
- *   1. at most one description-less wildcard entry, and
- *   2. a wildcard never coexists with description-bearing entries.
- * Either would let a result's `<Description>` that matches no specific entry fall to the wildcard and
- * be misattributed; forbidding the shape at load (deterministic, CI-caught) removes that path.
+ *   1. at most one description-less wildcard entry,
+ *   2. a wildcard never coexists with description-bearing entries, and
+ *   3. entries sharing a `<Description>` are disambiguated by DISTINCT `pts.scale` pins on every one
+ *      of them (fio: the same run posts a bandwidth and an IOPS `<Result>` under one description) —
+ *      never a scale-less twin the description-first matcher would resolve arbitrarily,
+ *   4. a `pts.scale` pin only appears on a description-bearing entry (the wildcard arm never compares
+ *      `<Scale>`, so a pinned wildcard would silently match results of ANY scale), and
+ *   5. a pinned entry's `unit` equals its `pts.scale` (both name the same runtime `<Scale>` string;
+ *      crossed pins would rank one scale's samples under the other's unit label).
+ * Any of these would let a `<Result>` be misattributed (fall to the wrong twin or the wildcard);
+ * forbidding the shape at load (deterministic, CI-caught) removes that path.
  * Exported so the invariant is unit-testable against crafted catalogs, independent of the singleton.
  */
 export const catalogSchema = metricDefSchema.array().narrow((cat, ctx) => {
 	const wildcardTests = new Set<string>();
 	const describedTests = new Set<string>();
+	// (test, description) -> the pts.scale pins seen for that description (undefined = no pin).
+	const scalesByDescription = new Map<string, (string | undefined)[]>();
 	for (const metric of cat) {
 		if (!metric.pts) continue;
+		if (metric.pts.scale !== undefined && metric.unit !== metric.pts.scale) {
+			return ctx.reject({
+				expected: `a pts.scale pin equal to the entry's unit ("${metric.id}" pins "${metric.pts.scale}" but is labeled "${metric.unit}")`,
+				actual: "",
+			});
+		}
 		if (metric.pts.description === undefined) {
+			if (metric.pts.scale !== undefined) {
+				return ctx.reject({
+					expected: `no pts.scale pin on a description-less wildcard ("${metric.id}": the wildcard arm never compares <Scale>, so the pin would be silently ignored)`,
+					actual: "",
+				});
+			}
 			if (wildcardTests.has(metric.pts.test)) {
-				return ctx.mustBe(
-					`at most one description-less wildcard per PTS test ("${metric.pts.test}")`,
-				);
+				return ctx.reject({
+					expected: `at most one description-less wildcard per PTS test ("${metric.pts.test}")`,
+					actual: "",
+				});
 			}
 			wildcardTests.add(metric.pts.test);
 		} else {
 			describedTests.add(metric.pts.test);
+			const key = ptsKey(metric.pts.test, metric.pts.description);
+			const scales = scalesByDescription.get(key) ?? [];
+			scales.push(metric.pts.scale);
+			scalesByDescription.set(key, scales);
 		}
 	}
 	for (const test of wildcardTests) {
 		if (describedTests.has(test)) {
-			return ctx.mustBe(
-				`no description-bearing entries alongside the description-less wildcard for "${test}"`,
-			);
+			return ctx.reject({
+				expected: `no description-bearing entries alongside the description-less wildcard for "${test}"`,
+				actual: "",
+			});
+		}
+	}
+	for (const [key, scales] of scalesByDescription) {
+		if (scales.length < 2) continue;
+		// Every twin must carry a pin, and no two pins may repeat — stated directly so there is no
+		// cross-array length arithmetic to repair wrongly.
+		if (scales.includes(undefined) || new Set(scales).size !== scales.length) {
+			return ctx.reject({
+				expected: `entries sharing a description disambiguated by distinct pts.scale pins on all of them (${key})`,
+				actual: "",
+			});
 		}
 	}
 	return true;

--- a/packages/schema/src/metrics.ts
+++ b/packages/schema/src/metrics.ts
@@ -31,6 +31,28 @@ export const dimensionSchema = type.enumerated(...DIMENSIONS);
 export type Dimension = typeof dimensionSchema.infer;
 
 /**
+ * The PTS provenance pin on a catalogued Metric. `onUndeclaredKey("reject")` because arktype keeps
+ * undeclared keys by default: a typo'd pin (`scael: "MB/s"`) would otherwise validate, keep the junk
+ * key, and silently degrade the entry to UNPINNED — which the matcher then resolves by description
+ * alone, i.e. arbitrarily between a scale twin pair. A rejected key is a loud generator/authoring bug.
+ */
+const ptsSourceSchema = type({
+	test: "string >= 1",
+	"description?": "string >= 1",
+	"scale?": "string >= 1",
+}).onUndeclaredKey("reject");
+
+/**
+ * The PTS match key. The index build and lookup (results/pts.ts) and the catalog invariant
+ * (catalog.ts) must spell key equality IDENTICALLY — the invariant is only sound because it groups
+ * entries the same way the matcher indexes them, so a divergence would bless catalogs the matcher
+ * still collides on. One definition, three call sites.
+ */
+export function ptsKey(test: string, description?: string, scale?: string): string {
+	return JSON.stringify([test, description, scale]);
+}
+
+/**
  * One Metric's definition: its stable id, the Dimension it belongs to, unit, Direction, and whether
  * it headlines that Dimension on the leaderboard. PTS-derived Metrics also carry the `pts` provenance
  * the results normalizer uses to map a parsed `<Result>` onto the Catalog.
@@ -53,9 +75,12 @@ export const metricDefSchema = type({
 	description: "string >= 1",
 	// For Metrics parsed from a PTS `<Result>`: the versionless test profile (e.g.
 	// "pts/node-web-tooling") and — for multi-result tests — the exact `<Description>` this Metric maps
-	// to. Each PTS `<Result>` maps to exactly one Metric. Both non-empty when present (an empty
-	// `test`/`description` would never match a real `<Result>`).
-	"pts?": { test: "string >= 1", "description?": "string >= 1" },
+	// to. Each PTS `<Result>` maps to exactly one Metric. All non-empty when present (an empty
+	// `test`/`description`/`scale` would never match a real `<Result>`). `scale` exists for tests whose
+	// parsers emit MULTIPLE `<Result>`s under one `<Description>` differing only in `<Scale>` (fio: the
+	// same run reports bandwidth in MB/s and IOPS) — it pins this Metric to the exact runtime `<Scale>`
+	// so the two results can't collapse onto one Metric. Absent when the description alone is unique.
+	"pts?": ptsSourceSchema,
 	// Primary-source definition (upstream PTS profile, methodology doc, …).
 	"sourceUrl?": "string",
 	// Economics Metrics derived from other Metrics + pricing, never parsed.


### PR DESCRIPTION
**PTS BENCHMARK MATRIX — vendor the PTS catalog, then light up four benchmark suites.**
Shipped as a 12-PR stack. The trunk merges bottom-up; the four suite PRs at the top are SIBLINGS and
can be reviewed (and merged) in parallel — none blocks the others.

```
main
 └─ #136  schema: scale-aware PTS metric identity (pts.scale) + O(1) matcher
     └─ #137  catalog generator: per-parser scales + virtual axes
         └─ #138  ⚙ VENDOR fio + regenerate catalog        (autogenerated)
             └─ #146  fio curation + disk headline + goldens
                 └─ #139  ⚙ VENDOR loopback/zstd/pgbench + regenerate   (autogenerated)
                     └─ #147  their curation + recorded fixtures
                         └─ #148  shared PTS runner (lib/bench.sh)
                             └─ #144  toolchain image: bake PTS deps + pin drift gates
                                 ├─ #140  disk suite     ┐
                                 ├─ #141  network suite  │  siblings — parallel review
                                 ├─ #142  cpu-generic    │
                                 └─ #143  system suite   ┘
```
⚙ = the diff is machine-produced; reproduce it with the commands in the body. Everything hand-written
was lifted out into the small PR directly above it.

↑ **This PR is #136 (1/12) — schema foundation, based on main.**

---

**Stack 1/9** (bench-matrix expansion; graphite-style stack, each PR based on its parent)

A PTS profile can post multiple `<Result>` blocks under one `<Description>` differing only by `<Scale>` — fio emits MB/s and IOPS twins from a single run. This slice extends the catalog contract so results can be routed unambiguously:

- `MetricDef.pts` gains an optional `scale` pin (`packages/schema/src/metrics.ts`)
- catalog load rejects ambiguous twins: entries sharing (test, description) must **all** carry distinct `scale` pins (`catalog.ts` narrow invariant + 3 new schema tests)
- `ptsResultToMetric` routes through three precedence-bucketed O(1) maps (test+description+scale → test+description → test wildcard) instead of a linear scan; a wrong scale on a pinned description resolves to `uncatalogued` rather than misattributing the sample (`packages/results/src/lib/pts.ts`)

No generated-catalog change yet — the generator learns to mint scale-suffixed ids in the next slice; this one is pure contract + routing.

**LOC**: 106+/19− hand-written. Gate: typecheck, 524 tests, Biome, typos all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BHkDUJmxVAz1sCWFcS9btJ

---
_Generated by [Claude Code](https://claude.ai/code/session_01BHkDUJmxVAz1sCWFcS9btJ)_

## Validation

Every branch in this stack was checked out **in isolation** (i.e. on top of its own parent, with
nothing from the PRs above it) and run through the full gate set. A reviewer merges bottom-up, so
each PR has to stand on its own — this is what verifies that.

**This PR (`01`), verified standalone — all seven gates green:**

| gate | command | result |
|---|---|---|
| install | `bun install --frozen-lockfile` | ✅ |
| typecheck | `bun run typecheck` | ✅ |
| lint | `bun run lint` (biome, `--error-on-warnings`) | ✅ |
| spell | `mise exec -- typos` | ✅ |
| shell | `bun run lint:shell` (shellcheck) | ✅ |
| catalog drift | `bun run check:catalog-drift` | ✅ |
| tests | `bun run test` (whole workspace) | ✅ **535 passing, 0 failing** |

The same matrix is green on all 12 branches, and the passing-test count climbs monotonically up the
trunk (535 → 576) — each PR adds coverage and none regresses it.

**What this PR's own tests prove:**

- `buildPtsIndex` routing over a crafted catalog: each scale twin resolves to its OWN entry (the symmetric half a twin-swap breaks), a `<Scale>` matching no pin falls to `uncatalogued` rather than the nearest twin, and a key collision throws at build.
- `catalogSchema` invariants: the twin-description rule is scoped per-`(test, description)` (verified by mutation — re-keying by description alone still passed every pre-existing case), and a typo'd pin key (`scael`) is now rejected instead of silently un-pinning the entry.

### What this does NOT prove

Being explicit, because the gates above are all static:

- **No benchmark has been run on a real provider sandbox.** Nothing in CI executes the `.mise` producer
  tasks against a live Phoronix Test Suite. Their correctness rests on `shellcheck`, on the golden
  byte-match gate (which compares against RECORDED composites — real PTS output, but replayed, not
  produced), and on the suite-contract tests. The first live signal is the `bench-smoke` workflow
  (manual dispatch) after these merge.
- **The image is only built by CI on #144** — it is the only PR that touches it. The suite PRs assume
  that image; they do not rebuild it.
- `Bake, validate & promote toolchain` is skipped on pull requests by design
  (`if: github.event_name != 'pull_request'`), so image PROMOTION is exercised only on `main`.
- The recorded fixtures prove byte-match against PTS output captured at a point in time; a future PTS
  release could change a `<Description>` string. That is precisely what the golden gate would catch.

Additionally, the four suite PRs at the top are siblings on #144; merging all four reproduces the
pre-restructure tree byte-for-byte (verified), so the 12-PR split moved every change and dropped none.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds scale-aware identity for PTS metrics and switches result matching to O(1) lookups to prevent cross-scale misrouting. Uncatalogued results now include `scale`, and straggler ids add it so twins don’t collapse.

- **New Features**
  - Added optional `pts.scale` to `MetricDef`; catalog enforces: twins sharing the same test+description must each have a distinct `scale`, `pts.scale` is forbidden on wildcard entries, and a pinned entry’s `unit` must equal its `pts.scale`.
  - Uncatalogued mappings include `scale`, and `extract` appends it to the straggler id (`<test>::<description>::<scale>`).

- **Refactors**
  - Introduced shared `ptsKey()` and `buildPtsIndex(catalog)` for a three-map O(1) matcher; `ptsResultToMetric` is now built from it and key collisions throw at build.
  - Hardened schema: the `pts` pin rejects undeclared keys to catch typos.

<sup>Written for commit 5537b94e81bb31359e486b7b14a54be15ce784f1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/starslingdev/sandbox-benchmarks/pull/136?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added scale-based disambiguation to PTS metric mapping with more precise match precedence for results sharing the same description.
* **Bug Fixes**
  * Strengthened catalog validation to reject invalid/conflicting PTS pins (including wildcard restrictions, missing/duplicate scales, and cross-scale unit conflicts).
  * Improved uncatalogued straggler identifiers so scale-pinned measurements no longer collapse.
  * Added collision detection to prevent ambiguous catalog matches.
* **Tests**
  * Expanded schema and PTS mapping test coverage for the new scale pinning and routing behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->