### PR TITLE
feat(results): fold replicate shards + replicate-aware leaderboard ranking

### DIFF
--- a/apps/cli/src/bin/bench-suite.test.ts
+++ b/apps/cli/src/bin/bench-suite.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from "bun:test";
+import { parseReplicateFlag } from "./bench-suite.ts";
+
+describe("parseReplicateFlag", () => {
+	it("returns undefined when the flag is absent", () => {
+		expect(parseReplicateFlag(["daytona", "cpu-node", "run-1"])).toBeUndefined();
+	});
+
+	it("parses both the space-separated and =-joined spellings", () => {
+		expect(parseReplicateFlag(["daytona", "--replicate", "3"])).toBe(3);
+		expect(parseReplicateFlag(["daytona", "--replicate=0"])).toBe(0);
+	});
+
+	it("takes the last occurrence when the flag repeats", () => {
+		expect(parseReplicateFlag(["--replicate", "1", "--replicate=4"])).toBe(4);
+	});
+
+	it("rejects a dangling flag, an empty operand, a negative, and a non-integer", () => {
+		expect(() => parseReplicateFlag(["--replicate"])).toThrow(/requires an index/);
+		// Number("")/Number("  ") coerce to 0, so a blank operand must throw, not silently stamp replicate 0.
+		expect(() => parseReplicateFlag(["--replicate", ""])).toThrow(/non-negative integer/);
+		expect(() => parseReplicateFlag(["--replicate="])).toThrow(/non-negative integer/);
+		expect(() => parseReplicateFlag(["--replicate", "  "])).toThrow(/non-negative integer/);
+		expect(() => parseReplicateFlag(["--replicate", "-1"])).toThrow(/non-negative integer/);
+		expect(() => parseReplicateFlag(["--replicate", "1.5"])).toThrow(/non-negative integer/);
+		expect(() => parseReplicateFlag(["--replicate", "x"])).toThrow(/non-negative integer/);
+	});
+});

--- a/apps/cli/src/bin/bench-suite.ts
+++ b/apps/cli/src/bin/bench-suite.ts
@@ -50,6 +50,8 @@ usage: bench-suite [provider] [suite] [runId]
   provider           Provider to run on (default: daytona). See --list-providers.
   suite              Suite to run (default: cpu-node). See --list-suites.
   runId              Run identifier for the data/ tree (default: local-<timestamp>).
+  --replicate <idx>  Replicate sandbox index this shard represents (a non-negative integer). Stamped
+                     onto the shard Run so the aggregate folds ≥2 replicates of one suite together.
   --require <ids>    Comma-separated providers that MUST reach "validated"; exit 1 otherwise.
                      Also read from REQUIRE_PROVIDERS. CI sets this so a missing secret fails loudly.
   --list-providers   List the registered providers.
@@ -137,9 +139,40 @@ async function failCell(opts: Omit<CellReport, "failed"> & { detail: string }): 
 	return fail(opts.detail, { annotate: false });
 }
 
