### PR TITLE
feat(cli): build-candidate bin — build once, record the immutable digest

### DIFF
--- a/apps/cli/src/bin/build-candidate.ts
+++ b/apps/cli/src/bin/build-candidate.ts
@@ -1,0 +1,60 @@
+#!/usr/bin/env bun
+// `build-candidate` — the BUILD phase of the toolchain release: build the base image (+ variants) and
+// push the mutable candidate base to GHCR ONCE, then resolve and record its immutable digest. Split
+// from the provider bake so the image is built a single time here and every provider cell fans out
+// from the already-pushed candidate ref (build once, fan out). The local iteration loop still uses
+// `bake --build-push` (which build-pushes AND bakes in one process); CI splits the two.
+//
+// Emits, in one invocation:
+//   • the `key=value` step outputs (candidate digest + digest-pinned ref) straight to $GITHUB_OUTPUT
+//     via emitStepOutputs — NOT to stdout: build.sh runs with inherited stdout, so a
+//     `bun … >> "$GITHUB_OUTPUT"` redirect would splice build.sh's progress into the outputs file and
+//     GitHub would reject it. stdout is left to carry the (inherited) build log, and
+//   • argv[1] (optional): a build-metadata.json diagnostic artifact with the same facts.
+import { config } from "@sandbox-benchmarks/providers";
+import { buildAndPushCandidate, imageRepo, resolveImageDigest } from "../lib/bake/image.ts";
+import type { Log } from "../lib/bake/types.ts";
+import { emitStepOutputs } from "../lib/gha-output.ts";
+
+if (import.meta.main) {
+	const log: Log = (m) => console.error(m);
+
+	// A failed build/push is the phase failing: report it as one line on stderr (where the job summary
+	// and the run log read it) and exit non-zero, rather than letting an unhandled rejection print a
+	// stack trace. Mirrors the `--build-push` path in bake.ts.
+	try {
+		await buildAndPushCandidate(log);
+	} catch (err) {
+		log(`<<< build/push failed — ${err instanceof Error ? err.message : String(err)}`);
+		process.exit(1);
+	}
+
+	// The digest is recorded provenance, not a release gate (promote re-validates the mutable tag), so a
+	// registry-inspect quirk must not block a candidate that pushed fine: fall back to the tag on failure.
+	const repo = imageRepo(config.toolchainImageCandidate);
+	let digest = "unknown";
+	let digestRef: string = config.toolchainImageCandidate;
+	try {
+		digest = await resolveImageDigest(config.toolchainImageCandidate);
+		digestRef = `${repo}@${digest}`;
+	} catch (err) {
+		log(
+			`::warning::could not resolve candidate digest (${err instanceof Error ? err.message : String(err)}); recording the tag instead.`,
+		);
+	}
+
+	const metadata = {
+		candidate: config.toolchainImageCandidate,
+		digest,
+		digestRef,
+		version: config.toolchainVersion,
+		buildRef: process.env.GITHUB_SHA ?? null,
+	};
+	// Optional first positional (flags filtered out).
+	const metaPath = process.argv.slice(2).find((a) => !a.startsWith("-"));
+	if (metaPath) await Bun.write(metaPath, `${JSON.stringify(metadata, null, 2)}\n`);
+
+	log(`<<< candidate pushed: ${digestRef}`);
+	// Straight to $GITHUB_OUTPUT (not stdout) — build.sh's inherited stdout must not reach the outputs.
+	emitStepOutputs([`digest=${digest}`, `candidate-digest-ref=${digestRef}`].join("\n"));
+}

--- a/apps/cli/src/lib/bake/image.ts
+++ b/apps/cli/src/lib/bake/image.ts
@@ -110,6 +110,42 @@ export function imageRepo(ref: string): string {
 	return lastColon > lastSlash ? withoutDigest.slice(0, lastColon) : withoutDigest;
 }
 
