### PR TITLE
feat(providers): add Namespace sandboxes

### DIFF
--- a/.github/workflows/bench-matrix.yml
+++ b/.github/workflows/bench-matrix.yml
@@ -75,7 +75,11 @@ on:
         type: boolean
         default: false
 
-# Least privilege: jobs only read the checked-out code and upload artifacts (publish elevates).
+# Least privilege, workflow default: jobs only read the checked-out code and upload artifacts (publish
+# elevates to contents: write). `id-token: write` is deliberately NOT granted here — only the `suite`
+# fan-out needs it (it must pass the scope down to bench-suite.yml's cells for Namespace's GitHub OIDC
+# federation), so it is scoped to that job; zizmor flags a workflow-level id-token: write as overly
+# broad since `plan` and `publish` never touch it.
 permissions:
   contents: read
 
@@ -145,6 +149,14 @@ jobs:
     if: >
       github.repository == 'starslingdev/hpc-sandbox-benchmarks' &&
       (github.ref == 'refs/heads/main' || inputs.allow_branch)
+    # A called workflow's token can never exceed its caller's, so the id-token: write that
+    # bench-suite.yml's cells need for Namespace's GitHub OIDC federation has to be granted here too.
+    # Scoped to this job, not the workflow level, per zizmor's excessive-permissions audit; `contents`
+    # is restated because a job-level `permissions:` replaces the workflow default rather than adding
+    # to it.
+    permissions:
+      contents: read
+      id-token: write
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/bench-smoke.yml
+++ b/.github/workflows/bench-smoke.yml
@@ -11,7 +11,7 @@ on:
         description: Provider to benchmark
         type: choice
         default: daytona-vm
-        options: [daytona-vm, daytona-container, e2b, modal-gvisor, modal-vm, blaxel, novita]
+        options: [daytona-vm, daytona-container, e2b, modal-gvisor, modal-vm, blaxel, novita, namespace]
       suite:
         # Constrained to the SUITE_NAMES registry (packages/schema/src/suites.ts); the
         # workflow-registry-sync drift gate (tooling/repo-checks) keeps this list in lockstep, so a
@@ -65,6 +65,13 @@ jobs:
     runs-on: ubuntu-24.04
     environment: privileged
     timeout-minutes: 180
+    # `id-token: write` is scoped to this job (not the workflow, which only has this one job today),
+    # matching bench-matrix.yml/toolchain-image.yml: a job added later must opt in explicitly rather
+    # than silently inheriting the ability to request OIDC tokens. Only Namespace uses it (GitHub
+    # OIDC federation, no stored secret); widened from the workflow default (contents: read).
+    permissions:
+      contents: read
+      id-token: write
     steps:
       # Third-party actions are pinned to a commit SHA (the tag comment is for humans) so a
       # moved/compromised tag can't silently change what runs.
@@ -74,6 +81,50 @@ jobs:
           # The job only reads code (the sandbox clones via BENCH_REPO_TOKEN when set, not the
           # checkout's credentials), so don't persist the job token in .git/config.
           persist-credentials: false
