### PR TITLE
feat: configure Cursor Cloud dev environment

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,51 @@
+# AGENTS.md
+
+## Cursor Cloud specific instructions
+
+This repo is a **Bun workspace monorepo** (source-first, no build step) whose product is a
+CLI (`@sandbox-benchmarks/cli`) that plans, runs, normalizes, and renders sandbox-provider
+benchmarks. There is no server or web UI — everything is exercised through Bun and the CLI bins.
+
+### Toolchain (already provisioned in the VM snapshot)
+- `bun` 1.3.14 and `mise` are pre-installed and symlinked into `/usr/local/bin`, so they resolve
+  on a bare `PATH`. The startup update script runs `mise install` + `bun install --ignore-scripts`,
+  then installs **Phoronix Test Suite** if `phoronix-test-suite` is missing.
+- Non-Bun tools (`typos`, `shellcheck`, `hadolint`, `actionlint`, `zizmor`) are pinned in
+  `mise.toml` and invoked via `mise exec` — never install them ad hoc.
+
+### Phoronix Test Suite (PTS)
+The `.mise/tasks/benchmark/**` leaves call `phoronix-test-suite` (via `lib/bench.sh`). In provider
+sandboxes PTS is baked into the toolchain image (`packages/templates/images/base/scripts/20-pts.sh`);
+on this host VM it is installed from the same pin as `packages/templates/src/lib/pins.ts`
+(`ptsVersion` 10.8.4 + `ptsDebSha256`).
+
+- Verify: `phoronix-test-suite version` (expect `Phoronix Test Suite v10.8.4`).
+- Host configure helper: `source lib/bench.sh && ensure_pts` (batch mode; returns 1 only if PTS
+  cannot be made available — leaves then skip rather than fail).
+- Cheap end-to-end mise leaf on the host (no provider keys):  
+  `mise run benchmark:disk:pts:hardlink` — needs `stress-ng` (`apt-get install -y stress-ng`).
+  Writes under `benchmark-results/` (local output; do not commit).
+- Full OpenBenchmarking profiles (c-ray, fio, zstd, …) download/build on first use and are heavy;
+  prefer the hardlink leaf or the Docker `benchmark:realworld:selftest` when validating PTS wiring.
+- `benchmark:realworld:selftest` requires Docker (not installed in this Cloud VM by default).
+
+### Running checks / the app
+The command contract lives in the root `package.json` and `README.md`; run those scripts directly:
+- `bun run lint`, `bun run typecheck`, `bun run test`, `bun run spell`, `bun run check:catalog-drift`,
+  `bun run lint:shell`, `bun run lint:docker`.
+- Run a CLI bin directly, e.g. `bun apps/cli/src/bin/plan-matrix.ts --list-providers` or
+  `bun apps/cli/src/bin/leaderboard.ts data/dataset/runs/<id>.json`. Bins are listed under
+  `apps/cli/package.json` `bin`.
+
+### Non-obvious gotchas
+- Use `bun install --ignore-scripts`. The `prepare` script runs `lefthook install`, which **fails**
+  in Cursor because `core.hooksPath` is set to a custom agent-hooks directory. `--ignore-scripts`
+  skips it (this is exactly what CI does) and dependencies still resolve fully. Git pre-commit hooks
+  are therefore not wired here — run the gate scripts manually before committing.
+- Live provider benches (E2B/Daytona/Modal/Blaxel/Novita) need per-provider API keys from `.env`
+  (see `.env.example`). Without keys a provider is recorded as a **skip, not a failure**, so lint /
+  typecheck / test / spell and the offline CLI bins (`plan-matrix`, `leaderboard` over the committed
+  `data/dataset` runs) all work with no credentials.
+- Mise PTS leaves that lack `phoronix-test-suite` (or a leaf-specific tool like `stress-ng` /
+  `nc`) call `skip_result` and exit 0 — a green task exit does **not** prove the benchmark ran.
+  Check for `benchmark-results/<prefix>.xml` (success) vs `benchmark-results/<prefix>--skipped.json`.


### PR DESCRIPTION
  
I autogenerated this PR from the Cursor Cloud automatic setup.<!-- CURSOR_AGENT_PR_BODY_BEGIN -->

## Summary

Sets up the development environment for this Bun workspace monorepo so future Cloud agents can lint, typecheck, test, spell-check, run the CLI, and exercise mise PTS benchmark leaves.

- Adds `AGENTS.md` with Cursor Cloud instructions (toolchain, command contract, gotchas).
- Installs **Phoronix Test Suite v10.8.4** (pinned in `packages/templates/src/lib/pins.ts`) plus `php-cli`/`php-xml` on the host VM — previously missing, so every mise PTS leaf silently skipped.
- Startup update script: `mise install`, `bun install --ignore-scripts`, and a guarded PTS install if `phoronix-test-suite` is absent.

## Verification

Command contract + CLI:

- `bun run lint` / `typecheck` / `test` / `spell` / catalog-drift / shell+docker lint — all green
- `plan-matrix` and `leaderboard` over a committed dataset run — produce expected output

PTS (this follow-up):

- `phoronix-test-suite version` → v10.8.4
- `source lib/bench.sh && ensure_pts` → exit 0
- `mise run benchmark:disk:pts:hardlink` → completed with `pts_hardlink.xml` (7.99 bogo ops/s), not a skip

[pts_hardlink_mise_run.log](https://cursor.com/agents/bc-012189c0-fc63-4562-8d61-24abb1b2a2bd/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fpts_hardlink_mise_run.log)

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-012189c0-fc63-4562-8d61-24abb1b2a2bd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a> <a href="https://cursor.com/background-agent?bcId=bc-012189c0-fc63-4562-8d61-24abb1b2a2bd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a> </div>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `AGENTS.md` with Cursor Cloud setup for this Bun monorepo so agents can lint, test, and run `@sandbox-benchmarks/cli` and PTS benchmarks without manual setup. Pins PTS v10.8.4 and documents quick checks to verify it’s wired.

- **New Features**
  - Cursor Cloud steps, command contract, and gotchas for `bun`/`mise`; standardizes installs via `mise install` and `bun install --ignore-scripts`.
  - PTS v10.8.4 host install from the repo pin, `ensure_pts` helper, and a simple `benchmark:disk:pts:hardlink` leaf to validate wiring (requires `stress-ng`); shows how to spot skips vs real runs.
  - Lists core scripts (`lint`, `typecheck`, `test`, `spell`, shell/docker checks); notes Docker isn’t preinstalled for `benchmark:realworld:selftest` and provider API keys are optional (benches skip if missing).

<sup>Written for commit 2fa979756be7890a46eb4a8f33f68aac7482cdb5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/starslingdev/hpc-sandbox-benchmarks/pull/197?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

