### PR TITLE
refactor(ci): stage toolchain-image release into plan/build/bake-matrix/promote

### DIFF
--- a/.github/actions/ensure-package-public/action.yml
+++ b/.github/actions/ensure-package-public/action.yml
@@ -1,10 +1,11 @@
 name: Ensure GHCR package is public
 description: >-
-  Fail fast if the candidate base package is not public. e2b builds its template on E2B's REMOTE
-  builder (FROM the ghcr candidate base) and daytona/modal/novita pull it to snapshot/boot — none are
-  handed ghcr pull credentials, so the candidate package MUST be public. GHCR packages are created
-  PRIVATE on first push with no API to flip visibility, so making it public is a one-time manual
-  bootstrap; this guard surfaces that plainly instead of an opaque provider "unauthorized" pull error.
+  Fail fast (with @actions/core annotations, via release-ensure-public.ts) if the candidate base package
+  is not public. e2b builds its template on E2B's REMOTE builder (FROM the ghcr candidate base) and
+  daytona/modal/novita pull it to snapshot/boot — none are handed ghcr pull credentials, so the candidate
+  package MUST be public. GHCR packages are created PRIVATE on first push with no API to flip visibility,
+  so making it public is a one-time manual bootstrap; this guard surfaces that plainly instead of an
+  opaque provider "unauthorized" pull error.
 
 inputs:
   owner:
@@ -22,41 +23,10 @@ runs:
   steps:
     - name: Ensure candidate package is public
       shell: bash
+      # Inputs reach the script as env (a composite `run` step gets no INPUT_* vars). The script does a
+      # real fetch + JSON parse and reports via core.setFailed/warning so the outcome is a run annotation.
       env:
-        IMAGE_OWNER: ${{ inputs.owner }}
-        IMAGE_NAME: ${{ inputs.package }}
+        OWNER: ${{ inputs.owner }}
+        PACKAGE: ${{ inputs.package }}
         GH_TOKEN: ${{ inputs.token }}
-      run: |
-        set -euo pipefail
-        # Capture the HTTP status separately so a real "absent" (404) is distinguished from auth/scope
-        # failures (403 SSO/token gap) and transport errors — `curl -f ... || echo '{}'` would collapse
-        # all of them into the same empty fallback and let the release proceed on a false "not found".
-        # A unique mktemp file (not a hardcoded /tmp path) avoids collisions/symlink races on the
-        # shared self-hosted runner; an `if !` block keeps `set -e` active around the curl (a `|| { }`
-        # group would suspend it).
-        api="https://api.github.com/orgs/${IMAGE_OWNER}/packages/container/${IMAGE_NAME}"
-        pkg_json="$(mktemp)"
-        if ! code="$(curl -sS -m 30 -o "${pkg_json}" -w '%{http_code}' \
-          -H "Authorization: Bearer ${GH_TOKEN}" \
-          -H "Accept: application/vnd.github+json" \
-          "${api}")"; then
-          echo "::error::Could not reach the GHCR package API (network/transport error) — refusing to publish blind."
-          exit 1
-        fi
-        case "${code}" in
-          200)
-            if grep -qE '"visibility"[[:space:]]*:[[:space:]]*"public"' "${pkg_json}"; then
-              echo "GHCR package ${IMAGE_OWNER}/${IMAGE_NAME} is public — providers can pull the candidate."
-            else
-              echo "::error::GHCR package ${IMAGE_OWNER}/${IMAGE_NAME} is not public. e2b/daytona/modal/novita pull the candidate base anonymously, so set it Public once (org package settings or link it to this repo), then re-run."
-              exit 1
-            fi
-            ;;
-          404)
-            echo "::warning::GHCR package ${IMAGE_OWNER}/${IMAGE_NAME} not found yet — the build below creates it PRIVATE. After this run, set it Public once so the candidate validate and the providers can pull it; this run's bake will fail until then."
-            ;;
-          *)
-            echo "::error::GHCR package API returned HTTP ${code} (expected 200 or 404) — likely a token-scope gap or org SSO enforcement, not a missing package. Resolve and re-run instead of publishing blind."
-            exit 1
-            ;;
-        esac
+      run: bun apps/cli/src/bin/release-ensure-public.ts

--- a/.github/actions/ensure-package-public/action.yml
+++ b/.github/actions/ensure-package-public/action.yml
@@ -31,14 +31,21 @@ runs:
         # Capture the HTTP status separately so a real "absent" (404) is distinguished from auth/scope
         # failures (403 SSO/token gap) and transport errors — `curl -f ... || echo '{}'` would collapse
         # all of them into the same empty fallback and let the release proceed on a false "not found".
+        # A unique mktemp file (not a hardcoded /tmp path) avoids collisions/symlink races on the
+        # shared self-hosted runner; an `if !` block keeps `set -e` active around the curl (a `|| { }`
+        # group would suspend it).
         api="https://api.github.com/orgs/${IMAGE_OWNER}/packages/container/${IMAGE_NAME}"
-        code="$(curl -sS -m 30 -o /tmp/ghcr-pkg.json -w '%{http_code}' \
+        pkg_json="$(mktemp)"
+        if ! code="$(curl -sS -m 30 -o "${pkg_json}" -w '%{http_code}' \
           -H "Authorization: Bearer ${GH_TOKEN}" \
           -H "Accept: application/vnd.github+json" \
-          "${api}")" || { echo "::error::Could not reach the GHCR package API (network/transport error) — refusing to publish blind."; exit 1; }
+          "${api}")"; then
+          echo "::error::Could not reach the GHCR package API (network/transport error) — refusing to publish blind."
+          exit 1
+        fi
         case "${code}" in
           200)
-            if grep -qE '"visibility"[[:space:]]*:[[:space:]]*"public"' /tmp/ghcr-pkg.json; then
+            if grep -qE '"visibility"[[:space:]]*:[[:space:]]*"public"' "${pkg_json}"; then
               echo "GHCR package ${IMAGE_OWNER}/${IMAGE_NAME} is public — providers can pull the candidate."
             else
               echo "::error::GHCR package ${IMAGE_OWNER}/${IMAGE_NAME} is not public. e2b/daytona/modal/novita pull the candidate base anonymously, so set it Public once (org package settings or link it to this repo), then re-run."

--- a/.github/actions/ensure-package-public/action.yml
+++ b/.github/actions/ensure-package-public/action.yml
@@ -1,0 +1,55 @@
+name: Ensure GHCR package is public
+description: >-
+  Fail fast if the candidate base package is not public. e2b builds its template on E2B's REMOTE
+  builder (FROM the ghcr candidate base) and daytona/modal/novita pull it to snapshot/boot — none are
+  handed ghcr pull credentials, so the candidate package MUST be public. GHCR packages are created
+  PRIVATE on first push with no API to flip visibility, so making it public is a one-time manual
+  bootstrap; this guard surfaces that plainly instead of an opaque provider "unauthorized" pull error.
+
+inputs:
+  owner:
+    description: The GHCR package owner (org).
+    required: true
+  package:
+    description: The container package name.
+    required: true
+  token:
+    description: A token with read:packages for the GHCR package API.
+    required: true
+
+runs:
+  using: composite
+  steps:
+    - name: Ensure candidate package is public
+      shell: bash
+      env:
+        IMAGE_OWNER: ${{ inputs.owner }}
+        IMAGE_NAME: ${{ inputs.package }}
+        GH_TOKEN: ${{ inputs.token }}
+      run: |
+        set -euo pipefail
+        # Capture the HTTP status separately so a real "absent" (404) is distinguished from auth/scope
+        # failures (403 SSO/token gap) and transport errors — `curl -f ... || echo '{}'` would collapse
+        # all of them into the same empty fallback and let the release proceed on a false "not found".
+        api="https://api.github.com/orgs/${IMAGE_OWNER}/packages/container/${IMAGE_NAME}"
+        code="$(curl -sS -m 30 -o /tmp/ghcr-pkg.json -w '%{http_code}' \
+          -H "Authorization: Bearer ${GH_TOKEN}" \
+          -H "Accept: application/vnd.github+json" \
+          "${api}")" || { echo "::error::Could not reach the GHCR package API (network/transport error) — refusing to publish blind."; exit 1; }
+        case "${code}" in
+          200)
+            if grep -qE '"visibility"[[:space:]]*:[[:space:]]*"public"' /tmp/ghcr-pkg.json; then
+              echo "GHCR package ${IMAGE_OWNER}/${IMAGE_NAME} is public — providers can pull the candidate."
+            else
+              echo "::error::GHCR package ${IMAGE_OWNER}/${IMAGE_NAME} is not public. e2b/daytona/modal/novita pull the candidate base anonymously, so set it Public once (org package settings or link it to this repo), then re-run."
+              exit 1
+            fi
+            ;;
+          404)
+            echo "::warning::GHCR package ${IMAGE_OWNER}/${IMAGE_NAME} not found yet — the build below creates it PRIVATE. After this run, set it Public once so the candidate validate and the providers can pull it; this run's bake will fail until then."
+            ;;
+          *)
+            echo "::error::GHCR package API returned HTTP ${code} (expected 200 or 404) — likely a token-scope gap or org SSO enforcement, not a missing package. Resolve and re-run instead of publishing blind."
+            exit 1
+            ;;
+        esac

--- a/.github/actions/ghcr-login/action.yml
+++ b/.github/actions/ghcr-login/action.yml
@@ -1,0 +1,26 @@
+name: GHCR session
+description: >-
+  Log in to the GitHub Container Registry with a pinned docker/login-action. Isolated so the privileged
+  registry session is introduced by exactly the jobs that push/retag/inspect images — never in shared
+  setup — and always after third-party tooling is installed.
+
+inputs:
+  token:
+    description: "Registry password (the job's GITHUB_TOKEN; the caller scopes packages read/write)."
+    required: true
+  registry:
+    description: Container registry host.
+    default: ghcr.io
+  username:
+    description: Registry username.
+    default: ${{ github.actor }}
+
+runs:
+  using: composite
+  steps:
+    - name: Log in to the container registry
+      uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
+      with:
+        registry: ${{ inputs.registry }}
+        username: ${{ inputs.username }}
+        password: ${{ inputs.token }}

--- a/.github/actions/release-summary/action.yml
+++ b/.github/actions/release-summary/action.yml
@@ -1,16 +1,17 @@
 name: Release summary
 description: >-
-  Append a consistent, machine-checkable phase table to $GITHUB_STEP_SUMMARY. Every release job calls
-  this with the same field vocabulary (mode, image, base, provider target, size tier, verify command,
-  published pointer, diagnostics, elapsed) so an operator reads one shape across build/bake/promote and
-  can grep the summaries. Rows with an empty value are omitted, so each phase shows only its own facts.
+  Append a consistent, machine-checkable phase table to the job summary and surface the phase result as
+  a run annotation, via @actions/core (release-summary.ts). Every release job calls this with the same
+  field vocabulary (mode, image, base, provider target, size tier, verify command, published pointer,
+  diagnostics, elapsed) so an operator reads one shape across build/bake/promote. Rows with an empty
+  value are omitted, so each phase shows only its own facts.
 
 inputs:
   phase:
     description: 'Phase label, e.g. "e2b/bake" or "publish".'
     required: true
   status:
-    description: Phase status (ok / failed / skipped).
+    description: Phase status (ok / failed / skipped / success / failure).
     default: ""
   mode:
     description: Release mode (build / republish).
@@ -37,7 +38,7 @@ inputs:
     description: The published pointer (tag / snapshot / template) this phase advanced.
     default: ""
   diagnostics:
-    description: A link (or name) of the uploaded diagnostics artifact for this phase.
+    description: The name of the uploaded diagnostics artifact for this phase.
     default: ""
   elapsed:
     description: Elapsed wall time for the phase.
@@ -48,6 +49,8 @@ runs:
   steps:
     - name: Append phase summary
       shell: bash
+      # Inputs reach the script as env (a composite `run` step gets no INPUT_* vars); the script owns the
+      # core.summary table + run annotation. RUN_URL links the diagnostics artifact to this run.
       env:
         PHASE: ${{ inputs.phase }}
         STATUS: ${{ inputs.status }}
@@ -61,39 +64,5 @@ runs:
         PUBLISHED: ${{ inputs.published }}
         DIAGNOSTICS: ${{ inputs.diagnostics }}
         ELAPSED: ${{ inputs.elapsed }}
-      run: |
-        set -euo pipefail
-        {
-          echo "### Image release: ${PHASE}"
-          echo ""
-          echo "| Field | Value |"
-          echo "| --- | --- |"
-          # Emit a row only when its value is non-empty. `code` wraps the value in backticks (refs,
-          # commands, pointers); `plain` leaves prose (status, mode) unquoted. A literal '|' in a value
-          # is escaped so it can't break the table.
-          row() { # $1=label $2=value $3=code|plain
-            local label="$1" value="$2" kind="${3:-plain}"
-            [ -n "${value}" ] || return 0
-            # Escape pipes and collapse CR/LF so a value with either can't break the table layout.
-            value="${value//|/\\|}"
-            value="${value//$'\r'/ }"
-            value="${value//$'\n'/ }"
-            if [ "${kind}" = "code" ]; then
-              echo "| ${label} | \`${value}\` |"
-            else
-              echo "| ${label} | ${value} |"
-            fi
-          }
-          row "Status"          "${STATUS}"          plain
-          row "Mode"            "${MODE}"            code
-          row "Source ref"      "${SOURCE_REF}"      code
-          row "Image"           "${IMAGE}"           code
-          row "Base image"      "${BASE_IMAGE}"      code
-          row "Provider target" "${PROVIDER_TARGET}" code
-          row "Size tier"       "${SIZE_TIER}"       plain
-          row "Verify command"  "${VERIFY}"          code
-          row "Published"       "${PUBLISHED}"       code
-          row "Elapsed"         "${ELAPSED}"         plain
-          row "Diagnostics"     "${DIAGNOSTICS}"     plain
-          echo ""
-        } >> "${GITHUB_STEP_SUMMARY}"
+        RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+      run: bun apps/cli/src/bin/release-summary.ts

--- a/.github/actions/release-summary/action.yml
+++ b/.github/actions/release-summary/action.yml
@@ -1,0 +1,96 @@
+name: Release summary
+description: >-
+  Append a consistent, machine-checkable phase table to $GITHUB_STEP_SUMMARY. Every release job calls
+  this with the same field vocabulary (mode, image, base, provider target, size tier, verify command,
+  published pointer, diagnostics, elapsed) so an operator reads one shape across build/bake/promote and
+  can grep the summaries. Rows with an empty value are omitted, so each phase shows only its own facts.
+
+inputs:
+  phase:
+    description: 'Phase label, e.g. "e2b/bake" or "publish".'
+    required: true
+  status:
+    description: Phase status (ok / failed / skipped).
+    default: ""
+  mode:
+    description: Release mode (build / republish).
+    default: ""
+  source-ref:
+    description: The source ref the release is cut from (github.sha).
+    default: ""
+  image:
+    description: The image ref (repo@sha256:… when a digest is known, else the tag).
+    default: ""
+  base-image:
+    description: The base image the artifact derives from.
+    default: ""
+  provider-target:
+    description: The provider region / workspace / template the artifact targets.
+    default: ""
+  size-tier:
+    description: The cpu/memory/disk size tier.
+    default: ""
+  verify:
+    description: The exact verify command an operator can rerun locally.
+    default: ""
+  published:
+    description: The published pointer (tag / snapshot / template) this phase advanced.
+    default: ""
+  diagnostics:
+    description: A link (or name) of the uploaded diagnostics artifact for this phase.
+    default: ""
+  elapsed:
+    description: Elapsed wall time for the phase.
+    default: ""
+
+runs:
+  using: composite
+  steps:
+    - name: Append phase summary
+      shell: bash
+      env:
+        PHASE: ${{ inputs.phase }}
+        STATUS: ${{ inputs.status }}
+        MODE: ${{ inputs.mode }}
+        SOURCE_REF: ${{ inputs.source-ref }}
+        IMAGE: ${{ inputs.image }}
+        BASE_IMAGE: ${{ inputs.base-image }}
+        PROVIDER_TARGET: ${{ inputs.provider-target }}
+        SIZE_TIER: ${{ inputs.size-tier }}
+        VERIFY: ${{ inputs.verify }}
+        PUBLISHED: ${{ inputs.published }}
+        DIAGNOSTICS: ${{ inputs.diagnostics }}
+        ELAPSED: ${{ inputs.elapsed }}
+      run: |
+        set -euo pipefail
+        {
+          echo "### Image release: ${PHASE}"
+          echo ""
+          echo "| Field | Value |"
+          echo "| --- | --- |"
+          # Emit a row only when its value is non-empty. `code` wraps the value in backticks (refs,
+          # commands, pointers); `plain` leaves prose (status, mode) unquoted. A literal '|' in a value
+          # is escaped so it can't break the table.
+          row() { # $1=label $2=value $3=code|plain
+            local label="$1" value="$2" kind="${3:-plain}"
+            [ -n "${value}" ] || return 0
+            value="${value//|/\\|}"
+            if [ "${kind}" = "code" ]; then
+              echo "| ${label} | \`${value}\` |"
+            else
+              echo "| ${label} | ${value} |"
+            fi
+          }
+          row "Status"          "${STATUS}"          plain
+          row "Mode"            "${MODE}"            code
+          row "Source ref"      "${SOURCE_REF}"      code
+          row "Image"           "${IMAGE}"           code
+          row "Base image"      "${BASE_IMAGE}"      code
+          row "Provider target" "${PROVIDER_TARGET}" code
+          row "Size tier"       "${SIZE_TIER}"       plain
+          row "Verify command"  "${VERIFY}"          code
+          row "Published"       "${PUBLISHED}"       code
+          row "Elapsed"         "${ELAPSED}"         plain
+          row "Diagnostics"     "${DIAGNOSTICS}"     plain
+          echo ""
+        } >> "${GITHUB_STEP_SUMMARY}"

