### PR TITLE
feat(cli): release-plan bin — make the release plan an artifact

### DIFF
--- a/apps/cli/src/bin/release-plan.test.ts
+++ b/apps/cli/src/bin/release-plan.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, test } from "bun:test";
+import { buildReleasePlan, planOutputs, RELEASE_REQUIRED_PROVIDERS } from "./release-plan.ts";
+
+const base = { sourceRef: "abc123", forceRepublish: false, alreadyPublished: false };
+
+describe("buildReleasePlan mode + skip", () => {
+	test("a fresh build of an unpublished version runs (mode build, skip false)", () => {
+		const plan = buildReleasePlan(base);
+		expect(plan.mode).toBe("build");
+		expect(plan.skip).toBe(false);
+	});
+
+	test("a plain build skips once the immutable version already exists", () => {
+		const plan = buildReleasePlan({ ...base, alreadyPublished: true });
+		expect(plan.mode).toBe("build");
+		expect(plan.skip).toBe(true);
+	});
+
+	test("force_republish regenerates in place even when already published (mode republish, skip false)", () => {
+		const plan = buildReleasePlan({ ...base, forceRepublish: true, alreadyPublished: true });
+		expect(plan.mode).toBe("republish");
+		expect(plan.skip).toBe(false);
+		expect(plan.gates.forceRepublish).toBe(true);
+	});
+});
+
+describe("buildReleasePlan matrix", () => {
+	test("fans out over every provider in registry order", () => {
+		const plan = buildReleasePlan(base);
+		expect(plan.matrix.include.map((c) => c.provider)).toEqual([
+			"e2b",
+			"daytona",
+			"blaxel",
+			"modal",
+			"novita",
+		]);
+	});
+
+	test("marks exactly the required providers as gating cells", () => {
+		const plan = buildReleasePlan(base);
+		const required = plan.matrix.include.filter((c) => c.required).map((c) => c.provider);
+		expect(required).toEqual([...RELEASE_REQUIRED_PROVIDERS]);
+		expect(plan.required).toEqual([...RELEASE_REQUIRED_PROVIDERS]);
+	});
+});
+
+describe("planOutputs", () => {
+	test("emits one key=value per line with a single-line matrix json", () => {
+		const lines = planOutputs(buildReleasePlan(base)).split("\n");
+		expect(lines).toContain("mode=build");
+		expect(lines).toContain("skip=false");
+		expect(lines).toContain(`required=${RELEASE_REQUIRED_PROVIDERS.join(",")}`);
+		const matrixLine = lines.find((l) => l.startsWith("matrix="));
+		expect(matrixLine).toBeDefined();
+		// The matrix value must be valid, single-line JSON (the fromJSON contract).
+		const parsed = JSON.parse((matrixLine as string).slice("matrix=".length));
+		expect(parsed.include).toHaveLength(5);
+		expect((matrixLine as string).includes("\n")).toBe(false);
+	});
+});

