### PR TITLE
refactor(ci): suite-matrix caller for native nesting + clean cell results

### DIFF
--- a/.github/workflows/bench-matrix.yml
+++ b/.github/workflows/bench-matrix.yml
@@ -93,9 +93,14 @@ jobs:
   # One matrix cell per selected suite → reusable workflow call. GitHub nests the reusable's provider
   # matrix under each suite name, so the Actions UI shows expandable "<suite>" groups with "<provider>"
   # children (display: "<suite> / <provider>"). fail-fast stays off so one bad suite doesn't cancel peers.
+  # The fork/branch guard is repeated here (not only inherited via `needs: plan`) so the job stays
+  # explicit when read in isolation — matching every other live-run job in the repo.
   suite:
     name: ${{ matrix.suite }}
     needs: plan
+    if: >
+      github.repository == 'starslingdev/hpc-sandbox-benchmarks' &&
+      (github.ref == 'refs/heads/main' || inputs.allow_branch)
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/bench-matrix.yml
+++ b/.github/workflows/bench-matrix.yml
@@ -1,14 +1,17 @@
 name: Bench matrix
 
-# Fan the live benchmark out across the full provider × suite matrix: one job per (provider, suite)
-# cell, each spinning up a real sandbox, running its suite, and uploading the normalized Run as an
-# artifact. The matrix is computed from the SUITES × PROVIDERS registries by `plan-matrix`; each suite
-# cell runs all of its registered leaves (for example, system runs pts/git and network runs
-# pts/fast-cli), rather than giving each PTS profile its own row. Adding a provider or suite to its
-# registry grows CI with no workflow edit. Off the PR path (real sandbox time + provider credentials);
-# main is the default, while an explicit allow_branch dispatch supports pre-merge validation. Every
-# benchmark cell remains gated by Environment `privileged` (required reviewers + environment secrets
-# — see docs/ci-secrets.md), and publishing stays main-only.
+# Fan the live benchmark out across the provider × suite matrix using GitHub's native reusable-workflow
+# nesting. `plan` emits both axes; a single suite-matrix job calls the reusable bench-suite.yml once per
+# suite (`name: ${{ matrix.suite }}`), and that reusable fans out providers (`name: ${{ matrix.provider
+# }}`) — so each cell displays as "<suite> / <provider>" (e.g. "system / e2b") and provider cells nest
+# under their suite in the Actions UI. Adding a suite is a schema change only: the suite axis is
+# `fromJSON(needs.plan.outputs.suites)`, kept in lockstep by the workflow-registry-sync gate. The
+# `suites` dispatch input narrows that axis to a subset (blank = every registered suite) — the
+# targeted/pre-merge knob, so a validation dispatch can run just one suite instead of the whole matrix.
+# Off the PR path (real sandbox time + provider credentials); main is the default, while an explicit
+# allow_branch dispatch supports pre-merge validation. Every benchmark cell remains gated by Environment
+# `privileged` (required reviewers + environment secrets — see docs/ci-secrets.md, declared inside
+# bench-suite.yml), and publishing stays main-only.
 on:
   workflow_dispatch:
     inputs:
@@ -19,8 +22,17 @@ on:
         # The providers with a baked toolchain artifact and credentials in CI. blaxel boots the stock
         # base image (nothing baked for it), so it is excluded by default rather than burning ~150min
         # of runner time per suite on cells that cannot produce a comparable result. Pass it explicitly
-        # to include it; `plan-matrix` rejects any name that is not in the registry.
+        # to include it; `plan-providers` rejects any name that is not in the registry.
         default: e2b,daytona,modal
+      suites:
+        description: 'Comma-separated suites to run (blank = every registered suite). E.g. "network" for a targeted pre-merge run.'
+        required: false
+        type: string
+        # Blank runs every registered suite (the main-publish default). A subset narrows the suite-matrix
+        # axis to just those suites — the pre-merge/targeted knob so a validation dispatch needn't spend
+        # the whole matrix. `plan-suites` rejects any name that is not in the registry, so a typo fails
+        # the plan.
+        default: ''
       allow_branch:
         description: 'Allow benchmark cells on a non-main ref (publish remains main-only).'
         required: false
@@ -37,9 +49,11 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
-  # Compute the provider × suite matrix once, as the single $GITHUB_OUTPUT contract the fan-out reads.
-  # No secrets — plan stays off the privileged environment so approval isn't needed just to dry-run
-  # the matrix shape; a non-main run requires the explicit dispatch opt-in below.
+  # Compute both matrix axes once, as the single $GITHUB_OUTPUT contract the suite job reads. No
+  # secrets — plan stays off the privileged environment so approval isn't needed just to dry-run the
+  # axes; a non-main run requires the explicit dispatch opt-in below. The suite job `needs: plan`, so
+  # this guard also gates the fan-out: a skipped plan (fork, or a non-main run without allow_branch)
+  # skips every cell.
   plan:
     name: Plan matrix
     if: >
@@ -47,7 +61,8 @@ jobs:
       (github.ref == 'refs/heads/main' || inputs.allow_branch)
     runs-on: ubuntu-24.04
     outputs:
-      matrix: ${{ steps.plan.outputs.matrix }}
+      providers: ${{ steps.plan.outputs.providers }}
+      suites: ${{ steps.plan.outputs.suites }}
     steps:
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
@@ -60,92 +75,39 @@ jobs:
           bun-version: 1.3.14
       - name: Install dependencies
         run: bun install --frozen-lockfile --ignore-scripts
-      # plan-matrix prints one line of compact JSON ({"include":[...]}) — the strategy.matrix contract.
+      # plan-providers / plan-suites each write their axis to $GITHUB_OUTPUT via emitStepOutputs and
+      # log through @actions/core (foldable groups + notices). An unregistered provider or suite name
+      # fails the step, so a typo fails the plan instead of quietly publishing a dataset with it
+      # missing or running nothing.
       - name: Plan
         id: plan
-        # The dispatch input reaches plan-matrix through the environment, never interpolated into the
+        # The dispatch inputs reach the planners through the environment, never interpolated into the
         # shell, so a crafted input can't inject into the runner command.
         env:
           BENCH_PROVIDERS: ${{ inputs.providers }}
-        # Capture into a variable first so a plan-matrix.ts failure aborts the step (set -e): inlining
-        # the command substitution inside `echo` would mask its exit code behind echo's 0. An
-        # unregistered provider name exits 2 here, so a typo fails the plan instead of quietly
-        # publishing a dataset with that provider missing.
+          BENCH_SUITES: ${{ inputs.suites }}
         run: |
-          matrix="$(bun apps/cli/src/bin/plan-matrix.ts)"
-          echo "matrix=$matrix" >> "$GITHUB_OUTPUT"
+          bun apps/cli/src/bin/plan-providers.ts
+          bun apps/cli/src/bin/plan-suites.ts
 
-  bench:
-    name: ${{ matrix.suite }} on ${{ matrix.provider }}
+  # One matrix cell per selected suite → reusable workflow call. GitHub nests the reusable's provider
+  # matrix under each suite name, so the Actions UI shows expandable "<suite>" groups with "<provider>"
+  # children (display: "<suite> / <provider>"). fail-fast stays off so one bad suite doesn't cancel peers.
+  suite:
+    name: ${{ matrix.suite }}
     needs: plan
-    if: >
-      github.repository == 'starslingdev/hpc-sandbox-benchmarks' &&
-      (github.ref == 'refs/heads/main' || inputs.allow_branch)
-    # The ephemeral self-hosted label is reaped after 70 minutes even while a step is healthy. The
-    # full CPU-generic and real-world matrices legitimately exceed that on slower providers, leaving
-    # the step stuck `in_progress` with no logs/artifact. Hosted runners honor timeout-minutes below;
-    # 180 minutes also leaves teardown/artifact margin around the longest 155-minute suite budget.
-    runs-on: ubuntu-24.04
-    environment: privileged
-    timeout-minutes: 180
     strategy:
-      # One cell's failure (a flaky provider) must not cancel the rest of the matrix.
       fail-fast: false
-      matrix: ${{ fromJSON(needs.plan.outputs.matrix) }}
-    steps:
-      - name: Checkout
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-        with:
-          # This cell only reads code (the sandbox clones via BENCH_REPO_TOKEN when set, not the
-          # checkout's credentials), so don't persist the job token in .git/config.
-          persist-credentials: false
-
-      - name: Set up Bun
-        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
-        with:
-          bun-version: 1.3.14
-
-      - name: Install dependencies
-        run: bun install --frozen-lockfile --ignore-scripts
-
-      # Drive the provider SDK to create a sandbox, run the suite, collect results, and normalize. The
-      # cell's provider/suite are matrix values, passed through the environment (never interpolated into
-      # the shell) so a registry value can't inject into the runner command.
-      - name: Run suite and normalize
-        env:
-          BENCH_REPO_REF: ${{ github.sha }}
-          # Optional once the repo is public (anonymous clone works). Still passed so private forks and
-          # rate-limited clones keep working via the short-lived job token.
-          BENCH_REPO_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          BENCH_PROVIDER: ${{ matrix.provider }}
-          BENCH_SUITE: ${{ matrix.suite }}
-          # Scope every provider credential to the cell that actually uses it: a cell receives ONLY
-          # the secret(s) for its own `matrix.provider`, so a compromised adapter or suite can't read
-          # another provider's credential out of the environment. A non-matching provider evaluates to
-          # '', which the config gatekeeper treats as unset (packages/providers/src/lib/config.ts:
-          # empty ⇒ unset), exactly like an unsynced secret — so blanking the others is inert.
-          DAYTONA_API_KEY: ${{ matrix.provider == 'daytona' && secrets.DAYTONA_API_KEY || '' }}
-          # Boot daytona sandboxes in the active region (us-west-2); the default applies only to the
-          # daytona cell so an unsynced secret can't fail the config gatekeeper at module load.
-          DAYTONA_TARGET: ${{ matrix.provider == 'daytona' && (secrets.DAYTONA_TARGET || 'us-west-2') || '' }}
-          E2B_API_KEY: ${{ matrix.provider == 'e2b' && secrets.E2B_API_KEY || '' }}
-          MODAL_TOKEN_ID: ${{ matrix.provider == 'modal' && secrets.MODAL_TOKEN_ID || '' }}
-          MODAL_TOKEN_SECRET: ${{ matrix.provider == 'modal' && secrets.MODAL_TOKEN_SECRET || '' }}
-          BL_API_KEY: ${{ matrix.provider == 'blaxel' && secrets.BL_API_KEY || '' }}
-          BL_WORKSPACE: ${{ matrix.provider == 'blaxel' && secrets.BL_WORKSPACE || '' }}
-          NOVITA_API_KEY: ${{ matrix.provider == 'novita' && secrets.NOVITA_API_KEY || '' }}
-        run: bun apps/cli/src/bin/bench-suite.ts "$BENCH_PROVIDER" "$BENCH_SUITE" "$GITHUB_RUN_ID"
-
-      - name: Upload Run + raw results
-        if: always()
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
-        with:
-          # Per-cell artifact name so every (provider, suite) shard uploads independently.
-          name: bench-${{ matrix.suite }}-${{ matrix.provider }}-${{ github.run_id }}
-          path: data/
-          # A successful run always writes data/runs/<id>.json (even an all-skipped Run), so an empty
-          # data/ means the job is genuinely broken — fail the upload rather than bury a warning.
-          if-no-files-found: error
+      matrix:
+        suite: ${{ fromJSON(needs.plan.outputs.suites) }}
+    # `secrets: inherit` keeps repository secrets / token context available to the callee; Environment
+    # secrets on `privileged` are resolved by the reusable job's own `environment:` declaration (a
+    # `uses:` caller can't set `environment:`).
+    uses: ./.github/workflows/bench-suite.yml
+    with:
+      providers: ${{ needs.plan.outputs.providers }}
+      suite: ${{ matrix.suite }}
+    secrets: inherit
 
   # Collect every shard Run, aggregate into one candidate, gate it (promote), regenerate the public
   # leaderboard, and open the PR that lands both on main. The logic lives in the reusable
@@ -154,12 +116,14 @@ jobs:
   # is declared inside that reusable workflow — a `uses:` caller can't set `environment:` itself.
   publish:
     name: Aggregate + promote dataset
-    needs: [plan, bench]
-    # Run even if some matrix cells failed (fail-fast is off) so the successful shards still publish:
-    # `aggregate` exits non-zero when zero shards are found and `promote` gates on >=1 validated
-    # provider, so the quality bar is preserved. `!cancelled()` still lets an explicit cancel stop it.
-    # `!cancelled()` opts out of the implicit success() gate, so require `plan` explicitly: a skipped
-    # or failed plan means there is no matrix contract, so there is nothing to publish.
+    needs:
+      - plan
+      - suite
+    # Run even if some suite matrix cells failed (fail-fast is off) so the successful shards still
+    # publish: `aggregate` exits non-zero when zero shards are found and `promote` gates on >=1
+    # validated provider, so the quality bar is preserved. `!cancelled()` still lets an explicit cancel
+    # stop it. `!cancelled()` opts out of the implicit success() gate, so require `plan` explicitly: a
+    # skipped or failed plan means there is no provider axis, so there is nothing to publish.
     if: >
       !cancelled() &&
       needs.plan.result == 'success' &&

--- a/.github/workflows/bench-suite.yml
+++ b/.github/workflows/bench-suite.yml
@@ -1,0 +1,109 @@
+name: Benchmark suite (reusable)
+
+# One suite, fanned out across a provider matrix. bench-matrix.yml calls this once per suite via its
+# suite-matrix job (`name: ${{ matrix.suite }}`), passing the plan's selected provider list — so N
+# providers nest under one suite label in the Actions UI and cells display as "<suite> / <provider>".
+# Factoring the shared cell here (checkout → run → upload, plus the per-provider credential wiring)
+# keeps that block in ONE place instead of copy-pasted into every suite job, mirroring
+# runner-benchmarking's reusable bench-suite.yml.
+#
+# The artifact name (bench-<suite>-<provider>-<run_id>) is load-bearing: publish-dataset.yml downloads
+# the shards by the `bench-*-<run_id>` pattern and aggregates them — keep the two in lockstep.
+#
+# Environment `privileged` (required reviewers + environment secrets — see docs/ci-secrets.md) lives on
+# the fan-out job here: a `uses:` caller can't declare `environment:`, so the approval gate and the
+# provider secrets are enforced at this layer. Environment secrets resolve from this job's
+# `environment:` declaration; the caller may still pass `secrets: inherit` for repository-level
+# secrets / token context.
+on:
+  workflow_call:
+    inputs:
+      providers:
+        description: 'JSON array of provider ids to fan out over (the plan job selected provider list).'
+        required: true
+        type: string
+      suite:
+        description: 'Suite to run — the bench-suite.ts arg and the artifact-name key. A registered SUITE_NAMES value.'
+        required: true
+        type: string
+
+# Least privilege: the fan-out only reads the checked-out code and uploads artifacts.
+permissions:
+  contents: read
+
+jobs:
+  bench:
+    # Display as "<caller suite job> / <provider>", e.g. "system / e2b" — the provider cells nest
+    # under their suite's job name in the Actions UI (GitHub-native reusable-workflow nesting).
+    name: ${{ matrix.provider }}
+    environment: privileged
+    # The ephemeral self-hosted label is reaped after 70 minutes even while a step is healthy. The
+    # full CPU-generic and real-world matrices legitimately exceed that on slower providers, leaving
+    # the step stuck `in_progress` with no logs/artifact. Hosted runners honor timeout-minutes below;
+    # 180 minutes also leaves teardown/artifact margin around the longest 155-minute suite budget.
+    # (workflow-registry-sync asserts this stays above the longest registered sandbox lifetime.)
+    runs-on: ubuntu-24.04
+    timeout-minutes: 180
+    strategy:
+      # One cell's failure (a flaky provider) must not cancel the rest of the matrix.
+      fail-fast: false
+      matrix:
+        provider: ${{ fromJSON(inputs.providers) }}
+    steps:
+      # Third-party actions are pinned to a commit SHA (the tag comment is for humans) so a
+      # moved/compromised tag can't silently change what runs.
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          # This cell only reads code (the sandbox clones via BENCH_REPO_TOKEN when set, not the
+          # checkout's credentials), so don't persist the job token in .git/config.
+          persist-credentials: false
+
+      - name: Set up Bun
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
+        with:
+          bun-version: 1.3.14
+
+      # Frozen lockfile + no lifecycle scripts, matching bunfig.toml's supply-chain posture.
+      - name: Install dependencies
+        run: bun install --frozen-lockfile --ignore-scripts
+
+      # Drive the provider SDK to create a sandbox, run the suite, collect results, and normalize. The
+      # cell's provider is a matrix value and its suite the reusable input, both passed through the
+      # environment (never interpolated into the shell) so neither can inject into the runner command.
+      # On success/failure the bin also writes a compact job summary + run annotation (clean Results).
+      - name: Run suite and normalize
+        env:
+          BENCH_REPO_REF: ${{ github.sha }}
+          # Optional once the repo is public (anonymous clone works). Still passed so private forks and
+          # rate-limited clones keep working via the short-lived job token.
+          BENCH_REPO_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          BENCH_PROVIDER: ${{ matrix.provider }}
+          BENCH_SUITE: ${{ inputs.suite }}
+          # Scope every provider credential to the cell that actually uses it: a cell receives ONLY
+          # the secret(s) for its own `matrix.provider`, so a compromised adapter or suite can't read
+          # another provider's credential out of the environment. A non-matching provider evaluates to
+          # '', which the config gatekeeper treats as unset (packages/providers/src/lib/config.ts:
+          # empty ⇒ unset), exactly like an unsynced secret — so blanking the others is inert.
+          DAYTONA_API_KEY: ${{ matrix.provider == 'daytona' && secrets.DAYTONA_API_KEY || '' }}
+          # Boot daytona sandboxes in the active region (us-west-2); the default applies only to the
+          # daytona cell so an unsynced secret can't fail the config gatekeeper at module load.
+          DAYTONA_TARGET: ${{ matrix.provider == 'daytona' && (secrets.DAYTONA_TARGET || 'us-west-2') || '' }}
+          E2B_API_KEY: ${{ matrix.provider == 'e2b' && secrets.E2B_API_KEY || '' }}
+          MODAL_TOKEN_ID: ${{ matrix.provider == 'modal' && secrets.MODAL_TOKEN_ID || '' }}
+          MODAL_TOKEN_SECRET: ${{ matrix.provider == 'modal' && secrets.MODAL_TOKEN_SECRET || '' }}
+          BL_API_KEY: ${{ matrix.provider == 'blaxel' && secrets.BL_API_KEY || '' }}
+          BL_WORKSPACE: ${{ matrix.provider == 'blaxel' && secrets.BL_WORKSPACE || '' }}
+          NOVITA_API_KEY: ${{ matrix.provider == 'novita' && secrets.NOVITA_API_KEY || '' }}
+        run: bun apps/cli/src/bin/bench-suite.ts "$BENCH_PROVIDER" "$BENCH_SUITE" "$GITHUB_RUN_ID"
+
+      - name: Upload Run + raw results
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          # Per-cell artifact name so every (provider, suite) shard uploads independently.
+          name: bench-${{ inputs.suite }}-${{ matrix.provider }}-${{ github.run_id }}
+          path: data/
+          # A successful run always writes data/runs/<id>.json (even an all-skipped Run), so an empty
+          # data/ means the job is genuinely broken — fail the upload rather than bury a warning.
+          if-no-files-found: error

--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -10,3 +10,14 @@ rules:
       # persist-credentials: false; this one can't, by design. (Filename-scoped, not repo-wide — this
       # reusable workflow's only checkout is the pushing one, so just its finding is accepted.)
       - publish-dataset.yml
