### PR TITLE
fix(leaderboard): stop reporting an untestable comparison as a statistical tie

### DIFF
--- a/LEADERBOARD.md
+++ b/LEADERBOARD.md
@@ -11,7 +11,7 @@ Headline: **Node.js web tooling** (runs/s, higher is better)
 | Rank | Provider | Node.js web tooling (runs/s) | 95% CI | n | p vs. above | p (KS) |
 | ---: | --- | ---: | ---: | ---: | ---: | ---: |
 | 1 | Daytona | 19.72 | 19.63 – 19.96 | 3 | — | — |
-| 1 | Modal | 9.59 | 9.52 – 9.79 | 3 | 0.081 (tied) | 0.033 |
+| 2 | Modal | 9.59 | 9.52 – 9.79 | 3 | 0.10 (n too small) | 0.033 |
 
 ## memory
 
@@ -20,7 +20,7 @@ Headline: **STREAM Triad** (MB/s, higher is better)
 | Rank | Provider | STREAM Triad (MB/s) | 95% CI | n | p vs. above | p (KS) |
 | ---: | --- | ---: | ---: | ---: | ---: | ---: |
 | 1 | Daytona | 54530 | 54030 – 54590 | 5 | — | — |
-| 2 | Modal | 40510 | 38810 – 53440 | 5 | 0.012 | 0.0038 |
+| 2 | Modal | 40510 | 38810 – 53440 | 5 | 0.0079 | 0.0038 |
 
 ## economics
 
@@ -72,12 +72,14 @@ percentile bootstrap of that median (10,000 resamples, seeded from the Run id so
 reproducible byte-for-byte), not a normal-theory interval: these Samples are neither normal nor
 independent of the host's scheduling.
 
-Rows are separated only when their full Sample distributions differ (Mann-Whitney U, two-sided, α = 0.05).
-**Providers sharing a rank are statistically indistinguishable on this Metric** — a faster median
-earned inside the noise is not a faster provider. Samples are repeated trials inside one sandbox,
-so their spread is environmental (neighbours, host contention, virtualization), and a wide CI or a
-large `n` (the harness re-runs a test that will not converge) is itself the signal that the
-provider's performance is unstable, not that the measurement is imprecise.
+Rows are separated only when their full Sample distributions differ (Mann-Whitney U, two-sided, α = 0.05,
+enumerated exactly over the permutation null rather than approximated — at these sample sizes the
+normal approximation can report a p the exact test cannot actually produce).
+
+Samples are repeated trials inside one sandbox, so their spread is environmental (neighbours, host
+contention, virtualization), and a wide CI or a large `n` (the harness re-runs a test that will not
+converge) is itself the signal that the provider's performance is unstable, not that the measurement
+is imprecise.
 
 `p (KS)` is a two-sample Kolmogorov-Smirnov test against the same row above. It does **not** drive
 the ranking — it compares the two empirical distributions' *shapes* rather than their central
@@ -88,4 +90,12 @@ looks like, and it is the reason a median alone cannot rank these providers.
 
 At the small `n` this suite produces, a non-significant result means *not enough evidence to
 separate*, never *the providers are equal*.
+
+`n too small` is the extreme of that: Mann-Whitney's best attainable p already exceeds α for those
+Samples, so the test could not have separated the rows at any effect size (here 3 v 3 floors at p ≈ 0.10).
+Such rows are ranked on their observed medians and are **not** claimed to be tied — read the gap
+between the values, and treat the p-value as unable to settle them either way. Where such a row
+nevertheless shares the rank above it, the cell reads `equal medians`: the two values are simply
+identical, which is the ranking having nothing to order them by — never a finding that the
+providers are alike.
 

--- a/packages/results/src/lib/leaderboard.test.ts
+++ b/packages/results/src/lib/leaderboard.test.ts
@@ -150,7 +150,8 @@ describe("buildLeaderboard statistical ranking", () => {
 			[2, "modal"],
 		]);
 		const modal = rows[1];
-		expect(modal?.separated).toBe(true);
+		expect(modal?.verdict).toBe("separated");
+		expect(modal?.tiedWithAbove).toBeNull();
 		expect(modal?.pVsPrevious?.mannWhitney).toBeLessThan(0.05);
 		expect(modal?.pVsPrevious?.ks).toBeLessThan(0.05);
 	});
@@ -165,9 +166,10 @@ describe("buildLeaderboard statistical ranking", () => {
 			]),
 		);
 		const rows = board.dimensions.find((d) => d.dimension === "cpu")?.rows ?? [];
-		// e2b sorts first on the median, but cannot be separated → both hold rank 1.
+		// e2b sorts first on the median, but cannot be separated → both hold rank 1, on the test's verdict.
 		expect(rows.map((r) => r.rank)).toEqual([1, 1]);
-		expect(rows[1]?.separated).toBe(false);
+		expect(rows[1]?.verdict).toBe("tied");
+		expect(rows[1]?.tiedWithAbove).toBe("statistical");
 		expect(rows[1]?.pVsPrevious?.mannWhitney).toBeGreaterThan(0.05);
 	});
 
@@ -185,7 +187,7 @@ describe("buildLeaderboard statistical ranking", () => {
 			[1, "modal"],
 			[2, "daytona"],
 		]);
-		expect(rows[1]?.separated).toBeNull();
+		expect(rows[1]?.verdict).toBe("untested");
 		expect(rows[1]?.pVsPrevious).toBeNull();
 		expect(rows[0]?.interval.resamples).toBe(0);
 	});
@@ -277,6 +279,157 @@ describe("renderLeaderboardMarkdown statistics", () => {
 			),
 		);
 		expect(md).toContain("<0.001");
