### PR TITLE
chore(dataset): publish run 29562866807

### DIFF
--- a/LEADERBOARD.md
+++ b/LEADERBOARD.md
@@ -1,10 +1,10 @@
 # Sandbox provider leaderboard
 
-Run `29546060837` · commit `dd1f6ef472e3de4b76043c74f3cce5ff0d636af2` · generated 2026-07-17T03:31:38.992Z
+Run `29562866807` · commit `74ccfe2aeba48cf36b287b15fbc765960c6395e9` · generated 2026-07-17T09:52:57.028Z
 
-Requested target for every provider: **2 vCPU · 8 GiB RAM · 40 GB disk**. This run contains **204 metric records**
-backed by **401 retained trial observations**, across **54 metrics** and
-**5 providers**; every emitted, catalogued metric has a ranked table below
+Requested target for every provider: **2 vCPU · 8 GiB RAM · 40 GB disk**. This run contains **155 metric records**
+backed by **307 retained trial observations**, across **54 metrics** and
+**4 providers**; every emitted, catalogued metric has a ranked table below
 (median of retained trials), grouped by dimension with its headline first.
 Generated from the published Run dataset — do not edit by hand. Methodology:
 [`docs/methodology.md`](docs/methodology.md).
@@ -22,15 +22,14 @@ surfaced through coverage gaps, not part of the compute-match verdict.
 
 runs/s · higher is better
 
-_Daytona leads · ~1.1× Novita on median (higher is better)._
+_Daytona leads · ~1.7× Blaxel on median (higher is better)._
 
 | Rank | Provider | Node.js web tooling (runs/s) | 95% bootstrap interval | n | Note |
 | ---: | --- | ---: | ---: | ---: | --- |
-| 1 | Daytona | 19.51 | 19.46 – 19.55 | 2 | — |
-| 2 | Novita | 17.5 | 17.43 – 17.58 | 2 | n too small |
-| 3 | Blaxel | 12.8 | 12.67 – 12.94 | 2 | n too small |
-| 4 | E2B | 11.05 | 10.99 – 11.12 | 2 | n too small |
-| 5 | Modal | 8.82 | 8.71 – 8.93 | 2 | n too small |
+| 1 | Daytona | 19.43 | 19.36 – 19.5 | 2 | — |
+| 2 | Blaxel | 11.72 | 11.47 – 11.97 | 2 | n too small |
+| 3 | E2B | 10.32 | 10.22 – 10.43 | 2 | n too small |
+| 4 | Modal | 8.78 | 8.77 – 8.79 | 2 | n too small |
 
 ### C-Ray (1080p, 16 RPP)
 
@@ -40,9 +39,8 @@ _Blaxel leads · Daytona is ~1.6× higher (lower is better)._
 
 | Rank | Provider | C-Ray (1080p, 16 RPP) (Seconds) | 95% bootstrap interval | n | Note |
 | ---: | --- | ---: | ---: | ---: | --- |
-| 1 | Blaxel | 127.6 | 127.6 – 127.7 | 2 | — |
-| 2 | Daytona | 199.7 | 199.4 – 200.1 | 2 | n too small |
-| 3 | Novita | 240.6 | 240.2 – 241 | 2 | n too small |
+| 1 | Blaxel | 128.9 | 128.8 – 129 | 2 | — |
+| 2 | Daytona | 201 | 200.8 – 201.1 | 2 | n too small |
 
 ### C-Ray (4K, 16 RPP)
 
@@ -52,9 +50,8 @@ _Blaxel leads · Daytona is ~1.6× higher (lower is better)._
 
 | Rank | Provider | C-Ray (4K, 16 RPP) (Seconds) | 95% bootstrap interval | n | Note |
 | ---: | --- | ---: | ---: | ---: | --- |
-| 1 | Blaxel | 509.7 | 509.7 – 509.8 | 2 | — |
-| 2 | Daytona | 799.3 | 798.1 – 800.4 | 2 | n too small |
-| 3 | Novita | 961.9 | 961.5 – 962.3 | 2 | n too small |
+| 1 | Blaxel | 514.1 | 513.8 – 514.4 | 2 | — |
+| 2 | Daytona | 800.8 | 799.6 – 801.9 | 2 | n too small |
 
 ### C-Ray (5K, 16 RPP)
 
@@ -64,176 +61,160 @@ _Blaxel leads · Daytona is ~1.6× higher (lower is better)._
 
 | Rank | Provider | C-Ray (5K, 16 RPP) (Seconds) | 95% bootstrap interval | n | Note |
 | ---: | --- | ---: | ---: | ---: | --- |
-| 1 | Blaxel | 907.5 | 907 – 908.1 | 2 | — |
-| 2 | Daytona | 1422 | 1418 – 1426 | 2 | n too small |
-| 3 | Novita | 1705 | 1704 – 1705 | 2 | n too small |
+| 1 | Blaxel | 912.9 | 912.5 – 913.2 | 2 | — |
+| 2 | Daytona | 1419 | 1418 – 1420 | 2 | n too small |
 
 ### Zstd 12 compress
 
 MB/s · higher is better
 
-_Blaxel leads · ~1.2× Daytona on median (higher is better)._
+_Blaxel leads · ~1.1× Daytona on median (higher is better)._
 
 | Rank | Provider | Zstd 12 compress (MB/s) | 95% bootstrap interval | n | Note |
 | ---: | --- | ---: | ---: | ---: | --- |
-| 1 | Blaxel | 117.1 | 115.9 – 118.3 | 2 | — |
-| 2 | Daytona | 99.45 | 99.3 – 99.6 | 2 | n too small |
-| 3 | Novita | 71.4 | 71.2 – 71.6 | 2 | n too small |
+| 1 | Blaxel | 107.4 | 106.3 – 108.5 | 2 | — |
+| 2 | Daytona | 98.75 | 98.6 – 98.9 | 2 | n too small |
 
 ### Zstd 12 decompress
 
 MB/s · higher is better
 
-_Daytona leads · ~1.2× Novita on median (higher is better)._
+_Daytona leads · ~2.3× Blaxel on median (higher is better)._
 
 | Rank | Provider | Zstd 12 decompress (MB/s) | 95% bootstrap interval | n | Note |
 | ---: | --- | ---: | ---: | ---: | --- |
-| 1 | Daytona | 2304 | 2299 – 2309 | 2 | — |
-| 2 | Novita | 1906 | 1897 – 1915 | 2 | n too small |
-| 3 | Blaxel | 1052 | 1044 – 1060 | 2 | n too small |
+| 1 | Daytona | 2294 | 2288 – 2301 | 2 | — |
+| 2 | Blaxel | 998.7 | 998.2 – 999.2 | 2 | n too small |
 
 ### Zstd 19 compress
 
 MB/s · higher is better
 
-_Blaxel leads · ~1.4× Daytona on median (higher is better)._
+_Blaxel leads · ~1.2× Daytona on median (higher is better)._
 
 | Rank | Provider | Zstd 19 compress (MB/s) | 95% bootstrap interval | n | Note |
 | ---: | --- | ---: | ---: | ---: | --- |
-| 1 | Blaxel | 11.1 | 11 – 11.2 | 2 | — |
-| 2 | Daytona | 8.09 | 8.04 – 8.14 | 2 | n too small |
-| 3 | Novita | 5.7 | 5.69 – 5.71 | 2 | n too small |
+| 1 | Blaxel | 10.05 | 10 – 10.1 | 2 | — |
+| 2 | Daytona | 8.15 | 8.14 – 8.16 | 2 | n too small |
 
 ### Zstd 19 decompress
 
 MB/s · higher is better
 
-_Daytona leads · ~1.2× Novita on median (higher is better)._
+_Daytona leads · ~2.3× Blaxel on median (higher is better)._
 
 | Rank | Provider | Zstd 19 decompress (MB/s) | 95% bootstrap interval | n | Note |
 | ---: | --- | ---: | ---: | ---: | --- |
-| 1 | Daytona | 1916 | 1915 – 1918 | 2 | — |
-| 2 | Novita | 1622 | 1617 – 1627 | 2 | n too small |
-| 3 | Blaxel | 881.8 | 868.9 – 894.6 | 2 | n too small |
+| 1 | Daytona | 1927 | 1923 – 1931 | 2 | — |
+| 2 | Blaxel | 841 | 823.6 – 858.5 | 2 | n too small |
 
 ### Zstd 19 (long) compress
 
 MB/s · higher is better
 
-_Daytona leads · ~1.2× Blaxel on median (higher is better)._
+_Daytona leads · ~1.4× Blaxel on median (higher is better)._
 
 | Rank | Provider | Zstd 19 (long) compress (MB/s) | 95% bootstrap interval | n | Note |
 | ---: | --- | ---: | ---: | ---: | --- |
-| 1 | Daytona | 7.075 | 7.03 – 7.12 | 2 | — |
-| 2 | Blaxel | 5.875 | 5.8 – 5.95 | 2 | n too small |
-| 3 | Novita | 5.225 | 5.22 – 5.23 | 2 | n too small |
+| 1 | Daytona | 7.16 | 7.13 – 7.19 | 2 | — |
+| 2 | Blaxel | 5.095 | 5.06 – 5.13 | 2 | n too small |
 
 ### Zstd 19 (long) decompress
 
 MB/s · higher is better
 
-_Daytona leads · ~1.2× Novita on median (higher is better)._
+_Daytona leads · ~2.2× Blaxel on median (higher is better)._
 
 | Rank | Provider | Zstd 19 (long) decompress (MB/s) | 95% bootstrap interval | n | Note |
 | ---: | --- | ---: | ---: | ---: | --- |
-| 1 | Daytona | 1842 | 1840 – 1845 | 2 | — |
-| 2 | Novita | 1544 | 1536 – 1552 | 2 | n too small |
-| 3 | Blaxel | 894.4 | 886.3 – 902.5 | 2 | n too small |
+| 1 | Daytona | 1859 | 1850 – 1869 | 2 | — |
+| 2 | Blaxel | 861.2 | 852.1 – 870.3 | 2 | n too small |
 
 ### Zstd 3 compress
 
 MB/s · higher is better
 
-_Blaxel leads · ~1.7× Daytona on median (higher is better)._
+_Blaxel leads · ~1.6× Daytona on median (higher is better)._
 
 | Rank | Provider | Zstd 3 compress (MB/s) | 95% bootstrap interval | n | Note |
 | ---: | --- | ---: | ---: | ---: | --- |
-| 1 | Blaxel | 1300 | 1294 – 1306 | 2 | — |
-| 2 | Daytona | 781.8 | 781.2 – 782.3 | 2 | n too small |
-| 3 | Novita | 677.7 | 673.2 – 682.1 | 2 | n too small |
+| 1 | Blaxel | 1240 | 1235 – 1246 | 2 | — |
+| 2 | Daytona | 787.5 | 787.5 – 787.6 | 2 | n too small |
 
 ### Zstd 3 decompress
 
 MB/s · higher is better
 
-_Daytona leads · ~1.2× Novita on median (higher is better)._
+_Daytona is the only ranked provider (2114 MB/s; higher is better)._
 
-| Rank | Provider | Zstd 3 decompress (MB/s) | 95% bootstrap interval | n | Note |
-| ---: | --- | ---: | ---: | ---: | --- |
-| 1 | Daytona | 2113 | 2112 – 2115 | 2 | — |
-| 2 | Novita | 1747 | 1743 – 1751 | 2 | n too small |
-| 3 | Blaxel | 1117 | — | 1 | — |
+| Rank | Provider | Zstd 3 decompress (MB/s) | 95% bootstrap interval | n |
+| ---: | --- | ---: | ---: | ---: |
+| 1 | Daytona | 2114 | 2110 – 2119 | 2 |
 
 ### Zstd 3 (long) compress
 
 MB/s · higher is better
 
-_Blaxel leads · ~1.6× Daytona on median (higher is better)._
+_Blaxel leads · ~1.5× Daytona on median (higher is better)._
 
 | Rank | Provider | Zstd 3 (long) compress (MB/s) | 95% bootstrap interval | n | Note |
 | ---: | --- | ---: | ---: | ---: | --- |
-| 1 | Blaxel | 847.9 | 841.7 – 854.1 | 2 | — |
-| 2 | Daytona | 535.7 | 534.9 – 536.5 | 2 | n too small |
-| 3 | Novita | 529.5 | 527.9 – 531 | 2 | n too small |
+| 1 | Blaxel | 777.7 | 770.9 – 784.5 | 2 | — |
+| 2 | Daytona | 534.2 | 532.1 – 536.3 | 2 | n too small |
 
 ### Zstd 3 (long) decompress
 
 MB/s · higher is better
 
-_Daytona leads · ~1.2× Novita on median (higher is better)._
+_Daytona leads · ~1.9× Blaxel on median (higher is better)._
 
 | Rank | Provider | Zstd 3 (long) decompress (MB/s) | 95% bootstrap interval | n | Note |
 | ---: | --- | ---: | ---: | ---: | --- |
-| 1 | Daytona | 2166 | 2161 – 2171 | 2 | — |
-| 2 | Novita | 1808 | 1805 – 1811 | 2 | n too small |
+| 1 | Daytona | 2165 | 2156 – 2175 | 2 | — |
+| 2 | Blaxel | 1147 | 1144 – 1151 | 2 | n too small |
 
 ### Zstd 8 compress
 
 MB/s · higher is better
 
-_Blaxel leads · ~1.7× Daytona on median (higher is better)._
+_Blaxel leads · ~1.5× Daytona on median (higher is better)._
 
 | Rank | Provider | Zstd 8 compress (MB/s) | 95% bootstrap interval | n | Note |
 | ---: | --- | ---: | ---: | ---: | --- |
-| 1 | Blaxel | 352.4 | 352 – 352.7 | 2 | — |
-| 2 | Daytona | 210.4 | 208.8 – 212 | 2 | n too small |
-| 3 | Novita | 179.4 | 178.7 – 180.2 | 2 | n too small |
+| 1 | Blaxel | 321.1 | 320.1 – 322.1 | 2 | — |
+| 2 | Daytona | 210.5 | 210.1 – 210.9 | 2 | n too small |
 
 ### Zstd 8 decompress
 
 MB/s · higher is better
 
-_Daytona leads · ~1.2× Novita on median (higher is better)._
+_Blaxel is the only ranked provider (1088 MB/s; higher is better)._
 
-| Rank | Provider | Zstd 8 decompress (MB/s) | 95% bootstrap interval | n | Note |
-| ---: | --- | ---: | ---: | ---: | --- |
-| 1 | Daytona | 2269 | 2269 – 2269 | 2 | — |
-| 2 | Novita | 1910 | 1908 – 1912 | 2 | n too small |
-| 3 | Blaxel | 1122 | 1117 – 1126 | 2 | n too small |
+| Rank | Provider | Zstd 8 decompress (MB/s) | 95% bootstrap interval | n |
+| ---: | --- | ---: | ---: | ---: |
+| 1 | Blaxel | 1088 | 1088 – 1088 | 2 |
 
 ### Zstd 8 (long) compress
 
 MB/s · higher is better
 
-_Blaxel leads · ~1.6× Daytona on median (higher is better)._
+_Blaxel leads · ~1.5× Daytona on median (higher is better)._
 
 | Rank | Provider | Zstd 8 (long) compress (MB/s) | 95% bootstrap interval | n | Note |
 | ---: | --- | ---: | ---: | ---: | --- |
-| 1 | Blaxel | 325.3 | 323.7 – 326.9 | 2 | — |
-| 2 | Daytona | 202.7 | 202.3 – 203 | 2 | n too small |
-| 3 | Novita | 174.7 | 174.5 – 174.8 | 2 | n too small |
+| 1 | Blaxel | 306.1 | 301.7 – 310.5 | 2 | — |
+| 2 | Daytona | 202.8 | 202.1 – 203.4 | 2 | n too small |
 
 ### Zstd 8 (long) decompress
 
 MB/s · higher is better
 
-_Daytona leads · ~1.2× Novita on median (higher is better)._
+_Daytona leads · ~2.1× Blaxel on median (higher is better)._
 
 | Rank | Provider | Zstd 8 (long) decompress (MB/s) | 95% bootstrap interval | n | Note |
 | ---: | --- | ---: | ---: | ---: | --- |
-| 1 | Daytona | 2308 | 2305 – 2311 | 2 | — |
-| 2 | Novita | 1913 | 1912 – 1915 | 2 | n too small |
-| 3 | Blaxel | 1135 | 1135 – 1136 | 2 | n too small |
+| 1 | Daytona | 2313 | 2301 – 2326 | 2 | — |
+| 2 | Blaxel | 1101 | 1098 – 1104 | 2 | n too small |
 
 ## disk
 
@@ -241,29 +222,27 @@ _Daytona leads · ~1.2× Novita on median (higher is better)._
 
 IOPS · higher is better
 
-_Blaxel leads · ~2.3× Daytona on median (higher is better)._
+_Blaxel leads · ~2.2× Daytona on median (higher is better)._
 
 | Rank | Provider | fio rand read 4KB, O_DIRECT (IOPS) (IOPS) | 95% bootstrap interval | n | Note |
 | ---: | --- | ---: | ---: | ---: | --- |
-| 1 | Blaxel | 576000 | 570000 – 582000 | 2 | — |
-| 2 | Daytona | 248500 | 240000 – 257000 | 2 | n too small |
-| 3 | Novita | 59500 | 55300 – 63700 | 2 | n too small |
-| 4 | E2B | 40000 | 38700 – 41300 | 2 | n too small |
-| 5 | Modal | 33900 | 33200 – 34600 | 2 | n too small |
+| 1 | Blaxel | 545000 | 531000 – 559000 | 2 | — |
+| 2 | Daytona | 247500 | 243000 – 252000 | 2 | n too small |
+| 3 | E2B | 40600 | 38600 – 42600 | 2 | n too small |
+| 4 | Modal | 36500 | 36400 – 36600 | 2 | n too small |
 
 ### fio rand read 4KB, O_DIRECT (MB/s)
 
 MB/s · higher is better
 
-_Blaxel leads · ~2.3× Daytona on median (higher is better)._
+_Blaxel leads · ~2.2× Daytona on median (higher is better)._
 
 | Rank | Provider | fio rand read 4KB, O_DIRECT (MB/s) (MB/s) | 95% bootstrap interval | n | Note |
 | ---: | --- | ---: | ---: | ---: | --- |
-| 1 | Blaxel | 2251 | 2226 – 2275 | 2 | — |
-| 2 | Daytona | 971 | 936 – 1006 | 2 | n too small |
-| 3 | Novita | 232.5 | 216 – 249 | 2 | n too small |
-| 4 | E2B | 156.5 | 151 – 162 | 2 | n too small |
-| 5 | Modal | 132.5 | 130 – 135 | 2 | n too small |
+| 1 | Blaxel | 2128 | 2073 – 2183 | 2 | — |
+| 2 | Daytona | 967.5 | 949 – 986 | 2 | n too small |
+| 3 | E2B | 158.5 | 151 – 166 | 2 | n too small |
+| 4 | Modal | 142.5 | 142 – 143 | 2 | n too small |
 
 ### fio rand write 4KB, O_DIRECT (IOPS)
 
@@ -273,11 +252,10 @@ _Blaxel leads · ~2.1× Daytona on median (higher is better)._
 
 | Rank | Provider | fio rand write 4KB, O_DIRECT (IOPS) (IOPS) | 95% bootstrap interval | n | Note |
 | ---: | --- | ---: | ---: | ---: | --- |
-| 1 | Blaxel | 495000 | 484000 – 506000 | 2 | — |
-| 2 | Daytona | 231500 | 208000 – 255000 | 2 | n too small |
-| 3 | Novita | 85150 | 75700 – 94600 | 2 | n too small |
-| 4 | E2B | 43900 | 43500 – 44300 | 2 | n too small |
-| 5 | Modal | 28300 | 27000 – 29600 | 2 | n too small |
+| 1 | Blaxel | 489500 | 487000 – 492000 | 2 | — |
+| 2 | Daytona | 230000 | 229000 – 231000 | 2 | n too small |
+| 3 | E2B | 42200 | 41900 – 42500 | 2 | n too small |
+| 4 | Modal | 30300 | 30100 – 30500 | 2 | n too small |
 
 ### fio rand write 4KB, O_DIRECT (MB/s)
 
@@ -287,79 +265,74 @@ _Blaxel leads · ~2.1× Daytona on median (higher is better)._
 
 | Rank | Provider | fio rand write 4KB, O_DIRECT (MB/s) (MB/s) | 95% bootstrap interval | n | Note |
 | ---: | --- | ---: | ---: | ---: | --- |
-| 1 | Blaxel | 1934 | 1891 – 1977 | 2 | — |
-| 2 | Daytona | 902.5 | 811 – 994 | 2 | n too small |
-| 3 | Novita | 332.5 | 296 – 369 | 2 | n too small |
-| 4 | E2B | 171.5 | 170 – 173 | 2 | n too small |
-| 5 | Modal | 110.5 | 105 – 116 | 2 | n too small |
+| 1 | Blaxel | 1912 | 1903 – 1921 | 2 | — |
+| 2 | Daytona | 898.5 | 895 – 902 | 2 | n too small |
+| 3 | E2B | 165 | 164 – 166 | 2 | n too small |
+| 4 | Modal | 118.5 | 118 – 119 | 2 | n too small |
 
 ### fio seq read 1MB, O_DIRECT (IOPS)
 
 IOPS · higher is better
 
-_Modal leads · ~1.1× Novita on median (higher is better)._
+_Modal leads · ~1.6× Daytona on median (higher is better)._
 
 | Rank | Provider | fio seq read 1MB, O_DIRECT (IOPS) (IOPS) | 95% bootstrap interval | n | Note |
 | ---: | --- | ---: | ---: | ---: | --- |
-| 1 | Modal | 12350 | 11900 – 12800 | 2 | — |
-| 2 | Novita | 11250 | 11200 – 11300 | 2 | n too small |
-| 3 | Daytona | 9142 | 5584 – 12700 | 2 | n too small |
-| 4 | Blaxel | 4709 | 4609 – 4809 | 2 | n too small |
-| 5 | E2B | 599 | 599 – 599 | 2 | n too small |
+| 1 | Modal | 13000 | 12700 – 13300 | 2 | — |
+| 2 | Daytona | 8041 | 7583 – 8499 | 2 | n too small |
+| 3 | Blaxel | 4489 | 4313 – 4664 | 2 | n too small |
+| 4 | E2B | 599 | 599 – 599 | 2 | n too small |
 
 ### fio seq read 1MB, O_DIRECT (MB/s)
 
 MB/s · higher is better
 
-_Daytona leads · ~1.2× Blaxel on median (higher is better)._
+_Daytona leads · ~1.8× Blaxel on median (higher is better)._
 
 | Rank | Provider | fio seq read 1MB, O_DIRECT (MB/s) (MB/s) | 95% bootstrap interval | n | Note |
 | ---: | --- | ---: | ---: | ---: | --- |
-| 1 | Daytona | 5585 | — | 1 | — |
-| 2 | Blaxel | 4711 | 4611 – 4811 | 2 | — |
+| 1 | Daytona | 8043 | 7585 – 8501 | 2 | — |
+| 2 | Blaxel | 4491 | 4315 – 4666 | 2 | n too small |
 | 3 | E2B | 601 | 601 – 601 | 2 | n too small |
 
 ### fio seq write 1MB, O_DIRECT (IOPS)
 
 IOPS · higher is better
 
-_Daytona leads · ~1.1× Novita on median (higher is better)._
+_Daytona leads · ~1.3× Blaxel on median (higher is better)._
 
 | Rank | Provider | fio seq write 1MB, O_DIRECT (IOPS) (IOPS) | 95% bootstrap interval | n | Note |
 | ---: | --- | ---: | ---: | ---: | --- |
-| 1 | Daytona | 5821 | 5714 – 5928 | 2 | — |
-| 2 | Novita | 5390 | 5210 – 5570 | 2 | n too small |
-| 3 | Blaxel | 3658 | 3616 – 3700 | 2 | n too small |
-| 4 | Modal | 3458 | 3362 – 3554 | 2 | n too small |
-| 5 | E2B | 599 | 598 – 600 | 2 | n too small |
+| 1 | Daytona | 4773 | 4767 – 4778 | 2 | — |
+| 2 | Blaxel | 3571 | 3549 – 3592 | 2 | n too small |
+| 3 | Modal | 2192 | 1872 – 2511 | 2 | n too small |
+| 4 | E2B | 599 | 599 – 599 | 2 | n too small |
 
 ### fio seq write 1MB, O_DIRECT (MB/s)
 
 MB/s · higher is better
 
-_Daytona leads · ~1.1× Novita on median (higher is better)._
+_Daytona leads · ~1.3× Blaxel on median (higher is better)._
 
 | Rank | Provider | fio seq write 1MB, O_DIRECT (MB/s) (MB/s) | 95% bootstrap interval | n | Note |
 | ---: | --- | ---: | ---: | ---: | --- |
-| 1 | Daytona | 5823 | 5716 – 5930 | 2 | — |
-| 2 | Novita | 5391 | 5211 – 5571 | 2 | n too small |
-| 3 | Blaxel | 3660 | 3618 – 3702 | 2 | n too small |
-| 4 | Modal | 3460 | 3363 – 3556 | 2 | n too small |
-| 5 | E2B | 600.5 | 600 – 601 | 2 | n too small |
+| 1 | Daytona | 4774 | 4769 – 4779 | 2 | — |
+| 2 | Blaxel | 3572 | 3550 – 3593 | 2 | n too small |
+| 3 | Modal | 2193 | 1873 – 2512 | 2 | n too small |
+| 4 | E2B | 600.5 | 600 – 601 | 2 | n too small |
 
 ### Hardlink throughput
 
 bogo ops/s · higher is better
 
-_Daytona leads · ~1.3× Novita on median (higher is better)._
+_Daytona leads · ~2.0× Blaxel on median (higher is better)._
 
 | Rank | Provider | Hardlink throughput (bogo ops/s) | 95% bootstrap interval | n | Note |
 | ---: | --- | ---: | ---: | ---: | --- |
-| 1 | Daytona | 23.66 | 23.62 – 23.69 | 2 | — |
-| 2 | Novita | 18.52 | 18.45 – 18.59 | 2 | n too small |
-| 3 | Blaxel | 12.43 | 12.39 – 12.46 | 2 | n too small |
-| 4 | Modal | 3.05 | 2.98 – 3.12 | 2 | n too small |
-| 5 | E2B | 1.46 | 1.46 – 1.46 | 2 | n too small |
+| 1 | Daytona | 23.27 | 23.09 – 23.45 | 2 | — |
+| 2 | Blaxel | 11.59 | 11.53 – 11.66 | 2 | n too small |
+| 3 | Modal | 3.23 | 3.23 – 3.23 | 2 | n too small |
+| 4 | E2B | 1.43 | 1.43 – 1.43 | 2 | n too small |
 
 ## memory
 
@@ -371,11 +344,10 @@ _Blaxel leads · ~1.3× Daytona on median (higher is better)._
 
 | Rank | Provider | STREAM Triad (MB/s) | 95% bootstrap interval | n | Note |
 | ---: | --- | ---: | ---: | ---: | --- |
-| 1 | Blaxel | 73890 | 70330 – 77460 | 2 | — |
-| 2 | Daytona | 56000 | 55980 – 56010 | 2 | n too small |
-| 3 | Novita | 46030 | 45840 – 46210 | 2 | n too small |
-| 4 | Modal | 45370 | 42050 – 48700 | 2 | n too small |
-| 5 | E2B | 22020 | 21770 – 22260 | 2 | n too small |
+| 1 | Blaxel | 70360 | 69840 – 70880 | 2 | — |
+| 2 | Daytona | 54670 | 54550 – 54790 | 2 | n too small |
+| 3 | Modal | 42090 | 37810 – 46380 | 2 | n too small |
+| 4 | E2B | 22450 | 22320 – 22570 | 2 | n too small |
 
 ### STREAM Add
 
@@ -385,11 +357,10 @@ _Blaxel leads · ~1.3× Daytona on median (higher is better)._
 
 | Rank | Provider | STREAM Add (MB/s) | 95% bootstrap interval | n | Note |
 | ---: | --- | ---: | ---: | ---: | --- |
-| 1 | Blaxel | 73910 | 70140 – 77690 | 2 | — |
-| 2 | Daytona | 55740 | 55730 – 55760 | 2 | n too small |
-| 3 | Modal | 45920 | 41170 – 50670 | 2 | n too small |
-| 4 | Novita | 45850 | 45780 – 45930 | 2 | n too small |
-| 5 | E2B | 22020 | 21840 – 22210 | 2 | n too small |
+| 1 | Blaxel | 69360 | 67700 – 71020 | 2 | — |
+| 2 | Daytona | 54460 | 54290 – 54630 | 2 | n too small |
+| 3 | Modal | 42880 | 40280 – 45481 | 2 | n too small |
+| 4 | E2B | 22338 | 22060 – 22610 | 2 | n too small |
 
 ### STREAM Copy
 
@@ -399,11 +370,10 @@ _Blaxel leads · ~1.7× Daytona on median (higher is better)._
 
 | Rank | Provider | STREAM Copy (MB/s) | 95% bootstrap interval | n | Note |
 | ---: | --- | ---: | ---: | ---: | --- |
-| 1 | Blaxel | 113800 | 107300 – 120400 | 2 | — |
-| 2 | Daytona | 65680 | 65676 – 65690 | 2 | n too small |
-| 3 | Modal | 62010 | 56590 – 67440 | 2 | n too small |
-| 4 | Novita | 54820 | 54520 – 55130 | 2 | n too small |
-| 5 | E2B | 45120 | 43480 – 46760 | 2 | n too small |
+| 1 | Blaxel | 111000 | 109600 – 112400 | 2 | — |
+| 2 | Daytona | 66780 | 66560 – 66990 | 2 | n too small |
+| 3 | Modal | 60448 | 54860 – 66030 | 2 | n too small |
+| 4 | E2B | 46760 | 46530 – 46980 | 2 | n too small |
 
 ### STREAM Scale
 
@@ -413,11 +383,10 @@ _Blaxel leads · ~1.2× Daytona on median (higher is better)._
 
 | Rank | Provider | STREAM Scale (MB/s) | 95% bootstrap interval | n | Note |
 | ---: | --- | ---: | ---: | ---: | --- |
-| 1 | Blaxel | 62620 | 58680 – 66567 | 2 | — |
-| 2 | Daytona | 50120 | 50050 – 50180 | 2 | n too small |
-| 3 | Novita | 45410 | 45210 – 45610 | 2 | n too small |
-| 4 | Modal | 37400 | 34140 – 40662 | 2 | n too small |
-| 5 | E2B | 20880 | 20700 – 21050 | 2 | n too small |
+| 1 | Blaxel | 61270 | 59900 – 62630 | 2 | — |
+| 2 | Daytona | 49730 | 49620 – 49840 | 2 | n too small |
+| 3 | Modal | 36520 | 35350 – 37680 | 2 | n too small |
+| 4 | E2B | 21130 | 20730 – 21520 | 2 | n too small |
 
 ## network
 
@@ -425,25 +394,24 @@ _Blaxel leads · ~1.2× Daytona on median (higher is better)._
 
 Seconds · lower is better
 
-_Daytona leads · Blaxel is ~1.2× higher (lower is better)._
+_Daytona leads · Blaxel is ~1.3× higher (lower is better)._
 
 | Rank | Provider | Loopback TCP (10GB) (Seconds) | 95% bootstrap interval | n | Note |
 | ---: | --- | ---: | ---: | ---: | --- |
-| 1 | Daytona | 5.441 | 5.286 – 5.595 | 2 | — |
-| 2 | Blaxel | 6.603 | 6.339 – 6.867 | 2 | n too small |
-| 3 | Novita | 7.944 | 7.928 – 7.959 | 2 | n too small |
-| 4 | E2B | 10.44 | 9.903 – 10.97 | 2 | n too small |
-| 5 | Modal | 54.1 | 51.35 – 56.86 | 2 | n too small |
+| 1 | Daytona | 5.191 | 4.68 – 5.702 | 2 | — |
+| 2 | Blaxel | 6.553 | 6.395 – 6.712 | 2 | n too small |
+| 3 | E2B | 13.57 | 12.57 – 14.56 | 2 | n too small |
+| 4 | Modal | 57.48 | 56.03 – 58.93 | 2 | n too small |
 
 ### fast.com download
 
 Mbit/s · higher is better
 
-_E2B is the only ranked provider (3.25 Mbit/s; higher is better)._
+_E2B is the only ranked provider (3.5 Mbit/s; higher is better)._
 
 | Rank | Provider | fast.com download (Mbit/s) | 95% bootstrap interval | n |
 | ---: | --- | ---: | ---: | ---: |
-| 1 | E2B | 3.25 | 3 – 3.5 | 2 |
+| 1 | E2B | 3.5 | 3.4 – 3.6 | 2 |
 
 ### fast.com latency
 
@@ -459,21 +427,21 @@ _E2B is the only ranked provider (7 ms; lower is better)._
 
 ms · lower is better
 
-_E2B is the only ranked provider (9 ms; lower is better)._
+_E2B is the only ranked provider (7.5 ms; lower is better)._
 
 | Rank | Provider | fast.com loaded latency (ms) | 95% bootstrap interval | n |
 | ---: | --- | ---: | ---: | ---: |
-| 1 | E2B | 9 | — | 1 |
+| 1 | E2B | 7.5 | 6 – 9 | 2 |
 
 ### fast.com upload
 
 Mbit/s · higher is better
 
-_E2B is the only ranked provider (770 Mbit/s; higher is better)._
+_E2B is the only ranked provider (690 Mbit/s; higher is better)._
 
 | Rank | Provider | fast.com upload (Mbit/s) | 95% bootstrap interval | n |
 | ---: | --- | ---: | ---: | ---: |
-| 1 | E2B | 770 | 760 – 780 | 2 |
+| 1 | E2B | 690 | 660 – 720 | 2 |
 
 ## system
 
@@ -481,39 +449,37 @@ _E2B is the only ranked provider (770 Mbit/s; higher is better)._
 
 Milliseconds · lower is better
 
-_Blaxel is the only ranked provider (844 Milliseconds; lower is better)._
+_Blaxel is the only ranked provider (841.5 Milliseconds; lower is better)._
 
 | Rank | Provider | PyBench (Milliseconds) | 95% bootstrap interval | n |
 | ---: | --- | ---: | ---: | ---: |
-| 1 | Blaxel | 844 | 839 – 849 | 2 |
+| 1 | Blaxel | 841.5 | 840 – 843 | 2 |
 
 ### Git common operations
 
 Seconds · lower is better
 
-_Daytona leads · Novita is ~1.2× higher (lower is better)._
+_Daytona leads · Blaxel is ~1.6× higher (lower is better)._
 
 | Rank | Provider | Git common operations (Seconds) | 95% bootstrap interval | n | Note |
 | ---: | --- | ---: | ---: | ---: | --- |
-| 1 | Daytona | 36.06 | 35.96 – 36.16 | 2 | — |
-| 2 | Novita | 43.59 | 43.49 – 43.68 | 2 | n too small |
-| 3 | Blaxel | 61.48 | 61.37 – 61.59 | 2 | n too small |
-| 4 | E2B | 70.21 | 69.92 – 70.51 | 2 | n too small |
-| 5 | Modal | 81.37 | 80.74 – 82 | 2 | n too small |
+| 1 | Daytona | 39.13 | 39.12 – 39.13 | 2 | — |
+| 2 | Blaxel | 60.99 | 60.6 – 61.38 | 2 | n too small |
+| 3 | E2B | 71.76 | 71.15 – 72.37 | 2 | n too small |
+| 4 | Modal | 80.56 | 79.5 – 81.63 | 2 | n too small |
 
 ### SQLite Speedtest
 
 Seconds · lower is better
 
-_Daytona leads · Novita is ~1.3× higher (lower is better)._
+_Daytona leads · Blaxel is ~2.0× higher (lower is better)._
 
 | Rank | Provider | SQLite Speedtest (Seconds) | 95% bootstrap interval | n | Note |
 | ---: | --- | ---: | ---: | ---: | --- |
-| 1 | Daytona | 30.54 | 30.41 – 30.67 | 2 | — |
-| 2 | Novita | 38.81 | 38.53 – 39.09 | 2 | n too small |
-| 3 | Blaxel | 68.11 | 67.98 – 68.25 | 2 | n too small |
-| 4 | E2B | 69.84 | 69.82 – 69.86 | 2 | n too small |
-| 5 | Modal | 514.7 | 505.6 – 523.8 | 2 | n too small |
+| 1 | Daytona | 34.07 | 33.94 – 34.2 | 2 | — |
+| 2 | Blaxel | 68.08 | 67.44 – 68.71 | 2 | n too small |
+| 3 | E2B | 71.03 | 70.97 – 71.08 | 2 | n too small |
+| 4 | Modal | 520.9 | 513.2 – 528.6 | 2 | n too small |
 
 ## realworld
 
@@ -521,41 +487,38 @@ _Daytona leads · Novita is ~1.3× higher (lower is better)._
 
 Seconds · lower is better
 
-_Daytona leads · Novita is ~1.5× higher (lower is better)._
+_Daytona leads · Modal is ~2.5× higher (lower is better)._
 
 | Rank | Provider | Mastra: cold install (Seconds) | 95% bootstrap interval | n | Note |
 | ---: | --- | ---: | ---: | ---: | --- |
-| 1 | Daytona | 28.84 | 28.66 – 29.03 | 2 | — |
-| 2 | Novita | 42.48 | 42.08 – 42.88 | 2 | n too small |
-| 3 | Modal | 73.78 | 72.94 – 74.61 | 2 | n too small |
+| 1 | Daytona | 29.45 | 29.26 – 29.64 | 2 | — |
+| 2 | Modal | 73.47 | 73.17 – 73.77 | 2 | n too small |
 
 ### Better-Auth: build
 
 Seconds · lower is better
 
-_Blaxel leads · Daytona is ~1.2× higher (lower is better)._
+_Blaxel leads · Daytona is ~1.3× higher (lower is better)._
 
 | Rank | Provider | Better-Auth: build (Seconds) | 95% bootstrap interval | n | Note |
 | ---: | --- | ---: | ---: | ---: | --- |
-| 1 | Blaxel | 10.93 | 10.79 – 11.08 | 2 | — |
-| 2 | Daytona | 12.78 | 12.62 – 12.94 | 2 | n too small |
-| 3 | Novita | 14.52 | 14.52 – 14.53 | 2 | n too small |
-| 4 | E2B | 21.4 | 21.28 – 21.52 | 2 | n too small |
-| 5 | Modal | 40.92 | 39.94 – 41.9 | 2 | n too small |
+| 1 | Blaxel | 10.1 | 9.952 – 10.25 | 2 | — |
+| 2 | Daytona | 13.6 | 13.48 – 13.72 | 2 | n too small |
+| 3 | E2B | 21.87 | 21.69 – 22.04 | 2 | n too small |
+| 4 | Modal | 38.58 | 38.54 – 38.61 | 2 | n too small |
 
 ### Better-Auth: cold install
 
 Seconds · lower is better
 
-_Daytona leads · Novita is ~1.1× higher (lower is better)._
+_Daytona leads · Blaxel is ~1.4× higher (lower is better)._
 
 | Rank | Provider | Better-Auth: cold install (Seconds) | 95% bootstrap interval | n | Note |
 | ---: | --- | ---: | ---: | ---: | --- |
-| 1 | Daytona | 10.89 | 10.74 – 11.04 | 2 | — |
-| 2 | Novita | 11.86 | 11.77 – 11.95 | 2 | n too small |
-| 3 | Blaxel | 16.87 | 16.56 – 17.17 | 2 | n too small |
-| 4 | E2B | 19.64 | 19.3 – 19.98 | 2 | n too small |
-| 5 | Modal | 31.14 | 30.67 – 31.61 | 2 | n too small |
+| 1 | Daytona | 11.9 | 11.61 – 12.19 | 2 | — |
+| 2 | Blaxel | 16.97 | 16.4 – 17.54 | 2 | n too small |
+| 3 | E2B | 19.92 | 19.66 – 20.19 | 2 | n too small |
+| 4 | Modal | 30.31 | 30.22 – 30.41 | 2 | n too small |
 
 ### Better-Auth: git clone
 
@@ -565,53 +528,49 @@ _Blaxel leads · Daytona is ~1.1× higher (lower is better)._
 
 | Rank | Provider | Better-Auth: git clone (Seconds) | 95% bootstrap interval | n | Note |
 | ---: | --- | ---: | ---: | ---: | --- |
-| 1 | Blaxel | 1.571 | 1.555 – 1.586 | 2 | — |
-| 2 | Daytona | 1.669 | 1.57 – 1.768 | 2 | n too small |
-| 3 | E2B | 1.777 | 1.768 – 1.787 | 2 | n too small |
-| 4 | Novita | 1.956 | 1.726 – 2.187 | 2 | n too small |
-| 5 | Modal | 2.388 | 2.251 – 2.524 | 2 | n too small |
+| 1 | Blaxel | 1.567 | 1.556 – 1.579 | 2 | — |
+| 2 | Daytona | 1.688 | 1.687 – 1.688 | 2 | n too small |
+| 3 | E2B | 1.691 | 1.621 – 1.76 | 2 | n too small |
+| 4 | Modal | 3.407 | 2.7 – 4.114 | 2 | n too small |
 
 ### Better-Auth: lint (Biome)
 
 Seconds · lower is better
 
-_Blaxel leads · Daytona is ~1.2× higher (lower is better)._
+_Blaxel leads · Daytona is ~1.4× higher (lower is better)._
 
 | Rank | Provider | Better-Auth: lint (Biome) (Seconds) | 95% bootstrap interval | n | Note |
 | ---: | --- | ---: | ---: | ---: | --- |
-| 1 | Blaxel | 3.939 | 3.936 – 3.942 | 2 | — |
-| 2 | Daytona | 4.869 | 4.869 – 4.869 | 2 | n too small |
-| 3 | Novita | 5.394 | 5.378 – 5.411 | 2 | n too small |
-| 4 | E2B | 8.346 | 8.259 – 8.433 | 2 | n too small |
-| 5 | Modal | 17.18 | 17.13 – 17.23 | 2 | n too small |
+| 1 | Blaxel | 3.696 | 3.59 – 3.802 | 2 | — |
+| 2 | Daytona | 5.073 | 5.011 – 5.135 | 2 | n too small |
+| 3 | E2B | 8.113 | 8.014 – 8.212 | 2 | n too small |
+| 4 | Modal | 16.07 | 16 – 16.15 | 2 | n too small |
 
 ### Better-Auth: lint deps (Knip)
 
 Seconds · lower is better
 
-_Daytona leads · Novita is ~1.1× higher (lower is better)._
+_Daytona leads · Blaxel is ~1.4× higher (lower is better)._
 
 | Rank | Provider | Better-Auth: lint deps (Knip) (Seconds) | 95% bootstrap interval | n | Note |
 | ---: | --- | ---: | ---: | ---: | --- |
-| 1 | Daytona | 10.96 | 10.96 – 10.97 | 2 | — |
-| 2 | Novita | 11.67 | 11.64 – 11.7 | 2 | n too small |
-| 3 | Blaxel | 16.78 | 16.59 – 16.97 | 2 | n too small |
-| 4 | E2B | 18.75 | 18.72 – 18.78 | 2 | n too small |
-| 5 | Modal | 28.5 | 28.34 – 28.66 | 2 | n too small |
+| 1 | Daytona | 11.19 | 10.89 – 11.49 | 2 | — |
+| 2 | Blaxel | 15.66 | 15.62 – 15.7 | 2 | n too small |
+| 3 | E2B | 20.01 | 19.01 – 21.01 | 2 | n too small |
+| 4 | Modal | 28.22 | 27.8 – 28.64 | 2 | n too small |
 
 ### Better-Auth: lint format
 
 Seconds · lower is better
 
-_Daytona leads · Novita is ~1.1× higher (lower is better)._
+_Daytona leads · Blaxel is ~1.6× higher (lower is better)._
 
 | Rank | Provider | Better-Auth: lint format (Seconds) | 95% bootstrap interval | n | Note |
 | ---: | --- | ---: | ---: | ---: | --- |
-| 1 | Daytona | 2.681 | 2.679 – 2.683 | 2 | — |
-| 2 | Novita | 3.045 | 3.038 – 3.053 | 2 | n too small |
-| 3 | Blaxel | 4.946 | 4.946 – 4.946 | 2 | n too small |
-| 4 | E2B | 5.212 | 5.157 – 5.266 | 2 | n too small |
-| 5 | Modal | 6.581 | 6.494 – 6.668 | 2 | n too small |
+| 1 | Daytona | 2.898 | 2.885 – 2.912 | 2 | — |
+| 2 | Blaxel | 4.776 | 4.673 – 4.878 | 2 | n too small |
+| 3 | E2B | 5.412 | 5.258 – 5.567 | 2 | n too small |
+| 4 | Modal | 6.41 | 6.109 – 6.712 | 2 | n too small |
 
 ### Better-Auth: lint packages
 
@@ -621,89 +580,82 @@ _Blaxel leads · Daytona is ~1.3× higher (lower is better)._
 
 | Rank | Provider | Better-Auth: lint packages (Seconds) | 95% bootstrap interval | n | Note |
 | ---: | --- | ---: | ---: | ---: | --- |
-| 1 | Blaxel | 2.984 | 2.966 – 3.001 | 2 | — |
-| 2 | Daytona | 4.015 | 4.01 – 4.02 | 2 | n too small |
-| 3 | Novita | 4.635 | 4.632 – 4.638 | 2 | n too small |
-| 4 | E2B | 7.606 | 7.593 – 7.619 | 2 | n too small |
-| 5 | Modal | 15.76 | 15.56 – 15.97 | 2 | n too small |
+| 1 | Blaxel | 2.987 | 2.946 – 3.028 | 2 | — |
+| 2 | Daytona | 4.014 | 4.013 – 4.014 | 2 | n too small |
+| 3 | E2B | 7.51 | 7.33 – 7.689 | 2 | n too small |
+| 4 | Modal | 14.85 | 14.67 – 15.02 | 2 | n too small |
 
 ### Better-Auth: lint spell
 
 Seconds · lower is better
 
-_Daytona leads · Novita is ~1.1× higher (lower is better)._
+_Daytona leads · Blaxel is ~1.7× higher (lower is better)._
 
 | Rank | Provider | Better-Auth: lint spell (Seconds) | 95% bootstrap interval | n | Note |
 | ---: | --- | ---: | ---: | ---: | --- |
-| 1 | Daytona | 6.838 | 6.769 – 6.908 | 2 | — |
-| 2 | Novita | 7.691 | 7.457 – 7.925 | 2 | n too small |
-| 3 | Blaxel | 12.2 | 12.19 – 12.21 | 2 | n too small |
-| 4 | E2B | 12.43 | 12.29 – 12.57 | 2 | n too small |
-| 5 | Modal | 15.18 | 14.7 – 15.65 | 2 | n too small |
+| 1 | Daytona | 6.873 | 6.801 – 6.944 | 2 | — |
+| 2 | Blaxel | 11.85 | 11.7 – 12 | 2 | n too small |
+| 3 | E2B | 13.27 | 13.06 – 13.48 | 2 | n too small |
+| 4 | Modal | 14.87 | 14.71 – 15.03 | 2 | n too small |
 
 ### Better-Auth: lint types
 
 Seconds · lower is better
 
-_Blaxel leads · Daytona is ~1.5× higher (lower is better)._
+_Blaxel leads · Daytona is ~1.7× higher (lower is better)._
 
 | Rank | Provider | Better-Auth: lint types (Seconds) | 95% bootstrap interval | n | Note |
 | ---: | --- | ---: | ---: | ---: | --- |
-| 1 | Blaxel | 33.64 | 33.48 – 33.8 | 2 | — |
-| 2 | Daytona | 51.07 | 50.95 – 51.19 | 2 | n too small |
-| 3 | Novita | 60.08 | 59.63 – 60.53 | 2 | n too small |
-| 4 | E2B | 98.64 | 97.8 – 99.48 | 2 | n too small |
-| 5 | Modal | 183.3 | 178.9 – 187.7 | 2 | n too small |
+| 1 | Blaxel | 30.94 | 30.56 – 31.32 | 2 | — |
+| 2 | Daytona | 53.2 | 51.83 – 54.57 | 2 | n too small |
+| 3 | E2B | 100.7 | 98.25 – 103.2 | 2 | n too small |
+| 4 | Modal | 175 | 170.4 – 179.5 | 2 | n too small |
 
 ### Better-Auth: typecheck
 
 Seconds · lower is better
 
-_Daytona leads · Novita is ~1.1× higher (lower is better)._
+_Daytona leads · Blaxel is ~1.5× higher (lower is better)._
 
 | Rank | Provider | Better-Auth: typecheck (Seconds) | 95% bootstrap interval | n | Note |
 | ---: | --- | ---: | ---: | ---: | --- |
-| 1 | Daytona | 1.388 | 1.378 – 1.398 | 2 | — |
-| 2 | Novita | 1.474 | 1.465 – 1.483 | 2 | n too small |
-| 3 | Blaxel | 2.037 | 2.037 – 2.038 | 2 | n too small |
-| 4 | E2B | 2.613 | 2.436 – 2.79 | 2 | n too small |
-| 5 | Modal | 3.308 | 3.29 – 3.326 | 2 | n too small |
+| 1 | Daytona | 1.421 | 1.407 – 1.436 | 2 | — |
+| 2 | Blaxel | 2.103 | 2.101 – 2.104 | 2 | n too small |
+| 3 | E2B | 2.423 | 2.371 – 2.474 | 2 | n too small |
+| 4 | Modal | 3.358 | 3.255 – 3.461 | 2 | n too small |
 
 ### Mastra: build:core
 
 Seconds · lower is better
 
-_Daytona leads · Novita is ~1.5× higher (lower is better)._
+_Daytona leads · Modal is ~2.4× higher (lower is better)._
 
 | Rank | Provider | Mastra: build:core (Seconds) | 95% bootstrap interval | n | Note |
 | ---: | --- | ---: | ---: | ---: | --- |
-| 1 | Daytona | 83 | 82.98 – 83.02 | 2 | — |
-| 2 | Novita | 125.6 | 125.2 – 126 | 2 | n too small |
-| 3 | Modal | 203 | 201.1 – 205 | 2 | n too small |
+| 1 | Daytona | 84.87 | 83.83 – 85.91 | 2 | — |
+| 2 | Modal | 201.4 | 197.2 – 205.5 | 2 | n too small |
 
 ### Mastra: git clone
 
 Seconds · lower is better
 
-_Daytona leads · Novita is ~1.1× higher (lower is better)._
+_Daytona leads · Modal is ~1.5× higher (lower is better)._
 
 | Rank | Provider | Mastra: git clone (Seconds) | 95% bootstrap interval | n | Note |
 | ---: | --- | ---: | ---: | ---: | --- |
-| 1 | Daytona | 6.626 | 6.425 – 6.827 | 2 | — |
-| 2 | Novita | 7.014 | 6.931 – 7.096 | 2 | n too small |
-| 3 | Modal | 9.957 | 9.35 – 10.56 | 2 | n too small |
+| 1 | Daytona | 6.64 | 6.59 – 6.69 | 2 | — |
+| 2 | Modal | 10.05 | 9.667 – 10.43 | 2 | n too small |
 
 ### Mastra: lint:format
 
 Seconds · lower is better
 
-_Daytona leads · Novita is ~1.4× higher (lower is better)._
+_Daytona leads · Modal is ~2.2× higher (lower is better)._
 
 | Rank | Provider | Mastra: lint:format (Seconds) | 95% bootstrap interval | n | Note |
 | ---: | --- | ---: | ---: | ---: | --- |
-| 1 | Daytona | 90.71 | 90.34 – 91.08 | 2 | — |
-| 2 | Novita | 128.7 | 128.5 – 128.8 | 2 | n too small |
-| 3 | Modal | 199.7 | 198.2 – 201.1 | 2 | n too small |
+| 1 | Daytona | 89.87 | 89.42 – 90.32 | 2 | — |
+| 2 | Modal | 194.8 | 193.6 – 196 | 2 | n too small |
 
 ## economics
 
@@ -711,18 +663,17 @@ _Daytona leads · Novita is ~1.4× higher (lower is better)._
 
 USD/hr · lower is better
 
-_Daytona is cheapest · Novita is ~1.1× higher (lower is better)._
+_Daytona is cheapest · E2B is ~1.5× higher (lower is better)._
 
 | Rank | Provider | Hourly cost (USD/hr) | 95% bootstrap interval | n |
 | ---: | --- | ---: | ---: | ---: |
 | 1 | Daytona | 0.1494 | — | 1 |
-| 2 | Novita | 0.1627 | — | 1 |
-| 3 | E2B | 0.2304 | — | 1 |
-| 4 | Modal | 0.4774 | — | 1 |
+| 2 | E2B | 0.2304 | — | 1 |
+| 3 | Modal | 0.4774 | — | 1 |
 
 ## Coverage gaps
 
-13 uncovered results across 5 providers (Blaxel 3, Daytona 2, E2B 3, Modal 3, Novita 2). A gap is a missing result — the provider **failing to cover** that workload — never a tie or a zero.
+20 uncovered results across 5 providers (Blaxel 3, Daytona 2, E2B 3, Modal 3, Novita 9). A gap is a missing result — the provider **failing to cover** that workload — never a tie or a zero.
 
 <details>
 <summary>Full coverage table</summary>
@@ -735,13 +686,20 @@ _Daytona is cheapest · Novita is ~1.1× higher (lower is better)._
 | E2B | realworld-openclaw | ❌ **disk** (skipped) | Insufficient disk: 20.0 GiB free, suite needs 25 GiB |
 | Blaxel | network | **failed** | Step "mise run benchmark:network:all" failed with exit code 1 |
 | Daytona | network | **failed** | Step "mise run benchmark:network:all" timed out after 2700s |
-| Daytona | realworld-openclaw | **failed** | Step "mise run benchmark:realworld:pts:openclaw" timed out after 8400s |
+| Daytona | realworld-openclaw | **failed** | Step "mise run benchmark:realworld:pts:openclaw" lost its sandbox: 12 consecutive detached polls failed (last: done-file fs exists) — the sandbox stopped responding, not a quiet long step |
 | E2B | cpu-generic | **failed** | Step "mise run benchmark:cpu:generic" timed out after 7800s |
 | Modal | cpu-generic | **failed** | Step "mise run benchmark:cpu:generic" timed out after 7800s |
 | Modal | network | **failed** | Step "mise run benchmark:network:all" failed with exit code 1 |
 | Modal | realworld-openclaw | **failed** | Step "mise run benchmark:realworld:pts:openclaw" timed out after 8400s |
-| Novita | network | **failed** | Step "mise run benchmark:network:all" failed with exit code 1 |
-| Novita | realworld-openclaw | **failed** | Step "mise run benchmark:realworld:pts:openclaw" lost its sandbox: 12 consecutive detached polls failed (last: done-file fs exists) — the sandbox stopped responding, not a quiet long step |
+| Novita | cpu-generic | **missing** | No result and no marker — the suite never reported for this provider. |
+| Novita | cpu-node | **missing** | No result and no marker — the suite never reported for this provider. |
+| Novita | disk | **missing** | No result and no marker — the suite never reported for this provider. |
+| Novita | memory | **missing** | No result and no marker — the suite never reported for this provider. |
+| Novita | network | **missing** | No result and no marker — the suite never reported for this provider. |
+| Novita | realworld-better-auth | **missing** | No result and no marker — the suite never reported for this provider. |
+| Novita | realworld-mastra | **missing** | No result and no marker — the suite never reported for this provider. |
+| Novita | realworld-openclaw | **missing** | No result and no marker — the suite never reported for this provider. |
+| Novita | system | **missing** | No result and no marker — the suite never reported for this provider. |
 
 **skipped** — a precondition said no before the benchmark was attempted. A ❌ **disk** skip is the
 loud one: the provider could not supply the disk the suite needs, so the workload does not run on
@@ -749,6 +707,11 @@ its current allocation at all. That is a structural absence, not a slow result.
 
 **failed** — the benchmark was attempted and broke: it threw, timed out, or died with the sandbox.
 Unlike a skip, this is a reliability fact about the provider, not a decision made on its behalf.
+
+**missing** — nothing was reported at all: no result, and no marker explaining why. The suite ran
+elsewhere in this run, so it was part of the comparison, and this provider is simply absent from
+it — a dropped job, a lost artifact, or a sandbox that died before it could say anything. Treat it
+as unmeasured, never as a pass: the provider has not been shown to run this workload.
 
 </details>
 
@@ -793,126 +756,94 @@ correction is applied across providers or metrics.
 | Dimension | Metric | Provider | p vs. above | p (KS) |
 | --- | --- | --- | ---: | ---: |
 | cpu | Node.js web tooling | Daytona | — | — |
-| cpu | Node.js web tooling | Novita | 0.33 (n too small) | 0.097 |
 | cpu | Node.js web tooling | Blaxel | 0.33 (n too small) | 0.097 |
 | cpu | Node.js web tooling | E2B | 0.33 (n too small) | 0.097 |
 | cpu | Node.js web tooling | Modal | 0.33 (n too small) | 0.097 |
 | cpu | C-Ray (1080p, 16 RPP) | Blaxel | — | — |
 | cpu | C-Ray (1080p, 16 RPP) | Daytona | 0.33 (n too small) | 0.097 |
-| cpu | C-Ray (1080p, 16 RPP) | Novita | 0.33 (n too small) | 0.097 |
 | cpu | C-Ray (4K, 16 RPP) | Blaxel | — | — |
 | cpu | C-Ray (4K, 16 RPP) | Daytona | 0.33 (n too small) | 0.097 |
-| cpu | C-Ray (4K, 16 RPP) | Novita | 0.33 (n too small) | 0.097 |
 | cpu | C-Ray (5K, 16 RPP) | Blaxel | — | — |
 | cpu | C-Ray (5K, 16 RPP) | Daytona | 0.33 (n too small) | 0.097 |
-| cpu | C-Ray (5K, 16 RPP) | Novita | 0.33 (n too small) | 0.097 |
 | cpu | Zstd 12 compress | Blaxel | — | — |
 | cpu | Zstd 12 compress | Daytona | 0.33 (n too small) | 0.097 |
-| cpu | Zstd 12 compress | Novita | 0.33 (n too small) | 0.097 |
 | cpu | Zstd 12 decompress | Daytona | — | — |
-| cpu | Zstd 12 decompress | Novita | 0.33 (n too small) | 0.097 |
 | cpu | Zstd 12 decompress | Blaxel | 0.33 (n too small) | 0.097 |
 | cpu | Zstd 19 compress | Blaxel | — | — |
 | cpu | Zstd 19 compress | Daytona | 0.33 (n too small) | 0.097 |
-| cpu | Zstd 19 compress | Novita | 0.33 (n too small) | 0.097 |
 | cpu | Zstd 19 decompress | Daytona | — | — |
-| cpu | Zstd 19 decompress | Novita | 0.33 (n too small) | 0.097 |
 | cpu | Zstd 19 decompress | Blaxel | 0.33 (n too small) | 0.097 |
 | cpu | Zstd 19 (long) compress | Daytona | — | — |
 | cpu | Zstd 19 (long) compress | Blaxel | 0.33 (n too small) | 0.097 |
-| cpu | Zstd 19 (long) compress | Novita | 0.33 (n too small) | 0.097 |
 | cpu | Zstd 19 (long) decompress | Daytona | — | — |
-| cpu | Zstd 19 (long) decompress | Novita | 0.33 (n too small) | 0.097 |
 | cpu | Zstd 19 (long) decompress | Blaxel | 0.33 (n too small) | 0.097 |
 | cpu | Zstd 3 compress | Blaxel | — | — |
 | cpu | Zstd 3 compress | Daytona | 0.33 (n too small) | 0.097 |
-| cpu | Zstd 3 compress | Novita | 0.33 (n too small) | 0.097 |
 | cpu | Zstd 3 decompress | Daytona | — | — |
-| cpu | Zstd 3 decompress | Novita | 0.33 (n too small) | 0.097 |
-| cpu | Zstd 3 decompress | Blaxel | — | — |
 | cpu | Zstd 3 (long) compress | Blaxel | — | — |
 | cpu | Zstd 3 (long) compress | Daytona | 0.33 (n too small) | 0.097 |
-| cpu | Zstd 3 (long) compress | Novita | 0.33 (n too small) | 0.097 |
 | cpu | Zstd 3 (long) decompress | Daytona | — | — |
-| cpu | Zstd 3 (long) decompress | Novita | 0.33 (n too small) | 0.097 |
+| cpu | Zstd 3 (long) decompress | Blaxel | 0.33 (n too small) | 0.097 |
 | cpu | Zstd 8 compress | Blaxel | — | — |
 | cpu | Zstd 8 compress | Daytona | 0.33 (n too small) | 0.097 |
-| cpu | Zstd 8 compress | Novita | 0.33 (n too small) | 0.097 |
-| cpu | Zstd 8 decompress | Daytona | — | — |
-| cpu | Zstd 8 decompress | Novita | 0.33 (n too small) | 0.097 |
-| cpu | Zstd 8 decompress | Blaxel | 0.33 (n too small) | 0.097 |
+| cpu | Zstd 8 decompress | Blaxel | — | — |
 | cpu | Zstd 8 (long) compress | Blaxel | — | — |
 | cpu | Zstd 8 (long) compress | Daytona | 0.33 (n too small) | 0.097 |
-| cpu | Zstd 8 (long) compress | Novita | 0.33 (n too small) | 0.097 |
 | cpu | Zstd 8 (long) decompress | Daytona | — | — |
-| cpu | Zstd 8 (long) decompress | Novita | 0.33 (n too small) | 0.097 |
 | cpu | Zstd 8 (long) decompress | Blaxel | 0.33 (n too small) | 0.097 |
 | disk | fio rand read 4KB, O_DIRECT (IOPS) | Blaxel | — | — |
 | disk | fio rand read 4KB, O_DIRECT (IOPS) | Daytona | 0.33 (n too small) | 0.097 |
-| disk | fio rand read 4KB, O_DIRECT (IOPS) | Novita | 0.33 (n too small) | 0.097 |
 | disk | fio rand read 4KB, O_DIRECT (IOPS) | E2B | 0.33 (n too small) | 0.097 |
 | disk | fio rand read 4KB, O_DIRECT (IOPS) | Modal | 0.33 (n too small) | 0.097 |
 | disk | fio rand read 4KB, O_DIRECT (MB/s) | Blaxel | — | — |
 | disk | fio rand read 4KB, O_DIRECT (MB/s) | Daytona | 0.33 (n too small) | 0.097 |
-| disk | fio rand read 4KB, O_DIRECT (MB/s) | Novita | 0.33 (n too small) | 0.097 |
 | disk | fio rand read 4KB, O_DIRECT (MB/s) | E2B | 0.33 (n too small) | 0.097 |
 | disk | fio rand read 4KB, O_DIRECT (MB/s) | Modal | 0.33 (n too small) | 0.097 |
 | disk | fio rand write 4KB, O_DIRECT (IOPS) | Blaxel | — | — |
 | disk | fio rand write 4KB, O_DIRECT (IOPS) | Daytona | 0.33 (n too small) | 0.097 |
-| disk | fio rand write 4KB, O_DIRECT (IOPS) | Novita | 0.33 (n too small) | 0.097 |
 | disk | fio rand write 4KB, O_DIRECT (IOPS) | E2B | 0.33 (n too small) | 0.097 |
 | disk | fio rand write 4KB, O_DIRECT (IOPS) | Modal | 0.33 (n too small) | 0.097 |
 | disk | fio rand write 4KB, O_DIRECT (MB/s) | Blaxel | — | — |
 | disk | fio rand write 4KB, O_DIRECT (MB/s) | Daytona | 0.33 (n too small) | 0.097 |
-| disk | fio rand write 4KB, O_DIRECT (MB/s) | Novita | 0.33 (n too small) | 0.097 |
 | disk | fio rand write 4KB, O_DIRECT (MB/s) | E2B | 0.33 (n too small) | 0.097 |
 | disk | fio rand write 4KB, O_DIRECT (MB/s) | Modal | 0.33 (n too small) | 0.097 |
 | disk | fio seq read 1MB, O_DIRECT (IOPS) | Modal | — | — |
-| disk | fio seq read 1MB, O_DIRECT (IOPS) | Novita | 0.33 (n too small) | 0.097 |
-| disk | fio seq read 1MB, O_DIRECT (IOPS) | Daytona | 1.0 (n too small) | 0.84 |
+| disk | fio seq read 1MB, O_DIRECT (IOPS) | Daytona | 0.33 (n too small) | 0.097 |
 | disk | fio seq read 1MB, O_DIRECT (IOPS) | Blaxel | 0.33 (n too small) | 0.097 |
 | disk | fio seq read 1MB, O_DIRECT (IOPS) | E2B | 0.33 (n too small) | 0.097 |
 | disk | fio seq read 1MB, O_DIRECT (MB/s) | Daytona | — | — |
-| disk | fio seq read 1MB, O_DIRECT (MB/s) | Blaxel | — | — |
+| disk | fio seq read 1MB, O_DIRECT (MB/s) | Blaxel | 0.33 (n too small) | 0.097 |
 | disk | fio seq read 1MB, O_DIRECT (MB/s) | E2B | 0.33 (n too small) | 0.097 |
 | disk | fio seq write 1MB, O_DIRECT (IOPS) | Daytona | — | — |
-| disk | fio seq write 1MB, O_DIRECT (IOPS) | Novita | 0.33 (n too small) | 0.097 |
 | disk | fio seq write 1MB, O_DIRECT (IOPS) | Blaxel | 0.33 (n too small) | 0.097 |
 | disk | fio seq write 1MB, O_DIRECT (IOPS) | Modal | 0.33 (n too small) | 0.097 |
 | disk | fio seq write 1MB, O_DIRECT (IOPS) | E2B | 0.33 (n too small) | 0.097 |
 | disk | fio seq write 1MB, O_DIRECT (MB/s) | Daytona | — | — |
-| disk | fio seq write 1MB, O_DIRECT (MB/s) | Novita | 0.33 (n too small) | 0.097 |
 | disk | fio seq write 1MB, O_DIRECT (MB/s) | Blaxel | 0.33 (n too small) | 0.097 |
 | disk | fio seq write 1MB, O_DIRECT (MB/s) | Modal | 0.33 (n too small) | 0.097 |
 | disk | fio seq write 1MB, O_DIRECT (MB/s) | E2B | 0.33 (n too small) | 0.097 |
 | disk | Hardlink throughput | Daytona | — | — |
-| disk | Hardlink throughput | Novita | 0.33 (n too small) | 0.097 |
 | disk | Hardlink throughput | Blaxel | 0.33 (n too small) | 0.097 |
 | disk | Hardlink throughput | Modal | 0.33 (n too small) | 0.097 |
 | disk | Hardlink throughput | E2B | 0.33 (n too small) | 0.097 |
 | memory | STREAM Triad | Blaxel | — | — |
 | memory | STREAM Triad | Daytona | 0.33 (n too small) | 0.097 |
-| memory | STREAM Triad | Novita | 0.33 (n too small) | 0.097 |
-| memory | STREAM Triad | Modal | 1.0 (n too small) | 0.84 |
+| memory | STREAM Triad | Modal | 0.33 (n too small) | 0.097 |
 | memory | STREAM Triad | E2B | 0.33 (n too small) | 0.097 |
 | memory | STREAM Add | Blaxel | — | — |
 | memory | STREAM Add | Daytona | 0.33 (n too small) | 0.097 |
 | memory | STREAM Add | Modal | 0.33 (n too small) | 0.097 |
-| memory | STREAM Add | Novita | 1.0 (n too small) | 0.84 |
 | memory | STREAM Add | E2B | 0.33 (n too small) | 0.097 |
 | memory | STREAM Copy | Blaxel | — | — |
 | memory | STREAM Copy | Daytona | 0.33 (n too small) | 0.097 |
-| memory | STREAM Copy | Modal | 1.0 (n too small) | 0.84 |
-| memory | STREAM Copy | Novita | 0.33 (n too small) | 0.097 |
+| memory | STREAM Copy | Modal | 0.33 (n too small) | 0.097 |
 | memory | STREAM Copy | E2B | 0.33 (n too small) | 0.097 |
 | memory | STREAM Scale | Blaxel | — | — |
 | memory | STREAM Scale | Daytona | 0.33 (n too small) | 0.097 |
-| memory | STREAM Scale | Novita | 0.33 (n too small) | 0.097 |
 | memory | STREAM Scale | Modal | 0.33 (n too small) | 0.097 |
 | memory | STREAM Scale | E2B | 0.33 (n too small) | 0.097 |
 | network | Loopback TCP (10GB) | Daytona | — | — |
 | network | Loopback TCP (10GB) | Blaxel | 0.33 (n too small) | 0.097 |
-| network | Loopback TCP (10GB) | Novita | 0.33 (n too small) | 0.097 |
 | network | Loopback TCP (10GB) | E2B | 0.33 (n too small) | 0.097 |
 | network | Loopback TCP (10GB) | Modal | 0.33 (n too small) | 0.097 |
 | network | fast.com download | E2B | — | — |
@@ -921,79 +852,62 @@ correction is applied across providers or metrics.
 | network | fast.com upload | E2B | — | — |
 | system | PyBench | Blaxel | — | — |
 | system | Git common operations | Daytona | — | — |
-| system | Git common operations | Novita | 0.33 (n too small) | 0.097 |
 | system | Git common operations | Blaxel | 0.33 (n too small) | 0.097 |
 | system | Git common operations | E2B | 0.33 (n too small) | 0.097 |
 | system | Git common operations | Modal | 0.33 (n too small) | 0.097 |
 | system | SQLite Speedtest | Daytona | — | — |
-| system | SQLite Speedtest | Novita | 0.33 (n too small) | 0.097 |
 | system | SQLite Speedtest | Blaxel | 0.33 (n too small) | 0.097 |
 | system | SQLite Speedtest | E2B | 0.33 (n too small) | 0.097 |
 | system | SQLite Speedtest | Modal | 0.33 (n too small) | 0.097 |
 | realworld | Mastra: cold install | Daytona | — | — |
-| realworld | Mastra: cold install | Novita | 0.33 (n too small) | 0.097 |
 | realworld | Mastra: cold install | Modal | 0.33 (n too small) | 0.097 |
 | realworld | Better-Auth: build | Blaxel | — | — |
 | realworld | Better-Auth: build | Daytona | 0.33 (n too small) | 0.097 |
-| realworld | Better-Auth: build | Novita | 0.33 (n too small) | 0.097 |
 | realworld | Better-Auth: build | E2B | 0.33 (n too small) | 0.097 |
 | realworld | Better-Auth: build | Modal | 0.33 (n too small) | 0.097 |
 | realworld | Better-Auth: cold install | Daytona | — | — |
-| realworld | Better-Auth: cold install | Novita | 0.33 (n too small) | 0.097 |
 | realworld | Better-Auth: cold install | Blaxel | 0.33 (n too small) | 0.097 |
 | realworld | Better-Auth: cold install | E2B | 0.33 (n too small) | 0.097 |
 | realworld | Better-Auth: cold install | Modal | 0.33 (n too small) | 0.097 |
 | realworld | Better-Auth: git clone | Blaxel | — | — |
-| realworld | Better-Auth: git clone | Daytona | 0.67 (n too small) | 0.84 |
-| realworld | Better-Auth: git clone | E2B | 0.67 (n too small) | 0.84 |
-| realworld | Better-Auth: git clone | Novita | 1.0 (n too small) | 0.84 |
+| realworld | Better-Auth: git clone | Daytona | 0.33 (n too small) | 0.097 |
+| realworld | Better-Auth: git clone | E2B | 1.0 (n too small) | 0.84 |
 | realworld | Better-Auth: git clone | Modal | 0.33 (n too small) | 0.097 |
 | realworld | Better-Auth: lint (Biome) | Blaxel | — | — |
 | realworld | Better-Auth: lint (Biome) | Daytona | 0.33 (n too small) | 0.097 |
-| realworld | Better-Auth: lint (Biome) | Novita | 0.33 (n too small) | 0.097 |
 | realworld | Better-Auth: lint (Biome) | E2B | 0.33 (n too small) | 0.097 |
 | realworld | Better-Auth: lint (Biome) | Modal | 0.33 (n too small) | 0.097 |
 | realworld | Better-Auth: lint deps (Knip) | Daytona | — | — |
-| realworld | Better-Auth: lint deps (Knip) | Novita | 0.33 (n too small) | 0.097 |
 | realworld | Better-Auth: lint deps (Knip) | Blaxel | 0.33 (n too small) | 0.097 |
 | realworld | Better-Auth: lint deps (Knip) | E2B | 0.33 (n too small) | 0.097 |
 | realworld | Better-Auth: lint deps (Knip) | Modal | 0.33 (n too small) | 0.097 |
 | realworld | Better-Auth: lint format | Daytona | — | — |
-| realworld | Better-Auth: lint format | Novita | 0.33 (n too small) | 0.097 |
 | realworld | Better-Auth: lint format | Blaxel | 0.33 (n too small) | 0.097 |
 | realworld | Better-Auth: lint format | E2B | 0.33 (n too small) | 0.097 |
 | realworld | Better-Auth: lint format | Modal | 0.33 (n too small) | 0.097 |
 | realworld | Better-Auth: lint packages | Blaxel | — | — |
 | realworld | Better-Auth: lint packages | Daytona | 0.33 (n too small) | 0.097 |
-| realworld | Better-Auth: lint packages | Novita | 0.33 (n too small) | 0.097 |
 | realworld | Better-Auth: lint packages | E2B | 0.33 (n too small) | 0.097 |
 | realworld | Better-Auth: lint packages | Modal | 0.33 (n too small) | 0.097 |
 | realworld | Better-Auth: lint spell | Daytona | — | — |
-| realworld | Better-Auth: lint spell | Novita | 0.33 (n too small) | 0.097 |
 | realworld | Better-Auth: lint spell | Blaxel | 0.33 (n too small) | 0.097 |
 | realworld | Better-Auth: lint spell | E2B | 0.33 (n too small) | 0.097 |
 | realworld | Better-Auth: lint spell | Modal | 0.33 (n too small) | 0.097 |
 | realworld | Better-Auth: lint types | Blaxel | — | — |
 | realworld | Better-Auth: lint types | Daytona | 0.33 (n too small) | 0.097 |
-| realworld | Better-Auth: lint types | Novita | 0.33 (n too small) | 0.097 |
 | realworld | Better-Auth: lint types | E2B | 0.33 (n too small) | 0.097 |
 | realworld | Better-Auth: lint types | Modal | 0.33 (n too small) | 0.097 |
 | realworld | Better-Auth: typecheck | Daytona | — | — |
-| realworld | Better-Auth: typecheck | Novita | 0.33 (n too small) | 0.097 |
 | realworld | Better-Auth: typecheck | Blaxel | 0.33 (n too small) | 0.097 |
 | realworld | Better-Auth: typecheck | E2B | 0.33 (n too small) | 0.097 |
 | realworld | Better-Auth: typecheck | Modal | 0.33 (n too small) | 0.097 |
 | realworld | Mastra: build:core | Daytona | — | — |
-| realworld | Mastra: build:core | Novita | 0.33 (n too small) | 0.097 |
 | realworld | Mastra: build:core | Modal | 0.33 (n too small) | 0.097 |
 | realworld | Mastra: git clone | Daytona | — | — |
-| realworld | Mastra: git clone | Novita | 0.33 (n too small) | 0.097 |
 | realworld | Mastra: git clone | Modal | 0.33 (n too small) | 0.097 |
 | realworld | Mastra: lint:format | Daytona | — | — |
-| realworld | Mastra: lint:format | Novita | 0.33 (n too small) | 0.097 |
 | realworld | Mastra: lint:format | Modal | 0.33 (n too small) | 0.097 |
 | economics | Hourly cost | Daytona | — | — |
-| economics | Hourly cost | Novita | — | — |
 | economics | Hourly cost | E2B | — | — |
 | economics | Hourly cost | Modal | — | — |
 

--- a/data/dataset/index.json
+++ b/data/dataset/index.json
@@ -2,6 +2,11 @@
   "schemaVersion": "1",
   "runs": [
     {
+      "runId": "29562866807",
+      "generatedAt": "2026-07-17T09:52:57.028Z",
+      "path": "runs/29562866807.json"
+    },
+    {
       "runId": "29546060837",
       "generatedAt": "2026-07-17T03:31:38.992Z",
       "path": "runs/29546060837.json"

--- a/data/dataset/runs/29562866807.json
+++ b/data/dataset/runs/29562866807.json
@@ -1,0 +1,7429 @@
+{
+  "schemaVersion": "2",
+  "runId": "29562866807",
+  "sha": "74ccfe2aeba48cf36b287b15fbc765960c6395e9",
+  "generatedAt": "2026-07-17T09:52:57.028Z",
+  "targetSpec": {
+    "vcpus": 2,
+    "memoryGb": 8,
+    "diskGb": 40
+  },
+  "providers": [
+    {
+      "providerId": "blaxel",
+      "validationStatus": "validated",
+      "specMatched": false,
+      "observedSpecs": {
+        "cpuModel": "Intel(R) Xeon(R) Processor @ 2.90GHz",
+        "hostVcpus": 6,
+        "hostMemoryGb": 16,
+        "os": "Debian GNU/Linux 12 (bookworm)",
+        "kernel": "6.12.75+",
+        "user": "root",
+        "vcpus": 6,
+        "virtualization": "unknown",
+        "memoryGb": 15.63,
+        "diskGb": 12.5,
+        "publicIp": "34.214.71.218",
+        "egressOrg": "AS16509 Amazon.com, Inc.",
+        "egressAsn": "AS16509",
+        "egressOrgName": "Amazon.com, Inc.",
+        "reverseDns": "ec2-34-214-71-218.us-west-2.compute.amazonaws.com",
+        "city": "Boardman",
+        "region": "Oregon",
+        "country": "US",
+        "location": "45.8399,-119.7006",
+        "timezone": "America/Los_Angeles",
+        "networkPrefix": "34.192.0.0/10",
+        "asnSource": "cymru",
+        "geoSource": "ipinfo"
+      },
+      "hostMetadata": [
+        {
+          "source": "phoronix/result-file-to-json",
+          "sourceFile": "cpu-generic/pts_c-ray--metadata.json",
+          "fields": [
+            {
+              "path": "ci.client_version",
+              "value": "10.8.4"
+            },
+            {
+              "path": "ci.data.compiler-configuration",
+              "value": "--build=x86_64-linux-gnu --disable-vtable-verify --disable-werror --enable-cet --enable-checking=release --enable-clocale=gnu --enable-default-pie --enable-gnu-unique-object --enable-languages=c,ada,c++,go,d,fortran,objc,obj-c++,m2 --enable-libphobos-checking=release --enable-libstdcxx-debug --enable-libstdcxx-time=yes --enable-multiarch --enable-multilib --enable-nls --enable-objc-gc=auto --enable-offload-defaulted --enable-offload-targets=nvptx-none=/build/reproducible-path/gcc-12-12.2.0/debian/tmp-nvptx/usr,amdgcn-amdhsa=/build/reproducible-path/gcc-12-12.2.0/debian/tmp-gcn/usr --enable-plugin --enable-shared --enable-threads=posix --host=x86_64-linux-gnu --program-prefix=x86_64-linux-gnu- --target=x86_64-linux-gnu --with-abi=m64 --with-arch-32=i686 --with-default-libstdcxx-abi=new --with-gcc-major-version-only --with-multilib-list=m32,m64,mx32 --with-target-system-zlib=auto --with-tune=generic --without-cuda-driver -v"
+            },
+            {
+              "path": "ci.data.cpu-microcode",
+              "value": "0x1"
+            },
+            {
+              "path": "ci.data.environment-variables",
+              "value": "BL_DEBUG_TELEMETRY=false"
+            },
+            {
+              "path": "ci.data.kernel-extra-details",
+              "value": "Transparent Huge Pages: madvise"
+            },
+            {
+              "path": "ci.data.security",
+              "value": "gather_data_sampling: Not affected + indirect_target_selection: Mitigation of Aligned branch/return thunks + itlb_multihit: Not affected + l1tf: Not affected + mds: Not affected + meltdown: Not affected + mmio_stale_data: Mitigation of Clear buffers; SMT Host state unknown + reg_file_data_sampling: Not affected + retbleed: Not affected + spec_rstack_overflow: Not affected + spec_store_bypass: Mitigation of SSB disabled via prctl + spectre_v1: Mitigation of usercopy/swapgs barriers and __user pointer sanitization + spectre_v2: Mitigation of Enhanced / Automatic IBRS; IBPB: conditional; PBRSB-eIBRS: SW sequence; BHI: SW loop KVM: SW loop + srbds: Not affected + tsa: Not affected + tsx_async_abort: Mitigation of TSX disabled + vmscape: Not affected"
+            },
+            {
+              "path": "ci.hardware.Disk",
+              "value": "13GB"
+            },
+            {
+              "path": "ci.hardware.Memory",
+              "value": "16GB"
+            },
+            {
+              "path": "ci.hardware.Processor",
+              "value": "Intel Xeon (6 Cores)"
+            },
+            {
+              "path": "ci.identifier",
+              "value": "ci"
+            },
+            {
+              "path": "ci.software.Compiler",
+              "value": "GCC 12.2.0"
+            },
+            {
+              "path": "ci.software.File-System",
+              "value": "overlayfs"
+            },
+            {
+              "path": "ci.software.Kernel",
+              "value": "6.12.75+ (x86_64)"
+            },
+            {
+              "path": "ci.software.OS",
+              "value": "Debian GNU/Linux 12"
+            },
+            {
+              "path": "ci.timestamp",
+              "value": "2026-07-17 07:23:51"
+            },
+            {
+              "path": "ci.user",
+              "value": "root"
+            }
+          ]
+        },
+        {
+          "source": "phoronix/result-file-to-json",
+          "sourceFile": "cpu-generic/pts_compress-zstd--metadata.json",
+          "fields": [
+            {
+              "path": "ci.client_version",
+              "value": "10.8.4"
+            },
+            {
+              "path": "ci.data.compiler-configuration",
+              "value": "--build=x86_64-linux-gnu --disable-vtable-verify --disable-werror --enable-cet --enable-checking=release --enable-clocale=gnu --enable-default-pie --enable-gnu-unique-object --enable-languages=c,ada,c++,go,d,fortran,objc,obj-c++,m2 --enable-libphobos-checking=release --enable-libstdcxx-debug --enable-libstdcxx-time=yes --enable-multiarch --enable-multilib --enable-nls --enable-objc-gc=auto --enable-offload-defaulted --enable-offload-targets=nvptx-none=/build/reproducible-path/gcc-12-12.2.0/debian/tmp-nvptx/usr,amdgcn-amdhsa=/build/reproducible-path/gcc-12-12.2.0/debian/tmp-gcn/usr --enable-plugin --enable-shared --enable-threads=posix --host=x86_64-linux-gnu --program-prefix=x86_64-linux-gnu- --target=x86_64-linux-gnu --with-abi=m64 --with-arch-32=i686 --with-default-libstdcxx-abi=new --with-gcc-major-version-only --with-multilib-list=m32,m64,mx32 --with-target-system-zlib=auto --with-tune=generic --without-cuda-driver -v"
+            },
+            {
+              "path": "ci.data.cpu-microcode",
+              "value": "0x1"
+            },
+            {
+              "path": "ci.data.environment-variables",
+              "value": "BL_DEBUG_TELEMETRY=false"
+            },
+            {
+              "path": "ci.data.kernel-extra-details",
+              "value": "Transparent Huge Pages: madvise"
+            },
+            {
+              "path": "ci.data.security",
+              "value": "gather_data_sampling: Not affected + indirect_target_selection: Mitigation of Aligned branch/return thunks + itlb_multihit: Not affected + l1tf: Not affected + mds: Not affected + meltdown: Not affected + mmio_stale_data: Mitigation of Clear buffers; SMT Host state unknown + reg_file_data_sampling: Not affected + retbleed: Not affected + spec_rstack_overflow: Not affected + spec_store_bypass: Mitigation of SSB disabled via prctl + spectre_v1: Mitigation of usercopy/swapgs barriers and __user pointer sanitization + spectre_v2: Mitigation of Enhanced / Automatic IBRS; IBPB: conditional; PBRSB-eIBRS: SW sequence; BHI: SW loop KVM: SW loop + srbds: Not affected + tsa: Not affected + tsx_async_abort: Mitigation of TSX disabled + vmscape: Not affected"
+            },
+            {
+              "path": "ci.hardware.Disk",
+              "value": "13GB"
+            },
+            {
+              "path": "ci.hardware.Memory",
+              "value": "16GB"
+            },
+            {
+              "path": "ci.hardware.Processor",
+              "value": "Intel Xeon (6 Cores)"
+            },
+            {
+              "path": "ci.identifier",
+              "value": "ci"
+            },
+            {
+              "path": "ci.software.Compiler",
+              "value": "GCC 12.2.0"
+            },
+            {
+              "path": "ci.software.File-System",
+              "value": "overlayfs"
+            },
+            {
+              "path": "ci.software.Kernel",
+              "value": "6.12.75+ (x86_64)"
+            },
+            {
+              "path": "ci.software.OS",
+              "value": "Debian GNU/Linux 12"
+            },
+            {
+              "path": "ci.timestamp",
+              "value": "2026-07-17 08:16:54"
+            },
+            {
+              "path": "ci.user",
+              "value": "root"
+            }
+          ]
+        },
+        {
+          "source": "phoronix/result-file-to-json",
+          "sourceFile": "cpu-node/pts_node-web-tooling--metadata.json",
+          "fields": [
+            {
+              "path": "ci.client_version",
+              "value": "10.8.4"
+            },
+            {
+              "path": "ci.data.cpu-microcode",
+              "value": "0x1"
+            },
+            {
+              "path": "ci.data.environment-variables",
+              "value": "BL_DEBUG_TELEMETRY=false"
+            },
+            {
+              "path": "ci.data.kernel-extra-details",
+              "value": "Transparent Huge Pages: madvise"
+            },
+            {
+              "path": "ci.data.security",
+              "value": "gather_data_sampling: Not affected + indirect_target_selection: Mitigation of Aligned branch/return thunks + itlb_multihit: Not affected + l1tf: Not affected + mds: Not affected + meltdown: Not affected + mmio_stale_data: Mitigation of Clear buffers; SMT Host state unknown + reg_file_data_sampling: Not affected + retbleed: Not affected + spec_rstack_overflow: Not affected + spec_store_bypass: Mitigation of SSB disabled via prctl + spectre_v1: Mitigation of usercopy/swapgs barriers and __user pointer sanitization + spectre_v2: Mitigation of Enhanced / Automatic IBRS; IBPB: conditional; PBRSB-eIBRS: SW sequence; BHI: SW loop KVM: SW loop + srbds: Not affected + tsa: Not affected + tsx_async_abort: Mitigation of TSX disabled + vmscape: Not affected"
+            },
+            {
+              "path": "ci.hardware.Disk",
+              "value": "13GB"
+            },
+            {
+              "path": "ci.hardware.Memory",
+              "value": "16GB"
+            },
+            {
+              "path": "ci.hardware.Processor",
+              "value": "Intel Xeon (6 Cores)"
+            },
+            {
+              "path": "ci.identifier",
+              "value": "ci"
+            },
+            {
+              "path": "ci.software.Compiler",
+              "value": "GCC 12.2.0"
+            },
+            {
+              "path": "ci.software.File-System",
+              "value": "overlayfs"
+            },
+            {
+              "path": "ci.software.Kernel",
+              "value": "6.12.75+ (x86_64)"
+            },
+            {
+              "path": "ci.software.OS",
+              "value": "Debian GNU/Linux 12"
+            },
+            {
+              "path": "ci.timestamp",
+              "value": "2026-07-17 07:24:16"
+            },
+            {
+              "path": "ci.user",
+              "value": "root"
+            }
+          ]
+        },
+        {
+          "source": "phoronix/result-file-to-json",
+          "sourceFile": "disk/pts_fio-rand-read--metadata.json",
+          "fields": [
+            {
+              "path": "ci.client_version",
+              "value": "10.8.4"
+            },
+            {
+              "path": "ci.data.compiler-configuration",
+              "value": "--build=x86_64-linux-gnu --disable-vtable-verify --disable-werror --enable-cet --enable-checking=release --enable-clocale=gnu --enable-default-pie --enable-gnu-unique-object --enable-languages=c,ada,c++,go,d,fortran,objc,obj-c++,m2 --enable-libphobos-checking=release --enable-libstdcxx-debug --enable-libstdcxx-time=yes --enable-multiarch --enable-multilib --enable-nls --enable-objc-gc=auto --enable-offload-defaulted --enable-offload-targets=nvptx-none=/build/reproducible-path/gcc-12-12.2.0/debian/tmp-nvptx/usr,amdgcn-amdhsa=/build/reproducible-path/gcc-12-12.2.0/debian/tmp-gcn/usr --enable-plugin --enable-shared --enable-threads=posix --host=x86_64-linux-gnu --program-prefix=x86_64-linux-gnu- --target=x86_64-linux-gnu --with-abi=m64 --with-arch-32=i686 --with-default-libstdcxx-abi=new --with-gcc-major-version-only --with-multilib-list=m32,m64,mx32 --with-target-system-zlib=auto --with-tune=generic --without-cuda-driver -v"
+            },
+            {
+              "path": "ci.data.cpu-microcode",
+              "value": "0x1"
+            },
+            {
+              "path": "ci.data.environment-variables",
+              "value": "BL_DEBUG_TELEMETRY=false"
+            },
+            {
+              "path": "ci.data.kernel-extra-details",
+              "value": "Transparent Huge Pages: madvise"
+            },
+            {
+              "path": "ci.data.security",
+              "value": "gather_data_sampling: Not affected + indirect_target_selection: Mitigation of Aligned branch/return thunks + itlb_multihit: Not affected + l1tf: Not affected + mds: Not affected + meltdown: Not affected + mmio_stale_data: Mitigation of Clear buffers; SMT Host state unknown + reg_file_data_sampling: Not affected + retbleed: Not affected + spec_rstack_overflow: Not affected + spec_store_bypass: Mitigation of SSB disabled via prctl + spectre_v1: Mitigation of usercopy/swapgs barriers and __user pointer sanitization + spectre_v2: Mitigation of Enhanced / Automatic IBRS; IBPB: conditional; PBRSB-eIBRS: SW sequence; BHI: SW loop KVM: SW loop + srbds: Not affected + tsa: Not affected + tsx_async_abort: Mitigation of TSX disabled + vmscape: Not affected"
+            },
+            {
+              "path": "ci.hardware.Disk",
+              "value": "13GB"
+            },
+            {
+              "path": "ci.hardware.Memory",
+              "value": "16GB"
+            },
+            {
+              "path": "ci.hardware.Processor",
+              "value": "Intel Xeon (6 Cores)"
+            },
+            {
+              "path": "ci.identifier",
+              "value": "ci"
+            },
+            {
+              "path": "ci.software.Compiler",
+              "value": "GCC 12.2.0"
+            },
+            {
+              "path": "ci.software.File-System",
+              "value": "overlayfs"
+            },
+            {
+              "path": "ci.software.Kernel",
+              "value": "6.12.75+ (x86_64)"
+            },
+            {
+              "path": "ci.software.OS",
+              "value": "Debian GNU/Linux 12"
+            },
+            {
+              "path": "ci.timestamp",
+              "value": "2026-07-17 07:30:15"
+            },
+            {
+              "path": "ci.user",
+              "value": "root"
+            }
+          ]
+        },
+        {
+          "source": "phoronix/result-file-to-json",
+          "sourceFile": "disk/pts_fio-rand-write--metadata.json",
+          "fields": [
+            {
+              "path": "ci.client_version",
+              "value": "10.8.4"
+            },
+            {
+              "path": "ci.data.compiler-configuration",
+              "value": "--build=x86_64-linux-gnu --disable-vtable-verify --disable-werror --enable-cet --enable-checking=release --enable-clocale=gnu --enable-default-pie --enable-gnu-unique-object --enable-languages=c,ada,c++,go,d,fortran,objc,obj-c++,m2 --enable-libphobos-checking=release --enable-libstdcxx-debug --enable-libstdcxx-time=yes --enable-multiarch --enable-multilib --enable-nls --enable-objc-gc=auto --enable-offload-defaulted --enable-offload-targets=nvptx-none=/build/reproducible-path/gcc-12-12.2.0/debian/tmp-nvptx/usr,amdgcn-amdhsa=/build/reproducible-path/gcc-12-12.2.0/debian/tmp-gcn/usr --enable-plugin --enable-shared --enable-threads=posix --host=x86_64-linux-gnu --program-prefix=x86_64-linux-gnu- --target=x86_64-linux-gnu --with-abi=m64 --with-arch-32=i686 --with-default-libstdcxx-abi=new --with-gcc-major-version-only --with-multilib-list=m32,m64,mx32 --with-target-system-zlib=auto --with-tune=generic --without-cuda-driver -v"
+            },
+            {
+              "path": "ci.data.cpu-microcode",
+              "value": "0x1"
+            },
+            {
+              "path": "ci.data.environment-variables",
+              "value": "BL_DEBUG_TELEMETRY=false"
+            },
+            {
+              "path": "ci.data.kernel-extra-details",
+              "value": "Transparent Huge Pages: madvise"
+            },
+            {
+              "path": "ci.data.security",
+              "value": "gather_data_sampling: Not affected + indirect_target_selection: Mitigation of Aligned branch/return thunks + itlb_multihit: Not affected + l1tf: Not affected + mds: Not affected + meltdown: Not affected + mmio_stale_data: Mitigation of Clear buffers; SMT Host state unknown + reg_file_data_sampling: Not affected + retbleed: Not affected + spec_rstack_overflow: Not affected + spec_store_bypass: Mitigation of SSB disabled via prctl + spectre_v1: Mitigation of usercopy/swapgs barriers and __user pointer sanitization + spectre_v2: Mitigation of Enhanced / Automatic IBRS; IBPB: conditional; PBRSB-eIBRS: SW sequence; BHI: SW loop KVM: SW loop + srbds: Not affected + tsa: Not affected + tsx_async_abort: Mitigation of TSX disabled + vmscape: Not affected"
+            },
+            {
+              "path": "ci.hardware.Disk",
+              "value": "13GB"
+            },
+            {
+              "path": "ci.hardware.Memory",
+              "value": "16GB"
+            },
+            {
+              "path": "ci.hardware.Processor",
+              "value": "Intel Xeon (6 Cores)"
+            },
+            {
+              "path": "ci.identifier",
+              "value": "ci"
+            },
+            {
+              "path": "ci.software.Compiler",
+              "value": "GCC 12.2.0"
+            },
+            {
+              "path": "ci.software.File-System",
+              "value": "overlayfs"
+            },
+            {
+              "path": "ci.software.Kernel",
+              "value": "6.12.75+ (x86_64)"
+            },
+            {
+              "path": "ci.software.OS",
+              "value": "Debian GNU/Linux 12"
+            },
+            {
+              "path": "ci.timestamp",
+              "value": "2026-07-17 07:33:25"
+            },
+            {
+              "path": "ci.user",
+              "value": "root"
+            }
+          ]
+        },
+        {
+          "source": "phoronix/result-file-to-json",
+          "sourceFile": "disk/pts_fio-seq-read--metadata.json",
+          "fields": [
+            {
+              "path": "ci.client_version",
+              "value": "10.8.4"
+            },
+            {
+              "path": "ci.data.compiler-configuration",
+              "value": "--build=x86_64-linux-gnu --disable-vtable-verify --disable-werror --enable-cet --enable-checking=release --enable-clocale=gnu --enable-default-pie --enable-gnu-unique-object --enable-languages=c,ada,c++,go,d,fortran,objc,obj-c++,m2 --enable-libphobos-checking=release --enable-libstdcxx-debug --enable-libstdcxx-time=yes --enable-multiarch --enable-multilib --enable-nls --enable-objc-gc=auto --enable-offload-defaulted --enable-offload-targets=nvptx-none=/build/reproducible-path/gcc-12-12.2.0/debian/tmp-nvptx/usr,amdgcn-amdhsa=/build/reproducible-path/gcc-12-12.2.0/debian/tmp-gcn/usr --enable-plugin --enable-shared --enable-threads=posix --host=x86_64-linux-gnu --program-prefix=x86_64-linux-gnu- --target=x86_64-linux-gnu --with-abi=m64 --with-arch-32=i686 --with-default-libstdcxx-abi=new --with-gcc-major-version-only --with-multilib-list=m32,m64,mx32 --with-target-system-zlib=auto --with-tune=generic --without-cuda-driver -v"
+            },
+            {
+              "path": "ci.data.cpu-microcode",
+              "value": "0x1"
+            },
+            {
+              "path": "ci.data.environment-variables",
+              "value": "BL_DEBUG_TELEMETRY=false"
+            },
+            {
+              "path": "ci.data.kernel-extra-details",
+              "value": "Transparent Huge Pages: madvise"
+            },
+            {
+              "path": "ci.data.security",
+              "value": "gather_data_sampling: Not affected + indirect_target_selection: Mitigation of Aligned branch/return thunks + itlb_multihit: Not affected + l1tf: Not affected + mds: Not affected + meltdown: Not affected + mmio_stale_data: Mitigation of Clear buffers; SMT Host state unknown + reg_file_data_sampling: Not affected + retbleed: Not affected + spec_rstack_overflow: Not affected + spec_store_bypass: Mitigation of SSB disabled via prctl + spectre_v1: Mitigation of usercopy/swapgs barriers and __user pointer sanitization + spectre_v2: Mitigation of Enhanced / Automatic IBRS; IBPB: conditional; PBRSB-eIBRS: SW sequence; BHI: SW loop KVM: SW loop + srbds: Not affected + tsa: Not affected + tsx_async_abort: Mitigation of TSX disabled + vmscape: Not affected"
+            },
+            {
+              "path": "ci.hardware.Disk",
+              "value": "13GB"
+            },
+            {
+              "path": "ci.hardware.Memory",
+              "value": "16GB"
+            },
+            {
+              "path": "ci.hardware.Processor",
+              "value": "Intel Xeon (6 Cores)"
+            },
+            {
+              "path": "ci.identifier",
+              "value": "ci"
+            },
+            {
+              "path": "ci.software.Compiler",
+              "value": "GCC 12.2.0"
+            },
+            {
+              "path": "ci.software.File-System",
+              "value": "overlayfs"
+            },
+            {
+              "path": "ci.software.Kernel",
+              "value": "6.12.75+ (x86_64)"
+            },
+            {
+              "path": "ci.software.OS",
+              "value": "Debian GNU/Linux 12"
+            },
+            {
+              "path": "ci.timestamp",
+              "value": "2026-07-17 07:23:55"
+            },
+            {
+              "path": "ci.user",
+              "value": "root"
+            }
+          ]
+        },
+        {
+          "source": "phoronix/result-file-to-json",
+          "sourceFile": "disk/pts_fio-seq-write--metadata.json",
+          "fields": [
+            {
+              "path": "ci.client_version",
+              "value": "10.8.4"
+            },
+            {
+              "path": "ci.data.compiler-configuration",
+              "value": "--build=x86_64-linux-gnu --disable-vtable-verify --disable-werror --enable-cet --enable-checking=release --enable-clocale=gnu --enable-default-pie --enable-gnu-unique-object --enable-languages=c,ada,c++,go,d,fortran,objc,obj-c++,m2 --enable-libphobos-checking=release --enable-libstdcxx-debug --enable-libstdcxx-time=yes --enable-multiarch --enable-multilib --enable-nls --enable-objc-gc=auto --enable-offload-defaulted --enable-offload-targets=nvptx-none=/build/reproducible-path/gcc-12-12.2.0/debian/tmp-nvptx/usr,amdgcn-amdhsa=/build/reproducible-path/gcc-12-12.2.0/debian/tmp-gcn/usr --enable-plugin --enable-shared --enable-threads=posix --host=x86_64-linux-gnu --program-prefix=x86_64-linux-gnu- --target=x86_64-linux-gnu --with-abi=m64 --with-arch-32=i686 --with-default-libstdcxx-abi=new --with-gcc-major-version-only --with-multilib-list=m32,m64,mx32 --with-target-system-zlib=auto --with-tune=generic --without-cuda-driver -v"
+            },
+            {
+              "path": "ci.data.cpu-microcode",
+              "value": "0x1"
+            },
+            {
+              "path": "ci.data.environment-variables",
+              "value": "BL_DEBUG_TELEMETRY=false"
+            },
+            {
+              "path": "ci.data.kernel-extra-details",
+              "value": "Transparent Huge Pages: madvise"
+            },
+            {
+              "path": "ci.data.security",
+              "value": "gather_data_sampling: Not affected + indirect_target_selection: Mitigation of Aligned branch/return thunks + itlb_multihit: Not affected + l1tf: Not affected + mds: Not affected + meltdown: Not affected + mmio_stale_data: Mitigation of Clear buffers; SMT Host state unknown + reg_file_data_sampling: Not affected + retbleed: Not affected + spec_rstack_overflow: Not affected + spec_store_bypass: Mitigation of SSB disabled via prctl + spectre_v1: Mitigation of usercopy/swapgs barriers and __user pointer sanitization + spectre_v2: Mitigation of Enhanced / Automatic IBRS; IBPB: conditional; PBRSB-eIBRS: SW sequence; BHI: SW loop KVM: SW loop + srbds: Not affected + tsa: Not affected + tsx_async_abort: Mitigation of TSX disabled + vmscape: Not affected"
+            },
+            {
+              "path": "ci.hardware.Disk",
+              "value": "13GB"
+            },
+            {
+              "path": "ci.hardware.Memory",
+              "value": "16GB"
+            },
+            {
+              "path": "ci.hardware.Processor",
+              "value": "Intel Xeon (6 Cores)"
+            },
+            {
+              "path": "ci.identifier",
+              "value": "ci"
+            },
+            {
+              "path": "ci.software.Compiler",
+              "value": "GCC 12.2.0"
+            },
+            {
+              "path": "ci.software.File-System",
+              "value": "overlayfs"
+            },
+            {
+              "path": "ci.software.Kernel",
+              "value": "6.12.75+ (x86_64)"
+            },
+            {
+              "path": "ci.software.OS",
+              "value": "Debian GNU/Linux 12"
+            },
+            {
+              "path": "ci.timestamp",
+              "value": "2026-07-17 07:27:06"
+            },
+            {
+              "path": "ci.user",
+              "value": "root"
+            }
+          ]
+        },
+        {
+          "source": "phoronix/result-file-to-json",
+          "sourceFile": "disk/pts_hardlink--metadata.json",
+          "fields": [
+            {
+              "path": "ci.client_version",
+              "value": "10.8.4"
+            },
+            {
+              "path": "ci.data.compiler-configuration",
+              "value": "--build=x86_64-linux-gnu --disable-vtable-verify --disable-werror --enable-cet --enable-checking=release --enable-clocale=gnu --enable-default-pie --enable-gnu-unique-object --enable-languages=c,ada,c++,go,d,fortran,objc,obj-c++,m2 --enable-libphobos-checking=release --enable-libstdcxx-debug --enable-libstdcxx-time=yes --enable-multiarch --enable-multilib --enable-nls --enable-objc-gc=auto --enable-offload-defaulted --enable-offload-targets=nvptx-none=/build/reproducible-path/gcc-12-12.2.0/debian/tmp-nvptx/usr,amdgcn-amdhsa=/build/reproducible-path/gcc-12-12.2.0/debian/tmp-gcn/usr --enable-plugin --enable-shared --enable-threads=posix --host=x86_64-linux-gnu --program-prefix=x86_64-linux-gnu- --target=x86_64-linux-gnu --with-abi=m64 --with-arch-32=i686 --with-default-libstdcxx-abi=new --with-gcc-major-version-only --with-multilib-list=m32,m64,mx32 --with-target-system-zlib=auto --with-tune=generic --without-cuda-driver -v"
+            },
+            {
+              "path": "ci.data.cpu-microcode",
+              "value": "0x1"
+            },
+            {
+              "path": "ci.data.environment-variables",
+              "value": "BL_DEBUG_TELEMETRY=false"
+            },
+            {
+              "path": "ci.data.kernel-extra-details",
+              "value": "Transparent Huge Pages: madvise"
+            },
+            {
+              "path": "ci.data.security",
+              "value": "gather_data_sampling: Not affected + indirect_target_selection: Mitigation of Aligned branch/return thunks + itlb_multihit: Not affected + l1tf: Not affected + mds: Not affected + meltdown: Not affected + mmio_stale_data: Mitigation of Clear buffers; SMT Host state unknown + reg_file_data_sampling: Not affected + retbleed: Not affected + spec_rstack_overflow: Not affected + spec_store_bypass: Mitigation of SSB disabled via prctl + spectre_v1: Mitigation of usercopy/swapgs barriers and __user pointer sanitization + spectre_v2: Mitigation of Enhanced / Automatic IBRS; IBPB: conditional; PBRSB-eIBRS: SW sequence; BHI: SW loop KVM: SW loop + srbds: Not affected + tsa: Not affected + tsx_async_abort: Mitigation of TSX disabled + vmscape: Not affected"
+            },
+            {
+              "path": "ci.hardware.Disk",
+              "value": "13GB"
+            },
+            {
+              "path": "ci.hardware.Memory",
+              "value": "16GB"
+            },
+            {
+              "path": "ci.hardware.Processor",
+              "value": "Intel Xeon (6 Cores)"
+            },
+            {
+              "path": "ci.identifier",
+              "value": "ci"
+            },
+            {
+              "path": "ci.software.Compiler",
+              "value": "GCC 12.2.0"
+            },
+            {
+              "path": "ci.software.File-System",
+              "value": "overlayfs"
+            },
+            {
+              "path": "ci.software.Kernel",
+              "value": "6.12.75+ (x86_64)"
+            },
+            {
+              "path": "ci.software.OS",
+              "value": "Debian GNU/Linux 12"
+            },
+            {
+              "path": "ci.timestamp",
+              "value": "2026-07-17 07:36:36"
+            },
+            {
+              "path": "ci.user",
+              "value": "root"
+            }
+          ]
+        },
+        {
+          "source": "phoronix/result-file-to-json",
+          "sourceFile": "memory/pts_stream--metadata.json",
+          "fields": [
+            {
+              "path": "ci.client_version",
+              "value": "10.8.4"
+            },
+            {
+              "path": "ci.data.compiler-configuration",
+              "value": "--build=x86_64-linux-gnu --disable-vtable-verify --disable-werror --enable-cet --enable-checking=release --enable-clocale=gnu --enable-default-pie --enable-gnu-unique-object --enable-languages=c,ada,c++,go,d,fortran,objc,obj-c++,m2 --enable-libphobos-checking=release --enable-libstdcxx-debug --enable-libstdcxx-time=yes --enable-multiarch --enable-multilib --enable-nls --enable-objc-gc=auto --enable-offload-defaulted --enable-offload-targets=nvptx-none=/build/reproducible-path/gcc-12-12.2.0/debian/tmp-nvptx/usr,amdgcn-amdhsa=/build/reproducible-path/gcc-12-12.2.0/debian/tmp-gcn/usr --enable-plugin --enable-shared --enable-threads=posix --host=x86_64-linux-gnu --program-prefix=x86_64-linux-gnu- --target=x86_64-linux-gnu --with-abi=m64 --with-arch-32=i686 --with-default-libstdcxx-abi=new --with-gcc-major-version-only --with-multilib-list=m32,m64,mx32 --with-target-system-zlib=auto --with-tune=generic --without-cuda-driver -v"
+            },
+            {
+              "path": "ci.data.cpu-microcode",
+              "value": "0x1"
+            },
+            {
+              "path": "ci.data.environment-variables",
+              "value": "CFLAGS_OVERRIDE=\"-O3 -march=native -DSTREAM_ARRAY_SIZE=150000000\" BL_DEBUG_TELEMETRY=false"
+            },
+            {
+              "path": "ci.data.kernel-extra-details",
+              "value": "Transparent Huge Pages: madvise"
+            },
+            {
+              "path": "ci.data.security",
+              "value": "gather_data_sampling: Not affected + indirect_target_selection: Mitigation of Aligned branch/return thunks + itlb_multihit: Not affected + l1tf: Not affected + mds: Not affected + meltdown: Not affected + mmio_stale_data: Mitigation of Clear buffers; SMT Host state unknown + reg_file_data_sampling: Not affected + retbleed: Not affected + spec_rstack_overflow: Not affected + spec_store_bypass: Mitigation of SSB disabled via prctl + spectre_v1: Mitigation of usercopy/swapgs barriers and __user pointer sanitization + spectre_v2: Mitigation of Enhanced / Automatic IBRS; IBPB: conditional; PBRSB-eIBRS: SW sequence; BHI: SW loop KVM: SW loop + srbds: Not affected + tsa: Not affected + tsx_async_abort: Mitigation of TSX disabled + vmscape: Not affected"
+            },
+            {
+              "path": "ci.hardware.Disk",
+              "value": "13GB"
+            },
+            {
+              "path": "ci.hardware.Memory",
+              "value": "16GB"
+            },
+            {
+              "path": "ci.hardware.Processor",
+              "value": "Intel Xeon (6 Cores)"
+            },
+            {
+              "path": "ci.identifier",
+              "value": "ci"
+            },
+            {
+              "path": "ci.software.Compiler",
+              "value": "GCC 12.2.0"
+            },
+            {
+              "path": "ci.software.File-System",
+              "value": "overlayfs"
+            },
+            {
+              "path": "ci.software.Kernel",
+              "value": "6.12.75+ (x86_64)"
+            },
+            {
+              "path": "ci.software.OS",
+              "value": "Debian GNU/Linux 12"
+            },
+            {
+              "path": "ci.timestamp",
+              "value": "2026-07-17 07:23:45"
+            },
+            {
+              "path": "ci.user",
+              "value": "root"
+            }
+          ]
+        },
+        {
+          "source": "phoronix/result-file-to-json",
+          "sourceFile": "network/pts_fast-cli--metadata.json",
+          "fields": [
+            {
+              "path": "ci.client_version",
+              "value": "10.8.4"
+            },
+            {
+              "path": "ci.data.cpu-microcode",
+              "value": "0x1"
+            },
+            {
+              "path": "ci.data.environment-variables",
+              "value": "BL_DEBUG_TELEMETRY=false"
+            },
+            {
+              "path": "ci.data.kernel-extra-details",
+              "value": "Transparent Huge Pages: madvise"
+            },
+            {
+              "path": "ci.data.security",
+              "value": "gather_data_sampling: Not affected + indirect_target_selection: Mitigation of Aligned branch/return thunks + itlb_multihit: Not affected + l1tf: Not affected + mds: Not affected + meltdown: Not affected + mmio_stale_data: Mitigation of Clear buffers; SMT Host state unknown + reg_file_data_sampling: Not affected + retbleed: Not affected + spec_rstack_overflow: Not affected + spec_store_bypass: Mitigation of SSB disabled via prctl + spectre_v1: Mitigation of usercopy/swapgs barriers and __user pointer sanitization + spectre_v2: Mitigation of Enhanced / Automatic IBRS; IBPB: conditional; PBRSB-eIBRS: SW sequence; BHI: SW loop KVM: SW loop + srbds: Not affected + tsa: Not affected + tsx_async_abort: Mitigation of TSX disabled + vmscape: Not affected"
+            },
+            {
+              "path": "ci.hardware.Disk",
+              "value": "13GB"
+            },
+            {
+              "path": "ci.hardware.Memory",
+              "value": "16GB"
+            },
+            {
+              "path": "ci.hardware.Processor",
+              "value": "Intel Xeon (6 Cores)"
+            },
+            {
+              "path": "ci.identifier",
+              "value": "ci"
+            },
+            {
+              "path": "ci.software.Compiler",
+              "value": "GCC 12.2.0"
+            },
+            {
+              "path": "ci.software.File-System",
+              "value": "overlayfs"
+            },
+            {
+              "path": "ci.software.Kernel",
+              "value": "6.12.75+ (x86_64)"
+            },
+            {
+              "path": "ci.software.OS",
+              "value": "Debian GNU/Linux 12"
+            },
+            {
+              "path": "ci.timestamp",
+              "value": "2026-07-17 07:24:33"
+            },
+            {
+              "path": "ci.user",
+              "value": "root"
+            }
+          ]
+        },
+        {
+          "source": "phoronix/result-file-to-json",
+          "sourceFile": "network/pts_network-loopback--metadata.json",
+          "fields": [
+            {
+              "path": "ci.client_version",
+              "value": "10.8.4"
+            },
+            {
+              "path": "ci.data.cpu-microcode",
+              "value": "0x1"
+            },
+            {
+              "path": "ci.data.environment-variables",
+              "value": "BL_DEBUG_TELEMETRY=false"
+            },
+            {
+              "path": "ci.data.kernel-extra-details",
+              "value": "Transparent Huge Pages: madvise"
+            },
+            {
+              "path": "ci.data.security",
+              "value": "gather_data_sampling: Not affected + indirect_target_selection: Mitigation of Aligned branch/return thunks + itlb_multihit: Not affected + l1tf: Not affected + mds: Not affected + meltdown: Not affected + mmio_stale_data: Mitigation of Clear buffers; SMT Host state unknown + reg_file_data_sampling: Not affected + retbleed: Not affected + spec_rstack_overflow: Not affected + spec_store_bypass: Mitigation of SSB disabled via prctl + spectre_v1: Mitigation of usercopy/swapgs barriers and __user pointer sanitization + spectre_v2: Mitigation of Enhanced / Automatic IBRS; IBPB: conditional; PBRSB-eIBRS: SW sequence; BHI: SW loop KVM: SW loop + srbds: Not affected + tsa: Not affected + tsx_async_abort: Mitigation of TSX disabled + vmscape: Not affected"
+            },
+            {
+              "path": "ci.hardware.Disk",
+              "value": "13GB"
+            },
+            {
+              "path": "ci.hardware.Memory",
+              "value": "16GB"
+            },
+            {
+              "path": "ci.hardware.Processor",
+              "value": "Intel Xeon (6 Cores)"
+            },
+            {
+              "path": "ci.identifier",
+              "value": "ci"
+            },
+            {
+              "path": "ci.software.Compiler",
+              "value": "GCC 12.2.0"
+            },
+            {
+              "path": "ci.software.File-System",
+              "value": "overlayfs"
+            },
+            {
+              "path": "ci.software.Kernel",
+              "value": "6.12.75+ (x86_64)"
+            },
+            {
+              "path": "ci.software.OS",
+              "value": "Debian GNU/Linux 12"
+            },
+            {
+              "path": "ci.timestamp",
+              "value": "2026-07-17 07:23:49"
+            },
+            {
+              "path": "ci.user",
+              "value": "root"
+            }
+          ]
+        },
+        {
+          "source": "phoronix/result-file-to-json",
+          "sourceFile": "realworld-better-auth/pts_realworld-better-auth--metadata.json",
+          "fields": [
+            {
+              "path": "ci.client_version",
+              "value": "10.8.4"
+            },
+            {
+              "path": "ci.data.cpu-microcode",
+              "value": "0x1"
+            },
+            {
+              "path": "ci.data.environment-variables",
+              "value": "BL_DEBUG_TELEMETRY=false"
+            },
+            {
+              "path": "ci.data.kernel-extra-details",
+              "value": "Transparent Huge Pages: madvise"
+            },
+            {
+              "path": "ci.data.security",
+              "value": "gather_data_sampling: Not affected + indirect_target_selection: Mitigation of Aligned branch/return thunks + itlb_multihit: Not affected + l1tf: Not affected + mds: Not affected + meltdown: Not affected + mmio_stale_data: Mitigation of Clear buffers; SMT Host state unknown + reg_file_data_sampling: Not affected + retbleed: Not affected + spec_rstack_overflow: Not affected + spec_store_bypass: Mitigation of SSB disabled via prctl + spectre_v1: Mitigation of usercopy/swapgs barriers and __user pointer sanitization + spectre_v2: Mitigation of Enhanced / Automatic IBRS; IBPB: conditional; PBRSB-eIBRS: SW sequence; BHI: SW loop KVM: SW loop + srbds: Not affected + tsa: Not affected + tsx_async_abort: Mitigation of TSX disabled + vmscape: Not affected"
+            },
+            {
+              "path": "ci.hardware.Disk",
+              "value": "13GB"
+            },
+            {
+              "path": "ci.hardware.Memory",
+              "value": "16GB"
+            },
+            {
+              "path": "ci.hardware.Processor",
+              "value": "Intel Xeon (6 Cores)"
+            },
+            {
+              "path": "ci.identifier",
+              "value": "ci"
+            },
+            {
+              "path": "ci.software.Compiler",
+              "value": "GCC 12.2.0"
+            },
+            {
+              "path": "ci.software.File-System",
+              "value": "overlayfs"
+            },
+            {
+              "path": "ci.software.Kernel",
+              "value": "6.12.75+ (x86_64)"
+            },
+            {
+              "path": "ci.software.OS",
+              "value": "Debian GNU/Linux 12"
+            },
+            {
+              "path": "ci.timestamp",
+              "value": "2026-07-17 07:24:08"
+            },
+            {
+              "path": "ci.user",
+              "value": "root"
+            }
+          ]
+        },
+        {
+          "source": "phoronix/result-file-to-json",
+          "sourceFile": "system/pts_git--metadata.json",
+          "fields": [
+            {
+              "path": "ci.client_version",
+              "value": "10.8.4"
+            },
+            {
+              "path": "ci.data.cpu-microcode",
+              "value": "0x1"
+            },
+            {
+              "path": "ci.data.environment-variables",
+              "value": "BL_DEBUG_TELEMETRY=false"
+            },
+            {
+              "path": "ci.data.kernel-extra-details",
+              "value": "Transparent Huge Pages: madvise"
+            },
+            {
+              "path": "ci.data.security",
+              "value": "gather_data_sampling: Not affected + indirect_target_selection: Mitigation of Aligned branch/return thunks + itlb_multihit: Not affected + l1tf: Not affected + mds: Not affected + meltdown: Not affected + mmio_stale_data: Mitigation of Clear buffers; SMT Host state unknown + reg_file_data_sampling: Not affected + retbleed: Not affected + spec_rstack_overflow: Not affected + spec_store_bypass: Mitigation of SSB disabled via prctl + spectre_v1: Mitigation of usercopy/swapgs barriers and __user pointer sanitization + spectre_v2: Mitigation of Enhanced / Automatic IBRS; IBPB: conditional; PBRSB-eIBRS: SW sequence; BHI: SW loop KVM: SW loop + srbds: Not affected + tsa: Not affected + tsx_async_abort: Mitigation of TSX disabled + vmscape: Not affected"
+            },
+            {
+              "path": "ci.hardware.Disk",
+              "value": "13GB"
+            },
+            {
+              "path": "ci.hardware.Memory",
+              "value": "16GB"
+            },
+            {
+              "path": "ci.hardware.Processor",
+              "value": "Intel Xeon (6 Cores)"
+            },
+            {
+              "path": "ci.identifier",
+              "value": "ci"
+            },
+            {
+              "path": "ci.software.Compiler",
+              "value": "GCC 12.2.0"
+            },
+            {
+              "path": "ci.software.File-System",
+              "value": "overlayfs"
+            },
+            {
+              "path": "ci.software.Kernel",
+              "value": "6.12.75+ (x86_64)"
+            },
+            {
+              "path": "ci.software.OS",
+              "value": "Debian GNU/Linux 12"
+            },
+            {
+              "path": "ci.timestamp",
+              "value": "2026-07-17 07:30:05"
+            },
+            {
+              "path": "ci.user",
+              "value": "root"
+            }
+          ]
+        },
+        {
+          "source": "phoronix/result-file-to-json",
+          "sourceFile": "system/pts_pgbench-read-only--metadata.json",
+          "fields": [
+            {
+              "path": "ci.client_version",
+              "value": "10.8.4"
+            },
+            {
+              "path": "ci.data.compiler-configuration",
+              "value": "--build=x86_64-linux-gnu --disable-vtable-verify --disable-werror --enable-cet --enable-checking=release --enable-clocale=gnu --enable-default-pie --enable-gnu-unique-object --enable-languages=c,ada,c++,go,d,fortran,objc,obj-c++,m2 --enable-libphobos-checking=release --enable-libstdcxx-debug --enable-libstdcxx-time=yes --enable-multiarch --enable-multilib --enable-nls --enable-objc-gc=auto --enable-offload-defaulted --enable-offload-targets=nvptx-none=/build/reproducible-path/gcc-12-12.2.0/debian/tmp-nvptx/usr,amdgcn-amdhsa=/build/reproducible-path/gcc-12-12.2.0/debian/tmp-gcn/usr --enable-plugin --enable-shared --enable-threads=posix --host=x86_64-linux-gnu --program-prefix=x86_64-linux-gnu- --target=x86_64-linux-gnu --with-abi=m64 --with-arch-32=i686 --with-default-libstdcxx-abi=new --with-gcc-major-version-only --with-multilib-list=m32,m64,mx32 --with-target-system-zlib=auto --with-tune=generic --without-cuda-driver -v"
+            },
+            {
+              "path": "ci.data.cpu-microcode",
+              "value": "0x1"
+            },
+            {
+              "path": "ci.data.environment-variables",
+              "value": "BL_DEBUG_TELEMETRY=false"
+            },
+            {
+              "path": "ci.data.kernel-extra-details",
+              "value": "Transparent Huge Pages: madvise"
+            },
+            {
+              "path": "ci.data.security",
+              "value": "gather_data_sampling: Not affected + indirect_target_selection: Mitigation of Aligned branch/return thunks + itlb_multihit: Not affected + l1tf: Not affected + mds: Not affected + meltdown: Not affected + mmio_stale_data: Mitigation of Clear buffers; SMT Host state unknown + reg_file_data_sampling: Not affected + retbleed: Not affected + spec_rstack_overflow: Not affected + spec_store_bypass: Mitigation of SSB disabled via prctl + spectre_v1: Mitigation of usercopy/swapgs barriers and __user pointer sanitization + spectre_v2: Mitigation of Enhanced / Automatic IBRS; IBPB: conditional; PBRSB-eIBRS: SW sequence; BHI: SW loop KVM: SW loop + srbds: Not affected + tsa: Not affected + tsx_async_abort: Mitigation of TSX disabled + vmscape: Not affected"
+            },
+            {
+              "path": "ci.hardware.Disk",
+              "value": "13GB"
+            },
+            {
+              "path": "ci.hardware.Memory",
+              "value": "16GB"
+            },
+            {
+              "path": "ci.hardware.Processor",
+              "value": "Intel Xeon (6 Cores)"
+            },
+            {
+              "path": "ci.identifier",
+              "value": "ci"
+            },
+            {
+              "path": "ci.software.Compiler",
+              "value": "GCC 12.2.0"
+            },
+            {
+              "path": "ci.software.File-System",
+              "value": "overlayfs"
+            },
+            {
+              "path": "ci.software.Kernel",
+              "value": "6.12.75+ (x86_64)"
+            },
+            {
+              "path": "ci.software.OS",
+              "value": "Debian GNU/Linux 12"
+            },
+            {
+              "path": "ci.timestamp",
+              "value": "2026-07-17 07:28:12"
+            },
+            {
+              "path": "ci.user",
+              "value": "root"
+            }
+          ]
+        },
+        {
+          "source": "phoronix/result-file-to-json",
+          "sourceFile": "system/pts_pgbench-read-write--metadata.json",
+          "fields": [
+            {
+              "path": "ci.client_version",
+              "value": "10.8.4"
+            },
+            {
+              "path": "ci.data.compiler-configuration",
+              "value": "--build=x86_64-linux-gnu --disable-vtable-verify --disable-werror --enable-cet --enable-checking=release --enable-clocale=gnu --enable-default-pie --enable-gnu-unique-object --enable-languages=c,ada,c++,go,d,fortran,objc,obj-c++,m2 --enable-libphobos-checking=release --enable-libstdcxx-debug --enable-libstdcxx-time=yes --enable-multiarch --enable-multilib --enable-nls --enable-objc-gc=auto --enable-offload-defaulted --enable-offload-targets=nvptx-none=/build/reproducible-path/gcc-12-12.2.0/debian/tmp-nvptx/usr,amdgcn-amdhsa=/build/reproducible-path/gcc-12-12.2.0/debian/tmp-gcn/usr --enable-plugin --enable-shared --enable-threads=posix --host=x86_64-linux-gnu --program-prefix=x86_64-linux-gnu- --target=x86_64-linux-gnu --with-abi=m64 --with-arch-32=i686 --with-default-libstdcxx-abi=new --with-gcc-major-version-only --with-multilib-list=m32,m64,mx32 --with-target-system-zlib=auto --with-tune=generic --without-cuda-driver -v"
+            },
+            {
+              "path": "ci.data.cpu-microcode",
+              "value": "0x1"
+            },
+            {
+              "path": "ci.data.environment-variables",
+              "value": "BL_DEBUG_TELEMETRY=false"
+            },
+            {
+              "path": "ci.data.kernel-extra-details",
+              "value": "Transparent Huge Pages: madvise"
+            },
+            {
+              "path": "ci.data.security",
+              "value": "gather_data_sampling: Not affected + indirect_target_selection: Mitigation of Aligned branch/return thunks + itlb_multihit: Not affected + l1tf: Not affected + mds: Not affected + meltdown: Not affected + mmio_stale_data: Mitigation of Clear buffers; SMT Host state unknown + reg_file_data_sampling: Not affected + retbleed: Not affected + spec_rstack_overflow: Not affected + spec_store_bypass: Mitigation of SSB disabled via prctl + spectre_v1: Mitigation of usercopy/swapgs barriers and __user pointer sanitization + spectre_v2: Mitigation of Enhanced / Automatic IBRS; IBPB: conditional; PBRSB-eIBRS: SW sequence; BHI: SW loop KVM: SW loop + srbds: Not affected + tsa: Not affected + tsx_async_abort: Mitigation of TSX disabled + vmscape: Not affected"
+            },
+            {
+              "path": "ci.hardware.Disk",
+              "value": "13GB"
+            },
+            {
+              "path": "ci.hardware.Memory",
+              "value": "16GB"
+            },
+            {
+              "path": "ci.hardware.Processor",
+              "value": "Intel Xeon (6 Cores)"
+            },
+            {
+              "path": "ci.identifier",
+              "value": "ci"
+            },
+            {
+              "path": "ci.software.Compiler",
+              "value": "GCC 12.2.0"
+            },
+            {
+              "path": "ci.software.File-System",
+              "value": "overlayfs"
+            },
+            {
+              "path": "ci.software.Kernel",
+              "value": "6.12.75+ (x86_64)"
+            },
+            {
+              "path": "ci.software.OS",
+              "value": "Debian GNU/Linux 12"
+            },
+            {
+              "path": "ci.timestamp",
+              "value": "2026-07-17 07:28:50"
+            },
+            {
+              "path": "ci.user",
+              "value": "root"
+            }
+          ]
+        },
+        {
+          "source": "phoronix/result-file-to-json",
+          "sourceFile": "system/pts_pybench--metadata.json",
+          "fields": [
+            {
+              "path": "ci.client_version",
+              "value": "10.8.4"
+            },
+            {
+              "path": "ci.data.cpu-microcode",
+              "value": "0x1"
+            },
+            {
+              "path": "ci.data.environment-variables",
+              "value": "BL_DEBUG_TELEMETRY=false"
+            },
+            {
+              "path": "ci.data.kernel-extra-details",
+              "value": "Transparent Huge Pages: madvise"
+            },
+            {
+              "path": "ci.data.python",
+              "value": "Python 3.11.2"
+            },
+            {
+              "path": "ci.data.security",
+              "value": "gather_data_sampling: Not affected + indirect_target_selection: Mitigation of Aligned branch/return thunks + itlb_multihit: Not affected + l1tf: Not affected + mds: Not affected + meltdown: Not affected + mmio_stale_data: Mitigation of Clear buffers; SMT Host state unknown + reg_file_data_sampling: Not affected + retbleed: Not affected + spec_rstack_overflow: Not affected + spec_store_bypass: Mitigation of SSB disabled via prctl + spectre_v1: Mitigation of usercopy/swapgs barriers and __user pointer sanitization + spectre_v2: Mitigation of Enhanced / Automatic IBRS; IBPB: conditional; PBRSB-eIBRS: SW sequence; BHI: SW loop KVM: SW loop + srbds: Not affected + tsa: Not affected + tsx_async_abort: Mitigation of TSX disabled + vmscape: Not affected"
+            },
+            {
+              "path": "ci.hardware.Disk",
+              "value": "13GB"
+            },
+            {
+              "path": "ci.hardware.Memory",
+              "value": "16GB"
+            },
+            {
+              "path": "ci.hardware.Processor",
+              "value": "Intel Xeon (6 Cores)"
+            },
+            {
+              "path": "ci.identifier",
+              "value": "ci"
+            },
+            {
+              "path": "ci.software.Compiler",
+              "value": "GCC 12.2.0"
+            },
+            {
+              "path": "ci.software.File-System",
+              "value": "overlayfs"
+            },
+            {
+              "path": "ci.software.Kernel",
+              "value": "6.12.75+ (x86_64)"
+            },
+            {
+              "path": "ci.software.OS",
+              "value": "Debian GNU/Linux 12"
+            },
+            {
+              "path": "ci.timestamp",
+              "value": "2026-07-17 07:23:56"
+            },
+            {
+              "path": "ci.user",
+              "value": "root"
+            }
+          ]
+        },
+        {
+          "source": "phoronix/result-file-to-json",
+          "sourceFile": "system/pts_sqlite-speedtest--metadata.json",
+          "fields": [
+            {
+              "path": "ci.client_version",
+              "value": "10.8.4"
+            },
+            {
+              "path": "ci.data.compiler-configuration",
+              "value": "--build=x86_64-linux-gnu --disable-vtable-verify --disable-werror --enable-cet --enable-checking=release --enable-clocale=gnu --enable-default-pie --enable-gnu-unique-object --enable-languages=c,ada,c++,go,d,fortran,objc,obj-c++,m2 --enable-libphobos-checking=release --enable-libstdcxx-debug --enable-libstdcxx-time=yes --enable-multiarch --enable-multilib --enable-nls --enable-objc-gc=auto --enable-offload-defaulted --enable-offload-targets=nvptx-none=/build/reproducible-path/gcc-12-12.2.0/debian/tmp-nvptx/usr,amdgcn-amdhsa=/build/reproducible-path/gcc-12-12.2.0/debian/tmp-gcn/usr --enable-plugin --enable-shared --enable-threads=posix --host=x86_64-linux-gnu --program-prefix=x86_64-linux-gnu- --target=x86_64-linux-gnu --with-abi=m64 --with-arch-32=i686 --with-default-libstdcxx-abi=new --with-gcc-major-version-only --with-multilib-list=m32,m64,mx32 --with-target-system-zlib=auto --with-tune=generic --without-cuda-driver -v"
+            },
+            {
+              "path": "ci.data.cpu-microcode",
+              "value": "0x1"
+            },
+            {
+              "path": "ci.data.environment-variables",
+              "value": "BL_DEBUG_TELEMETRY=false"
+            },
+            {
+              "path": "ci.data.kernel-extra-details",
+              "value": "Transparent Huge Pages: madvise"
+            },
+            {
+              "path": "ci.data.security",
+              "value": "gather_data_sampling: Not affected + indirect_target_selection: Mitigation of Aligned branch/return thunks + itlb_multihit: Not affected + l1tf: Not affected + mds: Not affected + meltdown: Not affected + mmio_stale_data: Mitigation of Clear buffers; SMT Host state unknown + reg_file_data_sampling: Not affected + retbleed: Not affected + spec_rstack_overflow: Not affected + spec_store_bypass: Mitigation of SSB disabled via prctl + spectre_v1: Mitigation of usercopy/swapgs barriers and __user pointer sanitization + spectre_v2: Mitigation of Enhanced / Automatic IBRS; IBPB: conditional; PBRSB-eIBRS: SW sequence; BHI: SW loop KVM: SW loop + srbds: Not affected + tsa: Not affected + tsx_async_abort: Mitigation of TSX disabled + vmscape: Not affected"
+            },
+            {
+              "path": "ci.hardware.Disk",
+              "value": "13GB"
+            },
+            {
+              "path": "ci.hardware.Memory",
+              "value": "16GB"
+            },
+            {
+              "path": "ci.hardware.Processor",
+              "value": "Intel Xeon (6 Cores)"
+            },
+            {
+              "path": "ci.identifier",
+              "value": "ci"
+            },
+            {
+              "path": "ci.software.Compiler",
+              "value": "GCC 12.2.0"
+            },
+            {
+              "path": "ci.software.File-System",
+              "value": "overlayfs"
+            },
+            {
+              "path": "ci.software.Kernel",
+              "value": "6.12.75+ (x86_64)"
+            },
+            {
+              "path": "ci.software.OS",
+              "value": "Debian GNU/Linux 12"
+            },
+            {
+              "path": "ci.timestamp",
+              "value": "2026-07-17 07:25:27"
+            },
+            {
+              "path": "ci.user",
+              "value": "root"
+            }
+          ]
+        },
+        {
+          "source": "mise/system-provider",
+          "sourceFile": "system/system-provider.json",
+          "fields": [
+            {
+              "path": "asn",
+              "value": "AS16509"
+            },
+            {
+              "path": "asn_source",
+              "value": "cymru"
+            },
+            {
+              "path": "bios_vendor",
+              "value": ""
+            },
+            {
+              "path": "city",
+              "value": "Boardman"
+            },
+            {
+              "path": "cores",
+              "value": "6"
+            },
+            {
+              "path": "country",
+              "value": "US"
+            },
+            {
+              "path": "cpu_model",
+              "value": "Intel(R) Xeon(R) Processor @ 2.90GHz"
+            },
+            {
+              "path": "geo_source",
+              "value": "ipinfo"
+            },
+            {
+              "path": "kernel",
+              "value": "6.12.75+"
+            },
+            {
+              "path": "loc",
+              "value": "45.8399,-119.7006"
+            },
+            {
+              "path": "manufacturer",
+              "value": ""
+            },
+            {
+              "path": "org",
+              "value": "AS16509 Amazon.com, Inc."
+            },
+            {
+              "path": "org_name",
+              "value": "Amazon.com, Inc."
+            },
+            {
+              "path": "prefix",
+              "value": "34.192.0.0/10"
+            },
+            {
+              "path": "product_name",
+              "value": ""
+            },
+            {
+              "path": "public_ip",
+              "value": "34.214.71.218"
+            },
+            {
+              "path": "ram",
+              "value": "15Gi"
+            },
+            {
+              "path": "region",
+              "value": "Oregon"
+            },
+            {
+              "path": "reverse_dns",
+              "value": "ec2-34-214-71-218.us-west-2.compute.amazonaws.com"
+            },
+            {
+              "path": "schema_version",
+              "value": "1.0"
+            },
+            {
+              "path": "timezone",
+              "value": "America/Los_Angeles"
+            },
+            {
+              "path": "virtualization",
+              "value": ""
+            }
+          ]
+        }
+      ],
+      "metrics": [
+        {
+          "metricId": "c_ray_resolution_1080p_rays_per_pixel_16",
+          "samples": [128.842, 129.024],
+          "aggregates": {
+            "p50": 128.933,
+            "p95": 129.0149,
+            "mean": 128.933,
+            "stdev": 0.12869343417595316,
+            "min": 128.842,
+            "max": 129.024,
+            "n": 2
+          },
+          "sourceFile": "cpu-generic/pts_c-ray.xml",
+          "appVersion": "2.0",
+          "arguments": "-s 1920x1080 -r 16"
+        },
+        {
+          "metricId": "c_ray_resolution_4k_rays_per_pixel_16",
+          "samples": [513.819, 514.36],
+          "aggregates": {
+            "p50": 514.0895,
+            "p95": 514.33295,
+            "mean": 514.0895,
+            "stdev": 0.38254476862192,
+            "min": 513.819,
+            "max": 514.36,
+            "n": 2
+          },
+          "sourceFile": "cpu-generic/pts_c-ray.xml",
+          "appVersion": "2.0",
+          "arguments": "-s 3840x2160 -r 16"
+        },
+        {
+          "metricId": "c_ray_resolution_5k_rays_per_pixel_16",
+          "samples": [913.193, 912.508],
+          "aggregates": {
+            "p50": 912.8505,
+            "p95": 913.1587499999999,
+            "mean": 912.8505,
+            "stdev": 0.48436814511274645,
+            "min": 912.508,
+            "max": 913.193,
+            "n": 2
+          },
+          "sourceFile": "cpu-generic/pts_c-ray.xml",
+          "appVersion": "2.0",
+          "arguments": "-s 5120x2880 -r 16"
+        },
+        {
+          "metricId": "compress_zstd_compression_level_12_compression_speed",
+          "samples": [108.5, 106.3],
+          "aggregates": {
+            "p50": 107.4,
+            "p95": 108.39,
+            "mean": 107.4,
+            "stdev": 1.5556349186104015,
+            "min": 106.3,
+            "max": 108.5,
+            "n": 2
+          },
+          "sourceFile": "cpu-generic/pts_compress-zstd.xml",
+          "appVersion": "1.5.4",
+          "arguments": "-b12"
+        },
+        {
+          "metricId": "compress_zstd_compression_level_12_decompression_speed",
+          "samples": [998.2, 999.2],
+          "aggregates": {
+            "p50": 998.7,
+            "p95": 999.1500000000001,
+            "mean": 998.7,
+            "stdev": 0.7071067811865476,
+            "min": 998.2,
+            "max": 999.2,
+            "n": 2
+          },
+          "sourceFile": "cpu-generic/pts_compress-zstd.xml",
+          "appVersion": "1.5.4",
+          "arguments": "-b12"
+        },
+        {
+          "metricId": "compress_zstd_compression_level_19_compression_speed",
+          "samples": [10, 10.1],
+          "aggregates": {
+            "p50": 10.05,
+            "p95": 10.094999999999999,
+            "mean": 10.05,
+            "stdev": 0.07071067811865388,
+            "min": 10,
+            "max": 10.1,
+            "n": 2
+          },
+          "sourceFile": "cpu-generic/pts_compress-zstd.xml",
+          "appVersion": "1.5.4",
+          "arguments": "-b19"
+        },
+        {
+          "metricId": "compress_zstd_compression_level_19_decompression_speed",
+          "samples": [858.5, 823.6],
+          "aggregates": {
+            "p50": 841.05,
+            "p95": 856.755,
+            "mean": 841.05,
+            "stdev": 24.678026663410535,
+            "min": 823.6,
+            "max": 858.5,
+            "n": 2
+          },
+          "sourceFile": "cpu-generic/pts_compress-zstd.xml",
+          "appVersion": "1.5.4",
+          "arguments": "-b19"
+        },
+        {
+          "metricId": "compress_zstd_compression_level_19_long_mode_compression_speed",
+          "samples": [5.06, 5.13],
+          "aggregates": {
+            "p50": 5.095,
+            "p95": 5.1265,
+            "mean": 5.095,
+            "stdev": 0.049497474683058526,
+            "min": 5.06,
+            "max": 5.13,
+            "n": 2
+          },
+          "sourceFile": "cpu-generic/pts_compress-zstd.xml",
+          "appVersion": "1.5.4",
+          "arguments": "-b19 --long"
+        },
+        {
+          "metricId": "compress_zstd_compression_level_19_long_mode_decompression_speed",
+          "samples": [870.3, 852.1],
+          "aggregates": {
+            "p50": 861.2,
+            "p95": 869.39,
+            "mean": 861.2,
+            "stdev": 12.869343417595077,
+            "min": 852.1,
+            "max": 870.3,
+            "n": 2
+          },
+          "sourceFile": "cpu-generic/pts_compress-zstd.xml",
+          "appVersion": "1.5.4",
+          "arguments": "-b19 --long"
+        },
+        {
+          "metricId": "compress_zstd_compression_level_3_compression_speed",
+          "samples": [1235.4, 1245.5],
+          "aggregates": {
+            "p50": 1240.45,
+            "p95": 1244.995,
+            "mean": 1240.45,
+            "stdev": 7.141778489984065,
+            "min": 1235.4,
+            "max": 1245.5,
+            "n": 2
+          },
+          "sourceFile": "cpu-generic/pts_compress-zstd.xml",
+          "appVersion": "1.5.4",
+          "arguments": "-b3"
+        },
+        {
+          "metricId": "compress_zstd_compression_level_3_long_mode_compression_speed",
+          "samples": [770.9, 784.5],
+          "aggregates": {
+            "p50": 777.7,
+            "p95": 783.82,
+            "mean": 777.7,
+            "stdev": 9.616652224137022,
+            "min": 770.9,
+            "max": 784.5,
+            "n": 2
+          },
+          "sourceFile": "cpu-generic/pts_compress-zstd.xml",
+          "appVersion": "1.5.4",
+          "arguments": "-b3 --long"
+        },
+        {
+          "metricId": "compress_zstd_compression_level_3_long_mode_decompression_speed",
+          "samples": [1144.1, 1150.6],
+          "aggregates": {
+            "p50": 1147.35,
+            "p95": 1150.2749999999999,
+            "mean": 1147.35,
+            "stdev": 4.596194077712559,
+            "min": 1144.1,
+            "max": 1150.6,
+            "n": 2
+          },
+          "sourceFile": "cpu-generic/pts_compress-zstd.xml",
+          "appVersion": "1.5.4",
+          "arguments": "-b3 --long"
+        },
+        {
+          "metricId": "compress_zstd_compression_level_8_compression_speed",
+          "samples": [320.1, 322.1],
+          "aggregates": {
+            "p50": 321.1,
+            "p95": 322,
+            "mean": 321.1,
+            "stdev": 1.4142135623730951,
+            "min": 320.1,
+            "max": 322.1,
+            "n": 2
+          },
+          "sourceFile": "cpu-generic/pts_compress-zstd.xml",
+          "appVersion": "1.5.4",
+          "arguments": "-b8"
+        },
+        {
+          "metricId": "compress_zstd_compression_level_8_decompression_speed",
+          "samples": [1088.2, 1088.4],
+          "aggregates": {
+            "p50": 1088.3000000000002,
+            "p95": 1088.39,
+            "mean": 1088.3000000000002,
+            "stdev": 0.14142135623726126,
+            "min": 1088.2,
+            "max": 1088.4,
+            "n": 2
+          },
+          "sourceFile": "cpu-generic/pts_compress-zstd.xml",
+          "appVersion": "1.5.4",
+          "arguments": "-b8"
+        },
+        {
+          "metricId": "compress_zstd_compression_level_8_long_mode_compression_speed",
+          "samples": [301.7, 310.5],
+          "aggregates": {
+            "p50": 306.1,
+            "p95": 310.06,
+            "mean": 306.1,
+            "stdev": 6.222539674441606,
+            "min": 301.7,
+            "max": 310.5,
+            "n": 2
+          },
+          "sourceFile": "cpu-generic/pts_compress-zstd.xml",
+          "appVersion": "1.5.4",
+          "arguments": "-b8 --long"
+        },
+        {
+          "metricId": "compress_zstd_compression_level_8_long_mode_decompression_speed",
+          "samples": [1098.3, 1103.9],
+          "aggregates": {
+            "p50": 1101.1,
+            "p95": 1103.6200000000001,
+            "mean": 1101.1,
+            "stdev": 3.959797974644843,
+            "min": 1098.3,
+            "max": 1103.9,
+            "n": 2
+          },
+          "sourceFile": "cpu-generic/pts_compress-zstd.xml",
+          "appVersion": "1.5.4",
+          "arguments": "-b8 --long"
+        },
+        {
+          "metricId": "fio_type_random_read_engine_linux_aio_direct_yes_block_size_4kb_job_count_1_disk_target_default_test_directory_iops",
+          "samples": [531000, 559000],
+          "aggregates": {
+            "p50": 545000,
+            "p95": 557600,
+            "mean": 545000,
+            "stdev": 19798.98987322333,
+            "min": 531000,
+            "max": 559000,
+            "n": 2
+          },
+          "sourceFile": "disk/pts_fio-rand-read.xml",
+          "appVersion": "3.36",
+          "arguments": "randread libaio 1 4k 1"
+        },
+        {
+          "metricId": "fio_type_random_read_engine_linux_aio_direct_yes_block_size_4kb_job_count_1_disk_target_default_test_directory_mb_per_s",
+          "samples": [2073, 2183],
+          "aggregates": {
+            "p50": 2128,
+            "p95": 2177.5,
+            "mean": 2128,
+            "stdev": 77.78174593052023,
+            "min": 2073,
+            "max": 2183,
+            "n": 2
+          },
+          "sourceFile": "disk/pts_fio-rand-read.xml",
+          "appVersion": "3.36",
+          "arguments": "randread libaio 1 4k 1"
+        },
+        {
+          "metricId": "fio_type_random_write_engine_linux_aio_direct_yes_block_size_4kb_job_count_1_disk_target_default_test_directory_iops",
+          "samples": [487000, 492000],
+          "aggregates": {
+            "p50": 489500,
+            "p95": 491750,
+            "mean": 489500,
+            "stdev": 3535.5339059327375,
+            "min": 487000,
+            "max": 492000,
+            "n": 2
+          },
+          "sourceFile": "disk/pts_fio-rand-write.xml",
+          "appVersion": "3.36",
+          "arguments": "randwrite libaio 1 4k 1"
+        },
+        {
+          "metricId": "fio_type_random_write_engine_linux_aio_direct_yes_block_size_4kb_job_count_1_disk_target_default_test_directory_mb_per_s",
+          "samples": [1903, 1921],
+          "aggregates": {
+            "p50": 1912,
+            "p95": 1920.1,
+            "mean": 1912,
+            "stdev": 12.727922061357855,
+            "min": 1903,
+            "max": 1921,
+            "n": 2
+          },
+          "sourceFile": "disk/pts_fio-rand-write.xml",
+          "appVersion": "3.36",
+          "arguments": "randwrite libaio 1 4k 1"
+        },
+        {
+          "metricId": "fio_type_sequential_read_engine_linux_aio_direct_yes_block_size_1mb_job_count_1_disk_target_default_test_directory_iops",
+          "samples": [4313, 4664],
+          "aggregates": {
+            "p50": 4488.5,
+            "p95": 4646.45,
+            "mean": 4488.5,
+            "stdev": 248.19448019647817,
+            "min": 4313,
+            "max": 4664,
+            "n": 2
+          },
+          "sourceFile": "disk/pts_fio-seq-read.xml",
+          "appVersion": "3.36",
+          "arguments": "read libaio 1 1m 1"
+        },
+        {
+          "metricId": "fio_type_sequential_read_engine_linux_aio_direct_yes_block_size_1mb_job_count_1_disk_target_default_test_directory_mb_per_s",
+          "samples": [4315, 4666],
+          "aggregates": {
+            "p50": 4490.5,
+            "p95": 4648.45,
+            "mean": 4490.5,
+            "stdev": 248.19448019647817,
+            "min": 4315,
+            "max": 4666,
+            "n": 2
+          },
+          "sourceFile": "disk/pts_fio-seq-read.xml",
+          "appVersion": "3.36",
+          "arguments": "read libaio 1 1m 1"
+        },
+        {
+          "metricId": "fio_type_sequential_write_engine_linux_aio_direct_yes_block_size_1mb_job_count_1_disk_target_default_test_directory_iops",
+          "samples": [3549, 3592],
+          "aggregates": {
+            "p50": 3570.5,
+            "p95": 3589.85,
+            "mean": 3570.5,
+            "stdev": 30.405591591021544,
+            "min": 3549,
+            "max": 3592,
+            "n": 2
+          },
+          "sourceFile": "disk/pts_fio-seq-write.xml",
+          "appVersion": "3.36",
+          "arguments": "write libaio 1 1m 1"
+        },
+        {
+          "metricId": "fio_type_sequential_write_engine_linux_aio_direct_yes_block_size_1mb_job_count_1_disk_target_default_test_directory_mb_per_s",
+          "samples": [3550, 3593],
+          "aggregates": {
+            "p50": 3571.5,
+            "p95": 3590.85,
+            "mean": 3571.5,
+            "stdev": 30.405591591021544,
+            "min": 3550,
+            "max": 3593,
+            "n": 2
+          },
+          "sourceFile": "disk/pts_fio-seq-write.xml",
+          "appVersion": "3.36",
+          "arguments": "write libaio 1 1m 1"
+        },
+        {
+          "metricId": "git_seconds",
+          "samples": [61.379, 60.602],
+          "aggregates": {
+            "p50": 60.9905,
+            "p95": 61.340149999999994,
+            "mean": 60.9905,
+            "stdev": 0.5494219689819482,
+            "min": 60.602,
+            "max": 61.379,
+            "n": 2
+          },
+          "sourceFile": "system/pts_git.xml"
+        },
+        {
+          "metricId": "hardlink_bogo_ops_per_s",
+          "samples": [11.66, 11.53],
+          "aggregates": {
+            "p50": 11.594999999999999,
+            "p95": 11.6535,
+            "mean": 11.594999999999999,
+            "stdev": 0.09192388155425237,
+            "min": 11.53,
+            "max": 11.66,
+            "n": 2
+          },
+          "sourceFile": "disk/pts_hardlink.xml",
+          "appVersion": "0.16"
+        },
+        {
+          "metricId": "network_loopback_seconds",
+          "samples": [6.395, 6.712],
+          "aggregates": {
+            "p50": 6.5535,
+            "p95": 6.696149999999999,
+            "mean": 6.5535,
+            "stdev": 0.2241528496361357,
+            "min": 6.395,
+            "max": 6.712,
+            "n": 2
+          },
+          "sourceFile": "network/pts_network-loopback.xml"
+        },
+        {
+          "metricId": "node_web_tooling_runs_per_s",
+          "samples": [11.47, 11.97],
+          "aggregates": {
+            "p50": 11.72,
+            "p95": 11.945,
+            "mean": 11.72,
+            "stdev": 0.3535533905932738,
+            "min": 11.47,
+            "max": 11.97,
+            "n": 2
+          },
+          "sourceFile": "cpu-node/pts_node-web-tooling.xml"
+        },
+        {
+          "metricId": "pybench_milliseconds",
+          "samples": [840, 843],
+          "aggregates": {
+            "p50": 841.5,
+            "p95": 842.85,
+            "mean": 841.5,
+            "stdev": 2.1213203435596424,
+            "min": 840,
+            "max": 843,
+            "n": 2
+          },
+          "sourceFile": "system/pts_pybench.xml",
+          "appVersion": "2018-02-16"
+        },
+        {
+          "metricId": "realworld_better_auth_task_build",
+          "samples": [9.952, 10.251],
+          "aggregates": {
+            "p50": 10.1015,
+            "p95": 10.236049999999999,
+            "mean": 10.1015,
+            "stdev": 0.21142492757477735,
+            "min": 9.952,
+            "max": 10.251,
+            "n": 2
+          },
+          "sourceFile": "realworld-better-auth/pts_realworld-better-auth.xml",
+          "appVersion": "6f3ba45639579da152b69e8e5342e02f28288670",
+          "arguments": "build"
+        },
+        {
+          "metricId": "realworld_better_auth_task_cold_install",
+          "samples": [17.536, 16.401],
+          "aggregates": {
+            "p50": 16.9685,
+            "p95": 17.47925,
+            "mean": 16.9685,
+            "stdev": 0.8025661966467338,
+            "min": 16.401,
+            "max": 17.536,
+            "n": 2
+          },
+          "sourceFile": "realworld-better-auth/pts_realworld-better-auth.xml",
+          "appVersion": "6f3ba45639579da152b69e8e5342e02f28288670",
+          "arguments": "cold_install"
+        },
+        {
+          "metricId": "realworld_better_auth_task_git_clone",
+          "samples": [1.556, 1.579],
+          "aggregates": {
+            "p50": 1.5675,
+            "p95": 1.57785,
+            "mean": 1.5675,
+            "stdev": 0.01626345596729061,
+            "min": 1.556,
+            "max": 1.579,
+            "n": 2
+          },
+          "sourceFile": "realworld-better-auth/pts_realworld-better-auth.xml",
+          "appVersion": "6f3ba45639579da152b69e8e5342e02f28288670",
+          "arguments": "git_clone"
+        },
+        {
+          "metricId": "realworld_better_auth_task_lint_biome",
+          "samples": [3.802, 3.59],
+          "aggregates": {
+            "p50": 3.6959999999999997,
+            "p95": 3.7914,
+            "mean": 3.6959999999999997,
+            "stdev": 0.14990663761154835,
+            "min": 3.59,
+            "max": 3.802,
+            "n": 2
+          },
+          "sourceFile": "realworld-better-auth/pts_realworld-better-auth.xml",
+          "appVersion": "6f3ba45639579da152b69e8e5342e02f28288670",
+          "arguments": "lint_biome"
+        },
+        {
+          "metricId": "realworld_better_auth_task_lint_deps_knip",
+          "samples": [15.697, 15.619],
+          "aggregates": {
+            "p50": 15.658,
+            "p95": 15.6931,
+            "mean": 15.658,
+            "stdev": 0.05515432893255029,
+            "min": 15.619,
+            "max": 15.697,
+            "n": 2
+          },
+          "sourceFile": "realworld-better-auth/pts_realworld-better-auth.xml",
+          "appVersion": "6f3ba45639579da152b69e8e5342e02f28288670",
+          "arguments": "lint_deps"
+        },
+        {
+          "metricId": "realworld_better_auth_task_lint_format",
+          "samples": [4.878, 4.673],
+          "aggregates": {
+            "p50": 4.7755,
+            "p95": 4.86775,
+            "mean": 4.7755,
+            "stdev": 0.14495689014324228,
+            "min": 4.673,
+            "max": 4.878,
+            "n": 2
+          },
+          "sourceFile": "realworld-better-auth/pts_realworld-better-auth.xml",
+          "appVersion": "6f3ba45639579da152b69e8e5342e02f28288670",
+          "arguments": "lint_format"
+        },
+        {
+          "metricId": "realworld_better_auth_task_lint_packages",
+          "samples": [3.028, 2.946],
+          "aggregates": {
+            "p50": 2.987,
+            "p95": 3.0239000000000003,
+            "mean": 2.987,
+            "stdev": 0.05798275605729679,
+            "min": 2.946,
+            "max": 3.028,
+            "n": 2
+          },
+          "sourceFile": "realworld-better-auth/pts_realworld-better-auth.xml",
+          "appVersion": "6f3ba45639579da152b69e8e5342e02f28288670",
+          "arguments": "lint_packages"
+        },
+        {
+          "metricId": "realworld_better_auth_task_lint_spell",
+          "samples": [11.702, 11.996],
+          "aggregates": {
+            "p50": 11.849,
+            "p95": 11.981300000000001,
+            "mean": 11.849,
+            "stdev": 0.20788939366884532,
+            "min": 11.702,
+            "max": 11.996,
+            "n": 2
+          },
+          "sourceFile": "realworld-better-auth/pts_realworld-better-auth.xml",
+          "appVersion": "6f3ba45639579da152b69e8e5342e02f28288670",
+          "arguments": "lint_spell"
+        },
+        {
+          "metricId": "realworld_better_auth_task_lint_types",
+          "samples": [30.562, 31.316],
+          "aggregates": {
+            "p50": 30.939,
+            "p95": 31.278299999999998,
+            "mean": 30.939,
+            "stdev": 0.5331585130146553,
+            "min": 30.562,
+            "max": 31.316,
+            "n": 2
+          },
+          "sourceFile": "realworld-better-auth/pts_realworld-better-auth.xml",
+          "appVersion": "6f3ba45639579da152b69e8e5342e02f28288670",
+          "arguments": "lint_types"
+        },
+        {
+          "metricId": "realworld_better_auth_task_typecheck",
+          "samples": [2.101, 2.104],
+          "aggregates": {
+            "p50": 2.1025,
+            "p95": 2.10385,
+            "mean": 2.1025,
+            "stdev": 0.002121320343559723,
+            "min": 2.101,
+            "max": 2.104,
+            "n": 2
+          },
+          "sourceFile": "realworld-better-auth/pts_realworld-better-auth.xml",
+          "appVersion": "6f3ba45639579da152b69e8e5342e02f28288670",
+          "arguments": "typecheck"
+        },
+        {
+          "metricId": "sqlite_speedtest_seconds",
+          "samples": [68.714, 67.445],
+          "aggregates": {
+            "p50": 68.0795,
+            "p95": 68.65055,
+            "mean": 68.0795,
+            "stdev": 0.8973185053257327,
+            "min": 67.445,
+            "max": 68.714,
+            "n": 2
+          },
+          "sourceFile": "system/pts_sqlite-speedtest.xml",
+          "appVersion": "3.30"
+        },
+        {
+          "metricId": "stream_type_add",
+          "samples": [71018.3, 67702.2],
+          "aggregates": {
+            "p50": 69360.25,
+            "p95": 70852.495,
+            "mean": 69360.25,
+            "stdev": 2344.8367970927143,
+            "min": 67702.2,
+            "max": 71018.3,
+            "n": 2
+          },
+          "sourceFile": "memory/pts_stream.xml",
+          "appVersion": "2013-01-17",
+          "arguments": "Add"
+        },
+        {
+          "metricId": "stream_type_copy",
+          "samples": [112396.4, 109559.5],
+          "aggregates": {
+            "p50": 110977.95,
+            "p95": 112254.555,
+            "mean": 110977.95,
+            "stdev": 2005.9912275481126,
+            "min": 109559.5,
+            "max": 112396.4,
+            "n": 2
+          },
+          "sourceFile": "memory/pts_stream.xml",
+          "appVersion": "2013-01-17",
+          "arguments": "Copy"
+        },
+        {
+          "metricId": "stream_type_scale",
+          "samples": [62633.9, 59896.5],
+          "aggregates": {
+            "p50": 61265.2,
+            "p95": 62497.03,
+            "mean": 61265.2,
+            "stdev": 1935.6341028200588,
+            "min": 59896.5,
+            "max": 62633.9,
+            "n": 2
+          },
+          "sourceFile": "memory/pts_stream.xml",
+          "appVersion": "2013-01-17",
+          "arguments": "Scale"
+        },
+        {
+          "metricId": "stream_type_triad",
+          "samples": [70880, 69840.4],
+          "aggregates": {
+            "p50": 70360.2,
+            "p95": 70828.02,
+            "mean": 70360.2,
+            "stdev": 735.1082097215389,
+            "min": 69840.4,
+            "max": 70880,
+            "n": 2
+          },
+          "sourceFile": "memory/pts_stream.xml",
+          "appVersion": "2013-01-17",
+          "arguments": "Triad"
+        }
+      ],
+      "suitesCovered": [
+        "cpu-generic",
+        "cpu-node",
+        "disk",
+        "memory",
+        "network",
+        "realworld-better-auth",
+        "system"
+      ],
+      "gaps": [
+        {
+          "scope": "suite",
+          "id": "network",
+          "outcome": "failed",
+          "reason": "Step \"mise run benchmark:network:all\" failed with exit code 1"
+        },
+        {
+          "scope": "suite",
+          "id": "realworld-mastra",
+          "outcome": "skipped",
+          "reason": "Insufficient disk: 12.5 GiB free, suite needs 30 GiB"
+        },
+        {
+          "scope": "suite",
+          "id": "realworld-openclaw",
+          "outcome": "skipped",
+          "reason": "Insufficient disk: 12.5 GiB free, suite needs 25 GiB"
+        }
+      ],
+      "uncatalogued": []
+    },
+    {
+      "providerId": "daytona",
+      "validationStatus": "validated",
+      "specMatched": true,
+      "observedSpecs": {
+        "cpuModel": "AMD EPYC",
+        "hostVcpus": 2,
+        "hostMemoryGb": 8,
+        "os": "Debian GNU/Linux 13 (trixie)",
+        "kernel": "6.19.14",
+        "virtualization": "kvm",
+        "user": "root",
+        "vcpus": 2,
+        "memoryGb": 7.78,
+        "diskGb": 39.1,
+        "publicIp": "162.43.189.207",
+        "egressOrg": "AS396356 Latitude.sh",
+        "egressAsn": "AS396356",
+        "egressOrgName": "Latitude.sh",
+        "city": "Los Angeles",
+        "region": "California",
+        "country": "US",
+        "location": "34.0522,-118.2437",
+        "timezone": "America/Los_Angeles",
+        "networkPrefix": "162.43.189.0/24",
+        "asnSource": "cymru",
+        "geoSource": "ipinfo"
+      },
+      "hostMetadata": [
+        {
+          "source": "phoronix/result-file-to-json",
+          "sourceFile": "cpu-generic/pts_c-ray--metadata.json",
+          "fields": [
+            {
+              "path": "ci.client_version",
+              "value": "10.8.4"
+            },
+            {
+              "path": "ci.data.compiler-configuration",
+              "value": "--build=x86_64-linux-gnu --disable-vtable-verify --disable-werror --enable-bootstrap --enable-cet --enable-checking=release --enable-clocale=gnu --enable-default-pie --enable-gnu-unique-object --enable-languages=c,ada,c++,go,d,fortran,objc,obj-c++,m2,rust --enable-libphobos-checking=release --enable-libstdcxx-backtrace --enable-libstdcxx-debug --enable-libstdcxx-time=yes --enable-link-serialization=3 --enable-multiarch --enable-multilib --enable-nls --enable-objc-gc=auto --enable-offload-defaulted --enable-offload-targets=nvptx-none=/build/reproducible-path/gcc-14-14.2.0/debian/tmp-nvptx/usr,amdgcn-amdhsa=/build/reproducible-path/gcc-14-14.2.0/debian/tmp-gcn/usr --enable-plugin --enable-shared --enable-threads=posix --host=x86_64-linux-gnu --program-prefix=x86_64-linux-gnu- --target=x86_64-linux-gnu --with-abi=m64 --with-arch-32=i686 --with-build-config=bootstrap-lto-lean --with-default-libstdcxx-abi=new --with-gcc-major-version-only --with-multilib-list=m32,m64,mx32 --with-target-system-zlib=auto --with-tune=generic --without-cuda-driver -v"
+            },
+            {
+              "path": "ci.data.cpu-microcode",
+              "value": "0x1000065"
+            },
+            {
+              "path": "ci.data.kernel-extra-details",
+              "value": "Transparent Huge Pages: madvise"
+            },
+            {
+              "path": "ci.data.security",
+              "value": "gather_data_sampling: Not affected + ghostwrite: Not affected + indirect_target_selection: Not affected + itlb_multihit: Not affected + l1tf: Not affected + mds: Not affected + meltdown: Not affected + mmio_stale_data: Not affected + old_microcode: Not affected + reg_file_data_sampling: Not affected + retbleed: Not affected + spec_rstack_overflow: Vulnerable: Microcode no safe RET + spec_store_bypass: Mitigation of SSB disabled via prctl + spectre_v1: Mitigation of usercopy/swapgs barriers and __user pointer sanitization + spectre_v2: Mitigation of Enhanced / Automatic IBRS; IBPB: conditional; STIBP: disabled; PBRSB-eIBRS: Not affected; BHI: Not affected + srbds: Not affected + tsa: Not affected + tsx_async_abort: Not affected + vmscape: Not affected"
+            },
+            {
+              "path": "ci.hardware.Disk",
+              "value": "40GB"
+            },
+            {
+              "path": "ci.hardware.Memory",
+              "value": "8GB"
+            },
+            {
+              "path": "ci.hardware.Processor",
+              "value": "AMD EPYC (2 Cores)"
+            },
+            {
+              "path": "ci.identifier",
+              "value": "ci"
+            },
+            {
+              "path": "ci.software.Compiler",
+              "value": "GCC 14.2.0"
+            },
+            {
+              "path": "ci.software.File-System",
+              "value": "ext4"
+            },
+            {
+              "path": "ci.software.Kernel",
+              "value": "6.19.14 (x86_64)"
+            },
+            {
+              "path": "ci.software.OS",
+              "value": "Debian GNU/Linux 13"
+            },
+            {
+              "path": "ci.software.System Layer",
+              "value": "KVM"
+            },
+            {
+              "path": "ci.timestamp",
+              "value": "2026-07-17 07:23:13"
+            },
+            {
+              "path": "ci.user",
+              "value": "root"
+            }
+          ]
+        },
+        {
+          "source": "phoronix/result-file-to-json",
+          "sourceFile": "cpu-generic/pts_compress-zstd--metadata.json",
+          "fields": [
+            {
+              "path": "ci.client_version",
+              "value": "10.8.4"
+            },
+            {
+              "path": "ci.data.compiler-configuration",
+              "value": "--build=x86_64-linux-gnu --disable-vtable-verify --disable-werror --enable-bootstrap --enable-cet --enable-checking=release --enable-clocale=gnu --enable-default-pie --enable-gnu-unique-object --enable-languages=c,ada,c++,go,d,fortran,objc,obj-c++,m2,rust --enable-libphobos-checking=release --enable-libstdcxx-backtrace --enable-libstdcxx-debug --enable-libstdcxx-time=yes --enable-link-serialization=3 --enable-multiarch --enable-multilib --enable-nls --enable-objc-gc=auto --enable-offload-defaulted --enable-offload-targets=nvptx-none=/build/reproducible-path/gcc-14-14.2.0/debian/tmp-nvptx/usr,amdgcn-amdhsa=/build/reproducible-path/gcc-14-14.2.0/debian/tmp-gcn/usr --enable-plugin --enable-shared --enable-threads=posix --host=x86_64-linux-gnu --program-prefix=x86_64-linux-gnu- --target=x86_64-linux-gnu --with-abi=m64 --with-arch-32=i686 --with-build-config=bootstrap-lto-lean --with-default-libstdcxx-abi=new --with-gcc-major-version-only --with-multilib-list=m32,m64,mx32 --with-target-system-zlib=auto --with-tune=generic --without-cuda-driver -v"
+            },
+            {
+              "path": "ci.data.cpu-microcode",
+              "value": "0x1000065"
+            },
+            {
+              "path": "ci.data.kernel-extra-details",
+              "value": "Transparent Huge Pages: madvise"
+            },
+            {
+              "path": "ci.data.security",
+              "value": "gather_data_sampling: Not affected + ghostwrite: Not affected + indirect_target_selection: Not affected + itlb_multihit: Not affected + l1tf: Not affected + mds: Not affected + meltdown: Not affected + mmio_stale_data: Not affected + old_microcode: Not affected + reg_file_data_sampling: Not affected + retbleed: Not affected + spec_rstack_overflow: Vulnerable: Microcode no safe RET + spec_store_bypass: Mitigation of SSB disabled via prctl + spectre_v1: Mitigation of usercopy/swapgs barriers and __user pointer sanitization + spectre_v2: Mitigation of Enhanced / Automatic IBRS; IBPB: conditional; STIBP: disabled; PBRSB-eIBRS: Not affected; BHI: Not affected + srbds: Not affected + tsa: Not affected + tsx_async_abort: Not affected + vmscape: Not affected"
+            },
+            {
+              "path": "ci.hardware.Disk",
+              "value": "40GB"
+            },
+            {
+              "path": "ci.hardware.Memory",
+              "value": "8GB"
+            },
+            {
+              "path": "ci.hardware.Processor",
+              "value": "AMD EPYC (2 Cores)"
+            },
+            {
+              "path": "ci.identifier",
+              "value": "ci"
+            },
+            {
+              "path": "ci.software.Compiler",
+              "value": "GCC 14.2.0"
+            },
+            {
+              "path": "ci.software.File-System",
+              "value": "ext4"
+            },
+            {
+              "path": "ci.software.Kernel",
+              "value": "6.19.14 (x86_64)"
+            },
+            {
+              "path": "ci.software.OS",
+              "value": "Debian GNU/Linux 13"
+            },
+            {
+              "path": "ci.software.System Layer",
+              "value": "KVM"
+            },
+            {
+              "path": "ci.timestamp",
+              "value": "2026-07-17 08:44:42"
+            },
+            {
+              "path": "ci.user",
+              "value": "root"
+            }
+          ]
+        },
+        {
+          "source": "phoronix/result-file-to-json",
+          "sourceFile": "cpu-node/pts_node-web-tooling--metadata.json",
+          "fields": [
+            {
+              "path": "ci.client_version",
+              "value": "10.8.4"
+            },
+            {
+              "path": "ci.data.cpu-microcode",
+              "value": "0x1000065"
+            },
+            {
+              "path": "ci.data.kernel-extra-details",
+              "value": "Transparent Huge Pages: madvise"
+            },
+            {
+              "path": "ci.data.security",
+              "value": "gather_data_sampling: Not affected + ghostwrite: Not affected + indirect_target_selection: Not affected + itlb_multihit: Not affected + l1tf: Not affected + mds: Not affected + meltdown: Not affected + mmio_stale_data: Not affected + old_microcode: Not affected + reg_file_data_sampling: Not affected + retbleed: Not affected + spec_rstack_overflow: Vulnerable: Microcode no safe RET + spec_store_bypass: Mitigation of SSB disabled via prctl + spectre_v1: Mitigation of usercopy/swapgs barriers and __user pointer sanitization + spectre_v2: Mitigation of Enhanced / Automatic IBRS; IBPB: conditional; STIBP: disabled; PBRSB-eIBRS: Not affected; BHI: Not affected + srbds: Not affected + tsa: Not affected + tsx_async_abort: Not affected + vmscape: Not affected"
+            },
+            {
+              "path": "ci.hardware.Disk",
+              "value": "40GB"
+            },
+            {
+              "path": "ci.hardware.Memory",
+              "value": "8GB"
+            },
+            {
+              "path": "ci.hardware.Processor",
+              "value": "AMD EPYC (2 Cores)"
+            },
+            {
+              "path": "ci.identifier",
+              "value": "ci"
+            },
+            {
+              "path": "ci.software.Compiler",
+              "value": "GCC 14.2.0"
+            },
+            {
+              "path": "ci.software.File-System",
+              "value": "ext4"
+            },
+            {
+              "path": "ci.software.Kernel",
+              "value": "6.19.14 (x86_64)"
+            },
+            {
+              "path": "ci.software.OS",
+              "value": "Debian GNU/Linux 13"
+            },
+            {
+              "path": "ci.software.System Layer",
+              "value": "KVM"
+            },
+            {
+              "path": "ci.timestamp",
+              "value": "2026-07-17 07:23:20"
+            },
+            {
+              "path": "ci.user",
+              "value": "root"
+            }
+          ]
+        },
+        {
+          "source": "phoronix/result-file-to-json",
+          "sourceFile": "disk/pts_fio-rand-read--metadata.json",
+          "fields": [
+            {
+              "path": "ci.client_version",
+              "value": "10.8.4"
+            },
+            {
+              "path": "ci.data.compiler-configuration",
+              "value": "--build=x86_64-linux-gnu --disable-vtable-verify --disable-werror --enable-bootstrap --enable-cet --enable-checking=release --enable-clocale=gnu --enable-default-pie --enable-gnu-unique-object --enable-languages=c,ada,c++,go,d,fortran,objc,obj-c++,m2,rust --enable-libphobos-checking=release --enable-libstdcxx-backtrace --enable-libstdcxx-debug --enable-libstdcxx-time=yes --enable-link-serialization=3 --enable-multiarch --enable-multilib --enable-nls --enable-objc-gc=auto --enable-offload-defaulted --enable-offload-targets=nvptx-none=/build/reproducible-path/gcc-14-14.2.0/debian/tmp-nvptx/usr,amdgcn-amdhsa=/build/reproducible-path/gcc-14-14.2.0/debian/tmp-gcn/usr --enable-plugin --enable-shared --enable-threads=posix --host=x86_64-linux-gnu --program-prefix=x86_64-linux-gnu- --target=x86_64-linux-gnu --with-abi=m64 --with-arch-32=i686 --with-build-config=bootstrap-lto-lean --with-default-libstdcxx-abi=new --with-gcc-major-version-only --with-multilib-list=m32,m64,mx32 --with-target-system-zlib=auto --with-tune=generic --without-cuda-driver -v"
+            },
+            {
+              "path": "ci.data.cpu-microcode",
+              "value": "0x1000065"
+            },
+            {
+              "path": "ci.data.disk-details",
+              "value": "Block Size: 4096"
+            },
+            {
+              "path": "ci.data.disk-mount-options",
+              "value": "relatime,rw"
+            },
+            {
+              "path": "ci.data.kernel-extra-details",
+              "value": "Transparent Huge Pages: madvise"
+            },
+            {
+              "path": "ci.data.security",
+              "value": "gather_data_sampling: Not affected + ghostwrite: Not affected + indirect_target_selection: Not affected + itlb_multihit: Not affected + l1tf: Not affected + mds: Not affected + meltdown: Not affected + mmio_stale_data: Not affected + old_microcode: Not affected + reg_file_data_sampling: Not affected + retbleed: Not affected + spec_rstack_overflow: Vulnerable: Microcode no safe RET + spec_store_bypass: Mitigation of SSB disabled via prctl + spectre_v1: Mitigation of usercopy/swapgs barriers and __user pointer sanitization + spectre_v2: Mitigation of Enhanced / Automatic IBRS; IBPB: conditional; STIBP: disabled; PBRSB-eIBRS: Not affected; BHI: Not affected + srbds: Not affected + tsa: Not affected + tsx_async_abort: Not affected + vmscape: Not affected"
+            },
+            {
+              "path": "ci.hardware.Disk",
+              "value": "40GB"
+            },
+            {
+              "path": "ci.hardware.Memory",
+              "value": "8GB"
+            },
+            {
+              "path": "ci.hardware.Processor",
+              "value": "AMD EPYC (2 Cores)"
+            },
+            {
+              "path": "ci.identifier",
+              "value": "ci"
+            },
+            {
+              "path": "ci.software.Compiler",
+              "value": "GCC 14.2.0"
+            },
+            {
+              "path": "ci.software.File-System",
+              "value": "ext4"
+            },
+            {
+              "path": "ci.software.Kernel",
+              "value": "6.19.14 (x86_64)"
+            },
+            {
+              "path": "ci.software.OS",
+              "value": "Debian GNU/Linux 13"
+            },
+            {
+              "path": "ci.software.System Layer",
+              "value": "KVM"
+            },
+            {
+              "path": "ci.timestamp",
+              "value": "2026-07-17 07:29:54"
+            },
+            {
+              "path": "ci.user",
+              "value": "root"
+            }
+          ]
+        },
+        {
+          "source": "phoronix/result-file-to-json",
+          "sourceFile": "disk/pts_fio-rand-write--metadata.json",
+          "fields": [
+            {
+              "path": "ci.client_version",
+              "value": "10.8.4"
+            },
+            {
+              "path": "ci.data.compiler-configuration",
+              "value": "--build=x86_64-linux-gnu --disable-vtable-verify --disable-werror --enable-bootstrap --enable-cet --enable-checking=release --enable-clocale=gnu --enable-default-pie --enable-gnu-unique-object --enable-languages=c,ada,c++,go,d,fortran,objc,obj-c++,m2,rust --enable-libphobos-checking=release --enable-libstdcxx-backtrace --enable-libstdcxx-debug --enable-libstdcxx-time=yes --enable-link-serialization=3 --enable-multiarch --enable-multilib --enable-nls --enable-objc-gc=auto --enable-offload-defaulted --enable-offload-targets=nvptx-none=/build/reproducible-path/gcc-14-14.2.0/debian/tmp-nvptx/usr,amdgcn-amdhsa=/build/reproducible-path/gcc-14-14.2.0/debian/tmp-gcn/usr --enable-plugin --enable-shared --enable-threads=posix --host=x86_64-linux-gnu --program-prefix=x86_64-linux-gnu- --target=x86_64-linux-gnu --with-abi=m64 --with-arch-32=i686 --with-build-config=bootstrap-lto-lean --with-default-libstdcxx-abi=new --with-gcc-major-version-only --with-multilib-list=m32,m64,mx32 --with-target-system-zlib=auto --with-tune=generic --without-cuda-driver -v"
+            },
+            {
+              "path": "ci.data.cpu-microcode",
+              "value": "0x1000065"
+            },
+            {
+              "path": "ci.data.disk-details",
+              "value": "Block Size: 4096"
+            },
+            {
+              "path": "ci.data.disk-mount-options",
+              "value": "relatime,rw"
+            },
+            {
+              "path": "ci.data.kernel-extra-details",
+              "value": "Transparent Huge Pages: madvise"
+            },
+            {
+              "path": "ci.data.security",
+              "value": "gather_data_sampling: Not affected + ghostwrite: Not affected + indirect_target_selection: Not affected + itlb_multihit: Not affected + l1tf: Not affected + mds: Not affected + meltdown: Not affected + mmio_stale_data: Not affected + old_microcode: Not affected + reg_file_data_sampling: Not affected + retbleed: Not affected + spec_rstack_overflow: Vulnerable: Microcode no safe RET + spec_store_bypass: Mitigation of SSB disabled via prctl + spectre_v1: Mitigation of usercopy/swapgs barriers and __user pointer sanitization + spectre_v2: Mitigation of Enhanced / Automatic IBRS; IBPB: conditional; STIBP: disabled; PBRSB-eIBRS: Not affected; BHI: Not affected + srbds: Not affected + tsa: Not affected + tsx_async_abort: Not affected + vmscape: Not affected"
+            },
+            {
+              "path": "ci.hardware.Disk",
+              "value": "40GB"
+            },
+            {
+              "path": "ci.hardware.Memory",
+              "value": "8GB"
+            },
+            {
+              "path": "ci.hardware.Processor",
+              "value": "AMD EPYC (2 Cores)"
+            },
+            {
+              "path": "ci.identifier",
+              "value": "ci"
+            },
+            {
+              "path": "ci.software.Compiler",
+              "value": "GCC 14.2.0"
+            },
+            {
+              "path": "ci.software.File-System",
+              "value": "ext4"
+            },
+            {
+              "path": "ci.software.Kernel",
+              "value": "6.19.14 (x86_64)"
+            },
+            {
+              "path": "ci.software.OS",
+              "value": "Debian GNU/Linux 13"
+            },
+            {
+              "path": "ci.software.System Layer",
+              "value": "KVM"
+            },
+            {
+              "path": "ci.timestamp",
+              "value": "2026-07-17 07:33:05"
+            },
+            {
+              "path": "ci.user",
+              "value": "root"
+            }
+          ]
+        },
+        {
+          "source": "phoronix/result-file-to-json",
+          "sourceFile": "disk/pts_fio-seq-read--metadata.json",
+          "fields": [
+            {
+              "path": "ci.client_version",
+              "value": "10.8.4"
+            },
+            {
+              "path": "ci.data.compiler-configuration",
+              "value": "--build=x86_64-linux-gnu --disable-vtable-verify --disable-werror --enable-bootstrap --enable-cet --enable-checking=release --enable-clocale=gnu --enable-default-pie --enable-gnu-unique-object --enable-languages=c,ada,c++,go,d,fortran,objc,obj-c++,m2,rust --enable-libphobos-checking=release --enable-libstdcxx-backtrace --enable-libstdcxx-debug --enable-libstdcxx-time=yes --enable-link-serialization=3 --enable-multiarch --enable-multilib --enable-nls --enable-objc-gc=auto --enable-offload-defaulted --enable-offload-targets=nvptx-none=/build/reproducible-path/gcc-14-14.2.0/debian/tmp-nvptx/usr,amdgcn-amdhsa=/build/reproducible-path/gcc-14-14.2.0/debian/tmp-gcn/usr --enable-plugin --enable-shared --enable-threads=posix --host=x86_64-linux-gnu --program-prefix=x86_64-linux-gnu- --target=x86_64-linux-gnu --with-abi=m64 --with-arch-32=i686 --with-build-config=bootstrap-lto-lean --with-default-libstdcxx-abi=new --with-gcc-major-version-only --with-multilib-list=m32,m64,mx32 --with-target-system-zlib=auto --with-tune=generic --without-cuda-driver -v"
+            },
+            {
+              "path": "ci.data.cpu-microcode",
+              "value": "0x1000065"
+            },
+            {
+              "path": "ci.data.disk-details",
+              "value": "Block Size: 4096"
+            },
+            {
+              "path": "ci.data.disk-mount-options",
+              "value": "relatime,rw"
+            },
+            {
+              "path": "ci.data.kernel-extra-details",
+              "value": "Transparent Huge Pages: madvise"
+            },
+            {
+              "path": "ci.data.security",
+              "value": "gather_data_sampling: Not affected + ghostwrite: Not affected + indirect_target_selection: Not affected + itlb_multihit: Not affected + l1tf: Not affected + mds: Not affected + meltdown: Not affected + mmio_stale_data: Not affected + old_microcode: Not affected + reg_file_data_sampling: Not affected + retbleed: Not affected + spec_rstack_overflow: Vulnerable: Microcode no safe RET + spec_store_bypass: Mitigation of SSB disabled via prctl + spectre_v1: Mitigation of usercopy/swapgs barriers and __user pointer sanitization + spectre_v2: Mitigation of Enhanced / Automatic IBRS; IBPB: conditional; STIBP: disabled; PBRSB-eIBRS: Not affected; BHI: Not affected + srbds: Not affected + tsa: Not affected + tsx_async_abort: Not affected + vmscape: Not affected"
+            },
+            {
+              "path": "ci.hardware.Disk",
+              "value": "40GB"
+            },
+            {
+              "path": "ci.hardware.Memory",
+              "value": "8GB"
+            },
+            {
+              "path": "ci.hardware.Processor",
+              "value": "AMD EPYC (2 Cores)"
+            },
+            {
+              "path": "ci.identifier",
+              "value": "ci"
+            },
+            {
+              "path": "ci.software.Compiler",
+              "value": "GCC 14.2.0"
+            },
+            {
+              "path": "ci.software.File-System",
+              "value": "ext4"
+            },
+            {
+              "path": "ci.software.Kernel",
+              "value": "6.19.14 (x86_64)"
+            },
+            {
+              "path": "ci.software.OS",
+              "value": "Debian GNU/Linux 13"
+            },
+            {
+              "path": "ci.software.System Layer",
+              "value": "KVM"
+            },
+            {
+              "path": "ci.timestamp",
+              "value": "2026-07-17 07:23:16"
+            },
+            {
+              "path": "ci.user",
+              "value": "root"
+            }
+          ]
+        },
+        {
+          "source": "phoronix/result-file-to-json",
+          "sourceFile": "disk/pts_fio-seq-write--metadata.json",
+          "fields": [
+            {
+              "path": "ci.client_version",
+              "value": "10.8.4"
+            },
+            {
+              "path": "ci.data.compiler-configuration",
+              "value": "--build=x86_64-linux-gnu --disable-vtable-verify --disable-werror --enable-bootstrap --enable-cet --enable-checking=release --enable-clocale=gnu --enable-default-pie --enable-gnu-unique-object --enable-languages=c,ada,c++,go,d,fortran,objc,obj-c++,m2,rust --enable-libphobos-checking=release --enable-libstdcxx-backtrace --enable-libstdcxx-debug --enable-libstdcxx-time=yes --enable-link-serialization=3 --enable-multiarch --enable-multilib --enable-nls --enable-objc-gc=auto --enable-offload-defaulted --enable-offload-targets=nvptx-none=/build/reproducible-path/gcc-14-14.2.0/debian/tmp-nvptx/usr,amdgcn-amdhsa=/build/reproducible-path/gcc-14-14.2.0/debian/tmp-gcn/usr --enable-plugin --enable-shared --enable-threads=posix --host=x86_64-linux-gnu --program-prefix=x86_64-linux-gnu- --target=x86_64-linux-gnu --with-abi=m64 --with-arch-32=i686 --with-build-config=bootstrap-lto-lean --with-default-libstdcxx-abi=new --with-gcc-major-version-only --with-multilib-list=m32,m64,mx32 --with-target-system-zlib=auto --with-tune=generic --without-cuda-driver -v"
+            },
+            {
+              "path": "ci.data.cpu-microcode",
+              "value": "0x1000065"
+            },
+            {
+              "path": "ci.data.disk-details",
+              "value": "Block Size: 4096"
+            },
+            {
+              "path": "ci.data.disk-mount-options",
+              "value": "relatime,rw"
+            },
+            {
+              "path": "ci.data.kernel-extra-details",
+              "value": "Transparent Huge Pages: madvise"
+            },
+            {
+              "path": "ci.data.security",
+              "value": "gather_data_sampling: Not affected + ghostwrite: Not affected + indirect_target_selection: Not affected + itlb_multihit: Not affected + l1tf: Not affected + mds: Not affected + meltdown: Not affected + mmio_stale_data: Not affected + old_microcode: Not affected + reg_file_data_sampling: Not affected + retbleed: Not affected + spec_rstack_overflow: Vulnerable: Microcode no safe RET + spec_store_bypass: Mitigation of SSB disabled via prctl + spectre_v1: Mitigation of usercopy/swapgs barriers and __user pointer sanitization + spectre_v2: Mitigation of Enhanced / Automatic IBRS; IBPB: conditional; STIBP: disabled; PBRSB-eIBRS: Not affected; BHI: Not affected + srbds: Not affected + tsa: Not affected + tsx_async_abort: Not affected + vmscape: Not affected"
+            },
+            {
+              "path": "ci.hardware.Disk",
+              "value": "40GB"
+            },
+            {
+              "path": "ci.hardware.Memory",
+              "value": "8GB"
+            },
+            {
+              "path": "ci.hardware.Processor",
+              "value": "AMD EPYC (2 Cores)"
+            },
+            {
+              "path": "ci.identifier",
+              "value": "ci"
+            },
+            {
+              "path": "ci.software.Compiler",
+              "value": "GCC 14.2.0"
+            },
+            {
+              "path": "ci.software.File-System",
+              "value": "ext4"
+            },
+            {
+              "path": "ci.software.Kernel",
+              "value": "6.19.14 (x86_64)"
+            },
+            {
+              "path": "ci.software.OS",
+              "value": "Debian GNU/Linux 13"
+            },
+            {
+              "path": "ci.software.System Layer",
+              "value": "KVM"
+            },
+            {
+              "path": "ci.timestamp",
+              "value": "2026-07-17 07:26:26"
+            },
+            {
+              "path": "ci.user",
+              "value": "root"
+            }
+          ]
+        },
+        {
+          "source": "phoronix/result-file-to-json",
+          "sourceFile": "disk/pts_hardlink--metadata.json",
+          "fields": [
+            {
+              "path": "ci.client_version",
+              "value": "10.8.4"
+            },
+            {
+              "path": "ci.data.compiler-configuration",
+              "value": "--build=x86_64-linux-gnu --disable-vtable-verify --disable-werror --enable-bootstrap --enable-cet --enable-checking=release --enable-clocale=gnu --enable-default-pie --enable-gnu-unique-object --enable-languages=c,ada,c++,go,d,fortran,objc,obj-c++,m2,rust --enable-libphobos-checking=release --enable-libstdcxx-backtrace --enable-libstdcxx-debug --enable-libstdcxx-time=yes --enable-link-serialization=3 --enable-multiarch --enable-multilib --enable-nls --enable-objc-gc=auto --enable-offload-defaulted --enable-offload-targets=nvptx-none=/build/reproducible-path/gcc-14-14.2.0/debian/tmp-nvptx/usr,amdgcn-amdhsa=/build/reproducible-path/gcc-14-14.2.0/debian/tmp-gcn/usr --enable-plugin --enable-shared --enable-threads=posix --host=x86_64-linux-gnu --program-prefix=x86_64-linux-gnu- --target=x86_64-linux-gnu --with-abi=m64 --with-arch-32=i686 --with-build-config=bootstrap-lto-lean --with-default-libstdcxx-abi=new --with-gcc-major-version-only --with-multilib-list=m32,m64,mx32 --with-target-system-zlib=auto --with-tune=generic --without-cuda-driver -v"
+            },
+            {
+              "path": "ci.data.cpu-microcode",
+              "value": "0x1000065"
+            },
+            {
+              "path": "ci.data.disk-details",
+              "value": "Block Size: 4096"
+            },
+            {
+              "path": "ci.data.disk-mount-options",
+              "value": "relatime,rw"
+            },
+            {
+              "path": "ci.data.kernel-extra-details",
+              "value": "Transparent Huge Pages: madvise"
+            },
+            {
+              "path": "ci.data.security",
+              "value": "gather_data_sampling: Not affected + ghostwrite: Not affected + indirect_target_selection: Not affected + itlb_multihit: Not affected + l1tf: Not affected + mds: Not affected + meltdown: Not affected + mmio_stale_data: Not affected + old_microcode: Not affected + reg_file_data_sampling: Not affected + retbleed: Not affected + spec_rstack_overflow: Vulnerable: Microcode no safe RET + spec_store_bypass: Mitigation of SSB disabled via prctl + spectre_v1: Mitigation of usercopy/swapgs barriers and __user pointer sanitization + spectre_v2: Mitigation of Enhanced / Automatic IBRS; IBPB: conditional; STIBP: disabled; PBRSB-eIBRS: Not affected; BHI: Not affected + srbds: Not affected + tsa: Not affected + tsx_async_abort: Not affected + vmscape: Not affected"
+            },
+            {
+              "path": "ci.hardware.Disk",
+              "value": "40GB"
+            },
+            {
+              "path": "ci.hardware.Memory",
+              "value": "8GB"
+            },
+            {
+              "path": "ci.hardware.Processor",
+              "value": "AMD EPYC (2 Cores)"
+            },
+            {
+              "path": "ci.identifier",
+              "value": "ci"
+            },
+            {
+              "path": "ci.software.Compiler",
+              "value": "GCC 14.2.0"
+            },
+            {
+              "path": "ci.software.File-System",
+              "value": "ext4"
+            },
+            {
+              "path": "ci.software.Kernel",
+              "value": "6.19.14 (x86_64)"
+            },
+            {
+              "path": "ci.software.OS",
+              "value": "Debian GNU/Linux 13"
+            },
+            {
+              "path": "ci.software.System Layer",
+              "value": "KVM"
+            },
+            {
+              "path": "ci.timestamp",
+              "value": "2026-07-17 07:36:15"
+            },
+            {
+              "path": "ci.user",
+              "value": "root"
+            }
+          ]
+        },
+        {
+          "source": "phoronix/result-file-to-json",
+          "sourceFile": "memory/pts_stream--metadata.json",
+          "fields": [
+            {
+              "path": "ci.client_version",
+              "value": "10.8.4"
+            },
+            {
+              "path": "ci.data.compiler-configuration",
+              "value": "--build=x86_64-linux-gnu --disable-vtable-verify --disable-werror --enable-bootstrap --enable-cet --enable-checking=release --enable-clocale=gnu --enable-default-pie --enable-gnu-unique-object --enable-languages=c,ada,c++,go,d,fortran,objc,obj-c++,m2,rust --enable-libphobos-checking=release --enable-libstdcxx-backtrace --enable-libstdcxx-debug --enable-libstdcxx-time=yes --enable-link-serialization=3 --enable-multiarch --enable-multilib --enable-nls --enable-objc-gc=auto --enable-offload-defaulted --enable-offload-targets=nvptx-none=/build/reproducible-path/gcc-14-14.2.0/debian/tmp-nvptx/usr,amdgcn-amdhsa=/build/reproducible-path/gcc-14-14.2.0/debian/tmp-gcn/usr --enable-plugin --enable-shared --enable-threads=posix --host=x86_64-linux-gnu --program-prefix=x86_64-linux-gnu- --target=x86_64-linux-gnu --with-abi=m64 --with-arch-32=i686 --with-build-config=bootstrap-lto-lean --with-default-libstdcxx-abi=new --with-gcc-major-version-only --with-multilib-list=m32,m64,mx32 --with-target-system-zlib=auto --with-tune=generic --without-cuda-driver -v"
+            },
+            {
+              "path": "ci.data.cpu-microcode",
+              "value": "0x1000065"
+            },
+            {
+              "path": "ci.data.environment-variables",
+              "value": "CFLAGS_OVERRIDE=\"-O3 -march=native -DSTREAM_ARRAY_SIZE=150000000\""
+            },
+            {
+              "path": "ci.data.kernel-extra-details",
+              "value": "Transparent Huge Pages: madvise"
+            },
+            {
+              "path": "ci.data.security",
+              "value": "gather_data_sampling: Not affected + ghostwrite: Not affected + indirect_target_selection: Not affected + itlb_multihit: Not affected + l1tf: Not affected + mds: Not affected + meltdown: Not affected + mmio_stale_data: Not affected + old_microcode: Not affected + reg_file_data_sampling: Not affected + retbleed: Not affected + spec_rstack_overflow: Vulnerable: Microcode no safe RET + spec_store_bypass: Mitigation of SSB disabled via prctl + spectre_v1: Mitigation of usercopy/swapgs barriers and __user pointer sanitization + spectre_v2: Mitigation of Enhanced / Automatic IBRS; IBPB: conditional; STIBP: disabled; PBRSB-eIBRS: Not affected; BHI: Not affected + srbds: Not affected + tsa: Not affected + tsx_async_abort: Not affected + vmscape: Not affected"
+            },
+            {
+              "path": "ci.hardware.Disk",
+              "value": "40GB"
+            },
+            {
+              "path": "ci.hardware.Memory",
+              "value": "8GB"
+            },
+            {
+              "path": "ci.hardware.Processor",
+              "value": "AMD EPYC (2 Cores)"
+            },
+            {
+              "path": "ci.identifier",
+              "value": "ci"
+            },
+            {
+              "path": "ci.software.Compiler",
+              "value": "GCC 14.2.0"
+            },
+            {
+              "path": "ci.software.File-System",
+              "value": "ext4"
+            },
+            {
+              "path": "ci.software.Kernel",
+              "value": "6.19.14 (x86_64)"
+            },
+            {
+              "path": "ci.software.OS",
+              "value": "Debian GNU/Linux 13"
+            },
+            {
+              "path": "ci.software.System Layer",
+              "value": "KVM"
+            },
+            {
+              "path": "ci.timestamp",
+              "value": "2026-07-17 07:23:13"
+            },
+            {
+              "path": "ci.user",
+              "value": "root"
+            }
+          ]
+        },
+        {
+          "source": "phoronix/result-file-to-json",
+          "sourceFile": "network/pts_network-loopback--metadata.json",
+          "fields": [
+            {
+              "path": "ci.client_version",
+              "value": "10.8.4"
+            },
+            {
+              "path": "ci.data.cpu-microcode",
+              "value": "0x1000065"
+            },
+            {
+              "path": "ci.data.kernel-extra-details",
+              "value": "Transparent Huge Pages: madvise"
+            },
+            {
+              "path": "ci.data.security",
+              "value": "gather_data_sampling: Not affected + ghostwrite: Not affected + indirect_target_selection: Not affected + itlb_multihit: Not affected + l1tf: Not affected + mds: Not affected + meltdown: Not affected + mmio_stale_data: Not affected + old_microcode: Not affected + reg_file_data_sampling: Not affected + retbleed: Not affected + spec_rstack_overflow: Vulnerable: Microcode no safe RET + spec_store_bypass: Mitigation of SSB disabled via prctl + spectre_v1: Mitigation of usercopy/swapgs barriers and __user pointer sanitization + spectre_v2: Mitigation of Enhanced / Automatic IBRS; IBPB: conditional; STIBP: disabled; PBRSB-eIBRS: Not affected; BHI: Not affected + srbds: Not affected + tsa: Not affected + tsx_async_abort: Not affected + vmscape: Not affected"
+            },
+            {
+              "path": "ci.hardware.Disk",
+              "value": "40GB"
+            },
+            {
+              "path": "ci.hardware.Memory",
+              "value": "8GB"
+            },
+            {
+              "path": "ci.hardware.Processor",
+              "value": "AMD EPYC (2 Cores)"
+            },
+            {
+              "path": "ci.identifier",
+              "value": "ci"
+            },
+            {
+              "path": "ci.software.Compiler",
+              "value": "GCC 14.2.0"
+            },
+            {
+              "path": "ci.software.File-System",
+              "value": "ext4"
+            },
+            {
+              "path": "ci.software.Kernel",
+              "value": "6.19.14 (x86_64)"
+            },
+            {
+              "path": "ci.software.OS",
+              "value": "Debian GNU/Linux 13"
+            },
+            {
+              "path": "ci.software.System Layer",
+              "value": "KVM"
+            },
+            {
+              "path": "ci.timestamp",
+              "value": "2026-07-17 07:23:21"
+            },
+            {
+              "path": "ci.user",
+              "value": "root"
+            }
+          ]
+        },
+        {
+          "source": "phoronix/result-file-to-json",
+          "sourceFile": "realworld-better-auth/pts_realworld-better-auth--metadata.json",
+          "fields": [
+            {
+              "path": "ci.client_version",
+              "value": "10.8.4"
+            },
+            {
+              "path": "ci.data.cpu-microcode",
+              "value": "0x1000065"
+            },
+            {
+              "path": "ci.data.kernel-extra-details",
+              "value": "Transparent Huge Pages: madvise"
+            },
+            {
+              "path": "ci.data.security",
+              "value": "gather_data_sampling: Not affected + ghostwrite: Not affected + indirect_target_selection: Not affected + itlb_multihit: Not affected + l1tf: Not affected + mds: Not affected + meltdown: Not affected + mmio_stale_data: Not affected + old_microcode: Not affected + reg_file_data_sampling: Not affected + retbleed: Not affected + spec_rstack_overflow: Vulnerable: Microcode no safe RET + spec_store_bypass: Mitigation of SSB disabled via prctl + spectre_v1: Mitigation of usercopy/swapgs barriers and __user pointer sanitization + spectre_v2: Mitigation of Enhanced / Automatic IBRS; IBPB: conditional; STIBP: disabled; PBRSB-eIBRS: Not affected; BHI: Not affected + srbds: Not affected + tsa: Not affected + tsx_async_abort: Not affected + vmscape: Not affected"
+            },
+            {
+              "path": "ci.hardware.Disk",
+              "value": "40GB"
+            },
+            {
+              "path": "ci.hardware.Memory",
+              "value": "8GB"
+            },
+            {
+              "path": "ci.hardware.Processor",
+              "value": "AMD EPYC (2 Cores)"
+            },
+            {
+              "path": "ci.identifier",
+              "value": "ci"
+            },
+            {
+              "path": "ci.software.Compiler",
+              "value": "GCC 14.2.0"
+            },
+            {
+              "path": "ci.software.File-System",
+              "value": "ext4"
+            },
+            {
+              "path": "ci.software.Kernel",
+              "value": "6.19.14 (x86_64)"
+            },
+            {
+              "path": "ci.software.OS",
+              "value": "Debian GNU/Linux 13"
+            },
+            {
+              "path": "ci.software.System Layer",
+              "value": "KVM"
+            },
+            {
+              "path": "ci.timestamp",
+              "value": "2026-07-17 07:23:36"
+            },
+            {
+              "path": "ci.user",
+              "value": "root"
+            }
+          ]
+        },
+        {
+          "source": "phoronix/result-file-to-json",
+          "sourceFile": "realworld-mastra/pts_realworld-mastra--metadata.json",
+          "fields": [
+            {
+              "path": "ci.client_version",
+              "value": "10.8.4"
+            },
+            {
+              "path": "ci.data.cpu-microcode",
+              "value": "0x1000065"
+            },
+            {
+              "path": "ci.data.kernel-extra-details",
+              "value": "Transparent Huge Pages: madvise"
+            },
+            {
+              "path": "ci.data.security",
+              "value": "gather_data_sampling: Not affected + ghostwrite: Not affected + indirect_target_selection: Not affected + itlb_multihit: Not affected + l1tf: Not affected + mds: Not affected + meltdown: Not affected + mmio_stale_data: Not affected + old_microcode: Not affected + reg_file_data_sampling: Not affected + retbleed: Not affected + spec_rstack_overflow: Vulnerable: Microcode no safe RET + spec_store_bypass: Mitigation of SSB disabled via prctl + spectre_v1: Mitigation of usercopy/swapgs barriers and __user pointer sanitization + spectre_v2: Mitigation of Enhanced / Automatic IBRS; IBPB: conditional; STIBP: disabled; PBRSB-eIBRS: Not affected; BHI: Not affected + srbds: Not affected + tsa: Not affected + tsx_async_abort: Not affected + vmscape: Not affected"
+            },
+            {
+              "path": "ci.hardware.Disk",
+              "value": "40GB"
+            },
+            {
+              "path": "ci.hardware.Memory",
+              "value": "8GB"
+            },
+            {
+              "path": "ci.hardware.Processor",
+              "value": "AMD EPYC (2 Cores)"
+            },
+            {
+              "path": "ci.identifier",
+              "value": "ci"
+            },
+            {
+              "path": "ci.software.Compiler",
+              "value": "GCC 14.2.0"
+            },
+            {
+              "path": "ci.software.File-System",
+              "value": "ext4"
+            },
+            {
+              "path": "ci.software.Kernel",
+              "value": "6.19.14 (x86_64)"
+            },
+            {
+              "path": "ci.software.OS",
+              "value": "Debian GNU/Linux 13"
+            },
+            {
+              "path": "ci.software.System Layer",
+              "value": "KVM"
+            },
+            {
+              "path": "ci.timestamp",
+              "value": "2026-07-17 07:24:34"
+            },
+            {
+              "path": "ci.user",
+              "value": "root"
+            }
+          ]
+        },
+        {
+          "source": "phoronix/result-file-to-json",
+          "sourceFile": "system/pts_git--metadata.json",
+          "fields": [
+            {
+              "path": "ci.client_version",
+              "value": "10.8.4"
+            },
+            {
+              "path": "ci.data.cpu-microcode",
+              "value": "0x1000065"
+            },
+            {
+              "path": "ci.data.kernel-extra-details",
+              "value": "Transparent Huge Pages: madvise"
+            },
+            {
+              "path": "ci.data.security",
+              "value": "gather_data_sampling: Not affected + ghostwrite: Not affected + indirect_target_selection: Not affected + itlb_multihit: Not affected + l1tf: Not affected + mds: Not affected + meltdown: Not affected + mmio_stale_data: Not affected + old_microcode: Not affected + reg_file_data_sampling: Not affected + retbleed: Not affected + spec_rstack_overflow: Vulnerable: Microcode no safe RET + spec_store_bypass: Mitigation of SSB disabled via prctl + spectre_v1: Mitigation of usercopy/swapgs barriers and __user pointer sanitization + spectre_v2: Mitigation of Enhanced / Automatic IBRS; IBPB: conditional; STIBP: disabled; PBRSB-eIBRS: Not affected; BHI: Not affected + srbds: Not affected + tsa: Not affected + tsx_async_abort: Not affected + vmscape: Not affected"
+            },
+            {
+              "path": "ci.hardware.Disk",
+              "value": "40GB"
+            },
+            {
+              "path": "ci.hardware.Memory",
+              "value": "8GB"
+            },
+            {
+              "path": "ci.hardware.Processor",
+              "value": "AMD EPYC (2 Cores)"
+            },
+            {
+              "path": "ci.identifier",
+              "value": "ci"
+            },
+            {
+              "path": "ci.software.Compiler",
+              "value": "GCC 14.2.0"
+            },
+            {
+              "path": "ci.software.File-System",
+              "value": "ext4"
+            },
+            {
+              "path": "ci.software.Kernel",
+              "value": "6.19.14 (x86_64)"
+            },
+            {
+              "path": "ci.software.OS",
+              "value": "Debian GNU/Linux 13"
+            },
+            {
+              "path": "ci.software.System Layer",
+              "value": "KVM"
+            },
+            {
+              "path": "ci.timestamp",
+              "value": "2026-07-17 07:26:05"
+            },
+            {
+              "path": "ci.user",
+              "value": "root"
+            }
+          ]
+        },
+        {
+          "source": "phoronix/result-file-to-json",
+          "sourceFile": "system/pts_pgbench-read-only--metadata.json",
+          "fields": [
+            {
+              "path": "ci.client_version",
+              "value": "10.8.4"
+            },
+            {
+              "path": "ci.data.compiler-configuration",
+              "value": "--build=x86_64-linux-gnu --disable-vtable-verify --disable-werror --enable-bootstrap --enable-cet --enable-checking=release --enable-clocale=gnu --enable-default-pie --enable-gnu-unique-object --enable-languages=c,ada,c++,go,d,fortran,objc,obj-c++,m2,rust --enable-libphobos-checking=release --enable-libstdcxx-backtrace --enable-libstdcxx-debug --enable-libstdcxx-time=yes --enable-link-serialization=3 --enable-multiarch --enable-multilib --enable-nls --enable-objc-gc=auto --enable-offload-defaulted --enable-offload-targets=nvptx-none=/build/reproducible-path/gcc-14-14.2.0/debian/tmp-nvptx/usr,amdgcn-amdhsa=/build/reproducible-path/gcc-14-14.2.0/debian/tmp-gcn/usr --enable-plugin --enable-shared --enable-threads=posix --host=x86_64-linux-gnu --program-prefix=x86_64-linux-gnu- --target=x86_64-linux-gnu --with-abi=m64 --with-arch-32=i686 --with-build-config=bootstrap-lto-lean --with-default-libstdcxx-abi=new --with-gcc-major-version-only --with-multilib-list=m32,m64,mx32 --with-target-system-zlib=auto --with-tune=generic --without-cuda-driver -v"
+            },
+            {
+              "path": "ci.data.cpu-microcode",
+              "value": "0x1000065"
+            },
+            {
+              "path": "ci.data.kernel-extra-details",
+              "value": "Transparent Huge Pages: madvise"
+            },
+            {
+              "path": "ci.data.security",
+              "value": "gather_data_sampling: Not affected + ghostwrite: Not affected + indirect_target_selection: Not affected + itlb_multihit: Not affected + l1tf: Not affected + mds: Not affected + meltdown: Not affected + mmio_stale_data: Not affected + old_microcode: Not affected + reg_file_data_sampling: Not affected + retbleed: Not affected + spec_rstack_overflow: Vulnerable: Microcode no safe RET + spec_store_bypass: Mitigation of SSB disabled via prctl + spectre_v1: Mitigation of usercopy/swapgs barriers and __user pointer sanitization + spectre_v2: Mitigation of Enhanced / Automatic IBRS; IBPB: conditional; STIBP: disabled; PBRSB-eIBRS: Not affected; BHI: Not affected + srbds: Not affected + tsa: Not affected + tsx_async_abort: Not affected + vmscape: Not affected"
+            },
+            {
+              "path": "ci.hardware.Disk",
+              "value": "40GB"
+            },
+            {
+              "path": "ci.hardware.Memory",
+              "value": "8GB"
+            },
+            {
+              "path": "ci.hardware.Processor",
+              "value": "AMD EPYC (2 Cores)"
+            },
+            {
+              "path": "ci.identifier",
+              "value": "ci"
+            },
+            {
+              "path": "ci.software.Compiler",
+              "value": "GCC 14.2.0"
+            },
+            {
+              "path": "ci.software.File-System",
+              "value": "ext4"
+            },
+            {
+              "path": "ci.software.Kernel",
+              "value": "6.19.14 (x86_64)"
+            },
+            {
+              "path": "ci.software.OS",
+              "value": "Debian GNU/Linux 13"
+            },
+            {
+              "path": "ci.software.System Layer",
+              "value": "KVM"
+            },
+            {
+              "path": "ci.timestamp",
+              "value": "2026-07-17 07:24:53"
+            },
+            {
+              "path": "ci.user",
+              "value": "root"
+            }
+          ]
+        },
+        {
+          "source": "phoronix/result-file-to-json",
+          "sourceFile": "system/pts_pgbench-read-write--metadata.json",
+          "fields": [
+            {
+              "path": "ci.client_version",
+              "value": "10.8.4"
+            },
+            {
+              "path": "ci.data.compiler-configuration",
+              "value": "--build=x86_64-linux-gnu --disable-vtable-verify --disable-werror --enable-bootstrap --enable-cet --enable-checking=release --enable-clocale=gnu --enable-default-pie --enable-gnu-unique-object --enable-languages=c,ada,c++,go,d,fortran,objc,obj-c++,m2,rust --enable-libphobos-checking=release --enable-libstdcxx-backtrace --enable-libstdcxx-debug --enable-libstdcxx-time=yes --enable-link-serialization=3 --enable-multiarch --enable-multilib --enable-nls --enable-objc-gc=auto --enable-offload-defaulted --enable-offload-targets=nvptx-none=/build/reproducible-path/gcc-14-14.2.0/debian/tmp-nvptx/usr,amdgcn-amdhsa=/build/reproducible-path/gcc-14-14.2.0/debian/tmp-gcn/usr --enable-plugin --enable-shared --enable-threads=posix --host=x86_64-linux-gnu --program-prefix=x86_64-linux-gnu- --target=x86_64-linux-gnu --with-abi=m64 --with-arch-32=i686 --with-build-config=bootstrap-lto-lean --with-default-libstdcxx-abi=new --with-gcc-major-version-only --with-multilib-list=m32,m64,mx32 --with-target-system-zlib=auto --with-tune=generic --without-cuda-driver -v"
+            },
+            {
+              "path": "ci.data.cpu-microcode",
+              "value": "0x1000065"
+            },
+            {
+              "path": "ci.data.kernel-extra-details",
+              "value": "Transparent Huge Pages: madvise"
+            },
+            {
+              "path": "ci.data.security",
+              "value": "gather_data_sampling: Not affected + ghostwrite: Not affected + indirect_target_selection: Not affected + itlb_multihit: Not affected + l1tf: Not affected + mds: Not affected + meltdown: Not affected + mmio_stale_data: Not affected + old_microcode: Not affected + reg_file_data_sampling: Not affected + retbleed: Not affected + spec_rstack_overflow: Vulnerable: Microcode no safe RET + spec_store_bypass: Mitigation of SSB disabled via prctl + spectre_v1: Mitigation of usercopy/swapgs barriers and __user pointer sanitization + spectre_v2: Mitigation of Enhanced / Automatic IBRS; IBPB: conditional; STIBP: disabled; PBRSB-eIBRS: Not affected; BHI: Not affected + srbds: Not affected + tsa: Not affected + tsx_async_abort: Not affected + vmscape: Not affected"
+            },
+            {
+              "path": "ci.hardware.Disk",
+              "value": "40GB"
+            },
+            {
+              "path": "ci.hardware.Memory",
+              "value": "8GB"
+            },
+            {
+              "path": "ci.hardware.Processor",
+              "value": "AMD EPYC (2 Cores)"
+            },
+            {
+              "path": "ci.identifier",
+              "value": "ci"
+            },
+            {
+              "path": "ci.software.Compiler",
+              "value": "GCC 14.2.0"
+            },
+            {
+              "path": "ci.software.File-System",
+              "value": "ext4"
+            },
+            {
+              "path": "ci.software.Kernel",
+              "value": "6.19.14 (x86_64)"
+            },
+            {
+              "path": "ci.software.OS",
+              "value": "Debian GNU/Linux 13"
+            },
+            {
+              "path": "ci.software.System Layer",
+              "value": "KVM"
+            },
+            {
+              "path": "ci.timestamp",
+              "value": "2026-07-17 07:25:30"
+            },
+            {
+              "path": "ci.user",
+              "value": "root"
+            }
+          ]
+        },
+        {
+          "source": "phoronix/result-file-to-json",
+          "sourceFile": "system/pts_pybench--metadata.json",
+          "fields": [
+            {
+              "path": "ci.client_version",
+              "value": "10.8.4"
+            },
+            {
+              "path": "ci.data.cpu-microcode",
+              "value": "0x1000065"
+            },
+            {
+              "path": "ci.data.kernel-extra-details",
+              "value": "Transparent Huge Pages: madvise"
+            },
+            {
+              "path": "ci.data.python",
+              "value": "mise ERROR python is not a valid shim. This likely means you uninstalled a tool and the shim does not point anything. Run `mise use ` reinstall the tool.mise ERROR : 2026.5.16 linux-x64 (2026-05-28)mise ERROR Run with--verbose or MISE_VERBOSE=1 for more information + mise ERROR python3 is not a valid shim. This likely means you uninstalled a tool and the shim does not point anything. Run `mise use ` reinstall the tool.mise ERROR : 2026.5.16 linux-x64 (2026-05-28)mise ERROR Run with--verbose or MISE_VERBOSE=1 for more information"
+            },
+            {
+              "path": "ci.data.security",
+              "value": "gather_data_sampling: Not affected + ghostwrite: Not affected + indirect_target_selection: Not affected + itlb_multihit: Not affected + l1tf: Not affected + mds: Not affected + meltdown: Not affected + mmio_stale_data: Not affected + old_microcode: Not affected + reg_file_data_sampling: Not affected + retbleed: Not affected + spec_rstack_overflow: Vulnerable: Microcode no safe RET + spec_store_bypass: Mitigation of SSB disabled via prctl + spectre_v1: Mitigation of usercopy/swapgs barriers and __user pointer sanitization + spectre_v2: Mitigation of Enhanced / Automatic IBRS; IBPB: conditional; STIBP: disabled; PBRSB-eIBRS: Not affected; BHI: Not affected + srbds: Not affected + tsa: Not affected + tsx_async_abort: Not affected + vmscape: Not affected"
+            },
+            {
+              "path": "ci.hardware.Disk",
+              "value": "40GB"
+            },
+            {
+              "path": "ci.hardware.Memory",
+              "value": "8GB"
+            },
+            {
+              "path": "ci.hardware.Processor",
+              "value": "AMD EPYC (2 Cores)"
+            },
+            {
+              "path": "ci.identifier",
+              "value": "ci"
+            },
+            {
+              "path": "ci.software.Compiler",
+              "value": "GCC 14.2.0"
+            },
+            {
+              "path": "ci.software.File-System",
+              "value": "ext4"
+            },
+            {
+              "path": "ci.software.Kernel",
+              "value": "6.19.14 (x86_64)"
+            },
+            {
+              "path": "ci.software.OS",
+              "value": "Debian GNU/Linux 13"
+            },
+            {
+              "path": "ci.software.System Layer",
+              "value": "KVM"
+            },
+            {
+              "path": "ci.timestamp",
+              "value": "2026-07-17 07:23:13"
+            },
+            {
+              "path": "ci.user",
+              "value": "root"
+            }
+          ]
+        },
+        {
+          "source": "phoronix/result-file-to-json",
+          "sourceFile": "system/pts_sqlite-speedtest--metadata.json",
+          "fields": [
+            {
+              "path": "ci.client_version",
+              "value": "10.8.4"
+            },
+            {
+              "path": "ci.data.compiler-configuration",
+              "value": "--build=x86_64-linux-gnu --disable-vtable-verify --disable-werror --enable-bootstrap --enable-cet --enable-checking=release --enable-clocale=gnu --enable-default-pie --enable-gnu-unique-object --enable-languages=c,ada,c++,go,d,fortran,objc,obj-c++,m2,rust --enable-libphobos-checking=release --enable-libstdcxx-backtrace --enable-libstdcxx-debug --enable-libstdcxx-time=yes --enable-link-serialization=3 --enable-multiarch --enable-multilib --enable-nls --enable-objc-gc=auto --enable-offload-defaulted --enable-offload-targets=nvptx-none=/build/reproducible-path/gcc-14-14.2.0/debian/tmp-nvptx/usr,amdgcn-amdhsa=/build/reproducible-path/gcc-14-14.2.0/debian/tmp-gcn/usr --enable-plugin --enable-shared --enable-threads=posix --host=x86_64-linux-gnu --program-prefix=x86_64-linux-gnu- --target=x86_64-linux-gnu --with-abi=m64 --with-arch-32=i686 --with-build-config=bootstrap-lto-lean --with-default-libstdcxx-abi=new --with-gcc-major-version-only --with-multilib-list=m32,m64,mx32 --with-target-system-zlib=auto --with-tune=generic --without-cuda-driver -v"
+            },
+            {
+              "path": "ci.data.cpu-microcode",
+              "value": "0x1000065"
+            },
+            {
+              "path": "ci.data.kernel-extra-details",
+              "value": "Transparent Huge Pages: madvise"
+            },
+            {
+              "path": "ci.data.security",
+              "value": "gather_data_sampling: Not affected + ghostwrite: Not affected + indirect_target_selection: Not affected + itlb_multihit: Not affected + l1tf: Not affected + mds: Not affected + meltdown: Not affected + mmio_stale_data: Not affected + old_microcode: Not affected + reg_file_data_sampling: Not affected + retbleed: Not affected + spec_rstack_overflow: Vulnerable: Microcode no safe RET + spec_store_bypass: Mitigation of SSB disabled via prctl + spectre_v1: Mitigation of usercopy/swapgs barriers and __user pointer sanitization + spectre_v2: Mitigation of Enhanced / Automatic IBRS; IBPB: conditional; STIBP: disabled; PBRSB-eIBRS: Not affected; BHI: Not affected + srbds: Not affected + tsa: Not affected + tsx_async_abort: Not affected + vmscape: Not affected"
+            },
+            {
+              "path": "ci.hardware.Disk",
+              "value": "40GB"
+            },
+            {
+              "path": "ci.hardware.Memory",
+              "value": "8GB"
+            },
+            {
+              "path": "ci.hardware.Processor",
+              "value": "AMD EPYC (2 Cores)"
+            },
+            {
+              "path": "ci.identifier",
+              "value": "ci"
+            },
+            {
+              "path": "ci.software.Compiler",
+              "value": "GCC 14.2.0"
+            },
+            {
+              "path": "ci.software.File-System",
+              "value": "ext4"
+            },
+            {
+              "path": "ci.software.Kernel",
+              "value": "6.19.14 (x86_64)"
+            },
+            {
+              "path": "ci.software.OS",
+              "value": "Debian GNU/Linux 13"
+            },
+            {
+              "path": "ci.software.System Layer",
+              "value": "KVM"
+            },
+            {
+              "path": "ci.timestamp",
+              "value": "2026-07-17 07:23:28"
+            },
+            {
+              "path": "ci.user",
+              "value": "root"
+            }
+          ]
+        },
+        {
+          "source": "mise/system-provider",
+          "sourceFile": "system/system-provider.json",
+          "fields": [
+            {
+              "path": "asn",
+              "value": "AS396356"
+            },
+            {
+              "path": "asn_source",
+              "value": "cymru"
+            },
+            {
+              "path": "bios_vendor",
+              "value": ""
+            },
+            {
+              "path": "city",
+              "value": "Los Angeles"
+            },
+            {
+              "path": "cores",
+              "value": "2"
+            },
+            {
+              "path": "country",
+              "value": "US"
+            },
+            {
+              "path": "cpu_model",
+              "value": "AMD EPYC"
+            },
+            {
+              "path": "geo_source",
+              "value": "ipinfo"
+            },
+            {
+              "path": "kernel",
+              "value": "6.19.14"
+            },
+            {
+              "path": "loc",
+              "value": "34.0522,-118.2437"
+            },
+            {
+              "path": "manufacturer",
+              "value": ""
+            },
+            {
+              "path": "org",
+              "value": "AS396356 Latitude.sh"
+            },
+            {
+              "path": "org_name",
+              "value": "Latitude.sh"
+            },
+            {
+              "path": "prefix",
+              "value": "162.43.189.0/24"
+            },
+            {
+              "path": "product_name",
+              "value": ""
+            },
+            {
+              "path": "public_ip",
+              "value": "162.43.189.207"
+            },
+            {
+              "path": "ram",
+              "value": "7.8Gi"
+            },
+            {
+              "path": "region",
+              "value": "California"
+            },
+            {
+              "path": "reverse_dns",
+              "value": ""
+            },
+            {
+              "path": "schema_version",
+              "value": "1.0"
+            },
+            {
+              "path": "timezone",
+              "value": "America/Los_Angeles"
+            },
+            {
+              "path": "virtualization",
+              "value": "kvm"
+            }
+          ]
+        }
+      ],
+      "metrics": [
+        {
+          "metricId": "c_ray_resolution_1080p_rays_per_pixel_16",
+          "samples": [201.065, 200.836],
+          "aggregates": {
+            "p50": 200.9505,
+            "p95": 201.05355,
+            "mean": 200.9505,
+            "stdev": 0.16192745289170876,
+            "min": 200.836,
+            "max": 201.065,
+            "n": 2
+          },
+          "sourceFile": "cpu-generic/pts_c-ray.xml",
+          "appVersion": "2.0",
+          "arguments": "-s 1920x1080 -r 16"
+        },
+        {
+          "metricId": "c_ray_resolution_4k_rays_per_pixel_16",
+          "samples": [801.855, 799.647],
+          "aggregates": {
+            "p50": 800.751,
+            "p95": 801.7446,
+            "mean": 800.751,
+            "stdev": 1.5612917728599158,
+            "min": 799.647,
+            "max": 801.855,
+            "n": 2
+          },
+          "sourceFile": "cpu-generic/pts_c-ray.xml",
+          "appVersion": "2.0",
+          "arguments": "-s 3840x2160 -r 16"
+        },
+        {
+          "metricId": "c_ray_resolution_5k_rays_per_pixel_16",
+          "samples": [1418.356, 1420.164],
+          "aggregates": {
+            "p50": 1419.26,
+            "p95": 1420.0736,
+            "mean": 1419.26,
+            "stdev": 1.2784490603852727,
+            "min": 1418.356,
+            "max": 1420.164,
+            "n": 2
+          },
+          "sourceFile": "cpu-generic/pts_c-ray.xml",
+          "appVersion": "2.0",
+          "arguments": "-s 5120x2880 -r 16"
+        },
+        {
+          "metricId": "compress_zstd_compression_level_12_compression_speed",
+          "samples": [98.6, 98.9],
+          "aggregates": {
+            "p50": 98.75,
+            "p95": 98.885,
+            "mean": 98.75,
+            "stdev": 0.2121320343559723,
+            "min": 98.6,
+            "max": 98.9,
+            "n": 2
+          },
+          "sourceFile": "cpu-generic/pts_compress-zstd.xml",
+          "appVersion": "1.5.4",
+          "arguments": "-b12"
+        },
+        {
+          "metricId": "compress_zstd_compression_level_12_decompression_speed",
+          "samples": [2300.5, 2288.4],
+          "aggregates": {
+            "p50": 2294.45,
+            "p95": 2299.895,
+            "mean": 2294.45,
+            "stdev": 8.555992052357322,
+            "min": 2288.4,
+            "max": 2300.5,
+            "n": 2
+          },
+          "sourceFile": "cpu-generic/pts_compress-zstd.xml",
+          "appVersion": "1.5.4",
+          "arguments": "-b12"
+        },
+        {
+          "metricId": "compress_zstd_compression_level_19_compression_speed",
+          "samples": [8.14, 8.16],
+          "aggregates": {
+            "p50": 8.15,
+            "p95": 8.159,
+            "mean": 8.15,
+            "stdev": 0.014142135623730649,
+            "min": 8.14,
+            "max": 8.16,
+            "n": 2
+          },
+          "sourceFile": "cpu-generic/pts_compress-zstd.xml",
+          "appVersion": "1.5.4",
+          "arguments": "-b19"
+        },
+        {
+          "metricId": "compress_zstd_compression_level_19_decompression_speed",
+          "samples": [1923.4, 1930.7],
+          "aggregates": {
+            "p50": 1927.0500000000002,
+            "p95": 1930.335,
+            "mean": 1927.0500000000002,
+            "stdev": 5.161879502661685,
+            "min": 1923.4,
+            "max": 1930.7,
+            "n": 2
+          },
+          "sourceFile": "cpu-generic/pts_compress-zstd.xml",
+          "appVersion": "1.5.4",
+          "arguments": "-b19"
+        },
+        {
+          "metricId": "compress_zstd_compression_level_19_long_mode_compression_speed",
+          "samples": [7.13, 7.19],
+          "aggregates": {
+            "p50": 7.16,
+            "p95": 7.187,
+            "mean": 7.16,
+            "stdev": 0.0424264068711932,
+            "min": 7.13,
+            "max": 7.19,
+            "n": 2
+          },
+          "sourceFile": "cpu-generic/pts_compress-zstd.xml",
+          "appVersion": "1.5.4",
+          "arguments": "-b19 --long"
+        },
+        {
+          "metricId": "compress_zstd_compression_level_19_long_mode_decompression_speed",
+          "samples": [1849.9, 1868.9],
+          "aggregates": {
+            "p50": 1859.4,
+            "p95": 1867.95,
+            "mean": 1859.4,
+            "stdev": 13.435028842544403,
+            "min": 1849.9,
+            "max": 1868.9,
+            "n": 2
+          },
+          "sourceFile": "cpu-generic/pts_compress-zstd.xml",
+          "appVersion": "1.5.4",
+          "arguments": "-b19 --long"
+        },
+        {
+          "metricId": "compress_zstd_compression_level_3_compression_speed",
+          "samples": [787.5, 787.6],
+          "aggregates": {
+            "p50": 787.55,
+            "p95": 787.595,
+            "mean": 787.55,
+            "stdev": 0.07071067811871103,
+            "min": 787.5,
+            "max": 787.6,
+            "n": 2
+          },
+          "sourceFile": "cpu-generic/pts_compress-zstd.xml",
+          "appVersion": "1.5.4",
+          "arguments": "-b3"
+        },
+        {
+          "metricId": "compress_zstd_compression_level_3_decompression_speed",
+          "samples": [2110.1, 2118.7],
+          "aggregates": {
+            "p50": 2114.3999999999996,
+            "p95": 2118.27,
+            "mean": 2114.3999999999996,
+            "stdev": 6.081118318204405,
+            "min": 2110.1,
+            "max": 2118.7,
+            "n": 2
+          },
+          "sourceFile": "cpu-generic/pts_compress-zstd.xml",
+          "appVersion": "1.5.4",
+          "arguments": "-b3"
+        },
+        {
+          "metricId": "compress_zstd_compression_level_3_long_mode_compression_speed",
+          "samples": [532.1, 536.3],
+          "aggregates": {
+            "p50": 534.2,
+            "p95": 536.0899999999999,
+            "mean": 534.2,
+            "stdev": 2.969848480983411,
+            "min": 532.1,
+            "max": 536.3,
+            "n": 2
+          },
+          "sourceFile": "cpu-generic/pts_compress-zstd.xml",
+          "appVersion": "1.5.4",
+          "arguments": "-b3 --long"
+        },
+        {
+          "metricId": "compress_zstd_compression_level_3_long_mode_decompression_speed",
+          "samples": [2174.5, 2155.8],
+          "aggregates": {
+            "p50": 2165.15,
+            "p95": 2173.565,
+            "mean": 2165.15,
+            "stdev": 13.22289680818831,
+            "min": 2155.8,
+            "max": 2174.5,
+            "n": 2
+          },
+          "sourceFile": "cpu-generic/pts_compress-zstd.xml",
+          "appVersion": "1.5.4",
+          "arguments": "-b3 --long"
+        },
+        {
+          "metricId": "compress_zstd_compression_level_8_compression_speed",
+          "samples": [210.1, 210.9],
+          "aggregates": {
+            "p50": 210.5,
+            "p95": 210.86,
+            "mean": 210.5,
+            "stdev": 0.5656854249492461,
+            "min": 210.1,
+            "max": 210.9,
+            "n": 2
+          },
+          "sourceFile": "cpu-generic/pts_compress-zstd.xml",
+          "appVersion": "1.5.4",
+          "arguments": "-b8"
+        },
+        {
+          "metricId": "compress_zstd_compression_level_8_long_mode_compression_speed",
+          "samples": [203.4, 202.1],
+          "aggregates": {
+            "p50": 202.75,
+            "p95": 203.335,
+            "mean": 202.75,
+            "stdev": 0.9192388155425198,
+            "min": 202.1,
+            "max": 203.4,
+            "n": 2
+          },
+          "sourceFile": "cpu-generic/pts_compress-zstd.xml",
+          "appVersion": "1.5.4",
+          "arguments": "-b8 --long"
+        },
+        {
+          "metricId": "compress_zstd_compression_level_8_long_mode_decompression_speed",
+          "samples": [2326.2, 2300.6],
+          "aggregates": {
+            "p50": 2313.3999999999996,
+            "p95": 2324.9199999999996,
+            "mean": 2313.3999999999996,
+            "stdev": 18.101933598375712,
+            "min": 2300.6,
+            "max": 2326.2,
+            "n": 2
+          },
+          "sourceFile": "cpu-generic/pts_compress-zstd.xml",
+          "appVersion": "1.5.4",
+          "arguments": "-b8 --long"
+        },
+        {
+          "metricId": "fio_type_random_read_engine_linux_aio_direct_yes_block_size_4kb_job_count_1_disk_target_default_test_directory_iops",
+          "samples": [243000, 252000],
+          "aggregates": {
+            "p50": 247500,
+            "p95": 251550,
+            "mean": 247500,
+            "stdev": 6363.961030678927,
+            "min": 243000,
+            "max": 252000,
+            "n": 2
+          },
+          "sourceFile": "disk/pts_fio-rand-read.xml",
+          "appVersion": "3.36",
+          "arguments": "randread libaio 1 4k 1"
+        },
+        {
+          "metricId": "fio_type_random_read_engine_linux_aio_direct_yes_block_size_4kb_job_count_1_disk_target_default_test_directory_mb_per_s",
+          "samples": [949, 986],
+          "aggregates": {
+            "p50": 967.5,
+            "p95": 984.15,
+            "mean": 967.5,
+            "stdev": 26.16295090390226,
+            "min": 949,
+            "max": 986,
+            "n": 2
+          },
+          "sourceFile": "disk/pts_fio-rand-read.xml",
+          "appVersion": "3.36",
+          "arguments": "randread libaio 1 4k 1"
+        },
+        {
+          "metricId": "fio_type_random_write_engine_linux_aio_direct_yes_block_size_4kb_job_count_1_disk_target_default_test_directory_iops",
+          "samples": [231000, 229000],
+          "aggregates": {
+            "p50": 230000,
+            "p95": 230900,
+            "mean": 230000,
+            "stdev": 1414.213562373095,
+            "min": 229000,
+            "max": 231000,
+            "n": 2
+          },
+          "sourceFile": "disk/pts_fio-rand-write.xml",
+          "appVersion": "3.36",
+          "arguments": "randwrite libaio 1 4k 1"
+        },
+        {
+          "metricId": "fio_type_random_write_engine_linux_aio_direct_yes_block_size_4kb_job_count_1_disk_target_default_test_directory_mb_per_s",
+          "samples": [902, 895],
+          "aggregates": {
+            "p50": 898.5,
+            "p95": 901.65,
+            "mean": 898.5,
+            "stdev": 4.949747468305833,
+            "min": 895,
+            "max": 902,
+            "n": 2
+          },
+          "sourceFile": "disk/pts_fio-rand-write.xml",
+          "appVersion": "3.36",
+          "arguments": "randwrite libaio 1 4k 1"
+        },
+        {
+          "metricId": "fio_type_sequential_read_engine_linux_aio_direct_yes_block_size_1mb_job_count_1_disk_target_default_test_directory_iops",
+          "samples": [8499, 7583],
+          "aggregates": {
+            "p50": 8041,
+            "p95": 8453.2,
+            "mean": 8041,
+            "stdev": 647.7098115668775,
+            "min": 7583,
+            "max": 8499,
+            "n": 2
+          },
+          "sourceFile": "disk/pts_fio-seq-read.xml",
+          "appVersion": "3.36",
+          "arguments": "read libaio 1 1m 1"
+        },
+        {
+          "metricId": "fio_type_sequential_read_engine_linux_aio_direct_yes_block_size_1mb_job_count_1_disk_target_default_test_directory_mb_per_s",
+          "samples": [8501, 7585],
+          "aggregates": {
+            "p50": 8043,
+            "p95": 8455.2,
+            "mean": 8043,
+            "stdev": 647.7098115668775,
+            "min": 7585,
+            "max": 8501,
+            "n": 2
+          },
+          "sourceFile": "disk/pts_fio-seq-read.xml",
+          "appVersion": "3.36",
+          "arguments": "read libaio 1 1m 1"
+        },
+        {
+          "metricId": "fio_type_sequential_write_engine_linux_aio_direct_yes_block_size_1mb_job_count_1_disk_target_default_test_directory_iops",
+          "samples": [4778, 4767],
+          "aggregates": {
+            "p50": 4772.5,
+            "p95": 4777.45,
+            "mean": 4772.5,
+            "stdev": 7.7781745930520225,
+            "min": 4767,
+            "max": 4778,
+            "n": 2
+          },
+          "sourceFile": "disk/pts_fio-seq-write.xml",
+          "appVersion": "3.36",
+          "arguments": "write libaio 1 1m 1"
+        },
+        {
+          "metricId": "fio_type_sequential_write_engine_linux_aio_direct_yes_block_size_1mb_job_count_1_disk_target_default_test_directory_mb_per_s",
+          "samples": [4779, 4769],
+          "aggregates": {
+            "p50": 4774,
+            "p95": 4778.5,
+            "mean": 4774,
+            "stdev": 7.0710678118654755,
+            "min": 4769,
+            "max": 4779,
+            "n": 2
+          },
+          "sourceFile": "disk/pts_fio-seq-write.xml",
+          "appVersion": "3.36",
+          "arguments": "write libaio 1 1m 1"
+        },
+        {
+          "metricId": "git_seconds",
+          "samples": [39.133, 39.119],
+          "aggregates": {
+            "p50": 39.126000000000005,
+            "p95": 39.1323,
+            "mean": 39.126000000000005,
+            "stdev": 0.009899494936611204,
+            "min": 39.119,
+            "max": 39.133,
+            "n": 2
+          },
+          "sourceFile": "system/pts_git.xml"
+        },
+        {
+          "metricId": "hardlink_bogo_ops_per_s",
+          "samples": [23.45, 23.09],
+          "aggregates": {
+            "p50": 23.27,
+            "p95": 23.432,
+            "mean": 23.27,
+            "stdev": 0.2545584412271567,
+            "min": 23.09,
+            "max": 23.45,
+            "n": 2
+          },
+          "sourceFile": "disk/pts_hardlink.xml",
+          "appVersion": "0.16"
+        },
+        {
+          "metricId": "network_loopback_seconds",
+          "samples": [5.702, 4.68],
+          "aggregates": {
+            "p50": 5.191,
+            "p95": 5.6509,
+            "mean": 5.191,
+            "stdev": 0.7226631303726517,
+            "min": 4.68,
+            "max": 5.702,
+            "n": 2
+          },
+          "sourceFile": "network/pts_network-loopback.xml"
+        },
+        {
+          "metricId": "node_web_tooling_runs_per_s",
+          "samples": [19.5, 19.36],
+          "aggregates": {
+            "p50": 19.43,
+            "p95": 19.493,
+            "mean": 19.43,
+            "stdev": 0.09899494936611705,
+            "min": 19.36,
+            "max": 19.5,
+            "n": 2
+          },
+          "sourceFile": "cpu-node/pts_node-web-tooling.xml"
+        },
+        {
+          "metricId": "realworld_better_auth_task_build",
+          "samples": [13.482, 13.722],
+          "aggregates": {
+            "p50": 13.602,
+            "p95": 13.709999999999999,
+            "mean": 13.602,
+            "stdev": 0.16970562748477094,
+            "min": 13.482,
+            "max": 13.722,
+            "n": 2
+          },
+          "sourceFile": "realworld-better-auth/pts_realworld-better-auth.xml",
+          "appVersion": "6f3ba45639579da152b69e8e5342e02f28288670",
+          "arguments": "build"
+        },
+        {
+          "metricId": "realworld_better_auth_task_cold_install",
+          "samples": [12.191, 11.611],
+          "aggregates": {
+            "p50": 11.901,
+            "p95": 12.162,
+            "mean": 11.901,
+            "stdev": 0.4101219330881982,
+            "min": 11.611,
+            "max": 12.191,
+            "n": 2
+          },
+          "sourceFile": "realworld-better-auth/pts_realworld-better-auth.xml",
+          "appVersion": "6f3ba45639579da152b69e8e5342e02f28288670",
+          "arguments": "cold_install"
+        },
+        {
+          "metricId": "realworld_better_auth_task_git_clone",
+          "samples": [1.687, 1.688],
+          "aggregates": {
+            "p50": 1.6875,
+            "p95": 1.6879499999999998,
+            "mean": 1.6875,
+            "stdev": 0.0007071067811864697,
+            "min": 1.687,
+            "max": 1.688,
+            "n": 2
+          },
+          "sourceFile": "realworld-better-auth/pts_realworld-better-auth.xml",
+          "appVersion": "6f3ba45639579da152b69e8e5342e02f28288670",
+          "arguments": "git_clone"
+        },
+        {
+          "metricId": "realworld_better_auth_task_lint_biome",
+          "samples": [5.135, 5.011],
+          "aggregates": {
+            "p50": 5.073,
+            "p95": 5.1288,
+            "mean": 5.073,
+            "stdev": 0.08768124086713135,
+            "min": 5.011,
+            "max": 5.135,
+            "n": 2
+          },
+          "sourceFile": "realworld-better-auth/pts_realworld-better-auth.xml",
+          "appVersion": "6f3ba45639579da152b69e8e5342e02f28288670",
+          "arguments": "lint_biome"
+        },
+        {
+          "metricId": "realworld_better_auth_task_lint_deps_knip",
+          "samples": [10.886, 11.486],
+          "aggregates": {
+            "p50": 11.186,
+            "p95": 11.456000000000001,
+            "mean": 11.186,
+            "stdev": 0.4242640687119295,
+            "min": 10.886,
+            "max": 11.486,
+            "n": 2
+          },
+          "sourceFile": "realworld-better-auth/pts_realworld-better-auth.xml",
+          "appVersion": "6f3ba45639579da152b69e8e5342e02f28288670",
+          "arguments": "lint_deps"
+        },
+        {
+          "metricId": "realworld_better_auth_task_lint_format",
+          "samples": [2.885, 2.912],
+          "aggregates": {
+            "p50": 2.8985,
+            "p95": 2.91065,
+            "mean": 2.8985,
+            "stdev": 0.01909188309203688,
+            "min": 2.885,
+            "max": 2.912,
+            "n": 2
+          },
+          "sourceFile": "realworld-better-auth/pts_realworld-better-auth.xml",
+          "appVersion": "6f3ba45639579da152b69e8e5342e02f28288670",
+          "arguments": "lint_format"
+        },
+        {
+          "metricId": "realworld_better_auth_task_lint_packages",
+          "samples": [4.014, 4.013],
+          "aggregates": {
+            "p50": 4.0135000000000005,
+            "p95": 4.01395,
+            "mean": 4.0135000000000005,
+            "stdev": 0.0007071067811864697,
+            "min": 4.013,
+            "max": 4.014,
+            "n": 2
+          },
+          "sourceFile": "realworld-better-auth/pts_realworld-better-auth.xml",
+          "appVersion": "6f3ba45639579da152b69e8e5342e02f28288670",
+          "arguments": "lint_packages"
+        },
+        {
+          "metricId": "realworld_better_auth_task_lint_spell",
+          "samples": [6.801, 6.944],
+          "aggregates": {
+            "p50": 6.8725000000000005,
+            "p95": 6.93685,
+            "mean": 6.8725000000000005,
+            "stdev": 0.10111626970967584,
+            "min": 6.801,
+            "max": 6.944,
+            "n": 2
+          },
+          "sourceFile": "realworld-better-auth/pts_realworld-better-auth.xml",
+          "appVersion": "6f3ba45639579da152b69e8e5342e02f28288670",
+          "arguments": "lint_spell"
+        },
+        {
+          "metricId": "realworld_better_auth_task_lint_types",
+          "samples": [54.574, 51.827],
+          "aggregates": {
+            "p50": 53.2005,
+            "p95": 54.43665,
+            "mean": 53.2005,
+            "stdev": 1.942422327919446,
+            "min": 51.827,
+            "max": 54.574,
+            "n": 2
+          },
+          "sourceFile": "realworld-better-auth/pts_realworld-better-auth.xml",
+          "appVersion": "6f3ba45639579da152b69e8e5342e02f28288670",
+          "arguments": "lint_types"
+        },
+        {
+          "metricId": "realworld_better_auth_task_typecheck",
+          "samples": [1.407, 1.436],
+          "aggregates": {
+            "p50": 1.4215,
+            "p95": 1.43455,
+            "mean": 1.4215,
+            "stdev": 0.02050609665440982,
+            "min": 1.407,
+            "max": 1.436,
+            "n": 2
+          },
+          "sourceFile": "realworld-better-auth/pts_realworld-better-auth.xml",
+          "appVersion": "6f3ba45639579da152b69e8e5342e02f28288670",
+          "arguments": "typecheck"
+        },
+        {
+          "metricId": "realworld_mastra_task_build_core",
+          "samples": [85.911, 83.826],
+          "aggregates": {
+            "p50": 84.8685,
+            "p95": 85.80675,
+            "mean": 84.8685,
+            "stdev": 1.4743176387739572,
+            "min": 83.826,
+            "max": 85.911,
+            "n": 2
+          },
+          "sourceFile": "realworld-mastra/pts_realworld-mastra.xml",
+          "appVersion": "b6eeb9d08ebeaf27bc6fd16b6b88087040aaf767",
+          "arguments": "build_core"
+        },
+        {
+          "metricId": "realworld_mastra_task_cold_install",
+          "samples": [29.259, 29.637],
+          "aggregates": {
+            "p50": 29.448,
+            "p95": 29.618100000000002,
+            "mean": 29.448,
+            "stdev": 0.26728636328851507,
+            "min": 29.259,
+            "max": 29.637,
+            "n": 2
+          },
+          "sourceFile": "realworld-mastra/pts_realworld-mastra.xml",
+          "appVersion": "b6eeb9d08ebeaf27bc6fd16b6b88087040aaf767",
+          "arguments": "cold_install"
+        },
+        {
+          "metricId": "realworld_mastra_task_git_clone",
+          "samples": [6.69, 6.59],
+          "aggregates": {
+            "p50": 6.640000000000001,
+            "p95": 6.6850000000000005,
+            "mean": 6.640000000000001,
+            "stdev": 0.07071067811865482,
+            "min": 6.59,
+            "max": 6.69,
+            "n": 2
+          },
+          "sourceFile": "realworld-mastra/pts_realworld-mastra.xml",
+          "appVersion": "b6eeb9d08ebeaf27bc6fd16b6b88087040aaf767",
+          "arguments": "git_clone"
+        },
+        {
+          "metricId": "realworld_mastra_task_lint_format",
+          "samples": [89.42, 90.317],
+          "aggregates": {
+            "p50": 89.8685,
+            "p95": 90.27215,
+            "mean": 89.8685,
+            "stdev": 0.634274782724327,
+            "min": 89.42,
+            "max": 90.317,
+            "n": 2
+          },
+          "sourceFile": "realworld-mastra/pts_realworld-mastra.xml",
+          "appVersion": "b6eeb9d08ebeaf27bc6fd16b6b88087040aaf767",
+          "arguments": "lint_format"
+        },
+        {
+          "metricId": "sqlite_speedtest_seconds",
+          "samples": [34.197, 33.943],
+          "aggregates": {
+            "p50": 34.07,
+            "p95": 34.1843,
+            "mean": 34.07,
+            "stdev": 0.17960512242138654,
+            "min": 33.943,
+            "max": 34.197,
+            "n": 2
+          },
+          "sourceFile": "system/pts_sqlite-speedtest.xml",
+          "appVersion": "3.30"
+        },
+        {
+          "metricId": "stream_type_add",
+          "samples": [54629.5, 54292.3],
+          "aggregates": {
+            "p50": 54460.9,
+            "p95": 54612.64,
+            "mean": 54460.9,
+            "stdev": 238.43640661610175,
+            "min": 54292.3,
+            "max": 54629.5,
+            "n": 2
+          },
+          "sourceFile": "memory/pts_stream.xml",
+          "appVersion": "2013-01-17",
+          "arguments": "Add"
+        },
+        {
+          "metricId": "stream_type_copy",
+          "samples": [66987.4, 66563.7],
+          "aggregates": {
+            "p50": 66775.54999999999,
+            "p95": 66966.215,
+            "mean": 66775.54999999999,
+            "stdev": 299.60114318874327,
+            "min": 66563.7,
+            "max": 66987.4,
+            "n": 2
+          },
+          "sourceFile": "memory/pts_stream.xml",
+          "appVersion": "2013-01-17",
+          "arguments": "Copy"
+        },
+        {
+          "metricId": "stream_type_scale",
+          "samples": [49838.4, 49621.8],
+          "aggregates": {
+            "p50": 49730.100000000006,
+            "p95": 49827.57,
+            "mean": 49730.100000000006,
+            "stdev": 153.1593288050026,
+            "min": 49621.8,
+            "max": 49838.4,
+            "n": 2
+          },
+          "sourceFile": "memory/pts_stream.xml",
+          "appVersion": "2013-01-17",
+          "arguments": "Scale"
+        },
+        {
+          "metricId": "stream_type_triad",
+          "samples": [54792.1, 54552.5],
+          "aggregates": {
+            "p50": 54672.3,
+            "p95": 54780.119999999995,
+            "mean": 54672.3,
+            "stdev": 169.4227847722932,
+            "min": 54552.5,
+            "max": 54792.1,
+            "n": 2
+          },
+          "sourceFile": "memory/pts_stream.xml",
+          "appVersion": "2013-01-17",
+          "arguments": "Triad"
+        },
+        {
+          "metricId": "usd_per_hour",
+          "samples": [0.1494],
+          "aggregates": {
+            "p50": 0.1494,
+            "p95": 0.1494,
+            "mean": 0.1494,
+            "stdev": 0,
+            "min": 0.1494,
+            "max": 0.1494,
+            "n": 1
+          }
+        }
+      ],
+      "suitesCovered": [
+        "cpu-generic",
+        "cpu-node",
+        "disk",
+        "memory",
+        "network",
+        "realworld-better-auth",
+        "realworld-mastra",
+        "system"
+      ],
+      "gaps": [
+        {
+          "scope": "suite",
+          "id": "network",
+          "outcome": "failed",
+          "reason": "Step \"mise run benchmark:network:all\" timed out after 2700s"
+        },
+        {
+          "scope": "suite",
+          "id": "realworld-openclaw",
+          "outcome": "failed",
+          "reason": "Step \"mise run benchmark:realworld:pts:openclaw\" lost its sandbox: 12 consecutive detached polls failed (last: done-file fs exists) — the sandbox stopped responding, not a quiet long step"
+        }
+      ],
+      "uncatalogued": []
+    },
+    {
+      "providerId": "e2b",
+      "validationStatus": "validated",
+      "specMatched": true,
+      "observedSpecs": {
+        "vcpus": 2,
+        "cpuModel": "Intel(R) Xeon(R) Processor @ 2.60GHz",
+        "virtualization": "kvm",
+        "memoryGb": 7.78,
+        "diskGb": 24.3,
+        "kernel": "6.1.158+",
+        "os": "Debian GNU/Linux 13 (trixie)",
+        "user": "root",
+        "hostMemoryGb": 8,
+        "publicIp": "35.252.65.249",
+        "egressOrg": "AS396982 Google LLC",
+        "egressAsn": "AS396982",
+        "egressOrgName": "Google LLC",
+        "reverseDns": "249.65.252.35.bc.googleusercontent.com",
+        "city": "The Dalles",
+        "region": "Oregon",
+        "country": "US",
+        "location": "45.5946,-121.1787",
+        "timezone": "America/Los_Angeles",
+        "networkPrefix": "35.252.64.0/18",
+        "asnSource": "cymru",
+        "geoSource": "ipinfo"
+      },
+      "hostMetadata": [
+        {
+          "source": "phoronix/result-file-to-json",
+          "sourceFile": "cpu-node/pts_node-web-tooling--metadata.json",
+          "fields": [
+            {
+              "path": "ci.client_version",
+              "value": "10.8.4"
+            },
+            {
+              "path": "ci.data.cpu-microcode",
+              "value": "0x1"
+            },
+            {
+              "path": "ci.data.kernel-extra-details",
+              "value": "Transparent Huge Pages: madvise"
+            },
+            {
+              "path": "ci.data.security",
+              "value": "gather_data_sampling: Not affected + indirect_target_selection: Mitigation of Aligned branch/return thunks + itlb_multihit: Not affected + l1tf: Not affected + mds: Not affected + meltdown: Not affected + mmio_stale_data: Not affected + reg_file_data_sampling: Not affected + retbleed: Not affected + spec_rstack_overflow: Not affected + spec_store_bypass: Mitigation of SSB disabled via prctl + spectre_v1: Mitigation of usercopy/swapgs barriers and __user pointer sanitization + spectre_v2: Mitigation of Enhanced / Automatic IBRS; IBPB: conditional; PBRSB-eIBRS: SW sequence; BHI: SW loop KVM: SW loop + srbds: Not affected + tsa: Not affected + tsx_async_abort: Not affected + vmscape: Not affected"
+            },
+            {
+              "path": "ci.hardware.Disk",
+              "value": "25GB"
+            },
+            {
+              "path": "ci.hardware.Memory",
+              "value": "8GB"
+            },
+            {
+              "path": "ci.hardware.Processor",
+              "value": "Intel Xeon (1 Core / 2 Threads)"
+            },
+            {
+              "path": "ci.identifier",
+              "value": "ci"
+            },
+            {
+              "path": "ci.software.Compiler",
+              "value": "GCC 14.2.0"
+            },
+            {
+              "path": "ci.software.File-System",
+              "value": "ext4"
+            },
+            {
+              "path": "ci.software.Kernel",
+              "value": "6.1.158+ (x86_64)"
+            },
+            {
+              "path": "ci.software.OS",
+              "value": "Debian GNU/Linux 13"
+            },
+            {
+              "path": "ci.software.System Layer",
+              "value": "KVM"
+            },
+            {
+              "path": "ci.timestamp",
+              "value": "2026-07-17 07:23:21"
+            },
+            {
+              "path": "ci.user",
+              "value": "root"
+            }
+          ]
+        },
+        {
+          "source": "phoronix/result-file-to-json",
+          "sourceFile": "disk/pts_fio-rand-read--metadata.json",
+          "fields": [
+            {
+              "path": "ci.client_version",
+              "value": "10.8.4"
+            },
+            {
+              "path": "ci.data.compiler-configuration",
+              "value": "--build=x86_64-linux-gnu --disable-vtable-verify --disable-werror --enable-bootstrap --enable-cet --enable-checking=release --enable-clocale=gnu --enable-default-pie --enable-gnu-unique-object --enable-languages=c,ada,c++,go,d,fortran,objc,obj-c++,m2,rust --enable-libphobos-checking=release --enable-libstdcxx-backtrace --enable-libstdcxx-debug --enable-libstdcxx-time=yes --enable-link-serialization=3 --enable-multiarch --enable-multilib --enable-nls --enable-objc-gc=auto --enable-offload-defaulted --enable-offload-targets=nvptx-none=/build/reproducible-path/gcc-14-14.2.0/debian/tmp-nvptx/usr,amdgcn-amdhsa=/build/reproducible-path/gcc-14-14.2.0/debian/tmp-gcn/usr --enable-plugin --enable-shared --enable-threads=posix --host=x86_64-linux-gnu --program-prefix=x86_64-linux-gnu- --target=x86_64-linux-gnu --with-abi=m64 --with-arch-32=i686 --with-build-config=bootstrap-lto-lean --with-default-libstdcxx-abi=new --with-gcc-major-version-only --with-multilib-list=m32,m64,mx32 --with-target-system-zlib=auto --with-tune=generic --without-cuda-driver -v"
+            },
+            {
+              "path": "ci.data.cpu-microcode",
+              "value": "0x1"
+            },
+            {
+              "path": "ci.data.disk-details",
+              "value": "Block Size: 4096"
+            },
+            {
+              "path": "ci.data.disk-mount-options",
+              "value": "discard,relatime,rw"
+            },
+            {
+              "path": "ci.data.kernel-extra-details",
+              "value": "Transparent Huge Pages: madvise"
+            },
+            {
+              "path": "ci.data.security",
+              "value": "gather_data_sampling: Not affected + indirect_target_selection: Mitigation of Aligned branch/return thunks + itlb_multihit: Not affected + l1tf: Not affected + mds: Not affected + meltdown: Not affected + mmio_stale_data: Not affected + reg_file_data_sampling: Not affected + retbleed: Not affected + spec_rstack_overflow: Not affected + spec_store_bypass: Mitigation of SSB disabled via prctl + spectre_v1: Mitigation of usercopy/swapgs barriers and __user pointer sanitization + spectre_v2: Mitigation of Enhanced / Automatic IBRS; IBPB: conditional; PBRSB-eIBRS: SW sequence; BHI: SW loop KVM: SW loop + srbds: Not affected + tsa: Not affected + tsx_async_abort: Not affected + vmscape: Not affected"
+            },
+            {
+              "path": "ci.hardware.Disk",
+              "value": "25GB"
+            },
+            {
+              "path": "ci.hardware.Memory",
+              "value": "8GB"
+            },
+            {
+              "path": "ci.hardware.Processor",
+              "value": "Intel Xeon (1 Core / 2 Threads)"
+            },
+            {
+              "path": "ci.identifier",
+              "value": "ci"
+            },
+            {
+              "path": "ci.software.Compiler",
+              "value": "GCC 14.2.0"
+            },
+            {
+              "path": "ci.software.File-System",
+              "value": "ext4"
+            },
+            {
+              "path": "ci.software.Kernel",
+              "value": "6.1.158+ (x86_64)"
+            },
+            {
+              "path": "ci.software.OS",
+              "value": "Debian GNU/Linux 13"
+            },
+            {
+              "path": "ci.software.System Layer",
+              "value": "KVM"
+            },
+            {
+              "path": "ci.timestamp",
+              "value": "2026-07-17 07:29:45"
+            },
+            {
+              "path": "ci.user",
+              "value": "root"
+            }
+          ]
+        },
+        {
+          "source": "phoronix/result-file-to-json",
+          "sourceFile": "disk/pts_fio-rand-write--metadata.json",
+          "fields": [
+            {
+              "path": "ci.client_version",
+              "value": "10.8.4"
+            },
+            {
+              "path": "ci.data.compiler-configuration",
+              "value": "--build=x86_64-linux-gnu --disable-vtable-verify --disable-werror --enable-bootstrap --enable-cet --enable-checking=release --enable-clocale=gnu --enable-default-pie --enable-gnu-unique-object --enable-languages=c,ada,c++,go,d,fortran,objc,obj-c++,m2,rust --enable-libphobos-checking=release --enable-libstdcxx-backtrace --enable-libstdcxx-debug --enable-libstdcxx-time=yes --enable-link-serialization=3 --enable-multiarch --enable-multilib --enable-nls --enable-objc-gc=auto --enable-offload-defaulted --enable-offload-targets=nvptx-none=/build/reproducible-path/gcc-14-14.2.0/debian/tmp-nvptx/usr,amdgcn-amdhsa=/build/reproducible-path/gcc-14-14.2.0/debian/tmp-gcn/usr --enable-plugin --enable-shared --enable-threads=posix --host=x86_64-linux-gnu --program-prefix=x86_64-linux-gnu- --target=x86_64-linux-gnu --with-abi=m64 --with-arch-32=i686 --with-build-config=bootstrap-lto-lean --with-default-libstdcxx-abi=new --with-gcc-major-version-only --with-multilib-list=m32,m64,mx32 --with-target-system-zlib=auto --with-tune=generic --without-cuda-driver -v"
+            },
+            {
+              "path": "ci.data.cpu-microcode",
+              "value": "0x1"
+            },
+            {
+              "path": "ci.data.disk-details",
+              "value": "Block Size: 4096"
+            },
+            {
+              "path": "ci.data.disk-mount-options",
+              "value": "discard,relatime,rw"
+            },
+            {
+              "path": "ci.data.kernel-extra-details",
+              "value": "Transparent Huge Pages: madvise"
+            },
+            {
+              "path": "ci.data.security",
+              "value": "gather_data_sampling: Not affected + indirect_target_selection: Mitigation of Aligned branch/return thunks + itlb_multihit: Not affected + l1tf: Not affected + mds: Not affected + meltdown: Not affected + mmio_stale_data: Not affected + reg_file_data_sampling: Not affected + retbleed: Not affected + spec_rstack_overflow: Not affected + spec_store_bypass: Mitigation of SSB disabled via prctl + spectre_v1: Mitigation of usercopy/swapgs barriers and __user pointer sanitization + spectre_v2: Mitigation of Enhanced / Automatic IBRS; IBPB: conditional; PBRSB-eIBRS: SW sequence; BHI: SW loop KVM: SW loop + srbds: Not affected + tsa: Not affected + tsx_async_abort: Not affected + vmscape: Not affected"
+            },
+            {
+              "path": "ci.hardware.Disk",
+              "value": "25GB"
+            },
+            {
+              "path": "ci.hardware.Memory",
+              "value": "8GB"
+            },
+            {
+              "path": "ci.hardware.Processor",
+              "value": "Intel Xeon (1 Core / 2 Threads)"
+            },
+            {
+              "path": "ci.identifier",
+              "value": "ci"
+            },
+            {
+              "path": "ci.software.Compiler",
+              "value": "GCC 14.2.0"
+            },
+            {
+              "path": "ci.software.File-System",
+              "value": "ext4"
+            },
+            {
+              "path": "ci.software.Kernel",
+              "value": "6.1.158+ (x86_64)"
+            },
+            {
+              "path": "ci.software.OS",
+              "value": "Debian GNU/Linux 13"
+            },
+            {
+              "path": "ci.software.System Layer",
+              "value": "KVM"
+            },
+            {
+              "path": "ci.timestamp",
+              "value": "2026-07-17 07:32:58"
+            },
+            {
+              "path": "ci.user",
+              "value": "root"
+            }
+          ]
+        },
+        {
+          "source": "phoronix/result-file-to-json",
+          "sourceFile": "disk/pts_fio-seq-read--metadata.json",
+          "fields": [
+            {
+              "path": "ci.client_version",
+              "value": "10.8.4"
+            },
+            {
+              "path": "ci.data.compiler-configuration",
+              "value": "--build=x86_64-linux-gnu --disable-vtable-verify --disable-werror --enable-bootstrap --enable-cet --enable-checking=release --enable-clocale=gnu --enable-default-pie --enable-gnu-unique-object --enable-languages=c,ada,c++,go,d,fortran,objc,obj-c++,m2,rust --enable-libphobos-checking=release --enable-libstdcxx-backtrace --enable-libstdcxx-debug --enable-libstdcxx-time=yes --enable-link-serialization=3 --enable-multiarch --enable-multilib --enable-nls --enable-objc-gc=auto --enable-offload-defaulted --enable-offload-targets=nvptx-none=/build/reproducible-path/gcc-14-14.2.0/debian/tmp-nvptx/usr,amdgcn-amdhsa=/build/reproducible-path/gcc-14-14.2.0/debian/tmp-gcn/usr --enable-plugin --enable-shared --enable-threads=posix --host=x86_64-linux-gnu --program-prefix=x86_64-linux-gnu- --target=x86_64-linux-gnu --with-abi=m64 --with-arch-32=i686 --with-build-config=bootstrap-lto-lean --with-default-libstdcxx-abi=new --with-gcc-major-version-only --with-multilib-list=m32,m64,mx32 --with-target-system-zlib=auto --with-tune=generic --without-cuda-driver -v"
+            },
+            {
+              "path": "ci.data.cpu-microcode",
+              "value": "0x1"
+            },
+            {
+              "path": "ci.data.disk-details",
+              "value": "Block Size: 4096"
+            },
+            {
+              "path": "ci.data.disk-mount-options",
+              "value": "discard,relatime,rw"
+            },
+            {
+              "path": "ci.data.kernel-extra-details",
+              "value": "Transparent Huge Pages: madvise"
+            },
+            {
+              "path": "ci.data.security",
+              "value": "gather_data_sampling: Not affected + indirect_target_selection: Mitigation of Aligned branch/return thunks + itlb_multihit: Not affected + l1tf: Not affected + mds: Not affected + meltdown: Not affected + mmio_stale_data: Not affected + reg_file_data_sampling: Not affected + retbleed: Not affected + spec_rstack_overflow: Not affected + spec_store_bypass: Mitigation of SSB disabled via prctl + spectre_v1: Mitigation of usercopy/swapgs barriers and __user pointer sanitization + spectre_v2: Mitigation of Enhanced / Automatic IBRS; IBPB: conditional; PBRSB-eIBRS: SW sequence; BHI: SW loop KVM: SW loop + srbds: Not affected + tsa: Not affected + tsx_async_abort: Not affected + vmscape: Not affected"
+            },
+            {
+              "path": "ci.hardware.Disk",
+              "value": "25GB"
+            },
+            {
+              "path": "ci.hardware.Memory",
+              "value": "8GB"
+            },
+            {
+              "path": "ci.hardware.Processor",
+              "value": "Intel Xeon (1 Core / 2 Threads)"
+            },
+            {
+              "path": "ci.identifier",
+              "value": "ci"
+            },
+            {
+              "path": "ci.software.Compiler",
+              "value": "GCC 14.2.0"
+            },
+            {
+              "path": "ci.software.File-System",
+              "value": "ext4"
+            },
+            {
+              "path": "ci.software.Kernel",
+              "value": "6.1.158+ (x86_64)"
+            },
+            {
+              "path": "ci.software.OS",
+              "value": "Debian GNU/Linux 13"
+            },
+            {
+              "path": "ci.software.System Layer",
+              "value": "KVM"
+            },
+            {
+              "path": "ci.timestamp",
+              "value": "2026-07-17 07:23:20"
+            },
+            {
+              "path": "ci.user",
+              "value": "root"
+            }
+          ]
+        },
+        {
+          "source": "phoronix/result-file-to-json",
+          "sourceFile": "disk/pts_fio-seq-write--metadata.json",
+          "fields": [
+            {
+              "path": "ci.client_version",
+              "value": "10.8.4"
+            },
+            {
+              "path": "ci.data.compiler-configuration",
+              "value": "--build=x86_64-linux-gnu --disable-vtable-verify --disable-werror --enable-bootstrap --enable-cet --enable-checking=release --enable-clocale=gnu --enable-default-pie --enable-gnu-unique-object --enable-languages=c,ada,c++,go,d,fortran,objc,obj-c++,m2,rust --enable-libphobos-checking=release --enable-libstdcxx-backtrace --enable-libstdcxx-debug --enable-libstdcxx-time=yes --enable-link-serialization=3 --enable-multiarch --enable-multilib --enable-nls --enable-objc-gc=auto --enable-offload-defaulted --enable-offload-targets=nvptx-none=/build/reproducible-path/gcc-14-14.2.0/debian/tmp-nvptx/usr,amdgcn-amdhsa=/build/reproducible-path/gcc-14-14.2.0/debian/tmp-gcn/usr --enable-plugin --enable-shared --enable-threads=posix --host=x86_64-linux-gnu --program-prefix=x86_64-linux-gnu- --target=x86_64-linux-gnu --with-abi=m64 --with-arch-32=i686 --with-build-config=bootstrap-lto-lean --with-default-libstdcxx-abi=new --with-gcc-major-version-only --with-multilib-list=m32,m64,mx32 --with-target-system-zlib=auto --with-tune=generic --without-cuda-driver -v"
+            },
+            {
+              "path": "ci.data.cpu-microcode",
+              "value": "0x1"
+            },
+            {
+              "path": "ci.data.disk-details",
+              "value": "Block Size: 4096"
+            },
+            {
+              "path": "ci.data.disk-mount-options",
+              "value": "discard,relatime,rw"
+            },
+            {
+              "path": "ci.data.kernel-extra-details",
+              "value": "Transparent Huge Pages: madvise"
+            },
+            {
+              "path": "ci.data.security",
+              "value": "gather_data_sampling: Not affected + indirect_target_selection: Mitigation of Aligned branch/return thunks + itlb_multihit: Not affected + l1tf: Not affected + mds: Not affected + meltdown: Not affected + mmio_stale_data: Not affected + reg_file_data_sampling: Not affected + retbleed: Not affected + spec_rstack_overflow: Not affected + spec_store_bypass: Mitigation of SSB disabled via prctl + spectre_v1: Mitigation of usercopy/swapgs barriers and __user pointer sanitization + spectre_v2: Mitigation of Enhanced / Automatic IBRS; IBPB: conditional; PBRSB-eIBRS: SW sequence; BHI: SW loop KVM: SW loop + srbds: Not affected + tsa: Not affected + tsx_async_abort: Not affected + vmscape: Not affected"
+            },
+            {
+              "path": "ci.hardware.Disk",
+              "value": "25GB"
+            },
+            {
+              "path": "ci.hardware.Memory",
+              "value": "8GB"
+            },
+            {
+              "path": "ci.hardware.Processor",
+              "value": "Intel Xeon (1 Core / 2 Threads)"
+            },
+            {
+              "path": "ci.identifier",
+              "value": "ci"
+            },
+            {
+              "path": "ci.software.Compiler",
+              "value": "GCC 14.2.0"
+            },
+            {
+              "path": "ci.software.File-System",
+              "value": "ext4"
+            },
+            {
+              "path": "ci.software.Kernel",
+              "value": "6.1.158+ (x86_64)"
+            },
+            {
+              "path": "ci.software.OS",
+              "value": "Debian GNU/Linux 13"
+            },
+            {
+              "path": "ci.software.System Layer",
+              "value": "KVM"
+            },
+            {
+              "path": "ci.timestamp",
+              "value": "2026-07-17 07:26:35"
+            },
+            {
+              "path": "ci.user",
+              "value": "root"
+            }
+          ]
+        },
+        {
+          "source": "phoronix/result-file-to-json",
+          "sourceFile": "disk/pts_hardlink--metadata.json",
+          "fields": [
+            {
+              "path": "ci.client_version",
+              "value": "10.8.4"
+            },
+            {
+              "path": "ci.data.compiler-configuration",
+              "value": "--build=x86_64-linux-gnu --disable-vtable-verify --disable-werror --enable-bootstrap --enable-cet --enable-checking=release --enable-clocale=gnu --enable-default-pie --enable-gnu-unique-object --enable-languages=c,ada,c++,go,d,fortran,objc,obj-c++,m2,rust --enable-libphobos-checking=release --enable-libstdcxx-backtrace --enable-libstdcxx-debug --enable-libstdcxx-time=yes --enable-link-serialization=3 --enable-multiarch --enable-multilib --enable-nls --enable-objc-gc=auto --enable-offload-defaulted --enable-offload-targets=nvptx-none=/build/reproducible-path/gcc-14-14.2.0/debian/tmp-nvptx/usr,amdgcn-amdhsa=/build/reproducible-path/gcc-14-14.2.0/debian/tmp-gcn/usr --enable-plugin --enable-shared --enable-threads=posix --host=x86_64-linux-gnu --program-prefix=x86_64-linux-gnu- --target=x86_64-linux-gnu --with-abi=m64 --with-arch-32=i686 --with-build-config=bootstrap-lto-lean --with-default-libstdcxx-abi=new --with-gcc-major-version-only --with-multilib-list=m32,m64,mx32 --with-target-system-zlib=auto --with-tune=generic --without-cuda-driver -v"
+            },
+            {
+              "path": "ci.data.cpu-microcode",
+              "value": "0x1"
+            },
+            {
+              "path": "ci.data.disk-details",
+              "value": "Block Size: 4096"
+            },
+            {
+              "path": "ci.data.disk-mount-options",
+              "value": "discard,relatime,rw"
+            },
+            {
+              "path": "ci.data.kernel-extra-details",
+              "value": "Transparent Huge Pages: madvise"
+            },
+            {
+              "path": "ci.data.security",
+              "value": "gather_data_sampling: Not affected + indirect_target_selection: Mitigation of Aligned branch/return thunks + itlb_multihit: Not affected + l1tf: Not affected + mds: Not affected + meltdown: Not affected + mmio_stale_data: Not affected + reg_file_data_sampling: Not affected + retbleed: Not affected + spec_rstack_overflow: Not affected + spec_store_bypass: Mitigation of SSB disabled via prctl + spectre_v1: Mitigation of usercopy/swapgs barriers and __user pointer sanitization + spectre_v2: Mitigation of Enhanced / Automatic IBRS; IBPB: conditional; PBRSB-eIBRS: SW sequence; BHI: SW loop KVM: SW loop + srbds: Not affected + tsa: Not affected + tsx_async_abort: Not affected + vmscape: Not affected"
+            },
+            {
+              "path": "ci.hardware.Disk",
+              "value": "25GB"
+            },
+            {
+              "path": "ci.hardware.Memory",
+              "value": "8GB"
+            },
+            {
+              "path": "ci.hardware.Processor",
+              "value": "Intel Xeon (1 Core / 2 Threads)"
+            },
+            {
+              "path": "ci.identifier",
+              "value": "ci"
+            },
+            {
+              "path": "ci.software.Compiler",
+              "value": "GCC 14.2.0"
+            },
+            {
+              "path": "ci.software.File-System",
+              "value": "ext4"
+            },
+            {
+              "path": "ci.software.Kernel",
+              "value": "6.1.158+ (x86_64)"
+            },
+            {
+              "path": "ci.software.OS",
+              "value": "Debian GNU/Linux 13"
+            },
+            {
+              "path": "ci.software.System Layer",
+              "value": "KVM"
+            },
+            {
+              "path": "ci.timestamp",
+              "value": "2026-07-17 07:36:10"
+            },
+            {
+              "path": "ci.user",
+              "value": "root"
+            }
+          ]
+        },
+        {
+          "source": "phoronix/result-file-to-json",
+          "sourceFile": "memory/pts_stream--metadata.json",
+          "fields": [
+            {
+              "path": "ci.client_version",
+              "value": "10.8.4"
+            },
+            {
+              "path": "ci.data.compiler-configuration",
+              "value": "--build=x86_64-linux-gnu --disable-vtable-verify --disable-werror --enable-bootstrap --enable-cet --enable-checking=release --enable-clocale=gnu --enable-default-pie --enable-gnu-unique-object --enable-languages=c,ada,c++,go,d,fortran,objc,obj-c++,m2,rust --enable-libphobos-checking=release --enable-libstdcxx-backtrace --enable-libstdcxx-debug --enable-libstdcxx-time=yes --enable-link-serialization=3 --enable-multiarch --enable-multilib --enable-nls --enable-objc-gc=auto --enable-offload-defaulted --enable-offload-targets=nvptx-none=/build/reproducible-path/gcc-14-14.2.0/debian/tmp-nvptx/usr,amdgcn-amdhsa=/build/reproducible-path/gcc-14-14.2.0/debian/tmp-gcn/usr --enable-plugin --enable-shared --enable-threads=posix --host=x86_64-linux-gnu --program-prefix=x86_64-linux-gnu- --target=x86_64-linux-gnu --with-abi=m64 --with-arch-32=i686 --with-build-config=bootstrap-lto-lean --with-default-libstdcxx-abi=new --with-gcc-major-version-only --with-multilib-list=m32,m64,mx32 --with-target-system-zlib=auto --with-tune=generic --without-cuda-driver -v"
+            },
+            {
+              "path": "ci.data.cpu-microcode",
+              "value": "0x1"
+            },
+            {
+              "path": "ci.data.environment-variables",
+              "value": "CFLAGS_OVERRIDE=\"-O3 -march=native -DSTREAM_ARRAY_SIZE=150000000\""
+            },
+            {
+              "path": "ci.data.kernel-extra-details",
+              "value": "Transparent Huge Pages: madvise"
+            },
+            {
+              "path": "ci.data.security",
+              "value": "gather_data_sampling: Not affected + indirect_target_selection: Mitigation of Aligned branch/return thunks + itlb_multihit: Not affected + l1tf: Not affected + mds: Not affected + meltdown: Not affected + mmio_stale_data: Not affected + reg_file_data_sampling: Not affected + retbleed: Not affected + spec_rstack_overflow: Not affected + spec_store_bypass: Mitigation of SSB disabled via prctl + spectre_v1: Mitigation of usercopy/swapgs barriers and __user pointer sanitization + spectre_v2: Mitigation of Enhanced / Automatic IBRS; IBPB: conditional; PBRSB-eIBRS: SW sequence; BHI: SW loop KVM: SW loop + srbds: Not affected + tsa: Not affected + tsx_async_abort: Not affected + vmscape: Not affected"
+            },
+            {
+              "path": "ci.hardware.Disk",
+              "value": "25GB"
+            },
+            {
+              "path": "ci.hardware.Memory",
+              "value": "8GB"
+            },
+            {
+              "path": "ci.hardware.Processor",
+              "value": "Intel Xeon (1 Core / 2 Threads)"
+            },
+            {
+              "path": "ci.identifier",
+              "value": "ci"
+            },
+            {
+              "path": "ci.software.Compiler",
+              "value": "GCC 14.2.0"
+            },
+            {
+              "path": "ci.software.File-System",
+              "value": "ext4"
+            },
+            {
+              "path": "ci.software.Kernel",
+              "value": "6.1.158+ (x86_64)"
+            },
+            {
+              "path": "ci.software.OS",
+              "value": "Debian GNU/Linux 13"
+            },
+            {
+              "path": "ci.software.System Layer",
+              "value": "KVM"
+            },
+            {
+              "path": "ci.timestamp",
+              "value": "2026-07-17 07:23:15"
+            },
+            {
+              "path": "ci.user",
+              "value": "root"
+            }
+          ]
+        },
+        {
+          "source": "phoronix/result-file-to-json",
+          "sourceFile": "network/pts_fast-cli--metadata.json",
+          "fields": [
+            {
+              "path": "ci.client_version",
+              "value": "10.8.4"
+            },
+            {
+              "path": "ci.data.cpu-microcode",
+              "value": "0x1"
+            },
+            {
+              "path": "ci.data.kernel-extra-details",
+              "value": "Transparent Huge Pages: madvise"
+            },
+            {
+              "path": "ci.data.security",
+              "value": "gather_data_sampling: Not affected + indirect_target_selection: Mitigation of Aligned branch/return thunks + itlb_multihit: Not affected + l1tf: Not affected + mds: Not affected + meltdown: Not affected + mmio_stale_data: Not affected + reg_file_data_sampling: Not affected + retbleed: Not affected + spec_rstack_overflow: Not affected + spec_store_bypass: Mitigation of SSB disabled via prctl + spectre_v1: Mitigation of usercopy/swapgs barriers and __user pointer sanitization + spectre_v2: Mitigation of Enhanced / Automatic IBRS; IBPB: conditional; PBRSB-eIBRS: SW sequence; BHI: SW loop KVM: SW loop + srbds: Not affected + tsa: Not affected + tsx_async_abort: Not affected + vmscape: Not affected"
+            },
+            {
+              "path": "ci.hardware.Disk",
+              "value": "25GB"
+            },
+            {
+              "path": "ci.hardware.Memory",
+              "value": "8GB"
+            },
+            {
+              "path": "ci.hardware.Processor",
+              "value": "Intel Xeon (1 Core / 2 Threads)"
+            },
+            {
+              "path": "ci.identifier",
+              "value": "ci"
+            },
+            {
+              "path": "ci.software.Compiler",
+              "value": "GCC 14.2.0"
+            },
+            {
+              "path": "ci.software.File-System",
+              "value": "ext4"
+            },
+            {
+              "path": "ci.software.Kernel",
+              "value": "6.1.158+ (x86_64)"
+            },
+            {
+              "path": "ci.software.OS",
+              "value": "Debian GNU/Linux 13"
+            },
+            {
+              "path": "ci.software.System Layer",
+              "value": "KVM"
+            },
+            {
+              "path": "ci.timestamp",
+              "value": "2026-07-17 07:24:16"
+            },
+            {
+              "path": "ci.user",
+              "value": "root"
+            }
+          ]
+        },
+        {
+          "source": "phoronix/result-file-to-json",
+          "sourceFile": "network/pts_network-loopback--metadata.json",
+          "fields": [
+            {
+              "path": "ci.client_version",
+              "value": "10.8.4"
+            },
+            {
+              "path": "ci.data.cpu-microcode",
+              "value": "0x1"
+            },
+            {
+              "path": "ci.data.kernel-extra-details",
+              "value": "Transparent Huge Pages: madvise"
+            },
+            {
+              "path": "ci.data.security",
+              "value": "gather_data_sampling: Not affected + indirect_target_selection: Mitigation of Aligned branch/return thunks + itlb_multihit: Not affected + l1tf: Not affected + mds: Not affected + meltdown: Not affected + mmio_stale_data: Not affected + reg_file_data_sampling: Not affected + retbleed: Not affected + spec_rstack_overflow: Not affected + spec_store_bypass: Mitigation of SSB disabled via prctl + spectre_v1: Mitigation of usercopy/swapgs barriers and __user pointer sanitization + spectre_v2: Mitigation of Enhanced / Automatic IBRS; IBPB: conditional; PBRSB-eIBRS: SW sequence; BHI: SW loop KVM: SW loop + srbds: Not affected + tsa: Not affected + tsx_async_abort: Not affected + vmscape: Not affected"
+            },
+            {
+              "path": "ci.hardware.Disk",
+              "value": "25GB"
+            },
+            {
+              "path": "ci.hardware.Memory",
+              "value": "8GB"
+            },
+            {
+              "path": "ci.hardware.Processor",
+              "value": "Intel Xeon (1 Core / 2 Threads)"
+            },
+            {
+              "path": "ci.identifier",
+              "value": "ci"
+            },
+            {
+              "path": "ci.software.Compiler",
+              "value": "GCC 14.2.0"
+            },
+            {
+              "path": "ci.software.File-System",
+              "value": "ext4"
+            },
+            {
+              "path": "ci.software.Kernel",
+              "value": "6.1.158+ (x86_64)"
+            },
+            {
+              "path": "ci.software.OS",
+              "value": "Debian GNU/Linux 13"
+            },
+            {
+              "path": "ci.software.System Layer",
+              "value": "KVM"
+            },
+            {
+              "path": "ci.timestamp",
+              "value": "2026-07-17 07:23:29"
+            },
+            {
+              "path": "ci.user",
+              "value": "root"
+            }
+          ]
+        },
+        {
+          "source": "phoronix/result-file-to-json",
+          "sourceFile": "realworld-better-auth/pts_realworld-better-auth--metadata.json",
+          "fields": [
+            {
+              "path": "ci.client_version",
+              "value": "10.8.4"
+            },
+            {
+              "path": "ci.data.cpu-microcode",
+              "value": "0x1"
+            },
+            {
+              "path": "ci.data.kernel-extra-details",
+              "value": "Transparent Huge Pages: madvise"
+            },
+            {
+              "path": "ci.data.security",
+              "value": "gather_data_sampling: Not affected + indirect_target_selection: Mitigation of Aligned branch/return thunks + itlb_multihit: Not affected + l1tf: Not affected + mds: Not affected + meltdown: Not affected + mmio_stale_data: Not affected + reg_file_data_sampling: Not affected + retbleed: Not affected + spec_rstack_overflow: Not affected + spec_store_bypass: Mitigation of SSB disabled via prctl + spectre_v1: Mitigation of usercopy/swapgs barriers and __user pointer sanitization + spectre_v2: Mitigation of Enhanced / Automatic IBRS; IBPB: conditional; PBRSB-eIBRS: SW sequence; BHI: SW loop KVM: SW loop + srbds: Not affected + tsa: Not affected + tsx_async_abort: Not affected + vmscape: Not affected"
+            },
+            {
+              "path": "ci.hardware.Disk",
+              "value": "25GB"
+            },
+            {
+              "path": "ci.hardware.Memory",
+              "value": "8GB"
+            },
+            {
+              "path": "ci.hardware.Processor",
+              "value": "Intel Xeon (1 Core / 2 Threads)"
+            },
+            {
+              "path": "ci.identifier",
+              "value": "ci"
+            },
+            {
+              "path": "ci.software.Compiler",
+              "value": "GCC 14.2.0"
+            },
+            {
+              "path": "ci.software.File-System",
+              "value": "ext4"
+            },
+            {
+              "path": "ci.software.Kernel",
+              "value": "6.1.158+ (x86_64)"
+            },
+            {
+              "path": "ci.software.OS",
+              "value": "Debian GNU/Linux 13"
+            },
+            {
+              "path": "ci.software.System Layer",
+              "value": "KVM"
+            },
+            {
+              "path": "ci.timestamp",
+              "value": "2026-07-17 07:24:06"
+            },
+            {
+              "path": "ci.user",
+              "value": "root"
+            }
+          ]
+        },
+        {
+          "source": "phoronix/result-file-to-json",
+          "sourceFile": "system/pts_git--metadata.json",
+          "fields": [
+            {
+              "path": "ci.client_version",
+              "value": "10.8.4"
+            },
+            {
+              "path": "ci.data.cpu-microcode",
+              "value": "0x1"
+            },
+            {
+              "path": "ci.data.kernel-extra-details",
+              "value": "Transparent Huge Pages: madvise"
+            },
+            {
+              "path": "ci.data.security",
+              "value": "gather_data_sampling: Not affected + indirect_target_selection: Mitigation of Aligned branch/return thunks + itlb_multihit: Not affected + l1tf: Not affected + mds: Not affected + meltdown: Not affected + mmio_stale_data: Not affected + reg_file_data_sampling: Not affected + retbleed: Not affected + spec_rstack_overflow: Not affected + spec_store_bypass: Mitigation of SSB disabled via prctl + spectre_v1: Mitigation of usercopy/swapgs barriers and __user pointer sanitization + spectre_v2: Mitigation of Enhanced / Automatic IBRS; IBPB: conditional; PBRSB-eIBRS: SW sequence; BHI: SW loop KVM: SW loop + srbds: Not affected + tsa: Not affected + tsx_async_abort: Not affected + vmscape: Not affected"
+            },
+            {
+              "path": "ci.hardware.Disk",
+              "value": "25GB"
+            },
+            {
+              "path": "ci.hardware.Memory",
+              "value": "8GB"
+            },
+            {
+              "path": "ci.hardware.Processor",
+              "value": "Intel Xeon (1 Core / 2 Threads)"
+            },
+            {
+              "path": "ci.identifier",
+              "value": "ci"
+            },
+            {
+              "path": "ci.software.Compiler",
+              "value": "GCC 14.2.0"
+            },
+            {
+              "path": "ci.software.File-System",
+              "value": "ext4"
+            },
+            {
+              "path": "ci.software.Kernel",
+              "value": "6.1.158+ (x86_64)"
+            },
+            {
+              "path": "ci.software.OS",
+              "value": "Debian GNU/Linux 13"
+            },
+            {
+              "path": "ci.software.System Layer",
+              "value": "KVM"
+            },
+            {
+              "path": "ci.timestamp",
+              "value": "2026-07-17 07:27:30"
+            },
+            {
+              "path": "ci.user",
+              "value": "root"
+            }
+          ]
+        },
+        {
+          "source": "phoronix/result-file-to-json",
+          "sourceFile": "system/pts_pgbench-read-only--metadata.json",
+          "fields": [
+            {
+              "path": "ci.client_version",
+              "value": "10.8.4"
+            },
+            {
+              "path": "ci.data.compiler-configuration",
+              "value": "--build=x86_64-linux-gnu --disable-vtable-verify --disable-werror --enable-bootstrap --enable-cet --enable-checking=release --enable-clocale=gnu --enable-default-pie --enable-gnu-unique-object --enable-languages=c,ada,c++,go,d,fortran,objc,obj-c++,m2,rust --enable-libphobos-checking=release --enable-libstdcxx-backtrace --enable-libstdcxx-debug --enable-libstdcxx-time=yes --enable-link-serialization=3 --enable-multiarch --enable-multilib --enable-nls --enable-objc-gc=auto --enable-offload-defaulted --enable-offload-targets=nvptx-none=/build/reproducible-path/gcc-14-14.2.0/debian/tmp-nvptx/usr,amdgcn-amdhsa=/build/reproducible-path/gcc-14-14.2.0/debian/tmp-gcn/usr --enable-plugin --enable-shared --enable-threads=posix --host=x86_64-linux-gnu --program-prefix=x86_64-linux-gnu- --target=x86_64-linux-gnu --with-abi=m64 --with-arch-32=i686 --with-build-config=bootstrap-lto-lean --with-default-libstdcxx-abi=new --with-gcc-major-version-only --with-multilib-list=m32,m64,mx32 --with-target-system-zlib=auto --with-tune=generic --without-cuda-driver -v"
+            },
+            {
+              "path": "ci.data.cpu-microcode",
+              "value": "0x1"
+            },
+            {
+              "path": "ci.data.kernel-extra-details",
+              "value": "Transparent Huge Pages: madvise"
+            },
+            {
+              "path": "ci.data.security",
+              "value": "gather_data_sampling: Not affected + indirect_target_selection: Mitigation of Aligned branch/return thunks + itlb_multihit: Not affected + l1tf: Not affected + mds: Not affected + meltdown: Not affected + mmio_stale_data: Not affected + reg_file_data_sampling: Not affected + retbleed: Not affected + spec_rstack_overflow: Not affected + spec_store_bypass: Mitigation of SSB disabled via prctl + spectre_v1: Mitigation of usercopy/swapgs barriers and __user pointer sanitization + spectre_v2: Mitigation of Enhanced / Automatic IBRS; IBPB: conditional; PBRSB-eIBRS: SW sequence; BHI: SW loop KVM: SW loop + srbds: Not affected + tsa: Not affected + tsx_async_abort: Not affected + vmscape: Not affected"
+            },
+            {
+              "path": "ci.hardware.Disk",
+              "value": "25GB"
+            },
+            {
+              "path": "ci.hardware.Memory",
+              "value": "8GB"
+            },
+            {
+              "path": "ci.hardware.Processor",
+              "value": "Intel Xeon (1 Core / 2 Threads)"
+            },
+            {
+              "path": "ci.identifier",
+              "value": "ci"
+            },
+            {
+              "path": "ci.software.Compiler",
+              "value": "GCC 14.2.0"
+            },
+            {
+              "path": "ci.software.File-System",
+              "value": "ext4"
+            },
+            {
+              "path": "ci.software.Kernel",
+              "value": "6.1.158+ (x86_64)"
+            },
+            {
+              "path": "ci.software.OS",
+              "value": "Debian GNU/Linux 13"
+            },
+            {
+              "path": "ci.software.System Layer",
+              "value": "KVM"
+            },
+            {
+              "path": "ci.timestamp",
+              "value": "2026-07-17 07:26:15"
+            },
+            {
+              "path": "ci.user",
+              "value": "root"
+            }
+          ]
+        },
+        {
+          "source": "phoronix/result-file-to-json",
+          "sourceFile": "system/pts_pgbench-read-write--metadata.json",
+          "fields": [
+            {
+              "path": "ci.client_version",
+              "value": "10.8.4"
+            },
+            {
+              "path": "ci.data.compiler-configuration",
+              "value": "--build=x86_64-linux-gnu --disable-vtable-verify --disable-werror --enable-bootstrap --enable-cet --enable-checking=release --enable-clocale=gnu --enable-default-pie --enable-gnu-unique-object --enable-languages=c,ada,c++,go,d,fortran,objc,obj-c++,m2,rust --enable-libphobos-checking=release --enable-libstdcxx-backtrace --enable-libstdcxx-debug --enable-libstdcxx-time=yes --enable-link-serialization=3 --enable-multiarch --enable-multilib --enable-nls --enable-objc-gc=auto --enable-offload-defaulted --enable-offload-targets=nvptx-none=/build/reproducible-path/gcc-14-14.2.0/debian/tmp-nvptx/usr,amdgcn-amdhsa=/build/reproducible-path/gcc-14-14.2.0/debian/tmp-gcn/usr --enable-plugin --enable-shared --enable-threads=posix --host=x86_64-linux-gnu --program-prefix=x86_64-linux-gnu- --target=x86_64-linux-gnu --with-abi=m64 --with-arch-32=i686 --with-build-config=bootstrap-lto-lean --with-default-libstdcxx-abi=new --with-gcc-major-version-only --with-multilib-list=m32,m64,mx32 --with-target-system-zlib=auto --with-tune=generic --without-cuda-driver -v"
+            },
+            {
+              "path": "ci.data.cpu-microcode",
+              "value": "0x1"
+            },
+            {
+              "path": "ci.data.kernel-extra-details",
+              "value": "Transparent Huge Pages: madvise"
+            },
+            {
+              "path": "ci.data.security",
+              "value": "gather_data_sampling: Not affected + indirect_target_selection: Mitigation of Aligned branch/return thunks + itlb_multihit: Not affected + l1tf: Not affected + mds: Not affected + meltdown: Not affected + mmio_stale_data: Not affected + reg_file_data_sampling: Not affected + retbleed: Not affected + spec_rstack_overflow: Not affected + spec_store_bypass: Mitigation of SSB disabled via prctl + spectre_v1: Mitigation of usercopy/swapgs barriers and __user pointer sanitization + spectre_v2: Mitigation of Enhanced / Automatic IBRS; IBPB: conditional; PBRSB-eIBRS: SW sequence; BHI: SW loop KVM: SW loop + srbds: Not affected + tsa: Not affected + tsx_async_abort: Not affected + vmscape: Not affected"
+            },
+            {
+              "path": "ci.hardware.Disk",
+              "value": "25GB"
+            },
+            {
+              "path": "ci.hardware.Memory",
+              "value": "8GB"
+            },
+            {
+              "path": "ci.hardware.Processor",
+              "value": "Intel Xeon (1 Core / 2 Threads)"
+            },
+            {
+              "path": "ci.identifier",
+              "value": "ci"
+            },
+            {
+              "path": "ci.software.Compiler",
+              "value": "GCC 14.2.0"
+            },
+            {
+              "path": "ci.software.File-System",
+              "value": "ext4"
+            },
+            {
+              "path": "ci.software.Kernel",
+              "value": "6.1.158+ (x86_64)"
+            },
+            {
+              "path": "ci.software.OS",
+              "value": "Debian GNU/Linux 13"
+            },
+            {
+              "path": "ci.software.System Layer",
+              "value": "KVM"
+            },
+            {
+              "path": "ci.timestamp",
+              "value": "2026-07-17 07:26:54"
+            },
+            {
+              "path": "ci.user",
+              "value": "root"
+            }
+          ]
+        },
+        {
+          "source": "phoronix/result-file-to-json",
+          "sourceFile": "system/pts_pybench--metadata.json",
+          "fields": [
+            {
+              "path": "ci.client_version",
+              "value": "10.8.4"
+            },
+            {
+              "path": "ci.data.cpu-microcode",
+              "value": "0x1"
+            },
+            {
+              "path": "ci.data.kernel-extra-details",
+              "value": "Transparent Huge Pages: madvise"
+            },
+            {
+              "path": "ci.data.python",
+              "value": "mise ERROR python is not a valid shim. This likely means you uninstalled a tool and the shim does not point anything. Run `mise use ` reinstall the tool.mise ERROR : 2026.5.16 linux-x64 (2026-05-28)mise ERROR Run with--verbose or MISE_VERBOSE=1 for more information + mise ERROR python3 is not a valid shim. This likely means you uninstalled a tool and the shim does not point anything. Run `mise use ` reinstall the tool.mise ERROR : 2026.5.16 linux-x64 (2026-05-28)mise ERROR Run with--verbose or MISE_VERBOSE=1 for more information"
+            },
+            {
+              "path": "ci.data.security",
+              "value": "gather_data_sampling: Not affected + indirect_target_selection: Mitigation of Aligned branch/return thunks + itlb_multihit: Not affected + l1tf: Not affected + mds: Not affected + meltdown: Not affected + mmio_stale_data: Not affected + reg_file_data_sampling: Not affected + retbleed: Not affected + spec_rstack_overflow: Not affected + spec_store_bypass: Mitigation of SSB disabled via prctl + spectre_v1: Mitigation of usercopy/swapgs barriers and __user pointer sanitization + spectre_v2: Mitigation of Enhanced / Automatic IBRS; IBPB: conditional; PBRSB-eIBRS: SW sequence; BHI: SW loop KVM: SW loop + srbds: Not affected + tsa: Not affected + tsx_async_abort: Not affected + vmscape: Not affected"
+            },
+            {
+              "path": "ci.hardware.Disk",
+              "value": "25GB"
+            },
+            {
+              "path": "ci.hardware.Memory",
+              "value": "8GB"
+            },
+            {
+              "path": "ci.hardware.Processor",
+              "value": "Intel Xeon (1 Core / 2 Threads)"
+            },
+            {
+              "path": "ci.identifier",
+              "value": "ci"
+            },
+            {
+              "path": "ci.software.Compiler",
+              "value": "GCC 14.2.0"
+            },
+            {
+              "path": "ci.software.File-System",
+              "value": "ext4"
+            },
+            {
+              "path": "ci.software.Kernel",
+              "value": "6.1.158+ (x86_64)"
+            },
+            {
+              "path": "ci.software.OS",
+              "value": "Debian GNU/Linux 13"
+            },
+            {
+              "path": "ci.software.System Layer",
+              "value": "KVM"
+            },
+            {
+              "path": "ci.timestamp",
+              "value": "2026-07-17 07:23:16"
+            },
+            {
+              "path": "ci.user",
+              "value": "root"
+            }
+          ]
+        },
+        {
+          "source": "phoronix/result-file-to-json",
+          "sourceFile": "system/pts_sqlite-speedtest--metadata.json",
+          "fields": [
+            {
+              "path": "ci.client_version",
+              "value": "10.8.4"
+            },
+            {
+              "path": "ci.data.compiler-configuration",
+              "value": "--build=x86_64-linux-gnu --disable-vtable-verify --disable-werror --enable-bootstrap --enable-cet --enable-checking=release --enable-clocale=gnu --enable-default-pie --enable-gnu-unique-object --enable-languages=c,ada,c++,go,d,fortran,objc,obj-c++,m2,rust --enable-libphobos-checking=release --enable-libstdcxx-backtrace --enable-libstdcxx-debug --enable-libstdcxx-time=yes --enable-link-serialization=3 --enable-multiarch --enable-multilib --enable-nls --enable-objc-gc=auto --enable-offload-defaulted --enable-offload-targets=nvptx-none=/build/reproducible-path/gcc-14-14.2.0/debian/tmp-nvptx/usr,amdgcn-amdhsa=/build/reproducible-path/gcc-14-14.2.0/debian/tmp-gcn/usr --enable-plugin --enable-shared --enable-threads=posix --host=x86_64-linux-gnu --program-prefix=x86_64-linux-gnu- --target=x86_64-linux-gnu --with-abi=m64 --with-arch-32=i686 --with-build-config=bootstrap-lto-lean --with-default-libstdcxx-abi=new --with-gcc-major-version-only --with-multilib-list=m32,m64,mx32 --with-target-system-zlib=auto --with-tune=generic --without-cuda-driver -v"
+            },
+            {
+              "path": "ci.data.cpu-microcode",
+              "value": "0x1"
+            },
+            {
+              "path": "ci.data.kernel-extra-details",
+              "value": "Transparent Huge Pages: madvise"
+            },
+            {
+              "path": "ci.data.security",
+              "value": "gather_data_sampling: Not affected + indirect_target_selection: Mitigation of Aligned branch/return thunks + itlb_multihit: Not affected + l1tf: Not affected + mds: Not affected + meltdown: Not affected + mmio_stale_data: Not affected + reg_file_data_sampling: Not affected + retbleed: Not affected + spec_rstack_overflow: Not affected + spec_store_bypass: Mitigation of SSB disabled via prctl + spectre_v1: Mitigation of usercopy/swapgs barriers and __user pointer sanitization + spectre_v2: Mitigation of Enhanced / Automatic IBRS; IBPB: conditional; PBRSB-eIBRS: SW sequence; BHI: SW loop KVM: SW loop + srbds: Not affected + tsa: Not affected + tsx_async_abort: Not affected + vmscape: Not affected"
+            },
+            {
+              "path": "ci.hardware.Disk",
+              "value": "25GB"
+            },
+            {
+              "path": "ci.hardware.Memory",
+              "value": "8GB"
+            },
+            {
+              "path": "ci.hardware.Processor",
+              "value": "Intel Xeon (1 Core / 2 Threads)"
+            },
+            {
+              "path": "ci.identifier",
+              "value": "ci"
+            },
+            {
+              "path": "ci.software.Compiler",
+              "value": "GCC 14.2.0"
+            },
+            {
+              "path": "ci.software.File-System",
+              "value": "ext4"
+            },
+            {
+              "path": "ci.software.Kernel",
+              "value": "6.1.158+ (x86_64)"
+            },
+            {
+              "path": "ci.software.OS",
+              "value": "Debian GNU/Linux 13"
+            },
+            {
+              "path": "ci.software.System Layer",
+              "value": "KVM"
+            },
+            {
+              "path": "ci.timestamp",
+              "value": "2026-07-17 07:23:33"
+            },
+            {
+              "path": "ci.user",
+              "value": "root"
+            }
+          ]
+        },
+        {
+          "source": "mise/system-provider",
+          "sourceFile": "system/system-provider.json",
+          "fields": [
+            {
+              "path": "asn",
+              "value": "AS396982"
+            },
+            {
+              "path": "asn_source",
+              "value": "cymru"
+            },
+            {
+              "path": "bios_vendor",
+              "value": ""
+            },
+            {
+              "path": "city",
+              "value": "The Dalles"
+            },
+            {
+              "path": "cores",
+              "value": "2"
+            },
+            {
+              "path": "country",
+              "value": "US"
+            },
+            {
+              "path": "cpu_model",
+              "value": "Intel(R) Xeon(R) Processor @ 2.60GHz"
+            },
+            {
+              "path": "geo_source",
+              "value": "ipinfo"
+            },
+            {
+              "path": "kernel",
+              "value": "6.1.158+"
+            },
+            {
+              "path": "loc",
+              "value": "45.5946,-121.1787"
+            },
+            {
+              "path": "manufacturer",
+              "value": ""
+            },
+            {
+              "path": "org",
+              "value": "AS396982 Google LLC"
+            },
+            {
+              "path": "org_name",
+              "value": "Google LLC"
+            },
+            {
+              "path": "prefix",
+              "value": "35.252.64.0/18"
+            },
+            {
+              "path": "product_name",
+              "value": ""
+            },
+            {
+              "path": "public_ip",
+              "value": "35.252.65.249"
+            },
+            {
+              "path": "ram",
+              "value": "7.8Gi"
+            },
+            {
+              "path": "region",
+              "value": "Oregon"
+            },
+            {
+              "path": "reverse_dns",
+              "value": "249.65.252.35.bc.googleusercontent.com"
+            },
+            {
+              "path": "schema_version",
+              "value": "1.0"
+            },
+            {
+              "path": "timezone",
+              "value": "America/Los_Angeles"
+            },
+            {
+              "path": "virtualization",
+              "value": "kvm"
+            }
+          ]
+        }
+      ],
+      "metrics": [
+        {
+          "metricId": "fast_cli_internet_download_speed",
+          "samples": [3.4, 3.6],
+          "aggregates": {
+            "p50": 3.5,
+            "p95": 3.59,
+            "mean": 3.5,
+            "stdev": 0.14142135623730964,
+            "min": 3.4,
+            "max": 3.6,
+            "n": 2
+          },
+          "sourceFile": "network/pts_fast-cli.xml"
+        },
+        {
+          "metricId": "fast_cli_internet_latency",
+          "samples": [7, 7],
+          "aggregates": {
+            "p50": 7,
+            "p95": 7,
+            "mean": 7,
+            "stdev": 0,
+            "min": 7,
+            "max": 7,
+            "n": 2
+          },
+          "sourceFile": "network/pts_fast-cli.xml"
+        },
+        {
+          "metricId": "fast_cli_internet_loaded_latency_bufferbloat",
+          "samples": [6, 9],
+          "aggregates": {
+            "p50": 7.5,
+            "p95": 8.85,
+            "mean": 7.5,
+            "stdev": 2.1213203435596424,
+            "min": 6,
+            "max": 9,
+            "n": 2
+          },
+          "sourceFile": "network/pts_fast-cli.xml"
+        },
+        {
+          "metricId": "fast_cli_internet_upload_speed",
+          "samples": [720, 660],
+          "aggregates": {
+            "p50": 690,
+            "p95": 717,
+            "mean": 690,
+            "stdev": 42.42640687119285,
+            "min": 660,
+            "max": 720,
+            "n": 2
+          },
+          "sourceFile": "network/pts_fast-cli.xml"
+        },
+        {
+          "metricId": "fio_type_random_read_engine_linux_aio_direct_yes_block_size_4kb_job_count_1_disk_target_default_test_directory_iops",
+          "samples": [42600, 38600],
+          "aggregates": {
+            "p50": 40600,
+            "p95": 42400,
+            "mean": 40600,
+            "stdev": 2828.42712474619,
+            "min": 38600,
+            "max": 42600,
+            "n": 2
+          },
+          "sourceFile": "disk/pts_fio-rand-read.xml",
+          "appVersion": "3.36",
+          "arguments": "randread libaio 1 4k 1"
+        },
+        {
+          "metricId": "fio_type_random_read_engine_linux_aio_direct_yes_block_size_4kb_job_count_1_disk_target_default_test_directory_mb_per_s",
+          "samples": [166, 151],
+          "aggregates": {
+            "p50": 158.5,
+            "p95": 165.25,
+            "mean": 158.5,
+            "stdev": 10.606601717798213,
+            "min": 151,
+            "max": 166,
+            "n": 2
+          },
+          "sourceFile": "disk/pts_fio-rand-read.xml",
+          "appVersion": "3.36",
+          "arguments": "randread libaio 1 4k 1"
+        },
+        {
+          "metricId": "fio_type_random_write_engine_linux_aio_direct_yes_block_size_4kb_job_count_1_disk_target_default_test_directory_iops",
+          "samples": [42500, 41900],
+          "aggregates": {
+            "p50": 42200,
+            "p95": 42470,
+            "mean": 42200,
+            "stdev": 424.26406871192853,
+            "min": 41900,
+            "max": 42500,
+            "n": 2
+          },
+          "sourceFile": "disk/pts_fio-rand-write.xml",
+          "appVersion": "3.36",
+          "arguments": "randwrite libaio 1 4k 1"
+        },
+        {
+          "metricId": "fio_type_random_write_engine_linux_aio_direct_yes_block_size_4kb_job_count_1_disk_target_default_test_directory_mb_per_s",
+          "samples": [166, 164],
+          "aggregates": {
+            "p50": 165,
+            "p95": 165.9,
+            "mean": 165,
+            "stdev": 1.4142135623730951,
+            "min": 164,
+            "max": 166,
+            "n": 2
+          },
+          "sourceFile": "disk/pts_fio-rand-write.xml",
+          "appVersion": "3.36",
+          "arguments": "randwrite libaio 1 4k 1"
+        },
+        {
+          "metricId": "fio_type_sequential_read_engine_linux_aio_direct_yes_block_size_1mb_job_count_1_disk_target_default_test_directory_iops",
+          "samples": [599, 599],
+          "aggregates": {
+            "p50": 599,
+            "p95": 599,
+            "mean": 599,
+            "stdev": 0,
+            "min": 599,
+            "max": 599,
+            "n": 2
+          },
+          "sourceFile": "disk/pts_fio-seq-read.xml",
+          "appVersion": "3.36",
+          "arguments": "read libaio 1 1m 1"
+        },
+        {
+          "metricId": "fio_type_sequential_read_engine_linux_aio_direct_yes_block_size_1mb_job_count_1_disk_target_default_test_directory_mb_per_s",
+          "samples": [601, 601],
+          "aggregates": {
+            "p50": 601,
+            "p95": 601,
+            "mean": 601,
+            "stdev": 0,
+            "min": 601,
+            "max": 601,
+            "n": 2
+          },
+          "sourceFile": "disk/pts_fio-seq-read.xml",
+          "appVersion": "3.36",
+          "arguments": "read libaio 1 1m 1"
+        },
+        {
+          "metricId": "fio_type_sequential_write_engine_linux_aio_direct_yes_block_size_1mb_job_count_1_disk_target_default_test_directory_iops",
+          "samples": [599, 599],
+          "aggregates": {
+            "p50": 599,
+            "p95": 599,
+            "mean": 599,
+            "stdev": 0,
+            "min": 599,
+            "max": 599,
+            "n": 2
+          },
+          "sourceFile": "disk/pts_fio-seq-write.xml",
+          "appVersion": "3.36",
+          "arguments": "write libaio 1 1m 1"
+        },
+        {
+          "metricId": "fio_type_sequential_write_engine_linux_aio_direct_yes_block_size_1mb_job_count_1_disk_target_default_test_directory_mb_per_s",
+          "samples": [600, 601],
+          "aggregates": {
+            "p50": 600.5,
+            "p95": 600.95,
+            "mean": 600.5,
+            "stdev": 0.7071067811865476,
+            "min": 600,
+            "max": 601,
+            "n": 2
+          },
+          "sourceFile": "disk/pts_fio-seq-write.xml",
+          "appVersion": "3.36",
+          "arguments": "write libaio 1 1m 1"
+        },
+        {
+          "metricId": "git_seconds",
+          "samples": [72.368, 71.152],
+          "aggregates": {
+            "p50": 71.75999999999999,
+            "p95": 72.3072,
+            "mean": 71.75999999999999,
+            "stdev": 0.8598418459228425,
+            "min": 71.152,
+            "max": 72.368,
+            "n": 2
+          },
+          "sourceFile": "system/pts_git.xml"
+        },
+        {
+          "metricId": "hardlink_bogo_ops_per_s",
+          "samples": [1.43, 1.43],
+          "aggregates": {
+            "p50": 1.43,
+            "p95": 1.43,
+            "mean": 1.43,
+            "stdev": 0,
+            "min": 1.43,
+            "max": 1.43,
+            "n": 2
+          },
+          "sourceFile": "disk/pts_hardlink.xml",
+          "appVersion": "0.16"
+        },
+        {
+          "metricId": "network_loopback_seconds",
+          "samples": [12.574, 14.562],
+          "aggregates": {
+            "p50": 13.568,
+            "p95": 14.462599999999998,
+            "mean": 13.568,
+            "stdev": 1.4057282809988563,
+            "min": 12.574,
+            "max": 14.562,
+            "n": 2
+          },
+          "sourceFile": "network/pts_network-loopback.xml"
+        },
+        {
+          "metricId": "node_web_tooling_runs_per_s",
+          "samples": [10.43, 10.22],
+          "aggregates": {
+            "p50": 10.325,
+            "p95": 10.4195,
+            "mean": 10.325,
+            "stdev": 0.14849242404917495,
+            "min": 10.22,
+            "max": 10.43,
+            "n": 2
+          },
+          "sourceFile": "cpu-node/pts_node-web-tooling.xml"
+        },
+        {
+          "metricId": "realworld_better_auth_task_build",
+          "samples": [22.044, 21.692],
+          "aggregates": {
+            "p50": 21.868000000000002,
+            "p95": 22.0264,
+            "mean": 21.868000000000002,
+            "stdev": 0.2489015869776637,
+            "min": 21.692,
+            "max": 22.044,
+            "n": 2
+          },
+          "sourceFile": "realworld-better-auth/pts_realworld-better-auth.xml",
+          "appVersion": "6f3ba45639579da152b69e8e5342e02f28288670",
+          "arguments": "build"
+        },
+        {
+          "metricId": "realworld_better_auth_task_cold_install",
+          "samples": [20.191, 19.655],
+          "aggregates": {
+            "p50": 19.923000000000002,
+            "p95": 20.164199999999997,
+            "mean": 19.923000000000002,
+            "stdev": 0.3790092347159867,
+            "min": 19.655,
+            "max": 20.191,
+            "n": 2
+          },
+          "sourceFile": "realworld-better-auth/pts_realworld-better-auth.xml",
+          "appVersion": "6f3ba45639579da152b69e8e5342e02f28288670",
+          "arguments": "cold_install"
+        },
+        {
+          "metricId": "realworld_better_auth_task_git_clone",
+          "samples": [1.76, 1.621],
+          "aggregates": {
+            "p50": 1.6905000000000001,
+            "p95": 1.75305,
+            "mean": 1.6905000000000001,
+            "stdev": 0.09828784258493004,
+            "min": 1.621,
+            "max": 1.76,
+            "n": 2
+          },
+          "sourceFile": "realworld-better-auth/pts_realworld-better-auth.xml",
+          "appVersion": "6f3ba45639579da152b69e8e5342e02f28288670",
+          "arguments": "git_clone"
+        },
+        {
+          "metricId": "realworld_better_auth_task_lint_biome",
+          "samples": [8.212, 8.014],
+          "aggregates": {
+            "p50": 8.113,
+            "p95": 8.2021,
+            "mean": 8.113,
+            "stdev": 0.1400071426749367,
+            "min": 8.014,
+            "max": 8.212,
+            "n": 2
+          },
+          "sourceFile": "realworld-better-auth/pts_realworld-better-auth.xml",
+          "appVersion": "6f3ba45639579da152b69e8e5342e02f28288670",
+          "arguments": "lint_biome"
+        },
+        {
+          "metricId": "realworld_better_auth_task_lint_deps_knip",
+          "samples": [21.006, 19.014],
+          "aggregates": {
+            "p50": 20.009999999999998,
+            "p95": 20.9064,
+            "mean": 20.009999999999998,
+            "stdev": 1.4085567081236046,
+            "min": 19.014,
+            "max": 21.006,
+            "n": 2
+          },
+          "sourceFile": "realworld-better-auth/pts_realworld-better-auth.xml",
+          "appVersion": "6f3ba45639579da152b69e8e5342e02f28288670",
+          "arguments": "lint_deps"
+        },
+        {
+          "metricId": "realworld_better_auth_task_lint_format",
+          "samples": [5.567, 5.258],
+          "aggregates": {
+            "p50": 5.4125,
+            "p95": 5.55155,
+            "mean": 5.4125,
+            "stdev": 0.2184959953866436,
+            "min": 5.258,
+            "max": 5.567,
+            "n": 2
+          },
+          "sourceFile": "realworld-better-auth/pts_realworld-better-auth.xml",
+          "appVersion": "6f3ba45639579da152b69e8e5342e02f28288670",
+          "arguments": "lint_format"
+        },
+        {
+          "metricId": "realworld_better_auth_task_lint_packages",
+          "samples": [7.33, 7.689],
+          "aggregates": {
+            "p50": 7.5095,
+            "p95": 7.67105,
+            "mean": 7.5095,
+            "stdev": 0.2538513344459706,
+            "min": 7.33,
+            "max": 7.689,
+            "n": 2
+          },
+          "sourceFile": "realworld-better-auth/pts_realworld-better-auth.xml",
+          "appVersion": "6f3ba45639579da152b69e8e5342e02f28288670",
+          "arguments": "lint_packages"
+        },
+        {
+          "metricId": "realworld_better_auth_task_lint_spell",
+          "samples": [13.485, 13.062],
+          "aggregates": {
+            "p50": 13.273499999999999,
+            "p95": 13.463849999999999,
+            "mean": 13.273499999999999,
+            "stdev": 0.29910616844191024,
+            "min": 13.062,
+            "max": 13.485,
+            "n": 2
+          },
+          "sourceFile": "realworld-better-auth/pts_realworld-better-auth.xml",
+          "appVersion": "6f3ba45639579da152b69e8e5342e02f28288670",
+          "arguments": "lint_spell"
+        },
+        {
+          "metricId": "realworld_better_auth_task_lint_types",
+          "samples": [98.254, 103.19],
+          "aggregates": {
+            "p50": 100.72200000000001,
+            "p95": 102.9432,
+            "mean": 100.72200000000001,
+            "stdev": 3.490279071936788,
+            "min": 98.254,
+            "max": 103.19,
+            "n": 2
+          },
+          "sourceFile": "realworld-better-auth/pts_realworld-better-auth.xml",
+          "appVersion": "6f3ba45639579da152b69e8e5342e02f28288670",
+          "arguments": "lint_types"
+        },
+        {
+          "metricId": "realworld_better_auth_task_typecheck",
+          "samples": [2.474, 2.371],
+          "aggregates": {
+            "p50": 2.4225000000000003,
+            "p95": 2.46885,
+            "mean": 2.4225000000000003,
+            "stdev": 0.07283199846221437,
+            "min": 2.371,
+            "max": 2.474,
+            "n": 2
+          },
+          "sourceFile": "realworld-better-auth/pts_realworld-better-auth.xml",
+          "appVersion": "6f3ba45639579da152b69e8e5342e02f28288670",
+          "arguments": "typecheck"
+        },
+        {
+          "metricId": "sqlite_speedtest_seconds",
+          "samples": [70.973, 71.077],
+          "aggregates": {
+            "p50": 71.025,
+            "p95": 71.0718,
+            "mean": 71.025,
+            "stdev": 0.07353910524339535,
+            "min": 70.973,
+            "max": 71.077,
+            "n": 2
+          },
+          "sourceFile": "system/pts_sqlite-speedtest.xml",
+          "appVersion": "3.30"
+        },
+        {
+          "metricId": "stream_type_add",
+          "samples": [22614.3, 22061.7],
+          "aggregates": {
+            "p50": 22338,
+            "p95": 22586.67,
+            "mean": 22338,
+            "stdev": 390.7472072836851,
+            "min": 22061.7,
+            "max": 22614.3,
+            "n": 2
+          },
+          "sourceFile": "memory/pts_stream.xml",
+          "appVersion": "2013-01-17",
+          "arguments": "Add"
+        },
+        {
+          "metricId": "stream_type_copy",
+          "samples": [46984.7, 46532.7],
+          "aggregates": {
+            "p50": 46758.7,
+            "p95": 46962.1,
+            "mean": 46758.7,
+            "stdev": 319.6122650963195,
+            "min": 46532.7,
+            "max": 46984.7,
+            "n": 2
+          },
+          "sourceFile": "memory/pts_stream.xml",
+          "appVersion": "2013-01-17",
+          "arguments": "Copy"
+        },
+        {
+          "metricId": "stream_type_scale",
+          "samples": [21523.7, 20727.4],
+          "aggregates": {
+            "p50": 21125.550000000003,
+            "p95": 21483.885000000002,
+            "mean": 21125.550000000003,
+            "stdev": 563.069129858846,
+            "min": 20727.4,
+            "max": 21523.7,
+            "n": 2
+          },
+          "sourceFile": "memory/pts_stream.xml",
+          "appVersion": "2013-01-17",
+          "arguments": "Scale"
+        },
+        {
+          "metricId": "stream_type_triad",
+          "samples": [22574.2, 22321.6],
+          "aggregates": {
+            "p50": 22447.9,
+            "p95": 22561.57,
+            "mean": 22447.9,
+            "stdev": 178.61517292772217,
+            "min": 22321.6,
+            "max": 22574.2,
+            "n": 2
+          },
+          "sourceFile": "memory/pts_stream.xml",
+          "appVersion": "2013-01-17",
+          "arguments": "Triad"
+        },
+        {
+          "metricId": "usd_per_hour",
+          "samples": [0.2304],
+          "aggregates": {
+            "p50": 0.2304,
+            "p95": 0.2304,
+            "mean": 0.2304,
+            "stdev": 0,
+            "min": 0.2304,
+            "max": 0.2304,
+            "n": 1
+          }
+        }
+      ],
+      "suitesCovered": ["cpu-node", "disk", "memory", "network", "realworld-better-auth", "system"],
+      "gaps": [
+        {
+          "scope": "suite",
+          "id": "cpu-generic",
+          "outcome": "failed",
+          "reason": "Step \"mise run benchmark:cpu:generic\" timed out after 7800s"
+        },
+        {
+          "scope": "suite",
+          "id": "realworld-mastra",
+          "outcome": "skipped",
+          "reason": "Insufficient disk: 20.0 GiB free, suite needs 30 GiB"
+        },
+        {
+          "scope": "suite",
+          "id": "realworld-openclaw",
+          "outcome": "skipped",
+          "reason": "Insufficient disk: 20.0 GiB free, suite needs 25 GiB"
+        }
+      ],
+      "uncatalogued": []
+    },
+    {
+      "providerId": "modal",
+      "validationStatus": "validated",
+      "specMatched": true,
+      "observedSpecs": {
+        "vcpus": 2,
+        "cpuModel": "unknown",
+        "virtualization": "unknown",
+        "memoryGb": 8,
+        "kernel": "4.19.0-gvisor",
+        "os": "Debian GNU/Linux 13 (trixie)",
+        "user": "root",
+        "hostVcpus": 2,
+        "hostMemoryGb": 8,
+        "publicIp": "172.202.193.152",
+        "egressOrg": "AS8075 Microsoft Corporation",
+        "egressAsn": "AS8075",
+        "egressOrgName": "Microsoft Corporation",
+        "city": "San Antonio",
+        "region": "Texas",
+        "country": "US",
+        "location": "29.4241,-98.4936",
+        "timezone": "America/Chicago",
+        "networkPrefix": "172.200.0.0/13",
+        "asnSource": "cymru",
+        "geoSource": "ipinfo"
+      },
+      "hostMetadata": [
+        {
+          "source": "phoronix/result-file-to-json",
+          "sourceFile": "cpu-node/pts_node-web-tooling--metadata.json",
+          "fields": [
+            {
+              "path": "ci.client_version",
+              "value": "10.8.4"
+            },
+            {
+              "path": "ci.data.environment-variables",
+              "value": "CFLAGS=-g0"
+            },
+            {
+              "path": "ci.hardware.Disk",
+              "value": "8589934592GB"
+            },
+            {
+              "path": "ci.hardware.Memory",
+              "value": "8GB"
+            },
+            {
+              "path": "ci.hardware.Processor",
+              "value": "unknown (2 Cores)"
+            },
+            {
+              "path": "ci.identifier",
+              "value": "ci"
+            },
+            {
+              "path": "ci.software.Compiler",
+              "value": "GCC 14.2.0"
+            },
+            {
+              "path": "ci.software.File-System",
+              "value": "overlayfs"
+            },
+            {
+              "path": "ci.software.Kernel",
+              "value": "4.19.0-gvisor (x86_64)"
+            },
+            {
+              "path": "ci.software.OS",
+              "value": "Debian GNU/Linux 13"
+            },
+            {
+              "path": "ci.timestamp",
+              "value": "2026-07-17 07:23:32"
+            },
+            {
+              "path": "ci.user",
+              "value": "root"
+            }
+          ]
+        },
+        {
+          "source": "phoronix/result-file-to-json",
+          "sourceFile": "disk/pts_fio-rand-read--metadata.json",
+          "fields": [
+            {
+              "path": "ci.client_version",
+              "value": "10.8.4"
+            },
+            {
+              "path": "ci.data.compiler-configuration",
+              "value": "--build=x86_64-linux-gnu --disable-vtable-verify --disable-werror --enable-bootstrap --enable-cet --enable-checking=release --enable-clocale=gnu --enable-default-pie --enable-gnu-unique-object --enable-languages=c,ada,c++,go,d,fortran,objc,obj-c++,m2,rust --enable-libphobos-checking=release --enable-libstdcxx-backtrace --enable-libstdcxx-debug --enable-libstdcxx-time=yes --enable-link-serialization=3 --enable-multiarch --enable-multilib --enable-nls --enable-objc-gc=auto --enable-offload-defaulted --enable-offload-targets=nvptx-none=/build/reproducible-path/gcc-14-14.2.0/debian/tmp-nvptx/usr,amdgcn-amdhsa=/build/reproducible-path/gcc-14-14.2.0/debian/tmp-gcn/usr --enable-plugin --enable-shared --enable-threads=posix --host=x86_64-linux-gnu --program-prefix=x86_64-linux-gnu- --target=x86_64-linux-gnu --with-abi=m64 --with-arch-32=i686 --with-build-config=bootstrap-lto-lean --with-default-libstdcxx-abi=new --with-gcc-major-version-only --with-multilib-list=m32,m64,mx32 --with-target-system-zlib=auto --with-tune=generic --without-cuda-driver -v"
+            },
+            {
+              "path": "ci.data.environment-variables",
+              "value": "CFLAGS=-g0"
+            },
+            {
+              "path": "ci.hardware.Disk",
+              "value": "8589934592GB"
+            },
+            {
+              "path": "ci.hardware.Memory",
+              "value": "8GB"
+            },
+            {
+              "path": "ci.hardware.Processor",
+              "value": "unknown (2 Cores)"
+            },
+            {
+              "path": "ci.identifier",
+              "value": "ci"
+            },
+            {
+              "path": "ci.software.Compiler",
+              "value": "GCC 14.2.0"
+            },
+            {
+              "path": "ci.software.File-System",
+              "value": "overlayfs"
+            },
+            {
+              "path": "ci.software.Kernel",
+              "value": "4.19.0-gvisor (x86_64)"
+            },
+            {
+              "path": "ci.software.OS",
+              "value": "Debian GNU/Linux 13"
+            },
+            {
+              "path": "ci.timestamp",
+              "value": "2026-07-17 07:31:13"
+            },
+            {
+              "path": "ci.user",
+              "value": "root"
+            }
+          ]
+        },
+        {
+          "source": "phoronix/result-file-to-json",
+          "sourceFile": "disk/pts_fio-rand-write--metadata.json",
+          "fields": [
+            {
+              "path": "ci.client_version",
+              "value": "10.8.4"
+            },
+            {
+              "path": "ci.data.compiler-configuration",
+              "value": "--build=x86_64-linux-gnu --disable-vtable-verify --disable-werror --enable-bootstrap --enable-cet --enable-checking=release --enable-clocale=gnu --enable-default-pie --enable-gnu-unique-object --enable-languages=c,ada,c++,go,d,fortran,objc,obj-c++,m2,rust --enable-libphobos-checking=release --enable-libstdcxx-backtrace --enable-libstdcxx-debug --enable-libstdcxx-time=yes --enable-link-serialization=3 --enable-multiarch --enable-multilib --enable-nls --enable-objc-gc=auto --enable-offload-defaulted --enable-offload-targets=nvptx-none=/build/reproducible-path/gcc-14-14.2.0/debian/tmp-nvptx/usr,amdgcn-amdhsa=/build/reproducible-path/gcc-14-14.2.0/debian/tmp-gcn/usr --enable-plugin --enable-shared --enable-threads=posix --host=x86_64-linux-gnu --program-prefix=x86_64-linux-gnu- --target=x86_64-linux-gnu --with-abi=m64 --with-arch-32=i686 --with-build-config=bootstrap-lto-lean --with-default-libstdcxx-abi=new --with-gcc-major-version-only --with-multilib-list=m32,m64,mx32 --with-target-system-zlib=auto --with-tune=generic --without-cuda-driver -v"
+            },
+            {
+              "path": "ci.data.environment-variables",
+              "value": "CFLAGS=-g0"
+            },
+            {
+              "path": "ci.hardware.Disk",
+              "value": "8589934592GB"
+            },
+            {
+              "path": "ci.hardware.Memory",
+              "value": "8GB"
+            },
+            {
+              "path": "ci.hardware.Processor",
+              "value": "unknown (2 Cores)"
+            },
+            {
+              "path": "ci.identifier",
+              "value": "ci"
+            },
+            {
+              "path": "ci.software.Compiler",
+              "value": "GCC 14.2.0"
+            },
+            {
+              "path": "ci.software.File-System",
+              "value": "overlayfs"
+            },
+            {
+              "path": "ci.software.Kernel",
+              "value": "4.19.0-gvisor (x86_64)"
+            },
+            {
+              "path": "ci.software.OS",
+              "value": "Debian GNU/Linux 13"
+            },
+            {
+              "path": "ci.timestamp",
+              "value": "2026-07-17 07:34:36"
+            },
+            {
+              "path": "ci.user",
+              "value": "root"
+            }
+          ]
+        },
+        {
+          "source": "phoronix/result-file-to-json",
+          "sourceFile": "disk/pts_fio-seq-read--metadata.json",
+          "fields": [
+            {
+              "path": "ci.client_version",
+              "value": "10.8.4"
+            },
+            {
+              "path": "ci.data.compiler-configuration",
+              "value": "--build=x86_64-linux-gnu --disable-vtable-verify --disable-werror --enable-bootstrap --enable-cet --enable-checking=release --enable-clocale=gnu --enable-default-pie --enable-gnu-unique-object --enable-languages=c,ada,c++,go,d,fortran,objc,obj-c++,m2,rust --enable-libphobos-checking=release --enable-libstdcxx-backtrace --enable-libstdcxx-debug --enable-libstdcxx-time=yes --enable-link-serialization=3 --enable-multiarch --enable-multilib --enable-nls --enable-objc-gc=auto --enable-offload-defaulted --enable-offload-targets=nvptx-none=/build/reproducible-path/gcc-14-14.2.0/debian/tmp-nvptx/usr,amdgcn-amdhsa=/build/reproducible-path/gcc-14-14.2.0/debian/tmp-gcn/usr --enable-plugin --enable-shared --enable-threads=posix --host=x86_64-linux-gnu --program-prefix=x86_64-linux-gnu- --target=x86_64-linux-gnu --with-abi=m64 --with-arch-32=i686 --with-build-config=bootstrap-lto-lean --with-default-libstdcxx-abi=new --with-gcc-major-version-only --with-multilib-list=m32,m64,mx32 --with-target-system-zlib=auto --with-tune=generic --without-cuda-driver -v"
+            },
+            {
+              "path": "ci.data.environment-variables",
+              "value": "CFLAGS=-g0"
+            },
+            {
+              "path": "ci.hardware.Disk",
+              "value": "8589934592GB"
+            },
+            {
+              "path": "ci.hardware.Memory",
+              "value": "8GB"
+            },
+            {
+              "path": "ci.hardware.Processor",
+              "value": "unknown (2 Cores)"
+            },
+            {
+              "path": "ci.identifier",
+              "value": "ci"
+            },
+            {
+              "path": "ci.software.Compiler",
+              "value": "GCC 14.2.0"
+            },
+            {
+              "path": "ci.software.File-System",
+              "value": "overlayfs"
+            },
+            {
+              "path": "ci.software.Kernel",
+              "value": "4.19.0-gvisor (x86_64)"
+            },
+            {
+              "path": "ci.software.OS",
+              "value": "Debian GNU/Linux 13"
+            },
+            {
+              "path": "ci.timestamp",
+              "value": "2026-07-17 07:24:25"
+            },
+            {
+              "path": "ci.user",
+              "value": "root"
+            }
+          ]
+        },
+        {
+          "source": "phoronix/result-file-to-json",
+          "sourceFile": "disk/pts_fio-seq-write--metadata.json",
+          "fields": [
+            {
+              "path": "ci.client_version",
+              "value": "10.8.4"
+            },
+            {
+              "path": "ci.data.compiler-configuration",
+              "value": "--build=x86_64-linux-gnu --disable-vtable-verify --disable-werror --enable-bootstrap --enable-cet --enable-checking=release --enable-clocale=gnu --enable-default-pie --enable-gnu-unique-object --enable-languages=c,ada,c++,go,d,fortran,objc,obj-c++,m2,rust --enable-libphobos-checking=release --enable-libstdcxx-backtrace --enable-libstdcxx-debug --enable-libstdcxx-time=yes --enable-link-serialization=3 --enable-multiarch --enable-multilib --enable-nls --enable-objc-gc=auto --enable-offload-defaulted --enable-offload-targets=nvptx-none=/build/reproducible-path/gcc-14-14.2.0/debian/tmp-nvptx/usr,amdgcn-amdhsa=/build/reproducible-path/gcc-14-14.2.0/debian/tmp-gcn/usr --enable-plugin --enable-shared --enable-threads=posix --host=x86_64-linux-gnu --program-prefix=x86_64-linux-gnu- --target=x86_64-linux-gnu --with-abi=m64 --with-arch-32=i686 --with-build-config=bootstrap-lto-lean --with-default-libstdcxx-abi=new --with-gcc-major-version-only --with-multilib-list=m32,m64,mx32 --with-target-system-zlib=auto --with-tune=generic --without-cuda-driver -v"
+            },
+            {
+              "path": "ci.data.environment-variables",
+              "value": "CFLAGS=-g0"
+            },
+            {
+              "path": "ci.hardware.Disk",
+              "value": "8589934592GB"
+            },
+            {
+              "path": "ci.hardware.Memory",
+              "value": "8GB"
+            },
+            {
+              "path": "ci.hardware.Processor",
+              "value": "unknown (2 Cores)"
+            },
+            {
+              "path": "ci.identifier",
+              "value": "ci"
+            },
+            {
+              "path": "ci.software.Compiler",
+              "value": "GCC 14.2.0"
+            },
+            {
+              "path": "ci.software.File-System",
+              "value": "overlayfs"
+            },
+            {
+              "path": "ci.software.Kernel",
+              "value": "4.19.0-gvisor (x86_64)"
+            },
+            {
+              "path": "ci.software.OS",
+              "value": "Debian GNU/Linux 13"
+            },
+            {
+              "path": "ci.timestamp",
+              "value": "2026-07-17 07:27:41"
+            },
+            {
+              "path": "ci.user",
+              "value": "root"
+            }
+          ]
+        },
+        {
+          "source": "phoronix/result-file-to-json",
+          "sourceFile": "disk/pts_hardlink--metadata.json",
+          "fields": [
+            {
+              "path": "ci.client_version",
+              "value": "10.8.4"
+            },
+            {
+              "path": "ci.data.compiler-configuration",
+              "value": "--build=x86_64-linux-gnu --disable-vtable-verify --disable-werror --enable-bootstrap --enable-cet --enable-checking=release --enable-clocale=gnu --enable-default-pie --enable-gnu-unique-object --enable-languages=c,ada,c++,go,d,fortran,objc,obj-c++,m2,rust --enable-libphobos-checking=release --enable-libstdcxx-backtrace --enable-libstdcxx-debug --enable-libstdcxx-time=yes --enable-link-serialization=3 --enable-multiarch --enable-multilib --enable-nls --enable-objc-gc=auto --enable-offload-defaulted --enable-offload-targets=nvptx-none=/build/reproducible-path/gcc-14-14.2.0/debian/tmp-nvptx/usr,amdgcn-amdhsa=/build/reproducible-path/gcc-14-14.2.0/debian/tmp-gcn/usr --enable-plugin --enable-shared --enable-threads=posix --host=x86_64-linux-gnu --program-prefix=x86_64-linux-gnu- --target=x86_64-linux-gnu --with-abi=m64 --with-arch-32=i686 --with-build-config=bootstrap-lto-lean --with-default-libstdcxx-abi=new --with-gcc-major-version-only --with-multilib-list=m32,m64,mx32 --with-target-system-zlib=auto --with-tune=generic --without-cuda-driver -v"
+            },
+            {
+              "path": "ci.data.environment-variables",
+              "value": "CFLAGS=-g0"
+            },
+            {
+              "path": "ci.hardware.Disk",
+              "value": "8589934592GB"
+            },
+            {
+              "path": "ci.hardware.Memory",
+              "value": "8GB"
+            },
+            {
+              "path": "ci.hardware.Processor",
+              "value": "unknown (2 Cores)"
+            },
+            {
+              "path": "ci.identifier",
+              "value": "ci"
+            },
+            {
+              "path": "ci.software.Compiler",
+              "value": "GCC 14.2.0"
+            },
+            {
+              "path": "ci.software.File-System",
+              "value": "overlayfs"
+            },
+            {
+              "path": "ci.software.Kernel",
+              "value": "4.19.0-gvisor (x86_64)"
+            },
+            {
+              "path": "ci.software.OS",
+              "value": "Debian GNU/Linux 13"
+            },
+            {
+              "path": "ci.timestamp",
+              "value": "2026-07-17 07:37:57"
+            },
+            {
+              "path": "ci.user",
+              "value": "root"
+            }
+          ]
+        },
+        {
+          "source": "phoronix/result-file-to-json",
+          "sourceFile": "memory/pts_stream--metadata.json",
+          "fields": [
+            {
+              "path": "ci.client_version",
+              "value": "10.8.4"
+            },
+            {
+              "path": "ci.data.compiler-configuration",
+              "value": "--build=x86_64-linux-gnu --disable-vtable-verify --disable-werror --enable-bootstrap --enable-cet --enable-checking=release --enable-clocale=gnu --enable-default-pie --enable-gnu-unique-object --enable-languages=c,ada,c++,go,d,fortran,objc,obj-c++,m2,rust --enable-libphobos-checking=release --enable-libstdcxx-backtrace --enable-libstdcxx-debug --enable-libstdcxx-time=yes --enable-link-serialization=3 --enable-multiarch --enable-multilib --enable-nls --enable-objc-gc=auto --enable-offload-defaulted --enable-offload-targets=nvptx-none=/build/reproducible-path/gcc-14-14.2.0/debian/tmp-nvptx/usr,amdgcn-amdhsa=/build/reproducible-path/gcc-14-14.2.0/debian/tmp-gcn/usr --enable-plugin --enable-shared --enable-threads=posix --host=x86_64-linux-gnu --program-prefix=x86_64-linux-gnu- --target=x86_64-linux-gnu --with-abi=m64 --with-arch-32=i686 --with-build-config=bootstrap-lto-lean --with-default-libstdcxx-abi=new --with-gcc-major-version-only --with-multilib-list=m32,m64,mx32 --with-target-system-zlib=auto --with-tune=generic --without-cuda-driver -v"
+            },
+            {
+              "path": "ci.data.environment-variables",
+              "value": "CFLAGS=-g0 CFLAGS_OVERRIDE=\"-O3 -march=native -DSTREAM_ARRAY_SIZE=150000000\""
+            },
+            {
+              "path": "ci.hardware.Disk",
+              "value": "8589934592GB"
+            },
+            {
+              "path": "ci.hardware.Memory",
+              "value": "8GB"
+            },
+            {
+              "path": "ci.hardware.Processor",
+              "value": "unknown (2 Cores)"
+            },
+            {
+              "path": "ci.identifier",
+              "value": "ci"
+            },
+            {
+              "path": "ci.software.Compiler",
+              "value": "GCC 14.2.0"
+            },
+            {
+              "path": "ci.software.File-System",
+              "value": "overlayfs"
+            },
+            {
+              "path": "ci.software.Kernel",
+              "value": "4.19.0-gvisor (x86_64)"
+            },
+            {
+              "path": "ci.software.OS",
+              "value": "Debian GNU/Linux 13"
+            },
+            {
+              "path": "ci.timestamp",
+              "value": "2026-07-17 07:23:32"
+            },
+            {
+              "path": "ci.user",
+              "value": "root"
+            }
+          ]
+        },
+        {
+          "source": "phoronix/result-file-to-json",
+          "sourceFile": "network/pts_fast-cli--metadata.json",
+          "fields": [
+            {
+              "path": "ci.client_version",
+              "value": "10.8.4"
+            },
+            {
+              "path": "ci.data.environment-variables",
+              "value": "CFLAGS=-g0"
+            },
+            {
+              "path": "ci.hardware.Disk",
+              "value": "8589934592GB"
+            },
+            {
+              "path": "ci.hardware.Memory",
+              "value": "8GB"
+            },
+            {
+              "path": "ci.hardware.Processor",
+              "value": "unknown (2 Cores)"
+            },
+            {
+              "path": "ci.identifier",
+              "value": "ci"
+            },
+            {
+              "path": "ci.software.Compiler",
+              "value": "GCC 14.2.0"
+            },
+            {
+              "path": "ci.software.File-System",
+              "value": "overlayfs"
+            },
+            {
+              "path": "ci.software.Kernel",
+              "value": "4.19.0-gvisor (x86_64)"
+            },
+            {
+              "path": "ci.software.OS",
+              "value": "Debian GNU/Linux 13"
+            },
+            {
+              "path": "ci.timestamp",
+              "value": "2026-07-17 07:26:22"
+            },
+            {
+              "path": "ci.user",
+              "value": "root"
+            }
+          ]
+        },
+        {
+          "source": "phoronix/result-file-to-json",
+          "sourceFile": "network/pts_network-loopback--metadata.json",
+          "fields": [
+            {
+              "path": "ci.client_version",
+              "value": "10.8.4"
+            },
+            {
+              "path": "ci.data.environment-variables",
+              "value": "CFLAGS=-g0"
+            },
+            {
+              "path": "ci.hardware.Disk",
+              "value": "8589934592GB"
+            },
+            {
+              "path": "ci.hardware.Memory",
+              "value": "8GB"
+            },
+            {
+              "path": "ci.hardware.Processor",
+              "value": "unknown (2 Cores)"
+            },
+            {
+              "path": "ci.identifier",
+              "value": "ci"
+            },
+            {
+              "path": "ci.software.Compiler",
+              "value": "GCC 14.2.0"
+            },
+            {
+              "path": "ci.software.File-System",
+              "value": "overlayfs"
+            },
+            {
+              "path": "ci.software.Kernel",
+              "value": "4.19.0-gvisor (x86_64)"
+            },
+            {
+              "path": "ci.software.OS",
+              "value": "Debian GNU/Linux 13"
+            },
+            {
+              "path": "ci.timestamp",
+              "value": "2026-07-17 07:23:30"
+            },
+            {
+              "path": "ci.user",
+              "value": "root"
+            }
+          ]
+        },
+        {
+          "source": "phoronix/result-file-to-json",
+          "sourceFile": "realworld-better-auth/pts_realworld-better-auth--metadata.json",
+          "fields": [
+            {
+              "path": "ci.client_version",
+              "value": "10.8.4"
+            },
+            {
+              "path": "ci.data.environment-variables",
+              "value": "CFLAGS=-g0"
+            },
+            {
+              "path": "ci.hardware.Disk",
+              "value": "8589934592GB"
+            },
+            {
+              "path": "ci.hardware.Memory",
+              "value": "8GB"
+            },
+            {
+              "path": "ci.hardware.Processor",
+              "value": "unknown (2 Cores)"
+            },
+            {
+              "path": "ci.identifier",
+              "value": "ci"
+            },
+            {
+              "path": "ci.software.Compiler",
+              "value": "GCC 14.2.0"
+            },
+            {
+              "path": "ci.software.File-System",
+              "value": "overlayfs"
+            },
+            {
+              "path": "ci.software.Kernel",
+              "value": "4.19.0-gvisor (x86_64)"
+            },
+            {
+              "path": "ci.software.OS",
+              "value": "Debian GNU/Linux 13"
+            },
+            {
+              "path": "ci.timestamp",
+              "value": "2026-07-17 07:24:31"
+            },
+            {
+              "path": "ci.user",
+              "value": "root"
+            }
+          ]
+        },
+        {
+          "source": "phoronix/result-file-to-json",
+          "sourceFile": "realworld-mastra/pts_realworld-mastra--metadata.json",
+          "fields": [
+            {
+              "path": "ci.client_version",
+              "value": "10.8.4"
+            },
+            {
+              "path": "ci.data.environment-variables",
+              "value": "CFLAGS=-g0"
+            },
+            {
+              "path": "ci.hardware.Disk",
+              "value": "8589934592GB"
+            },
+            {
+              "path": "ci.hardware.Memory",
+              "value": "8GB"
+            },
+            {
+              "path": "ci.hardware.Processor",
+              "value": "unknown (2 Cores)"
+            },
+            {
+              "path": "ci.identifier",
+              "value": "ci"
+            },
+            {
+              "path": "ci.software.Compiler",
+              "value": "GCC 14.2.0"
+            },
+            {
+              "path": "ci.software.File-System",
+              "value": "overlayfs"
+            },
+            {
+              "path": "ci.software.Kernel",
+              "value": "4.19.0-gvisor (x86_64)"
+            },
+            {
+              "path": "ci.software.OS",
+              "value": "Debian GNU/Linux 13"
+            },
+            {
+              "path": "ci.timestamp",
+              "value": "2026-07-17 07:26:25"
+            },
+            {
+              "path": "ci.user",
+              "value": "root"
+            }
+          ]
+        },
+        {
+          "source": "phoronix/result-file-to-json",
+          "sourceFile": "system/pts_git--metadata.json",
+          "fields": [
+            {
+              "path": "ci.client_version",
+              "value": "10.8.4"
+            },
+            {
+              "path": "ci.data.environment-variables",
+              "value": "CFLAGS=-g0"
+            },
+            {
+              "path": "ci.hardware.Disk",
+              "value": "8589934592GB"
+            },
+            {
+              "path": "ci.hardware.Memory",
+              "value": "8GB"
+            },
+            {
+              "path": "ci.hardware.Processor",
+              "value": "unknown (2 Cores)"
+            },
+            {
+              "path": "ci.identifier",
+              "value": "ci"
+            },
+            {
+              "path": "ci.software.Compiler",
+              "value": "GCC 14.2.0"
+            },
+            {
+              "path": "ci.software.File-System",
+              "value": "overlayfs"
+            },
+            {
+              "path": "ci.software.Kernel",
+              "value": "4.19.0-gvisor (x86_64)"
+            },
+            {
+              "path": "ci.software.OS",
+              "value": "Debian GNU/Linux 13"
+            },
+            {
+              "path": "ci.timestamp",
+              "value": "2026-07-17 07:45:21"
+            },
+            {
+              "path": "ci.user",
+              "value": "root"
+            }
+          ]
+        },
+        {
+          "source": "phoronix/result-file-to-json",
+          "sourceFile": "system/pts_pgbench-read-only--metadata.json",
+          "fields": [
+            {
+              "path": "ci.client_version",
+              "value": "10.8.4"
+            },
+            {
+              "path": "ci.data.compiler-configuration",
+              "value": "--build=x86_64-linux-gnu --disable-vtable-verify --disable-werror --enable-bootstrap --enable-cet --enable-checking=release --enable-clocale=gnu --enable-default-pie --enable-gnu-unique-object --enable-languages=c,ada,c++,go,d,fortran,objc,obj-c++,m2,rust --enable-libphobos-checking=release --enable-libstdcxx-backtrace --enable-libstdcxx-debug --enable-libstdcxx-time=yes --enable-link-serialization=3 --enable-multiarch --enable-multilib --enable-nls --enable-objc-gc=auto --enable-offload-defaulted --enable-offload-targets=nvptx-none=/build/reproducible-path/gcc-14-14.2.0/debian/tmp-nvptx/usr,amdgcn-amdhsa=/build/reproducible-path/gcc-14-14.2.0/debian/tmp-gcn/usr --enable-plugin --enable-shared --enable-threads=posix --host=x86_64-linux-gnu --program-prefix=x86_64-linux-gnu- --target=x86_64-linux-gnu --with-abi=m64 --with-arch-32=i686 --with-build-config=bootstrap-lto-lean --with-default-libstdcxx-abi=new --with-gcc-major-version-only --with-multilib-list=m32,m64,mx32 --with-target-system-zlib=auto --with-tune=generic --without-cuda-driver -v"
+            },
+            {
+              "path": "ci.data.environment-variables",
+              "value": "CFLAGS=-g0"
+            },
+            {
+              "path": "ci.hardware.Disk",
+              "value": "8589934592GB"
+            },
+            {
+              "path": "ci.hardware.Memory",
+              "value": "8GB"
+            },
+            {
+              "path": "ci.hardware.Processor",
+              "value": "unknown (2 Cores)"
+            },
+            {
+              "path": "ci.identifier",
+              "value": "ci"
+            },
+            {
+              "path": "ci.software.Compiler",
+              "value": "GCC 14.2.0"
+            },
+            {
+              "path": "ci.software.File-System",
+              "value": "overlayfs"
+            },
+            {
+              "path": "ci.software.Kernel",
+              "value": "4.19.0-gvisor (x86_64)"
+            },
+            {
+              "path": "ci.software.OS",
+              "value": "Debian GNU/Linux 13"
+            },
+            {
+              "path": "ci.timestamp",
+              "value": "2026-07-17 07:42:37"
+            },
+            {
+              "path": "ci.user",
+              "value": "root"
+            }
+          ]
+        },
+        {
+          "source": "phoronix/result-file-to-json",
+          "sourceFile": "system/pts_pgbench-read-write--metadata.json",
+          "fields": [
+            {
+              "path": "ci.client_version",
+              "value": "10.8.4"
+            },
+            {
+              "path": "ci.data.compiler-configuration",
+              "value": "--build=x86_64-linux-gnu --disable-vtable-verify --disable-werror --enable-bootstrap --enable-cet --enable-checking=release --enable-clocale=gnu --enable-default-pie --enable-gnu-unique-object --enable-languages=c,ada,c++,go,d,fortran,objc,obj-c++,m2,rust --enable-libphobos-checking=release --enable-libstdcxx-backtrace --enable-libstdcxx-debug --enable-libstdcxx-time=yes --enable-link-serialization=3 --enable-multiarch --enable-multilib --enable-nls --enable-objc-gc=auto --enable-offload-defaulted --enable-offload-targets=nvptx-none=/build/reproducible-path/gcc-14-14.2.0/debian/tmp-nvptx/usr,amdgcn-amdhsa=/build/reproducible-path/gcc-14-14.2.0/debian/tmp-gcn/usr --enable-plugin --enable-shared --enable-threads=posix --host=x86_64-linux-gnu --program-prefix=x86_64-linux-gnu- --target=x86_64-linux-gnu --with-abi=m64 --with-arch-32=i686 --with-build-config=bootstrap-lto-lean --with-default-libstdcxx-abi=new --with-gcc-major-version-only --with-multilib-list=m32,m64,mx32 --with-target-system-zlib=auto --with-tune=generic --without-cuda-driver -v"
+            },
+            {
+              "path": "ci.data.environment-variables",
+              "value": "CFLAGS=-g0"
+            },
+            {
+              "path": "ci.hardware.Disk",
+              "value": "8589934592GB"
+            },
+            {
+              "path": "ci.hardware.Memory",
+              "value": "8GB"
+            },
+            {
+              "path": "ci.hardware.Processor",
+              "value": "unknown (2 Cores)"
+            },
+            {
+              "path": "ci.identifier",
+              "value": "ci"
+            },
+            {
+              "path": "ci.software.Compiler",
+              "value": "GCC 14.2.0"
+            },
+            {
+              "path": "ci.software.File-System",
+              "value": "overlayfs"
+            },
+            {
+              "path": "ci.software.Kernel",
+              "value": "4.19.0-gvisor (x86_64)"
+            },
+            {
+              "path": "ci.software.OS",
+              "value": "Debian GNU/Linux 13"
+            },
+            {
+              "path": "ci.timestamp",
+              "value": "2026-07-17 07:43:20"
+            },
+            {
+              "path": "ci.user",
+              "value": "root"
+            }
+          ]
+        },
+        {
+          "source": "phoronix/result-file-to-json",
+          "sourceFile": "system/pts_pybench--metadata.json",
+          "fields": [
+            {
+              "path": "ci.client_version",
+              "value": "10.8.4"
+            },
+            {
+              "path": "ci.data.environment-variables",
+              "value": "CFLAGS=-g0"
+            },
+            {
+              "path": "ci.data.python",
+              "value": "mise ERROR python is not a valid shim. This likely means you uninstalled a tool and the shim does not point anything. Run `mise use ` reinstall the tool.mise ERROR : 2026.5.16 linux-x64 (2026-05-28)mise ERROR Run with--verbose or MISE_VERBOSE=1 for more information + mise ERROR python3 is not a valid shim. This likely means you uninstalled a tool and the shim does not point anything. Run `mise use ` reinstall the tool.mise ERROR : 2026.5.16 linux-x64 (2026-05-28)mise ERROR Run with--verbose or MISE_VERBOSE=1 for more information"
+            },
+            {
+              "path": "ci.hardware.Disk",
+              "value": "8589934592GB"
+            },
+            {
+              "path": "ci.hardware.Memory",
+              "value": "8GB"
+            },
+            {
+              "path": "ci.hardware.Processor",
+              "value": "unknown (2 Cores)"
+            },
+            {
+              "path": "ci.identifier",
+              "value": "ci"
+            },
+            {
+              "path": "ci.software.Compiler",
+              "value": "GCC 14.2.0"
+            },
+            {
+              "path": "ci.software.File-System",
+              "value": "overlayfs"
+            },
+            {
+              "path": "ci.software.Kernel",
+              "value": "4.19.0-gvisor (x86_64)"
+            },
+            {
+              "path": "ci.software.OS",
+              "value": "Debian GNU/Linux 13"
+            },
+            {
+              "path": "ci.timestamp",
+              "value": "2026-07-17 07:23:28"
+            },
+            {
+              "path": "ci.user",
+              "value": "root"
+            }
+          ]
+        },
+        {
+          "source": "phoronix/result-file-to-json",
+          "sourceFile": "system/pts_sqlite-speedtest--metadata.json",
+          "fields": [
+            {
+              "path": "ci.client_version",
+              "value": "10.8.4"
+            },
+            {
+              "path": "ci.data.compiler-configuration",
+              "value": "--build=x86_64-linux-gnu --disable-vtable-verify --disable-werror --enable-bootstrap --enable-cet --enable-checking=release --enable-clocale=gnu --enable-default-pie --enable-gnu-unique-object --enable-languages=c,ada,c++,go,d,fortran,objc,obj-c++,m2,rust --enable-libphobos-checking=release --enable-libstdcxx-backtrace --enable-libstdcxx-debug --enable-libstdcxx-time=yes --enable-link-serialization=3 --enable-multiarch --enable-multilib --enable-nls --enable-objc-gc=auto --enable-offload-defaulted --enable-offload-targets=nvptx-none=/build/reproducible-path/gcc-14-14.2.0/debian/tmp-nvptx/usr,amdgcn-amdhsa=/build/reproducible-path/gcc-14-14.2.0/debian/tmp-gcn/usr --enable-plugin --enable-shared --enable-threads=posix --host=x86_64-linux-gnu --program-prefix=x86_64-linux-gnu- --target=x86_64-linux-gnu --with-abi=m64 --with-arch-32=i686 --with-build-config=bootstrap-lto-lean --with-default-libstdcxx-abi=new --with-gcc-major-version-only --with-multilib-list=m32,m64,mx32 --with-target-system-zlib=auto --with-tune=generic --without-cuda-driver -v"
+            },
+            {
+              "path": "ci.data.environment-variables",
+              "value": "CFLAGS=-g0"
+            },
+            {
+              "path": "ci.hardware.Disk",
+              "value": "8589934592GB"
+            },
+            {
+              "path": "ci.hardware.Memory",
+              "value": "8GB"
+            },
+            {
+              "path": "ci.hardware.Processor",
+              "value": "unknown (2 Cores)"
+            },
+            {
+              "path": "ci.identifier",
+              "value": "ci"
+            },
+            {
+              "path": "ci.software.Compiler",
+              "value": "GCC 14.2.0"
+            },
+            {
+              "path": "ci.software.File-System",
+              "value": "overlayfs"
+            },
+            {
+              "path": "ci.software.Kernel",
+              "value": "4.19.0-gvisor (x86_64)"
+            },
+            {
+              "path": "ci.software.OS",
+              "value": "Debian GNU/Linux 13"
+            },
+            {
+              "path": "ci.timestamp",
+              "value": "2026-07-17 07:24:27"
+            },
+            {
+              "path": "ci.user",
+              "value": "root"
+            }
+          ]
+        },
+        {
+          "source": "mise/system-provider",
+          "sourceFile": "system/system-provider.json",
+          "fields": [
+            {
+              "path": "asn",
+              "value": "AS8075"
+            },
+            {
+              "path": "asn_source",
+              "value": "cymru"
+            },
+            {
+              "path": "bios_vendor",
+              "value": ""
+            },
+            {
+              "path": "city",
+              "value": "San Antonio"
+            },
+            {
+              "path": "cores",
+              "value": "2"
+            },
+            {
+              "path": "country",
+              "value": "US"
+            },
+            {
+              "path": "cpu_model",
+              "value": "unknown"
+            },
+            {
+              "path": "geo_source",
+              "value": "ipinfo"
+            },
+            {
+              "path": "kernel",
+              "value": "4.19.0-gvisor"
+            },
+            {
+              "path": "loc",
+              "value": "29.4241,-98.4936"
+            },
+            {
+              "path": "manufacturer",
+              "value": ""
+            },
+            {
+              "path": "org",
+              "value": "AS8075 Microsoft Corporation"
+            },
+            {
+              "path": "org_name",
+              "value": "Microsoft Corporation"
+            },
+            {
+              "path": "prefix",
+              "value": "172.200.0.0/13"
+            },
+            {
+              "path": "product_name",
+              "value": ""
+            },
+            {
+              "path": "public_ip",
+              "value": "172.202.193.152"
+            },
+            {
+              "path": "ram",
+              "value": "8.0Gi"
+            },
+            {
+              "path": "region",
+              "value": "Texas"
+            },
+            {
+              "path": "reverse_dns",
+              "value": ""
+            },
+            {
+              "path": "schema_version",
+              "value": "1.0"
+            },
+            {
+              "path": "timezone",
+              "value": "America/Chicago"
+            },
+            {
+              "path": "virtualization",
+              "value": ""
+            }
+          ]
+        }
+      ],
+      "metrics": [
+        {
+          "metricId": "fio_type_random_read_engine_linux_aio_direct_yes_block_size_4kb_job_count_1_disk_target_default_test_directory_iops",
+          "samples": [36600, 36400],
+          "aggregates": {
+            "p50": 36500,
+            "p95": 36590,
+            "mean": 36500,
+            "stdev": 141.4213562373095,
+            "min": 36400,
+            "max": 36600,
+            "n": 2
+          },
+          "sourceFile": "disk/pts_fio-rand-read.xml",
+          "appVersion": "3.36",
+          "arguments": "randread libaio 1 4k 1"
+        },
+        {
+          "metricId": "fio_type_random_read_engine_linux_aio_direct_yes_block_size_4kb_job_count_1_disk_target_default_test_directory_mb_per_s",
+          "samples": [143, 142],
+          "aggregates": {
+            "p50": 142.5,
+            "p95": 142.95,
+            "mean": 142.5,
+            "stdev": 0.7071067811865476,
+            "min": 142,
+            "max": 143,
+            "n": 2
+          },
+          "sourceFile": "disk/pts_fio-rand-read.xml",
+          "appVersion": "3.36",
+          "arguments": "randread libaio 1 4k 1"
+        },
+        {
+          "metricId": "fio_type_random_write_engine_linux_aio_direct_yes_block_size_4kb_job_count_1_disk_target_default_test_directory_iops",
+          "samples": [30100, 30500],
+          "aggregates": {
+            "p50": 30300,
+            "p95": 30480,
+            "mean": 30300,
+            "stdev": 282.842712474619,
+            "min": 30100,
+            "max": 30500,
+            "n": 2
+          },
+          "sourceFile": "disk/pts_fio-rand-write.xml",
+          "appVersion": "3.36",
+          "arguments": "randwrite libaio 1 4k 1"
+        },
+        {
+          "metricId": "fio_type_random_write_engine_linux_aio_direct_yes_block_size_4kb_job_count_1_disk_target_default_test_directory_mb_per_s",
+          "samples": [118, 119],
+          "aggregates": {
+            "p50": 118.5,
+            "p95": 118.95,
+            "mean": 118.5,
+            "stdev": 0.7071067811865476,
+            "min": 118,
+            "max": 119,
+            "n": 2
+          },
+          "sourceFile": "disk/pts_fio-rand-write.xml",
+          "appVersion": "3.36",
+          "arguments": "randwrite libaio 1 4k 1"
+        },
+        {
+          "metricId": "fio_type_sequential_read_engine_linux_aio_direct_yes_block_size_1mb_job_count_1_disk_target_default_test_directory_iops",
+          "samples": [12700, 13300],
+          "aggregates": {
+            "p50": 13000,
+            "p95": 13270,
+            "mean": 13000,
+            "stdev": 424.26406871192853,
+            "min": 12700,
+            "max": 13300,
+            "n": 2
+          },
+          "sourceFile": "disk/pts_fio-seq-read.xml",
+          "appVersion": "3.36",
+          "arguments": "read libaio 1 1m 1"
+        },
+        {
+          "metricId": "fio_type_sequential_write_engine_linux_aio_direct_yes_block_size_1mb_job_count_1_disk_target_default_test_directory_iops",
+          "samples": [2511, 1872],
+          "aggregates": {
+            "p50": 2191.5,
+            "p95": 2479.05,
+            "mean": 2191.5,
+            "stdev": 451.8412331782039,
+            "min": 1872,
+            "max": 2511,
+            "n": 2
+          },
+          "sourceFile": "disk/pts_fio-seq-write.xml",
+          "appVersion": "3.36",
+          "arguments": "write libaio 1 1m 1"
+        },
+        {
+          "metricId": "fio_type_sequential_write_engine_linux_aio_direct_yes_block_size_1mb_job_count_1_disk_target_default_test_directory_mb_per_s",
+          "samples": [2512, 1873],
+          "aggregates": {
+            "p50": 2192.5,
+            "p95": 2480.05,
+            "mean": 2192.5,
+            "stdev": 451.8412331782039,
+            "min": 1873,
+            "max": 2512,
+            "n": 2
+          },
+          "sourceFile": "disk/pts_fio-seq-write.xml",
+          "appVersion": "3.36",
+          "arguments": "write libaio 1 1m 1"
+        },
+        {
+          "metricId": "git_seconds",
+          "samples": [81.633, 79.497],
+          "aggregates": {
+            "p50": 80.565,
+            "p95": 81.52619999999999,
+            "mean": 80.565,
+            "stdev": 1.5103800846144624,
+            "min": 79.497,
+            "max": 81.633,
+            "n": 2
+          },
+          "sourceFile": "system/pts_git.xml"
+        },
+        {
+          "metricId": "hardlink_bogo_ops_per_s",
+          "samples": [3.23, 3.23],
+          "aggregates": {
+            "p50": 3.23,
+            "p95": 3.23,
+            "mean": 3.23,
+            "stdev": 0,
+            "min": 3.23,
+            "max": 3.23,
+            "n": 2
+          },
+          "sourceFile": "disk/pts_hardlink.xml",
+          "appVersion": "0.16"
+        },
+        {
+          "metricId": "network_loopback_seconds",
+          "samples": [58.93, 56.034],
+          "aggregates": {
+            "p50": 57.482,
+            "p95": 58.7852,
+            "mean": 57.482,
+            "stdev": 2.0477812383162424,
+            "min": 56.034,
+            "max": 58.93,
+            "n": 2
+          },
+          "sourceFile": "network/pts_network-loopback.xml"
+        },
+        {
+          "metricId": "node_web_tooling_runs_per_s",
+          "samples": [8.79, 8.77],
+          "aggregates": {
+            "p50": 8.78,
+            "p95": 8.789,
+            "mean": 8.78,
+            "stdev": 0.014142135623730649,
+            "min": 8.77,
+            "max": 8.79,
+            "n": 2
+          },
+          "sourceFile": "cpu-node/pts_node-web-tooling.xml"
+        },
+        {
+          "metricId": "realworld_better_auth_task_build",
+          "samples": [38.613, 38.537],
+          "aggregates": {
+            "p50": 38.575,
+            "p95": 38.6092,
+            "mean": 38.575,
+            "stdev": 0.05374011537017546,
+            "min": 38.537,
+            "max": 38.613,
+            "n": 2
+          },
+          "sourceFile": "realworld-better-auth/pts_realworld-better-auth.xml",
+          "appVersion": "6f3ba45639579da152b69e8e5342e02f28288670",
+          "arguments": "build"
+        },
+        {
+          "metricId": "realworld_better_auth_task_cold_install",
+          "samples": [30.412, 30.217],
+          "aggregates": {
+            "p50": 30.3145,
+            "p95": 30.40225,
+            "mean": 30.3145,
+            "stdev": 0.13788582233137697,
+            "min": 30.217,
+            "max": 30.412,
+            "n": 2
+          },
+          "sourceFile": "realworld-better-auth/pts_realworld-better-auth.xml",
+          "appVersion": "6f3ba45639579da152b69e8e5342e02f28288670",
+          "arguments": "cold_install"
+        },
+        {
+          "metricId": "realworld_better_auth_task_git_clone",
+          "samples": [2.7, 4.114],
+          "aggregates": {
+            "p50": 3.407,
+            "p95": 4.0433,
+            "mean": 3.407,
+            "stdev": 0.9998489885977779,
+            "min": 2.7,
+            "max": 4.114,
+            "n": 2
+          },
+          "sourceFile": "realworld-better-auth/pts_realworld-better-auth.xml",
+          "appVersion": "6f3ba45639579da152b69e8e5342e02f28288670",
+          "arguments": "git_clone"
+        },
+        {
+          "metricId": "realworld_better_auth_task_lint_biome",
+          "samples": [15.997, 16.15],
+          "aggregates": {
+            "p50": 16.0735,
+            "p95": 16.14235,
+            "mean": 16.0735,
+            "stdev": 0.10818733752154085,
+            "min": 15.997,
+            "max": 16.15,
+            "n": 2
+          },
+          "sourceFile": "realworld-better-auth/pts_realworld-better-auth.xml",
+          "appVersion": "6f3ba45639579da152b69e8e5342e02f28288670",
+          "arguments": "lint_biome"
+        },
+        {
+          "metricId": "realworld_better_auth_task_lint_deps_knip",
+          "samples": [28.639, 27.802],
+          "aggregates": {
+            "p50": 28.2205,
+            "p95": 28.59715,
+            "mean": 28.2205,
+            "stdev": 0.5918483758531389,
+            "min": 27.802,
+            "max": 28.639,
+            "n": 2
+          },
+          "sourceFile": "realworld-better-auth/pts_realworld-better-auth.xml",
+          "appVersion": "6f3ba45639579da152b69e8e5342e02f28288670",
+          "arguments": "lint_deps"
+        },
+        {
+          "metricId": "realworld_better_auth_task_lint_format",
+          "samples": [6.712, 6.109],
+          "aggregates": {
+            "p50": 6.4105,
+            "p95": 6.68185,
+            "mean": 6.4105,
+            "stdev": 0.42638538905548795,
+            "min": 6.109,
+            "max": 6.712,
+            "n": 2
+          },
+          "sourceFile": "realworld-better-auth/pts_realworld-better-auth.xml",
+          "appVersion": "6f3ba45639579da152b69e8e5342e02f28288670",
+          "arguments": "lint_format"
+        },
+        {
+          "metricId": "realworld_better_auth_task_lint_packages",
+          "samples": [14.671, 15.02],
+          "aggregates": {
+            "p50": 14.8455,
+            "p95": 15.00255,
+            "mean": 14.8455,
+            "stdev": 0.24678026663410524,
+            "min": 14.671,
+            "max": 15.02,
+            "n": 2
+          },
+          "sourceFile": "realworld-better-auth/pts_realworld-better-auth.xml",
+          "appVersion": "6f3ba45639579da152b69e8e5342e02f28288670",
+          "arguments": "lint_packages"
+        },
+        {
+          "metricId": "realworld_better_auth_task_lint_spell",
+          "samples": [14.715, 15.033],
+          "aggregates": {
+            "p50": 14.873999999999999,
+            "p95": 15.0171,
+            "mean": 14.873999999999999,
+            "stdev": 0.22485995641732248,
+            "min": 14.715,
+            "max": 15.033,
+            "n": 2
+          },
+          "sourceFile": "realworld-better-auth/pts_realworld-better-auth.xml",
+          "appVersion": "6f3ba45639579da152b69e8e5342e02f28288670",
+          "arguments": "lint_spell"
+        },
+        {
+          "metricId": "realworld_better_auth_task_lint_types",
+          "samples": [179.539, 170.441],
+          "aggregates": {
+            "p50": 174.99,
+            "p95": 179.08409999999998,
+            "mean": 174.99,
+            "stdev": 6.433257495235188,
+            "min": 170.441,
+            "max": 179.539,
+            "n": 2
+          },
+          "sourceFile": "realworld-better-auth/pts_realworld-better-auth.xml",
+          "appVersion": "6f3ba45639579da152b69e8e5342e02f28288670",
+          "arguments": "lint_types"
+        },
+        {
+          "metricId": "realworld_better_auth_task_typecheck",
+          "samples": [3.255, 3.461],
+          "aggregates": {
+            "p50": 3.3579999999999997,
+            "p95": 3.4507,
+            "mean": 3.3579999999999997,
+            "stdev": 0.1456639969244289,
+            "min": 3.255,
+            "max": 3.461,
+            "n": 2
+          },
+          "sourceFile": "realworld-better-auth/pts_realworld-better-auth.xml",
+          "appVersion": "6f3ba45639579da152b69e8e5342e02f28288670",
+          "arguments": "typecheck"
+        },
+        {
+          "metricId": "realworld_mastra_task_build_core",
+          "samples": [197.181, 205.521],
+          "aggregates": {
+            "p50": 201.351,
+            "p95": 205.10399999999998,
+            "mean": 201.351,
+            "stdev": 5.897270555095789,
+            "min": 197.181,
+            "max": 205.521,
+            "n": 2
+          },
+          "sourceFile": "realworld-mastra/pts_realworld-mastra.xml",
+          "appVersion": "b6eeb9d08ebeaf27bc6fd16b6b88087040aaf767",
+          "arguments": "build_core"
+        },
+        {
+          "metricId": "realworld_mastra_task_cold_install",
+          "samples": [73.167, 73.766],
+          "aggregates": {
+            "p50": 73.4665,
+            "p95": 73.73605,
+            "mean": 73.4665,
+            "stdev": 0.42355696193074965,
+            "min": 73.167,
+            "max": 73.766,
+            "n": 2
+          },
+          "sourceFile": "realworld-mastra/pts_realworld-mastra.xml",
+          "appVersion": "b6eeb9d08ebeaf27bc6fd16b6b88087040aaf767",
+          "arguments": "cold_install"
+        },
+        {
+          "metricId": "realworld_mastra_task_git_clone",
+          "samples": [9.667, 10.434],
+          "aggregates": {
+            "p50": 10.0505,
+            "p95": 10.39565,
+            "mean": 10.0505,
+            "stdev": 0.5423509011700816,
+            "min": 9.667,
+            "max": 10.434,
+            "n": 2
+          },
+          "sourceFile": "realworld-mastra/pts_realworld-mastra.xml",
+          "appVersion": "b6eeb9d08ebeaf27bc6fd16b6b88087040aaf767",
+          "arguments": "git_clone"
+        },
+        {
+          "metricId": "realworld_mastra_task_lint_format",
+          "samples": [193.567, 195.951],
+          "aggregates": {
+            "p50": 194.75900000000001,
+            "p95": 195.8318,
+            "mean": 194.75900000000001,
+            "stdev": 1.6857425663487096,
+            "min": 193.567,
+            "max": 195.951,
+            "n": 2
+          },
+          "sourceFile": "realworld-mastra/pts_realworld-mastra.xml",
+          "appVersion": "b6eeb9d08ebeaf27bc6fd16b6b88087040aaf767",
+          "arguments": "lint_format"
+        },
+        {
+          "metricId": "sqlite_speedtest_seconds",
+          "samples": [528.591, 513.224],
+          "aggregates": {
+            "p50": 520.9075,
+            "p95": 527.8226500000001,
+            "mean": 520.9075,
+            "stdev": 10.86610990649365,
+            "min": 513.224,
+            "max": 528.591,
+            "n": 2
+          },
+          "sourceFile": "system/pts_sqlite-speedtest.xml",
+          "appVersion": "3.30"
+        },
+        {
+          "metricId": "stream_type_add",
+          "samples": [45481, 40275.2],
+          "aggregates": {
+            "p50": 42878.1,
+            "p95": 45220.71,
+            "mean": 42878.1,
+            "stdev": 3681.056481500931,
+            "min": 40275.2,
+            "max": 45481,
+            "n": 2
+          },
+          "sourceFile": "memory/pts_stream.xml",
+          "appVersion": "2013-01-17",
+          "arguments": "Add"
+        },
+        {
+          "metricId": "stream_type_copy",
+          "samples": [66033.8, 54862.2],
+          "aggregates": {
+            "p50": 60448,
+            "p95": 65475.22,
+            "mean": 60448,
+            "stdev": 7899.514116703639,
+            "min": 54862.2,
+            "max": 66033.8,
+            "n": 2
+          },
+          "sourceFile": "memory/pts_stream.xml",
+          "appVersion": "2013-01-17",
+          "arguments": "Copy"
+        },
+        {
+          "metricId": "stream_type_scale",
+          "samples": [37680.7, 35353.9],
+          "aggregates": {
+            "p50": 36517.3,
+            "p95": 37564.36,
+            "mean": 36517.3,
+            "stdev": 1645.296058464853,
+            "min": 35353.9,
+            "max": 37680.7,
+            "n": 2
+          },
+          "sourceFile": "memory/pts_stream.xml",
+          "appVersion": "2013-01-17",
+          "arguments": "Scale"
+        },
+        {
+          "metricId": "stream_type_triad",
+          "samples": [46376.1, 37810.4],
+          "aggregates": {
+            "p50": 42093.25,
+            "p95": 45947.815,
+            "mean": 42093.25,
+            "stdev": 6056.864555609608,
+            "min": 37810.4,
+            "max": 46376.1,
+            "n": 2
+          },
+          "sourceFile": "memory/pts_stream.xml",
+          "appVersion": "2013-01-17",
+          "arguments": "Triad"
+        },
+        {
+          "metricId": "usd_per_hour",
+          "samples": [0.47736],
+          "aggregates": {
+            "p50": 0.47736,
+            "p95": 0.47736,
+            "mean": 0.47736,
+            "stdev": 0,
+            "min": 0.47736,
+            "max": 0.47736,
+            "n": 1
+          }
+        }
+      ],
+      "suitesCovered": [
+        "cpu-node",
+        "disk",
+        "memory",
+        "network",
+        "realworld-better-auth",
+        "realworld-mastra",
+        "system"
+      ],
+      "gaps": [
+        {
+          "scope": "suite",
+          "id": "cpu-generic",
+          "outcome": "failed",
+          "reason": "Step \"mise run benchmark:cpu:generic\" timed out after 7800s"
+        },
+        {
+          "scope": "suite",
+          "id": "network",
+          "outcome": "failed",
+          "reason": "Step \"mise run benchmark:network:all\" failed with exit code 1"
+        },
+        {
+          "scope": "suite",
+          "id": "realworld-openclaw",
+          "outcome": "failed",
+          "reason": "Step \"mise run benchmark:realworld:pts:openclaw\" timed out after 8400s"
+        }
+      ],
+      "uncatalogued": []
+    },
+    {
+      "providerId": "novita",
+      "validationStatus": "pending",
+      "observedSpecs": {},
+      "metrics": [],
+      "suitesCovered": [],
+      "gaps": [],
+      "uncatalogued": []
+    }
+  ]
+}


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Publish run 29562866807 and refresh the leaderboard to reflect the latest benchmarks. Adds the new run file and index entry, and regenerates LEADERBOARD.md with 155 metric records from 307 trials across 54 metrics and 4 providers (Novita absent this run; coverage updated).

<sup>Written for commit fb2cdf12aebc5c98a90105e203a3ad8170289ed5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/starslingdev/hpc-sandbox-benchmarks/pull/200?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Data**
  * Added a new benchmark run with results from multiple execution providers.
  * Expanded the dataset with detailed performance metrics and environment information.

* **Leaderboard Updates**
  * Refreshed rankings across CPU, compression, storage, memory, network, system, and real-world benchmarks.
  * Updated performance values, confidence intervals, provider rankings, and statistical comparisons.

* **Documentation**
  * Updated coverage reporting, failure details, and provider availability indicators.
  * Clarified that “missing” means no result was available for a benchmark.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->