### PR TITLE
feat(results): richer leaderboard render with dimension takeaways and target spec

### DIFF
--- a/LEADERBOARD.md
+++ b/LEADERBOARD.md
@@ -2,20 +2,29 @@
 
 Run `29365910084` · commit `0343acb5c1cfd3a0aac81afc3262d4af0fa69bc7` · generated 2026-07-14T22:52:05.191Z
 
-Same pinned target for every provider (**2 vCPU · 8 GiB RAM · 40 GB disk**). Each table ranks providers on that
-dimension's headline metric (median of retained trials). Generated from the published Run
-dataset — do not edit by hand. Methodology: [`docs/methodology.md`](docs/methodology.md).
+Requested target for every provider: **2 vCPU · 8 GiB RAM · 40 GB disk**. This run contains **146 metric records**
+backed by **702 retained trial observations**, across **35 metrics** and
+**5 providers**; every emitted, catalogued metric has a ranked table below
+(median of retained trials), grouped by dimension with its headline first.
+Generated from the published Run dataset — do not edit by hand. Methodology:
+[`docs/methodology.md`](docs/methodology.md).
 
-**How to read:** value = median (p50) · 95% CI = bootstrap around that median · ranks split only
+**How to read:** value = median (p50) · 95% bootstrap interval around that median · ranks split only
 when distributions differ (see details below) · a coverage gap means unmeasured, never a score of zero.
+CPU/RAM comparability uses observed vCPU and RAM (±10% RAM); disk is a workload-capacity gate
+surfaced through coverage gaps, not part of the compute-match verdict.
+
+> **Comparability warning:** Blaxel's observed compute did not match the requested CPU/RAM target; its observed allocation was **6 vCPU · 15.63 GiB RAM · 12.5 GB disk**. Its measured ranks are not like-for-like with compute-matched providers.
 
 ## cpu
 
-Headline: **Node.js web tooling** (runs/s, higher is better)
+### Node.js web tooling _(headline)_
+
+runs/s · higher is better
 
 _Daytona leads · ~1.1× Novita on median (higher is better)._
 
-| Rank | Provider | Node.js web tooling (runs/s) | 95% CI | n |
+| Rank | Provider | Node.js web tooling (runs/s) | 95% bootstrap interval | n |
 | ---: | --- | ---: | ---: | ---: |
 | 1 | Daytona | 19.14 | 18.48 – 19.89 | 5 |
 | 2 | Novita | 17.59 | 17.22 – 18.65 | 5 |
@@ -25,11 +34,13 @@ _Daytona leads · ~1.1× Novita on median (higher is better)._
 
 ## disk
 
-Headline: **fio rand read 4KB, O_DIRECT (IOPS)** (IOPS, higher is better)
+### fio rand read 4KB, O_DIRECT (IOPS) _(headline)_
+
+IOPS · higher is better
 
 _Blaxel leads · ~2.3× Daytona on median (higher is better)._
 
-| Rank | Provider | fio rand read 4KB, O_DIRECT (IOPS) (IOPS) | 95% CI | n |
+| Rank | Provider | fio rand read 4KB, O_DIRECT (IOPS) (IOPS) | 95% bootstrap interval | n |
 | ---: | --- | ---: | ---: | ---: |
 | 1 | Blaxel | 556000 | 549000 – 580000 | 5 |
 | 2 | Daytona | 246000 | 241000 – 255000 | 5 |
@@ -37,13 +48,127 @@ _Blaxel leads · ~2.3× Daytona on median (higher is better)._
 | 4 | E2B | 40800 | 39800 – 42000 | 5 |
 | 5 | Modal | 34900 | 33600 – 35200 | 5 |
 
+### fio rand read 4KB, O_DIRECT (MB/s)
+
+MB/s · higher is better
+
+_Blaxel leads · ~2.3× Daytona on median (higher is better)._
+
+| Rank | Provider | fio rand read 4KB, O_DIRECT (MB/s) (MB/s) | 95% bootstrap interval | n |
+| ---: | --- | ---: | ---: | ---: |
+| 1 | Blaxel | 2173 | 2144 – 2264 | 5 |
+| 2 | Daytona | 960 | 941 – 996 | 5 |
+| 3 | Novita | 266 | 260 – 279 | 5 |
+| 4 | E2B | 159 | 155 – 164 | 5 |
+| 5 | Modal | 136 | 131 – 138 | 5 |
+
+### fio rand write 4KB, O_DIRECT (IOPS)
+
+IOPS · higher is better
+
+_Blaxel leads · ~2.3× Daytona on median (higher is better)._
+
+| Rank | Provider | fio rand write 4KB, O_DIRECT (IOPS) (IOPS) | 95% bootstrap interval | n |
+| ---: | --- | ---: | ---: | ---: |
+| 1 | Blaxel | 492000 | 471000 – 500000 | 5 |
+| 2 | Daytona | 218000 | 213000 – 236000 | 5 |
+| 3 | Novita | 69400 | 67200 – 75500 | 5 |
+| 4 | E2B | 41800 | 40200 – 43300 | 5 |
+| 5 | Modal | 29500 | 29200 – 30000 | 5 |
+
+### fio rand write 4KB, O_DIRECT (MB/s)
+
+MB/s · higher is better
+
+_Blaxel leads · ~2.3× Daytona on median (higher is better)._
+
+| Rank | Provider | fio rand write 4KB, O_DIRECT (MB/s) (MB/s) | 95% bootstrap interval | n |
+| ---: | --- | ---: | ---: | ---: |
+| 1 | Blaxel | 1923 | 1842 – 1955 | 5 |
+| 2 | Daytona | 850 | 833 – 923 | 5 |
+| 3 | Novita | 271 | 263 – 295 | 5 |
+| 4 | E2B | 163 | 157 – 169 | 5 |
+| 5 | Modal | 115 | 114 – 117 | 5 |
+
+### fio seq read 1MB, O_DIRECT (IOPS)
+
+IOPS · higher is better
+
+_Modal, Novita and Daytona share the top on this metric (higher is better)._
+
+| Rank | Provider | fio seq read 1MB, O_DIRECT (IOPS) (IOPS) | 95% bootstrap interval | n | Note |
+| ---: | --- | ---: | ---: | ---: | --- |
+| 1 | Modal | 12300 | 9000 – 13100 | 5 | — |
+| 1 | Novita | 11000 | 9742 – 12300 | 5 | tied |
+| 1 | Daytona | 10800 | 5160 – 15400 | 5 | tied |
+| 4 | Blaxel | 4535 | 4336 – 4815 | 5 | — |
+| 5 | E2B | 600 | 599 – 600 | 5 | — |
+
+### fio seq read 1MB, O_DIRECT (MB/s)
+
+MB/s · higher is better
+
+_Novita leads · ~1.1× Modal on median (higher is better)._
+
+| Rank | Provider | fio seq read 1MB, O_DIRECT (MB/s) (MB/s) | 95% bootstrap interval | n |
+| ---: | --- | ---: | ---: | ---: |
+| 1 | Novita | 9744 | — | 1 |
+| 2 | Modal | 9001 | — | 1 |
+| 3 | Daytona | 5161 | — | 1 |
+| 4 | Blaxel | 4536 | 4338 – 4816 | 5 |
+| 5 | E2B | 601 | 601 – 601 | 5 |
+
+### fio seq write 1MB, O_DIRECT (IOPS)
+
+IOPS · higher is better
+
+_Novita leads · ~1.2× Daytona on median (higher is better)._
+
+| Rank | Provider | fio seq write 1MB, O_DIRECT (IOPS) (IOPS) | 95% bootstrap interval | n | Note |
+| ---: | --- | ---: | ---: | ---: | --- |
+| 1 | Novita | 6435 | 6005 – 6854 | 5 | — |
+| 2 | Daytona | 5188 | 3227 – 5992 | 5 | — |
+| 2 | Blaxel | 3630 | 3486 – 3780 | 5 | tied |
+| 4 | Modal | 2537 | 2230 – 2930 | 5 | — |
+| 5 | E2B | 599 | 599 – 600 | 5 | — |
+
+### fio seq write 1MB, O_DIRECT (MB/s)
+
+MB/s · higher is better
+
+_Novita leads · ~1.2× Daytona on median (higher is better)._
+
+| Rank | Provider | fio seq write 1MB, O_DIRECT (MB/s) (MB/s) | 95% bootstrap interval | n | Note |
+| ---: | --- | ---: | ---: | ---: | --- |
+| 1 | Novita | 6437 | 6006 – 6855 | 5 | — |
+| 2 | Daytona | 5189 | 3228 – 5993 | 5 | — |
+| 2 | Blaxel | 3632 | 3487 – 3782 | 5 | tied |
+| 4 | Modal | 2538 | 2232 – 2932 | 5 | — |
+| 5 | E2B | 601 | 601 – 602 | 5 | — |
+
+### Hardlink throughput
+
+bogo ops/s · higher is better
+
+_Daytona leads · ~1.3× Novita on median (higher is better)._
+
+| Rank | Provider | Hardlink throughput (bogo ops/s) | 95% bootstrap interval | n |
+| ---: | --- | ---: | ---: | ---: |
+| 1 | Daytona | 23.42 | 23.29 – 23.66 | 5 |
+| 2 | Novita | 18.49 | 18.35 – 18.75 | 5 |
+| 3 | Blaxel | 11.53 | 11.49 – 12.07 | 5 |
+| 4 | Modal | 3.22 | 3.09 – 3.28 | 5 |
+| 5 | E2B | 1.5 | 1.46 – 1.5 | 5 |
+
 ## memory
 
-Headline: **STREAM Triad** (MB/s, higher is better)
+### STREAM Triad _(headline)_
 
-_Daytona and Blaxel share the top on this headline (higher is better)._
+MB/s · higher is better
 
-| Rank | Provider | STREAM Triad (MB/s) | 95% CI | n | Note |
+_Daytona and Blaxel share the top on this metric (higher is better)._
+
+| Rank | Provider | STREAM Triad (MB/s) | 95% bootstrap interval | n | Note |
 | ---: | --- | ---: | ---: | ---: | --- |
 | 1 | Daytona | 71508 | 69090 – 78270 | 5 | — |
 | 1 | Blaxel | 70090 | 66760 – 79980 | 5 | tied |
@@ -51,13 +176,57 @@ _Daytona and Blaxel share the top on this headline (higher is better)._
 | 3 | Novita | 53140 | 52970 – 53313 | 5 | tied |
 | 5 | E2B | 23850 | 22450 – 25430 | 5 | — |
 
+### STREAM Add
+
+MB/s · higher is better
+
+_Daytona and Blaxel share the top on this metric (higher is better)._
+
+| Rank | Provider | STREAM Add (MB/s) | 95% bootstrap interval | n | Note |
+| ---: | --- | ---: | ---: | ---: | --- |
+| 1 | Daytona | 73370 | 68930 – 78380 | 5 | — |
+| 1 | Blaxel | 70610 | 66050 – 79130 | 5 | tied |
+| 3 | Novita | 53070 | 52840 – 53350 | 5 | — |
+| 3 | Modal | 52420 | 43647 – 53400 | 5 | tied |
+| 5 | E2B | 23460 | 22180 – 25530 | 5 | — |
+
+### STREAM Copy
+
+MB/s · higher is better
+
+_Blaxel leads · ~1.3× Daytona on median (higher is better)._
+
+| Rank | Provider | STREAM Copy (MB/s) | 95% bootstrap interval | n |
+| ---: | --- | ---: | ---: | ---: |
+| 1 | Blaxel | 110100 | 107500 – 124600 | 5 |
+| 2 | Daytona | 81820 | 79960 – 87430 | 5 |
+| 3 | Modal | 75810 | 65240 – 79250 | 5 |
+| 4 | Novita | 56950 | 56640 – 57050 | 5 |
+| 5 | E2B | 48480 | 43450 – 50283 | 5 |
+
+### STREAM Scale
+
+MB/s · higher is better
+
+_Daytona and Blaxel share the top on this metric (higher is better)._
+
+| Rank | Provider | STREAM Scale (MB/s) | 95% bootstrap interval | n | Note |
+| ---: | --- | ---: | ---: | ---: | --- |
+| 1 | Daytona | 69760 | 63140 – 73820 | 5 | — |
+| 1 | Blaxel | 60580 | 58210 – 72340 | 5 | tied |
+| 3 | Novita | 50510 | 50390 – 50560 | 5 | — |
+| 3 | Modal | 46810 | 35800 – 51220 | 5 | tied |
+| 5 | E2B | 21740 | 21120 – 23930 | 5 | — |
+
 ## network
 
-Headline: **Loopback TCP (10GB)** (Seconds, lower is better)
+### Loopback TCP (10GB) _(headline)_
+
+Seconds · lower is better
 
 _Daytona leads · ~1.5× lower than Blaxel (lower is better)._
 
-| Rank | Provider | Loopback TCP (10GB) (Seconds) | 95% CI | n | Note |
+| Rank | Provider | Loopback TCP (10GB) (Seconds) | 95% bootstrap interval | n | Note |
 | ---: | --- | ---: | ---: | ---: | --- |
 | 1 | Daytona | 4.898 | 4.682 – 5.402 | 5 | — |
 | 2 | Blaxel | 7.252 | 6.38 – 7.791 | 5 | — |
@@ -67,32 +236,255 @@ _Daytona leads · ~1.5× lower than Blaxel (lower is better)._
 
 ## system
 
-Headline: **PyBench** (Milliseconds, lower is better)
+### PyBench _(headline)_
+
+Milliseconds · lower is better
 
 _Blaxel is the only ranked provider (841 Milliseconds; lower is better)._
 
-| Rank | Provider | PyBench (Milliseconds) | 95% CI | n |
+| Rank | Provider | PyBench (Milliseconds) | 95% bootstrap interval | n |
 | ---: | --- | ---: | ---: | ---: |
 | 1 | Blaxel | 841 | 838 – 855 | 5 |
 
+### SQLite Speedtest
+
+Seconds · lower is better
+
+_Daytona leads · ~1.2× lower than Novita (lower is better)._
+
+| Rank | Provider | SQLite Speedtest (Seconds) | 95% bootstrap interval | n |
+| ---: | --- | ---: | ---: | ---: |
+| 1 | Daytona | 34.02 | 33.71 – 34.27 | 5 |
+| 2 | Novita | 41.26 | 41.01 – 41.75 | 5 |
+| 3 | Blaxel | 67.77 | 66.05 – 69.22 | 5 |
+| 4 | E2B | 71.99 | 71.59 – 73.35 | 5 |
+| 5 | Modal | 516.3 | 510 – 539.9 | 5 |
+
 ## realworld
 
-Headline: **Mastra: cold install** (Seconds, lower is better)
+### Mastra: cold install _(headline)_
 
-_Daytona and Novita share the top on this headline (lower is better)._
+Seconds · lower is better
 
-| Rank | Provider | Mastra: cold install (Seconds) | 95% CI | n | Note |
+_Daytona and Novita share the top on this metric (lower is better)._
+
+| Rank | Provider | Mastra: cold install (Seconds) | 95% bootstrap interval | n | Note |
 | ---: | --- | ---: | ---: | ---: | --- |
 | 1 | Daytona | 31.68 | 31.27 – 33.71 | 5 | — |
 | 1 | Novita | 33.12 | 32.84 – 33.84 | 5 | tied |
 
