### PR TITLE
feat(schema,results): curate the zstd and pgbench catalog entries; record their golden fixtures

### DIFF
--- a/packages/results/src/lib/__fixtures__/local-pts/pts_compress-zstd.xml
+++ b/packages/results/src/lib/__fixtures__/local-pts/pts_compress-zstd.xml
@@ -1,0 +1,264 @@
+<?xml version="1.0"?>
+<!--Phoronix Test Suite v10.8.4-->
+<!--
+  Recorded pts/compress-zstd-1.6.0 composite for the golden byte-match gate (design par. 3.7): the
+  full Compression Level matrix the cpu-generic suite runs in batch mode (RunAllTestCombinations),
+  two <Result>s per level via the profile's AppendToArgumentsDescription parsers (Compression /
+  Decompression Speed).
+
+  13 <Result>s, not the 14 the level menu implies: this recording is missing "Compression Level: 3 -
+  Decompression Speed". The level-3 run's timing matches the two-phase duration of every sibling
+  whose pair IS present, so the decompression phase ran and PTS dropped the node. The fixture is
+  verbatim — NOT hand-repaired — so the golden gate does not cover the curated
+  `compress_zstd_compression_level_3_decompression_speed` id; its byte-match rides on the 12 sibling
+  Decompression descriptions, which the same parser rule synthesizes.
+
+  REAL output of Phoronix Test Suite 10.8.4 running zstd 1.5.4 (the pinned vendored profile version)
+  under FORCE_TIMES_TO_RUN=1. Recorded in a network-restricted container: the zstd source and the
+  silesia corpus were staged from their upstream git/GitHub mirrors instead of the profile's
+  download URLs (identical sources; only the transport differed), which affects measured VALUES not
+  the description/scale strings this gate proves. The <System> host-fingerprint block was removed
+  (recording-container identity, not result data); the <Result> nodes are verbatim.
+-->
+<PhoronixTestSuite>
+  <Generated>
+    <Title>fixture-compress-zstd</Title>
+    <LastModified>2026-07-11 22:53:30</LastModified>
+    <TestClient>Phoronix Test Suite v10.8.4</TestClient>
+    <Description>docker testing on Ubuntu 24.04 via the Phoronix Test Suite.</Description>
+  </Generated>
+  <Result>
+    <Identifier>pts/compress-zstd-1.6.0</Identifier>
+    <Title>Zstd Compression</Title>
+    <AppVersion>1.5.4</AppVersion>
+    <Arguments>-b3</Arguments>
+    <Description>Compression Level: 3 - Compression Speed</Description>
+    <Scale>MB/s</Scale>
+    <Proportion>HIB</Proportion>
+    <DisplayFormat>BAR_GRAPH</DisplayFormat>
+    <Data>
+      <Entry>
+        <Identifier>ci</Identifier>
+        <Value>839.5</Value>
+        <RawString></RawString>
+        <JSON>{"compiler-options":{"compiler-type":"CC","compiler":"gcc","compiler-options":"-O3 -pthread -lz -llzma"},"test-run-times":"63.67"}</JSON>
+      </Entry>
+    </Data>
+  </Result>
+  <Result>
+    <Identifier>pts/compress-zstd-1.6.0</Identifier>
+    <Title>Zstd Compression</Title>
+    <AppVersion>1.5.4</AppVersion>
+    <Arguments>-b3 --long</Arguments>
+    <Description>Compression Level: 3, Long Mode - Compression Speed</Description>
+    <Scale>MB/s</Scale>
+    <Proportion>HIB</Proportion>
+    <DisplayFormat>BAR_GRAPH</DisplayFormat>
+    <Data>
+      <Entry>
+        <Identifier>ci</Identifier>
+        <Value>535</Value>
+        <RawString></RawString>
+        <JSON>{"compiler-options":{"compiler-type":"CC","compiler":"gcc","compiler-options":"-O3 -pthread -lz -llzma"},"test-run-times":"63.87"}</JSON>
+      </Entry>
+    </Data>
+  </Result>
+  <Result>
+    <Identifier>pts/compress-zstd-1.6.0</Identifier>
+    <Title>Zstd Compression</Title>
+    <AppVersion>1.5.4</AppVersion>
+    <Arguments>-b3 --long</Arguments>
+    <Description>Compression Level: 3, Long Mode - Decompression Speed</Description>
+    <Scale>MB/s</Scale>
+    <Proportion>HIB</Proportion>
+    <DisplayFormat>BAR_GRAPH</DisplayFormat>
+    <Data>
+      <Entry>
+        <Identifier>ci</Identifier>
+        <Value>1050</Value>
+        <RawString></RawString>
+        <JSON>{"compiler-options":{"compiler-type":"CC","compiler":"gcc","compiler-options":"-O3 -pthread -lz -llzma"},"test-run-times":"63.87"}</JSON>
+      </Entry>
+    </Data>
+  </Result>
+  <Result>
+    <Identifier>pts/compress-zstd-1.6.0</Identifier>
+    <Title>Zstd Compression</Title>
+    <AppVersion>1.5.4</AppVersion>
+    <Arguments>-b8</Arguments>
+    <Description>Compression Level: 8 - Compression Speed</Description>
+    <Scale>MB/s</Scale>
+    <Proportion>HIB</Proportion>
+    <DisplayFormat>BAR_GRAPH</DisplayFormat>
+    <Data>
+      <Entry>
+        <Identifier>ci</Identifier>
+        <Value>220.7</Value>
+        <RawString></RawString>
+        <JSON>{"compiler-options":{"compiler-type":"CC","compiler":"gcc","compiler-options":"-O3 -pthread -lz -llzma"},"test-run-times":"63.47"}</JSON>
+      </Entry>
+    </Data>
+  </Result>
+  <Result>
+    <Identifier>pts/compress-zstd-1.6.0</Identifier>
+    <Title>Zstd Compression</Title>
+    <AppVersion>1.5.4</AppVersion>
+    <Arguments>-b8</Arguments>
+    <Description>Compression Level: 8 - Decompression Speed</Description>
+    <Scale>MB/s</Scale>
+    <Proportion>HIB</Proportion>
+    <DisplayFormat>BAR_GRAPH</DisplayFormat>
+    <Data>
+      <Entry>
+        <Identifier>ci</Identifier>
+        <Value>1006.2</Value>
+        <RawString></RawString>
+        <JSON>{"compiler-options":{"compiler-type":"CC","compiler":"gcc","compiler-options":"-O3 -pthread -lz -llzma"},"test-run-times":"63.47"}</JSON>
+      </Entry>
+    </Data>
+  </Result>
+  <Result>
+    <Identifier>pts/compress-zstd-1.6.0</Identifier>
+    <Title>Zstd Compression</Title>
+    <AppVersion>1.5.4</AppVersion>
+    <Arguments>-b8 --long</Arguments>
+    <Description>Compression Level: 8, Long Mode - Compression Speed</Description>
+    <Scale>MB/s</Scale>
+    <Proportion>HIB</Proportion>
+    <DisplayFormat>BAR_GRAPH</DisplayFormat>
+    <Data>
+      <Entry>
+        <Identifier>ci</Identifier>
+        <Value>208.7</Value>
+        <RawString></RawString>
+        <JSON>{"compiler-options":{"compiler-type":"CC","compiler":"gcc","compiler-options":"-O3 -pthread -lz -llzma"},"test-run-times":"63.96"}</JSON>
+      </Entry>
+    </Data>
+  </Result>
+  <Result>
+    <Identifier>pts/compress-zstd-1.6.0</Identifier>
+    <Title>Zstd Compression</Title>
+    <AppVersion>1.5.4</AppVersion>
+    <Arguments>-b8 --long</Arguments>
+    <Description>Compression Level: 8, Long Mode - Decompression Speed</Description>
+    <Scale>MB/s</Scale>
+    <Proportion>HIB</Proportion>
+    <DisplayFormat>BAR_GRAPH</DisplayFormat>
+    <Data>
+      <Entry>
+        <Identifier>ci</Identifier>
+        <Value>1007.6</Value>
+        <RawString></RawString>
+        <JSON>{"compiler-options":{"compiler-type":"CC","compiler":"gcc","compiler-options":"-O3 -pthread -lz -llzma"},"test-run-times":"63.96"}</JSON>
+      </Entry>
+    </Data>
+  </Result>
+  <Result>
+    <Identifier>pts/compress-zstd-1.6.0</Identifier>
+    <Title>Zstd Compression</Title>
+    <AppVersion>1.5.4</AppVersion>
+    <Arguments>-b12</Arguments>
+    <Description>Compression Level: 12 - Compression Speed</Description>
+    <Scale>MB/s</Scale>
+    <Proportion>HIB</Proportion>
+    <DisplayFormat>BAR_GRAPH</DisplayFormat>
+    <Data>
+      <Entry>
+        <Identifier>ci</Identifier>
+        <Value>98.2</Value>
+        <RawString></RawString>
+        <JSON>{"compiler-options":{"compiler-type":"CC","compiler":"gcc","compiler-options":"-O3 -pthread -lz -llzma"},"test-run-times":"63.44"}</JSON>
+      </Entry>
+    </Data>
+  </Result>
+  <Result>
+    <Identifier>pts/compress-zstd-1.6.0</Identifier>
+    <Title>Zstd Compression</Title>
+    <AppVersion>1.5.4</AppVersion>
+    <Arguments>-b12</Arguments>
+    <Description>Compression Level: 12 - Decompression Speed</Description>
+    <Scale>MB/s</Scale>
+    <Proportion>HIB</Proportion>
+    <DisplayFormat>BAR_GRAPH</DisplayFormat>
+    <Data>
+      <Entry>
+        <Identifier>ci</Identifier>
+        <Value>930.5</Value>
+        <RawString></RawString>
+        <JSON>{"compiler-options":{"compiler-type":"CC","compiler":"gcc","compiler-options":"-O3 -pthread -lz -llzma"},"test-run-times":"63.44"}</JSON>
+      </Entry>
+    </Data>
+  </Result>
+  <Result>
+    <Identifier>pts/compress-zstd-1.6.0</Identifier>
+    <Title>Zstd Compression</Title>
+    <AppVersion>1.5.4</AppVersion>
+    <Arguments>-b19</Arguments>
+    <Description>Compression Level: 19 - Compression Speed</Description>
+    <Scale>MB/s</Scale>
+    <Proportion>HIB</Proportion>
+    <DisplayFormat>BAR_GRAPH</DisplayFormat>
+    <Data>
+      <Entry>
+        <Identifier>ci</Identifier>
+        <Value>6.05</Value>
+        <RawString></RawString>
+        <JSON>{"compiler-options":{"compiler-type":"CC","compiler":"gcc","compiler-options":"-O3 -pthread -lz -llzma"},"test-run-times":"66.97"}</JSON>
+      </Entry>
+    </Data>
+  </Result>
+  <Result>
+    <Identifier>pts/compress-zstd-1.6.0</Identifier>
+    <Title>Zstd Compression</Title>
+    <AppVersion>1.5.4</AppVersion>
+    <Arguments>-b19</Arguments>
+    <Description>Compression Level: 19 - Decompression Speed</Description>
+    <Scale>MB/s</Scale>
+    <Proportion>HIB</Proportion>
+    <DisplayFormat>BAR_GRAPH</DisplayFormat>
+    <Data>
+      <Entry>
+        <Identifier>ci</Identifier>
+        <Value>782.4</Value>
+        <RawString></RawString>
+        <JSON>{"compiler-options":{"compiler-type":"CC","compiler":"gcc","compiler-options":"-O3 -pthread -lz -llzma"},"test-run-times":"66.97"}</JSON>
+      </Entry>
+    </Data>
+  </Result>
+  <Result>
+    <Identifier>pts/compress-zstd-1.6.0</Identifier>
+    <Title>Zstd Compression</Title>
+    <AppVersion>1.5.4</AppVersion>
+    <Arguments>-b19 --long</Arguments>
+    <Description>Compression Level: 19, Long Mode - Compression Speed</Description>
+    <Scale>MB/s</Scale>
+    <Proportion>HIB</Proportion>
+    <DisplayFormat>BAR_GRAPH</DisplayFormat>
+    <Data>
+      <Entry>
+        <Identifier>ci</Identifier>
+        <Value>5.62</Value>
+        <RawString></RawString>
+        <JSON>{"compiler-options":{"compiler-type":"CC","compiler":"gcc","compiler-options":"-O3 -pthread -lz -llzma"},"test-run-times":"70.00"}</JSON>
+      </Entry>
+    </Data>
+  </Result>
+  <Result>
+    <Identifier>pts/compress-zstd-1.6.0</Identifier>
+    <Title>Zstd Compression</Title>
+    <AppVersion>1.5.4</AppVersion>
+    <Arguments>-b19 --long</Arguments>
+    <Description>Compression Level: 19, Long Mode - Decompression Speed</Description>
+    <Scale>MB/s</Scale>
+    <Proportion>HIB</Proportion>
+    <DisplayFormat>BAR_GRAPH</DisplayFormat>
+    <Data>
+      <Entry>
+        <Identifier>ci</Identifier>
+        <Value>807.5</Value>
+        <RawString></RawString>
+        <JSON>{"compiler-options":{"compiler-type":"CC","compiler":"gcc","compiler-options":"-O3 -pthread -lz -llzma"},"test-run-times":"70.00"}</JSON>
+      </Entry>
+    </Data>
+  </Result>
+</PhoronixTestSuite>

