### PR TITLE
chore(dataset): publish run 29472826358

### DIFF
--- a/LEADERBOARD.md
+++ b/LEADERBOARD.md
@@ -1,10 +1,10 @@
 # Sandbox provider leaderboard
 
-Run `29365910084` · commit `0343acb5c1cfd3a0aac81afc3262d4af0fa69bc7` · generated 2026-07-14T22:52:05.191Z
+Run `29472826358` · commit `d85e6a9f905d428b9efd469a1d287f4075fddef7` · generated 2026-07-16T07:25:11.693Z
 
 Requested target for every provider: **2 vCPU · 8 GiB RAM · 40 GB disk**. This run contains **146 metric records**
-backed by **702 retained trial observations**, across **35 metrics** and
-**5 providers**; every emitted, catalogued metric has a ranked table below
+backed by **288 retained trial observations**, across **49 metrics** and
+**4 providers**; every emitted, catalogued metric has a ranked table below
 (median of retained trials), grouped by dimension with its headline first.
 Generated from the published Run dataset — do not edit by hand. Methodology:
 [`docs/methodology.md`](docs/methodology.md).
@@ -22,15 +22,198 @@ surfaced through coverage gaps, not part of the compute-match verdict.
 
 runs/s · higher is better
 
-_Daytona leads · ~1.1× Novita on median (higher is better)._
+_Daytona leads · ~1.5× Blaxel on median (higher is better)._
 
-| Rank | Provider | Node.js web tooling (runs/s) | 95% bootstrap interval | n |
+| Rank | Provider | Node.js web tooling (runs/s) | 95% bootstrap interval | n | Note |
+| ---: | --- | ---: | ---: | ---: | --- |
+| 1 | Daytona | 19.43 | 18.79 – 20.08 | 2 | — |
+| 2 | Blaxel | 12.7 | 12.67 – 12.73 | 2 | n too small |
+| 3 | E2B | 10.63 | 10.59 – 10.66 | 2 | n too small |
+| 4 | Modal | 9.24 | 9 – 9.48 | 2 | n too small |
+
+### C-Ray (1080p, 16 RPP)
+
+Seconds · lower is better
+
+_Blaxel leads · Daytona is ~1.6× higher (lower is better)._
+
+| Rank | Provider | C-Ray (1080p, 16 RPP) (Seconds) | 95% bootstrap interval | n | Note |
+| ---: | --- | ---: | ---: | ---: | --- |
+| 1 | Blaxel | 128.4 | 128.1 – 128.8 | 2 | — |
+| 2 | Daytona | 201.8 | 201.5 – 202.1 | 2 | n too small |
+
+### C-Ray (4K, 16 RPP)
+
+Seconds · lower is better
+
+_Blaxel leads · Daytona is ~1.6× higher (lower is better)._
+
+| Rank | Provider | C-Ray (4K, 16 RPP) (Seconds) | 95% bootstrap interval | n | Note |
+| ---: | --- | ---: | ---: | ---: | --- |
+| 1 | Blaxel | 512.4 | 511.2 – 513.5 | 2 | — |
+| 2 | Daytona | 806.1 | 803.3 – 809 | 2 | n too small |
+
+### C-Ray (5K, 16 RPP)
+
+Seconds · lower is better
+
+_Blaxel leads · Daytona is ~1.6× higher (lower is better)._
+
+| Rank | Provider | C-Ray (5K, 16 RPP) (Seconds) | 95% bootstrap interval | n | Note |
+| ---: | --- | ---: | ---: | ---: | --- |
+| 1 | Blaxel | 907.6 | 906.9 – 908.3 | 2 | — |
+| 2 | Daytona | 1420 | 1417 – 1423 | 2 | n too small |
+
+### Zstd 12 compress
+
+MB/s · higher is better
+
+_Blaxel leads · ~1.2× Daytona on median (higher is better)._
+
+| Rank | Provider | Zstd 12 compress (MB/s) | 95% bootstrap interval | n | Note |
+| ---: | --- | ---: | ---: | ---: | --- |
+| 1 | Blaxel | 115.9 | 115.3 – 116.5 | 2 | — |
+| 2 | Daytona | 99.4 | 99.3 – 99.5 | 2 | n too small |
+
+### Zstd 12 decompress
+
+MB/s · higher is better
+
+_Daytona leads · ~2.2× Blaxel on median (higher is better)._
+
+| Rank | Provider | Zstd 12 decompress (MB/s) | 95% bootstrap interval | n | Note |
+| ---: | --- | ---: | ---: | ---: | --- |
+| 1 | Daytona | 2294 | 2283 – 2305 | 2 | — |
+| 2 | Blaxel | 1054 | 1052 – 1056 | 2 | n too small |
+
+### Zstd 19 compress
+
+MB/s · higher is better
+
+_Blaxel leads · ~1.4× Daytona on median (higher is better)._
+
+| Rank | Provider | Zstd 19 compress (MB/s) | 95% bootstrap interval | n | Note |
+| ---: | --- | ---: | ---: | ---: | --- |
+| 1 | Blaxel | 11.35 | 11.1 – 11.6 | 2 | — |
+| 2 | Daytona | 8.155 | 8.15 – 8.16 | 2 | n too small |
+
+### Zstd 19 decompress
+
+MB/s · higher is better
+
+_Daytona leads · ~2.2× Blaxel on median (higher is better)._
+
+| Rank | Provider | Zstd 19 decompress (MB/s) | 95% bootstrap interval | n | Note |
+| ---: | --- | ---: | ---: | ---: | --- |
+| 1 | Daytona | 1921 | 1920 – 1922 | 2 | — |
+| 2 | Blaxel | 887.8 | 882 – 893.6 | 2 | n too small |
+
+### Zstd 19 (long) compress
+
+MB/s · higher is better
+
+_Daytona leads · ~1.1× Blaxel on median (higher is better)._
+
+| Rank | Provider | Zstd 19 (long) compress (MB/s) | 95% bootstrap interval | n | Note |
+| ---: | --- | ---: | ---: | ---: | --- |
+| 1 | Daytona | 7.055 | 6.96 – 7.15 | 2 | — |
+| 2 | Blaxel | 6.135 | 6.09 – 6.18 | 2 | n too small |
+
+### Zstd 19 (long) decompress
+
+MB/s · higher is better
+
+_Daytona leads · ~2.0× Blaxel on median (higher is better)._
+
+| Rank | Provider | Zstd 19 (long) decompress (MB/s) | 95% bootstrap interval | n | Note |
+| ---: | --- | ---: | ---: | ---: | --- |
+| 1 | Daytona | 1828 | 1810 – 1846 | 2 | — |
+| 2 | Blaxel | 896.6 | 893.3 – 900 | 2 | n too small |
+
+### Zstd 3 compress
+
+MB/s · higher is better
+
+_Blaxel leads · ~1.7× Daytona on median (higher is better)._
+
+| Rank | Provider | Zstd 3 compress (MB/s) | 95% bootstrap interval | n | Note |
+| ---: | --- | ---: | ---: | ---: | --- |
+| 1 | Blaxel | 1299 | 1295 – 1304 | 2 | — |
+| 2 | Daytona | 781.2 | 778.7 – 783.7 | 2 | n too small |
+
+### Zstd 3 decompress
+
+MB/s · higher is better
+
+_Daytona is the only ranked provider (2112 MB/s; higher is better)._
+
+| Rank | Provider | Zstd 3 decompress (MB/s) | 95% bootstrap interval | n |
 | ---: | --- | ---: | ---: | ---: |
-| 1 | Daytona | 19.14 | 18.48 – 19.89 | 5 |
-| 2 | Novita | 17.59 | 17.22 – 18.65 | 5 |
-| 3 | Blaxel | 14.01 | 13.64 – 14.25 | 5 |
-| 4 | E2B | 10.58 | 10.25 – 10.83 | 5 |
-| 5 | Modal | 9.25 | 8.7 – 9.58 | 5 |
+| 1 | Daytona | 2112 | 2110 – 2115 | 2 |
+
+### Zstd 3 (long) compress
+
+MB/s · higher is better
+
+_Blaxel leads · ~1.6× Daytona on median (higher is better)._
+
+| Rank | Provider | Zstd 3 (long) compress (MB/s) | 95% bootstrap interval | n | Note |
+| ---: | --- | ---: | ---: | ---: | --- |
+| 1 | Blaxel | 840.3 | 832.3 – 848.2 | 2 | — |
+| 2 | Daytona | 534 | 530.4 – 537.7 | 2 | n too small |
+
+### Zstd 3 (long) decompress
+
+MB/s · higher is better
+
+_Daytona is the only ranked provider (2162 MB/s; higher is better)._
+
+| Rank | Provider | Zstd 3 (long) decompress (MB/s) | 95% bootstrap interval | n |
+| ---: | --- | ---: | ---: | ---: |
+| 1 | Daytona | 2162 | 2162 – 2163 | 2 |
+
+### Zstd 8 compress
+
+MB/s · higher is better
+
+_Blaxel leads · ~1.6× Daytona on median (higher is better)._
+
+| Rank | Provider | Zstd 8 compress (MB/s) | 95% bootstrap interval | n | Note |
+| ---: | --- | ---: | ---: | ---: | --- |
+| 1 | Blaxel | 344.6 | 344.2 – 345 | 2 | — |
+| 2 | Daytona | 209.2 | 208.9 – 209.5 | 2 | n too small |
+
+### Zstd 8 decompress
+
+MB/s · higher is better
+
+_Blaxel is the only ranked provider (1118 MB/s; higher is better)._
+
+| Rank | Provider | Zstd 8 decompress (MB/s) | 95% bootstrap interval | n |
+| ---: | --- | ---: | ---: | ---: |
+| 1 | Blaxel | 1118 | 1111 – 1126 | 2 |
+
+### Zstd 8 (long) compress
+
+MB/s · higher is better
+
+_Blaxel leads · ~1.6× Daytona on median (higher is better)._
+
+| Rank | Provider | Zstd 8 (long) compress (MB/s) | 95% bootstrap interval | n | Note |
+| ---: | --- | ---: | ---: | ---: | --- |
+| 1 | Blaxel | 327 | 323.5 – 330.5 | 2 | — |
+| 2 | Daytona | 202.9 | 202.3 – 203.6 | 2 | n too small |
+
+### Zstd 8 (long) decompress
+
+MB/s · higher is better
+
+_Daytona leads · ~2.0× Blaxel on median (higher is better)._
+
+| Rank | Provider | Zstd 8 (long) decompress (MB/s) | 95% bootstrap interval | n | Note |
+| ---: | --- | ---: | ---: | ---: | --- |
+| 1 | Daytona | 2314 | 2307 – 2321 | 2 | — |
+| 2 | Blaxel | 1134 | 1130 – 1137 | 2 | n too small |
 
 ## disk
 
@@ -38,127 +221,117 @@ _Daytona leads · ~1.1× Novita on median (higher is better)._
 
 IOPS · higher is better
 
-_Blaxel leads · ~2.3× Daytona on median (higher is better)._
+_Blaxel leads · ~2.0× Daytona on median (higher is better)._
 
-| Rank | Provider | fio rand read 4KB, O_DIRECT (IOPS) (IOPS) | 95% bootstrap interval | n |
-| ---: | --- | ---: | ---: | ---: |
-| 1 | Blaxel | 556000 | 549000 – 580000 | 5 |
-| 2 | Daytona | 246000 | 241000 – 255000 | 5 |
-| 3 | Novita | 68100 | 66600 – 71500 | 5 |
-| 4 | E2B | 40800 | 39800 – 42000 | 5 |
-| 5 | Modal | 34900 | 33600 – 35200 | 5 |
+| Rank | Provider | fio rand read 4KB, O_DIRECT (IOPS) (IOPS) | 95% bootstrap interval | n | Note |
+| ---: | --- | ---: | ---: | ---: | --- |
+| 1 | Blaxel | 540000 | 525000 – 555000 | 2 | — |
+| 2 | Daytona | 266500 | 264000 – 269000 | 2 | n too small |
+| 3 | Modal | 33200 | 32800 – 33600 | 2 | n too small |
+| 4 | E2B | 32550 | 31600 – 33500 | 2 | n too small |
 
 ### fio rand read 4KB, O_DIRECT (MB/s)
 
 MB/s · higher is better
 
-_Blaxel leads · ~2.3× Daytona on median (higher is better)._
+_Blaxel leads · ~2.0× Daytona on median (higher is better)._
 
-| Rank | Provider | fio rand read 4KB, O_DIRECT (MB/s) (MB/s) | 95% bootstrap interval | n |
-| ---: | --- | ---: | ---: | ---: |
-| 1 | Blaxel | 2173 | 2144 – 2264 | 5 |
-| 2 | Daytona | 960 | 941 – 996 | 5 |
-| 3 | Novita | 266 | 260 – 279 | 5 |
-| 4 | E2B | 159 | 155 – 164 | 5 |
-| 5 | Modal | 136 | 131 – 138 | 5 |
+| Rank | Provider | fio rand read 4KB, O_DIRECT (MB/s) (MB/s) | 95% bootstrap interval | n | Note |
+| ---: | --- | ---: | ---: | ---: | --- |
+| 1 | Blaxel | 2110 | 2050 – 2169 | 2 | — |
+| 2 | Daytona | 1041 | 1031 – 1050 | 2 | n too small |
+| 3 | Modal | 129.5 | 128 – 131 | 2 | n too small |
+| 4 | E2B | 127 | 123 – 131 | 2 | n too small |
 
 ### fio rand write 4KB, O_DIRECT (IOPS)
 
 IOPS · higher is better
 
-_Blaxel leads · ~2.3× Daytona on median (higher is better)._
+_Blaxel leads · ~2.2× Daytona on median (higher is better)._
 
-| Rank | Provider | fio rand write 4KB, O_DIRECT (IOPS) (IOPS) | 95% bootstrap interval | n |
-| ---: | --- | ---: | ---: | ---: |
-| 1 | Blaxel | 492000 | 471000 – 500000 | 5 |
-| 2 | Daytona | 218000 | 213000 – 236000 | 5 |
-| 3 | Novita | 69400 | 67200 – 75500 | 5 |
-| 4 | E2B | 41800 | 40200 – 43300 | 5 |
-| 5 | Modal | 29500 | 29200 – 30000 | 5 |
+| Rank | Provider | fio rand write 4KB, O_DIRECT (IOPS) (IOPS) | 95% bootstrap interval | n | Note |
+| ---: | --- | ---: | ---: | ---: | --- |
+| 1 | Blaxel | 493500 | 492000 – 495000 | 2 | — |
+| 2 | Daytona | 228500 | 228000 – 229000 | 2 | n too small |
+| 3 | E2B | 53950 | 52600 – 55300 | 2 | n too small |
+| 4 | Modal | 29200 | 29000 – 29400 | 2 | n too small |
 
 ### fio rand write 4KB, O_DIRECT (MB/s)
 
 MB/s · higher is better
 
-_Blaxel leads · ~2.3× Daytona on median (higher is better)._
+_Blaxel leads · ~2.2× Daytona on median (higher is better)._
 
-| Rank | Provider | fio rand write 4KB, O_DIRECT (MB/s) (MB/s) | 95% bootstrap interval | n |
-| ---: | --- | ---: | ---: | ---: |
-| 1 | Blaxel | 1923 | 1842 – 1955 | 5 |
-| 2 | Daytona | 850 | 833 – 923 | 5 |
-| 3 | Novita | 271 | 263 – 295 | 5 |
-| 4 | E2B | 163 | 157 – 169 | 5 |
-| 5 | Modal | 115 | 114 – 117 | 5 |
+| Rank | Provider | fio rand write 4KB, O_DIRECT (MB/s) (MB/s) | 95% bootstrap interval | n | Note |
+| ---: | --- | ---: | ---: | ---: | --- |
+| 1 | Blaxel | 1929 | 1922 – 1935 | 2 | — |
+| 2 | Daytona | 893.5 | 891 – 896 | 2 | n too small |
+| 3 | E2B | 211 | 206 – 216 | 2 | n too small |
+| 4 | Modal | 114 | 113 – 115 | 2 | n too small |
 
 ### fio seq read 1MB, O_DIRECT (IOPS)
 
 IOPS · higher is better
 
-_Modal, Novita and Daytona share the top on this metric (higher is better)._
+_Daytona leads · ~1.2× Modal on median (higher is better)._
 
 | Rank | Provider | fio seq read 1MB, O_DIRECT (IOPS) (IOPS) | 95% bootstrap interval | n | Note |
 | ---: | --- | ---: | ---: | ---: | --- |
-| 1 | Modal | 12300 | 9000 – 13100 | 5 | — |
-| 1 | Novita | 11000 | 9742 – 12300 | 5 | tied |
-| 1 | Daytona | 10800 | 5160 – 15400 | 5 | tied |
-| 4 | Blaxel | 4535 | 4336 – 4815 | 5 | — |
-| 5 | E2B | 600 | 599 – 600 | 5 | — |
+| 1 | Daytona | 13900 | 8801 – 19000 | 2 | — |
+| 2 | Modal | 12000 | 10700 – 13300 | 2 | n too small |
+| 3 | Blaxel | 4603 | 4535 – 4670 | 2 | n too small |
+| 4 | E2B | 599 | 599 – 599 | 2 | n too small |
 
 ### fio seq read 1MB, O_DIRECT (MB/s)
 
 MB/s · higher is better
 
-_Novita leads · ~1.1× Modal on median (higher is better)._
+_Daytona leads · ~1.9× Blaxel on median (higher is better)._
 
-| Rank | Provider | fio seq read 1MB, O_DIRECT (MB/s) (MB/s) | 95% bootstrap interval | n |
-| ---: | --- | ---: | ---: | ---: |
-| 1 | Novita | 9744 | — | 1 |
-| 2 | Modal | 9001 | — | 1 |
-| 3 | Daytona | 5161 | — | 1 |
-| 4 | Blaxel | 4536 | 4338 – 4816 | 5 |
-| 5 | E2B | 601 | 601 – 601 | 5 |
+| Rank | Provider | fio seq read 1MB, O_DIRECT (MB/s) (MB/s) | 95% bootstrap interval | n | Note |
+| ---: | --- | ---: | ---: | ---: | --- |
+| 1 | Daytona | 8803 | — | 1 | — |
+| 2 | Blaxel | 4605 | 4537 – 4672 | 2 | — |
+| 3 | E2B | 601 | 601 – 601 | 2 | n too small |
 
 ### fio seq write 1MB, O_DIRECT (IOPS)
 
 IOPS · higher is better
 
-_Novita leads · ~1.2× Daytona on median (higher is better)._
+_Daytona leads · ~1.6× Blaxel on median (higher is better)._
 
 | Rank | Provider | fio seq write 1MB, O_DIRECT (IOPS) (IOPS) | 95% bootstrap interval | n | Note |
 | ---: | --- | ---: | ---: | ---: | --- |
-| 1 | Novita | 6435 | 6005 – 6854 | 5 | — |
-| 2 | Daytona | 5188 | 3227 – 5992 | 5 | — |
-| 2 | Blaxel | 3630 | 3486 – 3780 | 5 | tied |
-| 4 | Modal | 2537 | 2230 – 2930 | 5 | — |
-| 5 | E2B | 599 | 599 – 600 | 5 | — |
+| 1 | Daytona | 5732 | 5697 – 5766 | 2 | — |
+| 2 | Blaxel | 3583 | 3544 – 3622 | 2 | n too small |
+| 3 | Modal | 2233 | 1695 – 2770 | 2 | n too small |
+| 4 | E2B | 599.5 | 599 – 600 | 2 | n too small |
 
 ### fio seq write 1MB, O_DIRECT (MB/s)
 
 MB/s · higher is better
 
-_Novita leads · ~1.2× Daytona on median (higher is better)._
+_Daytona leads · ~1.6× Blaxel on median (higher is better)._
 
 | Rank | Provider | fio seq write 1MB, O_DIRECT (MB/s) (MB/s) | 95% bootstrap interval | n | Note |
 | ---: | --- | ---: | ---: | ---: | --- |
