### PR TITLE
feat(schema): replicate-aware stats primitives + v3 run schema

### DIFF
--- a/packages/schema/src/analysis.test.ts
+++ b/packages/schema/src/analysis.test.ts
@@ -1,9 +1,11 @@
 import { describe, expect, it } from "bun:test";
 import {
 	aggregate,
+	bootstrapMedianDifferenceInterval,
 	bootstrapMedianInterval,
 	canSeparate,
 	DEFAULT_ALPHA,
+	hierarchicalBootstrapMedianInterval,
 	kolmogorovSmirnov,
 	mannWhitneyU,
 	percentileOf,
@@ -184,6 +186,215 @@ describe("bootstrapMedianInterval", () => {
 			level: 0.95,
 			resamples: 0,
 		});
+	});
+});
+
+describe("hierarchicalBootstrapMedianInterval", () => {
+	it("reports the pooled median and brackets it", () => {
+		const interval = hierarchicalBootstrapMedianInterval([MODAL_COPY, DAYTONA_COPY], { seed: "s" });
+		expect(interval.median).toBe(percentileOf([...MODAL_COPY, ...DAYTONA_COPY], 0.5));
+		expect(interval.lo).toBeLessThanOrEqual(interval.median);
+		expect(interval.hi).toBeGreaterThanOrEqual(interval.median);
+	});
+
+	it("widens when the replicates disagree across sandboxes (between-sandbox variance)", () => {
+		// Same pooled median (55) both ways; the only difference is machine-to-machine spread. The
+		// hierarchical resample draws the clusters first, so a run where the two sandboxes landed far
+		// apart must report a wider interval than one where they agreed — the whole point of the level.
+		const disagree = hierarchicalBootstrapMedianInterval(
+			[
+				[10, 10],
+				[100, 100],
+			],
+			{ seed: "s" },
+		);
+		const agree = hierarchicalBootstrapMedianInterval(
+			[
+				[54, 54],
+				[56, 56],
+			],
+			{ seed: "s" },
+		);
+		expect(disagree.hi - disagree.lo).toBeGreaterThan(agree.hi - agree.lo);
+	});
+
+	it("degenerates to the ordinary bootstrap's median at R = 1", () => {
+		// One replicate: the cluster draw always re-selects it, so the resample distribution is the plain
+		// bootstrap's. The observed median is identical; the raw draw sequence is not, which is why the
+		// leaderboard keeps the single-level function at R = 1 for byte-stability.
+		const single = hierarchicalBootstrapMedianInterval([MODAL_COPY], { seed: "s" });
+		const plain = bootstrapMedianInterval(MODAL_COPY, { seed: "s" });
+		expect(single.median).toBe(plain.median);
+		expect(single.lo).toBeLessThanOrEqual(single.median);
+		expect(single.hi).toBeGreaterThanOrEqual(single.median);
+	});
+
+	it("degenerates to a point interval for a single pooled Sample", () => {
+		expect(hierarchicalBootstrapMedianInterval([[42]])).toEqual({
+			median: 42,
+			lo: 42,
+			hi: 42,
+			level: 0.95,
+			resamples: 0,
+		});
+	});
+
+	it("is reproducible for a given seed", () => {
+		const shape = [MODAL_COPY, DAYTONA_COPY];
+		expect(hierarchicalBootstrapMedianInterval(shape, { seed: "run-1" })).toEqual(
+			hierarchicalBootstrapMedianInterval(shape, { seed: "run-1" }),
+		);
+	});
+
+	it("rejects an empty structure, a non-finite Sample, and bad options", () => {
+		expect(() => hierarchicalBootstrapMedianInterval([])).toThrow(/at least one replicate/);
+		expect(() => hierarchicalBootstrapMedianInterval([[]])).toThrow(/at least one sample/);
+		expect(() => hierarchicalBootstrapMedianInterval([[1, Number.NaN]])).toThrow(/finite/);
+		expect(() => hierarchicalBootstrapMedianInterval([[1, 2]], { level: 0 })).toThrow(/level/);
+		expect(() => hierarchicalBootstrapMedianInterval([[1, 2]], { resamples: 0 })).toThrow(
+			/positive integer/,
+		);
+	});
+});
+
+describe("bootstrapMedianDifferenceInterval", () => {
+	it("reports the difference of pooled medians, sign following argument order", () => {
+		const diff = bootstrapMedianDifferenceInterval([[100, 100]], [[10, 10]], { seed: "s" });
+		expect(diff.difference).toBe(90);
+		const flipped = bootstrapMedianDifferenceInterval([[10, 10]], [[100, 100]], { seed: "s" });
+		expect(flipped.difference).toBe(-90);
+	});
+
+	it("separates two providers whose replicate sandboxes never overlap, once R clears the floor", () => {
+		// Four non-overlapping sandboxes per side: the exact cluster test floors at 2/C(8,4) ≈ 0.029, so
+		// complete separation clears α = 0.05. Every replicate of A is 1000 and of B is 1, so every
+		// hierarchical resample still yields exactly 999 — the DISPLAYED interval collapses to [999, 999].
+		const diff = bootstrapMedianDifferenceInterval(
+			[
+				[1000, 1000],
+				[1000, 1000],
+				[1000, 1000],
+				[1000, 1000],
+			],
+			[
+				[1, 1],
+				[1, 1],
+				[1, 1],
+				[1, 1],
+			],
+			{ seed: "s" },
+		);
+		expect(diff.separated).toBe(true);
+		expect(diff.pValue).toBeLessThan(0.05);
+		expect(diff.lo).toBeGreaterThan(0);
+	});
+
+	it("ties two providers drawn from the same distribution (interval straddles 0)", () => {
+		const shape = [
+			[10, 20],
+			[10, 20],
+			[10, 20],
+		];
+		const diff = bootstrapMedianDifferenceInterval(shape, shape, { seed: "s" });
+		expect(diff.difference).toBe(0);
+		expect(diff.separated).toBe(false);
+		expect(diff.lo).toBeLessThanOrEqual(0);
+		expect(diff.hi).toBeGreaterThanOrEqual(0);
+	});
+
+	it("ties adjacent R = 3 providers whose medians are close — replicas are the dial, not more trials", () => {
+		// The honest small-R behaviour the design accepts: three replicate sandboxes a step apart cannot
+		// be told from three a step higher. A caller must read this as "not separated", never "equal".
+		const diff = bootstrapMedianDifferenceInterval([[10], [20], [30]], [[15], [25], [35]], {
+			seed: "s",
+		});
+		expect(diff.separated).toBe(false);
+	});
+
+	it("cannot separate at R = 3 even under complete separation — the 2/C(6,3) = 0.1 floor", () => {
+		// The reviewer's case: three sandboxes per side, perfectly separated. The exact cluster test's
+		// smallest attainable two-sided p is 2/C(6,3) = 0.1, above α = 0.05, so NO R=3 comparison can be
+		// declared separated — the old "interval clears 0" rule would have over-claimed it. Raising k
+		// (in-sandbox trials) cannot lower this floor; only more sandboxes (R) can.
+		const diff = bootstrapMedianDifferenceInterval([[100], [101], [102]], [[1], [2], [3]], {
+			seed: "s",
+		});
+		expect(diff.separated).toBe(false);
+		expect(diff.pValue).toBeCloseTo(0.1, 12); // 2 / C(6,3)
+		expect(diff.minAttainablePValue).toBeCloseTo(0.1, 12);
+		expect(diff.lo).toBeGreaterThan(0); // the DISPLAYED bootstrap interval still excludes 0
+	});
+
+	it("a single sandbox per side can never separate, however many in-sandbox trials", () => {
+		// One replicate cluster per side reduces to a 1-vs-1 cluster test (floor p = 1), so no gap and no
+		// trial count can separate the providers — the between-sandbox axis is simply absent. This is the
+		// case the pooled-sample CI missed: four identical trials look like power, but are one sandbox.
+		const diff = bootstrapMedianDifferenceInterval([[10, 10, 10, 10]], [[99, 99, 99, 99]], {
+			seed: "s",
+		});
+		expect(diff.separated).toBe(false);
+		expect(diff.minAttainablePValue).toBe(1);
+	});
+
+	it("reports the verdict's method — exact at the R this benchmark runs", () => {
+		// The verdict is the cluster permutation via Mann-Whitney U on R_a + R_b sandboxes; at any real R
+		// that stays under mannWhitneyU's exact-N ceiling, so `method` is "exact" and the label is honest.
+		const diff = bootstrapMedianDifferenceInterval([[1], [2], [3]], [[4], [5], [6]], { seed: "s" });
+		expect(diff.method).toBe("exact");
+	});
+
+	it("falls back to the asymptotic method past the exact-N ceiling, and says so rather than claiming exact", () => {
+		// Above mannWhitneyU's MAX_EXACT_N (50 total sandboxes) the cluster test uses the normal
+		// approximation. Far beyond any real R, but the verdict must surface that rather than mislabel an
+		// approximated p as exact — so `method` flips to "asymptotic".
+		const many = (base: number) => Array.from({ length: 30 }, (_, i) => [base + i]);
+		const diff = bootstrapMedianDifferenceInterval(many(0), many(1000), { seed: "s" });
+		expect(diff.method).toBe("asymptotic");
+	});
+
+	it("degenerates to a point interval when each side pools to a single Sample (no power to separate)", () => {
+		// One Sample per side has no spread, so there is nothing to resample: report resamples: 0 and a
+		// point interval — never 10 000 identical draws, and never a separation verdict on zero power
+		// (mirrors hierarchicalBootstrapMedianInterval's single-pooled-sample short-circuit).
+		const diff = bootstrapMedianDifferenceInterval([[5]], [[8]]);
+		expect(diff.resamples).toBe(0);
+		expect(diff.separated).toBe(false);
+		expect(diff.difference).toBe(-3);
+		expect(diff.lo).toBe(-3);
+		expect(diff.hi).toBe(-3);
+	});
+
+	it("is reproducible for a given seed", () => {
+		const a = [[10, 12], [11]];
+		const b = [[20, 22], [21]];
+		expect(bootstrapMedianDifferenceInterval(a, b, { seed: "r" })).toEqual(
+			bootstrapMedianDifferenceInterval(a, b, { seed: "r" }),
+		);
+	});
+
+	it("negates the observed difference on reversal; the separation verdict is order-invariant", () => {
+		// The shared seeded RNG draws A then B in order, so the resampled lo/hi bounds are not guaranteed
+		// mirror images on reversal (a deliberate trade for one reproducible seed). What IS guaranteed:
+		// `difference` negates exactly (computed directly, not resampled), and the separation VERDICT is
+		// order-invariant — it comes from Mann-Whitney U on the per-sandbox medians, symmetric in its two
+		// arguments. Uses R=4 so a clearly-separated pair can actually clear the 5% floor.
+		const hi = [[100], [101], [102], [103]];
+		const lo = [[1], [2], [3], [4]];
+		const forward = bootstrapMedianDifferenceInterval(hi, lo, { seed: "rev" });
+		const reversed = bootstrapMedianDifferenceInterval(lo, hi, { seed: "rev" });
+		expect(reversed.difference).toBe(-forward.difference);
+		expect(forward.separated).toBe(true);
+		expect(reversed.separated).toBe(true);
+		expect(forward.pValue).toBe(reversed.pValue);
+	});
+
+	it("rejects an empty side, a non-finite Sample, and bad options", () => {
+		expect(() => bootstrapMedianDifferenceInterval([], [[1]])).toThrow(/at least one replicate/);
+		expect(() => bootstrapMedianDifferenceInterval([[1]], [[Number.NaN]])).toThrow(/finite/);
+		expect(() => bootstrapMedianDifferenceInterval([[1]], [[2]], { level: 1 })).toThrow(/level/);
+		expect(() => bootstrapMedianDifferenceInterval([[1]], [[2]], { resamples: -1 })).toThrow(
+			/positive integer/,
+		);
 	});
 });
 

