### PR TITLE
fix(bench): make PTS runtime setup portable

### DIFF
--- a/lib/bench.sh
+++ b/lib/bench.sh
@@ -135,9 +135,16 @@ bench_cmd() {
 
 # --- Phoronix Test Suite (PTS) helpers ---
 
-# Locate PTS's data directory. PTS uses $HOME/.phoronix-test-suite for an unprivileged user but
-# /var/lib/phoronix-test-suite for root (the case on sandbox runners). Detected by core.pt2so, which
-# pts_init guarantees exists. Cached for the shell.
+# The toolchain bakes profiles as root under /var/lib, but E2B-compatible providers inject an
+# unprivileged runtime user. PTS 10.8.4 supports this official override when the directory exists.
+# Set it here as a fallback in case an image importer strips the Docker ENV; the harness preamble does
+# the same before setup/smoke commands, so all PTS call sites see one registry.
+if [ -d /var/lib/phoronix-test-suite ]; then
+	export PTS_USER_PATH_OVERRIDE=/var/lib/phoronix-test-suite/
+fi
+
+# Locate PTS's effective data directory. Prefer its supported override, then probe legacy root/user
+# locations by core.pt2so, which pts_init guarantees exists. Cached for the shell.
 _pts_user_dir_cached=""
 pts_init() {
 	# system-info is cheap and writes core.pt2so on first run; swallow all output.
@@ -148,8 +155,9 @@ pts_user_dir() {
 		echo "$_pts_user_dir_cached"
 		return 0
 	fi
-	local cand dir="${HOME}/.phoronix-test-suite"
-	for cand in "${HOME}/.phoronix-test-suite" "/var/lib/phoronix-test-suite" "/root/.phoronix-test-suite"; do
+	local cand dir="${PTS_USER_PATH_OVERRIDE:-${HOME}/.phoronix-test-suite}"
+	for cand in "${PTS_USER_PATH_OVERRIDE:-}" "${HOME}/.phoronix-test-suite" "/var/lib/phoronix-test-suite" "/root/.phoronix-test-suite"; do
+		[ -n "$cand" ] || continue
 		if [ -e "${cand}/core.pt2so" ]; then
 			dir="$cand"
 			break
@@ -164,15 +172,80 @@ pts_user_dir() {
 # PTS_IS_DAEMONIZED_SERVER_PROCESS whenever /var/lib AND /etc are both writable — i.e. whenever it
 # runs as root, which is every sandbox provider here — and in that mode it uses
 # /etc/phoronix-test-suite.xml UNCONDITIONALLY, without so much as probing the user dir. So under
-# root, user-config.xml is the file PTS never touches, and /etc is the live config. Only an
-# unprivileged run falls through to ${PTS_USER_PATH}/user-config.xml — and even then a writable
-# /etc/phoronix-test-suite.xml, if one exists, still wins.
+# root, user-config.xml is the file PTS never touches, and /etc is the live config. An unprivileged
+# run falls through to ${PTS_USER_PATH}/user-config.xml (the baked override here) — and even then a
+# writable /etc/phoronix-test-suite.xml, if one exists, still wins.
 pts_config_file() {
 	if { [ -w /var/lib ] && [ -w /etc ]; } || [ -w /etc/phoronix-test-suite.xml ]; then
 		echo /etc/phoronix-test-suite.xml
 		return 0
 	fi
 	echo "$(pts_user_dir)/user-config.xml"
+}
+
+# Ask PTS whether the fully-qualified profile is installed. The on-disk manifest name is an internal,
+# version-dependent detail (10.8.4 writes pts-install.json; older releases wrote .xml), while this is
+# the same public command the image bake uses to verify every preinstalled profile.
+_pts_is_installed() {
+	phoronix-test-suite list-installed-tests 2>/dev/null | awk '{print $1}' | grep -qxF -- "$1"
+}
+
+# Installation failures are otherwise opaque because PTS can exit 0 after a compiler/dependency
+# failure. Emit its own installed list, candidate data roots, and the newest install-failed.log. This
+# is diagnostic-only and callers run it best-effort, so it cannot turn an honest skip into a crash.
+_pts_install_diagnostics() {
+	local test_name="$1"
+	# Build this list at call time: provider preambles can change HOME or the supported PTS override
+	# after bench.sh is sourced. Normalize trailing slashes and deduplicate before handing the roots to
+	# find, otherwise the baked /var/lib override is traversed twice and every diagnostic is repeated.
+	local d existing seen pts_dir
+	local -a data_dirs=()
+	for d in "${PTS_USER_PATH_OVERRIDE:-${HOME}/.phoronix-test-suite}" "${HOME}/.phoronix-test-suite" /var/lib/phoronix-test-suite /root/.phoronix-test-suite; do
+		[ -n "$d" ] || continue
+		[ "$d" = "/" ] || d="${d%/}"
+		seen=0
+		for existing in "${data_dirs[@]}"; do
+			if [ "$existing" = "$d" ]; then
+				seen=1
+				break
+			fi
+		done
+		[ "$seen" -eq 1 ] || data_dirs+=("$d")
+	done
+
+	# Initialize before the first pts_user_dir lookup so its process-lifetime cache records the data
+	# directory PTS actually selected, rather than a pre-initialization fallback.
+	pts_init
+	pts_dir="$(pts_user_dir)"
+	echo "--- PTS install diagnostics: ${test_name} ---"
+	echo "user=$(id -un 2>/dev/null) HOME=${HOME}"
+	echo "resolved pts_user_dir=${pts_dir}"
+	echo "resolved pts_config_file=$(pts_config_file)"
+	for d in "${data_dirs[@]}"; do
+		[ -e "$d/core.pt2so" ] && echo "  core.pt2so present in: $d"
+	done
+	echo "  phoronix-test-suite list-installed-tests:"
+	phoronix-test-suite list-installed-tests 2>/dev/null | sed 's/^/    /' || true
+	echo "  install manifests on disk:"
+	find "${data_dirs[@]}" -maxdepth 5 \( -name pts-install.json -o -name pts-install.xml \) \
+		2>/dev/null | sed 's/^/    /' || true
+	echo "  installed-tests tree (${pts_dir}/installed-tests):"
+	find "${pts_dir}/installed-tests" -maxdepth 3 2>/dev/null | sed 's/^/    /' | head -40 || true
+	local log
+	log=$(find "${data_dirs[@]}" -name install-failed.log -exec ls -t {} + 2>/dev/null | head -1)
+	if [ -n "$log" ] && [ -f "$log" ]; then
+		echo "  install-failed.log ($log), last 40 lines:"
+		tail -40 "$log" 2>/dev/null | sed 's/^/    /' || true
+	else
+		echo "  (no install-failed.log found under any candidate data dir)"
+	fi
+	echo "--- end diagnostics ---"
+}
+
+# Profile names become both source and destructive destination paths below. Restrict them to one
+# ordinary path segment before either function reaches rm -rf.
+_pts_profile_name_is_safe() {
+	[[ "$1" =~ ^[a-z0-9][a-z0-9._-]*$ ]]
 }
 
 # Configure PTS batch mode in the current process. Must run before batch-run, since mise subtasks
@@ -195,11 +268,11 @@ _configure_pts_batch() {
 	# name would let a failed later leaf collect an earlier leaf's merged composite as its own.
 	export TEST_RESULTS_DESCRIPTION=ci
 	export TEST_RESULTS_IDENTIFIER=ci
-	# FORCE_TIMES_TO_RUN=1 pins every test to a single pass (fast, but no in-sandbox repeats to
-	# aggregate). The sandbox harness sets PTS_RESPECT_TIMES_TO_RUN=1 to opt out, so PTS honours each
-	# profile's TimesToRun (our profiles pin 2 — the floor; PTS re-runs beyond it when a test's
-	# stddev stays high) and writes the repeated samples our normalizer reads from RawString — the
-	# statistical confidence we want there.
+	# FORCE_TIMES_TO_RUN=1 pins contract-verification runs to a single pass. Published sandbox runs
+	# export PTS_RESPECT_TIMES_TO_RUN=1 plus FORCE_TIMES_TO_RUN=2 in the harness preamble: two balanced
+	# trials are the pinned count (see the preamble on why more trials aren't bought), while disabling
+	# PTS's adaptive variance policy (which otherwise expanded noisy fio cases to 20-40 runs and
+	# exhausted the suite).
 	if [ -z "${PTS_RESPECT_TIMES_TO_RUN:-}" ]; then
 		export FORCE_TIMES_TO_RUN=1
 	fi
@@ -254,15 +327,15 @@ ensure_pts() {
 			local tmp_deb
 			tmp_deb="$(mktemp /tmp/pts-XXXXXX.deb)"
 			# Group with `|| true` so a failed install can't abort a caller running under `set -e` —
-			# ensure_pts's contract is to return 1 gracefully so the caller can skip.
-			# The package list mirrors the harness setup fallback (packages/harness/src/lib/setup.ts):
+			# ensure_pts's contract is to return 1 gracefully so the caller can skip. This is the
+			# last-resort stock-image path; keep the package set aligned with setup.ts and 00-apt.sh.
 			# php for PTS itself, the build toolchain for the source-built profiles, libaio-dev (fio's
-			# Linux AIO engine), libicu-dev (postgres's configure hard-requires ICU), and the probe deps
-			# — without them the profiles install "successfully" and then burn their timed runs failing.
+			# Linux AIO engine), libicu-dev (postgres), tcl (sqlite), stress-ng (hardlink), and probes.
 			(curl -fsSL "$deb_url" -o "$tmp_deb" &&
-				${SUDO:-} apt-get update -qq &&
-				${SUDO:-} apt-get install -y -qq php-cli php-xml build-essential flex bison bc \
-					libelf-dev libssl-dev libaio-dev libicu-dev dnsutils jq netcat-openbsd iputils-ping &&
+				${SUDO:-} apt-get -o Acquire::Retries=3 update -qq &&
+				${SUDO:-} apt-get install -y -qq php-cli php-xml build-essential autoconf flex bison bc \
+					libelf-dev libssl-dev libaio-dev libicu-dev dnsutils jq netcat-openbsd iputils-ping \
+					tcl stress-ng unzip procps &&
 				${SUDO:-} dpkg -i "$tmp_deb") || true
 			rm -f "$tmp_deb"
 		fi
@@ -290,6 +363,10 @@ install_local_pts_profile() {
 		echo "ERROR: install_local_pts_profile requires a profile name" >&2
 		return 1
 	fi
+	if ! _pts_profile_name_is_safe "$name"; then
+		echo "ERROR: install_local_pts_profile: invalid profile name: ${name}" >&2
+		return 1
+	fi
 	shift
 	local src="${REPO_ROOT}/packages/schema/src/pts-profiles/local/${name}"
 	# Fail before the rm -rf below: a missing source (typo'd name, wrong REPO_ROOT) must not delete
@@ -315,6 +392,42 @@ install_local_pts_profile() {
 	echo "Installed local PTS profile: ${dst} (PTS data dir: ${pts_dir})"
 }
 
+# Stage a vendored override for one pinned upstream `pts/` profile and discard the baked installed
+# copy so run_pts_benchmark verifies and installs the override. This preserves the upstream
+# `pts/<name>` identifier (and therefore the catalog join key) while letting us repair a broken
+# runner reproducibly instead of depending on a mutable OpenBenchmarking copy.
+# Usage: install_vendored_pts_profile <name-version>
+install_vendored_pts_profile() {
+	local name="${1:-}"
+	if [ -z "$name" ]; then
+		echo "ERROR: install_vendored_pts_profile requires a profile name" >&2
+		return 1
+	fi
+	if ! _pts_profile_name_is_safe "$name"; then
+		echo "ERROR: install_vendored_pts_profile: invalid profile name: ${name}" >&2
+		return 1
+	fi
+	local src="${REPO_ROOT}/packages/schema/src/pts-profiles/${name}"
+	if [ ! -d "$src" ]; then
+		echo "ERROR: install_vendored_pts_profile: source profile not found: ${src}" >&2
+		return 1
+	fi
+
+	pts_init
+	local pts_dir profile_dst installed_dst
+	pts_dir="$(pts_user_dir)"
+	profile_dst="${pts_dir}/test-profiles/pts/${name}"
+	installed_dst="${pts_dir}/installed-tests/pts/${name}"
+	mkdir -p "$(dirname "$profile_dst")"
+	rm -rf "$profile_dst"
+	cp -r "$src" "$profile_dst"
+	# The image bakes the upstream profile. Removing only this pinned install makes the ordinary
+	# run_pts_benchmark path reinstall our staged source and retain all of its exit/registry checks.
+	rm -rf "$installed_dst"
+
+	echo "Staged vendored PTS override: ${profile_dst} (removed ${installed_dst})"
+}
+
 # Install and run one PTS test, capturing timing via bench_cmd and copying the result XML to
 # benchmark-results/<prefix>.xml (the contract the results extractor reads).
 # Usage: run_pts_benchmark <test-name> <results-prefix>
@@ -335,35 +448,24 @@ run_pts_benchmark() {
 	save_name="benchmark-$(printf '%s' "$prefix" | tr -cs 'a-z0-9' '-')"
 	export TEST_RESULTS_NAME="$save_name"
 
-	# Skip the install for a version-pinned test that is already on disk (the toolchain image
-	# pre-installs every registered profile): batch-install would only no-op through several seconds
-	# of PHP. Probe the ONE data dir this PTS invocation will actually use (pts_init first, so
-	# pts_user_dir doesn't cache the $HOME fallback on a fresh machine — the fio_direct_choice
-	# precedent), and require the pts-install.xml manifest, not the bare directory: PTS only treats a
-	# test as installed once that manifest exists, so a batch-install killed mid-build would otherwise
-	# permanently disable both install and run. (Trade-off vs full batch-install: PTS's same-version
-	# reinstall triggers — installer checksum, system hash — are bypassed for baked profiles.)
-	local installed=""
+	# Skip the install for a profile PTS itself reports installed. Do not infer this from an internal
+	# manifest filename; `_pts_is_installed` is version-agnostic and matches the bake verification.
 	pts_init
-	if [ -f "$(pts_user_dir)/installed-tests/${test_name}/pts-install.xml" ]; then
-		installed=1
-	fi
-	if [ -n "$installed" ]; then
+	if _pts_is_installed "$test_name"; then
 		echo "=== PTS test already installed (baked): ${test_name} ==="
 	else
 		echo "=== Installing PTS test: ${test_name} ==="
 		phoronix-test-suite batch-install "$test_name" 2>&1 || {
 			echo "WARNING: PTS install of ${test_name} failed"
+			( set +e; _pts_install_diagnostics "$test_name" ) || true
 			skip_result "PTS install of ${test_name} failed" "$prefix"
 			return 0
 		}
-		# PTS EXITS 0 EVEN WHEN AN INSTALL FAILS (it writes install-failed.log and moves on), so the
-		# `||` branch above is dead for the common failure — a missing build dependency. Without this
-		# the leaf proceeds to batch-run, burns its whole budget producing nothing, and lands on the
-		# generic "produced no composite.xml" skip that names the wrong cause. Re-probe the manifest.
-		if [ ! -f "$(pts_user_dir)/installed-tests/${test_name}/pts-install.xml" ]; then
-			echo "WARNING: PTS reported success but ${test_name} is not installed (see install-failed.log)"
-			skip_result "PTS install of ${test_name} failed (exit 0, no pts-install.xml)" "$prefix"
+		# PTS can exit 0 even when compilation failed, so verify through its installed-test registry.
+		if ! _pts_is_installed "$test_name"; then
+			echo "WARNING: PTS reported success but ${test_name} is not installed"
+			( set +e; _pts_install_diagnostics "$test_name" ) || true
+			skip_result "PTS install of ${test_name} failed (exit 0, not in list-installed-tests)" "$prefix"
 			return 0
 		fi
 	fi

--- a/packages/harness/src/lib/execute.test.ts
+++ b/packages/harness/src/lib/execute.test.ts
@@ -36,6 +36,21 @@ describe("selectTransport", () => {
 	});
 });
 
+describe("sandbox preamble", () => {
+	it("does not auto-install repository developer tools when running benchmark tasks", () => {
+		expect(PREAMBLE).toContain("MISE_TASK_RUN_AUTO_INSTALL=0");
+	});
+
+	it("reuses the baked PTS registry for an injected unprivileged runtime user", () => {
+		expect(PREAMBLE).toContain("PTS_USER_PATH_OVERRIDE=/var/lib/phoronix-test-suite/");
+	});
+
+	it("uses two fixed PTS trials for a publishable comparison", () => {
+		expect(PREAMBLE).toContain("PTS_RESPECT_TIMES_TO_RUN=1");
+		expect(PREAMBLE).toContain("FORCE_TIMES_TO_RUN=2");
+	});
+});
+
 describe("shellQuote", () => {
 	it("wraps in single quotes and escapes embedded quotes", () => {
 		expect(shellQuote("echo hi")).toBe("'echo hi'");

--- a/packages/harness/src/lib/execute.ts
+++ b/packages/harness/src/lib/execute.ts
@@ -167,17 +167,29 @@ export const PREAMBLE = [
 	'if [ -d /mise ]; then export MISE_DATA_DIR=/mise MISE_CONFIG_DIR=/mise MISE_CACHE_DIR=/mise/cache PATH="/mise/shims:$PATH"; fi',
 	// Some sandbox networks reset connections to *.jdx.dev — fetch versions/tools from GitHub instead.
 	"export MISE_USE_VERSIONS_HOST=0",
+	// Repository mise.toml contains developer-only linters (typos, shellcheck, hadolint, actionlint,
+	// zizmor), none of which a benchmark task uses. Never auto-install them when `mise run` resolves a
+	// task: stock-image providers fan the matrix out behind one egress IP, and seven concurrent aqua
+	// lookups exhaust GitHub's anonymous API quota before a benchmark starts. Suite runtime tools are
+	// installed explicitly by setupSteps (node/pnpm/PTS) or by the base-package fallback instead.
+	"export MISE_TASK_RUN_AUTO_INSTALL=0",
 	// The precompiled-python index is jdx.dev-only (no GitHub fallback) — use the distro python3.
 	"export MISE_DISABLE_TOOLS=python",
 	// Distro pythons are PEP 668 externally-managed, but PTS profiles pip-install their harness —
 	// fine in a throwaway sandbox; the baked image sets the same.
 	"export PIP_BREAK_SYSTEM_PACKAGES=1",
-	// Honour each PTS profile's TimesToRun (lib/bench.sh otherwise forces a single pass). The sandbox
-	// is the statistical-confidence path: the in-sandbox repeats give p50/stdev per Metric.
-	// BENCH_PASSES=1 (host env) opts a run out for fast contract-verification iteration -- one pass
-	// per task, ~2x faster on multi-pass suites (profiles pin TimesToRun=2); never set it for a run
-	// whose numbers you publish.
-	...(process.env.BENCH_PASSES === "1" ? [] : ["export PTS_RESPECT_TIMES_TO_RUN=1"]),
+	// E2B-compatible builders inject an unprivileged runtime user. Point PTS at the root-baked profile
+	// registry explicitly even if a provider strips the Docker ENV while importing the image.
+	"if [ -d /var/lib/phoronix-test-suite ]; then export PTS_USER_PATH_OVERRIDE=/var/lib/phoronix-test-suite/; fi",
+	// Published comparisons use exactly two trials per PTS case — the balanced count the suites pin
+	// (PR #129 lowered it from three). Five overran the command and sandbox lifetimes (a two-repeat run
+	// already took ~67 min), and chasing significance with more trials is a non-goal: the leaderboard
+	// LABELS underpowered comparisons rather than buying statistical power with extra runs. Fixing the
+	// count also prevents PTS's variance-driven policy from giving noisy providers 20-40 trials until the
+	// suite times out. BENCH_PASSES=1 keeps contract-verification runs at one pass via lib/bench.sh.
+	...(process.env.BENCH_PASSES === "1"
+		? []
+		: ["export PTS_RESPECT_TIMES_TO_RUN=1", "export FORCE_TIMES_TO_RUN=2"]),
 	'if [ "$(id -u)" = 0 ]; then SUDO=""; elif command -v sudo >/dev/null 2>&1; then SUDO="sudo -E"; else SUDO=""; fi',
 ].join("; ");
 

--- a/packages/harness/src/lib/setup.test.ts
+++ b/packages/harness/src/lib/setup.test.ts
@@ -10,10 +10,47 @@ describe("setupSteps", () => {
 			"install base packages",
 			"clone repo",
 			"install mise",
-			"mise install",
+			"trust mise config",
 			"setup node 22 + pnpm 10",
+			"ensure PTS build deps + fresh apt index",
 			"setup phoronix-test-suite",
 		]);
+	});
+
+	it("refreshes apt + build deps for every PTS suite, including a stale baked image", () => {
+		const ptsStep = setupSteps(SUITES["cpu-node"]).find(
+			(step) => step.label === "ensure PTS build deps + fresh apt index",
+		);
+		expect(ptsStep?.script).toMatch(/apt-get.*update/);
+		expect(ptsStep?.script).toContain("autoconf");
+		expect(ptsStep?.script).not.toContain("command -v phoronix-test-suite");
+	});
+
+	it("does not install repository developer tools inside benchmark sandboxes", () => {
+		expect(labels).not.toContain("mise install");
+		const nodeStep = setupSteps(SUITES["cpu-node"]).find(
+			(step) => step.label === "setup node 22 + pnpm 10",
+		);
+		expect(nodeStep?.script).toContain('cd "$HOME"');
+		expect(nodeStep?.script).toContain("mise use --global");
+		expect(nodeStep?.script).toContain("node@22.22.3");
+		expect(nodeStep?.script).toContain('npm install --global --prefix "$HOME/.local" pnpm@10.34.3');
+		expect(nodeStep?.script).not.toMatch(/mise use[^&]*pnpm/);
+		expect(nodeStep?.script).not.toContain(`cd "$HOME/sandbox-benchmarks" && mise use`);
+	});
+
+	it("checksum-verifies the pinned mise fallback without executing a remote installer", () => {
+		const miseStep = setupSteps(SUITES["cpu-node"]).find((step) => step.label === "install mise");
+		expect(miseStep?.script).toContain("sha256sum -c -");
+		expect(miseStep?.script).toContain("mise-v2026.5.16-linux-$a");
+		expect(miseStep?.script).not.toContain("mise.run");
+	});
+
+	it("emits syntactically valid shell for every setup step", () => {
+		for (const step of setupSteps(SUITES["cpu-node"])) {
+			const result = Bun.spawnSync(["bash", "-n", "-c", step.script]);
+			expect(result.exitCode, `${step.label}: ${result.stderr.toString()}`).toBe(0);
+		}
 	});
 
 	it("clones this repo by default, so the in-sandbox producer matches the harness", () => {

--- a/packages/harness/src/lib/setup.ts
+++ b/packages/harness/src/lib/setup.ts
@@ -23,9 +23,14 @@ const CLONE_URL = REPO_TOKEN
 // Resolved in-sandbox: images differ on user (root vs daytona), so the checkout lives under $HOME.
 export const DIR = '"$HOME/sandbox-benchmarks"';
 
-// mise/PTS versions for the runtime-setup fallback path (no-ops on the baked image, which already
-// ships them). Kept as best-effort constants rather than a pins import to keep the harness decoupled.
+// Runtime versions for the stock-image fallback path (no-ops on the baked image, which already
+// ships them). Keep node/pnpm aligned with packages/templates/images/base/mise.toml. These stay as
+// local constants rather than a templates-package import so the harness remains decoupled.
 const MISE_VERSION = "v2026.5.16";
+const MISE_SHA256_X64 = "fb2d7bf1a3751398a5c336a3565cd3c60af9b41952abe6fd62e2f2f0d5f06b60";
+const MISE_SHA256_ARM64 = "a068f29d8821ab0707f1a006721b5ab0baa80acaafc5a7b71e04371287108b92";
+const NODE_VERSION = "22.22.3";
+const PNPM_VERSION = "10.34.3";
 const PTS_VERSION = "10.8.4";
 
 export interface SetupStep {
@@ -56,57 +61,79 @@ export function setupSteps(suite: Suite): SetupStep[] {
 		},
 		{
 			label: "install mise",
-			// No-op on pre-baked images. mise.run can be unreachable from some sandbox networks — fall
-			// back to the static binary from GitHub releases (GitHub is reachable: we clone from it).
+			// No-op on pre-baked images. Install the same pinned, checksum-verified static binary as the
+			// toolchain image; GitHub is already required for the repository clone immediately above.
 			script: [
 				"command -v mise >/dev/null 2>&1 || {",
 				'mkdir -p "$HOME/.local/bin";',
-				"(curl -fsSL --retry 3 --retry-all-errors --retry-delay 2 https://mise.run | sh)",
-				'|| { arch=$(uname -m); case "$arch" in aarch64|arm64) a=arm64;; *) a=x64;; esac;',
-				`curl -fsSL --retry 5 --retry-all-errors --retry-delay 2 -o "$HOME/.local/bin/mise" "https://github.com/jdx/mise/releases/download/${MISE_VERSION}/mise-${MISE_VERSION}-linux-$a" && chmod +x "$HOME/.local/bin/mise"; }; };`,
+				'arch=$(uname -m); case "$arch" in',
+				`aarch64|arm64) a=arm64; sha=${MISE_SHA256_ARM64};;`,
+				`x86_64|amd64) a=x64; sha=${MISE_SHA256_X64};;`,
+				'*) echo "Unsupported architecture for mise: $arch" >&2; exit 1;; esac;',
+				"tmp=$(mktemp); trap 'rm -f \"$tmp\"' EXIT;",
+				`curl -fsSL --retry 5 --retry-all-errors --retry-delay 2 -o "$tmp" "https://github.com/jdx/mise/releases/download/${MISE_VERSION}/mise-${MISE_VERSION}-linux-$a"`,
+				'&& printf "%s  %s\\n" "$sha" "$tmp" | sha256sum -c -',
+				'&& chmod +x "$tmp" && mv "$tmp" "$HOME/.local/bin/mise"; };',
 				"mise --version",
 			].join(" "),
 			timeoutMs: 5 * MIN,
 			retries: 2,
 		},
 		{
-			label: "mise install",
-			script: `cd ${DIR} && mise trust --yes && mise install --yes`,
-			timeoutMs: 20 * MIN,
-			retries: 2,
+			label: "trust mise config",
+			// Trust the cloned task definitions without installing the repository's developer-only tools.
+			script: `cd ${DIR} && mise trust --yes`,
+			timeoutMs: MIN,
 		},
 	];
 
 	if (suite.setupNode) {
 		steps.push({
 			label: "setup node 22 + pnpm 10",
-			script: `cd ${DIR} && mise use --yes node@22 pnpm@10 && node -v && pnpm -v`,
+			// Activate only the benchmark runtimes from outside the checkout. Exact Node avoids version
+			// discovery, and pnpm comes from npm rather than mise's GitHub-API-backed aqua plugin. Blaxel
+			// matrix cells share one unauthenticated egress IP, so even the one pnpm API lookup can hit an
+			// exhausted 60-request quota. Later `mise run` commands inherit the global Node config while
+			// task auto-install stays off. The pinned baked image takes the fast path for both checks.
+			script: [
+				`cd "$HOME"`,
+				`(node -e 'process.exit(process.versions.node === "${NODE_VERSION}" ? 0 : 1)' 2>/dev/null || mise use --global --yes node@${NODE_VERSION})`,
+				`if command -v pnpm >/dev/null 2>&1 && [ "$(pnpm -v)" = "${PNPM_VERSION}" ]; then :; else npm install --global --prefix "$HOME/.local" pnpm@${PNPM_VERSION}; fi`,
+				"node -v && pnpm -v",
+			].join(" && "),
 			timeoutMs: 10 * MIN,
 			retries: 2,
 		});
 	}
 
 	if (suite.setupPts) {
+		// Refresh the apt index and ensure PTS's build/runtime deps at runtime unconditionally. A baked
+		// image deliberately cleans /var/lib/apt/lists, while a stock-image provider must compile every
+		// profile locally; in either case PTS's own dependency install needs a usable package index.
+		// Best-effort lets a healthy baked image proceed when a provider cannot reach its distro mirror.
+		// Keep this set aligned with packages/templates/images/base/scripts/00-apt.sh.
+		const ptsDeps =
+			"php-cli php-xml build-essential autoconf flex bison bc libelf-dev libssl-dev " +
+			"libaio-dev libicu-dev dnsutils jq netcat-openbsd iputils-ping tcl stress-ng unzip procps";
+		steps.push({
+			label: "ensure PTS build deps + fresh apt index",
+			script:
+				"$SUDO apt-get -o Acquire::Retries=3 update -qq || true; " +
+				`$SUDO apt-get install -y -qq ${ptsDeps} || echo "WARNING: apt dep refresh failed (best-effort); relying on the baked image"`,
+			timeoutMs: 15 * MIN,
+		});
 		steps.push({
 			label: "setup phoronix-test-suite",
-			// No-op on pre-baked images.
+			// No-op on pre-baked images; on stock images the step above already populated apt's index and
+			// installed the profile build dependencies.
 			script:
 				"command -v phoronix-test-suite >/dev/null 2>&1 || { " +
 				[
 					`curl -fsSL --retry 5 --retry-all-errors --retry-delay 2 "https://github.com/phoronix-test-suite/phoronix-test-suite/releases/download/v${PTS_VERSION}/phoronix-test-suite_${PTS_VERSION}_all.deb" -o /tmp/phoronix-test-suite.deb`,
-					"$SUDO apt-get update -qq",
-					// libaio-dev: fio's libaio engine (disk suite). libicu-dev: postgres's configure hard-
-					// requires ICU (pgbench). dnsutils+jq: the system provider probe. netcat-openbsd:
-					// network-loopback's dd|nc runner. stress-ng: the disk suite's hardlink leaf (its
-					// `command -v` guard would otherwise silently skip the metric on stock images while
-					// the fio metrics report). All no-ops on the pre-baked image.
-					// tcl: sqlite-speedtest builds SQLite from source and its Makefile shells out to `tclsh`
-					// to generate opcodes.h — without it the build dies with exit 127 and PTS still exits 0.
-					"$SUDO apt-get install -y -qq php-cli php-xml build-essential flex bison bc libelf-dev libssl-dev libaio-dev libicu-dev dnsutils jq netcat-openbsd iputils-ping tcl stress-ng",
 					"($SUDO dpkg -i /tmp/phoronix-test-suite.deb || $SUDO apt-get install -y -qq -f)",
 				].join(" && ") +
 				"; }; phoronix-test-suite version",
-			timeoutMs: 15 * MIN,
+			timeoutMs: 10 * MIN,
 			retries: 2,
 		});
 	}


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Make the Phoronix Test Suite runtime portable across root and unprivileged sandboxes. Reuse the baked `/var/lib` registry, pin published runs to two fixed trials, and harden stock-image setup and diagnostics.

- **New Features**
  - Use `PTS_USER_PATH_OVERRIDE` so `phoronix-test-suite` reads the baked registry under `/var/lib` across all calls; set in the harness preamble and as a fallback in `lib/bench.sh`.
  - Verify installs via `list-installed-tests`; on failure, emit concise diagnostics (resolved data dir, config path, installed list, install manifests, installed-tests tree, newest `install-failed.log`).
  - Add `install_vendored_pts_profile <name-version>` to stage a pinned upstream override while keeping the `pts/<name>` ID; drop the baked install to force a reinstall; validate profile names first.
  - Default to 2 fixed PTS trials for publishable comparisons (`PTS_RESPECT_TIMES_TO_RUN=1` + `FORCE_TIMES_TO_RUN=2`); contract checks keep 1 pass with `BENCH_PASSES=1`.

- **Refactors**
  - Preamble: disable `MISE_TASK_RUN_AUTO_INSTALL`, set `PTS_USER_PATH_OVERRIDE`, and apply the 2-trial policy.
  - Setup: trust `mise` config (skip `mise install`), install a pinned `mise` binary with SHA256 verification, and configure exact `node`/`pnpm` outside the repo without GitHub-backed plugins or repo dev tools.
  - Always refresh apt (with retries) and ensure PTS build/runtime deps on stock images with an expanded set (`autoconf`, `tcl`, `stress-ng`, `unzip`, `procps`); streamline `phoronix-test-suite` install.

<sup>Written for commit b73da1c99c9b00de677608db12de57c993618a92. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/starslingdev/sandbox-benchmarks/pull/162?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

