### PR TITLE
feat(schema,results): curate the fio catalog entries and promote 4K rand-read IOPS to the disk headline

### DIFF
--- a/LEADERBOARD.md
+++ b/LEADERBOARD.md
@@ -13,15 +13,6 @@ Headline: **Node.js web tooling** (runs/s, higher is better)
 | 1 | Daytona | 19.72 | 19.63 – 19.96 | 3 | — | — |
 | 1 | Modal | 9.59 | 9.52 – 9.79 | 3 | 0.081 (tied) | 0.033 |
 
-## disk
-
-Headline: **Hardlink throughput** (bogo ops/s, higher is better)
-
-| Rank | Provider | Hardlink throughput (bogo ops/s) | 95% CI | n | p vs. above | p (KS) |
-| ---: | --- | ---: | ---: | ---: | ---: | ---: |
-| 1 | Daytona | 23.39 | 23.35 – 23.42 | 3 | — | — |
-| 2 | Modal | 3.25 | 3.18 – 3.34 | 15 | 0.0090 | 0.0038 |
-
 ## memory
 
 Headline: **STREAM Triad** (MB/s, higher is better)

--- a/packages/results/src/lib/__fixtures__/local-pts/pts_fio-rand-read-buffered.xml
+++ b/packages/results/src/lib/__fixtures__/local-pts/pts_fio-rand-read-buffered.xml
@@ -1,0 +1,59 @@
+<?xml version="1.0"?>
+<!--Phoronix Test Suite v10.8.4-->
+<!--
+  Recorded pts/fio-2.1.0 composite for the golden byte-match gate (design par. 3.7): the random-read (4KB, buffered fallback)
+  scenario the benchmark:disk:pts:fio-* producer tasks pin via PRESET_OPTIONS (Engine: Linux AIO,
+  Job Count: 1, Disk Target: Default Test Directory).
+
+  REAL output of Phoronix Test Suite 10.8.4 running fio 3.36 (both at the pinned upstream versions
+  this repo vendors), recorded under FORCE_TIMES_TO_RUN=1 with RunAllTestCombinations off - the exact
+  batch path run_fio_pts drives. One run posts TWO <Result>s under the SAME <Description>, split only
+  by <Scale> (MB/s bandwidth + IOPS) - the shape the catalog's pts.scale pins disambiguate; this
+  fixture proves both the synthesized description strings and that scale routing against reality.
+  The <System> host-fingerprint block was removed (recording-container identity, not result data);
+  the <Result> nodes are verbatim.
+-->
+<PhoronixTestSuite>
+  <Generated>
+    <Title>fixture-fio-rr-buffered</Title>
+    <LastModified>2026-07-11 22:38:49</LastModified>
+    <TestClient>Phoronix Test Suite v10.8.4</TestClient>
+    <Description>docker testing on Ubuntu 24.04 via the Phoronix Test Suite.</Description>
+  </Generated>
+  <Result>
+    <Identifier>pts/fio-2.1.0</Identifier>
+    <Title>Flexible IO Tester</Title>
+    <AppVersion>3.36</AppVersion>
+    <Arguments>randread libaio 0 4k 1</Arguments>
+    <Description>Type: Random Read - Engine: Linux AIO - Direct: No - Block Size: 4KB - Job Count: 1 - Disk Target: Default Test Directory</Description>
+    <Scale>MB/s</Scale>
+    <Proportion>HIB</Proportion>
+    <DisplayFormat>BAR_GRAPH</DisplayFormat>
+    <Data>
+      <Entry>
+        <Identifier>ci</Identifier>
+        <Value>82.9</Value>
+        <RawString></RawString>
+        <JSON>{"compiler-options":{"compiler-type":"CC","compiler":"gcc","compiler-options":"-rdynamic -lz -lm -laio -lpthread -ldl -std=gnu99 -ffast-math -include -O3 -fcommon -march=native"},"test-run-times":"85.68"}</JSON>
+      </Entry>
+    </Data>
+  </Result>
+  <Result>
+    <Identifier>pts/fio-2.1.0</Identifier>
+    <Title>Flexible IO Tester</Title>
+    <AppVersion>3.36</AppVersion>
+    <Arguments>randread libaio 0 4k 1</Arguments>
+    <Description>Type: Random Read - Engine: Linux AIO - Direct: No - Block Size: 4KB - Job Count: 1 - Disk Target: Default Test Directory</Description>
+    <Scale>IOPS</Scale>
+    <Proportion>HIB</Proportion>
+    <DisplayFormat>BAR_GRAPH</DisplayFormat>
+    <Data>
+      <Entry>
+        <Identifier>ci</Identifier>
+        <Value>21200</Value>
+        <RawString></RawString>
+        <JSON>{"compiler-options":{"compiler-type":"CC","compiler":"gcc","compiler-options":"-rdynamic -lz -lm -laio -lpthread -ldl -std=gnu99 -ffast-math -include -O3 -fcommon -march=native"},"test-run-times":"85.68"}</JSON>
+      </Entry>
+    </Data>
+  </Result>
+</PhoronixTestSuite>

