### PR TITLE
feat(cli): drive the release's gates and summaries through @actions/core

### DIFF
--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -23,6 +23,7 @@
     "bake": "bun src/bin/bake.ts"
   },
   "dependencies": {
+    "@actions/core": "1.11.1",
     "@sandbox-benchmarks/schema": "workspace:*",
     "@sandbox-benchmarks/providers": "workspace:*",
     "@sandbox-benchmarks/templates": "workspace:*",

--- a/apps/cli/src/bin/release-ensure-public.ts
+++ b/apps/cli/src/bin/release-ensure-public.ts
@@ -1,0 +1,78 @@
+#!/usr/bin/env bun
+// `release-ensure-public` — the script behind the `ensure-package-public` composite action. Fails fast
+// (with rich @actions/core annotations) if the candidate base package is not public. e2b builds its
+// template on E2B's REMOTE builder (FROM the ghcr candidate base) and daytona/modal/novita pull it to
+// snapshot/boot — none are handed ghcr pull credentials, so the candidate package MUST be public. GHCR
+// packages are created PRIVATE on first push with no API to flip visibility, so making it public is a
+// one-time manual bootstrap; this guard surfaces that plainly instead of an opaque provider pull error.
+//
+// Inputs arrive as env (the composite maps its `with:` inputs). Uses Bun's fetch + a real JSON parse
+// (not a curl+grep), and core.setFailed/warning so the outcome renders as a run annotation.
+import * as core from "@actions/core";
+
+const owner = process.env.OWNER?.trim() ?? "";
+const pkg = process.env.PACKAGE?.trim() ?? "";
+const token = process.env.GH_TOKEN?.trim() ?? "";
+
+// Refuse to run on a missing input rather than probing a malformed URL. With an empty OWNER/PACKAGE the
+// URL degenerates to `…/orgs//packages/container/`, which the API answers 404 — and 404 is the one
+// status this gate treats as a WARNING (the package legitimately may not exist yet). So a typo'd or
+// unwired composite input would make a SECURITY GATE pass silently while checking nothing at all.
+const inputs: Array<[name: string, value: string]> = [
+	["OWNER", owner],
+	["PACKAGE", pkg],
+	["GH_TOKEN", token],
+];
+const missing = inputs.filter(([, value]) => value.length === 0).map(([name]) => name);
+if (missing.length > 0) {
+	core.setFailed(
+		`release-ensure-public: missing required input(s): ${missing.join(", ")}. Refusing to run — an empty input would probe a malformed URL, 404, and let the public-package gate pass without checking anything.`,
+	);
+	process.exit(1);
+}
+
+const label = `${owner}/${pkg}`;
+const api = `https://api.github.com/orgs/${owner}/packages/container/${encodeURIComponent(pkg)}`;
+
+await core.group(`Ensure GHCR package ${label} is public`, async () => {
+	let res: Response;
+	try {
+		// Distinguish a real transport failure (throws) from an HTTP status (a 404/403 does NOT throw) —
+		// the whole point of the guard is not to publish blind on a swallowed error.
+		res = await fetch(api, {
+			headers: {
+				Authorization: `Bearer ${token}`,
+				Accept: "application/vnd.github+json",
+				"User-Agent": "sandbox-benchmarks-release",
+			},
+			signal: AbortSignal.timeout(30_000),
+		});
+	} catch (err) {
+		core.setFailed(
+			`Could not reach the GHCR package API (network/transport error) — refusing to publish blind: ${err instanceof Error ? err.message : String(err)}`,
+		);
+		return;
+	}
+
+	if (res.status === 200) {
+		const body = (await res.json().catch(() => ({}))) as { visibility?: string };
+		if (body.visibility === "public") {
+			core.info(`GHCR package ${label} is public — providers can pull the candidate.`);
+		} else {
+			core.error(
+				`GHCR package ${label} is ${body.visibility ?? "not public"}. e2b/daytona/modal/novita pull the candidate base anonymously, so set it Public once (org package settings or link it to this repo), then re-run.`,
+				{ title: "GHCR candidate package is not public" },
+			);
+			core.setFailed(`GHCR package ${label} is not public.`);
+		}
+	} else if (res.status === 404) {
+		core.warning(
+			`GHCR package ${label} not found yet — the build below creates it PRIVATE. After this run, set it Public once so the candidate validate and the providers can pull it; this run's bake will fail until then.`,
+			{ title: "GHCR candidate package not found yet" },
+		);
+	} else {
+		core.setFailed(
+			`GHCR package API returned HTTP ${res.status} (expected 200 or 404) — likely a token-scope gap or org SSO enforcement, not a missing package. Resolve and re-run instead of publishing blind.`,
+		);
+	}
+});

--- a/apps/cli/src/bin/release-summary.test.ts
+++ b/apps/cli/src/bin/release-summary.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, test } from "bun:test";
+import { escapeHtml, isFailure, renderCell } from "./release-summary.ts";
+
+describe("isFailure", () => {
+	// Both spellings are in circulation (GitHub's job.status says `failure`; the bake report and the
+	// composite's documented vocabulary say `failed`). Matching only one renders a FAILED phase as a
+	// green notice — the exact way a broken release looks healthy.
+	test("treats both `failure` and `failed` as failure", () => {
+		expect(isFailure("failure")).toBe(true);
+		expect(isFailure("failed")).toBe(true);
+		expect(isFailure("FAILED")).toBe(true);
+		expect(isFailure(" failure ")).toBe(true);
+	});
+
+	test("does not treat a success/skip status as failure", () => {
+		expect(isFailure("success")).toBe(false);
+		expect(isFailure("ok")).toBe(false);
+		expect(isFailure("skipped")).toBe(false);
+		expect(isFailure("")).toBe(false);
+	});
+});
+
+describe("escapeHtml", () => {
+	test("escapes the HTML metacharacters so a value can't inject into the summary table", () => {
+		expect(escapeHtml('<img src=x onerror=alert(1)> & "ok"')).toBe(
+			'&lt;img src=x onerror=alert(1)&gt; &amp; "ok"',
+		);
+	});
+
+	test("escapes & before < > so an entity can't be double-decoded", () => {
+		expect(escapeHtml("a & <b>")).toBe("a &amp; &lt;b&gt;");
+	});
+});
+
+describe("renderCell", () => {
+	test("wraps code values in <code> after escaping", () => {
+		expect(renderCell("ghcr.io/x@sha256:ab", "code")).toBe("<code>ghcr.io/x@sha256:ab</code>");
+	});
+
+	test("leaves plain prose unwrapped (still escaped)", () => {
+		expect(renderCell("2 vCPU / 8 GiB", "plain")).toBe("2 vCPU / 8 GiB");
+		expect(renderCell("<b>", "plain")).toBe("&lt;b&gt;");
+	});
+});

