### PR TITLE
ci: gate privileged workflows behind Environment 'privileged' + docs

### DIFF
--- a/.github/workflows/bench-matrix.yml
+++ b/.github/workflows/bench-matrix.yml
@@ -4,7 +4,8 @@ name: Bench matrix
 # cell, each spinning up a real sandbox, running its suite, and uploading the normalized Run as an
 # artifact. The matrix is computed from the SUITES × PROVIDERS registries by `plan-matrix` — adding a
 # provider or suite to its registry grows CI with no workflow edit. Off the PR path (real sandbox time
-# + provider credentials); dispatch on demand.
+# + provider credentials); dispatch on demand from main only, gated by Environment `privileged`
+# (required reviewers + environment secrets — see docs/ci-secrets.md).
 on:
   workflow_dispatch:
     inputs:
@@ -18,7 +19,7 @@ on:
         # to include it; `plan-matrix` rejects any name that is not in the registry.
         default: e2b,daytona,modal
 
-# Least privilege: jobs only read the checked-out code and upload artifacts.
+# Least privilege: jobs only read the checked-out code and upload artifacts (publish elevates).
 permissions:
   contents: read
 
@@ -29,8 +30,13 @@ concurrency:
 
 jobs:
   # Compute the provider × suite matrix once, as the single $GITHUB_OUTPUT contract the fan-out reads.
+  # No secrets — plan stays off the privileged environment so approval isn't needed just to dry-run
+  # the matrix shape; the gate below still confines dispatch to this repo's main.
   plan:
     name: Plan matrix
+    if: >
+      github.ref == 'refs/heads/main' &&
+      github.repository == 'starslingdev/sandbox-benchmarks'
     runs-on: ubuntu-24.04
     outputs:
       matrix: ${{ steps.plan.outputs.matrix }}
@@ -64,11 +70,15 @@ jobs:
   bench:
     name: ${{ matrix.suite }} on ${{ matrix.provider }}
     needs: plan
+    if: >
+      github.ref == 'refs/heads/main' &&
+      github.repository == 'starslingdev/sandbox-benchmarks'
     # The ephemeral self-hosted label is reaped after 70 minutes even while a step is healthy. The
     # full CPU-generic and real-world matrices legitimately exceed that on slower providers, leaving
     # the step stuck `in_progress` with no logs/artifact. Hosted runners honor timeout-minutes below;
     # 180 minutes also leaves teardown/artifact margin around the longest 155-minute suite budget.
     runs-on: ubuntu-24.04
+    environment: privileged
     timeout-minutes: 180
     strategy:
       # One cell's failure (a flaky provider) must not cancel the rest of the matrix.
@@ -78,8 +88,8 @@ jobs:
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
-          # This cell only reads code (the sandbox clones via BENCH_REPO_TOKEN, not the checkout's
-          # credentials), so don't persist the job token in .git/config.
+          # This cell only reads code (the sandbox clones via BENCH_REPO_TOKEN when set, not the
+          # checkout's credentials), so don't persist the job token in .git/config.
           persist-credentials: false
 
       - name: Set up Bun
@@ -96,19 +106,26 @@ jobs:
       - name: Run suite and normalize
         env:
           BENCH_REPO_REF: ${{ github.sha }}
+          # Optional once the repo is public (anonymous clone works). Still passed so private forks and
+          # rate-limited clones keep working via the short-lived job token.
           BENCH_REPO_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           BENCH_PROVIDER: ${{ matrix.provider }}
           BENCH_SUITE: ${{ matrix.suite }}
