### PR TITLE
feat(ci): composite actions for the release's shared preamble and gates

### DIFF
--- a/.github/actions/ensure-package-public/action.yml
+++ b/.github/actions/ensure-package-public/action.yml
@@ -1,0 +1,32 @@
+name: Ensure GHCR package is public
+description: >-
+  Fail fast (with @actions/core annotations, via release-ensure-public.ts) if the candidate base package
+  is not public. e2b builds its template on E2B's REMOTE builder (FROM the ghcr candidate base) and
+  daytona/modal/novita pull it to snapshot/boot — none are handed ghcr pull credentials, so the candidate
+  package MUST be public. GHCR packages are created PRIVATE on first push with no API to flip visibility,
+  so making it public is a one-time manual bootstrap; this guard surfaces that plainly instead of an
+  opaque provider "unauthorized" pull error.
+
+inputs:
+  owner:
+    description: The GHCR package owner (org).
+    required: true
+  package:
+    description: The container package name.
+    required: true
+  token:
+    description: A token with read:packages for the GHCR package API.
+    required: true
+
+runs:
+  using: composite
+  steps:
+    - name: Ensure candidate package is public
+      shell: bash
+      # Inputs reach the script as env (a composite `run` step gets no INPUT_* vars). The script does a
+      # real fetch + JSON parse and reports via core.setFailed/warning so the outcome is a run annotation.
+      env:
+        OWNER: ${{ inputs.owner }}
+        PACKAGE: ${{ inputs.package }}
+        GH_TOKEN: ${{ inputs.token }}
+      run: bun apps/cli/src/bin/release-ensure-public.ts

--- a/.github/actions/ghcr-login/action.yml
+++ b/.github/actions/ghcr-login/action.yml
@@ -1,0 +1,26 @@
+name: GHCR session
+description: >-
+  Log in to the GitHub Container Registry with a pinned docker/login-action. Isolated so the privileged
+  registry session is introduced by exactly the jobs that push/retag/inspect images — never in shared
+  setup — and always after third-party tooling is installed.
+
+inputs:
+  token:
+    description: "Registry password (the job's GITHUB_TOKEN; the caller scopes packages read/write)."
+    required: true
+  registry:
+    description: Container registry host.
+    default: ghcr.io
+  username:
+    description: Registry username.
+    default: ${{ github.actor }}
+
+runs:
+  using: composite
+  steps:
+    - name: Log in to the container registry
+      uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
+      with:
+        registry: ${{ inputs.registry }}
+        username: ${{ inputs.username }}
+        password: ${{ inputs.token }}

--- a/.github/actions/release-summary/action.yml
+++ b/.github/actions/release-summary/action.yml
@@ -1,0 +1,68 @@
+name: Release summary
+description: >-
+  Append a consistent, machine-checkable phase table to the job summary and surface the phase result as
+  a run annotation, via @actions/core (release-summary.ts). Every release job calls this with the same
+  field vocabulary (mode, image, base, provider target, size tier, verify command, published pointer,
+  diagnostics, elapsed) so an operator reads one shape across build/bake/promote. Rows with an empty
+  value are omitted, so each phase shows only its own facts.
+
+inputs:
+  phase:
+    description: 'Phase label, e.g. "e2b/bake" or "publish".'
+    required: true
+  status:
+    description: Phase status (ok / failed / skipped / success / failure).
+    default: ""
+  mode:
+    description: Release mode (build / republish).
+    default: ""
+  source-ref:
+    description: The source ref the release is cut from (github.sha).
+    default: ""
+  image:
+    description: The image ref (repo@sha256:… when a digest is known, else the tag).
+    default: ""
+  base-image:
+    description: The base image the artifact derives from.
+    default: ""
+  provider-target:
+    description: The provider region / workspace / template the artifact targets.
+    default: ""
+  size-tier:
+    description: The cpu/memory/disk size tier.
+    default: ""
+  verify:
+    description: The exact verify command an operator can rerun locally.
+    default: ""
+  published:
+    description: The published pointer (tag / snapshot / template) this phase advanced.
+    default: ""
+  diagnostics:
+    description: The name of the uploaded diagnostics artifact for this phase.
+    default: ""
+  elapsed:
+    description: Elapsed wall time for the phase.
+    default: ""
+
+runs:
+  using: composite
+  steps:
+    - name: Append phase summary
+      shell: bash
+      # Inputs reach the script as env (a composite `run` step gets no INPUT_* vars); the script owns the
+      # core.summary table + run annotation. RUN_URL links the diagnostics artifact to this run.
+      env:
+        PHASE: ${{ inputs.phase }}
+        STATUS: ${{ inputs.status }}
+        MODE: ${{ inputs.mode }}
+        SOURCE_REF: ${{ inputs.source-ref }}
+        IMAGE: ${{ inputs.image }}
+        BASE_IMAGE: ${{ inputs.base-image }}
+        PROVIDER_TARGET: ${{ inputs.provider-target }}
+        SIZE_TIER: ${{ inputs.size-tier }}
+        VERIFY: ${{ inputs.verify }}
+        PUBLISHED: ${{ inputs.published }}
+        DIAGNOSTICS: ${{ inputs.diagnostics }}
+        ELAPSED: ${{ inputs.elapsed }}
+        RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+      run: bun apps/cli/src/bin/release-summary.ts

