### PR TITLE
bench: add blob and git PTS coverage

### DIFF
--- a/.github/workflows/bench-matrix.yml
+++ b/.github/workflows/bench-matrix.yml
@@ -2,8 +2,10 @@ name: Bench matrix
 
 # Fan the live benchmark out across the full provider × suite matrix: one job per (provider, suite)
 # cell, each spinning up a real sandbox, running its suite, and uploading the normalized Run as an
-# artifact. The matrix is computed from the SUITES × PROVIDERS registries by `plan-matrix` — adding a
-# provider or suite to its registry grows CI with no workflow edit. Off the PR path (real sandbox time
+# artifact. The matrix is computed from the SUITES × PROVIDERS registries by `plan-matrix`; each suite
+# cell runs all of its registered leaves (for example, system runs pts/git and network runs
+# pts/fast-cli), rather than giving each PTS profile its own row. Adding a provider or suite to its
+# registry grows CI with no workflow edit. Off the PR path (real sandbox time
 # + provider credentials); dispatch on demand from main only, gated by Environment `privileged`
 # (required reviewers + environment secrets — see docs/ci-secrets.md).
 on:

--- a/.github/workflows/bench-matrix.yml
+++ b/.github/workflows/bench-matrix.yml
@@ -5,9 +5,10 @@ name: Bench matrix
 # artifact. The matrix is computed from the SUITES × PROVIDERS registries by `plan-matrix`; each suite
 # cell runs all of its registered leaves (for example, system runs pts/git and network runs
 # pts/fast-cli), rather than giving each PTS profile its own row. Adding a provider or suite to its
-# registry grows CI with no workflow edit. Off the PR path (real sandbox time
-# + provider credentials); dispatch on demand from main only, gated by Environment `privileged`
-# (required reviewers + environment secrets — see docs/ci-secrets.md).
+# registry grows CI with no workflow edit. Off the PR path (real sandbox time + provider credentials);
+# main is the default, while an explicit allow_branch dispatch supports pre-merge validation. Every
+# benchmark cell remains gated by Environment `privileged` (required reviewers + environment secrets
+# — see docs/ci-secrets.md), and publishing stays main-only.
 on:
   workflow_dispatch:
     inputs:
@@ -20,6 +21,11 @@ on:
         # of runner time per suite on cells that cannot produce a comparable result. Pass it explicitly
         # to include it; `plan-matrix` rejects any name that is not in the registry.
         default: e2b,daytona,modal
+      allow_branch:
+        description: 'Allow benchmark cells on a non-main ref (publish remains main-only).'
+        required: false
+        type: boolean
+        default: false
 
 # Least privilege: jobs only read the checked-out code and upload artifacts (publish elevates).
 permissions:
@@ -33,12 +39,12 @@ concurrency:
 jobs:
   # Compute the provider × suite matrix once, as the single $GITHUB_OUTPUT contract the fan-out reads.
   # No secrets — plan stays off the privileged environment so approval isn't needed just to dry-run
-  # the matrix shape; the gate below still confines dispatch to this repo's main.
+  # the matrix shape; a non-main run requires the explicit dispatch opt-in below.
   plan:
     name: Plan matrix
     if: >
-      github.ref == 'refs/heads/main' &&
-      github.repository == 'starslingdev/sandbox-benchmarks'
+      github.repository == 'starslingdev/hpc-sandbox-benchmarks' &&
+      (github.ref == 'refs/heads/main' || inputs.allow_branch)
     runs-on: ubuntu-24.04
     outputs:
       matrix: ${{ steps.plan.outputs.matrix }}
@@ -73,8 +79,8 @@ jobs:
     name: ${{ matrix.suite }} on ${{ matrix.provider }}
     needs: plan
     if: >
-      github.ref == 'refs/heads/main' &&
-      github.repository == 'starslingdev/sandbox-benchmarks'
+      github.repository == 'starslingdev/hpc-sandbox-benchmarks' &&
+      (github.ref == 'refs/heads/main' || inputs.allow_branch)
     # The ephemeral self-hosted label is reaped after 70 minutes even while a step is healthy. The
     # full CPU-generic and real-world matrices legitimately exceed that on slower providers, leaving
     # the step stuck `in_progress` with no logs/artifact. Hosted runners honor timeout-minutes below;
@@ -158,7 +164,7 @@ jobs:
       !cancelled() &&
       needs.plan.result == 'success' &&
       github.ref == 'refs/heads/main' &&
-      github.repository == 'starslingdev/sandbox-benchmarks'
+      github.repository == 'starslingdev/hpc-sandbox-benchmarks'
     # Grant the reusable workflow the token scopes it needs: commit/push the dataset (contents), open
     # the PR (pull-requests), and download this run's shard artifacts by run-id (actions: read).
     permissions:

--- a/.github/workflows/bench-smoke.yml
+++ b/.github/workflows/bench-smoke.yml
@@ -48,7 +48,7 @@ jobs:
     name: ${{ inputs.suite }} on ${{ inputs.provider }}
     if: >
       github.ref == 'refs/heads/main' &&
-      github.repository == 'starslingdev/sandbox-benchmarks'
+      github.repository == 'starslingdev/hpc-sandbox-benchmarks'
     # The ephemeral self-hosted label is reaped after 70 minutes, while this dispatch exposes suites
     # with a 155-minute sandbox budget. Match the matrix's hosted runner and leave job-level margin
     # for checkout, sandbox teardown, normalization, and artifact upload.

--- a/.github/workflows/publish-dataset.yml
+++ b/.github/workflows/publish-dataset.yml
@@ -41,7 +41,7 @@ jobs:
     # (Environment `privileged`'s deployment-branch policy pins it to main too; this is defense in depth.)
     if: >
       github.ref == 'refs/heads/main' &&
-      github.repository == 'starslingdev/sandbox-benchmarks'
+      github.repository == 'starslingdev/hpc-sandbox-benchmarks'
     runs-on: ubuntu-24.04
     environment: privileged
     # contents: write to commit + push the dataset branch; pull-requests: write to open the PR;

--- a/.github/workflows/toolchain-image.yml
+++ b/.github/workflows/toolchain-image.yml
@@ -129,7 +129,7 @@ jobs:
     if: >
       github.event_name == 'workflow_dispatch' &&
       github.ref == 'refs/heads/main' &&
-      github.repository == 'starslingdev/sandbox-benchmarks'
+      github.repository == 'starslingdev/hpc-sandbox-benchmarks'
     runs-on: starsling-ubuntu-24.04-2
     # Validation + one registry probe; it should take a minute. A hang means the registry is wedged.
     timeout-minutes: 15
@@ -383,7 +383,7 @@ jobs:
       needs.plan.outputs.skip != 'true' &&
       github.event_name == 'workflow_dispatch' &&
       github.ref == 'refs/heads/main' &&
-      github.repository == 'starslingdev/sandbox-benchmarks'
+      github.repository == 'starslingdev/hpc-sandbox-benchmarks'
     runs-on: starsling-ubuntu-24.04-2
     environment: privileged
     # Re-validates the candidate and promotes across all five providers SERIALLY (it is a transaction,

--- a/.mise/tasks/benchmark/network/all
+++ b/.mise/tasks/benchmark/network/all
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-#MISE description="Run network benchmarks (PTS loopback TCP + latency/DNS/download probes)"
+#MISE description="Run network benchmarks (PTS loopback + fast.com throughput/latency + probes)"
 # Orchestrator: no -e — run_task isolates child failures and summary reports them at the end
 # (error-mode conventions: lib/bench.sh).
 set -uo pipefail
@@ -15,9 +15,11 @@ echo "========================================"
 ensure_pts || true
 
 run_task benchmark:network:pts:loopback
+run_task benchmark:network:pts:fast-cli
 
 # Tolerant probes (raw JSON provenance, no catalogued metrics): where does this sandbox's traffic
-# actually go, and how fast? Egress latency, resolver behavior, and real-world download timing.
+# actually go, and how fast? fast-cli above is the sustained real-world transfer; these probes retain
+# endpoint-specific connection timings and a small GitHub control transfer for diagnosis.
 run_task benchmark:network:latency
 run_task benchmark:network:dns
 run_task benchmark:network:download

--- a/.mise/tasks/benchmark/network/pts/fast-cli
+++ b/.mise/tasks/benchmark/network/pts/fast-cli
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+#MISE description="PTS: sustained Internet download/upload throughput and latency via fast.com"
+# Measurement leaf: -e guards the scaffolding; the measured run is isolated by run_pts_benchmark.
+set -euo pipefail
+REPO_ROOT="$(git -C "$(dirname "${BASH_SOURCE[0]}")" rev-parse --show-toplevel)"
+source "${REPO_ROOT}/lib/bench.sh"
+
+if ! command -v phoronix-test-suite &>/dev/null; then
+	skip_result "phoronix-test-suite not installed" "pts_fast-cli"
+	exit 0
+fi
+
+# Version-pinned to the vendored definition/catalog and pre-installed in the toolchain image. The
+# installed fast-cli package performs sustained transfers through Netflix's fast.com CDN and emits
+# download/upload throughput plus idle/loaded latency from one JSON-producing invocation.
+run_pts_benchmark "pts/fast-cli-1.0.0" "pts_fast-cli"

