### PR TITLE
feat(schema,results): vendor pts/network-loopback, pts/compress-zstd, pts/pgbench

### DIFF
--- a/packages/schema/scripts/fetch-profiles.ts
+++ b/packages/schema/scripts/fetch-profiles.ts
@@ -52,6 +52,19 @@ const PROFILES = [
 	// combination emits TWO <Result>s under one <Description> (bandwidth MB/s + IOPS), disambiguated by
 	// the generator's `pts.scale` pins and proven by a recorded composite golden fixture.
 	"fio-2.1.0",
+	// Network dimension — single-result (sys.time monitor, no <Option> matrix), so it generates one
+	// description-less wildcard entry (zero byte-match risk).
+	"network-loopback-1.0.1",
+	// Cpu dimension — Zstd compression across its Compression Level matrix; two parsers per level
+	// (Compression/Decompression Speed via AppendToArgumentsDescription), byte-match-proven by a
+	// recorded composite golden fixture.
+	"compress-zstd-1.6.0",
+	// System dimension — PostgreSQL via its integrated pgbench, fully in-sandbox (the profile builds
+	// postgres 17.0 and runs server + client locally, so every provider measures the same topology).
+	// The producer pins one (Scaling Factor, Clients) point per mode via PRESET_OPTIONS; two parsers
+	// per combination (TPS + Average Latency, distinct descriptions), proven by a recorded fixture.
+	// 1.15.0 is the newest pgbench profile published upstream at REF.
+	"pgbench-1.15.0",
 ] as const;
 
 // Only these definition files feed the generator; siblings (downloads.xml, install.sh) are ignored.

--- a/packages/schema/src/catalog.test.ts
+++ b/packages/schema/src/catalog.test.ts
@@ -41,10 +41,15 @@ describe("metric catalog", () => {
 		}
 	});
 
