### PR TITLE
fix(leaderboard): exclude incomparable providers

### DIFF
--- a/docs/methodology.md
+++ b/docs/methodology.md
@@ -14,7 +14,10 @@ schema-validated dataset.
 Every provider is created at one pinned [`TARGET_SPEC`](../packages/schema/src/providers.ts): **2 vCPU,
 8 GiB RAM, 20 GB disk**. It's sized to fit inside every provider's reproducible envelope (E2B caps
 sandbox RAM at 8 GiB), so anyone can rerun on the same shape. A provider that can't express a dimension
-runs with its actuals recorded and the mismatch disclosed (`specMatched`).
+runs with its actuals recorded and the mismatch disclosed (`specMatched`). Its measurements remain in
+the dataset for auditability, but the leaderboard excludes them from rankings and lists the provider in
+an explicit **Not ranked** section. An absent `specMatched` is also unrankable: comparability must be
+positively established, not assumed.
 
 ## Dimensions and metrics
 

--- a/packages/results/src/lib/aggregate.test.ts
+++ b/packages/results/src/lib/aggregate.test.ts
@@ -147,4 +147,34 @@ describe("aggregateRuns", () => {
 		expect(() => aggregateRuns([a, b])).toThrow(/identity mismatch/);
 		expect(() => aggregateRuns([])).toThrow(/at least one/);
 	});
+
+	it("disqualifies a provider whose specMatched fold has any mismatched shard, regardless of order", () => {
+		const matched = provider("daytona", [metric("node_web_tooling_runs_per_s", [10])]);
+		matched.specMatched = true;
+		const mismatched = provider("daytona", [metric("pybench_milliseconds", [900])]);
+		mismatched.specMatched = false;
+
+		// false is sticky no matter which shard arrives first.
+		for (const order of [
+			[shard([matched]), shard([mismatched])],
+			[shard([mismatched]), shard([matched])],
+		]) {
+			const daytona = aggregateRuns(order).providers.find((p) => p.providerId === "daytona");
+			expect(daytona?.specMatched).toBe(false);
+		}
+	});
+
+	it("keeps specMatched undefined when no shard observed the spec, and true when only matches did", () => {
+		const noProbe = shard([provider("daytona", [metric("node_web_tooling_runs_per_s", [10])])]);
+		expect(
+			aggregateRuns([noProbe]).providers.find((p) => p.providerId === "daytona")?.specMatched,
+		).toBeUndefined();
+
+		const matchOnly = provider("daytona", [metric("pybench_milliseconds", [900])]);
+		matchOnly.specMatched = true;
+		expect(
+			aggregateRuns([noProbe, shard([matchOnly])]).providers.find((p) => p.providerId === "daytona")
+				?.specMatched,
+		).toBe(true);
+	});
 });

--- a/packages/results/src/lib/aggregate.ts
+++ b/packages/results/src/lib/aggregate.ts
@@ -84,7 +84,14 @@ function mergeProvider(providerId: string, slices: readonly ProviderRun[]): Prov
 			}
 		}
 		if (slice.observedSpecs.cpuModel) hostCpuModels.add(slice.observedSpecs.cpuModel);
-		if (specMatched === undefined) specMatched = slice.specMatched;
+		// specMatched folds ORDER-INDEPENDENTLY across shards (was first-shard-wins, which made ranking
+		// eligibility depend on shard arrival order). The merged provider row shares one aggregate, so a
+		// single shard that ran off the target spec (specMatched === false) contaminates it and
+		// disqualifies the whole provider — false is sticky and always wins. An affirmative match stands
+		// only while no shard contradicts it; all-undefined stays undefined ("refuse to judge on partial
+		// evidence", see computeSpecMatched).
+		if (slice.specMatched === false) specMatched = false;
+		else if (slice.specMatched === true && specMatched !== false) specMatched = true;
 	}
 
 	// Disclose the distinct host CPUs when the shards saw more than one — names the confound rather than

--- a/packages/results/src/lib/leaderboard.test.ts
+++ b/packages/results/src/lib/leaderboard.test.ts
@@ -12,15 +12,18 @@ function provider(
 	metrics: MetricResult[],
 	gaps: ProviderRun["gaps"] = [],
 	suitesCovered: ProviderRun["suitesCovered"] = [],
+	overrides: Partial<ProviderRun> = {},
 ): ProviderRun {
 	return {
 		providerId,
 		validationStatus: metrics.length > 0 ? "validated" : "pending",
+		specMatched: true,
 		observedSpecs: {},
 		metrics,
 		suitesCovered,
 		gaps,
 		uncatalogued: [],
+		...overrides,
 	};
 }
 