+### Better-Auth: build
+
+Seconds · lower is better
+
+_Blaxel leads · ~1.3× lower than Daytona (lower is better)._
+
+| Rank | Provider | Better-Auth: build (Seconds) | 95% bootstrap interval | n |
+| ---: | --- | ---: | ---: | ---: |
+| 1 | Blaxel | 9.993 | 9.834 – 10.4 | 5 |
+| 2 | Daytona | 12.68 | 12.47 – 12.75 | 5 |
+| 3 | Novita | 14.27 | 14.21 – 14.71 | 5 |
+| 4 | E2B | 22.24 | 22.15 – 22.99 | 5 |
+| 5 | Modal | 39.61 | 37.55 – 40.28 | 5 |
+
+### Better-Auth: cold install
+
+Seconds · lower is better
+
+_Daytona leads · ~1.1× lower than Novita (lower is better)._
+
+| Rank | Provider | Better-Auth: cold install (Seconds) | 95% bootstrap interval | n |
+| ---: | --- | ---: | ---: | ---: |
+| 1 | Daytona | 10.43 | 10.31 – 11.03 | 5 |
+| 2 | Novita | 11.42 | 11.34 – 11.62 | 5 |
+| 3 | Blaxel | 16.11 | 15.64 – 16.21 | 5 |
+| 4 | E2B | 20.08 | 19.88 – 20.28 | 5 |
+| 5 | Modal | 30.84 | 30.2 – 34.26 | 5 |
+
+### Better-Auth: git clone
+
+Seconds · lower is better
+
+_Blaxel, Daytona and E2B share the top on this metric (lower is better)._
+
+| Rank | Provider | Better-Auth: git clone (Seconds) | 95% bootstrap interval | n | Note |
+| ---: | --- | ---: | ---: | ---: | --- |
+| 1 | Blaxel | 1.614 | 1.469 – 1.989 | 5 | — |
+| 1 | Daytona | 1.653 | 1.331 – 1.937 | 5 | tied |
+| 1 | E2B | 1.723 | 1.642 – 1.861 | 5 | tied |
+| 4 | Novita | 2.297 | 1.748 – 318.2 | 5 | — |
+| 4 | Modal | 5.609 | 2.559 – 6.714 | 5 | tied |
+
+### Better-Auth: lint (Biome)
+
+Seconds · lower is better
+
+_Blaxel leads · ~1.4× lower than Daytona (lower is better)._
+
+| Rank | Provider | Better-Auth: lint (Biome) (Seconds) | 95% bootstrap interval | n |
+| ---: | --- | ---: | ---: | ---: |
+| 1 | Blaxel | 3.402 | 3.311 – 3.479 | 5 |
+| 2 | Daytona | 4.881 | 4.851 – 4.904 | 5 |
+| 3 | Novita | 5.301 | 5.28 – 5.429 | 5 |
+| 4 | E2B | 8.622 | 8.489 – 8.657 | 5 |
+| 5 | Modal | 16.36 | 15.72 – 16.66 | 5 |
+
+### Better-Auth: lint deps (Knip)
+
+Seconds · lower is better
+
+_Daytona leads · ~1.1× lower than Novita (lower is better)._
+
+| Rank | Provider | Better-Auth: lint deps (Knip) (Seconds) | 95% bootstrap interval | n |
+| ---: | --- | ---: | ---: | ---: |
+| 1 | Daytona | 10.92 | 10.73 – 11.04 | 5 |
+| 2 | Novita | 11.49 | 11.39 – 11.74 | 5 |
+| 3 | Blaxel | 15.41 | 14.74 – 15.55 | 5 |
+| 4 | E2B | 19.72 | 19.57 – 20.09 | 5 |
+| 5 | Modal | 28.71 | 26.79 – 29.23 | 5 |
+
+### Better-Auth: lint format
+
+Seconds · lower is better
+
+_Daytona leads · ~1.1× lower than Novita (lower is better)._
+
+| Rank | Provider | Better-Auth: lint format (Seconds) | 95% bootstrap interval | n |
+| ---: | --- | ---: | ---: | ---: |
+| 1 | Daytona | 2.785 | 2.7 – 2.901 | 5 |
+| 2 | Novita | 3.008 | 2.904 – 3.026 | 5 |
+| 3 | Blaxel | 4.42 | 4.287 – 4.463 | 5 |
+| 4 | E2B | 5.392 | 5.272 – 5.469 | 5 |
+| 5 | Modal | 6.129 | 6.071 – 6.6 | 5 |
+
+### Better-Auth: lint packages
+
+Seconds · lower is better
+
+_Blaxel leads · ~1.5× lower than Daytona (lower is better)._
+
+| Rank | Provider | Better-Auth: lint packages (Seconds) | 95% bootstrap interval | n |
+| ---: | --- | ---: | ---: | ---: |
+| 1 | Blaxel | 2.794 | 2.697 – 2.859 | 5 |
+| 2 | Daytona | 4.061 | 4.006 – 4.062 | 5 |
+| 3 | Novita | 4.555 | 4.477 – 4.642 | 5 |
+| 4 | E2B | 7.39 | 7.347 – 7.483 | 5 |
+| 5 | Modal | 14.83 | 14.35 – 15.09 | 5 |
+
+### Better-Auth: lint spell
+
+Seconds · lower is better
+
+_Daytona leads · ~1.1× lower than Novita (lower is better)._
+
+| Rank | Provider | Better-Auth: lint spell (Seconds) | 95% bootstrap interval | n |
+| ---: | --- | ---: | ---: | ---: |
+| 1 | Daytona | 6.738 | 6.693 – 6.827 | 5 |
+| 2 | Novita | 7.492 | 7.454 – 7.583 | 5 |
+| 3 | Blaxel | 10.85 | 10.63 – 11.12 | 5 |
+| 4 | E2B | 13.48 | 13.08 – 14.04 | 5 |
+| 5 | Modal | 14.13 | 13.87 – 14.68 | 5 |
+
+### Better-Auth: lint types
+
+Seconds · lower is better
+
+_Blaxel leads · ~1.7× lower than Daytona (lower is better)._
+
+| Rank | Provider | Better-Auth: lint types (Seconds) | 95% bootstrap interval | n |
+| ---: | --- | ---: | ---: | ---: |
+| 1 | Blaxel | 30.17 | 29.43 – 31.45 | 5 |
+| 2 | Daytona | 50.34 | 49.89 – 51.16 | 5 |
+| 3 | Novita | 58.52 | 57.86 – 59.01 | 5 |
+| 4 | E2B | 103.4 | 101.3 – 107.6 | 5 |
+| 5 | Modal | 166 | 162.4 – 170.1 | 5 |
+
+### Better-Auth: typecheck
+
+Seconds · lower is better
+
+_Daytona and Novita share the top on this metric (lower is better)._
+
+| Rank | Provider | Better-Auth: typecheck (Seconds) | 95% bootstrap interval | n | Note |
+| ---: | --- | ---: | ---: | ---: | --- |
+| 1 | Daytona | 1.43 | 1.413 – 1.47 | 5 | — |
+| 1 | Novita | 1.447 | 1.407 – 1.461 | 5 | tied |
+| 3 | Blaxel | 1.72 | 1.673 – 1.778 | 5 | — |
+| 4 | E2B | 2.359 | 2.276 – 2.416 | 5 | — |
+| 5 | Modal | 3.093 | 2.968 – 3.316 | 5 | — |
+
+### Mastra: build:core
+
+Seconds · lower is better
+
+_Daytona leads · ~1.1× lower than Novita (lower is better)._
+
+| Rank | Provider | Mastra: build:core (Seconds) | 95% bootstrap interval | n |
+| ---: | --- | ---: | ---: | ---: |
+| 1 | Daytona | 88.35 | 87.2 – 88.81 | 5 |
+| 2 | Novita | 94.01 | 93.5 – 94.85 | 5 |
+
+### Mastra: git clone
+
+Seconds · lower is better
+
+_Daytona and Novita share the top on this metric (lower is better)._
+
+| Rank | Provider | Mastra: git clone (Seconds) | 95% bootstrap interval | n | Note |
+| ---: | --- | ---: | ---: | ---: | --- |
+| 1 | Daytona | 6.36 | 2.617 – 6.993 | 5 | — |
+| 1 | Novita | 6.844 | 3.157 – 7.166 | 5 | tied |
+
+### Mastra: lint:format
+
+Seconds · lower is better
+
+_Daytona leads · ~1.1× lower than Novita (lower is better)._
+
+| Rank | Provider | Mastra: lint:format (Seconds) | 95% bootstrap interval | n |
+| ---: | --- | ---: | ---: | ---: |
+| 1 | Daytona | 92.22 | 91.09 – 93.24 | 5 |
+| 2 | Novita | 97.96 | 96.87 – 99.5 | 5 |
+
+### OpenClaw: cold install
+
+Seconds · lower is better
+
+_Novita is the only ranked provider (7.025 Seconds; lower is better)._
+
+| Rank | Provider | OpenClaw: cold install (Seconds) | 95% bootstrap interval | n |
+| ---: | --- | ---: | ---: | ---: |
+| 1 | Novita | 7.025 | 6.871 – 7.463 | 5 |
+
+### OpenClaw: git clone
+
+Seconds · lower is better
+
+_Novita is the only ranked provider (9.353 Seconds; lower is better)._
+
+| Rank | Provider | OpenClaw: git clone (Seconds) | 95% bootstrap interval | n |
+| ---: | --- | ---: | ---: | ---: |
+| 1 | Novita | 9.353 | 4.083 – 11.68 | 5 |
+
+### OpenClaw: typecheck (tsgo)
+
+Seconds · lower is better
+
+_Novita is the only ranked provider (49.13 Seconds; lower is better)._
+
+| Rank | Provider | OpenClaw: typecheck (tsgo) (Seconds) | 95% bootstrap interval | n |
+| ---: | --- | ---: | ---: | ---: |
+| 1 | Novita | 49.13 | 47.39 – 50.68 | 5 |
+
 ## economics
 
-Headline: **Hourly cost** (USD/hr, lower is better)
+### Hourly cost _(headline)_
+
+USD/hr · lower is better
 
 _Daytona is cheapest · ~1.1× lower than Novita (lower is better)._
 
-| Rank | Provider | Hourly cost (USD/hr) | 95% CI | n |
+| Rank | Provider | Hourly cost (USD/hr) | 95% bootstrap interval | n |
 | ---: | --- | ---: | ---: | ---: |
 | 1 | Daytona | 0.1494 | — | 1 |
 | 2 | Novita | 0.1627 | — | 1 |
@@ -134,9 +526,10 @@ Unlike a skip, this is a reliability fact about the provider, not a decision mad
 <summary>How rankings are decided</summary>
 
 The value is the median (p50) of the retained per-trial Samples, not the mean — a single stalled
-pass drags a mean far more than it moves a median. The 95% CI is a percentile bootstrap of that
-median (10,000 resamples, seeded from the Run id so the table is reproducible byte-for-byte), not
-a normal-theory interval: these Samples are neither normal nor independent of the host's scheduling.
+pass drags a mean far more than it moves a median. The 95% interval is a percentile bootstrap of
+that median (10,000 resamples, seeded from the Run id so the table is reproducible byte-for-byte).
+It is a descriptive interval conditional on the retained trials, **not a calibrated frequentist
+confidence interval**: n is small and within-sandbox trials may be dependent on host scheduling.
 
 Rows are separated only when Mann-Whitney U (two-sided, α = 0.05, enumerated exactly
 over the permutation null rather than approximated) finds a shift in central tendency — at these
@@ -149,7 +542,7 @@ inside the noise is not a faster provider. This is the only note that claims two
 statistically indistinguishable.
 
 Samples are repeated trials inside one sandbox, so their spread is environmental (neighbours, host
-contention, virtualization), and a wide CI or a large `n` (the harness re-runs a test that will not
+contention, virtualization), and a wide bootstrap interval or a large `n` (the harness re-runs a test that will not
 converge) is itself the signal that the provider's performance is unstable, not that the measurement
 is imprecise.
 
@@ -161,36 +554,157 @@ separate*, never *the providers are equal*.
 `p vs. above` is Mann-Whitney (drives rank). `p (KS)` is Kolmogorov-Smirnov on distribution
 *shape* — it does not drive the ranking. A tied Mann-Whitney beside a small KS often means the
 same typical speed with different behaviour (e.g. bimodal stalls).
+These are unadjusted, exploratory per-comparison p-values; no family-wise or false-discovery-rate
+correction is applied across providers or metrics.
 
-| Dimension | Provider | p vs. above | p (KS) |
-| --- | --- | ---: | ---: |
-| cpu | Daytona | — | — |
-| cpu | Novita | 0.016 | 0.036 |
-| cpu | Blaxel | 0.0079 | 0.0038 |
-| cpu | E2B | 0.0079 | 0.0038 |
-| cpu | Modal | 0.0079 | 0.0038 |
-| disk | Blaxel | — | — |
-| disk | Daytona | 0.0079 | 0.0038 |
-| disk | Novita | 0.0079 | 0.0038 |
-| disk | E2B | 0.0079 | 0.0038 |
-| disk | Modal | 0.0079 | 0.0038 |
-| memory | Daytona | — | — |
-| memory | Blaxel | 0.55 (tied) | 0.70 |
-| memory | Modal | 0.0079 | 0.0038 |
-| memory | Novita | 0.69 (tied) | 0.21 |
-| memory | E2B | 0.0079 | 0.0038 |
-| network | Daytona | — | — |
-| network | Blaxel | 0.0079 | 0.0038 |
-| network | E2B | 0.095 (tied) | 0.21 |
-| network | Novita | 0.0079 | 0.0038 |
-| network | Modal | 0.0079 | 0.0038 |
-| system | Blaxel | — | — |
-| realworld | Daytona | — | — |
-| realworld | Novita | 0.095 (tied) | 0.036 |
-| economics | Daytona | — | — |
-| economics | Novita | — | — |
-| economics | E2B | — | — |
-| economics | Modal | — | — |
+| Dimension | Metric | Provider | p vs. above | p (KS) |
+| --- | --- | --- | ---: | ---: |
+| cpu | Node.js web tooling | Daytona | — | — |
+| cpu | Node.js web tooling | Novita | 0.016 | 0.036 |
+| cpu | Node.js web tooling | Blaxel | 0.0079 | 0.0038 |
+| cpu | Node.js web tooling | E2B | 0.0079 | 0.0038 |
+| cpu | Node.js web tooling | Modal | 0.0079 | 0.0038 |
+| disk | fio rand read 4KB, O_DIRECT (IOPS) | Blaxel | — | — |
+| disk | fio rand read 4KB, O_DIRECT (IOPS) | Daytona | 0.0079 | 0.0038 |
+| disk | fio rand read 4KB, O_DIRECT (IOPS) | Novita | 0.0079 | 0.0038 |
+| disk | fio rand read 4KB, O_DIRECT (IOPS) | E2B | 0.0079 | 0.0038 |
+| disk | fio rand read 4KB, O_DIRECT (IOPS) | Modal | 0.0079 | 0.0038 |
+| disk | fio rand read 4KB, O_DIRECT (MB/s) | Blaxel | — | — |
+| disk | fio rand read 4KB, O_DIRECT (MB/s) | Daytona | 0.0079 | 0.0038 |
+| disk | fio rand read 4KB, O_DIRECT (MB/s) | Novita | 0.0079 | 0.0038 |
+| disk | fio rand read 4KB, O_DIRECT (MB/s) | E2B | 0.0079 | 0.0038 |
+| disk | fio rand read 4KB, O_DIRECT (MB/s) | Modal | 0.0079 | 0.0038 |
+| disk | fio rand write 4KB, O_DIRECT (IOPS) | Blaxel | — | — |
+| disk | fio rand write 4KB, O_DIRECT (IOPS) | Daytona | 0.0079 | 0.0038 |
+| disk | fio rand write 4KB, O_DIRECT (IOPS) | Novita | 0.0079 | 0.0038 |
+| disk | fio rand write 4KB, O_DIRECT (IOPS) | E2B | 0.0079 | 0.0038 |
+| disk | fio rand write 4KB, O_DIRECT (IOPS) | Modal | 0.0079 | 0.0038 |
+| disk | fio rand write 4KB, O_DIRECT (MB/s) | Blaxel | — | — |
+| disk | fio rand write 4KB, O_DIRECT (MB/s) | Daytona | 0.0079 | 0.0038 |
+| disk | fio rand write 4KB, O_DIRECT (MB/s) | Novita | 0.0079 | 0.0038 |
+| disk | fio rand write 4KB, O_DIRECT (MB/s) | E2B | 0.0079 | 0.0038 |
+| disk | fio rand write 4KB, O_DIRECT (MB/s) | Modal | 0.0079 | 0.0038 |
+| disk | fio seq read 1MB, O_DIRECT (IOPS) | Modal | — | — |
+| disk | fio seq read 1MB, O_DIRECT (IOPS) | Novita | 0.38 (tied) | 0.70 |
+| disk | fio seq read 1MB, O_DIRECT (IOPS) | Daytona | 0.89 (tied) | 0.70 |
+| disk | fio seq read 1MB, O_DIRECT (IOPS) | Blaxel | 0.0079 | 0.0038 |
+| disk | fio seq read 1MB, O_DIRECT (IOPS) | E2B | 0.0079 | 0.0038 |
+| disk | fio seq read 1MB, O_DIRECT (MB/s) | Novita | — | — |
+| disk | fio seq read 1MB, O_DIRECT (MB/s) | Modal | — | — |
+| disk | fio seq read 1MB, O_DIRECT (MB/s) | Daytona | — | — |
+| disk | fio seq read 1MB, O_DIRECT (MB/s) | Blaxel | — | — |
+| disk | fio seq read 1MB, O_DIRECT (MB/s) | E2B | 0.0079 | 0.0038 |
+| disk | fio seq write 1MB, O_DIRECT (IOPS) | Novita | — | — |
+| disk | fio seq write 1MB, O_DIRECT (IOPS) | Daytona | 0.0079 | 0.0038 |
+| disk | fio seq write 1MB, O_DIRECT (IOPS) | Blaxel | 0.42 (tied) | 0.21 |
+| disk | fio seq write 1MB, O_DIRECT (IOPS) | Modal | 0.0079 | 0.0038 |
+| disk | fio seq write 1MB, O_DIRECT (IOPS) | E2B | 0.0079 | 0.0038 |
+| disk | fio seq write 1MB, O_DIRECT (MB/s) | Novita | — | — |
+| disk | fio seq write 1MB, O_DIRECT (MB/s) | Daytona | 0.0079 | 0.0038 |
+| disk | fio seq write 1MB, O_DIRECT (MB/s) | Blaxel | 0.42 (tied) | 0.21 |
+| disk | fio seq write 1MB, O_DIRECT (MB/s) | Modal | 0.0079 | 0.0038 |
+| disk | fio seq write 1MB, O_DIRECT (MB/s) | E2B | 0.0079 | 0.0038 |
+| disk | Hardlink throughput | Daytona | — | — |
+| disk | Hardlink throughput | Novita | 0.0079 | 0.0038 |
+| disk | Hardlink throughput | Blaxel | 0.0079 | 0.0038 |
+| disk | Hardlink throughput | Modal | 0.0079 | 0.0038 |
+| disk | Hardlink throughput | E2B | 0.0079 | 0.0038 |
+| memory | STREAM Triad | Daytona | — | — |
+| memory | STREAM Triad | Blaxel | 0.55 (tied) | 0.70 |
+| memory | STREAM Triad | Modal | 0.0079 | 0.0038 |
+| memory | STREAM Triad | Novita | 0.69 (tied) | 0.21 |
+| memory | STREAM Triad | E2B | 0.0079 | 0.0038 |
+| memory | STREAM Add | Daytona | — | — |
+| memory | STREAM Add | Blaxel | 0.69 (tied) | 0.70 |
+| memory | STREAM Add | Novita | 0.0079 | 0.0038 |
+| memory | STREAM Add | Modal | 0.15 (tied) | 0.036 |
+| memory | STREAM Add | E2B | 0.0079 | 0.0038 |
+| memory | STREAM Copy | Blaxel | — | — |
+| memory | STREAM Copy | Daytona | 0.0079 | 0.0038 |
+| memory | STREAM Copy | Modal | 0.0079 | 0.0038 |
+| memory | STREAM Copy | Novita | 0.0079 | 0.0038 |
+| memory | STREAM Copy | E2B | 0.0079 | 0.0038 |
+| memory | STREAM Scale | Daytona | — | — |
+| memory | STREAM Scale | Blaxel | 0.056 (tied) | 0.036 |
+| memory | STREAM Scale | Novita | 0.0079 | 0.0038 |
+| memory | STREAM Scale | Modal | 0.15 (tied) | 0.036 |
+| memory | STREAM Scale | E2B | 0.0079 | 0.0038 |
+| network | Loopback TCP (10GB) | Daytona | — | — |
+| network | Loopback TCP (10GB) | Blaxel | 0.0079 | 0.0038 |
+| network | Loopback TCP (10GB) | E2B | 0.095 (tied) | 0.21 |
+| network | Loopback TCP (10GB) | Novita | 0.0079 | 0.0038 |
+| network | Loopback TCP (10GB) | Modal | 0.0079 | 0.0038 |
+| system | PyBench | Blaxel | — | — |
+| system | SQLite Speedtest | Daytona | — | — |
+| system | SQLite Speedtest | Novita | 0.0079 | 0.0038 |
+| system | SQLite Speedtest | Blaxel | 0.0079 | 0.0038 |
+| system | SQLite Speedtest | E2B | 0.0079 | 0.0038 |
+| system | SQLite Speedtest | Modal | 0.0079 | 0.0038 |
+| realworld | Mastra: cold install | Daytona | — | — |
+| realworld | Mastra: cold install | Novita | 0.095 (tied) | 0.036 |
+| realworld | Better-Auth: build | Blaxel | — | — |
+| realworld | Better-Auth: build | Daytona | 0.0079 | 0.0038 |
+| realworld | Better-Auth: build | Novita | 0.0079 | 0.0038 |
+| realworld | Better-Auth: build | E2B | 0.0079 | 0.0038 |
+| realworld | Better-Auth: build | Modal | 0.0079 | 0.0038 |
+| realworld | Better-Auth: cold install | Daytona | — | — |
+| realworld | Better-Auth: cold install | Novita | 0.0079 | 0.0038 |
+| realworld | Better-Auth: cold install | Blaxel | 0.0079 | 0.0038 |
+| realworld | Better-Auth: cold install | E2B | 0.0079 | 0.0038 |
+| realworld | Better-Auth: cold install | Modal | 0.0079 | 0.0038 |
+| realworld | Better-Auth: git clone | Blaxel | — | — |
+| realworld | Better-Auth: git clone | Daytona | 1.0 (tied) | 0.70 |
+| realworld | Better-Auth: git clone | E2B | 0.69 (tied) | 0.70 |
+| realworld | Better-Auth: git clone | Novita | 0.032 | 0.036 |
+| realworld | Better-Auth: git clone | Modal | 0.69 (tied) | 0.21 |
+| realworld | Better-Auth: lint (Biome) | Blaxel | — | — |
+| realworld | Better-Auth: lint (Biome) | Daytona | 0.0079 | 0.0038 |
+| realworld | Better-Auth: lint (Biome) | Novita | 0.0079 | 0.0038 |
+| realworld | Better-Auth: lint (Biome) | E2B | 0.0079 | 0.0038 |
+| realworld | Better-Auth: lint (Biome) | Modal | 0.0079 | 0.0038 |
+| realworld | Better-Auth: lint deps (Knip) | Daytona | — | — |
+| realworld | Better-Auth: lint deps (Knip) | Novita | 0.0079 | 0.0038 |
+| realworld | Better-Auth: lint deps (Knip) | Blaxel | 0.0079 | 0.0038 |
+| realworld | Better-Auth: lint deps (Knip) | E2B | 0.0079 | 0.0038 |
+| realworld | Better-Auth: lint deps (Knip) | Modal | 0.0079 | 0.0038 |
+| realworld | Better-Auth: lint format | Daytona | — | — |
+| realworld | Better-Auth: lint format | Novita | 0.0079 | 0.0038 |
+| realworld | Better-Auth: lint format | Blaxel | 0.0079 | 0.0038 |
+| realworld | Better-Auth: lint format | E2B | 0.0079 | 0.0038 |
+| realworld | Better-Auth: lint format | Modal | 0.0079 | 0.0038 |
+| realworld | Better-Auth: lint packages | Blaxel | — | — |
+| realworld | Better-Auth: lint packages | Daytona | 0.0079 | 0.0038 |
+| realworld | Better-Auth: lint packages | Novita | 0.0079 | 0.0038 |
+| realworld | Better-Auth: lint packages | E2B | 0.0079 | 0.0038 |
+| realworld | Better-Auth: lint packages | Modal | 0.0079 | 0.0038 |
+| realworld | Better-Auth: lint spell | Daytona | — | — |
+| realworld | Better-Auth: lint spell | Novita | 0.0079 | 0.0038 |
+| realworld | Better-Auth: lint spell | Blaxel | 0.0079 | 0.0038 |
+| realworld | Better-Auth: lint spell | E2B | 0.0079 | 0.0038 |
+| realworld | Better-Auth: lint spell | Modal | 0.032 | 0.036 |
+| realworld | Better-Auth: lint types | Blaxel | — | — |
+| realworld | Better-Auth: lint types | Daytona | 0.0079 | 0.0038 |
+| realworld | Better-Auth: lint types | Novita | 0.0079 | 0.0038 |
+| realworld | Better-Auth: lint types | E2B | 0.0079 | 0.0038 |
+| realworld | Better-Auth: lint types | Modal | 0.0079 | 0.0038 |
+| realworld | Better-Auth: typecheck | Daytona | — | — |
+| realworld | Better-Auth: typecheck | Novita | 0.55 (tied) | 0.21 |
+| realworld | Better-Auth: typecheck | Blaxel | 0.0079 | 0.0038 |
+| realworld | Better-Auth: typecheck | E2B | 0.0079 | 0.0038 |
+| realworld | Better-Auth: typecheck | Modal | 0.0079 | 0.0038 |
+| realworld | Mastra: build:core | Daytona | — | — |
+| realworld | Mastra: build:core | Novita | 0.0079 | 0.0038 |
+| realworld | Mastra: git clone | Daytona | — | — |
+| realworld | Mastra: git clone | Novita | 0.22 (tied) | 0.21 |
+| realworld | Mastra: lint:format | Daytona | — | — |
+| realworld | Mastra: lint:format | Novita | 0.0079 | 0.0038 |
+| realworld | OpenClaw: cold install | Novita | — | — |
+| realworld | OpenClaw: git clone | Novita | — | — |
+| realworld | OpenClaw: typecheck (tsgo) | Novita | — | — |
+| economics | Hourly cost | Daytona | — | — |
+| economics | Hourly cost | Novita | — | — |
+| economics | Hourly cost | E2B | — | — |
+| economics | Hourly cost | Modal | — | — |
 
 </details>
 

