### PR TITLE
fix(toolchain): bake portable PTS state

### DIFF
--- a/packages/templates/images/README.md
+++ b/packages/templates/images/README.md
@@ -40,7 +40,7 @@ The base image is built in layers, one install script per concern:
   apt, whose mise repo is rolling and serves only the latest, which would break the pin.
 - `10-mise.sh` — the mise-managed language/CLI toolchain, installed system-wide from the generated
   `mise.toml`. (This is why node/python/etc. are *not* apt packages — mise owns them.)
-- `20-pts.sh` — the Phoronix Test Suite + offline caches.
+- `20-pts.sh` — the Phoronix Test Suite + pre-installed profiles for offline runs.
 - `99-manifest.sh` — a verification manifest that fails the build on any drift.
 
 > **TODO-pin status.** The pins ship as `__TODO__` placeholders — the reference image they come from
@@ -63,8 +63,9 @@ the freshly built base. Variants share `_shared/validate-base.sh`, so their buil
 
 ## Conventions every Dockerfile / script follows
 
-- **Thin Dockerfile, fat scripts** — the Dockerfile's only `RUN` is the orchestrator; logic lives in
-  small, single-concern, `shellcheck`-clean scripts run via `bash <script>`.
+- **Thin Dockerfile, fat scripts** — Docker layers only dispatch logical groups through the
+  orchestrator; logic lives in small, single-concern, `shellcheck`-clean scripts run via
+  `bash <script>`. The groups bound compressed layer size for provider registries.
 - **Script hygiene** — `set -Eeuxo pipefail`; downloads use `curl --retry … && sha256sum -c`; `/tmp`
   is cleaned up.
 - **Variants validate their base** — `_shared/validate-base.sh` fails with a "rebuild the base first"

--- a/packages/templates/images/_shared/validate-base.sh
+++ b/packages/templates/images/_shared/validate-base.sh
@@ -17,9 +17,10 @@ command -v mise >/dev/null 2>&1 || fail "mise not found on PATH"
 [[ -x /usr/local/bin/bench-node ]] || fail "stable node symlink /usr/local/bin/bench-node missing"
 bench-node --version >/dev/null 2>&1 || fail "/usr/local/bin/bench-node is not runnable"
 
-# > Phoronix Test Suite + its pre-seeded offline caches (the whole point of baking the base).
+# > Phoronix Test Suite + at least one completely pre-installed profile for offline execution.
 command -v phoronix-test-suite >/dev/null 2>&1 || fail "phoronix-test-suite not found on PATH"
-[[ -d /var/lib/phoronix-test-suite/download-cache ]] || fail "PTS download cache missing"
+pts_installed="$(find /var/lib/phoronix-test-suite/installed-tests -name pts-install.json -type f -print -quit 2>/dev/null)"
+[[ -n "${pts_installed}" ]] || fail "pre-installed PTS profiles missing"
 
 # > The base's enforced manifest — present iff the base build's verification step ran.
 [[ -f /toolchain-manifest.json ]] || fail "/toolchain-manifest.json missing"

--- a/packages/templates/images/base/Dockerfile
+++ b/packages/templates/images/base/Dockerfile
@@ -4,8 +4,8 @@
 # (images/{e2b,daytona,modal}) composes on top via `ARG BASE_IMAGE` and adds only its delta, so the
 # toolchain layers stay byte-identical across providers via registry dedupe.
 #
-# > Thin Dockerfile, fat scripts: the only RUN is the orchestrator, which runs each numbered install
-# > script (base/scripts/NN-*.sh) in order. Scripts are shellcheck-linted outside Docker.
+# > Thin Dockerfile, fat scripts: RUN instructions only dispatch numbered install scripts
+# > (base/scripts/NN-*.sh) through the orchestrator. Scripts are shellcheck-linted outside Docker.
 #
 # > Pins are NOT read from a file. The single source of truth is the arktype-validated TypeScript
 # > config (packages/templates/src/pins.ts); build.sh validates it, passes the image/PTS pins as
@@ -45,7 +45,7 @@ ARG PTS_INSTALL_TESTS
 
 # > The description is what anonymous visitors see on the public ghcr package page.
 LABEL org.opencontainers.image.title="sandbox-benchmarks-toolchain" \
