### PR TITLE
refactor(ci): name and group bench-matrix jobs by suite

### DIFF
--- a/.github/workflows/bench-matrix.yml
+++ b/.github/workflows/bench-matrix.yml
@@ -6,9 +6,11 @@ name: Bench matrix
 # "system / e2b") and provider cells group under their suite. The provider axis is computed once by
 # `plan-providers` from the PROVIDERS registry (honoring the `providers` dispatch input); the suite
 # jobs are enumerated here from SUITE_NAMES and kept in lockstep by the workflow-registry-sync gate
-# (tooling/repo-checks), so adding a suite is one job below (its provider fan-out is automatic). Off the
-# PR path (real sandbox time + provider credentials); main is the default, while an explicit
-# allow_branch dispatch supports pre-merge validation. Every benchmark cell remains gated by
+# (tooling/repo-checks), so adding a suite is one job below (its provider fan-out is automatic). The
+# `suites` dispatch input narrows the run to a subset of suites (blank = all) — the targeted/pre-merge
+# knob, so a validation dispatch can run just one suite instead of the whole matrix. Off the PR path
+# (real sandbox time + provider credentials); main is the default, while an explicit allow_branch
+# dispatch supports pre-merge validation. Every benchmark cell remains gated by
 # Environment `privileged` (required reviewers + environment secrets — see docs/ci-secrets.md, declared
 # inside bench-suite.yml), and publishing stays main-only.
 on:
@@ -23,6 +25,14 @@ on:
         # of runner time per suite on cells that cannot produce a comparable result. Pass it explicitly
         # to include it; `plan-providers` rejects any name that is not in the registry.
         default: e2b,daytona,modal
+      suites:
+        description: 'Comma-separated suites to run (blank = every registered suite). E.g. "network" for a targeted pre-merge run.'
+        required: false
+        type: string
+        # Blank runs every registered suite (the main-publish default). A subset runs only those suites'
+        # jobs — the pre-merge/targeted knob so a validation dispatch needn't spend the whole matrix.
+        # `plan-suites` rejects any name that is not in the registry, so a typo fails the plan.
+        default: ''
       allow_branch:
         description: 'Allow benchmark cells on a non-main ref (publish remains main-only).'
         required: false
@@ -45,13 +55,16 @@ jobs:
   # job `needs: plan`, so this guard also gates them: a skipped plan (fork, or a non-main run without
   # allow_branch) skips the whole fan-out.
   plan:
-    name: Plan providers
+    name: Plan matrix
     if: >
       github.repository == 'starslingdev/hpc-sandbox-benchmarks' &&
       (github.ref == 'refs/heads/main' || inputs.allow_branch)
     runs-on: ubuntu-24.04
     outputs:
+      # The provider axis every suite matrix fans out over, and the set of suites whose jobs run (each
+      # suite job is gated on membership in `suites`).
       providers: ${{ steps.plan.outputs.providers }}
+      suites: ${{ steps.plan.outputs.suites }}
     steps:
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
@@ -64,25 +77,32 @@ jobs:
           bun-version: 1.3.14
       - name: Install dependencies
         run: bun install --frozen-lockfile --ignore-scripts
-      # plan-providers prints one line of compact JSON (["e2b","daytona", …]) — each suite matrix's
-      # `provider` axis.
+      # plan-providers prints the `provider` axis (["e2b","daytona", …]); plan-suites prints the suites
+      # whose jobs run (["cpu-node", …]), blank input = every registered suite. Both are one line of
+      # compact JSON — the strategy/`if:` contracts the suite jobs read.
       - name: Plan
         id: plan
-        # The dispatch input reaches plan-providers through the environment, never interpolated into the
+        # The dispatch inputs reach the planners through the environment, never interpolated into the
         # shell, so a crafted input can't inject into the runner command.
         env:
           BENCH_PROVIDERS: ${{ inputs.providers }}
-        # Capture into a variable first so a plan-providers.ts failure aborts the step (set -e): inlining
-        # the command substitution inside `echo` would mask its exit code behind echo's 0. An
-        # unregistered provider name exits 2 here, so a typo fails the plan instead of quietly
-        # publishing a dataset with that provider missing.
+          BENCH_SUITES: ${{ inputs.suites }}
+        # Capture into a variable first so a planner failure aborts the step (set -e): inlining the
+        # command substitution inside `echo` would mask its exit code behind echo's 0. An unregistered
+        # provider or suite name exits 2 here, so a typo fails the plan instead of quietly publishing a
+        # dataset with that provider missing or running nothing.
         run: |
           providers="$(bun apps/cli/src/bin/plan-providers.ts)"
+          suites="$(bun apps/cli/src/bin/plan-suites.ts)"
           echo "providers=$providers" >> "$GITHUB_OUTPUT"
+          echo "suites=$suites" >> "$GITHUB_OUTPUT"
 
   # ── CPU ──────────────────────────────────────────────────────────────
   cpu-node:
     needs: plan
+    # Run only when this suite is in the plan's selected set (blank `suites` input = all). This is the
+    # per-suite half of the targeted-run knob; the provider fan-out lives inside bench-suite.yml.
+    if: ${{ contains(fromJSON(needs.plan.outputs.suites), 'cpu-node') }}
     uses: ./.github/workflows/bench-suite.yml
     with:
       providers: ${{ needs.plan.outputs.providers }}
@@ -93,6 +113,7 @@ jobs:
 
   cpu-generic:
     needs: plan
+    if: ${{ contains(fromJSON(needs.plan.outputs.suites), 'cpu-generic') }}
     uses: ./.github/workflows/bench-suite.yml
     with:
       providers: ${{ needs.plan.outputs.providers }}
@@ -102,6 +123,7 @@ jobs:
   # ── System ───────────────────────────────────────────────────────────
   system:
     needs: plan
+    if: ${{ contains(fromJSON(needs.plan.outputs.suites), 'system') }}
     uses: ./.github/workflows/bench-suite.yml
     with:
       providers: ${{ needs.plan.outputs.providers }}
@@ -111,6 +133,7 @@ jobs:
   # ── Memory ───────────────────────────────────────────────────────────
   memory:
     needs: plan
+    if: ${{ contains(fromJSON(needs.plan.outputs.suites), 'memory') }}
     uses: ./.github/workflows/bench-suite.yml
     with:
       providers: ${{ needs.plan.outputs.providers }}
@@ -120,6 +143,7 @@ jobs:
   # ── Disk ─────────────────────────────────────────────────────────────
   disk:
     needs: plan
+    if: ${{ contains(fromJSON(needs.plan.outputs.suites), 'disk') }}
     uses: ./.github/workflows/bench-suite.yml
     with:
       providers: ${{ needs.plan.outputs.providers }}
@@ -129,6 +153,7 @@ jobs:
   # ── Network ──────────────────────────────────────────────────────────
   network:
     needs: plan
+    if: ${{ contains(fromJSON(needs.plan.outputs.suites), 'network') }}
     uses: ./.github/workflows/bench-suite.yml
     with:
       providers: ${{ needs.plan.outputs.providers }}
@@ -138,6 +163,7 @@ jobs:
   # ── Real-world (per-repo CI suites) ──────────────────────────────────
   realworld-mastra:
     needs: plan
+    if: ${{ contains(fromJSON(needs.plan.outputs.suites), 'realworld-mastra') }}
     uses: ./.github/workflows/bench-suite.yml
     with:
       providers: ${{ needs.plan.outputs.providers }}
@@ -146,6 +172,7 @@ jobs:
 
   realworld-better-auth:
     needs: plan
+    if: ${{ contains(fromJSON(needs.plan.outputs.suites), 'realworld-better-auth') }}
     uses: ./.github/workflows/bench-suite.yml
     with:
       providers: ${{ needs.plan.outputs.providers }}
@@ -154,6 +181,7 @@ jobs:
 
   realworld-openclaw:
     needs: plan
+    if: ${{ contains(fromJSON(needs.plan.outputs.suites), 'realworld-openclaw') }}
     uses: ./.github/workflows/bench-suite.yml
     with:
       providers: ${{ needs.plan.outputs.providers }}

--- a/.github/workflows/bench-matrix.yml
+++ b/.github/workflows/bench-matrix.yml
@@ -1,18 +1,17 @@
 name: Bench matrix
 
-# Fan the live benchmark out across the full provider × suite matrix. Each registered suite is its own
-# intuitively-named job (grouped by dimension below), and every suite job fans out across the selected
-# providers via the reusable bench-suite.yml — so a cell displays as "<suite> / <provider>" (e.g.
-# "system / e2b") and provider cells group under their suite. The provider axis is computed once by
-# `plan-providers` from the PROVIDERS registry (honoring the `providers` dispatch input); the suite
-# jobs are enumerated here from SUITE_NAMES and kept in lockstep by the workflow-registry-sync gate
-# (tooling/repo-checks), so adding a suite is one job below (its provider fan-out is automatic). The
-# `suites` dispatch input narrows the run to a subset of suites (blank = all) — the targeted/pre-merge
-# knob, so a validation dispatch can run just one suite instead of the whole matrix. Off the PR path
-# (real sandbox time + provider credentials); main is the default, while an explicit allow_branch
-# dispatch supports pre-merge validation. Every benchmark cell remains gated by
-# Environment `privileged` (required reviewers + environment secrets — see docs/ci-secrets.md, declared
-# inside bench-suite.yml), and publishing stays main-only.
+# Fan the live benchmark out across the provider × suite matrix using GitHub's native reusable-workflow
+# nesting. `plan` emits both axes; a single suite-matrix job calls the reusable bench-suite.yml once per
+# suite (`name: ${{ matrix.suite }}`), and that reusable fans out providers (`name: ${{ matrix.provider
+# }}`) — so each cell displays as "<suite> / <provider>" (e.g. "system / e2b") and provider cells nest
+# under their suite in the Actions UI. Adding a suite is a schema change only: the suite axis is
+# `fromJSON(needs.plan.outputs.suites)`, kept in lockstep by the workflow-registry-sync gate. The
+# `suites` dispatch input narrows that axis to a subset (blank = every registered suite) — the
+# targeted/pre-merge knob, so a validation dispatch can run just one suite instead of the whole matrix.
+# Off the PR path (real sandbox time + provider credentials); main is the default, while an explicit
+# allow_branch dispatch supports pre-merge validation. Every benchmark cell remains gated by Environment
+# `privileged` (required reviewers + environment secrets — see docs/ci-secrets.md, declared inside
+# bench-suite.yml), and publishing stays main-only.
 on:
   workflow_dispatch:
     inputs:
@@ -29,9 +28,10 @@ on:
         description: 'Comma-separated suites to run (blank = every registered suite). E.g. "network" for a targeted pre-merge run.'
         required: false
         type: string
-        # Blank runs every registered suite (the main-publish default). A subset runs only those suites'
-        # jobs — the pre-merge/targeted knob so a validation dispatch needn't spend the whole matrix.
-        # `plan-suites` rejects any name that is not in the registry, so a typo fails the plan.
+        # Blank runs every registered suite (the main-publish default). A subset narrows the suite-matrix
+        # axis to just those suites — the pre-merge/targeted knob so a validation dispatch needn't spend
+        # the whole matrix. `plan-suites` rejects any name that is not in the registry, so a typo fails
+        # the plan.
         default: ''
       allow_branch:
         description: 'Allow benchmark cells on a non-main ref (publish remains main-only).'
@@ -49,11 +49,11 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
-  # Compute the provider axis once, as the single $GITHUB_OUTPUT contract every suite job's matrix
-  # reads. No secrets — plan stays off the privileged environment so approval isn't needed just to
-  # dry-run the provider list; a non-main run requires the explicit dispatch opt-in below. Every suite
-  # job `needs: plan`, so this guard also gates them: a skipped plan (fork, or a non-main run without
-  # allow_branch) skips the whole fan-out.
+  # Compute both matrix axes once, as the single $GITHUB_OUTPUT contract the suite job reads. No
+  # secrets — plan stays off the privileged environment so approval isn't needed just to dry-run the
+  # axes; a non-main run requires the explicit dispatch opt-in below. The suite job `needs: plan`, so
+  # this guard also gates the fan-out: a skipped plan (fork, or a non-main run without allow_branch)
+  # skips every cell.
   plan:
     name: Plan matrix
     if: >
@@ -61,8 +61,6 @@ jobs:
       (github.ref == 'refs/heads/main' || inputs.allow_branch)
     runs-on: ubuntu-24.04
     outputs:
-      # The provider axis every suite matrix fans out over, and the set of suites whose jobs run (each
-      # suite job is gated on membership in `suites`).
       providers: ${{ steps.plan.outputs.providers }}
       suites: ${{ steps.plan.outputs.suites }}
     steps:
@@ -77,9 +75,10 @@ jobs:
           bun-version: 1.3.14
       - name: Install dependencies
         run: bun install --frozen-lockfile --ignore-scripts
-      # plan-providers prints the `provider` axis (["e2b","daytona", …]); plan-suites prints the suites
-      # whose jobs run (["cpu-node", …]), blank input = every registered suite. Both are one line of
-      # compact JSON — the strategy/`if:` contracts the suite jobs read.
+      # plan-providers prints the `provider` axis (["e2b","daytona", …]) the reusable fans out over;
+      # plan-suites prints the suite axis (["cpu-node", …]) this job's matrix expands, blank input =
+      # every registered suite. Both are one line of compact JSON — the strategy contracts the suite job
+      # reads.
       - name: Plan
         id: plan
         # The dispatch inputs reach the planners through the environment, never interpolated into the
@@ -87,7 +86,7 @@ jobs:
         env:
           BENCH_PROVIDERS: ${{ inputs.providers }}
           BENCH_SUITES: ${{ inputs.suites }}
-        # Capture into a variable first so a planner failure aborts the step (set -e): inlining the
+        # Capture into variables first so a planner failure aborts the step (set -e): inlining the
         # command substitution inside `echo` would mask its exit code behind echo's 0. An unregistered
         # provider or suite name exits 2 here, so a typo fails the plan instead of quietly publishing a
         # dataset with that provider missing or running nothing.
@@ -97,95 +96,23 @@ jobs:
           echo "providers=$providers" >> "$GITHUB_OUTPUT"
           echo "suites=$suites" >> "$GITHUB_OUTPUT"
 
-  # ── CPU ──────────────────────────────────────────────────────────────
-  cpu-node:
+  # One matrix cell per selected suite → reusable workflow call. GitHub nests the reusable's provider
+  # matrix under each suite name, so the Actions UI shows expandable "<suite>" groups with "<provider>"
+  # children (display: "<suite> / <provider>"). fail-fast stays off so one bad suite doesn't cancel peers.
+  suite:
+    name: ${{ matrix.suite }}
     needs: plan
-    # Run only when this suite is in the plan's selected set (blank `suites` input = all). This is the
-    # per-suite half of the targeted-run knob; the provider fan-out lives inside bench-suite.yml.
-    if: ${{ contains(fromJSON(needs.plan.outputs.suites), 'cpu-node') }}
+    strategy:
+      fail-fast: false
+      matrix:
+        suite: ${{ fromJSON(needs.plan.outputs.suites) }}
+    # `secrets: inherit` keeps repository secrets / token context available to the callee; Environment
+    # secrets on `privileged` are resolved by the reusable job's own `environment:` declaration (a
+    # `uses:` caller can't set `environment:`).
     uses: ./.github/workflows/bench-suite.yml
     with:
       providers: ${{ needs.plan.outputs.providers }}