--- a/apps/cli/src/bin/release-plan.ts
+++ b/apps/cli/src/bin/release-plan.ts
@@ -1,0 +1,194 @@
+#!/usr/bin/env bun
+// `release-plan` — the FIRST job of the toolchain release. Resolve the toolchain identity from the
+// arktype-validated config, decide the release mode, and emit ONE machine-checkable release plan that
+// every downstream job (build, the provider bake matrix, promote) consumes instead of re-deriving the
+// refs and gates from the raw workflow inputs (the "make the plan an artifact" contract).
+//
+// Two outputs, one invocation:
+//   • the full plan as pretty JSON, written to the path in argv[1] (uploaded as the release-plan.json
+//     diagnostic artifact), and
+//   • the consumed `key=value` lines written straight to $GITHUB_OUTPUT (skip, mode, matrix, refs, …)
+//     via emitStepOutputs — never a stdout redirect, so no subprocess chatter can corrupt them.
+//
+// Credential posture: importing `config`/`validatedPins` validates env + pins with NO cloud creds
+// (the fail-fast gate). The one privileged call is the immutability probe (`imageExistsInRegistry`,
+// a `docker manifest inspect` that needs the GHCR login the plan job does first). That probe is only
+// a best-effort EARLY skip — the authoritative immutable-version guard lives in `promote` (which
+// REFUSES on an uncertain check), so an inconclusive probe here proceeds rather than blocks.
+import { config } from "@sandbox-benchmarks/providers";
+import type { ProviderId } from "@sandbox-benchmarks/schema";
+import { PROVIDERS } from "@sandbox-benchmarks/schema";
+import { validatedPins } from "@sandbox-benchmarks/templates/pins";
+import { imageExistsInRegistry, imageRepo } from "../lib/bake/image.ts";
+import { emitStepOutputs } from "../lib/gha-output.ts";
+
+/**
+ * Providers the release is REQUIRED to bake + validate before the public version is published — the
+ * same set CI passes to `bake --promote --require …`, single-sourced here so the matrix's per-cell
+ * `required` flags and promote's gate can't drift. e2b/daytona bake a real artifact; modal is required
+ * because its `Image.fromRegistry` boot validates the published image the same way. blaxel (a no-op
+ * bake booting the stock base) and novita (optional control plane) are best-effort: a missing secret
+ * skips them without failing the release.
+ */
+export const RELEASE_REQUIRED_PROVIDERS: readonly ProviderId[] = ["e2b", "daytona", "modal"];
+
+/** Every provider the release fans out over, derived from the registry (never a hand-maintained
+ *  literal) so adding a provider grows the matrix automatically — in registry order, matching the
+ *  matrix cell order. `providerArtifact` below is exhaustive over `ProviderId`, so a new provider is a
+ *  compile error there until it's handled. */
+const RELEASE_PROVIDERS: readonly ProviderId[] = PROVIDERS.map((p) => p.id);
+
+/** Per-provider baked artifact name (what a cell produces), or a note for the providers that bake none. */
+function providerArtifact(id: ProviderId): string {
+	switch (id) {
+		case "e2b":
+			return config.e2bTemplateCandidate;
+		case "daytona":
+			return config.daytonaSnapshotCandidate;
+		case "novita":
+			return config.novitaTemplateCandidate;
+		case "modal":
+			return "boots the candidate image directly (no baked artifact)";
+		case "blaxel":
+			return "boots the stock base image (no baked artifact)";
+	}
+}
+
+export interface ReleasePlanInputs {
+	/** `github.sha` — the source ref the release is cut from (recorded, not resolved). */
+	sourceRef: string;
+	/** `force_republish` dispatch input: regenerate the version in place even if already published. */
+	forceRepublish: boolean;
+	/** Whether the immutable public version already exists in the registry (the early-skip probe). */
+	alreadyPublished: boolean;
+}
+
+export interface ReleaseProviderPlan {
+	provider: ProviderId;
+	required: boolean;
+	artifact: string;
+}
+
+export interface ReleasePlan {
+	/** `build` for a fresh release; `republish` when force_republish regenerates an existing version. */
+	mode: "build" | "republish";
+	/** Skip the whole release: the version is already published and this is not a forced republish. */
+	skip: boolean;
+	sourceRef: string;
+	/** The single cross-provider size tier (this benchmark pins exactly one — no size-tier fan-out). */
+	sizeTier: string;
+	image: {
+		repo: string;
+		/** The bare package name (the GHCR package the public-package guard checks). */
+		name: string;
+		version: string;
+		candidate: string;
+		toolchainVersion: string;
+	};
+	providers: ReleaseProviderPlan[];
+	/** The providers that must pass before publish (single-sourced for the matrix + promote gate). */
+	required: ProviderId[];
+	gates: {
+		alreadyPublished: boolean;
+		forceRepublish: boolean;
+		/** The immutable pointer promote advances — the only mutation the release makes public. */
+		publishTarget: string;
+	};
+	/** The `strategy.matrix` contract the bake fan-out reads: one cell per provider. */
+	matrix: { include: Array<{ provider: ProviderId; required: boolean }> };
+}
+
+/**
+ * Build the release plan from resolved inputs + the config refs. Pure (no env, no I/O) so the mode /
+ * skip / matrix logic is unit-testable without a registry or a real config — the bin injects the live
+ * `config`-derived values below.
+ */
+export function buildReleasePlan(inputs: ReleasePlanInputs): ReleasePlan {
+	const mode = inputs.forceRepublish ? "republish" : "build";
+	// force_republish deliberately regenerates the version in place, so "already published" never skips
+	// it; a plain build skips once the immutable version exists (bump TOOLCHAIN_VERSION to publish anew).
+	const skip = inputs.alreadyPublished && !inputs.forceRepublish;
+
+	const providers: ReleaseProviderPlan[] = RELEASE_PROVIDERS.map((provider) => ({
+		provider,
+		required: RELEASE_REQUIRED_PROVIDERS.includes(provider),
+		artifact: providerArtifact(provider),
+	}));
+
+	const { vcpus, memoryGb, diskGb } = config.targetSpec;
+	const repo = imageRepo(config.toolchainImageVersion);
+
+	return {
+		mode,
+		skip,
+		sourceRef: inputs.sourceRef,
+		sizeTier: `${vcpus} vCPU / ${memoryGb} GiB / ${diskGb} GB`,
+		image: {
+			repo,
+			name: repo.split("/").pop() ?? repo,
+			version: config.toolchainImageVersion,
+			candidate: config.toolchainImageCandidate,
+			toolchainVersion: config.toolchainVersion,
+		},
+		providers,
+		required: [...RELEASE_REQUIRED_PROVIDERS],
+		gates: {
+			alreadyPublished: inputs.alreadyPublished,
+			forceRepublish: inputs.forceRepublish,
+			publishTarget: config.toolchainImageVersion,
+		},
+		matrix: {
+			include: providers.map(({ provider, required }) => ({ provider, required })),
+		},
+	};
+}
+
+/** The flat `key=value` lines a downstream job reads via `steps.<id>.outputs.*` (one per line). Only
+ *  the outputs the workflow actually consumes are emitted; the full plan (repo, version, gates, …)
+ *  lives in the release-plan.json artifact for diagnostics. */
+export function planOutputs(plan: ReleasePlan): string {
+	return [
+		`mode=${plan.mode}`,
+		`skip=${plan.skip}`,
+		`image-name=${plan.image.name}`,
+		`image-candidate=${plan.image.candidate}`,
+		`toolchain-version=${plan.image.toolchainVersion}`,
+		`size-tier=${plan.sizeTier}`,
+		`required=${plan.required.join(",")}`,
+		`publish-target=${plan.gates.publishTarget}`,
+		// The matrix must be a single line of compact JSON — it becomes `fromJSON(needs.plan.outputs.matrix)`.
+		`matrix=${JSON.stringify(plan.matrix)}`,
+	].join("\n");
+}
+
+if (import.meta.main) {
+	// Validate the pins up front (throws on any unfilled/invalid pin) — the credential-free fail-fast
+	// gate, before the registry probe below touches the (already-logged-in) registry.
+	validatedPins();
+
+	const forceRepublish = process.env.FORCE_REPUBLISH === "true";
+	const sourceRef = process.env.GITHUB_SHA ?? "unknown";
+
+	// Best-effort immutability probe: an inconclusive result (auth/network) proceeds — promote does the
+	// authoritative, refuse-on-uncertain check before it writes the immutable base.
+	let alreadyPublished = false;
+	try {
+		alreadyPublished = await imageExistsInRegistry(config.toolchainImageVersion);
+	} catch (err) {
+		console.error(
+			`::warning::could not probe whether ${config.toolchainImageVersion} is already published ` +
+				`(${err instanceof Error ? err.message : String(err)}); proceeding — promote does the authoritative guard.`,
+		);
+	}
+
+	const plan = buildReleasePlan({ sourceRef, forceRepublish, alreadyPublished });
+
+	// Optional first positional (flags filtered out): write the full plan JSON here for the
+	// release-plan.json diagnostic artifact.
+	const planPath = process.argv.slice(2).find((a) => !a.startsWith("-"));
+	if (planPath) await Bun.write(planPath, `${JSON.stringify(plan, null, 2)}\n`);
+
+	// Write the `key=value` outputs straight to $GITHUB_OUTPUT (never via a stdout redirect), so nothing
+	// a child process prints can corrupt them.
+	emitStepOutputs(planOutputs(plan));
+}

