### PR TITLE
Publish machine-readable leaderboard JSON

### DIFF
--- a/.github/workflows/publish-dataset.yml
+++ b/.github/workflows/publish-dataset.yml
@@ -97,9 +97,12 @@ jobs:
           bun apps/cli/src/bin/aggregate.ts "$RUN_ID" data/candidate "${shards[@]}"
           bun apps/cli/src/bin/promote.ts "data/candidate/runs/$RUN_ID.json" data/dataset
 
-      # Keep LEADERBOARD.md byte-identical to what the renderer produces from the newly promoted Run.
-      - name: Regenerate leaderboard
-        run: bun apps/cli/src/bin/leaderboard.ts "data/dataset/runs/$RUN_ID.json" LEADERBOARD.md
+      # Keep both public leaderboard surfaces byte-identical to what the renderer produces from the
+      # newly promoted Run. The JSON path is run-addressed so older published artifacts remain pinned.
+      - name: Regenerate leaderboards
+        run: |
+          bun apps/cli/src/bin/leaderboard.ts "data/dataset/runs/$RUN_ID.json" LEADERBOARD.md
+          bun apps/cli/src/bin/leaderboard.ts "data/dataset/runs/$RUN_ID.json" "data/dataset/leaderboards/$RUN_ID.json"
 
       # Canonicalize the promoted dataset to Biome's format before the gate + commit. The promote
       # writer emits `JSON.stringify(run, null, 2)` (every array element on its own line), but Biome's

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ or bandwidth-capped disk turns that into the longest step of your run.
 | | |
 | --- | --- |
 | **[Leaderboard](./LEADERBOARD.md)** | Provider rankings from the latest published run |
-| **[Leaderboard JSON](./data/dataset/leaderboards/29546060837.json)** | Machine-readable projection of the same ranks, intervals, gaps, and comparability evidence |
+| **[Leaderboard JSON](./data/dataset/leaderboards/)** | Machine-readable projections of published ranks, intervals, gaps, and comparability evidence |
 | **[Methodology](./docs/methodology.md)** | How a measurement is produced |
 | **[Docs hub](./docs/README.md)** | ADRs, CI secrets, security, contributing |
 

--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ or bandwidth-capped disk turns that into the longest step of your run.
 | | |
 | --- | --- |
 | **[Leaderboard](./LEADERBOARD.md)** | Provider rankings from the latest published run |
+| **[Leaderboard JSON](./data/dataset/leaderboards/29546060837.json)** | Machine-readable projection of the same ranks, intervals, gaps, and comparability evidence |
 | **[Methodology](./docs/methodology.md)** | How a measurement is produced |
 | **[Docs hub](./docs/README.md)** | ADRs, CI secrets, security, contributing |
 

--- a/apps/cli/src/bin/leaderboard.test.ts
+++ b/apps/cli/src/bin/leaderboard.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, test } from "bun:test";
+import { spawnSync } from "node:child_process";
+import { mkdtempSync, readFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+// Exercise the real bin end-to-end: the renderer it dispatches to is decided purely by the output
+// path's extension (`.json` → public JSON, anything else → Markdown), and with no output path stdout
+// carries the Markdown. None of that wiring is reachable as an exported function, so drive the process.
+const BIN = join(import.meta.dir, "leaderboard.ts");
+const REPO_ROOT = join(import.meta.dir, "..", "..", "..", "..");
+
+/** The Run the committed dataset publishes — guaranteed present and valid, named by LEADERBOARD.md. */
+function publishedRun(): { runId: string; runFile: string } {
+	const leaderboard = readFileSync(join(REPO_ROOT, "LEADERBOARD.md"), "utf8");
+	const runId = leaderboard.match(/^Run `([^`]+)`/m)?.[1];
+	if (!runId) throw new Error("LEADERBOARD.md does not name its published Run");
+	return { runId, runFile: join(REPO_ROOT, "data", "dataset", "runs", `${runId}.json`) };
+}
+
+function runBin(args: string[]): { stdout: string; status: number | null } {
+	const result = spawnSync("bun", [BIN, ...args], { cwd: REPO_ROOT, encoding: "utf8" });
+	return { stdout: result.stdout, status: result.status };
+}
+
+describe("leaderboard bin output dispatch", () => {
+	const { runId, runFile } = publishedRun();
+	const outDir = mkdtempSync(join(tmpdir(), "leaderboard-cli-"));
+
+	test("a .json output path writes the public leaderboard JSON", () => {
+		const out = join(outDir, "board.json");
+		expect(runBin([runFile, out]).status).toBe(0);
+		const written = readFileSync(out, "utf8");
+		expect(written.endsWith("\n")).toBe(true);
+		const parsed = JSON.parse(written);
+		expect(parsed.schemaVersion).toBe("1");
+		expect(parsed.runId).toBe(runId);
+	});
+
+	test("a .md output path writes the Markdown surface, not JSON", () => {
+		const out = join(outDir, "board.md");
+		expect(runBin([runFile, out]).status).toBe(0);
+		const written = readFileSync(out, "utf8");
+		expect(written).toContain(`Run \`${runId}\``);
+		expect(written.startsWith("{")).toBe(false);
+	});
+
+	test("no output path prints the Markdown surface to stdout, unpolluted by logs", () => {
+		const { stdout, status } = runBin([runFile]);
+		expect(status).toBe(0);
+		expect(stdout).toContain(`Run \`${runId}\``);
+		expect(stdout.startsWith("{")).toBe(false);
+	});
+});

--- a/apps/cli/src/bin/leaderboard.ts
+++ b/apps/cli/src/bin/leaderboard.ts
@@ -6,7 +6,12 @@
 import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { dirname } from "node:path";
 import * as core from "@actions/core";
-import { buildLeaderboard, renderLeaderboardMarkdown } from "@sandbox-benchmarks/results";
+import {
+	buildLeaderboard,
+	buildPublicLeaderboard,
+	renderLeaderboardMarkdown,
+	renderPublicLeaderboardJson,
+} from "@sandbox-benchmarks/results";
 import { parseRun } from "@sandbox-benchmarks/schema";
 import { fail, inActions, logInfo, withGroup, writeJobSummary } from "../lib/actions-log.ts";
 import { handleDiscovery } from "../lib/discovery.ts";
@@ -15,11 +20,12 @@ import { handleDiscovery } from "../lib/discovery.ts";
  *  listings are offered only as cross-CLI-consistent discovery, not the primary input. */
 export const HELP = `leaderboard — render a published Run document into the Markdown comparison surface.
 
-usage: leaderboard <run.json> [outFile.md]
+usage: leaderboard <run.json> [outFile.md|outFile.json]
        leaderboard [--help] [--list-providers] [--list-suites] [--json]
 
   <run.json>         Path to a normalized Run document (required).
-  [outFile.md]       Write the Markdown here; omit to print to stdout.
+  [outFile.md]       Write the Markdown leaderboard here; omit to print Markdown to stdout.
+  [outFile.json]     Write the machine-readable public leaderboard JSON here.
   --list-providers   List the registered providers.
   --list-suites      List the registered suites.
   --json             Emit --list-* output as JSON instead of human-readable lines.
@@ -28,6 +34,8 @@ usage: leaderboard <run.json> [outFile.md]
 examples:
   leaderboard data/runs/local-1.json                 # print the table to stdout
   leaderboard data/runs/local-1.json LEADERBOARD.md  # write the comparison surface to a file
+  leaderboard data/runs/local-1.json data/dataset/leaderboards/local-1.json
+                                                       # write the public JSON artifact
 
 Next: produce a Run with  bench-suite <provider> <suite> <runId>`;
 
@@ -76,11 +84,14 @@ if (import.meta.main) {
 		}
 		return built;
 	});
-	const markdown = renderLeaderboardMarkdown(board);
+	const jsonOutput = outFile?.endsWith(".json") === true;
+	const output = jsonOutput
+		? renderPublicLeaderboardJson(buildPublicLeaderboard(run, board))
+		: renderLeaderboardMarkdown(board);
 
 	if (outFile) {
 		mkdirSync(dirname(outFile), { recursive: true });
-		writeFileSync(outFile, markdown);
+		writeFileSync(outFile, output);
 		logInfo(`Wrote leaderboard → ${outFile}`);
 		await writeJobSummary({
 			heading: `Leaderboard ${run.runId}`,
@@ -100,6 +111,6 @@ if (import.meta.main) {
 		});
 	} else {
 		// stdout is the Markdown contract when no outFile is given — keep it pristine.
-		process.stdout.write(markdown);
+		process.stdout.write(output);
 	}
 }

--- a/data/dataset/leaderboards/29546060837.json
+++ b/data/dataset/leaderboards/29546060837.json
@@ -179,7 +179,10 @@
                 "low": 19.46,
                 "high": 19.55
               },
-              "n": 2
+              "n": 2,
+              "verdict": null,
+              "tiedWithAbove": null,
+              "pVsPrevious": null
             },
             {
               "providerId": "novita",
@@ -190,6 +193,13 @@
                 "high": 17.58
               },
               "n": 2,
+              "verdict": "underpowered",
+              "tiedWithAbove": null,
+              "pVsPrevious": {
+                "mannWhitney": 0.3333333333333333,
+                "ks": 0.0970268975952207,
+                "floor": 0.3333333333333333
+              },
               "note": "n too small"
             },
             {
@@ -201,6 +211,13 @@
                 "high": 12.94
               },
               "n": 2,
+              "verdict": "underpowered",
+              "tiedWithAbove": null,
+              "pVsPrevious": {
+                "mannWhitney": 0.3333333333333333,
+                "ks": 0.0970268975952207,
+                "floor": 0.3333333333333333
+              },
               "note": "n too small"
             },
             {
@@ -212,6 +229,13 @@
                 "high": 11.12
               },
               "n": 2,
+              "verdict": "underpowered",
+              "tiedWithAbove": null,
+              "pVsPrevious": {
+                "mannWhitney": 0.3333333333333333,
+                "ks": 0.0970268975952207,
+                "floor": 0.3333333333333333
+              },
               "note": "n too small"
             },
             {
@@ -223,6 +247,13 @@
                 "high": 8.93
               },
               "n": 2,
+              "verdict": "underpowered",
+              "tiedWithAbove": null,
+              "pVsPrevious": {
+                "mannWhitney": 0.3333333333333333,
+                "ks": 0.0970268975952207,
+                "floor": 0.3333333333333333
+              },
               "note": "n too small"
             }
           ]
@@ -242,7 +273,10 @@
                 "low": 127.58,
                 "high": 127.687
               },
-              "n": 2
+              "n": 2,
+              "verdict": null,
+              "tiedWithAbove": null,
+              "pVsPrevious": null
             },
             {
               "providerId": "daytona",
@@ -253,6 +287,13 @@
                 "high": 200.073
               },
               "n": 2,
+              "verdict": "underpowered",
+              "tiedWithAbove": null,
+              "pVsPrevious": {
+                "mannWhitney": 0.3333333333333333,
+                "ks": 0.0970268975952207,
+                "floor": 0.3333333333333333
+              },
               "note": "n too small"
             },
             {
@@ -264,6 +305,13 @@
                 "high": 240.99
               },
               "n": 2,
+              "verdict": "underpowered",
+              "tiedWithAbove": null,
+              "pVsPrevious": {
+                "mannWhitney": 0.3333333333333333,
+                "ks": 0.0970268975952207,
+                "floor": 0.3333333333333333
+              },
               "note": "n too small"
             }
           ]
@@ -283,7 +331,10 @@
                 "low": 509.653,
                 "high": 509.793
               },
-              "n": 2
+              "n": 2,
+              "verdict": null,
+              "tiedWithAbove": null,
+              "pVsPrevious": null
             },
             {
               "providerId": "daytona",
@@ -294,6 +345,13 @@
                 "high": 800.445
               },
               "n": 2,
+              "verdict": "underpowered",
+              "tiedWithAbove": null,
+              "pVsPrevious": {
+                "mannWhitney": 0.3333333333333333,
+                "ks": 0.0970268975952207,
+                "floor": 0.3333333333333333
+              },
               "note": "n too small"
             },
             {
@@ -305,6 +363,13 @@
                 "high": 962.324
               },
               "n": 2,
+              "verdict": "underpowered",
+              "tiedWithAbove": null,
+              "pVsPrevious": {
+                "mannWhitney": 0.3333333333333333,
+                "ks": 0.0970268975952207,
+                "floor": 0.3333333333333333
+              },
               "note": "n too small"
             }
           ]
@@ -324,7 +389,10 @@
                 "low": 907.024,
                 "high": 908.074
               },
-              "n": 2
+              "n": 2,
+              "verdict": null,
+              "tiedWithAbove": null,
+              "pVsPrevious": null
             },
             {
               "providerId": "daytona",
@@ -335,6 +403,13 @@
                 "high": 1425.799
               },
               "n": 2,
+              "verdict": "underpowered",
+              "tiedWithAbove": null,
+              "pVsPrevious": {
+                "mannWhitney": 0.3333333333333333,
+                "ks": 0.0970268975952207,
+                "floor": 0.3333333333333333
+              },
               "note": "n too small"
             },
             {
@@ -346,6 +421,13 @@
                 "high": 1705.315
               },
               "n": 2,
+              "verdict": "underpowered",
+              "tiedWithAbove": null,
+              "pVsPrevious": {
+                "mannWhitney": 0.3333333333333333,
+                "ks": 0.0970268975952207,
+                "floor": 0.3333333333333333
+              },
               "note": "n too small"
             }
           ]
@@ -365,7 +447,10 @@
                 "low": 115.9,
                 "high": 118.3
               },
-              "n": 2
+              "n": 2,
+              "verdict": null,
+              "tiedWithAbove": null,
+              "pVsPrevious": null
             },
             {
               "providerId": "daytona",
@@ -376,6 +461,13 @@
                 "high": 99.6
               },
               "n": 2,
+              "verdict": "underpowered",
+              "tiedWithAbove": null,
+              "pVsPrevious": {
+                "mannWhitney": 0.3333333333333333,
+                "ks": 0.0970268975952207,
+                "floor": 0.3333333333333333
+              },
               "note": "n too small"
             },
             {
@@ -387,6 +479,13 @@
                 "high": 71.6
               },
               "n": 2,
+              "verdict": "underpowered",
+              "tiedWithAbove": null,
+              "pVsPrevious": {
+                "mannWhitney": 0.3333333333333333,
+                "ks": 0.0970268975952207,
+                "floor": 0.3333333333333333
+              },
               "note": "n too small"
             }
           ]
@@ -406,7 +505,10 @@
                 "low": 2298.9,
                 "high": 2308.8
               },
-              "n": 2
+              "n": 2,
+              "verdict": null,
+              "tiedWithAbove": null,
+              "pVsPrevious": null
             },
             {
               "providerId": "novita",
@@ -417,6 +519,13 @@
                 "high": 1915.4
               },
               "n": 2,
+              "verdict": "underpowered",
+              "tiedWithAbove": null,
+              "pVsPrevious": {
+                "mannWhitney": 0.3333333333333333,
+                "ks": 0.0970268975952207,
+                "floor": 0.3333333333333333
+              },
               "note": "n too small"
             },
             {
@@ -428,6 +537,13 @@
                 "high": 1060.2
               },
               "n": 2,
+              "verdict": "underpowered",
+              "tiedWithAbove": null,
+              "pVsPrevious": {
+                "mannWhitney": 0.3333333333333333,
+                "ks": 0.0970268975952207,
+                "floor": 0.3333333333333333
+              },
               "note": "n too small"
             }
           ]
@@ -447,7 +563,10 @@
                 "low": 11,
                 "high": 11.2
               },
-              "n": 2
+              "n": 2,
+              "verdict": null,
+              "tiedWithAbove": null,
+              "pVsPrevious": null
             },
             {
               "providerId": "daytona",
@@ -458,6 +577,13 @@
                 "high": 8.14
               },
               "n": 2,
+              "verdict": "underpowered",
+              "tiedWithAbove": null,
+              "pVsPrevious": {
+                "mannWhitney": 0.3333333333333333,
+                "ks": 0.0970268975952207,
+                "floor": 0.3333333333333333
+              },
               "note": "n too small"
             },
             {
@@ -469,6 +595,13 @@
                 "high": 5.71
               },
               "n": 2,
+              "verdict": "underpowered",
+              "tiedWithAbove": null,
+              "pVsPrevious": {
+                "mannWhitney": 0.3333333333333333,
+                "ks": 0.0970268975952207,
+                "floor": 0.3333333333333333
+              },
               "note": "n too small"
             }
           ]
@@ -488,7 +621,10 @@
                 "low": 1914.5,
                 "high": 1917.6
               },
-              "n": 2
+              "n": 2,
+              "verdict": null,
+              "tiedWithAbove": null,
+              "pVsPrevious": null
             },
             {
               "providerId": "novita",
@@ -499,6 +635,13 @@
                 "high": 1626.9
               },
               "n": 2,
+              "verdict": "underpowered",
+              "tiedWithAbove": null,
+              "pVsPrevious": {
+                "mannWhitney": 0.3333333333333333,
+                "ks": 0.0970268975952207,
+                "floor": 0.3333333333333333
+              },
               "note": "n too small"
             },
             {
@@ -510,6 +653,13 @@
                 "high": 894.6
               },
               "n": 2,
+              "verdict": "underpowered",
+              "tiedWithAbove": null,
+              "pVsPrevious": {
+                "mannWhitney": 0.3333333333333333,
+                "ks": 0.0970268975952207,
+                "floor": 0.3333333333333333
+              },
               "note": "n too small"
             }
           ]
@@ -529,7 +679,10 @@
                 "low": 7.03,
                 "high": 7.12
               },
-              "n": 2
+              "n": 2,
+              "verdict": null,
+              "tiedWithAbove": null,
+              "pVsPrevious": null
             },
             {
               "providerId": "blaxel",
@@ -540,6 +693,13 @@
                 "high": 5.95
               },
               "n": 2,
+              "verdict": "underpowered",
+              "tiedWithAbove": null,
+              "pVsPrevious": {
+                "mannWhitney": 0.3333333333333333,
+                "ks": 0.0970268975952207,
+                "floor": 0.3333333333333333
+              },
               "note": "n too small"
             },
             {
@@ -551,6 +711,13 @@
                 "high": 5.23
               },
               "n": 2,
+              "verdict": "underpowered",
+              "tiedWithAbove": null,
+              "pVsPrevious": {
+                "mannWhitney": 0.3333333333333333,
+                "ks": 0.0970268975952207,
+                "floor": 0.3333333333333333
+              },
               "note": "n too small"
             }
           ]
@@ -570,7 +737,10 @@
                 "low": 1839.6,
                 "high": 1844.7
               },
-              "n": 2
+              "n": 2,
+              "verdict": null,
+              "tiedWithAbove": null,
+              "pVsPrevious": null
             },
             {
               "providerId": "novita",
@@ -581,6 +751,13 @@
                 "high": 1551.5
               },
               "n": 2,
+              "verdict": "underpowered",
+              "tiedWithAbove": null,
+              "pVsPrevious": {
+                "mannWhitney": 0.3333333333333333,
+                "ks": 0.0970268975952207,
+                "floor": 0.3333333333333333
+              },
               "note": "n too small"
             },
             {
@@ -592,6 +769,13 @@
                 "high": 902.5
               },
               "n": 2,
+              "verdict": "underpowered",
+              "tiedWithAbove": null,
+              "pVsPrevious": {
+                "mannWhitney": 0.3333333333333333,
+                "ks": 0.0970268975952207,
+                "floor": 0.3333333333333333
+              },
               "note": "n too small"
             }
           ]
@@ -611,7 +795,10 @@
                 "low": 1293.9,
                 "high": 1305.8
               },
-              "n": 2
+              "n": 2,
+              "verdict": null,
+              "tiedWithAbove": null,
+              "pVsPrevious": null
             },
             {
               "providerId": "daytona",
@@ -622,6 +809,13 @@
                 "high": 782.3
               },
               "n": 2,
+              "verdict": "underpowered",
+              "tiedWithAbove": null,
+              "pVsPrevious": {
+                "mannWhitney": 0.3333333333333333,
+                "ks": 0.0970268975952207,
+                "floor": 0.3333333333333333
+              },
               "note": "n too small"
             },
             {
@@ -633,6 +827,13 @@
                 "high": 682.1
               },
               "n": 2,
+              "verdict": "underpowered",
+              "tiedWithAbove": null,
+              "pVsPrevious": {
+                "mannWhitney": 0.3333333333333333,
+                "ks": 0.0970268975952207,
+                "floor": 0.3333333333333333
+              },
               "note": "n too small"
             }
           ]
@@ -652,7 +853,10 @@
                 "low": 2112.1,
                 "high": 2114.5
               },
-              "n": 2
+              "n": 2,
+              "verdict": null,
+              "tiedWithAbove": null,
+              "pVsPrevious": null
             },
             {
               "providerId": "novita",
@@ -663,6 +867,13 @@
                 "high": 1751.3
               },
               "n": 2,
