### PR TITLE
feat(schema): raise target spec to 4 vCPU / 8 GiB / 40 GB

### DIFF
--- a/docs/methodology.md
+++ b/docs/methodology.md
@@ -11,9 +11,10 @@ schema-validated dataset.
 
 ## Target spec
 
-Every provider is created at one pinned [`TARGET_SPEC`](../packages/schema/src/providers.ts): **2 vCPU,
-8 GiB RAM, 40 GB disk**. It's sized to fit inside every provider's reproducible envelope (E2B caps
-sandbox RAM at 8 GiB), so anyone can rerun on the same shape. A provider that can't express a dimension
+Every provider is created at one pinned [`TARGET_SPEC`](../packages/schema/src/providers.ts): **4 vCPU,
+8 GiB RAM, 40 GB disk**. 8 GiB RAM fits inside every provider's reproducible envelope (E2B caps sandbox
+RAM at 8 GiB); vCPU is pinned at 4 because Blaxel couples CPU to RAM (8 GiB forces 4 vCPU there), so
+targeting 4 lets every provider — Blaxel included — match on the same shape. A provider that can't express a dimension
 runs with its actuals recorded and the mismatch disclosed (`specMatched`). Its measurements stay in the
 rankings, but the leaderboard flags the provider with an explicit **Comparability warning** naming its
 observed allocation, so its ranks are never read as like-for-like with the compute-matched providers.
@@ -60,7 +61,7 @@ enriches a provider that already produced ≥1 measured metric — it never prom
 - **Host** (`hostVcpus`/`hostMemoryGb`/`cpuModel`/…) — the underlying machine, parsed from the PTS
   composite's `<System>` block.
 