--- a/apps/cli/src/lib/bake/image.test.ts
+++ b/apps/cli/src/lib/bake/image.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "bun:test";
 import {
 	digestPinnedRef,
+	imageRepo,
 	imagetoolsNormalizeCmd,
 	imagetoolsRetagCmd,
 	registryManifestAbsent,
@@ -78,5 +79,28 @@ describe("registryManifestAbsent", () => {
 		expect(registryManifestAbsent("error getting credentials: executable not found")).toBe(false);
 		expect(registryManifestAbsent("docker-credential-osxkeychain: not found")).toBe(false);
 		expect(registryManifestAbsent("unauthorized: authentication required")).toBe(false);
+	});
+});
+
+describe("imageRepo", () => {
+	it("strips the tag from the refs we actually publish", () => {
+		expect(imageRepo("ghcr.io/starslingdev/toolchain:v1")).toBe("ghcr.io/starslingdev/toolchain");
+		expect(imageRepo("ghcr.io/starslingdev/toolchain:v1-candidate")).toBe(
+			"ghcr.io/starslingdev/toolchain",
+		);
+	});
+
+	// The bug in the `split(":")[0]` this replaced: it truncated the repo to the bare host.
+	it("keeps a registry port — a colon before the last slash is host:port, not a tag", () => {
+		expect(imageRepo("localhost:5001/org/image:tag")).toBe("localhost:5001/org/image");
+		expect(imageRepo("localhost:5001/org/image")).toBe("localhost:5001/org/image");
+	});
+
+	it("strips a digest", () => {
+		expect(imageRepo(`ghcr.io/org/image@sha256:${"a".repeat(64)}`)).toBe("ghcr.io/org/image");
+	});
+
+	it("returns an untagged ref unchanged", () => {
+		expect(imageRepo("ghcr.io/org/image")).toBe("ghcr.io/org/image");
 	});
 });

