### PR TITLE
feat(repo-checks): secret-hygiene drift gate + tighten .gitignore blocklist

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -79,7 +79,21 @@ typings/
 
 # dotenv environment variables file
 .env
-.env.test
+.env.*
+!.env.example
+# Credential / key material — kept in lockstep with the secret-hygiene gate's KEY_EXTENSIONS +
+# SECRET_BASENAMES (tooling/repo-checks) so the working-tree defense matches what CI enforces.
+*.pem
+*.p12
+*.key
+*.pfx
+*.jks
+*.keystore
+id_rsa
+id_dsa
+id_ecdsa
+id_ed25519
+credentials.json
 
 # parcel-bundler cache (https://parceljs.org/)
 .cache

--- a/tooling/repo-checks/src/lib/secret-hygiene.ts
+++ b/tooling/repo-checks/src/lib/secret-hygiene.ts
@@ -1,0 +1,192 @@
+// Drift gate: the repository never commits credential material. SECURITY.md promises "Never commit
+// API keys, tokens, or `.env` files"; .gitignore blocks the usual filenames — but a convention plus
+// an ignore list is not enforcement (a `git add -f`, a renamed file, or a pasted key in a source
+// string all slip past both). This gate turns the promise into an invariant checked in CI, over the
+// set of files git actually tracks. Two independent checks:
+//
+//   1. Forbidden filenames — a tracked path whose name is a credential file by convention
+//      (`.env`/`.env.<env>` except the documented `.env.example`, private-key material `*.pem` /
+//      `*.key` / `*.p12` / `*.pfx` / `id_rsa` …, `credentials.json`). These carry secrets by their
+//      very name; none belongs in version control.
+//   2. Secret material in content — a tracked text file whose bytes contain a high-signal secret
+//      token (a PEM private-key header, an AWS access-key id, a GitHub PAT, a Slack/Google key).
+//      The patterns are deliberately specific (fixed vendor prefixes + length) so real source does
+//      not trip them; low-signal shapes (bare `password=`, provider tokens with no fixed prefix) are
+//      left to human review rather than risk a false gate failure.
+//
+// Pure detectors below are unit-tested on synthetic input; `checkSecretHygiene()` runs them against
+// the real tracked tree and IS the CI enforcement point (same precedent as workflow-hardening.ts).
+import { readFileSync, statSync } from "node:fs";
+import { join } from "node:path";
+import { findRepoRoot } from "./workspace.ts";
+
+/** Files whose CONTENT is not scanned for secret material, with the reason. Their bytes legitimately
+ *  contain secret-shaped strings, so scanning them would be a guaranteed false positive:
+ *   - this gate's own source + test carry the detector patterns and example tokens by necessity;
+ *   - `bun.lock` is a machine-generated dependency graph (integrity hashes look tokenish, and it is
+ *     large) — its filenames are still subject to the forbidden-name check, only its content is skipped.
+ *  Keyed by repo-relative path. Filename rules (check 1) still apply to every tracked file. */
+export const CONTENT_SCAN_EXCLUDED: Readonly<Record<string, string>> = {
+	"tooling/repo-checks/src/lib/secret-hygiene.ts": "defines the secret-material detector patterns",
+	"tooling/repo-checks/src/secret-hygiene.test.ts": "exercises the detectors with example tokens",
+	"bun.lock": "generated lockfile; integrity hashes are token-shaped and the file is large",
+};
+
+/** A tracked file larger than this is assumed generated/binary and skipped for content scanning.
+ *  Real source files are far smaller; a committed secret lives in a small text file, not a blob. */
+const MAX_CONTENT_SCAN_BYTES = 512 * 1024;
+
+/** One forbidden-filename rule: a predicate over the repo-relative path and the reason it is banned. */
+export interface FilenameRule {
+	readonly label: string;
+	readonly test: (relPath: string) => boolean;
+}
+
+/** The final path segment (works for both "/"-joined git paths and bare names). */
+function baseName(relPath: string): string {
+	const slash = relPath.lastIndexOf("/");
+	return slash === -1 ? relPath : relPath.slice(slash + 1);
+}
+
+/** Lowercased extension including the dot, or "" if none (e.g. "a/b/key.PEM" → ".pem"). */
+function extension(name: string): string {
+	const dot = name.lastIndexOf(".");
+	return dot <= 0 ? "" : name.slice(dot).toLowerCase();
+}
+
+/** Private-key / keystore extensions that should never be committed. */
+const KEY_EXTENSIONS = new Set([".pem", ".key", ".p12", ".pfx", ".jks", ".keystore"]);
+
+/** Exact basenames of conventional secret files. */
+const SECRET_BASENAMES = new Set([
+	"id_rsa",
+	"id_dsa",
+	"id_ecdsa",
+	"id_ed25519",
+	"credentials.json",
+]);
+
+/** Filename rules. A tracked path matching any of these fails the gate regardless of its content. */
+export const FILENAME_RULES: readonly FilenameRule[] = [
+	{
+		label: "dotenv file (holds environment credentials)",
+		// The dotenv family is exactly `.env` or `.env.<suffix>`. `.env.example` is the documented,
+		// secret-free template (see .gitignore `!.env.example`) and is allowed. Config files that merely
+		// end in `.env` (e.g. `target.env`, a PTS suite descriptor) are NOT dotenv files and are fine.
+		test: (rel) => {
+			const name = baseName(rel);
+			if (name === ".env.example") return false;
+			return name === ".env" || name.startsWith(".env.");
+		},
+	},
+	{
+		label: "private key / keystore material",
+		test: (rel) => KEY_EXTENSIONS.has(extension(baseName(rel))),
+	},
+	{
+		label: "conventional credential file",
+		test: (rel) => SECRET_BASENAMES.has(baseName(rel).toLowerCase()),
+	},
+];
+
+/** Repo-relative paths that trip a filename rule. Empty when the tree is clean. */
+export function forbiddenTrackedFilenames(relPaths: readonly string[]): string[] {
+	const errors: string[] = [];
+	for (const rel of relPaths) {
+		for (const rule of FILENAME_RULES) {
+			if (rule.test(rel)) {
+				errors.push(`${rel}: ${rule.label} must not be committed (see SECURITY.md)`);
+			}
+		}
+	}
+	return errors.sort();
+}
+
+/** One secret-material content detector: a label and the token pattern. Patterns are non-global: only
+ *  presence is checked (`pattern.test`), so a `g` flag would add stateful `lastIndex` for no benefit —
+ *  and this array is exported, so an external caller reusing a stateful regex could get wrong results. */
+export interface SecretPattern {
+	readonly label: string;
+	readonly pattern: RegExp;
+}
+
+/** High-signal secret tokens: fixed vendor prefixes + length so ordinary source can't trip them. New
+ *  vendor formats can be appended here. Kept narrow on purpose — see the module header. */
+export const SECRET_PATTERNS: readonly SecretPattern[] = [
+	{
+		label: "PEM private key header",
+		pattern: /-----BEGIN (?:RSA |EC |DSA |OPENSSH |PGP )?PRIVATE KEY-----/,
+	},
+	{ label: "AWS access key id", pattern: /\b(?:AKIA|ASIA)[0-9A-Z]{16}\b/ },
+	{ label: "GitHub token", pattern: /\bgh[posru]_[A-Za-z0-9]{36,}\b/ },
+	{ label: "Slack token", pattern: /\bxox[baprs]-[A-Za-z0-9-]{10,}\b/ },
+	{ label: "Google API key", pattern: /\bAIza[0-9A-Za-z_-]{35}\b/ },
+	// `sk-` (legacy) and `sk-proj-` (current) OpenAI keys; the hyphen in `proj-` needs the optional group.
+	{ label: "OpenAI-style API key", pattern: /\bsk-(?:proj-)?[A-Za-z0-9]{32,}\b/ },
+];
+
+/** Distinct secret-pattern labels found in `text` (sorted, deduped). Empty for clean content. */
+export function secretMaterialIn(text: string): string[] {
+	const hits = new Set<string>();
+	for (const { label, pattern } of SECRET_PATTERNS) {
+		if (pattern.test(text)) hits.add(label);
+	}
+	return [...hits].sort();
+}
+
+/** Bytes look binary if the head contains a NUL — skip content scanning (and its decode cost). */
+function looksBinary(buf: Buffer): boolean {
+	const end = Math.min(buf.length, 8192);
+	for (let i = 0; i < end; i++) {
+		if (buf[i] === 0) return true;
+	}
+	return false;
+}
+
+/** Repo-relative paths of every file git tracks, from `git ls-files -z` under `root`. */
+export function trackedFiles(root: string = findRepoRoot()): string[] {
+	const res = Bun.spawnSync(["git", "ls-files", "-z"], { cwd: root });
+	if (res.exitCode !== 0) {
+		throw new Error(`git ls-files failed: ${res.stderr.toString()}`);
+	}
+	return res.stdout
+		.toString("utf8")
+		.split("\0")
+		.filter((p) => p.length > 0);
+}
+
+/**
+ * The whole gate: no tracked file has a forbidden credential filename, and no scanned tracked file
+ * contains high-signal secret material. `excluded` maps content-scan-exempt paths to their reason.
+ */
+export function checkSecretHygiene(
+	root: string = findRepoRoot(),
+	excluded: Readonly<Record<string, string>> = CONTENT_SCAN_EXCLUDED,
+): string[] {
+	const files = trackedFiles(root);
+	const errors = forbiddenTrackedFilenames(files);
+
+	for (const rel of files) {
+		if (rel in excluded) continue;
+		const abs = join(root, rel);
+		let buf: Buffer;
+		try {
+			const stat = statSync(abs);
+			if (!stat.isFile() || stat.size > MAX_CONTENT_SCAN_BYTES) continue;
+			// readFileSync stays inside the try: a file tracked-but-absent can also vanish between the
+			// stat and the read (TOCTOU), so both go through the same ENOENT guard. Any other I/O error
+			// (permissions, etc.) is unexpected and must fail loudly rather than be silently skipped.
+			buf = readFileSync(abs);
+		} catch (err) {
+			if ((err as NodeJS.ErrnoException).code === "ENOENT") continue;
+			throw err;
+		}
+		if (looksBinary(buf)) continue;
+		for (const label of secretMaterialIn(buf.toString("utf8"))) {
+			errors.push(
+				`${rel}: looks like it contains a ${label} — remove the secret (see SECURITY.md)`,
+			);
+		}
+	}
+	return errors.sort();
+}

