### PR TITLE
feat(bake): retry daytona snapshot create with rich diagnostics

### DIFF
--- a/.codex/config.toml
+++ b/.codex/config.toml
@@ -1,0 +1,3 @@
+[mcp_servers.graphite]
+command = "gt"
+args = ["mcp"]

--- a/apps/cli/src/lib/bake/daytona.test.ts
+++ b/apps/cli/src/lib/bake/daytona.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "bun:test";
 import {
 	daytonaTransientPushCommands,
 	daytonaTransientRef,
+	describeDaytonaError,
 	snapshotDestroyedMessage,
 	withCleanupPreservingPrimaryError,
 } from "./daytona.ts";
@@ -122,5 +123,48 @@ describe("withCleanupPreservingPrimaryError", () => {
 				},
 			),
 		).rejects.toBe(cleanup);
+	});
+});
+
+describe("describeDaytonaError", () => {
+	it("surfaces status code, error code, and response body from the opaque SDK error", () => {
+		const out = describeDaytonaError({
+			name: "DaytonaError",
+			statusCode: 500,
+			code: "INTERNAL",
+			response: { data: { message: "failed to inspect in registry" } },
+		});
+		expect(out).toContain("name=DaytonaError");
+		expect(out).toContain("status=500");
+		expect(out).toContain("code=INTERNAL");
+		expect(out).toContain("failed to inspect in registry");
+	});
+
+	// `JSON.stringify` returns undefined (not a string) for a function/symbol response body, so the
+	// formatter must fall back to String() rather than call `.slice` on undefined — it runs on the
+	// error path and must never throw over a non-serializable SDK payload.
+	it("does not throw when the response body is a non-serializable value", () => {
+		const out = describeDaytonaError({ statusCode: 500, response: { data: () => "boom" } });
+		expect(out).toContain("status=500");
+		expect(out).toContain("response=");
+	});
+
+	it("includes the cause chain when present", () => {
+		expect(
+			describeDaytonaError({ message: "boom", cause: new Error("registry unreachable") }),
+		).toContain("cause=registry unreachable");
+	});
+
+	it("never throws on a non-object error, and says so", () => {
+		expect(describeDaytonaError("plain string")).toContain("plain string");
+		expect(describeDaytonaError(undefined)).toContain("non-object");
+	});
+
+	// The function is exported, so it has to be useful on its own — a caller that doesn't separately log
+	// `.message` must not be left with just `name=Error` and no diagnostic.
+	it("keeps the error's own message for a plain Error (no SDK shape to mine)", () => {
+		const out = describeDaytonaError(new Error("failed to inspect registry for image"));
+		expect(out).toContain("name=Error");
+		expect(out).toContain("message=failed to inspect registry for image");
 	});
 });

--- a/apps/cli/src/lib/bake/daytona.ts
+++ b/apps/cli/src/lib/bake/daytona.ts
@@ -128,6 +128,51 @@ async function deleteExistingSnapshots(daytona: Daytona, name: string, log: Log)
 	}
 }
 
