### PR TITLE
feat(bench): shared PTS runner — pinned-option leaves, per-leaf save names, real install verification

### DIFF
--- a/lib/bench.sh
+++ b/lib/bench.sh
@@ -159,6 +159,22 @@ pts_user_dir() {
 	echo "$dir"
 }
 
+# Resolve the config file PTS itself reads and writes, mirroring its own selection order
+# (pts_config::get_config_file_location + pts_config_nye_XmlReader::__construct, v10.8.4). PTS sets
+# PTS_IS_DAEMONIZED_SERVER_PROCESS whenever /var/lib AND /etc are both writable — i.e. whenever it
+# runs as root, which is every sandbox provider here — and in that mode it uses
+# /etc/phoronix-test-suite.xml UNCONDITIONALLY, without so much as probing the user dir. So under
+# root, user-config.xml is the file PTS never touches, and /etc is the live config. Only an
+# unprivileged run falls through to ${PTS_USER_PATH}/user-config.xml — and even then a writable
+# /etc/phoronix-test-suite.xml, if one exists, still wins.
+pts_config_file() {
+	if { [ -w /var/lib ] && [ -w /etc ]; } || [ -w /etc/phoronix-test-suite.xml ]; then
+		echo /etc/phoronix-test-suite.xml
+		return 0
+	fi
+	echo "$(pts_user_dir)/user-config.xml"
+}
+
 # Configure PTS batch mode in the current process. Must run before batch-run, since mise subtasks
 # don't inherit the parent's env.
 _configure_pts_batch() {
@@ -173,7 +189,10 @@ _configure_pts_batch() {
 	# test's option matrix — which would run build-dependent tasks before the measured `build`
 	# their unmeasured prep replays (correct either way, but the prep then pays a full rebuild).
 	export TEST_EXECUTION_SORT=none
-	export TEST_RESULTS_NAME=benchmark
+	# TEST_RESULTS_NAME is set per leaf by run_pts_benchmark (benchmark-<prefix>): PTS MERGES batch-runs
+	# that share a save name into one result dir and rewrites its composite.xml even when a run produced
+	# zero successful results (pts_test_run_manager::standard_run → post_execution_process), so a shared
+	# name would let a failed later leaf collect an earlier leaf's merged composite as its own.
 	export TEST_RESULTS_DESCRIPTION=ci
 	export TEST_RESULTS_IDENTIFIER=ci
 	# FORCE_TIMES_TO_RUN=1 pins every test to a single pass (fast, but no in-sandbox repeats to
@@ -186,7 +205,41 @@ _configure_pts_batch() {
 	fi
 	# batch-setup answers: SaveResults, OpenBrowser, UploadResults, PromptForTestIdentifier,
 	# PromptForTestDescription, PromptSaveName, RunAllTestCombinations.
-	printf 'y\nn\nn\nn\nn\nn\ny\n' | phoronix-test-suite batch-setup 2>/dev/null || true
+	#
+	# The last answer is overridable because PTS's batch runner consults PRESET_OPTIONS ONLY when
+	# RunAllTestCombinations is off (pts_test_run_manager::test_prompts_to_result_objects) — a
+	# pinned-scenario caller (run_pinned_pts) exports PTS_RUN_ALL_TEST_COMBINATIONS=n around its run,
+	# and the next unpinned caller's reconfigure restores the run-all default the option-matrix suites
+	# (STREAM's Type axis, the realworld Task axis, compress-zstd's levels) rely on.
+	printf 'y\nn\nn\nn\nn\nn\n%s\n' "${PTS_RUN_ALL_TEST_COMBINATIONS:-y}" | phoronix-test-suite batch-setup 2>/dev/null || true
+	# batch-setup's failure is swallowed above, so verify the on-disk config in BOTH directions — the
+	# flip is a state change either way. A PINNED caller depends on FALSE landing (PTS would otherwise
+	# ignore its presets and fan out the whole option matrix); an UNPINNED caller depends on TRUE being
+	# restored after a pinned leaf left FALSE behind (a persisted FALSE with no PRESET_OPTIONS drops
+	# PTS into its interactive option prompt, which loops on EOF stdin until the command timeout).
+	# The config lives at /etc/phoronix-test-suite.xml for root (the sandbox case) or under $HOME for
+	# unprivileged runs. Idempotent under retry: once any call has landed the wanted value on disk,
+	# later verifications pass even if their own batch-setup hiccuped.
+	local want cfg
+	if [ "${PTS_RUN_ALL_TEST_COMBINATIONS:-y}" = "n" ]; then
+		want="FALSE"
+	else
+		want="TRUE"
+	fi
+	# pts_init BEFORE the first pts_user_dir: pts_user_dir detects the data dir by probing for
+	# core.pt2so and then CACHES the answer for the life of the process. This function is the first
+	# thing to touch PTS in a run, so without an explicit init the probe can miss (no core.pt2so yet)
+	# and permanently cache ${HOME}/.phoronix-test-suite — the wrong dir for the root sandbox, where
+	# PTS keeps its state under /var/lib. Every later lookup (this check, the install probe, the
+	# composite search) would then read a path PTS never writes. pts_init is idempotent and cheap.
+	pts_init
+	# Verify the ONE file PTS actually consults (pts_config_file), never a first-match-wins OR across
+	# both candidates: a stale copy of the OTHER file holding the wanted value would green-light a
+	# pinned run that then ignores PRESET_OPTIONS and fans out the whole option matrix — precisely the
+	# failure this check exists to prevent. A missing config means batch-setup wrote nothing at all.
+	cfg="$(pts_config_file)"
+	[ -f "$cfg" ] || return 1
+	grep -q "<RunAllTestCombinations>${want}</RunAllTestCombinations>" "$cfg"
 }
 
 # Ensure phoronix-test-suite is available, configuring batch mode. The toolchain image bakes PTS, so
@@ -202,9 +255,14 @@ ensure_pts() {
 			tmp_deb="$(mktemp /tmp/pts-XXXXXX.deb)"
 			# Group with `|| true` so a failed install can't abort a caller running under `set -e` —
 			# ensure_pts's contract is to return 1 gracefully so the caller can skip.
+			# The package list mirrors the harness setup fallback (packages/harness/src/lib/setup.ts):
+			# php for PTS itself, the build toolchain for the source-built profiles, libaio-dev (fio's
+			# Linux AIO engine), libicu-dev (postgres's configure hard-requires ICU), and the probe deps
+			# — without them the profiles install "successfully" and then burn their timed runs failing.
 			(curl -fsSL "$deb_url" -o "$tmp_deb" &&
 				${SUDO:-} apt-get update -qq &&
-				${SUDO:-} apt-get install -y -qq php-cli php-xml &&
+				${SUDO:-} apt-get install -y -qq php-cli php-xml build-essential flex bison bc \
+					libelf-dev libssl-dev libaio-dev libicu-dev dnsutils jq netcat-openbsd iputils-ping &&
 				${SUDO:-} dpkg -i "$tmp_deb") || true
 			rm -f "$tmp_deb"
 		fi
@@ -262,14 +320,62 @@ install_local_pts_profile() {
 # Usage: run_pts_benchmark <test-name> <results-prefix>
 run_pts_benchmark() {
 	local test_name="$1" prefix="$2"
-	_configure_pts_batch
-
-	echo "=== Installing PTS test: ${test_name} ==="
-	phoronix-test-suite batch-install "$test_name" 2>&1 || {
-		echo "WARNING: PTS install of ${test_name} failed"
-		skip_result "PTS install of ${test_name} failed" "$prefix"
+	if ! _configure_pts_batch; then
+		# batch-setup never landed a usable config (see _configure_pts_batch): batch-run would either
+		# error out or fall into an interactive prompt loop that burns the whole command budget.
+		skip_result "PTS batch mode could not be configured (batch-setup failed)" "$prefix"
 		return 0
-	}
+	fi
+
+	# Isolate this leaf's results under its own save name (see _configure_pts_batch on why sharing one
+	# name would let a failed leaf collect a predecessor's merged composite). Sanitized to the
+	# lowercase-alnum-dash alphabet PTS save names pass through unchanged, so the find below matches
+	# the directory PTS actually creates.
+	local save_name
+	save_name="benchmark-$(printf '%s' "$prefix" | tr -cs 'a-z0-9' '-')"
+	export TEST_RESULTS_NAME="$save_name"
+
+	# Skip the install for a version-pinned test that is already on disk (the toolchain image
+	# pre-installs every registered profile): batch-install would only no-op through several seconds
+	# of PHP. Probe the ONE data dir this PTS invocation will actually use (pts_init first, so
+	# pts_user_dir doesn't cache the $HOME fallback on a fresh machine — the fio_direct_choice
+	# precedent), and require the pts-install.xml manifest, not the bare directory: PTS only treats a
+	# test as installed once that manifest exists, so a batch-install killed mid-build would otherwise
+	# permanently disable both install and run. (Trade-off vs full batch-install: PTS's same-version
+	# reinstall triggers — installer checksum, system hash — are bypassed for baked profiles.)
+	local installed=""
+	pts_init
+	if [ -f "$(pts_user_dir)/installed-tests/${test_name}/pts-install.xml" ]; then
+		installed=1
+	fi
+	if [ -n "$installed" ]; then
+		echo "=== PTS test already installed (baked): ${test_name} ==="
+	else
+		echo "=== Installing PTS test: ${test_name} ==="
+		phoronix-test-suite batch-install "$test_name" 2>&1 || {
+			echo "WARNING: PTS install of ${test_name} failed"
+			skip_result "PTS install of ${test_name} failed" "$prefix"
+			return 0
+		}
+		# PTS EXITS 0 EVEN WHEN AN INSTALL FAILS (it writes install-failed.log and moves on), so the
+		# `||` branch above is dead for the common failure — a missing build dependency. Without this
+		# the leaf proceeds to batch-run, burns its whole budget producing nothing, and lands on the
+		# generic "produced no composite.xml" skip that names the wrong cause. Re-probe the manifest.
+		if [ ! -f "$(pts_user_dir)/installed-tests/${test_name}/pts-install.xml" ]; then
+			echo "WARNING: PTS reported success but ${test_name} is not installed (see install-failed.log)"
+			skip_result "PTS install of ${test_name} failed (exit 0, no pts-install.xml)" "$prefix"
+			return 0
+		fi
+	fi
+
+	# Stamp the instant before the run: the composite search below must only accept output THIS
+	# batch-run wrote. Suites now run several PTS leaves in one sandbox (fio ×4 + hardlink; pybench +
+	# sqlite + pgbench ×2), so a bare "newest composite" would, when a later batch-run produces
+	# nothing, silently copy the PREVIOUS leaf's composite under this leaf's prefix — masking the
+	# failure AND suppressing the skip marker. (A merged-into result dir still matches: PTS rewrites
+	# composite.xml, updating its mtime past the stamp.)
+	local run_stamp
+	run_stamp="$(mktemp)"
 
 	bench_cmd "PTS: ${test_name}" "$prefix" phoronix-test-suite batch-run "$test_name"
 
@@ -281,10 +387,13 @@ run_pts_benchmark() {
 		# `find … -exec ls -t {} +` is portable (no GNU `-printf`, which crashes BSD/macOS `find` under
 		# `set -e`) and runs `ls -t` only when matches exist (so an empty match can't list `.` and copy a
 		# stray file). `ls -t` orders newest-first; head -1 takes it.
-		# Scope to benchmark-named result dirs (TEST_RESULTS_NAME=benchmark, plus PTS's -1/-2 suffixes)
-		# so a stray composite.xml under another result name can't be misattributed as suites accumulate.
-		xml_found=$(find "$pts_base" -path "*benchmark*/composite.xml" -exec ls -t {} + 2>/dev/null | head -1)
+		# Scope to THIS leaf's save name (TEST_RESULTS_NAME=benchmark-<prefix>, plus PTS's -1/-2
+		# suffixes) so another leaf's composite can never be misattributed to this one, and to files
+		# newer than the pre-run stamp so a stale dir from a previous run of the SAME leaf can't stand
+		# in for a failed run (see run_stamp above).
+		xml_found=$(find "$pts_base" -path "*${save_name}*/composite.xml" -newer "$run_stamp" -exec ls -t {} + 2>/dev/null | head -1)
 	fi
+	rm -f "$run_stamp"
 	if [ -n "$xml_found" ] && [ -f "$xml_found" ]; then
 		cp "$xml_found" "$(results_dir)/${prefix}.xml" 2>/dev/null || true
 		echo "Structured result: ${prefix}.xml (from $(dirname "$xml_found"))"
@@ -305,6 +414,45 @@ run_pts_benchmark() {
 		skip_result "PTS batch-run of ${test_name} produced no composite.xml" "$prefix"
 	fi
 	return 0
+}
+
+# Run ONE PTS test with a fully-pinned option combination. PRESET_OPTIONS pins every axis so
+# batch-run executes exactly one combination instead of the profile's whole matrix. Owns the
+# phoronix-test-suite availability guard (like run_realworld_pts), so pinned leaves don't replicate it.
+#
+# RunAllTestCombinations MUST be off for the run: PTS's batch path only consults PRESET_OPTIONS on
+# that branch (pts_test_run_manager::test_prompts_to_result_objects) — with the repo's run-all default
+# it ignores the presets and fans out the full option matrix (for fio, hundreds of 60s runs).
+# PTS_RUN_ALL_TEST_COMBINATIONS=n reaches batch-setup via _configure_pts_batch INSIDE
+# run_pts_benchmark (setting the config before the call would be undone by that reconfigure); the
+# next unpinned PTS child's reconfigure restores the run-all default the option-matrix suites rely on.
+# _configure_pts_batch itself verifies the flip landed on disk when pinning is requested (returning
+# non-zero on failure), so the pre-call below exists to catch that failure and skip honestly rather
+# than let a silently-ignored preset fan out the matrix until the suite timeout kills the cell.
+# run_pts_benchmark's own (idempotent) reconfigure re-verifies against the already-flipped config.
+#
+# Preset values are the runtime option NAMES (PTS matches non-numeric presets by entry name), with
+# ONE trap: a NUMERIC preset that is < the menu's entry count is interpreted as a 0-based menu INDEX,
+# never a name (pts_test_option::is_valid_select_choice) — pin small numeric menus by index, larger
+# numeric names (pgbench's "100"/"50") match by name because they exceed the entry count.
+# Usage: run_pinned_pts <versioned-test> <results-prefix> <preset-options>
+run_pinned_pts() {
+	local test_name="$1" prefix="$2" presets="$3"
+	if ! command -v phoronix-test-suite &>/dev/null; then
+		skip_result "phoronix-test-suite not installed" "$prefix"
+		return 0
+	fi
+
+	export PTS_RUN_ALL_TEST_COMBINATIONS=n
+	export PRESET_OPTIONS="$presets"
+	if ! _configure_pts_batch; then
+		skip_result "could not disable RunAllTestCombinations (batch-setup failed?) — refusing to fan out the full ${test_name} option matrix" "$prefix"
+		unset PRESET_OPTIONS PTS_RUN_ALL_TEST_COMBINATIONS
+		return 0
+	fi
+
+	run_pts_benchmark "$test_name" "$prefix"
+	unset PRESET_OPTIONS PTS_RUN_ALL_TEST_COMBINATIONS
 }
 
 # Run one realworld suite end to end: gate on the toolchain, install the repo-local profile with


### PR DESCRIPTION
**PTS BENCHMARK MATRIX — vendor the PTS catalog, then light up four benchmark suites.**
Shipped as a 12-PR stack. The trunk merges bottom-up; the four suite PRs at the top are SIBLINGS and
can be reviewed (and merged) in parallel — none blocks the others.

```
main
 └─ #136  schema: scale-aware PTS metric identity (pts.scale) + O(1) matcher
     └─ #137  catalog generator: per-parser scales + virtual axes
         └─ #138  ⚙ VENDOR fio + regenerate catalog        (autogenerated)
             └─ #146  fio curation + disk headline + goldens
                 └─ #139  ⚙ VENDOR loopback/zstd/pgbench + regenerate   (autogenerated)
                     └─ #147  their curation + recorded fixtures
                         └─ #148  shared PTS runner (lib/bench.sh)
                             └─ #144  toolchain image: bake PTS deps + pin drift gates
                                 ├─ #140  disk suite     ┐
                                 ├─ #141  network suite  │  siblings — parallel review
                                 ├─ #142  cpu-generic    │
                                 └─ #143  system suite   ┘
```
⚙ = the diff is machine-produced; reproduce it with the commands in the body. Everything hand-written
was lifted out into the small PR directly above it.

↑ **This PR is #148 (7/12) — shared runner, based on #147.**

---

The PTS runner every suite above depends on. It lands BELOW the four suite PRs precisely because it
is shared: run_pinned_pts is called by both the disk and the system suites, so it cannot live inside
either one — a sibling that owned it would leave the other red.

- run_pts_benchmark re-probes pts-install.xml after batch-install. PTS EXITS 0 even when an install
  fails (it writes install-failed.log and moves on), so the `|| skip` branch was dead for the common
  failure — a missing build dep — and the leaf ran on to burn its whole budget before landing on a
  generic "produced no composite.xml" skip that named the wrong cause.
- Per-leaf TEST_RESULTS_NAME, with the composite search scoped to it: two leaves of one profile
  (pgbench read-only + read-write) otherwise share a save dir, and PTS MERGES them — so a failed
  second leaf would collect the first leaf's composite and report its numbers.
- run_pinned_pts pins one option combination per leaf via PRESET_OPTIONS, and the batch-config flip
  is verified in BOTH directions against $(pts_user_dir)/user-config.xml — not a hard-coded ${HOME},
  which PTS does not use (it resolves the passwd home), so a sandbox overriding HOME had batch-setup
  write the flip to one path while the check grepped another.

fio's helpers (run_fio_pts, fio_direct_choice) are deliberately NOT here — only the disk suite uses
them, so they ship in that PR.

Co-authored-by: Daniel Worku <daniel@starsling.dev>

## Validation

Every branch in this stack was checked out **in isolation** (i.e. on top of its own parent, with
nothing from the PRs above it) and run through the full gate set. A reviewer merges bottom-up, so
each PR has to stand on its own — this is what verifies that.

**This PR (`04c`), verified standalone — all seven gates green:**

| gate | command | result |
|---|---|---|
| install | `bun install --frozen-lockfile` | ✅ |
| typecheck | `bun run typecheck` | ✅ |
| lint | `bun run lint` (biome, `--error-on-warnings`) | ✅ |
| spell | `mise exec -- typos` | ✅ |
| shell | `bun run lint:shell` (shellcheck) | ✅ |
| catalog drift | `bun run check:catalog-drift` | ✅ |
| tests | `bun run test` (whole workspace) | ✅ **572 passing, 0 failing** |

The same matrix is green on all 12 branches, and the passing-test count climbs monotonically up the
trunk (535 → 576) — each PR adds coverage and none regresses it.

**What this PR's own tests prove:**

- `shellcheck` over `lib/bench.sh` (the repo's `lint:shell` gate).
- Note this PR is pure shell: its logic is **not executed** by CI (see the gap below). It is placed below the suites so that `run_pinned_pts` — called by both the disk and system suites — cannot be owned by a sibling.

### What this does NOT prove

Being explicit, because the gates above are all static:

- **No benchmark has been run on a real provider sandbox.** Nothing in CI executes the `.mise` producer
  tasks against a live Phoronix Test Suite. Their correctness rests on `shellcheck`, on the golden
  byte-match gate (which compares against RECORDED composites — real PTS output, but replayed, not
  produced), and on the suite-contract tests. The first live signal is the `bench-smoke` workflow
  (manual dispatch) after these merge.
- **The image is only built by CI on #144** — it is the only PR that touches it. The suite PRs assume
  that image; they do not rebuild it.
- `Bake, validate & promote toolchain` is skipped on pull requests by design
  (`if: github.event_name != 'pull_request'`), so image PROMOTION is exercised only on `main`.
- The recorded fixtures prove byte-match against PTS output captured at a point in time; a future PTS
  release could change a `<Description>` string. That is precisely what the golden gate would catch.

Additionally, the four suite PRs at the top are siblings on #144; merging all four reproduces the
pre-restructure tree byte-for-byte (verified), so the 12-PR split moved every change and dropped none.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a shared PTS runner with pinned-option leaves, per-leaf save names, and strict install/config verification to prevent misattributed results and runaway option matrices. Initializes PTS early and verifies `RunAllTestCombinations` in the config PTS actually reads (mirrors `/etc`-first precedence under root).

- **New Features**
  - Added `run_pinned_pts` to run a single option combo via `PRESET_OPTIONS`, disabling `RunAllTestCombinations` for that run and restoring it afterward (pre-verifies the flip).
  - `run_pts_benchmark` sets a per-leaf `TEST_RESULTS_NAME` (`benchmark-<prefix>`) and copies only that leaf’s `composite.xml` newer than a pre-run stamp.
  - Skips `batch-install` when `$(pts_user_dir)/installed-tests/<test>/pts-install.xml` exists; `ensure_pts` installs PTS plus required build/probe deps (php, toolchain, ICU, network/probe tools).

- **Bug Fixes**
  - Re-checks for `pts-install.xml` after `batch-install` (PTS can exit 0 on failed installs) and skips with a clear reason.
  - Calls `pts_init` before the first `pts_user_dir`; config/value checks use `pts_config_file` to target the exact file PTS consults (`/etc/phoronix-test-suite.xml` under root, else user config).
  - Fails fast when batch mode can’t be configured to avoid interactive option prompts/timeouts; pinned runs refuse to fan out if the run-all flag cannot be disabled.

<sup>Written for commit fdefe7cb700509111df16982e578c02316a8a594. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/starslingdev/sandbox-benchmarks/pull/148?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