--- a/.github/actions/release-summary/action.yml
+++ b/.github/actions/release-summary/action.yml
@@ -74,7 +74,10 @@ runs:
           row() { # $1=label $2=value $3=code|plain
             local label="$1" value="$2" kind="${3:-plain}"
             [ -n "${value}" ] || return 0
+            # Escape pipes and collapse CR/LF so a value with either can't break the table layout.
             value="${value//|/\\|}"
+            value="${value//$'\r'/ }"
+            value="${value//$'\n'/ }"
             if [ "${kind}" = "code" ]; then
               echo "| ${label} | \`${value}\` |"
             else

--- a/.github/actions/release-validate-inputs/action.yml
+++ b/.github/actions/release-validate-inputs/action.yml
@@ -1,8 +1,9 @@
 name: Validate release inputs
 description: >-
-  The credential-free fail-fast gate: validate the toolchain pins and the dispatch inputs BEFORE any
-  registry or provider credential is introduced. Runs after setup-toolchain (needs Bun + deps) but
-  before ghcr-login, so a bad pin or a malformed input fails the release without ever touching creds.
+  The credential-free fail-fast gate (release-validate.ts): validate the toolchain pins and the dispatch
+  inputs BEFORE any registry/provider credential is introduced, reporting failures as @actions/core
+  annotations (a pin failure is annotated ON the pins source file). Runs after setup-toolchain (needs
+  Bun + deps) but before ghcr-login, so a bad pin or a malformed input fails the release without creds.
 
 inputs:
   force-republish:
@@ -12,26 +13,9 @@ inputs:
 runs:
   using: composite
   steps:
-    # `bun pins.ts` re-runs the arktype pin gatekeeper (hex sha256s, non-empty versions) and exits
-    # non-zero on any unfilled/invalid pin — the same gate build.sh uses, run here first so the release
-    # fails on a bad pin before it spends a build. Output discarded; we only want the exit code.
-    - name: Validate toolchain pins
+    - name: Validate pins and dispatch inputs
       shell: bash
-      run: bun packages/templates/src/pins.ts > /dev/null
-
-    # A dispatch input reaches the release as an env var (never interpolated into a command); still,
-    # reject anything but the two booleans so a hand-typed dispatch value can't slip through as a
-    # surprise "truthy" string downstream.
-    - name: Validate dispatch inputs
-      shell: bash
+      # Input reaches the script as env (a composite `run` step gets no INPUT_* vars).
       env:
         FORCE_REPUBLISH: ${{ inputs.force-republish }}
-      run: |
-        set -euo pipefail
-        case "${FORCE_REPUBLISH}" in
-          true|false|"") ;;
-          *)
-            echo "::error::force_republish must be true or false (got '${FORCE_REPUBLISH}')."
-            exit 1
-            ;;
-        esac
+      run: bun apps/cli/src/bin/release-validate.ts

--- a/.github/actions/release-validate-inputs/action.yml
+++ b/.github/actions/release-validate-inputs/action.yml
@@ -1,0 +1,37 @@
+name: Validate release inputs
+description: >-
+  The credential-free fail-fast gate: validate the toolchain pins and the dispatch inputs BEFORE any
+  registry or provider credential is introduced. Runs after setup-toolchain (needs Bun + deps) but
+  before ghcr-login, so a bad pin or a malformed input fails the release without ever touching creds.
+
+inputs:
+  force-republish:
+    description: The force_republish dispatch input (regenerate an already-published version in place).
+    default: "false"
+
+runs:
+  using: composite
+  steps:
+    # `bun pins.ts` re-runs the arktype pin gatekeeper (hex sha256s, non-empty versions) and exits
+    # non-zero on any unfilled/invalid pin — the same gate build.sh uses, run here first so the release
+    # fails on a bad pin before it spends a build. Output discarded; we only want the exit code.
+    - name: Validate toolchain pins
+      shell: bash
+      run: bun packages/templates/src/pins.ts > /dev/null
+
+    # A dispatch input reaches the release as an env var (never interpolated into a command); still,
+    # reject anything but the two booleans so a hand-typed dispatch value can't slip through as a
+    # surprise "truthy" string downstream.
+    - name: Validate dispatch inputs
+      shell: bash
+      env:
+        FORCE_REPUBLISH: ${{ inputs.force-republish }}
+      run: |
+        set -euo pipefail
+        case "${FORCE_REPUBLISH}" in
+          true|false|"") ;;
+          *)
+            echo "::error::force_republish must be true or false (got '${FORCE_REPUBLISH}')."
+            exit 1
+            ;;
+        esac

--- a/.github/actions/setup-toolchain/action.yml
+++ b/.github/actions/setup-toolchain/action.yml
@@ -1,0 +1,36 @@
+name: Set up toolchain
+description: >-
+  Bun + dependencies (optionally Docker Buildx) — the setup preamble every toolchain-image job shares
+  after its checkout. Third-party tooling installs BEFORE any cloud credential is introduced, so a
+  credentialed job's setup stays credential-free (the release's credential-minimization posture).
+
+  NOTE: this composite deliberately does NOT run actions/checkout. A local action (`./.github/actions/…`)
+  is read from the workspace, so the repo must already be checked out before this action can run — the
+  caller keeps an explicit `actions/checkout` as its first step (which also keeps each job's
+  persist-credentials posture visible to zizmor).
+
+inputs:
+  buildx:
+    description: Set up Docker Buildx (only the jobs that build/retag images need it).
+    default: "false"
+
+runs:
+  using: composite
+  steps:
+    # Third-party actions are pinned to a commit SHA (the tag comment is for humans) so a moved or
+    # compromised tag can't silently change what runs — the repo-wide supply-chain posture.
+    - name: Set up Bun
+      uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
+      with:
+        bun-version: 1.3.14
+        # This runner's setup-bun cache restores without a working ~/.bun/bin/bun, so a cache hit
+        # fails the "Set up Bun" step. Always download bun fresh instead of restoring the cache.
+        no-cache: true
+
+    - name: Install dependencies
+      shell: bash
+      run: bun install --frozen-lockfile --ignore-scripts
+
+    - name: Set up Docker Buildx
+      if: ${{ inputs.buildx == 'true' }}
+      uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4.1.0

--- a/.github/workflows/bench-matrix.yml
+++ b/.github/workflows/bench-matrix.yml
@@ -36,7 +36,7 @@ jobs:
       matrix: ${{ steps.plan.outputs.matrix }}
     steps:
       - name: Checkout
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           # Planning only reads code; don't persist the job token in .git/config.
           persist-credentials: false
@@ -72,7 +72,7 @@ jobs:
       matrix: ${{ fromJSON(needs.plan.outputs.matrix) }}
     steps:
       - name: Checkout
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           # This cell only reads code (the sandbox clones via BENCH_REPO_TOKEN, not the checkout's
           # credentials), so don't persist the job token in .git/config.
@@ -118,7 +118,7 @@ jobs:
 
       - name: Upload Run + raw results
         if: always()
-        uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5.0.0
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           # Per-cell artifact name so every (provider, suite) shard uploads independently.
           name: bench-${{ matrix.suite }}-${{ matrix.provider }}-${{ github.run_id }}
@@ -145,7 +145,7 @@ jobs:
       # keeps the default persisted job token (contents: write above authorizes it). Don't add
       # persist-credentials: false here or the push at the end of the job loses its credentials.
       - name: Checkout
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - name: Set up Bun
         uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
         with:
@@ -155,7 +155,7 @@ jobs:
 
       # Pull every per-cell shard artifact into ./shards (each in its own subdir).
       - name: Download shard artifacts
-        uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0 # v5.0.0
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           path: shards
           pattern: bench-*-${{ github.run_id }}

--- a/.github/workflows/bench-matrix.yml
+++ b/.github/workflows/bench-matrix.yml
@@ -118,7 +118,7 @@ jobs:
 
       - name: Upload Run + raw results
         if: always()
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5.0.0
         with:
           # Per-cell artifact name so every (provider, suite) shard uploads independently.
           name: bench-${{ matrix.suite }}-${{ matrix.provider }}-${{ github.run_id }}
@@ -155,7 +155,7 @@ jobs:
 
       # Pull every per-cell shard artifact into ./shards (each in its own subdir).
       - name: Download shard artifacts
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+        uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0 # v5.0.0
         with:
           path: shards
           pattern: bench-*-${{ github.run_id }}

--- a/.github/workflows/bench-smoke.yml
+++ b/.github/workflows/bench-smoke.yml
@@ -99,7 +99,7 @@ jobs:
 
       - name: Upload Run + raw results
         if: always()
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5.0.0
         with:
           name: bench-${{ inputs.suite }}-${{ inputs.provider }}-${{ github.run_id }}
           path: data/

--- a/.github/workflows/bench-smoke.yml
+++ b/.github/workflows/bench-smoke.yml
@@ -50,7 +50,7 @@ jobs:
       # Third-party actions are pinned to a commit SHA (the tag comment is for humans) so a
       # moved/compromised tag can't silently change what runs.
       - name: Checkout
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           # The job only reads code (the sandbox clones via BENCH_REPO_TOKEN, not the checkout's
           # credentials), so don't persist the job token in .git/config.
@@ -99,7 +99,7 @@ jobs:
 
       - name: Upload Run + raw results
         if: always()
-        uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5.0.0
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: bench-${{ inputs.suite }}-${{ inputs.provider }}-${{ github.run_id }}
           path: data/

--- a/.github/workflows/ci-lint.yml
+++ b/.github/workflows/ci-lint.yml
@@ -42,7 +42,7 @@ jobs:
       # Third-party actions are pinned to a commit SHA (the tag comment is for humans only) so a
       # moved/compromised tag can't silently change what runs.
       - name: Checkout
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           # The linter only reads the workflows; never persist the job token in .git/config.
           persist-credentials: false
@@ -71,7 +71,7 @@ jobs:
       github.event.pull_request.head.repo.full_name == github.repository
     steps:
       - name: Checkout
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ jobs:
       # Third-party actions are pinned to a commit SHA (the tag comment is for humans only) so a
       # moved/compromised tag can't silently change what runs in CI.
       - name: Checkout
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           # The gate only reads code (it never pushes), so don't leave the job token in .git/config.
           persist-credentials: false

--- a/.github/workflows/toolchain-image.yml
+++ b/.github/workflows/toolchain-image.yml
@@ -1,17 +1,31 @@
 name: Toolchain image
 
-# Build, validate, and publish the sandbox-benchmarks toolchain. Two lanes:
+# Build, validate, and publish the sandbox-benchmarks toolchain — staged as a release pipeline rather
+# than one monolithic job. Two lanes:
 #   • Pull requests — build the base (no push) and run the docker smoke. Fast gate, no credentials.
-#   • Push to main / manual dispatch — build + push the mutable CANDIDATE (:v1-candidate), bake each
-#     provider's candidate artifact and validate it by booting a sandbox and running the shared smoke
-#     spec (behind each provider's secret; missing ones skip), then promote the validated candidate to
-#     the immutable public :v1. Iteration never touches :v1; bump TOOLCHAIN_VERSION
-#     (packages/schema/src/toolchain.ts) to publish a new version.
+#   • Push to main / manual dispatch — the release phases: PLAN → BUILD candidate → BAKE + verify each
+#     provider (a matrix, one cell per provider) → PROMOTE the validated candidate to the immutable
+#     public :v1. Iteration never touches :v1; bump TOOLCHAIN_VERSION (packages/schema/src/toolchain.ts)
+#     to publish a new version.
+#
+# Phase split (needs edges only where an artifact is required, so build/bake work runs in parallel and
+# the ONLY serialized section is the promote transaction):
+#
+#   plan ──> build ──> bake (matrix: provider × required) ──> promote
+#     │        │                                                  ▲
+#     └── emits release-plan.json; every downstream job consumes  │
+#         the plan (mode, refs, provider matrix, gates) rather    │
+#         than re-reading the raw workflow inputs. ───────────────┘
+#
+# Cross-cutting GitHub Actions mechanics live in .github/actions/* composites (setup, ghcr login,
+# input validation, package-visibility guard, summaries); provider bake/verify/promote logic lives in
+# the package scripts under apps/cli (thin YAML, fat scripts). There is no OIDC here — GHCR auth is the
+# job's GITHUB_TOKEN — so no job needs id-token: write.
 on:
   # Manual re-trigger (e.g. after bumping TOOLCHAIN_VERSION). The public version is immutable on the
   # automated push path; `force_republish` (manual dispatch only) deliberately regenerates it over an
   # existing version for fast dev iteration. Normally, to republish you bump TOOLCHAIN_VERSION; an
-  # already-published version is skipped at the guard below unless force_republish is set.
+  # already-published version is skipped by the plan phase unless force_republish is set.
   workflow_dispatch:
     inputs:
       force_republish:
@@ -20,8 +34,8 @@ on:
         default: false
   push:
     branches: [main]
-    # The publish lane runs `bake`/`promote`, which pull in the whole provider-run + smoke + harness
-    # surface (not just packages/templates and the bake libs). Trigger on every file that can change
+    # The release lane runs bake/promote, which pull in the whole provider-run + smoke + harness surface
+    # (not just packages/templates and the bake libs). Trigger on every file that can change
     # bake/validate/promote behavior so a relevant change to main can't ship a version untested by it.
     paths:
       - "packages/templates/**"
@@ -31,13 +45,17 @@ on:
       - "apps/cli/src/lib/providers-run.ts"
       - "apps/cli/src/lib/smoke-run.ts"
       - "apps/cli/src/bin/bake.ts"
+      - "apps/cli/src/bin/build-candidate.ts"
+      - "apps/cli/src/bin/release-plan.ts"
       - "packages/schema/src/toolchain.ts"
       - ".github/workflows/toolchain-image.yml"
+      - ".github/actions/**"
   pull_request:
     paths:
       - "packages/templates/**"
       - "packages/schema/src/toolchain.ts"
       - ".github/workflows/toolchain-image.yml"
+      - ".github/actions/**"
 
 # Serialize publishes by ref (NOT by event_name): a push to main and a manual workflow_dispatch on the
 # same ref must not publish concurrently and race on the version tag. PR runs key off their own head ref
