### PR TITLE
docs: add community-health files and public-facing README/docs hub

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,38 @@
+# Local benchmark credentials — template. Copy to `.env` and fill in the providers you have.
+#
+#   cp .env.example .env
+#
+# `.env` is gitignored (never commit it); only this `.env.example` is tracked, and it must stay
+# secret-free (the repo-checks secret-hygiene gate scans tracked files). Bun auto-loads `.env` when
+# you run a bin (e.g. `bun apps/cli/src/bin/bench-smoke.ts e2b memory`), so these become process.env.
+#
+# You do NOT need every provider: a missing credential is recorded as a skip, not a failure. CI reads
+# these from the GitHub Environment `privileged`, never from a committed file — see docs/ci-secrets.md.
+
+# --- e2b (https://e2b.dev) ---
+E2B_API_KEY=
+
+# --- Daytona (https://daytona.io) ---
+DAYTONA_API_KEY=
+# Runner target / region the sandbox boots in. Defaults to us-west-2 when unset (the active region);
+# the account default has no `container` runners, so leave this as us-west-2 unless you know otherwise.
+DAYTONA_TARGET=us-west-2
+
+# --- Modal (https://modal.com) ---
+MODAL_TOKEN_ID=
+MODAL_TOKEN_SECRET=
+
+# --- Blaxel (https://blaxel.ai) ---
+BL_API_KEY=
+BL_WORKSPACE=
+
+# --- Novita (https://novita.ai) — E2B-protocol-compatible control plane ---
+NOVITA_API_KEY=
+
+# --- Optional overrides (leave unset for the pinned public toolchain) ---
+# Point the adapters at a specific toolchain image / template instead of the canonical published one.
+# Useful only when iterating on the toolchain locally; see packages/providers/src/lib/config.ts.
+# BENCH_TOOLCHAIN_IMAGE=
+# E2B_TEMPLATE=
+# DAYTONA_SNAPSHOT=
+# NOVITA_TEMPLATE=

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,13 @@
+# Code owners — auto-requested for review on matching paths. See
+# https://docs.github.com/en/repositories/managing-your-repos-settings-and-features/customizing-your-repository/about-code-owners
+#
+# Default owner for everything in the repo.
+* @dbworku
+
+# Security-sensitive surfaces — the CI/secrets posture and its enforcing gate. Changes here alter
+# what runs with credentials or what the hardening invariants allow, so they always want maintainer eyes.
+/.github/                                       @dbworku
+/tooling/repo-checks/                           @dbworku
+/scripts/setup-privileged-environment.sh        @dbworku
+/SECURITY.md                                    @dbworku
+/docs/ci-secrets.md                             @dbworku

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,27 @@
+# Dependabot — scoped to GitHub Actions only.
+#
+# Third-party actions are SHA-pinned (the tag comment is for humans; see SECURITY.md), which is
+# secure but goes stale silently — a pin never moves on its own. Dependabot opens a PR to bump each
+# pinned SHA (and its tag comment) when a new release lands, so the pins stay current AND pinned.
+#
+# npm/Bun dependencies are deliberately NOT managed here: the repo installs with Bun's
+# `minimumReleaseAge = 604800` supply-chain delay (bunfig.toml) and a frozen `bun.lock`, and updates
+# them by hand through that gate. A Dependabot npm updater would fight that posture, so it is omitted.
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    # One grouped PR for routine action bumps keeps review noise low; a major bump still opens its own.
+    groups:
+      github-actions:
+        # A group must name at least one matcher; `*` groups every action bump into the one PR.
+        patterns:
+          - "*"
+        update-types: [minor, patch]
+    commit-message:
+      prefix: "chore(ci)"
+    labels:
+      - dependencies
+      - github-actions

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,8 +1,23 @@
 # Contributing
 
+Thanks for helping improve sandbox provider comparisons. Read the
+[methodology](./docs/methodology.md) for how a measurement is produced before extending the matrix.
+
 This repo is a Bun workspace monorepo with a strict, enforced dependency DAG (see the
-[README](./README.md)) and a source-first, no-build layout. Read the [methodology](./docs/methodology.md)
-for how a measurement is produced before extending the matrix.
+[README](./README.md)) and a source-first, no-build layout.
+
+## Pull requests from forks
+
+1. Fork, branch, and open a PR against `main`.
+2. Hosted CI (`ci.yml` / `ci-lint.yml`) runs the command contract on your PR — no provider secrets.
+3. Self-hosted Docker toolchain smoke and live provider benches **do not** run on fork PRs (by
+   design: untrusted code must not execute on org runners or spend provider quota).
+4. Live benches, dataset publish, and GHCR toolchain releases are maintainer-only:
+   `workflow_dispatch` on `main` behind Environment `privileged`. See [CI & secrets](./docs/ci-secrets.md).
+
+For local benches, copy [`.env.example`](./.env.example) to a gitignored `.env`. Never commit API
+keys or paste them into issues/PRs — the repo-checks secret-hygiene gate fails CI if a credential
+file or secret token is tracked ([SECURITY.md](./SECURITY.md)).
 
 ## Local checks (the gate)
 