-          DAYTONA_API_KEY: ${{ secrets.DAYTONA_API_KEY }}
-          # Boot daytona sandboxes in the active region (us-west-2). Defaulted so an unsynced secret
-          # can't fail the config gatekeeper at module load.
-          DAYTONA_TARGET: ${{ secrets.DAYTONA_TARGET || 'us-west-2' }}
-          E2B_API_KEY: ${{ secrets.E2B_API_KEY }}
-          MODAL_TOKEN_ID: ${{ secrets.MODAL_TOKEN_ID }}
-          MODAL_TOKEN_SECRET: ${{ secrets.MODAL_TOKEN_SECRET }}
-          BL_API_KEY: ${{ secrets.BL_API_KEY }}
-          BL_WORKSPACE: ${{ secrets.BL_WORKSPACE }}
-          NOVITA_API_KEY: ${{ secrets.NOVITA_API_KEY }}
+          # Scope every provider credential to the cell that actually uses it: a cell receives ONLY
+          # the secret(s) for its own `matrix.provider`, so a compromised adapter or suite can't read
+          # another provider's credential out of the environment. A non-matching provider evaluates to
+          # '', which the config gatekeeper treats as unset (packages/providers/src/lib/config.ts:
+          # empty ⇒ unset), exactly like an unsynced secret — so blanking the others is inert.
+          DAYTONA_API_KEY: ${{ matrix.provider == 'daytona' && secrets.DAYTONA_API_KEY || '' }}
+          # Boot daytona sandboxes in the active region (us-west-2); the default applies only to the
+          # daytona cell so an unsynced secret can't fail the config gatekeeper at module load.
+          DAYTONA_TARGET: ${{ matrix.provider == 'daytona' && (secrets.DAYTONA_TARGET || 'us-west-2') || '' }}
+          E2B_API_KEY: ${{ matrix.provider == 'e2b' && secrets.E2B_API_KEY || '' }}
+          MODAL_TOKEN_ID: ${{ matrix.provider == 'modal' && secrets.MODAL_TOKEN_ID || '' }}
+          MODAL_TOKEN_SECRET: ${{ matrix.provider == 'modal' && secrets.MODAL_TOKEN_SECRET || '' }}
+          BL_API_KEY: ${{ matrix.provider == 'blaxel' && secrets.BL_API_KEY || '' }}
+          BL_WORKSPACE: ${{ matrix.provider == 'blaxel' && secrets.BL_WORKSPACE || '' }}
+          NOVITA_API_KEY: ${{ matrix.provider == 'novita' && secrets.NOVITA_API_KEY || '' }}
         run: bun apps/cli/src/bin/bench-suite.ts "$BENCH_PROVIDER" "$BENCH_SUITE" "$GITHUB_RUN_ID"
 
       - name: Upload Run + raw results
@@ -122,17 +139,26 @@ jobs:
           # data/ means the job is genuinely broken — fail the upload rather than bury a warning.
           if-no-files-found: error
 
-  # Collect every shard Run, aggregate into one candidate, gate it (promote), and commit the published
-  # dataset. candidate→promote: aggregate is the collect half, promote the validate-and-publish half.
+  # Collect every shard Run, aggregate into one candidate, gate it (promote), regenerate the public
+  # leaderboard, and commit both. candidate→promote: aggregate is the collect half, promote the
+  # validate-and-publish half. Environment `privileged` is required even without provider secrets —
+  # this job is the dataset release surface (`contents: write`).
   publish:
     name: Aggregate + promote dataset
-    needs: bench
+    needs: [plan, bench]
     # Run even if some matrix cells failed (fail-fast is off) so the successful shards still publish:
     # `aggregate` exits non-zero when zero shards are found and `promote` gates on >=1 validated
     # provider, so the quality bar is preserved. `!cancelled()` still lets an explicit cancel stop it.
-    if: ${{ !cancelled() }}
+    # `!cancelled()` opts out of the implicit success() gate, so require `plan` explicitly: a skipped
+    # or failed plan means there is no matrix contract, so there is nothing to publish.
+    if: >
+      !cancelled() &&
+      needs.plan.result == 'success' &&
+      github.ref == 'refs/heads/main' &&
+      github.repository == 'starslingdev/sandbox-benchmarks'
     runs-on: ubuntu-24.04
-    # Commit the published dataset back to the branch.
+    environment: privileged
+    # Commit the published dataset + leaderboard back to the branch.
     permissions:
       contents: write
     steps:
@@ -173,11 +199,15 @@ jobs:
           bun apps/cli/src/bin/aggregate.ts "$GITHUB_RUN_ID" data/candidate "${shards[@]}"
           bun apps/cli/src/bin/promote.ts "data/candidate/runs/$GITHUB_RUN_ID.json" data/dataset
 
+      # Keep LEADERBOARD.md byte-identical to what the renderer produces from the newly promoted Run.
+      - name: Regenerate leaderboard
+        run: bun apps/cli/src/bin/leaderboard.ts "data/dataset/runs/$GITHUB_RUN_ID.json" LEADERBOARD.md
+
       - name: Commit the published dataset
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
-          git add data/dataset
+          git add data/dataset LEADERBOARD.md
           if git diff --cached --quiet; then
             echo "dataset unchanged; nothing to commit"
           else

--- a/.github/workflows/bench-smoke.yml
+++ b/.github/workflows/bench-smoke.yml
@@ -2,7 +2,8 @@ name: Bench smoke
 
 # Manually-dispatched live benchmark: spins up a real provider sandbox, runs one suite, normalizes
 # the result into a Run document, and uploads it as an artifact. Off the PR path (it costs real
