### PR TITLE
Public-ready hardening: Environments, docs, and leaderboard

### DIFF
--- a/.github/workflows/bench-matrix.yml
+++ b/.github/workflows/bench-matrix.yml
@@ -4,7 +4,8 @@ name: Bench matrix
 # cell, each spinning up a real sandbox, running its suite, and uploading the normalized Run as an
 # artifact. The matrix is computed from the SUITES × PROVIDERS registries by `plan-matrix` — adding a
 # provider or suite to its registry grows CI with no workflow edit. Off the PR path (real sandbox time
-# + provider credentials); dispatch on demand.
+# + provider credentials); dispatch on demand from main only, gated by Environment `privileged`
+# (required reviewers + environment secrets — see docs/ci-secrets.md).
 on:
   workflow_dispatch:
     inputs:
@@ -18,7 +19,7 @@ on:
         # to include it; `plan-matrix` rejects any name that is not in the registry.
         default: e2b,daytona,modal
 
-# Least privilege: jobs only read the checked-out code and upload artifacts.
+# Least privilege: jobs only read the checked-out code and upload artifacts (publish elevates).
 permissions:
   contents: read
 
@@ -29,8 +30,13 @@ concurrency:
 
 jobs:
   # Compute the provider × suite matrix once, as the single $GITHUB_OUTPUT contract the fan-out reads.
+  # No secrets — plan stays off the privileged environment so approval isn't needed just to dry-run
+  # the matrix shape; the gate below still confines dispatch to this repo's main.
   plan:
     name: Plan matrix
+    if: >
+      github.ref == 'refs/heads/main' &&
+      github.repository == 'starslingdev/sandbox-benchmarks'
     runs-on: ubuntu-24.04
     outputs:
       matrix: ${{ steps.plan.outputs.matrix }}
@@ -64,7 +70,11 @@ jobs:
   bench:
     name: ${{ matrix.suite }} on ${{ matrix.provider }}
     needs: plan
+    if: >
+      github.ref == 'refs/heads/main' &&
+      github.repository == 'starslingdev/sandbox-benchmarks'
     runs-on: starsling-ubuntu-24.04-2
+    environment: privileged
     timeout-minutes: 150
     strategy:
       # One cell's failure (a flaky provider) must not cancel the rest of the matrix.
@@ -74,8 +84,8 @@ jobs:
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
-          # This cell only reads code (the sandbox clones via BENCH_REPO_TOKEN, not the checkout's
-          # credentials), so don't persist the job token in .git/config.
+          # This cell only reads code (the sandbox clones via BENCH_REPO_TOKEN when set, not the
+          # checkout's credentials), so don't persist the job token in .git/config.
           persist-credentials: false
 
       # `no-cache` is REQUIRED on this label, unlike the hosted-runner jobs above/below. Two runner
@@ -101,6 +111,8 @@ jobs:
       - name: Run suite and normalize
         env:
           BENCH_REPO_REF: ${{ github.sha }}
+          # Optional once the repo is public (anonymous clone works). Still passed so private forks and
+          # rate-limited clones keep working via the short-lived job token.
           BENCH_REPO_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           BENCH_PROVIDER: ${{ matrix.provider }}
           BENCH_SUITE: ${{ matrix.suite }}
@@ -127,17 +139,23 @@ jobs:
           # data/ means the job is genuinely broken — fail the upload rather than bury a warning.
           if-no-files-found: error
 
-  # Collect every shard Run, aggregate into one candidate, gate it (promote), and commit the published
-  # dataset. candidate→promote: aggregate is the collect half, promote the validate-and-publish half.
+  # Collect every shard Run, aggregate into one candidate, gate it (promote), regenerate the public
+  # leaderboard, and commit both. candidate→promote: aggregate is the collect half, promote the
+  # validate-and-publish half. Environment `privileged` is required even without provider secrets —
+  # this job is the dataset release surface (`contents: write`).
   publish:
     name: Aggregate + promote dataset
     needs: bench
     # Run even if some matrix cells failed (fail-fast is off) so the successful shards still publish:
     # `aggregate` exits non-zero when zero shards are found and `promote` gates on >=1 validated
     # provider, so the quality bar is preserved. `!cancelled()` still lets an explicit cancel stop it.
-    if: ${{ !cancelled() }}
+    if: >
+      !cancelled() &&
+      github.ref == 'refs/heads/main' &&
+      github.repository == 'starslingdev/sandbox-benchmarks'
     runs-on: ubuntu-24.04
-    # Commit the published dataset back to the branch.
+    environment: privileged
+    # Commit the published dataset + leaderboard back to the branch.
     permissions:
       contents: write
     steps:
@@ -178,11 +196,15 @@ jobs:
           bun apps/cli/src/bin/aggregate.ts "$GITHUB_RUN_ID" data/candidate "${shards[@]}"
           bun apps/cli/src/bin/promote.ts "data/candidate/runs/$GITHUB_RUN_ID.json" data/dataset
 
+      # Keep LEADERBOARD.md byte-identical to what the renderer produces from the newly promoted Run.
+      - name: Regenerate leaderboard
+        run: bun apps/cli/src/bin/leaderboard.ts "data/dataset/runs/$GITHUB_RUN_ID.json" LEADERBOARD.md
+
       - name: Commit the published dataset
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
-          git add data/dataset
+          git add data/dataset LEADERBOARD.md
           if git diff --cached --quiet; then
             echo "dataset unchanged; nothing to commit"
           else

--- a/.github/workflows/bench-smoke.yml
+++ b/.github/workflows/bench-smoke.yml
@@ -2,7 +2,8 @@ name: Bench smoke
 
 # Manually-dispatched live benchmark: spins up a real provider sandbox, runs one suite, normalizes
 # the result into a Run document, and uploads it as an artifact. Off the PR path (it costs real
-# sandbox time and needs provider credentials) — run it on demand to validate the end-to-end lane.
+# sandbox time and needs provider credentials) — run it on demand from main only, gated by
+# Environment `privileged` (required reviewers + environment secrets — see docs/ci-secrets.md).
 on:
   workflow_dispatch:
     inputs:
@@ -45,7 +46,11 @@ concurrency:
 jobs:
   smoke:
     name: ${{ inputs.suite }} on ${{ inputs.provider }}
+    if: >
+      github.ref == 'refs/heads/main' &&
+      github.repository == 'starslingdev/sandbox-benchmarks'
     runs-on: starsling-ubuntu-24.04-2
+    environment: privileged
     # The suite itself runs for many minutes inside the sandbox; give the host job ample headroom.
     timeout-minutes: 150
     steps:
@@ -54,8 +59,8 @@ jobs:
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
-          # The job only reads code (the sandbox clones via BENCH_REPO_TOKEN, not the checkout's
-          # credentials), so don't persist the job token in .git/config.
+          # The job only reads code (the sandbox clones via BENCH_REPO_TOKEN when set, not the
+          # checkout's credentials), so don't persist the job token in .git/config.
           persist-credentials: false
 
       - name: Set up Bun
@@ -75,7 +80,8 @@ jobs:
       - name: Run suite and normalize
         env:
           BENCH_REPO_REF: ${{ github.sha }}
-          # The sandbox clones this private repo at the run's SHA; the short-lived job token authorizes it.
+          # Optional once the repo is public (anonymous clone works). Still passed so private forks and
+          # rate-limited clones keep working via the short-lived job token.
           BENCH_REPO_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           # Pass the dispatch inputs through the environment, never interpolated into the `run` script.
           # `provider` and `suite` are both constrained choices, but env passthrough is kept as

--- a/.github/workflows/toolchain-image.yml
+++ b/.github/workflows/toolchain-image.yml
@@ -2,15 +2,17 @@ name: Toolchain image
 
 # Build, validate, and publish the sandbox-benchmarks toolchain. Two lanes:
 #   • Pull requests — build the base (no push) and run the docker smoke. Fast gate, no credentials.
-#   • Push to main / manual dispatch — build + push the mutable CANDIDATE (:v1-candidate), bake each
-#     provider's candidate artifact and validate it by booting a sandbox and running the shared smoke
-#     spec (behind each provider's secret; missing ones skip), then promote the validated candidate to
-#     the immutable public :v1. Iteration never touches :v1; bump TOOLCHAIN_VERSION
-#     (packages/schema/src/toolchain.ts) to publish a new version.
+#   • Manual dispatch on main (GitHub Environment `privileged`) — build + push the mutable
+#     CANDIDATE (:v1-candidate), bake each provider's candidate artifact and validate it by booting a
+#     sandbox and running the shared smoke spec (behind each provider's secret; missing ones skip),
+#     then promote the validated candidate to the immutable public :v1. Iteration never touches :v1;
+#     bump TOOLCHAIN_VERSION (packages/schema/src/toolchain.ts) to publish a new version.
+#
+# Releases never fire on push/merge: only workflow_dispatch reaches the publish job, and that job
+# requires Environment `privileged` approval so the public cannot complete a release.
 on:
-  # Manual re-trigger (e.g. after bumping TOOLCHAIN_VERSION). The public version is immutable on the
-  # automated push path; `force_republish` (manual dispatch only) deliberately regenerates it over an
-  # existing version for fast dev iteration. Normally, to republish you bump TOOLCHAIN_VERSION; an
+  # Manual publish (e.g. after bumping TOOLCHAIN_VERSION). `force_republish` deliberately regenerates
+  # an existing version for fast iteration. Normally, to republish you bump TOOLCHAIN_VERSION; an
   # already-published version is skipped at the guard below unless force_republish is set.
   workflow_dispatch:
     inputs:
@@ -18,31 +20,15 @@ on:
         description: "Regenerate the current version, overwriting it if already published (dev only)"
         type: boolean
         default: false
-  push:
-    branches: [main]
-    # The publish lane runs `bake`/`promote`, which pull in the whole provider-run + smoke + harness
-    # surface (not just packages/templates and the bake libs). Trigger on every file that can change
-    # bake/validate/promote behavior so a relevant change to main can't ship a version untested by it.
-    paths:
-      - "packages/templates/**"
-      - "packages/providers/**"
-      - "packages/harness/**"
-      - "apps/cli/src/lib/bake/**"
-      - "apps/cli/src/lib/providers-run.ts"
-      - "apps/cli/src/lib/smoke-run.ts"
-      - "apps/cli/src/bin/bake.ts"
-      - "packages/schema/src/toolchain.ts"
-      - ".github/workflows/toolchain-image.yml"
   pull_request:
     paths:
       - "packages/templates/**"
       - "packages/schema/src/toolchain.ts"
       - ".github/workflows/toolchain-image.yml"
 
