### PR TITLE
feat(bench,schema): network suite — loopback TCP headline + latency/DNS/download probes

### DIFF
--- a/.github/workflows/bench-smoke.yml
+++ b/.github/workflows/bench-smoke.yml
@@ -28,6 +28,7 @@ on:
             memory,
             disk,
             cpu-generic,
+            network,
             realworld-mastra,
             realworld-better-auth,
             realworld-openclaw,

--- a/.mise/tasks/benchmark/network/all
+++ b/.mise/tasks/benchmark/network/all
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+#MISE description="Run network benchmarks (PTS loopback TCP + latency/DNS/download probes)"
+# Orchestrator: no -e — run_task isolates child failures and summary reports them at the end
+# (error-mode conventions: lib/bench.sh).
+set -uo pipefail
+REPO_ROOT="$(git -C "$(dirname "${BASH_SOURCE[0]}")" rev-parse --show-toplevel)"
+source "${REPO_ROOT}/lib/bench.sh"
+
+echo "========================================"
+echo "  NETWORK BENCHMARKS"
+echo "========================================"
+
+# The catalogued metric first: loopback TCP is self-contained (no external endpoint), so it isolates
+# the sandbox's network stack (virtio vs gVisor netstack vs host namespaces) from internet weather.
+ensure_pts || true
+
+run_task benchmark:network:pts:loopback
+
+# Tolerant probes (raw JSON provenance, no catalogued metrics): where does this sandbox's traffic
+# actually go, and how fast? Egress latency, resolver behavior, and real-world download timing.
+run_task benchmark:network:latency
+run_task benchmark:network:dns
+run_task benchmark:network:download
+
+summary

--- a/.mise/tasks/benchmark/network/dns
+++ b/.mise/tasks/benchmark/network/dns
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+#MISE description="DNS resolver identity and resolution timing for common registries"
+# Tolerant probe: no -e — report whatever the sandbox exposes (error-mode conventions:
+# lib/bench.sh). Sandbox resolvers differ wildly (host stub vs provider DNS vs public), and slow
+# resolution taxes every clone/install a real CI job does.
+#
+# Each domain is resolved ONCE, with the structured record parsed from the same bytes the log shows —
+# a second dig for jc would measure a cache-warmed resolver query, systematically underreporting the
+# very number this probe exists to capture.
+set -uo pipefail
+REPO_ROOT="$(git -C "$(dirname "${BASH_SOURCE[0]}")" rev-parse --show-toplevel)"
+source "${REPO_ROOT}/lib/bench.sh"
+
+echo "=== DNS Resolver ==="
+try cat /etc/resolv.conf
+
+echo ""
+echo "=== DNS Resolution ==="
+for domain in github.com registry.npmjs.org docker.io pypi.org rubygems.org; do
+	echo ""
+	echo "--- $domain ---"
+	if command -v dig &>/dev/null; then
+		rc=0
+		out="$(dig "$domain" 2>/dev/null)" || rc=$?
+		if [ "$rc" -ne 0 ] || [ -z "$out" ]; then
+			echo "(dig failed — exit ${rc})"
+			# Keep dig's own diagnostic (";; connection timed out" vs NXDOMAIN vs REFUSED) — the resolver
+			# behaviour this probe exists to capture. Discarding it left only "(dig failed)".
+			[ -n "$out" ] && printf '%s\n' "$out"
+			continue
+		fi
+		echo "$out"
+		# Structured output via jc. Staged through a temp file: redirecting straight at the .json
+		# truncates it BEFORE jc runs, so a swallowed parse failure leaves a zero-byte file behind.
+		if command -v jc &>/dev/null; then
+			json="$(results_dir)/$(task_result_name "$domain").json"
+			tmp="$(mktemp)"
+			if printf '%s\n' "$out" | jc --dig >"$tmp" 2>/dev/null && [ -s "$tmp" ]; then
+				mv "$tmp" "$json"
+			else
+				echo "(jc --dig produced no structured record)"
+				rm -f "$tmp"
+			fi
+		fi
+	else
+		start=$(_now_ms)
+		getent_rc=0
+		getent hosts "$domain" >/dev/null 2>&1 || getent_rc=$?
+		end=$(_now_ms)
+		if [ "$getent_rc" -eq 0 ]; then
+			echo "$domain: $((end - start))ms (getent)"
+		else
+			# A failed lookup printed a timing line indistinguishable from a successful one.
+			echo "$domain: (getent failed — exit ${getent_rc}, after $((end - start))ms)"
+		fi
+	fi
+done

