### PR TITLE
feat(bench,schema): fio producer tasks + preset-pinned PTS runner; expand the disk suite

### DIFF
--- a/.mise/tasks/benchmark/disk/all
+++ b/.mise/tasks/benchmark/disk/all
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-#MISE description="Run disk benchmarks (PTS hardlink throughput)"
+#MISE description="Run disk benchmarks (PTS fio scenarios + hardlink throughput)"
 # Orchestrator: no -e — run_task isolates child failures and summary reports them at the end
 # (error-mode conventions: lib/bench.sh).
 set -uo pipefail
@@ -12,6 +12,13 @@ echo "========================================"
 
 ensure_pts || true
 
+# The four Bench-Global-shaped fio scenarios (sequential 1MB + random 4KB, read + write) first, then
+# the hardlink metadata storm — streaming bandwidth/IOPS and create/link throughput are different
+# failure modes and a slow one must not shadow the other.
+run_task benchmark:disk:pts:fio-seq-read
+run_task benchmark:disk:pts:fio-seq-write
+run_task benchmark:disk:pts:fio-rand-read
+run_task benchmark:disk:pts:fio-rand-write
 run_task benchmark:disk:pts:hardlink
 
 summary

--- a/.mise/tasks/benchmark/disk/pts/fio-rand-read
+++ b/.mise/tasks/benchmark/disk/pts/fio-rand-read
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+#MISE description="PTS: fio random read, 4KB blocks (Linux AIO, 1 job, O_DIRECT probed)"
+# Measurement leaf: -e guards the scaffolding; the measured run is isolated by run_pts_benchmark
+# (via run_fio_pts → run_pinned_pts, which owns the PTS availability guard and pins this scenario's
+# option combination through PRESET_OPTIONS).
+set -euo pipefail
+REPO_ROOT="$(git -C "$(dirname "${BASH_SOURCE[0]}")" rev-parse --show-toplevel)"
+source "${REPO_ROOT}/lib/bench.sh"
+
+run_fio_pts "Random Read" "4KB" "pts_fio-rand-read"

--- a/.mise/tasks/benchmark/disk/pts/fio-rand-write
+++ b/.mise/tasks/benchmark/disk/pts/fio-rand-write
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+#MISE description="PTS: fio random write, 4KB blocks (Linux AIO, 1 job, O_DIRECT probed)"
+# Measurement leaf: -e guards the scaffolding; the measured run is isolated by run_pts_benchmark
+# (via run_fio_pts → run_pinned_pts, which owns the PTS availability guard and pins this scenario's
+# option combination through PRESET_OPTIONS).
+set -euo pipefail
+REPO_ROOT="$(git -C "$(dirname "${BASH_SOURCE[0]}")" rev-parse --show-toplevel)"
+source "${REPO_ROOT}/lib/bench.sh"
+
+run_fio_pts "Random Write" "4KB" "pts_fio-rand-write"

--- a/.mise/tasks/benchmark/disk/pts/fio-seq-read
+++ b/.mise/tasks/benchmark/disk/pts/fio-seq-read
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+#MISE description="PTS: fio sequential read, 1MB blocks (Linux AIO, 1 job, O_DIRECT probed)"
+# Measurement leaf: -e guards the scaffolding; the measured run is isolated by run_pts_benchmark
+# (via run_fio_pts → run_pinned_pts, which owns the PTS availability guard and pins this scenario's
+# option combination through PRESET_OPTIONS).
+set -euo pipefail
+REPO_ROOT="$(git -C "$(dirname "${BASH_SOURCE[0]}")" rev-parse --show-toplevel)"
+source "${REPO_ROOT}/lib/bench.sh"
+
+run_fio_pts "Sequential Read" "1MB" "pts_fio-seq-read"

--- a/.mise/tasks/benchmark/disk/pts/fio-seq-write
+++ b/.mise/tasks/benchmark/disk/pts/fio-seq-write
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+#MISE description="PTS: fio sequential write, 1MB blocks (Linux AIO, 1 job, O_DIRECT probed)"
+# Measurement leaf: -e guards the scaffolding; the measured run is isolated by run_pts_benchmark
+# (via run_fio_pts → run_pinned_pts, which owns the PTS availability guard and pins this scenario's
+# option combination through PRESET_OPTIONS).
+set -euo pipefail
+REPO_ROOT="$(git -C "$(dirname "${BASH_SOURCE[0]}")" rev-parse --show-toplevel)"
+source "${REPO_ROOT}/lib/bench.sh"
+
+run_fio_pts "Sequential Write" "1MB" "pts_fio-seq-write"