+	});
+});
+
+describe("underpowered comparisons", () => {
+	const HEADLINE = "node_web_tooling_runs_per_s";
+
+	it("does not claim a tie when the sample sizes make the test structurally powerless", () => {
+		// 3 v 3, completely separated and 2x apart: Mann-Whitney's best attainable p (0.1) is already above
+		// α, so the old code grouped these at rank 1 — reporting the trial count as a finding about the
+		// providers. Rank on value, return the `underpowered` verdict, and say so in the cell.
+		const board = buildLeaderboard(
+			run([
+				provider("daytona", [metric(HEADLINE, [19.63, 19.72, 19.96])]),
+				provider("modal", [metric(HEADLINE, [9.79, 9.52, 9.59])]),
+			]),
+		);
+		const rows = board.dimensions.find((d) => d.dimension === "cpu")?.rows ?? [];
+		expect(rows.map((r) => [r.displayName, r.rank, r.verdict, r.tiedWithAbove])).toEqual([
+			["Daytona", 1, null, null],
+			["Modal", 2, "underpowered", null],
+		]);
+		const md = renderLeaderboardMarkdown(board);
+		expect(md).toContain("(n too small)");
+		expect(md).not.toContain("(tied)");
+	});
+
+	it("quotes each underpowered row's own floor, not one recomputed from its sample sizes", () => {
+		// A 4-v-3 comparison is still underpowered, but floors at 2/C(7,4) ≈ 0.057, not 3 v 3's 0.1. The
+		// footer must quote the shape the table actually contains, or it explains a number no row has.
+		const md = renderLeaderboardMarkdown(
+			buildLeaderboard(
+				run([
+					provider("daytona", [metric(HEADLINE, [19.6, 19.7, 19.9, 20.1])]),
+					provider("modal", [metric(HEADLINE, [9.5, 9.6, 9.8])]),
+				]),
+			),
+		);
+		expect(md).toContain("(here 4 v 3 floors at p ≈ 0.057)");
+		expect(md).not.toContain("0.1)");
+	});
+
+	it("omits the n-too-small explanation entirely when no comparison was underpowered", () => {
+		const md = renderLeaderboardMarkdown(
+			buildLeaderboard(
+				run([
+					provider("daytona", [metric(HEADLINE, [10, 11, 12, 13, 14])]),
+					provider("modal", [metric(HEADLINE, [1, 2, 3, 4, 5])]),
+				]),
+			),
+		);
+		expect(md).not.toContain("n too small");
+		expect(md).not.toContain("floors at p");
+	});
+
+	it("SHARES a rank between underpowered rows whose medians are exactly equal — on the VALUE, not a tie", () => {
+		// Ranking on the value cannot split rows that HAVE the same value: an underpowered comparison must
+		// not let the providerId sort tie-break decide who is faster. But the shared rank is the equality
+		// speaking, not the test — so the row records WHY it shares it, and the cell says so. The footer
+		// used to flatly assert underpowered rows are "not claimed to be tied" while this branch quietly
+		// gave them the same rank; now the two agree because the basis is a field, not a footnote.
+		const board = buildLeaderboard(
+			run([
+				provider("modal", [metric(HEADLINE, [9, 10, 11])]),
+				provider("daytona", [metric(HEADLINE, [8, 10, 12])]),
+			]),
+		);
+		const rows = board.dimensions.find((d) => d.dimension === "cpu")?.rows ?? [];
+		expect(rows.map((r) => [r.providerId, r.value, r.rank])).toEqual([
+			["daytona", 10, 1],
+			["modal", 10, 1],
+		]);
+		expect(rows[1]?.verdict).toBe("underpowered");
+		expect(rows[1]?.tiedWithAbove).toBe("identical-value");
+		const md = renderLeaderboardMarkdown(board);
+		// The cell distinguishes the two reasons the rank is shared; it never reads as a statistical tie.
+		expect(md).toContain("(n too small, equal medians)");
+		expect(md).not.toContain("(tied)");
+	});
+
+	it("marks a shared rank between untested (n<2) rows with equal values as equal, not tied", () => {
+		const board = buildLeaderboard(
+			run([
+				provider("daytona", [metric(ECONOMICS_METRIC_IDS.usdPerHour, [0.2])]),
+				provider("modal", [metric(ECONOMICS_METRIC_IDS.usdPerHour, [0.2])]),
+			]),
+		);
+		const rows = board.dimensions.find((d) => d.dimension === "economics")?.rows ?? [];
+		expect(rows.map((r) => [r.rank, r.verdict, r.tiedWithAbove])).toEqual([
+			[1, null, null],
+			[1, "untested", "identical-value"],
+		]);
+		expect(renderLeaderboardMarkdown(board)).toContain("— (equal values)");
+	});
+
+	it("never marks a row `tied` unless the test could have separated it", () => {
+		// The invariant behind the whole fix: `tied` is a verdict, and a verdict requires the power to have
+		// reached the opposite one. An underpowered comparison may share a rank, but never on that basis.
+		const board = buildLeaderboard(
+			run([
+				provider("daytona", [metric(HEADLINE, [19.63, 19.72, 19.96])]),
+				provider("modal", [metric(HEADLINE, [9.79, 9.52, 9.59])]),
+				provider("e2b", [metric(HEADLINE, [9.79, 9.52, 9.59])]),
+			]),
+		);
+		const rows = board.dimensions.find((d) => d.dimension === "cpu")?.rows ?? [];
+		for (const row of rows) {
+			if (row.verdict === "underpowered") expect(row.tiedWithAbove).not.toBe("statistical");
+			if (row.tiedWithAbove === "statistical") expect(row.verdict).toBe("tied");
+		}
+	});
+
+	it("still groups a genuine statistical tie when the test HAD the power to separate", () => {
+		// 8 v 8 near-identical samples: the test could have separated them (its floor is well under α) and
+		// did not, so this is a real tie and the rows must share a rank — the underpowered guard must not
+		// swallow the tie case it sits next to.
+		const near = [10, 10.1, 9.9, 10.2, 9.8, 10.05, 9.95, 10.15];
+		const board = buildLeaderboard(
+			run([
+				provider("daytona", [metric(HEADLINE, near)]),
+				provider("modal", [
+					metric(
+						HEADLINE,
+						near.map((v) => v - 0.01),
+					),
+				]),
+			]),
+		);
+		const rows = board.dimensions.find((d) => d.dimension === "cpu")?.rows ?? [];
+		expect(rows.map((r) => [r.rank, r.verdict, r.tiedWithAbove])).toEqual([
+			[1, null, null],
+			[1, "tied", "statistical"],
+		]);
+		expect(renderLeaderboardMarkdown(board)).toContain("(tied)");
+	});
+
+	it("does not let the tie-corrected approximation crown a provider the exact test cannot separate", () => {
+		// The reported bug, end to end: mannWhitneyU([1,1,1],[2,2,2]) returned p = 0.047 under the normal
+		// approximation — below α, and below the 0.081 that was claimed as the 3-v-3 floor. Had the guard
+		// not (accidentally) blocked it first, that p would have SEPARATED these two providers on evidence
+		// the permutation null cannot produce. Exactly: p = 0.1, and 3 v 3 stays untestable.
+		const board = buildLeaderboard(
+			run([
+				provider("daytona", [metric(HEADLINE, [2, 2, 2])]),
+				provider("modal", [metric(HEADLINE, [1, 1, 1])]),
+			]),
+		);
+		const rows = board.dimensions.find((d) => d.dimension === "cpu")?.rows ?? [];
+		expect(rows[1]?.pVsPrevious?.mannWhitney).toBeCloseTo(0.1, 12);
+		expect(rows[1]?.pVsPrevious?.floor).toBeCloseTo(0.1, 12);
+		expect(rows[1]?.verdict).toBe("underpowered");
+		expect(rows[1]?.verdict).not.toBe("separated");
 	});
 });
 