--- a/README.md
+++ b/README.md
@@ -1,11 +1,20 @@
 # sandbox-benchmarks
 
-Compare top sandbox providers' performance for real developer and CI/CD tasks.
+Compare top sandbox providers on the same pinned machine shape for real developer and CI/CD workloads — not bare-metal hardware benches.
 
-> **Docs:** [Methodology](./docs/methodology.md) — how a measurement is produced (target spec,
-> dimensions, economics, host-vs-effective specs, transport model, the dataset pipeline). ·
-> [ADRs](./docs/adr/README.md) — the load-bearing architecture decisions and why. ·
-> [Contributing](./CONTRIBUTING.md) — the local gate and how to add a provider, suite, or metric.
+**Same target everywhere:** 2 vCPU · 8 GiB RAM · 40 GB disk. One headline metric per dimension, ranked with honest statistics.
+
+## Start here
+
+| | |
+| --- | --- |
+| **[Leaderboard](./LEADERBOARD.md)** | Provider rankings from the latest published run |
+| **[Methodology](./docs/methodology.md)** | How a measurement is produced |
+| **[Docs hub](./docs/README.md)** | ADRs, CI secrets, security, contributing |
+
+Live provider benches and toolchain releases are **maintainer-only** (GitHub Environment `privileged`). Pull requests never receive provider secrets — see [CI & secrets](./docs/ci-secrets.md).
+
+---
 
 This repo is a **Bun workspace monorepo** with a strict, enforced dependency DAG and a uniform
 package shape. The guiding rule: *"can I import this?"* is answered by the path alone, and