-| 1 | Novita | 6437 | 6006 – 6855 | 5 | — |
-| 2 | Daytona | 5189 | 3228 – 5993 | 5 | — |
-| 2 | Blaxel | 3632 | 3487 – 3782 | 5 | tied |
-| 4 | Modal | 2538 | 2232 – 2932 | 5 | — |
-| 5 | E2B | 601 | 601 – 602 | 5 | — |
+| 1 | Daytona | 5733 | 5699 – 5767 | 2 | — |
+| 2 | Blaxel | 3585 | 3545 – 3624 | 2 | n too small |
+| 3 | Modal | 2235 | 1697 – 2772 | 2 | n too small |
+| 4 | E2B | 601 | 601 – 601 | 2 | n too small |
 
 ### Hardlink throughput
 
 bogo ops/s · higher is better
 
-_Daytona leads · ~1.3× Novita on median (higher is better)._
+_Daytona leads · ~2.2× Blaxel on median (higher is better)._
 
-| Rank | Provider | Hardlink throughput (bogo ops/s) | 95% bootstrap interval | n |
-| ---: | --- | ---: | ---: | ---: |
-| 1 | Daytona | 23.42 | 23.29 – 23.66 | 5 |
-| 2 | Novita | 18.49 | 18.35 – 18.75 | 5 |
-| 3 | Blaxel | 11.53 | 11.49 – 12.07 | 5 |
-| 4 | Modal | 3.22 | 3.09 – 3.28 | 5 |
-| 5 | E2B | 1.5 | 1.46 – 1.5 | 5 |
+| Rank | Provider | Hardlink throughput (bogo ops/s) | 95% bootstrap interval | n | Note |
+| ---: | --- | ---: | ---: | ---: | --- |
+| 1 | Daytona | 26.21 | 26.13 – 26.29 | 2 | — |
+| 2 | Blaxel | 12.13 | 11.96 – 12.29 | 2 | n too small |
+| 3 | Modal | 3.195 | 3.18 – 3.21 | 2 | n too small |
+| 4 | E2B | 1.43 | 1.43 – 1.43 | 2 | n too small |
 
 ## memory
 
@@ -166,29 +339,27 @@ _Daytona leads · ~1.3× Novita on median (higher is better)._
 
 MB/s · higher is better
 
-_Daytona and Blaxel share the top on this metric (higher is better)._
+_Daytona leads · ~1.1× Blaxel on median (higher is better)._
 
 | Rank | Provider | STREAM Triad (MB/s) | 95% bootstrap interval | n | Note |
 | ---: | --- | ---: | ---: | ---: | --- |
-| 1 | Daytona | 71508 | 69090 – 78270 | 5 | — |
-| 1 | Blaxel | 70090 | 66760 – 79980 | 5 | tied |
-| 3 | Modal | 53700 | 45390 – 57730 | 5 | — |
-| 3 | Novita | 53140 | 52970 – 53313 | 5 | tied |
-| 5 | E2B | 23850 | 22450 – 25430 | 5 | — |
+| 1 | Daytona | 78310 | 77380 – 79250 | 2 | — |
+| 2 | Blaxel | 72290 | 72270 – 72320 | 2 | n too small |
+| 3 | Modal | 46230 | 44680 – 47780 | 2 | n too small |
+| 4 | E2B | 23460 | 22640 – 24280 | 2 | n too small |
 
 ### STREAM Add
 
 MB/s · higher is better
 
-_Daytona and Blaxel share the top on this metric (higher is better)._
+_Daytona leads · ~1.1× Blaxel on median (higher is better)._
 
 | Rank | Provider | STREAM Add (MB/s) | 95% bootstrap interval | n | Note |
 | ---: | --- | ---: | ---: | ---: | --- |
-| 1 | Daytona | 73370 | 68930 – 78380 | 5 | — |
-| 1 | Blaxel | 70610 | 66050 – 79130 | 5 | tied |
-| 3 | Novita | 53070 | 52840 – 53350 | 5 | — |
-| 3 | Modal | 52420 | 43647 – 53400 | 5 | tied |
-| 5 | E2B | 23460 | 22180 – 25530 | 5 | — |
+| 1 | Daytona | 78090 | 77810 – 78380 | 2 | — |
+| 2 | Blaxel | 72160 | 72130 – 72180 | 2 | n too small |
+| 3 | Modal | 49240 | 47414 – 51060 | 2 | n too small |
+| 4 | E2B | 23300 | 22660 – 23940 | 2 | n too small |
 
 ### STREAM Copy
 
@@ -196,27 +367,25 @@ MB/s · higher is better
 
 _Blaxel leads · ~1.3× Daytona on median (higher is better)._
 
-| Rank | Provider | STREAM Copy (MB/s) | 95% bootstrap interval | n |
-| ---: | --- | ---: | ---: | ---: |
-| 1 | Blaxel | 110100 | 107500 – 124600 | 5 |
-| 2 | Daytona | 81820 | 79960 – 87430 | 5 |
-| 3 | Modal | 75810 | 65240 – 79250 | 5 |
-| 4 | Novita | 56950 | 56640 – 57050 | 5 |
-| 5 | E2B | 48480 | 43450 – 50283 | 5 |
+| Rank | Provider | STREAM Copy (MB/s) | 95% bootstrap interval | n | Note |
+| ---: | --- | ---: | ---: | ---: | --- |
+| 1 | Blaxel | 108200 | 107200 – 109200 | 2 | — |
+| 2 | Daytona | 86490 | 85820 – 87150 | 2 | n too small |
+| 3 | Modal | 62510 | 61910 – 63110 | 2 | n too small |
+| 4 | E2B | 48850 | 46640 – 51070 | 2 | n too small |
 
 ### STREAM Scale
 
 MB/s · higher is better
 
-_Daytona and Blaxel share the top on this metric (higher is better)._
+_Daytona leads · ~1.2× Blaxel on median (higher is better)._
 
 | Rank | Provider | STREAM Scale (MB/s) | 95% bootstrap interval | n | Note |
 | ---: | --- | ---: | ---: | ---: | --- |
-| 1 | Daytona | 69760 | 63140 – 73820 | 5 | — |
-| 1 | Blaxel | 60580 | 58210 – 72340 | 5 | tied |
-| 3 | Novita | 50510 | 50390 – 50560 | 5 | — |
-| 3 | Modal | 46810 | 35800 – 51220 | 5 | tied |
-| 5 | E2B | 21740 | 21120 – 23930 | 5 | — |
+| 1 | Daytona | 72730 | 71570 – 73890 | 2 | — |
+| 2 | Blaxel | 61560 | 61410 – 61710 | 2 | n too small |
+| 3 | Modal | 37960 | 35060 – 40860 | 2 | n too small |
+| 4 | E2B | 21510 | 21140 – 21880 | 2 | n too small |
 
 ## network
 
@@ -228,11 +397,10 @@ _Daytona leads · Blaxel is ~1.5× higher (lower is better)._
 
 | Rank | Provider | Loopback TCP (10GB) (Seconds) | 95% bootstrap interval | n | Note |
 | ---: | --- | ---: | ---: | ---: | --- |
-| 1 | Daytona | 4.898 | 4.682 – 5.402 | 5 | — |
-| 2 | Blaxel | 7.252 | 6.38 – 7.791 | 5 | — |
-| 2 | E2B | 7.764 | 7.373 – 8.467 | 5 | tied |
-| 4 | Novita | 11.32 | 10.03 – 11.45 | 5 | — |
-| 5 | Modal | 52.14 | 51.04 – 55.37 | 5 | — |
+| 1 | Daytona | 4.531 | 4.326 – 4.737 | 2 | — |
+| 2 | Blaxel | 6.957 | 6.732 – 7.183 | 2 | n too small |
+| 3 | E2B | 14.98 | 14.89 – 15.07 | 2 | n too small |
+| 4 | Modal | 56.93 | 55.71 – 58.15 | 2 | n too small |
 
 ## system
 
@@ -240,25 +408,24 @@ _Daytona leads · Blaxel is ~1.5× higher (lower is better)._
 
 Milliseconds · lower is better
 
-_Blaxel is the only ranked provider (841 Milliseconds; lower is better)._
+_Blaxel is the only ranked provider (839.5 Milliseconds; lower is better)._
 
 | Rank | Provider | PyBench (Milliseconds) | 95% bootstrap interval | n |
 | ---: | --- | ---: | ---: | ---: |
-| 1 | Blaxel | 841 | 838 – 855 | 5 |
+| 1 | Blaxel | 839.5 | 838 – 841 | 2 |
 
 ### SQLite Speedtest
 
 Seconds · lower is better
 
-_Daytona leads · Novita is ~1.2× higher (lower is better)._
+_Daytona leads · E2B is ~2.0× higher (lower is better)._
 
-| Rank | Provider | SQLite Speedtest (Seconds) | 95% bootstrap interval | n |
-| ---: | --- | ---: | ---: | ---: |
-| 1 | Daytona | 34.02 | 33.71 – 34.27 | 5 |
-| 2 | Novita | 41.26 | 41.01 – 41.75 | 5 |
-| 3 | Blaxel | 67.77 | 66.05 – 69.22 | 5 |
-| 4 | E2B | 71.99 | 71.59 – 73.35 | 5 |
-| 5 | Modal | 516.3 | 510 – 539.9 | 5 |
+| Rank | Provider | SQLite Speedtest (Seconds) | 95% bootstrap interval | n | Note |
+| ---: | --- | ---: | ---: | ---: | --- |
+| 1 | Daytona | 34.47 | 34.31 – 34.64 | 2 | — |
+| 2 | E2B | 67.73 | 67.64 – 67.82 | 2 | n too small |
+| 3 | Blaxel | 69.59 | 69.38 – 69.81 | 2 | n too small |
+| 4 | Modal | 539.9 | 504.9 – 575 | 2 | n too small |
 
 ## realworld
 
@@ -266,12 +433,12 @@ _Daytona leads · Novita is ~1.2× higher (lower is better)._
 
 Seconds · lower is better
 
-_Daytona and Novita share the top on this metric (lower is better)._
+_Daytona leads · Modal is ~2.4× higher (lower is better)._
 
 | Rank | Provider | Mastra: cold install (Seconds) | 95% bootstrap interval | n | Note |
 | ---: | --- | ---: | ---: | ---: | --- |
-| 1 | Daytona | 31.68 | 31.27 – 33.71 | 5 | — |
-| 1 | Novita | 33.12 | 32.84 – 33.84 | 5 | tied |
+| 1 | Daytona | 29 | 28.73 – 29.26 | 2 | — |
+| 2 | Modal | 70.32 | 70.28 – 70.36 | 2 | n too small |
 
 ### Better-Auth: build
 
@@ -279,111 +446,103 @@ Seconds · lower is better
 
 _Blaxel leads · Daytona is ~1.3× higher (lower is better)._
 
-| Rank | Provider | Better-Auth: build (Seconds) | 95% bootstrap interval | n |
-| ---: | --- | ---: | ---: | ---: |
-| 1 | Blaxel | 9.993 | 9.834 – 10.4 | 5 |
-| 2 | Daytona | 12.68 | 12.47 – 12.75 | 5 |
-| 3 | Novita | 14.27 | 14.21 – 14.71 | 5 |
-| 4 | E2B | 22.24 | 22.15 – 22.99 | 5 |
-| 5 | Modal | 39.61 | 37.55 – 40.28 | 5 |
+| Rank | Provider | Better-Auth: build (Seconds) | 95% bootstrap interval | n | Note |
+| ---: | --- | ---: | ---: | ---: | --- |
+| 1 | Blaxel | 9.915 | 9.754 – 10.08 | 2 | — |
+| 2 | Daytona | 12.45 | 12.44 – 12.47 | 2 | n too small |
+| 3 | E2B | 22.88 | 22.26 – 23.5 | 2 | n too small |
+| 4 | Modal | 40.77 | 40.48 – 41.06 | 2 | n too small |
 
 ### Better-Auth: cold install
 
 Seconds · lower is better
 
-_Daytona leads · Novita is ~1.1× higher (lower is better)._
+_Daytona leads · Blaxel is ~1.5× higher (lower is better)._
 
-| Rank | Provider | Better-Auth: cold install (Seconds) | 95% bootstrap interval | n |
-| ---: | --- | ---: | ---: | ---: |
-| 1 | Daytona | 10.43 | 10.31 – 11.03 | 5 |
-| 2 | Novita | 11.42 | 11.34 – 11.62 | 5 |
-| 3 | Blaxel | 16.11 | 15.64 – 16.21 | 5 |
-| 4 | E2B | 20.08 | 19.88 – 20.28 | 5 |
-| 5 | Modal | 30.84 | 30.2 – 34.26 | 5 |
+| Rank | Provider | Better-Auth: cold install (Seconds) | 95% bootstrap interval | n | Note |
+| ---: | --- | ---: | ---: | ---: | --- |
+| 1 | Daytona | 11.6 | 11.09 – 12.12 | 2 | — |
+| 2 | Blaxel | 17.52 | 16.53 – 18.51 | 2 | n too small |
+| 3 | E2B | 19.92 | 19.8 – 20.04 | 2 | n too small |
+| 4 | Modal | 30.8 | 30.66 – 30.95 | 2 | n too small |
 
 ### Better-Auth: git clone
 
 Seconds · lower is better
 
-_Blaxel, Daytona and E2B share the top on this metric (lower is better)._
+_Blaxel leads · Daytona is ~1.2× higher (lower is better)._
 
 | Rank | Provider | Better-Auth: git clone (Seconds) | 95% bootstrap interval | n | Note |
 | ---: | --- | ---: | ---: | ---: | --- |
-| 1 | Blaxel | 1.614 | 1.469 – 1.989 | 5 | — |
-| 1 | Daytona | 1.653 | 1.331 – 1.937 | 5 | tied |
-| 1 | E2B | 1.723 | 1.642 – 1.861 | 5 | tied |
-| 4 | Novita | 2.297 | 1.748 – 318.2 | 5 | — |
-| 4 | Modal | 5.609 | 2.559 – 6.714 | 5 | tied |
+| 1 | Blaxel | 1.409 | 1.286 – 1.532 | 2 | — |
+| 2 | Daytona | 1.72 | 1.696 – 1.745 | 2 | n too small |
+| 3 | E2B | 1.738 | 1.724 – 1.753 | 2 | n too small |
+| 4 | Modal | 2.73 | 2.588 – 2.872 | 2 | n too small |
 
 ### Better-Auth: lint (Biome)
 
 Seconds · lower is better
 
-_Blaxel leads · Daytona is ~1.4× higher (lower is better)._
+_Blaxel leads · Daytona is ~1.2× higher (lower is better)._
 
-| Rank | Provider | Better-Auth: lint (Biome) (Seconds) | 95% bootstrap interval | n |
-| ---: | --- | ---: | ---: | ---: |
-| 1 | Blaxel | 3.402 | 3.311 – 3.479 | 5 |
-| 2 | Daytona | 4.881 | 4.851 – 4.904 | 5 |
-| 3 | Novita | 5.301 | 5.28 – 5.429 | 5 |
-| 4 | E2B | 8.622 | 8.489 – 8.657 | 5 |
-| 5 | Modal | 16.36 | 15.72 – 16.66 | 5 |
+| Rank | Provider | Better-Auth: lint (Biome) (Seconds) | 95% bootstrap interval | n | Note |
+| ---: | --- | ---: | ---: | ---: | --- |
+| 1 | Blaxel | 3.892 | 3.827 – 3.957 | 2 | — |
+| 2 | Daytona | 4.863 | 4.849 – 4.876 | 2 | n too small |
+| 3 | E2B | 8.624 | 8.502 – 8.746 | 2 | n too small |
+| 4 | Modal | 17.45 | 17.33 – 17.58 | 2 | n too small |
 
 ### Better-Auth: lint deps (Knip)
 
 Seconds · lower is better
 
-_Daytona leads · Novita is ~1.1× higher (lower is better)._
+_Daytona leads · Blaxel is ~1.4× higher (lower is better)._
 
-| Rank | Provider | Better-Auth: lint deps (Knip) (Seconds) | 95% bootstrap interval | n |
-| ---: | --- | ---: | ---: | ---: |
-| 1 | Daytona | 10.92 | 10.73 – 11.04 | 5 |
-| 2 | Novita | 11.49 | 11.39 – 11.74 | 5 |
-| 3 | Blaxel | 15.41 | 14.74 – 15.55 | 5 |
-| 4 | E2B | 19.72 | 19.57 – 20.09 | 5 |
-| 5 | Modal | 28.71 | 26.79 – 29.23 | 5 |
+| Rank | Provider | Better-Auth: lint deps (Knip) (Seconds) | 95% bootstrap interval | n | Note |
+| ---: | --- | ---: | ---: | ---: | --- |
+| 1 | Daytona | 10.82 | 10.77 – 10.87 | 2 | — |
+| 2 | Blaxel | 15.32 | 14.89 – 15.75 | 2 | n too small |
+| 3 | E2B | 19.86 | 19.78 – 19.95 | 2 | n too small |
+| 4 | Modal | 29 | 28.67 – 29.32 | 2 | n too small |
 
 ### Better-Auth: lint format
 
 Seconds · lower is better
 
-_Daytona leads · Novita is ~1.1× higher (lower is better)._
+_Daytona leads · Blaxel is ~1.8× higher (lower is better)._
 
-| Rank | Provider | Better-Auth: lint format (Seconds) | 95% bootstrap interval | n |
-| ---: | --- | ---: | ---: | ---: |
-| 1 | Daytona | 2.785 | 2.7 – 2.901 | 5 |
-| 2 | Novita | 3.008 | 2.904 – 3.026 | 5 |
-| 3 | Blaxel | 4.42 | 4.287 – 4.463 | 5 |
-| 4 | E2B | 5.392 | 5.272 – 5.469 | 5 |
-| 5 | Modal | 6.129 | 6.071 – 6.6 | 5 |
+| Rank | Provider | Better-Auth: lint format (Seconds) | 95% bootstrap interval | n | Note |
+| ---: | --- | ---: | ---: | ---: | --- |
+| 1 | Daytona | 2.719 | 2.679 – 2.759 | 2 | — |
+| 2 | Blaxel | 4.885 | 4.834 – 4.936 | 2 | n too small |
+| 3 | E2B | 5.392 | 5.18 – 5.604 | 2 | n too small |
+| 4 | Modal | 6.547 | 6.486 – 6.608 | 2 | n too small |
 
 ### Better-Auth: lint packages
 
 Seconds · lower is better
 
-_Blaxel leads · Daytona is ~1.5× higher (lower is better)._
+_Blaxel leads · Daytona is ~1.4× higher (lower is better)._
 
-| Rank | Provider | Better-Auth: lint packages (Seconds) | 95% bootstrap interval | n |
-| ---: | --- | ---: | ---: | ---: |
-| 1 | Blaxel | 2.794 | 2.697 – 2.859 | 5 |
-| 2 | Daytona | 4.061 | 4.006 – 4.062 | 5 |
-| 3 | Novita | 4.555 | 4.477 – 4.642 | 5 |
-| 4 | E2B | 7.39 | 7.347 – 7.483 | 5 |
-| 5 | Modal | 14.83 | 14.35 – 15.09 | 5 |
+| Rank | Provider | Better-Auth: lint packages (Seconds) | 95% bootstrap interval | n | Note |
+| ---: | --- | ---: | ---: | ---: | --- |
+| 1 | Blaxel | 2.952 | 2.939 – 2.965 | 2 | — |
+| 2 | Daytona | 4.024 | 3.999 – 4.05 | 2 | n too small |
+| 3 | E2B | 7.285 | 7.226 – 7.345 | 2 | n too small |
+| 4 | Modal | 15.76 | 15.72 – 15.81 | 2 | n too small |
 
 ### Better-Auth: lint spell
 
 Seconds · lower is better
 
-_Daytona leads · Novita is ~1.1× higher (lower is better)._
+_Daytona leads · Blaxel is ~1.7× higher (lower is better)._
 
-| Rank | Provider | Better-Auth: lint spell (Seconds) | 95% bootstrap interval | n |
-| ---: | --- | ---: | ---: | ---: |
-| 1 | Daytona | 6.738 | 6.693 – 6.827 | 5 |
-| 2 | Novita | 7.492 | 7.454 – 7.583 | 5 |
-| 3 | Blaxel | 10.85 | 10.63 – 11.12 | 5 |
-| 4 | E2B | 13.48 | 13.08 – 14.04 | 5 |
-| 5 | Modal | 14.13 | 13.87 – 14.68 | 5 |
+| Rank | Provider | Better-Auth: lint spell (Seconds) | 95% bootstrap interval | n | Note |
+| ---: | --- | ---: | ---: | ---: | --- |
+| 1 | Daytona | 6.757 | 6.711 – 6.803 | 2 | — |
+| 2 | Blaxel | 11.73 | 11.7 – 11.76 | 2 | n too small |
+| 3 | E2B | 13.38 | 13.36 – 13.4 | 2 | n too small |
+| 4 | Modal | 15.39 | 14.8 – 15.98 | 2 | n too small |
 
 ### Better-Auth: lint types
 