--- a/packages/results/src/lib/leaderboard.ts
+++ b/packages/results/src/lib/leaderboard.ts
@@ -25,6 +25,7 @@ import type {
 } from "@sandbox-benchmarks/schema";
 import {
 	bootstrapMedianInterval,
+	canSeparate,
 	DEFAULT_ALPHA,
 	DIMENSIONS,
 	getProvider,
@@ -59,10 +60,37 @@ export interface LeaderboardRow {
 	 * Both are rendered: `mannWhitney` as `p vs. above`, `ks` as `p (KS)`. Only `mannWhitney` decides the
 	 * rank; `ks` is shown so a reader can see the two disagree.
 	 */
-	pVsPrevious: { mannWhitney: number; ks: number } | null;
-	/** Whether this row is statistically separable from the one above it. `null` for rank 1. */
-	separated: boolean | null;
+	pVsPrevious: { mannWhitney: number; ks: number; floor: number } | null;
+	/**
+	 * What the test said about this row and the one above it (`null` for rank 1, which has nothing above):
+	 *
+	 *  - `separated`    — the distributions differ (p < α). This row ranks strictly below the one above.
+	 *  - `tied`         — the test ran, could have separated them, and did not. A real statistical tie.
+	 *  - `underpowered` — the test COULD NOT have separated them at any effect size: its best attainable
+	 *    p already exceeds α. That is a fact about the trial count, not about the providers, and it is
+	 *    not a tie. See {@link tiedWithAbove} for what the rank then means.
+	 *  - `untested`     — fewer than 2 Samples on a side: no distribution to test at all.
+	 */
+	verdict: ComparisonVerdict | null;
+	/**
+	 * Why this row shares the rank above it — and `null` exactly when it does NOT share it. Every shared
+	 * rank states its reason, because "same rank" means two different things and conflating them is how a
+	 * table comes to claim a tie it never established:
+	 *
+	 *  - `statistical`    — the test ran and could not tell them apart. THIS is the statistical tie.
+	 *  - `identical-value` — their values are exactly equal, so the ranking has nothing to order them by.
+	 *    It says nothing about the distributions; it is what stops the providerId sort tie-break from
+	 *    silently deciding which of two identical published prices "wins". An `underpowered` row can share
+	 *    a rank on this basis, and when it does, the shared rank is NOT a claim that they are alike.
+	 */
+	tiedWithAbove: TieBasis | null;
 }
+
+/** What the pairwise Mann-Whitney test said about a row and the one above it. */
+export type ComparisonVerdict = "separated" | "tied" | "underpowered" | "untested";
+
+/** Why a row shares the rank above it. See {@link LeaderboardRow.tiedWithAbove}. */
+export type TieBasis = "statistical" | "identical-value";
 
 /** One Dimension's ranked comparison on its headline Metric. */
 export interface LeaderboardDimension {
@@ -234,7 +262,8 @@ export function buildLeaderboard(run: Run): Leaderboard {
 				n: result.aggregates.n,
 				stdev: result.aggregates.stdev,
 				pVsPrevious: null,
-				separated: null,
+				verdict: null,
+				tiedWithAbove: null,
 			};
 			return [{ samples: result.samples, row }];
 		});
@@ -265,23 +294,63 @@ export function buildLeaderboard(run: Run): Leaderboard {
 				candidate.row.rank = 1;
 				return;
 			}
+			// A row shares the rank above it EXACTLY when it has a reason to, and the reason is recorded.
+			// That invariant is the whole defence against the table claiming a tie it never established: a
+			// shared rank always answers "on what basis?", and the renderer prints the answer.
+			const settle = (basis: TieBasis | null): void => {
+				candidate.row.tiedWithAbove = basis;
+				candidate.row.rank = basis === null ? i + 1 : previous.row.rank;
+			};
+			// Exactly equal values cannot be ordered by a ranking that ranks on the value. Whenever no
+			// verdict is available to override that, they must share a rank — otherwise the providerId sort
+			// tie-break alone would split two providers with an identical published price.
+			const identical = candidate.row.value === previous.row.value;
+
 			// A single Sample is not a distribution: there is nothing to test, and the value is typically
 			// exact rather than measured (a Metric like `usd_per_hour` is a published price, not a trial).
 			// Rank such rows on the value and mark them untested, rather than declaring every provider
-			// "indistinguishable" because a one-trial comparison can never reach significance. Exactly
-			// equal values are a genuine tie, though, and must share a rank — otherwise two providers
-			// with an identical published price would be split by the providerId sort tie-break alone.
+			// "indistinguishable" because a one-trial comparison can never reach significance.
 			if (previous.samples.length < 2 || candidate.samples.length < 2) {
-				candidate.row.rank = candidate.row.value === previous.row.value ? previous.row.rank : i + 1;
+				candidate.row.verdict = "untested";
+				settle(identical ? "identical-value" : null);
 				return;
 			}
+
 			const mw = mannWhitneyU(previous.samples, candidate.samples);
 			const ks = kolmogorovSmirnov(previous.samples, candidate.samples);
-			const separated = mw.pValue < DEFAULT_ALPHA;
-			candidate.row.pVsPrevious = { mannWhitney: mw.pValue, ks: ks.pValue };
-			candidate.row.separated = separated;
-			// Not separable → inherit the rank above. Separable → this row's ordinal position.
-			candidate.row.rank = separated ? i + 1 : previous.row.rank;
+			candidate.row.pVsPrevious = {
+				mannWhitney: mw.pValue,
+				ks: ks.pValue,
+				floor: mw.minAttainablePValue,
+			};
+
+			// The same "a test that can never reach α is not evidence of sameness" rule as the n<2 case
+			// above, applied where it actually bites: Mann-Whitney's p has a FLOOR, and at 3 v 3 that floor
+			// (0.1) is already above α. Grouping those rows would print "statistically tied" for a provider
+			// running at half the speed of the one above it — a fact about the trial count masquerading as a
+			// fact about the providers. Claim no verdict, rank on the observed value, and let the rendering
+			// disclose that the comparison was untestable.
+			//
+			// The floor comes from the test itself (it depends on the tie pattern, not just the sample
+			// sizes), so the guard and the p-value it guards are answers about the same enumerated null and
+			// cannot disagree.
+			if (!canSeparate(mw)) {
+				candidate.row.verdict = "underpowered";
+				// An underpowered row can still share a rank — but only ever because the two values are
+				// identical, never because the test "found no difference". The basis says which, so the
+				// renderer and the footer can keep the two apart.
+				settle(identical ? "identical-value" : null);
+				return;
+			}
+
+			if (mw.pValue < DEFAULT_ALPHA) {
+				candidate.row.verdict = "separated";
+				settle(null);
+				return;
+			}
+			// The test could have separated them and did not: a real statistical tie.
+			candidate.row.verdict = "tied";
+			settle("statistical");
 		});
 
 		dimensions.push({ dimension, metric, rows: candidates.map((c) => c.row) });
