### PR TITLE
fix(matrix): complete suites with balanced trials

### DIFF
--- a/.github/workflows/bench-matrix.yml
+++ b/.github/workflows/bench-matrix.yml
@@ -64,8 +64,12 @@ jobs:
   bench:
     name: ${{ matrix.suite }} on ${{ matrix.provider }}
     needs: plan
-    runs-on: starsling-ubuntu-24.04-2
-    timeout-minutes: 150
+    # The ephemeral self-hosted label is reaped after 70 minutes even while a step is healthy. The
+    # full CPU-generic and real-world matrices legitimately exceed that on slower providers, leaving
+    # the step stuck `in_progress` with no logs/artifact. Hosted runners honor timeout-minutes below;
+    # 180 minutes also leaves teardown/artifact margin around the longest 155-minute suite budget.
+    runs-on: ubuntu-24.04
+    timeout-minutes: 180
     strategy:
       # One cell's failure (a flaky provider) must not cancel the rest of the matrix.
       fail-fast: false
@@ -78,19 +82,10 @@ jobs:
           # credentials), so don't persist the job token in .git/config.
           persist-credentials: false
 
-      # `no-cache` is REQUIRED on this label, unlike the hosted-runner jobs above/below. Two runner
-      # images answer to `starsling-ubuntu-24.04-2` and they root the workspace at different depths
-      # (`/home/runner/_work/…` vs `/home/runner/actions-runner/_work/…`), yet setup-bun keys its cache
-      # only on the bun version. The cached `~/.bun` is stored relative to the save-time workspace and
-      # extracted with `-C <workspace>`, so an entry saved on one image unpacks to
-      # `/home/runner/actions-runner/.bun` on the other — the cache reports "restored successfully" and
-      # the next line dies with "Unable to locate executable file: /home/runner/.bun/bin/bun". Downloading
-      # bun (~32 MB) costs a couple of seconds; restoring a cache built for the other image costs the cell.
       - name: Set up Bun
         uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
         with:
           bun-version: 1.3.14
-          no-cache: true
 
       - name: Install dependencies
         run: bun install --frozen-lockfile --ignore-scripts

--- a/.github/workflows/bench-smoke.yml
+++ b/.github/workflows/bench-smoke.yml
@@ -27,8 +27,8 @@ on:
             system,
             memory,
             disk,
-            cpu-generic,
             network,
+            cpu-generic,
             realworld-mastra,
             realworld-better-auth,
             realworld-openclaw,
@@ -45,9 +45,11 @@ concurrency:
 jobs:
   smoke:
     name: ${{ inputs.suite }} on ${{ inputs.provider }}
-    runs-on: starsling-ubuntu-24.04-2
-    # The suite itself runs for many minutes inside the sandbox; give the host job ample headroom.
-    timeout-minutes: 150
+    # The ephemeral self-hosted label is reaped after 70 minutes, while this dispatch exposes suites
+    # with a 155-minute sandbox budget. Match the matrix's hosted runner and leave job-level margin
+    # for checkout, sandbox teardown, normalization, and artifact upload.
+    runs-on: ubuntu-24.04
+    timeout-minutes: 180
     steps:
       # Third-party actions are pinned to a commit SHA (the tag comment is for humans) so a
       # moved/compromised tag can't silently change what runs.
@@ -62,9 +64,6 @@ jobs:
         uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
         with:
           bun-version: 1.3.14
-          # This runner's setup-bun cache restores without a working ~/.bun/bin/bun, so a cache hit
-          # fails the "Set up Bun" step. Always download bun fresh instead of restoring the cache.
-          no-cache: true
 
       # Frozen lockfile + no lifecycle scripts, matching bunfig.toml's supply-chain posture.
       - name: Install dependencies

--- a/.mise/tasks/benchmark/network/pts/loopback
+++ b/.mise/tasks/benchmark/network/pts/loopback
@@ -17,5 +17,7 @@ if ! command -v nc &>/dev/null; then
 	exit 0
 fi
 