--- a/apps/cli/src/bin/release-summary.ts
+++ b/apps/cli/src/bin/release-summary.ts
@@ -1,0 +1,94 @@
+#!/usr/bin/env bun
+// `release-summary` — the script behind the `release-summary` composite action. Renders a consistent
+// per-phase job summary and a run annotation via @actions/core (GitHub's Actions Toolkit) instead of
+// hand-rolled `>> "$GITHUB_STEP_SUMMARY"` bash: core.summary owns the Markdown/HTML table + link, and
+// core.notice/core.error surface the phase result in the run's annotations panel. Inputs arrive as env
+// (the composite maps its `with:` inputs), NOT via core.getInput (that only works for JS/Docker actions).
+import * as core from "@actions/core";
+
+type Kind = "plain" | "code";
+
+/** Escape the HTML metacharacters so a value (an image ref, a command) can't break — or inject into —
+ *  the summary table. Pure + exported for unit testing. */
+export function escapeHtml(value: string): string {
+	return value.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
+}
+
+/** Render a table cell: `code` values are HTML-escaped and wrapped in `<code>`; `plain` prose is only
+ *  escaped. Pure + exported for unit testing. */
+export function renderCell(value: string, kind: Kind): string {
+	const escaped = escapeHtml(value);
+	return kind === "code" ? `<code>${escaped}</code>` : escaped;
+}
+
+/** Whether a phase `status` denotes failure. Accepts BOTH spellings in circulation: GitHub's own
+ *  `job.status` yields `failure`, while the bake report and this composite's documented vocabulary say
+ *  `failed`. Matching only one would render a failed phase as a green notice. Pure + exported. */
+export function isFailure(status: string): boolean {
+	const s = status.trim().toLowerCase();
+	return s === "failure" || s === "failed";
+}
+
+if (import.meta.main) {
+	const env = (key: string): string => process.env[key]?.trim() ?? "";
+	const phase = env("PHASE") || "release";
+	const status = env("STATUS");
+
+	// The field vocabulary, in display order. `code` fields (refs, commands, pointers) render monospaced.
+	const fields: Array<[label: string, value: string, kind: Kind]> = [
+		["Status", status, "plain"],
+		["Mode", env("MODE"), "code"],
+		["Source ref", env("SOURCE_REF"), "code"],
+		["Image", env("IMAGE"), "code"],
+		["Base image", env("BASE_IMAGE"), "code"],
+		["Provider target", env("PROVIDER_TARGET"), "code"],
+		["Size tier", env("SIZE_TIER"), "plain"],
+		["Verify command", env("VERIFY"), "code"],
+		["Published", env("PUBLISHED"), "code"],
+		["Elapsed", env("ELAPSED"), "plain"],
+	];
+
+	// A header row plus one row per non-empty field, so each phase shows only its own facts.
+	// Typed structurally as the (SummaryTableCell | string)[][] core.summary.addTable accepts.
+	const headerRow: Array<{ data: string; header: boolean } | string> = [
+		{ data: "Field", header: true },
+		{ data: "Value", header: true },
+	];
+	const rows = [
+		headerRow,
+		...fields
+			.filter(([, value]) => value.length > 0)
+			.map(([label, value, kind]) => [label, renderCell(value, kind)]),
+	];
+
+	// `addTable` escapes its cells, but `addHeading`/`addLink`/`addRaw` do NOT — @actions/core wraps the
+	// text in a tag and emits it verbatim. So every value reaching those three is escaped here by hand;
+	// otherwise a phase label or artifact name carrying HTML would inject into the job summary, which is
+	// the one release surface an operator reads and trusts.
+	core.summary.addHeading(`Image release: ${escapeHtml(phase)}`, 3).addTable(rows);
+
+	// Link the uploaded diagnostics artifact to the run's artifacts, so an operator can jump straight there.
+	const diagnostics = env("DIAGNOSTICS");
+	const runUrl = env("RUN_URL");
+	if (diagnostics) {
+		core.summary.addRaw("Diagnostics: ", false);
+		if (runUrl) core.summary.addLink(escapeHtml(diagnostics), `${runUrl}#artifacts`);
+		else core.summary.addRaw(escapeHtml(diagnostics));
+		core.summary.addEOL();
+	}
+
+	await core.summary.write();
+
+	// Surface the phase result in the run's annotations panel (grouped/filterable), not just the log.
+	const title = `Image release: ${phase}${status ? ` — ${status}` : ""}`;
+	const detail =
+		[env("IMAGE") && `image=${env("IMAGE")}`, env("PUBLISHED") && `published=${env("PUBLISHED")}`]
+			.filter(Boolean)
+			.join(" · ") || phase;
+	// Both spellings mean the same thing and both are in circulation: GitHub's own `job.status` yields
+	// `failure`, while the bake report (and this composite's documented vocabulary) says `failed`. Match
+	// on either — a release phase that FAILED must never render as a green notice because the caller
+	// picked the other word.
+	if (isFailure(status)) core.error(detail, { title });
+	else core.notice(detail, { title });
+}