@@ -391,90 +550,58 @@ Seconds · lower is better
 
 _Blaxel leads · Daytona is ~1.7× higher (lower is better)._
 
-| Rank | Provider | Better-Auth: lint types (Seconds) | 95% bootstrap interval | n |
-| ---: | --- | ---: | ---: | ---: |
-| 1 | Blaxel | 30.17 | 29.43 – 31.45 | 5 |
-| 2 | Daytona | 50.34 | 49.89 – 51.16 | 5 |
-| 3 | Novita | 58.52 | 57.86 – 59.01 | 5 |
-| 4 | E2B | 103.4 | 101.3 – 107.6 | 5 |
-| 5 | Modal | 166 | 162.4 – 170.1 | 5 |
+| Rank | Provider | Better-Auth: lint types (Seconds) | 95% bootstrap interval | n | Note |
+| ---: | --- | ---: | ---: | ---: | --- |
+| 1 | Blaxel | 30.36 | 30.16 – 30.57 | 2 | — |
+| 2 | Daytona | 51.09 | 49.97 – 52.21 | 2 | n too small |
+| 3 | E2B | 103.2 | 102.5 – 103.9 | 2 | n too small |
+| 4 | Modal | 187.6 | 187.2 – 188 | 2 | n too small |
 
 ### Better-Auth: typecheck
 
 Seconds · lower is better
 
-_Daytona and Novita share the top on this metric (lower is better)._
+_Daytona leads · Blaxel is ~1.4× higher (lower is better)._
 
 | Rank | Provider | Better-Auth: typecheck (Seconds) | 95% bootstrap interval | n | Note |
 | ---: | --- | ---: | ---: | ---: | --- |
-| 1 | Daytona | 1.43 | 1.413 – 1.47 | 5 | — |
-| 1 | Novita | 1.447 | 1.407 – 1.461 | 5 | tied |
-| 3 | Blaxel | 1.72 | 1.673 – 1.778 | 5 | — |
-| 4 | E2B | 2.359 | 2.276 – 2.416 | 5 | — |
-| 5 | Modal | 3.093 | 2.968 – 3.316 | 5 | — |
+| 1 | Daytona | 1.443 | 1.439 – 1.447 | 2 | — |
+| 2 | Blaxel | 2.044 | 2.014 – 2.074 | 2 | n too small |
+| 3 | E2B | 2.335 | 2.301 – 2.369 | 2 | n too small |
+| 4 | Modal | 3.367 | 3.288 – 3.447 | 2 | n too small |
 
 ### Mastra: build:core
 
 Seconds · lower is better
 
-_Daytona leads · Novita is ~1.1× higher (lower is better)._
+_Daytona leads · Modal is ~2.4× higher (lower is better)._
 
-| Rank | Provider | Mastra: build:core (Seconds) | 95% bootstrap interval | n |
-| ---: | --- | ---: | ---: | ---: |
-| 1 | Daytona | 88.35 | 87.2 – 88.81 | 5 |
-| 2 | Novita | 94.01 | 93.5 – 94.85 | 5 |
+| Rank | Provider | Mastra: build:core (Seconds) | 95% bootstrap interval | n | Note |
+| ---: | --- | ---: | ---: | ---: | --- |
+| 1 | Daytona | 85.3 | 82.89 – 87.72 | 2 | — |
+| 2 | Modal | 205.6 | 203.4 – 207.9 | 2 | n too small |
 
 ### Mastra: git clone
 
 Seconds · lower is better
 
-_Daytona and Novita share the top on this metric (lower is better)._
+_Daytona leads · Modal is ~1.4× higher (lower is better)._
 
 | Rank | Provider | Mastra: git clone (Seconds) | 95% bootstrap interval | n | Note |
 | ---: | --- | ---: | ---: | ---: | --- |
-| 1 | Daytona | 6.36 | 2.617 – 6.993 | 5 | — |
-| 1 | Novita | 6.844 | 3.157 – 7.166 | 5 | tied |
+| 1 | Daytona | 7.524 | 7.144 – 7.904 | 2 | — |
+| 2 | Modal | 10.33 | 10.11 – 10.54 | 2 | n too small |
 
 ### Mastra: lint:format
 
 Seconds · lower is better
 
-_Daytona leads · Novita is ~1.1× higher (lower is better)._
+_Daytona leads · Modal is ~2.3× higher (lower is better)._
 
-| Rank | Provider | Mastra: lint:format (Seconds) | 95% bootstrap interval | n |
-| ---: | --- | ---: | ---: | ---: |
-| 1 | Daytona | 92.22 | 91.09 – 93.24 | 5 |
-| 2 | Novita | 97.96 | 96.87 – 99.5 | 5 |
-
-### OpenClaw: cold install
-
-Seconds · lower is better
-
-_Novita is the only ranked provider (7.025 Seconds; lower is better)._
-
-| Rank | Provider | OpenClaw: cold install (Seconds) | 95% bootstrap interval | n |
-| ---: | --- | ---: | ---: | ---: |
-| 1 | Novita | 7.025 | 6.871 – 7.463 | 5 |
-
-### OpenClaw: git clone
-
-Seconds · lower is better
-
-_Novita is the only ranked provider (9.353 Seconds; lower is better)._
-
-| Rank | Provider | OpenClaw: git clone (Seconds) | 95% bootstrap interval | n |
-| ---: | --- | ---: | ---: | ---: |
-| 1 | Novita | 9.353 | 4.083 – 11.68 | 5 |
-
-### OpenClaw: typecheck (tsgo)
-
-Seconds · lower is better
-
-_Novita is the only ranked provider (49.13 Seconds; lower is better)._
-
-| Rank | Provider | OpenClaw: typecheck (tsgo) (Seconds) | 95% bootstrap interval | n |
-| ---: | --- | ---: | ---: | ---: |
-| 1 | Novita | 49.13 | 47.39 – 50.68 | 5 |
+| Rank | Provider | Mastra: lint:format (Seconds) | 95% bootstrap interval | n | Note |
+| ---: | --- | ---: | ---: | ---: | --- |
+| 1 | Daytona | 91.36 | 91.29 – 91.43 | 2 | — |
+| 2 | Modal | 206.6 | 201 – 212.1 | 2 | n too small |
 
 ## economics
 
@@ -482,18 +609,17 @@ _Novita is the only ranked provider (49.13 Seconds; lower is better)._
 
 USD/hr · lower is better
 
-_Daytona is cheapest · Novita is ~1.1× higher (lower is better)._
+_Daytona is cheapest · E2B is ~1.5× higher (lower is better)._
 
 | Rank | Provider | Hourly cost (USD/hr) | 95% bootstrap interval | n |
 | ---: | --- | ---: | ---: | ---: |
 | 1 | Daytona | 0.1494 | — | 1 |
-| 2 | Novita | 0.1627 | — | 1 |
-| 3 | E2B | 0.2304 | — | 1 |
-| 4 | Modal | 0.4774 | — | 1 |
+| 2 | E2B | 0.2304 | — | 1 |
+| 3 | Modal | 0.4774 | — | 1 |
 
 ## Coverage gaps
 
-12 uncovered results across 5 providers (Blaxel 3, Daytona 2, E2B 3, Modal 3, Novita 1). A gap is a missing result — the provider **failing to cover** that workload — never a tie or a zero.
+17 uncovered results across 5 providers (Blaxel 2, Daytona 1, E2B 3, Modal 2, Novita 9). A gap is a missing result — the provider **failing to cover** that workload — never a tie or a zero.
 
 <details>
 <summary>Full coverage table</summary>
@@ -504,14 +630,19 @@ _Daytona is cheapest · Novita is ~1.1× higher (lower is better)._
 | Blaxel | realworld-openclaw | ❌ **disk** (skipped) | Insufficient disk: 12.5 GiB free, suite needs 25 GiB |
 | E2B | realworld-mastra | ❌ **disk** (skipped) | Insufficient disk: 19.7 GiB free, suite needs 30 GiB |
 | E2B | realworld-openclaw | ❌ **disk** (skipped) | Insufficient disk: 19.7 GiB free, suite needs 25 GiB |
-| Blaxel | cpu-generic | **failed** | Step "mise run benchmark:cpu:generic" timed out after 7800s |
-| Daytona | cpu-generic | **failed** | Step "mise run benchmark:cpu:generic" timed out after 7800s |
 | Daytona | realworld-openclaw | **failed** | Step "mise run benchmark:realworld:pts:openclaw" lost its sandbox: 12 consecutive detached polls failed (last: done-file fs exists) — the sandbox stopped responding, not a quiet long step |
 | E2B | cpu-generic | **failed** | Step "mise run benchmark:cpu:generic" timed out after 7800s |
 | Modal | cpu-generic | **failed** | Step "mise run benchmark:cpu:generic" timed out after 7800s |
-| Modal | realworld-mastra | **failed** | Step "mise run benchmark:realworld:pts:mastra" timed out after 8400s |
 | Modal | realworld-openclaw | **failed** | Step "mise run benchmark:realworld:pts:openclaw" timed out after 8400s |
-| Novita | cpu-generic | **failed** | Step "mise run benchmark:cpu:generic" timed out after 7800s |
+| Novita | cpu-generic | **missing** | No result and no marker — the suite never reported for this provider. |
+| Novita | cpu-node | **missing** | No result and no marker — the suite never reported for this provider. |
+| Novita | disk | **missing** | No result and no marker — the suite never reported for this provider. |
+| Novita | memory | **missing** | No result and no marker — the suite never reported for this provider. |
+| Novita | network | **missing** | No result and no marker — the suite never reported for this provider. |
+| Novita | realworld-better-auth | **missing** | No result and no marker — the suite never reported for this provider. |
+| Novita | realworld-mastra | **missing** | No result and no marker — the suite never reported for this provider. |
+| Novita | realworld-openclaw | **missing** | No result and no marker — the suite never reported for this provider. |
+| Novita | system | **missing** | No result and no marker — the suite never reported for this provider. |
 
 **skipped** — a precondition said no before the benchmark was attempted. A ❌ **disk** skip is the
 loud one: the provider could not supply the disk the suite needs, so the workload does not run on
@@ -519,6 +650,11 @@ its current allocation at all. That is a structural absence, not a slow result.
 
 **failed** — the benchmark was attempted and broke: it threw, timed out, or died with the sandbox.
 Unlike a skip, this is a reliability fact about the provider, not a decision made on its behalf.
+
+**missing** — nothing was reported at all: no result, and no marker explaining why. The suite ran
+elsewhere in this run, so it was part of the comparison, and this provider is simply absent from
+it — a dropped job, a lost artifact, or a sandbox that died before it could say anything. Treat it
+as unmeasured, never as a pass: the provider has not been shown to run this workload.
 
 </details>
 
@@ -536,11 +672,6 @@ over the permutation null rather than approximated) finds evidence of stochastic
 sample sizes the normal approximation can report a p the exact test cannot actually produce. KS is
 reported separately for distribution *shape* and does not drive the ranking.
 
-**A Note cell always says why a rank is shared, and the reasons are not interchangeable.**
-`tied` — the test could have separated those providers and did not, so a faster median earned
-inside the noise is not a faster provider. This is the only note that claims two providers are
-statistically indistinguishable.
-
 Samples are repeated trials inside one sandbox, so their spread is environmental (neighbours, host
 contention, virtualization), and a wide bootstrap interval or a large `n` (the harness re-runs a test that will not
 converge) is itself the signal that the provider's performance is unstable, not that the measurement
@@ -548,6 +679,14 @@ is imprecise.
 
 At the small `n` this suite produces, a non-significant result means *not enough evidence to
 separate*, never *the providers are equal*.
+
+`n too small` is the extreme of that: Mann-Whitney's best attainable p already exceeds α for those
+Samples, so the test could not have separated the rows at any effect size (here 2 v 2 floors at p ≈ 0.33).
+Such rows are ranked on their observed medians and are **not** claimed to be tied — read the gap
+between the values, and treat the p-value as unable to settle them either way. Where such a row
+nevertheless shares the rank above it, the note reads `equal medians`: the two values are simply
+identical, which is the ranking having nothing to order them by — never a finding that the
+providers are alike.
 
 ### Pairwise tests (vs. row above)
 
@@ -560,149 +699,149 @@ correction is applied across providers or metrics.
 | Dimension | Metric | Provider | p vs. above | p (KS) |
 | --- | --- | --- | ---: | ---: |
 | cpu | Node.js web tooling | Daytona | — | — |
-| cpu | Node.js web tooling | Novita | 0.016 | 0.036 |
-| cpu | Node.js web tooling | Blaxel | 0.0079 | 0.0038 |
-| cpu | Node.js web tooling | E2B | 0.0079 | 0.0038 |
-| cpu | Node.js web tooling | Modal | 0.0079 | 0.0038 |
+| cpu | Node.js web tooling | Blaxel | 0.33 (n too small) | 0.097 |
+| cpu | Node.js web tooling | E2B | 0.33 (n too small) | 0.097 |
+| cpu | Node.js web tooling | Modal | 0.33 (n too small) | 0.097 |
+| cpu | C-Ray (1080p, 16 RPP) | Blaxel | — | — |
+| cpu | C-Ray (1080p, 16 RPP) | Daytona | 0.33 (n too small) | 0.097 |
+| cpu | C-Ray (4K, 16 RPP) | Blaxel | — | — |
+| cpu | C-Ray (4K, 16 RPP) | Daytona | 0.33 (n too small) | 0.097 |
+| cpu | C-Ray (5K, 16 RPP) | Blaxel | — | — |
+| cpu | C-Ray (5K, 16 RPP) | Daytona | 0.33 (n too small) | 0.097 |
+| cpu | Zstd 12 compress | Blaxel | — | — |
+| cpu | Zstd 12 compress | Daytona | 0.33 (n too small) | 0.097 |
+| cpu | Zstd 12 decompress | Daytona | — | — |
+| cpu | Zstd 12 decompress | Blaxel | 0.33 (n too small) | 0.097 |
+| cpu | Zstd 19 compress | Blaxel | — | — |
+| cpu | Zstd 19 compress | Daytona | 0.33 (n too small) | 0.097 |
+| cpu | Zstd 19 decompress | Daytona | — | — |
+| cpu | Zstd 19 decompress | Blaxel | 0.33 (n too small) | 0.097 |
+| cpu | Zstd 19 (long) compress | Daytona | — | — |
+| cpu | Zstd 19 (long) compress | Blaxel | 0.33 (n too small) | 0.097 |
+| cpu | Zstd 19 (long) decompress | Daytona | — | — |
+| cpu | Zstd 19 (long) decompress | Blaxel | 0.33 (n too small) | 0.097 |
+| cpu | Zstd 3 compress | Blaxel | — | — |
+| cpu | Zstd 3 compress | Daytona | 0.33 (n too small) | 0.097 |
+| cpu | Zstd 3 decompress | Daytona | — | — |
+| cpu | Zstd 3 (long) compress | Blaxel | — | — |
+| cpu | Zstd 3 (long) compress | Daytona | 0.33 (n too small) | 0.097 |
+| cpu | Zstd 3 (long) decompress | Daytona | — | — |
+| cpu | Zstd 8 compress | Blaxel | — | — |
+| cpu | Zstd 8 compress | Daytona | 0.33 (n too small) | 0.097 |
+| cpu | Zstd 8 decompress | Blaxel | — | — |
+| cpu | Zstd 8 (long) compress | Blaxel | — | — |
+| cpu | Zstd 8 (long) compress | Daytona | 0.33 (n too small) | 0.097 |
+| cpu | Zstd 8 (long) decompress | Daytona | — | — |
+| cpu | Zstd 8 (long) decompress | Blaxel | 0.33 (n too small) | 0.097 |
 | disk | fio rand read 4KB, O_DIRECT (IOPS) | Blaxel | — | — |
-| disk | fio rand read 4KB, O_DIRECT (IOPS) | Daytona | 0.0079 | 0.0038 |
-| disk | fio rand read 4KB, O_DIRECT (IOPS) | Novita | 0.0079 | 0.0038 |
-| disk | fio rand read 4KB, O_DIRECT (IOPS) | E2B | 0.0079 | 0.0038 |
-| disk | fio rand read 4KB, O_DIRECT (IOPS) | Modal | 0.0079 | 0.0038 |
+| disk | fio rand read 4KB, O_DIRECT (IOPS) | Daytona | 0.33 (n too small) | 0.097 |
+| disk | fio rand read 4KB, O_DIRECT (IOPS) | Modal | 0.33 (n too small) | 0.097 |
+| disk | fio rand read 4KB, O_DIRECT (IOPS) | E2B | 0.67 (n too small) | 0.84 |
 | disk | fio rand read 4KB, O_DIRECT (MB/s) | Blaxel | — | — |
-| disk | fio rand read 4KB, O_DIRECT (MB/s) | Daytona | 0.0079 | 0.0038 |
-| disk | fio rand read 4KB, O_DIRECT (MB/s) | Novita | 0.0079 | 0.0038 |
-| disk | fio rand read 4KB, O_DIRECT (MB/s) | E2B | 0.0079 | 0.0038 |
-| disk | fio rand read 4KB, O_DIRECT (MB/s) | Modal | 0.0079 | 0.0038 |
+| disk | fio rand read 4KB, O_DIRECT (MB/s) | Daytona | 0.33 (n too small) | 0.097 |
+| disk | fio rand read 4KB, O_DIRECT (MB/s) | Modal | 0.33 (n too small) | 0.097 |
+| disk | fio rand read 4KB, O_DIRECT (MB/s) | E2B | 1.0 (n too small) | 0.84 |
 | disk | fio rand write 4KB, O_DIRECT (IOPS) | Blaxel | — | — |
-| disk | fio rand write 4KB, O_DIRECT (IOPS) | Daytona | 0.0079 | 0.0038 |
-| disk | fio rand write 4KB, O_DIRECT (IOPS) | Novita | 0.0079 | 0.0038 |
-| disk | fio rand write 4KB, O_DIRECT (IOPS) | E2B | 0.0079 | 0.0038 |
-| disk | fio rand write 4KB, O_DIRECT (IOPS) | Modal | 0.0079 | 0.0038 |
+| disk | fio rand write 4KB, O_DIRECT (IOPS) | Daytona | 0.33 (n too small) | 0.097 |
+| disk | fio rand write 4KB, O_DIRECT (IOPS) | E2B | 0.33 (n too small) | 0.097 |
+| disk | fio rand write 4KB, O_DIRECT (IOPS) | Modal | 0.33 (n too small) | 0.097 |
 | disk | fio rand write 4KB, O_DIRECT (MB/s) | Blaxel | — | — |
-| disk | fio rand write 4KB, O_DIRECT (MB/s) | Daytona | 0.0079 | 0.0038 |
-| disk | fio rand write 4KB, O_DIRECT (MB/s) | Novita | 0.0079 | 0.0038 |
-| disk | fio rand write 4KB, O_DIRECT (MB/s) | E2B | 0.0079 | 0.0038 |
-| disk | fio rand write 4KB, O_DIRECT (MB/s) | Modal | 0.0079 | 0.0038 |
-| disk | fio seq read 1MB, O_DIRECT (IOPS) | Modal | — | — |
-| disk | fio seq read 1MB, O_DIRECT (IOPS) | Novita | 0.38 (tied) | 0.70 |
-| disk | fio seq read 1MB, O_DIRECT (IOPS) | Daytona | 0.89 (tied) | 0.70 |
-| disk | fio seq read 1MB, O_DIRECT (IOPS) | Blaxel | 0.0079 | 0.0038 |
-| disk | fio seq read 1MB, O_DIRECT (IOPS) | E2B | 0.0079 | 0.0038 |
-| disk | fio seq read 1MB, O_DIRECT (MB/s) | Novita | — | — |
-| disk | fio seq read 1MB, O_DIRECT (MB/s) | Modal | — | — |
+| disk | fio rand write 4KB, O_DIRECT (MB/s) | Daytona | 0.33 (n too small) | 0.097 |
+| disk | fio rand write 4KB, O_DIRECT (MB/s) | E2B | 0.33 (n too small) | 0.097 |
+| disk | fio rand write 4KB, O_DIRECT (MB/s) | Modal | 0.33 (n too small) | 0.097 |
+| disk | fio seq read 1MB, O_DIRECT (IOPS) | Daytona | — | — |
+| disk | fio seq read 1MB, O_DIRECT (IOPS) | Modal | 1.0 (n too small) | 0.84 |
+| disk | fio seq read 1MB, O_DIRECT (IOPS) | Blaxel | 0.33 (n too small) | 0.097 |
+| disk | fio seq read 1MB, O_DIRECT (IOPS) | E2B | 0.33 (n too small) | 0.097 |
 | disk | fio seq read 1MB, O_DIRECT (MB/s) | Daytona | — | — |
 | disk | fio seq read 1MB, O_DIRECT (MB/s) | Blaxel | — | — |