-# Version-pinned to the vendored profile so an upstream release can't drift under the catalog.
+# The pinned upstream runner hangs on netcat-openbsd after starting trial 1. Stage the vendored
+# repair under the same `pts/` identifier, then let run_pts_benchmark install and verify it.
+install_vendored_pts_profile "network-loopback-1.0.1"
 run_pts_benchmark "pts/network-loopback-1.0.1" "pts_network-loopback"

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "lint": "biome check . --error-on-warnings",
     "lint:fix": "biome check . --write",
     "lint:fix:unsafe": "biome check . --fix --unsafe",
-    "lint:shell": "find packages/templates/images lib .mise/tasks -type f \\( -name '*.sh' -o -path '*.mise/tasks/*' \\) -exec mise exec -- shellcheck {} +",
+    "lint:shell": "find packages/templates/images packages/schema/src/pts-profiles lib .mise/tasks -type f \\( -name '*.sh' -o -path '*.mise/tasks/*' \\) -exec mise exec -- shellcheck {} +",
     "lint:docker": "find packages/templates/images -name 'Dockerfile' -exec mise exec -- hadolint {} +",
     "spell": "mise exec -- typos",
     "spell:fix": "mise exec -- typos --write-changes",

--- a/packages/schema/src/pts-profiles/network-loopback-1.0.1/install.sh
+++ b/packages/schema/src/pts-profiles/network-loopback-1.0.1/install.sh
@@ -1,0 +1,45 @@
+#!/bin/sh
+set -eu
+
+# The upstream profile's generated dd|nc runner can race its listener and hung indefinitely on every
+# provider in matrix run 29346212440. Generate a deterministic netcat-openbsd runner: wait until the
+# listener is visible in /proc/net/tcp, stream exactly 10 GiB through loopback, then reap it.
+cat <<'EOF' > network-loopback
+#!/bin/sh
+set -eu
+
+port=12345
+listener=""
+cleanup() {
+  if [ -n "$listener" ]; then
+    kill "$listener" 2>/dev/null || true
+    wait "$listener" 2>/dev/null || true
+  fi
+}
+trap cleanup EXIT HUP INT TERM
+
+nc -l 127.0.0.1 "$port" >/dev/null &
+listener=$!
+port_hex=$(printf '%04X' "$port")
+attempt=0
+while ! awk -v port=":${port_hex}" '$2 ~ (port "$") && $4 == "0A" { found=1 } END { exit !found }' /proc/net/tcp; do
+  if ! kill -0 "$listener" 2>/dev/null; then
+    echo "loopback listener exited before accepting a connection" >&2
+    exit 1
+  fi
+  attempt=$((attempt + 1))
+  if [ "$attempt" -ge 1000 ]; then
+    echo "loopback listener did not become ready" >&2
+    exit 1
+  fi
+  # Avoid a CPU-starving busy loop and give a loaded sandbox up to ten seconds to bind.
+  sleep 0.01
+done
+
+dd if=/dev/zero bs=16M count=640 status=none | nc -N 127.0.0.1 "$port"
+wait "$listener"
+listener=""
+EOF
+chmod +x network-loopback
+
+echo 0 > ~/install-exit-status