+
+      # Namespace has no stored secret: it federates via GitHub's OIDC identity (id-token: write
+      # above), logging the `nsc` CLI into the workspace via `nsc auth exchange-github-token` under
+      # the hood. That login lives in the CLI's own local session store, not a discoverable file —
+      # /var/run/nsc/token.json is only pre-populated on Namespace-hosted runners (confirmed by a
+      # live smoke run: ENOENT on a regular GitHub-hosted runner) — so the next step mints a portable
+      # token file from that session for @computesdk/namespace to read. Requires a trust relationship
+      # (this repo -> the Namespace tenant) registered once on the Namespace side.
+      #
+      # continue-on-error buys a LEGIBLE failure, not a passing job. This lane sets
+      # `REQUIRE_PROVIDERS: ${{ inputs.provider }}`, so the one provider you dispatched is required by
+      # construction: a not-yet-registered trust relationship (or any transient mint failure) leaves
+      # NSC_TOKEN_FILE empty, the harness records the standard "missing credentials" skip, and the D1
+      # gate in bench-smoke.ts then fails the job by name ("required providers did not pass"). That is
+      # deliberate — a green smoke must never hide that the provider was never actually smoked. What
+      # continue-on-error avoids is the raw step abort, which would kill the job with no Run document
+      # and no summary to diagnose from. The genuinely graceful skip lives in the matrix lanes
+      # (bench-suite.yml), which set no REQUIRE_PROVIDERS, so one unauthenticated cell doesn't sink
+      # the run.
+      - name: Set up Namespace CLI
+        if: inputs.provider == 'namespace'
+        continue-on-error: true
+        id: nsc-setup
+        uses: namespacelabs/nscloud-setup@df198f982fcecfb8264bea3f1274b56a61b6dfdc # v0
+
+      # `nsc token create` mints a scoped, revocable token from the CLI session above and writes it as
+      # a {"bearer_token": "..."} JSON file @computesdk/namespace can read via NSC_TOKEN_FILE. The
+      # grant below is the minimal permission set the harness needs against the Compute API's
+      # instance resource: create (CreateInstance), list (ListInstances), get (DescribeInstance),
+      # destroy (DestroyInstance), and exec (RunCommandSync) — found by live trial: a wildcard action
+      # is rejected outright ("not allowed in revokable tokens"), and each wrong verb name (e.g.
+      # "read"/"delete" instead of "get"/"destroy") is named individually in the CLI's error.
+      # run_attempt is part of the name because run_id is PRESERVED across re-runs: without it a retry
+      # collides with the first attempt's token, and continue-on-error would turn that name clash into a
+      # silent namespace skip — on exactly the re-run where you wanted the smoke to run.
+      - name: Mint a portable Namespace token
+        if: inputs.provider == 'namespace' && steps.nsc-setup.outcome == 'success'
+        continue-on-error: true
+        id: nsc-token
+        run: |
+          nsc token create \
+            --name "sandbox-benchmarks-smoke-${{ github.run_id }}-${{ github.run_attempt }}" \
+            --grant '{"resource_type":"instance","resource_id":"*","actions":["create","list","get","destroy","exec"]}' \
+            --token_file "${{ runner.temp }}/nsc-token.json"
 
       - name: Set up Bun
         uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
@@ -124,6 +175,11 @@ jobs:
           BL_API_KEY: ${{ inputs.provider == 'blaxel' && secrets.BL_API_KEY || '' }}
           BL_WORKSPACE: ${{ inputs.provider == 'blaxel' && secrets.BL_WORKSPACE || '' }}
           NOVITA_API_KEY: ${{ inputs.provider == 'novita' && secrets.NOVITA_API_KEY || '' }}
+          # OIDC-federated per-run token file (see the Namespace CLI steps above). Not a stored secret:
+          # empty unless namespace was dispatched AND the mint above succeeded (steps.nsc-token only
+          # runs when inputs.provider == 'namespace'), which the harness reads as the standard
+          # missing-credentials skip on every other dispatch.
+          NSC_TOKEN_FILE: ${{ steps.nsc-token.outcome == 'success' && format('{0}/nsc-token.json', runner.temp) || '' }}
         run: bun apps/cli/src/bin/bench-suite.ts "$BENCH_PROVIDER" "$BENCH_SUITE" "$GITHUB_RUN_ID"
 
       - name: Upload Run + raw results

--- a/.github/workflows/bench-suite.yml
+++ b/.github/workflows/bench-suite.yml
@@ -49,9 +49,13 @@ on:
         type: string
         default: ''
 
-# Least privilege: the fan-out only reads the checked-out code and uploads artifacts.
+# Least privilege: the fan-out only reads the checked-out code and uploads artifacts, plus the OIDC
+# id-token the namespace cell exchanges for a Namespace login (no stored secret — see the CLI steps
+# below). The caller must grant `id-token: write` too: a called workflow's token can never exceed its
+# caller's.
 permissions:
   contents: read
+  id-token: write
 
 jobs:
   bench:
@@ -86,6 +90,50 @@ jobs:
           # This cell only reads code (the sandbox clones via BENCH_REPO_TOKEN when set, not the
           # checkout's credentials), so don't persist the job token in .git/config.
           persist-credentials: false