-      org.opencontainers.image.description="Pre-baked toolchain for ComputeSDK sandbox benchmarks: mise-managed tools (node, python, pnpm, hyperfine, warp, jc, quarto) and the Phoronix Test Suite with offline caches, so sandbox wall time goes to benchmarks, not setup." \
+      org.opencontainers.image.description="Pre-baked toolchain for ComputeSDK sandbox benchmarks: mise-managed tools (node, python, pnpm, hyperfine, warp, jc, quarto) and pre-installed Phoronix Test Suite profiles for offline runs, so sandbox wall time goes to benchmarks, not setup." \
       org.opencontainers.image.source="https://github.com/starslingdev/sandbox-benchmarks" \
       org.opencontainers.image.base.name="${BASE_IMAGE}" \
       org.opencontainers.image.created="${BUILD_DATE}" \
@@ -54,7 +54,7 @@ LABEL org.opencontainers.image.title="sandbox-benchmarks-toolchain" \
 
 # > Build-only: DEBIAN_FRONTEND is an ARG, not ENV, so it isn't baked into this image or the variants
 # > built FROM it (a persistent ENV would silently suppress interactive prompts in derived images).
-# > It's handed to the orchestrator RUN below, scoped to the build.
+# > It's handed to the orchestrator RUNs below, scoped to the build.
 ARG DEBIAN_FRONTEND=noninteractive
 
 # > mise lives system-wide: one shared toolchain for every sandbox user, on PATH via its shims dir.
@@ -62,6 +62,7 @@ ARG DEBIAN_FRONTEND=noninteractive
 # > These MUST persist at runtime, so they stay ENV.
 ENV MISE_DATA_DIR=/usr/local/share/mise \
     MISE_CONFIG_DIR=/etc/mise \
+    PTS_USER_PATH_OVERRIDE=/var/lib/phoronix-test-suite/ \
     PATH=/usr/local/share/mise/shims:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
 
 # > Login bash with pipefail so a failure anywhere in a piped RUN (and inside the scripts) aborts
@@ -76,22 +77,31 @@ COPY mise.toml /etc/mise/config.toml
 # > shipped as-is — 99-manifest.sh confirms it landed; the smoke spec verifies the runtime matches it.
 COPY toolchain-manifest.json /toolchain-manifest.json
 
-# > orchestrator.sh runs each NN-*.sh install script in order; the manifest step fails the build on
-# > any drift. Pins are passed to the orchestrator as env (from the ARGs above) for this RUN only, so
-# > versions are not baked into the final image's environment.
+# > Split the install into bounded layers. The expanded PTS profile matrix made the former single
+# > compressed layer exceed 1 GiB; Daytona's snapshot registry rejects that layer with an opaque
+# > inspection error. Grouping apt+mise, PTS, and verification separately keeps each layer portable
+# > without moving install logic out of the shellcheck-linted scripts. Pins remain RUN-scoped and are
+# > not baked into the final image's environment.
 COPY scripts /tmp/build/scripts
 RUN DEBIAN_FRONTEND="${DEBIAN_FRONTEND}" \
-    IMAGE_NAME="${IMAGE_NAME}" IMAGE_VERSION="${IMAGE_VERSION}" BASE_IMAGE="${BASE_IMAGE}" \
     MISE_VERSION="${MISE_VERSION}" MISE_SHA256_X64="${MISE_SHA256_X64}" MISE_SHA256_ARM64="${MISE_SHA256_ARM64}" \
+    bash /tmp/build/scripts/orchestrator.sh 00-apt.sh 10-mise.sh
+# Separate layer is the provider portability constraint documented above.
+# hadolint ignore=DL3059
+RUN DEBIAN_FRONTEND="${DEBIAN_FRONTEND}" \
     PTS_VERSION="${PTS_VERSION}" PTS_DEB_SHA256="${PTS_DEB_SHA256}" PTS_INSTALL_TESTS="${PTS_INSTALL_TESTS}" \
