### PR TITLE
feat(results): richer leaderboard render with dimension takeaways and target spec

### DIFF
--- a/LEADERBOARD.md
+++ b/LEADERBOARD.md
@@ -2,71 +2,88 @@
 
 Run `29365910084` · commit `0343acb5c1cfd3a0aac81afc3262d4af0fa69bc7` · generated 2026-07-14T22:52:05.191Z
 
-Each table ranks the providers on that dimension's headline metric. Generated from the published Run dataset — do not edit by hand.
+Same pinned target for every provider (**2 vCPU · 8 GiB RAM · 40 GB disk**). Each table ranks providers on that
+dimension's headline metric (median of retained trials). Generated from the published Run
+dataset — do not edit by hand. Methodology: [`docs/methodology.md`](docs/methodology.md).
+
+**How to read:** value = median (p50) · 95% CI = bootstrap around that median · rows share a rank only
+when statistically indistinguishable or tied on the median (see details below) · a coverage gap means unmeasured, never a score of zero.
 
 ## cpu
 
 Headline: **Node.js web tooling** (runs/s, higher is better)
 
-| Rank | Provider | Node.js web tooling (runs/s) | 95% CI | n | p vs. above | p (KS) |
-| ---: | --- | ---: | ---: | ---: | ---: | ---: |
-| 1 | Daytona | 19.14 | 18.48 – 19.89 | 5 | — | — |
-| 2 | Novita | 17.59 | 17.22 – 18.65 | 5 | 0.016 | 0.036 |
-| 3 | E2B | 10.58 | 10.25 – 10.83 | 5 | 0.0079 | 0.0038 |
-| 4 | Modal | 9.25 | 8.7 – 9.58 | 5 | 0.0079 | 0.0038 |
+_Daytona leads · ~1.1× Novita on median (higher is better)._
+
+| Rank | Provider | Node.js web tooling (runs/s) | 95% CI | n |
+| ---: | --- | ---: | ---: | ---: |
+| 1 | Daytona | 19.14 | 18.48 – 19.89 | 5 |
+| 2 | Novita | 17.59 | 17.22 – 18.65 | 5 |
+| 3 | E2B | 10.58 | 10.25 – 10.83 | 5 |
+| 4 | Modal | 9.25 | 8.7 – 9.58 | 5 |
 
 ## disk
 
 Headline: **fio rand read 4KB, O_DIRECT (IOPS)** (higher is better)
 
-| Rank | Provider | fio rand read 4KB, O_DIRECT (IOPS) | 95% CI | n | p vs. above | p (KS) |
-| ---: | --- | ---: | ---: | ---: | ---: | ---: |
-| 1 | Daytona | 246000 | 241000 – 255000 | 5 | — | — |
-| 2 | Novita | 68100 | 66600 – 71500 | 5 | 0.0079 | 0.0038 |
-| 3 | E2B | 40800 | 39800 – 42000 | 5 | 0.0079 | 0.0038 |
-| 4 | Modal | 34900 | 33600 – 35200 | 5 | 0.0079 | 0.0038 |
+_Daytona leads · ~3.6× Novita on median (higher is better)._
+
+| Rank | Provider | fio rand read 4KB, O_DIRECT (IOPS) | 95% CI | n |
+| ---: | --- | ---: | ---: | ---: |
+| 1 | Daytona | 246000 | 241000 – 255000 | 5 |
+| 2 | Novita | 68100 | 66600 – 71500 | 5 |
+| 3 | E2B | 40800 | 39800 – 42000 | 5 |
+| 4 | Modal | 34900 | 33600 – 35200 | 5 |
 
 ## memory
 
 Headline: **STREAM Triad** (MB/s, higher is better)
 
-| Rank | Provider | STREAM Triad (MB/s) | 95% CI | n | p vs. above | p (KS) |
-| ---: | --- | ---: | ---: | ---: | ---: | ---: |
-| 1 | Daytona | 71508 | 69090 – 78270 | 5 | — | — |
-| 2 | Modal | 53700 | 45390 – 57730 | 5 | 0.0079 | 0.0038 |
-| 2 | Novita | 53140 | 52970 – 53313 | 5 | 0.69 (tied) | 0.21 |
-| 4 | E2B | 23850 | 22450 – 25430 | 5 | 0.0079 | 0.0038 |
+_Daytona leads · ~1.3× Modal on median (higher is better)._
+
+| Rank | Provider | STREAM Triad (MB/s) | 95% CI | n | Note |
+| ---: | --- | ---: | ---: | ---: | --- |
+| 1 | Daytona | 71508 | 69090 – 78270 | 5 | — |
+| 2 | Modal | 53700 | 45390 – 57730 | 5 | — |
+| 2 | Novita | 53140 | 52970 – 53313 | 5 | tied |
+| 4 | E2B | 23850 | 22450 – 25430 | 5 | — |
 
 ## network
 
 Headline: **Loopback TCP (10GB)** (Seconds, lower is better)
 
