### PR TITLE
refactor(bake): per-provider selection + file-based report

### DIFF
--- a/apps/cli/src/bin/bake.test.ts
+++ b/apps/cli/src/bin/bake.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, test } from "bun:test";
+import { requestedProviders } from "./bake.ts";
+
+describe("requestedProviders", () => {
+	test("no flag → undefined (drive every registered provider, the local default)", () => {
+		expect(requestedProviders(["--build-push"])).toBeUndefined();
+	});
+
+	test("a matrix cell's single id selects just that provider", () => {
+		expect(requestedProviders(["--provider", "e2b"])).toEqual(["e2b"]);
+		expect(requestedProviders(["--provider=daytona"])).toEqual(["daytona"]);
+	});
+
+	test("a comma-separated list returns registry order, not request order", () => {
+		expect(requestedProviders(["--provider", "modal,e2b"])).toEqual(["e2b", "modal"]);
+	});
+
+	test("an unknown id throws, naming the registered providers", () => {
+		expect(() => requestedProviders(["--provider", "dayton"])).toThrow(/dayton/);
+	});
+
+	// The dangerous case: `selectProviders` maps a blank list to "every provider", so without an explicit
+	// guard a cell whose `--provider` value failed to interpolate would bake all five instead of its one.
+	test("a present-but-valueless flag throws instead of silently selecting every provider", () => {
+		expect(() => requestedProviders(["--provider"])).toThrow(/requires at least one provider/);
+		expect(() => requestedProviders(["--provider="])).toThrow(/requires at least one provider/);
+		expect(() => requestedProviders(["--provider", "--force"])).toThrow(
+			/requires at least one provider/,
+		);
+		expect(() => requestedProviders(["--provider", " "])).toThrow(/requires at least one provider/);
+	});
+});

--- a/apps/cli/src/bin/bake.ts
+++ b/apps/cli/src/bin/bake.ts
@@ -8,6 +8,7 @@
 //
 // The provider loop + skip-vs-fail contract is shared with bench-smoke/promote (providers-run.ts);
 // the boot+smoke lifecycle (probe results captured before teardown) is shared too (smoke-run.ts).
+import { writeFileSync } from "node:fs";
 import { requiredProviders, unmetRequirements } from "@sandbox-benchmarks/harness";
 import type { ProviderConfig } from "@sandbox-benchmarks/providers";
 import { config } from "@sandbox-benchmarks/providers";
@@ -20,6 +21,7 @@ import { bakeNovitaTemplate } from "../lib/bake/novita.ts";
 import { promoteAll } from "../lib/bake/promote.ts";
 import type { BakeReport, Log } from "../lib/bake/types.ts";
 import { candidateCreateOptions } from "../lib/bake/validate.ts";
+import { selectProviders } from "../lib/matrix.ts";
 import { anyFailed, forEachProviderWithCreds } from "../lib/providers-run.ts";
 import { bootAndSmoke, logChecks, smokeFailureReason, smokeOk } from "../lib/smoke-run.ts";
 
@@ -35,6 +37,56 @@ const bakers: Record<ProviderId, (image: string, log: Log) => Promise<void>> = {
 	novita: (image, log) => bakeNovitaTemplate(config.novitaTemplateCandidate, image, log),
 };
 