+
+      # Namespace has no stored secret: it federates via GitHub's OIDC identity (id-token: write
+      # above), logging the `nsc` CLI into the workspace via `nsc auth exchange-github-token` under
+      # the hood. That login lives in the CLI's own local session store, not a discoverable file —
+      # /var/run/nsc/token.json is only pre-populated on Namespace-hosted runners (confirmed by a
+      # live smoke run: ENOENT on a regular GitHub-hosted runner) — so the next step mints a portable
+      # token file from that session for @computesdk/namespace to read. Requires a trust relationship
+      # (this repo -> the Namespace tenant) registered once on the Namespace side — continue-on-error
+      # so a not-yet-registered trust relationship (or any transient failure) degrades to the same
+      # "missing credentials" skip every other provider gets from an absent secret, rather than
+      # failing the whole cell.
+      - name: Set up Namespace CLI
+        if: matrix.provider == 'namespace'
+        continue-on-error: true
+        id: nsc-setup
+        uses: namespacelabs/nscloud-setup@df198f982fcecfb8264bea3f1274b56a61b6dfdc # v0
+
+      # `nsc token create` mints a scoped, revocable token from the CLI session above and writes it as
+      # a {"bearer_token": "..."} JSON file @computesdk/namespace can read via NSC_TOKEN_FILE. The
+      # grant below is the minimal permission set the harness needs against the Compute API's
+      # instance resource: create (CreateInstance), list (ListInstances), get (DescribeInstance),
+      # destroy (DestroyInstance), and exec (RunCommandSync) — found by live trial: a wildcard action
+      # is rejected outright ("not allowed in revokable tokens"), and each wrong verb name (e.g.
+      # "read"/"delete" instead of "get"/"destroy") is named individually in the CLI's error.
+      #
+      # The cell's suite/replicate name the token so a leaked one is traceable to the cell that minted
+      # it; both reach the shell through the environment, never interpolated into the run block, so a
+      # dispatch-controlled suite name can't inject into the runner command (zizmor template-injection).
+      # run_attempt is part of the name because run_id is PRESERVED across re-runs: without it a retry
+      # collides with the first attempt's token, and continue-on-error would turn that name clash into a
+      # silent namespace skip — on exactly the re-run where you wanted the validation.
+      - name: Mint a portable Namespace token
+        if: matrix.provider == 'namespace' && steps.nsc-setup.outcome == 'success'
+        continue-on-error: true
+        id: nsc-token
+        env:
+          BENCH_SUITE: ${{ inputs.suite }}
+          BENCH_REPLICATE: ${{ matrix.replicate }}
+          NSC_TOKEN_PATH: ${{ runner.temp }}/nsc-token.json
+        run: |
+          nsc token create \
+            --name "sandbox-benchmarks-${BENCH_SUITE}-r${BENCH_REPLICATE}-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}" \
+            --grant '{"resource_type":"instance","resource_id":"*","actions":["create","list","get","destroy","exec"]}' \
+            --token_file "$NSC_TOKEN_PATH"
 
       - name: Set up Bun
         uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
@@ -133,6 +181,11 @@ jobs:
           BL_API_KEY: ${{ matrix.provider == 'blaxel' && secrets.BL_API_KEY || '' }}
           BL_WORKSPACE: ${{ matrix.provider == 'blaxel' && secrets.BL_WORKSPACE || '' }}
           NOVITA_API_KEY: ${{ matrix.provider == 'novita' && secrets.NOVITA_API_KEY || '' }}
+          # OIDC-federated per-cell token file (see the Namespace CLI steps above). Not a stored
+          # secret: it is empty unless THIS cell is the namespace cell AND the mint above succeeded
+          # (steps.nsc-token only runs when matrix.provider == 'namespace'), which the harness reads
+          # as the standard missing-credentials skip on every other cell.
+          NSC_TOKEN_FILE: ${{ steps.nsc-token.outcome == 'success' && format('{0}/nsc-token.json', runner.temp) || '' }}
         run: bun apps/cli/src/bin/bench-suite.ts "$BENCH_PROVIDER" "$BENCH_SUITE" "$GITHUB_RUN_ID" --replicate "$BENCH_REPLICATE"
 
       - name: Upload Run + raw results