--- a/.mise/tasks/benchmark/network/download
+++ b/.mise/tasks/benchmark/network/download
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+#MISE description="Download speed and connection timing against GitHub (curl probe)"
+# Tolerant probe: no -e — report whatever the sandbox exposes (error-mode conventions:
+# lib/bench.sh). The endpoint is GitHub deliberately: it is the one host every suite already depends
+# on (the harness clones this repo from it), so reachability is a given and the number reflects the
+# path real CI traffic takes.
+#
+# Each probe runs curl ONCE, writing the native `%{json}` write-out as the structured result and
+# rendering the human-readable log lines from that JSON — a second curl for display would double the
+# ~10MB transfer (and the two could disagree on a flaky path, which is exactly when this probe matters).
+set -uo pipefail
+REPO_ROOT="$(git -C "$(dirname "${BASH_SOURCE[0]}")" rev-parse --show-toplevel)"
+source "${REPO_ROOT}/lib/bench.sh"
+
+# Render selected write-out fields from a curl %{json} result file, tolerating a missing jq (the
+# toolchain image ships it; elsewhere the raw JSON line is still meaningful provenance).
+summarize() {
+	local file="$1" template="$2"
+	if [ ! -s "$file" ]; then
+		echo "(probe produced no result)"
+	elif command -v jq &>/dev/null; then
+		jq -r "$template" "$file" 2>/dev/null || cat "$file"
+	else
+		cat "$file"
+	fi
+}
+
+# Both probes ARE curl — without it there is nothing to measure. Guard before the redirects below:
+# `>"$SPEED_JSON"` creates the file whether or not curl exists, so an unguarded run on a curl-less
+# sandbox would leave zero-byte `.json` artifacts — provenance that reads as "the probe ran and
+# measured nothing" rather than "the tool was missing". Skip markers are the negative the normalizer
+# expects (see skip_result in lib/bench.sh), one per probe, matching the pts/loopback guard.
+if ! command -v curl &>/dev/null; then
+	skip_result "curl not installed" "$(task_result_name "speed")"
+	skip_result "curl not installed" "$(task_result_name "timing")"
+	exit 0
+fi
+
+echo "=== Download Speed Test ==="
+echo "Downloading ~10MB test archive from GitHub..."
+
+SPEED_JSON="$(results_dir)/$(task_result_name "speed").json"
+# -sS, and stderr NOT discarded: the %{json} write-out goes to stdout (captured in $SPEED_JSON), so
+# curl's diagnostic on stderr can't corrupt the result file — and it is the whole story when the probe
+# fails (DNS vs TLS vs proxy refusal), which is precisely what a network probe exists to record.
+curl -sSL --max-time 120 -o /dev/null -w '%{json}' \
+	"https://github.com/anthropics/anthropic-sdk-python/archive/refs/heads/main.zip" \
+	>"$SPEED_JSON" || echo "(download probe failed — curl exited non-zero)"
+summarize "$SPEED_JSON" \
+	'"HTTP \(.http_code) | \(.size_download) bytes | \(.time_total)s total | \(.speed_download) bytes/sec"'
+
+echo ""
+echo "=== Connection Timing (github.com) ==="
+TIMING_JSON="$(results_dir)/$(task_result_name "timing").json"
+curl -sSL --max-time 30 -o /dev/null -w '%{json}' "https://github.com" \
+	>"$TIMING_JSON" || echo "(timing probe failed — curl exited non-zero)"
+summarize "$TIMING_JSON" \
+	'"DNS:        \(.time_namelookup)s\nConnect:    \(.time_connect)s\nTLS:        \(.time_appconnect)s\nFirst byte: \(.time_starttransfer)s\nTotal:      \(.time_total)s"'