@@ -79,6 +82,20 @@ describe("buildLeaderboard", () => {
 		expect(md).toMatch(/\| 1 \| Daytona \| 10 \|/);
 	});
 
+	it("does not print a unit twice when the catalog label already embeds it", () => {
+		// The fio disk headline label is "fio rand read 4KB, O_DIRECT (IOPS)" and its unit is "IOPS" —
+		// naively appending "(IOPS)" would render "(IOPS) (IOPS)" in the header and headline lines.
+		const fioIops =
+			"fio_type_random_read_engine_linux_aio_direct_yes_block_size_4kb_job_count_1_disk_target_default_test_directory_iops";
+		const md = renderLeaderboardMarkdown(
+			buildLeaderboard(run([provider("daytona", [metric(fioIops, [1000])])])),
+		);
+		expect(md).toContain("fio rand read 4KB, O_DIRECT (IOPS)");
+		expect(md).not.toContain("(IOPS) (IOPS)");
+		// The headline still names the direction, just without the duplicated unit.
+		expect(md).toContain("**fio rand read 4KB, O_DIRECT (IOPS)** (higher is better)");
+	});
+
 	it("orders equal headline values deterministically by providerId and shares their rank", () => {
 		// Input order is modal-then-daytona; equal values must reorder to alphabetical providerId AND
 		// share a rank — an exact tie is not a ranking win for whoever sorts first.
@@ -96,6 +113,60 @@ describe("buildLeaderboard", () => {
 	it("renders a placeholder when nothing is ranked", () => {
 		const md = renderLeaderboardMarkdown(buildLeaderboard(run([provider("daytona", [])])));
 		expect(md).toContain("No ranked dimensions yet");
+	});
+
+	it("excludes a faster spec-mismatched provider and discloses its observed shape", () => {
+		const board = buildLeaderboard(
+			run([
+				provider("daytona", [metric("node_web_tooling_runs_per_s", [10])]),
+				provider("blaxel", [metric("node_web_tooling_runs_per_s", [100])], [], [], {
+					specMatched: false,
+					observedSpecs: { vcpus: 6, memoryGb: 15.63, diskGb: 12.5 },
+				}),
+			]),
+		);
+
+		expect(
+			board.dimensions.find((d) => d.dimension === "cpu")?.rows.map((r) => r.providerId),
+		).toEqual(["daytona"]);
+		expect(board.rankingExclusions).toEqual([
+			{
+				providerId: "blaxel",
+				displayName: "Blaxel",
+				reason: "spec-mismatch",
+				validationStatus: "validated",
+				observedSpecs: { vcpus: 6, memoryGb: 15.63, diskGb: 12.5 },
+			},
+		]);
+
+		const md = renderLeaderboardMarkdown(board);
+		expect(md).toContain("## Not ranked");
+		expect(md).toContain("not included in any ranking");
+		expect(md).toContain("| Blaxel | **target spec mismatch** |");
+		expect(md).toContain("Target: 2 vCPU / 8 GiB RAM / 20 GB disk");
+		expect(md).toContain("observed: 6 vCPU / 15.63 GiB RAM / 12.5 GB disk");
+	});
+
+	it("requires positive validation and spec-match evidence before ranking measured results", () => {
+		const board = buildLeaderboard(
+			run([
+				provider("daytona", [metric("node_web_tooling_runs_per_s", [10])]),
+				provider("e2b", [metric("node_web_tooling_runs_per_s", [20])], [], [], {
+					specMatched: undefined,
+				}),
+				provider("modal", [metric("node_web_tooling_runs_per_s", [30])], [], [], {
+					validationStatus: "pending",
+				}),
+			]),
+		);
+
+		expect(
+			board.dimensions.find((d) => d.dimension === "cpu")?.rows.map((r) => r.providerId),
+		).toEqual(["daytona"]);
+		expect(board.rankingExclusions.map((e) => [e.providerId, e.reason])).toEqual([
+			["e2b", "spec-unverified"],
+			["modal", "validation-incomplete"],
+		]);
 	});
 });
 

--- a/packages/results/src/lib/leaderboard.ts
+++ b/packages/results/src/lib/leaderboard.ts
@@ -21,7 +21,10 @@ import type {
 	GapScope,
 	MedianInterval,
 	MetricDef,
+	ObservedSpecs,
 	Run,
+	TargetSpec,
+	ValidationStatus,
 } from "@sandbox-benchmarks/schema";
 import {
 	bootstrapMedianInterval,
@@ -133,12 +136,27 @@ export interface CoverageGap {
 	disk: boolean;
 }
 
+/** Why a provider with measured results was kept out of the comparative rankings. */
+export type RankingExclusionReason = "validation-incomplete" | "spec-mismatch" | "spec-unverified";
+
+/** A measured provider that is visible in the report but not comparable enough to rank. */
+export interface RankingExclusion {
+	providerId: string;
+	displayName: string;
+	reason: RankingExclusionReason;
+	validationStatus: ValidationStatus;
+	observedSpecs: ObservedSpecs;
+}
+
 /** The full comparison surface derived from one Run. */
 export interface Leaderboard {
 	runId: string;
 	sha: string;
 	generatedAt: string;
+	targetSpec: TargetSpec;
 	dimensions: LeaderboardDimension[];
+	/** Measured providers excluded from rankings, retained here so exclusion can never become invisibility. */
+	rankingExclusions: RankingExclusion[];
 	/** Every benchmark that produced no result somewhere, disk gaps first. Empty when coverage is complete. */
 	coverageGaps: CoverageGap[];
 }
@@ -231,6 +249,36 @@ function coverageGapsOf(run: Run): CoverageGap[] {
 	);
 }
 
+/**
+ * Measured results that cannot enter a like-for-like ranking. A provider is rankable only after the
+ * producer validated its results AND positively established that the effective sandbox matched the
+ * target. Treating an absent `specMatched` as success would let an old or incomplete probe silently
+ * weaken the comparison contract.
+ */
+function rankingExclusionsOf(run: Run): RankingExclusion[] {
+	return run.providers
+		.filter(
+			(provider) =>
+				provider.metrics.length > 0 &&
+				(provider.validationStatus !== "validated" || provider.specMatched !== true),
+		)
+		.map(
+			(provider): RankingExclusion => ({
+				providerId: provider.providerId,
+				displayName: getProvider(provider.providerId)?.displayName ?? provider.providerId,
+				reason:
+					provider.validationStatus !== "validated"
+						? "validation-incomplete"
+						: provider.specMatched === false
+							? "spec-mismatch"
+							: "spec-unverified",
+				validationStatus: provider.validationStatus,
+				observedSpecs: provider.observedSpecs,
+			}),
+		)
+		.sort((a, b) => a.displayName.localeCompare(b.displayName, "en"));
+}
+
 /** Build the structured leaderboard from a validated Run. Pure — Run in, ranking out. */
 export function buildLeaderboard(run: Run): Leaderboard {
 	const dimensions: LeaderboardDimension[] = [];
@@ -247,6 +295,9 @@ export function buildLeaderboard(run: Run): Leaderboard {
 		// Carry each provider's raw Samples alongside its row: the ranking needs the full distributions,
 		// not just their medians, to tell a real difference from environmental noise.
 		const candidates = run.providers.flatMap((provider) => {
+			// Rankings compare like with like. Results remain in the Run and are disclosed below, but an
+			// unvalidated or non-matching sandbox must never win a target-spec provider table.
+			if (provider.validationStatus !== "validated" || provider.specMatched !== true) return [];
 			const result = provider.metrics.find((m) => m.metricId === metric.id);
 			if (!result) return [];
 			const row: LeaderboardRow = {
@@ -360,7 +411,9 @@ export function buildLeaderboard(run: Run): Leaderboard {
 		runId: run.runId,
 		sha: run.sha,
 		generatedAt: run.generatedAt,
+		targetSpec: run.targetSpec,
 		dimensions,
+		rankingExclusions: rankingExclusionsOf(run),
 		coverageGaps: coverageGapsOf(run),
 	};
 }
@@ -407,6 +460,17 @@ function formatPValue(p: number): string {
 	return p.toPrecision(2);
 }
 
+/** Render the effective, comparable part of a target or observed sandbox shape. */
+function formatSpec(spec: Partial<TargetSpec & ObservedSpecs>): string {
+	const value = (n: number | undefined, unit: string): string =>
+		n === undefined ? `unknown ${unit}` : `${formatValue(n)} ${unit}`;
+	return [
+		value(spec.vcpus, "vCPU"),
+		value(spec.memoryGb, "GiB RAM"),
+		value(spec.diskGb, "GB disk"),
+	].join(" / ");
+}
+
 /** Render a {@link Leaderboard} as a Markdown document — the committed comparison surface. */
 export function renderLeaderboardMarkdown(board: Leaderboard): string {
 	const lines: string[] = [
@@ -424,12 +488,18 @@ export function renderLeaderboardMarkdown(board: Leaderboard): string {
 
 	for (const { dimension, metric, rows } of board.dimensions) {
 		const better = metric.direction === "HIB" ? "higher is better" : "lower is better";
+		// Some catalog labels already carry their unit — the fio metrics embed "(IOPS)"/"(MB/s)" to tell
+		// the IOPS and throughput variants of one scenario apart. Appending metric.unit again would render
+		// "… (IOPS) (IOPS)", so only add it when the label does not already end with it.
+		const labelHasUnit = metric.label.endsWith(`(${metric.unit})`);
+		const columnHeader = labelHasUnit ? metric.label : `${metric.label} (${metric.unit})`;
+		const headlineMeta = labelHasUnit ? better : `${metric.unit}, ${better}`;
 		lines.push(
 			`## ${dimension}`,
 			"",
-			`Headline: **${metric.label}** (${metric.unit}, ${better})`,
+			`Headline: **${metric.label}** (${headlineMeta})`,
 			"",
-			`| Rank | Provider | ${metric.label} (${metric.unit}) | 95% CI | n | p vs. above | p (KS) |`,
+			`| Rank | Provider | ${columnHeader} | 95% CI | n | p vs. above | p (KS) |`,
 			"| ---: | --- | ---: | ---: | ---: | ---: | ---: |",
 			...rows.map((r) => {
 				const ci =
@@ -458,6 +528,34 @@ export function renderLeaderboardMarkdown(board: Leaderboard): string {
 				// a large, tied `p vs. above` is exactly that case — same typical speed, different machine.
 				const ks = r.pVsPrevious === null ? "—" : formatPValue(r.pVsPrevious.ks);
 				return `| ${r.rank} | ${r.displayName} | ${formatValue(r.value)} | ${ci} | ${r.n} | ${p} | ${ks} |`;
+			}),
+			"",
+		);
+	}
+
+	// Exclusion must be conspicuous rather than silent: these providers produced real measurements,
+	// but the measurements do not satisfy the like-for-like contract and therefore cannot be ranked.
+	if (board.rankingExclusions.length > 0) {
+		lines.push(
+			"## Not ranked",
+			"",
+			"These providers produced measurements, but their results are **not included in any ranking**",
+			"because validation or target-spec comparability was not established.",
+			"",
+			"| Provider | Reason | Detail |",
+			"| --- | --- | --- |",
+			...board.rankingExclusions.map((exclusion) => {
+				const reason =
+					exclusion.reason === "validation-incomplete"
+						? "validation incomplete"
+						: exclusion.reason === "spec-mismatch"
+							? "target spec mismatch"
+							: "target spec unverified";
+				const detail =
+					exclusion.reason === "validation-incomplete"
+						? `Status: ${exclusion.validationStatus}.`
+						: `Target: ${formatSpec(board.targetSpec)}; observed: ${formatSpec(exclusion.observedSpecs)}.`;
+				return `| ${exclusion.displayName} | **${reason}** | ${escapeCell(detail)} |`;
 			}),
 			"",
 		);


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Exclude providers that aren’t comparable from rankings and list them in a Not ranked section with reasons, validation status, and clear Target vs observed specs. Also fix duplicated unit labels so metric headers and headlines don’t repeat units.

- **Bug Fixes**
  - Rank only when `validationStatus` is "validated" and `specMatched` is true; undefined is treated as unverified and excluded.
  - Collect and show exclusions: build `rankingExclusions` with reason (`spec-mismatch`/`spec-unverified`/`validation-incomplete`), `validationStatus`, and `observedSpecs`; include `targetSpec` and render a Not ranked table with Target vs observed.
  - Fold `specMatched` across shards order-independently: false is sticky; true only if no shard contradicts; all-undefined stays undefined.
  - Prevent duplicate units when a catalog label already embeds its unit, in both headlines and table headers.
  - Update methodology and tests for exclusions, spec folding, and unit de-duplication.

<sup>Written for commit 7faaac666a141ed095870b5a631cf0cbc97e697a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/starslingdev/sandbox-benchmarks/pull/165?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