-	it("has at most one headline metric per dimension", () => {
+	it("gives every dimension EXACTLY one headline metric", () => {
+		// Both directions matter and neither is checked at load: the catalog's load check rejects a
+		// SECOND headline but never a MISSING one, and headlineMetric reads the METRIC_CATALOG singleton
+		// (it takes no catalog parameter), so its no-headline throw is unreachable from a crafted
+		// catalog. This test IS the zero-headline guard — dropping `headline: true` from any dimension's
+		// metric turns it red here rather than at runtime inside headlineMetric().
 		for (const dimension of DIMENSIONS) {
 			const headlines = metricsForDimension(dimension).filter((metric) => metric.headline);
-			expect(headlines.length).toBeLessThanOrEqual(1);
+			expect(headlines.length).toBe(1);
 		}
 	});
 
@@ -110,6 +115,23 @@ describe("metric catalog", () => {
 		expect(metric?.pts).toEqual({ test: "local/hardlink" });
 	});
 
+	it("returns undefined for an unknown metric id", () => {
+		expect(getMetric("not_a_metric")).toBeUndefined();
+	});
+
+	it("resolves the Loopback TCP headline for the network dimension (last unpopulated axis)", () => {
+		// network was the one dimension still without metrics; network-loopback populates it. With that,
+		// every Dimension is populated + headlined, so headlineMetric's no-headline throw is no longer
+		// reachable through the real catalog — the "exactly one headline per dimension" test above keeps
+		// it that way. NOT the load check, which only ever rejects a SECOND headline.
+		const metric = headlineMetric("network");
+		expect(metric.id).toBe("network_loopback_seconds");
+		expect(metric.label).toBe("Loopback TCP (10GB)");
+		expect(metric.direction).toBe("LIB");
+		// Single-result wildcard: no pts.description (so the byte-match gate needs no recorded composite).
+		expect(metric.pts).toEqual({ test: "pts/network-loopback" });
+	});
+
 	it("resolves fio's scale-pinned twin metrics for one description (disk dimension)", () => {
 		const mbps = getMetric(
 			"fio_type_random_read_engine_linux_aio_direct_yes_block_size_4kb_job_count_1_disk_target_default_test_directory_mb_per_s",
@@ -135,16 +157,6 @@ describe("metric catalog", () => {
 		// silently drops the twins for some engines would stay green everywhere. This pins the arithmetic.
 		const fio = METRIC_CATALOG.filter((metric) => metric.pts?.test === "pts/fio");
 		expect(fio.length).toBe(960);
-	});
-
-	it("returns undefined for an unknown metric id", () => {
-		expect(getMetric("not_a_metric")).toBeUndefined();
-	});
-
-	it("throws when a dimension has no headline metric", () => {
-		// `network` is the dimension still without any metrics (economics and realworld are now
-		// populated + headlined too).
-		expect(() => headlineMetric("network")).toThrow();
 	});
 });
 

--- a/packages/schema/src/pts-generated.ts
+++ b/packages/schema/src/pts-generated.ts
@@ -41,6 +41,192 @@ const chunk1: MetricDef[] = [
 		sourceUrl: "http://nuclear.mutantstargoat.com/sw/c-ray/",
 	},
 	{
+		id: "compress_zstd_compression_level_12_compression_speed",
+		dimension: "cpu",
+		unit: "MB/s",
+		direction: "HIB",
+		headline: false,
+		label: "Zstd Compression - Compression Level: 12 - Compression Speed",
+		description:
+			"This test measures the time needed to compress/decompress a sample file (silesia.tar) using Zstd (Zstandard) compression with options for different compression levels / settings.",
+		pts: { test: "pts/compress-zstd", description: "Compression Level: 12 - Compression Speed" },
+		sourceUrl: "https://facebook.github.io/zstd/",
+	},
+	{
+		id: "compress_zstd_compression_level_12_decompression_speed",
+		dimension: "cpu",
+		unit: "MB/s",
+		direction: "HIB",
+		headline: false,
+		label: "Zstd Compression - Compression Level: 12 - Decompression Speed",
+		description:
+			"This test measures the time needed to compress/decompress a sample file (silesia.tar) using Zstd (Zstandard) compression with options for different compression levels / settings.",
+		pts: { test: "pts/compress-zstd", description: "Compression Level: 12 - Decompression Speed" },
+		sourceUrl: "https://facebook.github.io/zstd/",
+	},
+	{
+		id: "compress_zstd_compression_level_19_compression_speed",
+		dimension: "cpu",
+		unit: "MB/s",
+		direction: "HIB",
+		headline: false,
+		label: "Zstd Compression - Compression Level: 19 - Compression Speed",
+		description:
+			"This test measures the time needed to compress/decompress a sample file (silesia.tar) using Zstd (Zstandard) compression with options for different compression levels / settings.",
+		pts: { test: "pts/compress-zstd", description: "Compression Level: 19 - Compression Speed" },
+		sourceUrl: "https://facebook.github.io/zstd/",
+	},
+	{
+		id: "compress_zstd_compression_level_19_decompression_speed",
+		dimension: "cpu",
+		unit: "MB/s",
+		direction: "HIB",
+		headline: false,
+		label: "Zstd Compression - Compression Level: 19 - Decompression Speed",
+		description:
+			"This test measures the time needed to compress/decompress a sample file (silesia.tar) using Zstd (Zstandard) compression with options for different compression levels / settings.",
+		pts: { test: "pts/compress-zstd", description: "Compression Level: 19 - Decompression Speed" },
+		sourceUrl: "https://facebook.github.io/zstd/",
+	},
+	{
+		id: "compress_zstd_compression_level_19_long_mode_compression_speed",
+		dimension: "cpu",
+		unit: "MB/s",
+		direction: "HIB",
+		headline: false,
+		label: "Zstd Compression - Compression Level: 19, Long Mode - Compression Speed",
+		description:
+			"This test measures the time needed to compress/decompress a sample file (silesia.tar) using Zstd (Zstandard) compression with options for different compression levels / settings.",
+		pts: {
+			test: "pts/compress-zstd",
+			description: "Compression Level: 19, Long Mode - Compression Speed",
+		},
+		sourceUrl: "https://facebook.github.io/zstd/",
+	},
+	{
+		id: "compress_zstd_compression_level_19_long_mode_decompression_speed",
+		dimension: "cpu",
+		unit: "MB/s",
+		direction: "HIB",
+		headline: false,
+		label: "Zstd Compression - Compression Level: 19, Long Mode - Decompression Speed",
+		description:
+			"This test measures the time needed to compress/decompress a sample file (silesia.tar) using Zstd (Zstandard) compression with options for different compression levels / settings.",
+		pts: {
+			test: "pts/compress-zstd",
+			description: "Compression Level: 19, Long Mode - Decompression Speed",
+		},
+		sourceUrl: "https://facebook.github.io/zstd/",
+	},
+	{
+		id: "compress_zstd_compression_level_3_compression_speed",
+		dimension: "cpu",
+		unit: "MB/s",
+		direction: "HIB",
+		headline: false,
+		label: "Zstd Compression - Compression Level: 3 - Compression Speed",
+		description:
+			"This test measures the time needed to compress/decompress a sample file (silesia.tar) using Zstd (Zstandard) compression with options for different compression levels / settings.",
+		pts: { test: "pts/compress-zstd", description: "Compression Level: 3 - Compression Speed" },
+		sourceUrl: "https://facebook.github.io/zstd/",
+	},
+	{
+		id: "compress_zstd_compression_level_3_decompression_speed",
+		dimension: "cpu",
+		unit: "MB/s",
+		direction: "HIB",
+		headline: false,
+		label: "Zstd Compression - Compression Level: 3 - Decompression Speed",
+		description:
+			"This test measures the time needed to compress/decompress a sample file (silesia.tar) using Zstd (Zstandard) compression with options for different compression levels / settings.",
+		pts: { test: "pts/compress-zstd", description: "Compression Level: 3 - Decompression Speed" },
+		sourceUrl: "https://facebook.github.io/zstd/",
+	},
+	{
+		id: "compress_zstd_compression_level_3_long_mode_compression_speed",
+		dimension: "cpu",
+		unit: "MB/s",
+		direction: "HIB",
+		headline: false,
+		label: "Zstd Compression - Compression Level: 3, Long Mode - Compression Speed",
+		description:
+			"This test measures the time needed to compress/decompress a sample file (silesia.tar) using Zstd (Zstandard) compression with options for different compression levels / settings.",
+		pts: {
+			test: "pts/compress-zstd",
+			description: "Compression Level: 3, Long Mode - Compression Speed",
+		},
+		sourceUrl: "https://facebook.github.io/zstd/",
+	},
+	{
+		id: "compress_zstd_compression_level_3_long_mode_decompression_speed",
+		dimension: "cpu",
+		unit: "MB/s",
+		direction: "HIB",
+		headline: false,
+		label: "Zstd Compression - Compression Level: 3, Long Mode - Decompression Speed",
+		description:
+			"This test measures the time needed to compress/decompress a sample file (silesia.tar) using Zstd (Zstandard) compression with options for different compression levels / settings.",
+		pts: {
+			test: "pts/compress-zstd",
+			description: "Compression Level: 3, Long Mode - Decompression Speed",
+		},
+		sourceUrl: "https://facebook.github.io/zstd/",
+	},
+	{
+		id: "compress_zstd_compression_level_8_compression_speed",
+		dimension: "cpu",
+		unit: "MB/s",
+		direction: "HIB",
+		headline: false,
+		label: "Zstd Compression - Compression Level: 8 - Compression Speed",
+		description:
+			"This test measures the time needed to compress/decompress a sample file (silesia.tar) using Zstd (Zstandard) compression with options for different compression levels / settings.",
+		pts: { test: "pts/compress-zstd", description: "Compression Level: 8 - Compression Speed" },
+		sourceUrl: "https://facebook.github.io/zstd/",
+	},
+	{
+		id: "compress_zstd_compression_level_8_decompression_speed",
+		dimension: "cpu",
+		unit: "MB/s",
+		direction: "HIB",
+		headline: false,
+		label: "Zstd Compression - Compression Level: 8 - Decompression Speed",
+		description:
+			"This test measures the time needed to compress/decompress a sample file (silesia.tar) using Zstd (Zstandard) compression with options for different compression levels / settings.",
+		pts: { test: "pts/compress-zstd", description: "Compression Level: 8 - Decompression Speed" },
+		sourceUrl: "https://facebook.github.io/zstd/",
+	},
+	{
+		id: "compress_zstd_compression_level_8_long_mode_compression_speed",
+		dimension: "cpu",
+		unit: "MB/s",
+		direction: "HIB",
+		headline: false,
+		label: "Zstd Compression - Compression Level: 8, Long Mode - Compression Speed",
+		description:
+			"This test measures the time needed to compress/decompress a sample file (silesia.tar) using Zstd (Zstandard) compression with options for different compression levels / settings.",
+		pts: {
+			test: "pts/compress-zstd",
+			description: "Compression Level: 8, Long Mode - Compression Speed",
+		},
+		sourceUrl: "https://facebook.github.io/zstd/",
+	},
+	{
+		id: "compress_zstd_compression_level_8_long_mode_decompression_speed",
+		dimension: "cpu",
+		unit: "MB/s",
+		direction: "HIB",
+		headline: false,
+		label: "Zstd Compression - Compression Level: 8, Long Mode - Decompression Speed",
+		description:
+			"This test measures the time needed to compress/decompress a sample file (silesia.tar) using Zstd (Zstandard) compression with options for different compression levels / settings.",
+		pts: {
+			test: "pts/compress-zstd",
+			description: "Compression Level: 8, Long Mode - Decompression Speed",
+		},
+		sourceUrl: "https://facebook.github.io/zstd/",
+	},
+	{
 		id: "fio_type_random_read_engine_io_uring_direct_no_block_size_128kb_job_count_1_disk_target_default_test_directory_iops",
 		dimension: "disk",
 		unit: "IOPS",
@@ -4234,6 +4420,9 @@ const chunk1: MetricDef[] = [
 		},
 		sourceUrl: "https://fio.readthedocs.io/en/latest/fio_doc.html",
 	},
+];
+
+const chunk2: MetricDef[] = [
 	{
 		id: "fio_type_random_read_engine_windows_aio_direct_yes_block_size_512kb_job_count_1_disk_target_default_test_directory_mb_per_s",
 		dimension: "disk",
@@ -4486,9 +4675,6 @@ const chunk1: MetricDef[] = [
 		},
 		sourceUrl: "https://fio.readthedocs.io/en/latest/fio_doc.html",
 	},
-];
-
-const chunk2: MetricDef[] = [
 	{
 		id: "fio_type_random_write_engine_io_uring_direct_no_block_size_256kb_job_count_1_disk_target_default_test_directory_mb_per_s",
 		dimension: "disk",
@@ -8737,6 +8923,9 @@ const chunk2: MetricDef[] = [
 		},
 		sourceUrl: "https://fio.readthedocs.io/en/latest/fio_doc.html",
 	},
+];
+
+const chunk3: MetricDef[] = [
 	{
 		id: "fio_type_sequential_read_engine_io_uring_direct_no_block_size_16kb_job_count_1_disk_target_default_test_directory_mb_per_s",
 		dimension: "disk",
@@ -8989,9 +9178,6 @@ const chunk2: MetricDef[] = [
 		},
 		sourceUrl: "https://fio.readthedocs.io/en/latest/fio_doc.html",
 	},
-];
-
-const chunk3: MetricDef[] = [
 	{
 		id: "fio_type_sequential_read_engine_io_uring_direct_no_block_size_512kb_job_count_1_disk_target_default_test_directory_mb_per_s",
 		dimension: "disk",
@@ -13240,6 +13426,9 @@ const chunk3: MetricDef[] = [
 		},
 		sourceUrl: "https://fio.readthedocs.io/en/latest/fio_doc.html",
 	},
+];
+
+const chunk4: MetricDef[] = [
 	{
 		id: "fio_type_sequential_write_engine_io_uring_direct_no_block_size_4kb_job_count_1_disk_target_default_test_directory_mb_per_s",
 		dimension: "disk",
@@ -13492,9 +13681,6 @@ const chunk3: MetricDef[] = [
 		},
 		sourceUrl: "https://fio.readthedocs.io/en/latest/fio_doc.html",
 	},
-];
-
-const chunk4: MetricDef[] = [
 	{
 		id: "fio_type_sequential_write_engine_io_uring_direct_yes_block_size_16kb_job_count_1_disk_target_default_test_directory_mb_per_s",
 		dimension: "disk",
@@ -17342,6 +17528,18 @@ const chunk4: MetricDef[] = [
 		sourceUrl: "https://github.com/ColinIanKing/stress-ng",
 	},
 	{
+		id: "network_loopback_seconds",
+		dimension: "network",
+		unit: "Seconds",
+		direction: "LIB",
+		headline: false,
+		label: "Loopback TCP Network Performance - Time To Transfer 10GB Via Loopback",
+		description:
+			"This test measures the loopback network adapter performance using a micro-benchmark to measure the TCP performance.",
+		pts: { test: "pts/network-loopback" },
+		sourceUrl: "http://developer.amazonwebservices.com/connect/thread.jspa?threadID=45513",
+	},
+	{
 		id: "node_web_tooling_runs_per_s",
 		dimension: "cpu",
 		unit: "runs/s",
@@ -17352,6 +17550,2386 @@ const chunk4: MetricDef[] = [
 			"Running the V8 project's Web-Tooling-Benchmark under Node.js. The Web-Tooling-Benchmark stresses JavaScript-related workloads common to web developers like Babel and TypeScript and Babylon. This test profile can test the system's JavaScript performance with Node.js.",
 		pts: { test: "pts/node-web-tooling" },
 		sourceUrl: "https://v8.github.io/web-tooling-benchmark/",
+	},
+	{
+		id: "pgbench_scaling_factor_10000_clients_1000_mode_read_only",
+		dimension: "system",
+		unit: "TPS",
+		direction: "HIB",
+		headline: false,
+		label: "PostgreSQL - Scaling Factor: 10000 - Clients: 1000 - Mode: Read Only",
+		description:
+			"This is a benchmark of PostgreSQL using the integrated pgbench for facilitating the database benchmarks.",
+		pts: {
+			test: "pts/pgbench",
+			description: "Scaling Factor: 10000 - Clients: 1000 - Mode: Read Only",
+		},
+		sourceUrl: "https://www.postgresql.org/",
+	},
+	{
+		id: "pgbench_scaling_factor_10000_clients_1000_mode_read_only_average_latency",
+		dimension: "system",
+		unit: "ms",
+		direction: "LIB",
+		headline: false,
+		label: "PostgreSQL - Scaling Factor: 10000 - Clients: 1000 - Mode: Read Only - Average Latency",
+		description:
+			"This is a benchmark of PostgreSQL using the integrated pgbench for facilitating the database benchmarks.",
+		pts: {
+			test: "pts/pgbench",
+			description: "Scaling Factor: 10000 - Clients: 1000 - Mode: Read Only - Average Latency",
+		},
+		sourceUrl: "https://www.postgresql.org/",
+	},
+	{
+		id: "pgbench_scaling_factor_10000_clients_1000_mode_read_write",
+		dimension: "system",
+		unit: "TPS",
+		direction: "HIB",
+		headline: false,
+		label: "PostgreSQL - Scaling Factor: 10000 - Clients: 1000 - Mode: Read Write",
+		description:
+			"This is a benchmark of PostgreSQL using the integrated pgbench for facilitating the database benchmarks.",
+		pts: {
+			test: "pts/pgbench",
+			description: "Scaling Factor: 10000 - Clients: 1000 - Mode: Read Write",
+		},
+		sourceUrl: "https://www.postgresql.org/",
+	},
+	{
+		id: "pgbench_scaling_factor_10000_clients_1000_mode_read_write_average_latency",
+		dimension: "system",
+		unit: "ms",
+		direction: "LIB",
+		headline: false,
+		label:
+			"PostgreSQL - Scaling Factor: 10000 - Clients: 1000 - Mode: Read Write - Average Latency",
+		description:
+			"This is a benchmark of PostgreSQL using the integrated pgbench for facilitating the database benchmarks.",
+		pts: {
+			test: "pts/pgbench",
+			description: "Scaling Factor: 10000 - Clients: 1000 - Mode: Read Write - Average Latency",
+		},
+		sourceUrl: "https://www.postgresql.org/",
+	},
+	{
+		id: "pgbench_scaling_factor_10000_clients_100_mode_read_only",
+		dimension: "system",
+		unit: "TPS",
+		direction: "HIB",
+		headline: false,
+		label: "PostgreSQL - Scaling Factor: 10000 - Clients: 100 - Mode: Read Only",
+		description:
+			"This is a benchmark of PostgreSQL using the integrated pgbench for facilitating the database benchmarks.",
+		pts: {
+			test: "pts/pgbench",
+			description: "Scaling Factor: 10000 - Clients: 100 - Mode: Read Only",
+		},
+		sourceUrl: "https://www.postgresql.org/",
+	},
+	{
+		id: "pgbench_scaling_factor_10000_clients_100_mode_read_only_average_latency",
+		dimension: "system",
+		unit: "ms",
+		direction: "LIB",
+		headline: false,
+		label: "PostgreSQL - Scaling Factor: 10000 - Clients: 100 - Mode: Read Only - Average Latency",
+		description:
+			"This is a benchmark of PostgreSQL using the integrated pgbench for facilitating the database benchmarks.",
+		pts: {
+			test: "pts/pgbench",
+			description: "Scaling Factor: 10000 - Clients: 100 - Mode: Read Only - Average Latency",
+		},
+		sourceUrl: "https://www.postgresql.org/",
+	},
+	{
+		id: "pgbench_scaling_factor_10000_clients_100_mode_read_write",
+		dimension: "system",
+		unit: "TPS",
+		direction: "HIB",
+		headline: false,
+		label: "PostgreSQL - Scaling Factor: 10000 - Clients: 100 - Mode: Read Write",
+		description:
+			"This is a benchmark of PostgreSQL using the integrated pgbench for facilitating the database benchmarks.",
+		pts: {
+			test: "pts/pgbench",
+			description: "Scaling Factor: 10000 - Clients: 100 - Mode: Read Write",
+		},
+		sourceUrl: "https://www.postgresql.org/",
+	},
+	{
+		id: "pgbench_scaling_factor_10000_clients_100_mode_read_write_average_latency",
+		dimension: "system",
+		unit: "ms",
+		direction: "LIB",
+		headline: false,
+		label: "PostgreSQL - Scaling Factor: 10000 - Clients: 100 - Mode: Read Write - Average Latency",
+		description:
+			"This is a benchmark of PostgreSQL using the integrated pgbench for facilitating the database benchmarks.",
+		pts: {
+			test: "pts/pgbench",
+			description: "Scaling Factor: 10000 - Clients: 100 - Mode: Read Write - Average Latency",
+		},
+		sourceUrl: "https://www.postgresql.org/",
+	},
+	{
+		id: "pgbench_scaling_factor_10000_clients_1_mode_read_only",
+		dimension: "system",
+		unit: "TPS",
+		direction: "HIB",
+		headline: false,
+		label: "PostgreSQL - Scaling Factor: 10000 - Clients: 1 - Mode: Read Only",
+		description:
+			"This is a benchmark of PostgreSQL using the integrated pgbench for facilitating the database benchmarks.",
+		pts: {
+			test: "pts/pgbench",
+			description: "Scaling Factor: 10000 - Clients: 1 - Mode: Read Only",
+		},
+		sourceUrl: "https://www.postgresql.org/",
+	},
+	{
+		id: "pgbench_scaling_factor_10000_clients_1_mode_read_only_average_latency",
+		dimension: "system",
+		unit: "ms",
+		direction: "LIB",
+		headline: false,
+		label: "PostgreSQL - Scaling Factor: 10000 - Clients: 1 - Mode: Read Only - Average Latency",
+		description:
+			"This is a benchmark of PostgreSQL using the integrated pgbench for facilitating the database benchmarks.",
+		pts: {
+			test: "pts/pgbench",
+			description: "Scaling Factor: 10000 - Clients: 1 - Mode: Read Only - Average Latency",
+		},
+		sourceUrl: "https://www.postgresql.org/",
+	},
+	{
+		id: "pgbench_scaling_factor_10000_clients_1_mode_read_write",
+		dimension: "system",
+		unit: "TPS",
+		direction: "HIB",
+		headline: false,
+		label: "PostgreSQL - Scaling Factor: 10000 - Clients: 1 - Mode: Read Write",
+		description:
+			"This is a benchmark of PostgreSQL using the integrated pgbench for facilitating the database benchmarks.",
+		pts: {
+			test: "pts/pgbench",
+			description: "Scaling Factor: 10000 - Clients: 1 - Mode: Read Write",
+		},
+		sourceUrl: "https://www.postgresql.org/",
+	},
+	{
+		id: "pgbench_scaling_factor_10000_clients_1_mode_read_write_average_latency",
+		dimension: "system",
+		unit: "ms",
+		direction: "LIB",
+		headline: false,
+		label: "PostgreSQL - Scaling Factor: 10000 - Clients: 1 - Mode: Read Write - Average Latency",
+		description:
+			"This is a benchmark of PostgreSQL using the integrated pgbench for facilitating the database benchmarks.",
+		pts: {
+			test: "pts/pgbench",
+			description: "Scaling Factor: 10000 - Clients: 1 - Mode: Read Write - Average Latency",
+		},
+		sourceUrl: "https://www.postgresql.org/",
+	},
+	{
+		id: "pgbench_scaling_factor_10000_clients_250_mode_read_only",
+		dimension: "system",
+		unit: "TPS",
+		direction: "HIB",
+		headline: false,
+		label: "PostgreSQL - Scaling Factor: 10000 - Clients: 250 - Mode: Read Only",
+		description:
+			"This is a benchmark of PostgreSQL using the integrated pgbench for facilitating the database benchmarks.",
+		pts: {
+			test: "pts/pgbench",
+			description: "Scaling Factor: 10000 - Clients: 250 - Mode: Read Only",
+		},
+		sourceUrl: "https://www.postgresql.org/",
+	},
+	{
+		id: "pgbench_scaling_factor_10000_clients_250_mode_read_only_average_latency",
+		dimension: "system",
+		unit: "ms",
+		direction: "LIB",
+		headline: false,
+		label: "PostgreSQL - Scaling Factor: 10000 - Clients: 250 - Mode: Read Only - Average Latency",
+		description:
+			"This is a benchmark of PostgreSQL using the integrated pgbench for facilitating the database benchmarks.",
+		pts: {
+			test: "pts/pgbench",
+			description: "Scaling Factor: 10000 - Clients: 250 - Mode: Read Only - Average Latency",
+		},
+		sourceUrl: "https://www.postgresql.org/",
+	},
+	{
+		id: "pgbench_scaling_factor_10000_clients_250_mode_read_write",
+		dimension: "system",
+		unit: "TPS",
+		direction: "HIB",
+		headline: false,
+		label: "PostgreSQL - Scaling Factor: 10000 - Clients: 250 - Mode: Read Write",
+		description:
+			"This is a benchmark of PostgreSQL using the integrated pgbench for facilitating the database benchmarks.",
+		pts: {
+			test: "pts/pgbench",
+			description: "Scaling Factor: 10000 - Clients: 250 - Mode: Read Write",
+		},
+		sourceUrl: "https://www.postgresql.org/",
+	},
+	{
+		id: "pgbench_scaling_factor_10000_clients_250_mode_read_write_average_latency",
+		dimension: "system",
+		unit: "ms",
+		direction: "LIB",
+		headline: false,
+		label: "PostgreSQL - Scaling Factor: 10000 - Clients: 250 - Mode: Read Write - Average Latency",
+		description:
+			"This is a benchmark of PostgreSQL using the integrated pgbench for facilitating the database benchmarks.",
+		pts: {
+			test: "pts/pgbench",
+			description: "Scaling Factor: 10000 - Clients: 250 - Mode: Read Write - Average Latency",
+		},
+		sourceUrl: "https://www.postgresql.org/",
+	},
+	{
+		id: "pgbench_scaling_factor_10000_clients_5000_mode_read_only",
+		dimension: "system",
+		unit: "TPS",
+		direction: "HIB",
+		headline: false,
+		label: "PostgreSQL - Scaling Factor: 10000 - Clients: 5000 - Mode: Read Only",
+		description:
+			"This is a benchmark of PostgreSQL using the integrated pgbench for facilitating the database benchmarks.",
+		pts: {
+			test: "pts/pgbench",
+			description: "Scaling Factor: 10000 - Clients: 5000 - Mode: Read Only",
+		},
+		sourceUrl: "https://www.postgresql.org/",
+	},
+	{
+		id: "pgbench_scaling_factor_10000_clients_5000_mode_read_only_average_latency",
+		dimension: "system",
+		unit: "ms",
+		direction: "LIB",
+		headline: false,
+		label: "PostgreSQL - Scaling Factor: 10000 - Clients: 5000 - Mode: Read Only - Average Latency",
+		description:
+			"This is a benchmark of PostgreSQL using the integrated pgbench for facilitating the database benchmarks.",
+		pts: {
+			test: "pts/pgbench",
+			description: "Scaling Factor: 10000 - Clients: 5000 - Mode: Read Only - Average Latency",
+		},
+		sourceUrl: "https://www.postgresql.org/",
+	},
+	{
+		id: "pgbench_scaling_factor_10000_clients_5000_mode_read_write",
+		dimension: "system",
+		unit: "TPS",
+		direction: "HIB",
+		headline: false,
+		label: "PostgreSQL - Scaling Factor: 10000 - Clients: 5000 - Mode: Read Write",
+		description:
+			"This is a benchmark of PostgreSQL using the integrated pgbench for facilitating the database benchmarks.",
+		pts: {
+			test: "pts/pgbench",
+			description: "Scaling Factor: 10000 - Clients: 5000 - Mode: Read Write",
+		},
+		sourceUrl: "https://www.postgresql.org/",
+	},
+	{
+		id: "pgbench_scaling_factor_10000_clients_5000_mode_read_write_average_latency",
+		dimension: "system",
+		unit: "ms",
+		direction: "LIB",
+		headline: false,
+		label:
+			"PostgreSQL - Scaling Factor: 10000 - Clients: 5000 - Mode: Read Write - Average Latency",
+		description:
+			"This is a benchmark of PostgreSQL using the integrated pgbench for facilitating the database benchmarks.",
+		pts: {
+			test: "pts/pgbench",
+			description: "Scaling Factor: 10000 - Clients: 5000 - Mode: Read Write - Average Latency",
+		},
+		sourceUrl: "https://www.postgresql.org/",
+	},
+];
+
+const chunk5: MetricDef[] = [
+	{
+		id: "pgbench_scaling_factor_10000_clients_500_mode_read_only",
+		dimension: "system",
+		unit: "TPS",
+		direction: "HIB",
+		headline: false,
+		label: "PostgreSQL - Scaling Factor: 10000 - Clients: 500 - Mode: Read Only",
+		description:
+			"This is a benchmark of PostgreSQL using the integrated pgbench for facilitating the database benchmarks.",
+		pts: {
+			test: "pts/pgbench",
+			description: "Scaling Factor: 10000 - Clients: 500 - Mode: Read Only",
+		},
+		sourceUrl: "https://www.postgresql.org/",
+	},
+	{
+		id: "pgbench_scaling_factor_10000_clients_500_mode_read_only_average_latency",
+		dimension: "system",
+		unit: "ms",
+		direction: "LIB",
+		headline: false,
+		label: "PostgreSQL - Scaling Factor: 10000 - Clients: 500 - Mode: Read Only - Average Latency",
+		description:
+			"This is a benchmark of PostgreSQL using the integrated pgbench for facilitating the database benchmarks.",
+		pts: {
+			test: "pts/pgbench",
+			description: "Scaling Factor: 10000 - Clients: 500 - Mode: Read Only - Average Latency",
+		},
+		sourceUrl: "https://www.postgresql.org/",
+	},
+	{
+		id: "pgbench_scaling_factor_10000_clients_500_mode_read_write",
+		dimension: "system",
+		unit: "TPS",
+		direction: "HIB",
+		headline: false,
+		label: "PostgreSQL - Scaling Factor: 10000 - Clients: 500 - Mode: Read Write",
+		description:
+			"This is a benchmark of PostgreSQL using the integrated pgbench for facilitating the database benchmarks.",
+		pts: {
+			test: "pts/pgbench",
+			description: "Scaling Factor: 10000 - Clients: 500 - Mode: Read Write",
+		},
+		sourceUrl: "https://www.postgresql.org/",
+	},
+	{
+		id: "pgbench_scaling_factor_10000_clients_500_mode_read_write_average_latency",
+		dimension: "system",
+		unit: "ms",
+		direction: "LIB",
+		headline: false,
+		label: "PostgreSQL - Scaling Factor: 10000 - Clients: 500 - Mode: Read Write - Average Latency",
+		description:
+			"This is a benchmark of PostgreSQL using the integrated pgbench for facilitating the database benchmarks.",
+		pts: {
+			test: "pts/pgbench",
+			description: "Scaling Factor: 10000 - Clients: 500 - Mode: Read Write - Average Latency",
+		},
+		sourceUrl: "https://www.postgresql.org/",
+	},
+	{
+		id: "pgbench_scaling_factor_10000_clients_50_mode_read_only",
+		dimension: "system",
+		unit: "TPS",
+		direction: "HIB",
+		headline: false,
+		label: "PostgreSQL - Scaling Factor: 10000 - Clients: 50 - Mode: Read Only",
+		description:
+			"This is a benchmark of PostgreSQL using the integrated pgbench for facilitating the database benchmarks.",
+		pts: {
+			test: "pts/pgbench",
+			description: "Scaling Factor: 10000 - Clients: 50 - Mode: Read Only",
+		},
+		sourceUrl: "https://www.postgresql.org/",
+	},
+	{
+		id: "pgbench_scaling_factor_10000_clients_50_mode_read_only_average_latency",
+		dimension: "system",
+		unit: "ms",
+		direction: "LIB",
+		headline: false,
+		label: "PostgreSQL - Scaling Factor: 10000 - Clients: 50 - Mode: Read Only - Average Latency",
+		description:
+			"This is a benchmark of PostgreSQL using the integrated pgbench for facilitating the database benchmarks.",
+		pts: {
+			test: "pts/pgbench",
+			description: "Scaling Factor: 10000 - Clients: 50 - Mode: Read Only - Average Latency",
+		},
+		sourceUrl: "https://www.postgresql.org/",
+	},
+	{
+		id: "pgbench_scaling_factor_10000_clients_50_mode_read_write",
+		dimension: "system",
+		unit: "TPS",
+		direction: "HIB",
+		headline: false,
+		label: "PostgreSQL - Scaling Factor: 10000 - Clients: 50 - Mode: Read Write",
+		description:
+			"This is a benchmark of PostgreSQL using the integrated pgbench for facilitating the database benchmarks.",
+		pts: {
+			test: "pts/pgbench",
+			description: "Scaling Factor: 10000 - Clients: 50 - Mode: Read Write",
+		},
+		sourceUrl: "https://www.postgresql.org/",
+	},
+	{
+		id: "pgbench_scaling_factor_10000_clients_50_mode_read_write_average_latency",
+		dimension: "system",
+		unit: "ms",
+		direction: "LIB",
+		headline: false,
+		label: "PostgreSQL - Scaling Factor: 10000 - Clients: 50 - Mode: Read Write - Average Latency",
+		description:
+			"This is a benchmark of PostgreSQL using the integrated pgbench for facilitating the database benchmarks.",
+		pts: {
+			test: "pts/pgbench",
+			description: "Scaling Factor: 10000 - Clients: 50 - Mode: Read Write - Average Latency",
+		},
+		sourceUrl: "https://www.postgresql.org/",
+	},
+	{
+		id: "pgbench_scaling_factor_10000_clients_800_mode_read_only",
+		dimension: "system",
+		unit: "TPS",
+		direction: "HIB",
+		headline: false,
+		label: "PostgreSQL - Scaling Factor: 10000 - Clients: 800 - Mode: Read Only",
+		description:
+			"This is a benchmark of PostgreSQL using the integrated pgbench for facilitating the database benchmarks.",
+		pts: {
+			test: "pts/pgbench",
+			description: "Scaling Factor: 10000 - Clients: 800 - Mode: Read Only",
+		},
+		sourceUrl: "https://www.postgresql.org/",
+	},
+	{
+		id: "pgbench_scaling_factor_10000_clients_800_mode_read_only_average_latency",
+		dimension: "system",
+		unit: "ms",
+		direction: "LIB",
+		headline: false,
+		label: "PostgreSQL - Scaling Factor: 10000 - Clients: 800 - Mode: Read Only - Average Latency",
+		description:
+			"This is a benchmark of PostgreSQL using the integrated pgbench for facilitating the database benchmarks.",
+		pts: {
+			test: "pts/pgbench",
+			description: "Scaling Factor: 10000 - Clients: 800 - Mode: Read Only - Average Latency",
+		},
+		sourceUrl: "https://www.postgresql.org/",
+	},
+	{
+		id: "pgbench_scaling_factor_10000_clients_800_mode_read_write",
+		dimension: "system",
+		unit: "TPS",
+		direction: "HIB",
+		headline: false,
+		label: "PostgreSQL - Scaling Factor: 10000 - Clients: 800 - Mode: Read Write",
+		description:
+			"This is a benchmark of PostgreSQL using the integrated pgbench for facilitating the database benchmarks.",
+		pts: {
+			test: "pts/pgbench",
+			description: "Scaling Factor: 10000 - Clients: 800 - Mode: Read Write",
+		},
+		sourceUrl: "https://www.postgresql.org/",
+	},
+	{
+		id: "pgbench_scaling_factor_10000_clients_800_mode_read_write_average_latency",
+		dimension: "system",
+		unit: "ms",
+		direction: "LIB",
+		headline: false,
+		label: "PostgreSQL - Scaling Factor: 10000 - Clients: 800 - Mode: Read Write - Average Latency",
+		description:
+			"This is a benchmark of PostgreSQL using the integrated pgbench for facilitating the database benchmarks.",
+		pts: {
+			test: "pts/pgbench",
+			description: "Scaling Factor: 10000 - Clients: 800 - Mode: Read Write - Average Latency",
+		},
+		sourceUrl: "https://www.postgresql.org/",
+	},
+	{
+		id: "pgbench_scaling_factor_1000_clients_1000_mode_read_only",
+		dimension: "system",
+		unit: "TPS",
+		direction: "HIB",
+		headline: false,
+		label: "PostgreSQL - Scaling Factor: 1000 - Clients: 1000 - Mode: Read Only",
+		description:
+			"This is a benchmark of PostgreSQL using the integrated pgbench for facilitating the database benchmarks.",
+		pts: {
+			test: "pts/pgbench",
+			description: "Scaling Factor: 1000 - Clients: 1000 - Mode: Read Only",
+		},
+		sourceUrl: "https://www.postgresql.org/",
+	},
+	{
+		id: "pgbench_scaling_factor_1000_clients_1000_mode_read_only_average_latency",
+		dimension: "system",
+		unit: "ms",
+		direction: "LIB",
+		headline: false,
+		label: "PostgreSQL - Scaling Factor: 1000 - Clients: 1000 - Mode: Read Only - Average Latency",
+		description:
+			"This is a benchmark of PostgreSQL using the integrated pgbench for facilitating the database benchmarks.",
+		pts: {
+			test: "pts/pgbench",
+			description: "Scaling Factor: 1000 - Clients: 1000 - Mode: Read Only - Average Latency",
+		},
+		sourceUrl: "https://www.postgresql.org/",
+	},
+	{
+		id: "pgbench_scaling_factor_1000_clients_1000_mode_read_write",
+		dimension: "system",
+		unit: "TPS",
+		direction: "HIB",
+		headline: false,
+		label: "PostgreSQL - Scaling Factor: 1000 - Clients: 1000 - Mode: Read Write",
+		description:
+			"This is a benchmark of PostgreSQL using the integrated pgbench for facilitating the database benchmarks.",
+		pts: {
+			test: "pts/pgbench",
+			description: "Scaling Factor: 1000 - Clients: 1000 - Mode: Read Write",
+		},
+		sourceUrl: "https://www.postgresql.org/",
+	},
+	{
+		id: "pgbench_scaling_factor_1000_clients_1000_mode_read_write_average_latency",
+		dimension: "system",
+		unit: "ms",
+		direction: "LIB",
+		headline: false,
+		label: "PostgreSQL - Scaling Factor: 1000 - Clients: 1000 - Mode: Read Write - Average Latency",
+		description:
+			"This is a benchmark of PostgreSQL using the integrated pgbench for facilitating the database benchmarks.",
+		pts: {
+			test: "pts/pgbench",
+			description: "Scaling Factor: 1000 - Clients: 1000 - Mode: Read Write - Average Latency",
+		},
+		sourceUrl: "https://www.postgresql.org/",
+	},
+	{
+		id: "pgbench_scaling_factor_1000_clients_100_mode_read_only",
+		dimension: "system",
+		unit: "TPS",
+		direction: "HIB",
+		headline: false,
+		label: "PostgreSQL - Scaling Factor: 1000 - Clients: 100 - Mode: Read Only",
+		description:
+			"This is a benchmark of PostgreSQL using the integrated pgbench for facilitating the database benchmarks.",
+		pts: {
+			test: "pts/pgbench",
+			description: "Scaling Factor: 1000 - Clients: 100 - Mode: Read Only",
+		},
+		sourceUrl: "https://www.postgresql.org/",
+	},
+	{
+		id: "pgbench_scaling_factor_1000_clients_100_mode_read_only_average_latency",
+		dimension: "system",
+		unit: "ms",
+		direction: "LIB",
+		headline: false,
+		label: "PostgreSQL - Scaling Factor: 1000 - Clients: 100 - Mode: Read Only - Average Latency",
+		description:
+			"This is a benchmark of PostgreSQL using the integrated pgbench for facilitating the database benchmarks.",
+		pts: {
+			test: "pts/pgbench",
+			description: "Scaling Factor: 1000 - Clients: 100 - Mode: Read Only - Average Latency",
+		},
+		sourceUrl: "https://www.postgresql.org/",
+	},
+	{
+		id: "pgbench_scaling_factor_1000_clients_100_mode_read_write",
+		dimension: "system",
+		unit: "TPS",
+		direction: "HIB",
+		headline: false,
+		label: "PostgreSQL - Scaling Factor: 1000 - Clients: 100 - Mode: Read Write",
+		description:
+			"This is a benchmark of PostgreSQL using the integrated pgbench for facilitating the database benchmarks.",
+		pts: {
+			test: "pts/pgbench",
+			description: "Scaling Factor: 1000 - Clients: 100 - Mode: Read Write",
+		},
+		sourceUrl: "https://www.postgresql.org/",
+	},
+	{
+		id: "pgbench_scaling_factor_1000_clients_100_mode_read_write_average_latency",
+		dimension: "system",
+		unit: "ms",
+		direction: "LIB",
+		headline: false,
+		label: "PostgreSQL - Scaling Factor: 1000 - Clients: 100 - Mode: Read Write - Average Latency",
+		description:
+			"This is a benchmark of PostgreSQL using the integrated pgbench for facilitating the database benchmarks.",
+		pts: {
+			test: "pts/pgbench",
+			description: "Scaling Factor: 1000 - Clients: 100 - Mode: Read Write - Average Latency",
+		},
+		sourceUrl: "https://www.postgresql.org/",
+	},
+	{
+		id: "pgbench_scaling_factor_1000_clients_1_mode_read_only",
+		dimension: "system",
+		unit: "TPS",
+		direction: "HIB",
+		headline: false,
+		label: "PostgreSQL - Scaling Factor: 1000 - Clients: 1 - Mode: Read Only",
+		description:
+			"This is a benchmark of PostgreSQL using the integrated pgbench for facilitating the database benchmarks.",
+		pts: {
+			test: "pts/pgbench",
+			description: "Scaling Factor: 1000 - Clients: 1 - Mode: Read Only",
+		},
+		sourceUrl: "https://www.postgresql.org/",
+	},
+	{
+		id: "pgbench_scaling_factor_1000_clients_1_mode_read_only_average_latency",
+		dimension: "system",
+		unit: "ms",
+		direction: "LIB",
+		headline: false,
+		label: "PostgreSQL - Scaling Factor: 1000 - Clients: 1 - Mode: Read Only - Average Latency",
+		description:
+			"This is a benchmark of PostgreSQL using the integrated pgbench for facilitating the database benchmarks.",
+		pts: {
+			test: "pts/pgbench",
+			description: "Scaling Factor: 1000 - Clients: 1 - Mode: Read Only - Average Latency",
+		},
+		sourceUrl: "https://www.postgresql.org/",
+	},
+	{
+		id: "pgbench_scaling_factor_1000_clients_1_mode_read_write",
+		dimension: "system",
+		unit: "TPS",
+		direction: "HIB",
+		headline: false,
+		label: "PostgreSQL - Scaling Factor: 1000 - Clients: 1 - Mode: Read Write",
+		description:
+			"This is a benchmark of PostgreSQL using the integrated pgbench for facilitating the database benchmarks.",
+		pts: {
+			test: "pts/pgbench",
+			description: "Scaling Factor: 1000 - Clients: 1 - Mode: Read Write",
+		},
+		sourceUrl: "https://www.postgresql.org/",
+	},
+	{
+		id: "pgbench_scaling_factor_1000_clients_1_mode_read_write_average_latency",
+		dimension: "system",
+		unit: "ms",
+		direction: "LIB",
+		headline: false,
+		label: "PostgreSQL - Scaling Factor: 1000 - Clients: 1 - Mode: Read Write - Average Latency",
+		description:
+			"This is a benchmark of PostgreSQL using the integrated pgbench for facilitating the database benchmarks.",
+		pts: {
+			test: "pts/pgbench",
+			description: "Scaling Factor: 1000 - Clients: 1 - Mode: Read Write - Average Latency",
+		},
+		sourceUrl: "https://www.postgresql.org/",
+	},
+	{
+		id: "pgbench_scaling_factor_1000_clients_250_mode_read_only",
+		dimension: "system",
+		unit: "TPS",
+		direction: "HIB",
+		headline: false,
+		label: "PostgreSQL - Scaling Factor: 1000 - Clients: 250 - Mode: Read Only",
+		description:
+			"This is a benchmark of PostgreSQL using the integrated pgbench for facilitating the database benchmarks.",
+		pts: {
+			test: "pts/pgbench",
+			description: "Scaling Factor: 1000 - Clients: 250 - Mode: Read Only",
+		},
+		sourceUrl: "https://www.postgresql.org/",
+	},
+	{
+		id: "pgbench_scaling_factor_1000_clients_250_mode_read_only_average_latency",
+		dimension: "system",
+		unit: "ms",
+		direction: "LIB",
+		headline: false,
+		label: "PostgreSQL - Scaling Factor: 1000 - Clients: 250 - Mode: Read Only - Average Latency",
+		description:
+			"This is a benchmark of PostgreSQL using the integrated pgbench for facilitating the database benchmarks.",
+		pts: {
+			test: "pts/pgbench",
+			description: "Scaling Factor: 1000 - Clients: 250 - Mode: Read Only - Average Latency",
+		},
+		sourceUrl: "https://www.postgresql.org/",
+	},
+	{
+		id: "pgbench_scaling_factor_1000_clients_250_mode_read_write",
+		dimension: "system",
+		unit: "TPS",
+		direction: "HIB",
+		headline: false,
+		label: "PostgreSQL - Scaling Factor: 1000 - Clients: 250 - Mode: Read Write",
+		description:
+			"This is a benchmark of PostgreSQL using the integrated pgbench for facilitating the database benchmarks.",
+		pts: {
+			test: "pts/pgbench",
+			description: "Scaling Factor: 1000 - Clients: 250 - Mode: Read Write",
+		},
+		sourceUrl: "https://www.postgresql.org/",
+	},
+	{
+		id: "pgbench_scaling_factor_1000_clients_250_mode_read_write_average_latency",
+		dimension: "system",
+		unit: "ms",
+		direction: "LIB",
+		headline: false,
+		label: "PostgreSQL - Scaling Factor: 1000 - Clients: 250 - Mode: Read Write - Average Latency",
+		description:
+			"This is a benchmark of PostgreSQL using the integrated pgbench for facilitating the database benchmarks.",
+		pts: {
+			test: "pts/pgbench",
+			description: "Scaling Factor: 1000 - Clients: 250 - Mode: Read Write - Average Latency",
+		},
+		sourceUrl: "https://www.postgresql.org/",
+	},
+	{
+		id: "pgbench_scaling_factor_1000_clients_5000_mode_read_only",
+		dimension: "system",
+		unit: "TPS",
+		direction: "HIB",
+		headline: false,
+		label: "PostgreSQL - Scaling Factor: 1000 - Clients: 5000 - Mode: Read Only",
+		description:
+			"This is a benchmark of PostgreSQL using the integrated pgbench for facilitating the database benchmarks.",
+		pts: {
+			test: "pts/pgbench",
+			description: "Scaling Factor: 1000 - Clients: 5000 - Mode: Read Only",
+		},
+		sourceUrl: "https://www.postgresql.org/",
+	},
+	{
+		id: "pgbench_scaling_factor_1000_clients_5000_mode_read_only_average_latency",
+		dimension: "system",
+		unit: "ms",
+		direction: "LIB",
+		headline: false,
+		label: "PostgreSQL - Scaling Factor: 1000 - Clients: 5000 - Mode: Read Only - Average Latency",
+		description:
+			"This is a benchmark of PostgreSQL using the integrated pgbench for facilitating the database benchmarks.",
+		pts: {
+			test: "pts/pgbench",
+			description: "Scaling Factor: 1000 - Clients: 5000 - Mode: Read Only - Average Latency",
+		},
+		sourceUrl: "https://www.postgresql.org/",
+	},
+	{
+		id: "pgbench_scaling_factor_1000_clients_5000_mode_read_write",
+		dimension: "system",
+		unit: "TPS",
+		direction: "HIB",
+		headline: false,
+		label: "PostgreSQL - Scaling Factor: 1000 - Clients: 5000 - Mode: Read Write",
+		description:
+			"This is a benchmark of PostgreSQL using the integrated pgbench for facilitating the database benchmarks.",
+		pts: {
+			test: "pts/pgbench",
+			description: "Scaling Factor: 1000 - Clients: 5000 - Mode: Read Write",
+		},
+		sourceUrl: "https://www.postgresql.org/",
+	},
+	{
+		id: "pgbench_scaling_factor_1000_clients_5000_mode_read_write_average_latency",
+		dimension: "system",
+		unit: "ms",
+		direction: "LIB",
+		headline: false,
+		label: "PostgreSQL - Scaling Factor: 1000 - Clients: 5000 - Mode: Read Write - Average Latency",
+		description:
+			"This is a benchmark of PostgreSQL using the integrated pgbench for facilitating the database benchmarks.",
+		pts: {
+			test: "pts/pgbench",
+			description: "Scaling Factor: 1000 - Clients: 5000 - Mode: Read Write - Average Latency",
+		},
+		sourceUrl: "https://www.postgresql.org/",
+	},
+	{
+		id: "pgbench_scaling_factor_1000_clients_500_mode_read_only",
+		dimension: "system",
+		unit: "TPS",
+		direction: "HIB",
+		headline: false,
+		label: "PostgreSQL - Scaling Factor: 1000 - Clients: 500 - Mode: Read Only",
+		description:
+			"This is a benchmark of PostgreSQL using the integrated pgbench for facilitating the database benchmarks.",
+		pts: {
+			test: "pts/pgbench",
+			description: "Scaling Factor: 1000 - Clients: 500 - Mode: Read Only",
+		},
+		sourceUrl: "https://www.postgresql.org/",
+	},
+	{
+		id: "pgbench_scaling_factor_1000_clients_500_mode_read_only_average_latency",
+		dimension: "system",
+		unit: "ms",
+		direction: "LIB",
+		headline: false,
+		label: "PostgreSQL - Scaling Factor: 1000 - Clients: 500 - Mode: Read Only - Average Latency",
+		description:
+			"This is a benchmark of PostgreSQL using the integrated pgbench for facilitating the database benchmarks.",
+		pts: {
+			test: "pts/pgbench",
+			description: "Scaling Factor: 1000 - Clients: 500 - Mode: Read Only - Average Latency",
+		},
+		sourceUrl: "https://www.postgresql.org/",
+	},
+	{
+		id: "pgbench_scaling_factor_1000_clients_500_mode_read_write",
+		dimension: "system",
+		unit: "TPS",
+		direction: "HIB",
+		headline: false,
+		label: "PostgreSQL - Scaling Factor: 1000 - Clients: 500 - Mode: Read Write",
+		description:
+			"This is a benchmark of PostgreSQL using the integrated pgbench for facilitating the database benchmarks.",
+		pts: {
+			test: "pts/pgbench",
+			description: "Scaling Factor: 1000 - Clients: 500 - Mode: Read Write",
+		},
+		sourceUrl: "https://www.postgresql.org/",
+	},
+	{
+		id: "pgbench_scaling_factor_1000_clients_500_mode_read_write_average_latency",
+		dimension: "system",
+		unit: "ms",
+		direction: "LIB",
+		headline: false,
+		label: "PostgreSQL - Scaling Factor: 1000 - Clients: 500 - Mode: Read Write - Average Latency",
+		description:
+			"This is a benchmark of PostgreSQL using the integrated pgbench for facilitating the database benchmarks.",
+		pts: {
+			test: "pts/pgbench",
+			description: "Scaling Factor: 1000 - Clients: 500 - Mode: Read Write - Average Latency",
+		},
+		sourceUrl: "https://www.postgresql.org/",
+	},
+	{
+		id: "pgbench_scaling_factor_1000_clients_50_mode_read_only",
+		dimension: "system",
+		unit: "TPS",
+		direction: "HIB",
+		headline: false,
+		label: "PostgreSQL - Scaling Factor: 1000 - Clients: 50 - Mode: Read Only",
+		description:
+			"This is a benchmark of PostgreSQL using the integrated pgbench for facilitating the database benchmarks.",
+		pts: {
+			test: "pts/pgbench",
+			description: "Scaling Factor: 1000 - Clients: 50 - Mode: Read Only",
+		},
+		sourceUrl: "https://www.postgresql.org/",
+	},
+	{
+		id: "pgbench_scaling_factor_1000_clients_50_mode_read_only_average_latency",
+		dimension: "system",
+		unit: "ms",
+		direction: "LIB",
+		headline: false,
+		label: "PostgreSQL - Scaling Factor: 1000 - Clients: 50 - Mode: Read Only - Average Latency",
+		description:
+			"This is a benchmark of PostgreSQL using the integrated pgbench for facilitating the database benchmarks.",
+		pts: {
+			test: "pts/pgbench",
+			description: "Scaling Factor: 1000 - Clients: 50 - Mode: Read Only - Average Latency",
+		},
+		sourceUrl: "https://www.postgresql.org/",
+	},
+	{
+		id: "pgbench_scaling_factor_1000_clients_50_mode_read_write",
+		dimension: "system",
+		unit: "TPS",
+		direction: "HIB",
+		headline: false,
+		label: "PostgreSQL - Scaling Factor: 1000 - Clients: 50 - Mode: Read Write",
+		description:
+			"This is a benchmark of PostgreSQL using the integrated pgbench for facilitating the database benchmarks.",
+		pts: {
+			test: "pts/pgbench",
+			description: "Scaling Factor: 1000 - Clients: 50 - Mode: Read Write",
+		},
+		sourceUrl: "https://www.postgresql.org/",
+	},
+	{
+		id: "pgbench_scaling_factor_1000_clients_50_mode_read_write_average_latency",
+		dimension: "system",
+		unit: "ms",
+		direction: "LIB",
+		headline: false,
+		label: "PostgreSQL - Scaling Factor: 1000 - Clients: 50 - Mode: Read Write - Average Latency",
+		description:
+			"This is a benchmark of PostgreSQL using the integrated pgbench for facilitating the database benchmarks.",
+		pts: {
+			test: "pts/pgbench",
+			description: "Scaling Factor: 1000 - Clients: 50 - Mode: Read Write - Average Latency",
+		},
+		sourceUrl: "https://www.postgresql.org/",
+	},
+	{
+		id: "pgbench_scaling_factor_1000_clients_800_mode_read_only",
+		dimension: "system",
+		unit: "TPS",
+		direction: "HIB",
+		headline: false,
+		label: "PostgreSQL - Scaling Factor: 1000 - Clients: 800 - Mode: Read Only",
+		description:
+			"This is a benchmark of PostgreSQL using the integrated pgbench for facilitating the database benchmarks.",
+		pts: {
+			test: "pts/pgbench",
+			description: "Scaling Factor: 1000 - Clients: 800 - Mode: Read Only",
+		},
+		sourceUrl: "https://www.postgresql.org/",
+	},
+	{
+		id: "pgbench_scaling_factor_1000_clients_800_mode_read_only_average_latency",
+		dimension: "system",
+		unit: "ms",
+		direction: "LIB",
+		headline: false,
+		label: "PostgreSQL - Scaling Factor: 1000 - Clients: 800 - Mode: Read Only - Average Latency",
+		description:
+			"This is a benchmark of PostgreSQL using the integrated pgbench for facilitating the database benchmarks.",
+		pts: {
+			test: "pts/pgbench",
+			description: "Scaling Factor: 1000 - Clients: 800 - Mode: Read Only - Average Latency",
+		},
+		sourceUrl: "https://www.postgresql.org/",
+	},
+	{
+		id: "pgbench_scaling_factor_1000_clients_800_mode_read_write",
+		dimension: "system",
+		unit: "TPS",
+		direction: "HIB",
+		headline: false,
+		label: "PostgreSQL - Scaling Factor: 1000 - Clients: 800 - Mode: Read Write",
+		description:
+			"This is a benchmark of PostgreSQL using the integrated pgbench for facilitating the database benchmarks.",
+		pts: {
+			test: "pts/pgbench",
+			description: "Scaling Factor: 1000 - Clients: 800 - Mode: Read Write",
+		},
+		sourceUrl: "https://www.postgresql.org/",
+	},
+	{
+		id: "pgbench_scaling_factor_1000_clients_800_mode_read_write_average_latency",
+		dimension: "system",
+		unit: "ms",
+		direction: "LIB",
+		headline: false,
+		label: "PostgreSQL - Scaling Factor: 1000 - Clients: 800 - Mode: Read Write - Average Latency",
+		description:
+			"This is a benchmark of PostgreSQL using the integrated pgbench for facilitating the database benchmarks.",
+		pts: {
+			test: "pts/pgbench",
+			description: "Scaling Factor: 1000 - Clients: 800 - Mode: Read Write - Average Latency",
+		},
+		sourceUrl: "https://www.postgresql.org/",
+	},
+	{
+		id: "pgbench_scaling_factor_100_clients_1000_mode_read_only",
+		dimension: "system",
+		unit: "TPS",
+		direction: "HIB",
+		headline: false,
+		label: "PostgreSQL - Scaling Factor: 100 - Clients: 1000 - Mode: Read Only",
+		description:
+			"This is a benchmark of PostgreSQL using the integrated pgbench for facilitating the database benchmarks.",
+		pts: {
+			test: "pts/pgbench",
+			description: "Scaling Factor: 100 - Clients: 1000 - Mode: Read Only",
+		},
+		sourceUrl: "https://www.postgresql.org/",
+	},
+	{
+		id: "pgbench_scaling_factor_100_clients_1000_mode_read_only_average_latency",
+		dimension: "system",
+		unit: "ms",
+		direction: "LIB",
+		headline: false,
+		label: "PostgreSQL - Scaling Factor: 100 - Clients: 1000 - Mode: Read Only - Average Latency",
+		description:
+			"This is a benchmark of PostgreSQL using the integrated pgbench for facilitating the database benchmarks.",
+		pts: {
+			test: "pts/pgbench",
+			description: "Scaling Factor: 100 - Clients: 1000 - Mode: Read Only - Average Latency",
+		},
+		sourceUrl: "https://www.postgresql.org/",
+	},
+	{
+		id: "pgbench_scaling_factor_100_clients_1000_mode_read_write",
+		dimension: "system",
+		unit: "TPS",
+		direction: "HIB",
+		headline: false,
+		label: "PostgreSQL - Scaling Factor: 100 - Clients: 1000 - Mode: Read Write",
+		description:
+			"This is a benchmark of PostgreSQL using the integrated pgbench for facilitating the database benchmarks.",
+		pts: {
+			test: "pts/pgbench",
+			description: "Scaling Factor: 100 - Clients: 1000 - Mode: Read Write",
+		},
+		sourceUrl: "https://www.postgresql.org/",
+	},
+	{
+		id: "pgbench_scaling_factor_100_clients_1000_mode_read_write_average_latency",
+		dimension: "system",
+		unit: "ms",
+		direction: "LIB",
+		headline: false,
+		label: "PostgreSQL - Scaling Factor: 100 - Clients: 1000 - Mode: Read Write - Average Latency",
+		description:
+			"This is a benchmark of PostgreSQL using the integrated pgbench for facilitating the database benchmarks.",
+		pts: {
+			test: "pts/pgbench",
+			description: "Scaling Factor: 100 - Clients: 1000 - Mode: Read Write - Average Latency",
+		},
+		sourceUrl: "https://www.postgresql.org/",
+	},
+	{
+		id: "pgbench_scaling_factor_100_clients_100_mode_read_only",
+		dimension: "system",
+		unit: "TPS",
+		direction: "HIB",
+		headline: false,
+		label: "PostgreSQL - Scaling Factor: 100 - Clients: 100 - Mode: Read Only",
+		description:
+			"This is a benchmark of PostgreSQL using the integrated pgbench for facilitating the database benchmarks.",
+		pts: {
+			test: "pts/pgbench",
+			description: "Scaling Factor: 100 - Clients: 100 - Mode: Read Only",
+		},
+		sourceUrl: "https://www.postgresql.org/",
+	},
+	{
+		id: "pgbench_scaling_factor_100_clients_100_mode_read_only_average_latency",
+		dimension: "system",
+		unit: "ms",
+		direction: "LIB",
+		headline: false,
+		label: "PostgreSQL - Scaling Factor: 100 - Clients: 100 - Mode: Read Only - Average Latency",
+		description:
+			"This is a benchmark of PostgreSQL using the integrated pgbench for facilitating the database benchmarks.",
+		pts: {
+			test: "pts/pgbench",
+			description: "Scaling Factor: 100 - Clients: 100 - Mode: Read Only - Average Latency",
+		},
+		sourceUrl: "https://www.postgresql.org/",
+	},
+	{
+		id: "pgbench_scaling_factor_100_clients_100_mode_read_write",
+		dimension: "system",
+		unit: "TPS",
+		direction: "HIB",
+		headline: false,
+		label: "PostgreSQL - Scaling Factor: 100 - Clients: 100 - Mode: Read Write",
+		description:
+			"This is a benchmark of PostgreSQL using the integrated pgbench for facilitating the database benchmarks.",
+		pts: {
+			test: "pts/pgbench",
+			description: "Scaling Factor: 100 - Clients: 100 - Mode: Read Write",
+		},
+		sourceUrl: "https://www.postgresql.org/",
+	},
+	{
+		id: "pgbench_scaling_factor_100_clients_100_mode_read_write_average_latency",
+		dimension: "system",
+		unit: "ms",
+		direction: "LIB",
+		headline: false,
+		label: "PostgreSQL - Scaling Factor: 100 - Clients: 100 - Mode: Read Write - Average Latency",
+		description:
+			"This is a benchmark of PostgreSQL using the integrated pgbench for facilitating the database benchmarks.",
+		pts: {
+			test: "pts/pgbench",
+			description: "Scaling Factor: 100 - Clients: 100 - Mode: Read Write - Average Latency",
+		},
+		sourceUrl: "https://www.postgresql.org/",
+	},
+	{
+		id: "pgbench_scaling_factor_100_clients_1_mode_read_only",
+		dimension: "system",
+		unit: "TPS",
+		direction: "HIB",
+		headline: false,
+		label: "PostgreSQL - Scaling Factor: 100 - Clients: 1 - Mode: Read Only",
+		description:
+			"This is a benchmark of PostgreSQL using the integrated pgbench for facilitating the database benchmarks.",
+		pts: { test: "pts/pgbench", description: "Scaling Factor: 100 - Clients: 1 - Mode: Read Only" },
+		sourceUrl: "https://www.postgresql.org/",
+	},
+	{
+		id: "pgbench_scaling_factor_100_clients_1_mode_read_only_average_latency",
+		dimension: "system",
+		unit: "ms",
+		direction: "LIB",
+		headline: false,
+		label: "PostgreSQL - Scaling Factor: 100 - Clients: 1 - Mode: Read Only - Average Latency",
+		description:
+			"This is a benchmark of PostgreSQL using the integrated pgbench for facilitating the database benchmarks.",
+		pts: {
+			test: "pts/pgbench",
+			description: "Scaling Factor: 100 - Clients: 1 - Mode: Read Only - Average Latency",
+		},
+		sourceUrl: "https://www.postgresql.org/",
+	},
+	{
+		id: "pgbench_scaling_factor_100_clients_1_mode_read_write",
+		dimension: "system",
+		unit: "TPS",
+		direction: "HIB",
+		headline: false,
+		label: "PostgreSQL - Scaling Factor: 100 - Clients: 1 - Mode: Read Write",
+		description:
+			"This is a benchmark of PostgreSQL using the integrated pgbench for facilitating the database benchmarks.",
+		pts: {
+			test: "pts/pgbench",
+			description: "Scaling Factor: 100 - Clients: 1 - Mode: Read Write",
+		},
+		sourceUrl: "https://www.postgresql.org/",
+	},
+	{
+		id: "pgbench_scaling_factor_100_clients_1_mode_read_write_average_latency",
+		dimension: "system",
+		unit: "ms",
+		direction: "LIB",
+		headline: false,
+		label: "PostgreSQL - Scaling Factor: 100 - Clients: 1 - Mode: Read Write - Average Latency",
+		description:
+			"This is a benchmark of PostgreSQL using the integrated pgbench for facilitating the database benchmarks.",
+		pts: {
+			test: "pts/pgbench",
+			description: "Scaling Factor: 100 - Clients: 1 - Mode: Read Write - Average Latency",
+		},
+		sourceUrl: "https://www.postgresql.org/",
+	},
+	{
+		id: "pgbench_scaling_factor_100_clients_250_mode_read_only",
+		dimension: "system",
+		unit: "TPS",
+		direction: "HIB",
+		headline: false,
+		label: "PostgreSQL - Scaling Factor: 100 - Clients: 250 - Mode: Read Only",
+		description:
+			"This is a benchmark of PostgreSQL using the integrated pgbench for facilitating the database benchmarks.",
+		pts: {
+			test: "pts/pgbench",
+			description: "Scaling Factor: 100 - Clients: 250 - Mode: Read Only",
+		},
+		sourceUrl: "https://www.postgresql.org/",
+	},
+	{
+		id: "pgbench_scaling_factor_100_clients_250_mode_read_only_average_latency",
+		dimension: "system",
+		unit: "ms",
+		direction: "LIB",
+		headline: false,
+		label: "PostgreSQL - Scaling Factor: 100 - Clients: 250 - Mode: Read Only - Average Latency",
+		description:
+			"This is a benchmark of PostgreSQL using the integrated pgbench for facilitating the database benchmarks.",
+		pts: {
+			test: "pts/pgbench",
+			description: "Scaling Factor: 100 - Clients: 250 - Mode: Read Only - Average Latency",
+		},
+		sourceUrl: "https://www.postgresql.org/",
+	},
+	{
+		id: "pgbench_scaling_factor_100_clients_250_mode_read_write",
+		dimension: "system",
+		unit: "TPS",
+		direction: "HIB",
+		headline: false,
+		label: "PostgreSQL - Scaling Factor: 100 - Clients: 250 - Mode: Read Write",
+		description:
+			"This is a benchmark of PostgreSQL using the integrated pgbench for facilitating the database benchmarks.",
+		pts: {
+			test: "pts/pgbench",
+			description: "Scaling Factor: 100 - Clients: 250 - Mode: Read Write",
+		},
+		sourceUrl: "https://www.postgresql.org/",
+	},
+	{
+		id: "pgbench_scaling_factor_100_clients_250_mode_read_write_average_latency",
+		dimension: "system",
+		unit: "ms",
+		direction: "LIB",
+		headline: false,
+		label: "PostgreSQL - Scaling Factor: 100 - Clients: 250 - Mode: Read Write - Average Latency",
+		description:
+			"This is a benchmark of PostgreSQL using the integrated pgbench for facilitating the database benchmarks.",
+		pts: {
+			test: "pts/pgbench",
+			description: "Scaling Factor: 100 - Clients: 250 - Mode: Read Write - Average Latency",
+		},
+		sourceUrl: "https://www.postgresql.org/",
+	},
+	{
+		id: "pgbench_scaling_factor_100_clients_5000_mode_read_only",
+		dimension: "system",
+		unit: "TPS",
+		direction: "HIB",
+		headline: false,
+		label: "PostgreSQL - Scaling Factor: 100 - Clients: 5000 - Mode: Read Only",
+		description:
+			"This is a benchmark of PostgreSQL using the integrated pgbench for facilitating the database benchmarks.",
+		pts: {
+			test: "pts/pgbench",
+			description: "Scaling Factor: 100 - Clients: 5000 - Mode: Read Only",
+		},
+		sourceUrl: "https://www.postgresql.org/",
+	},
+	{
+		id: "pgbench_scaling_factor_100_clients_5000_mode_read_only_average_latency",
+		dimension: "system",
+		unit: "ms",
+		direction: "LIB",
+		headline: false,
+		label: "PostgreSQL - Scaling Factor: 100 - Clients: 5000 - Mode: Read Only - Average Latency",
+		description:
+			"This is a benchmark of PostgreSQL using the integrated pgbench for facilitating the database benchmarks.",
+		pts: {
+			test: "pts/pgbench",
+			description: "Scaling Factor: 100 - Clients: 5000 - Mode: Read Only - Average Latency",
+		},
+		sourceUrl: "https://www.postgresql.org/",
+	},
+	{
+		id: "pgbench_scaling_factor_100_clients_5000_mode_read_write",
+		dimension: "system",
+		unit: "TPS",
+		direction: "HIB",
+		headline: false,
+		label: "PostgreSQL - Scaling Factor: 100 - Clients: 5000 - Mode: Read Write",
+		description:
+			"This is a benchmark of PostgreSQL using the integrated pgbench for facilitating the database benchmarks.",
+		pts: {
+			test: "pts/pgbench",
+			description: "Scaling Factor: 100 - Clients: 5000 - Mode: Read Write",
+		},
+		sourceUrl: "https://www.postgresql.org/",
+	},
+	{
+		id: "pgbench_scaling_factor_100_clients_5000_mode_read_write_average_latency",
+		dimension: "system",
+		unit: "ms",
+		direction: "LIB",
+		headline: false,
+		label: "PostgreSQL - Scaling Factor: 100 - Clients: 5000 - Mode: Read Write - Average Latency",
+		description:
+			"This is a benchmark of PostgreSQL using the integrated pgbench for facilitating the database benchmarks.",
+		pts: {
+			test: "pts/pgbench",
+			description: "Scaling Factor: 100 - Clients: 5000 - Mode: Read Write - Average Latency",
+		},
+		sourceUrl: "https://www.postgresql.org/",
+	},
+	{
+		id: "pgbench_scaling_factor_100_clients_500_mode_read_only",
+		dimension: "system",
+		unit: "TPS",
+		direction: "HIB",
+		headline: false,
+		label: "PostgreSQL - Scaling Factor: 100 - Clients: 500 - Mode: Read Only",
+		description:
+			"This is a benchmark of PostgreSQL using the integrated pgbench for facilitating the database benchmarks.",
+		pts: {
+			test: "pts/pgbench",
+			description: "Scaling Factor: 100 - Clients: 500 - Mode: Read Only",
+		},
+		sourceUrl: "https://www.postgresql.org/",
+	},
+	{
+		id: "pgbench_scaling_factor_100_clients_500_mode_read_only_average_latency",
+		dimension: "system",
+		unit: "ms",
+		direction: "LIB",
+		headline: false,
+		label: "PostgreSQL - Scaling Factor: 100 - Clients: 500 - Mode: Read Only - Average Latency",
+		description:
+			"This is a benchmark of PostgreSQL using the integrated pgbench for facilitating the database benchmarks.",
+		pts: {
+			test: "pts/pgbench",
+			description: "Scaling Factor: 100 - Clients: 500 - Mode: Read Only - Average Latency",
+		},
+		sourceUrl: "https://www.postgresql.org/",
+	},
+	{
+		id: "pgbench_scaling_factor_100_clients_500_mode_read_write",
+		dimension: "system",
+		unit: "TPS",
+		direction: "HIB",
+		headline: false,
+		label: "PostgreSQL - Scaling Factor: 100 - Clients: 500 - Mode: Read Write",
+		description:
+			"This is a benchmark of PostgreSQL using the integrated pgbench for facilitating the database benchmarks.",
+		pts: {
+			test: "pts/pgbench",
+			description: "Scaling Factor: 100 - Clients: 500 - Mode: Read Write",
+		},
+		sourceUrl: "https://www.postgresql.org/",
+	},
+	{
+		id: "pgbench_scaling_factor_100_clients_500_mode_read_write_average_latency",
+		dimension: "system",
+		unit: "ms",
+		direction: "LIB",
+		headline: false,
+		label: "PostgreSQL - Scaling Factor: 100 - Clients: 500 - Mode: Read Write - Average Latency",
+		description:
+			"This is a benchmark of PostgreSQL using the integrated pgbench for facilitating the database benchmarks.",
+		pts: {
+			test: "pts/pgbench",
+			description: "Scaling Factor: 100 - Clients: 500 - Mode: Read Write - Average Latency",
+		},
+		sourceUrl: "https://www.postgresql.org/",
+	},
+	{
+		id: "pgbench_scaling_factor_100_clients_50_mode_read_only",
+		dimension: "system",
+		unit: "TPS",
+		direction: "HIB",
+		headline: false,
+		label: "PostgreSQL - Scaling Factor: 100 - Clients: 50 - Mode: Read Only",
+		description:
+			"This is a benchmark of PostgreSQL using the integrated pgbench for facilitating the database benchmarks.",
+		pts: {
+			test: "pts/pgbench",
+			description: "Scaling Factor: 100 - Clients: 50 - Mode: Read Only",
+		},
+		sourceUrl: "https://www.postgresql.org/",
+	},
+	{
+		id: "pgbench_scaling_factor_100_clients_50_mode_read_only_average_latency",
+		dimension: "system",
+		unit: "ms",
+		direction: "LIB",
+		headline: false,
+		label: "PostgreSQL - Scaling Factor: 100 - Clients: 50 - Mode: Read Only - Average Latency",
+		description:
+			"This is a benchmark of PostgreSQL using the integrated pgbench for facilitating the database benchmarks.",
+		pts: {
+			test: "pts/pgbench",
+			description: "Scaling Factor: 100 - Clients: 50 - Mode: Read Only - Average Latency",
+		},
+		sourceUrl: "https://www.postgresql.org/",
+	},
+	{
+		id: "pgbench_scaling_factor_100_clients_50_mode_read_write",
+		dimension: "system",
+		unit: "TPS",
+		direction: "HIB",
+		headline: false,
+		label: "PostgreSQL - Scaling Factor: 100 - Clients: 50 - Mode: Read Write",
+		description:
+			"This is a benchmark of PostgreSQL using the integrated pgbench for facilitating the database benchmarks.",
+		pts: {
+			test: "pts/pgbench",
+			description: "Scaling Factor: 100 - Clients: 50 - Mode: Read Write",
+		},
+		sourceUrl: "https://www.postgresql.org/",
+	},
+	{
+		id: "pgbench_scaling_factor_100_clients_50_mode_read_write_average_latency",
+		dimension: "system",
+		unit: "ms",
+		direction: "LIB",
+		headline: false,
+		label: "PostgreSQL - Scaling Factor: 100 - Clients: 50 - Mode: Read Write - Average Latency",
+		description:
+			"This is a benchmark of PostgreSQL using the integrated pgbench for facilitating the database benchmarks.",
+		pts: {
+			test: "pts/pgbench",
+			description: "Scaling Factor: 100 - Clients: 50 - Mode: Read Write - Average Latency",
+		},
+		sourceUrl: "https://www.postgresql.org/",
+	},
+	{
+		id: "pgbench_scaling_factor_100_clients_800_mode_read_only",
+		dimension: "system",
+		unit: "TPS",
+		direction: "HIB",
+		headline: false,
+		label: "PostgreSQL - Scaling Factor: 100 - Clients: 800 - Mode: Read Only",
+		description:
+			"This is a benchmark of PostgreSQL using the integrated pgbench for facilitating the database benchmarks.",
+		pts: {
+			test: "pts/pgbench",
+			description: "Scaling Factor: 100 - Clients: 800 - Mode: Read Only",
+		},
+		sourceUrl: "https://www.postgresql.org/",
+	},
+	{
+		id: "pgbench_scaling_factor_100_clients_800_mode_read_only_average_latency",
+		dimension: "system",
+		unit: "ms",
+		direction: "LIB",
+		headline: false,
+		label: "PostgreSQL - Scaling Factor: 100 - Clients: 800 - Mode: Read Only - Average Latency",
+		description:
+			"This is a benchmark of PostgreSQL using the integrated pgbench for facilitating the database benchmarks.",
+		pts: {
+			test: "pts/pgbench",
+			description: "Scaling Factor: 100 - Clients: 800 - Mode: Read Only - Average Latency",
+		},
+		sourceUrl: "https://www.postgresql.org/",
+	},
+	{
+		id: "pgbench_scaling_factor_100_clients_800_mode_read_write",
+		dimension: "system",
+		unit: "TPS",
+		direction: "HIB",
+		headline: false,
+		label: "PostgreSQL - Scaling Factor: 100 - Clients: 800 - Mode: Read Write",
+		description:
+			"This is a benchmark of PostgreSQL using the integrated pgbench for facilitating the database benchmarks.",
+		pts: {
+			test: "pts/pgbench",
+			description: "Scaling Factor: 100 - Clients: 800 - Mode: Read Write",
+		},
+		sourceUrl: "https://www.postgresql.org/",
+	},
+	{
+		id: "pgbench_scaling_factor_100_clients_800_mode_read_write_average_latency",
+		dimension: "system",
+		unit: "ms",
+		direction: "LIB",
+		headline: false,
+		label: "PostgreSQL - Scaling Factor: 100 - Clients: 800 - Mode: Read Write - Average Latency",
+		description:
+			"This is a benchmark of PostgreSQL using the integrated pgbench for facilitating the database benchmarks.",
+		pts: {
+			test: "pts/pgbench",
+			description: "Scaling Factor: 100 - Clients: 800 - Mode: Read Write - Average Latency",
+		},
+		sourceUrl: "https://www.postgresql.org/",
+	},
+	{
+		id: "pgbench_scaling_factor_1_clients_1000_mode_read_only",
+		dimension: "system",
+		unit: "TPS",
+		direction: "HIB",
+		headline: false,
+		label: "PostgreSQL - Scaling Factor: 1 - Clients: 1000 - Mode: Read Only",
+		description:
+			"This is a benchmark of PostgreSQL using the integrated pgbench for facilitating the database benchmarks.",
+		pts: {
+			test: "pts/pgbench",
+			description: "Scaling Factor: 1 - Clients: 1000 - Mode: Read Only",
+		},
+		sourceUrl: "https://www.postgresql.org/",
+	},
+	{
+		id: "pgbench_scaling_factor_1_clients_1000_mode_read_only_average_latency",
+		dimension: "system",
+		unit: "ms",
+		direction: "LIB",
+		headline: false,
+		label: "PostgreSQL - Scaling Factor: 1 - Clients: 1000 - Mode: Read Only - Average Latency",
+		description:
+			"This is a benchmark of PostgreSQL using the integrated pgbench for facilitating the database benchmarks.",
+		pts: {
+			test: "pts/pgbench",
+			description: "Scaling Factor: 1 - Clients: 1000 - Mode: Read Only - Average Latency",
+		},
+		sourceUrl: "https://www.postgresql.org/",
+	},
+	{
+		id: "pgbench_scaling_factor_1_clients_1000_mode_read_write",
+		dimension: "system",
+		unit: "TPS",
+		direction: "HIB",
+		headline: false,
+		label: "PostgreSQL - Scaling Factor: 1 - Clients: 1000 - Mode: Read Write",
+		description:
+			"This is a benchmark of PostgreSQL using the integrated pgbench for facilitating the database benchmarks.",
+		pts: {
+			test: "pts/pgbench",
+			description: "Scaling Factor: 1 - Clients: 1000 - Mode: Read Write",
+		},
+		sourceUrl: "https://www.postgresql.org/",
+	},
+	{
+		id: "pgbench_scaling_factor_1_clients_1000_mode_read_write_average_latency",
+		dimension: "system",
+		unit: "ms",
+		direction: "LIB",
+		headline: false,
+		label: "PostgreSQL - Scaling Factor: 1 - Clients: 1000 - Mode: Read Write - Average Latency",
+		description:
+			"This is a benchmark of PostgreSQL using the integrated pgbench for facilitating the database benchmarks.",
+		pts: {
+			test: "pts/pgbench",
+			description: "Scaling Factor: 1 - Clients: 1000 - Mode: Read Write - Average Latency",
+		},
+		sourceUrl: "https://www.postgresql.org/",
+	},
+	{
+		id: "pgbench_scaling_factor_1_clients_100_mode_read_only",
+		dimension: "system",
+		unit: "TPS",
+		direction: "HIB",
+		headline: false,
+		label: "PostgreSQL - Scaling Factor: 1 - Clients: 100 - Mode: Read Only",
+		description:
+			"This is a benchmark of PostgreSQL using the integrated pgbench for facilitating the database benchmarks.",
+		pts: { test: "pts/pgbench", description: "Scaling Factor: 1 - Clients: 100 - Mode: Read Only" },
+		sourceUrl: "https://www.postgresql.org/",
+	},
+	{
+		id: "pgbench_scaling_factor_1_clients_100_mode_read_only_average_latency",
+		dimension: "system",
+		unit: "ms",
+		direction: "LIB",
+		headline: false,
+		label: "PostgreSQL - Scaling Factor: 1 - Clients: 100 - Mode: Read Only - Average Latency",
+		description:
+			"This is a benchmark of PostgreSQL using the integrated pgbench for facilitating the database benchmarks.",
+		pts: {
+			test: "pts/pgbench",
+			description: "Scaling Factor: 1 - Clients: 100 - Mode: Read Only - Average Latency",
+		},
+		sourceUrl: "https://www.postgresql.org/",
+	},
+	{
+		id: "pgbench_scaling_factor_1_clients_100_mode_read_write",
+		dimension: "system",
+		unit: "TPS",
+		direction: "HIB",
+		headline: false,
+		label: "PostgreSQL - Scaling Factor: 1 - Clients: 100 - Mode: Read Write",
+		description:
+			"This is a benchmark of PostgreSQL using the integrated pgbench for facilitating the database benchmarks.",
+		pts: {
+			test: "pts/pgbench",
+			description: "Scaling Factor: 1 - Clients: 100 - Mode: Read Write",
+		},
+		sourceUrl: "https://www.postgresql.org/",
+	},
+	{
+		id: "pgbench_scaling_factor_1_clients_100_mode_read_write_average_latency",
+		dimension: "system",
+		unit: "ms",
+		direction: "LIB",
+		headline: false,
+		label: "PostgreSQL - Scaling Factor: 1 - Clients: 100 - Mode: Read Write - Average Latency",
+		description:
+			"This is a benchmark of PostgreSQL using the integrated pgbench for facilitating the database benchmarks.",
+		pts: {
+			test: "pts/pgbench",
+			description: "Scaling Factor: 1 - Clients: 100 - Mode: Read Write - Average Latency",
+		},
+		sourceUrl: "https://www.postgresql.org/",
+	},
+	{
+		id: "pgbench_scaling_factor_1_clients_1_mode_read_only",
+		dimension: "system",
+		unit: "TPS",
+		direction: "HIB",
+		headline: false,
+		label: "PostgreSQL - Scaling Factor: 1 - Clients: 1 - Mode: Read Only",
+		description:
+			"This is a benchmark of PostgreSQL using the integrated pgbench for facilitating the database benchmarks.",
+		pts: { test: "pts/pgbench", description: "Scaling Factor: 1 - Clients: 1 - Mode: Read Only" },
+		sourceUrl: "https://www.postgresql.org/",
+	},
+	{
+		id: "pgbench_scaling_factor_1_clients_1_mode_read_only_average_latency",
+		dimension: "system",
+		unit: "ms",
+		direction: "LIB",
+		headline: false,
+		label: "PostgreSQL - Scaling Factor: 1 - Clients: 1 - Mode: Read Only - Average Latency",
+		description:
+			"This is a benchmark of PostgreSQL using the integrated pgbench for facilitating the database benchmarks.",
+		pts: {
+			test: "pts/pgbench",
+			description: "Scaling Factor: 1 - Clients: 1 - Mode: Read Only - Average Latency",
+		},
+		sourceUrl: "https://www.postgresql.org/",
+	},
+	{
+		id: "pgbench_scaling_factor_1_clients_1_mode_read_write",
+		dimension: "system",
+		unit: "TPS",
+		direction: "HIB",
+		headline: false,
+		label: "PostgreSQL - Scaling Factor: 1 - Clients: 1 - Mode: Read Write",
+		description:
+			"This is a benchmark of PostgreSQL using the integrated pgbench for facilitating the database benchmarks.",
+		pts: { test: "pts/pgbench", description: "Scaling Factor: 1 - Clients: 1 - Mode: Read Write" },
+		sourceUrl: "https://www.postgresql.org/",
+	},
+	{
+		id: "pgbench_scaling_factor_1_clients_1_mode_read_write_average_latency",
+		dimension: "system",
+		unit: "ms",
+		direction: "LIB",
+		headline: false,
+		label: "PostgreSQL - Scaling Factor: 1 - Clients: 1 - Mode: Read Write - Average Latency",
+		description:
+			"This is a benchmark of PostgreSQL using the integrated pgbench for facilitating the database benchmarks.",
+		pts: {
+			test: "pts/pgbench",
+			description: "Scaling Factor: 1 - Clients: 1 - Mode: Read Write - Average Latency",
+		},
+		sourceUrl: "https://www.postgresql.org/",
+	},
+	{
+		id: "pgbench_scaling_factor_1_clients_250_mode_read_only",
+		dimension: "system",
+		unit: "TPS",
+		direction: "HIB",
+		headline: false,
+		label: "PostgreSQL - Scaling Factor: 1 - Clients: 250 - Mode: Read Only",
+		description:
+			"This is a benchmark of PostgreSQL using the integrated pgbench for facilitating the database benchmarks.",
+		pts: { test: "pts/pgbench", description: "Scaling Factor: 1 - Clients: 250 - Mode: Read Only" },
+		sourceUrl: "https://www.postgresql.org/",
+	},
+	{
+		id: "pgbench_scaling_factor_1_clients_250_mode_read_only_average_latency",
+		dimension: "system",
+		unit: "ms",
+		direction: "LIB",
+		headline: false,
+		label: "PostgreSQL - Scaling Factor: 1 - Clients: 250 - Mode: Read Only - Average Latency",
+		description:
+			"This is a benchmark of PostgreSQL using the integrated pgbench for facilitating the database benchmarks.",
+		pts: {
+			test: "pts/pgbench",
+			description: "Scaling Factor: 1 - Clients: 250 - Mode: Read Only - Average Latency",
+		},
+		sourceUrl: "https://www.postgresql.org/",
+	},
+	{
+		id: "pgbench_scaling_factor_1_clients_250_mode_read_write",
+		dimension: "system",
+		unit: "TPS",
+		direction: "HIB",
+		headline: false,
+		label: "PostgreSQL - Scaling Factor: 1 - Clients: 250 - Mode: Read Write",
+		description:
+			"This is a benchmark of PostgreSQL using the integrated pgbench for facilitating the database benchmarks.",
+		pts: {
+			test: "pts/pgbench",
+			description: "Scaling Factor: 1 - Clients: 250 - Mode: Read Write",
+		},
+		sourceUrl: "https://www.postgresql.org/",
+	},
+	{
+		id: "pgbench_scaling_factor_1_clients_250_mode_read_write_average_latency",
+		dimension: "system",
+		unit: "ms",
+		direction: "LIB",
+		headline: false,
+		label: "PostgreSQL - Scaling Factor: 1 - Clients: 250 - Mode: Read Write - Average Latency",
+		description:
+			"This is a benchmark of PostgreSQL using the integrated pgbench for facilitating the database benchmarks.",
+		pts: {
+			test: "pts/pgbench",
+			description: "Scaling Factor: 1 - Clients: 250 - Mode: Read Write - Average Latency",
+		},
+		sourceUrl: "https://www.postgresql.org/",
+	},
+	{
+		id: "pgbench_scaling_factor_1_clients_5000_mode_read_only",
+		dimension: "system",
+		unit: "TPS",
+		direction: "HIB",
+		headline: false,
+		label: "PostgreSQL - Scaling Factor: 1 - Clients: 5000 - Mode: Read Only",
+		description:
+			"This is a benchmark of PostgreSQL using the integrated pgbench for facilitating the database benchmarks.",
+		pts: {
+			test: "pts/pgbench",
+			description: "Scaling Factor: 1 - Clients: 5000 - Mode: Read Only",
+		},
+		sourceUrl: "https://www.postgresql.org/",
+	},
+	{
+		id: "pgbench_scaling_factor_1_clients_5000_mode_read_only_average_latency",
+		dimension: "system",
+		unit: "ms",
+		direction: "LIB",
+		headline: false,
+		label: "PostgreSQL - Scaling Factor: 1 - Clients: 5000 - Mode: Read Only - Average Latency",
+		description:
+			"This is a benchmark of PostgreSQL using the integrated pgbench for facilitating the database benchmarks.",
+		pts: {
+			test: "pts/pgbench",
+			description: "Scaling Factor: 1 - Clients: 5000 - Mode: Read Only - Average Latency",
+		},
+		sourceUrl: "https://www.postgresql.org/",
+	},
+	{
+		id: "pgbench_scaling_factor_1_clients_5000_mode_read_write",
+		dimension: "system",
+		unit: "TPS",
+		direction: "HIB",
+		headline: false,
+		label: "PostgreSQL - Scaling Factor: 1 - Clients: 5000 - Mode: Read Write",
+		description:
+			"This is a benchmark of PostgreSQL using the integrated pgbench for facilitating the database benchmarks.",
+		pts: {
+			test: "pts/pgbench",
+			description: "Scaling Factor: 1 - Clients: 5000 - Mode: Read Write",
+		},
+		sourceUrl: "https://www.postgresql.org/",
+	},
+	{
+		id: "pgbench_scaling_factor_1_clients_5000_mode_read_write_average_latency",
+		dimension: "system",
+		unit: "ms",
+		direction: "LIB",
+		headline: false,
+		label: "PostgreSQL - Scaling Factor: 1 - Clients: 5000 - Mode: Read Write - Average Latency",
+		description:
+			"This is a benchmark of PostgreSQL using the integrated pgbench for facilitating the database benchmarks.",
+		pts: {
+			test: "pts/pgbench",
+			description: "Scaling Factor: 1 - Clients: 5000 - Mode: Read Write - Average Latency",
+		},
+		sourceUrl: "https://www.postgresql.org/",
+	},
+	{
+		id: "pgbench_scaling_factor_1_clients_500_mode_read_only",
+		dimension: "system",
+		unit: "TPS",
+		direction: "HIB",
+		headline: false,
+		label: "PostgreSQL - Scaling Factor: 1 - Clients: 500 - Mode: Read Only",
+		description:
+			"This is a benchmark of PostgreSQL using the integrated pgbench for facilitating the database benchmarks.",
+		pts: { test: "pts/pgbench", description: "Scaling Factor: 1 - Clients: 500 - Mode: Read Only" },
+		sourceUrl: "https://www.postgresql.org/",
+	},
+	{
+		id: "pgbench_scaling_factor_1_clients_500_mode_read_only_average_latency",
+		dimension: "system",
+		unit: "ms",
+		direction: "LIB",
+		headline: false,
+		label: "PostgreSQL - Scaling Factor: 1 - Clients: 500 - Mode: Read Only - Average Latency",
+		description:
+			"This is a benchmark of PostgreSQL using the integrated pgbench for facilitating the database benchmarks.",
+		pts: {
+			test: "pts/pgbench",
+			description: "Scaling Factor: 1 - Clients: 500 - Mode: Read Only - Average Latency",
+		},
+		sourceUrl: "https://www.postgresql.org/",
+	},
+	{
+		id: "pgbench_scaling_factor_1_clients_500_mode_read_write",
+		dimension: "system",
+		unit: "TPS",
+		direction: "HIB",
+		headline: false,
+		label: "PostgreSQL - Scaling Factor: 1 - Clients: 500 - Mode: Read Write",
+		description:
+			"This is a benchmark of PostgreSQL using the integrated pgbench for facilitating the database benchmarks.",
+		pts: {
+			test: "pts/pgbench",
+			description: "Scaling Factor: 1 - Clients: 500 - Mode: Read Write",
+		},
+		sourceUrl: "https://www.postgresql.org/",
+	},
+	{
+		id: "pgbench_scaling_factor_1_clients_500_mode_read_write_average_latency",
+		dimension: "system",
+		unit: "ms",
+		direction: "LIB",
+		headline: false,
+		label: "PostgreSQL - Scaling Factor: 1 - Clients: 500 - Mode: Read Write - Average Latency",
+		description:
+			"This is a benchmark of PostgreSQL using the integrated pgbench for facilitating the database benchmarks.",
+		pts: {
+			test: "pts/pgbench",
+			description: "Scaling Factor: 1 - Clients: 500 - Mode: Read Write - Average Latency",
+		},
+		sourceUrl: "https://www.postgresql.org/",
+	},
+	{
+		id: "pgbench_scaling_factor_1_clients_50_mode_read_only",
+		dimension: "system",
+		unit: "TPS",
+		direction: "HIB",
+		headline: false,
+		label: "PostgreSQL - Scaling Factor: 1 - Clients: 50 - Mode: Read Only",
+		description:
+			"This is a benchmark of PostgreSQL using the integrated pgbench for facilitating the database benchmarks.",
+		pts: { test: "pts/pgbench", description: "Scaling Factor: 1 - Clients: 50 - Mode: Read Only" },
+		sourceUrl: "https://www.postgresql.org/",
+	},
+	{
+		id: "pgbench_scaling_factor_1_clients_50_mode_read_only_average_latency",
+		dimension: "system",
+		unit: "ms",
+		direction: "LIB",
+		headline: false,
+		label: "PostgreSQL - Scaling Factor: 1 - Clients: 50 - Mode: Read Only - Average Latency",
+		description:
+			"This is a benchmark of PostgreSQL using the integrated pgbench for facilitating the database benchmarks.",
+		pts: {
+			test: "pts/pgbench",
+			description: "Scaling Factor: 1 - Clients: 50 - Mode: Read Only - Average Latency",
+		},
+		sourceUrl: "https://www.postgresql.org/",
+	},
+	{
+		id: "pgbench_scaling_factor_1_clients_50_mode_read_write",
+		dimension: "system",
+		unit: "TPS",
+		direction: "HIB",
+		headline: false,
+		label: "PostgreSQL - Scaling Factor: 1 - Clients: 50 - Mode: Read Write",
+		description:
+			"This is a benchmark of PostgreSQL using the integrated pgbench for facilitating the database benchmarks.",
+		pts: { test: "pts/pgbench", description: "Scaling Factor: 1 - Clients: 50 - Mode: Read Write" },
+		sourceUrl: "https://www.postgresql.org/",
+	},
+	{
+		id: "pgbench_scaling_factor_1_clients_50_mode_read_write_average_latency",
+		dimension: "system",
+		unit: "ms",
+		direction: "LIB",
+		headline: false,
+		label: "PostgreSQL - Scaling Factor: 1 - Clients: 50 - Mode: Read Write - Average Latency",
+		description:
+			"This is a benchmark of PostgreSQL using the integrated pgbench for facilitating the database benchmarks.",
+		pts: {
+			test: "pts/pgbench",
+			description: "Scaling Factor: 1 - Clients: 50 - Mode: Read Write - Average Latency",
+		},
+		sourceUrl: "https://www.postgresql.org/",
+	},
+	{
+		id: "pgbench_scaling_factor_1_clients_800_mode_read_only",
+		dimension: "system",
+		unit: "TPS",
+		direction: "HIB",
+		headline: false,
+		label: "PostgreSQL - Scaling Factor: 1 - Clients: 800 - Mode: Read Only",
+		description:
+			"This is a benchmark of PostgreSQL using the integrated pgbench for facilitating the database benchmarks.",
+		pts: { test: "pts/pgbench", description: "Scaling Factor: 1 - Clients: 800 - Mode: Read Only" },
+		sourceUrl: "https://www.postgresql.org/",
+	},
+	{
+		id: "pgbench_scaling_factor_1_clients_800_mode_read_only_average_latency",
+		dimension: "system",
+		unit: "ms",
+		direction: "LIB",
+		headline: false,
+		label: "PostgreSQL - Scaling Factor: 1 - Clients: 800 - Mode: Read Only - Average Latency",
+		description:
+			"This is a benchmark of PostgreSQL using the integrated pgbench for facilitating the database benchmarks.",
+		pts: {
+			test: "pts/pgbench",
+			description: "Scaling Factor: 1 - Clients: 800 - Mode: Read Only - Average Latency",
+		},
+		sourceUrl: "https://www.postgresql.org/",
+	},
+	{
+		id: "pgbench_scaling_factor_1_clients_800_mode_read_write",
+		dimension: "system",
+		unit: "TPS",
+		direction: "HIB",
+		headline: false,
+		label: "PostgreSQL - Scaling Factor: 1 - Clients: 800 - Mode: Read Write",
+		description:
+			"This is a benchmark of PostgreSQL using the integrated pgbench for facilitating the database benchmarks.",
+		pts: {
+			test: "pts/pgbench",
+			description: "Scaling Factor: 1 - Clients: 800 - Mode: Read Write",
+		},
+		sourceUrl: "https://www.postgresql.org/",
+	},
+	{
+		id: "pgbench_scaling_factor_1_clients_800_mode_read_write_average_latency",
+		dimension: "system",
+		unit: "ms",
+		direction: "LIB",
+		headline: false,
+		label: "PostgreSQL - Scaling Factor: 1 - Clients: 800 - Mode: Read Write - Average Latency",
+		description:
+			"This is a benchmark of PostgreSQL using the integrated pgbench for facilitating the database benchmarks.",
+		pts: {
+			test: "pts/pgbench",
+			description: "Scaling Factor: 1 - Clients: 800 - Mode: Read Write - Average Latency",
+		},
+		sourceUrl: "https://www.postgresql.org/",
+	},
+	{
+		id: "pgbench_scaling_factor_25000_clients_1000_mode_read_only",
+		dimension: "system",
+		unit: "TPS",
+		direction: "HIB",
+		headline: false,
+		label: "PostgreSQL - Scaling Factor: 25000 - Clients: 1000 - Mode: Read Only",
+		description:
+			"This is a benchmark of PostgreSQL using the integrated pgbench for facilitating the database benchmarks.",
+		pts: {
+			test: "pts/pgbench",
+			description: "Scaling Factor: 25000 - Clients: 1000 - Mode: Read Only",
+		},
+		sourceUrl: "https://www.postgresql.org/",
+	},
+	{
+		id: "pgbench_scaling_factor_25000_clients_1000_mode_read_only_average_latency",
+		dimension: "system",
+		unit: "ms",
+		direction: "LIB",
+		headline: false,
+		label: "PostgreSQL - Scaling Factor: 25000 - Clients: 1000 - Mode: Read Only - Average Latency",
+		description:
+			"This is a benchmark of PostgreSQL using the integrated pgbench for facilitating the database benchmarks.",
+		pts: {
+			test: "pts/pgbench",
+			description: "Scaling Factor: 25000 - Clients: 1000 - Mode: Read Only - Average Latency",
+		},
+		sourceUrl: "https://www.postgresql.org/",
+	},
+	{
+		id: "pgbench_scaling_factor_25000_clients_1000_mode_read_write",
+		dimension: "system",
+		unit: "TPS",
+		direction: "HIB",
+		headline: false,
+		label: "PostgreSQL - Scaling Factor: 25000 - Clients: 1000 - Mode: Read Write",
+		description:
+			"This is a benchmark of PostgreSQL using the integrated pgbench for facilitating the database benchmarks.",
+		pts: {
+			test: "pts/pgbench",
+			description: "Scaling Factor: 25000 - Clients: 1000 - Mode: Read Write",
+		},
+		sourceUrl: "https://www.postgresql.org/",
+	},
+	{
+		id: "pgbench_scaling_factor_25000_clients_1000_mode_read_write_average_latency",
+		dimension: "system",
+		unit: "ms",
+		direction: "LIB",
+		headline: false,
+		label:
+			"PostgreSQL - Scaling Factor: 25000 - Clients: 1000 - Mode: Read Write - Average Latency",
+		description:
+			"This is a benchmark of PostgreSQL using the integrated pgbench for facilitating the database benchmarks.",
+		pts: {
+			test: "pts/pgbench",
+			description: "Scaling Factor: 25000 - Clients: 1000 - Mode: Read Write - Average Latency",
+		},
+		sourceUrl: "https://www.postgresql.org/",
+	},
+	{
+		id: "pgbench_scaling_factor_25000_clients_100_mode_read_only",
+		dimension: "system",
+		unit: "TPS",
+		direction: "HIB",
+		headline: false,
+		label: "PostgreSQL - Scaling Factor: 25000 - Clients: 100 - Mode: Read Only",
+		description:
+			"This is a benchmark of PostgreSQL using the integrated pgbench for facilitating the database benchmarks.",
+		pts: {
+			test: "pts/pgbench",
+			description: "Scaling Factor: 25000 - Clients: 100 - Mode: Read Only",
+		},
+		sourceUrl: "https://www.postgresql.org/",
+	},
+	{
+		id: "pgbench_scaling_factor_25000_clients_100_mode_read_only_average_latency",
+		dimension: "system",
+		unit: "ms",
+		direction: "LIB",
+		headline: false,
+		label: "PostgreSQL - Scaling Factor: 25000 - Clients: 100 - Mode: Read Only - Average Latency",
+		description:
+			"This is a benchmark of PostgreSQL using the integrated pgbench for facilitating the database benchmarks.",
+		pts: {
+			test: "pts/pgbench",
+			description: "Scaling Factor: 25000 - Clients: 100 - Mode: Read Only - Average Latency",
+		},
+		sourceUrl: "https://www.postgresql.org/",
+	},
+	{
+		id: "pgbench_scaling_factor_25000_clients_100_mode_read_write",
+		dimension: "system",
+		unit: "TPS",
+		direction: "HIB",
+		headline: false,
+		label: "PostgreSQL - Scaling Factor: 25000 - Clients: 100 - Mode: Read Write",
+		description:
+			"This is a benchmark of PostgreSQL using the integrated pgbench for facilitating the database benchmarks.",
+		pts: {
+			test: "pts/pgbench",
+			description: "Scaling Factor: 25000 - Clients: 100 - Mode: Read Write",
+		},
+		sourceUrl: "https://www.postgresql.org/",
+	},
+	{
+		id: "pgbench_scaling_factor_25000_clients_100_mode_read_write_average_latency",
+		dimension: "system",
+		unit: "ms",
+		direction: "LIB",
+		headline: false,
+		label: "PostgreSQL - Scaling Factor: 25000 - Clients: 100 - Mode: Read Write - Average Latency",
+		description:
+			"This is a benchmark of PostgreSQL using the integrated pgbench for facilitating the database benchmarks.",
+		pts: {
+			test: "pts/pgbench",
+			description: "Scaling Factor: 25000 - Clients: 100 - Mode: Read Write - Average Latency",
+		},
+		sourceUrl: "https://www.postgresql.org/",
+	},
+	{
+		id: "pgbench_scaling_factor_25000_clients_1_mode_read_only",
+		dimension: "system",
+		unit: "TPS",
+		direction: "HIB",
+		headline: false,
+		label: "PostgreSQL - Scaling Factor: 25000 - Clients: 1 - Mode: Read Only",
+		description:
+			"This is a benchmark of PostgreSQL using the integrated pgbench for facilitating the database benchmarks.",
+		pts: {
+			test: "pts/pgbench",
+			description: "Scaling Factor: 25000 - Clients: 1 - Mode: Read Only",
+		},
+		sourceUrl: "https://www.postgresql.org/",
+	},
+	{
+		id: "pgbench_scaling_factor_25000_clients_1_mode_read_only_average_latency",
+		dimension: "system",
+		unit: "ms",
+		direction: "LIB",
+		headline: false,
+		label: "PostgreSQL - Scaling Factor: 25000 - Clients: 1 - Mode: Read Only - Average Latency",
+		description:
+			"This is a benchmark of PostgreSQL using the integrated pgbench for facilitating the database benchmarks.",
+		pts: {
+			test: "pts/pgbench",
+			description: "Scaling Factor: 25000 - Clients: 1 - Mode: Read Only - Average Latency",
+		},
+		sourceUrl: "https://www.postgresql.org/",
+	},
+	{
+		id: "pgbench_scaling_factor_25000_clients_1_mode_read_write",
+		dimension: "system",
+		unit: "TPS",
+		direction: "HIB",
+		headline: false,
+		label: "PostgreSQL - Scaling Factor: 25000 - Clients: 1 - Mode: Read Write",
+		description:
+			"This is a benchmark of PostgreSQL using the integrated pgbench for facilitating the database benchmarks.",
+		pts: {
+			test: "pts/pgbench",
+			description: "Scaling Factor: 25000 - Clients: 1 - Mode: Read Write",
+		},
+		sourceUrl: "https://www.postgresql.org/",
+	},
+	{
+		id: "pgbench_scaling_factor_25000_clients_1_mode_read_write_average_latency",
+		dimension: "system",
+		unit: "ms",
+		direction: "LIB",
+		headline: false,
+		label: "PostgreSQL - Scaling Factor: 25000 - Clients: 1 - Mode: Read Write - Average Latency",
+		description:
+			"This is a benchmark of PostgreSQL using the integrated pgbench for facilitating the database benchmarks.",
+		pts: {
+			test: "pts/pgbench",
+			description: "Scaling Factor: 25000 - Clients: 1 - Mode: Read Write - Average Latency",
+		},
+		sourceUrl: "https://www.postgresql.org/",
+	},
+	{
+		id: "pgbench_scaling_factor_25000_clients_250_mode_read_only",
+		dimension: "system",
+		unit: "TPS",
+		direction: "HIB",
+		headline: false,
+		label: "PostgreSQL - Scaling Factor: 25000 - Clients: 250 - Mode: Read Only",
+		description:
+			"This is a benchmark of PostgreSQL using the integrated pgbench for facilitating the database benchmarks.",
+		pts: {
+			test: "pts/pgbench",
+			description: "Scaling Factor: 25000 - Clients: 250 - Mode: Read Only",
+		},
+		sourceUrl: "https://www.postgresql.org/",
+	},
+	{
+		id: "pgbench_scaling_factor_25000_clients_250_mode_read_only_average_latency",
+		dimension: "system",
+		unit: "ms",
+		direction: "LIB",
+		headline: false,
+		label: "PostgreSQL - Scaling Factor: 25000 - Clients: 250 - Mode: Read Only - Average Latency",
+		description:
+			"This is a benchmark of PostgreSQL using the integrated pgbench for facilitating the database benchmarks.",
+		pts: {
+			test: "pts/pgbench",
+			description: "Scaling Factor: 25000 - Clients: 250 - Mode: Read Only - Average Latency",
+		},
+		sourceUrl: "https://www.postgresql.org/",
+	},
+	{
+		id: "pgbench_scaling_factor_25000_clients_250_mode_read_write",
+		dimension: "system",
+		unit: "TPS",
+		direction: "HIB",
+		headline: false,
+		label: "PostgreSQL - Scaling Factor: 25000 - Clients: 250 - Mode: Read Write",
+		description:
+			"This is a benchmark of PostgreSQL using the integrated pgbench for facilitating the database benchmarks.",
+		pts: {
+			test: "pts/pgbench",
+			description: "Scaling Factor: 25000 - Clients: 250 - Mode: Read Write",
+		},
+		sourceUrl: "https://www.postgresql.org/",
+	},
+	{
+		id: "pgbench_scaling_factor_25000_clients_250_mode_read_write_average_latency",
+		dimension: "system",
+		unit: "ms",
+		direction: "LIB",
+		headline: false,
+		label: "PostgreSQL - Scaling Factor: 25000 - Clients: 250 - Mode: Read Write - Average Latency",
+		description:
+			"This is a benchmark of PostgreSQL using the integrated pgbench for facilitating the database benchmarks.",
+		pts: {
+			test: "pts/pgbench",
+			description: "Scaling Factor: 25000 - Clients: 250 - Mode: Read Write - Average Latency",
+		},
+		sourceUrl: "https://www.postgresql.org/",
+	},
+	{
+		id: "pgbench_scaling_factor_25000_clients_5000_mode_read_only",
+		dimension: "system",
+		unit: "TPS",
+		direction: "HIB",
+		headline: false,
+		label: "PostgreSQL - Scaling Factor: 25000 - Clients: 5000 - Mode: Read Only",
+		description:
+			"This is a benchmark of PostgreSQL using the integrated pgbench for facilitating the database benchmarks.",
+		pts: {
+			test: "pts/pgbench",
+			description: "Scaling Factor: 25000 - Clients: 5000 - Mode: Read Only",
+		},
+		sourceUrl: "https://www.postgresql.org/",
+	},
+	{
+		id: "pgbench_scaling_factor_25000_clients_5000_mode_read_only_average_latency",
+		dimension: "system",
+		unit: "ms",
+		direction: "LIB",
+		headline: false,
+		label: "PostgreSQL - Scaling Factor: 25000 - Clients: 5000 - Mode: Read Only - Average Latency",
+		description:
+			"This is a benchmark of PostgreSQL using the integrated pgbench for facilitating the database benchmarks.",
+		pts: {
+			test: "pts/pgbench",
+			description: "Scaling Factor: 25000 - Clients: 5000 - Mode: Read Only - Average Latency",
+		},
+		sourceUrl: "https://www.postgresql.org/",
+	},
+	{
+		id: "pgbench_scaling_factor_25000_clients_5000_mode_read_write",
+		dimension: "system",
+		unit: "TPS",
+		direction: "HIB",
+		headline: false,
+		label: "PostgreSQL - Scaling Factor: 25000 - Clients: 5000 - Mode: Read Write",
+		description:
+			"This is a benchmark of PostgreSQL using the integrated pgbench for facilitating the database benchmarks.",
+		pts: {
+			test: "pts/pgbench",
+			description: "Scaling Factor: 25000 - Clients: 5000 - Mode: Read Write",
+		},
+		sourceUrl: "https://www.postgresql.org/",
+	},
+	{
+		id: "pgbench_scaling_factor_25000_clients_5000_mode_read_write_average_latency",
+		dimension: "system",
+		unit: "ms",
+		direction: "LIB",
+		headline: false,
+		label:
+			"PostgreSQL - Scaling Factor: 25000 - Clients: 5000 - Mode: Read Write - Average Latency",
+		description:
+			"This is a benchmark of PostgreSQL using the integrated pgbench for facilitating the database benchmarks.",
+		pts: {
+			test: "pts/pgbench",
+			description: "Scaling Factor: 25000 - Clients: 5000 - Mode: Read Write - Average Latency",
+		},
+		sourceUrl: "https://www.postgresql.org/",
+	},
+	{
+		id: "pgbench_scaling_factor_25000_clients_500_mode_read_only",
+		dimension: "system",
+		unit: "TPS",
+		direction: "HIB",
+		headline: false,
+		label: "PostgreSQL - Scaling Factor: 25000 - Clients: 500 - Mode: Read Only",
+		description:
+			"This is a benchmark of PostgreSQL using the integrated pgbench for facilitating the database benchmarks.",
+		pts: {
+			test: "pts/pgbench",
+			description: "Scaling Factor: 25000 - Clients: 500 - Mode: Read Only",
+		},
+		sourceUrl: "https://www.postgresql.org/",
+	},
+	{
+		id: "pgbench_scaling_factor_25000_clients_500_mode_read_only_average_latency",
+		dimension: "system",
+		unit: "ms",
+		direction: "LIB",
+		headline: false,
+		label: "PostgreSQL - Scaling Factor: 25000 - Clients: 500 - Mode: Read Only - Average Latency",
+		description:
+			"This is a benchmark of PostgreSQL using the integrated pgbench for facilitating the database benchmarks.",
+		pts: {
+			test: "pts/pgbench",
+			description: "Scaling Factor: 25000 - Clients: 500 - Mode: Read Only - Average Latency",
+		},
+		sourceUrl: "https://www.postgresql.org/",
+	},
+	{
+		id: "pgbench_scaling_factor_25000_clients_500_mode_read_write",
+		dimension: "system",
+		unit: "TPS",
+		direction: "HIB",
+		headline: false,
+		label: "PostgreSQL - Scaling Factor: 25000 - Clients: 500 - Mode: Read Write",
+		description:
+			"This is a benchmark of PostgreSQL using the integrated pgbench for facilitating the database benchmarks.",
+		pts: {
+			test: "pts/pgbench",
+			description: "Scaling Factor: 25000 - Clients: 500 - Mode: Read Write",
+		},
+		sourceUrl: "https://www.postgresql.org/",
+	},
+	{
+		id: "pgbench_scaling_factor_25000_clients_500_mode_read_write_average_latency",
+		dimension: "system",
+		unit: "ms",
+		direction: "LIB",
+		headline: false,
+		label: "PostgreSQL - Scaling Factor: 25000 - Clients: 500 - Mode: Read Write - Average Latency",
+		description:
+			"This is a benchmark of PostgreSQL using the integrated pgbench for facilitating the database benchmarks.",
+		pts: {
+			test: "pts/pgbench",
+			description: "Scaling Factor: 25000 - Clients: 500 - Mode: Read Write - Average Latency",
+		},
+		sourceUrl: "https://www.postgresql.org/",
+	},
+	{
+		id: "pgbench_scaling_factor_25000_clients_50_mode_read_only",
+		dimension: "system",
+		unit: "TPS",
+		direction: "HIB",
+		headline: false,
+		label: "PostgreSQL - Scaling Factor: 25000 - Clients: 50 - Mode: Read Only",
+		description:
+			"This is a benchmark of PostgreSQL using the integrated pgbench for facilitating the database benchmarks.",
+		pts: {
+			test: "pts/pgbench",
+			description: "Scaling Factor: 25000 - Clients: 50 - Mode: Read Only",
+		},
+		sourceUrl: "https://www.postgresql.org/",
+	},
+	{
+		id: "pgbench_scaling_factor_25000_clients_50_mode_read_only_average_latency",
+		dimension: "system",
+		unit: "ms",
+		direction: "LIB",
+		headline: false,
+		label: "PostgreSQL - Scaling Factor: 25000 - Clients: 50 - Mode: Read Only - Average Latency",
+		description:
+			"This is a benchmark of PostgreSQL using the integrated pgbench for facilitating the database benchmarks.",
+		pts: {
+			test: "pts/pgbench",
+			description: "Scaling Factor: 25000 - Clients: 50 - Mode: Read Only - Average Latency",
+		},
+		sourceUrl: "https://www.postgresql.org/",
+	},
+	{
+		id: "pgbench_scaling_factor_25000_clients_50_mode_read_write",
+		dimension: "system",
+		unit: "TPS",
+		direction: "HIB",
+		headline: false,
+		label: "PostgreSQL - Scaling Factor: 25000 - Clients: 50 - Mode: Read Write",
+		description:
+			"This is a benchmark of PostgreSQL using the integrated pgbench for facilitating the database benchmarks.",
+		pts: {
+			test: "pts/pgbench",
+			description: "Scaling Factor: 25000 - Clients: 50 - Mode: Read Write",
+		},
+		sourceUrl: "https://www.postgresql.org/",
+	},
+	{
+		id: "pgbench_scaling_factor_25000_clients_50_mode_read_write_average_latency",
+		dimension: "system",
+		unit: "ms",
+		direction: "LIB",
+		headline: false,
+		label: "PostgreSQL - Scaling Factor: 25000 - Clients: 50 - Mode: Read Write - Average Latency",
+		description:
+			"This is a benchmark of PostgreSQL using the integrated pgbench for facilitating the database benchmarks.",
+		pts: {
+			test: "pts/pgbench",
+			description: "Scaling Factor: 25000 - Clients: 50 - Mode: Read Write - Average Latency",
+		},
+		sourceUrl: "https://www.postgresql.org/",
+	},
+	{
+		id: "pgbench_scaling_factor_25000_clients_800_mode_read_only",
+		dimension: "system",
+		unit: "TPS",
+		direction: "HIB",
+		headline: false,
+		label: "PostgreSQL - Scaling Factor: 25000 - Clients: 800 - Mode: Read Only",
+		description:
+			"This is a benchmark of PostgreSQL using the integrated pgbench for facilitating the database benchmarks.",
+		pts: {
+			test: "pts/pgbench",
+			description: "Scaling Factor: 25000 - Clients: 800 - Mode: Read Only",
+		},
+		sourceUrl: "https://www.postgresql.org/",
+	},
+	{
+		id: "pgbench_scaling_factor_25000_clients_800_mode_read_only_average_latency",
+		dimension: "system",
+		unit: "ms",
+		direction: "LIB",
+		headline: false,
+		label: "PostgreSQL - Scaling Factor: 25000 - Clients: 800 - Mode: Read Only - Average Latency",
+		description:
+			"This is a benchmark of PostgreSQL using the integrated pgbench for facilitating the database benchmarks.",
+		pts: {
+			test: "pts/pgbench",
+			description: "Scaling Factor: 25000 - Clients: 800 - Mode: Read Only - Average Latency",
+		},
+		sourceUrl: "https://www.postgresql.org/",
+	},
+	{
+		id: "pgbench_scaling_factor_25000_clients_800_mode_read_write",
+		dimension: "system",
+		unit: "TPS",
+		direction: "HIB",
+		headline: false,
+		label: "PostgreSQL - Scaling Factor: 25000 - Clients: 800 - Mode: Read Write",
+		description:
+			"This is a benchmark of PostgreSQL using the integrated pgbench for facilitating the database benchmarks.",
+		pts: {
+			test: "pts/pgbench",
+			description: "Scaling Factor: 25000 - Clients: 800 - Mode: Read Write",
+		},
+		sourceUrl: "https://www.postgresql.org/",
+	},
+	{
+		id: "pgbench_scaling_factor_25000_clients_800_mode_read_write_average_latency",
+		dimension: "system",
+		unit: "ms",
+		direction: "LIB",
+		headline: false,
+		label: "PostgreSQL - Scaling Factor: 25000 - Clients: 800 - Mode: Read Write - Average Latency",
+		description:
+			"This is a benchmark of PostgreSQL using the integrated pgbench for facilitating the database benchmarks.",
+		pts: {
+			test: "pts/pgbench",
+			description: "Scaling Factor: 25000 - Clients: 800 - Mode: Read Write - Average Latency",
+		},
+		sourceUrl: "https://www.postgresql.org/",
 	},
 	{
 		id: "pybench_milliseconds",
@@ -17699,4 +20277,4 @@ const chunk4: MetricDef[] = [
 	},
 ];
 
-export const ptsGenerated: MetricDef[] = [...chunk1, ...chunk2, ...chunk3, ...chunk4];
+export const ptsGenerated: MetricDef[] = [...chunk1, ...chunk2, ...chunk3, ...chunk4, ...chunk5];

--- a/packages/schema/src/pts-overrides.ts
+++ b/packages/schema/src/pts-overrides.ts
@@ -23,8 +23,6 @@ export const ptsOverrides: Record<string, MetricOverride> = {
 	// rounds it out. Both single-result wildcards, so curation only supplies labels + the one headline.
 	pybench_milliseconds: { headline: true, label: "PyBench" },
 	sqlite_speedtest_seconds: { label: "SQLite Speedtest" },
-	// Memory dimension: STREAM Triad is the canonical headline (the fused multiply-add is the most
-	// representative memory-bandwidth figure); the other three operations round out the matrix.
 	stream_type_triad: { headline: true, label: "STREAM Triad" },
 	stream_type_copy: { label: "STREAM Copy" },
 	stream_type_scale: { label: "STREAM Scale" },
@@ -77,6 +75,11 @@ export const ptsOverrides: Record<string, MetricOverride> = {
 		{ label: "fio rand write 4KB, buffered (IOPS)" },
 	fio_type_random_write_engine_linux_aio_direct_no_block_size_4kb_job_count_1_disk_target_default_test_directory_mb_per_s:
 		{ label: "fio rand write 4KB, buffered (MB/s)" },
+
+	// Network dimension: loopback TCP is its first (and headline) metric — a self-contained synthetic
+	// with no external endpoint, so it isolates the sandbox's network stack (virtio vs gVisor netstack
+	// vs host namespaces) from internet weather.
+	network_loopback_seconds: { headline: true, label: "Loopback TCP (10GB)" },
 
 	// Realworld dimension (ENG-135/137): mastra-ai/mastra run through its own CI tasks, a repo-local
 	// PTS profile with a Task option axis. TestType System's default dimension is corrected to

--- a/packages/schema/src/pts-profiles/compress-zstd-1.6.0/results-definition.xml
+++ b/packages/schema/src/pts-profiles/compress-zstd-1.6.0/results-definition.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0"?>
+<!--Phoronix Test Suite v10.8.4-->
+<PhoronixTestSuite>
+  <ResultsParser>
+    <OutputTemplate> 3#desktop-amd64.iso :2082816000 -&gt;2063395360 (1.009) #_RESULT_# MB/s 8080.3 MB/s </OutputTemplate>
+    <LineHint>MB/s</LineHint>
+    <ResultBeforeString>MB/s</ResultBeforeString>
+    <AppendToArgumentsDescription>Compression Speed</AppendToArgumentsDescription>
+    <TurnCharsToSpace>,</TurnCharsToSpace>
+  </ResultsParser>
+  <ResultsParser>
+    <OutputTemplate> 3#desktop-amd64.iso :2082816000 -&gt;2063395360 (1.009) 111 MB/s #_RESULT_# MB/s </OutputTemplate>
+    <LineHint>MB/s</LineHint>
+    <ResultAfterString>MB/s</ResultAfterString>
+    <AppendToArgumentsDescription>Decompression Speed</AppendToArgumentsDescription>
+    <TurnCharsToSpace>,</TurnCharsToSpace>
+  </ResultsParser>
+</PhoronixTestSuite>

--- a/packages/schema/src/pts-profiles/compress-zstd-1.6.0/test-definition.xml
+++ b/packages/schema/src/pts-profiles/compress-zstd-1.6.0/test-definition.xml
@@ -1,0 +1,64 @@
+<?xml version="1.0"?>
+<!--Phoronix Test Suite v10.8.4-->
+<PhoronixTestSuite>
+  <TestInformation>
+    <Title>Zstd Compression</Title>
+    <AppVersion>1.5.4</AppVersion>
+    <Description>This test measures the time needed to compress/decompress a sample file (silesia.tar) using Zstd (Zstandard) compression with options for different compression levels / settings.</Description>
+    <ResultScale>MB/s</ResultScale>
+    <Proportion>HIB</Proportion>
+    <TimesToRun>3</TimesToRun>
+  </TestInformation>
+  <TestProfile>
+    <Version>1.6.0</Version>
+    <SupportedPlatforms>Linux, BSD, MacOSX, Solaris, Windows</SupportedPlatforms>
+    <SoftwareType>Utility</SoftwareType>
+    <TestType>Processor</TestType>
+    <License>Free</License>
+    <Status>Verified</Status>
+    <ExternalDependencies>build-utilities</ExternalDependencies>
+    <EnvironmentSize>400</EnvironmentSize>
+    <ProjectURL>https://facebook.github.io/zstd/</ProjectURL>
+    <RepositoryURL>https://github.com/facebook/zstd</RepositoryURL>
+    <Maintainer>Michael Larabel</Maintainer>
+  </TestProfile>
+  <TestSettings>
+    <Default>
+      <Arguments>-S -i30</Arguments>
+    </Default>
+    <Option>
+      <DisplayName>Compression Level</DisplayName>
+      <Identifier>compression</Identifier>
+      <Menu>
+        <Entry>
+          <Name>3</Name>
+          <Value>-b3</Value>
+        </Entry>
+        <Entry>
+          <Name>3, Long Mode</Name>
+          <Value>-b3 --long</Value>
+        </Entry>
+        <Entry>
+          <Name>8</Name>
+          <Value>-b8</Value>
+        </Entry>
+        <Entry>
+          <Name>8, Long Mode</Name>
+          <Value>-b8 --long</Value>
+        </Entry>
+        <Entry>
+          <Name>12</Name>
+          <Value>-b12</Value>
+        </Entry>
+        <Entry>
+          <Name>19</Name>
+          <Value>-b19</Value>
+        </Entry>
+        <Entry>
+          <Name>19, Long Mode</Name>
+          <Value>-b19 --long</Value>
+        </Entry>
+      </Menu>
+    </Option>
+  </TestSettings>
+</PhoronixTestSuite>

--- a/packages/schema/src/pts-profiles/network-loopback-1.0.1/results-definition.xml
+++ b/packages/schema/src/pts-profiles/network-loopback-1.0.1/results-definition.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0"?>
+<!--Phoronix Test Suite v5.0.0m1 (Plavsk)-->
+<PhoronixTestSuite>
+  <SystemMonitor>
+    <Sensor>sys.time</Sensor>
+  </SystemMonitor>
+</PhoronixTestSuite>

--- a/packages/schema/src/pts-profiles/network-loopback-1.0.1/test-definition.xml
+++ b/packages/schema/src/pts-profiles/network-loopback-1.0.1/test-definition.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0"?>
+<!--Phoronix Test Suite v5.0.0m1 (Plavsk)-->
+<PhoronixTestSuite>
+  <TestInformation>
+    <Title>Loopback TCP Network Performance</Title>
+    <Description>This test measures the loopback network adapter performance using a micro-benchmark to measure the TCP performance.</Description>
+    <ResultScale>Seconds</ResultScale>
+    <Proportion>LIB</Proportion>
+    <SubTitle>Time To Transfer 10GB Via Loopback</SubTitle>
+    <TimesToRun>3</TimesToRun>
+  </TestInformation>
+  <TestProfile>
+    <Version>1.0.1</Version>
+    <SupportedPlatforms>Linux</SupportedPlatforms>
+    <SoftwareType>Utility</SoftwareType>
+    <TestType>Network</TestType>
+    <License>Free</License>
+    <Status>Verified</Status>
+    <EnvironmentSize>1</EnvironmentSize>
+    <ProjectURL>http://developer.amazonwebservices.com/connect/thread.jspa?threadID=45513</ProjectURL>
+    <Maintainer>Michael Larabel</Maintainer>
+  </TestProfile>
+</PhoronixTestSuite>

--- a/packages/schema/src/pts-profiles/pgbench-1.15.0/results-definition.xml
+++ b/packages/schema/src/pts-profiles/pgbench-1.15.0/results-definition.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0"?>
+<!--Phoronix Test Suite v10.8.5-->
+<PhoronixTestSuite>
+  <ResultsParser>
+    <OutputTemplate>tps = #_RESULT_# (excluding connections establishing) TPS</OutputTemplate>
+    <LineHint>tps = </LineHint>
+    <ResultScale>TPS</ResultScale>
+    <ResultProportion>HIB</ResultProportion>
+    <ResultPrecision>0</ResultPrecision>
+  </ResultsParser>
+  <ResultsParser>
+    <OutputTemplate>latency average = #_RESULT_# ms</OutputTemplate>
+    <LineHint>latency average</LineHint>
+    <ResultScale>ms</ResultScale>
+    <ResultProportion>LIB</ResultProportion>
+    <AppendToArgumentsDescription>Average Latency</AppendToArgumentsDescription>
+  </ResultsParser>
+</PhoronixTestSuite>

--- a/packages/schema/src/pts-profiles/pgbench-1.15.0/test-definition.xml
+++ b/packages/schema/src/pts-profiles/pgbench-1.15.0/test-definition.xml
@@ -1,0 +1,110 @@
+<?xml version="1.0"?>
+<!--Phoronix Test Suite v10.8.5-->
+<PhoronixTestSuite>
+  <TestInformation>
+    <Title>PostgreSQL</Title>
+    <AppVersion>17</AppVersion>
+    <Description>This is a benchmark of PostgreSQL using the integrated pgbench for facilitating the database benchmarks.</Description>
+    <ResultScale>TPS</ResultScale>
+    <Proportion>HIB</Proportion>
+    <TimesToRun>3</TimesToRun>
+  </TestInformation>
+  <TestProfile>
+    <Version>1.15.0</Version>
+    <SupportedPlatforms>Linux, MacOSX, BSD, Solaris</SupportedPlatforms>
+    <SoftwareType>Benchmark</SoftwareType>
+    <TestType>System</TestType>
+    <License>Free</License>
+    <Status>Verified</Status>
+    <ExternalDependencies>build-utilities, bc</ExternalDependencies>
+    <EnvironmentSize>1500</EnvironmentSize>
+    <ProjectURL>https://www.postgresql.org/</ProjectURL>
+    <RepositoryURL>https://github.com/postgres/postgres</RepositoryURL>
+    <InternalTags>SMP</InternalTags>
+    <Maintainer>Michael Larabel</Maintainer>
+    <SystemDependencies>bc, libicuuc.so, unicode/utf.h</SystemDependencies>
+  </TestProfile>
+  <TestSettings>
+    <Option>
+      <DisplayName>Scaling Factor</DisplayName>
+      <Identifier>scaling-factor</Identifier>
+      <ArgumentPrefix>-s </ArgumentPrefix>
+      <Menu>
+        <Entry>
+          <Name>1</Name>
+          <Value>1</Value>
+        </Entry>
+        <Entry>
+          <Name>100</Name>
+          <Value>100</Value>
+        </Entry>
+        <Entry>
+          <Name>1000</Name>
+          <Value>1000</Value>
+        </Entry>
+        <Entry>
+          <Name>10000</Name>
+          <Value>10000</Value>
+        </Entry>
+        <Entry>
+          <Name>25000</Name>
+          <Value>25000</Value>
+          <Message>Intended for very large servers.</Message>
+        </Entry>
+      </Menu>
+    </Option>
+    <Option>
+      <DisplayName>Clients</DisplayName>
+      <Identifier>clients</Identifier>
+      <ArgumentPrefix>-c </ArgumentPrefix>
+      <Menu>
+        <Entry>
+          <Name>1</Name>
+          <Value>1</Value>
+        </Entry>
+        <Entry>
+          <Name>50</Name>
+          <Value>50</Value>
+        </Entry>
+        <Entry>
+          <Name>100</Name>
+          <Value>100</Value>
+        </Entry>
+        <Entry>
+          <Name>250</Name>
+          <Value>250</Value>
+        </Entry>
+        <Entry>
+          <Name>500</Name>
+          <Value>500</Value>
+        </Entry>
+        <Entry>
+          <Name>800</Name>
+          <Value>800</Value>
+        </Entry>
+        <Entry>
+          <Name>1000</Name>
+          <Value>1000</Value>
+        </Entry>
+        <Entry>
+          <Name>5000</Name>
+          <Value>5000</Value>
+        </Entry>
+      </Menu>
+    </Option>
+    <Option>
+      <DisplayName>Mode</DisplayName>
+      <Identifier>run-mode</Identifier>
+      <Menu>
+        <Entry>
+          <Name>Read Write</Name>
+          <Value> </Value>
+        </Entry>
+        <Entry>
+          <Name>Read Only</Name>
+          <Value>-S </Value>
+        </Entry>
+      </Menu>
+    </Option>
+  </TestSettings>
+</PhoronixTestSuite>


### PR DESCRIPTION
**PTS BENCHMARK MATRIX — vendor the PTS catalog, then light up four benchmark suites.**
Shipped as a 12-PR stack. The trunk merges bottom-up; the four suite PRs at the top are SIBLINGS and
can be reviewed (and merged) in parallel — none blocks the others.

```
main
 └─ #136  schema: scale-aware PTS metric identity (pts.scale) + O(1) matcher
     └─ #137  catalog generator: per-parser scales + virtual axes
         └─ #138  ⚙ VENDOR fio + regenerate catalog        (autogenerated)
             └─ #146  fio curation + disk headline + goldens
                 └─ #139  ⚙ VENDOR loopback/zstd/pgbench + regenerate   (autogenerated)
                     └─ #147  their curation + recorded fixtures
                         └─ #148  shared PTS runner (lib/bench.sh)
                             └─ #144  toolchain image: bake PTS deps + pin drift gates
                                 ├─ #140  disk suite     ┐
                                 ├─ #141  network suite  │  siblings — parallel review
                                 ├─ #142  cpu-generic    │
                                 └─ #143  system suite   ┘
```
⚙ = the diff is machine-produced; reproduce it with the commands in the body. Everything hand-written
was lifted out into the small PR directly above it.

↑ **This PR is #139 (5/12) — AUTOGENERATED, based on #146.**

---

**Stack 4/9** — based on #138

Vendors the remaining three upstream profiles from the pinned REF (catalog 994 → 1169) and curates their producible combinations:

- **network-loopback-1.0.1** — the network dimension's first (and headline) metric. Loopback TCP is self-contained (no external endpoint), isolating the sandbox's network stack (virtio vs gVisor netstack vs host namespaces) from internet weather. With it every Dimension is populated + headlined, so `catalog.test.ts`'s "no headline throws" case is replaced by the real network headline test.
- **compress-zstd-1.6.0** — the classic CPU-throughput synthetic across its Compression Level matrix; labels only, node-web-tooling keeps the cpu headline.
- **pgbench-1.15.0** — PostgreSQL via its integrated pgbench, fully in-sandbox (the profile builds postgres and runs server + client locally — same topology on every provider). TPS + Average Latency curated for the pinned (scale 100, 50 clients) point per mode. Note: 1.15.0 is the newest pgbench profile published upstream at REF (1.17.0 does not exist).

Four more REAL recorded composites extend the golden byte-match gate (zstd's 13-result matrix, loopback, pgbench RO+RW).

**LOC**: ~84 hand-written (excluding vendored XML, fixtures, regenerated catalog). Gate green (542 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BHkDUJmxVAz1sCWFcS9btJ

---
_Generated by [Claude Code](https://claude.ai/code/session_01BHkDUJmxVAz1sCWFcS9btJ)_

## Validation

Every branch in this stack was checked out **in isolation** (i.e. on top of its own parent, with
nothing from the PRs above it) and run through the full gate set. A reviewer merges bottom-up, so
each PR has to stand on its own — this is what verifies that.

**This PR (`04`), verified standalone — all seven gates green:**

| gate | command | result |
|---|---|---|
| install | `bun install --frozen-lockfile` | ✅ |
| typecheck | `bun run typecheck` | ✅ |
| lint | `bun run lint` (biome, `--error-on-warnings`) | ✅ |
| spell | `mise exec -- typos` | ✅ |
| shell | `bun run lint:shell` (shellcheck) | ✅ |
| catalog drift | `bun run check:catalog-drift` | ✅ |
| tests | `bun run test` (whole workspace) | ✅ **563 passing, 0 failing** |

The same matrix is green on all 12 branches, and the passing-test count climbs monotonically up the
trunk (535 → 576) — each PR adds coverage and none regresses it.

**What this PR's own tests prove:**

- **`check:catalog-drift` IS this PR's proof** — CI regenerates and byte-compares (994 → 1169 metrics).
- The one hand-written exception (the network headline + the test it forces) is covered by the catalog invariants: "every populated dimension has exactly one headline" is exactly the test that would have gone red had it been deferred upward.

### What this does NOT prove

Being explicit, because the gates above are all static:

- **No benchmark has been run on a real provider sandbox.** Nothing in CI executes the `.mise` producer
  tasks against a live Phoronix Test Suite. Their correctness rests on `shellcheck`, on the golden
  byte-match gate (which compares against RECORDED composites — real PTS output, but replayed, not
  produced), and on the suite-contract tests. The first live signal is the `bench-smoke` workflow
  (manual dispatch) after these merge.
- **The image is only built by CI on #144** — it is the only PR that touches it. The suite PRs assume
  that image; they do not rebuild it.
- `Bake, validate & promote toolchain` is skipped on pull requests by design
  (`if: github.event_name != 'pull_request'`), so image PROMOTION is exercised only on `main`.
- The recorded fixtures prove byte-match against PTS output captured at a point in time; a future PTS
  release could change a `<Description>` string. That is precisely what the golden gate would catch.

Additionally, the four suite PRs at the top are siblings on #144; merging all four reproduces the
pre-restructure tree byte-for-byte (verified), so the 12-PR split moved every change and dropped none.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Vendors `pts/network-loopback`, `pts/compress-zstd`, and `pts/pgbench`, then regenerates the catalog (994 → 1169). Sets the `network` headline.

- **New Features**
  - Network: `pts/network-loopback` single-result metric (Seconds, LIB).
  - CPU: `pts/compress-zstd` 1.6.0 across Compression Level; two metrics per level (Compression/Decompression Speed, MB/s, HIB).
  - System: `pts/pgbench` 1.15.0 with TPS (HIB) and Average Latency (LIB).

- **Bug Fixes**
  - Tests now require exactly one headline per dimension; `network` is headlined to satisfy it.

<sup>Written for commit 66b7b7b5ae3c6af5d03396cfeb36e1586ddcf7bb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/starslingdev/sandbox-benchmarks/pull/139?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

