### PR TITLE
feat(providers): give Blaxel the 40 GiB target disk via a mounted volume

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -62,6 +62,7 @@
       "name": "@sandbox-benchmarks/providers",
       "version": "0.0.0",
       "dependencies": {
+        "@blaxel/core": "catalog:computesdk",
         "@computesdk/blaxel": "catalog:computesdk",
         "@computesdk/daytona": "catalog:computesdk",
         "@computesdk/e2b": "catalog:computesdk",
@@ -162,6 +163,7 @@
   },
   "catalogs": {
     "computesdk": {
+      "@blaxel/core": "0.2.95",
       "@computesdk/blaxel": "1.6.16",
       "@computesdk/daytona": "1.7.31",
       "@computesdk/e2b": "1.7.51",
@@ -520,9 +522,9 @@
 
     "ansi-colors": ["ansi-colors@4.1.3", "", {}, "sha512-/6w/C21Pm1A7aZitlI5Ni/2J6FFQN8i1Cvz3kHABAAbw93v/NlvKdVOqz7CCWz/3iv/JplRSEEZ83XION15ovw=="],
 
-    "ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
+    "ansi-regex": ["ansi-regex@6.2.2", "", {}, "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg=="],
 
-    "ansi-styles": ["ansi-styles@4.3.0", "", { "dependencies": { "color-convert": "^2.0.1" } }, "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg=="],
+    "ansi-styles": ["ansi-styles@6.2.3", "", {}, "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg=="],
 
     "archiver": ["archiver@7.0.1", "", { "dependencies": { "archiver-utils": "^5.0.2", "async": "^3.2.4", "buffer-crc32": "^1.0.0", "readable-stream": "^4.0.0", "readdir-glob": "^1.1.2", "tar-stream": "^3.0.0", "zip-stream": "^6.0.1" } }, "sha512-ZcbTaIqJOfCc03QwD468Unz/5Ir8ATtvAHsK+FdXbDIbGfihqh9mrvdcYunQzqn4HrvWWaFyaxJhGZagaJJpPQ=="],
 
@@ -956,7 +958,7 @@
 
     "rc9": ["rc9@3.0.1", "", { "dependencies": { "defu": "^6.1.6", "destr": "^2.0.5" } }, "sha512-gMDyleLWVE+i6Sgtc0QbbY6pEKqYs97NGi6isHQPqYlLemPoO8dxQ3uGi0f4NiP98c+jMW6cG1Kx9dDwfvqARQ=="],
 
-    "readable-stream": ["readable-stream@3.6.2", "", { "dependencies": { "inherits": "^2.0.3", "string_decoder": "^1.1.1", "util-deprecate": "^1.0.1" } }, "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA=="],
+    "readable-stream": ["readable-stream@4.7.0", "", { "dependencies": { "abort-controller": "^3.0.0", "buffer": "^6.0.3", "events": "^3.3.0", "process": "^0.11.10", "string_decoder": "^1.3.0" } }, "sha512-oIGGmcpTLwPga8Bn6/Z75SVaH1z5dUut2ibSyAMVhmUggWpmDn2dapB0n7f8nwaSiRtepAsfJyfXIO5DCVAODg=="],
 
     "readdir-glob": ["readdir-glob@1.1.3", "", { "dependencies": { "minimatch": "^5.1.0" } }, "sha512-v05I2k7xN8zXvPD9N+z/uhXPaj0sUFCe2rcWZIpBsqxfP7xXFQ0tipAd/wjj1YxWyWtUS5IDJpOG82JKt2EAVA=="],
 
@@ -1022,7 +1024,7 @@
 
     "string_decoder": ["string_decoder@1.3.0", "", { "dependencies": { "safe-buffer": "~5.2.0" } }, "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA=="],
 
-    "strip-ansi": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
+    "strip-ansi": ["strip-ansi@7.2.0", "", { "dependencies": { "ansi-regex": "^6.2.2" } }, "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w=="],
 
     "strip-ansi-cjs": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
 
@@ -1072,7 +1074,7 @@
 
     "which": ["which@2.0.2", "", { "dependencies": { "isexe": "^2.0.0" }, "bin": { "node-which": "./bin/node-which" } }, "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA=="],
 
-    "wrap-ansi": ["wrap-ansi@7.0.0", "", { "dependencies": { "ansi-styles": "^4.0.0", "string-width": "^4.1.0", "strip-ansi": "^6.0.0" } }, "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q=="],
+    "wrap-ansi": ["wrap-ansi@8.1.0", "", { "dependencies": { "ansi-styles": "^6.1.0", "string-width": "^5.0.1", "strip-ansi": "^7.0.1" } }, "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ=="],
 
     "wrap-ansi-cjs": ["wrap-ansi@7.0.0", "", { "dependencies": { "ansi-styles": "^4.0.0", "string-width": "^4.1.0", "strip-ansi": "^6.0.0" } }, "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q=="],
 
@@ -1108,17 +1110,13 @@
 
     "accepts/mime-types": ["mime-types@3.0.2", "", { "dependencies": { "mime-db": "^1.54.0" } }, "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A=="],
 
-    "archiver/readable-stream": ["readable-stream@4.7.0", "", { "dependencies": { "abort-controller": "^3.0.0", "buffer": "^6.0.3", "events": "^3.3.0", "process": "^0.11.10", "string_decoder": "^1.3.0" } }, "sha512-oIGGmcpTLwPga8Bn6/Z75SVaH1z5dUut2ibSyAMVhmUggWpmDn2dapB0n7f8nwaSiRtepAsfJyfXIO5DCVAODg=="],
-
     "archiver-utils/glob": ["glob@10.5.0", "", { "dependencies": { "foreground-child": "^3.1.0", "jackspeak": "^3.1.2", "minimatch": "^9.0.4", "minipass": "^7.1.2", "package-json-from-dist": "^1.0.0", "path-scurry": "^1.11.1" }, "bin": { "glob": "dist/esm/bin.mjs" } }, "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg=="],
-
-    "archiver-utils/readable-stream": ["readable-stream@4.7.0", "", { "dependencies": { "abort-controller": "^3.0.0", "buffer": "^6.0.3", "events": "^3.3.0", "process": "^0.11.10", "string_decoder": "^1.3.0" } }, "sha512-oIGGmcpTLwPga8Bn6/Z75SVaH1z5dUut2ibSyAMVhmUggWpmDn2dapB0n7f8nwaSiRtepAsfJyfXIO5DCVAODg=="],
 
     "body-parser/content-type": ["content-type@2.0.0", "", {}, "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ=="],
 
-    "compress-commons/readable-stream": ["readable-stream@4.7.0", "", { "dependencies": { "abort-controller": "^3.0.0", "buffer": "^6.0.3", "events": "^3.3.0", "process": "^0.11.10", "string_decoder": "^1.3.0" } }, "sha512-oIGGmcpTLwPga8Bn6/Z75SVaH1z5dUut2ibSyAMVhmUggWpmDn2dapB0n7f8nwaSiRtepAsfJyfXIO5DCVAODg=="],
+    "cliui/strip-ansi": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
 
-    "crc32-stream/readable-stream": ["readable-stream@4.7.0", "", { "dependencies": { "abort-controller": "^3.0.0", "buffer": "^6.0.3", "events": "^3.3.0", "process": "^0.11.10", "string_decoder": "^1.3.0" } }, "sha512-oIGGmcpTLwPga8Bn6/Z75SVaH1z5dUut2ibSyAMVhmUggWpmDn2dapB0n7f8nwaSiRtepAsfJyfXIO5DCVAODg=="],
+    "cliui/wrap-ansi": ["wrap-ansi@7.0.0", "", { "dependencies": { "ansi-styles": "^4.0.0", "string-width": "^4.1.0", "strip-ansi": "^6.0.0" } }, "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q=="],
 
     "e2b/undici": ["undici@7.27.2", "", {}, "sha512-uZsKNuzQxDMUY6M3pIMvy5tvlGmtq8XJ2oLAkfRKGNu+1VQAIvLy2xIVG5ATZl5wDXl/tddByAWCizRbOme+TA=="],
 
@@ -1126,15 +1124,29 @@
 
     "lazystream/readable-stream": ["readable-stream@2.3.8", "", { "dependencies": { "core-util-is": "~1.0.0", "inherits": "~2.0.3", "isarray": "~1.0.0", "process-nextick-args": "~2.0.0", "safe-buffer": "~5.1.1", "string_decoder": "~1.1.1", "util-deprecate": "~1.0.1" } }, "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA=="],
 
+    "readable-stream/buffer": ["buffer@6.0.3", "", { "dependencies": { "base64-js": "^1.3.1", "ieee754": "^1.2.1" } }, "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA=="],
+
     "readdir-glob/minimatch": ["minimatch@5.1.9", "", { "dependencies": { "brace-expansion": "^2.0.1" } }, "sha512-7o1wEA2RyMP7Iu7GNba9vc0RWWGACJOCZBJX2GJWip0ikV+wcOsgVuY9uE8CPiyQhkGFSlhuSkZPavN7u1c2Fw=="],
 
     "send/mime-types": ["mime-types@3.0.2", "", { "dependencies": { "mime-db": "^1.54.0" } }, "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A=="],
+
+    "stream-browserify/readable-stream": ["readable-stream@3.6.2", "", { "dependencies": { "inherits": "^2.0.3", "string_decoder": "^1.1.1", "util-deprecate": "^1.0.1" } }, "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA=="],
+
+    "string-width/strip-ansi": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
+
+    "string-width-cjs/strip-ansi": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
+
+    "strip-ansi-cjs/ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
 
     "type-is/content-type": ["content-type@2.0.0", "", {}, "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ=="],
 
     "type-is/mime-types": ["mime-types@3.0.2", "", { "dependencies": { "mime-db": "^1.54.0" } }, "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A=="],
 
-    "zip-stream/readable-stream": ["readable-stream@4.7.0", "", { "dependencies": { "abort-controller": "^3.0.0", "buffer": "^6.0.3", "events": "^3.3.0", "process": "^0.11.10", "string_decoder": "^1.3.0" } }, "sha512-oIGGmcpTLwPga8Bn6/Z75SVaH1z5dUut2ibSyAMVhmUggWpmDn2dapB0n7f8nwaSiRtepAsfJyfXIO5DCVAODg=="],
+    "wrap-ansi/string-width": ["string-width@5.1.2", "", { "dependencies": { "eastasianwidth": "^0.2.0", "emoji-regex": "^9.2.2", "strip-ansi": "^7.0.1" } }, "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA=="],
+
+    "wrap-ansi-cjs/ansi-styles": ["ansi-styles@4.3.0", "", { "dependencies": { "color-convert": "^2.0.1" } }, "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg=="],
+
+    "wrap-ansi-cjs/strip-ansi": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
 
     "accepts/mime-types/mime-db": ["mime-db@1.54.0", "", {}, "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ=="],
 
@@ -1144,13 +1156,9 @@
 
     "archiver-utils/glob/path-scurry": ["path-scurry@1.11.1", "", { "dependencies": { "lru-cache": "^10.2.0", "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0" } }, "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA=="],
 
-    "archiver-utils/readable-stream/buffer": ["buffer@6.0.3", "", { "dependencies": { "base64-js": "^1.3.1", "ieee754": "^1.2.1" } }, "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA=="],
+    "cliui/strip-ansi/ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
 
-    "archiver/readable-stream/buffer": ["buffer@6.0.3", "", { "dependencies": { "base64-js": "^1.3.1", "ieee754": "^1.2.1" } }, "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA=="],
-
-    "compress-commons/readable-stream/buffer": ["buffer@6.0.3", "", { "dependencies": { "base64-js": "^1.3.1", "ieee754": "^1.2.1" } }, "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA=="],
-
-    "crc32-stream/readable-stream/buffer": ["buffer@6.0.3", "", { "dependencies": { "base64-js": "^1.3.1", "ieee754": "^1.2.1" } }, "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA=="],
+    "cliui/wrap-ansi/ansi-styles": ["ansi-styles@4.3.0", "", { "dependencies": { "color-convert": "^2.0.1" } }, "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg=="],
 
     "express/mime-types/mime-db": ["mime-db@1.54.0", "", {}, "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ=="],
 
@@ -1162,9 +1170,15 @@
 
     "send/mime-types/mime-db": ["mime-db@1.54.0", "", {}, "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ=="],
 
+    "string-width-cjs/strip-ansi/ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
+
+    "string-width/strip-ansi/ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
+
     "type-is/mime-types/mime-db": ["mime-db@1.54.0", "", {}, "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ=="],
 
-    "zip-stream/readable-stream/buffer": ["buffer@6.0.3", "", { "dependencies": { "base64-js": "^1.3.1", "ieee754": "^1.2.1" } }, "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA=="],
+    "wrap-ansi-cjs/strip-ansi/ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
+
+    "wrap-ansi/string-width/emoji-regex": ["emoji-regex@9.2.2", "", {}, "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg=="],
 
     "archiver-utils/glob/jackspeak/@isaacs/cliui": ["@isaacs/cliui@8.0.2", "", { "dependencies": { "string-width": "^5.1.2", "string-width-cjs": "npm:string-width@^4.2.0", "strip-ansi": "^7.0.1", "strip-ansi-cjs": "npm:strip-ansi@^6.0.1", "wrap-ansi": "^8.1.0", "wrap-ansi-cjs": "npm:wrap-ansi@^7.0.0" } }, "sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA=="],
 
@@ -1176,16 +1190,8 @@
 
     "archiver-utils/glob/jackspeak/@isaacs/cliui/string-width": ["string-width@5.1.2", "", { "dependencies": { "eastasianwidth": "^0.2.0", "emoji-regex": "^9.2.2", "strip-ansi": "^7.0.1" } }, "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA=="],
 
-    "archiver-utils/glob/jackspeak/@isaacs/cliui/strip-ansi": ["strip-ansi@7.2.0", "", { "dependencies": { "ansi-regex": "^6.2.2" } }, "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w=="],
-
-    "archiver-utils/glob/jackspeak/@isaacs/cliui/wrap-ansi": ["wrap-ansi@8.1.0", "", { "dependencies": { "ansi-styles": "^6.1.0", "string-width": "^5.0.1", "strip-ansi": "^7.0.1" } }, "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ=="],
-
     "archiver-utils/glob/minimatch/brace-expansion/balanced-match": ["balanced-match@1.0.2", "", {}, "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="],
 
     "archiver-utils/glob/jackspeak/@isaacs/cliui/string-width/emoji-regex": ["emoji-regex@9.2.2", "", {}, "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg=="],
-
-    "archiver-utils/glob/jackspeak/@isaacs/cliui/strip-ansi/ansi-regex": ["ansi-regex@6.2.2", "", {}, "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg=="],
-
-    "archiver-utils/glob/jackspeak/@isaacs/cliui/wrap-ansi/ansi-styles": ["ansi-styles@6.2.3", "", {}, "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg=="],
   }
 }

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     },
     "catalogs": {
       "computesdk": {
+        "@blaxel/core": "0.2.95",
         "@computesdk/blaxel": "1.6.16",
         "@computesdk/daytona": "1.7.31",
         "@computesdk/e2b": "1.7.51",

--- a/packages/harness/src/index.ts
+++ b/packages/harness/src/index.ts
@@ -277,7 +277,18 @@ export async function runSuiteOnSandbox(
 		const runner = new StepRunner(sandbox, transport, undefined, suite.ptsTimesToRun);
 		runner.phase = "setup";
 		if (suite.minDiskGb) {
-			const df = await runner.run("check free disk", "df -Pk / | awk 'NR==2 {print $4}'", MIN);
+			// Measure free space where the disk-heavy suites actually write, not the sandbox root. The
+			// heavy PTS data (realworld clones/builds, pgbench cluster, fio test files, installed-tests)
+			// lives under the PTS data dir; on Blaxel a 40 GiB volume is mounted there while / stays a
+			// small RAM-overlay tmpfs, so gating on `/` would wrongly skip suites the volume has room for.
+			// The dir exists on every baked-image provider (on the root fs → identical to `/`) and on
+			// Blaxel (the mount); it's absent only pre-PTS on a stock gVisor root (Modal), where the `/`
+			// fallback preserves today's behavior.
+			const df = await runner.run(
+				"check free disk",
+				'd=/var/lib/phoronix-test-suite; [ -d "$d" ] || d=/; df -Pk "$d" | awk \'NR==2 {print $4}\'',
+				MIN,
+			);
 			// Treat non-numeric df output as 0 free (skip) — a NaN comparison would silently pass the check.
 			const freeKb = Number.parseInt((df.stdout || "").trim(), 10);
 			const freeGb = Number.isNaN(freeKb) ? 0 : freeKb / 1024 / 1024;

--- a/packages/harness/src/lib/setup.ts
+++ b/packages/harness/src/lib/setup.ts
@@ -173,10 +173,15 @@ export const OBSERVED_SPECS_SCRIPT = [
 	"if [ -f /sys/fs/cgroup/memory.max ] && grep -qv max /sys/fs/cgroup/memory.max; then",
 	`  memory_gb=$(awk '{ printf "%.2f", $1 / 1073741824 }' /sys/fs/cgroup/memory.max) && limited=1`,
 	"fi",
-	// gVisor (Modal) reports / as 2^63 bytes — a "no limit" sentinel, not a size. Emit diskGb only
+	// Report the disk the benchmark actually writes to, not the sandbox root: the PTS data dir when it
+	// exists (on Blaxel that's the mounted 40 GiB volume; on baked-image providers it's on the root fs,
+	// so identical to `/`), else `/` (a stock gVisor root pre-PTS — Modal). Keep this dir in sync with
+	// the harness disk gate and the blaxel volume mount path.
+	`disk_src=/var/lib/phoronix-test-suite; [ -d "$disk_src" ] || disk_src=/`,
+	// gVisor (Modal) reports the root as 2^63 bytes — a "no limit" sentinel, not a size. Emit diskGb only
 	// when df's answer is plausible for a sandbox (positive, < 100 TB); a sentinel, a failed df, or
 	// a non-numeric column all leave it unset as unknown.
-	`disk_gb=$(df -Pk / | awk 'NR==2 && $2 + 0 > 0 && $2 / 1048576 < 100000 { printf "%.1f", $2 / 1048576 }')`,
+	`disk_gb=$(df -Pk "$disk_src" | awk 'NR==2 && $2 + 0 > 0 && $2 / 1048576 < 100000 { printf "%.1f", $2 / 1048576 }')`,
 	`cpu_model=$(LC_ALL=C lscpu 2>/dev/null | sed -n 's/^Model name:[[:space:]]*//p' | head -1 || true)`,
 	"kernel=$(uname -r)",
 	`os=$(sed -n 's/^PRETTY_NAME=//p' /etc/os-release 2>/dev/null | tr -d '"' || true)`,

--- a/packages/providers/package.json
+++ b/packages/providers/package.json
@@ -11,6 +11,7 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
+    "@blaxel/core": "catalog:computesdk",
     "@computesdk/blaxel": "catalog:computesdk",
     "@computesdk/daytona": "catalog:computesdk",
     "@computesdk/e2b": "catalog:computesdk",

--- a/packages/providers/src/lib/adapters.ts
+++ b/packages/providers/src/lib/adapters.ts
@@ -9,6 +9,7 @@ import { e2b } from "@computesdk/e2b";
 import { modal } from "@computesdk/modal";
 import type { ProviderId } from "@sandbox-benchmarks/schema";
 import { TARGET_SPEC } from "@sandbox-benchmarks/schema";
+import { blaxelWithVolume } from "./blaxel-volume.ts";
 import { config } from "./config.ts";
 import { e2bCommandsAsRoot } from "./e2b-root.ts";
 import { novitaCompute } from "./novita.ts";
@@ -50,12 +51,16 @@ export const adapters: Record<ProviderId, ProviderAdapter> = {
 		},
 	},
 	blaxel: {
-		// Credentials come from BL_API_KEY/BL_WORKSPACE (the factory's env fallback). The stock
-		// base-image is Alpine (no apt — PTS uninstallable) and disk is a tmpfs overlay carved from VM
-		// RAM (~78%), so boot the Debian ts-app image and buy disk with memory: 16384 MB ≈ 12.5 GiB
-		// disk. No pre-baked toolchain snapshot yet — setup steps run their fallback paths.
+		// Credentials come from BL_API_KEY/BL_WORKSPACE (the factory's env fallback). Boot the Debian
+		// ts-app image as root (the stock Alpine base-image has no apt — PTS uninstallable). Blaxel
+		// couples CPU to RAM (measured: vCPU ≈ memory_MB / 2048) and exposes no cgroup cpu.max, so
+		// memory=8192 buys the target's 8 GiB RAM but 4 vCPU (2× the 2-vCPU target) — the closest match
+		// possible, recorded as an actual and surfaced via the leaderboard comparability warning rather
+		// than silently claimed. Disk no longer rides on RAM: blaxelWithVolume mounts a 40 GiB volume at
+		// the PTS data dir where the heavy suites write (see blaxel-volume.ts), so it now clears the disk
+		// gate like the other runners. No pre-baked toolchain snapshot yet — setup steps run fallbacks.
 		createCompute: () =>
-			blaxel({ image: "blaxel/ts-app:latest", memory: 16384, region: "us-pdx-1" }),
+			blaxelWithVolume(blaxel({ image: "blaxel/ts-app:latest", memory: 8192, region: "us-pdx-1" })),
 		createOptions: {},
 	},
 	modal: {

--- a/packages/providers/src/lib/blaxel-volume.ts
+++ b/packages/providers/src/lib/blaxel-volume.ts
@@ -1,0 +1,163 @@
+// Blaxel is the one provider that cannot express disk independently of RAM: its sandbox root is a
+// RAM-overlay tmpfs (~50-80% of memory), and the control plane silently ignores the documented
+// `storageMb`/`diskPercent` knobs on this plan (verified: they pass validation but never resize the
+// root). The @computesdk/blaxel wrapper's config only exposes image/memory/region/ports, so there is
+// no create-time disk option to pin either. The only mechanism that yields real disk decoupled from
+// RAM is a durable Volume mounted at a path — so this module provisions one per sandbox and mounts it
+// where the benchmark's heavy writes actually land.
+//
+// Every disk-heavy suite (the realworld repo clones/builds — mastra ~30 GiB, openclaw ~25 GiB — plus
+// pgbench's ~1.5 GiB cluster, fio's test files, and all PTS installed-tests) writes under PTS's data
+// dir, which resolves to /var/lib/phoronix-test-suite once PTS_USER_PATH_OVERRIDE is active (see
+// packages/harness/src/lib/execute.ts and lib/bench.sh). Mounting the volume there both hands those
+// suites their 40 GiB AND makes the override's `[ -d /var/lib/phoronix-test-suite ]` guard true from
+// boot, so PTS deterministically writes onto the volume. The sandbox root stays a small tmpfs — fine,
+// since only the light repo checkout lives there.
+//
+// A Blaxel volume attaches to exactly one sandbox at a time, and concurrent replicate/suite jobs share
+// this account, so a shared volume name would collide. Each sandbox therefore gets its own uniquely-
+// named volume, created just before it and deleted just after — patched onto the provider's
+// create/destroy the same clone-the-method-table way e2b-root patches runCommand, so nothing re-wraps
+// the SDK.
+
+import { randomUUID } from "node:crypto";
+import type { SandboxInstance } from "@blaxel/core";
+import { initialize, VolumeInstance } from "@blaxel/core";
+import type { BlaxelConfig } from "@computesdk/blaxel";
+import type { SandboxMethods } from "@computesdk/provider";
+import { TARGET_SPEC } from "@sandbox-benchmarks/schema";
+import type { CreateSandboxOptions } from "computesdk";
+import type { DirectProvider } from "./types.ts";
+
+// The absolute path PTS writes all heavy data to. Must equal the PTS_USER_PATH_OVERRIDE value the
+// harness preamble exports (packages/harness/src/lib/execute.ts) and the disk-measurement path the gate
+// + observed-specs probe use — keep the three in lockstep.
+const PTS_DATA_DIR = "/var/lib/phoronix-test-suite";
+
+// Volume capacity, in MB (Blaxel's unit): the shared target spec's disk, so Blaxel matches the other
+// runners' 40 GiB rather than the RAM-derived sliver it got before.
+const VOLUME_SIZE_MB = TARGET_SPEC.diskGb * 1024;
+
+// Volume-name prefix; the random suffix keeps concurrent sandboxes on distinct volumes.
+const VOLUME_PREFIX = "sbx-bench";
+
+type BlaxelSandboxMethods = SandboxMethods<SandboxInstance, BlaxelConfig>;
+type BlaxelCreate = BlaxelSandboxMethods["create"];
+type BlaxelDestroy = BlaxelSandboxMethods["destroy"];
+
+interface PatchableManager {
+	methods: Record<string, unknown> & { create: BlaxelCreate; destroy: BlaxelDestroy };
+}
+
+function patchableManager(provider: DirectProvider): PatchableManager {
+	const manager = provider.sandbox as unknown as { methods?: Record<string, unknown> };
+	if (
+		typeof manager.methods?.create !== "function" ||
+		typeof manager.methods?.destroy !== "function"
+	) {
+		throw new Error(
+			"@computesdk/blaxel provider internals changed shape (sandbox manager has no patchable " +
+				"create/destroy methods); revisit the volume adapter against the upgraded wrapper",
+		);
+	}
+	return manager as PatchableManager;
+}
+
+/** Initialize the raw Blaxel SDK so VolumeInstance calls carry auth — the wrapper only does this inside
+ *  its own create, and the volume is provisioned before that runs. Mirrors the wrapper's credential
+ *  fallback (config, else BL_API_KEY/BL_WORKSPACE); idempotent, so the wrapper re-initializing is fine. */
+function ensureBlaxelInitialized(config: BlaxelConfig): void {
+	initialize({
+		apikey: config.apiKey ?? process.env.BL_API_KEY,
+		workspace: config.workspace ?? process.env.BL_WORKSPACE,
+	});
+}
+
+/** Best-effort volume teardown. After the sandbox is deleted its volume's `attachedTo` clears
+ *  asynchronously, so a delete issued immediately can fail as still-attached — retry with backoff, then
+ *  give up with a warning. Teardown must never fail a Run, so a leaked volume is logged, not thrown. */
+async function deleteVolumeWithRetry(name: string): Promise<void> {
+	const BACKOFF_MS = [1_000, 3_000, 5_000, 8_000];
+	for (let attempt = 0; ; attempt++) {
+		try {
+			await VolumeInstance.delete(name);
+			return;
+		} catch (err) {
+			if (attempt >= BACKOFF_MS.length) {
+				console.warn(
+					`[blaxel] volume ${name} not deleted after ${attempt + 1} attempts ` +
+						`(${err instanceof Error ? err.message : String(err)}); may need manual cleanup`,
+				);
+				return;
+			}
+			await new Promise((r) => setTimeout(r, BACKOFF_MS[attempt]));
+		}
+	}
+}
+
+/**
+ * Patch one Blaxel provider instance so every sandbox it creates gets a dedicated {@link VOLUME_SIZE_MB}
+ * MB volume mounted at {@link PTS_DATA_DIR}, torn down with the sandbox. Clones and mutates only this
+ * instance's method table (never the wrapper's shared one).
+ */
+export function blaxelWithVolume(provider: DirectProvider): DirectProvider {
+	const manager = patchableManager(provider);
+	const originalCreate = manager.methods.create;
+	const originalDestroy = manager.methods.destroy;
+	// sandboxId → its volume name, so destroy tears down exactly the volume create provisioned. The
+	// wrapper drops any `name` we pass (it destructures it out), so the sandbox id can't be pinned to the
+	// volume name a priori; one entry per live sandbox, cleared on destroy.
+	const sandboxVolumes = new Map<string, string>();
+
+	const create: BlaxelCreate = async (config, options) => {
+		ensureBlaxelInitialized(config);
+		const volumeName = `${VOLUME_PREFIX}-${randomUUID().slice(0, 8)}`;
+		await VolumeInstance.createIfNotExists({
+			name: volumeName,
+			size: VOLUME_SIZE_MB,
+			region: config.region,
+		});
+		try {
+			const result = await originalCreate(config, {
+				...options,
+				// `volumes` isn't in the wrapper's destructured-out set, so it rides through to the raw SDK's
+				// createIfNotExists. Prepend ours; keep any caller-supplied bindings (there are none today).
+				volumes: [
+					{ name: volumeName, mountPath: PTS_DATA_DIR },
+					...(Array.isArray(options?.volumes) ? options.volumes : []),
+				],
+			} as CreateSandboxOptions);
+			sandboxVolumes.set(result.sandboxId, volumeName);
+			return result;
+		} catch (err) {
+			// The sandbox never came up — don't leak the volume just provisioned for it.
+			await deleteVolumeWithRetry(volumeName);
+			throw err;
+		}
+	};
+
+	const destroy: BlaxelDestroy = async (config, sandboxId) => {
+		ensureBlaxelInitialized(config);
+		try {
+			await originalDestroy(config, sandboxId);
+		} finally {
+			const volumeName = sandboxVolumes.get(sandboxId);
+			if (volumeName) {
+				sandboxVolumes.delete(sandboxId);
+				await deleteVolumeWithRetry(volumeName);
+			} else {
+				// No volume tracked for this sandbox in THIS process, so we can't name one to delete: the
+				// map was lost to a process restart between create and teardown, or this sandbox came from
+				// a getById/pre-patch path. Surface it like the other leak paths above so an operator can
+				// sweep any orphaned volume by name — an in-process map can't collect a cross-process leak.
+				console.warn(
+					`[blaxel] destroy(${sandboxId}): no volume tracked in this process; ` +
+						`if it was created here, look for an orphaned ${VOLUME_PREFIX}-* volume to delete`,
+				);
+			}
+		}
+	};
+
+	manager.methods = { ...manager.methods, create, destroy };
+	return provider;
+}

--- a/packages/results/src/lib/leaderboard.test.ts
+++ b/packages/results/src/lib/leaderboard.test.ts
@@ -140,7 +140,10 @@ describe("buildLeaderboard", () => {
 		const blaxel = {
 			...provider("blaxel", [metric("node_web_tooling_runs_per_s", [10])]),
 			specMatched: false,
-			observedSpecs: { vcpus: 6, memoryGb: 15.63, diskGb: 12.5 },
+			// Blaxel's real observed shape: memory=8192 pins the 8 GiB RAM target and a mounted volume the
+			// 40 GiB disk, but CPU is coupled to RAM so it lands at 4 vCPU (2x the 2-vCPU target) — enough
+			// to keep specMatched false and fire the comparability warning below.
+			observedSpecs: { vcpus: 4, memoryGb: 8, diskGb: 40 },
 		};
 		const board = buildLeaderboard(run([blaxel]));
 		expect(board.targetSpec).toEqual({ vcpus: 2, memoryGb: 8, diskGb: 20 });
@@ -153,7 +156,7 @@ describe("buildLeaderboard", () => {
 		expect(md).toContain(
 			"**Comparability warning:** Blaxel's observed compute did not match the requested CPU/RAM target",
 		);
-		expect(md).toContain("**6 vCPU · 15.63 GiB RAM · 12.5 GB disk**");
+		expect(md).toContain("**4 vCPU · 8 GiB RAM · 40 GB disk**");
 		expect(md).not.toContain("Same pinned target");
 	});
 });

--- a/packages/schema/src/providers.ts
+++ b/packages/schema/src/providers.ts
@@ -120,10 +120,12 @@ export interface ProviderMeta {
  *
  * Providers that expose a per-sandbox/snapshot disk get 40 GiB (Daytona, via the snapshot's
  * `resources.disk`); Modal has no disk knob but its gVisor root reports effectively unbounded disk,
- * so it clears the gate anyway. Providers that CANNOT express disk — e2b/novita (the `@e2b/cli`
- * `template create` takes only `--cpu-count`/`--memory-mb`) and blaxel (disk is a RAM-derived tmpfs)
- * — run with actuals recorded, and the heavy suites that need the disk skip there. Those skips are
- * surfaced as an explicit coverage gap in the leaderboard, never silently dropped.
+ * so it clears the gate anyway. Blaxel's sandbox root is a RAM-derived tmpfs with no independent disk
+ * knob, so it mounts a 40 GiB volume at the PTS data dir where the heavy suites write (see
+ * packages/providers/src/lib/blaxel-volume.ts) — clearing the gate like the others. Only e2b/novita
+ * still CANNOT express disk (the `@e2b/cli` `template create` takes only `--cpu-count`/`--memory-mb`):
+ * they run with actuals recorded and the heavy suites skip there, surfaced as an explicit coverage gap
+ * in the leaderboard, never silently dropped.
  */
 export const TARGET_SPEC = { vcpus: 2, memoryGb: 8, diskGb: 40 } as const;
 
@@ -218,7 +220,7 @@ const REGISTRY: Record<ProviderId, Omit<ProviderMeta, "id">> = {
 		isolation: {
 			technology: "microVM",
 			notes:
-				"Blaxel sandboxes (sub-25ms boot claim). Spec dimensions are COUPLED: CPU cores = memory MB / 2048 and disk is a tmpfs overlay at ~78% of memory, so the 2 vCPU / 8 GiB / 40 GB target spec is inexpressible -- the adapter runs oversized (16 GiB => 8-core allocation, ~12.5 GiB disk) and relies on observed-specs disclosure (specMatched=false) downstream.",
+				"Blaxel sandboxes (sub-25ms boot claim). CPU is COUPLED to RAM (measured: cores = memory MB / 2048) with no cgroup cpu.max, and the sandbox root is a RAM-overlay tmpfs with no independent disk knob (storageMb/diskPercent are accepted but silently ignored on this plan). So the adapter pins memory=8192 -> 8 GiB RAM (matches target) but 4 vCPU (2x the 2-vCPU target), and mounts a 40 GiB volume at the PTS data dir for disk (see blaxel-volume.ts). Disk and RAM match the target; the 4-vCPU overshoot is recorded via observed-specs disclosure (specMatched=false) downstream.",
 		},
 		pricing: {
 			model: "unknown",
@@ -228,10 +230,11 @@ const REGISTRY: Record<ProviderId, Omit<ProviderMeta, "id">> = {
 		maturity: {
 			status: "beta",
 			notes:
-				"Local e2e validation wiring; not yet a committed run. Realworld suites with minDiskGb > ~12.5 (mastra 30, openclaw 25) skip on the harness disk gate until Blaxel exposes disk independently of memory.",
+				"Local e2e validation wiring; not yet a committed run. The 40 GiB volume (mounted at the PTS data dir) now lets the realworld suites (mastra 30, openclaw 25) clear the disk gate instead of skipping; the remaining spec deviation is CPU (4 vCPU vs the 2-vCPU target, from Blaxel's memory/CPU coupling).",
 		},
-		// Values ARE settable, but the CPU/disk coupling makes the shared target spec unreachable --
-		// "fixed" is the honest capability for cross-provider comparability purposes.
+		// Disk and RAM are now pinned to the target (40 GiB volume + memory=8192), but CPU stays coupled
+		// to RAM -- 2 vCPU AND 8 GiB RAM is unreachable -- so "fixed" remains the honest capability for
+		// cross-provider comparability purposes.
 		specPinning: "fixed",
 		transport: {
 			// `@computesdk/blaxel` execs through the sandbox gateway; long synchronous execs are not


### PR DESCRIPTION
## Summary

Give Blaxel the shared **8 GiB RAM · 40 GB** target disk the way every other runner has it, by mounting a **40 GiB volume** instead of inflating RAM. This lets Blaxel's disk-heavy suites run instead of skipping. NOTE: blaxel controls cores so this still might be a 4 vCPU machine

## Why

Blaxel can't express disk independently of RAM — the sandbox root is a RAM-overlay tmpfs. The old adapter inflated `memory` to **16384 MB** just to buy ~12.5 GiB of tmpfs disk. Two problems fell out of that:

- It silently ran the benchmark at **6 vCPU / 15.6 GiB RAM / 12.5 GiB disk** — off-target on _every_ axis (Blaxel derives CPU from memory, and exposes no `cpu.max`, so observed-specs read `nproc`).
- It still wasn't enough disk: the realworld suites (`mastra` needs 30 GiB, `openclaw` 25 GiB) skipped the disk gate.

I evaluated the alternatives against the live API before landing the volume:

- **`storageMb`** **(disk-backed root fs).** Real and documented, but **no published** **`@blaxel/core`** **(≤ 0.3.3) forwards it** — the SDK rebuilds the request from a hardcoded whitelist and drops it. Even hand-injecting a raw `spec.runtime.storageMb`/`diskPercent` past the whitelist: the API accepts it (no 400) and silently ignores it — root stays a RAM tmpfs. Unusable today.
- **Volume** — the only mechanism that yields real disk decoupled from RAM. ✅

## What changed

| File | Change |
| --- | --- |
| `packages/providers/src/lib/blaxel-volume.ts`_(new)_ | `blaxelWithVolume` patches the provider's `create`/`destroy` (same clone-the-method-table seam as `e2b-root.ts`) to provision a **per-sandbox 40 GiB volume** mounted at `/var/lib/phoronix-test-suite`, deleted on teardown (retried, best-effort — a leaked volume never fails a run). Each sandbox gets its own uniquely-named volume, since a Blaxel volume attaches to one sandbox at a time. |
| `packages/providers/src/lib/adapters.ts` | Wrap `blaxel(...)` in `blaxelWithVolume`; **`memory`** **16384 → 8192** (drop the disk-via-RAM inflation). |
| `packages/harness/src/index.ts`, `.../lib/setup.ts` | Disk gate + observed-specs probe now measure the **PTS data dir** when present (the volume on Blaxel; the root fs elsewhere → identical to `/`), else `/`. |
| `packages/schema/src/providers.ts` | Blaxel comments/comparability notes: disk-via-volume, the 4-vCPU coupling. |
| `packages/results/src/lib/leaderboard.test.ts` | Refresh the synthetic Blaxel fixture to the new observed shape (`4 / 8 / 40`). |
| `package.json`, `packages/providers/package.json`, `bun.lock` | Add `@blaxel/core@0.2.95` as a direct dep (volume ops need the raw SDK). No version bumps. |

## The one unavoidable deviation: CPU

Blaxel couples CPU to RAM (measured: `vCPU ≈ memory_MB / 2048`), so **2 vCPU** **_and_** **8 GiB RAM is impossible**. `memory=8192` pins the 8 GiB RAM target but lands at **4 vCPU** — the closest reachable point. This is recorded as an observed actual and surfaced through the existing leaderboard **comparability warning** (`specMatched=false`), not silently claimed. It's still strictly better than the old 6 vCPU / 15.6 GiB.

## Downstream (analysis / leaderboard)

No logic change needed — the layer is data-driven:

- `computeSpecMatched` reads observed specs (compares vCPU exactly + RAM ±10%, **excludes disk**). Blaxel stays `specMatched=false`, now via the vCPU axis only (RAM matches) — the comparability warning still fires.
- `LEADERBOARD.md` is generated from committed run data ("do not edit by hand") and self-corrects when a fresh Blaxel run is committed (mastra/openclaw disk-skip rows drop; the warning's numbers update). Historical run JSON is left untouched.

## Verification

Exercised the **real adapter path** (`providers.find("blaxel").createCompute()` → wrapper → volume patch → create/destroy) against the live API:

- `/var/lib/phoronix-test-suite` = **40 GB**, writable; root stays 6.2 GB tmpfs
- `nproc=4`, RAM `7.77 GiB` (memory=8192)
- observed-specs reports **`diskGb=40`**; disk gate sees **40 GB free** → realworld suites (30/25 GiB) now clear the gate
- volume **cleaned up on destroy** (no leak)
- **mastra realworld disk gate: 40 GiB free ≥ 30 GiB → PASS**, verified live through the real
harness executor (`StepRunner`) + our `realworld-runner.sh` — the exact path that previously
skipped. The full cold `pnpm install` + lint is a ~20–40 min job best validated in CI (a bench
run for `blaxel` / `realworld-mastra`); the local run confirmed boot + gate + toolchain setup.

## Checks

- `bun run typecheck` ✅ · `bun run lint` ✅ · `bun run check:catalog-drift` ✅
- Tests: schema 239 · results 171 · providers 16 · harness 83 · cli 131 · templates 29 · repo-checks 145 — **0 fail**

## Review

- Addressed Greptile P2: `destroy` now warns when it finds no tracked volume for a sandbox (process-restart / `getById` teardown), so an orphaned `sbx-bench-*` volume is auditable rather than silently skipped.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Mounts a per-sandbox 40 GiB volume on Blaxel and sets RAM to 8 GiB so disk‑heavy suites run instead of skipping. CPU remains coupled to RAM and observes 4 vCPU; the leaderboard warns about the mismatch.

- **New Features**
  - Added `blaxelWithVolume` to provision and attach a 40 GiB volume at /var/lib/phoronix-test-suite with best‑effort teardown (via `@blaxel/core@0.2.95`).
  - Reduced memory from 16384 MB to 8192 MB; disk gate and observed-specs now measure the PTS data dir so the volume is detected.

- **Bug Fixes**
  - Warn when `destroy` finds no tracked volume to surface possible orphaned `sbx-bench-*` volumes.

<sup>Written for commit c463232a6e6868040e28e86dacac2f0daed71b3a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/starslingdev/hpc-sandbox-benchmarks/pull/207?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Blaxel compute environments now provide dedicated persistent storage for benchmark data.
  * Benchmark disk-space checks now use the filesystem where test data is stored, improving suite eligibility and reported capacity.

* **Bug Fixes**
  * Prevented benchmarks from being skipped or misreported when test data resides on a separate mounted volume.

* **Documentation**
  * Updated provider notes to reflect Blaxel’s storage support and remaining hardware specification differences.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->