### PR TITLE
fix(ci): bound fast-cli hangs, cover novita by default, surface publish PR failures

### DIFF
--- a/.github/workflows/bench-matrix.yml
+++ b/.github/workflows/bench-matrix.yml
@@ -19,11 +19,13 @@ on:
         description: 'Comma-separated providers to benchmark (blank = every registered provider).'
         required: false
         type: string
-        # The providers with a baked toolchain artifact and credentials in CI. blaxel boots the stock
-        # base image (nothing baked for it), so it is excluded by default rather than burning ~150min
-        # of runner time per suite on cells that cannot produce a comparable result. Pass it explicitly
-        # to include it; `plan-providers` rejects any name that is not in the registry.
-        default: e2b,daytona,modal
+        # The providers with a baked toolchain artifact and credentials in CI. novita also boots its
+        # own pre-baked template (novita-sandbox Template.build), so it is comparable and included by
+        # default despite its "beta" maturity. blaxel boots the stock base image (nothing baked for
+        # it), so it is excluded by default rather than burning ~150min of runner time per suite on
+        # cells that cannot produce a comparable result. Pass it explicitly to include it;
+        # `plan-providers` rejects any name that is not in the registry.
+        default: e2b,daytona,modal,novita
       suites:
         description: 'Comma-separated suites to run (blank = every registered suite). E.g. "network" for a targeted pre-merge run.'
         required: false

--- a/.github/workflows/publish-dataset.yml
+++ b/.github/workflows/publish-dataset.yml
@@ -168,7 +168,7 @@ jobs:
               "This is almost always the repo's 'Allow GitHub Actions to create and approve pull" \
               "requests' setting being off (Settings → Actions → General → Workflow permissions)." \
               "A maintainer must either enable it and re-dispatch this workflow with run_id=$RUN_ID," \
-              "or open the PR for '$branch' manually. See docs/ci-secrets.md." >&2
+              "or open the PR for '$branch' manually. See docs/ci-secrets.md."
             exit 1
           fi
           # Queue GitHub-native auto-merge: it merges only after the PR's required checks pass (and any

--- a/.github/workflows/publish-dataset.yml
+++ b/.github/workflows/publish-dataset.yml
@@ -154,11 +154,23 @@ jobs:
           # overwritten rather than rejected as non-fast-forward; it is a bot-owned branch and a re-run
           # recomputes byte-identical content, so the overwrite is a no-op in the common case.
           git push -u --force origin "$branch"
-          gh pr create \
+          # `gh pr create` fails outright (GraphQL "GitHub Actions is not permitted to create or
+          # approve pull requests") when the repo's Settings → Actions → General → Workflow
+          # permissions → "Allow GitHub Actions to create and approve pull requests" toggle is off —
+          # see docs/ci-secrets.md. The dataset branch above is already pushed at that point, so
+          # surface the fix instead of a bare GraphQL error before failing the job.
+          if ! gh pr create \
             --base main \
             --head "$branch" \
             --title "chore(dataset): publish run ${RUN_ID}" \
-            --body "Automated dataset + leaderboard publish for run [\`${RUN_ID}\`](${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${RUN_ID}). Biome was pre-flighted green on the promoted content; auto-merge lands it once branch protection is satisfied."
+            --body "Automated dataset + leaderboard publish for run [\`${RUN_ID}\`](${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${RUN_ID}). Biome was pre-flighted green on the promoted content; auto-merge lands it once branch protection is satisfied."; then
+            echo "::error::gh pr create failed — branch '$branch' was pushed but no PR was opened." \
+              "This is almost always the repo's 'Allow GitHub Actions to create and approve pull" \
+              "requests' setting being off (Settings → Actions → General → Workflow permissions)." \
+              "A maintainer must either enable it and re-dispatch this workflow with run_id=$RUN_ID," \
+              "or open the PR for '$branch' manually. See docs/ci-secrets.md." >&2
+            exit 1
+          fi
           # Queue GitHub-native auto-merge: it merges only after the PR's required checks pass (and any
           # required reviews land), never bypassing branch protection. Best-effort — if the repo hasn't
           # enabled auto-merge, leave the PR open for a maintainer.

--- a/docs/ci-secrets.md
+++ b/docs/ci-secrets.md
@@ -98,6 +98,11 @@ Do this in the GitHub UI (Settings → Environments), then delete any matching *
 
 5. Confirm the GHCR package `sandbox-benchmarks-toolchain` is **public** so providers can pull
    the candidate base anonymously (Org → Packages → package settings).
+6. Enable **Settings → Actions → General → Workflow permissions → "Allow GitHub Actions to create
+   and approve pull requests"**. `publish-dataset.yml`'s `gh pr create` fails outright without it
+   (`GraphQL: GitHub Actions is not permitted to create or approve pull requests`) — the job pushes
+   the `dataset/publish-<run-id>` branch and then dies, so every matrix run's publish step needs a
+   maintainer to open the PR by hand until this is on.
 
 Optional bootstrap (creates the empty environment; reviewers/secrets still need a human):
 

--- a/packages/schema/src/pts-profiles/fast-cli-1.0.0/install.sh
+++ b/packages/schema/src/pts-profiles/fast-cli-1.0.0/install.sh
@@ -18,7 +18,11 @@ fi
 
 cat <<'EOF' >fast-cli
 #!/bin/sh