-In a container `<System>` discloses the **host** (e.g. a 48-thread EPYC), not the 2-vCPU sandbox quota.
+In a container `<System>` discloses the **host** (e.g. a 48-thread EPYC), not the 4-vCPU sandbox quota.
 The normalizer therefore maps `<System>` only to the host side and merges it **under** the spec probe,
 so a host disclosure can never masquerade as the sandbox's effective size. Forensic logs are captured as
 a `*--forensics.tar.gz` tarball (a tarball, not loose files, so nested `.xml` can't be misrouted).

--- a/packages/providers/src/lib/adapters.ts
+++ b/packages/providers/src/lib/adapters.ts
@@ -54,11 +54,12 @@ export const adapters: Record<ProviderId, ProviderAdapter> = {
 		// Credentials come from BL_API_KEY/BL_WORKSPACE (the factory's env fallback). Boot the Debian
 		// ts-app image as root (the stock Alpine base-image has no apt — PTS uninstallable). Blaxel
 		// couples CPU to RAM (measured: vCPU ≈ memory_MB / 2048) and exposes no cgroup cpu.max, so
-		// memory=8192 buys the target's 8 GiB RAM but 4 vCPU (2× the 2-vCPU target) — the closest match
-		// possible, recorded as an actual and surfaced via the leaderboard comparability warning rather
-		// than silently claimed. Disk no longer rides on RAM: blaxelWithVolume mounts a 40 GiB volume at
-		// the PTS data dir where the heavy suites write (see blaxel-volume.ts), so it now clears the disk
-		// gate like the other runners. No pre-baked toolchain snapshot yet — setup steps run fallbacks.
+		// memory=8192 yields the target's 8 GiB RAM and 4 vCPU — the target pins vCPU at 4 precisely so
+		// Blaxel's coupled point matches on effective vCPU/memory (specMatched=true), no comparability
+		// caveat. Disk is separate: blaxelWithVolume mounts a 40 GiB volume at
+		// the PTS data dir where the heavy suites write (see blaxel-volume.ts), so it clears the disk
+		// gate like the other runners (not part of the specMatched check). No pre-baked toolchain
+		// snapshot yet — setup steps run fallbacks.
 		createCompute: () =>
 			blaxelWithVolume(blaxel({ image: "blaxel/ts-app:latest", memory: 8192, region: "us-pdx-1" })),
 		createOptions: {},

--- a/packages/results/src/lib/__fixtures__/daytona/observed-specs.json
+++ b/packages/results/src/lib/__fixtures__/daytona/observed-specs.json
@@ -1,7 +1,7 @@
 {
-  "vcpus": 2,
+  "vcpus": 4,
   "memoryGb": 8,
-  "diskGb": 20,
+  "diskGb": 40,
   "hostVcpus": 48,
   "hostMemoryGb": 377,
   "kernel": "6.8.0-generic",

--- a/packages/results/src/lib/specs.test.ts
+++ b/packages/results/src/lib/specs.test.ts
@@ -236,31 +236,31 @@ describe("readObservedSpecs: jc probe fallback (edge shapes)", () => {
 	});
 });
 
-describe("computeSpecMatched (target: 2 vCPU / 8 GB ±10%)", () => {
+describe("computeSpecMatched (target: 4 vCPU / 8 GB ±10%)", () => {
 	it("undefined when vcpus or memoryGb is unobserved — no judging partial evidence", () => {
 		expect(computeSpecMatched({})).toBeUndefined();
-		expect(computeSpecMatched({ vcpus: 2 })).toBeUndefined();
+		expect(computeSpecMatched({ vcpus: 4 })).toBeUndefined();
 		expect(computeSpecMatched({ memoryGb: 8 })).toBeUndefined();
 		// Other fields don't substitute for the required pair.
-		expect(computeSpecMatched({ hostVcpus: 2, hostMemoryGb: 8 })).toBeUndefined();
+		expect(computeSpecMatched({ hostVcpus: 4, hostMemoryGb: 8 })).toBeUndefined();
 	});
 
 	it("exact target matches", () => {
-		expect(computeSpecMatched({ vcpus: 2, memoryGb: 8 })).toBe(true);
+		expect(computeSpecMatched({ vcpus: 4, memoryGb: 8 })).toBe(true);
 	});
 
 	it("memory within ±10% still matches (kernels reserve some)", () => {
-		expect(computeSpecMatched({ vcpus: 2, memoryGb: 7.5 })).toBe(true);
-		expect(computeSpecMatched({ vcpus: 2, memoryGb: 8.5 })).toBe(true);
+		expect(computeSpecMatched({ vcpus: 4, memoryGb: 7.5 })).toBe(true);
+		expect(computeSpecMatched({ vcpus: 4, memoryGb: 8.5 })).toBe(true);
 	});
 
 	it("memory beyond the tolerance fails", () => {
-		expect(computeSpecMatched({ vcpus: 2, memoryGb: 4 })).toBe(false);
-		expect(computeSpecMatched({ vcpus: 2, memoryGb: 16 })).toBe(false);
+		expect(computeSpecMatched({ vcpus: 4, memoryGb: 4 })).toBe(false);
+		expect(computeSpecMatched({ vcpus: 4, memoryGb: 16 })).toBe(false);
 	});
 
 	it("vCPUs must match exactly", () => {
-		expect(computeSpecMatched({ vcpus: 4, memoryGb: 8 })).toBe(false);
-		expect(computeSpecMatched({ vcpus: 1, memoryGb: 8 })).toBe(false);
+		expect(computeSpecMatched({ vcpus: 2, memoryGb: 8 })).toBe(false);
+		expect(computeSpecMatched({ vcpus: 8, memoryGb: 8 })).toBe(false);
 	});
 });

--- a/packages/schema/src/economics.ts
+++ b/packages/schema/src/economics.ts
@@ -55,7 +55,7 @@ export const economicsMetrics: MetricDef[] = [
 		headline: true,
 		label: "Hourly cost",
 		description:
-			"USD per hour to run a sandbox at the pinned target spec (2 vCPU / 8 GiB), from the provider's published per-vCPU/per-GiB rates. The price/performance denominator; null-rated providers emit nothing.",
+			"USD per hour to run a sandbox at the pinned target spec (4 vCPU / 8 GiB), from the provider's published per-vCPU/per-GiB rates. The price/performance denominator; null-rated providers emit nothing.",
 		derived: true,
 	},
 	{

--- a/packages/schema/src/providers.ts
+++ b/packages/schema/src/providers.ts
@@ -111,10 +111,16 @@ export interface ProviderMeta {
 }
 
 /**
- * The pinned cross-provider target spec: 2 vCPU, 8 GiB RAM, 40 GB disk. vCPU/RAM are sized to fit
- * inside every provider's reproducible envelope — E2B caps sandbox RAM at 8 GiB — so anyone can rerun
- * the benchmark on the same shape. Disk is sized for the realworld suites' working set instead: a
- * cold monorepo install + full build needs ~30 GiB free (mastra's `minDiskGb`), and at 20 GB a
+ * The pinned cross-provider target spec: 4 vCPU, 8 GiB RAM, 40 GB disk. Every provider is created at
+ * this exact shape so the numbers are like-for-like. 8 GiB RAM fits inside every provider's
+ * reproducible envelope (E2B caps sandbox RAM at 8 GiB). vCPU is pinned at 4 because Blaxel couples
+ * CPU to RAM (cores = memory_MB / 2048, no independent knob), so 8 GiB RAM there forces exactly 4
+ * vCPU — targeting 4 lets Blaxel match on every axis instead of carrying a permanent comparability
+ * caveat, while the others set 4 vCPU directly (Modal per-create; e2b/daytona/novita at bake time).
+ * This assumes every provider can provision 4 vCPU at 8 GiB; one that can't would flip to mismatched,
+ * so re-verify each provider's observed vCPU after a bump. Disk, by contrast, is sized for the
+ * realworld suites' working set: a cold monorepo install + full build needs ~30 GiB free (mastra's
+ * `minDiskGb`), and at 20 GB a
  * Daytona sandbox had only 16.7 GiB free, silently skipping mastra/openclaw. Disk is NOT a comparison
  * axis and is excluded from {@link hourlyCostAtTargetSpec}, so a larger disk can't bias the ranking.
  *
@@ -127,7 +133,7 @@ export interface ProviderMeta {
  * they run with actuals recorded and the heavy suites skip there, surfaced as an explicit coverage gap
  * in the leaderboard, never silently dropped.
  */
-export const TARGET_SPEC = { vcpus: 2, memoryGb: 8, diskGb: 40 } as const;
+export const TARGET_SPEC = { vcpus: 4, memoryGb: 8, diskGb: 40 } as const;
 
 /**
  * The registry, keyed by {@link ProviderId} — the inspiration is the harness adapter map, which
@@ -220,7 +226,7 @@ const REGISTRY: Record<ProviderId, Omit<ProviderMeta, "id">> = {
 		isolation: {
 			technology: "microVM",
 			notes:
-				"Blaxel sandboxes (sub-25ms boot claim). CPU is COUPLED to RAM (measured: cores = memory MB / 2048) with no cgroup cpu.max, and the sandbox root is a RAM-overlay tmpfs with no independent disk knob (storageMb/diskPercent are accepted but silently ignored on this plan). So the adapter pins memory=8192 -> 8 GiB RAM (matches target) but 4 vCPU (2x the 2-vCPU target), and mounts a 40 GiB volume at the PTS data dir for disk (see blaxel-volume.ts). Disk and RAM match the target; the 4-vCPU overshoot is recorded via observed-specs disclosure (specMatched=false) downstream.",
+				"Blaxel sandboxes (sub-25ms boot claim). CPU is COUPLED to RAM (measured: cores = memory MB / 2048) with no cgroup cpu.max, and the sandbox root is a RAM-overlay tmpfs with no independent disk knob (storageMb/diskPercent are accepted but silently ignored on this plan). The adapter pins memory=8192 -> 8 GiB RAM and 4 vCPU (specMatched=true covers that effective vCPU/memory pair only), and mounts a 40 GiB volume at the PTS data dir so the separate disk gate clears (see blaxel-volume.ts). The target's vCPU is 4 precisely so Blaxel's coupled point lands on-spec — the dimensions stay coupled, so a different target shape would put Blaxel off-spec again.",
 		},
 		pricing: {
 			model: "unknown",
@@ -230,11 +236,13 @@ const REGISTRY: Record<ProviderId, Omit<ProviderMeta, "id">> = {
 		maturity: {
 			status: "beta",
 			notes:
-				"Local e2e validation wiring; not yet a committed run. The 40 GiB volume (mounted at the PTS data dir) now lets the realworld suites (mastra 30, openclaw 25) clear the disk gate instead of skipping; the remaining spec deviation is CPU (4 vCPU vs the 2-vCPU target, from Blaxel's memory/CPU coupling).",
+				"Local e2e validation wiring; not yet a committed run. memory=8192 hits the 4 vCPU / 8 GiB target (specMatched=true is that vCPU/memory check only); the 40 GiB volume (mounted at the PTS data dir) separately lets the realworld suites (mastra 30, openclaw 25) clear the disk gate instead of skipping.",
 		},
-		// Disk and RAM are now pinned to the target (40 GiB volume + memory=8192), but CPU stays coupled
-		// to RAM -- 2 vCPU AND 8 GiB RAM is unreachable -- so "fixed" remains the honest capability for
-		// cross-provider comparability purposes.
+		// memory=8192 lands on the target's 8 GiB / 4 vCPU point because the target's vCPU was chosen to
+		// sit on Blaxel's RAM/CPU coupling curve (specMatched only judges that pair). The 40 GiB volume
+		// is the separate disk-gate path, not part of specMatched. The dimensions are still coupled --
+		// you can't set CPU and RAM independently -- so "fixed" remains the honest capability: this
+		// particular target is reachable, an arbitrary one would not be.
 		specPinning: "fixed",
 		transport: {
 			// `@computesdk/blaxel` execs through the sandbox gateway; long synchronous execs are not

--- a/packages/schema/src/toolchain.ts
+++ b/packages/schema/src/toolchain.ts
@@ -4,4 +4,7 @@
 // tag is immutable: a change to the toolchain image means bumping TOOLCHAIN_VERSION.
 
 export const TOOLCHAIN_IMAGE_NAME = "sandbox-benchmarks-toolchain";
-export const TOOLCHAIN_VERSION = "v2";
+// v3: the 4 vCPU / 8 GiB target spec. The e2b/daytona/novita templates are version-scoped, so this
+// bump forces new artifacts to be baked+promoted at cpu_count=4 rather than silently reusing the
+// immutable v2 templates (baked at 2 vCPU). Re-bake all providers before the runs that consume v3.
+export const TOOLCHAIN_VERSION = "v3";

--- a/packages/templates/src/pins.test.ts
+++ b/packages/templates/src/pins.test.ts
@@ -71,7 +71,7 @@ describe("@sandbox-benchmarks/templates pins", () => {
 	it("generates an e2b manifest with the version-scoped template name and TARGET_SPEC", () => {
 		const toml = e2bToml();
 		expect(toml).toContain(`template_name = "${TOOLCHAIN_IMAGE_NAME}-${TOOLCHAIN_VERSION}"`);
-		expect(toml).toContain("cpu_count = 2");
+		expect(toml).toContain("cpu_count = 4");
 		expect(toml).toContain("memory_mb = 8192");
 	});
 


### PR DESCRIPTION
> **Stacked on #207** (`blaxel-volume-disk`). Review/merge that first — this branch builds on it. Kept as a **draft** because it isn't safe to land until the re-bake + re-run below happen.

## Summary

Pin the cross-provider target spec at **4 vCPU / 8 GiB / 40 GB** (was 2 vCPU) so **every provider matches on all three axes** — including Blaxel, which #207 leaves with a CPU comparability caveat.

## Why 4 vCPU

Blaxel couples CPU to RAM (`cores = memory_MB / 2048`, no independent knob), so 8 GiB RAM forces **exactly 4 vCPU** there — 2 vCPU + 8 GiB is unreachable. Rather than carry a permanent comparability warning on Blaxel, pin the target at its only reachable point. The other providers set 4 vCPU directly:

| Provider | How 4 vCPU is applied |
|---|---|
| Modal | per-create (`cpu`/`cpuLimit` = `TARGET_SPEC.vcpus`) |
| e2b / novita | bake `--cpu-count` / `cpuCount` (e2b manifest now emits `cpu_count = 4`) |
| daytona | snapshot `resources.cpu` at bake |
| Blaxel | `memory=8192` → 4 vCPU (coupled) |

## What's in the diff

Only the spec + the things that read it or describe it — the analysis layer is data-driven and auto-adapts (`computeSpecMatched`, `hourlyCostAtTargetSpec` read `TARGET_SPEC`):

- `TARGET_SPEC.vcpus` 2 → 4, docstring rationale, Blaxel schema/adapter comments (now *matches*, no caveat), `economics.ts` + `methodology.md` target text.
- **`TOOLCHAIN_VERSION` v2 → v3** so e2b/daytona/novita get new artifacts baked at `cpu_count=4` instead of reusing the immutable 2-vCPU v2 templates.
- Tests: `computeSpecMatched` cases, the e2b manifest `cpu_count` assertion, and the daytona observed-specs fixture (2 → 4 so it stays a *matched* provider).

Full suite green (schema 239 · results 171 · providers 16 · templates 29 · harness 83 · cli 131 · repo-checks 145), lint + typecheck + catalog-drift clean.

## Feasibility — confirmed live ✅

Provisioned 4 vCPU / 8 GiB on every provider and verified the effective size:

| Provider | Result | Mechanism |
|---|---|---|
| Modal | `nproc=4` | per-create |
| Daytona | effective **4 vCPU / 8 GiB** (cgroup `cpu.max=400000/100000`; nproc leaks the shared host) | create resources |
| e2b | `nproc=4`, ~8 GiB | template built at `--cpu-count 4` |
| novita | `nproc=4`, ~8 GiB | `Template.build` `cpuCount:4` |
| Blaxel | 4 vCPU / 8 GiB | memory coupling |

No provider clamps below 4 — the target is reachable everywhere. (Orthogonal note: Daytona's *from-image* create caps disk at 10 GB; its 40 GB comes via the snapshot/bake path, unrelated to this change.)

## ⚠️ Still required before un-drafting / leaderboard

1. **Re-bake + promote v3** for e2b, daytona, and novita (Modal & Blaxel are per-create, no bake). The `TOOLCHAIN_VERSION` bump above scopes the new 4-vCPU artifacts.
2. **Re-run** the full benchmark — the committed runs were measured at 2 vCPU and become stale; `LEADERBOARD.md` regenerates from the new run. Roughly **2× the CPU cost**.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Updates**
  * Standardized sandbox target to **4 vCPUs, 8 GiB RAM, and 40 GB disk** across providers, including updated spec comparability messaging.
  * Updated pricing/metrics descriptions to reflect the **4 vCPU / 8 GiB** pinned target.
  * Ensured Blaxel environments align with the target for CPU, memory, and disk.
  * Updated generated environment manifests to request **4 vCPUs**.
  * Advanced the **toolchain version to v3**.
* **Tests**
  * Updated fixtures and spec-matching/unit tests to use the **4 vCPU** target.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->