### PR TITLE
feat(repo-checks): enforce privileged-environment + dispatch-only drift gate

### DIFF
--- a/tooling/repo-checks/src/lib/workflow-hardening.ts
+++ b/tooling/repo-checks/src/lib/workflow-hardening.ts
@@ -1,5 +1,5 @@
-// Drift gate: the security posture of the GitHub Actions layer. Two invariants the .github/ files
-// must hold, neither of which the type system can enforce (GHA is YAML):
+// Drift gate: the security posture of the GitHub Actions layer. Invariants the .github/ files must
+// hold, none of which the type system can enforce (GHA is YAML):
 //
 //   1. persist-credentials hygiene — every `actions/checkout` step sets `persist-credentials: false`
 //      UNLESS it is one of the few jobs that later `git push`es (it needs the persisted job token).
@@ -9,8 +9,11 @@
 //   2. The ci-lint workflow actually runs the two linters at the agreed gate threshold — an actionlint
 //      job and a zizmor job invoked with `--min-severity medium --min-confidence high`. A renamed job
 //      or a loosened threshold (e.g. someone dropping --min-confidence) must fail this gate.
+//   3. Privileged-environment gate — every job that reads a custom secret (anything other than
+//      GITHUB_TOKEN / github.token) OR elevates to contents:write / packages:write must declare
+//      `environment: privileged`, so secrets and releases stay behind Environment protection rules.
+//   4. Toolchain publish is dispatch-only — toolchain-image.yml must not fire a release on push/merge.
 //
-// Mirrors runner-benchmarking's ci-lint.yml + zizmor.yml hardening, adapted to this repo's workflows.
 // Bun.YAML.parse is built into bun >= 1.3 (no new dependency).
 import { readFileSync } from "node:fs";
 import { join } from "node:path";
@@ -19,6 +22,10 @@ import { findRepoRoot } from "./workspace.ts";
 
 export const WORKFLOWS_DIR = ".github/workflows";
 export const CI_LINT_WORKFLOW = ".github/workflows/ci-lint.yml";
+export const TOOLCHAIN_WORKFLOW = "toolchain-image.yml";
+
+/** GitHub Environment name that holds provider secrets and gates releases. See docs/ci-secrets.md. */
+export const PRIVILEGED_ENVIRONMENT = "privileged";
 
 /** Checkout steps that intentionally keep the persisted job token, keyed "<file>::<jobId>", with the
  *  reason they push. Every other `actions/checkout` must set persist-credentials: false. */
@@ -27,6 +34,25 @@ export const CREDENTIALED_CHECKOUTS: Readonly<Record<string, string>> = {
 	// branch (it grants `contents: write` for exactly this), so it must keep the persisted token.
 	"bench-matrix.yml::publish": "commits + pushes the promoted dataset back to the branch",
 };
