### PR TITLE
refactor(ci): stage the toolchain release into plan → build → bake matrix → promote

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -1,7 +1,12 @@
-# actionlint configuration. The only custom entry is the self-hosted runner label every CI job
-# targets: `starsling-ubuntu-24.04-2` is registered at the org (starslingdev) level, not in
-# actionlint's built-in label set, so without this entry actionlint flags every `runs-on:` as an
-# unknown label. Keep this list in sync with the labels used across .github/workflows/.
+# actionlint configuration. The only custom entries are the self-hosted runner labels CI jobs target:
+# these are registered at the org (starslingdev) level, not in actionlint's built-in label set, so
+# without them actionlint flags every `runs-on:` as an unknown label. Keep this list in sync with the
+# labels used across .github/workflows/.
+#
+# `-2` is the default for the I/O-bound majority of jobs; `-16` is for the jobs whose wall time is
+# dominated by a parallel compile (the toolchain base-image build, where PTS builds its benchmark
+# profiles from source).
 self-hosted-runner:
   labels:
     - starsling-ubuntu-24.04-2
+    - starsling-ubuntu-24.04-16

--- a/.github/workflows/toolchain-image.yml
+++ b/.github/workflows/toolchain-image.yml
@@ -1,19 +1,35 @@
 name: Toolchain image
 
-# Build, validate, and publish the sandbox-benchmarks toolchain. Two lanes:
+# Build, validate, and publish the sandbox-benchmarks toolchain — staged as a release pipeline rather
+# than one monolithic job. Two lanes:
 #   • Pull requests — build the base (no push) and run the docker smoke. Fast gate, no credentials.
-#   • Manual dispatch on main (GitHub Environment `privileged`) — build + push the mutable
-#     CANDIDATE (:v1-candidate), bake each provider's candidate artifact and validate it by booting a
-#     sandbox and running the shared smoke spec (behind each provider's secret; missing ones skip),
-#     then promote the validated candidate to the immutable public :v1. Iteration never touches :v1;
-#     bump TOOLCHAIN_VERSION (packages/schema/src/toolchain.ts) to publish a new version.
+#   • Manual dispatch on main (GitHub Environment `privileged`) — the release phases: PLAN → BUILD
+#     candidate → BAKE + verify each provider (a matrix, one cell per provider) → PROMOTE the validated
+#     candidate to the immutable public :v1. Iteration never touches :v1; bump TOOLCHAIN_VERSION
+#     (packages/schema/src/toolchain.ts) to publish a new version.
 #
-# Releases never fire on push/merge: only workflow_dispatch reaches the publish job, and that job
-# requires Environment `privileged` approval so the public cannot complete a release.
+# Releases never fire on push/merge: only workflow_dispatch reaches the publish lane, and every
+# credentialed job runs behind Environment `privileged` (reviewer approval) so the public cannot
+# complete a release.
+#
+# Phase split (needs edges only where an artifact is required, so build/bake work runs in parallel and
+# the ONLY serialized section is the promote transaction):
+#
+#   plan ──> build ──> bake (matrix: provider × required) ──> publish
+#     │        │                                                  ▲
+#     └── emits release-plan.json; every downstream job consumes  │
+#         the plan (mode, refs, provider matrix, gates) rather    │
+#         than re-reading the raw workflow inputs. ───────────────┘
+#
+# Cross-cutting GitHub Actions mechanics live in .github/actions/* composites (setup, ghcr login,
+# input validation, package-visibility guard, summaries); provider bake/verify/promote logic lives in
+# the package scripts under apps/cli (thin YAML, fat scripts). There is no OIDC here — GHCR auth is the
+# job's GITHUB_TOKEN — so no job needs id-token: write.
 on:
-  # Manual publish (e.g. after bumping TOOLCHAIN_VERSION). `force_republish` deliberately regenerates
-  # an existing version for fast iteration. Normally, to republish you bump TOOLCHAIN_VERSION; an
-  # already-published version is skipped at the guard below unless force_republish is set.
+  # Manual publish (e.g. after bumping TOOLCHAIN_VERSION). The public version is immutable;
+  # `force_republish` deliberately regenerates it over an existing version for fast dev iteration.
+  # Normally, to republish you bump TOOLCHAIN_VERSION; an already-published version is skipped by the
+  # plan phase unless force_republish is set.
   workflow_dispatch:
     inputs:
       force_republish:
@@ -25,6 +41,7 @@ on:
       - "packages/templates/**"
       - "packages/schema/src/toolchain.ts"
       - ".github/workflows/toolchain-image.yml"
+      - ".github/actions/**"
 
 # Serialize publishes by ref: concurrent dispatches on the same ref must not race on the version tag.
 # PR runs key off their own head ref (separate group) and may cancel superseded runs; a publish is