-# sandbox time and needs provider credentials) — run it on demand to validate the end-to-end lane.
+# sandbox time and needs provider credentials) — run it on demand from main only, gated by
+# Environment `privileged` (required reviewers + environment secrets — see docs/ci-secrets.md).
 on:
   workflow_dispatch:
     inputs:
@@ -45,10 +46,14 @@ concurrency:
 jobs:
   smoke:
     name: ${{ inputs.suite }} on ${{ inputs.provider }}
+    if: >
+      github.ref == 'refs/heads/main' &&
+      github.repository == 'starslingdev/sandbox-benchmarks'
     # The ephemeral self-hosted label is reaped after 70 minutes, while this dispatch exposes suites
     # with a 155-minute sandbox budget. Match the matrix's hosted runner and leave job-level margin
     # for checkout, sandbox teardown, normalization, and artifact upload.
     runs-on: ubuntu-24.04
+    environment: privileged
     timeout-minutes: 180
     steps:
       # Third-party actions are pinned to a commit SHA (the tag comment is for humans) so a
@@ -56,8 +61,8 @@ jobs:
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
-          # The job only reads code (the sandbox clones via BENCH_REPO_TOKEN, not the checkout's
-          # credentials), so don't persist the job token in .git/config.
+          # The job only reads code (the sandbox clones via BENCH_REPO_TOKEN when set, not the
+          # checkout's credentials), so don't persist the job token in .git/config.
           persist-credentials: false
 
       - name: Set up Bun
@@ -74,7 +79,8 @@ jobs:
       - name: Run suite and normalize
         env:
           BENCH_REPO_REF: ${{ github.sha }}
-          # The sandbox clones this private repo at the run's SHA; the short-lived job token authorizes it.
+          # Optional once the repo is public (anonymous clone works). Still passed so private forks and
+          # rate-limited clones keep working via the short-lived job token.
           BENCH_REPO_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           # Pass the dispatch inputs through the environment, never interpolated into the `run` script.
           # `provider` and `suite` are both constrained choices, but env passthrough is kept as
@@ -86,16 +92,21 @@ jobs:
           # misnamed provider secret is recorded as a skip and the job still exits 0 having
           # benchmarked nothing — assert the dispatched provider actually reached "validated".
           REQUIRE_PROVIDERS: ${{ inputs.provider }}
-          DAYTONA_API_KEY: ${{ secrets.DAYTONA_API_KEY }}
-          # Boot daytona sandboxes in the active region (us-west-2). Defaulted so an unsynced secret
-          # can't fail the config gatekeeper at module load.
-          DAYTONA_TARGET: ${{ secrets.DAYTONA_TARGET || 'us-west-2' }}
-          E2B_API_KEY: ${{ secrets.E2B_API_KEY }}
-          MODAL_TOKEN_ID: ${{ secrets.MODAL_TOKEN_ID }}
-          MODAL_TOKEN_SECRET: ${{ secrets.MODAL_TOKEN_SECRET }}
-          BL_API_KEY: ${{ secrets.BL_API_KEY }}
-          BL_WORKSPACE: ${{ secrets.BL_WORKSPACE }}
-          NOVITA_API_KEY: ${{ secrets.NOVITA_API_KEY }}
+          # Scope every provider credential to the dispatched provider: this run receives ONLY the
+          # secret(s) for `inputs.provider`, so a compromised adapter or suite can't read another
+          # provider's credential out of the environment. A non-matching provider evaluates to '',
+          # which the config gatekeeper treats as unset (packages/providers/src/lib/config.ts:
+          # empty ⇒ unset), exactly like an unsynced secret — so blanking the others is inert.
+          DAYTONA_API_KEY: ${{ inputs.provider == 'daytona' && secrets.DAYTONA_API_KEY || '' }}
+          # Boot daytona sandboxes in the active region (us-west-2); the default applies only to a
+          # daytona dispatch so an unsynced secret can't fail the config gatekeeper at module load.
+          DAYTONA_TARGET: ${{ inputs.provider == 'daytona' && (secrets.DAYTONA_TARGET || 'us-west-2') || '' }}
+          E2B_API_KEY: ${{ inputs.provider == 'e2b' && secrets.E2B_API_KEY || '' }}
+          MODAL_TOKEN_ID: ${{ inputs.provider == 'modal' && secrets.MODAL_TOKEN_ID || '' }}
+          MODAL_TOKEN_SECRET: ${{ inputs.provider == 'modal' && secrets.MODAL_TOKEN_SECRET || '' }}
+          BL_API_KEY: ${{ inputs.provider == 'blaxel' && secrets.BL_API_KEY || '' }}
+          BL_WORKSPACE: ${{ inputs.provider == 'blaxel' && secrets.BL_WORKSPACE || '' }}
+          NOVITA_API_KEY: ${{ inputs.provider == 'novita' && secrets.NOVITA_API_KEY || '' }}
         run: bun apps/cli/src/bin/bench-suite.ts "$BENCH_PROVIDER" "$BENCH_SUITE" "$GITHUB_RUN_ID"
 
       - name: Upload Run + raw results

