### PR TITLE
chore(leaderboard): regenerate from run 29365910084

### DIFF
--- a/LEADERBOARD.md
+++ b/LEADERBOARD.md
@@ -1,6 +1,6 @@
 # Sandbox provider leaderboard
 
-Run `29130741476` · commit `663be0904797890a24fdaf1cc6e3ea8d77b3b89c` · generated 2026-07-11T00:18:19.295Z
+Run `29365910084` · commit `0343acb5c1cfd3a0aac81afc3262d4af0fa69bc7` · generated 2026-07-14T22:52:05.191Z
 
 Each table ranks the providers on that dimension's headline metric. Generated from the published Run dataset — do not edit by hand.
 
@@ -10,8 +10,21 @@ Headline: **Node.js web tooling** (runs/s, higher is better)
 
 | Rank | Provider | Node.js web tooling (runs/s) | 95% CI | n | p vs. above | p (KS) |
 | ---: | --- | ---: | ---: | ---: | ---: | ---: |
-| 1 | Daytona | 19.72 | 19.63 – 19.96 | 3 | — | — |
-| 2 | Modal | 9.59 | 9.52 – 9.79 | 3 | 0.10 (n too small) | 0.033 |
+| 1 | Daytona | 19.14 | 18.48 – 19.89 | 5 | — | — |
+| 2 | Novita | 17.59 | 17.22 – 18.65 | 5 | 0.016 | 0.036 |
+| 3 | E2B | 10.58 | 10.25 – 10.83 | 5 | 0.0079 | 0.0038 |
+| 4 | Modal | 9.25 | 8.7 – 9.58 | 5 | 0.0079 | 0.0038 |
+
+## disk
+
+Headline: **fio rand read 4KB, O_DIRECT (IOPS)** (higher is better)
+
+| Rank | Provider | fio rand read 4KB, O_DIRECT (IOPS) | 95% CI | n | p vs. above | p (KS) |
+| ---: | --- | ---: | ---: | ---: | ---: | ---: |
+| 1 | Daytona | 246000 | 241000 – 255000 | 5 | — | — |
+| 2 | Novita | 68100 | 66600 – 71500 | 5 | 0.0079 | 0.0038 |
+| 3 | E2B | 40800 | 39800 – 42000 | 5 | 0.0079 | 0.0038 |
+| 4 | Modal | 34900 | 33600 – 35200 | 5 | 0.0079 | 0.0038 |
 
 ## memory
 
@@ -19,8 +32,30 @@ Headline: **STREAM Triad** (MB/s, higher is better)
 
 | Rank | Provider | STREAM Triad (MB/s) | 95% CI | n | p vs. above | p (KS) |
 | ---: | --- | ---: | ---: | ---: | ---: | ---: |
-| 1 | Daytona | 54530 | 54030 – 54590 | 5 | — | — |
-| 2 | Modal | 40510 | 38810 – 53440 | 5 | 0.0079 | 0.0038 |
+| 1 | Daytona | 71508 | 69090 – 78270 | 5 | — | — |
+| 2 | Modal | 53700 | 45390 – 57730 | 5 | 0.0079 | 0.0038 |
+| 2 | Novita | 53140 | 52970 – 53313 | 5 | 0.69 (tied) | 0.21 |
+| 4 | E2B | 23850 | 22450 – 25430 | 5 | 0.0079 | 0.0038 |
+
+## network
+
+Headline: **Loopback TCP (10GB)** (Seconds, lower is better)
+
+| Rank | Provider | Loopback TCP (10GB) (Seconds) | 95% CI | n | p vs. above | p (KS) |
+| ---: | --- | ---: | ---: | ---: | ---: | ---: |
+| 1 | Daytona | 4.898 | 4.682 – 5.402 | 5 | — | — |
+| 2 | E2B | 7.764 | 7.373 – 8.467 | 5 | 0.0079 | 0.0038 |
+| 3 | Novita | 11.32 | 10.03 – 11.45 | 5 | 0.0079 | 0.0038 |
+| 4 | Modal | 52.14 | 51.04 – 55.37 | 5 | 0.0079 | 0.0038 |
+
+## realworld
+
+Headline: **Mastra: cold install** (Seconds, lower is better)
+
+| Rank | Provider | Mastra: cold install (Seconds) | 95% CI | n | p vs. above | p (KS) |
+| ---: | --- | ---: | ---: | ---: | ---: | ---: |
+| 1 | Daytona | 31.68 | 31.27 – 33.71 | 5 | — | — |
+| 1 | Novita | 33.12 | 32.84 – 33.84 | 5 | 0.095 (tied) | 0.036 |
 
 ## economics
 