--- a/tooling/repo-checks/src/secret-hygiene.test.ts
+++ b/tooling/repo-checks/src/secret-hygiene.test.ts
@@ -1,0 +1,134 @@
+// Invariant: no credential material is ever committed. checkSecretHygiene() against the real tracked
+// tree IS the CI enforcement point (same precedent as workflow-hardening.test.ts); the rest is unit
+// coverage of the pure detectors on synthetic drift so a regression names the offender. The example
+// tokens below are syntactically valid vendor formats but are NOT real credentials — this file is in
+// CONTENT_SCAN_EXCLUDED so the gate does not scan its own fixtures. See ./lib/secret-hygiene.ts.
+import { describe, expect, test } from "bun:test";
+import {
+	CONTENT_SCAN_EXCLUDED,
+	checkSecretHygiene,
+	forbiddenTrackedFilenames,
+	SECRET_PATTERNS,
+	secretMaterialIn,
+	trackedFiles,
+} from "./lib/secret-hygiene.ts";
+
+describe("forbiddenTrackedFilenames", () => {
+	test("flags dotenv files but allows .env.example and non-dotenv *.env config", () => {
+		const errors = forbiddenTrackedFilenames([
+			".env",
+			".env.local",
+			"apps/cli/.env.production",
+			".env.example", // documented template — allowed
+			"lib/pts/realworld/selftest/target.env", // PTS suite config, not a dotenv — allowed
+			"packages/schema/src/pts-profiles/local/x/target.env", // allowed
+		]);
+		expect(errors).toEqual([
+			".env.local: dotenv file (holds environment credentials) must not be committed (see SECURITY.md)",
+			".env: dotenv file (holds environment credentials) must not be committed (see SECURITY.md)",
+			"apps/cli/.env.production: dotenv file (holds environment credentials) must not be committed (see SECURITY.md)",
+		]);
+	});
+
+	test("flags private-key / keystore extensions case-insensitively", () => {
+		const errors = forbiddenTrackedFilenames([
+			"certs/server.pem",
+			"deploy/id.KEY",
+			"a/b/store.p12",
+			"c/keystore.jks",
+			"d/app.pfx",
+			"src/index.ts", // ordinary source — allowed
+		]);
+		expect(errors).toHaveLength(5);
+		expect(errors.every((e) => e.includes("private key / keystore material"))).toBe(true);
+	});
+
+	test("flags conventional credential basenames", () => {
+		const errors = forbiddenTrackedFilenames([
+			"deploy/id_rsa",
+			"home/.ssh/id_ed25519",
+			"gcp/credentials.json",
+			"packages/schema/src/config.json", // ordinary json — allowed
+		]);
+		expect(errors).toHaveLength(3);
+		expect(errors.every((e) => e.includes("conventional credential file"))).toBe(true);
+	});
+
+	test("returns [] for a clean list", () => {
+		expect(forbiddenTrackedFilenames(["README.md", "src/index.ts", "docs/methodology.md"])).toEqual(
+			[],
+		);
+	});
+});
+
+describe("secretMaterialIn", () => {
+	test("detects a PEM private-key header", () => {
+		expect(secretMaterialIn("prefix\n-----BEGIN OPENSSH PRIVATE KEY-----\n...")).toEqual([
+			"PEM private key header",
+		]);
+	});
+
+	test("detects an AWS access key id", () => {
+		expect(secretMaterialIn("aws_access_key_id = AKIAIOSFODNN7EXAMPLE")).toEqual([
+			"AWS access key id",
+		]);
+	});
+
+	test("detects a GitHub token", () => {
+		expect(secretMaterialIn("token: ghp_0123456789abcdefghijklmnopqrstuvwxyz")).toEqual([
+			"GitHub token",
+		]);
+	});
+
+	test("detects a Google API key and an OpenAI-style key", () => {
+		// Google keys are AIza + exactly 35 of [0-9A-Za-z_-]; OpenAI-style are sk- + 32+ alnum.
+		const google = `AIza${"b".repeat(35)}`;
+		const openai = `sk-${"a".repeat(36)}`;
+		expect(secretMaterialIn(`key1 ${google} key2 ${openai}`)).toEqual([
+			"Google API key",
+			"OpenAI-style API key",
+		]);
+	});
+
+	test("does not fire on ordinary source text", () => {
+		expect(
+			secretMaterialIn(
+				"const E2B_API_KEY = process.env.E2B_API_KEY; // read the key from the environment\nhttps://example.com/sk-not-a-key",
+			),
+		).toEqual([]);
+	});
+
+	test("does not fire on a short sk- string (below the length floor)", () => {
+		expect(secretMaterialIn("sk-short")).toEqual([]);
+	});
+
+	test("detects a project-scoped OpenAI key (sk-proj- prefix)", () => {
+		expect(secretMaterialIn(`sk-proj-${"a".repeat(36)}`)).toEqual(["OpenAI-style API key"]);
+	});
+
+	test("is not stateful across calls (patterns carry no g flag)", () => {
+		// The exported SECRET_PATTERNS are non-global, so repeated presence checks never desync on
+		// lastIndex. Same input twice must give the same result.
+		const openai = `sk-${"a".repeat(36)}`;
+		expect(secretMaterialIn(openai)).toEqual(secretMaterialIn(openai));
+		expect(SECRET_PATTERNS.every((p) => !p.pattern.global)).toBe(true);
+	});
+});
+
+describe("the gate itself", () => {
+	test("the real tracked tree carries no committed secrets", () => {
+		expect(checkSecretHygiene()).toEqual([]);
+	});
+
+	test("every content-scan exclusion is a tracked file with a documented reason", () => {
+		// The exclusion list can't rot into scanning nothing: each excluded path must still be tracked,
+		// and must carry a non-empty reason (parity with workflow-hardening's CREDENTIALED_CHECKOUTS).
+		// Use the library helper (rooted at the repo, not the process cwd) so the paths are repo-relative
+		// under `bun --filter`, which runs this test from the package directory.
+		const tracked = new Set(trackedFiles());
+		for (const [path, reason] of Object.entries(CONTENT_SCAN_EXCLUDED)) {
+			expect(reason.length).toBeGreaterThan(0);
+			expect(tracked.has(path)).toBe(true);
+		}
+	});
+});


