### PR TITLE
fix(toolchain): publish portable benchmark images

### DIFF
--- a/.github/workflows/toolchain-image.yml
+++ b/.github/workflows/toolchain-image.yml
@@ -120,6 +120,9 @@ jobs:
           no-cache: true
       - name: Install dependencies
         run: bun install --frozen-lockfile --ignore-scripts
+      # Daytona's remote-registry snapshot paths reject this otherwise valid public GHCR image. The
+      # bake code uses Daytona's transient-registry API instead, with Buildx providing the immutable
+      # source digest and Docker copying those exact bytes into the transient registry.
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4.1.0
       - name: Log in to the container registry

--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -28,6 +28,7 @@
     "@sandbox-benchmarks/templates": "workspace:*",
     "@sandbox-benchmarks/harness": "workspace:*",
     "@sandbox-benchmarks/results": "workspace:*",
+    "@daytona/api-client": "catalog:computesdk",
     "@daytona/sdk": "catalog:computesdk",
     "novita-sandbox": "catalog:computesdk",
     "dotenv": "catalog:"

--- a/apps/cli/src/bin/bake.ts
+++ b/apps/cli/src/bin/bake.ts
@@ -14,7 +14,7 @@ import { config } from "@sandbox-benchmarks/providers";
 import type { ProviderId } from "@sandbox-benchmarks/schema";
 import { bakeDaytonaSnapshot } from "../lib/bake/daytona.ts";
 import { bakeE2bTemplate } from "../lib/bake/e2b.ts";
-import { buildAndPushCandidate } from "../lib/bake/image.ts";
+import { buildAndPushCandidate, resolveImageDigestRef } from "../lib/bake/image.ts";
 import { bakeModalImage } from "../lib/bake/modal.ts";
 import { bakeNovitaTemplate } from "../lib/bake/novita.ts";
 import { promoteAll } from "../lib/bake/promote.ts";
@@ -23,25 +23,16 @@ import { candidateCreateOptions } from "../lib/bake/validate.ts";
 import { anyFailed, forEachProviderWithCreds } from "../lib/providers-run.ts";
 import { bootAndSmoke, logChecks, smokeFailureReason, smokeOk } from "../lib/smoke-run.ts";
 