--- a/.mise/tasks/benchmark/network/latency
+++ b/.mise/tasks/benchmark/network/latency
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+#MISE description="Network latency to common developer endpoints (ping probe)"
+# Tolerant probe: no -e — report whatever the sandbox exposes (error-mode conventions:
+# lib/bench.sh). Some sandbox networks drop ICMP entirely; that answer is itself provenance.
+#
+# Each host is pinged ONCE, with the structured record parsed from the same bytes the log shows —
+# a second ping for jc would double the runtime and could disagree with the displayed run.
+set -uo pipefail
+REPO_ROOT="$(git -C "$(dirname "${BASH_SOURCE[0]}")" rev-parse --show-toplevel)"
+source "${REPO_ROOT}/lib/bench.sh"
+
+echo "=== Ping Latency (3 packets each) ==="
+for host in github.com registry.npmjs.org google.com api.github.com; do
+	echo ""
+	echo "--- $host ---"
+	if ! out="$(ping -c 3 -W 5 "$host" 2>/dev/null)"; then
+		# Distinguish "no ping binary" from "host unreachable/ICMP dropped" like try() would.
+		if command -v ping &>/dev/null; then echo "(ping failed — ICMP dropped or unreachable)"; else echo "(ping not found)"; fi
+		# On total packet loss ping still prints its statistics block to stdout and exits 1: keep it, so
+		# the log separates "name resolved, every ICMP filtered" from "name never resolved".
+		[ -n "$out" ] && printf '%s\n' "$out"
+		continue
+	fi
+	echo "$out"
+	# Structured output via jc (mise-managed in the toolchain image; probes degrade to logs without it).
+	# Staged through a temp file: redirecting straight at the .json truncates it BEFORE jc runs, so a
+	# swallowed parse failure would leave a zero-byte file that the harness collects as real provenance.
+	if command -v jc &>/dev/null; then
+		json="$(results_dir)/$(task_result_name "$host").json"
+		tmp="$(mktemp)"
+		if printf '%s\n' "$out" | jc --ping >"$tmp" 2>/dev/null && [ -s "$tmp" ]; then
+			mv "$tmp" "$json"
+		else
+			echo "(jc --ping produced no structured record)"
+			rm -f "$tmp"
+		fi
+	fi
+done

--- a/.mise/tasks/benchmark/network/pts/loopback
+++ b/.mise/tasks/benchmark/network/pts/loopback
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+#MISE description="PTS: loopback TCP network performance (time to transfer 10GB via nc)"
+# Measurement leaf: -e guards the scaffolding; the measured run is isolated by run_pts_benchmark.
+set -euo pipefail
+REPO_ROOT="$(git -C "$(dirname "${BASH_SOURCE[0]}")" rev-parse --show-toplevel)"
+source "${REPO_ROOT}/lib/bench.sh"
+
+if ! command -v phoronix-test-suite &>/dev/null; then
+	skip_result "phoronix-test-suite not installed" "pts_network-loopback"
+	exit 0
+fi
+# The profile's runner is `dd | nc` — netcat is its only real dependency (the toolchain image bakes
+# netcat-openbsd; stock images may lack it, and PTS's install.sh would "succeed" into a runner that
+# dies at measure time).
+if ! command -v nc &>/dev/null; then
+	skip_result "nc (netcat) not installed (apt-get install -y netcat-openbsd)" "pts_network-loopback"
+	exit 0
+fi
+
+# Version-pinned to the vendored profile so an upstream release can't drift under the catalog.
+run_pts_benchmark "pts/network-loopback-1.0.1" "pts_network-loopback"