--- a/LEADERBOARD.md
+++ b/LEADERBOARD.md
@@ -1,101 +1,196 @@
 # Sandbox provider leaderboard
 
-Run `29130741476` · commit `663be0904797890a24fdaf1cc6e3ea8d77b3b89c` · generated 2026-07-11T00:18:19.295Z
+Run `29365910084` · commit `0343acb5c1cfd3a0aac81afc3262d4af0fa69bc7` · generated 2026-07-14T22:52:05.191Z
 
-Each table ranks the providers on that dimension's headline metric. Generated from the published Run dataset — do not edit by hand.
+Same pinned target for every provider (**2 vCPU · 8 GiB RAM · 40 GB disk**). Each table ranks providers on that
+dimension's headline metric (median of retained trials). Generated from the published Run
+dataset — do not edit by hand. Methodology: [`docs/methodology.md`](docs/methodology.md).
+
+**How to read:** value = median (p50) · 95% CI = bootstrap around that median · ranks split only
+when distributions differ (see details below) · a coverage gap means unmeasured, never a score of zero.
 
 ## cpu
 
 Headline: **Node.js web tooling** (runs/s, higher is better)
 
-| Rank | Provider | Node.js web tooling (runs/s) | 95% CI | n | p vs. above | p (KS) |
-| ---: | --- | ---: | ---: | ---: | ---: | ---: |
-| 1 | Daytona | 19.72 | 19.63 – 19.96 | 3 | — | — |
-| 2 | Modal | 9.59 | 9.52 – 9.79 | 3 | 0.10 (n too small) | 0.033 |
+_Daytona leads · ~1.1× Novita on median (higher is better)._
+
+| Rank | Provider | Node.js web tooling (runs/s) | 95% CI | n |
+| ---: | --- | ---: | ---: | ---: |
+| 1 | Daytona | 19.14 | 18.48 – 19.89 | 5 |
+| 2 | Novita | 17.59 | 17.22 – 18.65 | 5 |
+| 3 | Blaxel | 14.01 | 13.64 – 14.25 | 5 |
+| 4 | E2B | 10.58 | 10.25 – 10.83 | 5 |
+| 5 | Modal | 9.25 | 8.7 – 9.58 | 5 |
+
+## disk
+
+Headline: **fio rand read 4KB, O_DIRECT (IOPS)** (IOPS, higher is better)
+
+_Blaxel leads · ~2.3× Daytona on median (higher is better)._
+
+| Rank | Provider | fio rand read 4KB, O_DIRECT (IOPS) (IOPS) | 95% CI | n |
+| ---: | --- | ---: | ---: | ---: |
+| 1 | Blaxel | 556000 | 549000 – 580000 | 5 |
+| 2 | Daytona | 246000 | 241000 – 255000 | 5 |
+| 3 | Novita | 68100 | 66600 – 71500 | 5 |
+| 4 | E2B | 40800 | 39800 – 42000 | 5 |
+| 5 | Modal | 34900 | 33600 – 35200 | 5 |
 
 ## memory
 
 Headline: **STREAM Triad** (MB/s, higher is better)
 
-| Rank | Provider | STREAM Triad (MB/s) | 95% CI | n | p vs. above | p (KS) |
-| ---: | --- | ---: | ---: | ---: | ---: | ---: |
-| 1 | Daytona | 54530 | 54030 – 54590 | 5 | — | — |
-| 2 | Modal | 40510 | 38810 – 53440 | 5 | 0.0079 | 0.0038 |
+_Daytona and Blaxel share the top on this headline (higher is better)._
+
+| Rank | Provider | STREAM Triad (MB/s) | 95% CI | n | Note |
+| ---: | --- | ---: | ---: | ---: | --- |
+| 1 | Daytona | 71508 | 69090 – 78270 | 5 | — |
+| 1 | Blaxel | 70090 | 66760 – 79980 | 5 | tied |
+| 3 | Modal | 53700 | 45390 – 57730 | 5 | — |
+| 3 | Novita | 53140 | 52970 – 53313 | 5 | tied |
+| 5 | E2B | 23850 | 22450 – 25430 | 5 | — |
+
+## network
+
+Headline: **Loopback TCP (10GB)** (Seconds, lower is better)
+
+_Daytona leads · ~1.5× lower than Blaxel (lower is better)._
+
+| Rank | Provider | Loopback TCP (10GB) (Seconds) | 95% CI | n | Note |
+| ---: | --- | ---: | ---: | ---: | --- |
+| 1 | Daytona | 4.898 | 4.682 – 5.402 | 5 | — |
+| 2 | Blaxel | 7.252 | 6.38 – 7.791 | 5 | — |
+| 2 | E2B | 7.764 | 7.373 – 8.467 | 5 | tied |
+| 4 | Novita | 11.32 | 10.03 – 11.45 | 5 | — |
+| 5 | Modal | 52.14 | 51.04 – 55.37 | 5 | — |
+
+## system
+
+Headline: **PyBench** (Milliseconds, lower is better)
+
+_Blaxel is the only ranked provider (841 Milliseconds; lower is better)._
+
+| Rank | Provider | PyBench (Milliseconds) | 95% CI | n |
+| ---: | --- | ---: | ---: | ---: |
+| 1 | Blaxel | 841 | 838 – 855 | 5 |
+
+## realworld
+
+Headline: **Mastra: cold install** (Seconds, lower is better)
+
+_Daytona and Novita share the top on this headline (lower is better)._
+
+| Rank | Provider | Mastra: cold install (Seconds) | 95% CI | n | Note |
+| ---: | --- | ---: | ---: | ---: | --- |
+| 1 | Daytona | 31.68 | 31.27 – 33.71 | 5 | — |
+| 1 | Novita | 33.12 | 32.84 – 33.84 | 5 | tied |
 
 ## economics
 
 Headline: **Hourly cost** (USD/hr, lower is better)
 
-| Rank | Provider | Hourly cost (USD/hr) | 95% CI | n | p vs. above | p (KS) |
-| ---: | --- | ---: | ---: | ---: | ---: | ---: |
-| 1 | Daytona | 0.1494 | — | 1 | — | — |
-| 2 | Modal | 0.4774 | — | 1 | — | — |
+_Daytona is cheapest · ~1.1× lower than Novita (lower is better)._
+
+| Rank | Provider | Hourly cost (USD/hr) | 95% CI | n |
+| ---: | --- | ---: | ---: | ---: |
+| 1 | Daytona | 0.1494 | — | 1 |
+| 2 | Novita | 0.1627 | — | 1 |
+| 3 | E2B | 0.2304 | — | 1 |
+| 4 | Modal | 0.4774 | — | 1 |
 
 ## Coverage gaps
 
-Benchmarks that produced **no result** on a provider. A gap is a missing result, not a comparable
-one — read it as the provider **failing to cover** that workload, never as a tie or a zero.
+12 uncovered results across 5 providers (Blaxel 3, Daytona 2, E2B 3, Modal 3, Novita 1). A gap is a missing result — the provider **failing to cover** that workload — never a tie or a zero.
+
+<details>
+<summary>Full coverage table</summary>
 
 | Provider | Benchmark | Outcome | Detail |
 | --- | --- | --- | --- |
-| Daytona | realworld-mastra | ❌ **disk** (skipped) | Insufficient disk: 16.7 GiB free, suite needs 30 GiB |
-| Daytona | realworld-openclaw | ❌ **disk** (skipped) | Insufficient disk: 16.7 GiB free, suite needs 25 GiB |
-| Blaxel | cpu-node | **missing** | No result and no marker — the suite never reported for this provider. |
-| Blaxel | disk | **missing** | No result and no marker — the suite never reported for this provider. |
-| Blaxel | memory | **missing** | No result and no marker — the suite never reported for this provider. |
-| Blaxel | realworld-better-auth | **missing** | No result and no marker — the suite never reported for this provider. |
-| Blaxel | realworld-mastra | **missing** | No result and no marker — the suite never reported for this provider. |
-| Blaxel | realworld-openclaw | **missing** | No result and no marker — the suite never reported for this provider. |
-| E2B | cpu-node | **missing** | No result and no marker — the suite never reported for this provider. |
-| E2B | disk | **missing** | No result and no marker — the suite never reported for this provider. |
-| E2B | memory | **missing** | No result and no marker — the suite never reported for this provider. |
-| E2B | realworld-better-auth | **missing** | No result and no marker — the suite never reported for this provider. |
-| E2B | realworld-mastra | **missing** | No result and no marker — the suite never reported for this provider. |
-| E2B | realworld-openclaw | **missing** | No result and no marker — the suite never reported for this provider. |
-| Modal | realworld-mastra | **missing** | No result and no marker — the suite never reported for this provider. |
-| Modal | realworld-openclaw | **missing** | No result and no marker — the suite never reported for this provider. |
+| Blaxel | realworld-mastra | ❌ **disk** (skipped) | Insufficient disk: 12.5 GiB free, suite needs 30 GiB |
+| Blaxel | realworld-openclaw | ❌ **disk** (skipped) | Insufficient disk: 12.5 GiB free, suite needs 25 GiB |
+| E2B | realworld-mastra | ❌ **disk** (skipped) | Insufficient disk: 19.7 GiB free, suite needs 30 GiB |
+| E2B | realworld-openclaw | ❌ **disk** (skipped) | Insufficient disk: 19.7 GiB free, suite needs 25 GiB |
+| Blaxel | cpu-generic | **failed** | Step "mise run benchmark:cpu:generic" timed out after 7800s |
+| Daytona | cpu-generic | **failed** | Step "mise run benchmark:cpu:generic" timed out after 7800s |
+| Daytona | realworld-openclaw | **failed** | Step "mise run benchmark:realworld:pts:openclaw" lost its sandbox: 12 consecutive detached polls failed (last: done-file fs exists) — the sandbox stopped responding, not a quiet long step |
+| E2B | cpu-generic | **failed** | Step "mise run benchmark:cpu:generic" timed out after 7800s |
+| Modal | cpu-generic | **failed** | Step "mise run benchmark:cpu:generic" timed out after 7800s |
+| Modal | realworld-mastra | **failed** | Step "mise run benchmark:realworld:pts:mastra" timed out after 8400s |
+| Modal | realworld-openclaw | **failed** | Step "mise run benchmark:realworld:pts:openclaw" timed out after 8400s |
+| Novita | cpu-generic | **failed** | Step "mise run benchmark:cpu:generic" timed out after 7800s |
 
 **skipped** — a precondition said no before the benchmark was attempted. A ❌ **disk** skip is the
 loud one: the provider could not supply the disk the suite needs, so the workload does not run on
 its current allocation at all. That is a structural absence, not a slow result.
 