+              "verdict": "underpowered",
+              "tiedWithAbove": null,
+              "pVsPrevious": {
+                "mannWhitney": 0.3333333333333333,
+                "ks": 0.0970268975952207,
+                "floor": 0.3333333333333333
+              },
               "note": "n too small"
             },
             {
@@ -670,7 +881,10 @@
               "rank": 3,
               "value": 1116.9,
               "interval": null,
-              "n": 1
+              "n": 1,
+              "verdict": "untested",
+              "tiedWithAbove": null,
+              "pVsPrevious": null
             }
           ]
         },
@@ -689,7 +903,10 @@
                 "low": 841.7,
                 "high": 854.1
               },
-              "n": 2
+              "n": 2,
+              "verdict": null,
+              "tiedWithAbove": null,
+              "pVsPrevious": null
             },
             {
               "providerId": "daytona",
@@ -700,6 +917,13 @@
                 "high": 536.5
               },
               "n": 2,
+              "verdict": "underpowered",
+              "tiedWithAbove": null,
+              "pVsPrevious": {
+                "mannWhitney": 0.3333333333333333,
+                "ks": 0.0970268975952207,
+                "floor": 0.3333333333333333
+              },
               "note": "n too small"
             },
             {
@@ -711,6 +935,13 @@
                 "high": 531
               },
               "n": 2,
+              "verdict": "underpowered",
+              "tiedWithAbove": null,
+              "pVsPrevious": {
+                "mannWhitney": 0.3333333333333333,
+                "ks": 0.0970268975952207,
+                "floor": 0.3333333333333333
+              },
               "note": "n too small"
             }
           ]
@@ -730,7 +961,10 @@
                 "low": 2161,
                 "high": 2171.2
               },
-              "n": 2
+              "n": 2,
+              "verdict": null,
+              "tiedWithAbove": null,
+              "pVsPrevious": null
             },
             {
               "providerId": "novita",
@@ -741,6 +975,13 @@
                 "high": 1810.9
               },
               "n": 2,
+              "verdict": "underpowered",
+              "tiedWithAbove": null,
+              "pVsPrevious": {
+                "mannWhitney": 0.3333333333333333,
+                "ks": 0.0970268975952207,
+                "floor": 0.3333333333333333
+              },
               "note": "n too small"
             }
           ]
@@ -760,7 +1001,10 @@
                 "low": 352,
                 "high": 352.7
               },
-              "n": 2
+              "n": 2,
+              "verdict": null,
+              "tiedWithAbove": null,
+              "pVsPrevious": null
             },
             {
               "providerId": "daytona",
@@ -771,6 +1015,13 @@
                 "high": 212
               },
               "n": 2,
+              "verdict": "underpowered",
+              "tiedWithAbove": null,
+              "pVsPrevious": {
+                "mannWhitney": 0.3333333333333333,
+                "ks": 0.0970268975952207,
+                "floor": 0.3333333333333333
+              },
               "note": "n too small"
             },
             {
@@ -782,6 +1033,13 @@
                 "high": 180.2
               },
               "n": 2,
+              "verdict": "underpowered",
+              "tiedWithAbove": null,
+              "pVsPrevious": {
+                "mannWhitney": 0.3333333333333333,
+                "ks": 0.0970268975952207,
+                "floor": 0.3333333333333333
+              },
               "note": "n too small"
             }
           ]
@@ -801,7 +1059,10 @@
                 "low": 2269,
                 "high": 2269.2
               },
-              "n": 2
+              "n": 2,
+              "verdict": null,
+              "tiedWithAbove": null,
+              "pVsPrevious": null
             },
             {
               "providerId": "novita",
@@ -812,6 +1073,13 @@
                 "high": 1912.3
               },
               "n": 2,
+              "verdict": "underpowered",
+              "tiedWithAbove": null,
+              "pVsPrevious": {
+                "mannWhitney": 0.3333333333333333,
+                "ks": 0.0970268975952207,
+                "floor": 0.3333333333333333
+              },
               "note": "n too small"
             },
             {
@@ -823,6 +1091,13 @@
                 "high": 1126.2
               },
               "n": 2,
+              "verdict": "underpowered",
+              "tiedWithAbove": null,
+              "pVsPrevious": {
+                "mannWhitney": 0.3333333333333333,
+                "ks": 0.0970268975952207,
+                "floor": 0.3333333333333333
+              },
               "note": "n too small"
             }
           ]
@@ -842,7 +1117,10 @@
                 "low": 323.7,
                 "high": 326.9
               },
-              "n": 2
+              "n": 2,
+              "verdict": null,
+              "tiedWithAbove": null,
+              "pVsPrevious": null
             },
             {
               "providerId": "daytona",
@@ -853,6 +1131,13 @@
                 "high": 203
               },
               "n": 2,
+              "verdict": "underpowered",
+              "tiedWithAbove": null,
+              "pVsPrevious": {
+                "mannWhitney": 0.3333333333333333,
+                "ks": 0.0970268975952207,
+                "floor": 0.3333333333333333
+              },
               "note": "n too small"
             },
             {
@@ -864,6 +1149,13 @@
                 "high": 174.8
               },
               "n": 2,
+              "verdict": "underpowered",
+              "tiedWithAbove": null,
+              "pVsPrevious": {
+                "mannWhitney": 0.3333333333333333,
+                "ks": 0.0970268975952207,
+                "floor": 0.3333333333333333
+              },
               "note": "n too small"
             }
           ]
@@ -883,7 +1175,10 @@
                 "low": 2304.8,
                 "high": 2310.5
               },
-              "n": 2
+              "n": 2,
+              "verdict": null,
+              "tiedWithAbove": null,
+              "pVsPrevious": null
             },
             {
               "providerId": "novita",
@@ -894,6 +1189,13 @@
                 "high": 1915
               },
               "n": 2,
+              "verdict": "underpowered",
+              "tiedWithAbove": null,
+              "pVsPrevious": {
+                "mannWhitney": 0.3333333333333333,
+                "ks": 0.0970268975952207,
+                "floor": 0.3333333333333333
+              },
               "note": "n too small"
             },
             {
@@ -905,6 +1207,13 @@
                 "high": 1136
               },
               "n": 2,
+              "verdict": "underpowered",
+              "tiedWithAbove": null,
+              "pVsPrevious": {
+                "mannWhitney": 0.3333333333333333,
+                "ks": 0.0970268975952207,
+                "floor": 0.3333333333333333
+              },
               "note": "n too small"
             }
           ]
@@ -929,7 +1238,10 @@
                 "low": 570000,
                 "high": 582000
               },
-              "n": 2
+              "n": 2,
+              "verdict": null,
+              "tiedWithAbove": null,
+              "pVsPrevious": null
             },
             {
               "providerId": "daytona",
@@ -940,6 +1252,13 @@
                 "high": 257000
               },
               "n": 2,
+              "verdict": "underpowered",
+              "tiedWithAbove": null,
+              "pVsPrevious": {
+                "mannWhitney": 0.3333333333333333,
+                "ks": 0.0970268975952207,
+                "floor": 0.3333333333333333
+              },
               "note": "n too small"
             },
             {
@@ -951,6 +1270,13 @@
                 "high": 63700
               },
               "n": 2,
+              "verdict": "underpowered",
+              "tiedWithAbove": null,
+              "pVsPrevious": {
+                "mannWhitney": 0.3333333333333333,
+                "ks": 0.0970268975952207,
+                "floor": 0.3333333333333333
+              },
               "note": "n too small"
             },
             {
@@ -962,6 +1288,13 @@
                 "high": 41300
               },
               "n": 2,
+              "verdict": "underpowered",
+              "tiedWithAbove": null,
+              "pVsPrevious": {
+                "mannWhitney": 0.3333333333333333,
+                "ks": 0.0970268975952207,
+                "floor": 0.3333333333333333
+              },
               "note": "n too small"
             },
             {
@@ -973,6 +1306,13 @@
                 "high": 34600
               },
               "n": 2,
+              "verdict": "underpowered",
+              "tiedWithAbove": null,
+              "pVsPrevious": {
+                "mannWhitney": 0.3333333333333333,
+                "ks": 0.0970268975952207,
+                "floor": 0.3333333333333333
+              },
               "note": "n too small"
             }
           ]
@@ -992,7 +1332,10 @@
                 "low": 2226,
                 "high": 2275
               },
-              "n": 2
+              "n": 2,
+              "verdict": null,
+              "tiedWithAbove": null,
+              "pVsPrevious": null
             },
             {
               "providerId": "daytona",
@@ -1003,6 +1346,13 @@
                 "high": 1006
               },
               "n": 2,
+              "verdict": "underpowered",
+              "tiedWithAbove": null,
+              "pVsPrevious": {
+                "mannWhitney": 0.3333333333333333,
+                "ks": 0.0970268975952207,
+                "floor": 0.3333333333333333
+              },
               "note": "n too small"
             },
             {
@@ -1014,6 +1364,13 @@
                 "high": 249
               },
               "n": 2,
+              "verdict": "underpowered",
+              "tiedWithAbove": null,
+              "pVsPrevious": {
+                "mannWhitney": 0.3333333333333333,
+                "ks": 0.0970268975952207,
+                "floor": 0.3333333333333333
+              },
               "note": "n too small"
             },
             {
@@ -1025,6 +1382,13 @@
                 "high": 162
               },
               "n": 2,
+              "verdict": "underpowered",
+              "tiedWithAbove": null,
+              "pVsPrevious": {
+                "mannWhitney": 0.3333333333333333,
+                "ks": 0.0970268975952207,
+                "floor": 0.3333333333333333
+              },
               "note": "n too small"
             },
             {
@@ -1036,6 +1400,13 @@
                 "high": 135
               },
               "n": 2,
+              "verdict": "underpowered",
+              "tiedWithAbove": null,
+              "pVsPrevious": {
+                "mannWhitney": 0.3333333333333333,
+                "ks": 0.0970268975952207,
+                "floor": 0.3333333333333333
+              },
               "note": "n too small"
             }
           ]
@@ -1055,7 +1426,10 @@
                 "low": 484000,
                 "high": 506000
               },
-              "n": 2
+              "n": 2,
+              "verdict": null,
+              "tiedWithAbove": null,
+              "pVsPrevious": null
             },
             {
               "providerId": "daytona",
@@ -1066,6 +1440,13 @@
                 "high": 255000
               },
               "n": 2,
+              "verdict": "underpowered",
+              "tiedWithAbove": null,
+              "pVsPrevious": {
+                "mannWhitney": 0.3333333333333333,
+                "ks": 0.0970268975952207,
+                "floor": 0.3333333333333333
+              },
               "note": "n too small"
             },
             {
@@ -1077,6 +1458,13 @@
                 "high": 94600
               },
               "n": 2,
+              "verdict": "underpowered",
+              "tiedWithAbove": null,
+              "pVsPrevious": {
+                "mannWhitney": 0.3333333333333333,
+                "ks": 0.0970268975952207,
+                "floor": 0.3333333333333333
+              },
               "note": "n too small"
             },
             {
@@ -1088,6 +1476,13 @@
                 "high": 44300
               },
               "n": 2,
+              "verdict": "underpowered",
+              "tiedWithAbove": null,
+              "pVsPrevious": {
+                "mannWhitney": 0.3333333333333333,
+                "ks": 0.0970268975952207,
+                "floor": 0.3333333333333333
+              },
               "note": "n too small"
             },
             {
@@ -1099,6 +1494,13 @@
                 "high": 29600
               },
               "n": 2,
+              "verdict": "underpowered",
+              "tiedWithAbove": null,
+              "pVsPrevious": {
+                "mannWhitney": 0.3333333333333333,
+                "ks": 0.0970268975952207,
+                "floor": 0.3333333333333333
+              },
               "note": "n too small"
             }
           ]
@@ -1118,7 +1520,10 @@
                 "low": 1891,
                 "high": 1977
               },
-              "n": 2
+              "n": 2,
+              "verdict": null,
+              "tiedWithAbove": null,
+              "pVsPrevious": null
             },
             {
               "providerId": "daytona",
@@ -1129,6 +1534,13 @@
                 "high": 994
               },
               "n": 2,
+              "verdict": "underpowered",
+              "tiedWithAbove": null,
+              "pVsPrevious": {
+                "mannWhitney": 0.3333333333333333,
+                "ks": 0.0970268975952207,
+                "floor": 0.3333333333333333
+              },
               "note": "n too small"
             },
             {
@@ -1140,6 +1552,13 @@
                 "high": 369
               },
               "n": 2,
+              "verdict": "underpowered",
+              "tiedWithAbove": null,
+              "pVsPrevious": {
+                "mannWhitney": 0.3333333333333333,
+                "ks": 0.0970268975952207,
+                "floor": 0.3333333333333333
+              },
               "note": "n too small"
             },
             {
@@ -1151,6 +1570,13 @@
                 "high": 173
               },
               "n": 2,
+              "verdict": "underpowered",
+              "tiedWithAbove": null,
+              "pVsPrevious": {
+                "mannWhitney": 0.3333333333333333,
+                "ks": 0.0970268975952207,
+                "floor": 0.3333333333333333
+              },
               "note": "n too small"
             },
             {
@@ -1162,6 +1588,13 @@
                 "high": 116
               },
               "n": 2,
+              "verdict": "underpowered",
+              "tiedWithAbove": null,
+              "pVsPrevious": {
+                "mannWhitney": 0.3333333333333333,
+                "ks": 0.0970268975952207,
+                "floor": 0.3333333333333333
+              },
               "note": "n too small"
             }
           ]
@@ -1181,7 +1614,10 @@
                 "low": 11900,
                 "high": 12800
               },
-              "n": 2
+              "n": 2,
+              "verdict": null,
+              "tiedWithAbove": null,
+              "pVsPrevious": null
             },
             {
               "providerId": "novita",
@@ -1192,6 +1628,13 @@
                 "high": 11300
               },
               "n": 2,
+              "verdict": "underpowered",
+              "tiedWithAbove": null,
+              "pVsPrevious": {
+                "mannWhitney": 0.3333333333333333,
+                "ks": 0.0970268975952207,
+                "floor": 0.3333333333333333
+              },
               "note": "n too small"
             },
             {
@@ -1203,6 +1646,13 @@
                 "high": 12700
               },
               "n": 2,
+              "verdict": "underpowered",
+              "tiedWithAbove": null,
+              "pVsPrevious": {
+                "mannWhitney": 1,
+                "ks": 0.8438198245415606,
+                "floor": 0.3333333333333333
+              },
               "note": "n too small"
             },
             {
@@ -1214,6 +1664,13 @@
                 "high": 4809
               },
               "n": 2,
+              "verdict": "underpowered",
+              "tiedWithAbove": null,
+              "pVsPrevious": {
+                "mannWhitney": 0.3333333333333333,
+                "ks": 0.0970268975952207,
+                "floor": 0.3333333333333333
+              },
               "note": "n too small"
             },
             {
@@ -1225,6 +1682,13 @@
                 "high": 599
               },
               "n": 2,
+              "verdict": "underpowered",
+              "tiedWithAbove": null,
+              "pVsPrevious": {
+                "mannWhitney": 0.3333333333333333,
+                "ks": 0.0970268975952207,
+                "floor": 0.3333333333333333
+              },
               "note": "n too small"
             }
           ]
@@ -1241,7 +1705,10 @@
               "rank": 1,
               "value": 5585,
               "interval": null,
-              "n": 1
+              "n": 1,
+              "verdict": null,
+              "tiedWithAbove": null,
+              "pVsPrevious": null
             },
             {
               "providerId": "blaxel",
@@ -1251,7 +1718,10 @@
                 "low": 4611,
                 "high": 4811
               },
-              "n": 2
+              "n": 2,
+              "verdict": "untested",
+              "tiedWithAbove": null,
+              "pVsPrevious": null
             },
             {
               "providerId": "e2b",
@@ -1262,6 +1732,13 @@
                 "high": 601
               },
               "n": 2,
+              "verdict": "underpowered",
+              "tiedWithAbove": null,
+              "pVsPrevious": {
+                "mannWhitney": 0.3333333333333333,
+                "ks": 0.0970268975952207,
+                "floor": 0.3333333333333333
+              },
               "note": "n too small"
             }
           ]
@@ -1281,7 +1758,10 @@
                 "low": 5714,
                 "high": 5928
               },
-              "n": 2
+              "n": 2,
+              "verdict": null,
+              "tiedWithAbove": null,
+              "pVsPrevious": null
             },
             {
               "providerId": "novita",
@@ -1292,6 +1772,13 @@
                 "high": 5570
               },
               "n": 2,
+              "verdict": "underpowered",
+              "tiedWithAbove": null,
+              "pVsPrevious": {
+                "mannWhitney": 0.3333333333333333,
+                "ks": 0.0970268975952207,
+                "floor": 0.3333333333333333
+              },
               "note": "n too small"
             },
             {
@@ -1303,6 +1790,13 @@
                 "high": 3700
               },
               "n": 2,
+              "verdict": "underpowered",
+              "tiedWithAbove": null,
+              "pVsPrevious": {
+                "mannWhitney": 0.3333333333333333,
+                "ks": 0.0970268975952207,
+                "floor": 0.3333333333333333
+              },
               "note": "n too small"
             },
             {
@@ -1314,6 +1808,13 @@
                 "high": 3554
               },
               "n": 2,
+              "verdict": "underpowered",
+              "tiedWithAbove": null,
+              "pVsPrevious": {
+                "mannWhitney": 0.3333333333333333,
+                "ks": 0.0970268975952207,
+                "floor": 0.3333333333333333
+              },
               "note": "n too small"
             },
             {
@@ -1325,6 +1826,13 @@
                 "high": 600
               },
               "n": 2,
+              "verdict": "underpowered",
+              "tiedWithAbove": null,
+              "pVsPrevious": {
+                "mannWhitney": 0.3333333333333333,
+                "ks": 0.0970268975952207,
+                "floor": 0.3333333333333333
+              },
               "note": "n too small"
             }
           ]
@@ -1344,7 +1852,10 @@
                 "low": 5716,
                 "high": 5930
               },
-              "n": 2
+              "n": 2,
+              "verdict": null,
+              "tiedWithAbove": null,
+              "pVsPrevious": null
             },
             {
               "providerId": "novita",
@@ -1355,6 +1866,13 @@
                 "high": 5571
               },
               "n": 2,
+              "verdict": "underpowered",
+              "tiedWithAbove": null,
+              "pVsPrevious": {
+                "mannWhitney": 0.3333333333333333,
+                "ks": 0.0970268975952207,
+                "floor": 0.3333333333333333
+              },
               "note": "n too small"
             },
             {
@@ -1366,6 +1884,13 @@
                 "high": 3702
               },
               "n": 2,
+              "verdict": "underpowered",
+              "tiedWithAbove": null,
+              "pVsPrevious": {
+                "mannWhitney": 0.3333333333333333,
+                "ks": 0.0970268975952207,
+                "floor": 0.3333333333333333
+              },
               "note": "n too small"
             },
             {
@@ -1377,6 +1902,13 @@
                 "high": 3556
               },
               "n": 2,
+              "verdict": "underpowered",
+              "tiedWithAbove": null,
+              "pVsPrevious": {
+                "mannWhitney": 0.3333333333333333,
+                "ks": 0.0970268975952207,
+                "floor": 0.3333333333333333
+              },
               "note": "n too small"
             },
             {
@@ -1388,6 +1920,13 @@
                 "high": 601
               },
               "n": 2,
+              "verdict": "underpowered",
+              "tiedWithAbove": null,
+              "pVsPrevious": {
+                "mannWhitney": 0.3333333333333333,
+                "ks": 0.0970268975952207,
+                "floor": 0.3333333333333333
+              },
               "note": "n too small"
             }
           ]
@@ -1407,7 +1946,10 @@
                 "low": 23.62,
                 "high": 23.69
               },
-              "n": 2
+              "n": 2,
+              "verdict": null,
+              "tiedWithAbove": null,
+              "pVsPrevious": null
             },
             {
               "providerId": "novita",
@@ -1418,6 +1960,13 @@
                 "high": 18.59
               },
               "n": 2,
+              "verdict": "underpowered",
+              "tiedWithAbove": null,
+              "pVsPrevious": {
+                "mannWhitney": 0.3333333333333333,
+                "ks": 0.0970268975952207,
+                "floor": 0.3333333333333333
+              },
               "note": "n too small"
             },
             {
@@ -1429,6 +1978,13 @@
                 "high": 12.46
               },
               "n": 2,
+              "verdict": "underpowered",
+              "tiedWithAbove": null,
+              "pVsPrevious": {
+                "mannWhitney": 0.3333333333333333,
+                "ks": 0.0970268975952207,
+                "floor": 0.3333333333333333
+              },
               "note": "n too small"
             },
             {
@@ -1440,6 +1996,13 @@
                 "high": 3.12
               },
               "n": 2,
+              "verdict": "underpowered",
+              "tiedWithAbove": null,
+              "pVsPrevious": {
+                "mannWhitney": 0.3333333333333333,
+                "ks": 0.0970268975952207,
+                "floor": 0.3333333333333333
+              },
               "note": "n too small"
             },
             {
@@ -1451,6 +2014,13 @@
                 "high": 1.46
               },
               "n": 2,
+              "verdict": "underpowered",
+              "tiedWithAbove": null,
+              "pVsPrevious": {
+                "mannWhitney": 0.3333333333333333,
+                "ks": 0.0970268975952207,
+                "floor": 0.3333333333333333
+              },
               "note": "n too small"
             }
           ]