@@ -33,39 +50,55 @@ concurrency:
   group: toolchain-image-${{ github.ref }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
+# Least privilege, global default: read-only. Only build and promote widen to packages: write; plan
+# widens to packages: read (the immutability probe + package-visibility guard); bake needs neither
+# (providers pull the public candidate anonymously).
 permissions:
   contents: read
 
+env:
+  # Only IMAGE_OWNER is consumed (ensure-package-public's `owner`). The former REGISTRY host is owned by
+  # the ghcr-login composite default and imageRepo(), so it's not re-declared here.
+  IMAGE_OWNER: starslingdev
+
 jobs:
+  # ── PR lane ──────────────────────────────────────────────────────────────────────────────────────
   # Fast PR gate: prove the base image still builds and the toolchain is complete, without pushing or
   # touching any provider. Uses the same shared smoke spec as the in-sandbox bake validation.
   #
   # Same-repo guard: this job checks out the PR head and runs scripts FROM that checkout (build.sh,
   # smoke.ts) on a self-hosted runner, so a fork PR could execute arbitrary code on the runner itself.
-  # Gate on same-repo head as defense-in-depth. Branches pushed to this repo satisfy it; a fork-based
-  # PR skips the gate and needs a maintainer to re-run from an in-repo branch.
+  # The repo is private (no untrusted forks today), but we gate on same-repo head as defense-in-depth
+  # against a compromised account / outside-collaborator fork.
   pr-gate:
     name: Build base + docker smoke
     if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
-    runs-on: starsling-ubuntu-24.04-2
+    # 16 cores, not the repo-standard 2: this job runs a real base-image build, whose dominant cost is
+    # `phoronix-test-suite batch-install` compiling the benchmark profiles from source. That compile is
+    # embarrassingly parallel (the PTS profile installers build with `make -j$(nproc)`), so it scales
+    # with cores where the rest of the release — which only waits on registries and provider APIs — does
+    # not. Only this job and `build` do local compute; the others stay on the 2-core standard.
+    runs-on: starsling-ubuntu-24.04-16
+    # Every job caps its wall time. The default is GitHub's 6-hour ceiling, and each of these jobs makes
+    # calls that can hang rather than fail (a registry pull, a provider SDK, a remote builder) — a hang
+    # would otherwise hold a self-hosted runner for hours. Sized to a few times the observed run.
+    timeout-minutes: 30
     steps:
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           # Builds and smokes the image locally — no git push, so don't persist the job token.
           persist-credentials: false
-      - name: Set up Bun
-        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
+      - name: Set up toolchain
+        uses: ./.github/actions/setup-toolchain
         with:
-          bun-version: 1.3.14
-          # This runner's setup-bun cache restores without a working ~/.bun/bin/bun, so a cache hit
-          # fails the "Set up Bun" step. Always download bun fresh instead of restoring the cache.
-          no-cache: true
-      - name: Install dependencies
-        run: bun install --frozen-lockfile --ignore-scripts
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
+          buildx: "true"
       - name: Build base (no push) + docker smoke
+        # Hand build.sh the job's own read-only token so mise's tool-release lookups hit GitHub's
+        # authenticated rate limit (5000/h) instead of the anonymous 60/h that flakes the base build.
+        # GITHUB_TOKEN is a built-in (not a custom secret), so this needs no `environment: privileged`.
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           set -euo pipefail
           name="$(bun packages/templates/src/pins.ts | sed -n 's/^IMAGE_NAME=//p')"
@@ -75,178 +108,347 @@ jobs:
           # (not swallowed inside docker's command substitution, which would smoke an empty script).
           smoke_script="$(bun packages/templates/src/smoke.ts --bash)"
           docker run --rm "${name}:dev" bash -lc "$smoke_script"
+      - name: Release summary
+        if: always()
+        uses: ./.github/actions/release-summary
+        with:
+          phase: pr-gate
+          status: ${{ job.status }}
+          mode: pr-gate
+          source-ref: ${{ github.sha }}
+          verify: bash packages/templates/images/build.sh
 
-  # Publish lane: candidate → validate → promote. Thin wrapper over the bake bin (thin workflow, fat
-  # script). Provider steps are guarded by their secrets inside the bin (missing creds skip).
-  # Environment `privileged` holds provider secrets and requires reviewer approval on main only —
-  # see docs/ci-secrets.md.
-  publish:
-    name: Bake, validate & promote toolchain
+  # ── Release lane ─────────────────────────────────────────────────────────────────────────────────
+  # PLAN: validate inputs/pins (credential-free), then resolve identity and emit ONE release plan that
+  # every downstream job consumes. The plan decides `skip` (immutable version already published and not
+  # force_republish) and the provider matrix. Emits release-plan.json as a diagnostic artifact.
+  plan:
+    name: Plan release
+    # Dispatch-only release lane (no push trigger): confine the whole pipeline to a manual dispatch on
+    # main of this repo. Every downstream job `needs` plan, so a skipped plan skips build/bake/publish too.
     if: >
       github.event_name == 'workflow_dispatch' &&
       github.ref == 'refs/heads/main' &&
       github.repository == 'starslingdev/sandbox-benchmarks'
     runs-on: starsling-ubuntu-24.04-2
-    environment: privileged
+    # Validation + one registry probe; it should take a minute. A hang means the registry is wedged.
+    timeout-minutes: 15
     permissions:
       contents: read
-      packages: write
-    env:
-      REGISTRY: ghcr.io
-      IMAGE_OWNER: starslingdev
+      packages: read
+    outputs:
+      skip: ${{ steps.plan.outputs.skip }}
+      mode: ${{ steps.plan.outputs.mode }}
+      matrix: ${{ steps.plan.outputs.matrix }}
+      required: ${{ steps.plan.outputs.required }}
+      size-tier: ${{ steps.plan.outputs.size-tier }}
+      image-candidate: ${{ steps.plan.outputs.image-candidate }}
+      toolchain-version: ${{ steps.plan.outputs.toolchain-version }}
+      publish-target: ${{ steps.plan.outputs.publish-target }}
     steps:
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
-          # Publishes to GHCR via docker/login-action (the GITHUB_TOKEN below), never `git push`, so
-          # the checkout's own credentials aren't needed — don't persist the job token.
+          # Reads code and probes the registry via docker/login — never git push.
           persist-credentials: false
-      - name: Set up Bun
-        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
+      - name: Set up toolchain
+        uses: ./.github/actions/setup-toolchain
+      # Fail-fast, credential-free: validate pins + the dispatch input BEFORE the registry login below.
+      - name: Validate release inputs
+        uses: ./.github/actions/release-validate-inputs
         with:
-          bun-version: 1.3.14
-          # This runner's setup-bun cache restores without a working ~/.bun/bin/bun, so a cache hit
-          # fails the "Set up Bun" step. Always download bun fresh instead of restoring the cache.
-          no-cache: true
-      - name: Install dependencies
-        run: bun install --frozen-lockfile --ignore-scripts
-      # Daytona's remote-registry snapshot paths reject this otherwise valid public GHCR image. The
-      # bake code uses Daytona's transient-registry API instead, with Buildx providing the immutable
-      # source digest and Docker copying those exact bytes into the transient registry.
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
-      - name: Log in to the container registry
-        uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0 # v4.4.0
+          force-republish: ${{ inputs.force_republish }}
+      # The one privileged step in plan: the immutability probe (`docker manifest inspect`) needs a
+      # GHCR session. GITHUB_TOKEN with packages: read suffices.
+      - name: GHCR session
+        uses: ./.github/actions/ghcr-login
         with:
-          registry: ${{ env.REGISTRY }}
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      # Resolve identity from the arktype-validated TS config; `bun pins.ts` also validates every pin
-      # and exits non-zero on any unfilled/invalid one (the early fail-fast gate).
-      - name: Resolve identity & validate pins
-        run: |
-          set -euo pipefail
-          pins="$(bun packages/templates/src/pins.ts)"
-          name="$(echo "${pins}" | sed -n 's/^IMAGE_NAME=//p')"
-          version="$(echo "${pins}" | sed -n 's/^IMAGE_VERSION=//p')"
-          {
-            echo "IMAGE_NAME=${name}"
-            echo "IMAGE_VERSION=${version}"
-            echo "VERSION_REF=${REGISTRY}/${IMAGE_OWNER}/${name}:${version}"
-          } >> "${GITHUB_ENV}"
-
-      # Guard the immutable public version: skip the whole publish if :v1 already exists. The version is
-      # immutable (promote refuses to overwrite it), so a published version is never re-promoted — bump
-      # TOOLCHAIN_VERSION to publish a new one. The candidate is mutable and always rebuilt within a run.
-      # `force_republish` overrides the skip to regenerate the version in place.
-      - name: Check if version already published
-        id: guard
+          token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Resolve identity & build release plan
+        id: plan
         env:
           FORCE_REPUBLISH: ${{ inputs.force_republish }}
-        run: |
-          if [ "${FORCE_REPUBLISH}" = "true" ]; then
-            echo "::notice::force_republish set — regenerating ${VERSION_REF} even though it may already exist."
-            echo "skip=false" >> "${GITHUB_OUTPUT}"
-          elif docker manifest inspect "${VERSION_REF}" >/dev/null 2>&1; then
-            echo "::notice::${VERSION_REF} already published — skipping (bump TOOLCHAIN_VERSION, or dispatch with force_republish, to publish again)."
-            echo "skip=true" >> "${GITHUB_OUTPUT}"
-          else
-            echo "skip=false" >> "${GITHUB_OUTPUT}"
-          fi
-
-      # The candidate base image must be PUBLIC so providers can pull it anonymously: e2b builds the
-      # template on its REMOTE builder (FROM the ghcr candidate base) and daytona/modal pull it to
-      # snapshot/boot — none are handed ghcr pull credentials. GHCR packages are created PRIVATE on
-      # first push and GitHub exposes no API to flip visibility, so making it public is a one-time
-      # manual bootstrap (Org → Packages → this package → Package settings → Change visibility → Public,
-      # or link the package to this public repo). This guard fails fast with that instruction instead of
-      # letting an opaque provider "unauthorized/not found" pull error surface mid-bake.
+        # release-plan.ts validates pins again, probes whether :v1 is already published (best-effort —
+        # promote does the authoritative guard), writes release-plan.json, and prints the key=value
+        # outputs the downstream jobs read.
+        # release-plan.ts writes the key=value outputs straight to $GITHUB_OUTPUT (not via a stdout
+        # redirect), so a child process's stdout can never corrupt the outputs file.
+        run: bun apps/cli/src/bin/release-plan.ts release-plan.json
+      # Guard the candidate package visibility so providers can pull it anonymously (see the composite).
+      # Skipped when the release itself is skipped (version already published).
       - name: Ensure candidate package is public
-        if: steps.guard.outputs.skip != 'true'
-        run: |
-          set -euo pipefail
-          # > Capture the HTTP status separately so a real "absent" (404) is distinguished from auth/scope
-          # > failures (403 SSO/token gap) and transport errors — `curl -f ... || echo '{}'` would collapse
-          # > all of them into the same empty fallback and let the publish proceed on a false "not found".
-          api="https://api.github.com/orgs/${IMAGE_OWNER}/packages/container/${IMAGE_NAME}"
-          code="$(curl -sS -m 30 -o /tmp/ghcr-pkg.json -w '%{http_code}' \
-            -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
-            -H "Accept: application/vnd.github+json" \
-            "${api}")" || { echo "::error::Could not reach the GHCR package API (network/transport error) — refusing to publish blind."; exit 1; }
-          case "${code}" in
-            200)
-              if grep -qE '"visibility"[[:space:]]*:[[:space:]]*"public"' /tmp/ghcr-pkg.json; then
-                echo "GHCR package ${IMAGE_OWNER}/${IMAGE_NAME} is public — providers can pull the candidate."
-              else
-                echo "::error::GHCR package ${IMAGE_OWNER}/${IMAGE_NAME} is not public. e2b/daytona/modal pull the candidate base anonymously, so set it Public once (org package settings or link it to this repo), then re-run."
-                exit 1
-              fi
-              ;;
-            404)
-              echo "::warning::GHCR package ${IMAGE_OWNER}/${IMAGE_NAME} not found yet — the push below creates it PRIVATE. After this run, set it Public once so the candidate validate and the providers can pull it; this run's validate will fail until then."
-              ;;
-            *)
-              echo "::error::GHCR package API returned HTTP ${code} (expected 200 or 404) — likely a token-scope gap or org SSO enforcement, not a missing package. Resolve and re-run instead of publishing blind."
-              exit 1
-              ;;
-          esac
+        if: steps.plan.outputs.skip != 'true'
+        uses: ./.github/actions/ensure-package-public
+        with:
+          owner: ${{ env.IMAGE_OWNER }}
+          package: ${{ steps.plan.outputs.image-name }}
+          token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Upload release plan
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: release-plan-${{ github.run_id }}
+          path: release-plan.json
+          if-no-files-found: warn
+          # A "Re-run failed jobs" keeps github.run_id and only bumps run_attempt, so the artifact name
+          # is unchanged; upload-artifact@v4+ fails a duplicate name by default. Overwrite so a re-run's
+          # if:always() upload can't fail the job over a name that the first attempt already claimed.
+          overwrite: true
+      - name: Release summary
+        if: always()
+        uses: ./.github/actions/release-summary
+        with:
+          phase: plan
+          status: ${{ job.status }}
+          mode: ${{ steps.plan.outputs.mode }}
+          source-ref: ${{ github.sha }}
+          image: ${{ steps.plan.outputs.image-candidate }}
+          size-tier: ${{ steps.plan.outputs.size-tier }}
+          published: ${{ steps.plan.outputs.publish-target }}
+          diagnostics: release-plan-${{ github.run_id }}
 