+/** A verbose one-line description of a Daytona SDK error for diagnostics — pulls status codes, any
+ *  response body, an error code, and the `cause` chain out of the opaque object the SDK throws, so a
+ *  bake log records more than the bare `.message`. Pure and defensive (never throws), so it is safe on
+ *  an error path and unit-testable without the SDK. */
+export function describeDaytonaError(err: unknown): string {
+	if (typeof err !== "object" || err === null) return `non-object error: ${String(err)}`;
+	const e = err as {
+		name?: unknown;
+		message?: unknown;
+		statusCode?: number;
+		status?: number;
+		code?: string | number;
+		response?: { status?: number; data?: unknown };
+		cause?: unknown;
+	};
+	const parts: string[] = [];
+	if (typeof e.name === "string") parts.push(`name=${e.name}`);
+	// Include the error's OWN message. The current caller (logCreateFailure) logs it on a separate line,
+	// but this function is exported: a caller that doesn't know to log `.message` separately would
+	// otherwise get `name=Error` and lose the entire diagnostic for a plain `new Error("…")`.
+	if (typeof e.message === "string" && e.message.length > 0) parts.push(`message=${e.message}`);
+	const status = e.statusCode ?? e.status ?? e.response?.status;
+	if (status !== undefined) parts.push(`status=${status}`);
+	if (e.code !== undefined) parts.push(`code=${String(e.code)}`);
+	if (e.response?.data !== undefined) {
+		let body: string;
+		try {
+			body =
+				typeof e.response.data === "string"
+					? e.response.data
+					: (JSON.stringify(e.response.data) ?? String(e.response.data));
+		} catch {
+			body = String(e.response.data);
+		}
+		parts.push(`response=${body.slice(0, 500)}`);
+	}
+	if (e.cause !== undefined && e.cause !== null) {
+		const cause = e.cause as { message?: unknown };
+		const causeText =
+			typeof cause.message === "string" ? cause.message : String(e.cause).slice(0, 300);
+		parts.push(`cause=${causeText}`);
+	}
+	return parts.length > 0 ? parts.join(" ") : "no structured detail";
+}
+
 /** The message for a create that failed after `deleted` (> 0) pre-existing snapshots of `name` were
  *  removed to free the name: `name` now resolves to nothing. Stated plainly because the caller that
  *  passes a published name (promote `--force`) surfaces this as the report's `reason`, where "failed"
@@ -246,6 +291,39 @@ async function transientPushAccess(
 	return (await registryApi.getTransientPushAccess(undefined, region)).data;
 }
 
+/** Create attempts — a small resilient retry that self-heals a transient registry-inspect blip; a
+ *  persistent failure is characterized across every attempt by {@link logCreateFailure}. */
+const CREATE_ATTEMPTS = 5;
+
+/** Log the diagnostics for a failed create attempt: the structured SDK error, plus where the snapshot
+ *  landed — "absent" vs an `error`-state snapshot (with its richer `errorReason`) distinguishes a failed
+ *  registry inspect from a failed build. Best-effort: never throws (it runs on an error path). */
+async function logCreateFailure(
+	daytona: Daytona,
+	name: string,
+	err: unknown,
+	log: Log,
+): Promise<void> {
+	log(`    message: ${err instanceof Error ? err.message : String(err)}`);
+	log(`    detail:  ${describeDaytonaError(err)}`);
+	try {
+		const landed = await listSnapshotsByName(daytona, name);
+		if (landed.length === 0) {
+			log(`    post-failure: no snapshot named ${name} exists (create never landed one)`);
+		}
+		for (const snap of landed) {
+			const errorReason = (snap as { errorReason?: unknown }).errorReason;
+			log(
+				`    post-failure snapshot: state=${snap.state}${errorReason ? ` errorReason=${String(errorReason)}` : ""}`,
+			);
+		}
+	} catch (listErr) {
+		log(
+			`    post-failure: could not list ${name} — ${listErr instanceof Error ? listErr.message : String(listErr)}`,
+		);
+	}
+}
+
 /** Create the daytona snapshot `name` from `image` (candidate while iterating, version on promote).
  *  Idempotent: delete any existing snapshot of that name first.
  *
@@ -289,29 +367,88 @@ export async function bakeDaytonaSnapshot(name: string, image: string, log: Log)
 	);
 
 	const deleted = await deleteExistingSnapshots(daytona, name, log);
-	log(
-		`creating Linux-VM snapshot ${name} from uploaded image (target ${daytonaCfg.target ?? "default"})`,
-	);
-	try {
-		await daytona.snapshot.create(
-			{
-				name,
-				image: transientRef,
-				resources: {
-					cpu: targetSpec.vcpus,
-					memory: targetSpec.memoryGb,
-					disk: targetSpec.diskGb,
-				},
-				...(daytonaCfg.target ? { regionId: daytonaCfg.target } : {}),
-				sandboxClass: SandboxClass.LINUX_VM,
-			},
-			{ onLogs: (chunk) => log(chunk) },
+
+	const params = {
+		name,
+		image: transientRef,
+		resources: { cpu: targetSpec.vcpus, memory: targetSpec.memoryGb, disk: targetSpec.diskGb },
+		...(daytonaCfg.target ? { regionId: daytonaCfg.target } : {}),
+		// Pin to microVM runners (never the `container` default) — the fleet's hard constraint.
+		sandboxClass: SandboxClass.LINUX_VM,
+	};
+
+	// Daytona's create inspects `image` in the registry on a build runner, and that inspect can fail with
+	// an opaque, often-transient "internal error" (a different runner/registry blip each time). Retry with
+	// backoff — self-healing when it's genuinely transient — and on every failed attempt capture rich
+	// diagnostics (see logCreateFailure) so a PERSISTENT failure is precisely characterized rather than
+	// reported once and lost.
+	let lastErr: unknown;
+	// Set only when a pre-retry cleanup failed and stopped the loop early. Kept SEPARATE from `lastErr`:
+	// the create failure is what failed the bake and carries the real diagnostic, while this explains why
+	// we stopped retrying. Folding the cleanup error into `lastErr` would overwrite (and misattribute)
+	// the create error in the message below.
+	let cleanupErr: unknown;
+	for (let attempt = 1; attempt <= CREATE_ATTEMPTS; attempt++) {
+		// A failed create can leave the name held by an error-state snapshot; sweep it before retrying so
+		// the next attempt isn't rejected with "already exists". (The initial `deleted` count above is
+		// what the destroyed-message reports — these are our own failed remnants, not a pre-existing one.)
+		if (attempt > 1) {
+			try {
+				await deleteExistingSnapshots(daytona, name, log);
+			} catch (err) {
+				// STOP retrying. deleteExistingSnapshots already absorbs transient blips itself — it polls
+				// for a 3-minute deadline before throwing — so a throw here is a PERSISTENT failure to free
+				// the name, not a blip. The name is still held, every remaining create would just fail
+				// "already exists" after burning another 3-minute pre-clean, and the real blocker (the
+				// undeletable snapshot) would be buried under a generic create error. Fail fast on it.
+				log(
+					`!!! attempt ${attempt}: could not free ${name} — ${err instanceof Error ? err.message : String(err)}`,
+				);
+				log("    the name is still held, so further create attempts cannot succeed; giving up.");
+				cleanupErr = err;
+				break;
+			}
+		}
+		log(
+			`>>> daytona snapshot create attempt ${attempt}/${CREATE_ATTEMPTS}: ${name} from ${transientRef} (target ${daytonaCfg.target ?? "default"})`,
 		);
-	} catch (err) {
-		// Nothing was deleted → the name was already free, so the prior state (none) is intact: rethrow
-		// verbatim rather than dress up an ordinary create failure as a destroyed artifact.
-		if (deleted === 0) throw err;
-		const reason = err instanceof Error ? err.message : String(err);
-		throw new Error(snapshotDestroyedMessage(name, deleted, reason), { cause: err });
+		const startMs = performance.now();
+		try {
+			await daytona.snapshot.create(params, { onLogs: log });
+			log(
+				`<<< daytona snapshot create succeeded on attempt ${attempt}/${CREATE_ATTEMPTS} (${(performance.now() - startMs).toFixed(0)}ms)`,
+			);
+			return;
+		} catch (err) {
+			lastErr = err;
+			log(
+				`!!! daytona create attempt ${attempt}/${CREATE_ATTEMPTS} failed after ${(performance.now() - startMs).toFixed(0)}ms`,
+			);
+			await logCreateFailure(daytona, name, err, log);
+			if (attempt < CREATE_ATTEMPTS) {
+				const backoffMs = Math.min(attempt * 5000, 20000);
+				log(`    backing off ${backoffMs}ms before retry…`);
+				await new Promise((resolve) => setTimeout(resolve, backoffMs));
+			}
+		}
 	}
+
+	// Every attempt failed (or a failed pre-clean stopped them early). Report BOTH causes when there are
+	// two: the create failure is what actually failed the bake, and the cleanup failure is why we stopped
+	// retrying it. `lastErr` stays the create error, so the `cause` chain still points at the real thing.
+	const createReason = lastErr instanceof Error ? lastErr.message : String(lastErr);
+	const reason =
+		cleanupErr === undefined
+			? createReason
+			: `${createReason}; retries stopped because ${name} could not be freed for another attempt: ${
+					cleanupErr instanceof Error ? cleanupErr.message : String(cleanupErr)
+				}`;
+
+	// Nothing was deleted → the name was already free, so the prior state (none) is intact: rethrow
+	// verbatim rather than dress up an ordinary create failure as a destroyed artifact.
+	if (deleted === 0) {
+		if (cleanupErr === undefined) throw lastErr;
+		throw new Error(`daytona snapshot ${name} create failed — ${reason}`, { cause: lastErr });
+	}
+	throw new Error(snapshotDestroyedMessage(name, deleted, reason), { cause: lastErr });
 }


### PR DESCRIPTION
**TOOLCHAIN RELEASE — restage the monolithic publish job into a parallel, resumable, plan-driven pipeline.**
Shipped as an 8-PR stack. The trunk merges bottom-up: the four CLI PRs (#155–#157) are pure-additive
mechanism (nothing calls them yet), and #158/#159 are the wiring that finally consumes them.

```
main
 └─ #152  ci: pin actions/* to the current latest (checkout v7, upload v7, download v8)
     └─ #153  bake: retry the daytona snapshot create + rich failure diagnostics
         └─ #154  bake: `--provider <id>` selection + a file-based report
             └─ #155  cli: `release-plan` — the release plan as an artifact
                 └─ #156  cli: `build-candidate` — build once, record the digest
                     └─ #157  cli: `release-{validate,summary,ensure-public}` via @actions/core
                         └─ #158  ci: the five composite actions the release jobs share
                             └─ #159  ci: restage toolchain-image.yml (plan → build → bake → promote)
```

↑ **This PR is #153 (2/8) — a standalone reliability fix, based on #152.**

---

**Stack 2/8** — based on #152

Daytona's snapshot create inspects the image in the registry **on a Daytona build runner**, and that
inspect intermittently fails with an opaque "internal error" — a different runner/registry blip each
time. A single attempt turns a transient blip into a failed release.

- **Retry** the create up to 5× with linear backoff (5s → 20s), sweeping any error-state snapshot
  holding the name before each retry so the next attempt isn't rejected with "already exists". A
  transient failure now self-heals.
- **Characterize** a persistent failure instead of losing it. Every failed attempt logs the structured
  SDK error via the new `describeDaytonaError` (status code, error code, response body, cause chain —
  the SDK's error object is opaque and its `.message` alone says nothing), plus *where the snapshot
  landed*. "absent" vs an `error`-state snapshot with its `errorReason` is what distinguishes a failed
  **registry inspect** from a failed **build**.

`describeDaytonaError` is pure and defensive (it never throws — it runs on an error path), so it is
unit-tested directly without the SDK. The destroyed-snapshot contract is unchanged: it still fires only
when pre-existing snapshots were deleted, now after all attempts are exhausted.

Independent of the release restructure above it; it just happens to make that release far less flaky.

**LOC**: 152 added / 18 removed.

---

## Validation

Every branch in this stack was checked out **in isolation** (on top of its own parent, with nothing
from the PRs above it) and run through the full gate set. A reviewer merges bottom-up, so each PR has
to stand on its own — this is what verifies that.

**This PR (`02`), verified standalone — all gates green:**

| gate | command | result |
|---|---|---|
| install | `bun install --frozen-lockfile` | ✅ |
| typecheck | `bun run typecheck` | ✅ |
| lint | `bun run lint` (biome, `--error-on-warnings`) | ✅ |
| spell | `mise exec -- typos` | ✅ |
| shell | `bun run lint:shell` (shellcheck) | ✅ |
| catalog drift | `bun run check:catalog-drift` | ✅ |
| workflow lint | `actionlint` + `zizmor` | ✅ |
| tests | `bun run test` (whole workspace) | ✅ **615 passing, 0 failing** |

The same matrix is green on all 8 branches, and the passing-test count climbs monotonically up the
trunk (612 → 633) — each PR adds coverage and none regresses it. The top of the stack was also diffed
against the pre-split branch to prove the decomposition moved every change and dropped nothing.

**What this PR's own tests prove:** `describeDaytonaError` extracts status/code/body/cause from the
opaque SDK error object, includes the cause chain, and — the important one — **never throws** on a
non-object error, since it runs on the error path where a second throw would mask the original failure.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Makes Daytona snapshot creation resilient and easier to debug so transient registry/runner blips self-heal, and persistent failures are clearly explained.

- **New Features**
  - Retries create up to 5 times with linear backoff (5s→20s); logs attempt number, duration, and success.
  - Cleans up error-state snapshots before each retry; stops early if the name can’t be freed and explains why.
  - Adds `describeDaytonaError` and post-failure snapshot checks to surface status/code/body/cause and where the attempt landed; preserves destroyed-snapshot behavior.

- **Bug Fixes**
  - Guarded `describeDaytonaError` against non-serializable response bodies (fallback to String) so diagnostics never throw on the error path.

<sup>Written for commit 5674596fabfdc49ada9e5c23c10928892d0c038c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/starslingdev/sandbox-benchmarks/pull/153?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Graphite MCP server configuration to the CLI tooling.

* **Bug Fixes**
  * Improved Daytona snapshot creation reliability with up to 5 retry attempts.
  * Added safety cleanup between retries to avoid “already exists” conflicts.
  * Better final error handling when recovery cleanup is interrupted.

* **Diagnostics**
  * Enhanced Daytona error reporting with status, error code, response details, and full cause chains.

* **Tests**
  * Added coverage for detailed Daytona error formatting and edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->