--- a/.github/workflows/toolchain-image.yml
+++ b/.github/workflows/toolchain-image.yml
@@ -2,15 +2,17 @@ name: Toolchain image
 
 # Build, validate, and publish the sandbox-benchmarks toolchain. Two lanes:
 #   • Pull requests — build the base (no push) and run the docker smoke. Fast gate, no credentials.
-#   • Push to main / manual dispatch — build + push the mutable CANDIDATE (:v1-candidate), bake each
-#     provider's candidate artifact and validate it by booting a sandbox and running the shared smoke
-#     spec (behind each provider's secret; missing ones skip), then promote the validated candidate to
-#     the immutable public :v1. Iteration never touches :v1; bump TOOLCHAIN_VERSION
-#     (packages/schema/src/toolchain.ts) to publish a new version.
+#   • Manual dispatch on main (GitHub Environment `privileged`) — build + push the mutable
+#     CANDIDATE (:v1-candidate), bake each provider's candidate artifact and validate it by booting a
+#     sandbox and running the shared smoke spec (behind each provider's secret; missing ones skip),
+#     then promote the validated candidate to the immutable public :v1. Iteration never touches :v1;
+#     bump TOOLCHAIN_VERSION (packages/schema/src/toolchain.ts) to publish a new version.
+#
+# Releases never fire on push/merge: only workflow_dispatch reaches the publish job, and that job
+# requires Environment `privileged` approval so the public cannot complete a release.
 on:
-  # Manual re-trigger (e.g. after bumping TOOLCHAIN_VERSION). The public version is immutable on the
-  # automated push path; `force_republish` (manual dispatch only) deliberately regenerates it over an
-  # existing version for fast dev iteration. Normally, to republish you bump TOOLCHAIN_VERSION; an
+  # Manual publish (e.g. after bumping TOOLCHAIN_VERSION). `force_republish` deliberately regenerates
+  # an existing version for fast iteration. Normally, to republish you bump TOOLCHAIN_VERSION; an
   # already-published version is skipped at the guard below unless force_republish is set.
   workflow_dispatch:
     inputs:
@@ -18,31 +20,15 @@ on:
         description: "Regenerate the current version, overwriting it if already published (dev only)"
         type: boolean
         default: false
-  push:
-    branches: [main]
-    # The publish lane runs `bake`/`promote`, which pull in the whole provider-run + smoke + harness
-    # surface (not just packages/templates and the bake libs). Trigger on every file that can change
-    # bake/validate/promote behavior so a relevant change to main can't ship a version untested by it.
-    paths:
-      - "packages/templates/**"
-      - "packages/providers/**"
-      - "packages/harness/**"
-      - "apps/cli/src/lib/bake/**"
-      - "apps/cli/src/lib/providers-run.ts"
-      - "apps/cli/src/lib/smoke-run.ts"
-      - "apps/cli/src/bin/bake.ts"
-      - "packages/schema/src/toolchain.ts"
-      - ".github/workflows/toolchain-image.yml"
   pull_request:
     paths:
       - "packages/templates/**"
       - "packages/schema/src/toolchain.ts"
       - ".github/workflows/toolchain-image.yml"
 