--- a/packages/results/src/lib/__fixtures__/local-pts/pts_fio-rand-read.xml
+++ b/packages/results/src/lib/__fixtures__/local-pts/pts_fio-rand-read.xml
@@ -1,0 +1,59 @@
+<?xml version="1.0"?>
+<!--Phoronix Test Suite v10.8.4-->
+<!--
+  Recorded pts/fio-2.1.0 composite for the golden byte-match gate (design par. 3.7): the random-read (4KB, O_DIRECT)
+  scenario the benchmark:disk:pts:fio-* producer tasks pin via PRESET_OPTIONS (Engine: Linux AIO,
+  Job Count: 1, Disk Target: Default Test Directory).
+
+  REAL output of Phoronix Test Suite 10.8.4 running fio 3.36 (both at the pinned upstream versions
+  this repo vendors), recorded under FORCE_TIMES_TO_RUN=1 with RunAllTestCombinations off - the exact
+  batch path run_fio_pts drives. One run posts TWO <Result>s under the SAME <Description>, split only
+  by <Scale> (MB/s bandwidth + IOPS) - the shape the catalog's pts.scale pins disambiguate; this
+  fixture proves both the synthesized description strings and that scale routing against reality.
+  The <System> host-fingerprint block was removed (recording-container identity, not result data);
+  the <Result> nodes are verbatim.
+-->
+<PhoronixTestSuite>
+  <Generated>
+    <Title>fixture-fio-rand-read</Title>
+    <LastModified>2026-07-11 22:35:39</LastModified>
+    <TestClient>Phoronix Test Suite v10.8.4</TestClient>
+    <Description>docker testing on Ubuntu 24.04 via the Phoronix Test Suite.</Description>
+  </Generated>
+  <Result>
+    <Identifier>pts/fio-2.1.0</Identifier>
+    <Title>Flexible IO Tester</Title>
+    <AppVersion>3.36</AppVersion>
+    <Arguments>randread libaio 1 4k 1</Arguments>
+    <Description>Type: Random Read - Engine: Linux AIO - Direct: Yes - Block Size: 4KB - Job Count: 1 - Disk Target: Default Test Directory</Description>
+    <Scale>MB/s</Scale>
+    <Proportion>HIB</Proportion>
+    <DisplayFormat>BAR_GRAPH</DisplayFormat>
+    <Data>
+      <Entry>
+        <Identifier>ci</Identifier>
+        <Value>357</Value>
+        <RawString></RawString>
+        <JSON>{"compiler-options":{"compiler-type":"CC","compiler":"gcc","compiler-options":"-rdynamic -lz -lm -laio -lpthread -ldl -std=gnu99 -ffast-math -include -O3 -fcommon -march=native"},"test-run-times":"85.67"}</JSON>
+      </Entry>
+    </Data>
+  </Result>
+  <Result>
+    <Identifier>pts/fio-2.1.0</Identifier>
+    <Title>Flexible IO Tester</Title>
+    <AppVersion>3.36</AppVersion>
+    <Arguments>randread libaio 1 4k 1</Arguments>
+    <Description>Type: Random Read - Engine: Linux AIO - Direct: Yes - Block Size: 4KB - Job Count: 1 - Disk Target: Default Test Directory</Description>
+    <Scale>IOPS</Scale>
+    <Proportion>HIB</Proportion>
+    <DisplayFormat>BAR_GRAPH</DisplayFormat>
+    <Data>
+      <Entry>
+        <Identifier>ci</Identifier>
+        <Value>91400</Value>
+        <RawString></RawString>
+        <JSON>{"compiler-options":{"compiler-type":"CC","compiler":"gcc","compiler-options":"-rdynamic -lz -lm -laio -lpthread -ldl -std=gnu99 -ffast-math -include -O3 -fcommon -march=native"},"test-run-times":"85.67"}</JSON>
+      </Entry>
+    </Data>
+  </Result>
+</PhoronixTestSuite>

