### PR TITLE
feat(bench,schema): provider-identification task + pgbench in the system suite

### DIFF
--- a/.mise/tasks/benchmark/system/all
+++ b/.mise/tasks/benchmark/system/all
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-#MISE description="Run system benchmarks (PTS PyBench + SQLite Speedtest)"
+#MISE description="Run system benchmarks (provider identity probe + PTS PyBench, SQLite Speedtest, pgbench)"
 # Orchestrator: no -e — run_task isolates child failures and summary reports them at the end
 # (error-mode conventions: lib/bench.sh).
 set -uo pipefail
@@ -11,10 +11,17 @@ echo "  SYSTEM BENCHMARKS"
 echo "========================================"
 
 # One install/configure attempt for the PTS children; each leaf skips fast via its own `command -v`
-# guard and writes a skip record if PTS is still unavailable.
+# guard and writes a skip record if PTS is still unavailable. Runs BEFORE the provider probe: on a
+# stock image its apt fallback is also what installs the probe's own tools (dig from dnsutils, jq),
+# so ordering the probe first would silently degrade the identity lookups to their fallbacks.
 ensure_pts || true
+
+# Who/where is this sandbox actually running? Egress ASN + geo + SMBIOS identity — provenance for
+# every number the PTS children below produce (a tolerant probe: it never fails the suite).
+run_task benchmark:system:provider
 
 run_task benchmark:system:pts:pybench
 run_task benchmark:system:pts:sqlite-speedtest
+run_task benchmark:system:pts:pgbench
 
 summary