-    bash /tmp/build/scripts/orchestrator.sh \
+    bash /tmp/build/scripts/orchestrator.sh 20-pts.sh
+# Keep verification/cleanup out of the already bounded install layers.
+# hadolint ignore=DL3059
+RUN IMAGE_NAME="${IMAGE_NAME}" IMAGE_VERSION="${IMAGE_VERSION}" BASE_IMAGE="${BASE_IMAGE}" \
+    bash /tmp/build/scripts/orchestrator.sh 99-manifest.sh \
     && rm -rf /tmp/build
 
-# > Security note: this image intentionally runs as root. Sandbox providers manage their own user
-# > namespace/isolation around it, and the PTS suites + their root-owned state under
-# > /var/lib/phoronix-test-suite assume root at runtime. Hardening is therefore done by minimizing the
-# > image (digest-pinned base, no sudo, --no-install-recommends, pruned apt lists) rather than dropping
-# > privileges. Any setuid binary added later should be justified here.
+# > Security note: the generic image defaults to root, while E2B-compatible template builders inject
+# > an unprivileged runtime user. PTS_USER_PATH_OVERRIDE keeps both identities on the same pre-baked
+# > state under /var/lib/phoronix-test-suite; 20-pts.sh grants sandbox users write access because PTS
+# > writes per-run config and results there. Isolation remains the provider's outer VM/container
+# > boundary. Any setuid binary added later should be justified here.
 #
 # > Plain `docker build` yields the generic toolchain image. Provider glue lives in the variant
 # > Dockerfiles (FROM this image) — never here — so these layers stay shared across providers.

--- a/packages/templates/images/base/scripts/00-apt.sh
+++ b/packages/templates/images/base/scripts/00-apt.sh
@@ -31,7 +31,7 @@ apt-get update
 # > 0 there, so the failure only surfaces in 20-pts.sh's post-install verification.
 apt-get install -y --no-install-recommends \
 	curl git ca-certificates \
-	build-essential \
+	build-essential autoconf \
 	php-cli php-xml \
 	flex bison bc libelf-dev libssl-dev libaio-dev libicu-dev \
 	dnsutils jq netcat-openbsd iputils-ping \

--- a/packages/templates/images/base/scripts/20-pts.sh
+++ b/packages/templates/images/base/scripts/20-pts.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
-# Install the Phoronix Test Suite, pre-seed its offline download caches, and pre-install the small
-# profiles so sandbox wall time goes to benchmarks, not setup. Pins arrive as environment variables
+# Install the Phoronix Test Suite and pre-install the benchmark profiles for offline execution, so
+# sandbox wall time goes to benchmarks, not setup. Pins arrive as environment variables
 # (from the arktype-validated packages/templates/src/pins.ts via build-args). Runs after 10-mise so
 # pyperformance's pip-install targets the mise-managed python on PATH.
 set -Eeuxo pipefail
@@ -33,19 +33,18 @@ for unit in phoromatic-client phoromatic-server phoronix-result-server; do
 	ln -sf /dev/null "/etc/systemd/system/${unit}.service"
 done
 
-# > Non-interactive batch config + offline download caches for the PTS-backed suites. Build and
+# > Non-interactive batch config + staged downloads for the PTS-backed suites. Build and
 # > sandboxes both run as root, so PTS state under /var/lib/phoronix-test-suite lines up at runtime.
 # > PTS_INSTALL_TESTS is a space-separated list, so split it into an array to pass each profile as
 # > its own argument.
 printf 'y\nn\nn\nn\nn\nn\ny\n' | phoronix-test-suite batch-setup
 read -ra pts_tests <<< "${PTS_INSTALL_TESTS}"
 
-# > The cache list DERIVES from the install list (same versioned pins — caching a different version
-# > than the leaves batch-run would send the runtime back to the network), plus the build-* / git
-# > profiles that are cached-but-not-preinstalled (too big to bake; not yet wired to a suite).
+# > The staging list DERIVES from the install list (same versioned pins — caching a different version
+# > than the leaves batch-run would send the installer back to the network). Do not cache unwired
+# > future profiles: provider snapshot registries must import the complete compressed image.
 # > network-loopback has no downloads and no-ops here harmlessly.