--- a/lib/bench.sh
+++ b/lib/bench.sh
@@ -416,6 +416,53 @@ run_pts_benchmark() {
 	return 0
 }
 
+# Whether the filesystem PTS's fio writes its test files to supports O_DIRECT: echoes the fio
+# profile's Direct option NAME ("Yes"/"No"). Probed with dd against the PTS data dir (the same
+# filesystem installed-tests/.../fiofile lands on) because sandbox filesystems differ here — overlay
+# and gVisor gofer mounts can reject O_DIRECT outright, and a hard fio failure would void the whole
+# scenario. The chosen mode is part of the fio option matrix, so it travels in the metric identity
+# (each scenario has an O_DIRECT and a buffered catalog variant) instead of being silently mixed.
+fio_direct_choice() {
+	local dir probe cache choice
+	# Without PTS the answer is irrelevant (the leaf's availability guard skips before running fio) —
+	# return without probing OR caching, so a dep-less dry run can't persist a verdict probed against
+	# the wrong filesystem for a later, properly-provisioned run to reuse.
+	if ! command -v phoronix-test-suite >/dev/null 2>&1; then
+		echo "No"
+		return 0
+	fi
+	# Each mise leaf is a fresh process, so cache the answer for the suite run — the filesystem's
+	# O_DIRECT support cannot change between the four scenarios, and each probe otherwise pays a
+	# pts_init (a multi-second PTS PHP invocation) per leaf. Cached under /tmp (per-sandbox,
+	# ephemeral), NOT results_dir: the harness tars results_dir back verbatim into the curated raw
+	# tree, and a bash-internal dotfile must not ship as a dataset artifact.
+	cache="${TMPDIR:-/tmp}/.bench-fio-direct-choice"
+	if [ -f "$cache" ]; then
+		cat "$cache"
+		return 0
+	fi
+	# pts_init BEFORE pts_user_dir (the install_local_pts_profile precedent): this probe is the fio
+	# leaf's first PTS-dir touch, and on a stock image with no core.pt2so yet the detector would
+	# cache the $HOME fallback for the whole shell — batch-run then writes results under
+	# /var/lib/phoronix-test-suite while run_pts_benchmark's composite finder searches the stale
+	# cached dir and records a bogus "produced no composite.xml" skip for every scenario.
+	pts_init
+	dir="$(pts_user_dir)"
+	mkdir -p "$dir"
+	probe="${dir}/.o-direct-probe"
+	# bs=4096, not 512: O_DIRECT requires logical-sector alignment, so a 512-byte write EINVALs on a
+	# 4Kn-sector filesystem even where the real scenarios' 4KB/1MB blocks would run fine. 4096 is
+	# aligned on both 512e and 4Kn and matches the smallest fio scenario block size.
+	if dd if=/dev/zero of="$probe" bs=4096 count=1 oflag=direct >/dev/null 2>&1; then
+		choice="Yes"
+	else
+		choice="No"
+	fi
+	rm -f "$probe"
+	echo "$choice" >"$cache"
+	echo "$choice"
+}
+
 # Run ONE PTS test with a fully-pinned option combination. PRESET_OPTIONS pins every axis so
 # batch-run executes exactly one combination instead of the profile's whole matrix. Owns the
 # phoronix-test-suite availability guard (like run_realworld_pts), so pinned leaves don't replicate it.