--- a/packages/results/src/lib/__fixtures__/local-pts/pts_network-loopback.xml
+++ b/packages/results/src/lib/__fixtures__/local-pts/pts_network-loopback.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0"?>
+<!--Phoronix Test Suite v10.8.4-->
+<!--
+  Recorded pts/network-loopback-1.0.1 composite for the golden byte-match gate (design par. 3.7):
+  the network suite's single (wildcard) metric. A single-result profile needs no description
+  byte-match, but network-loopback is MONITOR-based (its value comes from PTS's sys.time sensor
+  around a dd|nc transfer, not a ResultsParser) - this fixture proves that composite shape parses
+  and maps like any other.
+
+  REAL output of Phoronix Test Suite 10.8.4 under FORCE_TIMES_TO_RUN=1. The <System>
+  host-fingerprint block was removed (recording-container identity, not result data); the <Result>
+  nodes are verbatim.
+-->
+<PhoronixTestSuite>
+  <Generated>
+    <Title>fixture-network-loopback</Title>
+    <LastModified>2026-07-11 22:53:53</LastModified>
+    <TestClient>Phoronix Test Suite v10.8.4</TestClient>
+    <Description>docker testing on Ubuntu 24.04 via the Phoronix Test Suite.</Description>
+  </Generated>
+  <Result>
+    <Identifier>pts/network-loopback-1.0.1</Identifier>
+    <Title>Loopback TCP Network Performance</Title>
+    <AppVersion></AppVersion>
+    <Arguments></Arguments>
+    <Description>Time To Transfer 10GB Via Loopback</Description>
+    <Scale>Seconds</Scale>
+    <Proportion>LIB</Proportion>
+    <DisplayFormat>BAR_GRAPH</DisplayFormat>
+    <Data>
+      <Entry>
+        <Identifier>ci</Identifier>
+        <Value>17.655</Value>
+        <RawString></RawString>
+        <JSON>{"test-run-times":"17.65"}</JSON>
+      </Entry>
+    </Data>
+  </Result>
+</PhoronixTestSuite>