-phoronix-test-suite make-download-cache \
-	build-linux-kernel build-nodejs git "${pts_tests[@]}"
+phoronix-test-suite make-download-cache "${pts_tests[@]}"
 # > PTS exits 0 even when an install fails, so verify each requested profile actually reports installed.
 # > A versionless entry anchors on "<test>-<version>" (versions start with a digit); a version-pinned
 # > entry ("fio-2.1.0") already ends in its version, so it anchors on a following non-name character
@@ -56,3 +55,29 @@ installed="$(phoronix-test-suite list-installed-tests)"
 for t in "${pts_tests[@]}"; do
 	echo "${installed}" | grep -qE "(^|/)${t}(-[0-9]|[[:space:]]|$)" || { echo "ERROR: pre-install of ${t} failed" >&2; exit 1; }
 done
+
+# > batch-install copies each staged archive into its installed-test tree. Keeping the byte-identical
+# > source in download-cache pays for it twice in every provider snapshot (silesia.tar alone is
+# > ~212 MiB). Runtime leaves explicitly detect pts-install.json and skip reinstall, so the installed
+# > copy is the offline source of truth. Remove only files proven identical; retain PTS's small cache
+# > index and any non-duplicated payload defensively.
+cache_dir=/var/lib/phoronix-test-suite/download-cache
+installed_dir=/var/lib/phoronix-test-suite/installed-tests
+if [ -d "${cache_dir}" ] && [ -d "${installed_dir}" ]; then
+	find "${cache_dir}" -maxdepth 1 -type f ! -name pts-download-cache.json -print0 |
+		while IFS= read -r -d '' cached; do
+			name="$(basename "${cached}")"
+			duplicate="$(find "${installed_dir}" -type f -name "${name}" -print -quit)"
+			if [ -n "${duplicate}" ] && cmp -s "${cached}" "${duplicate}"; then
+				echo "::: pruning duplicate PTS download: ${name}"
+				rm -f "${cached}"
+			fi
+		done
+fi
+
+# > E2B and Novita inject an unprivileged runtime user after importing this image. PTS otherwise
+# > switches from the root bake's /var/lib state to $HOME/.phoronix-test-suite, making every baked
+# > profile invisible. The image ENV pins PTS_USER_PATH_OVERRIDE to this existing directory; make the
+# > ephemeral benchmark state writable so that user can create batch config and result XML beside the
+# > read-mostly installed profiles. Provider isolation is the outer security boundary for this image.
+chmod -R a+rwX /var/lib/phoronix-test-suite

--- a/packages/templates/images/base/scripts/99-manifest.sh
+++ b/packages/templates/images/base/scripts/99-manifest.sh
@@ -2,16 +2,18 @@
 # Verification step. /toolchain-manifest.json is generated host-side from the arktype-validated pins
 # (the single source of truth — see packages/templates/src/manifest.ts) and COPY'd in by the
 # Dockerfile, so it can't drift from what `mise install` baked (both derive from the same pins). Here
-# we confirm it landed for the expected image and that the pre-seeded PTS cache is non-empty; the
+# we confirm it landed for the expected image and that pre-installed PTS state is non-empty; the
 # in-sandbox smoke spec verifies the actual runtime versions match the declared manifest.
 set -Eeuxo pipefail
 
 : "${IMAGE_NAME:?}"
 
-# > PTS exits 0 even when downloads fail, so an empty cache would silently ship a toolchain that
-# > benchmarks nothing — the whole point of baking is the pre-seeded cache.
-[ -n "$(ls -A /var/lib/phoronix-test-suite/download-cache 2>/dev/null)" ] \
-	|| { echo "ERROR: PTS download-cache is empty (make-download-cache failed?)" >&2; exit 1; }
+# > PTS exits 0 even when installs fail, so require a completed install manifest here too. The build
+# > step verifies every requested profile individually; this final stage proves installed state still
+# > exists after duplicate download payloads were pruned.
+pts_installed="$(find /var/lib/phoronix-test-suite/installed-tests -name pts-install.json -type f -print -quit 2>/dev/null)"
+[ -n "${pts_installed}" ] \
+	|| { echo "ERROR: no pre-installed PTS profiles found" >&2; exit 1; }
 
 # > Confirm the generated manifest was COPY'd in and is for this image.
 [ -f /toolchain-manifest.json ] \