@@ -453,6 +500,28 @@ run_pinned_pts() {
 
 	run_pts_benchmark "$test_name" "$prefix"
 	unset PRESET_OPTIONS PTS_RUN_ALL_TEST_COMBINATIONS
+}
+
+# Run ONE pinned pts/fio scenario; Direct comes from fio_direct_choice above.
+#
+# Axis notes on top of run_pinned_pts's rules: "Job Count" is a numeric menu expanded from the
+# machine's core count at run time (cpu-threads: 1,2,…,N), so it must be pinned by INDEX 0 — the
+# first entry, name "1" on every machine ("cpu-threads=1" would select index 1 = "Job Count: 2").
+# "Disk Target" is also runtime-expanded (auto-disk-mount-points) but pins cleanly by name:
+# "Default Test Directory" always exists. These are the same pins the catalog generator synthesizes
+# descriptions for. Version-pinned (unlike the older versionless leaves): the catalog vendors
+# fio-2.1.0's exact option matrix and PRESET_OPTIONS addresses its axes by identifier, so a
+# versionless install resolving to a newer upstream fio would silently unmap every description. Keep
+# in lockstep with packages/schema/src/pts-profiles/fio-2.1.0 (and the golden fixture) when bumping.
+# Usage: run_fio_pts <type-name> <block-size-name> <results-prefix>   (e.g. "Sequential Read" 1MB pts_fio-seq-read)
+run_fio_pts() {
+	local type_name="$1" bs_name="$2" prefix="$3"
+	local direct
+	direct="$(fio_direct_choice)"
+	echo "fio scenario: Type=${type_name} Block Size=${bs_name} Direct=${direct} (O_DIRECT probe)"
+
+	run_pinned_pts "pts/fio-2.1.0" "$prefix" \
+		"fio.type=${type_name};fio.engine=Linux AIO;fio.direct=${direct};fio.size=${bs_name};fio.cpu-threads=0;fio.auto-disk-mount-points=Default Test Directory"
 }
 
 # Run one realworld suite end to end: gate on the toolchain, install the repo-local profile with

--- a/packages/results/src/lib/pts-golden.test.ts
+++ b/packages/results/src/lib/pts-golden.test.ts
@@ -8,7 +8,7 @@
 import { describe, expect, it } from "bun:test";
 import { readdirSync, readFileSync } from "node:fs";
 import { join } from "node:path";
-import { isPtsResultFile, ptsOverrides } from "@sandbox-benchmarks/schema";
+import { isPtsResultFile, ptsOverrides, SUITES } from "@sandbox-benchmarks/schema";
 import { parsePtsComposite, ptsResultToMetric } from "./pts.ts";
 
 const FIXTURES_DIR = join(import.meta.dir, "__fixtures__");
@@ -112,4 +112,28 @@ describe("golden composite byte-match (design §3.7)", () => {
 			}
 		});
 	}
+});
+
+describe("recorded fio fixtures pin the DECLARED disk-suite subset", () => {
+	// With fio's full 960-combination matrix catalogued, "resolves to a catalogued Metric" cannot
+	// falsify the combination SELECTION: a fixture re-recorded under drifted presets (a different
+	// engine or block size) — or a preset drift in run_fio_pts's PRESET_OPTIONS — would still resolve
+	// against some catalogued draft entry and stay green while the 16 declared metrics (disk headline
+	// included) silently never receive samples. The fixtures were recorded through the real producer
+	// path, so requiring every resolved fio id to be a DECLARED SUITES.disk metric transitively pins
+	// the bash presets, the curated ids, and the scale routing in one place.
+	it("every fio fixture <Result> resolves to a metric the disk suite declares", () => {
+		const declared = new Set<string>(SUITES.disk.metrics.filter((id) => id.startsWith("fio_")));
+		expect(declared.size).toBeGreaterThan(0);
+		const fioComposites = composites.filter(([name]) => name.includes("fio"));
+		expect(fioComposites.length).toBeGreaterThan(0);
+		const offenders = fioComposites.flatMap(([name, xml]) =>
+			parsePtsComposite(xml).PhoronixTestSuite.Result.flatMap((result) => {
+				const mapping = ptsResultToMetric(result);
+				if (mapping.kind !== "matched") return [`${name}: uncatalogued "${result.Description}"`];
+				return declared.has(mapping.def.id) ? [] : [`${name}: undeclared ${mapping.def.id}`];
+			}),
+		);
+		expect(offenders).toEqual([]);
+	});
 });

--- a/packages/schema/src/suites.test.ts
+++ b/packages/schema/src/suites.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it } from "bun:test";
 import { METRIC_CATALOG, paddedSuiteToken, padSuiteList, SUITE_NAMES, SUITES } from "./index.ts";
