### PR TITLE
fix(ci): publish the bench dataset via PR instead of pushing to main

### DIFF
--- a/.github/workflows/bench-matrix.yml
+++ b/.github/workflows/bench-matrix.yml
@@ -140,9 +140,10 @@ jobs:
           if-no-files-found: error
 
   # Collect every shard Run, aggregate into one candidate, gate it (promote), regenerate the public
-  # leaderboard, and commit both. candidate→promote: aggregate is the collect half, promote the
-  # validate-and-publish half. Environment `privileged` is required even without provider secrets —
-  # this job is the dataset release surface (`contents: write`).
+  # leaderboard, and open the PR that lands both on main. The logic lives in the reusable
+  # publish-dataset.yml so a maintainer can also run it standalone (workflow_dispatch) to backfill a
+  # run whose publish failed. Environment `privileged` (the dataset release surface, `contents: write`)
+  # is declared inside that reusable workflow — a `uses:` caller can't set `environment:` itself.
   publish:
     name: Aggregate + promote dataset
     needs: [plan, bench]
@@ -156,93 +157,12 @@ jobs:
       needs.plan.result == 'success' &&
       github.ref == 'refs/heads/main' &&
       github.repository == 'starslingdev/sandbox-benchmarks'
-    runs-on: ubuntu-24.04
-    environment: privileged
-    # Commit the published dataset + leaderboard, then open the PR that lands them on main.
+    # Grant the reusable workflow the token scopes it needs: commit/push the dataset (contents), open
+    # the PR (pull-requests), and download this run's shard artifacts by run-id (actions: read).
     permissions:
       contents: write
       pull-requests: write