-// Each provider's candidate bake, bound to the candidate names + base ref from config.
-const bakers: Record<ProviderId, (log: Log) => Promise<void>> = {
-	e2b: (log) => bakeE2bTemplate(config.e2bTemplateCandidate, config.toolchainImageCandidate, log),
-	daytona: (log) =>
-		bakeDaytonaSnapshot(config.daytonaSnapshotCandidate, config.toolchainImageCandidate, log),
+// Each provider's candidate bake, bound to the candidate artifact name but NOT the mutable image
+// tag. The caller resolves that tag once and passes the same immutable digest to every baker.
+const bakers: Record<ProviderId, (image: string, log: Log) => Promise<void>> = {
+	e2b: (image, log) => bakeE2bTemplate(config.e2bTemplateCandidate, image, log),
+	daytona: (image, log) => bakeDaytonaSnapshot(config.daytonaSnapshotCandidate, image, log),
 	modal: bakeModalImage,
-	blaxel: async (log) => {
+	blaxel: async (_image, log) => {
 		log("blaxel boots the stock base image — no candidate artifact to bake");
 	},
-	novita: (log) =>
-		bakeNovitaTemplate(config.novitaTemplateCandidate, config.toolchainImageCandidate, log),
-};
-
-const candidateRefs = {
-	e2bTemplateCandidate: config.e2bTemplateCandidate,
-	daytonaSnapshotCandidate: config.daytonaSnapshotCandidate,
-	novitaTemplateCandidate: config.novitaTemplateCandidate,
-	toolchainImageCandidate: config.toolchainImageCandidate,
-	daytonaTarget: config.daytona.target,
+	novita: (image, log) => bakeNovitaTemplate(config.novitaTemplateCandidate, image, log),
 };
 
 if (import.meta.main) {
@@ -86,10 +77,31 @@ if (import.meta.main) {
 		}
 	}
 
+	// Modal's registry importer, like the remote E2B-compatible builders, may cache a mutable tag.
+	// Resolve once after the push and validate the exact candidate bytes by immutable digest. This also
+	// makes a tag change between provider bakes unable to redirect Modal's validation to different bytes.
+	let pinnedCandidateImage: string;
+	try {
+		pinnedCandidateImage = await resolveImageDigestRef(config.toolchainImageCandidate);
+		log(`>>> candidate image pinned for validation: ${pinnedCandidateImage}`);
+	} catch (err) {
+		log(
+			`<<< could not resolve candidate image digest — ${err instanceof Error ? err.message : String(err)}`,
+		);
+		process.exit(1);
+	}
+	const candidateRefs = {
+		e2bTemplateCandidate: config.e2bTemplateCandidate,
+		daytonaSnapshotCandidate: config.daytonaSnapshotCandidate,
+		novitaTemplateCandidate: config.novitaTemplateCandidate,
+		toolchainImageCandidate: pinnedCandidateImage,
+		daytonaTarget: config.daytona.target,
+	};
+
 	const runs = await forEachProviderWithCreds(
 		async (provider) => {
 			log(`>>> ${provider.name}: baking candidate…`);
-			await bakers[provider.name]((m) => log(`    ${m}`));
+			await bakers[provider.name](pinnedCandidateImage, (m) => log(`    ${m}`));
 
 			log(`>>> ${provider.name}: validating (boot + smoke)…`);
 			// Boot the just-baked candidate (override the registry adapter's version create-options).
@@ -132,7 +144,7 @@ if (import.meta.main) {
 		JSON.stringify(
 			{
 				candidate: {
-					image: config.toolchainImageCandidate,
+					image: pinnedCandidateImage,
 					e2bTemplate: config.e2bTemplateCandidate,
 					daytonaSnapshot: config.daytonaSnapshotCandidate,
 					novitaTemplate: config.novitaTemplateCandidate,

--- a/apps/cli/src/lib/bake/daytona.test.ts
+++ b/apps/cli/src/lib/bake/daytona.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, it } from "bun:test";
-import { snapshotDestroyedMessage } from "./daytona.ts";
+import {
+	daytonaTransientPushCommands,
+	daytonaTransientRef,
+	snapshotDestroyedMessage,
+	withCleanupPreservingPrimaryError,
+} from "./daytona.ts";
 
 // The published snapshot name a `promote --force` regenerates in place — the case where a create that
 // fails after the delete leaves a *public* artifact absent rather than stale.
@@ -25,5 +30,97 @@ describe("snapshotDestroyedMessage", () => {
 		// listSnapshotsByName sweeps every snapshot of the name in any state (a failed mid-create leaves
 		// one `get` won't return), so the count is genuinely unbounded above 1 — don't hardcode "1".
 		expect(snapshotDestroyedMessage(PUBLISHED, 3, "boom")).toContain("deleting 3 pre-existing");
+	});
+});
+
+describe("daytonaTransientRef", () => {
+	it("preserves the source repository and replaces its tag under Daytona's transient project", () => {
+		expect(
+			daytonaTransientRef(
+				{ registryUrl: "https://cr.app.daytona.io/", project: "/sbox-transient/" },
+				"ghcr.io/starslingdev/toolchain:v1-candidate",
+				"20260714041422",
+			),
+		).toBe("cr.app.daytona.io/sbox-transient/ghcr.io/starslingdev/toolchain:20260714041422");
+	});
+
+	it("does not mistake a registry port for an image tag", () => {
+		expect(
+			daytonaTransientRef(
+				{ registryUrl: "registry.example:5000", project: "transient" },
+				"registry.example:5000/org/image",
+				"upload",
+			),
+		).toBe("registry.example:5000/transient/registry.example:5000/org/image:upload");
+	});
+
+	it("replaces an immutable source digest with the transient upload tag", () => {
+		expect(
+			daytonaTransientRef(
+				{ registryUrl: "https://cr.app.daytona.io", project: "sbox-transient" },
+				"ghcr.io/starslingdev/toolchain@sha256:c70601f8c3c93bf6",
+				"20260714060245",
+			),
+		).toBe("cr.app.daytona.io/sbox-transient/ghcr.io/starslingdev/toolchain:20260714060245");
+	});
+
+	it("rejects incomplete registry credentials before invoking Docker", () => {
+		expect(() =>
+			daytonaTransientRef(
+				{ registryUrl: "cr.app.daytona.io", project: "" },
+				"ghcr.io/o/image:v1",
+				"upload",
+			),
+		).toThrow("incomplete upload destination");
+	});
+});
+
+describe("daytonaTransientPushCommands", () => {
+	it("pulls a buildx-pushed digest before tagging and pushing it", () => {
+		const source = "ghcr.io/starslingdev/toolchain@sha256:c70601f8c3c93bf6";
+		const destination = "cr.app.daytona.io/sbox-transient/ghcr.io/starslingdev/toolchain:upload";
+
+		expect(daytonaTransientPushCommands(source, destination)).toEqual([
+			["docker", "pull", source],
+			["docker", "tag", source, destination],
+			["docker", "push", destination],
+		]);
+	});
+});
+
+describe("withCleanupPreservingPrimaryError", () => {
+	it("runs cleanup and preserves the operation error when both fail", async () => {
+		const primary = new Error("push failed");
+		const cleanup = new Error("logout failed");
+		const suppressed: unknown[] = [];
+
+		await expect(
+			withCleanupPreservingPrimaryError(
+				async () => {
+					throw primary;
+				},
+				async () => {
+					throw cleanup;
+				},
+				(error) => suppressed.push(error),
+			),
+		).rejects.toBe(primary);
+		expect(suppressed).toEqual([cleanup]);
+	});
+
+	it("surfaces a cleanup error when the operation succeeded", async () => {
+		const cleanup = new Error("logout failed");
+
+		await expect(
+			withCleanupPreservingPrimaryError(
+				async () => "uploaded",
+				async () => {
+					throw cleanup;
+				},
+				() => {
+					throw new Error("cleanup error must not be suppressed after success");
+				},
+			),
+		).rejects.toBe(cleanup);
 	});
 });

--- a/apps/cli/src/lib/bake/daytona.ts
+++ b/apps/cli/src/lib/bake/daytona.ts
@@ -1,7 +1,12 @@
-// Bake a daytona snapshot directly from a pushed toolchain image, via the raw Daytona SDK (the
-// @computesdk/daytona wrapper only snapshots a running sandbox). Idempotent: delete an existing
-// snapshot of that name, then recreate. The API key + runner target come from config.daytona
-// (single-region: DAYTONA_API_KEY + DAYTONA_TARGET, e.g. us-west-2).
+// Bake a Daytona Linux-VM snapshot by uploading the already-built local Docker image to Daytona's
+// transient registry, then registering that private image through the SDK. Both public-GHCR paths are
+// broken for this valid image: the direct importer returns an opaque inspection error, while the
+// declarative builder cannot authenticate its FROM pull. Daytona's CLI local-image path successfully
+// uploads the same layers, but hardcodes the `container` sandbox class; our active region is Linux VM
+// only. This implements the same documented transient-registry push and explicitly registers
+// `SandboxClass.LINUX_VM`. Idempotent: upload first, then delete an existing snapshot of that name and
+// recreate it. The API key + runner target come from config.daytona (single-region:
+// DAYTONA_API_KEY + DAYTONA_TARGET, e.g. us-west-2).
 //
 // Delete-then-create is idempotent but NOT atomic: the SDK exposes no snapshot rename or overwrite,
 // so the name is unavoidably ABSENT between the delete and a successful create. Reruns converge, but
@@ -13,11 +18,10 @@
 // Iteration surface: a snapshot's region must match where sandboxes boot. We pass the client `target`;
 // if the target also needs an explicit snapshot `regionId`, add it to CreateSnapshotParams here.
 //
-// microVM-only: the fleet is Firecracker microVMs, never containers. We pin the snapshot's
-// `sandboxClass` to LINUX_VM so its create — and every sandbox booted from it — routes to microVM
-// runners. Without it Daytona defaults to the `container` class, which fails on a region that only has
-// microVM runners with "No runners are configured … for sandbox class 'container'". (Needs
-// @daytona/sdk ≥ 0.192, which first exposed the selector.)
+// microVM-only: the fleet is Linux VMs. Snapshot registration pins that class rather than relying on
+// the transient-push API's container default.
+import type { RegistryPushAccessDto } from "@daytona/api-client";
+import { Configuration, DockerRegistryApi } from "@daytona/api-client";
 import { Daytona, SandboxClass } from "@daytona/sdk";
 import { config } from "@sandbox-benchmarks/providers";
 import type { Log } from "./types.ts";
@@ -136,6 +140,112 @@ export function snapshotDestroyedMessage(name: string, deleted: number, reason: 
 	);
 }
 
+/** Daytona's transient registry preserves the source repository path and replaces its source tag or
+ *  digest with a unique upload tag. Pure so the security-sensitive path construction is unit-testable. */
+export function daytonaTransientRef(
+	access: Pick<RegistryPushAccessDto, "registryUrl" | "project">,
+	image: string,
+	tag: string,
+): string {
+	const registry = access.registryUrl.replace(/^https?:\/\//, "").replace(/\/+$/, "");
+	const project = access.project.replace(/^\/+|\/+$/g, "");
+	const digest = image.indexOf("@");
+	const imageWithoutDigest = digest === -1 ? image : image.slice(0, digest);
+	const lastSlash = imageWithoutDigest.lastIndexOf("/");
+	const lastColon = imageWithoutDigest.lastIndexOf(":");
+	const repository =
+		lastColon > lastSlash ? imageWithoutDigest.slice(0, lastColon) : imageWithoutDigest;
+	if (!(registry && project && repository && tag)) {
+		throw new Error("Daytona transient registry returned an incomplete upload destination");
+	}
+	return `${registry}/${project}/${repository}:${tag}`;
+}
+
+/** Commands required to copy a buildx-pushed source into Daytona's transient registry. The explicit
+ *  pull is required because `docker buildx build --push` does not load the image into the daemon. */
+export function daytonaTransientPushCommands(image: string, transientRef: string): string[][] {
+	return [
+		["docker", "pull", image],
+		["docker", "tag", image, transientRef],
+		["docker", "push", transientRef],
+	];
+}
+
+/** Run a non-secret Docker command and fail with the exact executable/exit status. */
+async function runDocker(cmd: string[], log: Log): Promise<void> {
+	log(`$ ${cmd.join(" ")}`);
+	const proc = Bun.spawn(cmd, { stdout: "inherit", stderr: "inherit", env: process.env });
+	const code = await proc.exited;
+	if (code !== 0) throw new Error(`${cmd.slice(0, 2).join(" ")} exited ${code}`);
+}
+
+/** Authenticate Docker to Daytona's short-lived registry without putting the secret in argv/logs. */
+async function dockerLogin(access: RegistryPushAccessDto, log: Log): Promise<string> {
+	const registry = access.registryUrl.replace(/^https?:\/\//, "").replace(/\/+$/, "");
+	log(`authenticating Docker to Daytona transient registry ${registry}`);
+	const proc = Bun.spawn(
+		["docker", "login", registry, "--username", access.username, "--password-stdin"],
+		{ stdin: "pipe", stdout: "inherit", stderr: "inherit", env: process.env },
+	);
+	proc.stdin.write(access.secret);
+	// Bun's FileSink.end() returns a Promise; await it so the write-end of the pipe is closed before we
+	// wait on exit, otherwise `docker login --password-stdin` can block on an unflushed EOF.
+	await proc.stdin.end();
+	const code = await proc.exited;
+	if (code !== 0) throw new Error(`docker login ${registry} exited ${code}`);
+	return registry;
+}
+
+/** Run cleanup after an operation without letting a cleanup failure hide the primary failure. */
+export async function withCleanupPreservingPrimaryError<T>(
+	operation: () => Promise<T>,
+	cleanup: () => Promise<void>,
+	onSuppressedCleanupError: (err: unknown) => void,
+): Promise<T> {
+	let outcome: { ok: true; value: T } | { ok: false; error: unknown };
+	try {
+		outcome = { ok: true, value: await operation() };
+	} catch (error) {
+		outcome = { ok: false, error };
+	}
+
+	try {
+		await cleanup();
+	} catch (cleanupError) {
+		if (outcome.ok) throw cleanupError;
+		onSuppressedCleanupError(cleanupError);
+	}
+
+	if (!outcome.ok) throw outcome.error;
+	return outcome.value;
+}
+
+/** Remove the short-lived registry credential and fail if Docker did not remove it. */
+async function dockerLogout(registry: string, log: Log): Promise<void> {
+	log(`removing Docker credentials for Daytona transient registry ${registry}`);
+	const proc = Bun.spawn(["docker", "logout", registry], {
+		stdout: "inherit",
+		stderr: "inherit",
+		env: process.env,
+	});
+	const code = await proc.exited;
+	if (code !== 0) throw new Error(`docker logout ${registry} exited ${code}`);
+}
+
+async function transientPushAccess(
+	apiKey: string,
+	region?: string,
+): Promise<RegistryPushAccessDto> {
+	const registryApi = new DockerRegistryApi(
+		new Configuration({
+			accessToken: apiKey,
+			basePath: "https://app.daytona.io/api",
+			baseOptions: { headers: { "X-Daytona-Source": "sandbox-benchmarks" } },
+		}),
+	);
+	return (await registryApi.getTransientPushAccess(undefined, region)).data;
+}
+
 /** Create the daytona snapshot `name` from `image` (candidate while iterating, version on promote).
  *  Idempotent: delete any existing snapshot of that name first.
  *
@@ -146,24 +256,56 @@ export function snapshotDestroyedMessage(name: string, deleted: number, reason: 
  *  unchanged. */
 export async function bakeDaytonaSnapshot(name: string, image: string, log: Log): Promise<void> {
 	const { daytona: daytonaCfg, targetSpec } = config;
+	const apiKey = daytonaCfg.apiKey;
+	if (!apiKey) throw new Error("DAYTONA_API_KEY is required to bake a Daytona snapshot");
 	const daytona = new Daytona({
-		apiKey: daytonaCfg.apiKey,
+		apiKey,
 		...(daytonaCfg.target ? { target: daytonaCfg.target } : {}),
 	});
 
-	const deleted = await deleteExistingSnapshots(daytona, name, log);
+	// The buildx publish lane does not load the pushed image into the runner's Docker daemon. Pull the
+	// immutable digest explicitly before tagging it for Daytona's transient registry.
+	// Upload fully before the destructive delete. A registry/auth/network failure therefore leaves an
+	// existing published snapshot intact and the delete→create outage is as short as the API permits.
+	const access = await transientPushAccess(apiKey, daytonaCfg.target);
+	const registry = await dockerLogin(access, log);
+	const transientRef = await withCleanupPreservingPrimaryError(
+		async () => {
+			// Construct the destination only after login so every post-login failure is inside the cleanup
+			// boundary. In particular, malformed registry metadata must not leave credentials behind.
+			const tag = new Date().toISOString().replace(/\D/g, "");
+			const destination = daytonaTransientRef(access, image, tag);
+			for (const command of daytonaTransientPushCommands(image, destination)) {
+				await runDocker(command, log);
+			}
+			return destination;
+		},
+		() => dockerLogout(registry, log),
+		(cleanupError) => {
+			log(
+				`warning: could not remove Daytona transient registry credentials after upload failure — ${cleanupError instanceof Error ? cleanupError.message : String(cleanupError)}`,
+			);
+		},
+	);
 
-	log(`creating snapshot ${name} from ${image} (target ${daytonaCfg.target ?? "default"})`);
+	const deleted = await deleteExistingSnapshots(daytona, name, log);
+	log(
+		`creating Linux-VM snapshot ${name} from uploaded image (target ${daytonaCfg.target ?? "default"})`,
+	);
 	try {
 		await daytona.snapshot.create(
 			{
 				name,
-				image,
-				resources: { cpu: targetSpec.vcpus, memory: targetSpec.memoryGb, disk: targetSpec.diskGb },
-				// Pin to microVM runners (never the `container` default) — the fleet's hard constraint.
+				image: transientRef,
+				resources: {
+					cpu: targetSpec.vcpus,
+					memory: targetSpec.memoryGb,
+					disk: targetSpec.diskGb,
+				},
+				...(daytonaCfg.target ? { regionId: daytonaCfg.target } : {}),
 				sandboxClass: SandboxClass.LINUX_VM,
 			},
-			{ onLogs: log },
+			{ onLogs: (chunk) => log(chunk) },
 		);
 	} catch (err) {
 		// Nothing was deleted → the name was already free, so the prior state (none) is intact: rethrow

--- a/apps/cli/src/lib/bake/e2b.ts
+++ b/apps/cli/src/lib/bake/e2b.ts
@@ -15,6 +15,7 @@ import { readFileSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { config } from "@sandbox-benchmarks/providers";
 import { e2bToml } from "@sandbox-benchmarks/templates/pins";
+import { resolveImageDigestRef } from "./image.ts";
 import type { Log } from "./types.ts";
 
 /** Pinned so the build is reproducible (every other tool in the toolchain is version-pinned). */
@@ -69,11 +70,12 @@ function writeE2bDockerfile(baseImage: string): void {
 /** Build the e2b template `name` from `baseImage` (the candidate base while iterating, the published
  *  version base on promote — so the template provably derives from the validated bytes). */
 export async function bakeE2bTemplate(name: string, baseImage: string, log: Log): Promise<void> {
+	const pinnedBaseImage = await resolveImageDigestRef(baseImage);
 	// Keep the on-disk manifest's template_name in sync with the name we create, and pin the base.
 	writeFileSync(`${E2B_CONTEXT}/${E2B_TOML}`, e2bToml(name));
-	writeE2bDockerfile(baseImage);
+	writeE2bDockerfile(pinnedBaseImage);
 
-	log(`e2b template create ${name} (base ${baseImage})`);
+	log(`e2b template create ${name} (base ${pinnedBaseImage})`);
 	const proc = Bun.spawn(
 		[
 			"bunx",

--- a/apps/cli/src/lib/bake/image.test.ts
+++ b/apps/cli/src/lib/bake/image.test.ts
@@ -1,5 +1,11 @@
 import { describe, expect, it } from "bun:test";
-import { imagetoolsRetagCmd } from "./image.ts";
+import {
+	digestPinnedRef,
+	imagetoolsNormalizeCmd,
+	imagetoolsRetagCmd,
+	registryManifestAbsent,
+	resolveImageDigestRef,
+} from "./image.ts";
 
 describe("imagetoolsRetagCmd", () => {
 	it("builds a registry-side retag (candidate → version) with no pull", () => {
@@ -12,5 +18,65 @@ describe("imagetoolsRetagCmd", () => {
 			"ghcr.io/o/tc:v1",
 			"ghcr.io/o/tc:v1-candidate",
 		]);
+	});
+});
+
+describe("imagetoolsNormalizeCmd", () => {
+	it("wraps the mutable candidate tag without changing its image bytes", () => {
+		const ref = "ghcr.io/o/tc:v1-candidate";
+		expect(imagetoolsNormalizeCmd(ref)).toEqual([
+			"docker",
+			"buildx",
+			"imagetools",
+			"create",
+			"-t",
+			ref,
+			ref,
+		]);
+	});
+});
+
+describe("digestPinnedRef", () => {
+	const digest = `sha256:${"a".repeat(64)}`;
+	const inspect = JSON.stringify({ manifest: { digest } });
+
+	it("replaces a mutable tag with the immutable outer image-index digest", () => {
+		expect(digestPinnedRef("ghcr.io/o/tc:v1-candidate", inspect)).toBe(`ghcr.io/o/tc@${digest}`);
+	});
+
+	it("does not mistake a registry port for a tag", () => {
+		expect(digestPinnedRef("registry.example:5000/o/tc", inspect)).toBe(
+			`registry.example:5000/o/tc@${digest}`,
+		);
+	});
+
+	it("rejects malformed or missing digests instead of falling back to the stale tag", () => {
+		expect(() => digestPinnedRef("ghcr.io/o/tc:v1", "{}")).toThrow("no valid manifest digest");
+		expect(() => digestPinnedRef("ghcr.io/o/tc:v1", "not json")).toThrow(
+			"invalid imagetools inspect JSON",
+		);
+	});
+});
+
+describe("resolveImageDigestRef", () => {
+	it("preserves an already-pinned digest instead of resolving it a second time", async () => {
+		const ref = `ghcr.io/o/tc@sha256:${"b".repeat(64)}`;
+		expect(await resolveImageDigestRef(ref)).toBe(ref);
+	});
+});
+
+describe("registryManifestAbsent", () => {
+	it("recognizes registry manifest/name absence responses", () => {
+		expect(registryManifestAbsent("no such manifest: ghcr.io/o/t:v1")).toBe(true);
+		expect(registryManifestAbsent("manifest unknown")).toBe(true);
+		expect(registryManifestAbsent("NAME_UNKNOWN: repository name not known to registry")).toBe(
+			true,
+		);
+	});
+
+	it("does not mistake local credential/tool failures for an absent remote image", () => {
+		expect(registryManifestAbsent("error getting credentials: executable not found")).toBe(false);
+		expect(registryManifestAbsent("docker-credential-osxkeychain: not found")).toBe(false);
+		expect(registryManifestAbsent("unauthorized: authentication required")).toBe(false);
 	});
 });

--- a/apps/cli/src/lib/bake/image.ts
+++ b/apps/cli/src/lib/bake/image.ts
@@ -1,6 +1,6 @@
 // Build the toolchain images and push the *candidate* base to GHCR. daytona (snapshot source) and
-// modal (Image.fromRegistry) boot the base image by ref, so the candidate base must be pushed;
-// e2b builds its template from the local `:dev` base that build.sh produces, so it needs no push.
+// modal (Image.fromRegistry) boot the base image by ref, and e2b/novita build remotely from its
+// digest-pinned registry ref, so the candidate base must be pushed before any provider bake.
 // The public `:v1` is never pushed here — that is promote's job.
 import { join } from "node:path";
 import { config } from "@sandbox-benchmarks/providers";
@@ -18,16 +18,81 @@ async function run(cmd: string[], log: Log): Promise<void> {
 }
 
 /** build.sh (base + variants, tagged `:dev` and `:v1`) → retag base `:v1`→`:v1-candidate` → push the
- *  candidate. Idempotent: the candidate tag is mutable and simply overwritten each run. */
+ *  candidate. Idempotent: the candidate tag is mutable and simply overwritten each run.
+ *
+ *  A plain `docker push` publishes a bare image manifest, while the public version is a one-platform
+ *  image index produced by `imagetools create`. Daytona's registry importer rejects the bare
+ *  candidate with an opaque inspection error even when its total compressed size is below the
+ *  accepted public image. Normalize the mutable candidate to the same envelope before providers
+ *  consume it; the config and layers stay byte-identical. */
 export async function buildAndPushCandidate(log: Log): Promise<void> {
 	await run(["bash", BUILD_SH], log);
 	await run(["docker", "tag", config.toolchainImageVersion, config.toolchainImageCandidate], log);
 	await run(["docker", "push", config.toolchainImageCandidate], log);
+	await run(imagetoolsNormalizeCmd(config.toolchainImageCandidate), log);
 }
 
 /** Pure: the buildx command that retags one pushed image ref to another registry-side (no pull). */
 export function imagetoolsRetagCmd(from: string, to: string): string[] {
 	return ["docker", "buildx", "imagetools", "create", "-t", to, from];
+}
+
+/** Wrap one pushed image manifest in a one-platform image-index envelope. Source and target
+ * intentionally name the same mutable candidate tag. */
+export function imagetoolsNormalizeCmd(ref: string): string[] {
+	return imagetoolsRetagCmd(ref, ref);
+}
+
+/** Pin a mutable registry ref to the digest returned by `imagetools inspect`. Remote template
+ * builders cache FROM/fromImage by the literal tag, so reusing `:v1-candidate` can silently rebuild
+ * from yesterday's bytes. The outer image-index digest is the immutable identity providers resolve. */
+export function digestPinnedRef(ref: string, inspectJson: string): string {
+	let parsed: { manifest?: { digest?: unknown } };
+	try {
+		parsed = JSON.parse(inspectJson);
+	} catch (err) {
+		throw new Error(`invalid imagetools inspect JSON for ${ref}`, { cause: err });
+	}
+	const digest = parsed.manifest?.digest;
+	if (typeof digest !== "string" || !/^sha256:[a-f0-9]{64}$/.test(digest)) {
+		throw new Error(`imagetools inspect returned no valid manifest digest for ${ref}`);
+	}
+	const withoutDigest = ref.split("@", 1)[0] ?? ref;
+	const lastSlash = withoutDigest.lastIndexOf("/");
+	const lastColon = withoutDigest.lastIndexOf(":");
+	const repository = lastColon > lastSlash ? withoutDigest.slice(0, lastColon) : withoutDigest;
+	return `${repository}@${digest}`;
+}
+
+/** Resolve a registry ref to its immutable outer-manifest digest for remote provider builders. */
+export async function resolveImageDigestRef(ref: string): Promise<string> {
+	// Callers pass the once-resolved digest through several provider-specific helpers. Preserve that
+	// identity instead of inspecting the registry again: a second lookup is unnecessary and could
+	// accidentally select a platform manifest rather than the outer index on a CLI behavior change.
+	if (/@sha256:[a-f0-9]{64}$/.test(ref)) return ref;
+
+	const proc = Bun.spawn(
+		["docker", "buildx", "imagetools", "inspect", ref, "--format", "{{json .}}"],
+		{ stdout: "pipe", stderr: "pipe", env: process.env },
+	);
+	const [code, stdout, stderr] = await Promise.all([
+		proc.exited,
+		new Response(proc.stdout).text(),
+		new Response(proc.stderr).text(),
+	]);
+	if (code !== 0) {
+		throw new Error(
+			`docker buildx imagetools inspect ${ref} exited ${code}: ${stderr.trim() || "unknown error"}`,
+		);
+	}
+	return digestPinnedRef(ref, stdout);
+}
+
+/** Whether Docker's registry response specifically says the manifest is absent. Keep this narrower
+ * than a generic "not found": credential helpers and executables can also be "not found", and
+ * treating those failures as an absent image would bypass the immutable-version guard. */
+export function registryManifestAbsent(stderr: string): boolean {
+	return /no such manifest|manifest unknown|name[_ ]unknown/i.test(stderr);
 }
 
 /** Whether `ref` already exists in the registry — a successful `docker manifest inspect`. Queries the
@@ -46,7 +111,7 @@ export async function imageExistsInRegistry(ref: string): Promise<boolean> {
 	});
 	const [code, stderr] = await Promise.all([proc.exited, new Response(proc.stderr).text()]);
 	if (code === 0) return true;
-	if (/no such manifest|manifest unknown|not found/i.test(stderr)) return false;
+	if (registryManifestAbsent(stderr)) return false;
 	throw new Error(
 		`docker manifest inspect ${ref} failed (exit ${code}): ${stderr.trim() || "unknown error"}`,
 	);
@@ -54,6 +119,9 @@ export async function imageExistsInRegistry(ref: string): Promise<boolean> {
 
 /** Publish the validated candidate base as the immutable public version — a registry-side retag of
  *  the exact validated bytes, so `:v1` is the same image the candidate validate booted. */
-export async function promoteImage(log: Log): Promise<void> {
-	await run(imagetoolsRetagCmd(config.toolchainImageCandidate, config.toolchainImageVersion), log);
+export async function promoteImage(
+	log: Log,
+	source: string = config.toolchainImageCandidate,
+): Promise<void> {
+	await run(imagetoolsRetagCmd(source, config.toolchainImageVersion), log);
 }

--- a/apps/cli/src/lib/bake/modal.ts
+++ b/apps/cli/src/lib/bake/modal.ts
@@ -1,12 +1,11 @@
 // "Bake" for modal: there is no separate artifact — modal boots the image directly via
 // Image.fromRegistry at create time. The candidate image just needs to be pushed (buildAndPushCandidate
 // / `--build-push`); reachability with credentials is proven by the validate boot that follows.
-import { config } from "@sandbox-benchmarks/providers";
 import type { Log } from "./types.ts";
 
-export function bakeModalImage(log: Log): Promise<void> {
+export function bakeModalImage(image: string, log: Log): Promise<void> {
 	log(
-		`modal boots ${config.toolchainImageCandidate} via fromRegistry — no artifact to bake; ` +
+		`modal boots ${image} via fromRegistry — no artifact to bake; ` +
 			`the candidate image must be pushed and reachability is the validate boot`,
 	);
 	return Promise.resolve();

--- a/apps/cli/src/lib/bake/novita.ts
+++ b/apps/cli/src/lib/bake/novita.ts
@@ -12,6 +12,7 @@
 // (independent of e2b.dev), which is why it can reuse the same version-scoped artifact name.
 import { createRequire } from "node:module";
 import { config, novitaConnection } from "@sandbox-benchmarks/providers";
+import { resolveImageDigestRef } from "./image.ts";
 import type { Log } from "./types.ts";
 
 // CJS build on purpose — same chalk dual-format race the compat module documents
@@ -28,7 +29,8 @@ export async function bakeNovitaTemplate(name: string, baseImage: string, log: L
 	if (!apiKey) throw new Error("NOVITA_API_KEY is required to bake the novita template");
 
 	const connection = novitaConnection(apiKey);
-	log(`novita Template.build ${name} via ${connection.domain} (base ${baseImage})`);
+	const pinnedBaseImage = await resolveImageDigestRef(baseImage);
+	log(`novita Template.build ${name} via ${connection.domain} (base ${pinnedBaseImage})`);
 	// Mask the PTS phoromatic units at template-build time, mirroring the base image's own mask
 	// (packages/templates/images/base/scripts/20-pts.sh). Novita boots the image with systemd as
 	// PID 1 exactly like e2b, and an unmasked phoromatic-client POWERS OFF the guest at t+300s
@@ -36,7 +38,7 @@ export async function bakeNovitaTemplate(name: string, baseImage: string, log: L
 	// Redundant-but-idempotent once the base image ships the mask — kept so the novita template is
 	// protected even when it's rebuilt from a candidate base that predates the base-image fix.
 	const template = Template()
-		.fromImage(baseImage)
+		.fromImage(pinnedBaseImage)
 		.runCmd(
 			// `set -e` so any failed mask fails the BUILD: without it the loop's exit status is the
 			// last ln's, and an unmasked phoromatic-client means every sandbox booted from this

--- a/apps/cli/src/lib/bake/promote.ts
+++ b/apps/cli/src/lib/bake/promote.ts
@@ -26,7 +26,7 @@ import { config } from "@sandbox-benchmarks/providers";
 import { forEachProviderWithCreds } from "../providers-run.ts";
 import { bakeDaytonaSnapshot } from "./daytona.ts";
 import { bakeE2bTemplate } from "./e2b.ts";
-import { imageExistsInRegistry, promoteImage } from "./image.ts";
+import { imageExistsInRegistry, promoteImage, resolveImageDigestRef } from "./image.ts";
 import { bakeNovitaTemplate } from "./novita.ts";
 import type { BakeReport, Log } from "./types.ts";
 import type { CandidateRefs } from "./validate.ts";
@@ -70,14 +70,23 @@ export async function promoteAll(log: Log, force = false): Promise<BakeReport[]>
 
 	// 2. Re-validate the candidate immediately before publishing, so the bytes we promote are verified
 	//    again (the candidate tag is mutable). Abort the whole promote if any provider fails to validate.
+	let pinnedCandidateImage: string;
+	try {
+		pinnedCandidateImage = await resolveImageDigestRef(config.toolchainImageCandidate);
+	} catch (err) {
+		const reason = `could not resolve immutable digest for ${config.toolchainImageCandidate}: ${err instanceof Error ? err.message : String(err)}`;
+		log(`<<< promote aborted — ${reason} (nothing published)`);
+		reports.push({ provider: "image", status: "failed", reason });
+		return reports;
+	}
 	const candidateRefs: CandidateRefs = {
 		e2bTemplateCandidate: config.e2bTemplateCandidate,
 		daytonaSnapshotCandidate: config.daytonaSnapshotCandidate,
 		novitaTemplateCandidate: config.novitaTemplateCandidate,
-		toolchainImageCandidate: config.toolchainImageCandidate,
+		toolchainImageCandidate: pinnedCandidateImage,
 		daytonaTarget: config.daytona.target,
 	};
-	log(`>>> re-validating candidate ${config.toolchainImageCandidate} before promote…`);
+	log(`>>> re-validating candidate ${pinnedCandidateImage} before promote…`);
 	const validateRuns = await validateCandidates(candidateRefs, log);
 	if (validateRuns.some((r) => r.status === "failed")) {
 		log("<<< promote aborted — candidate re-validation failed (nothing published)");
@@ -104,15 +113,13 @@ export async function promoteAll(log: Log, force = false): Promise<BakeReport[]>
 			log(`>>> ${provider.name}: building version artifact from candidate…`);
 			switch (provider.name) {
 				case "e2b":
-					await bakeE2bTemplate(config.e2bTemplateVersion, config.toolchainImageCandidate, (m) =>
+					await bakeE2bTemplate(config.e2bTemplateVersion, pinnedCandidateImage, (m) =>
 						log(`    ${m}`),
 					);
 					break;
 				case "daytona":
-					await bakeDaytonaSnapshot(
-						config.daytonaSnapshotDefault,
-						config.toolchainImageCandidate,
-						(m) => log(`    ${m}`),
+					await bakeDaytonaSnapshot(config.daytonaSnapshotDefault, pinnedCandidateImage, (m) =>
+						log(`    ${m}`),
 					);
 					break;
 				case "modal":
@@ -122,10 +129,8 @@ export async function promoteAll(log: Log, force = false): Promise<BakeReport[]>
 					log("    blaxel boots the stock base image — nothing to promote");
 					break;
 				case "novita":
-					await bakeNovitaTemplate(
-						config.novitaTemplateVersion,
-						config.toolchainImageCandidate,
-						(m) => log(`    ${m}`),
+					await bakeNovitaTemplate(config.novitaTemplateVersion, pinnedCandidateImage, (m) =>
+						log(`    ${m}`),
 					);
 					break;
 				default: {
@@ -199,10 +204,10 @@ export async function promoteAll(log: Log, force = false): Promise<BakeReport[]>
 	}
 
 	// 4. LAST: publish the candidate base as the immutable public version — the commit point.
-	log(`>>> promoting image ${config.toolchainImageCandidate} → ${config.toolchainImageVersion}…`);
+	log(`>>> promoting image ${pinnedCandidateImage} → ${config.toolchainImageVersion}…`);
 	const imageStart = performance.now();
 	try {
-		await promoteImage(log);
+		await promoteImage(log, pinnedCandidateImage);
 		reports.push({ provider: "image", status: "ok", durationMs: performance.now() - imageStart });
 	} catch (err) {
 		const reason = err instanceof Error ? err.message : String(err);

--- a/bun.lock
+++ b/bun.lock
@@ -28,6 +28,7 @@
         "leaderboard": "./src/bin/leaderboard.ts",
       },
       "dependencies": {
+        "@daytona/api-client": "catalog:computesdk",
         "@daytona/sdk": "catalog:computesdk",
         "@sandbox-benchmarks/harness": "workspace:*",
         "@sandbox-benchmarks/providers": "workspace:*",
@@ -165,6 +166,7 @@
       "@computesdk/e2b": "1.7.51",
       "@computesdk/modal": "1.9.3",
       "@computesdk/provider": "2.1.3",
+      "@daytona/api-client": "0.192.0",
       "@daytona/sdk": "0.192.0",
       "computesdk": "4.1.3",
       "novita-sandbox": "2.0.6",

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
         "@computesdk/e2b": "1.7.51",
         "@computesdk/modal": "1.9.3",
         "@computesdk/provider": "2.1.3",
+        "@daytona/api-client": "0.192.0",
         "@daytona/sdk": "0.192.0",
         "computesdk": "4.1.3",
         "novita-sandbox": "2.0.6"


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Make benchmark images portable and reproducible across providers by pinning the candidate image to an immutable digest and using it end to end. Daytona snapshots are now published via its transient registry with secure auth and cleanup.

- **Bug Fixes**
  - Candidate image: normalize the mutable tag to a one‑platform image index with `docker buildx imagetools`; resolve its immutable digest once after push and reuse it for validation, E2B/Novita remote builds, Modal `fromRegistry`, and promote (promote re‑validates the pinned digest and aborts if it can’t be resolved).
  - Daytona: get transient‑registry push access via `@daytona/api-client`; do secure `docker login` with stdin secret and await EOF; pull→tag→push the exact digest to a unique transient ref; always `docker logout` and preserve the primary error if cleanup fails; upload completes before snapshot delete; create a Linux‑VM snapshot in the target region from the uploaded ref.
  - Hardening: stricter manifest‑absent detection, clearer inspect errors, and CLI refactors so all bakers receive the same pinned image; added helpers/tests for imagetools normalization and digest pinning/resolve and Daytona transient refs/push/cleanup.

- **Dependencies**
  - Added `@daytona/api-client` to request transient registry push access.

<sup>Written for commit ac7e88c93213fcf1f4723c77ec02f311d1135c18. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/starslingdev/sandbox-benchmarks/pull/160?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

