### PR TITLE
fix(bench): wipe per-package caches so realworld builds/typechecks measure cold artifacts

### DIFF
--- a/lib/pts/realworld/realworld-runner.sh
+++ b/lib/pts/realworld/realworld-runner.sh
@@ -34,6 +34,16 @@ export COREPACK_ENABLE_DOWNLOAD_PROMPT=0
 start_ns=""
 end_ns=""
 
+# Wipe every workspace node_modules/.cache entry except turbo. A root-only wipe misses
+# per-package paths (e.g. better-auth packages/<pkg>/node_modules/.cache/ts), which made
+# warm-up leave an incremental TS cache and under-measure build/typecheck.
+wipe_tool_caches() {
+	find . -type d -path '*/node_modules/.cache' 2>/dev/null |
+		while IFS= read -r cache_dir; do
+			find "$cache_dir" -mindepth 1 -maxdepth 1 ! -name turbo -exec rm -rf {} +
+		done
+}
+
 case "$TASK" in
 git_clone)
 	# Measured clone: what actions/checkout does -- deterministic content, network-inclusive on
@@ -85,20 +95,22 @@ cold_install)
 		# standalone). TURBO_FORCE is lifted for the prep only; the measured command keeps
 		# TURBO_FORCE=true so it is always a genuine execution, never a cache replay.
 		git clean -xdff -e node_modules -e dist -e .turbo
+		wipe_tool_caches
 		if [ ! -d node_modules ]; then
 			eval "$TASK_CMD_cold_install"
 		fi
 		(unset TURBO_FORCE && eval "$prep")
+		# Prep may restore turbo outputs under per-package node_modules/.cache; clear them so the
+		# timed command keeps dist warm but does not inherit incremental TS/vitest caches.
+		wipe_tool_caches
 	else
 		# Turbo's cache dirs (.turbo/ at the root, node_modules/.cache/turbo) survive EVERY generic
 		# reset — not just prep tasks' — so the cache the measured build wrote is still there when a
 		# later prep replays it, regardless of which tasks ran in between. Measurement-safe: every
 		# measured turbo command runs with TURBO_FORCE=true, so preserved cache is never read inside
-		# a timed window; all other tool caches in node_modules/.cache are still wiped.
+		# a timed window; all other tool caches under any node_modules/.cache are wiped.
 		git clean -xdff -e node_modules -e .turbo
-		if [ -d node_modules/.cache ]; then
-			find node_modules/.cache -mindepth 1 -maxdepth 1 ! -name turbo -exec rm -rf {} +
-		fi
+		wipe_tool_caches
 		if [ ! -d node_modules ]; then
 			# Recovery install: output stays on the (already-redirected) log — discarding it would
 			# hide the one diagnostic that explains a subsequent task failure.
@@ -112,20 +124,15 @@ cold_install)
 		exit 1
 	fi
 	if [ -z "$prep" ]; then
-		# Steady-state warm-up (fio's ramp_time, adapted): the FIRST execution of a JS toolchain in a
-		# fresh sandbox pays one-time JIT/compile-cache costs that live outside work/ and survive the
-		# per-pass reset — observed 75s vs ~10s on an identical better-auth build, an asymmetry that
-		# poisons the sample set and trips PTS's dynamic run count. One unmeasured execution, then
-		# the same reset again, so the measured run is warm-toolchain + cold-artifact on every pass.
-		# Prep-carrying tasks skip this: their prep already exercised the toolchain.
+		# Steady-state warm-up (fio's ramp_time, adapted): one unmeasured execution, then the same
+		# cold-artifact reset again so every sample is warm-toolchain + cold-artifact. Artifact
+		# caches (including per-package node_modules/.cache/ts) must be wiped here.
 		eval "$cmd"
 		# Same PRESERVING reset as above — the old destructive form here wiped the turbo cache the
 		# measured build had written, killing the replay for any prep task downstream of a no-prep
 		# task's warm-up cycle.
 		git clean -xdff -e node_modules -e .turbo
-		if [ -d node_modules/.cache ]; then
-			find node_modules/.cache -mindepth 1 -maxdepth 1 ! -name turbo -exec rm -rf {} +
-		fi
+		wipe_tool_caches
 	fi
 	start_ns=$(date +%s%N)
 	eval "$cmd"

