### PR TITLE
chore: update GitHub Actions to avoid node 20

### DIFF
--- a/.github/workflows/bench-matrix.yml
+++ b/.github/workflows/bench-matrix.yml
@@ -36,7 +36,7 @@ jobs:
       matrix: ${{ steps.plan.outputs.matrix }}
     steps:
       - name: Checkout
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           # Planning only reads code; don't persist the job token in .git/config.
           persist-credentials: false
@@ -72,7 +72,7 @@ jobs:
       matrix: ${{ fromJSON(needs.plan.outputs.matrix) }}
     steps:
       - name: Checkout
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           # This cell only reads code (the sandbox clones via BENCH_REPO_TOKEN, not the checkout's
           # credentials), so don't persist the job token in .git/config.
@@ -118,7 +118,7 @@ jobs:
 
       - name: Upload Run + raw results
         if: always()
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           # Per-cell artifact name so every (provider, suite) shard uploads independently.
           name: bench-${{ matrix.suite }}-${{ matrix.provider }}-${{ github.run_id }}
@@ -145,7 +145,7 @@ jobs:
       # keeps the default persisted job token (contents: write above authorizes it). Don't add
       # persist-credentials: false here or the push at the end of the job loses its credentials.
       - name: Checkout
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - name: Set up Bun
         uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
         with:
@@ -155,7 +155,7 @@ jobs:
 
       # Pull every per-cell shard artifact into ./shards (each in its own subdir).
       - name: Download shard artifacts
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           path: shards
           pattern: bench-*-${{ github.run_id }}

--- a/.github/workflows/bench-smoke.yml
+++ b/.github/workflows/bench-smoke.yml
@@ -52,7 +52,7 @@ jobs:
       # Third-party actions are pinned to a commit SHA (the tag comment is for humans) so a
       # moved/compromised tag can't silently change what runs.
       - name: Checkout
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           # The job only reads code (the sandbox clones via BENCH_REPO_TOKEN, not the checkout's
           # credentials), so don't persist the job token in .git/config.
@@ -101,7 +101,7 @@ jobs:
 
       - name: Upload Run + raw results
         if: always()
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: bench-${{ inputs.suite }}-${{ inputs.provider }}-${{ github.run_id }}
           path: data/


### PR DESCRIPTION
## Summary
This PR updates several GitHub Actions dependencies to their latest versions across the benchmark workflow files.

## Key Changes
- **actions/checkout**: Updated from v6.0.3 to v7.0.0 in three workflow files (bench-matrix.yml and bench-smoke.yml)
- **actions/upload-artifact**: Updated from v4.6.2 to v7.0.1 in both benchmark workflow files
- **actions/download-artifact**: Updated from v4.3.0 to v8.0.1 in bench-matrix.yml

## Details
All updates are pinned to specific commit SHAs (with version tags as comments) to maintain security and reproducibility. The changes affect:
- Repository checkout steps in planning and result aggregation jobs
- Artifact upload steps for benchmark results
- Artifact download steps for shard collection

No workflow logic or configuration changes were made; this is purely a dependency version update.

https://claude.ai/code/session_01VVzs7mkeHTS3PxpngsEvPy

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updates benchmark workflows to the latest GitHub Actions so they run on Node 24 and avoid the deprecated Node 20 runtime. No workflow logic changes.

- **Dependencies**
  - `actions/checkout` -> v7.0.0 (bench-matrix, bench-smoke)
  - `actions/upload-artifact` -> v7.0.1 (bench-matrix, bench-smoke)
  - `actions/download-artifact` -> v8.0.1 (bench-matrix)
  - All actions remain SHA-pinned for reproducibility and supply-chain safety.

<sup>Written for commit edde51f35ef9e2f65fb5004c8ea1c377d35abf72. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/starslingdev/sandbox-benchmarks/pull/150?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI workflow tooling to newer versions.
  * Improved reliability of benchmark, artifact upload, and artifact download processes without changing workflow behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->