### PR TITLE
chore(toolchain): bump TOOLCHAIN_VERSION v1 → v2

### DIFF
--- a/packages/schema/src/toolchain.ts
+++ b/packages/schema/src/toolchain.ts
@@ -4,4 +4,4 @@
 // tag is immutable: a change to the toolchain image means bumping TOOLCHAIN_VERSION.
 
 export const TOOLCHAIN_IMAGE_NAME = "sandbox-benchmarks-toolchain";
-export const TOOLCHAIN_VERSION = "v1";
+export const TOOLCHAIN_VERSION = "v2";


### PR DESCRIPTION
## Why

The `v1` force-republish mutated the "immutable" `:v1` tag, so providers keying on the mutable `v1` artifact names could serve **stale** bytes. The all-provider `network` bench-matrix ([run 29546060837](https://github.com/starslingdev/hpc-sandbox-benchmarks/actions/runs/29546060837)) confirmed it:

| provider | `network` | cause |
|---|---|---|
| e2b | ✅ pass | fresh template from the new `0941` bytes |
| modal | ❌ `libglib-2.0.so.0` missing | booted a **stale cached `:v1`** (pre-#190 image, no Chrome libs) |
| daytona | ❌ fast-cli hang/timeout | Chrome started (fresh snapshot) → separate fast.com-upload reliability issue |
| novita | ❌ no metrics | under investigation |
| blaxel | ❌ `libglib` | runtime toolchain, no baked artifact (known non-comparable) |

Bumping to a brand-new version name forces **every** provider to build/pull fresh artifacts under names nothing has cached — eliminating the stale-`:v1` class of failure (modal).

## Why `v2`, not `v1.1`

This project's toolchain versioning is a flat `vN` sequence, not semver. The version flows into the e2b/novita template names (`sandbox-benchmarks-toolchain-<version>`), whose aliases disallow dots — so a dotted "minor" would break template creation. `v2` is the clean, charset-safe next value.

## Release steps after merge

1. Dispatch **`toolchain-image`** — normal publish (v2 doesn't exist, so `force_republish=false`); promote **creates** the v2 daytona snapshot fresh (no destructive delete).
2. Re-dispatch **`bench-matrix`** against v2.

fast-cli reliability on daytona/novita (a hang / no-metrics on the fast.com upload, independent of the toolchain version) is deferred to after the v2 re-bench, per discussion.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bumps `TOOLCHAIN_VERSION` from `v1` to `v2` to invalidate stale `:v1` artifacts and force fresh pulls across providers, fixing modal boots missing `libglib-2.0.so.0`. We use a flat `vN` scheme; `v2` is the next safe alias.

- **Migration**
  - Publish the toolchain image normally (`force_republish=false`) to create `v2` and the Daytona snapshot.
  - Re-run the `bench-matrix` against `v2`.

<sup>Written for commit 953e8b257e8bec36b2e77eab0c82375014ff2cb0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/starslingdev/hpc-sandbox-benchmarks/pull/191?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the pinned toolchain version to v2 for builds and runtime configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->