+
+/** Built-in / non-environment tokens that may appear as `${{ secrets.* }}` without requiring the
+ *  privileged Environment. Provider API keys and other org secrets must NOT be listed here. */
+const BUILTIN_SECRET_NAMES = new Set(["GITHUB_TOKEN"]);
+
+/** The only top-level triggers toolchain-image.yml may declare: manual dispatch (the sole path to
+ *  the publish job) plus the secret-free PR docker smoke gate. Anything else can fire a release. */
+const ALLOWED_TOOLCHAIN_TRIGGERS = new Set(["workflow_dispatch", "pull_request"]);
+
+/** Each `${{ … }}` expression block (inner text captured). A secret access can sit anywhere inside —
+ *  `${{ inputs.provider == 'daytona' && secrets.DAYTONA_API_KEY || '' }}` is the scoped form the
+ *  bench workflows use — so we scan the whole block for accesses rather than anchoring on `${{ secrets`.
+ *  The `s` flag lets a block span newlines. */
+const EXPR_BLOCK = /\$\{\{(.*?)\}\}/gs;
+
+/** A `secrets.NAME`, `secrets['NAME']`, or `secrets["NAME"]` access anywhere within an expression
+ *  block. GHA allows whitespace around the `.` accessor (`secrets . NAME`), so the dot form tolerates
+ *  it too — otherwise the spaced form is a silent bypass. Bracket form is rarer but just as real. */
+const SECRET_ACCESS = /secrets(?:\s*\.\s*([A-Za-z0-9_]+)|\s*\[\s*['"]([A-Za-z0-9_]+)['"]\s*\])/g;
 
 function asRecord(value: unknown, message: string): Record<string, unknown> {
 	if (value === null || typeof value !== "object" || Array.isArray(value)) {
@@ -168,13 +194,249 @@ export function checkCiLintGate(doc: unknown, label: string = CI_LINT_WORKFLOW):
 	return errors;
 }
 
+/** Collect string leaves from an `env:` mapping (job- or step-level). */
+function envStrings(envValue: unknown): string[] {
+	if (envValue === undefined || envValue === null) return [];
+	const env = asRecord(envValue, "env is not a mapping");
+	return Object.values(env).filter((v): v is string => typeof v === "string");
+}
+
+/** String values of a `with:` block (job- or step-level) — only string inputs can carry a secret
+ *  expression. Shared by the step scan and the job-level (`uses:` job) scan below. */
+function withStrings(withValue: unknown, file: string): string[] {
+	if (withValue === undefined || withValue === null) return [];
+	const withBlock = asRecord(withValue, `${file}: malformed with`);
+	return Object.values(withBlock).filter((v): v is string => typeof v === "string");
+}
+
+/** Custom secret names referenced in a string (excludes GITHUB_TOKEN). Scans every `${{ … }}` block
+ *  for secret accesses, so a secret guarded behind a condition (`… && secrets.NAME || ''`) or paired
+ *  with others in one block is caught, not just a block that opens with `secrets`. */
+export function customSecretsIn(text: string): string[] {
+	const found: string[] = [];
+	for (const block of text.matchAll(EXPR_BLOCK)) {
+		const inner = block[1] ?? "";
+		for (const match of inner.matchAll(SECRET_ACCESS)) {
+			const name = match[1] || match[2];
+			if (name && !BUILTIN_SECRET_NAMES.has(name)) found.push(name);
+		}
+	}
+	return found;
+}
+
+/** Normalize GHA `permissions:` to a scope mapping. It may be a mapping, `undefined`, or the string
+ *  shorthand `write-all` (every scope → write) / `read-all` (no scope → write); the shorthand is
+ *  expanded here so every downstream reader sees one shape and never re-decodes the string form. */
+type Permissions = Record<string, unknown> | undefined;
+function parsePermissions(value: unknown, message: string): Permissions {
+	if (value === undefined || value === null) return undefined;
+	if (typeof value === "string")
+		return value === "write-all" ? { contents: "write", packages: "write" } : {};
+	return asRecord(value, message);
+}
+
+/** Effective write scopes for a job: job permissions override top-level when the job sets any (a job
+ *  that declares `read-all` normalizes to `{}` — defined, so it still overrides). */
+function effectiveWriteScopes(
+	workflowPerms: Permissions,
+	jobPerms: Permissions,
+): { contentsWrite: boolean; packagesWrite: boolean } {
+	const scopes = jobPerms ?? workflowPerms ?? {};
+	return {
+		contentsWrite: scopes.contents === "write",
+		packagesWrite: scopes.packages === "write",
+	};
+}
+
+/** Resolve a job's `environment` name (string form or `{ name: … }` mapping). */
+export function jobEnvironmentName(job: Record<string, unknown>): string | undefined {
+	const env = job.environment;
+	if (typeof env === "string") return env;
+	if (env !== null && typeof env === "object" && !Array.isArray(env)) {
+		const name = (env as Record<string, unknown>).name;
+		return typeof name === "string" ? name : undefined;
+	}
+	return undefined;
+}
+
+/** Every string on a job that could embed a `${{ secrets.* }}` reference: the job's `if`, env leaves,
+ *  and job-level `with:` values, plus each step's `if`, env leaves, `with:` values, and `run`.
+ *  Gathering them in one place means the secret scan is a single pass, and a new secret-bearing
+ *  surface is one more push here. */
+function jobSecretStrings(job: Record<string, unknown>, file: string, jobId: string): string[] {
+	const strings: string[] = [];
+	if (typeof job.if === "string") strings.push(job.if);
+	strings.push(...envStrings(job.env));
+	// A reusable-workflow call (`uses:` on the job) has no steps: its inputs ride a JOB-LEVEL `with:`.
+	// A caller can pass `${{ secrets.* }}` as an input there (instead of via the `secrets:` block), so
+	// scan it too — otherwise that path is a silent bypass of the privileged-environment gate.
+	strings.push(...withStrings(job.with, file));
+	const steps = Array.isArray(job.steps) ? job.steps : [];
+	for (const stepValue of steps) {
+		const step = asRecord(stepValue, `${file}: job "${jobId}" has a malformed step`);
+		if (typeof step.if === "string") strings.push(step.if);
+		strings.push(...envStrings(step.env));
+		// Inline secrets in `with:` (e.g. docker/login-action password) — only string values can carry one.
+		strings.push(...withStrings(step.with, file));
+		if (typeof step.run === "string") strings.push(step.run);
+	}
+	return strings;
+}
+
+/**
+ * Invariant 3: jobs that touch custom secrets or elevate write permissions must sit behind the
+ * `privileged` GitHub Environment so Environment secrets + required reviewers apply.
+ */
+export function checkPrivilegedEnvironment(
+	doc: unknown,
+	file: string,
+	privileged: string = PRIVILEGED_ENVIRONMENT,
+): string[] {
+	const errors: string[] = [];
+	const root = asRecord(doc, `${file}: not a YAML mapping`);
+	const workflowPerms = parsePermissions(root.permissions, `${file}: malformed permissions`);
+	// Workflow-level `env` is inherited by every job/step — secrets there must not bypass the gate.
+	const workflowSecrets = envStrings(root.env).flatMap(customSecretsIn);
+	const jobs = asRecord(root.jobs, `${file}: no jobs mapping`);
+
+	for (const [jobId, jobValue] of Object.entries(jobs)) {
+		const job = asRecord(jobValue, `${file}: job "${jobId}" is not a mapping`);
+		const key = `${file}::${jobId}`;
+		const secrets = new Set([
+			...workflowSecrets,
+			...jobSecretStrings(job, file, jobId).flatMap(customSecretsIn),
+		]);
+
+		// A reusable-workflow call (`uses:` on the job) with a `secrets:` block forwards secrets to the
+		// callee with no `${{ secrets.* }}` appearing here — `secrets: inherit` forwards ALL of them.
+		// A non-null secrets block on a uses-job is therefore a custom-secret exposure the gate must see.
+		const forwardsSecrets =
+			typeof job.uses === "string" && job.secrets !== undefined && job.secrets !== null;
+
+		const jobPerms = parsePermissions(
+			job.permissions,
+			`${file}: job "${jobId}" malformed permissions`,
+		);
+		const { contentsWrite, packagesWrite } = effectiveWriteScopes(workflowPerms, jobPerms);
+		const needsPrivileged = secrets.size > 0 || forwardsSecrets || contentsWrite || packagesWrite;
+		if (!needsPrivileged) continue;
+
+		const envName = jobEnvironmentName(job);
+		if (envName !== privileged) {
+			const reasons: string[] = [];
+			if (secrets.size > 0) {
+				reasons.push(`custom secrets (${[...secrets].sort().join(", ")})`);
+			}
+			if (forwardsSecrets) reasons.push("secrets forwarded to a reusable workflow");
+			if (contentsWrite) reasons.push("contents: write");
+			if (packagesWrite) reasons.push("packages: write");
+			errors.push(
+				`${key}: must set \`environment: ${privileged}\` because it uses ${reasons.join(" and ")} — ` +
+					`see docs/ci-secrets.md`,
+			);
+		}
+	}
+	return errors;
+}
+
+/**
+ * Invariant 4: toolchain-image.yml publishes only via workflow_dispatch — a push/merge must never
+ * start a GHCR release. Allowed top-level triggers are exactly `workflow_dispatch` + `pull_request`
+ * (the secret-free PR gate). Call only with that workflow's document; {@link runHardeningCheck}
+ * does the file selection.
+ */
+export function checkToolchainDispatchOnly(
+	doc: unknown,
+	file: string = TOOLCHAIN_WORKFLOW,
+): string[] {
+	const errors: string[] = [];
+	const root = asRecord(doc, `${file}: not a YAML mapping`);
+	// Bun.YAML keeps the GHA `on:` key as the string "on" (see workflow-sync.ts). `on:` may be a
+	// mapping, a single string (`on: workflow_dispatch`), or an array (`on: [dispatch, pull_request]`).
+	// Normalize all three to a trigger-name set so a shorthand form can't slip past the check.
+	const on = root.on;
+	let triggers: Record<string, unknown>;
+	if (typeof on === "string") {
+		triggers = { [on]: {} };
+	} else if (Array.isArray(on)) {
+		triggers = Object.fromEntries(
+			on.filter((t): t is string => typeof t === "string").map((t) => [t, {}]),
+		);
+	} else if (on !== null && typeof on === "object") {
+		triggers = on as Record<string, unknown>;
+	} else {
+		errors.push(`${file}: missing or malformed \`on:\` trigger map`);
+		return errors;
+	}
+	for (const key of Object.keys(triggers)) {
+		if (!ALLOWED_TOOLCHAIN_TRIGGERS.has(key)) {
+			errors.push(
+				`${file}: trigger \`${key}\` is not allowed — toolchain publish is workflow_dispatch-only ` +
+					`(plus pull_request for the secret-free PR gate); see docs/ci-secrets.md`,
+			);
+		}
+	}
+	if (!("workflow_dispatch" in triggers)) {
+		errors.push(
+			`${file}: must declare \`workflow_dispatch\` — that is the only path that reaches the publish job`,
+		);
+	}
+	if (!("pull_request" in triggers)) {
+		errors.push(
+			`${file}: must declare \`pull_request\` — the secret-free PR docker smoke gate must stay on the PR path`,
+		);
+	}
+
+	const jobs = asRecord(root.jobs, `${file}: no jobs mapping`);
+	if (!("publish" in jobs)) {
+		errors.push(`${file}: missing the "publish" job — that is the GHCR release lane`);
+		return errors;
+	}
+	const publish = asRecord(jobs.publish, `${file}: publish job is not a mapping`);
+	if (jobEnvironmentName(publish) !== PRIVILEGED_ENVIRONMENT) {
+		errors.push(
+			`${file}::publish: must set \`environment: ${PRIVILEGED_ENVIRONMENT}\` — GHCR promote is a release`,
+		);
+	}
+	const publishIf = typeof publish.if === "string" ? publish.if : "";
+	for (const needle of [
+		"workflow_dispatch",
+		"refs/heads/main",
+		"starslingdev/sandbox-benchmarks",
+	] as const) {
+		if (!publishIf.includes(needle)) {
+			errors.push(
+				`${file}::publish: \`if:\` must confine the release to workflow_dispatch on main of ` +
+					`starslingdev/sandbox-benchmarks (missing "${needle}")`,
+			);
+		}
+	}
+	return errors;
+}
+
 /** The whole gate against the real .github files under `root`. */
 export function runHardeningCheck(root: string = findRepoRoot()): string[] {
-	const steps = listWorkflowFiles(root).flatMap((file) =>
-		checkoutSteps(readWorkflow(`${WORKFLOWS_DIR}/${file}`, root), file),
+	const files = listWorkflowFiles(root);
+	const docs = new Map(
+		files.map((file) => [file, readWorkflow(`${WORKFLOWS_DIR}/${file}`, root)] as const),
 	);
-	return [
+	const steps = files.flatMap((file) => checkoutSteps(docs.get(file), file));
+	const ciLintFile = CI_LINT_WORKFLOW.slice(`${WORKFLOWS_DIR}/`.length);
+	const ciLintDoc = docs.get(ciLintFile);
+	const errors = [
 		...checkPersistCredentials(steps),
-		...checkCiLintGate(readWorkflow(CI_LINT_WORKFLOW, root)),
+		...(ciLintDoc === undefined
+			? [`${CI_LINT_WORKFLOW}: missing from ${WORKFLOWS_DIR}`]
+			: checkCiLintGate(ciLintDoc)),
 	];
+	for (const file of files) {
+		errors.push(...checkPrivilegedEnvironment(docs.get(file), file));
+	}
+	const toolchainDoc = docs.get(TOOLCHAIN_WORKFLOW);
+	if (toolchainDoc === undefined) {
+		errors.push(`${TOOLCHAIN_WORKFLOW}: missing from ${WORKFLOWS_DIR}`);
+	} else {
+		errors.push(...checkToolchainDispatchOnly(toolchainDoc, TOOLCHAIN_WORKFLOW));
+	}
+	return errors;
 }

--- a/tooling/repo-checks/src/workflow-hardening.test.ts
+++ b/tooling/repo-checks/src/workflow-hardening.test.ts
@@ -1,9 +1,10 @@
 // Invariant: the GitHub Actions layer stays hardened. (1) every actions/checkout opts out of
-// credential persistence unless it is an allowlisted pushing checkout, and (2) ci-lint.yml runs
-// actionlint + zizmor at the agreed gate threshold. The runHardeningCheck() test against the real
-// .github files IS the gate's CI enforcement point (same precedent as workflow-registry-sync.test.ts);
-// the rest is unit coverage of the pure checks on synthetic drift so a regression names the offender.
-// See ./lib/workflow-hardening.ts.
+// credential persistence unless it is an allowlisted pushing checkout, (2) ci-lint.yml runs
+// actionlint + zizmor at the agreed gate threshold, (3) custom-secret / write jobs declare
+// environment: privileged, and (4) toolchain publish is workflow_dispatch-only. The
+// runHardeningCheck() test against the real .github files IS the gate's CI enforcement point
+// (same precedent as workflow-registry-sync.test.ts); the rest is unit coverage of the pure checks
+// on synthetic drift so a regression names the offender. See ./lib/workflow-hardening.ts.
 import { describe, expect, test } from "bun:test";
 import type { CheckoutStep } from "./lib/workflow-hardening.ts";
 import {
@@ -12,11 +13,21 @@ import {
 	checkCiLintGate,
 	checkoutSteps,
 	checkPersistCredentials,
+	checkPrivilegedEnvironment,
+	checkToolchainDispatchOnly,
+	customSecretsIn,
 	listWorkflowFiles,
+	PRIVILEGED_ENVIRONMENT,
 	readWorkflow,
 	runHardeningCheck,
+	TOOLCHAIN_WORKFLOW,
 	WORKFLOWS_DIR,
 } from "./lib/workflow-hardening.ts";
+
+/** A no-op step — the body for fixtures whose step content is irrelevant to what they assert. */
+const NOOP_STEP = { run: "true" };
+/** Build a single-job workflow doc: `{ ...root, jobs: { [id]: job } }`. */
+const oneJob = (id: string, job: object, root: object = {}) => ({ ...root, jobs: { [id]: job } });
 
 describe("checkoutSteps against the real workflows", () => {
 	test("every workflow's checkouts are extracted with a persist-credentials reading", () => {
@@ -135,6 +146,241 @@ describe("checkCiLintGate", () => {
 		const errors = checkCiLintGate(loosened);
 		expect(errors).toHaveLength(1);
 		expect(errors[0]).toContain("--min-confidence high");
+	});
+});
+
+describe("customSecretsIn", () => {
+	test("ignores GITHUB_TOKEN and extracts provider secrets in dot and bracket notation", () => {
+		expect(
+			customSecretsIn(
+				// biome-ignore lint/suspicious/noTemplateCurlyInString: literal GitHub Actions expression under test
+				"${{ secrets.GITHUB_TOKEN }} ${{ secrets.E2B_API_KEY }} ${{ secrets.DAYTONA_TARGET || 'us-west-2' }} ${{ secrets['NOVITA_API_KEY'] }} ${{ secrets[\"BL_API_KEY\"] }}",
+			),
+		).toEqual(["E2B_API_KEY", "DAYTONA_TARGET", "NOVITA_API_KEY", "BL_API_KEY"]);
+	});
+
+	test("matches the dot accessor even with GHA-legal whitespace around it", () => {
+		expect(
+			// biome-ignore lint/suspicious/noTemplateCurlyInString: literal GitHub Actions expression under test
+			customSecretsIn("${{ secrets . E2B_API_KEY }} ${{ secrets. DAYTONA_API_KEY }}"),
+		).toEqual(["E2B_API_KEY", "DAYTONA_API_KEY"]);
+	});
+
+	test("detects a secret guarded behind a condition (the scoped `&& secrets.X || ''` form)", () => {
+		expect(
+			// biome-ignore lint/suspicious/noTemplateCurlyInString: literal GitHub Actions expression under test
+			customSecretsIn("${{ inputs.provider == 'daytona' && secrets.DAYTONA_API_KEY || '' }}"),
+		).toEqual(["DAYTONA_API_KEY"]);
+	});
+
+	test("finds every secret access within a single expression block", () => {
+		expect(
+			// biome-ignore lint/suspicious/noTemplateCurlyInString: literal GitHub Actions expression under test
+			customSecretsIn("${{ secrets.A || secrets.B }}"),
+		).toEqual(["A", "B"]);
+	});
+});
+
+describe("checkPrivilegedEnvironment", () => {
+	test("passes the real privileged workflows", () => {
+		for (const file of ["bench-matrix.yml", "bench-smoke.yml", "toolchain-image.yml"]) {
+			expect(checkPrivilegedEnvironment(readWorkflow(`${WORKFLOWS_DIR}/${file}`), file)).toEqual(
+				[],
+			);
+		}
+	});
+
+	test("passes jobs that only use GITHUB_TOKEN without an environment", () => {
+		// biome-ignore lint/suspicious/noTemplateCurlyInString: literal GitHub Actions expression under test
+		const env = { TOKEN: "${{ secrets.GITHUB_TOKEN }}" };
+		const doc = oneJob("clone", { steps: [{ env, run: "true" }] });
+		expect(checkPrivilegedEnvironment(doc, "safe.yml")).toEqual([]);
+	});
+
+	test("flags a custom secret without environment: privileged", () => {
+		// biome-ignore lint/suspicious/noTemplateCurlyInString: literal GitHub Actions expression under test
+		const env = { E2B_API_KEY: "${{ secrets.E2B_API_KEY }}" };
+		const doc = oneJob("bench", { steps: [{ env, run: "true" }] });
+		const errors = checkPrivilegedEnvironment(doc, "leak.yml");
+		expect(errors).toHaveLength(1);
+		expect(errors[0]).toContain("leak.yml::bench");
+		expect(errors[0]).toContain(`environment: ${PRIVILEGED_ENVIRONMENT}`);
+		expect(errors[0]).toContain("E2B_API_KEY");
+	});
+
+	test("flags a provider-scoped secret env value (condition && secrets.X || '') without privileged", () => {
+		// The bench/smoke lanes scope each secret behind a condition; the gate must still require
+		// `environment: privileged` for such a job, or removing it would silently pass the drift gate.
+		const env = {
+			// biome-ignore lint/suspicious/noTemplateCurlyInString: literal GitHub Actions expression under test
+			DAYTONA_API_KEY: "${{ matrix.provider == 'daytona' && secrets.DAYTONA_API_KEY || '' }}",
+		};
+		const doc = oneJob("bench", { steps: [{ env, run: "true" }] });
+		const errors = checkPrivilegedEnvironment(doc, "scoped-leak.yml");
+		expect(errors).toHaveLength(1);
+		expect(errors[0]).toContain("scoped-leak.yml::bench");
+		expect(errors[0]).toContain("DAYTONA_API_KEY");
+		expect(errors[0]).toContain(`environment: ${PRIVILEGED_ENVIRONMENT}`);
+	});
+
+	test("flags custom secrets in job or step if conditions without environment: privileged", () => {
+		const doc = oneJob("bench", {
+			// biome-ignore lint/suspicious/noTemplateCurlyInString: literal GitHub Actions expression under test
+			if: "${{ secrets.JOB_SECRET != '' }}",
+			// biome-ignore lint/suspicious/noTemplateCurlyInString: literal GitHub Actions expression under test
+			steps: [{ if: "${{ secrets.STEP_SECRET != '' }}", run: "true" }],
+		});
+		const errors = checkPrivilegedEnvironment(doc, "leak-if.yml");
+		expect(errors).toHaveLength(1);
+		expect(errors[0]).toContain("leak-if.yml::bench");
+		expect(errors[0]).toContain("JOB_SECRET");
+		expect(errors[0]).toContain("STEP_SECRET");
+	});
+
+	test("flags custom secrets in workflow-level env inherited by every job", () => {
+		const doc = oneJob(
+			"plan",
+			{ steps: [NOOP_STEP] },
+			// biome-ignore lint/suspicious/noTemplateCurlyInString: literal GitHub Actions expression under test
+			{ env: { E2B_API_KEY: "${{ secrets.E2B_API_KEY }}" } },
+		);
+		const errors = checkPrivilegedEnvironment(doc, "leak-root-env.yml");
+		expect(errors).toHaveLength(1);
+		expect(errors[0]).toContain("leak-root-env.yml::plan");
+		expect(errors[0]).toContain("E2B_API_KEY");
+	});
+
+	test("flags packages: write without the privileged environment", () => {
+		const doc = oneJob("publish", { permissions: { packages: "write" }, steps: [NOOP_STEP] });
+		const errors = checkPrivilegedEnvironment(doc, "ghcr.yml");
+		expect(errors).toHaveLength(1);
+		expect(errors[0]).toContain("packages: write");
+	});
+
+	test("accepts a write job that declares environment: privileged", () => {
+		const doc = oneJob("publish", {
+			environment: PRIVILEGED_ENVIRONMENT,
+			permissions: { contents: "write" },
+			steps: [NOOP_STEP],
+		});
+		expect(checkPrivilegedEnvironment(doc, "ok.yml")).toEqual([]);
+	});
+
+	test("handles the string permissions shorthand (write-all elevates, read-all does not)", () => {
+		// `permissions: write-all` grants contents+packages write — must be flagged; the string form
+		// must not throw (it once crashed asRecord). `read-all` grants no write, so it is clean.
+		const errors = checkPrivilegedEnvironment(
+			oneJob("publish", { permissions: "write-all", steps: [NOOP_STEP] }),
+			"write-all.yml",
+		);
+		expect(errors).toHaveLength(1);
+		expect(errors[0]).toContain("contents: write");
+		expect(errors[0]).toContain("packages: write");
+
+		expect(
+			checkPrivilegedEnvironment(
+				oneJob("publish", { permissions: "read-all", steps: [NOOP_STEP] }),
+				"read-all.yml",
+			),
+		).toEqual([]);
+	});
+
+	test("flags secrets forwarded to a reusable workflow (secrets: inherit) without privileged", () => {
+		// `secrets: inherit` on a `uses:` job forwards every repo secret with no ${{ secrets.* }} here.
+		const doc = oneJob("call", {
+			uses: "org/repo/.github/workflows/release.yml@main",
+			secrets: "inherit",
+		});
+		const errors = checkPrivilegedEnvironment(doc, "reusable.yml");
+		expect(errors).toHaveLength(1);
+		expect(errors[0]).toContain("reusable workflow");
+		expect(errors[0]).toContain(`environment: ${PRIVILEGED_ENVIRONMENT}`);
+	});
+
+	test("accepts a reusable-workflow call that forwards secrets behind privileged", () => {
+		const doc = oneJob("call", {
+			uses: "org/repo/.github/workflows/release.yml@main",
+			secrets: "inherit",
+			environment: PRIVILEGED_ENVIRONMENT,
+		});
+		expect(checkPrivilegedEnvironment(doc, "reusable-ok.yml")).toEqual([]);
+	});
+
+	test("flags a secret passed to a reusable workflow via a JOB-LEVEL with: input", () => {
+		// A `uses:` job has no steps: its inputs ride a job-level `with:`. Passing a secret as an input
+		// there (instead of the `secrets:` block) must not slip past the gate.
+		const doc = oneJob("call", {
+			uses: "org/repo/.github/workflows/deploy.yml@main",
+			// biome-ignore lint/suspicious/noTemplateCurlyInString: literal GitHub Actions expression under test
+			with: { api_key: "${{ secrets.DEPLOY_KEY }}" },
+		});
+		const errors = checkPrivilegedEnvironment(doc, "with-leak.yml");
+		expect(errors).toHaveLength(1);
+		expect(errors[0]).toContain("DEPLOY_KEY");
+		expect(errors[0]).toContain(`environment: ${PRIVILEGED_ENVIRONMENT}`);
+	});
+
+	test("accepts a job-level with: secret input behind privileged", () => {
+		const doc = oneJob("call", {
+			uses: "org/repo/.github/workflows/deploy.yml@main",
+			// biome-ignore lint/suspicious/noTemplateCurlyInString: literal GitHub Actions expression under test
+			with: { api_key: "${{ secrets.DEPLOY_KEY }}" },
+			environment: PRIVILEGED_ENVIRONMENT,
+		});
+		expect(checkPrivilegedEnvironment(doc, "with-ok.yml")).toEqual([]);
+	});
+});
+
+describe("checkToolchainDispatchOnly", () => {
+	// The main-only dispatch guard the publish job's `if:` must carry, and a publish job that passes.
+	const DISPATCH_GATE_IF =
+		"github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main' && github.repository == 'starslingdev/sandbox-benchmarks'";
+	const gatedPublish = {
+		environment: PRIVILEGED_ENVIRONMENT,
+		if: DISPATCH_GATE_IF,
+		steps: [NOOP_STEP],
+	};
+
+	test("passes the real toolchain-image.yml", () => {
+		expect(
+			checkToolchainDispatchOnly(
+				readWorkflow(`${WORKFLOWS_DIR}/${TOOLCHAIN_WORKFLOW}`),
+				TOOLCHAIN_WORKFLOW,
+			),
+		).toEqual([]);
+	});
+
+	test("flags a push trigger on the toolchain workflow", () => {
+		const doc = {
+			on: { workflow_dispatch: {}, pull_request: {}, push: { branches: ["main"] } },
+			jobs: { publish: gatedPublish },
+		};
+		const errors = checkToolchainDispatchOnly(doc, TOOLCHAIN_WORKFLOW);
+		expect(errors).toHaveLength(1);
+		expect(errors[0]).toContain("trigger `push` is not allowed");
+	});
+
+	test("flags a publish job missing the main-only dispatch gate", () => {
+		const doc = {
+			on: { workflow_dispatch: {}, pull_request: {} },
+			jobs: { publish: { ...gatedPublish, if: "true" } },
+		};
+		const errors = checkToolchainDispatchOnly(doc, TOOLCHAIN_WORKFLOW);
+		expect(errors.some((e) => e.includes('missing "workflow_dispatch"'))).toBe(true);
+		expect(errors.some((e) => e.includes('missing "refs/heads/main"'))).toBe(true);
+	});
+
+	test("normalizes the string and array `on:` shorthand forms", () => {
+		// `on: workflow_dispatch` (string) has no pull_request → the PR-gate requirement fires.
+		const stringForm = { on: "workflow_dispatch", jobs: { publish: gatedPublish } };
+		const stringErrors = checkToolchainDispatchOnly(stringForm, TOOLCHAIN_WORKFLOW);
+		expect(stringErrors.some((e) => e.includes("must declare `pull_request`"))).toBe(true);
+		// `on: [workflow_dispatch, pull_request]` (array) is the allowed pair → clean.
+		const arrayForm = {
+			on: ["workflow_dispatch", "pull_request"],
+			jobs: { publish: gatedPublish },
+		};
+		expect(checkToolchainDispatchOnly(arrayForm, TOOLCHAIN_WORKFLOW)).toEqual([]);
 	});
 });
 


### PR DESCRIPTION
**Public-repo hardening — split into a 5-PR stack (merge bottom-up, each branch independently green):**
1. #173 — community-health: GitHub community files (`CODEOWNERS`, issue/PR templates, dependabot, CoC, SECURITY) + public README/docs hub
2. #174 — leaderboard: richer render (per-dimension takeaways, target-spec header, coverage summary) + regenerated `LEADERBOARD.md`
3. #175 — secret hygiene: repo-checks drift gate over the tracked tree + widened `.gitignore` blocklist
4. #176 — workflow YAML: gate live-bench / dataset-publish / GHCR-release behind Environment `privileged`; releases are dispatch-only
5. #177 — workflow gate: enforce the privileged-environment + dispatch-only invariants as a repo-checks drift gate

↑ **This PR is #177 (5/5)**, based on #176. Enforces the YAML hardening in #176 — RED if it landed below it.

---

<!--
Thanks for contributing! Keep the summary tight and let the diff carry the detail.
Live provider benches and toolchain releases are maintainer-only (Environment `privileged`); a fork
PR runs only the hosted CI gate — see CONTRIBUTING.md and docs/ci-secrets.md.
-->

## Summary

<!-- What changes and why, in a sentence or two. -->

## Type of change

- [ ] Bug fix
- [ ] New provider / suite / metric (see CONTRIBUTING.md)
- [ ] CI / tooling / docs
- [ ] Other

## Checklist

- [ ] `bun run lint`, `bun run typecheck`, and `bun run test` pass locally (the same gate CI runs)
- [ ] `bun run spell` passes (via `mise`), if text changed
- [ ] For PTS-catalog changes: regenerated and `bun run check:catalog-drift` is clean
- [ ] No secrets, `.env` files, or credentials are committed (SECURITY.md)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a repo-checks drift gate that requires `environment: privileged` for jobs that read custom secrets or request write permissions, and locks `toolchain-image.yml` publishing to manual `workflow_dispatch` on `main`. Secret detection now scans full `${{ … }}` blocks (including conditional/scoped forms) and covers GHA shorthands and reusable workflow paths.

- **New Features**
  - Enforce `environment: privileged` when jobs read non-`GITHUB_TOKEN` secrets (incl. workflow-level `env`), forward secrets via job `uses` (`secrets`/`inherit`), pass secrets via job-level `with:` on a `uses:` job, or set `contents`/`packages: write`; scans job/step `if`, `env`, `with`, and `run`; detects secrets anywhere inside `${{ … }}` (supports spaced `secrets . NAME` and bracket forms); normalizes `permissions` (`write-all`/`read-all`) and respects job overrides.
  - Lock `toolchain-image.yml` to `workflow_dispatch` and `pull_request`; require `publish` to set `environment: privileged` and guard its `if:` to `workflow_dispatch` on `refs/heads/main` in `starslingdev/sandbox-benchmarks`; normalize `on:` string/array forms and reject other triggers.

- **Migration**
  - Add `environment: privileged` to any job that uses `${{ secrets.* }}` (except `GITHUB_TOKEN`), forwards secrets to a reusable workflow, passes a secret via job-level `with:` inputs, or grants write perms.
  - In `.github/workflows/toolchain-image.yml`, keep only `workflow_dispatch` and `pull_request`; ensure `publish` is `environment: privileged` and gated to dispatch on `refs/heads/main` in `starslingdev/sandbox-benchmarks`.

<sup>Written for commit d85e6a9f905d428b9efd469a1d287f4075fddef7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/starslingdev/sandbox-benchmarks/pull/177?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