--- a/.mise/tasks/benchmark/system/provider
+++ b/.mise/tasks/benchmark/system/provider
@@ -1,0 +1,206 @@
+#!/usr/bin/env bash
+#MISE description="Identify the infrastructure under a sandbox: egress ASN/org, geo, and DMI hardware identity"
+# Mirrors the "Provider Info" step of runs-on Bench Global, which is the source of the
+# `Infrastructure` column in their published table:
+#
+#     IPINFO=$(curl -s ipinfo.io); ORG=$(jq -r '.org') ; # => "AS31898 Oracle Corporation"
+#     MANUFACTURER=$(sudo dmidecode -s system-manufacturer)
+#
+# WHAT `.org` ACTUALLY IS: the ASN that announces the sandbox's *public egress IP*. It is a network
+# fact, not a hardware one. A sandbox NATs its egress through the provider's own network, so this
+# names whoever owns the address block the traffic leaves from — which may be the underlying host
+# cloud (Oracle, AWS) rather than the vendor you buy from (Daytona, Novita), or a transit/proxy
+# network belonging to neither.
+#
+# So we record the DMI identity alongside it. `system-manufacturer` / `product-name` come from the
+# hypervisor's SMBIOS tables and describe the machine the kernel is running on. When the two
+# disagree, the DMI is the better answer to "whose metal is this" and the ASN answers "whose network
+# is this". Both are reported; neither is silently preferred.
+#
+# WHY NOT ipinfo.io FOR THE ASN. Anonymous ipinfo is quota'd per source IP, and a matrix fan-out
+# behind one NAT egress makes many anonymous calls. On a 429 it returns a JSON error body, `.org`
+# resolves to empty, and the provider column silently reads "unknown" — indistinguishable from a
+# sandbox we genuinely could not identify. So the ASN comes from Team Cymru's DNS whois instead:
+# authoritative BGP origin data, no HTTP, no quota, no install, and no key. ipinfo is retained only
+# for city/region, and its failure is recorded in `geo_source` rather than blanking the identity.
+#
+# Tolerant probe: no -e — report whatever the sandbox exposes (error-mode conventions: lib/bench.sh).
+set -uo pipefail
+REPO_ROOT="$(git -C "$(dirname "${BASH_SOURCE[0]}")" rev-parse --show-toplevel)"
+source "${REPO_ROOT}/lib/bench.sh"
+
+RESULT_FILE="$(results_dir)/$(task_result_name).json"
+
+# --- Public egress IP --------------------------------------------------------
+# DNS echoes first: no quota, and they answer over :53 where an HTTP egress proxy may not exist.
+# Each is capped so a blackholed resolver cannot stall the leg. HTTP echoes are the fallback.
+# Keep only the first line that IS an IPv4 address. Validation must happen PER LEG: dig prints
+# multi-record answers (edns-client-subnet lines) and even failure diagnostics (";; communications
+# error …") to stdout under +short, and a proxy can serve HTML to curl — any non-empty garbage
+# accepted here would short-circuit the remaining legs and yield no IP on a working network.
+_first_ipv4() { tr -d '"' | grep -m1 -xE '[0-9]{1,3}(\.[0-9]{1,3}){3}' || true; }
+public_ip() {
+	# -4 on every leg: the Cymru lookup and ipinfo geo below describe an IPv4 egress, and a v6 echo
+	# would make one row's identity fields describe two different addresses.
+	local ip=""
+	if command -v dig &>/dev/null; then
+		ip="$(dig -4 @ns1.google.com TXT o-o.myaddr.l.google.com +short +time=2 +tries=1 2>/dev/null | _first_ipv4)"
+		[ -z "$ip" ] && ip="$(dig -4 @resolver1.opendns.com myip.opendns.com +short +time=2 +tries=1 2>/dev/null | _first_ipv4)"
+		[ -z "$ip" ] && ip="$(dig -4 @1.0.0.1 ch txt whoami.cloudflare +short +time=2 +tries=1 2>/dev/null | _first_ipv4)"
+	fi
+	[ -z "$ip" ] && ip="$(curl -s -4 --max-time 3 https://ifconfig.me 2>/dev/null | _first_ipv4)"
+	[ -z "$ip" ] && ip="$(curl -s -4 --max-time 3 https://ipinfo.io/ip 2>/dev/null | _first_ipv4)"
+	printf '%s' "$ip"
+}
+PUBLIC_IP="$(public_ip)"
+
+# --- ASN + org, from Team Cymru DNS whois ------------------------------------
+# <reversed-ip>.origin.asn.cymru.com TXT => "31898 | 161.153.0.0/17 | US | arin | 2024-07-01"
+# AS<n>.asn.cymru.com          TXT      => "31898 | US | arin | ... | ORACLE-BMC-31898 - Oracle Corporation, US"
+ASN=""
+ORG_NAME=""
+PREFIX=""
+ASN_SOURCE="unavailable"
+cymru_lookup() {
+	local ip="$1" rev origin asn name
+	command -v dig &>/dev/null || return 1
+	# IPv4 only: the IPv6 nibble form is a different zone and we have no v6-only sandboxes. Bail
+	# rather than silently querying a malformed name.
+	[[ "$ip" =~ ^[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+$ ]] || return 1
+	rev="$(printf '%s' "$ip" | awk -F. '{print $4"."$3"."$2"."$1}')"
+	origin="$(dig +short +time=2 +tries=1 "${rev}.origin.asn.cymru.com" TXT 2>/dev/null | tr -d '"' | head -1)"
+	# Require the answer's documented shape ("31898 | 161.153.0.0/17 | …"): dig prints resolver
+	# failure diagnostics (";; communications error …") to STDOUT even under +short, and treating one
+	# as an answer would record asn="AS;;" with asn_source=cymru while blocking the ipinfo fallback.
+	[[ "$origin" =~ ^[0-9]+[0-9\ ]*\| ]] || return 1
+	# Field 1 lists SEVERAL space-separated origin ASNs for a MOAS prefix ("23028 23029 | …"); take
+	# the first — stripping the spaces instead would fabricate a nonexistent AS number.
+	asn="$(printf '%s' "$origin" | awk -F'|' '{split($1, parts, " "); print parts[1]}')"
+	[[ "$asn" =~ ^[0-9]+$ ]] || return 1
+	PREFIX="$(printf '%s' "$origin" | awk -F'|' '{gsub(/^ +| +$/,"",$2); print $2}')"
+	# Field 5 of the AS record is "HANDLE - Org Name, CC"; take the org half.
+	name="$(dig +short +time=2 +tries=1 "AS${asn}.asn.cymru.com" TXT 2>/dev/null | tr -d '"' |
+		awk -F'|' '{gsub(/^ +| +$/,"",$5); print $5}' | head -1)"
+	name="$(printf '%s' "$name" | sed -E 's/^[A-Z0-9_-]+ - //; s/, [A-Z]{2}$//')"
+	ASN="AS${asn}"
+	ORG_NAME="$name"
+	ASN_SOURCE="cymru"
+}
+[ -n "$PUBLIC_IP" ] && { cymru_lookup "$PUBLIC_IP" || true; }
+
+# --- Geo, best-effort, from ipinfo -------------------------------------------
+# 3s cap: an unreachable metadata service must not stall a benchmark leg.
+# -4 like every other leg: the Cymru lookup and this geo record must describe the SAME (IPv4) egress,
+# or a dual-stack sandbox reports an ASN for one address and a city for another.
+IPINFO="$(curl -s -4 --max-time 3 https://ipinfo.io 2>/dev/null || echo '{}')"
+jq_get() { printf '%s' "$IPINFO" | jq -r "$1 // \"\"" 2>/dev/null || printf ''; }
+
+# A quota'd or errored ipinfo returns a body with `.error` (or no `.ip` at all). Distinguish that
+# from a genuine answer instead of silently reporting blanks.
+GEO_SOURCE="ipinfo"
+if ! command -v jq &>/dev/null; then
+	# "No parser on this image" is NOT "ipinfo refused us": jq_get's `|| printf ''` swallows exit 127,
+	# so without this every field reads empty under a geo_source claiming an upstream outage.
+	GEO_SOURCE="no-jq"
+	IPINFO='{}'
+elif [ -n "$(jq_get .error.title)" ] || [ -z "$(jq_get .ip)" ]; then
+	GEO_SOURCE="unavailable"
+	IPINFO='{}'
+fi
+
+CITY="$(jq_get .city)"
+REGION="$(jq_get .region)"
+COUNTRY="$(jq_get .country)"
+LOC="$(jq_get .loc)" # "lat,lon"
+TIMEZONE="$(jq_get .timezone)"
+HOSTNAME_PTR="$(jq_get .hostname)"
+[ -z "$PUBLIC_IP" ] && PUBLIC_IP="$(jq_get .ip)"
+# The echo legs can fail while Cymru's DNS still works (an HTTP-only egress proxy). Retry the
+# BGP-origin lookup with the address ipinfo just recovered, rather than settling for its `.org` —
+# which is quota'd per source IP and loses Cymru's MOAS-first ordering.
+[ -z "$ASN" ] && [ -n "$PUBLIC_IP" ] && { cymru_lookup "$PUBLIC_IP" || true; }
+
+# Fall back to ipinfo's org string only if Cymru could not answer, splitting
+# "AS31898 Oracle Corporation" into its halves. An org string without a leading ASN leaves asn empty
+# rather than swallowing the first word.
+if [ -z "$ASN" ]; then
+	IPINFO_ORG="$(jq_get .org)"
+	if [[ "$IPINFO_ORG" =~ ^(AS[0-9]+)[[:space:]]+(.*)$ ]]; then
+		ASN="${BASH_REMATCH[1]}"
+		ORG_NAME="${BASH_REMATCH[2]}"
+		ASN_SOURCE="ipinfo"
+	elif [ -n "$IPINFO_ORG" ]; then
+		ORG_NAME="$IPINFO_ORG"
+		ASN_SOURCE="ipinfo"
+	fi
+fi
+
+# runs-on's `Infrastructure` column is this literal string; keep the shape so our table and theirs
+# can be read side by side. No trailing space when the AS-name lookup came back empty — exact-match
+# grouping on this field must not split "AS31898" from "AS31898 ".
+if [ -n "$ASN" ] && [ -n "$ORG_NAME" ]; then
+	ORG="$ASN $ORG_NAME"
+else
+	ORG="${ASN}${ORG_NAME}"
+fi
+
+# --- Hardware identity (SMBIOS/DMI) ------------------------------------------
+dmi() {
+	# /sys is readable without dmidecode or root; fall back to dmidecode (sandboxes run as root).
+	local sysfile="/sys/class/dmi/id/$1" key="$2"
+	if [ -r "$sysfile" ]; then
+		tr -d '\n' <"$sysfile"
+	else
+		dmidecode -s "$key" 2>/dev/null | grep -v '^#' | head -1 | tr -d '\n'
+	fi
+}
+MANUFACTURER="$(dmi sys_vendor system-manufacturer)"
+PRODUCT_NAME="$(dmi product_name system-product-name)"
+BIOS_VENDOR="$(dmi bios_vendor bios-vendor)"
+
+# Which hypervisor, if any. NOT via get(): systemd-detect-virt prints "none" AND exits 1 on bare
+# metal, and get()'s discard-on-nonzero would turn confirmed bare metal into an empty field —
+# indistinguishable from "tool missing" on exactly the whose-metal-is-this axis this probe answers.
+VIRT="$(systemd-detect-virt 2>/dev/null || true)"
+
+# --- Machine shape -----------------------------------------------------------
+# What actually distinguishes two sandboxes behind the same ASN. Without them a cross-vendor
+# comparison cannot tell "different cloud" from "same cloud, different CPU generation".
+CPU_MODEL="$(get "" sh -c "grep -m1 'model name' /proc/cpuinfo | cut -d: -f2 | xargs")"
+[ -z "$CPU_MODEL" ] && CPU_MODEL="$(get "" sh -c "lscpu | grep -m1 'Model name:' | cut -d: -f2 | xargs")"
+KERNEL="$(get "" uname -r)"
+CORES="$(get "" nproc)"
+RAM="$(get "" sh -c "free -h | awk '/Mem:/{print \$2}'")"
+
+echo "=== Infrastructure ==="
+echo "Public IP    = ${PUBLIC_IP:-N/A}"
+echo "Provider     = ${ORG:-N/A}   (asn_source=${ASN_SOURCE})"
+echo "  ASN        = ${ASN:-N/A}"
+echo "  Org        = ${ORG_NAME:-N/A}"
+echo "  Prefix     = ${PREFIX:-N/A}"
+echo "Reverse DNS  = ${HOSTNAME_PTR:-N/A}"
+echo "Location     = ${CITY:-N/A}, ${REGION:-N/A}, ${COUNTRY:-N/A} (${LOC:-N/A}) ${TIMEZONE:-}   (geo_source=${GEO_SOURCE})"
+echo "Manufacturer = ${MANUFACTURER:-N/A}"
+echo "Product      = ${PRODUCT_NAME:-N/A}"
+echo "BIOS vendor  = ${BIOS_VENDOR:-N/A}"
+echo "Virtualized  = ${VIRT:-N/A}"
+echo "CPU Model    = ${CPU_MODEL:-N/A}  (${CORES:-?} cores)"
+echo "Kernel       = ${KERNEL:-N/A}"
+echo "RAM          = ${RAM:-N/A}"
+echo ""
+echo "note: Provider/ASN describe the public egress network, not the host."
+echo "      ASN is BGP origin data (Team Cymru DNS); geo is best-effort (ipinfo)."
+echo "      Manufacturer/Product come from SMBIOS and describe the machine."
+
+esc() { _json_escape "$1"; }
+printf '{"schema_version":"1.0","public_ip":"%s","org":"%s","asn":"%s","org_name":"%s","reverse_dns":"%s","city":"%s","region":"%s","country":"%s","loc":"%s","timezone":"%s","manufacturer":"%s","product_name":"%s","bios_vendor":"%s","virtualization":"%s","cpu_model":"%s","kernel":"%s","cores":"%s","ram":"%s","prefix":"%s","asn_source":"%s","geo_source":"%s"}\n' \
+	"$(esc "$PUBLIC_IP")" "$(esc "$ORG")" "$(esc "$ASN")" "$(esc "$ORG_NAME")" \
+	"$(esc "$HOSTNAME_PTR")" "$(esc "$CITY")" "$(esc "$REGION")" "$(esc "$COUNTRY")" \
+	"$(esc "$LOC")" "$(esc "$TIMEZONE")" "$(esc "$MANUFACTURER")" "$(esc "$PRODUCT_NAME")" \
+	"$(esc "$BIOS_VENDOR")" "$(esc "$VIRT")" \
+	"$(esc "$CPU_MODEL")" "$(esc "$KERNEL")" "$(esc "$CORES")" "$(esc "$RAM")" \
+	"$(esc "$PREFIX")" "$(esc "$ASN_SOURCE")" "$(esc "$GEO_SOURCE")" \
+	>"$RESULT_FILE"
+
+echo ""
+echo "Structured result: $(task_result_name).json"