--- a/apps/cli/src/bin/bake.ts
+++ b/apps/cli/src/bin/bake.ts
@@ -39,6 +39,13 @@ const bakers: Record<ProviderId, (image: string, log: Log) => Promise<void>> = {
 		log("blaxel boots the stock base image — no candidate artifact to bake");
 	},
 	novita: (image, log) => bakeNovitaTemplate(config.novitaTemplateCandidate, image, log),
+	// Same shape as blaxel: namespace pulls the toolchain image straight into a container instance at
+	// create time (no template/snapshot system), so there's no candidate artifact to bake — the
+	// validate boot right after this proves reachability. Takes the pinned candidate image like the
+	// others but doesn't need it (nothing to bake), so `_image`.
+	namespace: async (_image, log) => {
+		log("namespace boots the candidate image directly — no candidate artifact to bake");
+	},
 };
 
 /**

--- a/apps/cli/src/bin/release-plan.test.ts
+++ b/apps/cli/src/bin/release-plan.test.ts
@@ -35,6 +35,7 @@ describe("buildReleasePlan matrix", () => {
 			"modal-gvisor",
 			"modal-vm",
 			"novita",
+			"namespace",
 		]);
 	});
 
@@ -56,7 +57,7 @@ describe("planOutputs", () => {
 		expect(matrixLine).toBeDefined();
 		// The matrix value must be valid, single-line JSON (the fromJSON contract).
 		const parsed = JSON.parse((matrixLine as string).slice("matrix=".length));
-		expect(parsed.include).toHaveLength(7);
+		expect(parsed.include).toHaveLength(8);
 		expect((matrixLine as string).includes("\n")).toBe(false);
 	});
 });

--- a/apps/cli/src/bin/release-plan.ts
+++ b/apps/cli/src/bin/release-plan.ts
@@ -59,6 +59,10 @@ function providerArtifact(id: ProviderId): string {
 			return "boots the candidate image directly (no baked artifact)";
 		case "blaxel":
 			return "boots the stock base image (no baked artifact)";
+		case "namespace":
+			// No template/snapshot system — pulls the candidate image straight into an instance at
+			// create time (same as modal), so there is no baked artifact to name.
+			return "boots the candidate image directly (no baked artifact)";
 	}
 }
 

--- a/apps/cli/src/lib/bake/promote.ts
+++ b/apps/cli/src/lib/bake/promote.ts
@@ -153,6 +153,9 @@ export async function promoteAll(log: Log, force = false): Promise<BakeReport[]>
 						log(`    ${m}`),
 					);
 					break;
+				case "namespace":
+					log("    namespace pulls the published version image — nothing to build");
+					break;
 				default: {
 					// Exhaustiveness: a new ProviderId must add a promote branch above (compile error here).
 					const unhandled: never = provider.name;

--- a/apps/cli/src/lib/bake/validate.test.ts
+++ b/apps/cli/src/lib/bake/validate.test.ts
@@ -58,4 +58,10 @@ describe("candidateCreateOptions", () => {
 			templateId: "ghcr.io/o/tc:v1-candidate",
 		});
 	});
+
+	it("points namespace directly at the candidate image", () => {
+		expect(candidateCreateOptions("namespace", refs)).toEqual({
+			image: "ghcr.io/o/tc:v1-candidate",
+		});
+	});
 });

--- a/apps/cli/src/lib/bake/validate.ts
+++ b/apps/cli/src/lib/bake/validate.ts
@@ -50,5 +50,8 @@ export function candidateCreateOptions(
 		case "novita":
 			// Same mapping as e2b (snapshotId → template name), against Novita's control plane.
 			return { snapshotId: refs.novitaTemplateCandidate };
+		case "namespace":
+			// No template/snapshot system — points create() at the candidate image directly, same as modal.
+			return { image: refs.toolchainImageCandidate };
 	}
 }

--- a/apps/cli/src/lib/providers-run.test.ts
+++ b/apps/cli/src/lib/providers-run.test.ts
@@ -39,6 +39,7 @@ describe("forEachProviderWithCreds `only`", () => {
 			"modal-gvisor",
 			"modal-vm",
 			"novita",
+			"namespace",
 		]);
 	});
 

--- a/bun.lock
+++ b/bun.lock
@@ -69,6 +69,7 @@
         "@computesdk/daytona": "catalog:computesdk",
         "@computesdk/e2b": "catalog:computesdk",
         "@computesdk/modal": "catalog:computesdk",
+        "@computesdk/namespace": "catalog:computesdk",
         "@computesdk/provider": "catalog:computesdk",
         "@sandbox-benchmarks/schema": "workspace:*",
         "arktype": "catalog:",
@@ -171,6 +172,7 @@
       "@computesdk/daytona": "1.7.31",
       "@computesdk/e2b": "1.7.51",
       "@computesdk/modal": "1.9.3",
+      "@computesdk/namespace": "1.6.12",
       "@computesdk/provider": "2.1.3",
       "@daytona/api-client": "0.192.0",
       "@daytona/sdk": "0.192.0",
@@ -294,6 +296,8 @@
     "@computesdk/e2b": ["@computesdk/e2b@1.7.51", "", { "dependencies": { "@computesdk/provider": "2.1.3", "computesdk": "4.1.3", "e2b": "^2.26.0" } }, "sha512-fFDLFtPp8acJdJbdAFn8Uvbps+pvCGTf1mq84jFbNroDNim/rWa3T1C0c7iBTWufBz2An5tWqRBxIZzb+5JUPw=="],
 
     "@computesdk/modal": ["@computesdk/modal@1.9.3", "", { "dependencies": { "@computesdk/provider": "2.1.3", "computesdk": "4.1.3", "modal": "0.7.6" } }, "sha512-kD69VIcUe56UpqolNZqIp16B2cLCSyYBeHMXuEcZYcV912IG/ZaiLRut2OS8QGIDxUdpBvl4LrdDiYqEayZweg=="],
+
+    "@computesdk/namespace": ["@computesdk/namespace@1.6.12", "", { "dependencies": { "@computesdk/provider": "2.1.3", "computesdk": "4.1.3" } }, "sha512-CkPkDxrD3coI0bpePMLku1mrVH/vFKBYQ8oZ/XB1JxuVdo5VDXGKraIGKtViDSn9hI/1ViTUCr2miePfjnAbVQ=="],
 
     "@computesdk/provider": ["@computesdk/provider@2.1.3", "", { "dependencies": { "@computesdk/cmd": "0.4.1", "computesdk": "4.1.3", "daemond": "0.1.4" } }, "sha512-soT+eu9VdeLkDjMdHe2fWh0WoiQ1C6xlMIdw8UKlJz5ivipJE6HP6Emm05qUdpeXooWquL1o3LQtRQDMFsrTfA=="],
 

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
         "@computesdk/daytona": "1.7.31",
         "@computesdk/e2b": "1.7.51",
         "@computesdk/modal": "1.9.3",
+        "@computesdk/namespace": "1.6.12",
         "@computesdk/provider": "2.1.3",
         "@daytona/api-client": "0.192.0",
         "@daytona/sdk": "0.192.0",

--- a/packages/providers/package.json
+++ b/packages/providers/package.json
@@ -16,6 +16,7 @@
     "@computesdk/daytona": "catalog:computesdk",
     "@computesdk/e2b": "catalog:computesdk",
     "@computesdk/modal": "catalog:computesdk",
+    "@computesdk/namespace": "catalog:computesdk",
     "@computesdk/provider": "catalog:computesdk",
     "@sandbox-benchmarks/schema": "workspace:*",
     "arktype": "catalog:",

--- a/packages/providers/src/lib/adapters.ts
+++ b/packages/providers/src/lib/adapters.ts
@@ -7,6 +7,7 @@ import { blaxel } from "@computesdk/blaxel";
 import { daytona } from "@computesdk/daytona";
 import { e2b } from "@computesdk/e2b";
 import { modal } from "@computesdk/modal";
+import { namespace } from "@computesdk/namespace";
 import type { ProviderId } from "@sandbox-benchmarks/schema";
 import { TARGET_SPEC } from "@sandbox-benchmarks/schema";
 import type { CreateSandboxOptions } from "computesdk";
@@ -133,5 +134,21 @@ export const adapters: Record<ProviderId, ProviderAdapter> = {
 		// template name); cpu/memory are pinned at template create, not per-sandbox.
 		createCompute: () => novitaCompute(config.novita.apiKey),
 		createOptions: { snapshotId: config.novitaTemplate },
+	},
+	namespace: {
+		// The token rides the factory's own NSC_TOKEN_FILE env fallback (getAndValidateCredentials) —
+		// CI's OIDC federation (nscloud-setup) lands the token there, not in NSC_TOKEN — never read
+		// here, same as blaxel's BL_API_KEY. virtualCpu/memoryMegabytes are per-instance knobs on this
+		// factory config (not per-create options), so the target spec is pinned once, at construction,
+		// like blaxel's/modal's cpu/memory.
+		createCompute: () =>
+			namespace({
+				virtualCpu: TARGET_SPEC.vcpus,
+				memoryMegabytes: TARGET_SPEC.memoryGb * 1024,
+			}),
+		// Namespace has no template/snapshot system — `create()` pulls an arbitrary OCI ref straight
+		// from `options.image` (computesdk's open CreateSandboxOptions passthrough), so, like modal's
+		// fromRegistry boot, this points directly at the published toolchain image; nothing to bake.
+		createOptions: { image: config.toolchainImage },
 	},
 };

--- a/packages/schema/src/providers.test.ts
+++ b/packages/schema/src/providers.test.ts
@@ -28,6 +28,7 @@ describe("@sandbox-benchmarks/schema providers", () => {
 			"e2b",
 			"modal-gvisor",
 			"modal-vm",
+			"namespace",
 			"novita",
 		]);
 	});

--- a/packages/schema/src/providers.ts
+++ b/packages/schema/src/providers.ts
@@ -18,7 +18,8 @@ export type ProviderId =
 	| "modal-gvisor"
 	| "modal-vm"
 	| "blaxel"
-	| "novita";
+	| "novita"
+	| "namespace";
 
 /** Can the SDK request a pinned target spec (vCPU / memory) at create() time? */
 export type SpecPinning = "settable" | "fixed" | "unknown";