-      # Build + push the candidate, then bake each provider's candidate artifact and validate it by
-      # booting a sandbox (skip-on-missing-creds). Fails the job if any baked provider fails to validate.
-      - name: Bake + validate candidate
-        if: steps.guard.outputs.skip != 'true'
+  # BUILD: build the base image (+ variants) and push the mutable candidate base to GHCR ONCE, then
+  # record its immutable digest. The providers below all fan out from this single pushed candidate.
+  build:
+    name: Build + push candidate
+    needs: plan
+    if: needs.plan.outputs.skip != 'true'
+    # 16 cores — the same compile-bound base-image build as pr-gate (see the note there), and it sits on
+    # the critical path of every release: nothing bakes until the candidate is pushed.
+    runs-on: starsling-ubuntu-24.04-16
+    # The heavy phase: a full base-image build (apt, mise, the PTS install) plus the push.
+    timeout-minutes: 60
+    environment: privileged
+    permissions:
+      contents: read
+      packages: write
+    outputs:
+      digest: ${{ steps.build.outputs.digest }}
+      candidate-digest-ref: ${{ steps.build.outputs.candidate-digest-ref }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          # Publishes to GHCR via docker/login-action, never git push — don't persist the job token.
+          persist-credentials: false
+      - name: Set up toolchain
+        uses: ./.github/actions/setup-toolchain
+        with:
+          buildx: "true"
+      - name: GHCR session
+        uses: ./.github/actions/ghcr-login
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Build + push candidate image
+        id: build
         env:
           BUILD_REF: ${{ github.sha }}
-          BUILD_VERSION: ${{ env.IMAGE_VERSION }}
-          E2B_API_KEY: ${{ secrets.E2B_API_KEY }}
-          DAYTONA_API_KEY: ${{ secrets.DAYTONA_API_KEY }}
-          # Bake/validate the daytona snapshot in the active region. Without a target the snapshot lands
-          # in the account's default region (which has no `container` runners) and the bake fails at
-          # snapshot creation. Defaulted to the active target so an unsynced secret can't break the
-          # publish at module load (parity with bench-matrix.yml / bench-smoke.yml).
-          DAYTONA_TARGET: ${{ secrets.DAYTONA_TARGET || 'us-west-2' }}
-          MODAL_TOKEN_ID: ${{ secrets.MODAL_TOKEN_ID }}
-          MODAL_TOKEN_SECRET: ${{ secrets.MODAL_TOKEN_SECRET }}
-          # Bake the novita template on Novita's E2B-compatible control plane. Optional: a missing
-          # secret skips the novita bake (it is not in --require) without failing the publish.
-          NOVITA_API_KEY: ${{ secrets.NOVITA_API_KEY }}
+          BUILD_VERSION: ${{ needs.plan.outputs.toolchain-version }}
+          # Same mise rate-limit fix as pr-gate: the release build runs the identical build.sh, so give
+          # it the authenticated GitHub API limit too. Built-in token; this job is already privileged.
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           set -euo pipefail
           # Declare then assign so the command substitution's exit status isn't masked (SC2155).
           BUILD_DATE="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
           export BUILD_DATE
-          # --require fails the publish loudly if a required provider's secret is missing/misnamed, so a
-          # release can't bless a candidate while a required provider was silently skipped (never built or
-          # validated). modal boots the toolchain image via fromRegistry under this project's Modal app
-          # and is validated the same as e2b/daytona, so it's required — MODAL_TOKEN_* must be synced.
-          # (blaxel is excluded — its bake is a no-op.)
-          bun apps/cli/src/bin/bake.ts --build-push --require e2b,daytona,modal
+          # No `>> "$GITHUB_OUTPUT"` redirect: build.sh runs with inherited stdout, so redirecting this
+          # command's stdout would splice its build log into the outputs file (GitHub would reject it).
+          # build-candidate.ts writes the digest outputs straight to $GITHUB_OUTPUT itself.
+          bun apps/cli/src/bin/build-candidate.ts build-metadata.json
+      - name: Upload build metadata
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: build-metadata-${{ github.run_id }}
+          path: build-metadata.json
+          if-no-files-found: warn
+          # See the plan upload: overwrite so a re-run (same run_id, new run_attempt) can't fail on a
+          # duplicate artifact name.
+          overwrite: true
+      - name: Release summary
+        if: always()
+        uses: ./.github/actions/release-summary
+        with:
+          phase: build
+          status: ${{ job.status }}
+          mode: ${{ needs.plan.outputs.mode }}
+          source-ref: ${{ github.sha }}
+          image: ${{ steps.build.outputs.candidate-digest-ref }}
+          size-tier: ${{ needs.plan.outputs.size-tier }}
+          verify: bun apps/cli/src/bin/build-candidate.ts
+          diagnostics: build-metadata-${{ github.run_id }}
 
-      # Promote the validated candidate to the immutable public version (+ version-named artifacts).
-      - name: Promote candidate → version
-        if: steps.guard.outputs.skip != 'true'
+  # BAKE + verify: one matrix cell per provider (from the plan). Each cell bakes its candidate artifact
+  # from the pushed candidate base and validates it by booting a sandbox and running the shared smoke
+  # spec. fail-fast: false so a flaky provider doesn't cancel the others' diagnostics — but ANY cell
+  # that RAN and failed still fails this job (and, being a `needs`, blocks promote). Required cells
+  # (plan `required`) additionally pass `--require`, so a missing/misnamed secret fails the cell instead
+  # of silently skipping a provider the release must ship.
+  bake:
+    name: Bake + verify (${{ matrix.provider }})
+    needs: [plan, build]
+    if: needs.plan.outputs.skip != 'true'
+    runs-on: starsling-ubuntu-24.04-2
+    # Each cell boots a provider sandbox with that provider's secret — a credentialed job, so it runs
+    # behind Environment `privileged` like the rest of the release lane.
+    environment: privileged
+    timeout-minutes: 60
+    strategy:
+      fail-fast: false
+      matrix: ${{ fromJSON(needs.plan.outputs.matrix) }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          # Boots the just-baked candidate via provider SDKs — no git push, no ghcr push. Don't persist.
+          persist-credentials: false
+      - name: Set up toolchain
+        uses: ./.github/actions/setup-toolchain
+      - name: Bake + verify candidate
+        id: bake
+        # The cell's provider + required flag reach the script through the environment, never
+        # interpolated into the shell, so a matrix value can't inject into the runner command. Provider
+        # creds are optional: a missing one SKIPS that provider (required cells fail instead — see
+        # --require below). blaxel gets no creds here (its bake is a no-op booting the stock base), so
+        # it skips, exactly as the previous monolithic lane did.
+        #
+        # Each cell is handed ONLY its own provider's credentials. The cell already restricts execution
+        # to one provider (`--provider`), so injecting all five providers' secrets into all five cells
+        # would hand a compromised dependency in any one cell (a provider SDK, the bun toolchain) every
+        # other provider's key for no benefit — a 5× blast radius across a parallel fan-out. Scoping
+        # them here is what makes the fan-out least-privilege rather than just concurrent.
         env:
-          E2B_API_KEY: ${{ secrets.E2B_API_KEY }}
-          DAYTONA_API_KEY: ${{ secrets.DAYTONA_API_KEY }}
+          PROVIDER: ${{ matrix.provider }}
+          REQUIRED: ${{ matrix.required }}
+          E2B_API_KEY: ${{ matrix.provider == 'e2b' && secrets.E2B_API_KEY || '' }}
+          DAYTONA_API_KEY: ${{ matrix.provider == 'daytona' && secrets.DAYTONA_API_KEY || '' }}
           # Bake/validate the daytona snapshot in the active region. Without a target the snapshot lands
           # in the account's default region (which has no `container` runners) and the bake fails at
-          # snapshot creation. Defaulted to the active target so an unsynced secret can't break the
-          # publish at module load (parity with bench-matrix.yml / bench-smoke.yml).
+          # snapshot creation. Defaulted so an unsynced secret can't break the release at module load.
+          DAYTONA_TARGET: ${{ matrix.provider == 'daytona' && (secrets.DAYTONA_TARGET || 'us-west-2') || '' }}
+          MODAL_TOKEN_ID: ${{ matrix.provider == 'modal' && secrets.MODAL_TOKEN_ID || '' }}
+          MODAL_TOKEN_SECRET: ${{ matrix.provider == 'modal' && secrets.MODAL_TOKEN_SECRET || '' }}
+          # Optional: a missing NOVITA_API_KEY skips the novita bake without failing the release.
+          NOVITA_API_KEY: ${{ matrix.provider == 'novita' && secrets.NOVITA_API_KEY || '' }}
+        run: |
+          set -euo pipefail
+          args=(--provider "${PROVIDER}")
+          # Required providers must not silently skip: --require fails the cell if this provider's
+          # secret is missing/misnamed or it fails to validate.
+          if [ "${REQUIRED}" = "true" ]; then args+=(--require "${PROVIDER}"); fi
+          # Route the report JSON to a file via env (not a `> file` redirect): the provider CLIs inherit
+          # stdout, so a redirect would splice their chatter into the report. bake.ts writes the file
+          # even when it exits non-zero, so it's a clean diagnostic on failure too.
+          export BAKE_REPORT_FILE="bake-${PROVIDER}.json"
+          bun apps/cli/src/bin/bake.ts "${args[@]}"
+      - name: Upload bake report
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: bake-${{ matrix.provider }}-${{ github.run_id }}
+          path: bake-${{ matrix.provider }}.json
+          if-no-files-found: warn
+          # See the plan upload: overwrite so re-running a single failed cell (same run_id) can't fail on
+          # its own first-attempt artifact — the whole point of the per-cell re-run.
+          overwrite: true
+      - name: Release summary
+        if: always()
+        uses: ./.github/actions/release-summary
+        with:
+          phase: ${{ matrix.provider }}/bake
+          status: ${{ job.status }}
+          mode: ${{ needs.plan.outputs.mode }}
+          source-ref: ${{ github.sha }}
+          image: ${{ needs.build.outputs.candidate-digest-ref }}
+          base-image: ${{ needs.plan.outputs.image-candidate }}
+          provider-target: ${{ matrix.provider }}
+          size-tier: ${{ needs.plan.outputs.size-tier }}
+          verify: bun apps/cli/src/bin/bake.ts --provider ${{ matrix.provider }}${{ matrix.required && format(' --require {0}', matrix.provider) || '' }}
+          diagnostics: bake-${{ matrix.provider }}-${{ github.run_id }}
+
+  # PROMOTE: the serialized publication barrier and the ONLY job that mutates the public :v1. Runs only
+  # after every bake cell converges (a failed required cell fails `bake` and blocks this via `needs`).
+  # promote re-validates the candidate (TOCTOU: the candidate tag is mutable), builds each provider's
+  # version-named artifact FROM the revalidated bytes, then retags the base → :v1 LAST as the commit
+  # point. `--require` (from the plan) fails the promote before publish if a required provider's version
+  # artifact was skipped/failed. `--force` (force_republish only) regenerates an existing version.
+  # The release job (named `publish` — the drift gate requires this name for the GHCR release lane).
+  publish:
+    name: Promote candidate → version
+    needs: [plan, build, bake]
+    # The only job that mutates the public :v1. Confine it to a manual dispatch on main of this repo
+    # (redundant with plan's gate, but the hardening gate asserts this literally on the publish job).
+    if: >
+      needs.plan.outputs.skip != 'true' &&
+      github.event_name == 'workflow_dispatch' &&
+      github.ref == 'refs/heads/main' &&
+      github.repository == 'starslingdev/sandbox-benchmarks'
+    runs-on: starsling-ubuntu-24.04-2
+    environment: privileged
+    # Re-validates the candidate and promotes across all five providers SERIALLY (it is a transaction,
+    # not a fan-out), so it is the longest-running credentialed job.
+    timeout-minutes: 60
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          # Publishes to GHCR via docker/login-action, never git push — don't persist the job token.
+          persist-credentials: false
+      - name: Set up toolchain
+        uses: ./.github/actions/setup-toolchain
+        with:
+          buildx: "true"
+      - name: GHCR session
+        uses: ./.github/actions/ghcr-login
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Promote candidate → version
+        id: promote
+        env:
+          REQUIRED: ${{ needs.plan.outputs.required }}
+          FORCE_REPUBLISH: ${{ inputs.force_republish }}
+          # Route the promote payload JSON to a file via env (not a `> file` redirect): the provider
+          # CLIs inherit stdout, so a redirect would splice their chatter into the payload. bake.ts
+          # writes the file even when promote aborts (it records the structured reports before exiting).
+          BAKE_REPORT_FILE: promote-payload.json
+          E2B_API_KEY: ${{ secrets.E2B_API_KEY }}
+          DAYTONA_API_KEY: ${{ secrets.DAYTONA_API_KEY }}
           DAYTONA_TARGET: ${{ secrets.DAYTONA_TARGET || 'us-west-2' }}
           MODAL_TOKEN_ID: ${{ secrets.MODAL_TOKEN_ID }}
           MODAL_TOKEN_SECRET: ${{ secrets.MODAL_TOKEN_SECRET }}
-          # Bake the novita template on Novita's E2B-compatible control plane. Optional: a missing
-          # secret skips the novita bake (it is not in --require) without failing the publish.
           NOVITA_API_KEY: ${{ secrets.NOVITA_API_KEY }}
-          FORCE_REPUBLISH: ${{ inputs.force_republish }}
-        # --require fails promote loudly if a required provider's secret is missing/misnamed, so the
-        # public version is never published while a required provider's version artifact was silently
-        # skipped. modal is required (validated via its fromRegistry boot); MODAL_TOKEN_* must be synced.
-        # (blaxel is excluded — its bake is a no-op.) `--force` (force_republish dispatch only)
-        # republishes over an existing immutable version.
         run: |
           set -euo pipefail
-          args=(--promote --require "e2b,daytona,modal")
+          args=(--promote --require "${REQUIRED}")
+          # --force (manual force_republish dispatch only) republishes over an existing immutable
+          # version; never set on the automated push path.
           if [ "${FORCE_REPUBLISH}" = "true" ]; then args+=(--force); fi
           bun apps/cli/src/bin/bake.ts "${args[@]}"
+      - name: Upload promote payload
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: promote-payload-${{ github.run_id }}
+          path: promote-payload.json
+          if-no-files-found: warn
+          # See the plan upload: overwrite so a re-run (same run_id, new run_attempt) can't fail on a
+          # duplicate artifact name.
+          overwrite: true
+      - name: Release summary
+        if: always()
+        uses: ./.github/actions/release-summary
+        with:
+          phase: publish
+          status: ${{ job.status }}
+          mode: ${{ needs.plan.outputs.mode }}
+          source-ref: ${{ github.sha }}
+          image: ${{ needs.build.outputs.candidate-digest-ref }}
+          base-image: ${{ needs.plan.outputs.image-candidate }}
+          size-tier: ${{ needs.plan.outputs.size-tier }}
+          verify: bun apps/cli/src/bin/bake.ts --promote --require ${{ needs.plan.outputs.required }}${{ inputs.force_republish && ' --force' || '' }}
+          published: ${{ needs.plan.outputs.publish-target }}
+          diagnostics: promote-payload-${{ github.run_id }}


### PR DESCRIPTION
**TOOLCHAIN RELEASE — restage the monolithic publish job into a parallel, resumable, plan-driven pipeline.**
Shipped as a 7-PR stack. The trunk merges bottom-up: the CLI PRs (#155–#157) are pure-additive
mechanism (nothing calls them yet), and #158/#159 are the wiring that finally consumes them.

```
main
 └─ #153  bake: retry the daytona snapshot create + rich failure diagnostics
     └─ #154  bake: `--provider <id>` selection + a file-based report
         └─ #155  cli: `release-plan` — the release plan as an artifact
             └─ #156  cli: `build-candidate` — build once, record the digest
                 └─ #157  cli: `release-{validate,summary,ensure-public}` via @actions/core
                     └─ #158  ci: the five composite actions the release jobs share
                         └─ #159  ci: restage toolchain-image.yml (plan → build → bake → publish)
```

↑ **This PR is #159 (7/7) — wiring, part 2 — the workflow that consumes the whole stack, based on #158.**

---

**Stack 7/7** — based on #158

The release was two jobs: a PR gate, and one monolithic `publish` that built the image, baked every
provider **serially**, and promoted — all in a single credentialed job. A daytona blip failed the whole
thing after e2b had already baked, and a rerun rebuilt the image from scratch.

Restage it into four jobs that consume the plan artifact from the bins below:

```
plan → build → bake (matrix: one cell per provider) → publish
```

- **`plan`** resolves the release identity **once** and emits the mode, skip decision, refs, required
  set, and the `strategy.matrix` the fan-out reads via `fromJSON`. Downstream jobs read the plan instead
  of re-deriving refs and gates from raw inputs.
- **`build`** pushes the candidate a single time and records its digest.
- **`bake`** fans out over the matrix, so each provider bakes and validates in its own job
  (`--provider <id>`). Providers now bake **in parallel**, a failure is **isolated to its own cell**, and
  a rerun of a failed cell **reuses the already-pushed candidate** instead of rebuilding.
- **`publish`** runs last and is unchanged in contract — still all-providers, still self-gating on the
  required set. (Renamed from `promote`; see "Hardening-gate conformance" below.)

Every job reports through the shared `release-summary` composite with one field vocabulary and uploads
its phase diagnostics as an artifact (the plan JSON, the build metadata, each cell's bake report — via
`$BAKE_REPORT_FILE`, so subprocess chatter can't corrupt them). Each summary carries the **exact verify
command** an operator can rerun locally.

**Credential posture** is tightened along the way: each job checks out, installs tooling, and validates
inputs **before** any registry/provider credential is introduced, and `ghcr-login` appears only in the
jobs that actually touch the registry.

**Hardening-gate conformance (rebased onto latest `main`).** Since this stack was first opened, `main`
landed the workflow-hardening drift gate (#176/#177), which asserts that `toolchain-image.yml` is
**dispatch-only** and that every credentialed / `packages: write` job sits behind the `privileged` GitHub
Environment. This PR is reconciled to that gate rather than reverting it:

- **Dispatch-only** — the `push:` trigger is dropped; the whole lane is confined to a manual
  `workflow_dispatch` on `main` of this repo (the `plan` gate cascades to every downstream job via
  `needs`).
- **`environment: privileged`** added to `build`, `bake`, and `publish` (the release lane's credentialed
  jobs), so Environment secrets + required-reviewer protection apply to each.
- **`promote` → `publish`** — the release job is renamed to the name the gate requires for the GHCR
  release lane, and carries the confining `if:` (workflow_dispatch · `refs/heads/main` · this repo).

  Trade-off worth noting: because the gate requires the Environment on all three credentialed jobs, a
  release dispatch now requests Environment approval **per credentialed job** rather than once for a
  single monolithic job — inherent to combining the staged fan-out with the per-job protection rule.

**Review fixes (from #149):**
- **Least-privilege secrets.** Each bake cell is now handed **only its own provider's** credentials. The
  cell already restricts execution to one provider, so injecting all five providers' secrets into all
  five cells handed a compromised dependency in any one cell (a provider SDK, the bun toolchain) every
  other provider's key for no benefit — a **5× blast radius across a parallel fan-out**. (Safe because
  `config.ts` treats a set-but-empty env var as unset and `missingCreds` treats `""` as missing, so the
  four unused keys read as absent and those providers skip — exactly as before.)
- **`timeout-minutes` on every job** (pr-gate 30, plan 15, build 60, publish 60; bake already had 60).
  The default is GitHub's **6-hour** ceiling, and each job makes calls that can hang rather than fail — a
  hang would otherwise hold a self-hosted runner for hours.

**Runner sizing.** `pr-gate` and `build` move to `starsling-ubuntu-24.04-16`; the rest stay on the
2-core standard. Those two are the only jobs doing **local compute** — a real base-image build whose wall
time is dominated by `phoronix-test-suite batch-install` compiling the benchmark profiles from source,
which parallelizes across cores. `plan`/`publish` only wait on registries and provider APIs, and the five
`bake` cells build **remotely** (e2b's builder, daytona's runner, modal) — giving them 16 cores each
would burn 80 cores to wait on HTTP. The new label is registered in `.github/actionlint.yaml`, without
which `actionlint` fails the lint gate.

**LOC**: 352 added / 167 removed (1 workflow + the actionlint label).

---

## Validation

Every branch in this stack was checked out **in isolation** (on top of its own parent, with nothing
from the PRs above it) and run through frozen install + typecheck + the full workspace test suite. A
reviewer merges bottom-up, so each PR has to stand on its own — this is what verifies that.

After rebasing the stack onto the hardened `main` and resolving the resulting conflicts, **all seven
branches were re-verified green in isolation**, and the real workflow-hardening gate
(`runHardeningCheck` over the actual `.github` files) passes on the final workflow — confirming the
dispatch-only + privileged-environment reconciliation above is enforced, not just described.

**What this PR's own tests prove:** the workflow is YAML, so its gates are static: `actionlint` (clean,
including the newly-registered runner label) and `zizmor` at `--min-severity medium` (**no findings**),
which is what audits the credential posture and the per-cell secret scoping this PR introduces. The
behavior it wires up — plan/matrix/provider-selection/summary rendering — is unit-tested in #154–#157
below, which is the point of the split: the wiring PR carries no untested logic of its own.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restages the toolchain release into a staged pipeline (plan → build → bake matrix → publish) for faster publishes, isolated provider failures, and reuse of the pushed candidate on reruns. Tightens permissions, scopes secrets per provider, adds artifacts/summaries, and fixes `mise` rate limits by building with an authenticated `GITHUB_TOKEN`.

- **Refactors**
  - Pipeline: one shared plan; build pushes once and records the digest; bake runs per provider in parallel; publish re‑validates, enforces the required set, and supports `force_republish`.
  - Reliability: pass `GITHUB_TOKEN` to base builds (`pr-gate`/`build`); set `overwrite: true` on artifact uploads to fix “Re‑run failed jobs” collisions; summaries include exact verify commands and real flags.
  - Security/permissions: dispatch‑only; `environment: privileged` on `build`/`bake`/`publish`; per‑provider secret scoping in the bake matrix; GHCR visibility guard via `./.github/actions/ensure-package-public`; `ghcr-login` only where needed; default read‑only; no `id-token`.
  - Tooling/runners: shared composites for setup/login/validation/summaries; compute‑bound `pr-gate` and `build` on `starsling-ubuntu-24.04-16` (added to `actionlint`); others on `-2`; timeouts on all jobs.

- **Migration**
  - Make the GHCR package public once so providers can pull the candidate anonymously (or link it to this repo).
  - Ensure provider secrets: `E2B_API_KEY`, `DAYTONA_API_KEY` (and `DAYTONA_TARGET`), `MODAL_TOKEN_ID`, `MODAL_TOKEN_SECRET`; `NOVITA_API_KEY` is optional.
  - Use `workflow_dispatch` with `force_republish` to regenerate an existing version if needed.

<sup>Written for commit 6ee25df7e421aeddf9cb2de6e2702f188e96a8d2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/starslingdev/sandbox-benchmarks/pull/159?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a staged toolchain image release flow (plan → build → provider bake → publish) with per-provider validation and reporting.
  - Added generated release diagnostics/metadata to improve visibility during planning, building, baking, and promotion.

- **Bug Fixes**
  - Improved release gating to prevent promotion when provider builds are incomplete or invalid.
  - Hardened workflow safety with least-privilege defaults and more consistent environment/permissions handling.

- **Tests**
  - Updated CI checks to build and run Docker smoke tests without publishing.

- **Chores**
  - Expanded the CI runner label set used for action linting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->