--- a/.mise/tasks/benchmark/system/pts/pgbench
+++ b/.mise/tasks/benchmark/system/pts/pgbench
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+#MISE description="PTS: PostgreSQL pgbench TPS + latency (scale 100, 50 clients, read-only + read-write)"
+# Measurement leaf: -e guards the scaffolding; the measured runs are isolated by run_pts_benchmark
+# (via run_pinned_pts, which owns the PTS availability guard — one skip marker per prefix — and pins
+# each mode's option combination through PRESET_OPTIONS).
+#
+# Fully in-sandbox: the profile builds postgres 17.0 (root-check patched) and runs server + pgbench
+# client locally, so every provider measures the same topology — unlike the services-container shape
+# runs-on Bench Global uses, which no sandbox can reproduce. One (Scaling Factor, Clients) point per
+# mode: scale 100 (~1.5 GB dataset — large enough to be a realistic working set, small enough not to
+# blow the 8 GiB target spec; note it FITS IN PAGE CACHE there, so read-only TPS measures memory/CPU
+# and the write path is what actually touches disk) and 50 clients (a standard concurrent load; the
+# profile pins -j to the core count).
+# Each mode posts a TPS and an Average Latency result (two catalogued metrics per mode).
+set -euo pipefail
+REPO_ROOT="$(git -C "$(dirname "${BASH_SOURCE[0]}")" rev-parse --show-toplevel)"
+source "${REPO_ROOT}/lib/bench.sh"
+
+# Version-pinned to the vendored profile (and its recorded fixture) so an upstream pgbench release
+# can't silently unmap the catalogued descriptions. "100"/"50" pin by NAME (they exceed the menus'
+# entry counts, so the numeric-index trap in run_pinned_pts's contract doesn't bite).
+run_pinned_pts "pts/pgbench-1.15.0" "pts_pgbench-read-only" \
+	"pgbench.scaling-factor=100;pgbench.clients=50;pgbench.run-mode=Read Only"
+run_pinned_pts "pts/pgbench-1.15.0" "pts_pgbench-read-write" \
+	"pgbench.scaling-factor=100;pgbench.clients=50;pgbench.run-mode=Read Write"