--- a/apps/cli/src/bin/release-validate.ts
+++ b/apps/cli/src/bin/release-validate.ts
@@ -1,0 +1,36 @@
+#!/usr/bin/env bun
+// `release-validate` — the script behind the `release-validate-inputs` composite action: the
+// credential-free fail-fast gate. Validates the toolchain pins and the dispatch inputs BEFORE any
+// registry/provider credential is introduced, and reports failures as rich @actions/core annotations
+// (a pin failure is annotated ON the pins source file, so the run's "Files changed" view links to it).
+// Inputs arrive as env (the composite maps its `with:` inputs).
+import * as core from "@actions/core";
+import { validatedPins } from "@sandbox-benchmarks/templates/pins";
+
+// The arktype pin gatekeeper lives here; annotate failures on it so the run links straight to the pins.
+const PINS_FILE = "packages/templates/src/lib/pins.ts";
+
+// A dispatch input reaches the release as an env var; still, reject anything but the two booleans so a
+// hand-typed dispatch value can't slip through as a surprise "truthy" string downstream.
+const forceRepublish = process.env.FORCE_REPUBLISH ?? "";
+if (!["true", "false", ""].includes(forceRepublish)) {
+	core.error(`force_republish must be true or false (got '${forceRepublish}').`, {
+		title: "Invalid dispatch input",
+	});
+	core.setFailed("Invalid force_republish input.");
+}
+
+// Re-run the arktype pin gatekeeper (hex sha256s, non-empty versions); an unfilled/invalid pin fails the
+// release here, before it spends a build. On failure, annotate the exact source file.
+await core.group("Validate toolchain pins", async () => {
+	try {
+		validatedPins();
+		core.info("Toolchain pins valid.");
+	} catch (err) {
+		core.error(err instanceof Error ? err.message : String(err), {
+			title: "Toolchain pin validation failed",
+			file: PINS_FILE,
+		});
+		core.setFailed("Toolchain pin validation failed — see the annotation on the pins file.");
+	}
+});