--- a/.mise/tasks/benchmark/system/all
+++ b/.mise/tasks/benchmark/system/all
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-#MISE description="Run system benchmarks (provider identity probe + PTS PyBench, SQLite Speedtest, pgbench)"
+#MISE description="Run system benchmarks (provider identity + PTS PyBench, SQLite, pgbench, Git)"
 # Orchestrator: no -e — run_task isolates child failures and summary reports them at the end
 # (error-mode conventions: lib/bench.sh).
 set -uo pipefail
@@ -23,5 +23,6 @@ run_task benchmark:system:provider
 run_task benchmark:system:pts:pybench
 run_task benchmark:system:pts:sqlite-speedtest
 run_task benchmark:system:pts:pgbench
+run_task benchmark:system:pts:git
 
 summary

--- a/.mise/tasks/benchmark/system/pts/git
+++ b/.mise/tasks/benchmark/system/pts/git
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+#MISE description="PTS: common Git operations against a fixed GTK repository"
+# Measurement leaf: -e guards the scaffolding; the measured run is isolated by run_pts_benchmark.
+set -euo pipefail
+REPO_ROOT="$(git -C "$(dirname "${BASH_SOURCE[0]}")" rev-parse --show-toplevel)"
+source "${REPO_ROOT}/lib/bench.sh"
+
+if ! command -v phoronix-test-suite &>/dev/null; then
+	skip_result "phoronix-test-suite not installed" "pts_git"
+	exit 0
+fi
+
+# The matrix used to carry only an old pts_git skip fixture: no registered suite actually invoked
+# the profile. Pin the vendored version so its GTK corpus and command sequence cannot drift.
+run_pts_benchmark "pts/git-1.1.0" "pts_git"