--- a/packages/results/src/lib/__fixtures__/local-pts/pts_fio-rand-write.xml
+++ b/packages/results/src/lib/__fixtures__/local-pts/pts_fio-rand-write.xml
@@ -1,0 +1,59 @@
+<?xml version="1.0"?>
+<!--Phoronix Test Suite v10.8.4-->
+<!--
+  Recorded pts/fio-2.1.0 composite for the golden byte-match gate (design par. 3.7): the random-write (4KB, O_DIRECT)
+  scenario the benchmark:disk:pts:fio-* producer tasks pin via PRESET_OPTIONS (Engine: Linux AIO,
+  Job Count: 1, Disk Target: Default Test Directory).
+
+  REAL output of Phoronix Test Suite 10.8.4 running fio 3.36 (both at the pinned upstream versions
+  this repo vendors), recorded under FORCE_TIMES_TO_RUN=1 with RunAllTestCombinations off - the exact
+  batch path run_fio_pts drives. One run posts TWO <Result>s under the SAME <Description>, split only
+  by <Scale> (MB/s bandwidth + IOPS) - the shape the catalog's pts.scale pins disambiguate; this
+  fixture proves both the synthesized description strings and that scale routing against reality.
+  The <System> host-fingerprint block was removed (recording-container identity, not result data);
+  the <Result> nodes are verbatim.
+-->
+<PhoronixTestSuite>
+  <Generated>
+    <Title>fixture-fio-rand-write</Title>
+    <LastModified>2026-07-11 22:37:14</LastModified>
+    <TestClient>Phoronix Test Suite v10.8.4</TestClient>
+    <Description>docker testing on Ubuntu 24.04 via the Phoronix Test Suite.</Description>
+  </Generated>
+  <Result>
+    <Identifier>pts/fio-2.1.0</Identifier>
+    <Title>Flexible IO Tester</Title>
+    <AppVersion>3.36</AppVersion>
+    <Arguments>randwrite libaio 1 4k 1</Arguments>
+    <Description>Type: Random Write - Engine: Linux AIO - Direct: Yes - Block Size: 4KB - Job Count: 1 - Disk Target: Default Test Directory</Description>
+    <Scale>MB/s</Scale>
+    <Proportion>HIB</Proportion>
+    <DisplayFormat>BAR_GRAPH</DisplayFormat>
+    <Data>
+      <Entry>
+        <Identifier>ci</Identifier>
+        <Value>694</Value>
+        <RawString></RawString>
+        <JSON>{"compiler-options":{"compiler-type":"CC","compiler":"gcc","compiler-options":"-rdynamic -lz -lm -laio -lpthread -ldl -std=gnu99 -ffast-math -include -O3 -fcommon -march=native"},"test-run-times":"88.71"}</JSON>
+      </Entry>
+    </Data>
+  </Result>
+  <Result>
+    <Identifier>pts/fio-2.1.0</Identifier>
+    <Title>Flexible IO Tester</Title>
+    <AppVersion>3.36</AppVersion>
+    <Arguments>randwrite libaio 1 4k 1</Arguments>
+    <Description>Type: Random Write - Engine: Linux AIO - Direct: Yes - Block Size: 4KB - Job Count: 1 - Disk Target: Default Test Directory</Description>
+    <Scale>IOPS</Scale>
+    <Proportion>HIB</Proportion>
+    <DisplayFormat>BAR_GRAPH</DisplayFormat>
+    <Data>
+      <Entry>
+        <Identifier>ci</Identifier>
+        <Value>178000</Value>
+        <RawString></RawString>
+        <JSON>{"compiler-options":{"compiler-type":"CC","compiler":"gcc","compiler-options":"-rdynamic -lz -lm -laio -lpthread -ldl -std=gnu99 -ffast-math -include -O3 -fcommon -march=native"},"test-run-times":"88.71"}</JSON>
+      </Entry>
+    </Data>
+  </Result>
+</PhoronixTestSuite>

--- a/packages/results/src/lib/__fixtures__/local-pts/pts_fio-seq-read.xml
+++ b/packages/results/src/lib/__fixtures__/local-pts/pts_fio-seq-read.xml
@@ -1,0 +1,59 @@
+<?xml version="1.0"?>
+<!--Phoronix Test Suite v10.8.4-->
+<!--
+  Recorded pts/fio-2.1.0 composite for the golden byte-match gate (design par. 3.7): the sequential-read (1MB, O_DIRECT)
+  scenario the benchmark:disk:pts:fio-* producer tasks pin via PRESET_OPTIONS (Engine: Linux AIO,
+  Job Count: 1, Disk Target: Default Test Directory).
+
+  REAL output of Phoronix Test Suite 10.8.4 running fio 3.36 (both at the pinned upstream versions
+  this repo vendors), recorded under FORCE_TIMES_TO_RUN=1 with RunAllTestCombinations off - the exact
+  batch path run_fio_pts drives. One run posts TWO <Result>s under the SAME <Description>, split only
+  by <Scale> (MB/s bandwidth + IOPS) - the shape the catalog's pts.scale pins disambiguate; this
+  fixture proves both the synthesized description strings and that scale routing against reality.
+  The <System> host-fingerprint block was removed (recording-container identity, not result data);
+  the <Result> nodes are verbatim.
+-->
+<PhoronixTestSuite>
+  <Generated>
+    <Title>fixture-fio-seq-read</Title>
+    <LastModified>2026-07-11 22:43:57</LastModified>
+    <TestClient>Phoronix Test Suite v10.8.4</TestClient>
+    <Description>docker testing on Ubuntu 24.04 via the Phoronix Test Suite.</Description>
+  </Generated>
+  <Result>
+    <Identifier>pts/fio-2.1.0</Identifier>
+    <Title>Flexible IO Tester</Title>
+    <AppVersion>3.36</AppVersion>
+    <Arguments>read libaio 1 1m 1</Arguments>
+    <Description>Type: Sequential Read - Engine: Linux AIO - Direct: Yes - Block Size: 1MB - Job Count: 1 - Disk Target: Default Test Directory</Description>
+    <Scale>MB/s</Scale>
+    <Proportion>HIB</Proportion>
+    <DisplayFormat>BAR_GRAPH</DisplayFormat>
+    <Data>
+      <Entry>
+        <Identifier>ci</Identifier>
+        <Value>1792</Value>
+        <RawString></RawString>
+        <JSON>{"compiler-options":{"compiler-type":"CC","compiler":"gcc","compiler-options":"-rdynamic -lz -lm -laio -lpthread -ldl -std=gnu99 -ffast-math -include -O3 -fcommon -march=native"},"test-run-times":"85.78"}</JSON>
+      </Entry>
+    </Data>
+  </Result>
+  <Result>
+    <Identifier>pts/fio-2.1.0</Identifier>
+    <Title>Flexible IO Tester</Title>
+    <AppVersion>3.36</AppVersion>
+    <Arguments>read libaio 1 1m 1</Arguments>
+    <Description>Type: Sequential Read - Engine: Linux AIO - Direct: Yes - Block Size: 1MB - Job Count: 1 - Disk Target: Default Test Directory</Description>
+    <Scale>IOPS</Scale>
+    <Proportion>HIB</Proportion>
+    <DisplayFormat>BAR_GRAPH</DisplayFormat>
+    <Data>
+      <Entry>
+        <Identifier>ci</Identifier>
+        <Value>1791</Value>
+        <RawString></RawString>
+        <JSON>{"compiler-options":{"compiler-type":"CC","compiler":"gcc","compiler-options":"-rdynamic -lz -lm -laio -lpthread -ldl -std=gnu99 -ffast-math -include -O3 -fcommon -march=native"},"test-run-times":"85.78"}</JSON>
+      </Entry>
+    </Data>
+  </Result>
+</PhoronixTestSuite>