--- a/packages/schema/src/suites.test.ts
+++ b/packages/schema/src/suites.test.ts
@@ -25,6 +25,7 @@ describe("suite registry", () => {
 			"memory",
 			"disk",
 			"cpu-generic",
+			"network",
 			"realworld-mastra",
 			"realworld-better-auth",
 			"realworld-openclaw",
@@ -56,10 +57,10 @@ describe("suite registry", () => {
 		// the test is exactly what the suite emits — pin the declared list to it in BOTH directions (a
 		// profile bump that adds/renames a combination fails here instead of silently stranding the
 		// list). stream's Type axis is the real matrix case; pybench and sqlite-speedtest declare no
-		// <Option> axes at all, so the pin holds over their single wildcard result. The suites that
-		// arrive later (network, cpu-generic) add themselves here.
+		// <Option> axes at all, so the pin holds over their single wildcard result.
 		const profilesOf = {
 			"cpu-generic": ["pts/c-ray", "pts/compress-zstd"],
+			network: ["pts/network-loopback"],
 			memory: ["pts/stream"],
 			system: ["pts/pybench", "pts/sqlite-speedtest"],
 		} as const;

--- a/packages/schema/src/suites.ts
+++ b/packages/schema/src/suites.ts
@@ -151,6 +151,17 @@ export const SUITES = {
 		],
 		commands: ["mise run benchmark:cpu:generic"],
 	},
+	// The network dimension: loopback TCP (10GB via nc) — self-contained, no external endpoint, so it
+	// isolates the sandbox's network stack from internet weather. The suite task also runs the
+	// latency/DNS/download probes (raw JSON provenance, no catalogued metrics).
+	network: {
+		setupPts: true,
+		commandTimeoutMinutes: 30,
+		timeoutMinutes: 40,
+		dimensions: ["network"],
+		metrics: ["network_loopback_seconds"],
+		commands: ["mise run benchmark:network:all"],
+	},
 	// The realworld dimension (ENG-135/136/137/138): real OSS repos run through their own CI tasks,
 	// each a repo-local PTS profile with a Task option axis. Budgets are starting points (tuned from
 	// smoke); mastra's task matrix is the narrowest (scoped to packages/core) but its monorepo has


### PR DESCRIPTION
**PTS BENCHMARK MATRIX — vendor the PTS catalog, then light up four benchmark suites.**
Shipped as a 12-PR stack. The trunk merges bottom-up; the four suite PRs at the top are SIBLINGS and
can be reviewed (and merged) in parallel — none blocks the others.

```
main
 └─ #136  schema: scale-aware PTS metric identity (pts.scale) + O(1) matcher
     └─ #137  catalog generator: per-parser scales + virtual axes
         └─ #138  ⚙ VENDOR fio + regenerate catalog        (autogenerated)
             └─ #146  fio curation + disk headline + goldens
                 └─ #139  ⚙ VENDOR loopback/zstd/pgbench + regenerate   (autogenerated)
                     └─ #147  their curation + recorded fixtures
                         └─ #148  shared PTS runner (lib/bench.sh)
                             └─ #144  toolchain image: bake PTS deps + pin drift gates
                                 ├─ #140  disk suite     ┐
                                 ├─ #141  network suite  │  siblings — parallel review
                                 ├─ #142  cpu-generic    │
                                 └─ #143  system suite   ┘
```
⚙ = the diff is machine-produced; reproduce it with the commands in the body. Everything hand-written
was lifted out into the small PR directly above it.

↑ **This PR is #141 — SIBLING suite PR, based on #144. Reviewable in parallel with #140/#142/#143.**

---

**Stack 6/9** — based on #140

Adds the network dimension's producer tasks and registers the suite:

- `benchmark:network:pts:loopback` pins `pts/network-loopback-1.0.1` (10GB over `nc` through loopback) — self-contained, no external endpoint, so it isolates the sandbox's network stack from internet weather. Its single metric `network_loopback_seconds` headlines the previously-empty network dimension.
- `benchmark:network:{latency,dns,download}` record ping/dig/curl probes as raw JSON provenance — each probe runs **once** and both the human-readable log and the parsed JSON come from the same bytes. External-endpoint numbers are too weather-dependent to rank, so no catalogued metrics.
- The registry mirror test pins network's declared metrics to the catalog's `pts/network-loopback` entries in both directions; bench-smoke's suite dropdown gains `network` (held in lockstep by the workflow-registry-sync gate).

**LOC**: 188 hand-written. Gate green (544 tests, shellcheck).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BHkDUJmxVAz1sCWFcS9btJ

---
_Generated by [Claude Code](https://claude.ai/code/session_01BHkDUJmxVAz1sCWFcS9btJ)_

## Validation

Every branch in this stack was checked out **in isolation** (i.e. on top of its own parent, with
nothing from the PRs above it) and run through the full gate set. A reviewer merges bottom-up, so
each PR has to stand on its own — this is what verifies that.

**This PR (`06`), verified standalone — all seven gates green:**

| gate | command | result |
|---|---|---|
| install | `bun install --frozen-lockfile` | ✅ |
| typecheck | `bun run typecheck` | ✅ |
| lint | `bun run lint` (biome, `--error-on-warnings`) | ✅ |
| spell | `mise exec -- typos` | ✅ |
| shell | `bun run lint:shell` (shellcheck) | ✅ |
| catalog drift | `bun run check:catalog-drift` | ✅ |
| tests | `bun run test` (whole workspace) | ✅ **576 passing, 0 failing** |

The same matrix is green on all 12 branches, and the passing-test count climbs monotonically up the
trunk (535 → 576) — each PR adds coverage and none regresses it.

**What this PR's own tests prove:**

- `shellcheck` over the loopback runner and the latency/DNS/download probes.
- The suite's declared metrics are mirrored against the generated catalog in BOTH directions, so a profile bump that adds or renames a combination fails here rather than stranding the list.

### What this does NOT prove

Being explicit, because the gates above are all static:

- **No benchmark has been run on a real provider sandbox.** Nothing in CI executes the `.mise` producer
  tasks against a live Phoronix Test Suite. Their correctness rests on `shellcheck`, on the golden
  byte-match gate (which compares against RECORDED composites — real PTS output, but replayed, not
  produced), and on the suite-contract tests. The first live signal is the `bench-smoke` workflow
  (manual dispatch) after these merge.
- **The image is only built by CI on #144** — it is the only PR that touches it. The suite PRs assume
  that image; they do not rebuild it.
- `Bake, validate & promote toolchain` is skipped on pull requests by design
  (`if: github.event_name != 'pull_request'`), so image PROMOTION is exercised only on `main`.
- The recorded fixtures prove byte-match against PTS output captured at a point in time; a future PTS
  release could change a `<Description>` string. That is precisely what the golden gate would catch.

Additionally, the four suite PRs at the top are siblings on #144; merging all four reproduces the
pre-restructure tree byte-for-byte (verified), so the 12-PR split moved every change and dropped none.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a new `network` benchmark suite with a loopback TCP headline metric and one‑shot latency/DNS/download probes to profile sandbox networking. The suite is registered in the schema and selectable in `bench-smoke`.

- **New Features**
  - Register `network` with metric `network_loopback_seconds`; `setupPts: true`, 30/40‑min timeouts; run with `mise run benchmark:network:all`. Loopback pinned to `pts/network-loopback-1.0.1`; add tasks for `latency`, `dns`, and `download`.
  - Mirror metrics to `pts/network-loopback` in suite tests; add `network` to `.github/workflows/bench-smoke.yml`.

- **Bug Fixes**
  - Harden probes: stage `jc` JSON via temp files, keep failure evidence, use `curl -sSL` with `%{json}` write‑out and stderr preserved; tolerate missing `jq`.
  - Clear skip markers when `phoronix-test-suite`/`nc`/`curl` are missing, avoiding empty `.json` artifacts.

<sup>Written for commit 1a44427aa3efc70c48d52b9b4fc19951533242f3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/starslingdev/sandbox-benchmarks/pull/141?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new network benchmark suite covering loopback performance, latency, DNS resolution, and download timing.
  * Enabled running the network suite from manual benchmark dispatch.
  * Added network suite metrics and consolidated results output.
* **Tests**
  * Updated suite registry/validation tests to include the new network benchmark suite and its expected mirrored profile metrics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->