--- a/packages/templates/images/base/scripts/orchestrator.sh
+++ b/packages/templates/images/base/scripts/orchestrator.sh
@@ -1,21 +1,36 @@
 #!/usr/bin/env bash
-# Orchestrates the base toolchain build: run each numbered install script in order. The two-digit
-# prefix encodes the build sequence (00-apt → 10-mise → 20-pts → 99-manifest); dropping a new
-# NN-*.sh into this directory adds it to the build with no edit here.
+# Orchestrates the base toolchain build: run either the named scripts passed by the Dockerfile or,
+# when called without arguments, every numbered install script in order. The two-digit prefix encodes
+# the build sequence (00-apt → 10-mise → 20-pts → 99-manifest).
 #
 # The pins each script needs arrive as environment variables (the Dockerfile passes them from build
 # args sourced, in turn, from the arktype-validated TS config — packages/templates/src/pins.ts). Each
 # script asserts what it needs with `: "${VAR:?}"`, so a missing pin fails the build loudly.
 #
-# > Thin Dockerfile, fat scripts: the Dockerfile's only RUN is this orchestrator. Scripts run via
-# > `bash <script>` (not `./<script>`) so a lost exec bit from git/COPY never breaks the build.
+# > Thin Dockerfile, fat scripts: each Docker layer calls this orchestrator with one logical group.
+# > Scripts run via `bash <script>` (not `./<script>`) so a lost exec bit from git/COPY never breaks
+# > the build.
 set -Eeuxo pipefail
 
 HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