-# Serialize publishes by ref (NOT by event_name): a push to main and a manual workflow_dispatch on the
-# same ref must not publish concurrently and race on the version tag. PR runs key off their own head ref
-# (separate group) and may cancel superseded runs; a publish is never cancelled (a half-published
-# version is worse than a slow one).
+# Serialize publishes by ref: concurrent dispatches on the same ref must not race on the version tag.
+# PR runs key off their own head ref (separate group) and may cancel superseded runs; a publish is
+# never cancelled (a half-published version is worse than a slow one).
 concurrency:
   group: toolchain-image-${{ github.ref }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
@@ -56,10 +42,8 @@ jobs:
   #
   # Same-repo guard: this job checks out the PR head and runs scripts FROM that checkout (build.sh,
   # smoke.ts) on a self-hosted runner, so a fork PR could execute arbitrary code on the runner itself.
-  # The repo is private (no untrusted forks today), but we gate on same-repo head as defense-in-depth
-  # against a compromised account / outside-collaborator fork. Branches pushed to this repo (the normal
-  # Graphite flow) satisfy it; a legitimate fork-based PR would skip the gate and need a maintainer to
-  # re-run it from an in-repo branch.
+  # Gate on same-repo head as defense-in-depth. Branches pushed to this repo satisfy it; a fork-based
+  # PR skips the gate and needs a maintainer to re-run from an in-repo branch.
   pr-gate:
     name: Build base + docker smoke
     if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
@@ -94,10 +78,16 @@ jobs:
 
   # Publish lane: candidate → validate → promote. Thin wrapper over the bake bin (thin workflow, fat
   # script). Provider steps are guarded by their secrets inside the bin (missing creds skip).
+  # Environment `privileged` holds provider secrets and requires reviewer approval on main only —
+  # see docs/ci-secrets.md.
   publish:
     name: Bake, validate & promote toolchain
-    if: github.event_name != 'pull_request'
+    if: >
+      github.event_name == 'workflow_dispatch' &&
+      github.ref == 'refs/heads/main' &&
+      github.repository == 'starslingdev/sandbox-benchmarks'
     runs-on: starsling-ubuntu-24.04-2
+    environment: privileged
     permissions:
       contents: read
       packages: write
@@ -146,7 +136,7 @@ jobs:
       # Guard the immutable public version: skip the whole publish if :v1 already exists. The version is
       # immutable (promote refuses to overwrite it), so a published version is never re-promoted — bump
       # TOOLCHAIN_VERSION to publish a new one. The candidate is mutable and always rebuilt within a run.
-      # `force_republish` (manual dispatch only) overrides the skip to regenerate the version in place.
+      # `force_republish` overrides the skip to regenerate the version in place.
       - name: Check if version already published
         id: guard
         env:
@@ -224,7 +214,7 @@ jobs:
           BUILD_DATE="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
           export BUILD_DATE
           # --require fails the publish loudly if a required provider's secret is missing/misnamed, so a
-          # merge can't bless a candidate while a required provider was silently skipped (never built or
+          # release can't bless a candidate while a required provider was silently skipped (never built or
           # validated). modal boots the toolchain image via fromRegistry under this project's Modal app
           # and is validated the same as e2b/daytona, so it's required — MODAL_TOKEN_* must be synced.
           # (blaxel is excluded — its bake is a no-op.)
@@ -250,8 +240,8 @@ jobs:
         # --require fails promote loudly if a required provider's secret is missing/misnamed, so the
         # public version is never published while a required provider's version artifact was silently
         # skipped. modal is required (validated via its fromRegistry boot); MODAL_TOKEN_* must be synced.
-        # (blaxel is excluded — its bake is a no-op.) `--force` (manual force_republish dispatch only)
-        # republishes over an existing immutable version; never set on the automated push path.
+        # (blaxel is excluded — its bake is a no-op.) `--force` (force_republish dispatch only)
+        # republishes over an existing immutable version.
         run: |
           set -euo pipefail
           args=(--promote --require "e2b,daytona,modal")

--- a/.gitignore
+++ b/.gitignore
@@ -79,7 +79,12 @@ typings/
 
 # dotenv environment variables file
 .env
-.env.test
+.env.*
+!.env.example
+*.pem
+*.p12
+*.key
+credentials.json
 
 # parcel-bundler cache (https://parceljs.org/)
 .cache

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,132 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our
+community a harassment-free experience for everyone, regardless of age, body
+size, visible or invisible disability, ethnicity, sex characteristics, gender
+identity and expression, level of experience, education, socio-economic status,
+nationality, personal appearance, race, caste, color, religion, or sexual
+identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming,
+diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our
+community include:
+
+* Demonstrating empathy and kindness toward other people
+* Being respectful of differing opinions, viewpoints, and experiences
+* Giving and gracefully accepting constructive feedback
+* Accepting responsibility and apologizing to those affected by our mistakes,
+  and learning from the experience
+* Focusing on what is best not just for us as individuals, but for the overall
+  community
+
+Examples of unacceptable behavior include:
+
+* The use of sexualized language or imagery, and sexual attention or advances of
+  any kind
+* Trolling, insulting or derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or email address,
+  without their explicit permission
+* Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of
+acceptable behavior and will take appropriate and fair corrective action in
+response to any behavior that they deem inappropriate, threatening, offensive,
+or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject
+comments, commits, code, wiki edits, issues, and other contributions that are
+not aligned to this Code of Conduct, and will communicate reasons for moderation
+decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when
+an individual is officially representing the community in public spaces.
+Examples of representing our community include using an official email address,
+posting via an official social media account, or acting as an appointed
+representative at an online or offline event.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported to the community leaders responsible for enforcement at
+**security@starsling.dev**. All complaints will be reviewed and investigated
+promptly and fairly.
+
+All community leaders are obligated to respect the privacy and security of the
+reporter of any incident.
+
+## Enforcement Guidelines
+
+Community leaders will follow these Community Impact Guidelines in determining
+the consequences for any action they deem in violation of this Code of Conduct:
+
+### 1. Correction
+
+**Community Impact**: Use of inappropriate language or other behavior deemed
+unprofessional or unwelcome in the community.
+
+**Consequence**: A private, written warning from community leaders, providing
+clarity around the nature of the violation and an explanation of why the
+behavior was inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+**Community Impact**: A violation through a single incident or series of
+actions.
+
+**Consequence**: A warning with consequences for continued behavior. No
+interaction with the people involved, including unsolicited interaction with
+those enforcing the Code of Conduct, for a specified period of time. This
+includes avoiding interaction in community spaces as well as external channels
+like social media. Violating these terms may lead to a temporary or permanent
+ban.
+
+### 3. Temporary Ban
+
+**Community Impact**: A serious violation of community standards, including
+sustained inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public
+communication with the community for a specified period of time. No public or
+private interaction with the people involved, including unsolicited interaction
+with those enforcing the Code of Conduct, is allowed during this period.
+Violating these terms may lead to a permanent ban.
+
+### 4. Permanent Ban
+
+**Community Impact**: Demonstrating a pattern of violation of community
+standards, including sustained inappropriate behavior, harassment of an
+individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within the
+community.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage],
+version 2.1, available at
+[https://www.contributor-covenant.org/version/2/1/code_of_conduct.html][v2.1].
+
+Community Impact Guidelines were inspired by
+[Mozilla's code of conduct enforcement ladder][Mozilla CoC].
+
+For answers to common questions about this code of conduct, see the FAQ at
+[https://www.contributor-covenant.org/faq][FAQ]. Translations are available at
+[https://www.contributor-covenant.org/translations][translations].
+
+[homepage]: https://www.contributor-covenant.org
+[v2.1]: https://www.contributor-covenant.org/version/2/1/code_of_conduct.html
+[Mozilla CoC]: https://github.com/mozilla/diversity
+[FAQ]: https://www.contributor-covenant.org/faq
+[translations]: https://www.contributor-covenant.org/translations

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,8 +1,22 @@
 # Contributing
 
+Thanks for helping improve sandbox provider comparisons. Please follow the
+[Code of Conduct](./CODE_OF_CONDUCT.md). Read the [methodology](./docs/methodology.md) for how a
+measurement is produced before extending the matrix.
+
 This repo is a Bun workspace monorepo with a strict, enforced dependency DAG (see the
-[README](./README.md)) and a source-first, no-build layout. Read the [methodology](./docs/methodology.md)
-for how a measurement is produced before extending the matrix.
+[README](./README.md)) and a source-first, no-build layout.
+
+## Pull requests from forks
+
+1. Fork, branch, and open a PR against `main`.
+2. Hosted CI (`ci.yml` / `ci-lint.yml`) runs the command contract on your PR — no provider secrets.
+3. Self-hosted Docker toolchain smoke and live provider benches **do not** run on fork PRs (by
+   design: untrusted code must not execute on org runners or spend provider quota).
+4. Live benches, dataset publish, and GHCR toolchain releases are maintainer-only:
+   `workflow_dispatch` on `main` behind Environment `privileged`. See [CI & secrets](./docs/ci-secrets.md).
+
+Never commit API keys or paste them into issues/PRs ([SECURITY.md](./SECURITY.md)).
 
 ## Local checks (the gate)
 

--- a/LEADERBOARD.md
+++ b/LEADERBOARD.md
@@ -41,7 +41,7 @@ _Blaxel leads · ~2.3× Daytona on median (higher is better)._
 
 Headline: **STREAM Triad** (MB/s, higher is better)
 
-_Daytona leads · ~1.3× Modal on median (higher is better)._
+_Daytona and Blaxel share the top on this headline (higher is better)._
 
 | Rank | Provider | STREAM Triad (MB/s) | 95% CI | n | Note |
 | ---: | --- | ---: | ---: | ---: | --- |
@@ -79,7 +79,7 @@ _Blaxel is the only ranked provider (841 Milliseconds; lower is better)._
 
 Headline: **Mastra: cold install** (Seconds, lower is better)
 
-_Daytona is the only ranked provider (31.68 Seconds; lower is better)._
+_Daytona and Novita share the top on this headline (lower is better)._
 
 | Rank | Provider | Mastra: cold install (Seconds) | 95% CI | n | Note |
 | ---: | --- | ---: | ---: | ---: | --- |
@@ -138,9 +138,10 @@ pass drags a mean far more than it moves a median. The 95% CI is a percentile bo
 median (10,000 resamples, seeded from the Run id so the table is reproducible byte-for-byte), not
 a normal-theory interval: these Samples are neither normal nor independent of the host's scheduling.
 
-Rows are separated only when their full Sample distributions differ (Mann-Whitney U, two-sided, α = 0.05,
-enumerated exactly over the permutation null rather than approximated — at these sample sizes the
-normal approximation can report a p the exact test cannot actually produce).
+Rows are separated only when Mann-Whitney U (two-sided, α = 0.05, enumerated exactly
+over the permutation null rather than approximated) finds a shift in central tendency — at these
+sample sizes the normal approximation can report a p the exact test cannot actually produce. KS is
+reported separately for distribution *shape* and does not drive the ranking.
 
 **A Note cell always says why a rank is shared, and the reasons are not interchangeable.**
 `tied` — the test could have separated those providers and did not, so a faster median earned

--- a/LEADERBOARD.md
+++ b/LEADERBOARD.md
@@ -1,101 +1,195 @@
 # Sandbox provider leaderboard
 
-Run `29130741476` · commit `663be0904797890a24fdaf1cc6e3ea8d77b3b89c` · generated 2026-07-11T00:18:19.295Z
+Run `29365910084` · commit `0343acb5c1cfd3a0aac81afc3262d4af0fa69bc7` · generated 2026-07-14T22:52:05.191Z
 
-Each table ranks the providers on that dimension's headline metric. Generated from the published Run dataset — do not edit by hand.
+Same pinned target for every provider (**2 vCPU · 8 GiB RAM · 40 GB disk**). Each table ranks providers on that
+dimension's headline metric (median of retained trials). Generated from the published Run
+dataset — do not edit by hand. Methodology: [`docs/methodology.md`](docs/methodology.md).
+
+**How to read:** value = median (p50) · 95% CI = bootstrap around that median · ranks split only
+when distributions differ (see details below) · a coverage gap means unmeasured, never a score of zero.
 
 ## cpu
 
 Headline: **Node.js web tooling** (runs/s, higher is better)
 
-| Rank | Provider | Node.js web tooling (runs/s) | 95% CI | n | p vs. above | p (KS) |
-| ---: | --- | ---: | ---: | ---: | ---: | ---: |
-| 1 | Daytona | 19.72 | 19.63 – 19.96 | 3 | — | — |
-| 2 | Modal | 9.59 | 9.52 – 9.79 | 3 | 0.10 (n too small) | 0.033 |
+_Daytona leads · ~1.1× Novita on median (higher is better)._
+
+| Rank | Provider | Node.js web tooling (runs/s) | 95% CI | n |
+| ---: | --- | ---: | ---: | ---: |
+| 1 | Daytona | 19.14 | 18.48 – 19.89 | 5 |
+| 2 | Novita | 17.59 | 17.22 – 18.65 | 5 |
+| 3 | Blaxel | 14.01 | 13.64 – 14.25 | 5 |
+| 4 | E2B | 10.58 | 10.25 – 10.83 | 5 |
+| 5 | Modal | 9.25 | 8.7 – 9.58 | 5 |
+
+## disk
+
+Headline: **fio rand read 4KB, O_DIRECT (IOPS)** (IOPS, higher is better)
+
+_Blaxel leads · ~2.3× Daytona on median (higher is better)._
+
+| Rank | Provider | fio rand read 4KB, O_DIRECT (IOPS) (IOPS) | 95% CI | n |
+| ---: | --- | ---: | ---: | ---: |
+| 1 | Blaxel | 556000 | 549000 – 580000 | 5 |
+| 2 | Daytona | 246000 | 241000 – 255000 | 5 |
+| 3 | Novita | 68100 | 66600 – 71500 | 5 |
+| 4 | E2B | 40800 | 39800 – 42000 | 5 |
+| 5 | Modal | 34900 | 33600 – 35200 | 5 |
 
 ## memory
 
 Headline: **STREAM Triad** (MB/s, higher is better)
 
-| Rank | Provider | STREAM Triad (MB/s) | 95% CI | n | p vs. above | p (KS) |
-| ---: | --- | ---: | ---: | ---: | ---: | ---: |
-| 1 | Daytona | 54530 | 54030 – 54590 | 5 | — | — |
-| 2 | Modal | 40510 | 38810 – 53440 | 5 | 0.0079 | 0.0038 |
+_Daytona leads · ~1.3× Modal on median (higher is better)._
+
+| Rank | Provider | STREAM Triad (MB/s) | 95% CI | n | Note |
+| ---: | --- | ---: | ---: | ---: | --- |
+| 1 | Daytona | 71508 | 69090 – 78270 | 5 | — |
+| 1 | Blaxel | 70090 | 66760 – 79980 | 5 | tied |
+| 3 | Modal | 53700 | 45390 – 57730 | 5 | — |
+| 3 | Novita | 53140 | 52970 – 53313 | 5 | tied |
+| 5 | E2B | 23850 | 22450 – 25430 | 5 | — |
+
+## network
+
+Headline: **Loopback TCP (10GB)** (Seconds, lower is better)
+
+_Daytona leads · ~1.5× lower than Blaxel (lower is better)._
+
+| Rank | Provider | Loopback TCP (10GB) (Seconds) | 95% CI | n | Note |
+| ---: | --- | ---: | ---: | ---: | --- |
+| 1 | Daytona | 4.898 | 4.682 – 5.402 | 5 | — |
+| 2 | Blaxel | 7.252 | 6.38 – 7.791 | 5 | — |
+| 2 | E2B | 7.764 | 7.373 – 8.467 | 5 | tied |
+| 4 | Novita | 11.32 | 10.03 – 11.45 | 5 | — |
+| 5 | Modal | 52.14 | 51.04 – 55.37 | 5 | — |
+
+## system
+
+Headline: **PyBench** (Milliseconds, lower is better)
+
+_Blaxel is the only ranked provider (841 Milliseconds; lower is better)._
+
+| Rank | Provider | PyBench (Milliseconds) | 95% CI | n |
+| ---: | --- | ---: | ---: | ---: |
+| 1 | Blaxel | 841 | 838 – 855 | 5 |
+
+## realworld
+
+Headline: **Mastra: cold install** (Seconds, lower is better)
+
+_Daytona is the only ranked provider (31.68 Seconds; lower is better)._
+
+| Rank | Provider | Mastra: cold install (Seconds) | 95% CI | n | Note |
+| ---: | --- | ---: | ---: | ---: | --- |
+| 1 | Daytona | 31.68 | 31.27 – 33.71 | 5 | — |
+| 1 | Novita | 33.12 | 32.84 – 33.84 | 5 | tied |
 
 ## economics
 
 Headline: **Hourly cost** (USD/hr, lower is better)
 
-| Rank | Provider | Hourly cost (USD/hr) | 95% CI | n | p vs. above | p (KS) |
-| ---: | --- | ---: | ---: | ---: | ---: | ---: |
-| 1 | Daytona | 0.1494 | — | 1 | — | — |
-| 2 | Modal | 0.4774 | — | 1 | — | — |
+_Daytona is cheapest · ~1.1× lower than Novita (lower is better)._
+
+| Rank | Provider | Hourly cost (USD/hr) | 95% CI | n |
+| ---: | --- | ---: | ---: | ---: |
+| 1 | Daytona | 0.1494 | — | 1 |
+| 2 | Novita | 0.1627 | — | 1 |
+| 3 | E2B | 0.2304 | — | 1 |
+| 4 | Modal | 0.4774 | — | 1 |
 
 ## Coverage gaps
 
-Benchmarks that produced **no result** on a provider. A gap is a missing result, not a comparable
-one — read it as the provider **failing to cover** that workload, never as a tie or a zero.
+12 uncovered results across 5 providers (Blaxel 3, Daytona 2, E2B 3, Modal 3, Novita 1). A gap is a missing result — the provider **failing to cover** that workload — never a tie or a zero.
+
+<details>
+<summary>Full coverage table</summary>
 
 | Provider | Benchmark | Outcome | Detail |
 | --- | --- | --- | --- |
-| Daytona | realworld-mastra | ❌ **disk** (skipped) | Insufficient disk: 16.7 GiB free, suite needs 30 GiB |
-| Daytona | realworld-openclaw | ❌ **disk** (skipped) | Insufficient disk: 16.7 GiB free, suite needs 25 GiB |
-| Blaxel | cpu-node | **missing** | No result and no marker — the suite never reported for this provider. |
-| Blaxel | disk | **missing** | No result and no marker — the suite never reported for this provider. |
-| Blaxel | memory | **missing** | No result and no marker — the suite never reported for this provider. |
-| Blaxel | realworld-better-auth | **missing** | No result and no marker — the suite never reported for this provider. |
-| Blaxel | realworld-mastra | **missing** | No result and no marker — the suite never reported for this provider. |
-| Blaxel | realworld-openclaw | **missing** | No result and no marker — the suite never reported for this provider. |
-| E2B | cpu-node | **missing** | No result and no marker — the suite never reported for this provider. |
-| E2B | disk | **missing** | No result and no marker — the suite never reported for this provider. |
-| E2B | memory | **missing** | No result and no marker — the suite never reported for this provider. |
-| E2B | realworld-better-auth | **missing** | No result and no marker — the suite never reported for this provider. |
-| E2B | realworld-mastra | **missing** | No result and no marker — the suite never reported for this provider. |
-| E2B | realworld-openclaw | **missing** | No result and no marker — the suite never reported for this provider. |
-| Modal | realworld-mastra | **missing** | No result and no marker — the suite never reported for this provider. |
-| Modal | realworld-openclaw | **missing** | No result and no marker — the suite never reported for this provider. |
+| Blaxel | realworld-mastra | ❌ **disk** (skipped) | Insufficient disk: 12.5 GiB free, suite needs 30 GiB |
+| Blaxel | realworld-openclaw | ❌ **disk** (skipped) | Insufficient disk: 12.5 GiB free, suite needs 25 GiB |
+| E2B | realworld-mastra | ❌ **disk** (skipped) | Insufficient disk: 19.7 GiB free, suite needs 30 GiB |
+| E2B | realworld-openclaw | ❌ **disk** (skipped) | Insufficient disk: 19.7 GiB free, suite needs 25 GiB |
+| Blaxel | cpu-generic | **failed** | Step "mise run benchmark:cpu:generic" timed out after 7800s |
+| Daytona | cpu-generic | **failed** | Step "mise run benchmark:cpu:generic" timed out after 7800s |
+| Daytona | realworld-openclaw | **failed** | Step "mise run benchmark:realworld:pts:openclaw" lost its sandbox: 12 consecutive detached polls failed (last: done-file fs exists) — the sandbox stopped responding, not a quiet long step |
+| E2B | cpu-generic | **failed** | Step "mise run benchmark:cpu:generic" timed out after 7800s |
+| Modal | cpu-generic | **failed** | Step "mise run benchmark:cpu:generic" timed out after 7800s |
+| Modal | realworld-mastra | **failed** | Step "mise run benchmark:realworld:pts:mastra" timed out after 8400s |
+| Modal | realworld-openclaw | **failed** | Step "mise run benchmark:realworld:pts:openclaw" timed out after 8400s |
+| Novita | cpu-generic | **failed** | Step "mise run benchmark:cpu:generic" timed out after 7800s |
 
 **skipped** — a precondition said no before the benchmark was attempted. A ❌ **disk** skip is the
 loud one: the provider could not supply the disk the suite needs, so the workload does not run on
 its current allocation at all. That is a structural absence, not a slow result.
 
-**missing** — nothing was reported at all: no result, and no marker explaining why. The suite ran
-elsewhere in this run, so it was part of the comparison, and this provider is simply absent from
-it — a dropped job, a lost artifact, or a sandbox that died before it could say anything. Treat it
-as unmeasured, never as a pass: the provider has not been shown to run this workload.
+**failed** — the benchmark was attempted and broke: it threw, timed out, or died with the sandbox.
+Unlike a skip, this is a reliability fact about the provider, not a decision made on its behalf.
 
----
+</details>
 
-**Reading this table.** The value is the median (p50) of the retained per-trial Samples, not the
-mean — a single stalled pass drags a mean far more than it moves a median. The 95% CI is a
-percentile bootstrap of that median (10,000 resamples, seeded from the Run id so the table is
-reproducible byte-for-byte), not a normal-theory interval: these Samples are neither normal nor
-independent of the host's scheduling.
+<details>
+<summary>How rankings are decided</summary>
+
+The value is the median (p50) of the retained per-trial Samples, not the mean — a single stalled
+pass drags a mean far more than it moves a median. The 95% CI is a percentile bootstrap of that
+median (10,000 resamples, seeded from the Run id so the table is reproducible byte-for-byte), not
+a normal-theory interval: these Samples are neither normal nor independent of the host's scheduling.
 
 Rows are separated only when their full Sample distributions differ (Mann-Whitney U, two-sided, α = 0.05,
 enumerated exactly over the permutation null rather than approximated — at these sample sizes the
 normal approximation can report a p the exact test cannot actually produce).
+
+**A Note cell always says why a rank is shared, and the reasons are not interchangeable.**
+`tied` — the test could have separated those providers and did not, so a faster median earned
+inside the noise is not a faster provider. This is the only note that claims two providers are
+statistically indistinguishable.
 
 Samples are repeated trials inside one sandbox, so their spread is environmental (neighbours, host
 contention, virtualization), and a wide CI or a large `n` (the harness re-runs a test that will not
 converge) is itself the signal that the provider's performance is unstable, not that the measurement
 is imprecise.
 
-`p (KS)` is a two-sample Kolmogorov-Smirnov test against the same row above. It does **not** drive
-the ranking — it compares the two empirical distributions' *shapes* rather than their central
-tendency. Read it where it disagrees with `p vs. above`: a tied rank (large Mann-Whitney p) beside a
-small `p (KS)` means two providers with the same typical speed but different behaviour — usually one
-of them alternating between fast and stalled passes. That bimodality is what environmental noise
-looks like, and it is the reason a median alone cannot rank these providers.
-
 At the small `n` this suite produces, a non-significant result means *not enough evidence to
 separate*, never *the providers are equal*.
 
-`n too small` is the extreme of that: Mann-Whitney's best attainable p already exceeds α for those
-Samples, so the test could not have separated the rows at any effect size (here 3 v 3 floors at p ≈ 0.10).
-Such rows are ranked on their observed medians and are **not** claimed to be tied — read the gap
-between the values, and treat the p-value as unable to settle them either way. Where such a row
-nevertheless shares the rank above it, the cell reads `equal medians`: the two values are simply
-identical, which is the ranking having nothing to order them by — never a finding that the
-providers are alike.
+### Pairwise tests (vs. row above)
+
+`p vs. above` is Mann-Whitney (drives rank). `p (KS)` is Kolmogorov-Smirnov on distribution
+*shape* — it does not drive the ranking. A tied Mann-Whitney beside a small KS often means the
+same typical speed with different behaviour (e.g. bimodal stalls).
+
+| Dimension | Provider | p vs. above | p (KS) |
+| --- | --- | ---: | ---: |
+| cpu | Daytona | — | — |
+| cpu | Novita | 0.016 | 0.036 |
+| cpu | Blaxel | 0.0079 | 0.0038 |
+| cpu | E2B | 0.0079 | 0.0038 |
+| cpu | Modal | 0.0079 | 0.0038 |
+| disk | Blaxel | — | — |
+| disk | Daytona | 0.0079 | 0.0038 |
+| disk | Novita | 0.0079 | 0.0038 |
+| disk | E2B | 0.0079 | 0.0038 |
+| disk | Modal | 0.0079 | 0.0038 |
+| memory | Daytona | — | — |
+| memory | Blaxel | 0.55 (tied) | 0.70 |
+| memory | Modal | 0.0079 | 0.0038 |
+| memory | Novita | 0.69 (tied) | 0.21 |
+| memory | E2B | 0.0079 | 0.0038 |
+| network | Daytona | — | — |
+| network | Blaxel | 0.0079 | 0.0038 |
+| network | E2B | 0.095 (tied) | 0.21 |
+| network | Novita | 0.0079 | 0.0038 |
+| network | Modal | 0.0079 | 0.0038 |
+| system | Blaxel | — | — |
+| realworld | Daytona | — | — |
+| realworld | Novita | 0.095 (tied) | 0.036 |
+| economics | Daytona | — | — |
+| economics | Novita | — | — |
+| economics | E2B | — | — |
+| economics | Modal | — | — |
+
+</details>
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Compare top sandbox providers on the same pinned machine shape for real develope
 
 **Same target everywhere:** 2 vCPU · 8 GiB RAM · 40 GB disk. One headline metric per dimension, ranked with honest statistics.
 
-### Start here
+## Start here
 
 | | |
 | --- | --- |

--- a/README.md
+++ b/README.md
@@ -1,11 +1,20 @@
 # sandbox-benchmarks
 
-Compare top sandbox providers' performance for real developer and CI/CD tasks.
+Compare top sandbox providers on the same pinned machine shape for real developer and CI/CD workloads — not bare-metal hardware benches.
 
-> **Docs:** [Methodology](./docs/methodology.md) — how a measurement is produced (target spec,
-> dimensions, economics, host-vs-effective specs, transport model, the dataset pipeline). ·
-> [ADRs](./docs/adr/README.md) — the load-bearing architecture decisions and why. ·
-> [Contributing](./CONTRIBUTING.md) — the local gate and how to add a provider, suite, or metric.
+**Same target everywhere:** 2 vCPU · 8 GiB RAM · 40 GB disk. One headline metric per dimension, ranked with honest statistics.
+
+### Start here
+
+| | |
+| --- | --- |
+| **[Leaderboard](./LEADERBOARD.md)** | Provider rankings from the latest published run |
+| **[Methodology](./docs/methodology.md)** | How a measurement is produced |
+| **[Docs hub](./docs/README.md)** | ADRs, CI secrets, security, contributing |
+
+Live provider benches and toolchain releases are **maintainer-only** (GitHub Environment `privileged`). Pull requests never receive provider secrets — see [CI & secrets](./docs/ci-secrets.md).
+
+---
 
 This repo is a **Bun workspace monorepo** with a strict, enforced dependency DAG and a uniform
 package shape. The guiding rule: *"can I import this?"* is answered by the path alone, and
@@ -85,6 +94,9 @@ npm republisher and no install-time postinstall.
 [mise](https://mise.jdx.dev)). The same checks run locally, so green-on-your-machine means
 green-in-CI.
 
+Fork PRs get the hosted CI gate only. Self-hosted jobs and anything that needs provider credentials
+run only from this repository, on `main`, behind Environment [`privileged`](./docs/ci-secrets.md).
+
 ## Git hooks (pre-commit)
 
 [Lefthook](https://lefthook.dev) runs a fast local mirror of CI on every commit, configured in
@@ -107,3 +119,9 @@ compromised — releases are not installed, and **no third-party lifecycle scrip
 `trustedDependencies`). The git hooks above are wired by the project's own first-party `prepare`
 script, not a dependency's postinstall, and CI installs with `--ignore-scripts` so it runs none
 either. Lint and formatting are root-only via a single `biome.json`.
+
+## Community
+
+- [Contributing](./CONTRIBUTING.md) — local gate; how to add a provider, suite, or metric
+- [Code of Conduct](./CODE_OF_CONDUCT.md)
+- [Security](./SECURITY.md) — vulnerability reporting; never paste secrets into issues or PRs

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,26 @@
+# Security Policy
+
+## Reporting a vulnerability
+
+Please report security issues privately. Do **not** open a public issue for anything that could
+expose credentials, allow remote code execution in CI, or leak provider API keys.
+
+- Preferred: email **security@starsling.dev** (or the contact listed on the StarSling org profile).
+- Include steps to reproduce, affected workflows/packages, and any mitigating details you already have.
+- We will acknowledge receipt and work a fix before any public disclosure.
+
+## Secrets
+
+- Never commit API keys, tokens, or `.env` files. Broader `.env*` patterns are gitignored.
+- Never paste secrets into issues, pull request bodies, or comments.
+- Provider credentials for CI live only in the GitHub Environment **`privileged`** — not as
+  repository secrets. See [docs/ci-secrets.md](./docs/ci-secrets.md).
+- Pull requests (including forks) do not receive those secrets. Live benches and toolchain
+  releases require a maintainer `workflow_dispatch` on `main` plus Environment approval.
+
+## Scope notes
+
+- Self-hosted runners only execute same-repository PR heads and privileged maintainer jobs.
+- We do not use `pull_request_target`.
+- Third-party Actions are SHA-pinned; installs use `--ignore-scripts` / Bun's empty
+  `trustedDependencies` posture.

--- a/apps/cli/README.md
+++ b/apps/cli/README.md
@@ -11,7 +11,10 @@
 - `plan-matrix` — print the **provider × suite** benchmark matrix as **single-line compact JSON** for `$GITHUB_OUTPUT` (the `bench-matrix` workflow's fan-out contract).
 - `build-template` — build a provider's sandbox template.
 - `normalize` — turn raw runs into normalized run documents.
+- `aggregate` — merge shard Runs into one candidate.
 - `promote` — promote normalized results to the published dataset.
+- `leaderboard` — render a Run as Markdown (`LEADERBOARD.md`); used by the dataset publish job.
+- `bake` / `bench-smoke` / `stability` — toolchain bake, single-cell smoke, cross-run stability gate.
 
 **Depends on:** all five packages (`workspace:*`) + `dotenv` (`catalog:`).
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,16 @@
+# Docs
+
+| Doc | What it covers |
+| --- | --- |
+| [Methodology](./methodology.md) | Target spec, dimensions, economics, host vs effective specs, dataset pipeline |
+| [Leaderboard](../LEADERBOARD.md) | Public provider rankings (generated from the published Run dataset) |
+| [ADRs](./adr/README.md) | Load-bearing architecture decisions |
+| [Contributing](../CONTRIBUTING.md) | Local gate; adding a provider, suite, or metric |
+| [CI & secrets](./ci-secrets.md) | GitHub Environment `privileged`, release gates, operator setup |
+| [Security](../SECURITY.md) | Vulnerability reporting |
+| [Code of Conduct](../CODE_OF_CONDUCT.md) | Community norms |
+
+### Historical / design notes
+
+- [PTS catalog and analysis design](./pts-catalog-and-analysis-design.md) — early design notes (historical; prefer ADRs + methodology for current truth)
+- [Evidence: Daytona exec transport](./evidence/daytona-exec-transport.md) — research notes on Daytona exec limits

--- a/docs/README.md
+++ b/docs/README.md
@@ -10,7 +10,7 @@
 | [Security](../SECURITY.md) | Vulnerability reporting |
 | [Code of Conduct](../CODE_OF_CONDUCT.md) | Community norms |
 
-### Historical / design notes
+## Historical / design notes
 
 - [PTS catalog and analysis design](./pts-catalog-and-analysis-design.md) — early design notes (historical; prefer ADRs + methodology for current truth)
 - [Evidence: Daytona exec transport](./evidence/daytona-exec-transport.md) — research notes on Daytona exec limits

--- a/docs/ci-secrets.md
+++ b/docs/ci-secrets.md
@@ -1,0 +1,65 @@
+# CI & secrets
+
+Provider credentials and release mutations live only in the GitHub Environment **`privileged`**.
+Repository-level copies of those secrets must not exist: that is how we keep them unavailable to
+PR workflows, forks, and any job that forgot to declare the environment.
+
+`tooling/repo-checks` enforces the workflow side of this posture (see `workflow-hardening.ts`):
+custom secrets and `contents: write` / `packages: write` jobs must set `environment: privileged`,
+and toolchain publish must not trigger on `push`.
+
+## What is gated
+
+| Workflow | Job | Why |
+| --- | --- | --- |
+| `toolchain-image.yml` | `publish` | Provider bake secrets + `packages: write` (GHCR release) |
+| `bench-matrix.yml` | `bench` | Provider API keys |
+| `bench-matrix.yml` | `publish` | Dataset + leaderboard commit (`contents: write`) |
+| `bench-smoke.yml` | `smoke` | Provider API keys |
+
+Ungated: `ci.yml`, `ci-lint.yml`, and the toolchain `pr-gate` (Docker smoke, no secrets).
+
+## Release rules (public-safe)
+
+1. **No publish on merge.** Toolchain GHCR promote is `workflow_dispatch` only (never `push`).
+2. **Main only, this repo only.** Privileged jobs require
+   `github.ref == 'refs/heads/main'` and
+   `github.repository == 'starslingdev/sandbox-benchmarks'`.
+3. **Environment approval.** `privileged` must require at least one reviewer and restrict
+   deployments to the `main` branch. Write access alone cannot finish a release.
+4. **Fork PRs.** Same-repo guard on self-hosted PR jobs; fork PR code never runs on
+   `starsling-ubuntu-24.04-2`. Forks never receive Environment secrets on `pull_request`.
+
+## Operator setup (before flipping the repo public)
+
+Do this in the GitHub UI (Settings → Environments), then delete any matching **repository** secrets.
+
+1. Create Environment **`privileged`**.
+2. **Required reviewers:** at least one maintainer (two preferred).
+3. **Deployment branches:** `Selected branches` → `main` only.
+4. Add these **environment** secrets (then delete repository-level copies if present):
+
+   | Secret | Used by |
+   | --- | --- |
+   | `E2B_API_KEY` | toolchain bake, bench matrix/smoke |
+   | `DAYTONA_API_KEY` | toolchain bake, bench matrix/smoke |
+   | `DAYTONA_TARGET` | optional; workflows default to `us-west-2` |
+   | `MODAL_TOKEN_ID` | toolchain bake, bench matrix/smoke |
+   | `MODAL_TOKEN_SECRET` | toolchain bake, bench matrix/smoke |
+   | `NOVITA_API_KEY` | optional for toolchain; bench matrix/smoke |
+   | `BL_API_KEY` | bench matrix/smoke only |
+   | `BL_WORKSPACE` | bench matrix/smoke only |
+
+5. Confirm the GHCR package `sandbox-benchmarks-toolchain` is **public** so providers can pull
+   the candidate base anonymously (Org → Packages → package settings).
+
+Optional bootstrap (creates the empty environment; reviewers/secrets still need a human):
+
+```sh
+./scripts/setup-privileged-environment.sh
+```
+
+## Local credentials
+
+Copy provider keys into a gitignored `.env` for local benches. Never commit them; never paste them
+into issues or pull requests. See [SECURITY.md](../SECURITY.md).

--- a/docs/methodology.md
+++ b/docs/methodology.md
@@ -12,7 +12,7 @@ schema-validated dataset.
 ## Target spec
 
 Every provider is created at one pinned [`TARGET_SPEC`](../packages/schema/src/providers.ts): **2 vCPU,
-8 GiB RAM, 20 GB disk**. It's sized to fit inside every provider's reproducible envelope (E2B caps
+8 GiB RAM, 40 GB disk**. It's sized to fit inside every provider's reproducible envelope (E2B caps
 sandbox RAM at 8 GiB), so anyone can rerun on the same shape. A provider that can't express a dimension
 runs with its actuals recorded and the mismatch disclosed (`specMatched`).
 

--- a/docs/pts-catalog-and-analysis-design.md
+++ b/docs/pts-catalog-and-analysis-design.md
@@ -1,6 +1,9 @@
 # Design Doc: Scaling the PTS Catalog + Analysis Layer
 
-Status: Draft for implementation
+> **Historical design notes.** Prefer [methodology](./methodology.md) and the ADRs for current truth.
+> Kept for provenance of the catalog/analysis work; line numbers and branch names below may be stale.
+
+Status: Historical (implemented in stages; not the living source of truth)
 Branch base: `harness-live-suite` (PTS stack tops out at PR #38)
 Audience: repo owner → stacked PR series
 

--- a/packages/results/src/lib/leaderboard.test.ts
+++ b/packages/results/src/lib/leaderboard.test.ts
@@ -209,7 +209,7 @@ describe("buildLeaderboard statistical ranking", () => {
 describe("renderLeaderboardMarkdown statistics", () => {
 	const HEADLINE = "node_web_tooling_runs_per_s";
 
-	it("renders CI, n and the p-value, and marks a statistical tie", () => {
+	it("renders CI, n and a Note for a statistical tie", () => {
 		const md = renderLeaderboardMarkdown(
 			buildLeaderboard(
 				run([
@@ -219,14 +219,14 @@ describe("renderLeaderboardMarkdown statistics", () => {
 			),
 		);
 		expect(md).toContain("95% CI");
-		expect(md).toContain("p vs. above");
-		expect(md).toContain("(tied)");
+		expect(md).toContain("| Note |");
+		expect(md).toContain("| tied |");
 		// The reader must be told what a shared rank means, not left to infer it.
 		expect(md).toContain("statistically indistinguishable");
 		expect(md).toContain("Mann-Whitney");
 	});
 
-	it("surfaces the KS p-value in the table, not only on the row object", () => {
+	it("surfaces the KS p-value in the details section, not only on the row object", () => {
 		// Regression: `ks` was computed and stored on every LeaderboardRow, documented as the way to spot
 		// a bimodal provider, and then never rendered — so no reader of LEADERBOARD.md could ever see it.
 		const board = buildLeaderboard(
@@ -238,23 +238,21 @@ describe("renderLeaderboardMarkdown statistics", () => {
 		const md = renderLeaderboardMarkdown(board);
 
 		expect(md).toContain("p (KS)");
-		// The note must explain the column, since a second p-value is otherwise cryptic.
 		expect(md).toContain("Kolmogorov-Smirnov");
 
-		// The second row carries both p-values (rank 1 has no predecessor, so both cells are em-dashes).
 		expect(board.dimensions[0]?.rows[1]?.pVsPrevious).not.toBeNull();
 
-		// Assert the SHAPE of the rendered rows, not a re-derived format string: duplicating
-		// `formatPValue`'s rule here would let the test agree with itself and drift from the renderer
-		// (`toPrecision(2)` keeps a trailing zero — "0.0080" — which a `Number(...)` round-trip drops).
-		const rows = md.split("\n").filter((l) => /^\| \d+ \| (Daytona|E2B) \|/.test(l));
-		expect(rows).toHaveLength(2);
-		for (const row of rows) {
-			// 7 columns: rank, provider, value, CI, n, p vs. above, p (KS).
-			expect(row.split("|").filter((c) => c.trim() !== "")).toHaveLength(7);
+		// Main ranking table stays slim (Note column because of the tie); KS lives in the details table.
+		const mainRows = md.split("\n").filter((l) => /^\| \d+ \| (Daytona|E2B) \|/.test(l));
+		expect(mainRows).toHaveLength(2);
+		for (const row of mainRows) {
+			expect(row.split("|").filter((c) => c.trim() !== "").length).toBe(6);
 		}
-		const [first, second] = rows as [string, string];
-		expect(first.trimEnd().endsWith("| — |")).toBe(true); // no predecessor → no KS
+
+		const detailRows = md.split("\n").filter((l) => /^\| cpu \| (Daytona|E2B) \|/.test(l));
+		expect(detailRows).toHaveLength(2);
+		const [first, second] = detailRows as [string, string];
+		expect(first).toContain("| — |");
 		const secondKs = second.trimEnd().split("|").at(-2)?.trim() as string;
 		expect(secondKs).not.toBe("—");
 		expect(secondKs).toMatch(/^(<0\.001|\d+(\.\d+)?(e[+-]?\d+)?)$/);
@@ -264,9 +262,8 @@ describe("renderLeaderboardMarkdown statistics", () => {
 		const md = renderLeaderboardMarkdown(
 			buildLeaderboard(run([provider("daytona", [metric(HEADLINE, [10])])])),
 		);
-		// n=1 → em-dash for the CI and BOTH p-values, never a fabricated bound. Anchored to the row end so
-		// a future column can't be silently dropped from the assertion.
-		expect(md).toMatch(/\| 1 \| Daytona \| 10 \| — \| 1 \| — \| — \|\n/);
+		// n=1 → em-dash for the CI; no Note column when nothing needs calling out.
+		expect(md).toMatch(/\| 1 \| Daytona \| 10 \| — \| 1 \|\n/);
 	});
 
 	it("never prints a p-value as a misleading 0", () => {
@@ -301,7 +298,8 @@ describe("underpowered comparisons", () => {
 			["Modal", 2, "underpowered", null],
 		]);
 		const md = renderLeaderboardMarkdown(board);
-		expect(md).toContain("(n too small)");
+		expect(md).toContain("n too small");
+		expect(md).not.toMatch(/\| tied \|/);
 		expect(md).not.toContain("(tied)");
 	});
 
@@ -354,7 +352,8 @@ describe("underpowered comparisons", () => {
 		expect(rows[1]?.tiedWithAbove).toBe("identical-value");
 		const md = renderLeaderboardMarkdown(board);
 		// The cell distinguishes the two reasons the rank is shared; it never reads as a statistical tie.
-		expect(md).toContain("(n too small, equal medians)");
+		expect(md).toContain("n too small, equal medians");
+		expect(md).not.toMatch(/\| tied \|/);
 		expect(md).not.toContain("(tied)");
 	});
 
@@ -370,7 +369,7 @@ describe("underpowered comparisons", () => {
 			[1, null, null],
 			[1, "untested", "identical-value"],
 		]);
-		expect(renderLeaderboardMarkdown(board)).toContain("— (equal values)");
+		expect(renderLeaderboardMarkdown(board)).toContain("equal values");
 	});
 
 	it("never marks a row `tied` unless the test could have separated it", () => {
@@ -411,7 +410,7 @@ describe("underpowered comparisons", () => {
 			[1, null, null],
 			[1, "tied", "statistical"],
 		]);
-		expect(renderLeaderboardMarkdown(board)).toContain("(tied)");
+		expect(renderLeaderboardMarkdown(board)).toContain("| tied |");
 	});
 
 	it("does not let the tie-corrected approximation crown a provider the exact test cannot separate", () => {

--- a/packages/results/src/lib/leaderboard.test.ts
+++ b/packages/results/src/lib/leaderboard.test.ts
@@ -171,6 +171,9 @@ describe("buildLeaderboard statistical ranking", () => {
 		expect(rows[1]?.verdict).toBe("tied");
 		expect(rows[1]?.tiedWithAbove).toBe("statistical");
 		expect(rows[1]?.pVsPrevious?.mannWhitney).toBeGreaterThan(0.05);
+		// Takeaway must not claim a sole provider when the top cohort is a statistical tie.
+		expect(renderLeaderboardMarkdown(board)).toContain("share the top on this headline");
+		expect(renderLeaderboardMarkdown(board)).not.toContain("is the only ranked provider");
 	});
 
 	it("leaves a single-Sample Metric untested and ranked on its exact value", () => {

--- a/packages/results/src/lib/leaderboard.ts
+++ b/packages/results/src/lib/leaderboard.ts
@@ -444,9 +444,14 @@ function dimensionTakeaway(
 	const leader = rows[0];
 	if (!leader) return "";
 	const better = metric.direction === "HIB" ? "higher is better" : "lower is better";
-	const next = rows.find((r) => r.rank > leader.rank);
+	// Immediate neighbor — not the next distinct rank — so a top-of-board statistical tie is not
+	// misread as "only one provider ranked".
+	const next = rows[1];
 	if (!next) {
 		return `${leader.displayName} is the only ranked provider (${formatValue(leader.value)} ${metric.unit}; ${better}).`;
+	}
+	if (next.tiedWithAbove === "statistical" || next.rank === leader.rank) {
+		return `${leader.displayName} and ${next.displayName} share the top on this headline (${better}).`;
 	}
 	if (metric.direction === "HIB") {
 		const ratio = leader.value / next.value;
@@ -459,9 +464,6 @@ function dimensionTakeaway(
 			const verb = dimension === "economics" ? "is cheapest" : "leads";
 			return `${leader.displayName} ${verb} · ~${ratio.toFixed(1)}× lower than ${next.displayName} (${better}).`;
 		}
-	}
-	if (next.tiedWithAbove === "statistical" || next.rank === leader.rank) {
-		return `${leader.displayName} and ${next.displayName} share the top on this headline (${better}).`;
 	}
 	return `${leader.displayName} leads on median (${better}); see notes for how ranks are decided.`;
 }
@@ -584,9 +586,10 @@ export function renderLeaderboardMarkdown(board: Leaderboard): string {
 		"median (10,000 resamples, seeded from the Run id so the table is reproducible byte-for-byte), not",
 		"a normal-theory interval: these Samples are neither normal nor independent of the host's scheduling.",
 		"",
-		`Rows are separated only when their full Sample distributions differ (Mann-Whitney U, two-sided, α = ${DEFAULT_ALPHA},`,
-		"enumerated exactly over the permutation null rather than approximated — at these sample sizes the",
-		"normal approximation can report a p the exact test cannot actually produce).",
+		`Rows are separated only when Mann-Whitney U (two-sided, α = ${DEFAULT_ALPHA}, enumerated exactly`,
+		"over the permutation null rather than approximated) finds a shift in central tendency — at these",
+		"sample sizes the normal approximation can report a p the exact test cannot actually produce. KS is",
+		"reported separately for distribution *shape* and does not drive the ranking.",
 		"",
 	);
 

--- a/packages/results/src/lib/leaderboard.ts
+++ b/packages/results/src/lib/leaderboard.ts
@@ -421,6 +421,20 @@ function rowNote(r: LeaderboardRow): string {
 	return "";
 }
 
+/** Mann-Whitney cell in the pairwise details table — reuses {@link rowNote} for the verdict suffix. */
+function formatPairwiseP(r: LeaderboardRow): string {
+	const note = rowNote(r);
+	if (r.pVsPrevious === null) return note ? `— (${note})` : "—";
+	const p = formatPValue(r.pVsPrevious.mannWhitney);
+	return note ? `${p} (${note})` : p;
+}
+
+function formatInterval(r: LeaderboardRow): string {
+	return r.interval.resamples === 0
+		? "—"
+		: `${formatValue(r.interval.lo)} – ${formatValue(r.interval.hi)}`;
+}
+
 /** One-line takeaway above each dimension table (leader vs next, or sole provider). */
 function dimensionTakeaway(
 	dimension: Dimension,
@@ -439,15 +453,11 @@ function dimensionTakeaway(
 		if (Number.isFinite(ratio) && ratio >= 1.05) {
 			return `${leader.displayName} leads · ~${ratio.toFixed(1)}× ${next.displayName} on median (${better}).`;
 		}
-	} else if (dimension === "economics") {
-		const ratio = next.value / leader.value;
-		if (Number.isFinite(ratio) && ratio >= 1.05) {
-			return `${leader.displayName} is cheapest · ~${ratio.toFixed(1)}× lower than ${next.displayName} (${better}).`;
-		}
 	} else {
 		const ratio = next.value / leader.value;
 		if (Number.isFinite(ratio) && ratio >= 1.05) {
-			return `${leader.displayName} leads · ~${ratio.toFixed(1)}× lower than ${next.displayName} (${better}).`;
+			const verb = dimension === "economics" ? "is cheapest" : "leads";
+			return `${leader.displayName} ${verb} · ~${ratio.toFixed(1)}× lower than ${next.displayName} (${better}).`;
 		}
 	}
 	if (next.tiedWithAbove === "statistical" || next.rank === leader.rank) {
@@ -457,7 +467,7 @@ function dimensionTakeaway(
 }
 
 /** Summary line for coverage gaps by provider — keeps the main board scannable. */
-function coverageSummary(gaps: CoverageGap[]): string[] {
+function coverageSummary(gaps: CoverageGap[]): string {
 	const byProvider = new Map<string, number>();
 	for (const g of gaps) {
 		byProvider.set(g.displayName, (byProvider.get(g.displayName) ?? 0) + 1);
@@ -465,9 +475,7 @@ function coverageSummary(gaps: CoverageGap[]): string[] {
 	const parts = [...byProvider.entries()]
 		.sort(([a], [b]) => a.localeCompare(b, "en"))
 		.map(([name, n]) => `${name} ${n}`);
-	return [
-		`${gaps.length} uncovered result${gaps.length === 1 ? "" : "s"} across ${byProvider.size} provider${byProvider.size === 1 ? "" : "s"} (${parts.join(", ")}). A gap is a missing result — the provider **failing to cover** that workload — never a tie or a zero.`,
-	];
+	return `${gaps.length} uncovered result${gaps.length === 1 ? "" : "s"} across ${byProvider.size} provider${byProvider.size === 1 ? "" : "s"} (${parts.join(", ")}). A gap is a missing result — the provider **failing to cover** that workload — never a tie or a zero.`;
 }
 
 /** Render a {@link Leaderboard} as a Markdown document — the committed comparison surface. */
@@ -493,7 +501,8 @@ export function renderLeaderboardMarkdown(board: Leaderboard): string {
 
 	for (const { dimension, metric, rows } of board.dimensions) {
 		const better = metric.direction === "HIB" ? "higher is better" : "lower is better";
-		const hasNotes = rows.some((r) => rowNote(r) !== "");
+		const notes = rows.map(rowNote);
+		const hasNotes = notes.some((n) => n !== "");
 		lines.push(
 			`## ${dimension}`,
 			"",
@@ -501,35 +510,18 @@ export function renderLeaderboardMarkdown(board: Leaderboard): string {
 			"",
 			`_${dimensionTakeaway(dimension, metric, rows)}_`,
 			"",
+			hasNotes
+				? `| Rank | Provider | ${metric.label} (${metric.unit}) | 95% CI | n | Note |`
+				: `| Rank | Provider | ${metric.label} (${metric.unit}) | 95% CI | n |`,
+			hasNotes
+				? "| ---: | --- | ---: | ---: | ---: | --- |"
+				: "| ---: | --- | ---: | ---: | ---: |",
+			...rows.map((r, i) => {
+				const base = `| ${r.rank} | ${r.displayName} | ${formatValue(r.value)} | ${formatInterval(r)} | ${r.n} |`;
+				return hasNotes ? `${base} ${notes[i] || "—"} |` : base;
+			}),
+			"",
 		);
-		if (hasNotes) {
-			lines.push(
-				`| Rank | Provider | ${metric.label} (${metric.unit}) | 95% CI | n | Note |`,
-				"| ---: | --- | ---: | ---: | ---: | --- |",
-				...rows.map((r) => {
-					const ci =
-						r.interval.resamples === 0
-							? "—"
-							: `${formatValue(r.interval.lo)} – ${formatValue(r.interval.hi)}`;
-					const note = rowNote(r);
-					return `| ${r.rank} | ${r.displayName} | ${formatValue(r.value)} | ${ci} | ${r.n} | ${note || "—"} |`;
-				}),
-				"",
-			);
-		} else {
-			lines.push(
-				`| Rank | Provider | ${metric.label} (${metric.unit}) | 95% CI | n |`,
-				"| ---: | --- | ---: | ---: | ---: |",
-				...rows.map((r) => {
-					const ci =
-						r.interval.resamples === 0
-							? "—"
-							: `${formatValue(r.interval.lo)} – ${formatValue(r.interval.hi)}`;
-					return `| ${r.rank} | ${r.displayName} | ${formatValue(r.value)} | ${ci} | ${r.n} |`;
-				}),
-				"",
-			);
-		}
 	}
 
 	// Coverage gaps: summary first; full table + legends inside <details> so unfinished providers
@@ -539,7 +531,7 @@ export function renderLeaderboardMarkdown(board: Leaderboard): string {
 		lines.push(
 			"## Coverage gaps",
 			"",
-			...coverageSummary(board.coverageGaps),
+			coverageSummary(board.coverageGaps),
 			"",
 			"<details>",
 			"<summary>Full coverage table</summary>",
@@ -647,8 +639,7 @@ export function renderLeaderboardMarkdown(board: Leaderboard): string {
 	}
 
 	// Detail table with p vs. above + KS for readers who want distribution shape.
-	const anyCompared = rows.some((r) => r.pVsPrevious !== null);
-	if (anyCompared) {
+	if (rows.some((r) => r.pVsPrevious !== null)) {
 		lines.push(
 			"### Pairwise tests (vs. row above)",
 			"",
@@ -661,19 +652,8 @@ export function renderLeaderboardMarkdown(board: Leaderboard): string {
 		);
 		for (const { dimension, rows: dimRows } of board.dimensions) {
 			for (const r of dimRows) {
-				const equalValues = r.tiedWithAbove === "identical-value";
-				const p =
-					r.pVsPrevious === null
-						? equalValues
-							? "— (equal values)"
-							: "—"
-						: r.verdict === "underpowered"
-							? `${formatPValue(r.pVsPrevious.mannWhitney)} (n too small${equalValues ? ", equal medians" : ""})`
-							: r.verdict === "tied"
-								? `${formatPValue(r.pVsPrevious.mannWhitney)} (tied)`
-								: formatPValue(r.pVsPrevious.mannWhitney);
 				const ks = r.pVsPrevious === null ? "—" : formatPValue(r.pVsPrevious.ks);
-				lines.push(`| ${dimension} | ${r.displayName} | ${p} | ${ks} |`);
+				lines.push(`| ${dimension} | ${r.displayName} | ${formatPairwiseP(r)} | ${ks} |`);
 			}
 		}
 		lines.push("");

--- a/packages/results/src/lib/leaderboard.ts
+++ b/packages/results/src/lib/leaderboard.ts
@@ -32,6 +32,7 @@ import {
 	kolmogorovSmirnov,
 	METRIC_CATALOG,
 	mannWhitneyU,
+	TARGET_SPEC,
 } from "@sandbox-benchmarks/schema";
 
 /** One provider's standing on a Dimension's headline Metric. */
@@ -407,14 +408,82 @@ function formatPValue(p: number): string {
 	return p.toPrecision(2);
 }
 
+/** Compact note for the main table's Note column — empty when nothing needs calling out. */
+function rowNote(r: LeaderboardRow): string {
+	const equalValues = r.tiedWithAbove === "identical-value";
+	if (r.pVsPrevious === null) {
+		return equalValues ? "equal values" : "";
+	}
+	if (r.verdict === "underpowered") {
+		return equalValues ? "n too small, equal medians" : "n too small";
+	}
+	if (r.verdict === "tied") return "tied";
+	return "";
+}
+
+/** One-line takeaway above each dimension table (leader vs next, or sole provider). */
+function dimensionTakeaway(
+	dimension: Dimension,
+	metric: MetricDef,
+	rows: LeaderboardRow[],
+): string {
+	const leader = rows[0];
+	if (!leader) return "";
+	const better = metric.direction === "HIB" ? "higher is better" : "lower is better";
+	const next = rows.find((r) => r.rank > leader.rank);
+	if (!next) {
+		return `${leader.displayName} is the only ranked provider (${formatValue(leader.value)} ${metric.unit}; ${better}).`;
+	}
+	if (metric.direction === "HIB") {
+		const ratio = leader.value / next.value;
+		if (Number.isFinite(ratio) && ratio >= 1.05) {
+			return `${leader.displayName} leads · ~${ratio.toFixed(1)}× ${next.displayName} on median (${better}).`;
+		}
+	} else if (dimension === "economics") {
+		const ratio = next.value / leader.value;
+		if (Number.isFinite(ratio) && ratio >= 1.05) {
+			return `${leader.displayName} is cheapest · ~${ratio.toFixed(1)}× lower than ${next.displayName} (${better}).`;
+		}
+	} else {
+		const ratio = next.value / leader.value;
+		if (Number.isFinite(ratio) && ratio >= 1.05) {
+			return `${leader.displayName} leads · ~${ratio.toFixed(1)}× lower than ${next.displayName} (${better}).`;
+		}
+	}
+	if (next.tiedWithAbove === "statistical" || next.rank === leader.rank) {
+		return `${leader.displayName} and ${next.displayName} share the top on this headline (${better}).`;
+	}
+	return `${leader.displayName} leads on median (${better}); see notes for how ranks are decided.`;
+}
+
+/** Summary line for coverage gaps by provider — keeps the main board scannable. */
+function coverageSummary(gaps: CoverageGap[]): string[] {
+	const byProvider = new Map<string, number>();
+	for (const g of gaps) {
+		byProvider.set(g.displayName, (byProvider.get(g.displayName) ?? 0) + 1);
+	}
+	const parts = [...byProvider.entries()]
+		.sort(([a], [b]) => a.localeCompare(b, "en"))
+		.map(([name, n]) => `${name} ${n}`);
+	return [
+		`${gaps.length} uncovered result${gaps.length === 1 ? "" : "s"} across ${byProvider.size} provider${byProvider.size === 1 ? "" : "s"} (${parts.join(", ")}). A gap is a missing result — the provider **failing to cover** that workload — never a tie or a zero.`,
+	];
+}
+
 /** Render a {@link Leaderboard} as a Markdown document — the committed comparison surface. */
 export function renderLeaderboardMarkdown(board: Leaderboard): string {
+	const spec = `${TARGET_SPEC.vcpus} vCPU · ${TARGET_SPEC.memoryGb} GiB RAM · ${TARGET_SPEC.diskGb} GB disk`;
 	const lines: string[] = [
 		"# Sandbox provider leaderboard",
 		"",
 		`Run \`${board.runId}\` · commit \`${board.sha}\` · generated ${board.generatedAt}`,
 		"",
-		"Each table ranks the providers on that dimension's headline metric. Generated from the published Run dataset — do not edit by hand.",
+		`Same pinned target for every provider (**${spec}**). Each table ranks providers on that`,
+		"dimension's headline metric (median of retained trials). Generated from the published Run",
+		"dataset — do not edit by hand. Methodology: [`docs/methodology.md`](docs/methodology.md).",
+		"",
+		"**How to read:** value = median (p50) · 95% CI = bootstrap around that median · ranks split only",
+		"when distributions differ (see details below) · a coverage gap means unmeasured, never a score of zero.",
 		"",
 	];
 
@@ -424,57 +493,56 @@ export function renderLeaderboardMarkdown(board: Leaderboard): string {
 
 	for (const { dimension, metric, rows } of board.dimensions) {
 		const better = metric.direction === "HIB" ? "higher is better" : "lower is better";
+		const hasNotes = rows.some((r) => rowNote(r) !== "");
 		lines.push(
 			`## ${dimension}`,
 			"",
 			`Headline: **${metric.label}** (${metric.unit}, ${better})`,
 			"",
-			`| Rank | Provider | ${metric.label} (${metric.unit}) | 95% CI | n | p vs. above | p (KS) |`,
-			"| ---: | --- | ---: | ---: | ---: | ---: | ---: |",
-			...rows.map((r) => {
-				const ci =
-					r.interval.resamples === 0
-						? "—"
-						: `${formatValue(r.interval.lo)} – ${formatValue(r.interval.hi)}`;
-				// Every shared rank says why, in the cell — a reader must never have to infer the reason from
-				// two rows carrying the same number. The three are distinct claims: `tied` is a verdict the
-				// test reached; `n too small` is the ABSENCE of one (it could not have separated them at any
-				// effect size, so it must not read as a tie); `equal medians` is arithmetic (the ranking sorts
-				// on the value, and it cannot order two values that are the same). The last can co-occur with
-				// `n too small`, and when it does, the shared rank is the equality speaking, not the test.
-				const equalValues = r.tiedWithAbove === "identical-value";
-				const p =
-					r.pVsPrevious === null
-						? equalValues
-							? "— (equal values)"
-							: "—"
-						: r.verdict === "underpowered"
-							? `${formatPValue(r.pVsPrevious.mannWhitney)} (n too small${equalValues ? ", equal medians" : ""})`
-							: r.verdict === "tied"
-								? `${formatPValue(r.pVsPrevious.mannWhitney)} (tied)`
-								: formatPValue(r.pVsPrevious.mannWhitney);
-				// KS is rendered, not just stored: it is the only column that exposes a provider whose
-				// median matches its neighbour's while its distribution is bimodal. A small `p (KS)` beside
-				// a large, tied `p vs. above` is exactly that case — same typical speed, different machine.
-				const ks = r.pVsPrevious === null ? "—" : formatPValue(r.pVsPrevious.ks);
-				return `| ${r.rank} | ${r.displayName} | ${formatValue(r.value)} | ${ci} | ${r.n} | ${p} | ${ks} |`;
-			}),
+			`_${dimensionTakeaway(dimension, metric, rows)}_`,
 			"",
 		);
+		if (hasNotes) {
+			lines.push(
+				`| Rank | Provider | ${metric.label} (${metric.unit}) | 95% CI | n | Note |`,
+				"| ---: | --- | ---: | ---: | ---: | --- |",
+				...rows.map((r) => {
+					const ci =
+						r.interval.resamples === 0
+							? "—"
+							: `${formatValue(r.interval.lo)} – ${formatValue(r.interval.hi)}`;
+					const note = rowNote(r);
+					return `| ${r.rank} | ${r.displayName} | ${formatValue(r.value)} | ${ci} | ${r.n} | ${note || "—"} |`;
+				}),
+				"",
+			);
+		} else {
+			lines.push(
+				`| Rank | Provider | ${metric.label} (${metric.unit}) | 95% CI | n |`,
+				"| ---: | --- | ---: | ---: | ---: |",
+				...rows.map((r) => {
+					const ci =
+						r.interval.resamples === 0
+							? "—"
+							: `${formatValue(r.interval.lo)} – ${formatValue(r.interval.hi)}`;
+					return `| ${r.rank} | ${r.displayName} | ${formatValue(r.value)} | ${ci} | ${r.n} |`;
+				}),
+				"",
+			);
+		}
 	}
 
-	// Coverage gaps: everything that did NOT produce a result somewhere. Rendered whether or not any
-	// dimension ranked, so an all-skipped run still says why. Disk gaps lead and are marked ❌ — a
-	// provider that cannot fit the workload is a structural absence, not a slow result, and must not
-	// read as "no data". Each row states its OUTCOME, because the three are not the same fact and a
-	// reader who cannot tell them apart will read a crash as a design decision.
+	// Coverage gaps: summary first; full table + legends inside <details> so unfinished providers
+	// don't bury the rankings.
 	if (board.coverageGaps.length > 0) {
 		const outcomes = new Set(board.coverageGaps.map((g) => g.outcome));
 		lines.push(
 			"## Coverage gaps",
 			"",
-			"Benchmarks that produced **no result** on a provider. A gap is a missing result, not a comparable",
-			"one — read it as the provider **failing to cover** that workload, never as a tie or a zero.",
+			...coverageSummary(board.coverageGaps),
+			"",
+			"<details>",
+			"<summary>Full coverage table</summary>",
 			"",
 			"| Provider | Benchmark | Outcome | Detail |",
 			"| --- | --- | --- | --- |",
@@ -485,9 +553,6 @@ export function renderLeaderboardMarkdown(board: Leaderboard): string {
 			}),
 			"",
 		);
-		// Each legend line is emitted only when the table actually contains that outcome, so the section
-		// never explains a category the reader cannot see (and so an all-`missing` run reads as one clear
-		// statement instead of three paragraphs of hypotheticals).
 		if (outcomes.has("skipped")) {
 			lines.push(
 				"**skipped** — a precondition said no before the benchmark was attempted. A ❌ **disk** skip is the",
@@ -512,18 +577,20 @@ export function renderLeaderboardMarkdown(board: Leaderboard): string {
 				"",
 			);
 		}
+		lines.push("</details>", "");
 	}
 
 	if (board.dimensions.length === 0) return `${lines.join("\n")}\n`;
 
+	// Statistics essay + optional p-value / KS detail table for readers who want the receipts.
 	lines.push(
-		"---",
+		"<details>",
+		"<summary>How rankings are decided</summary>",
 		"",
-		"**Reading this table.** The value is the median (p50) of the retained per-trial Samples, not the",
-		"mean — a single stalled pass drags a mean far more than it moves a median. The 95% CI is a",
-		"percentile bootstrap of that median (10,000 resamples, seeded from the Run id so the table is",
-		"reproducible byte-for-byte), not a normal-theory interval: these Samples are neither normal nor",
-		"independent of the host's scheduling.",
+		"The value is the median (p50) of the retained per-trial Samples, not the mean — a single stalled",
+		"pass drags a mean far more than it moves a median. The 95% CI is a percentile bootstrap of that",
+		"median (10,000 resamples, seeded from the Run id so the table is reproducible byte-for-byte), not",
+		"a normal-theory interval: these Samples are neither normal nor independent of the host's scheduling.",
 		"",
 		`Rows are separated only when their full Sample distributions differ (Mann-Whitney U, two-sided, α = ${DEFAULT_ALPHA},`,
 		"enumerated exactly over the permutation null rather than approximated — at these sample sizes the",
@@ -531,28 +598,24 @@ export function renderLeaderboardMarkdown(board: Leaderboard): string {
 		"",
 	);
 
-	// A shared rank means different things, and the footer must explain exactly the ones the table
-	// contains — no more (a legend for an absent case teaches the reader to skim) and no less (an
-	// unexplained shared rank is read as a tie, which is the misreading this whole section exists to
-	// prevent). Collected from the rows themselves, so the prose cannot drift from the table.
 	const rows = board.dimensions.flatMap((d) => d.rows);
 	const sharedRankReasons: string[] = [];
 	if (rows.some((r) => r.tiedWithAbove === "statistical")) {
 		sharedRankReasons.push(
-			"`(tied)` — the test could have separated those providers and did not, so a faster median earned",
-			"inside the noise is not a faster provider. This is the only one that claims two providers are",
+			"`tied` — the test could have separated those providers and did not, so a faster median earned",
+			"inside the noise is not a faster provider. This is the only note that claims two providers are",
 			"statistically indistinguishable.",
 		);
 	}
 	if (rows.some((r) => r.tiedWithAbove === "identical-value")) {
 		sharedRankReasons.push(
-			"`(equal medians)` / `(equal values)` — arithmetic, not a finding: the ranking sorts on the value,",
+			"`equal medians` / `equal values` — arithmetic, not a finding: the ranking sorts on the value,",
 			"and two identical values have no order between them. It says nothing about the distributions.",
 		);
 	}
 	if (sharedRankReasons.length > 0) {
 		lines.push(
-			"**A shared rank always says why, in the `p vs. above` cell, and the reasons are not interchangeable.**",
+			"**A Note cell always says why a rank is shared, and the reasons are not interchangeable.**",
 			...sharedRankReasons,
 			"",
 		);
@@ -564,21 +627,11 @@ export function renderLeaderboardMarkdown(board: Leaderboard): string {
 		"converge) is itself the signal that the provider's performance is unstable, not that the measurement",
 		"is imprecise.",
 		"",
-		"`p (KS)` is a two-sample Kolmogorov-Smirnov test against the same row above. It does **not** drive",
-		"the ranking — it compares the two empirical distributions' *shapes* rather than their central",
-		"tendency. Read it where it disagrees with `p vs. above`: a tied rank (large Mann-Whitney p) beside a",
-		"small `p (KS)` means two providers with the same typical speed but different behaviour — usually one",
-		"of them alternating between fast and stalled passes. That bimodality is what environmental noise",
-		"looks like, and it is the reason a median alone cannot rank these providers.",
-		"",
 		"At the small `n` this suite produces, a non-significant result means *not enough evidence to",
 		"separate*, never *the providers are equal*.",
 		"",
 	);
 
-	// `n too small` needs explaining only when the table actually contains one, and the floor it cites is
-	// the one those rows' own tests reported — a hardcoded example would misquote both the floor and the n
-	// the moment a run pairs, say, 3 trials against 4.
 	const floors = underpoweredFloors(board);
 	if (floors.length > 0) {
 		lines.push(
@@ -586,12 +639,47 @@ export function renderLeaderboardMarkdown(board: Leaderboard): string {
 			`Samples, so the test could not have separated the rows at any effect size (here ${floors.join("; ")}).`,
 			"Such rows are ranked on their observed medians and are **not** claimed to be tied — read the gap",
 			"between the values, and treat the p-value as unable to settle them either way. Where such a row",
-			"nevertheless shares the rank above it, the cell reads `equal medians`: the two values are simply",
+			"nevertheless shares the rank above it, the note reads `equal medians`: the two values are simply",
 			"identical, which is the ranking having nothing to order them by — never a finding that the",
 			"providers are alike.",
 			"",
 		);
 	}
+
+	// Detail table with p vs. above + KS for readers who want distribution shape.
+	const anyCompared = rows.some((r) => r.pVsPrevious !== null);
+	if (anyCompared) {
+		lines.push(
+			"### Pairwise tests (vs. row above)",
+			"",
+			"`p vs. above` is Mann-Whitney (drives rank). `p (KS)` is Kolmogorov-Smirnov on distribution",
+			"*shape* — it does not drive the ranking. A tied Mann-Whitney beside a small KS often means the",
+			"same typical speed with different behaviour (e.g. bimodal stalls).",
+			"",
+			"| Dimension | Provider | p vs. above | p (KS) |",
+			"| --- | --- | ---: | ---: |",
+		);
+		for (const { dimension, rows: dimRows } of board.dimensions) {
+			for (const r of dimRows) {
+				const equalValues = r.tiedWithAbove === "identical-value";
+				const p =
+					r.pVsPrevious === null
+						? equalValues
+							? "— (equal values)"
+							: "—"
+						: r.verdict === "underpowered"
+							? `${formatPValue(r.pVsPrevious.mannWhitney)} (n too small${equalValues ? ", equal medians" : ""})`
+							: r.verdict === "tied"
+								? `${formatPValue(r.pVsPrevious.mannWhitney)} (tied)`
+								: formatPValue(r.pVsPrevious.mannWhitney);
+				const ks = r.pVsPrevious === null ? "—" : formatPValue(r.pVsPrevious.ks);
+				lines.push(`| ${dimension} | ${r.displayName} | ${p} | ${ks} |`);
+			}
+		}
+		lines.push("");
+	}
+
+	lines.push("</details>", "");
 
 	return `${lines.join("\n")}\n`;
 }

--- a/scripts/setup-privileged-environment.sh
+++ b/scripts/setup-privileged-environment.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+# Create the empty GitHub Environment `privileged` for this repo.
+# Required reviewers, deployment-branch rules, and secrets must still be set in the GitHub UI —
+# see docs/ci-secrets.md. Requires `gh` authenticated with admin rights on the repository.
+set -euo pipefail
+
+REPO="${GITHUB_REPOSITORY:-starslingdev/sandbox-benchmarks}"
+ENV_NAME="privileged"
+
+if ! command -v gh >/dev/null 2>&1; then
+  echo "gh is required (https://cli.github.com/)" >&2
+  exit 1
+fi
+
+echo "Ensuring Environment '${ENV_NAME}' exists on ${REPO}…"
+# PUT is idempotent: creates the environment or no-ops if it already exists.
+gh api --method PUT "repos/${REPO}/environments/${ENV_NAME}" >/dev/null
+
+echo "Created/verified Environment '${ENV_NAME}'."
+echo
+echo "Still required in the GitHub UI (Settings → Environments → ${ENV_NAME}):"
+echo "  1. Required reviewers (at least one maintainer)"
+echo "  2. Deployment branches: main only"
+echo "  3. Move provider secrets onto this environment; delete repository-level copies"
+echo
+echo "Secret checklist:"
+echo "  E2B_API_KEY, DAYTONA_API_KEY, DAYTONA_TARGET,"
+echo "  MODAL_TOKEN_ID, MODAL_TOKEN_SECRET, NOVITA_API_KEY,"
+echo "  BL_API_KEY, BL_WORKSPACE"
+echo
+echo "Full runbook: docs/ci-secrets.md"

--- a/tooling/repo-checks/src/lib/workflow-hardening.ts
+++ b/tooling/repo-checks/src/lib/workflow-hardening.ts
@@ -1,5 +1,5 @@
-// Drift gate: the security posture of the GitHub Actions layer. Two invariants the .github/ files
-// must hold, neither of which the type system can enforce (GHA is YAML):
+// Drift gate: the security posture of the GitHub Actions layer. Invariants the .github/ files must
+// hold, none of which the type system can enforce (GHA is YAML):
 //
 //   1. persist-credentials hygiene — every `actions/checkout` step sets `persist-credentials: false`
 //      UNLESS it is one of the few jobs that later `git push`es (it needs the persisted job token).
@@ -9,8 +9,11 @@
 //   2. The ci-lint workflow actually runs the two linters at the agreed gate threshold — an actionlint
 //      job and a zizmor job invoked with `--min-severity medium --min-confidence high`. A renamed job
 //      or a loosened threshold (e.g. someone dropping --min-confidence) must fail this gate.
+//   3. Privileged-environment gate — every job that reads a custom secret (anything other than
+//      GITHUB_TOKEN / github.token) OR elevates to contents:write / packages:write must declare
+//      `environment: privileged`, so secrets and releases stay behind Environment protection rules.
+//   4. Toolchain publish is dispatch-only — toolchain-image.yml must not fire a release on push/merge.
 //
-// Mirrors runner-benchmarking's ci-lint.yml + zizmor.yml hardening, adapted to this repo's workflows.
 // Bun.YAML.parse is built into bun >= 1.3 (no new dependency).
 import { readFileSync } from "node:fs";
 import { join } from "node:path";
@@ -19,6 +22,10 @@ import { findRepoRoot } from "./workspace.ts";
 
 export const WORKFLOWS_DIR = ".github/workflows";
 export const CI_LINT_WORKFLOW = ".github/workflows/ci-lint.yml";
+export const TOOLCHAIN_WORKFLOW = "toolchain-image.yml";
+
+/** GitHub Environment name that holds provider secrets and gates releases. See docs/ci-secrets.md. */
+export const PRIVILEGED_ENVIRONMENT = "privileged";
 
 /** Checkout steps that intentionally keep the persisted job token, keyed "<file>::<jobId>", with the
  *  reason they push. Every other `actions/checkout` must set persist-credentials: false. */
@@ -27,6 +34,13 @@ export const CREDENTIALED_CHECKOUTS: Readonly<Record<string, string>> = {
 	// branch (it grants `contents: write` for exactly this), so it must keep the persisted token.
 	"bench-matrix.yml::publish": "commits + pushes the promoted dataset back to the branch",
 };
+
+/** Built-in / non-environment tokens that may appear as `${{ secrets.* }}` without requiring the
+ *  privileged Environment. Provider API keys and other org secrets must NOT be listed here. */
+const BUILTIN_SECRET_NAMES = new Set(["GITHUB_TOKEN"]);
+
+/** Matches `${{ secrets.NAME }}` / `${{ secrets.NAME || '…' }}` in workflow expression strings. */
+const SECRET_EXPR = /\$\{\{\s*secrets\.([A-Za-z0-9_]+)/g;
 
 function asRecord(value: unknown, message: string): Record<string, unknown> {
 	if (value === null || typeof value !== "object" || Array.isArray(value)) {
@@ -168,13 +182,161 @@ export function checkCiLintGate(doc: unknown, label: string = CI_LINT_WORKFLOW):
 	return errors;
 }
 
+/** Collect string leaves from an `env:` mapping (job- or step-level). */
+function envStrings(envValue: unknown): string[] {
+	if (envValue === undefined || envValue === null) return [];
+	const env = asRecord(envValue, "env is not a mapping");
+	return Object.values(env).filter((v): v is string => typeof v === "string");
+}
+
+/** Custom secret names referenced in a string (excludes GITHUB_TOKEN). */
+export function customSecretsIn(text: string): string[] {
+	const found: string[] = [];
+	for (const match of text.matchAll(SECRET_EXPR)) {
+		const name = match[1];
+		if (name && !BUILTIN_SECRET_NAMES.has(name)) found.push(name);
+	}
+	return found;
+}
+
+/** Effective write scopes for a job: job permissions override top-level when the job sets any. */
+function effectiveWriteScopes(
+	workflowPerms: Record<string, unknown> | undefined,
+	jobPerms: Record<string, unknown> | undefined,
+): { contentsWrite: boolean; packagesWrite: boolean } {
+	const scopes = jobPerms !== undefined ? jobPerms : (workflowPerms ?? {});
+	return {
+		contentsWrite: scopes.contents === "write",
+		packagesWrite: scopes.packages === "write",
+	};
+}
+
+/** Resolve a job's `environment` name (string form or `{ name: … }` mapping). */
+export function jobEnvironmentName(job: Record<string, unknown>): string | undefined {
+	const env = job.environment;
+	if (typeof env === "string") return env;
+	if (env !== null && typeof env === "object" && !Array.isArray(env)) {
+		const name = (env as Record<string, unknown>).name;
+		return typeof name === "string" ? name : undefined;
+	}
+	return undefined;
+}
+
+/**
+ * Invariant 3: jobs that touch custom secrets or elevate write permissions must sit behind the
+ * `privileged` GitHub Environment so Environment secrets + required reviewers apply.
+ */
+export function checkPrivilegedEnvironment(
+	doc: unknown,
+	file: string,
+	privileged: string = PRIVILEGED_ENVIRONMENT,
+): string[] {
+	const errors: string[] = [];
+	const root = asRecord(doc, `${file}: not a YAML mapping`);
+	const workflowPerms =
+		root.permissions === undefined || root.permissions === null
+			? undefined
+			: asRecord(root.permissions, `${file}: malformed permissions`);
+	const jobs = asRecord(root.jobs, `${file}: no jobs mapping`);
+
+	for (const [jobId, jobValue] of Object.entries(jobs)) {
+		const job = asRecord(jobValue, `${file}: job "${jobId}" is not a mapping`);
+		const key = `${file}::${jobId}`;
+		const secrets = new Set<string>();
+
+		for (const text of envStrings(job.env)) {
+			for (const name of customSecretsIn(text)) secrets.add(name);
+		}
+		const steps = Array.isArray(job.steps) ? job.steps : [];
+		for (const stepValue of steps) {
+			const step = asRecord(stepValue, `${file}: job "${jobId}" has a malformed step`);
+			for (const text of envStrings(step.env)) {
+				for (const name of customSecretsIn(text)) secrets.add(name);
+			}
+			// Inline secrets in `with:` (e.g. docker/login-action password) — only flag custom ones.
+			if (step.with !== undefined && step.with !== null) {
+				const withBlock = asRecord(step.with, `${file}: malformed with`);
+				for (const value of Object.values(withBlock)) {
+					if (typeof value !== "string") continue;
+					for (const name of customSecretsIn(value)) secrets.add(name);
+				}
+			}
+			if (typeof step.run === "string") {
+				for (const name of customSecretsIn(step.run)) secrets.add(name);
+			}
+		}
+
+		const jobPerms =
+			job.permissions === undefined || job.permissions === null
+				? undefined
+				: asRecord(job.permissions, `${file}: job "${jobId}" malformed permissions`);
+		const { contentsWrite, packagesWrite } = effectiveWriteScopes(workflowPerms, jobPerms);
+		const needsPrivileged = secrets.size > 0 || contentsWrite || packagesWrite;
+		if (!needsPrivileged) continue;
+
+		const envName = jobEnvironmentName(job);
+		if (envName !== privileged) {
+			const reasons: string[] = [];
+			if (secrets.size > 0) {
+				reasons.push(`custom secrets (${[...secrets].sort().join(", ")})`);
+			}
+			if (contentsWrite) reasons.push("contents: write");
+			if (packagesWrite) reasons.push("packages: write");
+			errors.push(
+				`${key}: must set \`environment: ${privileged}\` because it uses ${reasons.join(" and ")} — ` +
+					`see docs/ci-secrets.md`,
+			);
+		}
+	}
+	return errors;
+}
+
+/**
+ * Invariant 4: toolchain-image.yml publishes only via workflow_dispatch — a push/merge must never
+ * start a GHCR release. PR triggers are fine (secret-free pr-gate).
+ */
+export function checkToolchainDispatchOnly(
+	doc: unknown,
+	file: string = TOOLCHAIN_WORKFLOW,
+): string[] {
+	if (file !== TOOLCHAIN_WORKFLOW) return [];
+	const errors: string[] = [];
+	const root = asRecord(doc, `${file}: not a YAML mapping`);
+	// Bun.YAML keeps the GHA `on:` key as the string "on" (see workflow-sync.ts).
+	const on = root.on;
+	if (on === null || typeof on !== "object" || Array.isArray(on)) {
+		errors.push(`${file}: missing or malformed \`on:\` trigger map`);
+		return errors;
+	}
+	const triggers = on as Record<string, unknown>;
+	if ("push" in triggers) {
+		errors.push(
+			`${file}: must not trigger on \`push\` — toolchain publish is workflow_dispatch-only so a ` +
+				`merge cannot start a release (see docs/ci-secrets.md)`,
+		);
+	}
+	if (!("workflow_dispatch" in triggers)) {
+		errors.push(
+			`${file}: must declare \`workflow_dispatch\` — that is the only path that reaches the publish job`,
+		);
+	}
+	return errors;
+}
+
 /** The whole gate against the real .github files under `root`. */
 export function runHardeningCheck(root: string = findRepoRoot()): string[] {
-	const steps = listWorkflowFiles(root).flatMap((file) =>
+	const files = listWorkflowFiles(root);
+	const steps = files.flatMap((file) =>
 		checkoutSteps(readWorkflow(`${WORKFLOWS_DIR}/${file}`, root), file),
 	);
-	return [
+	const errors = [
 		...checkPersistCredentials(steps),
 		...checkCiLintGate(readWorkflow(CI_LINT_WORKFLOW, root)),
 	];
+	for (const file of files) {
+		const doc = readWorkflow(`${WORKFLOWS_DIR}/${file}`, root);
+		errors.push(...checkPrivilegedEnvironment(doc, file));
+		errors.push(...checkToolchainDispatchOnly(doc, file));
+	}
+	return errors;
 }

--- a/tooling/repo-checks/src/lib/workflow-hardening.ts
+++ b/tooling/repo-checks/src/lib/workflow-hardening.ts
@@ -39,8 +39,9 @@ export const CREDENTIALED_CHECKOUTS: Readonly<Record<string, string>> = {
  *  privileged Environment. Provider API keys and other org secrets must NOT be listed here. */
 const BUILTIN_SECRET_NAMES = new Set(["GITHUB_TOKEN"]);
 
-/** Matches `${{ secrets.NAME }}` / `${{ secrets.NAME || '…' }}` in workflow expression strings. */
-const SECRET_EXPR = /\$\{\{\s*secrets\.([A-Za-z0-9_]+)/g;
+/** Matches `${{ secrets.NAME }}`, `${{ secrets['NAME'] }}`, or `${{ secrets["NAME"] }}`
+ *  (with optional `|| …` after the access). Bracket form is rarer but a real bypass if ignored. */
+const SECRET_EXPR = /\$\{\{\s*secrets(?:\.([A-Za-z0-9_]+)|\s*\[\s*['"]([A-Za-z0-9_]+)['"]\s*\])/g;
 
 function asRecord(value: unknown, message: string): Record<string, unknown> {
 	if (value === null || typeof value !== "object" || Array.isArray(value)) {
@@ -193,7 +194,7 @@ function envStrings(envValue: unknown): string[] {
 export function customSecretsIn(text: string): string[] {
 	const found: string[] = [];
 	for (const match of text.matchAll(SECRET_EXPR)) {
-		const name = match[1];
+		const name = match[1] || match[2];
 		if (name && !BUILTIN_SECRET_NAMES.has(name)) found.push(name);
 	}
 	return found;
@@ -244,12 +245,18 @@ export function checkPrivilegedEnvironment(
 		const key = `${file}::${jobId}`;
 		const secrets = new Set<string>();
 
+		if (typeof job.if === "string") {
+			for (const name of customSecretsIn(job.if)) secrets.add(name);
+		}
 		for (const text of envStrings(job.env)) {
 			for (const name of customSecretsIn(text)) secrets.add(name);
 		}
 		const steps = Array.isArray(job.steps) ? job.steps : [];
 		for (const stepValue of steps) {
 			const step = asRecord(stepValue, `${file}: job "${jobId}" has a malformed step`);
+			if (typeof step.if === "string") {
+				for (const name of customSecretsIn(step.if)) secrets.add(name);
+			}
 			for (const text of envStrings(step.env)) {
 				for (const name of customSecretsIn(text)) secrets.add(name);
 			}

--- a/tooling/repo-checks/src/lib/workflow-hardening.ts
+++ b/tooling/repo-checks/src/lib/workflow-hardening.ts
@@ -238,12 +238,14 @@ export function checkPrivilegedEnvironment(
 		root.permissions === undefined || root.permissions === null
 			? undefined
 			: asRecord(root.permissions, `${file}: malformed permissions`);
+	// Workflow-level `env` is inherited by every job/step — secrets there must not bypass the gate.
+	const workflowSecrets = new Set(envStrings(root.env).flatMap((text) => customSecretsIn(text)));
 	const jobs = asRecord(root.jobs, `${file}: no jobs mapping`);
 
 	for (const [jobId, jobValue] of Object.entries(jobs)) {
 		const job = asRecord(jobValue, `${file}: job "${jobId}" is not a mapping`);
 		const key = `${file}::${jobId}`;
-		const secrets = new Set<string>();
+		const secrets = new Set(workflowSecrets);
 
 		if (typeof job.if === "string") {
 			for (const name of customSecretsIn(job.if)) secrets.add(name);
@@ -300,8 +302,9 @@ export function checkPrivilegedEnvironment(
 
 /**
  * Invariant 4: toolchain-image.yml publishes only via workflow_dispatch — a push/merge must never
- * start a GHCR release. PR triggers are fine (secret-free pr-gate). Call only with that workflow's
- * document; {@link runHardeningCheck} does the file selection.
+ * start a GHCR release. Allowed top-level triggers are exactly `workflow_dispatch` + `pull_request`
+ * (the secret-free PR gate). Call only with that workflow's document; {@link runHardeningCheck}
+ * does the file selection.
  */
 export function checkToolchainDispatchOnly(
 	doc: unknown,
@@ -316,16 +319,50 @@ export function checkToolchainDispatchOnly(
 		return errors;
 	}
 	const triggers = on as Record<string, unknown>;
-	if ("push" in triggers) {
-		errors.push(
-			`${file}: must not trigger on \`push\` — toolchain publish is workflow_dispatch-only so a ` +
-				`merge cannot start a release (see docs/ci-secrets.md)`,
-		);
+	const allowed = new Set(["workflow_dispatch", "pull_request"]);
+	const triggerKeys = Object.keys(triggers);
+	for (const key of triggerKeys) {
+		if (!allowed.has(key)) {
+			errors.push(
+				`${file}: trigger \`${key}\` is not allowed — toolchain publish is workflow_dispatch-only ` +
+					`(plus pull_request for the secret-free PR gate); see docs/ci-secrets.md`,
+			);
+		}
 	}
 	if (!("workflow_dispatch" in triggers)) {
 		errors.push(
 			`${file}: must declare \`workflow_dispatch\` — that is the only path that reaches the publish job`,
 		);
+	}
+	if (!("pull_request" in triggers)) {
+		errors.push(
+			`${file}: must declare \`pull_request\` — the secret-free PR docker smoke gate must stay on the PR path`,
+		);
+	}
+
+	const jobs = asRecord(root.jobs, `${file}: no jobs mapping`);
+	if (!("publish" in jobs)) {
+		errors.push(`${file}: missing the "publish" job — that is the GHCR release lane`);
+		return errors;
+	}
+	const publish = asRecord(jobs.publish, `${file}: publish job is not a mapping`);
+	if (jobEnvironmentName(publish) !== PRIVILEGED_ENVIRONMENT) {
+		errors.push(
+			`${file}::publish: must set \`environment: ${PRIVILEGED_ENVIRONMENT}\` — GHCR promote is a release`,
+		);
+	}
+	const publishIf = typeof publish.if === "string" ? publish.if : "";
+	for (const needle of [
+		"workflow_dispatch",
+		"refs/heads/main",
+		"starslingdev/sandbox-benchmarks",
+	] as const) {
+		if (!publishIf.includes(needle)) {
+			errors.push(
+				`${file}::publish: \`if:\` must confine the release to workflow_dispatch on main of ` +
+					`starslingdev/sandbox-benchmarks (missing "${needle}")`,
+			);
+		}
 	}
 	return errors;
 }

--- a/tooling/repo-checks/src/lib/workflow-hardening.ts
+++ b/tooling/repo-checks/src/lib/workflow-hardening.ts
@@ -293,13 +293,13 @@ export function checkPrivilegedEnvironment(
 
 /**
  * Invariant 4: toolchain-image.yml publishes only via workflow_dispatch — a push/merge must never
- * start a GHCR release. PR triggers are fine (secret-free pr-gate).
+ * start a GHCR release. PR triggers are fine (secret-free pr-gate). Call only with that workflow's
+ * document; {@link runHardeningCheck} does the file selection.
  */
 export function checkToolchainDispatchOnly(
 	doc: unknown,
 	file: string = TOOLCHAIN_WORKFLOW,
 ): string[] {
-	if (file !== TOOLCHAIN_WORKFLOW) return [];
 	const errors: string[] = [];
 	const root = asRecord(doc, `${file}: not a YAML mapping`);
 	// Bun.YAML keeps the GHA `on:` key as the string "on" (see workflow-sync.ts).
@@ -326,17 +326,26 @@ export function checkToolchainDispatchOnly(
 /** The whole gate against the real .github files under `root`. */
 export function runHardeningCheck(root: string = findRepoRoot()): string[] {
 	const files = listWorkflowFiles(root);
-	const steps = files.flatMap((file) =>
-		checkoutSteps(readWorkflow(`${WORKFLOWS_DIR}/${file}`, root), file),
+	const docs = new Map(
+		files.map((file) => [file, readWorkflow(`${WORKFLOWS_DIR}/${file}`, root)] as const),
 	);
+	const steps = files.flatMap((file) => checkoutSteps(docs.get(file), file));
+	const ciLintFile = CI_LINT_WORKFLOW.slice(`${WORKFLOWS_DIR}/`.length);
+	const ciLintDoc = docs.get(ciLintFile);
 	const errors = [
 		...checkPersistCredentials(steps),
-		...checkCiLintGate(readWorkflow(CI_LINT_WORKFLOW, root)),
+		...(ciLintDoc === undefined
+			? [`${CI_LINT_WORKFLOW}: missing from ${WORKFLOWS_DIR}`]
+			: checkCiLintGate(ciLintDoc)),
 	];
 	for (const file of files) {
-		const doc = readWorkflow(`${WORKFLOWS_DIR}/${file}`, root);
-		errors.push(...checkPrivilegedEnvironment(doc, file));
-		errors.push(...checkToolchainDispatchOnly(doc, file));
+		errors.push(...checkPrivilegedEnvironment(docs.get(file), file));
+	}
+	const toolchainDoc = docs.get(TOOLCHAIN_WORKFLOW);
+	if (toolchainDoc === undefined) {
+		errors.push(`${TOOLCHAIN_WORKFLOW}: missing from ${WORKFLOWS_DIR}`);
+	} else {
+		errors.push(...checkToolchainDispatchOnly(toolchainDoc, TOOLCHAIN_WORKFLOW));
 	}
 	return errors;
 }

--- a/tooling/repo-checks/src/workflow-hardening.test.ts
+++ b/tooling/repo-checks/src/workflow-hardening.test.ts
@@ -1,9 +1,10 @@
 // Invariant: the GitHub Actions layer stays hardened. (1) every actions/checkout opts out of
-// credential persistence unless it is an allowlisted pushing checkout, and (2) ci-lint.yml runs
-// actionlint + zizmor at the agreed gate threshold. The runHardeningCheck() test against the real
-// .github files IS the gate's CI enforcement point (same precedent as workflow-registry-sync.test.ts);
-// the rest is unit coverage of the pure checks on synthetic drift so a regression names the offender.
-// See ./lib/workflow-hardening.ts.
+// credential persistence unless it is an allowlisted pushing checkout, (2) ci-lint.yml runs
+// actionlint + zizmor at the agreed gate threshold, (3) custom-secret / write jobs declare
+// environment: privileged, and (4) toolchain publish is workflow_dispatch-only. The
+// runHardeningCheck() test against the real .github files IS the gate's CI enforcement point
+// (same precedent as workflow-registry-sync.test.ts); the rest is unit coverage of the pure checks
+// on synthetic drift so a regression names the offender. See ./lib/workflow-hardening.ts.
 import { describe, expect, test } from "bun:test";
 import type { CheckoutStep } from "./lib/workflow-hardening.ts";
 import {
@@ -12,9 +13,14 @@ import {
 	checkCiLintGate,
 	checkoutSteps,
 	checkPersistCredentials,
+	checkPrivilegedEnvironment,
+	checkToolchainDispatchOnly,
+	customSecretsIn,
 	listWorkflowFiles,
+	PRIVILEGED_ENVIRONMENT,
 	readWorkflow,
 	runHardeningCheck,
+	TOOLCHAIN_WORKFLOW,
 	WORKFLOWS_DIR,
 } from "./lib/workflow-hardening.ts";
 
@@ -135,6 +141,121 @@ describe("checkCiLintGate", () => {
 		const errors = checkCiLintGate(loosened);
 		expect(errors).toHaveLength(1);
 		expect(errors[0]).toContain("--min-confidence high");
+	});
+});
+
+describe("customSecretsIn", () => {
+	test("ignores GITHUB_TOKEN and extracts provider secrets", () => {
+		expect(
+			customSecretsIn(
+				// biome-ignore lint/suspicious/noTemplateCurlyInString: literal GitHub Actions expression under test
+				"${{ secrets.GITHUB_TOKEN }} ${{ secrets.E2B_API_KEY }} ${{ secrets.DAYTONA_TARGET || 'us-west-2' }}",
+			),
+		).toEqual(["E2B_API_KEY", "DAYTONA_TARGET"]);
+	});
+});
+
+describe("checkPrivilegedEnvironment", () => {
+	test("passes the real privileged workflows", () => {
+		for (const file of ["bench-matrix.yml", "bench-smoke.yml", "toolchain-image.yml"]) {
+			expect(checkPrivilegedEnvironment(readWorkflow(`${WORKFLOWS_DIR}/${file}`), file)).toEqual(
+				[],
+			);
+		}
+	});
+
+	test("passes jobs that only use GITHUB_TOKEN without an environment", () => {
+		const doc = {
+			jobs: {
+				clone: {
+					steps: [
+						{
+							name: "Run",
+							// biome-ignore lint/suspicious/noTemplateCurlyInString: literal GitHub Actions expression under test
+							env: { TOKEN: "${{ secrets.GITHUB_TOKEN }}" },
+							run: "true",
+						},
+					],
+				},
+			},
+		};
+		expect(checkPrivilegedEnvironment(doc, "safe.yml")).toEqual([]);
+	});
+
+	test("flags a custom secret without environment: privileged", () => {
+		const doc = {
+			jobs: {
+				bench: {
+					steps: [
+						{
+							name: "Run",
+							// biome-ignore lint/suspicious/noTemplateCurlyInString: literal GitHub Actions expression under test
+							env: { E2B_API_KEY: "${{ secrets.E2B_API_KEY }}" },
+							run: "true",
+						},
+					],
+				},
+			},
+		};
+		const errors = checkPrivilegedEnvironment(doc, "leak.yml");
+		expect(errors).toHaveLength(1);
+		expect(errors[0]).toContain("leak.yml::bench");
+		expect(errors[0]).toContain(`environment: ${PRIVILEGED_ENVIRONMENT}`);
+		expect(errors[0]).toContain("E2B_API_KEY");
+	});
+
+	test("flags packages: write without the privileged environment", () => {
+		const doc = {
+			jobs: {
+				publish: {
+					permissions: { packages: "write" },
+					steps: [{ run: "true" }],
+				},
+			},
+		};
+		const errors = checkPrivilegedEnvironment(doc, "ghcr.yml");
+		expect(errors).toHaveLength(1);
+		expect(errors[0]).toContain("packages: write");
+	});
+
+	test("accepts a write job that declares environment: privileged", () => {
+		const doc = {
+			jobs: {
+				publish: {
+					environment: PRIVILEGED_ENVIRONMENT,
+					permissions: { contents: "write" },
+					steps: [{ run: "true" }],
+				},
+			},
+		};
+		expect(checkPrivilegedEnvironment(doc, "ok.yml")).toEqual([]);
+	});
+});
+
+describe("checkToolchainDispatchOnly", () => {
+	test("passes the real toolchain-image.yml", () => {
+		expect(
+			checkToolchainDispatchOnly(
+				readWorkflow(`${WORKFLOWS_DIR}/${TOOLCHAIN_WORKFLOW}`),
+				TOOLCHAIN_WORKFLOW,
+			),
+		).toEqual([]);
+	});
+
+	test("flags a push trigger on the toolchain workflow", () => {
+		const doc = {
+			on: {
+				workflow_dispatch: {},
+				push: { branches: ["main"] },
+			},
+		};
+		const errors = checkToolchainDispatchOnly(doc, TOOLCHAIN_WORKFLOW);
+		expect(errors).toHaveLength(1);
+		expect(errors[0]).toContain("must not trigger on `push`");
+	});
+
+	test("ignores non-toolchain workflows", () => {
+		expect(checkToolchainDispatchOnly({ on: { push: {} } }, "ci.yml")).toEqual([]);
 	});
 });
 

--- a/tooling/repo-checks/src/workflow-hardening.test.ts
+++ b/tooling/repo-checks/src/workflow-hardening.test.ts
@@ -228,6 +228,20 @@ describe("checkPrivilegedEnvironment", () => {
 		expect(errors[0]).toContain("STEP_SECRET");
 	});
 
+	test("flags custom secrets in workflow-level env inherited by every job", () => {
+		const doc = {
+			// biome-ignore lint/suspicious/noTemplateCurlyInString: literal GitHub Actions expression under test
+			env: { E2B_API_KEY: "${{ secrets.E2B_API_KEY }}" },
+			jobs: {
+				plan: { steps: [{ run: "true" }] },
+			},
+		};
+		const errors = checkPrivilegedEnvironment(doc, "leak-root-env.yml");
+		expect(errors).toHaveLength(1);
+		expect(errors[0]).toContain("leak-root-env.yml::plan");
+		expect(errors[0]).toContain("E2B_API_KEY");
+	});
+
 	test("flags packages: write without the privileged environment", () => {
 		const doc = {
 			jobs: {
@@ -270,12 +284,36 @@ describe("checkToolchainDispatchOnly", () => {
 		const doc = {
 			on: {
 				workflow_dispatch: {},
+				pull_request: {},
 				push: { branches: ["main"] },
+			},
+			jobs: {
+				publish: {
+					environment: PRIVILEGED_ENVIRONMENT,
+					if: "github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main' && github.repository == 'starslingdev/sandbox-benchmarks'",
+					steps: [{ run: "true" }],
+				},
 			},
 		};
 		const errors = checkToolchainDispatchOnly(doc, TOOLCHAIN_WORKFLOW);
 		expect(errors).toHaveLength(1);
-		expect(errors[0]).toContain("must not trigger on `push`");
+		expect(errors[0]).toContain("trigger `push` is not allowed");
+	});
+
+	test("flags a publish job missing the main-only dispatch gate", () => {
+		const doc = {
+			on: { workflow_dispatch: {}, pull_request: {} },
+			jobs: {
+				publish: {
+					environment: PRIVILEGED_ENVIRONMENT,
+					if: "true",
+					steps: [{ run: "true" }],
+				},
+			},
+		};
+		const errors = checkToolchainDispatchOnly(doc, TOOLCHAIN_WORKFLOW);
+		expect(errors.some((e) => e.includes('missing "workflow_dispatch"'))).toBe(true);
+		expect(errors.some((e) => e.includes('missing "refs/heads/main"'))).toBe(true);
 	});
 });
 

--- a/tooling/repo-checks/src/workflow-hardening.test.ts
+++ b/tooling/repo-checks/src/workflow-hardening.test.ts
@@ -253,10 +253,6 @@ describe("checkToolchainDispatchOnly", () => {
 		expect(errors).toHaveLength(1);
 		expect(errors[0]).toContain("must not trigger on `push`");
 	});
-
-	test("ignores non-toolchain workflows", () => {
-		expect(checkToolchainDispatchOnly({ on: { push: {} } }, "ci.yml")).toEqual([]);
-	});
 });
 
 describe("the gate itself", () => {

--- a/tooling/repo-checks/src/workflow-hardening.test.ts
+++ b/tooling/repo-checks/src/workflow-hardening.test.ts
@@ -145,13 +145,13 @@ describe("checkCiLintGate", () => {
 });
 
 describe("customSecretsIn", () => {
-	test("ignores GITHUB_TOKEN and extracts provider secrets", () => {
+	test("ignores GITHUB_TOKEN and extracts provider secrets in dot and bracket notation", () => {
 		expect(
 			customSecretsIn(
 				// biome-ignore lint/suspicious/noTemplateCurlyInString: literal GitHub Actions expression under test
-				"${{ secrets.GITHUB_TOKEN }} ${{ secrets.E2B_API_KEY }} ${{ secrets.DAYTONA_TARGET || 'us-west-2' }}",
+				"${{ secrets.GITHUB_TOKEN }} ${{ secrets.E2B_API_KEY }} ${{ secrets.DAYTONA_TARGET || 'us-west-2' }} ${{ secrets['NOVITA_API_KEY'] }} ${{ secrets[\"BL_API_KEY\"] }}",
 			),
-		).toEqual(["E2B_API_KEY", "DAYTONA_TARGET"]);
+		).toEqual(["E2B_API_KEY", "DAYTONA_TARGET", "NOVITA_API_KEY", "BL_API_KEY"]);
 	});
 });
 
@@ -202,6 +202,30 @@ describe("checkPrivilegedEnvironment", () => {
 		expect(errors[0]).toContain("leak.yml::bench");
 		expect(errors[0]).toContain(`environment: ${PRIVILEGED_ENVIRONMENT}`);
 		expect(errors[0]).toContain("E2B_API_KEY");
+	});
+
+	test("flags custom secrets in job or step if conditions without environment: privileged", () => {
+		const doc = {
+			jobs: {
+				bench: {
+					// biome-ignore lint/suspicious/noTemplateCurlyInString: literal GitHub Actions expression under test
+					if: "${{ secrets.JOB_SECRET != '' }}",
+					steps: [
+						{
+							name: "Run",
+							// biome-ignore lint/suspicious/noTemplateCurlyInString: literal GitHub Actions expression under test
+							if: "${{ secrets.STEP_SECRET != '' }}",
+							run: "true",
+						},
+					],
+				},
+			},
+		};
+		const errors = checkPrivilegedEnvironment(doc, "leak-if.yml");
+		expect(errors).toHaveLength(1);
+		expect(errors[0]).toContain("leak-if.yml::bench");
+		expect(errors[0]).toContain("JOB_SECRET");
+		expect(errors[0]).toContain("STEP_SECRET");
 	});
 
 	test("flags packages: write without the privileged environment", () => {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Prepares the repo to flip public: secrets and releases behind GitHub Environments, public-facing documentation, and a crisper leaderboard.

### GitHub Actions / secrets
- Privileged jobs (`toolchain-image` publish, `bench-matrix` bench+publish, `bench-smoke`) declare `environment: privileged`.
- Toolchain GHCR publish is **workflow_dispatch-only** (no publish on push/merge).
- Jobs require `main` + `starslingdev/sandbox-benchmarks`.
- `tooling/repo-checks` enforces: custom secrets and write permissions need `environment: privileged`; toolchain must not trigger on `push`.
- Dataset publish regenerates `LEADERBOARD.md` in the same commit.

### Docs
- README leads with leaderboard + docs map.
- Added `SECURITY.md`, `CODE_OF_CONDUCT.md`, `docs/README.md`, `docs/ci-secrets.md`, `scripts/setup-privileged-environment.sh`.
- CONTRIBUTING covers fork PRs vs maintainer-only live benches.

### Leaderboard
- Slim tables (takeaway + Rank/Provider/Value/CI/n; Note only when needed).
- Coverage gaps summarized; full table + stats under `<details>`.
- Regenerated from newest published Run `29365910084`.

## Manual steps before making the repo public

1. Create Environment **`privileged`** (or run `./scripts/setup-privileged-environment.sh`).
2. Required reviewers (1–2 maintainers).
3. Deployment branches: **`main` only**.
4. Move provider secrets onto the environment; **delete repository-level copies**:
   `E2B_API_KEY`, `DAYTONA_API_KEY`, `DAYTONA_TARGET`, `MODAL_TOKEN_ID`, `MODAL_TOKEN_SECRET`, `NOVITA_API_KEY`, `BL_API_KEY`, `BL_WORKSPACE`.
5. Confirm GHCR package `sandbox-benchmarks-toolchain` is public.
6. Then flip repository visibility to public.

Full runbook: [`docs/ci-secrets.md`](docs/ci-secrets.md).

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f6474-4e20-77b9-a3e4-b09e4c5f1aae"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f6474-4e20-77b9-a3e4-b09e4c5f1aae"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prepares the repo to go public by gating provider secrets and releases behind GitHub Environment `privileged`, tightening CI hardening (trigger allowlist, env/if secret scans), and shipping a slimmer, auto-regenerated leaderboard with accurate tie takeaways.

- **New Features**
  - Workflows: `bench-matrix`/`bench-smoke` run only on `main` in this repo with `environment: privileged`; dataset publish aggregates, regenerates `LEADERBOARD.md`, and commits both; toolchain publish is `workflow_dispatch`-only on `main` with `environment: privileged` and an allowlisted trigger set (`workflow_dispatch` + `pull_request`).
  - Hardening: `tooling/repo-checks` enforces checkout token hygiene; actionlint/zizmor gates; requires `environment: privileged` for any job using custom secrets or `contents/packages: write`; scans workflow-level `env`, job/step `env` and `if:` (dot and bracket secret notation); verifies toolchain triggers allowlist and publish job’s `if` guards; parses each workflow YAML once.
  - Leaderboard: slimmer tables with a Note column and tie-aware takeaways; KS/p-values moved to a details section with a compact pairwise table; coverage summary collapsed with full table in details; renderer deduped; CLI adds `leaderboard`; regenerated from the latest Run.
  - Docs: README leads with the leaderboard and docs hub; added `SECURITY.md`, `CODE_OF_CONDUCT.md`, `docs/README.md`, `docs/ci-secrets.md`; CONTRIBUTING clarifies fork PRs; broadened `.gitignore`; target spec now 2 vCPU · 8 GiB RAM · 40 GB disk.

- **Migration**
  - Create Environment `privileged` (restrict to `main`, require reviewers).
  - Move provider secrets to the environment and delete repo-level copies: `E2B_API_KEY`, `DAYTONA_API_KEY`, `DAYTONA_TARGET`, `MODAL_TOKEN_ID`, `MODAL_TOKEN_SECRET`, `NOVITA_API_KEY`, `BL_API_KEY`, `BL_WORKSPACE`.
  - Ensure GHCR package `sandbox-benchmarks-toolchain` is public.
  - Then flip the repository to public.

<sup>Written for commit 23b0bbcd370831f3d596c89126bf71ddbd13563a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/starslingdev/sandbox-benchmarks/pull/171?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Expanded benchmark coverage and refreshed leaderboard presentation (updated ranking/ties, confidence intervals, coverage gaps, and pairwise test details).
  * Leaderboards are now regenerated automatically during benchmark publishing.
  * CLI docs now include `aggregate` and `leaderboard` commands.
* **Documentation**
  * Added/updated documentation indexes, community guidance, and CI/secrets security posture guidance.
  * Updated methodology with the pinned target’s increased disk size and clarified fork PR behavior.
* **Security**
  * Strengthened CI/release protections around the privileged environment and repository/branch gating.
  * Added/updated security policy and reduced risk of accidentally committing secrets.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->