-      suite: cpu-node
-    # `secrets: inherit` so the `privileged` environment secrets reach bench-suite.yml's fan-out job,
-    # which scopes each provider's credential to its own cell.
-    secrets: inherit
-
-  cpu-generic:
-    needs: plan
-    if: ${{ contains(fromJSON(needs.plan.outputs.suites), 'cpu-generic') }}
-    uses: ./.github/workflows/bench-suite.yml
-    with:
-      providers: ${{ needs.plan.outputs.providers }}
-      suite: cpu-generic
-    secrets: inherit
-
-  # ── System ───────────────────────────────────────────────────────────
-  system:
-    needs: plan
-    if: ${{ contains(fromJSON(needs.plan.outputs.suites), 'system') }}
-    uses: ./.github/workflows/bench-suite.yml
-    with:
-      providers: ${{ needs.plan.outputs.providers }}
-      suite: system
-    secrets: inherit
-
-  # ── Memory ───────────────────────────────────────────────────────────
-  memory:
-    needs: plan
-    if: ${{ contains(fromJSON(needs.plan.outputs.suites), 'memory') }}
-    uses: ./.github/workflows/bench-suite.yml
-    with:
-      providers: ${{ needs.plan.outputs.providers }}
-      suite: memory
-    secrets: inherit
-
-  # ── Disk ─────────────────────────────────────────────────────────────
-  disk:
-    needs: plan
-    if: ${{ contains(fromJSON(needs.plan.outputs.suites), 'disk') }}
-    uses: ./.github/workflows/bench-suite.yml
-    with:
-      providers: ${{ needs.plan.outputs.providers }}
-      suite: disk
-    secrets: inherit
-
-  # ── Network ──────────────────────────────────────────────────────────
-  network:
-    needs: plan
-    if: ${{ contains(fromJSON(needs.plan.outputs.suites), 'network') }}
-    uses: ./.github/workflows/bench-suite.yml
-    with:
-      providers: ${{ needs.plan.outputs.providers }}
-      suite: network
-    secrets: inherit
-
-  # ── Real-world (per-repo CI suites) ──────────────────────────────────
-  realworld-mastra:
-    needs: plan
-    if: ${{ contains(fromJSON(needs.plan.outputs.suites), 'realworld-mastra') }}
-    uses: ./.github/workflows/bench-suite.yml
-    with:
-      providers: ${{ needs.plan.outputs.providers }}
-      suite: realworld-mastra
-    secrets: inherit
-
-  realworld-better-auth:
-    needs: plan
-    if: ${{ contains(fromJSON(needs.plan.outputs.suites), 'realworld-better-auth') }}
-    uses: ./.github/workflows/bench-suite.yml
-    with:
-      providers: ${{ needs.plan.outputs.providers }}
-      suite: realworld-better-auth
-    secrets: inherit
-
-  realworld-openclaw:
-    needs: plan
-    if: ${{ contains(fromJSON(needs.plan.outputs.suites), 'realworld-openclaw') }}
-    uses: ./.github/workflows/bench-suite.yml
-    with:
-      providers: ${{ needs.plan.outputs.providers }}
-      suite: realworld-openclaw
+      suite: ${{ matrix.suite }}
     secrets: inherit
 
   # Collect every shard Run, aggregate into one candidate, gate it (promote), regenerate the public
@@ -197,20 +124,12 @@ jobs:
     name: Aggregate + promote dataset
     needs:
       - plan
-      - cpu-node
-      - cpu-generic
-      - system
-      - memory
-      - disk
-      - network
-      - realworld-mastra
-      - realworld-better-auth
-      - realworld-openclaw
-    # Run even if some suite jobs failed (fail-fast is off) so the successful shards still publish:
-    # `aggregate` exits non-zero when zero shards are found and `promote` gates on >=1 validated
-    # provider, so the quality bar is preserved. `!cancelled()` still lets an explicit cancel stop it.
-    # `!cancelled()` opts out of the implicit success() gate, so require `plan` explicitly: a skipped
-    # or failed plan means there is no provider axis, so there is nothing to publish.
+      - suite
+    # Run even if some suite matrix cells failed (fail-fast is off) so the successful shards still
+    # publish: `aggregate` exits non-zero when zero shards are found and `promote` gates on >=1
+    # validated provider, so the quality bar is preserved. `!cancelled()` still lets an explicit cancel
+    # stop it. `!cancelled()` opts out of the implicit success() gate, so require `plan` explicitly: a
+    # skipped or failed plan means there is no provider axis, so there is nothing to publish.
     if: >
       !cancelled() &&
       needs.plan.result == 'success' &&

--- a/.github/workflows/bench-matrix.yml
+++ b/.github/workflows/bench-matrix.yml
@@ -1,14 +1,16 @@
 name: Bench matrix
 
-# Fan the live benchmark out across the full provider × suite matrix: one job per (provider, suite)
-# cell, each spinning up a real sandbox, running its suite, and uploading the normalized Run as an
-# artifact. The matrix is computed from the SUITES × PROVIDERS registries by `plan-matrix`; each suite
-# cell runs all of its registered leaves (for example, system runs pts/git and network runs
-# pts/fast-cli), rather than giving each PTS profile its own row. Adding a provider or suite to its
-# registry grows CI with no workflow edit. Off the PR path (real sandbox time + provider credentials);
-# main is the default, while an explicit allow_branch dispatch supports pre-merge validation. Every
-# benchmark cell remains gated by Environment `privileged` (required reviewers + environment secrets
-# — see docs/ci-secrets.md), and publishing stays main-only.
+# Fan the live benchmark out across the full provider × suite matrix. Each registered suite is its own
+# intuitively-named job (grouped by dimension below), and every suite job fans out across the selected
+# providers via the reusable bench-suite.yml — so a cell displays as "<suite> / <provider>" (e.g.
+# "system / e2b") and provider cells group under their suite. The provider axis is computed once by
+# `plan-providers` from the PROVIDERS registry (honoring the `providers` dispatch input); the suite
+# jobs are enumerated here from SUITE_NAMES and kept in lockstep by the workflow-registry-sync gate
+# (tooling/repo-checks), so adding a suite is one job below (its provider fan-out is automatic). Off the
+# PR path (real sandbox time + provider credentials); main is the default, while an explicit
+# allow_branch dispatch supports pre-merge validation. Every benchmark cell remains gated by
+# Environment `privileged` (required reviewers + environment secrets — see docs/ci-secrets.md, declared
+# inside bench-suite.yml), and publishing stays main-only.
 on:
   workflow_dispatch:
     inputs:
@@ -19,7 +21,7 @@ on:
         # The providers with a baked toolchain artifact and credentials in CI. blaxel boots the stock
         # base image (nothing baked for it), so it is excluded by default rather than burning ~150min
         # of runner time per suite on cells that cannot produce a comparable result. Pass it explicitly
-        # to include it; `plan-matrix` rejects any name that is not in the registry.
+        # to include it; `plan-providers` rejects any name that is not in the registry.
         default: e2b,daytona,modal
       allow_branch:
         description: 'Allow benchmark cells on a non-main ref (publish remains main-only).'
@@ -37,17 +39,19 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
-  # Compute the provider × suite matrix once, as the single $GITHUB_OUTPUT contract the fan-out reads.
-  # No secrets — plan stays off the privileged environment so approval isn't needed just to dry-run
-  # the matrix shape; a non-main run requires the explicit dispatch opt-in below.
+  # Compute the provider axis once, as the single $GITHUB_OUTPUT contract every suite job's matrix
+  # reads. No secrets — plan stays off the privileged environment so approval isn't needed just to
+  # dry-run the provider list; a non-main run requires the explicit dispatch opt-in below. Every suite
+  # job `needs: plan`, so this guard also gates them: a skipped plan (fork, or a non-main run without
+  # allow_branch) skips the whole fan-out.
   plan:
-    name: Plan matrix
+    name: Plan providers
     if: >
       github.repository == 'starslingdev/hpc-sandbox-benchmarks' &&
       (github.ref == 'refs/heads/main' || inputs.allow_branch)
     runs-on: ubuntu-24.04
     outputs:
-      matrix: ${{ steps.plan.outputs.matrix }}
+      providers: ${{ steps.plan.outputs.providers }}
     steps:
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
@@ -60,92 +64,101 @@ jobs:
           bun-version: 1.3.14
       - name: Install dependencies
         run: bun install --frozen-lockfile --ignore-scripts
-      # plan-matrix prints one line of compact JSON ({"include":[...]}) — the strategy.matrix contract.
+      # plan-providers prints one line of compact JSON (["e2b","daytona", …]) — each suite matrix's
+      # `provider` axis.
       - name: Plan
         id: plan
-        # The dispatch input reaches plan-matrix through the environment, never interpolated into the
+        # The dispatch input reaches plan-providers through the environment, never interpolated into the
         # shell, so a crafted input can't inject into the runner command.
         env:
           BENCH_PROVIDERS: ${{ inputs.providers }}
-        # Capture into a variable first so a plan-matrix.ts failure aborts the step (set -e): inlining
+        # Capture into a variable first so a plan-providers.ts failure aborts the step (set -e): inlining
         # the command substitution inside `echo` would mask its exit code behind echo's 0. An
         # unregistered provider name exits 2 here, so a typo fails the plan instead of quietly
         # publishing a dataset with that provider missing.
         run: |
-          matrix="$(bun apps/cli/src/bin/plan-matrix.ts)"
-          echo "matrix=$matrix" >> "$GITHUB_OUTPUT"
+          providers="$(bun apps/cli/src/bin/plan-providers.ts)"
+          echo "providers=$providers" >> "$GITHUB_OUTPUT"
 
-  bench:
-    name: ${{ matrix.suite }} on ${{ matrix.provider }}
+  # ── CPU ──────────────────────────────────────────────────────────────
+  cpu-node:
     needs: plan
-    if: >
-      github.repository == 'starslingdev/hpc-sandbox-benchmarks' &&
-      (github.ref == 'refs/heads/main' || inputs.allow_branch)
-    # The ephemeral self-hosted label is reaped after 70 minutes even while a step is healthy. The
-    # full CPU-generic and real-world matrices legitimately exceed that on slower providers, leaving
-    # the step stuck `in_progress` with no logs/artifact. Hosted runners honor timeout-minutes below;
-    # 180 minutes also leaves teardown/artifact margin around the longest 155-minute suite budget.
-    runs-on: ubuntu-24.04
-    environment: privileged
-    timeout-minutes: 180
-    strategy:
-      # One cell's failure (a flaky provider) must not cancel the rest of the matrix.
-      fail-fast: false
-      matrix: ${{ fromJSON(needs.plan.outputs.matrix) }}
-    steps:
-      - name: Checkout
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-        with:
-          # This cell only reads code (the sandbox clones via BENCH_REPO_TOKEN when set, not the
-          # checkout's credentials), so don't persist the job token in .git/config.
-          persist-credentials: false
+    uses: ./.github/workflows/bench-suite.yml
+    with:
+      providers: ${{ needs.plan.outputs.providers }}
+      suite: cpu-node
+    # `secrets: inherit` so the `privileged` environment secrets reach bench-suite.yml's fan-out job,
+    # which scopes each provider's credential to its own cell.
+    secrets: inherit
 
-      - name: Set up Bun
-        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
-        with:
-          bun-version: 1.3.14
+  cpu-generic:
+    needs: plan
+    uses: ./.github/workflows/bench-suite.yml
+    with:
+      providers: ${{ needs.plan.outputs.providers }}
+      suite: cpu-generic
+    secrets: inherit
 
-      - name: Install dependencies
-        run: bun install --frozen-lockfile --ignore-scripts
+  # ── System ───────────────────────────────────────────────────────────
+  system:
+    needs: plan
+    uses: ./.github/workflows/bench-suite.yml
+    with:
+      providers: ${{ needs.plan.outputs.providers }}
+      suite: system
+    secrets: inherit
 
-      # Drive the provider SDK to create a sandbox, run the suite, collect results, and normalize. The
-      # cell's provider/suite are matrix values, passed through the environment (never interpolated into
-      # the shell) so a registry value can't inject into the runner command.
-      - name: Run suite and normalize
-        env:
-          BENCH_REPO_REF: ${{ github.sha }}
-          # Optional once the repo is public (anonymous clone works). Still passed so private forks and
-          # rate-limited clones keep working via the short-lived job token.
-          BENCH_REPO_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          BENCH_PROVIDER: ${{ matrix.provider }}
-          BENCH_SUITE: ${{ matrix.suite }}
-          # Scope every provider credential to the cell that actually uses it: a cell receives ONLY
-          # the secret(s) for its own `matrix.provider`, so a compromised adapter or suite can't read
-          # another provider's credential out of the environment. A non-matching provider evaluates to
-          # '', which the config gatekeeper treats as unset (packages/providers/src/lib/config.ts:
-          # empty ⇒ unset), exactly like an unsynced secret — so blanking the others is inert.
-          DAYTONA_API_KEY: ${{ matrix.provider == 'daytona' && secrets.DAYTONA_API_KEY || '' }}
-          # Boot daytona sandboxes in the active region (us-west-2); the default applies only to the
-          # daytona cell so an unsynced secret can't fail the config gatekeeper at module load.
-          DAYTONA_TARGET: ${{ matrix.provider == 'daytona' && (secrets.DAYTONA_TARGET || 'us-west-2') || '' }}
-          E2B_API_KEY: ${{ matrix.provider == 'e2b' && secrets.E2B_API_KEY || '' }}
-          MODAL_TOKEN_ID: ${{ matrix.provider == 'modal' && secrets.MODAL_TOKEN_ID || '' }}
-          MODAL_TOKEN_SECRET: ${{ matrix.provider == 'modal' && secrets.MODAL_TOKEN_SECRET || '' }}
-          BL_API_KEY: ${{ matrix.provider == 'blaxel' && secrets.BL_API_KEY || '' }}
-          BL_WORKSPACE: ${{ matrix.provider == 'blaxel' && secrets.BL_WORKSPACE || '' }}
-          NOVITA_API_KEY: ${{ matrix.provider == 'novita' && secrets.NOVITA_API_KEY || '' }}
-        run: bun apps/cli/src/bin/bench-suite.ts "$BENCH_PROVIDER" "$BENCH_SUITE" "$GITHUB_RUN_ID"
+  # ── Memory ───────────────────────────────────────────────────────────
+  memory:
+    needs: plan
+    uses: ./.github/workflows/bench-suite.yml
+    with:
+      providers: ${{ needs.plan.outputs.providers }}
+      suite: memory
+    secrets: inherit
 