@@ -47,19 +65,25 @@ concurrency:
   group: toolchain-image-${{ github.ref }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
+# Least privilege, global default: read-only. Only build and promote widen to packages: write; plan
+# widens to packages: read (the immutability probe + package-visibility guard); bake needs neither
+# (providers pull the public candidate anonymously).
 permissions:
   contents: read
 
+env:
+  REGISTRY: ghcr.io
+  IMAGE_OWNER: starslingdev
+
 jobs:
+  # ── PR lane ──────────────────────────────────────────────────────────────────────────────────────
   # Fast PR gate: prove the base image still builds and the toolchain is complete, without pushing or
   # touching any provider. Uses the same shared smoke spec as the in-sandbox bake validation.
   #
   # Same-repo guard: this job checks out the PR head and runs scripts FROM that checkout (build.sh,
   # smoke.ts) on a self-hosted runner, so a fork PR could execute arbitrary code on the runner itself.
   # The repo is private (no untrusted forks today), but we gate on same-repo head as defense-in-depth
-  # against a compromised account / outside-collaborator fork. Branches pushed to this repo (the normal
-  # Graphite flow) satisfy it; a legitimate fork-based PR would skip the gate and need a maintainer to
-  # re-run it from an in-repo branch.
+  # against a compromised account / outside-collaborator fork.
   pr-gate:
     name: Build base + docker smoke
     if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
@@ -70,17 +94,10 @@ jobs:
         with:
           # Builds and smokes the image locally — no git push, so don't persist the job token.
           persist-credentials: false
-      - name: Set up Bun
-        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
+      - name: Set up toolchain
+        uses: ./.github/actions/setup-toolchain
         with:
-          bun-version: 1.3.14
-          # This runner's setup-bun cache restores without a working ~/.bun/bin/bun, so a cache hit
-          # fails the "Set up Bun" step. Always download bun fresh instead of restoring the cache.
-          no-cache: true
-      - name: Install dependencies
-        run: bun install --frozen-lockfile --ignore-scripts
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4.1.0
+          buildx: "true"
       - name: Build base (no push) + docker smoke
         run: |
           set -euo pipefail
@@ -91,169 +108,291 @@ jobs:
           # (not swallowed inside docker's command substitution, which would smoke an empty script).
           smoke_script="$(bun packages/templates/src/smoke.ts --bash)"
           docker run --rm "${name}:dev" bash -lc "$smoke_script"
+      - name: Release summary
+        if: always()
+        uses: ./.github/actions/release-summary
+        with:
+          phase: pr-gate
+          status: ${{ job.status }}
+          mode: pr-gate
+          source-ref: ${{ github.sha }}
+          verify: bash packages/templates/images/build.sh
 
-  # Publish lane: candidate → validate → promote. Thin wrapper over the bake bin (thin workflow, fat
-  # script). Provider steps are guarded by their secrets inside the bin (missing creds skip).
-  publish:
-    name: Bake, validate & promote toolchain
+  # ── Release lane ─────────────────────────────────────────────────────────────────────────────────
+  # PLAN: validate inputs/pins (credential-free), then resolve identity and emit ONE release plan that
+  # every downstream job consumes. The plan decides `skip` (immutable version already published and not
+  # force_republish) and the provider matrix. Emits release-plan.json as a diagnostic artifact.
+  plan:
+    name: Plan release
     if: github.event_name != 'pull_request'
     runs-on: starsling-ubuntu-24.04-2
     permissions:
       contents: read
-      packages: write
-    env:
-      REGISTRY: ghcr.io
-      IMAGE_OWNER: starslingdev
+      packages: read
+    outputs:
+      skip: ${{ steps.plan.outputs.skip }}
+      mode: ${{ steps.plan.outputs.mode }}
+      matrix: ${{ steps.plan.outputs.matrix }}
+      required: ${{ steps.plan.outputs.required }}
+      size-tier: ${{ steps.plan.outputs.size-tier }}
+      image-candidate: ${{ steps.plan.outputs.image-candidate }}
+      image-version: ${{ steps.plan.outputs.image-version }}
+      toolchain-version: ${{ steps.plan.outputs.toolchain-version }}
+      publish-target: ${{ steps.plan.outputs.publish-target }}
     steps:
       - name: Checkout
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
-          # Publishes to GHCR via docker/login-action (the GITHUB_TOKEN below), never `git push`, so
-          # the checkout's own credentials aren't needed — don't persist the job token.
+          # Reads code and probes the registry via docker/login — never git push.
           persist-credentials: false
-      - name: Set up Bun
-        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
+      - name: Set up toolchain
+        uses: ./.github/actions/setup-toolchain
+      # Fail-fast, credential-free: validate pins + the dispatch input BEFORE the registry login below.
+      - name: Validate release inputs
+        uses: ./.github/actions/release-validate-inputs
         with:
-          bun-version: 1.3.14
-          # This runner's setup-bun cache restores without a working ~/.bun/bin/bun, so a cache hit
-          # fails the "Set up Bun" step. Always download bun fresh instead of restoring the cache.
-          no-cache: true
-      - name: Install dependencies
-        run: bun install --frozen-lockfile --ignore-scripts
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4.1.0
-      - name: Log in to the container registry
-        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
+          force-republish: ${{ inputs.force_republish }}
+      # The one privileged step in plan: the immutability probe (`docker manifest inspect`) needs a
+      # GHCR session. GITHUB_TOKEN with packages: read suffices.
+      - name: GHCR session
+        uses: ./.github/actions/ghcr-login
         with:
-          registry: ${{ env.REGISTRY }}
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      # Resolve identity from the arktype-validated TS config; `bun pins.ts` also validates every pin
-      # and exits non-zero on any unfilled/invalid one (the early fail-fast gate).
-      - name: Resolve identity & validate pins
-        run: |
-          set -euo pipefail
-          pins="$(bun packages/templates/src/pins.ts)"
-          name="$(echo "${pins}" | sed -n 's/^IMAGE_NAME=//p')"
-          version="$(echo "${pins}" | sed -n 's/^IMAGE_VERSION=//p')"
-          {
-            echo "IMAGE_NAME=${name}"
-            echo "IMAGE_VERSION=${version}"
-            echo "VERSION_REF=${REGISTRY}/${IMAGE_OWNER}/${name}:${version}"
-          } >> "${GITHUB_ENV}"
-
-      # Guard the immutable public version: skip the whole publish if :v1 already exists. The version is
-      # immutable (promote refuses to overwrite it), so a published version is never re-promoted — bump
-      # TOOLCHAIN_VERSION to publish a new one. The candidate is mutable and always rebuilt within a run.
-      # `force_republish` (manual dispatch only) overrides the skip to regenerate the version in place.
-      - name: Check if version already published
-        id: guard
+          token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Resolve identity & build release plan
+        id: plan
         env:
           FORCE_REPUBLISH: ${{ inputs.force_republish }}
-        run: |
-          if [ "${FORCE_REPUBLISH}" = "true" ]; then
-            echo "::notice::force_republish set — regenerating ${VERSION_REF} even though it may already exist."
-            echo "skip=false" >> "${GITHUB_OUTPUT}"
-          elif docker manifest inspect "${VERSION_REF}" >/dev/null 2>&1; then
-            echo "::notice::${VERSION_REF} already published — skipping (bump TOOLCHAIN_VERSION, or dispatch with force_republish, to publish again)."
-            echo "skip=true" >> "${GITHUB_OUTPUT}"
-          else
-            echo "skip=false" >> "${GITHUB_OUTPUT}"
-          fi
-
-      # The candidate base image must be PUBLIC so providers can pull it anonymously: e2b builds the
-      # template on its REMOTE builder (FROM the ghcr candidate base) and daytona/modal pull it to
-      # snapshot/boot — none are handed ghcr pull credentials. GHCR packages are created PRIVATE on
-      # first push and GitHub exposes no API to flip visibility, so making it public is a one-time
-      # manual bootstrap (Org → Packages → this package → Package settings → Change visibility → Public,
-      # or link the package to this public repo). This guard fails fast with that instruction instead of
-      # letting an opaque provider "unauthorized/not found" pull error surface mid-bake.
+        # release-plan.ts validates pins again, probes whether :v1 is already published (best-effort —
+        # promote does the authoritative guard), writes release-plan.json, and prints the key=value
+        # outputs the downstream jobs read.
+        run: bun apps/cli/src/bin/release-plan.ts release-plan.json >> "$GITHUB_OUTPUT"
+      # Guard the candidate package visibility so providers can pull it anonymously (see the composite).
+      # Skipped when the release itself is skipped (version already published).
       - name: Ensure candidate package is public
-        if: steps.guard.outputs.skip != 'true'
-        run: |
-          set -euo pipefail
-          # > Capture the HTTP status separately so a real "absent" (404) is distinguished from auth/scope
-          # > failures (403 SSO/token gap) and transport errors — `curl -f ... || echo '{}'` would collapse
-          # > all of them into the same empty fallback and let the publish proceed on a false "not found".
-          api="https://api.github.com/orgs/${IMAGE_OWNER}/packages/container/${IMAGE_NAME}"
-          code="$(curl -sS -m 30 -o /tmp/ghcr-pkg.json -w '%{http_code}' \
-            -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
-            -H "Accept: application/vnd.github+json" \
-            "${api}")" || { echo "::error::Could not reach the GHCR package API (network/transport error) — refusing to publish blind."; exit 1; }
-          case "${code}" in
-            200)
-              if grep -qE '"visibility"[[:space:]]*:[[:space:]]*"public"' /tmp/ghcr-pkg.json; then
-                echo "GHCR package ${IMAGE_OWNER}/${IMAGE_NAME} is public — providers can pull the candidate."
-              else
-                echo "::error::GHCR package ${IMAGE_OWNER}/${IMAGE_NAME} is not public. e2b/daytona/modal pull the candidate base anonymously, so set it Public once (org package settings or link it to this repo), then re-run."
-                exit 1
-              fi
-              ;;
-            404)
-              echo "::warning::GHCR package ${IMAGE_OWNER}/${IMAGE_NAME} not found yet — the push below creates it PRIVATE. After this run, set it Public once so the candidate validate and the providers can pull it; this run's validate will fail until then."
-              ;;
-            *)
-              echo "::error::GHCR package API returned HTTP ${code} (expected 200 or 404) — likely a token-scope gap or org SSO enforcement, not a missing package. Resolve and re-run instead of publishing blind."
-              exit 1
-              ;;
-          esac
+        if: steps.plan.outputs.skip != 'true'
+        uses: ./.github/actions/ensure-package-public
+        with:
+          owner: ${{ env.IMAGE_OWNER }}
+          package: ${{ steps.plan.outputs.image-name }}
+          token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Upload release plan
+        if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: release-plan-${{ github.run_id }}
+          path: release-plan.json
+          if-no-files-found: warn
+      - name: Release summary
+        if: always()
+        uses: ./.github/actions/release-summary
+        with:
+          phase: plan
+          status: ${{ job.status }}
+          mode: ${{ steps.plan.outputs.mode }}
+          source-ref: ${{ github.sha }}
+          image: ${{ steps.plan.outputs.image-candidate }}
+          size-tier: ${{ steps.plan.outputs.size-tier }}
+          published: ${{ steps.plan.outputs.publish-target }}
+          diagnostics: release-plan-${{ github.run_id }}
 