@@ -136,7 +137,8 @@ export interface ProviderMeta {
  * so it clears the gate anyway. Blaxel's sandbox root is a RAM-derived tmpfs with no independent disk
  * knob, so it mounts a 40 GiB volume at the PTS data dir where the heavy suites write (see
  * packages/providers/src/lib/blaxel-volume.ts) — clearing the gate like the others. Only e2b/novita
- * still CANNOT express disk (the `@e2b/cli` `template create` takes only `--cpu-count`/`--memory-mb`):
+ * (the `@e2b/cli` `template create` takes only `--cpu-count`/`--memory-mb`) and namespace
+ * (`NamespaceConfig` has no disk field at all) still CANNOT express disk:
  * they run with actuals recorded and the heavy suites skip there, surfaced as an explicit coverage gap
  * in the leaderboard, never silently dropped.
  */
@@ -397,6 +399,52 @@ const REGISTRY: Record<ProviderId, Omit<ProviderMeta, "id">> = {
 			streaming: false,
 			syncCapMs: 60_000,
 			detachedPoll: true,
+		},
+	},
+	namespace: {
+		displayName: "Namespace",
+		website: "https://namespace.so",
+		sdkPackage: "@computesdk/namespace",
+		// NSC_TOKEN_FILE, not NSC_TOKEN: CI federates via GitHub's OIDC identity (nscloud-setup +
+		// `nsc auth exchange-github-token`, no stored secret), which lands the token at the CLI's
+		// standard cache path, wired to NSC_TOKEN_FILE — never a bare bearer string in the environment.
+		// This gate is a strict AND (missingCreds has no OR-group concept), so a local run with a bare
+		// NSC_TOKEN alone still skips even though @computesdk/namespace's own fallback chain would
+		// accept it — for local dev, mint a file instead (`nsc token create --token_file <path>` after
+		// `nsc auth login`) and point NSC_TOKEN_FILE at it, mirroring what CI does.
+		requiredEnvVars: ["NSC_TOKEN_FILE"],
+		isolation: {
+			technology: "microVM (dedicated instance)",
+			notes:
+				"Namespace runs each instance on its own hardware/network (namespace.so/docs/architecture/compute). The @computesdk/namespace wrapper deploys one container workload per instance via the Compute API's `containers` shape, and defines no template/snapshot managers (unexposed, same clean skip as novita) — and, unlike every other provider here, no filesystem manager either.",
+		},
+		pricing: {
+			model: "unknown",
+			notes:
+				"Not yet vetted against a published per-second/hour rate for the Compute API this wrapper drives; namespace.so/pricing documents CI-runner minutes, a distinct product.",
+			sourceUrl: "https://namespace.so/pricing",
+		},
+		maturity: {
+			status: "beta",
+			notes:
+				"Local e2e validation wiring; not yet a committed run. The wrapper's `methods.sandbox` declares no `filesystem` table, so computesdk falls back to its UnsupportedFileSystem (every filesystem op throws) — realworld suites that read/write through `sandbox.filesystem` skip on this provider.",
+		},
+		// virtualCpu/memoryMegabytes are independent, uncoupled knobs on the factory config (unlike
+		// blaxel's memory-derived cpu/disk), so the 4 vCPU / 8 GiB target spec is exactly expressible.
+		specPinning: "settable",
+		transport: {
+			// `runCommand` POSTs to the CommandService's RunCommandSync RPC and awaits the full response
+			// with no client-side timeout — but there is no evidence (SDK default, docs, or a measured
+			// probe) of a server-side cap either, unlike e2b's documented 60s or Daytona's measured 408.
+			// Declaring a guessed cap here would trip the schema's own invariant (a finite syncCapMs
+			// requires detachedPoll: true), and there IS no detached alternative — see below — so the
+			// honest declaration is uncapped, and every step, however long, stays synchronous.
+			streaming: false,
+			syncCapMs: null,
+			// No `filesystem` table on the wrapper (see isolation notes) means no pollable done-file for
+			// the harness's background+poll pattern — the durable long-step path other providers get is
+			// simply unavailable here.
+			detachedPoll: false,
 		},
 	},
 };