--- a/packages/schema/src/analysis.ts
+++ b/packages/schema/src/analysis.ts
@@ -242,6 +242,228 @@ export function bootstrapMedianInterval(
 	};
 }
 
+// ---------------------------------------------------------------------------------------------
+// Replicate-aware inference. A replicate is one whole sandbox: R replicates of a (provider, suite)
+// capture BETWEEN-sandbox variance (host placement, region, noisy neighbours) that the within-sandbox
+// trials cannot see. Pooling every replicate's Samples into one flat set and bootstrapping THAT
+// under-states the spread — it treats R×k correlated draws as R×k independent ones, so the interval
+// narrows with the trial count even when the true machine-to-machine variance is large. The
+// hierarchical bootstrap below resamples at BOTH levels (replicates, then Samples within each), so the
+// interval it reports reflects the variance a user actually experiences. At R = 1 it degenerates to the
+// ordinary percentile bootstrap {@link bootstrapMedianInterval} computes.
+// ---------------------------------------------------------------------------------------------
+
+/** Reject empty/non-finite replicate structure at the boundary, naming the caller. Every replicate
+ *  must carry at least one finite Sample, and there must be at least one replicate — the same
+ *  fail-fast posture as {@link assertFiniteSamples}, extended to the two-level shape. */
+function assertReplicates(fn: string, replicates: readonly (readonly number[])[]): void {
+	if (replicates.length === 0) {
+		throw new Error(`${fn}() requires at least one replicate`);
+	}
+	for (const replicate of replicates) {
+		assertFiniteSamples(fn, replicate);
+	}
+}
+
+/**
+ * One hierarchical resample's median: draw R replicates WITH REPLACEMENT, then within each drawn
+ * replicate draw its own number of Samples with replacement, pool the lot, and take the median. Drawing
+ * the clusters first is what carries the between-sandbox variance into the resample distribution — a
+ * flat bootstrap that skipped this level would treat the pooled Samples as exchangeable and hide it.
+ */
+function hierarchicalResampleMedian(
+	replicates: readonly (readonly number[])[],
+	rng: () => number,
+): number {
+	const R = replicates.length;
+	const pool: number[] = [];
+	for (let r = 0; r < R; r++) {
+		const chosen = replicates[Math.floor(rng() * R)] as readonly number[];
+		const n = chosen.length;
+		for (let i = 0; i < n; i++) pool.push(chosen[Math.floor(rng() * n)] as number);
+	}
+	pool.sort((x, y) => x - y);
+	return percentile(pool, 0.5);
+}
+
+/**
+ * Hierarchical (two-level) percentile bootstrap of the median across replicate sandboxes. The reported
+ * `median` is the observed median of the POOLED Samples — the same ranking value the leaderboard prints
+ * — and `[lo, hi]` is the [α/2, 1−α/2] envelope of the resampled medians, where each resample first
+ * draws replicates with replacement and then Samples within each.
+ *
+ * Degenerates deterministically:
+ *  - one replicate  → the cluster draw always re-selects it, so this is the ordinary percentile
+ *    bootstrap over that replicate's Samples (statistically identical to {@link bootstrapMedianInterval};
+ *    the raw draw sequence differs, so the leaderboard keeps calling the single-level function at R = 1
+ *    to stay byte-stable against the committed dataset).
+ *  - one pooled Sample → a point interval (`resamples: 0`, `lo === hi === median`), never a fabricated
+ *    bound, exactly as the single-level bootstrap does.
+ */
+export function hierarchicalBootstrapMedianInterval(
+	replicates: readonly (readonly number[])[],
+	options: { resamples?: number; level?: number; seed?: string } = {},
+): MedianInterval {
+	assertReplicates("hierarchicalBootstrapMedianInterval", replicates);
+	const level = options.level ?? 0.95;
+	if (!(level > 0 && level < 1)) {
+		throw new Error(`hierarchicalBootstrapMedianInterval() requires level in (0, 1); got ${level}`);
+	}
+	const resamples = options.resamples ?? DEFAULT_RESAMPLES;
+	if (!Number.isInteger(resamples) || resamples < 1) {
+		throw new Error(
+			`hierarchicalBootstrapMedianInterval() requires resamples to be a positive integer; got ${resamples}`,
+		);
+	}
+
+	const pooled = replicates.flat();
+	const median = percentileOf(pooled, 0.5);
+	// A single pooled Sample carries no information about its own spread — degenerate to a point interval
+	// rather than resampling one value into a fake bound (mirrors {@link bootstrapMedianInterval}).
+	if (pooled.length === 1) return { median, lo: median, hi: median, level, resamples: 0 };
+
+	const rng = seededRng(options.seed ?? "sandbox-benchmarks");
+	const medians = new Float64Array(resamples);
+	for (let b = 0; b < resamples; b++) medians[b] = hierarchicalResampleMedian(replicates, rng);
+	const sorted = Array.from(medians).sort((a, b) => a - b);
+	const tail = (1 - level) / 2;
+	return {
+		median,
+		lo: percentile(sorted, tail),
+		hi: percentile(sorted, 1 - tail),
+		level,
+		resamples,
+	};
+}
+
+/** A bootstrapped interval around the DIFFERENCE in two Metrics' medians, plus the cluster-level
+ *  separation verdict a ranking reads. Interval and verdict come from deliberately-different methods. */
+export interface MedianDifferenceInterval {
+	/** Observed difference: median(pooled A) − median(pooled B). Sign follows the argument order. */
+	difference: number;
+	/** Lower/upper bound of the hierarchical-bootstrap interval at {@link level} — the DISPLAYED interval. */
+	lo: number;
+	hi: number;
+	/** Coverage, e.g. 0.95. */
+	level: number;
+	/** Resamples drawn for the interval. `0` is the degenerate single-pooled-Sample-per-side case: the
+	 *  bounds collapse to the observed `difference`. */
+	resamples: number;
+	/**
+	 * How the verdict's p-value was computed, straight from the underlying {@link mannWhitneyU}: `exact` —
+	 * enumerated over the cluster permutation null — up to that test's exact-N ceiling (`MAX_EXACT_N` total
+	 * sandboxes, far beyond any R this benchmark runs), and the normal `asymptotic` approximation only
+	 * above it. Surfaced so a consumer is never told an approximated verdict is exact.
+	 */
+	method: PValueMethod;
+	/**
+	 * Two-sided p-value of the cluster-level rank permutation — Mann-Whitney U on each side's per-sandbox
+	 * medians, with whole replicate sandboxes as the exchangeable unit (exact per {@link method}). This,
+	 * not the interval, decides {@link separated}: MW on Samples pooled across replicates treats clustered
+	 * draws as independent (anti-conservative), while the CI's `lo > 0 || hi < 0` rule read between-provider
+	 * power off within-sandbox spread and over-claimed at small R. Resampling the sandboxes is honest.
+	 */
+	pValue: number;
+	/**
+	 * The smallest p this comparison could ever yield — the attainable floor under complete separation. It
+	 * depends on the sandbox counts AND the tie pattern among the per-sandbox medians (for DISTINCT medians
+	 * it is `2/C(R_a+R_b, R_a)`: 1 at R=1, 0.1 at R=3, 0.029 at R=4). When it already meets or exceeds
+	 * α (= 1 − {@link level}) the comparison is UNDERPOWERED: no data separates the two at this coverage,
+	 * so a consumer must not read a non-separation as a tie. Mirrors {@link mannWhitneyU}'s field of the
+	 * same name — because it IS that field, computed on the per-sandbox medians.
+	 */
+	minAttainablePValue: number;
+	/**
+	 * Separation verdict: {@link pValue} < α (α = 1 − {@link level}). True only when the sandboxes
+	 * themselves separate the two providers — never from within-sandbox spread alone, and never below the
+	 * R ≥ 4 the 5% floor requires. A single sandbox per side (however many in-sandbox trials) can never be
+	 * separated: its 1-vs-1 cluster test floors at p = 1.
+	 */
+	separated: boolean;
+}
+
+/**
+ * Compare two Metrics measured across replicate sandboxes, returning BOTH a displayed interval and a
+ * separation verdict — computed by different, deliberately-matched methods:
+ *
+ *  - INTERVAL (`lo`/`hi`): the hierarchical bootstrap of the difference in medians. Each resample draws a
+ *    hierarchical median for A and one for B (replicates with replacement, then Samples within) from ONE
+ *    shared seeded RNG and records their difference; the interval is the [α/2, 1−α/2] envelope. Because
+ *    that RNG draws A then B in order, the bounds depend on argument ORDER — reversing A and B negates
+ *    `difference` but need not mirror `lo`/`hi`. A deliberate trade for one reproducible seed; the
+ *    leaderboard always calls it higher-vs-lower, so the committed artifact stays byte-stable.
+ *
+ *  - VERDICT (`separated`/`pValue`/`minAttainablePValue`/`method`): a cluster-level rank permutation —
+ *    {@link mannWhitneyU} on each side's per-sandbox medians, with whole sandboxes as the exchangeable
+ *    unit (EXACT up to that test's exact-N ceiling — far beyond any real R — else asymptotic; see
+ *    `method`). Unlike the interval this is ORDER-INVARIANT and carries the honest attainable floor
+ *    (`2/C(R_a+R_b, R_a)` for distinct medians), so a single sandbox per side never separates and R < 4
+ *    cannot clear α = 0.05. It replaces the old "interval clears 0" rule, which over-claimed separation.
+ *
+ * Deterministic given `seed`, so a committed leaderboard built from it is byte-stable across machines.
+ */
+export function bootstrapMedianDifferenceInterval(
+	a: readonly (readonly number[])[],
+	b: readonly (readonly number[])[],
+	options: { resamples?: number; level?: number; seed?: string } = {},
+): MedianDifferenceInterval {
+	assertReplicates("bootstrapMedianDifferenceInterval", a);
+	assertReplicates("bootstrapMedianDifferenceInterval", b);
+	const level = options.level ?? 0.95;
+	if (!(level > 0 && level < 1)) {
+		throw new Error(`bootstrapMedianDifferenceInterval() requires level in (0, 1); got ${level}`);
+	}
+	const resamples = options.resamples ?? DEFAULT_RESAMPLES;
+	if (!Number.isInteger(resamples) || resamples < 1) {
+		throw new Error(
+			`bootstrapMedianDifferenceInterval() requires resamples to be a positive integer; got ${resamples}`,
+		);
+	}
+
+	const pooledA = a.flat();
+	const pooledB = b.flat();
+	const difference = percentileOf(pooledA, 0.5) - percentileOf(pooledB, 0.5);
+
+	// VERDICT — a cluster-level rank permutation: Mann-Whitney U on each side's per-sandbox medians (one
+	// summary per replicate), so the sandboxes themselves are the exchangeable unit. It is EXACT up to
+	// mannWhitneyU's MAX_EXACT_N total sandboxes (far beyond any real R), asymptotic above; `method` records
+	// which. Its `minAttainablePValue` is the honest between-sandbox floor — 1 at R=1, 0.1 at R=3 — the
+	// power the CI rule below cannot see. `separated` reads this, never the interval.
+	const clusterTest = mannWhitneyU(
+		a.map((replicate) => percentileOf(replicate, 0.5)),
+		b.map((replicate) => percentileOf(replicate, 0.5)),
+	);
+	const { pValue, minAttainablePValue, method } = clusterTest;
+	const separated = pValue < 1 - level;
+
+	// INTERVAL — one pooled Sample per side carries no spread, so the DISPLAYED interval degenerates to a
+	// point (resamples: 0) rather than 10 000 identical draws. The verdict above already forced `separated`
+	// false for it (its 1-vs-1 cluster test floors at p = 1).
+	if (pooledA.length === 1 && pooledB.length === 1) {
+		return {
+			difference,
+			lo: difference,
+			hi: difference,
+			level,
+			resamples: 0,
+			method,
+			pValue,
+			minAttainablePValue,
+			separated,
+		};
+	}
+	const rng = seededRng(options.seed ?? "sandbox-benchmarks");
+	const diffs = new Float64Array(resamples);
+	for (let i = 0; i < resamples; i++) {
+		diffs[i] = hierarchicalResampleMedian(a, rng) - hierarchicalResampleMedian(b, rng);
+	}
+	const sorted = Array.from(diffs).sort((x, y) => x - y);
+	const tail = (1 - level) / 2;
+	const lo = percentile(sorted, tail);
+	const hi = percentile(sorted, 1 - tail);
+	return { difference, lo, hi, level, resamples, method, pValue, minAttainablePValue, separated };
+}
+
 /** Standard normal CDF, via a rational approximation to erfc (Numerical Recipes `erfcc`,
  *  |ε| < 1.2e-7 — far finer than any p-value we act on). */
 function normalCdf(z: number): number {

--- a/packages/schema/src/run.test.ts
+++ b/packages/schema/src/run.test.ts
@@ -42,8 +42,88 @@ describe("Run schema", () => {
 		expect(run.providers[0]?.validationStatus).toBe("validated");
 	});
 
+	it("accepts both the v2 and v3 schemaVersion", () => {
+		expect(parseRun({ ...validRun, schemaVersion: "2" }).schemaVersion).toBe("2");
+		expect(parseRun({ ...validRun, schemaVersion: "3" }).schemaVersion).toBe("3");
+	});
+
+	it("rejects a v2 Run that carries a v3-only replicate field", () => {
+		// replicateIndex and MetricResult.replicates are v3-only; a v2 document that carries either is a
+		// producer that wrote a replicate field without bumping schemaVersion — rejected at the boundary so
+		// "v2 == the pre-replicate schema" stays a real guarantee.
+		expect(() => parseRun({ ...validRun, schemaVersion: "2", replicateIndex: 0 })).toThrow(
+			/v3 Run/,
+		);
+		const v2WithReplicates = structuredClone(validRun);
+		v2WithReplicates.schemaVersion = "2"; // stays v2 while carrying an otherwise-consistent breakdown
+		const metric = v2WithReplicates.providers[0]?.metrics[0];
+		if (metric)
+			(metric as Record<string, unknown>).replicates = [
+				{ index: 0, samples: [16.19, 16.3] },
+				{ index: 1, samples: [16.08] },
+			];
+		expect(() => parseRun(v2WithReplicates)).toThrow(/v3 Run/);
+		// A v3 shard legitimately carries the replicateIndex.
+		expect(parseRun({ ...validRun, schemaVersion: "3", replicateIndex: 2 }).replicateIndex).toBe(2);
+	});
+
 	it("rejects an unknown schemaVersion", () => {
-		expect(() => parseRun({ ...validRun, schemaVersion: "3" })).toThrow();
+		expect(() => parseRun({ ...validRun, schemaVersion: "1" })).toThrow();
+		expect(() => parseRun({ ...validRun, schemaVersion: "4" })).toThrow();
+	});
+
+	it("accepts a v3 Metric carrying a consistent replicate breakdown", () => {
+		const withReplicates = structuredClone(validRun);
+		withReplicates.schemaVersion = "3";
+		const provider = withReplicates.providers[0];
+		const metric = provider?.metrics[0];
+		if (metric) {
+			// Pooled samples are the union of the two replicate slices, aggregates match the pooled set.
+			(metric as Record<string, unknown>).replicates = [
+				{ index: 0, samples: [16.19, 16.3] },
+				{ index: 1, samples: [16.08] },
+			];
+		}
+		expect(parseRun(withReplicates).providers[0]?.metrics[0]?.replicates).toHaveLength(2);
+	});
+
+	it("rejects a v3 Run that carries both a shard replicateIndex and folded replicates", () => {
+		// replicateIndex marks a per-replicate SHARD (pre-fold); MetricResult.replicates marks the AGGREGATE
+		// (the fold across shards, which drops replicateIndex). A Run with both is neither — reject it.
+		const both = structuredClone(validRun);
+		both.schemaVersion = "3";
+		(both as Record<string, unknown>).replicateIndex = 0;
+		const metric = both.providers[0]?.metrics[0];
+		if (metric)
+			(metric as Record<string, unknown>).replicates = [
+				{ index: 0, samples: [16.19, 16.3] },
+				{ index: 1, samples: [16.08] },
+			];
+		expect(() => parseRun(both)).toThrow(/never both/);
+	});
+
+	it("rejects a replicate breakdown that disagrees with the pooled samples", () => {
+		const bad = structuredClone(validRun);
+		bad.schemaVersion = "3";
+		const metric = bad.providers[0]?.metrics[0];
+		// samples are [16.19, 16.3, 16.08]; the replicates below pool to a different multiset.
+		if (metric)
+			(metric as Record<string, unknown>).replicates = [
+				{ index: 0, samples: [16.19, 16.3] },
+				{ index: 1, samples: [99] },
+			];
+		expect(() => parseRun(bad)).toThrow();
+	});
+
+	it("rejects a lone replicate (a single sandbox is just samples)", () => {
+		const bad = structuredClone(validRun);
+		bad.schemaVersion = "3";
+		const metric = bad.providers[0]?.metrics[0];
+		if (metric)
+			(metric as Record<string, unknown>).replicates = [
+				{ index: 0, samples: [16.19, 16.3, 16.08] },
+			];
+		expect(() => parseRun(bad)).toThrow();
 	});
 
 	it("rejects a non-positive target spec", () => {

--- a/packages/schema/src/run.ts
+++ b/packages/schema/src/run.ts
@@ -15,6 +15,20 @@ import { directionSchema } from "./metrics.ts";
 export const validationStatusSchema = type("'validated' | 'pending'");
 export type ValidationStatus = typeof validationStatusSchema.infer;
 
+/**
+ * One replicate sandbox's contribution to a Metric: the raw per-pass Samples that one (provider, suite)
+ * replicate produced, tagged with its {@link index}. Present only on a Metric merged from ≥2 replicate
+ * shards ({@link MetricResult.replicates}); the pooled `samples`/`aggregates` above stay the ranking
+ * value, this is the between-sandbox breakdown the hierarchical-bootstrap inference reads.
+ */
+export const metricReplicateSchema = type({
+	// The replicate sandbox this slice came from (the `--replicate` index the shard was run under).
+	index: "number.integer >= 0",
+	// This replicate's retained per-pass Samples (>= 1, all finite — enforced by the parent narrow).
+	samples: "number[] >= 1",
+});
+export type MetricReplicate = typeof metricReplicateSchema.infer;
+
 /** One catalogued Metric's result: the retained Samples and their distribution, with provenance. */
 export const metricResultSchema = type({
 	metricId: "string",
@@ -29,6 +43,11 @@ export const metricResultSchema = type({
 	// was measured under, so a profile/option bump can't silently shift numbers across Runs.
 	"appVersion?": "string",
 	"arguments?": "string",
+	// The per-replicate breakdown, set only when the aggregate merged ≥2 replicate sandboxes for this
+	// Metric. `samples` above is the pooled union (the ranking median is unchanged); `replicates` keeps
+	// the clusters distinct so render-time inference can resample the between-sandbox level. Absent at
+	// R = 1, so a single-replicate Run is byte-identical to the pre-replicate schema.
+	"replicates?": metricReplicateSchema.array(),
 }).narrow((metric, ctx) => {
 	// `aggregate()` already guarantees these at the producer; enforce them at the dataset boundary too,
 	// so a hand-edited/corrupt persisted Run can't carry NaN/Infinity samples or a sample count that
@@ -38,6 +57,40 @@ export const metricResultSchema = type({
 	}
 	if (metric.aggregates.n !== metric.samples.length) {
 		return ctx.mustBe("a MetricResult whose aggregates.n equals samples.length");
+	}
+	if (metric.replicates !== undefined) {
+		// The replicate structure only exists to hold ≥2 clusters; a lone replicate is just `samples`.
+		if (metric.replicates.length < 2) {
+			return ctx.mustBe(
+				"a MetricResult whose replicates hold at least two sandboxes (or omit them)",
+			);
+		}
+		const indices = new Set<number>();
+		const pooled: number[] = [];
+		for (const replicate of metric.replicates) {
+			if (indices.has(replicate.index)) {
+				return ctx.mustBe("a MetricResult whose replicate indices are distinct");
+			}
+			indices.add(replicate.index);
+			if (!replicate.samples.every((s) => Number.isFinite(s))) {
+				return ctx.mustBe("a MetricResult whose replicate samples are all finite");
+			}
+			pooled.push(...replicate.samples);
+		}
+		// The pooled `samples` must be exactly the union of the replicate slices (as a multiset), so the
+		// ranking distribution and the between-sandbox breakdown can never silently disagree.
+		if (pooled.length !== metric.samples.length) {
+			return ctx.mustBe(
+				"a MetricResult whose pooled samples count equals the sum of its replicates",
+			);
+		}
+		const sortedPooled = [...pooled].sort((a, b) => a - b);
+		const sortedSamples = [...metric.samples].sort((a, b) => a - b);
+		if (!sortedPooled.every((value, i) => value === sortedSamples[i])) {
+			return ctx.mustBe(
+				"a MetricResult whose pooled samples are the union of its replicate samples",
+			);
+		}
 	}
 	return true;
 });
@@ -210,22 +263,56 @@ export type ProviderRun = typeof providerRunSchema.infer;
 /**
  * A full benchmark Run: every provider measured against one pinned target spec at one SHA.
  *
- * `schemaVersion` is `"2"`: v1's `skips: { suite, reason }[]` could not say whether a benchmark was
- * deliberately not run or had crashed, and carried no positive record of what DID run — so a suite
- * that vanished (job died, artifact never uploaded) left no trace anywhere in the document. v2
- * replaces it with {@link resultGapSchema} + {@link ProviderRun.suitesCovered}. The committed dataset
- * is migrated in place, not dual-read: one shape, validated at every boundary.
+ * `schemaVersion` accepts `"2"` and `"3"`. v1's `skips: { suite, reason }[]` could not say whether a
+ * benchmark was deliberately not run or had crashed, and carried no positive record of what DID run —
+ * so a suite that vanished (job died, artifact never uploaded) left no trace anywhere in the document.
+ * v2 replaced it with {@link resultGapSchema} + {@link ProviderRun.suitesCovered}. v3 adds the
+ * replicate model: a shard Run carries its {@link replicateIndex}, and the aggregate folds ≥2
+ * replicate sandboxes of one (provider, suite) into {@link MetricResult.replicates}. Both versions
+ * validate here — already-published v2 Runs (single replicate, no `replicates` field) are read
+ * unchanged, and the parser never migrates them in place.
  */
 export const runSchema = type({
-	schemaVersion: "'2'",
+	schemaVersion: "'2' | '3'",
 	runId: "string",
 	sha: "string",
 	// ISO-8601 timestamp the Run was generated at — validated so the RunIndex sort key can't be a
 	// free-form string ("tomorrow") that silently breaks newest-first ordering.
 	generatedAt: "string.date.iso",
 	"sourceRunUrl?": "string",
+	// The replicate sandbox index a SHARD Run was measured under (the `--replicate` argument). Present on
+	// a per-replicate shard; the aggregate reads it to key {@link MetricResult.replicates} and drops it
+	// from the merged Run (which spans every replicate). Absent on legacy shards and aggregated Runs.
+	"replicateIndex?": "number.integer >= 0",
 	targetSpec: targetSpecSchema,
 	providers: providerRunSchema.array(),
+}).narrow((run, ctx) => {
+	// The replicate fields (`replicateIndex`, `MetricResult.replicates`) are v3-only, so "v2 == the
+	// pre-replicate schema" stays a real guarantee: a producer that writes a replicate field but forgets
+	// to bump schemaVersion is rejected here rather than silently read by a v3-gated consumer that then
+	// ignores the between-sandbox breakdown (reporting the anti-conservative pooled interval instead).
+	if (run.schemaVersion !== "3") {
+		if (run.replicateIndex !== undefined) {
+			return ctx.mustBe("a v3 Run when it carries a replicateIndex");
+		}
+		if (
+			run.providers.some((provider) => provider.metrics.some((m) => m.replicates !== undefined))
+		) {
+			return ctx.mustBe("a v3 Run when a MetricResult carries replicates");
+		}
+	}
+	// `replicateIndex` marks a per-replicate SHARD (one sandbox, not yet folded); `MetricResult.replicates`
+	// marks the AGGREGATE (the fold across shards, which drops `replicateIndex`). A Run carrying both is
+	// neither — reject it here rather than leave a consumer to guess which level it is looking at.
+	if (
+		run.replicateIndex !== undefined &&
+		run.providers.some((provider) => provider.metrics.some((m) => m.replicates !== undefined))
+	) {
+		return ctx.mustBe(
+			"either a replicate shard (replicateIndex, no folded replicates) or an aggregate (folded replicates, no replicateIndex), never both",
+		);
+	}
+	return true;
 });
 export type Run = typeof runSchema.infer;
 


### PR DESCRIPTION
**bench-matrix refactor — replicate-aware benchmark pipeline**

Shipped as a 4-PR stack (merge bottom-up, each branch is independently green and tree-verified):
1. #192 — **schema-core**: replicate stats primitives + v3 run schema
2. #193 — **suite-catalog**: restructure suites + catalog (pgbench split, cpu-generic retired, per-tier k/R)
3. #194 — **harness-k**: per-suite `ptsTimesToRun` (k) in the sandbox preamble
4. #195 — **results-replicate**: fold replicate shards + replicate-aware leaderboard ranking

↑ **This PR is #192 (1/4)** — based on `main`.

---

The schema foundation for the replicate-based benchmark pipeline. Pure-additive and inert in production (all current data is R=1): nothing emits v3 or calls the new stats yet — the results package upstack (#195) consumes them.

- **analysis.ts**: a hierarchical (two-level) bootstrap median interval and a difference-in-medians CI separation test (`canSeparate`), each degenerating to the ordinary percentile bootstrap at R=1 so the render path is byte-identical.
- **run.ts**: `schemaVersion "3"` (`parseRun` accepts `"2"` and `"3"`; already-published v2 Runs read unchanged, never migrated in place). Adds the optional `MetricResult.replicates` breakdown and shard-level `Run.replicateIndex`, with `narrow()` cross-field validation (≥2 distinct replicates whose pooled samples are exactly the union of the slices).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds replicate-aware stats primitives and a v3 run schema for multi-sandbox benchmarks. R=1 output stays identical; v2 runs parse unchanged.

- **New Features**
  - `packages/schema/src/analysis.ts`: Add `hierarchicalBootstrapMedianInterval` and replicate-aware `bootstrapMedianDifferenceInterval` with exact per-replicate Mann–Whitney U (order-invariant) and `pValue`/`minAttainablePValue`/`method`. Deterministic by seed; hierarchical bootstrap; degenerates to ordinary bootstrap at R=1 and to a point when a side pools to one sample.
  - `packages/schema/src/run.ts`: Accept `schemaVersion` "2" or "3". Add `MetricResult.replicates` and shard `replicateIndex` with validation (≥2 replicates, distinct indices, finite samples, pooled union matches `samples`, `aggregates.n === samples.length`). V3-only gating rejects v2 runs with replicate fields and runs mixing `replicateIndex` with folded `replicates`; unknown versions rejected.

- **Migration**
  - No changes needed; existing v2 data reads as-is.
  - To enable replicate-aware stats, emit `schemaVersion: "3"` with per-metric `replicates` and shard `replicateIndex`. R=1 remains byte-identical.

<sup>Written for commit abee8db1cfdfb62e8541ce304396d5fa913e6da0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/starslingdev/hpc-sandbox-benchmarks/pull/192?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added schema version 3 support for replicate-level metric data, including shard vs aggregate replicate modeling and pooled-sample consistency checks.
  * Introduced replicate-aware hierarchical bootstrap median interval and median-difference interval with seeded, reproducible resampling and separation verdicts.
* **Bug Fixes**
  * Strengthened validation to reject incompatible schema versions and inconsistent/invalid replicate payloads (including mutual-exclusion and “lone replicate” cases).
* **Tests**
  * Expanded coverage for interval correctness (edge cases like `resamples: 0`), bracketing, reproducibility, and option/input validation; added v2/v3 boundary tests for run parsing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->