-| Rank | Provider | Loopback TCP (10GB) (Seconds) | 95% CI | n | p vs. above | p (KS) |
-| ---: | --- | ---: | ---: | ---: | ---: | ---: |
-| 1 | Daytona | 4.898 | 4.682 – 5.402 | 5 | — | — |
-| 2 | E2B | 7.764 | 7.373 – 8.467 | 5 | 0.0079 | 0.0038 |
-| 3 | Novita | 11.32 | 10.03 – 11.45 | 5 | 0.0079 | 0.0038 |
-| 4 | Modal | 52.14 | 51.04 – 55.37 | 5 | 0.0079 | 0.0038 |
+_Daytona leads · E2B is ~1.6× higher (lower is better)._
+
+| Rank | Provider | Loopback TCP (10GB) (Seconds) | 95% CI | n |
+| ---: | --- | ---: | ---: | ---: |
+| 1 | Daytona | 4.898 | 4.682 – 5.402 | 5 |
+| 2 | E2B | 7.764 | 7.373 – 8.467 | 5 |
+| 3 | Novita | 11.32 | 10.03 – 11.45 | 5 |
+| 4 | Modal | 52.14 | 51.04 – 55.37 | 5 |
 
 ## realworld
 
 Headline: **Mastra: cold install** (Seconds, lower is better)
 
-| Rank | Provider | Mastra: cold install (Seconds) | 95% CI | n | p vs. above | p (KS) |
-| ---: | --- | ---: | ---: | ---: | ---: | ---: |
-| 1 | Daytona | 31.68 | 31.27 – 33.71 | 5 | — | — |
-| 1 | Novita | 33.12 | 32.84 – 33.84 | 5 | 0.095 (tied) | 0.036 |
+_Daytona and Novita share the top on this headline (lower is better)._
+
+| Rank | Provider | Mastra: cold install (Seconds) | 95% CI | n | Note |
+| ---: | --- | ---: | ---: | ---: | --- |
+| 1 | Daytona | 31.68 | 31.27 – 33.71 | 5 | — |
+| 1 | Novita | 33.12 | 32.84 – 33.84 | 5 | tied |
 
 ## economics
 
 Headline: **Hourly cost** (USD/hr, lower is better)
 
-| Rank | Provider | Hourly cost (USD/hr) | 95% CI | n | p vs. above | p (KS) |
-| ---: | --- | ---: | ---: | ---: | ---: | ---: |
-| 1 | Daytona | 0.1494 | — | 1 | — | — |
-| 2 | Novita | 0.1627 | — | 1 | — | — |
-| 3 | E2B | 0.2304 | — | 1 | — | — |
-| 4 | Modal | 0.4774 | — | 1 | — | — |
+_Daytona is cheapest · Novita is ~1.1× higher (lower is better)._
+
+| Rank | Provider | Hourly cost (USD/hr) | 95% CI | n |
+| ---: | --- | ---: | ---: | ---: |
+| 1 | Daytona | 0.1494 | — | 1 |
+| 2 | Novita | 0.1627 | — | 1 |
+| 3 | E2B | 0.2304 | — | 1 |
+| 4 | Modal | 0.4774 | — | 1 |
 
 ## Not ranked
 
@@ -79,8 +96,10 @@ because validation or target-spec comparability was not established.
 
 ## Coverage gaps
 
-Benchmarks that produced **no result** on a provider. A gap is a missing result, not a comparable
-one — read it as the provider **failing to cover** that workload, never as a tie or a zero.
+12 uncovered results across 5 providers (Blaxel 3, Daytona 2, E2B 3, Modal 3, Novita 1). A gap is a missing result — the provider **failing to cover** that workload — never a tie or a zero.
+
+<details>
+<summary>Full coverage table</summary>
 
 | Provider | Benchmark | Outcome | Detail |
 | --- | --- | --- | --- |
@@ -104,21 +123,24 @@ its current allocation at all. That is a structural absence, not a slow result.
 **failed** — the benchmark was attempted and broke: it threw, timed out, or died with the sandbox.
 Unlike a skip, this is a reliability fact about the provider, not a decision made on its behalf.
 
----
+</details>
 
-**Reading this table.** The value is the median (p50) of the retained per-trial Samples, not the
-mean — a single stalled pass drags a mean far more than it moves a median. The 95% CI is a
-percentile bootstrap of that median (10,000 resamples, seeded from the Run id so the table is
-reproducible byte-for-byte), not a normal-theory interval: these Samples are neither normal nor
-independent of the host's scheduling.
+<details>
+<summary>How rankings are decided</summary>
 
-Rows are separated only when their full Sample distributions differ (Mann-Whitney U, two-sided, α = 0.05,
-enumerated exactly over the permutation null rather than approximated — at these sample sizes the
-normal approximation can report a p the exact test cannot actually produce).
+The value is the median (p50) of the retained per-trial Samples, not the mean — a single stalled
+pass drags a mean far more than it moves a median. The 95% CI is a percentile bootstrap of that
+median (10,000 resamples, seeded from the Run id so the table is reproducible byte-for-byte), not
+a normal-theory interval: these Samples are neither normal nor independent of the host's scheduling.
 
-**A shared rank always says why, in the `p vs. above` cell, and the reasons are not interchangeable.**
-`(tied)` — the test could have separated those providers and did not, so a faster median earned
-inside the noise is not a faster provider. This is the only one that claims two providers are
+Rows are separated only when Mann-Whitney U (two-sided, α = 0.05, enumerated exactly
+over the permutation null rather than approximated) finds evidence of stochastic ordering — at these
+sample sizes the normal approximation can report a p the exact test cannot actually produce. KS is
+reported separately for distribution *shape* and does not drive the ranking.
+
+**A Note cell always says why a rank is shared, and the reasons are not interchangeable.**
+`tied` — the test could have separated those providers and did not, so a faster median earned
+inside the noise is not a faster provider. This is the only note that claims two providers are
 statistically indistinguishable.
 
 Samples are repeated trials inside one sandbox, so their spread is environmental (neighbours, host
@@ -126,13 +148,39 @@ contention, virtualization), and a wide CI or a large `n` (the harness re-runs a
 converge) is itself the signal that the provider's performance is unstable, not that the measurement
 is imprecise.
 