-node node_modules/fast-cli/distribution/cli.js --upload --json > "$LOG_FILE" 2>&1
+# fast.com's transfer can stall mid-measurement instead of erroring (observed: a daytona run hung the
+# whole 45-minute network suite budget with no exit). Bound the CLI itself so a stalled trial fails
+# fast — as a normal nonzero trial, letting PTS's own TimesToRun retry the next trial or the composite
+# report a failed result — rather than consuming the outer suite's step timeout.
+timeout 240 node node_modules/fast-cli/distribution/cli.js --upload --json > "$LOG_FILE" 2>&1
 status=$?
 echo "$status" > ~/test-exit-status
 exit "$status"


### PR DESCRIPTION
## Summary

Root-caused every job failure and coverage gap in [run 29562866807](https://github.com/starslingdev/hpc-sandbox-benchmarks/actions/runs/29562866807/job/87856230941) (results stuck on `dataset/publish-29562866807`, now open as #200) and fixed what's safely fixable without live provider credentials:

- **`network` suite failing on daytona/blaxel/modal** — the `fast-cli` PTS test transfers through Netflix's fast.com CDN and can stall mid-measurement instead of erroring; it hung the *entire* 45-minute network suite budget on daytona with no exit. Wrapped the launcher in `timeout 240` so a stalled trial fails fast as an ordinary nonzero trial, instead of eating the whole step budget.
- **Novita missing from the published dataset for most metrics** — it has its own pre-baked toolchain template (unlike blaxel, which boots the stock base image with no baked artifact), so it's comparable and belongs in `bench-matrix.yml`'s default provider list. It was silently excluded from both the default and this run's explicit provider override.
- **`Aggregate + promote dataset` job failing outright** — `gh pr create` fails with a bare GraphQL error (`GitHub Actions is not permitted to create or approve pull requests`) when the repo's Settings → Actions → General → Workflow permissions → "Allow GitHub Actions to create and approve pull requests" is off. That's exactly what happened here: the `dataset/publish-*` branch was pushed but the PR was never opened, and the job died with no actionable message. Now the job surfaces the actual fix, and `docs/ci-secrets.md` documents the required repo setting.

## Not fixed here (flagged, not guessed at)

- **`cpu-generic` timing out on e2b/modal**: c-ray's 5K-resolution passes alone need ~90 more minutes than the 130-minute command budget on slower providers — even a generous timeout bump doesn't leave headroom for the suite's zstd portion, which never got a chance to run in this data. This is already being addressed upstream in the (currently unmerged) 4-PR bench-matrix refactor stack — #193 specifically retires `cpu-generic`. Bumping timeouts here would just duplicate/conflict with that work.
- **`realworld-openclaw` losing its sandbox** (daytona: closed socket after ~13 min; modal: unresponsive for the full 140-min budget, "memory exhaustion or a dead agent") — plausible root causes but needs live-infra reproduction with actual provider credentials to diagnose safely; nothing here to change blind.
- **Toolchain still pinned at `v1`**: #191 (unmerged) bumps `TOOLCHAIN_VERSION` to `v2` to eliminate a stale-cached-artifact failure class independent of the fixes in this PR.

## Test plan

- [x] `bun test` — full suite green except one pre-existing, unrelated failure (`apps/cli/src/lib/suite-tasks.test.ts`, fails identically on `main`; caused by no `mise` binary in this sandbox, not a real regression)
- [x] `tooling/repo-checks` workflow-registry-sync gate green (workflow timeout/provider-input invariants unaffected)
- [x] `sh -n` on the modified `install.sh`
- [ ] Live bench-matrix re-dispatch — needs a maintainer with `privileged` environment approval and provider credentials; out of scope for this session

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_016UPKbWL77zAYDWUFR4ZCbK

---
_Generated by [Claude Code](https://claude.ai/code/session_016UPKbWL77zAYDWUFR4ZCbK)_

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bound the `network` suite’s `fast-cli` test to prevent hangs, added `novita` to the default provider list, and improved dataset publish failure messaging so it appears in the Actions UI. This keeps runs moving, restores coverage, and improves CI debuggability.

- **Bug Fixes**
  - Wrapped `fast-cli` in `timeout 240` so stalled transfers fail fast instead of consuming the suite budget.
  - Included `novita` in `bench-matrix.yml` defaults so it’s covered and appears in published datasets.
  - Updated `publish-dataset.yml` to show a clear message when `gh pr create` is blocked by repo permissions and emit the `::error::` on stdout so it renders in the Actions UI; documented the required setting in `docs/ci-secrets.md`.

<sup>Written for commit 8beb72d4769d0d230d5311991c83ae74bb93d51b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/starslingdev/hpc-sandbox-benchmarks/pull/201?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fast CLI installations now stop stalled transfers after four minutes, helping benchmark runs finish with a result instead of timing out.
  * Dataset publishing now reports clear errors when pull request creation is blocked by repository permissions.

* **Chores**
  * Benchmark workflows now include Novita by default while keeping Blaxel opt-in.

* **Documentation**
  * Added setup guidance for enabling GitHub Actions to create and approve pull requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->