-      # Build + push the candidate, then bake each provider's candidate artifact and validate it by
-      # booting a sandbox (skip-on-missing-creds). Fails the job if any baked provider fails to validate.
-      - name: Bake + validate candidate
-        if: steps.guard.outputs.skip != 'true'
+  # BUILD: build the base image (+ variants) and push the mutable candidate base to GHCR ONCE, then
+  # record its immutable digest. The providers below all fan out from this single pushed candidate.
+  build:
+    name: Build + push candidate
+    needs: plan
+    if: needs.plan.outputs.skip != 'true'
+    runs-on: starsling-ubuntu-24.04-2
+    permissions:
+      contents: read
+      packages: write
+    outputs:
+      digest: ${{ steps.build.outputs.digest }}
+      candidate-digest-ref: ${{ steps.build.outputs.candidate-digest-ref }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          # Publishes to GHCR via docker/login-action, never git push — don't persist the job token.
+          persist-credentials: false
+      - name: Set up toolchain
+        uses: ./.github/actions/setup-toolchain
+        with:
+          buildx: "true"
+      - name: GHCR session
+        uses: ./.github/actions/ghcr-login
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Build + push candidate image
+        id: build
         env:
           BUILD_REF: ${{ github.sha }}
-          BUILD_VERSION: ${{ env.IMAGE_VERSION }}
-          E2B_API_KEY: ${{ secrets.E2B_API_KEY }}
-          DAYTONA_API_KEY: ${{ secrets.DAYTONA_API_KEY }}
-          # Bake/validate the daytona snapshot in the active region. Without a target the snapshot lands
-          # in the account's default region (which has no `container` runners) and the bake fails at
-          # snapshot creation. Defaulted to the active target so an unsynced secret can't break the
-          # publish at module load (parity with bench-matrix.yml / bench-smoke.yml).
-          DAYTONA_TARGET: ${{ secrets.DAYTONA_TARGET || 'us-west-2' }}
-          MODAL_TOKEN_ID: ${{ secrets.MODAL_TOKEN_ID }}
-          MODAL_TOKEN_SECRET: ${{ secrets.MODAL_TOKEN_SECRET }}
-          # Bake the novita template on Novita's E2B-compatible control plane. Optional: a missing
-          # secret skips the novita bake (it is not in --require) without failing the publish.
-          NOVITA_API_KEY: ${{ secrets.NOVITA_API_KEY }}
+          BUILD_VERSION: ${{ needs.plan.outputs.toolchain-version }}
         run: |
           set -euo pipefail
           # Declare then assign so the command substitution's exit status isn't masked (SC2155).
           BUILD_DATE="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
           export BUILD_DATE
-          # --require fails the publish loudly if a required provider's secret is missing/misnamed, so a
-          # merge can't bless a candidate while a required provider was silently skipped (never built or
-          # validated). modal boots the toolchain image via fromRegistry under this project's Modal app
-          # and is validated the same as e2b/daytona, so it's required — MODAL_TOKEN_* must be synced.
-          # (blaxel is excluded — its bake is a no-op.)
-          bun apps/cli/src/bin/bake.ts --build-push --require e2b,daytona,modal
+          bun apps/cli/src/bin/build-candidate.ts build-metadata.json >> "$GITHUB_OUTPUT"
+      - name: Upload build metadata
+        if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: build-metadata-${{ github.run_id }}
+          path: build-metadata.json
+          if-no-files-found: warn
+      - name: Release summary
+        if: always()
+        uses: ./.github/actions/release-summary
+        with:
+          phase: build
+          status: ${{ job.status }}
+          mode: ${{ needs.plan.outputs.mode }}
+          source-ref: ${{ github.sha }}
+          image: ${{ steps.build.outputs.candidate-digest-ref }}
+          size-tier: ${{ needs.plan.outputs.size-tier }}
+          verify: bun apps/cli/src/bin/build-candidate.ts
+          diagnostics: build-metadata-${{ github.run_id }}
 
-      # Promote the validated candidate to the immutable public version (+ version-named artifacts).
-      - name: Promote candidate → version
-        if: steps.guard.outputs.skip != 'true'
+  # BAKE + verify: one matrix cell per provider (from the plan). Each cell bakes its candidate artifact
+  # from the pushed candidate base and validates it by booting a sandbox and running the shared smoke
+  # spec. fail-fast: false so a flaky provider doesn't cancel the others' diagnostics — but ANY cell
+  # that RAN and failed still fails this job (and, being a `needs`, blocks promote). Required cells
+  # (plan `required`) additionally pass `--require`, so a missing/misnamed secret fails the cell instead
+  # of silently skipping a provider the release must ship.
+  bake:
+    name: Bake + verify (${{ matrix.provider }})
+    needs: [plan, build]
+    if: needs.plan.outputs.skip != 'true'
+    runs-on: starsling-ubuntu-24.04-2
+    timeout-minutes: 60
+    strategy:
+      fail-fast: false
+      matrix: ${{ fromJSON(needs.plan.outputs.matrix) }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          # Boots the just-baked candidate via provider SDKs — no git push, no ghcr push. Don't persist.
+          persist-credentials: false
+      - name: Set up toolchain
+        uses: ./.github/actions/setup-toolchain
+      - name: Bake + verify candidate
+        id: bake
+        # The cell's provider + required flag reach the script through the environment, never
+        # interpolated into the shell, so a matrix value can't inject into the runner command. Provider
+        # creds are optional: a missing one SKIPS that provider (required cells fail instead — see
+        # --require below). blaxel gets no creds here (its bake is a no-op booting the stock base), so
+        # it skips, exactly as the previous monolithic lane did.
         env:
+          PROVIDER: ${{ matrix.provider }}
+          REQUIRED: ${{ matrix.required }}
           E2B_API_KEY: ${{ secrets.E2B_API_KEY }}
           DAYTONA_API_KEY: ${{ secrets.DAYTONA_API_KEY }}
           # Bake/validate the daytona snapshot in the active region. Without a target the snapshot lands
           # in the account's default region (which has no `container` runners) and the bake fails at
-          # snapshot creation. Defaulted to the active target so an unsynced secret can't break the
-          # publish at module load (parity with bench-matrix.yml / bench-smoke.yml).
+          # snapshot creation. Defaulted so an unsynced secret can't break the release at module load.
           DAYTONA_TARGET: ${{ secrets.DAYTONA_TARGET || 'us-west-2' }}
           MODAL_TOKEN_ID: ${{ secrets.MODAL_TOKEN_ID }}
           MODAL_TOKEN_SECRET: ${{ secrets.MODAL_TOKEN_SECRET }}
-          # Bake the novita template on Novita's E2B-compatible control plane. Optional: a missing
-          # secret skips the novita bake (it is not in --require) without failing the publish.
+          # Optional: a missing NOVITA_API_KEY skips the novita bake without failing the release.
           NOVITA_API_KEY: ${{ secrets.NOVITA_API_KEY }}
-          FORCE_REPUBLISH: ${{ inputs.force_republish }}
-        # --require fails promote loudly if a required provider's secret is missing/misnamed, so the
-        # public version is never published while a required provider's version artifact was silently
-        # skipped. modal is required (validated via its fromRegistry boot); MODAL_TOKEN_* must be synced.
-        # (blaxel is excluded — its bake is a no-op.) `--force` (manual force_republish dispatch only)
-        # republishes over an existing immutable version; never set on the automated push path.
         run: |
           set -euo pipefail
-          args=(--promote --require "e2b,daytona,modal")
+          args=(--provider "${PROVIDER}")
+          # Required providers must not silently skip: --require fails the cell if this provider's
+          # secret is missing/misnamed or it fails to validate.
+          if [ "${REQUIRED}" = "true" ]; then args+=(--require "${PROVIDER}"); fi
+          # bake.ts prints the report JSON to stdout (progress goes to stderr, visible in the log), so
+          # capture it as this cell's diagnostic even when the bake exits non-zero.
+          bun apps/cli/src/bin/bake.ts "${args[@]}" > "bake-${PROVIDER}.json"
+      - name: Upload bake report
+        if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: bake-${{ matrix.provider }}-${{ github.run_id }}
+          path: bake-${{ matrix.provider }}.json
+          if-no-files-found: warn
+      - name: Release summary
+        if: always()
+        uses: ./.github/actions/release-summary
+        with:
+          phase: ${{ matrix.provider }}/bake
+          status: ${{ job.status }}
+          mode: ${{ needs.plan.outputs.mode }}
+          source-ref: ${{ github.sha }}
+          image: ${{ needs.build.outputs.candidate-digest-ref }}
+          base-image: ${{ needs.plan.outputs.image-candidate }}
+          provider-target: ${{ matrix.provider }}
+          size-tier: ${{ needs.plan.outputs.size-tier }}
+          verify: bun apps/cli/src/bin/bake.ts --provider ${{ matrix.provider }}
+          diagnostics: bake-${{ matrix.provider }}-${{ github.run_id }}
+
+  # PROMOTE: the serialized publication barrier and the ONLY job that mutates the public :v1. Runs only
+  # after every bake cell converges (a failed required cell fails `bake` and blocks this via `needs`).
+  # promote re-validates the candidate (TOCTOU: the candidate tag is mutable), builds each provider's
+  # version-named artifact FROM the revalidated bytes, then retags the base → :v1 LAST as the commit
+  # point. `--require` (from the plan) fails the promote before publish if a required provider's version
+  # artifact was skipped/failed. `--force` (force_republish only) regenerates an existing version.
+  promote:
+    name: Promote candidate → version
+    needs: [plan, build, bake]
+    if: needs.plan.outputs.skip != 'true'
+    runs-on: starsling-ubuntu-24.04-2
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          # Publishes to GHCR via docker/login-action, never git push — don't persist the job token.
+          persist-credentials: false
+      - name: Set up toolchain
+        uses: ./.github/actions/setup-toolchain
+        with:
+          buildx: "true"
+      - name: GHCR session
+        uses: ./.github/actions/ghcr-login
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Promote candidate → version
+        id: promote
+        env:
+          REQUIRED: ${{ needs.plan.outputs.required }}
+          FORCE_REPUBLISH: ${{ inputs.force_republish }}
+          E2B_API_KEY: ${{ secrets.E2B_API_KEY }}
+          DAYTONA_API_KEY: ${{ secrets.DAYTONA_API_KEY }}
+          DAYTONA_TARGET: ${{ secrets.DAYTONA_TARGET || 'us-west-2' }}
+          MODAL_TOKEN_ID: ${{ secrets.MODAL_TOKEN_ID }}
+          MODAL_TOKEN_SECRET: ${{ secrets.MODAL_TOKEN_SECRET }}
+          NOVITA_API_KEY: ${{ secrets.NOVITA_API_KEY }}
+        run: |
+          set -euo pipefail
+          args=(--promote --require "${REQUIRED}")
+          # --force (manual force_republish dispatch only) republishes over an existing immutable
+          # version; never set on the automated push path.
           if [ "${FORCE_REPUBLISH}" = "true" ]; then args+=(--force); fi
-          bun apps/cli/src/bin/bake.ts "${args[@]}"
+          # bake.ts --promote prints the promote payload JSON to stdout — capture it as the diagnostic
+          # even when promote aborts (it prints the structured reports before exiting non-zero).
+          bun apps/cli/src/bin/bake.ts "${args[@]}" > promote-payload.json
+      - name: Upload promote payload
+        if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: promote-payload-${{ github.run_id }}
+          path: promote-payload.json
+          if-no-files-found: warn
+      - name: Release summary
+        if: always()
+        uses: ./.github/actions/release-summary
+        with:
+          phase: publish
+          status: ${{ job.status }}
+          mode: ${{ needs.plan.outputs.mode }}
+          source-ref: ${{ github.sha }}
+          image: ${{ needs.build.outputs.candidate-digest-ref }}
+          base-image: ${{ needs.plan.outputs.image-candidate }}
+          size-tier: ${{ needs.plan.outputs.size-tier }}
+          verify: bun apps/cli/src/bin/bake.ts --promote --require ${{ needs.plan.outputs.required }}
+          published: ${{ needs.plan.outputs.publish-target }}
+          diagnostics: promote-payload-${{ github.run_id }}

--- a/.github/workflows/toolchain-image.yml
+++ b/.github/workflows/toolchain-image.yml
@@ -136,7 +136,6 @@ jobs:
       required: ${{ steps.plan.outputs.required }}
       size-tier: ${{ steps.plan.outputs.size-tier }}
       image-candidate: ${{ steps.plan.outputs.image-candidate }}
-      image-version: ${{ steps.plan.outputs.image-version }}
       toolchain-version: ${{ steps.plan.outputs.toolchain-version }}
       publish-target: ${{ steps.plan.outputs.publish-target }}
     steps:

--- a/.github/workflows/toolchain-image.yml
+++ b/.github/workflows/toolchain-image.yml
@@ -90,7 +90,7 @@ jobs:
     runs-on: starsling-ubuntu-24.04-2
     steps:
       - name: Checkout
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           # Builds and smokes the image locally — no git push, so don't persist the job token.
           persist-credentials: false
@@ -140,7 +140,7 @@ jobs:
       publish-target: ${{ steps.plan.outputs.publish-target }}
     steps:
       - name: Checkout
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           # Reads code and probes the registry via docker/login — never git push.
           persist-credentials: false
@@ -178,7 +178,7 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
       - name: Upload release plan
         if: always()
-        uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5.0.0
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: release-plan-${{ github.run_id }}
           path: release-plan.json
@@ -211,7 +211,7 @@ jobs:
       candidate-digest-ref: ${{ steps.build.outputs.candidate-digest-ref }}
     steps:
       - name: Checkout
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           # Publishes to GHCR via docker/login-action, never git push — don't persist the job token.
           persist-credentials: false
@@ -239,7 +239,7 @@ jobs:
           bun apps/cli/src/bin/build-candidate.ts build-metadata.json
       - name: Upload build metadata
         if: always()
-        uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5.0.0
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: build-metadata-${{ github.run_id }}
           path: build-metadata.json
@@ -274,7 +274,7 @@ jobs:
       matrix: ${{ fromJSON(needs.plan.outputs.matrix) }}
     steps:
       - name: Checkout
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           # Boots the just-baked candidate via provider SDKs — no git push, no ghcr push. Don't persist.
           persist-credentials: false
@@ -313,7 +313,7 @@ jobs:
           bun apps/cli/src/bin/bake.ts "${args[@]}"
       - name: Upload bake report
         if: always()
-        uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5.0.0
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: bake-${{ matrix.provider }}-${{ github.run_id }}
           path: bake-${{ matrix.provider }}.json
@@ -349,7 +349,7 @@ jobs:
       packages: write
     steps:
       - name: Checkout
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           # Publishes to GHCR via docker/login-action, never git push — don't persist the job token.
           persist-credentials: false
@@ -385,7 +385,7 @@ jobs:
           bun apps/cli/src/bin/bake.ts "${args[@]}"
       - name: Upload promote payload
         if: always()
-        uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5.0.0
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: promote-payload-${{ github.run_id }}
           path: promote-payload.json

--- a/.github/workflows/toolchain-image.yml
+++ b/.github/workflows/toolchain-image.yml
@@ -165,7 +165,9 @@ jobs:
         # release-plan.ts validates pins again, probes whether :v1 is already published (best-effort —
         # promote does the authoritative guard), writes release-plan.json, and prints the key=value
         # outputs the downstream jobs read.
-        run: bun apps/cli/src/bin/release-plan.ts release-plan.json >> "$GITHUB_OUTPUT"
+        # release-plan.ts writes the key=value outputs straight to $GITHUB_OUTPUT (not via a stdout
+        # redirect), so a child process's stdout can never corrupt the outputs file.
+        run: bun apps/cli/src/bin/release-plan.ts release-plan.json
       # Guard the candidate package visibility so providers can pull it anonymously (see the composite).
       # Skipped when the release itself is skipped (version already published).
       - name: Ensure candidate package is public
@@ -232,7 +234,10 @@ jobs:
           # Declare then assign so the command substitution's exit status isn't masked (SC2155).
           BUILD_DATE="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
           export BUILD_DATE
-          bun apps/cli/src/bin/build-candidate.ts build-metadata.json >> "$GITHUB_OUTPUT"
+          # No `>> "$GITHUB_OUTPUT"` redirect: build.sh runs with inherited stdout, so redirecting this
+          # command's stdout would splice its build log into the outputs file (GitHub would reject it).
+          # build-candidate.ts writes the digest outputs straight to $GITHUB_OUTPUT itself.
+          bun apps/cli/src/bin/build-candidate.ts build-metadata.json
       - name: Upload build metadata
         if: always()
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
@@ -302,9 +307,11 @@ jobs:
           # Required providers must not silently skip: --require fails the cell if this provider's
           # secret is missing/misnamed or it fails to validate.
           if [ "${REQUIRED}" = "true" ]; then args+=(--require "${PROVIDER}"); fi
-          # bake.ts prints the report JSON to stdout (progress goes to stderr, visible in the log), so
-          # capture it as this cell's diagnostic even when the bake exits non-zero.
-          bun apps/cli/src/bin/bake.ts "${args[@]}" > "bake-${PROVIDER}.json"
+          # Route the report JSON to a file via env (not a `> file` redirect): the provider CLIs inherit
+          # stdout, so a redirect would splice their chatter into the report. bake.ts writes the file
+          # even when it exits non-zero, so it's a clean diagnostic on failure too.
+          export BAKE_REPORT_FILE="bake-${PROVIDER}.json"
+          bun apps/cli/src/bin/bake.ts "${args[@]}"
       - name: Upload bake report
         if: always()
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
@@ -360,6 +367,10 @@ jobs:
         env:
           REQUIRED: ${{ needs.plan.outputs.required }}
           FORCE_REPUBLISH: ${{ inputs.force_republish }}
+          # Route the promote payload JSON to a file via env (not a `> file` redirect): the provider
+          # CLIs inherit stdout, so a redirect would splice their chatter into the payload. bake.ts
+          # writes the file even when promote aborts (it records the structured reports before exiting).
+          BAKE_REPORT_FILE: promote-payload.json
           E2B_API_KEY: ${{ secrets.E2B_API_KEY }}
           DAYTONA_API_KEY: ${{ secrets.DAYTONA_API_KEY }}
           DAYTONA_TARGET: ${{ secrets.DAYTONA_TARGET || 'us-west-2' }}
@@ -372,9 +383,7 @@ jobs:
           # --force (manual force_republish dispatch only) republishes over an existing immutable
           # version; never set on the automated push path.
           if [ "${FORCE_REPUBLISH}" = "true" ]; then args+=(--force); fi
-          # bake.ts --promote prints the promote payload JSON to stdout — capture it as the diagnostic
-          # even when promote aborts (it prints the structured reports before exiting non-zero).
-          bun apps/cli/src/bin/bake.ts "${args[@]}" > promote-payload.json
+          bun apps/cli/src/bin/bake.ts "${args[@]}"
       - name: Upload promote payload
         if: always()
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2

--- a/.github/workflows/toolchain-image.yml
+++ b/.github/workflows/toolchain-image.yml
@@ -178,7 +178,7 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
       - name: Upload release plan
         if: always()
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5.0.0
         with:
           name: release-plan-${{ github.run_id }}
           path: release-plan.json
@@ -239,7 +239,7 @@ jobs:
           bun apps/cli/src/bin/build-candidate.ts build-metadata.json
       - name: Upload build metadata
         if: always()
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5.0.0
         with:
           name: build-metadata-${{ github.run_id }}
           path: build-metadata.json
@@ -313,7 +313,7 @@ jobs:
           bun apps/cli/src/bin/bake.ts "${args[@]}"
       - name: Upload bake report
         if: always()
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5.0.0
         with:
           name: bake-${{ matrix.provider }}-${{ github.run_id }}
           path: bake-${{ matrix.provider }}.json
@@ -385,7 +385,7 @@ jobs:
           bun apps/cli/src/bin/bake.ts "${args[@]}"
       - name: Upload promote payload
         if: always()
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5.0.0
         with:
           name: promote-payload-${{ github.run_id }}
           path: promote-payload.json

--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -23,6 +23,7 @@
     "bake": "bun src/bin/bake.ts"
   },
   "dependencies": {
+    "@actions/core": "1.11.1",
     "@sandbox-benchmarks/schema": "workspace:*",
     "@sandbox-benchmarks/providers": "workspace:*",
     "@sandbox-benchmarks/templates": "workspace:*",

--- a/apps/cli/src/bin/bake.ts
+++ b/apps/cli/src/bin/bake.ts
@@ -21,7 +21,8 @@ import { bakeNovitaTemplate } from "../lib/bake/novita.ts";
 import { promoteAll } from "../lib/bake/promote.ts";
 import type { BakeReport, Log } from "../lib/bake/types.ts";
 import { candidateCreateOptions } from "../lib/bake/validate.ts";
-import { anyFailed, forEachProviderWithCreds, unknownProviderIds } from "../lib/providers-run.ts";
+import { selectProviders } from "../lib/matrix.ts";
+import { anyFailed, forEachProviderWithCreds } from "../lib/providers-run.ts";
 import { bootAndSmoke, logChecks, smokeFailureReason, smokeOk } from "../lib/smoke-run.ts";
 
 // Each provider's candidate bake, bound to the candidate names + base ref from config.
@@ -62,8 +63,10 @@ function writeReport(report: unknown): void {
  * The provider ids a `--provider <ids>` (or `--provider=<ids>`) flag restricts the bake+validate loop
  * to — a comma-separated list, so the CI matrix passes one id per cell (`--provider e2b`) and each
  * provider bakes in its own job. Absent → undefined (drive every registered provider, the local
- * default). Parsed the same shape as `--require` (harness `requiredProviders`) for consistency. The
- * flag applies only to the candidate bake loop; `--promote` is always all-providers (a transaction).
+ * default). The argv scan mirrors `--require` (harness `requiredProviders`); the CSV is split and
+ * validated against the registry by the shared {@link selectProviders} (which dedups, is
+ * case-insensitive, returns registry order, and throws a registry-derived message on an unknown id).
+ * The flag applies only to the candidate bake loop; `--promote` is always all-providers (a transaction).
  */
 function requestedProviders(argv: string[]): ProviderId[] | undefined {
 	let raw: string | undefined;
@@ -75,18 +78,7 @@ function requestedProviders(argv: string[]): ProviderId[] | undefined {
 		const next = i === -1 ? undefined : argv[i + 1];
 		if (next !== undefined && !next.startsWith("-")) raw = next;
 	}
-	if (raw === undefined) return undefined;
-	const ids = raw
-		.split(",")
-		.map((s) => s.trim())
-		.filter(Boolean);
-	const unknown = unknownProviderIds(ids);
-	if (unknown.length > 0) {
-		throw new Error(
-			`unknown --provider id(s): ${unknown.join(", ")} — registered providers are e2b, daytona, blaxel, modal, novita`,
-		);
-	}
-	return ids as ProviderId[];
+	return raw === undefined ? undefined : selectProviders(raw);
 }
 
 if (import.meta.main) {

--- a/apps/cli/src/bin/bake.ts
+++ b/apps/cli/src/bin/bake.ts
@@ -20,7 +20,7 @@ import { bakeNovitaTemplate } from "../lib/bake/novita.ts";
 import { promoteAll } from "../lib/bake/promote.ts";
 import type { BakeReport, Log } from "../lib/bake/types.ts";
 import { candidateCreateOptions } from "../lib/bake/validate.ts";
-import { anyFailed, forEachProviderWithCreds } from "../lib/providers-run.ts";
+import { anyFailed, forEachProviderWithCreds, unknownProviderIds } from "../lib/providers-run.ts";
 import { bootAndSmoke, logChecks, smokeFailureReason, smokeOk } from "../lib/smoke-run.ts";
 
 // Each provider's candidate bake, bound to the candidate names + base ref from config.
@@ -43,6 +43,37 @@ const candidateRefs = {
 	toolchainImageCandidate: config.toolchainImageCandidate,
 	daytonaTarget: config.daytona.target,
 };
+
+/**
+ * The provider ids a `--provider <ids>` (or `--provider=<ids>`) flag restricts the bake+validate loop
+ * to — a comma-separated list, so the CI matrix passes one id per cell (`--provider e2b`) and each
+ * provider bakes in its own job. Absent → undefined (drive every registered provider, the local
+ * default). Parsed the same shape as `--require` (harness `requiredProviders`) for consistency. The
+ * flag applies only to the candidate bake loop; `--promote` is always all-providers (a transaction).
+ */
+function requestedProviders(argv: string[]): ProviderId[] | undefined {
+	let raw: string | undefined;
+	const eq = argv.find((a) => a.startsWith("--provider="));
+	if (eq) {
+		raw = eq.slice("--provider=".length);
+	} else {
+		const i = argv.indexOf("--provider");
+		const next = i === -1 ? undefined : argv[i + 1];
+		if (next !== undefined && !next.startsWith("-")) raw = next;
+	}
+	if (raw === undefined) return undefined;
+	const ids = raw
+		.split(",")
+		.map((s) => s.trim())
+		.filter(Boolean);
+	const unknown = unknownProviderIds(ids);
+	if (unknown.length > 0) {
+		throw new Error(
+			`unknown --provider id(s): ${unknown.join(", ")} — registered providers are e2b, daytona, blaxel, modal, novita`,
+		);
+	}
+	return ids as ProviderId[];
+}
 
 if (import.meta.main) {
 	const log: Log = (m) => console.error(m);
@@ -76,6 +107,17 @@ if (import.meta.main) {
 		process.exit(promoted.some((r) => r.status === "failed") ? 1 : 0);
 	}
 
+	// Optional per-provider restriction for the CI matrix fan-out (one cell per provider). Parsed before
+	// any build so a typo'd id fails the cell fast (clean message, no stack), before the candidate is touched.
+	let only: ProviderId[] | undefined;
+	try {
+		only = requestedProviders(process.argv);
+	} catch (err) {
+		log(`error: ${err instanceof Error ? err.message : String(err)}`);
+		process.exit(2);
+	}
+	if (only) log(`>>> restricting bake+validate to: ${only.join(", ")}`);
+
 	if (process.argv.includes("--build-push")) {
 		log(">>> building + pushing candidate image…");
 		try {
@@ -104,6 +146,7 @@ if (import.meta.main) {
 		},
 		{
 			log,
+			only,
 			ok: smokeOk,
 			failureReason: smokeFailureReason,
 			onComplete: (run) => {

--- a/apps/cli/src/bin/bake.ts
+++ b/apps/cli/src/bin/bake.ts
@@ -8,6 +8,7 @@
 //
 // The provider loop + skip-vs-fail contract is shared with bench-smoke/promote (providers-run.ts);
 // the boot+smoke lifecycle (probe results captured before teardown) is shared too (smoke-run.ts).
+import { writeFileSync } from "node:fs";
 import { requiredProviders, unmetRequirements } from "@sandbox-benchmarks/harness";
 import type { ProviderConfig } from "@sandbox-benchmarks/providers";
 import { config } from "@sandbox-benchmarks/providers";
@@ -43,6 +44,19 @@ const candidateRefs = {
 	toolchainImageCandidate: config.toolchainImageCandidate,
 	daytonaTarget: config.daytona.target,
 };
+
+/**
+ * Emit the bake/promote report JSON. To `$BAKE_REPORT_FILE` when set — the provider CLIs (e2b) and
+ * docker inherit stdout, so a `bun bake.ts … > report.json` redirect would splice their chatter into
+ * the report and corrupt the diagnostic. Writing the JSON to a file keeps the captured artifact clean
+ * regardless. Falls back to stdout locally (no env var) so the bin stays runnable by hand.
+ */
+function writeReport(report: unknown): void {
+	const json = `${JSON.stringify(report, null, 2)}\n`;
+	const file = process.env.BAKE_REPORT_FILE;
+	if (file) writeFileSync(file, json);
+	else process.stdout.write(json);
+}
 
 /**
  * The provider ids a `--provider <ids>` (or `--provider=<ids>`) flag restricts the bake+validate loop
@@ -83,21 +97,15 @@ if (import.meta.main) {
 		// `--force` republishes over an existing (immutable) version — dev regeneration, set only by a
 		// manual toolchain-image.yml dispatch. Automated pushes never pass it, so :v1 stays immutable there.
 		const promoted = await promoteAll(log, process.argv.includes("--force"));
-		console.log(
-			JSON.stringify(
-				{
-					version: {
-						image: config.toolchainImageVersion,
-						e2bTemplate: config.e2bTemplateVersion,
-						daytonaSnapshot: config.daytonaSnapshotDefault,
-						novitaTemplate: config.novitaTemplateVersion,
-					},
-					reports: promoted,
-				},
-				null,
-				2,
-			),
-		);
+		writeReport({
+			version: {
+				image: config.toolchainImageVersion,
+				e2bTemplate: config.e2bTemplateVersion,
+				daytonaSnapshot: config.daytonaSnapshotDefault,
+				novitaTemplate: config.novitaTemplateVersion,
+			},
+			reports: promoted,
+		});
 		// promoteAll is self-gating: the D1 required-providers gate (CI passes `--require e2b,daytona,modal`)
 		// runs INSIDE promoteAll before the immutable base is written, and every abort path (version already
 		// published, candidate re-validation failed, artifact failed, unmet requirements) pushes a structured
@@ -171,21 +179,15 @@ if (import.meta.main) {
 		...(run.value && run.value.checks.length > 0 ? { checks: run.value.checks } : {}),
 	}));
 
-	console.log(
-		JSON.stringify(
-			{
-				candidate: {
-					image: config.toolchainImageCandidate,
-					e2bTemplate: config.e2bTemplateCandidate,
-					daytonaSnapshot: config.daytonaSnapshotCandidate,
-					novitaTemplate: config.novitaTemplateCandidate,
-				},
-				reports,
-			},
-			null,
-			2,
-		),
-	);
+	writeReport({
+		candidate: {
+			image: config.toolchainImageCandidate,
+			e2bTemplate: config.e2bTemplateCandidate,
+			daytonaSnapshot: config.daytonaSnapshotCandidate,
+			novitaTemplate: config.novitaTemplateCandidate,
+		},
+		reports,
+	});
 
 	if (anyFailed(runs)) process.exit(1);
 

--- a/apps/cli/src/bin/build-candidate.ts
+++ b/apps/cli/src/bin/build-candidate.ts
@@ -6,11 +6,15 @@
 // `bake --build-push` (which build-pushes AND bakes in one process); CI splits the two.
 //
 // Emits, in one invocation:
-//   • stdout: `key=value` lines for `>> "$GITHUB_OUTPUT"` (the candidate digest + digest-pinned ref), and
-//   • argv[2] (optional): a build-metadata.json diagnostic artifact with the same facts.
+//   • the `key=value` step outputs (candidate digest + digest-pinned ref) straight to $GITHUB_OUTPUT
+//     via emitStepOutputs — NOT to stdout: build.sh runs with inherited stdout, so a
+//     `bun … >> "$GITHUB_OUTPUT"` redirect would splice build.sh's progress into the outputs file and
+//     GitHub would reject it. stdout is left to carry the (inherited) build log, and
+//   • argv[1] (optional): a build-metadata.json diagnostic artifact with the same facts.
 import { config } from "@sandbox-benchmarks/providers";
 import { buildAndPushCandidate, resolveImageDigest } from "../lib/bake/image.ts";
 import type { Log } from "../lib/bake/types.ts";
+import { emitStepOutputs } from "../lib/gha-output.ts";
 
 if (import.meta.main) {
 	const log: Log = (m) => console.error(m);
@@ -43,7 +47,6 @@ if (import.meta.main) {
 	if (metaPath) await Bun.write(metaPath, `${JSON.stringify(metadata, null, 2)}\n`);
 
 	log(`<<< candidate pushed: ${digestRef}`);
-	// stdout is the $GITHUB_OUTPUT contract — `key=value` lines only.
-	console.log(`digest=${digest}`);
-	console.log(`candidate-digest-ref=${digestRef}`);
+	// Straight to $GITHUB_OUTPUT (not stdout) — build.sh's inherited stdout must not reach the outputs.
+	emitStepOutputs([`digest=${digest}`, `candidate-digest-ref=${digestRef}`].join("\n"));
 }

--- a/apps/cli/src/bin/build-candidate.ts
+++ b/apps/cli/src/bin/build-candidate.ts
@@ -38,7 +38,8 @@ if (import.meta.main) {
 		version: config.toolchainVersion,
 		buildRef: process.env.GITHUB_SHA ?? null,
 	};
-	const metaPath = process.argv[2];
+	// Optional first positional (flags filtered out).
+	const metaPath = process.argv.slice(2).find((a) => !a.startsWith("-"));
 	if (metaPath) await Bun.write(metaPath, `${JSON.stringify(metadata, null, 2)}\n`);
 
 	log(`<<< candidate pushed: ${digestRef}`);

--- a/apps/cli/src/bin/build-candidate.ts
+++ b/apps/cli/src/bin/build-candidate.ts
@@ -1,0 +1,48 @@
+#!/usr/bin/env bun
+// `build-candidate` — the BUILD phase of the toolchain release: build the base image (+ variants) and
+// push the mutable candidate base to GHCR ONCE, then resolve and record its immutable digest. Split
+// from the provider bake so the image is built a single time here and every provider cell fans out
+// from the already-pushed candidate ref (build once, fan out). The local iteration loop still uses
+// `bake --build-push` (which build-pushes AND bakes in one process); CI splits the two.
+//
+// Emits, in one invocation:
+//   • stdout: `key=value` lines for `>> "$GITHUB_OUTPUT"` (the candidate digest + digest-pinned ref), and
+//   • argv[2] (optional): a build-metadata.json diagnostic artifact with the same facts.
+import { config } from "@sandbox-benchmarks/providers";
+import { buildAndPushCandidate, resolveImageDigest } from "../lib/bake/image.ts";
+import type { Log } from "../lib/bake/types.ts";
+
+if (import.meta.main) {
+	const log: Log = (m) => console.error(m);
+
+	await buildAndPushCandidate(log);
+
+	// The digest is recorded provenance, not a release gate (promote re-validates the mutable tag), so a
+	// registry-inspect quirk must not block a candidate that pushed fine: fall back to the tag on failure.
+	const repo = config.toolchainImageCandidate.split(":")[0] ?? config.toolchainImageCandidate;
+	let digest = "unknown";
+	let digestRef: string = config.toolchainImageCandidate;
+	try {
+		digest = await resolveImageDigest(config.toolchainImageCandidate);
+		digestRef = `${repo}@${digest}`;
+	} catch (err) {
+		log(
+			`::warning::could not resolve candidate digest (${err instanceof Error ? err.message : String(err)}); recording the tag instead.`,
+		);
+	}
+
+	const metadata = {
+		candidate: config.toolchainImageCandidate,
+		digest,
+		digestRef,
+		version: config.toolchainVersion,
+		buildRef: process.env.GITHUB_SHA ?? null,
+	};
+	const metaPath = process.argv[2];
+	if (metaPath) await Bun.write(metaPath, `${JSON.stringify(metadata, null, 2)}\n`);
+
+	log(`<<< candidate pushed: ${digestRef}`);
+	// stdout is the $GITHUB_OUTPUT contract — `key=value` lines only.
+	console.log(`digest=${digest}`);
+	console.log(`candidate-digest-ref=${digestRef}`);
+}

--- a/apps/cli/src/bin/release-ensure-public.ts
+++ b/apps/cli/src/bin/release-ensure-public.ts
@@ -1,0 +1,61 @@
+#!/usr/bin/env bun
+// `release-ensure-public` — the script behind the `ensure-package-public` composite action. Fails fast
+// (with rich @actions/core annotations) if the candidate base package is not public. e2b builds its
+// template on E2B's REMOTE builder (FROM the ghcr candidate base) and daytona/modal/novita pull it to
+// snapshot/boot — none are handed ghcr pull credentials, so the candidate package MUST be public. GHCR
+// packages are created PRIVATE on first push with no API to flip visibility, so making it public is a
+// one-time manual bootstrap; this guard surfaces that plainly instead of an opaque provider pull error.
+//
+// Inputs arrive as env (the composite maps its `with:` inputs). Uses Bun's fetch + a real JSON parse
+// (not a curl+grep), and core.setFailed/warning so the outcome renders as a run annotation.
+import * as core from "@actions/core";
+
+const owner = process.env.OWNER ?? "";
+const pkg = process.env.PACKAGE ?? "";
+const token = process.env.GH_TOKEN ?? "";
+
+const label = `${owner}/${pkg}`;
+const api = `https://api.github.com/orgs/${owner}/packages/container/${encodeURIComponent(pkg)}`;
+
+await core.group(`Ensure GHCR package ${label} is public`, async () => {
+	let res: Response;
+	try {
+		// Distinguish a real transport failure (throws) from an HTTP status (a 404/403 does NOT throw) —
+		// the whole point of the guard is not to publish blind on a swallowed error.
+		res = await fetch(api, {
+			headers: {
+				Authorization: `Bearer ${token}`,
+				Accept: "application/vnd.github+json",
+				"User-Agent": "sandbox-benchmarks-release",
+			},
+			signal: AbortSignal.timeout(30_000),
+		});
+	} catch (err) {
+		core.setFailed(
+			`Could not reach the GHCR package API (network/transport error) — refusing to publish blind: ${err instanceof Error ? err.message : String(err)}`,
+		);
+		return;
+	}
+
+	if (res.status === 200) {
+		const body = (await res.json().catch(() => ({}))) as { visibility?: string };
+		if (body.visibility === "public") {
+			core.info(`GHCR package ${label} is public — providers can pull the candidate.`);
+		} else {
+			core.error(
+				`GHCR package ${label} is ${body.visibility ?? "not public"}. e2b/daytona/modal/novita pull the candidate base anonymously, so set it Public once (org package settings or link it to this repo), then re-run.`,
+				{ title: "GHCR candidate package is not public" },
+			);
+			core.setFailed(`GHCR package ${label} is not public.`);
+		}
+	} else if (res.status === 404) {
+		core.warning(
+			`GHCR package ${label} not found yet — the build below creates it PRIVATE. After this run, set it Public once so the candidate validate and the providers can pull it; this run's bake will fail until then.`,
+			{ title: "GHCR candidate package not found yet" },
+		);
+	} else {
+		core.setFailed(
+			`GHCR package API returned HTTP ${res.status} (expected 200 or 404) — likely a token-scope gap or org SSO enforcement, not a missing package. Resolve and re-run instead of publishing blind.`,
+		);
+	}
+});

--- a/apps/cli/src/bin/release-plan.test.ts
+++ b/apps/cli/src/bin/release-plan.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, test } from "bun:test";
+import { buildReleasePlan, planOutputs, RELEASE_REQUIRED_PROVIDERS } from "./release-plan.ts";
+
+const base = { sourceRef: "abc123", forceRepublish: false, alreadyPublished: false };
+
+describe("buildReleasePlan mode + skip", () => {
+	test("a fresh build of an unpublished version runs (mode build, skip false)", () => {
+		const plan = buildReleasePlan(base);
+		expect(plan.mode).toBe("build");
+		expect(plan.skip).toBe(false);
+	});
+
+	test("a plain build skips once the immutable version already exists", () => {
+		const plan = buildReleasePlan({ ...base, alreadyPublished: true });
+		expect(plan.mode).toBe("build");
+		expect(plan.skip).toBe(true);
+	});
+
+	test("force_republish regenerates in place even when already published (mode republish, skip false)", () => {
+		const plan = buildReleasePlan({ ...base, forceRepublish: true, alreadyPublished: true });
+		expect(plan.mode).toBe("republish");
+		expect(plan.skip).toBe(false);
+		expect(plan.gates.forceRepublish).toBe(true);
+	});
+});
+
+describe("buildReleasePlan matrix", () => {
+	test("fans out over every provider in registry order", () => {
+		const plan = buildReleasePlan(base);
+		expect(plan.matrix.include.map((c) => c.provider)).toEqual([
+			"e2b",
+			"daytona",
+			"blaxel",
+			"modal",
+			"novita",
+		]);
+	});
+
+	test("marks exactly the required providers as gating cells", () => {
+		const plan = buildReleasePlan(base);
+		const required = plan.matrix.include.filter((c) => c.required).map((c) => c.provider);
+		expect(required).toEqual([...RELEASE_REQUIRED_PROVIDERS]);
+		expect(plan.required).toEqual([...RELEASE_REQUIRED_PROVIDERS]);
+	});
+});
+
+describe("planOutputs", () => {
+	test("emits one key=value per line with a single-line matrix json", () => {
+		const lines = planOutputs(buildReleasePlan(base)).split("\n");
+		expect(lines).toContain("mode=build");
+		expect(lines).toContain("skip=false");
+		expect(lines).toContain(`required=${RELEASE_REQUIRED_PROVIDERS.join(",")}`);
+		const matrixLine = lines.find((l) => l.startsWith("matrix="));
+		expect(matrixLine).toBeDefined();
+		// The matrix value must be valid, single-line JSON (the fromJSON contract).
+		const parsed = JSON.parse((matrixLine as string).slice("matrix=".length));
+		expect(parsed.include).toHaveLength(5);
+		expect((matrixLine as string).includes("\n")).toBe(false);
+	});
+});

--- a/apps/cli/src/bin/release-plan.ts
+++ b/apps/cli/src/bin/release-plan.ts
@@ -18,6 +18,7 @@ import { config } from "@sandbox-benchmarks/providers";
 import type { ProviderId } from "@sandbox-benchmarks/schema";
 import { validatedPins } from "@sandbox-benchmarks/templates/pins";
 import { imageExistsInRegistry } from "../lib/bake/image.ts";
+import { emitStepOutputs } from "../lib/gha-output.ts";
 
 /**
  * Providers the release is REQUIRED to bake + validate before the public version is published — the
@@ -183,6 +184,7 @@ if (import.meta.main) {
 	const planPath = process.argv.slice(2).find((a) => !a.startsWith("-"));
 	if (planPath) await Bun.write(planPath, `${JSON.stringify(plan, null, 2)}\n`);
 
-	// stdout is the $GITHUB_OUTPUT contract — keep it to `key=value` lines only.
-	console.log(planOutputs(plan));
+	// Write the `key=value` outputs straight to $GITHUB_OUTPUT (never via a stdout redirect), so nothing
+	// a child process prints can corrupt them.
+	emitStepOutputs(planOutputs(plan));
 }

--- a/apps/cli/src/bin/release-plan.ts
+++ b/apps/cli/src/bin/release-plan.ts
@@ -178,8 +178,9 @@ if (import.meta.main) {
 
 	const plan = buildReleasePlan({ sourceRef, forceRepublish, alreadyPublished });
 
-	// argv[2] (optional): write the full plan JSON here for the release-plan.json diagnostic artifact.
-	const planPath = process.argv[2];
+	// Optional first positional (flags filtered out): write the full plan JSON here for the
+	// release-plan.json diagnostic artifact.
+	const planPath = process.argv.slice(2).find((a) => !a.startsWith("-"));
 	if (planPath) await Bun.write(planPath, `${JSON.stringify(plan, null, 2)}\n`);
 
 	// stdout is the $GITHUB_OUTPUT contract — keep it to `key=value` lines only.

--- a/apps/cli/src/bin/release-plan.ts
+++ b/apps/cli/src/bin/release-plan.ts
@@ -1,0 +1,187 @@
+#!/usr/bin/env bun
+// `release-plan` — the FIRST job of the toolchain release. Resolve the toolchain identity from the
+// arktype-validated config, decide the release mode, and emit ONE machine-checkable release plan that
+// every downstream job (build, the provider bake matrix, promote) consumes instead of re-deriving the
+// refs and gates from the raw workflow inputs (the "make the plan an artifact" contract).
+//
+// Two outputs, one invocation:
+//   • the full plan as pretty JSON, written to the path in argv[2] (uploaded as the release-plan.json
+//     diagnostic artifact), and
+//   • flat `key=value` lines on stdout for `>> "$GITHUB_OUTPUT"` (skip, mode, matrix, refs, …).
+//
+// Credential posture: importing `config`/`validatedPins` validates env + pins with NO cloud creds
+// (the fail-fast gate). The one privileged call is the immutability probe (`imageExistsInRegistry`,
+// a `docker manifest inspect` that needs the GHCR login the plan job does first). That probe is only
+// a best-effort EARLY skip — the authoritative immutable-version guard lives in `promote` (which
+// REFUSES on an uncertain check), so an inconclusive probe here proceeds rather than blocks.
+import { config } from "@sandbox-benchmarks/providers";
+import type { ProviderId } from "@sandbox-benchmarks/schema";
+import { validatedPins } from "@sandbox-benchmarks/templates/pins";
+import { imageExistsInRegistry } from "../lib/bake/image.ts";
+
+/**
+ * Providers the release is REQUIRED to bake + validate before the public version is published — the
+ * same set CI passes to `bake --promote --require …`, single-sourced here so the matrix's per-cell
+ * `required` flags and promote's gate can't drift. e2b/daytona bake a real artifact; modal is required
+ * because its `Image.fromRegistry` boot validates the published image the same way. blaxel (a no-op
+ * bake booting the stock base) and novita (optional control plane) are best-effort: a missing secret
+ * skips them without failing the release.
+ */
+export const RELEASE_REQUIRED_PROVIDERS: readonly ProviderId[] = ["e2b", "daytona", "modal"];
+
+/** Registry order (matches the provider registry) — the order the matrix cells are listed in. */
+const RELEASE_PROVIDERS: readonly ProviderId[] = ["e2b", "daytona", "blaxel", "modal", "novita"];
+
+/** Per-provider baked artifact name (what a cell produces), or a note for the providers that bake none. */
+function providerArtifact(id: ProviderId): string {
+	switch (id) {
+		case "e2b":
+			return config.e2bTemplateCandidate;
+		case "daytona":
+			return config.daytonaSnapshotCandidate;
+		case "novita":
+			return config.novitaTemplateCandidate;
+		case "modal":
+			return "boots the candidate image directly (no baked artifact)";
+		case "blaxel":
+			return "boots the stock base image (no baked artifact)";
+	}
+}
+
+export interface ReleasePlanInputs {
+	/** `github.sha` — the source ref the release is cut from (recorded, not resolved). */
+	sourceRef: string;
+	/** `force_republish` dispatch input: regenerate the version in place even if already published. */
+	forceRepublish: boolean;
+	/** Whether the immutable public version already exists in the registry (the early-skip probe). */
+	alreadyPublished: boolean;
+}
+
+export interface ReleaseProviderPlan {
+	provider: ProviderId;
+	required: boolean;
+	artifact: string;
+}
+
+export interface ReleasePlan {
+	/** `build` for a fresh release; `republish` when force_republish regenerates an existing version. */
+	mode: "build" | "republish";
+	/** Skip the whole release: the version is already published and this is not a forced republish. */
+	skip: boolean;
+	sourceRef: string;
+	/** The single cross-provider size tier (this benchmark pins exactly one — no size-tier fan-out). */
+	sizeTier: string;
+	image: {
+		repo: string;
+		/** The bare package name (the GHCR package the public-package guard checks). */
+		name: string;
+		version: string;
+		candidate: string;
+		toolchainVersion: string;
+	};
+	providers: ReleaseProviderPlan[];
+	/** The providers that must pass before publish (single-sourced for the matrix + promote gate). */
+	required: ProviderId[];
+	gates: {
+		alreadyPublished: boolean;
+		forceRepublish: boolean;
+		/** The immutable pointer promote advances — the only mutation the release makes public. */
+		publishTarget: string;
+	};
+	/** The `strategy.matrix` contract the bake fan-out reads: one cell per provider. */
+	matrix: { include: Array<{ provider: ProviderId; required: boolean }> };
+}
+
+/**
+ * Build the release plan from resolved inputs + the config refs. Pure (no env, no I/O) so the mode /
+ * skip / matrix logic is unit-testable without a registry or a real config — the bin injects the live
+ * `config`-derived values below.
+ */
+export function buildReleasePlan(inputs: ReleasePlanInputs): ReleasePlan {
+	const mode = inputs.forceRepublish ? "republish" : "build";
+	// force_republish deliberately regenerates the version in place, so "already published" never skips
+	// it; a plain build skips once the immutable version exists (bump TOOLCHAIN_VERSION to publish anew).
+	const skip = inputs.alreadyPublished && !inputs.forceRepublish;
+
+	const providers: ReleaseProviderPlan[] = RELEASE_PROVIDERS.map((provider) => ({
+		provider,
+		required: RELEASE_REQUIRED_PROVIDERS.includes(provider),
+		artifact: providerArtifact(provider),
+	}));
+
+	const { vcpus, memoryGb, diskGb } = config.targetSpec;
+	const repo = config.toolchainImageVersion.split(":")[0] ?? config.toolchainImageVersion;
+
+	return {
+		mode,
+		skip,
+		sourceRef: inputs.sourceRef,
+		sizeTier: `${vcpus} vCPU / ${memoryGb} GiB / ${diskGb} GB`,
+		image: {
+			repo,
+			name: repo.split("/").pop() ?? repo,
+			version: config.toolchainImageVersion,
+			candidate: config.toolchainImageCandidate,
+			toolchainVersion: config.toolchainVersion,
+		},
+		providers,
+		required: [...RELEASE_REQUIRED_PROVIDERS],
+		gates: {
+			alreadyPublished: inputs.alreadyPublished,
+			forceRepublish: inputs.forceRepublish,
+			publishTarget: config.toolchainImageVersion,
+		},
+		matrix: {
+			include: providers.map(({ provider, required }) => ({ provider, required })),
+		},
+	};
+}
+
+/** The flat `key=value` lines a downstream job reads via `steps.<id>.outputs.*` (one per line). */
+export function planOutputs(plan: ReleasePlan): string {
+	return [
+		`mode=${plan.mode}`,
+		`skip=${plan.skip}`,
+		`already-published=${plan.gates.alreadyPublished}`,
+		`image-repo=${plan.image.repo}`,
+		`image-name=${plan.image.name}`,
+		`image-version=${plan.image.version}`,
+		`image-candidate=${plan.image.candidate}`,
+		`toolchain-version=${plan.image.toolchainVersion}`,
+		`size-tier=${plan.sizeTier}`,
+		`required=${plan.required.join(",")}`,
+		`publish-target=${plan.gates.publishTarget}`,
+		// The matrix must be a single line of compact JSON — it becomes `fromJSON(needs.plan.outputs.matrix)`.
+		`matrix=${JSON.stringify(plan.matrix)}`,
+	].join("\n");
+}
+
+if (import.meta.main) {
+	// Validate the pins up front (throws on any unfilled/invalid pin) — the credential-free fail-fast
+	// gate, before the registry probe below touches the (already-logged-in) registry.
+	validatedPins();
+
+	const forceRepublish = process.env.FORCE_REPUBLISH === "true";
+	const sourceRef = process.env.GITHUB_SHA ?? "unknown";
+
+	// Best-effort immutability probe: an inconclusive result (auth/network) proceeds — promote does the
+	// authoritative, refuse-on-uncertain check before it writes the immutable base.
+	let alreadyPublished = false;
+	try {
+		alreadyPublished = await imageExistsInRegistry(config.toolchainImageVersion);
+	} catch (err) {
+		console.error(
+			`::warning::could not probe whether ${config.toolchainImageVersion} is already published ` +
+				`(${err instanceof Error ? err.message : String(err)}); proceeding — promote does the authoritative guard.`,
+		);
+	}
+
+	const plan = buildReleasePlan({ sourceRef, forceRepublish, alreadyPublished });
+
+	// argv[2] (optional): write the full plan JSON here for the release-plan.json diagnostic artifact.
+	const planPath = process.argv[2];
+	if (planPath) await Bun.write(planPath, `${JSON.stringify(plan, null, 2)}\n`);
+
+	// stdout is the $GITHUB_OUTPUT contract — keep it to `key=value` lines only.
+	console.log(planOutputs(plan));
+}

--- a/apps/cli/src/bin/release-plan.ts
+++ b/apps/cli/src/bin/release-plan.ts
@@ -5,9 +5,10 @@
 // refs and gates from the raw workflow inputs (the "make the plan an artifact" contract).
 //
 // Two outputs, one invocation:
-//   • the full plan as pretty JSON, written to the path in argv[2] (uploaded as the release-plan.json
+//   • the full plan as pretty JSON, written to the path in argv[1] (uploaded as the release-plan.json
 //     diagnostic artifact), and
-//   • flat `key=value` lines on stdout for `>> "$GITHUB_OUTPUT"` (skip, mode, matrix, refs, …).
+//   • the consumed `key=value` lines written straight to $GITHUB_OUTPUT (skip, mode, matrix, refs, …)
+//     via emitStepOutputs — never a stdout redirect, so no subprocess chatter can corrupt them.
 //
 // Credential posture: importing `config`/`validatedPins` validates env + pins with NO cloud creds
 // (the fail-fast gate). The one privileged call is the immutability probe (`imageExistsInRegistry`,
@@ -16,6 +17,7 @@
 // REFUSES on an uncertain check), so an inconclusive probe here proceeds rather than blocks.
 import { config } from "@sandbox-benchmarks/providers";
 import type { ProviderId } from "@sandbox-benchmarks/schema";
+import { PROVIDERS } from "@sandbox-benchmarks/schema";
 import { validatedPins } from "@sandbox-benchmarks/templates/pins";
 import { imageExistsInRegistry } from "../lib/bake/image.ts";
 import { emitStepOutputs } from "../lib/gha-output.ts";
@@ -30,8 +32,11 @@ import { emitStepOutputs } from "../lib/gha-output.ts";
  */
 export const RELEASE_REQUIRED_PROVIDERS: readonly ProviderId[] = ["e2b", "daytona", "modal"];
 
-/** Registry order (matches the provider registry) — the order the matrix cells are listed in. */
-const RELEASE_PROVIDERS: readonly ProviderId[] = ["e2b", "daytona", "blaxel", "modal", "novita"];
+/** Every provider the release fans out over, derived from the registry (never a hand-maintained
+ *  literal) so adding a provider grows the matrix automatically — in registry order, matching the
+ *  matrix cell order. `providerArtifact` below is exhaustive over `ProviderId`, so a new provider is a
+ *  compile error there until it's handled. */
+const RELEASE_PROVIDERS: readonly ProviderId[] = PROVIDERS.map((p) => p.id);
 
 /** Per-provider baked artifact name (what a cell produces), or a note for the providers that bake none. */
 function providerArtifact(id: ProviderId): string {
@@ -138,15 +143,14 @@ export function buildReleasePlan(inputs: ReleasePlanInputs): ReleasePlan {
 	};
 }
 
-/** The flat `key=value` lines a downstream job reads via `steps.<id>.outputs.*` (one per line). */
+/** The flat `key=value` lines a downstream job reads via `steps.<id>.outputs.*` (one per line). Only
+ *  the outputs the workflow actually consumes are emitted; the full plan (repo, version, gates, …)
+ *  lives in the release-plan.json artifact for diagnostics. */
 export function planOutputs(plan: ReleasePlan): string {
 	return [
 		`mode=${plan.mode}`,
 		`skip=${plan.skip}`,
-		`already-published=${plan.gates.alreadyPublished}`,
-		`image-repo=${plan.image.repo}`,
 		`image-name=${plan.image.name}`,
-		`image-version=${plan.image.version}`,
 		`image-candidate=${plan.image.candidate}`,
 		`toolchain-version=${plan.image.toolchainVersion}`,
 		`size-tier=${plan.sizeTier}`,

--- a/apps/cli/src/bin/release-summary.test.ts
+++ b/apps/cli/src/bin/release-summary.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, test } from "bun:test";
+import { escapeHtml, renderCell } from "./release-summary.ts";
+
+describe("escapeHtml", () => {
+	test("escapes the HTML metacharacters so a value can't inject into the summary table", () => {
+		expect(escapeHtml('<img src=x onerror=alert(1)> & "ok"')).toBe(
+			'&lt;img src=x onerror=alert(1)&gt; &amp; "ok"',
+		);
+	});
+
+	test("escapes & before < > so an entity can't be double-decoded", () => {
+		expect(escapeHtml("a & <b>")).toBe("a &amp; &lt;b&gt;");
+	});
+});
+
+describe("renderCell", () => {
+	test("wraps code values in <code> after escaping", () => {
+		expect(renderCell("ghcr.io/x@sha256:ab", "code")).toBe("<code>ghcr.io/x@sha256:ab</code>");
+	});
+
+	test("leaves plain prose unwrapped (still escaped)", () => {
+		expect(renderCell("2 vCPU / 8 GiB", "plain")).toBe("2 vCPU / 8 GiB");
+		expect(renderCell("<b>", "plain")).toBe("&lt;b&gt;");
+	});
+});

--- a/apps/cli/src/bin/release-summary.ts
+++ b/apps/cli/src/bin/release-summary.ts
@@ -1,0 +1,78 @@
+#!/usr/bin/env bun
+// `release-summary` — the script behind the `release-summary` composite action. Renders a consistent
+// per-phase job summary and a run annotation via @actions/core (GitHub's Actions Toolkit) instead of
+// hand-rolled `>> "$GITHUB_STEP_SUMMARY"` bash: core.summary owns the Markdown/HTML table + link, and
+// core.notice/core.error surface the phase result in the run's annotations panel. Inputs arrive as env
+// (the composite maps its `with:` inputs), NOT via core.getInput (that only works for JS/Docker actions).
+import * as core from "@actions/core";
+
+type Kind = "plain" | "code";
+
+/** Escape the HTML metacharacters so a value (an image ref, a command) can't break — or inject into —
+ *  the summary table. Pure + exported for unit testing. */
+export function escapeHtml(value: string): string {
+	return value.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
+}
+
+/** Render a table cell: `code` values are HTML-escaped and wrapped in `<code>`; `plain` prose is only
+ *  escaped. Pure + exported for unit testing. */
+export function renderCell(value: string, kind: Kind): string {
+	const escaped = escapeHtml(value);
+	return kind === "code" ? `<code>${escaped}</code>` : escaped;
+}
+
+if (import.meta.main) {
+	const env = (key: string): string => process.env[key]?.trim() ?? "";
+	const phase = env("PHASE") || "release";
+	const status = env("STATUS");
+
+	// The field vocabulary, in display order. `code` fields (refs, commands, pointers) render monospaced.
+	const fields: Array<[label: string, value: string, kind: Kind]> = [
+		["Status", status, "plain"],
+		["Mode", env("MODE"), "code"],
+		["Source ref", env("SOURCE_REF"), "code"],
+		["Image", env("IMAGE"), "code"],
+		["Base image", env("BASE_IMAGE"), "code"],
+		["Provider target", env("PROVIDER_TARGET"), "code"],
+		["Size tier", env("SIZE_TIER"), "plain"],
+		["Verify command", env("VERIFY"), "code"],
+		["Published", env("PUBLISHED"), "code"],
+		["Elapsed", env("ELAPSED"), "plain"],
+	];
+
+	// A header row plus one row per non-empty field, so each phase shows only its own facts.
+	// Typed structurally as the (SummaryTableCell | string)[][] core.summary.addTable accepts.
+	const headerRow: Array<{ data: string; header: boolean } | string> = [
+		{ data: "Field", header: true },
+		{ data: "Value", header: true },
+	];
+	const rows = [
+		headerRow,
+		...fields
+			.filter(([, value]) => value.length > 0)
+			.map(([label, value, kind]) => [label, renderCell(value, kind)]),
+	];
+
+	core.summary.addHeading(`Image release: ${phase}`, 3).addTable(rows);
+
+	// Link the uploaded diagnostics artifact to the run's artifacts, so an operator can jump straight there.
+	const diagnostics = env("DIAGNOSTICS");
+	const runUrl = env("RUN_URL");
+	if (diagnostics) {
+		core.summary.addRaw("Diagnostics: ", false);
+		if (runUrl) core.summary.addLink(diagnostics, `${runUrl}#artifacts`);
+		else core.summary.addRaw(diagnostics);
+		core.summary.addEOL();
+	}
+
+	await core.summary.write();
+
+	// Surface the phase result in the run's annotations panel (grouped/filterable), not just the log.
+	const title = `Image release: ${phase}${status ? ` — ${status}` : ""}`;
+	const detail =
+		[env("IMAGE") && `image=${env("IMAGE")}`, env("PUBLISHED") && `published=${env("PUBLISHED")}`]
+			.filter(Boolean)
+			.join(" · ") || phase;
+	if (status === "failure") core.error(detail, { title });
+	else core.notice(detail, { title });
+}

--- a/apps/cli/src/bin/release-validate.ts
+++ b/apps/cli/src/bin/release-validate.ts
@@ -1,0 +1,36 @@
+#!/usr/bin/env bun
+// `release-validate` — the script behind the `release-validate-inputs` composite action: the
+// credential-free fail-fast gate. Validates the toolchain pins and the dispatch inputs BEFORE any
+// registry/provider credential is introduced, and reports failures as rich @actions/core annotations
+// (a pin failure is annotated ON the pins source file, so the run's "Files changed" view links to it).
+// Inputs arrive as env (the composite maps its `with:` inputs).
+import * as core from "@actions/core";
+import { validatedPins } from "@sandbox-benchmarks/templates/pins";
+
+// The arktype pin gatekeeper lives here; annotate failures on it so the run links straight to the pins.
+const PINS_FILE = "packages/templates/src/lib/pins.ts";
+
+// A dispatch input reaches the release as an env var; still, reject anything but the two booleans so a
+// hand-typed dispatch value can't slip through as a surprise "truthy" string downstream.
+const forceRepublish = process.env.FORCE_REPUBLISH ?? "";
+if (!["true", "false", ""].includes(forceRepublish)) {
+	core.error(`force_republish must be true or false (got '${forceRepublish}').`, {
+		title: "Invalid dispatch input",
+	});
+	core.setFailed("Invalid force_republish input.");
+}
+
+// Re-run the arktype pin gatekeeper (hex sha256s, non-empty versions); an unfilled/invalid pin fails the
+// release here, before it spends a build. On failure, annotate the exact source file.
+await core.group("Validate toolchain pins", async () => {
+	try {
+		validatedPins();
+		core.info("Toolchain pins valid.");
+	} catch (err) {
+		core.error(err instanceof Error ? err.message : String(err), {
+			title: "Toolchain pin validation failed",
+			file: PINS_FILE,
+		});
+		core.setFailed("Toolchain pin validation failed — see the annotation on the pins file.");
+	}
+});

--- a/apps/cli/src/lib/bake/daytona.test.ts
+++ b/apps/cli/src/lib/bake/daytona.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "bun:test";
-import { snapshotDestroyedMessage } from "./daytona.ts";
+import { describeDaytonaError, snapshotDestroyedMessage } from "./daytona.ts";
 
 // The published snapshot name a `promote --force` regenerates in place — the case where a create that
 // fails after the delete leaves a *public* artifact absent rather than stale.
@@ -25,5 +25,31 @@ describe("snapshotDestroyedMessage", () => {
 		// listSnapshotsByName sweeps every snapshot of the name in any state (a failed mid-create leaves
 		// one `get` won't return), so the count is genuinely unbounded above 1 — don't hardcode "1".
 		expect(snapshotDestroyedMessage(PUBLISHED, 3, "boom")).toContain("deleting 3 pre-existing");
+	});
+});
+
+describe("describeDaytonaError", () => {
+	it("surfaces status code, error code, and response body from the opaque SDK error", () => {
+		const out = describeDaytonaError({
+			name: "DaytonaError",
+			statusCode: 500,
+			code: "INTERNAL",
+			response: { data: { message: "failed to inspect in registry" } },
+		});
+		expect(out).toContain("name=DaytonaError");
+		expect(out).toContain("status=500");
+		expect(out).toContain("code=INTERNAL");
+		expect(out).toContain("failed to inspect in registry");
+	});
+
+	it("includes the cause chain when present", () => {
+		expect(
+			describeDaytonaError({ message: "boom", cause: new Error("registry unreachable") }),
+		).toContain("cause=registry unreachable");
+	});
+
+	it("never throws on a non-object error, and says so", () => {
+		expect(describeDaytonaError("plain string")).toContain("plain string");
+		expect(describeDaytonaError(undefined)).toContain("non-object");
 	});
 });

--- a/apps/cli/src/lib/bake/daytona.ts
+++ b/apps/cli/src/lib/bake/daytona.ts
@@ -124,6 +124,44 @@ async function deleteExistingSnapshots(daytona: Daytona, name: string, log: Log)
 	}
 }
 
+/** A verbose one-line description of a Daytona SDK error for diagnostics — pulls status codes, any
+ *  response body, an error code, and the `cause` chain out of the opaque object the SDK throws, so a
+ *  bake log records more than the bare `.message`. Pure and defensive (never throws), so it is safe on
+ *  an error path and unit-testable without the SDK. */
+export function describeDaytonaError(err: unknown): string {
+	if (typeof err !== "object" || err === null) return `non-object error: ${String(err)}`;
+	const e = err as {
+		name?: unknown;
+		statusCode?: number;
+		status?: number;
+		code?: string | number;
+		response?: { status?: number; data?: unknown };
+		cause?: unknown;
+	};
+	const parts: string[] = [];
+	if (typeof e.name === "string") parts.push(`name=${e.name}`);
+	const status = e.statusCode ?? e.status ?? e.response?.status;
+	if (status !== undefined) parts.push(`status=${status}`);
+	if (e.code !== undefined) parts.push(`code=${String(e.code)}`);
+	if (e.response?.data !== undefined) {
+		let body: string;
+		try {
+			body =
+				typeof e.response.data === "string" ? e.response.data : JSON.stringify(e.response.data);
+		} catch {
+			body = String(e.response.data);
+		}
+		parts.push(`response=${body.slice(0, 500)}`);
+	}
+	if (e.cause !== undefined && e.cause !== null) {
+		const cause = e.cause as { message?: unknown };
+		const causeText =
+			typeof cause.message === "string" ? cause.message : String(e.cause).slice(0, 300);
+		parts.push(`cause=${causeText}`);
+	}
+	return parts.length > 0 ? parts.join(" ") : "no structured detail";
+}
+
 /** The message for a create that failed after `deleted` (> 0) pre-existing snapshots of `name` were
  *  removed to free the name: `name` now resolves to nothing. Stated plainly because the caller that
  *  passes a published name (promote `--force`) surfaces this as the report's `reason`, where "failed"
@@ -153,23 +191,81 @@ export async function bakeDaytonaSnapshot(name: string, image: string, log: Log)
 
 	const deleted = await deleteExistingSnapshots(daytona, name, log);
 
-	log(`creating snapshot ${name} from ${image} (target ${daytonaCfg.target ?? "default"})`);
-	try {
-		await daytona.snapshot.create(
-			{
-				name,
-				image,
-				resources: { cpu: targetSpec.vcpus, memory: targetSpec.memoryGb, disk: targetSpec.diskGb },
-				// Pin to microVM runners (never the `container` default) — the fleet's hard constraint.
-				sandboxClass: SandboxClass.LINUX_VM,
-			},
-			{ onLogs: log },
+	const params = {
+		name,
+		image,
+		resources: { cpu: targetSpec.vcpus, memory: targetSpec.memoryGb, disk: targetSpec.diskGb },
+		// Pin to microVM runners (never the `container` default) — the fleet's hard constraint.
+		sandboxClass: SandboxClass.LINUX_VM,
+	};
+
+	// Daytona's create inspects `image` in the registry on a build runner, and that inspect can fail with
+	// an opaque, often-transient "internal error" (a different runner/registry blip each time). Retry with
+	// backoff — self-healing when it's genuinely transient — and on every failed attempt capture rich
+	// diagnostics (structured error + where the snapshot landed + Daytona's streamed build log via onLogs)
+	// so a PERSISTENT failure is precisely characterized rather than reported once and lost. Attempt count
+	// is tunable (DAYTONA_CREATE_ATTEMPTS) for deeper investigation; default is a small resilient retry.
+	const attempts = Number.parseInt(process.env.DAYTONA_CREATE_ATTEMPTS ?? "5", 10) || 5;
+	let lastErr: unknown;
+	for (let attempt = 1; attempt <= attempts; attempt++) {
+		// A failed create can leave the name held by an error-state snapshot; sweep it before retrying so
+		// the next attempt isn't rejected with "already exists". (The initial `deleted` count above is
+		// what the destroyed-message reports — these are our own failed remnants, not a pre-existing one.)
+		if (attempt > 1) {
+			try {
+				await deleteExistingSnapshots(daytona, name, log);
+			} catch (err) {
+				log(
+					`    attempt ${attempt}: could not pre-clean ${name} — ${err instanceof Error ? err.message : String(err)}`,
+				);
+			}
+		}
+		log(
+			`>>> daytona snapshot create attempt ${attempt}/${attempts}: ${name} from ${image} (target ${daytonaCfg.target ?? "default"})`,
 		);
-	} catch (err) {
-		// Nothing was deleted → the name was already free, so the prior state (none) is intact: rethrow
-		// verbatim rather than dress up an ordinary create failure as a destroyed artifact.
-		if (deleted === 0) throw err;
-		const reason = err instanceof Error ? err.message : String(err);
-		throw new Error(snapshotDestroyedMessage(name, deleted, reason), { cause: err });
+		const startMs = performance.now();
+		try {
+			await daytona.snapshot.create(params, { onLogs: log });
+			log(
+				`<<< daytona snapshot create succeeded on attempt ${attempt}/${attempts} (${(performance.now() - startMs).toFixed(0)}ms)`,
+			);
+			return;
+		} catch (err) {
+			lastErr = err;
+			log(
+				`!!! daytona create attempt ${attempt}/${attempts} failed after ${(performance.now() - startMs).toFixed(0)}ms`,
+			);
+			log(`    message: ${err instanceof Error ? err.message : String(err)}`);
+			log(`    detail:  ${describeDaytonaError(err)}`);
+			// Where did the snapshot land? An error-state snapshot often carries a richer errorReason than
+			// the thrown message, and "absent" vs "error-state" distinguishes a failed inspect from a failed build.
+			try {
+				const landed = await listSnapshotsByName(daytona, name);
+				if (landed.length === 0) {
+					log(`    post-failure: no snapshot named ${name} exists (create never landed one)`);
+				}
+				for (const snap of landed) {
+					const errorReason = (snap as { errorReason?: unknown }).errorReason;
+					log(
+						`    post-failure snapshot: state=${snap.state}${errorReason ? ` errorReason=${String(errorReason)}` : ""}`,
+					);
+				}
+			} catch (listErr) {
+				log(
+					`    post-failure: could not list ${name} — ${listErr instanceof Error ? listErr.message : String(listErr)}`,
+				);
+			}
+			if (attempt < attempts) {
+				const backoffMs = Math.min(attempt * 5000, 20000);
+				log(`    backing off ${backoffMs}ms before retry…`);
+				await new Promise((resolve) => setTimeout(resolve, backoffMs));
+			}
+		}
 	}
+
+	// Every attempt failed. Nothing was deleted → the name was already free, so the prior state (none) is
+	// intact: rethrow verbatim rather than dress up an ordinary create failure as a destroyed artifact.
+	if (deleted === 0) throw lastErr;
+	const reason = lastErr instanceof Error ? lastErr.message : String(lastErr);
+	throw new Error(snapshotDestroyedMessage(name, deleted, reason), { cause: lastErr });
 }

--- a/apps/cli/src/lib/bake/daytona.ts
+++ b/apps/cli/src/lib/bake/daytona.ts
@@ -174,6 +174,39 @@ export function snapshotDestroyedMessage(name: string, deleted: number, reason: 
 	);
 }
 
+/** Create attempts — a small resilient retry that self-heals a transient registry-inspect blip; a
+ *  persistent failure is characterized across every attempt by {@link logCreateFailure}. */
+const CREATE_ATTEMPTS = 5;
+
+/** Log the diagnostics for a failed create attempt: the structured SDK error, plus where the snapshot
+ *  landed — "absent" vs an `error`-state snapshot (with its richer `errorReason`) distinguishes a failed
+ *  registry inspect from a failed build. Best-effort: never throws (it runs on an error path). */
+async function logCreateFailure(
+	daytona: Daytona,
+	name: string,
+	err: unknown,
+	log: Log,
+): Promise<void> {
+	log(`    message: ${err instanceof Error ? err.message : String(err)}`);
+	log(`    detail:  ${describeDaytonaError(err)}`);
+	try {
+		const landed = await listSnapshotsByName(daytona, name);
+		if (landed.length === 0) {
+			log(`    post-failure: no snapshot named ${name} exists (create never landed one)`);
+		}
+		for (const snap of landed) {
+			const errorReason = (snap as { errorReason?: unknown }).errorReason;
+			log(
+				`    post-failure snapshot: state=${snap.state}${errorReason ? ` errorReason=${String(errorReason)}` : ""}`,
+			);
+		}
+	} catch (listErr) {
+		log(
+			`    post-failure: could not list ${name} — ${listErr instanceof Error ? listErr.message : String(listErr)}`,
+		);
+	}
+}
+
 /** Create the daytona snapshot `name` from `image` (candidate while iterating, version on promote).
  *  Idempotent: delete any existing snapshot of that name first.
  *
@@ -202,12 +235,10 @@ export async function bakeDaytonaSnapshot(name: string, image: string, log: Log)
 	// Daytona's create inspects `image` in the registry on a build runner, and that inspect can fail with
 	// an opaque, often-transient "internal error" (a different runner/registry blip each time). Retry with
 	// backoff — self-healing when it's genuinely transient — and on every failed attempt capture rich
-	// diagnostics (structured error + where the snapshot landed + Daytona's streamed build log via onLogs)
-	// so a PERSISTENT failure is precisely characterized rather than reported once and lost. Attempt count
-	// is tunable (DAYTONA_CREATE_ATTEMPTS) for deeper investigation; default is a small resilient retry.
-	const attempts = Number.parseInt(process.env.DAYTONA_CREATE_ATTEMPTS ?? "5", 10) || 5;
+	// diagnostics (see logCreateFailure) so a PERSISTENT failure is precisely characterized rather than
+	// reported once and lost.
 	let lastErr: unknown;
-	for (let attempt = 1; attempt <= attempts; attempt++) {
+	for (let attempt = 1; attempt <= CREATE_ATTEMPTS; attempt++) {
 		// A failed create can leave the name held by an error-state snapshot; sweep it before retrying so
 		// the next attempt isn't rejected with "already exists". (The initial `deleted` count above is
 		// what the destroyed-message reports — these are our own failed remnants, not a pre-existing one.)
@@ -221,41 +252,22 @@ export async function bakeDaytonaSnapshot(name: string, image: string, log: Log)
 			}
 		}
 		log(
-			`>>> daytona snapshot create attempt ${attempt}/${attempts}: ${name} from ${image} (target ${daytonaCfg.target ?? "default"})`,
+			`>>> daytona snapshot create attempt ${attempt}/${CREATE_ATTEMPTS}: ${name} from ${image} (target ${daytonaCfg.target ?? "default"})`,
 		);
 		const startMs = performance.now();
 		try {
 			await daytona.snapshot.create(params, { onLogs: log });
 			log(
-				`<<< daytona snapshot create succeeded on attempt ${attempt}/${attempts} (${(performance.now() - startMs).toFixed(0)}ms)`,
+				`<<< daytona snapshot create succeeded on attempt ${attempt}/${CREATE_ATTEMPTS} (${(performance.now() - startMs).toFixed(0)}ms)`,
 			);
 			return;
 		} catch (err) {
 			lastErr = err;
 			log(
-				`!!! daytona create attempt ${attempt}/${attempts} failed after ${(performance.now() - startMs).toFixed(0)}ms`,
+				`!!! daytona create attempt ${attempt}/${CREATE_ATTEMPTS} failed after ${(performance.now() - startMs).toFixed(0)}ms`,
 			);
-			log(`    message: ${err instanceof Error ? err.message : String(err)}`);
-			log(`    detail:  ${describeDaytonaError(err)}`);
-			// Where did the snapshot land? An error-state snapshot often carries a richer errorReason than
-			// the thrown message, and "absent" vs "error-state" distinguishes a failed inspect from a failed build.
-			try {
-				const landed = await listSnapshotsByName(daytona, name);
-				if (landed.length === 0) {
-					log(`    post-failure: no snapshot named ${name} exists (create never landed one)`);
-				}
-				for (const snap of landed) {
-					const errorReason = (snap as { errorReason?: unknown }).errorReason;
-					log(
-						`    post-failure snapshot: state=${snap.state}${errorReason ? ` errorReason=${String(errorReason)}` : ""}`,
-					);
-				}
-			} catch (listErr) {
-				log(
-					`    post-failure: could not list ${name} — ${listErr instanceof Error ? listErr.message : String(listErr)}`,
-				);
-			}
-			if (attempt < attempts) {
+			await logCreateFailure(daytona, name, err, log);
+			if (attempt < CREATE_ATTEMPTS) {
 				const backoffMs = Math.min(attempt * 5000, 20000);
 				log(`    backing off ${backoffMs}ms before retry…`);
 				await new Promise((resolve) => setTimeout(resolve, backoffMs));

--- a/apps/cli/src/lib/bake/image.ts
+++ b/apps/cli/src/lib/bake/image.ts
@@ -34,22 +34,27 @@ export function imagetoolsRetagCmd(from: string, to: string): string[] {
  *  no pull. The release records this so every phase pins/records the exact bytes the candidate push
  *  produced (provenance); the TOCTOU guard proper is promote's re-validation of the mutable candidate. */
 export async function resolveImageDigest(ref: string): Promise<string> {
-	const proc = Bun.spawn(
-		["docker", "buildx", "imagetools", "inspect", ref, "--format", "{{.Manifest.Digest}}"],
-		{ stdout: "pipe", stderr: "pipe", env: process.env },
-	);
+	// Parse the `Digest:` line from the default `imagetools inspect` output rather than a
+	// `--format '{{.Manifest.Digest}}'` template: on the runner's buildx that template prints the whole
+	// default descriptor block, so parsing the labelled line is the portable read. The first match is
+	// the top-level manifest/index digest (the ref's digest); per-platform sub-digests, if any, follow.
+	const proc = Bun.spawn(["docker", "buildx", "imagetools", "inspect", ref], {
+		stdout: "pipe",
+		stderr: "pipe",
+		env: process.env,
+	});
 	const [code, stdout, stderr] = await Promise.all([
 		proc.exited,
 		new Response(proc.stdout).text(),
 		new Response(proc.stderr).text(),
 	]);
-	const digest = stdout.trim();
-	if (code !== 0 || !/^sha256:[0-9a-f]{64}$/.test(digest)) {
+	const match = stdout.match(/\bDigest:\s*(sha256:[0-9a-f]{64})\b/);
+	if (code !== 0 || !match) {
 		throw new Error(
-			`could not resolve digest for ${ref} (exit ${code}): ${digest || stderr.trim() || "no digest"}`,
+			`could not resolve digest for ${ref} (exit ${code}): ${stderr.trim() || stdout.trim() || "no digest"}`,
 		);
 	}
-	return digest;
+	return match[1] as string;
 }
 
 /** Whether `ref` already exists in the registry — a successful `docker manifest inspect`. Queries the

--- a/apps/cli/src/lib/bake/image.ts
+++ b/apps/cli/src/lib/bake/image.ts
@@ -30,6 +30,28 @@ export function imagetoolsRetagCmd(from: string, to: string): string[] {
 	return ["docker", "buildx", "imagetools", "create", "-t", to, from];
 }
 
+/** Resolve a pushed `ref` to its immutable registry digest (`sha256:…`) via a registry-side inspect —
+ *  no pull. The release records this so every phase pins/records the exact bytes the candidate push
+ *  produced (provenance); the TOCTOU guard proper is promote's re-validation of the mutable candidate. */
+export async function resolveImageDigest(ref: string): Promise<string> {
+	const proc = Bun.spawn(
+		["docker", "buildx", "imagetools", "inspect", ref, "--format", "{{.Manifest.Digest}}"],
+		{ stdout: "pipe", stderr: "pipe", env: process.env },
+	);
+	const [code, stdout, stderr] = await Promise.all([
+		proc.exited,
+		new Response(proc.stdout).text(),
+		new Response(proc.stderr).text(),
+	]);
+	const digest = stdout.trim();
+	if (code !== 0 || !/^sha256:[0-9a-f]{64}$/.test(digest)) {
+		throw new Error(
+			`could not resolve digest for ${ref} (exit ${code}): ${digest || stderr.trim() || "no digest"}`,
+		);
+	}
+	return digest;
+}
+
 /** Whether `ref` already exists in the registry — a successful `docker manifest inspect`. Queries the
  *  registry (not local images), so a locally-built `:v1` tag never reads as published. promote uses
  *  this to REFUSE overwriting the immutable public version.

--- a/apps/cli/src/lib/gha-output.ts
+++ b/apps/cli/src/lib/gha-output.ts
@@ -1,0 +1,22 @@
+// Emit a release bin's machine-readable output WITHOUT relying on a pristine stdout. The build/plan
+// bins spawn subprocesses (build.sh, provider CLIs) that inherit stdout, so a `bun bin >> "$GITHUB_OUTPUT"`
+// redirect would splice that subprocess chatter into the outputs file and GitHub would reject it
+// ("Unable to process file command 'output'"). Writing the `key=value` lines straight to the file named
+// by $GITHUB_OUTPUT keeps the outputs clean regardless of what a child process prints. Locally
+// ($GITHUB_OUTPUT unset) it falls back to stdout so the bins stay runnable by hand.
+import { appendFileSync } from "node:fs";
+
+/**
+ * Append newline-terminated `key=value` output lines to the GitHub Actions step-output file
+ * ($GITHUB_OUTPUT), or print them to stdout when that env var is absent (local dev). `lines` is the
+ * already-joined block (no trailing newline required).
+ */
+export function emitStepOutputs(lines: string): void {
+	const file = process.env.GITHUB_OUTPUT;
+	const block = lines.endsWith("\n") ? lines : `${lines}\n`;
+	if (file) {
+		appendFileSync(file, block);
+	} else {
+		process.stdout.write(block);
+	}
+}

--- a/apps/cli/src/lib/providers-run.test.ts
+++ b/apps/cli/src/lib/providers-run.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, test } from "bun:test";
+import { forEachProviderWithCreds, unknownProviderIds } from "./providers-run.ts";
+
+describe("unknownProviderIds", () => {
+	test("returns the ids that are not registered providers", () => {
+		expect(unknownProviderIds(["e2b", "dayton", "nope"])).toEqual(["dayton", "nope"]);
+	});
+
+	test("is empty when every id is registered", () => {
+		expect(unknownProviderIds(["e2b", "daytona", "modal"])).toEqual([]);
+	});
+});
+
+describe("forEachProviderWithCreds `only`", () => {
+	test("visits only the requested provider (a matrix cell reports just its own)", async () => {
+		const bodyRan: string[] = [];
+		const runs = await forEachProviderWithCreds(
+			async (provider) => {
+				bodyRan.push(provider.name);
+				return null;
+			},
+			// No creds for daytona in this env → it skips, but nothing else is even considered.
+			{ only: ["daytona"], env: {} },
+		);
+		expect(runs.map((r) => r.provider)).toEqual(["daytona"]);
+		expect(runs[0]?.status).toBe("skipped");
+		expect(bodyRan).toEqual([]); // skipped: the body never runs
+	});
+
+	test("runs the body for a selected provider whose creds are present", async () => {
+		const runs = await forEachProviderWithCreds(async () => "smoked", {
+			only: ["e2b"],
+			env: { E2B_API_KEY: "present" },
+		});
+		expect(runs).toHaveLength(1);
+		expect(runs[0]?.provider).toBe("e2b");
+		expect(runs[0]?.status).toBe("ok");
+		expect(runs[0]?.value).toBe("smoked");
+	});
+
+	test("without `only`, drives every registered provider (unchanged default)", async () => {
+		const runs = await forEachProviderWithCreds(async () => null, { env: {} });
+		// All registered providers are visited (all skipped here for want of creds).
+		expect(runs.map((r) => r.provider)).toEqual(["e2b", "daytona", "blaxel", "modal", "novita"]);
+	});
+});

--- a/apps/cli/src/lib/providers-run.test.ts
+++ b/apps/cli/src/lib/providers-run.test.ts
@@ -1,15 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { forEachProviderWithCreds, unknownProviderIds } from "./providers-run.ts";
-
-describe("unknownProviderIds", () => {
-	test("returns the ids that are not registered providers", () => {
-		expect(unknownProviderIds(["e2b", "dayton", "nope"])).toEqual(["dayton", "nope"]);
-	});
-
-	test("is empty when every id is registered", () => {
-		expect(unknownProviderIds(["e2b", "daytona", "modal"])).toEqual([]);
-	});
-});
+import { forEachProviderWithCreds } from "./providers-run.ts";
 
 describe("forEachProviderWithCreds `only`", () => {
 	test("visits only the requested provider (a matrix cell reports just its own)", async () => {

--- a/apps/cli/src/lib/providers-run.ts
+++ b/apps/cli/src/lib/providers-run.ts
@@ -47,16 +47,6 @@ export interface ForEachProviderOptions<T> {
 const noop = () => {};
 
 /**
- * Of `requested` (e.g. a `--provider e2b,daytona` value), the ids that are not registered providers.
- * The bake bin rejects a non-empty result so a typo'd `--provider dayton` fails the cell loudly rather
- * than silently baking nothing (which `only` would otherwise treat as "no providers to visit").
- */
-export function unknownProviderIds(requested: readonly string[]): string[] {
-	const registered = new Set<string>(providers.map((p) => p.name));
-	return requested.filter((id) => !registered.has(id));
-}
-
-/**
  * Run `body` against every provider whose credentials are present, in registry order, collecting a
  * {@link ProviderRun} per provider. Never throws: a body that throws becomes a `failed` run carrying
  * the coerced error message; a provider with missing creds becomes a `skipped` run.

--- a/apps/cli/src/lib/providers-run.ts
+++ b/apps/cli/src/lib/providers-run.ts
@@ -34,9 +34,27 @@ export interface ForEachProviderOptions<T> {
 	failureReason?: (value: T) => string;
 	/** Called right after each provider settles (ok/failed), so callers can log results in order. */
 	onComplete?: (run: ProviderRun<T>) => void;
+	/**
+	 * Restrict the loop to these provider ids — the CI fan-out passes one id per matrix cell so each
+	 * provider bakes/validates in its own job. Absent → every registered provider (the default, so the
+	 * local `bake` still drives them all). The registry order is preserved; ids not in `only` are simply
+	 * not visited (no report), so a cell reports only its own provider. Validate names against the
+	 * registry before calling — an unknown id here just yields zero runs, which the caller must reject.
+	 */
+	only?: readonly ProviderId[];
 }
 
 const noop = () => {};
+
+/**
+ * Of `requested` (e.g. a `--provider e2b,daytona` value), the ids that are not registered providers.
+ * The bake bin rejects a non-empty result so a typo'd `--provider dayton` fails the cell loudly rather
+ * than silently baking nothing (which `only` would otherwise treat as "no providers to visit").
+ */
+export function unknownProviderIds(requested: readonly string[]): string[] {
+	const registered = new Set<string>(providers.map((p) => p.name));
+	return requested.filter((id) => !registered.has(id));
+}
 
 /**
  * Run `body` against every provider whose credentials are present, in registry order, collecting a
@@ -50,7 +68,14 @@ export async function forEachProviderWithCreds<T>(
 	const log = options.log ?? noop;
 	const runs: ProviderRun<T>[] = [];
 
-	for (const provider of providers) {
+	// A CI matrix cell passes `only: [<its provider>]`; the local `bake` passes nothing and drives them
+	// all. `only` filters which registry entries are visited — order (and thus report order) is the
+	// registry's, never the request's, so a cell's report is a stable subset of the whole.
+	const selected = options.only
+		? providers.filter((p) => options.only?.includes(p.name))
+		: providers;
+
+	for (const provider of selected) {
 		const missing = missingCreds(provider, options.env);
 		if (missing.length > 0) {
 			log(`skip: ${provider.name} (missing ${missing.join(", ")})`);

--- a/bun.lock
+++ b/bun.lock
@@ -28,6 +28,7 @@
         "leaderboard": "./src/bin/leaderboard.ts",
       },
       "dependencies": {
+        "@actions/core": "1.11.1",
         "@daytona/sdk": "catalog:computesdk",
         "@sandbox-benchmarks/harness": "workspace:*",
         "@sandbox-benchmarks/providers": "workspace:*",
@@ -175,6 +176,14 @@
     },
   },
   "packages": {
+    "@actions/core": ["@actions/core@1.11.1", "", { "dependencies": { "@actions/exec": "^1.1.1", "@actions/http-client": "^2.0.1" } }, "sha512-hXJCSrkwfA46Vd9Z3q4cpEpHB1rL5NG04+/rbqW9d3+CSvtB1tYe8UTpAlixa1vj0m/ULglfEK2UKxMGxCxv5A=="],
+
+    "@actions/exec": ["@actions/exec@1.1.1", "", { "dependencies": { "@actions/io": "^1.0.1" } }, "sha512-+sCcHHbVdk93a0XT19ECtO/gIXoxvdsgQLzb2fE2/5sIZmWQuluYyjPQtrtTHdU1YzTZ7bAPN4sITq2xi1679w=="],
+
+    "@actions/http-client": ["@actions/http-client@2.2.3", "", { "dependencies": { "tunnel": "^0.0.6", "undici": "^5.25.4" } }, "sha512-mx8hyJi/hjFvbPokCg4uRd4ZX78t+YyRPtnKWwIl+RzNaVuFpQHfmlGVfsKEJN8LwTCvL+DfVgAM04XaHkm6bA=="],
+
+    "@actions/io": ["@actions/io@1.1.3", "", {}, "sha512-wi9JjgKLYS7U/z8PPbco+PvTb/nRWjeoFlJ1Qer83k/3C5PHQi28hiVdeE2kHXmIL99mQFawx8qt/JPjZilJ8Q=="],
+
     "@ark/schema": ["@ark/schema@0.56.0", "", { "dependencies": { "@ark/util": "0.56.0" } }, "sha512-ECg3hox/6Z/nLajxXqNhgPtNdHWC9zNsDyskwO28WinoFEnWow4IsERNz9AnXRhTZJnYIlAJ4uGn3nlLk65vZA=="],
 
     "@ark/util": ["@ark/util@0.56.0", "", {}, "sha512-BghfRC8b9pNs3vBoDJhcta0/c1J1rsoS1+HgVUreMFPdhz/CRAKReAu57YEllNaSy98rWAdY1gE+gFup7OXpgA=="],
@@ -292,6 +301,8 @@
     "@daytona/toolbox-api-client": ["@daytona/toolbox-api-client@0.192.0", "", { "dependencies": { "axios": "^1.6.1" } }, "sha512-fEyA3YPK+IJezECBfZoNhf29qtZhy8AqI0lcgR+Bob6hEiInx9+sH26506ZkxmpGM4/5EApeLzUI1g5B9u2XHA=="],
 
     "@daytonaio/sdk": ["@daytona/sdk@0.192.0", "", { "dependencies": { "@aws-sdk/client-s3": "^3.787.0", "@aws-sdk/lib-storage": "^3.798.0", "@daytona/api-client": "0.192.0", "@daytona/toolbox-api-client": "0.192.0", "@iarna/toml": "^2.2.5", "@opentelemetry/api": "^1.9.0", "@opentelemetry/exporter-trace-otlp-http": "^0.217.0", "@opentelemetry/instrumentation-http": "^0.217.0", "@opentelemetry/otlp-exporter-base": "0.217.0", "@opentelemetry/resources": "2.7.1", "@opentelemetry/sdk-node": "^0.217.0", "@opentelemetry/sdk-trace-base": "^2.7.1", "@opentelemetry/semantic-conventions": "^1.40.0", "axios": "^1.15.2", "busboy": "^1.0.0", "dotenv": "^17.0.1", "expand-tilde": "^2.0.2", "fast-glob": "^3.3.0", "form-data": "^4.0.4", "isomorphic-ws": "^5.0.0", "pathe": "^2.0.3", "shell-quote": "^1.8.2", "tar": "^7.5.11" } }, "sha512-pAA1curJCiZ0rqZcE0BUIjsgS90QdDFZ2QYw8nVWwGjjdr+Fndof4MaJfoZRjpcMHjUBoqEZpzO9C5HPv38QeA=="],
+
+    "@fastify/busboy": ["@fastify/busboy@2.1.1", "", {}, "sha512-vBZP4NlzfOlerQTnba4aqZoMhE/a9HY7HRqoOPaETQcSQuWEIyZMHGfVu6w9wGtGK5fED5qRs2DteVCjOH60sA=="],
 
     "@grpc/grpc-js": ["@grpc/grpc-js@1.14.4", "", { "dependencies": { "@grpc/proto-loader": "^0.8.0", "@js-sdsl/ordered-map": "^4.4.2" } }, "sha512-k9Dj3DV/itK9D06Y8f190Qgop7/Ui+D0njFV3LHMPwPT75DpXLQohE9Wmz0QElrJnzsjB7KPWiKJbOl7IPDArQ=="],
 
@@ -1033,11 +1044,13 @@
 
     "tslib": ["tslib@2.8.1", "", {}, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
 
+    "tunnel": ["tunnel@0.0.6", "", {}, "sha512-1h/Lnq9yajKY2PEbBadPXj3VxsDDu844OnaAo52UVmIzIvwwtBPIuNvkjuzBlTWpfJyUbG3ez0KSBibQkj4ojg=="],
+
     "type-is": ["type-is@2.1.0", "", { "dependencies": { "content-type": "^2.0.0", "media-typer": "^1.1.0", "mime-types": "^3.0.0" } }, "sha512-faYHw0anBbc/kWF3zFTEnxSFOAGUX9GFbOBthvDdLsIlEoWOFOtS0zgCiQYwIskL9iGXZL3kAXD8OoZ4GmMATA=="],
 
     "typescript": ["typescript@6.0.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw=="],
 
-    "undici": ["undici@7.27.2", "", {}, "sha512-uZsKNuzQxDMUY6M3pIMvy5tvlGmtq8XJ2oLAkfRKGNu+1VQAIvLy2xIVG5ATZl5wDXl/tddByAWCizRbOme+TA=="],
+    "undici": ["undici@5.29.0", "", { "dependencies": { "@fastify/busboy": "^2.0.0" } }, "sha512-raqeBD6NQK4SkWhQzeYKd1KmIG6dllBOTt55Rmkt4HtI9mwdWtJljnrXjAFUBLTSN67HWrOIZ3EPF4kjUw80Bg=="],
 
     "undici-types": ["undici-types@7.24.6", "", {}, "sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg=="],
 
@@ -1104,6 +1117,8 @@
     "compress-commons/readable-stream": ["readable-stream@4.7.0", "", { "dependencies": { "abort-controller": "^3.0.0", "buffer": "^6.0.3", "events": "^3.3.0", "process": "^0.11.10", "string_decoder": "^1.3.0" } }, "sha512-oIGGmcpTLwPga8Bn6/Z75SVaH1z5dUut2ibSyAMVhmUggWpmDn2dapB0n7f8nwaSiRtepAsfJyfXIO5DCVAODg=="],
 
     "crc32-stream/readable-stream": ["readable-stream@4.7.0", "", { "dependencies": { "abort-controller": "^3.0.0", "buffer": "^6.0.3", "events": "^3.3.0", "process": "^0.11.10", "string_decoder": "^1.3.0" } }, "sha512-oIGGmcpTLwPga8Bn6/Z75SVaH1z5dUut2ibSyAMVhmUggWpmDn2dapB0n7f8nwaSiRtepAsfJyfXIO5DCVAODg=="],
+
+    "e2b/undici": ["undici@7.27.2", "", {}, "sha512-uZsKNuzQxDMUY6M3pIMvy5tvlGmtq8XJ2oLAkfRKGNu+1VQAIvLy2xIVG5ATZl5wDXl/tddByAWCizRbOme+TA=="],
 
     "express/mime-types": ["mime-types@3.0.2", "", { "dependencies": { "mime-db": "^1.54.0" } }, "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A=="],
 


### PR DESCRIPTION
Split the monolithic toolchain-image.yml publish job into a phased release
pipeline: plan → build → per-provider bake+verify matrix → promote. `needs`
edges are placed only where an artifact is required, so the image builds once
and every provider bake/verify runs in parallel; the sole serialized section is
the promote transaction (the only job that mutates the immutable public :v1).

Key changes
- plan phase emits a single release plan (release-plan.ts): mode (build/
  republish), skip gate, resolved image refs, size tier, the provider matrix and
  the required-provider set. Every downstream job consumes the plan instead of
  re-reading the raw workflow inputs; the plan is uploaded as a diagnostic
  artifact.
- build phase builds+pushes the candidate base once (build-candidate.ts) and
  records its immutable digest for provenance.
- bake fans out one matrix cell per provider (bake --provider <id>); required
  cells add --require so a missing/misnamed secret fails the release before
  publish. fail-fast: false collects every cell's diagnostics without letting a
  flaky provider cancel the others, while any cell that ran and failed still
  blocks promote. This preserves the previous bake+validate semantics, now
  parallelized.
- cross-cutting GitHub Actions mechanics move into .github/actions/* composites
  (setup-toolchain, ghcr-login, release-validate-inputs, ensure-package-public,
  release-summary); provider logic stays in the apps/cli scripts, keeping the
  YAML shallow.
- every phase appends a consistent debug table to $GITHUB_STEP_SUMMARY and
  uploads structured diagnostics (plan / build metadata / bake reports / promote
  payload) on if: always().
- credential minimization: global contents: read; packages: read only for plan's
  immutability probe; packages: write only for build and promote; bake needs
  neither (providers pull the public candidate anonymously). Third-party tooling
  and pin/input validation run before any registry login.

New capabilities are unit-tested: the bake --provider filter (providers-run) and
the pure release-plan builder.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01W3y7wg3spffzRuugfeazvA

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Split the toolchain-image CI into a staged pipeline: plan → build → per-provider bake+verify (matrix) → promote. Builds once, bakes in parallel, adds annotated job summaries, hardens outputs and Daytona bakes, and updates `actions/*` pins.

- **Refactors**
  - Moved shared CI steps into local composites wired to TypeScript scripts using `@actions/core` for summaries and run annotations: `release-summary`, `ensure-package-public`, `release-validate-inputs`.
  - Least-privilege posture: plan (packages read), build/promote (packages write), bake (no registry creds). Provider set derives from the registry via `selectProviders`.
  - Hardened I/O: step outputs written via `$GITHUB_OUTPUT` (`emitStepOutputs`), bake/promote reports to `$BAKE_REPORT_FILE`, candidate digest via `resolveImageDigest`. GHCR visibility guard uses a real API fetch/parse.
  - Daytona snapshot create now retries with backoff, cleans error-state remnants between attempts, and logs structured diagnostics.
  - Pinned `actions/checkout` to v7, `actions/upload-artifact` to v7, and `actions/download-artifact` to v8 across workflows.

- **New Features**
  - `release-plan.ts` emits one plan (mode, skip, refs, provider matrix, required set) and uploads `release-plan.json`; `build-candidate.ts` builds/pushes once and records the digest.
  - Bake runs as a matrix (`--provider <id>`) with `--require` gating required providers; `fail-fast: false` collects diagnostics while failed cells still block promote.
  - Tests expanded: provider filter, release plan builder, Daytona error diagnostics, and release-summary HTML escaping.

<sup>Written for commit 07b1a0d4612105790fe464692b926a6c857eed90. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/starslingdev/sandbox-benchmarks/pull/149?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced a staged release pipeline (plan, build, bake, promote) with structured phase summaries.
  * Added release gating and input validation, plus standardized GitHub step output reporting.
  * Added targeted provider selection and candidate digest capture for better release traceability.
* **Bug Fixes**
  * Enforced container package visibility checks before publishing.
  * Improved release behavior when digest resolution/probing is unreliable.
  * Enhanced snapshot bake error reporting and added resilient retry/cleanup during snapshot creation.
* **Tests**
  * Added/updated tests for release planning, provider filtering/execution, and snapshot error diagnostics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->