-`p (KS)` is a two-sample Kolmogorov-Smirnov test against the same row above. It does **not** drive
-the ranking — it compares the two empirical distributions' *shapes* rather than their central
-tendency. Read it where it disagrees with `p vs. above`: a tied rank (large Mann-Whitney p) beside a
-small `p (KS)` means two providers with the same typical speed but different behaviour — usually one
-of them alternating between fast and stalled passes. That bimodality is what environmental noise
-looks like, and it is the reason a median alone cannot rank these providers.
-
 At the small `n` this suite produces, a non-significant result means *not enough evidence to
 separate*, never *the providers are equal*.
+
+### Pairwise tests (vs. row above)
+
+`p vs. above` is Mann-Whitney (drives rank). `p (KS)` is Kolmogorov-Smirnov on distribution
+*shape* — it does not drive the ranking. A tied Mann-Whitney beside a small KS often means the
+same typical speed with different behaviour (e.g. bimodal stalls).
+
+| Dimension | Provider | p vs. above | p (KS) |
+| --- | --- | ---: | ---: |
+| cpu | Daytona | — | — |
+| cpu | Novita | 0.016 | 0.036 |
+| cpu | E2B | 0.0079 | 0.0038 |
+| cpu | Modal | 0.0079 | 0.0038 |
+| disk | Daytona | — | — |
+| disk | Novita | 0.0079 | 0.0038 |
+| disk | E2B | 0.0079 | 0.0038 |
+| disk | Modal | 0.0079 | 0.0038 |
+| memory | Daytona | — | — |
+| memory | Modal | 0.0079 | 0.0038 |
+| memory | Novita | 0.69 (tied) | 0.21 |
+| memory | E2B | 0.0079 | 0.0038 |
+| network | Daytona | — | — |
+| network | E2B | 0.0079 | 0.0038 |
+| network | Novita | 0.0079 | 0.0038 |
+| network | Modal | 0.0079 | 0.0038 |
+| realworld | Daytona | — | — |
+| realworld | Novita | 0.095 (tied) | 0.036 |
+| economics | Daytona | — | — |
+| economics | Novita | — | — |
+| economics | E2B | — | — |
+| economics | Modal | — | — |
+
+</details>
 