--- a/packages/results/src/lib/__fixtures__/local-pts/pts_fio-seq-write.xml
+++ b/packages/results/src/lib/__fixtures__/local-pts/pts_fio-seq-write.xml
@@ -1,0 +1,59 @@
+<?xml version="1.0"?>
+<!--Phoronix Test Suite v10.8.4-->
+<!--
+  Recorded pts/fio-2.1.0 composite for the golden byte-match gate (design par. 3.7): the sequential-write (1MB, O_DIRECT)
+  scenario the benchmark:disk:pts:fio-* producer tasks pin via PRESET_OPTIONS (Engine: Linux AIO,
+  Job Count: 1, Disk Target: Default Test Directory).
+
+  REAL output of Phoronix Test Suite 10.8.4 running fio 3.36 (both at the pinned upstream versions
+  this repo vendors), recorded under FORCE_TIMES_TO_RUN=1 with RunAllTestCombinations off - the exact
+  batch path run_fio_pts drives. One run posts TWO <Result>s under the SAME <Description>, split only
+  by <Scale> (MB/s bandwidth + IOPS) - the shape the catalog's pts.scale pins disambiguate; this
+  fixture proves both the synthesized description strings and that scale routing against reality.
+  The <System> host-fingerprint block was removed (recording-container identity, not result data);
+  the <Result> nodes are verbatim.
+-->
+<PhoronixTestSuite>
+  <Generated>
+    <Title>fixture-fio-seq-write</Title>
+    <LastModified>2026-07-11 22:34:06</LastModified>
+    <TestClient>Phoronix Test Suite v10.8.4</TestClient>
+    <Description>docker testing on Ubuntu 24.04 via the Phoronix Test Suite.</Description>
+  </Generated>
+  <Result>
+    <Identifier>pts/fio-2.1.0</Identifier>
+    <Title>Flexible IO Tester</Title>
+    <AppVersion>3.36</AppVersion>
+    <Arguments>write libaio 1 1m 1</Arguments>
+    <Description>Type: Sequential Write - Engine: Linux AIO - Direct: Yes - Block Size: 1MB - Job Count: 1 - Disk Target: Default Test Directory</Description>
+    <Scale>MB/s</Scale>
+    <Proportion>HIB</Proportion>
+    <DisplayFormat>BAR_GRAPH</DisplayFormat>
+    <Data>
+      <Entry>
+        <Identifier>ci</Identifier>
+        <Value>953</Value>
+        <RawString></RawString>
+        <JSON>{"compiler-options":{"compiler-type":"CC","compiler":"gcc","compiler-options":"-rdynamic -lz -lm -laio -lpthread -ldl -std=gnu99 -ffast-math -include -O3 -fcommon -march=native"},"test-run-times":"85.76"}</JSON>
+      </Entry>
+    </Data>
+  </Result>
+  <Result>
+    <Identifier>pts/fio-2.1.0</Identifier>
+    <Title>Flexible IO Tester</Title>
+    <AppVersion>3.36</AppVersion>
+    <Arguments>write libaio 1 1m 1</Arguments>
+    <Description>Type: Sequential Write - Engine: Linux AIO - Direct: Yes - Block Size: 1MB - Job Count: 1 - Disk Target: Default Test Directory</Description>
+    <Scale>IOPS</Scale>
+    <Proportion>HIB</Proportion>
+    <DisplayFormat>BAR_GRAPH</DisplayFormat>
+    <Data>
+      <Entry>
+        <Identifier>ci</Identifier>
+        <Value>951</Value>
+        <RawString></RawString>
+        <JSON>{"compiler-options":{"compiler-type":"CC","compiler":"gcc","compiler-options":"-rdynamic -lz -lm -laio -lpthread -ldl -std=gnu99 -ffast-math -include -O3 -fcommon -march=native"},"test-run-times":"85.76"}</JSON>
+      </Entry>
+    </Data>
+  </Result>
+</PhoronixTestSuite>

--- a/packages/results/src/lib/pts-golden.test.ts
+++ b/packages/results/src/lib/pts-golden.test.ts
@@ -8,7 +8,7 @@
 import { describe, expect, it } from "bun:test";
 import { readdirSync, readFileSync } from "node:fs";
 import { join } from "node:path";
-import { isPtsResultFile } from "@sandbox-benchmarks/schema";
+import { isPtsResultFile, ptsOverrides } from "@sandbox-benchmarks/schema";
 import { parsePtsComposite, ptsResultToMetric } from "./pts.ts";
 
 const FIXTURES_DIR = join(import.meta.dir, "__fixtures__");