--- a/packages/schema/src/suites.test.ts
+++ b/packages/schema/src/suites.test.ts
@@ -57,7 +57,13 @@ describe("suite registry", () => {
 		// the test is exactly what the suite emits — pin the declared list to it in BOTH directions (a
 		// profile bump that adds/renames a combination fails here instead of silently stranding the
 		// list). stream's Type axis is the real matrix case; pybench and sqlite-speedtest declare no
-		// <Option> axes at all, so the pin holds over their single wildcard result.
+		// <Option> axes at all, so the pin holds over their single wildcard result. The suites that
+		// arrive later (network, cpu-generic) add themselves here.
+		// `system` is MIXED: pybench + sqlite-speedtest are unpinned wildcards (mirrored here), while
+		// pgbench is preset-pinned and declares a 4-of-160 subset — pinned to its curated override keys
+		// by the subset test below. Subtracting the pinned prefix keeps this a both-directions mirror
+		// over the unpinned half instead of dropping the suite from the gate entirely.
+		const PINNED_PREFIXES = ["pgbench_"];
 		const profilesOf = {
 			"cpu-generic": ["pts/c-ray", "pts/compress-zstd"],
 			network: ["pts/network-loopback"],
@@ -71,20 +77,25 @@ describe("suite registry", () => {
 				.map((m) => m.id)
 				.sort();
 			expect(fromCatalog.length).toBeGreaterThan(0);
-			const declared: string[] = [...SUITES[suiteName as keyof typeof SUITES].metrics];
+			const declared: string[] = [...SUITES[suiteName as keyof typeof SUITES].metrics].filter(
+				(id) => !PINNED_PREFIXES.some((prefix) => id.startsWith(prefix)),
+			);
 			expect(declared.sort()).toEqual(fromCatalog);
 		}
 	});
 
-	it("pins the fio PINNED-subset suite to its curated override keys", () => {
-		// disk (fio) deliberately declares a SUBSET of its profile's catalogued
+	it("pins the PINNED-subset suites to their curated override keys", () => {
+		// disk (fio) and system (pgbench) deliberately declare a SUBSET of their profile's catalogued
 		// combinations — the ones the producer tasks pin via PRESET_OPTIONS — so a catalog mirror
 		// can't gate them. Every declared subset id is also a curated pts-overrides key (only the
 		// producible combinations get short labels), so equality against the override keys catches a
-		// wrong-axis id here: with the full matrix catalogued, a typo'd engine or block size would
-		// otherwise pass the suite contract and just never receive samples.
+		// wrong-axis id here: with the full matrix catalogued, a typo'd engine, block size or scale
+		// would otherwise pass the suite contract and just never receive samples.
 		const overrideKeys = Object.keys(ptsOverrides);
-		const subsets = [{ suite: "disk", prefix: "fio_" }] as const;
+		const subsets = [
+			{ suite: "disk", prefix: "fio_" },
+			{ suite: "system", prefix: "pgbench_" },
+		] as const;
 		for (const { suite, prefix } of subsets) {
 			const declared: string[] = SUITES[suite].metrics.filter((id) => id.startsWith(prefix)).sort();
 			const curated = overrideKeys.filter((id) => id.startsWith(prefix)).sort();

--- a/packages/schema/src/suites.ts
+++ b/packages/schema/src/suites.ts
@@ -66,14 +66,28 @@ export const SUITES = {
 		metrics: ["node_web_tooling_runs_per_s"],
 		commands: ["mise run benchmark:cpu:node"],
 	},
-	// The system dimension: PyBench (Python interpreter) + SQLite Speedtest, both single-result PTS
-	// profiles. Lighter than cpu-node (no Node toolchain, shorter runtime), so smaller budgets.
+	// The system dimension: PyBench (Python interpreter) + SQLite Speedtest (single-result PTS
+	// profiles) + PostgreSQL via pgbench, pinned to one (scale 100, 50 clients) point per mode —
+	// each mode posts a TPS and an Average Latency metric. pgbench runs server + client fully
+	// in-sandbox (same topology on every provider). Budget: the harness sets PTS_RESPECT_TIMES_TO_RUN,
+	// so the profile's TimesToRun=3 makes SIX timed passes (3 per mode), each with its own scale-100
+	// `pgbench -i` — not the two the budgets were once described against. That and the ~1.5 GB dataset
+	// set the budgets and the disk floor. Requires the baked image (postgres pre-built, libicu-dev
+	// present); on a stock image the from-source postgres build lands inside this budget too.
 	system: {
 		setupPts: true,
-		commandTimeoutMinutes: 40,
-		timeoutMinutes: 50,
+		commandTimeoutMinutes: 80,
+		timeoutMinutes: 95,
+		minDiskGb: 5,
 		dimensions: ["system"],
-		metrics: ["pybench_milliseconds", "sqlite_speedtest_seconds"],
+		metrics: [
+			"pybench_milliseconds",
+			"sqlite_speedtest_seconds",
+			"pgbench_scaling_factor_100_clients_50_mode_read_only",
+			"pgbench_scaling_factor_100_clients_50_mode_read_only_average_latency",
+			"pgbench_scaling_factor_100_clients_50_mode_read_write",
+			"pgbench_scaling_factor_100_clients_50_mode_read_write_average_latency",
+		],
 		commands: ["mise run benchmark:system:all"],
 	},
 	// The memory dimension: STREAM (Copy/Scale/Add/Triad). Short — STREAM runs in a couple of minutes.


### PR DESCRIPTION
**PTS BENCHMARK MATRIX — vendor the PTS catalog, then light up four benchmark suites.**
Shipped as a 12-PR stack. The trunk merges bottom-up; the four suite PRs at the top are SIBLINGS and
can be reviewed (and merged) in parallel — none blocks the others.

```
main
 └─ #136  schema: scale-aware PTS metric identity (pts.scale) + O(1) matcher
     └─ #137  catalog generator: per-parser scales + virtual axes
         └─ #138  ⚙ VENDOR fio + regenerate catalog        (autogenerated)
             └─ #146  fio curation + disk headline + goldens
                 └─ #139  ⚙ VENDOR loopback/zstd/pgbench + regenerate   (autogenerated)
                     └─ #147  their curation + recorded fixtures
                         └─ #148  shared PTS runner (lib/bench.sh)
                             └─ #144  toolchain image: bake PTS deps + pin drift gates
                                 ├─ #140  disk suite     ┐
                                 ├─ #141  network suite  │  siblings — parallel review
                                 ├─ #142  cpu-generic    │
                                 └─ #143  system suite   ┘
```
⚙ = the diff is machine-produced; reproduce it with the commands in the body. Everything hand-written
was lifted out into the small PR directly above it.

↑ **This PR is #143 — SIBLING suite PR, based on #144. Reviewable in parallel with #140/#141/#142.**

---

**Stack 8/9** — based on #142

- **`benchmark:system:provider`** fingerprints which cloud the sandbox actually runs on — the metadata a provider-comparison dataset needs but no PTS profile can see. Resolves the egress ASN via Team Cymru's DNS interface (taking the first ASN on multi-origin announcements), geolocates via ipinfo, reads DMI vendor strings, and records the machine shape — one JSON provenance document per run. No catalogued metrics: identity, not performance.
- **`benchmark:system:pts:pgbench`** runs `pts/pgbench` read-only and read-write, each preset-pinned to scale 100 / 50 clients — server + client fully in-sandbox, so every provider measures the same topology. The system suite declares the four resulting metrics (TPS + Average Latency per mode) with budgets raised for the two 120s timed passes and the ~1.5 GB scale-100 dataset (80/95 min, 5 GB disk floor).
- The pinned-subset registry test now covers pgbench alongside fio.

**LOC**: 237 hand-written. Gate green (544 tests, shellcheck).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BHkDUJmxVAz1sCWFcS9btJ

---
_Generated by [Claude Code](https://claude.ai/code/session_01BHkDUJmxVAz1sCWFcS9btJ)_

## Validation

Every branch in this stack was checked out **in isolation** (i.e. on top of its own parent, with
nothing from the PRs above it) and run through the full gate set. A reviewer merges bottom-up, so
each PR has to stand on its own — this is what verifies that.

**This PR (`08`), verified standalone — all seven gates green:**

| gate | command | result |
|---|---|---|
| install | `bun install --frozen-lockfile` | ✅ |
| typecheck | `bun run typecheck` | ✅ |
| lint | `bun run lint` (biome, `--error-on-warnings`) | ✅ |
| spell | `mise exec -- typos` | ✅ |
| shell | `bun run lint:shell` (shellcheck) | ✅ |
| catalog drift | `bun run check:catalog-drift` | ✅ |
| tests | `bun run test` (whole workspace) | ✅ **577 passing, 0 failing** |

The same matrix is green on all 12 branches, and the passing-test count climbs monotonically up the
trunk (535 → 576) — each PR adds coverage and none regresses it.

**What this PR's own tests prove:**

- `shellcheck` over the provider probe and the pgbench leaves.
- The pgbench subset is pinned to its curated override keys; the unpinned half of the `system` suite (pybench, sqlite-speedtest) is mirrored against the catalog.

### What this does NOT prove

Being explicit, because the gates above are all static:

- **No benchmark has been run on a real provider sandbox.** Nothing in CI executes the `.mise` producer
  tasks against a live Phoronix Test Suite. Their correctness rests on `shellcheck`, on the golden
  byte-match gate (which compares against RECORDED composites — real PTS output, but replayed, not
  produced), and on the suite-contract tests. The first live signal is the `bench-smoke` workflow
  (manual dispatch) after these merge.
- **The image is only built by CI on #144** — it is the only PR that touches it. The suite PRs assume
  that image; they do not rebuild it.
- `Bake, validate & promote toolchain` is skipped on pull requests by design
  (`if: github.event_name != 'pull_request'`), so image PROMOTION is exercised only on `main`.
- The recorded fixtures prove byte-match against PTS output captured at a point in time; a future PTS
  release could change a `<Description>` string. That is precisely what the golden gate would catch.

Additionally, the four suite PRs at the top are siblings on #144; merging all four reproduces the
pre-restructure tree byte-for-byte (verified), so the 12-PR split moved every change and dropped none.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a provider-identification task and integrates `pgbench` into the system suite to attribute runs to the underlying infra and measure PostgreSQL TPS/latency with a fully in-sandbox server/client. Raises budgets, sets a disk floor, updates run order, schema, and tests, and writes a per-run JSON provenance record.

- **New Features**
  - `benchmark:system:provider`: egress ASN/org via Team Cymru DNS (MOAS-first), geo via ipinfo; reverse DNS; DMI vendor/product, BIOS, virt; CPU model/cores, kernel, RAM. Prints a summary, writes one JSON per run, and never fails the suite.
  - `benchmark:system:pts:pgbench` pinned to `pts/pgbench-1.15.0`: Read Only and Read Write at scale 100 with 50 clients; server and client run in-sandbox. Declares four metrics (TPS + average latency per mode). System suite budgets set to 80/95 minutes with `minDiskGb` 5; run order: PTS setup → provider probe → PyBench → SQLite → `pgbench` (PTS setup first so its apt fallback installs `dig`/`jq`). Schema adds the four pgbench metrics; tests pin the `pgbench_` subset to curated `ptsOverrides` and mirror only the unpinned half.

- **Bug Fixes**
  - Probe hardening: force IPv4 on all legs, validate responses, retry Cymru after ipinfo backfills the public IP, and record `geo_source="no-jq"` when `jq` is absent.

<sup>Written for commit 5489fefe18cb72f44407345f706777510287df69. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/starslingdev/sandbox-benchmarks/pull/143?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added provider identity and infrastructure details to system benchmark results.
  * Added PostgreSQL `pgbench` read-only and read-write throughput and latency benchmarks.
  * Expanded system benchmark metrics and increased resource and timeout allowances.

* **Bug Fixes**
  * Improved suite metric validation for pinned benchmark metrics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->