### PR TITLE
fix(ci): close network-suite gaps for daytona, modal, and novita

### DIFF
--- a/packages/harness/src/lib/setup.test.ts
+++ b/packages/harness/src/lib/setup.test.ts
@@ -39,6 +39,14 @@ describe("setupSteps", () => {
 			"libgtk-3-0",
 			"libx11-6",
 			"fonts-liberation",
+			"libasound2",
+			"libatk-bridge2.0-0",
+			"libcairo2",
+			"libgbm1",
+			"libxcomposite1",
+			"libxdamage1",
+			"libxrandr2",
+			"xdg-utils",
 		]) {
 			expect(ptsStep?.script).toContain(chromeDep);
 		}

--- a/packages/harness/src/lib/setup.test.ts
+++ b/packages/harness/src/lib/setup.test.ts
@@ -26,6 +26,24 @@ describe("setupSteps", () => {
 		expect(ptsStep?.script).not.toContain("command -v phoronix-test-suite");
 	});
 
+	it("includes fast-cli's Puppeteer/Chrome runtime libs in the stock-image PTS deps fallback", () => {
+		// Regression guard for the class of bug fixed in a2dd493: this list must stay in lockstep with
+		// packages/templates/images/base/scripts/00-apt.sh's Chrome/Puppeteer block, or a stock-image
+		// provider (e.g. modal) crashes fast-cli's freshly-downloaded Chrome with a missing-.so error.
+		const ptsStep = setupSteps(SUITES["cpu-node"]).find(
+			(step) => step.label === "ensure PTS build deps + fresh apt index",
+		);
+		for (const chromeDep of [
+			"libglib2.0-0",
+			"libnss3",
+			"libgtk-3-0",
+			"libx11-6",
+			"fonts-liberation",
+		]) {
+			expect(ptsStep?.script).toContain(chromeDep);
+		}
+	});
+
 	it("does not install repository developer tools inside benchmark sandboxes", () => {
 		expect(labels).not.toContain("mise install");
 		const nodeStep = setupSteps(SUITES["cpu-node"]).find(

--- a/packages/harness/src/lib/setup.ts
+++ b/packages/harness/src/lib/setup.ts
@@ -112,9 +112,23 @@ export function setupSteps(suite: Suite): SetupStep[] {
 		// profile locally; in either case PTS's own dependency install needs a usable package index.
 		// Best-effort lets a healthy baked image proceed when a provider cannot reach its distro mirror.
 		// Keep this set aligned with packages/templates/images/base/scripts/00-apt.sh.
+		//
+		// The fonts/GTK/X11 block is fast-cli's Puppeteer/Chrome runtime dependencies. Without them, a
+		// stock-image provider (e.g. modal, which takes this fallback path rather than the baked image)
+		// downloads a fresh Chrome via npm install that fails immediately with "error while loading
+		// shared libraries: libglib-2.0.so.0: cannot open shared object file" — a same-day-observed live
+		// failure (run 29587815350, modal/network) with zero fast-cli metrics produced. 00-apt.sh already
+		// bakes these for the pre-baked image path; this was the one runtime fallback that had drifted
+		// out of lockstep with it.
 		const ptsDeps =
 			"php-cli php-xml build-essential autoconf flex bison bc libelf-dev libssl-dev " +
-			"libaio-dev libicu-dev dnsutils jq netcat-openbsd iputils-ping tcl stress-ng unzip procps";
+			"libaio-dev libicu-dev dnsutils jq netcat-openbsd iputils-ping tcl stress-ng unzip procps " +
+			"fonts-liberation libasound2 libatk-bridge2.0-0 libatk1.0-0 " +
+			"libcairo2 libcups2 libdbus-1-3 libdrm2 libfontconfig1 libgbm1 libglib2.0-0 libgtk-3-0 " +
+			"libnspr4 libnss3 libpango-1.0-0 libpangocairo-1.0-0 " +
+			"libx11-6 libx11-xcb1 libxcb1 libxcomposite1 libxcursor1 libxdamage1 " +
+			"libxext6 libxfixes3 libxi6 libxkbcommon0 libxrandr2 libxrender1 libxss1 libxtst6 " +
+			"xdg-utils";
 		steps.push({
 			label: "ensure PTS build deps + fresh apt index",
 			script:

--- a/packages/schema/src/pts-profiles/fast-cli-1.0.0/install.sh
+++ b/packages/schema/src/pts-profiles/fast-cli-1.0.0/install.sh
@@ -22,7 +22,13 @@ cat <<'EOF' >fast-cli
 # whole 45-minute network suite budget with no exit). Bound the CLI itself so a stalled trial fails
 # fast — as a normal nonzero trial, letting PTS's own TimesToRun retry the next trial or the composite
 # report a failed result — rather than consuming the outer suite's step timeout.
-timeout 240 node node_modules/fast-cli/distribution/cli.js --upload --json > "$LOG_FILE" 2>&1
+#
+# Plain `timeout 240` isn't enough: on daytona specifically, a stalled fast.com transfer sits in an
+# uninterruptible network wait that ignores `timeout`'s default SIGTERM, so the process never exits and
+# the hang just gets caught by the outer 45-minute step timeout instead (confirmed live: run 29587815350
+# ran the full 2700s before GitHub force-killed the step). `-k 10` escalates to SIGKILL 10s after the
+# SIGTERM if the process is still alive, which reaps it unconditionally.
+timeout -k 10 240 node node_modules/fast-cli/distribution/cli.js --upload --json > "$LOG_FILE" 2>&1
 status=$?
 echo "$status" > ~/test-exit-status
 exit "$status"

--- a/packages/schema/src/pts-profiles/fast-cli-1.0.0/install.sh
+++ b/packages/schema/src/pts-profiles/fast-cli-1.0.0/install.sh
@@ -28,7 +28,14 @@ cat <<'EOF' >fast-cli
 # the hang just gets caught by the outer 45-minute step timeout instead (confirmed live: run 29587815350
 # ran the full 2700s before GitHub force-killed the step). `-k 10` escalates to SIGKILL 10s after the
 # SIGTERM if the process is still alive, which reaps it unconditionally.
-timeout -k 10 240 node node_modules/fast-cli/distribution/cli.js --upload --json > "$LOG_FILE" 2>&1
+#
+# 420s (not 240s): novita's fast-cli trials (run 29587815350) exited cleanly on plain SIGTERM at ~240s
+# with no crash/stderr — unlike modal's immediate Chrome-library crash — meaning the run was still
+# making progress (Chrome launched, fast.com loaded) and simply hadn't converged yet. novita's sandbox
+# is single-vCPU (vs. 2+ on e2b/modal/daytona), and fast-cli's own issue tracker documents Puppeteer's
+# Chrome needing generous headroom on constrained hardware (sindresorhus/fast-cli#81). 2 trials at 420s
+# (+10s SIGKILL grace each) is at most ~860s, still well inside the 2700s suite budget.
+timeout -k 10 420 node node_modules/fast-cli/distribution/cli.js --upload --json > "$LOG_FILE" 2>&1
 status=$?
 echo "$status" > ~/test-exit-status
 exit "$status"


### PR DESCRIPTION
## Summary

Follow-up to #201 (merged) — live validation of a post-#201 run ([29587815350](https://github.com/starslingdev/hpc-sandbox-benchmarks/actions/runs/29587815350)) found the `network` suite still failing on 3 providers even with #201's `timeout 240` fix in place. Root-caused each via job logs and fixed:

- **daytona still hung the full 45-minute suite budget.** `timeout 240` (from #201) only sends SIGTERM by default — daytona's stalled fast.com transfer sat in an uninterruptible wait and ignored it, so the process never exited and the hang just got caught by the *outer* step timeout instead. `timeout -k 10 240 …` now escalates to SIGKILL 10s later, reaping it unconditionally.
- **modal's fast-cli crashed instantly**: `error while loading shared libraries: libglib-2.0.so.0`. Modal doesn't take the pre-baked toolchain image, so it falls back to `setup.ts`'s runtime apt-install list — which had drifted out of lockstep with `00-apt.sh` and was missing the whole Chrome/Puppeteer font/GTK/X11 dependency block that `00-apt.sh` already bakes for the pre-baked-image path. Added the same package set to the fallback.
- **novita's fast-cli timed out cleanly on both trials with no crash** — meaning it was making real progress (Chrome launched, fast.com loaded) but hadn't converged within 240s. novita's sandbox is single-vCPU (vs. 2+ elsewhere), and upstream ([sindresorhus/fast-cli#81](https://github.com/sindresorhus/fast-cli/issues/81)) documents Puppeteer needing more headroom on constrained hardware. Widened the per-trial timeout to 420s (worst case ~860s for 2 trials, still well under the 2700s suite budget).

## Not in scope here

- `cpu-generic` timing out on e2b/modal (c-ray's fixed resolution/repeat counts assume more host performance than these providers deliver) — a structural suite-catalog fix already exists as unmerged #193, which retires the suite; not duplicating that here.
- `realworld-openclaw` losing its sandbox on all 5 providers — every provider fails this suite via a different mechanism, all pointing at the same root cause (its 140-minute budget is insufficient for the suite's actual JS-monorepo workload, compounded by Modal's hard memory cgroup cap). No minimal, high-confidence fix identified yet; needs a live, profiled run to size a real budget rather than a blind bump.

## Test plan

- [x] `bun test packages/harness/src/lib/setup.test.ts packages/schema/src/suites.test.ts` — green
- [x] `bunx biome check` on the modified `.ts` file — clean
- [x] `sh -n` on the modified `install.sh` — clean
- [ ] Live bench-matrix re-dispatch on `main` post-merge — this PR's fixes are otherwise unvalidated: the `privileged` environment's branch policy (main-only) blocks any pre-merge dispatch, which is why this needs to land before it can be confirmed.

Co-Authored-By: Claude Sonnet 5
Claude-Session: https://claude.ai/code/session_016UPKbWL77zAYDWUFR4ZCbK

---
_Generated by [Claude Code](https://claude.ai/code/session_016UPKbWL77zAYDWUFR4ZCbK)_

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the failing `network` suite on daytona, modal, and novita by hardening `fast-cli` timeouts, adding missing Chrome/`Puppeteer` deps for stock images, and extending per‑trial timeouts for slower sandboxes. Broadens the regression test to cover more Chrome/`Puppeteer` runtime libs and keep parity with `00-apt.sh`.

- **Bug Fixes**
  - Daytona: run `fast-cli` under `timeout -k 10 …` to SIGKILL 10s after SIGTERM, preventing 45‑min hangs.
  - Modal: align the stock‑image `apt` deps in `packages/harness/src/lib/setup.ts` with `00-apt.sh` to include Chrome/`Puppeteer` font/GTK/X11 libs and fix the `libglib-2.0.so.0` crash.
  - Novita: raise per‑trial timeout to 420s in the `fast-cli` profile; worst case ~860s for two trials, still within the 2700s suite budget.
  - Harness: broaden the regression test to assert a wider set of Chrome/`Puppeteer` libs in the stock‑image deps list to prevent future drift.

<sup>Written for commit a26db30a8185cf34aa83c8f0fadfe4c738f00424. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/starslingdev/hpc-sandbox-benchmarks/pull/202?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved PTS setup reliability by installing additional graphics and runtime libraries when using a stock environment.
  * Updated fast-cli execution timeouts to better handle slow or stalled transfers, including forced termination when needed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->