### PR TITLE
fix(providers): normalize benchmark runtimes

### DIFF
--- a/packages/providers/src/index.test.ts
+++ b/packages/providers/src/index.test.ts
@@ -4,6 +4,7 @@ import { describe, expect, it } from "bun:test";
 import { e2b } from "@computesdk/e2b";
 import { PROVIDERS, TARGET_SPEC } from "@sandbox-benchmarks/schema";
 import { config, NOVITA_E2B_DOMAIN, novitaCompute, novitaConnection, providers } from "./index.ts";
+import { runE2bCommandAsRoot } from "./lib/e2b-root.ts";
 import { assertProviderJoin } from "./lib/join.ts";
 
 describe("@sandbox-benchmarks/providers", () => {
@@ -69,6 +70,8 @@ describe("@sandbox-benchmarks/providers", () => {
 			expect(methodsOf(e2b({ apiKey: "e2b_unit-test-key" }))[method]).toBe(stock[method]);
 			expect(patched[method]).not.toBe(stock[method]);
 		}
+		expect(patched.runCommand).toBe(runE2bCommandAsRoot);
+		expect(patched.runCommand).not.toBe(stock.runCommand);
 		expect(compute.snapshot).toBeUndefined();
 		// `template` is a runtime property of the generated provider (computesdk's type doesn't model
 		// it), so reach through a structural cast to pin its removal too.
@@ -108,13 +111,21 @@ describe("@sandbox-benchmarks/providers", () => {
 		}
 	});
 
-	it("boots e2b from the configured template and daytona from the configured snapshot", () => {
-		const e2b = providers.find((p) => p.name === "e2b");
-		expect(e2b?.createOptions?.snapshotId).toBe(config.e2bTemplate);
+	it("boots e2b from the configured template and keeps Daytona alive for long suites", () => {
+		const e2bAdapter = providers.find((p) => p.name === "e2b");
+		expect(e2bAdapter?.createOptions?.snapshotId).toBe(config.e2bTemplate);
+		const compute = e2bAdapter?.createCompute();
+		const methods = (compute as unknown as { sandbox: { methods: Record<string, unknown> } })
+			.sandbox.methods;
+		expect(methods.runCommand).toBe(runE2bCommandAsRoot);
 
 		const daytona = providers.find((p) => p.name === "daytona");
 		expect(daytona).toBeDefined();
 		expect(daytona?.createOptions?.snapshotId).toBe(config.daytona.snapshot);
+		// ComputeSDK maps its universal timeout to the Daytona SDK's create-operation timeout, not the
+		// sandbox lifetime. Pass the native option through so an 8+ minute detached suite is not stopped
+		// underneath the harness; runSuite's finally block remains the cleanup authority.
+		expect(daytona?.createOptions?.autoStopInterval).toBe(0);
 
 		// No adapter override — requiredEnvVars falls back to the schema meta's static list. Pin the
 		// concrete value rather than only comparing the two lookups against each other: if both `find`s
@@ -122,6 +133,80 @@ describe("@sandbox-benchmarks/providers", () => {
 		const daytonaMeta = PROVIDERS.find((m) => m.id === "daytona");
 		expect(daytonaMeta?.requiredEnvVars).toEqual(["DAYTONA_API_KEY"]);
 		expect(daytona?.requiredEnvVars).toEqual(daytonaMeta?.requiredEnvVars);
+	});
+
+	it("passes E2B-compatible cwd and env options through envd's structured root channel", async () => {
+		const calls: Array<{ command: string; options?: Record<string, unknown> }> = [];
+		const sandbox = {
+			commands: {
+				run: async (command: string, options?: Record<string, unknown>) => {
+					calls.push({ command, options });
+					return { stdout: "ok", stderr: "", exitCode: 0 };
+				},
+			},
+		};
+		const result = await runE2bCommandAsRoot(sandbox as never, "echo hi", {
+			cwd: "/work dir",
+			env: { TOKEN: "not a shell; value" },
+			timeout: 1234,
+		});
+
+		expect(result).toMatchObject({ stdout: "ok", stderr: "", exitCode: 0 });
+		expect(calls).toHaveLength(1);
+		expect(calls[0]).toEqual({
+			command: "echo hi",
+			options: {
+				user: "root",
+				cwd: "/work dir",
+				envs: { TOKEN: "not a shell; value" },
+				timeoutMs: 1234,
+				background: false,
+			},
+		});
+	});
+
+	it("translates a native background handle into ComputeSDK's completed launch result", async () => {
+		const calls: Array<{ command: string; options?: Record<string, unknown> }> = [];
+		const sandbox = {
+			commands: {
+				run: async (command: string, options?: Record<string, unknown>) => {
+					calls.push({ command, options });
+					return { pid: 42 };
+				},
+			},
+		};
+		const result = await runE2bCommandAsRoot(sandbox as never, "long command", {
+			background: true,
+		});
+
+		expect(result).toMatchObject({ stdout: "", stderr: "", exitCode: 0 });
+		expect(calls).toEqual([
+			{ command: "long command", options: { user: "root", background: true } },
+		]);
+	});
+
+	it("recovers a failed command's structured result when the SDK throws it", async () => {
+		const sandbox = {
+			commands: {
+				run: async () => {
+					throw { result: { stdout: "partial", stderr: "boom", exitCode: 2 } };
+				},
+			},
+		};
+		const result = await runE2bCommandAsRoot(sandbox as never, "false", {});
+		expect(result).toMatchObject({ stdout: "partial", stderr: "boom", exitCode: 2 });
+	});
+
+	it("defaults a thrown result's missing fields rather than crashing", async () => {
+		const sandbox = {
+			commands: {
+				run: async () => {
+					throw { result: {} };
+				},
+			},
+		};
+		const result = await runE2bCommandAsRoot(sandbox as never, "false", {});
+		expect(result).toMatchObject({ stdout: "", stderr: "", exitCode: 1 });
 	});
 });
 

--- a/packages/providers/src/lib/adapters.ts
+++ b/packages/providers/src/lib/adapters.ts
@@ -10,6 +10,7 @@ import { modal } from "@computesdk/modal";
 import type { ProviderId } from "@sandbox-benchmarks/schema";
 import { TARGET_SPEC } from "@sandbox-benchmarks/schema";
 import { config } from "./config.ts";
+import { e2bCommandsAsRoot } from "./e2b-root.ts";
 import { novitaCompute } from "./novita.ts";
 import type { ProviderAdapter } from "./types.ts";
 
@@ -28,19 +29,23 @@ const MODAL_APP_NAME = "sandbox-benchmarks";
  */
 export const adapters: Record<ProviderId, ProviderAdapter> = {
 	// Boot the e2b template built from the toolchain image (computesdk maps snapshotId → the e2b
-	// template id/name). cpu/memory are pinned in the template's e2b.toml, not per-create.
+	// template id/name). cpu/memory are pinned in the template's e2b.toml, not per-create. The raw
+	// E2B SDK's root user keeps apt fallbacks, PTS config, and the root-baked registry on one runtime
+	// identity; ComputeSDK does not expose that native command option, so patch this instance.
 	e2b: {
-		createCompute: () => e2b({}),
+		createCompute: () => e2bCommandsAsRoot(e2b({})),
 		createOptions: { snapshotId: config.e2bTemplate },
 	},
 	daytona: {
 		// The account API key; the toolchain snapshot and runner target are pinned per-create. `target`
-		// rides the wrapper's create-options passthrough into Daytona's createParams. No requiredEnvVars
-		// override needed — it falls back to the schema meta's static ["DAYTONA_API_KEY"], so a missing
-		// credential skips (not errors).
+		// and autoStopInterval ride the wrapper's provider-options passthrough into Daytona's native
+		// createParams. The universal `timeout` is only the Daytona SDK create-call deadline — it does
+		// not extend sandbox lifetime — so disable native auto-stop and rely on the harness's guaranteed
+		// teardown. No requiredEnvVars override needed: the schema meta owns DAYTONA_API_KEY.
 		createCompute: () => daytona({ apiKey: daytonaCfg.apiKey }),
 		createOptions: {
 			snapshotId: daytonaCfg.snapshot,
+			autoStopInterval: 0,
 			...(daytonaCfg.target ? { target: daytonaCfg.target } : {}),
 		},
 	},

--- a/packages/providers/src/lib/e2b-root.ts
+++ b/packages/providers/src/lib/e2b-root.ts
@@ -1,0 +1,89 @@
+// ComputeSDK's E2B wrapper always uses the template's default user and does not expose the raw
+// SDK's `user` command option. Our E2B/Novita template importers install that user after the image
+// is built. Run the benchmark lane as root through envd — the native SDK-supported identity — so
+// apt fallbacks, /etc PTS config, and the toolchain state baked under /var/lib all use one consistent
+// runtime identity. Daytona and Modal already run the same image as root.
+
+import type { SandboxMethods } from "@computesdk/provider";
+import type { CommandResult } from "computesdk";
+import type { Sandbox as E2bSandbox } from "e2b";
+import type { DirectProvider } from "./types.ts";
+
+type E2bLikeSandbox = Pick<E2bSandbox, "commands">;
+type RootCommandMethod = SandboxMethods<E2bLikeSandbox>["runCommand"];
+
+interface PatchableManager {
+	methods: Record<string, unknown> & { runCommand: RootCommandMethod };
+}
+
+function patchableManager(provider: DirectProvider): PatchableManager {
+	const manager = provider.sandbox as unknown as { methods?: Record<string, unknown> };
+	if (typeof manager.methods?.runCommand !== "function") {
+		throw new Error(
+			"@computesdk/e2b provider internals changed shape (sandbox manager has no patchable " +
+				"runCommand method); revisit the root-user adapter against the upgraded wrapper",
+		);
+	}
+	return manager as PatchableManager;
+}
+
+/** The stock @computesdk/e2b runCommand behavior, with the native E2B user pinned to root. */
+export const runE2bCommandAsRoot: RootCommandMethod = async (
+	sandbox,
+	command,
+	options,
+): Promise<CommandResult> => {
+	const startTime = Date.now();
+	try {
+		// Use envd's structured channels instead of reconstructing cwd/env as shell source. Besides
+		// preserving argument boundaries, the native background option avoids the stock wrapper's broken
+		// `nohup cd … && command &` expansion. ComputeSDK expects a completed launch result rather than
+		// E2B's CommandHandle, so translate a successful background start into exit 0; the harness polls
+		// its own done-file for the detached job's eventual result.
+		const nativeOptions = {
+			user: "root" as const,
+			...(options?.cwd !== undefined ? { cwd: options.cwd } : {}),
+			...(options?.env ? { envs: options.env } : {}),
+			...(options?.timeout !== undefined ? { timeoutMs: options.timeout } : {}),
+			...(options?.onStdout ? { onStdout: options.onStdout } : {}),
+			...(options?.onStderr ? { onStderr: options.onStderr } : {}),
+		};
+		if (options?.background) {
+			await sandbox.commands.run(command, { ...nativeOptions, background: true });
+			return { stdout: "", stderr: "", exitCode: 0, durationMs: Date.now() - startTime };
+		}
+		const execution = await sandbox.commands.run(command, {
+			...nativeOptions,
+			background: false,
+		});
+		return {
+			stdout: execution.stdout,
+			stderr: execution.stderr,
+			exitCode: execution.exitCode,
+			durationMs: Date.now() - startTime,
+		};
+	} catch (error) {
+		const result = (error as { result?: Partial<CommandResult> })?.result;
+		if (result) {
+			return {
+				stdout: result.stdout ?? "",
+				stderr: result.stderr ?? "",
+				exitCode: result.exitCode ?? 1,
+				durationMs: Date.now() - startTime,
+			};
+		}
+		return {
+			stdout: "",
+			stderr: error instanceof Error ? error.message : String(error),
+			exitCode: 127,
+			durationMs: Date.now() - startTime,
+		};
+	}
+};
+
+/** Clone and patch one E2B-compatible provider instance without mutating the wrapper's shared table. */
+export function e2bCommandsAsRoot(provider: DirectProvider): DirectProvider {
+	const manager = patchableManager(provider);
+	manager.methods = { ...manager.methods, runCommand: runE2bCommandAsRoot };
+	return provider;
+}

--- a/packages/providers/src/lib/novita.ts
+++ b/packages/providers/src/lib/novita.ts
@@ -33,6 +33,7 @@ import type {
 	SandboxConnectOpts,
 	SandboxOpts,
 } from "novita-sandbox";
+import { e2bCommandsAsRoot } from "./e2b-root.ts";
 import type { DirectProvider } from "./types.ts";
 
 // Loaded through the package's `require` (CJS) build, NOT an import: `@computesdk/e2b` is CJS and
@@ -184,5 +185,8 @@ export function novitaCompute(apiKey: string | undefined): DirectProvider {
 	// reconnect without a domain, i.e. against the wrong control plane.
 	(compute as { snapshot?: unknown }).snapshot = undefined;
 	(compute as { template?: unknown }).template = undefined;
-	return compute;
+	// Novita imports the same image through an E2B-compatible builder and injects the same
+	// unprivileged default user. Use envd's native root identity for the benchmark lane so setup and
+	// baked PTS state share one identity (the stock ComputeSDK wrapper omits the SDK's user option).
+	return e2bCommandsAsRoot(compute);
 }


### PR DESCRIPTION
## Summary

- Run E2B and Novita benchmark commands as root through their native E2B-compatible command option so they can update the baked PTS registry.
- Preserve ComputeSDK's command, environment, working-directory, background, error, and timing contracts in the patched adapter.
- Disable Daytona's native auto-stop and rely on the harness's guaranteed teardown.

## Verification

Passed the full local CI contract at this stack boundary: Biome, shellcheck, hadolint, typecheck, tests, catalog drift, and spelling.