-      - name: Upload Run + raw results
-        if: always()
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
-        with:
-          # Per-cell artifact name so every (provider, suite) shard uploads independently.
-          name: bench-${{ matrix.suite }}-${{ matrix.provider }}-${{ github.run_id }}
-          path: data/
-          # A successful run always writes data/runs/<id>.json (even an all-skipped Run), so an empty
-          # data/ means the job is genuinely broken — fail the upload rather than bury a warning.
-          if-no-files-found: error
+  # ── Disk ─────────────────────────────────────────────────────────────
+  disk:
+    needs: plan
+    uses: ./.github/workflows/bench-suite.yml
+    with:
+      providers: ${{ needs.plan.outputs.providers }}
+      suite: disk
+    secrets: inherit
+
+  # ── Network ──────────────────────────────────────────────────────────
+  network:
+    needs: plan
+    uses: ./.github/workflows/bench-suite.yml
+    with:
+      providers: ${{ needs.plan.outputs.providers }}
+      suite: network
+    secrets: inherit
+
+  # ── Real-world (per-repo CI suites) ──────────────────────────────────
+  realworld-mastra:
+    needs: plan
+    uses: ./.github/workflows/bench-suite.yml
+    with:
+      providers: ${{ needs.plan.outputs.providers }}
+      suite: realworld-mastra
+    secrets: inherit
+
+  realworld-better-auth:
+    needs: plan
+    uses: ./.github/workflows/bench-suite.yml
+    with:
+      providers: ${{ needs.plan.outputs.providers }}
+      suite: realworld-better-auth
+    secrets: inherit
+
+  realworld-openclaw:
+    needs: plan
+    uses: ./.github/workflows/bench-suite.yml
+    with:
+      providers: ${{ needs.plan.outputs.providers }}
+      suite: realworld-openclaw
+    secrets: inherit
 
   # Collect every shard Run, aggregate into one candidate, gate it (promote), regenerate the public
   # leaderboard, and open the PR that lands both on main. The logic lives in the reusable
@@ -154,12 +167,22 @@ jobs:
   # is declared inside that reusable workflow — a `uses:` caller can't set `environment:` itself.
   publish:
     name: Aggregate + promote dataset
-    needs: [plan, bench]
-    # Run even if some matrix cells failed (fail-fast is off) so the successful shards still publish:
+    needs:
+      - plan
+      - cpu-node
+      - cpu-generic
+      - system
+      - memory
+      - disk
+      - network
+      - realworld-mastra
+      - realworld-better-auth
+      - realworld-openclaw
+    # Run even if some suite jobs failed (fail-fast is off) so the successful shards still publish:
     # `aggregate` exits non-zero when zero shards are found and `promote` gates on >=1 validated
     # provider, so the quality bar is preserved. `!cancelled()` still lets an explicit cancel stop it.
     # `!cancelled()` opts out of the implicit success() gate, so require `plan` explicitly: a skipped
-    # or failed plan means there is no matrix contract, so there is nothing to publish.
+    # or failed plan means there is no provider axis, so there is nothing to publish.
     if: >
       !cancelled() &&
       needs.plan.result == 'success' &&

--- a/.github/workflows/bench-suite.yml
+++ b/.github/workflows/bench-suite.yml
@@ -1,0 +1,108 @@
+name: Benchmark suite (reusable)
+
+# One suite, fanned out across a provider matrix. bench-matrix.yml calls this once per registered
+# suite (a named job each, grouped by dimension), passing the plan's selected provider list — so N
+# providers group under one suite label in the UI and jobs display as "<suite> / <provider>". Factoring
+# the shared cell here (checkout → run → upload, plus the per-provider credential wiring) keeps that
+# block in ONE place instead of copy-pasted into every suite job, mirroring runner-benchmarking's
+# reusable bench-suite.yml.
+#
+# The artifact name (bench-<suite>-<provider>-<run_id>) is load-bearing: publish-dataset.yml downloads
+# the shards by the `bench-*-<run_id>` pattern and aggregates them — keep the two in lockstep.
+#
+# Environment `privileged` (required reviewers + environment secrets — see docs/ci-secrets.md) lives on
+# the fan-out job here: a `uses:` caller can't declare `environment:`, so the approval gate and the
+# provider secrets are enforced at this layer. The caller passes `secrets: inherit` so the environment
+# secrets on `privileged` reach this job — a caller job has no environment of its own, so it could not
+# resolve them to pass explicitly.
+on:
+  workflow_call:
+    inputs:
+      providers:
+        description: 'JSON array of provider ids to fan out over (the plan job selected provider list).'
+        required: true
+        type: string
+      suite:
+        description: 'Suite to run — the bench-suite.ts arg and the artifact-name key. A registered SUITE_NAMES value.'
+        required: true
+        type: string
+
+# Least privilege: the fan-out only reads the checked-out code and uploads artifacts.
+permissions:
+  contents: read
+
+jobs:
+  bench:
+    # Display as "<caller suite job> / <provider>", e.g. "system / e2b" — the provider cells group
+    # under their suite's job name in the Actions UI.
+    name: ${{ matrix.provider }}
+    environment: privileged
+    # The ephemeral self-hosted label is reaped after 70 minutes even while a step is healthy. The
+    # full CPU-generic and real-world matrices legitimately exceed that on slower providers, leaving
+    # the step stuck `in_progress` with no logs/artifact. Hosted runners honor timeout-minutes below;
+    # 180 minutes also leaves teardown/artifact margin around the longest 155-minute suite budget.
+    # (workflow-registry-sync asserts this stays above the longest registered sandbox lifetime.)
+    runs-on: ubuntu-24.04
+    timeout-minutes: 180
+    strategy:
+      # One cell's failure (a flaky provider) must not cancel the rest of the matrix.
+      fail-fast: false
+      matrix:
+        provider: ${{ fromJSON(inputs.providers) }}
+    steps:
+      # Third-party actions are pinned to a commit SHA (the tag comment is for humans) so a
+      # moved/compromised tag can't silently change what runs.
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          # This cell only reads code (the sandbox clones via BENCH_REPO_TOKEN when set, not the
+          # checkout's credentials), so don't persist the job token in .git/config.
+          persist-credentials: false
+
+      - name: Set up Bun
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
+        with:
+          bun-version: 1.3.14
+
+      # Frozen lockfile + no lifecycle scripts, matching bunfig.toml's supply-chain posture.
+      - name: Install dependencies
+        run: bun install --frozen-lockfile --ignore-scripts
+
+      # Drive the provider SDK to create a sandbox, run the suite, collect results, and normalize. The
+      # cell's provider is a matrix value and its suite the reusable input, both passed through the
+      # environment (never interpolated into the shell) so neither can inject into the runner command.
+      - name: Run suite and normalize
+        env:
+          BENCH_REPO_REF: ${{ github.sha }}
+          # Optional once the repo is public (anonymous clone works). Still passed so private forks and
+          # rate-limited clones keep working via the short-lived job token.
+          BENCH_REPO_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          BENCH_PROVIDER: ${{ matrix.provider }}
+          BENCH_SUITE: ${{ inputs.suite }}
+          # Scope every provider credential to the cell that actually uses it: a cell receives ONLY
+          # the secret(s) for its own `matrix.provider`, so a compromised adapter or suite can't read
+          # another provider's credential out of the environment. A non-matching provider evaluates to
+          # '', which the config gatekeeper treats as unset (packages/providers/src/lib/config.ts:
+          # empty ⇒ unset), exactly like an unsynced secret — so blanking the others is inert.
+          DAYTONA_API_KEY: ${{ matrix.provider == 'daytona' && secrets.DAYTONA_API_KEY || '' }}
+          # Boot daytona sandboxes in the active region (us-west-2); the default applies only to the
+          # daytona cell so an unsynced secret can't fail the config gatekeeper at module load.
+          DAYTONA_TARGET: ${{ matrix.provider == 'daytona' && (secrets.DAYTONA_TARGET || 'us-west-2') || '' }}
+          E2B_API_KEY: ${{ matrix.provider == 'e2b' && secrets.E2B_API_KEY || '' }}
+          MODAL_TOKEN_ID: ${{ matrix.provider == 'modal' && secrets.MODAL_TOKEN_ID || '' }}
+          MODAL_TOKEN_SECRET: ${{ matrix.provider == 'modal' && secrets.MODAL_TOKEN_SECRET || '' }}
+          BL_API_KEY: ${{ matrix.provider == 'blaxel' && secrets.BL_API_KEY || '' }}
+          BL_WORKSPACE: ${{ matrix.provider == 'blaxel' && secrets.BL_WORKSPACE || '' }}
+          NOVITA_API_KEY: ${{ matrix.provider == 'novita' && secrets.NOVITA_API_KEY || '' }}
+        run: bun apps/cli/src/bin/bench-suite.ts "$BENCH_PROVIDER" "$BENCH_SUITE" "$GITHUB_RUN_ID"
+
+      - name: Upload Run + raw results
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          # Per-cell artifact name so every (provider, suite) shard uploads independently.
+          name: bench-${{ inputs.suite }}-${{ matrix.provider }}-${{ github.run_id }}
+          path: data/
+          # A successful run always writes data/runs/<id>.json (even an all-skipped Run), so an empty
+          # data/ means the job is genuinely broken — fail the upload rather than bury a warning.
+          if-no-files-found: error

--- a/.github/workflows/bench-suite.yml
+++ b/.github/workflows/bench-suite.yml
@@ -1,20 +1,20 @@
 name: Benchmark suite (reusable)
 
-# One suite, fanned out across a provider matrix. bench-matrix.yml calls this once per registered
-# suite (a named job each, grouped by dimension), passing the plan's selected provider list — so N
-# providers group under one suite label in the UI and jobs display as "<suite> / <provider>". Factoring
-# the shared cell here (checkout → run → upload, plus the per-provider credential wiring) keeps that
-# block in ONE place instead of copy-pasted into every suite job, mirroring runner-benchmarking's
-# reusable bench-suite.yml.
+# One suite, fanned out across a provider matrix. bench-matrix.yml calls this once per suite via its
+# suite-matrix job (`name: ${{ matrix.suite }}`), passing the plan's selected provider list — so N
+# providers nest under one suite label in the Actions UI and cells display as "<suite> / <provider>".
+# Factoring the shared cell here (checkout → run → upload, plus the per-provider credential wiring)
+# keeps that block in ONE place instead of copy-pasted into every suite job, mirroring
+# runner-benchmarking's reusable bench-suite.yml.
 #
 # The artifact name (bench-<suite>-<provider>-<run_id>) is load-bearing: publish-dataset.yml downloads
 # the shards by the `bench-*-<run_id>` pattern and aggregates them — keep the two in lockstep.
 #
 # Environment `privileged` (required reviewers + environment secrets — see docs/ci-secrets.md) lives on
 # the fan-out job here: a `uses:` caller can't declare `environment:`, so the approval gate and the
-# provider secrets are enforced at this layer. The caller passes `secrets: inherit` so the environment
-# secrets on `privileged` reach this job — a caller job has no environment of its own, so it could not
-# resolve them to pass explicitly.
+# provider secrets are enforced at this layer. Environment secrets resolve from this job's
+# `environment:` declaration; the caller may still pass `secrets: inherit` for repository-level
+# secrets / token context.
 on:
   workflow_call:
     inputs:
@@ -33,8 +33,8 @@ permissions:
 
 jobs:
   bench:
-    # Display as "<caller suite job> / <provider>", e.g. "system / e2b" — the provider cells group
-    # under their suite's job name in the Actions UI.
+    # Display as "<caller suite job> / <provider>", e.g. "system / e2b" — the provider cells nest
+    # under their suite's job name in the Actions UI (GitHub-native reusable-workflow nesting).
     name: ${{ matrix.provider }}
     environment: privileged
     # The ephemeral self-hosted label is reaped after 70 minutes even while a step is healthy. The
@@ -71,6 +71,7 @@ jobs:
       # Drive the provider SDK to create a sandbox, run the suite, collect results, and normalize. The
       # cell's provider is a matrix value and its suite the reusable input, both passed through the
       # environment (never interpolated into the shell) so neither can inject into the runner command.
+      # On success/failure the bin also writes a compact job summary + run annotation (clean Results).
       - name: Run suite and normalize
         env:
           BENCH_REPO_REF: ${{ github.sha }}

--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -10,3 +10,15 @@ rules:
       # persist-credentials: false; this one can't, by design. (Filename-scoped, not repo-wide — this
       # reusable workflow's only checkout is the pushing one, so just its finding is accepted.)
       - publish-dataset.yml
+  secrets-inherit:
+    ignore:
+      # bench-matrix.yml's per-suite jobs call the reusable bench-suite.yml with `secrets: inherit`.
+      # The provider credentials are ENVIRONMENT secrets on `privileged` (docs/ci-secrets.md) with no
+      # repository-level copy, so only a job that declares `environment: privileged` can resolve them —
+      # and a `uses:` caller can't declare an environment. That makes `inherit` the only way to hand
+      # them to the reusable's privileged fan-out job, which re-scopes each credential to its own
+      # provider cell (`matrix.provider == 'daytona' && secrets.DAYTONA_API_KEY || ''`). Enumerating and
+      # passing them explicitly would resolve to empty in the caller (no environment there). The
+      # workflow-hardening drift gate independently verifies the callee self-gates on `privileged`.
+      # (Filename-scoped, not repo-wide.)
+      - bench-matrix.yml

--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -12,13 +12,12 @@ rules:
       - publish-dataset.yml
   secrets-inherit:
     ignore:
