### PR TITLE
chore(dataset): publish run 29546060837

### DIFF
--- a/LEADERBOARD.md
+++ b/LEADERBOARD.md
@@ -1,10 +1,10 @@
 # Sandbox provider leaderboard
 
-Run `29472826358` · commit `d85e6a9f905d428b9efd469a1d287f4075fddef7` · generated 2026-07-16T07:25:11.693Z
+Run `29546060837` · commit `dd1f6ef472e3de4b76043c74f3cce5ff0d636af2` · generated 2026-07-17T03:31:38.992Z
 
-Requested target for every provider: **2 vCPU · 8 GiB RAM · 40 GB disk**. This run contains **146 metric records**
-backed by **288 retained trial observations**, across **49 metrics** and
-**4 providers**; every emitted, catalogued metric has a ranked table below
+Requested target for every provider: **2 vCPU · 8 GiB RAM · 40 GB disk**. This run contains **204 metric records**
+backed by **401 retained trial observations**, across **54 metrics** and
+**5 providers**; every emitted, catalogued metric has a ranked table below
 (median of retained trials), grouped by dimension with its headline first.
 Generated from the published Run dataset — do not edit by hand. Methodology:
 [`docs/methodology.md`](docs/methodology.md).
@@ -22,14 +22,15 @@ surfaced through coverage gaps, not part of the compute-match verdict.
 
 runs/s · higher is better
 
-_Daytona leads · ~1.5× Blaxel on median (higher is better)._
+_Daytona leads · ~1.1× Novita on median (higher is better)._
 
 | Rank | Provider | Node.js web tooling (runs/s) | 95% bootstrap interval | n | Note |
 | ---: | --- | ---: | ---: | ---: | --- |
-| 1 | Daytona | 19.43 | 18.79 – 20.08 | 2 | — |
-| 2 | Blaxel | 12.7 | 12.67 – 12.73 | 2 | n too small |
-| 3 | E2B | 10.63 | 10.59 – 10.66 | 2 | n too small |
-| 4 | Modal | 9.24 | 9 – 9.48 | 2 | n too small |
+| 1 | Daytona | 19.51 | 19.46 – 19.55 | 2 | — |
+| 2 | Novita | 17.5 | 17.43 – 17.58 | 2 | n too small |
+| 3 | Blaxel | 12.8 | 12.67 – 12.94 | 2 | n too small |
+| 4 | E2B | 11.05 | 10.99 – 11.12 | 2 | n too small |
+| 5 | Modal | 8.82 | 8.71 – 8.93 | 2 | n too small |
 
 ### C-Ray (1080p, 16 RPP)
 
@@ -39,8 +40,9 @@ _Blaxel leads · Daytona is ~1.6× higher (lower is better)._
 
 | Rank | Provider | C-Ray (1080p, 16 RPP) (Seconds) | 95% bootstrap interval | n | Note |
 | ---: | --- | ---: | ---: | ---: | --- |
-| 1 | Blaxel | 128.4 | 128.1 – 128.8 | 2 | — |
-| 2 | Daytona | 201.8 | 201.5 – 202.1 | 2 | n too small |
+| 1 | Blaxel | 127.6 | 127.6 – 127.7 | 2 | — |
+| 2 | Daytona | 199.7 | 199.4 – 200.1 | 2 | n too small |
+| 3 | Novita | 240.6 | 240.2 – 241 | 2 | n too small |
 
 ### C-Ray (4K, 16 RPP)
 
@@ -50,8 +52,9 @@ _Blaxel leads · Daytona is ~1.6× higher (lower is better)._
 
 | Rank | Provider | C-Ray (4K, 16 RPP) (Seconds) | 95% bootstrap interval | n | Note |
 | ---: | --- | ---: | ---: | ---: | --- |
-| 1 | Blaxel | 512.4 | 511.2 – 513.5 | 2 | — |
-| 2 | Daytona | 806.1 | 803.3 – 809 | 2 | n too small |
+| 1 | Blaxel | 509.7 | 509.7 – 509.8 | 2 | — |
+| 2 | Daytona | 799.3 | 798.1 – 800.4 | 2 | n too small |
+| 3 | Novita | 961.9 | 961.5 – 962.3 | 2 | n too small |
 
 ### C-Ray (5K, 16 RPP)
 
@@ -61,8 +64,9 @@ _Blaxel leads · Daytona is ~1.6× higher (lower is better)._
 
 | Rank | Provider | C-Ray (5K, 16 RPP) (Seconds) | 95% bootstrap interval | n | Note |
 | ---: | --- | ---: | ---: | ---: | --- |
-| 1 | Blaxel | 907.6 | 906.9 – 908.3 | 2 | — |
-| 2 | Daytona | 1420 | 1417 – 1423 | 2 | n too small |
+| 1 | Blaxel | 907.5 | 907 – 908.1 | 2 | — |
+| 2 | Daytona | 1422 | 1418 – 1426 | 2 | n too small |
+| 3 | Novita | 1705 | 1704 – 1705 | 2 | n too small |
 
 ### Zstd 12 compress
 
@@ -72,19 +76,21 @@ _Blaxel leads · ~1.2× Daytona on median (higher is better)._
 
 | Rank | Provider | Zstd 12 compress (MB/s) | 95% bootstrap interval | n | Note |
 | ---: | --- | ---: | ---: | ---: | --- |
-| 1 | Blaxel | 115.9 | 115.3 – 116.5 | 2 | — |
-| 2 | Daytona | 99.4 | 99.3 – 99.5 | 2 | n too small |
+| 1 | Blaxel | 117.1 | 115.9 – 118.3 | 2 | — |
+| 2 | Daytona | 99.45 | 99.3 – 99.6 | 2 | n too small |
+| 3 | Novita | 71.4 | 71.2 – 71.6 | 2 | n too small |
 
 ### Zstd 12 decompress
 
 MB/s · higher is better
 
-_Daytona leads · ~2.2× Blaxel on median (higher is better)._
+_Daytona leads · ~1.2× Novita on median (higher is better)._
 
 | Rank | Provider | Zstd 12 decompress (MB/s) | 95% bootstrap interval | n | Note |
 | ---: | --- | ---: | ---: | ---: | --- |
-| 1 | Daytona | 2294 | 2283 – 2305 | 2 | — |
-| 2 | Blaxel | 1054 | 1052 – 1056 | 2 | n too small |
+| 1 | Daytona | 2304 | 2299 – 2309 | 2 | — |
+| 2 | Novita | 1906 | 1897 – 1915 | 2 | n too small |
+| 3 | Blaxel | 1052 | 1044 – 1060 | 2 | n too small |
 
 ### Zstd 19 compress
 
@@ -94,41 +100,45 @@ _Blaxel leads · ~1.4× Daytona on median (higher is better)._
 
 | Rank | Provider | Zstd 19 compress (MB/s) | 95% bootstrap interval | n | Note |
 | ---: | --- | ---: | ---: | ---: | --- |
-| 1 | Blaxel | 11.35 | 11.1 – 11.6 | 2 | — |
-| 2 | Daytona | 8.155 | 8.15 – 8.16 | 2 | n too small |
+| 1 | Blaxel | 11.1 | 11 – 11.2 | 2 | — |
+| 2 | Daytona | 8.09 | 8.04 – 8.14 | 2 | n too small |
+| 3 | Novita | 5.7 | 5.69 – 5.71 | 2 | n too small |
 
 ### Zstd 19 decompress
 
 MB/s · higher is better
 
-_Daytona leads · ~2.2× Blaxel on median (higher is better)._
+_Daytona leads · ~1.2× Novita on median (higher is better)._
 
 | Rank | Provider | Zstd 19 decompress (MB/s) | 95% bootstrap interval | n | Note |
 | ---: | --- | ---: | ---: | ---: | --- |
-| 1 | Daytona | 1921 | 1920 – 1922 | 2 | — |
-| 2 | Blaxel | 887.8 | 882 – 893.6 | 2 | n too small |
+| 1 | Daytona | 1916 | 1915 – 1918 | 2 | — |
+| 2 | Novita | 1622 | 1617 – 1627 | 2 | n too small |
+| 3 | Blaxel | 881.8 | 868.9 – 894.6 | 2 | n too small |
 
 ### Zstd 19 (long) compress
 
 MB/s · higher is better
 
-_Daytona leads · ~1.1× Blaxel on median (higher is better)._
+_Daytona leads · ~1.2× Blaxel on median (higher is better)._
 
 | Rank | Provider | Zstd 19 (long) compress (MB/s) | 95% bootstrap interval | n | Note |
 | ---: | --- | ---: | ---: | ---: | --- |
-| 1 | Daytona | 7.055 | 6.96 – 7.15 | 2 | — |
-| 2 | Blaxel | 6.135 | 6.09 – 6.18 | 2 | n too small |
+| 1 | Daytona | 7.075 | 7.03 – 7.12 | 2 | — |
+| 2 | Blaxel | 5.875 | 5.8 – 5.95 | 2 | n too small |
+| 3 | Novita | 5.225 | 5.22 – 5.23 | 2 | n too small |
 
 ### Zstd 19 (long) decompress
 
 MB/s · higher is better
 
-_Daytona leads · ~2.0× Blaxel on median (higher is better)._
+_Daytona leads · ~1.2× Novita on median (higher is better)._
 
 | Rank | Provider | Zstd 19 (long) decompress (MB/s) | 95% bootstrap interval | n | Note |
 | ---: | --- | ---: | ---: | ---: | --- |
-| 1 | Daytona | 1828 | 1810 – 1846 | 2 | — |
-| 2 | Blaxel | 896.6 | 893.3 – 900 | 2 | n too small |
+| 1 | Daytona | 1842 | 1840 – 1845 | 2 | — |
+| 2 | Novita | 1544 | 1536 – 1552 | 2 | n too small |
+| 3 | Blaxel | 894.4 | 886.3 – 902.5 | 2 | n too small |
 
 ### Zstd 3 compress
 
@@ -138,18 +148,21 @@ _Blaxel leads · ~1.7× Daytona on median (higher is better)._
 
 | Rank | Provider | Zstd 3 compress (MB/s) | 95% bootstrap interval | n | Note |
 | ---: | --- | ---: | ---: | ---: | --- |
-| 1 | Blaxel | 1299 | 1295 – 1304 | 2 | — |
-| 2 | Daytona | 781.2 | 778.7 – 783.7 | 2 | n too small |
+| 1 | Blaxel | 1300 | 1294 – 1306 | 2 | — |
+| 2 | Daytona | 781.8 | 781.2 – 782.3 | 2 | n too small |
+| 3 | Novita | 677.7 | 673.2 – 682.1 | 2 | n too small |
 
 ### Zstd 3 decompress
 
 MB/s · higher is better
 
-_Daytona is the only ranked provider (2112 MB/s; higher is better)._
+_Daytona leads · ~1.2× Novita on median (higher is better)._
 
-| Rank | Provider | Zstd 3 decompress (MB/s) | 95% bootstrap interval | n |
-| ---: | --- | ---: | ---: | ---: |
-| 1 | Daytona | 2112 | 2110 – 2115 | 2 |
+| Rank | Provider | Zstd 3 decompress (MB/s) | 95% bootstrap interval | n | Note |
+| ---: | --- | ---: | ---: | ---: | --- |
+| 1 | Daytona | 2113 | 2112 – 2115 | 2 | — |
+| 2 | Novita | 1747 | 1743 – 1751 | 2 | n too small |
+| 3 | Blaxel | 1117 | — | 1 | — |
 
 ### Zstd 3 (long) compress
 
@@ -159,39 +172,44 @@ _Blaxel leads · ~1.6× Daytona on median (higher is better)._
 
 | Rank | Provider | Zstd 3 (long) compress (MB/s) | 95% bootstrap interval | n | Note |
 | ---: | --- | ---: | ---: | ---: | --- |
-| 1 | Blaxel | 840.3 | 832.3 – 848.2 | 2 | — |
-| 2 | Daytona | 534 | 530.4 – 537.7 | 2 | n too small |
+| 1 | Blaxel | 847.9 | 841.7 – 854.1 | 2 | — |
+| 2 | Daytona | 535.7 | 534.9 – 536.5 | 2 | n too small |
+| 3 | Novita | 529.5 | 527.9 – 531 | 2 | n too small |
 
 ### Zstd 3 (long) decompress
 
 MB/s · higher is better
 
-_Daytona is the only ranked provider (2162 MB/s; higher is better)._
+_Daytona leads · ~1.2× Novita on median (higher is better)._
 
-| Rank | Provider | Zstd 3 (long) decompress (MB/s) | 95% bootstrap interval | n |
-| ---: | --- | ---: | ---: | ---: |
-| 1 | Daytona | 2162 | 2162 – 2163 | 2 |
+| Rank | Provider | Zstd 3 (long) decompress (MB/s) | 95% bootstrap interval | n | Note |
+| ---: | --- | ---: | ---: | ---: | --- |
+| 1 | Daytona | 2166 | 2161 – 2171 | 2 | — |
+| 2 | Novita | 1808 | 1805 – 1811 | 2 | n too small |
 
 ### Zstd 8 compress
 
 MB/s · higher is better
 
-_Blaxel leads · ~1.6× Daytona on median (higher is better)._
+_Blaxel leads · ~1.7× Daytona on median (higher is better)._
 
 | Rank | Provider | Zstd 8 compress (MB/s) | 95% bootstrap interval | n | Note |
 | ---: | --- | ---: | ---: | ---: | --- |
-| 1 | Blaxel | 344.6 | 344.2 – 345 | 2 | — |
-| 2 | Daytona | 209.2 | 208.9 – 209.5 | 2 | n too small |
+| 1 | Blaxel | 352.4 | 352 – 352.7 | 2 | — |
+| 2 | Daytona | 210.4 | 208.8 – 212 | 2 | n too small |
+| 3 | Novita | 179.4 | 178.7 – 180.2 | 2 | n too small |
 
 ### Zstd 8 decompress
 
 MB/s · higher is better
 
-_Blaxel is the only ranked provider (1118 MB/s; higher is better)._
+_Daytona leads · ~1.2× Novita on median (higher is better)._
 
-| Rank | Provider | Zstd 8 decompress (MB/s) | 95% bootstrap interval | n |
-| ---: | --- | ---: | ---: | ---: |
-| 1 | Blaxel | 1118 | 1111 – 1126 | 2 |
+| Rank | Provider | Zstd 8 decompress (MB/s) | 95% bootstrap interval | n | Note |
+| ---: | --- | ---: | ---: | ---: | --- |
+| 1 | Daytona | 2269 | 2269 – 2269 | 2 | — |
+| 2 | Novita | 1910 | 1908 – 1912 | 2 | n too small |
+| 3 | Blaxel | 1122 | 1117 – 1126 | 2 | n too small |
 
 ### Zstd 8 (long) compress
 
@@ -201,19 +219,21 @@ _Blaxel leads · ~1.6× Daytona on median (higher is better)._
 
 | Rank | Provider | Zstd 8 (long) compress (MB/s) | 95% bootstrap interval | n | Note |
 | ---: | --- | ---: | ---: | ---: | --- |
-| 1 | Blaxel | 327 | 323.5 – 330.5 | 2 | — |
-| 2 | Daytona | 202.9 | 202.3 – 203.6 | 2 | n too small |
+| 1 | Blaxel | 325.3 | 323.7 – 326.9 | 2 | — |
+| 2 | Daytona | 202.7 | 202.3 – 203 | 2 | n too small |
+| 3 | Novita | 174.7 | 174.5 – 174.8 | 2 | n too small |
 
 ### Zstd 8 (long) decompress
 
 MB/s · higher is better
 
-_Daytona leads · ~2.0× Blaxel on median (higher is better)._
+_Daytona leads · ~1.2× Novita on median (higher is better)._
 
 | Rank | Provider | Zstd 8 (long) decompress (MB/s) | 95% bootstrap interval | n | Note |
 | ---: | --- | ---: | ---: | ---: | --- |
-| 1 | Daytona | 2314 | 2307 – 2321 | 2 | — |
-| 2 | Blaxel | 1134 | 1130 – 1137 | 2 | n too small |
+| 1 | Daytona | 2308 | 2305 – 2311 | 2 | — |
+| 2 | Novita | 1913 | 1912 – 1915 | 2 | n too small |
+| 3 | Blaxel | 1135 | 1135 – 1136 | 2 | n too small |
 
 ## disk
 
@@ -221,117 +241,125 @@ _Daytona leads · ~2.0× Blaxel on median (higher is better)._
 
 IOPS · higher is better
 
-_Blaxel leads · ~2.0× Daytona on median (higher is better)._
+_Blaxel leads · ~2.3× Daytona on median (higher is better)._
 
 | Rank | Provider | fio rand read 4KB, O_DIRECT (IOPS) (IOPS) | 95% bootstrap interval | n | Note |
 | ---: | --- | ---: | ---: | ---: | --- |
-| 1 | Blaxel | 540000 | 525000 – 555000 | 2 | — |
-| 2 | Daytona | 266500 | 264000 – 269000 | 2 | n too small |
-| 3 | Modal | 33200 | 32800 – 33600 | 2 | n too small |
-| 4 | E2B | 32550 | 31600 – 33500 | 2 | n too small |
+| 1 | Blaxel | 576000 | 570000 – 582000 | 2 | — |
+| 2 | Daytona | 248500 | 240000 – 257000 | 2 | n too small |
+| 3 | Novita | 59500 | 55300 – 63700 | 2 | n too small |
+| 4 | E2B | 40000 | 38700 – 41300 | 2 | n too small |
+| 5 | Modal | 33900 | 33200 – 34600 | 2 | n too small |
 
 ### fio rand read 4KB, O_DIRECT (MB/s)
 
 MB/s · higher is better
 
-_Blaxel leads · ~2.0× Daytona on median (higher is better)._
+_Blaxel leads · ~2.3× Daytona on median (higher is better)._
 
 | Rank | Provider | fio rand read 4KB, O_DIRECT (MB/s) (MB/s) | 95% bootstrap interval | n | Note |
 | ---: | --- | ---: | ---: | ---: | --- |
-| 1 | Blaxel | 2110 | 2050 – 2169 | 2 | — |
-| 2 | Daytona | 1041 | 1031 – 1050 | 2 | n too small |
-| 3 | Modal | 129.5 | 128 – 131 | 2 | n too small |
-| 4 | E2B | 127 | 123 – 131 | 2 | n too small |
+| 1 | Blaxel | 2251 | 2226 – 2275 | 2 | — |
+| 2 | Daytona | 971 | 936 – 1006 | 2 | n too small |
+| 3 | Novita | 232.5 | 216 – 249 | 2 | n too small |
+| 4 | E2B | 156.5 | 151 – 162 | 2 | n too small |
+| 5 | Modal | 132.5 | 130 – 135 | 2 | n too small |
 
 ### fio rand write 4KB, O_DIRECT (IOPS)
 
 IOPS · higher is better
 
-_Blaxel leads · ~2.2× Daytona on median (higher is better)._
+_Blaxel leads · ~2.1× Daytona on median (higher is better)._
 
 | Rank | Provider | fio rand write 4KB, O_DIRECT (IOPS) (IOPS) | 95% bootstrap interval | n | Note |
 | ---: | --- | ---: | ---: | ---: | --- |
-| 1 | Blaxel | 493500 | 492000 – 495000 | 2 | — |
-| 2 | Daytona | 228500 | 228000 – 229000 | 2 | n too small |
-| 3 | E2B | 53950 | 52600 – 55300 | 2 | n too small |
-| 4 | Modal | 29200 | 29000 – 29400 | 2 | n too small |
+| 1 | Blaxel | 495000 | 484000 – 506000 | 2 | — |
+| 2 | Daytona | 231500 | 208000 – 255000 | 2 | n too small |
+| 3 | Novita | 85150 | 75700 – 94600 | 2 | n too small |
+| 4 | E2B | 43900 | 43500 – 44300 | 2 | n too small |
+| 5 | Modal | 28300 | 27000 – 29600 | 2 | n too small |
 
 ### fio rand write 4KB, O_DIRECT (MB/s)
 
 MB/s · higher is better
 
-_Blaxel leads · ~2.2× Daytona on median (higher is better)._
+_Blaxel leads · ~2.1× Daytona on median (higher is better)._
 
 | Rank | Provider | fio rand write 4KB, O_DIRECT (MB/s) (MB/s) | 95% bootstrap interval | n | Note |
 | ---: | --- | ---: | ---: | ---: | --- |
-| 1 | Blaxel | 1929 | 1922 – 1935 | 2 | — |
-| 2 | Daytona | 893.5 | 891 – 896 | 2 | n too small |
-| 3 | E2B | 211 | 206 – 216 | 2 | n too small |
-| 4 | Modal | 114 | 113 – 115 | 2 | n too small |
+| 1 | Blaxel | 1934 | 1891 – 1977 | 2 | — |
+| 2 | Daytona | 902.5 | 811 – 994 | 2 | n too small |
+| 3 | Novita | 332.5 | 296 – 369 | 2 | n too small |
+| 4 | E2B | 171.5 | 170 – 173 | 2 | n too small |
+| 5 | Modal | 110.5 | 105 – 116 | 2 | n too small |
 
 ### fio seq read 1MB, O_DIRECT (IOPS)
 
 IOPS · higher is better
 
-_Daytona leads · ~1.2× Modal on median (higher is better)._
+_Modal leads · ~1.1× Novita on median (higher is better)._
 
 | Rank | Provider | fio seq read 1MB, O_DIRECT (IOPS) (IOPS) | 95% bootstrap interval | n | Note |
 | ---: | --- | ---: | ---: | ---: | --- |
-| 1 | Daytona | 13900 | 8801 – 19000 | 2 | — |
-| 2 | Modal | 12000 | 10700 – 13300 | 2 | n too small |
-| 3 | Blaxel | 4603 | 4535 – 4670 | 2 | n too small |
-| 4 | E2B | 599 | 599 – 599 | 2 | n too small |
+| 1 | Modal | 12350 | 11900 – 12800 | 2 | — |
+| 2 | Novita | 11250 | 11200 – 11300 | 2 | n too small |
+| 3 | Daytona | 9142 | 5584 – 12700 | 2 | n too small |
+| 4 | Blaxel | 4709 | 4609 – 4809 | 2 | n too small |
+| 5 | E2B | 599 | 599 – 599 | 2 | n too small |
 
 ### fio seq read 1MB, O_DIRECT (MB/s)
 
 MB/s · higher is better
 
-_Daytona leads · ~1.9× Blaxel on median (higher is better)._
+_Daytona leads · ~1.2× Blaxel on median (higher is better)._
 
 | Rank | Provider | fio seq read 1MB, O_DIRECT (MB/s) (MB/s) | 95% bootstrap interval | n | Note |
 | ---: | --- | ---: | ---: | ---: | --- |
-| 1 | Daytona | 8803 | — | 1 | — |
-| 2 | Blaxel | 4605 | 4537 – 4672 | 2 | — |
+| 1 | Daytona | 5585 | — | 1 | — |
+| 2 | Blaxel | 4711 | 4611 – 4811 | 2 | — |
 | 3 | E2B | 601 | 601 – 601 | 2 | n too small |
 
 ### fio seq write 1MB, O_DIRECT (IOPS)
 
 IOPS · higher is better
 
-_Daytona leads · ~1.6× Blaxel on median (higher is better)._
+_Daytona leads · ~1.1× Novita on median (higher is better)._
 
 | Rank | Provider | fio seq write 1MB, O_DIRECT (IOPS) (IOPS) | 95% bootstrap interval | n | Note |
 | ---: | --- | ---: | ---: | ---: | --- |
-| 1 | Daytona | 5732 | 5697 – 5766 | 2 | — |
-| 2 | Blaxel | 3583 | 3544 – 3622 | 2 | n too small |
-| 3 | Modal | 2233 | 1695 – 2770 | 2 | n too small |
-| 4 | E2B | 599.5 | 599 – 600 | 2 | n too small |
+| 1 | Daytona | 5821 | 5714 – 5928 | 2 | — |
+| 2 | Novita | 5390 | 5210 – 5570 | 2 | n too small |
+| 3 | Blaxel | 3658 | 3616 – 3700 | 2 | n too small |
+| 4 | Modal | 3458 | 3362 – 3554 | 2 | n too small |
+| 5 | E2B | 599 | 598 – 600 | 2 | n too small |
 
 ### fio seq write 1MB, O_DIRECT (MB/s)
 
 MB/s · higher is better
 
-_Daytona leads · ~1.6× Blaxel on median (higher is better)._
+_Daytona leads · ~1.1× Novita on median (higher is better)._
 
 | Rank | Provider | fio seq write 1MB, O_DIRECT (MB/s) (MB/s) | 95% bootstrap interval | n | Note |
 | ---: | --- | ---: | ---: | ---: | --- |
-| 1 | Daytona | 5733 | 5699 – 5767 | 2 | — |
-| 2 | Blaxel | 3585 | 3545 – 3624 | 2 | n too small |
-| 3 | Modal | 2235 | 1697 – 2772 | 2 | n too small |
-| 4 | E2B | 601 | 601 – 601 | 2 | n too small |
+| 1 | Daytona | 5823 | 5716 – 5930 | 2 | — |
+| 2 | Novita | 5391 | 5211 – 5571 | 2 | n too small |
+| 3 | Blaxel | 3660 | 3618 – 3702 | 2 | n too small |
+| 4 | Modal | 3460 | 3363 – 3556 | 2 | n too small |
+| 5 | E2B | 600.5 | 600 – 601 | 2 | n too small |
 
 ### Hardlink throughput
 
 bogo ops/s · higher is better
 
-_Daytona leads · ~2.2× Blaxel on median (higher is better)._
+_Daytona leads · ~1.3× Novita on median (higher is better)._
 
 | Rank | Provider | Hardlink throughput (bogo ops/s) | 95% bootstrap interval | n | Note |
 | ---: | --- | ---: | ---: | ---: | --- |
-| 1 | Daytona | 26.21 | 26.13 – 26.29 | 2 | — |
-| 2 | Blaxel | 12.13 | 11.96 – 12.29 | 2 | n too small |
-| 3 | Modal | 3.195 | 3.18 – 3.21 | 2 | n too small |
-| 4 | E2B | 1.43 | 1.43 – 1.43 | 2 | n too small |
+| 1 | Daytona | 23.66 | 23.62 – 23.69 | 2 | — |
+| 2 | Novita | 18.52 | 18.45 – 18.59 | 2 | n too small |
+| 3 | Blaxel | 12.43 | 12.39 – 12.46 | 2 | n too small |
+| 4 | Modal | 3.05 | 2.98 – 3.12 | 2 | n too small |
+| 5 | E2B | 1.46 | 1.46 – 1.46 | 2 | n too small |
 
 ## memory
 
@@ -339,53 +367,57 @@ _Daytona leads · ~2.2× Blaxel on median (higher is better)._
 
 MB/s · higher is better
 
-_Daytona leads · ~1.1× Blaxel on median (higher is better)._
+_Blaxel leads · ~1.3× Daytona on median (higher is better)._
 
 | Rank | Provider | STREAM Triad (MB/s) | 95% bootstrap interval | n | Note |
 | ---: | --- | ---: | ---: | ---: | --- |
-| 1 | Daytona | 78310 | 77380 – 79250 | 2 | — |
-| 2 | Blaxel | 72290 | 72270 – 72320 | 2 | n too small |
-| 3 | Modal | 46230 | 44680 – 47780 | 2 | n too small |
-| 4 | E2B | 23460 | 22640 – 24280 | 2 | n too small |
+| 1 | Blaxel | 73890 | 70330 – 77460 | 2 | — |
+| 2 | Daytona | 56000 | 55980 – 56010 | 2 | n too small |
+| 3 | Novita | 46030 | 45840 – 46210 | 2 | n too small |
+| 4 | Modal | 45370 | 42050 – 48700 | 2 | n too small |
+| 5 | E2B | 22020 | 21770 – 22260 | 2 | n too small |
 
 ### STREAM Add
 
 MB/s · higher is better
 
-_Daytona leads · ~1.1× Blaxel on median (higher is better)._
+_Blaxel leads · ~1.3× Daytona on median (higher is better)._
 
 | Rank | Provider | STREAM Add (MB/s) | 95% bootstrap interval | n | Note |
 | ---: | --- | ---: | ---: | ---: | --- |
-| 1 | Daytona | 78090 | 77810 – 78380 | 2 | — |
-| 2 | Blaxel | 72160 | 72130 – 72180 | 2 | n too small |
-| 3 | Modal | 49240 | 47414 – 51060 | 2 | n too small |
-| 4 | E2B | 23300 | 22660 – 23940 | 2 | n too small |
+| 1 | Blaxel | 73910 | 70140 – 77690 | 2 | — |
+| 2 | Daytona | 55740 | 55730 – 55760 | 2 | n too small |
+| 3 | Modal | 45920 | 41170 – 50670 | 2 | n too small |
+| 4 | Novita | 45850 | 45780 – 45930 | 2 | n too small |
+| 5 | E2B | 22020 | 21840 – 22210 | 2 | n too small |
 
 ### STREAM Copy
 
 MB/s · higher is better
 
-_Blaxel leads · ~1.3× Daytona on median (higher is better)._
+_Blaxel leads · ~1.7× Daytona on median (higher is better)._
 
 | Rank | Provider | STREAM Copy (MB/s) | 95% bootstrap interval | n | Note |
 | ---: | --- | ---: | ---: | ---: | --- |
-| 1 | Blaxel | 108200 | 107200 – 109200 | 2 | — |
-| 2 | Daytona | 86490 | 85820 – 87150 | 2 | n too small |
-| 3 | Modal | 62510 | 61910 – 63110 | 2 | n too small |
-| 4 | E2B | 48850 | 46640 – 51070 | 2 | n too small |
+| 1 | Blaxel | 113800 | 107300 – 120400 | 2 | — |
+| 2 | Daytona | 65680 | 65676 – 65690 | 2 | n too small |
+| 3 | Modal | 62010 | 56590 – 67440 | 2 | n too small |
+| 4 | Novita | 54820 | 54520 – 55130 | 2 | n too small |
+| 5 | E2B | 45120 | 43480 – 46760 | 2 | n too small |
 
 ### STREAM Scale
 
 MB/s · higher is better
 
-_Daytona leads · ~1.2× Blaxel on median (higher is better)._
+_Blaxel leads · ~1.2× Daytona on median (higher is better)._
 
 | Rank | Provider | STREAM Scale (MB/s) | 95% bootstrap interval | n | Note |
 | ---: | --- | ---: | ---: | ---: | --- |
-| 1 | Daytona | 72730 | 71570 – 73890 | 2 | — |
-| 2 | Blaxel | 61560 | 61410 – 61710 | 2 | n too small |
-| 3 | Modal | 37960 | 35060 – 40860 | 2 | n too small |
-| 4 | E2B | 21510 | 21140 – 21880 | 2 | n too small |
+| 1 | Blaxel | 62620 | 58680 – 66567 | 2 | — |
+| 2 | Daytona | 50120 | 50050 – 50180 | 2 | n too small |
+| 3 | Novita | 45410 | 45210 – 45610 | 2 | n too small |
+| 4 | Modal | 37400 | 34140 – 40662 | 2 | n too small |
+| 5 | E2B | 20880 | 20700 – 21050 | 2 | n too small |
 
 ## network
 
@@ -393,14 +425,55 @@ _Daytona leads · ~1.2× Blaxel on median (higher is better)._
 
 Seconds · lower is better
 
-_Daytona leads · Blaxel is ~1.5× higher (lower is better)._
+_Daytona leads · Blaxel is ~1.2× higher (lower is better)._
 
 | Rank | Provider | Loopback TCP (10GB) (Seconds) | 95% bootstrap interval | n | Note |
 | ---: | --- | ---: | ---: | ---: | --- |
-| 1 | Daytona | 4.531 | 4.326 – 4.737 | 2 | — |
-| 2 | Blaxel | 6.957 | 6.732 – 7.183 | 2 | n too small |
-| 3 | E2B | 14.98 | 14.89 – 15.07 | 2 | n too small |
-| 4 | Modal | 56.93 | 55.71 – 58.15 | 2 | n too small |
+| 1 | Daytona | 5.441 | 5.286 – 5.595 | 2 | — |
+| 2 | Blaxel | 6.603 | 6.339 – 6.867 | 2 | n too small |
+| 3 | Novita | 7.944 | 7.928 – 7.959 | 2 | n too small |
+| 4 | E2B | 10.44 | 9.903 – 10.97 | 2 | n too small |
+| 5 | Modal | 54.1 | 51.35 – 56.86 | 2 | n too small |
+
+### fast.com download
+
+Mbit/s · higher is better
+
+_E2B is the only ranked provider (3.25 Mbit/s; higher is better)._
+
+| Rank | Provider | fast.com download (Mbit/s) | 95% bootstrap interval | n |
+| ---: | --- | ---: | ---: | ---: |
+| 1 | E2B | 3.25 | 3 – 3.5 | 2 |
+
+### fast.com latency
+
+ms · lower is better
+
+_E2B is the only ranked provider (7 ms; lower is better)._
+
+| Rank | Provider | fast.com latency (ms) | 95% bootstrap interval | n |
+| ---: | --- | ---: | ---: | ---: |
+| 1 | E2B | 7 | 7 – 7 | 2 |
+
+### fast.com loaded latency
+
+ms · lower is better
+
+_E2B is the only ranked provider (9 ms; lower is better)._
+
+| Rank | Provider | fast.com loaded latency (ms) | 95% bootstrap interval | n |
+| ---: | --- | ---: | ---: | ---: |
+| 1 | E2B | 9 | — | 1 |
+
+### fast.com upload
+
+Mbit/s · higher is better
+
+_E2B is the only ranked provider (770 Mbit/s; higher is better)._
+
+| Rank | Provider | fast.com upload (Mbit/s) | 95% bootstrap interval | n |
+| ---: | --- | ---: | ---: | ---: |
+| 1 | E2B | 770 | 760 – 780 | 2 |
 
 ## system
 
@@ -408,24 +481,39 @@ _Daytona leads · Blaxel is ~1.5× higher (lower is better)._
 
 Milliseconds · lower is better
 
-_Blaxel is the only ranked provider (839.5 Milliseconds; lower is better)._
+_Blaxel is the only ranked provider (844 Milliseconds; lower is better)._
 
 | Rank | Provider | PyBench (Milliseconds) | 95% bootstrap interval | n |
 | ---: | --- | ---: | ---: | ---: |
-| 1 | Blaxel | 839.5 | 838 – 841 | 2 |
+| 1 | Blaxel | 844 | 839 – 849 | 2 |
+
+### Git common operations
+
+Seconds · lower is better
+
+_Daytona leads · Novita is ~1.2× higher (lower is better)._
+
+| Rank | Provider | Git common operations (Seconds) | 95% bootstrap interval | n | Note |
+| ---: | --- | ---: | ---: | ---: | --- |
+| 1 | Daytona | 36.06 | 35.96 – 36.16 | 2 | — |
+| 2 | Novita | 43.59 | 43.49 – 43.68 | 2 | n too small |
+| 3 | Blaxel | 61.48 | 61.37 – 61.59 | 2 | n too small |
+| 4 | E2B | 70.21 | 69.92 – 70.51 | 2 | n too small |
+| 5 | Modal | 81.37 | 80.74 – 82 | 2 | n too small |
 
 ### SQLite Speedtest
 
 Seconds · lower is better
 
-_Daytona leads · E2B is ~2.0× higher (lower is better)._
+_Daytona leads · Novita is ~1.3× higher (lower is better)._
 
 | Rank | Provider | SQLite Speedtest (Seconds) | 95% bootstrap interval | n | Note |
 | ---: | --- | ---: | ---: | ---: | --- |
-| 1 | Daytona | 34.47 | 34.31 – 34.64 | 2 | — |
-| 2 | E2B | 67.73 | 67.64 – 67.82 | 2 | n too small |
-| 3 | Blaxel | 69.59 | 69.38 – 69.81 | 2 | n too small |
-| 4 | Modal | 539.9 | 504.9 – 575 | 2 | n too small |
+| 1 | Daytona | 30.54 | 30.41 – 30.67 | 2 | — |
+| 2 | Novita | 38.81 | 38.53 – 39.09 | 2 | n too small |
+| 3 | Blaxel | 68.11 | 67.98 – 68.25 | 2 | n too small |
+| 4 | E2B | 69.84 | 69.82 – 69.86 | 2 | n too small |
+| 5 | Modal | 514.7 | 505.6 – 523.8 | 2 | n too small |
 
 ## realworld
 
@@ -433,51 +521,55 @@ _Daytona leads · E2B is ~2.0× higher (lower is better)._
 
 Seconds · lower is better
 
-_Daytona leads · Modal is ~2.4× higher (lower is better)._
+_Daytona leads · Novita is ~1.5× higher (lower is better)._
 
 | Rank | Provider | Mastra: cold install (Seconds) | 95% bootstrap interval | n | Note |
 | ---: | --- | ---: | ---: | ---: | --- |
-| 1 | Daytona | 29 | 28.73 – 29.26 | 2 | — |
-| 2 | Modal | 70.32 | 70.28 – 70.36 | 2 | n too small |
+| 1 | Daytona | 28.84 | 28.66 – 29.03 | 2 | — |
+| 2 | Novita | 42.48 | 42.08 – 42.88 | 2 | n too small |
+| 3 | Modal | 73.78 | 72.94 – 74.61 | 2 | n too small |
 
 ### Better-Auth: build
 
 Seconds · lower is better
 
-_Blaxel leads · Daytona is ~1.3× higher (lower is better)._
+_Blaxel leads · Daytona is ~1.2× higher (lower is better)._
 
 | Rank | Provider | Better-Auth: build (Seconds) | 95% bootstrap interval | n | Note |
 | ---: | --- | ---: | ---: | ---: | --- |
-| 1 | Blaxel | 9.915 | 9.754 – 10.08 | 2 | — |
-| 2 | Daytona | 12.45 | 12.44 – 12.47 | 2 | n too small |
-| 3 | E2B | 22.88 | 22.26 – 23.5 | 2 | n too small |
-| 4 | Modal | 40.77 | 40.48 – 41.06 | 2 | n too small |
+| 1 | Blaxel | 10.93 | 10.79 – 11.08 | 2 | — |
+| 2 | Daytona | 12.78 | 12.62 – 12.94 | 2 | n too small |
+| 3 | Novita | 14.52 | 14.52 – 14.53 | 2 | n too small |
+| 4 | E2B | 21.4 | 21.28 – 21.52 | 2 | n too small |
+| 5 | Modal | 40.92 | 39.94 – 41.9 | 2 | n too small |
 
 ### Better-Auth: cold install
 
 Seconds · lower is better
 
-_Daytona leads · Blaxel is ~1.5× higher (lower is better)._
+_Daytona leads · Novita is ~1.1× higher (lower is better)._
 
 | Rank | Provider | Better-Auth: cold install (Seconds) | 95% bootstrap interval | n | Note |
 | ---: | --- | ---: | ---: | ---: | --- |
-| 1 | Daytona | 11.6 | 11.09 – 12.12 | 2 | — |
-| 2 | Blaxel | 17.52 | 16.53 – 18.51 | 2 | n too small |
-| 3 | E2B | 19.92 | 19.8 – 20.04 | 2 | n too small |
-| 4 | Modal | 30.8 | 30.66 – 30.95 | 2 | n too small |
+| 1 | Daytona | 10.89 | 10.74 – 11.04 | 2 | — |
+| 2 | Novita | 11.86 | 11.77 – 11.95 | 2 | n too small |
+| 3 | Blaxel | 16.87 | 16.56 – 17.17 | 2 | n too small |
+| 4 | E2B | 19.64 | 19.3 – 19.98 | 2 | n too small |
+| 5 | Modal | 31.14 | 30.67 – 31.61 | 2 | n too small |
 
 ### Better-Auth: git clone
 
 Seconds · lower is better
 
-_Blaxel leads · Daytona is ~1.2× higher (lower is better)._
+_Blaxel leads · Daytona is ~1.1× higher (lower is better)._
 
 | Rank | Provider | Better-Auth: git clone (Seconds) | 95% bootstrap interval | n | Note |
 | ---: | --- | ---: | ---: | ---: | --- |
-| 1 | Blaxel | 1.409 | 1.286 – 1.532 | 2 | — |
-| 2 | Daytona | 1.72 | 1.696 – 1.745 | 2 | n too small |
-| 3 | E2B | 1.738 | 1.724 – 1.753 | 2 | n too small |
-| 4 | Modal | 2.73 | 2.588 – 2.872 | 2 | n too small |
+| 1 | Blaxel | 1.571 | 1.555 – 1.586 | 2 | — |
+| 2 | Daytona | 1.669 | 1.57 – 1.768 | 2 | n too small |
+| 3 | E2B | 1.777 | 1.768 – 1.787 | 2 | n too small |
+| 4 | Novita | 1.956 | 1.726 – 2.187 | 2 | n too small |
+| 5 | Modal | 2.388 | 2.251 – 2.524 | 2 | n too small |
 
 ### Better-Auth: lint (Biome)
 
@@ -487,121 +579,131 @@ _Blaxel leads · Daytona is ~1.2× higher (lower is better)._
 
 | Rank | Provider | Better-Auth: lint (Biome) (Seconds) | 95% bootstrap interval | n | Note |
 | ---: | --- | ---: | ---: | ---: | --- |
-| 1 | Blaxel | 3.892 | 3.827 – 3.957 | 2 | — |
-| 2 | Daytona | 4.863 | 4.849 – 4.876 | 2 | n too small |
-| 3 | E2B | 8.624 | 8.502 – 8.746 | 2 | n too small |
-| 4 | Modal | 17.45 | 17.33 – 17.58 | 2 | n too small |
+| 1 | Blaxel | 3.939 | 3.936 – 3.942 | 2 | — |
+| 2 | Daytona | 4.869 | 4.869 – 4.869 | 2 | n too small |
+| 3 | Novita | 5.394 | 5.378 – 5.411 | 2 | n too small |
+| 4 | E2B | 8.346 | 8.259 – 8.433 | 2 | n too small |
+| 5 | Modal | 17.18 | 17.13 – 17.23 | 2 | n too small |
 
 ### Better-Auth: lint deps (Knip)
 
 Seconds · lower is better
 
-_Daytona leads · Blaxel is ~1.4× higher (lower is better)._
+_Daytona leads · Novita is ~1.1× higher (lower is better)._
 
 | Rank | Provider | Better-Auth: lint deps (Knip) (Seconds) | 95% bootstrap interval | n | Note |
 | ---: | --- | ---: | ---: | ---: | --- |
-| 1 | Daytona | 10.82 | 10.77 – 10.87 | 2 | — |
-| 2 | Blaxel | 15.32 | 14.89 – 15.75 | 2 | n too small |
-| 3 | E2B | 19.86 | 19.78 – 19.95 | 2 | n too small |
-| 4 | Modal | 29 | 28.67 – 29.32 | 2 | n too small |
+| 1 | Daytona | 10.96 | 10.96 – 10.97 | 2 | — |
+| 2 | Novita | 11.67 | 11.64 – 11.7 | 2 | n too small |
+| 3 | Blaxel | 16.78 | 16.59 – 16.97 | 2 | n too small |
+| 4 | E2B | 18.75 | 18.72 – 18.78 | 2 | n too small |
+| 5 | Modal | 28.5 | 28.34 – 28.66 | 2 | n too small |
 
 ### Better-Auth: lint format
 
 Seconds · lower is better
 
-_Daytona leads · Blaxel is ~1.8× higher (lower is better)._
+_Daytona leads · Novita is ~1.1× higher (lower is better)._
 
 | Rank | Provider | Better-Auth: lint format (Seconds) | 95% bootstrap interval | n | Note |
 | ---: | --- | ---: | ---: | ---: | --- |
-| 1 | Daytona | 2.719 | 2.679 – 2.759 | 2 | — |
-| 2 | Blaxel | 4.885 | 4.834 – 4.936 | 2 | n too small |
-| 3 | E2B | 5.392 | 5.18 – 5.604 | 2 | n too small |
-| 4 | Modal | 6.547 | 6.486 – 6.608 | 2 | n too small |
+| 1 | Daytona | 2.681 | 2.679 – 2.683 | 2 | — |
+| 2 | Novita | 3.045 | 3.038 – 3.053 | 2 | n too small |
+| 3 | Blaxel | 4.946 | 4.946 – 4.946 | 2 | n too small |
+| 4 | E2B | 5.212 | 5.157 – 5.266 | 2 | n too small |
+| 5 | Modal | 6.581 | 6.494 – 6.668 | 2 | n too small |
 
 ### Better-Auth: lint packages
 
 Seconds · lower is better
 
-_Blaxel leads · Daytona is ~1.4× higher (lower is better)._
+_Blaxel leads · Daytona is ~1.3× higher (lower is better)._
 
 | Rank | Provider | Better-Auth: lint packages (Seconds) | 95% bootstrap interval | n | Note |
 | ---: | --- | ---: | ---: | ---: | --- |
-| 1 | Blaxel | 2.952 | 2.939 – 2.965 | 2 | — |
-| 2 | Daytona | 4.024 | 3.999 – 4.05 | 2 | n too small |
-| 3 | E2B | 7.285 | 7.226 – 7.345 | 2 | n too small |
-| 4 | Modal | 15.76 | 15.72 – 15.81 | 2 | n too small |
+| 1 | Blaxel | 2.984 | 2.966 – 3.001 | 2 | — |
+| 2 | Daytona | 4.015 | 4.01 – 4.02 | 2 | n too small |
+| 3 | Novita | 4.635 | 4.632 – 4.638 | 2 | n too small |
+| 4 | E2B | 7.606 | 7.593 – 7.619 | 2 | n too small |
+| 5 | Modal | 15.76 | 15.56 – 15.97 | 2 | n too small |
 
 ### Better-Auth: lint spell
 
 Seconds · lower is better
 
-_Daytona leads · Blaxel is ~1.7× higher (lower is better)._
+_Daytona leads · Novita is ~1.1× higher (lower is better)._
 
 | Rank | Provider | Better-Auth: lint spell (Seconds) | 95% bootstrap interval | n | Note |
 | ---: | --- | ---: | ---: | ---: | --- |
-| 1 | Daytona | 6.757 | 6.711 – 6.803 | 2 | — |
-| 2 | Blaxel | 11.73 | 11.7 – 11.76 | 2 | n too small |
-| 3 | E2B | 13.38 | 13.36 – 13.4 | 2 | n too small |
-| 4 | Modal | 15.39 | 14.8 – 15.98 | 2 | n too small |
+| 1 | Daytona | 6.838 | 6.769 – 6.908 | 2 | — |
+| 2 | Novita | 7.691 | 7.457 – 7.925 | 2 | n too small |
+| 3 | Blaxel | 12.2 | 12.19 – 12.21 | 2 | n too small |
+| 4 | E2B | 12.43 | 12.29 – 12.57 | 2 | n too small |
+| 5 | Modal | 15.18 | 14.7 – 15.65 | 2 | n too small |
 
 ### Better-Auth: lint types
 
 Seconds · lower is better
 
-_Blaxel leads · Daytona is ~1.7× higher (lower is better)._
+_Blaxel leads · Daytona is ~1.5× higher (lower is better)._
 
 | Rank | Provider | Better-Auth: lint types (Seconds) | 95% bootstrap interval | n | Note |
 | ---: | --- | ---: | ---: | ---: | --- |
-| 1 | Blaxel | 30.36 | 30.16 – 30.57 | 2 | — |
-| 2 | Daytona | 51.09 | 49.97 – 52.21 | 2 | n too small |
-| 3 | E2B | 103.2 | 102.5 – 103.9 | 2 | n too small |
-| 4 | Modal | 187.6 | 187.2 – 188 | 2 | n too small |
+| 1 | Blaxel | 33.64 | 33.48 – 33.8 | 2 | — |
+| 2 | Daytona | 51.07 | 50.95 – 51.19 | 2 | n too small |
+| 3 | Novita | 60.08 | 59.63 – 60.53 | 2 | n too small |
+| 4 | E2B | 98.64 | 97.8 – 99.48 | 2 | n too small |
+| 5 | Modal | 183.3 | 178.9 – 187.7 | 2 | n too small |
 
 ### Better-Auth: typecheck
 
 Seconds · lower is better
 
-_Daytona leads · Blaxel is ~1.4× higher (lower is better)._
+_Daytona leads · Novita is ~1.1× higher (lower is better)._
 
 | Rank | Provider | Better-Auth: typecheck (Seconds) | 95% bootstrap interval | n | Note |
 | ---: | --- | ---: | ---: | ---: | --- |
-| 1 | Daytona | 1.443 | 1.439 – 1.447 | 2 | — |
-| 2 | Blaxel | 2.044 | 2.014 – 2.074 | 2 | n too small |
-| 3 | E2B | 2.335 | 2.301 – 2.369 | 2 | n too small |
-| 4 | Modal | 3.367 | 3.288 – 3.447 | 2 | n too small |
+| 1 | Daytona | 1.388 | 1.378 – 1.398 | 2 | — |
+| 2 | Novita | 1.474 | 1.465 – 1.483 | 2 | n too small |
+| 3 | Blaxel | 2.037 | 2.037 – 2.038 | 2 | n too small |
+| 4 | E2B | 2.613 | 2.436 – 2.79 | 2 | n too small |
+| 5 | Modal | 3.308 | 3.29 – 3.326 | 2 | n too small |
 
 ### Mastra: build:core
 
 Seconds · lower is better
 
-_Daytona leads · Modal is ~2.4× higher (lower is better)._
+_Daytona leads · Novita is ~1.5× higher (lower is better)._
 
 | Rank | Provider | Mastra: build:core (Seconds) | 95% bootstrap interval | n | Note |
 | ---: | --- | ---: | ---: | ---: | --- |
-| 1 | Daytona | 85.3 | 82.89 – 87.72 | 2 | — |
-| 2 | Modal | 205.6 | 203.4 – 207.9 | 2 | n too small |
+| 1 | Daytona | 83 | 82.98 – 83.02 | 2 | — |
+| 2 | Novita | 125.6 | 125.2 – 126 | 2 | n too small |
+| 3 | Modal | 203 | 201.1 – 205 | 2 | n too small |
 
 ### Mastra: git clone
 
 Seconds · lower is better
 
-_Daytona leads · Modal is ~1.4× higher (lower is better)._
+_Daytona leads · Novita is ~1.1× higher (lower is better)._
 
 | Rank | Provider | Mastra: git clone (Seconds) | 95% bootstrap interval | n | Note |
 | ---: | --- | ---: | ---: | ---: | --- |
-| 1 | Daytona | 7.524 | 7.144 – 7.904 | 2 | — |
-| 2 | Modal | 10.33 | 10.11 – 10.54 | 2 | n too small |
+| 1 | Daytona | 6.626 | 6.425 – 6.827 | 2 | — |
+| 2 | Novita | 7.014 | 6.931 – 7.096 | 2 | n too small |
+| 3 | Modal | 9.957 | 9.35 – 10.56 | 2 | n too small |
 
 ### Mastra: lint:format
 
 Seconds · lower is better
 
-_Daytona leads · Modal is ~2.3× higher (lower is better)._
+_Daytona leads · Novita is ~1.4× higher (lower is better)._
 
 | Rank | Provider | Mastra: lint:format (Seconds) | 95% bootstrap interval | n | Note |
 | ---: | --- | ---: | ---: | ---: | --- |
-| 1 | Daytona | 91.36 | 91.29 – 91.43 | 2 | — |
-| 2 | Modal | 206.6 | 201 – 212.1 | 2 | n too small |
+| 1 | Daytona | 90.71 | 90.34 – 91.08 | 2 | — |
+| 2 | Novita | 128.7 | 128.5 – 128.8 | 2 | n too small |
+| 3 | Modal | 199.7 | 198.2 – 201.1 | 2 | n too small |
 
 ## economics
 
@@ -609,17 +711,18 @@ _Daytona leads · Modal is ~2.3× higher (lower is better)._
 
 USD/hr · lower is better
 
-_Daytona is cheapest · E2B is ~1.5× higher (lower is better)._
+_Daytona is cheapest · Novita is ~1.1× higher (lower is better)._
 
 | Rank | Provider | Hourly cost (USD/hr) | 95% bootstrap interval | n |
 | ---: | --- | ---: | ---: | ---: |
 | 1 | Daytona | 0.1494 | — | 1 |
-| 2 | E2B | 0.2304 | — | 1 |
-| 3 | Modal | 0.4774 | — | 1 |
+| 2 | Novita | 0.1627 | — | 1 |
+| 3 | E2B | 0.2304 | — | 1 |
+| 4 | Modal | 0.4774 | — | 1 |
 
 ## Coverage gaps
 
-17 uncovered results across 5 providers (Blaxel 2, Daytona 1, E2B 3, Modal 2, Novita 9). A gap is a missing result — the provider **failing to cover** that workload — never a tie or a zero.
+13 uncovered results across 5 providers (Blaxel 3, Daytona 2, E2B 3, Modal 3, Novita 2). A gap is a missing result — the provider **failing to cover** that workload — never a tie or a zero.
 
 <details>
 <summary>Full coverage table</summary>
@@ -628,21 +731,17 @@ _Daytona is cheapest · E2B is ~1.5× higher (lower is better)._
 | --- | --- | --- | --- |
 | Blaxel | realworld-mastra | ❌ **disk** (skipped) | Insufficient disk: 12.5 GiB free, suite needs 30 GiB |
 | Blaxel | realworld-openclaw | ❌ **disk** (skipped) | Insufficient disk: 12.5 GiB free, suite needs 25 GiB |
-| E2B | realworld-mastra | ❌ **disk** (skipped) | Insufficient disk: 19.7 GiB free, suite needs 30 GiB |
-| E2B | realworld-openclaw | ❌ **disk** (skipped) | Insufficient disk: 19.7 GiB free, suite needs 25 GiB |
-| Daytona | realworld-openclaw | **failed** | Step "mise run benchmark:realworld:pts:openclaw" lost its sandbox: 12 consecutive detached polls failed (last: done-file fs exists) — the sandbox stopped responding, not a quiet long step |
+| E2B | realworld-mastra | ❌ **disk** (skipped) | Insufficient disk: 20.0 GiB free, suite needs 30 GiB |
+| E2B | realworld-openclaw | ❌ **disk** (skipped) | Insufficient disk: 20.0 GiB free, suite needs 25 GiB |
+| Blaxel | network | **failed** | Step "mise run benchmark:network:all" failed with exit code 1 |
+| Daytona | network | **failed** | Step "mise run benchmark:network:all" timed out after 2700s |
+| Daytona | realworld-openclaw | **failed** | Step "mise run benchmark:realworld:pts:openclaw" timed out after 8400s |
 | E2B | cpu-generic | **failed** | Step "mise run benchmark:cpu:generic" timed out after 7800s |
 | Modal | cpu-generic | **failed** | Step "mise run benchmark:cpu:generic" timed out after 7800s |
+| Modal | network | **failed** | Step "mise run benchmark:network:all" failed with exit code 1 |
 | Modal | realworld-openclaw | **failed** | Step "mise run benchmark:realworld:pts:openclaw" timed out after 8400s |
-| Novita | cpu-generic | **missing** | No result and no marker — the suite never reported for this provider. |
-| Novita | cpu-node | **missing** | No result and no marker — the suite never reported for this provider. |
-| Novita | disk | **missing** | No result and no marker — the suite never reported for this provider. |
-| Novita | memory | **missing** | No result and no marker — the suite never reported for this provider. |
-| Novita | network | **missing** | No result and no marker — the suite never reported for this provider. |
-| Novita | realworld-better-auth | **missing** | No result and no marker — the suite never reported for this provider. |
-| Novita | realworld-mastra | **missing** | No result and no marker — the suite never reported for this provider. |
-| Novita | realworld-openclaw | **missing** | No result and no marker — the suite never reported for this provider. |
-| Novita | system | **missing** | No result and no marker — the suite never reported for this provider. |
+| Novita | network | **failed** | Step "mise run benchmark:network:all" failed with exit code 1 |
+| Novita | realworld-openclaw | **failed** | Step "mise run benchmark:realworld:pts:openclaw" lost its sandbox: 12 consecutive detached polls failed (last: done-file fs exists) — the sandbox stopped responding, not a quiet long step |
 
 **skipped** — a precondition said no before the benchmark was attempted. A ❌ **disk** skip is the
 loud one: the provider could not supply the disk the suite needs, so the workload does not run on
@@ -650,11 +749,6 @@ its current allocation at all. That is a structural absence, not a slow result.
 
 **failed** — the benchmark was attempted and broke: it threw, timed out, or died with the sandbox.
 Unlike a skip, this is a reliability fact about the provider, not a decision made on its behalf.
-
-**missing** — nothing was reported at all: no result, and no marker explaining why. The suite ran
-elsewhere in this run, so it was part of the comparison, and this provider is simply absent from
-it — a dropped job, a lost artifact, or a sandbox that died before it could say anything. Treat it
-as unmeasured, never as a pass: the provider has not been shown to run this workload.
 
 </details>
 
@@ -699,149 +793,207 @@ correction is applied across providers or metrics.
 | Dimension | Metric | Provider | p vs. above | p (KS) |
 | --- | --- | --- | ---: | ---: |
 | cpu | Node.js web tooling | Daytona | — | — |
+| cpu | Node.js web tooling | Novita | 0.33 (n too small) | 0.097 |
 | cpu | Node.js web tooling | Blaxel | 0.33 (n too small) | 0.097 |
 | cpu | Node.js web tooling | E2B | 0.33 (n too small) | 0.097 |
 | cpu | Node.js web tooling | Modal | 0.33 (n too small) | 0.097 |
 | cpu | C-Ray (1080p, 16 RPP) | Blaxel | — | — |
 | cpu | C-Ray (1080p, 16 RPP) | Daytona | 0.33 (n too small) | 0.097 |
+| cpu | C-Ray (1080p, 16 RPP) | Novita | 0.33 (n too small) | 0.097 |
 | cpu | C-Ray (4K, 16 RPP) | Blaxel | — | — |
 | cpu | C-Ray (4K, 16 RPP) | Daytona | 0.33 (n too small) | 0.097 |
+| cpu | C-Ray (4K, 16 RPP) | Novita | 0.33 (n too small) | 0.097 |
 | cpu | C-Ray (5K, 16 RPP) | Blaxel | — | — |
 | cpu | C-Ray (5K, 16 RPP) | Daytona | 0.33 (n too small) | 0.097 |
+| cpu | C-Ray (5K, 16 RPP) | Novita | 0.33 (n too small) | 0.097 |
 | cpu | Zstd 12 compress | Blaxel | — | — |
 | cpu | Zstd 12 compress | Daytona | 0.33 (n too small) | 0.097 |
+| cpu | Zstd 12 compress | Novita | 0.33 (n too small) | 0.097 |
 | cpu | Zstd 12 decompress | Daytona | — | — |
+| cpu | Zstd 12 decompress | Novita | 0.33 (n too small) | 0.097 |
 | cpu | Zstd 12 decompress | Blaxel | 0.33 (n too small) | 0.097 |
 | cpu | Zstd 19 compress | Blaxel | — | — |
 | cpu | Zstd 19 compress | Daytona | 0.33 (n too small) | 0.097 |
+| cpu | Zstd 19 compress | Novita | 0.33 (n too small) | 0.097 |
 | cpu | Zstd 19 decompress | Daytona | — | — |
+| cpu | Zstd 19 decompress | Novita | 0.33 (n too small) | 0.097 |
 | cpu | Zstd 19 decompress | Blaxel | 0.33 (n too small) | 0.097 |
 | cpu | Zstd 19 (long) compress | Daytona | — | — |
 | cpu | Zstd 19 (long) compress | Blaxel | 0.33 (n too small) | 0.097 |
+| cpu | Zstd 19 (long) compress | Novita | 0.33 (n too small) | 0.097 |
 | cpu | Zstd 19 (long) decompress | Daytona | — | — |
+| cpu | Zstd 19 (long) decompress | Novita | 0.33 (n too small) | 0.097 |
 | cpu | Zstd 19 (long) decompress | Blaxel | 0.33 (n too small) | 0.097 |
 | cpu | Zstd 3 compress | Blaxel | — | — |
 | cpu | Zstd 3 compress | Daytona | 0.33 (n too small) | 0.097 |
+| cpu | Zstd 3 compress | Novita | 0.33 (n too small) | 0.097 |
 | cpu | Zstd 3 decompress | Daytona | — | — |
+| cpu | Zstd 3 decompress | Novita | 0.33 (n too small) | 0.097 |
+| cpu | Zstd 3 decompress | Blaxel | — | — |
 | cpu | Zstd 3 (long) compress | Blaxel | — | — |
 | cpu | Zstd 3 (long) compress | Daytona | 0.33 (n too small) | 0.097 |
+| cpu | Zstd 3 (long) compress | Novita | 0.33 (n too small) | 0.097 |
 | cpu | Zstd 3 (long) decompress | Daytona | — | — |
+| cpu | Zstd 3 (long) decompress | Novita | 0.33 (n too small) | 0.097 |
 | cpu | Zstd 8 compress | Blaxel | — | — |
 | cpu | Zstd 8 compress | Daytona | 0.33 (n too small) | 0.097 |
-| cpu | Zstd 8 decompress | Blaxel | — | — |
+| cpu | Zstd 8 compress | Novita | 0.33 (n too small) | 0.097 |
+| cpu | Zstd 8 decompress | Daytona | — | — |
+| cpu | Zstd 8 decompress | Novita | 0.33 (n too small) | 0.097 |
+| cpu | Zstd 8 decompress | Blaxel | 0.33 (n too small) | 0.097 |
 | cpu | Zstd 8 (long) compress | Blaxel | — | — |
 | cpu | Zstd 8 (long) compress | Daytona | 0.33 (n too small) | 0.097 |
+| cpu | Zstd 8 (long) compress | Novita | 0.33 (n too small) | 0.097 |
 | cpu | Zstd 8 (long) decompress | Daytona | — | — |
+| cpu | Zstd 8 (long) decompress | Novita | 0.33 (n too small) | 0.097 |
 | cpu | Zstd 8 (long) decompress | Blaxel | 0.33 (n too small) | 0.097 |
 | disk | fio rand read 4KB, O_DIRECT (IOPS) | Blaxel | — | — |
 | disk | fio rand read 4KB, O_DIRECT (IOPS) | Daytona | 0.33 (n too small) | 0.097 |
+| disk | fio rand read 4KB, O_DIRECT (IOPS) | Novita | 0.33 (n too small) | 0.097 |
+| disk | fio rand read 4KB, O_DIRECT (IOPS) | E2B | 0.33 (n too small) | 0.097 |
 | disk | fio rand read 4KB, O_DIRECT (IOPS) | Modal | 0.33 (n too small) | 0.097 |
-| disk | fio rand read 4KB, O_DIRECT (IOPS) | E2B | 0.67 (n too small) | 0.84 |
 | disk | fio rand read 4KB, O_DIRECT (MB/s) | Blaxel | — | — |
 | disk | fio rand read 4KB, O_DIRECT (MB/s) | Daytona | 0.33 (n too small) | 0.097 |
+| disk | fio rand read 4KB, O_DIRECT (MB/s) | Novita | 0.33 (n too small) | 0.097 |
+| disk | fio rand read 4KB, O_DIRECT (MB/s) | E2B | 0.33 (n too small) | 0.097 |
 | disk | fio rand read 4KB, O_DIRECT (MB/s) | Modal | 0.33 (n too small) | 0.097 |
-| disk | fio rand read 4KB, O_DIRECT (MB/s) | E2B | 1.0 (n too small) | 0.84 |
 | disk | fio rand write 4KB, O_DIRECT (IOPS) | Blaxel | — | — |
 | disk | fio rand write 4KB, O_DIRECT (IOPS) | Daytona | 0.33 (n too small) | 0.097 |
+| disk | fio rand write 4KB, O_DIRECT (IOPS) | Novita | 0.33 (n too small) | 0.097 |
 | disk | fio rand write 4KB, O_DIRECT (IOPS) | E2B | 0.33 (n too small) | 0.097 |
 | disk | fio rand write 4KB, O_DIRECT (IOPS) | Modal | 0.33 (n too small) | 0.097 |
 | disk | fio rand write 4KB, O_DIRECT (MB/s) | Blaxel | — | — |
 | disk | fio rand write 4KB, O_DIRECT (MB/s) | Daytona | 0.33 (n too small) | 0.097 |
+| disk | fio rand write 4KB, O_DIRECT (MB/s) | Novita | 0.33 (n too small) | 0.097 |
 | disk | fio rand write 4KB, O_DIRECT (MB/s) | E2B | 0.33 (n too small) | 0.097 |
 | disk | fio rand write 4KB, O_DIRECT (MB/s) | Modal | 0.33 (n too small) | 0.097 |
-| disk | fio seq read 1MB, O_DIRECT (IOPS) | Daytona | — | — |
-| disk | fio seq read 1MB, O_DIRECT (IOPS) | Modal | 1.0 (n too small) | 0.84 |
+| disk | fio seq read 1MB, O_DIRECT (IOPS) | Modal | — | — |
+| disk | fio seq read 1MB, O_DIRECT (IOPS) | Novita | 0.33 (n too small) | 0.097 |
+| disk | fio seq read 1MB, O_DIRECT (IOPS) | Daytona | 1.0 (n too small) | 0.84 |
 | disk | fio seq read 1MB, O_DIRECT (IOPS) | Blaxel | 0.33 (n too small) | 0.097 |
 | disk | fio seq read 1MB, O_DIRECT (IOPS) | E2B | 0.33 (n too small) | 0.097 |
 | disk | fio seq read 1MB, O_DIRECT (MB/s) | Daytona | — | — |
 | disk | fio seq read 1MB, O_DIRECT (MB/s) | Blaxel | — | — |
 | disk | fio seq read 1MB, O_DIRECT (MB/s) | E2B | 0.33 (n too small) | 0.097 |
 | disk | fio seq write 1MB, O_DIRECT (IOPS) | Daytona | — | — |
+| disk | fio seq write 1MB, O_DIRECT (IOPS) | Novita | 0.33 (n too small) | 0.097 |
 | disk | fio seq write 1MB, O_DIRECT (IOPS) | Blaxel | 0.33 (n too small) | 0.097 |
 | disk | fio seq write 1MB, O_DIRECT (IOPS) | Modal | 0.33 (n too small) | 0.097 |
 | disk | fio seq write 1MB, O_DIRECT (IOPS) | E2B | 0.33 (n too small) | 0.097 |
 | disk | fio seq write 1MB, O_DIRECT (MB/s) | Daytona | — | — |
+| disk | fio seq write 1MB, O_DIRECT (MB/s) | Novita | 0.33 (n too small) | 0.097 |
 | disk | fio seq write 1MB, O_DIRECT (MB/s) | Blaxel | 0.33 (n too small) | 0.097 |
 | disk | fio seq write 1MB, O_DIRECT (MB/s) | Modal | 0.33 (n too small) | 0.097 |
 | disk | fio seq write 1MB, O_DIRECT (MB/s) | E2B | 0.33 (n too small) | 0.097 |
 | disk | Hardlink throughput | Daytona | — | — |
+| disk | Hardlink throughput | Novita | 0.33 (n too small) | 0.097 |
 | disk | Hardlink throughput | Blaxel | 0.33 (n too small) | 0.097 |
 | disk | Hardlink throughput | Modal | 0.33 (n too small) | 0.097 |
 | disk | Hardlink throughput | E2B | 0.33 (n too small) | 0.097 |
-| memory | STREAM Triad | Daytona | — | — |
-| memory | STREAM Triad | Blaxel | 0.33 (n too small) | 0.097 |
-| memory | STREAM Triad | Modal | 0.33 (n too small) | 0.097 |
+| memory | STREAM Triad | Blaxel | — | — |
+| memory | STREAM Triad | Daytona | 0.33 (n too small) | 0.097 |
+| memory | STREAM Triad | Novita | 0.33 (n too small) | 0.097 |
+| memory | STREAM Triad | Modal | 1.0 (n too small) | 0.84 |
 | memory | STREAM Triad | E2B | 0.33 (n too small) | 0.097 |
-| memory | STREAM Add | Daytona | — | — |
-| memory | STREAM Add | Blaxel | 0.33 (n too small) | 0.097 |
+| memory | STREAM Add | Blaxel | — | — |
+| memory | STREAM Add | Daytona | 0.33 (n too small) | 0.097 |
 | memory | STREAM Add | Modal | 0.33 (n too small) | 0.097 |
+| memory | STREAM Add | Novita | 1.0 (n too small) | 0.84 |
 | memory | STREAM Add | E2B | 0.33 (n too small) | 0.097 |
 | memory | STREAM Copy | Blaxel | — | — |
 | memory | STREAM Copy | Daytona | 0.33 (n too small) | 0.097 |
-| memory | STREAM Copy | Modal | 0.33 (n too small) | 0.097 |
+| memory | STREAM Copy | Modal | 1.0 (n too small) | 0.84 |
+| memory | STREAM Copy | Novita | 0.33 (n too small) | 0.097 |
 | memory | STREAM Copy | E2B | 0.33 (n too small) | 0.097 |
-| memory | STREAM Scale | Daytona | — | — |
-| memory | STREAM Scale | Blaxel | 0.33 (n too small) | 0.097 |
+| memory | STREAM Scale | Blaxel | — | — |
+| memory | STREAM Scale | Daytona | 0.33 (n too small) | 0.097 |
+| memory | STREAM Scale | Novita | 0.33 (n too small) | 0.097 |
 | memory | STREAM Scale | Modal | 0.33 (n too small) | 0.097 |
 | memory | STREAM Scale | E2B | 0.33 (n too small) | 0.097 |
 | network | Loopback TCP (10GB) | Daytona | — | — |
 | network | Loopback TCP (10GB) | Blaxel | 0.33 (n too small) | 0.097 |
+| network | Loopback TCP (10GB) | Novita | 0.33 (n too small) | 0.097 |
 | network | Loopback TCP (10GB) | E2B | 0.33 (n too small) | 0.097 |
 | network | Loopback TCP (10GB) | Modal | 0.33 (n too small) | 0.097 |
+| network | fast.com download | E2B | — | — |
+| network | fast.com latency | E2B | — | — |
+| network | fast.com loaded latency | E2B | — | — |
+| network | fast.com upload | E2B | — | — |
 | system | PyBench | Blaxel | — | — |
+| system | Git common operations | Daytona | — | — |
+| system | Git common operations | Novita | 0.33 (n too small) | 0.097 |
+| system | Git common operations | Blaxel | 0.33 (n too small) | 0.097 |
+| system | Git common operations | E2B | 0.33 (n too small) | 0.097 |
+| system | Git common operations | Modal | 0.33 (n too small) | 0.097 |
 | system | SQLite Speedtest | Daytona | — | — |
-| system | SQLite Speedtest | E2B | 0.33 (n too small) | 0.097 |
+| system | SQLite Speedtest | Novita | 0.33 (n too small) | 0.097 |
 | system | SQLite Speedtest | Blaxel | 0.33 (n too small) | 0.097 |
+| system | SQLite Speedtest | E2B | 0.33 (n too small) | 0.097 |
 | system | SQLite Speedtest | Modal | 0.33 (n too small) | 0.097 |
 | realworld | Mastra: cold install | Daytona | — | — |
+| realworld | Mastra: cold install | Novita | 0.33 (n too small) | 0.097 |
 | realworld | Mastra: cold install | Modal | 0.33 (n too small) | 0.097 |
 | realworld | Better-Auth: build | Blaxel | — | — |
 | realworld | Better-Auth: build | Daytona | 0.33 (n too small) | 0.097 |
+| realworld | Better-Auth: build | Novita | 0.33 (n too small) | 0.097 |
 | realworld | Better-Auth: build | E2B | 0.33 (n too small) | 0.097 |
 | realworld | Better-Auth: build | Modal | 0.33 (n too small) | 0.097 |
 | realworld | Better-Auth: cold install | Daytona | — | — |
+| realworld | Better-Auth: cold install | Novita | 0.33 (n too small) | 0.097 |
 | realworld | Better-Auth: cold install | Blaxel | 0.33 (n too small) | 0.097 |
 | realworld | Better-Auth: cold install | E2B | 0.33 (n too small) | 0.097 |
 | realworld | Better-Auth: cold install | Modal | 0.33 (n too small) | 0.097 |
 | realworld | Better-Auth: git clone | Blaxel | — | — |
-| realworld | Better-Auth: git clone | Daytona | 0.33 (n too small) | 0.097 |
+| realworld | Better-Auth: git clone | Daytona | 0.67 (n too small) | 0.84 |
 | realworld | Better-Auth: git clone | E2B | 0.67 (n too small) | 0.84 |
+| realworld | Better-Auth: git clone | Novita | 1.0 (n too small) | 0.84 |
 | realworld | Better-Auth: git clone | Modal | 0.33 (n too small) | 0.097 |
 | realworld | Better-Auth: lint (Biome) | Blaxel | — | — |
 | realworld | Better-Auth: lint (Biome) | Daytona | 0.33 (n too small) | 0.097 |
+| realworld | Better-Auth: lint (Biome) | Novita | 0.33 (n too small) | 0.097 |
 | realworld | Better-Auth: lint (Biome) | E2B | 0.33 (n too small) | 0.097 |
 | realworld | Better-Auth: lint (Biome) | Modal | 0.33 (n too small) | 0.097 |
 | realworld | Better-Auth: lint deps (Knip) | Daytona | — | — |
+| realworld | Better-Auth: lint deps (Knip) | Novita | 0.33 (n too small) | 0.097 |
 | realworld | Better-Auth: lint deps (Knip) | Blaxel | 0.33 (n too small) | 0.097 |
 | realworld | Better-Auth: lint deps (Knip) | E2B | 0.33 (n too small) | 0.097 |
 | realworld | Better-Auth: lint deps (Knip) | Modal | 0.33 (n too small) | 0.097 |
 | realworld | Better-Auth: lint format | Daytona | — | — |
+| realworld | Better-Auth: lint format | Novita | 0.33 (n too small) | 0.097 |
 | realworld | Better-Auth: lint format | Blaxel | 0.33 (n too small) | 0.097 |
 | realworld | Better-Auth: lint format | E2B | 0.33 (n too small) | 0.097 |
 | realworld | Better-Auth: lint format | Modal | 0.33 (n too small) | 0.097 |
 | realworld | Better-Auth: lint packages | Blaxel | — | — |
 | realworld | Better-Auth: lint packages | Daytona | 0.33 (n too small) | 0.097 |
+| realworld | Better-Auth: lint packages | Novita | 0.33 (n too small) | 0.097 |
 | realworld | Better-Auth: lint packages | E2B | 0.33 (n too small) | 0.097 |
 | realworld | Better-Auth: lint packages | Modal | 0.33 (n too small) | 0.097 |
 | realworld | Better-Auth: lint spell | Daytona | — | — |
+| realworld | Better-Auth: lint spell | Novita | 0.33 (n too small) | 0.097 |
 | realworld | Better-Auth: lint spell | Blaxel | 0.33 (n too small) | 0.097 |
 | realworld | Better-Auth: lint spell | E2B | 0.33 (n too small) | 0.097 |
 | realworld | Better-Auth: lint spell | Modal | 0.33 (n too small) | 0.097 |
 | realworld | Better-Auth: lint types | Blaxel | — | — |
 | realworld | Better-Auth: lint types | Daytona | 0.33 (n too small) | 0.097 |
+| realworld | Better-Auth: lint types | Novita | 0.33 (n too small) | 0.097 |
 | realworld | Better-Auth: lint types | E2B | 0.33 (n too small) | 0.097 |
 | realworld | Better-Auth: lint types | Modal | 0.33 (n too small) | 0.097 |
 | realworld | Better-Auth: typecheck | Daytona | — | — |
+| realworld | Better-Auth: typecheck | Novita | 0.33 (n too small) | 0.097 |
 | realworld | Better-Auth: typecheck | Blaxel | 0.33 (n too small) | 0.097 |
 | realworld | Better-Auth: typecheck | E2B | 0.33 (n too small) | 0.097 |
 | realworld | Better-Auth: typecheck | Modal | 0.33 (n too small) | 0.097 |
 | realworld | Mastra: build:core | Daytona | — | — |
+| realworld | Mastra: build:core | Novita | 0.33 (n too small) | 0.097 |
 | realworld | Mastra: build:core | Modal | 0.33 (n too small) | 0.097 |
 | realworld | Mastra: git clone | Daytona | — | — |
+| realworld | Mastra: git clone | Novita | 0.33 (n too small) | 0.097 |
 | realworld | Mastra: git clone | Modal | 0.33 (n too small) | 0.097 |
 | realworld | Mastra: lint:format | Daytona | — | — |
+| realworld | Mastra: lint:format | Novita | 0.33 (n too small) | 0.097 |
 | realworld | Mastra: lint:format | Modal | 0.33 (n too small) | 0.097 |
 | economics | Hourly cost | Daytona | — | — |
+| economics | Hourly cost | Novita | — | — |
 | economics | Hourly cost | E2B | — | — |
 | economics | Hourly cost | Modal | — | — |
 

--- a/data/dataset/index.json
+++ b/data/dataset/index.json
@@ -2,6 +2,11 @@
   "schemaVersion": "1",
   "runs": [
     {
+      "runId": "29546060837",
+      "generatedAt": "2026-07-17T03:31:38.992Z",
+      "path": "runs/29546060837.json"
+    },
+    {
       "runId": "29472826358",
       "generatedAt": "2026-07-16T07:25:11.693Z",
       "path": "runs/29472826358.json"

--- a/data/dataset/runs/29546060837.json
+++ b/data/dataset/runs/29546060837.json
@@ -1,0 +1,9624 @@
+{
+  "schemaVersion": "2",
+  "runId": "29546060837",
+  "sha": "dd1f6ef472e3de4b76043c74f3cce5ff0d636af2",
+  "generatedAt": "2026-07-17T03:31:38.992Z",
+  "targetSpec": {
+    "vcpus": 2,
+    "memoryGb": 8,
+    "diskGb": 40
+  },
+  "providers": [
+    {
+      "providerId": "blaxel",
+      "validationStatus": "validated",
+      "specMatched": false,
+      "observedSpecs": {
+        "cpuModel": "Intel(R) Xeon(R) Processor @ 2.90GHz",
+        "hostVcpus": 6,
+        "hostMemoryGb": 16,
+        "os": "Debian GNU/Linux 12 (bookworm)",
+        "kernel": "6.12.75+",
+        "user": "root",
+        "vcpus": 6,
+        "virtualization": "unknown",
+        "memoryGb": 15.63,
+        "diskGb": 12.5,
+        "publicIp": "34.214.71.218",
+        "egressOrg": "AS16509 Amazon.com, Inc.",
+        "egressAsn": "AS16509",
+        "egressOrgName": "Amazon.com, Inc.",
+        "reverseDns": "ec2-34-214-71-218.us-west-2.compute.amazonaws.com",
+        "city": "Boardman",
+        "region": "Oregon",
+        "country": "US",
+        "location": "45.8399,-119.7006",
+        "timezone": "America/Los_Angeles",
+        "networkPrefix": "34.208.0.0/12",
+        "asnSource": "cymru",
+        "geoSource": "ipinfo"
+      },
+      "hostMetadata": [
+        {
+          "source": "phoronix/result-file-to-json",
+          "sourceFile": "cpu-generic/pts_c-ray--metadata.json",
+          "fields": [
+            {
+              "path": "ci.client_version",
+              "value": "10.8.4"
+            },
+            {
+              "path": "ci.data.compiler-configuration",
+              "value": "--build=x86_64-linux-gnu --disable-vtable-verify --disable-werror --enable-cet --enable-checking=release --enable-clocale=gnu --enable-default-pie --enable-gnu-unique-object --enable-languages=c,ada,c++,go,d,fortran,objc,obj-c++,m2 --enable-libphobos-checking=release --enable-libstdcxx-debug --enable-libstdcxx-time=yes --enable-multiarch --enable-multilib --enable-nls --enable-objc-gc=auto --enable-offload-defaulted --enable-offload-targets=nvptx-none=/build/reproducible-path/gcc-12-12.2.0/debian/tmp-nvptx/usr,amdgcn-amdhsa=/build/reproducible-path/gcc-12-12.2.0/debian/tmp-gcn/usr --enable-plugin --enable-shared --enable-threads=posix --host=x86_64-linux-gnu --program-prefix=x86_64-linux-gnu- --target=x86_64-linux-gnu --with-abi=m64 --with-arch-32=i686 --with-default-libstdcxx-abi=new --with-gcc-major-version-only --with-multilib-list=m32,m64,mx32 --with-target-system-zlib=auto --with-tune=generic --without-cuda-driver -v"
+            },
+            {
+              "path": "ci.data.cpu-microcode",
+              "value": "0x1"
+            },
+            {
+              "path": "ci.data.environment-variables",
+              "value": "BL_DEBUG_TELEMETRY=false"
+            },
+            {
+              "path": "ci.data.kernel-extra-details",
+              "value": "Transparent Huge Pages: madvise"
+            },
+            {
+              "path": "ci.data.security",
+              "value": "gather_data_sampling: Not affected + indirect_target_selection: Mitigation of Aligned branch/return thunks + itlb_multihit: Not affected + l1tf: Not affected + mds: Not affected + meltdown: Not affected + mmio_stale_data: Mitigation of Clear buffers; SMT Host state unknown + reg_file_data_sampling: Not affected + retbleed: Not affected + spec_rstack_overflow: Not affected + spec_store_bypass: Mitigation of SSB disabled via prctl + spectre_v1: Mitigation of usercopy/swapgs barriers and __user pointer sanitization + spectre_v2: Mitigation of Enhanced / Automatic IBRS; IBPB: conditional; PBRSB-eIBRS: SW sequence; BHI: SW loop KVM: SW loop + srbds: Not affected + tsa: Not affected + tsx_async_abort: Mitigation of TSX disabled + vmscape: Not affected"
+            },
+            {
+              "path": "ci.hardware.Disk",
+              "value": "13GB"
+            },
+            {
+              "path": "ci.hardware.Memory",
+              "value": "16GB"
+            },
+            {
+              "path": "ci.hardware.Processor",
+              "value": "Intel Xeon (6 Cores)"
+            },
+            {
+              "path": "ci.identifier",
+              "value": "ci"
+            },
+            {
+              "path": "ci.software.Compiler",
+              "value": "GCC 12.2.0"
+            },
+            {
+              "path": "ci.software.File-System",
+              "value": "overlayfs"
+            },
+            {
+              "path": "ci.software.Kernel",
+              "value": "6.12.75+ (x86_64)"
+            },
+            {
+              "path": "ci.software.OS",
+              "value": "Debian GNU/Linux 12"
+            },
+            {
+              "path": "ci.timestamp",
+              "value": "2026-07-17 01:07:28"
+            },
+            {
+              "path": "ci.user",
+              "value": "root"
+            }
+          ]
+        },
+        {
+          "source": "phoronix/result-file-to-json",
+          "sourceFile": "cpu-generic/pts_compress-zstd--metadata.json",
+          "fields": [
+            {
+              "path": "ci.client_version",
+              "value": "10.8.4"
+            },
+            {
+              "path": "ci.data.compiler-configuration",
+              "value": "--build=x86_64-linux-gnu --disable-vtable-verify --disable-werror --enable-cet --enable-checking=release --enable-clocale=gnu --enable-default-pie --enable-gnu-unique-object --enable-languages=c,ada,c++,go,d,fortran,objc,obj-c++,m2 --enable-libphobos-checking=release --enable-libstdcxx-debug --enable-libstdcxx-time=yes --enable-multiarch --enable-multilib --enable-nls --enable-objc-gc=auto --enable-offload-defaulted --enable-offload-targets=nvptx-none=/build/reproducible-path/gcc-12-12.2.0/debian/tmp-nvptx/usr,amdgcn-amdhsa=/build/reproducible-path/gcc-12-12.2.0/debian/tmp-gcn/usr --enable-plugin --enable-shared --enable-threads=posix --host=x86_64-linux-gnu --program-prefix=x86_64-linux-gnu- --target=x86_64-linux-gnu --with-abi=m64 --with-arch-32=i686 --with-default-libstdcxx-abi=new --with-gcc-major-version-only --with-multilib-list=m32,m64,mx32 --with-target-system-zlib=auto --with-tune=generic --without-cuda-driver -v"
+            },
+            {
+              "path": "ci.data.cpu-microcode",
+              "value": "0x1"
+            },
+            {
+              "path": "ci.data.environment-variables",
+              "value": "BL_DEBUG_TELEMETRY=false"
+            },
+            {
+              "path": "ci.data.kernel-extra-details",
+              "value": "Transparent Huge Pages: madvise"
+            },
+            {
+              "path": "ci.data.security",
+              "value": "gather_data_sampling: Not affected + indirect_target_selection: Mitigation of Aligned branch/return thunks + itlb_multihit: Not affected + l1tf: Not affected + mds: Not affected + meltdown: Not affected + mmio_stale_data: Mitigation of Clear buffers; SMT Host state unknown + reg_file_data_sampling: Not affected + retbleed: Not affected + spec_rstack_overflow: Not affected + spec_store_bypass: Mitigation of SSB disabled via prctl + spectre_v1: Mitigation of usercopy/swapgs barriers and __user pointer sanitization + spectre_v2: Mitigation of Enhanced / Automatic IBRS; IBPB: conditional; PBRSB-eIBRS: SW sequence; BHI: SW loop KVM: SW loop + srbds: Not affected + tsa: Not affected + tsx_async_abort: Mitigation of TSX disabled + vmscape: Not affected"
+            },
+            {
+              "path": "ci.hardware.Disk",
+              "value": "13GB"
+            },
+            {
+              "path": "ci.hardware.Memory",
+              "value": "16GB"
+            },
+            {
+              "path": "ci.hardware.Processor",
+              "value": "Intel Xeon (6 Cores)"
+            },
+            {
+              "path": "ci.identifier",
+              "value": "ci"
+            },
+            {
+              "path": "ci.software.Compiler",
+              "value": "GCC 12.2.0"
+            },
+            {
+              "path": "ci.software.File-System",
+              "value": "overlayfs"
+            },
+            {
+              "path": "ci.software.Kernel",
+              "value": "6.12.75+ (x86_64)"
+            },
+            {
+              "path": "ci.software.OS",
+              "value": "Debian GNU/Linux 12"
+            },
+            {
+              "path": "ci.timestamp",
+              "value": "2026-07-17 02:00:09"
+            },
+            {
+              "path": "ci.user",
+              "value": "root"
+            }
+          ]
+        },
+        {
+          "source": "phoronix/result-file-to-json",
+          "sourceFile": "cpu-node/pts_node-web-tooling--metadata.json",
+          "fields": [
+            {
+              "path": "ci.client_version",
+              "value": "10.8.4"
+            },
+            {
+              "path": "ci.data.cpu-microcode",
+              "value": "0x1"
+            },
+            {
+              "path": "ci.data.environment-variables",
+              "value": "BL_DEBUG_TELEMETRY=false"
+            },
+            {
+              "path": "ci.data.kernel-extra-details",
+              "value": "Transparent Huge Pages: madvise"
+            },
+            {
+              "path": "ci.data.security",
+              "value": "gather_data_sampling: Not affected + indirect_target_selection: Mitigation of Aligned branch/return thunks + itlb_multihit: Not affected + l1tf: Not affected + mds: Not affected + meltdown: Not affected + mmio_stale_data: Mitigation of Clear buffers; SMT Host state unknown + reg_file_data_sampling: Not affected + retbleed: Not affected + spec_rstack_overflow: Not affected + spec_store_bypass: Mitigation of SSB disabled via prctl + spectre_v1: Mitigation of usercopy/swapgs barriers and __user pointer sanitization + spectre_v2: Mitigation of Enhanced / Automatic IBRS; IBPB: conditional; PBRSB-eIBRS: SW sequence; BHI: SW loop KVM: SW loop + srbds: Not affected + tsa: Not affected + tsx_async_abort: Mitigation of TSX disabled + vmscape: Not affected"
+            },
+            {
+              "path": "ci.hardware.Disk",
+              "value": "13GB"
+            },
+            {
+              "path": "ci.hardware.Memory",
+              "value": "16GB"
+            },
+            {
+              "path": "ci.hardware.Processor",
+              "value": "Intel Xeon (6 Cores)"
+            },
+            {
+              "path": "ci.identifier",
+              "value": "ci"
+            },
+            {
+              "path": "ci.software.Compiler",
+              "value": "GCC 12.2.0"
+            },
+            {
+              "path": "ci.software.File-System",
+              "value": "overlayfs"
+            },
+            {
+              "path": "ci.software.Kernel",
+              "value": "6.12.75+ (x86_64)"
+            },
+            {
+              "path": "ci.software.OS",
+              "value": "Debian GNU/Linux 12"
+            },
+            {
+              "path": "ci.timestamp",
+              "value": "2026-07-17 01:08:01"
+            },
+            {
+              "path": "ci.user",
+              "value": "root"
+            }
+          ]
+        },
+        {
+          "source": "phoronix/result-file-to-json",
+          "sourceFile": "disk/pts_fio-rand-read--metadata.json",
+          "fields": [
+            {
+              "path": "ci.client_version",
+              "value": "10.8.4"
+            },
+            {
+              "path": "ci.data.compiler-configuration",
+              "value": "--build=x86_64-linux-gnu --disable-vtable-verify --disable-werror --enable-cet --enable-checking=release --enable-clocale=gnu --enable-default-pie --enable-gnu-unique-object --enable-languages=c,ada,c++,go,d,fortran,objc,obj-c++,m2 --enable-libphobos-checking=release --enable-libstdcxx-debug --enable-libstdcxx-time=yes --enable-multiarch --enable-multilib --enable-nls --enable-objc-gc=auto --enable-offload-defaulted --enable-offload-targets=nvptx-none=/build/reproducible-path/gcc-12-12.2.0/debian/tmp-nvptx/usr,amdgcn-amdhsa=/build/reproducible-path/gcc-12-12.2.0/debian/tmp-gcn/usr --enable-plugin --enable-shared --enable-threads=posix --host=x86_64-linux-gnu --program-prefix=x86_64-linux-gnu- --target=x86_64-linux-gnu --with-abi=m64 --with-arch-32=i686 --with-default-libstdcxx-abi=new --with-gcc-major-version-only --with-multilib-list=m32,m64,mx32 --with-target-system-zlib=auto --with-tune=generic --without-cuda-driver -v"
+            },
+            {
+              "path": "ci.data.cpu-microcode",
+              "value": "0x1"
+            },
+            {
+              "path": "ci.data.environment-variables",
+              "value": "BL_DEBUG_TELEMETRY=false"
+            },
+            {
+              "path": "ci.data.kernel-extra-details",
+              "value": "Transparent Huge Pages: madvise"
+            },
+            {
+              "path": "ci.data.security",
+              "value": "gather_data_sampling: Not affected + indirect_target_selection: Mitigation of Aligned branch/return thunks + itlb_multihit: Not affected + l1tf: Not affected + mds: Not affected + meltdown: Not affected + mmio_stale_data: Mitigation of Clear buffers; SMT Host state unknown + reg_file_data_sampling: Not affected + retbleed: Not affected + spec_rstack_overflow: Not affected + spec_store_bypass: Mitigation of SSB disabled via prctl + spectre_v1: Mitigation of usercopy/swapgs barriers and __user pointer sanitization + spectre_v2: Mitigation of Enhanced / Automatic IBRS; IBPB: conditional; PBRSB-eIBRS: SW sequence; BHI: SW loop KVM: SW loop + srbds: Not affected + tsa: Not affected + tsx_async_abort: Mitigation of TSX disabled + vmscape: Not affected"
+            },
+            {
+              "path": "ci.hardware.Disk",
+              "value": "13GB"
+            },
+            {
+              "path": "ci.hardware.Memory",
+              "value": "16GB"
+            },
+            {
+              "path": "ci.hardware.Processor",
+              "value": "Intel Xeon (6 Cores)"
+            },
+            {
+              "path": "ci.identifier",
+              "value": "ci"
+            },
+            {
+              "path": "ci.software.Compiler",
+              "value": "GCC 12.2.0"
+            },
+            {
+              "path": "ci.software.File-System",
+              "value": "overlayfs"
+            },
+            {
+              "path": "ci.software.Kernel",
+              "value": "6.12.75+ (x86_64)"
+            },
+            {
+              "path": "ci.software.OS",
+              "value": "Debian GNU/Linux 12"
+            },
+            {
+              "path": "ci.timestamp",
+              "value": "2026-07-17 01:14:00"
+            },
+            {
+              "path": "ci.user",
+              "value": "root"
+            }
+          ]
+        },
+        {
+          "source": "phoronix/result-file-to-json",
+          "sourceFile": "disk/pts_fio-rand-write--metadata.json",
+          "fields": [
+            {
+              "path": "ci.client_version",
+              "value": "10.8.4"
+            },
+            {
+              "path": "ci.data.compiler-configuration",
+              "value": "--build=x86_64-linux-gnu --disable-vtable-verify --disable-werror --enable-cet --enable-checking=release --enable-clocale=gnu --enable-default-pie --enable-gnu-unique-object --enable-languages=c,ada,c++,go,d,fortran,objc,obj-c++,m2 --enable-libphobos-checking=release --enable-libstdcxx-debug --enable-libstdcxx-time=yes --enable-multiarch --enable-multilib --enable-nls --enable-objc-gc=auto --enable-offload-defaulted --enable-offload-targets=nvptx-none=/build/reproducible-path/gcc-12-12.2.0/debian/tmp-nvptx/usr,amdgcn-amdhsa=/build/reproducible-path/gcc-12-12.2.0/debian/tmp-gcn/usr --enable-plugin --enable-shared --enable-threads=posix --host=x86_64-linux-gnu --program-prefix=x86_64-linux-gnu- --target=x86_64-linux-gnu --with-abi=m64 --with-arch-32=i686 --with-default-libstdcxx-abi=new --with-gcc-major-version-only --with-multilib-list=m32,m64,mx32 --with-target-system-zlib=auto --with-tune=generic --without-cuda-driver -v"
+            },
+            {
+              "path": "ci.data.cpu-microcode",
+              "value": "0x1"
+            },
+            {
+              "path": "ci.data.environment-variables",
+              "value": "BL_DEBUG_TELEMETRY=false"
+            },
+            {
+              "path": "ci.data.kernel-extra-details",
+              "value": "Transparent Huge Pages: madvise"
+            },
+            {
+              "path": "ci.data.security",
+              "value": "gather_data_sampling: Not affected + indirect_target_selection: Mitigation of Aligned branch/return thunks + itlb_multihit: Not affected + l1tf: Not affected + mds: Not affected + meltdown: Not affected + mmio_stale_data: Mitigation of Clear buffers; SMT Host state unknown + reg_file_data_sampling: Not affected + retbleed: Not affected + spec_rstack_overflow: Not affected + spec_store_bypass: Mitigation of SSB disabled via prctl + spectre_v1: Mitigation of usercopy/swapgs barriers and __user pointer sanitization + spectre_v2: Mitigation of Enhanced / Automatic IBRS; IBPB: conditional; PBRSB-eIBRS: SW sequence; BHI: SW loop KVM: SW loop + srbds: Not affected + tsa: Not affected + tsx_async_abort: Mitigation of TSX disabled + vmscape: Not affected"
+            },
+            {
+              "path": "ci.hardware.Disk",
+              "value": "13GB"
+            },
+            {
+              "path": "ci.hardware.Memory",
+              "value": "16GB"
+            },
+            {
+              "path": "ci.hardware.Processor",
+              "value": "Intel Xeon (6 Cores)"
+            },
+            {
+              "path": "ci.identifier",
+              "value": "ci"
+            },
+            {
+              "path": "ci.software.Compiler",
+              "value": "GCC 12.2.0"
+            },
+            {
+              "path": "ci.software.File-System",
+              "value": "overlayfs"
+            },
+            {
+              "path": "ci.software.Kernel",
+              "value": "6.12.75+ (x86_64)"
+            },
+            {
+              "path": "ci.software.OS",
+              "value": "Debian GNU/Linux 12"
+            },
+            {
+              "path": "ci.timestamp",
+              "value": "2026-07-17 01:17:10"
+            },
+            {
+              "path": "ci.user",
+              "value": "root"
+            }
+          ]
+        },
+        {
+          "source": "phoronix/result-file-to-json",
+          "sourceFile": "disk/pts_fio-seq-read--metadata.json",
+          "fields": [
+            {
+              "path": "ci.client_version",
+              "value": "10.8.4"
+            },
+            {
+              "path": "ci.data.compiler-configuration",
+              "value": "--build=x86_64-linux-gnu --disable-vtable-verify --disable-werror --enable-cet --enable-checking=release --enable-clocale=gnu --enable-default-pie --enable-gnu-unique-object --enable-languages=c,ada,c++,go,d,fortran,objc,obj-c++,m2 --enable-libphobos-checking=release --enable-libstdcxx-debug --enable-libstdcxx-time=yes --enable-multiarch --enable-multilib --enable-nls --enable-objc-gc=auto --enable-offload-defaulted --enable-offload-targets=nvptx-none=/build/reproducible-path/gcc-12-12.2.0/debian/tmp-nvptx/usr,amdgcn-amdhsa=/build/reproducible-path/gcc-12-12.2.0/debian/tmp-gcn/usr --enable-plugin --enable-shared --enable-threads=posix --host=x86_64-linux-gnu --program-prefix=x86_64-linux-gnu- --target=x86_64-linux-gnu --with-abi=m64 --with-arch-32=i686 --with-default-libstdcxx-abi=new --with-gcc-major-version-only --with-multilib-list=m32,m64,mx32 --with-target-system-zlib=auto --with-tune=generic --without-cuda-driver -v"
+            },
+            {
+              "path": "ci.data.cpu-microcode",
+              "value": "0x1"
+            },
+            {
+              "path": "ci.data.environment-variables",
+              "value": "BL_DEBUG_TELEMETRY=false"
+            },
+            {
+              "path": "ci.data.kernel-extra-details",
+              "value": "Transparent Huge Pages: madvise"
+            },
+            {
+              "path": "ci.data.security",
+              "value": "gather_data_sampling: Not affected + indirect_target_selection: Mitigation of Aligned branch/return thunks + itlb_multihit: Not affected + l1tf: Not affected + mds: Not affected + meltdown: Not affected + mmio_stale_data: Mitigation of Clear buffers; SMT Host state unknown + reg_file_data_sampling: Not affected + retbleed: Not affected + spec_rstack_overflow: Not affected + spec_store_bypass: Mitigation of SSB disabled via prctl + spectre_v1: Mitigation of usercopy/swapgs barriers and __user pointer sanitization + spectre_v2: Mitigation of Enhanced / Automatic IBRS; IBPB: conditional; PBRSB-eIBRS: SW sequence; BHI: SW loop KVM: SW loop + srbds: Not affected + tsa: Not affected + tsx_async_abort: Mitigation of TSX disabled + vmscape: Not affected"
+            },
+            {
+              "path": "ci.hardware.Disk",
+              "value": "13GB"
+            },
+            {
+              "path": "ci.hardware.Memory",
+              "value": "16GB"
+            },
+            {
+              "path": "ci.hardware.Processor",
+              "value": "Intel Xeon (6 Cores)"
+            },
+            {
+              "path": "ci.identifier",
+              "value": "ci"
+            },
+            {
+              "path": "ci.software.Compiler",
+              "value": "GCC 12.2.0"
+            },
+            {
+              "path": "ci.software.File-System",
+              "value": "overlayfs"
+            },
+            {
+              "path": "ci.software.Kernel",
+              "value": "6.12.75+ (x86_64)"
+            },
+            {
+              "path": "ci.software.OS",
+              "value": "Debian GNU/Linux 12"
+            },
+            {
+              "path": "ci.timestamp",
+              "value": "2026-07-17 01:07:40"
+            },
+            {
+              "path": "ci.user",
+              "value": "root"
+            }
+          ]
+        },
+        {
+          "source": "phoronix/result-file-to-json",
+          "sourceFile": "disk/pts_fio-seq-write--metadata.json",
+          "fields": [
+            {
+              "path": "ci.client_version",
+              "value": "10.8.4"
+            },
+            {
+              "path": "ci.data.compiler-configuration",
+              "value": "--build=x86_64-linux-gnu --disable-vtable-verify --disable-werror --enable-cet --enable-checking=release --enable-clocale=gnu --enable-default-pie --enable-gnu-unique-object --enable-languages=c,ada,c++,go,d,fortran,objc,obj-c++,m2 --enable-libphobos-checking=release --enable-libstdcxx-debug --enable-libstdcxx-time=yes --enable-multiarch --enable-multilib --enable-nls --enable-objc-gc=auto --enable-offload-defaulted --enable-offload-targets=nvptx-none=/build/reproducible-path/gcc-12-12.2.0/debian/tmp-nvptx/usr,amdgcn-amdhsa=/build/reproducible-path/gcc-12-12.2.0/debian/tmp-gcn/usr --enable-plugin --enable-shared --enable-threads=posix --host=x86_64-linux-gnu --program-prefix=x86_64-linux-gnu- --target=x86_64-linux-gnu --with-abi=m64 --with-arch-32=i686 --with-default-libstdcxx-abi=new --with-gcc-major-version-only --with-multilib-list=m32,m64,mx32 --with-target-system-zlib=auto --with-tune=generic --without-cuda-driver -v"
+            },
+            {
+              "path": "ci.data.cpu-microcode",
+              "value": "0x1"
+            },
+            {
+              "path": "ci.data.environment-variables",
+              "value": "BL_DEBUG_TELEMETRY=false"
+            },
+            {
+              "path": "ci.data.kernel-extra-details",
+              "value": "Transparent Huge Pages: madvise"
+            },
+            {
+              "path": "ci.data.security",
+              "value": "gather_data_sampling: Not affected + indirect_target_selection: Mitigation of Aligned branch/return thunks + itlb_multihit: Not affected + l1tf: Not affected + mds: Not affected + meltdown: Not affected + mmio_stale_data: Mitigation of Clear buffers; SMT Host state unknown + reg_file_data_sampling: Not affected + retbleed: Not affected + spec_rstack_overflow: Not affected + spec_store_bypass: Mitigation of SSB disabled via prctl + spectre_v1: Mitigation of usercopy/swapgs barriers and __user pointer sanitization + spectre_v2: Mitigation of Enhanced / Automatic IBRS; IBPB: conditional; PBRSB-eIBRS: SW sequence; BHI: SW loop KVM: SW loop + srbds: Not affected + tsa: Not affected + tsx_async_abort: Mitigation of TSX disabled + vmscape: Not affected"
+            },
+            {
+              "path": "ci.hardware.Disk",
+              "value": "13GB"
+            },
+            {
+              "path": "ci.hardware.Memory",
+              "value": "16GB"
+            },
+            {
+              "path": "ci.hardware.Processor",
+              "value": "Intel Xeon (6 Cores)"
+            },
+            {
+              "path": "ci.identifier",
+              "value": "ci"
+            },
+            {
+              "path": "ci.software.Compiler",
+              "value": "GCC 12.2.0"
+            },
+            {
+              "path": "ci.software.File-System",
+              "value": "overlayfs"
+            },
+            {
+              "path": "ci.software.Kernel",
+              "value": "6.12.75+ (x86_64)"
+            },
+            {
+              "path": "ci.software.OS",
+              "value": "Debian GNU/Linux 12"
+            },
+            {
+              "path": "ci.timestamp",
+              "value": "2026-07-17 01:10:50"
+            },
+            {
+              "path": "ci.user",
+              "value": "root"
+            }
+          ]
+        },
+        {
+          "source": "phoronix/result-file-to-json",
+          "sourceFile": "disk/pts_hardlink--metadata.json",
+          "fields": [
+            {
+              "path": "ci.client_version",
+              "value": "10.8.4"
+            },
+            {
+              "path": "ci.data.compiler-configuration",
+              "value": "--build=x86_64-linux-gnu --disable-vtable-verify --disable-werror --enable-cet --enable-checking=release --enable-clocale=gnu --enable-default-pie --enable-gnu-unique-object --enable-languages=c,ada,c++,go,d,fortran,objc,obj-c++,m2 --enable-libphobos-checking=release --enable-libstdcxx-debug --enable-libstdcxx-time=yes --enable-multiarch --enable-multilib --enable-nls --enable-objc-gc=auto --enable-offload-defaulted --enable-offload-targets=nvptx-none=/build/reproducible-path/gcc-12-12.2.0/debian/tmp-nvptx/usr,amdgcn-amdhsa=/build/reproducible-path/gcc-12-12.2.0/debian/tmp-gcn/usr --enable-plugin --enable-shared --enable-threads=posix --host=x86_64-linux-gnu --program-prefix=x86_64-linux-gnu- --target=x86_64-linux-gnu --with-abi=m64 --with-arch-32=i686 --with-default-libstdcxx-abi=new --with-gcc-major-version-only --with-multilib-list=m32,m64,mx32 --with-target-system-zlib=auto --with-tune=generic --without-cuda-driver -v"
+            },
+            {
+              "path": "ci.data.cpu-microcode",
+              "value": "0x1"
+            },
+            {
+              "path": "ci.data.environment-variables",
+              "value": "BL_DEBUG_TELEMETRY=false"
+            },
+            {
+              "path": "ci.data.kernel-extra-details",
+              "value": "Transparent Huge Pages: madvise"
+            },
+            {
+              "path": "ci.data.security",
+              "value": "gather_data_sampling: Not affected + indirect_target_selection: Mitigation of Aligned branch/return thunks + itlb_multihit: Not affected + l1tf: Not affected + mds: Not affected + meltdown: Not affected + mmio_stale_data: Mitigation of Clear buffers; SMT Host state unknown + reg_file_data_sampling: Not affected + retbleed: Not affected + spec_rstack_overflow: Not affected + spec_store_bypass: Mitigation of SSB disabled via prctl + spectre_v1: Mitigation of usercopy/swapgs barriers and __user pointer sanitization + spectre_v2: Mitigation of Enhanced / Automatic IBRS; IBPB: conditional; PBRSB-eIBRS: SW sequence; BHI: SW loop KVM: SW loop + srbds: Not affected + tsa: Not affected + tsx_async_abort: Mitigation of TSX disabled + vmscape: Not affected"
+            },
+            {
+              "path": "ci.hardware.Disk",
+              "value": "13GB"
+            },
+            {
+              "path": "ci.hardware.Memory",
+              "value": "16GB"
+            },
+            {
+              "path": "ci.hardware.Processor",
+              "value": "Intel Xeon (6 Cores)"
+            },
+            {
+              "path": "ci.identifier",
+              "value": "ci"
+            },
+            {
+              "path": "ci.software.Compiler",
+              "value": "GCC 12.2.0"
+            },
+            {
+              "path": "ci.software.File-System",
+              "value": "overlayfs"
+            },
+            {
+              "path": "ci.software.Kernel",
+              "value": "6.12.75+ (x86_64)"
+            },
+            {
+              "path": "ci.software.OS",
+              "value": "Debian GNU/Linux 12"
+            },
+            {
+              "path": "ci.timestamp",
+              "value": "2026-07-17 01:20:20"
+            },
+            {
+              "path": "ci.user",
+              "value": "root"
+            }
+          ]
+        },
+        {
+          "source": "phoronix/result-file-to-json",
+          "sourceFile": "memory/pts_stream--metadata.json",
+          "fields": [
+            {
+              "path": "ci.client_version",
+              "value": "10.8.4"
+            },
+            {
+              "path": "ci.data.compiler-configuration",
+              "value": "--build=x86_64-linux-gnu --disable-vtable-verify --disable-werror --enable-cet --enable-checking=release --enable-clocale=gnu --enable-default-pie --enable-gnu-unique-object --enable-languages=c,ada,c++,go,d,fortran,objc,obj-c++,m2 --enable-libphobos-checking=release --enable-libstdcxx-debug --enable-libstdcxx-time=yes --enable-multiarch --enable-multilib --enable-nls --enable-objc-gc=auto --enable-offload-defaulted --enable-offload-targets=nvptx-none=/build/reproducible-path/gcc-12-12.2.0/debian/tmp-nvptx/usr,amdgcn-amdhsa=/build/reproducible-path/gcc-12-12.2.0/debian/tmp-gcn/usr --enable-plugin --enable-shared --enable-threads=posix --host=x86_64-linux-gnu --program-prefix=x86_64-linux-gnu- --target=x86_64-linux-gnu --with-abi=m64 --with-arch-32=i686 --with-default-libstdcxx-abi=new --with-gcc-major-version-only --with-multilib-list=m32,m64,mx32 --with-target-system-zlib=auto --with-tune=generic --without-cuda-driver -v"
+            },
+            {
+              "path": "ci.data.cpu-microcode",
+              "value": "0x1"
+            },
+            {
+              "path": "ci.data.environment-variables",
+              "value": "CFLAGS_OVERRIDE=\"-O3 -march=native -DSTREAM_ARRAY_SIZE=150000000\" BL_DEBUG_TELEMETRY=false"
+            },
+            {
+              "path": "ci.data.kernel-extra-details",
+              "value": "Transparent Huge Pages: madvise"
+            },
+            {
+              "path": "ci.data.security",
+              "value": "gather_data_sampling: Not affected + indirect_target_selection: Mitigation of Aligned branch/return thunks + itlb_multihit: Not affected + l1tf: Not affected + mds: Not affected + meltdown: Not affected + mmio_stale_data: Mitigation of Clear buffers; SMT Host state unknown + reg_file_data_sampling: Not affected + retbleed: Not affected + spec_rstack_overflow: Not affected + spec_store_bypass: Mitigation of SSB disabled via prctl + spectre_v1: Mitigation of usercopy/swapgs barriers and __user pointer sanitization + spectre_v2: Mitigation of Enhanced / Automatic IBRS; IBPB: conditional; PBRSB-eIBRS: SW sequence; BHI: SW loop KVM: SW loop + srbds: Not affected + tsa: Not affected + tsx_async_abort: Mitigation of TSX disabled + vmscape: Not affected"
+            },
+            {
+              "path": "ci.hardware.Disk",
+              "value": "13GB"
+            },
+            {
+              "path": "ci.hardware.Memory",
+              "value": "16GB"
+            },
+            {
+              "path": "ci.hardware.Processor",
+              "value": "Intel Xeon (6 Cores)"
+            },
+            {
+              "path": "ci.identifier",
+              "value": "ci"
+            },
+            {
+              "path": "ci.software.Compiler",
+              "value": "GCC 12.2.0"
+            },
+            {
+              "path": "ci.software.File-System",
+              "value": "overlayfs"
+            },
+            {
+              "path": "ci.software.Kernel",
+              "value": "6.12.75+ (x86_64)"
+            },
+            {
+              "path": "ci.software.OS",
+              "value": "Debian GNU/Linux 12"
+            },
+            {
+              "path": "ci.timestamp",
+              "value": "2026-07-17 01:07:29"
+            },
+            {
+              "path": "ci.user",
+              "value": "root"
+            }
+          ]
+        },
+        {
+          "source": "phoronix/result-file-to-json",
+          "sourceFile": "network/pts_fast-cli--metadata.json",
+          "fields": [
+            {
+              "path": "ci.client_version",
+              "value": "10.8.4"
+            },
+            {
+              "path": "ci.data.cpu-microcode",
+              "value": "0x1"
+            },
+            {
+              "path": "ci.data.environment-variables",
+              "value": "BL_DEBUG_TELEMETRY=false"
+            },
+            {
+              "path": "ci.data.kernel-extra-details",
+              "value": "Transparent Huge Pages: madvise"
+            },
+            {
+              "path": "ci.data.security",
+              "value": "gather_data_sampling: Not affected + indirect_target_selection: Mitigation of Aligned branch/return thunks + itlb_multihit: Not affected + l1tf: Not affected + mds: Not affected + meltdown: Not affected + mmio_stale_data: Mitigation of Clear buffers; SMT Host state unknown + reg_file_data_sampling: Not affected + retbleed: Not affected + spec_rstack_overflow: Not affected + spec_store_bypass: Mitigation of SSB disabled via prctl + spectre_v1: Mitigation of usercopy/swapgs barriers and __user pointer sanitization + spectre_v2: Mitigation of Enhanced / Automatic IBRS; IBPB: conditional; PBRSB-eIBRS: SW sequence; BHI: SW loop KVM: SW loop + srbds: Not affected + tsa: Not affected + tsx_async_abort: Mitigation of TSX disabled + vmscape: Not affected"
+            },
+            {
+              "path": "ci.hardware.Disk",
+              "value": "13GB"
+            },
+            {
+              "path": "ci.hardware.Memory",
+              "value": "16GB"
+            },
+            {
+              "path": "ci.hardware.Processor",
+              "value": "Intel Xeon (6 Cores)"
+            },
+            {
+              "path": "ci.identifier",
+              "value": "ci"
+            },
+            {
+              "path": "ci.software.Compiler",
+              "value": "GCC 12.2.0"
+            },
+            {
+              "path": "ci.software.File-System",
+              "value": "overlayfs"
+            },
+            {
+              "path": "ci.software.Kernel",
+              "value": "6.12.75+ (x86_64)"
+            },
+            {
+              "path": "ci.software.OS",
+              "value": "Debian GNU/Linux 12"
+            },
+            {
+              "path": "ci.timestamp",
+              "value": "2026-07-17 01:08:16"
+            },
+            {
+              "path": "ci.user",
+              "value": "root"
+            }
+          ]
+        },
+        {
+          "source": "phoronix/result-file-to-json",
+          "sourceFile": "network/pts_network-loopback--metadata.json",
+          "fields": [
+            {
+              "path": "ci.client_version",
+              "value": "10.8.4"
+            },
+            {
+              "path": "ci.data.cpu-microcode",
+              "value": "0x1"
+            },
+            {
+              "path": "ci.data.environment-variables",
+              "value": "BL_DEBUG_TELEMETRY=false"
+            },
+            {
+              "path": "ci.data.kernel-extra-details",
+              "value": "Transparent Huge Pages: madvise"
+            },
+            {
+              "path": "ci.data.security",
+              "value": "gather_data_sampling: Not affected + indirect_target_selection: Mitigation of Aligned branch/return thunks + itlb_multihit: Not affected + l1tf: Not affected + mds: Not affected + meltdown: Not affected + mmio_stale_data: Mitigation of Clear buffers; SMT Host state unknown + reg_file_data_sampling: Not affected + retbleed: Not affected + spec_rstack_overflow: Not affected + spec_store_bypass: Mitigation of SSB disabled via prctl + spectre_v1: Mitigation of usercopy/swapgs barriers and __user pointer sanitization + spectre_v2: Mitigation of Enhanced / Automatic IBRS; IBPB: conditional; PBRSB-eIBRS: SW sequence; BHI: SW loop KVM: SW loop + srbds: Not affected + tsa: Not affected + tsx_async_abort: Mitigation of TSX disabled + vmscape: Not affected"
+            },
+            {
+              "path": "ci.hardware.Disk",
+              "value": "13GB"
+            },
+            {
+              "path": "ci.hardware.Memory",
+              "value": "16GB"
+            },
+            {
+              "path": "ci.hardware.Processor",
+              "value": "Intel Xeon (6 Cores)"
+            },
+            {
+              "path": "ci.identifier",
+              "value": "ci"
+            },
+            {
+              "path": "ci.software.Compiler",
+              "value": "GCC 12.2.0"
+            },
+            {
+              "path": "ci.software.File-System",
+              "value": "overlayfs"
+            },
+            {
+              "path": "ci.software.Kernel",
+              "value": "6.12.75+ (x86_64)"
+            },
+            {
+              "path": "ci.software.OS",
+              "value": "Debian GNU/Linux 12"
+            },
+            {
+              "path": "ci.timestamp",
+              "value": "2026-07-17 01:07:32"
+            },
+            {
+              "path": "ci.user",
+              "value": "root"
+            }
+          ]
+        },
+        {
+          "source": "phoronix/result-file-to-json",
+          "sourceFile": "realworld-better-auth/pts_realworld-better-auth--metadata.json",
+          "fields": [
+            {
+              "path": "ci.client_version",
+              "value": "10.8.4"
+            },
+            {
+              "path": "ci.data.cpu-microcode",
+              "value": "0x1"
+            },
+            {
+              "path": "ci.data.environment-variables",
+              "value": "BL_DEBUG_TELEMETRY=false"
+            },
+            {
+              "path": "ci.data.kernel-extra-details",
+              "value": "Transparent Huge Pages: madvise"
+            },
+            {
+              "path": "ci.data.security",
+              "value": "gather_data_sampling: Not affected + indirect_target_selection: Mitigation of Aligned branch/return thunks + itlb_multihit: Not affected + l1tf: Not affected + mds: Not affected + meltdown: Not affected + mmio_stale_data: Mitigation of Clear buffers; SMT Host state unknown + reg_file_data_sampling: Not affected + retbleed: Not affected + spec_rstack_overflow: Not affected + spec_store_bypass: Mitigation of SSB disabled via prctl + spectre_v1: Mitigation of usercopy/swapgs barriers and __user pointer sanitization + spectre_v2: Mitigation of Enhanced / Automatic IBRS; IBPB: conditional; PBRSB-eIBRS: SW sequence; BHI: SW loop KVM: SW loop + srbds: Not affected + tsa: Not affected + tsx_async_abort: Mitigation of TSX disabled + vmscape: Not affected"
+            },
+            {
+              "path": "ci.hardware.Disk",
+              "value": "13GB"
+            },
+            {
+              "path": "ci.hardware.Memory",
+              "value": "16GB"
+            },
+            {
+              "path": "ci.hardware.Processor",
+              "value": "Intel Xeon (6 Cores)"
+            },
+            {
+              "path": "ci.identifier",
+              "value": "ci"
+            },
+            {
+              "path": "ci.software.Compiler",
+              "value": "GCC 12.2.0"
+            },
+            {
+              "path": "ci.software.File-System",
+              "value": "overlayfs"
+            },
+            {
+              "path": "ci.software.Kernel",
+              "value": "6.12.75+ (x86_64)"
+            },
+            {
+              "path": "ci.software.OS",
+              "value": "Debian GNU/Linux 12"
+            },
+            {
+              "path": "ci.timestamp",
+              "value": "2026-07-17 01:07:45"
+            },
+            {
+              "path": "ci.user",
+              "value": "root"
+            }
+          ]
+        },
+        {
+          "source": "phoronix/result-file-to-json",
+          "sourceFile": "system/pts_git--metadata.json",
+          "fields": [
+            {
+              "path": "ci.client_version",
+              "value": "10.8.4"
+            },
+            {
+              "path": "ci.data.cpu-microcode",
+              "value": "0x1"
+            },
+            {
+              "path": "ci.data.environment-variables",
+              "value": "BL_DEBUG_TELEMETRY=false"
+            },
+            {
+              "path": "ci.data.kernel-extra-details",
+              "value": "Transparent Huge Pages: madvise"
+            },
+            {
+              "path": "ci.data.security",
+              "value": "gather_data_sampling: Not affected + indirect_target_selection: Mitigation of Aligned branch/return thunks + itlb_multihit: Not affected + l1tf: Not affected + mds: Not affected + meltdown: Not affected + mmio_stale_data: Mitigation of Clear buffers; SMT Host state unknown + reg_file_data_sampling: Not affected + retbleed: Not affected + spec_rstack_overflow: Not affected + spec_store_bypass: Mitigation of SSB disabled via prctl + spectre_v1: Mitigation of usercopy/swapgs barriers and __user pointer sanitization + spectre_v2: Mitigation of Enhanced / Automatic IBRS; IBPB: conditional; PBRSB-eIBRS: SW sequence; BHI: SW loop KVM: SW loop + srbds: Not affected + tsa: Not affected + tsx_async_abort: Mitigation of TSX disabled + vmscape: Not affected"
+            },
+            {
+              "path": "ci.hardware.Disk",
+              "value": "13GB"
+            },
+            {
+              "path": "ci.hardware.Memory",
+              "value": "16GB"
+            },
+            {
+              "path": "ci.hardware.Processor",
+              "value": "Intel Xeon (6 Cores)"
+            },
+            {
+              "path": "ci.identifier",
+              "value": "ci"
+            },
+            {
+              "path": "ci.software.Compiler",
+              "value": "GCC 12.2.0"
+            },
+            {
+              "path": "ci.software.File-System",
+              "value": "overlayfs"
+            },
+            {
+              "path": "ci.software.Kernel",
+              "value": "6.12.75+ (x86_64)"
+            },
+            {
+              "path": "ci.software.OS",
+              "value": "Debian GNU/Linux 12"
+            },
+            {
+              "path": "ci.timestamp",
+              "value": "2026-07-17 01:13:45"
+            },
+            {
+              "path": "ci.user",
+              "value": "root"
+            }
+          ]
+        },
+        {
+          "source": "phoronix/result-file-to-json",
+          "sourceFile": "system/pts_pgbench-read-only--metadata.json",
+          "fields": [
+            {
+              "path": "ci.client_version",
+              "value": "10.8.4"
+            },
+            {
+              "path": "ci.data.compiler-configuration",
+              "value": "--build=x86_64-linux-gnu --disable-vtable-verify --disable-werror --enable-cet --enable-checking=release --enable-clocale=gnu --enable-default-pie --enable-gnu-unique-object --enable-languages=c,ada,c++,go,d,fortran,objc,obj-c++,m2 --enable-libphobos-checking=release --enable-libstdcxx-debug --enable-libstdcxx-time=yes --enable-multiarch --enable-multilib --enable-nls --enable-objc-gc=auto --enable-offload-defaulted --enable-offload-targets=nvptx-none=/build/reproducible-path/gcc-12-12.2.0/debian/tmp-nvptx/usr,amdgcn-amdhsa=/build/reproducible-path/gcc-12-12.2.0/debian/tmp-gcn/usr --enable-plugin --enable-shared --enable-threads=posix --host=x86_64-linux-gnu --program-prefix=x86_64-linux-gnu- --target=x86_64-linux-gnu --with-abi=m64 --with-arch-32=i686 --with-default-libstdcxx-abi=new --with-gcc-major-version-only --with-multilib-list=m32,m64,mx32 --with-target-system-zlib=auto --with-tune=generic --without-cuda-driver -v"
+            },
+            {
+              "path": "ci.data.cpu-microcode",
+              "value": "0x1"
+            },
+            {
+              "path": "ci.data.environment-variables",
+              "value": "BL_DEBUG_TELEMETRY=false"
+            },
+            {
+              "path": "ci.data.kernel-extra-details",
+              "value": "Transparent Huge Pages: madvise"
+            },
+            {
+              "path": "ci.data.security",
+              "value": "gather_data_sampling: Not affected + indirect_target_selection: Mitigation of Aligned branch/return thunks + itlb_multihit: Not affected + l1tf: Not affected + mds: Not affected + meltdown: Not affected + mmio_stale_data: Mitigation of Clear buffers; SMT Host state unknown + reg_file_data_sampling: Not affected + retbleed: Not affected + spec_rstack_overflow: Not affected + spec_store_bypass: Mitigation of SSB disabled via prctl + spectre_v1: Mitigation of usercopy/swapgs barriers and __user pointer sanitization + spectre_v2: Mitigation of Enhanced / Automatic IBRS; IBPB: conditional; PBRSB-eIBRS: SW sequence; BHI: SW loop KVM: SW loop + srbds: Not affected + tsa: Not affected + tsx_async_abort: Mitigation of TSX disabled + vmscape: Not affected"
+            },
+            {
+              "path": "ci.hardware.Disk",
+              "value": "13GB"
+            },
+            {
+              "path": "ci.hardware.Memory",
+              "value": "16GB"
+            },
+            {
+              "path": "ci.hardware.Processor",
+              "value": "Intel Xeon (6 Cores)"
+            },
+            {
+              "path": "ci.identifier",
+              "value": "ci"
+            },
+            {
+              "path": "ci.software.Compiler",
+              "value": "GCC 12.2.0"
+            },
+            {
+              "path": "ci.software.File-System",
+              "value": "overlayfs"
+            },
+            {
+              "path": "ci.software.Kernel",
+              "value": "6.12.75+ (x86_64)"
+            },
+            {
+              "path": "ci.software.OS",
+              "value": "Debian GNU/Linux 12"
+            },
+            {
+              "path": "ci.timestamp",
+              "value": "2026-07-17 01:11:52"
+            },
+            {
+              "path": "ci.user",
+              "value": "root"
+            }
+          ]
+        },
+        {
+          "source": "phoronix/result-file-to-json",
+          "sourceFile": "system/pts_pgbench-read-write--metadata.json",
+          "fields": [
+            {
+              "path": "ci.client_version",
+              "value": "10.8.4"
+            },
+            {
+              "path": "ci.data.compiler-configuration",
+              "value": "--build=x86_64-linux-gnu --disable-vtable-verify --disable-werror --enable-cet --enable-checking=release --enable-clocale=gnu --enable-default-pie --enable-gnu-unique-object --enable-languages=c,ada,c++,go,d,fortran,objc,obj-c++,m2 --enable-libphobos-checking=release --enable-libstdcxx-debug --enable-libstdcxx-time=yes --enable-multiarch --enable-multilib --enable-nls --enable-objc-gc=auto --enable-offload-defaulted --enable-offload-targets=nvptx-none=/build/reproducible-path/gcc-12-12.2.0/debian/tmp-nvptx/usr,amdgcn-amdhsa=/build/reproducible-path/gcc-12-12.2.0/debian/tmp-gcn/usr --enable-plugin --enable-shared --enable-threads=posix --host=x86_64-linux-gnu --program-prefix=x86_64-linux-gnu- --target=x86_64-linux-gnu --with-abi=m64 --with-arch-32=i686 --with-default-libstdcxx-abi=new --with-gcc-major-version-only --with-multilib-list=m32,m64,mx32 --with-target-system-zlib=auto --with-tune=generic --without-cuda-driver -v"
+            },
+            {
+              "path": "ci.data.cpu-microcode",
+              "value": "0x1"
+            },
+            {
+              "path": "ci.data.environment-variables",
+              "value": "BL_DEBUG_TELEMETRY=false"
+            },
+            {
+              "path": "ci.data.kernel-extra-details",
+              "value": "Transparent Huge Pages: madvise"
+            },
+            {
+              "path": "ci.data.security",
+              "value": "gather_data_sampling: Not affected + indirect_target_selection: Mitigation of Aligned branch/return thunks + itlb_multihit: Not affected + l1tf: Not affected + mds: Not affected + meltdown: Not affected + mmio_stale_data: Mitigation of Clear buffers; SMT Host state unknown + reg_file_data_sampling: Not affected + retbleed: Not affected + spec_rstack_overflow: Not affected + spec_store_bypass: Mitigation of SSB disabled via prctl + spectre_v1: Mitigation of usercopy/swapgs barriers and __user pointer sanitization + spectre_v2: Mitigation of Enhanced / Automatic IBRS; IBPB: conditional; PBRSB-eIBRS: SW sequence; BHI: SW loop KVM: SW loop + srbds: Not affected + tsa: Not affected + tsx_async_abort: Mitigation of TSX disabled + vmscape: Not affected"
+            },
+            {
+              "path": "ci.hardware.Disk",
+              "value": "13GB"
+            },
+            {
+              "path": "ci.hardware.Memory",
+              "value": "16GB"
+            },
+            {
+              "path": "ci.hardware.Processor",
+              "value": "Intel Xeon (6 Cores)"
+            },
+            {
+              "path": "ci.identifier",
+              "value": "ci"
+            },
+            {
+              "path": "ci.software.Compiler",
+              "value": "GCC 12.2.0"
+            },
+            {
+              "path": "ci.software.File-System",
+              "value": "overlayfs"
+            },
+            {
+              "path": "ci.software.Kernel",
+              "value": "6.12.75+ (x86_64)"
+            },
+            {
+              "path": "ci.software.OS",
+              "value": "Debian GNU/Linux 12"
+            },
+            {
+              "path": "ci.timestamp",
+              "value": "2026-07-17 01:12:31"
+            },
+            {
+              "path": "ci.user",
+              "value": "root"
+            }
+          ]
+        },
+        {
+          "source": "phoronix/result-file-to-json",
+          "sourceFile": "system/pts_pybench--metadata.json",
+          "fields": [
+            {
+              "path": "ci.client_version",
+              "value": "10.8.4"
+            },
+            {
+              "path": "ci.data.cpu-microcode",
+              "value": "0x1"
+            },
+            {
+              "path": "ci.data.environment-variables",
+              "value": "BL_DEBUG_TELEMETRY=false"
+            },
+            {
+              "path": "ci.data.kernel-extra-details",
+              "value": "Transparent Huge Pages: madvise"
+            },
+            {
+              "path": "ci.data.python",
+              "value": "Python 3.11.2"
+            },
+            {
+              "path": "ci.data.security",
+              "value": "gather_data_sampling: Not affected + indirect_target_selection: Mitigation of Aligned branch/return thunks + itlb_multihit: Not affected + l1tf: Not affected + mds: Not affected + meltdown: Not affected + mmio_stale_data: Mitigation of Clear buffers; SMT Host state unknown + reg_file_data_sampling: Not affected + retbleed: Not affected + spec_rstack_overflow: Not affected + spec_store_bypass: Mitigation of SSB disabled via prctl + spectre_v1: Mitigation of usercopy/swapgs barriers and __user pointer sanitization + spectre_v2: Mitigation of Enhanced / Automatic IBRS; IBPB: conditional; PBRSB-eIBRS: SW sequence; BHI: SW loop KVM: SW loop + srbds: Not affected + tsa: Not affected + tsx_async_abort: Mitigation of TSX disabled + vmscape: Not affected"
+            },
+            {
+              "path": "ci.hardware.Disk",
+              "value": "13GB"
+            },
+            {
+              "path": "ci.hardware.Memory",
+              "value": "16GB"
+            },
+            {
+              "path": "ci.hardware.Processor",
+              "value": "Intel Xeon (6 Cores)"
+            },
+            {
+              "path": "ci.identifier",
+              "value": "ci"
+            },
+            {
+              "path": "ci.software.Compiler",
+              "value": "GCC 12.2.0"
+            },
+            {
+              "path": "ci.software.File-System",
+              "value": "overlayfs"
+            },
+            {
+              "path": "ci.software.Kernel",
+              "value": "6.12.75+ (x86_64)"
+            },
+            {
+              "path": "ci.software.OS",
+              "value": "Debian GNU/Linux 12"
+            },
+            {
+              "path": "ci.timestamp",
+              "value": "2026-07-17 01:07:39"
+            },
+            {
+              "path": "ci.user",
+              "value": "root"
+            }
+          ]
+        },
+        {
+          "source": "phoronix/result-file-to-json",
+          "sourceFile": "system/pts_sqlite-speedtest--metadata.json",
+          "fields": [
+            {
+              "path": "ci.client_version",
+              "value": "10.8.4"
+            },
+            {
+              "path": "ci.data.compiler-configuration",
+              "value": "--build=x86_64-linux-gnu --disable-vtable-verify --disable-werror --enable-cet --enable-checking=release --enable-clocale=gnu --enable-default-pie --enable-gnu-unique-object --enable-languages=c,ada,c++,go,d,fortran,objc,obj-c++,m2 --enable-libphobos-checking=release --enable-libstdcxx-debug --enable-libstdcxx-time=yes --enable-multiarch --enable-multilib --enable-nls --enable-objc-gc=auto --enable-offload-defaulted --enable-offload-targets=nvptx-none=/build/reproducible-path/gcc-12-12.2.0/debian/tmp-nvptx/usr,amdgcn-amdhsa=/build/reproducible-path/gcc-12-12.2.0/debian/tmp-gcn/usr --enable-plugin --enable-shared --enable-threads=posix --host=x86_64-linux-gnu --program-prefix=x86_64-linux-gnu- --target=x86_64-linux-gnu --with-abi=m64 --with-arch-32=i686 --with-default-libstdcxx-abi=new --with-gcc-major-version-only --with-multilib-list=m32,m64,mx32 --with-target-system-zlib=auto --with-tune=generic --without-cuda-driver -v"
+            },
+            {
+              "path": "ci.data.cpu-microcode",
+              "value": "0x1"
+            },
+            {
+              "path": "ci.data.environment-variables",
+              "value": "BL_DEBUG_TELEMETRY=false"
+            },
+            {
+              "path": "ci.data.kernel-extra-details",
+              "value": "Transparent Huge Pages: madvise"
+            },
+            {
+              "path": "ci.data.security",
+              "value": "gather_data_sampling: Not affected + indirect_target_selection: Mitigation of Aligned branch/return thunks + itlb_multihit: Not affected + l1tf: Not affected + mds: Not affected + meltdown: Not affected + mmio_stale_data: Mitigation of Clear buffers; SMT Host state unknown + reg_file_data_sampling: Not affected + retbleed: Not affected + spec_rstack_overflow: Not affected + spec_store_bypass: Mitigation of SSB disabled via prctl + spectre_v1: Mitigation of usercopy/swapgs barriers and __user pointer sanitization + spectre_v2: Mitigation of Enhanced / Automatic IBRS; IBPB: conditional; PBRSB-eIBRS: SW sequence; BHI: SW loop KVM: SW loop + srbds: Not affected + tsa: Not affected + tsx_async_abort: Mitigation of TSX disabled + vmscape: Not affected"
+            },
+            {
+              "path": "ci.hardware.Disk",
+              "value": "13GB"
+            },
+            {
+              "path": "ci.hardware.Memory",
+              "value": "16GB"
+            },
+            {
+              "path": "ci.hardware.Processor",
+              "value": "Intel Xeon (6 Cores)"
+            },
+            {
+              "path": "ci.identifier",
+              "value": "ci"
+            },
+            {
+              "path": "ci.software.Compiler",
+              "value": "GCC 12.2.0"
+            },
+            {
+              "path": "ci.software.File-System",
+              "value": "overlayfs"
+            },
+            {
+              "path": "ci.software.Kernel",
+              "value": "6.12.75+ (x86_64)"
+            },
+            {
+              "path": "ci.software.OS",
+              "value": "Debian GNU/Linux 12"
+            },
+            {
+              "path": "ci.timestamp",
+              "value": "2026-07-17 01:09:10"
+            },
+            {
+              "path": "ci.user",
+              "value": "root"
+            }
+          ]
+        },
+        {
+          "source": "mise/system-provider",
+          "sourceFile": "system/system-provider.json",
+          "fields": [
+            {
+              "path": "asn",
+              "value": "AS16509"
+            },
+            {
+              "path": "asn_source",
+              "value": "cymru"
+            },
+            {
+              "path": "bios_vendor",
+              "value": ""
+            },
+            {
+              "path": "city",
+              "value": "Boardman"
+            },
+            {
+              "path": "cores",
+              "value": "6"
+            },
+            {
+              "path": "country",
+              "value": "US"
+            },
+            {
+              "path": "cpu_model",
+              "value": "Intel(R) Xeon(R) Processor @ 2.90GHz"
+            },
+            {
+              "path": "geo_source",
+              "value": "ipinfo"
+            },
+            {
+              "path": "kernel",
+              "value": "6.12.75+"
+            },
+            {
+              "path": "loc",
+              "value": "45.8399,-119.7006"
+            },
+            {
+              "path": "manufacturer",
+              "value": ""
+            },
+            {
+              "path": "org",
+              "value": "AS16509 Amazon.com, Inc."
+            },
+            {
+              "path": "org_name",
+              "value": "Amazon.com, Inc."
+            },
+            {
+              "path": "prefix",
+              "value": "34.208.0.0/12"
+            },
+            {
+              "path": "product_name",
+              "value": ""
+            },
+            {
+              "path": "public_ip",
+              "value": "34.214.71.218"
+            },
+            {
+              "path": "ram",
+              "value": "15Gi"
+            },
+            {
+              "path": "region",
+              "value": "Oregon"
+            },
+            {
+              "path": "reverse_dns",
+              "value": "ec2-34-214-71-218.us-west-2.compute.amazonaws.com"
+            },
+            {
+              "path": "schema_version",
+              "value": "1.0"
+            },
+            {
+              "path": "timezone",
+              "value": "America/Los_Angeles"
+            },
+            {
+              "path": "virtualization",
+              "value": ""
+            }
+          ]
+        }
+      ],
+      "metrics": [
+        {
+          "metricId": "c_ray_resolution_1080p_rays_per_pixel_16",
+          "samples": [127.687, 127.58],
+          "aggregates": {
+            "p50": 127.6335,
+            "p95": 127.68164999999999,
+            "mean": 127.6335,
+            "stdev": 0.0756604255869601,
+            "min": 127.58,
+            "max": 127.687,
+            "n": 2
+          },
+          "sourceFile": "cpu-generic/pts_c-ray.xml",
+          "appVersion": "2.0",
+          "arguments": "-s 1920x1080 -r 16"
+        },
+        {
+          "metricId": "c_ray_resolution_4k_rays_per_pixel_16",
+          "samples": [509.653, 509.793],
+          "aggregates": {
+            "p50": 509.723,
+            "p95": 509.786,
+            "mean": 509.723,
+            "stdev": 0.098994949366107,
+            "min": 509.653,
+            "max": 509.793,
+            "n": 2
+          },
+          "sourceFile": "cpu-generic/pts_c-ray.xml",
+          "appVersion": "2.0",
+          "arguments": "-s 3840x2160 -r 16"
+        },
+        {
+          "metricId": "c_ray_resolution_5k_rays_per_pixel_16",
+          "samples": [908.074, 907.024],
+          "aggregates": {
+            "p50": 907.549,
+            "p95": 908.0215,
+            "mean": 907.549,
+            "stdev": 0.7424621202458428,
+            "min": 907.024,
+            "max": 908.074,
+            "n": 2
+          },
+          "sourceFile": "cpu-generic/pts_c-ray.xml",
+          "appVersion": "2.0",
+          "arguments": "-s 5120x2880 -r 16"
+        },
+        {
+          "metricId": "compress_zstd_compression_level_12_compression_speed",
+          "samples": [115.9, 118.3],
+          "aggregates": {
+            "p50": 117.1,
+            "p95": 118.17999999999999,
+            "mean": 117.1,
+            "stdev": 1.6970562748477132,
+            "min": 115.9,
+            "max": 118.3,
+            "n": 2
+          },
+          "sourceFile": "cpu-generic/pts_compress-zstd.xml",
+          "appVersion": "1.5.4",
+          "arguments": "-b12"
+        },
+        {
+          "metricId": "compress_zstd_compression_level_12_decompression_speed",
+          "samples": [1043.8, 1060.2],
+          "aggregates": {
+            "p50": 1052,
+            "p95": 1059.38,
+            "mean": 1052,
+            "stdev": 11.596551211459444,
+            "min": 1043.8,
+            "max": 1060.2,
+            "n": 2
+          },
+          "sourceFile": "cpu-generic/pts_compress-zstd.xml",
+          "appVersion": "1.5.4",
+          "arguments": "-b12"
+        },
+        {
+          "metricId": "compress_zstd_compression_level_19_compression_speed",
+          "samples": [11.2, 11],
+          "aggregates": {
+            "p50": 11.1,
+            "p95": 11.19,
+            "mean": 11.1,
+            "stdev": 0.141421356237309,
+            "min": 11,
+            "max": 11.2,
+            "n": 2
+          },
+          "sourceFile": "cpu-generic/pts_compress-zstd.xml",
+          "appVersion": "1.5.4",
+          "arguments": "-b19"
+        },
+        {
+          "metricId": "compress_zstd_compression_level_19_decompression_speed",
+          "samples": [868.9, 894.6],
+          "aggregates": {
+            "p50": 881.75,
+            "p95": 893.315,
+            "mean": 881.75,
+            "stdev": 18.172644276494303,
+            "min": 868.9,
+            "max": 894.6,
+            "n": 2
+          },
+          "sourceFile": "cpu-generic/pts_compress-zstd.xml",
+          "appVersion": "1.5.4",
+          "arguments": "-b19"
+        },
+        {
+          "metricId": "compress_zstd_compression_level_19_long_mode_compression_speed",
+          "samples": [5.95, 5.8],
+          "aggregates": {
+            "p50": 5.875,
+            "p95": 5.9425,
+            "mean": 5.875,
+            "stdev": 0.10606601717798238,
+            "min": 5.8,
+            "max": 5.95,
+            "n": 2
+          },
+          "sourceFile": "cpu-generic/pts_compress-zstd.xml",
+          "appVersion": "1.5.4",
+          "arguments": "-b19 --long"
+        },
+        {
+          "metricId": "compress_zstd_compression_level_19_long_mode_decompression_speed",
+          "samples": [902.5, 886.3],
+          "aggregates": {
+            "p50": 894.4,
+            "p95": 901.69,
+            "mean": 894.4,
+            "stdev": 11.455129855222102,
+            "min": 886.3,
+            "max": 902.5,
+            "n": 2
+          },
+          "sourceFile": "cpu-generic/pts_compress-zstd.xml",
+          "appVersion": "1.5.4",
+          "arguments": "-b19 --long"
+        },
+        {
+          "metricId": "compress_zstd_compression_level_3_compression_speed",
+          "samples": [1293.9, 1305.8],
+          "aggregates": {
+            "p50": 1299.85,
+            "p95": 1305.205,
+            "mean": 1299.85,
+            "stdev": 8.414570696119899,
+            "min": 1293.9,
+            "max": 1305.8,
+            "n": 2
+          },
+          "sourceFile": "cpu-generic/pts_compress-zstd.xml",
+          "appVersion": "1.5.4",
+          "arguments": "-b3"
+        },
+        {
+          "metricId": "compress_zstd_compression_level_3_decompression_speed",
+          "samples": [1116.9],
+          "aggregates": {
+            "p50": 1116.9,
+            "p95": 1116.9,
+            "mean": 1116.9,
+            "stdev": 0,
+            "min": 1116.9,
+            "max": 1116.9,
+            "n": 1
+          },
+          "sourceFile": "cpu-generic/pts_compress-zstd.xml",
+          "appVersion": "1.5.4",
+          "arguments": "-b3"
+        },
+        {
+          "metricId": "compress_zstd_compression_level_3_long_mode_compression_speed",
+          "samples": [854.1, 841.7],
+          "aggregates": {
+            "p50": 847.9000000000001,
+            "p95": 853.48,
+            "mean": 847.9000000000001,
+            "stdev": 8.768124086713133,
+            "min": 841.7,
+            "max": 854.1,
+            "n": 2
+          },
+          "sourceFile": "cpu-generic/pts_compress-zstd.xml",
+          "appVersion": "1.5.4",
+          "arguments": "-b3 --long"
+        },
+        {
+          "metricId": "compress_zstd_compression_level_8_compression_speed",
+          "samples": [352.7, 352],
+          "aggregates": {
+            "p50": 352.35,
+            "p95": 352.66499999999996,
+            "mean": 352.35,
+            "stdev": 0.49497474683055515,
+            "min": 352,
+            "max": 352.7,
+            "n": 2
+          },
+          "sourceFile": "cpu-generic/pts_compress-zstd.xml",
+          "appVersion": "1.5.4",
+          "arguments": "-b8"
+        },
+        {
+          "metricId": "compress_zstd_compression_level_8_decompression_speed",
+          "samples": [1117.3, 1126.2],
+          "aggregates": {
+            "p50": 1121.75,
+            "p95": 1125.755,
+            "mean": 1121.75,
+            "stdev": 6.293250352560337,
+            "min": 1117.3,
+            "max": 1126.2,
+            "n": 2
+          },
+          "sourceFile": "cpu-generic/pts_compress-zstd.xml",
+          "appVersion": "1.5.4",
+          "arguments": "-b8"
+        },
+        {
+          "metricId": "compress_zstd_compression_level_8_long_mode_compression_speed",
+          "samples": [326.9, 323.7],
+          "aggregates": {
+            "p50": 325.29999999999995,
+            "p95": 326.73999999999995,
+            "mean": 325.29999999999995,
+            "stdev": 2.262741699796964,
+            "min": 323.7,
+            "max": 326.9,
+            "n": 2
+          },
+          "sourceFile": "cpu-generic/pts_compress-zstd.xml",
+          "appVersion": "1.5.4",
+          "arguments": "-b8 --long"
+        },
+        {
+          "metricId": "compress_zstd_compression_level_8_long_mode_decompression_speed",
+          "samples": [1136, 1134.7],
+          "aggregates": {
+            "p50": 1135.35,
+            "p95": 1135.935,
+            "mean": 1135.35,
+            "stdev": 0.91923881554256,
+            "min": 1134.7,
+            "max": 1136,
+            "n": 2
+          },
+          "sourceFile": "cpu-generic/pts_compress-zstd.xml",
+          "appVersion": "1.5.4",
+          "arguments": "-b8 --long"
+        },
+        {
+          "metricId": "fio_type_random_read_engine_linux_aio_direct_yes_block_size_4kb_job_count_1_disk_target_default_test_directory_iops",
+          "samples": [570000, 582000],
+          "aggregates": {
+            "p50": 576000,
+            "p95": 581400,
+            "mean": 576000,
+            "stdev": 8485.28137423857,
+            "min": 570000,
+            "max": 582000,
+            "n": 2
+          },
+          "sourceFile": "disk/pts_fio-rand-read.xml",
+          "appVersion": "3.36",
+          "arguments": "randread libaio 1 4k 1"
+        },
+        {
+          "metricId": "fio_type_random_read_engine_linux_aio_direct_yes_block_size_4kb_job_count_1_disk_target_default_test_directory_mb_per_s",
+          "samples": [2226, 2275],
+          "aggregates": {
+            "p50": 2250.5,
+            "p95": 2272.55,
+            "mean": 2250.5,
+            "stdev": 34.64823227814083,
+            "min": 2226,
+            "max": 2275,
+            "n": 2
+          },
+          "sourceFile": "disk/pts_fio-rand-read.xml",
+          "appVersion": "3.36",
+          "arguments": "randread libaio 1 4k 1"
+        },
+        {
+          "metricId": "fio_type_random_write_engine_linux_aio_direct_yes_block_size_4kb_job_count_1_disk_target_default_test_directory_iops",
+          "samples": [484000, 506000],
+          "aggregates": {
+            "p50": 495000,
+            "p95": 504900,
+            "mean": 495000,
+            "stdev": 15556.349186104046,
+            "min": 484000,
+            "max": 506000,
+            "n": 2
+          },
+          "sourceFile": "disk/pts_fio-rand-write.xml",
+          "appVersion": "3.36",
+          "arguments": "randwrite libaio 1 4k 1"
+        },
+        {
+          "metricId": "fio_type_random_write_engine_linux_aio_direct_yes_block_size_4kb_job_count_1_disk_target_default_test_directory_mb_per_s",
+          "samples": [1891, 1977],
+          "aggregates": {
+            "p50": 1934,
+            "p95": 1972.7,
+            "mean": 1934,
+            "stdev": 60.81118318204309,
+            "min": 1891,
+            "max": 1977,
+            "n": 2
+          },
+          "sourceFile": "disk/pts_fio-rand-write.xml",
+          "appVersion": "3.36",
+          "arguments": "randwrite libaio 1 4k 1"
+        },
+        {
+          "metricId": "fio_type_sequential_read_engine_linux_aio_direct_yes_block_size_1mb_job_count_1_disk_target_default_test_directory_iops",
+          "samples": [4609, 4809],
+          "aggregates": {
+            "p50": 4709,
+            "p95": 4799,
+            "mean": 4709,
+            "stdev": 141.4213562373095,
+            "min": 4609,
+            "max": 4809,
+            "n": 2
+          },
+          "sourceFile": "disk/pts_fio-seq-read.xml",
+          "appVersion": "3.36",
+          "arguments": "read libaio 1 1m 1"
+        },
+        {
+          "metricId": "fio_type_sequential_read_engine_linux_aio_direct_yes_block_size_1mb_job_count_1_disk_target_default_test_directory_mb_per_s",
+          "samples": [4611, 4811],
+          "aggregates": {
+            "p50": 4711,
+            "p95": 4801,
+            "mean": 4711,
+            "stdev": 141.4213562373095,
+            "min": 4611,
+            "max": 4811,
+            "n": 2
+          },
+          "sourceFile": "disk/pts_fio-seq-read.xml",
+          "appVersion": "3.36",
+          "arguments": "read libaio 1 1m 1"
+        },
+        {
+          "metricId": "fio_type_sequential_write_engine_linux_aio_direct_yes_block_size_1mb_job_count_1_disk_target_default_test_directory_iops",
+          "samples": [3616, 3700],
+          "aggregates": {
+            "p50": 3658,
+            "p95": 3695.8,
+            "mean": 3658,
+            "stdev": 59.39696961966999,
+            "min": 3616,
+            "max": 3700,
+            "n": 2
+          },
+          "sourceFile": "disk/pts_fio-seq-write.xml",
+          "appVersion": "3.36",
+          "arguments": "write libaio 1 1m 1"
+        },
+        {
+          "metricId": "fio_type_sequential_write_engine_linux_aio_direct_yes_block_size_1mb_job_count_1_disk_target_default_test_directory_mb_per_s",
+          "samples": [3618, 3702],
+          "aggregates": {
+            "p50": 3660,
+            "p95": 3697.8,
+            "mean": 3660,
+            "stdev": 59.39696961966999,
+            "min": 3618,
+            "max": 3702,
+            "n": 2
+          },
+          "sourceFile": "disk/pts_fio-seq-write.xml",
+          "appVersion": "3.36",
+          "arguments": "write libaio 1 1m 1"
+        },
+        {
+          "metricId": "git_seconds",
+          "samples": [61.365, 61.589],
+          "aggregates": {
+            "p50": 61.477000000000004,
+            "p95": 61.577799999999996,
+            "mean": 61.477000000000004,
+            "stdev": 0.15839191898578175,
+            "min": 61.365,
+            "max": 61.589,
+            "n": 2
+          },
+          "sourceFile": "system/pts_git.xml"
+        },
+        {
+          "metricId": "hardlink_bogo_ops_per_s",
+          "samples": [12.46, 12.39],
+          "aggregates": {
+            "p50": 12.425,
+            "p95": 12.4565,
+            "mean": 12.425,
+            "stdev": 0.049497474683058526,
+            "min": 12.39,
+            "max": 12.46,
+            "n": 2
+          },
+          "sourceFile": "disk/pts_hardlink.xml",
+          "appVersion": "0.16"
+        },
+        {
+          "metricId": "network_loopback_seconds",
+          "samples": [6.867, 6.339],
+          "aggregates": {
+            "p50": 6.603,
+            "p95": 6.8406,
+            "mean": 6.603,
+            "stdev": 0.3733523804664971,
+            "min": 6.339,
+            "max": 6.867,
+            "n": 2
+          },
+          "sourceFile": "network/pts_network-loopback.xml"
+        },
+        {
+          "metricId": "node_web_tooling_runs_per_s",
+          "samples": [12.67, 12.94],
+          "aggregates": {
+            "p50": 12.805,
+            "p95": 12.926499999999999,
+            "mean": 12.805,
+            "stdev": 0.19091883092036754,
+            "min": 12.67,
+            "max": 12.94,
+            "n": 2
+          },
+          "sourceFile": "cpu-node/pts_node-web-tooling.xml"
+        },
+        {
+          "metricId": "pybench_milliseconds",
+          "samples": [839, 849],
+          "aggregates": {
+            "p50": 844,
+            "p95": 848.5,
+            "mean": 844,
+            "stdev": 7.0710678118654755,
+            "min": 839,
+            "max": 849,
+            "n": 2
+          },
+          "sourceFile": "system/pts_pybench.xml",
+          "appVersion": "2018-02-16"
+        },
+        {
+          "metricId": "realworld_better_auth_task_build",
+          "samples": [10.786, 11.083],
+          "aggregates": {
+            "p50": 10.9345,
+            "p95": 11.06815,
+            "mean": 10.9345,
+            "stdev": 0.21001071401240504,
+            "min": 10.786,
+            "max": 11.083,
+            "n": 2
+          },
+          "sourceFile": "realworld-better-auth/pts_realworld-better-auth.xml",
+          "appVersion": "6f3ba45639579da152b69e8e5342e02f28288670",
+          "arguments": "build"
+        },
+        {
+          "metricId": "realworld_better_auth_task_cold_install",
+          "samples": [17.174, 16.557],
+          "aggregates": {
+            "p50": 16.865499999999997,
+            "p95": 17.14315,
+            "mean": 16.865499999999997,
+            "stdev": 0.4362848839921017,
+            "min": 16.557,
+            "max": 17.174,
+            "n": 2
+          },
+          "sourceFile": "realworld-better-auth/pts_realworld-better-auth.xml",
+          "appVersion": "6f3ba45639579da152b69e8e5342e02f28288670",
+          "arguments": "cold_install"
+        },
+        {
+          "metricId": "realworld_better_auth_task_git_clone",
+          "samples": [1.586, 1.555],
+          "aggregates": {
+            "p50": 1.5705,
+            "p95": 1.5844500000000001,
+            "mean": 1.5705,
+            "stdev": 0.021920310216783073,
+            "min": 1.555,
+            "max": 1.586,
+            "n": 2
+          },
+          "sourceFile": "realworld-better-auth/pts_realworld-better-auth.xml",
+          "appVersion": "6f3ba45639579da152b69e8e5342e02f28288670",
+          "arguments": "git_clone"
+        },
+        {
+          "metricId": "realworld_better_auth_task_lint_biome",
+          "samples": [3.936, 3.942],
+          "aggregates": {
+            "p50": 3.939,
+            "p95": 3.9417,
+            "mean": 3.939,
+            "stdev": 0.004242640687119446,
+            "min": 3.936,
+            "max": 3.942,
+            "n": 2
+          },
+          "sourceFile": "realworld-better-auth/pts_realworld-better-auth.xml",
+          "appVersion": "6f3ba45639579da152b69e8e5342e02f28288670",
+          "arguments": "lint_biome"
+        },
+        {
+          "metricId": "realworld_better_auth_task_lint_deps_knip",
+          "samples": [16.97, 16.586],
+          "aggregates": {
+            "p50": 16.778,
+            "p95": 16.950799999999997,
+            "mean": 16.778,
+            "stdev": 0.2715290039756345,
+            "min": 16.586,
+            "max": 16.97,
+            "n": 2
+          },
+          "sourceFile": "realworld-better-auth/pts_realworld-better-auth.xml",
+          "appVersion": "6f3ba45639579da152b69e8e5342e02f28288670",
+          "arguments": "lint_deps"
+        },
+        {
+          "metricId": "realworld_better_auth_task_lint_format",
+          "samples": [4.946, 4.946],
+          "aggregates": {
+            "p50": 4.946,
+            "p95": 4.946,
+            "mean": 4.946,
+            "stdev": 0,
+            "min": 4.946,
+            "max": 4.946,
+            "n": 2
+          },
+          "sourceFile": "realworld-better-auth/pts_realworld-better-auth.xml",
+          "appVersion": "6f3ba45639579da152b69e8e5342e02f28288670",
+          "arguments": "lint_format"
+        },
+        {
+          "metricId": "realworld_better_auth_task_lint_packages",
+          "samples": [3.001, 2.966],
+          "aggregates": {
+            "p50": 2.9835000000000003,
+            "p95": 2.99925,
+            "mean": 2.9835000000000003,
+            "stdev": 0.02474873734152879,
+            "min": 2.966,
+            "max": 3.001,
+            "n": 2
+          },
+          "sourceFile": "realworld-better-auth/pts_realworld-better-auth.xml",
+          "appVersion": "6f3ba45639579da152b69e8e5342e02f28288670",
+          "arguments": "lint_packages"
+        },
+        {
+          "metricId": "realworld_better_auth_task_lint_spell",
+          "samples": [12.208, 12.192],
+          "aggregates": {
+            "p50": 12.2,
+            "p95": 12.2072,
+            "mean": 12.2,
+            "stdev": 0.011313708498985399,
+            "min": 12.192,
+            "max": 12.208,
+            "n": 2
+          },
+          "sourceFile": "realworld-better-auth/pts_realworld-better-auth.xml",
+          "appVersion": "6f3ba45639579da152b69e8e5342e02f28288670",
+          "arguments": "lint_spell"
+        },
+        {
+          "metricId": "realworld_better_auth_task_lint_types",
+          "samples": [33.801, 33.475],
+          "aggregates": {
+            "p50": 33.638000000000005,
+            "p95": 33.7847,
+            "mean": 33.638000000000005,
+            "stdev": 0.23051681066681234,
+            "min": 33.475,
+            "max": 33.801,
+            "n": 2
+          },
+          "sourceFile": "realworld-better-auth/pts_realworld-better-auth.xml",
+          "appVersion": "6f3ba45639579da152b69e8e5342e02f28288670",
+          "arguments": "lint_types"
+        },
+        {
+          "metricId": "realworld_better_auth_task_typecheck",
+          "samples": [2.038, 2.037],
+          "aggregates": {
+            "p50": 2.0374999999999996,
+            "p95": 2.03795,
+            "mean": 2.0374999999999996,
+            "stdev": 0.0007071067811866267,
+            "min": 2.037,
+            "max": 2.038,
+            "n": 2
+          },
+          "sourceFile": "realworld-better-auth/pts_realworld-better-auth.xml",
+          "appVersion": "6f3ba45639579da152b69e8e5342e02f28288670",
+          "arguments": "typecheck"
+        },
+        {
+          "metricId": "sqlite_speedtest_seconds",
+          "samples": [68.245, 67.984],
+          "aggregates": {
+            "p50": 68.11449999999999,
+            "p95": 68.23195,
+            "mean": 68.11449999999999,
+            "stdev": 0.1845548698897009,
+            "min": 67.984,
+            "max": 68.245,
+            "n": 2
+          },
+          "sourceFile": "system/pts_sqlite-speedtest.xml",
+          "appVersion": "3.30"
+        },
+        {
+          "metricId": "stream_type_add",
+          "samples": [77686.7, 70135.9],
+          "aggregates": {
+            "p50": 73911.29999999999,
+            "p95": 77309.16,
+            "mean": 73911.29999999999,
+            "stdev": 5339.22188338339,
+            "min": 70135.9,
+            "max": 77686.7,
+            "n": 2
+          },
+          "sourceFile": "memory/pts_stream.xml",
+          "appVersion": "2013-01-17",
+          "arguments": "Add"
+        },
+        {
+          "metricId": "stream_type_copy",
+          "samples": [120361.7, 107305.5],
+          "aggregates": {
+            "p50": 113833.6,
+            "p95": 119708.89,
+            "mean": 113833.6,
+            "stdev": 9232.127556527794,
+            "min": 107305.5,
+            "max": 120361.7,
+            "n": 2
+          },
+          "sourceFile": "memory/pts_stream.xml",
+          "appVersion": "2013-01-17",
+          "arguments": "Copy"
+        },
+        {
+          "metricId": "stream_type_scale",
+          "samples": [66567, 58675.3],
+          "aggregates": {
+            "p50": 62621.15,
+            "p95": 66172.415,
+            "mean": 62621.15,
+            "stdev": 5580.2745850898755,
+            "min": 58675.3,
+            "max": 66567,
+            "n": 2
+          },
+          "sourceFile": "memory/pts_stream.xml",
+          "appVersion": "2013-01-17",
+          "arguments": "Scale"
+        },
+        {
+          "metricId": "stream_type_triad",
+          "samples": [77460.7, 70326.4],
+          "aggregates": {
+            "p50": 73893.54999999999,
+            "p95": 77103.985,
+            "mean": 73893.54999999999,
+            "stdev": 5044.711909019193,
+            "min": 70326.4,
+            "max": 77460.7,
+            "n": 2
+          },
+          "sourceFile": "memory/pts_stream.xml",
+          "appVersion": "2013-01-17",
+          "arguments": "Triad"
+        }
+      ],
+      "suitesCovered": [
+        "cpu-generic",
+        "cpu-node",
+        "disk",
+        "memory",
+        "network",
+        "realworld-better-auth",
+        "system"
+      ],
+      "gaps": [
+        {
+          "scope": "suite",
+          "id": "network",
+          "outcome": "failed",
+          "reason": "Step \"mise run benchmark:network:all\" failed with exit code 1"
+        },
+        {
+          "scope": "suite",
+          "id": "realworld-mastra",
+          "outcome": "skipped",
+          "reason": "Insufficient disk: 12.5 GiB free, suite needs 30 GiB"
+        },
+        {
+          "scope": "suite",
+          "id": "realworld-openclaw",
+          "outcome": "skipped",
+          "reason": "Insufficient disk: 12.5 GiB free, suite needs 25 GiB"
+        }
+      ],
+      "uncatalogued": []
+    },
+    {
+      "providerId": "daytona",
+      "validationStatus": "validated",
+      "specMatched": true,
+      "observedSpecs": {
+        "cpuModel": "AMD EPYC",
+        "hostVcpus": 2,
+        "hostMemoryGb": 8,
+        "os": "Debian GNU/Linux 13 (trixie)",
+        "kernel": "6.19.14",
+        "virtualization": "kvm",
+        "user": "root",
+        "vcpus": 2,
+        "memoryGb": 7.78,
+        "diskGb": 39.1,
+        "publicIp": "67.213.124.39",
+        "egressOrg": "AS396356 Latitude.sh",
+        "egressAsn": "AS396356",
+        "egressOrgName": "Latitude.sh",
+        "city": "Los Angeles",
+        "region": "California",
+        "country": "US",
+        "location": "34.0522,-118.2437",
+        "timezone": "America/Los_Angeles",
+        "networkPrefix": "67.213.124.0/24",
+        "asnSource": "cymru",
+        "geoSource": "ipinfo"
+      },
+      "hostMetadata": [
+        {
+          "source": "phoronix/result-file-to-json",
+          "sourceFile": "cpu-generic/pts_c-ray--metadata.json",
+          "fields": [
+            {
+              "path": "ci.client_version",
+              "value": "10.8.4"
+            },
+            {
+              "path": "ci.data.compiler-configuration",
+              "value": "--build=x86_64-linux-gnu --disable-vtable-verify --disable-werror --enable-bootstrap --enable-cet --enable-checking=release --enable-clocale=gnu --enable-default-pie --enable-gnu-unique-object --enable-languages=c,ada,c++,go,d,fortran,objc,obj-c++,m2,rust --enable-libphobos-checking=release --enable-libstdcxx-backtrace --enable-libstdcxx-debug --enable-libstdcxx-time=yes --enable-link-serialization=3 --enable-multiarch --enable-multilib --enable-nls --enable-objc-gc=auto --enable-offload-defaulted --enable-offload-targets=nvptx-none=/build/reproducible-path/gcc-14-14.2.0/debian/tmp-nvptx/usr,amdgcn-amdhsa=/build/reproducible-path/gcc-14-14.2.0/debian/tmp-gcn/usr --enable-plugin --enable-shared --enable-threads=posix --host=x86_64-linux-gnu --program-prefix=x86_64-linux-gnu- --target=x86_64-linux-gnu --with-abi=m64 --with-arch-32=i686 --with-build-config=bootstrap-lto-lean --with-default-libstdcxx-abi=new --with-gcc-major-version-only --with-multilib-list=m32,m64,mx32 --with-target-system-zlib=auto --with-tune=generic --without-cuda-driver -v"
+            },
+            {
+              "path": "ci.data.cpu-microcode",
+              "value": "0x1000065"
+            },
+            {
+              "path": "ci.data.kernel-extra-details",
+              "value": "Transparent Huge Pages: madvise"
+            },
+            {
+              "path": "ci.data.security",
+              "value": "gather_data_sampling: Not affected + ghostwrite: Not affected + indirect_target_selection: Not affected + itlb_multihit: Not affected + l1tf: Not affected + mds: Not affected + meltdown: Not affected + mmio_stale_data: Not affected + old_microcode: Not affected + reg_file_data_sampling: Not affected + retbleed: Not affected + spec_rstack_overflow: Vulnerable: Microcode no safe RET + spec_store_bypass: Mitigation of SSB disabled via prctl + spectre_v1: Mitigation of usercopy/swapgs barriers and __user pointer sanitization + spectre_v2: Mitigation of Enhanced / Automatic IBRS; IBPB: conditional; STIBP: disabled; PBRSB-eIBRS: Not affected; BHI: Not affected + srbds: Not affected + tsa: Not affected + tsx_async_abort: Not affected + vmscape: Not affected"
+            },
+            {
+              "path": "ci.hardware.Disk",
+              "value": "40GB"
+            },
+            {
+              "path": "ci.hardware.Memory",
+              "value": "8GB"
+            },
+            {
+              "path": "ci.hardware.Processor",
+              "value": "AMD EPYC (2 Cores)"
+            },
+            {
+              "path": "ci.identifier",
+              "value": "ci"
+            },
+            {
+              "path": "ci.software.Compiler",
+              "value": "GCC 14.2.0"
+            },
+            {
+              "path": "ci.software.File-System",
+              "value": "ext4"
+            },
+            {
+              "path": "ci.software.Kernel",
+              "value": "6.19.14 (x86_64)"
+            },
+            {
+              "path": "ci.software.OS",
+              "value": "Debian GNU/Linux 13"
+            },
+            {
+              "path": "ci.software.System Layer",
+              "value": "KVM"
+            },
+            {
+              "path": "ci.timestamp",
+              "value": "2026-07-17 01:07:18"
+            },
+            {
+              "path": "ci.user",
+              "value": "root"
+            }
+          ]
+        },
+        {
+          "source": "phoronix/result-file-to-json",
+          "sourceFile": "cpu-generic/pts_compress-zstd--metadata.json",
+          "fields": [
+            {
+              "path": "ci.client_version",
+              "value": "10.8.4"
+            },
+            {
+              "path": "ci.data.compiler-configuration",
+              "value": "--build=x86_64-linux-gnu --disable-vtable-verify --disable-werror --enable-bootstrap --enable-cet --enable-checking=release --enable-clocale=gnu --enable-default-pie --enable-gnu-unique-object --enable-languages=c,ada,c++,go,d,fortran,objc,obj-c++,m2,rust --enable-libphobos-checking=release --enable-libstdcxx-backtrace --enable-libstdcxx-debug --enable-libstdcxx-time=yes --enable-link-serialization=3 --enable-multiarch --enable-multilib --enable-nls --enable-objc-gc=auto --enable-offload-defaulted --enable-offload-targets=nvptx-none=/build/reproducible-path/gcc-14-14.2.0/debian/tmp-nvptx/usr,amdgcn-amdhsa=/build/reproducible-path/gcc-14-14.2.0/debian/tmp-gcn/usr --enable-plugin --enable-shared --enable-threads=posix --host=x86_64-linux-gnu --program-prefix=x86_64-linux-gnu- --target=x86_64-linux-gnu --with-abi=m64 --with-arch-32=i686 --with-build-config=bootstrap-lto-lean --with-default-libstdcxx-abi=new --with-gcc-major-version-only --with-multilib-list=m32,m64,mx32 --with-target-system-zlib=auto --with-tune=generic --without-cuda-driver -v"
+            },
+            {
+              "path": "ci.data.cpu-microcode",
+              "value": "0x1000065"
+            },
+            {
+              "path": "ci.data.kernel-extra-details",
+              "value": "Transparent Huge Pages: madvise"
+            },
+            {
+              "path": "ci.data.security",
+              "value": "gather_data_sampling: Not affected + ghostwrite: Not affected + indirect_target_selection: Not affected + itlb_multihit: Not affected + l1tf: Not affected + mds: Not affected + meltdown: Not affected + mmio_stale_data: Not affected + old_microcode: Not affected + reg_file_data_sampling: Not affected + retbleed: Not affected + spec_rstack_overflow: Vulnerable: Microcode no safe RET + spec_store_bypass: Mitigation of SSB disabled via prctl + spectre_v1: Mitigation of usercopy/swapgs barriers and __user pointer sanitization + spectre_v2: Mitigation of Enhanced / Automatic IBRS; IBPB: conditional; STIBP: disabled; PBRSB-eIBRS: Not affected; BHI: Not affected + srbds: Not affected + tsa: Not affected + tsx_async_abort: Not affected + vmscape: Not affected"
+            },
+            {
+              "path": "ci.hardware.Disk",
+              "value": "40GB"
+            },
+            {
+              "path": "ci.hardware.Memory",
+              "value": "8GB"
+            },
+            {
+              "path": "ci.hardware.Processor",
+              "value": "AMD EPYC (2 Cores)"
+            },
+            {
+              "path": "ci.identifier",
+              "value": "ci"
+            },
+            {
+              "path": "ci.software.Compiler",
+              "value": "GCC 14.2.0"
+            },
+            {
+              "path": "ci.software.File-System",
+              "value": "ext4"
+            },
+            {
+              "path": "ci.software.Kernel",
+              "value": "6.19.14 (x86_64)"
+            },
+            {
+              "path": "ci.software.OS",
+              "value": "Debian GNU/Linux 13"
+            },
+            {
+              "path": "ci.software.System Layer",
+              "value": "KVM"
+            },
+            {
+              "path": "ci.timestamp",
+              "value": "2026-07-17 02:28:48"
+            },
+            {
+              "path": "ci.user",
+              "value": "root"
+            }
+          ]
+        },
+        {
+          "source": "phoronix/result-file-to-json",
+          "sourceFile": "cpu-node/pts_node-web-tooling--metadata.json",
+          "fields": [
+            {
+              "path": "ci.client_version",
+              "value": "10.8.4"
+            },
+            {
+              "path": "ci.data.cpu-microcode",
+              "value": "0x1000065"
+            },
+            {
+              "path": "ci.data.kernel-extra-details",
+              "value": "Transparent Huge Pages: madvise"
+            },
+            {
+              "path": "ci.data.security",
+              "value": "gather_data_sampling: Not affected + ghostwrite: Not affected + indirect_target_selection: Not affected + itlb_multihit: Not affected + l1tf: Not affected + mds: Not affected + meltdown: Not affected + mmio_stale_data: Not affected + old_microcode: Not affected + reg_file_data_sampling: Not affected + retbleed: Not affected + spec_rstack_overflow: Vulnerable: Microcode no safe RET + spec_store_bypass: Mitigation of SSB disabled via prctl + spectre_v1: Mitigation of usercopy/swapgs barriers and __user pointer sanitization + spectre_v2: Mitigation of Enhanced / Automatic IBRS; IBPB: conditional; STIBP: disabled; PBRSB-eIBRS: Not affected; BHI: Not affected + srbds: Not affected + tsa: Not affected + tsx_async_abort: Not affected + vmscape: Not affected"
+            },
+            {
+              "path": "ci.hardware.Disk",
+              "value": "40GB"
+            },
+            {
+              "path": "ci.hardware.Memory",
+              "value": "8GB"
+            },
+            {
+              "path": "ci.hardware.Processor",
+              "value": "AMD EPYC (2 Cores)"
+            },
+            {
+              "path": "ci.identifier",
+              "value": "ci"
+            },
+            {
+              "path": "ci.software.Compiler",
+              "value": "GCC 14.2.0"
+            },
+            {
+              "path": "ci.software.File-System",
+              "value": "ext4"
+            },
+            {
+              "path": "ci.software.Kernel",
+              "value": "6.19.14 (x86_64)"
+            },
+            {
+              "path": "ci.software.OS",
+              "value": "Debian GNU/Linux 13"
+            },
+            {
+              "path": "ci.software.System Layer",
+              "value": "KVM"
+            },
+            {
+              "path": "ci.timestamp",
+              "value": "2026-07-17 01:07:19"
+            },
+            {
+              "path": "ci.user",
+              "value": "root"
+            }
+          ]
+        },
+        {
+          "source": "phoronix/result-file-to-json",
+          "sourceFile": "disk/pts_fio-rand-read--metadata.json",
+          "fields": [
+            {
+              "path": "ci.client_version",
+              "value": "10.8.4"
+            },
+            {
+              "path": "ci.data.compiler-configuration",
+              "value": "--build=x86_64-linux-gnu --disable-vtable-verify --disable-werror --enable-bootstrap --enable-cet --enable-checking=release --enable-clocale=gnu --enable-default-pie --enable-gnu-unique-object --enable-languages=c,ada,c++,go,d,fortran,objc,obj-c++,m2,rust --enable-libphobos-checking=release --enable-libstdcxx-backtrace --enable-libstdcxx-debug --enable-libstdcxx-time=yes --enable-link-serialization=3 --enable-multiarch --enable-multilib --enable-nls --enable-objc-gc=auto --enable-offload-defaulted --enable-offload-targets=nvptx-none=/build/reproducible-path/gcc-14-14.2.0/debian/tmp-nvptx/usr,amdgcn-amdhsa=/build/reproducible-path/gcc-14-14.2.0/debian/tmp-gcn/usr --enable-plugin --enable-shared --enable-threads=posix --host=x86_64-linux-gnu --program-prefix=x86_64-linux-gnu- --target=x86_64-linux-gnu --with-abi=m64 --with-arch-32=i686 --with-build-config=bootstrap-lto-lean --with-default-libstdcxx-abi=new --with-gcc-major-version-only --with-multilib-list=m32,m64,mx32 --with-target-system-zlib=auto --with-tune=generic --without-cuda-driver -v"
+            },
+            {
+              "path": "ci.data.cpu-microcode",
+              "value": "0x1000065"
+            },
+            {
+              "path": "ci.data.disk-details",
+              "value": "Block Size: 4096"
+            },
+            {
+              "path": "ci.data.disk-mount-options",
+              "value": "relatime,rw"
+            },
+            {
+              "path": "ci.data.kernel-extra-details",
+              "value": "Transparent Huge Pages: madvise"
+            },
+            {
+              "path": "ci.data.security",
+              "value": "gather_data_sampling: Not affected + ghostwrite: Not affected + indirect_target_selection: Not affected + itlb_multihit: Not affected + l1tf: Not affected + mds: Not affected + meltdown: Not affected + mmio_stale_data: Not affected + old_microcode: Not affected + reg_file_data_sampling: Not affected + retbleed: Not affected + spec_rstack_overflow: Vulnerable: Microcode no safe RET + spec_store_bypass: Mitigation of SSB disabled via prctl + spectre_v1: Mitigation of usercopy/swapgs barriers and __user pointer sanitization + spectre_v2: Mitigation of Enhanced / Automatic IBRS; IBPB: conditional; STIBP: disabled; PBRSB-eIBRS: Not affected; BHI: Not affected + srbds: Not affected + tsa: Not affected + tsx_async_abort: Not affected + vmscape: Not affected"
+            },
+            {
+              "path": "ci.hardware.Disk",
+              "value": "40GB"
+            },
+            {
+              "path": "ci.hardware.Memory",
+              "value": "8GB"
+            },
+            {
+              "path": "ci.hardware.Processor",
+              "value": "AMD EPYC (2 Cores)"
+            },
+            {
+              "path": "ci.identifier",
+              "value": "ci"
+            },
+            {
+              "path": "ci.software.Compiler",
+              "value": "GCC 14.2.0"
+            },
+            {
+              "path": "ci.software.File-System",
+              "value": "ext4"
+            },
+            {
+              "path": "ci.software.Kernel",
+              "value": "6.19.14 (x86_64)"
+            },
+            {
+              "path": "ci.software.OS",
+              "value": "Debian GNU/Linux 13"
+            },
+            {
+              "path": "ci.software.System Layer",
+              "value": "KVM"
+            },
+            {
+              "path": "ci.timestamp",
+              "value": "2026-07-17 01:13:58"
+            },
+            {
+              "path": "ci.user",
+              "value": "root"
+            }
+          ]
+        },
+        {
+          "source": "phoronix/result-file-to-json",
+          "sourceFile": "disk/pts_fio-rand-write--metadata.json",
+          "fields": [
+            {
+              "path": "ci.client_version",
+              "value": "10.8.4"
+            },
+            {
+              "path": "ci.data.compiler-configuration",
+              "value": "--build=x86_64-linux-gnu --disable-vtable-verify --disable-werror --enable-bootstrap --enable-cet --enable-checking=release --enable-clocale=gnu --enable-default-pie --enable-gnu-unique-object --enable-languages=c,ada,c++,go,d,fortran,objc,obj-c++,m2,rust --enable-libphobos-checking=release --enable-libstdcxx-backtrace --enable-libstdcxx-debug --enable-libstdcxx-time=yes --enable-link-serialization=3 --enable-multiarch --enable-multilib --enable-nls --enable-objc-gc=auto --enable-offload-defaulted --enable-offload-targets=nvptx-none=/build/reproducible-path/gcc-14-14.2.0/debian/tmp-nvptx/usr,amdgcn-amdhsa=/build/reproducible-path/gcc-14-14.2.0/debian/tmp-gcn/usr --enable-plugin --enable-shared --enable-threads=posix --host=x86_64-linux-gnu --program-prefix=x86_64-linux-gnu- --target=x86_64-linux-gnu --with-abi=m64 --with-arch-32=i686 --with-build-config=bootstrap-lto-lean --with-default-libstdcxx-abi=new --with-gcc-major-version-only --with-multilib-list=m32,m64,mx32 --with-target-system-zlib=auto --with-tune=generic --without-cuda-driver -v"
+            },
+            {
+              "path": "ci.data.cpu-microcode",
+              "value": "0x1000065"
+            },
+            {
+              "path": "ci.data.disk-details",
+              "value": "Block Size: 4096"
+            },
+            {
+              "path": "ci.data.disk-mount-options",
+              "value": "relatime,rw"
+            },
+            {
+              "path": "ci.data.kernel-extra-details",
+              "value": "Transparent Huge Pages: madvise"
+            },
+            {
+              "path": "ci.data.security",
+              "value": "gather_data_sampling: Not affected + ghostwrite: Not affected + indirect_target_selection: Not affected + itlb_multihit: Not affected + l1tf: Not affected + mds: Not affected + meltdown: Not affected + mmio_stale_data: Not affected + old_microcode: Not affected + reg_file_data_sampling: Not affected + retbleed: Not affected + spec_rstack_overflow: Vulnerable: Microcode no safe RET + spec_store_bypass: Mitigation of SSB disabled via prctl + spectre_v1: Mitigation of usercopy/swapgs barriers and __user pointer sanitization + spectre_v2: Mitigation of Enhanced / Automatic IBRS; IBPB: conditional; STIBP: disabled; PBRSB-eIBRS: Not affected; BHI: Not affected + srbds: Not affected + tsa: Not affected + tsx_async_abort: Not affected + vmscape: Not affected"
+            },
+            {
+              "path": "ci.hardware.Disk",
+              "value": "40GB"
+            },
+            {
+              "path": "ci.hardware.Memory",
+              "value": "8GB"
+            },
+            {
+              "path": "ci.hardware.Processor",
+              "value": "AMD EPYC (2 Cores)"
+            },
+            {
+              "path": "ci.identifier",
+              "value": "ci"
+            },
+            {
+              "path": "ci.software.Compiler",
+              "value": "GCC 14.2.0"
+            },
+            {
+              "path": "ci.software.File-System",
+              "value": "ext4"
+            },
+            {
+              "path": "ci.software.Kernel",
+              "value": "6.19.14 (x86_64)"
+            },
+            {
+              "path": "ci.software.OS",
+              "value": "Debian GNU/Linux 13"
+            },
+            {
+              "path": "ci.software.System Layer",
+              "value": "KVM"
+            },
+            {
+              "path": "ci.timestamp",
+              "value": "2026-07-17 01:17:28"
+            },
+            {
+              "path": "ci.user",
+              "value": "root"
+            }
+          ]
+        },
+        {
+          "source": "phoronix/result-file-to-json",
+          "sourceFile": "disk/pts_fio-seq-read--metadata.json",
+          "fields": [
+            {
+              "path": "ci.client_version",
+              "value": "10.8.4"
+            },
+            {
+              "path": "ci.data.compiler-configuration",
+              "value": "--build=x86_64-linux-gnu --disable-vtable-verify --disable-werror --enable-bootstrap --enable-cet --enable-checking=release --enable-clocale=gnu --enable-default-pie --enable-gnu-unique-object --enable-languages=c,ada,c++,go,d,fortran,objc,obj-c++,m2,rust --enable-libphobos-checking=release --enable-libstdcxx-backtrace --enable-libstdcxx-debug --enable-libstdcxx-time=yes --enable-link-serialization=3 --enable-multiarch --enable-multilib --enable-nls --enable-objc-gc=auto --enable-offload-defaulted --enable-offload-targets=nvptx-none=/build/reproducible-path/gcc-14-14.2.0/debian/tmp-nvptx/usr,amdgcn-amdhsa=/build/reproducible-path/gcc-14-14.2.0/debian/tmp-gcn/usr --enable-plugin --enable-shared --enable-threads=posix --host=x86_64-linux-gnu --program-prefix=x86_64-linux-gnu- --target=x86_64-linux-gnu --with-abi=m64 --with-arch-32=i686 --with-build-config=bootstrap-lto-lean --with-default-libstdcxx-abi=new --with-gcc-major-version-only --with-multilib-list=m32,m64,mx32 --with-target-system-zlib=auto --with-tune=generic --without-cuda-driver -v"
+            },
+            {
+              "path": "ci.data.cpu-microcode",
+              "value": "0x1000065"
+            },
+            {
+              "path": "ci.data.disk-details",
+              "value": "Block Size: 4096"
+            },
+            {
+              "path": "ci.data.disk-mount-options",
+              "value": "relatime,rw"
+            },
+            {
+              "path": "ci.data.kernel-extra-details",
+              "value": "Transparent Huge Pages: madvise"
+            },
+            {
+              "path": "ci.data.security",
+              "value": "gather_data_sampling: Not affected + ghostwrite: Not affected + indirect_target_selection: Not affected + itlb_multihit: Not affected + l1tf: Not affected + mds: Not affected + meltdown: Not affected + mmio_stale_data: Not affected + old_microcode: Not affected + reg_file_data_sampling: Not affected + retbleed: Not affected + spec_rstack_overflow: Vulnerable: Microcode no safe RET + spec_store_bypass: Mitigation of SSB disabled via prctl + spectre_v1: Mitigation of usercopy/swapgs barriers and __user pointer sanitization + spectre_v2: Mitigation of Enhanced / Automatic IBRS; IBPB: conditional; STIBP: disabled; PBRSB-eIBRS: Not affected; BHI: Not affected + srbds: Not affected + tsa: Not affected + tsx_async_abort: Not affected + vmscape: Not affected"
+            },
+            {
+              "path": "ci.hardware.Disk",
+              "value": "40GB"
+            },
+            {
+              "path": "ci.hardware.Memory",
+              "value": "8GB"
+            },
+            {
+              "path": "ci.hardware.Processor",
+              "value": "AMD EPYC (2 Cores)"
+            },
+            {
+              "path": "ci.identifier",
+              "value": "ci"
+            },
+            {
+              "path": "ci.software.Compiler",
+              "value": "GCC 14.2.0"
+            },
+            {
+              "path": "ci.software.File-System",
+              "value": "ext4"
+            },
+            {
+              "path": "ci.software.Kernel",
+              "value": "6.19.14 (x86_64)"
+            },
+            {
+              "path": "ci.software.OS",
+              "value": "Debian GNU/Linux 13"
+            },
+            {
+              "path": "ci.software.System Layer",
+              "value": "KVM"
+            },
+            {
+              "path": "ci.timestamp",
+              "value": "2026-07-17 01:07:38"
+            },
+            {
+              "path": "ci.user",
+              "value": "root"
+            }
+          ]
+        },
+        {
+          "source": "phoronix/result-file-to-json",
+          "sourceFile": "disk/pts_fio-seq-write--metadata.json",
+          "fields": [
+            {
+              "path": "ci.client_version",
+              "value": "10.8.4"
+            },
+            {
+              "path": "ci.data.compiler-configuration",
+              "value": "--build=x86_64-linux-gnu --disable-vtable-verify --disable-werror --enable-bootstrap --enable-cet --enable-checking=release --enable-clocale=gnu --enable-default-pie --enable-gnu-unique-object --enable-languages=c,ada,c++,go,d,fortran,objc,obj-c++,m2,rust --enable-libphobos-checking=release --enable-libstdcxx-backtrace --enable-libstdcxx-debug --enable-libstdcxx-time=yes --enable-link-serialization=3 --enable-multiarch --enable-multilib --enable-nls --enable-objc-gc=auto --enable-offload-defaulted --enable-offload-targets=nvptx-none=/build/reproducible-path/gcc-14-14.2.0/debian/tmp-nvptx/usr,amdgcn-amdhsa=/build/reproducible-path/gcc-14-14.2.0/debian/tmp-gcn/usr --enable-plugin --enable-shared --enable-threads=posix --host=x86_64-linux-gnu --program-prefix=x86_64-linux-gnu- --target=x86_64-linux-gnu --with-abi=m64 --with-arch-32=i686 --with-build-config=bootstrap-lto-lean --with-default-libstdcxx-abi=new --with-gcc-major-version-only --with-multilib-list=m32,m64,mx32 --with-target-system-zlib=auto --with-tune=generic --without-cuda-driver -v"
+            },
+            {
+              "path": "ci.data.cpu-microcode",
+              "value": "0x1000065"
+            },
+            {
+              "path": "ci.data.disk-details",
+              "value": "Block Size: 4096"
+            },
+            {
+              "path": "ci.data.disk-mount-options",
+              "value": "relatime,rw"
+            },
+            {
+              "path": "ci.data.kernel-extra-details",
+              "value": "Transparent Huge Pages: madvise"
+            },
+            {
+              "path": "ci.data.security",
+              "value": "gather_data_sampling: Not affected + ghostwrite: Not affected + indirect_target_selection: Not affected + itlb_multihit: Not affected + l1tf: Not affected + mds: Not affected + meltdown: Not affected + mmio_stale_data: Not affected + old_microcode: Not affected + reg_file_data_sampling: Not affected + retbleed: Not affected + spec_rstack_overflow: Vulnerable: Microcode no safe RET + spec_store_bypass: Mitigation of SSB disabled via prctl + spectre_v1: Mitigation of usercopy/swapgs barriers and __user pointer sanitization + spectre_v2: Mitigation of Enhanced / Automatic IBRS; IBPB: conditional; STIBP: disabled; PBRSB-eIBRS: Not affected; BHI: Not affected + srbds: Not affected + tsa: Not affected + tsx_async_abort: Not affected + vmscape: Not affected"
+            },
+            {
+              "path": "ci.hardware.Disk",
+              "value": "40GB"
+            },
+            {
+              "path": "ci.hardware.Memory",
+              "value": "8GB"
+            },
+            {
+              "path": "ci.hardware.Processor",
+              "value": "AMD EPYC (2 Cores)"
+            },
+            {
+              "path": "ci.identifier",
+              "value": "ci"
+            },
+            {
+              "path": "ci.software.Compiler",
+              "value": "GCC 14.2.0"
+            },
+            {
+              "path": "ci.software.File-System",
+              "value": "ext4"
+            },
+            {
+              "path": "ci.software.Kernel",
+              "value": "6.19.14 (x86_64)"
+            },
+            {
+              "path": "ci.software.OS",
+              "value": "Debian GNU/Linux 13"
+            },
+            {
+              "path": "ci.software.System Layer",
+              "value": "KVM"
+            },
+            {
+              "path": "ci.timestamp",
+              "value": "2026-07-17 01:10:49"
+            },
+            {
+              "path": "ci.user",
+              "value": "root"
+            }
+          ]
+        },
+        {
+          "source": "phoronix/result-file-to-json",
+          "sourceFile": "disk/pts_hardlink--metadata.json",
+          "fields": [
+            {
+              "path": "ci.client_version",
+              "value": "10.8.4"
+            },
+            {
+              "path": "ci.data.compiler-configuration",
+              "value": "--build=x86_64-linux-gnu --disable-vtable-verify --disable-werror --enable-bootstrap --enable-cet --enable-checking=release --enable-clocale=gnu --enable-default-pie --enable-gnu-unique-object --enable-languages=c,ada,c++,go,d,fortran,objc,obj-c++,m2,rust --enable-libphobos-checking=release --enable-libstdcxx-backtrace --enable-libstdcxx-debug --enable-libstdcxx-time=yes --enable-link-serialization=3 --enable-multiarch --enable-multilib --enable-nls --enable-objc-gc=auto --enable-offload-defaulted --enable-offload-targets=nvptx-none=/build/reproducible-path/gcc-14-14.2.0/debian/tmp-nvptx/usr,amdgcn-amdhsa=/build/reproducible-path/gcc-14-14.2.0/debian/tmp-gcn/usr --enable-plugin --enable-shared --enable-threads=posix --host=x86_64-linux-gnu --program-prefix=x86_64-linux-gnu- --target=x86_64-linux-gnu --with-abi=m64 --with-arch-32=i686 --with-build-config=bootstrap-lto-lean --with-default-libstdcxx-abi=new --with-gcc-major-version-only --with-multilib-list=m32,m64,mx32 --with-target-system-zlib=auto --with-tune=generic --without-cuda-driver -v"
+            },
+            {
+              "path": "ci.data.cpu-microcode",
+              "value": "0x1000065"
+            },
+            {
+              "path": "ci.data.disk-details",
+              "value": "Block Size: 4096"
+            },
+            {
+              "path": "ci.data.disk-mount-options",
+              "value": "relatime,rw"
+            },
+            {
+              "path": "ci.data.kernel-extra-details",
+              "value": "Transparent Huge Pages: madvise"
+            },
+            {
+              "path": "ci.data.security",
+              "value": "gather_data_sampling: Not affected + ghostwrite: Not affected + indirect_target_selection: Not affected + itlb_multihit: Not affected + l1tf: Not affected + mds: Not affected + meltdown: Not affected + mmio_stale_data: Not affected + old_microcode: Not affected + reg_file_data_sampling: Not affected + retbleed: Not affected + spec_rstack_overflow: Vulnerable: Microcode no safe RET + spec_store_bypass: Mitigation of SSB disabled via prctl + spectre_v1: Mitigation of usercopy/swapgs barriers and __user pointer sanitization + spectre_v2: Mitigation of Enhanced / Automatic IBRS; IBPB: conditional; STIBP: disabled; PBRSB-eIBRS: Not affected; BHI: Not affected + srbds: Not affected + tsa: Not affected + tsx_async_abort: Not affected + vmscape: Not affected"
+            },
+            {
+              "path": "ci.hardware.Disk",
+              "value": "40GB"
+            },
+            {
+              "path": "ci.hardware.Memory",
+              "value": "8GB"
+            },
+            {
+              "path": "ci.hardware.Processor",
+              "value": "AMD EPYC (2 Cores)"
+            },
+            {
+              "path": "ci.identifier",
+              "value": "ci"
+            },
+            {
+              "path": "ci.software.Compiler",
+              "value": "GCC 14.2.0"
+            },
+            {
+              "path": "ci.software.File-System",
+              "value": "ext4"
+            },
+            {
+              "path": "ci.software.Kernel",
+              "value": "6.19.14 (x86_64)"
+            },
+            {
+              "path": "ci.software.OS",
+              "value": "Debian GNU/Linux 13"
+            },
+            {
+              "path": "ci.software.System Layer",
+              "value": "KVM"
+            },
+            {
+              "path": "ci.timestamp",
+              "value": "2026-07-17 01:20:57"
+            },
+            {
+              "path": "ci.user",
+              "value": "root"
+            }
+          ]
+        },
+        {
+          "source": "phoronix/result-file-to-json",
+          "sourceFile": "memory/pts_stream--metadata.json",
+          "fields": [
+            {
+              "path": "ci.client_version",
+              "value": "10.8.4"
+            },
+            {
+              "path": "ci.data.compiler-configuration",
+              "value": "--build=x86_64-linux-gnu --disable-vtable-verify --disable-werror --enable-bootstrap --enable-cet --enable-checking=release --enable-clocale=gnu --enable-default-pie --enable-gnu-unique-object --enable-languages=c,ada,c++,go,d,fortran,objc,obj-c++,m2,rust --enable-libphobos-checking=release --enable-libstdcxx-backtrace --enable-libstdcxx-debug --enable-libstdcxx-time=yes --enable-link-serialization=3 --enable-multiarch --enable-multilib --enable-nls --enable-objc-gc=auto --enable-offload-defaulted --enable-offload-targets=nvptx-none=/build/reproducible-path/gcc-14-14.2.0/debian/tmp-nvptx/usr,amdgcn-amdhsa=/build/reproducible-path/gcc-14-14.2.0/debian/tmp-gcn/usr --enable-plugin --enable-shared --enable-threads=posix --host=x86_64-linux-gnu --program-prefix=x86_64-linux-gnu- --target=x86_64-linux-gnu --with-abi=m64 --with-arch-32=i686 --with-build-config=bootstrap-lto-lean --with-default-libstdcxx-abi=new --with-gcc-major-version-only --with-multilib-list=m32,m64,mx32 --with-target-system-zlib=auto --with-tune=generic --without-cuda-driver -v"
+            },
+            {
+              "path": "ci.data.cpu-microcode",
+              "value": "0x1000065"
+            },
+            {
+              "path": "ci.data.environment-variables",
+              "value": "CFLAGS_OVERRIDE=\"-O3 -march=native -DSTREAM_ARRAY_SIZE=150000000\""
+            },
+            {
+              "path": "ci.data.kernel-extra-details",
+              "value": "Transparent Huge Pages: madvise"
+            },
+            {
+              "path": "ci.data.security",
+              "value": "gather_data_sampling: Not affected + ghostwrite: Not affected + indirect_target_selection: Not affected + itlb_multihit: Not affected + l1tf: Not affected + mds: Not affected + meltdown: Not affected + mmio_stale_data: Not affected + old_microcode: Not affected + reg_file_data_sampling: Not affected + retbleed: Not affected + spec_rstack_overflow: Vulnerable: Microcode no safe RET + spec_store_bypass: Mitigation of SSB disabled via prctl + spectre_v1: Mitigation of usercopy/swapgs barriers and __user pointer sanitization + spectre_v2: Mitigation of Enhanced / Automatic IBRS; IBPB: conditional; STIBP: disabled; PBRSB-eIBRS: Not affected; BHI: Not affected + srbds: Not affected + tsa: Not affected + tsx_async_abort: Not affected + vmscape: Not affected"
+            },
+            {
+              "path": "ci.hardware.Disk",
+              "value": "40GB"
+            },
+            {
+              "path": "ci.hardware.Memory",
+              "value": "8GB"
+            },
+            {
+              "path": "ci.hardware.Processor",
+              "value": "AMD EPYC (2 Cores)"
+            },
+            {
+              "path": "ci.identifier",
+              "value": "ci"
+            },
+            {
+              "path": "ci.software.Compiler",
+              "value": "GCC 14.2.0"
+            },
+            {
+              "path": "ci.software.File-System",
+              "value": "ext4"
+            },
+            {
+              "path": "ci.software.Kernel",
+              "value": "6.19.14 (x86_64)"
+            },
+            {
+              "path": "ci.software.OS",
+              "value": "Debian GNU/Linux 13"
+            },
+            {
+              "path": "ci.software.System Layer",
+              "value": "KVM"
+            },
+            {
+              "path": "ci.timestamp",
+              "value": "2026-07-17 01:06:54"
+            },
+            {
+              "path": "ci.user",
+              "value": "root"
+            }
+          ]
+        },
+        {
+          "source": "phoronix/result-file-to-json",
+          "sourceFile": "network/pts_network-loopback--metadata.json",
+          "fields": [
+            {
+              "path": "ci.client_version",
+              "value": "10.8.4"
+            },
+            {
+              "path": "ci.data.cpu-microcode",
+              "value": "0x1000065"
+            },
+            {
+              "path": "ci.data.kernel-extra-details",
+              "value": "Transparent Huge Pages: madvise"
+            },
+            {
+              "path": "ci.data.security",
+              "value": "gather_data_sampling: Not affected + ghostwrite: Not affected + indirect_target_selection: Not affected + itlb_multihit: Not affected + l1tf: Not affected + mds: Not affected + meltdown: Not affected + mmio_stale_data: Not affected + old_microcode: Not affected + reg_file_data_sampling: Not affected + retbleed: Not affected + spec_rstack_overflow: Vulnerable: Microcode no safe RET + spec_store_bypass: Mitigation of SSB disabled via prctl + spectre_v1: Mitigation of usercopy/swapgs barriers and __user pointer sanitization + spectre_v2: Mitigation of Enhanced / Automatic IBRS; IBPB: conditional; STIBP: disabled; PBRSB-eIBRS: Not affected; BHI: Not affected + srbds: Not affected + tsa: Not affected + tsx_async_abort: Not affected + vmscape: Not affected"
+            },
+            {
+              "path": "ci.hardware.Disk",
+              "value": "40GB"
+            },
+            {
+              "path": "ci.hardware.Memory",
+              "value": "8GB"
+            },
+            {
+              "path": "ci.hardware.Processor",
+              "value": "AMD EPYC (2 Cores)"
+            },
+            {
+              "path": "ci.identifier",
+              "value": "ci"
+            },
+            {
+              "path": "ci.software.Compiler",
+              "value": "GCC 14.2.0"
+            },
+            {
+              "path": "ci.software.File-System",
+              "value": "ext4"
+            },
+            {
+              "path": "ci.software.Kernel",
+              "value": "6.19.14 (x86_64)"
+            },
+            {
+              "path": "ci.software.OS",
+              "value": "Debian GNU/Linux 13"
+            },
+            {
+              "path": "ci.software.System Layer",
+              "value": "KVM"
+            },
+            {
+              "path": "ci.timestamp",
+              "value": "2026-07-17 01:07:23"
+            },
+            {
+              "path": "ci.user",
+              "value": "root"
+            }
+          ]
+        },
+        {
+          "source": "phoronix/result-file-to-json",
+          "sourceFile": "realworld-better-auth/pts_realworld-better-auth--metadata.json",
+          "fields": [
+            {
+              "path": "ci.client_version",
+              "value": "10.8.4"
+            },
+            {
+              "path": "ci.data.cpu-microcode",
+              "value": "0x1000065"
+            },
+            {
+              "path": "ci.data.kernel-extra-details",
+              "value": "Transparent Huge Pages: madvise"
+            },
+            {
+              "path": "ci.data.security",
+              "value": "gather_data_sampling: Not affected + ghostwrite: Not affected + indirect_target_selection: Not affected + itlb_multihit: Not affected + l1tf: Not affected + mds: Not affected + meltdown: Not affected + mmio_stale_data: Not affected + old_microcode: Not affected + reg_file_data_sampling: Not affected + retbleed: Not affected + spec_rstack_overflow: Vulnerable: Microcode no safe RET + spec_store_bypass: Mitigation of SSB disabled via prctl + spectre_v1: Mitigation of usercopy/swapgs barriers and __user pointer sanitization + spectre_v2: Mitigation of Enhanced / Automatic IBRS; IBPB: conditional; STIBP: disabled; PBRSB-eIBRS: Not affected; BHI: Not affected + srbds: Not affected + tsa: Not affected + tsx_async_abort: Not affected + vmscape: Not affected"
+            },
+            {
+              "path": "ci.hardware.Disk",
+              "value": "40GB"
+            },
+            {
+              "path": "ci.hardware.Memory",
+              "value": "8GB"
+            },
+            {
+              "path": "ci.hardware.Processor",
+              "value": "AMD EPYC (2 Cores)"
+            },
+            {
+              "path": "ci.identifier",
+              "value": "ci"
+            },
+            {
+              "path": "ci.software.Compiler",
+              "value": "GCC 14.2.0"
+            },
+            {
+              "path": "ci.software.File-System",
+              "value": "ext4"
+            },
+            {
+              "path": "ci.software.Kernel",
+              "value": "6.19.14 (x86_64)"
+            },
+            {
+              "path": "ci.software.OS",
+              "value": "Debian GNU/Linux 13"
+            },
+            {
+              "path": "ci.software.System Layer",
+              "value": "KVM"
+            },
+            {
+              "path": "ci.timestamp",
+              "value": "2026-07-17 01:07:38"
+            },
+            {
+              "path": "ci.user",
+              "value": "root"
+            }
+          ]
+        },
+        {
+          "source": "phoronix/result-file-to-json",
+          "sourceFile": "realworld-mastra/pts_realworld-mastra--metadata.json",
+          "fields": [
+            {
+              "path": "ci.client_version",
+              "value": "10.8.4"
+            },
+            {
+              "path": "ci.data.cpu-microcode",
+              "value": "0x1000065"
+            },
+            {
+              "path": "ci.data.kernel-extra-details",
+              "value": "Transparent Huge Pages: madvise"
+            },
+            {
+              "path": "ci.data.security",
+              "value": "gather_data_sampling: Not affected + ghostwrite: Not affected + indirect_target_selection: Not affected + itlb_multihit: Not affected + l1tf: Not affected + mds: Not affected + meltdown: Not affected + mmio_stale_data: Not affected + old_microcode: Not affected + reg_file_data_sampling: Not affected + retbleed: Not affected + spec_rstack_overflow: Vulnerable: Microcode no safe RET + spec_store_bypass: Mitigation of SSB disabled via prctl + spectre_v1: Mitigation of usercopy/swapgs barriers and __user pointer sanitization + spectre_v2: Mitigation of Enhanced / Automatic IBRS; IBPB: conditional; STIBP: disabled; PBRSB-eIBRS: Not affected; BHI: Not affected + srbds: Not affected + tsa: Not affected + tsx_async_abort: Not affected + vmscape: Not affected"
+            },
+            {
+              "path": "ci.hardware.Disk",
+              "value": "40GB"
+            },
+            {
+              "path": "ci.hardware.Memory",
+              "value": "8GB"
+            },
+            {
+              "path": "ci.hardware.Processor",
+              "value": "AMD EPYC (2 Cores)"
+            },
+            {
+              "path": "ci.identifier",
+              "value": "ci"
+            },
+            {
+              "path": "ci.software.Compiler",
+              "value": "GCC 14.2.0"
+            },
+            {
+              "path": "ci.software.File-System",
+              "value": "ext4"
+            },
+            {
+              "path": "ci.software.Kernel",
+              "value": "6.19.14 (x86_64)"
+            },
+            {
+              "path": "ci.software.OS",
+              "value": "Debian GNU/Linux 13"
+            },
+            {
+              "path": "ci.software.System Layer",
+              "value": "KVM"
+            },
+            {
+              "path": "ci.timestamp",
+              "value": "2026-07-17 01:08:22"
+            },
+            {
+              "path": "ci.user",
+              "value": "root"
+            }
+          ]
+        },
+        {
+          "source": "phoronix/result-file-to-json",
+          "sourceFile": "system/pts_git--metadata.json",
+          "fields": [
+            {
+              "path": "ci.client_version",
+              "value": "10.8.4"
+            },
+            {
+              "path": "ci.data.cpu-microcode",
+              "value": "0x1000065"
+            },
+            {
+              "path": "ci.data.kernel-extra-details",
+              "value": "Transparent Huge Pages: madvise"
+            },
+            {
+              "path": "ci.data.security",
+              "value": "gather_data_sampling: Not affected + ghostwrite: Not affected + indirect_target_selection: Not affected + itlb_multihit: Not affected + l1tf: Not affected + mds: Not affected + meltdown: Not affected + mmio_stale_data: Not affected + old_microcode: Not affected + reg_file_data_sampling: Not affected + retbleed: Not affected + spec_rstack_overflow: Vulnerable: Microcode no safe RET + spec_store_bypass: Mitigation of SSB disabled via prctl + spectre_v1: Mitigation of usercopy/swapgs barriers and __user pointer sanitization + spectre_v2: Mitigation of Enhanced / Automatic IBRS; IBPB: conditional; STIBP: disabled; PBRSB-eIBRS: Not affected; BHI: Not affected + srbds: Not affected + tsa: Not affected + tsx_async_abort: Not affected + vmscape: Not affected"
+            },
+            {
+              "path": "ci.hardware.Disk",
+              "value": "40GB"
+            },
+            {
+              "path": "ci.hardware.Memory",
+              "value": "8GB"
+            },
+            {
+              "path": "ci.hardware.Processor",
+              "value": "AMD EPYC (2 Cores)"
+            },
+            {
+              "path": "ci.identifier",
+              "value": "ci"
+            },
+            {
+              "path": "ci.software.Compiler",
+              "value": "GCC 14.2.0"
+            },
+            {
+              "path": "ci.software.File-System",
+              "value": "ext4"
+            },
+            {
+              "path": "ci.software.Kernel",
+              "value": "6.19.14 (x86_64)"
+            },
+            {
+              "path": "ci.software.OS",
+              "value": "Debian GNU/Linux 13"
+            },
+            {
+              "path": "ci.software.System Layer",
+              "value": "KVM"
+            },
+            {
+              "path": "ci.timestamp",
+              "value": "2026-07-17 01:09:43"
+            },
+            {
+              "path": "ci.user",
+              "value": "root"
+            }
+          ]
+        },
+        {
+          "source": "phoronix/result-file-to-json",
+          "sourceFile": "system/pts_pgbench-read-only--metadata.json",
+          "fields": [
+            {
+              "path": "ci.client_version",
+              "value": "10.8.4"
+            },
+            {
+              "path": "ci.data.compiler-configuration",
+              "value": "--build=x86_64-linux-gnu --disable-vtable-verify --disable-werror --enable-bootstrap --enable-cet --enable-checking=release --enable-clocale=gnu --enable-default-pie --enable-gnu-unique-object --enable-languages=c,ada,c++,go,d,fortran,objc,obj-c++,m2,rust --enable-libphobos-checking=release --enable-libstdcxx-backtrace --enable-libstdcxx-debug --enable-libstdcxx-time=yes --enable-link-serialization=3 --enable-multiarch --enable-multilib --enable-nls --enable-objc-gc=auto --enable-offload-defaulted --enable-offload-targets=nvptx-none=/build/reproducible-path/gcc-14-14.2.0/debian/tmp-nvptx/usr,amdgcn-amdhsa=/build/reproducible-path/gcc-14-14.2.0/debian/tmp-gcn/usr --enable-plugin --enable-shared --enable-threads=posix --host=x86_64-linux-gnu --program-prefix=x86_64-linux-gnu- --target=x86_64-linux-gnu --with-abi=m64 --with-arch-32=i686 --with-build-config=bootstrap-lto-lean --with-default-libstdcxx-abi=new --with-gcc-major-version-only --with-multilib-list=m32,m64,mx32 --with-target-system-zlib=auto --with-tune=generic --without-cuda-driver -v"
+            },
+            {
+              "path": "ci.data.cpu-microcode",
+              "value": "0x1000065"
+            },
+            {
+              "path": "ci.data.kernel-extra-details",
+              "value": "Transparent Huge Pages: madvise"
+            },
+            {
+              "path": "ci.data.security",
+              "value": "gather_data_sampling: Not affected + ghostwrite: Not affected + indirect_target_selection: Not affected + itlb_multihit: Not affected + l1tf: Not affected + mds: Not affected + meltdown: Not affected + mmio_stale_data: Not affected + old_microcode: Not affected + reg_file_data_sampling: Not affected + retbleed: Not affected + spec_rstack_overflow: Vulnerable: Microcode no safe RET + spec_store_bypass: Mitigation of SSB disabled via prctl + spectre_v1: Mitigation of usercopy/swapgs barriers and __user pointer sanitization + spectre_v2: Mitigation of Enhanced / Automatic IBRS; IBPB: conditional; STIBP: disabled; PBRSB-eIBRS: Not affected; BHI: Not affected + srbds: Not affected + tsa: Not affected + tsx_async_abort: Not affected + vmscape: Not affected"
+            },
+            {
+              "path": "ci.hardware.Disk",
+              "value": "40GB"
+            },
+            {
+              "path": "ci.hardware.Memory",
+              "value": "8GB"
+            },
+            {
+              "path": "ci.hardware.Processor",
+              "value": "AMD EPYC (2 Cores)"
+            },
+            {
+              "path": "ci.identifier",
+              "value": "ci"
+            },
+            {
+              "path": "ci.software.Compiler",
+              "value": "GCC 14.2.0"
+            },
+            {
+              "path": "ci.software.File-System",
+              "value": "ext4"
+            },
+            {
+              "path": "ci.software.Kernel",
+              "value": "6.19.14 (x86_64)"
+            },
+            {
+              "path": "ci.software.OS",
+              "value": "Debian GNU/Linux 13"
+            },
+            {
+              "path": "ci.software.System Layer",
+              "value": "KVM"
+            },
+            {
+              "path": "ci.timestamp",
+              "value": "2026-07-17 01:08:30"
+            },
+            {
+              "path": "ci.user",
+              "value": "root"
+            }
+          ]
+        },
+        {
+          "source": "phoronix/result-file-to-json",
+          "sourceFile": "system/pts_pgbench-read-write--metadata.json",
+          "fields": [
+            {
+              "path": "ci.client_version",
+              "value": "10.8.4"
+            },
+            {
+              "path": "ci.data.compiler-configuration",
+              "value": "--build=x86_64-linux-gnu --disable-vtable-verify --disable-werror --enable-bootstrap --enable-cet --enable-checking=release --enable-clocale=gnu --enable-default-pie --enable-gnu-unique-object --enable-languages=c,ada,c++,go,d,fortran,objc,obj-c++,m2,rust --enable-libphobos-checking=release --enable-libstdcxx-backtrace --enable-libstdcxx-debug --enable-libstdcxx-time=yes --enable-link-serialization=3 --enable-multiarch --enable-multilib --enable-nls --enable-objc-gc=auto --enable-offload-defaulted --enable-offload-targets=nvptx-none=/build/reproducible-path/gcc-14-14.2.0/debian/tmp-nvptx/usr,amdgcn-amdhsa=/build/reproducible-path/gcc-14-14.2.0/debian/tmp-gcn/usr --enable-plugin --enable-shared --enable-threads=posix --host=x86_64-linux-gnu --program-prefix=x86_64-linux-gnu- --target=x86_64-linux-gnu --with-abi=m64 --with-arch-32=i686 --with-build-config=bootstrap-lto-lean --with-default-libstdcxx-abi=new --with-gcc-major-version-only --with-multilib-list=m32,m64,mx32 --with-target-system-zlib=auto --with-tune=generic --without-cuda-driver -v"
+            },
+            {
+              "path": "ci.data.cpu-microcode",
+              "value": "0x1000065"
+            },
+            {
+              "path": "ci.data.kernel-extra-details",
+              "value": "Transparent Huge Pages: madvise"
+            },
+            {
+              "path": "ci.data.security",
+              "value": "gather_data_sampling: Not affected + ghostwrite: Not affected + indirect_target_selection: Not affected + itlb_multihit: Not affected + l1tf: Not affected + mds: Not affected + meltdown: Not affected + mmio_stale_data: Not affected + old_microcode: Not affected + reg_file_data_sampling: Not affected + retbleed: Not affected + spec_rstack_overflow: Vulnerable: Microcode no safe RET + spec_store_bypass: Mitigation of SSB disabled via prctl + spectre_v1: Mitigation of usercopy/swapgs barriers and __user pointer sanitization + spectre_v2: Mitigation of Enhanced / Automatic IBRS; IBPB: conditional; STIBP: disabled; PBRSB-eIBRS: Not affected; BHI: Not affected + srbds: Not affected + tsa: Not affected + tsx_async_abort: Not affected + vmscape: Not affected"
+            },
+            {
+              "path": "ci.hardware.Disk",
+              "value": "40GB"
+            },
+            {
+              "path": "ci.hardware.Memory",
+              "value": "8GB"
+            },
+            {
+              "path": "ci.hardware.Processor",
+              "value": "AMD EPYC (2 Cores)"
+            },
+            {
+              "path": "ci.identifier",
+              "value": "ci"
+            },
+            {
+              "path": "ci.software.Compiler",
+              "value": "GCC 14.2.0"
+            },
+            {
+              "path": "ci.software.File-System",
+              "value": "ext4"
+            },
+            {
+              "path": "ci.software.Kernel",
+              "value": "6.19.14 (x86_64)"
+            },
+            {
+              "path": "ci.software.OS",
+              "value": "Debian GNU/Linux 13"
+            },
+            {
+              "path": "ci.software.System Layer",
+              "value": "KVM"
+            },
+            {
+              "path": "ci.timestamp",
+              "value": "2026-07-17 01:09:08"
+            },
+            {
+              "path": "ci.user",
+              "value": "root"
+            }
+          ]
+        },
+        {
+          "source": "phoronix/result-file-to-json",
+          "sourceFile": "system/pts_pybench--metadata.json",
+          "fields": [
+            {
+              "path": "ci.client_version",
+              "value": "10.8.4"
+            },
+            {
+              "path": "ci.data.cpu-microcode",
+              "value": "0x1000065"
+            },
+            {
+              "path": "ci.data.kernel-extra-details",
+              "value": "Transparent Huge Pages: madvise"
+            },
+            {
+              "path": "ci.data.python",
+              "value": "mise ERROR python is not a valid shim. This likely means you uninstalled a tool and the shim does not point anything. Run `mise use ` reinstall the tool.mise ERROR : 2026.5.16 linux-x64 (2026-05-28)mise ERROR Run with--verbose or MISE_VERBOSE=1 for more information + mise ERROR python3 is not a valid shim. This likely means you uninstalled a tool and the shim does not point anything. Run `mise use ` reinstall the tool.mise ERROR : 2026.5.16 linux-x64 (2026-05-28)mise ERROR Run with--verbose or MISE_VERBOSE=1 for more information"
+            },
+            {
+              "path": "ci.data.security",
+              "value": "gather_data_sampling: Not affected + ghostwrite: Not affected + indirect_target_selection: Not affected + itlb_multihit: Not affected + l1tf: Not affected + mds: Not affected + meltdown: Not affected + mmio_stale_data: Not affected + old_microcode: Not affected + reg_file_data_sampling: Not affected + retbleed: Not affected + spec_rstack_overflow: Vulnerable: Microcode no safe RET + spec_store_bypass: Mitigation of SSB disabled via prctl + spectre_v1: Mitigation of usercopy/swapgs barriers and __user pointer sanitization + spectre_v2: Mitigation of Enhanced / Automatic IBRS; IBPB: conditional; STIBP: disabled; PBRSB-eIBRS: Not affected; BHI: Not affected + srbds: Not affected + tsa: Not affected + tsx_async_abort: Not affected + vmscape: Not affected"
+            },
+            {
+              "path": "ci.hardware.Disk",
+              "value": "40GB"
+            },
+            {
+              "path": "ci.hardware.Memory",
+              "value": "8GB"
+            },
+            {
+              "path": "ci.hardware.Processor",
+              "value": "AMD EPYC (2 Cores)"
+            },
+            {
+              "path": "ci.identifier",
+              "value": "ci"
+            },
+            {
+              "path": "ci.software.Compiler",
+              "value": "GCC 14.2.0"
+            },
+            {
+              "path": "ci.software.File-System",
+              "value": "ext4"
+            },
+            {
+              "path": "ci.software.Kernel",
+              "value": "6.19.14 (x86_64)"
+            },
+            {
+              "path": "ci.software.OS",
+              "value": "Debian GNU/Linux 13"
+            },
+            {
+              "path": "ci.software.System Layer",
+              "value": "KVM"
+            },
+            {
+              "path": "ci.timestamp",
+              "value": "2026-07-17 01:06:55"
+            },
+            {
+              "path": "ci.user",
+              "value": "root"
+            }
+          ]
+        },
+        {
+          "source": "phoronix/result-file-to-json",
+          "sourceFile": "system/pts_sqlite-speedtest--metadata.json",
+          "fields": [
+            {
+              "path": "ci.client_version",
+              "value": "10.8.4"
+            },
+            {
+              "path": "ci.data.compiler-configuration",
+              "value": "--build=x86_64-linux-gnu --disable-vtable-verify --disable-werror --enable-bootstrap --enable-cet --enable-checking=release --enable-clocale=gnu --enable-default-pie --enable-gnu-unique-object --enable-languages=c,ada,c++,go,d,fortran,objc,obj-c++,m2,rust --enable-libphobos-checking=release --enable-libstdcxx-backtrace --enable-libstdcxx-debug --enable-libstdcxx-time=yes --enable-link-serialization=3 --enable-multiarch --enable-multilib --enable-nls --enable-objc-gc=auto --enable-offload-defaulted --enable-offload-targets=nvptx-none=/build/reproducible-path/gcc-14-14.2.0/debian/tmp-nvptx/usr,amdgcn-amdhsa=/build/reproducible-path/gcc-14-14.2.0/debian/tmp-gcn/usr --enable-plugin --enable-shared --enable-threads=posix --host=x86_64-linux-gnu --program-prefix=x86_64-linux-gnu- --target=x86_64-linux-gnu --with-abi=m64 --with-arch-32=i686 --with-build-config=bootstrap-lto-lean --with-default-libstdcxx-abi=new --with-gcc-major-version-only --with-multilib-list=m32,m64,mx32 --with-target-system-zlib=auto --with-tune=generic --without-cuda-driver -v"
+            },
+            {
+              "path": "ci.data.cpu-microcode",
+              "value": "0x1000065"
+            },
+            {
+              "path": "ci.data.kernel-extra-details",
+              "value": "Transparent Huge Pages: madvise"
+            },
+            {
+              "path": "ci.data.security",
+              "value": "gather_data_sampling: Not affected + ghostwrite: Not affected + indirect_target_selection: Not affected + itlb_multihit: Not affected + l1tf: Not affected + mds: Not affected + meltdown: Not affected + mmio_stale_data: Not affected + old_microcode: Not affected + reg_file_data_sampling: Not affected + retbleed: Not affected + spec_rstack_overflow: Vulnerable: Microcode no safe RET + spec_store_bypass: Mitigation of SSB disabled via prctl + spectre_v1: Mitigation of usercopy/swapgs barriers and __user pointer sanitization + spectre_v2: Mitigation of Enhanced / Automatic IBRS; IBPB: conditional; STIBP: disabled; PBRSB-eIBRS: Not affected; BHI: Not affected + srbds: Not affected + tsa: Not affected + tsx_async_abort: Not affected + vmscape: Not affected"
+            },
+            {
+              "path": "ci.hardware.Disk",
+              "value": "40GB"
+            },
+            {
+              "path": "ci.hardware.Memory",
+              "value": "8GB"
+            },
+            {
+              "path": "ci.hardware.Processor",
+              "value": "AMD EPYC (2 Cores)"
+            },
+            {
+              "path": "ci.identifier",
+              "value": "ci"
+            },
+            {
+              "path": "ci.software.Compiler",
+              "value": "GCC 14.2.0"
+            },
+            {
+              "path": "ci.software.File-System",
+              "value": "ext4"
+            },
+            {
+              "path": "ci.software.Kernel",
+              "value": "6.19.14 (x86_64)"
+            },
+            {
+              "path": "ci.software.OS",
+              "value": "Debian GNU/Linux 13"
+            },
+            {
+              "path": "ci.software.System Layer",
+              "value": "KVM"
+            },
+            {
+              "path": "ci.timestamp",
+              "value": "2026-07-17 01:07:11"
+            },
+            {
+              "path": "ci.user",
+              "value": "root"
+            }
+          ]
+        },
+        {
+          "source": "mise/system-provider",
+          "sourceFile": "system/system-provider.json",
+          "fields": [
+            {
+              "path": "asn",
+              "value": "AS396356"
+            },
+            {
+              "path": "asn_source",
+              "value": "cymru"
+            },
+            {
+              "path": "bios_vendor",
+              "value": ""
+            },
+            {
+              "path": "city",
+              "value": "Los Angeles"
+            },
+            {
+              "path": "cores",
+              "value": "2"
+            },
+            {
+              "path": "country",
+              "value": "US"
+            },
+            {
+              "path": "cpu_model",
+              "value": "AMD EPYC"
+            },
+            {
+              "path": "geo_source",
+              "value": "ipinfo"
+            },
+            {
+              "path": "kernel",
+              "value": "6.19.14"
+            },
+            {
+              "path": "loc",
+              "value": "34.0522,-118.2437"
+            },
+            {
+              "path": "manufacturer",
+              "value": ""
+            },
+            {
+              "path": "org",
+              "value": "AS396356 Latitude.sh"
+            },
+            {
+              "path": "org_name",
+              "value": "Latitude.sh"
+            },
+            {
+              "path": "prefix",
+              "value": "67.213.124.0/24"
+            },
+            {
+              "path": "product_name",
+              "value": ""
+            },
+            {
+              "path": "public_ip",
+              "value": "67.213.124.39"
+            },
+            {
+              "path": "ram",
+              "value": "7.8Gi"
+            },
+            {
+              "path": "region",
+              "value": "California"
+            },
+            {
+              "path": "reverse_dns",
+              "value": ""
+            },
+            {
+              "path": "schema_version",
+              "value": "1.0"
+            },
+            {
+              "path": "timezone",
+              "value": "America/Los_Angeles"
+            },
+            {
+              "path": "virtualization",
+              "value": "kvm"
+            }
+          ]
+        }
+      ],
+      "metrics": [
+        {
+          "metricId": "c_ray_resolution_1080p_rays_per_pixel_16",
+          "samples": [200.073, 199.4],
+          "aggregates": {
+            "p50": 199.7365,
+            "p95": 200.03935,
+            "mean": 199.7365,
+            "stdev": 0.47588286373854777,
+            "min": 199.4,
+            "max": 200.073,
+            "n": 2
+          },
+          "sourceFile": "cpu-generic/pts_c-ray.xml",
+          "appVersion": "2.0",
+          "arguments": "-s 1920x1080 -r 16"
+        },
+        {
+          "metricId": "c_ray_resolution_4k_rays_per_pixel_16",
+          "samples": [798.147, 800.445],
+          "aggregates": {
+            "p50": 799.296,
+            "p95": 800.3301,
+            "mean": 799.296,
+            "stdev": 1.6249313831666876,
+            "min": 798.147,
+            "max": 800.445,
+            "n": 2
+          },
+          "sourceFile": "cpu-generic/pts_c-ray.xml",
+          "appVersion": "2.0",
+          "arguments": "-s 3840x2160 -r 16"
+        },
+        {
+          "metricId": "c_ray_resolution_5k_rays_per_pixel_16",
+          "samples": [1418.293, 1425.799],
+          "aggregates": {
+            "p50": 1422.0459999999998,
+            "p95": 1425.4237,
+            "mean": 1422.0459999999998,
+            "stdev": 5.307543499586367,
+            "min": 1418.293,
+            "max": 1425.799,
+            "n": 2
+          },
+          "sourceFile": "cpu-generic/pts_c-ray.xml",
+          "appVersion": "2.0",
+          "arguments": "-s 5120x2880 -r 16"
+        },
+        {
+          "metricId": "compress_zstd_compression_level_12_compression_speed",
+          "samples": [99.6, 99.3],
+          "aggregates": {
+            "p50": 99.44999999999999,
+            "p95": 99.585,
+            "mean": 99.44999999999999,
+            "stdev": 0.21213203435596728,
+            "min": 99.3,
+            "max": 99.6,
+            "n": 2
+          },
+          "sourceFile": "cpu-generic/pts_compress-zstd.xml",
+          "appVersion": "1.5.4",
+          "arguments": "-b12"
+        },
+        {
+          "metricId": "compress_zstd_compression_level_12_decompression_speed",
+          "samples": [2298.9, 2308.8],
+          "aggregates": {
+            "p50": 2303.8500000000004,
+            "p95": 2308.3050000000003,
+            "mean": 2303.8500000000004,
+            "stdev": 7.000357133746724,
+            "min": 2298.9,
+            "max": 2308.8,
+            "n": 2
+          },
+          "sourceFile": "cpu-generic/pts_compress-zstd.xml",
+          "appVersion": "1.5.4",
+          "arguments": "-b12"
+        },
+        {
+          "metricId": "compress_zstd_compression_level_19_compression_speed",
+          "samples": [8.14, 8.04],
+          "aggregates": {
+            "p50": 8.09,
+            "p95": 8.135,
+            "mean": 8.09,
+            "stdev": 0.07071067811865576,
+            "min": 8.04,
+            "max": 8.14,
+            "n": 2
+          },
+          "sourceFile": "cpu-generic/pts_compress-zstd.xml",
+          "appVersion": "1.5.4",
+          "arguments": "-b19"
+        },
+        {
+          "metricId": "compress_zstd_compression_level_19_decompression_speed",
+          "samples": [1914.5, 1917.6],
+          "aggregates": {
+            "p50": 1916.05,
+            "p95": 1917.445,
+            "mean": 1916.05,
+            "stdev": 2.192031021678233,
+            "min": 1914.5,
+            "max": 1917.6,
+            "n": 2
+          },
+          "sourceFile": "cpu-generic/pts_compress-zstd.xml",
+          "appVersion": "1.5.4",
+          "arguments": "-b19"
+        },
+        {
+          "metricId": "compress_zstd_compression_level_19_long_mode_compression_speed",
+          "samples": [7.03, 7.12],
+          "aggregates": {
+            "p50": 7.075,
+            "p95": 7.1155,
+            "mean": 7.075,
+            "stdev": 0.06363961030678918,
+            "min": 7.03,
+            "max": 7.12,
+            "n": 2
+          },
+          "sourceFile": "cpu-generic/pts_compress-zstd.xml",
+          "appVersion": "1.5.4",
+          "arguments": "-b19 --long"
+        },
+        {
+          "metricId": "compress_zstd_compression_level_19_long_mode_decompression_speed",
+          "samples": [1844.7, 1839.6],
+          "aggregates": {
+            "p50": 1842.15,
+            "p95": 1844.445,
+            "mean": 1842.15,
+            "stdev": 3.6062445840514084,
+            "min": 1839.6,
+            "max": 1844.7,
+            "n": 2
+          },
+          "sourceFile": "cpu-generic/pts_compress-zstd.xml",
+          "appVersion": "1.5.4",
+          "arguments": "-b19 --long"
+        },
+        {
+          "metricId": "compress_zstd_compression_level_3_compression_speed",
+          "samples": [781.2, 782.3],
+          "aggregates": {
+            "p50": 781.75,
+            "p95": 782.245,
+            "mean": 781.75,
+            "stdev": 0.777817459305138,
+            "min": 781.2,
+            "max": 782.3,
+            "n": 2
+          },
+          "sourceFile": "cpu-generic/pts_compress-zstd.xml",
+          "appVersion": "1.5.4",
+          "arguments": "-b3"
+        },
+        {
+          "metricId": "compress_zstd_compression_level_3_decompression_speed",
+          "samples": [2112.1, 2114.5],
+          "aggregates": {
+            "p50": 2113.3,
+            "p95": 2114.38,
+            "mean": 2113.3,
+            "stdev": 1.6970562748476177,
+            "min": 2112.1,
+            "max": 2114.5,
+            "n": 2
+          },
+          "sourceFile": "cpu-generic/pts_compress-zstd.xml",
+          "appVersion": "1.5.4",
+          "arguments": "-b3"
+        },
+        {
+          "metricId": "compress_zstd_compression_level_3_long_mode_compression_speed",
+          "samples": [534.9, 536.5],
+          "aggregates": {
+            "p50": 535.7,
+            "p95": 536.42,
+            "mean": 535.7,
+            "stdev": 1.1313708498984518,
+            "min": 534.9,
+            "max": 536.5,
+            "n": 2
+          },
+          "sourceFile": "cpu-generic/pts_compress-zstd.xml",
+          "appVersion": "1.5.4",
+          "arguments": "-b3 --long"
+        },
+        {
+          "metricId": "compress_zstd_compression_level_3_long_mode_decompression_speed",
+          "samples": [2161, 2171.2],
+          "aggregates": {
+            "p50": 2166.1,
+            "p95": 2170.6899999999996,
+            "mean": 2166.1,
+            "stdev": 7.212489168102656,
+            "min": 2161,
+            "max": 2171.2,
+            "n": 2
+          },
+          "sourceFile": "cpu-generic/pts_compress-zstd.xml",
+          "appVersion": "1.5.4",
+          "arguments": "-b3 --long"
+        },
+        {
+          "metricId": "compress_zstd_compression_level_8_compression_speed",
+          "samples": [212, 208.8],
+          "aggregates": {
+            "p50": 210.4,
+            "p95": 211.84,
+            "mean": 210.4,
+            "stdev": 2.262741699796944,
+            "min": 208.8,
+            "max": 212,
+            "n": 2
+          },
+          "sourceFile": "cpu-generic/pts_compress-zstd.xml",
+          "appVersion": "1.5.4",
+          "arguments": "-b8"
+        },
+        {
+          "metricId": "compress_zstd_compression_level_8_decompression_speed",
+          "samples": [2269.2, 2269],
+          "aggregates": {
+            "p50": 2269.1,
+            "p95": 2269.1899999999996,
+            "mean": 2269.1,
+            "stdev": 0.14142135623718088,
+            "min": 2269,
+            "max": 2269.2,
+            "n": 2
+          },
+          "sourceFile": "cpu-generic/pts_compress-zstd.xml",
+          "appVersion": "1.5.4",
+          "arguments": "-b8"
+        },
+        {
+          "metricId": "compress_zstd_compression_level_8_long_mode_compression_speed",
+          "samples": [202.3, 203],
+          "aggregates": {
+            "p50": 202.65,
+            "p95": 202.965,
+            "mean": 202.65,
+            "stdev": 0.49497474683057524,
+            "min": 202.3,
+            "max": 203,
+            "n": 2
+          },
+          "sourceFile": "cpu-generic/pts_compress-zstd.xml",
+          "appVersion": "1.5.4",
+          "arguments": "-b8 --long"
+        },
+        {
+          "metricId": "compress_zstd_compression_level_8_long_mode_decompression_speed",
+          "samples": [2304.8, 2310.5],
+          "aggregates": {
+            "p50": 2307.65,
+            "p95": 2310.215,
+            "mean": 2307.65,
+            "stdev": 4.030508652763192,
+            "min": 2304.8,
+            "max": 2310.5,
+            "n": 2
+          },
+          "sourceFile": "cpu-generic/pts_compress-zstd.xml",
+          "appVersion": "1.5.4",
+          "arguments": "-b8 --long"
+        },
+        {
+          "metricId": "fio_type_random_read_engine_linux_aio_direct_yes_block_size_4kb_job_count_1_disk_target_default_test_directory_iops",
+          "samples": [257000, 240000],
+          "aggregates": {
+            "p50": 248500,
+            "p95": 256150,
+            "mean": 248500,
+            "stdev": 12020.815280171308,
+            "min": 240000,
+            "max": 257000,
+            "n": 2
+          },
+          "sourceFile": "disk/pts_fio-rand-read.xml",
+          "appVersion": "3.36",
+          "arguments": "randread libaio 1 4k 1"
+        },
+        {
+          "metricId": "fio_type_random_read_engine_linux_aio_direct_yes_block_size_4kb_job_count_1_disk_target_default_test_directory_mb_per_s",
+          "samples": [1006, 936],
+          "aggregates": {
+            "p50": 971,
+            "p95": 1002.5,
+            "mean": 971,
+            "stdev": 49.49747468305833,
+            "min": 936,
+            "max": 1006,
+            "n": 2
+          },
+          "sourceFile": "disk/pts_fio-rand-read.xml",
+          "appVersion": "3.36",
+          "arguments": "randread libaio 1 4k 1"
+        },
+        {
+          "metricId": "fio_type_random_write_engine_linux_aio_direct_yes_block_size_4kb_job_count_1_disk_target_default_test_directory_iops",
+          "samples": [255000, 208000],
+          "aggregates": {
+            "p50": 231500,
+            "p95": 252650,
+            "mean": 231500,
+            "stdev": 33234.018715767736,
+            "min": 208000,
+            "max": 255000,
+            "n": 2
+          },
+          "sourceFile": "disk/pts_fio-rand-write.xml",
+          "appVersion": "3.36",
+          "arguments": "randwrite libaio 1 4k 1"
+        },
+        {
+          "metricId": "fio_type_random_write_engine_linux_aio_direct_yes_block_size_4kb_job_count_1_disk_target_default_test_directory_mb_per_s",
+          "samples": [994, 811],
+          "aggregates": {
+            "p50": 902.5,
+            "p95": 984.85,
+            "mean": 902.5,
+            "stdev": 129.4005409571382,
+            "min": 811,
+            "max": 994,
+            "n": 2
+          },
+          "sourceFile": "disk/pts_fio-rand-write.xml",
+          "appVersion": "3.36",
+          "arguments": "randwrite libaio 1 4k 1"
+        },
+        {
+          "metricId": "fio_type_sequential_read_engine_linux_aio_direct_yes_block_size_1mb_job_count_1_disk_target_default_test_directory_iops",
+          "samples": [12700, 5584],
+          "aggregates": {
+            "p50": 9142,
+            "p95": 12344.2,
+            "mean": 9142,
+            "stdev": 5031.771854923472,
+            "min": 5584,
+            "max": 12700,
+            "n": 2
+          },
+          "sourceFile": "disk/pts_fio-seq-read.xml",
+          "appVersion": "3.36",
+          "arguments": "read libaio 1 1m 1"
+        },
+        {
+          "metricId": "fio_type_sequential_read_engine_linux_aio_direct_yes_block_size_1mb_job_count_1_disk_target_default_test_directory_mb_per_s",
+          "samples": [5585],
+          "aggregates": {
+            "p50": 5585,
+            "p95": 5585,
+            "mean": 5585,
+            "stdev": 0,
+            "min": 5585,
+            "max": 5585,
+            "n": 1
+          },
+          "sourceFile": "disk/pts_fio-seq-read.xml",
+          "appVersion": "3.36",
+          "arguments": "read libaio 1 1m 1"
+        },
+        {
+          "metricId": "fio_type_sequential_write_engine_linux_aio_direct_yes_block_size_1mb_job_count_1_disk_target_default_test_directory_iops",
+          "samples": [5928, 5714],
+          "aggregates": {
+            "p50": 5821,
+            "p95": 5917.3,
+            "mean": 5821,
+            "stdev": 151.32085117392117,
+            "min": 5714,
+            "max": 5928,
+            "n": 2
+          },
+          "sourceFile": "disk/pts_fio-seq-write.xml",
+          "appVersion": "3.36",
+          "arguments": "write libaio 1 1m 1"
+        },
+        {
+          "metricId": "fio_type_sequential_write_engine_linux_aio_direct_yes_block_size_1mb_job_count_1_disk_target_default_test_directory_mb_per_s",
+          "samples": [5930, 5716],
+          "aggregates": {
+            "p50": 5823,
+            "p95": 5919.3,
+            "mean": 5823,
+            "stdev": 151.32085117392117,
+            "min": 5716,
+            "max": 5930,
+            "n": 2
+          },
+          "sourceFile": "disk/pts_fio-seq-write.xml",
+          "appVersion": "3.36",
+          "arguments": "write libaio 1 1m 1"
+        },
+        {
+          "metricId": "git_seconds",
+          "samples": [36.164, 35.962],
+          "aggregates": {
+            "p50": 36.063,
+            "p95": 36.1539,
+            "mean": 36.063,
+            "stdev": 0.14283556979968132,
+            "min": 35.962,
+            "max": 36.164,
+            "n": 2
+          },
+          "sourceFile": "system/pts_git.xml"
+        },
+        {
+          "metricId": "hardlink_bogo_ops_per_s",
+          "samples": [23.62, 23.69],
+          "aggregates": {
+            "p50": 23.655,
+            "p95": 23.686500000000002,
+            "mean": 23.655,
+            "stdev": 0.049497474683058526,
+            "min": 23.62,
+            "max": 23.69,
+            "n": 2
+          },
+          "sourceFile": "disk/pts_hardlink.xml",
+          "appVersion": "0.16"
+        },
+        {
+          "metricId": "network_loopback_seconds",
+          "samples": [5.595, 5.286],
+          "aggregates": {
+            "p50": 5.4405,
+            "p95": 5.579549999999999,
+            "mean": 5.4405,
+            "stdev": 0.218495995386643,
+            "min": 5.286,
+            "max": 5.595,
+            "n": 2
+          },
+          "sourceFile": "network/pts_network-loopback.xml"
+        },
+        {
+          "metricId": "node_web_tooling_runs_per_s",
+          "samples": [19.55, 19.46],
+          "aggregates": {
+            "p50": 19.505000000000003,
+            "p95": 19.5455,
+            "mean": 19.505000000000003,
+            "stdev": 0.06363961030678791,
+            "min": 19.46,
+            "max": 19.55,
+            "n": 2
+          },
+          "sourceFile": "cpu-node/pts_node-web-tooling.xml"
+        },
+        {
+          "metricId": "realworld_better_auth_task_build",
+          "samples": [12.944, 12.616],
+          "aggregates": {
+            "p50": 12.780000000000001,
+            "p95": 12.9276,
+            "mean": 12.780000000000001,
+            "stdev": 0.2319310242291878,
+            "min": 12.616,
+            "max": 12.944,
+            "n": 2
+          },
+          "sourceFile": "realworld-better-auth/pts_realworld-better-auth.xml",
+          "appVersion": "6f3ba45639579da152b69e8e5342e02f28288670",
+          "arguments": "build"
+        },
+        {
+          "metricId": "realworld_better_auth_task_cold_install",
+          "samples": [11.035, 10.743],
+          "aggregates": {
+            "p50": 10.889,
+            "p95": 11.0204,
+            "mean": 10.889,
+            "stdev": 0.20647518010647237,
+            "min": 10.743,
+            "max": 11.035,
+            "n": 2
+          },
+          "sourceFile": "realworld-better-auth/pts_realworld-better-auth.xml",
+          "appVersion": "6f3ba45639579da152b69e8e5342e02f28288670",
+          "arguments": "cold_install"
+        },
+        {
+          "metricId": "realworld_better_auth_task_git_clone",
+          "samples": [1.768, 1.57],
+          "aggregates": {
+            "p50": 1.669,
+            "p95": 1.7581,
+            "mean": 1.669,
+            "stdev": 0.14000714267493639,
+            "min": 1.57,
+            "max": 1.768,
+            "n": 2
+          },
+          "sourceFile": "realworld-better-auth/pts_realworld-better-auth.xml",
+          "appVersion": "6f3ba45639579da152b69e8e5342e02f28288670",
+          "arguments": "git_clone"
+        },
+        {
+          "metricId": "realworld_better_auth_task_lint_biome",
+          "samples": [4.869, 4.869],
+          "aggregates": {
+            "p50": 4.869,
+            "p95": 4.869,
+            "mean": 4.869,
+            "stdev": 0,
+            "min": 4.869,
+            "max": 4.869,
+            "n": 2
+          },
+          "sourceFile": "realworld-better-auth/pts_realworld-better-auth.xml",
+          "appVersion": "6f3ba45639579da152b69e8e5342e02f28288670",
+          "arguments": "lint_biome"
+        },
+        {
+          "metricId": "realworld_better_auth_task_lint_deps_knip",
+          "samples": [10.955, 10.975],
+          "aggregates": {
+            "p50": 10.965,
+            "p95": 10.974,
+            "mean": 10.965,
+            "stdev": 0.014142135623730649,
+            "min": 10.955,
+            "max": 10.975,
+            "n": 2
+          },
+          "sourceFile": "realworld-better-auth/pts_realworld-better-auth.xml",
+          "appVersion": "6f3ba45639579da152b69e8e5342e02f28288670",
+          "arguments": "lint_deps"
+        },
+        {
+          "metricId": "realworld_better_auth_task_lint_format",
+          "samples": [2.683, 2.679],
+          "aggregates": {
+            "p50": 2.681,
+            "p95": 2.6828,
+            "mean": 2.681,
+            "stdev": 0.0028284271247460357,
+            "min": 2.679,
+            "max": 2.683,
+            "n": 2
+          },
+          "sourceFile": "realworld-better-auth/pts_realworld-better-auth.xml",
+          "appVersion": "6f3ba45639579da152b69e8e5342e02f28288670",
+          "arguments": "lint_format"
+        },
+        {
+          "metricId": "realworld_better_auth_task_lint_packages",
+          "samples": [4.01, 4.02],
+          "aggregates": {
+            "p50": 4.015,
+            "p95": 4.0195,
+            "mean": 4.015,
+            "stdev": 0.007071067811865324,
+            "min": 4.01,
+            "max": 4.02,
+            "n": 2
+          },
+          "sourceFile": "realworld-better-auth/pts_realworld-better-auth.xml",
+          "appVersion": "6f3ba45639579da152b69e8e5342e02f28288670",
+          "arguments": "lint_packages"
+        },
+        {
+          "metricId": "realworld_better_auth_task_lint_spell",
+          "samples": [6.908, 6.769],
+          "aggregates": {
+            "p50": 6.8385,
+            "p95": 6.901050000000001,
+            "mean": 6.8385,
+            "stdev": 0.09828784258493059,
+            "min": 6.769,
+            "max": 6.908,
+            "n": 2
+          },
+          "sourceFile": "realworld-better-auth/pts_realworld-better-auth.xml",
+          "appVersion": "6f3ba45639579da152b69e8e5342e02f28288670",
+          "arguments": "lint_spell"
+        },
+        {
+          "metricId": "realworld_better_auth_task_lint_types",
+          "samples": [51.19, 50.946],
+          "aggregates": {
+            "p50": 51.068,
+            "p95": 51.1778,
+            "mean": 51.068,
+            "stdev": 0.17253405460951743,
+            "min": 50.946,
+            "max": 51.19,
+            "n": 2
+          },
+          "sourceFile": "realworld-better-auth/pts_realworld-better-auth.xml",
+          "appVersion": "6f3ba45639579da152b69e8e5342e02f28288670",
+          "arguments": "lint_types"
+        },
+        {
+          "metricId": "realworld_better_auth_task_typecheck",
+          "samples": [1.398, 1.378],
+          "aggregates": {
+            "p50": 1.388,
+            "p95": 1.3969999999999998,
+            "mean": 1.388,
+            "stdev": 0.014142135623730963,
+            "min": 1.378,
+            "max": 1.398,
+            "n": 2
+          },
+          "sourceFile": "realworld-better-auth/pts_realworld-better-auth.xml",
+          "appVersion": "6f3ba45639579da152b69e8e5342e02f28288670",
+          "arguments": "typecheck"
+        },
+        {
+          "metricId": "realworld_mastra_task_build_core",
+          "samples": [83.024, 82.979],
+          "aggregates": {
+            "p50": 83.0015,
+            "p95": 83.02175,
+            "mean": 83.0015,
+            "stdev": 0.03181980515340087,
+            "min": 82.979,
+            "max": 83.024,
+            "n": 2
+          },
+          "sourceFile": "realworld-mastra/pts_realworld-mastra.xml",
+          "appVersion": "b6eeb9d08ebeaf27bc6fd16b6b88087040aaf767",
+          "arguments": "build_core"
+        },
+        {
+          "metricId": "realworld_mastra_task_cold_install",
+          "samples": [29.027, 28.657],
+          "aggregates": {
+            "p50": 28.842,
+            "p95": 29.0085,
+            "mean": 28.842,
+            "stdev": 0.26162950903902454,
+            "min": 28.657,
+            "max": 29.027,
+            "n": 2
+          },
+          "sourceFile": "realworld-mastra/pts_realworld-mastra.xml",
+          "appVersion": "b6eeb9d08ebeaf27bc6fd16b6b88087040aaf767",
+          "arguments": "cold_install"
+        },
+        {
+          "metricId": "realworld_mastra_task_git_clone",
+          "samples": [6.425, 6.827],
+          "aggregates": {
+            "p50": 6.6259999999999994,
+            "p95": 6.8069,
+            "mean": 6.6259999999999994,
+            "stdev": 0.28425692603699254,
+            "min": 6.425,
+            "max": 6.827,
+            "n": 2
+          },
+          "sourceFile": "realworld-mastra/pts_realworld-mastra.xml",
+          "appVersion": "b6eeb9d08ebeaf27bc6fd16b6b88087040aaf767",
+          "arguments": "git_clone"
+        },
+        {
+          "metricId": "realworld_mastra_task_lint_format",
+          "samples": [90.341, 91.077],
+          "aggregates": {
+            "p50": 90.709,
+            "p95": 91.0402,
+            "mean": 90.709,
+            "stdev": 0.5204305909532969,
+            "min": 90.341,
+            "max": 91.077,
+            "n": 2
+          },
+          "sourceFile": "realworld-mastra/pts_realworld-mastra.xml",
+          "appVersion": "b6eeb9d08ebeaf27bc6fd16b6b88087040aaf767",
+          "arguments": "lint_format"
+        },
+        {
+          "metricId": "sqlite_speedtest_seconds",
+          "samples": [30.671, 30.412],
+          "aggregates": {
+            "p50": 30.5415,
+            "p95": 30.65805,
+            "mean": 30.5415,
+            "stdev": 0.18314065632731605,
+            "min": 30.412,
+            "max": 30.671,
+            "n": 2
+          },
+          "sourceFile": "system/pts_sqlite-speedtest.xml",
+          "appVersion": "3.30"
+        },
+        {
+          "metricId": "stream_type_add",
+          "samples": [55725.7, 55755.6],
+          "aggregates": {
+            "p50": 55740.649999999994,
+            "p95": 55754.104999999996,
+            "mean": 55740.649999999994,
+            "stdev": 21.14249275748137,
+            "min": 55725.7,
+            "max": 55755.6,
+            "n": 2
+          },
+          "sourceFile": "memory/pts_stream.xml",
+          "appVersion": "2013-01-17",
+          "arguments": "Add"
+        },
+        {
+          "metricId": "stream_type_copy",
+          "samples": [65692.3, 65676],
+          "aggregates": {
+            "p50": 65684.15,
+            "p95": 65691.485,
+            "mean": 65684.15,
+            "stdev": 11.525840533347928,
+            "min": 65676,
+            "max": 65692.3,
+            "n": 2
+          },
+          "sourceFile": "memory/pts_stream.xml",
+          "appVersion": "2013-01-17",
+          "arguments": "Copy"
+        },
+        {
+          "metricId": "stream_type_scale",
+          "samples": [50181.9, 50049.7],
+          "aggregates": {
+            "p50": 50115.8,
+            "p95": 50175.29,
+            "mean": 50115.8,
+            "stdev": 93.4795164728621,
+            "min": 50049.7,
+            "max": 50181.9,
+            "n": 2
+          },
+          "sourceFile": "memory/pts_stream.xml",
+          "appVersion": "2013-01-17",
+          "arguments": "Scale"
+        },
+        {
+          "metricId": "stream_type_triad",
+          "samples": [55980.6, 56009.6],
+          "aggregates": {
+            "p50": 55995.1,
+            "p95": 56008.15,
+            "mean": 55995.1,
+            "stdev": 20.506096654409877,
+            "min": 55980.6,
+            "max": 56009.6,
+            "n": 2
+          },
+          "sourceFile": "memory/pts_stream.xml",
+          "appVersion": "2013-01-17",
+          "arguments": "Triad"
+        },
+        {
+          "metricId": "usd_per_hour",
+          "samples": [0.1494],
+          "aggregates": {
+            "p50": 0.1494,
+            "p95": 0.1494,
+            "mean": 0.1494,
+            "stdev": 0,
+            "min": 0.1494,
+            "max": 0.1494,
+            "n": 1
+          }
+        }
+      ],
+      "suitesCovered": [
+        "cpu-generic",
+        "cpu-node",
+        "disk",
+        "memory",
+        "network",
+        "realworld-better-auth",
+        "realworld-mastra",
+        "system"
+      ],
+      "gaps": [
+        {
+          "scope": "suite",
+          "id": "network",
+          "outcome": "failed",
+          "reason": "Step \"mise run benchmark:network:all\" timed out after 2700s"
+        },
+        {
+          "scope": "suite",
+          "id": "realworld-openclaw",
+          "outcome": "failed",
+          "reason": "Step \"mise run benchmark:realworld:pts:openclaw\" timed out after 8400s"
+        }
+      ],
+      "uncatalogued": []
+    },
+    {
+      "providerId": "e2b",
+      "validationStatus": "validated",
+      "specMatched": true,
+      "observedSpecs": {
+        "vcpus": 2,
+        "cpuModel": "Intel(R) Xeon(R) Processor @ 2.60GHz",
+        "virtualization": "kvm",
+        "memoryGb": 7.78,
+        "diskGb": 24.3,
+        "kernel": "6.1.158+",
+        "os": "Debian GNU/Linux 13 (trixie)",
+        "user": "root",
+        "hostMemoryGb": 8,
+        "publicIp": "34.169.9.225",
+        "egressOrg": "AS396982 Google LLC",
+        "egressAsn": "AS396982",
+        "egressOrgName": "Google LLC",
+        "reverseDns": "225.9.169.34.bc.googleusercontent.com",
+        "city": "The Dalles",
+        "region": "Oregon",
+        "country": "US",
+        "location": "45.5946,-121.1787",
+        "timezone": "America/Los_Angeles",
+        "networkPrefix": "34.169.0.0/17",
+        "asnSource": "cymru",
+        "geoSource": "ipinfo"
+      },
+      "hostMetadata": [
+        {
+          "source": "phoronix/result-file-to-json",
+          "sourceFile": "cpu-node/pts_node-web-tooling--metadata.json",
+          "fields": [
+            {
+              "path": "ci.client_version",
+              "value": "10.8.4"
+            },
+            {
+              "path": "ci.data.cpu-microcode",
+              "value": "0x1"
+            },
+            {
+              "path": "ci.data.kernel-extra-details",
+              "value": "Transparent Huge Pages: madvise"
+            },
+            {
+              "path": "ci.data.security",
+              "value": "gather_data_sampling: Not affected + indirect_target_selection: Mitigation of Aligned branch/return thunks + itlb_multihit: Not affected + l1tf: Not affected + mds: Not affected + meltdown: Not affected + mmio_stale_data: Not affected + reg_file_data_sampling: Not affected + retbleed: Not affected + spec_rstack_overflow: Not affected + spec_store_bypass: Mitigation of SSB disabled via prctl + spectre_v1: Mitigation of usercopy/swapgs barriers and __user pointer sanitization + spectre_v2: Mitigation of Enhanced / Automatic IBRS; IBPB: conditional; PBRSB-eIBRS: SW sequence; BHI: SW loop KVM: SW loop + srbds: Not affected + tsa: Not affected + tsx_async_abort: Not affected + vmscape: Not affected"
+            },
+            {
+              "path": "ci.hardware.Disk",
+              "value": "25GB"
+            },
+            {
+              "path": "ci.hardware.Memory",
+              "value": "8GB"
+            },
+            {
+              "path": "ci.hardware.Processor",
+              "value": "Intel Xeon (1 Core / 2 Threads)"
+            },
+            {
+              "path": "ci.identifier",
+              "value": "ci"
+            },
+            {
+              "path": "ci.software.Compiler",
+              "value": "GCC 14.2.0"
+            },
+            {
+              "path": "ci.software.File-System",
+              "value": "ext4"
+            },
+            {
+              "path": "ci.software.Kernel",
+              "value": "6.1.158+ (x86_64)"
+            },
+            {
+              "path": "ci.software.OS",
+              "value": "Debian GNU/Linux 13"
+            },
+            {
+              "path": "ci.software.System Layer",
+              "value": "KVM"
+            },
+            {
+              "path": "ci.timestamp",
+              "value": "2026-07-17 01:07:04"
+            },
+            {
+              "path": "ci.user",
+              "value": "root"
+            }
+          ]
+        },
+        {
+          "source": "phoronix/result-file-to-json",
+          "sourceFile": "disk/pts_fio-rand-read--metadata.json",
+          "fields": [
+            {
+              "path": "ci.client_version",
+              "value": "10.8.4"
+            },
+            {
+              "path": "ci.data.compiler-configuration",
+              "value": "--build=x86_64-linux-gnu --disable-vtable-verify --disable-werror --enable-bootstrap --enable-cet --enable-checking=release --enable-clocale=gnu --enable-default-pie --enable-gnu-unique-object --enable-languages=c,ada,c++,go,d,fortran,objc,obj-c++,m2,rust --enable-libphobos-checking=release --enable-libstdcxx-backtrace --enable-libstdcxx-debug --enable-libstdcxx-time=yes --enable-link-serialization=3 --enable-multiarch --enable-multilib --enable-nls --enable-objc-gc=auto --enable-offload-defaulted --enable-offload-targets=nvptx-none=/build/reproducible-path/gcc-14-14.2.0/debian/tmp-nvptx/usr,amdgcn-amdhsa=/build/reproducible-path/gcc-14-14.2.0/debian/tmp-gcn/usr --enable-plugin --enable-shared --enable-threads=posix --host=x86_64-linux-gnu --program-prefix=x86_64-linux-gnu- --target=x86_64-linux-gnu --with-abi=m64 --with-arch-32=i686 --with-build-config=bootstrap-lto-lean --with-default-libstdcxx-abi=new --with-gcc-major-version-only --with-multilib-list=m32,m64,mx32 --with-target-system-zlib=auto --with-tune=generic --without-cuda-driver -v"
+            },
+            {
+              "path": "ci.data.cpu-microcode",
+              "value": "0x1"
+            },
+            {
+              "path": "ci.data.disk-details",
+              "value": "Block Size: 4096"
+            },
+            {
+              "path": "ci.data.disk-mount-options",
+              "value": "discard,relatime,rw"
+            },
+            {
+              "path": "ci.data.kernel-extra-details",
+              "value": "Transparent Huge Pages: madvise"
+            },
+            {
+              "path": "ci.data.security",
+              "value": "gather_data_sampling: Not affected + indirect_target_selection: Mitigation of Aligned branch/return thunks + itlb_multihit: Not affected + l1tf: Not affected + mds: Not affected + meltdown: Not affected + mmio_stale_data: Not affected + reg_file_data_sampling: Not affected + retbleed: Not affected + spec_rstack_overflow: Not affected + spec_store_bypass: Mitigation of SSB disabled via prctl + spectre_v1: Mitigation of usercopy/swapgs barriers and __user pointer sanitization + spectre_v2: Mitigation of Enhanced / Automatic IBRS; IBPB: conditional; PBRSB-eIBRS: SW sequence; BHI: SW loop KVM: SW loop + srbds: Not affected + tsa: Not affected + tsx_async_abort: Not affected + vmscape: Not affected"
+            },
+            {
+              "path": "ci.hardware.Disk",
+              "value": "25GB"
+            },
+            {
+              "path": "ci.hardware.Memory",
+              "value": "8GB"
+            },
+            {
+              "path": "ci.hardware.Processor",
+              "value": "Intel Xeon (1 Core / 2 Threads)"
+            },
+            {
+              "path": "ci.identifier",
+              "value": "ci"
+            },
+            {
+              "path": "ci.software.Compiler",
+              "value": "GCC 14.2.0"
+            },
+            {
+              "path": "ci.software.File-System",
+              "value": "ext4"
+            },
+            {
+              "path": "ci.software.Kernel",
+              "value": "6.1.158+ (x86_64)"
+            },
+            {
+              "path": "ci.software.OS",
+              "value": "Debian GNU/Linux 13"
+            },
+            {
+              "path": "ci.software.System Layer",
+              "value": "KVM"
+            },
+            {
+              "path": "ci.timestamp",
+              "value": "2026-07-17 01:13:28"
+            },
+            {
+              "path": "ci.user",
+              "value": "root"
+            }
+          ]
+        },
+        {
+          "source": "phoronix/result-file-to-json",
+          "sourceFile": "disk/pts_fio-rand-write--metadata.json",
+          "fields": [
+            {
+              "path": "ci.client_version",
+              "value": "10.8.4"
+            },
+            {
+              "path": "ci.data.compiler-configuration",
+              "value": "--build=x86_64-linux-gnu --disable-vtable-verify --disable-werror --enable-bootstrap --enable-cet --enable-checking=release --enable-clocale=gnu --enable-default-pie --enable-gnu-unique-object --enable-languages=c,ada,c++,go,d,fortran,objc,obj-c++,m2,rust --enable-libphobos-checking=release --enable-libstdcxx-backtrace --enable-libstdcxx-debug --enable-libstdcxx-time=yes --enable-link-serialization=3 --enable-multiarch --enable-multilib --enable-nls --enable-objc-gc=auto --enable-offload-defaulted --enable-offload-targets=nvptx-none=/build/reproducible-path/gcc-14-14.2.0/debian/tmp-nvptx/usr,amdgcn-amdhsa=/build/reproducible-path/gcc-14-14.2.0/debian/tmp-gcn/usr --enable-plugin --enable-shared --enable-threads=posix --host=x86_64-linux-gnu --program-prefix=x86_64-linux-gnu- --target=x86_64-linux-gnu --with-abi=m64 --with-arch-32=i686 --with-build-config=bootstrap-lto-lean --with-default-libstdcxx-abi=new --with-gcc-major-version-only --with-multilib-list=m32,m64,mx32 --with-target-system-zlib=auto --with-tune=generic --without-cuda-driver -v"
+            },
+            {
+              "path": "ci.data.cpu-microcode",
+              "value": "0x1"
+            },
+            {
+              "path": "ci.data.disk-details",
+              "value": "Block Size: 4096"
+            },
+            {
+              "path": "ci.data.disk-mount-options",
+              "value": "discard,relatime,rw"
+            },
+            {
+              "path": "ci.data.kernel-extra-details",
+              "value": "Transparent Huge Pages: madvise"
+            },
+            {
+              "path": "ci.data.security",
+              "value": "gather_data_sampling: Not affected + indirect_target_selection: Mitigation of Aligned branch/return thunks + itlb_multihit: Not affected + l1tf: Not affected + mds: Not affected + meltdown: Not affected + mmio_stale_data: Not affected + reg_file_data_sampling: Not affected + retbleed: Not affected + spec_rstack_overflow: Not affected + spec_store_bypass: Mitigation of SSB disabled via prctl + spectre_v1: Mitigation of usercopy/swapgs barriers and __user pointer sanitization + spectre_v2: Mitigation of Enhanced / Automatic IBRS; IBPB: conditional; PBRSB-eIBRS: SW sequence; BHI: SW loop KVM: SW loop + srbds: Not affected + tsa: Not affected + tsx_async_abort: Not affected + vmscape: Not affected"
+            },
+            {
+              "path": "ci.hardware.Disk",
+              "value": "25GB"
+            },
+            {
+              "path": "ci.hardware.Memory",
+              "value": "8GB"
+            },
+            {
+              "path": "ci.hardware.Processor",
+              "value": "Intel Xeon (1 Core / 2 Threads)"
+            },
+            {
+              "path": "ci.identifier",
+              "value": "ci"
+            },
+            {
+              "path": "ci.software.Compiler",
+              "value": "GCC 14.2.0"
+            },
+            {
+              "path": "ci.software.File-System",
+              "value": "ext4"
+            },
+            {
+              "path": "ci.software.Kernel",
+              "value": "6.1.158+ (x86_64)"
+            },
+            {
+              "path": "ci.software.OS",
+              "value": "Debian GNU/Linux 13"
+            },
+            {
+              "path": "ci.software.System Layer",
+              "value": "KVM"
+            },
+            {
+              "path": "ci.timestamp",
+              "value": "2026-07-17 01:16:40"
+            },
+            {
+              "path": "ci.user",
+              "value": "root"
+            }
+          ]
+        },
+        {
+          "source": "phoronix/result-file-to-json",
+          "sourceFile": "disk/pts_fio-seq-read--metadata.json",
+          "fields": [
+            {
+              "path": "ci.client_version",
+              "value": "10.8.4"
+            },
+            {
+              "path": "ci.data.compiler-configuration",
+              "value": "--build=x86_64-linux-gnu --disable-vtable-verify --disable-werror --enable-bootstrap --enable-cet --enable-checking=release --enable-clocale=gnu --enable-default-pie --enable-gnu-unique-object --enable-languages=c,ada,c++,go,d,fortran,objc,obj-c++,m2,rust --enable-libphobos-checking=release --enable-libstdcxx-backtrace --enable-libstdcxx-debug --enable-libstdcxx-time=yes --enable-link-serialization=3 --enable-multiarch --enable-multilib --enable-nls --enable-objc-gc=auto --enable-offload-defaulted --enable-offload-targets=nvptx-none=/build/reproducible-path/gcc-14-14.2.0/debian/tmp-nvptx/usr,amdgcn-amdhsa=/build/reproducible-path/gcc-14-14.2.0/debian/tmp-gcn/usr --enable-plugin --enable-shared --enable-threads=posix --host=x86_64-linux-gnu --program-prefix=x86_64-linux-gnu- --target=x86_64-linux-gnu --with-abi=m64 --with-arch-32=i686 --with-build-config=bootstrap-lto-lean --with-default-libstdcxx-abi=new --with-gcc-major-version-only --with-multilib-list=m32,m64,mx32 --with-target-system-zlib=auto --with-tune=generic --without-cuda-driver -v"
+            },
+            {
+              "path": "ci.data.cpu-microcode",
+              "value": "0x1"
+            },
+            {
+              "path": "ci.data.disk-details",
+              "value": "Block Size: 4096"
+            },
+            {
+              "path": "ci.data.disk-mount-options",
+              "value": "discard,relatime,rw"
+            },
+            {
+              "path": "ci.data.kernel-extra-details",
+              "value": "Transparent Huge Pages: madvise"
+            },
+            {
+              "path": "ci.data.security",
+              "value": "gather_data_sampling: Not affected + indirect_target_selection: Mitigation of Aligned branch/return thunks + itlb_multihit: Not affected + l1tf: Not affected + mds: Not affected + meltdown: Not affected + mmio_stale_data: Not affected + reg_file_data_sampling: Not affected + retbleed: Not affected + spec_rstack_overflow: Not affected + spec_store_bypass: Mitigation of SSB disabled via prctl + spectre_v1: Mitigation of usercopy/swapgs barriers and __user pointer sanitization + spectre_v2: Mitigation of Enhanced / Automatic IBRS; IBPB: conditional; PBRSB-eIBRS: SW sequence; BHI: SW loop KVM: SW loop + srbds: Not affected + tsa: Not affected + tsx_async_abort: Not affected + vmscape: Not affected"
+            },
+            {
+              "path": "ci.hardware.Disk",
+              "value": "25GB"
+            },
+            {
+              "path": "ci.hardware.Memory",
+              "value": "8GB"
+            },
+            {
+              "path": "ci.hardware.Processor",
+              "value": "Intel Xeon (1 Core / 2 Threads)"
+            },
+            {
+              "path": "ci.identifier",
+              "value": "ci"
+            },
+            {
+              "path": "ci.software.Compiler",
+              "value": "GCC 14.2.0"
+            },
+            {
+              "path": "ci.software.File-System",
+              "value": "ext4"
+            },
+            {
+              "path": "ci.software.Kernel",
+              "value": "6.1.158+ (x86_64)"
+            },
+            {
+              "path": "ci.software.OS",
+              "value": "Debian GNU/Linux 13"
+            },
+            {
+              "path": "ci.software.System Layer",
+              "value": "KVM"
+            },
+            {
+              "path": "ci.timestamp",
+              "value": "2026-07-17 01:07:03"
+            },
+            {
+              "path": "ci.user",
+              "value": "root"
+            }
+          ]
+        },
+        {
+          "source": "phoronix/result-file-to-json",
+          "sourceFile": "disk/pts_fio-seq-write--metadata.json",
+          "fields": [
+            {
+              "path": "ci.client_version",
+              "value": "10.8.4"
+            },
+            {
+              "path": "ci.data.compiler-configuration",
+              "value": "--build=x86_64-linux-gnu --disable-vtable-verify --disable-werror --enable-bootstrap --enable-cet --enable-checking=release --enable-clocale=gnu --enable-default-pie --enable-gnu-unique-object --enable-languages=c,ada,c++,go,d,fortran,objc,obj-c++,m2,rust --enable-libphobos-checking=release --enable-libstdcxx-backtrace --enable-libstdcxx-debug --enable-libstdcxx-time=yes --enable-link-serialization=3 --enable-multiarch --enable-multilib --enable-nls --enable-objc-gc=auto --enable-offload-defaulted --enable-offload-targets=nvptx-none=/build/reproducible-path/gcc-14-14.2.0/debian/tmp-nvptx/usr,amdgcn-amdhsa=/build/reproducible-path/gcc-14-14.2.0/debian/tmp-gcn/usr --enable-plugin --enable-shared --enable-threads=posix --host=x86_64-linux-gnu --program-prefix=x86_64-linux-gnu- --target=x86_64-linux-gnu --with-abi=m64 --with-arch-32=i686 --with-build-config=bootstrap-lto-lean --with-default-libstdcxx-abi=new --with-gcc-major-version-only --with-multilib-list=m32,m64,mx32 --with-target-system-zlib=auto --with-tune=generic --without-cuda-driver -v"
+            },
+            {
+              "path": "ci.data.cpu-microcode",
+              "value": "0x1"
+            },
+            {
+              "path": "ci.data.disk-details",
+              "value": "Block Size: 4096"
+            },
+            {
+              "path": "ci.data.disk-mount-options",
+              "value": "discard,relatime,rw"
+            },
+            {
+              "path": "ci.data.kernel-extra-details",
+              "value": "Transparent Huge Pages: madvise"
+            },
+            {
+              "path": "ci.data.security",
+              "value": "gather_data_sampling: Not affected + indirect_target_selection: Mitigation of Aligned branch/return thunks + itlb_multihit: Not affected + l1tf: Not affected + mds: Not affected + meltdown: Not affected + mmio_stale_data: Not affected + reg_file_data_sampling: Not affected + retbleed: Not affected + spec_rstack_overflow: Not affected + spec_store_bypass: Mitigation of SSB disabled via prctl + spectre_v1: Mitigation of usercopy/swapgs barriers and __user pointer sanitization + spectre_v2: Mitigation of Enhanced / Automatic IBRS; IBPB: conditional; PBRSB-eIBRS: SW sequence; BHI: SW loop KVM: SW loop + srbds: Not affected + tsa: Not affected + tsx_async_abort: Not affected + vmscape: Not affected"
+            },
+            {
+              "path": "ci.hardware.Disk",
+              "value": "25GB"
+            },
+            {
+              "path": "ci.hardware.Memory",
+              "value": "8GB"
+            },
+            {
+              "path": "ci.hardware.Processor",
+              "value": "Intel Xeon (1 Core / 2 Threads)"
+            },
+            {
+              "path": "ci.identifier",
+              "value": "ci"
+            },
+            {
+              "path": "ci.software.Compiler",
+              "value": "GCC 14.2.0"
+            },
+            {
+              "path": "ci.software.File-System",
+              "value": "ext4"
+            },
+            {
+              "path": "ci.software.Kernel",
+              "value": "6.1.158+ (x86_64)"
+            },
+            {
+              "path": "ci.software.OS",
+              "value": "Debian GNU/Linux 13"
+            },
+            {
+              "path": "ci.software.System Layer",
+              "value": "KVM"
+            },
+            {
+              "path": "ci.timestamp",
+              "value": "2026-07-17 01:10:17"
+            },
+            {
+              "path": "ci.user",
+              "value": "root"
+            }
+          ]
+        },
+        {
+          "source": "phoronix/result-file-to-json",
+          "sourceFile": "disk/pts_hardlink--metadata.json",
+          "fields": [
+            {
+              "path": "ci.client_version",
+              "value": "10.8.4"
+            },
+            {
+              "path": "ci.data.compiler-configuration",
+              "value": "--build=x86_64-linux-gnu --disable-vtable-verify --disable-werror --enable-bootstrap --enable-cet --enable-checking=release --enable-clocale=gnu --enable-default-pie --enable-gnu-unique-object --enable-languages=c,ada,c++,go,d,fortran,objc,obj-c++,m2,rust --enable-libphobos-checking=release --enable-libstdcxx-backtrace --enable-libstdcxx-debug --enable-libstdcxx-time=yes --enable-link-serialization=3 --enable-multiarch --enable-multilib --enable-nls --enable-objc-gc=auto --enable-offload-defaulted --enable-offload-targets=nvptx-none=/build/reproducible-path/gcc-14-14.2.0/debian/tmp-nvptx/usr,amdgcn-amdhsa=/build/reproducible-path/gcc-14-14.2.0/debian/tmp-gcn/usr --enable-plugin --enable-shared --enable-threads=posix --host=x86_64-linux-gnu --program-prefix=x86_64-linux-gnu- --target=x86_64-linux-gnu --with-abi=m64 --with-arch-32=i686 --with-build-config=bootstrap-lto-lean --with-default-libstdcxx-abi=new --with-gcc-major-version-only --with-multilib-list=m32,m64,mx32 --with-target-system-zlib=auto --with-tune=generic --without-cuda-driver -v"
+            },
+            {
+              "path": "ci.data.cpu-microcode",
+              "value": "0x1"
+            },
+            {
+              "path": "ci.data.disk-details",
+              "value": "Block Size: 4096"
+            },
+            {
+              "path": "ci.data.disk-mount-options",
+              "value": "discard,relatime,rw"
+            },
+            {
+              "path": "ci.data.kernel-extra-details",
+              "value": "Transparent Huge Pages: madvise"
+            },
+            {
+              "path": "ci.data.security",
+              "value": "gather_data_sampling: Not affected + indirect_target_selection: Mitigation of Aligned branch/return thunks + itlb_multihit: Not affected + l1tf: Not affected + mds: Not affected + meltdown: Not affected + mmio_stale_data: Not affected + reg_file_data_sampling: Not affected + retbleed: Not affected + spec_rstack_overflow: Not affected + spec_store_bypass: Mitigation of SSB disabled via prctl + spectre_v1: Mitigation of usercopy/swapgs barriers and __user pointer sanitization + spectre_v2: Mitigation of Enhanced / Automatic IBRS; IBPB: conditional; PBRSB-eIBRS: SW sequence; BHI: SW loop KVM: SW loop + srbds: Not affected + tsa: Not affected + tsx_async_abort: Not affected + vmscape: Not affected"
+            },
+            {
+              "path": "ci.hardware.Disk",
+              "value": "25GB"
+            },
+            {
+              "path": "ci.hardware.Memory",
+              "value": "8GB"
+            },
+            {
+              "path": "ci.hardware.Processor",
+              "value": "Intel Xeon (1 Core / 2 Threads)"
+            },
+            {
+              "path": "ci.identifier",
+              "value": "ci"
+            },
+            {
+              "path": "ci.software.Compiler",
+              "value": "GCC 14.2.0"
+            },
+            {
+              "path": "ci.software.File-System",
+              "value": "ext4"
+            },
+            {
+              "path": "ci.software.Kernel",
+              "value": "6.1.158+ (x86_64)"
+            },
+            {
+              "path": "ci.software.OS",
+              "value": "Debian GNU/Linux 13"
+            },
+            {
+              "path": "ci.software.System Layer",
+              "value": "KVM"
+            },
+            {
+              "path": "ci.timestamp",
+              "value": "2026-07-17 01:19:52"
+            },
+            {
+              "path": "ci.user",
+              "value": "root"
+            }
+          ]
+        },
+        {
+          "source": "phoronix/result-file-to-json",
+          "sourceFile": "memory/pts_stream--metadata.json",
+          "fields": [
+            {
+              "path": "ci.client_version",
+              "value": "10.8.4"
+            },
+            {
+              "path": "ci.data.compiler-configuration",
+              "value": "--build=x86_64-linux-gnu --disable-vtable-verify --disable-werror --enable-bootstrap --enable-cet --enable-checking=release --enable-clocale=gnu --enable-default-pie --enable-gnu-unique-object --enable-languages=c,ada,c++,go,d,fortran,objc,obj-c++,m2,rust --enable-libphobos-checking=release --enable-libstdcxx-backtrace --enable-libstdcxx-debug --enable-libstdcxx-time=yes --enable-link-serialization=3 --enable-multiarch --enable-multilib --enable-nls --enable-objc-gc=auto --enable-offload-defaulted --enable-offload-targets=nvptx-none=/build/reproducible-path/gcc-14-14.2.0/debian/tmp-nvptx/usr,amdgcn-amdhsa=/build/reproducible-path/gcc-14-14.2.0/debian/tmp-gcn/usr --enable-plugin --enable-shared --enable-threads=posix --host=x86_64-linux-gnu --program-prefix=x86_64-linux-gnu- --target=x86_64-linux-gnu --with-abi=m64 --with-arch-32=i686 --with-build-config=bootstrap-lto-lean --with-default-libstdcxx-abi=new --with-gcc-major-version-only --with-multilib-list=m32,m64,mx32 --with-target-system-zlib=auto --with-tune=generic --without-cuda-driver -v"
+            },
+            {
+              "path": "ci.data.cpu-microcode",
+              "value": "0x1"
+            },
+            {
+              "path": "ci.data.environment-variables",
+              "value": "CFLAGS_OVERRIDE=\"-O3 -march=native -DSTREAM_ARRAY_SIZE=150000000\""
+            },
+            {
+              "path": "ci.data.kernel-extra-details",
+              "value": "Transparent Huge Pages: madvise"
+            },
+            {
+              "path": "ci.data.security",
+              "value": "gather_data_sampling: Not affected + indirect_target_selection: Mitigation of Aligned branch/return thunks + itlb_multihit: Not affected + l1tf: Not affected + mds: Not affected + meltdown: Not affected + mmio_stale_data: Not affected + reg_file_data_sampling: Not affected + retbleed: Not affected + spec_rstack_overflow: Not affected + spec_store_bypass: Mitigation of SSB disabled via prctl + spectre_v1: Mitigation of usercopy/swapgs barriers and __user pointer sanitization + spectre_v2: Mitigation of Enhanced / Automatic IBRS; IBPB: conditional; PBRSB-eIBRS: SW sequence; BHI: SW loop KVM: SW loop + srbds: Not affected + tsa: Not affected + tsx_async_abort: Not affected + vmscape: Not affected"
+            },
+            {
+              "path": "ci.hardware.Disk",
+              "value": "25GB"
+            },
+            {
+              "path": "ci.hardware.Memory",
+              "value": "8GB"
+            },
+            {
+              "path": "ci.hardware.Processor",
+              "value": "Intel Xeon (1 Core / 2 Threads)"
+            },
+            {
+              "path": "ci.identifier",
+              "value": "ci"
+            },
+            {
+              "path": "ci.software.Compiler",
+              "value": "GCC 14.2.0"
+            },
+            {
+              "path": "ci.software.File-System",
+              "value": "ext4"
+            },
+            {
+              "path": "ci.software.Kernel",
+              "value": "6.1.158+ (x86_64)"
+            },
+            {
+              "path": "ci.software.OS",
+              "value": "Debian GNU/Linux 13"
+            },
+            {
+              "path": "ci.software.System Layer",
+              "value": "KVM"
+            },
+            {
+              "path": "ci.timestamp",
+              "value": "2026-07-17 01:07:01"
+            },
+            {
+              "path": "ci.user",
+              "value": "root"
+            }
+          ]
+        },
+        {
+          "source": "phoronix/result-file-to-json",
+          "sourceFile": "network/pts_fast-cli--metadata.json",
+          "fields": [
+            {
+              "path": "ci.client_version",
+              "value": "10.8.4"
+            },
+            {
+              "path": "ci.data.cpu-microcode",
+              "value": "0x1"
+            },
+            {
+              "path": "ci.data.kernel-extra-details",
+              "value": "Transparent Huge Pages: madvise"
+            },
+            {
+              "path": "ci.data.security",
+              "value": "gather_data_sampling: Not affected + indirect_target_selection: Mitigation of Aligned branch/return thunks + itlb_multihit: Not affected + l1tf: Not affected + mds: Not affected + meltdown: Not affected + mmio_stale_data: Not affected + reg_file_data_sampling: Not affected + retbleed: Not affected + spec_rstack_overflow: Not affected + spec_store_bypass: Mitigation of SSB disabled via prctl + spectre_v1: Mitigation of usercopy/swapgs barriers and __user pointer sanitization + spectre_v2: Mitigation of Enhanced / Automatic IBRS; IBPB: conditional; PBRSB-eIBRS: SW sequence; BHI: SW loop KVM: SW loop + srbds: Not affected + tsa: Not affected + tsx_async_abort: Not affected + vmscape: Not affected"
+            },
+            {
+              "path": "ci.hardware.Disk",
+              "value": "25GB"
+            },
+            {
+              "path": "ci.hardware.Memory",
+              "value": "8GB"
+            },
+            {
+              "path": "ci.hardware.Processor",
+              "value": "Intel Xeon (1 Core / 2 Threads)"
+            },
+            {
+              "path": "ci.identifier",
+              "value": "ci"
+            },
+            {
+              "path": "ci.software.Compiler",
+              "value": "GCC 14.2.0"
+            },
+            {
+              "path": "ci.software.File-System",
+              "value": "ext4"
+            },
+            {
+              "path": "ci.software.Kernel",
+              "value": "6.1.158+ (x86_64)"
+            },
+            {
+              "path": "ci.software.OS",
+              "value": "Debian GNU/Linux 13"
+            },
+            {
+              "path": "ci.software.System Layer",
+              "value": "KVM"
+            },
+            {
+              "path": "ci.timestamp",
+              "value": "2026-07-17 01:07:48"
+            },
+            {
+              "path": "ci.user",
+              "value": "root"
+            }
+          ]
+        },
+        {
+          "source": "phoronix/result-file-to-json",
+          "sourceFile": "network/pts_network-loopback--metadata.json",
+          "fields": [
+            {
+              "path": "ci.client_version",
+              "value": "10.8.4"
+            },
+            {
+              "path": "ci.data.cpu-microcode",
+              "value": "0x1"
+            },
+            {
+              "path": "ci.data.kernel-extra-details",
+              "value": "Transparent Huge Pages: madvise"
+            },
+            {
+              "path": "ci.data.security",
+              "value": "gather_data_sampling: Not affected + indirect_target_selection: Mitigation of Aligned branch/return thunks + itlb_multihit: Not affected + l1tf: Not affected + mds: Not affected + meltdown: Not affected + mmio_stale_data: Not affected + reg_file_data_sampling: Not affected + retbleed: Not affected + spec_rstack_overflow: Not affected + spec_store_bypass: Mitigation of SSB disabled via prctl + spectre_v1: Mitigation of usercopy/swapgs barriers and __user pointer sanitization + spectre_v2: Mitigation of Enhanced / Automatic IBRS; IBPB: conditional; PBRSB-eIBRS: SW sequence; BHI: SW loop KVM: SW loop + srbds: Not affected + tsa: Not affected + tsx_async_abort: Not affected + vmscape: Not affected"
+            },
+            {
+              "path": "ci.hardware.Disk",
+              "value": "25GB"
+            },
+            {
+              "path": "ci.hardware.Memory",
+              "value": "8GB"
+            },
+            {
+              "path": "ci.hardware.Processor",
+              "value": "Intel Xeon (1 Core / 2 Threads)"
+            },
+            {
+              "path": "ci.identifier",
+              "value": "ci"
+            },
+            {
+              "path": "ci.software.Compiler",
+              "value": "GCC 14.2.0"
+            },
+            {
+              "path": "ci.software.File-System",
+              "value": "ext4"
+            },
+            {
+              "path": "ci.software.Kernel",
+              "value": "6.1.158+ (x86_64)"
+            },
+            {
+              "path": "ci.software.OS",
+              "value": "Debian GNU/Linux 13"
+            },
+            {
+              "path": "ci.software.System Layer",
+              "value": "KVM"
+            },
+            {
+              "path": "ci.timestamp",
+              "value": "2026-07-17 01:07:08"
+            },
+            {
+              "path": "ci.user",
+              "value": "root"
+            }
+          ]
+        },
+        {
+          "source": "phoronix/result-file-to-json",
+          "sourceFile": "realworld-better-auth/pts_realworld-better-auth--metadata.json",
+          "fields": [
+            {
+              "path": "ci.client_version",
+              "value": "10.8.4"
+            },
+            {
+              "path": "ci.data.cpu-microcode",
+              "value": "0x1"
+            },
+            {
+              "path": "ci.data.kernel-extra-details",
+              "value": "Transparent Huge Pages: madvise"
+            },
+            {
+              "path": "ci.data.security",
+              "value": "gather_data_sampling: Not affected + indirect_target_selection: Mitigation of Aligned branch/return thunks + itlb_multihit: Not affected + l1tf: Not affected + mds: Not affected + meltdown: Not affected + mmio_stale_data: Not affected + reg_file_data_sampling: Not affected + retbleed: Not affected + spec_rstack_overflow: Not affected + spec_store_bypass: Mitigation of SSB disabled via prctl + spectre_v1: Mitigation of usercopy/swapgs barriers and __user pointer sanitization + spectre_v2: Mitigation of Enhanced / Automatic IBRS; IBPB: conditional; PBRSB-eIBRS: SW sequence; BHI: SW loop KVM: SW loop + srbds: Not affected + tsa: Not affected + tsx_async_abort: Not affected + vmscape: Not affected"
+            },
+            {
+              "path": "ci.hardware.Disk",
+              "value": "25GB"
+            },
+            {
+              "path": "ci.hardware.Memory",
+              "value": "8GB"
+            },
+            {
+              "path": "ci.hardware.Processor",
+              "value": "Intel Xeon (1 Core / 2 Threads)"
+            },
+            {
+              "path": "ci.identifier",
+              "value": "ci"
+            },
+            {
+              "path": "ci.software.Compiler",
+              "value": "GCC 14.2.0"
+            },
+            {
+              "path": "ci.software.File-System",
+              "value": "ext4"
+            },
+            {
+              "path": "ci.software.Kernel",
+              "value": "6.1.158+ (x86_64)"
+            },
+            {
+              "path": "ci.software.OS",
+              "value": "Debian GNU/Linux 13"
+            },
+            {
+              "path": "ci.software.System Layer",
+              "value": "KVM"
+            },
+            {
+              "path": "ci.timestamp",
+              "value": "2026-07-17 01:07:40"
+            },
+            {
+              "path": "ci.user",
+              "value": "root"
+            }
+          ]
+        },
+        {
+          "source": "phoronix/result-file-to-json",
+          "sourceFile": "system/pts_git--metadata.json",
+          "fields": [
+            {
+              "path": "ci.client_version",
+              "value": "10.8.4"
+            },
+            {
+              "path": "ci.data.cpu-microcode",
+              "value": "0x1"
+            },
+            {
+              "path": "ci.data.kernel-extra-details",
+              "value": "Transparent Huge Pages: madvise"
+            },
+            {
+              "path": "ci.data.security",
+              "value": "gather_data_sampling: Not affected + indirect_target_selection: Mitigation of Aligned branch/return thunks + itlb_multihit: Not affected + l1tf: Not affected + mds: Not affected + meltdown: Not affected + mmio_stale_data: Not affected + reg_file_data_sampling: Not affected + retbleed: Not affected + spec_rstack_overflow: Not affected + spec_store_bypass: Mitigation of SSB disabled via prctl + spectre_v1: Mitigation of usercopy/swapgs barriers and __user pointer sanitization + spectre_v2: Mitigation of Enhanced / Automatic IBRS; IBPB: conditional; PBRSB-eIBRS: SW sequence; BHI: SW loop KVM: SW loop + srbds: Not affected + tsa: Not affected + tsx_async_abort: Not affected + vmscape: Not affected"
+            },
+            {
+              "path": "ci.hardware.Disk",
+              "value": "25GB"
+            },
+            {
+              "path": "ci.hardware.Memory",
+              "value": "8GB"
+            },
+            {
+              "path": "ci.hardware.Processor",
+              "value": "Intel Xeon (1 Core / 2 Threads)"
+            },
+            {
+              "path": "ci.identifier",
+              "value": "ci"
+            },
+            {
+              "path": "ci.software.Compiler",
+              "value": "GCC 14.2.0"
+            },
+            {
+              "path": "ci.software.File-System",
+              "value": "ext4"
+            },
+            {
+              "path": "ci.software.Kernel",
+              "value": "6.1.158+ (x86_64)"
+            },
+            {
+              "path": "ci.software.OS",
+              "value": "Debian GNU/Linux 13"
+            },
+            {
+              "path": "ci.software.System Layer",
+              "value": "KVM"
+            },
+            {
+              "path": "ci.timestamp",
+              "value": "2026-07-17 01:11:16"
+            },
+            {
+              "path": "ci.user",
+              "value": "root"
+            }
+          ]
+        },
+        {
+          "source": "phoronix/result-file-to-json",
+          "sourceFile": "system/pts_pgbench-read-only--metadata.json",
+          "fields": [
+            {
+              "path": "ci.client_version",
+              "value": "10.8.4"
+            },
+            {
+              "path": "ci.data.compiler-configuration",
+              "value": "--build=x86_64-linux-gnu --disable-vtable-verify --disable-werror --enable-bootstrap --enable-cet --enable-checking=release --enable-clocale=gnu --enable-default-pie --enable-gnu-unique-object --enable-languages=c,ada,c++,go,d,fortran,objc,obj-c++,m2,rust --enable-libphobos-checking=release --enable-libstdcxx-backtrace --enable-libstdcxx-debug --enable-libstdcxx-time=yes --enable-link-serialization=3 --enable-multiarch --enable-multilib --enable-nls --enable-objc-gc=auto --enable-offload-defaulted --enable-offload-targets=nvptx-none=/build/reproducible-path/gcc-14-14.2.0/debian/tmp-nvptx/usr,amdgcn-amdhsa=/build/reproducible-path/gcc-14-14.2.0/debian/tmp-gcn/usr --enable-plugin --enable-shared --enable-threads=posix --host=x86_64-linux-gnu --program-prefix=x86_64-linux-gnu- --target=x86_64-linux-gnu --with-abi=m64 --with-arch-32=i686 --with-build-config=bootstrap-lto-lean --with-default-libstdcxx-abi=new --with-gcc-major-version-only --with-multilib-list=m32,m64,mx32 --with-target-system-zlib=auto --with-tune=generic --without-cuda-driver -v"
+            },
+            {
+              "path": "ci.data.cpu-microcode",
+              "value": "0x1"
+            },
+            {
+              "path": "ci.data.kernel-extra-details",
+              "value": "Transparent Huge Pages: madvise"
+            },
+            {
+              "path": "ci.data.security",
+              "value": "gather_data_sampling: Not affected + indirect_target_selection: Mitigation of Aligned branch/return thunks + itlb_multihit: Not affected + l1tf: Not affected + mds: Not affected + meltdown: Not affected + mmio_stale_data: Not affected + reg_file_data_sampling: Not affected + retbleed: Not affected + spec_rstack_overflow: Not affected + spec_store_bypass: Mitigation of SSB disabled via prctl + spectre_v1: Mitigation of usercopy/swapgs barriers and __user pointer sanitization + spectre_v2: Mitigation of Enhanced / Automatic IBRS; IBPB: conditional; PBRSB-eIBRS: SW sequence; BHI: SW loop KVM: SW loop + srbds: Not affected + tsa: Not affected + tsx_async_abort: Not affected + vmscape: Not affected"
+            },
+            {
+              "path": "ci.hardware.Disk",
+              "value": "25GB"
+            },
+            {
+              "path": "ci.hardware.Memory",
+              "value": "8GB"
+            },
+            {
+              "path": "ci.hardware.Processor",
+              "value": "Intel Xeon (1 Core / 2 Threads)"
+            },
+            {
+              "path": "ci.identifier",
+              "value": "ci"
+            },
+            {
+              "path": "ci.software.Compiler",
+              "value": "GCC 14.2.0"
+            },
+            {
+              "path": "ci.software.File-System",
+              "value": "ext4"
+            },
+            {
+              "path": "ci.software.Kernel",
+              "value": "6.1.158+ (x86_64)"
+            },
+            {
+              "path": "ci.software.OS",
+              "value": "Debian GNU/Linux 13"
+            },
+            {
+              "path": "ci.software.System Layer",
+              "value": "KVM"
+            },
+            {
+              "path": "ci.timestamp",
+              "value": "2026-07-17 01:10:01"
+            },
+            {
+              "path": "ci.user",
+              "value": "root"
+            }
+          ]
+        },
+        {
+          "source": "phoronix/result-file-to-json",
+          "sourceFile": "system/pts_pgbench-read-write--metadata.json",
+          "fields": [
+            {
+              "path": "ci.client_version",
+              "value": "10.8.4"
+            },
+            {
+              "path": "ci.data.compiler-configuration",
+              "value": "--build=x86_64-linux-gnu --disable-vtable-verify --disable-werror --enable-bootstrap --enable-cet --enable-checking=release --enable-clocale=gnu --enable-default-pie --enable-gnu-unique-object --enable-languages=c,ada,c++,go,d,fortran,objc,obj-c++,m2,rust --enable-libphobos-checking=release --enable-libstdcxx-backtrace --enable-libstdcxx-debug --enable-libstdcxx-time=yes --enable-link-serialization=3 --enable-multiarch --enable-multilib --enable-nls --enable-objc-gc=auto --enable-offload-defaulted --enable-offload-targets=nvptx-none=/build/reproducible-path/gcc-14-14.2.0/debian/tmp-nvptx/usr,amdgcn-amdhsa=/build/reproducible-path/gcc-14-14.2.0/debian/tmp-gcn/usr --enable-plugin --enable-shared --enable-threads=posix --host=x86_64-linux-gnu --program-prefix=x86_64-linux-gnu- --target=x86_64-linux-gnu --with-abi=m64 --with-arch-32=i686 --with-build-config=bootstrap-lto-lean --with-default-libstdcxx-abi=new --with-gcc-major-version-only --with-multilib-list=m32,m64,mx32 --with-target-system-zlib=auto --with-tune=generic --without-cuda-driver -v"
+            },
+            {
+              "path": "ci.data.cpu-microcode",
+              "value": "0x1"
+            },
+            {
+              "path": "ci.data.kernel-extra-details",
+              "value": "Transparent Huge Pages: madvise"
+            },
+            {
+              "path": "ci.data.security",
+              "value": "gather_data_sampling: Not affected + indirect_target_selection: Mitigation of Aligned branch/return thunks + itlb_multihit: Not affected + l1tf: Not affected + mds: Not affected + meltdown: Not affected + mmio_stale_data: Not affected + reg_file_data_sampling: Not affected + retbleed: Not affected + spec_rstack_overflow: Not affected + spec_store_bypass: Mitigation of SSB disabled via prctl + spectre_v1: Mitigation of usercopy/swapgs barriers and __user pointer sanitization + spectre_v2: Mitigation of Enhanced / Automatic IBRS; IBPB: conditional; PBRSB-eIBRS: SW sequence; BHI: SW loop KVM: SW loop + srbds: Not affected + tsa: Not affected + tsx_async_abort: Not affected + vmscape: Not affected"
+            },
+            {
+              "path": "ci.hardware.Disk",
+              "value": "25GB"
+            },
+            {
+              "path": "ci.hardware.Memory",
+              "value": "8GB"
+            },
+            {
+              "path": "ci.hardware.Processor",
+              "value": "Intel Xeon (1 Core / 2 Threads)"
+            },
+            {
+              "path": "ci.identifier",
+              "value": "ci"
+            },
+            {
+              "path": "ci.software.Compiler",
+              "value": "GCC 14.2.0"
+            },
+            {
+              "path": "ci.software.File-System",
+              "value": "ext4"
+            },
+            {
+              "path": "ci.software.Kernel",
+              "value": "6.1.158+ (x86_64)"
+            },
+            {
+              "path": "ci.software.OS",
+              "value": "Debian GNU/Linux 13"
+            },
+            {
+              "path": "ci.software.System Layer",
+              "value": "KVM"
+            },
+            {
+              "path": "ci.timestamp",
+              "value": "2026-07-17 01:10:40"
+            },
+            {
+              "path": "ci.user",
+              "value": "root"
+            }
+          ]
+        },
+        {
+          "source": "phoronix/result-file-to-json",
+          "sourceFile": "system/pts_pybench--metadata.json",
+          "fields": [
+            {
+              "path": "ci.client_version",
+              "value": "10.8.4"
+            },
+            {
+              "path": "ci.data.cpu-microcode",
+              "value": "0x1"
+            },
+            {
+              "path": "ci.data.kernel-extra-details",
+              "value": "Transparent Huge Pages: madvise"
+            },
+            {
+              "path": "ci.data.python",
+              "value": "mise ERROR python is not a valid shim. This likely means you uninstalled a tool and the shim does not point anything. Run `mise use ` reinstall the tool.mise ERROR : 2026.5.16 linux-x64 (2026-05-28)mise ERROR Run with--verbose or MISE_VERBOSE=1 for more information + mise ERROR python3 is not a valid shim. This likely means you uninstalled a tool and the shim does not point anything. Run `mise use ` reinstall the tool.mise ERROR : 2026.5.16 linux-x64 (2026-05-28)mise ERROR Run with--verbose or MISE_VERBOSE=1 for more information"
+            },
+            {
+              "path": "ci.data.security",
+              "value": "gather_data_sampling: Not affected + indirect_target_selection: Mitigation of Aligned branch/return thunks + itlb_multihit: Not affected + l1tf: Not affected + mds: Not affected + meltdown: Not affected + mmio_stale_data: Not affected + reg_file_data_sampling: Not affected + retbleed: Not affected + spec_rstack_overflow: Not affected + spec_store_bypass: Mitigation of SSB disabled via prctl + spectre_v1: Mitigation of usercopy/swapgs barriers and __user pointer sanitization + spectre_v2: Mitigation of Enhanced / Automatic IBRS; IBPB: conditional; PBRSB-eIBRS: SW sequence; BHI: SW loop KVM: SW loop + srbds: Not affected + tsa: Not affected + tsx_async_abort: Not affected + vmscape: Not affected"
+            },
+            {
+              "path": "ci.hardware.Disk",
+              "value": "25GB"
+            },
+            {
+              "path": "ci.hardware.Memory",
+              "value": "8GB"
+            },
+            {
+              "path": "ci.hardware.Processor",
+              "value": "Intel Xeon (1 Core / 2 Threads)"
+            },
+            {
+              "path": "ci.identifier",
+              "value": "ci"
+            },
+            {
+              "path": "ci.software.Compiler",
+              "value": "GCC 14.2.0"
+            },
+            {
+              "path": "ci.software.File-System",
+              "value": "ext4"
+            },
+            {
+              "path": "ci.software.Kernel",
+              "value": "6.1.158+ (x86_64)"
+            },
+            {
+              "path": "ci.software.OS",
+              "value": "Debian GNU/Linux 13"
+            },
+            {
+              "path": "ci.software.System Layer",
+              "value": "KVM"
+            },
+            {
+              "path": "ci.timestamp",
+              "value": "2026-07-17 01:07:05"
+            },
+            {
+              "path": "ci.user",
+              "value": "root"
+            }
+          ]
+        },
+        {
+          "source": "phoronix/result-file-to-json",
+          "sourceFile": "system/pts_sqlite-speedtest--metadata.json",
+          "fields": [
+            {
+              "path": "ci.client_version",
+              "value": "10.8.4"
+            },
+            {
+              "path": "ci.data.compiler-configuration",
+              "value": "--build=x86_64-linux-gnu --disable-vtable-verify --disable-werror --enable-bootstrap --enable-cet --enable-checking=release --enable-clocale=gnu --enable-default-pie --enable-gnu-unique-object --enable-languages=c,ada,c++,go,d,fortran,objc,obj-c++,m2,rust --enable-libphobos-checking=release --enable-libstdcxx-backtrace --enable-libstdcxx-debug --enable-libstdcxx-time=yes --enable-link-serialization=3 --enable-multiarch --enable-multilib --enable-nls --enable-objc-gc=auto --enable-offload-defaulted --enable-offload-targets=nvptx-none=/build/reproducible-path/gcc-14-14.2.0/debian/tmp-nvptx/usr,amdgcn-amdhsa=/build/reproducible-path/gcc-14-14.2.0/debian/tmp-gcn/usr --enable-plugin --enable-shared --enable-threads=posix --host=x86_64-linux-gnu --program-prefix=x86_64-linux-gnu- --target=x86_64-linux-gnu --with-abi=m64 --with-arch-32=i686 --with-build-config=bootstrap-lto-lean --with-default-libstdcxx-abi=new --with-gcc-major-version-only --with-multilib-list=m32,m64,mx32 --with-target-system-zlib=auto --with-tune=generic --without-cuda-driver -v"
+            },
+            {
+              "path": "ci.data.cpu-microcode",
+              "value": "0x1"
+            },
+            {
+              "path": "ci.data.kernel-extra-details",
+              "value": "Transparent Huge Pages: madvise"
+            },
+            {
+              "path": "ci.data.security",
+              "value": "gather_data_sampling: Not affected + indirect_target_selection: Mitigation of Aligned branch/return thunks + itlb_multihit: Not affected + l1tf: Not affected + mds: Not affected + meltdown: Not affected + mmio_stale_data: Not affected + reg_file_data_sampling: Not affected + retbleed: Not affected + spec_rstack_overflow: Not affected + spec_store_bypass: Mitigation of SSB disabled via prctl + spectre_v1: Mitigation of usercopy/swapgs barriers and __user pointer sanitization + spectre_v2: Mitigation of Enhanced / Automatic IBRS; IBPB: conditional; PBRSB-eIBRS: SW sequence; BHI: SW loop KVM: SW loop + srbds: Not affected + tsa: Not affected + tsx_async_abort: Not affected + vmscape: Not affected"
+            },
+            {
+              "path": "ci.hardware.Disk",
+              "value": "25GB"
+            },
+            {
+              "path": "ci.hardware.Memory",
+              "value": "8GB"
+            },
+            {
+              "path": "ci.hardware.Processor",
+              "value": "Intel Xeon (1 Core / 2 Threads)"
+            },
+            {
+              "path": "ci.identifier",
+              "value": "ci"
+            },
+            {
+              "path": "ci.software.Compiler",
+              "value": "GCC 14.2.0"
+            },
+            {
+              "path": "ci.software.File-System",
+              "value": "ext4"
+            },
+            {
+              "path": "ci.software.Kernel",
+              "value": "6.1.158+ (x86_64)"
+            },
+            {
+              "path": "ci.software.OS",
+              "value": "Debian GNU/Linux 13"
+            },
+            {
+              "path": "ci.software.System Layer",
+              "value": "KVM"
+            },
+            {
+              "path": "ci.timestamp",
+              "value": "2026-07-17 01:07:22"
+            },
+            {
+              "path": "ci.user",
+              "value": "root"
+            }
+          ]
+        },
+        {
+          "source": "mise/system-provider",
+          "sourceFile": "system/system-provider.json",
+          "fields": [
+            {
+              "path": "asn",
+              "value": "AS396982"
+            },
+            {
+              "path": "asn_source",
+              "value": "cymru"
+            },
+            {
+              "path": "bios_vendor",
+              "value": ""
+            },
+            {
+              "path": "city",
+              "value": "The Dalles"
+            },
+            {
+              "path": "cores",
+              "value": "2"
+            },
+            {
+              "path": "country",
+              "value": "US"
+            },
+            {
+              "path": "cpu_model",
+              "value": "Intel(R) Xeon(R) Processor @ 2.60GHz"
+            },
+            {
+              "path": "geo_source",
+              "value": "ipinfo"
+            },
+            {
+              "path": "kernel",
+              "value": "6.1.158+"
+            },
+            {
+              "path": "loc",
+              "value": "45.5946,-121.1787"
+            },
+            {
+              "path": "manufacturer",
+              "value": ""
+            },
+            {
+              "path": "org",
+              "value": "AS396982 Google LLC"
+            },
+            {
+              "path": "org_name",
+              "value": "Google LLC"
+            },
+            {
+              "path": "prefix",
+              "value": "34.169.0.0/17"
+            },
+            {
+              "path": "product_name",
+              "value": ""
+            },
+            {
+              "path": "public_ip",
+              "value": "34.169.9.225"
+            },
+            {
+              "path": "ram",
+              "value": "7.8Gi"
+            },
+            {
+              "path": "region",
+              "value": "Oregon"
+            },
+            {
+              "path": "reverse_dns",
+              "value": "225.9.169.34.bc.googleusercontent.com"
+            },
+            {
+              "path": "schema_version",
+              "value": "1.0"
+            },
+            {
+              "path": "timezone",
+              "value": "America/Los_Angeles"
+            },
+            {
+              "path": "virtualization",
+              "value": "kvm"
+            }
+          ]
+        }
+      ],
+      "metrics": [
+        {
+          "metricId": "fast_cli_internet_download_speed",
+          "samples": [3.5, 3],
+          "aggregates": {
+            "p50": 3.25,
+            "p95": 3.475,
+            "mean": 3.25,
+            "stdev": 0.3535533905932738,
+            "min": 3,
+            "max": 3.5,
+            "n": 2
+          },
+          "sourceFile": "network/pts_fast-cli.xml"
+        },
+        {
+          "metricId": "fast_cli_internet_latency",
+          "samples": [7, 7],
+          "aggregates": {
+            "p50": 7,
+            "p95": 7,
+            "mean": 7,
+            "stdev": 0,
+            "min": 7,
+            "max": 7,
+            "n": 2
+          },
+          "sourceFile": "network/pts_fast-cli.xml"
+        },
+        {
+          "metricId": "fast_cli_internet_loaded_latency_bufferbloat",
+          "samples": [9],
+          "aggregates": {
+            "p50": 9,
+            "p95": 9,
+            "mean": 9,
+            "stdev": 0,
+            "min": 9,
+            "max": 9,
+            "n": 1
+          },
+          "sourceFile": "network/pts_fast-cli.xml"
+        },
+        {
+          "metricId": "fast_cli_internet_upload_speed",
+          "samples": [780, 760],
+          "aggregates": {
+            "p50": 770,
+            "p95": 779,
+            "mean": 770,
+            "stdev": 14.142135623730951,
+            "min": 760,
+            "max": 780,
+            "n": 2
+          },
+          "sourceFile": "network/pts_fast-cli.xml"
+        },
+        {
+          "metricId": "fio_type_random_read_engine_linux_aio_direct_yes_block_size_4kb_job_count_1_disk_target_default_test_directory_iops",
+          "samples": [41300, 38700],
+          "aggregates": {
+            "p50": 40000,
+            "p95": 41170,
+            "mean": 40000,
+            "stdev": 1838.4776310850236,
+            "min": 38700,
+            "max": 41300,
+            "n": 2
+          },
+          "sourceFile": "disk/pts_fio-rand-read.xml",
+          "appVersion": "3.36",
+          "arguments": "randread libaio 1 4k 1"
+        },
+        {
+          "metricId": "fio_type_random_read_engine_linux_aio_direct_yes_block_size_4kb_job_count_1_disk_target_default_test_directory_mb_per_s",
+          "samples": [162, 151],
+          "aggregates": {
+            "p50": 156.5,
+            "p95": 161.45,
+            "mean": 156.5,
+            "stdev": 7.7781745930520225,
+            "min": 151,
+            "max": 162,
+            "n": 2
+          },
+          "sourceFile": "disk/pts_fio-rand-read.xml",
+          "appVersion": "3.36",
+          "arguments": "randread libaio 1 4k 1"
+        },
+        {
+          "metricId": "fio_type_random_write_engine_linux_aio_direct_yes_block_size_4kb_job_count_1_disk_target_default_test_directory_iops",
+          "samples": [43500, 44300],
+          "aggregates": {
+            "p50": 43900,
+            "p95": 44260,
+            "mean": 43900,
+            "stdev": 565.685424949238,
+            "min": 43500,
+            "max": 44300,
+            "n": 2
+          },
+          "sourceFile": "disk/pts_fio-rand-write.xml",
+          "appVersion": "3.36",
+          "arguments": "randwrite libaio 1 4k 1"
+        },
+        {
+          "metricId": "fio_type_random_write_engine_linux_aio_direct_yes_block_size_4kb_job_count_1_disk_target_default_test_directory_mb_per_s",
+          "samples": [170, 173],
+          "aggregates": {
+            "p50": 171.5,
+            "p95": 172.85,
+            "mean": 171.5,
+            "stdev": 2.1213203435596424,
+            "min": 170,
+            "max": 173,
+            "n": 2
+          },
+          "sourceFile": "disk/pts_fio-rand-write.xml",
+          "appVersion": "3.36",
+          "arguments": "randwrite libaio 1 4k 1"
+        },
+        {
+          "metricId": "fio_type_sequential_read_engine_linux_aio_direct_yes_block_size_1mb_job_count_1_disk_target_default_test_directory_iops",
+          "samples": [599, 599],
+          "aggregates": {
+            "p50": 599,
+            "p95": 599,
+            "mean": 599,
+            "stdev": 0,
+            "min": 599,
+            "max": 599,
+            "n": 2
+          },
+          "sourceFile": "disk/pts_fio-seq-read.xml",
+          "appVersion": "3.36",
+          "arguments": "read libaio 1 1m 1"
+        },
+        {
+          "metricId": "fio_type_sequential_read_engine_linux_aio_direct_yes_block_size_1mb_job_count_1_disk_target_default_test_directory_mb_per_s",
+          "samples": [601, 601],
+          "aggregates": {
+            "p50": 601,
+            "p95": 601,
+            "mean": 601,
+            "stdev": 0,
+            "min": 601,
+            "max": 601,
+            "n": 2
+          },
+          "sourceFile": "disk/pts_fio-seq-read.xml",
+          "appVersion": "3.36",
+          "arguments": "read libaio 1 1m 1"
+        },
+        {
+          "metricId": "fio_type_sequential_write_engine_linux_aio_direct_yes_block_size_1mb_job_count_1_disk_target_default_test_directory_iops",
+          "samples": [600, 598],
+          "aggregates": {
+            "p50": 599,
+            "p95": 599.9,
+            "mean": 599,
+            "stdev": 1.4142135623730951,
+            "min": 598,
+            "max": 600,
+            "n": 2
+          },
+          "sourceFile": "disk/pts_fio-seq-write.xml",
+          "appVersion": "3.36",
+          "arguments": "write libaio 1 1m 1"
+        },
+        {
+          "metricId": "fio_type_sequential_write_engine_linux_aio_direct_yes_block_size_1mb_job_count_1_disk_target_default_test_directory_mb_per_s",
+          "samples": [601, 600],
+          "aggregates": {
+            "p50": 600.5,
+            "p95": 600.95,
+            "mean": 600.5,
+            "stdev": 0.7071067811865476,
+            "min": 600,
+            "max": 601,
+            "n": 2
+          },
+          "sourceFile": "disk/pts_fio-seq-write.xml",
+          "appVersion": "3.36",
+          "arguments": "write libaio 1 1m 1"
+        },
+        {
+          "metricId": "git_seconds",
+          "samples": [69.915, 70.513],
+          "aggregates": {
+            "p50": 70.214,
+            "p95": 70.48310000000001,
+            "mean": 70.214,
+            "stdev": 0.4228498551495597,
+            "min": 69.915,
+            "max": 70.513,
+            "n": 2
+          },
+          "sourceFile": "system/pts_git.xml"
+        },
+        {
+          "metricId": "hardlink_bogo_ops_per_s",
+          "samples": [1.46, 1.46],
+          "aggregates": {
+            "p50": 1.46,
+            "p95": 1.46,
+            "mean": 1.46,
+            "stdev": 0,
+            "min": 1.46,
+            "max": 1.46,
+            "n": 2
+          },
+          "sourceFile": "disk/pts_hardlink.xml",
+          "appVersion": "0.16"
+        },
+        {
+          "metricId": "network_loopback_seconds",
+          "samples": [10.97, 9.903],
+          "aggregates": {
+            "p50": 10.4365,
+            "p95": 10.91665,
+            "mean": 10.4365,
+            "stdev": 0.7544829355260463,
+            "min": 9.903,
+            "max": 10.97,
+            "n": 2
+          },
+          "sourceFile": "network/pts_network-loopback.xml"
+        },
+        {
+          "metricId": "node_web_tooling_runs_per_s",
+          "samples": [10.99, 11.12],
+          "aggregates": {
+            "p50": 11.055,
+            "p95": 11.113499999999998,
+            "mean": 11.055,
+            "stdev": 0.09192388155425048,
+            "min": 10.99,
+            "max": 11.12,
+            "n": 2
+          },
+          "sourceFile": "cpu-node/pts_node-web-tooling.xml"
+        },
+        {
+          "metricId": "realworld_better_auth_task_build",
+          "samples": [21.28, 21.517],
+          "aggregates": {
+            "p50": 21.3985,
+            "p95": 21.50515,
+            "mean": 21.3985,
+            "stdev": 0.16758430714121184,
+            "min": 21.28,
+            "max": 21.517,
+            "n": 2
+          },
+          "sourceFile": "realworld-better-auth/pts_realworld-better-auth.xml",
+          "appVersion": "6f3ba45639579da152b69e8e5342e02f28288670",
+          "arguments": "build"
+        },
+        {
+          "metricId": "realworld_better_auth_task_cold_install",
+          "samples": [19.98, 19.303],
+          "aggregates": {
+            "p50": 19.6415,
+            "p95": 19.94615,
+            "mean": 19.6415,
+            "stdev": 0.4787112908632924,
+            "min": 19.303,
+            "max": 19.98,
+            "n": 2
+          },
+          "sourceFile": "realworld-better-auth/pts_realworld-better-auth.xml",
+          "appVersion": "6f3ba45639579da152b69e8e5342e02f28288670",
+          "arguments": "cold_install"
+        },
+        {
+          "metricId": "realworld_better_auth_task_git_clone",
+          "samples": [1.787, 1.768],
+          "aggregates": {
+            "p50": 1.7774999999999999,
+            "p95": 1.78605,
+            "mean": 1.7774999999999999,
+            "stdev": 0.013435028842544414,
+            "min": 1.768,
+            "max": 1.787,
+            "n": 2
+          },
+          "sourceFile": "realworld-better-auth/pts_realworld-better-auth.xml",
+          "appVersion": "6f3ba45639579da152b69e8e5342e02f28288670",
+          "arguments": "git_clone"
+        },
+        {
+          "metricId": "realworld_better_auth_task_lint_biome",
+          "samples": [8.433, 8.259],
+          "aggregates": {
+            "p50": 8.346,
+            "p95": 8.4243,
+            "mean": 8.346,
+            "stdev": 0.1230365799264589,
+            "min": 8.259,
+            "max": 8.433,
+            "n": 2
+          },
+          "sourceFile": "realworld-better-auth/pts_realworld-better-auth.xml",
+          "appVersion": "6f3ba45639579da152b69e8e5342e02f28288670",
+          "arguments": "lint_biome"
+        },
+        {
+          "metricId": "realworld_better_auth_task_lint_deps_knip",
+          "samples": [18.722, 18.778],
+          "aggregates": {
+            "p50": 18.75,
+            "p95": 18.775199999999998,
+            "mean": 18.75,
+            "stdev": 0.039597979746444814,
+            "min": 18.722,
+            "max": 18.778,
+            "n": 2
+          },
+          "sourceFile": "realworld-better-auth/pts_realworld-better-auth.xml",
+          "appVersion": "6f3ba45639579da152b69e8e5342e02f28288670",
+          "arguments": "lint_deps"
+        },
+        {
+          "metricId": "realworld_better_auth_task_lint_format",
+          "samples": [5.266, 5.157],
+          "aggregates": {
+            "p50": 5.2115,
+            "p95": 5.26055,
+            "mean": 5.2115,
+            "stdev": 0.07707463914933367,
+            "min": 5.157,
+            "max": 5.266,
+            "n": 2
+          },
+          "sourceFile": "realworld-better-auth/pts_realworld-better-auth.xml",
+          "appVersion": "6f3ba45639579da152b69e8e5342e02f28288670",
+          "arguments": "lint_format"
+        },
+        {
+          "metricId": "realworld_better_auth_task_lint_packages",
+          "samples": [7.619, 7.593],
+          "aggregates": {
+            "p50": 7.606,
+            "p95": 7.6177,
+            "mean": 7.606,
+            "stdev": 0.018384776310850094,
+            "min": 7.593,
+            "max": 7.619,
+            "n": 2
+          },
+          "sourceFile": "realworld-better-auth/pts_realworld-better-auth.xml",
+          "appVersion": "6f3ba45639579da152b69e8e5342e02f28288670",
+          "arguments": "lint_packages"
+        },
+        {
+          "metricId": "realworld_better_auth_task_lint_spell",
+          "samples": [12.292, 12.568],
+          "aggregates": {
+            "p50": 12.43,
+            "p95": 12.5542,
+            "mean": 12.43,
+            "stdev": 0.19516147160748698,
+            "min": 12.292,
+            "max": 12.568,
+            "n": 2
+          },
+          "sourceFile": "realworld-better-auth/pts_realworld-better-auth.xml",
+          "appVersion": "6f3ba45639579da152b69e8e5342e02f28288670",
+          "arguments": "lint_spell"
+        },
+        {
+          "metricId": "realworld_better_auth_task_lint_types",
+          "samples": [97.798, 99.48],
+          "aggregates": {
+            "p50": 98.63900000000001,
+            "p95": 99.3959,
+            "mean": 98.63900000000001,
+            "stdev": 1.1893536059557694,
+            "min": 97.798,
+            "max": 99.48,
+            "n": 2
+          },
+          "sourceFile": "realworld-better-auth/pts_realworld-better-auth.xml",
+          "appVersion": "6f3ba45639579da152b69e8e5342e02f28288670",
+          "arguments": "lint_types"
+        },
+        {
+          "metricId": "realworld_better_auth_task_typecheck",
+          "samples": [2.436, 2.79],
+          "aggregates": {
+            "p50": 2.613,
+            "p95": 2.7723,
+            "mean": 2.613,
+            "stdev": 0.2503158005400379,
+            "min": 2.436,
+            "max": 2.79,
+            "n": 2
+          },
+          "sourceFile": "realworld-better-auth/pts_realworld-better-auth.xml",
+          "appVersion": "6f3ba45639579da152b69e8e5342e02f28288670",
+          "arguments": "typecheck"
+        },
+        {
+          "metricId": "sqlite_speedtest_seconds",
+          "samples": [69.818, 69.863],
+          "aggregates": {
+            "p50": 69.84049999999999,
+            "p95": 69.86075,
+            "mean": 69.84049999999999,
+            "stdev": 0.03181980515340087,
+            "min": 69.818,
+            "max": 69.863,
+            "n": 2
+          },
+          "sourceFile": "system/pts_sqlite-speedtest.xml",
+          "appVersion": "3.30"
+        },
+        {
+          "metricId": "stream_type_add",
+          "samples": [22208.7, 21838.2],
+          "aggregates": {
+            "p50": 22023.45,
+            "p95": 22190.175,
+            "mean": 22023.45,
+            "stdev": 261.98306242961587,
+            "min": 21838.2,
+            "max": 22208.7,
+            "n": 2
+          },
+          "sourceFile": "memory/pts_stream.xml",
+          "appVersion": "2013-01-17",
+          "arguments": "Add"
+        },
+        {
+          "metricId": "stream_type_copy",
+          "samples": [46760.5, 43483.6],
+          "aggregates": {
+            "p50": 45122.05,
+            "p95": 46596.655,
+            "mean": 45122.05,
+            "stdev": 2317.1182112701963,
+            "min": 43483.6,
+            "max": 46760.5,
+            "n": 2
+          },
+          "sourceFile": "memory/pts_stream.xml",
+          "appVersion": "2013-01-17",
+          "arguments": "Copy"
+        },
+        {
+          "metricId": "stream_type_scale",
+          "samples": [20700.6, 21051.5],
+          "aggregates": {
+            "p50": 20876.05,
+            "p95": 21033.955,
+            "mean": 20876.05,
+            "stdev": 248.12376951836055,
+            "min": 20700.6,
+            "max": 21051.5,
+            "n": 2
+          },
+          "sourceFile": "memory/pts_stream.xml",
+          "appVersion": "2013-01-17",
+          "arguments": "Scale"
+        },
+        {
+          "metricId": "stream_type_triad",
+          "samples": [22264.7, 21772.7],
+          "aggregates": {
+            "p50": 22018.7,
+            "p95": 22240.100000000002,
+            "mean": 22018.7,
+            "stdev": 347.8965363437814,
+            "min": 21772.7,
+            "max": 22264.7,
+            "n": 2
+          },
+          "sourceFile": "memory/pts_stream.xml",
+          "appVersion": "2013-01-17",
+          "arguments": "Triad"
+        },
+        {
+          "metricId": "usd_per_hour",
+          "samples": [0.2304],
+          "aggregates": {
+            "p50": 0.2304,
+            "p95": 0.2304,
+            "mean": 0.2304,
+            "stdev": 0,
+            "min": 0.2304,
+            "max": 0.2304,
+            "n": 1
+          }
+        }
+      ],
+      "suitesCovered": ["cpu-node", "disk", "memory", "network", "realworld-better-auth", "system"],
+      "gaps": [
+        {
+          "scope": "suite",
+          "id": "cpu-generic",
+          "outcome": "failed",
+          "reason": "Step \"mise run benchmark:cpu:generic\" timed out after 7800s"
+        },
+        {
+          "scope": "suite",
+          "id": "realworld-mastra",
+          "outcome": "skipped",
+          "reason": "Insufficient disk: 20.0 GiB free, suite needs 30 GiB"
+        },
+        {
+          "scope": "suite",
+          "id": "realworld-openclaw",
+          "outcome": "skipped",
+          "reason": "Insufficient disk: 20.0 GiB free, suite needs 25 GiB"
+        }
+      ],
+      "uncatalogued": []
+    },
+    {
+      "providerId": "modal",
+      "validationStatus": "validated",
+      "specMatched": true,
+      "observedSpecs": {
+        "vcpus": 2,
+        "cpuModel": "unknown",
+        "virtualization": "unknown",
+        "memoryGb": 8,
+        "kernel": "4.19.0-gvisor",
+        "os": "Debian GNU/Linux 13 (trixie)",
+        "user": "root",
+        "hostVcpus": 2,
+        "hostMemoryGb": 8,
+        "publicIp": "20.118.128.192",
+        "egressOrg": "AS8075 Microsoft Corporation",
+        "egressAsn": "AS8075",
+        "egressOrgName": "Microsoft Corporation",
+        "city": "Phoenix",
+        "region": "Arizona",
+        "country": "US",
+        "location": "33.4484,-112.0740",
+        "timezone": "America/Phoenix",
+        "networkPrefix": "20.64.0.0/10",
+        "asnSource": "cymru",
+        "geoSource": "ipinfo"
+      },
+      "hostMetadata": [
+        {
+          "source": "phoronix/result-file-to-json",
+          "sourceFile": "cpu-node/pts_node-web-tooling--metadata.json",
+          "fields": [
+            {
+              "path": "ci.client_version",
+              "value": "10.8.4"
+            },
+            {
+              "path": "ci.data.environment-variables",
+              "value": "CFLAGS=-g0"
+            },
+            {
+              "path": "ci.hardware.Disk",
+              "value": "8589934592GB"
+            },
+            {
+              "path": "ci.hardware.Memory",
+              "value": "8GB"
+            },
+            {
+              "path": "ci.hardware.Processor",
+              "value": "unknown (2 Cores)"
+            },
+            {
+              "path": "ci.identifier",
+              "value": "ci"
+            },
+            {
+              "path": "ci.software.Compiler",
+              "value": "GCC 14.2.0"
+            },
+            {
+              "path": "ci.software.File-System",
+              "value": "overlayfs"
+            },
+            {
+              "path": "ci.software.Kernel",
+              "value": "4.19.0-gvisor (x86_64)"
+            },
+            {
+              "path": "ci.software.OS",
+              "value": "Debian GNU/Linux 13"
+            },
+            {
+              "path": "ci.timestamp",
+              "value": "2026-07-17 01:07:30"
+            },
+            {
+              "path": "ci.user",
+              "value": "root"
+            }
+          ]
+        },
+        {
+          "source": "phoronix/result-file-to-json",
+          "sourceFile": "disk/pts_fio-rand-read--metadata.json",
+          "fields": [
+            {
+              "path": "ci.client_version",
+              "value": "10.8.4"
+            },
+            {
+              "path": "ci.data.compiler-configuration",
+              "value": "--build=x86_64-linux-gnu --disable-vtable-verify --disable-werror --enable-bootstrap --enable-cet --enable-checking=release --enable-clocale=gnu --enable-default-pie --enable-gnu-unique-object --enable-languages=c,ada,c++,go,d,fortran,objc,obj-c++,m2,rust --enable-libphobos-checking=release --enable-libstdcxx-backtrace --enable-libstdcxx-debug --enable-libstdcxx-time=yes --enable-link-serialization=3 --enable-multiarch --enable-multilib --enable-nls --enable-objc-gc=auto --enable-offload-defaulted --enable-offload-targets=nvptx-none=/build/reproducible-path/gcc-14-14.2.0/debian/tmp-nvptx/usr,amdgcn-amdhsa=/build/reproducible-path/gcc-14-14.2.0/debian/tmp-gcn/usr --enable-plugin --enable-shared --enable-threads=posix --host=x86_64-linux-gnu --program-prefix=x86_64-linux-gnu- --target=x86_64-linux-gnu --with-abi=m64 --with-arch-32=i686 --with-build-config=bootstrap-lto-lean --with-default-libstdcxx-abi=new --with-gcc-major-version-only --with-multilib-list=m32,m64,mx32 --with-target-system-zlib=auto --with-tune=generic --without-cuda-driver -v"
+            },
+            {
+              "path": "ci.data.environment-variables",
+              "value": "CFLAGS=-g0"
+            },
+            {
+              "path": "ci.hardware.Disk",
+              "value": "8589934592GB"
+            },
+            {
+              "path": "ci.hardware.Memory",
+              "value": "8GB"
+            },
+            {
+              "path": "ci.hardware.Processor",
+              "value": "unknown (2 Cores)"
+            },
+            {
+              "path": "ci.identifier",
+              "value": "ci"
+            },
+            {
+              "path": "ci.software.Compiler",
+              "value": "GCC 14.2.0"
+            },
+            {
+              "path": "ci.software.File-System",
+              "value": "overlayfs"
+            },
+            {
+              "path": "ci.software.Kernel",
+              "value": "4.19.0-gvisor (x86_64)"
+            },
+            {
+              "path": "ci.software.OS",
+              "value": "Debian GNU/Linux 13"
+            },
+            {
+              "path": "ci.timestamp",
+              "value": "2026-07-17 01:15:00"
+            },
+            {
+              "path": "ci.user",
+              "value": "root"
+            }
+          ]
+        },
+        {
+          "source": "phoronix/result-file-to-json",
+          "sourceFile": "disk/pts_fio-rand-write--metadata.json",
+          "fields": [
+            {
+              "path": "ci.client_version",
+              "value": "10.8.4"
+            },
+            {
+              "path": "ci.data.compiler-configuration",
+              "value": "--build=x86_64-linux-gnu --disable-vtable-verify --disable-werror --enable-bootstrap --enable-cet --enable-checking=release --enable-clocale=gnu --enable-default-pie --enable-gnu-unique-object --enable-languages=c,ada,c++,go,d,fortran,objc,obj-c++,m2,rust --enable-libphobos-checking=release --enable-libstdcxx-backtrace --enable-libstdcxx-debug --enable-libstdcxx-time=yes --enable-link-serialization=3 --enable-multiarch --enable-multilib --enable-nls --enable-objc-gc=auto --enable-offload-defaulted --enable-offload-targets=nvptx-none=/build/reproducible-path/gcc-14-14.2.0/debian/tmp-nvptx/usr,amdgcn-amdhsa=/build/reproducible-path/gcc-14-14.2.0/debian/tmp-gcn/usr --enable-plugin --enable-shared --enable-threads=posix --host=x86_64-linux-gnu --program-prefix=x86_64-linux-gnu- --target=x86_64-linux-gnu --with-abi=m64 --with-arch-32=i686 --with-build-config=bootstrap-lto-lean --with-default-libstdcxx-abi=new --with-gcc-major-version-only --with-multilib-list=m32,m64,mx32 --with-target-system-zlib=auto --with-tune=generic --without-cuda-driver -v"
+            },
+            {
+              "path": "ci.data.environment-variables",
+              "value": "CFLAGS=-g0"
+            },
+            {
+              "path": "ci.hardware.Disk",
+              "value": "8589934592GB"
+            },
+            {
+              "path": "ci.hardware.Memory",
+              "value": "8GB"
+            },
+            {
+              "path": "ci.hardware.Processor",
+              "value": "unknown (2 Cores)"
+            },
+            {
+              "path": "ci.identifier",
+              "value": "ci"
+            },
+            {
+              "path": "ci.software.Compiler",
+              "value": "GCC 14.2.0"
+            },
+            {
+              "path": "ci.software.File-System",
+              "value": "overlayfs"
+            },
+            {
+              "path": "ci.software.Kernel",
+              "value": "4.19.0-gvisor (x86_64)"
+            },
+            {
+              "path": "ci.software.OS",
+              "value": "Debian GNU/Linux 13"
+            },
+            {
+              "path": "ci.timestamp",
+              "value": "2026-07-17 01:18:26"
+            },
+            {
+              "path": "ci.user",
+              "value": "root"
+            }
+          ]
+        },
+        {
+          "source": "phoronix/result-file-to-json",
+          "sourceFile": "disk/pts_fio-seq-read--metadata.json",
+          "fields": [
+            {
+              "path": "ci.client_version",
+              "value": "10.8.4"
+            },
+            {
+              "path": "ci.data.compiler-configuration",
+              "value": "--build=x86_64-linux-gnu --disable-vtable-verify --disable-werror --enable-bootstrap --enable-cet --enable-checking=release --enable-clocale=gnu --enable-default-pie --enable-gnu-unique-object --enable-languages=c,ada,c++,go,d,fortran,objc,obj-c++,m2,rust --enable-libphobos-checking=release --enable-libstdcxx-backtrace --enable-libstdcxx-debug --enable-libstdcxx-time=yes --enable-link-serialization=3 --enable-multiarch --enable-multilib --enable-nls --enable-objc-gc=auto --enable-offload-defaulted --enable-offload-targets=nvptx-none=/build/reproducible-path/gcc-14-14.2.0/debian/tmp-nvptx/usr,amdgcn-amdhsa=/build/reproducible-path/gcc-14-14.2.0/debian/tmp-gcn/usr --enable-plugin --enable-shared --enable-threads=posix --host=x86_64-linux-gnu --program-prefix=x86_64-linux-gnu- --target=x86_64-linux-gnu --with-abi=m64 --with-arch-32=i686 --with-build-config=bootstrap-lto-lean --with-default-libstdcxx-abi=new --with-gcc-major-version-only --with-multilib-list=m32,m64,mx32 --with-target-system-zlib=auto --with-tune=generic --without-cuda-driver -v"
+            },
+            {
+              "path": "ci.data.environment-variables",
+              "value": "CFLAGS=-g0"
+            },
+            {
+              "path": "ci.hardware.Disk",
+              "value": "8589934592GB"
+            },
+            {
+              "path": "ci.hardware.Memory",
+              "value": "8GB"
+            },
+            {
+              "path": "ci.hardware.Processor",
+              "value": "unknown (2 Cores)"
+            },
+            {
+              "path": "ci.identifier",
+              "value": "ci"
+            },
+            {
+              "path": "ci.software.Compiler",
+              "value": "GCC 14.2.0"
+            },
+            {
+              "path": "ci.software.File-System",
+              "value": "overlayfs"
+            },
+            {
+              "path": "ci.software.Kernel",
+              "value": "4.19.0-gvisor (x86_64)"
+            },
+            {
+              "path": "ci.software.OS",
+              "value": "Debian GNU/Linux 13"
+            },
+            {
+              "path": "ci.timestamp",
+              "value": "2026-07-17 01:08:26"
+            },
+            {
+              "path": "ci.user",
+              "value": "root"
+            }
+          ]
+        },
+        {
+          "source": "phoronix/result-file-to-json",
+          "sourceFile": "disk/pts_fio-seq-write--metadata.json",
+          "fields": [
+            {
+              "path": "ci.client_version",
+              "value": "10.8.4"
+            },
+            {
+              "path": "ci.data.compiler-configuration",
+              "value": "--build=x86_64-linux-gnu --disable-vtable-verify --disable-werror --enable-bootstrap --enable-cet --enable-checking=release --enable-clocale=gnu --enable-default-pie --enable-gnu-unique-object --enable-languages=c,ada,c++,go,d,fortran,objc,obj-c++,m2,rust --enable-libphobos-checking=release --enable-libstdcxx-backtrace --enable-libstdcxx-debug --enable-libstdcxx-time=yes --enable-link-serialization=3 --enable-multiarch --enable-multilib --enable-nls --enable-objc-gc=auto --enable-offload-defaulted --enable-offload-targets=nvptx-none=/build/reproducible-path/gcc-14-14.2.0/debian/tmp-nvptx/usr,amdgcn-amdhsa=/build/reproducible-path/gcc-14-14.2.0/debian/tmp-gcn/usr --enable-plugin --enable-shared --enable-threads=posix --host=x86_64-linux-gnu --program-prefix=x86_64-linux-gnu- --target=x86_64-linux-gnu --with-abi=m64 --with-arch-32=i686 --with-build-config=bootstrap-lto-lean --with-default-libstdcxx-abi=new --with-gcc-major-version-only --with-multilib-list=m32,m64,mx32 --with-target-system-zlib=auto --with-tune=generic --without-cuda-driver -v"
+            },
+            {
+              "path": "ci.data.environment-variables",
+              "value": "CFLAGS=-g0"
+            },
+            {
+              "path": "ci.hardware.Disk",
+              "value": "8589934592GB"
+            },
+            {
+              "path": "ci.hardware.Memory",
+              "value": "8GB"
+            },
+            {
+              "path": "ci.hardware.Processor",
+              "value": "unknown (2 Cores)"
+            },
+            {
+              "path": "ci.identifier",
+              "value": "ci"
+            },
+            {
+              "path": "ci.software.Compiler",
+              "value": "GCC 14.2.0"
+            },
+            {
+              "path": "ci.software.File-System",
+              "value": "overlayfs"
+            },
+            {
+              "path": "ci.software.Kernel",
+              "value": "4.19.0-gvisor (x86_64)"
+            },
+            {
+              "path": "ci.software.OS",
+              "value": "Debian GNU/Linux 13"
+            },
+            {
+              "path": "ci.timestamp",
+              "value": "2026-07-17 01:11:43"
+            },
+            {
+              "path": "ci.user",
+              "value": "root"
+            }
+          ]
+        },
+        {
+          "source": "phoronix/result-file-to-json",
+          "sourceFile": "disk/pts_hardlink--metadata.json",
+          "fields": [
+            {
+              "path": "ci.client_version",
+              "value": "10.8.4"
+            },
+            {
+              "path": "ci.data.compiler-configuration",
+              "value": "--build=x86_64-linux-gnu --disable-vtable-verify --disable-werror --enable-bootstrap --enable-cet --enable-checking=release --enable-clocale=gnu --enable-default-pie --enable-gnu-unique-object --enable-languages=c,ada,c++,go,d,fortran,objc,obj-c++,m2,rust --enable-libphobos-checking=release --enable-libstdcxx-backtrace --enable-libstdcxx-debug --enable-libstdcxx-time=yes --enable-link-serialization=3 --enable-multiarch --enable-multilib --enable-nls --enable-objc-gc=auto --enable-offload-defaulted --enable-offload-targets=nvptx-none=/build/reproducible-path/gcc-14-14.2.0/debian/tmp-nvptx/usr,amdgcn-amdhsa=/build/reproducible-path/gcc-14-14.2.0/debian/tmp-gcn/usr --enable-plugin --enable-shared --enable-threads=posix --host=x86_64-linux-gnu --program-prefix=x86_64-linux-gnu- --target=x86_64-linux-gnu --with-abi=m64 --with-arch-32=i686 --with-build-config=bootstrap-lto-lean --with-default-libstdcxx-abi=new --with-gcc-major-version-only --with-multilib-list=m32,m64,mx32 --with-target-system-zlib=auto --with-tune=generic --without-cuda-driver -v"
+            },
+            {
+              "path": "ci.data.environment-variables",
+              "value": "CFLAGS=-g0"
+            },
+            {
+              "path": "ci.hardware.Disk",
+              "value": "8589934592GB"
+            },
+            {
+              "path": "ci.hardware.Memory",
+              "value": "8GB"
+            },
+            {
+              "path": "ci.hardware.Processor",
+              "value": "unknown (2 Cores)"
+            },
+            {
+              "path": "ci.identifier",
+              "value": "ci"
+            },
+            {
+              "path": "ci.software.Compiler",
+              "value": "GCC 14.2.0"
+            },
+            {
+              "path": "ci.software.File-System",
+              "value": "overlayfs"
+            },
+            {
+              "path": "ci.software.Kernel",
+              "value": "4.19.0-gvisor (x86_64)"
+            },
+            {
+              "path": "ci.software.OS",
+              "value": "Debian GNU/Linux 13"
+            },
+            {
+              "path": "ci.timestamp",
+              "value": "2026-07-17 01:21:45"
+            },
+            {
+              "path": "ci.user",
+              "value": "root"
+            }
+          ]
+        },
+        {
+          "source": "phoronix/result-file-to-json",
+          "sourceFile": "memory/pts_stream--metadata.json",
+          "fields": [
+            {
+              "path": "ci.client_version",
+              "value": "10.8.4"
+            },
+            {
+              "path": "ci.data.compiler-configuration",
+              "value": "--build=x86_64-linux-gnu --disable-vtable-verify --disable-werror --enable-bootstrap --enable-cet --enable-checking=release --enable-clocale=gnu --enable-default-pie --enable-gnu-unique-object --enable-languages=c,ada,c++,go,d,fortran,objc,obj-c++,m2,rust --enable-libphobos-checking=release --enable-libstdcxx-backtrace --enable-libstdcxx-debug --enable-libstdcxx-time=yes --enable-link-serialization=3 --enable-multiarch --enable-multilib --enable-nls --enable-objc-gc=auto --enable-offload-defaulted --enable-offload-targets=nvptx-none=/build/reproducible-path/gcc-14-14.2.0/debian/tmp-nvptx/usr,amdgcn-amdhsa=/build/reproducible-path/gcc-14-14.2.0/debian/tmp-gcn/usr --enable-plugin --enable-shared --enable-threads=posix --host=x86_64-linux-gnu --program-prefix=x86_64-linux-gnu- --target=x86_64-linux-gnu --with-abi=m64 --with-arch-32=i686 --with-build-config=bootstrap-lto-lean --with-default-libstdcxx-abi=new --with-gcc-major-version-only --with-multilib-list=m32,m64,mx32 --with-target-system-zlib=auto --with-tune=generic --without-cuda-driver -v"
+            },
+            {
+              "path": "ci.data.environment-variables",
+              "value": "CFLAGS=-g0 CFLAGS_OVERRIDE=\"-O3 -march=native -DSTREAM_ARRAY_SIZE=150000000\""
+            },
+            {
+              "path": "ci.hardware.Disk",
+              "value": "8589934592GB"
+            },
+            {
+              "path": "ci.hardware.Memory",
+              "value": "8GB"
+            },
+            {
+              "path": "ci.hardware.Processor",
+              "value": "unknown (2 Cores)"
+            },
+            {
+              "path": "ci.identifier",
+              "value": "ci"
+            },
+            {
+              "path": "ci.software.Compiler",
+              "value": "GCC 14.2.0"
+            },
+            {
+              "path": "ci.software.File-System",
+              "value": "overlayfs"
+            },
+            {
+              "path": "ci.software.Kernel",
+              "value": "4.19.0-gvisor (x86_64)"
+            },
+            {
+              "path": "ci.software.OS",
+              "value": "Debian GNU/Linux 13"
+            },
+            {
+              "path": "ci.timestamp",
+              "value": "2026-07-17 01:07:17"
+            },
+            {
+              "path": "ci.user",
+              "value": "root"
+            }
+          ]
+        },
+        {
+          "source": "phoronix/result-file-to-json",
+          "sourceFile": "network/pts_fast-cli--metadata.json",
+          "fields": [
+            {
+              "path": "ci.client_version",
+              "value": "10.8.4"
+            },
+            {
+              "path": "ci.data.environment-variables",
+              "value": "CFLAGS=-g0"
+            },
+            {
+              "path": "ci.hardware.Disk",
+              "value": "8589934592GB"
+            },
+            {
+              "path": "ci.hardware.Memory",
+              "value": "8GB"
+            },
+            {
+              "path": "ci.hardware.Processor",
+              "value": "unknown (2 Cores)"
+            },
+            {
+              "path": "ci.identifier",
+              "value": "ci"
+            },
+            {
+              "path": "ci.software.Compiler",
+              "value": "GCC 14.2.0"
+            },
+            {
+              "path": "ci.software.File-System",
+              "value": "overlayfs"
+            },
+            {
+              "path": "ci.software.Kernel",
+              "value": "4.19.0-gvisor (x86_64)"
+            },
+            {
+              "path": "ci.software.OS",
+              "value": "Debian GNU/Linux 13"
+            },
+            {
+              "path": "ci.timestamp",
+              "value": "2026-07-17 01:10:03"
+            },
+            {
+              "path": "ci.user",
+              "value": "root"
+            }
+          ]
+        },
+        {
+          "source": "phoronix/result-file-to-json",
+          "sourceFile": "network/pts_network-loopback--metadata.json",
+          "fields": [
+            {
+              "path": "ci.client_version",
+              "value": "10.8.4"
+            },
+            {
+              "path": "ci.data.environment-variables",
+              "value": "CFLAGS=-g0"
+            },
+            {
+              "path": "ci.hardware.Disk",
+              "value": "8589934592GB"
+            },
+            {
+              "path": "ci.hardware.Memory",
+              "value": "8GB"
+            },
+            {
+              "path": "ci.hardware.Processor",
+              "value": "unknown (2 Cores)"
+            },
+            {
+              "path": "ci.identifier",
+              "value": "ci"
+            },
+            {
+              "path": "ci.software.Compiler",
+              "value": "GCC 14.2.0"
+            },
+            {
+              "path": "ci.software.File-System",
+              "value": "overlayfs"
+            },
+            {
+              "path": "ci.software.Kernel",
+              "value": "4.19.0-gvisor (x86_64)"
+            },
+            {
+              "path": "ci.software.OS",
+              "value": "Debian GNU/Linux 13"
+            },
+            {
+              "path": "ci.timestamp",
+              "value": "2026-07-17 01:07:19"
+            },
+            {
+              "path": "ci.user",
+              "value": "root"
+            }
+          ]
+        },
+        {
+          "source": "phoronix/result-file-to-json",
+          "sourceFile": "realworld-better-auth/pts_realworld-better-auth--metadata.json",
+          "fields": [
+            {
+              "path": "ci.client_version",
+              "value": "10.8.4"
+            },
+            {
+              "path": "ci.data.environment-variables",
+              "value": "CFLAGS=-g0"
+            },
+            {
+              "path": "ci.hardware.Disk",
+              "value": "8589934592GB"
+            },
+            {
+              "path": "ci.hardware.Memory",
+              "value": "8GB"
+            },
+            {
+              "path": "ci.hardware.Processor",
+              "value": "unknown (2 Cores)"
+            },
+            {
+              "path": "ci.identifier",
+              "value": "ci"
+            },
+            {
+              "path": "ci.software.Compiler",
+              "value": "GCC 14.2.0"
+            },
+            {
+              "path": "ci.software.File-System",
+              "value": "overlayfs"
+            },
+            {
+              "path": "ci.software.Kernel",
+              "value": "4.19.0-gvisor (x86_64)"
+            },
+            {
+              "path": "ci.software.OS",
+              "value": "Debian GNU/Linux 13"
+            },
+            {
+              "path": "ci.timestamp",
+              "value": "2026-07-17 01:08:14"
+            },
+            {
+              "path": "ci.user",
+              "value": "root"
+            }
+          ]
+        },
+        {
+          "source": "phoronix/result-file-to-json",
+          "sourceFile": "realworld-mastra/pts_realworld-mastra--metadata.json",
+          "fields": [
+            {
+              "path": "ci.client_version",
+              "value": "10.8.4"
+            },
+            {
+              "path": "ci.data.environment-variables",
+              "value": "CFLAGS=-g0"
+            },
+            {
+              "path": "ci.hardware.Disk",
+              "value": "8589934592GB"
+            },
+            {
+              "path": "ci.hardware.Memory",
+              "value": "8GB"
+            },
+            {
+              "path": "ci.hardware.Processor",
+              "value": "unknown (2 Cores)"
+            },
+            {
+              "path": "ci.identifier",
+              "value": "ci"
+            },
+            {
+              "path": "ci.software.Compiler",
+              "value": "GCC 14.2.0"
+            },
+            {
+              "path": "ci.software.File-System",
+              "value": "overlayfs"
+            },
+            {
+              "path": "ci.software.Kernel",
+              "value": "4.19.0-gvisor (x86_64)"
+            },
+            {
+              "path": "ci.software.OS",
+              "value": "Debian GNU/Linux 13"
+            },
+            {
+              "path": "ci.timestamp",
+              "value": "2026-07-17 01:09:58"
+            },
+            {
+              "path": "ci.user",
+              "value": "root"
+            }
+          ]
+        },
+        {
+          "source": "phoronix/result-file-to-json",
+          "sourceFile": "system/pts_git--metadata.json",
+          "fields": [
+            {
+              "path": "ci.client_version",
+              "value": "10.8.4"
+            },
+            {
+              "path": "ci.data.environment-variables",
+              "value": "CFLAGS=-g0"
+            },
+            {
+              "path": "ci.hardware.Disk",
+              "value": "8589934592GB"
+            },
+            {
+              "path": "ci.hardware.Memory",
+              "value": "8GB"
+            },
+            {
+              "path": "ci.hardware.Processor",
+              "value": "unknown (2 Cores)"
+            },
+            {
+              "path": "ci.identifier",
+              "value": "ci"
+            },
+            {
+              "path": "ci.software.Compiler",
+              "value": "GCC 14.2.0"
+            },
+            {
+              "path": "ci.software.File-System",
+              "value": "overlayfs"
+            },
+            {
+              "path": "ci.software.Kernel",
+              "value": "4.19.0-gvisor (x86_64)"
+            },
+            {
+              "path": "ci.software.OS",
+              "value": "Debian GNU/Linux 13"
+            },
+            {
+              "path": "ci.timestamp",
+              "value": "2026-07-17 01:29:55"
+            },
+            {
+              "path": "ci.user",
+              "value": "root"
+            }
+          ]
+        },
+        {
+          "source": "phoronix/result-file-to-json",
+          "sourceFile": "system/pts_pgbench-read-only--metadata.json",
+          "fields": [
+            {
+              "path": "ci.client_version",
+              "value": "10.8.4"
+            },
+            {
+              "path": "ci.data.compiler-configuration",
+              "value": "--build=x86_64-linux-gnu --disable-vtable-verify --disable-werror --enable-bootstrap --enable-cet --enable-checking=release --enable-clocale=gnu --enable-default-pie --enable-gnu-unique-object --enable-languages=c,ada,c++,go,d,fortran,objc,obj-c++,m2,rust --enable-libphobos-checking=release --enable-libstdcxx-backtrace --enable-libstdcxx-debug --enable-libstdcxx-time=yes --enable-link-serialization=3 --enable-multiarch --enable-multilib --enable-nls --enable-objc-gc=auto --enable-offload-defaulted --enable-offload-targets=nvptx-none=/build/reproducible-path/gcc-14-14.2.0/debian/tmp-nvptx/usr,amdgcn-amdhsa=/build/reproducible-path/gcc-14-14.2.0/debian/tmp-gcn/usr --enable-plugin --enable-shared --enable-threads=posix --host=x86_64-linux-gnu --program-prefix=x86_64-linux-gnu- --target=x86_64-linux-gnu --with-abi=m64 --with-arch-32=i686 --with-build-config=bootstrap-lto-lean --with-default-libstdcxx-abi=new --with-gcc-major-version-only --with-multilib-list=m32,m64,mx32 --with-target-system-zlib=auto --with-tune=generic --without-cuda-driver -v"
+            },
+            {
+              "path": "ci.data.environment-variables",
+              "value": "CFLAGS=-g0"
+            },
+            {
+              "path": "ci.hardware.Disk",
+              "value": "8589934592GB"
+            },
+            {
+              "path": "ci.hardware.Memory",
+              "value": "8GB"
+            },
+            {
+              "path": "ci.hardware.Processor",
+              "value": "unknown (2 Cores)"
+            },
+            {
+              "path": "ci.identifier",
+              "value": "ci"
+            },
+            {
+              "path": "ci.software.Compiler",
+              "value": "GCC 14.2.0"
+            },
+            {
+              "path": "ci.software.File-System",
+              "value": "overlayfs"
+            },
+            {
+              "path": "ci.software.Kernel",
+              "value": "4.19.0-gvisor (x86_64)"
+            },
+            {
+              "path": "ci.software.OS",
+              "value": "Debian GNU/Linux 13"
+            },
+            {
+              "path": "ci.timestamp",
+              "value": "2026-07-17 01:27:09"
+            },
+            {
+              "path": "ci.user",
+              "value": "root"
+            }
+          ]
+        },
+        {
+          "source": "phoronix/result-file-to-json",
+          "sourceFile": "system/pts_pgbench-read-write--metadata.json",
+          "fields": [
+            {
+              "path": "ci.client_version",
+              "value": "10.8.4"
+            },
+            {
+              "path": "ci.data.compiler-configuration",
+              "value": "--build=x86_64-linux-gnu --disable-vtable-verify --disable-werror --enable-bootstrap --enable-cet --enable-checking=release --enable-clocale=gnu --enable-default-pie --enable-gnu-unique-object --enable-languages=c,ada,c++,go,d,fortran,objc,obj-c++,m2,rust --enable-libphobos-checking=release --enable-libstdcxx-backtrace --enable-libstdcxx-debug --enable-libstdcxx-time=yes --enable-link-serialization=3 --enable-multiarch --enable-multilib --enable-nls --enable-objc-gc=auto --enable-offload-defaulted --enable-offload-targets=nvptx-none=/build/reproducible-path/gcc-14-14.2.0/debian/tmp-nvptx/usr,amdgcn-amdhsa=/build/reproducible-path/gcc-14-14.2.0/debian/tmp-gcn/usr --enable-plugin --enable-shared --enable-threads=posix --host=x86_64-linux-gnu --program-prefix=x86_64-linux-gnu- --target=x86_64-linux-gnu --with-abi=m64 --with-arch-32=i686 --with-build-config=bootstrap-lto-lean --with-default-libstdcxx-abi=new --with-gcc-major-version-only --with-multilib-list=m32,m64,mx32 --with-target-system-zlib=auto --with-tune=generic --without-cuda-driver -v"
+            },
+            {
+              "path": "ci.data.environment-variables",
+              "value": "CFLAGS=-g0"
+            },
+            {
+              "path": "ci.hardware.Disk",
+              "value": "8589934592GB"
+            },
+            {
+              "path": "ci.hardware.Memory",
+              "value": "8GB"
+            },
+            {
+              "path": "ci.hardware.Processor",
+              "value": "unknown (2 Cores)"
+            },
+            {
+              "path": "ci.identifier",
+              "value": "ci"
+            },
+            {
+              "path": "ci.software.Compiler",
+              "value": "GCC 14.2.0"
+            },
+            {
+              "path": "ci.software.File-System",
+              "value": "overlayfs"
+            },
+            {
+              "path": "ci.software.Kernel",
+              "value": "4.19.0-gvisor (x86_64)"
+            },
+            {
+              "path": "ci.software.OS",
+              "value": "Debian GNU/Linux 13"
+            },
+            {
+              "path": "ci.timestamp",
+              "value": "2026-07-17 01:27:52"
+            },
+            {
+              "path": "ci.user",
+              "value": "root"
+            }
+          ]
+        },
+        {
+          "source": "phoronix/result-file-to-json",
+          "sourceFile": "system/pts_pybench--metadata.json",
+          "fields": [
+            {
+              "path": "ci.client_version",
+              "value": "10.8.4"
+            },
+            {
+              "path": "ci.data.environment-variables",
+              "value": "CFLAGS=-g0"
+            },
+            {
+              "path": "ci.data.python",
+              "value": "mise ERROR python is not a valid shim. This likely means you uninstalled a tool and the shim does not point anything. Run `mise use ` reinstall the tool.mise ERROR : 2026.5.16 linux-x64 (2026-05-28)mise ERROR Run with--verbose or MISE_VERBOSE=1 for more information + mise ERROR python3 is not a valid shim. This likely means you uninstalled a tool and the shim does not point anything. Run `mise use ` reinstall the tool.mise ERROR : 2026.5.16 linux-x64 (2026-05-28)mise ERROR Run with--verbose or MISE_VERBOSE=1 for more information"
+            },
+            {
+              "path": "ci.hardware.Disk",
+              "value": "8589934592GB"
+            },
+            {
+              "path": "ci.hardware.Memory",
+              "value": "8GB"
+            },
+            {
+              "path": "ci.hardware.Processor",
+              "value": "unknown (2 Cores)"
+            },
+            {
+              "path": "ci.identifier",
+              "value": "ci"
+            },
+            {
+              "path": "ci.software.Compiler",
+              "value": "GCC 14.2.0"
+            },
+            {
+              "path": "ci.software.File-System",
+              "value": "overlayfs"
+            },
+            {
+              "path": "ci.software.Kernel",
+              "value": "4.19.0-gvisor (x86_64)"
+            },
+            {
+              "path": "ci.software.OS",
+              "value": "Debian GNU/Linux 13"
+            },
+            {
+              "path": "ci.timestamp",
+              "value": "2026-07-17 01:07:58"
+            },
+            {
+              "path": "ci.user",
+              "value": "root"
+            }
+          ]
+        },
+        {
+          "source": "phoronix/result-file-to-json",
+          "sourceFile": "system/pts_sqlite-speedtest--metadata.json",
+          "fields": [
+            {
+              "path": "ci.client_version",
+              "value": "10.8.4"
+            },
+            {
+              "path": "ci.data.compiler-configuration",
+              "value": "--build=x86_64-linux-gnu --disable-vtable-verify --disable-werror --enable-bootstrap --enable-cet --enable-checking=release --enable-clocale=gnu --enable-default-pie --enable-gnu-unique-object --enable-languages=c,ada,c++,go,d,fortran,objc,obj-c++,m2,rust --enable-libphobos-checking=release --enable-libstdcxx-backtrace --enable-libstdcxx-debug --enable-libstdcxx-time=yes --enable-link-serialization=3 --enable-multiarch --enable-multilib --enable-nls --enable-objc-gc=auto --enable-offload-defaulted --enable-offload-targets=nvptx-none=/build/reproducible-path/gcc-14-14.2.0/debian/tmp-nvptx/usr,amdgcn-amdhsa=/build/reproducible-path/gcc-14-14.2.0/debian/tmp-gcn/usr --enable-plugin --enable-shared --enable-threads=posix --host=x86_64-linux-gnu --program-prefix=x86_64-linux-gnu- --target=x86_64-linux-gnu --with-abi=m64 --with-arch-32=i686 --with-build-config=bootstrap-lto-lean --with-default-libstdcxx-abi=new --with-gcc-major-version-only --with-multilib-list=m32,m64,mx32 --with-target-system-zlib=auto --with-tune=generic --without-cuda-driver -v"
+            },
+            {
+              "path": "ci.data.environment-variables",
+              "value": "CFLAGS=-g0"
+            },
+            {
+              "path": "ci.hardware.Disk",
+              "value": "8589934592GB"
+            },
+            {
+              "path": "ci.hardware.Memory",
+              "value": "8GB"
+            },
+            {
+              "path": "ci.hardware.Processor",
+              "value": "unknown (2 Cores)"
+            },
+            {
+              "path": "ci.identifier",
+              "value": "ci"
+            },
+            {
+              "path": "ci.software.Compiler",
+              "value": "GCC 14.2.0"
+            },
+            {
+              "path": "ci.software.File-System",
+              "value": "overlayfs"
+            },
+            {
+              "path": "ci.software.Kernel",
+              "value": "4.19.0-gvisor (x86_64)"
+            },
+            {
+              "path": "ci.software.OS",
+              "value": "Debian GNU/Linux 13"
+            },
+            {
+              "path": "ci.timestamp",
+              "value": "2026-07-17 01:09:15"
+            },
+            {
+              "path": "ci.user",
+              "value": "root"
+            }
+          ]
+        },
+        {
+          "source": "mise/system-provider",
+          "sourceFile": "system/system-provider.json",
+          "fields": [
+            {
+              "path": "asn",
+              "value": "AS8075"
+            },
+            {
+              "path": "asn_source",
+              "value": "cymru"
+            },
+            {
+              "path": "bios_vendor",
+              "value": ""
+            },
+            {
+              "path": "city",
+              "value": "Phoenix"
+            },
+            {
+              "path": "cores",
+              "value": "2"
+            },
+            {
+              "path": "country",
+              "value": "US"
+            },
+            {
+              "path": "cpu_model",
+              "value": "unknown"
+            },
+            {
+              "path": "geo_source",
+              "value": "ipinfo"
+            },
+            {
+              "path": "kernel",
+              "value": "4.19.0-gvisor"
+            },
+            {
+              "path": "loc",
+              "value": "33.4484,-112.0740"
+            },
+            {
+              "path": "manufacturer",
+              "value": ""
+            },
+            {
+              "path": "org",
+              "value": "AS8075 Microsoft Corporation"
+            },
+            {
+              "path": "org_name",
+              "value": "Microsoft Corporation"
+            },
+            {
+              "path": "prefix",
+              "value": "20.64.0.0/10"
+            },
+            {
+              "path": "product_name",
+              "value": ""
+            },
+            {
+              "path": "public_ip",
+              "value": "20.118.128.192"
+            },
+            {
+              "path": "ram",
+              "value": "8.0Gi"
+            },
+            {
+              "path": "region",
+              "value": "Arizona"
+            },
+            {
+              "path": "reverse_dns",
+              "value": ""
+            },
+            {
+              "path": "schema_version",
+              "value": "1.0"
+            },
+            {
+              "path": "timezone",
+              "value": "America/Phoenix"
+            },
+            {
+              "path": "virtualization",
+              "value": ""
+            }
+          ]
+        }
+      ],
+      "metrics": [
+        {
+          "metricId": "fio_type_random_read_engine_linux_aio_direct_yes_block_size_4kb_job_count_1_disk_target_default_test_directory_iops",
+          "samples": [34600, 33200],
+          "aggregates": {
+            "p50": 33900,
+            "p95": 34530,
+            "mean": 33900,
+            "stdev": 989.9494936611666,
+            "min": 33200,
+            "max": 34600,
+            "n": 2
+          },
+          "sourceFile": "disk/pts_fio-rand-read.xml",
+          "appVersion": "3.36",
+          "arguments": "randread libaio 1 4k 1"
+        },
+        {
+          "metricId": "fio_type_random_read_engine_linux_aio_direct_yes_block_size_4kb_job_count_1_disk_target_default_test_directory_mb_per_s",
+          "samples": [135, 130],
+          "aggregates": {
+            "p50": 132.5,
+            "p95": 134.75,
+            "mean": 132.5,
+            "stdev": 3.5355339059327378,
+            "min": 130,
+            "max": 135,
+            "n": 2
+          },
+          "sourceFile": "disk/pts_fio-rand-read.xml",
+          "appVersion": "3.36",
+          "arguments": "randread libaio 1 4k 1"
+        },
+        {
+          "metricId": "fio_type_random_write_engine_linux_aio_direct_yes_block_size_4kb_job_count_1_disk_target_default_test_directory_iops",
+          "samples": [27000, 29600],
+          "aggregates": {
+            "p50": 28300,
+            "p95": 29470,
+            "mean": 28300,
+            "stdev": 1838.4776310850236,
+            "min": 27000,
+            "max": 29600,
+            "n": 2
+          },
+          "sourceFile": "disk/pts_fio-rand-write.xml",
+          "appVersion": "3.36",
+          "arguments": "randwrite libaio 1 4k 1"
+        },
+        {
+          "metricId": "fio_type_random_write_engine_linux_aio_direct_yes_block_size_4kb_job_count_1_disk_target_default_test_directory_mb_per_s",
+          "samples": [105, 116],
+          "aggregates": {
+            "p50": 110.5,
+            "p95": 115.45,
+            "mean": 110.5,
+            "stdev": 7.7781745930520225,
+            "min": 105,
+            "max": 116,
+            "n": 2
+          },
+          "sourceFile": "disk/pts_fio-rand-write.xml",
+          "appVersion": "3.36",
+          "arguments": "randwrite libaio 1 4k 1"
+        },
+        {
+          "metricId": "fio_type_sequential_read_engine_linux_aio_direct_yes_block_size_1mb_job_count_1_disk_target_default_test_directory_iops",
+          "samples": [12800, 11900],
+          "aggregates": {
+            "p50": 12350,
+            "p95": 12755,
+            "mean": 12350,
+            "stdev": 636.3961030678928,
+            "min": 11900,
+            "max": 12800,
+            "n": 2
+          },
+          "sourceFile": "disk/pts_fio-seq-read.xml",
+          "appVersion": "3.36",
+          "arguments": "read libaio 1 1m 1"
+        },
+        {
+          "metricId": "fio_type_sequential_write_engine_linux_aio_direct_yes_block_size_1mb_job_count_1_disk_target_default_test_directory_iops",
+          "samples": [3362, 3554],
+          "aggregates": {
+            "p50": 3458,
+            "p95": 3544.4,
+            "mean": 3458,
+            "stdev": 135.7645019878171,
+            "min": 3362,
+            "max": 3554,
+            "n": 2
+          },
+          "sourceFile": "disk/pts_fio-seq-write.xml",
+          "appVersion": "3.36",
+          "arguments": "write libaio 1 1m 1"
+        },
+        {
+          "metricId": "fio_type_sequential_write_engine_linux_aio_direct_yes_block_size_1mb_job_count_1_disk_target_default_test_directory_mb_per_s",
+          "samples": [3363, 3556],
+          "aggregates": {
+            "p50": 3459.5,
+            "p95": 3546.35,
+            "mean": 3459.5,
+            "stdev": 136.47160876900367,
+            "min": 3363,
+            "max": 3556,
+            "n": 2
+          },
+          "sourceFile": "disk/pts_fio-seq-write.xml",
+          "appVersion": "3.36",
+          "arguments": "write libaio 1 1m 1"
+        },
+        {
+          "metricId": "git_seconds",
+          "samples": [80.736, 81.995],
+          "aggregates": {
+            "p50": 81.3655,
+            "p95": 81.93205,
+            "mean": 81.3655,
+            "stdev": 0.8902474375138686,
+            "min": 80.736,
+            "max": 81.995,
+            "n": 2
+          },
+          "sourceFile": "system/pts_git.xml"
+        },
+        {
+          "metricId": "hardlink_bogo_ops_per_s",
+          "samples": [2.98, 3.12],
+          "aggregates": {
+            "p50": 3.05,
+            "p95": 3.113,
+            "mean": 3.05,
+            "stdev": 0.0989949493661169,
+            "min": 2.98,
+            "max": 3.12,
+            "n": 2
+          },
+          "sourceFile": "disk/pts_hardlink.xml",
+          "appVersion": "0.16"
+        },
+        {
+          "metricId": "network_loopback_seconds",
+          "samples": [56.857, 51.351],
+          "aggregates": {
+            "p50": 54.104,
+            "p95": 56.5817,
+            "mean": 54.104,
+            "stdev": 3.893329937213131,
+            "min": 51.351,
+            "max": 56.857,
+            "n": 2
+          },
+          "sourceFile": "network/pts_network-loopback.xml"
+        },
+        {
+          "metricId": "node_web_tooling_runs_per_s",
+          "samples": [8.93, 8.71],
+          "aggregates": {
+            "p50": 8.82,
+            "p95": 8.919,
+            "mean": 8.82,
+            "stdev": 0.15556349186103965,
+            "min": 8.71,
+            "max": 8.93,
+            "n": 2
+          },
+          "sourceFile": "cpu-node/pts_node-web-tooling.xml"
+        },
+        {
+          "metricId": "realworld_better_auth_task_build",
+          "samples": [39.941, 41.897],
+          "aggregates": {
+            "p50": 40.919,
+            "p95": 41.7992,
+            "mean": 40.919,
+            "stdev": 1.3831008640008866,
+            "min": 39.941,
+            "max": 41.897,
+            "n": 2
+          },
+          "sourceFile": "realworld-better-auth/pts_realworld-better-auth.xml",
+          "appVersion": "6f3ba45639579da152b69e8e5342e02f28288670",
+          "arguments": "build"
+        },
+        {
+          "metricId": "realworld_better_auth_task_cold_install",
+          "samples": [31.611, 30.672],
+          "aggregates": {
+            "p50": 31.1415,
+            "p95": 31.56405,
+            "mean": 31.1415,
+            "stdev": 0.6639732675341682,
+            "min": 30.672,
+            "max": 31.611,
+            "n": 2
+          },
+          "sourceFile": "realworld-better-auth/pts_realworld-better-auth.xml",
+          "appVersion": "6f3ba45639579da152b69e8e5342e02f28288670",
+          "arguments": "cold_install"
+        },
+        {
+          "metricId": "realworld_better_auth_task_git_clone",
+          "samples": [2.524, 2.251],
+          "aggregates": {
+            "p50": 2.3875,
+            "p95": 2.51035,
+            "mean": 2.3875,
+            "stdev": 0.19304015126392743,
+            "min": 2.251,
+            "max": 2.524,
+            "n": 2
+          },
+          "sourceFile": "realworld-better-auth/pts_realworld-better-auth.xml",
+          "appVersion": "6f3ba45639579da152b69e8e5342e02f28288670",
+          "arguments": "git_clone"
+        },
+        {
+          "metricId": "realworld_better_auth_task_lint_biome",
+          "samples": [17.134, 17.23],
+          "aggregates": {
+            "p50": 17.182000000000002,
+            "p95": 17.2252,
+            "mean": 17.182000000000002,
+            "stdev": 0.06788225099390736,
+            "min": 17.134,
+            "max": 17.23,
+            "n": 2
+          },
+          "sourceFile": "realworld-better-auth/pts_realworld-better-auth.xml",
+          "appVersion": "6f3ba45639579da152b69e8e5342e02f28288670",
+          "arguments": "lint_biome"
+        },
+        {
+          "metricId": "realworld_better_auth_task_lint_deps_knip",
+          "samples": [28.336, 28.658],
+          "aggregates": {
+            "p50": 28.497,
+            "p95": 28.6419,
+            "mean": 28.497,
+            "stdev": 0.22768838354207024,
+            "min": 28.336,
+            "max": 28.658,
+            "n": 2
+          },
+          "sourceFile": "realworld-better-auth/pts_realworld-better-auth.xml",
+          "appVersion": "6f3ba45639579da152b69e8e5342e02f28288670",
+          "arguments": "lint_deps"
+        },
+        {
+          "metricId": "realworld_better_auth_task_lint_format",
+          "samples": [6.668, 6.494],
+          "aggregates": {
+            "p50": 6.5809999999999995,
+            "p95": 6.6593,
+            "mean": 6.5809999999999995,
+            "stdev": 0.12303657992645985,
+            "min": 6.494,
+            "max": 6.668,
+            "n": 2
+          },
+          "sourceFile": "realworld-better-auth/pts_realworld-better-auth.xml",
+          "appVersion": "6f3ba45639579da152b69e8e5342e02f28288670",
+          "arguments": "lint_format"
+        },
+        {
+          "metricId": "realworld_better_auth_task_lint_packages",
+          "samples": [15.968, 15.556],
+          "aggregates": {
+            "p50": 15.762,
+            "p95": 15.9474,
+            "mean": 15.762,
+            "stdev": 0.2913279938488575,
+            "min": 15.556,
+            "max": 15.968,
+            "n": 2
+          },
+          "sourceFile": "realworld-better-auth/pts_realworld-better-auth.xml",
+          "appVersion": "6f3ba45639579da152b69e8e5342e02f28288670",
+          "arguments": "lint_packages"
+        },
+        {
+          "metricId": "realworld_better_auth_task_lint_spell",
+          "samples": [14.704, 15.65],
+          "aggregates": {
+            "p50": 15.177,
+            "p95": 15.6027,
+            "mean": 15.177,
+            "stdev": 0.6689230150024744,
+            "min": 14.704,
+            "max": 15.65,
+            "n": 2
+          },
+          "sourceFile": "realworld-better-auth/pts_realworld-better-auth.xml",
+          "appVersion": "6f3ba45639579da152b69e8e5342e02f28288670",
+          "arguments": "lint_spell"
+        },
+        {
+          "metricId": "realworld_better_auth_task_lint_types",
+          "samples": [187.659, 178.903],
+          "aggregates": {
+            "p50": 183.281,
+            "p95": 187.22119999999998,
+            "mean": 183.281,
+            "stdev": 6.1914269760694,
+            "min": 178.903,
+            "max": 187.659,
+            "n": 2
+          },
+          "sourceFile": "realworld-better-auth/pts_realworld-better-auth.xml",
+          "appVersion": "6f3ba45639579da152b69e8e5342e02f28288670",
+          "arguments": "lint_types"
+        },
+        {
+          "metricId": "realworld_better_auth_task_typecheck",
+          "samples": [3.29, 3.326],
+          "aggregates": {
+            "p50": 3.308,
+            "p95": 3.3242000000000003,
+            "mean": 3.308,
+            "stdev": 0.02545584412271589,
+            "min": 3.29,
+            "max": 3.326,
+            "n": 2
+          },
+          "sourceFile": "realworld-better-auth/pts_realworld-better-auth.xml",
+          "appVersion": "6f3ba45639579da152b69e8e5342e02f28288670",
+          "arguments": "typecheck"
+        },
+        {
+          "metricId": "realworld_mastra_task_build_core",
+          "samples": [204.988, 201.052],
+          "aggregates": {
+            "p50": 203.01999999999998,
+            "p95": 204.7912,
+            "mean": 203.01999999999998,
+            "stdev": 2.783172290750266,
+            "min": 201.052,
+            "max": 204.988,
+            "n": 2
+          },
+          "sourceFile": "realworld-mastra/pts_realworld-mastra.xml",
+          "appVersion": "b6eeb9d08ebeaf27bc6fd16b6b88087040aaf767",
+          "arguments": "build_core"
+        },
+        {
+          "metricId": "realworld_mastra_task_cold_install",
+          "samples": [74.61, 72.945],
+          "aggregates": {
+            "p50": 73.7775,
+            "p95": 74.52674999999999,
+            "mean": 73.7775,
+            "stdev": 1.177332790675601,
+            "min": 72.945,
+            "max": 74.61,
+            "n": 2
+          },
+          "sourceFile": "realworld-mastra/pts_realworld-mastra.xml",
+          "appVersion": "b6eeb9d08ebeaf27bc6fd16b6b88087040aaf767",
+          "arguments": "cold_install"
+        },
+        {
+          "metricId": "realworld_mastra_task_git_clone",
+          "samples": [10.564, 9.35],
+          "aggregates": {
+            "p50": 9.957,
+            "p95": 10.5033,
+            "mean": 9.957,
+            "stdev": 0.8584276323604684,
+            "min": 9.35,
+            "max": 10.564,
+            "n": 2
+          },
+          "sourceFile": "realworld-mastra/pts_realworld-mastra.xml",
+          "appVersion": "b6eeb9d08ebeaf27bc6fd16b6b88087040aaf767",
+          "arguments": "git_clone"
+        },
+        {
+          "metricId": "realworld_mastra_task_lint_format",
+          "samples": [201.084, 198.234],
+          "aggregates": {
+            "p50": 199.659,
+            "p95": 200.9415,
+            "mean": 199.659,
+            "stdev": 2.0152543263816662,
+            "min": 198.234,
+            "max": 201.084,
+            "n": 2
+          },
+          "sourceFile": "realworld-mastra/pts_realworld-mastra.xml",
+          "appVersion": "b6eeb9d08ebeaf27bc6fd16b6b88087040aaf767",
+          "arguments": "lint_format"
+        },
+        {
+          "metricId": "sqlite_speedtest_seconds",
+          "samples": [523.75, 505.569],
+          "aggregates": {
+            "p50": 514.6595,
+            "p95": 522.84095,
+            "mean": 514.6595,
+            "stdev": 12.855908388752628,
+            "min": 505.569,
+            "max": 523.75,
+            "n": 2
+          },
+          "sourceFile": "system/pts_sqlite-speedtest.xml",
+          "appVersion": "3.30"
+        },
+        {
+          "metricId": "stream_type_add",
+          "samples": [41168.8, 50672.2],
+          "aggregates": {
+            "p50": 45920.5,
+            "p95": 50197.03,
+            "mean": 45920.5,
+            "stdev": 6719.918584328231,
+            "min": 41168.8,
+            "max": 50672.2,
+            "n": 2
+          },
+          "sourceFile": "memory/pts_stream.xml",
+          "appVersion": "2013-01-17",
+          "arguments": "Add"
+        },
+        {
+          "metricId": "stream_type_copy",
+          "samples": [56585.2, 67440.2],
+          "aggregates": {
+            "p50": 62012.7,
+            "p95": 66897.45,
+            "mean": 62012.7,
+            "stdev": 7675.644109779973,
+            "min": 56585.2,
+            "max": 67440.2,
+            "n": 2
+          },
+          "sourceFile": "memory/pts_stream.xml",
+          "appVersion": "2013-01-17",
+          "arguments": "Copy"
+        },
+        {
+          "metricId": "stream_type_scale",
+          "samples": [34143.3, 40662],
+          "aggregates": {
+            "p50": 37402.65,
+            "p95": 40336.065,
+            "mean": 37402.65,
+            "stdev": 4609.4169745207455,
+            "min": 34143.3,
+            "max": 40662,
+            "n": 2
+          },
+          "sourceFile": "memory/pts_stream.xml",
+          "appVersion": "2013-01-17",
+          "arguments": "Scale"
+        },
+        {
+          "metricId": "stream_type_triad",
+          "samples": [42047.8, 48697.4],
+          "aggregates": {
+            "p50": 45372.600000000006,
+            "p95": 48364.92,
+            "mean": 45372.600000000006,
+            "stdev": 4701.977252178062,
+            "min": 42047.8,
+            "max": 48697.4,
+            "n": 2
+          },
+          "sourceFile": "memory/pts_stream.xml",
+          "appVersion": "2013-01-17",
+          "arguments": "Triad"
+        },
+        {
+          "metricId": "usd_per_hour",
+          "samples": [0.47736],
+          "aggregates": {
+            "p50": 0.47736,
+            "p95": 0.47736,
+            "mean": 0.47736,
+            "stdev": 0,
+            "min": 0.47736,
+            "max": 0.47736,
+            "n": 1
+          }
+        }
+      ],
+      "suitesCovered": [
+        "cpu-node",
+        "disk",
+        "memory",
+        "network",
+        "realworld-better-auth",
+        "realworld-mastra",
+        "system"
+      ],
+      "gaps": [
+        {
+          "scope": "suite",
+          "id": "cpu-generic",
+          "outcome": "failed",
+          "reason": "Step \"mise run benchmark:cpu:generic\" timed out after 7800s"
+        },
+        {
+          "scope": "suite",
+          "id": "network",
+          "outcome": "failed",
+          "reason": "Step \"mise run benchmark:network:all\" failed with exit code 1"
+        },
+        {
+          "scope": "suite",
+          "id": "realworld-openclaw",
+          "outcome": "failed",
+          "reason": "Step \"mise run benchmark:realworld:pts:openclaw\" timed out after 8400s"
+        }
+      ],
+      "uncatalogued": []
+    },
+    {
+      "providerId": "novita",
+      "validationStatus": "validated",
+      "specMatched": true,
+      "observedSpecs": {
+        "cpuModel": "AMD EPYC",
+        "hostMemoryGb": 8,
+        "os": "Debian GNU/Linux 13 (trixie)",
+        "kernel": "6.1.158+",
+        "virtualization": "kvm",
+        "user": "root",
+        "vcpus": 2,
+        "memoryGb": 7.78,
+        "diskGb": 103.7,
+        "publicIp": "161.153.9.169",
+        "egressOrg": "AS31898 Oracle Corporation",
+        "egressAsn": "AS31898",
+        "egressOrgName": "Oracle Corporation",
+        "city": "Phoenix",
+        "region": "Arizona",
+        "country": "US",
+        "location": "33.4484,-112.0740",
+        "timezone": "America/Phoenix",
+        "networkPrefix": "161.153.0.0/17",
+        "asnSource": "cymru",
+        "geoSource": "ipinfo"
+      },
+      "hostMetadata": [
+        {
+          "source": "phoronix/result-file-to-json",
+          "sourceFile": "cpu-generic/pts_c-ray--metadata.json",
+          "fields": [
+            {
+              "path": "ci.client_version",
+              "value": "10.8.4"
+            },
+            {
+              "path": "ci.data.compiler-configuration",
+              "value": "--build=x86_64-linux-gnu --disable-vtable-verify --disable-werror --enable-bootstrap --enable-cet --enable-checking=release --enable-clocale=gnu --enable-default-pie --enable-gnu-unique-object --enable-languages=c,ada,c++,go,d,fortran,objc,obj-c++,m2,rust --enable-libphobos-checking=release --enable-libstdcxx-backtrace --enable-libstdcxx-debug --enable-libstdcxx-time=yes --enable-link-serialization=3 --enable-multiarch --enable-multilib --enable-nls --enable-objc-gc=auto --enable-offload-defaulted --enable-offload-targets=nvptx-none=/build/reproducible-path/gcc-14-14.2.0/debian/tmp-nvptx/usr,amdgcn-amdhsa=/build/reproducible-path/gcc-14-14.2.0/debian/tmp-gcn/usr --enable-plugin --enable-shared --enable-threads=posix --host=x86_64-linux-gnu --program-prefix=x86_64-linux-gnu- --target=x86_64-linux-gnu --with-abi=m64 --with-arch-32=i686 --with-build-config=bootstrap-lto-lean --with-default-libstdcxx-abi=new --with-gcc-major-version-only --with-multilib-list=m32,m64,mx32 --with-target-system-zlib=auto --with-tune=generic --without-cuda-driver -v"
+            },
+            {
+              "path": "ci.data.cpu-microcode",
+              "value": "0x1000065"
+            },
+            {
+              "path": "ci.data.kernel-extra-details",
+              "value": "Transparent Huge Pages: madvise"
+            },
+            {
+              "path": "ci.data.security",
+              "value": "gather_data_sampling: Not affected + indirect_target_selection: Not affected + itlb_multihit: Not affected + l1tf: Not affected + mds: Not affected + meltdown: Not affected + mmio_stale_data: Not affected + reg_file_data_sampling: Not affected + retbleed: Not affected + spec_rstack_overflow: Vulnerable + spec_store_bypass: Mitigation of SSB disabled via prctl + spectre_v1: Mitigation of usercopy/swapgs barriers and __user pointer sanitization + spectre_v2: Mitigation of Enhanced / Automatic IBRS; IBPB: conditional; STIBP: always-on; PBRSB-eIBRS: Not affected; BHI: Not affected + srbds: Not affected + tsa: Vulnerable + tsx_async_abort: Not affected + vmscape: Not affected"
+            },
+            {
+              "path": "ci.hardware.Disk",
+              "value": "104GB"
+            },
+            {
+              "path": "ci.hardware.Memory",
+              "value": "8GB"
+            },
+            {
+              "path": "ci.hardware.Processor",
+              "value": "AMD EPYC (1 Core / 2 Threads)"
+            },
+            {
+              "path": "ci.identifier",
+              "value": "ci"
+            },
+            {
+              "path": "ci.software.Compiler",
+              "value": "GCC 14.2.0"
+            },
+            {
+              "path": "ci.software.File-System",
+              "value": "ext4"
+            },
+            {
+              "path": "ci.software.Kernel",
+              "value": "6.1.158+ (x86_64)"
+            },
+            {
+              "path": "ci.software.OS",
+              "value": "Debian GNU/Linux 13"
+            },
+            {
+              "path": "ci.software.System Layer",
+              "value": "KVM"
+            },
+            {
+              "path": "ci.timestamp",
+              "value": "2026-07-17 01:07:19"
+            },
+            {
+              "path": "ci.user",
+              "value": "root"
+            }
+          ]
+        },
+        {
+          "source": "phoronix/result-file-to-json",
+          "sourceFile": "cpu-generic/pts_compress-zstd--metadata.json",
+          "fields": [
+            {
+              "path": "ci.client_version",
+              "value": "10.8.4"
+            },
+            {
+              "path": "ci.data.compiler-configuration",
+              "value": "--build=x86_64-linux-gnu --disable-vtable-verify --disable-werror --enable-bootstrap --enable-cet --enable-checking=release --enable-clocale=gnu --enable-default-pie --enable-gnu-unique-object --enable-languages=c,ada,c++,go,d,fortran,objc,obj-c++,m2,rust --enable-libphobos-checking=release --enable-libstdcxx-backtrace --enable-libstdcxx-debug --enable-libstdcxx-time=yes --enable-link-serialization=3 --enable-multiarch --enable-multilib --enable-nls --enable-objc-gc=auto --enable-offload-defaulted --enable-offload-targets=nvptx-none=/build/reproducible-path/gcc-14-14.2.0/debian/tmp-nvptx/usr,amdgcn-amdhsa=/build/reproducible-path/gcc-14-14.2.0/debian/tmp-gcn/usr --enable-plugin --enable-shared --enable-threads=posix --host=x86_64-linux-gnu --program-prefix=x86_64-linux-gnu- --target=x86_64-linux-gnu --with-abi=m64 --with-arch-32=i686 --with-build-config=bootstrap-lto-lean --with-default-libstdcxx-abi=new --with-gcc-major-version-only --with-multilib-list=m32,m64,mx32 --with-target-system-zlib=auto --with-tune=generic --without-cuda-driver -v"
+            },
+            {
+              "path": "ci.data.cpu-microcode",
+              "value": "0x1000065"
+            },
+            {
+              "path": "ci.data.kernel-extra-details",
+              "value": "Transparent Huge Pages: madvise"
+            },
+            {
+              "path": "ci.data.security",
+              "value": "gather_data_sampling: Not affected + indirect_target_selection: Not affected + itlb_multihit: Not affected + l1tf: Not affected + mds: Not affected + meltdown: Not affected + mmio_stale_data: Not affected + reg_file_data_sampling: Not affected + retbleed: Not affected + spec_rstack_overflow: Vulnerable + spec_store_bypass: Mitigation of SSB disabled via prctl + spectre_v1: Mitigation of usercopy/swapgs barriers and __user pointer sanitization + spectre_v2: Mitigation of Enhanced / Automatic IBRS; IBPB: conditional; STIBP: always-on; PBRSB-eIBRS: Not affected; BHI: Not affected + srbds: Not affected + tsa: Vulnerable + tsx_async_abort: Not affected + vmscape: Not affected"
+            },
+            {
+              "path": "ci.hardware.Disk",
+              "value": "104GB"
+            },
+            {
+              "path": "ci.hardware.Memory",
+              "value": "8GB"
+            },
+            {
+              "path": "ci.hardware.Processor",
+              "value": "AMD EPYC (1 Core / 2 Threads)"
+            },
+            {
+              "path": "ci.identifier",
+              "value": "ci"
+            },
+            {
+              "path": "ci.software.Compiler",
+              "value": "GCC 14.2.0"
+            },
+            {
+              "path": "ci.software.File-System",
+              "value": "ext4"
+            },
+            {
+              "path": "ci.software.Kernel",
+              "value": "6.1.158+ (x86_64)"
+            },
+            {
+              "path": "ci.software.OS",
+              "value": "Debian GNU/Linux 13"
+            },
+            {
+              "path": "ci.software.System Layer",
+              "value": "KVM"
+            },
+            {
+              "path": "ci.timestamp",
+              "value": "2026-07-17 02:45:01"
+            },
+            {
+              "path": "ci.user",
+              "value": "root"
+            }
+          ]
+        },
+        {
+          "source": "phoronix/result-file-to-json",
+          "sourceFile": "cpu-node/pts_node-web-tooling--metadata.json",
+          "fields": [
+            {
+              "path": "ci.client_version",
+              "value": "10.8.4"
+            },
+            {
+              "path": "ci.data.cpu-microcode",
+              "value": "0x1000065"
+            },
+            {
+              "path": "ci.data.kernel-extra-details",
+              "value": "Transparent Huge Pages: madvise"
+            },
+            {
+              "path": "ci.data.security",
+              "value": "gather_data_sampling: Not affected + indirect_target_selection: Not affected + itlb_multihit: Not affected + l1tf: Not affected + mds: Not affected + meltdown: Not affected + mmio_stale_data: Not affected + reg_file_data_sampling: Not affected + retbleed: Not affected + spec_rstack_overflow: Vulnerable + spec_store_bypass: Mitigation of SSB disabled via prctl + spectre_v1: Mitigation of usercopy/swapgs barriers and __user pointer sanitization + spectre_v2: Mitigation of Enhanced / Automatic IBRS; IBPB: conditional; STIBP: always-on; PBRSB-eIBRS: Not affected; BHI: Not affected + srbds: Not affected + tsa: Vulnerable + tsx_async_abort: Not affected + vmscape: Not affected"
+            },
+            {
+              "path": "ci.hardware.Disk",
+              "value": "104GB"
+            },
+            {
+              "path": "ci.hardware.Memory",
+              "value": "8GB"
+            },
+            {
+              "path": "ci.hardware.Processor",
+              "value": "AMD EPYC (1 Core / 2 Threads)"
+            },
+            {
+              "path": "ci.identifier",
+              "value": "ci"
+            },
+            {
+              "path": "ci.software.Compiler",
+              "value": "GCC 14.2.0"
+            },
+            {
+              "path": "ci.software.File-System",
+              "value": "ext4"
+            },
+            {
+              "path": "ci.software.Kernel",
+              "value": "6.1.158+ (x86_64)"
+            },
+            {
+              "path": "ci.software.OS",
+              "value": "Debian GNU/Linux 13"
+            },
+            {
+              "path": "ci.software.System Layer",
+              "value": "KVM"
+            },
+            {
+              "path": "ci.timestamp",
+              "value": "2026-07-17 01:07:25"
+            },
+            {
+              "path": "ci.user",
+              "value": "root"
+            }
+          ]
+        },
+        {
+          "source": "phoronix/result-file-to-json",
+          "sourceFile": "disk/pts_fio-rand-read--metadata.json",
+          "fields": [
+            {
+              "path": "ci.client_version",
+              "value": "10.8.4"
+            },
+            {
+              "path": "ci.data.compiler-configuration",
+              "value": "--build=x86_64-linux-gnu --disable-vtable-verify --disable-werror --enable-bootstrap --enable-cet --enable-checking=release --enable-clocale=gnu --enable-default-pie --enable-gnu-unique-object --enable-languages=c,ada,c++,go,d,fortran,objc,obj-c++,m2,rust --enable-libphobos-checking=release --enable-libstdcxx-backtrace --enable-libstdcxx-debug --enable-libstdcxx-time=yes --enable-link-serialization=3 --enable-multiarch --enable-multilib --enable-nls --enable-objc-gc=auto --enable-offload-defaulted --enable-offload-targets=nvptx-none=/build/reproducible-path/gcc-14-14.2.0/debian/tmp-nvptx/usr,amdgcn-amdhsa=/build/reproducible-path/gcc-14-14.2.0/debian/tmp-gcn/usr --enable-plugin --enable-shared --enable-threads=posix --host=x86_64-linux-gnu --program-prefix=x86_64-linux-gnu- --target=x86_64-linux-gnu --with-abi=m64 --with-arch-32=i686 --with-build-config=bootstrap-lto-lean --with-default-libstdcxx-abi=new --with-gcc-major-version-only --with-multilib-list=m32,m64,mx32 --with-target-system-zlib=auto --with-tune=generic --without-cuda-driver -v"
+            },
+            {
+              "path": "ci.data.cpu-microcode",
+              "value": "0x1000065"
+            },
+            {
+              "path": "ci.data.disk-details",
+              "value": "Block Size: 4096"
+            },
+            {
+              "path": "ci.data.disk-mount-options",
+              "value": "relatime,rw"
+            },
+            {
+              "path": "ci.data.kernel-extra-details",
+              "value": "Transparent Huge Pages: madvise"
+            },
+            {
+              "path": "ci.data.security",
+              "value": "gather_data_sampling: Not affected + indirect_target_selection: Not affected + itlb_multihit: Not affected + l1tf: Not affected + mds: Not affected + meltdown: Not affected + mmio_stale_data: Not affected + reg_file_data_sampling: Not affected + retbleed: Not affected + spec_rstack_overflow: Vulnerable + spec_store_bypass: Mitigation of SSB disabled via prctl + spectre_v1: Mitigation of usercopy/swapgs barriers and __user pointer sanitization + spectre_v2: Mitigation of Enhanced / Automatic IBRS; IBPB: conditional; STIBP: always-on; PBRSB-eIBRS: Not affected; BHI: Not affected + srbds: Not affected + tsa: Vulnerable + tsx_async_abort: Not affected + vmscape: Not affected"
+            },
+            {
+              "path": "ci.hardware.Disk",
+              "value": "104GB"
+            },
+            {
+              "path": "ci.hardware.Memory",
+              "value": "8GB"
+            },
+            {
+              "path": "ci.hardware.Processor",
+              "value": "AMD EPYC (1 Core / 2 Threads)"
+            },
+            {
+              "path": "ci.identifier",
+              "value": "ci"
+            },
+            {
+              "path": "ci.software.Compiler",
+              "value": "GCC 14.2.0"
+            },
+            {
+              "path": "ci.software.File-System",
+              "value": "ext4"
+            },
+            {
+              "path": "ci.software.Kernel",
+              "value": "6.1.158+ (x86_64)"
+            },
+            {
+              "path": "ci.software.OS",
+              "value": "Debian GNU/Linux 13"
+            },
+            {
+              "path": "ci.software.System Layer",
+              "value": "KVM"
+            },
+            {
+              "path": "ci.timestamp",
+              "value": "2026-07-17 01:13:41"
+            },
+            {
+              "path": "ci.user",
+              "value": "root"
+            }
+          ]
+        },
+        {
+          "source": "phoronix/result-file-to-json",
+          "sourceFile": "disk/pts_fio-rand-write--metadata.json",
+          "fields": [
+            {
+              "path": "ci.client_version",
+              "value": "10.8.4"
+            },
+            {
+              "path": "ci.data.compiler-configuration",
+              "value": "--build=x86_64-linux-gnu --disable-vtable-verify --disable-werror --enable-bootstrap --enable-cet --enable-checking=release --enable-clocale=gnu --enable-default-pie --enable-gnu-unique-object --enable-languages=c,ada,c++,go,d,fortran,objc,obj-c++,m2,rust --enable-libphobos-checking=release --enable-libstdcxx-backtrace --enable-libstdcxx-debug --enable-libstdcxx-time=yes --enable-link-serialization=3 --enable-multiarch --enable-multilib --enable-nls --enable-objc-gc=auto --enable-offload-defaulted --enable-offload-targets=nvptx-none=/build/reproducible-path/gcc-14-14.2.0/debian/tmp-nvptx/usr,amdgcn-amdhsa=/build/reproducible-path/gcc-14-14.2.0/debian/tmp-gcn/usr --enable-plugin --enable-shared --enable-threads=posix --host=x86_64-linux-gnu --program-prefix=x86_64-linux-gnu- --target=x86_64-linux-gnu --with-abi=m64 --with-arch-32=i686 --with-build-config=bootstrap-lto-lean --with-default-libstdcxx-abi=new --with-gcc-major-version-only --with-multilib-list=m32,m64,mx32 --with-target-system-zlib=auto --with-tune=generic --without-cuda-driver -v"
+            },
+            {
+              "path": "ci.data.cpu-microcode",
+              "value": "0x1000065"
+            },
+            {
+              "path": "ci.data.disk-details",
+              "value": "Block Size: 4096"
+            },
+            {
+              "path": "ci.data.disk-mount-options",
+              "value": "relatime,rw"
+            },
+            {
+              "path": "ci.data.kernel-extra-details",
+              "value": "Transparent Huge Pages: madvise"
+            },
+            {
+              "path": "ci.data.security",
+              "value": "gather_data_sampling: Not affected + indirect_target_selection: Not affected + itlb_multihit: Not affected + l1tf: Not affected + mds: Not affected + meltdown: Not affected + mmio_stale_data: Not affected + reg_file_data_sampling: Not affected + retbleed: Not affected + spec_rstack_overflow: Vulnerable + spec_store_bypass: Mitigation of SSB disabled via prctl + spectre_v1: Mitigation of usercopy/swapgs barriers and __user pointer sanitization + spectre_v2: Mitigation of Enhanced / Automatic IBRS; IBPB: conditional; STIBP: always-on; PBRSB-eIBRS: Not affected; BHI: Not affected + srbds: Not affected + tsa: Vulnerable + tsx_async_abort: Not affected + vmscape: Not affected"
+            },
+            {
+              "path": "ci.hardware.Disk",
+              "value": "104GB"
+            },
+            {
+              "path": "ci.hardware.Memory",
+              "value": "8GB"
+            },
+            {
+              "path": "ci.hardware.Processor",
+              "value": "AMD EPYC (1 Core / 2 Threads)"
+            },
+            {
+              "path": "ci.identifier",
+              "value": "ci"
+            },
+            {
+              "path": "ci.software.Compiler",
+              "value": "GCC 14.2.0"
+            },
+            {
+              "path": "ci.software.File-System",
+              "value": "ext4"
+            },
+            {
+              "path": "ci.software.Kernel",
+              "value": "6.1.158+ (x86_64)"
+            },
+            {
+              "path": "ci.software.OS",
+              "value": "Debian GNU/Linux 13"
+            },
+            {
+              "path": "ci.software.System Layer",
+              "value": "KVM"
+            },
+            {
+              "path": "ci.timestamp",
+              "value": "2026-07-17 01:16:50"
+            },
+            {
+              "path": "ci.user",
+              "value": "root"
+            }
+          ]
+        },
+        {
+          "source": "phoronix/result-file-to-json",
+          "sourceFile": "disk/pts_fio-seq-read--metadata.json",
+          "fields": [
+            {
+              "path": "ci.client_version",
+              "value": "10.8.4"
+            },
+            {
+              "path": "ci.data.compiler-configuration",
+              "value": "--build=x86_64-linux-gnu --disable-vtable-verify --disable-werror --enable-bootstrap --enable-cet --enable-checking=release --enable-clocale=gnu --enable-default-pie --enable-gnu-unique-object --enable-languages=c,ada,c++,go,d,fortran,objc,obj-c++,m2,rust --enable-libphobos-checking=release --enable-libstdcxx-backtrace --enable-libstdcxx-debug --enable-libstdcxx-time=yes --enable-link-serialization=3 --enable-multiarch --enable-multilib --enable-nls --enable-objc-gc=auto --enable-offload-defaulted --enable-offload-targets=nvptx-none=/build/reproducible-path/gcc-14-14.2.0/debian/tmp-nvptx/usr,amdgcn-amdhsa=/build/reproducible-path/gcc-14-14.2.0/debian/tmp-gcn/usr --enable-plugin --enable-shared --enable-threads=posix --host=x86_64-linux-gnu --program-prefix=x86_64-linux-gnu- --target=x86_64-linux-gnu --with-abi=m64 --with-arch-32=i686 --with-build-config=bootstrap-lto-lean --with-default-libstdcxx-abi=new --with-gcc-major-version-only --with-multilib-list=m32,m64,mx32 --with-target-system-zlib=auto --with-tune=generic --without-cuda-driver -v"
+            },
+            {
+              "path": "ci.data.cpu-microcode",
+              "value": "0x1000065"
+            },
+            {
+              "path": "ci.data.disk-details",
+              "value": "Block Size: 4096"
+            },
+            {
+              "path": "ci.data.disk-mount-options",
+              "value": "relatime,rw"
+            },
+            {
+              "path": "ci.data.kernel-extra-details",
+              "value": "Transparent Huge Pages: madvise"
+            },
+            {
+              "path": "ci.data.security",
+              "value": "gather_data_sampling: Not affected + indirect_target_selection: Not affected + itlb_multihit: Not affected + l1tf: Not affected + mds: Not affected + meltdown: Not affected + mmio_stale_data: Not affected + reg_file_data_sampling: Not affected + retbleed: Not affected + spec_rstack_overflow: Vulnerable + spec_store_bypass: Mitigation of SSB disabled via prctl + spectre_v1: Mitigation of usercopy/swapgs barriers and __user pointer sanitization + spectre_v2: Mitigation of Enhanced / Automatic IBRS; IBPB: conditional; STIBP: always-on; PBRSB-eIBRS: Not affected; BHI: Not affected + srbds: Not affected + tsa: Vulnerable + tsx_async_abort: Not affected + vmscape: Not affected"
+            },
+            {
+              "path": "ci.hardware.Disk",
+              "value": "104GB"
+            },
+            {
+              "path": "ci.hardware.Memory",
+              "value": "8GB"
+            },
+            {
+              "path": "ci.hardware.Processor",
+              "value": "AMD EPYC (1 Core / 2 Threads)"
+            },
+            {
+              "path": "ci.identifier",
+              "value": "ci"
+            },
+            {
+              "path": "ci.software.Compiler",
+              "value": "GCC 14.2.0"
+            },
+            {
+              "path": "ci.software.File-System",
+              "value": "ext4"
+            },
+            {
+              "path": "ci.software.Kernel",
+              "value": "6.1.158+ (x86_64)"
+            },
+            {
+              "path": "ci.software.OS",
+              "value": "Debian GNU/Linux 13"
+            },
+            {
+              "path": "ci.software.System Layer",
+              "value": "KVM"
+            },
+            {
+              "path": "ci.timestamp",
+              "value": "2026-07-17 01:07:23"
+            },
+            {
+              "path": "ci.user",
+              "value": "root"
+            }
+          ]
+        },
+        {
+          "source": "phoronix/result-file-to-json",
+          "sourceFile": "disk/pts_fio-seq-write--metadata.json",
+          "fields": [
+            {
+              "path": "ci.client_version",
+              "value": "10.8.4"
+            },
+            {
+              "path": "ci.data.compiler-configuration",
+              "value": "--build=x86_64-linux-gnu --disable-vtable-verify --disable-werror --enable-bootstrap --enable-cet --enable-checking=release --enable-clocale=gnu --enable-default-pie --enable-gnu-unique-object --enable-languages=c,ada,c++,go,d,fortran,objc,obj-c++,m2,rust --enable-libphobos-checking=release --enable-libstdcxx-backtrace --enable-libstdcxx-debug --enable-libstdcxx-time=yes --enable-link-serialization=3 --enable-multiarch --enable-multilib --enable-nls --enable-objc-gc=auto --enable-offload-defaulted --enable-offload-targets=nvptx-none=/build/reproducible-path/gcc-14-14.2.0/debian/tmp-nvptx/usr,amdgcn-amdhsa=/build/reproducible-path/gcc-14-14.2.0/debian/tmp-gcn/usr --enable-plugin --enable-shared --enable-threads=posix --host=x86_64-linux-gnu --program-prefix=x86_64-linux-gnu- --target=x86_64-linux-gnu --with-abi=m64 --with-arch-32=i686 --with-build-config=bootstrap-lto-lean --with-default-libstdcxx-abi=new --with-gcc-major-version-only --with-multilib-list=m32,m64,mx32 --with-target-system-zlib=auto --with-tune=generic --without-cuda-driver -v"
+            },
+            {
+              "path": "ci.data.cpu-microcode",
+              "value": "0x1000065"
+            },
+            {
+              "path": "ci.data.disk-details",
+              "value": "Block Size: 4096"
+            },
+            {
+              "path": "ci.data.disk-mount-options",
+              "value": "relatime,rw"
+            },
+            {
+              "path": "ci.data.kernel-extra-details",
+              "value": "Transparent Huge Pages: madvise"
+            },
+            {
+              "path": "ci.data.security",
+              "value": "gather_data_sampling: Not affected + indirect_target_selection: Not affected + itlb_multihit: Not affected + l1tf: Not affected + mds: Not affected + meltdown: Not affected + mmio_stale_data: Not affected + reg_file_data_sampling: Not affected + retbleed: Not affected + spec_rstack_overflow: Vulnerable + spec_store_bypass: Mitigation of SSB disabled via prctl + spectre_v1: Mitigation of usercopy/swapgs barriers and __user pointer sanitization + spectre_v2: Mitigation of Enhanced / Automatic IBRS; IBPB: conditional; STIBP: always-on; PBRSB-eIBRS: Not affected; BHI: Not affected + srbds: Not affected + tsa: Vulnerable + tsx_async_abort: Not affected + vmscape: Not affected"
+            },
+            {
+              "path": "ci.hardware.Disk",
+              "value": "104GB"
+            },
+            {
+              "path": "ci.hardware.Memory",
+              "value": "8GB"
+            },
+            {
+              "path": "ci.hardware.Processor",
+              "value": "AMD EPYC (1 Core / 2 Threads)"
+            },
+            {
+              "path": "ci.identifier",
+              "value": "ci"
+            },
+            {
+              "path": "ci.software.Compiler",
+              "value": "GCC 14.2.0"
+            },
+            {
+              "path": "ci.software.File-System",
+              "value": "ext4"
+            },
+            {
+              "path": "ci.software.Kernel",
+              "value": "6.1.158+ (x86_64)"
+            },
+            {
+              "path": "ci.software.OS",
+              "value": "Debian GNU/Linux 13"
+            },
+            {
+              "path": "ci.software.System Layer",
+              "value": "KVM"
+            },
+            {
+              "path": "ci.timestamp",
+              "value": "2026-07-17 01:10:32"
+            },
+            {
+              "path": "ci.user",
+              "value": "root"
+            }
+          ]
+        },
+        {
+          "source": "phoronix/result-file-to-json",
+          "sourceFile": "disk/pts_hardlink--metadata.json",
+          "fields": [
+            {
+              "path": "ci.client_version",
+              "value": "10.8.4"
+            },
+            {
+              "path": "ci.data.compiler-configuration",
+              "value": "--build=x86_64-linux-gnu --disable-vtable-verify --disable-werror --enable-bootstrap --enable-cet --enable-checking=release --enable-clocale=gnu --enable-default-pie --enable-gnu-unique-object --enable-languages=c,ada,c++,go,d,fortran,objc,obj-c++,m2,rust --enable-libphobos-checking=release --enable-libstdcxx-backtrace --enable-libstdcxx-debug --enable-libstdcxx-time=yes --enable-link-serialization=3 --enable-multiarch --enable-multilib --enable-nls --enable-objc-gc=auto --enable-offload-defaulted --enable-offload-targets=nvptx-none=/build/reproducible-path/gcc-14-14.2.0/debian/tmp-nvptx/usr,amdgcn-amdhsa=/build/reproducible-path/gcc-14-14.2.0/debian/tmp-gcn/usr --enable-plugin --enable-shared --enable-threads=posix --host=x86_64-linux-gnu --program-prefix=x86_64-linux-gnu- --target=x86_64-linux-gnu --with-abi=m64 --with-arch-32=i686 --with-build-config=bootstrap-lto-lean --with-default-libstdcxx-abi=new --with-gcc-major-version-only --with-multilib-list=m32,m64,mx32 --with-target-system-zlib=auto --with-tune=generic --without-cuda-driver -v"
+            },
+            {
+              "path": "ci.data.cpu-microcode",
+              "value": "0x1000065"
+            },
+            {
+              "path": "ci.data.disk-details",
+              "value": "Block Size: 4096"
+            },
+            {
+              "path": "ci.data.disk-mount-options",
+              "value": "relatime,rw"
+            },
+            {
+              "path": "ci.data.kernel-extra-details",
+              "value": "Transparent Huge Pages: madvise"
+            },
+            {
+              "path": "ci.data.security",
+              "value": "gather_data_sampling: Not affected + indirect_target_selection: Not affected + itlb_multihit: Not affected + l1tf: Not affected + mds: Not affected + meltdown: Not affected + mmio_stale_data: Not affected + reg_file_data_sampling: Not affected + retbleed: Not affected + spec_rstack_overflow: Vulnerable + spec_store_bypass: Mitigation of SSB disabled via prctl + spectre_v1: Mitigation of usercopy/swapgs barriers and __user pointer sanitization + spectre_v2: Mitigation of Enhanced / Automatic IBRS; IBPB: conditional; STIBP: always-on; PBRSB-eIBRS: Not affected; BHI: Not affected + srbds: Not affected + tsa: Vulnerable + tsx_async_abort: Not affected + vmscape: Not affected"
+            },
+            {
+              "path": "ci.hardware.Disk",
+              "value": "104GB"
+            },
+            {
+              "path": "ci.hardware.Memory",
+              "value": "8GB"
+            },
+            {
+              "path": "ci.hardware.Processor",
+              "value": "AMD EPYC (1 Core / 2 Threads)"
+            },
+            {
+              "path": "ci.identifier",
+              "value": "ci"
+            },
+            {
+              "path": "ci.software.Compiler",
+              "value": "GCC 14.2.0"
+            },
+            {
+              "path": "ci.software.File-System",
+              "value": "ext4"
+            },
+            {
+              "path": "ci.software.Kernel",
+              "value": "6.1.158+ (x86_64)"
+            },
+            {
+              "path": "ci.software.OS",
+              "value": "Debian GNU/Linux 13"
+            },
+            {
+              "path": "ci.software.System Layer",
+              "value": "KVM"
+            },
+            {
+              "path": "ci.timestamp",
+              "value": "2026-07-17 01:20:00"
+            },
+            {
+              "path": "ci.user",
+              "value": "root"
+            }
+          ]
+        },
+        {
+          "source": "phoronix/result-file-to-json",
+          "sourceFile": "memory/pts_stream--metadata.json",
+          "fields": [
+            {
+              "path": "ci.client_version",
+              "value": "10.8.4"
+            },
+            {
+              "path": "ci.data.compiler-configuration",
+              "value": "--build=x86_64-linux-gnu --disable-vtable-verify --disable-werror --enable-bootstrap --enable-cet --enable-checking=release --enable-clocale=gnu --enable-default-pie --enable-gnu-unique-object --enable-languages=c,ada,c++,go,d,fortran,objc,obj-c++,m2,rust --enable-libphobos-checking=release --enable-libstdcxx-backtrace --enable-libstdcxx-debug --enable-libstdcxx-time=yes --enable-link-serialization=3 --enable-multiarch --enable-multilib --enable-nls --enable-objc-gc=auto --enable-offload-defaulted --enable-offload-targets=nvptx-none=/build/reproducible-path/gcc-14-14.2.0/debian/tmp-nvptx/usr,amdgcn-amdhsa=/build/reproducible-path/gcc-14-14.2.0/debian/tmp-gcn/usr --enable-plugin --enable-shared --enable-threads=posix --host=x86_64-linux-gnu --program-prefix=x86_64-linux-gnu- --target=x86_64-linux-gnu --with-abi=m64 --with-arch-32=i686 --with-build-config=bootstrap-lto-lean --with-default-libstdcxx-abi=new --with-gcc-major-version-only --with-multilib-list=m32,m64,mx32 --with-target-system-zlib=auto --with-tune=generic --without-cuda-driver -v"
+            },
+            {
+              "path": "ci.data.cpu-microcode",
+              "value": "0x1000065"
+            },
+            {
+              "path": "ci.data.environment-variables",
+              "value": "CFLAGS_OVERRIDE=\"-O3 -march=native -DSTREAM_ARRAY_SIZE=150000000\""
+            },
+            {
+              "path": "ci.data.kernel-extra-details",
+              "value": "Transparent Huge Pages: madvise"
+            },
+            {
+              "path": "ci.data.security",
+              "value": "gather_data_sampling: Not affected + indirect_target_selection: Not affected + itlb_multihit: Not affected + l1tf: Not affected + mds: Not affected + meltdown: Not affected + mmio_stale_data: Not affected + reg_file_data_sampling: Not affected + retbleed: Not affected + spec_rstack_overflow: Vulnerable + spec_store_bypass: Mitigation of SSB disabled via prctl + spectre_v1: Mitigation of usercopy/swapgs barriers and __user pointer sanitization + spectre_v2: Mitigation of Enhanced / Automatic IBRS; IBPB: conditional; STIBP: always-on; PBRSB-eIBRS: Not affected; BHI: Not affected + srbds: Not affected + tsa: Vulnerable + tsx_async_abort: Not affected + vmscape: Not affected"
+            },
+            {
+              "path": "ci.hardware.Disk",
+              "value": "104GB"
+            },
+            {
+              "path": "ci.hardware.Memory",
+              "value": "8GB"
+            },
+            {
+              "path": "ci.hardware.Processor",
+              "value": "AMD EPYC (1 Core / 2 Threads)"
+            },
+            {
+              "path": "ci.identifier",
+              "value": "ci"
+            },
+            {
+              "path": "ci.software.Compiler",
+              "value": "GCC 14.2.0"
+            },
+            {
+              "path": "ci.software.File-System",
+              "value": "ext4"
+            },
+            {
+              "path": "ci.software.Kernel",
+              "value": "6.1.158+ (x86_64)"
+            },
+            {
+              "path": "ci.software.OS",
+              "value": "Debian GNU/Linux 13"
+            },
+            {
+              "path": "ci.software.System Layer",
+              "value": "KVM"
+            },
+            {
+              "path": "ci.timestamp",
+              "value": "2026-07-17 01:07:19"
+            },
+            {
+              "path": "ci.user",
+              "value": "root"
+            }
+          ]
+        },
+        {
+          "source": "phoronix/result-file-to-json",
+          "sourceFile": "network/pts_fast-cli--metadata.json",
+          "fields": [
+            {
+              "path": "ci.client_version",
+              "value": "10.8.4"
+            },
+            {
+              "path": "ci.data.cpu-microcode",
+              "value": "0x1000065"
+            },
+            {
+              "path": "ci.data.kernel-extra-details",
+              "value": "Transparent Huge Pages: madvise"
+            },
+            {
+              "path": "ci.data.security",
+              "value": "gather_data_sampling: Not affected + indirect_target_selection: Not affected + itlb_multihit: Not affected + l1tf: Not affected + mds: Not affected + meltdown: Not affected + mmio_stale_data: Not affected + reg_file_data_sampling: Not affected + retbleed: Not affected + spec_rstack_overflow: Vulnerable + spec_store_bypass: Mitigation of SSB disabled via prctl + spectre_v1: Mitigation of usercopy/swapgs barriers and __user pointer sanitization + spectre_v2: Mitigation of Enhanced / Automatic IBRS; IBPB: conditional; STIBP: always-on; PBRSB-eIBRS: Not affected; BHI: Not affected + srbds: Not affected + tsa: Vulnerable + tsx_async_abort: Not affected + vmscape: Not affected"
+            },
+            {
+              "path": "ci.hardware.Disk",
+              "value": "104GB"
+            },
+            {
+              "path": "ci.hardware.Memory",
+              "value": "8GB"
+            },
+            {
+              "path": "ci.hardware.Processor",
+              "value": "AMD EPYC (1 Core / 2 Threads)"
+            },
+            {
+              "path": "ci.identifier",
+              "value": "ci"
+            },
+            {
+              "path": "ci.software.Compiler",
+              "value": "GCC 14.2.0"
+            },
+            {
+              "path": "ci.software.File-System",
+              "value": "ext4"
+            },
+            {
+              "path": "ci.software.Kernel",
+              "value": "6.1.158+ (x86_64)"
+            },
+            {
+              "path": "ci.software.OS",
+              "value": "Debian GNU/Linux 13"
+            },
+            {
+              "path": "ci.software.System Layer",
+              "value": "KVM"
+            },
+            {
+              "path": "ci.timestamp",
+              "value": "2026-07-17 01:07:56"
+            },
+            {
+              "path": "ci.user",
+              "value": "root"
+            }
+          ]
+        },
+        {
+          "source": "phoronix/result-file-to-json",
+          "sourceFile": "network/pts_network-loopback--metadata.json",
+          "fields": [
+            {
+              "path": "ci.client_version",
+              "value": "10.8.4"
+            },
+            {
+              "path": "ci.data.cpu-microcode",
+              "value": "0x1000065"
+            },
+            {
+              "path": "ci.data.kernel-extra-details",
+              "value": "Transparent Huge Pages: madvise"
+            },
+            {
+              "path": "ci.data.security",
+              "value": "gather_data_sampling: Not affected + indirect_target_selection: Not affected + itlb_multihit: Not affected + l1tf: Not affected + mds: Not affected + meltdown: Not affected + mmio_stale_data: Not affected + reg_file_data_sampling: Not affected + retbleed: Not affected + spec_rstack_overflow: Vulnerable + spec_store_bypass: Mitigation of SSB disabled via prctl + spectre_v1: Mitigation of usercopy/swapgs barriers and __user pointer sanitization + spectre_v2: Mitigation of Enhanced / Automatic IBRS; IBPB: conditional; STIBP: always-on; PBRSB-eIBRS: Not affected; BHI: Not affected + srbds: Not affected + tsa: Vulnerable + tsx_async_abort: Not affected + vmscape: Not affected"
+            },
+            {
+              "path": "ci.hardware.Disk",
+              "value": "104GB"
+            },
+            {
+              "path": "ci.hardware.Memory",
+              "value": "8GB"
+            },
+            {
+              "path": "ci.hardware.Processor",
+              "value": "AMD EPYC (1 Core / 2 Threads)"
+            },
+            {
+              "path": "ci.identifier",
+              "value": "ci"
+            },
+            {
+              "path": "ci.software.Compiler",
+              "value": "GCC 14.2.0"
+            },
+            {
+              "path": "ci.software.File-System",
+              "value": "ext4"
+            },
+            {
+              "path": "ci.software.Kernel",
+              "value": "6.1.158+ (x86_64)"
+            },
+            {
+              "path": "ci.software.OS",
+              "value": "Debian GNU/Linux 13"
+            },
+            {
+              "path": "ci.software.System Layer",
+              "value": "KVM"
+            },
+            {
+              "path": "ci.timestamp",
+              "value": "2026-07-17 01:07:23"
+            },
+            {
+              "path": "ci.user",
+              "value": "root"
+            }
+          ]
+        },
+        {
+          "source": "phoronix/result-file-to-json",
+          "sourceFile": "realworld-better-auth/pts_realworld-better-auth--metadata.json",
+          "fields": [
+            {
+              "path": "ci.client_version",
+              "value": "10.8.4"
+            },
+            {
+              "path": "ci.data.cpu-microcode",
+              "value": "0x1000065"
+            },
+            {
+              "path": "ci.data.kernel-extra-details",
+              "value": "Transparent Huge Pages: madvise"
+            },
+            {
+              "path": "ci.data.security",
+              "value": "gather_data_sampling: Not affected + indirect_target_selection: Not affected + itlb_multihit: Not affected + l1tf: Not affected + mds: Not affected + meltdown: Not affected + mmio_stale_data: Not affected + reg_file_data_sampling: Not affected + retbleed: Not affected + spec_rstack_overflow: Vulnerable + spec_store_bypass: Mitigation of SSB disabled via prctl + spectre_v1: Mitigation of usercopy/swapgs barriers and __user pointer sanitization + spectre_v2: Mitigation of Enhanced / Automatic IBRS; IBPB: conditional; STIBP: always-on; PBRSB-eIBRS: Not affected; BHI: Not affected + srbds: Not affected + tsa: Vulnerable + tsx_async_abort: Not affected + vmscape: Not affected"
+            },
+            {
+              "path": "ci.hardware.Disk",
+              "value": "104GB"
+            },
+            {
+              "path": "ci.hardware.Memory",
+              "value": "8GB"
+            },
+            {
+              "path": "ci.hardware.Processor",
+              "value": "AMD EPYC (1 Core / 2 Threads)"
+            },
+            {
+              "path": "ci.identifier",
+              "value": "ci"
+            },
+            {
+              "path": "ci.software.Compiler",
+              "value": "GCC 14.2.0"
+            },
+            {
+              "path": "ci.software.File-System",
+              "value": "ext4"
+            },
+            {
+              "path": "ci.software.Kernel",
+              "value": "6.1.158+ (x86_64)"
+            },
+            {
+              "path": "ci.software.OS",
+              "value": "Debian GNU/Linux 13"
+            },
+            {
+              "path": "ci.software.System Layer",
+              "value": "KVM"
+            },
+            {
+              "path": "ci.timestamp",
+              "value": "2026-07-17 01:07:47"
+            },
+            {
+              "path": "ci.user",
+              "value": "root"
+            }
+          ]
+        },
+        {
+          "source": "phoronix/result-file-to-json",
+          "sourceFile": "realworld-mastra/pts_realworld-mastra--metadata.json",
+          "fields": [
+            {
+              "path": "ci.client_version",
+              "value": "10.8.4"
+            },
+            {
+              "path": "ci.data.cpu-microcode",
+              "value": "0x1000065"
+            },
+            {
+              "path": "ci.data.kernel-extra-details",
+              "value": "Transparent Huge Pages: madvise"
+            },
+            {
+              "path": "ci.data.security",
+              "value": "gather_data_sampling: Not affected + indirect_target_selection: Not affected + itlb_multihit: Not affected + l1tf: Not affected + mds: Not affected + meltdown: Not affected + mmio_stale_data: Not affected + reg_file_data_sampling: Not affected + retbleed: Not affected + spec_rstack_overflow: Vulnerable + spec_store_bypass: Mitigation of SSB disabled via prctl + spectre_v1: Mitigation of usercopy/swapgs barriers and __user pointer sanitization + spectre_v2: Mitigation of Enhanced / Automatic IBRS; IBPB: conditional; STIBP: always-on; PBRSB-eIBRS: Not affected; BHI: Not affected + srbds: Not affected + tsa: Vulnerable + tsx_async_abort: Not affected + vmscape: Not affected"
+            },
+            {
+              "path": "ci.hardware.Disk",
+              "value": "104GB"
+            },
+            {
+              "path": "ci.hardware.Memory",
+              "value": "8GB"
+            },
+            {
+              "path": "ci.hardware.Processor",
+              "value": "AMD EPYC (1 Core / 2 Threads)"
+            },
+            {
+              "path": "ci.identifier",
+              "value": "ci"
+            },
+            {
+              "path": "ci.software.Compiler",
+              "value": "GCC 14.2.0"
+            },
+            {
+              "path": "ci.software.File-System",
+              "value": "ext4"
+            },
+            {
+              "path": "ci.software.Kernel",
+              "value": "6.1.158+ (x86_64)"
+            },
+            {
+              "path": "ci.software.OS",
+              "value": "Debian GNU/Linux 13"
+            },
+            {
+              "path": "ci.software.System Layer",
+              "value": "KVM"
+            },
+            {
+              "path": "ci.timestamp",
+              "value": "2026-07-17 01:08:39"
+            },
+            {
+              "path": "ci.user",
+              "value": "root"
+            }
+          ]
+        },
+        {
+          "source": "phoronix/result-file-to-json",
+          "sourceFile": "system/pts_git--metadata.json",
+          "fields": [
+            {
+              "path": "ci.client_version",
+              "value": "10.8.4"
+            },
+            {
+              "path": "ci.data.cpu-microcode",
+              "value": "0x1000065"
+            },
+            {
+              "path": "ci.data.kernel-extra-details",
+              "value": "Transparent Huge Pages: madvise"
+            },
+            {
+              "path": "ci.data.security",
+              "value": "gather_data_sampling: Not affected + indirect_target_selection: Not affected + itlb_multihit: Not affected + l1tf: Not affected + mds: Not affected + meltdown: Not affected + mmio_stale_data: Not affected + reg_file_data_sampling: Not affected + retbleed: Not affected + spec_rstack_overflow: Vulnerable + spec_store_bypass: Mitigation of SSB disabled via prctl + spectre_v1: Mitigation of usercopy/swapgs barriers and __user pointer sanitization + spectre_v2: Mitigation of Enhanced / Automatic IBRS; IBPB: conditional; STIBP: always-on; PBRSB-eIBRS: Not affected; BHI: Not affected + srbds: Not affected + tsa: Vulnerable + tsx_async_abort: Not affected + vmscape: Not affected"
+            },
+            {
+              "path": "ci.hardware.Disk",
+              "value": "104GB"
+            },
+            {
+              "path": "ci.hardware.Memory",
+              "value": "8GB"
+            },
+            {
+              "path": "ci.hardware.Processor",
+              "value": "AMD EPYC (1 Core / 2 Threads)"
+            },
+            {
+              "path": "ci.identifier",
+              "value": "ci"
+            },
+            {
+              "path": "ci.software.Compiler",
+              "value": "GCC 14.2.0"
+            },
+            {
+              "path": "ci.software.File-System",
+              "value": "ext4"
+            },
+            {
+              "path": "ci.software.Kernel",
+              "value": "6.1.158+ (x86_64)"
+            },
+            {
+              "path": "ci.software.OS",
+              "value": "Debian GNU/Linux 13"
+            },
+            {
+              "path": "ci.software.System Layer",
+              "value": "KVM"
+            },
+            {
+              "path": "ci.timestamp",
+              "value": "2026-07-17 01:10:38"
+            },
+            {
+              "path": "ci.user",
+              "value": "root"
+            }
+          ]
+        },
+        {
+          "source": "phoronix/result-file-to-json",
+          "sourceFile": "system/pts_pgbench-read-only--metadata.json",
+          "fields": [
+            {
+              "path": "ci.client_version",
+              "value": "10.8.4"
+            },
+            {
+              "path": "ci.data.compiler-configuration",
+              "value": "--build=x86_64-linux-gnu --disable-vtable-verify --disable-werror --enable-bootstrap --enable-cet --enable-checking=release --enable-clocale=gnu --enable-default-pie --enable-gnu-unique-object --enable-languages=c,ada,c++,go,d,fortran,objc,obj-c++,m2,rust --enable-libphobos-checking=release --enable-libstdcxx-backtrace --enable-libstdcxx-debug --enable-libstdcxx-time=yes --enable-link-serialization=3 --enable-multiarch --enable-multilib --enable-nls --enable-objc-gc=auto --enable-offload-defaulted --enable-offload-targets=nvptx-none=/build/reproducible-path/gcc-14-14.2.0/debian/tmp-nvptx/usr,amdgcn-amdhsa=/build/reproducible-path/gcc-14-14.2.0/debian/tmp-gcn/usr --enable-plugin --enable-shared --enable-threads=posix --host=x86_64-linux-gnu --program-prefix=x86_64-linux-gnu- --target=x86_64-linux-gnu --with-abi=m64 --with-arch-32=i686 --with-build-config=bootstrap-lto-lean --with-default-libstdcxx-abi=new --with-gcc-major-version-only --with-multilib-list=m32,m64,mx32 --with-target-system-zlib=auto --with-tune=generic --without-cuda-driver -v"
+            },
+            {
+              "path": "ci.data.cpu-microcode",
+              "value": "0x1000065"
+            },
+            {
+              "path": "ci.data.kernel-extra-details",
+              "value": "Transparent Huge Pages: madvise"
+            },
+            {
+              "path": "ci.data.security",
+              "value": "gather_data_sampling: Not affected + indirect_target_selection: Not affected + itlb_multihit: Not affected + l1tf: Not affected + mds: Not affected + meltdown: Not affected + mmio_stale_data: Not affected + reg_file_data_sampling: Not affected + retbleed: Not affected + spec_rstack_overflow: Vulnerable + spec_store_bypass: Mitigation of SSB disabled via prctl + spectre_v1: Mitigation of usercopy/swapgs barriers and __user pointer sanitization + spectre_v2: Mitigation of Enhanced / Automatic IBRS; IBPB: conditional; STIBP: always-on; PBRSB-eIBRS: Not affected; BHI: Not affected + srbds: Not affected + tsa: Vulnerable + tsx_async_abort: Not affected + vmscape: Not affected"
+            },
+            {
+              "path": "ci.hardware.Disk",
+              "value": "104GB"
+            },
+            {
+              "path": "ci.hardware.Memory",
+              "value": "8GB"
+            },
+            {
+              "path": "ci.hardware.Processor",
+              "value": "AMD EPYC (1 Core / 2 Threads)"
+            },
+            {
+              "path": "ci.identifier",
+              "value": "ci"
+            },
+            {
+              "path": "ci.software.Compiler",
+              "value": "GCC 14.2.0"
+            },
+            {
+              "path": "ci.software.File-System",
+              "value": "ext4"
+            },
+            {
+              "path": "ci.software.Kernel",
+              "value": "6.1.158+ (x86_64)"
+            },
+            {
+              "path": "ci.software.OS",
+              "value": "Debian GNU/Linux 13"
+            },
+            {
+              "path": "ci.software.System Layer",
+              "value": "KVM"
+            },
+            {
+              "path": "ci.timestamp",
+              "value": "2026-07-17 01:09:25"
+            },
+            {
+              "path": "ci.user",
+              "value": "root"
+            }
+          ]
+        },
+        {
+          "source": "phoronix/result-file-to-json",
+          "sourceFile": "system/pts_pgbench-read-write--metadata.json",
+          "fields": [
+            {
+              "path": "ci.client_version",
+              "value": "10.8.4"
+            },
+            {
+              "path": "ci.data.compiler-configuration",
+              "value": "--build=x86_64-linux-gnu --disable-vtable-verify --disable-werror --enable-bootstrap --enable-cet --enable-checking=release --enable-clocale=gnu --enable-default-pie --enable-gnu-unique-object --enable-languages=c,ada,c++,go,d,fortran,objc,obj-c++,m2,rust --enable-libphobos-checking=release --enable-libstdcxx-backtrace --enable-libstdcxx-debug --enable-libstdcxx-time=yes --enable-link-serialization=3 --enable-multiarch --enable-multilib --enable-nls --enable-objc-gc=auto --enable-offload-defaulted --enable-offload-targets=nvptx-none=/build/reproducible-path/gcc-14-14.2.0/debian/tmp-nvptx/usr,amdgcn-amdhsa=/build/reproducible-path/gcc-14-14.2.0/debian/tmp-gcn/usr --enable-plugin --enable-shared --enable-threads=posix --host=x86_64-linux-gnu --program-prefix=x86_64-linux-gnu- --target=x86_64-linux-gnu --with-abi=m64 --with-arch-32=i686 --with-build-config=bootstrap-lto-lean --with-default-libstdcxx-abi=new --with-gcc-major-version-only --with-multilib-list=m32,m64,mx32 --with-target-system-zlib=auto --with-tune=generic --without-cuda-driver -v"
+            },
+            {
+              "path": "ci.data.cpu-microcode",
+              "value": "0x1000065"
+            },
+            {
+              "path": "ci.data.kernel-extra-details",
+              "value": "Transparent Huge Pages: madvise"
+            },
+            {
+              "path": "ci.data.security",
+              "value": "gather_data_sampling: Not affected + indirect_target_selection: Not affected + itlb_multihit: Not affected + l1tf: Not affected + mds: Not affected + meltdown: Not affected + mmio_stale_data: Not affected + reg_file_data_sampling: Not affected + retbleed: Not affected + spec_rstack_overflow: Vulnerable + spec_store_bypass: Mitigation of SSB disabled via prctl + spectre_v1: Mitigation of usercopy/swapgs barriers and __user pointer sanitization + spectre_v2: Mitigation of Enhanced / Automatic IBRS; IBPB: conditional; STIBP: always-on; PBRSB-eIBRS: Not affected; BHI: Not affected + srbds: Not affected + tsa: Vulnerable + tsx_async_abort: Not affected + vmscape: Not affected"
+            },
+            {
+              "path": "ci.hardware.Disk",
+              "value": "104GB"
+            },
+            {
+              "path": "ci.hardware.Memory",
+              "value": "8GB"
+            },
+            {
+              "path": "ci.hardware.Processor",
+              "value": "AMD EPYC (1 Core / 2 Threads)"
+            },
+            {
+              "path": "ci.identifier",
+              "value": "ci"
+            },
+            {
+              "path": "ci.software.Compiler",
+              "value": "GCC 14.2.0"
+            },
+            {
+              "path": "ci.software.File-System",
+              "value": "ext4"
+            },
+            {
+              "path": "ci.software.Kernel",
+              "value": "6.1.158+ (x86_64)"
+            },
+            {
+              "path": "ci.software.OS",
+              "value": "Debian GNU/Linux 13"
+            },
+            {
+              "path": "ci.software.System Layer",
+              "value": "KVM"
+            },
+            {
+              "path": "ci.timestamp",
+              "value": "2026-07-17 01:10:03"
+            },
+            {
+              "path": "ci.user",
+              "value": "root"
+            }
+          ]
+        },
+        {
+          "source": "phoronix/result-file-to-json",
+          "sourceFile": "system/pts_pybench--metadata.json",
+          "fields": [
+            {
+              "path": "ci.client_version",
+              "value": "10.8.4"
+            },
+            {
+              "path": "ci.data.cpu-microcode",
+              "value": "0x1000065"
+            },
+            {
+              "path": "ci.data.kernel-extra-details",
+              "value": "Transparent Huge Pages: madvise"
+            },
+            {
+              "path": "ci.data.python",
+              "value": "mise ERROR python is not a valid shim. This likely means you uninstalled a tool and the shim does not point anything. Run `mise use ` reinstall the tool.mise ERROR : 2026.5.16 linux-x64 (2026-05-28)mise ERROR Run with--verbose or MISE_VERBOSE=1 for more information + mise ERROR python3 is not a valid shim. This likely means you uninstalled a tool and the shim does not point anything. Run `mise use ` reinstall the tool.mise ERROR : 2026.5.16 linux-x64 (2026-05-28)mise ERROR Run with--verbose or MISE_VERBOSE=1 for more information"
+            },
+            {
+              "path": "ci.data.security",
+              "value": "gather_data_sampling: Not affected + indirect_target_selection: Not affected + itlb_multihit: Not affected + l1tf: Not affected + mds: Not affected + meltdown: Not affected + mmio_stale_data: Not affected + reg_file_data_sampling: Not affected + retbleed: Not affected + spec_rstack_overflow: Vulnerable + spec_store_bypass: Mitigation of SSB disabled via prctl + spectre_v1: Mitigation of usercopy/swapgs barriers and __user pointer sanitization + spectre_v2: Mitigation of Enhanced / Automatic IBRS; IBPB: conditional; STIBP: always-on; PBRSB-eIBRS: Not affected; BHI: Not affected + srbds: Not affected + tsa: Vulnerable + tsx_async_abort: Not affected + vmscape: Not affected"
+            },
+            {
+              "path": "ci.hardware.Disk",
+              "value": "104GB"
+            },
+            {
+              "path": "ci.hardware.Memory",
+              "value": "8GB"
+            },
+            {
+              "path": "ci.hardware.Processor",
+              "value": "AMD EPYC (1 Core / 2 Threads)"
+            },
+            {
+              "path": "ci.identifier",
+              "value": "ci"
+            },
+            {
+              "path": "ci.software.Compiler",
+              "value": "GCC 14.2.0"
+            },
+            {
+              "path": "ci.software.File-System",
+              "value": "ext4"
+            },
+            {
+              "path": "ci.software.Kernel",
+              "value": "6.1.158+ (x86_64)"
+            },
+            {
+              "path": "ci.software.OS",
+              "value": "Debian GNU/Linux 13"
+            },
+            {
+              "path": "ci.software.System Layer",
+              "value": "KVM"
+            },
+            {
+              "path": "ci.timestamp",
+              "value": "2026-07-17 01:07:15"
+            },
+            {
+              "path": "ci.user",
+              "value": "root"
+            }
+          ]
+        },
+        {
+          "source": "phoronix/result-file-to-json",
+          "sourceFile": "system/pts_sqlite-speedtest--metadata.json",
+          "fields": [
+            {
+              "path": "ci.client_version",
+              "value": "10.8.4"
+            },
+            {
+              "path": "ci.data.compiler-configuration",
+              "value": "--build=x86_64-linux-gnu --disable-vtable-verify --disable-werror --enable-bootstrap --enable-cet --enable-checking=release --enable-clocale=gnu --enable-default-pie --enable-gnu-unique-object --enable-languages=c,ada,c++,go,d,fortran,objc,obj-c++,m2,rust --enable-libphobos-checking=release --enable-libstdcxx-backtrace --enable-libstdcxx-debug --enable-libstdcxx-time=yes --enable-link-serialization=3 --enable-multiarch --enable-multilib --enable-nls --enable-objc-gc=auto --enable-offload-defaulted --enable-offload-targets=nvptx-none=/build/reproducible-path/gcc-14-14.2.0/debian/tmp-nvptx/usr,amdgcn-amdhsa=/build/reproducible-path/gcc-14-14.2.0/debian/tmp-gcn/usr --enable-plugin --enable-shared --enable-threads=posix --host=x86_64-linux-gnu --program-prefix=x86_64-linux-gnu- --target=x86_64-linux-gnu --with-abi=m64 --with-arch-32=i686 --with-build-config=bootstrap-lto-lean --with-default-libstdcxx-abi=new --with-gcc-major-version-only --with-multilib-list=m32,m64,mx32 --with-target-system-zlib=auto --with-tune=generic --without-cuda-driver -v"
+            },
+            {
+              "path": "ci.data.cpu-microcode",
+              "value": "0x1000065"
+            },
+            {
+              "path": "ci.data.kernel-extra-details",
+              "value": "Transparent Huge Pages: madvise"
+            },
+            {
+              "path": "ci.data.security",
+              "value": "gather_data_sampling: Not affected + indirect_target_selection: Not affected + itlb_multihit: Not affected + l1tf: Not affected + mds: Not affected + meltdown: Not affected + mmio_stale_data: Not affected + reg_file_data_sampling: Not affected + retbleed: Not affected + spec_rstack_overflow: Vulnerable + spec_store_bypass: Mitigation of SSB disabled via prctl + spectre_v1: Mitigation of usercopy/swapgs barriers and __user pointer sanitization + spectre_v2: Mitigation of Enhanced / Automatic IBRS; IBPB: conditional; STIBP: always-on; PBRSB-eIBRS: Not affected; BHI: Not affected + srbds: Not affected + tsa: Vulnerable + tsx_async_abort: Not affected + vmscape: Not affected"
+            },
+            {
+              "path": "ci.hardware.Disk",
+              "value": "104GB"
+            },
+            {
+              "path": "ci.hardware.Memory",
+              "value": "8GB"
+            },
+            {
+              "path": "ci.hardware.Processor",
+              "value": "AMD EPYC (1 Core / 2 Threads)"
+            },
+            {
+              "path": "ci.identifier",
+              "value": "ci"
+            },
+            {
+              "path": "ci.software.Compiler",
+              "value": "GCC 14.2.0"
+            },
+            {
+              "path": "ci.software.File-System",
+              "value": "ext4"
+            },
+            {
+              "path": "ci.software.Kernel",
+              "value": "6.1.158+ (x86_64)"
+            },
+            {
+              "path": "ci.software.OS",
+              "value": "Debian GNU/Linux 13"
+            },
+            {
+              "path": "ci.software.System Layer",
+              "value": "KVM"
+            },
+            {
+              "path": "ci.timestamp",
+              "value": "2026-07-17 01:07:31"
+            },
+            {
+              "path": "ci.user",
+              "value": "root"
+            }
+          ]
+        },
+        {
+          "source": "mise/system-provider",
+          "sourceFile": "system/system-provider.json",
+          "fields": [
+            {
+              "path": "asn",
+              "value": "AS31898"
+            },
+            {
+              "path": "asn_source",
+              "value": "cymru"
+            },
+            {
+              "path": "bios_vendor",
+              "value": ""
+            },
+            {
+              "path": "city",
+              "value": "Phoenix"
+            },
+            {
+              "path": "cores",
+              "value": "2"
+            },
+            {
+              "path": "country",
+              "value": "US"
+            },
+            {
+              "path": "cpu_model",
+              "value": "AMD EPYC"
+            },
+            {
+              "path": "geo_source",
+              "value": "ipinfo"
+            },
+            {
+              "path": "kernel",
+              "value": "6.1.158+"
+            },
+            {
+              "path": "loc",
+              "value": "33.4484,-112.0740"
+            },
+            {
+              "path": "manufacturer",
+              "value": ""
+            },
+            {
+              "path": "org",
+              "value": "AS31898 Oracle Corporation"
+            },
+            {
+              "path": "org_name",
+              "value": "Oracle Corporation"
+            },
+            {
+              "path": "prefix",
+              "value": "161.153.0.0/17"
+            },
+            {
+              "path": "product_name",
+              "value": ""
+            },
+            {
+              "path": "public_ip",
+              "value": "161.153.9.169"
+            },
+            {
+              "path": "ram",
+              "value": "7.8Gi"
+            },
+            {
+              "path": "region",
+              "value": "Arizona"
+            },
+            {
+              "path": "reverse_dns",
+              "value": ""
+            },
+            {
+              "path": "schema_version",
+              "value": "1.0"
+            },
+            {
+              "path": "timezone",
+              "value": "America/Phoenix"
+            },
+            {
+              "path": "virtualization",
+              "value": "kvm"
+            }
+          ]
+        }
+      ],
+      "metrics": [
+        {
+          "metricId": "c_ray_resolution_1080p_rays_per_pixel_16",
+          "samples": [240.99, 240.249],
+          "aggregates": {
+            "p50": 240.61950000000002,
+            "p95": 240.95295000000002,
+            "mean": 240.61950000000002,
+            "stdev": 0.5239661248592314,
+            "min": 240.249,
+            "max": 240.99,
+            "n": 2
+          },
+          "sourceFile": "cpu-generic/pts_c-ray.xml",
+          "appVersion": "2.0",
+          "arguments": "-s 1920x1080 -r 16"
+        },
+        {
+          "metricId": "c_ray_resolution_4k_rays_per_pixel_16",
+          "samples": [962.324, 961.525],
+          "aggregates": {
+            "p50": 961.9245,
+            "p95": 962.28405,
+            "mean": 961.9245,
+            "stdev": 0.564978318168036,
+            "min": 961.525,
+            "max": 962.324,
+            "n": 2
+          },
+          "sourceFile": "cpu-generic/pts_c-ray.xml",
+          "appVersion": "2.0",
+          "arguments": "-s 3840x2160 -r 16"
+        },
+        {
+          "metricId": "c_ray_resolution_5k_rays_per_pixel_16",
+          "samples": [1705.315, 1704.092],
+          "aggregates": {
+            "p50": 1704.7035,
+            "p95": 1705.25385,
+            "mean": 1704.7035,
+            "stdev": 0.8647915933911168,
+            "min": 1704.092,
+            "max": 1705.315,
+            "n": 2
+          },
+          "sourceFile": "cpu-generic/pts_c-ray.xml",
+          "appVersion": "2.0",
+          "arguments": "-s 5120x2880 -r 16"
+        },
+        {
+          "metricId": "compress_zstd_compression_level_12_compression_speed",
+          "samples": [71.2, 71.6],
+          "aggregates": {
+            "p50": 71.4,
+            "p95": 71.58,
+            "mean": 71.4,
+            "stdev": 0.28284271247460796,
+            "min": 71.2,
+            "max": 71.6,
+            "n": 2
+          },
+          "sourceFile": "cpu-generic/pts_compress-zstd.xml",
+          "appVersion": "1.5.4",
+          "arguments": "-b12"
+        },
+        {
+          "metricId": "compress_zstd_compression_level_12_decompression_speed",
+          "samples": [1915.4, 1897.3],
+          "aggregates": {
+            "p50": 1906.35,
+            "p95": 1914.4950000000001,
+            "mean": 1906.35,
+            "stdev": 12.798632739476687,
+            "min": 1897.3,
+            "max": 1915.4,
+            "n": 2
+          },
+          "sourceFile": "cpu-generic/pts_compress-zstd.xml",
+          "appVersion": "1.5.4",
+          "arguments": "-b12"
+        },
+        {
+          "metricId": "compress_zstd_compression_level_19_compression_speed",
+          "samples": [5.71, 5.69],
+          "aggregates": {
+            "p50": 5.7,
+            "p95": 5.709,
+            "mean": 5.7,
+            "stdev": 0.014142135623730649,
+            "min": 5.69,
+            "max": 5.71,
+            "n": 2
+          },
+          "sourceFile": "cpu-generic/pts_compress-zstd.xml",
+          "appVersion": "1.5.4",
+          "arguments": "-b19"
+        },
+        {
+          "metricId": "compress_zstd_compression_level_19_decompression_speed",
+          "samples": [1616.7, 1626.9],
+          "aggregates": {
+            "p50": 1621.8000000000002,
+            "p95": 1626.39,
+            "mean": 1621.8000000000002,
+            "stdev": 7.212489168102737,
+            "min": 1616.7,
+            "max": 1626.9,
+            "n": 2
+          },
+          "sourceFile": "cpu-generic/pts_compress-zstd.xml",
+          "appVersion": "1.5.4",
+          "arguments": "-b19"
+        },
+        {
+          "metricId": "compress_zstd_compression_level_19_long_mode_compression_speed",
+          "samples": [5.23, 5.22],
+          "aggregates": {
+            "p50": 5.225,
+            "p95": 5.229500000000001,
+            "mean": 5.225,
+            "stdev": 0.007071067811866266,
+            "min": 5.22,
+            "max": 5.23,
+            "n": 2
+          },
+          "sourceFile": "cpu-generic/pts_compress-zstd.xml",
+          "appVersion": "1.5.4",
+          "arguments": "-b19 --long"
+        },
+        {
+          "metricId": "compress_zstd_compression_level_19_long_mode_decompression_speed",
+          "samples": [1551.5, 1535.7],
+          "aggregates": {
+            "p50": 1543.6,
+            "p95": 1550.71,
+            "mean": 1543.6,
+            "stdev": 11.172287142747498,
+            "min": 1535.7,
+            "max": 1551.5,
+            "n": 2
+          },
+          "sourceFile": "cpu-generic/pts_compress-zstd.xml",
+          "appVersion": "1.5.4",
+          "arguments": "-b19 --long"
+        },
+        {
+          "metricId": "compress_zstd_compression_level_3_compression_speed",
+          "samples": [682.1, 673.2],
+          "aggregates": {
+            "p50": 677.6500000000001,
+            "p95": 681.655,
+            "mean": 677.6500000000001,
+            "stdev": 6.293250352560217,
+            "min": 673.2,
+            "max": 682.1,
+            "n": 2
+          },
+          "sourceFile": "cpu-generic/pts_compress-zstd.xml",
+          "appVersion": "1.5.4",
+          "arguments": "-b3"
+        },
+        {
+          "metricId": "compress_zstd_compression_level_3_decompression_speed",
+          "samples": [1742.5, 1751.3],
+          "aggregates": {
+            "p50": 1746.9,
+            "p95": 1750.86,
+            "mean": 1746.9,
+            "stdev": 6.222539674441506,
+            "min": 1742.5,
+            "max": 1751.3,
+            "n": 2
+          },
+          "sourceFile": "cpu-generic/pts_compress-zstd.xml",
+          "appVersion": "1.5.4",
+          "arguments": "-b3"
+        },
+        {
+          "metricId": "compress_zstd_compression_level_3_long_mode_compression_speed",
+          "samples": [531, 527.9],
+          "aggregates": {
+            "p50": 529.45,
+            "p95": 530.845,
+            "mean": 529.45,
+            "stdev": 2.192031021678273,
+            "min": 527.9,
+            "max": 531,
+            "n": 2
+          },
+          "sourceFile": "cpu-generic/pts_compress-zstd.xml",
+          "appVersion": "1.5.4",
+          "arguments": "-b3 --long"
+        },
+        {
+          "metricId": "compress_zstd_compression_level_3_long_mode_decompression_speed",
+          "samples": [1810.9, 1805],
+          "aggregates": {
+            "p50": 1807.95,
+            "p95": 1810.605,
+            "mean": 1807.95,
+            "stdev": 4.171930009000695,
+            "min": 1805,
+            "max": 1810.9,
+            "n": 2
+          },
+          "sourceFile": "cpu-generic/pts_compress-zstd.xml",
+          "appVersion": "1.5.4",
+          "arguments": "-b3 --long"
+        },
+        {
+          "metricId": "compress_zstd_compression_level_8_compression_speed",
+          "samples": [178.7, 180.2],
+          "aggregates": {
+            "p50": 179.45,
+            "p95": 180.125,
+            "mean": 179.45,
+            "stdev": 1.0606601717798212,
+            "min": 178.7,
+            "max": 180.2,
+            "n": 2
+          },
+          "sourceFile": "cpu-generic/pts_compress-zstd.xml",
+          "appVersion": "1.5.4",
+          "arguments": "-b8"
+        },
+        {
+          "metricId": "compress_zstd_compression_level_8_decompression_speed",
+          "samples": [1907.7, 1912.3],
+          "aggregates": {
+            "p50": 1910,
+            "p95": 1912.07,
+            "mean": 1910,
+            "stdev": 3.252691193458054,
+            "min": 1907.7,
+            "max": 1912.3,
+            "n": 2
+          },
+          "sourceFile": "cpu-generic/pts_compress-zstd.xml",
+          "appVersion": "1.5.4",
+          "arguments": "-b8"
+        },
+        {
+          "metricId": "compress_zstd_compression_level_8_long_mode_compression_speed",
+          "samples": [174.8, 174.5],
+          "aggregates": {
+            "p50": 174.65,
+            "p95": 174.78500000000003,
+            "mean": 174.65,
+            "stdev": 0.2121320343559723,
+            "min": 174.5,
+            "max": 174.8,
+            "n": 2
+          },
+          "sourceFile": "cpu-generic/pts_compress-zstd.xml",
+          "appVersion": "1.5.4",
+          "arguments": "-b8 --long"
+        },
+        {
+          "metricId": "compress_zstd_compression_level_8_long_mode_decompression_speed",
+          "samples": [1915, 1911.5],
+          "aggregates": {
+            "p50": 1913.25,
+            "p95": 1914.825,
+            "mean": 1913.25,
+            "stdev": 2.4748737341529163,
+            "min": 1911.5,
+            "max": 1915,
+            "n": 2
+          },
+          "sourceFile": "cpu-generic/pts_compress-zstd.xml",
+          "appVersion": "1.5.4",
+          "arguments": "-b8 --long"
+        },
+        {
+          "metricId": "fio_type_random_read_engine_linux_aio_direct_yes_block_size_4kb_job_count_1_disk_target_default_test_directory_iops",
+          "samples": [63700, 55300],
+          "aggregates": {
+            "p50": 59500,
+            "p95": 63280,
+            "mean": 59500,
+            "stdev": 5939.696961966999,
+            "min": 55300,
+            "max": 63700,
+            "n": 2
+          },
+          "sourceFile": "disk/pts_fio-rand-read.xml",
+          "appVersion": "3.36",
+          "arguments": "randread libaio 1 4k 1"
+        },
+        {
+          "metricId": "fio_type_random_read_engine_linux_aio_direct_yes_block_size_4kb_job_count_1_disk_target_default_test_directory_mb_per_s",
+          "samples": [249, 216],
+          "aggregates": {
+            "p50": 232.5,
+            "p95": 247.35,
+            "mean": 232.5,
+            "stdev": 23.33452377915607,
+            "min": 216,
+            "max": 249,
+            "n": 2
+          },
+          "sourceFile": "disk/pts_fio-rand-read.xml",
+          "appVersion": "3.36",
+          "arguments": "randread libaio 1 4k 1"
+        },
+        {
+          "metricId": "fio_type_random_write_engine_linux_aio_direct_yes_block_size_4kb_job_count_1_disk_target_default_test_directory_iops",
+          "samples": [94600, 75700],
+          "aggregates": {
+            "p50": 85150,
+            "p95": 93655,
+            "mean": 85150,
+            "stdev": 13364.318164425747,
+            "min": 75700,
+            "max": 94600,
+            "n": 2
+          },
+          "sourceFile": "disk/pts_fio-rand-write.xml",
+          "appVersion": "3.36",
+          "arguments": "randwrite libaio 1 4k 1"
+        },
+        {
+          "metricId": "fio_type_random_write_engine_linux_aio_direct_yes_block_size_4kb_job_count_1_disk_target_default_test_directory_mb_per_s",
+          "samples": [369, 296],
+          "aggregates": {
+            "p50": 332.5,
+            "p95": 365.35,
+            "mean": 332.5,
+            "stdev": 51.61879502661797,
+            "min": 296,
+            "max": 369,
+            "n": 2
+          },
+          "sourceFile": "disk/pts_fio-rand-write.xml",
+          "appVersion": "3.36",
+          "arguments": "randwrite libaio 1 4k 1"
+        },
+        {
+          "metricId": "fio_type_sequential_read_engine_linux_aio_direct_yes_block_size_1mb_job_count_1_disk_target_default_test_directory_iops",
+          "samples": [11200, 11300],
+          "aggregates": {
+            "p50": 11250,
+            "p95": 11295,
+            "mean": 11250,
+            "stdev": 70.71067811865476,
+            "min": 11200,
+            "max": 11300,
+            "n": 2
+          },
+          "sourceFile": "disk/pts_fio-seq-read.xml",
+          "appVersion": "3.36",
+          "arguments": "read libaio 1 1m 1"
+        },
+        {
+          "metricId": "fio_type_sequential_write_engine_linux_aio_direct_yes_block_size_1mb_job_count_1_disk_target_default_test_directory_iops",
+          "samples": [5210, 5570],
+          "aggregates": {
+            "p50": 5390,
+            "p95": 5552,
+            "mean": 5390,
+            "stdev": 254.55844122715712,
+            "min": 5210,
+            "max": 5570,
+            "n": 2
+          },
+          "sourceFile": "disk/pts_fio-seq-write.xml",
+          "appVersion": "3.36",
+          "arguments": "write libaio 1 1m 1"
+        },
+        {
+          "metricId": "fio_type_sequential_write_engine_linux_aio_direct_yes_block_size_1mb_job_count_1_disk_target_default_test_directory_mb_per_s",
+          "samples": [5211, 5571],
+          "aggregates": {
+            "p50": 5391,
+            "p95": 5553,
+            "mean": 5391,
+            "stdev": 254.55844122715712,
+            "min": 5211,
+            "max": 5571,
+            "n": 2
+          },
+          "sourceFile": "disk/pts_fio-seq-write.xml",
+          "appVersion": "3.36",
+          "arguments": "write libaio 1 1m 1"
+        },
+        {
+          "metricId": "git_seconds",
+          "samples": [43.678, 43.495],
+          "aggregates": {
+            "p50": 43.5865,
+            "p95": 43.66885,
+            "mean": 43.5865,
+            "stdev": 0.12940054095713557,
+            "min": 43.495,
+            "max": 43.678,
+            "n": 2
+          },
+          "sourceFile": "system/pts_git.xml"
+        },
+        {
+          "metricId": "hardlink_bogo_ops_per_s",
+          "samples": [18.45, 18.59],
+          "aggregates": {
+            "p50": 18.52,
+            "p95": 18.583,
+            "mean": 18.52,
+            "stdev": 0.09899494936611705,
+            "min": 18.45,
+            "max": 18.59,
+            "n": 2
+          },
+          "sourceFile": "disk/pts_hardlink.xml",
+          "appVersion": "0.16"
+        },
+        {
+          "metricId": "network_loopback_seconds",
+          "samples": [7.928, 7.959],
+          "aggregates": {
+            "p50": 7.9435,
+            "p95": 7.95745,
+            "mean": 7.9435,
+            "stdev": 0.021920310216782445,
+            "min": 7.928,
+            "max": 7.959,
+            "n": 2
+          },
+          "sourceFile": "network/pts_network-loopback.xml"
+        },
+        {
+          "metricId": "node_web_tooling_runs_per_s",
+          "samples": [17.43, 17.58],
+          "aggregates": {
+            "p50": 17.505,
+            "p95": 17.572499999999998,
+            "mean": 17.505,
+            "stdev": 0.10606601717798111,
+            "min": 17.43,
+            "max": 17.58,
+            "n": 2
+          },
+          "sourceFile": "cpu-node/pts_node-web-tooling.xml"
+        },
+        {
+          "metricId": "realworld_better_auth_task_build",
+          "samples": [14.519, 14.528],
+          "aggregates": {
+            "p50": 14.5235,
+            "p95": 14.52755,
+            "mean": 14.5235,
+            "stdev": 0.006363961030679169,
+            "min": 14.519,
+            "max": 14.528,
+            "n": 2
+          },
+          "sourceFile": "realworld-better-auth/pts_realworld-better-auth.xml",
+          "appVersion": "6f3ba45639579da152b69e8e5342e02f28288670",
+          "arguments": "build"
+        },
+        {
+          "metricId": "realworld_better_auth_task_cold_install",
+          "samples": [11.952, 11.768],
+          "aggregates": {
+            "p50": 11.86,
+            "p95": 11.9428,
+            "mean": 11.86,
+            "stdev": 0.13010764773832487,
+            "min": 11.768,
+            "max": 11.952,
+            "n": 2
+          },
+          "sourceFile": "realworld-better-auth/pts_realworld-better-auth.xml",
+          "appVersion": "6f3ba45639579da152b69e8e5342e02f28288670",
+          "arguments": "cold_install"
+        },
+        {
+          "metricId": "realworld_better_auth_task_git_clone",
+          "samples": [1.726, 2.187],
+          "aggregates": {
+            "p50": 1.9565,
+            "p95": 2.16395,
+            "mean": 1.9565,
+            "stdev": 0.32597622612699834,
+            "min": 1.726,
+            "max": 2.187,
+            "n": 2
+          },
+          "sourceFile": "realworld-better-auth/pts_realworld-better-auth.xml",
+          "appVersion": "6f3ba45639579da152b69e8e5342e02f28288670",
+          "arguments": "git_clone"
+        },
+        {
+          "metricId": "realworld_better_auth_task_lint_biome",
+          "samples": [5.411, 5.378],
+          "aggregates": {
+            "p50": 5.3945,
+            "p95": 5.40935,
+            "mean": 5.3945,
+            "stdev": 0.023334523779155694,
+            "min": 5.378,
+            "max": 5.411,
+            "n": 2
+          },
+          "sourceFile": "realworld-better-auth/pts_realworld-better-auth.xml",
+          "appVersion": "6f3ba45639579da152b69e8e5342e02f28288670",
+          "arguments": "lint_biome"
+        },
+        {
+          "metricId": "realworld_better_auth_task_lint_deps_knip",
+          "samples": [11.645, 11.703],
+          "aggregates": {
+            "p50": 11.674,
+            "p95": 11.700099999999999,
+            "mean": 11.674,
+            "stdev": 0.04101219330881964,
+            "min": 11.645,
+            "max": 11.703,
+            "n": 2
+          },
+          "sourceFile": "realworld-better-auth/pts_realworld-better-auth.xml",
+          "appVersion": "6f3ba45639579da152b69e8e5342e02f28288670",
+          "arguments": "lint_deps"
+        },
+        {
+          "metricId": "realworld_better_auth_task_lint_format",
+          "samples": [3.038, 3.053],
+          "aggregates": {
+            "p50": 3.0454999999999997,
+            "p95": 3.05225,
+            "mean": 3.0454999999999997,
+            "stdev": 0.010606601717798458,
+            "min": 3.038,
+            "max": 3.053,
+            "n": 2
+          },
+          "sourceFile": "realworld-better-auth/pts_realworld-better-auth.xml",
+          "appVersion": "6f3ba45639579da152b69e8e5342e02f28288670",
+          "arguments": "lint_format"
+        },
+        {
+          "metricId": "realworld_better_auth_task_lint_packages",
+          "samples": [4.632, 4.638],
+          "aggregates": {
+            "p50": 4.635,
+            "p95": 4.6377,
+            "mean": 4.635,
+            "stdev": 0.004242640687119446,
+            "min": 4.632,
+            "max": 4.638,
+            "n": 2
+          },
+          "sourceFile": "realworld-better-auth/pts_realworld-better-auth.xml",
+          "appVersion": "6f3ba45639579da152b69e8e5342e02f28288670",
+          "arguments": "lint_packages"
+        },
+        {
+          "metricId": "realworld_better_auth_task_lint_spell",
+          "samples": [7.457, 7.925],
+          "aggregates": {
+            "p50": 7.691,
+            "p95": 7.9016,
+            "mean": 7.691,
+            "stdev": 0.33092597359530423,
+            "min": 7.457,
+            "max": 7.925,
+            "n": 2
+          },
+          "sourceFile": "realworld-better-auth/pts_realworld-better-auth.xml",
+          "appVersion": "6f3ba45639579da152b69e8e5342e02f28288670",
+          "arguments": "lint_spell"
+        },
+        {
+          "metricId": "realworld_better_auth_task_lint_types",
+          "samples": [60.534, 59.626],
+          "aggregates": {
+            "p50": 60.08,
+            "p95": 60.4886,
+            "mean": 60.08,
+            "stdev": 0.6420529573173861,
+            "min": 59.626,
+            "max": 60.534,
+            "n": 2
+          },
+          "sourceFile": "realworld-better-auth/pts_realworld-better-auth.xml",
+          "appVersion": "6f3ba45639579da152b69e8e5342e02f28288670",
+          "arguments": "lint_types"
+        },
+        {
+          "metricId": "realworld_better_auth_task_typecheck",
+          "samples": [1.465, 1.483],
+          "aggregates": {
+            "p50": 1.4740000000000002,
+            "p95": 1.4821000000000002,
+            "mean": 1.4740000000000002,
+            "stdev": 0.012727922061357788,
+            "min": 1.465,
+            "max": 1.483,
+            "n": 2
+          },
+          "sourceFile": "realworld-better-auth/pts_realworld-better-auth.xml",
+          "appVersion": "6f3ba45639579da152b69e8e5342e02f28288670",
+          "arguments": "typecheck"
+        },
+        {
+          "metricId": "realworld_mastra_task_build_core",
+          "samples": [125.233, 126.008],
+          "aggregates": {
+            "p50": 125.62049999999999,
+            "p95": 125.96925,
+            "mean": 125.62049999999999,
+            "stdev": 0.5480077554195733,
+            "min": 125.233,
+            "max": 126.008,
+            "n": 2
+          },
+          "sourceFile": "realworld-mastra/pts_realworld-mastra.xml",
+          "appVersion": "b6eeb9d08ebeaf27bc6fd16b6b88087040aaf767",
+          "arguments": "build_core"
+        },
+        {
+          "metricId": "realworld_mastra_task_cold_install",
+          "samples": [42.079, 42.881],
+          "aggregates": {
+            "p50": 42.480000000000004,
+            "p95": 42.8409,
+            "mean": 42.480000000000004,
+            "stdev": 0.5670996385116083,
+            "min": 42.079,
+            "max": 42.881,
+            "n": 2
+          },
+          "sourceFile": "realworld-mastra/pts_realworld-mastra.xml",
+          "appVersion": "b6eeb9d08ebeaf27bc6fd16b6b88087040aaf767",
+          "arguments": "cold_install"
+        },
+        {
+          "metricId": "realworld_mastra_task_git_clone",
+          "samples": [7.096, 6.931],
+          "aggregates": {
+            "p50": 7.0135000000000005,
+            "p95": 7.08775,
+            "mean": 7.0135000000000005,
+            "stdev": 0.11667261889578005,
+            "min": 6.931,
+            "max": 7.096,
+            "n": 2
+          },
+          "sourceFile": "realworld-mastra/pts_realworld-mastra.xml",
+          "appVersion": "b6eeb9d08ebeaf27bc6fd16b6b88087040aaf767",
+          "arguments": "git_clone"
+        },
+        {
+          "metricId": "realworld_mastra_task_lint_format",
+          "samples": [128.834, 128.509],
+          "aggregates": {
+            "p50": 128.67149999999998,
+            "p95": 128.81775,
+            "mean": 128.67149999999998,
+            "stdev": 0.22980970388565006,
+            "min": 128.509,
+            "max": 128.834,
+            "n": 2
+          },
+          "sourceFile": "realworld-mastra/pts_realworld-mastra.xml",
+          "appVersion": "b6eeb9d08ebeaf27bc6fd16b6b88087040aaf767",
+          "arguments": "lint_format"
+        },
+        {
+          "metricId": "sqlite_speedtest_seconds",
+          "samples": [39.091, 38.532],
+          "aggregates": {
+            "p50": 38.811499999999995,
+            "p95": 39.063050000000004,
+            "mean": 38.811499999999995,
+            "stdev": 0.39527269068328585,
+            "min": 38.532,
+            "max": 39.091,
+            "n": 2
+          },
+          "sourceFile": "system/pts_sqlite-speedtest.xml",
+          "appVersion": "3.30"
+        },
+        {
+          "metricId": "stream_type_add",
+          "samples": [45779.5, 45928.2],
+          "aggregates": {
+            "p50": 45853.85,
+            "p95": 45920.765,
+            "mean": 45853.85,
+            "stdev": 105.14677836243756,
+            "min": 45779.5,
+            "max": 45928.2,
+            "n": 2
+          },
+          "sourceFile": "memory/pts_stream.xml",
+          "appVersion": "2013-01-17",
+          "arguments": "Add"
+        },
+        {
+          "metricId": "stream_type_copy",
+          "samples": [54518.4, 55127.3],
+          "aggregates": {
+            "p50": 54822.850000000006,
+            "p95": 55096.855,
+            "mean": 54822.850000000006,
+            "stdev": 430.5573190644872,
+            "min": 54518.4,
+            "max": 55127.3,
+            "n": 2
+          },
+          "sourceFile": "memory/pts_stream.xml",
+          "appVersion": "2013-01-17",
+          "arguments": "Copy"
+        },
+        {
+          "metricId": "stream_type_scale",
+          "samples": [45209.1, 45606.5],
+          "aggregates": {
+            "p50": 45407.8,
+            "p95": 45586.63,
+            "mean": 45407.8,
+            "stdev": 281.00423484353246,
+            "min": 45209.1,
+            "max": 45606.5,
+            "n": 2
+          },
+          "sourceFile": "memory/pts_stream.xml",
+          "appVersion": "2013-01-17",
+          "arguments": "Scale"
+        },
+        {
+          "metricId": "stream_type_triad",
+          "samples": [45843.9, 46212.3],
+          "aggregates": {
+            "p50": 46028.100000000006,
+            "p95": 46193.880000000005,
+            "mean": 46028.100000000006,
+            "stdev": 260.4981381891226,
+            "min": 45843.9,
+            "max": 46212.3,
+            "n": 2
+          },
+          "sourceFile": "memory/pts_stream.xml",
+          "appVersion": "2013-01-17",
+          "arguments": "Triad"
+        },
+        {
+          "metricId": "usd_per_hour",
+          "samples": [0.16272],
+          "aggregates": {
+            "p50": 0.16272,
+            "p95": 0.16272,
+            "mean": 0.16272,
+            "stdev": 0,
+            "min": 0.16272,
+            "max": 0.16272,
+            "n": 1
+          }
+        }
+      ],
+      "suitesCovered": [
+        "cpu-generic",
+        "cpu-node",
+        "disk",
+        "memory",
+        "network",
+        "realworld-better-auth",
+        "realworld-mastra",
+        "system"
+      ],
+      "gaps": [
+        {
+          "scope": "suite",
+          "id": "network",
+          "outcome": "failed",
+          "reason": "Step \"mise run benchmark:network:all\" failed with exit code 1"
+        },
+        {
+          "scope": "suite",
+          "id": "realworld-openclaw",
+          "outcome": "failed",
+          "reason": "Step \"mise run benchmark:realworld:pts:openclaw\" lost its sandbox: 12 consecutive detached polls failed (last: done-file fs exists) — the sandbox stopped responding, not a quiet long step"
+        }
+      ],
+      "uncatalogued": []
+    }
+  ]
+}


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Publishes dataset run 29546060837 and regenerates the leaderboard with expanded benchmarks and providers. Adds Novita, updates rankings, and refreshes coverage and significance tables.

- **New Features**
  - Added `data/dataset/runs/29546060837.json` and indexed it in `data/dataset/index.json`.
  - Regenerated `LEADERBOARD.md` for Run 29546060837 with:
    - 5 providers (Novita added), 54 metrics, 204 records, 401 trials.
    - New network fast.com metrics and a “Git common operations” system benchmark.
    - Updated rankings, coverage gaps, and p-value tables.

<sup>Written for commit 49874a3fe37d19bff548d07bfdc6461260cb540b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/starslingdev/hpc-sandbox-benchmarks/pull/196?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