--- a/apps/cli/src/lib/bake/image.ts
+++ b/apps/cli/src/lib/bake/image.ts
@@ -95,6 +95,21 @@ export function registryManifestAbsent(stderr: string): boolean {
 	return /no such manifest|manifest unknown|name[_ ]unknown/i.test(stderr);
 }
 
+/**
+ * The repository part of an image ref — `ghcr.io/org/image:v1` → `ghcr.io/org/image`.
+ *
+ * NOT `ref.split(":")[0]`: a registry host may carry a PORT (`localhost:5001/org/image:tag`), and
+ * splitting on the first colon would truncate the repo to the bare host. A colon is only a tag
+ * separator when it comes after the last `/`; anywhere earlier it belongs to the host:port. A digest
+ * (`repo@sha256:…`) is stripped first, so the function is total over every ref shape we build.
+ */
+export function imageRepo(ref: string): string {
+	const withoutDigest = ref.split("@")[0] ?? ref;
+	const lastColon = withoutDigest.lastIndexOf(":");
+	const lastSlash = withoutDigest.lastIndexOf("/");
+	return lastColon > lastSlash ? withoutDigest.slice(0, lastColon) : withoutDigest;
+}
+
 /** Whether `ref` already exists in the registry — a successful `docker manifest inspect`. Queries the
  *  registry (not local images), so a locally-built `:v1` tag never reads as published. promote uses
  *  this to REFUSE overwriting the immutable public version.

--- a/apps/cli/src/lib/gha-output.ts
+++ b/apps/cli/src/lib/gha-output.ts
@@ -1,0 +1,22 @@
+// Emit a release bin's machine-readable output WITHOUT relying on a pristine stdout. The build/plan
+// bins spawn subprocesses (build.sh, provider CLIs) that inherit stdout, so a `bun bin >> "$GITHUB_OUTPUT"`
+// redirect would splice that subprocess chatter into the outputs file and GitHub would reject it
+// ("Unable to process file command 'output'"). Writing the `key=value` lines straight to the file named
+// by $GITHUB_OUTPUT keeps the outputs clean regardless of what a child process prints. Locally
+// ($GITHUB_OUTPUT unset) it falls back to stdout so the bins stay runnable by hand.
+import { appendFileSync } from "node:fs";
+
+/**
+ * Append newline-terminated `key=value` output lines to the GitHub Actions step-output file
+ * ($GITHUB_OUTPUT), or print them to stdout when that env var is absent (local dev). `lines` is the
+ * already-joined block (no trailing newline required).
+ */
+export function emitStepOutputs(lines: string): void {
+	const file = process.env.GITHUB_OUTPUT;
+	const block = lines.endsWith("\n") ? lines : `${lines}\n`;
+	if (file) {
+		appendFileSync(file, block);
+	} else {
+		process.stdout.write(block);
+	}
+}