--- a/packages/results/src/lib/leaderboard.test.ts
+++ b/packages/results/src/lib/leaderboard.test.ts
@@ -242,6 +242,9 @@ describe("buildLeaderboard statistical ranking", () => {
 		expect(rows[1]?.verdict).toBe("tied");
 		expect(rows[1]?.tiedWithAbove).toBe("statistical");
 		expect(rows[1]?.pVsPrevious?.mannWhitney).toBeGreaterThan(0.05);
+		// Takeaway must not claim a sole provider when the top cohort is a statistical tie.
+		expect(renderLeaderboardMarkdown(board)).toContain("share the top on this headline");
+		expect(renderLeaderboardMarkdown(board)).not.toContain("is the only ranked provider");
 	});
 
 	it("leaves a single-Sample Metric untested and ranked on its exact value", () => {
@@ -280,7 +283,7 @@ describe("buildLeaderboard statistical ranking", () => {
 describe("renderLeaderboardMarkdown statistics", () => {
 	const HEADLINE = "node_web_tooling_runs_per_s";
 
-	it("renders CI, n and the p-value, and marks a statistical tie", () => {
+	it("renders CI, n and a Note for a statistical tie", () => {
 		const md = renderLeaderboardMarkdown(
 			buildLeaderboard(
 				run([
@@ -290,14 +293,14 @@ describe("renderLeaderboardMarkdown statistics", () => {
 			),
 		);
 		expect(md).toContain("95% CI");
-		expect(md).toContain("p vs. above");
-		expect(md).toContain("(tied)");
+		expect(md).toContain("| Note |");
+		expect(md).toContain("| tied |");
 		// The reader must be told what a shared rank means, not left to infer it.
 		expect(md).toContain("statistically indistinguishable");
 		expect(md).toContain("Mann-Whitney");
 	});
 
-	it("surfaces the KS p-value in the table, not only on the row object", () => {
+	it("surfaces the KS p-value in the details section, not only on the row object", () => {
 		// Regression: `ks` was computed and stored on every LeaderboardRow, documented as the way to spot
 		// a bimodal provider, and then never rendered — so no reader of LEADERBOARD.md could ever see it.
 		const board = buildLeaderboard(
@@ -309,23 +312,21 @@ describe("renderLeaderboardMarkdown statistics", () => {
 		const md = renderLeaderboardMarkdown(board);
 
 		expect(md).toContain("p (KS)");
-		// The note must explain the column, since a second p-value is otherwise cryptic.
 		expect(md).toContain("Kolmogorov-Smirnov");
 
-		// The second row carries both p-values (rank 1 has no predecessor, so both cells are em-dashes).
 		expect(board.dimensions[0]?.rows[1]?.pVsPrevious).not.toBeNull();
 
-		// Assert the SHAPE of the rendered rows, not a re-derived format string: duplicating
-		// `formatPValue`'s rule here would let the test agree with itself and drift from the renderer
-		// (`toPrecision(2)` keeps a trailing zero — "0.0080" — which a `Number(...)` round-trip drops).
-		const rows = md.split("\n").filter((l) => /^\| \d+ \| (Daytona|E2B) \|/.test(l));
-		expect(rows).toHaveLength(2);
-		for (const row of rows) {
-			// 7 columns: rank, provider, value, CI, n, p vs. above, p (KS).
-			expect(row.split("|").filter((c) => c.trim() !== "")).toHaveLength(7);
+		// Main ranking table stays slim (Note column because of the tie); KS lives in the details table.
+		const mainRows = md.split("\n").filter((l) => /^\| \d+ \| (Daytona|E2B) \|/.test(l));
+		expect(mainRows).toHaveLength(2);
+		for (const row of mainRows) {
+			expect(row.split("|").filter((c) => c.trim() !== "").length).toBe(6);
 		}
-		const [first, second] = rows as [string, string];
-		expect(first.trimEnd().endsWith("| — |")).toBe(true); // no predecessor → no KS
+
+		const detailRows = md.split("\n").filter((l) => /^\| cpu \| (Daytona|E2B) \|/.test(l));
+		expect(detailRows).toHaveLength(2);
+		const [first, second] = detailRows as [string, string];
+		expect(first).toContain("| — |");
 		const secondKs = second.trimEnd().split("|").at(-2)?.trim() as string;
 		expect(secondKs).not.toBe("—");
 		expect(secondKs).toMatch(/^(<0\.001|\d+(\.\d+)?(e[+-]?\d+)?)$/);
@@ -335,9 +336,8 @@ describe("renderLeaderboardMarkdown statistics", () => {
 		const md = renderLeaderboardMarkdown(
 			buildLeaderboard(run([provider("daytona", [metric(HEADLINE, [10])])])),
 		);
-		// n=1 → em-dash for the CI and BOTH p-values, never a fabricated bound. Anchored to the row end so
-		// a future column can't be silently dropped from the assertion.
-		expect(md).toMatch(/\| 1 \| Daytona \| 10 \| — \| 1 \| — \| — \|\n/);
+		// n=1 → em-dash for the CI; no Note column when nothing needs calling out.
+		expect(md).toMatch(/\| 1 \| Daytona \| 10 \| — \| 1 \|\n/);
 	});
 
 	it("never prints a p-value as a misleading 0", () => {
@@ -372,7 +372,8 @@ describe("underpowered comparisons", () => {
 			["Modal", 2, "underpowered", null],
 		]);
 		const md = renderLeaderboardMarkdown(board);
-		expect(md).toContain("(n too small)");
+		expect(md).toContain("n too small");
+		expect(md).not.toMatch(/\| tied \|/);
 		expect(md).not.toContain("(tied)");
 	});
 
@@ -425,7 +426,8 @@ describe("underpowered comparisons", () => {
 		expect(rows[1]?.tiedWithAbove).toBe("identical-value");
 		const md = renderLeaderboardMarkdown(board);
 		// The cell distinguishes the two reasons the rank is shared; it never reads as a statistical tie.
-		expect(md).toContain("(n too small, equal medians)");
+		expect(md).toContain("n too small, equal medians");
+		expect(md).not.toMatch(/\| tied \|/);
 		expect(md).not.toContain("(tied)");
 	});
 
@@ -441,7 +443,25 @@ describe("underpowered comparisons", () => {
 			[1, null, null],
 			[1, "untested", "identical-value"],
 		]);
-		expect(renderLeaderboardMarkdown(board)).toContain("— (equal values)");
+		expect(renderLeaderboardMarkdown(board)).toContain("equal values");
+	});
+
+	it("names every co-leader when three or more providers share the top rank", () => {
+		// Three providers at identical prices share rank 1; the takeaway must list all three, not just two.
+		const board = buildLeaderboard(
+			run([
+				provider("daytona", [metric(ECONOMICS_METRIC_IDS.usdPerHour, [0.1])]),
+				provider("e2b", [metric(ECONOMICS_METRIC_IDS.usdPerHour, [0.1])]),
+				provider("modal", [metric(ECONOMICS_METRIC_IDS.usdPerHour, [0.1])]),
+			]),
+		);
+		const rows = board.dimensions.find((d) => d.dimension === "economics")?.rows ?? [];
+		expect(rows.map((r) => r.rank)).toEqual([1, 1, 1]);
+		const md = renderLeaderboardMarkdown(board);
+		// Match the common phrasing across branches (the takeaway says "…this headline" here and
+		// "…this metric" once the per-metric renderer lands) so this test survives the flow up-stack.
+		expect(md).toMatch(/\w+, \w+ and \w+ share the top on this/);
+		for (const name of ["Daytona", "E2B", "Modal"]) expect(md).toContain(name);
 	});
 
 	it("never marks a row `tied` unless the test could have separated it", () => {
@@ -482,7 +502,7 @@ describe("underpowered comparisons", () => {
 			[1, null, null],
 			[1, "tied", "statistical"],
 		]);
-		expect(renderLeaderboardMarkdown(board)).toContain("(tied)");
+		expect(renderLeaderboardMarkdown(board)).toContain("| tied |");
 	});
 
 	it("does not let the tie-corrected approximation crown a provider the exact test cannot separate", () => {

--- a/packages/results/src/lib/leaderboard.ts
+++ b/packages/results/src/lib/leaderboard.ts
@@ -320,13 +320,14 @@ export function buildLeaderboard(run: Run): Leaderboard {
 		});
 		if (candidates.length === 0) continue;
 
-		// Order by Direction; tie-break on providerId so the output is deterministic.
+		// Order by Direction; tie-break on providerId so the output is deterministic. Locale pinned to
+		// "en" so the byte-identical artifact gate can't flake on a runner built with a different locale.
 		candidates.sort((a, b) =>
 			a.row.value !== b.row.value
 				? metric.direction === "HIB"
 					? b.row.value - a.row.value
 					: a.row.value - b.row.value
-				: a.row.providerId.localeCompare(b.row.providerId),
+				: a.row.providerId.localeCompare(b.row.providerId, "en"),
 		);
 
 		// Competition ranking with STATISTICAL ties. Walk the ordered rows and test each against the one
@@ -460,6 +461,33 @@ function formatPValue(p: number): string {
 	return p.toPrecision(2);
 }
 
+/** Compact note for the main table's Note column — empty when nothing needs calling out. */
+function rowNote(r: LeaderboardRow): string {
+	const equalValues = r.tiedWithAbove === "identical-value";
+	if (r.pVsPrevious === null) {
+		return equalValues ? "equal values" : "";
+	}
+	if (r.verdict === "underpowered") {
+		return equalValues ? "n too small, equal medians" : "n too small";
+	}
+	if (r.verdict === "tied") return "tied";
+	return "";
+}
+
+/** Mann-Whitney cell in the pairwise details table — reuses {@link rowNote} for the verdict suffix. */
+function formatPairwiseP(r: LeaderboardRow): string {
+	const note = rowNote(r);
+	if (r.pVsPrevious === null) return note ? `— (${note})` : "—";
+	const p = formatPValue(r.pVsPrevious.mannWhitney);
+	return note ? `${p} (${note})` : p;
+}
+
+function formatInterval(r: LeaderboardRow): string {
+	return r.interval.resamples === 0
+		? "—"
+		: `${formatValue(r.interval.lo)} – ${formatValue(r.interval.hi)}`;
+}
+
 /** Render the effective, comparable part of a target or observed sandbox shape. */
 function formatSpec(spec: Partial<TargetSpec & ObservedSpecs>): string {
 	const value = (n: number | undefined, unit: string): string =>
@@ -471,14 +499,77 @@ function formatSpec(spec: Partial<TargetSpec & ObservedSpecs>): string {
 	].join(" / ");
 }
 
+/** One-line takeaway above each dimension table (leader vs next, or sole provider). */
+function dimensionTakeaway(
+	dimension: Dimension,
+	metric: MetricDef,
+	rows: LeaderboardRow[],
+): string {
+	const leader = rows[0];
+	if (!leader) return "";
+	const better = metric.direction === "HIB" ? "higher is better" : "lower is better";
+	// Immediate neighbor — not the next distinct rank — so a top-of-board statistical tie is not
+	// misread as "only one provider ranked".
+	const next = rows[1];
+	if (!next) {
+		return `${leader.displayName} is the only ranked provider (${formatValue(leader.value)} ${metric.unit}; ${better}).`;
+	}
+	// Name the FULL top cohort, not just the immediate neighbor: three or more providers can share
+	// rank 1, and naming only the first two silently drops the rest. Rows are rank-sorted, so every
+	// row at the leader's rank is the contiguous top group.
+	const coLeaders = rows.filter((r) => r.rank === leader.rank);
+	if (coLeaders.length > 1) {
+		const names = coLeaders.map((r) => r.displayName);
+		const list = `${names.slice(0, -1).join(", ")} and ${names[names.length - 1]}`;
+		return `${list} share the top on this headline (${better}).`;
+	}
+	if (metric.direction === "HIB") {
+		const ratio = leader.value / next.value;
+		if (Number.isFinite(ratio) && ratio >= 1.05) {
+			return `${leader.displayName} leads · ~${ratio.toFixed(1)}× ${next.displayName} on median (${better}).`;
+		}
+	} else {
+		const ratio = next.value / leader.value;
+		if (Number.isFinite(ratio) && ratio >= 1.05) {
+			const verb = dimension === "economics" ? "is cheapest" : "leads";
+			// ratio = next / leader, so it is how many times HIGHER the neighbour is — phrase it that way.
+			// "~1.5× lower than X" reads as "the leader is 1.5× below X", which is not what next/leader means
+			// (4.898 vs 7.252 is 1.5× higher for the neighbour, i.e. 32% lower for the leader — not "1.5× lower").
+			return `${leader.displayName} ${verb} · ${next.displayName} is ~${ratio.toFixed(1)}× higher (${better}).`;
+		}
+	}
+	return `${leader.displayName} leads on median (${better}); see notes for how ranks are decided.`;
+}
+
+/** Summary line for coverage gaps by provider — keeps the main board scannable. */
+function coverageSummary(gaps: CoverageGap[]): string {
+	const byProvider = new Map<string, number>();
+	for (const g of gaps) {
+		byProvider.set(g.displayName, (byProvider.get(g.displayName) ?? 0) + 1);
+	}
+	const parts = [...byProvider.entries()]
+		.sort(([a], [b]) => a.localeCompare(b, "en"))
+		.map(([name, n]) => `${name} ${n}`);
+	return `${gaps.length} uncovered result${gaps.length === 1 ? "" : "s"} across ${byProvider.size} provider${byProvider.size === 1 ? "" : "s"} (${parts.join(", ")}). A gap is a missing result — the provider **failing to cover** that workload — never a tie or a zero.`;
+}
+
 /** Render a {@link Leaderboard} as a Markdown document — the committed comparison surface. */
 export function renderLeaderboardMarkdown(board: Leaderboard): string {
+	// Render the board's OWN target, not the global constant: the header must agree with the target
+	// echoed in the "Not ranked" detail (which already uses board.targetSpec), so a board built from a
+	// different target can never claim the pinned spec here while reporting another one below.
+	const spec = `${board.targetSpec.vcpus} vCPU · ${board.targetSpec.memoryGb} GiB RAM · ${board.targetSpec.diskGb} GB disk`;
 	const lines: string[] = [
 		"# Sandbox provider leaderboard",
 		"",
 		`Run \`${board.runId}\` · commit \`${board.sha}\` · generated ${board.generatedAt}`,
 		"",
-		"Each table ranks the providers on that dimension's headline metric. Generated from the published Run dataset — do not edit by hand.",
+		`Same pinned target for every provider (**${spec}**). Each table ranks providers on that`,
+		"dimension's headline metric (median of retained trials). Generated from the published Run",
+		"dataset — do not edit by hand. Methodology: [`docs/methodology.md`](docs/methodology.md).",
+		"",
+		"**How to read:** value = median (p50) · 95% CI = bootstrap around that median · rows share a rank only",
+		"when statistically indistinguishable or tied on the median (see details below) · a coverage gap means unmeasured, never a score of zero.",
 		"",
 	];
 
@@ -494,40 +585,24 @@ export function renderLeaderboardMarkdown(board: Leaderboard): string {
 		const labelHasUnit = metric.label.endsWith(`(${metric.unit})`);
 		const columnHeader = labelHasUnit ? metric.label : `${metric.label} (${metric.unit})`;
 		const headlineMeta = labelHasUnit ? better : `${metric.unit}, ${better}`;
+		const notes = rows.map(rowNote);
+		const hasNotes = notes.some((n) => n !== "");
 		lines.push(
 			`## ${dimension}`,
 			"",
 			`Headline: **${metric.label}** (${headlineMeta})`,
 			"",
-			`| Rank | Provider | ${columnHeader} | 95% CI | n | p vs. above | p (KS) |`,
-			"| ---: | --- | ---: | ---: | ---: | ---: | ---: |",
-			...rows.map((r) => {
-				const ci =
-					r.interval.resamples === 0
-						? "—"
-						: `${formatValue(r.interval.lo)} – ${formatValue(r.interval.hi)}`;
-				// Every shared rank says why, in the cell — a reader must never have to infer the reason from
-				// two rows carrying the same number. The three are distinct claims: `tied` is a verdict the
-				// test reached; `n too small` is the ABSENCE of one (it could not have separated them at any
-				// effect size, so it must not read as a tie); `equal medians` is arithmetic (the ranking sorts
-				// on the value, and it cannot order two values that are the same). The last can co-occur with
-				// `n too small`, and when it does, the shared rank is the equality speaking, not the test.
-				const equalValues = r.tiedWithAbove === "identical-value";
-				const p =
-					r.pVsPrevious === null
-						? equalValues
-							? "— (equal values)"
-							: "—"
-						: r.verdict === "underpowered"
-							? `${formatPValue(r.pVsPrevious.mannWhitney)} (n too small${equalValues ? ", equal medians" : ""})`
-							: r.verdict === "tied"
-								? `${formatPValue(r.pVsPrevious.mannWhitney)} (tied)`
-								: formatPValue(r.pVsPrevious.mannWhitney);
-				// KS is rendered, not just stored: it is the only column that exposes a provider whose
-				// median matches its neighbour's while its distribution is bimodal. A small `p (KS)` beside
-				// a large, tied `p vs. above` is exactly that case — same typical speed, different machine.
-				const ks = r.pVsPrevious === null ? "—" : formatPValue(r.pVsPrevious.ks);
-				return `| ${r.rank} | ${r.displayName} | ${formatValue(r.value)} | ${ci} | ${r.n} | ${p} | ${ks} |`;
+			`_${dimensionTakeaway(dimension, metric, rows)}_`,
+			"",
+			hasNotes
+				? `| Rank | Provider | ${columnHeader} | 95% CI | n | Note |`
+				: `| Rank | Provider | ${columnHeader} | 95% CI | n |`,
+			hasNotes
+				? "| ---: | --- | ---: | ---: | ---: | --- |"
+				: "| ---: | --- | ---: | ---: | ---: |",
+			...rows.map((r, i) => {
+				const base = `| ${r.rank} | ${r.displayName} | ${formatValue(r.value)} | ${formatInterval(r)} | ${r.n} |`;
+				return hasNotes ? `${base} ${notes[i] || "—"} |` : base;
 			}),
 			"",
 		);
@@ -561,18 +636,17 @@ export function renderLeaderboardMarkdown(board: Leaderboard): string {
 		);
 	}
 
-	// Coverage gaps: everything that did NOT produce a result somewhere. Rendered whether or not any
-	// dimension ranked, so an all-skipped run still says why. Disk gaps lead and are marked ❌ — a
-	// provider that cannot fit the workload is a structural absence, not a slow result, and must not
-	// read as "no data". Each row states its OUTCOME, because the three are not the same fact and a
-	// reader who cannot tell them apart will read a crash as a design decision.
+	// Coverage gaps: summary first; full table + legends inside <details> so unfinished providers
+	// don't bury the rankings.
 	if (board.coverageGaps.length > 0) {
 		const outcomes = new Set(board.coverageGaps.map((g) => g.outcome));
 		lines.push(
 			"## Coverage gaps",
 			"",
-			"Benchmarks that produced **no result** on a provider. A gap is a missing result, not a comparable",
-			"one — read it as the provider **failing to cover** that workload, never as a tie or a zero.",
+			coverageSummary(board.coverageGaps),
+			"",
+			"<details>",
+			"<summary>Full coverage table</summary>",
 			"",
 			"| Provider | Benchmark | Outcome | Detail |",
 			"| --- | --- | --- | --- |",
@@ -583,9 +657,6 @@ export function renderLeaderboardMarkdown(board: Leaderboard): string {
 			}),
 			"",
 		);
-		// Each legend line is emitted only when the table actually contains that outcome, so the section
-		// never explains a category the reader cannot see (and so an all-`missing` run reads as one clear
-		// statement instead of three paragraphs of hypotheticals).
 		if (outcomes.has("skipped")) {
 			lines.push(
 				"**skipped** — a precondition said no before the benchmark was attempted. A ❌ **disk** skip is the",
@@ -610,47 +681,46 @@ export function renderLeaderboardMarkdown(board: Leaderboard): string {
 				"",
 			);
 		}
+		lines.push("</details>", "");
 	}
 
 	if (board.dimensions.length === 0) return `${lines.join("\n")}\n`;
 
+	// Statistics essay + optional p-value / KS detail table for readers who want the receipts.
 	lines.push(
-		"---",
+		"<details>",
+		"<summary>How rankings are decided</summary>",
 		"",
-		"**Reading this table.** The value is the median (p50) of the retained per-trial Samples, not the",
-		"mean — a single stalled pass drags a mean far more than it moves a median. The 95% CI is a",
-		"percentile bootstrap of that median (10,000 resamples, seeded from the Run id so the table is",
-		"reproducible byte-for-byte), not a normal-theory interval: these Samples are neither normal nor",
-		"independent of the host's scheduling.",
+		"The value is the median (p50) of the retained per-trial Samples, not the mean — a single stalled",
+		"pass drags a mean far more than it moves a median. The 95% CI is a percentile bootstrap of that",
+		"median (10,000 resamples, seeded from the Run id so the table is reproducible byte-for-byte), not",
+		"a normal-theory interval: these Samples are neither normal nor independent of the host's scheduling.",
 		"",
-		`Rows are separated only when their full Sample distributions differ (Mann-Whitney U, two-sided, α = ${DEFAULT_ALPHA},`,
-		"enumerated exactly over the permutation null rather than approximated — at these sample sizes the",
-		"normal approximation can report a p the exact test cannot actually produce).",
+		`Rows are separated only when Mann-Whitney U (two-sided, α = ${DEFAULT_ALPHA}, enumerated exactly`,
+		"over the permutation null rather than approximated) finds evidence of stochastic ordering — at these",
+		"sample sizes the normal approximation can report a p the exact test cannot actually produce. KS is",
+		"reported separately for distribution *shape* and does not drive the ranking.",
 		"",
 	);
 
-	// A shared rank means different things, and the footer must explain exactly the ones the table
-	// contains — no more (a legend for an absent case teaches the reader to skim) and no less (an
-	// unexplained shared rank is read as a tie, which is the misreading this whole section exists to
-	// prevent). Collected from the rows themselves, so the prose cannot drift from the table.
 	const rows = board.dimensions.flatMap((d) => d.rows);
 	const sharedRankReasons: string[] = [];
 	if (rows.some((r) => r.tiedWithAbove === "statistical")) {
 		sharedRankReasons.push(
-			"`(tied)` — the test could have separated those providers and did not, so a faster median earned",
-			"inside the noise is not a faster provider. This is the only one that claims two providers are",
+			"`tied` — the test could have separated those providers and did not, so a faster median earned",
+			"inside the noise is not a faster provider. This is the only note that claims two providers are",
 			"statistically indistinguishable.",
 		);
 	}
 	if (rows.some((r) => r.tiedWithAbove === "identical-value")) {
 		sharedRankReasons.push(
-			"`(equal medians)` / `(equal values)` — arithmetic, not a finding: the ranking sorts on the value,",
+			"`equal medians` / `equal values` — arithmetic, not a finding: the ranking sorts on the value,",
 			"and two identical values have no order between them. It says nothing about the distributions.",
 		);
 	}
 	if (sharedRankReasons.length > 0) {
 		lines.push(
-			"**A shared rank always says why, in the `p vs. above` cell, and the reasons are not interchangeable.**",
+			"**A Note cell always says why a rank is shared, and the reasons are not interchangeable.**",
 			...sharedRankReasons,
 			"",
 		);
@@ -662,21 +732,11 @@ export function renderLeaderboardMarkdown(board: Leaderboard): string {
 		"converge) is itself the signal that the provider's performance is unstable, not that the measurement",
 		"is imprecise.",
 		"",
-		"`p (KS)` is a two-sample Kolmogorov-Smirnov test against the same row above. It does **not** drive",
-		"the ranking — it compares the two empirical distributions' *shapes* rather than their central",
-		"tendency. Read it where it disagrees with `p vs. above`: a tied rank (large Mann-Whitney p) beside a",
-		"small `p (KS)` means two providers with the same typical speed but different behaviour — usually one",
-		"of them alternating between fast and stalled passes. That bimodality is what environmental noise",
-		"looks like, and it is the reason a median alone cannot rank these providers.",
-		"",
 		"At the small `n` this suite produces, a non-significant result means *not enough evidence to",
 		"separate*, never *the providers are equal*.",
 		"",
 	);
 
-	// `n too small` needs explaining only when the table actually contains one, and the floor it cites is
-	// the one those rows' own tests reported — a hardcoded example would misquote both the floor and the n
-	// the moment a run pairs, say, 3 trials against 4.
 	const floors = underpoweredFloors(board);
 	if (floors.length > 0) {
 		lines.push(
@@ -684,12 +744,35 @@ export function renderLeaderboardMarkdown(board: Leaderboard): string {
 			`Samples, so the test could not have separated the rows at any effect size (here ${floors.join("; ")}).`,
 			"Such rows are ranked on their observed medians and are **not** claimed to be tied — read the gap",
 			"between the values, and treat the p-value as unable to settle them either way. Where such a row",
-			"nevertheless shares the rank above it, the cell reads `equal medians`: the two values are simply",
+			"nevertheless shares the rank above it, the note reads `equal medians`: the two values are simply",
 			"identical, which is the ranking having nothing to order them by — never a finding that the",
 			"providers are alike.",
 			"",
 		);
 	}
+
+	// Detail table with p vs. above + KS for readers who want distribution shape.
+	if (rows.some((r) => r.pVsPrevious !== null)) {
+		lines.push(
+			"### Pairwise tests (vs. row above)",
+			"",
+			"`p vs. above` is Mann-Whitney (drives rank). `p (KS)` is Kolmogorov-Smirnov on distribution",
+			"*shape* — it does not drive the ranking. A tied Mann-Whitney beside a small KS often means the",
+			"same typical speed with different behaviour (e.g. bimodal stalls).",
+			"",
+			"| Dimension | Provider | p vs. above | p (KS) |",
+			"| --- | --- | ---: | ---: |",
+		);
+		for (const { dimension, rows: dimRows } of board.dimensions) {
+			for (const r of dimRows) {
+				const ks = r.pVsPrevious === null ? "—" : formatPValue(r.pVsPrevious.ks);
+				lines.push(`| ${dimension} | ${r.displayName} | ${formatPairwiseP(r)} | ${ks} |`);
+			}
+		}
+		lines.push("");
+	}
+
+	lines.push("</details>", "");
 
 	return `${lines.join("\n")}\n`;
 }


### PR DESCRIPTION
renderLeaderboardMarkdown gains a one-line takeaway per dimension (leader vs immediate
neighbor, statistical-tie aware, naming all co-leaders in a 3+ way tie), a compact Note column,
a coverage-gap summary, and a 'how to read' header naming the pinned TARGET_SPEC.

LEADERBOARD.md is regenerated so the artifact-sync gate stays green (renderer + artifact move
together). Regenerate with:
  bun apps/cli/src/bin/leaderboard.ts data/dataset/runs/<runId>.json LEADERBOARD.md

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Builds a cleaner, easier-to-scan leaderboard with one-line takeaways, a slim main table with an optional Note column, and collapsible details for stats and methodology. Also fixes deterministic sorting, lower‑is‑better phrasing, and aligns the header’s target spec with the board.

- **New Features**
  - One-line takeaway per dimension; tie-aware; lists all co-leaders; ratio when clear; sole-provider message.
  - Slim main table; adds a Note column with “tied”, “n too small”, or “equal medians/values” when needed.
  - Moves p-values out of the main table; adds a details section with Mann‑Whitney + KS pairwise tests and “How rankings are decided”.
  - Coverage gaps now start with a compact summary; full table and legends are collapsible.
  - Top header shows the board’s pinned target spec and links to methodology; tests updated.

- **Bug Fixes**
  - Name every co-leader when 3+ providers share rank 1.
  - Deterministic tie-break via `localeCompare(..., 'en')` for byte-identical artifacts.
  - Render header spec from the board’s target (not global `TARGET_SPEC`) to match “Not ranked”.
  - Correct lower‑is‑better ratio wording (“X is ~N× higher”); clarify MW for ordering and KS for shape only.

<sup>Written for commit 61644fa104a88c51c1b660944741941bf3f0701a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/starslingdev/sandbox-benchmarks/pull/179?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Improvements**
  - Simplified leaderboard layout with clearer per-dimension tables, confidence intervals, and compact “Note” callouts for ties.
  - Enhanced takeaway and messaging for statistical ties, shared top ranks, and underpowered comparisons.
  - Made ordering deterministic when providers are tied.
  - Reorganized coverage gaps and ranking methodology into expandable sections, including an optional pairwise-tests view with clearer statistical labels.
- **Documentation**
  - Updated “How to read” guidance, tie/ranking semantics, and dimension-specific narrative notes.
- **Tests**
  - Revised assertions to match the updated markdown structure and tie/underpowered wording.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->