-    steps:
-      # Unlike the read-only jobs above, this one commits + `git push`es the published dataset, so it
-      # keeps the default persisted job token (contents: write above authorizes it). Don't add
-      # persist-credentials: false here or the push at the end of the job loses its credentials.
-      - name: Checkout
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-      - name: Set up Bun
-        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
-        with:
-          bun-version: 1.3.14
-      - name: Install dependencies
-        run: bun install --frozen-lockfile --ignore-scripts
-
-      # Pull every per-cell shard artifact into ./shards (each in its own subdir).
-      - name: Download shard artifacts
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
-        with:
-          path: shards
-          pattern: bench-*-${{ github.run_id }}
-          merge-multiple: false
-
-      # Aggregate the shards' Run documents into one candidate, then promote (gate on >=1 validated
-      # provider) and publish into the committed dataset at data/dataset/. The run-id matches the shards.
-      #
-      # The glob names the Run document EXACTLY, `<runId>.json`, and must not gain a `data/` segment:
-      # the bench cell uploads `path: data/`, and upload-artifact roots the artifact at the least common
-      # ancestor of the matched files — so a shard unpacks as `shards/<artifact>/runs/<runId>.json`, with
-      # no `data/` prefix. Two decoys sit next to it that a `runs/*.json` wildcard would sweep in: the
-      # sibling `runs/index.json` (an index, not a Run), and `dataset/runs/<oldRunId>.json` (the committed
-      # dataset, which rides along because it lives under data/). Both would poison the aggregate.
-      - name: Aggregate + promote
-        run: |
-          shopt -s nullglob
-          shards=(shards/*/runs/"$GITHUB_RUN_ID".json)
-          if [ ${#shards[@]} -eq 0 ]; then echo "no shard Run documents found" >&2; exit 1; fi
-          bun apps/cli/src/bin/aggregate.ts "$GITHUB_RUN_ID" data/candidate "${shards[@]}"
-          bun apps/cli/src/bin/promote.ts "data/candidate/runs/$GITHUB_RUN_ID.json" data/dataset
-
-      # Keep LEADERBOARD.md byte-identical to what the renderer produces from the newly promoted Run.
-      - name: Regenerate leaderboard
-        run: bun apps/cli/src/bin/leaderboard.ts "data/dataset/runs/$GITHUB_RUN_ID.json" LEADERBOARD.md
-
-      # Pre-flight the PR's lint gate on the generated content. The dataset + leaderboard are committed
-      # files, so ci.yml's Biome gate (`biome check .`) lints them — Biome formats JSON (2-space, per
-      # biome.json's `**/*.json` override), so an unformatted Run document would fail the PR. Running
-      # the exact gate here fails the job early (before any PR is opened) on a formatting/lint miss,
-      # instead of leaving a doomed PR behind. This does not replace the PR's own required checks — it
-      # just gives fast, in-run feedback on exactly the content being published.
-      - name: Confirm the published dataset passes Biome (the PR lint gate)
-        run: bun run lint
-
-      # main is protected by a "changes must be made through a pull request" ruleset (the public-repo
-      # hardening in #176/#177), so this job can no longer push the promoted dataset straight to main —
-      # a direct push is rejected with GH013. Publish through a short-lived branch + pull request and
-      # enable GitHub-native auto-merge (`--auto`): the PR merges itself only once branch protection is
-      # satisfied — required status checks (the PR's Biome/CI gate) green and any required reviews in.
-      # `--auto` waits for those rules, it does not bypass them, so the dataset never lands unlinted or
-      # unreviewed. If auto-merge can't be armed (e.g. the repo hasn't enabled it), the PR stays open
-      # for a maintainer to merge normally.
-      - name: Publish the dataset via pull request
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-          git add data/dataset LEADERBOARD.md
-          if git diff --cached --quiet; then
-            echo "dataset unchanged; nothing to commit"
-            exit 0
-          fi
-          branch="dataset/publish-${GITHUB_RUN_ID}"
-          git switch -c "$branch"
-          git commit -m "chore(dataset): publish run ${GITHUB_RUN_ID}"
-          git push -u origin "$branch"
-          gh pr create \
-            --base main \
-            --head "$branch" \
-            --title "chore(dataset): publish run ${GITHUB_RUN_ID}" \
-            --body "Automated dataset + leaderboard publish for run [\`${GITHUB_RUN_ID}\`](${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}). Biome was pre-flighted green on the promoted content; auto-merge lands it once branch protection is satisfied."
-          # Queue GitHub-native auto-merge: it merges only after the PR's required checks pass (and any
-          # required reviews land), never bypassing branch protection. Best-effort — if the repo hasn't
-          # enabled auto-merge, leave the PR open for a maintainer.
-          gh pr merge "$branch" --squash --delete-branch --auto \
-            || echo "auto-merge not armed; dataset PR left open for a maintainer to merge"
+      actions: read
+    uses: ./.github/workflows/publish-dataset.yml
+    with:
+      run_id: ${{ github.run_id }}

--- a/.github/workflows/bench-matrix.yml
+++ b/.github/workflows/bench-matrix.yml
@@ -204,12 +204,23 @@ jobs:
       - name: Regenerate leaderboard
         run: bun apps/cli/src/bin/leaderboard.ts "data/dataset/runs/$GITHUB_RUN_ID.json" LEADERBOARD.md
 
+      # Pre-flight the PR's lint gate on the generated content. The dataset + leaderboard are committed
+      # files, so ci.yml's Biome gate (`biome check .`) lints them — Biome formats JSON (2-space, per
+      # biome.json's `**/*.json` override), so an unformatted Run document would fail the PR. Running
+      # the exact gate here fails the job early (before any PR is opened) on a formatting/lint miss,
+      # instead of leaving a doomed PR behind. This does not replace the PR's own required checks — it
+      # just gives fast, in-run feedback on exactly the content being published.
+      - name: Confirm the published dataset passes Biome (the PR lint gate)
+        run: bun run lint
+
       # main is protected by a "changes must be made through a pull request" ruleset (the public-repo
       # hardening in #176/#177), so this job can no longer push the promoted dataset straight to main —
-      # a direct push is rejected with GH013. Publish through a short-lived branch + pull request
-      # instead, then best-effort auto-land it. Opening the PR is the publish now: if the repo can land
-      # it without a human (admin bypass, else queued auto-merge) it does; otherwise the PR stays open
-      # for a maintainer to merge, which is exactly what the ruleset exists to require.
+      # a direct push is rejected with GH013. Publish through a short-lived branch + pull request and
+      # enable GitHub-native auto-merge (`--auto`): the PR merges itself only once branch protection is
+      # satisfied — required status checks (the PR's Biome/CI gate) green and any required reviews in.
+      # `--auto` waits for those rules, it does not bypass them, so the dataset never lands unlinted or
+      # unreviewed. If auto-merge can't be armed (e.g. the repo hasn't enabled it), the PR stays open
+      # for a maintainer to merge normally.
       - name: Publish the dataset via pull request
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -229,10 +240,9 @@ jobs:
             --base main \
             --head "$branch" \
             --title "chore(dataset): publish run ${GITHUB_RUN_ID}" \
-            --body "Automated dataset + leaderboard publish for run [\`${GITHUB_RUN_ID}\`](${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID})."
-          # Land it without a human round-trip when the repo permits: admin bypass if this token may
-          # bypass the ruleset, else queued auto-merge for when required checks pass. Both are
-          # best-effort — the PR is already open, so a failure here is not a publish failure.
-          gh pr merge "$branch" --squash --delete-branch --admin \
-            || gh pr merge "$branch" --squash --delete-branch --auto \
-            || echo "dataset PR left open for a maintainer to merge"
+            --body "Automated dataset + leaderboard publish for run [\`${GITHUB_RUN_ID}\`](${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}). Biome was pre-flighted green on the promoted content; auto-merge lands it once branch protection is satisfied."
+          # Queue GitHub-native auto-merge: it merges only after the PR's required checks pass (and any
+          # required reviews land), never bypassing branch protection. Best-effort — if the repo hasn't
+          # enabled auto-merge, leave the PR open for a maintainer.
+          gh pr merge "$branch" --squash --delete-branch --auto \
+            || echo "auto-merge not armed; dataset PR left open for a maintainer to merge"

--- a/.github/workflows/bench-matrix.yml
+++ b/.github/workflows/bench-matrix.yml
@@ -158,9 +158,10 @@ jobs:
       github.repository == 'starslingdev/sandbox-benchmarks'
     runs-on: ubuntu-24.04
     environment: privileged
-    # Commit the published dataset + leaderboard back to the branch.
+    # Commit the published dataset + leaderboard, then open the PR that lands them on main.
     permissions:
       contents: write
+      pull-requests: write
     steps:
       # Unlike the read-only jobs above, this one commits + `git push`es the published dataset, so it
       # keeps the default persisted job token (contents: write above authorizes it). Don't add
@@ -203,14 +204,35 @@ jobs:
       - name: Regenerate leaderboard
         run: bun apps/cli/src/bin/leaderboard.ts "data/dataset/runs/$GITHUB_RUN_ID.json" LEADERBOARD.md
 
-      - name: Commit the published dataset
+      # main is protected by a "changes must be made through a pull request" ruleset (the public-repo
+      # hardening in #176/#177), so this job can no longer push the promoted dataset straight to main —
+      # a direct push is rejected with GH013. Publish through a short-lived branch + pull request
+      # instead, then best-effort auto-land it. Opening the PR is the publish now: if the repo can land
+      # it without a human (admin bypass, else queued auto-merge) it does; otherwise the PR stays open
+      # for a maintainer to merge, which is exactly what the ruleset exists to require.
+      - name: Publish the dataset via pull request
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git add data/dataset LEADERBOARD.md
           if git diff --cached --quiet; then
             echo "dataset unchanged; nothing to commit"
-          else
-            git commit -m "chore(dataset): publish run ${GITHUB_RUN_ID}"
-            git push
+            exit 0
           fi
+          branch="dataset/publish-${GITHUB_RUN_ID}"
+          git switch -c "$branch"
+          git commit -m "chore(dataset): publish run ${GITHUB_RUN_ID}"
+          git push -u origin "$branch"
+          gh pr create \
+            --base main \
+            --head "$branch" \
+            --title "chore(dataset): publish run ${GITHUB_RUN_ID}" \
+            --body "Automated dataset + leaderboard publish for run [\`${GITHUB_RUN_ID}\`](${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID})."
+          # Land it without a human round-trip when the repo permits: admin bypass if this token may
+          # bypass the ruleset, else queued auto-merge for when required checks pass. Both are
+          # best-effort — the PR is already open, so a failure here is not a publish failure.
+          gh pr merge "$branch" --squash --delete-branch --admin \
+            || gh pr merge "$branch" --squash --delete-branch --auto \
+            || echo "dataset PR left open for a maintainer to merge"

--- a/.github/workflows/publish-dataset.yml
+++ b/.github/workflows/publish-dataset.yml
@@ -103,12 +103,13 @@ jobs:
 
       # Pre-flight the PR's lint gate on the generated content. The dataset + leaderboard are committed
       # files, so ci.yml's Biome gate (`biome check .`) lints them — Biome formats JSON (2-space, per
-      # biome.json's `**/*.json` override), so an unformatted Run document would fail the PR. Running
-      # the exact gate here fails the job early (before any PR is opened) on a formatting/lint miss,
-      # instead of leaving a doomed PR behind. This does not replace the PR's own required checks — it
-      # just gives fast, in-run feedback on exactly the content being published.
+      # biome.json's `**/*.json` override), so an unformatted Run document would fail the PR. Check
+      # exactly the files this job writes (not the whole workspace) with the same rules and severity
+      # ci.yml uses, so the pre-flight fails the job early on a bad Run document — but a pre-existing,
+      # unrelated lint failure elsewhere on main can't strand a clean dataset publish. The PR's own
+      # `biome check .` still gates the merge; this is just fast, in-run feedback on the new content.
       - name: Confirm the published dataset passes Biome (the PR lint gate)
-        run: bun run lint
+        run: bunx biome check data/dataset LEADERBOARD.md --error-on-warnings
 
       # main is protected by a "changes must be made through a pull request" ruleset (the public-repo
       # hardening in #176/#177), so this job can't push the promoted dataset straight to main — a direct
@@ -130,9 +131,21 @@ jobs:
             exit 0
           fi
           branch="dataset/publish-${RUN_ID}"
+          # The branch name is deterministic per run, so a re-run (retried matrix run, or a re-dispatched
+          # backfill) must converge on the existing PR instead of colliding. If an open PR for this run's
+          # branch already exists (a prior attempt got past the push), just (re-)arm auto-merge and stop.
+          if [ -n "$(gh pr list --head "$branch" --state open --json number --jq '.[].number')" ]; then
+            echo "dataset PR for $branch already open; re-arming auto-merge"
+            gh pr merge "$branch" --squash --delete-branch --auto \
+              || echo "auto-merge not armed; dataset PR left open for a maintainer to merge"
+            exit 0
+          fi
           git switch -c "$branch"
           git commit -m "chore(dataset): publish run ${RUN_ID}"
-          git push -u origin "$branch"
+          # --force so a leftover branch from a partial prior run (pushed, but PR never created) is
+          # overwritten rather than rejected as non-fast-forward; it is a bot-owned branch and a re-run
+          # recomputes byte-identical content, so the overwrite is a no-op in the common case.
+          git push -u --force origin "$branch"
           gh pr create \
             --base main \
             --head "$branch" \

--- a/.github/workflows/publish-dataset.yml
+++ b/.github/workflows/publish-dataset.yml
@@ -1,0 +1,145 @@
+name: Publish dataset
+
+# Aggregate a Bench matrix run's per-cell shards into one candidate, gate it (promote), regenerate the
+# public leaderboard, and open the PR that lands both on main. Extracted from bench-matrix.yml so it
+# has two entry points:
+#   - workflow_call: bench-matrix.yml invokes it at the end of a matrix run (run_id = that run).
+#   - workflow_dispatch: a maintainer re-runs it standalone to BACKFILL a run whose publish failed —
+#     pass the old run's id, and its still-retained bench-* shard artifacts are re-aggregated and
+#     published. (Artifacts expire on the repo's retention window, so backfill only works while the
+#     shards still exist.)
+#
+# Environment `privileged` lives on the job here (the dataset release surface, `contents: write`); a
+# `uses:` caller can't declare it, so the approval gate is enforced at this layer for both entry points.
+on:
+  workflow_call:
+    inputs:
+      run_id:
+        description: 'Bench matrix run id whose shard artifacts to aggregate + publish.'
+        required: true
+        type: string
+  workflow_dispatch:
+    inputs:
+      run_id:
+        description: 'Previous Bench matrix run id to backfill the dataset from (its bench-* shard artifacts must still be retained).'
+        required: true
+        type: string
+
+# Least privilege at the top level; the publish job elevates for exactly what it needs.
+permissions:
+  contents: read
+
+# Serialize dataset publishes so a matrix run and a manual backfill can't race the same branch/push.
+concurrency:
+  group: publish-dataset
+  cancel-in-progress: false
+
+jobs:
+  publish:
+    name: Aggregate + promote dataset
+    # Confine the release to this repo's main, whether called by the matrix or dispatched to backfill.
+    # (Environment `privileged`'s deployment-branch policy pins it to main too; this is defense in depth.)
+    if: >
+      github.ref == 'refs/heads/main' &&
+      github.repository == 'starslingdev/sandbox-benchmarks'
+    runs-on: ubuntu-24.04
+    environment: privileged
+    # contents: write to commit + push the dataset branch; pull-requests: write to open the PR;
+    # actions: read to download another run's shard artifacts by run-id (the backfill path).
+    permissions:
+      contents: write
+      pull-requests: write
+      actions: read
+    # The target run id (this run for the matrix call, an older run for a backfill) reaches the shell
+    # only through the environment, never interpolated into a `run:` command.
+    env:
+      RUN_ID: ${{ inputs.run_id }}
+    steps:
+      # Unlike the read-only bench jobs, this one commits + `git push`es the published dataset, so it
+      # keeps the default persisted job token (contents: write above authorizes it). Don't add
+      # persist-credentials: false here or the push at the end of the job loses its credentials.
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - name: Set up Bun
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
+        with:
+          bun-version: 1.3.14
+      - name: Install dependencies
+        run: bun install --frozen-lockfile --ignore-scripts
+
+      # Pull every per-cell shard artifact for the target run into ./shards (each in its own subdir).
+      # run-id + github-token make this work across runs: for a matrix call run-id is the current run,
+      # for a backfill it is the older run whose publish failed. (Downloading by run-id needs the
+      # actions: read scope granted above.)
+      - name: Download shard artifacts
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          path: shards
+          pattern: bench-*-${{ inputs.run_id }}
+          merge-multiple: false
+          run-id: ${{ inputs.run_id }}
+          github-token: ${{ github.token }}
+
+      # Aggregate the shards' Run documents into one candidate, then promote (gate on >=1 validated
+      # provider) and publish into the committed dataset at data/dataset/. The run-id matches the shards.
+      #
+      # The glob names the Run document EXACTLY, `<runId>.json`, and must not gain a `data/` segment:
+      # the bench cell uploads `path: data/`, and upload-artifact roots the artifact at the least common
+      # ancestor of the matched files — so a shard unpacks as `shards/<artifact>/runs/<runId>.json`, with
+      # no `data/` prefix. Two decoys sit next to it that a `runs/*.json` wildcard would sweep in: the
+      # sibling `runs/index.json` (an index, not a Run), and `dataset/runs/<oldRunId>.json` (the committed
+      # dataset, which rides along because it lives under data/). Both would poison the aggregate.
+      - name: Aggregate + promote
+        run: |
+          shopt -s nullglob
+          shards=(shards/*/runs/"$RUN_ID".json)
+          if [ ${#shards[@]} -eq 0 ]; then echo "no shard Run documents found for run $RUN_ID" >&2; exit 1; fi
+          bun apps/cli/src/bin/aggregate.ts "$RUN_ID" data/candidate "${shards[@]}"
+          bun apps/cli/src/bin/promote.ts "data/candidate/runs/$RUN_ID.json" data/dataset
+
+      # Keep LEADERBOARD.md byte-identical to what the renderer produces from the newly promoted Run.
+      - name: Regenerate leaderboard
+        run: bun apps/cli/src/bin/leaderboard.ts "data/dataset/runs/$RUN_ID.json" LEADERBOARD.md
+
+      # Pre-flight the PR's lint gate on the generated content. The dataset + leaderboard are committed
+      # files, so ci.yml's Biome gate (`biome check .`) lints them — Biome formats JSON (2-space, per
+      # biome.json's `**/*.json` override), so an unformatted Run document would fail the PR. Running
+      # the exact gate here fails the job early (before any PR is opened) on a formatting/lint miss,
+      # instead of leaving a doomed PR behind. This does not replace the PR's own required checks — it
+      # just gives fast, in-run feedback on exactly the content being published.
+      - name: Confirm the published dataset passes Biome (the PR lint gate)
+        run: bun run lint
+
+      # main is protected by a "changes must be made through a pull request" ruleset (the public-repo
+      # hardening in #176/#177), so this job can't push the promoted dataset straight to main — a direct
+      # push is rejected with GH013. Publish through a short-lived branch + pull request and enable
+      # GitHub-native auto-merge (`--auto`): the PR merges itself only once branch protection is
+      # satisfied — required status checks (the PR's Biome/CI gate) green and any required reviews in.
+      # `--auto` waits for those rules, it does not bypass them, so the dataset never lands unlinted or
+      # unreviewed. If auto-merge can't be armed (e.g. the repo hasn't enabled it), the PR stays open
+      # for a maintainer to merge normally.
+      - name: Publish the dataset via pull request
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add data/dataset LEADERBOARD.md
+          if git diff --cached --quiet; then
+            echo "dataset for run $RUN_ID unchanged; nothing to commit"
+            exit 0
+          fi
+          branch="dataset/publish-${RUN_ID}"
+          git switch -c "$branch"
+          git commit -m "chore(dataset): publish run ${RUN_ID}"
+          git push -u origin "$branch"
+          gh pr create \
+            --base main \
+            --head "$branch" \
+            --title "chore(dataset): publish run ${RUN_ID}" \
+            --body "Automated dataset + leaderboard publish for run [\`${RUN_ID}\`](${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${RUN_ID}). Biome was pre-flighted green on the promoted content; auto-merge lands it once branch protection is satisfied."
+          # Queue GitHub-native auto-merge: it merges only after the PR's required checks pass (and any
+          # required reviews land), never bypassing branch protection. Best-effort — if the repo hasn't
+          # enabled auto-merge, leave the PR open for a maintainer.
+          gh pr merge "$branch" --squash --delete-branch --auto \
+            || echo "auto-merge not armed; dataset PR left open for a maintainer to merge"

--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -4,9 +4,9 @@
 rules:
   artipacked:
     ignore:
-      # bench-matrix.yml's `publish` job is the one checkout that must keep its persisted job token:
+      # publish-dataset.yml's `publish` job is the one checkout that must keep its persisted job token:
       # it commits the promoted dataset and `git push`es it back to the branch (the job grants
       # `contents: write` for exactly this). Every other checkout in the repo sets
-      # persist-credentials: false; this one can't, by design. (Filename-scoped, not repo-wide — the
-      # other checkouts in this file already opt out, so only the publish-job finding is accepted.)
-      - bench-matrix.yml
+      # persist-credentials: false; this one can't, by design. (Filename-scoped, not repo-wide — this
+      # reusable workflow's only checkout is the pushing one, so just its finding is accepted.)
+      - publish-dataset.yml

--- a/docs/ci-secrets.md
+++ b/docs/ci-secrets.md
@@ -14,7 +14,7 @@ and toolchain publish must not trigger on `push`.
 | --- | --- | --- |
 | `toolchain-image.yml` | `publish` | Provider bake secrets + `packages: write` (GHCR release) |
 | `bench-matrix.yml` | `bench` | Provider API keys |
-| `bench-matrix.yml` | `publish` | Dataset + leaderboard commit (`contents: write`) |
+| `bench-matrix.yml` | `publish` | Dataset + leaderboard publish (`contents: write` + `pull-requests: write`) |
 | `bench-smoke.yml` | `smoke` | Provider API keys |
 
 Ungated: `ci.yml`, `ci-lint.yml`, and the toolchain `pr-gate` (Docker smoke, no secrets).
@@ -29,6 +29,11 @@ Ungated: `ci.yml`, `ci-lint.yml`, and the toolchain `pr-gate` (Docker smoke, no 
    deployments to the `main` branch. Write access alone cannot finish a release.
 4. **Fork PRs.** Same-repo guard on self-hosted PR jobs; fork PR code never runs on
    `starsling-ubuntu-24.04-2`. Forks never receive Environment secrets on `pull_request`.
+5. **Dataset lands via PR.** `main` is protected by a "changes must be made through a pull request"
+   ruleset, so `bench-matrix.yml`'s `publish` job cannot push the promoted dataset straight to
+   `main` (a direct push is rejected with `GH013`). It opens a `dataset/publish-<run-id>` PR instead
+   and best-effort auto-merges it; if the repo can't land it automatically the PR stays open for a
+   maintainer to merge. This is why `publish` also holds `pull-requests: write`.
 
 > **Two approvals per bench-matrix run.** `bench` and `publish` both carry `environment:
 > privileged` and run sequentially, so GitHub raises **two** separate pending-deployment gates: one

--- a/docs/ci-secrets.md
+++ b/docs/ci-secrets.md
@@ -39,10 +39,18 @@ Ungated: `ci.yml`, `ci-lint.yml`, and the toolchain `pr-gate` (Docker smoke, no 
    straight to `main` (a direct push is rejected with `GH013`). It opens a `dataset/publish-<run-id>`
    PR instead (hence `pull-requests: write`) and arms GitHub-native auto-merge (`gh pr merge --auto`),
    which merges only once branch protection is satisfied — required status checks green and any
-   required reviews in. It never bypasses those rules. As a fast pre-flight, the job first re-runs the
-   Biome gate (`bun run lint`) on the generated dataset + leaderboard — Biome formats JSON, so an
-   unformatted Run document would fail the PR — and aborts before opening a doomed PR on a miss. If
-   auto-merge can't be armed, the PR stays open for a maintainer.
+   required reviews in. It never bypasses those rules. As a fast pre-flight, the job first runs the
+   Biome gate on the generated dataset + leaderboard (`biome check data/dataset LEADERBOARD.md`, the
+   same rules ci.yml runs) — Biome formats JSON, so an unformatted Run document would fail the PR — and
+   aborts before opening a doomed PR on a miss. The push/PR step is idempotent: a re-run reuses the
+   existing open PR instead of colliding on the deterministic branch.
+
+   > **`GITHUB_TOKEN` caveat.** A PR opened with the default `GITHUB_TOKEN` does **not** trigger
+   > `ci.yml` (GitHub suppresses workflow events raised by the Actions token). So if the Biome/CI check
+   > is a *required* status, auto-merge waits for a check that never runs, and a maintainer completes
+   > the merge (their merge to `main` runs `ci.yml` normally); the in-job pre-flight guarantees the
+   > content is already clean. For fully hands-off auto-merge, open the PR with a GitHub App
+   > installation token or PAT instead of `GITHUB_TOKEN` so the PR's own checks run.
 6. **Backfilling a failed publish.** The publish logic is the reusable `publish-dataset.yml`, so when
    a matrix run's publish fails (or was never reached) a maintainer can re-run it standalone:
    **Actions → Publish dataset → Run workflow**, passing the original run's id. It re-downloads that

--- a/docs/ci-secrets.md
+++ b/docs/ci-secrets.md
@@ -14,8 +14,13 @@ and toolchain publish must not trigger on `push`.
 | --- | --- | --- |
 | `toolchain-image.yml` | `publish` | Provider bake secrets + `packages: write` (GHCR release) |
 | `bench-matrix.yml` | `bench` | Provider API keys |
-| `bench-matrix.yml` | `publish` | Dataset + leaderboard publish (`contents: write` + `pull-requests: write`) |
+| `publish-dataset.yml` | `publish` | Dataset + leaderboard publish (`contents: write` + `pull-requests: write`) |
 | `bench-smoke.yml` | `smoke` | Provider API keys |
+
+`publish-dataset.yml` is a reusable workflow: `bench-matrix.yml`'s `publish` job calls it at the end
+of a matrix run, and a maintainer can dispatch it standalone to backfill (see rule 6). A `uses:` caller
+can't declare `environment:`, so the `privileged` gate lives on the reusable workflow's own job — the
+workflow-hardening drift gate checks it there and passes the local caller.
 
 Ungated: `ci.yml`, `ci-lint.yml`, and the toolchain `pr-gate` (Docker smoke, no secrets).
 
@@ -30,7 +35,7 @@ Ungated: `ci.yml`, `ci-lint.yml`, and the toolchain `pr-gate` (Docker smoke, no 
 4. **Fork PRs.** Same-repo guard on self-hosted PR jobs; fork PR code never runs on
    `starsling-ubuntu-24.04-2`. Forks never receive Environment secrets on `pull_request`.
 5. **Dataset lands via PR, lint-gated.** `main` is protected by a "changes must be made through a
-   pull request" ruleset, so `bench-matrix.yml`'s `publish` job cannot push the promoted dataset
+   pull request" ruleset, so `publish-dataset.yml`'s `publish` job cannot push the promoted dataset
    straight to `main` (a direct push is rejected with `GH013`). It opens a `dataset/publish-<run-id>`
    PR instead (hence `pull-requests: write`) and arms GitHub-native auto-merge (`gh pr merge --auto`),
    which merges only once branch protection is satisfied — required status checks green and any
@@ -38,6 +43,13 @@ Ungated: `ci.yml`, `ci-lint.yml`, and the toolchain `pr-gate` (Docker smoke, no 
    Biome gate (`bun run lint`) on the generated dataset + leaderboard — Biome formats JSON, so an
    unformatted Run document would fail the PR — and aborts before opening a doomed PR on a miss. If
    auto-merge can't be armed, the PR stays open for a maintainer.
+6. **Backfilling a failed publish.** The publish logic is the reusable `publish-dataset.yml`, so when
+   a matrix run's publish fails (or was never reached) a maintainer can re-run it standalone:
+   **Actions → Publish dataset → Run workflow**, passing the original run's id. It re-downloads that
+   run's `bench-*` shard artifacts by run-id (needs `actions: read`), re-aggregates, and opens the
+   same lint-gated dataset PR — no re-benching. This only works while that run's shard artifacts are
+   still within the repo's artifact-retention window. Dispatch is still gated by Environment
+   `privileged` (main-only, required reviewer), so it is effectively maintainer-only.
 
 > **Two approvals per bench-matrix run.** `bench` and `publish` both carry `environment:
 > privileged` and run sequentially, so GitHub raises **two** separate pending-deployment gates: one

--- a/docs/ci-secrets.md
+++ b/docs/ci-secrets.md
@@ -29,11 +29,15 @@ Ungated: `ci.yml`, `ci-lint.yml`, and the toolchain `pr-gate` (Docker smoke, no 
    deployments to the `main` branch. Write access alone cannot finish a release.
 4. **Fork PRs.** Same-repo guard on self-hosted PR jobs; fork PR code never runs on
    `starsling-ubuntu-24.04-2`. Forks never receive Environment secrets on `pull_request`.
-5. **Dataset lands via PR.** `main` is protected by a "changes must be made through a pull request"
-   ruleset, so `bench-matrix.yml`'s `publish` job cannot push the promoted dataset straight to
-   `main` (a direct push is rejected with `GH013`). It opens a `dataset/publish-<run-id>` PR instead
-   and best-effort auto-merges it; if the repo can't land it automatically the PR stays open for a
-   maintainer to merge. This is why `publish` also holds `pull-requests: write`.
+5. **Dataset lands via PR, lint-gated.** `main` is protected by a "changes must be made through a
+   pull request" ruleset, so `bench-matrix.yml`'s `publish` job cannot push the promoted dataset
+   straight to `main` (a direct push is rejected with `GH013`). It opens a `dataset/publish-<run-id>`
+   PR instead (hence `pull-requests: write`) and arms GitHub-native auto-merge (`gh pr merge --auto`),
+   which merges only once branch protection is satisfied — required status checks green and any
+   required reviews in. It never bypasses those rules. As a fast pre-flight, the job first re-runs the
+   Biome gate (`bun run lint`) on the generated dataset + leaderboard — Biome formats JSON, so an
+   unformatted Run document would fail the PR — and aborts before opening a doomed PR on a miss. If
+   auto-merge can't be armed, the PR stays open for a maintainer.
 
 > **Two approvals per bench-matrix run.** `bench` and `publish` both carry `environment:
 > privileged` and run sequentially, so GitHub raises **two** separate pending-deployment gates: one

--- a/tooling/repo-checks/src/lib/workflow-hardening.ts
+++ b/tooling/repo-checks/src/lib/workflow-hardening.ts
@@ -12,6 +12,8 @@
 //   3. Privileged-environment gate — every job that reads a custom secret (anything other than
 //      GITHUB_TOKEN / github.token) OR elevates to contents:write / packages:write must declare
 //      `environment: privileged`, so secrets and releases stay behind Environment protection rules.
+//      A reusable-workflow caller (`uses:` job) can't declare `environment:`; a LOCAL call defers the
+//      gate to the called file (checked here in its own right), a REMOTE one is flagged (unverifiable).
 //   4. Toolchain publish is dispatch-only — toolchain-image.yml must not fire a release on push/merge.
 //
 // Bun.YAML.parse is built into bun >= 1.3 (no new dependency).
@@ -30,9 +32,10 @@ export const PRIVILEGED_ENVIRONMENT = "privileged";
 /** Checkout steps that intentionally keep the persisted job token, keyed "<file>::<jobId>", with the
  *  reason they push. Every other `actions/checkout` must set persist-credentials: false. */
 export const CREDENTIALED_CHECKOUTS: Readonly<Record<string, string>> = {
-	// bench-matrix.yml's publish job commits the promoted dataset and `git push`es it back to the
-	// branch (it grants `contents: write` for exactly this), so it must keep the persisted token.
-	"bench-matrix.yml::publish": "commits + pushes the promoted dataset back to the branch",
+	// publish-dataset.yml's publish job commits the promoted dataset and `git push`es it back to the
+	// branch (it grants `contents: write` for exactly this), so it must keep the persisted token. It is
+	// the reusable workflow bench-matrix.yml's publish job calls, and a maintainer dispatches to backfill.
+	"publish-dataset.yml::publish": "commits + pushes the promoted dataset back to the branch",
 };
 
 /** Built-in / non-environment tokens that may appear as `${{ secrets.* }}` without requiring the
@@ -283,9 +286,31 @@ function jobSecretStrings(job: Record<string, unknown>, file: string, jobId: str
 	return strings;
 }
 
+/** Human-readable list of why a job needs the privileged Environment (secrets it reads/forwards and
+ *  the write scopes it grants), used in both the normal-job and reusable-call error messages. */
+function privilegeReasons(f: {
+	secrets: Set<string>;
+	forwardsSecrets: boolean;
+	contentsWrite: boolean;
+	packagesWrite: boolean;
+}): string[] {
+	const reasons: string[] = [];
+	if (f.secrets.size > 0) reasons.push(`custom secrets (${[...f.secrets].sort().join(", ")})`);
+	if (f.forwardsSecrets) reasons.push("secrets forwarded to a reusable workflow");
+	if (f.contentsWrite) reasons.push("contents: write");
+	if (f.packagesWrite) reasons.push("packages: write");
+	return reasons;
+}
+
 /**
  * Invariant 3: jobs that touch custom secrets or elevate write permissions must sit behind the
  * `privileged` GitHub Environment so Environment secrets + required reviewers apply.
+ *
+ * A job that calls a reusable workflow (`uses:` at the job level) is special: GHA forbids
+ * `environment:` on such a job, so the gate can't live on the caller. A LOCAL call
+ * (`./.github/workflows/*`) targets a file this same gate walks, so that file's own write/secret jobs
+ * are independently required to declare `environment: privileged` — trust that and pass the caller. A
+ * REMOTE call can't be verified, so a remote caller that forwards secrets or write access is flagged.
  */
 export function checkPrivilegedEnvironment(
 	doc: unknown,
@@ -321,15 +346,27 @@ export function checkPrivilegedEnvironment(
 		const needsPrivileged = secrets.size > 0 || forwardsSecrets || contentsWrite || packagesWrite;
 		if (!needsPrivileged) continue;
 
+		// Reusable-workflow caller: can't declare `environment:`, so gating moves into the called file.
+		if (typeof job.uses === "string") {
+			if (!job.uses.startsWith("./")) {
+				const reasons = privilegeReasons({
+					secrets,
+					forwardsSecrets,
+					contentsWrite,
+					packagesWrite,
+				});
+				errors.push(
+					`${key}: calls a remote reusable workflow (${job.uses}) with ${reasons.join(" and ")} — ` +
+						`it can't be verified to gate on \`environment: ${privileged}\`; call a local ` +
+						`./.github/workflows reusable workflow (which this gate checks) instead — see docs/ci-secrets.md`,
+				);
+			}
+			continue;
+		}
+
 		const envName = jobEnvironmentName(job);
 		if (envName !== privileged) {
-			const reasons: string[] = [];
-			if (secrets.size > 0) {
-				reasons.push(`custom secrets (${[...secrets].sort().join(", ")})`);
-			}
-			if (forwardsSecrets) reasons.push("secrets forwarded to a reusable workflow");
-			if (contentsWrite) reasons.push("contents: write");
-			if (packagesWrite) reasons.push("packages: write");
+			const reasons = privilegeReasons({ secrets, forwardsSecrets, contentsWrite, packagesWrite });
 			errors.push(
 				`${key}: must set \`environment: ${privileged}\` because it uses ${reasons.join(" and ")} — ` +
 					`see docs/ci-secrets.md`,

--- a/tooling/repo-checks/src/lib/workflow-hardening.ts
+++ b/tooling/repo-checks/src/lib/workflow-hardening.ts
@@ -302,20 +302,40 @@ function privilegeReasons(f: {
 	return reasons;
 }
 
+/** True if any job in a parsed workflow declares `environment: <privileged>`. Used to confirm a local
+ *  reusable workflow carries its own approval gate (the caller can't declare one for it). */
+function hasPrivilegedJob(doc: unknown, privileged: string): boolean {
+	const root = asRecord(doc, "reusable workflow: not a YAML mapping");
+	const jobs = asRecord(root.jobs, "reusable workflow: no jobs mapping");
+	return Object.values(jobs).some(
+		(j) =>
+			j !== null &&
+			typeof j === "object" &&
+			!Array.isArray(j) &&
+			jobEnvironmentName(j as Record<string, unknown>) === privileged,
+	);
+}
+
 /**
  * Invariant 3: jobs that touch custom secrets or elevate write permissions must sit behind the
  * `privileged` GitHub Environment so Environment secrets + required reviewers apply.
  *
  * A job that calls a reusable workflow (`uses:` at the job level) is special: GHA forbids
  * `environment:` on such a job, so the gate can't live on the caller. A LOCAL call
- * (`./.github/workflows/*`) targets a file this same gate walks, so that file's own write/secret jobs
- * are independently required to declare `environment: privileged` — trust that and pass the caller. A
- * REMOTE call can't be verified, so a remote caller that forwards secrets or write access is flagged.
+ * (`./.github/workflows/*`) hands the gate to the called file — but the caller's grant of write /
+ * secrets does NOT show up in that file's own YAML (the callee may inherit it), so the callee's
+ * per-file check can miss it. To close that bypass, a privileged local caller must point at a callee
+ * that gates at least one job on `environment: privileged` — verified by resolving the callee here.
+ * (`resolveLocalWorkflow` maps a repo-relative workflow path to its parsed doc; it defaults to reading
+ * from disk, and {@link runHardeningCheck} passes the already-parsed docs. An unresolvable callee is
+ * skipped — actionlint separately fails a `uses:` pointing at a missing local workflow.) A REMOTE call
+ * can't be verified at all, so a remote caller that forwards secrets or write access is flagged.
  */
 export function checkPrivilegedEnvironment(
 	doc: unknown,
 	file: string,
 	privileged: string = PRIVILEGED_ENVIRONMENT,
+	resolveLocalWorkflow: (relPath: string) => unknown = (relPath) => readWorkflow(relPath),
 ): string[] {
 	const errors: string[] = [];
 	const root = asRecord(doc, `${file}: not a YAML mapping`);
@@ -348,17 +368,30 @@ export function checkPrivilegedEnvironment(
 
 		// Reusable-workflow caller: can't declare `environment:`, so gating moves into the called file.
 		if (typeof job.uses === "string") {
+			const reasons = privilegeReasons({ secrets, forwardsSecrets, contentsWrite, packagesWrite });
 			if (!job.uses.startsWith("./")) {
-				const reasons = privilegeReasons({
-					secrets,
-					forwardsSecrets,
-					contentsWrite,
-					packagesWrite,
-				});
 				errors.push(
 					`${key}: calls a remote reusable workflow (${job.uses}) with ${reasons.join(" and ")} — ` +
 						`it can't be verified to gate on \`environment: ${privileged}\`; call a local ` +
 						`./.github/workflows reusable workflow (which this gate checks) instead — see docs/ci-secrets.md`,
+				);
+				continue;
+			}
+			// Local call: verify the callee actually carries an approval gate. The caller's grant of
+			// write/secrets is invisible in the callee's own YAML, so its per-file check can't be relied
+			// on to catch an ungated callee — check it here. Skip only if the callee can't be resolved
+			// (actionlint fails a `uses:` at a missing local workflow).
+			let calledDoc: unknown;
+			try {
+				calledDoc = resolveLocalWorkflow(job.uses.replace(/^\.\//, ""));
+			} catch {
+				calledDoc = undefined;
+			}
+			if (calledDoc !== undefined && !hasPrivilegedJob(calledDoc, privileged)) {
+				errors.push(
+					`${key}: calls local reusable workflow ${job.uses} with ${reasons.join(" and ")} but no ` +
+						`job in it sets \`environment: ${privileged}\` — a \`uses:\` caller can't gate itself, so ` +
+						`the called workflow must — see docs/ci-secrets.md`,
 				);
 			}
 			continue;
@@ -466,8 +499,22 @@ export function runHardeningCheck(root: string = findRepoRoot()): string[] {
 			? [`${CI_LINT_WORKFLOW}: missing from ${WORKFLOWS_DIR}`]
 			: checkCiLintGate(ciLintDoc)),
 	];
+	// Resolve a local `uses: ./.github/workflows/<f>` to its already-parsed doc so the privileged-env
+	// check can verify a reusable callee gates itself; throw on a miss so it's treated as unresolvable.
+	const resolveLocalWorkflow = (relPath: string): unknown => {
+		const doc = docs.get(relPath.slice(`${WORKFLOWS_DIR}/`.length));
+		if (doc === undefined) throw new Error(`no such local workflow: ${relPath}`);
+		return doc;
+	};
 	for (const file of files) {
-		errors.push(...checkPrivilegedEnvironment(docs.get(file), file));
+		errors.push(
+			...checkPrivilegedEnvironment(
+				docs.get(file),
+				file,
+				PRIVILEGED_ENVIRONMENT,
+				resolveLocalWorkflow,
+			),
+		);
 	}
 	const toolchainDoc = docs.get(TOOLCHAIN_WORKFLOW);
 	if (toolchainDoc === undefined) {

--- a/tooling/repo-checks/src/workflow-hardening.test.ts
+++ b/tooling/repo-checks/src/workflow-hardening.test.ts
@@ -285,30 +285,33 @@ describe("checkPrivilegedEnvironment", () => {
 		).toEqual([]);
 	});
 
-	test("flags secrets forwarded to a reusable workflow (secrets: inherit) without privileged", () => {
+	test("flags secrets forwarded to a REMOTE reusable workflow (secrets: inherit) — unverifiable", () => {
 		// `secrets: inherit` on a `uses:` job forwards every repo secret with no ${{ secrets.* }} here.
+		// A remote callee can't be checked to gate on the privileged Environment, so it is flagged.
 		const doc = oneJob("call", {
 			uses: "org/repo/.github/workflows/release.yml@main",
 			secrets: "inherit",
 		});
 		const errors = checkPrivilegedEnvironment(doc, "reusable.yml");
 		expect(errors).toHaveLength(1);
-		expect(errors[0]).toContain("reusable workflow");
+		expect(errors[0]).toContain("remote reusable workflow");
 		expect(errors[0]).toContain(`environment: ${PRIVILEGED_ENVIRONMENT}`);
 	});
 
-	test("accepts a reusable-workflow call that forwards secrets behind privileged", () => {
+	test("accepts a local reusable-workflow call that forwards secrets (gating defers to the called file)", () => {
+		// GHA forbids `environment:` on a `uses:` job, so a local call can't gate on the caller — the
+		// called ./.github/workflows file is walked by this same gate and must gate its own write/secret
+		// jobs, so the caller passes.
 		const doc = oneJob("call", {
-			uses: "org/repo/.github/workflows/release.yml@main",
+			uses: "./.github/workflows/publish-dataset.yml",
 			secrets: "inherit",
-			environment: PRIVILEGED_ENVIRONMENT,
 		});
 		expect(checkPrivilegedEnvironment(doc, "reusable-ok.yml")).toEqual([]);
 	});
 
-	test("flags a secret passed to a reusable workflow via a JOB-LEVEL with: input", () => {
+	test("flags a secret passed to a REMOTE reusable workflow via a JOB-LEVEL with: input", () => {
 		// A `uses:` job has no steps: its inputs ride a job-level `with:`. Passing a secret as an input
-		// there (instead of the `secrets:` block) must not slip past the gate.
+		// there (instead of the `secrets:` block) to an unverifiable remote callee must not slip past.
 		const doc = oneJob("call", {
 			uses: "org/repo/.github/workflows/deploy.yml@main",
 			// biome-ignore lint/suspicious/noTemplateCurlyInString: literal GitHub Actions expression under test
@@ -320,14 +323,26 @@ describe("checkPrivilegedEnvironment", () => {
 		expect(errors[0]).toContain(`environment: ${PRIVILEGED_ENVIRONMENT}`);
 	});
 
-	test("accepts a job-level with: secret input behind privileged", () => {
+	test("accepts a local reusable call that passes a secret via a job-level with: input", () => {
+		// Same as above: a local call defers the privileged gate to the called file, which this gate
+		// checks in its own right.
 		const doc = oneJob("call", {
-			uses: "org/repo/.github/workflows/deploy.yml@main",
+			uses: "./.github/workflows/deploy.yml",
 			// biome-ignore lint/suspicious/noTemplateCurlyInString: literal GitHub Actions expression under test
 			with: { api_key: "${{ secrets.DEPLOY_KEY }}" },
-			environment: PRIVILEGED_ENVIRONMENT,
 		});
 		expect(checkPrivilegedEnvironment(doc, "with-ok.yml")).toEqual([]);
+	});
+
+	test("accepts a local reusable call that grants write perms (bench-matrix.yml::publish shape)", () => {
+		// The real case: bench-matrix's publish job grants contents/pull-requests write to the local
+		// publish-dataset.yml. A `uses:` job can't set `environment:`; the called file gates itself.
+		const doc = oneJob("publish", {
+			uses: "./.github/workflows/publish-dataset.yml",
+			permissions: { contents: "write", "pull-requests": "write", actions: "read" },
+			with: { run_id: "123" },
+		});
+		expect(checkPrivilegedEnvironment(doc, "bench-matrix.yml")).toEqual([]);
 	});
 });
 

--- a/tooling/repo-checks/src/workflow-hardening.test.ts
+++ b/tooling/repo-checks/src/workflow-hardening.test.ts
@@ -298,15 +298,54 @@ describe("checkPrivilegedEnvironment", () => {
 		expect(errors[0]).toContain(`environment: ${PRIVILEGED_ENVIRONMENT}`);
 	});
 
-	test("accepts a local reusable-workflow call that forwards secrets (gating defers to the called file)", () => {
-		// GHA forbids `environment:` on a `uses:` job, so a local call can't gate on the caller — the
-		// called ./.github/workflows file is walked by this same gate and must gate its own write/secret
-		// jobs, so the caller passes.
+	// A local callee that gates a job on the privileged Environment, and one that gates nothing —
+	// injected via the resolver so these stay pure unit tests independent of on-disk workflow files.
+	const gatedCallee = oneJob("run", {
+		environment: PRIVILEGED_ENVIRONMENT,
+		permissions: { contents: "write" },
+		steps: [NOOP_STEP],
+	});
+	const ungatedCallee = oneJob("run", { permissions: { contents: "write" }, steps: [NOOP_STEP] });
+
+	test("accepts a local reusable-workflow call that forwards secrets when the callee gates a job", () => {
+		// GHA forbids `environment:` on a `uses:` job, so a local call can't gate on the caller — but the
+		// caller's grant is invisible in the callee's YAML, so the gate resolves the callee and requires
+		// it to gate a job itself.
 		const doc = oneJob("call", {
 			uses: "./.github/workflows/publish-dataset.yml",
 			secrets: "inherit",
 		});
-		expect(checkPrivilegedEnvironment(doc, "reusable-ok.yml")).toEqual([]);
+		expect(
+			checkPrivilegedEnvironment(doc, "reusable-ok.yml", PRIVILEGED_ENVIRONMENT, () => gatedCallee),
+		).toEqual([]);
+	});
+
+	test("flags a local reusable call whose callee gates no job (caller can't gate itself)", () => {
+		const doc = oneJob("publish", {
+			uses: "./.github/workflows/ungated.yml",
+			permissions: { contents: "write" },
+		});
+		const errors = checkPrivilegedEnvironment(
+			doc,
+			"caller.yml",
+			PRIVILEGED_ENVIRONMENT,
+			() => ungatedCallee,
+		);
+		expect(errors).toHaveLength(1);
+		expect(errors[0]).toContain("caller.yml::publish");
+		expect(errors[0]).toContain("no job in it sets");
+		expect(errors[0]).toContain(`environment: ${PRIVILEGED_ENVIRONMENT}`);
+	});
+
+	test("skips a local reusable call whose callee can't be resolved (actionlint covers a missing file)", () => {
+		const doc = oneJob("publish", {
+			uses: "./.github/workflows/missing.yml",
+			permissions: { contents: "write" },
+		});
+		const errors = checkPrivilegedEnvironment(doc, "caller.yml", PRIVILEGED_ENVIRONMENT, () => {
+			throw new Error("ENOENT");
+		});
+		expect(errors).toEqual([]);
 	});
 
 	test("flags a secret passed to a REMOTE reusable workflow via a JOB-LEVEL with: input", () => {
@@ -324,25 +363,33 @@ describe("checkPrivilegedEnvironment", () => {
 	});
 
 	test("accepts a local reusable call that passes a secret via a job-level with: input", () => {
-		// Same as above: a local call defers the privileged gate to the called file, which this gate
-		// checks in its own right.
+		// A local call defers the privileged gate to the called file, which must gate a job itself.
 		const doc = oneJob("call", {
 			uses: "./.github/workflows/deploy.yml",
 			// biome-ignore lint/suspicious/noTemplateCurlyInString: literal GitHub Actions expression under test
 			with: { api_key: "${{ secrets.DEPLOY_KEY }}" },
 		});
-		expect(checkPrivilegedEnvironment(doc, "with-ok.yml")).toEqual([]);
+		expect(
+			checkPrivilegedEnvironment(doc, "with-ok.yml", PRIVILEGED_ENVIRONMENT, () => gatedCallee),
+		).toEqual([]);
 	});
 
 	test("accepts a local reusable call that grants write perms (bench-matrix.yml::publish shape)", () => {
 		// The real case: bench-matrix's publish job grants contents/pull-requests write to the local
-		// publish-dataset.yml. A `uses:` job can't set `environment:`; the called file gates itself.
+		// publish-dataset.yml. A `uses:` job can't set `environment:`; the called file gates a job.
 		const doc = oneJob("publish", {
 			uses: "./.github/workflows/publish-dataset.yml",
 			permissions: { contents: "write", "pull-requests": "write", actions: "read" },
 			with: { run_id: "123" },
 		});
-		expect(checkPrivilegedEnvironment(doc, "bench-matrix.yml")).toEqual([]);
+		expect(
+			checkPrivilegedEnvironment(
+				doc,
+				"bench-matrix.yml",
+				PRIVILEGED_ENVIRONMENT,
+				() => gatedCallee,
+			),
+		).toEqual([]);
 	});
 });
 


### PR DESCRIPTION
The bench-matrix `publish` job pushed the promoted dataset + regenerated
LEADERBOARD.md straight to main. The public-repo hardening stack (#176/#177)
added a "changes must be made through a pull request" ruleset on main, so that
direct push is now rejected with GH013 and the whole publish job fails.

Route the publish through a short-lived `dataset/publish-<run-id>` branch and a
pull request, then best-effort auto-land it (admin bypass, else queued
auto-merge); if the repo can't merge it automatically the PR stays open for a
maintainer. Grant the job `pull-requests: write` for the PR create/merge.

The job still commits + pushes (to the branch), so its credentialed checkout
and the workflow-hardening allowlist entry stay valid.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01AZqw4j5hRfKgEfL4b549fq

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an automated dataset publishing workflow that aggregates benchmark results, updates the leaderboard, and opens a pull request with auto-merge.
  * Added support for manually backfilling datasets using retained benchmark artifacts.

* **Documentation**
  * Clarified privileged workflow requirements, publishing safeguards, and backfill procedures.

* **Bug Fixes**
  * Improved workflow security checks for reusable workflows and privileged permissions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Publish the bench dataset through a short‑lived branch and PR via reusable `publish-dataset.yml`, restoring PR‑only protection and gating merges on Biome. Adds manual backfill by `run_id`, an idempotent PR flow, and stricter workflow hardening.

- **New Features**
  - Reusable `publish-dataset.yml` aggregates, promotes, regenerates `LEADERBOARD.md`, preflights `biome check data/dataset LEADERBOARD.md`, and opens `dataset/publish-<run-id>` with GitHub auto-merge.
  - `workflow_dispatch` backfill by `run_id` re-downloads `bench-*` artifacts (needs `actions: read`) and reuses an open PR or force-pushes the deterministic branch.

- **Bug Fixes**
  - Restore publish under PR-only rules: `bench-matrix.yml` now calls the reusable with `contents: write`, `pull-requests: write`, and `actions: read`; merges only after required checks/reviews (admin bypass removed).
  - Hardened gates: require local reusable callees to gate a job on `environment: privileged`; flag remote `uses:` that forward secrets/permissions as unverifiable. Moved the credentialed-checkout allowlist and `zizmor` ignore to `publish-dataset.yml`; docs add the `GITHUB_TOKEN` PR-check caveat and backfill steps.

<sup>Written for commit 561e95ebfc6bcea0e37dfb906b503349a1a147e6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/starslingdev/sandbox-benchmarks/pull/185?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