--- a/docs/ci-secrets.md
+++ b/docs/ci-secrets.md
@@ -29,7 +29,9 @@ Ungated: `ci.yml`, `ci-lint.yml`, and the toolchain `pr-gate` (Docker smoke, no 
 1. **No publish on merge.** Toolchain GHCR promote is `workflow_dispatch` only (never `push`).
 2. **Main only, this repo only.** Privileged jobs require
    `github.ref == 'refs/heads/main'` and
-   `github.repository == 'starslingdev/sandbox-benchmarks'`.
+   `github.repository == 'starslingdev/hpc-sandbox-benchmarks'`. The benchmark matrix additionally
+   permits an explicitly opted-in non-main dispatch for pre-merge validation; those cells still
+   require `privileged` approval, and dataset publishing remains main-only.
 3. **Environment approval.** `privileged` must require at least one reviewer and restrict
    deployments to the `main` branch. Write access alone cannot finish a release.
 4. **Fork PRs.** Same-repo guard on self-hosted PR jobs; fork PR code never runs on

--- a/lib/bench.sh
+++ b/lib/bench.sh
@@ -499,12 +499,25 @@ run_pts_benchmark() {
 	if [ -n "$xml_found" ] && [ -f "$xml_found" ]; then
 		cp "$xml_found" "$(results_dir)/${prefix}.xml" 2>/dev/null || true
 		echo "Structured result: ${prefix}.xml (from $(dirname "$xml_found"))"
+		# Preserve PTS's own structured system record too. composite.xml carries Hardware/Software as
+		# comma-delimited prose; result-file-to-json expands those into component maps and also retains
+		# PTS's timestamp, client version, user, notes and collected JSON data. OUTPUT_FILE is an exact
+		# path in PTS 10.8.4, so every leaf gets a deterministic sibling that cannot collide with the
+		# metric XML predicate. Metadata export is provenance: warn but do not void a valid benchmark if
+		# an older/partial PTS install lacks the command.
+		local result_dir pts_metadata_file
+		result_dir="$(dirname "$xml_found")"
+		pts_metadata_file="$(results_dir)/${prefix}--metadata.json"
+		if OUTPUT_FILE="$pts_metadata_file" phoronix-test-suite result-file-to-json "$(basename "$result_dir")" >/dev/null 2>&1 && [ -s "$pts_metadata_file" ]; then
+			echo "Structured host metadata: ${prefix}--metadata.json"
+		else
+			echo "WARNING: PTS structured metadata export failed for ${test_name}" >&2
+			rm -f "$pts_metadata_file"
+		fi
 		# Capture the whole result dir (composite.xml + installation-logs/ + test-logs/) as a forensics
 		# tarball for debugging. A .tar.gz — not a flattened copy — so its nested .xml files can't be
 		# misrouted by the extractor (the name ends --forensics.tar.gz, which isPtsResultFile never
 		# matches). `|| true` so a /var/lib perms hiccup can't abort this `set -e` measurement leaf.
-		local result_dir
-		result_dir="$(dirname "$xml_found")"
 		tar -czf "$(results_dir)/${prefix}--forensics.tar.gz" \
 			-C "$(dirname "$result_dir")" "$(basename "$result_dir")" 2>/dev/null || true
 	else

--- a/packages/results/src/lib/aggregate.test.ts
+++ b/packages/results/src/lib/aggregate.test.ts
@@ -141,6 +141,42 @@ describe("aggregateRuns", () => {
 		expect(daytona?.observedSpecs.hostCpuModels).toBeUndefined();
 	});
 
+	it("unions rich host metadata across shards and removes byte-identical duplicates", () => {
+		const record = {
+			source: "mise/system-provider" as const,
+			sourceFile: "system/system-provider.json",
+			fields: [{ path: "asn", value: "AS64500" }],
+		};
+		const a = shard([
+			{
+				...provider("daytona", [metric("node_web_tooling_runs_per_s", [10])]),
+				hostMetadata: [record],
+			},
+		]);
+		const b = shard([
+			{
+				...provider("daytona", [metric("pybench_milliseconds", [900])]),
+				hostMetadata: [
+					record,
+					{
+						source: "phoronix/result-file-to-json" as const,
+						sourceFile: "system/pts_git--metadata.json",
+						fields: [{ path: "sandbox.hardware.Processor", value: "AMD EPYC" }],
+					},
+				],
+			},
+		]);
+
+		const metadata = aggregateRuns([a, b]).providers.find(
+			(p) => p.providerId === "daytona",
+		)?.hostMetadata;
+		expect(metadata).toHaveLength(2);
+		expect(metadata?.map((m) => m.source)).toEqual([
+			"mise/system-provider",
+			"phoronix/result-file-to-json",
+		]);
+	});
+
 	it("throws on a shard-identity mismatch and on empty input", () => {
 		const a = shard([provider("daytona", [metric("node_web_tooling_runs_per_s", [10])])]);
 		const b: Run = { ...a, sha: "different" };

--- a/packages/results/src/lib/aggregate.ts
+++ b/packages/results/src/lib/aggregate.ts
@@ -10,6 +10,7 @@
  * inconsistent merge fails here rather than reaching a consumer.
  */
 import type {
+	HostMetadataRecord,
 	MetricResult,
 	ObservedSpecs,
 	ProviderRun,
@@ -64,8 +65,16 @@ function mergeProvider(providerId: string, slices: readonly ProviderRun[]): Prov
 	// published Run must disclose. cpuModel is the key (cpuMicroarch is derived from it, so distinct
 	// microarchs can't arise without distinct models); collect the distinct disclosures, publish below.
 	const hostCpuModels = new Set<string>();
+	const hostMetadata: HostMetadataRecord[] = [];
+	const seenHostMetadata = new Set<string>();
 
 	for (const slice of slices) {
+		for (const record of slice.hostMetadata ?? []) {
+			const key = JSON.stringify(record);
+			if (seenHostMetadata.has(key)) continue;
+			seenHostMetadata.add(key);
+			hostMetadata.push(record);
+		}
 		for (const suite of slice.suitesCovered) suitesCovered.add(suite);
 		for (const gap of slice.gaps) {
 			const key = [gap.scope, gap.id, gap.outcome, gap.reason].join(NUL);
@@ -120,6 +129,7 @@ function mergeProvider(providerId: string, slices: readonly ProviderRun[]): Prov
 		validationStatus: metrics.length > 0 ? "validated" : "pending",
 		...(specMatched !== undefined ? { specMatched } : {}),
 		observedSpecs,
+		...(hostMetadata.length > 0 ? { hostMetadata } : {}),
 		metrics,
 		suitesCovered: [...suitesCovered].sort((a, b) => a.localeCompare(b)),
 		gaps,

--- a/packages/results/src/lib/host-metadata.test.ts
+++ b/packages/results/src/lib/host-metadata.test.ts
@@ -1,0 +1,64 @@
+import { afterEach, describe, expect, it } from "bun:test";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { flattenHostMetadata, readHostMetadata } from "./host-metadata.ts";
+
+let dirs: string[] = [];
+afterEach(() => {
+	for (const dir of dirs) rmSync(dir, { recursive: true, force: true });
+	dirs = [];
+});
+
+describe("host metadata", () => {
+	it("flattens nested objects and arrays deterministically without dropping null/false/zero", () => {
+		expect(flattenHostMetadata({ z: null, a: { list: [0, false, "x"] } })).toEqual([
+			{ path: "a.list.0", value: "0" },
+			{ path: "a.list.1", value: "false" },
+			{ path: "a.list.2", value: "x" },
+			{ path: "z", value: "null" },
+		]);
+	});
+
+	it("retains the full mise provider record and only PTS's structured systems block", () => {
+		const dir = mkdtempSync(join(tmpdir(), "host-metadata-"));
+		dirs.push(dir);
+		writeFileSync(
+			join(dir, "system-provider.json"),
+			JSON.stringify({ asn: "AS64500", manufacturer: "Amazon EC2" }),
+		);
+		writeFileSync(
+			join(dir, "pts_git--metadata.json"),
+			JSON.stringify({
+				systems: {
+					sandbox: {
+						hardware: { Processor: "AMD EPYC", Motherboard: "Amazon EC2" },
+						data: { "cpu-smt": "2" },
+					},
+				},
+				results: { huge: "metric payload is owned elsewhere" },
+			}),
+		);
+
+		const records = readHostMetadata(dir);
+		expect(records).toHaveLength(2);
+		expect(records[0]).toEqual({
+			source: "phoronix/result-file-to-json",
+			sourceFile: "pts_git--metadata.json",
+			fields: [
+				{ path: "sandbox.data.cpu-smt", value: "2" },
+				{ path: "sandbox.hardware.Motherboard", value: "Amazon EC2" },
+				{ path: "sandbox.hardware.Processor", value: "AMD EPYC" },
+			],
+		});
+		expect(records[1]).toEqual({
+			source: "mise/system-provider",
+			sourceFile: "system-provider.json",
+			fields: [
+				{ path: "asn", value: "AS64500" },
+				{ path: "manufacturer", value: "Amazon EC2" },
+			],
+		});
+		expect(records.flatMap((r) => r.fields).some((f) => f.path.startsWith("results"))).toBe(false);
+	});
+});

--- a/packages/results/src/lib/host-metadata.ts
+++ b/packages/results/src/lib/host-metadata.ts
@@ -1,0 +1,69 @@
+/**
+ * Preserve rich host metadata emitted by the producer without baking either source's evolving key
+ * vocabulary into the Run schema. Values are flattened to stable path/string pairs: this keeps the
+ * output queryable and byte-stable while retaining every scalar from the original structured JSON.
+ */
+import type { Dirent } from "node:fs";
+import { readdirSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+import type { HostMetadataField, HostMetadataRecord } from "@sandbox-benchmarks/schema";
+
+const PTS_METADATA_FILE = /^pts_.+--metadata\.json$/;
+
+function parseJson(path: string): unknown {
+	try {
+		return JSON.parse(readFileSync(path, "utf8"));
+	} catch {
+		return undefined;
+	}
+}
+
+/** Flatten every JSON scalar, including null and array positions, in lexical object-key order. */
+export function flattenHostMetadata(value: unknown, prefix = ""): HostMetadataField[] {
+	if (Array.isArray(value)) {
+		return value.flatMap((item, index) =>
+			flattenHostMetadata(item, prefix ? `${prefix}.${index}` : String(index)),
+		);
+	}
+	if (value !== null && typeof value === "object") {
+		return Object.entries(value as Record<string, unknown>)
+			.sort(([a], [b]) => a.localeCompare(b, "en"))
+			.flatMap(([key, child]) => flattenHostMetadata(child, prefix ? `${prefix}.${key}` : key));
+	}
+	if (!prefix) return [];
+	return [{ path: prefix, value: value === null ? "null" : String(value) }];
+}
+
+/** Read the repo's provider probe and PTS native System JSON siblings from one result directory. */
+export function readHostMetadata(dir: string): HostMetadataRecord[] {
+	let entries: Dirent[];
+	try {
+		entries = readdirSync(dir, { withFileTypes: true });
+	} catch {
+		return [];
+	}
+
+	const records: HostMetadataRecord[] = [];
+	for (const entry of entries.sort((a, b) => a.name.localeCompare(b.name, "en"))) {
+		if (!entry.isFile()) continue;
+		let source: HostMetadataRecord["source"] | undefined;
+		if (entry.name === "system-provider.json") source = "mise/system-provider";
+		else if (PTS_METADATA_FILE.test(entry.name)) source = "phoronix/result-file-to-json";
+		if (!source) continue;
+
+		const parsed = parseJson(join(dir, entry.name));
+		if (parsed === undefined) continue;
+		// PTS's export also contains every benchmark result. Retain only its native `systems` block:
+		// metrics already have a typed owner, while systems is the rich host provenance this path owns.
+		const metadata =
+			source === "phoronix/result-file-to-json" &&
+			parsed !== null &&
+			typeof parsed === "object" &&
+			!Array.isArray(parsed)
+				? (parsed as Record<string, unknown>).systems
+				: parsed;
+		const fields = flattenHostMetadata(metadata);
+		if (fields.length > 0) records.push({ source, sourceFile: entry.name, fields });
+	}
+	return records;
+}

--- a/packages/results/src/lib/normalize-tree.test.ts
+++ b/packages/results/src/lib/normalize-tree.test.ts
@@ -9,7 +9,7 @@ import {
 } from "@sandbox-benchmarks/schema";
 import { normalizeProviderDir } from "./normalize-tree.ts";
 
-// A composite carrying a catalogued node-web-tooling result plus an uncatalogued pts/git result.
+// A composite carrying a catalogued node-web-tooling result plus an uncatalogued synthetic result.
 // `samples` lets a second file diverge so we can prove the contamination-vs-benign distinction.
 function composite(samples: string): string {
 	return `<?xml version="1.0"?>
@@ -22,8 +22,8 @@ function composite(samples: string): string {
     <Data><Entry><Value>10.5</Value><RawString>${samples}</RawString></Entry></Data>
   </Result>
   <Result>
-    <Identifier>pts/git-1.1.0</Identifier>
-    <Title>Git</Title>
+    <Identifier>pts/not-in-catalog-1.0.0</Identifier>
+    <Title>Not In Catalog</Title>
     <Scale>Seconds</Scale><Proportion>LIB</Proportion>
     <Data><Entry><Value>54.27</Value></Entry></Data>
   </Result>
@@ -44,7 +44,7 @@ describe("normalizeProviderDir de-dupes a metric leaked into two composites", ()
 	});
 
 	it("keeps one copy and does NOT pool samples across files (no inflated n)", () => {
-		// Both files carry the same node-web-tooling + git result — the exact TEST_RESULTS_NAME-reuse
+		// Both files carry the same node-web-tooling + straggler — the exact TEST_RESULTS_NAME-reuse
 		// contamination seen in real PTS output. Pooling would give n=6 and a fabricated stddev.
 		writeFileSync(join(providerDir, "pts_compress_zstd.xml"), composite("10.5:10.6:10.4"));
 		writeFileSync(join(providerDir, "pts_node-web-tooling.xml"), composite("10.5:10.6:10.4"));
@@ -57,8 +57,8 @@ describe("normalizeProviderDir de-dupes a metric leaked into two composites", ()
 		const metric = matches[0];
 		expect(metric?.samples).toEqual([10.5, 10.6, 10.4]);
 		expect(metric?.aggregates.n).toBe(3);
-		// The uncatalogued git straggler is collapsed to a single entry too.
-		expect(run.uncatalogued.filter((u) => u.id.startsWith("pts/git"))).toHaveLength(1);
+		// The uncatalogued straggler is collapsed to a single entry too.
+		expect(run.uncatalogued.filter((u) => u.id.startsWith("pts/not-in-catalog"))).toHaveLength(1);
 	});
 
 	it("warns loudly when the duplicate's samples diverge (real contamination, not a rewrite)", () => {
@@ -97,12 +97,38 @@ describe("normalizeProviderDir reads the suite-tagged layout", () => {
 		const metric = run.metrics.find((m) => m.metricId === "node_web_tooling_runs_per_s");
 		// sourceFile is prefixed with the suite so a number stays traceable to the suite that wrote it.
 		expect(metric?.sourceFile).toBe("cpu-node/pts_node-web-tooling.xml");
-		// The git result is still an inert straggler, also suite-tagged.
+		// The synthetic result is still an inert straggler, also suite-tagged.
 		expect(run.uncatalogued.map((u) => u.sourceFile)).toEqual([
 			"cpu-node/pts_node-web-tooling.xml",
 		]);
 		// observed-specs.json is read from the suite subdirectory (per-sandbox), not just the provider dir.
 		expect(run.observedSpecs.vcpus).toBe(4);
+	});
+
+	it("retains suite-tagged mise and PTS host records in the normalized provider", () => {
+		const suiteDir = join(providerDir, "system");
+		mkdirSync(suiteDir);
+		writeFileSync(
+			join(suiteDir, "system-provider.json"),
+			JSON.stringify({ asn: "AS64500", manufacturer: "Amazon EC2" }),
+		);
+		writeFileSync(
+			join(suiteDir, "pts_git--metadata.json"),
+			JSON.stringify({ systems: { sandbox: { hardware: { Processor: "AMD EPYC" } } } }),
+		);
+
+		const run = normalizeProviderDir(root, "daytona");
+		expect(run.observedSpecs).toMatchObject({
+			egressAsn: "AS64500",
+			manufacturer: "Amazon EC2",
+		});
+		expect(run.hostMetadata?.map(({ source, sourceFile }) => ({ source, sourceFile }))).toEqual([
+			{
+				source: "phoronix/result-file-to-json",
+				sourceFile: "system/pts_git--metadata.json",
+			},
+			{ source: "mise/system-provider", sourceFile: "system/system-provider.json" },
+		]);
 	});
 
 	it("records suitesCovered from the metrics a suite produced, not from the directory existing", () => {

--- a/packages/results/src/lib/normalize-tree.ts
+++ b/packages/results/src/lib/normalize-tree.ts
@@ -7,6 +7,7 @@
 import { readdirSync, readFileSync, statSync } from "node:fs";
 import { join } from "node:path";
 import type {
+	HostMetadataRecord,
 	MetricResult,
 	ObservedSpecs,
 	OffDimensionEmission,
@@ -28,6 +29,7 @@ import {
 } from "@sandbox-benchmarks/schema";
 import type { SampleContribution } from "./extract.ts";
 import { extractProviderDir } from "./extract.ts";
+import { readHostMetadata } from "./host-metadata.ts";
 import { computeSpecMatched, readObservedSpecs } from "./specs.ts";
 
 export interface NormalizeInput {
@@ -138,12 +140,16 @@ export function normalizeProviderDir(rawRoot: string, providerId: string): Provi
 	// directory instead of the metrics would hide exactly that case.
 	const suitesCovered = new Set<string>();
 	const offDimension: OffDimensionEmission[] = [];
+	const hostMetadata: HostMetadataRecord[] = [];
 	// Host fingerprint from a composite's <System>, first non-empty across the read order (all suites of
 	// one provider ran on the same machine). Merged UNDER the spec probe below so the probe always wins.
 	let systemHost: ObservedSpecs | undefined;
 
 	for (const suite of suiteDirs) {
 		const ext = extractProviderDir(join(dir, suite), providerId);
+		for (const record of readHostMetadata(join(dir, suite))) {
+			hostMetadata.push({ ...record, sourceFile: `${suite}/${record.sourceFile}` });
+		}
 		if (!systemHost && ext.observedHost) systemHost = ext.observedHost;
 		// Runtime half of the contract: collect any catalogued metric this suite emitted on a Dimension it
 		// does not declare. (Uncatalogued emissions are NOT breaches — they stay inert stragglers below.)
@@ -177,6 +183,7 @@ export function normalizeProviderDir(rawRoot: string, providerId: string): Provi
 	// flat therefore claims no suite coverage, which correctly makes the derived missing-suite gaps
 	// empty (nothing is known to have run anywhere) rather than accusing every provider of a hole.
 	const flat = extractProviderDir(dir, providerId);
+	hostMetadata.push(...readHostMetadata(dir));
 	contributions.push(...flat.contributions);
 	rawUncatalogued.push(...flat.uncatalogued);
 	gaps.push(...flat.gaps);
@@ -280,6 +287,7 @@ export function normalizeProviderDir(rawRoot: string, providerId: string): Provi
 		validationStatus: metrics.length > 0 ? "validated" : "pending",
 		...(specMatched !== undefined ? { specMatched } : {}),
 		observedSpecs,
+		...(hostMetadata.length > 0 ? { hostMetadata } : {}),
 		metrics,
 		suitesCovered: [...suitesCovered].sort((a, b) => a.localeCompare(b)),
 		gaps,

--- a/packages/results/src/lib/pts.test.ts
+++ b/packages/results/src/lib/pts.test.ts
@@ -17,7 +17,7 @@ const realFixture = readFileSync(
 );
 
 // A two-result composite (as a batch run produces): proves Result stays an array, and exercises an
-// uncatalogued result (pts/git is not in this slice's Catalog) alongside the catalogued one.
+// uncatalogued synthetic result alongside the catalogued one.
 const multiResultXml = `<?xml version="1.0"?>
 <PhoronixTestSuite>
   <Generated><TestClient>phoronix-test-suite/10.8.4</TestClient></Generated>
@@ -29,8 +29,8 @@ const multiResultXml = `<?xml version="1.0"?>
     <Data><Entry><Value>20.5</Value><RawString>20.5</RawString></Entry></Data>
   </Result>
   <Result>
-    <Identifier>pts/git-1.1.0</Identifier>
-    <Title>Git</Title>
+    <Identifier>pts/not-in-catalog-1.0.0</Identifier>
+    <Title>Not In Catalog</Title>
     <Scale>Seconds</Scale>
     <Proportion>LIB</Proportion>
     <Data><Entry><Value>4.2</Value></Entry></Data>
@@ -95,8 +95,8 @@ describe("resultSamples", () => {
 	});
 
 	it("falls back to the single Value when RawString is absent", () => {
-		const git = parsePtsComposite(multiResultXml).PhoronixTestSuite.Result[1];
-		expect(git && resultSamples(git)).toEqual([4.2]);
+		const unknown = parsePtsComposite(multiResultXml).PhoronixTestSuite.Result[1];
+		expect(unknown && resultSamples(unknown)).toEqual([4.2]);
 	});
 
 	it("retains legitimate zero-valued samples (filters non-finite/negative, not zero)", () => {
@@ -138,10 +138,10 @@ describe("ptsResultToMetric", () => {
 	});
 
 	it("returns an uncatalogued mapping for a result with no catalogued Metric", () => {
-		const git = parsePtsComposite(multiResultXml).PhoronixTestSuite.Result[1];
-		expect(git && ptsResultToMetric(git)).toEqual({
+		const unknown = parsePtsComposite(multiResultXml).PhoronixTestSuite.Result[1];
+		expect(unknown && ptsResultToMetric(unknown)).toEqual({
 			kind: "uncatalogued",
-			test: "pts/git",
+			test: "pts/not-in-catalog",
 			description: "",
 			scale: "Seconds",
 		});

--- a/packages/results/src/lib/specs.test.ts
+++ b/packages/results/src/lib/specs.test.ts
@@ -104,6 +104,58 @@ describe("readObservedSpecs: observed-specs.json (harness-written, primary)", ()
 	});
 });
 
+describe("readObservedSpecs: system-provider.json rich identity projection", () => {
+	it("projects every queryable ASN/geo/DMI field and lets observed-specs stay authoritative", () => {
+		const specs = readObservedSpecs(
+			reader({
+				"system-provider.json": {
+					public_ip: "203.0.113.8",
+					org: "AS64500 Example Network",
+					asn: "AS64500",
+					org_name: "Example Network",
+					reverse_dns: "sandbox.example",
+					city: "Portland",
+					region: "Oregon",
+					country: "US",
+					loc: "45.52,-122.68",
+					timezone: "America/Los_Angeles",
+					manufacturer: "Amazon EC2",
+					product_name: "c7a.large",
+					bios_vendor: "Amazon EC2",
+					virtualization: "kvm",
+					cpu_model: "provider fallback",
+					kernel: "provider-kernel",
+					prefix: "203.0.113.0/24",
+					asn_source: "cymru",
+					geo_source: "ipinfo",
+				},
+				"observed-specs.json": { cpuModel: "direct model", kernel: "direct-kernel" },
+			}),
+		);
+		expect(specs).toMatchObject({
+			publicIp: "203.0.113.8",
+			egressOrg: "AS64500 Example Network",
+			egressAsn: "AS64500",
+			egressOrgName: "Example Network",
+			reverseDns: "sandbox.example",
+			city: "Portland",
+			region: "Oregon",
+			country: "US",
+			location: "45.52,-122.68",
+			timezone: "America/Los_Angeles",
+			manufacturer: "Amazon EC2",
+			productName: "c7a.large",
+			biosVendor: "Amazon EC2",
+			virtualization: "kvm",
+			cpuModel: "direct model",
+			kernel: "direct-kernel",
+			networkPrefix: "203.0.113.0/24",
+			asnSource: "cymru",
+			geoSource: "ipinfo",
+		});
+	});
+});
+
 describe("readObservedSpecs: jc probe fallback (real fixtures)", () => {
 	it("assembles vcpus/cpuModel/virtualization, memoryGb, kernel and diskGb from the four probes", () => {
 		const specs = readObservedSpecs(fixtureReader(PROBE_FILES));

--- a/packages/results/src/lib/specs.ts
+++ b/packages/results/src/lib/specs.ts
@@ -25,6 +25,28 @@ const NUMERIC_FIELDS = [
 ] as const;
 const STRING_FIELDS = ["cpuModel", "kernel", "os", "virtualization", "user"] as const;
 
+const PROVIDER_STRING_FIELDS = {
+	public_ip: "publicIp",
+	org: "egressOrg",
+	asn: "egressAsn",
+	org_name: "egressOrgName",
+	reverse_dns: "reverseDns",
+	city: "city",
+	region: "region",
+	country: "country",
+	loc: "location",
+	timezone: "timezone",
+	manufacturer: "manufacturer",
+	product_name: "productName",
+	bios_vendor: "biosVendor",
+	virtualization: "virtualization",
+	cpu_model: "cpuModel",
+	kernel: "kernel",
+	prefix: "networkPrefix",
+	asn_source: "asnSource",
+	geo_source: "geoSource",
+} as const satisfies Record<string, keyof ObservedSpecs>;
+
 function fromObservedSpecsFile(raw: Record<string, unknown>): ObservedSpecs {
 	const specs: ObservedSpecs = {};
 	for (const key of NUMERIC_FIELDS) {
@@ -34,6 +56,16 @@ function fromObservedSpecsFile(raw: Record<string, unknown>): ObservedSpecs {
 	for (const key of STRING_FIELDS) {
 		const value = str(raw[key]);
 		if (value !== undefined) specs[key] = value;
+	}
+	return specs;
+}
+
+/** Convenience projection of the rich system-provider record onto commonly queried Run fields. */
+function fromProviderFile(raw: Record<string, unknown>): ObservedSpecs {
+	const specs: ObservedSpecs = {};
+	for (const [source, target] of Object.entries(PROVIDER_STRING_FIELDS)) {
+		const value = str(raw[source]);
+		if (value !== undefined) (specs as Record<string, unknown>)[target] = value;
 	}
 	return specs;
 }
@@ -98,11 +130,16 @@ function fromProbeFiles(readJson: JsonReader): ObservedSpecs {
  */
 export function readObservedSpecs(readJson: JsonReader): ObservedSpecs {
 	const probes = fromProbeFiles(readJson);
+	const providerRaw = readJson("system-provider.json");
+	const provider =
+		providerRaw && typeof providerRaw === "object" && !Array.isArray(providerRaw)
+			? fromProviderFile(providerRaw as Record<string, unknown>)
+			: {};
 	const direct = readJson("observed-specs.json");
 	if (direct && typeof direct === "object" && !Array.isArray(direct)) {
-		return { ...probes, ...fromObservedSpecsFile(direct as Record<string, unknown>) };
+		return { ...probes, ...provider, ...fromObservedSpecsFile(direct as Record<string, unknown>) };
 	}
-	return probes;
+	return { ...probes, ...provider };
 }
 
 /**

--- a/packages/schema/scripts/fetch-profiles.ts
+++ b/packages/schema/scripts/fetch-profiles.ts
@@ -55,6 +55,9 @@ const PROFILES = [
 	// Network dimension — single-result (sys.time monitor, no <Option> matrix), so it generates one
 	// description-less wildcard entry (zero byte-match risk).
 	"network-loopback-1.0.1",
+	// Network dimension — a real Internet transfer through Netflix's fast.com CDN. The profile emits
+	// download/upload throughput plus idle/loaded latency from fast-cli's JSON output.
+	"fast-cli-1.0.0",
 	// Cpu dimension — Zstd compression across its Compression Level matrix; two parsers per level
 	// (Compression/Decompression Speed via AppendToArgumentsDescription), byte-match-proven by a
 	// recorded composite golden fixture.
@@ -65,7 +68,23 @@ const PROFILES = [
 	// per combination (TPS + Average Latency, distinct descriptions), proven by a recorded fixture.
 	// 1.15.0 is the newest pgbench profile published upstream at REF.
 	"pgbench-1.15.0",
+	// System dimension — common Git operations over a fixed GTK repository checkout. Kept alongside
+	// the realworld repo clones: this synthetic profile isolates Git itself and is short enough to run
+	// in the system matrix cell.
+	"git-1.1.0",
 ] as const;
+
+// These short profiles intentionally use two trials in the benchmark matrix. Keep that local
+// runtime policy in the vendoring tool itself so a refresh remains byte-for-byte idempotent instead
+// of silently restoring upstream's three-trial default. Longer profiles retain their upstream count.
+const TWO_TRIAL_PROFILES = new Set([
+	"node-web-tooling-1.0.1",
+	"c-ray-2.0.0",
+	"pybench-1.1.3",
+	"sqlite-speedtest-1.0.1",
+	"fast-cli-1.0.0",
+	"git-1.1.0",
+]);
 
 // Only these definition files feed the generator; siblings (downloads.xml, install.sh) are ignored.
 // `required` distinguishes the essential `test-definition.xml` (a missing one is a hard failure, not
@@ -134,7 +153,11 @@ async function vendorProfile(commitSha: string, profile: string): Promise<void> 
 			}
 			// Bun.write creates parent dirs, normalizes the path, and overwrites in place — no node:path
 			// join or mkdir + writeFile dance needed.
-			await Bun.write(`${OUT_DIR}/${profile}/${name}`, await fetchBlobText(sha));
+			let contents = await fetchBlobText(sha);
+			if (name === "test-definition.xml" && TWO_TRIAL_PROFILES.has(profile)) {
+				contents = contents.replace(/<TimesToRun>\d+<\/TimesToRun>/, "<TimesToRun>2</TimesToRun>");
+			}
+			await Bun.write(`${OUT_DIR}/${profile}/${name}`, contents);
 			console.log(`✓ ${profile}/${name}`);
 		}),
 	);

--- a/packages/schema/src/catalog.test.ts
+++ b/packages/schema/src/catalog.test.ts
@@ -119,16 +119,11 @@ describe("metric catalog", () => {
 		expect(getMetric("not_a_metric")).toBeUndefined();
 	});
 
-	it("resolves the Loopback TCP headline for the network dimension (last unpopulated axis)", () => {
-		// network was the one dimension still without metrics; network-loopback populates it. With that,
-		// every Dimension is populated + headlined, so headlineMetric's no-headline throw is no longer
-		// reachable through the real catalog — the "exactly one headline per dimension" test above keeps
-		// it that way. NOT the load check, which only ever rejects a SECOND headline.
+	it("keeps the controlled Loopback TCP measurement as the network headline", () => {
 		const metric = headlineMetric("network");
 		expect(metric.id).toBe("network_loopback_seconds");
 		expect(metric.label).toBe("Loopback TCP (10GB)");
 		expect(metric.direction).toBe("LIB");
-		// Single-result wildcard: no pts.description (so the byte-match gate needs no recorded composite).
 		expect(metric.pts).toEqual({ test: "pts/network-loopback" });
 	});
 

--- a/packages/schema/src/pts-generated.ts
+++ b/packages/schema/src/pts-generated.ts
@@ -227,6 +227,54 @@ const chunk1: MetricDef[] = [
 		sourceUrl: "https://facebook.github.io/zstd/",
 	},
 	{
+		id: "fast_cli_internet_download_speed",
+		dimension: "network",
+		unit: "Mbit/s",
+		direction: "HIB",
+		headline: false,
+		label: "fast-cli - Internet Download Speed",
+		description:
+			"This test profile uses the open-source fast-cli client to benchmark your Internet connection's upload/download performance and latency against Netflix's fast.com service.",
+		pts: { test: "pts/fast-cli", description: "Internet Download Speed" },
+		sourceUrl: "https://fast.com/",
+	},
+	{
+		id: "fast_cli_internet_latency",
+		dimension: "network",
+		unit: "ms",
+		direction: "LIB",
+		headline: false,
+		label: "fast-cli - Internet Latency",
+		description:
+			"This test profile uses the open-source fast-cli client to benchmark your Internet connection's upload/download performance and latency against Netflix's fast.com service.",
+		pts: { test: "pts/fast-cli", description: "Internet Latency" },
+		sourceUrl: "https://fast.com/",
+	},
+	{
+		id: "fast_cli_internet_loaded_latency_bufferbloat",
+		dimension: "network",
+		unit: "ms",
+		direction: "LIB",
+		headline: false,
+		label: "fast-cli - Internet Loaded Latency (Bufferbloat)",
+		description:
+			"This test profile uses the open-source fast-cli client to benchmark your Internet connection's upload/download performance and latency against Netflix's fast.com service.",
+		pts: { test: "pts/fast-cli", description: "Internet Loaded Latency (Bufferbloat)" },
+		sourceUrl: "https://fast.com/",
+	},
+	{
+		id: "fast_cli_internet_upload_speed",
+		dimension: "network",
+		unit: "Mbit/s",
+		direction: "HIB",
+		headline: false,
+		label: "fast-cli - Internet Upload Speed",
+		description:
+			"This test profile uses the open-source fast-cli client to benchmark your Internet connection's upload/download performance and latency against Netflix's fast.com service.",
+		pts: { test: "pts/fast-cli", description: "Internet Upload Speed" },
+		sourceUrl: "https://fast.com/",
+	},
+	{
 		id: "fio_type_random_read_engine_io_uring_direct_no_block_size_128kb_job_count_1_disk_target_default_test_directory_iops",
 		dimension: "disk",
 		unit: "IOPS",
@@ -4348,6 +4396,9 @@ const chunk1: MetricDef[] = [
 		},
 		sourceUrl: "https://fio.readthedocs.io/en/latest/fio_doc.html",
 	},
+];
+
+const chunk2: MetricDef[] = [
 	{
 		id: "fio_type_random_read_engine_windows_aio_direct_yes_block_size_4kb_job_count_1_disk_target_default_test_directory_mb_per_s",
 		dimension: "disk",
@@ -4420,9 +4471,6 @@ const chunk1: MetricDef[] = [
 		},
 		sourceUrl: "https://fio.readthedocs.io/en/latest/fio_doc.html",
 	},
-];
-
-const chunk2: MetricDef[] = [
 	{
 		id: "fio_type_random_read_engine_windows_aio_direct_yes_block_size_512kb_job_count_1_disk_target_default_test_directory_mb_per_s",
 		dimension: "disk",
@@ -8851,6 +8899,9 @@ const chunk2: MetricDef[] = [
 		},
 		sourceUrl: "https://fio.readthedocs.io/en/latest/fio_doc.html",
 	},
+];
+
+const chunk3: MetricDef[] = [
 	{
 		id: "fio_type_random_write_engine_windows_aio_direct_yes_block_size_8mb_job_count_1_disk_target_default_test_directory_mb_per_s",
 		dimension: "disk",
@@ -8923,9 +8974,6 @@ const chunk2: MetricDef[] = [
 		},
 		sourceUrl: "https://fio.readthedocs.io/en/latest/fio_doc.html",
 	},
-];
-
-const chunk3: MetricDef[] = [
 	{
 		id: "fio_type_sequential_read_engine_io_uring_direct_no_block_size_16kb_job_count_1_disk_target_default_test_directory_mb_per_s",
 		dimension: "disk",
@@ -13354,6 +13402,9 @@ const chunk3: MetricDef[] = [
 		},
 		sourceUrl: "https://fio.readthedocs.io/en/latest/fio_doc.html",
 	},
+];
+
+const chunk4: MetricDef[] = [
 	{
 		id: "fio_type_sequential_write_engine_io_uring_direct_no_block_size_2mb_job_count_1_disk_target_default_test_directory_mb_per_s",
 		dimension: "disk",
@@ -13426,9 +13477,6 @@ const chunk3: MetricDef[] = [
 		},
 		sourceUrl: "https://fio.readthedocs.io/en/latest/fio_doc.html",
 	},
-];
-
-const chunk4: MetricDef[] = [
 	{
 		id: "fio_type_sequential_write_engine_io_uring_direct_no_block_size_4kb_job_count_1_disk_target_default_test_directory_mb_per_s",
 		dimension: "disk",
@@ -17516,6 +17564,18 @@ const chunk4: MetricDef[] = [
 		sourceUrl: "https://fio.readthedocs.io/en/latest/fio_doc.html",
 	},
 	{
+		id: "git_seconds",
+		dimension: "system",
+		unit: "Seconds",
+		direction: "LIB",
+		headline: false,
+		label: "Git - Time To Complete Common Git Commands",
+		description:
+			"This test measures the time needed to carry out some sample Git operations on an example, static repository that happens to be a copy of the GNOME GTK tool-kit repository.",
+		pts: { test: "pts/git" },
+		sourceUrl: "https://git-scm.com/",
+	},
+	{
 		id: "hardlink_bogo_ops_per_s",
 		dimension: "disk",
 		unit: "bogo ops/s",
@@ -17777,6 +17837,9 @@ const chunk4: MetricDef[] = [
 		},
 		sourceUrl: "https://www.postgresql.org/",
 	},
+];
+
+const chunk5: MetricDef[] = [
 	{
 		id: "pgbench_scaling_factor_10000_clients_250_mode_read_write_average_latency",
 		dimension: "system",
@@ -17853,9 +17916,6 @@ const chunk4: MetricDef[] = [
 		},
 		sourceUrl: "https://www.postgresql.org/",
 	},
-];
-
-const chunk5: MetricDef[] = [
 	{
 		id: "pgbench_scaling_factor_10000_clients_500_mode_read_only",
 		dimension: "system",

--- a/packages/schema/src/pts-overrides.ts
+++ b/packages/schema/src/pts-overrides.ts
@@ -88,10 +88,17 @@ export const ptsOverrides: Record<string, MetricOverride> = {
 	fio_type_random_write_engine_linux_aio_direct_no_block_size_4kb_job_count_1_disk_target_default_test_directory_mb_per_s:
 		{ label: "fio rand write 4KB, buffered (MB/s)" },
 
-	// Network dimension: loopback TCP is its first (and headline) metric — a self-contained synthetic
-	// with no external endpoint, so it isolates the sandbox's network stack (virtio vs gVisor netstack
-	// vs host namespaces) from internet weather.
+	// Network dimension: loopback remains the stable headline that separates sandbox network-stack
+	// overhead from Internet/CDN weather; fast.com adds sustained real-world transfer measurements.
+	fast_cli_internet_download_speed: { label: "fast.com download" },
+	fast_cli_internet_upload_speed: { label: "fast.com upload" },
+	fast_cli_internet_latency: { label: "fast.com latency" },
+	fast_cli_internet_loaded_latency_bufferbloat: { label: "fast.com loaded latency" },
 	network_loopback_seconds: { headline: true, label: "Loopback TCP (10GB)" },
+
+	// System dimension: the synthetic Git profile complements the realworld repo tasks by isolating a
+	// fixed command sequence over a fixed GTK corpus.
+	git_seconds: { label: "Git common operations" },
 
 	// Cpu dimension (cpu-generic suite): Zstd compression across its Compression Level matrix — the
 	// classic CPU-throughput synthetic, run over every level in batch mode. Two metrics per level

--- a/packages/schema/src/pts-profiles/fast-cli-1.0.0/results-definition.xml
+++ b/packages/schema/src/pts-profiles/fast-cli-1.0.0/results-definition.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0"?>
+<!--Phoronix Test Suite v10.8.2-->
+<PhoronixTestSuite>
+  <ResultsParser>
+    <OutputTemplate>	"downloadSpeed": #_RESULT_#</OutputTemplate>
+    <StripFromResult>,</StripFromResult>
+    <ResultScale>Mbit/s</ResultScale>
+    <ResultProportion>HIB</ResultProportion>
+    <ArgumentsDescription>Internet Download Speed</ArgumentsDescription>
+  </ResultsParser>
+  <ResultsParser>
+    <OutputTemplate>	"uploadSpeed": #_RESULT_#</OutputTemplate>
+    <StripFromResult>,</StripFromResult>
+    <ResultScale>Mbit/s</ResultScale>
+    <ResultProportion>HIB</ResultProportion>
+    <ArgumentsDescription>Internet Upload Speed</ArgumentsDescription>
+  </ResultsParser>
+  <ResultsParser>
+    <OutputTemplate>	"latency": #_RESULT_#</OutputTemplate>
+    <StripFromResult>,</StripFromResult>
+    <ResultScale>ms</ResultScale>
+    <ResultProportion>LIB</ResultProportion>
+    <ArgumentsDescription>Internet Latency</ArgumentsDescription>
+  </ResultsParser>
+  <ResultsParser>
+    <OutputTemplate>	"bufferBloat": #_RESULT_#</OutputTemplate>
+    <StripFromResult>,</StripFromResult>
+    <ResultScale>ms</ResultScale>
+    <ResultProportion>LIB</ResultProportion>
+    <ArgumentsDescription>Internet Loaded Latency (Bufferbloat)</ArgumentsDescription>
+  </ResultsParser>
+</PhoronixTestSuite>

--- a/packages/schema/src/pts-profiles/fast-cli-1.0.0/test-definition.xml
+++ b/packages/schema/src/pts-profiles/fast-cli-1.0.0/test-definition.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0"?>
+<!--Phoronix Test Suite v10.8.2-->
+<PhoronixTestSuite>
+  <TestInformation>
+    <Title>fast-cli</Title>
+    <Description>This test profile uses the open-source fast-cli client to benchmark your Internet connection's upload/download performance and latency against Netflix's fast.com service.</Description>
+    <ResultScale>Mbit/s</ResultScale>
+    <Proportion>HIB</Proportion>
+    <TimesToRun>2</TimesToRun>
+  </TestInformation>
+  <TestProfile>
+    <Version>1.0.0</Version>
+    <SupportedPlatforms>Linux, BSD, MacOSX</SupportedPlatforms>
+    <SoftwareType>Utility</SoftwareType>
+    <TestType>Network</TestType>
+    <License>Free</License>
+    <Status>Verified</Status>
+    <ExternalDependencies>node-npm</ExternalDependencies>
+    <RequiresNetwork>TRUE</RequiresNetwork>
+    <RequiresInternet>TRUE</RequiresInternet>
+    <EnvironmentSize>1</EnvironmentSize>
+    <ProjectURL>https://fast.com/</ProjectURL>
+    <RepositoryURL>https://github.com/sindresorhus/fast-cli</RepositoryURL>
+    <Maintainer>Michael Larabel</Maintainer>
+  </TestProfile>
+</PhoronixTestSuite>

--- a/packages/schema/src/pts-profiles/git-1.1.0/results-definition.xml
+++ b/packages/schema/src/pts-profiles/git-1.1.0/results-definition.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0"?>
+<!--Phoronix Test Suite v9.6.0m2-->
+<PhoronixTestSuite>
+  <SystemMonitor>
+    <Sensor>sys.time</Sensor>
+  </SystemMonitor>
+</PhoronixTestSuite>

--- a/packages/schema/src/pts-profiles/git-1.1.0/test-definition.xml
+++ b/packages/schema/src/pts-profiles/git-1.1.0/test-definition.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0"?>
+<!--Phoronix Test Suite v9.6.0m2-->
+<PhoronixTestSuite>
+  <TestInformation>
+    <Title>Git</Title>
+    <Description>This test measures the time needed to carry out some sample Git operations on an example, static repository that happens to be a copy of the GNOME GTK tool-kit repository.</Description>
+    <ResultScale>Seconds</ResultScale>
+    <Proportion>LIB</Proportion>
+    <SubTitle>Time To Complete Common Git Commands</SubTitle>
+    <TimesToRun>2</TimesToRun>
+  </TestInformation>
+  <TestProfile>
+    <Version>1.1.0</Version>
+    <SupportedPlatforms>Linux, BSD, MacOSX, Windows</SupportedPlatforms>
+    <SoftwareType>Utility</SoftwareType>
+    <TestType>System</TestType>
+    <License>Free</License>
+    <Status>Verified</Status>
+    <ExternalDependencies>git</ExternalDependencies>
+    <RequiresInternet>TRUE</RequiresInternet>
+    <EnvironmentTestingSize>523</EnvironmentTestingSize>
+    <ProjectURL>https://git-scm.com/</ProjectURL>
+    <Maintainer>Michael Larabel</Maintainer>
+  </TestProfile>
+</PhoronixTestSuite>

--- a/packages/schema/src/raw-files.test.ts
+++ b/packages/schema/src/raw-files.test.ts
@@ -15,6 +15,7 @@ describe("raw-file naming", () => {
 	it("recognises PTS result XML by prefix and extension", () => {
 		expect(isPtsResultFile("pts_node-web-tooling.xml")).toBe(true);
 		expect(isPtsResultFile("pts_node-web-tooling.log")).toBe(false);
+		expect(isPtsResultFile("pts_node-web-tooling--metadata.json")).toBe(false);
 		expect(isPtsResultFile("observed-specs.json")).toBe(false);
 	});
 

--- a/packages/schema/src/run.ts
+++ b/packages/schema/src/run.ts
@@ -56,6 +56,26 @@ export const uncataloguedResultSchema = type({
 });
 export type UncataloguedResult = typeof uncataloguedResultSchema.infer;
 
+/** One flattened field from a host-metadata source. String values preserve the source value while
+ * the path retains its original nested shape (`hardware.Processor`, `data.cpu-smt`, ...). */
+export const hostMetadataFieldSchema = type({
+	path: "string >= 1",
+	value: "string",
+});
+export type HostMetadataField = typeof hostMetadataFieldSchema.infer;
+
+/**
+ * One rich host record retained from an in-sandbox producer. `mise/system-provider` is the repo's
+ * ASN/geo/DMI probe; `phoronix/result-file-to-json` is PTS's native structured System export. The
+ * generic flattened field list deliberately preserves new upstream keys without a Run schema bump.
+ */
+export const hostMetadataRecordSchema = type({
+	source: "'mise/system-provider' | 'phoronix/result-file-to-json'",
+	sourceFile: "string >= 1",
+	fields: hostMetadataFieldSchema.array(),
+});
+export type HostMetadataRecord = typeof hostMetadataRecordSchema.infer;
+
 /**
  * Observed actuals recorded per Run — what in-sandbox probes actually saw, versus the requested
  * {@link TargetSpec}. All optional: providers differ in what in-sandbox
@@ -83,6 +103,24 @@ export const observedSpecsSchema = type({
 	// The distinct host CPU models when merged shards of one provider disclosed more than one — the
 	// aggregate-only heterogeneity disclosure (cpuModel is the key; cpuMicroarch is derived from it).
 	"hostCpuModels?": "string[]",
+	// Rich identity from benchmark:system:provider. ASN/org describe public egress; DMI describes the
+	// machine/hypervisor. Full source records also live in ProviderRun.hostMetadata.
+	"publicIp?": "string",
+	"egressOrg?": "string",
+	"egressAsn?": "string",
+	"egressOrgName?": "string",
+	"reverseDns?": "string",
+	"city?": "string",
+	"region?": "string",
+	"country?": "string",
+	"location?": "string",
+	"timezone?": "string",
+	"manufacturer?": "string",
+	"productName?": "string",
+	"biosVendor?": "string",
+	"networkPrefix?": "string",
+	"asnSource?": "string",
+	"geoSource?": "string",
 });
 export type ObservedSpecs = typeof observedSpecsSchema.infer;
 
@@ -147,6 +185,8 @@ export const providerRunSchema = type({
 	// Whether observed specs honored the pinned target spec; absent when probes saw too little to judge.
 	"specMatched?": "boolean",
 	observedSpecs: observedSpecsSchema,
+	/** Rich, source-attributed host records; optional for historical Runs predating capture. */
+	"hostMetadata?": hostMetadataRecordSchema.array(),
 	metrics: metricResultSchema.array(),
 	/**
 	 * Every suite that produced at least one catalogued Metric here — the POSITIVE record of coverage,

--- a/packages/schema/src/suites.test.ts
+++ b/packages/schema/src/suites.test.ts
@@ -64,10 +64,10 @@ describe("suite registry", () => {
 		// over the unpinned half instead of dropping the suite from the gate entirely.
 		const PINNED_PREFIXES = ["pgbench_"];
 		const profilesOf = {
-			network: ["pts/network-loopback"],
+			network: ["pts/network-loopback", "pts/fast-cli"],
 			"cpu-generic": ["pts/c-ray", "pts/compress-zstd"],
 			memory: ["pts/stream"],
-			system: ["pts/pybench", "pts/sqlite-speedtest"],
+			system: ["pts/pybench", "pts/sqlite-speedtest", "pts/git"],
 		} as const;
 		for (const [suiteName, ptsTests] of Object.entries(profilesOf)) {
 			const fromCatalog = METRIC_CATALOG.filter(

--- a/packages/schema/src/suites.ts
+++ b/packages/schema/src/suites.ts
@@ -82,6 +82,7 @@ export const SUITES = {
 		metrics: [
 			"pybench_milliseconds",
 			"sqlite_speedtest_seconds",
+			"git_seconds",
 			"pgbench_scaling_factor_100_clients_50_mode_read_only",
 			"pgbench_scaling_factor_100_clients_50_mode_read_only_average_latency",
 			"pgbench_scaling_factor_100_clients_50_mode_read_write",
@@ -133,15 +134,23 @@ export const SUITES = {
 		],
 		commands: ["mise run benchmark:disk:all"],
 	},
-	// The network dimension: loopback TCP (10GB via nc) — self-contained, no external endpoint, so it
-	// isolates the sandbox's network stack from internet weather. The suite task also runs the
-	// latency/DNS/download probes (raw JSON provenance, no catalogued metrics).
+	// The network dimension: fast-cli performs sustained real-world download/upload transfers through
+	// Netflix's fast.com CDN and reports idle/loaded latency; loopback TCP (10GB via nc) is the paired
+	// self-contained synthetic that isolates the sandbox's network stack from Internet weather. The
+	// suite task also runs latency/DNS and a small GitHub control-download probe as raw provenance.
 	network: {
 		setupPts: true,
-		commandTimeoutMinutes: 30,
-		timeoutMinutes: 40,
+		setupNode: true,
+		commandTimeoutMinutes: 45,
+		timeoutMinutes: 55,
 		dimensions: ["network"],
-		metrics: ["network_loopback_seconds"],
+		metrics: [
+			"fast_cli_internet_download_speed",
+			"fast_cli_internet_upload_speed",
+			"fast_cli_internet_latency",
+			"fast_cli_internet_loaded_latency_bufferbloat",
+			"network_loopback_seconds",
+		],
 		commands: ["mise run benchmark:network:all"],
 	},
 	// The generic-compute dimension slice next to cpu-node: c-ray (float/thread scaling — the seam the

--- a/packages/templates/src/lib/pins.ts
+++ b/packages/templates/src/lib/pins.ts
@@ -77,7 +77,7 @@ export const rawPins = {
 	// > sandbox wall time goes to benchmarks, not setup: every PTS profile a registered suite runs —
 	// > fio, zstd and especially postgres (pgbench) are source builds worth paying at bake time
 	// > (stream covers the memory suite, so no registered suite pays a runtime install). The
-	// > six new profiles are VERSION-PINNED to exactly what their leaves batch-run (and the catalog
+	// > all profiles are VERSION-PINNED to exactly what their leaves batch-run (and the catalog
 	// > vendors): an unversioned name resolves to whatever upstream's latest is at bake time, so a
 	// > profile bump would silently void the pre-install and push the source build (postgres!) into
 	// > every sandbox. ALL entries are pinned — node-web-tooling/pybench/sqlite-speedtest included, with
@@ -87,5 +87,5 @@ export const rawPins = {
 	// > the leaf changes nothing downstream. (pyperformance was dropped: no registered suite or mise task
 	// > runs it, and its pip-driven install inflated every bake for nothing.)
 	ptsInstallTests:
-		"node-web-tooling-1.0.1 pybench-1.1.3 sqlite-speedtest-1.0.1 c-ray-2.0.0 compress-zstd-1.6.0 fio-2.1.0 network-loopback-1.0.1 pgbench-1.15.0 stream-1.3.4",
+		"node-web-tooling-1.0.1 pybench-1.1.3 sqlite-speedtest-1.0.1 c-ray-2.0.0 compress-zstd-1.6.0 fio-2.1.0 network-loopback-1.0.1 fast-cli-1.0.0 pgbench-1.15.0 git-1.1.0 stream-1.3.4",
 } satisfies Record<keyof Pins, string>;

--- a/packages/templates/src/smoke.test.ts
+++ b/packages/templates/src/smoke.test.ts
@@ -28,18 +28,20 @@ describe("@sandbox-benchmarks/templates smoke", () => {
 		}
 	});
 
-	// The count (9) and sample profile name are hardcoded on purpose: this is a drift tripwire, not a
+	// The count (11) and sample profile names are hardcoded on purpose: this is a drift tripwire, not a
 	// derived assertion. Deriving them from pins.ptsInstallTests would make the test a tautology that
 	// tracks the generator instead of pinning it — the exact failure this guards against (a mutable-tag
 	// cache once validated an old two-profile image against a nine-profile candidate). When the pin list
 	// changes, update these literals deliberately.
 	it("requires every pinned PTS profile, so a stale partial image cannot pass smoke", () => {
 		const pts = smokeChecks.find((check) => check.name === "pts-installed-tests");
-		expect(pts?.expect).toBe("pts-profile-count=9");
+		expect(pts?.expect).toBe("pts-profile-count=11");
 		expect(pts?.cmd).toContain("phoronix-test-suite list-installed-tests");
 		expect(pts?.cmd).toContain("PTS_USER_PATH_OVERRIDE=/var/lib/phoronix-test-suite/");
 		expect(pts?.cmd).toContain("node-web-tooling-1.0.1");
-		expect(pts?.cmd).toContain('[ "$actual" -eq 9 ]');
+		expect(pts?.cmd).toContain("fast-cli-1.0.0");
+		expect(pts?.cmd).toContain("git-1.1.0");
+		expect(pts?.cmd).toContain('[ "$actual" -eq 11 ]');
 		expect(pts?.cmd).toContain('echo "pts-profile-count=$actual"');
 	});
 

--- a/tooling/repo-checks/src/lib/workflow-hardening.ts
+++ b/tooling/repo-checks/src/lib/workflow-hardening.ts
@@ -472,12 +472,12 @@ export function checkToolchainDispatchOnly(
 	for (const needle of [
 		"workflow_dispatch",
 		"refs/heads/main",
-		"starslingdev/sandbox-benchmarks",
+		"starslingdev/hpc-sandbox-benchmarks",
 	] as const) {
 		if (!publishIf.includes(needle)) {
 			errors.push(
 				`${file}::publish: \`if:\` must confine the release to workflow_dispatch on main of ` +
-					`starslingdev/sandbox-benchmarks (missing "${needle}")`,
+					`starslingdev/hpc-sandbox-benchmarks (missing "${needle}")`,
 			);
 		}
 	}

--- a/tooling/repo-checks/src/workflow-hardening.test.ts
+++ b/tooling/repo-checks/src/workflow-hardening.test.ts
@@ -396,7 +396,7 @@ describe("checkPrivilegedEnvironment", () => {
 describe("checkToolchainDispatchOnly", () => {
 	// The main-only dispatch guard the publish job's `if:` must carry, and a publish job that passes.
 	const DISPATCH_GATE_IF =
-		"github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main' && github.repository == 'starslingdev/sandbox-benchmarks'";
+		"github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main' && github.repository == 'starslingdev/hpc-sandbox-benchmarks'";
 	const gatedPublish = {
 		environment: PRIVILEGED_ENVIRONMENT,
 		if: DISPATCH_GATE_IF,


### PR DESCRIPTION
## Summary

- vendor and bake pinned Phoronix fast-cli and Git profiles
- run sustained fast.com transfer metrics in the network suite and Git operations in the system suite
- export PTS structured system metadata and preserve rich mise provider metadata in normalized datasets
- add catalog, normalization, aggregation, image smoke, and workflow coverage

## Validation

- bun run test
- bun run typecheck
- bun run lint
- bun run lint:shell
- bun run spell
- mise exec -- actionlint
- repository integrity gates

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds real-world network throughput via `pts/fast-cli` and a `pts/git` profile, and captures rich host metadata from PTS and the provider for better provenance. Also enables guarded non‑main benchmark dispatch for pre‑merge validation.

- **New Features**
  - Vendor and pin `pts/fast-cli@1.0.0` and `pts/git@1.1.0`; run `fast-cli` in the network suite and `git` in the system suite; each suite cell runs its registered leaves.
  - Export PTS structured system metadata (`<prefix>--metadata.json` via `phoronix-test-suite result-file-to-json`) and retain `system-provider.json`; surface as `hostMetadata` and project common fields into `observedSpecs`.
  - Normalize and aggregate host metadata with de‑dup; preserve suite‑tagged source files; keep duplicate PTS result de‑dupe behavior.
  - Expand catalog: add `fast-cli` download/upload/latency/loaded‑latency and `git_seconds`; keep loopback as the network headline.
  - Update pins and smoke checks (11 preinstalled PTS profiles) and allow guarded non‑main matrix dispatch via `allow_branch` (publish remains main‑only); update repo gates to `starslingdev/hpc-sandbox-benchmarks`.

- **Migration**
  - Rebuild the toolchain image so `phoronix-test-suite` has `fast-cli` and `git` preinstalled, and Node is available for `fast-cli`.
  - No breaking schema changes; runs may now include `hostMetadata` and richer `observedSpecs`.
  - Network suite timeouts increased; CI may run slightly longer; smoke test expects 11 installed profiles.

<sup>Written for commit c6dd66d7311914f9f77491b84bfa56a63e248497. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/starslingdev/hpc-sandbox-benchmarks/pull/188?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