+  secrets-inherit:
+    ignore:
+      # bench-matrix.yml's suite-matrix job calls the reusable bench-suite.yml with `secrets: inherit`.
+      # The reusable's fan-out job declares `environment: privileged`, which raises the approval gate and
+      # scopes the provider ENVIRONMENT secrets (docs/ci-secrets.md) to that job, where it re-scopes each
+      # credential to its own provider cell (`matrix.provider == 'daytona' && secrets.DAYTONA_API_KEY ||
+      # ''`). `inherit` hands the reusable the caller's secret / token context in one line instead of
+      # enumerating each secret as a `workflow_call` input (a `uses:` caller can't declare the
+      # environment to resolve them itself). The workflow-hardening drift gate independently verifies the
+      # callee self-gates on `privileged`. (Filename-scoped, not repo-wide.)
+      - bench-matrix.yml

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -63,7 +63,11 @@ bun run check:catalog-drift                                    # fail if the com
 2. **Producer tasks** — add the mise task(s) under `.mise/tasks/benchmark/**` that the `commands` name,
    driving the benchmark via the helpers in [`lib/bench.sh`](./lib/bench.sh) (e.g. `run_pts_benchmark`).
    An orchestrator is a task *file*; its leaves live in a sibling *directory* (a task path can't be both).
-3. The CI matrix picks the suite up automatically (`plan-matrix` crosses `PROVIDERS × SUITE_NAMES`).
+3. **No matrix job edit** — `bench-matrix.yml` matrices over `plan.outputs.suites` (from `SUITE_NAMES`
+   via `plan-suites`), so a new suite is picked up automatically and nests as `<suite> / <provider>` in
+   the Actions UI; a dispatch can still narrow to a subset with the `suites` input. The
+   workflow-registry-sync drift gate keeps that nesting wiring honest. Add it to the `bench-smoke` suite
+   `options` too so it stays dispatchable on its own.
 
 ## Add a metric
 

--- a/apps/cli/README.md
+++ b/apps/cli/README.md
@@ -8,7 +8,9 @@
   `--iterations N` (cold-start cycles/provider), `--control-plane-samples N`, `--no-snapshot`. Providers
   with absent creds skip; per-Metric distributions go to stdout JSON, a timing log to stderr.
 - `bench-suite` — run the full suite across the matrix.
-- `plan-matrix` — print the **provider × suite** benchmark matrix as **single-line compact JSON** for `$GITHUB_OUTPUT` (the `bench-matrix` workflow's fan-out contract).
+- `plan-providers` — print the **selected provider ids** as **single-line compact JSON** (honors `BENCH_PROVIDERS`); in Actions writes `providers=` via `emitStepOutputs` and logs through `@actions/core`.
+- `plan-suites` — print the **selected suite names** as **single-line compact JSON** (blank `BENCH_SUITES` = every suite — the targeted/pre-merge knob); in Actions writes `suites=` the same way.
+- `plan-matrix` — print the full **provider × suite** benchmark matrix as **single-line compact JSON** (cell listing for local inspection / discovery; CI fans out via `plan-providers` + `plan-suites`).
 - `build-template` — build a provider's sandbox template.
 - `normalize` — turn raw runs into normalized run documents.
 - `aggregate` — merge shard Runs into one candidate.

--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -9,6 +9,8 @@
     "bench-smoke": "./src/bin/bench-smoke.ts",
     "bake": "./src/bin/bake.ts",
     "plan-matrix": "./src/bin/plan-matrix.ts",
+    "plan-providers": "./src/bin/plan-providers.ts",
+    "plan-suites": "./src/bin/plan-suites.ts",
     "build-template": "./src/bin/build-template.ts",
     "normalize": "./src/bin/normalize.ts",
     "aggregate": "./src/bin/aggregate.ts",

--- a/apps/cli/src/bin/aggregate.ts
+++ b/apps/cli/src/bin/aggregate.ts
@@ -12,16 +12,12 @@ import { parseRun } from "@sandbox-benchmarks/schema";
 import {
 	fail,
 	inActions,
+	logInfo,
 	logProviderStatuses,
 	providerSummaryRows,
 	withGroup,
 	writeJobSummary,
 } from "../lib/actions-log.ts";
-
-function logInfo(message: string): void {
-	if (inActions()) core.info(message);
-	else console.error(message);
-}
 
 if (import.meta.main) {
 	const [runId, outDir, ...shardFiles] = process.argv.slice(2);

--- a/apps/cli/src/bin/aggregate.ts
+++ b/apps/cli/src/bin/aggregate.ts
@@ -2,34 +2,87 @@
 // `aggregate` — merge the per-shard Run documents of one benchmark run (the CI matrix emits one per
 // `(provider, suite)` cell) into a single candidate Run, written to a candidate dataset + index. This
 // is the collect half of candidate→promote: `promote` then validates and publishes the candidate.
+// Uses @actions/core for foldable groups, debug metadata, annotations, and a job summary in CI.
 
 import { readFileSync } from "node:fs";
 import { join } from "node:path";
-import { aggregateRuns, summarizeRun, writeRunDocument } from "@sandbox-benchmarks/results";
+import * as core from "@actions/core";
+import { aggregateRuns, writeRunDocument } from "@sandbox-benchmarks/results";
 import { parseRun } from "@sandbox-benchmarks/schema";
+import {
+	fail,
+	inActions,
+	logProviderStatuses,
+	providerSummaryRows,
+	withGroup,
+	writeJobSummary,
+} from "../lib/actions-log.ts";
+
+function logInfo(message: string): void {
+	if (inActions()) core.info(message);
+	else console.error(message);
+}
 
 if (import.meta.main) {
 	const [runId, outDir, ...shardFiles] = process.argv.slice(2);
 	if (!runId || !outDir || shardFiles.length === 0) {
-		console.error("usage: aggregate <runId> <candidateDir> <shardRun.json...>");
-		process.exit(1);
+		fail("usage: aggregate <runId> <candidateDir> <shardRun.json...>", {
+			properties: { title: "aggregate usage" },
+			exitCode: 2,
+		});
 	}
 
+	logInfo(`Aggregating ${shardFiles.length} shard(s) for run ${runId}`);
+	if (inActions()) core.debug(JSON.stringify({ runId, outDir, shards: shardFiles }));
+
 	// Parse every shard at the boundary so a malformed artifact fails loudly here, not mid-merge.
-	const shards = shardFiles.map((file) => parseRun(JSON.parse(readFileSync(file, "utf8"))));
-	const merged = aggregateRuns(shards);
+	const shards = await withGroup(`Parse ${shardFiles.length} shard Run document(s)`, async () => {
+		return shardFiles.map((file) => {
+			if (inActions()) core.debug(`parse ${file}`);
+			return parseRun(JSON.parse(readFileSync(file, "utf8")));
+		});
+	});
+
+	const merged = await withGroup("Merge shards", async () => {
+		const result = aggregateRuns(shards);
+		logInfo(`Merged runId=${result.runId} providers=${result.providers.length} sha=${result.sha}`);
+		return result;
+	});
 
 	// The caller-supplied runId must match the id the shards agree on (aggregateRuns enforces shard
 	// agreement); otherwise a wrong argument would be silently ignored in favour of merged.runId.
 	if (merged.runId !== runId) {
-		console.error(`runId mismatch: argument "${runId}" but the shards agree on "${merged.runId}"`);
-		process.exit(1);
+		fail(`runId mismatch: argument "${runId}" but the shards agree on "${merged.runId}"`, {
+			properties: { title: "aggregate runId mismatch" },
+		});
 	}
 
 	const outFile = join(outDir, "runs", `${merged.runId}.json`);
 	const indexFile = join(outDir, "index.json");
-	writeRunDocument(merged, outFile, indexFile);
+	await withGroup(`Write candidate ${outFile}`, async () => {
+		writeRunDocument(merged, outFile, indexFile);
+		logInfo(`Wrote candidate Run → ${outFile}`);
+		// Already inside withGroup — don't nest another ::group::.
+		logProviderStatuses(merged, { grouped: false });
+	});
 
-	console.log(`\nAggregated ${shards.length} shard(s) for ${runId} → ${outFile}`);
-	for (const line of summarizeRun(merged)) console.log(line);
+	const validated = merged.providers.filter((p) => p.validationStatus === "validated").length;
+	await writeJobSummary({
+		heading: `Aggregate ${runId}`,
+		fields: [
+			["Status", "success", "plain"],
+			["Run id", runId, "code"],
+			["Shards", String(shards.length), "plain"],
+			["Providers", String(merged.providers.length), "plain"],
+			["Validated", String(validated), "plain"],
+			["SHA", merged.sha, "code"],
+			["Candidate", outFile, "code"],
+		],
+		tables: [{ heading: "Provider status", rows: providerSummaryRows(merged) }],
+		annotation: {
+			failed: false,
+			title: `Aggregate ${runId}`,
+			message: `${shards.length} shard(s) → ${validated} validated provider(s)`,
+		},
+	});
 }

--- a/apps/cli/src/bin/aggregate.ts
+++ b/apps/cli/src/bin/aggregate.ts
@@ -59,7 +59,7 @@ if (import.meta.main) {
 		writeRunDocument(merged, outFile, indexFile);
 		logInfo(`Wrote candidate Run → ${outFile}`);
 		// Already inside withGroup — don't nest another ::group::.
-		logProviderStatuses(merged, { grouped: false });
+		await logProviderStatuses(merged, { grouped: false });
 	});
 
 	const validated = merged.providers.filter((p) => p.validationStatus === "validated").length;

--- a/apps/cli/src/bin/bench-suite.ts
+++ b/apps/cli/src/bin/bench-suite.ts
@@ -18,18 +18,16 @@ import type { Run } from "@sandbox-benchmarks/schema";
 import {
 	fail,
 	inActions,
+	logInfo,
 	logProviderStatuses,
+	logWarning,
 	providerSummaryRows,
 	withGroup,
 	writeJobSummary,
 } from "../lib/actions-log.ts";
 import { handleDiscovery } from "../lib/discovery.ts";
-import type { SuiteTaskPlan } from "../lib/suite-tasks.ts";
-import {
-	describeSuiteTasks,
-	suiteMetricSummaryRows,
-	suiteTaskSummaryRows,
-} from "../lib/suite-tasks.ts";
+import { suiteMetricSummaryRows, suiteTaskSummaryRows } from "../lib/suite-summary.ts";
+import { describeSuiteTasks, type SuiteTaskPlan } from "../lib/suite-tasks.ts";
 
 function plural(n: number, singular: string, pluralForm: string = `${singular}s`): string {
 	return `${n} ${n === 1 ? singular : pluralForm}`;
@@ -69,25 +67,32 @@ examples:
 
 Next: render the Run with \`leaderboard data/runs/<runId>.json\`.`;
 
+/** One exit path for every cell outcome — success, usage error, normalize failure, suite gap, require. */
 async function reportCell(opts: {
 	provider: string;
 	suite: string;
 	runId: string;
-	sha: string;
-	outFile: string;
-	run: Run;
+	sha?: string;
+	outFile?: string;
+	run?: Run;
 	failed: boolean;
 	detail?: string;
 	taskPlan?: SuiteTaskPlan;
 }): Promise<void> {
 	const title = `${opts.suite} / ${opts.provider}`;
 	const status = opts.failed ? "failure" : "success";
-	const provider = opts.run.providers.find((p) => p.providerId === opts.provider);
+	const provider = opts.run?.providers.find((p) => p.providerId === opts.provider);
 	const annotationMessage =
 		opts.detail ??
 		(provider
 			? `${provider.providerId} ${provider.validationStatus} metrics=${provider.metrics.length}`
 			: title);
+	const taskTables = opts.taskPlan
+		? [
+				{ heading: "Mise tasks", rows: suiteTaskSummaryRows(opts.taskPlan) },
+				{ heading: "Declared metrics", rows: suiteMetricSummaryRows(opts.taskPlan) },
+			]
+		: [];
 	await writeJobSummary({
 		heading: title,
 		fields: [
@@ -95,14 +100,14 @@ async function reportCell(opts: {
 			["Suite", opts.suite, "code"],
 			["Provider", opts.provider, "code"],
 			["Run id", opts.runId, "code"],
-			["SHA", opts.sha, "code"],
-			["Artifact", opts.outFile, "code"],
+			["SHA", opts.sha ?? "", "code"],
+			["Artifact", opts.outFile ?? "", "code"],
 			["Harness commands", opts.taskPlan?.commands.join(" · ") ?? "", "code"],
 			["Mise tasks", opts.taskPlan ? miseTaskSummary(opts.taskPlan) : "", "plain"],
-			["Validation", provider?.validationStatus ?? "absent", "plain"],
-			["Metrics", String(provider?.metrics.length ?? 0), "plain"],
-			["Suites covered", String(provider?.suitesCovered.length ?? 0), "plain"],
-			["Gaps", String(provider?.gaps.length ?? 0), "plain"],
+			["Validation", provider?.validationStatus ?? (opts.run ? "absent" : ""), "plain"],
+			["Metrics", provider ? String(provider.metrics.length) : "", "plain"],
+			["Suites covered", provider ? String(provider.suitesCovered.length) : "", "plain"],
+			["Gaps", provider ? String(provider.gaps.length) : "", "plain"],
 			["Observed CPU", provider?.observedSpecs.cpuModel ?? "", "code"],
 			[
 				"Spec matched",
@@ -111,19 +116,10 @@ async function reportCell(opts: {
 			],
 		],
 		tables: [
-			...(opts.taskPlan
-				? [
-						{
-							heading: "Mise tasks",
-							rows: suiteTaskSummaryRows(opts.taskPlan),
-						},
-						{
-							heading: "Declared metrics",
-							rows: suiteMetricSummaryRows(opts.taskPlan),
-						},
-					]
+			...taskTables,
+			...(opts.run
+				? [{ heading: "Provider status", rows: providerSummaryRows(opts.run) }]
 				: []),
-			{ heading: "Provider status", rows: providerSummaryRows(opts.run) },
 		],
 		detail: opts.detail,
 		annotation: {
@@ -132,6 +128,16 @@ async function reportCell(opts: {
 			message: annotationMessage,
 		},
 	});
+}
+
+type CellReport = Parameters<typeof reportCell>[0];
+
+/** Write the cell summary then fail without a second annotation. */
+async function failCell(
+	opts: Omit<CellReport, "failed"> & { detail: string },
+): Promise<never> {
+	await reportCell({ ...opts, failed: true });
+	return fail(opts.detail, { annotate: false });
 }
 
 if (import.meta.main) {
@@ -172,8 +178,8 @@ if (import.meta.main) {
 	const outFile = join("data", "runs", `${runId}.json`);
 	const indexFile = join("data", "runs", "index.json");
 
+	logInfo(`Benchmark cell ${cell}`);
 	if (inActions()) {
-		core.info(`Benchmark cell ${cell}`);
 		core.debug(
 			JSON.stringify({
 				provider,
@@ -185,8 +191,6 @@ if (import.meta.main) {
 				require: requiredProviders(argv),
 			}),
 		);
-	} else {
-		console.error(`Benchmark cell ${cell}`);
 	}
 
 	// Resolve the precise mise tasks + PTS pins before the sandbox run so the job summary can name
@@ -195,12 +199,11 @@ if (import.meta.main) {
 	await withGroup(`Discover suite tasks (${suite})`, async () => {
 		try {
 			taskPlan = await describeSuiteTasks(suite);
-			const log = inActions() ? core.info.bind(core) : (m: string) => console.error(m);
-			log(`commands: ${taskPlan.commands.join(" · ")}`);
+			logInfo(`commands: ${taskPlan.commands.join(" · ")}`);
 			for (const task of taskPlan.tasks) {
 				const pts = task.ptsProfile ? ` pts=${task.ptsProfile}` : "";
 				const prefix = task.resultsPrefix ? ` prefix=${task.resultsPrefix}` : "";
-				log(
+				logInfo(
 					`${task.role} ${task.task}${task.description ? ` — ${task.description}` : ""}${pts}${prefix}`,
 				);
 			}
@@ -214,8 +217,7 @@ if (import.meta.main) {
 			}
 		} catch (err) {
 			const msg = `Could not describe suite tasks for "${suite}": ${err instanceof Error ? err.message : String(err)}`;
-			if (inActions()) core.warning(msg, { title: cell });
-			else console.error(msg);
+			logWarning(msg, { title: cell });
 		}
 	});
 
@@ -235,39 +237,28 @@ if (import.meta.main) {
 				// Dimensions (the runtime half of the suite↔dimension↔metric contract).
 				resultsDir: join(rawRoot, provider, suite),
 			});
-			if (inActions()) core.info(`Suite "${suite}" completed on ${provider}`);
-			else console.error(`Suite "${suite}" completed on ${provider}`);
+			logInfo(`Suite "${suite}" completed on ${provider}`);
 		} catch (err) {
 			// A usage error (unknown provider/suite) produced no raw tree and no marker: there is nothing to
 			// normalize, and pretending otherwise would write an empty Run for a cell that never existed.
 			if (err instanceof SuiteUsageError) {
-				await writeJobSummary({
-					heading: cell,
-					fields: [
-						["Status", "failure", "plain"],
-						["Suite", suite, "code"],
-						["Provider", provider, "code"],
-						["Run id", runId, "code"],
-						["Harness commands", taskPlan?.commands.join(" · ") ?? "", "code"],
-						["Mise tasks", taskPlan ? miseTaskSummary(taskPlan) : "", "plain"],
-					],
-					tables: taskPlan
-						? [
-								{ heading: "Mise tasks", rows: suiteTaskSummaryRows(taskPlan) },
-								{ heading: "Declared metrics", rows: suiteMetricSummaryRows(taskPlan) },
-							]
-						: undefined,
+				await failCell({
+					provider,
+					suite,
+					runId,
+					sha,
+					outFile,
 					detail: err.message,
-					annotation: { failed: true, title: cell, message: err.message },
+					taskPlan,
 				});
-				fail(err.message, { annotate: false });
 			}
 			suiteError = err;
-			const msg = `Suite "${suite}" threw on ${provider} — will normalize the failed marker into a gap: ${
-				err instanceof Error ? err.message : String(err)
-			}`;
-			if (inActions()) core.warning(msg, { title: cell });
-			else console.error(msg);
+			logWarning(
+				`Suite "${suite}" threw on ${provider} — will normalize the failed marker into a gap: ${
+					err instanceof Error ? err.message : String(err)
+				}`,
+				{ title: cell },
+			);
 		}
 	});
 
@@ -276,8 +267,7 @@ if (import.meta.main) {
 	await withGroup("Normalize Run document", async () => {
 		try {
 			run = writeNormalizedRun({ rawRoot, runId, sha, outFile, updateIndexFile: indexFile });
-			if (inActions()) core.info(`Normalized Run ${runId} → ${outFile}`);
-			else console.error(`Normalized Run ${runId} → ${outFile}`);
+			logInfo(`Normalized Run ${runId} → ${outFile}`);
 			// Already inside withGroup — don't nest another ::group::.
 			logProviderStatuses(run, { grouped: false });
 		} catch (err) {
@@ -292,46 +282,35 @@ if (import.meta.main) {
 				: normalizeError
 					? String(normalizeError)
 					: "normalize produced no Run document";
-		await writeJobSummary({
-			heading: cell,
-			fields: [
-				["Status", "failure", "plain"],
-				["Suite", suite, "code"],
-				["Provider", provider, "code"],
-				["Run id", runId, "code"],
-				["Artifact", outFile, "code"],
-				["Harness commands", taskPlan?.commands.join(" · ") ?? "", "code"],
-				["Mise tasks", taskPlan ? miseTaskSummary(taskPlan) : "", "plain"],
-			],
-			tables: taskPlan
-				? [
-						{ heading: "Mise tasks", rows: suiteTaskSummaryRows(taskPlan) },
-						{ heading: "Declared metrics", rows: suiteMetricSummaryRows(taskPlan) },
-					]
-				: undefined,
-			detail,
-			annotation: { failed: true, title: cell, message: detail },
-		});
-		fail(detail, { annotate: false });
-	}
-
-	if (suiteError) {
-		const detail =
-			`Suite "${suite}" failed on ${provider} — recorded as a failed gap in ${outFile}: ` +
-			`${suiteError instanceof Error ? suiteError.message : String(suiteError)}`;
 		await reportCell({
 			provider,
 			suite,
 			runId,
 			sha,
 			outFile,
-			run,
 			failed: true,
 			detail,
 			taskPlan,
 		});
-		// Annotation already written by reportCell — exit without a second ::error::.
+		// Synchronous `never` so TypeScript narrows `run` for the paths below.
 		fail(detail, { annotate: false });
+	}
+	const normalized = run;
+
+	if (suiteError) {
+		const detail =
+			`Suite "${suite}" failed on ${provider} — recorded as a failed gap in ${outFile}: ` +
+			`${suiteError instanceof Error ? suiteError.message : String(suiteError)}`;
+		await failCell({
+			provider,
+			suite,
+			runId,
+			sha,
+			outFile,
+			run: normalized,
+			detail,
+			taskPlan,
+		});
 	}
 
 	// Missing credentials (and an unusable sandbox) are recorded as a skip, not a throw — the lenient
@@ -342,7 +321,7 @@ if (import.meta.main) {
 	// carries the bun executable and script path), so the flag this bin parses is the flag this gate reads.
 	const required = requiredProviders(argv);
 	if (required.length > 0) {
-		const reports = run.providers.map((p) => ({
+		const reports = normalized.providers.map((p) => ({
 			provider: p.providerId,
 			status: p.validationStatus === "validated" ? "ok" : p.validationStatus,
 		}));
@@ -353,24 +332,21 @@ if (import.meta.main) {
 				// The gaps ARE the explanation for "no metrics", and their outcome is the important half of
 				// it: a required provider that skipped on a precondition is a configuration problem, one that
 				// failed is an outage, and the operator reading this line needs to know which they have.
-				const gaps = run.providers.find((p) => p.providerId === providerId)?.gaps ?? [];
+				const gaps = normalized.providers.find((p) => p.providerId === providerId)?.gaps ?? [];
 				const gapDetail = gaps.map((g) => `${g.id} ${g.outcome}: ${g.reason}`).join("; ");
 				const line = `Required provider "${providerId}" produced no metrics${gapDetail ? ` — ${gapDetail}` : " and was absent from the Run"}`;
 				details.push(line);
 			}
-			const detail = details.join("\n");
-			await reportCell({
+			await failCell({
 				provider,
 				suite,
 				runId,
 				sha,
 				outFile,
-				run,
-				failed: true,
-				detail,
+				run: normalized,
+				detail: details.join("\n"),
 				taskPlan,
 			});
-			fail(detail, { annotate: false });
 		}
 	}
 
@@ -380,10 +356,9 @@ if (import.meta.main) {
 		runId,
 		sha,
 		outFile,
-		run,
+		run: normalized,
 		failed: false,
 		taskPlan,
 	});
-	if (inActions()) core.info(`Cell ${cell} succeeded → ${outFile}`);
-	else console.error(`Cell ${cell} succeeded → ${outFile}`);
+	logInfo(`Cell ${cell} succeeded → ${outFile}`);
 }

--- a/apps/cli/src/bin/bench-suite.ts
+++ b/apps/cli/src/bin/bench-suite.ts
@@ -27,7 +27,8 @@ import {
 } from "../lib/actions-log.ts";
 import { handleDiscovery } from "../lib/discovery.ts";
 import { suiteMetricSummaryRows, suiteTaskSummaryRows } from "../lib/suite-summary.ts";
-import { describeSuiteTasks, type SuiteTaskPlan } from "../lib/suite-tasks.ts";
+import type { SuiteTaskPlan } from "../lib/suite-tasks.ts";
+import { describeSuiteTasks } from "../lib/suite-tasks.ts";
 
 function plural(n: number, singular: string, pluralForm: string = `${singular}s`): string {
 	return `${n} ${n === 1 ? singular : pluralForm}`;
@@ -117,9 +118,7 @@ async function reportCell(opts: {
 		],
 		tables: [
 			...taskTables,
-			...(opts.run
-				? [{ heading: "Provider status", rows: providerSummaryRows(opts.run) }]
-				: []),
+			...(opts.run ? [{ heading: "Provider status", rows: providerSummaryRows(opts.run) }] : []),
 		],
 		detail: opts.detail,
 		annotation: {
@@ -133,9 +132,7 @@ async function reportCell(opts: {
 type CellReport = Parameters<typeof reportCell>[0];
 
 /** Write the cell summary then fail without a second annotation. */
-async function failCell(
-	opts: Omit<CellReport, "failed"> & { detail: string },
-): Promise<never> {
+async function failCell(opts: Omit<CellReport, "failed"> & { detail: string }): Promise<never> {
 	await reportCell({ ...opts, failed: true });
 	return fail(opts.detail, { annotate: false });
 }
@@ -269,7 +266,7 @@ if (import.meta.main) {
 			run = writeNormalizedRun({ rawRoot, runId, sha, outFile, updateIndexFile: indexFile });
 			logInfo(`Normalized Run ${runId} → ${outFile}`);
 			// Already inside withGroup — don't nest another ::group::.
-			logProviderStatuses(run, { grouped: false });
+			await logProviderStatuses(run, { grouped: false });
 		} catch (err) {
 			// Prefer the suite failure that caused a bad tree; otherwise keep the normalize error.
 			normalizeError = suiteError ?? err;

--- a/apps/cli/src/bin/bench-suite.ts
+++ b/apps/cli/src/bin/bench-suite.ts
@@ -2,17 +2,45 @@
 // `bench-suite` — run a benchmark suite on a provider sandbox, collect the raw results into a
 // data/raw tree, and normalize them into a validated Run document. Missing provider credentials are
 // recorded as a skip (the provider stays `pending` in the Run), so this is runnable without secrets.
+// Logging and results go through @actions/core (groups, debug, annotations, job summary) so the
+// nested "<suite> / <provider>" cell is metadata-rich in the Actions UI.
 
 import { join } from "node:path";
+import * as core from "@actions/core";
 import {
 	requiredProviders,
 	runSuite,
 	SuiteUsageError,
 	unmetRequirements,
 } from "@sandbox-benchmarks/harness";
-import { summarizeRun, writeNormalizedRun } from "@sandbox-benchmarks/results";
+import { writeNormalizedRun } from "@sandbox-benchmarks/results";
 import type { Run } from "@sandbox-benchmarks/schema";
+import {
+	fail,
+	inActions,
+	logProviderStatuses,
+	providerSummaryRows,
+	withGroup,
+	writeJobSummary,
+} from "../lib/actions-log.ts";
 import { handleDiscovery } from "../lib/discovery.ts";
+import type { SuiteTaskPlan } from "../lib/suite-tasks.ts";
+import {
+	describeSuiteTasks,
+	suiteMetricSummaryRows,
+	suiteTaskSummaryRows,
+} from "../lib/suite-tasks.ts";
+
+function plural(n: number, singular: string, pluralForm: string = `${singular}s`): string {
+	return `${n} ${n === 1 ? singular : pluralForm}`;
+}
+
+function miseTaskSummary(plan: SuiteTaskPlan): string {
+	const commands = plan.tasks.filter((t) => t.role === "command").length;
+	const leaves = plan.tasks.filter((t) => t.role === "leaf").length;
+	if (leaves === 0) return plural(commands, "task");
+	return `${plural(commands, "command")} → ${plural(leaves, "leaf task")}`;
+}
 
 /** Agent-facing usage; bare invocation keeps the daytona/cpu-node local-dev default. */
 export const HELP = `bench-suite — run a benchmark suite on a provider sandbox and normalize it into a Run document.
@@ -41,12 +69,80 @@ examples:
 
 Next: render the Run with \`leaderboard data/runs/<runId>.json\`.`;
 
+async function reportCell(opts: {
+	provider: string;
+	suite: string;
+	runId: string;
+	sha: string;
+	outFile: string;
+	run: Run;
+	failed: boolean;
+	detail?: string;
+	taskPlan?: SuiteTaskPlan;
+}): Promise<void> {
+	const title = `${opts.suite} / ${opts.provider}`;
+	const status = opts.failed ? "failure" : "success";
+	const provider = opts.run.providers.find((p) => p.providerId === opts.provider);
+	const annotationMessage =
+		opts.detail ??
+		(provider
+			? `${provider.providerId} ${provider.validationStatus} metrics=${provider.metrics.length}`
+			: title);
+	await writeJobSummary({
+		heading: title,
+		fields: [
+			["Status", status, "plain"],
+			["Suite", opts.suite, "code"],
+			["Provider", opts.provider, "code"],
+			["Run id", opts.runId, "code"],
+			["SHA", opts.sha, "code"],
+			["Artifact", opts.outFile, "code"],
+			["Harness commands", opts.taskPlan?.commands.join(" · ") ?? "", "code"],
+			["Mise tasks", opts.taskPlan ? miseTaskSummary(opts.taskPlan) : "", "plain"],
+			["Validation", provider?.validationStatus ?? "absent", "plain"],
+			["Metrics", String(provider?.metrics.length ?? 0), "plain"],
+			["Suites covered", String(provider?.suitesCovered.length ?? 0), "plain"],
+			["Gaps", String(provider?.gaps.length ?? 0), "plain"],
+			["Observed CPU", provider?.observedSpecs.cpuModel ?? "", "code"],
+			[
+				"Spec matched",
+				provider?.specMatched === undefined ? "" : String(provider.specMatched),
+				"plain",
+			],
+		],
+		tables: [
+			...(opts.taskPlan
+				? [
+						{
+							heading: "Mise tasks",
+							rows: suiteTaskSummaryRows(opts.taskPlan),
+						},
+						{
+							heading: "Declared metrics",
+							rows: suiteMetricSummaryRows(opts.taskPlan),
+						},
+					]
+				: []),
+			{ heading: "Provider status", rows: providerSummaryRows(opts.run) },
+		],
+		detail: opts.detail,
+		annotation: {
+			failed: opts.failed,
+			title,
+			message: annotationMessage,
+		},
+	});
+}
+
 if (import.meta.main) {
 	const argv = process.argv.slice(2);
 	const discovery = handleDiscovery(argv, HELP, ["--require"]);
 	if (discovery !== null) {
-		(discovery.ok ? console.log : console.error)(discovery.text);
-		process.exit(discovery.ok ? 0 : 2);
+		if (discovery.ok) {
+			process.stdout.write(`${discovery.text}\n`);
+			process.exit(0);
+		}
+		fail(discovery.text, { properties: { title: "bench-suite discovery" }, exitCode: 2 });
 	}
 
 	// Filter flags out before positional resolution so a trailing/misplaced flag (e.g.
@@ -70,10 +166,58 @@ if (import.meta.main) {
 	const suite = positionals[1] ?? "cpu-node";
 	const runId = positionals[2] ?? `local-${Date.now()}`;
 	const sha = process.env.GITHUB_SHA ?? "local";
+	const cell = `${suite} / ${provider}`;
 
 	const rawRoot = join("data", "raw", runId);
 	const outFile = join("data", "runs", `${runId}.json`);
 	const indexFile = join("data", "runs", "index.json");
+
+	if (inActions()) {
+		core.info(`Benchmark cell ${cell}`);
+		core.debug(
+			JSON.stringify({
+				provider,
+				suite,
+				runId,
+				sha,
+				rawRoot,
+				outFile,
+				require: requiredProviders(argv),
+			}),
+		);
+	} else {
+		console.error(`Benchmark cell ${cell}`);
+	}
+
+	// Resolve the precise mise tasks + PTS pins before the sandbox run so the job summary can name
+	// what this cell planned to execute (schema commands → mise task info → run_task leaves).
+	let taskPlan: SuiteTaskPlan | undefined;
+	await withGroup(`Discover suite tasks (${suite})`, async () => {
+		try {
+			taskPlan = await describeSuiteTasks(suite);
+			const log = inActions() ? core.info.bind(core) : (m: string) => console.error(m);
+			log(`commands: ${taskPlan.commands.join(" · ")}`);
+			for (const task of taskPlan.tasks) {
+				const pts = task.ptsProfile ? ` pts=${task.ptsProfile}` : "";
+				const prefix = task.resultsPrefix ? ` prefix=${task.resultsPrefix}` : "";
+				log(
+					`${task.role} ${task.task}${task.description ? ` — ${task.description}` : ""}${pts}${prefix}`,
+				);
+			}
+			if (inActions()) {
+				for (const metric of taskPlan.metrics) {
+					core.debug(
+						`metric ${metric.id} label=${metric.label}` +
+							(metric.ptsTest ? ` pts.test=${metric.ptsTest}` : ""),
+					);
+				}
+			}
+		} catch (err) {
+			const msg = `Could not describe suite tasks for "${suite}": ${err instanceof Error ? err.message : String(err)}`;
+			if (inActions()) core.warning(msg, { title: cell });
+			else console.error(msg);
+		}
+	});
 
 	// A suite that RAN AND BROKE is a result — the harness has already written its `--failed.json` marker
 	// into the raw tree — so the error is held, not thrown. Normalizing anyway is what turns that marker
@@ -81,42 +225,113 @@ if (import.meta.main) {
 	// shard would contribute nothing for the aggregate to merge, and the only trace of the failure would
 	// die inside the CI artifact. The job still goes red at the bottom of this block.
 	let suiteError: unknown;
-	try {
-		await runSuite({
-			providerName: provider,
-			suiteName: suite,
-			// Tag the raw tree by suite: `<rawRoot>/<provider>/<suite>/`. The normalizer reads each suite
-			// subdirectory independently and rejects any catalogued metric a suite emits off its declared
-			// Dimensions (the runtime half of the suite↔dimension↔metric contract).
-			resultsDir: join(rawRoot, provider, suite),
-		});
-	} catch (err) {
-		// A usage error (unknown provider/suite) produced no raw tree and no marker: there is nothing to
-		// normalize, and pretending otherwise would write an empty Run for a cell that never existed.
-		if (err instanceof SuiteUsageError) {
-			console.error(err.message);
-			process.exit(1);
+	await withGroup(`Run suite ${suite} on ${provider}`, async () => {
+		try {
+			await runSuite({
+				providerName: provider,
+				suiteName: suite,
+				// Tag the raw tree by suite: `<rawRoot>/<provider>/<suite>/`. The normalizer reads each suite
+				// subdirectory independently and rejects any catalogued metric a suite emits off its declared
+				// Dimensions (the runtime half of the suite↔dimension↔metric contract).
+				resultsDir: join(rawRoot, provider, suite),
+			});
+			if (inActions()) core.info(`Suite "${suite}" completed on ${provider}`);
+			else console.error(`Suite "${suite}" completed on ${provider}`);
+		} catch (err) {
+			// A usage error (unknown provider/suite) produced no raw tree and no marker: there is nothing to
+			// normalize, and pretending otherwise would write an empty Run for a cell that never existed.
+			if (err instanceof SuiteUsageError) {
+				await writeJobSummary({
+					heading: cell,
+					fields: [
+						["Status", "failure", "plain"],
+						["Suite", suite, "code"],
+						["Provider", provider, "code"],
+						["Run id", runId, "code"],
+						["Harness commands", taskPlan?.commands.join(" · ") ?? "", "code"],
+						["Mise tasks", taskPlan ? miseTaskSummary(taskPlan) : "", "plain"],
+					],
+					tables: taskPlan
+						? [
+								{ heading: "Mise tasks", rows: suiteTaskSummaryRows(taskPlan) },
+								{ heading: "Declared metrics", rows: suiteMetricSummaryRows(taskPlan) },
+							]
+						: undefined,
+					detail: err.message,
+					annotation: { failed: true, title: cell, message: err.message },
+				});
+				fail(err.message, { annotate: false });
+			}
+			suiteError = err;
+			const msg = `Suite "${suite}" threw on ${provider} — will normalize the failed marker into a gap: ${
+				err instanceof Error ? err.message : String(err)
+			}`;
+			if (inActions()) core.warning(msg, { title: cell });
+			else console.error(msg);
 		}
-		suiteError = err;
-	}
+	});
 
-	let run: Run;
-	try {
-		run = writeNormalizedRun({ rawRoot, runId, sha, outFile, updateIndexFile: indexFile });
-	} catch (normalizeErr) {
-		// Never let a normalization failure mask the benchmark failure that caused it.
-		if (suiteError) throw suiteError;
-		throw normalizeErr;
+	let run: Run | undefined;
+	let normalizeError: unknown;
+	await withGroup("Normalize Run document", async () => {
+		try {
+			run = writeNormalizedRun({ rawRoot, runId, sha, outFile, updateIndexFile: indexFile });
+			if (inActions()) core.info(`Normalized Run ${runId} → ${outFile}`);
+			else console.error(`Normalized Run ${runId} → ${outFile}`);
+			// Already inside withGroup — don't nest another ::group::.
+			logProviderStatuses(run, { grouped: false });
+		} catch (err) {
+			// Prefer the suite failure that caused a bad tree; otherwise keep the normalize error.
+			normalizeError = suiteError ?? err;
+		}
+	});
+	if (!run) {
+		const detail =
+			normalizeError instanceof Error
+				? normalizeError.message
+				: normalizeError
+					? String(normalizeError)
+					: "normalize produced no Run document";
+		await writeJobSummary({
+			heading: cell,
+			fields: [
+				["Status", "failure", "plain"],
+				["Suite", suite, "code"],
+				["Provider", provider, "code"],
+				["Run id", runId, "code"],
+				["Artifact", outFile, "code"],
+				["Harness commands", taskPlan?.commands.join(" · ") ?? "", "code"],
+				["Mise tasks", taskPlan ? miseTaskSummary(taskPlan) : "", "plain"],
+			],
+			tables: taskPlan
+				? [
+						{ heading: "Mise tasks", rows: suiteTaskSummaryRows(taskPlan) },
+						{ heading: "Declared metrics", rows: suiteMetricSummaryRows(taskPlan) },
+					]
+				: undefined,
+			detail,
+			annotation: { failed: true, title: cell, message: detail },
+		});
+		fail(detail, { annotate: false });
 	}
-	console.log(`\nNormalized Run ${runId} → ${outFile}`);
-	for (const line of summarizeRun(run)) console.log(line);
 
 	if (suiteError) {
-		console.error(
-			`\nSuite "${suite}" failed on ${provider} — recorded as a failed gap in ${outFile}: ` +
-				`${suiteError instanceof Error ? suiteError.message : String(suiteError)}`,
-		);
-		process.exit(1);
+		const detail =
+			`Suite "${suite}" failed on ${provider} — recorded as a failed gap in ${outFile}: ` +
+			`${suiteError instanceof Error ? suiteError.message : String(suiteError)}`;
+		await reportCell({
+			provider,
+			suite,
+			runId,
+			sha,
+			outFile,
+			run,
+			failed: true,
+			detail,
+			taskPlan,
+		});
+		// Annotation already written by reportCell — exit without a second ::error::.
+		fail(detail, { annotate: false });
 	}
 
 	// Missing credentials (and an unusable sandbox) are recorded as a skip, not a throw — the lenient
@@ -133,17 +348,42 @@ if (import.meta.main) {
 		}));
 		const unmet = unmetRequirements(reports, required);
 		if (unmet.length > 0) {
+			const details: string[] = [];
 			for (const providerId of unmet) {
 				// The gaps ARE the explanation for "no metrics", and their outcome is the important half of
 				// it: a required provider that skipped on a precondition is a configuration problem, one that
 				// failed is an outage, and the operator reading this line needs to know which they have.
 				const gaps = run.providers.find((p) => p.providerId === providerId)?.gaps ?? [];
-				const detail = gaps.map((g) => `${g.id} ${g.outcome}: ${g.reason}`).join("; ");
-				console.error(
-					`Required provider "${providerId}" produced no metrics${detail ? ` — ${detail}` : " and was absent from the Run"}`,
-				);
+				const gapDetail = gaps.map((g) => `${g.id} ${g.outcome}: ${g.reason}`).join("; ");
+				const line = `Required provider "${providerId}" produced no metrics${gapDetail ? ` — ${gapDetail}` : " and was absent from the Run"}`;
+				details.push(line);
 			}
-			process.exit(1);
+			const detail = details.join("\n");
+			await reportCell({
+				provider,
+				suite,
+				runId,
+				sha,
+				outFile,
+				run,
+				failed: true,
+				detail,
+				taskPlan,
+			});
+			fail(detail, { annotate: false });
 		}
 	}
+
+	await reportCell({
+		provider,
+		suite,
+		runId,
+		sha,
+		outFile,
+		run,
+		failed: false,
+		taskPlan,
+	});
+	if (inActions()) core.info(`Cell ${cell} succeeded → ${outFile}`);
+	else console.error(`Cell ${cell} succeeded → ${outFile}`);
 }

--- a/apps/cli/src/bin/leaderboard.ts
+++ b/apps/cli/src/bin/leaderboard.ts
@@ -8,7 +8,7 @@ import { dirname } from "node:path";
 import * as core from "@actions/core";
 import { buildLeaderboard, renderLeaderboardMarkdown } from "@sandbox-benchmarks/results";
 import { parseRun } from "@sandbox-benchmarks/schema";
-import { fail, inActions, withGroup, writeJobSummary } from "../lib/actions-log.ts";
+import { fail, inActions, logInfo, withGroup, writeJobSummary } from "../lib/actions-log.ts";
 import { handleDiscovery } from "../lib/discovery.ts";
 
 /** Agent-facing usage. The Run document names the providers/suites it covers, so the registry
@@ -30,11 +30,6 @@ examples:
   leaderboard data/runs/local-1.json LEADERBOARD.md  # write the comparison surface to a file
 
 Next: produce a Run with  bench-suite <provider> <suite> <runId>`;
-
-function logInfo(message: string): void {
-	if (inActions()) core.info(message);
-	else console.error(message);
-}
 
 if (import.meta.main) {
 	const argv = process.argv.slice(2);

--- a/apps/cli/src/bin/leaderboard.ts
+++ b/apps/cli/src/bin/leaderboard.ts
@@ -1,11 +1,14 @@
 #!/usr/bin/env bun
 // `leaderboard` — render a published Run document into the Markdown comparison surface (one ranked
 // table per dimension on its headline metric). Writes to <outFile> when given, else prints to stdout.
+// Uses @actions/core for step logs, annotations, and a job summary when writing a file in CI.
 
 import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { dirname } from "node:path";
+import * as core from "@actions/core";
 import { buildLeaderboard, renderLeaderboardMarkdown } from "@sandbox-benchmarks/results";
 import { parseRun } from "@sandbox-benchmarks/schema";
+import { fail, inActions, withGroup, writeJobSummary } from "../lib/actions-log.ts";
 import { handleDiscovery } from "../lib/discovery.ts";
 
 /** Agent-facing usage. The Run document names the providers/suites it covers, so the registry
@@ -28,27 +31,80 @@ examples:
 
 Next: produce a Run with  bench-suite <provider> <suite> <runId>`;
 
+function logInfo(message: string): void {
+	if (inActions()) core.info(message);
+	else console.error(message);
+}
+
 if (import.meta.main) {
 	const argv = process.argv.slice(2);
 	const discovery = handleDiscovery(argv, HELP);
 	if (discovery !== null) {
-		(discovery.ok ? console.log : console.error)(discovery.text);
-		process.exit(discovery.ok ? 0 : 2);
+		if (discovery.ok) {
+			process.stdout.write(`${discovery.text}\n`);
+			process.exit(0);
+		}
+		fail(discovery.text, {
+			properties: { title: "leaderboard discovery" },
+			exitCode: 2,
+		});
 	}
 
 	const [runFile, outFile] = argv;
 	if (!runFile) {
-		console.error("usage: leaderboard <run.json> [outFile.md] (see --help)");
-		process.exit(1);
+		fail("usage: leaderboard <run.json> [outFile.md] (see --help)", {
+			properties: { title: "leaderboard usage" },
+			exitCode: 2,
+		});
 	}
-	const run = parseRun(JSON.parse(readFileSync(runFile, "utf8")));
-	const markdown = renderLeaderboardMarkdown(buildLeaderboard(run));
+
+	const run = await withGroup(`Load Run ${runFile}`, async () => {
+		const parsed = parseRun(JSON.parse(readFileSync(runFile, "utf8")));
+		logInfo(`runId=${parsed.runId} providers=${parsed.providers.length} sha=${parsed.sha}`);
+		return parsed;
+	});
+
+	const board = await withGroup("Build leaderboard", async () => {
+		const built = buildLeaderboard(run);
+		logInfo(`dimensions=${built.dimensions.length}`);
+		if (inActions()) {
+			core.debug(
+				JSON.stringify(
+					built.dimensions.map((d) => ({
+						dimension: d.dimension,
+						headline: d.metric.id,
+						metrics: d.metrics.length,
+						rows: d.rows.length,
+					})),
+				),
+			);
+		}
+		return built;
+	});
+	const markdown = renderLeaderboardMarkdown(board);
 
 	if (outFile) {
 		mkdirSync(dirname(outFile), { recursive: true });
 		writeFileSync(outFile, markdown);
-		console.error(`Wrote leaderboard → ${outFile}`);
+		logInfo(`Wrote leaderboard → ${outFile}`);
+		await writeJobSummary({
+			heading: `Leaderboard ${run.runId}`,
+			fields: [
+				["Status", "success", "plain"],
+				["Run id", run.runId, "code"],
+				["Source", runFile, "code"],
+				["Output", outFile, "code"],
+				["Dimensions", String(board.dimensions.length), "plain"],
+				["Providers", String(run.providers.length), "plain"],
+			],
+			annotation: {
+				failed: false,
+				title: `Leaderboard ${run.runId}`,
+				message: `Wrote ${outFile} (${board.dimensions.length} dimension(s))`,
+			},
+		});
 	} else {
+		// stdout is the Markdown contract when no outFile is given — keep it pristine.
 		process.stdout.write(markdown);
 	}
 }

--- a/apps/cli/src/bin/plan-matrix.ts
+++ b/apps/cli/src/bin/plan-matrix.ts
@@ -1,6 +1,8 @@
 #!/usr/bin/env bun
-// `plan-matrix` — emit the benchmark matrix as a SINGLE LINE of compact JSON.
-// This is the $GITHUB_OUTPUT contract: `matrix=<json>` must be one line, no pretty-printing.
+// `plan-matrix` — emit the full provider × suite cell list as a SINGLE LINE of compact JSON.
+// Local inspection / discovery helper. CI fans out via `plan-providers` + `plan-suites` (native
+// suite→provider nesting); this bin remains for `{"include":[…]}` listing without Actions wiring.
+import { fail } from "../lib/actions-log.ts";
 import { handleDiscovery } from "../lib/discovery.ts";
 import { buildMatrix, selectProviders } from "../lib/matrix.ts";
 
@@ -11,42 +13,53 @@ export function planMatrixJson(providersRaw?: string): string {
 	return JSON.stringify({ include: buildMatrix(selectProviders(providersRaw)) });
 }
 
-/** Agent-facing usage; the bare invocation stays the $GITHUB_OUTPUT matrix contract. */
+/** Agent-facing usage; bare invocation prints one line of cell JSON for local inspection. */
 export const HELP = `plan-matrix — emit the provider × suite benchmark matrix as one line of compact JSON.
 
 usage: plan-matrix [--help] [--list-providers] [--list-suites] [--json]
 
-  (no args)          Print {"include":[{provider,suite}, …]} on a single line (the GITHUB_OUTPUT contract).
+  (no args)          Print {"include":[{provider,suite}, …]} on a single line (local cell listing).
   --list-providers   List the registered providers the matrix fans out over.
   --list-suites      List the registered suites the matrix fans out over.
   --json             Emit --list-* output as JSON instead of human-readable lines.
   --help, -h         Show this help.
 
 environment:
-  BENCH_PROVIDERS    Comma-separated providers to fan out over (e.g. "e2b,daytona,modal"). Unset or
-                     blank fans out over every registered provider. An unregistered name is an error,
+  BENCH_PROVIDERS    Comma-separated providers to include (e.g. "e2b,daytona,modal"). Unset or
+                     blank includes every registered provider. An unregistered name is an error,
                      never a silently smaller matrix.
 
+note:
+  CI plans axes with plan-providers + plan-suites (bench-matrix.yml → reusable bench-suite.yml).
+  Use this bin for local inspection of the cartesian cell list, not as the live $GITHUB_OUTPUT
+  contract.
+
 examples:
-  plan-matrix                                  # the CI matrix: echo "matrix=$(plan-matrix)" >> "$GITHUB_OUTPUT"
+  plan-matrix                                  # every provider × suite cell
   BENCH_PROVIDERS=e2b,daytona plan-matrix      # only those two providers' cells
   plan-matrix --list-suites --json             # the suites + their dimensions/metrics as JSON
 
-Next: run one cell with  bench-suite <provider> <suite> <runId>`;
+Next: run one cell with  bench-suite <provider> <suite> <runId>
+      or plan CI axes with  plan-providers / plan-suites`;
 
 if (import.meta.main) {
 	const argv = process.argv.slice(2);
 	const discovery = handleDiscovery(argv, HELP);
 	if (discovery !== null) {
-		(discovery.ok ? console.log : console.error)(discovery.text);
-		process.exit(discovery.ok ? 0 : 2);
+		if (discovery.ok) {
+			process.stdout.write(`${discovery.text}\n`);
+			process.exit(0);
+		}
+		fail(discovery.text, { properties: { title: "plan-matrix discovery" }, exitCode: 2 });
 	}
 	// A bad BENCH_PROVIDERS must fail the step, not print a diagnostic onto stdout: stdout here IS the
-	// `matrix=` value CI captures, so an error message there would be parsed as the matrix.
+	// cell-list value local callers capture, so an error message there would be parsed as the matrix.
 	try {
-		console.log(planMatrixJson(process.env.BENCH_PROVIDERS));
+		process.stdout.write(`${planMatrixJson(process.env.BENCH_PROVIDERS)}\n`);
 	} catch (err) {
-		console.error(`plan-matrix: ${err instanceof Error ? err.message : String(err)}`);
-		process.exit(2);
+		fail(`plan-matrix: ${err instanceof Error ? err.message : String(err)}`, {
+			properties: { title: "plan-matrix" },
+			exitCode: 2,
+		});
 	}
 }

--- a/apps/cli/src/bin/plan-providers.ts
+++ b/apps/cli/src/bin/plan-providers.ts
@@ -1,0 +1,86 @@
+#!/usr/bin/env bun
+// `plan-providers` — emit the selected provider ids as a SINGLE LINE of compact JSON array.
+// This is the $GITHUB_OUTPUT contract the Bench matrix reads: `providers=<json>` must be one line.
+// Where `plan-matrix` emits the full provider × suite cell list, this emits just the provider axis —
+// bench-matrix.yml's suite-matrix job fans out over these providers via the reusable bench-suite.yml
+// (native nesting: "<suite> / <provider>"). Shares `selectProviders` with the matrix builder, so the
+// registry stays the single source of truth for which providers are valid.
+//
+// In Actions ($GITHUB_OUTPUT set) the bin writes `providers=` via emitStepOutputs and logs through
+// @actions/core — no bash capture that could splice diagnostics into the outputs file. The suite axis
+// is the sibling `plan-suites` bin (honors `BENCH_SUITES`).
+import * as core from "@actions/core";
+import { fail, inActions, withGroup } from "../lib/actions-log.ts";
+import { handleDiscovery } from "../lib/discovery.ts";
+import { emitStepOutputs } from "../lib/gha-output.ts";
+import { selectProviders } from "../lib/matrix.ts";
+
+/** The provider-axis JSON for `providersRaw` (a comma-separated `BENCH_PROVIDERS` value; blank/undefined
+ *  = every registered provider). Takes the raw string rather than reading `process.env` itself, so it
+ *  stays pure — the bin owns the env read, and a test can't be perturbed by an ambient value. */
+export function planProvidersJson(providersRaw?: string): string {
+	return JSON.stringify(selectProviders(providersRaw));
+}
+
+/** Agent-facing usage; the bare invocation stays the $GITHUB_OUTPUT providers contract. */
+export const HELP = `plan-providers — emit the selected benchmark provider ids as one line of compact JSON array.
+
+usage: plan-providers [--help] [--list-providers] [--list-suites] [--json]
+
+  (no args)          Print ["e2b","daytona", …] on a single line (local), or write providers= to
+                     $GITHUB_OUTPUT when set (the Bench matrix plan step).
+  --list-providers   List the registered providers the matrix can fan out over.
+  --list-suites      List the registered suites (the suite axis; see plan-suites).
+  --json             Emit --list-* output as JSON instead of human-readable lines.
+  --help, -h         Show this help.
+
+environment:
+  BENCH_PROVIDERS    Comma-separated providers to fan out over (e.g. "e2b,daytona,modal"). Unset or
+                     blank selects every registered provider. An unregistered name is an error,
+                     never a silently smaller matrix.
+  GITHUB_OUTPUT      When set (Actions), write providers= step output instead of printing on stdout.
+
+examples:
+  plan-providers                               # local: print the provider axis
+  BENCH_PROVIDERS=e2b,daytona plan-providers   # only those two providers
+  plan-providers --list-suites --json          # discover suites (selection is plan-suites)
+
+Next: run one cell with  bench-suite <provider> <suite> <runId>`;
+
+if (import.meta.main) {
+	const argv = process.argv.slice(2);
+	const discovery = handleDiscovery(argv, HELP);
+	if (discovery !== null) {
+		if (discovery.ok) {
+			process.stdout.write(`${discovery.text}\n`);
+			process.exit(0);
+		}
+		fail(discovery.text, { properties: { title: "plan-providers discovery" }, exitCode: 2 });
+	}
+	// A bad BENCH_PROVIDERS must fail the step, not print a diagnostic onto stdout: stdout here IS the
+	// `providers=` value local callers capture, so an error message there would be parsed as the axis.
+	try {
+		const providers = planProvidersJson(process.env.BENCH_PROVIDERS);
+		const providerList = JSON.parse(providers) as string[];
+
+		if (process.env.GITHUB_OUTPUT) {
+			await withGroup("Plan provider axis", async () => {
+				core.info(`${providerList.length} provider(s)`);
+				core.debug(`providers=${providers}`);
+				for (const id of providerList) core.info(`provider: ${id}`);
+			});
+			emitStepOutputs(`providers=${providers}`);
+			if (inActions()) {
+				core.notice(`Planned ${providerList.length} provider(s)`, { title: "Plan providers" });
+			}
+		} else {
+			// Local / test capture: keep the single-line providers stdout contract pristine.
+			process.stdout.write(`${providers}\n`);
+		}
+	} catch (err) {
+		fail(`plan-providers: ${err instanceof Error ? err.message : String(err)}`, {
+			properties: { title: "plan-providers" },
+			exitCode: 2,
+		});
+	}
+}

--- a/apps/cli/src/bin/plan-providers.ts
+++ b/apps/cli/src/bin/plan-providers.ts
@@ -8,18 +8,15 @@
 //
 // In Actions ($GITHUB_OUTPUT set) the bin writes `providers=` via emitStepOutputs and logs through
 // @actions/core — no bash capture that could splice diagnostics into the outputs file. The suite axis
-// is the sibling `plan-suites` bin (honors `BENCH_SUITES`).
-import * as core from "@actions/core";
-import { fail, inActions, withGroup } from "../lib/actions-log.ts";
-import { handleDiscovery } from "../lib/discovery.ts";
-import { emitStepOutputs } from "../lib/gha-output.ts";
+// is the sibling `plan-suites` bin (honors `BENCH_SUITES`). Control flow lives in `plan-axis.ts`.
 import { selectProviders } from "../lib/matrix.ts";
+import { planAxisJson, runAxisPlan } from "../lib/plan-axis.ts";
 
 /** The provider-axis JSON for `providersRaw` (a comma-separated `BENCH_PROVIDERS` value; blank/undefined
  *  = every registered provider). Takes the raw string rather than reading `process.env` itself, so it
  *  stays pure — the bin owns the env read, and a test can't be perturbed by an ambient value. */
 export function planProvidersJson(providersRaw?: string): string {
-	return JSON.stringify(selectProviders(providersRaw));
+	return planAxisJson(selectProviders, providersRaw);
 }
 
 /** Agent-facing usage; the bare invocation stays the $GITHUB_OUTPUT providers contract. */
@@ -48,39 +45,17 @@ examples:
 Next: run one cell with  bench-suite <provider> <suite> <runId>`;
 
 if (import.meta.main) {
-	const argv = process.argv.slice(2);
-	const discovery = handleDiscovery(argv, HELP);
-	if (discovery !== null) {
-		if (discovery.ok) {
-			process.stdout.write(`${discovery.text}\n`);
-			process.exit(0);
-		}
-		fail(discovery.text, { properties: { title: "plan-providers discovery" }, exitCode: 2 });
-	}
-	// A bad BENCH_PROVIDERS must fail the step, not print a diagnostic onto stdout: stdout here IS the
-	// `providers=` value local callers capture, so an error message there would be parsed as the axis.
-	try {
-		const providers = planProvidersJson(process.env.BENCH_PROVIDERS);
-		const providerList = JSON.parse(providers) as string[];
-
-		if (process.env.GITHUB_OUTPUT) {
-			await withGroup("Plan provider axis", async () => {
-				core.info(`${providerList.length} provider(s)`);
-				core.debug(`providers=${providers}`);
-				for (const id of providerList) core.info(`provider: ${id}`);
-			});
-			emitStepOutputs(`providers=${providers}`);
-			if (inActions()) {
-				core.notice(`Planned ${providerList.length} provider(s)`, { title: "Plan providers" });
-			}
-		} else {
-			// Local / test capture: keep the single-line providers stdout contract pristine.
-			process.stdout.write(`${providers}\n`);
-		}
-	} catch (err) {
-		fail(`plan-providers: ${err instanceof Error ? err.message : String(err)}`, {
-			properties: { title: "plan-providers" },
-			exitCode: 2,
-		});
-	}
+	await runAxisPlan(
+		{
+			binName: "plan-providers",
+			envKey: "BENCH_PROVIDERS",
+			outputKey: "providers",
+			groupTitle: "Plan provider axis",
+			noticeTitle: "Plan providers",
+			itemLabel: "provider",
+			help: HELP,
+			select: selectProviders,
+		},
+		process.argv.slice(2),
+	);
 }

--- a/apps/cli/src/bin/plan-suites.ts
+++ b/apps/cli/src/bin/plan-suites.ts
@@ -1,0 +1,83 @@
+#!/usr/bin/env bun
+// `plan-suites` — emit the selected suite names as a SINGLE LINE of compact JSON array.
+// This is a $GITHUB_OUTPUT contract the Bench matrix reads: `suites=<json>` must be one line. The
+// suite-matrix job expands `fromJSON(needs.plan.outputs.suites)`, so a dispatch can run a subset
+// (e.g. just `network`) for pre-merge/targeted validation instead of spending the whole matrix. Shares
+// `selectSuites` with the matrix builder, so SUITE_NAMES stays the single source of truth.
+//
+// In Actions ($GITHUB_OUTPUT set) the bin writes `suites=` via emitStepOutputs and logs through
+// @actions/core — no bash capture that could splice diagnostics into the outputs file.
+import * as core from "@actions/core";
+import { fail, inActions, withGroup } from "../lib/actions-log.ts";
+import { handleDiscovery } from "../lib/discovery.ts";
+import { emitStepOutputs } from "../lib/gha-output.ts";
+import { selectSuites } from "../lib/matrix.ts";
+
+/** The selected-suites JSON for `suitesRaw` (a comma-separated `BENCH_SUITES` value; blank/undefined =
+ *  every registered suite). Takes the raw string rather than reading `process.env` itself, so it stays
+ *  pure — the bin owns the env read, and a test can't be perturbed by an ambient value. */
+export function planSuitesJson(suitesRaw?: string): string {
+	return JSON.stringify(selectSuites(suitesRaw));
+}
+
+/** Agent-facing usage; the bare invocation stays the $GITHUB_OUTPUT suites contract. */
+export const HELP = `plan-suites — emit the selected benchmark suite names as one line of compact JSON array.
+
+usage: plan-suites [--help] [--list-providers] [--list-suites] [--json]
+
+  (no args)          Print ["cpu-node","system", …] on a single line (local), or write suites= to
+                     $GITHUB_OUTPUT when set (the Bench matrix plan step).
+  --list-providers   List the registered providers each suite-matrix cell fans out over.
+  --list-suites      List the registered suites (one suite-matrix cell each).
+  --json             Emit --list-* output as JSON instead of human-readable lines.
+  --help, -h         Show this help.
+
+environment:
+  BENCH_SUITES       Comma-separated suites to run (e.g. "network,memory"). Unset or blank selects every
+                     registered suite (the main-publish default). An unregistered name is an error,
+                     never a silently empty selection.
+  GITHUB_OUTPUT      When set (Actions), write suites= step output instead of printing on stdout.
+
+examples:
+  plan-suites                                  # local: print every suite
+  BENCH_SUITES=network plan-suites             # only the network suite's cells run
+  plan-suites --list-suites --json             # the suites the suite-matrix job can expand
+
+Next: run one cell with  bench-suite <provider> <suite> <runId>`;
+
+if (import.meta.main) {
+	const argv = process.argv.slice(2);
+	const discovery = handleDiscovery(argv, HELP);
+	if (discovery !== null) {
+		if (discovery.ok) {
+			process.stdout.write(`${discovery.text}\n`);
+			process.exit(0);
+		}
+		fail(discovery.text, { properties: { title: "plan-suites discovery" }, exitCode: 2 });
+	}
+	// A bad BENCH_SUITES must fail the step, not print a diagnostic onto stdout: stdout here IS the
+	// `suites=` value local callers capture, so an error message there would be parsed as the selection.
+	try {
+		const suites = planSuitesJson(process.env.BENCH_SUITES);
+		const suiteList = JSON.parse(suites) as string[];
+
+		if (process.env.GITHUB_OUTPUT) {
+			await withGroup("Plan suite axis", async () => {
+				core.info(`${suiteList.length} suite(s)`);
+				core.debug(`suites=${suites}`);
+				for (const name of suiteList) core.info(`suite: ${name}`);
+			});
+			emitStepOutputs(`suites=${suites}`);
+			if (inActions()) {
+				core.notice(`Planned ${suiteList.length} suite(s)`, { title: "Plan suites" });
+			}
+		} else {
+			process.stdout.write(`${suites}\n`);
+		}
+	} catch (err) {
+		fail(`plan-suites: ${err instanceof Error ? err.message : String(err)}`, {
+			properties: { title: "plan-suites" },
+			exitCode: 2,
+		});
+	}
+}

--- a/apps/cli/src/bin/plan-suites.ts
+++ b/apps/cli/src/bin/plan-suites.ts
@@ -6,18 +6,16 @@
 // `selectSuites` with the matrix builder, so SUITE_NAMES stays the single source of truth.
 //
 // In Actions ($GITHUB_OUTPUT set) the bin writes `suites=` via emitStepOutputs and logs through
-// @actions/core — no bash capture that could splice diagnostics into the outputs file.
-import * as core from "@actions/core";
-import { fail, inActions, withGroup } from "../lib/actions-log.ts";
-import { handleDiscovery } from "../lib/discovery.ts";
-import { emitStepOutputs } from "../lib/gha-output.ts";
+// @actions/core — no bash capture that could splice diagnostics into the outputs file. Control flow
+// lives in `plan-axis.ts` (shared with plan-providers).
 import { selectSuites } from "../lib/matrix.ts";
+import { planAxisJson, runAxisPlan } from "../lib/plan-axis.ts";
 
 /** The selected-suites JSON for `suitesRaw` (a comma-separated `BENCH_SUITES` value; blank/undefined =
  *  every registered suite). Takes the raw string rather than reading `process.env` itself, so it stays
  *  pure — the bin owns the env read, and a test can't be perturbed by an ambient value. */
 export function planSuitesJson(suitesRaw?: string): string {
-	return JSON.stringify(selectSuites(suitesRaw));
+	return planAxisJson(selectSuites, suitesRaw);
 }
 
 /** Agent-facing usage; the bare invocation stays the $GITHUB_OUTPUT suites contract. */
@@ -46,38 +44,17 @@ examples:
 Next: run one cell with  bench-suite <provider> <suite> <runId>`;
 
 if (import.meta.main) {
-	const argv = process.argv.slice(2);
-	const discovery = handleDiscovery(argv, HELP);
-	if (discovery !== null) {
-		if (discovery.ok) {
-			process.stdout.write(`${discovery.text}\n`);
-			process.exit(0);
-		}
-		fail(discovery.text, { properties: { title: "plan-suites discovery" }, exitCode: 2 });
-	}
-	// A bad BENCH_SUITES must fail the step, not print a diagnostic onto stdout: stdout here IS the
-	// `suites=` value local callers capture, so an error message there would be parsed as the selection.
-	try {
-		const suites = planSuitesJson(process.env.BENCH_SUITES);
-		const suiteList = JSON.parse(suites) as string[];
-
-		if (process.env.GITHUB_OUTPUT) {
-			await withGroup("Plan suite axis", async () => {
-				core.info(`${suiteList.length} suite(s)`);
-				core.debug(`suites=${suites}`);
-				for (const name of suiteList) core.info(`suite: ${name}`);
-			});
-			emitStepOutputs(`suites=${suites}`);
-			if (inActions()) {
-				core.notice(`Planned ${suiteList.length} suite(s)`, { title: "Plan suites" });
-			}
-		} else {
-			process.stdout.write(`${suites}\n`);
-		}
-	} catch (err) {
-		fail(`plan-suites: ${err instanceof Error ? err.message : String(err)}`, {
-			properties: { title: "plan-suites" },
-			exitCode: 2,
-		});
-	}
+	await runAxisPlan(
+		{
+			binName: "plan-suites",
+			envKey: "BENCH_SUITES",
+			outputKey: "suites",
+			groupTitle: "Plan suite axis",
+			noticeTitle: "Plan suites",
+			itemLabel: "suite",
+			help: HELP,
+			select: selectSuites,
+		},
+		process.argv.slice(2),
+	);
 }

--- a/apps/cli/src/bin/promote.ts
+++ b/apps/cli/src/bin/promote.ts
@@ -36,7 +36,7 @@ if (import.meta.main) {
 		const parsed = parseRun(JSON.parse(readFileSync(runFile, "utf8")));
 		logInfo(`runId=${parsed.runId} sha=${parsed.sha} providers=${parsed.providers.length}`);
 		// Already inside withGroup — don't nest another ::group::.
-		logProviderStatuses(parsed, { grouped: false });
+		await logProviderStatuses(parsed, { grouped: false });
 		return parsed;
 	});
 
@@ -98,11 +98,12 @@ if (import.meta.main) {
 		},
 	});
 
-	// Machine-readable line for any caller that still greps stdout (kept after the summary write).
+	// Machine-readable line for any caller that greps stdout — always on stdout (local and Actions)
+	// so `result=$(bun promote …)` keeps working in CI wrappers. Mirror to the step log in Actions.
 	const resultLine = JSON.stringify({
 		promoted: run.runId,
 		validatedProviders: validated,
 	});
+	process.stdout.write(`${resultLine}\n`);
 	if (inActions()) core.info(resultLine);
-	else process.stdout.write(`${resultLine}\n`);
 }

--- a/apps/cli/src/bin/promote.ts
+++ b/apps/cli/src/bin/promote.ts
@@ -3,36 +3,110 @@
 // candidate→promote: it gates on at least one validated provider (so a partial collection with no real
 // metrics can't publish an empty run), then writes the Run into the published dataset + its index. With
 // no publish target it stays a pure validation gate (the original behavior).
+// Uses @actions/core for groups, annotations, and a job summary in CI.
 
 import { readFileSync } from "node:fs";
 import { join } from "node:path";
-import { summarizeRun, writeRunDocument } from "@sandbox-benchmarks/results";
+import * as core from "@actions/core";
+import { writeRunDocument } from "@sandbox-benchmarks/results";
 import { parseRun } from "@sandbox-benchmarks/schema";
+import {
+	fail,
+	inActions,
+	logProviderStatuses,
+	providerSummaryRows,
+	withGroup,
+	writeJobSummary,
+} from "../lib/actions-log.ts";
+
+function logInfo(message: string): void {
+	if (inActions()) core.info(message);
+	else console.error(message);
+}
 
 if (import.meta.main) {
 	const [runFile, datasetDir] = process.argv.slice(2);
 	if (!runFile) {
-		console.error("usage: promote <candidateRun.json> [datasetDir]");
-		process.exit(1);
+		fail("usage: promote <candidateRun.json> [datasetDir]", {
+			properties: { title: "promote usage" },
+			exitCode: 2,
+		});
 	}
-	const run = parseRun(JSON.parse(readFileSync(runFile, "utf8")));
+
+	logInfo(`Promoting candidate ${runFile}`);
+	if (inActions()) core.debug(JSON.stringify({ runFile, datasetDir: datasetDir ?? null }));
+
+	const run = await withGroup("Load candidate Run", async () => {
+		const parsed = parseRun(JSON.parse(readFileSync(runFile, "utf8")));
+		logInfo(`runId=${parsed.runId} sha=${parsed.sha} providers=${parsed.providers.length}`);
+		// Already inside withGroup — don't nest another ::group::.
+		logProviderStatuses(parsed, { grouped: false });
+		return parsed;
+	});
+
 	const validated = run.providers.filter((p) => p.validationStatus === "validated").length;
-	for (const line of summarizeRun(run)) console.log(line);
 
 	// Gate FIRST: a Run with nothing validated (e.g. a partial collection with no PTS XML) must never
 	// reach the published dataset.
 	if (validated === 0) {
-		console.error("promote: refusing to promote a Run with zero validated providers");
-		process.exit(1);
+		await writeJobSummary({
+			heading: `Promote ${run.runId}`,
+			fields: [
+				["Status", "failure", "plain"],
+				["Run id", run.runId, "code"],
+				["Candidate", runFile, "code"],
+				["Validated", "0", "plain"],
+			],
+			tables: [{ heading: "Provider status", rows: providerSummaryRows(run) }],
+			detail: "Refusing to promote a Run with zero validated providers",
+			annotation: {
+				failed: true,
+				title: `Promote ${run.runId}`,
+				message: "refusing to promote a Run with zero validated providers",
+			},
+		});
+		// Annotation already written above — exit without a second ::error::.
+		fail("promote: refusing to promote a Run with zero validated providers", {
+			annotate: false,
+		});
 	}
 
+	let outFile = "";
 	// Publish into the committed dataset (data/dataset/runs/<id>.json + index.json), newest-first index.
 	if (datasetDir) {
-		const outFile = join(datasetDir, "runs", `${run.runId}.json`);
+		outFile = join(datasetDir, "runs", `${run.runId}.json`);
 		const indexFile = join(datasetDir, "index.json");
-		writeRunDocument(run, outFile, indexFile);
-		console.log(`\nPublished ${run.runId} → ${outFile}`);
+		await withGroup(`Publish ${outFile}`, async () => {
+			writeRunDocument(run, outFile, indexFile);
+			logInfo(`Published ${run.runId} → ${outFile}`);
+		});
+	} else {
+		logInfo(`Validation-only promote for ${run.runId} (${validated} validated provider(s))`);
 	}
 
-	console.log(JSON.stringify({ promoted: run.runId, validatedProviders: validated }));
+	await writeJobSummary({
+		heading: `Promote ${run.runId}`,
+		fields: [
+			["Status", "success", "plain"],
+			["Run id", run.runId, "code"],
+			["Validated", String(validated), "plain"],
+			["Providers", String(run.providers.length), "plain"],
+			["SHA", run.sha, "code"],
+			["Dataset", outFile || "(validation only)", "code"],
+		],
+		tables: [{ heading: "Provider status", rows: providerSummaryRows(run) }],
+		annotation: {
+			failed: false,
+			title: `Promote ${run.runId}`,
+			message: `promoted=${run.runId} validatedProviders=${validated}`,
+		},
+	});
+
+	// Machine-readable line for any caller that still greps stdout (kept after the summary write).
+	const resultLine = JSON.stringify({
+		promoted: run.runId,
+		validatedProviders: validated,
+	});
+	if (inActions()) core.info(resultLine);
+	else process.stdout.write(`${resultLine}\n`);
 }

--- a/apps/cli/src/bin/promote.ts
+++ b/apps/cli/src/bin/promote.ts
@@ -13,16 +13,12 @@ import { parseRun } from "@sandbox-benchmarks/schema";
 import {
 	fail,
 	inActions,
+	logInfo,
 	logProviderStatuses,
 	providerSummaryRows,
 	withGroup,
 	writeJobSummary,
 } from "../lib/actions-log.ts";
-
-function logInfo(message: string): void {
-	if (inActions()) core.info(message);
-	else console.error(message);
-}
 
 if (import.meta.main) {
 	const [runFile, datasetDir] = process.argv.slice(2);

--- a/apps/cli/src/bin/release-summary.ts
+++ b/apps/cli/src/bin/release-summary.ts
@@ -5,13 +5,13 @@
 // core.notice/core.error surface the phase result in the run's annotations panel. Inputs arrive as env
 // (the composite maps its `with:` inputs), NOT via core.getInput (that only works for JS/Docker actions).
 import * as core from "@actions/core";
+import type { CellKind } from "../lib/actions-log.ts";
 import {
 	canWriteSummary,
 	escapeHtml,
 	fieldTable,
 	isFailure,
 	renderCell,
-	type CellKind,
 } from "../lib/actions-log.ts";
 
 // Re-export pure helpers so existing unit tests keep importing from this bin path.

--- a/apps/cli/src/bin/release-summary.ts
+++ b/apps/cli/src/bin/release-summary.ts
@@ -5,29 +5,17 @@
 // core.notice/core.error surface the phase result in the run's annotations panel. Inputs arrive as env
 // (the composite maps its `with:` inputs), NOT via core.getInput (that only works for JS/Docker actions).
 import * as core from "@actions/core";
+import {
+	canWriteSummary,
+	escapeHtml,
+	fieldTable,
+	isFailure,
+	renderCell,
+	type CellKind,
+} from "../lib/actions-log.ts";
 
-type Kind = "plain" | "code";
-
-/** Escape the HTML metacharacters so a value (an image ref, a command) can't break — or inject into —
- *  the summary table. Pure + exported for unit testing. */
-export function escapeHtml(value: string): string {
-	return value.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
-}
-
-/** Render a table cell: `code` values are HTML-escaped and wrapped in `<code>`; `plain` prose is only
- *  escaped. Pure + exported for unit testing. */
-export function renderCell(value: string, kind: Kind): string {
-	const escaped = escapeHtml(value);
-	return kind === "code" ? `<code>${escaped}</code>` : escaped;
-}
-
-/** Whether a phase `status` denotes failure. Accepts BOTH spellings in circulation: GitHub's own
- *  `job.status` yields `failure`, while the bake report and this composite's documented vocabulary say
- *  `failed`. Matching only one would render a failed phase as a green notice. Pure + exported. */
-export function isFailure(status: string): boolean {
-	const s = status.trim().toLowerCase();
-	return s === "failure" || s === "failed";
-}
+// Re-export pure helpers so existing unit tests keep importing from this bin path.
+export { escapeHtml, isFailure, renderCell };
 
 if (import.meta.main) {
 	const env = (key: string): string => process.env[key]?.trim() ?? "";
@@ -35,7 +23,7 @@ if (import.meta.main) {
 	const status = env("STATUS");
 
 	// The field vocabulary, in display order. `code` fields (refs, commands, pointers) render monospaced.
-	const fields: Array<[label: string, value: string, kind: Kind]> = [
+	const fields: Array<[label: string, value: string, kind: CellKind]> = [
 		["Status", status, "plain"],
 		["Mode", env("MODE"), "code"],
 		["Source ref", env("SOURCE_REF"), "code"],
@@ -48,36 +36,22 @@ if (import.meta.main) {
 		["Elapsed", env("ELAPSED"), "plain"],
 	];
 
-	// A header row plus one row per non-empty field, so each phase shows only its own facts.
-	// Typed structurally as the (SummaryTableCell | string)[][] core.summary.addTable accepts.
-	const headerRow: Array<{ data: string; header: boolean } | string> = [
-		{ data: "Field", header: true },
-		{ data: "Value", header: true },
-	];
-	const rows = [
-		headerRow,
-		...fields
-			.filter(([, value]) => value.length > 0)
-			.map(([label, value, kind]) => [label, renderCell(value, kind)]),
-	];
+	// `addHeading`/`addLink`/`addRaw` do NOT escape — every value reaching those is escaped by hand.
+	if (canWriteSummary()) {
+		core.summary.addHeading(`Image release: ${escapeHtml(phase)}`, 3).addTable(fieldTable(fields));
 
-	// `addTable` escapes its cells, but `addHeading`/`addLink`/`addRaw` do NOT — @actions/core wraps the
-	// text in a tag and emits it verbatim. So every value reaching those three is escaped here by hand;
-	// otherwise a phase label or artifact name carrying HTML would inject into the job summary, which is
-	// the one release surface an operator reads and trusts.
-	core.summary.addHeading(`Image release: ${escapeHtml(phase)}`, 3).addTable(rows);
+		// Link the uploaded diagnostics artifact to the run's artifacts, so an operator can jump straight there.
+		const diagnostics = env("DIAGNOSTICS");
+		const runUrl = env("RUN_URL");
+		if (diagnostics) {
+			core.summary.addRaw("Diagnostics: ", false);
+			if (runUrl) core.summary.addLink(escapeHtml(diagnostics), `${runUrl}#artifacts`);
+			else core.summary.addRaw(escapeHtml(diagnostics));
+			core.summary.addEOL();
+		}
 
-	// Link the uploaded diagnostics artifact to the run's artifacts, so an operator can jump straight there.
-	const diagnostics = env("DIAGNOSTICS");
-	const runUrl = env("RUN_URL");
-	if (diagnostics) {
-		core.summary.addRaw("Diagnostics: ", false);
-		if (runUrl) core.summary.addLink(escapeHtml(diagnostics), `${runUrl}#artifacts`);
-		else core.summary.addRaw(escapeHtml(diagnostics));
-		core.summary.addEOL();
+		await core.summary.write();
 	}
-
-	await core.summary.write();
 
 	// Surface the phase result in the run's annotations panel (grouped/filterable), not just the log.
 	const title = `Image release: ${phase}${status ? ` — ${status}` : ""}`;
@@ -85,10 +59,6 @@ if (import.meta.main) {
 		[env("IMAGE") && `image=${env("IMAGE")}`, env("PUBLISHED") && `published=${env("PUBLISHED")}`]
 			.filter(Boolean)
 			.join(" · ") || phase;
-	// Both spellings mean the same thing and both are in circulation: GitHub's own `job.status` yields
-	// `failure`, while the bake report (and this composite's documented vocabulary) says `failed`. Match
-	// on either — a release phase that FAILED must never render as a green notice because the caller
-	// picked the other word.
 	if (isFailure(status)) core.error(detail, { title });
 	else core.notice(detail, { title });
 }

--- a/apps/cli/src/lib/actions-log.test.ts
+++ b/apps/cli/src/lib/actions-log.test.ts
@@ -1,10 +1,14 @@
 import { describe, expect, test } from "bun:test";
-import { escapeHtml, isFailure, renderCell } from "./release-summary.ts";
+import type { Run } from "@sandbox-benchmarks/schema";
+import {
+	escapeHtml,
+	fieldTable,
+	isFailure,
+	providerSummaryRows,
+	renderCell,
+} from "./actions-log.ts";
 
 describe("isFailure", () => {
-	// Both spellings are in circulation (GitHub's job.status says `failure`; the bake report and the
-	// composite's documented vocabulary say `failed`). Matching only one renders a FAILED phase as a
-	// green notice — the exact way a broken release looks healthy.
 	test("treats both `failure` and `failed` as failure", () => {
 		expect(isFailure("failure")).toBe(true);
 		expect(isFailure("failed")).toBe(true);
@@ -40,5 +44,38 @@ describe("renderCell", () => {
 	test("leaves plain prose unwrapped (still escaped)", () => {
 		expect(renderCell("2 vCPU / 8 GiB", "plain")).toBe("2 vCPU / 8 GiB");
 		expect(renderCell("<b>", "plain")).toBe("&lt;b&gt;");
+	});
+});
+
+describe("fieldTable", () => {
+	test("drops empty values and renders code cells", () => {
+		const rows = fieldTable([
+			["Status", "success", "plain"],
+			["Skip", "", "plain"],
+			["Suite", "cpu-node", "code"],
+		]);
+		expect(rows).toHaveLength(3); // header + 2 data rows
+		expect(rows[1]).toEqual(["Status", "success"]);
+		expect(rows[2]).toEqual(["Suite", "<code>cpu-node</code>"]);
+	});
+});
+
+describe("providerSummaryRows", () => {
+	test("builds one data row per provider with gap counts", () => {
+		const run = {
+			providers: [
+				{
+					providerId: "e2b",
+					validationStatus: "validated",
+					metrics: [{}, {}],
+					suitesCovered: ["cpu-node"],
+					gaps: [{ outcome: "skipped" }, { outcome: "failed" }, { outcome: "failed" }],
+					uncatalogued: [{}],
+				},
+			],
+		} as unknown as Run;
+		const rows = providerSummaryRows(run);
+		expect(rows).toHaveLength(2);
+		expect(rows[1]).toEqual(["<code>e2b</code>", "validated", "2", "1", "1", "2", "1"]);
 	});
 });

--- a/apps/cli/src/lib/actions-log.ts
+++ b/apps/cli/src/lib/actions-log.ts
@@ -19,6 +19,18 @@ export function canWriteSummary(): boolean {
 	return Boolean(process.env.GITHUB_STEP_SUMMARY?.trim());
 }
 
+/** Info log that uses @actions/core in CI and stderr locally (never pollutes JSON stdout contracts). */
+export function logInfo(message: string): void {
+	if (inActions()) core.info(message);
+	else console.error(message);
+}
+
+/** Warning log that uses @actions/core in CI and stderr locally. */
+export function logWarning(message: string, properties?: AnnotationProperties): void {
+	if (inActions()) core.warning(message, properties);
+	else console.error(message);
+}
+
 /** Escape HTML metacharacters for values reaching core.summary addHeading/addRaw/addLink. */
 export function escapeHtml(value: string): string {
 	return value
@@ -41,7 +53,8 @@ export function isFailure(status: string): boolean {
 	return s === "failure" || s === "failed";
 }
 
-type SummaryRow = Array<{ data: string; header: boolean } | string>;
+/** One job-summary table row (`@actions/core` addTable shape). */
+export type SummaryRow = Array<{ data: string; header: boolean } | string>;
 
 /** Build a Field/Value table from non-empty `[label, value, kind]` rows. */
 export function fieldTable(

--- a/apps/cli/src/lib/actions-log.ts
+++ b/apps/cli/src/lib/actions-log.ts
@@ -1,0 +1,216 @@
+// Shared GitHub Actions Toolkit helpers for CLI bins that also run locally.
+// Prefer @actions/core over console.* so step logs, foldable groups, annotations, and job
+// summaries stay metadata-rich in CI. Outside Actions, avoid emitting workflow-command prefixes
+// onto stdout (they break local JSON contracts); summary writes are gated on $GITHUB_STEP_SUMMARY.
+
+import type { AnnotationProperties } from "@actions/core";
+import * as core from "@actions/core";
+import type { Run } from "@sandbox-benchmarks/schema";
+
+export type CellKind = "plain" | "code";
+
+/** True when the process is running inside a GitHub Actions runner. */
+export function inActions(): boolean {
+	return process.env.GITHUB_ACTIONS === "true";
+}
+
+/** True when the job summary file is available (Actions sets $GITHUB_STEP_SUMMARY). */
+export function canWriteSummary(): boolean {
+	return Boolean(process.env.GITHUB_STEP_SUMMARY?.trim());
+}
+
+/** Escape HTML metacharacters for values reaching core.summary addHeading/addRaw/addLink. */
+export function escapeHtml(value: string): string {
+	return value
+		.replace(/&/g, "&amp;")
+		.replace(/</g, "&lt;")
+		.replace(/>/g, "&gt;")
+		.replace(/"/g, "&quot;")
+		.replace(/'/g, "&#39;");
+}
+
+/** Render a summary table cell: `code` wraps in `<code>` after escaping; `plain` only escapes. */
+export function renderCell(value: string, kind: CellKind): string {
+	const escaped = escapeHtml(value);
+	return kind === "code" ? `<code>${escaped}</code>` : escaped;
+}
+
+/** Whether a status string denotes failure (`failure` / `failed`, either casing). */
+export function isFailure(status: string): boolean {
+	const s = status.trim().toLowerCase();
+	return s === "failure" || s === "failed";
+}
+
+type SummaryRow = Array<{ data: string; header: boolean } | string>;
+
+/** Build a Field/Value table from non-empty `[label, value, kind]` rows. */
+export function fieldTable(
+	fields: Array<[label: string, value: string, kind: CellKind]>,
+): SummaryRow[] {
+	const header: SummaryRow = [
+		{ data: "Field", header: true },
+		{ data: "Value", header: true },
+	];
+	return [
+		header,
+		...fields
+			.filter(([, value]) => value.length > 0)
+			.map(([label, value, kind]) => [label, renderCell(value, kind)]),
+	];
+}
+
+/** Provider-status rows for a Run summary table (one row per provider). */
+export function providerSummaryRows(run: Run): SummaryRow[] {
+	const header: SummaryRow = [
+		{ data: "Provider", header: true },
+		{ data: "Status", header: true },
+		{ data: "Metrics", header: true },
+		{ data: "Suites", header: true },
+		{ data: "Skipped", header: true },
+		{ data: "Failed", header: true },
+		{ data: "Uncatalogued", header: true },
+	];
+	const rows = run.providers.map((provider) => {
+		const skipped = provider.gaps.filter((g) => g.outcome === "skipped").length;
+		const failed = provider.gaps.filter((g) => g.outcome === "failed").length;
+		return [
+			renderCell(provider.providerId, "code"),
+			escapeHtml(provider.validationStatus),
+			escapeHtml(String(provider.metrics.length)),
+			escapeHtml(String(provider.suitesCovered.length)),
+			escapeHtml(String(skipped)),
+			escapeHtml(String(failed)),
+			escapeHtml(String(provider.uncatalogued.length)),
+		];
+	});
+	return [header, ...rows];
+}
+
+/** Log each provider status line; optionally wrap in a foldable group (never nest inside core.group). */
+export function logProviderStatuses(
+	run: Run,
+	opts: { groupTitle?: string; grouped?: boolean } = {},
+): void {
+	const grouped = opts.grouped === true && inActions();
+	if (grouped) core.startGroup(opts.groupTitle ?? "Provider status");
+	for (const provider of run.providers) {
+		const skipped = provider.gaps.filter((g) => g.outcome === "skipped").length;
+		const failed = provider.gaps.filter((g) => g.outcome === "failed").length;
+		const line =
+			`${provider.providerId} status=${provider.validationStatus} ` +
+			`metrics=${provider.metrics.length} suites=${provider.suitesCovered.length} ` +
+			`skipped=${skipped} failed=${failed} uncatalogued=${provider.uncatalogued.length}`;
+		if (inActions()) core.info(line);
+		else console.error(line);
+		if (inActions() && core.isDebug()) {
+			for (const gap of provider.gaps) {
+				core.debug(`  gap ${gap.scope}/${gap.id} ${gap.outcome}: ${gap.reason}`);
+			}
+			if (provider.observedSpecs.cpuModel) {
+				core.debug(
+					`  observed cpu=${provider.observedSpecs.cpuModel}` +
+						(provider.observedSpecs.cpuMicroarch
+							? ` (${provider.observedSpecs.cpuMicroarch})`
+							: ""),
+				);
+			}
+		}
+	}
+	if (grouped) core.endGroup();
+}
+
+/**
+ * Run `fn` inside a foldable Actions group when in CI; otherwise just await `fn` so local stdout
+ * stays free of `::group::` prefixes (needed for single-line JSON contracts).
+ */
+export async function withGroup<T>(title: string, fn: () => Promise<T> | T): Promise<T> {
+	if (inActions()) return await core.group(title, async () => fn());
+	return await fn();
+}
+
+export interface JobSummaryOptions {
+	/** Heading text (HTML-escaped). */
+	heading: string;
+	/** Heading level 1–6 (default 3). */
+	headingLevel?: 1 | 2 | 3 | 4 | 5 | 6;
+	/** Field/value rows for the primary metadata table. */
+	fields: Array<[label: string, value: string, kind: CellKind]>;
+	/** Optional extra tables (e.g. provider status). */
+	tables?: Array<{ heading: string; rows: SummaryRow[] }>;
+	/** Optional free-form detail paragraph. */
+	detail?: string;
+	/**
+	 * Annotation for the run's annotations panel. Failures always annotate; successes stay in the
+	 * job summary unless `noticeOnSuccess` is set (avoids notice spam across matrix cells).
+	 */
+	annotation?: {
+		failed: boolean;
+		title: string;
+		message: string;
+		properties?: AnnotationProperties;
+		noticeOnSuccess?: boolean;
+	};
+}
+
+/**
+ * Write a metadata-rich job summary (when $GITHUB_STEP_SUMMARY is set) and optionally an
+ * annotation. Failure annotations always emit; success notices are opt-in.
+ */
+export async function writeJobSummary(opts: JobSummaryOptions): Promise<void> {
+	if (canWriteSummary()) {
+		core.summary
+			.addHeading(escapeHtml(opts.heading), opts.headingLevel ?? 3)
+			.addTable(fieldTable(opts.fields));
+		for (const table of opts.tables ?? []) {
+			core.summary.addHeading(escapeHtml(table.heading), 4).addTable(table.rows);
+		}
+		if (opts.detail) {
+			core.summary.addRaw(escapeHtml(opts.detail)).addEOL();
+		}
+		await core.summary.write();
+	}
+	if (opts.annotation?.failed) {
+		core.error(opts.annotation.message, {
+			title: opts.annotation.title,
+			...opts.annotation.properties,
+		});
+	} else if (opts.annotation?.noticeOnSuccess) {
+		core.notice(opts.annotation.message, {
+			title: opts.annotation.title,
+			...opts.annotation.properties,
+		});
+	}
+}
+
+export interface FailOptions {
+	/** Titled annotation properties (emits one core.error). */
+	properties?: AnnotationProperties;
+	/** Process exit code (default 1; plan/discovery usage errors use 2). */
+	exitCode?: number;
+	/**
+	 * When false, skip emitting another annotation — the caller already wrote one (e.g.
+	 * writeJobSummary). Non-zero exit still fails the Actions step.
+	 */
+	annotate?: boolean;
+}
+
+/**
+ * Fail the process with at most one Actions annotation. Prefer this over bare `console.error` +
+ * `process.exit`. Do not combine with a prior `core.error` for the same message — `setFailed`
+ * itself annotates, so titled failures use `core.error` alone. Outside Actions, always print to
+ * stderr (never `::error::` workflow commands that mangle multi-line HELP locally).
+ */
+export function fail(message: string, opts: FailOptions = {}): never {
+	const exitCode = opts.exitCode ?? 1;
+	const annotate = opts.annotate !== false;
+	if (inActions()) {
+		if (annotate) {
+			if (opts.properties) core.error(message, opts.properties);
+			else core.setFailed(message);
+		}
+		// annotate:false → silent non-zero exit; caller already wrote the annotation.
+	} else {
+		console.error(message);
+	}
+	process.exit(exitCode);
+}

--- a/apps/cli/src/lib/actions-log.ts
+++ b/apps/cli/src/lib/actions-log.ts
@@ -99,37 +99,41 @@ export function providerSummaryRows(run: Run): SummaryRow[] {
 	return [header, ...rows];
 }
 
-/** Log each provider status line; optionally wrap in a foldable group (never nest inside core.group). */
-export function logProviderStatuses(
+/** Log each provider status line; optionally wrap in a foldable group via {@link withGroup}. */
+export async function logProviderStatuses(
 	run: Run,
 	opts: { groupTitle?: string; grouped?: boolean } = {},
-): void {
-	const grouped = opts.grouped === true && inActions();
-	if (grouped) core.startGroup(opts.groupTitle ?? "Provider status");
-	for (const provider of run.providers) {
-		const skipped = provider.gaps.filter((g) => g.outcome === "skipped").length;
-		const failed = provider.gaps.filter((g) => g.outcome === "failed").length;
-		const line =
-			`${provider.providerId} status=${provider.validationStatus} ` +
-			`metrics=${provider.metrics.length} suites=${provider.suitesCovered.length} ` +
-			`skipped=${skipped} failed=${failed} uncatalogued=${provider.uncatalogued.length}`;
-		if (inActions()) core.info(line);
-		else console.error(line);
-		if (inActions() && core.isDebug()) {
-			for (const gap of provider.gaps) {
-				core.debug(`  gap ${gap.scope}/${gap.id} ${gap.outcome}: ${gap.reason}`);
-			}
-			if (provider.observedSpecs.cpuModel) {
-				core.debug(
-					`  observed cpu=${provider.observedSpecs.cpuModel}` +
-						(provider.observedSpecs.cpuMicroarch
-							? ` (${provider.observedSpecs.cpuMicroarch})`
-							: ""),
-				);
+): Promise<void> {
+	const write = (): void => {
+		for (const provider of run.providers) {
+			const skipped = provider.gaps.filter((g) => g.outcome === "skipped").length;
+			const failed = provider.gaps.filter((g) => g.outcome === "failed").length;
+			const line =
+				`${provider.providerId} status=${provider.validationStatus} ` +
+				`metrics=${provider.metrics.length} suites=${provider.suitesCovered.length} ` +
+				`skipped=${skipped} failed=${failed} uncatalogued=${provider.uncatalogued.length}`;
+			logInfo(line);
+			if (inActions() && core.isDebug()) {
+				for (const gap of provider.gaps) {
+					core.debug(`  gap ${gap.scope}/${gap.id} ${gap.outcome}: ${gap.reason}`);
+				}
+				if (provider.observedSpecs.cpuModel) {
+					core.debug(
+						`  observed cpu=${provider.observedSpecs.cpuModel}` +
+							(provider.observedSpecs.cpuMicroarch
+								? ` (${provider.observedSpecs.cpuMicroarch})`
+								: ""),
+					);
+				}
 			}
 		}
+	};
+	// Prefer withGroup/core.group over startGroup/endGroup so a throw can't leave a dangling group.
+	if (opts.grouped === true) {
+		await withGroup(opts.groupTitle ?? "Provider status", write);
+	} else {
+		write();
 	}
-	if (grouped) core.endGroup();
 }
 
 /**

--- a/apps/cli/src/lib/matrix.ts
+++ b/apps/cli/src/lib/matrix.ts
@@ -12,29 +12,29 @@ export interface MatrixEntry {
 }
 
 /**
- * The providers a dispatch asks the matrix to fan out over, parsed from a comma-separated list (the
- * `BENCH_PROVIDERS` dispatch input). Absent or blank → every registered provider, so the default CI
- * matrix is unchanged and the registry stays the source of truth.
- *
- * An unregistered name THROWS rather than being dropped: a typo'd `--providers e2b,dayton` would
- * otherwise silently shrink the matrix and publish a dataset missing that provider, which reads
- * downstream as "daytona had no results" instead of "you misspelled it". Duplicates collapse, and the
- * result is ordered by the registry, so a dispatch can't reorder or double-run a cell. Matching is
- * case-insensitive (every registered id is lowercase), so a hand-typed `E2B` still selects `e2b`.
+ * Parse a comma-separated dispatch list against a registry: blank → every registered id; unknown names
+ * throw (never silently shrink); duplicates collapse; order follows the registry, not the request;
+ * matching is case-insensitive. Shared by the provider and suite axes so they can't drift.
  */
-export function selectProviders(raw: string | undefined): ProviderId[] {
-	const registered = PROVIDERS.map((p) => p.id);
+export function selectRegistryIds<T extends string>(
+	raw: string | undefined,
+	registered: readonly T[],
+	kind: "provider" | "suite",
+): T[] {
 	const requested = (raw ?? "")
 		.toLowerCase()
 		.split(",")
 		.map((name) => name.trim())
 		.filter((name) => name.length > 0);
-	if (requested.length === 0) return registered;
+	if (requested.length === 0) return [...registered];
 
-	const unknown = requested.filter((name) => !registered.includes(name as ProviderId));
+	const registeredSet = new Set<string>(registered);
+	const unknown = requested.filter((name) => !registeredSet.has(name));
 	if (unknown.length > 0) {
+		const plural = kind === "provider" ? "provider(s)" : "suite(s)";
+		const registeredLabel = kind === "provider" ? "providers" : "suites";
 		throw new Error(
-			`unknown provider(s): ${unknown.join(", ")} — registered providers are ${registered.join(", ")}`,
+			`unknown ${plural}: ${unknown.join(", ")} — registered ${registeredLabel} are ${registered.join(", ")}`,
 		);
 	}
 	// Registry order, not request order: the matrix is a set of cells, and a stable order keeps the CI
@@ -43,30 +43,25 @@ export function selectProviders(raw: string | undefined): ProviderId[] {
 }
 
 /**
- * The suites a dispatch asks the matrix to run, parsed from a comma-separated list (the `BENCH_SUITES`
- * dispatch input). Absent or blank → every registered suite, so the default matrix is unchanged and the
- * registry stays the source of truth. Mirrors {@link selectProviders} on the suite axis: an unregistered
- * name THROWS (a typo must fail the plan, not silently run nothing), duplicates collapse, and the result
- * is ordered by the registry. Matching is case-insensitive to tolerate a hand-typed dispatch input.
+ * The providers a dispatch asks the matrix to fan out over, parsed from a comma-separated list (the
+ * `BENCH_PROVIDERS` dispatch input). Absent or blank → every registered provider, so the default CI
+ * matrix is unchanged and the registry stays the source of truth.
  *
- * This is the pre-merge/targeted-run knob: `BENCH_SUITES=network` runs only the network suite's jobs, so
- * a validation dispatch doesn't have to spend the whole matrix. Blank stays the main-publish default.
+ * An unregistered name THROWS rather than being dropped: a typo'd `--providers e2b,dayton` would
+ * otherwise silently shrink the matrix and publish a dataset missing that provider, which reads
+ * downstream as "daytona had no results" instead of "you misspelled it".
+ */
+export function selectProviders(raw: string | undefined): ProviderId[] {
+	return selectRegistryIds(raw, PROVIDERS.map((p) => p.id), "provider");
+}
+
+/**
+ * The suites a dispatch asks the matrix to run, parsed from a comma-separated list (the `BENCH_SUITES`
+ * dispatch input). Absent or blank → every registered suite. This is the pre-merge/targeted-run knob:
+ * `BENCH_SUITES=network` runs only the network suite's jobs.
  */
 export function selectSuites(raw: string | undefined): SuiteName[] {
-	const requested = (raw ?? "")
-		.toLowerCase()
-		.split(",")
-		.map((name) => name.trim())
-		.filter((name) => name.length > 0);
-	if (requested.length === 0) return [...SUITE_NAMES];
-
-	const unknown = requested.filter((name) => !SUITE_NAMES.includes(name as SuiteName));
-	if (unknown.length > 0) {
-		throw new Error(
-			`unknown suite(s): ${unknown.join(", ")} — registered suites are ${SUITE_NAMES.join(", ")}`,
-		);
-	}
-	return SUITE_NAMES.filter((name) => requested.includes(name));
+	return selectRegistryIds(raw, SUITE_NAMES, "suite");
 }
 
 /**

--- a/apps/cli/src/lib/matrix.ts
+++ b/apps/cli/src/lib/matrix.ts
@@ -52,7 +52,11 @@ export function selectRegistryIds<T extends string>(
  * downstream as "daytona had no results" instead of "you misspelled it".
  */
 export function selectProviders(raw: string | undefined): ProviderId[] {
-	return selectRegistryIds(raw, PROVIDERS.map((p) => p.id), "provider");
+	return selectRegistryIds(
+		raw,
+		PROVIDERS.map((p) => p.id),
+		"provider",
+	);
 }
 
 /**

--- a/apps/cli/src/lib/matrix.ts
+++ b/apps/cli/src/lib/matrix.ts
@@ -43,6 +43,33 @@ export function selectProviders(raw: string | undefined): ProviderId[] {
 }
 
 /**
+ * The suites a dispatch asks the matrix to run, parsed from a comma-separated list (the `BENCH_SUITES`
+ * dispatch input). Absent or blank → every registered suite, so the default matrix is unchanged and the
+ * registry stays the source of truth. Mirrors {@link selectProviders} on the suite axis: an unregistered
+ * name THROWS (a typo must fail the plan, not silently run nothing), duplicates collapse, and the result
+ * is ordered by the registry. Matching is case-insensitive to tolerate a hand-typed dispatch input.
+ *
+ * This is the pre-merge/targeted-run knob: `BENCH_SUITES=network` runs only the network suite's jobs, so
+ * a validation dispatch doesn't have to spend the whole matrix. Blank stays the main-publish default.
+ */
+export function selectSuites(raw: string | undefined): SuiteName[] {
+	const requested = (raw ?? "")
+		.toLowerCase()
+		.split(",")
+		.map((name) => name.trim())
+		.filter((name) => name.length > 0);
+	if (requested.length === 0) return [...SUITE_NAMES];
+
+	const unknown = requested.filter((name) => !SUITE_NAMES.includes(name as SuiteName));
+	if (unknown.length > 0) {
+		throw new Error(
+			`unknown suite(s): ${unknown.join(", ")} — registered suites are ${SUITE_NAMES.join(", ")}`,
+		);
+	}
+	return SUITE_NAMES.filter((name) => requested.includes(name));
+}
+
+/**
  * The full benchmark matrix: every provider × every registered suite. Each cell becomes one CI job
  * (`bench-suite <provider> <suite>`), so the dataset grows by adding a provider or a suite to its
  * registry — never by editing the workflow. Both lists are injectable for unit tests; the defaults are

--- a/apps/cli/src/lib/plan-axis.ts
+++ b/apps/cli/src/lib/plan-axis.ts
@@ -1,0 +1,81 @@
+// Shared runner for the Bench matrix axis planners (`plan-providers` / `plan-suites`).
+// Both bins share one control flow: discovery → select → emitStepOutputs / stdout → fail.
+// Keeping that here means Actions logging and $GITHUB_OUTPUT contracts can't drift per axis.
+import * as core from "@actions/core";
+import { fail, inActions, logInfo, withGroup } from "./actions-log.ts";
+import { handleDiscovery } from "./discovery.ts";
+import { emitStepOutputs } from "./gha-output.ts";
+
+export interface AxisPlanConfig {
+	/** Bin name for error titles / HELP identity (e.g. `plan-providers`). */
+	binName: string;
+	/** Env var holding the comma-separated selection (e.g. `BENCH_PROVIDERS`). */
+	envKey: string;
+	/** `$GITHUB_OUTPUT` key written in Actions (e.g. `providers`). */
+	outputKey: string;
+	/** Foldable group title in Actions. */
+	groupTitle: string;
+	/** Notice annotation title on success. */
+	noticeTitle: string;
+	/** Singular noun for log lines (`provider` / `suite`). */
+	itemLabel: string;
+	/** HELP text the bin exposes via `--help`. */
+	help: string;
+	/** Pure selector for the axis (registry-backed). */
+	select: (raw: string | undefined) => string[];
+}
+
+/** Compact single-line JSON for an axis selection — the local / `$GITHUB_OUTPUT` contract. */
+export function planAxisJson(
+	select: (raw: string | undefined) => string[],
+	raw?: string,
+): string {
+	return JSON.stringify(select(raw));
+}
+
+/**
+ * Run an axis planner bin: discovery flags first, then emit the selected ids. In Actions writes
+ * `$GITHUB_OUTPUT`; locally prints one JSON line on stdout. Never returns on failure.
+ */
+export async function runAxisPlan(config: AxisPlanConfig, argv: string[]): Promise<void> {
+	const discovery = handleDiscovery(argv, config.help);
+	if (discovery !== null) {
+		if (discovery.ok) {
+			process.stdout.write(`${discovery.text}\n`);
+			process.exit(0);
+		}
+		fail(discovery.text, {
+			properties: { title: `${config.binName} discovery` },
+			exitCode: 2,
+		});
+	}
+
+	// A bad selection must fail the step, not print a diagnostic onto stdout: stdout here IS the
+	// axis value local callers capture, so an error message there would be parsed as the axis.
+	try {
+		const json = planAxisJson(config.select, process.env[config.envKey]);
+		const items = JSON.parse(json) as string[];
+
+		if (process.env.GITHUB_OUTPUT) {
+			await withGroup(config.groupTitle, async () => {
+				logInfo(`${items.length} ${config.itemLabel}(s)`);
+				if (inActions()) core.debug(`${config.outputKey}=${json}`);
+				for (const id of items) logInfo(`${config.itemLabel}: ${id}`);
+			});
+			emitStepOutputs(`${config.outputKey}=${json}`);
+			if (inActions()) {
+				core.notice(`Planned ${items.length} ${config.itemLabel}(s)`, {
+					title: config.noticeTitle,
+				});
+			}
+		} else {
+			// Local / test capture: keep the single-line axis stdout contract pristine.
+			process.stdout.write(`${json}\n`);
+		}
+	} catch (err) {
+		fail(`${config.binName}: ${err instanceof Error ? err.message : String(err)}`, {
+			properties: { title: config.binName },
+			exitCode: 2,
+		});
+	}
+}

--- a/apps/cli/src/lib/plan-axis.ts
+++ b/apps/cli/src/lib/plan-axis.ts
@@ -26,10 +26,7 @@ export interface AxisPlanConfig {
 }
 
 /** Compact single-line JSON for an axis selection — the local / `$GITHUB_OUTPUT` contract. */
-export function planAxisJson(
-	select: (raw: string | undefined) => string[],
-	raw?: string,
-): string {
+export function planAxisJson(select: (raw: string | undefined) => string[], raw?: string): string {
 	return JSON.stringify(select(raw));
 }
 

--- a/apps/cli/src/lib/suite-summary.ts
+++ b/apps/cli/src/lib/suite-summary.ts
@@ -1,7 +1,8 @@
 // Actions job-summary table builders for a SuiteTaskPlan.
 // Kept separate from suite-tasks.ts so discovery (mise/bash mining) stays free of HTML / Toolkit
 // presentation concerns — only the CI cell reporter needs these rows.
-import { escapeHtml, renderCell, type SummaryRow } from "./actions-log.ts";
+import type { SummaryRow } from "./actions-log.ts";
+import { escapeHtml, renderCell } from "./actions-log.ts";
 import type { SuiteTaskPlan } from "./suite-tasks.ts";
 
 /** Summary-table rows for the suite's mise tasks (Task / Role / Description / PTS profile). */

--- a/apps/cli/src/lib/suite-summary.ts
+++ b/apps/cli/src/lib/suite-summary.ts
@@ -1,0 +1,54 @@
+// Actions job-summary table builders for a SuiteTaskPlan.
+// Kept separate from suite-tasks.ts so discovery (mise/bash mining) stays free of HTML / Toolkit
+// presentation concerns — only the CI cell reporter needs these rows.
+import { escapeHtml, renderCell, type SummaryRow } from "./actions-log.ts";
+import type { SuiteTaskPlan } from "./suite-tasks.ts";
+
+/** Summary-table rows for the suite's mise tasks (Task / Role / Description / PTS profile). */
+export function suiteTaskSummaryRows(plan: SuiteTaskPlan): SummaryRow[] {
+	const header: SummaryRow = [
+		{ data: "Task", header: true },
+		{ data: "Role", header: true },
+		{ data: "Description", header: true },
+		{ data: "PTS profile", header: true },
+		{ data: "Results prefix", header: true },
+	];
+	if (plan.tasks.length === 0) {
+		return [
+			header,
+			[renderCell("(none)", "code"), "", escapeHtml("No mise run commands on this suite"), "", ""],
+		];
+	}
+	return [
+		header,
+		...plan.tasks.map((task) => [
+			renderCell(task.task, "code"),
+			escapeHtml(task.role),
+			escapeHtml(task.description || task.file || "—"),
+			task.ptsProfile ? renderCell(task.ptsProfile, "code") : "",
+			task.resultsPrefix ? renderCell(task.resultsPrefix, "code") : "",
+		]),
+	];
+}
+
+/** Summary-table rows for the suite's declared catalog metrics. */
+export function suiteMetricSummaryRows(plan: SuiteTaskPlan): SummaryRow[] {
+	const header: SummaryRow = [
+		{ data: "Metric", header: true },
+		{ data: "Label", header: true },
+		{ data: "Dimension", header: true },
+		{ data: "PTS test", header: true },
+	];
+	if (plan.metrics.length === 0) {
+		return [header, [renderCell("(none)", "code"), "", "", ""]];
+	}
+	return [
+		header,
+		...plan.metrics.map((metric) => [
+			renderCell(metric.id, "code"),
+			escapeHtml(metric.label),
+			escapeHtml(metric.dimension),
+			metric.ptsTest ? renderCell(metric.ptsTest, "code") : "",
+		]),
+	];
+}

--- a/apps/cli/src/lib/suite-tasks.test.ts
+++ b/apps/cli/src/lib/suite-tasks.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "bun:test";
 import { readFileSync } from "node:fs";
 import { join } from "node:path";
 import { SUITE_NAMES, SUITES } from "@sandbox-benchmarks/schema";
+import { suiteMetricSummaryRows, suiteTaskSummaryRows } from "./suite-summary.ts";
 import {
 	conventionalTaskFile,
 	describeSuiteTasks,
@@ -11,8 +12,6 @@ import {
 	ptsPinsFromScript,
 	realworldVersionFromBenchSh,
 	runTaskChildren,
-	suiteMetricSummaryRows,
-	suiteTaskSummaryRows,
 } from "./suite-tasks.ts";
 
 // apps/cli/src/lib → repo root

--- a/apps/cli/src/lib/suite-tasks.test.ts
+++ b/apps/cli/src/lib/suite-tasks.test.ts
@@ -1,0 +1,209 @@
+import { describe, expect, it } from "bun:test";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { SUITE_NAMES, SUITES } from "@sandbox-benchmarks/schema";
+import {
+	conventionalTaskFile,
+	describeSuiteTasks,
+	fioProfileFromBenchSh,
+	miseTaskFromCommand,
+	parseMiseTaskInfoJson,
+	ptsPinsFromScript,
+	realworldVersionFromBenchSh,
+	runTaskChildren,
+	suiteMetricSummaryRows,
+	suiteTaskSummaryRows,
+} from "./suite-tasks.ts";
+
+// apps/cli/src/lib → repo root
+const root = join(import.meta.dir, "../../../..");
+
+describe("miseTaskFromCommand", () => {
+	it("extracts the task name from a mise run command", () => {
+		expect(miseTaskFromCommand("mise run benchmark:disk:all")).toBe("benchmark:disk:all");
+		expect(miseTaskFromCommand("  mise run benchmark:cpu:node")).toBe("benchmark:cpu:node");
+	});
+
+	it("returns undefined for non-mise commands", () => {
+		expect(miseTaskFromCommand("echo hi")).toBeUndefined();
+	});
+});
+
+describe("conventionalTaskFile", () => {
+	it("maps colon task names onto the .mise/tasks file layout", () => {
+		expect(conventionalTaskFile("benchmark:disk:all")).toBe(".mise/tasks/benchmark/disk/all");
+		expect(conventionalTaskFile("benchmark:system:pts:pgbench")).toBe(
+			".mise/tasks/benchmark/system/pts/pgbench",
+		);
+	});
+});
+
+describe("runTaskChildren", () => {
+	it("extracts ordered unique run_task children from an orchestrator", () => {
+		const script = readFileSync(join(root, ".mise/tasks/benchmark/disk/all"), "utf8");
+		expect(runTaskChildren(script)).toEqual([
+			"benchmark:disk:pts:fio-seq-read",
+			"benchmark:disk:pts:fio-seq-write",
+			"benchmark:disk:pts:fio-rand-read",
+			"benchmark:disk:pts:fio-rand-write",
+			"benchmark:disk:pts:hardlink",
+		]);
+	});
+});
+
+describe("ptsPinsFromScript", () => {
+	it("reads run_pts_benchmark pins", () => {
+		const script = readFileSync(
+			join(root, ".mise/tasks/benchmark/cpu/pts/node-web-tooling"),
+			"utf8",
+		);
+		expect(ptsPinsFromScript(script)).toEqual([
+			{
+				ptsProfile: "pts/node-web-tooling-1.0.1",
+				resultsPrefix: "pts_node-web-tooling",
+			},
+		]);
+	});
+
+	it("reads run_fio_pts prefixes and applies the fio profile pin", () => {
+		const script = readFileSync(join(root, ".mise/tasks/benchmark/disk/pts/fio-seq-read"), "utf8");
+		expect(ptsPinsFromScript(script, { fioProfile: "pts/fio-2.1.0" })).toEqual([
+			{
+				ptsProfile: "pts/fio-2.1.0",
+				resultsPrefix: "pts_fio-seq-read",
+			},
+		]);
+	});
+
+	it("derives realworld local profile pins", () => {
+		const script = readFileSync(join(root, ".mise/tasks/benchmark/realworld/pts/mastra"), "utf8");
+		expect(ptsPinsFromScript(script)).toEqual([
+			{
+				ptsProfile: "local/realworld-mastra-1.0.0",
+				resultsPrefix: "pts_realworld-mastra",
+			},
+		]);
+	});
+
+	it("collects every pin when a leaf runs multiple PTS scenarios", () => {
+		const script = readFileSync(join(root, ".mise/tasks/benchmark/system/pts/pgbench"), "utf8");
+		expect(ptsPinsFromScript(script)).toEqual([
+			{
+				ptsProfile: "pts/pgbench-1.15.0",
+				resultsPrefix: "pts_pgbench-read-only",
+			},
+			{
+				ptsProfile: "pts/pgbench-1.15.0",
+				resultsPrefix: "pts_pgbench-read-write",
+			},
+		]);
+	});
+
+	it("ignores commented-out helper calls", () => {
+		const script = `
+# run_pts_benchmark "pts/old-1.0.0" "pts_old"
+run_pts_benchmark "pts/new-1.0.0" "pts_new"
+# run_fio_pts "Sequential Read" "1MB" "pts_fio-commented"
+`;
+		expect(ptsPinsFromScript(script, { fioProfile: "pts/fio-2.1.0" })).toEqual([
+			{ ptsProfile: "pts/new-1.0.0", resultsPrefix: "pts_new" },
+		]);
+	});
+});
+
+describe("fioProfileFromBenchSh", () => {
+	it("mines the fio version pin from run_fio_pts in lib/bench.sh", () => {
+		const benchSh = readFileSync(join(root, "lib/bench.sh"), "utf8");
+		expect(fioProfileFromBenchSh(benchSh)).toBe("pts/fio-2.1.0");
+	});
+
+	it("ignores commented pins outside the function body", () => {
+		const fake = `
+# run_pinned_pts "pts/fio-9.9.9" "pts_fake"
+run_fio_pts() {
+	run_pinned_pts "pts/fio-2.1.0" "$prefix"
+}
+`;
+		expect(fioProfileFromBenchSh(fake)).toBe("pts/fio-2.1.0");
+	});
+
+	it("ignores a commented-out function stub before the real definition", () => {
+		const fake = `
+# run_fio_pts() {
+# 	run_pinned_pts "pts/fio-9.9.9" "$prefix"
+# }
+run_fio_pts() {
+	run_pinned_pts "pts/fio-2.1.0" "$prefix"
+}
+`;
+		expect(fioProfileFromBenchSh(fake)).toBe("pts/fio-2.1.0");
+	});
+});
+
+describe("realworldVersionFromBenchSh", () => {
+	it("mines the realworld profile version from run_realworld_pts", () => {
+		const benchSh = readFileSync(join(root, "lib/bench.sh"), "utf8");
+		expect(realworldVersionFromBenchSh(benchSh)).toBe("1.0.0");
+	});
+});
+
+describe("parseMiseTaskInfoJson", () => {
+	it("keeps name, description, and file from mise task info --json", () => {
+		expect(
+			parseMiseTaskInfoJson(
+				JSON.stringify({
+					name: "benchmark:disk:all",
+					description: "Run disk benchmarks",
+					file: "/repo/.mise/tasks/benchmark/disk/all",
+				}),
+			),
+		).toEqual({
+			name: "benchmark:disk:all",
+			description: "Run disk benchmarks",
+			file: "/repo/.mise/tasks/benchmark/disk/all",
+		});
+	});
+});
+
+describe("describeSuiteTasks", () => {
+	it("expands every registered suite's commands into mise leaves with PTS metadata", async () => {
+		for (const suite of SUITE_NAMES) {
+			const plan = await describeSuiteTasks(suite, root);
+			expect(plan.suite).toBe(suite);
+			expect(plan.commands).toEqual([...SUITES[suite].commands]);
+			expect(plan.tasks.length).toBeGreaterThan(0);
+			expect(plan.tasks.some((t) => t.role === "command")).toBe(true);
+			// Orchestrators expand to leaves; leaf suites (realworld-*) are themselves leaves.
+			expect(plan.metrics.map((m) => m.id)).toEqual([...SUITES[suite].metrics]);
+		}
+	});
+
+	it("surfaces disk fio leaves with mise descriptions and the fio profile pin", async () => {
+		const plan = await describeSuiteTasks("disk", root);
+		const fio = plan.tasks.find((t) => t.task === "benchmark:disk:pts:fio-seq-read");
+		expect(fio?.role).toBe("leaf");
+		expect(fio?.description).toContain("fio sequential read");
+		expect(fio?.ptsProfile).toBe("pts/fio-2.1.0");
+		expect(fio?.resultsPrefix).toBe("pts_fio-seq-read");
+		expect(fio?.file).toBe(".mise/tasks/benchmark/disk/pts/fio-seq-read");
+	});
+
+	it("joins multi-pin leaves (pgbench) into comma-separated summary fields", async () => {
+		const plan = await describeSuiteTasks("system", root);
+		const pgbench = plan.tasks.find((t) => t.task === "benchmark:system:pts:pgbench");
+		expect(pgbench?.ptsProfile).toBe("pts/pgbench-1.15.0");
+		expect(pgbench?.resultsPrefix).toBe("pts_pgbench-read-only, pts_pgbench-read-write");
+	});
+});
+
+describe("summary rows", () => {
+	it("renders task and metric tables for a suite plan", async () => {
+		const plan = await describeSuiteTasks("cpu-node", root);
+		const taskRows = suiteTaskSummaryRows(plan);
+		expect(taskRows[0]?.[0]).toEqual({ data: "Task", header: true });
+		expect(taskRows.length).toBeGreaterThan(1);
+		const metricRows = suiteMetricSummaryRows(plan);
+		expect(metricRows[0]?.[0]).toEqual({ data: "Metric", header: true });
+		expect(metricRows.length).toBe(1 + plan.metrics.length);
+	});
+});

--- a/apps/cli/src/lib/suite-tasks.ts
+++ b/apps/cli/src/lib/suite-tasks.ts
@@ -1,4 +1,4 @@
-// Discover the precise mise tasks a suite runs — for metadata-rich GHA job summaries.
+// Discover the precise mise tasks a suite runs — pure domain planning for metadata-rich summaries.
 // Sources (automated, no hard-coded per-suite leaf lists):
 //   1. SUITES[suite].commands — what the harness actually steps
 //   2. `mise task info <name> --json` — description + task file path
@@ -6,32 +6,14 @@
 //   4. Orchestrator file `run_task` lines — leaf expansion (mise `depends` is unused here)
 //   5. Leaf file PTS helper calls + lib/bench.sh pins — profile / results-prefix metadata
 //   6. Schema Metric Catalog — declared metrics with PTS test ids / labels
+//
+// Actions HTML table rendering lives in suite-summary.ts so this module stays free of Toolkit/
+// presentation concerns. Callers pass an explicit `root` (tests) or default to process.cwd()
+// (CI / local bins already run from the monorepo root).
 import { existsSync, readFileSync } from "node:fs";
-import { dirname, join, relative, resolve, sep } from "node:path";
+import { relative, resolve, sep } from "node:path";
 import type { SuiteName } from "@sandbox-benchmarks/schema";
 import { getMetric, SUITES } from "@sandbox-benchmarks/schema";
-import { escapeHtml, renderCell } from "./actions-log.ts";
-
-/** Walk up from `start` until a package.json declaring `workspaces` is found (the monorepo root). */
-function findRepoRoot(start: string = process.cwd()): string {
-	let dir = resolve(start);
-	for (;;) {
-		const pj = join(dir, "package.json");
-		if (existsSync(pj)) {
-			try {
-				const pkg = JSON.parse(readFileSync(pj, "utf8")) as { workspaces?: unknown };
-				if (pkg.workspaces) return dir;
-			} catch {
-				// keep walking
-			}
-		}
-		const parent = dirname(dir);
-		if (parent === dir) {
-			throw new Error("could not locate repo root (no package.json with workspaces)");
-		}
-		dir = parent;
-	}
-}
 
 /** One PTS/local pin mined from a leaf task script. */
 export interface PtsPin {
@@ -270,7 +252,7 @@ function joinPins(pins: PtsPin[], key: keyof PtsPin): string {
  */
 export async function describeSuiteTasks(
 	suiteName: string,
-	root: string = findRepoRoot(),
+	root: string = process.cwd(),
 ): Promise<SuiteTaskPlan> {
 	if (!(suiteName in SUITES)) {
 		throw new Error(`unknown suite "${suiteName}" — not in SUITE_NAMES`);
@@ -327,57 +309,4 @@ export async function describeSuiteTasks(
 		tasks,
 		metrics: suiteMetricInfo(suiteName as SuiteName),
 	};
-}
-
-/** Summary-table rows for the suite's mise tasks (Task / Role / Description / PTS profile). */
-export function suiteTaskSummaryRows(
-	plan: SuiteTaskPlan,
-): Array<Array<{ data: string; header: boolean } | string>> {
-	const header = [
-		{ data: "Task", header: true },
-		{ data: "Role", header: true },
-		{ data: "Description", header: true },
-		{ data: "PTS profile", header: true },
-		{ data: "Results prefix", header: true },
-	];
-	if (plan.tasks.length === 0) {
-		return [
-			header,
-			[renderCell("(none)", "code"), "", escapeHtml("No mise run commands on this suite"), "", ""],
-		];
-	}
-	return [
-		header,
-		...plan.tasks.map((task) => [
-			renderCell(task.task, "code"),
-			escapeHtml(task.role),
-			escapeHtml(task.description || task.file || "—"),
-			task.ptsProfile ? renderCell(task.ptsProfile, "code") : "",
-			task.resultsPrefix ? renderCell(task.resultsPrefix, "code") : "",
-		]),
-	];
-}
-
-/** Summary-table rows for the suite's declared catalog metrics. */
-export function suiteMetricSummaryRows(
-	plan: SuiteTaskPlan,
-): Array<Array<{ data: string; header: boolean } | string>> {
-	const header = [
-		{ data: "Metric", header: true },
-		{ data: "Label", header: true },
-		{ data: "Dimension", header: true },
-		{ data: "PTS test", header: true },
-	];
-	if (plan.metrics.length === 0) {
-		return [header, [renderCell("(none)", "code"), "", "", ""]];
-	}
-	return [
-		header,
-		...plan.metrics.map((metric) => [
-			renderCell(metric.id, "code"),
-			escapeHtml(metric.label),
-			escapeHtml(metric.dimension),
-			metric.ptsTest ? renderCell(metric.ptsTest, "code") : "",
-		]),
-	];
 }

--- a/apps/cli/src/lib/suite-tasks.ts
+++ b/apps/cli/src/lib/suite-tasks.ts
@@ -1,0 +1,383 @@
+// Discover the precise mise tasks a suite runs — for metadata-rich GHA job summaries.
+// Sources (automated, no hard-coded per-suite leaf lists):
+//   1. SUITES[suite].commands — what the harness actually steps
+//   2. `mise task info <name> --json` — description + task file path
+//   3. Conventional `.mise/tasks/<colon-path>` fallback when mise is unavailable
+//   4. Orchestrator file `run_task` lines — leaf expansion (mise `depends` is unused here)
+//   5. Leaf file PTS helper calls + lib/bench.sh pins — profile / results-prefix metadata
+//   6. Schema Metric Catalog — declared metrics with PTS test ids / labels
+import { existsSync, readFileSync } from "node:fs";
+import { dirname, join, relative, resolve, sep } from "node:path";
+import type { SuiteName } from "@sandbox-benchmarks/schema";
+import { getMetric, SUITES } from "@sandbox-benchmarks/schema";
+import { escapeHtml, renderCell } from "./actions-log.ts";
+
+/** Walk up from `start` until a package.json declaring `workspaces` is found (the monorepo root). */
+function findRepoRoot(start: string = process.cwd()): string {
+	let dir = resolve(start);
+	for (;;) {
+		const pj = join(dir, "package.json");
+		if (existsSync(pj)) {
+			try {
+				const pkg = JSON.parse(readFileSync(pj, "utf8")) as { workspaces?: unknown };
+				if (pkg.workspaces) return dir;
+			} catch {
+				// keep walking
+			}
+		}
+		const parent = dirname(dir);
+		if (parent === dir) {
+			throw new Error("could not locate repo root (no package.json with workspaces)");
+		}
+		dir = parent;
+	}
+}
+
+/** One PTS/local pin mined from a leaf task script. */
+export interface PtsPin {
+	ptsProfile: string;
+	resultsPrefix: string;
+}
+
+/** One mise task the suite plans to run (root command or expanded leaf). */
+export interface SuiteTask {
+	/** Mise task name, e.g. `benchmark:disk:pts:fio-seq-read`. */
+	task: string;
+	/** `#MISE description` / `mise task info` description when available. */
+	description: string;
+	/** Repo-relative task file path when resolvable. */
+	file: string;
+	/** Role in the suite: top-level harness command vs expanded `run_task` child. */
+	role: "command" | "leaf";
+	/** Version-pinned PTS/local profiles (joined with `, ` when a leaf runs several). */
+	ptsProfile: string;
+	/** Results-tree prefixes (joined with `, ` when a leaf runs several). */
+	resultsPrefix: string;
+}
+
+/** Catalogued metrics the suite declares — companion to the task list. */
+export interface SuiteMetricInfo {
+	id: string;
+	label: string;
+	dimension: string;
+	ptsTest: string;
+	ptsDescription: string;
+}
+
+/** Full plan for a suite: harness commands, expanded leaves, and declared metrics. */
+export interface SuiteTaskPlan {
+	suite: string;
+	commands: string[];
+	tasks: SuiteTask[];
+	metrics: SuiteMetricInfo[];
+}
+
+const MISE_RUN_RE = /^\s*mise\s+run\s+(\S+)/;
+const RUN_TASK_RE = /^\s*run_task\s+(\S+)/gm;
+const PTS_BENCHMARK_RE = /^\s*run_(?:pts_benchmark|pinned_pts)\s+"([^"]+)"\s+"([^"]+)"/gm;
+const FIO_PTS_RE = /^\s*run_fio_pts\s+"[^"]+"\s+"[^"]+"\s+"([^"]+)"/gm;
+const REALWORLD_PTS_RE = /^\s*run_realworld_pts\s+(\S+)/gm;
+
+/** Extract the mise task name from a suite command like `mise run benchmark:disk:all`. */
+export function miseTaskFromCommand(command: string): string | undefined {
+	const match = command.match(MISE_RUN_RE);
+	return match?.[1];
+}
+
+/**
+ * Conventional file-backed task path for a colon task name (`.mise/tasks/benchmark/disk/all`).
+ * Used when `mise task info` is unavailable so leaf expansion still works.
+ */
+export function conventionalTaskFile(task: string): string {
+	return `.mise/tasks/${task.replaceAll(":", "/")}`;
+}
+
+/** Every `run_task <name>` child in an orchestrator script (order preserved, de-duped). */
+export function runTaskChildren(script: string): string[] {
+	const seen = new Set<string>();
+	const children: string[] = [];
+	for (const match of script.matchAll(RUN_TASK_RE)) {
+		const task = match[1];
+		if (!task || seen.has(task)) continue;
+		seen.add(task);
+		children.push(task);
+	}
+	return children;
+}
+
+/** All PTS profile + results-prefix pins mined from a leaf task script. */
+export function ptsPinsFromScript(
+	script: string,
+	opts: { fioProfile?: string; realworldVersion?: string } = {},
+): PtsPin[] {
+	// Ignore `#` comment lines so commented-out helper calls never become summary pins.
+	const active = stripBashComments(script);
+	const pins: PtsPin[] = [];
+	for (const match of active.matchAll(PTS_BENCHMARK_RE)) {
+		pins.push({ ptsProfile: match[1] ?? "", resultsPrefix: match[2] ?? "" });
+	}
+	for (const match of active.matchAll(FIO_PTS_RE)) {
+		pins.push({
+			// Empty when bench.sh wasn't readable — don't invent an unpinned `pts/fio` label.
+			ptsProfile: opts.fioProfile ?? "",
+			resultsPrefix: match[1] ?? "",
+		});
+	}
+	const realworldVersion = opts.realworldVersion ?? "1.0.0";
+	for (const match of active.matchAll(REALWORLD_PTS_RE)) {
+		const repo = match[1] ?? "";
+		pins.push({
+			ptsProfile: `local/realworld-${repo}-${realworldVersion}`,
+			resultsPrefix: `pts_realworld-${repo}`,
+		});
+	}
+	return pins;
+}
+
+/** Strip `#` comment lines so pin mining can't latch onto commented-out calls. */
+function stripBashComments(text: string): string {
+	return text
+		.split("\n")
+		.filter((line) => !/^\s*#/.test(line))
+		.join("\n");
+}
+
+/**
+ * Body of a `name()` bash function (best-effort). Used to scope pin mining so a comment outside
+ * the function can't satisfy a loose regex. Comments are stripped first so a commented-out stub
+ * can't win over the real function.
+ */
+function bashFunctionBody(source: string, name: string): string | undefined {
+	const active = stripBashComments(source);
+	const match = active.match(new RegExp(`${name}\\(\\)\\s*\\{([\\s\\S]*?)\\n\\}`));
+	return match?.[1];
+}
+
+/**
+ * The fio profile pin inside `run_fio_pts` in lib/bench.sh (e.g. `pts/fio-2.1.0`). Automated so a
+ * bump in bench.sh shows up in summaries without a parallel edit here.
+ */
+export function fioProfileFromBenchSh(benchSh: string): string | undefined {
+	const body = bashFunctionBody(benchSh, "run_fio_pts");
+	if (!body) return undefined;
+	const match = stripBashComments(body).match(/run_pinned_pts\s+"([^"]+)"/);
+	return match?.[1];
+}
+
+/**
+ * The realworld profile version suffix inside `run_realworld_pts` (e.g. `1.0.0` from
+ * `profile="realworld-${repo}-1.0.0"`).
+ */
+export function realworldVersionFromBenchSh(benchSh: string): string | undefined {
+	const body = bashFunctionBody(benchSh, "run_realworld_pts");
+	if (!body) return undefined;
+	const match = stripBashComments(body).match(/profile="realworld-\$\{repo\}-([^"]+)"/);
+	return match?.[1];
+}
+
+interface MiseTaskInfo {
+	name: string;
+	description: string;
+	file: string;
+}
+
+/** Parse `mise task info --json` stdout into the fields we surface. Pure for testing. */
+export function parseMiseTaskInfoJson(json: string): MiseTaskInfo | undefined {
+	let raw: unknown;
+	try {
+		raw = JSON.parse(json);
+	} catch {
+		return undefined;
+	}
+	if (!raw || typeof raw !== "object") return undefined;
+	const obj = raw as Record<string, unknown>;
+	const name = typeof obj.name === "string" ? obj.name : "";
+	if (!name) return undefined;
+	const description = typeof obj.description === "string" ? obj.description : "";
+	const file =
+		(typeof obj.file === "string" && obj.file) ||
+		(typeof obj.source === "string" && obj.source) ||
+		"";
+	return { name, description, file };
+}
+
+async function miseTaskInfo(task: string, cwd: string): Promise<MiseTaskInfo | undefined> {
+	try {
+		const proc = Bun.spawn(["mise", "task", "info", task, "--json"], {
+			cwd,
+			stdout: "pipe",
+			stderr: "pipe",
+		});
+		const [stdout, exitCode] = await Promise.all([new Response(proc.stdout).text(), proc.exited]);
+		if (exitCode !== 0) return undefined;
+		return parseMiseTaskInfoJson(stdout);
+	} catch {
+		return undefined;
+	}
+}
+
+function relFile(absOrRel: string, root: string): string {
+	if (!absOrRel) return "";
+	const abs = resolve(absOrRel);
+	const rel = relative(root, abs);
+	return rel.startsWith("..") ? "" : rel;
+}
+
+/** Resolve a task file under the repo root — mise path first, then the conventional file layout. */
+function resolveTaskFile(task: string, miseFile: string | undefined, root: string): string {
+	const fromMise = miseFile ? relFile(miseFile, root) : "";
+	if (fromMise && existsSync(resolve(root, fromMise))) return fromMise;
+	const conventional = conventionalTaskFile(task);
+	if (existsSync(resolve(root, conventional))) return conventional;
+	return fromMise;
+}
+
+/** Refuse to read task files outside the repo root (symlink / absolute-path hardening). */
+function readRepoFile(root: string, relPath: string): string | undefined {
+	if (!relPath) return undefined;
+	const abs = resolve(root, relPath);
+	const rel = relative(root, abs);
+	if (rel.startsWith("..") || rel.split(sep).includes("..")) return undefined;
+	try {
+		return readFileSync(abs, "utf8");
+	} catch {
+		return undefined;
+	}
+}
+
+function suiteMetricInfo(suiteName: SuiteName): SuiteMetricInfo[] {
+	const suite = SUITES[suiteName];
+	return suite.metrics.map((id) => {
+		const def = getMetric(id);
+		return {
+			id,
+			label: def?.label ?? id,
+			dimension: def?.dimension ?? "",
+			ptsTest: def?.pts?.test ?? "",
+			ptsDescription: def?.pts?.description ?? "",
+		};
+	});
+}
+
+function joinPins(pins: PtsPin[], key: keyof PtsPin): string {
+	return [...new Set(pins.map((p) => p[key]).filter(Boolean))].join(", ");
+}
+
+/**
+ * Build the suite's task plan from the schema registry + mise task metadata + task-file PTS pins.
+ * Throws when `suiteName` is not registered. Mise lookup failures degrade to the conventional
+ * task-file path so leaf expansion still works without a mise binary.
+ */
+export async function describeSuiteTasks(
+	suiteName: string,
+	root: string = findRepoRoot(),
+): Promise<SuiteTaskPlan> {
+	if (!(suiteName in SUITES)) {
+		throw new Error(`unknown suite "${suiteName}" — not in SUITE_NAMES`);
+	}
+	const suite = SUITES[suiteName as SuiteName];
+	const commands = [...suite.commands];
+
+	let fioProfile: string | undefined;
+	let realworldVersion: string | undefined;
+	try {
+		const benchSh = readFileSync(resolve(root, "lib/bench.sh"), "utf8");
+		fioProfile = fioProfileFromBenchSh(benchSh);
+		realworldVersion = realworldVersionFromBenchSh(benchSh);
+	} catch {
+		// Optional enrichment — keep expanding tasks without bench.sh pins.
+	}
+
+	const tasks: SuiteTask[] = [];
+	const seen = new Set<string>();
+
+	const pushTask = async (taskName: string, role: "command" | "leaf"): Promise<string> => {
+		if (seen.has(taskName)) return "";
+		seen.add(taskName);
+		const info = await miseTaskInfo(taskName, root);
+		const file = resolveTaskFile(taskName, info?.file, root);
+		const script = file ? readRepoFile(root, file) : undefined;
+		const pins = script ? ptsPinsFromScript(script, { fioProfile, realworldVersion }) : [];
+		tasks.push({
+			task: taskName,
+			description: info?.description ?? "",
+			file,
+			role,
+			ptsProfile: joinPins(pins, "ptsProfile"),
+			resultsPrefix: joinPins(pins, "resultsPrefix"),
+		});
+		return file;
+	};
+
+	for (const command of commands) {
+		const rootTask = miseTaskFromCommand(command);
+		if (!rootTask) continue;
+		const file = await pushTask(rootTask, "command");
+		if (!file) continue;
+		const script = readRepoFile(root, file);
+		if (!script) continue;
+		for (const child of runTaskChildren(script)) {
+			await pushTask(child, "leaf");
+		}
+	}
+
+	return {
+		suite: suiteName,
+		commands,
+		tasks,
+		metrics: suiteMetricInfo(suiteName as SuiteName),
+	};
+}
+
+/** Summary-table rows for the suite's mise tasks (Task / Role / Description / PTS profile). */
+export function suiteTaskSummaryRows(
+	plan: SuiteTaskPlan,
+): Array<Array<{ data: string; header: boolean } | string>> {
+	const header = [
+		{ data: "Task", header: true },
+		{ data: "Role", header: true },
+		{ data: "Description", header: true },
+		{ data: "PTS profile", header: true },
+		{ data: "Results prefix", header: true },
+	];
+	if (plan.tasks.length === 0) {
+		return [
+			header,
+			[renderCell("(none)", "code"), "", escapeHtml("No mise run commands on this suite"), "", ""],
+		];
+	}
+	return [
+		header,
+		...plan.tasks.map((task) => [
+			renderCell(task.task, "code"),
+			escapeHtml(task.role),
+			escapeHtml(task.description || task.file || "—"),
+			task.ptsProfile ? renderCell(task.ptsProfile, "code") : "",
+			task.resultsPrefix ? renderCell(task.resultsPrefix, "code") : "",
+		]),
+	];
+}
+
+/** Summary-table rows for the suite's declared catalog metrics. */
+export function suiteMetricSummaryRows(
+	plan: SuiteTaskPlan,
+): Array<Array<{ data: string; header: boolean } | string>> {
+	const header = [
+		{ data: "Metric", header: true },
+		{ data: "Label", header: true },
+		{ data: "Dimension", header: true },
+		{ data: "PTS test", header: true },
+	];
+	if (plan.metrics.length === 0) {
+		return [header, [renderCell("(none)", "code"), "", "", ""]];
+	}
+	return [
+		header,
+		...plan.metrics.map((metric) => [
+			renderCell(metric.id, "code"),
+			escapeHtml(metric.label),
+			escapeHtml(metric.dimension),
+			metric.ptsTest ? renderCell(metric.ptsTest, "code") : "",
+		]),
+	];
+}

--- a/apps/cli/src/plan-matrix.test.ts
+++ b/apps/cli/src/plan-matrix.test.ts
@@ -5,7 +5,7 @@ import { handleDiscovery } from "./lib/discovery.ts";
 import { selectProviders } from "./lib/matrix.ts";
 
 describe("plan-matrix", () => {
-	it("emits a single line of compact JSON (the $GITHUB_OUTPUT contract)", () => {
+	it("emits a single line of compact JSON (local cell-list contract)", () => {
 		const out = planMatrixJson();
 		// Single line: no embedded newlines and no pretty-print indentation.
 		expect(out).not.toContain("\n");
@@ -39,8 +39,10 @@ describe("plan-matrix", () => {
 		) as Array<{ name: string }>;
 		expect(suites.map((s) => s.name)).toEqual([...SUITE_NAMES]);
 
-		// A bare invocation has no discovery flag, so the matrix path (the GITHUB_OUTPUT contract) runs.
+		// A bare invocation has no discovery flag, so the cell-list path runs.
 		expect(handleDiscovery([], HELP)).toBeNull();
+		expect(HELP).toContain("plan-providers");
+		expect(HELP).toContain("plan-suites");
 	});
 
 	it("narrows the matrix to the providers a dispatch names, still one line of JSON", () => {

--- a/apps/cli/src/plan-providers.test.ts
+++ b/apps/cli/src/plan-providers.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from "bun:test";
+import { PROVIDERS, SUITE_NAMES } from "@sandbox-benchmarks/schema";
+import { HELP, planProvidersJson } from "./bin/plan-providers.ts";
+import { handleDiscovery } from "./lib/discovery.ts";
+
+describe("plan-providers", () => {
+	it("emits a single line of compact JSON array (the $GITHUB_OUTPUT contract)", () => {
+		const out = planProvidersJson();
+		// Single line: no embedded newlines and no pretty-print indentation.
+		expect(out).not.toContain("\n");
+		expect(out).not.toMatch(/\n\s+/);
+
+		const parsed = JSON.parse(out) as string[];
+		// Every registered provider, in registry order — the provider axis each suite job fans out over.
+		expect(parsed).toEqual(PROVIDERS.map((p) => p.id));
+	});
+
+	it("narrows to the providers a dispatch names, still one line of JSON", () => {
+		// Reverse request order so this fails if the planner preserves input order instead of registry order.
+		const out = planProvidersJson("daytona,e2b");
+		expect(out).not.toContain("\n");
+		// Registry order, not request order — the CI job list can't be reordered by a dispatch.
+		expect(JSON.parse(out)).toEqual(["e2b", "daytona"]);
+	});
+
+	it("throws on an unregistered name rather than shrinking the matrix", () => {
+		// A typo'd provider must fail the plan step, not silently publish a dataset missing it.
+		expect(() => planProvidersJson("e2b,dayton")).toThrow(/unknown provider\(s\): dayton/);
+	});
+
+	it("exposes agent-friendly discovery: --help and --list-* listings the bin wires", () => {
+		expect(handleDiscovery(["--help"], HELP)).toEqual({ text: HELP, ok: true });
+		expect(HELP).toContain("plan-providers");
+		expect(HELP).toContain("examples:");
+
+		// Every registered provider and suite is discoverable through the bin's listings.
+		const listed = handleDiscovery(["--list-providers"], HELP)?.text ?? "";
+		for (const meta of PROVIDERS) expect(listed).toContain(meta.id);
+		const suites = JSON.parse(
+			handleDiscovery(["--list-suites", "--json"], HELP)?.text ?? "[]",
+		) as Array<{ name: string }>;
+		expect(suites.map((s) => s.name)).toEqual([...SUITE_NAMES]);
+
+		// A bare invocation has no discovery flag, so the providers path (the GITHUB_OUTPUT contract) runs.
+		expect(handleDiscovery([], HELP)).toBeNull();
+	});
+});

--- a/apps/cli/src/plan-suites.test.ts
+++ b/apps/cli/src/plan-suites.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from "bun:test";
+import { PROVIDERS, SUITE_NAMES } from "@sandbox-benchmarks/schema";
+import { HELP, planSuitesJson } from "./bin/plan-suites.ts";
+import { handleDiscovery } from "./lib/discovery.ts";
+import { selectSuites } from "./lib/matrix.ts";
+
+describe("plan-suites", () => {
+	it("emits a single line of compact JSON array (the $GITHUB_OUTPUT contract)", () => {
+		const out = planSuitesJson();
+		expect(out).not.toContain("\n");
+		expect(out).not.toMatch(/\n\s+/);
+		// Every registered suite, in registry order — each suite job is gated on membership here.
+		expect(JSON.parse(out)).toEqual([...SUITE_NAMES]);
+	});
+
+	it("narrows to the suites a dispatch names, still one line of JSON", () => {
+		const out = planSuitesJson("network");
+		expect(out).not.toContain("\n");
+		expect(JSON.parse(out)).toEqual(["network"]);
+	});
+
+	it("throws on an unregistered name rather than silently running nothing", () => {
+		expect(() => planSuitesJson("network,netwrk")).toThrow(/unknown suite\(s\): netwrk/);
+	});
+
+	it("exposes agent-friendly discovery: --help and --list-* listings the bin wires", () => {
+		expect(handleDiscovery(["--help"], HELP)).toEqual({ text: HELP, ok: true });
+		expect(HELP).toContain("plan-suites");
+		expect(HELP).toContain("examples:");
+		const listed = handleDiscovery(["--list-providers"], HELP)?.text ?? "";
+		for (const meta of PROVIDERS) expect(listed).toContain(meta.id);
+		expect(handleDiscovery([], HELP)).toBeNull();
+	});
+});
+
+describe("selectSuites", () => {
+	it("defaults to every registered suite when unset or blank", () => {
+		expect(selectSuites(undefined)).toEqual([...SUITE_NAMES]);
+		expect(selectSuites("")).toEqual([...SUITE_NAMES]);
+		expect(selectSuites("  , ,")).toEqual([...SUITE_NAMES]);
+	});
+
+	it("throws on an unregistered name rather than running nothing", () => {
+		expect(() => selectSuites("network,gpu")).toThrow(/unknown suite\(s\): gpu/);
+		expect(() => selectSuites("network,gpu")).toThrow(/registered suites are/);
+	});
+
+	it("collapses duplicates and orders by the registry, not by the request", () => {
+		expect(selectSuites("network,memory,network")).toEqual(["memory", "network"]);
+	});
+
+	it("tolerates whitespace and mixed casing around names", () => {
+		expect(selectSuites(" Network , Memory ")).toEqual(["memory", "network"]);
+	});
+});

--- a/docs/ci-secrets.md
+++ b/docs/ci-secrets.md
@@ -13,14 +13,20 @@ and toolchain publish must not trigger on `push`.
 | Workflow | Job | Why |
 | --- | --- | --- |
 | `toolchain-image.yml` | `publish` | Provider bake secrets + `packages: write` (GHCR release) |
-| `bench-matrix.yml` | `bench` | Provider API keys |
+| `bench-suite.yml` | `bench` | Provider API keys (reusable fan-out `bench-matrix.yml`'s suite-matrix job calls) |
 | `publish-dataset.yml` | `publish` | Dataset + leaderboard publish (`contents: write` + `pull-requests: write`) |
 | `bench-smoke.yml` | `smoke` | Provider API keys |
 
-`publish-dataset.yml` is a reusable workflow: `bench-matrix.yml`'s `publish` job calls it at the end
-of a matrix run, and a maintainer can dispatch it standalone to backfill (see rule 6). A `uses:` caller
-can't declare `environment:`, so the `privileged` gate lives on the reusable workflow's own job — the
-workflow-hardening drift gate checks it there and passes the local caller.
+Two of these are reusable workflows whose `privileged` gate lives on their own job, because a `uses:`
+caller can't declare `environment:` (the workflow-hardening drift gate checks the callee and passes the
+local caller):
+
+- `bench-suite.yml` runs one suite across a provider matrix; `bench-matrix.yml`'s suite-matrix job
+  calls it once per suite. Environment secrets on `privileged` resolve from the reusable job's own
+  `environment:` declaration (a `uses:` caller can't set `environment:`). The caller still passes
+  `secrets: inherit` for repository-level secrets / token context.
+- `publish-dataset.yml` runs the dataset publish: `bench-matrix.yml`'s `publish` job calls it at the end
+  of a matrix run, and a maintainer can dispatch it standalone to backfill (see rule 6).
 
 Ungated: `ci.yml`, `ci-lint.yml`, and the toolchain `pr-gate` (Docker smoke, no secrets).
 
@@ -61,11 +67,14 @@ Ungated: `ci.yml`, `ci-lint.yml`, and the toolchain `pr-gate` (Docker smoke, no 
    still within the repo's artifact-retention window. Dispatch is still gated by Environment
    `privileged` (main-only, required reviewer), so it is effectively maintainer-only.
 
-> **Two approvals per bench-matrix run.** `bench` and `publish` both carry `environment:
-> privileged` and run sequentially, so GitHub raises **two** separate pending-deployment gates: one
-> before the matrix starts, and a second (after the long matrix finishes, ~150 min) before the
-> dataset is committed. A reviewer who approves only `bench` and walks away leaves the run parked at
-> `publish` until the second approval lands or the protection rule times out.
+> **Two approval gates per bench-matrix run.** The suite-matrix fan-out (each cell calling
+> `bench-suite.yml` with `environment: privileged`) and the `publish` job both carry the environment
+> and run sequentially. Every suite × provider cell becomes pending together the moment `plan`
+> finishes, so they surface as one batch in "Review pending deployments" and a single approval of the
+> `privileged` environment releases the whole matrix; `publish` becomes pending only after the long
+> matrix (~150 min), raising a **second** gate before the dataset is committed. A reviewer who
+> approves only the matrix and walks away leaves the run parked at `publish` until the second approval
+> lands or the protection rule times out.
 
 ## Operator setup (before flipping the repo public)
 

--- a/docs/methodology.md
+++ b/docs/methodology.md
@@ -82,8 +82,10 @@ without being Daytona-specific.
 
 1. **Run** — `bench-suite <provider> <suite>` boots a sandbox, runs the suite's mise tasks, pulls the
    raw tree (`data/raw/<runId>/<provider>/<suite>/`), and normalizes it into a Run document.
-2. **Matrix** — the `bench-matrix` workflow fans `plan-matrix` (provider × suite) out into one job per
-   cell, each uploading its shard Run as an artifact.
+2. **Matrix** — the `bench-matrix` workflow plans both axes, then one suite-matrix job calls the
+   reusable `bench-suite` workflow per suite (GitHub-native nesting: `<suite> / <provider>`), fanning
+   out over the providers `plan-providers` selects; every (provider, suite) cell uploads its shard Run
+   as an artifact.
 3. **Aggregate → promote** — the `publish` job collects every shard, `aggregate`s them into one
    candidate Run (measured metrics unioned, economics re-derived from the merged set), then `promote`s
    it (gate: ≥1 validated provider) into the committed dataset at `data/dataset/` with a newest-first

--- a/tooling/repo-checks/src/lib/workflow-nesting.ts
+++ b/tooling/repo-checks/src/lib/workflow-nesting.ts
@@ -1,11 +1,6 @@
 // Invariant 6: GitHub-native suite→provider nesting wiring for bench-matrix.yml + bench-suite.yml.
 // Kept out of workflow-sync.ts so credential/timeout gates and nesting gates don't grow as one file.
-import {
-	asRecord,
-	MATRIX_WORKFLOW,
-	SUITE_JOB,
-	SUITE_WORKFLOW,
-} from "./workflow-yaml.ts";
+import { asRecord, MATRIX_WORKFLOW, SUITE_JOB, SUITE_WORKFLOW } from "./workflow-yaml.ts";
 
 /** A bench-matrix suite job is one that `uses` this reusable workflow (matched by path suffix). */
 const SUITE_WORKFLOW_USES_SUFFIX = "/bench-suite.yml";

--- a/tooling/repo-checks/src/lib/workflow-nesting.ts
+++ b/tooling/repo-checks/src/lib/workflow-nesting.ts
@@ -1,0 +1,164 @@
+// Invariant 6: GitHub-native suite→provider nesting wiring for bench-matrix.yml + bench-suite.yml.
+// Kept out of workflow-sync.ts so credential/timeout gates and nesting gates don't grow as one file.
+import {
+	asRecord,
+	MATRIX_WORKFLOW,
+	SUITE_JOB,
+	SUITE_WORKFLOW,
+} from "./workflow-yaml.ts";
+
+/** A bench-matrix suite job is one that `uses` this reusable workflow (matched by path suffix). */
+const SUITE_WORKFLOW_USES_SUFFIX = "/bench-suite.yml";
+
+/**
+ * The single bench-matrix suite-matrix caller: the job that `uses` the reusable bench-suite.yml and
+ * expands `strategy.matrix.suite` from the plan's suite axis. Native nesting depends on
+ * `name` / `with.suite` both resolving to `matrix.suite`.
+ */
+export interface SuiteMatrixCaller {
+	jobId: string;
+	name: string;
+	suiteInput: string;
+	matrixSuiteExpr: string;
+	/** Job ids listed in `publish.needs` (empty when publish is missing or has no needs list). */
+	publishNeeds: string[];
+}
+
+/** The expression the suite-matrix job must use for its suite axis (plan output → fromJSON). */
+// biome-ignore lint/suspicious/noTemplateCurlyInString: a GHA expression literal matched verbatim against the workflow, not a JS template.
+export const EXPECTED_SUITE_MATRIX_EXPR = "${{ fromJSON(needs.plan.outputs.suites) }}";
+/** The expression that makes each caller cell's display name the suite id (native nesting parent). */
+// biome-ignore lint/suspicious/noTemplateCurlyInString: a GHA expression literal matched verbatim against the workflow, not a JS template.
+export const EXPECTED_SUITE_NAME_EXPR = "${{ matrix.suite }}";
+/** The expression that makes each reusable fan-out cell's display name the provider id (nesting child). */
+// biome-ignore lint/suspicious/noTemplateCurlyInString: a GHA expression literal matched verbatim against the workflow, not a JS template.
+export const EXPECTED_PROVIDER_NAME_EXPR = "${{ matrix.provider }}";
+
+/**
+ * The bench-matrix suite-matrix caller — exactly one job whose `uses` targets the reusable
+ * bench-suite.yml, with its nesting wiring extracted. Zero or multiple callers throw (Invariant 6
+ * must fail loudly, not pick one). Jobs that don't call the reusable (plan, publish) are ignored
+ * except that `publish.needs` is captured for the dependency check.
+ */
+export function matrixSuiteCaller(
+	doc: unknown,
+	label: string = MATRIX_WORKFLOW,
+): SuiteMatrixCaller {
+	const root = asRecord(doc, `${label}: not a YAML mapping`);
+	const jobs = asRecord(root.jobs, `${label}: no jobs mapping`);
+	const callers: Array<Omit<SuiteMatrixCaller, "publishNeeds">> = [];
+	for (const [jobId, rawJob] of Object.entries(jobs)) {
+		const job = asRecord(rawJob, `${label}: job "${jobId}" is not a mapping`);
+		const uses = job.uses;
+		if (typeof uses !== "string" || !uses.endsWith(SUITE_WORKFLOW_USES_SUFFIX)) continue;
+		const withMap = asRecord(
+			job.with,
+			`${label}: job "${jobId}" calls ${uses} without a "with" mapping`,
+		);
+		const suiteInput = withMap.suite;
+		if (typeof suiteInput !== "string") {
+			throw new Error(`${label}: job "${jobId}" calls ${uses} without a string "suite" input`);
+		}
+		const name = typeof job.name === "string" ? job.name : "";
+		const strategy = asRecord(
+			job.strategy,
+			`${label}: job "${jobId}" calls ${uses} without a "strategy" mapping`,
+		);
+		const matrix = asRecord(
+			strategy.matrix,
+			`${label}: job "${jobId}" calls ${uses} without a "strategy.matrix" mapping`,
+		);
+		const matrixSuiteExpr = matrix.suite;
+		if (typeof matrixSuiteExpr !== "string") {
+			throw new Error(
+				`${label}: job "${jobId}" calls ${uses} without a string "strategy.matrix.suite" axis`,
+			);
+		}
+		callers.push({ jobId, name, suiteInput, matrixSuiteExpr });
+	}
+	if (callers.length === 0) {
+		throw new Error(
+			`${label}: no job calls the reusable bench-suite.yml — the suite-matrix caller is missing`,
+		);
+	}
+	if (callers.length > 1) {
+		throw new Error(
+			`${label}: expected exactly one suite-matrix caller of bench-suite.yml, found ` +
+				`${callers.length} (${callers.map((c) => c.jobId).join(", ")})`,
+		);
+	}
+	// biome-ignore lint/style/noNonNullAssertion: length checked above.
+	const caller = callers[0]!;
+	const publish = jobs.publish;
+	let publishNeeds: string[] = [];
+	if (publish !== undefined) {
+		const publishJob = asRecord(publish, `${label}: job "publish" is not a mapping`);
+		const needs = publishJob.needs;
+		if (Array.isArray(needs)) {
+			publishNeeds = needs.map((n) => String(n));
+		} else if (typeof needs === "string") {
+			publishNeeds = [needs];
+		}
+	}
+	return { ...caller, publishNeeds };
+}
+
+/**
+ * Invariant 6: the bench-matrix suite-matrix caller is wired for GitHub-native nesting and depends on
+ * the plan's suite axis — display name and `with.suite` are `${{ matrix.suite }}`, the matrix axis is
+ * `fromJSON(needs.plan.outputs.suites)`, and `publish` needs the caller job. `label` names the
+ * workflow in error messages.
+ */
+export function checkSuiteMatrixCaller(
+	caller: SuiteMatrixCaller,
+	label: string = MATRIX_WORKFLOW,
+): string[] {
+	const errors: string[] = [];
+	if (caller.name !== EXPECTED_SUITE_NAME_EXPR) {
+		errors.push(
+			`${label}: job "${caller.jobId}" name must be "${EXPECTED_SUITE_NAME_EXPR}" for native ` +
+				`suite nesting in the Actions UI (got ${caller.name ? `"${caller.name}"` : "no name"})`,
+		);
+	}
+	if (caller.suiteInput !== EXPECTED_SUITE_NAME_EXPR) {
+		errors.push(
+			`${label}: job "${caller.jobId}" with.suite must be "${EXPECTED_SUITE_NAME_EXPR}" so each ` +
+				`matrix cell dispatches its own suite (got "${caller.suiteInput}")`,
+		);
+	}
+	if (caller.matrixSuiteExpr !== EXPECTED_SUITE_MATRIX_EXPR) {
+		errors.push(
+			`${label}: job "${caller.jobId}" strategy.matrix.suite must be "${EXPECTED_SUITE_MATRIX_EXPR}" ` +
+				`so the suite axis stays registry-driven via plan.outputs.suites (got "${caller.matrixSuiteExpr}")`,
+		);
+	}
+	if (!caller.publishNeeds.includes(caller.jobId)) {
+		errors.push(
+			`${label}: job "publish" must need "${caller.jobId}" so aggregation waits for every suite ` +
+				`matrix cell (publish.needs=${JSON.stringify(caller.publishNeeds)})`,
+		);
+	}
+	return errors;
+}
+
+/**
+ * Invariant 6 (callee half): the reusable bench-suite fan-out job display name is the provider id so
+ * nested Actions UI cells read as "<suite> / <provider>".
+ */
+export function checkSuiteWorkflowNesting(doc: unknown, label: string = SUITE_WORKFLOW): string[] {
+	const root = asRecord(doc, `${label}: not a YAML mapping`);
+	const jobs = asRecord(root.jobs, `${label}: no jobs mapping`);
+	const job = jobs[SUITE_JOB];
+	if (job === undefined) {
+		return [`${label}: job "${SUITE_JOB}" is missing — the provider fan-out job is required`];
+	}
+	const bench = asRecord(job, `${label}: job "${SUITE_JOB}" is not a mapping`);
+	const name = typeof bench.name === "string" ? bench.name : "";
+	if (name !== EXPECTED_PROVIDER_NAME_EXPR) {
+		return [
+			`${label}: job "${SUITE_JOB}" name must be "${EXPECTED_PROVIDER_NAME_EXPR}" for native ` +
+				`provider nesting under each suite (got ${name ? `"${name}"` : "no name"})`,
+		];
+	}
+	return [];
+}

--- a/tooling/repo-checks/src/lib/workflow-sync.ts
+++ b/tooling/repo-checks/src/lib/workflow-sync.ts
@@ -2,22 +2,36 @@
 // schema registries. GHA can't import TypeScript, so the provider/suite vocabulary and the
 // per-provider credential wiring are re-spelled by hand in the workflow files; this module re-derives
 // the truth from PROVIDERS + SUITE_NAMES (packages/schema) and compares. It mirrors
-// runner-benchmarking's check-workflow-{env,suite}-sync.ts, adapted to this repo's two workflows.
+// runner-benchmarking's check-workflow-{env,suite}-sync.ts, adapted to this repo's workflows.
+//
+// Two workflows dispatch live benchmarks: bench-smoke.yml (one dispatched suite × provider) and
+// bench-matrix.yml (one suite-matrix job that calls the reusable bench-suite.yml once per suite, which
+// then fans out over the selected providers). The credential block + the run job's timeout therefore
+// live in bench-suite.yml for the matrix lane, so the "matrix side" of the credential/timeout checks
+// reads that reusable workflow, not bench-matrix.yml itself.
 //
 // Invariants (each maps to a real "added X, forgot the workflow" failure mode):
 //   1. bench-smoke.yml's `provider` dispatch input options == the PROVIDERS id set, and its default
 //      is one of them — a new provider must be dispatchable, a removed one must not linger.
 //   2. bench-smoke.yml's `suite` dispatch input options == SUITE_NAMES, with a valid default.
 //   3. Every provider's requiredEnvVars (schema) is present in the "Run suite and normalize" step env
-//      of BOTH bench-smoke.yml and bench-matrix.yml — the secret a new provider needs must be wired
-//      into both the smoke lane and the matrix lane, or the live run silently skips it.
-//   4. A credential key shared across the two workflows maps to the same value expression — both
-//      lanes must hand the suite the same secret, not plan one and run the other. Each lane scopes
-//      its secrets to the selected provider (so a cell only sees its own credential), and the two
-//      lanes pick that provider differently — `inputs.provider` in smoke, `matrix.provider` in the
-//      matrix fan-out — so the comparison folds those two selector tokens together before checking.
-//   5. Both live-run jobs outlast the longest registered sandbox lifetime by a fixed margin, so a
-//      suite budget increase cannot leave an otherwise healthy job to be killed by Actions first.
+//      of BOTH bench-smoke.yml and the reusable bench-suite.yml — the secret a new provider needs must
+//      be wired into both the smoke lane and the matrix fan-out, or the live run silently skips it.
+//   4. A credential key shared across the two lanes maps to the same value expression — both must hand
+//      the suite the same secret, not plan one and run the other. Each lane scopes its secrets to the
+//      selected provider (so a cell only sees its own credential), and the two lanes pick that provider
+//      differently — `inputs.provider` in smoke, `matrix.provider` in the fan-out — so the comparison
+//      folds those two selector tokens together before checking.
+//   5. Both live-run jobs (smoke's job and the reusable fan-out) outlast the longest registered sandbox
+//      lifetime by a fixed margin, so a suite budget increase cannot leave an otherwise healthy job to
+//      be killed by Actions first.
+//   6. bench-matrix.yml has exactly one suite-matrix caller of the reusable bench-suite.yml, wired for
+//      GitHub-native nesting: `name: ${{ matrix.suite }}`, `with.suite: ${{ matrix.suite }}`, and
+//      `strategy.matrix.suite: ${{ fromJSON(needs.plan.outputs.suites) }}`, with `publish` needing that
+//      caller; the reusable's fan-out job must be `name: ${{ matrix.provider }}` so cells display as
+//      "<suite> / <provider>". The suite axis itself comes from `plan-suites` (SUITE_NAMES, honoring
+//      the `suites` input), so adding a suite is a schema change — this invariant keeps the nesting
+//      wiring from drifting.
 //
 // Bun.YAML.parse is built into bun >= 1.3 (no new dependency), so the parse stays dependency-light.
 import { readFileSync } from "node:fs";
@@ -28,10 +42,15 @@ import { findRepoRoot } from "./workspace.ts";
 
 export const SMOKE_WORKFLOW = ".github/workflows/bench-smoke.yml";
 export const MATRIX_WORKFLOW = ".github/workflows/bench-matrix.yml";
-/** The step (in both workflows) that drives the provider SDK; it owns the credential env block. */
+/** The reusable workflow each bench-matrix suite job calls; it owns the credential block + run timeout. */
+export const SUITE_WORKFLOW = ".github/workflows/bench-suite.yml";
+/** The step (in bench-smoke.yml and bench-suite.yml) that drives the provider SDK; it owns the env. */
 export const RUN_STEP = "Run suite and normalize";
 export const SMOKE_JOB = "smoke";
-export const MATRIX_JOB = "bench";
+/** The fan-out job inside the reusable bench-suite.yml (its credential env + timeout). */
+export const SUITE_JOB = "bench";
+/** A bench-matrix suite job is one that `uses` this reusable workflow (matched by path suffix). */
+const SUITE_WORKFLOW_USES_SUFFIX = "/bench-suite.yml";
 /** Host-side checkout/teardown/normalization/upload allowance beyond the sandbox lifetime. */
 export const WORKFLOW_TIMEOUT_MARGIN_MINUTES = 15;
 
@@ -142,6 +161,99 @@ export function stepEnv(
 		entries[key] = value;
 	}
 	return entries;
+}
+
+/**
+ * The single bench-matrix suite-matrix caller: the job that `uses` the reusable bench-suite.yml and
+ * expands `strategy.matrix.suite` from the plan's suite axis. Native nesting depends on
+ * `name` / `with.suite` both resolving to `matrix.suite`.
+ */
+export interface SuiteMatrixCaller {
+	jobId: string;
+	name: string;
+	suiteInput: string;
+	matrixSuiteExpr: string;
+	/** Job ids listed in `publish.needs` (empty when publish is missing or has no needs list). */
+	publishNeeds: string[];
+}
+
+/** The expression the suite-matrix job must use for its suite axis (plan output → fromJSON). */
+// biome-ignore lint/suspicious/noTemplateCurlyInString: a GHA expression literal matched verbatim against the workflow, not a JS template.
+export const EXPECTED_SUITE_MATRIX_EXPR = "${{ fromJSON(needs.plan.outputs.suites) }}";
+/** The expression that makes each caller cell's display name the suite id (native nesting parent). */
+// biome-ignore lint/suspicious/noTemplateCurlyInString: a GHA expression literal matched verbatim against the workflow, not a JS template.
+export const EXPECTED_SUITE_NAME_EXPR = "${{ matrix.suite }}";
+/** The expression that makes each reusable fan-out cell's display name the provider id (nesting child). */
+// biome-ignore lint/suspicious/noTemplateCurlyInString: a GHA expression literal matched verbatim against the workflow, not a JS template.
+export const EXPECTED_PROVIDER_NAME_EXPR = "${{ matrix.provider }}";
+
+/**
+ * The bench-matrix suite-matrix caller — exactly one job whose `uses` targets the reusable
+ * bench-suite.yml, with its nesting wiring extracted. Zero or multiple callers throw (Invariant 6
+ * must fail loudly, not pick one). Jobs that don't call the reusable (plan, publish) are ignored
+ * except that `publish.needs` is captured for the dependency check.
+ */
+export function matrixSuiteCaller(
+	doc: unknown,
+	label: string = MATRIX_WORKFLOW,
+): SuiteMatrixCaller {
+	const root = asRecord(doc, `${label}: not a YAML mapping`);
+	const jobs = asRecord(root.jobs, `${label}: no jobs mapping`);
+	const callers: Array<Omit<SuiteMatrixCaller, "publishNeeds">> = [];
+	for (const [jobId, rawJob] of Object.entries(jobs)) {
+		const job = asRecord(rawJob, `${label}: job "${jobId}" is not a mapping`);
+		const uses = job.uses;
+		if (typeof uses !== "string" || !uses.endsWith(SUITE_WORKFLOW_USES_SUFFIX)) continue;
+		const withMap = asRecord(
+			job.with,
+			`${label}: job "${jobId}" calls ${uses} without a "with" mapping`,
+		);
+		const suiteInput = withMap.suite;
+		if (typeof suiteInput !== "string") {
+			throw new Error(`${label}: job "${jobId}" calls ${uses} without a string "suite" input`);
+		}
+		const name = typeof job.name === "string" ? job.name : "";
+		const strategy = asRecord(
+			job.strategy,
+			`${label}: job "${jobId}" calls ${uses} without a "strategy" mapping`,
+		);
+		const matrix = asRecord(
+			strategy.matrix,
+			`${label}: job "${jobId}" calls ${uses} without a "strategy.matrix" mapping`,
+		);
+		const matrixSuiteExpr = matrix.suite;
+		if (typeof matrixSuiteExpr !== "string") {
+			throw new Error(
+				`${label}: job "${jobId}" calls ${uses} without a string "strategy.matrix.suite" axis`,
+			);
+		}
+		callers.push({ jobId, name, suiteInput, matrixSuiteExpr });
+	}
+	if (callers.length === 0) {
+		throw new Error(
+			`${label}: no job calls the reusable bench-suite.yml — the suite-matrix caller is missing`,
+		);
+	}
+	if (callers.length > 1) {
+		throw new Error(
+			`${label}: expected exactly one suite-matrix caller of bench-suite.yml, found ` +
+				`${callers.length} (${callers.map((c) => c.jobId).join(", ")})`,
+		);
+	}
+	// biome-ignore lint/style/noNonNullAssertion: length checked above.
+	const caller = callers[0]!;
+	const publish = jobs.publish;
+	let publishNeeds: string[] = [];
+	if (publish !== undefined) {
+		const publishJob = asRecord(publish, `${label}: job "publish" is not a mapping`);
+		const needs = publishJob.needs;
+		if (Array.isArray(needs)) {
+			publishNeeds = needs.map((n) => String(n));
+		} else if (typeof needs === "string") {
+			publishNeeds = [needs];
+		}
+	}
+	return { ...caller, publishNeeds };
 }
 
 /** The canonical provider ids from the schema registry. */
@@ -288,6 +400,66 @@ export function checkCredentialEnv(
 	return errors;
 }
 
+/**
+ * Invariant 6: the bench-matrix suite-matrix caller is wired for GitHub-native nesting and depends on
+ * the plan's suite axis — display name and `with.suite` are `${{ matrix.suite }}`, the matrix axis is
+ * `fromJSON(needs.plan.outputs.suites)`, and `publish` needs the caller job. `label` names the
+ * workflow in error messages.
+ */
+export function checkSuiteMatrixCaller(
+	caller: SuiteMatrixCaller,
+	label: string = MATRIX_WORKFLOW,
+): string[] {
+	const errors: string[] = [];
+	if (caller.name !== EXPECTED_SUITE_NAME_EXPR) {
+		errors.push(
+			`${label}: job "${caller.jobId}" name must be "${EXPECTED_SUITE_NAME_EXPR}" for native ` +
+				`suite nesting in the Actions UI (got ${caller.name ? `"${caller.name}"` : "no name"})`,
+		);
+	}
+	if (caller.suiteInput !== EXPECTED_SUITE_NAME_EXPR) {
+		errors.push(
+			`${label}: job "${caller.jobId}" with.suite must be "${EXPECTED_SUITE_NAME_EXPR}" so each ` +
+				`matrix cell dispatches its own suite (got "${caller.suiteInput}")`,
+		);
+	}
+	if (caller.matrixSuiteExpr !== EXPECTED_SUITE_MATRIX_EXPR) {
+		errors.push(
+			`${label}: job "${caller.jobId}" strategy.matrix.suite must be "${EXPECTED_SUITE_MATRIX_EXPR}" ` +
+				`so the suite axis stays registry-driven via plan.outputs.suites (got "${caller.matrixSuiteExpr}")`,
+		);
+	}
+	if (!caller.publishNeeds.includes(caller.jobId)) {
+		errors.push(
+			`${label}: job "publish" must need "${caller.jobId}" so aggregation waits for every suite ` +
+				`matrix cell (publish.needs=${JSON.stringify(caller.publishNeeds)})`,
+		);
+	}
+	return errors;
+}
+
+/**
+ * Invariant 6 (callee half): the reusable bench-suite fan-out job display name is the provider id so
+ * nested Actions UI cells read as "<suite> / <provider>".
+ */
+export function checkSuiteWorkflowNesting(doc: unknown, label: string = SUITE_WORKFLOW): string[] {
+	const root = asRecord(doc, `${label}: not a YAML mapping`);
+	const jobs = asRecord(root.jobs, `${label}: no jobs mapping`);
+	const job = jobs[SUITE_JOB];
+	if (job === undefined) {
+		return [`${label}: job "${SUITE_JOB}" is missing — the provider fan-out job is required`];
+	}
+	const bench = asRecord(job, `${label}: job "${SUITE_JOB}" is not a mapping`);
+	const name = typeof bench.name === "string" ? bench.name : "";
+	if (name !== EXPECTED_PROVIDER_NAME_EXPR) {
+		return [
+			`${label}: job "${SUITE_JOB}" name must be "${EXPECTED_PROVIDER_NAME_EXPR}" for native ` +
+				`provider nesting under each suite (got ${name ? `"${name}"` : "no name"})`,
+		];
+	}
+	return [];
+}
+
 /** Invariant 5: every live-run job has margin beyond the longest registered sandbox lifetime. */
 export function checkWorkflowTimeouts(timeoutByWorkflow: Record<string, number>): string[] {
 	const longestSuite = Math.max(...Object.values(SUITES).map((suite) => suite.timeoutMinutes));
@@ -308,16 +480,21 @@ export function checkWorkflowTimeouts(timeoutByWorkflow: Record<string, number>)
 export function runCheck(root: string = findRepoRoot()): string[] {
 	const smoke = readWorkflow(SMOKE_WORKFLOW, root);
 	const matrix = readWorkflow(MATRIX_WORKFLOW, root);
+	// The matrix lane's credential block + run-job timeout live in the reusable bench-suite.yml that
+	// every suite job calls, so the "matrix side" of Invariants 3–5 reads that file.
+	const suiteWf = readWorkflow(SUITE_WORKFLOW, root);
 	return [
 		...checkProviderInput(dispatchInput(smoke, "provider", SMOKE_WORKFLOW)),
 		...checkSuiteInput(dispatchInput(smoke, "suite", SMOKE_WORKFLOW)),
 		...checkCredentialEnv({
 			[SMOKE_WORKFLOW]: stepEnv(smoke, SMOKE_JOB, RUN_STEP, SMOKE_WORKFLOW),
-			[MATRIX_WORKFLOW]: stepEnv(matrix, MATRIX_JOB, RUN_STEP, MATRIX_WORKFLOW),
+			[SUITE_WORKFLOW]: stepEnv(suiteWf, SUITE_JOB, RUN_STEP, SUITE_WORKFLOW),
 		}),
 		...checkWorkflowTimeouts({
 			[SMOKE_WORKFLOW]: jobTimeoutMinutes(smoke, SMOKE_JOB, SMOKE_WORKFLOW),
-			[MATRIX_WORKFLOW]: jobTimeoutMinutes(matrix, MATRIX_JOB, MATRIX_WORKFLOW),
+			[SUITE_WORKFLOW]: jobTimeoutMinutes(suiteWf, SUITE_JOB, SUITE_WORKFLOW),
 		}),
+		...checkSuiteMatrixCaller(matrixSuiteCaller(matrix, MATRIX_WORKFLOW), MATRIX_WORKFLOW),
+		...checkSuiteWorkflowNesting(suiteWf, SUITE_WORKFLOW),
 	];
 }

--- a/tooling/repo-checks/src/lib/workflow-sync.ts
+++ b/tooling/repo-checks/src/lib/workflow-sync.ts
@@ -31,29 +31,28 @@
 // credential/timeout invariants plus runCheck orchestration, and re-exports the public surface the
 // gate's tests import.
 import { PROVIDERS, SUITE_NAMES, SUITES } from "@sandbox-benchmarks/schema";
-import { findRepoRoot } from "./workspace.ts";
 import {
 	checkSuiteMatrixCaller,
 	checkSuiteWorkflowNesting,
 	matrixSuiteCaller,
 } from "./workflow-nesting.ts";
+import type { DispatchInput } from "./workflow-yaml.ts";
 import {
-	type DispatchInput,
 	dispatchInput,
 	jobTimeoutMinutes,
 	MATRIX_WORKFLOW,
-	readWorkflow,
 	RUN_STEP,
+	readWorkflow,
 	SMOKE_JOB,
 	SMOKE_WORKFLOW,
-	stepEnv,
 	SUITE_JOB,
 	SUITE_WORKFLOW,
+	stepEnv,
 	WORKFLOW_TIMEOUT_MARGIN_MINUTES,
 } from "./workflow-yaml.ts";
+import { findRepoRoot } from "./workspace.ts";
 
 export type { SuiteMatrixCaller } from "./workflow-nesting.ts";
-export type { DispatchInput } from "./workflow-yaml.ts";
 export {
 	checkSuiteMatrixCaller,
 	checkSuiteWorkflowNesting,
@@ -62,17 +61,18 @@ export {
 	EXPECTED_SUITE_NAME_EXPR,
 	matrixSuiteCaller,
 } from "./workflow-nesting.ts";
+export type { DispatchInput } from "./workflow-yaml.ts";
 export {
 	dispatchInput,
 	jobTimeoutMinutes,
 	MATRIX_WORKFLOW,
-	readWorkflow,
 	RUN_STEP,
+	readWorkflow,
 	SMOKE_JOB,
 	SMOKE_WORKFLOW,
-	stepEnv,
 	SUITE_JOB,
 	SUITE_WORKFLOW,
+	stepEnv,
 	WORKFLOW_TIMEOUT_MARGIN_MINUTES,
 } from "./workflow-yaml.ts";
 

--- a/tooling/repo-checks/src/lib/workflow-sync.ts
+++ b/tooling/repo-checks/src/lib/workflow-sync.ts
@@ -25,236 +25,56 @@
 //   5. Both live-run jobs (smoke's job and the reusable fan-out) outlast the longest registered sandbox
 //      lifetime by a fixed margin, so a suite budget increase cannot leave an otherwise healthy job to
 //      be killed by Actions first.
-//   6. bench-matrix.yml has exactly one suite-matrix caller of the reusable bench-suite.yml, wired for
-//      GitHub-native nesting: `name: ${{ matrix.suite }}`, `with.suite: ${{ matrix.suite }}`, and
-//      `strategy.matrix.suite: ${{ fromJSON(needs.plan.outputs.suites) }}`, with `publish` needing that
-//      caller; the reusable's fan-out job must be `name: ${{ matrix.provider }}` so cells display as
-//      "<suite> / <provider>". The suite axis itself comes from `plan-suites` (SUITE_NAMES, honoring
-//      the `suites` input), so adding a suite is a schema change — this invariant keeps the nesting
-//      wiring from drifting.
+//   6. Nesting wiring (suite-matrix caller + reusable provider job name) — see workflow-nesting.ts.
 //
-// Bun.YAML.parse is built into bun >= 1.3 (no new dependency), so the parse stays dependency-light.
-import { readFileSync } from "node:fs";
-import { join } from "node:path";
+// YAML navigation lives in workflow-yaml.ts; nesting checks in workflow-nesting.ts. This file owns
+// credential/timeout invariants plus runCheck orchestration, and re-exports the public surface the
+// gate's tests import.
 import { PROVIDERS, SUITE_NAMES, SUITES } from "@sandbox-benchmarks/schema";
-import { type } from "arktype";
 import { findRepoRoot } from "./workspace.ts";
+import {
+	checkSuiteMatrixCaller,
+	checkSuiteWorkflowNesting,
+	matrixSuiteCaller,
+} from "./workflow-nesting.ts";
+import {
+	type DispatchInput,
+	dispatchInput,
+	jobTimeoutMinutes,
+	MATRIX_WORKFLOW,
+	readWorkflow,
+	RUN_STEP,
+	SMOKE_JOB,
+	SMOKE_WORKFLOW,
+	stepEnv,
+	SUITE_JOB,
+	SUITE_WORKFLOW,
+	WORKFLOW_TIMEOUT_MARGIN_MINUTES,
+} from "./workflow-yaml.ts";
 
-export const SMOKE_WORKFLOW = ".github/workflows/bench-smoke.yml";
-export const MATRIX_WORKFLOW = ".github/workflows/bench-matrix.yml";
-/** The reusable workflow each bench-matrix suite job calls; it owns the credential block + run timeout. */
-export const SUITE_WORKFLOW = ".github/workflows/bench-suite.yml";
-/** The step (in bench-smoke.yml and bench-suite.yml) that drives the provider SDK; it owns the env. */
-export const RUN_STEP = "Run suite and normalize";
-export const SMOKE_JOB = "smoke";
-/** The fan-out job inside the reusable bench-suite.yml (its credential env + timeout). */
-export const SUITE_JOB = "bench";
-/** A bench-matrix suite job is one that `uses` this reusable workflow (matched by path suffix). */
-const SUITE_WORKFLOW_USES_SUFFIX = "/bench-suite.yml";
-/** Host-side checkout/teardown/normalization/upload allowance beyond the sandbox lifetime. */
-export const WORKFLOW_TIMEOUT_MARGIN_MINUTES = 15;
-
-// Single source of truth: this schema drives BOTH the runtime parse (coercions live in the morphs)
-// and the exported DispatchInput type (inferred below) — there is no hand-written interface or
-// typeof-narrowing that could drift from the parse. onUndeclaredKey("delete") drops the fields the
-// gate ignores (description/required/…) so the parsed value is exactly what gets compared.
-const dispatchInputSchema = type({
-	// Only `type: choice` makes GitHub enforce `options`. A non-string (malformed YAML) coerces to
-	// undefined so the invariant check reports it, rather than the parse throwing.
-	"type?": type("unknown").pipe((v) => (typeof v === "string" ? v : undefined)),
-	"default?": type("unknown").pipe((v) => (typeof v === "string" ? v : undefined)),
-	// A YAML option list may carry non-string scalars; coerce each. A non-list value is rejected.
-	"options?": type("unknown[]").pipe((arr) => arr.map((o) => String(o))),
-}).onUndeclaredKey("delete");
-
-/** A single `workflow_dispatch` input, narrowed to the fields the gate compares — inferred from
- *  {@link dispatchInputSchema} so the type and the parser can never disagree. */
-export type DispatchInput = typeof dispatchInputSchema.infer;
-
-// The workflow envelope down to the dynamic `inputs` map: validated once, with inference, so the
-// navigation is type-safe end to end instead of a hand-rolled chain of object guards. (Bun.YAML keeps
-// the GHA `on:` key as the string "on", so the YAML 1.1 boolean gotcha does not bite here.)
-const workflowEnvelope = type({
-	on: { workflow_dispatch: { inputs: { "[string]": "unknown" } } },
-});
-
-/** Parse a workflow YAML file under `root` (Bun.YAML — built-in, no dependency). */
-export function readWorkflow(relPath: string, root: string = findRepoRoot()): unknown {
-	return Bun.YAML.parse(readFileSync(join(root, relPath), "utf8"));
-}
-
-/**
- * The `on.workflow_dispatch.inputs.<name>` entry, parsed to its {@link DispatchInput}. Throws if the
- * envelope is malformed or the named input is missing — a renamed/removed input must fail the gate
- * loudly, not pass vacuously.
- */
-export function dispatchInput(doc: unknown, name: string, label: string): DispatchInput {
-	const envelope = workflowEnvelope(doc);
-	if (envelope instanceof type.errors) {
-		throw new Error(`${label}: ${envelope.summary}`);
-	}
-	const raw = envelope.on.workflow_dispatch.inputs[name];
-	if (raw === undefined) {
-		throw new Error(`${label}: workflow_dispatch input "${name}" not found`);
-	}
-	const input = dispatchInputSchema(raw);
-	if (input instanceof type.errors) {
-		throw new Error(`${label}: workflow_dispatch input "${name}" is malformed — ${input.summary}`);
-	}
-	return input;
-}
-
-/**
- * Assert `value` is a non-null, non-array object, or throw `message`. A lazy per-node guard for the
- * {@link stepEnv} navigation below: unlike the fixed `on.workflow_dispatch` path (an arktype envelope),
- * step-env walks to one *named* job/step, so validating the whole `jobs` map with a schema would
- * over-reject sibling jobs the gate doesn't care about.
- */
-function asRecord(value: unknown, message: string): Record<string, unknown> {
-	if (value === null || typeof value !== "object" || Array.isArray(value)) {
-		throw new Error(message);
-	}
-	return value as Record<string, unknown>;
-}
-
-/** Parse a job's literal positive integer `timeout-minutes`; expressions cannot satisfy this gate. */
-export function jobTimeoutMinutes(doc: unknown, jobId: string, label: string): number {
-	const root = asRecord(doc, `${label}: not a YAML mapping`);
-	const jobs = asRecord(root.jobs, `${label}: no jobs mapping`);
-	const job = asRecord(jobs[jobId], `${label}: job "${jobId}" not found`);
-	const timeout = job["timeout-minutes"];
-	if (typeof timeout !== "number" || !Number.isInteger(timeout) || timeout <= 0) {
-		throw new Error(`${label}: job "${jobId}" timeout-minutes must be a positive integer literal`);
-	}
-	return timeout;
-}
-
-/**
- * The `env` mapping of a named step inside a job, as key -> value-expression entries. Throws if the
- * job, the step, or its env block is missing, or an env value is not a string — a renamed job/step
- * must fail the gate, not silently match nothing.
- */
-export function stepEnv(
-	doc: unknown,
-	jobId: string,
-	stepName: string,
-	label: string,
-): Record<string, string> {
-	const root = asRecord(doc, `${label}: not a YAML mapping`);
-	const jobs = asRecord(root.jobs, `${label}: no jobs mapping`);
-	const job = asRecord(jobs[jobId], `${label}: job "${jobId}" not found`);
-	const steps = job.steps;
-	if (!Array.isArray(steps)) throw new Error(`${label}: job "${jobId}" has no steps list`);
-	const step = steps.find((s) => asRecord(s, `${label}: malformed step`).name === stepName);
-	if (step === undefined) {
-		throw new Error(`${label}: job "${jobId}" has no step named "${stepName}"`);
-	}
-	const env = asRecord(
-		(step as Record<string, unknown>).env,
-		`${label}: step "${stepName}" has no env mapping`,
-	);
-	const entries: Record<string, string> = {};
-	for (const [key, value] of Object.entries(env)) {
-		if (typeof value !== "string") {
-			throw new Error(`${label}: step "${stepName}" env.${key} is not a string value`);
-		}
-		entries[key] = value;
-	}
-	return entries;
-}
-
-/**
- * The single bench-matrix suite-matrix caller: the job that `uses` the reusable bench-suite.yml and
- * expands `strategy.matrix.suite` from the plan's suite axis. Native nesting depends on
- * `name` / `with.suite` both resolving to `matrix.suite`.
- */
-export interface SuiteMatrixCaller {
-	jobId: string;
-	name: string;
-	suiteInput: string;
-	matrixSuiteExpr: string;
-	/** Job ids listed in `publish.needs` (empty when publish is missing or has no needs list). */
-	publishNeeds: string[];
-}
-
-/** The expression the suite-matrix job must use for its suite axis (plan output → fromJSON). */
-// biome-ignore lint/suspicious/noTemplateCurlyInString: a GHA expression literal matched verbatim against the workflow, not a JS template.
-export const EXPECTED_SUITE_MATRIX_EXPR = "${{ fromJSON(needs.plan.outputs.suites) }}";
-/** The expression that makes each caller cell's display name the suite id (native nesting parent). */
-// biome-ignore lint/suspicious/noTemplateCurlyInString: a GHA expression literal matched verbatim against the workflow, not a JS template.
-export const EXPECTED_SUITE_NAME_EXPR = "${{ matrix.suite }}";
-/** The expression that makes each reusable fan-out cell's display name the provider id (nesting child). */
-// biome-ignore lint/suspicious/noTemplateCurlyInString: a GHA expression literal matched verbatim against the workflow, not a JS template.
-export const EXPECTED_PROVIDER_NAME_EXPR = "${{ matrix.provider }}";
-
-/**
- * The bench-matrix suite-matrix caller — exactly one job whose `uses` targets the reusable
- * bench-suite.yml, with its nesting wiring extracted. Zero or multiple callers throw (Invariant 6
- * must fail loudly, not pick one). Jobs that don't call the reusable (plan, publish) are ignored
- * except that `publish.needs` is captured for the dependency check.
- */
-export function matrixSuiteCaller(
-	doc: unknown,
-	label: string = MATRIX_WORKFLOW,
-): SuiteMatrixCaller {
-	const root = asRecord(doc, `${label}: not a YAML mapping`);
-	const jobs = asRecord(root.jobs, `${label}: no jobs mapping`);
-	const callers: Array<Omit<SuiteMatrixCaller, "publishNeeds">> = [];
-	for (const [jobId, rawJob] of Object.entries(jobs)) {
-		const job = asRecord(rawJob, `${label}: job "${jobId}" is not a mapping`);
-		const uses = job.uses;
-		if (typeof uses !== "string" || !uses.endsWith(SUITE_WORKFLOW_USES_SUFFIX)) continue;
-		const withMap = asRecord(
-			job.with,
-			`${label}: job "${jobId}" calls ${uses} without a "with" mapping`,
-		);
-		const suiteInput = withMap.suite;
-		if (typeof suiteInput !== "string") {
-			throw new Error(`${label}: job "${jobId}" calls ${uses} without a string "suite" input`);
-		}
-		const name = typeof job.name === "string" ? job.name : "";
-		const strategy = asRecord(
-			job.strategy,
-			`${label}: job "${jobId}" calls ${uses} without a "strategy" mapping`,
-		);
-		const matrix = asRecord(
-			strategy.matrix,
-			`${label}: job "${jobId}" calls ${uses} without a "strategy.matrix" mapping`,
-		);
-		const matrixSuiteExpr = matrix.suite;
-		if (typeof matrixSuiteExpr !== "string") {
-			throw new Error(
-				`${label}: job "${jobId}" calls ${uses} without a string "strategy.matrix.suite" axis`,
-			);
-		}
-		callers.push({ jobId, name, suiteInput, matrixSuiteExpr });
-	}
-	if (callers.length === 0) {
-		throw new Error(
-			`${label}: no job calls the reusable bench-suite.yml — the suite-matrix caller is missing`,
-		);
-	}
-	if (callers.length > 1) {
-		throw new Error(
-			`${label}: expected exactly one suite-matrix caller of bench-suite.yml, found ` +
-				`${callers.length} (${callers.map((c) => c.jobId).join(", ")})`,
-		);
-	}
-	// biome-ignore lint/style/noNonNullAssertion: length checked above.
-	const caller = callers[0]!;
-	const publish = jobs.publish;
-	let publishNeeds: string[] = [];
-	if (publish !== undefined) {
-		const publishJob = asRecord(publish, `${label}: job "publish" is not a mapping`);
-		const needs = publishJob.needs;
-		if (Array.isArray(needs)) {
-			publishNeeds = needs.map((n) => String(n));
-		} else if (typeof needs === "string") {
-			publishNeeds = [needs];
-		}
-	}
-	return { ...caller, publishNeeds };
-}
+export type { SuiteMatrixCaller } from "./workflow-nesting.ts";
+export type { DispatchInput } from "./workflow-yaml.ts";
+export {
+	checkSuiteMatrixCaller,
+	checkSuiteWorkflowNesting,
+	EXPECTED_PROVIDER_NAME_EXPR,
+	EXPECTED_SUITE_MATRIX_EXPR,
+	EXPECTED_SUITE_NAME_EXPR,
+	matrixSuiteCaller,
+} from "./workflow-nesting.ts";
+export {
+	dispatchInput,
+	jobTimeoutMinutes,
+	MATRIX_WORKFLOW,
+	readWorkflow,
+	RUN_STEP,
+	SMOKE_JOB,
+	SMOKE_WORKFLOW,
+	stepEnv,
+	SUITE_JOB,
+	SUITE_WORKFLOW,
+	WORKFLOW_TIMEOUT_MARGIN_MINUTES,
+} from "./workflow-yaml.ts";
 
 /** The canonical provider ids from the schema registry. */
 export function providerIds(): string[] {
@@ -398,66 +218,6 @@ export function checkCredentialEnv(
 		}
 	}
 	return errors;
-}
-
-/**
- * Invariant 6: the bench-matrix suite-matrix caller is wired for GitHub-native nesting and depends on
- * the plan's suite axis — display name and `with.suite` are `${{ matrix.suite }}`, the matrix axis is
- * `fromJSON(needs.plan.outputs.suites)`, and `publish` needs the caller job. `label` names the
- * workflow in error messages.
- */
-export function checkSuiteMatrixCaller(
-	caller: SuiteMatrixCaller,
-	label: string = MATRIX_WORKFLOW,
-): string[] {
-	const errors: string[] = [];
-	if (caller.name !== EXPECTED_SUITE_NAME_EXPR) {
-		errors.push(
-			`${label}: job "${caller.jobId}" name must be "${EXPECTED_SUITE_NAME_EXPR}" for native ` +
-				`suite nesting in the Actions UI (got ${caller.name ? `"${caller.name}"` : "no name"})`,
-		);
-	}
-	if (caller.suiteInput !== EXPECTED_SUITE_NAME_EXPR) {
-		errors.push(
-			`${label}: job "${caller.jobId}" with.suite must be "${EXPECTED_SUITE_NAME_EXPR}" so each ` +
-				`matrix cell dispatches its own suite (got "${caller.suiteInput}")`,
-		);
-	}
-	if (caller.matrixSuiteExpr !== EXPECTED_SUITE_MATRIX_EXPR) {
-		errors.push(
-			`${label}: job "${caller.jobId}" strategy.matrix.suite must be "${EXPECTED_SUITE_MATRIX_EXPR}" ` +
-				`so the suite axis stays registry-driven via plan.outputs.suites (got "${caller.matrixSuiteExpr}")`,
-		);
-	}
-	if (!caller.publishNeeds.includes(caller.jobId)) {
-		errors.push(
-			`${label}: job "publish" must need "${caller.jobId}" so aggregation waits for every suite ` +
-				`matrix cell (publish.needs=${JSON.stringify(caller.publishNeeds)})`,
-		);
-	}
-	return errors;
-}
-
-/**
- * Invariant 6 (callee half): the reusable bench-suite fan-out job display name is the provider id so
- * nested Actions UI cells read as "<suite> / <provider>".
- */
-export function checkSuiteWorkflowNesting(doc: unknown, label: string = SUITE_WORKFLOW): string[] {
-	const root = asRecord(doc, `${label}: not a YAML mapping`);
-	const jobs = asRecord(root.jobs, `${label}: no jobs mapping`);
-	const job = jobs[SUITE_JOB];
-	if (job === undefined) {
-		return [`${label}: job "${SUITE_JOB}" is missing — the provider fan-out job is required`];
-	}
-	const bench = asRecord(job, `${label}: job "${SUITE_JOB}" is not a mapping`);
-	const name = typeof bench.name === "string" ? bench.name : "";
-	if (name !== EXPECTED_PROVIDER_NAME_EXPR) {
-		return [
-			`${label}: job "${SUITE_JOB}" name must be "${EXPECTED_PROVIDER_NAME_EXPR}" for native ` +
-				`provider nesting under each suite (got ${name ? `"${name}"` : "no name"})`,
-		];
-	}
-	return [];
 }
 
 /** Invariant 5: every live-run job has margin beyond the longest registered sandbox lifetime. */

--- a/tooling/repo-checks/src/lib/workflow-yaml.ts
+++ b/tooling/repo-checks/src/lib/workflow-yaml.ts
@@ -1,0 +1,128 @@
+// Shared YAML navigation for workflow drift gates. Bun.YAML.parse is built into bun >= 1.3 (no new
+// dependency). Kept separate from credential/timeout checks and nesting invariants so each module
+// owns one concern.
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { type } from "arktype";
+import { findRepoRoot } from "./workspace.ts";
+
+export const SMOKE_WORKFLOW = ".github/workflows/bench-smoke.yml";
+export const MATRIX_WORKFLOW = ".github/workflows/bench-matrix.yml";
+/** The reusable workflow each bench-matrix suite job calls; it owns the credential block + run timeout. */
+export const SUITE_WORKFLOW = ".github/workflows/bench-suite.yml";
+/** The step (in bench-smoke.yml and bench-suite.yml) that drives the provider SDK; it owns the env. */
+export const RUN_STEP = "Run suite and normalize";
+export const SMOKE_JOB = "smoke";
+/** The fan-out job inside the reusable bench-suite.yml (its credential env + timeout). */
+export const SUITE_JOB = "bench";
+/** Host-side checkout/teardown/normalization/upload allowance beyond the sandbox lifetime. */
+export const WORKFLOW_TIMEOUT_MARGIN_MINUTES = 15;
+
+// Single source of truth: this schema drives BOTH the runtime parse (coercions live in the morphs)
+// and the exported DispatchInput type (inferred below) — there is no hand-written interface or
+// typeof-narrowing that could drift from the parse. onUndeclaredKey("delete") drops the fields the
+// gate ignores (description/required/…) so the parsed value is exactly what gets compared.
+const dispatchInputSchema = type({
+	// Only `type: choice` makes GitHub enforce `options`. A non-string (malformed YAML) coerces to
+	// undefined so the invariant check reports it, rather than the parse throwing.
+	"type?": type("unknown").pipe((v) => (typeof v === "string" ? v : undefined)),
+	"default?": type("unknown").pipe((v) => (typeof v === "string" ? v : undefined)),
+	// A YAML option list may carry non-string scalars; coerce each. A non-list value is rejected.
+	"options?": type("unknown[]").pipe((arr) => arr.map((o) => String(o))),
+}).onUndeclaredKey("delete");
+
+/** A single `workflow_dispatch` input, narrowed to the fields the gate compares — inferred from
+ *  {@link dispatchInputSchema} so the type and the parser can never disagree. */
+export type DispatchInput = typeof dispatchInputSchema.infer;
+
+// The workflow envelope down to the dynamic `inputs` map: validated once, with inference, so the
+// navigation is type-safe end to end instead of a hand-rolled chain of object guards. (Bun.YAML keeps
+// the GHA `on:` key as the string "on", so the YAML 1.1 boolean gotcha does not bite here.)
+const workflowEnvelope = type({
+	on: { workflow_dispatch: { inputs: { "[string]": "unknown" } } },
+});
+
+/** Parse a workflow YAML file under `root` (Bun.YAML — built-in, no dependency). */
+export function readWorkflow(relPath: string, root: string = findRepoRoot()): unknown {
+	return Bun.YAML.parse(readFileSync(join(root, relPath), "utf8"));
+}
+
+/**
+ * Assert `value` is a non-null, non-array object, or throw `message`. A lazy per-node guard for job/
+ * step navigation: unlike the fixed `on.workflow_dispatch` path (an arktype envelope), step-env walks
+ * to one *named* job/step, so validating the whole `jobs` map with a schema would over-reject sibling
+ * jobs the gate doesn't care about.
+ */
+export function asRecord(value: unknown, message: string): Record<string, unknown> {
+	if (value === null || typeof value !== "object" || Array.isArray(value)) {
+		throw new Error(message);
+	}
+	return value as Record<string, unknown>;
+}
+
+/**
+ * The `on.workflow_dispatch.inputs.<name>` entry, parsed to its {@link DispatchInput}. Throws if the
+ * envelope is malformed or the named input is missing — a renamed/removed input must fail the gate
+ * loudly, not pass vacuously.
+ */
+export function dispatchInput(doc: unknown, name: string, label: string): DispatchInput {
+	const envelope = workflowEnvelope(doc);
+	if (envelope instanceof type.errors) {
+		throw new Error(`${label}: ${envelope.summary}`);
+	}
+	const raw = envelope.on.workflow_dispatch.inputs[name];
+	if (raw === undefined) {
+		throw new Error(`${label}: workflow_dispatch input "${name}" not found`);
+	}
+	const input = dispatchInputSchema(raw);
+	if (input instanceof type.errors) {
+		throw new Error(`${label}: workflow_dispatch input "${name}" is malformed — ${input.summary}`);
+	}
+	return input;
+}
+
+/** Parse a job's literal positive integer `timeout-minutes`; expressions cannot satisfy this gate. */
+export function jobTimeoutMinutes(doc: unknown, jobId: string, label: string): number {
+	const root = asRecord(doc, `${label}: not a YAML mapping`);
+	const jobs = asRecord(root.jobs, `${label}: no jobs mapping`);
+	const job = asRecord(jobs[jobId], `${label}: job "${jobId}" not found`);
+	const timeout = job["timeout-minutes"];
+	if (typeof timeout !== "number" || !Number.isInteger(timeout) || timeout <= 0) {
+		throw new Error(`${label}: job "${jobId}" timeout-minutes must be a positive integer literal`);
+	}
+	return timeout;
+}
+
+/**
+ * The `env` mapping of a named step inside a job, as key -> value-expression entries. Throws if the
+ * job, the step, or its env block is missing, or an env value is not a string — a renamed job/step
+ * must fail the gate, not silently match nothing.
+ */
+export function stepEnv(
+	doc: unknown,
+	jobId: string,
+	stepName: string,
+	label: string,
+): Record<string, string> {
+	const root = asRecord(doc, `${label}: not a YAML mapping`);
+	const jobs = asRecord(root.jobs, `${label}: no jobs mapping`);
+	const job = asRecord(jobs[jobId], `${label}: job "${jobId}" not found`);
+	const steps = job.steps;
+	if (!Array.isArray(steps)) throw new Error(`${label}: job "${jobId}" has no steps list`);
+	const step = steps.find((s) => asRecord(s, `${label}: malformed step`).name === stepName);
+	if (step === undefined) {
+		throw new Error(`${label}: job "${jobId}" has no step named "${stepName}"`);
+	}
+	const env = asRecord(
+		(step as Record<string, unknown>).env,
+		`${label}: step "${stepName}" has no env mapping`,
+	);
+	const entries: Record<string, string> = {};
+	for (const [key, value] of Object.entries(env)) {
+		if (typeof value !== "string") {
+			throw new Error(`${label}: step "${stepName}" env.${key} is not a string value`);
+		}
+		entries[key] = value;
+	}
+	return entries;
+}

--- a/tooling/repo-checks/src/workflow-registry-sync.test.ts
+++ b/tooling/repo-checks/src/workflow-registry-sync.test.ts
@@ -1,40 +1,52 @@
 // Invariant: the GitHub workflows that dispatch live benchmarks stay in lockstep with the schema
-// registries (PROVIDERS + SUITE_NAMES). GHA can't import TypeScript, so the provider/suite choices
-// and the per-provider credential env block are hand-mirrored across .github/workflows/bench-*.yml;
-// this gate re-derives the truth from the registries and fails if someone adds a provider/suite (or
-// its required secret) without updating the workflows. Mirrors runner-benchmarking's
-// test/workflow-{env,suite}-sync.test.ts. See ./lib/workflow-sync.ts for the parsers + pure checks.
+// registries (PROVIDERS + SUITE_NAMES). GHA can't import TypeScript, so the provider/suite choices and
+// the per-provider credential env block are hand-mirrored across .github/workflows/bench-*.yml; this
+// gate re-derives the truth from the registries and fails if someone adds a provider/suite (or its
+// required secret) without updating the workflows. bench-matrix.yml has one suite-matrix job that calls
+// the reusable bench-suite.yml (native nesting: suite / provider) — so the credential block + run-job
+// timeout live in the reusable (the "matrix side" of the credential/timeout checks reads it), and a
+// separate invariant asserts the suite-matrix caller stays wired to plan.outputs.suites. Mirrors
+// runner-benchmarking's test/workflow-{env,suite}-sync.test.ts. See ./lib/workflow-sync.ts for the
+// parsers + pure checks.
 //
-// The runCheck() test against the real workflow files IS the gate's CI enforcement point (it runs
-// under `bun test`, same precedent as boundary.test.ts); the rest is unit coverage of the parsers and
-// the failure messages on synthetic drift, so a future regression names the offending file + key.
+// The runCheck() test against the real workflow files IS the gate's CI enforcement point (it runs under
+// `bun test`, same precedent as boundary.test.ts); the rest is unit coverage of the parsers and the
+// failure messages on synthetic drift, so a future regression names the offending file + key.
 import { describe, expect, test } from "bun:test";
 import { PROVIDERS, SUITE_NAMES } from "@sandbox-benchmarks/schema";
 import {
 	checkCredentialEnv,
 	checkProviderInput,
 	checkSuiteInput,
+	checkSuiteMatrixCaller,
+	checkSuiteWorkflowNesting,
 	checkWorkflowTimeouts,
 	dispatchInput,
+	EXPECTED_PROVIDER_NAME_EXPR,
+	EXPECTED_SUITE_MATRIX_EXPR,
+	EXPECTED_SUITE_NAME_EXPR,
 	jobTimeoutMinutes,
-	MATRIX_JOB,
 	MATRIX_WORKFLOW,
+	matrixSuiteCaller,
 	RUN_STEP,
 	readWorkflow,
 	requiredCredentialKeys,
 	runCheck,
 	SMOKE_JOB,
 	SMOKE_WORKFLOW,
+	SUITE_JOB,
+	SUITE_WORKFLOW,
 	stepEnv,
 	WORKFLOW_TIMEOUT_MARGIN_MINUTES,
 } from "./lib/workflow-sync.ts";
 
 const smoke = readWorkflow(SMOKE_WORKFLOW);
 const matrix = readWorkflow(MATRIX_WORKFLOW);
+const suiteWf = readWorkflow(SUITE_WORKFLOW);
 const providerInput = dispatchInput(smoke, "provider", SMOKE_WORKFLOW);
 const suiteInput = dispatchInput(smoke, "suite", SMOKE_WORKFLOW);
 const smokeEnv = stepEnv(smoke, SMOKE_JOB, RUN_STEP, SMOKE_WORKFLOW);
-const matrixEnv = stepEnv(matrix, MATRIX_JOB, RUN_STEP, MATRIX_WORKFLOW);
+const suiteEnv = stepEnv(suiteWf, SUITE_JOB, RUN_STEP, SUITE_WORKFLOW);
 
 describe("parsers against the real workflow files", () => {
 	test("dispatchInput extracts the smoke provider choice (type + options + default)", () => {
@@ -49,16 +61,17 @@ describe("parsers against the real workflow files", () => {
 		expect(suiteInput.type).toBe("choice");
 	});
 
-	test("stepEnv extracts a realistic credential block from both workflows", () => {
+	test("stepEnv extracts a realistic credential block from both lanes", () => {
 		expect(smokeEnv).toContainKey("DAYTONA_API_KEY");
-		expect(matrixEnv).toContainKey("E2B_API_KEY");
+		// The matrix lane's credential block lives in the reusable bench-suite.yml.
+		expect(suiteEnv).toContainKey("E2B_API_KEY");
 		// A real block (credentials + runtime context), not a parse fragment.
 		expect(Object.keys(smokeEnv).length).toBeGreaterThanOrEqual(8);
 	});
 
 	test("both live-run jobs reserve host margin beyond the longest suite", () => {
 		expect(jobTimeoutMinutes(smoke, SMOKE_JOB, SMOKE_WORKFLOW)).toBe(180);
-		expect(jobTimeoutMinutes(matrix, MATRIX_JOB, MATRIX_WORKFLOW)).toBe(180);
+		expect(jobTimeoutMinutes(suiteWf, SUITE_JOB, SUITE_WORKFLOW)).toBe(180);
 	});
 
 	test("dispatchInput throws on a missing input instead of passing vacuously", () => {
@@ -185,24 +198,24 @@ describe("checkCredentialEnv", () => {
 		expect(required.get("MODAL_TOKEN_ID")).toEqual(["modal"]);
 	});
 
-	test("flags a required key dropped from the matrix block, naming key and file", () => {
-		const { E2B_API_KEY: _, ...drifted } = matrixEnv;
+	test("flags a required key dropped from the matrix (reusable) block, naming key and file", () => {
+		const { E2B_API_KEY: _, ...drifted } = suiteEnv;
 		const errors = checkCredentialEnv({
 			[SMOKE_WORKFLOW]: smokeEnv,
-			[MATRIX_WORKFLOW]: drifted,
+			[SUITE_WORKFLOW]: drifted,
 		});
 		expect(errors).toHaveLength(1);
 		expect(errors[0]).toContain("E2B_API_KEY");
 		expect(errors[0]).toContain("required by provider e2b");
-		expect(errors[0]).toContain(MATRIX_WORKFLOW);
+		expect(errors[0]).toContain(SUITE_WORKFLOW);
 		expect(errors[0]).not.toContain(SMOKE_WORKFLOW);
 	});
 
 	test("flags a shared key whose value expression differs across the two lanes", () => {
-		const drifted = { ...matrixEnv, DAYTONA_API_KEY: `\${{ secrets.DAYTONA_API_KEY_OTHER }}` };
+		const drifted = { ...suiteEnv, DAYTONA_API_KEY: `\${{ secrets.DAYTONA_API_KEY_OTHER }}` };
 		const errors = checkCredentialEnv({
 			[SMOKE_WORKFLOW]: smokeEnv,
-			[MATRIX_WORKFLOW]: drifted,
+			[SUITE_WORKFLOW]: drifted,
 		});
 		expect(errors).toHaveLength(1);
 		expect(errors[0]).toContain("DAYTONA_API_KEY:");
@@ -213,9 +226,111 @@ describe("checkCredentialEnv", () => {
 	test("tolerates extra runtime-context vars beyond the required credentials", () => {
 		const errors = checkCredentialEnv({
 			[SMOKE_WORKFLOW]: { ...smokeEnv, SOME_RUNTIME_CONTEXT: "x" },
-			[MATRIX_WORKFLOW]: matrixEnv,
+			[SUITE_WORKFLOW]: suiteEnv,
 		});
 		expect(errors).toEqual([]);
+	});
+});
+
+describe("checkSuiteMatrixCaller", () => {
+	const realCaller = matrixSuiteCaller(matrix);
+
+	test("matrixSuiteCaller extracts the real suite-matrix nesting wiring", () => {
+		expect(realCaller.jobId).toBe("suite");
+		expect(realCaller.name).toBe(EXPECTED_SUITE_NAME_EXPR);
+		expect(realCaller.suiteInput).toBe(EXPECTED_SUITE_NAME_EXPR);
+		expect(realCaller.matrixSuiteExpr).toBe(EXPECTED_SUITE_MATRIX_EXPR);
+		expect(realCaller.publishNeeds).toContain("suite");
+	});
+
+	test("the real suite-matrix caller is wired for native nesting", () => {
+		expect(checkSuiteMatrixCaller(realCaller)).toEqual([]);
+	});
+
+	test("flags a caller whose display name is not matrix.suite", () => {
+		const errors = checkSuiteMatrixCaller({ ...realCaller, name: "Bench suites" });
+		expect(errors).toHaveLength(1);
+		expect(errors[0]).toContain("name must be");
+		expect(errors[0]).toContain(EXPECTED_SUITE_NAME_EXPR);
+	});
+
+	test("flags a caller whose with.suite is not matrix.suite", () => {
+		const errors = checkSuiteMatrixCaller({ ...realCaller, suiteInput: "cpu-node" });
+		expect(errors).toHaveLength(1);
+		expect(errors[0]).toContain("with.suite must be");
+	});
+
+	test("flags a caller whose suite axis is not plan.outputs.suites", () => {
+		const errors = checkSuiteMatrixCaller({
+			...realCaller,
+			// biome-ignore lint/suspicious/noTemplateCurlyInString: a GHA expression literal (wrong axis), not a JS template.
+			matrixSuiteExpr: "${{ fromJSON(needs.plan.outputs.providers) }}",
+		});
+		expect(errors).toHaveLength(1);
+		expect(errors[0]).toContain("strategy.matrix.suite must be");
+		expect(errors[0]).toContain(EXPECTED_SUITE_MATRIX_EXPR);
+	});
+
+	test("flags publish that does not need the suite-matrix caller", () => {
+		const errors = checkSuiteMatrixCaller({ ...realCaller, publishNeeds: ["plan"] });
+		expect(errors).toHaveLength(1);
+		expect(errors[0]).toContain('publish" must need "suite"');
+	});
+
+	test("matrixSuiteCaller throws when no job calls the reusable", () => {
+		const yaml = Bun.YAML.stringify({ jobs: { plan: { "runs-on": "ubuntu-24.04" } } });
+		expect(() => matrixSuiteCaller(Bun.YAML.parse(yaml), "synthetic.yml")).toThrow(
+			"no job calls the reusable bench-suite.yml",
+		);
+	});
+
+	test("matrixSuiteCaller throws on multiple suite-matrix callers", () => {
+		const yaml = Bun.YAML.stringify({
+			jobs: {
+				a: {
+					name: EXPECTED_SUITE_NAME_EXPR,
+					uses: "./.github/workflows/bench-suite.yml",
+					with: { suite: EXPECTED_SUITE_NAME_EXPR },
+					strategy: { matrix: { suite: EXPECTED_SUITE_MATRIX_EXPR } },
+				},
+				b: {
+					name: EXPECTED_SUITE_NAME_EXPR,
+					uses: "./.github/workflows/bench-suite.yml",
+					with: { suite: EXPECTED_SUITE_NAME_EXPR },
+					strategy: { matrix: { suite: EXPECTED_SUITE_MATRIX_EXPR } },
+				},
+			},
+		});
+		expect(() => matrixSuiteCaller(Bun.YAML.parse(yaml), "synthetic.yml")).toThrow(
+			"expected exactly one suite-matrix caller",
+		);
+	});
+
+	test("matrixSuiteCaller throws on a reusable-caller job with no string suite", () => {
+		const yaml = Bun.YAML.stringify({
+			jobs: { bad: { uses: "./.github/workflows/bench-suite.yml", with: { providers: "[]" } } },
+		});
+		expect(() => matrixSuiteCaller(Bun.YAML.parse(yaml), "synthetic.yml")).toThrow(
+			'without a string "suite" input',
+		);
+	});
+});
+
+describe("checkSuiteWorkflowNesting", () => {
+	const suiteWf = readWorkflow(SUITE_WORKFLOW);
+
+	test("the real reusable fan-out job is named matrix.provider", () => {
+		expect(checkSuiteWorkflowNesting(suiteWf)).toEqual([]);
+	});
+
+	test("flags a fan-out job whose display name is not matrix.provider", () => {
+		const yaml = Bun.YAML.stringify({
+			jobs: { [SUITE_JOB]: { name: "Run", "runs-on": "ubuntu-24.04" } },
+		});
+		const errors = checkSuiteWorkflowNesting(Bun.YAML.parse(yaml), "synthetic.yml");
+		expect(errors).toHaveLength(1);
+		expect(errors[0]).toContain("name must be");
+		expect(errors[0]).toContain(EXPECTED_PROVIDER_NAME_EXPR);
 	});
 });
 

--- a/tooling/repo-checks/src/workflow-registry-sync.test.ts
+++ b/tooling/repo-checks/src/workflow-registry-sync.test.ts
@@ -7,7 +7,8 @@
 // timeout live in the reusable (the "matrix side" of the credential/timeout checks reads it), and a
 // separate invariant asserts the suite-matrix caller stays wired to plan.outputs.suites. Mirrors
 // runner-benchmarking's test/workflow-{env,suite}-sync.test.ts. See ./lib/workflow-sync.ts for the
-// parsers + pure checks.
+// parsers + pure checks. Nesting (invariant 6) lives in ./lib/workflow-nesting.ts; YAML helpers in
+// ./lib/workflow-yaml.ts — workflow-sync.ts re-exports the public surface.
 //
 // The runCheck() test against the real workflow files IS the gate's CI enforcement point (it runs under
 // `bun test`, same precedent as boundary.test.ts); the rest is unit coverage of the parsers and the


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What

Tightens the bench-matrix nesting refactor so the Actions UI uses **GitHub-native reusable-workflow nesting** end-to-end, with cleaner per-cell Results — then applies a full maintainability cleanup from a thermo-nuclear review.

Cells still display as `system / e2b`, but the suite parents come from one matrix caller instead of nine hand-enumerated jobs, and each cell writes a job summary + run annotation.

## How

- **`bench-matrix.yml`**: one `suite` job with `strategy.matrix.suite` calling reusable `bench-suite.yml`
- **`plan-providers` / `plan-suites`**: shared `plan-axis` runner + shared `selectRegistryIds` (no twin control flows)
- **`bench-suite.ts`**: every cell exit goes through one `reportCell` / `failCell` path
- **`suite-tasks.ts`**: pure discovery; Actions HTML tables live in `suite-summary.ts`
- **`actions-log.ts`**: canonical `logInfo` / `logWarning` used by all bins
- **Workflow drift gate**: split into `workflow-yaml.ts` + `workflow-nesting.ts` + thin `workflow-sync.ts`
- Docs / package bins: register `plan-providers` / `plan-suites`; `plan-matrix` is local cell listing only

## UI shape

```
Plan matrix
cpu-node/
  e2b
  daytona
  modal
system/
  …
Aggregate + promote dataset
```

## Verification

`bun test` (plan-*/suite-tasks/actions-log/workflow-registry-sync + broader cli/repo-checks), `tsc --noEmit` for apps/cli and tooling/repo-checks.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-880f2762-415e-40f8-9a4e-88a86b53e268"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-880f2762-415e-40f8-9a4e-88a86b53e268"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Collapsed the bench matrix into one suite-matrix caller using GitHub-native reusable-workflow nesting so cells display as "<suite> / <provider>", and each cell writes a `@actions/core` job summary with provider status, precise mise tasks, PTS pins, and run metadata.

- **Refactors**
  - `.github/workflows/bench-matrix.yml`: single `suite` matrix calls `bench-suite.yml`; `plan` step writes `providers=`/`suites=` via `plan-providers`/`plan-suites`; `publish` stays `needs: [plan, suite]`; repeated the fork/branch if-guard on the suite job for explicit live-run gating.
  - New reusable `.github/workflows/bench-suite.yml`: fans out providers under `environment: privileged` with `secrets: inherit`; uploads `bench-<suite>-<provider>-<run_id>` artifacts.
  - CLI bins (`bench-suite`, `aggregate`, `leaderboard`, `promote`) now use shared `actions-log` for foldable groups, annotations, and job summaries; `withGroup` guards against dangling groups; `promote` always emits machine-readable JSON to stdout; `release-summary` uses shared HTML helpers from `actions-log`.
  - Drift gate split: new `workflow-nesting.ts` validates native nesting and `publish.needs`; `workflow-sync.ts` reads the reusable for credential/timeouts; shared `workflow-yaml.ts` helpers.
  - Fix: organized imports in `release-summary` to satisfy Biome lints.

- **New Features**
  - `apps/cli/src/lib/actions-log.ts`: `withGroup`, `writeJobSummary`, `fieldTable`, provider-status table, failure detection; tests added.
  - `apps/cli/src/lib/suite-tasks.ts` + `suite-summary.ts`: discover mise tasks and PTS pins from commands/task files/`lib/bench.sh`; render “Mise tasks” and “Declared metrics” tables; tests added.
  - New planners: `plan-providers` and `plan-suites` emit single-line JSON and write step outputs via `plan-axis.ts`; `plan-matrix` kept for local cell listing.

<sup>Written for commit 1aeb9ec51084eeac3d4d41e2fe6abb9ddd434abd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/starslingdev/hpc-sandbox-benchmarks/pull/199?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Bench CI now fans out via a two-stage planner and reusable suite workflow, showing suites nested under providers in GitHub Actions.
  * Workflow dispatch can select specific suites and providers.
  * Added CLI planning commands for providers/suites and enhanced per-cell job summaries and annotations.

* **Documentation**
  * Updated contributor guidance, CI secrets, methodology, and CLI docs to match the new workflow wiring and planning outputs.

* **Bug Fixes**
  * Improved detection/reporting of failed or incomplete benchmark cells and normalized outputs.
  * Strengthened workflow nesting/validation checks and expanded HTML escaping (including single quotes).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->