### PR DESCRIPTION
Register Namespace in the provider schema and ComputeSDK adapter, pin the target shape, and boot the shared GHCR toolchain image directly instead of introducing a provider-specific template. Wire benchmark authentication through a scoped token file minted from GitHub OIDC, extend candidate and promotion handling, and cover the direct-image mapping.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds Namespace sandboxes as a new provider that boots the shared GHCR toolchain image directly with pinned vCPU/memory. CI mints a scoped token via GitHub OIDC into `NSC_TOKEN_FILE`; smoke requires auth and fails cleanly if missing, while suite cells skip when unauthenticated.

- **New Features**
  - Schema: register `namespace`; pin vCPU/memory; no disk; sync-only transport (uncapped); no detached polling.
  - Providers: add adapter using `@computesdk/namespace`; set `virtualCpu`/`memoryMegabytes` from `TARGET_SPEC`; `createOptions.image` points to the toolchain image.
  - CLI: bake/promote are no-ops for `namespace`; `candidateCreateOptions` maps to `{ image }`; release plan + tests cover it.
  - CI: add `namespace` to smoke; scope `id-token: write` to suite fan-out and smoke jobs; set up `namespacelabs/nscloud-setup`, mint minimal-grant per-run tokens named with `run_attempt`, export `NSC_TOKEN_FILE`; smoke fails when unauthenticated, suite cells skip.

- **Dependencies**
  - Add `@computesdk/namespace@1.6.12`.

<sup>Written for commit de2f251b8594bb8a6856365435a9442e9dc11626. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/starslingdev/hpc-sandbox-benchmarks/pull/169?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added **Namespace** as a supported sandbox provider (beta), including its credential-based access via `NSC_TOKEN_FILE`, provider metadata, validation, and release planning.
  * Updated the CLI bake/promote flow and release planning to support Namespace execution.
  * Expanded benchmark/smoke workflows to run Namespace using OIDC and mint a temporary token for jobs.
* **Bug Fixes**
  * When Namespace token minting fails, the system now safely treats credentials as missing to avoid misleading failures.
* **Chores**
  * Tightened CI workflow permissions and extended provider tests and dependencies to include Namespace.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->