--- a/bun.lock
+++ b/bun.lock
@@ -28,6 +28,7 @@
         "leaderboard": "./src/bin/leaderboard.ts",
       },
       "dependencies": {
+        "@actions/core": "1.11.1",
         "@daytona/api-client": "catalog:computesdk",
         "@daytona/sdk": "catalog:computesdk",
         "@sandbox-benchmarks/harness": "workspace:*",
@@ -177,6 +178,14 @@
     },
   },
   "packages": {
+    "@actions/core": ["@actions/core@1.11.1", "", { "dependencies": { "@actions/exec": "^1.1.1", "@actions/http-client": "^2.0.1" } }, "sha512-hXJCSrkwfA46Vd9Z3q4cpEpHB1rL5NG04+/rbqW9d3+CSvtB1tYe8UTpAlixa1vj0m/ULglfEK2UKxMGxCxv5A=="],
+
+    "@actions/exec": ["@actions/exec@1.1.1", "", { "dependencies": { "@actions/io": "^1.0.1" } }, "sha512-+sCcHHbVdk93a0XT19ECtO/gIXoxvdsgQLzb2fE2/5sIZmWQuluYyjPQtrtTHdU1YzTZ7bAPN4sITq2xi1679w=="],
+
+    "@actions/http-client": ["@actions/http-client@2.2.3", "", { "dependencies": { "tunnel": "^0.0.6", "undici": "^5.25.4" } }, "sha512-mx8hyJi/hjFvbPokCg4uRd4ZX78t+YyRPtnKWwIl+RzNaVuFpQHfmlGVfsKEJN8LwTCvL+DfVgAM04XaHkm6bA=="],
+
+    "@actions/io": ["@actions/io@1.1.3", "", {}, "sha512-wi9JjgKLYS7U/z8PPbco+PvTb/nRWjeoFlJ1Qer83k/3C5PHQi28hiVdeE2kHXmIL99mQFawx8qt/JPjZilJ8Q=="],
+
     "@ark/schema": ["@ark/schema@0.56.0", "", { "dependencies": { "@ark/util": "0.56.0" } }, "sha512-ECg3hox/6Z/nLajxXqNhgPtNdHWC9zNsDyskwO28WinoFEnWow4IsERNz9AnXRhTZJnYIlAJ4uGn3nlLk65vZA=="],
 
     "@ark/util": ["@ark/util@0.56.0", "", {}, "sha512-BghfRC8b9pNs3vBoDJhcta0/c1J1rsoS1+HgVUreMFPdhz/CRAKReAu57YEllNaSy98rWAdY1gE+gFup7OXpgA=="],
@@ -294,6 +303,8 @@
     "@daytona/toolbox-api-client": ["@daytona/toolbox-api-client@0.192.0", "", { "dependencies": { "axios": "^1.6.1" } }, "sha512-fEyA3YPK+IJezECBfZoNhf29qtZhy8AqI0lcgR+Bob6hEiInx9+sH26506ZkxmpGM4/5EApeLzUI1g5B9u2XHA=="],
 
     "@daytonaio/sdk": ["@daytona/sdk@0.192.0", "", { "dependencies": { "@aws-sdk/client-s3": "^3.787.0", "@aws-sdk/lib-storage": "^3.798.0", "@daytona/api-client": "0.192.0", "@daytona/toolbox-api-client": "0.192.0", "@iarna/toml": "^2.2.5", "@opentelemetry/api": "^1.9.0", "@opentelemetry/exporter-trace-otlp-http": "^0.217.0", "@opentelemetry/instrumentation-http": "^0.217.0", "@opentelemetry/otlp-exporter-base": "0.217.0", "@opentelemetry/resources": "2.7.1", "@opentelemetry/sdk-node": "^0.217.0", "@opentelemetry/sdk-trace-base": "^2.7.1", "@opentelemetry/semantic-conventions": "^1.40.0", "axios": "^1.15.2", "busboy": "^1.0.0", "dotenv": "^17.0.1", "expand-tilde": "^2.0.2", "fast-glob": "^3.3.0", "form-data": "^4.0.4", "isomorphic-ws": "^5.0.0", "pathe": "^2.0.3", "shell-quote": "^1.8.2", "tar": "^7.5.11" } }, "sha512-pAA1curJCiZ0rqZcE0BUIjsgS90QdDFZ2QYw8nVWwGjjdr+Fndof4MaJfoZRjpcMHjUBoqEZpzO9C5HPv38QeA=="],
+
+    "@fastify/busboy": ["@fastify/busboy@2.1.1", "", {}, "sha512-vBZP4NlzfOlerQTnba4aqZoMhE/a9HY7HRqoOPaETQcSQuWEIyZMHGfVu6w9wGtGK5fED5qRs2DteVCjOH60sA=="],
 
     "@grpc/grpc-js": ["@grpc/grpc-js@1.14.4", "", { "dependencies": { "@grpc/proto-loader": "^0.8.0", "@js-sdsl/ordered-map": "^4.4.2" } }, "sha512-k9Dj3DV/itK9D06Y8f190Qgop7/Ui+D0njFV3LHMPwPT75DpXLQohE9Wmz0QElrJnzsjB7KPWiKJbOl7IPDArQ=="],
 
@@ -1035,11 +1046,13 @@
 
     "tslib": ["tslib@2.8.1", "", {}, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
 
+    "tunnel": ["tunnel@0.0.6", "", {}, "sha512-1h/Lnq9yajKY2PEbBadPXj3VxsDDu844OnaAo52UVmIzIvwwtBPIuNvkjuzBlTWpfJyUbG3ez0KSBibQkj4ojg=="],
+
     "type-is": ["type-is@2.1.0", "", { "dependencies": { "content-type": "^2.0.0", "media-typer": "^1.1.0", "mime-types": "^3.0.0" } }, "sha512-faYHw0anBbc/kWF3zFTEnxSFOAGUX9GFbOBthvDdLsIlEoWOFOtS0zgCiQYwIskL9iGXZL3kAXD8OoZ4GmMATA=="],
 
     "typescript": ["typescript@6.0.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw=="],
 
-    "undici": ["undici@7.27.2", "", {}, "sha512-uZsKNuzQxDMUY6M3pIMvy5tvlGmtq8XJ2oLAkfRKGNu+1VQAIvLy2xIVG5ATZl5wDXl/tddByAWCizRbOme+TA=="],
+    "undici": ["undici@5.29.0", "", { "dependencies": { "@fastify/busboy": "^2.0.0" } }, "sha512-raqeBD6NQK4SkWhQzeYKd1KmIG6dllBOTt55Rmkt4HtI9mwdWtJljnrXjAFUBLTSN67HWrOIZ3EPF4kjUw80Bg=="],
 
     "undici-types": ["undici-types@7.24.6", "", {}, "sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg=="],
 
@@ -1106,6 +1119,8 @@
     "compress-commons/readable-stream": ["readable-stream@4.7.0", "", { "dependencies": { "abort-controller": "^3.0.0", "buffer": "^6.0.3", "events": "^3.3.0", "process": "^0.11.10", "string_decoder": "^1.3.0" } }, "sha512-oIGGmcpTLwPga8Bn6/Z75SVaH1z5dUut2ibSyAMVhmUggWpmDn2dapB0n7f8nwaSiRtepAsfJyfXIO5DCVAODg=="],
 
     "crc32-stream/readable-stream": ["readable-stream@4.7.0", "", { "dependencies": { "abort-controller": "^3.0.0", "buffer": "^6.0.3", "events": "^3.3.0", "process": "^0.11.10", "string_decoder": "^1.3.0" } }, "sha512-oIGGmcpTLwPga8Bn6/Z75SVaH1z5dUut2ibSyAMVhmUggWpmDn2dapB0n7f8nwaSiRtepAsfJyfXIO5DCVAODg=="],
+
+    "e2b/undici": ["undici@7.27.2", "", {}, "sha512-uZsKNuzQxDMUY6M3pIMvy5tvlGmtq8XJ2oLAkfRKGNu+1VQAIvLy2xIVG5ATZl5wDXl/tddByAWCizRbOme+TA=="],
 
     "express/mime-types": ["mime-types@3.0.2", "", { "dependencies": { "mime-db": "^1.54.0" } }, "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A=="],
 


### PR DESCRIPTION
Three bins that report through GitHub's Actions Toolkit instead of hand-rolled bash, so the release
surfaces its outcome as real run annotations and job summaries rather than log grep. Adds
`@actions/core` (the dependency all three share) with the lockfile, so `--frozen-lockfile` stays
consistent.

`release-validate` — the credential-free fail-fast gate. Validates the toolchain pins and the dispatch
inputs BEFORE any registry/provider credential is introduced. A pin failure is annotated ON the pins
source file, so the run's "Files changed" view links straight to it. It also rejects any
`force_republish` value that isn't a boolean, so a hand-typed dispatch value can't slip through as a
surprise truthy string downstream.

`release-summary` — one consistent per-phase table (mode, image, base, provider target, size tier,
verify command, published pointer, diagnostics, elapsed) plus a run annotation, so an operator reads
the same shape across build/bake/promote. Empty rows are omitted, so each phase shows only its own
facts. Values are HTML-escaped before rendering — an image ref or command can't break, or inject
into, the summary table — and `escapeHtml`/`renderCell` are pure and unit-tested (& is escaped before
< > so an entity can't be double-decoded).

`release-ensure-public` — fails fast if the candidate base package is not public. e2b builds its
template on E2B's REMOTE builder (FROM the ghcr candidate base) and daytona/modal/novita pull it to
snapshot/boot — none are handed ghcr pull credentials, so the candidate MUST be public. GHCR packages
are created PRIVATE on first push with no API to flip visibility, making this a one-time manual
bootstrap; the guard surfaces that plainly instead of an opaque provider "unauthorized" pull error.
It uses a real fetch + JSON parse (not curl+grep) and distinguishes a transport failure from an HTTP
status, so it never publishes blind on a swallowed error.

Inputs arrive as env, not core.getInput — that only works for JS/Docker actions, and these are shelled
out from composite `run` steps, which get no INPUT_* vars. The composites and the workflow that call
them land further up the stack.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switch release gates and summaries to GitHub Actions Toolkit so results show as clear run annotations and job summaries instead of brittle log parsing.

- **New Features**
  - `release-validate`: Fail-fast gate that validates toolchain pins and rejects non-boolean `force_republish`. Annotates failures on the pins source file.
  - `release-summary`: Per-phase summary table and run annotation. Omits empty fields, HTML-escapes values, links diagnostics, unit-tests `escapeHtml`, `renderCell`, and `isFailure` (treats both “failure” and “failed”), and adds “Status” and “Source ref” fields.
  - `release-ensure-public`: Verifies the GHCR candidate package is public before publish. Fails on missing inputs, distinguishes network errors from HTTP statuses, and warns on 404.

- **Dependencies**
  - Added `@actions/core@1.11.1` and updated the lockfile to keep `--frozen-lockfile` stable.

<sup>Written for commit 5c8295c28c335d44a1d984f7b0f1a69d562c731c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/starslingdev/sandbox-benchmarks/pull/157?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