--- a/packages/results/src/lib/__fixtures__/local-pts/pts_pgbench-read-only.xml
+++ b/packages/results/src/lib/__fixtures__/local-pts/pts_pgbench-read-only.xml
@@ -1,0 +1,61 @@
+<?xml version="1.0"?>
+<!--Phoronix Test Suite v10.8.4-->
+<!--
+  Recorded pts/pgbench-1.15.0 composite for the golden byte-match gate (design par. 3.7): the
+  read-only scenario the benchmark:system:pts:pgbench producer task pins via PRESET_OPTIONS
+  (Scaling Factor: 100, Clients: 50). One run posts a TPS and an Average Latency <Result> (the
+  profile's two parsers, distinct descriptions via AppendToArgumentsDescription).
+
+  REAL output of Phoronix Test Suite 10.8.4 building and running PostgreSQL 17.0 fully locally
+  (server + pgbench client in one machine - the same in-sandbox topology the suite measures),
+  recorded under FORCE_TIMES_TO_RUN=1 with RunAllTestCombinations off - the exact batch path
+  run_pinned_pts drives. The postgresql-17.0.tar.bz2 source was staged from the upstream git tag
+  (release host unreachable from the recording container) and is byte-identical to the canonical
+  release tarball (sha256 verified against the profile's downloads.xml pin). The <System>
+  host-fingerprint block was removed (recording-container identity, not result data); the <Result>
+  nodes are verbatim.
+-->
+<PhoronixTestSuite>
+  <Generated>
+    <Title>fixture-pgbench-ro</Title>
+    <LastModified>2026-07-13 03:51:17</LastModified>
+    <TestClient>Phoronix Test Suite v10.8.4</TestClient>
+    <Description>docker testing on Ubuntu 24.04 via the Phoronix Test Suite.</Description>
+  </Generated>
+  <Result>
+    <Identifier>pts/pgbench-1.15.0</Identifier>
+    <Title>PostgreSQL</Title>
+    <AppVersion>17</AppVersion>
+    <Arguments>-s 100 -c 50 -S</Arguments>
+    <Description>Scaling Factor: 100 - Clients: 50 - Mode: Read Only</Description>
+    <Scale>TPS</Scale>
+    <Proportion>HIB</Proportion>
+    <DisplayFormat>BAR_GRAPH</DisplayFormat>
+    <Data>
+      <Entry>
+        <Identifier>ci</Identifier>
+        <Value>70329</Value>
+        <RawString>70329.161236</RawString>
+        <JSON>{"compiler-options":{"compiler-type":"CC","compiler":"gcc","compiler-options":"-fno-strict-aliasing -fwrapv -O2 -lpq -lpgcommon -lpgport -lm"},"test-run-times":"173.38"}</JSON>
+      </Entry>
+    </Data>
+  </Result>
+  <Result>
+    <Identifier>pts/pgbench-1.15.0</Identifier>
+    <Title>PostgreSQL</Title>
+    <AppVersion>17</AppVersion>
+    <Arguments>-s 100 -c 50 -S</Arguments>
+    <Description>Scaling Factor: 100 - Clients: 50 - Mode: Read Only - Average Latency</Description>
+    <Scale>ms</Scale>
+    <Proportion>LIB</Proportion>
+    <DisplayFormat>BAR_GRAPH</DisplayFormat>
+    <Data>
+      <Entry>
+        <Identifier>ci</Identifier>
+        <Value>0.711</Value>
+        <RawString></RawString>
+        <JSON>{"compiler-options":{"compiler-type":"CC","compiler":"gcc","compiler-options":"-fno-strict-aliasing -fwrapv -O2 -lpq -lpgcommon -lpgport -lm"},"test-run-times":"173.38"}</JSON>
+      </Entry>
+    </Data>
+  </Result>
+</PhoronixTestSuite>

--- a/packages/results/src/lib/__fixtures__/local-pts/pts_pgbench-read-write.xml
+++ b/packages/results/src/lib/__fixtures__/local-pts/pts_pgbench-read-write.xml
@@ -1,0 +1,61 @@
+<?xml version="1.0"?>
+<!--Phoronix Test Suite v10.8.4-->
+<!--
+  Recorded pts/pgbench-1.15.0 composite for the golden byte-match gate (design par. 3.7): the
+  read-write scenario the benchmark:system:pts:pgbench producer task pins via PRESET_OPTIONS
+  (Scaling Factor: 100, Clients: 50). One run posts a TPS and an Average Latency <Result> (the
+  profile's two parsers, distinct descriptions via AppendToArgumentsDescription).
+
+  REAL output of Phoronix Test Suite 10.8.4 building and running PostgreSQL 17.0 fully locally
+  (server + pgbench client in one machine - the same in-sandbox topology the suite measures),
+  recorded under FORCE_TIMES_TO_RUN=1 with RunAllTestCombinations off - the exact batch path
+  run_pinned_pts drives. The postgresql-17.0.tar.bz2 source was staged from the upstream git tag
+  (release host unreachable from the recording container) and is byte-identical to the canonical
+  release tarball (sha256 verified against the profile's downloads.xml pin). The <System>
+  host-fingerprint block was removed (recording-container identity, not result data); the <Result>
+  nodes are verbatim.
+-->
+<PhoronixTestSuite>
+  <Generated>
+    <Title>fixture-pgbench-rw</Title>
+    <LastModified>2026-07-13 03:53:52</LastModified>
+    <TestClient>Phoronix Test Suite v10.8.4</TestClient>
+    <Description>docker testing on Ubuntu 24.04 via the Phoronix Test Suite.</Description>
+  </Generated>
+  <Result>
+    <Identifier>pts/pgbench-1.15.0</Identifier>
+    <Title>PostgreSQL</Title>
+    <AppVersion>17</AppVersion>
+    <Arguments>-s 100 -c 50</Arguments>
+    <Description>Scaling Factor: 100 - Clients: 50 - Mode: Read Write</Description>
+    <Scale>TPS</Scale>
+    <Proportion>HIB</Proportion>
+    <DisplayFormat>BAR_GRAPH</DisplayFormat>
+    <Data>
+      <Entry>
+        <Identifier>ci</Identifier>
+        <Value>5653</Value>
+        <RawString>5653.074515</RawString>
+        <JSON>{"compiler-options":{"compiler-type":"CC","compiler":"gcc","compiler-options":"-fno-strict-aliasing -fwrapv -O2 -lpq -lpgcommon -lpgport -lm"},"test-run-times":"149.07"}</JSON>
+      </Entry>
+    </Data>
+  </Result>
+  <Result>
+    <Identifier>pts/pgbench-1.15.0</Identifier>
+    <Title>PostgreSQL</Title>
+    <AppVersion>17</AppVersion>
+    <Arguments>-s 100 -c 50</Arguments>
+    <Description>Scaling Factor: 100 - Clients: 50 - Mode: Read Write - Average Latency</Description>
+    <Scale>ms</Scale>
+    <Proportion>LIB</Proportion>
+    <DisplayFormat>BAR_GRAPH</DisplayFormat>
+    <Data>
+      <Entry>
+        <Identifier>ci</Identifier>
+        <Value>8.845</Value>
+        <RawString></RawString>
+        <JSON>{"compiler-options":{"compiler-type":"CC","compiler":"gcc","compiler-options":"-fno-strict-aliasing -fwrapv -O2 -lpq -lpgcommon -lpgport -lm"},"test-run-times":"149.07"}</JSON>
+      </Entry>
+    </Data>
+  </Result>
+</PhoronixTestSuite>

--- a/packages/schema/src/pts-overrides.ts
+++ b/packages/schema/src/pts-overrides.ts
@@ -23,6 +23,18 @@ export const ptsOverrides: Record<string, MetricOverride> = {
 	// rounds it out. Both single-result wildcards, so curation only supplies labels + the one headline.
 	pybench_milliseconds: { headline: true, label: "PyBench" },
 	sqlite_speedtest_seconds: { label: "SQLite Speedtest" },
+	// System dimension: PostgreSQL via pgbench, pinned by the producer to scale 100 / 50 clients per
+	// mode (the generator's other 156 combination entries keep draft labels and never get samples).
+	pgbench_scaling_factor_100_clients_50_mode_read_only: { label: "pgbench RO (s100, 50c)" },
+	pgbench_scaling_factor_100_clients_50_mode_read_only_average_latency: {
+		label: "pgbench RO latency (s100, 50c)",
+	},
+	pgbench_scaling_factor_100_clients_50_mode_read_write: { label: "pgbench RW (s100, 50c)" },
+	pgbench_scaling_factor_100_clients_50_mode_read_write_average_latency: {
+		label: "pgbench RW latency (s100, 50c)",
+	},
+	// Memory dimension: STREAM Triad is the canonical headline (the fused multiply-add is the most
+	// representative memory-bandwidth figure); the other three operations round out the matrix.
 	stream_type_triad: { headline: true, label: "STREAM Triad" },
 	stream_type_copy: { label: "STREAM Copy" },
 	stream_type_scale: { label: "STREAM Scale" },
@@ -80,6 +92,36 @@ export const ptsOverrides: Record<string, MetricOverride> = {
 	// with no external endpoint, so it isolates the sandbox's network stack (virtio vs gVisor netstack
 	// vs host namespaces) from internet weather.
 	network_loopback_seconds: { headline: true, label: "Loopback TCP (10GB)" },
+
+	// Cpu dimension (cpu-generic suite): Zstd compression across its Compression Level matrix — the
+	// classic CPU-throughput synthetic, run over every level in batch mode. Two metrics per level
+	// (compress/decompress via AppendToArgumentsDescription). node-web-tooling keeps the cpu headline.
+	compress_zstd_compression_level_3_compression_speed: { label: "Zstd 3 compress" },
+	compress_zstd_compression_level_3_decompression_speed: { label: "Zstd 3 decompress" },
+	compress_zstd_compression_level_3_long_mode_compression_speed: {
+		label: "Zstd 3 (long) compress",
+	},
+	compress_zstd_compression_level_3_long_mode_decompression_speed: {
+		label: "Zstd 3 (long) decompress",
+	},
+	compress_zstd_compression_level_8_compression_speed: { label: "Zstd 8 compress" },
+	compress_zstd_compression_level_8_decompression_speed: { label: "Zstd 8 decompress" },
+	compress_zstd_compression_level_8_long_mode_compression_speed: {
+		label: "Zstd 8 (long) compress",
+	},
+	compress_zstd_compression_level_8_long_mode_decompression_speed: {
+		label: "Zstd 8 (long) decompress",
+	},
+	compress_zstd_compression_level_12_compression_speed: { label: "Zstd 12 compress" },
+	compress_zstd_compression_level_12_decompression_speed: { label: "Zstd 12 decompress" },
+	compress_zstd_compression_level_19_compression_speed: { label: "Zstd 19 compress" },
+	compress_zstd_compression_level_19_decompression_speed: { label: "Zstd 19 decompress" },
+	compress_zstd_compression_level_19_long_mode_compression_speed: {
+		label: "Zstd 19 (long) compress",
+	},
+	compress_zstd_compression_level_19_long_mode_decompression_speed: {
+		label: "Zstd 19 (long) decompress",
+	},
 
 	// Realworld dimension (ENG-135/137): mastra-ai/mastra run through its own CI tasks, a repo-local
 	// PTS profile with a Task option axis. TestType System's default dimension is corrected to

--- a/packages/schema/src/suites.test.ts
+++ b/packages/schema/src/suites.test.ts
@@ -47,6 +47,29 @@ describe("suite registry", () => {
 		}
 	});
 
+	it("mirrors the unpinned suites' metrics from the generated catalog (no hand-drift)", () => {
+		// These suites batch-run their profiles WITHOUT PRESET_OPTIONS, so whatever the catalog lists for
+		// the test is exactly what the suite emits — pin the declared list to it in BOTH directions (a
+		// profile bump that adds/renames a combination fails here instead of silently stranding the
+		// list). stream's Type axis is the real matrix case; pybench and sqlite-speedtest declare no
+		// <Option> axes at all, so the pin holds over their single wildcard result. The suites that
+		// arrive later (network, cpu-generic) add themselves here.
+		const profilesOf = {
+			memory: ["pts/stream"],
+			system: ["pts/pybench", "pts/sqlite-speedtest"],
+		} as const;
+		for (const [suiteName, ptsTests] of Object.entries(profilesOf)) {
+			const fromCatalog = METRIC_CATALOG.filter(
+				(m) => m.pts && (ptsTests as readonly string[]).includes(m.pts.test),
+			)
+				.map((m) => m.id)
+				.sort();
+			expect(fromCatalog.length).toBeGreaterThan(0);
+			const declared: string[] = [...SUITES[suiteName as keyof typeof SUITES].metrics];
+			expect(declared.sort()).toEqual(fromCatalog);
+		}
+	});
+
 	it("keeps command timeouts within the requested sandbox lifetime", () => {
 		for (const suite of Object.values(SUITES)) {
 			expect(suite.commandTimeoutMinutes).toBeLessThanOrEqual(suite.timeoutMinutes);


### PR DESCRIPTION
**PTS BENCHMARK MATRIX — vendor the PTS catalog, then light up four benchmark suites.**
Shipped as a 12-PR stack. The trunk merges bottom-up; the four suite PRs at the top are SIBLINGS and
can be reviewed (and merged) in parallel — none blocks the others.

```
main
 └─ #136  schema: scale-aware PTS metric identity (pts.scale) + O(1) matcher
     └─ #137  catalog generator: per-parser scales + virtual axes
         └─ #138  ⚙ VENDOR fio + regenerate catalog        (autogenerated)
             └─ #146  fio curation + disk headline + goldens
                 └─ #139  ⚙ VENDOR loopback/zstd/pgbench + regenerate   (autogenerated)
                     └─ #147  their curation + recorded fixtures
                         └─ #148  shared PTS runner (lib/bench.sh)
                             └─ #144  toolchain image: bake PTS deps + pin drift gates
                                 ├─ #140  disk suite     ┐
                                 ├─ #141  network suite  │  siblings — parallel review
                                 ├─ #142  cpu-generic    │
                                 └─ #143  system suite   ┘
```
⚙ = the diff is machine-produced; reproduce it with the commands in the body. Everything hand-written
was lifted out into the small PR directly above it.

↑ **This PR is #147 (6/12) — the hand-written half, based on #139.**

---

Hand-written layer on top of the vendored/regenerated catalog below. Purely additive — 467 lines, no
removals:

- pts-overrides.ts: short labels for the zstd Compression Level matrix (compress/decompress per
  level) and for the four pgbench metrics the producer actually pins (scale 100 / 50 clients, TPS +
  Average Latency per mode). The generator's other 156 pgbench combinations keep draft labels and
  never receive samples. Neither profile needs a headline — zstd lands in `cpu` (headlined by
  node-web-tooling) and pgbench in `system` (headlined by PyBench), which is why only the network
  headline was forced down into the vendor PR.
- Four RECORDED composites (real PTS output) that extend the golden byte-match gate to these
  profiles, proving each synthesized `pts.description` byte-matches what PTS actually emits.

Note the zstd fixture holds 13 <Result>s, not the 14 its 7-level menu implies: the recording is
missing "Compression Level: 3 - Decompression Speed" (the level-3 run's timing matches the two-phase
duration of every paired sibling, so PTS dropped the node). Fixtures are verbatim and never
hand-repaired, so the header says so and states what the gate therefore does not cover.

Co-authored-by: Daniel Worku <daniel@starsling.dev>

## Validation

Every branch in this stack was checked out **in isolation** (i.e. on top of its own parent, with
nothing from the PRs above it) and run through the full gate set. A reviewer merges bottom-up, so
each PR has to stand on its own — this is what verifies that.

**This PR (`04b`), verified standalone — all seven gates green:**

| gate | command | result |
|---|---|---|
| install | `bun install --frozen-lockfile` | ✅ |
| typecheck | `bun run typecheck` | ✅ |
| lint | `bun run lint` (biome, `--error-on-warnings`) | ✅ |
| spell | `mise exec -- typos` | ✅ |
| shell | `bun run lint:shell` (shellcheck) | ✅ |
| catalog drift | `bun run check:catalog-drift` | ✅ |
| tests | `bun run test` (whole workspace) | ✅ **572 passing, 0 failing** |

The same matrix is green on all 12 branches, and the passing-test count climbs monotonically up the
trunk (535 → 576) — each PR adds coverage and none regresses it.

**What this PR's own tests prove:**

- The golden byte-match gate extends to **four more RECORDED composites** (zstd, network-loopback, pgbench read-only + read-write), proving their synthesized descriptions byte-match real PTS output.
- The curated override keys are pinned against the suite declarations, so a wrong-axis id can't pass the suite contract and then silently never receive samples.

### What this does NOT prove

Being explicit, because the gates above are all static:

- **No benchmark has been run on a real provider sandbox.** Nothing in CI executes the `.mise` producer
  tasks against a live Phoronix Test Suite. Their correctness rests on `shellcheck`, on the golden
  byte-match gate (which compares against RECORDED composites — real PTS output, but replayed, not
  produced), and on the suite-contract tests. The first live signal is the `bench-smoke` workflow
  (manual dispatch) after these merge.
- **The image is only built by CI on #144** — it is the only PR that touches it. The suite PRs assume
  that image; they do not rebuild it.
- `Bake, validate & promote toolchain` is skipped on pull requests by design
  (`if: github.event_name != 'pull_request'`), so image PROMOTION is exercised only on `main`.
- The recorded fixtures prove byte-match against PTS output captured at a point in time; a future PTS
  release could change a `<Description>` string. That is precisely what the golden gate would catch.

Additionally, the four suite PRs at the top are siblings on #144; merging all four reproduces the
pre-restructure tree byte-for-byte (verified), so the 12-PR split moved every change and dropped none.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Curated `zstd` and `pgbench` entries in the PTS metric catalog and added recorded fixtures to extend the golden byte‑match gate. Clarifies labels and verifies generated descriptions against real PTS output.

- **New Features**
  - `packages/schema/src/pts-overrides.ts`: short labels for the `zstd` Compression Level matrix (compress/decompress for 3, 8, 12, 19 incl. long mode) and the four pinned `pgbench` metrics (scale 100, 50 clients: RO/RW TPS and Avg Latency).
  - `packages/results/src/lib/__fixtures__/local-pts/`: recorded composites `pts_compress-zstd.xml` (13 results; level‑3 decompress missing), `pts_pgbench-read-only.xml`, `pts_pgbench-read-write.xml`, and `pts_network-loopback.xml`.
  - `packages/schema/src/suites.test.ts`: pins unpinned suites’ metric lists to the generated catalog to prevent drift.

<sup>Written for commit e5b1de9f7696a67875b148e9217e2d80b4b50494. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/starslingdev/sandbox-benchmarks/pull/147?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

