### PR TITLE
feat(harness): thread per-suite ptsTimesToRun (k) into the sandbox preamble

### DIFF
--- a/lib/bench.sh
+++ b/lib/bench.sh
@@ -269,10 +269,10 @@ _configure_pts_batch() {
 	export TEST_RESULTS_DESCRIPTION=ci
 	export TEST_RESULTS_IDENTIFIER=ci
 	# FORCE_TIMES_TO_RUN=1 pins contract-verification runs to a single pass. Published sandbox runs
-	# export PTS_RESPECT_TIMES_TO_RUN=1 plus FORCE_TIMES_TO_RUN=2 in the harness preamble: two balanced
-	# trials are the pinned count (see the preamble on why more trials aren't bought), while disabling
-	# PTS's adaptive variance policy (which otherwise expanded noisy fio cases to 20-40 runs and
-	# exhausted the suite).
+	# export PTS_RESPECT_TIMES_TO_RUN=1 plus a per-suite FORCE_TIMES_TO_RUN (k) in the harness preamble
+	# (Suite.ptsTimesToRun: realworld k=1, long synthetic k=2), while disabling PTS's adaptive
+	# variance policy (which otherwise expanded noisy fio cases to 20-40 runs and exhausted the suite).
+	# Between-sandbox variance is captured by REPLICATE sandboxes, not by more in-sandbox passes.
 	if [ -z "${PTS_RESPECT_TIMES_TO_RUN:-}" ]; then
 		export FORCE_TIMES_TO_RUN=1
 	fi

--- a/packages/harness/src/index.test.ts
+++ b/packages/harness/src/index.test.ts
@@ -402,6 +402,18 @@ describe("runSuiteOnSandbox (orchestration + teardown)", () => {
 		expect(destroyed.hit).toBe(true);
 	});
 
+	it("tears the sandbox down when an invalid ptsTimesToRun (k < 1) fails preamble construction", async () => {
+		// StepRunner builds the preamble in its constructor, and buildPreamble rejects k < 1. That throw
+		// must land inside the teardown try/finally rather than before it — otherwise the already-created
+		// sandbox leaks. Guards the "constructed inside the try" placement in runSuiteOnSandbox.
+		const destroyed = { hit: false };
+		const sandbox = makeSandbox({ destroyed });
+		await expect(
+			runSuiteOnSandbox(sandbox, ctx(suite({ ptsTimesToRun: 0 }), freshDir())),
+		).rejects.toThrow(/positive integer/);
+		expect(destroyed.hit).toBe(true);
+	});
+
 	it("tears the sandbox down even when the benchmark fails, and propagates the error", async () => {
 		const destroyed = { hit: false };
 		const sandbox = makeSandbox({ destroyed, benchmarkFails: true });

--- a/packages/harness/src/index.ts
+++ b/packages/harness/src/index.ts
@@ -269,9 +269,12 @@ export async function runSuiteOnSandbox(
 	ctx: SuiteRunContext,
 ): Promise<void> {
 	const { suite, suiteName, providerName, resultsDir, transport } = ctx;
-	const runner = new StepRunner(sandbox, transport);
 	let suiteError: unknown;
 	try {
+		// Thread the suite's in-sandbox repeat count (k) into the preamble; absent → the harness default.
+		// Constructed inside the try so a bad k (buildPreamble rejects k < 1) is still torn down by the
+		// finally below; a throw before the try would leak the already-created sandbox.
+		const runner = new StepRunner(sandbox, transport, undefined, suite.ptsTimesToRun);
 		runner.phase = "setup";
 		if (suite.minDiskGb) {
 			const df = await runner.run("check free disk", "df -Pk / | awk 'NR==2 {print $4}'", MIN);

--- a/packages/harness/src/lib/execute.test.ts
+++ b/packages/harness/src/lib/execute.test.ts
@@ -1,7 +1,14 @@
 import { describe, expect, it } from "bun:test";
 import type { ProviderTransport } from "@sandbox-benchmarks/schema";
 import type { SandboxHandle } from "./execute.ts";
-import { MIN, PREAMBLE, StepRunner, selectTransport, shellQuote } from "./execute.ts";
+import {
+	buildPreamble,
+	MIN,
+	PREAMBLE,
+	StepRunner,
+	selectTransport,
+	shellQuote,
+} from "./execute.ts";
 
 const CAPPED: ProviderTransport = { streaming: false, syncCapMs: MIN, detachedPoll: true };
 const UNCAPPED: ProviderTransport = { streaming: false, syncCapMs: null, detachedPoll: true };
@@ -45,9 +52,31 @@ describe("sandbox preamble", () => {
 		expect(PREAMBLE).toContain("PTS_USER_PATH_OVERRIDE=/var/lib/phoronix-test-suite/");
 	});
 
-	it("uses two fixed PTS trials for a publishable comparison", () => {
-		expect(PREAMBLE).toContain("PTS_RESPECT_TIMES_TO_RUN=1");
-		expect(PREAMBLE).toContain("FORCE_TIMES_TO_RUN=2");
+	// buildPreamble omits the trial vars entirely under BENCH_PASSES=1 (contract-verification mode), so
+	// these trial-count assertions only hold outside it — skip in that mode rather than fail a contract run.
+	it.skipIf(process.env.BENCH_PASSES === "1")(
+		"uses two fixed PTS trials by default for a publishable comparison",
+		() => {
+			expect(PREAMBLE).toContain("PTS_RESPECT_TIMES_TO_RUN=1");
+			expect(PREAMBLE).toContain("FORCE_TIMES_TO_RUN=2");
+		},
+	);
+
+	it.skipIf(process.env.BENCH_PASSES === "1")(
+		"pins the PTS repeat count (k) a suite requests",
+		() => {
+			expect(buildPreamble(1)).toContain("FORCE_TIMES_TO_RUN=1");
+			expect(buildPreamble(3)).toContain("FORCE_TIMES_TO_RUN=3");
+			// The variance-driven policy stays disabled at every k so a noisy provider can't stretch a suite.
+			expect(buildPreamble(3)).toContain("PTS_RESPECT_TIMES_TO_RUN=1");
+		},
+	);
+
+	it("rejects a non-positive or fractional k (would emit an empty/bogus FORCE_TIMES_TO_RUN)", () => {
+		// Throws before touching the env, so this holds in every mode including BENCH_PASSES=1.
+		expect(() => buildPreamble(0)).toThrow(/positive integer/);
+		expect(() => buildPreamble(-1)).toThrow(/positive integer/);
+		expect(() => buildPreamble(1.5)).toThrow(/positive integer/);
 	});
 });
 
@@ -78,6 +107,25 @@ describe("StepRunner", () => {
 		expect(commands[0]).toContain(PREAMBLE);
 		expect(commands[0]).toContain("echo hi");
 	});
+
+	// Same BENCH_PASSES=1 caveat as the preamble tests above: the k is only emitted when trials are on.
+	it.skipIf(process.env.BENCH_PASSES === "1")(
+		"threads a per-suite PTS repeat count (k) into every step's preamble",
+		async () => {
+			const commands: string[] = [];
+			const sandbox: SandboxHandle = {
+				runCommand: async (command) => {
+					commands.push(command);
+					return { exitCode: 0, stdout: "ok" };
+				},
+				destroy: async () => undefined,
+			};
+			const runner = new StepRunner(sandbox, undefined, undefined, 3);
+			await runner.run("echo", "echo hi", 5_000);
+			expect(commands[0]).toContain("FORCE_TIMES_TO_RUN=3");
+			expect(commands[0]).not.toContain("FORCE_TIMES_TO_RUN=2");
+		},
+	);
 
 	it("throws on a non-zero exit unless allowFailure is set", async () => {
 		const sandbox: SandboxHandle = {

--- a/packages/harness/src/lib/execute.ts
+++ b/packages/harness/src/lib/execute.ts
@@ -154,11 +154,20 @@ function parseExitCode(raw: string): number {
 }
 
 /**
- * Re-establish env + PATH on every step (each runCommand is a fresh shell). `$SUDO` covers both root
- * images (no prefix) and non-root images with sudo. The toolchain image (packages/templates/images)
- * installs mise globally under /mise, so prefer it when present.
+ * The default in-sandbox repeat count (k) applied when a suite pins none: two timed PTS passes per case
+ * — the balanced count published comparisons use (PR #129 lowered it from three). A per-suite override
+ * (`Suite.ptsTimesToRun`) is threaded through {@link StepRunner}; replicate sandboxes (aggregate.ts),
+ * not extra in-sandbox passes, carry the between-machine variance.
  */
-export const PREAMBLE = [
+export const DEFAULT_PTS_TIMES_TO_RUN = 2;
+
+/**
+ * The static head of the in-sandbox preamble: env + PATH re-established on every step (each runCommand is
+ * a fresh shell). `$SUDO` covers both root images (no prefix) and non-root images with sudo. The
+ * toolchain image (packages/templates/images) installs mise globally under /mise, so prefer it when
+ * present. The trials + sudo tail is appended by {@link buildPreamble}, which pins the PTS repeat count.
+ */
+const PREAMBLE_HEAD = [
 	"set -eo pipefail",
 	"export DEBIAN_FRONTEND=noninteractive",
 	// biome-ignore lint/suspicious/noTemplateCurlyInString: bash expansion, not a JS template
@@ -181,17 +190,36 @@ export const PREAMBLE = [
 	// E2B-compatible builders inject an unprivileged runtime user. Point PTS at the root-baked profile
 	// registry explicitly even if a provider strips the Docker ENV while importing the image.
 	"if [ -d /var/lib/phoronix-test-suite ]; then export PTS_USER_PATH_OVERRIDE=/var/lib/phoronix-test-suite/; fi",
-	// Published comparisons use exactly two trials per PTS case — the balanced count the suites pin
-	// (PR #129 lowered it from three). Five overran the command and sandbox lifetimes (a two-repeat run
-	// already took ~67 min), and chasing significance with more trials is a non-goal: the leaderboard
-	// LABELS underpowered comparisons rather than buying statistical power with extra runs. Fixing the
-	// count also prevents PTS's variance-driven policy from giving noisy providers 20-40 trials until the
-	// suite times out. BENCH_PASSES=1 keeps contract-verification runs at one pass via lib/bench.sh.
-	...(process.env.BENCH_PASSES === "1"
-		? []
-		: ["export PTS_RESPECT_TIMES_TO_RUN=1", "export FORCE_TIMES_TO_RUN=2"]),
-	'if [ "$(id -u)" = 0 ]; then SUDO=""; elif command -v sudo >/dev/null 2>&1; then SUDO="sudo -E"; else SUDO=""; fi',
-].join("; ");
+];
+
+/**
+ * The full preamble string for a step, pinning `ptsTimesToRun` (k) timed PTS passes per case. PTS's
+ * variance-driven policy is disabled (PTS_RESPECT_TIMES_TO_RUN=1) so a noisy provider can't stretch a
+ * suite to 20-40 passes; between-sandbox variance is captured by REPLICATE sandboxes (aggregate.ts), not
+ * more in-sandbox passes, and the leaderboard LABELS underpowered comparisons rather than buying
+ * significance with extra runs. BENCH_PASSES=1 keeps contract-verification runs at one pass via
+ * lib/bench.sh. Suites pin k per tier (realworld k=1, long synthetic k=2).
+ */
+export function buildPreamble(ptsTimesToRun: number = DEFAULT_PTS_TIMES_TO_RUN): string {
+	// A non-positive or fractional k would emit `FORCE_TIMES_TO_RUN=0` (a silently empty benchmark) or a
+	// bogus value into the shell — fail loudly instead, the same fail-fast posture analysis.ts takes.
+	if (!Number.isInteger(ptsTimesToRun) || ptsTimesToRun < 1) {
+		throw new Error(
+			`buildPreamble() requires ptsTimesToRun to be a positive integer; got ${ptsTimesToRun}`,
+		);
+	}
+	return [
+		...PREAMBLE_HEAD,
+		...(process.env.BENCH_PASSES === "1"
+			? []
+			: ["export PTS_RESPECT_TIMES_TO_RUN=1", `export FORCE_TIMES_TO_RUN=${ptsTimesToRun}`]),
+		'if [ "$(id -u)" = 0 ]; then SUDO=""; elif command -v sudo >/dev/null 2>&1; then SUDO="sudo -E"; else SUDO=""; fi',
+	].join("; ");
+}
+
+/** The preamble at the default repeat count (k = 2) — the StepRunner default and the value the preamble
+ *  tests pin; a per-suite k is threaded through {@link StepRunner}. */
+export const PREAMBLE = buildPreamble();
 
 /** Print liveness every 2 min while a long step runs — exec transports buffer output, so without
  *  this a healthy multi-minute benchmark looks hung in the CI log. */
@@ -214,6 +242,8 @@ export class StepRunner {
 	phase: Phase = "setup";
 	/** Every executed step with its phase, elapsed ms, and exit code. */
 	readonly stepLog: StepLogEntry[] = [];
+	/** The in-sandbox preamble prepended to every step, pinned to this suite's PTS repeat count (k). */
+	private readonly preamble: string;
 
 	constructor(
 		private readonly sandbox: SandboxHandle,
@@ -222,7 +252,12 @@ export class StepRunner {
 		/** The inter-poll sleep used by {@link runDetached}; injectable so tests can assert the backoff
 		 *  schedule without real waiting. */
 		private readonly sleep: (ms: number) => Promise<void> = delay,
-	) {}
+		/** The suite's in-sandbox repeat count (k) — how many timed PTS passes each case runs. Omitted →
+		 *  {@link DEFAULT_PTS_TIMES_TO_RUN}, so a StepRunner built without one keeps the old behaviour. */
+		ptsTimesToRun: number = DEFAULT_PTS_TIMES_TO_RUN,
+	) {
+		this.preamble = buildPreamble(ptsTimesToRun);
+	}
 
 	/**
 	 * Run a step on the transport the provider's {@link ProviderTransport} calls for: detached+poll when
@@ -261,7 +296,7 @@ export class StepRunner {
 		let result: CommandResult;
 		try {
 			result = await withTimeout(
-				this.sandbox.runCommand(`bash -c ${shellQuote(`${PREAMBLE}; ${script}`)}`),
+				this.sandbox.runCommand(`bash -c ${shellQuote(`${this.preamble}; ${script}`)}`),
 				timeoutMs,
 				`Step "${label}" timed out after ${Math.round(timeoutMs / 1000)}s`,
 			);
@@ -307,7 +342,7 @@ export class StepRunner {
 			// shell aborts on first failure and its real exit code flows through the `&&/||` capture —
 			// success writes 0, failure writes the real code.
 			const wrapped =
-				`bash -c ${shellQuote(`${PREAMBLE}; ${script}`)} > ${logPath} 2>&1 ` +
+				`bash -c ${shellQuote(`${this.preamble}; ${script}`)} > ${logPath} 2>&1 ` +
 				`&& echo 0 > ${donePath} || echo $? > ${donePath}`;
 			// Double-fork daemonization: a single nohup/setsid still blocks e2b's envd, which holds the
 			// exec open for as long as its DIRECT child lives (probed live: even `nohup ... &` pins the


### PR DESCRIPTION
**bench-matrix refactor — replicate-aware benchmark pipeline**

Shipped as a 4-PR stack (merge bottom-up, each branch is independently green and tree-verified):
1. #192 — **schema-core**: replicate stats primitives + v3 run schema
2. #193 — **suite-catalog**: restructure suites + catalog (pgbench split, cpu-generic retired, per-tier k/R)
3. #194 — **harness-k**: per-suite `ptsTimesToRun` (k) in the sandbox preamble
4. #195 — **results-replicate**: fold replicate shards + replicate-aware leaderboard ranking

↑ **This PR is #194 (3/4)** — based on #193.

---

Replace the global `FORCE_TIMES_TO_RUN=2` with a per-suite in-sandbox repeat count. `buildPreamble(k)` pins `FORCE_TIMES_TO_RUN=k` (`PTS_RESPECT_TIMES_TO_RUN=1` still disables PTS's adaptive variance policy that otherwise stretched noisy fio cases to 20-40 passes); `StepRunner` takes k (default `DEFAULT_PTS_TIMES_TO_RUN=2`, so an unparameterized runner keeps the old behaviour), and `runSuiteOnSandbox` threads `suite.ptsTimesToRun`. Between-sandbox variance is captured by replicate sandboxes, not extra in-sandbox passes; `lib/bench.sh`'s comment is updated to match.

Consumes `Suite.ptsTimesToRun` from the suite-catalog PR below (#193).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Thread a per-suite PTS repeat count (k) into the sandbox preamble so each suite controls how many timed passes run. Default stays 2; contract runs (`BENCH_PASSES=1`) omit trial vars, and replicate sandboxes capture variance.

- **New Features**
  - Added `buildPreamble(k)` with positive-integer validation; pins `PTS_RESPECT_TIMES_TO_RUN=1` and `FORCE_TIMES_TO_RUN=k`. `PREAMBLE` now comes from it with default `k=2`, and skips trial vars under `BENCH_PASSES=1`.
  - `StepRunner` accepts `ptsTimesToRun` and prepends a per-instance preamble to every step; `runSuiteOnSandbox` threads `suite.ptsTimesToRun`.

- **Bug Fixes**
  - Construct `StepRunner` inside the teardown try/finally so an invalid k (rejected by `buildPreamble`) still tears the sandbox down.

<sup>Written for commit 9c0c2048336680eca157e4d10b8934275e107710. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/starslingdev/hpc-sandbox-benchmarks/pull/194?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