+// Not part of the public surface (curation is an implementation detail of the catalog merge); this
+// PR's pinned-subset test reaches in directly to compare its suite's declarations against curated keys.
+import { ptsOverrides } from "./pts-overrides.ts";
 
 describe("suite registry", () => {
 	it("registers cpu-node as a PTS- and Node-backed suite", () => {
@@ -67,6 +70,23 @@ describe("suite registry", () => {
 			expect(fromCatalog.length).toBeGreaterThan(0);
 			const declared: string[] = [...SUITES[suiteName as keyof typeof SUITES].metrics];
 			expect(declared.sort()).toEqual(fromCatalog);
+		}
+	});
+
+	it("pins the fio PINNED-subset suite to its curated override keys", () => {
+		// disk (fio) deliberately declares a SUBSET of its profile's catalogued
+		// combinations — the ones the producer tasks pin via PRESET_OPTIONS — so a catalog mirror
+		// can't gate them. Every declared subset id is also a curated pts-overrides key (only the
+		// producible combinations get short labels), so equality against the override keys catches a
+		// wrong-axis id here: with the full matrix catalogued, a typo'd engine or block size would
+		// otherwise pass the suite contract and just never receive samples.
+		const overrideKeys = Object.keys(ptsOverrides);
+		const subsets = [{ suite: "disk", prefix: "fio_" }] as const;
+		for (const { suite, prefix } of subsets) {
+			const declared: string[] = SUITES[suite].metrics.filter((id) => id.startsWith(prefix)).sort();
+			const curated = overrideKeys.filter((id) => id.startsWith(prefix)).sort();
+			expect(declared.length).toBeGreaterThan(0);
+			expect(declared).toEqual(curated);
 		}
 	});
 

--- a/packages/schema/src/suites.ts
+++ b/packages/schema/src/suites.ts
@@ -85,15 +85,39 @@ export const SUITES = {
 		metrics: ["stream_type_copy", "stream_type_scale", "stream_type_add", "stream_type_triad"],
 		commands: ["mise run benchmark:memory:all"],
 	},
-	// The disk dimension: hardlink throughput (stress-ng --link), a repo-local PTS profile installed
-	// into PTS by the producer task. Needs a little free disk for the link storm.
+	// The disk dimension: pts/fio across four pinned scenarios (seq read/write 1MB, rand read/write
+	// 4KB; Engine Linux AIO, Job Count 1, Default Test Directory) plus hardlink throughput (stress-ng
+	// --link, a repo-local PTS profile). Each fio scenario posts a bandwidth AND an IOPS result —
+	// scale-pinned twin metrics. Direct is probed per sandbox (O_DIRECT fails on some sandbox
+	// filesystems), so every scenario declares an O_DIRECT and a buffered variant; each provider emits
+	// exactly one of the two and the mode travels in the metric identity (the contract allows declared-
+	// but-unrun combinations). Budgets cover the fio build + 4 timed 60s scenarios; fio writes 1 GiB
+	// test files, hence the raised disk floor.
 	disk: {
 		setupPts: true,
-		commandTimeoutMinutes: 30,
-		timeoutMinutes: 40,
-		minDiskGb: 2,
+		commandTimeoutMinutes: 60,
+		timeoutMinutes: 70,
+		minDiskGb: 4,
 		dimensions: ["disk"],
-		metrics: ["hardlink_bogo_ops_per_s"],
+		metrics: [
+			"hardlink_bogo_ops_per_s",
+			"fio_type_sequential_read_engine_linux_aio_direct_yes_block_size_1mb_job_count_1_disk_target_default_test_directory_mb_per_s",
+			"fio_type_sequential_read_engine_linux_aio_direct_yes_block_size_1mb_job_count_1_disk_target_default_test_directory_iops",
+			"fio_type_sequential_write_engine_linux_aio_direct_yes_block_size_1mb_job_count_1_disk_target_default_test_directory_mb_per_s",
+			"fio_type_sequential_write_engine_linux_aio_direct_yes_block_size_1mb_job_count_1_disk_target_default_test_directory_iops",
+			"fio_type_random_read_engine_linux_aio_direct_yes_block_size_4kb_job_count_1_disk_target_default_test_directory_mb_per_s",
+			"fio_type_random_read_engine_linux_aio_direct_yes_block_size_4kb_job_count_1_disk_target_default_test_directory_iops",
+			"fio_type_random_write_engine_linux_aio_direct_yes_block_size_4kb_job_count_1_disk_target_default_test_directory_mb_per_s",
+			"fio_type_random_write_engine_linux_aio_direct_yes_block_size_4kb_job_count_1_disk_target_default_test_directory_iops",
+			"fio_type_sequential_read_engine_linux_aio_direct_no_block_size_1mb_job_count_1_disk_target_default_test_directory_mb_per_s",
+			"fio_type_sequential_read_engine_linux_aio_direct_no_block_size_1mb_job_count_1_disk_target_default_test_directory_iops",
+			"fio_type_sequential_write_engine_linux_aio_direct_no_block_size_1mb_job_count_1_disk_target_default_test_directory_mb_per_s",
+			"fio_type_sequential_write_engine_linux_aio_direct_no_block_size_1mb_job_count_1_disk_target_default_test_directory_iops",
+			"fio_type_random_read_engine_linux_aio_direct_no_block_size_4kb_job_count_1_disk_target_default_test_directory_mb_per_s",
+			"fio_type_random_read_engine_linux_aio_direct_no_block_size_4kb_job_count_1_disk_target_default_test_directory_iops",
+			"fio_type_random_write_engine_linux_aio_direct_no_block_size_4kb_job_count_1_disk_target_default_test_directory_mb_per_s",
+			"fio_type_random_write_engine_linux_aio_direct_no_block_size_4kb_job_count_1_disk_target_default_test_directory_iops",
+		],
 		commands: ["mise run benchmark:disk:all"],
 	},
 	// The realworld dimension (ENG-135/136/137/138): real OSS repos run through their own CI tasks,


### PR DESCRIPTION
**PTS BENCHMARK MATRIX — vendor the PTS catalog, then light up four benchmark suites.**
Shipped as a 12-PR stack. The trunk merges bottom-up; the four suite PRs at the top are SIBLINGS and
can be reviewed (and merged) in parallel — none blocks the others.

```
main
 └─ #136  schema: scale-aware PTS metric identity (pts.scale) + O(1) matcher
     └─ #137  catalog generator: per-parser scales + virtual axes
         └─ #138  ⚙ VENDOR fio + regenerate catalog        (autogenerated)
             └─ #146  fio curation + disk headline + goldens
                 └─ #139  ⚙ VENDOR loopback/zstd/pgbench + regenerate   (autogenerated)
                     └─ #147  their curation + recorded fixtures
                         └─ #148  shared PTS runner (lib/bench.sh)
                             └─ #144  toolchain image: bake PTS deps + pin drift gates
                                 ├─ #140  disk suite     ┐
                                 ├─ #141  network suite  │  siblings — parallel review
                                 ├─ #142  cpu-generic    │
                                 └─ #143  system suite   ┘
```
⚙ = the diff is machine-produced; reproduce it with the commands in the body. Everything hand-written
was lifted out into the small PR directly above it.

↑ **This PR is #140 — SIBLING suite PR, based on #144. Reviewable in parallel with #141/#142/#143.**

---

**Stack 5/9** — based on #139

`lib/bench.sh` grows the preset-pinning machinery the fio scenarios need:

- **`run_pinned_pts(test, prefix, presets)`** — runs one PTS profile pinned to a single combination. PTS's batch runner *ignores* `PRESET_OPTIONS` while `RunAllTestCombinations=TRUE`, so batch setup is re-run with that answer flipped and the resulting user-config is verified before the run (a silent full-matrix fan-out would burn the suite budget and post unpinned combinations).
- **`fio_direct_choice()`** — probes O_DIRECT support once per run (4096-byte aligned `dd`; some sandbox filesystems reject O_DIRECT) and caches the Yes/No axis value so all four scenarios land on the same variant.
- **`run_fio_pts(type, bs, prefix)`** — one fio scenario, pinned by *index* for the runtime-expanded axes (`cpu-threads`, the virtual Disk Target menu) and by name elsewhere.
- `run_pts_benchmark` skips batch-install when the profile is already staged (the bake-first path, slice 9/9) and only collects composites newer than a per-run freshness stamp, so a stale composite from an earlier task can't mask a failed run.
- `ensure_pts`'s apt fallback carries the full builder dep list the new profiles compile against.

Four ten-line leaves (`benchmark:disk:pts:fio-{seq,rand}-{read,write}`) join hardlink in `benchmark:disk:all`; the disk suite declares the 17 resulting metrics (60/70 min budgets, 4 GB disk floor for fio's 1 GiB test files). A new suites test pins the declared fio subset to the curated override keys — with the full matrix catalogued, a typo'd axis would otherwise pass the suite contract and silently never receive samples.

**LOC**: 262 hand-written. Gate green (543 tests, repo-wide shellcheck).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BHkDUJmxVAz1sCWFcS9btJ

---
_Generated by [Claude Code](https://claude.ai/code/session_01BHkDUJmxVAz1sCWFcS9btJ)_

## Validation

Every branch in this stack was checked out **in isolation** (i.e. on top of its own parent, with
nothing from the PRs above it) and run through the full gate set. A reviewer merges bottom-up, so
each PR has to stand on its own — this is what verifies that.

**This PR (`05`), verified standalone — all seven gates green:**

| gate | command | result |
|---|---|---|
| install | `bun install --frozen-lockfile` | ✅ |
| typecheck | `bun run typecheck` | ✅ |
| lint | `bun run lint` (biome, `--error-on-warnings`) | ✅ |
| spell | `mise exec -- typos` | ✅ |
| shell | `bun run lint:shell` (shellcheck) | ✅ |
| catalog drift | `bun run check:catalog-drift` | ✅ |
| tests | `bun run test` (whole workspace) | ✅ **578 passing, 0 failing** |

The same matrix is green on all 12 branches, and the passing-test count climbs monotonically up the
trunk (535 → 576) — each PR adds coverage and none regresses it.

**What this PR's own tests prove:**

- `shellcheck` over the four fio producer leaves and the fio helpers.
- The golden gate requires every fio fixture `<Result>` to resolve to a metric **this suite declares**, which transitively pins the bash `PRESET_OPTIONS`, the curated ids and the scale routing in one assertion.
- The declared fio subset is pinned to its curated override keys, so a typo'd engine/block-size can't pass the suite contract and then silently never receive samples.

### What this does NOT prove

Being explicit, because the gates above are all static:

- **No benchmark has been run on a real provider sandbox.** Nothing in CI executes the `.mise` producer
  tasks against a live Phoronix Test Suite. Their correctness rests on `shellcheck`, on the golden
  byte-match gate (which compares against RECORDED composites — real PTS output, but replayed, not
  produced), and on the suite-contract tests. The first live signal is the `bench-smoke` workflow
  (manual dispatch) after these merge.
- **The image is only built by CI on #144** — it is the only PR that touches it. The suite PRs assume
  that image; they do not rebuild it.
- `Bake, validate & promote toolchain` is skipped on pull requests by design
  (`if: github.event_name != 'pull_request'`), so image PROMOTION is exercised only on `main`.
- The recorded fixtures prove byte-match against PTS output captured at a point in time; a future PTS
  release could change a `<Description>` string. That is precisely what the golden gate would catch.

Additionally, the four suite PRs at the top are siblings on #144; merging all four reproduces the
pre-restructure tree byte-for-byte (verified), so the 12-PR split moved every change and dropped none.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds four preset‑pinned `fio` scenarios and a pinned PTS runner to expand the disk suite with stable bandwidth and IOPS. Probes O_DIRECT per sandbox, pins `pts/fio-2.1.0`, and only records declared `fio_*` metrics.

- **New Features**
  - Adds four tasks: `benchmark:disk:pts:fio-seq-read`, `...:fio-seq-write`, `...:fio-rand-read`, `...:fio-rand-write` (run before hardlink in `benchmark:disk:all`).
  - Adds `run_pinned_pts`, `run_fio_pts`, `fio_direct_choice` in `lib/bench.sh` (pins runtime axes; probes/caches O_DIRECT once with 4096‑byte `dd`; version‑pins `pts/fio-2.1.0`; per‑run freshness stamp; skips batch‑install if already staged).
  - Expands `disk` suite: +16 `fio_*` metrics (MB/s and IOPS for seq 1MB and rand 4KB read/write, Direct Yes/No variants), budgets 60/70 min, min disk 4 GB; tests require each `fio` result to map to a declared metric and match curated override keys.

- **Bug Fixes**
  - Enforces batch config (`RunAllTestCombinations=FALSE`) with fail‑fast on misconfig.
  - Calls `pts_init` before `pts_user_dir` in the O_DIRECT probe to prevent a wrong results root and stale composites masking failed runs.

<sup>Written for commit c56b358232ef4c9cb82a948dc767e87254b77078. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/starslingdev/sandbox-benchmarks/pull/140?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