--- a/lib/pts/realworld/realworld-runner.sh
+++ b/lib/pts/realworld/realworld-runner.sh
@@ -36,9 +36,11 @@ end_ns=""
 
 # Wipe every workspace node_modules/.cache entry except turbo. A root-only wipe misses
 # per-package paths (e.g. better-auth packages/<pkg>/node_modules/.cache/ts), which made
-# warm-up leave an incremental TS cache and under-measure build/typecheck.
+# warm-up leave an incremental TS cache and under-measure build/typecheck. Anchored to
+# WORK_DIR (not `.`) so the blast radius is explicit even if a future call site forgets
+# to cd first.
 wipe_tool_caches() {
-	find . -type d -path '*/node_modules/.cache' 2>/dev/null |
+	find "$WORK_DIR" -type d -path '*/node_modules/.cache' 2>/dev/null |
 		while IFS= read -r cache_dir; do
 			find "$cache_dir" -mindepth 1 -maxdepth 1 ! -name turbo -exec rm -rf {} +
 		done

--- a/lib/pts/realworld/selftest-payload.sh
+++ b/lib/pts/realworld/selftest-payload.sh
@@ -95,5 +95,13 @@ count() { if [ -f "$COUNTS/$1" ]; then wc -l < "$COUNTS/$1" | tr -d ' '; else ec
 	echo "FAIL: per-package TS cache hits=$(count build-cache), expected 0" >&2
 	exit 1
 }
-echo "execution-count assertions OK (build=3 lint=2 test=1 build-cache=0)"
+# Positive counterpart to build-cache=0: the turbo sentinel primed by the first build must survive
+# every subsequent wipe_tool_caches reset (build runs 2 and 3 of 3), proving the `! -name turbo`
+# exception actually preserves turbo's own cache rather than the assertion passing by wiping
+# everything indiscriminately.
+[ "$(count turbo-survived)" = "2" ] || {
+	echo "FAIL: turbo cache survived $(count turbo-survived)x resets, expected 2" >&2
+	exit 1
+}
+echo "execution-count assertions OK (build=3 lint=2 test=1 build-cache=0 turbo-survived=2)"
 echo "SELFTEST PASS"

--- a/lib/pts/realworld/selftest-payload.sh
+++ b/lib/pts/realworld/selftest-payload.sh
@@ -89,5 +89,11 @@ count() { if [ -f "$COUNTS/$1" ]; then wc -l < "$COUNTS/$1" | tr -d ' '; else ec
 [ "$(count build)" = "3" ] || { echo "FAIL: build executed $(count build)x, expected 3 (warm-up+measured+prep)" >&2; exit 1; }
 [ "$(count lint)" = "2" ] || { echo "FAIL: lint executed $(count lint)x, expected 2 (warm-up+measured)" >&2; exit 1; }
 [ "$(count test)" = "1" ] || { echo "FAIL: test executed $(count test)x, expected 1 (no warm-up on prep tasks)" >&2; exit 1; }
-echo "execution-count assertions OK (build=3 lint=2 test=1)"
+# better-auth-shaped per-package TS cache must not survive cold-artifact resets (root-only wipe
+# left packages/*/node_modules/.cache/ts warm and under-measured build/typecheck).
+[ "$(count build-cache)" = "0" ] || {
+	echo "FAIL: per-package TS cache hits=$(count build-cache), expected 0" >&2
+	exit 1
+}
+echo "execution-count assertions OK (build=3 lint=2 test=1 build-cache=0)"
 echo "SELFTEST PASS"

--- a/lib/pts/realworld/selftest/fixture-package.json
+++ b/lib/pts/realworld/selftest/fixture-package.json
@@ -3,7 +3,7 @@
   "private": true,
   "packageManager": "pnpm@10.12.1",
   "scripts": {
-    "build": "mkdir -p dist && echo ok > dist/out.txt && echo x >> /tmp/counts/build && sleep 2",
+    "build": "if [ -f packages/core/node_modules/.cache/ts/tsbuildinfo ]; then echo CACHE_HIT >> /tmp/counts/build-cache; fi; mkdir -p dist packages/core/node_modules/.cache/ts && echo ok > dist/out.txt && echo warm > packages/core/node_modules/.cache/ts/tsbuildinfo && echo x >> /tmp/counts/build && sleep 2",
     "lint": "echo x >> /tmp/counts/lint && sleep 0.5",
     "test": "test -f dist/out.txt && echo x >> /tmp/counts/test && sleep 1"
   }

--- a/lib/pts/realworld/selftest/fixture-package.json
+++ b/lib/pts/realworld/selftest/fixture-package.json
@@ -3,7 +3,7 @@
   "private": true,
   "packageManager": "pnpm@10.12.1",
   "scripts": {
-    "build": "if [ -f packages/core/node_modules/.cache/ts/tsbuildinfo ]; then echo CACHE_HIT >> /tmp/counts/build-cache; fi; mkdir -p dist packages/core/node_modules/.cache/ts && echo ok > dist/out.txt && echo warm > packages/core/node_modules/.cache/ts/tsbuildinfo && echo x >> /tmp/counts/build && sleep 2",
+    "build": "if [ -f packages/core/node_modules/.cache/ts/tsbuildinfo ]; then echo CACHE_HIT >> /tmp/counts/build-cache; fi; if [ -f packages/core/node_modules/.cache/turbo/sentinel ]; then echo x >> /tmp/counts/turbo-survived; fi; mkdir -p dist packages/core/node_modules/.cache/ts packages/core/node_modules/.cache/turbo && echo ok > dist/out.txt && echo warm > packages/core/node_modules/.cache/ts/tsbuildinfo && echo turbo > packages/core/node_modules/.cache/turbo/sentinel && echo x >> /tmp/counts/build && sleep 2",
     "lint": "echo x >> /tmp/counts/lint && sleep 0.5",
     "test": "test -f dist/out.txt && echo x >> /tmp/counts/test && sleep 1"
   }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Realworld cold-artifact resets only wiped the **root** `node_modules/.cache`, so per-package TypeScript incremental caches survived warm-up and under-measured tasks — most visibly better-auth **build (~10s vs ~65s)** and **typecheck (~1.4s vs ~45s)**.

better-auth's `tsconfig.base.json` places `tsBuildInfoFile` / `outDir` at `packages/*/node_modules/.cache/ts/`. Those paths are excluded from `git clean -e node_modules`, and turbo still reports `0 cached` under `TURBO_FORCE` while tsdown/tsc reuse the surviving DTS/incremental cache.

## Fix

- Add `wipe_tool_caches` / `reset_cold_artifact` in `realworld-runner.sh` to clear every `*/node_modules/.cache/*` except `turbo`
- Wipe tool caches before and after `TASK_PREP` so measured prep-carrying tasks do not inherit incremental TS/vitest caches (dist + `.turbo` stay for replay)
- Extend the realworld selftest fixture to write a better-auth-shaped per-package cache and assert `CACHE_HIT` count stays `0`

## Local evidence (better-auth @ pin)

| Task | After root-only wipe (old) | After workspace wipe (new) |
| --- | ---: | ---: |
| `pnpm build` | 9.1s (984 ts cache files survived) | 64.5s (0 survived) |
| `pnpm typecheck` | 1.3s | 43.7s |

Cold first build on the same machine was ~67s; the old ~10s samples match the buggy wipe path.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1bc84277-ac83-47e9-ba3b-6f5f70ed0fce"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1bc84277-ac83-47e9-ba3b-6f5f70ed0fce"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Ensure realworld benches measure true cold artifacts by wiping every workspace `node_modules/.cache` except `turbo`, so builds/typechecks reflect real cold runs (e.g., `better-auth`). Adds a robust, `WORK_DIR`-anchored cache wipe in the shell shim and tightens selftest to catch TS cache reuse while proving `turbo` cache preservation.

- **Bug Fixes**
  - Add `wipe_tool_caches` to clear all `*/node_modules/.cache/*` except `turbo`; anchor traversal to `WORK_DIR`. Run on both reset paths, before/after `TASK_PREP`, and after warm-up.
  - Update selftest to write per-package TS cache, assert `build-cache=0`, and verify `turbo` cache survives two resets.

- **Refactors**
  - Keep a thin `realworld-runner.sh` shim with wipe logic; main measured runner stays in TypeScript.

<sup>Written for commit 52db9db0220ce916d9c81285fffc6db305b19f85. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/starslingdev/hpc-sandbox-benchmarks/pull/206?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved reset/warm-up behavior to reliably clear tool and per-package caches (including workspace and package-specific cache locations) while preserving intended Turbo cache data.
- **Tests**
  - Strengthened self-tests to assert `build-cache=0` after cold/wipe-style resets and to confirm Turbo cache survival (`turbo-survived=2`) with updated execution-count messaging.
  - Updated the fixture package build step to record TypeScript cache and Turbo sentinel presence during build.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->