@@ -1475,7 +2045,10 @@
                 "low": 70326.4,
                 "high": 77460.7
               },
-              "n": 2
+              "n": 2,
+              "verdict": null,
+              "tiedWithAbove": null,
+              "pVsPrevious": null
             },
             {
               "providerId": "daytona",
@@ -1486,6 +2059,13 @@
                 "high": 56009.6
               },
               "n": 2,
+              "verdict": "underpowered",
+              "tiedWithAbove": null,
+              "pVsPrevious": {
+                "mannWhitney": 0.3333333333333333,
+                "ks": 0.0970268975952207,
+                "floor": 0.3333333333333333
+              },
               "note": "n too small"
             },
             {
@@ -1497,6 +2077,13 @@
                 "high": 46212.3
               },
               "n": 2,
+              "verdict": "underpowered",
+              "tiedWithAbove": null,
+              "pVsPrevious": {
+                "mannWhitney": 0.3333333333333333,
+                "ks": 0.0970268975952207,
+                "floor": 0.3333333333333333
+              },
               "note": "n too small"
             },
             {
@@ -1508,6 +2095,13 @@
                 "high": 48697.4
               },
               "n": 2,
+              "verdict": "underpowered",
+              "tiedWithAbove": null,
+              "pVsPrevious": {
+                "mannWhitney": 1,
+                "ks": 0.8438198245415606,
+                "floor": 0.3333333333333333
+              },
               "note": "n too small"
             },
             {
@@ -1519,6 +2113,13 @@
                 "high": 22264.7
               },
               "n": 2,
+              "verdict": "underpowered",
+              "tiedWithAbove": null,
+              "pVsPrevious": {
+                "mannWhitney": 0.3333333333333333,
+                "ks": 0.0970268975952207,
+                "floor": 0.3333333333333333
+              },
               "note": "n too small"
             }
           ]
@@ -1538,7 +2139,10 @@
                 "low": 70135.9,
                 "high": 77686.7
               },
-              "n": 2
+              "n": 2,
+              "verdict": null,
+              "tiedWithAbove": null,
+              "pVsPrevious": null
             },
             {
               "providerId": "daytona",
@@ -1549,6 +2153,13 @@
                 "high": 55755.6
               },
               "n": 2,
+              "verdict": "underpowered",
+              "tiedWithAbove": null,
+              "pVsPrevious": {
+                "mannWhitney": 0.3333333333333333,
+                "ks": 0.0970268975952207,
+                "floor": 0.3333333333333333
+              },
               "note": "n too small"
             },
             {
@@ -1560,6 +2171,13 @@
                 "high": 50672.2
               },
               "n": 2,
+              "verdict": "underpowered",
+              "tiedWithAbove": null,
+              "pVsPrevious": {
+                "mannWhitney": 0.3333333333333333,
+                "ks": 0.0970268975952207,
+                "floor": 0.3333333333333333
+              },
               "note": "n too small"
             },
             {
@@ -1571,6 +2189,13 @@
                 "high": 45928.2
               },
               "n": 2,
+              "verdict": "underpowered",
+              "tiedWithAbove": null,
+              "pVsPrevious": {
+                "mannWhitney": 1,
+                "ks": 0.8438198245415606,
+                "floor": 0.3333333333333333
+              },
               "note": "n too small"
             },
             {
@@ -1582,6 +2207,13 @@
                 "high": 22208.7
               },
               "n": 2,
+              "verdict": "underpowered",
+              "tiedWithAbove": null,
+              "pVsPrevious": {
+                "mannWhitney": 0.3333333333333333,
+                "ks": 0.0970268975952207,
+                "floor": 0.3333333333333333
+              },
               "note": "n too small"
             }
           ]
@@ -1601,7 +2233,10 @@
                 "low": 107305.5,
                 "high": 120361.7
               },
-              "n": 2
+              "n": 2,
+              "verdict": null,
+              "tiedWithAbove": null,
+              "pVsPrevious": null
             },
             {
               "providerId": "daytona",
@@ -1612,6 +2247,13 @@
                 "high": 65692.3
               },
               "n": 2,
+              "verdict": "underpowered",
+              "tiedWithAbove": null,
+              "pVsPrevious": {
+                "mannWhitney": 0.3333333333333333,
+                "ks": 0.0970268975952207,
+                "floor": 0.3333333333333333
+              },
               "note": "n too small"
             },
             {
@@ -1623,6 +2265,13 @@
                 "high": 67440.2
               },
               "n": 2,
+              "verdict": "underpowered",
+              "tiedWithAbove": null,
+              "pVsPrevious": {
+                "mannWhitney": 1,
+                "ks": 0.8438198245415606,
+                "floor": 0.3333333333333333
+              },
               "note": "n too small"
             },
             {
@@ -1634,6 +2283,13 @@
                 "high": 55127.3
               },
               "n": 2,
+              "verdict": "underpowered",
+              "tiedWithAbove": null,
+              "pVsPrevious": {
+                "mannWhitney": 0.3333333333333333,
+                "ks": 0.0970268975952207,
+                "floor": 0.3333333333333333
+              },
               "note": "n too small"
             },
             {
@@ -1645,6 +2301,13 @@
                 "high": 46760.5
               },
               "n": 2,
+              "verdict": "underpowered",
+              "tiedWithAbove": null,
+              "pVsPrevious": {
+                "mannWhitney": 0.3333333333333333,
+                "ks": 0.0970268975952207,
+                "floor": 0.3333333333333333
+              },
               "note": "n too small"
             }
           ]
@@ -1664,7 +2327,10 @@
                 "low": 58675.3,
                 "high": 66567
               },
-              "n": 2
+              "n": 2,
+              "verdict": null,
+              "tiedWithAbove": null,
+              "pVsPrevious": null
             },
             {
               "providerId": "daytona",
@@ -1675,6 +2341,13 @@
                 "high": 50181.9
               },
               "n": 2,
+              "verdict": "underpowered",
+              "tiedWithAbove": null,
+              "pVsPrevious": {
+                "mannWhitney": 0.3333333333333333,
+                "ks": 0.0970268975952207,
+                "floor": 0.3333333333333333
+              },
               "note": "n too small"
             },
             {
@@ -1686,6 +2359,13 @@
                 "high": 45606.5
               },
               "n": 2,
+              "verdict": "underpowered",
+              "tiedWithAbove": null,
+              "pVsPrevious": {
+                "mannWhitney": 0.3333333333333333,
+                "ks": 0.0970268975952207,
+                "floor": 0.3333333333333333
+              },
               "note": "n too small"
             },
             {
@@ -1697,6 +2377,13 @@
                 "high": 40662
               },
               "n": 2,
+              "verdict": "underpowered",
+              "tiedWithAbove": null,
+              "pVsPrevious": {
+                "mannWhitney": 0.3333333333333333,
+                "ks": 0.0970268975952207,
+                "floor": 0.3333333333333333
+              },
               "note": "n too small"
             },
             {
@@ -1708,6 +2395,13 @@
                 "high": 21051.5
               },
               "n": 2,
+              "verdict": "underpowered",
+              "tiedWithAbove": null,
+              "pVsPrevious": {
+                "mannWhitney": 0.3333333333333333,
+                "ks": 0.0970268975952207,
+                "floor": 0.3333333333333333
+              },
               "note": "n too small"
             }
           ]
@@ -1732,7 +2426,10 @@
                 "low": 5.286,
                 "high": 5.595
               },
-              "n": 2
+              "n": 2,
+              "verdict": null,
+              "tiedWithAbove": null,
+              "pVsPrevious": null
             },
             {
               "providerId": "blaxel",
@@ -1743,6 +2440,13 @@
                 "high": 6.867
               },
               "n": 2,
+              "verdict": "underpowered",
+              "tiedWithAbove": null,
+              "pVsPrevious": {
+                "mannWhitney": 0.3333333333333333,
+                "ks": 0.0970268975952207,
+                "floor": 0.3333333333333333
+              },
               "note": "n too small"
             },
             {
@@ -1754,6 +2458,13 @@
                 "high": 7.959
               },
               "n": 2,
+              "verdict": "underpowered",
+              "tiedWithAbove": null,
+              "pVsPrevious": {
+                "mannWhitney": 0.3333333333333333,
+                "ks": 0.0970268975952207,
+                "floor": 0.3333333333333333
+              },
               "note": "n too small"
             },
             {
@@ -1765,6 +2476,13 @@
                 "high": 10.97
               },
               "n": 2,
+              "verdict": "underpowered",
+              "tiedWithAbove": null,
+              "pVsPrevious": {
+                "mannWhitney": 0.3333333333333333,
+                "ks": 0.0970268975952207,
+                "floor": 0.3333333333333333
+              },
               "note": "n too small"
             },
             {
@@ -1776,6 +2494,13 @@
                 "high": 56.857
               },
               "n": 2,
+              "verdict": "underpowered",
+              "tiedWithAbove": null,
+              "pVsPrevious": {
+                "mannWhitney": 0.3333333333333333,
+                "ks": 0.0970268975952207,
+                "floor": 0.3333333333333333
+              },
               "note": "n too small"
             }
           ]
@@ -1795,7 +2520,10 @@
                 "low": 3,
                 "high": 3.5
               },
-              "n": 2
+              "n": 2,
+              "verdict": null,
+              "tiedWithAbove": null,
+              "pVsPrevious": null
             }
           ]
         },
@@ -1814,7 +2542,10 @@
                 "low": 7,
                 "high": 7
               },
-              "n": 2
+              "n": 2,
+              "verdict": null,
+              "tiedWithAbove": null,
+              "pVsPrevious": null
             }
           ]
         },
@@ -1830,7 +2561,10 @@
               "rank": 1,
               "value": 9,
               "interval": null,
-              "n": 1
+              "n": 1,
+              "verdict": null,
+              "tiedWithAbove": null,
+              "pVsPrevious": null
             }
           ]
         },
@@ -1849,7 +2583,10 @@
                 "low": 760,
                 "high": 780
               },
-              "n": 2
+              "n": 2,
+              "verdict": null,
+              "tiedWithAbove": null,
+              "pVsPrevious": null
             }
           ]
         }
@@ -1873,7 +2610,10 @@
                 "low": 839,
                 "high": 849
               },
-              "n": 2
+              "n": 2,
+              "verdict": null,
+              "tiedWithAbove": null,
+              "pVsPrevious": null
             }
           ]
         },
@@ -1892,7 +2632,10 @@
                 "low": 35.962,
                 "high": 36.164
               },
-              "n": 2
+              "n": 2,
+              "verdict": null,
+              "tiedWithAbove": null,
+              "pVsPrevious": null
             },
             {
               "providerId": "novita",
@@ -1903,6 +2646,13 @@
                 "high": 43.678
               },
               "n": 2,
+              "verdict": "underpowered",
+              "tiedWithAbove": null,
+              "pVsPrevious": {
+                "mannWhitney": 0.3333333333333333,
+                "ks": 0.0970268975952207,
+                "floor": 0.3333333333333333
+              },
               "note": "n too small"
             },
             {
@@ -1914,6 +2664,13 @@
                 "high": 61.589
               },
               "n": 2,
+              "verdict": "underpowered",
+              "tiedWithAbove": null,
+              "pVsPrevious": {
+                "mannWhitney": 0.3333333333333333,
+                "ks": 0.0970268975952207,
+                "floor": 0.3333333333333333
+              },
               "note": "n too small"
             },
             {
@@ -1925,6 +2682,13 @@
                 "high": 70.513
               },
               "n": 2,
+              "verdict": "underpowered",
+              "tiedWithAbove": null,
+              "pVsPrevious": {
+                "mannWhitney": 0.3333333333333333,
+                "ks": 0.0970268975952207,
+                "floor": 0.3333333333333333
+              },
               "note": "n too small"
             },
             {
@@ -1936,6 +2700,13 @@
                 "high": 81.995
               },
               "n": 2,
+              "verdict": "underpowered",
+              "tiedWithAbove": null,
+              "pVsPrevious": {
+                "mannWhitney": 0.3333333333333333,
+                "ks": 0.0970268975952207,
+                "floor": 0.3333333333333333
+              },
               "note": "n too small"
             }
           ]
@@ -1955,7 +2726,10 @@
                 "low": 30.412,
                 "high": 30.671
               },
-              "n": 2
+              "n": 2,
+              "verdict": null,
+              "tiedWithAbove": null,
+              "pVsPrevious": null
             },
             {
               "providerId": "novita",
@@ -1966,6 +2740,13 @@
                 "high": 39.091
               },
               "n": 2,
+              "verdict": "underpowered",
+              "tiedWithAbove": null,
+              "pVsPrevious": {
+                "mannWhitney": 0.3333333333333333,
+                "ks": 0.0970268975952207,
+                "floor": 0.3333333333333333
+              },
               "note": "n too small"
             },
             {
@@ -1977,6 +2758,13 @@
                 "high": 68.245
               },
               "n": 2,
+              "verdict": "underpowered",
+              "tiedWithAbove": null,
+              "pVsPrevious": {
+                "mannWhitney": 0.3333333333333333,
+                "ks": 0.0970268975952207,
+                "floor": 0.3333333333333333
+              },
               "note": "n too small"
             },
             {
@@ -1988,6 +2776,13 @@
                 "high": 69.863
               },
               "n": 2,
+              "verdict": "underpowered",
+              "tiedWithAbove": null,
+              "pVsPrevious": {
+                "mannWhitney": 0.3333333333333333,
+                "ks": 0.0970268975952207,
+                "floor": 0.3333333333333333
+              },
               "note": "n too small"
             },
             {
@@ -1999,6 +2794,13 @@
                 "high": 523.75
               },
               "n": 2,
+              "verdict": "underpowered",
+              "tiedWithAbove": null,
+              "pVsPrevious": {
+                "mannWhitney": 0.3333333333333333,
+                "ks": 0.0970268975952207,
+                "floor": 0.3333333333333333
+              },
               "note": "n too small"
             }
           ]
@@ -2023,7 +2825,10 @@
                 "low": 28.657,
                 "high": 29.027
               },
-              "n": 2
+              "n": 2,
+              "verdict": null,
+              "tiedWithAbove": null,
+              "pVsPrevious": null
             },
             {
               "providerId": "novita",
@@ -2034,6 +2839,13 @@
                 "high": 42.881
               },
               "n": 2,
+              "verdict": "underpowered",
+              "tiedWithAbove": null,
+              "pVsPrevious": {
+                "mannWhitney": 0.3333333333333333,
+                "ks": 0.0970268975952207,
+                "floor": 0.3333333333333333
+              },
               "note": "n too small"
             },
             {
@@ -2045,6 +2857,13 @@
                 "high": 74.61
               },
               "n": 2,
+              "verdict": "underpowered",
+              "tiedWithAbove": null,
+              "pVsPrevious": {
+                "mannWhitney": 0.3333333333333333,
+                "ks": 0.0970268975952207,
+                "floor": 0.3333333333333333
+              },
               "note": "n too small"
             }
           ]
@@ -2064,7 +2883,10 @@
                 "low": 10.786,
                 "high": 11.083
               },
-              "n": 2
+              "n": 2,
+              "verdict": null,
+              "tiedWithAbove": null,
+              "pVsPrevious": null
             },
             {
               "providerId": "daytona",
@@ -2075,6 +2897,13 @@
                 "high": 12.944
               },
               "n": 2,
+              "verdict": "underpowered",
+              "tiedWithAbove": null,
+              "pVsPrevious": {
+                "mannWhitney": 0.3333333333333333,
+                "ks": 0.0970268975952207,
+                "floor": 0.3333333333333333
+              },
               "note": "n too small"
             },
             {
@@ -2086,6 +2915,13 @@
                 "high": 14.528
               },
               "n": 2,
+              "verdict": "underpowered",
+              "tiedWithAbove": null,
+              "pVsPrevious": {
+                "mannWhitney": 0.3333333333333333,
+                "ks": 0.0970268975952207,
+                "floor": 0.3333333333333333
+              },
               "note": "n too small"
             },
             {
@@ -2097,6 +2933,13 @@
                 "high": 21.517
               },
               "n": 2,
+              "verdict": "underpowered",
+              "tiedWithAbove": null,
+              "pVsPrevious": {
+                "mannWhitney": 0.3333333333333333,
+                "ks": 0.0970268975952207,
+                "floor": 0.3333333333333333
+              },
               "note": "n too small"
             },
             {
@@ -2108,6 +2951,13 @@
                 "high": 41.897
               },
               "n": 2,
+              "verdict": "underpowered",
+              "tiedWithAbove": null,
+              "pVsPrevious": {
+                "mannWhitney": 0.3333333333333333,
+                "ks": 0.0970268975952207,
+                "floor": 0.3333333333333333
+              },
               "note": "n too small"
             }
           ]
@@ -2127,7 +2977,10 @@
                 "low": 10.743,
                 "high": 11.035
               },
-              "n": 2
+              "n": 2,
+              "verdict": null,
+              "tiedWithAbove": null,
+              "pVsPrevious": null
             },
             {
               "providerId": "novita",
@@ -2138,6 +2991,13 @@
                 "high": 11.952
               },
               "n": 2,
+              "verdict": "underpowered",
+              "tiedWithAbove": null,
+              "pVsPrevious": {
+                "mannWhitney": 0.3333333333333333,
+                "ks": 0.0970268975952207,
+                "floor": 0.3333333333333333
+              },
               "note": "n too small"
             },
             {
@@ -2149,6 +3009,13 @@
                 "high": 17.174
               },
               "n": 2,
+              "verdict": "underpowered",
+              "tiedWithAbove": null,
+              "pVsPrevious": {
+                "mannWhitney": 0.3333333333333333,
+                "ks": 0.0970268975952207,
+                "floor": 0.3333333333333333
+              },
               "note": "n too small"
             },
             {
@@ -2160,6 +3027,13 @@
                 "high": 19.98
               },
               "n": 2,
+              "verdict": "underpowered",
+              "tiedWithAbove": null,
+              "pVsPrevious": {
+                "mannWhitney": 0.3333333333333333,
+                "ks": 0.0970268975952207,
+                "floor": 0.3333333333333333
+              },
               "note": "n too small"
             },
             {
@@ -2171,6 +3045,13 @@
                 "high": 31.611
               },
               "n": 2,
+              "verdict": "underpowered",
+              "tiedWithAbove": null,
+              "pVsPrevious": {
+                "mannWhitney": 0.3333333333333333,
+                "ks": 0.0970268975952207,
+                "floor": 0.3333333333333333
+              },
               "note": "n too small"
             }
           ]
@@ -2190,7 +3071,10 @@
                 "low": 1.555,
                 "high": 1.586
               },
-              "n": 2
+              "n": 2,
+              "verdict": null,
+              "tiedWithAbove": null,
+              "pVsPrevious": null
             },
             {
               "providerId": "daytona",
@@ -2201,6 +3085,13 @@
                 "high": 1.768
               },
               "n": 2,
+              "verdict": "underpowered",
+              "tiedWithAbove": null,
+              "pVsPrevious": {
+                "mannWhitney": 0.6666666666666666,
+                "ks": 0.8438198245415606,
+                "floor": 0.3333333333333333
+              },
               "note": "n too small"
             },
             {
@@ -2212,6 +3103,13 @@
                 "high": 1.787
               },
               "n": 2,
+              "verdict": "underpowered",
+              "tiedWithAbove": null,
+              "pVsPrevious": {
+                "mannWhitney": 0.6666666666666666,
+                "ks": 0.8438198245415606,
+                "floor": 0.6666666666666666
+              },
               "note": "n too small"
             },
             {
@@ -2223,6 +3121,13 @@
                 "high": 2.187
               },
               "n": 2,
+              "verdict": "underpowered",
+              "tiedWithAbove": null,
+              "pVsPrevious": {
+                "mannWhitney": 1,
+                "ks": 0.8438198245415606,
+                "floor": 0.3333333333333333
+              },
               "note": "n too small"
             },
             {
@@ -2234,6 +3139,13 @@
                 "high": 2.524
               },
               "n": 2,
+              "verdict": "underpowered",
+              "tiedWithAbove": null,
+              "pVsPrevious": {
+                "mannWhitney": 0.3333333333333333,
+                "ks": 0.0970268975952207,
+                "floor": 0.3333333333333333
+              },
               "note": "n too small"
             }
           ]
@@ -2253,7 +3165,10 @@
                 "low": 3.936,
                 "high": 3.942
               },
-              "n": 2
+              "n": 2,
+              "verdict": null,
+              "tiedWithAbove": null,
+              "pVsPrevious": null
             },
             {
               "providerId": "daytona",
@@ -2264,6 +3179,13 @@
                 "high": 4.869
               },
               "n": 2,
+              "verdict": "underpowered",
+              "tiedWithAbove": null,
+              "pVsPrevious": {
+                "mannWhitney": 0.3333333333333333,
+                "ks": 0.0970268975952207,
+                "floor": 0.3333333333333333
+              },
               "note": "n too small"
             },
             {
@@ -2275,6 +3197,13 @@
                 "high": 5.411
               },
               "n": 2,
