### PR TITLE
fix(ci): Biome-autofix the promoted dataset before publishing

### DIFF
--- a/.github/workflows/publish-dataset.yml
+++ b/.github/workflows/publish-dataset.yml
@@ -101,13 +101,21 @@ jobs:
       - name: Regenerate leaderboard
         run: bun apps/cli/src/bin/leaderboard.ts "data/dataset/runs/$RUN_ID.json" LEADERBOARD.md
 
-      # Pre-flight the PR's lint gate on the generated content. The dataset + leaderboard are committed
-      # files, so ci.yml's Biome gate (`biome check .`) lints them — Biome formats JSON (2-space, per
-      # biome.json's `**/*.json` override), so an unformatted Run document would fail the PR. Check
-      # exactly the files this job writes (not the whole workspace) with the same rules and severity
-      # ci.yml uses, so the pre-flight fails the job early on a bad Run document — but a pre-existing,
-      # unrelated lint failure elsewhere on main can't strand a clean dataset publish. The PR's own
-      # `biome check .` still gates the merge; this is just fast, in-run feedback on the new content.
+      # Canonicalize the promoted dataset to Biome's format before the gate + commit. The promote
+      # writer emits `JSON.stringify(run, null, 2)` (every array element on its own line), but Biome's
+      # JSON formatter inlines short arrays and wraps long ones at the 100-col width — so the committed
+      # dataset is in Biome's shape and a raw Run document fails `biome check .` on the PR. Autofixing
+      # the mechanical formatting here is exactly what a developer's `bun run lint:fix` would do. Scope
+      # the write to data/dataset (JSON only): LEADERBOARD.md must stay byte-identical to the renderer
+      # output (the leaderboard-artifact-sync gate), and Biome leaves the rendered Markdown untouched.
+      - name: Autofix the promoted dataset formatting (Biome)
+        run: bunx biome check data/dataset --write
+
+      # Confirm the published content passes the exact gate ci.yml runs (`biome check .`), scoped to the
+      # files this job writes. After the autofix above this should pass; if anything Biome can't fix
+      # mechanically remains, fail the job early (before any PR is opened) rather than leave a doomed PR.
+      # A pre-existing, unrelated lint failure elsewhere on main can't strand a clean dataset publish;
+      # the PR's own `biome check .` still gates the merge.
       - name: Confirm the published dataset passes Biome (the PR lint gate)
         run: bunx biome check data/dataset LEADERBOARD.md --error-on-warnings
 


### PR DESCRIPTION
## What

Add a `bunx biome check data/dataset --write` step to `publish-dataset.yml`, right after the dataset is promoted and the leaderboard regenerated, to autofix the mechanical JSON formatting before the lint gate and commit.

## Why

The dataset backfill dispatch for run `29472826358` ([failed run](https://github.com/starslingdev/sandbox-benchmarks/actions/runs/29522599908/job/87703020698)) died at the Biome pre-flight:

```
"samples": [        →   "samples": [344.2, 345],
  344.2,
  345
],
```

The promote writer emits `JSON.stringify(run, null, 2)` (one array element per line), but Biome's JSON formatter inlines short arrays and wraps long ones at the 100-col width. So a freshly promoted Run document is **not** Biome-canonical and fails `biome check` — both the in-job pre-flight and the eventual PR's `biome check .` gate.

This never surfaced before because the old direct-push publish never actually succeeded (that was the original bug this workflow replaced). The dataset already committed on `main` got its Biome shape from human/lefthook commits, which masked the mismatch — the committed files are Biome-clean, but the pipeline output isn't.

## The fix

Autofix the formatting in the workflow — exactly what a developer's `bun run lint:fix` does locally — scoped to `data/dataset` (JSON only). `LEADERBOARD.md` is deliberately excluded so it stays byte-identical to the renderer output (the `leaderboard-artifact-sync` gate); Biome leaves the rendered Markdown untouched anyway. The existing confirm step (`biome check data/dataset LEADERBOARD.md --error-on-warnings`) still gates on anything Biome can't fix mechanically.

This fixes both entry points of the reusable workflow — the backfill dispatch **and** the normal `bench-matrix` publish path (which would have hit the same wall on its first real run).

## Validation

- Reproduced the failure and the fix locally: raw `JSON.stringify` array → `biome format --write` → short arrays inline, long arrays wrapped at 100 cols (matching the committed dataset) → `biome check` clean.
- `runHardeningCheck()` clean; repo-checks 133/133 pass; `biome check .` and typecheck green.

Once merged I'll re-dispatch the backfill for `29472826358`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AZqw4j5hRfKgEfL4b549fq

---
_Generated by [Claude Code](https://claude.ai/code/session_01AZqw4j5hRfKgEfL4b549fq)_

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Autofixes the promoted dataset JSON in the publish workflow using `bunx biome` so runs match Biome’s format and don’t fail the lint gate. This resolves CI failures caused by `JSON.stringify` vs Biome formatting differences.

- **Bug Fixes**
  - Add `bunx biome check data/dataset --write` after promotion to format JSON canonically.
  - Exclude `LEADERBOARD.md` to keep it byte-identical; the existing check still gates unfixable issues.

<sup>Written for commit 905add8532e307f9625f462554af3abffa986f79. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/starslingdev/sandbox-benchmarks/pull/186?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the dataset publishing workflow to automatically format dataset JSON files before validation.
  * Improved workflow documentation to clarify the formatting and verification steps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->