-# Serialize publishes by ref (NOT by event_name): a push to main and a manual workflow_dispatch on the
-# same ref must not publish concurrently and race on the version tag. PR runs key off their own head ref
-# (separate group) and may cancel superseded runs; a publish is never cancelled (a half-published
-# version is worse than a slow one).
+# Serialize publishes by ref: concurrent dispatches on the same ref must not race on the version tag.
+# PR runs key off their own head ref (separate group) and may cancel superseded runs; a publish is
+# never cancelled (a half-published version is worse than a slow one).
 concurrency:
   group: toolchain-image-${{ github.ref }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
@@ -56,10 +42,8 @@ jobs:
   #
   # Same-repo guard: this job checks out the PR head and runs scripts FROM that checkout (build.sh,
   # smoke.ts) on a self-hosted runner, so a fork PR could execute arbitrary code on the runner itself.
-  # The repo is private (no untrusted forks today), but we gate on same-repo head as defense-in-depth
-  # against a compromised account / outside-collaborator fork. Branches pushed to this repo (the normal
-  # Graphite flow) satisfy it; a legitimate fork-based PR would skip the gate and need a maintainer to
-  # re-run it from an in-repo branch.
+  # Gate on same-repo head as defense-in-depth. Branches pushed to this repo satisfy it; a fork-based
+  # PR skips the gate and needs a maintainer to re-run from an in-repo branch.
   pr-gate:
     name: Build base + docker smoke
     if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
@@ -94,10 +78,16 @@ jobs:
 
   # Publish lane: candidate → validate → promote. Thin wrapper over the bake bin (thin workflow, fat
   # script). Provider steps are guarded by their secrets inside the bin (missing creds skip).
+  # Environment `privileged` holds provider secrets and requires reviewer approval on main only —
+  # see docs/ci-secrets.md.
   publish:
     name: Bake, validate & promote toolchain
-    if: github.event_name != 'pull_request'
+    if: >
+      github.event_name == 'workflow_dispatch' &&
+      github.ref == 'refs/heads/main' &&
+      github.repository == 'starslingdev/sandbox-benchmarks'
     runs-on: starsling-ubuntu-24.04-2
+    environment: privileged
     permissions:
       contents: read
       packages: write
@@ -149,7 +139,7 @@ jobs:
       # Guard the immutable public version: skip the whole publish if :v1 already exists. The version is
       # immutable (promote refuses to overwrite it), so a published version is never re-promoted — bump
       # TOOLCHAIN_VERSION to publish a new one. The candidate is mutable and always rebuilt within a run.
-      # `force_republish` (manual dispatch only) overrides the skip to regenerate the version in place.
+      # `force_republish` overrides the skip to regenerate the version in place.
       - name: Check if version already published
         id: guard
         env:
@@ -227,7 +217,7 @@ jobs:
           BUILD_DATE="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
           export BUILD_DATE
           # --require fails the publish loudly if a required provider's secret is missing/misnamed, so a
-          # merge can't bless a candidate while a required provider was silently skipped (never built or
+          # release can't bless a candidate while a required provider was silently skipped (never built or
           # validated). modal boots the toolchain image via fromRegistry under this project's Modal app
           # and is validated the same as e2b/daytona, so it's required — MODAL_TOKEN_* must be synced.
           # (blaxel is excluded — its bake is a no-op.)
@@ -253,8 +243,8 @@ jobs:
         # --require fails promote loudly if a required provider's secret is missing/misnamed, so the
         # public version is never published while a required provider's version artifact was silently
         # skipped. modal is required (validated via its fromRegistry boot); MODAL_TOKEN_* must be synced.
-        # (blaxel is excluded — its bake is a no-op.) `--force` (manual force_republish dispatch only)
-        # republishes over an existing immutable version; never set on the automated push path.
+        # (blaxel is excluded — its bake is a no-op.) `--force` (force_republish dispatch only)
+        # republishes over an existing immutable version.
         run: |
           set -euo pipefail
           args=(--promote --require "e2b,daytona,modal")

--- a/docs/ci-secrets.md
+++ b/docs/ci-secrets.md
@@ -1,0 +1,75 @@
+# CI & secrets
+
+Provider credentials and release mutations live only in the GitHub Environment **`privileged`**.
+Repository-level copies of those secrets must not exist: that is how we keep them unavailable to
+PR workflows, forks, and any job that forgot to declare the environment.
+
+`tooling/repo-checks` enforces the workflow side of this posture (see `workflow-hardening.ts`):
+custom secrets and `contents: write` / `packages: write` jobs must set `environment: privileged`,
+and toolchain publish must not trigger on `push`.
+
+## What is gated
+
+| Workflow | Job | Why |
+| --- | --- | --- |
+| `toolchain-image.yml` | `publish` | Provider bake secrets + `packages: write` (GHCR release) |
+| `bench-matrix.yml` | `bench` | Provider API keys |
+| `bench-matrix.yml` | `publish` | Dataset + leaderboard commit (`contents: write`) |
+| `bench-smoke.yml` | `smoke` | Provider API keys |
+
+Ungated: `ci.yml`, `ci-lint.yml`, and the toolchain `pr-gate` (Docker smoke, no secrets).
+
+## Release rules (public-safe)
+
+1. **No publish on merge.** Toolchain GHCR promote is `workflow_dispatch` only (never `push`).
+2. **Main only, this repo only.** Privileged jobs require
+   `github.ref == 'refs/heads/main'` and
+   `github.repository == 'starslingdev/sandbox-benchmarks'`.
+3. **Environment approval.** `privileged` must require at least one reviewer and restrict
+   deployments to the `main` branch. Write access alone cannot finish a release.
+4. **Fork PRs.** Same-repo guard on self-hosted PR jobs; fork PR code never runs on
+   `starsling-ubuntu-24.04-2`. Forks never receive Environment secrets on `pull_request`.
+
+> **Two approvals per bench-matrix run.** `bench` and `publish` both carry `environment:
+> privileged` and run sequentially, so GitHub raises **two** separate pending-deployment gates: one
+> before the matrix starts, and a second (after the long matrix finishes, ~150 min) before the
+> dataset is committed. A reviewer who approves only `bench` and walks away leaves the run parked at
+> `publish` until the second approval lands or the protection rule times out.
+
+## Operator setup (before flipping the repo public)
+
+Do this in the GitHub UI (Settings → Environments), then delete any matching **repository** secrets.
+
+1. Create Environment **`privileged`**.
+2. **Required reviewers:** at least one maintainer (two preferred).
+3. **Deployment branches:** `Selected branches` → `main` only.
+4. Add these **environment** secrets (then delete repository-level copies if present):
+
+   | Secret | Used by |
+   | --- | --- |
+   | `E2B_API_KEY` | toolchain bake, bench matrix/smoke |
+   | `DAYTONA_API_KEY` | toolchain bake, bench matrix/smoke |
+   | `DAYTONA_TARGET` | optional; workflows default to `us-west-2` |
+   | `MODAL_TOKEN_ID` | toolchain bake, bench matrix/smoke |
+   | `MODAL_TOKEN_SECRET` | toolchain bake, bench matrix/smoke |
+   | `NOVITA_API_KEY` | optional for toolchain; bench matrix/smoke |
+   | `BL_API_KEY` | bench matrix/smoke only |
+   | `BL_WORKSPACE` | bench matrix/smoke only |
+
+5. Confirm the GHCR package `sandbox-benchmarks-toolchain` is **public** so providers can pull
+   the candidate base anonymously (Org → Packages → package settings).
+
+Optional bootstrap (creates the empty environment; reviewers/secrets still need a human):
+
+```sh
+./scripts/setup-privileged-environment.sh
+```
+
+## Local credentials
+
+Copy [`.env.example`](../.env.example) to a gitignored `.env` and fill in the providers you have
+(Bun auto-loads `.env` when you run a bin). A missing credential is a skip, not a failure. Never
+commit them; never paste them into issues or pull requests. See [SECURITY.md](../SECURITY.md).
+
+The `tooling/repo-checks` secret-hygiene gate enforces this: it fails CI if any tracked file is a
+credential file (`.env`, `*.pem`, `id_rsa`, …) or contains a high-signal secret token.

--- a/scripts/setup-privileged-environment.sh
+++ b/scripts/setup-privileged-environment.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+# Create the empty GitHub Environment `privileged` for this repo.
+# Required reviewers, deployment-branch rules, and secrets must still be set in the GitHub UI —
+# see docs/ci-secrets.md. Requires `gh` authenticated with admin rights on the repository.
+set -euo pipefail
+
+if ! command -v gh >/dev/null 2>&1; then
+  echo "gh is required (https://cli.github.com/)" >&2
+  exit 1
+fi
+
+# Prefer the repo gh is pointed at (so a fork or renamed remote just works). GITHUB_REPOSITORY wins
+# if the caller set it. Fail closed if we can't resolve a name: silently defaulting to a hardcoded
+# repo could create/modify the environment on the WRONG repository.
+if [ -n "${GITHUB_REPOSITORY:-}" ]; then
+  REPO="$GITHUB_REPOSITORY"
+elif REPO="$(gh repo view --json nameWithOwner -q .nameWithOwner 2>/dev/null)" && [ -n "$REPO" ]; then
+  :
+else
+  echo "Could not determine the repository. Set GITHUB_REPOSITORY, or run inside a gh-authenticated clone." >&2
+  exit 1
+fi
+ENV_NAME="privileged"
+
+echo "Ensuring Environment '${ENV_NAME}' exists on ${REPO}…"
+# A bodyless PUT to /environments/{name} is a FULL REPLACE, not a no-op: re-running it against an
+# already-configured environment would silently reset every protection rule (required reviewers,
+# deployment-branch restriction, wait timer) to none. So probe first and create ONLY on a confirmed
+# 404 — a 403, rate limit, or transient network error must NOT be mistaken for "absent" and fall
+# through to the protection-wiping PUT. Fail closed on any non-404 error.
+set +e
+probe="$(gh api --include "repos/${REPO}/environments/${ENV_NAME}" 2>&1)"
+probe_status=$?
+set -e
+if [ "$probe_status" -eq 0 ]; then
+  echo "Environment '${ENV_NAME}' already exists — leaving its protection rules untouched."
+  echo "(Not re-PUTting: a bodyless PUT would wipe reviewers, branch rules, and the wait timer.)"
+elif printf '%s\n' "$probe" | grep -qiE '^HTTP/[0-9.]+ 404\b'; then
+  gh api --method PUT "repos/${REPO}/environments/${ENV_NAME}" >/dev/null
+  echo "Created empty Environment '${ENV_NAME}' — NOT YET PROTECTED."
+  echo "It has no required reviewers, no branch restriction, and no secrets until you finish the"
+  echo "steps below. Do not treat '${ENV_NAME}' as hardened until docs/ci-secrets.md is fully applied."
+else
+  echo "Could not determine whether Environment '${ENV_NAME}' exists (the API returned an error other" >&2
+  echo "than 404). Refusing to touch it — a blind PUT could wipe its protection rules. First response line:" >&2
+  printf '%s\n' "$probe" | head -n1 >&2
+  exit 1
+fi
+echo
+echo "Still required in the GitHub UI (Settings → Environments → ${ENV_NAME}):"
+echo "  1. Required reviewers (at least one maintainer)"
+echo "  2. Deployment branches: main only"
+echo "  3. Move provider secrets onto this environment; delete repository-level copies"
+echo
+echo "Secret checklist:"
+echo "  E2B_API_KEY, DAYTONA_API_KEY, DAYTONA_TARGET,"
+echo "  MODAL_TOKEN_ID, MODAL_TOKEN_SECRET, NOVITA_API_KEY,"
+echo "  BL_API_KEY, BL_WORKSPACE"
+echo
+echo "Full runbook: docs/ci-secrets.md"

--- a/tooling/repo-checks/src/lib/workflow-sync.ts
+++ b/tooling/repo-checks/src/lib/workflow-sync.ts
@@ -12,7 +12,10 @@
 //      of BOTH bench-smoke.yml and bench-matrix.yml — the secret a new provider needs must be wired
 //      into both the smoke lane and the matrix lane, or the live run silently skips it.
 //   4. A credential key shared across the two workflows maps to the same value expression — both
-//      lanes must hand the suite the same secret, not plan one and run the other.
+//      lanes must hand the suite the same secret, not plan one and run the other. Each lane scopes
+//      its secrets to the selected provider (so a cell only sees its own credential), and the two
+//      lanes pick that provider differently — `inputs.provider` in smoke, `matrix.provider` in the
+//      matrix fan-out — so the comparison folds those two selector tokens together before checking.
 //   5. Both live-run jobs outlast the longest registered sandbox lifetime by a fixed margin, so a
 //      suite budget increase cannot leave an otherwise healthy job to be killed by Actions first.
 //
@@ -234,9 +237,22 @@ export function checkSuiteInput(input: DispatchInput, label: string = SMOKE_WORK
 }
 
 /**
+ * Fold a credential value expression to its lane-independent form for cross-lane comparison. Each
+ * lane scopes a secret to the selected provider so a cell receives only its own credential, but the
+ * two lanes name that selector differently — `inputs.provider` (the smoke dispatch input) vs
+ * `matrix.provider` (the matrix cell) — so both selector tokens collapse to one placeholder. A
+ * genuine drift (a secret guarded on a different provider id, or a different secret entirely)
+ * survives the fold and still fails Invariant 4.
+ */
+function canonicalCredentialExpr(value: string): string {
+	return value.replace(/\b(?:inputs|matrix)\.provider\b/g, "<provider>");
+}
+
+/**
  * Invariants 3 + 4: every provider requiredEnvVar is present in the run-step env of every workflow,
- * and a key shared across them maps to the same value expression. `envByWorkflow` keys are workflow
- * paths so error messages name the offending file.
+ * and a key shared across them maps to the same value expression (modulo each lane's provider
+ * selector — see {@link canonicalCredentialExpr}). `envByWorkflow` keys are workflow paths so error
+ * messages name the offending file.
  */
 export function checkCredentialEnv(
 	envByWorkflow: Record<string, Record<string, string>>,
@@ -253,12 +269,19 @@ export function checkCredentialEnv(
 			);
 			continue;
 		}
-		// biome-ignore lint/style/noNonNullAssertion: presence checked above.
-		const values = new Set(workflows.map((wf) => envByWorkflow[wf]![key]!));
-		if (values.size > 1) {
+		// Dedupe on the canonical (selector-folded) form, but report the raw expressions so a human
+		// sees the real drift, not the placeholder. First raw value wins per canonical form.
+		const rawByCanonical = new Map<string, string>();
+		for (const wf of workflows) {
+			// biome-ignore lint/style/noNonNullAssertion: presence checked above.
+			const raw = envByWorkflow[wf]![key]!;
+			const canonical = canonicalCredentialExpr(raw);
+			if (!rawByCanonical.has(canonical)) rawByCanonical.set(canonical, raw);
+		}
+		if (rawByCanonical.size > 1) {
 			errors.push(
 				`${key}: maps to different value expressions across workflows ` +
-					`(${[...values].map((v) => `"${v}"`).join(" vs ")}) — every lane must hand the suite the same secret`,
+					`(${[...rawByCanonical.values()].map((v) => `"${v}"`).join(" vs ")}) — every lane must hand the suite the same secret`,
 			);
 		}
 	}


### PR DESCRIPTION
**Public-repo hardening — split into a 5-PR stack (merge bottom-up, each branch independently green):**
1. #173 — community-health: GitHub community files (`CODEOWNERS`, issue/PR templates, dependabot, CoC, SECURITY) + public README/docs hub
2. #174 — leaderboard: richer render (per-dimension takeaways, target-spec header, coverage summary) + regenerated `LEADERBOARD.md`
3. #175 — secret hygiene: repo-checks drift gate over the tracked tree + widened `.gitignore` blocklist
4. #176 — workflow YAML: gate live-bench / dataset-publish / GHCR-release behind Environment `privileged`; releases are dispatch-only
5. #177 — workflow gate: enforce the privileged-environment + dispatch-only invariants as a repo-checks drift gate

↑ **This PR is #176 (4/5)**, based on #175.

---

<!--
Thanks for contributing! Keep the summary tight and let the diff carry the detail.
Live provider benches and toolchain releases are maintainer-only (Environment `privileged`); a fork
PR runs only the hosted CI gate — see CONTRIBUTING.md and docs/ci-secrets.md.
-->

## Summary

<!-- What changes and why, in a sentence or two. -->

## Type of change

- [ ] Bug fix
- [ ] New provider / suite / metric (see CONTRIBUTING.md)
- [ ] CI / tooling / docs
- [ ] Other

## Checklist

- [ ] `bun run lint`, `bun run typecheck`, and `bun run test` pass locally (the same gate CI runs)
- [ ] `bun run spell` passes (via `mise`), if text changed
- [ ] For PTS-catalog changes: regenerated and `bun run check:catalog-drift` is clean
- [ ] No secrets, `.env` files, or credentials are committed (SECURITY.md)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Gate live benches, dataset publishing, and GHCR toolchain releases behind GitHub Environment `privileged`, approved on `main` only. Releases are manual (`workflow_dispatch`), and provider secrets are scoped per selected provider.

- **New Features**
  - Bench matrix/smoke: main-only; `bench` and `publish` use `environment: privileged`; `publish` depends on `[plan, bench]`, rebuilds and commits `LEADERBOARD.md`; `BENCH_REPO_TOKEN` uses `GITHUB_TOKEN`; provider creds scoped to the selected provider.
  - Toolchain image: `publish` is manual on `main` with `environment: privileged`; push triggers removed; PR gate unchanged.
  - Hardening + docs: `tooling/repo-checks` folds provider selectors across smoke/matrix; added `docs/ci-secrets.md` and `scripts/setup-privileged-environment.sh` (safe create, avoids wiping protections).

- **Migration**
  - Create Environment `privileged`, require reviewers, restrict deployments to `main`.
  - Move secrets to the environment and delete repo-level copies: `E2B_API_KEY`, `DAYTONA_API_KEY`, `DAYTONA_TARGET` (optional), `MODAL_TOKEN_ID`, `MODAL_TOKEN_SECRET`, `NOVITA_API_KEY` (optional), `BL_API_KEY`, `BL_WORKSPACE`.
  - Ensure GHCR package `sandbox-benchmarks-toolchain` is public; optionally run `./scripts/setup-privileged-environment.sh`.

<sup>Written for commit b561082b84beb1cc9da1620f59ddbf0571b20a68. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/starslingdev/sandbox-benchmarks/pull/176?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Security & Reliability**
  - Restricted benchmark/toolchain publishing to approved manual runs targeting the main branch, with required privileged environment approval.
  - Scoped provider credentials to only the selected provider for benchmark smoke and matrix executions.
  - Added extra safeguards to prevent unintended publishing/release mutations.

- **Workflow Improvements**
  - Benchmark publication now regenerates the leaderboard before publishing and updates the staged outputs accordingly.
  - Improved cross-workflow consistency checks for provider credential environment selection.

- **Documentation**
  - Added CI secrets runbook for the privileged environment and hardened release rules.
  - Added a script to set up the privileged environment with required secret checklist.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->