-| disk | fio seq read 1MB, O_DIRECT (MB/s) | E2B | 0.0079 | 0.0038 |
-| disk | fio seq write 1MB, O_DIRECT (IOPS) | Novita | — | — |
-| disk | fio seq write 1MB, O_DIRECT (IOPS) | Daytona | 0.0079 | 0.0038 |
-| disk | fio seq write 1MB, O_DIRECT (IOPS) | Blaxel | 0.42 (tied) | 0.21 |
-| disk | fio seq write 1MB, O_DIRECT (IOPS) | Modal | 0.0079 | 0.0038 |
-| disk | fio seq write 1MB, O_DIRECT (IOPS) | E2B | 0.0079 | 0.0038 |
-| disk | fio seq write 1MB, O_DIRECT (MB/s) | Novita | — | — |
-| disk | fio seq write 1MB, O_DIRECT (MB/s) | Daytona | 0.0079 | 0.0038 |
-| disk | fio seq write 1MB, O_DIRECT (MB/s) | Blaxel | 0.42 (tied) | 0.21 |
-| disk | fio seq write 1MB, O_DIRECT (MB/s) | Modal | 0.0079 | 0.0038 |
-| disk | fio seq write 1MB, O_DIRECT (MB/s) | E2B | 0.0079 | 0.0038 |
+| disk | fio seq read 1MB, O_DIRECT (MB/s) | E2B | 0.33 (n too small) | 0.097 |
+| disk | fio seq write 1MB, O_DIRECT (IOPS) | Daytona | — | — |
+| disk | fio seq write 1MB, O_DIRECT (IOPS) | Blaxel | 0.33 (n too small) | 0.097 |
+| disk | fio seq write 1MB, O_DIRECT (IOPS) | Modal | 0.33 (n too small) | 0.097 |
+| disk | fio seq write 1MB, O_DIRECT (IOPS) | E2B | 0.33 (n too small) | 0.097 |
+| disk | fio seq write 1MB, O_DIRECT (MB/s) | Daytona | — | — |
+| disk | fio seq write 1MB, O_DIRECT (MB/s) | Blaxel | 0.33 (n too small) | 0.097 |
+| disk | fio seq write 1MB, O_DIRECT (MB/s) | Modal | 0.33 (n too small) | 0.097 |
+| disk | fio seq write 1MB, O_DIRECT (MB/s) | E2B | 0.33 (n too small) | 0.097 |
 | disk | Hardlink throughput | Daytona | — | — |
-| disk | Hardlink throughput | Novita | 0.0079 | 0.0038 |
-| disk | Hardlink throughput | Blaxel | 0.0079 | 0.0038 |
-| disk | Hardlink throughput | Modal | 0.0079 | 0.0038 |
-| disk | Hardlink throughput | E2B | 0.0079 | 0.0038 |
+| disk | Hardlink throughput | Blaxel | 0.33 (n too small) | 0.097 |
+| disk | Hardlink throughput | Modal | 0.33 (n too small) | 0.097 |
+| disk | Hardlink throughput | E2B | 0.33 (n too small) | 0.097 |
 | memory | STREAM Triad | Daytona | — | — |
-| memory | STREAM Triad | Blaxel | 0.55 (tied) | 0.70 |
-| memory | STREAM Triad | Modal | 0.0079 | 0.0038 |
-| memory | STREAM Triad | Novita | 0.69 (tied) | 0.21 |
-| memory | STREAM Triad | E2B | 0.0079 | 0.0038 |
+| memory | STREAM Triad | Blaxel | 0.33 (n too small) | 0.097 |
+| memory | STREAM Triad | Modal | 0.33 (n too small) | 0.097 |
+| memory | STREAM Triad | E2B | 0.33 (n too small) | 0.097 |
 | memory | STREAM Add | Daytona | — | — |
-| memory | STREAM Add | Blaxel | 0.69 (tied) | 0.70 |
-| memory | STREAM Add | Novita | 0.0079 | 0.0038 |
-| memory | STREAM Add | Modal | 0.15 (tied) | 0.036 |
-| memory | STREAM Add | E2B | 0.0079 | 0.0038 |
+| memory | STREAM Add | Blaxel | 0.33 (n too small) | 0.097 |
+| memory | STREAM Add | Modal | 0.33 (n too small) | 0.097 |
+| memory | STREAM Add | E2B | 0.33 (n too small) | 0.097 |
 | memory | STREAM Copy | Blaxel | — | — |
-| memory | STREAM Copy | Daytona | 0.0079 | 0.0038 |
-| memory | STREAM Copy | Modal | 0.0079 | 0.0038 |
-| memory | STREAM Copy | Novita | 0.0079 | 0.0038 |
-| memory | STREAM Copy | E2B | 0.0079 | 0.0038 |
+| memory | STREAM Copy | Daytona | 0.33 (n too small) | 0.097 |
+| memory | STREAM Copy | Modal | 0.33 (n too small) | 0.097 |
+| memory | STREAM Copy | E2B | 0.33 (n too small) | 0.097 |
 | memory | STREAM Scale | Daytona | — | — |
-| memory | STREAM Scale | Blaxel | 0.056 (tied) | 0.036 |
-| memory | STREAM Scale | Novita | 0.0079 | 0.0038 |
-| memory | STREAM Scale | Modal | 0.15 (tied) | 0.036 |
-| memory | STREAM Scale | E2B | 0.0079 | 0.0038 |
+| memory | STREAM Scale | Blaxel | 0.33 (n too small) | 0.097 |
+| memory | STREAM Scale | Modal | 0.33 (n too small) | 0.097 |
+| memory | STREAM Scale | E2B | 0.33 (n too small) | 0.097 |
 | network | Loopback TCP (10GB) | Daytona | — | — |
-| network | Loopback TCP (10GB) | Blaxel | 0.0079 | 0.0038 |
-| network | Loopback TCP (10GB) | E2B | 0.095 (tied) | 0.21 |
-| network | Loopback TCP (10GB) | Novita | 0.0079 | 0.0038 |
-| network | Loopback TCP (10GB) | Modal | 0.0079 | 0.0038 |
+| network | Loopback TCP (10GB) | Blaxel | 0.33 (n too small) | 0.097 |
+| network | Loopback TCP (10GB) | E2B | 0.33 (n too small) | 0.097 |
+| network | Loopback TCP (10GB) | Modal | 0.33 (n too small) | 0.097 |
 | system | PyBench | Blaxel | — | — |
 | system | SQLite Speedtest | Daytona | — | — |
-| system | SQLite Speedtest | Novita | 0.0079 | 0.0038 |
-| system | SQLite Speedtest | Blaxel | 0.0079 | 0.0038 |
-| system | SQLite Speedtest | E2B | 0.0079 | 0.0038 |
-| system | SQLite Speedtest | Modal | 0.0079 | 0.0038 |
+| system | SQLite Speedtest | E2B | 0.33 (n too small) | 0.097 |
+| system | SQLite Speedtest | Blaxel | 0.33 (n too small) | 0.097 |
+| system | SQLite Speedtest | Modal | 0.33 (n too small) | 0.097 |
 | realworld | Mastra: cold install | Daytona | — | — |
-| realworld | Mastra: cold install | Novita | 0.095 (tied) | 0.036 |
+| realworld | Mastra: cold install | Modal | 0.33 (n too small) | 0.097 |
 | realworld | Better-Auth: build | Blaxel | — | — |
-| realworld | Better-Auth: build | Daytona | 0.0079 | 0.0038 |
-| realworld | Better-Auth: build | Novita | 0.0079 | 0.0038 |
-| realworld | Better-Auth: build | E2B | 0.0079 | 0.0038 |
-| realworld | Better-Auth: build | Modal | 0.0079 | 0.0038 |
+| realworld | Better-Auth: build | Daytona | 0.33 (n too small) | 0.097 |
+| realworld | Better-Auth: build | E2B | 0.33 (n too small) | 0.097 |
+| realworld | Better-Auth: build | Modal | 0.33 (n too small) | 0.097 |
 | realworld | Better-Auth: cold install | Daytona | — | — |
-| realworld | Better-Auth: cold install | Novita | 0.0079 | 0.0038 |
-| realworld | Better-Auth: cold install | Blaxel | 0.0079 | 0.0038 |
-| realworld | Better-Auth: cold install | E2B | 0.0079 | 0.0038 |
-| realworld | Better-Auth: cold install | Modal | 0.0079 | 0.0038 |
+| realworld | Better-Auth: cold install | Blaxel | 0.33 (n too small) | 0.097 |
+| realworld | Better-Auth: cold install | E2B | 0.33 (n too small) | 0.097 |
+| realworld | Better-Auth: cold install | Modal | 0.33 (n too small) | 0.097 |
 | realworld | Better-Auth: git clone | Blaxel | — | — |
-| realworld | Better-Auth: git clone | Daytona | 1.0 (tied) | 0.70 |
-| realworld | Better-Auth: git clone | E2B | 0.69 (tied) | 0.70 |
-| realworld | Better-Auth: git clone | Novita | 0.032 | 0.036 |
-| realworld | Better-Auth: git clone | Modal | 0.69 (tied) | 0.21 |
+| realworld | Better-Auth: git clone | Daytona | 0.33 (n too small) | 0.097 |
+| realworld | Better-Auth: git clone | E2B | 0.67 (n too small) | 0.84 |
+| realworld | Better-Auth: git clone | Modal | 0.33 (n too small) | 0.097 |
 | realworld | Better-Auth: lint (Biome) | Blaxel | — | — |
-| realworld | Better-Auth: lint (Biome) | Daytona | 0.0079 | 0.0038 |
-| realworld | Better-Auth: lint (Biome) | Novita | 0.0079 | 0.0038 |
-| realworld | Better-Auth: lint (Biome) | E2B | 0.0079 | 0.0038 |
-| realworld | Better-Auth: lint (Biome) | Modal | 0.0079 | 0.0038 |
+| realworld | Better-Auth: lint (Biome) | Daytona | 0.33 (n too small) | 0.097 |
+| realworld | Better-Auth: lint (Biome) | E2B | 0.33 (n too small) | 0.097 |
+| realworld | Better-Auth: lint (Biome) | Modal | 0.33 (n too small) | 0.097 |
 | realworld | Better-Auth: lint deps (Knip) | Daytona | — | — |
-| realworld | Better-Auth: lint deps (Knip) | Novita | 0.0079 | 0.0038 |
-| realworld | Better-Auth: lint deps (Knip) | Blaxel | 0.0079 | 0.0038 |
-| realworld | Better-Auth: lint deps (Knip) | E2B | 0.0079 | 0.0038 |
-| realworld | Better-Auth: lint deps (Knip) | Modal | 0.0079 | 0.0038 |
+| realworld | Better-Auth: lint deps (Knip) | Blaxel | 0.33 (n too small) | 0.097 |
+| realworld | Better-Auth: lint deps (Knip) | E2B | 0.33 (n too small) | 0.097 |
+| realworld | Better-Auth: lint deps (Knip) | Modal | 0.33 (n too small) | 0.097 |
 | realworld | Better-Auth: lint format | Daytona | — | — |
-| realworld | Better-Auth: lint format | Novita | 0.0079 | 0.0038 |
-| realworld | Better-Auth: lint format | Blaxel | 0.0079 | 0.0038 |
-| realworld | Better-Auth: lint format | E2B | 0.0079 | 0.0038 |
-| realworld | Better-Auth: lint format | Modal | 0.0079 | 0.0038 |
+| realworld | Better-Auth: lint format | Blaxel | 0.33 (n too small) | 0.097 |
+| realworld | Better-Auth: lint format | E2B | 0.33 (n too small) | 0.097 |
+| realworld | Better-Auth: lint format | Modal | 0.33 (n too small) | 0.097 |
 | realworld | Better-Auth: lint packages | Blaxel | — | — |
-| realworld | Better-Auth: lint packages | Daytona | 0.0079 | 0.0038 |
-| realworld | Better-Auth: lint packages | Novita | 0.0079 | 0.0038 |
-| realworld | Better-Auth: lint packages | E2B | 0.0079 | 0.0038 |
-| realworld | Better-Auth: lint packages | Modal | 0.0079 | 0.0038 |
+| realworld | Better-Auth: lint packages | Daytona | 0.33 (n too small) | 0.097 |
+| realworld | Better-Auth: lint packages | E2B | 0.33 (n too small) | 0.097 |
+| realworld | Better-Auth: lint packages | Modal | 0.33 (n too small) | 0.097 |
 | realworld | Better-Auth: lint spell | Daytona | — | — |
-| realworld | Better-Auth: lint spell | Novita | 0.0079 | 0.0038 |
-| realworld | Better-Auth: lint spell | Blaxel | 0.0079 | 0.0038 |
-| realworld | Better-Auth: lint spell | E2B | 0.0079 | 0.0038 |
-| realworld | Better-Auth: lint spell | Modal | 0.032 | 0.036 |
+| realworld | Better-Auth: lint spell | Blaxel | 0.33 (n too small) | 0.097 |
+| realworld | Better-Auth: lint spell | E2B | 0.33 (n too small) | 0.097 |
+| realworld | Better-Auth: lint spell | Modal | 0.33 (n too small) | 0.097 |
 | realworld | Better-Auth: lint types | Blaxel | — | — |
-| realworld | Better-Auth: lint types | Daytona | 0.0079 | 0.0038 |
-| realworld | Better-Auth: lint types | Novita | 0.0079 | 0.0038 |
-| realworld | Better-Auth: lint types | E2B | 0.0079 | 0.0038 |
-| realworld | Better-Auth: lint types | Modal | 0.0079 | 0.0038 |
+| realworld | Better-Auth: lint types | Daytona | 0.33 (n too small) | 0.097 |
+| realworld | Better-Auth: lint types | E2B | 0.33 (n too small) | 0.097 |
+| realworld | Better-Auth: lint types | Modal | 0.33 (n too small) | 0.097 |
 | realworld | Better-Auth: typecheck | Daytona | — | — |
-| realworld | Better-Auth: typecheck | Novita | 0.55 (tied) | 0.21 |
-| realworld | Better-Auth: typecheck | Blaxel | 0.0079 | 0.0038 |
-| realworld | Better-Auth: typecheck | E2B | 0.0079 | 0.0038 |
-| realworld | Better-Auth: typecheck | Modal | 0.0079 | 0.0038 |
+| realworld | Better-Auth: typecheck | Blaxel | 0.33 (n too small) | 0.097 |
+| realworld | Better-Auth: typecheck | E2B | 0.33 (n too small) | 0.097 |
+| realworld | Better-Auth: typecheck | Modal | 0.33 (n too small) | 0.097 |
 | realworld | Mastra: build:core | Daytona | — | — |
-| realworld | Mastra: build:core | Novita | 0.0079 | 0.0038 |
+| realworld | Mastra: build:core | Modal | 0.33 (n too small) | 0.097 |
 | realworld | Mastra: git clone | Daytona | — | — |
-| realworld | Mastra: git clone | Novita | 0.22 (tied) | 0.21 |
+| realworld | Mastra: git clone | Modal | 0.33 (n too small) | 0.097 |
 | realworld | Mastra: lint:format | Daytona | — | — |
-| realworld | Mastra: lint:format | Novita | 0.0079 | 0.0038 |
-| realworld | OpenClaw: cold install | Novita | — | — |
-| realworld | OpenClaw: git clone | Novita | — | — |
-| realworld | OpenClaw: typecheck (tsgo) | Novita | — | — |
+| realworld | Mastra: lint:format | Modal | 0.33 (n too small) | 0.097 |
 | economics | Hourly cost | Daytona | — | — |
-| economics | Hourly cost | Novita | — | — |
 | economics | Hourly cost | E2B | — | — |
 | economics | Hourly cost | Modal | — | — |
 