@@ -85,6 +94,9 @@ npm republisher and no install-time postinstall.
 [mise](https://mise.jdx.dev)). The same checks run locally, so green-on-your-machine means
 green-in-CI.
 
+Fork PRs get the hosted CI gate only. Self-hosted jobs and anything that needs provider credentials
+run only from this repository, on `main`, behind Environment [`privileged`](./docs/ci-secrets.md).
+
 ## Git hooks (pre-commit)
 
 [Lefthook](https://lefthook.dev) runs a fast local mirror of CI on every commit, configured in
@@ -107,3 +119,8 @@ compromised — releases are not installed, and **no third-party lifecycle scrip
 `trustedDependencies`). The git hooks above are wired by the project's own first-party `prepare`
 script, not a dependency's postinstall, and CI installs with `--ignore-scripts` so it runs none
 either. Lint and formatting are root-only via a single `biome.json`.
+
+## Community
+
+- [Contributing](./CONTRIBUTING.md) — local gate; how to add a provider, suite, or metric
+- [Security](./SECURITY.md) — vulnerability reporting; never paste secrets into issues or PRs

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,29 @@
+# Security Policy
+
+## Reporting a vulnerability
+
+Please report security issues privately. Do **not** open a public issue for anything that could
+expose credentials, allow remote code execution in CI, or leak provider API keys.
+
+- Preferred: email **security@starsling.dev** (or the contact listed on the StarSling org profile).
+- Include steps to reproduce, affected workflows/packages, and any mitigating details you already have.
+- We will acknowledge receipt and work a fix before any public disclosure.
+
+## Secrets
+
+- Never commit API keys, tokens, or `.env` files. Broader `.env*` patterns are gitignored, and the
+  `tooling/repo-checks` **secret-hygiene gate** fails CI if a credential file or high-signal secret
+  token is ever tracked — so this is enforced, not just convention.
+- Never paste secrets into issues, pull request bodies, or comments.
+- For local benches, copy [`.env.example`](./.env.example) to a gitignored `.env`.
+- Provider credentials for CI live only in the GitHub Environment **`privileged`** — not as
+  repository secrets. See [docs/ci-secrets.md](./docs/ci-secrets.md).
+- Pull requests (including forks) do not receive those secrets. Live benches and toolchain
+  releases require a maintainer `workflow_dispatch` on `main` plus Environment approval.
+
+## Scope notes
+
+- Self-hosted runners only execute same-repository PR heads and privileged maintainer jobs.
+- We do not use `pull_request_target`.
+- Third-party Actions are SHA-pinned; installs use `--ignore-scripts` / Bun's empty
+  `trustedDependencies` posture.

--- a/apps/cli/README.md
+++ b/apps/cli/README.md
@@ -11,7 +11,10 @@
 - `plan-matrix` — print the **provider × suite** benchmark matrix as **single-line compact JSON** for `$GITHUB_OUTPUT` (the `bench-matrix` workflow's fan-out contract).
 - `build-template` — build a provider's sandbox template.
 - `normalize` — turn raw runs into normalized run documents.
+- `aggregate` — merge shard Runs into one candidate.
 - `promote` — promote normalized results to the published dataset.
+- `leaderboard` — render a Run as Markdown (`LEADERBOARD.md`); used by the dataset publish job.
+- `bake` / `bench-smoke` / `stability` — toolchain bake, single-cell smoke, cross-run stability gate.
 
 **Depends on:** all five packages (`workspace:*`) + `dotenv` (`catalog:`).
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,15 @@
+# Docs
+
+| Doc | What it covers |
+| --- | --- |
+| [Methodology](./methodology.md) | Target spec, dimensions, economics, host vs effective specs, dataset pipeline |
+| [Leaderboard](../LEADERBOARD.md) | Public provider rankings (generated from the published Run dataset) |
+| [ADRs](./adr/README.md) | Load-bearing architecture decisions |
+| [Contributing](../CONTRIBUTING.md) | Local gate; adding a provider, suite, or metric |
+| [CI & secrets](./ci-secrets.md) | GitHub Environment `privileged`, release gates, operator setup |
+| [Security](../SECURITY.md) | Vulnerability reporting |
+
+## Historical / design notes
+
+- [PTS catalog and analysis design](./pts-catalog-and-analysis-design.md) — early design notes (historical; prefer ADRs + methodology for current truth)
+- [Evidence: Daytona exec transport](./evidence/daytona-exec-transport.md) — research notes on Daytona exec limits


### PR DESCRIPTION
**Public-repo hardening — split into a 5-PR stack (merge bottom-up, each branch independently green):**
1. #173 — community-health: GitHub community files (`CODEOWNERS`, issue/PR templates, dependabot, CoC, SECURITY) + public README/docs hub
2. #174 — leaderboard: richer render (per-dimension takeaways, target-spec header, coverage summary) + regenerated `LEADERBOARD.md`
3. #175 — secret hygiene: repo-checks drift gate over the tracked tree + widened `.gitignore` blocklist
4. #176 — workflow YAML: gate live-bench / dataset-publish / GHCR-release behind Environment `privileged`; releases are dispatch-only
5. #177 — workflow gate: enforce the privileged-environment + dispatch-only invariants as a repo-checks drift gate

↑ **This PR is #173 (1/5)**, based on `main`.

---

<!--
Thanks for contributing! Keep the summary tight and let the diff carry the detail.
Live provider benches and toolchain releases are maintainer-only (Environment `privileged`); a fork
PR runs only the hosted CI gate — see CONTRIBUTING.md and docs/ci-secrets.md.
-->

## Summary

<!-- What changes and why, in a sentence or two. -->

## Type of change

- [ ] Bug fix
- [ ] New provider / suite / metric (see CONTRIBUTING.md)
- [ ] CI / tooling / docs
- [ ] Other

## Checklist

- [ ] `bun run lint`, `bun run typecheck`, and `bun run test` pass locally (the same gate CI runs)
- [ ] `bun run spell` passes (via `mise`), if text changed
- [ ] For PTS-catalog changes: regenerated and `bun run check:catalog-drift` is clean
- [ ] No secrets, `.env` files, or credentials are committed (SECURITY.md)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds community-health basics and a public-facing docs hub to improve onboarding and security, with no runtime code changes. Reworks `README.md` into a clear entry point; the CI-secrets docs link will resolve after the full stack merges.

- **New Features**
  - Added `.github/CODEOWNERS` and `dependabot.yml` (GitHub Actions; grouped bumps).
  - Added `SECURITY.md` and a secret-free `.env.example` for local benches.
  - Expanded `CONTRIBUTING.md` with fork CI steps and local setup guidance.
  - Reworked `README.md` and added `docs/README.md` as a docs hub.
  - Updated `apps/cli/README.md` to include `aggregate`, `leaderboard`, and bench utilities.

<sup>Written for commit 2cf4f6c4f2d722e4b469428a5f6dc7f3f0790bf4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/starslingdev/sandbox-benchmarks/pull/173?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Added a central docs hub and expanded documentation links.
  - Updated README messaging for consistent benchmarking targets and clarified fork/CI and maintainer-only privileged actions.
  - Refreshed contribution and security guidance, including how credentials are handled and how to report vulnerabilities.
  - Updated the CLI README with commands for aggregation, leaderboard output, benchmarking, smoke tests, and stability checks.
- **Chores**
  - Added a tracked `.env.example` template for local benchmarking.
  - Introduced repository code ownership rules and a restricted Dependabot configuration for GitHub Actions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->