### PR TITLE
fix(ci): kill fast-cli's whole process group on daytona, not just node

### DIFF
--- a/packages/schema/src/pts-profiles/fast-cli-1.0.0/install.sh
+++ b/packages/schema/src/pts-profiles/fast-cli-1.0.0/install.sh
@@ -23,20 +23,39 @@ cat <<'EOF' >fast-cli
 # fast — as a normal nonzero trial, letting PTS's own TimesToRun retry the next trial or the composite
 # report a failed result — rather than consuming the outer suite's step timeout.
 #
-# Plain `timeout 240` isn't enough: on daytona specifically, a stalled fast.com transfer sits in an
-# uninterruptible network wait that ignores `timeout`'s default SIGTERM, so the process never exits and
-# the hang just gets caught by the outer 45-minute step timeout instead (confirmed live: run 29587815350
-# ran the full 2700s before GitHub force-killed the step). `-k 10` escalates to SIGKILL 10s after the
-# SIGTERM if the process is still alive, which reaps it unconditionally.
-#
 # 420s (not 240s): novita's fast-cli trials (run 29587815350) exited cleanly on plain SIGTERM at ~240s
 # with no crash/stderr — unlike modal's immediate Chrome-library crash — meaning the run was still
 # making progress (Chrome launched, fast.com loaded) and simply hadn't converged yet. novita's sandbox
 # is single-vCPU (vs. 2+ on e2b/modal/daytona), and fast-cli's own issue tracker documents Puppeteer's
 # Chrome needing generous headroom on constrained hardware (sindresorhus/fast-cli#81). 2 trials at 420s
-# (+10s SIGKILL grace each) is at most ~860s, still well inside the 2700s suite budget.
-timeout -k 10 420 node node_modules/fast-cli/distribution/cli.js --upload --json > "$LOG_FILE" 2>&1
+# is at most ~840s, still well inside the 2700s suite budget. Live-confirmed fixed on novita AND modal
+# (run 29603585550: both validated 6/6 metrics, 0 failures).
+#
+# Plain `timeout` — even with `-k 10` SIGKILL escalation — cannot fix daytona's hang: it only signals
+# the ONE process it directly launches (node). SIGKILL gives node zero chance to run its own
+# browser.close() cleanup, so Puppeteer's Chrome (and Chrome's own zygote/renderer children, which node
+# spawns but does not own in the same process group) survive as orphans after node is reaped. Something
+# downstream still tracking that process tree's output then blocks indefinitely on it, independent of
+# node's own exit — confirmed live: run 29603585550's daytona cell hung the full 2700s outer timeout
+# even with `-k 10` in place, identical to the pre-`-k` hang. Reaping node alone is not enough.
+#
+# Fix: `setsid` starts node as its own process group leader (PGID = its PID), so every process it
+# spawns — including Chrome and Chrome's own children — inherits that same PGID unless it explicitly
+# detaches. A negative PID passed to `kill` targets the WHOLE group at once, so both the timeout and
+# the final kill below reach Chrome's entire subprocess tree, not just the top-level node process.
+setsid node node_modules/fast-cli/distribution/cli.js --upload --json > "$LOG_FILE" 2>&1 &
+pid=$!
+(
+	sleep 420
+	kill -TERM -"$pid" 2>/dev/null
+	sleep 10
+	kill -KILL -"$pid" 2>/dev/null
+) &
+watcher=$!
+wait "$pid"
 status=$?
+kill "$watcher" 2>/dev/null
+wait "$watcher" 2>/dev/null
 echo "$status" > ~/test-exit-status
 exit "$status"
 EOF


### PR DESCRIPTION
## Summary

Follow-up to #202 (merged). Live validation of run [29603585550](https://github.com/starslingdev/hpc-sandbox-benchmarks/actions/runs/29603585550) confirmed:

- **modal and novita are fully fixed** — both validated 6/6 network metrics with zero failures. #202's Chrome-dep and timeout-widening fixes work as intended.
- **daytona still hung the full 45-minute suite budget**, identically to before the `-k 10` SIGKILL escalation was added ([job 87979892114](https://github.com/starslingdev/hpc-sandbox-benchmarks/actions/runs/29603585550/job/87979892114): `Started Run 1 @ 19:56:33` then silence until GitHub force-killed the step at 2700s). This proves killing `node` alone isn't the fix.

## Root cause

`timeout` only signals the *one* process it directly launches (`node`). SIGKILL gives `node` zero chance to run its own `browser.close()` cleanup, so Puppeteer's Chrome — and Chrome's own zygote/renderer children — survive `node`'s death as orphans. Whatever downstream still tracks that process tree's output then blocks indefinitely on it, regardless of whether `node` itself is long dead. `-k 10` only ever reached `node`, so the underlying hang was never actually addressed.

## Fix

Launch under `setsid` so `node` becomes its own process group leader; every process it spawns inherits that PGID unless it explicitly detaches. A background watcher sends TERM then KILL to the *negative* PID (the whole group) instead of relying on `timeout`'s single-process semantics, so Chrome's entire subprocess tree gets reaped, not just `node`.

## Test plan

- [x] `bun test packages/harness/src/lib/setup.test.ts packages/schema/src/suites.test.ts` — green
- [x] `sh -n` on the modified `install.sh` — clean
- [ ] Live bench-matrix re-dispatch on `main` post-merge to confirm daytona's network suite now completes — this is the one remaining unvalidated piece; modal, novita, and e2b are already confirmed working from run 29603585550.

Co-Authored-By: Claude Sonnet 5
Claude-Session: https://claude.ai/code/session_016UPKbWL77zAYDWUFR4ZCbK

---
_Generated by [Claude Code](https://claude.ai/code/session_016UPKbWL77zAYDWUFR4ZCbK)_

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stop daytona CI hangs by running `fast-cli` under `setsid` and killing its entire process group on timeout, not just `node`. This reaps Chrome and its children so trials end within the 420s budget instead of hitting the 45-minute step limit.

- **Bug Fixes**
  - Launch `node` with `setsid`; a watcher sends TERM at 420s and KILL 10s later to the negative PID (the whole group).
  - Prevent orphaned Chrome subprocesses that caused indefinite blocking on daytona.
  - Preserve existing behavior (exit code written and PTS retries); modal and novita remain green.

<sup>Written for commit 166a18d6f9a233f632cc13db4a8b3d4dfacb264f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/starslingdev/hpc-sandbox-benchmarks/pull/204?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