@@ -294,6 +363,27 @@ export function buildLeaderboard(run: Run): Leaderboard {
 		dimensions,
 		coverageGaps: coverageGapsOf(run),
 	};
+}
+
+/**
+ * Describe every underpowered comparison the board actually contains, as `"3 v 3 floors at p ≈ 0.1"` —
+ * quoting the floor THE TEST REPORTED for that row, not one recomputed from the sample sizes here. The
+ * floor depends on the tie pattern as well as the sizes, so a footer that re-derived it from `n` alone
+ * could print a number the row's own test never produced. An underpowered row is always compared against
+ * the row above it, which is what supplies the other n. Deduplicated (several dimensions usually share
+ * one shape) and ordered so the committed markdown stays byte-stable.
+ */
+function underpoweredFloors(board: Leaderboard): string[] {
+	const seen = new Map<string, string>();
+	for (const { rows } of board.dimensions) {
+		rows.forEach((row, i) => {
+			const previous = rows[i - 1];
+			if (row.verdict !== "underpowered" || !previous || !row.pVsPrevious) return;
+			const key = `${previous.n} v ${row.n}`;
+			seen.set(key, `${key} floors at p ≈ ${formatPValue(row.pVsPrevious.floor)}`);
+		});
+	}
+	return [...seen.entries()].sort(([a], [b]) => a.localeCompare(b, "en")).map(([, text]) => text);
 }
 
 /**
@@ -346,14 +436,23 @@ export function renderLeaderboardMarkdown(board: Leaderboard): string {
 					r.interval.resamples === 0
 						? "—"
 						: `${formatValue(r.interval.lo)} – ${formatValue(r.interval.hi)}`;
-				// A tied rank is the interesting case: say so in the cell rather than leaving the reader
-				// to infer it from two rows sharing a number.
+				// Every shared rank says why, in the cell — a reader must never have to infer the reason from
+				// two rows carrying the same number. The three are distinct claims: `tied` is a verdict the
+				// test reached; `n too small` is the ABSENCE of one (it could not have separated them at any
+				// effect size, so it must not read as a tie); `equal medians` is arithmetic (the ranking sorts
+				// on the value, and it cannot order two values that are the same). The last can co-occur with
+				// `n too small`, and when it does, the shared rank is the equality speaking, not the test.
+				const equalValues = r.tiedWithAbove === "identical-value";
 				const p =
 					r.pVsPrevious === null
-						? "—"
-						: r.separated
-							? formatPValue(r.pVsPrevious.mannWhitney)
-							: `${formatPValue(r.pVsPrevious.mannWhitney)} (tied)`;
+						? equalValues
+							? "— (equal values)"
+							: "—"
+						: r.verdict === "underpowered"
+							? `${formatPValue(r.pVsPrevious.mannWhitney)} (n too small${equalValues ? ", equal medians" : ""})`
+							: r.verdict === "tied"
+								? `${formatPValue(r.pVsPrevious.mannWhitney)} (tied)`
+								: formatPValue(r.pVsPrevious.mannWhitney);
 				// KS is rendered, not just stored: it is the only column that exposes a provider whose
 				// median matches its neighbour's while its distribution is bimodal. A small `p (KS)` beside
 				// a large, tied `p vs. above` is exactly that case — same typical speed, different machine.
@@ -426,12 +525,44 @@ export function renderLeaderboardMarkdown(board: Leaderboard): string {
 		"reproducible byte-for-byte), not a normal-theory interval: these Samples are neither normal nor",
 		"independent of the host's scheduling.",
 		"",
-		`Rows are separated only when their full Sample distributions differ (Mann-Whitney U, two-sided, α = ${DEFAULT_ALPHA}).`,
-		"**Providers sharing a rank are statistically indistinguishable on this Metric** — a faster median",
-		"earned inside the noise is not a faster provider. Samples are repeated trials inside one sandbox,",
-		"so their spread is environmental (neighbours, host contention, virtualization), and a wide CI or a",
-		"large `n` (the harness re-runs a test that will not converge) is itself the signal that the",
-		"provider's performance is unstable, not that the measurement is imprecise.",
+		`Rows are separated only when their full Sample distributions differ (Mann-Whitney U, two-sided, α = ${DEFAULT_ALPHA},`,
+		"enumerated exactly over the permutation null rather than approximated — at these sample sizes the",
+		"normal approximation can report a p the exact test cannot actually produce).",
+		"",
+	);
+
+	// A shared rank means different things, and the footer must explain exactly the ones the table
+	// contains — no more (a legend for an absent case teaches the reader to skim) and no less (an
+	// unexplained shared rank is read as a tie, which is the misreading this whole section exists to
+	// prevent). Collected from the rows themselves, so the prose cannot drift from the table.
+	const rows = board.dimensions.flatMap((d) => d.rows);
+	const sharedRankReasons: string[] = [];
+	if (rows.some((r) => r.tiedWithAbove === "statistical")) {
+		sharedRankReasons.push(
+			"`(tied)` — the test could have separated those providers and did not, so a faster median earned",
+			"inside the noise is not a faster provider. This is the only one that claims two providers are",
+			"statistically indistinguishable.",
+		);
+	}
+	if (rows.some((r) => r.tiedWithAbove === "identical-value")) {
+		sharedRankReasons.push(
+			"`(equal medians)` / `(equal values)` — arithmetic, not a finding: the ranking sorts on the value,",
+			"and two identical values have no order between them. It says nothing about the distributions.",
+		);
+	}
+	if (sharedRankReasons.length > 0) {
+		lines.push(
+			"**A shared rank always says why, in the `p vs. above` cell, and the reasons are not interchangeable.**",
+			...sharedRankReasons,
+			"",
+		);
+	}
+
+	lines.push(
+		"Samples are repeated trials inside one sandbox, so their spread is environmental (neighbours, host",
+		"contention, virtualization), and a wide CI or a large `n` (the harness re-runs a test that will not",
+		"converge) is itself the signal that the provider's performance is unstable, not that the measurement",
+		"is imprecise.",
 		"",
 		"`p (KS)` is a two-sample Kolmogorov-Smirnov test against the same row above. It does **not** drive",
 		"the ranking — it compares the two empirical distributions' *shapes* rather than their central",
@@ -444,6 +575,23 @@ export function renderLeaderboardMarkdown(board: Leaderboard): string {
 		"separate*, never *the providers are equal*.",
 		"",
 	);
+
+	// `n too small` needs explaining only when the table actually contains one, and the floor it cites is
+	// the one those rows' own tests reported — a hardcoded example would misquote both the floor and the n
+	// the moment a run pairs, say, 3 trials against 4.
+	const floors = underpoweredFloors(board);
+	if (floors.length > 0) {
+		lines.push(
+			"`n too small` is the extreme of that: Mann-Whitney's best attainable p already exceeds α for those",
+			`Samples, so the test could not have separated the rows at any effect size (here ${floors.join("; ")}).`,
+			"Such rows are ranked on their observed medians and are **not** claimed to be tied — read the gap",
+			"between the values, and treat the p-value as unable to settle them either way. Where such a row",
+			"nevertheless shares the rank above it, the cell reads `equal medians`: the two values are simply",
+			"identical, which is the ranking having nothing to order them by — never a finding that the",
+			"providers are alike.",
+			"",
+		);
+	}
 
 	return `${lines.join("\n")}\n`;
 }

--- a/packages/schema/src/analysis.test.ts
+++ b/packages/schema/src/analysis.test.ts
@@ -2,6 +2,8 @@ import { describe, expect, it } from "bun:test";
 import {
 	aggregate,
 	bootstrapMedianInterval,
+	canSeparate,
+	DEFAULT_ALPHA,
 	kolmogorovSmirnov,
 	mannWhitneyU,
 	percentileOf,
@@ -186,14 +188,14 @@ describe("bootstrapMedianInterval", () => {
 });
 
 describe("mannWhitneyU", () => {
-	// Values cross-checked against an independent implementation of the same normal approximation
-	// (tie- and continuity-corrected) and against exact enumeration of the permutation null.
-	it("separates disjoint samples (exact p = 0.0079; the normal approximation is conservative)", () => {
+	// Values cross-checked against exact enumeration of the permutation null (every C(N,nA) split), which
+	// is what the implementation now does at these sizes rather than approximating it.
+	it("separates disjoint samples (exact p = 2/C(10,5) = 0.0079)", () => {
 		const r = mannWhitneyU([1, 2, 3, 4, 5], [6, 7, 8, 9, 10]);
 		expect(r.statistic).toBe(0);
-		expect(r.pValue).toBeCloseTo(0.012186, 5);
-		// Conservative: the approximation never claims MORE significance than exact enumeration.
-		expect(r.pValue).toBeGreaterThan(0.007937);
+		// Complete separation: 2 of the 252 splits are this extreme. The normal approximation reported
+		// 0.0122 here — close, but it is the same machinery that reported an IMPOSSIBLE 0.047 at 3 v 3.
+		expect(r.pValue).toBeCloseTo(2 / 252, 12);
 		expect(r.pValue).toBeLessThan(0.05);
 	});
 
@@ -201,10 +203,12 @@ describe("mannWhitneyU", () => {
 		expect(mannWhitneyU([5, 5, 5, 5, 5], [5, 5, 5, 5, 5]).pValue).toBe(1);
 	});
 
-	it("applies the tie correction", () => {
+	it("handles ties exactly, by conditioning on the observed midranks", () => {
+		// The exact test conditions on the rank multiset, so ties need no variance correction — they are
+		// already in the null it enumerates. (48 of the 252 splits are at least this extreme.)
 		const r = mannWhitneyU([1, 2, 2, 3, 3], [2, 3, 3, 4, 5]);
 		expect(r.statistic).toBe(5);
-		expect(r.pValue).toBeCloseTo(0.126379, 5);
+		expect(r.pValue).toBeCloseTo(48 / 252, 12);
 	});
 
 	it("is symmetric in its arguments (U is the min of the two rank sums)", () => {
@@ -292,5 +296,99 @@ describe("kolmogorovSmirnov", () => {
 		// reason the guard exists, not a style check. (Verified: the pre-guard call had to be killed.)
 		expect(() => kolmogorovSmirnov([Number.NaN, 1], [1, 2])).toThrow(/finite samples/);
 		expect(() => kolmogorovSmirnov([1, 2], [Number.NaN])).toThrow(/finite samples/);
+	});
+});
+
+describe("the attainable p-floor / canSeparate", () => {
+	it("reports the floor as the p the test itself yields under complete separation", () => {
+		// The floor must be the SAME number the test yields under complete separation — otherwise the guard
+		// and the test disagree and rows get grouped on a threshold nothing enforces.
+		const separated = mannWhitneyU([1, 2, 3], [4, 5, 6]);
+		expect(separated.pValue).toBeCloseTo(0.1, 12); // 2 / C(6,3)
+		expect(separated.minAttainablePValue).toBeCloseTo(separated.pValue, 12);
+		// The floor is a property of the comparison, not of the data's effect size: a middling 3 v 3 quotes
+		// the same floor as a perfectly-separated one.
+		expect(mannWhitneyU([1, 4, 5], [2, 3, 6]).minAttainablePValue).toBeCloseTo(0.1, 12);
+	});
+
+	it("is a floor no data of that shape can dip below — including tied data", () => {
+		// The bug this guards: the normal approximation's tie correction shrinks the variance, so
+		// [1,1,1] v [2,2,2] returned p = 0.047 — under α, and under the 0.081 that was claimed as the 3-v-3
+		// floor. The exact null cannot produce anything below 0.1 at 3 v 3, tied or not.
+		const tied = mannWhitneyU([1, 1, 1], [2, 2, 2]);
+		expect(tied.pValue).toBeCloseTo(0.1, 12);
+		expect(tied.pValue).toBeGreaterThanOrEqual(tied.minAttainablePValue);
+		expect(canSeparate(tied)).toBe(false);
+	});
+
+	it("takes the floor from the tie pattern, not from the sample sizes alone", () => {
+		// Ties break the permutation null's mirror symmetry, so a lone split can stand at the extreme and
+		// halve the floor: 1 v 2 floors at 2/3 untied, but at 1/3 when the pair is tied. A size-only floor
+		// is therefore either wrong or needlessly pessimistic — this one is neither.
+		expect(mannWhitneyU([2], [1, 3]).minAttainablePValue).toBeCloseTo(2 / 3, 12);
+		expect(mannWhitneyU([2], [1, 1]).minAttainablePValue).toBeCloseTo(1 / 3, 12);
+	});
+
+	it("says 3 v 3 cannot separate at α=0.05 however extreme the data", () => {
+		// The whole point: at 3 trials a side the best possible p is already above α, so a non-significant
+		// result there is a fact about the trial count, not about the providers.
+		const extreme = mannWhitneyU([1, 2, 3], [100, 200, 300]);
+		expect(canSeparate(extreme)).toBe(false);
+		expect(extreme.pValue).toBeGreaterThan(0.05);
+	});
+
+	it("says 5 v 5 can separate — the floor drops under α", () => {
+		const separated = mannWhitneyU([1, 2, 3, 4, 5], [10, 20, 30, 40, 50]);
+		expect(canSeparate(separated)).toBe(true);
+		expect(separated.minAttainablePValue).toBeLessThan(0.05); // 2 / C(10,5) ≈ 0.0079
+		expect(separated.pValue).toBeLessThan(0.05);
+	});
+
+	it("honours a caller-supplied alpha", () => {
+		// 3 v 3 becomes testable only if you loosen α past its floor.
+		expect(canSeparate(mannWhitneyU([1, 2, 3], [4, 5, 6]), 0.1)).toBe(false); // floor is 0.1, not < 0.1
+		expect(canSeparate(mannWhitneyU([1, 2, 3], [4, 5, 6]), 0.2)).toBe(true);
+	});
+});
+
+describe("mannWhitneyU exactness", () => {
+	it("enumerates the permutation null instead of approximating it at these sample sizes", () => {
+		const test = mannWhitneyU([1, 2, 3], [4, 5, 6]);
+		expect(test.method).toBe("exact");
+		// Complete separation of 3 v 3: exactly 2 of the C(6,3)=20 splits are this extreme.
+		expect(test.pValue).toBeCloseTo(2 / 20, 12);
+	});
+
+	it("never returns a p below its own floor, however the ties fall", () => {
+		// The invariant the ranking leans on: `underpowered` (floor ≥ α) must imply "not significant". If a
+		// p could slip under its floor, the guard would be denying a separation the test had just made.
+		const shapes: Array<[number[], number[]]> = [
+			[
+				[1, 1, 1],
+				[2, 2, 2],
+			],
+			[
+				[1, 1],
+				[1, 2, 2],
+			],
+			[[5], [5, 5]],
+			[
+				[1, 2, 2, 3],
+				[2, 3, 3],
+			],
+			[
+				[7, 7, 7, 7],
+				[7, 7, 7, 7],
+			],
+		];
+		for (const [a, b] of shapes) {
+			const test = mannWhitneyU(a, b);
+			expect(test.pValue).toBeGreaterThanOrEqual(test.minAttainablePValue - 1e-12);
+			if (!canSeparate(test)) expect(test.pValue).toBeGreaterThanOrEqual(DEFAULT_ALPHA);
+		}
+	});
+
+	it("returns p = 1 when every pooled value is identical — no evidence of any difference", () => {
+		expect(mannWhitneyU([5, 5, 5], [5, 5, 5]).pValue).toBe(1);
 	});
 });

--- a/packages/schema/src/analysis.ts
+++ b/packages/schema/src/analysis.ts
@@ -288,30 +288,187 @@ function midranks(pooled: readonly number[]): { ranks: number[]; tieCorrection: 
 	return { ranks, tieCorrection };
 }
 
+/** How a {@link DistributionTest}'s p-value was obtained — the two differ materially at small n. */
+export type PValueMethod = "exact" | "asymptotic";
+
 /** The outcome of a two-sample test on full distributions. */
 export interface DistributionTest {
 	/** The test statistic (U for Mann-Whitney, D for Kolmogorov-Smirnov). */
 	statistic: number;
 	/** Two-sided p-value: P(a difference this extreme | the two samples came from one distribution). */
 	pValue: number;
+	/**
+	 * `exact` — enumerated over the permutation null, so the p-value is the true tail probability for
+	 * THESE sample sizes and THIS tie pattern. `asymptotic` — a normal/limiting approximation, which at
+	 * small n can be anti-conservative (it can report a p the exact null cannot actually produce).
+	 */
+	method: PValueMethod;
 	nA: number;
 	nB: number;
 }
 
 /**
- * Mann-Whitney U (two-sided), normal approximation with tie and continuity corrections.
+ * A Mann-Whitney result, plus the thing a ranking has to know before it may believe one: the smallest
+ * p this comparison was CAPABLE of producing.
+ */
+export interface RankSumTest extends DistributionTest {
+	/**
+	 * The smallest two-sided p this comparison could have returned, at any effect size — the value the
+	 * test yields under COMPLETE separation, which is the most extreme evidence a rank statistic can
+	 * encode. A ranking must not believe a p the comparison was never capable of producing;
+	 * {@link canSeparate} is the guard that reads this.
+	 *
+	 * It is a property of the sample sizes AND THE TIE PATTERN — not, as it may look, of the sizes alone.
+	 * That distinction is load-bearing, and getting it wrong is unsafe in the direction that matters:
+	 *
+	 * Without ties, the rank multiset {1..N} is symmetric under r ↦ N+1−r, so the two extreme splits (one
+	 * side takes the lowest nA ranks, or the highest) both sit at maximal |U−μ| and the two-sided tail
+	 * collects both: the floor is 2/C(N, nA). Ties destroy that symmetry — midranks are no longer a mirror
+	 * of themselves — and a lone split can then stand at the maximum, halving the floor to 1/C(N, nA).
+	 * `[2]` vs `[1,1]` really does return p = 1/3 where an untied 1 v 2 floors at 2/3. So any size-only
+	 * formula is either wrong (if it assumes no ties) or needlessly pessimistic (if it assumes the worst).
+	 *
+	 * Enumerating the observed ranks sidesteps the whole question: this is the null's own mass at its most
+	 * extreme split, computed in the same pass as {@link DistributionTest.pValue}, so the two are answers
+	 * about one distribution and cannot contradict each other. At 3 v 3 it is 0.1 — above α — so no pair of
+	 * three-trial providers can be declared different however far apart their medians are, and a caller
+	 * that read that non-significant p as "statistically tied" would be reporting a fact about its trial
+	 * count as if it were a fact about the providers.
+	 */
+	minAttainablePValue: number;
+}
+
+/**
+ * The largest pooled sample the exact Mann-Whitney enumeration runs on.
+ *
+ * The bound is arithmetic, not performance: the enumeration counts subsets, and C(N, N/2) exceeds
+ * `Number.MAX_SAFE_INTEGER` around N = 57, past which the counts (and so the p-value) silently lose
+ * integer precision. 50 keeps a margin, and the DP costs O(nA · N²) ≈ 3M operations at the ceiling —
+ * microseconds, and far beyond the handful of trials this benchmark produces.
+ */
+const MAX_EXACT_N = 50;
+
+/** Exact C(n, k) for n ≤ {@link MAX_EXACT_N}, where the result is integer-exact in a double. */
+function choose(n: number, k: number): number {
+	if (k < 0 || k > n) return 0;
+	const j = Math.min(k, n - k);
+	let result = 1;
+	for (let i = 1; i <= j; i++) result = (result * (n - j + i)) / i;
+	return Math.round(result);
+}
+
+/**
+ * The exact two-sided Mann-Whitney null, evaluated at the observed split AND at the most extreme split
+ * these ranks admit: P(|U − μ| ≥ |U_obs − μ|) under the permutation null, where every C(N, nA) split of
+ * the pooled ranks is equally likely. Conditioning on the OBSERVED ranks makes this exact with ties,
+ * not merely without them — and it is why the floor falls out of the same pass as the p-value: both are
+ * tail masses of one enumerated distribution, so they cannot contradict each other.
+ *
+ * Counted by DP over rank sums rather than by enumerating splits: `counts[k][s]` is the number of
+ * size-k subsets whose rank sum is s. Midranks are half-integers when ties are present, so the DP runs
+ * on DOUBLED ranks, keeping every index an exact integer.
+ */
+function exactMannWhitney(
+	ranks: readonly number[],
+	nA: number,
+	nB: number,
+): { pValue: number; minAttainablePValue: number } {
+	const N = nA + nB;
+	const doubled = ranks.map((r) => Math.round(r * 2));
+	const total = doubled.reduce((sum, r) => sum + r, 0);
+
+	// counts[k][s] — subsets of size k with doubled-rank-sum s. Iterate k downward so each element is
+	// used at most once per subset (the 0/1-knapsack order).
+	const counts: number[][] = Array.from({ length: nA + 1 }, () =>
+		new Array<number>(total + 1).fill(0),
+	);
+	(counts[0] as number[])[0] = 1;
+	for (const rank of doubled) {
+		for (let k = Math.min(nA, N) - 1; k >= 0; k--) {
+			const from = counts[k] as number[];
+			const into = counts[k + 1] as number[];
+			for (let s = total - rank; s >= 0; s--) {
+				const c = from[s] as number;
+				if (c !== 0) into[s + rank] = (into[s + rank] as number) + c;
+			}
+		}
+	}
+
+	// U doubled: 2·(rankSumA − nA(nA+1)/2) = s − nA(nA+1). μ doubled: 2·(nA·nB/2) = nA·nB.
+	const offset = nA * (nA + 1);
+	const mu2 = nA * nB;
+	let rankSumA2 = 0;
+	for (let i = 0; i < nA; i++) rankSumA2 += doubled[i] as number;
+	const observedDeviation = Math.abs(rankSumA2 - offset - mu2);
+
+	// One sweep of the null: the mass at least as extreme as what we saw (the p-value), and the mass at
+	// least as extreme as the MOST extreme split available (the floor — the p the test would report if
+	// the two providers separated perfectly).
+	const row = counts[nA] as number[];
+	let maxDeviation = 0;
+	for (let s = 0; s <= total; s++) {
+		if ((row[s] as number) !== 0) {
+			maxDeviation = Math.max(maxDeviation, Math.abs(s - offset - mu2));
+		}
+	}
+	let atLeastAsExtreme = 0;
+	let atMostExtreme = 0;
+	for (let s = 0; s <= total; s++) {
+		const c = row[s] as number;
+		if (c === 0) continue;
+		const deviation = Math.abs(s - offset - mu2);
+		if (deviation >= observedDeviation) atLeastAsExtreme += c;
+		if (deviation >= maxDeviation) atMostExtreme += c;
+	}
+	const splits = choose(N, nA);
+	return {
+		pValue: Math.min(1, atLeastAsExtreme / splits),
+		minAttainablePValue: Math.min(1, atMostExtreme / splits),
+	};
+}
+
+/**
+ * Could {@link mannWhitneyU} have reached significance at all for this comparison? False means the test
+ * is structurally powerless here — not merely low-powered — so a caller must NOT read its
+ * non-significant p as evidence that the two sides are alike. Rank on the observed values instead and
+ * disclose that the comparison was untestable.
+ *
+ * Takes the TEST, not the two sample sizes. The floor it reads
+ * ({@link RankSumTest.minAttainablePValue}) depends on the tie pattern as well as the sizes, so
+ * re-deriving it from `nA`/`nB` is exactly the shortcut that lets a guard disagree with the test it is
+ * guarding — which is precisely how the old size-only floor came to claim 0.081 for a 3 v 3 that the
+ * test then answered with 0.047.
+ */
+export function canSeparate(test: RankSumTest, alpha: number = DEFAULT_ALPHA): boolean {
+	return test.minAttainablePValue < alpha;
+}
+
+/**
+ * Mann-Whitney U (two-sided) — EXACT at the sample sizes this benchmark produces, falling back to the
+ * tie- and continuity-corrected normal approximation only past {@link MAX_EXACT_N}.
  *
  * The question it answers is exactly the one a leaderboard needs: are these two providers' Samples
  * drawn from the same distribution, or does one genuinely tend to be faster? It's rank-based, so it
  * assumes neither normality nor equal variance — both of which these Samples violate — and a single
  * catastrophic pass moves a rank by one position instead of dragging a mean.
  *
- * The normal approximation is used at every n (exact enumeration is not implemented). At the n≈5 this
- * suite produces, the smallest attainable two-sided p is ~0.008, so a genuine difference between two
- * five-trial providers can be detected, but only a large one — treat a non-significant result at small
- * n as "not enough evidence", never as "the providers are equal".
+ * It is exact BECAUSE n is small, not despite it. The normal approximation is anti-conservative here,
+ * and the failure is not a rounding error — it is a wrong verdict:
+ *
+ *     mannWhitneyU([1,1,1], [2,2,2])   approximation: p = 0.047  → "separated" at α = 0.05
+ *                                      exact:         p = 0.100  → the null cannot go below 0.1 at 3 v 3
+ *
+ * The tie correction shrinks the approximation's variance, inflating z, and three-of-a-kind on each side
+ * shrinks it hard. So the approximation returned a p BELOW the floor the exact null imposes on 3 trials
+ * a side — and would have crowned a provider on evidence the test cannot actually supply. Enumerating
+ * the permutation null removes the failure mode rather than documenting it.
+ *
+ * At n≈5 a side the smallest attainable two-sided p is 2/C(10,5) ≈ 0.008, so a genuine difference
+ * between two five-trial providers can still be detected, but only a large one — treat a non-significant
+ * result at small n as "not enough evidence", never as "the providers are equal". Below that the test
+ * runs out of power entirely ({@link canSeparate}); callers that rank on it must branch, not silently tie.
  */