--- a/.github/actions/release-validate-inputs/action.yml
+++ b/.github/actions/release-validate-inputs/action.yml
@@ -1,0 +1,21 @@
+name: Validate release inputs
+description: >-
+  The credential-free fail-fast gate (release-validate.ts): validate the toolchain pins and the dispatch
+  inputs BEFORE any registry/provider credential is introduced, reporting failures as @actions/core
+  annotations (a pin failure is annotated ON the pins source file). Runs after setup-toolchain (needs
+  Bun + deps) but before ghcr-login, so a bad pin or a malformed input fails the release without creds.
+
+inputs:
+  force-republish:
+    description: The force_republish dispatch input (regenerate an already-published version in place).
+    default: "false"
+
+runs:
+  using: composite
+  steps:
+    - name: Validate pins and dispatch inputs
+      shell: bash
+      # Input reaches the script as env (a composite `run` step gets no INPUT_* vars).
+      env:
+        FORCE_REPUBLISH: ${{ inputs.force-republish }}
+      run: bun apps/cli/src/bin/release-validate.ts

--- a/.github/actions/setup-toolchain/action.yml
+++ b/.github/actions/setup-toolchain/action.yml
@@ -1,0 +1,36 @@
+name: Set up toolchain
+description: >-
+  Bun + dependencies (optionally Docker Buildx) — the setup preamble every toolchain-image job shares
+  after its checkout. Third-party tooling installs BEFORE any cloud credential is introduced, so a
+  credentialed job's setup stays credential-free (the release's credential-minimization posture).
+
+  NOTE: this composite deliberately does NOT run actions/checkout. A local action (`./.github/actions/…`)
+  is read from the workspace, so the repo must already be checked out before this action can run — the
+  caller keeps an explicit `actions/checkout` as its first step (which also keeps each job's
+  persist-credentials posture visible to zizmor).
+
+inputs:
+  buildx:
+    description: Set up Docker Buildx (only the jobs that build/retag images need it).
+    default: "false"
+
+runs:
+  using: composite
+  steps:
+    # Third-party actions are pinned to a commit SHA (the tag comment is for humans) so a moved or
+    # compromised tag can't silently change what runs — the repo-wide supply-chain posture.
+    - name: Set up Bun
+      uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
+      with:
+        bun-version: 1.3.14
+        # This runner's setup-bun cache restores without a working ~/.bun/bin/bun, so a cache hit
+        # fails the "Set up Bun" step. Always download bun fresh instead of restoring the cache.
+        no-cache: true
+
+    - name: Install dependencies
+      shell: bash
+      run: bun install --frozen-lockfile --ignore-scripts
+
+    - name: Set up Docker Buildx
+      if: ${{ inputs.buildx == 'true' }}
+      uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4.1.0


### PR DESCRIPTION
Five composite actions the staged toolchain release shares, so five jobs don't each re-inline the
same setup and reporting. Each is a thin wrapper: the composites own the YAML plumbing, the bins below
own the logic (thin workflow, fat CLI).

`setup-toolchain` — Bun + deps, optionally Docker Buildx (only the jobs that build/retag images ask
for it). It deliberately does NOT run actions/checkout: a local action is read from the workspace, so
the repo must already be checked out before the action can run. Each caller keeps an explicit
checkout as its first step, which also keeps its persist-credentials posture visible to zizmor.

`ghcr-login` — the registry session, isolated so the privileged login is introduced by exactly the
jobs that push/retag/inspect images, never in shared setup, and always AFTER third-party tooling is
installed. That ordering is the release's credential-minimization posture: a credentialed job's setup
stays credential-free.

`release-validate-inputs`, `ensure-package-public`, `release-summary` — wrappers over the bins added
below. Inputs reach each script as env, because a composite `run` step gets no INPUT_* vars.

Third-party actions inside the composites are commit-SHA-pinned (the tag comment is for humans), per
the repo-wide supply-chain posture.

Nothing invokes these yet; the workflow that calls them is the next PR.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds five composite GitHub Actions to DRY release setup, gate inputs early, and standardize phase reporting while minimizing credential exposure. Callers will be wired up in a follow-up PR.

- **New Features**
  - `setup-toolchain`: Installs Bun and deps; optional Docker Buildx; deliberately no `actions/checkout`.
  - `ghcr-login`: Isolated GHCR session via pinned `docker/login-action`; runs only in image jobs, after tooling; defaults to `ghcr.io` and `${{ github.actor }}`.
  - `release-validate-inputs`: Credential-free gate; validates toolchain pins and dispatch inputs after setup and before login; annotates failures with `@actions/core`.
  - `ensure-package-public`: Fails fast if the candidate GHCR base package is private; requires a `read:packages` token.
  - `release-summary`: Appends a consistent phase table and a run annotation (phase, status, mode, source-ref, image, base, provider target, size tier, verify, published, diagnostics, elapsed); omits empty fields.
  - Third-party actions are commit-SHA pinned; `oven-sh/setup-bun` cache disabled; Bun pinned to 1.3.14.

<sup>Written for commit 354d280a06e8d74f034e6d570883cf362e107eb5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/starslingdev/sandbox-benchmarks/pull/158?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