### PR DESCRIPTION
**Public-repo hardening — split into a 5-PR stack (merge bottom-up, each branch independently green):**
1. #173 — community-health: GitHub community files (`CODEOWNERS`, issue/PR templates, dependabot, CoC, SECURITY) + public README/docs hub
2. #174 — leaderboard: richer render (per-dimension takeaways, target-spec header, coverage summary) + regenerated `LEADERBOARD.md`
3. #175 — secret hygiene: repo-checks drift gate over the tracked tree + widened `.gitignore` blocklist
4. #176 — workflow YAML: gate live-bench / dataset-publish / GHCR-release behind Environment `privileged`; releases are dispatch-only
5. #177 — workflow gate: enforce the privileged-environment + dispatch-only invariants as a repo-checks drift gate

↑ **This PR is #175 (3/5)**, based on #174.

---

<!--
Thanks for contributing! Keep the summary tight and let the diff carry the detail.
Live provider benches and toolchain releases are maintainer-only (Environment `privileged`); a fork
PR runs only the hosted CI gate — see CONTRIBUTING.md and docs/ci-secrets.md.
-->

## Summary

<!-- What changes and why, in a sentence or two. -->

## Type of change

- [ ] Bug fix
- [ ] New provider / suite / metric (see CONTRIBUTING.md)
- [ ] CI / tooling / docs
- [ ] Other