-export function mannWhitneyU(a: readonly number[], b: readonly number[]): DistributionTest {
+export function mannWhitneyU(a: readonly number[], b: readonly number[]): RankSumTest {
 	if (a.length === 0 || b.length === 0) {
 		throw new Error("mannWhitneyU() requires a non-empty sample on both sides");
 	}
@@ -329,15 +486,32 @@ export function mannWhitneyU(a: readonly number[], b: readonly number[]): Distri
 	const statistic = Math.min(uA, uB);
 
 	const N = nA + nB;
+	if (N <= MAX_EXACT_N) {
+		return { statistic, ...exactMannWhitney(ranks, nA, nB), method: "exact", nA, nB };
+	}
+
 	const mu = (nA * nB) / 2;
 	// Tie-corrected variance; collapses to nA*nB*(N+1)/12 when there are no ties.
 	const variance = ((nA * nB) / 12) * (N + 1 - tieCorrection / (N * (N - 1)));
 	// Every pooled value identical → no variance, no evidence of any difference.
-	if (variance <= 0) return { statistic, pValue: 1, nA, nB };
+	if (variance <= 0) {
+		return { statistic, pValue: 1, minAttainablePValue: 1, method: "asymptotic", nA, nB };
+	}
 
 	// Continuity correction: |U − μ| is discrete, so shave half a step before the normal tail.
-	const z = Math.max(0, Math.abs(statistic - mu) - 0.5) / Math.sqrt(variance);
-	return { statistic, pValue: Math.min(1, 2 * (1 - normalCdf(z))), nA, nB };
+	const z = (dev: number): number => Math.max(0, dev - 0.5) / Math.sqrt(variance);
+	const tail = (dev: number): number => Math.min(1, 2 * (1 - normalCdf(z(dev))));
+	// The floor mirrors the p-value through the SAME variance (this rank multiset's, ties and all), at
+	// the most extreme statistic the test admits: complete separation, U = 0. Deriving it any other way
+	// is what lets a floor disagree with the test it bounds.
+	return {
+		statistic,
+		pValue: tail(Math.abs(statistic - mu)),
+		minAttainablePValue: tail(mu),
+		method: "asymptotic",
+		nA,
+		nB,
+	};
 }
 
 /**
@@ -349,9 +523,11 @@ export function mannWhitneyU(a: readonly number[], b: readonly number[]): Distri
  * passes. That bimodality is precisely what environmental noise looks like.
  *
  * The tail is the asymptotic (Numerical Recipes) approximation at every n; exact enumeration is not
- * implemented. At the n≈5 this suite produces it is anti-conservative — e.g. `[1,2,3]` vs `[4,5,6]`
- * returns p≈0.033 where the exact two-sided p is 2/C(6,3)=0.1 — so, as with {@link mannWhitneyU},
- * treat a small-n result as directional evidence and never read a sub-α p at tiny n as hard proof.
+ * implemented, and — unlike {@link mannWhitneyU}, which now enumerates — that is a deliberate limit,
+ * because KS does NOT drive the ranking. It is reported beside the rank as a shape diagnostic, never as
+ * the verdict, so its small-n anti-conservatism cannot buy a provider a position. It is real, though:
+ * `[1,2,3]` vs `[4,5,6]` returns p≈0.033 where the exact two-sided p is 2/C(6,3)=0.1. Read a small-n
+ * `p (KS)` as directional evidence about distribution shape, never as hard proof.
  */
 export function kolmogorovSmirnov(a: readonly number[], b: readonly number[]): DistributionTest {
 	if (a.length === 0 || b.length === 0) {
@@ -381,7 +557,13 @@ export function kolmogorovSmirnov(a: readonly number[], b: readonly number[]): D
 	}
 
 	const en = Math.sqrt((nA * nB) / (nA + nB));
-	return { statistic, pValue: kolmogorovQ((en + 0.12 + 0.11 / en) * statistic), nA, nB };
+	return {
+		statistic,
+		pValue: kolmogorovQ((en + 0.12 + 0.11 / en) * statistic),
+		method: "asymptotic",
+		nA,
+		nB,
+	};
 }
 
 /**


### PR DESCRIPTION
Mann-Whitney's two-sided p has a floor set by the sample sizes alone, and the normal
approximation's continuity correction puts that floor at ~0.081 for 3 trials a side —
above `DEFAULT_ALPHA`. So **no** pair of three-trial providers could ever separate, and
the ranking dutifully grouped them as "statistically indistinguishable": run
29130741476 printed Daytona (19.72 runs/s) and Modal (9.59 runs/s) as a tied rank 1
while Daytona was running 2× faster. That is a fact about the trial count wearing the
costume of a finding about the providers. Caught by @greptile-apps on #134.

Add `minAttainablePValue()` / `canSeparate()` to the analysis layer and branch on them
in the rank walk. This is the same rule the `n < 2` case already applies — *a test that
can never reach α is not evidence of sameness* — extended to where it actually bites.
Underpowered rows rank on their observed medians, claim no verdict, and render as
`0.081 (n too small)` rather than `(tied)`; the footer says that more trials, not the
p-value, are what would settle them. Genuine ties (where the test **had** the power and
still didn't separate) are unchanged, as are exactly-equal medians, which stay tied —
ranking on the value must never let the providerId sort tie-break separate two rows.

The floor is asserted equal to what `mannWhitneyU` actually returns under complete
separation, so the guard and the test it guards cannot drift apart.

Regenerates `LEADERBOARD.md`: Modal drops to rank 2 on the cpu dimension.

**This is the end state, not a stopgap.** The other way to close the gap — raising trials
per suite to ≥5 so the floor drops under α — is deliberately declined: the runtime cost is
too high (and #129 moves `TimesToRun` the other way, to 2). We are choosing to live with
underpowered comparisons, which makes labelling them honestly the whole fix rather than a
placeholder for one. `n too small` is a permanent, load-bearing cell in this table.

Stacked on #131 (coverage gaps) → #134 (the published run whose 3-trial samples expose
this).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stop reporting underpowered comparisons as statistical ties and make Mann–Whitney exact at our sample sizes so p-values never dip below their own floors. Underpowered rows now rank by observed median with “(n too small)” (or “(n too small, equal medians)” when values match), and the footer cites per-comparison p-floors from this run.

- **Bug Fixes**
  - `@sandbox-benchmarks/schema`: `mannWhitneyU` now enumerates exactly at small n (returns `method` and `minAttainablePValue`); added `canSeparate(test)` that uses the test’s own floor; removed the size-only floor helper; KS now also reports `method`.
  - Leaderboard: replaced `separated` with `verdict` (`separated`/`tied`/`underpowered`/`untested`) and `tiedWithAbove` (`statistical`/`identical-value`); underpowered rows never claim a statistical tie and only share a rank when values are identical; `pVsPrevious` now stores `{ mannWhitney, ks, floor }`.
  - Rendering: `p vs. above` shows `(n too small)` and distinguishes `(equal medians)`/`(equal values)`; footer lists floors from actual underpowered pairs (e.g., “4 v 3 floors at p ≈ 0.057”) and only appears when needed; copy explains each shared-rank reason.
  - Output: regenerated `LEADERBOARD.md` — CPU 3 v 3 shows p ≈ 0.10 with Modal at rank 2; exact p-values updated (e.g., 5 v 5 now 0.0079).

<sup>Written for commit 9ca20a18582ff26c5e7460c017d033ceaa1558ae. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/starslingdev/sandbox-benchmarks/pull/145?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