-**missing** — nothing was reported at all: no result, and no marker explaining why. The suite ran
-elsewhere in this run, so it was part of the comparison, and this provider is simply absent from
-it — a dropped job, a lost artifact, or a sandbox that died before it could say anything. Treat it
-as unmeasured, never as a pass: the provider has not been shown to run this workload.
+**failed** — the benchmark was attempted and broke: it threw, timed out, or died with the sandbox.
+Unlike a skip, this is a reliability fact about the provider, not a decision made on its behalf.
 
----
+</details>
 
-**Reading this table.** The value is the median (p50) of the retained per-trial Samples, not the
-mean — a single stalled pass drags a mean far more than it moves a median. The 95% CI is a
-percentile bootstrap of that median (10,000 resamples, seeded from the Run id so the table is
-reproducible byte-for-byte), not a normal-theory interval: these Samples are neither normal nor
-independent of the host's scheduling.
+<details>
+<summary>How rankings are decided</summary>
 
-Rows are separated only when their full Sample distributions differ (Mann-Whitney U, two-sided, α = 0.05,
-enumerated exactly over the permutation null rather than approximated — at these sample sizes the
-normal approximation can report a p the exact test cannot actually produce).
+The value is the median (p50) of the retained per-trial Samples, not the mean — a single stalled
+pass drags a mean far more than it moves a median. The 95% CI is a percentile bootstrap of that
+median (10,000 resamples, seeded from the Run id so the table is reproducible byte-for-byte), not
+a normal-theory interval: these Samples are neither normal nor independent of the host's scheduling.
+
+Rows are separated only when Mann-Whitney U (two-sided, α = 0.05, enumerated exactly
+over the permutation null rather than approximated) finds a shift in central tendency — at these
+sample sizes the normal approximation can report a p the exact test cannot actually produce. KS is
+reported separately for distribution *shape* and does not drive the ranking.
+
+**A Note cell always says why a rank is shared, and the reasons are not interchangeable.**
+`tied` — the test could have separated those providers and did not, so a faster median earned
+inside the noise is not a faster provider. This is the only note that claims two providers are
+statistically indistinguishable.
 
 Samples are repeated trials inside one sandbox, so their spread is environmental (neighbours, host
 contention, virtualization), and a wide CI or a large `n` (the harness re-runs a test that will not
 converge) is itself the signal that the provider's performance is unstable, not that the measurement
 is imprecise.
 
-`p (KS)` is a two-sample Kolmogorov-Smirnov test against the same row above. It does **not** drive
-the ranking — it compares the two empirical distributions' *shapes* rather than their central
-tendency. Read it where it disagrees with `p vs. above`: a tied rank (large Mann-Whitney p) beside a
-small `p (KS)` means two providers with the same typical speed but different behaviour — usually one
-of them alternating between fast and stalled passes. That bimodality is what environmental noise
-looks like, and it is the reason a median alone cannot rank these providers.
-
 At the small `n` this suite produces, a non-significant result means *not enough evidence to
 separate*, never *the providers are equal*.
 
-`n too small` is the extreme of that: Mann-Whitney's best attainable p already exceeds α for those
-Samples, so the test could not have separated the rows at any effect size (here 3 v 3 floors at p ≈ 0.10).
-Such rows are ranked on their observed medians and are **not** claimed to be tied — read the gap
-between the values, and treat the p-value as unable to settle them either way. Where such a row
-nevertheless shares the rank above it, the cell reads `equal medians`: the two values are simply
-identical, which is the ranking having nothing to order them by — never a finding that the
-providers are alike.
+### Pairwise tests (vs. row above)
+
+`p vs. above` is Mann-Whitney (drives rank). `p (KS)` is Kolmogorov-Smirnov on distribution
+*shape* — it does not drive the ranking. A tied Mann-Whitney beside a small KS often means the
+same typical speed with different behaviour (e.g. bimodal stalls).
+
+| Dimension | Provider | p vs. above | p (KS) |
+| --- | --- | ---: | ---: |
+| cpu | Daytona | — | — |
+| cpu | Novita | 0.016 | 0.036 |
+| cpu | Blaxel | 0.0079 | 0.0038 |
+| cpu | E2B | 0.0079 | 0.0038 |
+| cpu | Modal | 0.0079 | 0.0038 |
+| disk | Blaxel | — | — |
+| disk | Daytona | 0.0079 | 0.0038 |
+| disk | Novita | 0.0079 | 0.0038 |
+| disk | E2B | 0.0079 | 0.0038 |
+| disk | Modal | 0.0079 | 0.0038 |
+| memory | Daytona | — | — |
+| memory | Blaxel | 0.55 (tied) | 0.70 |
+| memory | Modal | 0.0079 | 0.0038 |
+| memory | Novita | 0.69 (tied) | 0.21 |
+| memory | E2B | 0.0079 | 0.0038 |
+| network | Daytona | — | — |
+| network | Blaxel | 0.0079 | 0.0038 |
+| network | E2B | 0.095 (tied) | 0.21 |
+| network | Novita | 0.0079 | 0.0038 |
+| network | Modal | 0.0079 | 0.0038 |
+| system | Blaxel | — | — |
+| realworld | Daytona | — | — |
+| realworld | Novita | 0.095 (tied) | 0.036 |
+| economics | Daytona | — | — |
+| economics | Novita | — | — |
+| economics | E2B | — | — |
+| economics | Modal | — | — |
+
+</details>
 

--- a/docs/methodology.md
+++ b/docs/methodology.md
@@ -12,7 +12,7 @@ schema-validated dataset.
 ## Target spec
 
 Every provider is created at one pinned [`TARGET_SPEC`](../packages/schema/src/providers.ts): **2 vCPU,