## Checklist

- [ ] `bun run lint`, `bun run typecheck`, and `bun run test` pass locally (the same gate CI runs)
- [ ] `bun run spell` passes (via `mise`), if text changed
- [ ] For PTS-catalog changes: regenerated and `bun run check:catalog-drift` is clean
- [ ] No secrets, `.env` files, or credentials are committed (SECURITY.md)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a repo-checks CI gate that fails if any tracked file has a forbidden credential filename or high‑signal secret content. `.gitignore` is tightened to match the gate.

- **New Features**
  - Blocked filenames: `.env`/`.env.*` (allows `.env.example` and non-dotenv `*.env` like `target.env`); private-key/keystore `*.pem|*.p12|*.pfx|*.jks|*.keystore|*.key`; SSH keys `id_rsa|id_dsa|id_ecdsa|id_ed25519`; `credentials.json`.
  - Content scan: PEM private-key headers; AWS `AKIA`/`ASIA`; GitHub `gh[p|o|s|r|u]_…`; Slack `xox…`; Google `AIza…`; OpenAI `sk-…`/`sk-proj-…`. Skips large/binary files; excludes this gate’s source/tests and `bun.lock`. Regexes are non‑stateful and ENOENT is handled safely.

<sup>Written for commit f8415bd2cd38c0ea501209e6355737d882d54579. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/starslingdev/sandbox-benchmarks/pull/175?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