+/** Resolve a pushed `ref` to its immutable registry digest (`sha256:…`) via a registry-side inspect —
+ *  no pull. The release records this so every phase pins/records the exact bytes the candidate push
+ *  produced (provenance); the TOCTOU guard proper is promote's re-validation of the mutable candidate. */
+export async function resolveImageDigest(ref: string): Promise<string> {
+	// Parse the `Digest:` line from the default `imagetools inspect` output rather than a
+	// `--format '{{.Manifest.Digest}}'` template: on the runner's buildx that template prints the whole
+	// default descriptor block, so parsing the labelled line is the portable read. The first match is
+	// the top-level manifest/index digest (the ref's digest); per-platform sub-digests, if any, follow.
+	const proc = Bun.spawn(["docker", "buildx", "imagetools", "inspect", ref], {
+		stdout: "pipe",
+		stderr: "pipe",
+		env: process.env,
+	});
+	const [code, stdout, stderr] = await Promise.all([
+		proc.exited,
+		new Response(proc.stdout).text(),
+		new Response(proc.stderr).text(),
+	]);
+	const match = stdout.match(/\bDigest:\s*(sha256:[0-9a-f]{64})\b/);
+	// Distinguish the two failure modes: the inspect itself failed (non-zero exit — auth, network, no
+	// such ref) vs. it SUCCEEDED but printed no digest we recognize (exit 0, no match), which means the
+	// `imagetools inspect` output format changed under us. Same throw, but the message says which, so a
+	// future format change isn't misread as a registry outage.
+	if (code !== 0) {
+		throw new Error(
+			`could not resolve digest for ${ref}: imagetools inspect failed (exit ${code}): ${stderr.trim() || stdout.trim() || "no output"}`,
+		);
+	}
+	if (!match) {
+		throw new Error(
+			`could not resolve digest for ${ref}: imagetools inspect succeeded but printed no 'Digest: sha256:…' line — the output format may have changed. Output: ${stdout.trim() || "(empty)"}`,
+		);
+	}
+	return match[1] as string;
+}
+
 /** Whether `ref` already exists in the registry — a successful `docker manifest inspect`. Queries the
  *  registry (not local images), so a locally-built `:v1` tag never reads as published. promote uses
  *  this to REFUSE overwriting the immutable public version.


### PR DESCRIPTION
**TOOLCHAIN RELEASE — restage the monolithic publish job into a parallel, resumable, plan-driven pipeline.**
Shipped as an 8-PR stack. The trunk merges bottom-up: the four CLI PRs (#155–#157) are pure-additive
mechanism (nothing calls them yet), and #158/#159 are the wiring that finally consumes them.

```
main
 └─ #152  ci: pin actions/* to the current latest (checkout v7, upload v7, download v8)
     └─ #153  bake: retry the daytona snapshot create + rich failure diagnostics
         └─ #154  bake: `--provider <id>` selection + a file-based report
             └─ #155  cli: `release-plan` — the release plan as an artifact
                 └─ #156  cli: `build-candidate` — build once, record the digest
                     └─ #157  cli: `release-{validate,summary,ensure-public}` via @actions/core
                         └─ #158  ci: the five composite actions the release jobs share
                             └─ #159  ci: restage toolchain-image.yml (plan → build → bake → promote)
```

↑ **This PR is #156 (5/8) — pure-additive mechanism (nothing calls it yet), based on #155.**

---

**Stack 5/8** — based on #155

`build-candidate` is the BUILD phase: build the base image (+ variants) and push the mutable candidate
to GHCR **once**, then resolve and record its immutable digest. Split out from the provider bake so the
image is built a single time and every provider cell fans out from the already-pushed candidate ref —
*build once, fan out*. The local iteration loop still uses `bake --build-push` (which build-pushes AND
bakes in one process); only CI splits the two.

Adds `resolveImageDigest`, its only caller: a **registry-side** `imagetools inspect` — no pull —
parsing the labelled `Digest:` line rather than a `--format '{{.Manifest.Digest}}'` template, because on
the runner's buildx that template prints the whole descriptor block. The first match is the top-level
manifest/index digest. Recording it means every phase pins the exact bytes the candidate push produced
(provenance); the TOCTOU guard proper remains promote's re-validation of the mutable tag.

Because the digest is **provenance, not a release gate**, a registry-inspect quirk must not block a
candidate that pushed fine: the bin falls back to recording the tag and warns.

Outputs go straight to `$GITHUB_OUTPUT` via `emitStepOutputs`, never stdout — `build.sh` runs with
inherited stdout, so a redirect would splice its progress log into the outputs file. stdout is left to
carry the build log.

**Review fix (from #149):** a failed `buildAndPushCandidate` is now caught, logged as one line on
stderr, and exits 1 — rather than surfacing as an unhandled rejection with a stack trace. Mirrors the
`--build-push` path in `bake.ts`.

**LOC**: 87 added.

---

## Validation

Every branch in this stack was checked out **in isolation** (on top of its own parent, with nothing
from the PRs above it) and run through the full gate set. A reviewer merges bottom-up, so each PR has
to stand on its own — this is what verifies that.

**This PR (`05`), verified standalone — all gates green:**

| gate | command | result |
|---|---|---|
| install | `bun install --frozen-lockfile` | ✅ |
| typecheck | `bun run typecheck` | ✅ |
| lint | `bun run lint` (biome, `--error-on-warnings`) | ✅ |
| spell | `mise exec -- typos` | ✅ |
| shell | `bun run lint:shell` (shellcheck) | ✅ |
| catalog drift | `bun run check:catalog-drift` | ✅ |
| workflow lint | `actionlint` + `zizmor` | ✅ |
| tests | `bun run test` (whole workspace) | ✅ **629 passing, 0 failing** |

The same matrix is green on all 8 branches, and the passing-test count climbs monotonically up the
trunk (612 → 633) — each PR adds coverage and none regresses it. The top of the stack was also diffed
against the pre-split branch to prove the decomposition moved every change and dropped nothing.

**What this PR's own tests prove:** nothing new directly — `resolveImageDigest` and
`buildAndPushCandidate` both shell out to `docker`, so they are exercised by the **real base-image build**
in the `pr-gate` job rather than mocked. The existing suite guards the surface it touches, and the digest
path is explicitly best-effort (it falls back to the tag), so it cannot fail the release on its own.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a `build-candidate` CLI that builds the base image once in CI, pushes a mutable candidate to GHCR, then resolves and records its immutable digest so all provider bakes pin the same bytes.

- **New Features**
  - New `build-candidate` bin: builds base (+ variants), pushes once, resolves digest via registry-side `docker buildx imagetools inspect` (no pull), and writes `digest` and `candidate-digest-ref` to `$GITHUB_OUTPUT`. Optional JSON metadata file when a path is passed (includes version and `GITHUB_SHA`). CI-only split; local dev still uses `bake --build-push`.
  - Added `resolveImageDigest`: parses the `Digest:` line from `imagetools inspect`. On inspect/parse failure, warns and records the tag. Build/push failures now log a single-line stderr error and exit non-zero.

<sup>Written for commit a44c8e7fa00c51555d407bb80506a779029d1775. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/starslingdev/sandbox-benchmarks/pull/156?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