-8 GiB RAM, 20 GB disk**. It's sized to fit inside every provider's reproducible envelope (E2B caps
+8 GiB RAM, 40 GB disk**. It's sized to fit inside every provider's reproducible envelope (E2B caps
 sandbox RAM at 8 GiB), so anyone can rerun on the same shape. A provider that can't express a dimension
 runs with its actuals recorded and the mismatch disclosed (`specMatched`).
 

--- a/docs/pts-catalog-and-analysis-design.md
+++ b/docs/pts-catalog-and-analysis-design.md
@@ -1,6 +1,9 @@
 # Design Doc: Scaling the PTS Catalog + Analysis Layer
 
-Status: Draft for implementation
+> **Historical design notes.** Prefer [methodology](./methodology.md) and the ADRs for current truth.
+> Kept for provenance of the catalog/analysis work; line numbers and branch names below may be stale.
+
+Status: Historical (implemented in stages; not the living source of truth)
 Branch base: `harness-live-suite` (PTS stack tops out at PR #38)
 Audience: repo owner → stacked PR series
 

--- a/packages/results/src/index.ts
+++ b/packages/results/src/index.ts
@@ -8,12 +8,14 @@
 export { aggregateRuns } from "./lib/aggregate.ts";
 export {
 	buildLeaderboard,
+	type ComparabilityCaveat,
 	// Every type reachable from `Leaderboard` is exported with it: a consumer that can hold the value but
 	// cannot name the type of `leaderboard.coverageGaps` can't write a function that takes one.
 	type CoverageGap,
 	type CoverageOutcome,
 	type Leaderboard,
 	type LeaderboardDimension,
+	type LeaderboardMetric,
 	type LeaderboardRow,
 	renderLeaderboardMarkdown,
 } from "./lib/leaderboard.ts";

--- a/packages/results/src/lib/leaderboard.test.ts
+++ b/packages/results/src/lib/leaderboard.test.ts
@@ -171,6 +171,9 @@ describe("buildLeaderboard statistical ranking", () => {
 		expect(rows[1]?.verdict).toBe("tied");
 		expect(rows[1]?.tiedWithAbove).toBe("statistical");
 		expect(rows[1]?.pVsPrevious?.mannWhitney).toBeGreaterThan(0.05);
+		// Takeaway must not claim a sole provider when the top cohort is a statistical tie.
+		expect(renderLeaderboardMarkdown(board)).toContain("share the top on this headline");
+		expect(renderLeaderboardMarkdown(board)).not.toContain("is the only ranked provider");
 	});
 
 	it("leaves a single-Sample Metric untested and ranked on its exact value", () => {
@@ -209,7 +212,7 @@ describe("buildLeaderboard statistical ranking", () => {
 describe("renderLeaderboardMarkdown statistics", () => {
 	const HEADLINE = "node_web_tooling_runs_per_s";
 
-	it("renders CI, n and the p-value, and marks a statistical tie", () => {
+	it("renders CI, n and a Note for a statistical tie", () => {
 		const md = renderLeaderboardMarkdown(
 			buildLeaderboard(
 				run([
@@ -219,14 +222,14 @@ describe("renderLeaderboardMarkdown statistics", () => {
 			),
 		);
 		expect(md).toContain("95% CI");
-		expect(md).toContain("p vs. above");
-		expect(md).toContain("(tied)");
+		expect(md).toContain("| Note |");
+		expect(md).toContain("| tied |");
 		// The reader must be told what a shared rank means, not left to infer it.
 		expect(md).toContain("statistically indistinguishable");
 		expect(md).toContain("Mann-Whitney");
 	});
 
-	it("surfaces the KS p-value in the table, not only on the row object", () => {
+	it("surfaces the KS p-value in the details section, not only on the row object", () => {
 		// Regression: `ks` was computed and stored on every LeaderboardRow, documented as the way to spot
 		// a bimodal provider, and then never rendered — so no reader of LEADERBOARD.md could ever see it.
 		const board = buildLeaderboard(
@@ -238,23 +241,21 @@ describe("renderLeaderboardMarkdown statistics", () => {
 		const md = renderLeaderboardMarkdown(board);
 
 		expect(md).toContain("p (KS)");
-		// The note must explain the column, since a second p-value is otherwise cryptic.
 		expect(md).toContain("Kolmogorov-Smirnov");
 
-		// The second row carries both p-values (rank 1 has no predecessor, so both cells are em-dashes).
 		expect(board.dimensions[0]?.rows[1]?.pVsPrevious).not.toBeNull();
 
-		// Assert the SHAPE of the rendered rows, not a re-derived format string: duplicating
-		// `formatPValue`'s rule here would let the test agree with itself and drift from the renderer
-		// (`toPrecision(2)` keeps a trailing zero — "0.0080" — which a `Number(...)` round-trip drops).
-		const rows = md.split("\n").filter((l) => /^\| \d+ \| (Daytona|E2B) \|/.test(l));
-		expect(rows).toHaveLength(2);
-		for (const row of rows) {
-			// 7 columns: rank, provider, value, CI, n, p vs. above, p (KS).
-			expect(row.split("|").filter((c) => c.trim() !== "")).toHaveLength(7);
+		// Main ranking table stays slim (Note column because of the tie); KS lives in the details table.
+		const mainRows = md.split("\n").filter((l) => /^\| \d+ \| (Daytona|E2B) \|/.test(l));
+		expect(mainRows).toHaveLength(2);
+		for (const row of mainRows) {
+			expect(row.split("|").filter((c) => c.trim() !== "").length).toBe(6);
 		}
-		const [first, second] = rows as [string, string];
-		expect(first.trimEnd().endsWith("| — |")).toBe(true); // no predecessor → no KS
+
+		const detailRows = md.split("\n").filter((l) => /^\| cpu \| (Daytona|E2B) \|/.test(l));
+		expect(detailRows).toHaveLength(2);
+		const [first, second] = detailRows as [string, string];
+		expect(first).toContain("| — |");
 		const secondKs = second.trimEnd().split("|").at(-2)?.trim() as string;
 		expect(secondKs).not.toBe("—");
 		expect(secondKs).toMatch(/^(<0\.001|\d+(\.\d+)?(e[+-]?\d+)?)$/);
@@ -264,9 +265,8 @@ describe("renderLeaderboardMarkdown statistics", () => {
 		const md = renderLeaderboardMarkdown(
 			buildLeaderboard(run([provider("daytona", [metric(HEADLINE, [10])])])),
 		);
-		// n=1 → em-dash for the CI and BOTH p-values, never a fabricated bound. Anchored to the row end so
-		// a future column can't be silently dropped from the assertion.
-		expect(md).toMatch(/\| 1 \| Daytona \| 10 \| — \| 1 \| — \| — \|\n/);
+		// n=1 → em-dash for the CI; no Note column when nothing needs calling out.
+		expect(md).toMatch(/\| 1 \| Daytona \| 10 \| — \| 1 \|\n/);
 	});
 
 	it("never prints a p-value as a misleading 0", () => {
@@ -301,7 +301,8 @@ describe("underpowered comparisons", () => {
 			["Modal", 2, "underpowered", null],
 		]);
 		const md = renderLeaderboardMarkdown(board);
-		expect(md).toContain("(n too small)");
+		expect(md).toContain("n too small");
+		expect(md).not.toMatch(/\| tied \|/);
 		expect(md).not.toContain("(tied)");
 	});
 
@@ -354,7 +355,8 @@ describe("underpowered comparisons", () => {
 		expect(rows[1]?.tiedWithAbove).toBe("identical-value");
 		const md = renderLeaderboardMarkdown(board);
 		// The cell distinguishes the two reasons the rank is shared; it never reads as a statistical tie.
-		expect(md).toContain("(n too small, equal medians)");
+		expect(md).toContain("n too small, equal medians");
+		expect(md).not.toMatch(/\| tied \|/);
 		expect(md).not.toContain("(tied)");
 	});
 
@@ -370,7 +372,7 @@ describe("underpowered comparisons", () => {
 			[1, null, null],
 			[1, "untested", "identical-value"],
 		]);
-		expect(renderLeaderboardMarkdown(board)).toContain("— (equal values)");
+		expect(renderLeaderboardMarkdown(board)).toContain("equal values");
 	});
 
 	it("never marks a row `tied` unless the test could have separated it", () => {
@@ -411,7 +413,7 @@ describe("underpowered comparisons", () => {
 			[1, null, null],
 			[1, "tied", "statistical"],
 		]);
-		expect(renderLeaderboardMarkdown(board)).toContain("(tied)");
+		expect(renderLeaderboardMarkdown(board)).toContain("| tied |");
 	});
 
 	it("does not let the tie-corrected approximation crown a provider the exact test cannot separate", () => {

--- a/packages/results/src/lib/leaderboard.test.ts
+++ b/packages/results/src/lib/leaderboard.test.ts
@@ -66,7 +66,7 @@ describe("buildLeaderboard", () => {
 		expect(econ?.rows[0]?.displayName).toBe("E2B"); // resolved from the provider registry
 	});
 
-	it("omits dimensions with no headline value and renders Markdown tables", () => {
+	it("omits dimensions with no emitted value and renders Markdown tables", () => {
 		const board = buildLeaderboard(
 			run([provider("daytona", [metric("node_web_tooling_runs_per_s", [10])])]),
 		);
@@ -95,7 +95,54 @@ describe("buildLeaderboard", () => {
 
 	it("renders a placeholder when nothing is ranked", () => {
 		const md = renderLeaderboardMarkdown(buildLeaderboard(run([provider("daytona", [])])));
-		expect(md).toContain("No ranked dimensions yet");
+		expect(md).toContain("No ranked metrics yet");
+	});
+
+	it("ranks every emitted catalogued Metric, including non-headlines", () => {
+		const board = buildLeaderboard(
+			run([
+				provider("daytona", [
+					metric("node_web_tooling_runs_per_s", [10]),
+					metric("stream_type_copy", [20]),
+				]),
+				provider("modal", [metric("stream_type_copy", [15])]),
+			]),
+		);
+		expect(board.dimensions.map(({ dimension }) => dimension)).toEqual(["cpu", "memory"]);
+		expect(
+			board.dimensions.flatMap(({ metrics }) => metrics.map(({ metric }) => metric.id)),
+		).toEqual(["node_web_tooling_runs_per_s", "stream_type_copy"]);
+		expect(
+			board.dimensions.flatMap(({ metrics }) => metrics.flatMap(({ rows }) => rows)),
+		).toHaveLength(3);
+
+		const md = renderLeaderboardMarkdown(board);
+		expect(md).toContain("**3 metric records**");
+		expect(md).toContain("**3 retained trial observations**");
+		expect(md).toContain("**2 metrics**");
+		expect(md).toContain("### Node.js web tooling _(headline)_");
+		expect(md).toContain("### STREAM Copy");
+	});
+
+	it("uses the Run's target and warns when observed specs are not comparable", () => {
+		const blaxel = {
+			...provider("blaxel", [metric("node_web_tooling_runs_per_s", [10])]),
+			specMatched: false,
+			observedSpecs: { vcpus: 6, memoryGb: 15.63, diskGb: 12.5 },
+		};
+		const board = buildLeaderboard(run([blaxel]));
+		expect(board.targetSpec).toEqual({ vcpus: 2, memoryGb: 8, diskGb: 20 });
+		expect(board.comparabilityCaveats).toHaveLength(1);
+
+		const md = renderLeaderboardMarkdown(board);
+		expect(md).toContain(
+			"Requested target for every provider: **2 vCPU · 8 GiB RAM · 20 GB disk**",
+		);
+		expect(md).toContain(
+			"**Comparability warning:** Blaxel's observed compute did not match the requested CPU/RAM target",
+		);
+		expect(md).toContain("**6 vCPU · 15.63 GiB RAM · 12.5 GB disk**");
+		expect(md).not.toContain("Same pinned target");
 	});
 });
 
@@ -172,7 +219,7 @@ describe("buildLeaderboard statistical ranking", () => {
 		expect(rows[1]?.tiedWithAbove).toBe("statistical");
 		expect(rows[1]?.pVsPrevious?.mannWhitney).toBeGreaterThan(0.05);
 		// Takeaway must not claim a sole provider when the top cohort is a statistical tie.
-		expect(renderLeaderboardMarkdown(board)).toContain("share the top on this headline");
+		expect(renderLeaderboardMarkdown(board)).toContain("share the top on this metric");
 		expect(renderLeaderboardMarkdown(board)).not.toContain("is the only ranked provider");
 	});
 
@@ -207,12 +254,29 @@ describe("buildLeaderboard statistical ranking", () => {
 		const rows = board.dimensions.find((d) => d.dimension === "economics")?.rows ?? [];
 		expect(rows.map((r) => r.rank)).toEqual([1, 1]);
 	});
+
+	it("names EVERY co-leader when three or more providers share the top rank", () => {
+		// A three-way tie at rank 1: the takeaway must list all three, not silently drop the third.
+		const board = buildLeaderboard(
+			run([
+				provider("daytona", [metric(ECONOMICS_METRIC_IDS.usdPerHour, [0.1])]),
+				provider("e2b", [metric(ECONOMICS_METRIC_IDS.usdPerHour, [0.1])]),
+				provider("modal", [metric(ECONOMICS_METRIC_IDS.usdPerHour, [0.1])]),
+			]),
+		);
+		const rows = board.dimensions.find((d) => d.dimension === "economics")?.rows ?? [];
+		expect(rows.map((r) => r.rank)).toEqual([1, 1, 1]);
+		const md = renderLeaderboardMarkdown(board);
+		// All three display names appear in the "share the top" takeaway, joined as a list.
+		expect(md).toMatch(/\w+, \w+ and \w+ share the top on this metric/);
+		for (const name of ["Daytona", "E2B", "Modal"]) expect(md).toContain(name);
+	});
 });
 
 describe("renderLeaderboardMarkdown statistics", () => {
 	const HEADLINE = "node_web_tooling_runs_per_s";
 
-	it("renders CI, n and a Note for a statistical tie", () => {
+	it("renders a bootstrap interval, n and a Note for a statistical tie", () => {
 		const md = renderLeaderboardMarkdown(
 			buildLeaderboard(
 				run([
@@ -221,12 +285,13 @@ describe("renderLeaderboardMarkdown statistics", () => {
 				]),
 			),
 		);
-		expect(md).toContain("95% CI");
+		expect(md).toContain("95% bootstrap interval");
 		expect(md).toContain("| Note |");
 		expect(md).toContain("| tied |");
 		// The reader must be told what a shared rank means, not left to infer it.
 		expect(md).toContain("statistically indistinguishable");
 		expect(md).toContain("Mann-Whitney");
+		expect(md).toContain("unadjusted, exploratory per-comparison p-values");
 	});
 
 	it("surfaces the KS p-value in the details section, not only on the row object", () => {
@@ -252,7 +317,9 @@ describe("renderLeaderboardMarkdown statistics", () => {
 			expect(row.split("|").filter((c) => c.trim() !== "").length).toBe(6);
 		}
 
-		const detailRows = md.split("\n").filter((l) => /^\| cpu \| (Daytona|E2B) \|/.test(l));
+		const detailRows = md
+			.split("\n")
+			.filter((l) => /^\| cpu \| Node\.js web tooling \| (Daytona|E2B) \|/.test(l));
 		expect(detailRows).toHaveLength(2);
 		const [first, second] = detailRows as [string, string];
 		expect(first).toContain("| — |");
@@ -265,7 +332,7 @@ describe("renderLeaderboardMarkdown statistics", () => {
 		const md = renderLeaderboardMarkdown(
 			buildLeaderboard(run([provider("daytona", [metric(HEADLINE, [10])])])),
 		);
-		// n=1 → em-dash for the CI; no Note column when nothing needs calling out.
+		// n=1 → em-dash for the bootstrap interval; no Note column when nothing needs calling out.
 		expect(md).toMatch(/\| 1 \| Daytona \| 10 \| — \| 1 \|\n/);
 	});
 
@@ -511,7 +578,7 @@ describe("coverage gaps", () => {
 		const md = renderLeaderboardMarkdown(
 			buildLeaderboard(run([provider("e2b", [], [diskSkip(30)])])),
 		);
-		expect(md).toContain("_No ranked dimensions yet");
+		expect(md).toContain("_No ranked metrics yet");
 		expect(md).toContain("## Coverage gaps");
 		expect(md).toContain("realworld-mastra");
 	});

--- a/packages/results/src/lib/leaderboard.ts
+++ b/packages/results/src/lib/leaderboard.ts
@@ -1,12 +1,12 @@
 /**
- * Render a validated {@link Run} into the public comparison surface: one ranked table per Dimension,
- * keyed on that Dimension's headline Metric, plus economics. This is the payoff the dataset exists for
- * — a human-readable provider ranking. SDK-free: the Run model + the Catalog only.
+ * Render a validated {@link Run} into the public comparison surface: one ranked table per emitted,
+ * catalogued Metric, grouped by Dimension. This is the payoff the dataset exists for — a complete,
+ * human-readable provider ranking. SDK-free: the Run model + the Catalog only.
  *
- * Each Dimension shows its single headline Metric (catalog.ts guarantees exactly one), every provider
- * that produced it, ranked by the Metric's Direction (HIB → highest first, LIB → lowest first). A
- * Dimension with no headline Metric, or no provider value, is omitted. The representative value is the
- * Samples' p50 (median) — robust to a single slow pass.
+ * Each Dimension shows every Metric that at least one provider produced, with its headline Metric
+ * first (catalog.ts guarantees at most one), and every provider that produced each Metric ranked by
+ * its Direction (HIB → highest first, LIB → lowest first). A Metric with no provider value is omitted.
+ * The representative value is the Samples' p50 (median) — robust to a single slow pass.
  *
  * Ranking is INFERENTIAL, not a bare sort. A provider's Samples are repeated trials inside one sandbox,
  * so their spread is environmental noise, and ordering on the median alone would let a lucky draw buy a
@@ -21,7 +21,9 @@ import type {
 	GapScope,
 	MedianInterval,
 	MetricDef,
+	ObservedSpecs,
 	Run,
+	TargetSpec,
 } from "@sandbox-benchmarks/schema";
 import {
 	bootstrapMedianInterval,
@@ -32,14 +34,13 @@ import {
 	kolmogorovSmirnov,
 	METRIC_CATALOG,
 	mannWhitneyU,
-	TARGET_SPEC,
 } from "@sandbox-benchmarks/schema";
 
-/** One provider's standing on a Dimension's headline Metric. */
+/** One provider's standing on one Metric. */
 export interface LeaderboardRow {
 	providerId: string;
 	displayName: string;
-	/** Representative value (Samples' p50) of the headline Metric for this provider. */
+	/** Representative value (Samples' p50) of the Metric for this provider. */
 	value: number;
 	/**
 	 * 1-based rank by the Metric's Direction. Providers whose Sample distributions are NOT
@@ -47,7 +48,7 @@ export interface LeaderboardRow {
 	 * median earned inside the noise is not a faster provider.
 	 */
 	rank: number;
-	/** Bootstrapped interval around {@link value} — the honest precision of the median. */
+	/** Descriptive percentile-bootstrap interval around {@link value}. */
 	interval: MedianInterval;
 	/** Retained Sample count and their spread, so a wide/unstable row is legible at a glance. */
 	n: number;
@@ -93,11 +94,27 @@ export type ComparisonVerdict = "separated" | "tied" | "underpowered" | "unteste
 /** Why a row shares the rank above it. See {@link LeaderboardRow.tiedWithAbove}. */
 export type TieBasis = "statistical" | "identical-value";
 
-/** One Dimension's ranked comparison on its headline Metric. */
-export interface LeaderboardDimension {
-	dimension: Dimension;
+/** One emitted Metric's ranked provider comparison. */
+export interface LeaderboardMetric {
 	metric: MetricDef;
 	rows: LeaderboardRow[];
+}
+
+/** Every emitted Metric in one Dimension, with the headline first. */
+export interface LeaderboardDimension {
+	dimension: Dimension;
+	metrics: LeaderboardMetric[];
+	/** First rendered Metric (the headline when one was emitted), retained for API compatibility. */
+	metric: MetricDef;
+	/** Rows for {@link metric}, retained for API compatibility. */
+	rows: LeaderboardRow[];
+}
+
+/** A provider whose observed allocation did not match the Run's requested target. */
+export interface ComparabilityCaveat {
+	providerId: string;
+	displayName: string;
+	observedSpecs: ObservedSpecs;
 }
 
 /**
@@ -139,7 +156,11 @@ export interface Leaderboard {
 	runId: string;
 	sha: string;
 	generatedAt: string;
+	/** The requested comparison target recorded on this Run — never substituted from global config. */
+	targetSpec: TargetSpec;
 	dimensions: LeaderboardDimension[];
+	/** Providers explicitly recorded as failing to match {@link targetSpec}. */
+	comparabilityCaveats: ComparabilityCaveat[];
 	/** Every benchmark that produced no result somewhere, disk gaps first. Empty when coverage is complete. */
 	coverageGaps: CoverageGap[];
 }
@@ -232,136 +253,158 @@ function coverageGapsOf(run: Run): CoverageGap[] {
 	);
 }
 
+/** Rank all providers that emitted one Metric; empty when the Run has no result for it. */
+function rankMetric(run: Run, metric: MetricDef): LeaderboardRow[] {
+	// Carry each provider's raw Samples alongside its row: the ranking needs the full distributions,
+	// not just their medians, to tell a real difference from environmental noise.
+	const candidates = run.providers.flatMap((provider) => {
+		const result = provider.metrics.find((m) => m.metricId === metric.id);
+		if (!result) return [];
+		const row: LeaderboardRow = {
+			providerId: provider.providerId,
+			displayName: getProvider(provider.providerId)?.displayName ?? provider.providerId,
+			value: result.aggregates.p50,
+			rank: 0, // assigned after sort
+			// Seed from stable identity so a committed leaderboard is byte-identical on every
+			// regeneration — a Math.random() bootstrap would churn the diff on every run.
+			interval: bootstrapMedianInterval(result.samples, {
+				seed: `${run.runId}:${metric.id}:${provider.providerId}`,
+			}),
+			n: result.aggregates.n,
+			stdev: result.aggregates.stdev,
+			pVsPrevious: null,
+			verdict: null,
+			tiedWithAbove: null,
+		};
+		return [{ samples: result.samples, row }];
+	});
+	if (candidates.length === 0) return [];
+
+	// Order by Direction; tie-break on providerId so the output is deterministic.
+	candidates.sort((a, b) =>
+		a.row.value !== b.row.value
+			? metric.direction === "HIB"
+				? b.row.value - a.row.value
+				: a.row.value - b.row.value
+			: a.row.providerId.localeCompare(b.row.providerId),
+	);
+
+	// Competition ranking with STATISTICAL ties. Walk the ordered rows and test each against the one
+	// above: when Mann-Whitney can't separate them, they share a rank rather than letting a median
+	// won inside the noise buy a position. `separated` carries the verdict; `ks` is reported beside
+	// it because two providers can share a median while differing in distribution shape.
+	//
+	// Only ADJACENT rows are tested, which is deliberate: a leaderboard is a linear order, and the
+	// pairwise "which providers are mutually indistinguishable" relation is not transitive (A~B and
+	// B~C does not give A~C). Testing the chain keeps the table honest about the one comparison it
+	// actually renders — each row against the row above it — instead of implying a grouping the
+	// tests don't support. It also keeps this to k−1 tests. The rendered methodology explicitly labels
+	// their p-values unadjusted and exploratory; it does not claim family-wise error control.
+	candidates.forEach((candidate, i) => {
+		const previous = candidates[i - 1];
+		if (!previous) {
+			candidate.row.rank = 1;
+			return;
+		}
+		// A row shares the rank above it EXACTLY when it has a reason to, and the reason is recorded.
+		// That invariant is the whole defence against the table claiming a tie it never established: a
+		// shared rank always answers "on what basis?", and the renderer prints the answer.
+		const settle = (basis: TieBasis | null): void => {
+			candidate.row.tiedWithAbove = basis;
+			candidate.row.rank = basis === null ? i + 1 : previous.row.rank;
+		};
+		// Exactly equal values cannot be ordered by a ranking that ranks on the value. Whenever no
+		// verdict is available to override that, they must share a rank — otherwise the providerId sort
+		// tie-break alone would split two providers with an identical published price.
+		const identical = candidate.row.value === previous.row.value;
+
+		// A single Sample is not a distribution: there is nothing to test, and the value is typically
+		// exact rather than measured (a Metric like `usd_per_hour` is a published price, not a trial).
+		// Rank such rows on the value and mark them untested, rather than declaring every provider
+		// "indistinguishable" because a one-trial comparison can never reach significance.
+		if (previous.samples.length < 2 || candidate.samples.length < 2) {
+			candidate.row.verdict = "untested";
+			settle(identical ? "identical-value" : null);
+			return;
+		}
+
+		const mw = mannWhitneyU(previous.samples, candidate.samples);
+		const ks = kolmogorovSmirnov(previous.samples, candidate.samples);
+		candidate.row.pVsPrevious = {
+			mannWhitney: mw.pValue,
+			ks: ks.pValue,
+			floor: mw.minAttainablePValue,
+		};
+
+		// The same "a test that can never reach α is not evidence of sameness" rule as the n<2 case
+		// above, applied where it actually bites: Mann-Whitney's p has a FLOOR, and at 3 v 3 that floor
+		// (0.1) is already above α. Grouping those rows would print "statistically tied" for a provider
+		// running at half the speed of the one above it — a fact about the trial count masquerading as a
+		// fact about the providers. Claim no verdict, rank on the observed value, and let the rendering
+		// disclose that the comparison was untestable.
+		//
+		// The floor comes from the test itself (it depends on the tie pattern, not just the sample
+		// sizes), so the guard and the p-value it guards are answers about the same enumerated null and
+		// cannot disagree.
+		if (!canSeparate(mw)) {
+			candidate.row.verdict = "underpowered";
+			// An underpowered row can still share a rank — but only ever because the two values are
+			// identical, never because the test "found no difference". The basis says which, so the
+			// renderer and the footer can keep the two apart.
+			settle(identical ? "identical-value" : null);
+			return;
+		}
+
+		if (mw.pValue < DEFAULT_ALPHA) {
+			candidate.row.verdict = "separated";
+			settle(null);
+			return;
+		}
+		// The test could have separated them and did not: a real statistical tie.
+		candidate.row.verdict = "tied";
+		settle("statistical");
+	});
+
+	return candidates.map((candidate) => candidate.row);
+}
+
 /** Build the structured leaderboard from a validated Run. Pure — Run in, ranking out. */
 export function buildLeaderboard(run: Run): Leaderboard {
 	const dimensions: LeaderboardDimension[] = [];
 
 	for (const dimension of DIMENSIONS) {
-		// The headline Metric for this Dimension, if one is catalogued (else the Dimension is unpopulated).
-		// A direct lookup, not headlineMetric()+catch: an unpopulated Dimension is the expected case here,
-		// not an exceptional one, and a bare catch would also swallow real programming errors.
-		const metric: MetricDef | undefined = METRIC_CATALOG.find(
-			(m) => m.dimension === dimension && m.headline,
+		// Catalog order is the stable display order, except the dimension's editorial headline leads.
+		// Crucially, every emitted Metric gets a table: headline is presentation priority, not a filter.
+		const catalogued = METRIC_CATALOG.filter((metric) => metric.dimension === dimension).sort(
+			(a, b) => Number(b.headline) - Number(a.headline),
 		);
-		if (!metric) continue;
-
-		// Carry each provider's raw Samples alongside its row: the ranking needs the full distributions,
-		// not just their medians, to tell a real difference from environmental noise.
-		const candidates = run.providers.flatMap((provider) => {
-			const result = provider.metrics.find((m) => m.metricId === metric.id);
-			if (!result) return [];
-			const row: LeaderboardRow = {
-				providerId: provider.providerId,
-				displayName: getProvider(provider.providerId)?.displayName ?? provider.providerId,
-				value: result.aggregates.p50,
-				rank: 0, // assigned after sort
-				// Seed from stable identity so a committed leaderboard is byte-identical on every
-				// regeneration — a Math.random() bootstrap would churn the diff on every run.
-				interval: bootstrapMedianInterval(result.samples, {
-					seed: `${run.runId}:${metric.id}:${provider.providerId}`,
-				}),
-				n: result.aggregates.n,
-				stdev: result.aggregates.stdev,
-				pVsPrevious: null,
-				verdict: null,
-				tiedWithAbove: null,
-			};
-			return [{ samples: result.samples, row }];
+		const metrics = catalogued.flatMap((metric): LeaderboardMetric[] => {
+			const rows = rankMetric(run, metric);
+			return rows.length === 0 ? [] : [{ metric, rows }];
 		});
-		if (candidates.length === 0) continue;
-
-		// Order by Direction; tie-break on providerId so the output is deterministic.
-		candidates.sort((a, b) =>
-			a.row.value !== b.row.value
-				? metric.direction === "HIB"
-					? b.row.value - a.row.value
-					: a.row.value - b.row.value
-				: a.row.providerId.localeCompare(b.row.providerId),
-		);
-
-		// Competition ranking with STATISTICAL ties. Walk the ordered rows and test each against the one
-		// above: when Mann-Whitney can't separate them, they share a rank rather than letting a median
-		// won inside the noise buy a position. `separated` carries the verdict; `ks` is reported beside
-		// it because two providers can share a median while differing in distribution shape.
-		//
-		// Only ADJACENT rows are tested, which is deliberate: a leaderboard is a linear order, and the
-		// pairwise "which providers are mutually indistinguishable" relation is not transitive (A~B and
-		// B~C does not give A~C). Testing the chain keeps the table honest about the one comparison it
-		// actually renders — each row against the row above it — instead of implying a grouping the
-		// tests don't support. It also keeps this to k−1 tests, so no multiplicity correction is owed.
-		candidates.forEach((candidate, i) => {
-			const previous = candidates[i - 1];
-			if (!previous) {
-				candidate.row.rank = 1;
-				return;
-			}
-			// A row shares the rank above it EXACTLY when it has a reason to, and the reason is recorded.
-			// That invariant is the whole defence against the table claiming a tie it never established: a
-			// shared rank always answers "on what basis?", and the renderer prints the answer.
-			const settle = (basis: TieBasis | null): void => {
-				candidate.row.tiedWithAbove = basis;
-				candidate.row.rank = basis === null ? i + 1 : previous.row.rank;
-			};
-			// Exactly equal values cannot be ordered by a ranking that ranks on the value. Whenever no
-			// verdict is available to override that, they must share a rank — otherwise the providerId sort
-			// tie-break alone would split two providers with an identical published price.
-			const identical = candidate.row.value === previous.row.value;
-
-			// A single Sample is not a distribution: there is nothing to test, and the value is typically
-			// exact rather than measured (a Metric like `usd_per_hour` is a published price, not a trial).
-			// Rank such rows on the value and mark them untested, rather than declaring every provider
-			// "indistinguishable" because a one-trial comparison can never reach significance.
-			if (previous.samples.length < 2 || candidate.samples.length < 2) {
-				candidate.row.verdict = "untested";
-				settle(identical ? "identical-value" : null);
-				return;
-			}
-
-			const mw = mannWhitneyU(previous.samples, candidate.samples);
-			const ks = kolmogorovSmirnov(previous.samples, candidate.samples);
-			candidate.row.pVsPrevious = {
-				mannWhitney: mw.pValue,
-				ks: ks.pValue,
-				floor: mw.minAttainablePValue,
-			};
-
-			// The same "a test that can never reach α is not evidence of sameness" rule as the n<2 case
-			// above, applied where it actually bites: Mann-Whitney's p has a FLOOR, and at 3 v 3 that floor
-			// (0.1) is already above α. Grouping those rows would print "statistically tied" for a provider
-			// running at half the speed of the one above it — a fact about the trial count masquerading as a
-			// fact about the providers. Claim no verdict, rank on the observed value, and let the rendering
-			// disclose that the comparison was untestable.
-			//
-			// The floor comes from the test itself (it depends on the tie pattern, not just the sample
-			// sizes), so the guard and the p-value it guards are answers about the same enumerated null and
-			// cannot disagree.
-			if (!canSeparate(mw)) {
-				candidate.row.verdict = "underpowered";
-				// An underpowered row can still share a rank — but only ever because the two values are
-				// identical, never because the test "found no difference". The basis says which, so the
-				// renderer and the footer can keep the two apart.
-				settle(identical ? "identical-value" : null);
-				return;
-			}
-
-			if (mw.pValue < DEFAULT_ALPHA) {
-				candidate.row.verdict = "separated";
-				settle(null);
-				return;
-			}
-			// The test could have separated them and did not: a real statistical tie.
-			candidate.row.verdict = "tied";
-			settle("statistical");
-		});
-
-		dimensions.push({ dimension, metric, rows: candidates.map((c) => c.row) });
+		const primary = metrics[0];
+		if (primary) {
+			dimensions.push({ dimension, metrics, metric: primary.metric, rows: primary.rows });
+		}
 	}
 
 	return {
 		runId: run.runId,
 		sha: run.sha,
 		generatedAt: run.generatedAt,
+		targetSpec: run.targetSpec,
 		dimensions,
+		comparabilityCaveats: run.providers.flatMap((provider): ComparabilityCaveat[] =>
+			provider.specMatched === false
+				? [
+						{
+							providerId: provider.providerId,
+							displayName: getProvider(provider.providerId)?.displayName ?? provider.providerId,
+							observedSpecs: provider.observedSpecs,
+						},
+					]
+				: [],
+		),
 		coverageGaps: coverageGapsOf(run),
 	};
 }
@@ -376,13 +419,15 @@ export function buildLeaderboard(run: Run): Leaderboard {
  */
 function underpoweredFloors(board: Leaderboard): string[] {
 	const seen = new Map<string, string>();
-	for (const { rows } of board.dimensions) {
-		rows.forEach((row, i) => {
-			const previous = rows[i - 1];
-			if (row.verdict !== "underpowered" || !previous || !row.pVsPrevious) return;
-			const key = `${previous.n} v ${row.n}`;
-			seen.set(key, `${key} floors at p ≈ ${formatPValue(row.pVsPrevious.floor)}`);
-		});
+	for (const { metrics } of board.dimensions) {
+		for (const { rows } of metrics) {
+			rows.forEach((row, i) => {
+				const previous = rows[i - 1];
+				if (row.verdict !== "underpowered" || !previous || !row.pVsPrevious) return;
+				const key = `${previous.n} v ${row.n}`;
+				seen.set(key, `${key} floors at p ≈ ${formatPValue(row.pVsPrevious.floor)}`);
+			});
+		}
 	}
 	return [...seen.entries()].sort(([a], [b]) => a.localeCompare(b, "en")).map(([, text]) => text);
 }
@@ -435,12 +480,8 @@ function formatInterval(r: LeaderboardRow): string {
 		: `${formatValue(r.interval.lo)} – ${formatValue(r.interval.hi)}`;
 }
 
-/** One-line takeaway above each dimension table (leader vs next, or sole provider). */
-function dimensionTakeaway(
-	dimension: Dimension,
-	metric: MetricDef,
-	rows: LeaderboardRow[],
-): string {
+/** One-line takeaway above each Metric table (leader vs next, or sole provider). */
+function metricTakeaway(dimension: Dimension, metric: MetricDef, rows: LeaderboardRow[]): string {
 	const leader = rows[0];
 	if (!leader) return "";
 	const better = metric.direction === "HIB" ? "higher is better" : "lower is better";
@@ -450,8 +491,14 @@ function dimensionTakeaway(
 	if (!next) {
 		return `${leader.displayName} is the only ranked provider (${formatValue(leader.value)} ${metric.unit}; ${better}).`;
 	}
-	if (next.tiedWithAbove === "statistical" || next.rank === leader.rank) {
-		return `${leader.displayName} and ${next.displayName} share the top on this headline (${better}).`;
+	// Collect the full top cohort, not just the immediate neighbor: three or more providers can share
+	// rank 1 (statistical tie or identical values), and naming only the first two would silently drop
+	// the rest. Rows are rank-sorted, so everything at the leader's rank is the contiguous top group.
+	const coLeaders = rows.filter((r) => r.rank === leader.rank);
+	if (coLeaders.length > 1) {
+		const names = coLeaders.map((r) => r.displayName);
+		const list = `${names.slice(0, -1).join(", ")} and ${names[names.length - 1]}`;
+		return `${list} share the top on this metric (${better}).`;
 	}
 	if (metric.direction === "HIB") {
 		const ratio = leader.value / next.value;
@@ -480,50 +527,86 @@ function coverageSummary(gaps: CoverageGap[]): string {
 	return `${gaps.length} uncovered result${gaps.length === 1 ? "" : "s"} across ${byProvider.size} provider${byProvider.size === 1 ? "" : "s"} (${parts.join(", ")}). A gap is a missing result — the provider **failing to cover** that workload — never a tie or a zero.`;
 }
 
+/** Compact requested/observed allocation description, omitting fields probes could not see. */
+function formatSpec(spec: TargetSpec | ObservedSpecs): string {
+	const parts = [
+		spec.vcpus === undefined ? undefined : `${formatValue(spec.vcpus)} vCPU`,
+		spec.memoryGb === undefined ? undefined : `${formatValue(spec.memoryGb)} GiB RAM`,
+		spec.diskGb === undefined ? undefined : `${formatValue(spec.diskGb)} GB disk`,
+	].filter((part): part is string => part !== undefined);
+	return parts.length > 0 ? parts.join(" · ") : "allocation not observable";
+}
+
 /** Render a {@link Leaderboard} as a Markdown document — the committed comparison surface. */
 export function renderLeaderboardMarkdown(board: Leaderboard): string {
-	const spec = `${TARGET_SPEC.vcpus} vCPU · ${TARGET_SPEC.memoryGb} GiB RAM · ${TARGET_SPEC.diskGb} GB disk`;
+	const spec = formatSpec(board.targetSpec);
+	const metricCount = board.dimensions.reduce(
+		(sum, dimension) => sum + dimension.metrics.length,
+		0,
+	);
+	const rows = board.dimensions.flatMap((dimension) =>
+		dimension.metrics.flatMap((metric) => metric.rows),
+	);
+	const observationCount = rows.reduce((sum, row) => sum + row.n, 0);
+	const providerCount = new Set(rows.map((row) => row.providerId)).size;
+	const metricNoun = metricCount === 1 ? "metric" : "metrics";
+	const providerNoun = providerCount === 1 ? "provider" : "providers";
 	const lines: string[] = [
 		"# Sandbox provider leaderboard",
 		"",
 		`Run \`${board.runId}\` · commit \`${board.sha}\` · generated ${board.generatedAt}`,
 		"",
-		`Same pinned target for every provider (**${spec}**). Each table ranks providers on that`,
-		"dimension's headline metric (median of retained trials). Generated from the published Run",
-		"dataset — do not edit by hand. Methodology: [`docs/methodology.md`](docs/methodology.md).",
+		`Requested target for every provider: **${spec}**. This run contains **${rows.length} metric records**`,
+		`backed by **${observationCount} retained trial observations**, across **${metricCount} ${metricNoun}** and`,
+		`**${providerCount} ${providerNoun}**; every emitted, catalogued metric has a ranked table below`,
+		"(median of retained trials), grouped by dimension with its headline first.",
+		"Generated from the published Run dataset — do not edit by hand. Methodology:",
+		"[`docs/methodology.md`](docs/methodology.md).",
 		"",
-		"**How to read:** value = median (p50) · 95% CI = bootstrap around that median · ranks split only",
+		"**How to read:** value = median (p50) · 95% bootstrap interval around that median · ranks split only",
 		"when distributions differ (see details below) · a coverage gap means unmeasured, never a score of zero.",
+		"CPU/RAM comparability uses observed vCPU and RAM (±10% RAM); disk is a workload-capacity gate",
+		"surfaced through coverage gaps, not part of the compute-match verdict.",
 		"",
 	];
-
-	if (board.dimensions.length === 0) {
-		lines.push("_No ranked dimensions yet (no provider produced a headline metric)._", "");
-	}
-
-	for (const { dimension, metric, rows } of board.dimensions) {
-		const better = metric.direction === "HIB" ? "higher is better" : "lower is better";
-		const notes = rows.map(rowNote);
-		const hasNotes = notes.some((n) => n !== "");
+	for (const caveat of board.comparabilityCaveats) {
 		lines.push(
-			`## ${dimension}`,
-			"",
-			`Headline: **${metric.label}** (${metric.unit}, ${better})`,
-			"",
-			`_${dimensionTakeaway(dimension, metric, rows)}_`,
-			"",
-			hasNotes
-				? `| Rank | Provider | ${metric.label} (${metric.unit}) | 95% CI | n | Note |`
-				: `| Rank | Provider | ${metric.label} (${metric.unit}) | 95% CI | n |`,
-			hasNotes
-				? "| ---: | --- | ---: | ---: | ---: | --- |"
-				: "| ---: | --- | ---: | ---: | ---: |",
-			...rows.map((r, i) => {
-				const base = `| ${r.rank} | ${r.displayName} | ${formatValue(r.value)} | ${formatInterval(r)} | ${r.n} |`;
-				return hasNotes ? `${base} ${notes[i] || "—"} |` : base;
-			}),
+			`> **Comparability warning:** ${caveat.displayName}'s observed compute did not match the requested CPU/RAM target; its observed allocation was **${formatSpec(caveat.observedSpecs)}**. Its measured ranks are not like-for-like with compute-matched providers.`,
 			"",
 		);
+	}
+
+	if (board.dimensions.length === 0) {
+		lines.push("_No ranked metrics yet (no provider produced a catalogued metric)._", "");
+	}
+
+	for (const { dimension, metrics } of board.dimensions) {
+		lines.push(`## ${dimension}`, "");
+		for (const { metric, rows: metricRows } of metrics) {
+			const better = metric.direction === "HIB" ? "higher is better" : "lower is better";
+			const notes = metricRows.map(rowNote);
+			const hasNotes = notes.some((note) => note !== "");
+			const headline = metric.headline ? " _(headline)_" : "";
+			lines.push(
+				`### ${metric.label}${headline}`,
+				"",
+				`${metric.unit} · ${better}`,
+				"",
+				`_${metricTakeaway(dimension, metric, metricRows)}_`,
+				"",
+				hasNotes
+					? `| Rank | Provider | ${metric.label} (${metric.unit}) | 95% bootstrap interval | n | Note |`
+					: `| Rank | Provider | ${metric.label} (${metric.unit}) | 95% bootstrap interval | n |`,
+				hasNotes
+					? "| ---: | --- | ---: | ---: | ---: | --- |"
+					: "| ---: | --- | ---: | ---: | ---: |",
+				...metricRows.map((row, i) => {
+					const base = `| ${row.rank} | ${row.displayName} | ${formatValue(row.value)} | ${formatInterval(row)} | ${row.n} |`;
+					return hasNotes ? `${base} ${notes[i] || "—"} |` : base;
+				}),
+				"",
+			);
+		}
 	}
 
 	// Coverage gaps: summary first; full table + legends inside <details> so unfinished providers
@@ -582,9 +665,10 @@ export function renderLeaderboardMarkdown(board: Leaderboard): string {
 		"<summary>How rankings are decided</summary>",
 		"",
 		"The value is the median (p50) of the retained per-trial Samples, not the mean — a single stalled",
-		"pass drags a mean far more than it moves a median. The 95% CI is a percentile bootstrap of that",
-		"median (10,000 resamples, seeded from the Run id so the table is reproducible byte-for-byte), not",
-		"a normal-theory interval: these Samples are neither normal nor independent of the host's scheduling.",
+		"pass drags a mean far more than it moves a median. The 95% interval is a percentile bootstrap of",
+		"that median (10,000 resamples, seeded from the Run id so the table is reproducible byte-for-byte).",
+		"It is a descriptive interval conditional on the retained trials, **not a calibrated frequentist",
+		"confidence interval**: n is small and within-sandbox trials may be dependent on host scheduling.",
 		"",
 		`Rows are separated only when Mann-Whitney U (two-sided, α = ${DEFAULT_ALPHA}, enumerated exactly`,
 		"over the permutation null rather than approximated) finds a shift in central tendency — at these",
@@ -593,7 +677,6 @@ export function renderLeaderboardMarkdown(board: Leaderboard): string {
 		"",
 	);
 
-	const rows = board.dimensions.flatMap((d) => d.rows);
 	const sharedRankReasons: string[] = [];
 	if (rows.some((r) => r.tiedWithAbove === "statistical")) {
 		sharedRankReasons.push(
@@ -618,7 +701,7 @@ export function renderLeaderboardMarkdown(board: Leaderboard): string {
 
 	lines.push(
 		"Samples are repeated trials inside one sandbox, so their spread is environmental (neighbours, host",
-		"contention, virtualization), and a wide CI or a large `n` (the harness re-runs a test that will not",
+		"contention, virtualization), and a wide bootstrap interval or a large `n` (the harness re-runs a test that will not",
 		"converge) is itself the signal that the provider's performance is unstable, not that the measurement",
 		"is imprecise.",
 		"",
@@ -649,14 +732,20 @@ export function renderLeaderboardMarkdown(board: Leaderboard): string {
 			"`p vs. above` is Mann-Whitney (drives rank). `p (KS)` is Kolmogorov-Smirnov on distribution",
 			"*shape* — it does not drive the ranking. A tied Mann-Whitney beside a small KS often means the",
 			"same typical speed with different behaviour (e.g. bimodal stalls).",
+			"These are unadjusted, exploratory per-comparison p-values; no family-wise or false-discovery-rate",
+			"correction is applied across providers or metrics.",
 			"",
-			"| Dimension | Provider | p vs. above | p (KS) |",
-			"| --- | --- | ---: | ---: |",
+			"| Dimension | Metric | Provider | p vs. above | p (KS) |",
+			"| --- | --- | --- | ---: | ---: |",
 		);
-		for (const { dimension, rows: dimRows } of board.dimensions) {
-			for (const r of dimRows) {
-				const ks = r.pVsPrevious === null ? "—" : formatPValue(r.pVsPrevious.ks);
-				lines.push(`| ${dimension} | ${r.displayName} | ${formatPairwiseP(r)} | ${ks} |`);
+		for (const { dimension, metrics } of board.dimensions) {
+			for (const { metric, rows: metricRows } of metrics) {
+				for (const row of metricRows) {
+					const ks = row.pVsPrevious === null ? "—" : formatPValue(row.pVsPrevious.ks);
+					lines.push(
+						`| ${dimension} | ${metric.label} | ${row.displayName} | ${formatPairwiseP(row)} | ${ks} |`,
+					);
+				}
 			}
 		}
 		lines.push("");

--- a/packages/results/src/lib/leaderboard.ts
+++ b/packages/results/src/lib/leaderboard.ts
@@ -32,6 +32,7 @@ import {
 	kolmogorovSmirnov,
 	METRIC_CATALOG,
 	mannWhitneyU,
+	TARGET_SPEC,
 } from "@sandbox-benchmarks/schema";
 
 /** One provider's standing on a Dimension's headline Metric. */
@@ -407,14 +408,92 @@ function formatPValue(p: number): string {
 	return p.toPrecision(2);
 }
 
+/** Compact note for the main table's Note column — empty when nothing needs calling out. */
+function rowNote(r: LeaderboardRow): string {
+	const equalValues = r.tiedWithAbove === "identical-value";
+	if (r.pVsPrevious === null) {
+		return equalValues ? "equal values" : "";
+	}
+	if (r.verdict === "underpowered") {
+		return equalValues ? "n too small, equal medians" : "n too small";
+	}
+	if (r.verdict === "tied") return "tied";
+	return "";
+}
+
+/** Mann-Whitney cell in the pairwise details table — reuses {@link rowNote} for the verdict suffix. */
+function formatPairwiseP(r: LeaderboardRow): string {
+	const note = rowNote(r);
+	if (r.pVsPrevious === null) return note ? `— (${note})` : "—";
+	const p = formatPValue(r.pVsPrevious.mannWhitney);
+	return note ? `${p} (${note})` : p;
+}
+
+function formatInterval(r: LeaderboardRow): string {
+	return r.interval.resamples === 0
+		? "—"
+		: `${formatValue(r.interval.lo)} – ${formatValue(r.interval.hi)}`;
+}
+
+/** One-line takeaway above each dimension table (leader vs next, or sole provider). */
+function dimensionTakeaway(
+	dimension: Dimension,
+	metric: MetricDef,
+	rows: LeaderboardRow[],
+): string {
+	const leader = rows[0];
+	if (!leader) return "";
+	const better = metric.direction === "HIB" ? "higher is better" : "lower is better";
+	// Immediate neighbor — not the next distinct rank — so a top-of-board statistical tie is not
+	// misread as "only one provider ranked".
+	const next = rows[1];
+	if (!next) {
+		return `${leader.displayName} is the only ranked provider (${formatValue(leader.value)} ${metric.unit}; ${better}).`;
+	}
+	if (next.tiedWithAbove === "statistical" || next.rank === leader.rank) {
+		return `${leader.displayName} and ${next.displayName} share the top on this headline (${better}).`;
+	}
+	if (metric.direction === "HIB") {
+		const ratio = leader.value / next.value;
+		if (Number.isFinite(ratio) && ratio >= 1.05) {
+			return `${leader.displayName} leads · ~${ratio.toFixed(1)}× ${next.displayName} on median (${better}).`;
+		}
+	} else {
+		const ratio = next.value / leader.value;
+		if (Number.isFinite(ratio) && ratio >= 1.05) {
+			const verb = dimension === "economics" ? "is cheapest" : "leads";
+			return `${leader.displayName} ${verb} · ~${ratio.toFixed(1)}× lower than ${next.displayName} (${better}).`;
+		}
+	}
+	return `${leader.displayName} leads on median (${better}); see notes for how ranks are decided.`;
+}
+
+/** Summary line for coverage gaps by provider — keeps the main board scannable. */
+function coverageSummary(gaps: CoverageGap[]): string {
+	const byProvider = new Map<string, number>();
+	for (const g of gaps) {
+		byProvider.set(g.displayName, (byProvider.get(g.displayName) ?? 0) + 1);
+	}
+	const parts = [...byProvider.entries()]
+		.sort(([a], [b]) => a.localeCompare(b, "en"))
+		.map(([name, n]) => `${name} ${n}`);
+	return `${gaps.length} uncovered result${gaps.length === 1 ? "" : "s"} across ${byProvider.size} provider${byProvider.size === 1 ? "" : "s"} (${parts.join(", ")}). A gap is a missing result — the provider **failing to cover** that workload — never a tie or a zero.`;
+}
+
 /** Render a {@link Leaderboard} as a Markdown document — the committed comparison surface. */
 export function renderLeaderboardMarkdown(board: Leaderboard): string {
+	const spec = `${TARGET_SPEC.vcpus} vCPU · ${TARGET_SPEC.memoryGb} GiB RAM · ${TARGET_SPEC.diskGb} GB disk`;
 	const lines: string[] = [
 		"# Sandbox provider leaderboard",
 		"",
 		`Run \`${board.runId}\` · commit \`${board.sha}\` · generated ${board.generatedAt}`,
 		"",
-		"Each table ranks the providers on that dimension's headline metric. Generated from the published Run dataset — do not edit by hand.",
+		`Same pinned target for every provider (**${spec}**). Each table ranks providers on that`,
+		"dimension's headline metric (median of retained trials). Generated from the published Run",
+		"dataset — do not edit by hand. Methodology: [`docs/methodology.md`](docs/methodology.md).",
+		"",
+		"**How to read:** value = median (p50) · 95% CI = bootstrap around that median · ranks split only",
+		"when distributions differ (see details below) · a coverage gap means unmeasured, never a score of zero.",
 		"",
 	];
 
@@ -424,57 +503,40 @@ export function renderLeaderboardMarkdown(board: Leaderboard): string {
 
 	for (const { dimension, metric, rows } of board.dimensions) {
 		const better = metric.direction === "HIB" ? "higher is better" : "lower is better";
+		const notes = rows.map(rowNote);
+		const hasNotes = notes.some((n) => n !== "");
 		lines.push(
 			`## ${dimension}`,
 			"",
 			`Headline: **${metric.label}** (${metric.unit}, ${better})`,
 			"",
-			`| Rank | Provider | ${metric.label} (${metric.unit}) | 95% CI | n | p vs. above | p (KS) |`,
-			"| ---: | --- | ---: | ---: | ---: | ---: | ---: |",
-			...rows.map((r) => {
-				const ci =
-					r.interval.resamples === 0
-						? "—"
-						: `${formatValue(r.interval.lo)} – ${formatValue(r.interval.hi)}`;
-				// Every shared rank says why, in the cell — a reader must never have to infer the reason from
-				// two rows carrying the same number. The three are distinct claims: `tied` is a verdict the
-				// test reached; `n too small` is the ABSENCE of one (it could not have separated them at any
-				// effect size, so it must not read as a tie); `equal medians` is arithmetic (the ranking sorts
-				// on the value, and it cannot order two values that are the same). The last can co-occur with
-				// `n too small`, and when it does, the shared rank is the equality speaking, not the test.
-				const equalValues = r.tiedWithAbove === "identical-value";
-				const p =
-					r.pVsPrevious === null
-						? equalValues
-							? "— (equal values)"
-							: "—"
-						: r.verdict === "underpowered"
-							? `${formatPValue(r.pVsPrevious.mannWhitney)} (n too small${equalValues ? ", equal medians" : ""})`
-							: r.verdict === "tied"
-								? `${formatPValue(r.pVsPrevious.mannWhitney)} (tied)`
-								: formatPValue(r.pVsPrevious.mannWhitney);
-				// KS is rendered, not just stored: it is the only column that exposes a provider whose
-				// median matches its neighbour's while its distribution is bimodal. A small `p (KS)` beside
-				// a large, tied `p vs. above` is exactly that case — same typical speed, different machine.
-				const ks = r.pVsPrevious === null ? "—" : formatPValue(r.pVsPrevious.ks);
-				return `| ${r.rank} | ${r.displayName} | ${formatValue(r.value)} | ${ci} | ${r.n} | ${p} | ${ks} |`;
+			`_${dimensionTakeaway(dimension, metric, rows)}_`,
+			"",
+			hasNotes
+				? `| Rank | Provider | ${metric.label} (${metric.unit}) | 95% CI | n | Note |`
+				: `| Rank | Provider | ${metric.label} (${metric.unit}) | 95% CI | n |`,
+			hasNotes
+				? "| ---: | --- | ---: | ---: | ---: | --- |"
+				: "| ---: | --- | ---: | ---: | ---: |",
+			...rows.map((r, i) => {
+				const base = `| ${r.rank} | ${r.displayName} | ${formatValue(r.value)} | ${formatInterval(r)} | ${r.n} |`;
+				return hasNotes ? `${base} ${notes[i] || "—"} |` : base;
 			}),
 			"",
 		);
 	}
 
-	// Coverage gaps: everything that did NOT produce a result somewhere. Rendered whether or not any
-	// dimension ranked, so an all-skipped run still says why. Disk gaps lead and are marked ❌ — a
-	// provider that cannot fit the workload is a structural absence, not a slow result, and must not
-	// read as "no data". Each row states its OUTCOME, because the three are not the same fact and a
-	// reader who cannot tell them apart will read a crash as a design decision.
+	// Coverage gaps: summary first; full table + legends inside <details> so unfinished providers
+	// don't bury the rankings.
 	if (board.coverageGaps.length > 0) {
 		const outcomes = new Set(board.coverageGaps.map((g) => g.outcome));
 		lines.push(
 			"## Coverage gaps",
 			"",
-			"Benchmarks that produced **no result** on a provider. A gap is a missing result, not a comparable",
-			"one — read it as the provider **failing to cover** that workload, never as a tie or a zero.",
+			coverageSummary(board.coverageGaps),
+			"",
+			"<details>",
+			"<summary>Full coverage table</summary>",
 			"",
 			"| Provider | Benchmark | Outcome | Detail |",
 			"| --- | --- | --- | --- |",
@@ -485,9 +547,6 @@ export function renderLeaderboardMarkdown(board: Leaderboard): string {
 			}),
 			"",
 		);
-		// Each legend line is emitted only when the table actually contains that outcome, so the section
-		// never explains a category the reader cannot see (and so an all-`missing` run reads as one clear
-		// statement instead of three paragraphs of hypotheticals).
 		if (outcomes.has("skipped")) {
 			lines.push(
 				"**skipped** — a precondition said no before the benchmark was attempted. A ❌ **disk** skip is the",
@@ -512,47 +571,46 @@ export function renderLeaderboardMarkdown(board: Leaderboard): string {
 				"",
 			);
 		}
+		lines.push("</details>", "");
 	}
 
 	if (board.dimensions.length === 0) return `${lines.join("\n")}\n`;
 
+	// Statistics essay + optional p-value / KS detail table for readers who want the receipts.
 	lines.push(
-		"---",
+		"<details>",
+		"<summary>How rankings are decided</summary>",
 		"",
-		"**Reading this table.** The value is the median (p50) of the retained per-trial Samples, not the",
-		"mean — a single stalled pass drags a mean far more than it moves a median. The 95% CI is a",
-		"percentile bootstrap of that median (10,000 resamples, seeded from the Run id so the table is",
-		"reproducible byte-for-byte), not a normal-theory interval: these Samples are neither normal nor",
-		"independent of the host's scheduling.",
+		"The value is the median (p50) of the retained per-trial Samples, not the mean — a single stalled",
+		"pass drags a mean far more than it moves a median. The 95% CI is a percentile bootstrap of that",
+		"median (10,000 resamples, seeded from the Run id so the table is reproducible byte-for-byte), not",
+		"a normal-theory interval: these Samples are neither normal nor independent of the host's scheduling.",
 		"",
-		`Rows are separated only when their full Sample distributions differ (Mann-Whitney U, two-sided, α = ${DEFAULT_ALPHA},`,
-		"enumerated exactly over the permutation null rather than approximated — at these sample sizes the",
-		"normal approximation can report a p the exact test cannot actually produce).",
+		`Rows are separated only when Mann-Whitney U (two-sided, α = ${DEFAULT_ALPHA}, enumerated exactly`,
+		"over the permutation null rather than approximated) finds a shift in central tendency — at these",
+		"sample sizes the normal approximation can report a p the exact test cannot actually produce. KS is",
+		"reported separately for distribution *shape* and does not drive the ranking.",
 		"",
 	);
 
-	// A shared rank means different things, and the footer must explain exactly the ones the table
-	// contains — no more (a legend for an absent case teaches the reader to skim) and no less (an
-	// unexplained shared rank is read as a tie, which is the misreading this whole section exists to
-	// prevent). Collected from the rows themselves, so the prose cannot drift from the table.
 	const rows = board.dimensions.flatMap((d) => d.rows);
 	const sharedRankReasons: string[] = [];
 	if (rows.some((r) => r.tiedWithAbove === "statistical")) {
 		sharedRankReasons.push(
-			"`(tied)` — the test could have separated those providers and did not, so a faster median earned",
-			"inside the noise is not a faster provider. This is the only one that claims two providers are",
+			"`tied` — the test could have separated those providers and did not, so a faster median earned",
+			"inside the noise is not a faster provider. This is the only note that claims two providers are",
 			"statistically indistinguishable.",
 		);
 	}
 	if (rows.some((r) => r.tiedWithAbove === "identical-value")) {
 		sharedRankReasons.push(
-			"`(equal medians)` / `(equal values)` — arithmetic, not a finding: the ranking sorts on the value,",
+			"`equal medians` / `equal values` — arithmetic, not a finding: the ranking sorts on the value,",
 			"and two identical values have no order between them. It says nothing about the distributions.",
 		);
 	}
 	if (sharedRankReasons.length > 0) {
 		lines.push(
-			"**A shared rank always says why, in the `p vs. above` cell, and the reasons are not interchangeable.**",
+			"**A Note cell always says why a rank is shared, and the reasons are not interchangeable.**",
 			...sharedRankReasons,
 			"",
 		);
@@ -564,21 +622,11 @@ export function renderLeaderboardMarkdown(board: Leaderboard): string {
 		"converge) is itself the signal that the provider's performance is unstable, not that the measurement",
 		"is imprecise.",
 		"",
-		"`p (KS)` is a two-sample Kolmogorov-Smirnov test against the same row above. It does **not** drive",
-		"the ranking — it compares the two empirical distributions' *shapes* rather than their central",
-		"tendency. Read it where it disagrees with `p vs. above`: a tied rank (large Mann-Whitney p) beside a",
-		"small `p (KS)` means two providers with the same typical speed but different behaviour — usually one",
-		"of them alternating between fast and stalled passes. That bimodality is what environmental noise",
-		"looks like, and it is the reason a median alone cannot rank these providers.",
-		"",
 		"At the small `n` this suite produces, a non-significant result means *not enough evidence to",
 		"separate*, never *the providers are equal*.",
 		"",
 	);
 
-	// `n too small` needs explaining only when the table actually contains one, and the floor it cites is
-	// the one those rows' own tests reported — a hardcoded example would misquote both the floor and the n
-	// the moment a run pairs, say, 3 trials against 4.
 	const floors = underpoweredFloors(board);
 	if (floors.length > 0) {
 		lines.push(
@@ -586,12 +634,35 @@ export function renderLeaderboardMarkdown(board: Leaderboard): string {
 			`Samples, so the test could not have separated the rows at any effect size (here ${floors.join("; ")}).`,
 			"Such rows are ranked on their observed medians and are **not** claimed to be tied — read the gap",
 			"between the values, and treat the p-value as unable to settle them either way. Where such a row",
-			"nevertheless shares the rank above it, the cell reads `equal medians`: the two values are simply",
+			"nevertheless shares the rank above it, the note reads `equal medians`: the two values are simply",
 			"identical, which is the ranking having nothing to order them by — never a finding that the",
 			"providers are alike.",
 			"",
 		);
 	}
+
+	// Detail table with p vs. above + KS for readers who want distribution shape.
+	if (rows.some((r) => r.pVsPrevious !== null)) {
+		lines.push(
+			"### Pairwise tests (vs. row above)",
+			"",
+			"`p vs. above` is Mann-Whitney (drives rank). `p (KS)` is Kolmogorov-Smirnov on distribution",
+			"*shape* — it does not drive the ranking. A tied Mann-Whitney beside a small KS often means the",
+			"same typical speed with different behaviour (e.g. bimodal stalls).",
+			"",
+			"| Dimension | Provider | p vs. above | p (KS) |",
+			"| --- | --- | ---: | ---: |",
+		);
+		for (const { dimension, rows: dimRows } of board.dimensions) {
+			for (const r of dimRows) {
+				const ks = r.pVsPrevious === null ? "—" : formatPValue(r.pVsPrevious.ks);
+				lines.push(`| ${dimension} | ${r.displayName} | ${formatPairwiseP(r)} | ${ks} |`);
+			}
+		}
+		lines.push("");
+	}
+
+	lines.push("</details>", "");
 
 	return `${lines.join("\n")}\n`;
 }

--- a/tooling/repo-checks/src/leaderboard-artifact-sync.test.ts
+++ b/tooling/repo-checks/src/leaderboard-artifact-sync.test.ts
@@ -11,7 +11,17 @@ import { describe, expect, it } from "bun:test";
 import { readFileSync } from "node:fs";
 import { join } from "node:path";
 import { buildLeaderboard, renderLeaderboardMarkdown } from "@sandbox-benchmarks/results";
-import { parseRun } from "@sandbox-benchmarks/schema";
+import type { MetricDef, Run } from "@sandbox-benchmarks/schema";
+import {
+	canSeparate,
+	DEFAULT_ALPHA,
+	DIMENSIONS,
+	getMetric,
+	getProvider,
+	kolmogorovSmirnov,
+	mannWhitneyU,
+	parseRun,
+} from "@sandbox-benchmarks/schema";
 import { findRepoRoot } from "./lib/workspace.ts";
 
 const ROOT = findRepoRoot();
@@ -23,6 +33,250 @@ const ARTIFACT = join(ROOT, "LEADERBOARD.md");
 const runFile = (runId: string) => join(ROOT, "data", "dataset", "runs", `${runId}.json`);
 const regenCmd = (runId: string) =>
 	`bun apps/cli/src/bin/leaderboard.ts data/dataset/runs/${runId}.json LEADERBOARD.md`;
+
+/** Independent R-7 percentile implementation for auditing the persisted Aggregates and displayed p50. */
+function auditPercentile(samples: readonly number[], p: number): number {
+	const sorted = [...samples].sort((a, b) => a - b);
+	const h = (sorted.length - 1) * p;
+	const lo = Math.floor(h);
+	const hi = Math.ceil(h);
+	const a = sorted[lo] as number;
+	const b = sorted[hi] as number;
+	return a + (h - lo) * (b - a);
+}
+
+/** Conventional two-pass aggregates: intentionally separate from schema.aggregate's Welford path. */
+function auditAggregates(samples: readonly number[]) {
+	const mean = samples.reduce((sum, sample) => sum + sample, 0) / samples.length;
+	const squared = samples.reduce((sum, sample) => sum + (sample - mean) ** 2, 0);
+	return {
+		p50: auditPercentile(samples, 0.5),
+		p95: auditPercentile(samples, 0.95),
+		mean,
+		stdev: Math.sqrt(samples.length > 1 ? squared / (samples.length - 1) : 0),
+		min: Math.min(...samples),
+		max: Math.max(...samples),
+		n: samples.length,
+	};
+}
+
+/** Independent implementation of the documented FNV-like seed + mulberry32 generator. */
+function auditRng(seed: string): () => number {
+	let hash = 2166136261;
+	for (let i = 0; i < seed.length; i++) {
+		hash ^= seed.charCodeAt(i);
+		hash = Math.imul(hash, 16777619);
+	}
+	let state = hash >>> 0;
+	return () => {
+		state = (state + 0x6d2b79f5) >>> 0;
+		let mixed = state;
+		mixed = Math.imul(mixed ^ (mixed >>> 15), mixed | 1);
+		mixed ^= mixed + Math.imul(mixed ^ (mixed >>> 7), mixed | 61);
+		return ((mixed ^ (mixed >>> 14)) >>> 0) / 4294967296;
+	};
+}
+
+/** Independently reproduce the specified seeded 10k percentile bootstrap of the median. */
+function auditMedianInterval(
+	samples: readonly number[],
+	seed: string,
+): { lo: number; hi: number } | null {
+	if (samples.length === 1) return null;
+	const rng = auditRng(seed);
+	const medians = new Array<number>(10_000);
+	for (let iteration = 0; iteration < medians.length; iteration++) {
+		const draw = Array.from(
+			{ length: samples.length },
+			() => samples[Math.floor(rng() * samples.length)] as number,
+		);
+		medians[iteration] = auditPercentile(draw, 0.5);
+	}
+	const tail = (1 - 0.95) / 2;
+	return {
+		lo: auditPercentile(medians, tail),
+		hi: auditPercentile(medians, 1 - tail),
+	};
+}
+
+function formatValue(value: number): string {
+	return Number.isInteger(value)
+		? String(value)
+		: Number.parseFloat(value.toPrecision(4)).toString();
+}
+
+function formatPValue(value: number): string {
+	return value < 0.001 ? "<0.001" : value.toPrecision(2);
+}
+
+interface AuditRow {
+	providerId: string;
+	displayName: string;
+	value: number;
+	rank: number;
+	interval: string;
+	n: number;
+	note: string;
+	p: string;
+	ks: string;
+}
+
+/** Derive one table directly from raw Samples, without calling buildLeaderboard. */
+function auditRows(run: Run, metric: MetricDef): AuditRow[] {
+	const candidates = run.providers.flatMap((provider) => {
+		const result = provider.metrics.find(({ metricId }) => metricId === metric.id);
+		if (!result) return [];
+		const value = auditPercentile(result.samples, 0.5);
+		const interval = auditMedianInterval(
+			result.samples,
+			`${run.runId}:${metric.id}:${provider.providerId}`,
+		);
+		return [
+			{
+				providerId: provider.providerId,
+				displayName: getProvider(provider.providerId)?.displayName ?? provider.providerId,
+				result,
+				value,
+				interval: interval ? `${formatValue(interval.lo)} – ${formatValue(interval.hi)}` : "—",
+			},
+		];
+	});
+	candidates.sort((a, b) =>
+		a.value !== b.value
+			? metric.direction === "HIB"
+				? b.value - a.value
+				: a.value - b.value
+			: a.providerId.localeCompare(b.providerId),
+	);
+
+	const rows: AuditRow[] = [];
+	for (const [index, candidate] of candidates.entries()) {
+		const previousCandidate = candidates[index - 1];
+		const previousRow = rows[index - 1];
+		if (!previousCandidate || !previousRow) {
+			rows.push({
+				...candidate,
+				rank: 1,
+				n: candidate.result.samples.length,
+				note: "",
+				p: "—",
+				ks: "—",
+			});
+			continue;
+		}
+
+		const identical = candidate.value === previousCandidate.value;
+		let rank = index + 1;
+		let note = "";
+		let p = "—";
+		let ks = "—";
+		if (previousCandidate.result.samples.length < 2 || candidate.result.samples.length < 2) {
+			if (identical) {
+				rank = previousRow.rank;
+				note = "equal values";
+			}
+		} else {
+			const mw = mannWhitneyU(previousCandidate.result.samples, candidate.result.samples);
+			const shape = kolmogorovSmirnov(previousCandidate.result.samples, candidate.result.samples);
+			if (!canSeparate(mw)) {
+				note = identical ? "n too small, equal medians" : "n too small";
+				if (identical) rank = previousRow.rank;
+			} else if (mw.pValue >= DEFAULT_ALPHA) {
+				rank = previousRow.rank;
+				note = "tied";
+			}
+			p = `${formatPValue(mw.pValue)}${note ? ` (${note})` : ""}`;
+			ks = formatPValue(shape.pValue);
+		}
+
+		rows.push({
+			...candidate,
+			rank,
+			n: candidate.result.samples.length,
+			note,
+			p: p === "—" && note ? `— (${note})` : p,
+			ks,
+		});
+	}
+	return rows;
+}
+
+interface MarkdownMetricRow {
+	rank: string;
+	provider: string;
+	value: string;
+	interval: string;
+	n: string;
+	note: string;
+}
+
+/** Read the generated Markdown as an independent consumer would, rather than trusting its builder. */
+function parseMetricTables(markdown: string, emitted: Map<string, MetricDef>) {
+	const rows = new Map<string, MarkdownMetricRow[]>();
+	const pairwise = new Map<string, { p: string; ks: string }>();
+	let dimension: string | undefined;
+	let metric: MetricDef | undefined;
+	let inPairwise = false;
+
+	for (const line of markdown.split("\n")) {
+		if (line.startsWith("## ")) {
+			const heading = line.slice(3);
+			dimension = (DIMENSIONS as readonly string[]).includes(heading) ? heading : undefined;
+			metric = undefined;
+			inPairwise = false;
+			continue;
+		}
+		if (line === "### Pairwise tests (vs. row above)") {
+			metric = undefined;
+			inPairwise = true;
+			continue;
+		}
+		if (line.startsWith("### ") && dimension) {
+			const label = line.slice(4).replace(/ _\(headline\)_$/, "");
+			metric = emitted.get(`${dimension}\0${label}`);
+			if (!metric) throw new Error(`Markdown names unknown emitted Metric ${dimension}/${label}`);
+			continue;
+		}
+
+		if (metric && /^\| \d+ \|/.test(line)) {
+			const cells = line
+				.slice(1, -1)
+				.split("|")
+				.map((cell) => cell.trim());
+			const [rank, provider, value, interval, n, rawNote] = cells;
+			const note = rawNote === "—" || rawNote === undefined ? "" : rawNote;
+			const key = metric.id;
+			const metricRows = rows.get(key) ?? [];
+			metricRows.push({
+				rank: rank as string,
+				provider: provider as string,
+				value: value as string,
+				interval: interval as string,
+				n: n as string,
+				note,
+			});
+			rows.set(key, metricRows);
+			continue;
+		}
+
+		if (
+			inPairwise &&
+			/^\| (?:lifecycle|control-plane|cpu|disk|memory|network|system|realworld|economics) \|/.test(
+				line,
+			)
+		) {
+			const [pairDimension, label, provider, p, ks] = line
+				.slice(1, -1)
+				.split("|")
+				.map((cell) => cell.trim());
+			const pairMetric = emitted.get(`${pairDimension}\0${label}`);
+			if (!pairMetric)
+				throw new Error(`Pairwise table names unknown Metric ${pairDimension}/${label}`);
+			pairwise.set(`${pairMetric.id}\0${provider}`, { p: p as string, ks: ks as string });
+		}
+	}
+	return { rows, pairwise };
+}
 
 /** The Run id the committed artifact was generated from, read out of its own header line:
  *  "Run `<id>` · commit `<sha>` · generated <iso>". Parsed rather than hardcoded so regenerating the
@@ -66,6 +320,23 @@ function loadCommittedRun(): {
 }
 
 describe("LEADERBOARD.md stays in sync with the renderer", () => {
+	it("stores internally consistent Aggregates for every raw Sample distribution", () => {
+		const { run } = loadCommittedRun();
+		for (const provider of run.providers) {
+			for (const result of provider.metrics) {
+				const audited = auditAggregates(result.samples);
+				const context = `${provider.providerId}/${result.metricId}`;
+				expect(result.aggregates.n, `${context} n`).toBe(audited.n);
+				for (const field of ["p50", "p95", "mean", "stdev", "min", "max"] as const) {
+					const actual = result.aggregates[field];
+					const expected = audited[field];
+					const tolerance = 1e-12 * Math.max(1, Math.abs(expected));
+					expect(Math.abs(actual - expected), `${context} ${field}`).toBeLessThanOrEqual(tolerance);
+				}
+			}
+		}
+	});
+
 	it("is byte-identical to a fresh render of the Run it names", () => {
 		const { committed, runId, run } = loadCommittedRun();
 		const rendered = renderLeaderboardMarkdown(buildLeaderboard(run));
@@ -86,5 +357,100 @@ describe("LEADERBOARD.md stays in sync with the renderer", () => {
 		expect(renderLeaderboardMarkdown(buildLeaderboard(run))).toBe(
 			renderLeaderboardMarkdown(buildLeaderboard(run)),
 		);
+	});
+
+	it("renders one row for every provider/Metric record in the source Run", () => {
+		const { run } = loadCommittedRun();
+		const board = buildLeaderboard(run);
+		const expected = run.providers
+			.flatMap((provider) =>
+				provider.metrics.map((metric) => `${provider.providerId}/${metric.metricId}`),
+			)
+			.sort();
+		const rendered = board.dimensions
+			.flatMap(({ metrics }) =>
+				metrics.flatMap(({ metric, rows }) => rows.map((row) => `${row.providerId}/${metric.id}`)),
+			)
+			.sort();
+
+		expect(rendered).toEqual(expected);
+	});
+
+	it("renders every value, interval, rank, n, note, and pairwise p-value from raw Samples", () => {
+		const { committed, run } = loadCommittedRun();
+		const metrics = new Map<string, MetricDef>();
+		const emittedByHeading = new Map<string, MetricDef>();
+		for (const provider of run.providers) {
+			for (const result of provider.metrics) {
+				const metric = getMetric(result.metricId);
+				if (!metric) throw new Error(`Run contains uncatalogued MetricResult ${result.metricId}`);
+				metrics.set(metric.id, metric);
+				const heading = `${metric.dimension}\0${metric.label}`;
+				const collision = emittedByHeading.get(heading);
+				if (collision && collision.id !== metric.id) {
+					throw new Error(
+						`Emitted Metrics ${collision.id} and ${metric.id} share a Markdown heading`,
+					);
+				}
+				emittedByHeading.set(heading, metric);
+			}
+		}
+
+		const metricRecordCount = run.providers.reduce(
+			(sum, provider) => sum + provider.metrics.length,
+			0,
+		);
+		const providerCount = run.providers.filter((provider) => provider.metrics.length > 0).length;
+		const observationCount = run.providers.reduce(
+			(sum, provider) =>
+				sum +
+				provider.metrics.reduce((providerSum, result) => providerSum + result.samples.length, 0),
+			0,
+		);
+		expect(committed).toContain(`**${metricRecordCount} metric records**`);
+		expect(committed).toContain(`**${observationCount} retained trial observations**`);
+		expect(committed).toContain(`**${metrics.size} metrics**`);
+		expect(committed).toContain(`**${providerCount} providers**`);
+		const target = [
+			`${formatValue(run.targetSpec.vcpus)} vCPU`,
+			`${formatValue(run.targetSpec.memoryGb)} GiB RAM`,
+			run.targetSpec.diskGb === undefined
+				? undefined
+				: `${formatValue(run.targetSpec.diskGb)} GB disk`,
+		]
+			.filter((part): part is string => part !== undefined)
+			.join(" · ");
+		expect(committed).toContain(`Requested target for every provider: **${target}**`);
+		expect(committed).not.toContain("Same pinned target");
+		for (const provider of run.providers.filter(({ specMatched }) => specMatched === false)) {
+			const name = getProvider(provider.providerId)?.displayName ?? provider.providerId;
+			expect(committed).toContain(
+				`**Comparability warning:** ${name}'s observed compute did not match the requested CPU/RAM target`,
+			);
+		}
+
+		const parsed = parseMetricTables(committed, emittedByHeading);
+		expect(parsed.rows.size).toBe(metrics.size);
+		expect(parsed.pairwise.size).toBe(metricRecordCount);
+
+		for (const metric of metrics.values()) {
+			const audited = auditRows(run, metric);
+			const expectedRows: MarkdownMetricRow[] = audited.map((row) => ({
+				rank: String(row.rank),
+				provider: row.displayName,
+				value: formatValue(row.value),
+				interval: row.interval,
+				n: String(row.n),
+				note: row.note,
+			}));
+			expect(parsed.rows.get(metric.id), metric.id).toEqual(expectedRows);
+
+			for (const row of audited) {
+				expect(
+					parsed.pairwise.get(`${metric.id}\0${row.displayName}`),
+					`${metric.id}/${row.providerId} pairwise`,
+				).toEqual({ p: row.p, ks: row.ks });
+			}
+		}
 	});
 });


### PR DESCRIPTION
**Public-repo hardening — split into a 5-PR stack (merge bottom-up, each branch independently green):**
1. #173 — community-health: GitHub community files (`CODEOWNERS`, issue/PR templates, dependabot, CoC, SECURITY) + public README/docs hub
2. #174 — leaderboard: richer render (per-dimension takeaways, target-spec header, coverage summary) + regenerated `LEADERBOARD.md`
3. #175 — secret hygiene: repo-checks drift gate over the tracked tree + widened `.gitignore` blocklist
4. #176 — workflow YAML: gate live-bench / dataset-publish / GHCR-release behind Environment `privileged`; releases are dispatch-only
5. #177 — workflow gate: enforce the privileged-environment + dispatch-only invariants as a repo-checks drift gate

↑ **This PR is #174 (2/5)**, based on #173.

---

<!--
Thanks for contributing! Keep the summary tight and let the diff carry the detail.
Live provider benches and toolchain releases are maintainer-only (Environment `privileged`); a fork
PR runs only the hosted CI gate — see CONTRIBUTING.md and docs/ci-secrets.md.
-->

## Summary

<!-- What changes and why, in a sentence or two. -->

## Type of change

- [ ] Bug fix
- [ ] New provider / suite / metric (see CONTRIBUTING.md)
- [ ] CI / tooling / docs
- [ ] Other

## Checklist

- [ ] `bun run lint`, `bun run typecheck`, and `bun run test` pass locally (the same gate CI runs)
- [ ] `bun run spell` passes (via `mise`), if text changed
- [ ] For PTS-catalog changes: regenerated and `bun run check:catalog-drift` is clean
- [ ] No secrets, `.env` files, or credentials are committed (SECURITY.md)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Render all catalogued metrics (not just headlines) grouped by dimension, with a one‑line takeaway per metric, a slimmer main table, and a new details section for how ranks are decided. The header shows the pinned target spec and run counts, warns on compute mismatches, and coverage gaps now start with a concise summary.

- **New Features**
  - Render every emitted metric; headline is marked and shown first; dimensions with no metrics are omitted.
  - One-line takeaway per metric; tie-aware; shows ~× ratios when helpful.
  - Main table stays slim (value, 95% bootstrap interval, n) with an optional Note column: “tied”, “n too small”, “equal values/medians”; KS moves to a “Pairwise tests” details table.
  - Header prints the pinned `TARGET_SPEC` from `@sandbox-benchmarks/schema` (2 vCPU · 8 GiB RAM · 40 GB disk), plus metric/provider/observation counts; adds provider-specific comparability warnings when observed specs don’t match the target.
  - Coverage gaps add a one-line summary and keep the full table under a collapsible section.
  - API: expose `targetSpec` and `comparabilityCaveats`; export `LeaderboardMetric` and `ComparabilityCaveat`.

- **Bug Fixes**
  - Include non-headline metrics in the leaderboard and artifact sync; takeaway correctly lists every co-leader in 3+ way ties.

<sup>Written for commit 5ccd980dee484272f636aba45e672658f971c7b5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/starslingdev/sandbox-benchmarks/pull/174?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