+/**
+ * Emit the bake/promote report JSON. To `$BAKE_REPORT_FILE` when set — the provider CLIs (e2b) and
+ * docker inherit stdout, so a `bun bake.ts … > report.json` redirect would splice their chatter into
+ * the report and corrupt the diagnostic. Writing the JSON to a file keeps the captured artifact clean
+ * regardless. Falls back to stdout locally (no env var) so the bin stays runnable by hand.
+ */
+function writeReport(report: unknown): void {
+	const json = `${JSON.stringify(report, null, 2)}\n`;
+	const file = process.env.BAKE_REPORT_FILE;
+	if (file) writeFileSync(file, json);
+	else process.stdout.write(json);
+}
+
+/**
+ * The provider ids a `--provider <ids>` (or `--provider=<ids>`) flag restricts the bake+validate loop
+ * to — a comma-separated list, so the CI matrix passes one id per cell (`--provider e2b`) and each
+ * provider bakes in its own job. Absent → undefined (drive every registered provider, the local
+ * default). The argv scan mirrors `--require` (harness `requiredProviders`); the CSV is split and
+ * validated against the registry by the shared {@link selectProviders} (which dedups, is
+ * case-insensitive, returns registry order, and throws a registry-derived message on an unknown id).
+ * The flag applies only to the candidate bake loop; `--promote` is always all-providers (a transaction).
+ *
+ * A PRESENT-but-valueless flag (`--provider`, `--provider=`, `--provider --force`) THROWS rather than
+ * falling through to the all-providers default. `selectProviders` treats a blank list as "every
+ * provider", which is the right default for an *absent* dispatch input but exactly wrong here: a matrix
+ * cell whose value failed to interpolate would silently bake all five providers instead of its one, and
+ * five such cells would race on the same artifact names. Asking to restrict and getting everything is a
+ * failure, so it is reported as one.
+ */
+export function requestedProviders(argv: string[]): ProviderId[] | undefined {
+	let raw: string | undefined;
+	const eq = argv.find((a) => a.startsWith("--provider="));
+	if (eq) {
+		raw = eq.slice("--provider=".length);
+	} else {
+		const i = argv.indexOf("--provider");
+		// The flag is present, so a missing or flag-like next arg is a typo, not "no restriction" —
+		// record it as an empty request and let the blank check below reject it.
+		if (i !== -1) {
+			const next = argv[i + 1];
+			raw = next !== undefined && !next.startsWith("-") ? next : "";
+		}
+	}
+	if (raw === undefined) return undefined;
+	if (raw.trim() === "") {
+		throw new Error("--provider requires at least one provider id (e.g. --provider e2b)");
+	}
+	return selectProviders(raw);
+}
+
 if (import.meta.main) {
 	const log: Log = (m) => console.error(m);
 
@@ -43,21 +95,15 @@ if (import.meta.main) {
 		// `--force` republishes over an existing (immutable) version — dev regeneration, set only by a
 		// manual toolchain-image.yml dispatch. Automated pushes never pass it, so :v1 stays immutable there.
 		const promoted = await promoteAll(log, process.argv.includes("--force"));
-		console.log(
-			JSON.stringify(
-				{
-					version: {
-						image: config.toolchainImageVersion,
-						e2bTemplate: config.e2bTemplateVersion,
-						daytonaSnapshot: config.daytonaSnapshotDefault,
-						novitaTemplate: config.novitaTemplateVersion,
-					},
-					reports: promoted,
-				},
-				null,
-				2,
-			),
-		);
+		writeReport({
+			version: {
+				image: config.toolchainImageVersion,
+				e2bTemplate: config.e2bTemplateVersion,
+				daytonaSnapshot: config.daytonaSnapshotDefault,
+				novitaTemplate: config.novitaTemplateVersion,
+			},
+			reports: promoted,
+		});
 		// promoteAll is self-gating: the D1 required-providers gate (CI passes `--require e2b,daytona,modal`)
 		// runs INSIDE promoteAll before the immutable base is written, and every abort path (version already
 		// published, candidate re-validation failed, artifact failed, unmet requirements) pushes a structured
@@ -66,6 +112,17 @@ if (import.meta.main) {
 		// failure, since the early `reports` carry no provider "ok" entries.
 		process.exit(promoted.some((r) => r.status === "failed") ? 1 : 0);
 	}
+
+	// Optional per-provider restriction for the CI matrix fan-out (one cell per provider). Parsed before
+	// any build so a typo'd id fails the cell fast (clean message, no stack), before the candidate is touched.
+	let only: ProviderId[] | undefined;
+	try {
+		only = requestedProviders(process.argv);
+	} catch (err) {
+		log(`error: ${err instanceof Error ? err.message : String(err)}`);
+		process.exit(2);
+	}
+	if (only) log(`>>> restricting bake+validate to: ${only.join(", ")}`);
 
 	if (process.argv.includes("--build-push")) {
 		log(">>> building + pushing candidate image…");
@@ -116,6 +173,7 @@ if (import.meta.main) {
 		},
 		{
 			log,
+			only,
 			ok: smokeOk,
 			failureReason: smokeFailureReason,
 			onComplete: (run) => {
@@ -140,21 +198,15 @@ if (import.meta.main) {
 		...(run.value && run.value.checks.length > 0 ? { checks: run.value.checks } : {}),
 	}));
 
-	console.log(
-		JSON.stringify(
-			{
-				candidate: {
-					image: pinnedCandidateImage,
-					e2bTemplate: config.e2bTemplateCandidate,
-					daytonaSnapshot: config.daytonaSnapshotCandidate,
-					novitaTemplate: config.novitaTemplateCandidate,
-				},
-				reports,
-			},
-			null,
-			2,
-		),
-	);
+	writeReport({
+		candidate: {
+			image: pinnedCandidateImage,
+			e2bTemplate: config.e2bTemplateCandidate,
+			daytonaSnapshot: config.daytonaSnapshotCandidate,
+			novitaTemplate: config.novitaTemplateCandidate,
+		},
+		reports,
+	});
 
 	if (anyFailed(runs)) process.exit(1);
 

--- a/apps/cli/src/lib/providers-run.test.ts
+++ b/apps/cli/src/lib/providers-run.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, test } from "bun:test";
+import { forEachProviderWithCreds } from "./providers-run.ts";
+
+describe("forEachProviderWithCreds `only`", () => {
+	test("visits only the requested provider (a matrix cell reports just its own)", async () => {
+		const bodyRan: string[] = [];
+		const runs = await forEachProviderWithCreds(
+			async (provider) => {
+				bodyRan.push(provider.name);
+				return null;
+			},
+			// No creds for daytona in this env → it skips, but nothing else is even considered.
+			{ only: ["daytona"], env: {} },
+		);
+		expect(runs.map((r) => r.provider)).toEqual(["daytona"]);
+		expect(runs[0]?.status).toBe("skipped");
+		expect(bodyRan).toEqual([]); // skipped: the body never runs
+	});
+
+	test("runs the body for a selected provider whose creds are present", async () => {
+		const runs = await forEachProviderWithCreds(async () => "smoked", {
+			only: ["e2b"],
+			env: { E2B_API_KEY: "present" },
+		});
+		expect(runs).toHaveLength(1);
+		expect(runs[0]?.provider).toBe("e2b");
+		expect(runs[0]?.status).toBe("ok");
+		expect(runs[0]?.value).toBe("smoked");
+	});
+
+	test("without `only`, drives every registered provider (unchanged default)", async () => {
+		const runs = await forEachProviderWithCreds(async () => null, { env: {} });
+		// All registered providers are visited (all skipped here for want of creds).
+		expect(runs.map((r) => r.provider)).toEqual(["e2b", "daytona", "blaxel", "modal", "novita"]);
+	});
+
+	// `[]` is truthy, so without a guard it would select nothing, validate nothing, and still exit 0 —
+	// a release that baked nothing looking exactly like one that passed.
+	test("an empty `only` throws rather than silently validating zero providers", async () => {
+		await expect(forEachProviderWithCreds(async () => null, { only: [], env: {} })).rejects.toThrow(
+			/empty list/,
+		);
+	});
+});

--- a/apps/cli/src/lib/providers-run.ts
+++ b/apps/cli/src/lib/providers-run.ts
@@ -34,6 +34,14 @@ export interface ForEachProviderOptions<T> {
 	failureReason?: (value: T) => string;
 	/** Called right after each provider settles (ok/failed), so callers can log results in order. */
 	onComplete?: (run: ProviderRun<T>) => void;
+	/**
+	 * Restrict the loop to these provider ids — the CI fan-out passes one id per matrix cell so each
+	 * provider bakes/validates in its own job. Absent → every registered provider (the default, so the
+	 * local `bake` still drives them all). The registry order is preserved; ids not in `only` are simply
+	 * not visited (no report), so a cell reports only its own provider. Validate names against the
+	 * registry before calling — an unknown id here just yields zero runs, which the caller must reject.
+	 */
+	only?: readonly ProviderId[];
 }
 
 const noop = () => {};
@@ -50,7 +58,25 @@ export async function forEachProviderWithCreds<T>(
 	const log = options.log ?? noop;
 	const runs: ProviderRun<T>[] = [];
 
-	for (const provider of providers) {
+	// A CI matrix cell passes `only: [<its provider>]`; the local `bake` passes nothing and drives them
+	// all. `only` filters which registry entries are visited — order (and thus report order) is the
+	// registry's, never the request's, so a cell's report is a stable subset of the whole.
+	//
+	// A PRESENT-but-empty `only` is a caller bug, and a silent one: `[]` is truthy, so it would select
+	// zero providers, run zero bodies, and report zero runs — and `anyFailed([])` is false, so the cell
+	// would EXIT 0 having validated nothing. A release that bakes nothing must never look like a release
+	// that passed. Omit `only` to mean "every provider"; `[]` means "you computed an empty set", which is
+	// never a valid request.
+	if (options.only && options.only.length === 0) {
+		throw new Error(
+			"forEachProviderWithCreds: `only` is an empty list — pass at least one provider id, or omit `only` to visit every registered provider",
+		);
+	}
+	const selected = options.only
+		? providers.filter((p) => options.only?.includes(p.name))
+		: providers;
+
+	for (const provider of selected) {
 		const missing = missingCreds(provider, options.env);
 		if (missing.length > 0) {
 			log(`skip: ${provider.name} (missing ${missing.join(", ")})`);


### PR DESCRIPTION
**TOOLCHAIN RELEASE — restage the monolithic publish job into a parallel, resumable, plan-driven pipeline.**
Shipped as an 8-PR stack. The trunk merges bottom-up: the four CLI PRs (#155–#157) are pure-additive
mechanism (nothing calls them yet), and #158/#159 are the wiring that finally consumes them.

```
main
 └─ #152  ci: pin actions/* to the current latest (checkout v7, upload v7, download v8)
     └─ #153  bake: retry the daytona snapshot create + rich failure diagnostics
         └─ #154  bake: `--provider <id>` selection + a file-based report
             └─ #155  cli: `release-plan` — the release plan as an artifact
                 └─ #156  cli: `build-candidate` — build once, record the digest
                     └─ #157  cli: `release-{validate,summary,ensure-public}` via @actions/core
                         └─ #158  ci: the five composite actions the release jobs share
                             └─ #159  ci: restage toolchain-image.yml (plan → build → bake → promote)
```

↑ **This PR is #154 (3/8) — mechanism: make one `bake` serve one matrix cell, based on #153.**

---

**Stack 3/8** — based on #153

Two additive changes that let a single `bake` invocation serve one CI matrix cell — the mechanism the
fan-out in #159 consumes. Both default to today's behavior, so nothing changes until the workflow
starts passing them.

- **`--provider <ids>`** restricts the bake+validate loop to a comma-separated set, so the matrix can
  pass one id per cell and each provider bakes in its own job. Plumbed as a new optional `only` on
  `forEachProviderWithCreds`, which filters the registry **in registry order** — a cell's report is a
  stable subset of the whole, never reordered by the request. Parsing reuses the existing
  `selectProviders` (dedups, case-insensitive, registry-derived error on an unknown id), and runs
  before any build so a typo'd id fails the cell fast rather than after a push. `--promote` is
  deliberately unaffected: it is always all-providers (a transaction).

- **`$BAKE_REPORT_FILE`** redirects the report JSON to a file. The provider CLIs (e2b) and docker
  inherit stdout, so a `bun bake.ts … > report.json` redirect **splices their chatter into the report**
  and corrupts the diagnostic. Writing straight to the named file keeps the artifact clean regardless of
  what a child prints. Unset → stdout, as before.

**Review fix (from #149):** a *present-but-valueless* `--provider` (`--provider`, `--provider=`,
`--provider --force`) now **throws** instead of falling through to the all-providers default.
`selectProviders` maps a blank list to "every provider" — correct for an absent dispatch input, exactly
wrong here: a cell whose value failed to interpolate would have silently baked **all five** providers
instead of its one, and five such cells would race on the same artifact names. Asking to restrict and
getting everything is a failure, so it is reported as one.

**LOC**: 166 added / 31 removed.

---

## Validation

Every branch in this stack was checked out **in isolation** (on top of its own parent, with nothing
from the PRs above it) and run through the full gate set. A reviewer merges bottom-up, so each PR has
to stand on its own — this is what verifies that.

**This PR (`03`), verified standalone — all gates green:**

| gate | command | result |
|---|---|---|
| install | `bun install --frozen-lockfile` | ✅ |
| typecheck | `bun run typecheck` | ✅ |
| lint | `bun run lint` (biome, `--error-on-warnings`) | ✅ |
| spell | `mise exec -- typos` | ✅ |
| shell | `bun run lint:shell` (shellcheck) | ✅ |
| catalog drift | `bun run check:catalog-drift` | ✅ |
| workflow lint | `actionlint` + `zizmor` | ✅ |
| tests | `bun run test` (whole workspace) | ✅ **623 passing, 0 failing** |

The same matrix is green on all 8 branches, and the passing-test count climbs monotonically up the
trunk (612 → 633) — each PR adds coverage and none regresses it. The top of the stack was also diffed
against the pre-split branch to prove the decomposition moved every change and dropped nothing.

**What this PR's own tests prove:**

- `only` visits **only** the requested provider (a cell reports just its own), skips it when creds are
  absent without running the body, and — with no `only` — still drives every registered provider.
- `requestedProviders` returns registry order (not request order), throws on an unknown id, and
  **throws on all four valueless-flag spellings** — the regression the review caught, now pinned by a
  test so it can't come back.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add per-provider bake selection and file-based JSON reports so each CI matrix cell runs a single provider without corrupting output. Defaults stay the same; `--promote` still runs all providers.

- **New Features**
  - `--provider <ids>` limits bake+validate to selected providers (CSV). Case-insensitive, deduped, registry order; unknown ids throw. Parsed before any build and logs the restriction.
  - `$BAKE_REPORT_FILE` writes bake/promote report JSON to a file; unset → stdout. Prevents provider CLI/docker stdout from corrupting JSON.

- **Bug Fixes**
  - Present-but-valueless `--provider` now throws (`--provider`, `--provider=`, `--provider --force`, whitespace).
  - Empty `only` in `forEachProviderWithCreds` throws to prevent silently validating zero providers.

<sup>Written for commit a244c2beec5076619c33c3de853e85bc4cf8779e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/starslingdev/sandbox-benchmarks/pull/154?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