-# > nullglob so the loop is a no-op (not the literal pattern) if a stage hasn't landed yet.
-shopt -s nullglob
-for script in "${HERE}"/[0-9][0-9]-*.sh; do
+# > Explicit groups let the Dockerfile bound compressed layer size for provider registries. Keep the
+# > no-argument mode for local debugging and backwards compatibility.
+if (( $# > 0 )); then
+	scripts=()
+	for name in "$@"; do
+		[[ "${name}" =~ ^[0-9][0-9]-[a-z0-9_-]+\.sh$ ]] || { echo "invalid build script: ${name}" >&2; exit 1; }
+		scripts+=("${HERE}/${name}")
+	done
+else
+	shopt -s nullglob
+	scripts=("${HERE}"/[0-9][0-9]-*.sh)
+fi
+
+(( ${#scripts[@]} > 0 )) || { echo "no build scripts selected" >&2; exit 1; }
+
+for script in "${scripts[@]}"; do
+	[[ -f "${script}" ]] || { echo "missing build script: ${script}" >&2; exit 1; }
 	echo "::: running $(basename "${script}")"
 	bash "${script}"
 done

--- a/packages/templates/src/smoke.test.ts
+++ b/packages/templates/src/smoke.test.ts
@@ -1,6 +1,21 @@
 import { describe, expect, it } from "bun:test";
 import type { SmokeExec } from "./smoke.ts";
-import { runSmoke, smokeBashScript, smokeChecks } from "./smoke.ts";
+import { ptsInstalledTestsSmokeCheck, runSmoke, smokeBashScript, smokeChecks } from "./smoke.ts";
+
+async function runPtsCheck(
+	installTests: string,
+	installedProfiles: string[],
+): Promise<{
+	exitCode: number;
+	stdout: string;
+}> {
+	const check = ptsInstalledTestsSmokeCheck(installTests);
+	const output = installedProfiles.map((profile) => `'${profile}'`).join(" ");
+	const script = `phoronix-test-suite() { printf '%s\\n' ${output}; }; ${check.cmd}`;
+	const proc = Bun.spawn(["bash", "-c", script], { stdout: "pipe", stderr: "pipe" });
+	const [exitCode, stdout] = await Promise.all([proc.exited, new Response(proc.stdout).text()]);
+	return { exitCode, stdout };
+}
 
 describe("@sandbox-benchmarks/templates smoke", () => {
 	it("defines a non-empty spec with unique names and a cmd/expect per check", () => {
@@ -11,6 +26,39 @@ describe("@sandbox-benchmarks/templates smoke", () => {
 			expect(c.cmd.length).toBeGreaterThan(0);
 			expect(c.expect.length).toBeGreaterThan(0);
 		}
+	});
+
+	// The count (9) and sample profile name are hardcoded on purpose: this is a drift tripwire, not a
+	// derived assertion. Deriving them from pins.ptsInstallTests would make the test a tautology that
+	// tracks the generator instead of pinning it — the exact failure this guards against (a mutable-tag
+	// cache once validated an old two-profile image against a nine-profile candidate). When the pin list
+	// changes, update these literals deliberately.
+	it("requires every pinned PTS profile, so a stale partial image cannot pass smoke", () => {
+		const pts = smokeChecks.find((check) => check.name === "pts-installed-tests");
+		expect(pts?.expect).toBe("pts-profile-count=9");
+		expect(pts?.cmd).toContain("phoronix-test-suite list-installed-tests");
+		expect(pts?.cmd).toContain("PTS_USER_PATH_OVERRIDE=/var/lib/phoronix-test-suite/");
+		expect(pts?.cmd).toContain("node-web-tooling-1.0.1");
+		expect(pts?.cmd).toContain('[ "$actual" -eq 9 ]');
+		expect(pts?.cmd).toContain('echo "pts-profile-count=$actual"');
+	});
+
+	it("handles an empty PTS install list without emitting invalid shell", async () => {
+		const check = ptsInstalledTestsSmokeCheck("  ");
+		expect(check.cmd).not.toContain("for test in");
+		expect((await runPtsCheck("  ", [])).exitCode).toBe(0);
+		expect((await runPtsCheck("  ", ["pts/unexpected-1.0.0"])).exitCode).toBe(1);
+	});
+
+	it("accepts versionless pins but requires version-pinned entries literally", async () => {
+		const result = await runPtsCheck("c-ray fio-2.1.0", ["pts/c-ray-2.0.0", "pts/fio-2.1.0"]);
+		expect(result.exitCode).toBe(0);
+		expect(result.stdout).toContain("pts-profile-count=2");
+	});
+
+	it("rejects an unexpected extra installed profile instead of echoing the expected count", async () => {
+		const result = await runPtsCheck("fio-2.1.0", ["pts/fio-2.1.0", "pts/stream-1.3.4"]);
+		expect(result.exitCode).toBe(1);
 	});
 
 	it("emits a bash script asserting every probe", () => {

--- a/packages/templates/src/smoke.ts
+++ b/packages/templates/src/smoke.ts
@@ -37,6 +37,35 @@ export interface SmokeExecResult {
 }
 export type SmokeExec = (cmd: string) => Promise<SmokeExecResult>;
 
+const shellQuote = (value: string): string => `'${value.replace(/'/g, `'\\''`)}'`;
+
+/** Build the PTS smoke probe from an install list. Exported so edge cases stay executable tests. */
+export function ptsInstalledTestsSmokeCheck(installTests: string): SmokeCheck {
+	const expectedProfiles = installTests.split(/\s+/).filter(Boolean);
+	const expectedCount = expectedProfiles.length;
+	const tests = expectedProfiles.map(shellQuote).join(" ");
+	const verifyExpected =
+		expectedCount === 0
+			? ""
+			: `for test in ${tests}; do ` +
+				`if printf '%s\\n' "$profiles" | grep -qxF -- "pts/$test"; then continue; fi; ` +
+				`prefix="pts/$test-"; ` +
+				`if printf '%s\\n' "$profiles" | awk -v prefix="$prefix" 'index($0, prefix) == 1 { suffix = substr($0, length(prefix) + 1); if (suffix ~ /^[0-9]/) found = 1 } END { exit !found }'; then continue; fi; ` +
+				`printf 'missing pts/%s\\n%s\\n' "$test" "$installed"; exit 1; ` +
+				`done; `;
+	return {
+		name: "pts-installed-tests",
+		cmd:
+			'installed="$(PTS_USER_PATH_OVERRIDE=/var/lib/phoronix-test-suite/ phoronix-test-suite list-installed-tests 2>/dev/null)"; ' +
+			`profiles="$(printf '%s\\n' "$installed" | awk '$1 ~ /^pts\\// { print $1 }')"; ` +
+			verifyExpected +
+			`actual="$(printf '%s\\n' "$profiles" | awk 'NF { count++ } END { print count + 0 }')"; ` +
+			`[ "$actual" -eq ${expectedCount} ] || { printf 'expected ${expectedCount} PTS profiles, found %s\\n%s\\n' "$actual" "$installed"; exit 1; }; ` +
+			`echo "pts-profile-count=$actual"`,
+		expect: `pts-profile-count=${expectedCount}`,
+	};
+}
+
 /**
  * The probes, in run order. Expects are pinned to the same pins.ts that built the image, so this
  * asserts the *exact* toolchain is present — not merely that "a" node/python exists.
@@ -55,16 +84,10 @@ export const smokeChecks: readonly SmokeCheck[] = [
 	{ name: "jc", cmd: "jc --version", expect: pins.jcVersion },
 	{ name: "quarto", cmd: "quarto --version", expect: pins.quartoVersion },
 	{ name: "warp", cmd: "warp --version", expect: pins.warpVersion },
-	// PTS offline caches were pre-seeded (the whole point of baking the base). `find … -type f` lists
-	// the cached files; the trailing-slash expect matches a real file path (…/download-cache/<file>)
-	// but NOT find's missing-dir error (…/download-cache'), so this proves the cache is NON-EMPTY —
-	// not merely that the directory exists. A single command with no shell operators, so it behaves
-	// the same whether the executor runs it through a shell or via exec.
-	{
-		name: "pts-download-cache",
-		cmd: "find /var/lib/phoronix-test-suite/download-cache -type f",
-		expect: "download-cache/",
-	},
+	// Every pinned PTS profile was pre-installed for offline runs (the whole point of baking the base).
+	// Exact count is deliberate: a mutable-tag cache once made E2B/Novita validate an old two-profile
+	// image while the current candidate held nine. The sentinel also avoids substring false positives.
+	ptsInstalledTestsSmokeCheck(pins.ptsInstallTests),
 	// The enforced verification manifest is present (proves the base build's 99-manifest step ran)…
 	{ name: "manifest", cmd: "cat /toolchain-manifest.json", expect: TOOLCHAIN_IMAGE_NAME },
 	// …and declares the expected toolchain version, so a stale/wrong-version manifest fails loudly.


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Pre-installs pinned Phoronix Test Suite profiles and splits the build into three small layers to keep the image portable across provider snapshot registries. Tightens validation and smoke to require the exact 9-profile set, supports non-root runtimes, and prunes duplicate payloads to reduce size.

- **Bug Fixes**
  - Pre-install pinned `phoronix-test-suite` profiles for offline runs; only stage requested downloads and prune duplicate archives.
  - Replace cache checks with installed-profile checks in `_shared/validate-base.sh` and `99-manifest.sh`; smoke enforces exactly 9 profiles and fails on extras/missing.
  - Make baked PTS state work for non-root users via `PTS_USER_PATH_OVERRIDE=/var/lib/phoronix-test-suite/` and relaxed perms.
  - Add `autoconf`; update image label and README.

- **Refactors**
  - Split Docker build into three RUNs (apt+mise, PTS, manifest) to keep each layer under provider limits.
  - Update `orchestrator.sh` to accept explicit script lists per layer, with a no-arg fallback for local runs.

<sup>Written for commit da766e266c0db13b4a92d48085ad77f6a89d50bb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/starslingdev/sandbox-benchmarks/pull/161?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Base images now validate and include a complete, pre-installed Phoronix Test Suite set to support reliable offline runs.
  * PTS state is aligned for non-root runtime users.
* **Bug Fixes**
  * Reduced unnecessary PTS download-cache contents and deduplicated overlapping artifacts to shrink layers.
  * Added `autoconf` to base build dependencies.
  * Improved build-time validation so missing installed profiles fail clearly.
* **Documentation**
  * Updated guidance on offline PTS setup and image layer conventions.
* **Tests**
  * Expanded smoke checks to verify the exact installed PTS profile set and pin behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->