--- a/data/dataset/index.json
+++ b/data/dataset/index.json
@@ -2,6 +2,11 @@
   "schemaVersion": "1",
   "runs": [
     {
+      "runId": "29472826358",
+      "generatedAt": "2026-07-16T07:25:11.693Z",
+      "path": "runs/29472826358.json"
+    },
+    {
       "runId": "29365910084",
       "generatedAt": "2026-07-14T22:52:05.191Z",
       "path": "runs/29365910084.json"

--- a/data/dataset/runs/29472826358.json
+++ b/data/dataset/runs/29472826358.json
@@ -1,0 +1,2487 @@
+{
+  "schemaVersion": "2",
+  "runId": "29472826358",
+  "sha": "d85e6a9f905d428b9efd469a1d287f4075fddef7",
+  "generatedAt": "2026-07-16T07:25:11.693Z",
+  "targetSpec": {
+    "vcpus": 2,
+    "memoryGb": 8,
+    "diskGb": 40
+  },
+  "providers": [
+    {
+      "providerId": "blaxel",
+      "validationStatus": "validated",
+      "specMatched": false,
+      "observedSpecs": {
+        "cpuModel": "Intel(R) Xeon(R) Processor @ 2.90GHz",
+        "hostVcpus": 6,
+        "hostMemoryGb": 16,
+        "os": "Debian GNU/Linux 12 (bookworm)",
+        "kernel": "6.12.75+",
+        "user": "root",
+        "vcpus": 6,
+        "virtualization": "unknown",
+        "memoryGb": 15.63,
+        "diskGb": 12.5
+      },
+      "metrics": [
+        {
+          "metricId": "c_ray_resolution_1080p_rays_per_pixel_16",
+          "samples": [128.793, 128.091],
+          "aggregates": {
+            "p50": 128.442,
+            "p95": 128.7579,
+            "mean": 128.442,
+            "stdev": 0.4963889603929551,
+            "min": 128.091,
+            "max": 128.793,
+            "n": 2
+          },
+          "sourceFile": "cpu-generic/pts_c-ray.xml",
+          "appVersion": "2.0",
+          "arguments": "-s 1920x1080 -r 16"
+        },
+        {
+          "metricId": "c_ray_resolution_4k_rays_per_pixel_16",
+          "samples": [513.535, 511.165],
+          "aggregates": {
+            "p50": 512.35,
+            "p95": 513.4164999999999,
+            "mean": 512.35,
+            "stdev": 1.6758430714120605,
+            "min": 511.165,
+            "max": 513.535,
+            "n": 2
+          },
+          "sourceFile": "cpu-generic/pts_c-ray.xml",
+          "appVersion": "2.0",
+          "arguments": "-s 3840x2160 -r 16"
+        },
+        {
+          "metricId": "c_ray_resolution_5k_rays_per_pixel_16",
+          "samples": [908.26, 906.89],
+          "aggregates": {
+            "p50": 907.575,
+            "p95": 908.1915,
+            "mean": 907.575,
+            "stdev": 0.9687362902255332,
+            "min": 906.89,
+            "max": 908.26,
+            "n": 2
+          },
+          "sourceFile": "cpu-generic/pts_c-ray.xml",
+          "appVersion": "2.0",
+          "arguments": "-s 5120x2880 -r 16"
+        },
+        {
+          "metricId": "compress_zstd_compression_level_12_compression_speed",
+          "samples": [115.3, 116.5],
+          "aggregates": {
+            "p50": 115.9,
+            "p95": 116.44,
+            "mean": 115.9,
+            "stdev": 0.848528137423854,
+            "min": 115.3,
+            "max": 116.5,
+            "n": 2
+          },
+          "sourceFile": "cpu-generic/pts_compress-zstd.xml",
+          "appVersion": "1.5.4",
+          "arguments": "-b12"
+        },
+        {
+          "metricId": "compress_zstd_compression_level_12_decompression_speed",
+          "samples": [1055.5, 1051.6],
+          "aggregates": {
+            "p50": 1053.55,
+            "p95": 1055.305,
+            "mean": 1053.55,
+            "stdev": 2.7577164466275996,
+            "min": 1051.6,
+            "max": 1055.5,
+            "n": 2
+          },
+          "sourceFile": "cpu-generic/pts_compress-zstd.xml",
+          "appVersion": "1.5.4",
+          "arguments": "-b12"
+        },
+        {
+          "metricId": "compress_zstd_compression_level_19_compression_speed",
+          "samples": [11.6, 11.1],
+          "aggregates": {
+            "p50": 11.35,
+            "p95": 11.575,
+            "mean": 11.35,
+            "stdev": 0.3535533905932738,
+            "min": 11.1,
+            "max": 11.6,
+            "n": 2
+          },
+          "sourceFile": "cpu-generic/pts_compress-zstd.xml",
+          "appVersion": "1.5.4",
+          "arguments": "-b19"
+        },
+        {
+          "metricId": "compress_zstd_compression_level_19_decompression_speed",
+          "samples": [882, 893.6],
+          "aggregates": {
+            "p50": 887.8,
+            "p95": 893.02,
+            "mean": 887.8,
+            "stdev": 8.202438661764008,
+            "min": 882,
+            "max": 893.6,
+            "n": 2
+          },
+          "sourceFile": "cpu-generic/pts_compress-zstd.xml",
+          "appVersion": "1.5.4",
+          "arguments": "-b19"
+        },
+        {
+          "metricId": "compress_zstd_compression_level_19_long_mode_compression_speed",
+          "samples": [6.09, 6.18],
+          "aggregates": {
+            "p50": 6.135,
+            "p95": 6.1754999999999995,
+            "mean": 6.135,
+            "stdev": 0.06363961030678918,
+            "min": 6.09,
+            "max": 6.18,
+            "n": 2
+          },
+          "sourceFile": "cpu-generic/pts_compress-zstd.xml",
+          "appVersion": "1.5.4",
+          "arguments": "-b19 --long"
+        },
+        {
+          "metricId": "compress_zstd_compression_level_19_long_mode_decompression_speed",
+          "samples": [893.3, 900],
+          "aggregates": {
+            "p50": 896.65,
+            "p95": 899.665,
+            "mean": 896.65,
+            "stdev": 4.737615433949901,
+            "min": 893.3,
+            "max": 900,
+            "n": 2
+          },
+          "sourceFile": "cpu-generic/pts_compress-zstd.xml",
+          "appVersion": "1.5.4",
+          "arguments": "-b19 --long"
+        },
+        {
+          "metricId": "compress_zstd_compression_level_3_compression_speed",
+          "samples": [1295.2, 1303.5],
+          "aggregates": {
+            "p50": 1299.35,
+            "p95": 1303.085,
+            "mean": 1299.35,
+            "stdev": 5.868986283848393,
+            "min": 1295.2,
+            "max": 1303.5,
+            "n": 2
+          },
+          "sourceFile": "cpu-generic/pts_compress-zstd.xml",
+          "appVersion": "1.5.4",
+          "arguments": "-b3"
+        },
+        {
+          "metricId": "compress_zstd_compression_level_3_long_mode_compression_speed",
+          "samples": [848.2, 832.3],
+          "aggregates": {
+            "p50": 840.25,
+            "p95": 847.4050000000001,
+            "mean": 840.25,
+            "stdev": 11.24299782086617,
+            "min": 832.3,
+            "max": 848.2,
+            "n": 2
+          },
+          "sourceFile": "cpu-generic/pts_compress-zstd.xml",
+          "appVersion": "1.5.4",
+          "arguments": "-b3 --long"
+        },
+        {
+          "metricId": "compress_zstd_compression_level_8_compression_speed",
+          "samples": [344.2, 345],
+          "aggregates": {
+            "p50": 344.6,
+            "p95": 344.96,
+            "mean": 344.6,
+            "stdev": 0.5656854249492259,
+            "min": 344.2,
+            "max": 345,
+            "n": 2
+          },
+          "sourceFile": "cpu-generic/pts_compress-zstd.xml",
+          "appVersion": "1.5.4",
+          "arguments": "-b8"
+        },
+        {
+          "metricId": "compress_zstd_compression_level_8_decompression_speed",
+          "samples": [1125.5, 1111.1],
+          "aggregates": {
+            "p50": 1118.3,
+            "p95": 1124.78,
+            "mean": 1118.3,
+            "stdev": 10.18233764908635,
+            "min": 1111.1,
+            "max": 1125.5,
+            "n": 2
+          },
+          "sourceFile": "cpu-generic/pts_compress-zstd.xml",
+          "appVersion": "1.5.4",
+          "arguments": "-b8"
+        },
+        {
+          "metricId": "compress_zstd_compression_level_8_long_mode_compression_speed",
+          "samples": [323.5, 330.5],
+          "aggregates": {
+            "p50": 327,
+            "p95": 330.15,
+            "mean": 327,
+            "stdev": 4.949747468305833,
+            "min": 323.5,
+            "max": 330.5,
+            "n": 2
+          },
+          "sourceFile": "cpu-generic/pts_compress-zstd.xml",
+          "appVersion": "1.5.4",
+          "arguments": "-b8 --long"
+        },
+        {
+          "metricId": "compress_zstd_compression_level_8_long_mode_decompression_speed",
+          "samples": [1136.8, 1130.4],
+          "aggregates": {
+            "p50": 1133.6,
+            "p95": 1136.48,
+            "mean": 1133.6,
+            "stdev": 4.525483399593888,
+            "min": 1130.4,
+            "max": 1136.8,
+            "n": 2
+          },
+          "sourceFile": "cpu-generic/pts_compress-zstd.xml",
+          "appVersion": "1.5.4",
+          "arguments": "-b8 --long"
+        },
+        {
+          "metricId": "fio_type_random_read_engine_linux_aio_direct_yes_block_size_4kb_job_count_1_disk_target_default_test_directory_iops",
+          "samples": [525000, 555000],
+          "aggregates": {
+            "p50": 540000,
+            "p95": 553500,
+            "mean": 540000,
+            "stdev": 21213.203435596424,
+            "min": 525000,
+            "max": 555000,
+            "n": 2
+          },
+          "sourceFile": "disk/pts_fio-rand-read.xml",
+          "appVersion": "3.36",
+          "arguments": "randread libaio 1 4k 1"
+        },
+        {
+          "metricId": "fio_type_random_read_engine_linux_aio_direct_yes_block_size_4kb_job_count_1_disk_target_default_test_directory_mb_per_s",
+          "samples": [2050, 2169],
+          "aggregates": {
+            "p50": 2109.5,
+            "p95": 2163.05,
+            "mean": 2109.5,
+            "stdev": 84.14570696119915,
+            "min": 2050,
+            "max": 2169,
+            "n": 2
+          },
+          "sourceFile": "disk/pts_fio-rand-read.xml",
+          "appVersion": "3.36",
+          "arguments": "randread libaio 1 4k 1"
+        },
+        {
+          "metricId": "fio_type_random_write_engine_linux_aio_direct_yes_block_size_4kb_job_count_1_disk_target_default_test_directory_iops",
+          "samples": [492000, 495000],
+          "aggregates": {
+            "p50": 493500,
+            "p95": 494850,
+            "mean": 493500,
+            "stdev": 2121.3203435596424,
+            "min": 492000,
+            "max": 495000,
+            "n": 2
+          },
+          "sourceFile": "disk/pts_fio-rand-write.xml",
+          "appVersion": "3.36",
+          "arguments": "randwrite libaio 1 4k 1"
+        },
+        {
+          "metricId": "fio_type_random_write_engine_linux_aio_direct_yes_block_size_4kb_job_count_1_disk_target_default_test_directory_mb_per_s",
+          "samples": [1922, 1935],
+          "aggregates": {
+            "p50": 1928.5,
+            "p95": 1934.35,
+            "mean": 1928.5,
+            "stdev": 9.192388155425117,
+            "min": 1922,
+            "max": 1935,
+            "n": 2
+          },
+          "sourceFile": "disk/pts_fio-rand-write.xml",
+          "appVersion": "3.36",
+          "arguments": "randwrite libaio 1 4k 1"
+        },
+        {
+          "metricId": "fio_type_sequential_read_engine_linux_aio_direct_yes_block_size_1mb_job_count_1_disk_target_default_test_directory_iops",
+          "samples": [4535, 4670],
+          "aggregates": {
+            "p50": 4602.5,
+            "p95": 4663.25,
+            "mean": 4602.5,
+            "stdev": 95.45941546018392,
+            "min": 4535,
+            "max": 4670,
+            "n": 2
+          },
+          "sourceFile": "disk/pts_fio-seq-read.xml",
+          "appVersion": "3.36",
+          "arguments": "read libaio 1 1m 1"
+        },
+        {
+          "metricId": "fio_type_sequential_read_engine_linux_aio_direct_yes_block_size_1mb_job_count_1_disk_target_default_test_directory_mb_per_s",
+          "samples": [4537, 4672],
+          "aggregates": {
+            "p50": 4604.5,
+            "p95": 4665.25,
+            "mean": 4604.5,
+            "stdev": 95.45941546018392,
+            "min": 4537,
+            "max": 4672,
+            "n": 2
+          },
+          "sourceFile": "disk/pts_fio-seq-read.xml",
+          "appVersion": "3.36",
+          "arguments": "read libaio 1 1m 1"
+        },
+        {
+          "metricId": "fio_type_sequential_write_engine_linux_aio_direct_yes_block_size_1mb_job_count_1_disk_target_default_test_directory_iops",
+          "samples": [3544, 3622],
+          "aggregates": {
+            "p50": 3583,
+            "p95": 3618.1,
+            "mean": 3583,
+            "stdev": 55.154328932550705,
+            "min": 3544,
+            "max": 3622,
+            "n": 2
+          },
+          "sourceFile": "disk/pts_fio-seq-write.xml",
+          "appVersion": "3.36",
+          "arguments": "write libaio 1 1m 1"
+        },
+        {
+          "metricId": "fio_type_sequential_write_engine_linux_aio_direct_yes_block_size_1mb_job_count_1_disk_target_default_test_directory_mb_per_s",
+          "samples": [3545, 3624],
+          "aggregates": {
+            "p50": 3584.5,
+            "p95": 3620.05,
+            "mean": 3584.5,
+            "stdev": 55.86143571373726,
+            "min": 3545,
+            "max": 3624,
+            "n": 2
+          },
+          "sourceFile": "disk/pts_fio-seq-write.xml",
+          "appVersion": "3.36",
+          "arguments": "write libaio 1 1m 1"
+        },
+        {
+          "metricId": "hardlink_bogo_ops_per_s",
+          "samples": [12.29, 11.96],
+          "aggregates": {
+            "p50": 12.125,
+            "p95": 12.273499999999999,
+            "mean": 12.125,
+            "stdev": 0.23334523779155947,
+            "min": 11.96,
+            "max": 12.29,
+            "n": 2
+          },
+          "sourceFile": "disk/pts_hardlink.xml",
+          "appVersion": "0.16"
+        },
+        {
+          "metricId": "network_loopback_seconds",
+          "samples": [7.183, 6.732],
+          "aggregates": {
+            "p50": 6.9575,
+            "p95": 7.16045,
+            "mean": 6.9575,
+            "stdev": 0.318905158315133,
+            "min": 6.732,
+            "max": 7.183,
+            "n": 2
+          },
+          "sourceFile": "network/pts_network-loopback.xml"
+        },
+        {
+          "metricId": "node_web_tooling_runs_per_s",
+          "samples": [12.73, 12.67],
+          "aggregates": {
+            "p50": 12.7,
+            "p95": 12.727,
+            "mean": 12.7,
+            "stdev": 0.04242640687119383,
+            "min": 12.67,
+            "max": 12.73,
+            "n": 2
+          },
+          "sourceFile": "cpu-node/pts_node-web-tooling.xml"
+        },
+        {
+          "metricId": "pybench_milliseconds",
+          "samples": [841, 838],
+          "aggregates": {
+            "p50": 839.5,
+            "p95": 840.85,
+            "mean": 839.5,
+            "stdev": 2.1213203435596424,
+            "min": 838,
+            "max": 841,
+            "n": 2
+          },
+          "sourceFile": "system/pts_pybench.xml",
+          "appVersion": "2018-02-16"
+        },
+        {
+          "metricId": "realworld_better_auth_task_build",
+          "samples": [10.076, 9.754],
+          "aggregates": {
+            "p50": 9.915,
+            "p95": 10.0599,
+            "mean": 9.915,
+            "stdev": 0.2276883835420696,
+            "min": 9.754,
+            "max": 10.076,
+            "n": 2
+          },
+          "sourceFile": "realworld-better-auth/pts_realworld-better-auth.xml",
+          "appVersion": "6f3ba45639579da152b69e8e5342e02f28288670",
+          "arguments": "build"
+        },
+        {
+          "metricId": "realworld_better_auth_task_cold_install",
+          "samples": [18.511, 16.531],
+          "aggregates": {
+            "p50": 17.521,
+            "p95": 18.412,
+            "mean": 17.521,
+            "stdev": 1.400071426749363,
+            "min": 16.531,
+            "max": 18.511,
+            "n": 2
+          },
+          "sourceFile": "realworld-better-auth/pts_realworld-better-auth.xml",
+          "appVersion": "6f3ba45639579da152b69e8e5342e02f28288670",
+          "arguments": "cold_install"
+        },
+        {
+          "metricId": "realworld_better_auth_task_git_clone",
+          "samples": [1.286, 1.532],
+          "aggregates": {
+            "p50": 1.409,
+            "p95": 1.5197,
+            "mean": 1.409,
+            "stdev": 0.17394826817189069,
+            "min": 1.286,
+            "max": 1.532,
+            "n": 2
+          },
+          "sourceFile": "realworld-better-auth/pts_realworld-better-auth.xml",
+          "appVersion": "6f3ba45639579da152b69e8e5342e02f28288670",
+          "arguments": "git_clone"
+        },
+        {
+          "metricId": "realworld_better_auth_task_lint_biome",
+          "samples": [3.827, 3.957],
+          "aggregates": {
+            "p50": 3.892,
+            "p95": 3.9505,
+            "mean": 3.892,
+            "stdev": 0.0919238815542511,
+            "min": 3.827,
+            "max": 3.957,
+            "n": 2
+          },
+          "sourceFile": "realworld-better-auth/pts_realworld-better-auth.xml",
+          "appVersion": "6f3ba45639579da152b69e8e5342e02f28288670",
+          "arguments": "lint_biome"
+        },
+        {
+          "metricId": "realworld_better_auth_task_lint_deps_knip",
+          "samples": [15.754, 14.888],
+          "aggregates": {
+            "p50": 15.321,
+            "p95": 15.7107,
+            "mean": 15.321,
+            "stdev": 0.6123544725075499,
+            "min": 14.888,
+            "max": 15.754,
+            "n": 2
+          },
+          "sourceFile": "realworld-better-auth/pts_realworld-better-auth.xml",
+          "appVersion": "6f3ba45639579da152b69e8e5342e02f28288670",
+          "arguments": "lint_deps"
+        },
+        {
+          "metricId": "realworld_better_auth_task_lint_format",
+          "samples": [4.936, 4.834],
+          "aggregates": {
+            "p50": 4.885,
+            "p95": 4.9309,
+            "mean": 4.885,
+            "stdev": 0.07212489168102806,
+            "min": 4.834,
+            "max": 4.936,
+            "n": 2
+          },
+          "sourceFile": "realworld-better-auth/pts_realworld-better-auth.xml",
+          "appVersion": "6f3ba45639579da152b69e8e5342e02f28288670",
+          "arguments": "lint_format"
+        },
+        {
+          "metricId": "realworld_better_auth_task_lint_packages",
+          "samples": [2.965, 2.939],
+          "aggregates": {
+            "p50": 2.952,
+            "p95": 2.9637,
+            "mean": 2.952,
+            "stdev": 0.018384776310850094,
+            "min": 2.939,
+            "max": 2.965,
+            "n": 2
+          },
+          "sourceFile": "realworld-better-auth/pts_realworld-better-auth.xml",
+          "appVersion": "6f3ba45639579da152b69e8e5342e02f28288670",
+          "arguments": "lint_packages"
+        },
+        {
+          "metricId": "realworld_better_auth_task_lint_spell",
+          "samples": [11.757, 11.696],
+          "aggregates": {
+            "p50": 11.7265,
+            "p95": 11.75395,
+            "mean": 11.7265,
+            "stdev": 0.04313351365237936,
+            "min": 11.696,
+            "max": 11.757,
+            "n": 2
+          },
+          "sourceFile": "realworld-better-auth/pts_realworld-better-auth.xml",
+          "appVersion": "6f3ba45639579da152b69e8e5342e02f28288670",
+          "arguments": "lint_spell"
+        },
+        {
+          "metricId": "realworld_better_auth_task_lint_types",
+          "samples": [30.162, 30.565],
+          "aggregates": {
+            "p50": 30.363500000000002,
+            "p95": 30.54485,
+            "mean": 30.363500000000002,
+            "stdev": 0.284964032818179,
+            "min": 30.162,
+            "max": 30.565,
+            "n": 2
+          },
+          "sourceFile": "realworld-better-auth/pts_realworld-better-auth.xml",
+          "appVersion": "6f3ba45639579da152b69e8e5342e02f28288670",
+          "arguments": "lint_types"
+        },
+        {
+          "metricId": "realworld_better_auth_task_typecheck",
+          "samples": [2.074, 2.014],
+          "aggregates": {
+            "p50": 2.0439999999999996,
+            "p95": 2.0709999999999997,
+            "mean": 2.0439999999999996,
+            "stdev": 0.04242640687119305,
+            "min": 2.014,
+            "max": 2.074,
+            "n": 2
+          },
+          "sourceFile": "realworld-better-auth/pts_realworld-better-auth.xml",
+          "appVersion": "6f3ba45639579da152b69e8e5342e02f28288670",
+          "arguments": "typecheck"
+        },
+        {
+          "metricId": "sqlite_speedtest_seconds",
+          "samples": [69.812, 69.377],
+          "aggregates": {
+            "p50": 69.5945,
+            "p95": 69.79025,
+            "mean": 69.5945,
+            "stdev": 0.3075914498161498,
+            "min": 69.377,
+            "max": 69.812,
+            "n": 2
+          },
+          "sourceFile": "system/pts_sqlite-speedtest.xml",
+          "appVersion": "3.30"
+        },
+        {
+          "metricId": "stream_type_add",
+          "samples": [72177.7, 72132.8],
+          "aggregates": {
+            "p50": 72155.25,
+            "p95": 72175.455,
+            "mean": 72155.25,
+            "stdev": 31.749094475271868,
+            "min": 72132.8,
+            "max": 72177.7,
+            "n": 2
+          },
+          "sourceFile": "memory/pts_stream.xml",
+          "appVersion": "2013-01-17",
+          "arguments": "Add"
+        },
+        {
+          "metricId": "stream_type_copy",
+          "samples": [109160.3, 107214.1],
+          "aggregates": {
+            "p50": 108187.20000000001,
+            "p95": 109062.99,
+            "mean": 108187.20000000001,
+            "stdev": 1376.1712175452517,
+            "min": 107214.1,
+            "max": 109160.3,
+            "n": 2
+          },
+          "sourceFile": "memory/pts_stream.xml",
+          "appVersion": "2013-01-17",
+          "arguments": "Copy"
+        },
+        {
+          "metricId": "stream_type_scale",
+          "samples": [61712.3, 61410.8],
+          "aggregates": {
+            "p50": 61561.55,
+            "p95": 61697.225000000006,
+            "mean": 61561.55,
+            "stdev": 213.19269452774407,
+            "min": 61410.8,
+            "max": 61712.3,
+            "n": 2
+          },
+          "sourceFile": "memory/pts_stream.xml",
+          "appVersion": "2013-01-17",
+          "arguments": "Scale"
+        },
+        {
+          "metricId": "stream_type_triad",
+          "samples": [72315.2, 72268.9],
+          "aggregates": {
+            "p50": 72292.04999999999,
+            "p95": 72312.885,
+            "mean": 72292.04999999999,
+            "stdev": 32.73904396894435,
+            "min": 72268.9,
+            "max": 72315.2,
+            "n": 2
+          },
+          "sourceFile": "memory/pts_stream.xml",
+          "appVersion": "2013-01-17",
+          "arguments": "Triad"
+        }
+      ],
+      "suitesCovered": [
+        "cpu-generic",
+        "cpu-node",
+        "disk",
+        "memory",
+        "network",
+        "realworld-better-auth",
+        "system"
+      ],
+      "gaps": [
+        {
+          "scope": "suite",
+          "id": "realworld-mastra",
+          "outcome": "skipped",
+          "reason": "Insufficient disk: 12.5 GiB free, suite needs 30 GiB"
+        },
+        {
+          "scope": "suite",
+          "id": "realworld-openclaw",
+          "outcome": "skipped",
+          "reason": "Insufficient disk: 12.5 GiB free, suite needs 25 GiB"
+        }
+      ],
+      "uncatalogued": []
+    },
+    {
+      "providerId": "daytona",
+      "validationStatus": "validated",
+      "specMatched": true,
+      "observedSpecs": {
+        "cpuModel": "AMD EPYC",
+        "hostVcpus": 2,
+        "hostMemoryGb": 8,
+        "os": "Debian GNU/Linux 13 (trixie)",
+        "kernel": "6.19.14",
+        "virtualization": "kvm",
+        "user": "root",
+        "vcpus": 2,
+        "memoryGb": 7.78,
+        "diskGb": 39.1
+      },
+      "metrics": [
+        {
+          "metricId": "c_ray_resolution_1080p_rays_per_pixel_16",
+          "samples": [202.099, 201.501],
+          "aggregates": {
+            "p50": 201.8,
+            "p95": 202.0691,
+            "mean": 201.8,
+            "stdev": 0.4228498551495346,
+            "min": 201.501,
+            "max": 202.099,
+            "n": 2
+          },
+          "sourceFile": "cpu-generic/pts_c-ray.xml",
+          "appVersion": "2.0",
+          "arguments": "-s 1920x1080 -r 16"
+        },
+        {
+          "metricId": "c_ray_resolution_4k_rays_per_pixel_16",
+          "samples": [808.973, 803.302],
+          "aggregates": {
+            "p50": 806.1375,
+            "p95": 808.68945,
+            "mean": 806.1375,
+            "stdev": 4.010002556108825,
+            "min": 803.302,
+            "max": 808.973,
+            "n": 2
+          },
+          "sourceFile": "cpu-generic/pts_c-ray.xml",
+          "appVersion": "2.0",
+          "arguments": "-s 3840x2160 -r 16"
+        },
+        {
+          "metricId": "c_ray_resolution_5k_rays_per_pixel_16",
+          "samples": [1423.485, 1417.234],
+          "aggregates": {
+            "p50": 1420.3595,
+            "p95": 1423.1724499999998,
+            "mean": 1420.3595,
+            "stdev": 4.420124489197011,
+            "min": 1417.234,
+            "max": 1423.485,
+            "n": 2
+          },
+          "sourceFile": "cpu-generic/pts_c-ray.xml",
+          "appVersion": "2.0",
+          "arguments": "-s 5120x2880 -r 16"
+        },
+        {
+          "metricId": "compress_zstd_compression_level_12_compression_speed",
+          "samples": [99.5, 99.3],
+          "aggregates": {
+            "p50": 99.4,
+            "p95": 99.49,
+            "mean": 99.4,
+            "stdev": 0.14142135623730648,
+            "min": 99.3,
+            "max": 99.5,
+            "n": 2
+          },
+          "sourceFile": "cpu-generic/pts_compress-zstd.xml",
+          "appVersion": "1.5.4",
+          "arguments": "-b12"
+        },
+        {
+          "metricId": "compress_zstd_compression_level_12_decompression_speed",
+          "samples": [2304.5, 2283],
+          "aggregates": {
+            "p50": 2293.75,
+            "p95": 2303.425,
+            "mean": 2293.75,
+            "stdev": 15.202795795510772,
+            "min": 2283,
+            "max": 2304.5,
+            "n": 2
+          },
+          "sourceFile": "cpu-generic/pts_compress-zstd.xml",
+          "appVersion": "1.5.4",
+          "arguments": "-b12"
+        },
+        {
+          "metricId": "compress_zstd_compression_level_19_compression_speed",
+          "samples": [8.16, 8.15],
+          "aggregates": {
+            "p50": 8.155000000000001,
+            "p95": 8.1595,
+            "mean": 8.155000000000001,
+            "stdev": 0.0070710678118646965,
+            "min": 8.15,
+            "max": 8.16,
+            "n": 2
+          },
+          "sourceFile": "cpu-generic/pts_compress-zstd.xml",
+          "appVersion": "1.5.4",
+          "arguments": "-b19"
+        },
+        {
+          "metricId": "compress_zstd_compression_level_19_decompression_speed",
+          "samples": [1922.3, 1920],
+          "aggregates": {
+            "p50": 1921.15,
+            "p95": 1922.185,
+            "mean": 1921.15,
+            "stdev": 1.6263455967289469,
+            "min": 1920,
+            "max": 1922.3,
+            "n": 2
+          },
+          "sourceFile": "cpu-generic/pts_compress-zstd.xml",
+          "appVersion": "1.5.4",
+          "arguments": "-b19"
+        },
+        {
+          "metricId": "compress_zstd_compression_level_19_long_mode_compression_speed",
+          "samples": [7.15, 6.96],
+          "aggregates": {
+            "p50": 7.055,
+            "p95": 7.1405,
+            "mean": 7.055,
+            "stdev": 0.13435028842544464,
+            "min": 6.96,
+            "max": 7.15,
+            "n": 2
+          },
+          "sourceFile": "cpu-generic/pts_compress-zstd.xml",
+          "appVersion": "1.5.4",
+          "arguments": "-b19 --long"
+        },
+        {
+          "metricId": "compress_zstd_compression_level_19_long_mode_decompression_speed",
+          "samples": [1846.1, 1809.5],
+          "aggregates": {
+            "p50": 1827.8,
+            "p95": 1844.27,
+            "mean": 1827.8,
+            "stdev": 25.880108191427574,
+            "min": 1809.5,
+            "max": 1846.1,
+            "n": 2
+          },
+          "sourceFile": "cpu-generic/pts_compress-zstd.xml",
+          "appVersion": "1.5.4",
+          "arguments": "-b19 --long"
+        },
+        {
+          "metricId": "compress_zstd_compression_level_3_compression_speed",
+          "samples": [778.7, 783.7],
+          "aggregates": {
+            "p50": 781.2,
+            "p95": 783.45,
+            "mean": 781.2,
+            "stdev": 3.5355339059327378,
+            "min": 778.7,
+            "max": 783.7,
+            "n": 2
+          },
+          "sourceFile": "cpu-generic/pts_compress-zstd.xml",
+          "appVersion": "1.5.4",
+          "arguments": "-b3"
+        },
+        {
+          "metricId": "compress_zstd_compression_level_3_decompression_speed",
+          "samples": [2114.7, 2109.9],
+          "aggregates": {
+            "p50": 2112.3,
+            "p95": 2114.46,
+            "mean": 2112.3,
+            "stdev": 3.3941125496950746,
+            "min": 2109.9,
+            "max": 2114.7,
+            "n": 2
+          },
+          "sourceFile": "cpu-generic/pts_compress-zstd.xml",
+          "appVersion": "1.5.4",
+          "arguments": "-b3"
+        },
+        {
+          "metricId": "compress_zstd_compression_level_3_long_mode_compression_speed",
+          "samples": [530.4, 537.7],
+          "aggregates": {
+            "p50": 534.05,
+            "p95": 537.335,
+            "mean": 534.05,
+            "stdev": 5.161879502661885,
+            "min": 530.4,
+            "max": 537.7,
+            "n": 2
+          },
+          "sourceFile": "cpu-generic/pts_compress-zstd.xml",
+          "appVersion": "1.5.4",
+          "arguments": "-b3 --long"
+        },
+        {
+          "metricId": "compress_zstd_compression_level_3_long_mode_decompression_speed",
+          "samples": [2163, 2161.8],
+          "aggregates": {
+            "p50": 2162.4,
+            "p95": 2162.94,
+            "mean": 2162.4,
+            "stdev": 0.8485281374237283,
+            "min": 2161.8,
+            "max": 2163,
+            "n": 2
+          },
+          "sourceFile": "cpu-generic/pts_compress-zstd.xml",
+          "appVersion": "1.5.4",
+          "arguments": "-b3 --long"
+        },
+        {
+          "metricId": "compress_zstd_compression_level_8_compression_speed",
+          "samples": [208.9, 209.5],
+          "aggregates": {
+            "p50": 209.2,
+            "p95": 209.47,
+            "mean": 209.2,
+            "stdev": 0.42426406871193456,
+            "min": 208.9,
+            "max": 209.5,
+            "n": 2
+          },
+          "sourceFile": "cpu-generic/pts_compress-zstd.xml",
+          "appVersion": "1.5.4",
+          "arguments": "-b8"
+        },
+        {
+          "metricId": "compress_zstd_compression_level_8_long_mode_compression_speed",
+          "samples": [202.3, 203.6],
+          "aggregates": {
+            "p50": 202.95,
+            "p95": 203.535,
+            "mean": 202.95,
+            "stdev": 0.9192388155425097,
+            "min": 202.3,
+            "max": 203.6,
+            "n": 2
+          },
+          "sourceFile": "cpu-generic/pts_compress-zstd.xml",
+          "appVersion": "1.5.4",
+          "arguments": "-b8 --long"
+        },
+        {
+          "metricId": "compress_zstd_compression_level_8_long_mode_decompression_speed",
+          "samples": [2306.6, 2320.9],
+          "aggregates": {
+            "p50": 2313.75,
+            "p95": 2320.185,
+            "mean": 2313.75,
+            "stdev": 10.111626970967759,
+            "min": 2306.6,
+            "max": 2320.9,
+            "n": 2
+          },
+          "sourceFile": "cpu-generic/pts_compress-zstd.xml",
+          "appVersion": "1.5.4",
+          "arguments": "-b8 --long"
+        },
+        {
+          "metricId": "fio_type_random_read_engine_linux_aio_direct_yes_block_size_4kb_job_count_1_disk_target_default_test_directory_iops",
+          "samples": [269000, 264000],
+          "aggregates": {
+            "p50": 266500,
+            "p95": 268750,
+            "mean": 266500,
+            "stdev": 3535.5339059327375,
+            "min": 264000,
+            "max": 269000,
+            "n": 2
+          },
+          "sourceFile": "disk/pts_fio-rand-read.xml",
+          "appVersion": "3.36",
+          "arguments": "randread libaio 1 4k 1"
+        },
+        {
+          "metricId": "fio_type_random_read_engine_linux_aio_direct_yes_block_size_4kb_job_count_1_disk_target_default_test_directory_mb_per_s",
+          "samples": [1050, 1031],
+          "aggregates": {
+            "p50": 1040.5,
+            "p95": 1049.05,
+            "mean": 1040.5,
+            "stdev": 13.435028842544403,
+            "min": 1031,
+            "max": 1050,
+            "n": 2
+          },
+          "sourceFile": "disk/pts_fio-rand-read.xml",
+          "appVersion": "3.36",
+          "arguments": "randread libaio 1 4k 1"
+        },
+        {
+          "metricId": "fio_type_random_write_engine_linux_aio_direct_yes_block_size_4kb_job_count_1_disk_target_default_test_directory_iops",
+          "samples": [228000, 229000],
+          "aggregates": {
+            "p50": 228500,
+            "p95": 228950,
+            "mean": 228500,
+            "stdev": 707.1067811865476,
+            "min": 228000,
+            "max": 229000,
+            "n": 2
+          },
+          "sourceFile": "disk/pts_fio-rand-write.xml",
+          "appVersion": "3.36",
+          "arguments": "randwrite libaio 1 4k 1"
+        },
+        {
+          "metricId": "fio_type_random_write_engine_linux_aio_direct_yes_block_size_4kb_job_count_1_disk_target_default_test_directory_mb_per_s",
+          "samples": [891, 896],
+          "aggregates": {
+            "p50": 893.5,
+            "p95": 895.75,
+            "mean": 893.5,
+            "stdev": 3.5355339059327378,
+            "min": 891,
+            "max": 896,
+            "n": 2
+          },
+          "sourceFile": "disk/pts_fio-rand-write.xml",
+          "appVersion": "3.36",
+          "arguments": "randwrite libaio 1 4k 1"
+        },
+        {
+          "metricId": "fio_type_sequential_read_engine_linux_aio_direct_yes_block_size_1mb_job_count_1_disk_target_default_test_directory_iops",
+          "samples": [19000, 8801],
+          "aggregates": {
+            "p50": 13900.5,
+            "p95": 18490.05,
+            "mean": 13900.5,
+            "stdev": 7211.782061321598,
+            "min": 8801,
+            "max": 19000,
+            "n": 2
+          },
+          "sourceFile": "disk/pts_fio-seq-read.xml",
+          "appVersion": "3.36",
+          "arguments": "read libaio 1 1m 1"
+        },
+        {
+          "metricId": "fio_type_sequential_read_engine_linux_aio_direct_yes_block_size_1mb_job_count_1_disk_target_default_test_directory_mb_per_s",
+          "samples": [8803],
+          "aggregates": {
+            "p50": 8803,
+            "p95": 8803,
+            "mean": 8803,
+            "stdev": 0,
+            "min": 8803,
+            "max": 8803,
+            "n": 1
+          },
+          "sourceFile": "disk/pts_fio-seq-read.xml",
+          "appVersion": "3.36",
+          "arguments": "read libaio 1 1m 1"
+        },
+        {
+          "metricId": "fio_type_sequential_write_engine_linux_aio_direct_yes_block_size_1mb_job_count_1_disk_target_default_test_directory_iops",
+          "samples": [5766, 5697],
+          "aggregates": {
+            "p50": 5731.5,
+            "p95": 5762.55,
+            "mean": 5731.5,
+            "stdev": 48.79036790187178,
+            "min": 5697,
+            "max": 5766,
+            "n": 2
+          },
+          "sourceFile": "disk/pts_fio-seq-write.xml",
+          "appVersion": "3.36",
+          "arguments": "write libaio 1 1m 1"
+        },
+        {
+          "metricId": "fio_type_sequential_write_engine_linux_aio_direct_yes_block_size_1mb_job_count_1_disk_target_default_test_directory_mb_per_s",
+          "samples": [5767, 5699],
+          "aggregates": {
+            "p50": 5733,
+            "p95": 5763.6,
+            "mean": 5733,
+            "stdev": 48.08326112068523,
+            "min": 5699,
+            "max": 5767,
+            "n": 2
+          },
+          "sourceFile": "disk/pts_fio-seq-write.xml",
+          "appVersion": "3.36",
+          "arguments": "write libaio 1 1m 1"
+        },
+        {
+          "metricId": "hardlink_bogo_ops_per_s",
+          "samples": [26.29, 26.13],
+          "aggregates": {
+            "p50": 26.21,
+            "p95": 26.282,
+            "mean": 26.21,
+            "stdev": 0.11313708498984645,
+            "min": 26.13,
+            "max": 26.29,
+            "n": 2
+          },
+          "sourceFile": "disk/pts_hardlink.xml",
+          "appVersion": "0.16"
+        },
+        {
+          "metricId": "network_loopback_seconds",
+          "samples": [4.737, 4.326],
+          "aggregates": {
+            "p50": 4.531499999999999,
+            "p95": 4.71645,
+            "mean": 4.531499999999999,
+            "stdev": 0.2906208870676717,
+            "min": 4.326,
+            "max": 4.737,
+            "n": 2
+          },
+          "sourceFile": "network/pts_network-loopback.xml"
+        },
+        {
+          "metricId": "node_web_tooling_runs_per_s",
+          "samples": [20.08, 18.79],
+          "aggregates": {
+            "p50": 19.435,
+            "p95": 20.0155,
+            "mean": 19.435,
+            "stdev": 0.9121677477306457,
+            "min": 18.79,
+            "max": 20.08,
+            "n": 2
+          },
+          "sourceFile": "cpu-node/pts_node-web-tooling.xml"
+        },
+        {
+          "metricId": "realworld_better_auth_task_build",
+          "samples": [12.467, 12.437],
+          "aggregates": {
+            "p50": 12.452,
+            "p95": 12.4655,
+            "mean": 12.452,
+            "stdev": 0.02121320343559723,
+            "min": 12.437,
+            "max": 12.467,
+            "n": 2
+          },
+          "sourceFile": "realworld-better-auth/pts_realworld-better-auth.xml",
+          "appVersion": "6f3ba45639579da152b69e8e5342e02f28288670",
+          "arguments": "build"
+        },
+        {
+          "metricId": "realworld_better_auth_task_cold_install",
+          "samples": [12.118, 11.088],
+          "aggregates": {
+            "p50": 11.603,
+            "p95": 12.0665,
+            "mean": 11.603,
+            "stdev": 0.7283199846221448,
+            "min": 11.088,
+            "max": 12.118,
+            "n": 2
+          },
+          "sourceFile": "realworld-better-auth/pts_realworld-better-auth.xml",
+          "appVersion": "6f3ba45639579da152b69e8e5342e02f28288670",
+          "arguments": "cold_install"
+        },
+        {
+          "metricId": "realworld_better_auth_task_git_clone",
+          "samples": [1.696, 1.745],
+          "aggregates": {
+            "p50": 1.7205,
+            "p95": 1.74255,
+            "mean": 1.7205,
+            "stdev": 0.03464823227814102,
+            "min": 1.696,
+            "max": 1.745,
+            "n": 2
+          },
+          "sourceFile": "realworld-better-auth/pts_realworld-better-auth.xml",
+          "appVersion": "6f3ba45639579da152b69e8e5342e02f28288670",
+          "arguments": "git_clone"
+        },
+        {
+          "metricId": "realworld_better_auth_task_lint_biome",
+          "samples": [4.876, 4.849],
+          "aggregates": {
+            "p50": 4.862500000000001,
+            "p95": 4.87465,
+            "mean": 4.862500000000001,
+            "stdev": 0.019091883092036566,
+            "min": 4.849,
+            "max": 4.876,
+            "n": 2
+          },
+          "sourceFile": "realworld-better-auth/pts_realworld-better-auth.xml",
+          "appVersion": "6f3ba45639579da152b69e8e5342e02f28288670",
+          "arguments": "lint_biome"
+        },
+        {
+          "metricId": "realworld_better_auth_task_lint_deps_knip",
+          "samples": [10.867, 10.767],
+          "aggregates": {
+            "p50": 10.817,
+            "p95": 10.862,
+            "mean": 10.817,
+            "stdev": 0.07071067811865576,
+            "min": 10.767,
+            "max": 10.867,
+            "n": 2
+          },
+          "sourceFile": "realworld-better-auth/pts_realworld-better-auth.xml",
+          "appVersion": "6f3ba45639579da152b69e8e5342e02f28288670",
+          "arguments": "lint_deps"
+        },
+        {
+          "metricId": "realworld_better_auth_task_lint_format",
+          "samples": [2.679, 2.759],
+          "aggregates": {
+            "p50": 2.719,
+            "p95": 2.755,
+            "mean": 2.719,
+            "stdev": 0.05656854249492385,
+            "min": 2.679,
+            "max": 2.759,
+            "n": 2
+          },
+          "sourceFile": "realworld-better-auth/pts_realworld-better-auth.xml",
+          "appVersion": "6f3ba45639579da152b69e8e5342e02f28288670",
+          "arguments": "lint_format"
+        },
+        {
+          "metricId": "realworld_better_auth_task_lint_packages",
+          "samples": [4.05, 3.999],
+          "aggregates": {
+            "p50": 4.0245,
+            "p95": 4.0474499999999995,
+            "mean": 4.0245,
+            "stdev": 0.03606244584051388,
+            "min": 3.999,
+            "max": 4.05,
+            "n": 2
+          },
+          "sourceFile": "realworld-better-auth/pts_realworld-better-auth.xml",
+          "appVersion": "6f3ba45639579da152b69e8e5342e02f28288670",
+          "arguments": "lint_packages"
+        },
+        {
+          "metricId": "realworld_better_auth_task_lint_spell",
+          "samples": [6.711, 6.803],
+          "aggregates": {
+            "p50": 6.757,
+            "p95": 6.7984,
+            "mean": 6.757,
+            "stdev": 0.06505382386916243,
+            "min": 6.711,
+            "max": 6.803,
+            "n": 2
+          },
+          "sourceFile": "realworld-better-auth/pts_realworld-better-auth.xml",
+          "appVersion": "6f3ba45639579da152b69e8e5342e02f28288670",
+          "arguments": "lint_spell"
+        },
+        {
+          "metricId": "realworld_better_auth_task_lint_types",
+          "samples": [52.206, 49.969],
+          "aggregates": {
+            "p50": 51.087500000000006,
+            "p95": 52.094150000000006,
+            "mean": 51.087500000000006,
+            "stdev": 1.5817978695143056,
+            "min": 49.969,
+            "max": 52.206,
+            "n": 2
+          },
+          "sourceFile": "realworld-better-auth/pts_realworld-better-auth.xml",
+          "appVersion": "6f3ba45639579da152b69e8e5342e02f28288670",
+          "arguments": "lint_types"
+        },
+        {
+          "metricId": "realworld_better_auth_task_typecheck",
+          "samples": [1.447, 1.439],
+          "aggregates": {
+            "p50": 1.443,
+            "p95": 1.4466,
+            "mean": 1.443,
+            "stdev": 0.005656854249492385,
+            "min": 1.439,
+            "max": 1.447,
+            "n": 2
+          },
+          "sourceFile": "realworld-better-auth/pts_realworld-better-auth.xml",
+          "appVersion": "6f3ba45639579da152b69e8e5342e02f28288670",
+          "arguments": "typecheck"
+        },
+        {
+          "metricId": "realworld_mastra_task_build_core",
+          "samples": [82.893, 87.716],
+          "aggregates": {
+            "p50": 85.30449999999999,
+            "p95": 87.47484999999999,
+            "mean": 85.30449999999999,
+            "stdev": 3.410376005662719,
+            "min": 82.893,
+            "max": 87.716,
+            "n": 2
+          },
+          "sourceFile": "realworld-mastra/pts_realworld-mastra.xml",
+          "appVersion": "b6eeb9d08ebeaf27bc6fd16b6b88087040aaf767",
+          "arguments": "build_core"
+        },
+        {
+          "metricId": "realworld_mastra_task_cold_install",
+          "samples": [29.256, 28.734],
+          "aggregates": {
+            "p50": 28.995,
+            "p95": 29.2299,
+            "mean": 28.995,
+            "stdev": 0.3691097397793767,
+            "min": 28.734,
+            "max": 29.256,
+            "n": 2
+          },
+          "sourceFile": "realworld-mastra/pts_realworld-mastra.xml",
+          "appVersion": "b6eeb9d08ebeaf27bc6fd16b6b88087040aaf767",
+          "arguments": "cold_install"
+        },
+        {
+          "metricId": "realworld_mastra_task_git_clone",
+          "samples": [7.904, 7.144],
+          "aggregates": {
+            "p50": 7.524,
+            "p95": 7.866,
+            "mean": 7.524,
+            "stdev": 0.537401153701776,
+            "min": 7.144,
+            "max": 7.904,
+            "n": 2
+          },
+          "sourceFile": "realworld-mastra/pts_realworld-mastra.xml",
+          "appVersion": "b6eeb9d08ebeaf27bc6fd16b6b88087040aaf767",
+          "arguments": "git_clone"
+        },
+        {
+          "metricId": "realworld_mastra_task_lint_format",
+          "samples": [91.434, 91.288],
+          "aggregates": {
+            "p50": 91.36099999999999,
+            "p95": 91.4267,
+            "mean": 91.36099999999999,
+            "stdev": 0.10323759005324153,
+            "min": 91.288,
+            "max": 91.434,
+            "n": 2
+          },
+          "sourceFile": "realworld-mastra/pts_realworld-mastra.xml",
+          "appVersion": "b6eeb9d08ebeaf27bc6fd16b6b88087040aaf767",
+          "arguments": "lint_format"
+        },
+        {
+          "metricId": "sqlite_speedtest_seconds",
+          "samples": [34.638, 34.309],
+          "aggregates": {
+            "p50": 34.4735,
+            "p95": 34.62155,
+            "mean": 34.4735,
+            "stdev": 0.23263813101037206,
+            "min": 34.309,
+            "max": 34.638,
+            "n": 2
+          },
+          "sourceFile": "system/pts_sqlite-speedtest.xml",
+          "appVersion": "3.30"
+        },
+        {
+          "metricId": "stream_type_add",
+          "samples": [78375.3, 77807.5],
+          "aggregates": {
+            "p50": 78091.4,
+            "p95": 78346.91,
+            "mean": 78091.4,
+            "stdev": 401.4952303577289,
+            "min": 77807.5,
+            "max": 78375.3,
+            "n": 2
+          },
+          "sourceFile": "memory/pts_stream.xml",
+          "appVersion": "2013-01-17",
+          "arguments": "Add"
+        },
+        {
+          "metricId": "stream_type_copy",
+          "samples": [87151.5, 85820.4],
+          "aggregates": {
+            "p50": 86485.95,
+            "p95": 87084.945,
+            "mean": 86485.95,
+            "stdev": 941.2298364374176,
+            "min": 85820.4,
+            "max": 87151.5,
+            "n": 2
+          },
+          "sourceFile": "memory/pts_stream.xml",
+          "appVersion": "2013-01-17",
+          "arguments": "Copy"
+        },
+        {
+          "metricId": "stream_type_scale",
+          "samples": [73887.6, 71573.2],
+          "aggregates": {
+            "p50": 72730.4,
+            "p95": 73771.88,
+            "mean": 72730.4,
+            "stdev": 1636.527934378157,
+            "min": 71573.2,
+            "max": 73887.6,
+            "n": 2
+          },
+          "sourceFile": "memory/pts_stream.xml",
+          "appVersion": "2013-01-17",
+          "arguments": "Scale"
+        },
+        {
+          "metricId": "stream_type_triad",
+          "samples": [79252.9, 77375.7],
+          "aggregates": {
+            "p50": 78314.29999999999,
+            "p95": 79159.04,
+            "mean": 78314.29999999999,
+            "stdev": 1327.38084964339,
+            "min": 77375.7,
+            "max": 79252.9,
+            "n": 2
+          },
+          "sourceFile": "memory/pts_stream.xml",
+          "appVersion": "2013-01-17",
+          "arguments": "Triad"
+        },
+        {
+          "metricId": "usd_per_hour",
+          "samples": [0.1494],
+          "aggregates": {
+            "p50": 0.1494,
+            "p95": 0.1494,
+            "mean": 0.1494,
+            "stdev": 0,
+            "min": 0.1494,
+            "max": 0.1494,
+            "n": 1
+          }
+        }
+      ],
+      "suitesCovered": [
+        "cpu-generic",
+        "cpu-node",
+        "disk",
+        "memory",
+        "network",
+        "realworld-better-auth",
+        "realworld-mastra",
+        "system"
+      ],
+      "gaps": [
+        {
+          "scope": "suite",
+          "id": "realworld-openclaw",
+          "outcome": "failed",
+          "reason": "Step \"mise run benchmark:realworld:pts:openclaw\" lost its sandbox: 12 consecutive detached polls failed (last: done-file fs exists) — the sandbox stopped responding, not a quiet long step"
+        }
+      ],
+      "uncatalogued": []
+    },
+    {
+      "providerId": "e2b",
+      "validationStatus": "validated",
+      "specMatched": true,
+      "observedSpecs": {
+        "vcpus": 2,
+        "cpuModel": "Intel(R) Xeon(R) Processor @ 2.60GHz",
+        "virtualization": "kvm",
+        "memoryGb": 7.78,
+        "diskGb": 22.7,
+        "kernel": "6.1.158+",
+        "os": "Debian GNU/Linux 13 (trixie)",
+        "user": "root",
+        "hostMemoryGb": 8
+      },
+      "metrics": [
+        {
+          "metricId": "fio_type_random_read_engine_linux_aio_direct_yes_block_size_4kb_job_count_1_disk_target_default_test_directory_iops",
+          "samples": [31600, 33500],
+          "aggregates": {
+            "p50": 32550,
+            "p95": 33405,
+            "mean": 32550,
+            "stdev": 1343.5028842544402,
+            "min": 31600,
+            "max": 33500,
+            "n": 2
+          },
+          "sourceFile": "disk/pts_fio-rand-read.xml",
+          "appVersion": "3.36",
+          "arguments": "randread libaio 1 4k 1"
+        },
+        {
+          "metricId": "fio_type_random_read_engine_linux_aio_direct_yes_block_size_4kb_job_count_1_disk_target_default_test_directory_mb_per_s",
+          "samples": [123, 131],
+          "aggregates": {
+            "p50": 127,
+            "p95": 130.6,
+            "mean": 127,
+            "stdev": 5.656854249492381,
+            "min": 123,
+            "max": 131,
+            "n": 2
+          },
+          "sourceFile": "disk/pts_fio-rand-read.xml",
+          "appVersion": "3.36",
+          "arguments": "randread libaio 1 4k 1"
+        },
+        {
+          "metricId": "fio_type_random_write_engine_linux_aio_direct_yes_block_size_4kb_job_count_1_disk_target_default_test_directory_iops",
+          "samples": [55300, 52600],
+          "aggregates": {
+            "p50": 53950,
+            "p95": 55165,
+            "mean": 53950,
+            "stdev": 1909.1883092036783,
+            "min": 52600,
+            "max": 55300,
+            "n": 2
+          },
+          "sourceFile": "disk/pts_fio-rand-write.xml",
+          "appVersion": "3.36",
+          "arguments": "randwrite libaio 1 4k 1"
+        },
+        {
+          "metricId": "fio_type_random_write_engine_linux_aio_direct_yes_block_size_4kb_job_count_1_disk_target_default_test_directory_mb_per_s",
+          "samples": [216, 206],
+          "aggregates": {
+            "p50": 211,
+            "p95": 215.5,
+            "mean": 211,
+            "stdev": 7.0710678118654755,
+            "min": 206,
+            "max": 216,
+            "n": 2
+          },
+          "sourceFile": "disk/pts_fio-rand-write.xml",
+          "appVersion": "3.36",
+          "arguments": "randwrite libaio 1 4k 1"
+        },
+        {
+          "metricId": "fio_type_sequential_read_engine_linux_aio_direct_yes_block_size_1mb_job_count_1_disk_target_default_test_directory_iops",
+          "samples": [599, 599],
+          "aggregates": {
+            "p50": 599,
+            "p95": 599,
+            "mean": 599,
+            "stdev": 0,
+            "min": 599,
+            "max": 599,
+            "n": 2
+          },
+          "sourceFile": "disk/pts_fio-seq-read.xml",
+          "appVersion": "3.36",
+          "arguments": "read libaio 1 1m 1"
+        },
+        {
+          "metricId": "fio_type_sequential_read_engine_linux_aio_direct_yes_block_size_1mb_job_count_1_disk_target_default_test_directory_mb_per_s",
+          "samples": [601, 601],
+          "aggregates": {
+            "p50": 601,
+            "p95": 601,
+            "mean": 601,
+            "stdev": 0,
+            "min": 601,
+            "max": 601,
+            "n": 2
+          },
+          "sourceFile": "disk/pts_fio-seq-read.xml",
+          "appVersion": "3.36",
+          "arguments": "read libaio 1 1m 1"
+        },
+        {
+          "metricId": "fio_type_sequential_write_engine_linux_aio_direct_yes_block_size_1mb_job_count_1_disk_target_default_test_directory_iops",
+          "samples": [599, 600],
+          "aggregates": {
+            "p50": 599.5,
+            "p95": 599.95,
+            "mean": 599.5,
+            "stdev": 0.7071067811865476,
+            "min": 599,
+            "max": 600,
+            "n": 2
+          },
+          "sourceFile": "disk/pts_fio-seq-write.xml",
+          "appVersion": "3.36",
+          "arguments": "write libaio 1 1m 1"
+        },
+        {
+          "metricId": "fio_type_sequential_write_engine_linux_aio_direct_yes_block_size_1mb_job_count_1_disk_target_default_test_directory_mb_per_s",
+          "samples": [601, 601],
+          "aggregates": {
+            "p50": 601,
+            "p95": 601,
+            "mean": 601,
+            "stdev": 0,
+            "min": 601,
+            "max": 601,
+            "n": 2
+          },
+          "sourceFile": "disk/pts_fio-seq-write.xml",
+          "appVersion": "3.36",
+          "arguments": "write libaio 1 1m 1"
+        },
+        {
+          "metricId": "hardlink_bogo_ops_per_s",
+          "samples": [1.43, 1.43],
+          "aggregates": {
+            "p50": 1.43,
+            "p95": 1.43,
+            "mean": 1.43,
+            "stdev": 0,
+            "min": 1.43,
+            "max": 1.43,
+            "n": 2
+          },
+          "sourceFile": "disk/pts_hardlink.xml",
+          "appVersion": "0.16"
+        },
+        {
+          "metricId": "network_loopback_seconds",
+          "samples": [15.074, 14.891],
+          "aggregates": {
+            "p50": 14.9825,
+            "p95": 15.06485,
+            "mean": 14.9825,
+            "stdev": 0.12940054095713807,
+            "min": 14.891,
+            "max": 15.074,
+            "n": 2
+          },
+          "sourceFile": "network/pts_network-loopback.xml"
+        },
+        {
+          "metricId": "node_web_tooling_runs_per_s",
+          "samples": [10.59, 10.66],
+          "aggregates": {
+            "p50": 10.625,
+            "p95": 10.6565,
+            "mean": 10.625,
+            "stdev": 0.049497474683058526,
+            "min": 10.59,
+            "max": 10.66,
+            "n": 2
+          },
+          "sourceFile": "cpu-node/pts_node-web-tooling.xml"
+        },
+        {
+          "metricId": "realworld_better_auth_task_build",
+          "samples": [22.259, 23.495],
+          "aggregates": {
+            "p50": 22.877000000000002,
+            "p95": 23.4332,
+            "mean": 22.877000000000002,
+            "stdev": 0.873983981546572,
+            "min": 22.259,
+            "max": 23.495,
+            "n": 2
+          },
+          "sourceFile": "realworld-better-auth/pts_realworld-better-auth.xml",
+          "appVersion": "6f3ba45639579da152b69e8e5342e02f28288670",
+          "arguments": "build"
+        },
+        {
+          "metricId": "realworld_better_auth_task_cold_install",
+          "samples": [20.039, 19.799],
+          "aggregates": {
+            "p50": 19.919,
+            "p95": 20.027,
+            "mean": 19.919,
+            "stdev": 0.1697056274847728,
+            "min": 19.799,
+            "max": 20.039,
+            "n": 2
+          },
+          "sourceFile": "realworld-better-auth/pts_realworld-better-auth.xml",
+          "appVersion": "6f3ba45639579da152b69e8e5342e02f28288670",
+          "arguments": "cold_install"
+        },
+        {
+          "metricId": "realworld_better_auth_task_git_clone",
+          "samples": [1.753, 1.724],
+          "aggregates": {
+            "p50": 1.7385,
+            "p95": 1.75155,
+            "mean": 1.7385,
+            "stdev": 0.02050609665440982,
+            "min": 1.724,
+            "max": 1.753,
+            "n": 2
+          },
+          "sourceFile": "realworld-better-auth/pts_realworld-better-auth.xml",
+          "appVersion": "6f3ba45639579da152b69e8e5342e02f28288670",
+          "arguments": "git_clone"
+        },
+        {
+          "metricId": "realworld_better_auth_task_lint_biome",
+          "samples": [8.502, 8.746],
+          "aggregates": {
+            "p50": 8.624,
+            "p95": 8.7338,
+            "mean": 8.624,
+            "stdev": 0.17253405460951743,
+            "min": 8.502,
+            "max": 8.746,
+            "n": 2
+          },
+          "sourceFile": "realworld-better-auth/pts_realworld-better-auth.xml",
+          "appVersion": "6f3ba45639579da152b69e8e5342e02f28288670",
+          "arguments": "lint_biome"
+        },
+        {
+          "metricId": "realworld_better_auth_task_lint_deps_knip",
+          "samples": [19.952, 19.777],
+          "aggregates": {
+            "p50": 19.8645,
+            "p95": 19.943250000000003,
+            "mean": 19.8645,
+            "stdev": 0.12374368670764757,
+            "min": 19.777,
+            "max": 19.952,
+            "n": 2
+          },
+          "sourceFile": "realworld-better-auth/pts_realworld-better-auth.xml",
+          "appVersion": "6f3ba45639579da152b69e8e5342e02f28288670",
+          "arguments": "lint_deps"
+        },
+        {
+          "metricId": "realworld_better_auth_task_lint_format",
+          "samples": [5.604, 5.18],
+          "aggregates": {
+            "p50": 5.3919999999999995,
+            "p95": 5.5828,
+            "mean": 5.3919999999999995,
+            "stdev": 0.2998132752230967,
+            "min": 5.18,
+            "max": 5.604,
+            "n": 2
+          },
+          "sourceFile": "realworld-better-auth/pts_realworld-better-auth.xml",
+          "appVersion": "6f3ba45639579da152b69e8e5342e02f28288670",
+          "arguments": "lint_format"
+        },
+        {
+          "metricId": "realworld_better_auth_task_lint_packages",
+          "samples": [7.226, 7.345],
+          "aggregates": {
+            "p50": 7.2855,
+            "p95": 7.339049999999999,
+            "mean": 7.2855,
+            "stdev": 0.084145706961199,
+            "min": 7.226,
+            "max": 7.345,
+            "n": 2
+          },
+          "sourceFile": "realworld-better-auth/pts_realworld-better-auth.xml",
+          "appVersion": "6f3ba45639579da152b69e8e5342e02f28288670",
+          "arguments": "lint_packages"
+        },
+        {
+          "metricId": "realworld_better_auth_task_lint_spell",
+          "samples": [13.405, 13.364],
+          "aggregates": {
+            "p50": 13.3845,
+            "p95": 13.402949999999999,
+            "mean": 13.3845,
+            "stdev": 0.028991378028648082,
+            "min": 13.364,
+            "max": 13.405,
+            "n": 2
+          },
+          "sourceFile": "realworld-better-auth/pts_realworld-better-auth.xml",
+          "appVersion": "6f3ba45639579da152b69e8e5342e02f28288670",
+          "arguments": "lint_spell"
+        },
+        {
+          "metricId": "realworld_better_auth_task_lint_types",
+          "samples": [103.9, 102.462],
+          "aggregates": {
+            "p50": 103.18100000000001,
+            "p95": 103.8281,
+            "mean": 103.18100000000001,
+            "stdev": 1.016819551346252,
+            "min": 102.462,
+            "max": 103.9,
+            "n": 2
+          },
+          "sourceFile": "realworld-better-auth/pts_realworld-better-auth.xml",
+          "appVersion": "6f3ba45639579da152b69e8e5342e02f28288670",
+          "arguments": "lint_types"
+        },
+        {
+          "metricId": "realworld_better_auth_task_typecheck",
+          "samples": [2.301, 2.369],
+          "aggregates": {
+            "p50": 2.335,
+            "p95": 2.3656,
+            "mean": 2.335,
+            "stdev": 0.048083261120685436,
+            "min": 2.301,
+            "max": 2.369,
+            "n": 2
+          },
+          "sourceFile": "realworld-better-auth/pts_realworld-better-auth.xml",
+          "appVersion": "6f3ba45639579da152b69e8e5342e02f28288670",
+          "arguments": "typecheck"
+        },
+        {
+          "metricId": "sqlite_speedtest_seconds",
+          "samples": [67.822, 67.642],
+          "aggregates": {
+            "p50": 67.732,
+            "p95": 67.813,
+            "mean": 67.732,
+            "stdev": 0.12727922061358338,
+            "min": 67.642,
+            "max": 67.822,
+            "n": 2
+          },
+          "sourceFile": "system/pts_sqlite-speedtest.xml",
+          "appVersion": "3.30"
+        },
+        {
+          "metricId": "stream_type_add",
+          "samples": [23943.4, 22656.3],
+          "aggregates": {
+            "p50": 23299.85,
+            "p95": 23879.045000000002,
+            "mean": 23299.85,
+            "stdev": 910.1171380652082,
+            "min": 22656.3,
+            "max": 23943.4,
+            "n": 2
+          },
+          "sourceFile": "memory/pts_stream.xml",
+          "appVersion": "2013-01-17",
+          "arguments": "Add"
+        },
+        {
+          "metricId": "stream_type_copy",
+          "samples": [51070.8, 46635.8],
+          "aggregates": {
+            "p50": 48853.3,
+            "p95": 50849.05,
+            "mean": 48853.3,
+            "stdev": 3136.0185745623385,
+            "min": 46635.8,
+            "max": 51070.8,
+            "n": 2
+          },
+          "sourceFile": "memory/pts_stream.xml",
+          "appVersion": "2013-01-17",
+          "arguments": "Copy"
+        },
+        {
+          "metricId": "stream_type_scale",
+          "samples": [21882.5, 21139.7],
+          "aggregates": {
+            "p50": 21511.1,
+            "p95": 21845.36,
+            "mean": 21511.1,
+            "stdev": 525.2389170653682,
+            "min": 21139.7,
+            "max": 21882.5,
+            "n": 2
+          },
+          "sourceFile": "memory/pts_stream.xml",
+          "appVersion": "2013-01-17",
+          "arguments": "Scale"
+        },
+        {
+          "metricId": "stream_type_triad",
+          "samples": [24279.4, 22638.1],
+          "aggregates": {
+            "p50": 23458.75,
+            "p95": 24197.335000000003,
+            "mean": 23458.75,
+            "stdev": 1160.5743599614825,
+            "min": 22638.1,
+            "max": 24279.4,
+            "n": 2
+          },
+          "sourceFile": "memory/pts_stream.xml",
+          "appVersion": "2013-01-17",
+          "arguments": "Triad"
+        },
+        {
+          "metricId": "usd_per_hour",
+          "samples": [0.2304],
+          "aggregates": {
+            "p50": 0.2304,
+            "p95": 0.2304,
+            "mean": 0.2304,
+            "stdev": 0,
+            "min": 0.2304,
+            "max": 0.2304,
+            "n": 1
+          }
+        }
+      ],
+      "suitesCovered": ["cpu-node", "disk", "memory", "network", "realworld-better-auth", "system"],
+      "gaps": [
+        {
+          "scope": "suite",
+          "id": "cpu-generic",
+          "outcome": "failed",
+          "reason": "Step \"mise run benchmark:cpu:generic\" timed out after 7800s"
+        },
+        {
+          "scope": "suite",
+          "id": "realworld-mastra",
+          "outcome": "skipped",
+          "reason": "Insufficient disk: 19.7 GiB free, suite needs 30 GiB"
+        },
+        {
+          "scope": "suite",
+          "id": "realworld-openclaw",
+          "outcome": "skipped",
+          "reason": "Insufficient disk: 19.7 GiB free, suite needs 25 GiB"
+        }
+      ],
+      "uncatalogued": []
+    },
+    {
+      "providerId": "modal",
+      "validationStatus": "validated",
+      "specMatched": true,
+      "observedSpecs": {
+        "vcpus": 2,
+        "cpuModel": "unknown",
+        "virtualization": "unknown",
+        "memoryGb": 8,
+        "kernel": "4.19.0-gvisor",
+        "os": "Debian GNU/Linux 13 (trixie)",
+        "user": "root",
+        "hostVcpus": 2,
+        "hostMemoryGb": 8
+      },
+      "metrics": [
+        {
+          "metricId": "fio_type_random_read_engine_linux_aio_direct_yes_block_size_4kb_job_count_1_disk_target_default_test_directory_iops",
+          "samples": [33600, 32800],
+          "aggregates": {
+            "p50": 33200,
+            "p95": 33560,
+            "mean": 33200,
+            "stdev": 565.685424949238,
+            "min": 32800,
+            "max": 33600,
+            "n": 2
+          },
+          "sourceFile": "disk/pts_fio-rand-read.xml",
+          "appVersion": "3.36",
+          "arguments": "randread libaio 1 4k 1"
+        },
+        {
+          "metricId": "fio_type_random_read_engine_linux_aio_direct_yes_block_size_4kb_job_count_1_disk_target_default_test_directory_mb_per_s",
+          "samples": [131, 128],
+          "aggregates": {
+            "p50": 129.5,
+            "p95": 130.85,
+            "mean": 129.5,
+            "stdev": 2.1213203435596424,
+            "min": 128,
+            "max": 131,
+            "n": 2
+          },
+          "sourceFile": "disk/pts_fio-rand-read.xml",
+          "appVersion": "3.36",
+          "arguments": "randread libaio 1 4k 1"
+        },
+        {
+          "metricId": "fio_type_random_write_engine_linux_aio_direct_yes_block_size_4kb_job_count_1_disk_target_default_test_directory_iops",
+          "samples": [29400, 29000],
+          "aggregates": {
+            "p50": 29200,
+            "p95": 29380,
+            "mean": 29200,
+            "stdev": 282.842712474619,
+            "min": 29000,
+            "max": 29400,
+            "n": 2
+          },
+          "sourceFile": "disk/pts_fio-rand-write.xml",
+          "appVersion": "3.36",
+          "arguments": "randwrite libaio 1 4k 1"
+        },
+        {
+          "metricId": "fio_type_random_write_engine_linux_aio_direct_yes_block_size_4kb_job_count_1_disk_target_default_test_directory_mb_per_s",
+          "samples": [115, 113],
+          "aggregates": {
+            "p50": 114,
+            "p95": 114.9,
+            "mean": 114,
+            "stdev": 1.4142135623730951,
+            "min": 113,
+            "max": 115,
+            "n": 2
+          },
+          "sourceFile": "disk/pts_fio-rand-write.xml",
+          "appVersion": "3.36",
+          "arguments": "randwrite libaio 1 4k 1"
+        },
+        {
+          "metricId": "fio_type_sequential_read_engine_linux_aio_direct_yes_block_size_1mb_job_count_1_disk_target_default_test_directory_iops",
+          "samples": [10700, 13300],
+          "aggregates": {
+            "p50": 12000,
+            "p95": 13170,
+            "mean": 12000,
+            "stdev": 1838.4776310850236,
+            "min": 10700,
+            "max": 13300,
+            "n": 2
+          },
+          "sourceFile": "disk/pts_fio-seq-read.xml",
+          "appVersion": "3.36",
+          "arguments": "read libaio 1 1m 1"
+        },
+        {
+          "metricId": "fio_type_sequential_write_engine_linux_aio_direct_yes_block_size_1mb_job_count_1_disk_target_default_test_directory_iops",
+          "samples": [2770, 1695],
+          "aggregates": {
+            "p50": 2232.5,
+            "p95": 2716.25,
+            "mean": 2232.5,
+            "stdev": 760.1397897755386,
+            "min": 1695,
+            "max": 2770,
+            "n": 2
+          },
+          "sourceFile": "disk/pts_fio-seq-write.xml",
+          "appVersion": "3.36",
+          "arguments": "write libaio 1 1m 1"
+        },
+        {
+          "metricId": "fio_type_sequential_write_engine_linux_aio_direct_yes_block_size_1mb_job_count_1_disk_target_default_test_directory_mb_per_s",
+          "samples": [2772, 1697],
+          "aggregates": {
+            "p50": 2234.5,
+            "p95": 2718.25,
+            "mean": 2234.5,
+            "stdev": 760.1397897755386,
+            "min": 1697,
+            "max": 2772,
+            "n": 2
+          },
+          "sourceFile": "disk/pts_fio-seq-write.xml",
+          "appVersion": "3.36",
+          "arguments": "write libaio 1 1m 1"
+        },
+        {
+          "metricId": "hardlink_bogo_ops_per_s",
+          "samples": [3.21, 3.18],
+          "aggregates": {
+            "p50": 3.1950000000000003,
+            "p95": 3.2085,
+            "mean": 3.1950000000000003,
+            "stdev": 0.021213203435596132,
+            "min": 3.18,
+            "max": 3.21,
+            "n": 2
+          },
+          "sourceFile": "disk/pts_hardlink.xml",
+          "appVersion": "0.16"
+        },
+        {
+          "metricId": "network_loopback_seconds",
+          "samples": [58.153, 55.712],
+          "aggregates": {
+            "p50": 56.932500000000005,
+            "p95": 58.03095,
+            "mean": 56.932500000000005,
+            "stdev": 1.7260476528763566,
+            "min": 55.712,
+            "max": 58.153,
+            "n": 2
+          },
+          "sourceFile": "network/pts_network-loopback.xml"
+        },
+        {
+          "metricId": "node_web_tooling_runs_per_s",
+          "samples": [9, 9.48],
+          "aggregates": {
+            "p50": 9.24,
+            "p95": 9.456,
+            "mean": 9.24,
+            "stdev": 0.3394112549695431,
+            "min": 9,
+            "max": 9.48,
+            "n": 2
+          },
+          "sourceFile": "cpu-node/pts_node-web-tooling.xml"
+        },
+        {
+          "metricId": "realworld_better_auth_task_build",
+          "samples": [41.06, 40.485],
+          "aggregates": {
+            "p50": 40.7725,
+            "p95": 41.03125,
+            "mean": 40.7725,
+            "stdev": 0.40658639918226686,
+            "min": 40.485,
+            "max": 41.06,
+            "n": 2
+          },
+          "sourceFile": "realworld-better-auth/pts_realworld-better-auth.xml",
+          "appVersion": "6f3ba45639579da152b69e8e5342e02f28288670",
+          "arguments": "build"
+        },
+        {
+          "metricId": "realworld_better_auth_task_cold_install",
+          "samples": [30.946, 30.657],
+          "aggregates": {
+            "p50": 30.8015,
+            "p95": 30.93155,
+            "mean": 30.8015,
+            "stdev": 0.2043538597629133,
+            "min": 30.657,
+            "max": 30.946,
+            "n": 2
+          },
+          "sourceFile": "realworld-better-auth/pts_realworld-better-auth.xml",
+          "appVersion": "6f3ba45639579da152b69e8e5342e02f28288670",
+          "arguments": "cold_install"
+        },
+        {
+          "metricId": "realworld_better_auth_task_git_clone",
+          "samples": [2.588, 2.872],
+          "aggregates": {
+            "p50": 2.73,
+            "p95": 2.8578,
+            "mean": 2.73,
+            "stdev": 0.20081832585697937,
+            "min": 2.588,
+            "max": 2.872,
+            "n": 2
+          },
+          "sourceFile": "realworld-better-auth/pts_realworld-better-auth.xml",
+          "appVersion": "6f3ba45639579da152b69e8e5342e02f28288670",
+          "arguments": "git_clone"
+        },
+        {
+          "metricId": "realworld_better_auth_task_lint_biome",
+          "samples": [17.58, 17.326],
+          "aggregates": {
+            "p50": 17.453,
+            "p95": 17.5673,
+            "mean": 17.453,
+            "stdev": 0.17960512242138152,
+            "min": 17.326,
+            "max": 17.58,
+            "n": 2
+          },
+          "sourceFile": "realworld-better-auth/pts_realworld-better-auth.xml",
+          "appVersion": "6f3ba45639579da152b69e8e5342e02f28288670",
+          "arguments": "lint_biome"
+        },
+        {
+          "metricId": "realworld_better_auth_task_lint_deps_knip",
+          "samples": [29.325, 28.668],
+          "aggregates": {
+            "p50": 28.996499999999997,
+            "p95": 29.29215,
+            "mean": 28.996499999999997,
+            "stdev": 0.464569155239563,
+            "min": 28.668,
+            "max": 29.325,
+            "n": 2
+          },
+          "sourceFile": "realworld-better-auth/pts_realworld-better-auth.xml",
+          "appVersion": "6f3ba45639579da152b69e8e5342e02f28288670",
+          "arguments": "lint_deps"
+        },
+        {
+          "metricId": "realworld_better_auth_task_lint_format",
+          "samples": [6.608, 6.486],
+          "aggregates": {
+            "p50": 6.547,
+            "p95": 6.6019,
+            "mean": 6.547,
+            "stdev": 0.08626702730475871,
+            "min": 6.486,
+            "max": 6.608,
+            "n": 2
+          },
+          "sourceFile": "realworld-better-auth/pts_realworld-better-auth.xml",
+          "appVersion": "6f3ba45639579da152b69e8e5342e02f28288670",
+          "arguments": "lint_format"
+        },
+        {
+          "metricId": "realworld_better_auth_task_lint_packages",
+          "samples": [15.806, 15.718],
+          "aggregates": {
+            "p50": 15.762,
+            "p95": 15.801599999999999,
+            "mean": 15.762,
+            "stdev": 0.06222539674441498,
+            "min": 15.718,
+            "max": 15.806,
+            "n": 2
+          },
+          "sourceFile": "realworld-better-auth/pts_realworld-better-auth.xml",
+          "appVersion": "6f3ba45639579da152b69e8e5342e02f28288670",
+          "arguments": "lint_packages"
+        },
+        {
+          "metricId": "realworld_better_auth_task_lint_spell",
+          "samples": [15.979, 14.796],
+          "aggregates": {
+            "p50": 15.3875,
+            "p95": 15.919849999999999,
+            "mean": 15.3875,
+            "stdev": 0.8365073221436856,
+            "min": 14.796,
+            "max": 15.979,
+            "n": 2
+          },
+          "sourceFile": "realworld-better-auth/pts_realworld-better-auth.xml",
+          "appVersion": "6f3ba45639579da152b69e8e5342e02f28288670",
+          "arguments": "lint_spell"
+        },
+        {
+          "metricId": "realworld_better_auth_task_lint_types",
+          "samples": [187.989, 187.249],
+          "aggregates": {
+            "p50": 187.619,
+            "p95": 187.952,
+            "mean": 187.619,
+            "stdev": 0.5232590180780515,
+            "min": 187.249,
+            "max": 187.989,
+            "n": 2
+          },
+          "sourceFile": "realworld-better-auth/pts_realworld-better-auth.xml",
+          "appVersion": "6f3ba45639579da152b69e8e5342e02f28288670",
+          "arguments": "lint_types"
+        },
+        {
+          "metricId": "realworld_better_auth_task_typecheck",
+          "samples": [3.288, 3.447],
+          "aggregates": {
+            "p50": 3.3674999999999997,
+            "p95": 3.43905,
+            "mean": 3.3674999999999997,
+            "stdev": 0.1124299782086614,
+            "min": 3.288,
+            "max": 3.447,
+            "n": 2
+          },
+          "sourceFile": "realworld-better-auth/pts_realworld-better-auth.xml",
+          "appVersion": "6f3ba45639579da152b69e8e5342e02f28288670",
+          "arguments": "typecheck"
+        },
+        {
+          "metricId": "realworld_mastra_task_build_core",
+          "samples": [207.877, 203.39],
+          "aggregates": {
+            "p50": 205.6335,
+            "p95": 207.65265,
+            "mean": 205.6335,
+            "stdev": 3.172788127184055,
+            "min": 203.39,
+            "max": 207.877,
+            "n": 2
+          },
+          "sourceFile": "realworld-mastra/pts_realworld-mastra.xml",
+          "appVersion": "b6eeb9d08ebeaf27bc6fd16b6b88087040aaf767",
+          "arguments": "build_core"
+        },
+        {
+          "metricId": "realworld_mastra_task_cold_install",
+          "samples": [70.361, 70.283],
+          "aggregates": {
+            "p50": 70.322,
+            "p95": 70.3571,
+            "mean": 70.322,
+            "stdev": 0.0551543289325528,
+            "min": 70.283,
+            "max": 70.361,
+            "n": 2
+          },
+          "sourceFile": "realworld-mastra/pts_realworld-mastra.xml",
+          "appVersion": "b6eeb9d08ebeaf27bc6fd16b6b88087040aaf767",
+          "arguments": "cold_install"
+        },
+        {
+          "metricId": "realworld_mastra_task_git_clone",
+          "samples": [10.108, 10.545],
+          "aggregates": {
+            "p50": 10.3265,
+            "p95": 10.52315,
+            "mean": 10.3265,
+            "stdev": 0.3090056633785215,
+            "min": 10.108,
+            "max": 10.545,
+            "n": 2
+          },
+          "sourceFile": "realworld-mastra/pts_realworld-mastra.xml",
+          "appVersion": "b6eeb9d08ebeaf27bc6fd16b6b88087040aaf767",
+          "arguments": "git_clone"
+        },
+        {
+          "metricId": "realworld_mastra_task_lint_format",
+          "samples": [201.02, 212.119],
+          "aggregates": {
+            "p50": 206.5695,
+            "p95": 211.56405,
+            "mean": 206.5695,
+            "stdev": 7.848178164389483,
+            "min": 201.02,
+            "max": 212.119,
+            "n": 2
+          },
+          "sourceFile": "realworld-mastra/pts_realworld-mastra.xml",
+          "appVersion": "b6eeb9d08ebeaf27bc6fd16b6b88087040aaf767",
+          "arguments": "lint_format"
+        },
+        {
+          "metricId": "sqlite_speedtest_seconds",
+          "samples": [574.989, 504.878],
+          "aggregates": {
+            "p50": 539.9335,
+            "p95": 571.4834500000001,
+            "mean": 539.9335,
+            "stdev": 49.575963535770086,
+            "min": 504.878,
+            "max": 574.989,
+            "n": 2
+          },
+          "sourceFile": "system/pts_sqlite-speedtest.xml",
+          "appVersion": "3.30"
+        },
+        {
+          "metricId": "stream_type_add",
+          "samples": [51061.7, 47414],
+          "aggregates": {
+            "p50": 49237.85,
+            "p95": 50879.314999999995,
+            "mean": 49237.85,
+            "stdev": 2579.313405734167,
+            "min": 47414,
+            "max": 51061.7,
+            "n": 2
+          },
+          "sourceFile": "memory/pts_stream.xml",
+          "appVersion": "2013-01-17",
+          "arguments": "Add"
+        },
+        {
+          "metricId": "stream_type_copy",
+          "samples": [61908.2, 63111.4],
+          "aggregates": {
+            "p50": 62509.8,
+            "p95": 63051.24,
+            "mean": 62509.8,
+            "stdev": 850.7908791236546,
+            "min": 61908.2,
+            "max": 63111.4,
+            "n": 2
+          },
+          "sourceFile": "memory/pts_stream.xml",
+          "appVersion": "2013-01-17",
+          "arguments": "Copy"
+        },
+        {
+          "metricId": "stream_type_scale",
+          "samples": [40859.4, 35063.1],
+          "aggregates": {
+            "p50": 37961.25,
+            "p95": 40569.585,
+            "mean": 37961.25,
+            "stdev": 4098.603035791588,
+            "min": 35063.1,
+            "max": 40859.4,
+            "n": 2
+          },
+          "sourceFile": "memory/pts_stream.xml",
+          "appVersion": "2013-01-17",
+          "arguments": "Scale"
+        },
+        {
+          "metricId": "stream_type_triad",
+          "samples": [47777.6, 44678.3],
+          "aggregates": {
+            "p50": 46227.95,
+            "p95": 47622.634999999995,
+            "mean": 46227.95,
+            "stdev": 2191.536046931466,
+            "min": 44678.3,
+            "max": 47777.6,
+            "n": 2
+          },
+          "sourceFile": "memory/pts_stream.xml",
+          "appVersion": "2013-01-17",
+          "arguments": "Triad"
+        },
+        {
+          "metricId": "usd_per_hour",
+          "samples": [0.47736],
+          "aggregates": {
+            "p50": 0.47736,
+            "p95": 0.47736,
+            "mean": 0.47736,
+            "stdev": 0,
+            "min": 0.47736,
+            "max": 0.47736,
+            "n": 1
+          }
+        }
+      ],
+      "suitesCovered": [
+        "cpu-node",
+        "disk",
+        "memory",
+        "network",
+        "realworld-better-auth",
+        "realworld-mastra",
+        "system"
+      ],
+      "gaps": [
+        {
+          "scope": "suite",
+          "id": "cpu-generic",
+          "outcome": "failed",
+          "reason": "Step \"mise run benchmark:cpu:generic\" timed out after 7800s"
+        },
+        {
+          "scope": "suite",
+          "id": "realworld-openclaw",
+          "outcome": "failed",
+          "reason": "Step \"mise run benchmark:realworld:pts:openclaw\" timed out after 8400s"
+        }
+      ],
+      "uncatalogued": []
+    },
+    {
+      "providerId": "novita",
+      "validationStatus": "pending",
+      "observedSpecs": {},
+      "metrics": [],
+      "suitesCovered": [],
+      "gaps": [],
+      "uncatalogued": []
+    }
+  ]
+}


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Publish new dataset run 29472826358 and regenerate the leaderboard with updated results. Adds the run JSON (schema v2), updates the dataset index, and reflects 49 metrics across 4 providers backed by 288 retained observations.

<sup>Written for commit 5fd27b7acffb133cad13f74bfe7ade7c2dbf8f83. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/starslingdev/sandbox-benchmarks/pull/187?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