@@ -29,7 +64,18 @@ Headline: **Hourly cost** (USD/hr, lower is better)
 | Rank | Provider | Hourly cost (USD/hr) | 95% CI | n | p vs. above | p (KS) |
 | ---: | --- | ---: | ---: | ---: | ---: | ---: |
 | 1 | Daytona | 0.1494 | — | 1 | — | — |
-| 2 | Modal | 0.4774 | — | 1 | — | — |
+| 2 | Novita | 0.1627 | — | 1 | — | — |
+| 3 | E2B | 0.2304 | — | 1 | — | — |
+| 4 | Modal | 0.4774 | — | 1 | — | — |
+
+## Not ranked
+
+These providers produced measurements, but their results are **not included in any ranking**
+because validation or target-spec comparability was not established.
+
+| Provider | Reason | Detail |
+| --- | --- | --- |
+| Blaxel | **target spec mismatch** | Target: 2 vCPU / 8 GiB RAM / 40 GB disk; observed: 6 vCPU / 15.63 GiB RAM / 12.5 GB disk. |
 
 ## Coverage gaps
 
@@ -38,31 +84,25 @@ one — read it as the provider **failing to cover** that workload, never as a t
 
 | Provider | Benchmark | Outcome | Detail |
 | --- | --- | --- | --- |
-| Daytona | realworld-mastra | ❌ **disk** (skipped) | Insufficient disk: 16.7 GiB free, suite needs 30 GiB |
-| Daytona | realworld-openclaw | ❌ **disk** (skipped) | Insufficient disk: 16.7 GiB free, suite needs 25 GiB |
-| Blaxel | cpu-node | **missing** | No result and no marker — the suite never reported for this provider. |
-| Blaxel | disk | **missing** | No result and no marker — the suite never reported for this provider. |
-| Blaxel | memory | **missing** | No result and no marker — the suite never reported for this provider. |
-| Blaxel | realworld-better-auth | **missing** | No result and no marker — the suite never reported for this provider. |
-| Blaxel | realworld-mastra | **missing** | No result and no marker — the suite never reported for this provider. |
-| Blaxel | realworld-openclaw | **missing** | No result and no marker — the suite never reported for this provider. |
-| E2B | cpu-node | **missing** | No result and no marker — the suite never reported for this provider. |
-| E2B | disk | **missing** | No result and no marker — the suite never reported for this provider. |
-| E2B | memory | **missing** | No result and no marker — the suite never reported for this provider. |
-| E2B | realworld-better-auth | **missing** | No result and no marker — the suite never reported for this provider. |
-| E2B | realworld-mastra | **missing** | No result and no marker — the suite never reported for this provider. |
-| E2B | realworld-openclaw | **missing** | No result and no marker — the suite never reported for this provider. |
-| Modal | realworld-mastra | **missing** | No result and no marker — the suite never reported for this provider. |
-| Modal | realworld-openclaw | **missing** | No result and no marker — the suite never reported for this provider. |
+| Blaxel | realworld-mastra | ❌ **disk** (skipped) | Insufficient disk: 12.5 GiB free, suite needs 30 GiB |
+| Blaxel | realworld-openclaw | ❌ **disk** (skipped) | Insufficient disk: 12.5 GiB free, suite needs 25 GiB |
+| E2B | realworld-mastra | ❌ **disk** (skipped) | Insufficient disk: 19.7 GiB free, suite needs 30 GiB |
+| E2B | realworld-openclaw | ❌ **disk** (skipped) | Insufficient disk: 19.7 GiB free, suite needs 25 GiB |
+| Blaxel | cpu-generic | **failed** | Step "mise run benchmark:cpu:generic" timed out after 7800s |
+| Daytona | cpu-generic | **failed** | Step "mise run benchmark:cpu:generic" timed out after 7800s |
+| Daytona | realworld-openclaw | **failed** | Step "mise run benchmark:realworld:pts:openclaw" lost its sandbox: 12 consecutive detached polls failed (last: done-file fs exists) — the sandbox stopped responding, not a quiet long step |
+| E2B | cpu-generic | **failed** | Step "mise run benchmark:cpu:generic" timed out after 7800s |
+| Modal | cpu-generic | **failed** | Step "mise run benchmark:cpu:generic" timed out after 7800s |
+| Modal | realworld-mastra | **failed** | Step "mise run benchmark:realworld:pts:mastra" timed out after 8400s |
+| Modal | realworld-openclaw | **failed** | Step "mise run benchmark:realworld:pts:openclaw" timed out after 8400s |
+| Novita | cpu-generic | **failed** | Step "mise run benchmark:cpu:generic" timed out after 7800s |
 
 **skipped** — a precondition said no before the benchmark was attempted. A ❌ **disk** skip is the
 loud one: the provider could not supply the disk the suite needs, so the workload does not run on
 its current allocation at all. That is a structural absence, not a slow result.
 