@@ -50,10 +50,15 @@ function discoverComposites(): [string, string][] {
 const composites = discoverComposites();
 
 /**
- * Tasks deliberately removed from a profile AFTER its composite was recorded. Recorded fixtures are
- * never hand-edited (they prove the byte-match against real PTS output), so a dropped task's
- * `<Result>` now legitimately routes to `uncatalogued`. Every entry documents a deliberate drop;
- * anything not listed here must still resolve.
+ * Tasks deliberately removed from a profile AFTER its composite was recorded. Recorded fixtures'
+ * `<Result>` nodes are never hand-edited (they prove the byte-match against real PTS output), so a
+ * dropped task's `<Result>` now legitimately routes to `uncatalogued`. Every entry documents a
+ * deliberate drop; anything not listed here must still resolve.
+ *
+ * The ONE sanctioned post-recording edit is redacting the whole `<System>` block — the recording
+ * host's fingerprint, never result data — and only with a provenance note in the fixture's header
+ * (the fio composites). No other edit is permitted: a fixture that needs different `<Result>` data
+ * gets re-recorded, not tidied.
  */
 const DROPPED_RESULTS = new Set([
 	// better-auth's `test` needs docker-compose DB services (postgres, mongodb) no provider sandbox
@@ -81,6 +86,30 @@ describe("golden composite byte-match (design §3.7)", () => {
 					: [];
 			});
 			expect(uncatalogued.filter((id) => !DROPPED_RESULTS.has(id))).toEqual([]);
+		});
+
+		it(`every matched <Result> in ${name} landed on the RIGHT metric (scale/description byte-match)`, () => {
+			// "kind === matched" alone is scale-blind: with scale-pinned twins (fio's MB/s + IOPS under
+			// one description), a routing bug that SWAPS the twins still reports matched for both and the
+			// disk headline would silently rank bandwidth numbers as IOPS. Assert the matched def's pins
+			// byte-equal the recorded result's fields, so twin misattribution turns this gate red.
+			for (const result of parsePtsComposite(xml).PhoronixTestSuite.Result) {
+				const mapping = ptsResultToMetric(result);
+				if (mapping.kind !== "matched") continue;
+				if (mapping.def.pts?.scale !== undefined) {
+					expect(result.Scale).toBe(mapping.def.pts.scale);
+				}
+				// With all 960 fio combinations catalogued, "matched" is cheap: a fixture recorded under
+				// drifted presets lands on an UNCURATED draft entry and stays green, quietly voiding the
+				// byte-match proof for the 16 combinations the producer tasks actually emit. Require the
+				// resolved fio id to carry a curation key.
+				if (mapping.def.pts?.test === "pts/fio") {
+					expect(Object.keys(ptsOverrides)).toContain(mapping.def.id);
+				}
+				if (mapping.def.pts?.description !== undefined) {
+					expect(result.Description).toBe(mapping.def.pts.description);
+				}
+			}
 		});
 	}
 });

--- a/packages/results/src/lib/pts.test.ts
+++ b/packages/results/src/lib/pts.test.ts
@@ -146,6 +146,51 @@ describe("ptsResultToMetric", () => {
 			scale: "Seconds",
 		});
 	});
+
+	it("routes a scale-pinned description by <Scale>, and strands an unknown scale", () => {
+		// fio's twin results share one description and differ only in <Scale> — the catalog pins each
+		// twin with pts.scale. An unknown scale (a parser/profile drift) must fall to uncatalogued, not
+		// to the nearest twin.
+		const description =
+			"Type: Random Read - Engine: Linux AIO - Direct: Yes - Block Size: 4KB - Job Count: 1 - Disk Target: Default Test Directory";
+		const fioResult = (scale: string) =>
+			parsePtsComposite(`<?xml version="1.0"?>
+<PhoronixTestSuite>
+  <Generated><TestClient>phoronix-test-suite/10.8.4</TestClient></Generated>
+  <Result>
+    <Identifier>pts/fio-2.1.0</Identifier>
+    <Title>Flexible IO Tester</Title>
+    <Description>${description}</Description>
+    <Scale>${scale}</Scale>
+    <Proportion>HIB</Proportion>
+    <Data><Entry><Value>91400</Value></Entry></Data>
+  </Result>
+</PhoronixTestSuite>`).PhoronixTestSuite.Result[0];
+
+		const routedId = (scale: string): string => {
+			const result = fioResult(scale);
+			const mapped = result && ptsResultToMetric(result);
+			if (mapped?.kind !== "matched") throw new Error(`expected <Scale>${scale}</Scale> to match`);
+			return mapped.def.id;
+		};
+
+		// BOTH twins must land on their OWN entry. Asserting only the IOPS arm leaves the symmetric
+		// half — the one a twin SWAP actually breaks — unproven against the real catalog.
+		expect(routedId("IOPS")).toBe(
+			"fio_type_random_read_engine_linux_aio_direct_yes_block_size_4kb_job_count_1_disk_target_default_test_directory_iops",
+		);
+		expect(routedId("MB/s")).toBe(
+			"fio_type_random_read_engine_linux_aio_direct_yes_block_size_4kb_job_count_1_disk_target_default_test_directory_mb_per_s",
+		);
+
+		const unknownScale = fioResult("GB/s");
+		expect(unknownScale && ptsResultToMetric(unknownScale)).toEqual({
+			kind: "uncatalogued",
+			test: "pts/fio",
+			description,
+			scale: "GB/s",
+		});
+	});
 });
 
 // The scale-pinned arm has no coverage through the real catalog: no METRIC_CATALOG entry carries a

