### PR TITLE
docs: correct target-spec disk to 40 GB and mark PTS catalog design historical

### DIFF
--- a/docs/methodology.md
+++ b/docs/methodology.md
@@ -12,7 +12,7 @@ schema-validated dataset.
 ## Target spec
 
 Every provider is created at one pinned [`TARGET_SPEC`](../packages/schema/src/providers.ts): **2 vCPU,
-8 GiB RAM, 20 GB disk**. It's sized to fit inside every provider's reproducible envelope (E2B caps
+8 GiB RAM, 40 GB disk**. It's sized to fit inside every provider's reproducible envelope (E2B caps
 sandbox RAM at 8 GiB), so anyone can rerun on the same shape. A provider that can't express a dimension
 runs with its actuals recorded and the mismatch disclosed (`specMatched`). Its measurements remain in
 the dataset for auditability, but the leaderboard excludes them from rankings and lists the provider in

--- a/docs/pts-catalog-and-analysis-design.md
+++ b/docs/pts-catalog-and-analysis-design.md
@@ -1,6 +1,9 @@
 # Design Doc: Scaling the PTS Catalog + Analysis Layer
 
-Status: Draft for implementation
+> **Historical design notes.** Prefer [methodology](./methodology.md) and the ADRs for current truth.
+> Kept for provenance of the catalog/analysis work; line numbers and branch names below may be stale.
+
+Status: Historical (implemented in stages; not the living source of truth)
 Branch base: `harness-live-suite` (PTS stack tops out at PR #38)
 Audience: repo owner → stacked PR series
 


### PR DESCRIPTION
methodology.md: the pinned TARGET_SPEC disk is 40 GB (was 20). pts-catalog-and-analysis-design.md:
mark it historical — implemented in stages; methodology + ADRs are the living source of truth.

Docs only; split out of the leaderboard work so the renderer PRs above carry only code + the
regenerated artifact.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Update the pinned `TARGET_SPEC` disk to 40 GB (was 20 GB) and mark the PTS catalog/analysis design doc as historical; prefer methodology and ADRs as the current source of truth.

<sup>Written for commit 364ad6351bd1596d8502864547a2a3e0c414ce1b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/starslingdev/sandbox-benchmarks/pull/178?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