--- a/packages/schema/src/suites.test.ts
+++ b/packages/schema/src/suites.test.ts
@@ -24,8 +24,8 @@ describe("suite registry", () => {
 			"system",
 			"memory",
 			"disk",
-			"cpu-generic",
 			"network",
+			"cpu-generic",
 			"realworld-mastra",
 			"realworld-better-auth",
 			"realworld-openclaw",
@@ -57,16 +57,15 @@ describe("suite registry", () => {
 		// the test is exactly what the suite emits — pin the declared list to it in BOTH directions (a
 		// profile bump that adds/renames a combination fails here instead of silently stranding the
 		// list). stream's Type axis is the real matrix case; pybench and sqlite-speedtest declare no
-		// <Option> axes at all, so the pin holds over their single wildcard result. The suites that
-		// arrive later (network, cpu-generic) add themselves here.
+		// <Option> axes at all, so the pin holds over their single wildcard result.
 		// `system` is MIXED: pybench + sqlite-speedtest are unpinned wildcards (mirrored here), while
 		// pgbench is preset-pinned and declares a 4-of-160 subset — pinned to its curated override keys
 		// by the subset test below. Subtracting the pinned prefix keeps this a both-directions mirror
 		// over the unpinned half instead of dropping the suite from the gate entirely.
 		const PINNED_PREFIXES = ["pgbench_"];
 		const profilesOf = {
-			"cpu-generic": ["pts/c-ray", "pts/compress-zstd"],
 			network: ["pts/network-loopback"],
+			"cpu-generic": ["pts/c-ray", "pts/compress-zstd"],
 			memory: ["pts/stream"],
 			system: ["pts/pybench", "pts/sqlite-speedtest"],
 		} as const;

--- a/packages/schema/src/suites.ts
+++ b/packages/schema/src/suites.ts
@@ -69,15 +69,14 @@ export const SUITES = {
 	// The system dimension: PyBench (Python interpreter) + SQLite Speedtest (single-result PTS
 	// profiles) + PostgreSQL via pgbench, pinned to one (scale 100, 50 clients) point per mode —
 	// each mode posts a TPS and an Average Latency metric. pgbench runs server + client fully
-	// in-sandbox (same topology on every provider). Budget: the harness sets PTS_RESPECT_TIMES_TO_RUN,
-	// so the profile's TimesToRun=3 makes SIX timed passes (3 per mode), each with its own scale-100
-	// `pgbench -i` — not the two the budgets were once described against. That and the ~1.5 GB dataset
-	// set the budgets and the disk floor. Requires the baked image (postgres pre-built, libicu-dev
-	// present); on a stock image the from-source postgres build lands inside this budget too.
+	// in-sandbox (same topology on every provider). The harness fixes two trials per case, so pgbench
+	// makes four timed passes (two per mode), each with its own scale-100 `pgbench -i`. That and the
+	// ~1.5 GB dataset set the budgets and disk floor. Requires the baked image (postgres pre-built,
+	// libicu-dev present); on a stock image the from-source postgres build lands inside this budget too.
 	system: {
 		setupPts: true,
-		commandTimeoutMinutes: 80,
-		timeoutMinutes: 95,
+		commandTimeoutMinutes: 120,
+		timeoutMinutes: 135,
 		minDiskGb: 5,
 		dimensions: ["system"],
 		metrics: [
@@ -105,12 +104,12 @@ export const SUITES = {
 	// scale-pinned twin metrics. Direct is probed per sandbox (O_DIRECT fails on some sandbox
 	// filesystems), so every scenario declares an O_DIRECT and a buffered variant; each provider emits
 	// exactly one of the two and the mode travels in the metric identity (the contract allows declared-
-	// but-unrun combinations). Budgets cover the fio build + 4 timed 60s scenarios; fio writes 1 GiB
-	// test files, hence the raised disk floor.
+	// but-unrun combinations). Budgets cover five fixed trials of each of the four timed 60s scenarios
+	// plus the hardlink profile; fio writes 1 GiB test files, hence the raised disk floor.
 	disk: {
 		setupPts: true,
-		commandTimeoutMinutes: 60,
-		timeoutMinutes: 70,
+		commandTimeoutMinutes: 75,
+		timeoutMinutes: 90,
 		minDiskGb: 4,
 		dimensions: ["disk"],
 		metrics: [
@@ -134,14 +133,26 @@ export const SUITES = {
 		],
 		commands: ["mise run benchmark:disk:all"],
 	},
+	// The network dimension: loopback TCP (10GB via nc) — self-contained, no external endpoint, so it
+	// isolates the sandbox's network stack from internet weather. The suite task also runs the
+	// latency/DNS/download probes (raw JSON provenance, no catalogued metrics).
+	network: {
+		setupPts: true,
+		commandTimeoutMinutes: 30,
+		timeoutMinutes: 40,
+		dimensions: ["network"],
+		metrics: ["network_loopback_seconds"],
+		commands: ["mise run benchmark:network:all"],
+	},
 	// The generic-compute dimension slice next to cpu-node: c-ray (float/thread scaling — the seam the
 	// catalog's c-ray entries have waited on) and Zstd compression across its level matrix. Budgets
 	// cover the zstd build + silesia download, 7 zstd levels × compress+decompress, and c-ray's three
-	// resolutions × 3 passes on a 2-vCPU target (the 5K pass alone runs several minutes per repeat).
+	// resolutions × 5 fixed passes on a 2-vCPU target (the 5K pass alone runs several minutes per
+	// repeat). Fixed counts bound noisy hosts while giving every provider equal statistical weight.
 	"cpu-generic": {
 		setupPts: true,
-		commandTimeoutMinutes: 100,
-		timeoutMinutes: 115,
+		commandTimeoutMinutes: 130,
+		timeoutMinutes: 145,
 		minDiskGb: 2,
 		dimensions: ["cpu"],
 		metrics: [
@@ -165,17 +176,6 @@ export const SUITES = {
 		],
 		commands: ["mise run benchmark:cpu:generic"],
 	},
-	// The network dimension: loopback TCP (10GB via nc) — self-contained, no external endpoint, so it
-	// isolates the sandbox's network stack from internet weather. The suite task also runs the
-	// latency/DNS/download probes (raw JSON provenance, no catalogued metrics).
-	network: {
-		setupPts: true,
-		commandTimeoutMinutes: 30,
-		timeoutMinutes: 40,
-		dimensions: ["network"],
-		metrics: ["network_loopback_seconds"],
-		commands: ["mise run benchmark:network:all"],
-	},
 	// The realworld dimension (ENG-135/136/137/138): real OSS repos run through their own CI tasks,
 	// each a repo-local PTS profile with a Task option axis. Budgets are starting points (tuned from
 	// smoke); mastra's task matrix is the narrowest (scoped to packages/core) but its monorepo has
@@ -184,8 +184,8 @@ export const SUITES = {
 	"realworld-mastra": {
 		setupPts: true,
 		setupNode: true,
-		commandTimeoutMinutes: 90,
-		timeoutMinutes: 105,
+		commandTimeoutMinutes: 140,
+		timeoutMinutes: 155,
 		minDiskGb: 30,
 		dimensions: ["realworld"],
 		metrics: [
@@ -197,17 +197,15 @@ export const SUITES = {
 		],
 		commands: ["mise run benchmark:realworld:pts:mastra"],
 	},
-	// Budgets from measured 2026-07-10 runs at the 2-vCPU spec: daytona ~18 min, modal ~67 min (gVisor
-	// syscall overhead on the per-run git-clean/install resets; measured via a complete local run —
-	// the old 60-min command budget killed modal at test 9/10). 90 covers modal plus variance without
-	// letting a wedged provider eat the whole runner. e2b currently never gets past ~4.5 min: its
-	// sandboxes from our template are orchestrator-stopped regardless of requested lifetime (platform
-	// issue, tracked separately) — no budget fixes that.
+	// The five fixed trials multiply every task case, including the per-run git-clean/install resets;
+	// the 140-minute command budget covers slower virtualized filesystems while the 155-minute sandbox
+	// lifetime leaves setup and collection headroom. The workflow timeout gate independently reserves
+	// host-job margin beyond the longest sandbox lifetime.
 	"realworld-better-auth": {
 		setupPts: true,
 		setupNode: true,
-		commandTimeoutMinutes: 90,
-		timeoutMinutes: 105,
+		commandTimeoutMinutes: 140,
+		timeoutMinutes: 155,
 		minDiskGb: 10,
 		dimensions: ["realworld"],
 		metrics: [
@@ -227,8 +225,8 @@ export const SUITES = {
 	"realworld-openclaw": {
 		setupPts: true,
 		setupNode: true,
-		commandTimeoutMinutes: 90,
-		timeoutMinutes: 105,
+		commandTimeoutMinutes: 140,
+		timeoutMinutes: 155,
 		minDiskGb: 25,
 		dimensions: ["realworld"],
 		metrics: [

--- a/tooling/repo-checks/src/lib/workflow-sync.ts
+++ b/tooling/repo-checks/src/lib/workflow-sync.ts
@@ -13,11 +13,13 @@
 //      into both the smoke lane and the matrix lane, or the live run silently skips it.
 //   4. A credential key shared across the two workflows maps to the same value expression — both
 //      lanes must hand the suite the same secret, not plan one and run the other.
+//   5. Both live-run jobs outlast the longest registered sandbox lifetime by a fixed margin, so a
+//      suite budget increase cannot leave an otherwise healthy job to be killed by Actions first.
 //
 // Bun.YAML.parse is built into bun >= 1.3 (no new dependency), so the parse stays dependency-light.
 import { readFileSync } from "node:fs";
 import { join } from "node:path";
-import { PROVIDERS, SUITE_NAMES } from "@sandbox-benchmarks/schema";
+import { PROVIDERS, SUITE_NAMES, SUITES } from "@sandbox-benchmarks/schema";
 import { type } from "arktype";
 import { findRepoRoot } from "./workspace.ts";
 
@@ -27,6 +29,8 @@ export const MATRIX_WORKFLOW = ".github/workflows/bench-matrix.yml";
 export const RUN_STEP = "Run suite and normalize";
 export const SMOKE_JOB = "smoke";
 export const MATRIX_JOB = "bench";
+/** Host-side checkout/teardown/normalization/upload allowance beyond the sandbox lifetime. */
+export const WORKFLOW_TIMEOUT_MARGIN_MINUTES = 15;
 
 // Single source of truth: this schema drives BOTH the runtime parse (coercions live in the morphs)
 // and the exported DispatchInput type (inferred below) — there is no hand-written interface or
@@ -89,6 +93,18 @@ function asRecord(value: unknown, message: string): Record<string, unknown> {
 		throw new Error(message);
 	}
 	return value as Record<string, unknown>;
+}
+
+/** Parse a job's literal positive integer `timeout-minutes`; expressions cannot satisfy this gate. */
+export function jobTimeoutMinutes(doc: unknown, jobId: string, label: string): number {
+	const root = asRecord(doc, `${label}: not a YAML mapping`);
+	const jobs = asRecord(root.jobs, `${label}: no jobs mapping`);
+	const job = asRecord(jobs[jobId], `${label}: job "${jobId}" not found`);
+	const timeout = job["timeout-minutes"];
+	if (typeof timeout !== "number" || !Number.isInteger(timeout) || timeout <= 0) {
+		throw new Error(`${label}: job "${jobId}" timeout-minutes must be a positive integer literal`);
+	}
+	return timeout;
 }
 
 /**
@@ -249,6 +265,19 @@ export function checkCredentialEnv(
 	return errors;
 }
 
+/** Invariant 5: every live-run job has margin beyond the longest registered sandbox lifetime. */
+export function checkWorkflowTimeouts(timeoutByWorkflow: Record<string, number>): string[] {
+	const longestSuite = Math.max(...Object.values(SUITES).map((suite) => suite.timeoutMinutes));
+	const minimum = longestSuite + WORKFLOW_TIMEOUT_MARGIN_MINUTES;
+	return Object.entries(timeoutByWorkflow)
+		.filter(([, timeout]) => timeout < minimum)
+		.map(
+			([workflow, timeout]) =>
+				`${workflow}: job timeout-minutes ${timeout} is below the required ${minimum} ` +
+				`(${longestSuite}-minute longest suite + ${WORKFLOW_TIMEOUT_MARGIN_MINUTES}-minute host margin)`,
+		);
+}
+
 /**
  * The whole gate against the real workflow files under `root` — the single owner of which files feed
  * the gate, used by the real-file test in workflow-registry-sync.test.ts.
@@ -262,6 +291,10 @@ export function runCheck(root: string = findRepoRoot()): string[] {
 		...checkCredentialEnv({
 			[SMOKE_WORKFLOW]: stepEnv(smoke, SMOKE_JOB, RUN_STEP, SMOKE_WORKFLOW),
 			[MATRIX_WORKFLOW]: stepEnv(matrix, MATRIX_JOB, RUN_STEP, MATRIX_WORKFLOW),
+		}),
+		...checkWorkflowTimeouts({
+			[SMOKE_WORKFLOW]: jobTimeoutMinutes(smoke, SMOKE_JOB, SMOKE_WORKFLOW),
+			[MATRIX_WORKFLOW]: jobTimeoutMinutes(matrix, MATRIX_JOB, MATRIX_WORKFLOW),
 		}),
 	];
 }

--- a/tooling/repo-checks/src/workflow-registry-sync.test.ts
+++ b/tooling/repo-checks/src/workflow-registry-sync.test.ts
@@ -14,7 +14,9 @@ import {
 	checkCredentialEnv,
 	checkProviderInput,
 	checkSuiteInput,
+	checkWorkflowTimeouts,
 	dispatchInput,
+	jobTimeoutMinutes,
 	MATRIX_JOB,
 	MATRIX_WORKFLOW,
 	RUN_STEP,
@@ -24,6 +26,7 @@ import {
 	SMOKE_JOB,
 	SMOKE_WORKFLOW,
 	stepEnv,
+	WORKFLOW_TIMEOUT_MARGIN_MINUTES,
 } from "./lib/workflow-sync.ts";
 
 const smoke = readWorkflow(SMOKE_WORKFLOW);
@@ -53,6 +56,11 @@ describe("parsers against the real workflow files", () => {
 		expect(Object.keys(smokeEnv).length).toBeGreaterThanOrEqual(8);
 	});
 
+	test("both live-run jobs reserve host margin beyond the longest suite", () => {
+		expect(jobTimeoutMinutes(smoke, SMOKE_JOB, SMOKE_WORKFLOW)).toBe(180);
+		expect(jobTimeoutMinutes(matrix, MATRIX_JOB, MATRIX_WORKFLOW)).toBe(180);
+	});
+
 	test("dispatchInput throws on a missing input instead of passing vacuously", () => {
 		expect(() => dispatchInput(smoke, "no-such-input", SMOKE_WORKFLOW)).toThrow(
 			'input "no-such-input" not found',
@@ -70,6 +78,19 @@ describe("parsers against the real workflow files", () => {
 		expect(() => stepEnv(Bun.YAML.parse(yaml), "j", "bare", "synthetic.yml")).toThrow(
 			"has no env mapping",
 		);
+	});
+});
+
+describe("checkWorkflowTimeouts", () => {
+	test("passes timeouts with the required host margin", () => {
+		expect(checkWorkflowTimeouts({ smoke: 180, matrix: 180 })).toEqual([]);
+	});
+
+	test("flags a job cap that cannot outlast the longest suite", () => {
+		const errors = checkWorkflowTimeouts({ smoke: 155 });
+		expect(errors).toHaveLength(1);
+		expect(errors[0]).toContain("smoke");
+		expect(errors[0]).toContain(`${WORKFLOW_TIMEOUT_MARGIN_MINUTES}-minute host margin`);
 	});
 });
 


### PR DESCRIPTION
## Summary

- Move benchmark cells to hosted Ubuntu runners and raise the job/suite budgets so full CPU, disk, system, and real-world matrices can finish.
- Standardize publishable PTS runs at five trials and align suite budgets and comments with that policy.
- Vendor the repaired network-loopback installer so netcat-openbsd does not hang after the first trial.

## Verification

Passed the full local CI contract at this stack boundary: Biome, shellcheck, hadolint, typecheck, tests, catalog drift, and spelling.