--- a/packages/schema/src/catalog.test.ts
+++ b/packages/schema/src/catalog.test.ts
@@ -93,13 +93,48 @@ describe("metric catalog", () => {
 		).toEqual(["stream_type_add", "stream_type_copy", "stream_type_scale", "stream_type_triad"]);
 	});
 
-	it("resolves the Hardlink headline for the disk dimension via a non-`pts/` (local) join key", () => {
+	it("resolves the fio 4K random-read IOPS headline for the disk dimension", () => {
 		const metric = headlineMetric("disk");
-		expect(metric.id).toBe("hardlink_bogo_ops_per_s");
-		expect(metric.label).toBe("Hardlink throughput");
+		expect(metric.id).toBe(
+			"fio_type_random_read_engine_linux_aio_direct_yes_block_size_4kb_job_count_1_disk_target_default_test_directory_iops",
+		);
+		expect(metric.label).toBe("fio rand read 4KB, O_DIRECT (IOPS)");
 		expect(metric.direction).toBe("HIB");
+	});
+
+	it("resolves hardlink via a non-`pts/` (local) join key", () => {
+		const metric = getMetric("hardlink_bogo_ops_per_s");
+		expect(metric?.label).toBe("Hardlink throughput");
+		expect(metric?.direction).toBe("HIB");
 		// Repo-local profile: the join prefix is `local/`, proving the generator is source-segment-aware.
-		expect(metric.pts).toEqual({ test: "local/hardlink" });
+		expect(metric?.pts).toEqual({ test: "local/hardlink" });
+	});
+
+	it("resolves fio's scale-pinned twin metrics for one description (disk dimension)", () => {
+		const mbps = getMetric(
+			"fio_type_random_read_engine_linux_aio_direct_yes_block_size_4kb_job_count_1_disk_target_default_test_directory_mb_per_s",
+		);
+		const iops = getMetric(
+			"fio_type_random_read_engine_linux_aio_direct_yes_block_size_4kb_job_count_1_disk_target_default_test_directory_iops",
+		);
+		const description =
+			"Type: Random Read - Engine: Linux AIO - Direct: Yes - Block Size: 4KB - Job Count: 1 - Disk Target: Default Test Directory";
+		expect(mbps?.pts).toEqual({ test: "pts/fio", description, scale: "MB/s" });
+		expect(iops?.pts).toEqual({ test: "pts/fio", description, scale: "IOPS" });
+		expect(mbps?.unit).toBe("MB/s");
+		expect(iops?.unit).toBe("IOPS");
+		// Both HIB from the parser-level <ResultProportion> (fio has no profile-level <Proportion>).
+		expect(mbps?.direction).toBe("HIB");
+		expect(iops?.direction).toBe("HIB");
+	});
+
+	it("enumerates fio's FULL option matrix (960 scale-pinned entries)", () => {
+		// 4 Type × 5 Engine × 2 Direct × 12 Block Size × 1 Job Count × 1 (virtual) Disk Target × 2 scales.
+		// Only the 16 curated ids are otherwise guarded, and the drift gate compares the committed bytes
+		// against a run of the SAME (possibly regressed) generator — so a synthesize.ts regression that
+		// silently drops the twins for some engines would stay green everywhere. This pins the arithmetic.
+		const fio = METRIC_CATALOG.filter((metric) => metric.pts?.test === "pts/fio");
+		expect(fio.length).toBe(960);
 	});
 
 	it("returns undefined for an unknown metric id", () => {

--- a/packages/schema/src/index.ts
+++ b/packages/schema/src/index.ts
@@ -16,6 +16,8 @@ export * from "./harness-metrics.ts";
 export * from "./metrics.ts";
 // Provider identity & economics registry (id, requiredEnvVars, pricing, isolation, spec-pinning).
 export * from "./providers.ts";
+// The hand-authored curation layer over the generated PTS catalog (label/headline/dimension).
+export * from "./pts-overrides.ts";
 // The raw-file naming contract shared by the producers and the results extractor.
 export * from "./raw-files.ts";
 // The canonical Run dataset model (Run/ProviderRun/MetricResult/…) and its validators.

--- a/packages/schema/src/pts-overrides.ts
+++ b/packages/schema/src/pts-overrides.ts
@@ -30,7 +30,53 @@ export const ptsOverrides: Record<string, MetricOverride> = {
 	stream_type_scale: { label: "STREAM Scale" },
 	stream_type_add: { label: "STREAM Add" },
 	// Disk dimension: Hardlink throughput (a repo-local PTS profile sourced from runner-benchmarking).
-	hardlink_bogo_ops_per_s: { headline: true, label: "Hardlink throughput" },
+	hardlink_bogo_ops_per_s: { label: "Hardlink throughput" },
+
+	// Disk dimension: pts/fio, pinned per scenario by the benchmark:disk:pts:fio-* producer tasks (added
+	// by the fio producer-tasks slice; Engine: Linux AIO, Job Count: 1, Disk Target: Default Test
+	// Directory; seq 1MB / rand 4KB). Only the 16 combinations those tasks can emit are curated — the
+	// generator's other fio entries keep their verbose draft labels and never receive samples. Direct
+	// is probed at run time (O_DIRECT
+	// fails on some sandbox filesystems), so each scenario has an O_DIRECT and a buffered variant —
+	// the mode travels in the metric identity rather than being silently mixed across providers.
+	// 4K random-read IOPS (O_DIRECT) is the dimension's headline — the canonical disk figure, and the
+	// honest one (buffered 4K reads measure the page cache). Two consequences of pinning the headline
+	// to the O_DIRECT variant: the leaderboard omits its disk row until a matrix run publishes fio
+	// samples, and a provider whose filesystem rejects O_DIRECT (the probe's buffered fallback) never
+	// appears in the disk ranking — its numbers land on the buffered variants, visible on the Run but
+	// deliberately not ranked against O_DIRECT results.
+	fio_type_sequential_read_engine_linux_aio_direct_yes_block_size_1mb_job_count_1_disk_target_default_test_directory_mb_per_s:
+		{ label: "fio seq read 1MB, O_DIRECT (MB/s)" },
+	fio_type_sequential_read_engine_linux_aio_direct_yes_block_size_1mb_job_count_1_disk_target_default_test_directory_iops:
+		{ label: "fio seq read 1MB, O_DIRECT (IOPS)" },
+	fio_type_sequential_write_engine_linux_aio_direct_yes_block_size_1mb_job_count_1_disk_target_default_test_directory_mb_per_s:
+		{ label: "fio seq write 1MB, O_DIRECT (MB/s)" },
+	fio_type_sequential_write_engine_linux_aio_direct_yes_block_size_1mb_job_count_1_disk_target_default_test_directory_iops:
+		{ label: "fio seq write 1MB, O_DIRECT (IOPS)" },
+	fio_type_random_read_engine_linux_aio_direct_yes_block_size_4kb_job_count_1_disk_target_default_test_directory_iops:
+		{ headline: true, label: "fio rand read 4KB, O_DIRECT (IOPS)" },
+	fio_type_random_read_engine_linux_aio_direct_yes_block_size_4kb_job_count_1_disk_target_default_test_directory_mb_per_s:
+		{ label: "fio rand read 4KB, O_DIRECT (MB/s)" },
+	fio_type_random_write_engine_linux_aio_direct_yes_block_size_4kb_job_count_1_disk_target_default_test_directory_iops:
+		{ label: "fio rand write 4KB, O_DIRECT (IOPS)" },
+	fio_type_random_write_engine_linux_aio_direct_yes_block_size_4kb_job_count_1_disk_target_default_test_directory_mb_per_s:
+		{ label: "fio rand write 4KB, O_DIRECT (MB/s)" },
+	fio_type_sequential_read_engine_linux_aio_direct_no_block_size_1mb_job_count_1_disk_target_default_test_directory_mb_per_s:
+		{ label: "fio seq read 1MB, buffered (MB/s)" },
+	fio_type_sequential_read_engine_linux_aio_direct_no_block_size_1mb_job_count_1_disk_target_default_test_directory_iops:
+		{ label: "fio seq read 1MB, buffered (IOPS)" },
+	fio_type_sequential_write_engine_linux_aio_direct_no_block_size_1mb_job_count_1_disk_target_default_test_directory_mb_per_s:
+		{ label: "fio seq write 1MB, buffered (MB/s)" },
+	fio_type_sequential_write_engine_linux_aio_direct_no_block_size_1mb_job_count_1_disk_target_default_test_directory_iops:
+		{ label: "fio seq write 1MB, buffered (IOPS)" },
+	fio_type_random_read_engine_linux_aio_direct_no_block_size_4kb_job_count_1_disk_target_default_test_directory_iops:
+		{ label: "fio rand read 4KB, buffered (IOPS)" },
+	fio_type_random_read_engine_linux_aio_direct_no_block_size_4kb_job_count_1_disk_target_default_test_directory_mb_per_s:
+		{ label: "fio rand read 4KB, buffered (MB/s)" },
+	fio_type_random_write_engine_linux_aio_direct_no_block_size_4kb_job_count_1_disk_target_default_test_directory_iops:
+		{ label: "fio rand write 4KB, buffered (IOPS)" },
+	fio_type_random_write_engine_linux_aio_direct_no_block_size_4kb_job_count_1_disk_target_default_test_directory_mb_per_s:
+		{ label: "fio rand write 4KB, buffered (MB/s)" },
 
 	// Realworld dimension (ENG-135/137): mastra-ai/mastra run through its own CI tasks, a repo-local
 	// PTS profile with a Task option axis. TestType System's default dimension is corrected to


### PR DESCRIPTION
**PTS BENCHMARK MATRIX — vendor the PTS catalog, then light up four benchmark suites.**
Shipped as a 12-PR stack. The trunk merges bottom-up; the four suite PRs at the top are SIBLINGS and
can be reviewed (and merged) in parallel — none blocks the others.

```
main
 └─ #136  schema: scale-aware PTS metric identity (pts.scale) + O(1) matcher
     └─ #137  catalog generator: per-parser scales + virtual axes
         └─ #138  ⚙ VENDOR fio + regenerate catalog        (autogenerated)
             └─ #146  fio curation + disk headline + goldens
                 └─ #139  ⚙ VENDOR loopback/zstd/pgbench + regenerate   (autogenerated)
                     └─ #147  their curation + recorded fixtures
                         └─ #148  shared PTS runner (lib/bench.sh)
                             └─ #144  toolchain image: bake PTS deps + pin drift gates
                                 ├─ #140  disk suite     ┐
                                 ├─ #141  network suite  │  siblings — parallel review
                                 ├─ #142  cpu-generic    │
                                 └─ #143  system suite   ┘
```
⚙ = the diff is machine-produced; reproduce it with the commands in the body. Everything hand-written
was lifted out into the small PR directly above it.

↑ **This PR is #146 (4/12) — the hand-written half of the fio vendoring, based on #138.**

---

Hand-written layer on top of the vendored/regenerated fio catalog. Everything machine-produced lives
in the PR below; this is the part a human actually decides:

- pts-overrides.ts: short labels for the 16 fio combinations the producer tasks can emit, and the one
  headline — 4K random-read IOPS (O_DIRECT). The other 944 generated fio entries keep their verbose
  draft labels and never receive samples. Each scenario has an O_DIRECT and a buffered variant, so a
  provider whose filesystem rejects O_DIRECT lands on the buffered metric rather than being silently
  mixed into the O_DIRECT ranking.
- Five RECORDED fio composites (real PTS output, not hand-written) + the golden byte-match gate,
  which now also asserts a matched fio <Result> resolves to a CURATED id: with all 960 combinations
  catalogued, "matched" alone is cheap — a fixture recorded under drifted presets would land on an
  uncurated draft entry and stay green.
- pts.test.ts proves BOTH scale twins route to their own entry (the symmetric half is what a twin
  swap breaks); catalog.test.ts pins the 960-entry matrix arithmetic, which the drift gate cannot
  (it compares two runs of the same generator).
- LEADERBOARD.md drops its disk section: the headline now points at a metric nothing produces until
  the fio producer tasks land, and buildLeaderboard omits a dimension with no headline samples.

Co-authored-by: Daniel Worku <daniel@starsling.dev>

## Validation

Every branch in this stack was checked out **in isolation** (i.e. on top of its own parent, with
nothing from the PRs above it) and run through the full gate set. A reviewer merges bottom-up, so
each PR has to stand on its own — this is what verifies that.

**This PR (`03b`), verified standalone — all seven gates green:**

| gate | command | result |
|---|---|---|
| install | `bun install --frozen-lockfile` | ✅ |
| typecheck | `bun run typecheck` | ✅ |
| lint | `bun run lint` (biome, `--error-on-warnings`) | ✅ |
| spell | `mise exec -- typos` | ✅ |
| shell | `bun run lint:shell` (shellcheck) | ✅ |
| catalog drift | `bun run check:catalog-drift` | ✅ |
| tests | `bun run test` (whole workspace) | ✅ **563 passing, 0 failing** |

The same matrix is green on all 12 branches, and the passing-test count climbs monotonically up the
trunk (535 → 576) — each PR adds coverage and none regresses it.

**What this PR's own tests prove:**

- **The golden byte-match gate runs against five RECORDED fio composites** — real PTS output, not hand-written — proving each synthesized `pts.description`/`pts.scale` byte-matches what PTS actually emits. This is the highest-risk item in the whole stack: a one-character drift silently routes a result to `uncatalogued` instead of ranking it.
- Both scale twins are asserted to resolve to their own curated id, the 960-entry matrix arithmetic is pinned, and a matched fio result is required to carry a curation key (with the full matrix catalogued, `matched` alone is cheap).

### What this does NOT prove

Being explicit, because the gates above are all static:

- **No benchmark has been run on a real provider sandbox.** Nothing in CI executes the `.mise` producer
  tasks against a live Phoronix Test Suite. Their correctness rests on `shellcheck`, on the golden
  byte-match gate (which compares against RECORDED composites — real PTS output, but replayed, not
  produced), and on the suite-contract tests. The first live signal is the `bench-smoke` workflow
  (manual dispatch) after these merge.
- **The image is only built by CI on #144** — it is the only PR that touches it. The suite PRs assume
  that image; they do not rebuild it.
- `Bake, validate & promote toolchain` is skipped on pull requests by design
  (`if: github.event_name != 'pull_request'`), so image PROMOTION is exercised only on `main`.
- The recorded fixtures prove byte-match against PTS output captured at a point in time; a future PTS
  release could change a `<Description>` string. That is precisely what the golden gate would catch.

Additionally, the four suite PRs at the top are siblings on #144; merging all four reproduces the
pre-restructure tree byte-for-byte (verified), so the 12-PR split moved every change and dropped none.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Curates the `pts/fio` catalog and promotes 4K random‑read IOPS (O_DIRECT) to the disk headline. Adds real `pts/fio` fixtures and stricter scale routing; hides the disk leaderboard until fio results exist.

- **New Features**
  - Curated 16 `pts/fio` scenarios in `pts-overrides.ts` with short labels; headline set to 4K rand‑read IOPS (O_DIRECT). Buffered and O_DIRECT are separate ids.
  - Exported the curated layer from `@sandbox-benchmarks/schema`; the catalog enumerates all 960 `pts/fio` entries, but only the 16 curated receive samples.
  - Removed the disk row from `LEADERBOARD.md` until headline samples are published.

- **Tests**
  - Added five recorded `pts/fio-2.1.0` composites; golden gate byte-matches description/scale and requires matched `pts/fio` results to resolve to curated ids.
  - Verified MB/s vs IOPS twin routing and that unknown scales fall to uncatalogued; pinned the 960‑entry count and the new disk headline resolution.

<sup>Written for commit ea4fecaf644c3be7b8af8bb56164b524491d00bf. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/starslingdev/sandbox-benchmarks/pull/146?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