+              "verdict": "underpowered",
+              "tiedWithAbove": null,
+              "pVsPrevious": {
+                "mannWhitney": 0.3333333333333333,
+                "ks": 0.0970268975952207,
+                "floor": 0.3333333333333333
+              },
               "note": "n too small"
             },
             {
@@ -2286,6 +3215,13 @@
                 "high": 8.433
               },
               "n": 2,
+              "verdict": "underpowered",
+              "tiedWithAbove": null,
+              "pVsPrevious": {
+                "mannWhitney": 0.3333333333333333,
+                "ks": 0.0970268975952207,
+                "floor": 0.3333333333333333
+              },
               "note": "n too small"
             },
             {
@@ -2297,6 +3233,13 @@
                 "high": 17.23
               },
               "n": 2,
+              "verdict": "underpowered",
+              "tiedWithAbove": null,
+              "pVsPrevious": {
+                "mannWhitney": 0.3333333333333333,
+                "ks": 0.0970268975952207,
+                "floor": 0.3333333333333333
+              },
               "note": "n too small"
             }
           ]
@@ -2316,7 +3259,10 @@
                 "low": 10.955,
                 "high": 10.975
               },
-              "n": 2
+              "n": 2,
+              "verdict": null,
+              "tiedWithAbove": null,
+              "pVsPrevious": null
             },
             {
               "providerId": "novita",
@@ -2327,6 +3273,13 @@
                 "high": 11.703
               },
               "n": 2,
+              "verdict": "underpowered",
+              "tiedWithAbove": null,
+              "pVsPrevious": {
+                "mannWhitney": 0.3333333333333333,
+                "ks": 0.0970268975952207,
+                "floor": 0.3333333333333333
+              },
               "note": "n too small"
             },
             {
@@ -2338,6 +3291,13 @@
                 "high": 16.97
               },
               "n": 2,
+              "verdict": "underpowered",
+              "tiedWithAbove": null,
+              "pVsPrevious": {
+                "mannWhitney": 0.3333333333333333,
+                "ks": 0.0970268975952207,
+                "floor": 0.3333333333333333
+              },
               "note": "n too small"
             },
             {
@@ -2349,6 +3309,13 @@
                 "high": 18.778
               },
               "n": 2,
+              "verdict": "underpowered",
+              "tiedWithAbove": null,
+              "pVsPrevious": {
+                "mannWhitney": 0.3333333333333333,
+                "ks": 0.0970268975952207,
+                "floor": 0.3333333333333333
+              },
               "note": "n too small"
             },
             {
@@ -2360,6 +3327,13 @@
                 "high": 28.658
               },
               "n": 2,
+              "verdict": "underpowered",
+              "tiedWithAbove": null,
+              "pVsPrevious": {
+                "mannWhitney": 0.3333333333333333,
+                "ks": 0.0970268975952207,
+                "floor": 0.3333333333333333
+              },
               "note": "n too small"
             }
           ]
@@ -2379,7 +3353,10 @@
                 "low": 2.679,
                 "high": 2.683
               },
-              "n": 2
+              "n": 2,
+              "verdict": null,
+              "tiedWithAbove": null,
+              "pVsPrevious": null
             },
             {
               "providerId": "novita",
@@ -2390,6 +3367,13 @@
                 "high": 3.053
               },
               "n": 2,
+              "verdict": "underpowered",
+              "tiedWithAbove": null,
+              "pVsPrevious": {
+                "mannWhitney": 0.3333333333333333,
+                "ks": 0.0970268975952207,
+                "floor": 0.3333333333333333
+              },
               "note": "n too small"
             },
             {
@@ -2401,6 +3385,13 @@
                 "high": 4.946
               },
               "n": 2,
+              "verdict": "underpowered",
+              "tiedWithAbove": null,
+              "pVsPrevious": {
+                "mannWhitney": 0.3333333333333333,
+                "ks": 0.0970268975952207,
+                "floor": 0.3333333333333333
+              },
               "note": "n too small"
             },
             {
@@ -2412,6 +3403,13 @@
                 "high": 5.266
               },
               "n": 2,
+              "verdict": "underpowered",
+              "tiedWithAbove": null,
+              "pVsPrevious": {
+                "mannWhitney": 0.3333333333333333,
+                "ks": 0.0970268975952207,
+                "floor": 0.3333333333333333
+              },
               "note": "n too small"
             },
             {
@@ -2423,6 +3421,13 @@
                 "high": 6.668
               },
               "n": 2,
+              "verdict": "underpowered",
+              "tiedWithAbove": null,
+              "pVsPrevious": {
+                "mannWhitney": 0.3333333333333333,
+                "ks": 0.0970268975952207,
+                "floor": 0.3333333333333333
+              },
               "note": "n too small"
             }
           ]
@@ -2442,7 +3447,10 @@
                 "low": 2.966,
                 "high": 3.001
               },
-              "n": 2
+              "n": 2,
+              "verdict": null,
+              "tiedWithAbove": null,
+              "pVsPrevious": null
             },
             {
               "providerId": "daytona",
@@ -2453,6 +3461,13 @@
                 "high": 4.02
               },
               "n": 2,
+              "verdict": "underpowered",
+              "tiedWithAbove": null,
+              "pVsPrevious": {
+                "mannWhitney": 0.3333333333333333,
+                "ks": 0.0970268975952207,
+                "floor": 0.3333333333333333
+              },
               "note": "n too small"
             },
             {
@@ -2464,6 +3479,13 @@
                 "high": 4.638
               },
               "n": 2,
+              "verdict": "underpowered",
+              "tiedWithAbove": null,
+              "pVsPrevious": {
+                "mannWhitney": 0.3333333333333333,
+                "ks": 0.0970268975952207,
+                "floor": 0.3333333333333333
+              },
               "note": "n too small"
             },
             {
@@ -2475,6 +3497,13 @@
                 "high": 7.619
               },
               "n": 2,
+              "verdict": "underpowered",
+              "tiedWithAbove": null,
+              "pVsPrevious": {
+                "mannWhitney": 0.3333333333333333,
+                "ks": 0.0970268975952207,
+                "floor": 0.3333333333333333
+              },
               "note": "n too small"
             },
             {
@@ -2486,6 +3515,13 @@
                 "high": 15.968
               },
               "n": 2,
+              "verdict": "underpowered",
+              "tiedWithAbove": null,
+              "pVsPrevious": {
+                "mannWhitney": 0.3333333333333333,
+                "ks": 0.0970268975952207,
+                "floor": 0.3333333333333333
+              },
               "note": "n too small"
             }
           ]
@@ -2505,7 +3541,10 @@
                 "low": 6.769,
                 "high": 6.908
               },
-              "n": 2
+              "n": 2,
+              "verdict": null,
+              "tiedWithAbove": null,
+              "pVsPrevious": null
             },
             {
               "providerId": "novita",
@@ -2516,6 +3555,13 @@
                 "high": 7.925
               },
               "n": 2,
+              "verdict": "underpowered",
+              "tiedWithAbove": null,
+              "pVsPrevious": {
+                "mannWhitney": 0.3333333333333333,
+                "ks": 0.0970268975952207,
+                "floor": 0.3333333333333333
+              },
               "note": "n too small"
             },
             {
@@ -2527,6 +3573,13 @@
                 "high": 12.208
               },
               "n": 2,
+              "verdict": "underpowered",
+              "tiedWithAbove": null,
+              "pVsPrevious": {
+                "mannWhitney": 0.3333333333333333,
+                "ks": 0.0970268975952207,
+                "floor": 0.3333333333333333
+              },
               "note": "n too small"
             },
             {
@@ -2538,6 +3591,13 @@
                 "high": 12.568
               },
               "n": 2,
+              "verdict": "underpowered",
+              "tiedWithAbove": null,
+              "pVsPrevious": {
+                "mannWhitney": 0.3333333333333333,
+                "ks": 0.0970268975952207,
+                "floor": 0.3333333333333333
+              },
               "note": "n too small"
             },
             {
@@ -2549,6 +3609,13 @@
                 "high": 15.65
               },
               "n": 2,
+              "verdict": "underpowered",
+              "tiedWithAbove": null,
+              "pVsPrevious": {
+                "mannWhitney": 0.3333333333333333,
+                "ks": 0.0970268975952207,
+                "floor": 0.3333333333333333
+              },
               "note": "n too small"
             }
           ]
@@ -2568,7 +3635,10 @@
                 "low": 33.475,
                 "high": 33.801
               },
-              "n": 2
+              "n": 2,
+              "verdict": null,
+              "tiedWithAbove": null,
+              "pVsPrevious": null
             },
             {
               "providerId": "daytona",
@@ -2579,6 +3649,13 @@
                 "high": 51.19
               },
               "n": 2,
+              "verdict": "underpowered",
+              "tiedWithAbove": null,
+              "pVsPrevious": {
+                "mannWhitney": 0.3333333333333333,
+                "ks": 0.0970268975952207,
+                "floor": 0.3333333333333333
+              },
               "note": "n too small"
             },
             {
@@ -2590,6 +3667,13 @@
                 "high": 60.534
               },
               "n": 2,
+              "verdict": "underpowered",
+              "tiedWithAbove": null,
+              "pVsPrevious": {
+                "mannWhitney": 0.3333333333333333,
+                "ks": 0.0970268975952207,
+                "floor": 0.3333333333333333
+              },
               "note": "n too small"
             },
             {
@@ -2601,6 +3685,13 @@
                 "high": 99.48
               },
               "n": 2,
+              "verdict": "underpowered",
+              "tiedWithAbove": null,
+              "pVsPrevious": {
+                "mannWhitney": 0.3333333333333333,
+                "ks": 0.0970268975952207,
+                "floor": 0.3333333333333333
+              },
               "note": "n too small"
             },
             {
@@ -2612,6 +3703,13 @@
                 "high": 187.659
               },
               "n": 2,
+              "verdict": "underpowered",
+              "tiedWithAbove": null,
+              "pVsPrevious": {
+                "mannWhitney": 0.3333333333333333,
+                "ks": 0.0970268975952207,
+                "floor": 0.3333333333333333
+              },
               "note": "n too small"
             }
           ]
@@ -2631,7 +3729,10 @@
                 "low": 1.378,
                 "high": 1.398
               },
-              "n": 2
+              "n": 2,
+              "verdict": null,
+              "tiedWithAbove": null,
+              "pVsPrevious": null
             },
             {
               "providerId": "novita",
@@ -2642,6 +3743,13 @@
                 "high": 1.483
               },
               "n": 2,
+              "verdict": "underpowered",
+              "tiedWithAbove": null,
+              "pVsPrevious": {
+                "mannWhitney": 0.3333333333333333,
+                "ks": 0.0970268975952207,
+                "floor": 0.3333333333333333
+              },
               "note": "n too small"
             },
             {
@@ -2653,6 +3761,13 @@
                 "high": 2.038
               },
               "n": 2,
+              "verdict": "underpowered",
+              "tiedWithAbove": null,
+              "pVsPrevious": {
+                "mannWhitney": 0.3333333333333333,
+                "ks": 0.0970268975952207,
+                "floor": 0.3333333333333333
+              },
               "note": "n too small"
             },
             {
@@ -2664,6 +3779,13 @@
                 "high": 2.79
               },
               "n": 2,
+              "verdict": "underpowered",
+              "tiedWithAbove": null,
+              "pVsPrevious": {
+                "mannWhitney": 0.3333333333333333,
+                "ks": 0.0970268975952207,
+                "floor": 0.3333333333333333
+              },
               "note": "n too small"
             },
             {
@@ -2675,6 +3797,13 @@
                 "high": 3.326
               },
               "n": 2,
+              "verdict": "underpowered",
+              "tiedWithAbove": null,
+              "pVsPrevious": {
+                "mannWhitney": 0.3333333333333333,
+                "ks": 0.0970268975952207,
+                "floor": 0.3333333333333333
+              },
               "note": "n too small"
             }
           ]
@@ -2694,7 +3823,10 @@
                 "low": 82.979,
                 "high": 83.024
               },
-              "n": 2
+              "n": 2,
+              "verdict": null,
+              "tiedWithAbove": null,
+              "pVsPrevious": null
             },
             {
               "providerId": "novita",
@@ -2705,6 +3837,13 @@
                 "high": 126.008
               },
               "n": 2,
+              "verdict": "underpowered",
+              "tiedWithAbove": null,
+              "pVsPrevious": {
+                "mannWhitney": 0.3333333333333333,
+                "ks": 0.0970268975952207,
+                "floor": 0.3333333333333333
+              },
               "note": "n too small"
             },
             {
@@ -2716,6 +3855,13 @@
                 "high": 204.988
               },
               "n": 2,
+              "verdict": "underpowered",
+              "tiedWithAbove": null,
+              "pVsPrevious": {
+                "mannWhitney": 0.3333333333333333,
+                "ks": 0.0970268975952207,
+                "floor": 0.3333333333333333
+              },
               "note": "n too small"
             }
           ]
@@ -2735,7 +3881,10 @@
                 "low": 6.425,
                 "high": 6.827
               },
-              "n": 2
+              "n": 2,
+              "verdict": null,
+              "tiedWithAbove": null,
+              "pVsPrevious": null
             },
             {
               "providerId": "novita",
@@ -2746,6 +3895,13 @@
                 "high": 7.096
               },
               "n": 2,
+              "verdict": "underpowered",
+              "tiedWithAbove": null,
+              "pVsPrevious": {
+                "mannWhitney": 0.3333333333333333,
+                "ks": 0.0970268975952207,
+                "floor": 0.3333333333333333
+              },
               "note": "n too small"
             },
             {
@@ -2757,6 +3913,13 @@
                 "high": 10.564
               },
               "n": 2,
+              "verdict": "underpowered",
+              "tiedWithAbove": null,
+              "pVsPrevious": {
+                "mannWhitney": 0.3333333333333333,
+                "ks": 0.0970268975952207,
+                "floor": 0.3333333333333333
+              },
               "note": "n too small"
             }
           ]
@@ -2776,7 +3939,10 @@
                 "low": 90.341,
                 "high": 91.077
               },
-              "n": 2
+              "n": 2,
+              "verdict": null,
+              "tiedWithAbove": null,
+              "pVsPrevious": null
             },
             {
               "providerId": "novita",
@@ -2787,6 +3953,13 @@
                 "high": 128.834
               },
               "n": 2,
+              "verdict": "underpowered",
+              "tiedWithAbove": null,
+              "pVsPrevious": {
+                "mannWhitney": 0.3333333333333333,
+                "ks": 0.0970268975952207,
+                "floor": 0.3333333333333333
+              },
               "note": "n too small"
             },
             {
@@ -2798,6 +3971,13 @@
                 "high": 201.084
               },
               "n": 2,
+              "verdict": "underpowered",
+              "tiedWithAbove": null,
+              "pVsPrevious": {
+                "mannWhitney": 0.3333333333333333,
+                "ks": 0.0970268975952207,
+                "floor": 0.3333333333333333
+              },
               "note": "n too small"
             }
           ]
@@ -2819,28 +3999,40 @@
               "rank": 1,
               "value": 0.1494,
               "interval": null,
-              "n": 1
+              "n": 1,
+              "verdict": null,
+              "tiedWithAbove": null,
+              "pVsPrevious": null
             },
             {
               "providerId": "novita",
               "rank": 2,
               "value": 0.16272,
               "interval": null,
-              "n": 1
+              "n": 1,
+              "verdict": "untested",
+              "tiedWithAbove": null,
+              "pVsPrevious": null
             },
             {
               "providerId": "e2b",
               "rank": 3,
               "value": 0.2304,
               "interval": null,
-              "n": 1
+              "n": 1,
+              "verdict": "untested",
+              "tiedWithAbove": null,
+              "pVsPrevious": null
             },
             {
               "providerId": "modal",
               "rank": 4,
               "value": 0.47736,
               "interval": null,
-              "n": 1
+              "n": 1,
+              "verdict": "untested",
+              "tiedWithAbove": null,
+              "pVsPrevious": null
             }
           ]
         }