-**missing** — nothing was reported at all: no result, and no marker explaining why. The suite ran
-elsewhere in this run, so it was part of the comparison, and this provider is simply absent from
-it — a dropped job, a lost artifact, or a sandbox that died before it could say anything. Treat it
-as unmeasured, never as a pass: the provider has not been shown to run this workload.
+**failed** — the benchmark was attempted and broke: it threw, timed out, or died with the sandbox.
+Unlike a skip, this is a reliability fact about the provider, not a decision made on its behalf.
 
 ---
 
@@ -75,6 +115,11 @@ independent of the host's scheduling.
 Rows are separated only when their full Sample distributions differ (Mann-Whitney U, two-sided, α = 0.05,
 enumerated exactly over the permutation null rather than approximated — at these sample sizes the
 normal approximation can report a p the exact test cannot actually produce).
+
+**A shared rank always says why, in the `p vs. above` cell, and the reasons are not interchangeable.**
+`(tied)` — the test could have separated those providers and did not, so a faster median earned
+inside the noise is not a faster provider. This is the only one that claims two providers are
+statistically indistinguishable.
 
 Samples are repeated trials inside one sandbox, so their spread is environmental (neighbours, host
 contention, virtualization), and a wide CI or a large `n` (the harness re-runs a test that will not
@@ -90,12 +135,4 @@ looks like, and it is the reason a median alone cannot rank these providers.
 
 At the small `n` this suite produces, a non-significant result means *not enough evidence to
 separate*, never *the providers are equal*.
-
-`n too small` is the extreme of that: Mann-Whitney's best attainable p already exceeds α for those
-Samples, so the test could not have separated the rows at any effect size (here 3 v 3 floors at p ≈ 0.10).
-Such rows are ranked on their observed medians and are **not** claimed to be tied — read the gap
-between the values, and treat the p-value as unable to settle them either way. Where such a row
-nevertheless shares the rank above it, the cell reads `equal medians`: the two values are simply
-identical, which is the ranking having nothing to order them by — never a finding that the
-providers are alike.
 


### PR DESCRIPTION
Regenerates the committed `LEADERBOARD.md` comparison surface from the newly published run **`29365910084`** (the latest entry in `data/dataset/index.json`), replacing the prior render from `29130741476`.

Mechanically `leaderboard data/dataset/runs/29365910084.json LEADERBOARD.md` — no hand edits. Every table still ranks the four providers (Daytona, Novita, E2B, Modal) on each dimension's headline metric at n=5, so this is a pure data refresh on top of the leaderboard tooling in the stack below.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Regenerated the sandbox provider leaderboard from run 29365910084. Adds Novita and E2B, new benchmark tables, and clearer rankings, costs, and reliability signals.

- **New Features**
  - Added providers Novita and E2B; new tables: disk (fio rand read), network (Loopback TCP), and realworld (Mastra: cold install). Hourly cost now ranks all four.
  - Performance tables use n=5 and now show ties when statistically indistinguishable; removed “n too small” and clarified tie rules.
  - Added Not ranked section excluding Blaxel for target-spec mismatch; coverage gaps now show explicit failures and disk-capacity skips with timeouts.

<sup>Written for commit 513099a925bbc2641c81b9ecef8784cd402b586e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/starslingdev/sandbox-benchmarks/pull/167?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