-      # bench-matrix.yml's per-suite jobs call the reusable bench-suite.yml with `secrets: inherit`.
-      # The provider credentials are ENVIRONMENT secrets on `privileged` (docs/ci-secrets.md) with no
-      # repository-level copy, so only a job that declares `environment: privileged` can resolve them —
-      # and a `uses:` caller can't declare an environment. That makes `inherit` the only way to hand
-      # them to the reusable's privileged fan-out job, which re-scopes each credential to its own
-      # provider cell (`matrix.provider == 'daytona' && secrets.DAYTONA_API_KEY || ''`). Enumerating and
-      # passing them explicitly would resolve to empty in the caller (no environment there). The
-      # workflow-hardening drift gate independently verifies the callee self-gates on `privileged`.
-      # (Filename-scoped, not repo-wide.)
+      # bench-matrix.yml's suite-matrix job calls the reusable bench-suite.yml with `secrets: inherit`.
+      # The reusable's fan-out job declares `environment: privileged`, which raises the approval gate and
+      # scopes the provider ENVIRONMENT secrets (docs/ci-secrets.md) to that job, where it re-scopes each
+      # credential to its own provider cell (`matrix.provider == 'daytona' && secrets.DAYTONA_API_KEY ||
+      # ''`). `inherit` hands the reusable the caller's secret / token context in one line instead of
+      # enumerating each secret as a `workflow_call` input (a `uses:` caller can't declare the
+      # environment to resolve them itself). The workflow-hardening drift gate independently verifies the
+      # callee self-gates on `privileged`. (Filename-scoped, not repo-wide.)
       - bench-matrix.yml

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -63,7 +63,12 @@ bun run check:catalog-drift                                    # fail if the com
 2. **Producer tasks** — add the mise task(s) under `.mise/tasks/benchmark/**` that the `commands` name,
    driving the benchmark via the helpers in [`lib/bench.sh`](./lib/bench.sh) (e.g. `run_pts_benchmark`).
    An orchestrator is a task *file*; its leaves live in a sibling *directory* (a task path can't be both).
-3. The CI matrix picks the suite up automatically (`plan-matrix` crosses `PROVIDERS × SUITE_NAMES`).
+3. **Add its matrix job** in [`bench-matrix.yml`](./.github/workflows/bench-matrix.yml): one named job
+   (grouped under its dimension) that `uses: ./.github/workflows/bench-suite.yml` with `suite: <name>`.
+   The workflow-registry-sync drift gate (`tooling/repo-checks`) fails until every `SUITE_NAMES` entry
+   has exactly one such job, so a new suite can't silently go un-benchmarked. Its provider fan-out is
+   automatic (`plan-providers` selects the provider axis from `PROVIDERS`); add it to the `bench-smoke`
+   suite `options` too so it stays dispatchable on its own.
 
 ## Add a metric
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -63,12 +63,11 @@ bun run check:catalog-drift                                    # fail if the com
 2. **Producer tasks** — add the mise task(s) under `.mise/tasks/benchmark/**` that the `commands` name,
    driving the benchmark via the helpers in [`lib/bench.sh`](./lib/bench.sh) (e.g. `run_pts_benchmark`).
    An orchestrator is a task *file*; its leaves live in a sibling *directory* (a task path can't be both).
-3. **Add its matrix job** in [`bench-matrix.yml`](./.github/workflows/bench-matrix.yml): one named job
-   (grouped under its dimension) that `uses: ./.github/workflows/bench-suite.yml` with `suite: <name>`.
-   The workflow-registry-sync drift gate (`tooling/repo-checks`) fails until every `SUITE_NAMES` entry
-   has exactly one such job, so a new suite can't silently go un-benchmarked. Its provider fan-out is
-   automatic (`plan-providers` selects the provider axis from `PROVIDERS`); add it to the `bench-smoke`
-   suite `options` too so it stays dispatchable on its own.
+3. **No matrix job edit** — `bench-matrix.yml` matrices over `plan.outputs.suites` (from `SUITE_NAMES`
+   via `plan-suites`), so a new suite is picked up automatically and nests as `<suite> / <provider>` in
+   the Actions UI; a dispatch can still narrow to a subset with the `suites` input. The
+   workflow-registry-sync drift gate keeps that nesting wiring honest. Add it to the `bench-smoke` suite
+   `options` too so it stays dispatchable on its own.
 
 ## Add a metric
 

--- a/apps/cli/README.md
+++ b/apps/cli/README.md
@@ -8,7 +8,8 @@
   `--iterations N` (cold-start cycles/provider), `--control-plane-samples N`, `--no-snapshot`. Providers
   with absent creds skip; per-Metric distributions go to stdout JSON, a timing log to stderr.
 - `bench-suite` — run the full suite across the matrix.
-- `plan-matrix` — print the **provider × suite** benchmark matrix as **single-line compact JSON** for `$GITHUB_OUTPUT` (the `bench-matrix` workflow's fan-out contract).
+- `plan-providers` — print the **selected provider ids** as **single-line compact JSON** for `$GITHUB_OUTPUT` (the `bench-matrix` workflow's per-suite fan-out axis; honors `BENCH_PROVIDERS`).
+- `plan-matrix` — print the full **provider × suite** benchmark matrix as **single-line compact JSON** (cell listing for local inspection / discovery; the workflow's fan-out axis is `plan-providers`).
 - `build-template` — build a provider's sandbox template.
 - `normalize` — turn raw runs into normalized run documents.
 - `aggregate` — merge shard Runs into one candidate.

--- a/apps/cli/README.md
+++ b/apps/cli/README.md
@@ -9,6 +9,7 @@
   with absent creds skip; per-Metric distributions go to stdout JSON, a timing log to stderr.
 - `bench-suite` — run the full suite across the matrix.
 - `plan-providers` — print the **selected provider ids** as **single-line compact JSON** for `$GITHUB_OUTPUT` (the `bench-matrix` workflow's per-suite fan-out axis; honors `BENCH_PROVIDERS`).
+- `plan-suites` — print the **selected suite names** as **single-line compact JSON** for `$GITHUB_OUTPUT` (each `bench-matrix` suite job is gated on membership; blank `BENCH_SUITES` = every suite — the targeted/pre-merge knob).
 - `plan-matrix` — print the full **provider × suite** benchmark matrix as **single-line compact JSON** (cell listing for local inspection / discovery; the workflow's fan-out axis is `plan-providers`).
 - `build-template` — build a provider's sandbox template.
 - `normalize` — turn raw runs into normalized run documents.

--- a/apps/cli/src/bin/bench-suite.ts
+++ b/apps/cli/src/bin/bench-suite.ts
@@ -2,8 +2,11 @@
 // `bench-suite` — run a benchmark suite on a provider sandbox, collect the raw results into a
 // data/raw tree, and normalize them into a validated Run document. Missing provider credentials are
 // recorded as a skip (the provider stays `pending` in the Run), so this is runnable without secrets.
+// In GitHub Actions it also writes a compact job summary + run annotation so the nested
+// "<suite> / <provider>" cell shows a clean result without digging through the log.
 
 import { join } from "node:path";
+import * as core from "@actions/core";
 import {
 	requiredProviders,
 	runSuite,
@@ -13,6 +16,52 @@ import {
 import { summarizeRun, writeNormalizedRun } from "@sandbox-benchmarks/results";
 import type { Run } from "@sandbox-benchmarks/schema";
 import { handleDiscovery } from "../lib/discovery.ts";
+
+/** Escape HTML metacharacters for values reaching core.summary addHeading/addRaw (those APIs do not
+ *  escape). Mirrors release-summary.ts. */
+function escapeHtml(value: string): string {
+	return value.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
+}
+
+/** Write the cell's outcome to the Actions job summary + annotations panel when running in GHA.
+ *  No-op locally so `bun apps/cli/src/bin/bench-suite.ts` stays a plain CLI. */
+async function writeActionsResult(opts: {
+	provider: string;
+	suite: string;
+	runId: string;
+	outFile: string;
+	run: Run;
+	failed: boolean;
+	detail?: string;
+}): Promise<void> {
+	if (process.env.GITHUB_ACTIONS !== "true") return;
+	const status = opts.failed ? "failure" : "success";
+	const title = `${opts.suite} / ${opts.provider}`;
+	const lines = summarizeRun(opts.run);
+	core.summary.addHeading(escapeHtml(title), 3).addTable([
+		[
+			{ data: "Field", header: true },
+			{ data: "Value", header: true },
+		],
+		["Status", status],
+		["Suite", `<code>${escapeHtml(opts.suite)}</code>`],
+		["Provider", `<code>${escapeHtml(opts.provider)}</code>`],
+		["Run", `<code>${escapeHtml(opts.runId)}</code>`],
+		["Artifact path", `<code>${escapeHtml(opts.outFile)}</code>`],
+	]);
+	if (lines.length > 0) {
+		core.summary.addHeading("Provider status", 4);
+		core.summary.addCodeBlock(lines.join("\n"));
+	}
+	if (opts.detail) {
+		core.summary.addRaw(escapeHtml(opts.detail));
+		core.summary.addEOL();
+	}
+	await core.summary.write();
+	const annotation = lines[0] ?? opts.detail ?? title;
+	if (opts.failed) core.error(annotation, { title });
+	else core.notice(annotation, { title });
+}
 
 /** Agent-facing usage; bare invocation keeps the daytona/cpu-node local-dev default. */
 export const HELP = `bench-suite — run a benchmark suite on a provider sandbox and normalize it into a Run document.
@@ -112,10 +161,19 @@ if (import.meta.main) {
 	for (const line of summarizeRun(run)) console.log(line);
 
 	if (suiteError) {
-		console.error(
-			`\nSuite "${suite}" failed on ${provider} — recorded as a failed gap in ${outFile}: ` +
-				`${suiteError instanceof Error ? suiteError.message : String(suiteError)}`,
-		);
+		const detail =
+			`Suite "${suite}" failed on ${provider} — recorded as a failed gap in ${outFile}: ` +
+			`${suiteError instanceof Error ? suiteError.message : String(suiteError)}`;
+		console.error(`\n${detail}`);
+		await writeActionsResult({
+			provider,
+			suite,
+			runId,
+			outFile,
+			run,
+			failed: true,
+			detail,
+		});
 		process.exit(1);
 	}
 
@@ -133,17 +191,29 @@ if (import.meta.main) {
 		}));
 		const unmet = unmetRequirements(reports, required);
 		if (unmet.length > 0) {
+			const details: string[] = [];
 			for (const providerId of unmet) {
 				// The gaps ARE the explanation for "no metrics", and their outcome is the important half of
 				// it: a required provider that skipped on a precondition is a configuration problem, one that
 				// failed is an outage, and the operator reading this line needs to know which they have.
 				const gaps = run.providers.find((p) => p.providerId === providerId)?.gaps ?? [];
-				const detail = gaps.map((g) => `${g.id} ${g.outcome}: ${g.reason}`).join("; ");
-				console.error(
-					`Required provider "${providerId}" produced no metrics${detail ? ` — ${detail}` : " and was absent from the Run"}`,
-				);
+				const gapDetail = gaps.map((g) => `${g.id} ${g.outcome}: ${g.reason}`).join("; ");
+				const line = `Required provider "${providerId}" produced no metrics${gapDetail ? ` — ${gapDetail}` : " and was absent from the Run"}`;
+				console.error(line);
+				details.push(line);
 			}
+			await writeActionsResult({
+				provider,
+				suite,
+				runId,
+				outFile,
+				run,
+				failed: true,
+				detail: details.join("\n"),
+			});
 			process.exit(1);
 		}
 	}
+
+	await writeActionsResult({ provider, suite, runId, outFile, run, failed: false });
 }

--- a/apps/cli/src/bin/plan-providers.ts
+++ b/apps/cli/src/bin/plan-providers.ts
@@ -1,0 +1,57 @@
+#!/usr/bin/env bun
+// `plan-providers` — emit the selected provider ids as a SINGLE LINE of compact JSON array.
+// This is the $GITHUB_OUTPUT contract the Bench matrix reads: `providers=<json>` must be one line.
+// Where `plan-matrix` emits the full provider × suite cell list, this emits just the provider axis —
+// the Bench matrix now has one named job per suite (grouped by dimension), each fanning out over these
+// providers, so the workflow needs the provider list alone as each suite job's matrix. Both bins share
+// `selectProviders`, so the registry stays the single source of truth for which providers are valid.
+import { handleDiscovery } from "../lib/discovery.ts";
+import { selectProviders } from "../lib/matrix.ts";
+
+/** The provider-axis JSON for `providersRaw` (a comma-separated `BENCH_PROVIDERS` value; blank/undefined
+ *  = every registered provider). Takes the raw string rather than reading `process.env` itself, so it
+ *  stays pure — the bin owns the env read, and a test can't be perturbed by an ambient value. */
+export function planProvidersJson(providersRaw?: string): string {
+	return JSON.stringify(selectProviders(providersRaw));
+}
+
+/** Agent-facing usage; the bare invocation stays the $GITHUB_OUTPUT providers contract. */
+export const HELP = `plan-providers — emit the selected benchmark provider ids as one line of compact JSON array.
+
+usage: plan-providers [--help] [--list-providers] [--list-suites] [--json]
+
+  (no args)          Print ["e2b","daytona", …] on a single line (the GITHUB_OUTPUT contract): the
+                     provider axis every per-suite matrix job in bench-matrix.yml fans out over.
+  --list-providers   List the registered providers the matrix can fan out over.
+  --list-suites      List the registered suites (one named matrix job each).
+  --json             Emit --list-* output as JSON instead of human-readable lines.
+  --help, -h         Show this help.
+
+environment:
+  BENCH_PROVIDERS    Comma-separated providers to fan out over (e.g. "e2b,daytona,modal"). Unset or
+                     blank selects every registered provider. An unregistered name is an error,
+                     never a silently smaller matrix.
+
+examples:
+  plan-providers                               # the CI provider axis: echo "providers=$(plan-providers)" >> "$GITHUB_OUTPUT"
+  BENCH_PROVIDERS=e2b,daytona plan-providers   # only those two providers
+  plan-providers --list-suites --json          # the suites each matrix job runs
+
+Next: run one cell with  bench-suite <provider> <suite> <runId>`;
+
+if (import.meta.main) {
+	const argv = process.argv.slice(2);
+	const discovery = handleDiscovery(argv, HELP);
+	if (discovery !== null) {
+		(discovery.ok ? console.log : console.error)(discovery.text);
+		process.exit(discovery.ok ? 0 : 2);
+	}
+	// A bad BENCH_PROVIDERS must fail the step, not print a diagnostic onto stdout: stdout here IS the
+	// `providers=` value CI captures, so an error message there would be parsed as the matrix axis.
+	try {
+		console.log(planProvidersJson(process.env.BENCH_PROVIDERS));
+	} catch (err) {
+		console.error(`plan-providers: ${err instanceof Error ? err.message : String(err)}`);
+		process.exit(2);
+	}
+}

--- a/apps/cli/src/bin/plan-suites.ts
+++ b/apps/cli/src/bin/plan-suites.ts
@@ -1,0 +1,56 @@
+#!/usr/bin/env bun
+// `plan-suites` — emit the selected suite names as a SINGLE LINE of compact JSON array.
+// This is a $GITHUB_OUTPUT contract the Bench matrix reads: `suites=<json>` must be one line. Each
+// suite job in bench-matrix.yml is gated on membership in this array, so a dispatch can run a subset
+// (e.g. just `network`) for pre-merge/targeted validation instead of spending the whole matrix. Shares
+// `selectSuites` with the matrix builder, so SUITE_NAMES stays the single source of truth.
+import { handleDiscovery } from "../lib/discovery.ts";
+import { selectSuites } from "../lib/matrix.ts";
+
+/** The selected-suites JSON for `suitesRaw` (a comma-separated `BENCH_SUITES` value; blank/undefined =
+ *  every registered suite). Takes the raw string rather than reading `process.env` itself, so it stays
+ *  pure — the bin owns the env read, and a test can't be perturbed by an ambient value. */
+export function planSuitesJson(suitesRaw?: string): string {
+	return JSON.stringify(selectSuites(suitesRaw));
+}
+
+/** Agent-facing usage; the bare invocation stays the $GITHUB_OUTPUT suites contract. */
+export const HELP = `plan-suites — emit the selected benchmark suite names as one line of compact JSON array.
+
+usage: plan-suites [--help] [--list-providers] [--list-suites] [--json]
+
+  (no args)          Print ["cpu-node","system", …] on a single line (the GITHUB_OUTPUT contract): the
+                     suites whose matrix jobs run. Each suite job in bench-matrix.yml is gated on this.
+  --list-providers   List the registered providers each suite job fans out over.
+  --list-suites      List the registered suites (one named matrix job each).
+  --json             Emit --list-* output as JSON instead of human-readable lines.
+  --help, -h         Show this help.
+
+environment:
+  BENCH_SUITES       Comma-separated suites to run (e.g. "network,memory"). Unset or blank selects every
+                     registered suite (the main-publish default). An unregistered name is an error,
+                     never a silently empty selection.
+
+examples:
+  plan-suites                                  # every suite: echo "suites=$(plan-suites)" >> "$GITHUB_OUTPUT"
+  BENCH_SUITES=network plan-suites             # only the network suite's job runs
+  plan-suites --list-suites --json             # the suites each matrix job runs
+
+Next: run one cell with  bench-suite <provider> <suite> <runId>`;
+
+if (import.meta.main) {
+	const argv = process.argv.slice(2);
+	const discovery = handleDiscovery(argv, HELP);
+	if (discovery !== null) {
+		(discovery.ok ? console.log : console.error)(discovery.text);
+		process.exit(discovery.ok ? 0 : 2);
+	}
+	// A bad BENCH_SUITES must fail the step, not print a diagnostic onto stdout: stdout here IS the
+	// `suites=` value CI captures, so an error message there would be parsed as the selection array.
+	try {
+		console.log(planSuitesJson(process.env.BENCH_SUITES));
+	} catch (err) {
+		console.error(`plan-suites: ${err instanceof Error ? err.message : String(err)}`);
+		process.exit(2);
+	}
+}

--- a/apps/cli/src/lib/matrix.ts
+++ b/apps/cli/src/lib/matrix.ts
@@ -43,6 +43,33 @@ export function selectProviders(raw: string | undefined): ProviderId[] {
 }
 
 /**
+ * The suites a dispatch asks the matrix to run, parsed from a comma-separated list (the `BENCH_SUITES`
+ * dispatch input). Absent or blank → every registered suite, so the default matrix is unchanged and the
+ * registry stays the source of truth. Mirrors {@link selectProviders} on the suite axis: an unregistered
+ * name THROWS (a typo must fail the plan, not silently run nothing), duplicates collapse, and the result
+ * is ordered by the registry. Matching is case-insensitive to tolerate a hand-typed dispatch input.
+ *
+ * This is the pre-merge/targeted-run knob: `BENCH_SUITES=network` runs only the network suite's jobs, so
+ * a validation dispatch doesn't have to spend the whole matrix. Blank stays the main-publish default.
+ */
+export function selectSuites(raw: string | undefined): SuiteName[] {
+	const requested = (raw ?? "")
+		.toLowerCase()
+		.split(",")
+		.map((name) => name.trim())
+		.filter((name) => name.length > 0);
+	if (requested.length === 0) return [...SUITE_NAMES];
+
+	const unknown = requested.filter((name) => !SUITE_NAMES.includes(name as SuiteName));
+	if (unknown.length > 0) {
+		throw new Error(
+			`unknown suite(s): ${unknown.join(", ")} — registered suites are ${SUITE_NAMES.join(", ")}`,
+		);
+	}
+	return SUITE_NAMES.filter((name) => requested.includes(name));
+}
+
+/**
  * The full benchmark matrix: every provider × every registered suite. Each cell becomes one CI job
  * (`bench-suite <provider> <suite>`), so the dataset grows by adding a provider or a suite to its
  * registry — never by editing the workflow. Both lists are injectable for unit tests; the defaults are

--- a/apps/cli/src/plan-providers.test.ts
+++ b/apps/cli/src/plan-providers.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from "bun:test";
+import { PROVIDERS, SUITE_NAMES } from "@sandbox-benchmarks/schema";
+import { HELP, planProvidersJson } from "./bin/plan-providers.ts";
+import { handleDiscovery } from "./lib/discovery.ts";
+
+describe("plan-providers", () => {
+	it("emits a single line of compact JSON array (the $GITHUB_OUTPUT contract)", () => {
+		const out = planProvidersJson();
+		// Single line: no embedded newlines and no pretty-print indentation.
+		expect(out).not.toContain("\n");
+		expect(out).not.toMatch(/\n\s+/);
+
+		const parsed = JSON.parse(out) as string[];
+		// Every registered provider, in registry order — the provider axis each suite job fans out over.
+		expect(parsed).toEqual(PROVIDERS.map((p) => p.id));
+	});
+
+	it("narrows to the providers a dispatch names, still one line of JSON", () => {
+		const out = planProvidersJson("e2b,daytona");
+		expect(out).not.toContain("\n");
+		// Registry order, not request order — the CI job list can't be reordered by a dispatch.
+		expect(JSON.parse(out)).toEqual(["e2b", "daytona"]);
+	});
+
+	it("throws on an unregistered name rather than shrinking the matrix", () => {
+		// A typo'd provider must fail the plan step, not silently publish a dataset missing it.
+		expect(() => planProvidersJson("e2b,dayton")).toThrow(/unknown provider\(s\): dayton/);
+	});
+
+	it("exposes agent-friendly discovery: --help and --list-* listings the bin wires", () => {
+		expect(handleDiscovery(["--help"], HELP)).toEqual({ text: HELP, ok: true });
+		expect(HELP).toContain("plan-providers");
+		expect(HELP).toContain("examples:");
+
+		// Every registered provider and suite is discoverable through the bin's listings.
+		const listed = handleDiscovery(["--list-providers"], HELP)?.text ?? "";
+		for (const meta of PROVIDERS) expect(listed).toContain(meta.id);
+		const suites = JSON.parse(
+			handleDiscovery(["--list-suites", "--json"], HELP)?.text ?? "[]",
+		) as Array<{ name: string }>;
+		expect(suites.map((s) => s.name)).toEqual([...SUITE_NAMES]);
+
+		// A bare invocation has no discovery flag, so the providers path (the GITHUB_OUTPUT contract) runs.
+		expect(handleDiscovery([], HELP)).toBeNull();
+	});
+});

--- a/apps/cli/src/plan-suites.test.ts
+++ b/apps/cli/src/plan-suites.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from "bun:test";
+import { PROVIDERS, SUITE_NAMES } from "@sandbox-benchmarks/schema";
+import { HELP, planSuitesJson } from "./bin/plan-suites.ts";
+import { handleDiscovery } from "./lib/discovery.ts";
+import { selectSuites } from "./lib/matrix.ts";
+
+describe("plan-suites", () => {
+	it("emits a single line of compact JSON array (the $GITHUB_OUTPUT contract)", () => {
+		const out = planSuitesJson();
+		expect(out).not.toContain("\n");
+		expect(out).not.toMatch(/\n\s+/);
+		// Every registered suite, in registry order — each suite job is gated on membership here.
+		expect(JSON.parse(out)).toEqual([...SUITE_NAMES]);
+	});
+
+	it("narrows to the suites a dispatch names, still one line of JSON", () => {
+		const out = planSuitesJson("network");
+		expect(out).not.toContain("\n");
+		expect(JSON.parse(out)).toEqual(["network"]);
+	});
+
+	it("throws on an unregistered name rather than silently running nothing", () => {
+		expect(() => planSuitesJson("network,netwrk")).toThrow(/unknown suite\(s\): netwrk/);
+	});
+
+	it("exposes agent-friendly discovery: --help and --list-* listings the bin wires", () => {
+		expect(handleDiscovery(["--help"], HELP)).toEqual({ text: HELP, ok: true });
+		expect(HELP).toContain("plan-suites");
+		expect(HELP).toContain("examples:");
+		const listed = handleDiscovery(["--list-providers"], HELP)?.text ?? "";
+		for (const meta of PROVIDERS) expect(listed).toContain(meta.id);
+		expect(handleDiscovery([], HELP)).toBeNull();
+	});
+});
+
+describe("selectSuites", () => {
+	it("defaults to every registered suite when unset or blank", () => {
+		expect(selectSuites(undefined)).toEqual([...SUITE_NAMES]);
+		expect(selectSuites("")).toEqual([...SUITE_NAMES]);
+		expect(selectSuites("  , ,")).toEqual([...SUITE_NAMES]);
+	});
+
+	it("throws on an unregistered name rather than running nothing", () => {
+		expect(() => selectSuites("network,gpu")).toThrow(/unknown suite\(s\): gpu/);
+		expect(() => selectSuites("network,gpu")).toThrow(/registered suites are/);
+	});
+
+	it("collapses duplicates and orders by the registry, not by the request", () => {
+		expect(selectSuites("network,memory,network")).toEqual(["memory", "network"]);
+	});
+
+	it("tolerates whitespace and mixed casing around names", () => {
+		expect(selectSuites(" Network , Memory ")).toEqual(["memory", "network"]);
+	});
+});

--- a/docs/ci-secrets.md
+++ b/docs/ci-secrets.md
@@ -13,14 +13,20 @@ and toolchain publish must not trigger on `push`.
 | Workflow | Job | Why |
 | --- | --- | --- |
 | `toolchain-image.yml` | `publish` | Provider bake secrets + `packages: write` (GHCR release) |
-| `bench-matrix.yml` | `bench` | Provider API keys |
+| `bench-suite.yml` | `bench` | Provider API keys (reusable fan-out `bench-matrix.yml`'s per-suite jobs call) |
 | `publish-dataset.yml` | `publish` | Dataset + leaderboard publish (`contents: write` + `pull-requests: write`) |
 | `bench-smoke.yml` | `smoke` | Provider API keys |
 
-`publish-dataset.yml` is a reusable workflow: `bench-matrix.yml`'s `publish` job calls it at the end
-of a matrix run, and a maintainer can dispatch it standalone to backfill (see rule 6). A `uses:` caller
-can't declare `environment:`, so the `privileged` gate lives on the reusable workflow's own job — the
-workflow-hardening drift gate checks it there and passes the local caller.
+Two of these are reusable workflows whose `privileged` gate lives on their own job, because a `uses:`
+caller can't declare `environment:` (the workflow-hardening drift gate checks the callee and passes the
+local caller):
+
+- `bench-suite.yml` runs one suite across a provider matrix; `bench-matrix.yml`'s named per-suite jobs
+  each call it with `secrets: inherit` — required because the provider API keys are Environment secrets
+  on `privileged` (no repository copy), so only a job that declares that environment can resolve them,
+  and the `uses:` caller can't.
+- `publish-dataset.yml` runs the dataset publish: `bench-matrix.yml`'s `publish` job calls it at the end
+  of a matrix run, and a maintainer can dispatch it standalone to backfill (see rule 6).
 
 Ungated: `ci.yml`, `ci-lint.yml`, and the toolchain `pr-gate` (Docker smoke, no secrets).
 
@@ -61,11 +67,13 @@ Ungated: `ci.yml`, `ci-lint.yml`, and the toolchain `pr-gate` (Docker smoke, no 
    still within the repo's artifact-retention window. Dispatch is still gated by Environment
    `privileged` (main-only, required reviewer), so it is effectively maintainer-only.
 
-> **Two approvals per bench-matrix run.** `bench` and `publish` both carry `environment:
-> privileged` and run sequentially, so GitHub raises **two** separate pending-deployment gates: one
-> before the matrix starts, and a second (after the long matrix finishes, ~150 min) before the
-> dataset is committed. A reviewer who approves only `bench` and walks away leaves the run parked at
-> `publish` until the second approval lands or the protection rule times out.
+> **Two approval gates per bench-matrix run.** The per-suite fan-out jobs (each calling
+> `bench-suite.yml`) and the `publish` job all carry `environment: privileged` and run sequentially.
+> The suite jobs all become pending together the moment `plan` finishes, so they surface as one batch
+> in "Review pending deployments" and a single approval of the `privileged` environment releases the
+> whole matrix; `publish` becomes pending only after the long matrix (~150 min), raising a **second**
+> gate before the dataset is committed. A reviewer who approves only the matrix and walks away leaves
+> the run parked at `publish` until the second approval lands or the protection rule times out.
 
 ## Operator setup (before flipping the repo public)
 

--- a/docs/ci-secrets.md
+++ b/docs/ci-secrets.md
@@ -13,7 +13,7 @@ and toolchain publish must not trigger on `push`.
 | Workflow | Job | Why |
 | --- | --- | --- |
 | `toolchain-image.yml` | `publish` | Provider bake secrets + `packages: write` (GHCR release) |
-| `bench-suite.yml` | `bench` | Provider API keys (reusable fan-out `bench-matrix.yml`'s per-suite jobs call) |
+| `bench-suite.yml` | `bench` | Provider API keys (reusable fan-out `bench-matrix.yml`'s suite-matrix job calls) |
 | `publish-dataset.yml` | `publish` | Dataset + leaderboard publish (`contents: write` + `pull-requests: write`) |
 | `bench-smoke.yml` | `smoke` | Provider API keys |
 
@@ -21,10 +21,10 @@ Two of these are reusable workflows whose `privileged` gate lives on their own j
 caller can't declare `environment:` (the workflow-hardening drift gate checks the callee and passes the
 local caller):
 
-- `bench-suite.yml` runs one suite across a provider matrix; `bench-matrix.yml`'s named per-suite jobs
-  each call it with `secrets: inherit` — required because the provider API keys are Environment secrets
-  on `privileged` (no repository copy), so only a job that declares that environment can resolve them,
-  and the `uses:` caller can't.
+- `bench-suite.yml` runs one suite across a provider matrix; `bench-matrix.yml`'s suite-matrix job
+  calls it once per suite. Environment secrets on `privileged` resolve from the reusable job's own
+  `environment:` declaration (a `uses:` caller can't set `environment:`). The caller still passes
+  `secrets: inherit` for repository-level secrets / token context.
 - `publish-dataset.yml` runs the dataset publish: `bench-matrix.yml`'s `publish` job calls it at the end
   of a matrix run, and a maintainer can dispatch it standalone to backfill (see rule 6).
 
@@ -67,13 +67,14 @@ Ungated: `ci.yml`, `ci-lint.yml`, and the toolchain `pr-gate` (Docker smoke, no 
    still within the repo's artifact-retention window. Dispatch is still gated by Environment
    `privileged` (main-only, required reviewer), so it is effectively maintainer-only.
 
-> **Two approval gates per bench-matrix run.** The per-suite fan-out jobs (each calling
-> `bench-suite.yml`) and the `publish` job all carry `environment: privileged` and run sequentially.
-> The suite jobs all become pending together the moment `plan` finishes, so they surface as one batch
-> in "Review pending deployments" and a single approval of the `privileged` environment releases the
-> whole matrix; `publish` becomes pending only after the long matrix (~150 min), raising a **second**
-> gate before the dataset is committed. A reviewer who approves only the matrix and walks away leaves
-> the run parked at `publish` until the second approval lands or the protection rule times out.
+> **Two approval gates per bench-matrix run.** The suite-matrix fan-out (each cell calling
+> `bench-suite.yml` with `environment: privileged`) and the `publish` job both carry the environment
+> and run sequentially. Every suite × provider cell becomes pending together the moment `plan`
+> finishes, so they surface as one batch in "Review pending deployments" and a single approval of the
+> `privileged` environment releases the whole matrix; `publish` becomes pending only after the long
+> matrix (~150 min), raising a **second** gate before the dataset is committed. A reviewer who
+> approves only the matrix and walks away leaves the run parked at `publish` until the second approval
+> lands or the protection rule times out.
 
 ## Operator setup (before flipping the repo public)
 

--- a/docs/methodology.md
+++ b/docs/methodology.md
@@ -82,8 +82,9 @@ without being Daytona-specific.
 
 1. **Run** — `bench-suite <provider> <suite>` boots a sandbox, runs the suite's mise tasks, pulls the
    raw tree (`data/raw/<runId>/<provider>/<suite>/`), and normalizes it into a Run document.
-2. **Matrix** — the `bench-matrix` workflow fans `plan-matrix` (provider × suite) out into one job per
-   cell, each uploading its shard Run as an artifact.
+2. **Matrix** — the `bench-matrix` workflow runs one named job per suite (grouped by dimension), each
+   fanning out over the providers `plan-providers` selects via the reusable `bench-suite` workflow;
+   every (provider, suite) cell uploads its shard Run as an artifact.
 3. **Aggregate → promote** — the `publish` job collects every shard, `aggregate`s them into one
    candidate Run (measured metrics unioned, economics re-derived from the merged set), then `promote`s
    it (gate: ≥1 validated provider) into the committed dataset at `data/dataset/` with a newest-first

--- a/docs/methodology.md
+++ b/docs/methodology.md
@@ -82,9 +82,10 @@ without being Daytona-specific.
 
 1. **Run** — `bench-suite <provider> <suite>` boots a sandbox, runs the suite's mise tasks, pulls the
    raw tree (`data/raw/<runId>/<provider>/<suite>/`), and normalizes it into a Run document.
-2. **Matrix** — the `bench-matrix` workflow runs one named job per suite (grouped by dimension), each
-   fanning out over the providers `plan-providers` selects via the reusable `bench-suite` workflow;
-   every (provider, suite) cell uploads its shard Run as an artifact.
+2. **Matrix** — the `bench-matrix` workflow plans both axes, then one suite-matrix job calls the
+   reusable `bench-suite` workflow per suite (GitHub-native nesting: `<suite> / <provider>`), fanning
+   out over the providers `plan-providers` selects; every (provider, suite) cell uploads its shard Run
+   as an artifact.
 3. **Aggregate → promote** — the `publish` job collects every shard, `aggregate`s them into one
    candidate Run (measured metrics unioned, economics re-derived from the merged set), then `promote`s
    it (gate: ≥1 validated provider) into the committed dataset at `data/dataset/` with a newest-first

--- a/tooling/repo-checks/src/lib/workflow-sync.ts
+++ b/tooling/repo-checks/src/lib/workflow-sync.ts
@@ -2,22 +2,33 @@
 // schema registries. GHA can't import TypeScript, so the provider/suite vocabulary and the
 // per-provider credential wiring are re-spelled by hand in the workflow files; this module re-derives
 // the truth from PROVIDERS + SUITE_NAMES (packages/schema) and compares. It mirrors
-// runner-benchmarking's check-workflow-{env,suite}-sync.ts, adapted to this repo's two workflows.
+// runner-benchmarking's check-workflow-{env,suite}-sync.ts, adapted to this repo's workflows.
+//
+// Two workflows dispatch live benchmarks: bench-smoke.yml (one dispatched suite × provider) and
+// bench-matrix.yml (a named job per suite, each fanning out over the selected providers by CALLING the
+// reusable bench-suite.yml). The credential block + the run job's timeout therefore live in
+// bench-suite.yml for the matrix lane, so the "matrix side" of the credential/timeout checks reads
+// that reusable workflow, not bench-matrix.yml itself.
 //
 // Invariants (each maps to a real "added X, forgot the workflow" failure mode):
 //   1. bench-smoke.yml's `provider` dispatch input options == the PROVIDERS id set, and its default
 //      is one of them — a new provider must be dispatchable, a removed one must not linger.
 //   2. bench-smoke.yml's `suite` dispatch input options == SUITE_NAMES, with a valid default.
 //   3. Every provider's requiredEnvVars (schema) is present in the "Run suite and normalize" step env
-//      of BOTH bench-smoke.yml and bench-matrix.yml — the secret a new provider needs must be wired
-//      into both the smoke lane and the matrix lane, or the live run silently skips it.
-//   4. A credential key shared across the two workflows maps to the same value expression — both
-//      lanes must hand the suite the same secret, not plan one and run the other. Each lane scopes
-//      its secrets to the selected provider (so a cell only sees its own credential), and the two
-//      lanes pick that provider differently — `inputs.provider` in smoke, `matrix.provider` in the
-//      matrix fan-out — so the comparison folds those two selector tokens together before checking.
-//   5. Both live-run jobs outlast the longest registered sandbox lifetime by a fixed margin, so a
-//      suite budget increase cannot leave an otherwise healthy job to be killed by Actions first.
+//      of BOTH bench-smoke.yml and the reusable bench-suite.yml — the secret a new provider needs must
+//      be wired into both the smoke lane and the matrix fan-out, or the live run silently skips it.
+//   4. A credential key shared across the two lanes maps to the same value expression — both must hand
+//      the suite the same secret, not plan one and run the other. Each lane scopes its secrets to the
+//      selected provider (so a cell only sees its own credential), and the two lanes pick that provider
+//      differently — `inputs.provider` in smoke, `matrix.provider` in the fan-out — so the comparison
+//      folds those two selector tokens together before checking.
+//   5. Both live-run jobs (smoke's job and the reusable fan-out) outlast the longest registered sandbox
+//      lifetime by a fixed margin, so a suite budget increase cannot leave an otherwise healthy job to
+//      be killed by Actions first.
+//   6. bench-matrix.yml has exactly one matrix job per SUITE_NAMES entry (a job that `uses` the
+//      reusable bench-suite.yml with that `suite`) — a new suite must gain its named job, a removed one
+//      must not linger. This is what keeps the hand-enumerated suite jobs registry-driven now that the
+//      fan-out is a static named job per suite rather than one dynamic 2-D matrix.
 //
 // Bun.YAML.parse is built into bun >= 1.3 (no new dependency), so the parse stays dependency-light.
 import { readFileSync } from "node:fs";
@@ -28,10 +39,15 @@ import { findRepoRoot } from "./workspace.ts";
 
 export const SMOKE_WORKFLOW = ".github/workflows/bench-smoke.yml";
 export const MATRIX_WORKFLOW = ".github/workflows/bench-matrix.yml";
-/** The step (in both workflows) that drives the provider SDK; it owns the credential env block. */
+/** The reusable workflow each bench-matrix suite job calls; it owns the credential block + run timeout. */
+export const SUITE_WORKFLOW = ".github/workflows/bench-suite.yml";
+/** The step (in bench-smoke.yml and bench-suite.yml) that drives the provider SDK; it owns the env. */
 export const RUN_STEP = "Run suite and normalize";
 export const SMOKE_JOB = "smoke";
-export const MATRIX_JOB = "bench";
+/** The fan-out job inside the reusable bench-suite.yml (its credential env + timeout). */
+export const SUITE_JOB = "bench";
+/** A bench-matrix suite job is one that `uses` this reusable workflow (matched by path suffix). */
+const SUITE_WORKFLOW_USES_SUFFIX = "/bench-suite.yml";
 /** Host-side checkout/teardown/normalization/upload allowance beyond the sandbox lifetime. */
 export const WORKFLOW_TIMEOUT_MARGIN_MINUTES = 15;
 
@@ -142,6 +158,40 @@ export function stepEnv(
 		entries[key] = value;
 	}
 	return entries;
+}
+
+/** One bench-matrix suite job: its job id and the `suite` it dispatches to the reusable fan-out. */
+export interface SuiteJob {
+	jobId: string;
+	suite: string;
+}
+
+/**
+ * The bench-matrix suite jobs — every job whose `uses` targets the reusable bench-suite.yml, paired
+ * with the `suite` it passes. A job that calls the reusable without a string `with.suite` throws (a
+ * malformed suite job must fail the gate, not be silently skipped); jobs that don't call the reusable
+ * (plan, publish) are ignored. This is the workflow half of Invariant 6 — the schema half is
+ * {@link SUITE_NAMES}.
+ */
+export function matrixSuiteJobs(doc: unknown, label: string = MATRIX_WORKFLOW): SuiteJob[] {
+	const root = asRecord(doc, `${label}: not a YAML mapping`);
+	const jobs = asRecord(root.jobs, `${label}: no jobs mapping`);
+	const suiteJobs: SuiteJob[] = [];
+	for (const [jobId, rawJob] of Object.entries(jobs)) {
+		const job = asRecord(rawJob, `${label}: job "${jobId}" is not a mapping`);
+		const uses = job.uses;
+		if (typeof uses !== "string" || !uses.endsWith(SUITE_WORKFLOW_USES_SUFFIX)) continue;
+		const withMap = asRecord(
+			job.with,
+			`${label}: job "${jobId}" calls ${uses} without a "with" mapping`,
+		);
+		const suite = withMap.suite;
+		if (typeof suite !== "string") {
+			throw new Error(`${label}: job "${jobId}" calls ${uses} without a string "suite" input`);
+		}
+		suiteJobs.push({ jobId, suite });
+	}
+	return suiteJobs;
 }
 
 /** The canonical provider ids from the schema registry. */
@@ -288,6 +338,48 @@ export function checkCredentialEnv(
 	return errors;
 }
 
+/**
+ * Invariant 6: the bench-matrix suite jobs cover SUITE_NAMES exactly — every registered suite has one
+ * matrix job, no job names an unregistered suite, and no suite is dispatched twice. `label` names the
+ * workflow in error messages.
+ */
+export function checkSuiteJobCoverage(
+	suiteJobs: SuiteJob[],
+	label: string = MATRIX_WORKFLOW,
+): string[] {
+	const errors: string[] = [];
+	const expected = new Set<string>(SUITE_NAMES);
+	const seen = new Map<string, string>();
+	for (const { jobId, suite } of suiteJobs) {
+		if (!expected.has(suite)) {
+			errors.push(
+				`${label}: job "${jobId}" benchmarks suite "${suite}" which is not in SUITE_NAMES ` +
+					`(packages/schema/src/suites.ts) — remove it or add the suite to the registry`,
+			);
+			continue;
+		}
+		const prior = seen.get(suite);
+		if (prior !== undefined) {
+			errors.push(
+				`${label}: suite "${suite}" is dispatched by more than one job ("${prior}" and "${jobId}") — ` +
+					"each suite gets exactly one matrix job",
+			);
+			continue;
+		}
+		seen.set(suite, jobId);
+	}
+	for (const suite of expected) {
+		if (!seen.has(suite)) {
+			errors.push(
+				`${label}: no matrix job benchmarks suite "${suite}" — it is in SUITE_NAMES; add a job that ` +
+					"`uses: ./.github/workflows/bench-suite.yml` with `suite: " +
+					`${suite}\``,
+			);
+		}
+	}
+	return errors;
+}
+
 /** Invariant 5: every live-run job has margin beyond the longest registered sandbox lifetime. */
 export function checkWorkflowTimeouts(timeoutByWorkflow: Record<string, number>): string[] {
 	const longestSuite = Math.max(...Object.values(SUITES).map((suite) => suite.timeoutMinutes));
@@ -308,16 +400,20 @@ export function checkWorkflowTimeouts(timeoutByWorkflow: Record<string, number>)
 export function runCheck(root: string = findRepoRoot()): string[] {
 	const smoke = readWorkflow(SMOKE_WORKFLOW, root);
 	const matrix = readWorkflow(MATRIX_WORKFLOW, root);
+	// The matrix lane's credential block + run-job timeout live in the reusable bench-suite.yml that
+	// every suite job calls, so the "matrix side" of Invariants 3–5 reads that file.
+	const suiteWf = readWorkflow(SUITE_WORKFLOW, root);
 	return [
 		...checkProviderInput(dispatchInput(smoke, "provider", SMOKE_WORKFLOW)),
 		...checkSuiteInput(dispatchInput(smoke, "suite", SMOKE_WORKFLOW)),
 		...checkCredentialEnv({
 			[SMOKE_WORKFLOW]: stepEnv(smoke, SMOKE_JOB, RUN_STEP, SMOKE_WORKFLOW),
-			[MATRIX_WORKFLOW]: stepEnv(matrix, MATRIX_JOB, RUN_STEP, MATRIX_WORKFLOW),
+			[SUITE_WORKFLOW]: stepEnv(suiteWf, SUITE_JOB, RUN_STEP, SUITE_WORKFLOW),
 		}),
 		...checkWorkflowTimeouts({
 			[SMOKE_WORKFLOW]: jobTimeoutMinutes(smoke, SMOKE_JOB, SMOKE_WORKFLOW),
-			[MATRIX_WORKFLOW]: jobTimeoutMinutes(matrix, MATRIX_JOB, MATRIX_WORKFLOW),
+			[SUITE_WORKFLOW]: jobTimeoutMinutes(suiteWf, SUITE_JOB, SUITE_WORKFLOW),
 		}),
+		...checkSuiteJobCoverage(matrixSuiteJobs(matrix, MATRIX_WORKFLOW), MATRIX_WORKFLOW),
 	];
 }

--- a/tooling/repo-checks/src/lib/workflow-sync.ts
+++ b/tooling/repo-checks/src/lib/workflow-sync.ts
@@ -5,10 +5,10 @@
 // runner-benchmarking's check-workflow-{env,suite}-sync.ts, adapted to this repo's workflows.
 //
 // Two workflows dispatch live benchmarks: bench-smoke.yml (one dispatched suite × provider) and
-// bench-matrix.yml (a named job per suite, each fanning out over the selected providers by CALLING the
-// reusable bench-suite.yml). The credential block + the run job's timeout therefore live in
-// bench-suite.yml for the matrix lane, so the "matrix side" of the credential/timeout checks reads
-// that reusable workflow, not bench-matrix.yml itself.
+// bench-matrix.yml (one suite-matrix job that calls the reusable bench-suite.yml once per suite, which
+// then fans out over the selected providers). The credential block + the run job's timeout therefore
+// live in bench-suite.yml for the matrix lane, so the "matrix side" of the credential/timeout checks
+// reads that reusable workflow, not bench-matrix.yml itself.
 //
 // Invariants (each maps to a real "added X, forgot the workflow" failure mode):
 //   1. bench-smoke.yml's `provider` dispatch input options == the PROVIDERS id set, and its default
@@ -25,10 +25,12 @@
 //   5. Both live-run jobs (smoke's job and the reusable fan-out) outlast the longest registered sandbox
 //      lifetime by a fixed margin, so a suite budget increase cannot leave an otherwise healthy job to
 //      be killed by Actions first.
-//   6. bench-matrix.yml has exactly one matrix job per SUITE_NAMES entry (a job that `uses` the
-//      reusable bench-suite.yml with that `suite`) — a new suite must gain its named job, a removed one
-//      must not linger. This is what keeps the hand-enumerated suite jobs registry-driven now that the
-//      fan-out is a static named job per suite rather than one dynamic 2-D matrix.
+//   6. bench-matrix.yml has exactly one suite-matrix caller of the reusable bench-suite.yml, wired for
+//      GitHub-native nesting: `name: ${{ matrix.suite }}`, `with.suite: ${{ matrix.suite }}`, and
+//      `strategy.matrix.suite: ${{ fromJSON(needs.plan.outputs.suites) }}`, with `publish` needing that
+//      caller. The suite axis itself comes from `plan-suites` (SUITE_NAMES, honoring the `suites`
+//      input), so adding a suite is a schema change — this invariant keeps the nesting wiring from
+//      drifting.
 //
 // Bun.YAML.parse is built into bun >= 1.3 (no new dependency), so the parse stays dependency-light.
 import { readFileSync } from "node:fs";
@@ -160,23 +162,40 @@ export function stepEnv(
 	return entries;
 }
 
-/** One bench-matrix suite job: its job id and the `suite` it dispatches to the reusable fan-out. */
-export interface SuiteJob {
+/**
+ * The single bench-matrix suite-matrix caller: the job that `uses` the reusable bench-suite.yml and
+ * expands `strategy.matrix.suite` from the plan's suite axis. Native nesting depends on
+ * `name` / `with.suite` both resolving to `matrix.suite`.
+ */
+export interface SuiteMatrixCaller {
 	jobId: string;
-	suite: string;
+	name: string;
+	suiteInput: string;
+	matrixSuiteExpr: string;
+	/** Job ids listed in `publish.needs` (empty when publish is missing or has no needs list). */
+	publishNeeds: string[];
 }
 
+/** The expression the suite-matrix job must use for its suite axis (plan output → fromJSON). */
+// biome-ignore lint/suspicious/noTemplateCurlyInString: a GHA expression literal matched verbatim against the workflow, not a JS template.
+export const EXPECTED_SUITE_MATRIX_EXPR = "${{ fromJSON(needs.plan.outputs.suites) }}";
+/** The expression that makes each caller cell's display name the suite id (native nesting parent). */
+// biome-ignore lint/suspicious/noTemplateCurlyInString: a GHA expression literal matched verbatim against the workflow, not a JS template.
+export const EXPECTED_SUITE_NAME_EXPR = "${{ matrix.suite }}";
+
 /**
- * The bench-matrix suite jobs — every job whose `uses` targets the reusable bench-suite.yml, paired
- * with the `suite` it passes. A job that calls the reusable without a string `with.suite` throws (a
- * malformed suite job must fail the gate, not be silently skipped); jobs that don't call the reusable
- * (plan, publish) are ignored. This is the workflow half of Invariant 6 — the schema half is
- * {@link SUITE_NAMES}.
+ * The bench-matrix suite-matrix caller — exactly one job whose `uses` targets the reusable
+ * bench-suite.yml, with its nesting wiring extracted. Zero or multiple callers throw (Invariant 6
+ * must fail loudly, not pick one). Jobs that don't call the reusable (plan, publish) are ignored
+ * except that `publish.needs` is captured for the dependency check.
  */
-export function matrixSuiteJobs(doc: unknown, label: string = MATRIX_WORKFLOW): SuiteJob[] {
+export function matrixSuiteCaller(
+	doc: unknown,
+	label: string = MATRIX_WORKFLOW,
+): SuiteMatrixCaller {
 	const root = asRecord(doc, `${label}: not a YAML mapping`);
 	const jobs = asRecord(root.jobs, `${label}: no jobs mapping`);
-	const suiteJobs: SuiteJob[] = [];
+	const callers: Array<Omit<SuiteMatrixCaller, "publishNeeds">> = [];
 	for (const [jobId, rawJob] of Object.entries(jobs)) {
 		const job = asRecord(rawJob, `${label}: job "${jobId}" is not a mapping`);
 		const uses = job.uses;
@@ -185,13 +204,52 @@ export function matrixSuiteJobs(doc: unknown, label: string = MATRIX_WORKFLOW): 
 			job.with,
 			`${label}: job "${jobId}" calls ${uses} without a "with" mapping`,
 		);
-		const suite = withMap.suite;
-		if (typeof suite !== "string") {
+		const suiteInput = withMap.suite;
+		if (typeof suiteInput !== "string") {
 			throw new Error(`${label}: job "${jobId}" calls ${uses} without a string "suite" input`);
 		}
-		suiteJobs.push({ jobId, suite });
+		const name = typeof job.name === "string" ? job.name : "";
+		const strategy = asRecord(
+			job.strategy,
+			`${label}: job "${jobId}" calls ${uses} without a "strategy" mapping`,
+		);
+		const matrix = asRecord(
+			strategy.matrix,
+			`${label}: job "${jobId}" calls ${uses} without a "strategy.matrix" mapping`,
+		);
+		const matrixSuiteExpr = matrix.suite;
+		if (typeof matrixSuiteExpr !== "string") {
+			throw new Error(
+				`${label}: job "${jobId}" calls ${uses} without a string "strategy.matrix.suite" axis`,
+			);
+		}
+		callers.push({ jobId, name, suiteInput, matrixSuiteExpr });
 	}
-	return suiteJobs;
+	if (callers.length === 0) {
+		throw new Error(
+			`${label}: no job calls the reusable bench-suite.yml — the suite-matrix caller is missing`,
+		);
+	}
+	if (callers.length > 1) {
+		throw new Error(
+			`${label}: expected exactly one suite-matrix caller of bench-suite.yml, found ` +
+				`${callers.length} (${callers.map((c) => c.jobId).join(", ")})`,
+		);
+	}
+	// biome-ignore lint/style/noNonNullAssertion: length checked above.
+	const caller = callers[0]!;
+	const publish = jobs.publish;
+	let publishNeeds: string[] = [];
+	if (publish !== undefined) {
+		const publishJob = asRecord(publish, `${label}: job "publish" is not a mapping`);
+		const needs = publishJob.needs;
+		if (Array.isArray(needs)) {
+			publishNeeds = needs.map((n) => String(n));
+		} else if (typeof needs === "string") {
+			publishNeeds = [needs];
+		}
+	}
+	return { ...caller, publishNeeds };
 }
 
 /** The canonical provider ids from the schema registry. */
@@ -339,43 +397,39 @@ export function checkCredentialEnv(
 }
 
 /**
- * Invariant 6: the bench-matrix suite jobs cover SUITE_NAMES exactly — every registered suite has one
- * matrix job, no job names an unregistered suite, and no suite is dispatched twice. `label` names the
+ * Invariant 6: the bench-matrix suite-matrix caller is wired for GitHub-native nesting and depends on
+ * the plan's suite axis — display name and `with.suite` are `${{ matrix.suite }}`, the matrix axis is
+ * `fromJSON(needs.plan.outputs.suites)`, and `publish` needs the caller job. `label` names the
  * workflow in error messages.
  */
-export function checkSuiteJobCoverage(
-	suiteJobs: SuiteJob[],
+export function checkSuiteMatrixCaller(
+	caller: SuiteMatrixCaller,
 	label: string = MATRIX_WORKFLOW,
 ): string[] {
 	const errors: string[] = [];
-	const expected = new Set<string>(SUITE_NAMES);
-	const seen = new Map<string, string>();
-	for (const { jobId, suite } of suiteJobs) {
-		if (!expected.has(suite)) {
-			errors.push(
-				`${label}: job "${jobId}" benchmarks suite "${suite}" which is not in SUITE_NAMES ` +
-					`(packages/schema/src/suites.ts) — remove it or add the suite to the registry`,
-			);
-			continue;
-		}
-		const prior = seen.get(suite);
-		if (prior !== undefined) {
-			errors.push(
-				`${label}: suite "${suite}" is dispatched by more than one job ("${prior}" and "${jobId}") — ` +
-					"each suite gets exactly one matrix job",
-			);
-			continue;
-		}
-		seen.set(suite, jobId);
+	if (caller.name !== EXPECTED_SUITE_NAME_EXPR) {
+		errors.push(
+			`${label}: job "${caller.jobId}" name must be "${EXPECTED_SUITE_NAME_EXPR}" for native ` +
+				`suite nesting in the Actions UI (got ${caller.name ? `"${caller.name}"` : "no name"})`,
+		);
 	}
-	for (const suite of expected) {
-		if (!seen.has(suite)) {
-			errors.push(
-				`${label}: no matrix job benchmarks suite "${suite}" — it is in SUITE_NAMES; add a job that ` +
-					"`uses: ./.github/workflows/bench-suite.yml` with `suite: " +
-					`${suite}\``,
-			);
-		}
+	if (caller.suiteInput !== EXPECTED_SUITE_NAME_EXPR) {
+		errors.push(
+			`${label}: job "${caller.jobId}" with.suite must be "${EXPECTED_SUITE_NAME_EXPR}" so each ` +
+				`matrix cell dispatches its own suite (got "${caller.suiteInput}")`,
+		);
+	}
+	if (caller.matrixSuiteExpr !== EXPECTED_SUITE_MATRIX_EXPR) {
+		errors.push(
+			`${label}: job "${caller.jobId}" strategy.matrix.suite must be "${EXPECTED_SUITE_MATRIX_EXPR}" ` +
+				`so the suite axis stays registry-driven via plan.outputs.suites (got "${caller.matrixSuiteExpr}")`,
+		);
+	}
+	if (!caller.publishNeeds.includes(caller.jobId)) {
+		errors.push(
+			`${label}: job "publish" must need "${caller.jobId}" so aggregation waits for every suite ` +
+				`matrix cell (publish.needs=${JSON.stringify(caller.publishNeeds)})`,
+		);
 	}
 	return errors;
 }
@@ -414,6 +468,6 @@ export function runCheck(root: string = findRepoRoot()): string[] {
 			[SMOKE_WORKFLOW]: jobTimeoutMinutes(smoke, SMOKE_JOB, SMOKE_WORKFLOW),
 			[SUITE_WORKFLOW]: jobTimeoutMinutes(suiteWf, SUITE_JOB, SUITE_WORKFLOW),
 		}),
-		...checkSuiteJobCoverage(matrixSuiteJobs(matrix, MATRIX_WORKFLOW), MATRIX_WORKFLOW),
+		...checkSuiteMatrixCaller(matrixSuiteCaller(matrix, MATRIX_WORKFLOW), MATRIX_WORKFLOW),
 	];
 }

--- a/tooling/repo-checks/src/workflow-registry-sync.test.ts
+++ b/tooling/repo-checks/src/workflow-registry-sync.test.ts
@@ -2,11 +2,12 @@
 // registries (PROVIDERS + SUITE_NAMES). GHA can't import TypeScript, so the provider/suite choices and
 // the per-provider credential env block are hand-mirrored across .github/workflows/bench-*.yml; this
 // gate re-derives the truth from the registries and fails if someone adds a provider/suite (or its
-// required secret) without updating the workflows. bench-matrix.yml runs a named job per suite, each
-// calling the reusable bench-suite.yml — so the credential block + run-job timeout live in the reusable
-// (the "matrix side" of the credential/timeout checks reads it), and a separate invariant asserts the
-// suite jobs cover SUITE_NAMES. Mirrors runner-benchmarking's test/workflow-{env,suite}-sync.test.ts.
-// See ./lib/workflow-sync.ts for the parsers + pure checks.
+// required secret) without updating the workflows. bench-matrix.yml has one suite-matrix job that calls
+// the reusable bench-suite.yml (native nesting: suite / provider) — so the credential block + run-job
+// timeout live in the reusable (the "matrix side" of the credential/timeout checks reads it), and a
+// separate invariant asserts the suite-matrix caller stays wired to plan.outputs.suites. Mirrors
+// runner-benchmarking's test/workflow-{env,suite}-sync.test.ts. See ./lib/workflow-sync.ts for the
+// parsers + pure checks.
 //
 // The runCheck() test against the real workflow files IS the gate's CI enforcement point (it runs under
 // `bun test`, same precedent as boundary.test.ts); the rest is unit coverage of the parsers and the
@@ -17,12 +18,14 @@ import {
 	checkCredentialEnv,
 	checkProviderInput,
 	checkSuiteInput,
-	checkSuiteJobCoverage,
+	checkSuiteMatrixCaller,
 	checkWorkflowTimeouts,
 	dispatchInput,
+	EXPECTED_SUITE_MATRIX_EXPR,
+	EXPECTED_SUITE_NAME_EXPR,
 	jobTimeoutMinutes,
 	MATRIX_WORKFLOW,
-	matrixSuiteJobs,
+	matrixSuiteCaller,
 	RUN_STEP,
 	readWorkflow,
 	requiredCredentialKeys,
@@ -227,44 +230,85 @@ describe("checkCredentialEnv", () => {
 	});
 });
 
-describe("checkSuiteJobCoverage", () => {
-	const realJobs = matrixSuiteJobs(matrix);
+describe("checkSuiteMatrixCaller", () => {
+	const realCaller = matrixSuiteCaller(matrix);
 
-	test("matrixSuiteJobs extracts exactly one job per registered suite", () => {
-		expect(new Set(realJobs.map((j) => j.suite))).toEqual(new Set(SUITE_NAMES));
-		expect(realJobs).toHaveLength(SUITE_NAMES.length);
+	test("matrixSuiteCaller extracts the real suite-matrix nesting wiring", () => {
+		expect(realCaller.jobId).toBe("suite");
+		expect(realCaller.name).toBe(EXPECTED_SUITE_NAME_EXPR);
+		expect(realCaller.suiteInput).toBe(EXPECTED_SUITE_NAME_EXPR);
+		expect(realCaller.matrixSuiteExpr).toBe(EXPECTED_SUITE_MATRIX_EXPR);
+		expect(realCaller.publishNeeds).toContain("suite");
 	});
 
-	test("the real matrix suite jobs cover SUITE_NAMES", () => {
-		expect(checkSuiteJobCoverage(realJobs)).toEqual([]);
+	test("the real suite-matrix caller is wired for native nesting", () => {
+		expect(checkSuiteMatrixCaller(realCaller)).toEqual([]);
 	});
 
-	test("flags a registry suite that no matrix job benchmarks", () => {
-		const [dropped] = SUITE_NAMES;
-		const errors = checkSuiteJobCoverage(realJobs.filter((j) => j.suite !== dropped));
+	test("flags a caller whose display name is not matrix.suite", () => {
+		const errors = checkSuiteMatrixCaller({ ...realCaller, name: "Bench suites" });
 		expect(errors).toHaveLength(1);
-		expect(errors[0]).toContain(`no matrix job benchmarks suite "${dropped}"`);
-		expect(errors[0]).toContain("bench-suite.yml");
+		expect(errors[0]).toContain("name must be");
+		expect(errors[0]).toContain(EXPECTED_SUITE_NAME_EXPR);
 	});
 
-	test("flags a job dispatching a suite the registry doesn't know", () => {
-		const errors = checkSuiteJobCoverage([...realJobs, { jobId: "gpu", suite: "gpu" }]);
+	test("flags a caller whose with.suite is not matrix.suite", () => {
+		const errors = checkSuiteMatrixCaller({ ...realCaller, suiteInput: "cpu-node" });
 		expect(errors).toHaveLength(1);
-		expect(errors[0]).toContain('suite "gpu" which is not in SUITE_NAMES');
+		expect(errors[0]).toContain("with.suite must be");
 	});
 
-	test("flags a suite dispatched by two jobs", () => {
-		// "system" is a registered suite already covered by realJobs, so a second job for it is a dup.
-		const errors = checkSuiteJobCoverage([...realJobs, { jobId: "dup", suite: "system" }]);
+	test("flags a caller whose suite axis is not plan.outputs.suites", () => {
+		const errors = checkSuiteMatrixCaller({
+			...realCaller,
+			// biome-ignore lint/suspicious/noTemplateCurlyInString: a GHA expression literal (wrong axis), not a JS template.
+			matrixSuiteExpr: "${{ fromJSON(needs.plan.outputs.providers) }}",
+		});
 		expect(errors).toHaveLength(1);
-		expect(errors[0]).toContain("more than one job");
+		expect(errors[0]).toContain("strategy.matrix.suite must be");
+		expect(errors[0]).toContain(EXPECTED_SUITE_MATRIX_EXPR);
 	});
 
-	test("matrixSuiteJobs throws on a reusable-caller job with no string suite", () => {
+	test("flags publish that does not need the suite-matrix caller", () => {
+		const errors = checkSuiteMatrixCaller({ ...realCaller, publishNeeds: ["plan"] });
+		expect(errors).toHaveLength(1);
+		expect(errors[0]).toContain('publish" must need "suite"');
+	});
+
+	test("matrixSuiteCaller throws when no job calls the reusable", () => {
+		const yaml = Bun.YAML.stringify({ jobs: { plan: { "runs-on": "ubuntu-24.04" } } });
+		expect(() => matrixSuiteCaller(Bun.YAML.parse(yaml), "synthetic.yml")).toThrow(
+			"no job calls the reusable bench-suite.yml",
+		);
+	});
+
+	test("matrixSuiteCaller throws on multiple suite-matrix callers", () => {
+		const yaml = Bun.YAML.stringify({
+			jobs: {
+				a: {
+					name: EXPECTED_SUITE_NAME_EXPR,
+					uses: "./.github/workflows/bench-suite.yml",
+					with: { suite: EXPECTED_SUITE_NAME_EXPR },
+					strategy: { matrix: { suite: EXPECTED_SUITE_MATRIX_EXPR } },
+				},
+				b: {
+					name: EXPECTED_SUITE_NAME_EXPR,
+					uses: "./.github/workflows/bench-suite.yml",
+					with: { suite: EXPECTED_SUITE_NAME_EXPR },
+					strategy: { matrix: { suite: EXPECTED_SUITE_MATRIX_EXPR } },
+				},
+			},
+		});
+		expect(() => matrixSuiteCaller(Bun.YAML.parse(yaml), "synthetic.yml")).toThrow(
+			"expected exactly one suite-matrix caller",
+		);
+	});
+
+	test("matrixSuiteCaller throws on a reusable-caller job with no string suite", () => {
 		const yaml = Bun.YAML.stringify({
 			jobs: { bad: { uses: "./.github/workflows/bench-suite.yml", with: { providers: "[]" } } },
 		});
-		expect(() => matrixSuiteJobs(Bun.YAML.parse(yaml), "synthetic.yml")).toThrow(
+		expect(() => matrixSuiteCaller(Bun.YAML.parse(yaml), "synthetic.yml")).toThrow(
 			'without a string "suite" input',
 		);
 	});

--- a/tooling/repo-checks/src/workflow-registry-sync.test.ts
+++ b/tooling/repo-checks/src/workflow-registry-sync.test.ts
@@ -1,40 +1,47 @@
 // Invariant: the GitHub workflows that dispatch live benchmarks stay in lockstep with the schema
-// registries (PROVIDERS + SUITE_NAMES). GHA can't import TypeScript, so the provider/suite choices
-// and the per-provider credential env block are hand-mirrored across .github/workflows/bench-*.yml;
-// this gate re-derives the truth from the registries and fails if someone adds a provider/suite (or
-// its required secret) without updating the workflows. Mirrors runner-benchmarking's
-// test/workflow-{env,suite}-sync.test.ts. See ./lib/workflow-sync.ts for the parsers + pure checks.
+// registries (PROVIDERS + SUITE_NAMES). GHA can't import TypeScript, so the provider/suite choices and
+// the per-provider credential env block are hand-mirrored across .github/workflows/bench-*.yml; this
+// gate re-derives the truth from the registries and fails if someone adds a provider/suite (or its
+// required secret) without updating the workflows. bench-matrix.yml runs a named job per suite, each
+// calling the reusable bench-suite.yml — so the credential block + run-job timeout live in the reusable
+// (the "matrix side" of the credential/timeout checks reads it), and a separate invariant asserts the
+// suite jobs cover SUITE_NAMES. Mirrors runner-benchmarking's test/workflow-{env,suite}-sync.test.ts.
+// See ./lib/workflow-sync.ts for the parsers + pure checks.
 //
-// The runCheck() test against the real workflow files IS the gate's CI enforcement point (it runs
-// under `bun test`, same precedent as boundary.test.ts); the rest is unit coverage of the parsers and
-// the failure messages on synthetic drift, so a future regression names the offending file + key.
+// The runCheck() test against the real workflow files IS the gate's CI enforcement point (it runs under
+// `bun test`, same precedent as boundary.test.ts); the rest is unit coverage of the parsers and the
+// failure messages on synthetic drift, so a future regression names the offending file + key.
 import { describe, expect, test } from "bun:test";
 import { PROVIDERS, SUITE_NAMES } from "@sandbox-benchmarks/schema";
 import {
 	checkCredentialEnv,
 	checkProviderInput,
 	checkSuiteInput,
+	checkSuiteJobCoverage,
 	checkWorkflowTimeouts,
 	dispatchInput,
 	jobTimeoutMinutes,
-	MATRIX_JOB,
 	MATRIX_WORKFLOW,
+	matrixSuiteJobs,
 	RUN_STEP,
 	readWorkflow,
 	requiredCredentialKeys,
 	runCheck,
 	SMOKE_JOB,
 	SMOKE_WORKFLOW,
+	SUITE_JOB,
+	SUITE_WORKFLOW,
 	stepEnv,
 	WORKFLOW_TIMEOUT_MARGIN_MINUTES,
 } from "./lib/workflow-sync.ts";
 
 const smoke = readWorkflow(SMOKE_WORKFLOW);
 const matrix = readWorkflow(MATRIX_WORKFLOW);
+const suiteWf = readWorkflow(SUITE_WORKFLOW);
 const providerInput = dispatchInput(smoke, "provider", SMOKE_WORKFLOW);
 const suiteInput = dispatchInput(smoke, "suite", SMOKE_WORKFLOW);
 const smokeEnv = stepEnv(smoke, SMOKE_JOB, RUN_STEP, SMOKE_WORKFLOW);
-const matrixEnv = stepEnv(matrix, MATRIX_JOB, RUN_STEP, MATRIX_WORKFLOW);
+const suiteEnv = stepEnv(suiteWf, SUITE_JOB, RUN_STEP, SUITE_WORKFLOW);
 
 describe("parsers against the real workflow files", () => {
 	test("dispatchInput extracts the smoke provider choice (type + options + default)", () => {
@@ -49,16 +56,17 @@ describe("parsers against the real workflow files", () => {
 		expect(suiteInput.type).toBe("choice");
 	});
 
-	test("stepEnv extracts a realistic credential block from both workflows", () => {
+	test("stepEnv extracts a realistic credential block from both lanes", () => {
 		expect(smokeEnv).toContainKey("DAYTONA_API_KEY");
-		expect(matrixEnv).toContainKey("E2B_API_KEY");
+		// The matrix lane's credential block lives in the reusable bench-suite.yml.
+		expect(suiteEnv).toContainKey("E2B_API_KEY");
 		// A real block (credentials + runtime context), not a parse fragment.
 		expect(Object.keys(smokeEnv).length).toBeGreaterThanOrEqual(8);
 	});
 
 	test("both live-run jobs reserve host margin beyond the longest suite", () => {
 		expect(jobTimeoutMinutes(smoke, SMOKE_JOB, SMOKE_WORKFLOW)).toBe(180);
-		expect(jobTimeoutMinutes(matrix, MATRIX_JOB, MATRIX_WORKFLOW)).toBe(180);
+		expect(jobTimeoutMinutes(suiteWf, SUITE_JOB, SUITE_WORKFLOW)).toBe(180);
 	});
 
 	test("dispatchInput throws on a missing input instead of passing vacuously", () => {
@@ -185,24 +193,24 @@ describe("checkCredentialEnv", () => {
 		expect(required.get("MODAL_TOKEN_ID")).toEqual(["modal"]);
 	});
 
-	test("flags a required key dropped from the matrix block, naming key and file", () => {
-		const { E2B_API_KEY: _, ...drifted } = matrixEnv;
+	test("flags a required key dropped from the matrix (reusable) block, naming key and file", () => {
+		const { E2B_API_KEY: _, ...drifted } = suiteEnv;
 		const errors = checkCredentialEnv({
 			[SMOKE_WORKFLOW]: smokeEnv,
-			[MATRIX_WORKFLOW]: drifted,
+			[SUITE_WORKFLOW]: drifted,
 		});
 		expect(errors).toHaveLength(1);
 		expect(errors[0]).toContain("E2B_API_KEY");
 		expect(errors[0]).toContain("required by provider e2b");
-		expect(errors[0]).toContain(MATRIX_WORKFLOW);
+		expect(errors[0]).toContain(SUITE_WORKFLOW);
 		expect(errors[0]).not.toContain(SMOKE_WORKFLOW);
 	});
 
 	test("flags a shared key whose value expression differs across the two lanes", () => {
-		const drifted = { ...matrixEnv, DAYTONA_API_KEY: `\${{ secrets.DAYTONA_API_KEY_OTHER }}` };
+		const drifted = { ...suiteEnv, DAYTONA_API_KEY: `\${{ secrets.DAYTONA_API_KEY_OTHER }}` };
 		const errors = checkCredentialEnv({
 			[SMOKE_WORKFLOW]: smokeEnv,
-			[MATRIX_WORKFLOW]: drifted,
+			[SUITE_WORKFLOW]: drifted,
 		});
 		expect(errors).toHaveLength(1);
 		expect(errors[0]).toContain("DAYTONA_API_KEY:");
@@ -213,9 +221,52 @@ describe("checkCredentialEnv", () => {
 	test("tolerates extra runtime-context vars beyond the required credentials", () => {
 		const errors = checkCredentialEnv({
 			[SMOKE_WORKFLOW]: { ...smokeEnv, SOME_RUNTIME_CONTEXT: "x" },
-			[MATRIX_WORKFLOW]: matrixEnv,
+			[SUITE_WORKFLOW]: suiteEnv,
 		});
 		expect(errors).toEqual([]);
+	});
+});
+
+describe("checkSuiteJobCoverage", () => {
+	const realJobs = matrixSuiteJobs(matrix);
+
+	test("matrixSuiteJobs extracts exactly one job per registered suite", () => {
+		expect(new Set(realJobs.map((j) => j.suite))).toEqual(new Set(SUITE_NAMES));
+		expect(realJobs).toHaveLength(SUITE_NAMES.length);
+	});
+
+	test("the real matrix suite jobs cover SUITE_NAMES", () => {
+		expect(checkSuiteJobCoverage(realJobs)).toEqual([]);
+	});
+
+	test("flags a registry suite that no matrix job benchmarks", () => {
+		const [dropped] = SUITE_NAMES;
+		const errors = checkSuiteJobCoverage(realJobs.filter((j) => j.suite !== dropped));
+		expect(errors).toHaveLength(1);
+		expect(errors[0]).toContain(`no matrix job benchmarks suite "${dropped}"`);
+		expect(errors[0]).toContain("bench-suite.yml");
+	});
+
+	test("flags a job dispatching a suite the registry doesn't know", () => {
+		const errors = checkSuiteJobCoverage([...realJobs, { jobId: "gpu", suite: "gpu" }]);
+		expect(errors).toHaveLength(1);
+		expect(errors[0]).toContain('suite "gpu" which is not in SUITE_NAMES');
+	});
+
+	test("flags a suite dispatched by two jobs", () => {
+		// "system" is a registered suite already covered by realJobs, so a second job for it is a dup.
+		const errors = checkSuiteJobCoverage([...realJobs, { jobId: "dup", suite: "system" }]);
+		expect(errors).toHaveLength(1);
+		expect(errors[0]).toContain("more than one job");
+	});
+
+	test("matrixSuiteJobs throws on a reusable-caller job with no string suite", () => {
+		const yaml = Bun.YAML.stringify({
+			jobs: { bad: { uses: "./.github/workflows/bench-suite.yml", with: { providers: "[]" } } },
+		});
+		expect(() => matrixSuiteJobs(Bun.YAML.parse(yaml), "synthetic.yml")).toThrow(
+			'without a string "suite" input',
+		);
 	});
 });
 


### PR DESCRIPTION
## What

Refactors `bench-matrix.yml` from a single opaque `bench` job (one 2-D `provider × suite` matrix) into **one intuitively-named job per suite, grouped by dimension**, each fanning out over the selected providers via a new reusable **`bench-suite.yml`** — mirroring `runner-benchmarking`'s `disk-io-comparison.yml`.

Cells now display as `system / e2b`, `memory / daytona`, … (grouped under their suite) instead of `bench (daytona, system)`.

## How

- **`.github/workflows/bench-suite.yml`** (new, reusable) owns the per-provider fan-out: the credential env block (scoped per `matrix.provider`), `environment: privileged`, the run step, and the shard upload — factored out so it isn't copy-pasted into every suite job. Callers pass `secrets: inherit` because the provider keys are **Environment secrets on `privileged`** (no repo copy), which a `uses:` caller can't resolve any other way.
- **`bench-matrix.yml`**: `plan` now emits just the provider axis; one named job per suite (grouped CPU / System / Memory / Disk / Network / Real-world) calls the reusable; `publish` unchanged (still main-only).
- **`plan-providers`** (new bin): emits `["e2b",…]` for the matrix axis. `plan-matrix` stays for local inspection.
- **Drift gates** (`tooling/repo-checks`):
  - `workflow-registry-sync` gains **Invariant 6** — `bench-matrix.yml` must have exactly one matrix job per `SUITE_NAMES` entry, so the hand-enumerated jobs stay registry-driven (a new suite fails CI until its job is added). Credential/timeout invariants now read the reusable workflow.
  - `workflow-hardening` needed **no change** — its Invariant 3 already resolves the local `uses:` callee and confirms *it* self-gates on `environment: privileged`.
- **zizmor**: file-scoped `secrets-inherit` accept for `bench-matrix.yml`, with justification.
- **Docs**: `ci-secrets.md`, `methodology.md`, `CONTRIBUTING.md`, `apps/cli/README.md` updated.

## Tradeoff

GHA can't dynamically generate *named* jobs, so the suite jobs are hand-enumerated (adding a suite now needs a job here) — but Invariant 6 makes that a hard CI failure rather than a silent gap, preserving the "registry drives CI" guarantee.

## Verification

`bun test` (all packages), `typecheck`, `biome check`, `actionlint`, and `zizmor` (CI flags) all green locally. Dispatched on this branch (`allow_branch: true`) to confirm end-to-end.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Refactor the benchmark CI to a single dynamic suite matrix that calls a reusable `bench-suite.yml`, nesting provider cells under each suite and allowing targeted runs via a new `suites` input; adds clean per‑cell results in the Actions UI.

- **Refactors**
  - Added `.github/workflows/bench-suite.yml` to fan out providers with `environment: privileged`, per‑provider secret scoping, 180‑min timeout, and shard upload.
  - Rewrote `.github/workflows/bench-matrix.yml` to one `suite` matrix job (`strategy.matrix.suite: fromJSON(needs.plan.outputs.suites)`, `name`/`with.suite: ${{ matrix.suite }}`) that calls the reusable workflow; `publish` now needs `suite`.
  - `plan` now emits both axes via `plan-providers` and `plan-suites` (blank `suites` = all), removing hand‑enumerated suite jobs.
  - `bench-suite.ts` writes a job summary and notice/error annotations for each cell.
  - Drift gate reads the reusable workflow for credential/timeout checks and verifies the single suite‑matrix caller’s wiring; tests updated; `zizmor` accepts `secrets: inherit` for `bench-matrix.yml`.

- **Migration**
  - Adding a suite needs no workflow edit; it’s picked up automatically via `plan-suites`. Keep it dispatchable by adding it to `bench-smoke` options.

<sup>Written for commit aad2a205e5fc53c9c4358b210170d12359adb8eb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/starslingdev/hpc-sandbox-benchmarks/pull/198?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Benchmark runs now execute as separate suite jobs, automatically expanding across selected providers.
  * Added provider planning and discovery support, including provider and suite listing options.
  * Benchmark results continue to be uploaded separately for each provider and suite.

* **Documentation**
  * Updated CI, benchmarking, contribution, and secrets documentation to reflect the new workflow.

* **Bug Fixes**
  * Added validation to ensure every registered benchmark suite is represented exactly once.

* **Tests**
  * Expanded coverage for provider selection, discovery commands, and workflow suite validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->