--- a/data/dataset/leaderboards/29546060837.json
+++ b/data/dataset/leaderboards/29546060837.json
@@ -1,0 +1,2956 @@
+{
+  "schemaVersion": "1",
+  "runId": "29546060837",
+  "sha": "dd1f6ef472e3de4b76043c74f3cce5ff0d636af2",
+  "generatedAt": "2026-07-17T03:31:38.992Z",
+  "targetSpec": {
+    "vcpus": 2,
+    "memoryGb": 8,
+    "diskGb": 40
+  },
+  "summary": {
+    "providerCount": 5,
+    "metricCount": 54,
+    "metricRecordCount": 204,
+    "retainedObservationCount": 401
+  },
+  "providers": [
+    {
+      "id": "blaxel",
+      "name": "Blaxel",
+      "specMatched": false,
+      "observedSpecs": {
+        "cpuModel": "Intel(R) Xeon(R) Processor @ 2.90GHz",
+        "hostVcpus": 6,
+        "hostMemoryGb": 16,
+        "os": "Debian GNU/Linux 12 (bookworm)",
+        "kernel": "6.12.75+",
+        "user": "root",
+        "vcpus": 6,
+        "virtualization": "unknown",
+        "memoryGb": 15.63,
+        "diskGb": 12.5,
+        "publicIp": "34.214.71.218",
+        "egressOrg": "AS16509 Amazon.com, Inc.",
+        "egressAsn": "AS16509",
+        "egressOrgName": "Amazon.com, Inc.",
+        "reverseDns": "ec2-34-214-71-218.us-west-2.compute.amazonaws.com",
+        "city": "Boardman",
+        "region": "Oregon",
+        "country": "US",
+        "location": "45.8399,-119.7006",
+        "timezone": "America/Los_Angeles",
+        "networkPrefix": "34.208.0.0/12",
+        "asnSource": "cymru",
+        "geoSource": "ipinfo"
+      }
+    },
+    {
+      "id": "daytona",
+      "name": "Daytona",
+      "specMatched": true,
+      "observedSpecs": {
+        "cpuModel": "AMD EPYC",
+        "hostVcpus": 2,
+        "hostMemoryGb": 8,
+        "os": "Debian GNU/Linux 13 (trixie)",
+        "kernel": "6.19.14",
+        "virtualization": "kvm",
+        "user": "root",
+        "vcpus": 2,
+        "memoryGb": 7.78,
+        "diskGb": 39.1,
+        "publicIp": "67.213.124.39",
+        "egressOrg": "AS396356 Latitude.sh",
+        "egressAsn": "AS396356",
+        "egressOrgName": "Latitude.sh",
+        "city": "Los Angeles",
+        "region": "California",
+        "country": "US",
+        "location": "34.0522,-118.2437",
+        "timezone": "America/Los_Angeles",
+        "networkPrefix": "67.213.124.0/24",
+        "asnSource": "cymru",
+        "geoSource": "ipinfo"
+      }
+    },
+    {
+      "id": "e2b",
+      "name": "E2B",
+      "specMatched": true,
+      "observedSpecs": {
+        "vcpus": 2,
+        "cpuModel": "Intel(R) Xeon(R) Processor @ 2.60GHz",
+        "virtualization": "kvm",
+        "memoryGb": 7.78,
+        "diskGb": 24.3,
+        "kernel": "6.1.158+",
+        "os": "Debian GNU/Linux 13 (trixie)",
+        "user": "root",
+        "hostMemoryGb": 8,
+        "publicIp": "34.169.9.225",
+        "egressOrg": "AS396982 Google LLC",
+        "egressAsn": "AS396982",
+        "egressOrgName": "Google LLC",
+        "reverseDns": "225.9.169.34.bc.googleusercontent.com",
+        "city": "The Dalles",
+        "region": "Oregon",
+        "country": "US",
+        "location": "45.5946,-121.1787",
+        "timezone": "America/Los_Angeles",
+        "networkPrefix": "34.169.0.0/17",
+        "asnSource": "cymru",
+        "geoSource": "ipinfo"
+      }
+    },
+    {
+      "id": "modal",
+      "name": "Modal",
+      "specMatched": true,
+      "observedSpecs": {
+        "vcpus": 2,
+        "cpuModel": "unknown",
+        "virtualization": "unknown",
+        "memoryGb": 8,
+        "kernel": "4.19.0-gvisor",
+        "os": "Debian GNU/Linux 13 (trixie)",
+        "user": "root",
+        "hostVcpus": 2,
+        "hostMemoryGb": 8,
+        "publicIp": "20.118.128.192",
+        "egressOrg": "AS8075 Microsoft Corporation",
+        "egressAsn": "AS8075",
+        "egressOrgName": "Microsoft Corporation",
+        "city": "Phoenix",
+        "region": "Arizona",
+        "country": "US",
+        "location": "33.4484,-112.0740",
+        "timezone": "America/Phoenix",
+        "networkPrefix": "20.64.0.0/10",
+        "asnSource": "cymru",
+        "geoSource": "ipinfo"
+      }
+    },
+    {
+      "id": "novita",
+      "name": "Novita",
+      "specMatched": true,
+      "observedSpecs": {
+        "cpuModel": "AMD EPYC",
+        "hostMemoryGb": 8,
+        "os": "Debian GNU/Linux 13 (trixie)",
+        "kernel": "6.1.158+",
+        "virtualization": "kvm",
+        "user": "root",
+        "vcpus": 2,
+        "memoryGb": 7.78,
+        "diskGb": 103.7,
+        "publicIp": "161.153.9.169",
+        "egressOrg": "AS31898 Oracle Corporation",
+        "egressAsn": "AS31898",
+        "egressOrgName": "Oracle Corporation",
+        "city": "Phoenix",
+        "region": "Arizona",
+        "country": "US",
+        "location": "33.4484,-112.0740",
+        "timezone": "America/Phoenix",
+        "networkPrefix": "161.153.0.0/17",
+        "asnSource": "cymru",
+        "geoSource": "ipinfo"
+      }
+    }
+  ],
+  "dimensions": [
+    {
+      "id": "cpu",
+      "metrics": [
+        {
+          "id": "node_web_tooling_runs_per_s",
+          "name": "Node.js web tooling",
+          "unit": "runs/s",
+          "direction": "higher",
+          "headline": true,
+          "rows": [
+            {
+              "providerId": "daytona",
+              "rank": 1,
+              "value": 19.505000000000003,
+              "interval": {
+                "low": 19.46,
+                "high": 19.55
+              },
+              "n": 2
+            },
+            {
+              "providerId": "novita",
+              "rank": 2,
+              "value": 17.505,
+              "interval": {
+                "low": 17.43,
+                "high": 17.58
+              },
+              "n": 2,
+              "note": "n too small"
+            },
+            {
+              "providerId": "blaxel",
+              "rank": 3,
+              "value": 12.805,
+              "interval": {
+                "low": 12.67,
+                "high": 12.94
+              },
+              "n": 2,
+              "note": "n too small"
+            },
+            {
+              "providerId": "e2b",
+              "rank": 4,
+              "value": 11.055,
+              "interval": {
+                "low": 10.99,
+                "high": 11.12
+              },
+              "n": 2,
+              "note": "n too small"
+            },
+            {
+              "providerId": "modal",
+              "rank": 5,
+              "value": 8.82,
+              "interval": {
+                "low": 8.71,
+                "high": 8.93
+              },
+              "n": 2,
+              "note": "n too small"
+            }
+          ]
+        },
+        {
+          "id": "c_ray_resolution_1080p_rays_per_pixel_16",
+          "name": "C-Ray (1080p, 16 RPP)",
+          "unit": "Seconds",
+          "direction": "lower",
+          "headline": false,
+          "rows": [
+            {
+              "providerId": "blaxel",
+              "rank": 1,
+              "value": 127.6335,
+              "interval": {
+                "low": 127.58,
+                "high": 127.687
+              },
+              "n": 2
+            },
+            {
+              "providerId": "daytona",
+              "rank": 2,
+              "value": 199.7365,
+              "interval": {
+                "low": 199.4,
+                "high": 200.073
+              },
+              "n": 2,
+              "note": "n too small"
+            },
+            {
+              "providerId": "novita",
+              "rank": 3,
+              "value": 240.61950000000002,
+              "interval": {
+                "low": 240.249,
+                "high": 240.99
+              },
+              "n": 2,
+              "note": "n too small"
+            }
+          ]
+        },
+        {
+          "id": "c_ray_resolution_4k_rays_per_pixel_16",
+          "name": "C-Ray (4K, 16 RPP)",
+          "unit": "Seconds",
+          "direction": "lower",
+          "headline": false,
+          "rows": [
+            {
+              "providerId": "blaxel",
+              "rank": 1,
+              "value": 509.723,
+              "interval": {
+                "low": 509.653,
+                "high": 509.793
+              },
+              "n": 2
+            },
+            {
+              "providerId": "daytona",
+              "rank": 2,
+              "value": 799.296,
+              "interval": {
+                "low": 798.147,
+                "high": 800.445
+              },
+              "n": 2,
+              "note": "n too small"
+            },
+            {
+              "providerId": "novita",
+              "rank": 3,
+              "value": 961.9245,
+              "interval": {
+                "low": 961.525,
+                "high": 962.324
+              },
+              "n": 2,
+              "note": "n too small"
+            }
+          ]
+        },
+        {
+          "id": "c_ray_resolution_5k_rays_per_pixel_16",
+          "name": "C-Ray (5K, 16 RPP)",
+          "unit": "Seconds",
+          "direction": "lower",
+          "headline": false,
+          "rows": [
+            {
+              "providerId": "blaxel",
+              "rank": 1,
+              "value": 907.549,
+              "interval": {
+                "low": 907.024,
+                "high": 908.074
+              },
+              "n": 2
+            },
+            {
+              "providerId": "daytona",
+              "rank": 2,
+              "value": 1422.0459999999998,
+              "interval": {
+                "low": 1418.293,
+                "high": 1425.799
+              },
+              "n": 2,
+              "note": "n too small"
+            },
+            {
+              "providerId": "novita",
+              "rank": 3,
+              "value": 1704.7035,
+              "interval": {
+                "low": 1704.092,
+                "high": 1705.315
+              },
+              "n": 2,
+              "note": "n too small"
+            }
+          ]
+        },
+        {
+          "id": "compress_zstd_compression_level_12_compression_speed",
+          "name": "Zstd 12 compress",
+          "unit": "MB/s",
+          "direction": "higher",
+          "headline": false,
+          "rows": [
+            {
+              "providerId": "blaxel",
+              "rank": 1,
+              "value": 117.1,
+              "interval": {
+                "low": 115.9,
+                "high": 118.3
+              },
+              "n": 2
+            },
+            {
+              "providerId": "daytona",
+              "rank": 2,
+              "value": 99.44999999999999,
+              "interval": {
+                "low": 99.3,
+                "high": 99.6
+              },
+              "n": 2,
+              "note": "n too small"
+            },
+            {
+              "providerId": "novita",
+              "rank": 3,
+              "value": 71.4,
+              "interval": {
+                "low": 71.2,
+                "high": 71.6
+              },
+              "n": 2,
+              "note": "n too small"
+            }
+          ]
+        },
+        {
+          "id": "compress_zstd_compression_level_12_decompression_speed",
+          "name": "Zstd 12 decompress",
+          "unit": "MB/s",
+          "direction": "higher",
+          "headline": false,
+          "rows": [
+            {
+              "providerId": "daytona",
+              "rank": 1,
+              "value": 2303.8500000000004,
+              "interval": {
+                "low": 2298.9,
+                "high": 2308.8
+              },
+              "n": 2
+            },
+            {
+              "providerId": "novita",
+              "rank": 2,
+              "value": 1906.35,
+              "interval": {
+                "low": 1897.3,
+                "high": 1915.4
+              },
+              "n": 2,
+              "note": "n too small"
+            },
+            {
+              "providerId": "blaxel",
+              "rank": 3,
+              "value": 1052,
+              "interval": {
+                "low": 1043.8,
+                "high": 1060.2
+              },
+              "n": 2,
+              "note": "n too small"
+            }
+          ]
+        },
+        {
+          "id": "compress_zstd_compression_level_19_compression_speed",
+          "name": "Zstd 19 compress",
+          "unit": "MB/s",
+          "direction": "higher",
+          "headline": false,
+          "rows": [
+            {
+              "providerId": "blaxel",
+              "rank": 1,
+              "value": 11.1,
+              "interval": {
+                "low": 11,
+                "high": 11.2
+              },
+              "n": 2
+            },
+            {
+              "providerId": "daytona",
+              "rank": 2,
+              "value": 8.09,
+              "interval": {
+                "low": 8.04,
+                "high": 8.14
+              },
+              "n": 2,
+              "note": "n too small"
+            },
+            {
+              "providerId": "novita",
+              "rank": 3,
+              "value": 5.7,
+              "interval": {
+                "low": 5.69,
+                "high": 5.71
+              },
+              "n": 2,
+              "note": "n too small"
+            }
+          ]
+        },
+        {
+          "id": "compress_zstd_compression_level_19_decompression_speed",
+          "name": "Zstd 19 decompress",
+          "unit": "MB/s",
+          "direction": "higher",
+          "headline": false,
+          "rows": [
+            {
+              "providerId": "daytona",
+              "rank": 1,
+              "value": 1916.05,
+              "interval": {
+                "low": 1914.5,
+                "high": 1917.6
+              },
+              "n": 2
+            },
+            {
+              "providerId": "novita",
+              "rank": 2,
+              "value": 1621.8000000000002,
+              "interval": {
+                "low": 1616.7,
+                "high": 1626.9
+              },
+              "n": 2,
+              "note": "n too small"
+            },
+            {
+              "providerId": "blaxel",
+              "rank": 3,
+              "value": 881.75,
+              "interval": {
+                "low": 868.9,
+                "high": 894.6
+              },
+              "n": 2,
+              "note": "n too small"
+            }
+          ]
+        },
+        {
+          "id": "compress_zstd_compression_level_19_long_mode_compression_speed",
+          "name": "Zstd 19 (long) compress",
+          "unit": "MB/s",
+          "direction": "higher",
+          "headline": false,
+          "rows": [
+            {
+              "providerId": "daytona",
+              "rank": 1,
+              "value": 7.075,
+              "interval": {
+                "low": 7.03,
+                "high": 7.12
+              },
+              "n": 2
+            },
+            {
+              "providerId": "blaxel",
+              "rank": 2,
+              "value": 5.875,
+              "interval": {
+                "low": 5.8,
+                "high": 5.95
+              },
+              "n": 2,
+              "note": "n too small"
+            },
+            {
+              "providerId": "novita",
+              "rank": 3,
+              "value": 5.225,
+              "interval": {
+                "low": 5.22,
+                "high": 5.23
+              },
+              "n": 2,
+              "note": "n too small"
+            }
+          ]
+        },
+        {
+          "id": "compress_zstd_compression_level_19_long_mode_decompression_speed",
+          "name": "Zstd 19 (long) decompress",
+          "unit": "MB/s",
+          "direction": "higher",
+          "headline": false,
+          "rows": [
+            {
+              "providerId": "daytona",
+              "rank": 1,
+              "value": 1842.15,
+              "interval": {
+                "low": 1839.6,
+                "high": 1844.7
+              },
+              "n": 2
+            },
+            {
+              "providerId": "novita",
+              "rank": 2,
+              "value": 1543.6,
+              "interval": {
+                "low": 1535.7,
+                "high": 1551.5
+              },
+              "n": 2,
+              "note": "n too small"
+            },
+            {
+              "providerId": "blaxel",
+              "rank": 3,
+              "value": 894.4,
+              "interval": {
+                "low": 886.3,
+                "high": 902.5
+              },
+              "n": 2,
+              "note": "n too small"
+            }
+          ]
+        },
+        {
+          "id": "compress_zstd_compression_level_3_compression_speed",
+          "name": "Zstd 3 compress",
+          "unit": "MB/s",
+          "direction": "higher",
+          "headline": false,
+          "rows": [
+            {
+              "providerId": "blaxel",
+              "rank": 1,
+              "value": 1299.85,
+              "interval": {
+                "low": 1293.9,
+                "high": 1305.8
+              },
+              "n": 2
+            },
+            {
+              "providerId": "daytona",
+              "rank": 2,
+              "value": 781.75,
+              "interval": {
+                "low": 781.2,
+                "high": 782.3
+              },
+              "n": 2,
+              "note": "n too small"
+            },
+            {
+              "providerId": "novita",
+              "rank": 3,
+              "value": 677.6500000000001,
+              "interval": {
+                "low": 673.2,
+                "high": 682.1
+              },
+              "n": 2,
+              "note": "n too small"
+            }
+          ]
+        },
+        {
+          "id": "compress_zstd_compression_level_3_decompression_speed",
+          "name": "Zstd 3 decompress",
+          "unit": "MB/s",
+          "direction": "higher",
+          "headline": false,
+          "rows": [
+            {
+              "providerId": "daytona",
+              "rank": 1,
+              "value": 2113.3,
+              "interval": {
+                "low": 2112.1,
+                "high": 2114.5
+              },
+              "n": 2
+            },
+            {
+              "providerId": "novita",
+              "rank": 2,
+              "value": 1746.9,
+              "interval": {
+                "low": 1742.5,
+                "high": 1751.3
+              },
+              "n": 2,
+              "note": "n too small"
+            },
+            {
+              "providerId": "blaxel",
+              "rank": 3,
+              "value": 1116.9,
+              "interval": null,
+              "n": 1
+            }
+          ]
+        },
+        {
+          "id": "compress_zstd_compression_level_3_long_mode_compression_speed",
+          "name": "Zstd 3 (long) compress",
+          "unit": "MB/s",
+          "direction": "higher",
+          "headline": false,
+          "rows": [
+            {
+              "providerId": "blaxel",
+              "rank": 1,
+              "value": 847.9000000000001,
+              "interval": {
+                "low": 841.7,
+                "high": 854.1
+              },
+              "n": 2
+            },
+            {
+              "providerId": "daytona",
+              "rank": 2,
+              "value": 535.7,
+              "interval": {
+                "low": 534.9,
+                "high": 536.5
+              },
+              "n": 2,
+              "note": "n too small"
+            },
+            {
+              "providerId": "novita",
+              "rank": 3,
+              "value": 529.45,
+              "interval": {
+                "low": 527.9,
+                "high": 531
+              },
+              "n": 2,
+              "note": "n too small"
+            }
+          ]
+        },
+        {
+          "id": "compress_zstd_compression_level_3_long_mode_decompression_speed",
+          "name": "Zstd 3 (long) decompress",
+          "unit": "MB/s",
+          "direction": "higher",
+          "headline": false,
+          "rows": [
+            {
+              "providerId": "daytona",
+              "rank": 1,
+              "value": 2166.1,
+              "interval": {
+                "low": 2161,
+                "high": 2171.2
+              },
+              "n": 2
+            },
+            {
+              "providerId": "novita",
+              "rank": 2,
+              "value": 1807.95,
+              "interval": {
+                "low": 1805,
+                "high": 1810.9
+              },
+              "n": 2,
+              "note": "n too small"
+            }
+          ]
+        },
+        {
+          "id": "compress_zstd_compression_level_8_compression_speed",
+          "name": "Zstd 8 compress",
+          "unit": "MB/s",
+          "direction": "higher",
+          "headline": false,
+          "rows": [
+            {
+              "providerId": "blaxel",
+              "rank": 1,
+              "value": 352.35,
+              "interval": {
+                "low": 352,
+                "high": 352.7
+              },
+              "n": 2
+            },
+            {
+              "providerId": "daytona",
+              "rank": 2,
+              "value": 210.4,
+              "interval": {
+                "low": 208.8,
+                "high": 212
+              },
+              "n": 2,
+              "note": "n too small"
+            },
+            {
+              "providerId": "novita",
+              "rank": 3,
+              "value": 179.45,
+              "interval": {
+                "low": 178.7,
+                "high": 180.2
+              },
+              "n": 2,
+              "note": "n too small"
+            }
+          ]
+        },
+        {
+          "id": "compress_zstd_compression_level_8_decompression_speed",
+          "name": "Zstd 8 decompress",
+          "unit": "MB/s",
+          "direction": "higher",
+          "headline": false,
+          "rows": [
+            {
+              "providerId": "daytona",
+              "rank": 1,
+              "value": 2269.1,
+              "interval": {
+                "low": 2269,
+                "high": 2269.2
+              },
+              "n": 2
+            },
+            {
+              "providerId": "novita",
+              "rank": 2,
+              "value": 1910,
+              "interval": {
+                "low": 1907.7,
+                "high": 1912.3
+              },
+              "n": 2,
+              "note": "n too small"
+            },
+            {
+              "providerId": "blaxel",
+              "rank": 3,
+              "value": 1121.75,
+              "interval": {
+                "low": 1117.3,
+                "high": 1126.2
+              },
+              "n": 2,
+              "note": "n too small"
+            }
+          ]
+        },
+        {
+          "id": "compress_zstd_compression_level_8_long_mode_compression_speed",
+          "name": "Zstd 8 (long) compress",
+          "unit": "MB/s",
+          "direction": "higher",
+          "headline": false,
+          "rows": [
+            {
+              "providerId": "blaxel",
+              "rank": 1,
+              "value": 325.29999999999995,
+              "interval": {
+                "low": 323.7,
+                "high": 326.9
+              },
+              "n": 2
+            },
+            {
+              "providerId": "daytona",
+              "rank": 2,
+              "value": 202.65,
+              "interval": {
+                "low": 202.3,
+                "high": 203
+              },
+              "n": 2,
+              "note": "n too small"
+            },
+            {
+              "providerId": "novita",
+              "rank": 3,
+              "value": 174.65,
+              "interval": {
+                "low": 174.5,
+                "high": 174.8
+              },
+              "n": 2,
+              "note": "n too small"
+            }
+          ]
+        },
+        {
+          "id": "compress_zstd_compression_level_8_long_mode_decompression_speed",
+          "name": "Zstd 8 (long) decompress",
+          "unit": "MB/s",
+          "direction": "higher",
+          "headline": false,
+          "rows": [
+            {
+              "providerId": "daytona",
+              "rank": 1,
+              "value": 2307.65,
+              "interval": {
+                "low": 2304.8,
+                "high": 2310.5
+              },
+              "n": 2
+            },
+            {
+              "providerId": "novita",
+              "rank": 2,
+              "value": 1913.25,
+              "interval": {
+                "low": 1911.5,
+                "high": 1915
+              },
+              "n": 2,
+              "note": "n too small"
+            },
+            {
+              "providerId": "blaxel",
+              "rank": 3,
+              "value": 1135.35,
+              "interval": {
+                "low": 1134.7,
+                "high": 1136
+              },
+              "n": 2,
+              "note": "n too small"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "disk",
+      "metrics": [
+        {
+          "id": "fio_type_random_read_engine_linux_aio_direct_yes_block_size_4kb_job_count_1_disk_target_default_test_directory_iops",
+          "name": "fio rand read 4KB, O_DIRECT (IOPS)",
+          "unit": "IOPS",
+          "direction": "higher",
+          "headline": true,
+          "rows": [
+            {
+              "providerId": "blaxel",
+              "rank": 1,
+              "value": 576000,
+              "interval": {
+                "low": 570000,
+                "high": 582000
+              },
+              "n": 2
+            },
+            {
+              "providerId": "daytona",
+              "rank": 2,
+              "value": 248500,
+              "interval": {
+                "low": 240000,
+                "high": 257000
+              },
+              "n": 2,
+              "note": "n too small"
+            },
+            {
+              "providerId": "novita",
+              "rank": 3,
+              "value": 59500,
+              "interval": {
+                "low": 55300,
+                "high": 63700
+              },
+              "n": 2,
+              "note": "n too small"
+            },
+            {
+              "providerId": "e2b",
+              "rank": 4,
+              "value": 40000,
+              "interval": {
+                "low": 38700,
+                "high": 41300
+              },
+              "n": 2,
+              "note": "n too small"
+            },
+            {
+              "providerId": "modal",
+              "rank": 5,
+              "value": 33900,
+              "interval": {
+                "low": 33200,
+                "high": 34600
+              },
+              "n": 2,
+              "note": "n too small"
+            }
+          ]
+        },
+        {
+          "id": "fio_type_random_read_engine_linux_aio_direct_yes_block_size_4kb_job_count_1_disk_target_default_test_directory_mb_per_s",
+          "name": "fio rand read 4KB, O_DIRECT (MB/s)",
+          "unit": "MB/s",
+          "direction": "higher",
+          "headline": false,
+          "rows": [
+            {
+              "providerId": "blaxel",
+              "rank": 1,
+              "value": 2250.5,
+              "interval": {
+                "low": 2226,
+                "high": 2275
+              },
+              "n": 2
+            },
+            {
+              "providerId": "daytona",
+              "rank": 2,
+              "value": 971,
+              "interval": {
+                "low": 936,
+                "high": 1006
+              },
+              "n": 2,
+              "note": "n too small"
+            },
+            {
+              "providerId": "novita",
+              "rank": 3,
+              "value": 232.5,
+              "interval": {
+                "low": 216,
+                "high": 249
+              },
+              "n": 2,
+              "note": "n too small"
+            },
+            {
+              "providerId": "e2b",
+              "rank": 4,
+              "value": 156.5,
+              "interval": {
+                "low": 151,
+                "high": 162
+              },
+              "n": 2,
+              "note": "n too small"
+            },
+            {
+              "providerId": "modal",
+              "rank": 5,
+              "value": 132.5,
+              "interval": {
+                "low": 130,
+                "high": 135
+              },
+              "n": 2,
+              "note": "n too small"
+            }
+          ]
+        },
+        {
+          "id": "fio_type_random_write_engine_linux_aio_direct_yes_block_size_4kb_job_count_1_disk_target_default_test_directory_iops",
+          "name": "fio rand write 4KB, O_DIRECT (IOPS)",
+          "unit": "IOPS",
+          "direction": "higher",
+          "headline": false,
+          "rows": [
+            {
+              "providerId": "blaxel",
+              "rank": 1,
+              "value": 495000,
+              "interval": {
+                "low": 484000,
+                "high": 506000
+              },
+              "n": 2
+            },
+            {
+              "providerId": "daytona",
+              "rank": 2,
+              "value": 231500,
+              "interval": {
+                "low": 208000,
+                "high": 255000
+              },
+              "n": 2,
+              "note": "n too small"
+            },
+            {
+              "providerId": "novita",
+              "rank": 3,
+              "value": 85150,
+              "interval": {
+                "low": 75700,
+                "high": 94600
+              },
+              "n": 2,
+              "note": "n too small"
+            },
+            {
+              "providerId": "e2b",
+              "rank": 4,
+              "value": 43900,
+              "interval": {
+                "low": 43500,
+                "high": 44300
+              },
+              "n": 2,
+              "note": "n too small"
+            },
+            {
+              "providerId": "modal",
+              "rank": 5,
+              "value": 28300,
+              "interval": {
+                "low": 27000,
+                "high": 29600
+              },
+              "n": 2,
+              "note": "n too small"
+            }
+          ]
+        },
+        {
+          "id": "fio_type_random_write_engine_linux_aio_direct_yes_block_size_4kb_job_count_1_disk_target_default_test_directory_mb_per_s",
+          "name": "fio rand write 4KB, O_DIRECT (MB/s)",
+          "unit": "MB/s",
+          "direction": "higher",
+          "headline": false,
+          "rows": [
+            {
+              "providerId": "blaxel",
+              "rank": 1,
+              "value": 1934,
+              "interval": {
+                "low": 1891,
+                "high": 1977
+              },
+              "n": 2
+            },
+            {
+              "providerId": "daytona",
+              "rank": 2,
+              "value": 902.5,
+              "interval": {
+                "low": 811,
+                "high": 994
+              },
+              "n": 2,
+              "note": "n too small"
+            },
+            {
+              "providerId": "novita",
+              "rank": 3,
+              "value": 332.5,
+              "interval": {
+                "low": 296,
+                "high": 369
+              },
+              "n": 2,
+              "note": "n too small"
+            },
+            {
+              "providerId": "e2b",
+              "rank": 4,
+              "value": 171.5,
+              "interval": {
+                "low": 170,
+                "high": 173
+              },
+              "n": 2,
+              "note": "n too small"
+            },
+            {
+              "providerId": "modal",
+              "rank": 5,
+              "value": 110.5,
+              "interval": {
+                "low": 105,
+                "high": 116
+              },
+              "n": 2,
+              "note": "n too small"
+            }
+          ]
+        },
+        {
+          "id": "fio_type_sequential_read_engine_linux_aio_direct_yes_block_size_1mb_job_count_1_disk_target_default_test_directory_iops",
+          "name": "fio seq read 1MB, O_DIRECT (IOPS)",
+          "unit": "IOPS",
+          "direction": "higher",
+          "headline": false,
+          "rows": [
+            {
+              "providerId": "modal",
+              "rank": 1,
+              "value": 12350,
+              "interval": {
+                "low": 11900,
+                "high": 12800
+              },
+              "n": 2
+            },
+            {
+              "providerId": "novita",
+              "rank": 2,
+              "value": 11250,
+              "interval": {
+                "low": 11200,
+                "high": 11300
+              },
+              "n": 2,
+              "note": "n too small"
+            },
+            {
+              "providerId": "daytona",
+              "rank": 3,
+              "value": 9142,
+              "interval": {
+                "low": 5584,
+                "high": 12700
+              },
+              "n": 2,
+              "note": "n too small"
+            },
+            {
+              "providerId": "blaxel",
+              "rank": 4,
+              "value": 4709,
+              "interval": {
+                "low": 4609,
+                "high": 4809
+              },
+              "n": 2,
+              "note": "n too small"
+            },
+            {
+              "providerId": "e2b",
+              "rank": 5,
+              "value": 599,
+              "interval": {
+                "low": 599,
+                "high": 599
+              },
+              "n": 2,
+              "note": "n too small"
+            }
+          ]
+        },
+        {
+          "id": "fio_type_sequential_read_engine_linux_aio_direct_yes_block_size_1mb_job_count_1_disk_target_default_test_directory_mb_per_s",
+          "name": "fio seq read 1MB, O_DIRECT (MB/s)",
+          "unit": "MB/s",
+          "direction": "higher",
+          "headline": false,
+          "rows": [
+            {
+              "providerId": "daytona",
+              "rank": 1,
+              "value": 5585,
+              "interval": null,
+              "n": 1
+            },
+            {
+              "providerId": "blaxel",
+              "rank": 2,
+              "value": 4711,
+              "interval": {
+                "low": 4611,
+                "high": 4811
+              },
+              "n": 2
+            },
+            {
+              "providerId": "e2b",
+              "rank": 3,
+              "value": 601,
+              "interval": {
+                "low": 601,
+                "high": 601
+              },
+              "n": 2,
+              "note": "n too small"
+            }
+          ]
+        },
+        {
+          "id": "fio_type_sequential_write_engine_linux_aio_direct_yes_block_size_1mb_job_count_1_disk_target_default_test_directory_iops",
+          "name": "fio seq write 1MB, O_DIRECT (IOPS)",
+          "unit": "IOPS",
+          "direction": "higher",
+          "headline": false,
+          "rows": [
+            {
+              "providerId": "daytona",
+              "rank": 1,
+              "value": 5821,
+              "interval": {
+                "low": 5714,
+                "high": 5928
+              },
+              "n": 2
+            },
+            {
+              "providerId": "novita",
+              "rank": 2,
+              "value": 5390,
+              "interval": {
+                "low": 5210,
+                "high": 5570
+              },
+              "n": 2,
+              "note": "n too small"
+            },
+            {
+              "providerId": "blaxel",
+              "rank": 3,
+              "value": 3658,
+              "interval": {
+                "low": 3616,
+                "high": 3700
+              },
+              "n": 2,
+              "note": "n too small"
+            },
+            {
+              "providerId": "modal",
+              "rank": 4,
+              "value": 3458,
+              "interval": {
+                "low": 3362,
+                "high": 3554
+              },
+              "n": 2,
+              "note": "n too small"
+            },
+            {
+              "providerId": "e2b",
+              "rank": 5,
+              "value": 599,
+              "interval": {
+                "low": 598,
+                "high": 600
+              },
+              "n": 2,
+              "note": "n too small"
+            }
+          ]
+        },
+        {
+          "id": "fio_type_sequential_write_engine_linux_aio_direct_yes_block_size_1mb_job_count_1_disk_target_default_test_directory_mb_per_s",
+          "name": "fio seq write 1MB, O_DIRECT (MB/s)",
+          "unit": "MB/s",
+          "direction": "higher",
+          "headline": false,
+          "rows": [
+            {
+              "providerId": "daytona",
+              "rank": 1,
+              "value": 5823,
+              "interval": {
+                "low": 5716,
+                "high": 5930
+              },
+              "n": 2
+            },
+            {
+              "providerId": "novita",
+              "rank": 2,
+              "value": 5391,
+              "interval": {
+                "low": 5211,
+                "high": 5571
+              },
+              "n": 2,
+              "note": "n too small"
+            },
+            {
+              "providerId": "blaxel",
+              "rank": 3,
+              "value": 3660,
+              "interval": {
+                "low": 3618,
+                "high": 3702
+              },
+              "n": 2,
+              "note": "n too small"
+            },
+            {
+              "providerId": "modal",
+              "rank": 4,
+              "value": 3459.5,
+              "interval": {
+                "low": 3363,
+                "high": 3556
+              },
+              "n": 2,
+              "note": "n too small"
+            },
+            {
+              "providerId": "e2b",
+              "rank": 5,
+              "value": 600.5,
+              "interval": {
+                "low": 600,
+                "high": 601
+              },
+              "n": 2,
+              "note": "n too small"
+            }
+          ]
+        },
+        {
+          "id": "hardlink_bogo_ops_per_s",
+          "name": "Hardlink throughput",
+          "unit": "bogo ops/s",
+          "direction": "higher",
+          "headline": false,
+          "rows": [
+            {
+              "providerId": "daytona",
+              "rank": 1,
+              "value": 23.655,
+              "interval": {
+                "low": 23.62,
+                "high": 23.69
+              },
+              "n": 2
+            },
+            {
+              "providerId": "novita",
+              "rank": 2,
+              "value": 18.52,
+              "interval": {
+                "low": 18.45,
+                "high": 18.59
+              },
+              "n": 2,
+              "note": "n too small"
+            },
+            {
+              "providerId": "blaxel",
+              "rank": 3,
+              "value": 12.425,
+              "interval": {
+                "low": 12.39,
+                "high": 12.46
+              },
+              "n": 2,
+              "note": "n too small"
+            },
+            {
+              "providerId": "modal",
+              "rank": 4,
+              "value": 3.05,
+              "interval": {
+                "low": 2.98,
+                "high": 3.12
+              },
+              "n": 2,
+              "note": "n too small"
+            },
+            {
+              "providerId": "e2b",
+              "rank": 5,
+              "value": 1.46,
+              "interval": {
+                "low": 1.46,
+                "high": 1.46
+              },
+              "n": 2,
+              "note": "n too small"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "memory",
+      "metrics": [
+        {
+          "id": "stream_type_triad",
+          "name": "STREAM Triad",
+          "unit": "MB/s",
+          "direction": "higher",
+          "headline": true,
+          "rows": [
+            {
+              "providerId": "blaxel",
+              "rank": 1,
+              "value": 73893.54999999999,
+              "interval": {
+                "low": 70326.4,
+                "high": 77460.7
+              },
+              "n": 2
+            },
+            {
+              "providerId": "daytona",
+              "rank": 2,
+              "value": 55995.1,
+              "interval": {
+                "low": 55980.6,
+                "high": 56009.6
+              },
+              "n": 2,
+              "note": "n too small"
+            },
+            {
+              "providerId": "novita",
+              "rank": 3,
+              "value": 46028.100000000006,
+              "interval": {
+                "low": 45843.9,
+                "high": 46212.3
+              },
+              "n": 2,
+              "note": "n too small"
+            },
+            {
+              "providerId": "modal",
+              "rank": 4,
+              "value": 45372.600000000006,
+              "interval": {
+                "low": 42047.8,
+                "high": 48697.4
+              },
+              "n": 2,
+              "note": "n too small"
+            },
+            {
+              "providerId": "e2b",
+              "rank": 5,
+              "value": 22018.7,
+              "interval": {
+                "low": 21772.7,
+                "high": 22264.7
+              },
+              "n": 2,
+              "note": "n too small"
+            }
+          ]
+        },
+        {
+          "id": "stream_type_add",
+          "name": "STREAM Add",
+          "unit": "MB/s",
+          "direction": "higher",
+          "headline": false,
+          "rows": [
+            {
+              "providerId": "blaxel",
+              "rank": 1,
+              "value": 73911.29999999999,
+              "interval": {
+                "low": 70135.9,
+                "high": 77686.7
+              },
+              "n": 2
+            },
+            {
+              "providerId": "daytona",
+              "rank": 2,
+              "value": 55740.649999999994,
+              "interval": {
+                "low": 55725.7,
+                "high": 55755.6
+              },
+              "n": 2,
+              "note": "n too small"
+            },
+            {
+              "providerId": "modal",
+              "rank": 3,
+              "value": 45920.5,
+              "interval": {
+                "low": 41168.8,
+                "high": 50672.2
+              },
+              "n": 2,
+              "note": "n too small"
+            },
+            {
+              "providerId": "novita",
+              "rank": 4,
+              "value": 45853.85,
+              "interval": {
+                "low": 45779.5,
+                "high": 45928.2
+              },
+              "n": 2,
+              "note": "n too small"
+            },
+            {
+              "providerId": "e2b",
+              "rank": 5,
+              "value": 22023.45,
+              "interval": {
+                "low": 21838.2,
+                "high": 22208.7
+              },
+              "n": 2,
+              "note": "n too small"
+            }
+          ]
+        },
+        {
+          "id": "stream_type_copy",
+          "name": "STREAM Copy",
+          "unit": "MB/s",
+          "direction": "higher",
+          "headline": false,
+          "rows": [
+            {
+              "providerId": "blaxel",
+              "rank": 1,
+              "value": 113833.6,
+              "interval": {
+                "low": 107305.5,
+                "high": 120361.7
+              },
+              "n": 2
+            },
+            {
+              "providerId": "daytona",
+              "rank": 2,
+              "value": 65684.15,
+              "interval": {
+                "low": 65676,
+                "high": 65692.3
+              },
+              "n": 2,
+              "note": "n too small"
+            },
+            {
+              "providerId": "modal",
+              "rank": 3,
+              "value": 62012.7,
+              "interval": {
+                "low": 56585.2,
+                "high": 67440.2
+              },
+              "n": 2,
+              "note": "n too small"
+            },
+            {
+              "providerId": "novita",
+              "rank": 4,
+              "value": 54822.850000000006,
+              "interval": {
+                "low": 54518.4,
+                "high": 55127.3
+              },
+              "n": 2,
+              "note": "n too small"
+            },
+            {
+              "providerId": "e2b",
+              "rank": 5,
+              "value": 45122.05,
+              "interval": {
+                "low": 43483.6,
+                "high": 46760.5
+              },
+              "n": 2,
+              "note": "n too small"
+            }
+          ]
+        },
+        {
+          "id": "stream_type_scale",
+          "name": "STREAM Scale",
+          "unit": "MB/s",
+          "direction": "higher",
+          "headline": false,
+          "rows": [
+            {
+              "providerId": "blaxel",
+              "rank": 1,
+              "value": 62621.15,
+              "interval": {
+                "low": 58675.3,
+                "high": 66567
+              },
+              "n": 2
+            },
+            {
+              "providerId": "daytona",
+              "rank": 2,
+              "value": 50115.8,
+              "interval": {
+                "low": 50049.7,
+                "high": 50181.9
+              },
+              "n": 2,
+              "note": "n too small"
+            },
+            {
+              "providerId": "novita",
+              "rank": 3,
+              "value": 45407.8,
+              "interval": {
+                "low": 45209.1,
+                "high": 45606.5
+              },
+              "n": 2,
+              "note": "n too small"
+            },
+            {
+              "providerId": "modal",
+              "rank": 4,
+              "value": 37402.65,
+              "interval": {
+                "low": 34143.3,
+                "high": 40662
+              },
+              "n": 2,
+              "note": "n too small"
+            },
+            {
+              "providerId": "e2b",
+              "rank": 5,
+              "value": 20876.05,
+              "interval": {
+                "low": 20700.6,
+                "high": 21051.5
+              },
+              "n": 2,
+              "note": "n too small"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "network",
+      "metrics": [
+        {
+          "id": "network_loopback_seconds",
+          "name": "Loopback TCP (10GB)",
+          "unit": "Seconds",
+          "direction": "lower",
+          "headline": true,
+          "rows": [
+            {
+              "providerId": "daytona",
+              "rank": 1,
+              "value": 5.4405,
+              "interval": {
+                "low": 5.286,
+                "high": 5.595
+              },
+              "n": 2
+            },
+            {
+              "providerId": "blaxel",
+              "rank": 2,
+              "value": 6.603,
+              "interval": {
+                "low": 6.339,
+                "high": 6.867
+              },
+              "n": 2,
+              "note": "n too small"
+            },
+            {
+              "providerId": "novita",
+              "rank": 3,
+              "value": 7.9435,
+              "interval": {
+                "low": 7.928,
+                "high": 7.959
+              },
+              "n": 2,
+              "note": "n too small"
+            },
+            {
+              "providerId": "e2b",
+              "rank": 4,
+              "value": 10.4365,
+              "interval": {
+                "low": 9.903,
+                "high": 10.97
+              },
+              "n": 2,
+              "note": "n too small"
+            },
+            {
+              "providerId": "modal",
+              "rank": 5,
+              "value": 54.104,
+              "interval": {
+                "low": 51.351,
+                "high": 56.857
+              },
+              "n": 2,
+              "note": "n too small"
+            }
+          ]
+        },
+        {
+          "id": "fast_cli_internet_download_speed",
+          "name": "fast.com download",
+          "unit": "Mbit/s",
+          "direction": "higher",
+          "headline": false,
+          "rows": [
+            {
+              "providerId": "e2b",
+              "rank": 1,
+              "value": 3.25,
+              "interval": {
+                "low": 3,
+                "high": 3.5
+              },
+              "n": 2
+            }
+          ]
+        },
+        {
+          "id": "fast_cli_internet_latency",
+          "name": "fast.com latency",
+          "unit": "ms",
+          "direction": "lower",
+          "headline": false,
+          "rows": [
+            {
+              "providerId": "e2b",
+              "rank": 1,
+              "value": 7,
+              "interval": {
+                "low": 7,
+                "high": 7
+              },
+              "n": 2
+            }
+          ]
+        },
+        {
+          "id": "fast_cli_internet_loaded_latency_bufferbloat",
+          "name": "fast.com loaded latency",
+          "unit": "ms",
+          "direction": "lower",
+          "headline": false,
+          "rows": [
+            {
+              "providerId": "e2b",
+              "rank": 1,
+              "value": 9,
+              "interval": null,
+              "n": 1
+            }
+          ]
+        },
+        {
+          "id": "fast_cli_internet_upload_speed",
+          "name": "fast.com upload",
+          "unit": "Mbit/s",
+          "direction": "higher",
+          "headline": false,
+          "rows": [
+            {
+              "providerId": "e2b",
+              "rank": 1,
+              "value": 770,
+              "interval": {
+                "low": 760,
+                "high": 780
+              },
+              "n": 2
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "system",
+      "metrics": [
+        {
+          "id": "pybench_milliseconds",
+          "name": "PyBench",
+          "unit": "Milliseconds",
+          "direction": "lower",
+          "headline": true,
+          "rows": [
+            {
+              "providerId": "blaxel",
+              "rank": 1,
+              "value": 844,
+              "interval": {
+                "low": 839,
+                "high": 849
+              },
+              "n": 2
+            }
+          ]
+        },
+        {
+          "id": "git_seconds",
+          "name": "Git common operations",
+          "unit": "Seconds",
+          "direction": "lower",
+          "headline": false,
+          "rows": [
+            {
+              "providerId": "daytona",
+              "rank": 1,
+              "value": 36.063,
+              "interval": {
+                "low": 35.962,
+                "high": 36.164
+              },
+              "n": 2
+            },
+            {
+              "providerId": "novita",
+              "rank": 2,
+              "value": 43.5865,
+              "interval": {
+                "low": 43.495,
+                "high": 43.678
+              },
+              "n": 2,
+              "note": "n too small"
+            },
+            {
+              "providerId": "blaxel",
+              "rank": 3,
+              "value": 61.477000000000004,
+              "interval": {
+                "low": 61.365,
+                "high": 61.589
+              },
+              "n": 2,
+              "note": "n too small"
+            },
+            {
+              "providerId": "e2b",
+              "rank": 4,
+              "value": 70.214,
+              "interval": {
+                "low": 69.915,
+                "high": 70.513
+              },
+              "n": 2,
+              "note": "n too small"
+            },
+            {
+              "providerId": "modal",
+              "rank": 5,
+              "value": 81.3655,
+              "interval": {
+                "low": 80.736,
+                "high": 81.995
+              },
+              "n": 2,
+              "note": "n too small"
+            }
+          ]
+        },
+        {
+          "id": "sqlite_speedtest_seconds",
+          "name": "SQLite Speedtest",
+          "unit": "Seconds",
+          "direction": "lower",
+          "headline": false,
+          "rows": [
+            {
+              "providerId": "daytona",
+              "rank": 1,
+              "value": 30.5415,
+              "interval": {
+                "low": 30.412,
+                "high": 30.671
+              },
+              "n": 2
+            },
+            {
+              "providerId": "novita",
+              "rank": 2,
+              "value": 38.811499999999995,
+              "interval": {
+                "low": 38.532,
+                "high": 39.091
+              },
+              "n": 2,
+              "note": "n too small"
+            },
+            {
+              "providerId": "blaxel",
+              "rank": 3,
+              "value": 68.11449999999999,
+              "interval": {
+                "low": 67.984,
+                "high": 68.245
+              },
+              "n": 2,
+              "note": "n too small"
+            },
+            {
+              "providerId": "e2b",
+              "rank": 4,
+              "value": 69.84049999999999,
+              "interval": {
+                "low": 69.818,
+                "high": 69.863
+              },
+              "n": 2,
+              "note": "n too small"
+            },
+            {
+              "providerId": "modal",
+              "rank": 5,
+              "value": 514.6595,
+              "interval": {
+                "low": 505.569,
+                "high": 523.75
+              },
+              "n": 2,
+              "note": "n too small"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "realworld",
+      "metrics": [
+        {
+          "id": "realworld_mastra_task_cold_install",
+          "name": "Mastra: cold install",
+          "unit": "Seconds",
+          "direction": "lower",
+          "headline": true,
+          "rows": [
+            {
+              "providerId": "daytona",
+              "rank": 1,
+              "value": 28.842,
+              "interval": {
+                "low": 28.657,
+                "high": 29.027
+              },
+              "n": 2
+            },
+            {
+              "providerId": "novita",
+              "rank": 2,
+              "value": 42.480000000000004,
+              "interval": {
+                "low": 42.079,
+                "high": 42.881
+              },
+              "n": 2,
+              "note": "n too small"
+            },
+            {
+              "providerId": "modal",
+              "rank": 3,
+              "value": 73.7775,
+              "interval": {
+                "low": 72.945,
+                "high": 74.61
+              },
+              "n": 2,
+              "note": "n too small"
+            }
+          ]
+        },
+        {
+          "id": "realworld_better_auth_task_build",
+          "name": "Better-Auth: build",
+          "unit": "Seconds",
+          "direction": "lower",
+          "headline": false,
+          "rows": [
+            {
+              "providerId": "blaxel",
+              "rank": 1,
+              "value": 10.9345,
+              "interval": {
+                "low": 10.786,
+                "high": 11.083
+              },
+              "n": 2
+            },
+            {
+              "providerId": "daytona",
+              "rank": 2,
+              "value": 12.780000000000001,
+              "interval": {
+                "low": 12.616,
+                "high": 12.944
+              },
+              "n": 2,
+              "note": "n too small"
+            },
+            {
+              "providerId": "novita",
+              "rank": 3,
+              "value": 14.5235,
+              "interval": {
+                "low": 14.519,
+                "high": 14.528
+              },
+              "n": 2,
+              "note": "n too small"
+            },
+            {
+              "providerId": "e2b",
+              "rank": 4,
+              "value": 21.3985,
+              "interval": {
+                "low": 21.28,
+                "high": 21.517
+              },
+              "n": 2,
+              "note": "n too small"
+            },
+            {
+              "providerId": "modal",
+              "rank": 5,
+              "value": 40.919,
+              "interval": {
+                "low": 39.941,
+                "high": 41.897
+              },
+              "n": 2,
+              "note": "n too small"
+            }
+          ]
+        },
+        {
+          "id": "realworld_better_auth_task_cold_install",
+          "name": "Better-Auth: cold install",
+          "unit": "Seconds",
+          "direction": "lower",
+          "headline": false,
+          "rows": [
+            {
+              "providerId": "daytona",
+              "rank": 1,
+              "value": 10.889,
+              "interval": {
+                "low": 10.743,
+                "high": 11.035
+              },
+              "n": 2
+            },
+            {
+              "providerId": "novita",
+              "rank": 2,
+              "value": 11.86,
+              "interval": {
+                "low": 11.768,
+                "high": 11.952
+              },
+              "n": 2,
+              "note": "n too small"
+            },
+            {
+              "providerId": "blaxel",
+              "rank": 3,
+              "value": 16.865499999999997,
+              "interval": {
+                "low": 16.557,
+                "high": 17.174
+              },
+              "n": 2,
+              "note": "n too small"
+            },
+            {
+              "providerId": "e2b",
+              "rank": 4,
+              "value": 19.6415,
+              "interval": {
+                "low": 19.303,
+                "high": 19.98
+              },
+              "n": 2,
+              "note": "n too small"
+            },
+            {
+              "providerId": "modal",
+              "rank": 5,
+              "value": 31.1415,
+              "interval": {
+                "low": 30.672,
+                "high": 31.611
+              },
+              "n": 2,
+              "note": "n too small"
+            }
+          ]
+        },
+        {
+          "id": "realworld_better_auth_task_git_clone",
+          "name": "Better-Auth: git clone",
+          "unit": "Seconds",
+          "direction": "lower",
+          "headline": false,
+          "rows": [
+            {
+              "providerId": "blaxel",
+              "rank": 1,
+              "value": 1.5705,
+              "interval": {
+                "low": 1.555,
+                "high": 1.586
+              },
+              "n": 2
+            },
+            {
+              "providerId": "daytona",
+              "rank": 2,
+              "value": 1.669,
+              "interval": {
+                "low": 1.57,
+                "high": 1.768
+              },
+              "n": 2,
+              "note": "n too small"
+            },
+            {
+              "providerId": "e2b",
+              "rank": 3,
+              "value": 1.7774999999999999,
+              "interval": {
+                "low": 1.768,
+                "high": 1.787
+              },
+              "n": 2,
+              "note": "n too small"
+            },
+            {
+              "providerId": "novita",
+              "rank": 4,
+              "value": 1.9565,
+              "interval": {
+                "low": 1.726,
+                "high": 2.187
+              },
+              "n": 2,
+              "note": "n too small"
+            },
+            {
+              "providerId": "modal",
+              "rank": 5,
+              "value": 2.3875,
+              "interval": {
+                "low": 2.251,
+                "high": 2.524
+              },
+              "n": 2,
+              "note": "n too small"
+            }
+          ]
+        },
+        {
+          "id": "realworld_better_auth_task_lint_biome",
+          "name": "Better-Auth: lint (Biome)",
+          "unit": "Seconds",
+          "direction": "lower",
+          "headline": false,
+          "rows": [
+            {
+              "providerId": "blaxel",
+              "rank": 1,
+              "value": 3.939,
+              "interval": {
+                "low": 3.936,
+                "high": 3.942
+              },
+              "n": 2
+            },
+            {
+              "providerId": "daytona",
+              "rank": 2,
+              "value": 4.869,
+              "interval": {
+                "low": 4.869,
+                "high": 4.869
+              },
+              "n": 2,
+              "note": "n too small"
+            },
+            {
+              "providerId": "novita",
+              "rank": 3,
+              "value": 5.3945,
+              "interval": {
+                "low": 5.378,
+                "high": 5.411
+              },
+              "n": 2,
+              "note": "n too small"
+            },
+            {
+              "providerId": "e2b",
+              "rank": 4,
+              "value": 8.346,
+              "interval": {
+                "low": 8.259,
+                "high": 8.433
+              },
+              "n": 2,
+              "note": "n too small"
+            },
+            {
+              "providerId": "modal",
+              "rank": 5,
+              "value": 17.182000000000002,
+              "interval": {
+                "low": 17.134,
+                "high": 17.23
+              },
+              "n": 2,
+              "note": "n too small"
+            }
+          ]
+        },
+        {
+          "id": "realworld_better_auth_task_lint_deps_knip",
+          "name": "Better-Auth: lint deps (Knip)",
+          "unit": "Seconds",
+          "direction": "lower",
+          "headline": false,
+          "rows": [
+            {
+              "providerId": "daytona",
+              "rank": 1,
+              "value": 10.965,
+              "interval": {
+                "low": 10.955,
+                "high": 10.975
+              },
+              "n": 2
+            },
+            {
+              "providerId": "novita",
+              "rank": 2,
+              "value": 11.674,
+              "interval": {
+                "low": 11.645,
+                "high": 11.703
+              },
+              "n": 2,
+              "note": "n too small"
+            },
+            {
+              "providerId": "blaxel",
+              "rank": 3,
+              "value": 16.778,
+              "interval": {
+                "low": 16.586,
+                "high": 16.97
+              },
+              "n": 2,
+              "note": "n too small"
+            },
+            {
+              "providerId": "e2b",
+              "rank": 4,
+              "value": 18.75,
+              "interval": {
+                "low": 18.722,
+                "high": 18.778
+              },
+              "n": 2,
+              "note": "n too small"
+            },
+            {
+              "providerId": "modal",
+              "rank": 5,
+              "value": 28.497,
+              "interval": {
+                "low": 28.336,
+                "high": 28.658
+              },
+              "n": 2,
+              "note": "n too small"
+            }
+          ]
+        },
+        {
+          "id": "realworld_better_auth_task_lint_format",
+          "name": "Better-Auth: lint format",
+          "unit": "Seconds",
+          "direction": "lower",
+          "headline": false,
+          "rows": [
+            {
+              "providerId": "daytona",
+              "rank": 1,
+              "value": 2.681,
+              "interval": {
+                "low": 2.679,
+                "high": 2.683
+              },
+              "n": 2
+            },
+            {
+              "providerId": "novita",
+              "rank": 2,
+              "value": 3.0454999999999997,
+              "interval": {
+                "low": 3.038,
+                "high": 3.053
+              },
+              "n": 2,
+              "note": "n too small"
+            },
+            {
+              "providerId": "blaxel",
+              "rank": 3,
+              "value": 4.946,
+              "interval": {
+                "low": 4.946,
+                "high": 4.946
+              },
+              "n": 2,
+              "note": "n too small"
+            },
+            {
+              "providerId": "e2b",
+              "rank": 4,
+              "value": 5.2115,
+              "interval": {
+                "low": 5.157,
+                "high": 5.266
+              },
+              "n": 2,
+              "note": "n too small"
+            },
+            {
+              "providerId": "modal",
+              "rank": 5,
+              "value": 6.5809999999999995,
+              "interval": {
+                "low": 6.494,
+                "high": 6.668
+              },
+              "n": 2,
+              "note": "n too small"
+            }
+          ]
+        },
+        {
+          "id": "realworld_better_auth_task_lint_packages",
+          "name": "Better-Auth: lint packages",
+          "unit": "Seconds",
+          "direction": "lower",
+          "headline": false,
+          "rows": [
+            {
+              "providerId": "blaxel",
+              "rank": 1,
+              "value": 2.9835000000000003,
+              "interval": {
+                "low": 2.966,
+                "high": 3.001
+              },
+              "n": 2
+            },
+            {
+              "providerId": "daytona",
+              "rank": 2,
+              "value": 4.015,
+              "interval": {
+                "low": 4.01,
+                "high": 4.02
+              },
+              "n": 2,
+              "note": "n too small"
+            },
+            {
+              "providerId": "novita",
+              "rank": 3,
+              "value": 4.635,
+              "interval": {
+                "low": 4.632,
+                "high": 4.638
+              },
+              "n": 2,
+              "note": "n too small"
+            },
+            {
+              "providerId": "e2b",
+              "rank": 4,
+              "value": 7.606,
+              "interval": {
+                "low": 7.593,
+                "high": 7.619
+              },
+              "n": 2,
+              "note": "n too small"
+            },
+            {
+              "providerId": "modal",
+              "rank": 5,
+              "value": 15.762,
+              "interval": {
+                "low": 15.556,
+                "high": 15.968
+              },
+              "n": 2,
+              "note": "n too small"
+            }
+          ]
+        },
+        {
+          "id": "realworld_better_auth_task_lint_spell",
+          "name": "Better-Auth: lint spell",
+          "unit": "Seconds",
+          "direction": "lower",
+          "headline": false,
+          "rows": [
+            {
+              "providerId": "daytona",
+              "rank": 1,
+              "value": 6.8385,
+              "interval": {
+                "low": 6.769,
+                "high": 6.908
+              },
+              "n": 2
+            },
+            {
+              "providerId": "novita",
+              "rank": 2,
+              "value": 7.691,
+              "interval": {
+                "low": 7.457,
+                "high": 7.925
+              },
+              "n": 2,
+              "note": "n too small"
+            },
+            {
+              "providerId": "blaxel",
+              "rank": 3,
+              "value": 12.2,
+              "interval": {
+                "low": 12.192,
+                "high": 12.208
+              },
+              "n": 2,
+              "note": "n too small"
+            },
+            {
+              "providerId": "e2b",
+              "rank": 4,
+              "value": 12.43,
+              "interval": {
+                "low": 12.292,
+                "high": 12.568
+              },
+              "n": 2,
+              "note": "n too small"
+            },
+            {
+              "providerId": "modal",
+              "rank": 5,
+              "value": 15.177,
+              "interval": {
+                "low": 14.704,
+                "high": 15.65
+              },
+              "n": 2,
+              "note": "n too small"
+            }
+          ]
+        },
+        {
+          "id": "realworld_better_auth_task_lint_types",
+          "name": "Better-Auth: lint types",
+          "unit": "Seconds",
+          "direction": "lower",
+          "headline": false,
+          "rows": [
+            {
+              "providerId": "blaxel",
+              "rank": 1,
+              "value": 33.638000000000005,
+              "interval": {
+                "low": 33.475,
+                "high": 33.801
+              },
+              "n": 2
+            },
+            {
+              "providerId": "daytona",
+              "rank": 2,
+              "value": 51.068,
+              "interval": {
+                "low": 50.946,
+                "high": 51.19
+              },
+              "n": 2,
+              "note": "n too small"
+            },
+            {
+              "providerId": "novita",
+              "rank": 3,
+              "value": 60.08,
+              "interval": {
+                "low": 59.626,
+                "high": 60.534
+              },
+              "n": 2,
+              "note": "n too small"
+            },
+            {
+              "providerId": "e2b",
+              "rank": 4,
+              "value": 98.63900000000001,
+              "interval": {
+                "low": 97.798,
+                "high": 99.48
+              },
+              "n": 2,
+              "note": "n too small"
+            },
+            {
+              "providerId": "modal",
+              "rank": 5,
+              "value": 183.281,
+              "interval": {
+                "low": 178.903,
+                "high": 187.659
+              },
+              "n": 2,
+              "note": "n too small"
+            }
+          ]
+        },
+        {
+          "id": "realworld_better_auth_task_typecheck",
+          "name": "Better-Auth: typecheck",
+          "unit": "Seconds",
+          "direction": "lower",
+          "headline": false,
+          "rows": [
+            {
+              "providerId": "daytona",
+              "rank": 1,
+              "value": 1.388,
+              "interval": {
+                "low": 1.378,
+                "high": 1.398
+              },
+              "n": 2
+            },
+            {
+              "providerId": "novita",
+              "rank": 2,
+              "value": 1.4740000000000002,
+              "interval": {
+                "low": 1.465,
+                "high": 1.483
+              },
+              "n": 2,
+              "note": "n too small"
+            },
+            {
+              "providerId": "blaxel",
+              "rank": 3,
+              "value": 2.0374999999999996,
+              "interval": {
+                "low": 2.037,
+                "high": 2.038
+              },
+              "n": 2,
+              "note": "n too small"
+            },
+            {
+              "providerId": "e2b",
+              "rank": 4,
+              "value": 2.613,
+              "interval": {
+                "low": 2.436,
+                "high": 2.79
+              },
+              "n": 2,
+              "note": "n too small"
+            },
+            {
+              "providerId": "modal",
+              "rank": 5,
+              "value": 3.308,
+              "interval": {
+                "low": 3.29,
+                "high": 3.326
+              },
+              "n": 2,
+              "note": "n too small"
+            }
+          ]
+        },
+        {
+          "id": "realworld_mastra_task_build_core",
+          "name": "Mastra: build:core",
+          "unit": "Seconds",
+          "direction": "lower",
+          "headline": false,
+          "rows": [
+            {
+              "providerId": "daytona",
+              "rank": 1,
+              "value": 83.0015,
+              "interval": {
+                "low": 82.979,
+                "high": 83.024
+              },
+              "n": 2
+            },
+            {
+              "providerId": "novita",
+              "rank": 2,
+              "value": 125.62049999999999,
+              "interval": {
+                "low": 125.233,
+                "high": 126.008
+              },
+              "n": 2,
+              "note": "n too small"
+            },
+            {
+              "providerId": "modal",
+              "rank": 3,
+              "value": 203.01999999999998,
+              "interval": {
+                "low": 201.052,
+                "high": 204.988
+              },
+              "n": 2,
+              "note": "n too small"
+            }
+          ]
+        },
+        {
+          "id": "realworld_mastra_task_git_clone",
+          "name": "Mastra: git clone",
+          "unit": "Seconds",
+          "direction": "lower",
+          "headline": false,
+          "rows": [
+            {
+              "providerId": "daytona",
+              "rank": 1,
+              "value": 6.6259999999999994,
+              "interval": {
+                "low": 6.425,
+                "high": 6.827
+              },
+              "n": 2
+            },
+            {
+              "providerId": "novita",
+              "rank": 2,
+              "value": 7.0135000000000005,
+              "interval": {
+                "low": 6.931,
+                "high": 7.096
+              },
+              "n": 2,
+              "note": "n too small"
+            },
+            {
+              "providerId": "modal",
+              "rank": 3,
+              "value": 9.957,
+              "interval": {
+                "low": 9.35,
+                "high": 10.564
+              },
+              "n": 2,
+              "note": "n too small"
+            }
+          ]
+        },
+        {
+          "id": "realworld_mastra_task_lint_format",
+          "name": "Mastra: lint:format",
+          "unit": "Seconds",
+          "direction": "lower",
+          "headline": false,
+          "rows": [
+            {
+              "providerId": "daytona",
+              "rank": 1,
+              "value": 90.709,
+              "interval": {
+                "low": 90.341,
+                "high": 91.077
+              },
+              "n": 2
+            },
+            {
+              "providerId": "novita",
+              "rank": 2,
+              "value": 128.67149999999998,
+              "interval": {
+                "low": 128.509,
+                "high": 128.834
+              },
+              "n": 2,
+              "note": "n too small"
+            },
+            {
+              "providerId": "modal",
+              "rank": 3,
+              "value": 199.659,
+              "interval": {
+                "low": 198.234,
+                "high": 201.084
+              },
+              "n": 2,
+              "note": "n too small"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "economics",
+      "metrics": [
+        {
+          "id": "usd_per_hour",
+          "name": "Hourly cost",
+          "unit": "USD/hr",
+          "direction": "lower",
+          "headline": true,
+          "rows": [
+            {
+              "providerId": "daytona",
+              "rank": 1,
+              "value": 0.1494,
+              "interval": null,
+              "n": 1
+            },
+            {
+              "providerId": "novita",
+              "rank": 2,
+              "value": 0.16272,
+              "interval": null,
+              "n": 1
+            },
+            {
+              "providerId": "e2b",
+              "rank": 3,
+              "value": 0.2304,
+              "interval": null,
+              "n": 1
+            },
+            {
+              "providerId": "modal",
+              "rank": 4,
+              "value": 0.47736,
+              "interval": null,
+              "n": 1
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "coverageGaps": [
+    {
+      "providerId": "blaxel",
+      "benchmark": "realworld-mastra",
+      "scope": "suite",
+      "outcome": "skipped",
+      "detail": "Insufficient disk: 12.5 GiB free, suite needs 30 GiB",
+      "disk": true
+    },
+    {
+      "providerId": "blaxel",
+      "benchmark": "realworld-openclaw",
+      "scope": "suite",
+      "outcome": "skipped",
+      "detail": "Insufficient disk: 12.5 GiB free, suite needs 25 GiB",
+      "disk": true
+    },
+    {
+      "providerId": "e2b",
+      "benchmark": "realworld-mastra",
+      "scope": "suite",
+      "outcome": "skipped",
+      "detail": "Insufficient disk: 20.0 GiB free, suite needs 30 GiB",
+      "disk": true
+    },
+    {
+      "providerId": "e2b",
+      "benchmark": "realworld-openclaw",
+      "scope": "suite",
+      "outcome": "skipped",
+      "detail": "Insufficient disk: 20.0 GiB free, suite needs 25 GiB",
+      "disk": true
+    },
+    {
+      "providerId": "blaxel",
+      "benchmark": "network",
+      "scope": "suite",
+      "outcome": "failed",
+      "detail": "Step \"mise run benchmark:network:all\" failed with exit code 1",
+      "disk": false
+    },
+    {
+      "providerId": "daytona",
+      "benchmark": "network",
+      "scope": "suite",
+      "outcome": "failed",
+      "detail": "Step \"mise run benchmark:network:all\" timed out after 2700s",
+      "disk": false
+    },
+    {
+      "providerId": "daytona",
+      "benchmark": "realworld-openclaw",
+      "scope": "suite",
+      "outcome": "failed",
+      "detail": "Step \"mise run benchmark:realworld:pts:openclaw\" timed out after 8400s",
+      "disk": false
+    },
+    {
+      "providerId": "e2b",
+      "benchmark": "cpu-generic",
+      "scope": "suite",
+      "outcome": "failed",
+      "detail": "Step \"mise run benchmark:cpu:generic\" timed out after 7800s",
+      "disk": false
+    },
+    {
+      "providerId": "modal",
+      "benchmark": "cpu-generic",
+      "scope": "suite",
+      "outcome": "failed",
+      "detail": "Step \"mise run benchmark:cpu:generic\" timed out after 7800s",
+      "disk": false
+    },
+    {
+      "providerId": "modal",
+      "benchmark": "network",
+      "scope": "suite",
+      "outcome": "failed",
+      "detail": "Step \"mise run benchmark:network:all\" failed with exit code 1",
+      "disk": false
+    },
+    {
+      "providerId": "modal",
+      "benchmark": "realworld-openclaw",
+      "scope": "suite",
+      "outcome": "failed",
+      "detail": "Step \"mise run benchmark:realworld:pts:openclaw\" timed out after 8400s",
+      "disk": false
+    },
+    {
+      "providerId": "novita",
+      "benchmark": "network",
+      "scope": "suite",
+      "outcome": "failed",
+      "detail": "Step \"mise run benchmark:network:all\" failed with exit code 1",
+      "disk": false
+    },
+    {
+      "providerId": "novita",
+      "benchmark": "realworld-openclaw",
+      "scope": "suite",
+      "outcome": "failed",
+      "detail": "Step \"mise run benchmark:realworld:pts:openclaw\" lost its sandbox: 12 consecutive detached polls failed (last: done-file fs exists) — the sandbox stopped responding, not a quiet long step",
+      "disk": false
+    }
+  ]
+}

--- a/packages/results/src/index.ts
+++ b/packages/results/src/index.ts
@@ -8,6 +8,7 @@
 export { aggregateRuns } from "./lib/aggregate.ts";
 export {
 	buildLeaderboard,
+	buildPublicLeaderboard,
 	type ComparabilityCaveat,
 	// Every type reachable from `Leaderboard` is exported with it: a consumer that can hold the value but
 	// cannot name the type of `leaderboard.coverageGaps` can't write a function that takes one.
@@ -17,7 +18,9 @@ export {
 	type LeaderboardDimension,
 	type LeaderboardMetric,
 	type LeaderboardRow,
+	type PublicLeaderboard,
 	renderLeaderboardMarkdown,
+	renderPublicLeaderboardJson,
 } from "./lib/leaderboard.ts";
 export { type NormalizeInput, normalizeResultsTree } from "./lib/normalize-tree.ts";
 export {

--- a/packages/results/src/lib/leaderboard.ts
+++ b/packages/results/src/lib/leaderboard.ts
@@ -198,6 +198,9 @@ export interface PublicLeaderboard {
 				value: number;
 				interval: { low: number; high: number } | null;
 				n: number;
+				verdict: ComparisonVerdict | null;
+				tiedWithAbove: TieBasis | null;
+				pVsPrevious: LeaderboardRow["pVsPrevious"];
 				note?: string;
 			}>;
 		}>;
@@ -565,6 +568,9 @@ export function buildPublicLeaderboard(
 						interval:
 							row.interval.resamples === 0 ? null : { low: row.interval.lo, high: row.interval.hi },
 						n: row.n,
+						verdict: row.verdict,
+						tiedWithAbove: row.tiedWithAbove,
+						pVsPrevious: row.pVsPrevious,
 						...(note ? { note } : {}),
 					};
 				}),

--- a/packages/results/src/lib/leaderboard.ts
+++ b/packages/results/src/lib/leaderboard.ts
@@ -165,6 +165,53 @@ export interface Leaderboard {
 	coverageGaps: CoverageGap[];
 }
 
+/** Stable, machine-readable projection of the public leaderboard. */
+export interface PublicLeaderboard {
+	schemaVersion: "1";
+	runId: string;
+	sha: string;
+	generatedAt: string;
+	targetSpec: TargetSpec;
+	summary: {
+		providerCount: number;
+		metricCount: number;
+		metricRecordCount: number;
+		retainedObservationCount: number;
+	};
+	providers: Array<{
+		id: string;
+		name: string;
+		specMatched: boolean | null;
+		observedSpecs: ObservedSpecs;
+	}>;
+	dimensions: Array<{
+		id: Dimension;
+		metrics: Array<{
+			id: string;
+			name: string;
+			unit: string;
+			direction: "higher" | "lower";
+			headline: boolean;
+			rows: Array<{
+				providerId: string;
+				rank: number;
+				value: number;
+				interval: { low: number; high: number } | null;
+				n: number;
+				note?: string;
+			}>;
+		}>;
+	}>;
+	coverageGaps: Array<{
+		providerId: string;
+		benchmark: string;
+		scope: GapScope;
+		outcome: CoverageOutcome;
+		detail: string;
+		disk: boolean;
+	}>;
+}
+
 /**
  * Whether a skip reason is a disk-capacity gap — i.e. the harness wrote its "Insufficient disk: …"
  * marker because the sandbox had less free disk than the suite's `minDiskGb`. Matched by prefix rather
@@ -465,6 +512,78 @@ function rowNote(r: LeaderboardRow): string {
 	}
 	if (r.verdict === "tied") return "tied";
 	return "";
+}
+
+/**
+ * Project the existing leaderboard result into a stable JSON contract for downstream consumers.
+ * Ranking, intervals, ties, gaps, and comparability remain owned by {@link buildLeaderboard}; this
+ * function only names and serializes those already-derived facts.
+ */
+export function buildPublicLeaderboard(
+	run: Run,
+	board: Leaderboard = buildLeaderboard(run),
+): PublicLeaderboard {
+	if (board.runId !== run.runId || board.sha !== run.sha || board.generatedAt !== run.generatedAt) {
+		throw new Error("Leaderboard and Run provenance do not match");
+	}
+
+	const metrics = board.dimensions.flatMap((dimension) => dimension.metrics);
+	const rows = metrics.flatMap((metric) => metric.rows);
+
+	return {
+		schemaVersion: "1",
+		runId: board.runId,
+		sha: board.sha,
+		generatedAt: board.generatedAt,
+		targetSpec: board.targetSpec,
+		summary: {
+			providerCount: run.providers.length,
+			metricCount: metrics.length,
+			metricRecordCount: rows.length,
+			retainedObservationCount: rows.reduce((sum, row) => sum + row.n, 0),
+		},
+		providers: run.providers.map((provider) => ({
+			id: provider.providerId,
+			name: getProvider(provider.providerId)?.displayName ?? provider.providerId,
+			specMatched: provider.specMatched ?? null,
+			observedSpecs: provider.observedSpecs,
+		})),
+		dimensions: board.dimensions.map((dimension) => ({
+			id: dimension.dimension,
+			metrics: dimension.metrics.map(({ metric, rows: metricRows }) => ({
+				id: metric.id,
+				name: metric.label,
+				unit: metric.unit,
+				direction: metric.direction === "HIB" ? "higher" : "lower",
+				headline: metric.headline === true,
+				rows: metricRows.map((row) => {
+					const note = rowNote(row);
+					return {
+						providerId: row.providerId,
+						rank: row.rank,
+						value: row.value,
+						interval:
+							row.interval.resamples === 0 ? null : { low: row.interval.lo, high: row.interval.hi },
+						n: row.n,
+						...(note ? { note } : {}),
+					};
+				}),
+			})),
+		})),
+		coverageGaps: board.coverageGaps.map((gap) => ({
+			providerId: gap.providerId,
+			benchmark: gap.id,
+			scope: gap.scope,
+			outcome: gap.outcome,
+			detail: gap.reason,
+			disk: gap.disk,
+		})),
+	};
+}
+
+/** Deterministic, newline-terminated serialization used by the CLI and artifact-sync gate. */
+export function renderPublicLeaderboardJson(publicLeaderboard: PublicLeaderboard): string {
+	return `${JSON.stringify(publicLeaderboard, null, 2)}\n`;
 }
 
 /** Mann-Whitney cell in the pairwise details table — reuses {@link rowNote} for the verdict suffix. */

--- a/packages/results/src/lib/leaderboard.ts
+++ b/packages/results/src/lib/leaderboard.ts
@@ -165,7 +165,19 @@ export interface Leaderboard {
 	coverageGaps: CoverageGap[];
 }
 
-/** Stable, machine-readable projection of the public leaderboard. */
+/**
+ * Stable, machine-readable projection of the public leaderboard.
+ *
+ * INVARIANT — no arrays of scalars. Every array here is an array of objects. The committed artifact's
+ * byte-shape is pinned twice, and the two only agree because of this: the publish workflow runs
+ * `biome check data/dataset --write` over the file, while the artifact-sync gate re-renders it with
+ * `JSON.stringify(x, null, 2)`. Biome never inlines an array of objects (one element per line, same as
+ * `JSON.stringify`), so the shapes coincide. A scalar array — `string[]`, `number[]` — breaks that:
+ * Biome inlines the short ones (`["a", "b"]`) while `JSON.stringify` keeps one per line, so the
+ * workflow would commit the Biome shape, pass its own lint gate, and then fail the artifact-sync test —
+ * stranding the auto-generated publish PR with a check it can never satisfy. If you must add a scalar
+ * array, first make the writer and the gate share one formatter (see {@link renderPublicLeaderboardJson}).
+ */
 export interface PublicLeaderboard {
 	schemaVersion: "1";
 	runId: string;
@@ -540,6 +552,9 @@ export function buildPublicLeaderboard(
 		generatedAt: board.generatedAt,
 		targetSpec: board.targetSpec,
 		summary: {
+			// Counts every provider that participated in the Run, matching the `providers[]` array below —
+			// including a provider that produced only coverage gaps and no ranked row. This deliberately
+			// differs from the Markdown surface's "M providers", which counts only providers with a row.
 			providerCount: run.providers.length,
 			metricCount: metrics.length,
 			metricRecordCount: rows.length,
@@ -587,7 +602,12 @@ export function buildPublicLeaderboard(
 	};
 }
 
-/** Deterministic, newline-terminated serialization used by the CLI and artifact-sync gate. */
+/**
+ * Deterministic, newline-terminated serialization used by the CLI and artifact-sync gate. Its byte-shape
+ * must stay identical to what `biome check --write` produces for the committed artifact — see the
+ * no-scalar-arrays invariant on {@link PublicLeaderboard}. If that ever needs to change, this is the one
+ * place to route through Biome so the writer and the gate cannot drift apart.
+ */
 export function renderPublicLeaderboardJson(publicLeaderboard: PublicLeaderboard): string {
 	return `${JSON.stringify(publicLeaderboard, null, 2)}\n`;
 }

--- a/packages/results/src/lib/public-leaderboard.test.ts
+++ b/packages/results/src/lib/public-leaderboard.test.ts
@@ -78,6 +78,9 @@ describe("public leaderboard JSON", () => {
 			rank: sourceRow?.rank,
 			value: sourceRow?.value,
 			n: sourceRow?.n,
+			verdict: sourceRow?.verdict,
+			tiedWithAbove: sourceRow?.tiedWithAbove,
+			pVsPrevious: sourceRow?.pVsPrevious,
 		});
 		expect(publicRow.interval).toEqual({
 			low: sourceRow.interval.lo,

--- a/packages/results/src/lib/public-leaderboard.test.ts
+++ b/packages/results/src/lib/public-leaderboard.test.ts
@@ -1,0 +1,117 @@
+import { describe, expect, it } from "bun:test";
+import type { MetricResult, ProviderRun, Run } from "@sandbox-benchmarks/schema";
+import { aggregate } from "@sandbox-benchmarks/schema";
+import {
+	buildLeaderboard,
+	buildPublicLeaderboard,
+	renderPublicLeaderboardJson,
+} from "./leaderboard.ts";
+
+function metric(metricId: string, samples: number[]): MetricResult {
+	return { metricId, samples, aggregates: aggregate(samples) };
+}
+
+function fixtureRun(): Run {
+	const providers: ProviderRun[] = [
+		{
+			providerId: "daytona",
+			validationStatus: "validated",
+			specMatched: true,
+			observedSpecs: { vcpus: 2, memoryGb: 8, diskGb: 40 },
+			metrics: [metric("node_web_tooling_runs_per_s", [10, 12])],
+			suitesCovered: ["cpu-node"],
+			gaps: [],
+			uncatalogued: [],
+		},
+		{
+			providerId: "blaxel",
+			validationStatus: "pending",
+			specMatched: false,
+			observedSpecs: { vcpus: 6, memoryGb: 15.63, diskGb: 12.5 },
+			metrics: [],
+			suitesCovered: [],
+			gaps: [
+				{
+					scope: "suite",
+					id: "cpu-node",
+					outcome: "skipped",
+					reason: "Insufficient disk: 12.5 GiB free, suite needs 20 GiB",
+				},
+			],
+			uncatalogued: [],
+		},
+	];
+	return {
+		schemaVersion: "2",
+		runId: "run-public-1",
+		sha: "abc123",
+		generatedAt: "2026-07-17T00:00:00.000Z",
+		targetSpec: { vcpus: 2, memoryGb: 8, diskGb: 40 },
+		providers,
+	};
+}
+
+describe("public leaderboard JSON", () => {
+	it("projects the existing leaderboard without changing ranks, intervals, gaps, or provenance", () => {
+		const run = fixtureRun();
+		const board = buildLeaderboard(run);
+		const output = buildPublicLeaderboard(run, board);
+		const sourceRow = board.dimensions[0]?.rows[0];
+		const publicRow = output.dimensions[0]?.metrics[0]?.rows[0];
+		if (!sourceRow || !publicRow) throw new Error("fixture did not produce its expected row");
+
+		expect(output).toMatchObject({
+			schemaVersion: "1",
+			runId: run.runId,
+			sha: run.sha,
+			generatedAt: run.generatedAt,
+			targetSpec: run.targetSpec,
+			summary: {
+				providerCount: 2,
+				metricCount: 1,
+				metricRecordCount: 1,
+				retainedObservationCount: 2,
+			},
+		});
+		expect(publicRow).toMatchObject({
+			providerId: sourceRow?.providerId,
+			rank: sourceRow?.rank,
+			value: sourceRow?.value,
+			n: sourceRow?.n,
+		});
+		expect(publicRow.interval).toEqual({
+			low: sourceRow.interval.lo,
+			high: sourceRow.interval.hi,
+		});
+		expect(output.providers.find(({ id }) => id === "blaxel")).toMatchObject({
+			name: "Blaxel",
+			specMatched: false,
+			observedSpecs: { vcpus: 6, memoryGb: 15.63, diskGb: 12.5 },
+		});
+		expect(output.coverageGaps).toEqual([
+			{
+				providerId: "blaxel",
+				benchmark: "cpu-node",
+				scope: "suite",
+				outcome: "skipped",
+				detail: "Insufficient disk: 12.5 GiB free, suite needs 20 GiB",
+				disk: true,
+			},
+		]);
+	});
+
+	it("serializes deterministically with a trailing newline", () => {
+		const output = buildPublicLeaderboard(fixtureRun());
+		const first = renderPublicLeaderboardJson(output);
+		expect(first).toBe(renderPublicLeaderboardJson(output));
+		expect(first.endsWith("\n")).toBe(true);
+	});
+
+	it("refuses a leaderboard from a different run", () => {
+		const run = fixtureRun();
+		const board = { ...buildLeaderboard(run), runId: "other-run" };
+		expect(() => buildPublicLeaderboard(run, board)).toThrow(
+			"Leaderboard and Run provenance do not match",
+		);
+	});
+});

--- a/tooling/repo-checks/src/public-leaderboard-artifact-sync.test.ts
+++ b/tooling/repo-checks/src/public-leaderboard-artifact-sync.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from "bun:test";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import {
+	buildLeaderboard,
+	buildPublicLeaderboard,
+	renderPublicLeaderboardJson,
+} from "@sandbox-benchmarks/results";
+import { parseRun } from "@sandbox-benchmarks/schema";
+import { findRepoRoot } from "./lib/workspace.ts";
+
+const ROOT = findRepoRoot();
+
+function publishedRunId(): string {
+	const leaderboard = readFileSync(join(ROOT, "LEADERBOARD.md"), "utf8");
+	const match = leaderboard.match(/^Run `([^`]+)`/m);
+	if (!match?.[1]) throw new Error("LEADERBOARD.md does not name its published Run");
+	return match[1];
+}
+
+describe("public leaderboard artifact", () => {
+	it("is byte-identical to the existing leaderboard result for the published Run", () => {
+		const runId = publishedRunId();
+		const run = parseRun(
+			JSON.parse(readFileSync(join(ROOT, "data", "dataset", "runs", `${runId}.json`), "utf8")),
+		);
+		const artifactPath = join(ROOT, "data", "dataset", "leaderboards", `${runId}.json`);
+		const committed = readFileSync(artifactPath, "utf8");
+		const rendered = renderPublicLeaderboardJson(
+			buildPublicLeaderboard(run, buildLeaderboard(run)),
+		);
+
+		if (committed !== rendered) {
+			throw new Error(
+				`Public leaderboard is stale. Regenerate it:\n  bun apps/cli/src/bin/leaderboard.ts data/dataset/runs/${runId}.json data/dataset/leaderboards/${runId}.json`,
+			);
+		}
+		expect(committed).toBe(rendered);
+	});
+
+	it("covers every provider metric record and retained observation", () => {
+		const runId = publishedRunId();
+		const run = parseRun(
+			JSON.parse(readFileSync(join(ROOT, "data", "dataset", "runs", `${runId}.json`), "utf8")),
+		);
+		const artifact = buildPublicLeaderboard(run);
+		const metricRecordCount = run.providers.reduce(
+			(sum, provider) => sum + provider.metrics.length,
+			0,
+		);
+		const observationCount = run.providers.reduce(
+			(sum, provider) =>
+				sum +
+				provider.metrics.reduce((providerSum, metric) => providerSum + metric.samples.length, 0),
+			0,
+		);
+
+		expect(artifact.summary.metricRecordCount).toBe(metricRecordCount);
+		expect(artifact.summary.retainedObservationCount).toBe(observationCount);
+		expect(
+			artifact.dimensions.flatMap(({ metrics }) => metrics.flatMap(({ rows }) => rows)),
+		).toHaveLength(metricRecordCount);
+	});
+});

--- a/tooling/repo-checks/src/public-leaderboard-artifact-sync.test.ts
+++ b/tooling/repo-checks/src/public-leaderboard-artifact-sync.test.ts
@@ -43,7 +43,10 @@ describe("public leaderboard artifact", () => {
 		const run = parseRun(
 			JSON.parse(readFileSync(join(ROOT, "data", "dataset", "runs", `${runId}.json`), "utf8")),
 		);
-		const artifact = buildPublicLeaderboard(run);
+		const artifact = JSON.parse(
+			readFileSync(join(ROOT, "data", "dataset", "leaderboards", `${runId}.json`), "utf8"),
+		) as ReturnType<typeof buildPublicLeaderboard>;
+		const board = buildLeaderboard(run);
 		const metricRecordCount = run.providers.reduce(
 			(sum, provider) => sum + provider.metrics.length,
 			0,
@@ -60,5 +63,44 @@ describe("public leaderboard artifact", () => {
 		expect(
 			artifact.dimensions.flatMap(({ metrics }) => metrics.flatMap(({ rows }) => rows)),
 		).toHaveLength(metricRecordCount);
+
+		for (const sourceDimension of board.dimensions) {
+			const publicDimension = artifact.dimensions.find(
+				({ id }) => id === sourceDimension.dimension,
+			);
+			expect(publicDimension, sourceDimension.dimension).toBeDefined();
+			for (const sourceMetric of sourceDimension.metrics) {
+				const publicMetric = publicDimension?.metrics.find(
+					({ id }) => id === sourceMetric.metric.id,
+				);
+				expect(publicMetric, sourceMetric.metric.id).toMatchObject({
+					name: sourceMetric.metric.label,
+					unit: sourceMetric.metric.unit,
+					direction: sourceMetric.metric.direction === "HIB" ? "higher" : "lower",
+					headline: sourceMetric.metric.headline === true,
+				});
+				expect(publicMetric?.rows.map(({ providerId }) => providerId)).toEqual(
+					sourceMetric.rows.map(({ providerId }) => providerId),
+				);
+				for (const sourceRow of sourceMetric.rows) {
+					const publicRow = publicMetric?.rows.find(
+						({ providerId }) => providerId === sourceRow.providerId,
+					);
+					expect(publicRow, `${sourceMetric.metric.id}/${sourceRow.providerId}`).toMatchObject({
+						rank: sourceRow.rank,
+						value: sourceRow.value,
+						n: sourceRow.n,
+						verdict: sourceRow.verdict,
+						tiedWithAbove: sourceRow.tiedWithAbove,
+						pVsPrevious: sourceRow.pVsPrevious,
+					});
+					expect(publicRow?.interval).toEqual(
+						sourceRow.interval.resamples === 0
+							? null
+							: { low: sourceRow.interval.lo, high: sourceRow.interval.hi },
+					);
+				}
+			}
+		}
 	});
 });


### PR DESCRIPTION
## Summary

This PR adds a machine-readable JSON version of the benchmark leaderboard. It includes provider names, rankings, uncertainty ranges, sample counts, missing tests, and hardware mismatches. It does not change how rankings are calculated or build the StarSling website.

- expose a deterministic public JSON projection of the existing `buildLeaderboard(run)` result
- publish the current run at `data/dataset/leaderboards/29546060837.json`
- keep rankings, bootstrap intervals, statistical ties, coverage gaps, and comparability evidence owned by the results package
- add focused projection and committed-artifact drift tests

## Verification

- `bun run typecheck`
- `bun run lint`
- `bun run test`
- `bun run spell`
- `git diff --check`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Publishes a deterministic, machine-readable leaderboard JSON and updates the CLI and CI to emit and publish it. The current run `29546060837` JSON is committed and linked in the README.

- **New Features**
  - Added `buildPublicLeaderboard`, `renderPublicLeaderboardJson`, and `PublicLeaderboard` v1 schema to `@sandbox-benchmarks/results` (preserves ranks, intervals, ties, coverage gaps).
  - `leaderboard` CLI writes JSON when the output path ends with `.json`; help and examples updated; subprocess tests cover `.json` vs `.md` dispatch and stdout.
  - CI regenerates both `LEADERBOARD.md` and per-run JSON on publish; committed `data/dataset/leaderboards/29546060837.json` and added a README link.
  - Tests and a repo gate ensure deterministic serialization and committed artifact sync; documented and enforced the no-scalar-arrays invariant in the public schema.

- **Migration**
  - Generate/refresh a run’s JSON: `bun apps/cli/src/bin/leaderboard.ts data/dataset/runs/<runId>.json data/dataset/leaderboards/<runId>.json`

<sup>Written for commit ba98cd0950a77945823a69b0c4ce1a38c6c5cb48. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/starslingdev/hpc-sandbox-benchmarks/pull/203?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added machine-readable JSON leaderboard exports alongside the existing Markdown format.
  * Added a committed leaderboard JSON report containing rankings, metrics, provider details, and coverage gaps.
  * Updated the CLI help and README with instructions and links for accessing JSON leaderboards.
* **Bug Fixes**
  * Added validation to ensure leaderboard results match their source dataset run.
* **Tests**
  * Added coverage for JSON generation, Markdown output, deterministic serialization, artifact consistency, and CLI behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->