+/**
+ * Parse `--replicate <idx>` / `--replicate=<idx>` into a non-negative integer, or `undefined` when the
+ * flag is absent. A dangling or non-integer value fails loudly rather than silently defaulting the shard
+ * to replicate 0 — a wrong index would collide two sandboxes into one replicate slot at aggregate time.
+ * Exported so the parsing is unit-testable without spawning a process.
+ */
+export function parseReplicateFlag(argv: readonly string[]): number | undefined {
+	let raw: string | undefined;
+	for (let i = 0; i < argv.length; i++) {
+		const arg = argv[i];
+		if (arg === "--replicate") {
+			raw = argv[i + 1];
+			if (raw === undefined) throw new Error("--replicate requires an index argument");
+		} else if (arg?.startsWith("--replicate=")) {
+			raw = arg.slice("--replicate=".length);
+		}
+	}
+	if (raw === undefined) return undefined;
+	const idx = Number(raw);
+	// Number("")/Number("  ")/Number("\n") all coerce to 0, so `--replicate=` (or `--replicate ""`) would
+	// slip through as replicate 0 — guard the blank operand explicitly, else it silently collides two
+	// sandboxes into one replicate slot at aggregate time (the exact failure this function documents).
+	if (raw.trim() === "" || !Number.isInteger(idx) || idx < 0) {
+		throw new Error(`--replicate must be a non-negative integer; got "${raw}"`);
+	}
+	return idx;
+}
+
 if (import.meta.main) {
 	const argv = process.argv.slice(2);
-	const discovery = handleDiscovery(argv, HELP, ["--require"]);
+	// Flags that consume a separate operand — one source of truth so the discovery filter and the
+	// positional-skip loop below can never enumerate different sets.
+	const VALUE_FLAGS = ["--require", "--replicate"];
+	const discovery = handleDiscovery(argv, HELP, VALUE_FLAGS);
 	if (discovery !== null) {
 		if (discovery.ok) {
 			process.stdout.write(`${discovery.text}\n`);
@@ -156,9 +189,9 @@ if (import.meta.main) {
 	for (let i = 0; i < argv.length; i++) {
 		const arg = argv[i];
 		if (arg === undefined) continue;
-		// Only the space-separated spelling needs the skip: `--require=<ids>` is a single token and is
-		// already dropped by the leading-`-` guard below.
-		if (arg === "--require") {
+		// Only the space-separated spelling needs the skip: `--require=<ids>`/`--replicate=<idx>` are
+		// single tokens already dropped by the leading-`-` guard below. Both flags take a separate operand.
+		if (VALUE_FLAGS.includes(arg)) {
 			i++;
 			continue;
 		}
@@ -170,6 +203,7 @@ if (import.meta.main) {
 	const runId = positionals[2] ?? `local-${Date.now()}`;
 	const sha = process.env.GITHUB_SHA ?? "local";
 	const cell = `${suite} / ${provider}`;
+	const replicateIndex = parseReplicateFlag(argv);
 
 	const rawRoot = join("data", "raw", runId);
 	const outFile = join("data", "runs", `${runId}.json`);
@@ -263,7 +297,14 @@ if (import.meta.main) {
 	let normalizeError: unknown;
 	await withGroup("Normalize Run document", async () => {
 		try {
-			run = writeNormalizedRun({ rawRoot, runId, sha, outFile, updateIndexFile: indexFile });
+			run = writeNormalizedRun({
+				rawRoot,
+				runId,
+				sha,
+				outFile,
+				updateIndexFile: indexFile,
+				...(replicateIndex !== undefined ? { replicateIndex } : {}),
+			});
 			logInfo(`Normalized Run ${runId} → ${outFile}`);
 			// Already inside withGroup — don't nest another ::group::.
 			await logProviderStatuses(run, { grouped: false });

--- a/packages/results/src/index.test.ts
+++ b/packages/results/src/index.test.ts
@@ -16,7 +16,7 @@ describe("normalizeResultsTree", () => {
 	});
 
 	it("validates as a Run and includes every known provider", () => {
-		expect(run.schemaVersion).toBe("2");
+		expect(run.schemaVersion).toBe("3");
 		expect(run.providers.map((provider) => provider.providerId).sort()).toEqual(
 			PROVIDERS.map((provider) => provider.id).sort(),
 		);

--- a/packages/results/src/lib/aggregate.test.ts
+++ b/packages/results/src/lib/aggregate.test.ts
@@ -25,12 +25,18 @@ function provider(providerId: string, metrics: MetricResult[]): ProviderRun {
 	};
 }
 
-function shard(providers: ProviderRun[], generatedAt = "2026-06-01T00:00:00.000Z"): Run {
+function shard(
+	providers: ProviderRun[],
+	generatedAt = "2026-06-01T00:00:00.000Z",
+	replicateIndex?: number,
+): Run {
 	return {
-		schemaVersion: "2",
+		// A shard carrying a replicate index is a v3 shard; the plain per-suite shards stay v2.
+		schemaVersion: replicateIndex === undefined ? "2" : "3",
 		runId: "run-1",
 		sha: "abc123",
 		generatedAt,
+		...(replicateIndex !== undefined ? { replicateIndex } : {}),
 		targetSpec: { vcpus: 2, memoryGb: 8, diskGb: 20 },
 		providers,
 	};
@@ -49,6 +55,66 @@ describe("aggregateRuns", () => {
 		expect(ids).toContain("node_web_tooling_runs_per_s");
 		expect(ids).toContain("pybench_milliseconds");
 		expect(daytona?.validationStatus).toBe("validated");
+	});
+
+	it("folds ≥2 replicate shards of one suite into a replicate breakdown with pooled samples", () => {
+		const r0 = shard(
+			[provider("daytona", [metric("node_web_tooling_runs_per_s", [10, 11])])],
+			"2026-06-01T00:00:00.000Z",
+			0,
+		);
+		const r1 = shard(
+			[provider("daytona", [metric("node_web_tooling_runs_per_s", [20, 21])])],
+			"2026-06-01T00:00:00.000Z",
+			1,
+		);
+
+		const merged = aggregateRuns([r0, r1]);
+		const node = merged.providers
+			.find((p) => p.providerId === "daytona")
+			?.metrics.find((m) => m.metricId === "node_web_tooling_runs_per_s");
+		// Two replicates, indexed and ordered; the pooled samples are their union; aggregates recomputed.
+		expect(node?.replicates).toEqual([
+			{ index: 0, samples: [10, 11] },
+			{ index: 1, samples: [20, 21] },
+		]);
+		expect(node?.samples).toEqual([10, 11, 20, 21]);
+		expect(node?.aggregates.n).toBe(4);
+		// The merged Run is v3 (replicate-aware); its Metric carries no single replicateIndex.
+		expect(merged.schemaVersion).toBe("3");
+	});
+
+	it("keeps a single-replicate metric verbatim — no replicates field at R = 1", () => {
+		const only = shard(
+			[provider("daytona", [metric("node_web_tooling_runs_per_s", [10, 11])])],
+			"2026-06-01T00:00:00.000Z",
+			0,
+		);
+		const node = aggregateRuns([only])
+			.providers.find((p) => p.providerId === "daytona")
+			?.metrics.find((m) => m.metricId === "node_web_tooling_runs_per_s");
+		expect(node?.replicates).toBeUndefined();
+		expect(node?.samples).toEqual([10, 11]);
+	});
+
+	it("first-wins for a duplicate metric WITHIN one replicate (result-name contamination)", () => {
+		// Same replicate index, same metric id, divergent samples — a contaminated composite, not a
+		// second sandbox. Keep the first and never build a replicate breakdown from it.
+		const a = shard(
+			[provider("daytona", [metric("node_web_tooling_runs_per_s", [10, 11])])],
+			"2026-06-01T00:00:00.000Z",
+			0,
+		);
+		const b = shard(
+			[provider("daytona", [metric("node_web_tooling_runs_per_s", [99, 99])])],
+			"2026-06-01T00:00:00.000Z",
+			0,
+		);
+		const node = aggregateRuns([a, b])
+			.providers.find((p) => p.providerId === "daytona")
+			?.metrics.find((m) => m.metricId === "node_web_tooling_runs_per_s");
+		expect(node?.replicates).toBeUndefined();
+		expect(node?.samples).toEqual([10, 11]);
 	});
 
 	it("merges different providers' shards into one Run", () => {

--- a/packages/results/src/lib/aggregate.ts
+++ b/packages/results/src/lib/aggregate.ts
@@ -1,16 +1,24 @@
 /**
  * Aggregate the per-shard {@link Run}s of one benchmark run into a single published Run. The CI matrix
- * (ENG-66) fans out one job per `(provider, suite)` cell, each emitting a Run document where only that
- * cell's provider/suite carries data. This merges them back into the one Run the dataset publishes:
- * each provider's measured Metrics unioned across suites, coverage/gaps/uncatalogued/observed-specs
- * combined, and — critically — economics RE-DERIVED from the merged measured set so `usd_per_lifecycle`
- * reflects every suite's timings, not whichever shard happened to carry them.
+ * fans out one job per `(provider, suite, replicate)` cell, each emitting a Run document where only that
+ * cell's provider/suite carries data (and, on a v3 shard, its {@link Run.replicateIndex}). This merges
+ * them back into the one Run the dataset publishes: each provider's measured Metrics unioned across
+ * suites, coverage/gaps/uncatalogued/observed-specs combined, and — critically — economics RE-DERIVED
+ * from the merged measured set so `usd_per_lifecycle` reflects every suite's timings, not whichever shard
+ * happened to carry them.
+ *
+ * Replicate sandboxes report the SAME metric id (they ran the same suite), so the merge folds them by id:
+ * ≥2 replicate slices of one metric become a {@link MetricResult.replicates} breakdown with a pooled
+ * `samples`/`aggregates` recomputed across all of them, while a metric seen in a single replicate is kept
+ * verbatim (the R = 1 path — byte-identical to the pre-replicate merge). A repeated id WITHIN one
+ * replicate is still a duplicate (result-name contamination), so first-wins survives at that level.
  *
  * SDK-free — schema + the Run model only. Validates the result at the boundary (parseRun), so an
  * inconsistent merge fails here rather than reaching a consumer.
  */
 import type {
 	HostMetadataRecord,
+	MetricReplicate,
 	MetricResult,
 	ObservedSpecs,
 	ProviderRun,
@@ -18,7 +26,13 @@ import type {
 	Run,
 	UncataloguedResult,
 } from "@sandbox-benchmarks/schema";
-import { deriveEconomics, getMetric, getProvider, parseRun } from "@sandbox-benchmarks/schema";
+import {
+	aggregate,
+	deriveEconomics,
+	getMetric,
+	getProvider,
+	parseRun,
+} from "@sandbox-benchmarks/schema";
 
 /**
  * Field separator for the composite dedupe keys below. A NUL can't occur in a suite name, a reason, or
@@ -33,17 +47,64 @@ function isMeasured(metric: MetricResult): boolean {
 	return getMetric(metric.metricId)?.derived !== true;
 }
 
-/** Merge one provider's slice across every shard that carried it. */
-function mergeProvider(providerId: string, slices: readonly ProviderRun[]): ProviderRun {
-	// Union measured metrics by id, keeping the first occurrence (deterministic shard order). One
-	// <Result> owns a metric's samples, so the same id in two shards is a duplicate, not extra passes.
-	const measured = new Map<string, MetricResult>();
-	for (const slice of slices) {
+/** One provider's slice from one shard, tagged with the replicate sandbox the shard was measured under. */
+interface ReplicateSlice {
+	slice: ProviderRun;
+	replicateIndex: number;
+}
+
+/**
+ * Fold one metric id's per-replicate slices into a single {@link MetricResult}. A single replicate is
+ * returned verbatim (the R = 1 path stays byte-identical to the old first-wins union). Two or more become
+ * a {@link MetricResult.replicates} breakdown — replicates ordered by index, `samples` the pooled union
+ * in that order, `aggregates` recomputed over the pool — so the cluster structure survives for the
+ * hierarchical-bootstrap inference while the pooled median stays the ranking value. Provenance
+ * (`sourceFile`/`appVersion`/`arguments`) is carried from the lowest-index replicate.
+ */
+function mergeMetricReplicates(byReplicate: Map<number, MetricResult>): MetricResult {
+	const indices = [...byReplicate.keys()].sort((a, b) => a - b);
+	const first = byReplicate.get(indices[0] as number) as MetricResult;
+	if (indices.length === 1) return first;
+
+	const replicates: MetricReplicate[] = indices.map((index) => ({
+		index,
+		samples: [...(byReplicate.get(index) as MetricResult).samples],
+	}));
+	const pooled = replicates.flatMap((r) => r.samples);
+	// Spread `first` so every provenance field (sourceFile/appVersion/arguments — and any future optional
+	// MetricResult field) is carried from the lowest-index replicate without re-listing the schema here,
+	// then override the pooled fields. A shard's `first` never carries `replicates`, so this is byte-
+	// identical to the old field-by-field build today and stays correct if MetricResult gains a field.
+	return {
+		...first,
+		samples: pooled,
+		aggregates: aggregate(pooled),
+		replicates,
+	};
+}
+
+/** Merge one provider's slices across every replicate shard that carried it. */
+function mergeProvider(providerId: string, entries: readonly ReplicateSlice[]): ProviderRun {
+	const slices = entries.map((entry) => entry.slice);
+	// Group measured metrics by id, then by the replicate that produced them. A metric id recurring across
+	// replicate shards is R distinct sandboxes (folded into the replicate structure below); a metric id
+	// recurring WITHIN one replicate is a duplicate (one <Result> owns a metric's samples — result-name
+	// contamination), so first-wins survives at the per-replicate level.
+	const byMetric = new Map<string, Map<number, MetricResult>>();
+	for (const { slice, replicateIndex } of entries) {
 		for (const metric of slice.metrics) {
-			if (isMeasured(metric) && !measured.has(metric.metricId)) {
-				measured.set(metric.metricId, metric);
+			if (!isMeasured(metric)) continue;
+			let byReplicate = byMetric.get(metric.metricId);
+			if (!byReplicate) {
+				byReplicate = new Map<number, MetricResult>();
+				byMetric.set(metric.metricId, byReplicate);
 			}
+			if (!byReplicate.has(replicateIndex)) byReplicate.set(replicateIndex, metric);
 		}
+	}
+	const measured = new Map<string, MetricResult>();
+	for (const [metricId, byReplicate] of byMetric) {
+		measured.set(metricId, mergeMetricReplicates(byReplicate));
 	}
 
 	// Gaps deduped by (scope, id, outcome, reason); uncatalogued stragglers by id — both can recur across
@@ -164,7 +225,14 @@ export function aggregateRuns(runs: readonly Run[]): Run {
 	const providers = providerIds.map((id) =>
 		mergeProvider(
 			id,
-			runs.flatMap((run) => run.providers.filter((p) => p.providerId === id)),
+			// Carry each shard's replicate index alongside its slice so the merge can key the replicate
+			// breakdown by it. A shard without one (a legacy v2 shard) is replicate 0 — so a run of such
+			// shards folds every metric into a single replicate and stays byte-identical to the old merge.
+			runs.flatMap((run) =>
+				run.providers
+					.filter((p) => p.providerId === id)
+					.map((slice) => ({ slice, replicateIndex: run.replicateIndex ?? 0 })),
+			),
 		),
 	);
 
@@ -174,8 +242,10 @@ export function aggregateRuns(runs: readonly Run[]): Run {
 	];
 	const sourceRunUrl = runs.find((run) => run.sourceRunUrl !== undefined)?.sourceRunUrl;
 
+	// The merged Run spans every replicate, so it carries no single `replicateIndex` — that lived on the
+	// shards. Emit v3 (the replicate-aware schema); v2 shards read in above validate unchanged.
 	return parseRun({
-		schemaVersion: "2",
+		schemaVersion: "3",
 		runId: first.runId,
 		sha: first.sha,
 		generatedAt,

--- a/packages/results/src/lib/leaderboard.test.ts
+++ b/packages/results/src/lib/leaderboard.test.ts
@@ -7,6 +7,18 @@ function metric(metricId: string, samples: number[]): MetricResult {
 	return { metricId, samples, aggregates: aggregate(samples) };
 }
 
+/** A metric merged from replicate sandboxes: pooled samples + the per-replicate breakdown the R>1
+ *  inference reads (as the aggregate produces). */
+function replicatedMetric(metricId: string, replicateSamples: number[][]): MetricResult {
+	const samples = replicateSamples.flat();
+	return {
+		metricId,
+		samples,
+		aggregates: aggregate(samples),
+		replicates: replicateSamples.map((s, index) => ({ index, samples: s })),
+	};
+}
+
 function provider(
 	providerId: string,
 	metrics: MetricResult[],
@@ -103,15 +115,15 @@ describe("buildLeaderboard", () => {
 			run([
 				provider("daytona", [
 					metric("node_web_tooling_runs_per_s", [10]),
-					metric("stream_type_copy", [20]),
+					metric("sqlite_speedtest_seconds", [20]),
 				]),
-				provider("modal", [metric("stream_type_copy", [15])]),
+				provider("modal", [metric("sqlite_speedtest_seconds", [15])]),
 			]),
 		);
-		expect(board.dimensions.map(({ dimension }) => dimension)).toEqual(["cpu", "memory"]);
+		expect(board.dimensions.map(({ dimension }) => dimension)).toEqual(["cpu", "system"]);
 		expect(
 			board.dimensions.flatMap(({ metrics }) => metrics.map(({ metric }) => metric.id)),
-		).toEqual(["node_web_tooling_runs_per_s", "stream_type_copy"]);
+		).toEqual(["node_web_tooling_runs_per_s", "sqlite_speedtest_seconds"]);
 		expect(
 			board.dimensions.flatMap(({ metrics }) => metrics.flatMap(({ rows }) => rows)),
 		).toHaveLength(3);
@@ -121,7 +133,7 @@ describe("buildLeaderboard", () => {
 		expect(md).toContain("**3 retained trial observations**");
 		expect(md).toContain("**2 metrics**");
 		expect(md).toContain("### Node.js web tooling _(headline)_");
-		expect(md).toContain("### STREAM Copy");
+		expect(md).toContain("### SQLite Speedtest");
 	});
 
 	it("uses the Run's target and warns when observed specs are not comparable", () => {
@@ -270,6 +282,93 @@ describe("buildLeaderboard statistical ranking", () => {
 		// All three display names appear in the "share the top" takeaway, joined as a list.
 		expect(md).toMatch(/\w+, \w+ and \w+ share the top on this metric/);
 		for (const name of ["Daytona", "E2B", "Modal"]) expect(md).toContain(name);
+	});
+});
+
+describe("buildLeaderboard with replicate sandboxes (R>1)", () => {
+	const HEADLINE = "node_web_tooling_runs_per_s"; // HIB
+
+	it("uses the hierarchical bootstrap interval and pools every replicate's samples into n", () => {
+		const board = buildLeaderboard(
+			run([
+				provider("daytona", [
+					replicatedMetric(HEADLINE, [
+						[10, 11],
+						[40, 41],
+						[70, 71],
+					]),
+				]),
+			]),
+		);
+		const row = board.dimensions[0]?.metrics[0]?.rows[0];
+		// A real (not point) interval was drawn, and it brackets the pooled median; n is R×k = 6.
+		expect(row?.interval.resamples).toBeGreaterThan(0);
+		expect(row?.interval.lo).toBeLessThanOrEqual(row?.value ?? 0);
+		expect(row?.interval.hi).toBeGreaterThanOrEqual(row?.value ?? 0);
+		expect(row?.n).toBe(6);
+	});
+
+	it("reports R=3 as UNDERPOWERED even when the replicate sandboxes never overlap", () => {
+		// Three sandboxes per side, perfectly separated: the exact cluster test (Mann-Whitney U on the
+		// per-sandbox medians) floors at 2/C(6,3) = 0.1, above α, so it CANNOT be declared separated. The
+		// honest verdict is underpowered — ranked on the value, never a false "separated" or a false "tied".
+		// (The old difference-CI rule read power off within-sandbox spread and would have over-claimed it.)
+		const board = buildLeaderboard(
+			run([
+				provider("daytona", [replicatedMetric(HEADLINE, [[100], [101], [102]])]),
+				provider("modal", [replicatedMetric(HEADLINE, [[1], [2], [3]])]),
+			]),
+		);
+		const rows = board.dimensions[0]?.metrics[0]?.rows ?? [];
+		expect(rows.map((r) => r.rank)).toEqual([1, 2]);
+		expect(rows[1]?.verdict).toBe("underpowered");
+		expect(rows[1]?.tiedWithAbove).toBeNull();
+	});
+
+	it("separates providers at R=5 whose replicate sandboxes never overlap", () => {
+		// Five non-overlapping sandboxes per side clear the floor (2/C(10,5) ≈ 0.008 < α), so the exact
+		// cluster test can — and here does — declare a real separation. R, not k, is the dial that buys it.
+		const board = buildLeaderboard(
+			run([
+				provider("daytona", [replicatedMetric(HEADLINE, [[100], [101], [102], [103], [104]])]),
+				provider("modal", [replicatedMetric(HEADLINE, [[1], [2], [3], [4], [5]])]),
+			]),
+		);
+		const rows = board.dimensions[0]?.metrics[0]?.rows ?? [];
+		expect(rows.map((r) => r.rank)).toEqual([1, 2]);
+		expect(rows[1]?.verdict).toBe("separated");
+		// Mann-Whitney/KS are still reported as descriptive columns even though they no longer decide.
+		expect(rows[1]?.pVsPrevious).not.toBeNull();
+	});
+
+	it("reports a mixed-R pair (one provider replicated, one not) as underpowered", () => {
+		// A single-sandbox provider brings no between-sandbox replication, so a mixed pair floors at
+		// 2/C(R+1, 1) — 0.33 at R=3 — and can never separate. The R=1 side enters the exact cluster test as
+		// one cluster, and the pair is reported underpowered, never a false separation off pooled samples.
+		const board = buildLeaderboard(
+			run([
+				provider("daytona", [replicatedMetric(HEADLINE, [[100], [101], [102]])]),
+				provider("modal", [metric(HEADLINE, [1, 2, 3])]),
+			]),
+		);
+		const rows = board.dimensions[0]?.metrics[0]?.rows ?? [];
+		expect(rows.map((r) => r.rank)).toEqual([1, 2]);
+		expect(rows[1]?.verdict).toBe("underpowered");
+	});
+
+	it("ties adjacent providers at R=5 whose replicate spreads overlap (a statistical tie, not underpowered)", () => {
+		// R=5 clears the floor (the test COULD separate), but the five sandboxes interleave, so the exact
+		// cluster test does not — a genuine statistical tie, distinct from the underpowered R=3 case above.
+		const board = buildLeaderboard(
+			run([
+				provider("daytona", [replicatedMetric(HEADLINE, [[10], [30], [50], [70], [90]])]),
+				provider("modal", [replicatedMetric(HEADLINE, [[20], [40], [60], [80], [100]])]),
+			]),
+		);
+		const rows = board.dimensions[0]?.metrics[0]?.rows ?? [];
+		expect(rows[1]?.verdict).toBe("tied");
+		expect(rows[1]?.rank).toBe(rows[0]?.rank);
+		expect(rows[1]?.tiedWithAbove).toBe("statistical");
 	});
 });
 
@@ -782,7 +881,7 @@ describe("coverage gaps: the holes nobody recorded", () => {
 	it("orders disk skips first, then failures, then the unexplained absences", () => {
 		const board = buildLeaderboard(
 			run([
-				provider("daytona", [metric(HEADLINE, [10, 11])], [], ["cpu-node", "disk", "memory"]),
+				provider("daytona", [metric(HEADLINE, [10, 11])], [], ["cpu-node", "disk", "pgbench"]),
 				provider(
 					"e2b",
 					[],
@@ -801,7 +900,7 @@ describe("coverage gaps: the holes nobody recorded", () => {
 		expect(board.coverageGaps.map((g) => `${g.id}/${g.outcome}`)).toEqual([
 			"disk/skipped", // ❌ disk leads: a structural absence
 			"cpu-node/failed", // then what broke
-			"memory/missing", // then what never said anything at all
+			"pgbench/missing", // then what never said anything at all
 		]);
 	});
 });

--- a/packages/results/src/lib/leaderboard.ts
+++ b/packages/results/src/lib/leaderboard.ts
@@ -26,11 +26,13 @@ import type {
 	TargetSpec,
 } from "@sandbox-benchmarks/schema";
 import {
+	bootstrapMedianDifferenceInterval,
 	bootstrapMedianInterval,
 	canSeparate,
 	DEFAULT_ALPHA,
 	DIMENSIONS,
 	getProvider,
+	hierarchicalBootstrapMedianInterval,
 	kolmogorovSmirnov,
 	METRIC_CATALOG,
 	mannWhitneyU,
@@ -260,23 +262,28 @@ function rankMetric(run: Run, metric: MetricDef): LeaderboardRow[] {
 	const candidates = run.providers.flatMap((provider) => {
 		const result = provider.metrics.find((m) => m.metricId === metric.id);
 		if (!result) return [];
+		// The per-replicate sample slices, present only once the aggregate merged ≥2 replicate sandboxes.
+		const replicates = result.replicates?.map((r) => r.samples);
+		const seed = `${run.runId}:${metric.id}:${provider.providerId}`;
 		const row: LeaderboardRow = {
 			providerId: provider.providerId,
 			displayName: getProvider(provider.providerId)?.displayName ?? provider.providerId,
 			value: result.aggregates.p50,
 			rank: 0, // assigned after sort
-			// Seed from stable identity so a committed leaderboard is byte-identical on every
-			// regeneration — a Math.random() bootstrap would churn the diff on every run.
-			interval: bootstrapMedianInterval(result.samples, {
-				seed: `${run.runId}:${metric.id}:${provider.providerId}`,
-			}),
+			// Seed from stable identity so a committed leaderboard is byte-identical on every regeneration —
+			// a Math.random() bootstrap would churn the diff on every run. With replicate sandboxes the
+			// interval is the HIERARCHICAL bootstrap (resample sandboxes, then samples within), reflecting
+			// between-sandbox variance; at R=1 it stays the ordinary percentile bootstrap, byte-for-byte.
+			interval: replicates
+				? hierarchicalBootstrapMedianInterval(replicates, { seed })
+				: bootstrapMedianInterval(result.samples, { seed }),
 			n: result.aggregates.n,
 			stdev: result.aggregates.stdev,
 			pVsPrevious: null,
 			verdict: null,
 			tiedWithAbove: null,
 		};
-		return [{ samples: result.samples, row }];
+		return [{ samples: result.samples, replicates, row }];
 	});
 	if (candidates.length === 0) return [];
 
@@ -336,6 +343,36 @@ function rankMetric(run: Run, metric: MetricDef): LeaderboardRow[] {
 			ks: ks.pValue,
 			floor: mw.minAttainablePValue,
 		};
+
+		// Replicate-aware separation: when EITHER row carries ≥2 replicate sandboxes, the decider is the
+		// EXACT cluster-level rank permutation inside bootstrapMedianDifferenceInterval — Mann-Whitney U on
+		// the per-sandbox medians, whole sandboxes the exchangeable unit. That is cluster-honest where MW on
+		// samples pooled across replicates is anti-conservative, and it carries the real 2/C(2R,R) floor, so
+		// small R reads as UNDERPOWERED rather than a false tie or a false separation. A row with no
+		// replicate breakdown enters as a single cluster of its pooled Samples, so a mixed-R pair is judged
+		// the same honest way. MW/KS above stay as descriptive columns only. At R=1 on BOTH sides this is
+		// skipped and Mann-Whitney on the pooled Samples decides the rank, as before.
+		if (previous.replicates || candidate.replicates) {
+			const diff = bootstrapMedianDifferenceInterval(
+				previous.replicates ?? [previous.samples],
+				candidate.replicates ?? [candidate.samples],
+				{
+					seed: `${run.runId}:${metric.id}:${previous.row.providerId}:${candidate.row.providerId}`,
+				},
+			);
+			// The same "a test that can never reach α is not evidence of sameness" rule as the R=1 path:
+			// when the between-sandbox floor already meets α (2/C(6,3)=0.1 at R=3), no data could separate
+			// the pair, so it is underpowered — never a "tied" verdict, which would claim the test had the
+			// power to find a difference and didn't. Rank on the value; the renderer discloses it.
+			if (diff.minAttainablePValue >= DEFAULT_ALPHA) {
+				candidate.row.verdict = "underpowered";
+				settle(identical ? "identical-value" : null);
+				return;
+			}
+			candidate.row.verdict = diff.separated ? "separated" : "tied";
+			settle(diff.separated ? null : "statistical");
+			return;
+		}
 
 		// The same "a test that can never reach α is not evidence of sameness" rule as the n<2 case
 		// above, applied where it actually bites: Mann-Whitney's p has a FLOOR, and at 3 v 3 that floor

--- a/packages/results/src/lib/normalize-tree.ts
+++ b/packages/results/src/lib/normalize-tree.ts
@@ -38,6 +38,9 @@ export interface NormalizeInput {
 	sha: string;
 	generatedAt: string;
 	sourceRunUrl?: string;
+	/** The replicate sandbox index this shard was run under (the `--replicate` argument), stamped onto
+	 *  the shard Run so the aggregate can key its replicate breakdown. Absent for a non-replicate run. */
+	replicateIndex?: number;
 }
 
 /** Normalize a whole raw tree into one validated Run — every known provider appears in every Run. */
@@ -48,11 +51,13 @@ export function normalizeResultsTree(input: NormalizeInput): Run {
 		.map((meta) => normalizeProviderDir(input.rawRoot, meta.id));
 
 	const candidate = {
-		schemaVersion: "2" as const,
+		// v3: a shard may carry a replicateIndex the aggregate folds into MetricResult.replicates.
+		schemaVersion: "3" as const,
 		runId: input.runId,
 		sha: input.sha,
 		generatedAt: input.generatedAt,
 		...(input.sourceRunUrl !== undefined ? { sourceRunUrl: input.sourceRunUrl } : {}),
+		...(input.replicateIndex !== undefined ? { replicateIndex: input.replicateIndex } : {}),
 		targetSpec: { ...TARGET_SPEC },
 		providers,
 	};

--- a/packages/results/src/lib/write-run.ts
+++ b/packages/results/src/lib/write-run.ts
@@ -28,6 +28,8 @@ export interface WriteNormalizedRunInput {
 	generatedAt?: string;
 	sourceRunUrl?: string;
 	updateIndexFile?: string;
+	/** The replicate sandbox index for this shard (the `--replicate` argument), threaded onto the Run. */
+	replicateIndex?: number;
 }
 
 /** Insert a Run into the index (newest first, de-duplicated by runId) and rewrite the index file. */
@@ -79,6 +81,7 @@ export function writeNormalizedRun(input: WriteNormalizedRunInput): Run {
 		sha: input.sha,
 		generatedAt: input.generatedAt ?? new Date().toISOString(),
 		...(input.sourceRunUrl !== undefined ? { sourceRunUrl: input.sourceRunUrl } : {}),
+		...(input.replicateIndex !== undefined ? { replicateIndex: input.replicateIndex } : {}),
 	});
 
 	const outPath = resolve(input.outFile);


### PR DESCRIPTION
**bench-matrix refactor — replicate-aware benchmark pipeline**

Shipped as a 4-PR stack (merge bottom-up, each branch is independently green and tree-verified):
1. #192 — **schema-core**: replicate stats primitives + v3 run schema
2. #193 — **suite-catalog**: restructure suites + catalog (pgbench split, cpu-generic retired, per-tier k/R)
3. #194 — **harness-k**: per-suite `ptsTimesToRun` (k) in the sandbox preamble
4. #195 — **results-replicate**: fold replicate shards + replicate-aware leaderboard ranking

↑ **This PR is #195 (4/4)** — the top of the stack, based on #194.

---

The replicate data-plane and ranking, consuming the v3 schema + stats primitives from the schema-core PR (#192) at the base of the stack. Inert until the CI matrix fans out replicates: every current Run is R=1 and the render is byte-identical.

- **aggregate.ts**: `mergeProvider` folds ≥2 replicate slices of one metric (keyed by the shard's `Run.replicateIndex`) into the `MetricResult.replicates` breakdown — replicates ordered by index, `samples` the pooled union, aggregates recomputed from the pool. A single replicate is kept verbatim (R=1 byte-identical); the host-metadata fold is preserved.
- **normalize-tree.ts / write-run.ts**: thread an optional `replicateIndex` onto the shard Run and emit `schemaVersion "3"`.
- **bench-suite.ts**: a `--replicate <idx>` flag (validated non-negative integer via `parseReplicateFlag`, unit-tested in `bench-suite.test.ts`) stamps the shard's replicate index so the aggregate can key it.
- **leaderboard.ts**: replicate-bearing rows use the hierarchical bootstrap CI for the interval and a difference-in-medians CI (`canSeparate`) for the tie decision — cluster-honest where Mann-Whitney pooled across replicates is anti-conservative. MW/KS stay as descriptive columns. At R=1 this is skipped: Mann-Whitney decides the rank exactly as before.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds replicate-aware aggregation and ranking. Shards can carry a `replicateIndex`; metrics fold per‑replicate slices, and the leaderboard uses hierarchical intervals plus a cluster‑level test with an “underpowered” verdict when needed. R=1 output stays byte-identical.

- **New Features**
  - CLI: add `--replicate <idx>`/`--replicate=<idx>` with strict non‑negative int validation (last wins; blanks/negatives/non‑integers throw). Stamps `replicateIndex` onto the shard Run (unit-tested).
  - Results: emit schemaVersion "3" and thread `replicateIndex`. Aggregation folds ≥2 replicate slices into `MetricResult.replicates` (ordered by index), pools samples, and recomputes aggregates; a single replicate stays verbatim. Duplicate metrics within one replicate are first‑wins. Legacy v2 shards are treated as replicate 0; the merged Run is v3 and carries no single `replicateIndex`.
  - Leaderboard: replicate-bearing rows use hierarchical bootstrap intervals and rank via an exact cluster-level median‑difference permutation test. Reports “underpowered” when the min‑attainable p ≥ α (e.g., R=3 or mixed‑R with a single‑sandbox side); otherwise “separated” or “tied”. Mann–Whitney/KS remain descriptive; at R=1, Mann–Whitney decides ranking as before.

- **Migration**
  - Consumers must read v3 Runs from `@sandbox-benchmarks/schema`.
  - CI may fan out replicate sandboxes and pass `--replicate <idx>`; if not, behavior is unchanged.

<sup>Written for commit 3539637bb5f1bbf2da137b759d6eb49eeaaf0b7d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/starslingdev/hpc-sandbox-benchmarks/pull/195?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