### PR DESCRIPTION
**TOOLCHAIN RELEASE — restage the monolithic publish job into a parallel, resumable, plan-driven pipeline.**
Shipped as an 8-PR stack. The trunk merges bottom-up: the four CLI PRs (#155–#157) are pure-additive
mechanism (nothing calls them yet), and #158/#159 are the wiring that finally consumes them.

```
main
 └─ #152  ci: pin actions/* to the current latest (checkout v7, upload v7, download v8)
     └─ #153  bake: retry the daytona snapshot create + rich failure diagnostics
         └─ #154  bake: `--provider <id>` selection + a file-based report
             └─ #155  cli: `release-plan` — the release plan as an artifact
                 └─ #156  cli: `build-candidate` — build once, record the digest
                     └─ #157  cli: `release-{validate,summary,ensure-public}` via @actions/core
                         └─ #158  ci: the five composite actions the release jobs share
                             └─ #159  ci: restage toolchain-image.yml (plan → build → bake → promote)
```

↑ **This PR is #155 (4/8) — pure-additive mechanism (nothing calls it yet), based on #154.**

---

**Stack 4/8** — based on #154

`release-plan` is the first job of the staged release: resolve the toolchain identity from the
arktype-validated config, decide the release mode, and emit **one machine-checkable plan** that every
downstream job (build, the bake matrix, promote) consumes — instead of each re-deriving the refs and
gates from raw workflow inputs. *Make the plan an artifact.*

The plan carries the mode (`build` vs `republish`), the skip decision, the image refs, the size tier,
the required-provider set, and the `strategy.matrix` the fan-out reads via `fromJSON`.

- The provider list is **derived from the registry**, never a hand-maintained literal, so adding a
  provider grows the matrix automatically — and `providerArtifact` is exhaustive over `ProviderId`, so
  a new provider is a **compile error** until it's handled.
- `RELEASE_REQUIRED_PROVIDERS` is single-sourced here, so the matrix's per-cell `required` flags and
  promote's gate **cannot drift**.
- `buildReleasePlan` is pure (no env, no I/O), so the mode/skip/matrix logic is unit-testable without a
  registry or a real config.

**Credential posture:** importing config/pins validates with **no cloud creds** (the fail-fast gate).
The one privileged call is the immutability probe, and it is only a best-effort *early skip* — the
authoritative guard stays in `promote`, which refuses on an uncertain check. So an inconclusive probe
here proceeds rather than blocks.

Also adds `emitStepOutputs` (`lib/gha-output.ts`), of which this bin is the first consumer: it appends
`key=value` lines **straight to the file named by `$GITHUB_OUTPUT`** rather than relying on a
`bun bin >> "$GITHUB_OUTPUT"` redirect. The release bins spawn subprocesses that inherit stdout, and
that chatter would otherwise splice into the outputs file — GitHub rejects it outright with
"Unable to process file command 'output'". Locally (`$GITHUB_OUTPUT` unset) it falls back to stdout, so
the bins stay runnable by hand.

**LOC**: 276 added.

---

## Validation

Every branch in this stack was checked out **in isolation** (on top of its own parent, with nothing
from the PRs above it) and run through the full gate set. A reviewer merges bottom-up, so each PR has
to stand on its own — this is what verifies that.

**This PR (`04`), verified standalone — all gates green:**

| gate | command | result |
|---|---|---|
| install | `bun install --frozen-lockfile` | ✅ |
| typecheck | `bun run typecheck` | ✅ |
| lint | `bun run lint` (biome, `--error-on-warnings`) | ✅ |
| spell | `mise exec -- typos` | ✅ |
| shell | `bun run lint:shell` (shellcheck) | ✅ |
| catalog drift | `bun run check:catalog-drift` | ✅ |
| workflow lint | `actionlint` + `zizmor` | ✅ |
| tests | `bun run test` (whole workspace) | ✅ **629 passing, 0 failing** |

The same matrix is green on all 8 branches, and the passing-test count climbs monotonically up the
trunk (612 → 633) — each PR adds coverage and none regresses it. The top of the stack was also diffed
against the pre-split branch to prove the decomposition moved every change and dropped nothing.

**What this PR's own tests prove:** the mode/skip truth table (a fresh build runs; a plain build skips
once the immutable version exists; `force_republish` regenerates in place **even when already
published**), that the matrix fans out over every provider in registry order, that exactly the required
providers are flagged as gating cells, and — the `fromJSON` contract — that `matrix=` is emitted as
**valid single-line JSON**, which is what the workflow's `fromJSON(needs.plan.outputs.matrix)` requires.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a `release-plan` CLI that creates a single, machine-checkable plan artifact and writes GHA step outputs so build, bake, and promote share the same inputs. Also adds `emitStepOutputs` and fixes image repo parsing to keep `host:port` and remove tags/digests.

- **New Features**
  - Pure `buildReleasePlan` decides mode (`build`/`republish`), skip, and builds the provider matrix from the registry (`e2b`, `daytona`, `blaxel`, `modal`, `novita`); required providers are single-sourced as `e2b`, `daytona`, `modal`.
  - Outputs: writes `release-plan.json` and emits GHA outputs (`mode`, `skip`, `image-name`, `image-candidate`, `toolchain-version`, `size-tier`, `required`, `publish-target`, `matrix` as single-line JSON) via `emitStepOutputs` to `$GITHUB_OUTPUT` (stdout fallback).
  - Early immutability probe informs skip (best-effort); the authoritative immutable-version check stays in promote. Tests cover mode/skip, matrix order/required, and the `fromJSON` matrix contract.

- **Bug Fixes**
  - New `imageRepo` strips tags and digests while preserving registry ports (e.g., `localhost:5001`); tests added.

<sup>Written for commit 42e79a5524f4a87c0a70a13fea9a9d22a1ce245e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/starslingdev/sandbox-benchmarks/pull/155?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

