### PR TITLE
feat(results): surface per-provider isolation in the leaderboard

### DIFF
--- a/LEADERBOARD.md
+++ b/LEADERBOARD.md
@@ -14,6 +14,21 @@ when statistically indistinguishable or tied on the median (see details below) �
 CPU/RAM comparability uses observed vCPU and RAM (±10% RAM); disk is a workload-capacity gate
 surfaced through coverage gaps, not part of the compute-match verdict.
 
+## Providers in this run
+
+Each provider's isolation technology — the **declared** technology is authoritative; **detected**
+is a best-effort in-sandbox probe that cannot separate every isolation type (a container and a
+microVM can both read `kvm`; gVisor and a microVM can both read `unknown`), shown only as a
+cross-check.
+
+| Provider | Isolation (declared) | Detected |
+| --- | --- | --- |
+| Blaxel | microVM | — |
+| Daytona (VM) | microVM (Linux VM) | — |
+| E2B | Firecracker microVM | — |
+| Modal (gVisor) | gVisor container | — |
+| Novita | microVM | — |
+
 ## cpu
 
 ### Node.js web tooling _(headline)_

--- a/packages/results/src/index.ts
+++ b/packages/results/src/index.ts
@@ -17,6 +17,7 @@ export {
 	type LeaderboardDimension,
 	type LeaderboardMetric,
 	type LeaderboardRow,
+	type ProviderRosterEntry,
 	renderLeaderboardMarkdown,
 } from "./lib/leaderboard.ts";
 export { type NormalizeInput, normalizeResultsTree } from "./lib/normalize-tree.ts";

--- a/packages/results/src/lib/leaderboard.test.ts
+++ b/packages/results/src/lib/leaderboard.test.ts
@@ -47,6 +47,61 @@ function run(providers: ProviderRun[]): Run {
 	};
 }
 
+describe("provider isolation roster", () => {
+	const HEADLINE = "node_web_tooling_runs_per_s";
+	const withDetected = (providerId: string, detectedIsolation: string): ProviderRun => ({
+		...provider(providerId, [metric(HEADLINE, [10])]),
+		observedSpecs: { detectedIsolation },
+	});
+
+	it("pairs each provider's declared isolation with the probe's detected class", () => {
+		const board = buildLeaderboard(
+			run([withDetected("daytona-vm", "vm"), withDetected("modal-gvisor", "unknown")]),
+		);
+		expect(board.roster).toEqual([
+			{
+				providerId: "daytona-vm",
+				displayName: "Daytona (VM)",
+				declaredIsolation: "microVM (Linux VM)",
+				detectedIsolation: "vm",
+				mismatch: false,
+			},
+			{
+				providerId: "modal-gvisor",
+				displayName: "Modal (gVisor)",
+				declaredIsolation: "gVisor container",
+				detectedIsolation: "unknown",
+				mismatch: false,
+			},
+		]);
+	});
+
+	it("flags a mismatch only for the reliably-distinguishable gVisor↔VM contradiction", () => {
+		const board = buildLeaderboard(
+			run([
+				// declared gVisor, detected a real VM hypervisor → the one contradiction the probe can tell
+				// apart reliably (/proc/version gVisor token vs systemd-detect-virt --vm)
+				withDetected("modal-gvisor", "vm"),
+				// declared microVM, detected "container" → the cgroup-quota heuristic also fires for a
+				// microVM, so "container" can't contradict the declaration; never a mismatch
+				withDetected("daytona-vm", "container"),
+			]),
+		);
+		expect(board.roster.map((r) => r.mismatch)).toEqual([true, false]);
+		const md = renderLeaderboardMarkdown(board);
+		expect(md).toContain("## Providers in this run");
+		expect(md).toContain("| Modal (gVisor) | gVisor container | vm ⚠ |");
+		expect(md).toContain("Isolation mismatch");
+	});
+
+	it("renders an em-dash and no mismatch banner when no isolation was detected", () => {
+		const board = buildLeaderboard(run([provider("daytona-vm", [metric(HEADLINE, [10])])]));
+		const md = renderLeaderboardMarkdown(board);
+		expect(md).toContain("| Daytona (VM) | microVM (Linux VM) | — |");
+		expect(md).not.toContain("Isolation mismatch");
+	});
+});
+
 describe("buildLeaderboard", () => {
 	it("ranks the cpu headline HIB (highest first) and includes only providers with the metric", () => {
 		const board = buildLeaderboard(

--- a/packages/results/src/lib/leaderboard.ts
+++ b/packages/results/src/lib/leaderboard.ts
@@ -120,6 +120,25 @@ export interface ComparabilityCaveat {
 }
 
 /**
+ * One provider's isolation-technology standing in a Run: what it DECLARES it runs (the authoritative
+ * per-provider fact from the schema registry) alongside what the in-sandbox probe could actually
+ * DETECT ({@link ObservedSpecs.detectedIsolation}). The two are surfaced together so the comparison
+ * discloses which isolation each measured provider used — and `mismatch` flags the rare case where a
+ * detectable signal contradicts the declaration (a bake pointed at the wrong class, say), without ever
+ * letting the unreliable probe override the declared label.
+ */
+export interface ProviderRosterEntry {
+	providerId: string;
+	displayName: string;
+	/** The schema-declared isolation technology (authoritative), or `undefined` for an unknown id. */
+	declaredIsolation: string | undefined;
+	/** The probe's coarse best-effort class ("gvisor"/"container"/"vm"/"unknown"), or `undefined`. */
+	detectedIsolation: string | undefined;
+	/** True only when the probe returned a known class that contradicts the declared technology. */
+	mismatch: boolean;
+}
+
+/**
  * How a benchmark came to produce no result for a provider — the leaderboard's outcome vocabulary.
  * The first two are RECORDED by the producer ({@link GapOutcome}); `missing` is DERIVED here, and is
  * the one a Run cannot state about itself:
@@ -161,6 +180,8 @@ export interface Leaderboard {
 	/** The requested comparison target recorded on this Run — never substituted from global config. */
 	targetSpec: TargetSpec;
 	dimensions: LeaderboardDimension[];
+	/** Every provider measured in this Run with its declared vs detected isolation, in run order. */
+	roster: ProviderRosterEntry[];
 	/** Providers explicitly recorded as failing to match {@link targetSpec}. */
 	comparabilityCaveats: ComparabilityCaveat[];
 	/** Every benchmark that produced no result somewhere, disk gaps first. Empty when coverage is complete. */
@@ -406,6 +427,53 @@ function rankMetric(run: Run, metric: MetricDef): LeaderboardRow[] {
 	return candidates.map((candidate) => candidate.row);
 }
 
+/**
+ * Collapse a declared isolation technology to the coarse class the probe can speak in: "gvisor",
+ * "container", or "vm" (or `undefined` when it doesn't map). Order matters — Modal's "gVisor
+ * container" contains both "gvisor" and "container", so gVisor is checked first; "microVM" contains
+ * "vm", so VM is checked before the bare container fallback.
+ */
+function isolationClass(declared: string | undefined): "gvisor" | "container" | "vm" | undefined {
+	if (!declared) return undefined;
+	const lower = declared.toLowerCase();
+	if (lower.includes("gvisor")) return "gvisor";
+	if (lower.includes("vm")) return "vm";
+	if (lower.includes("container")) return "container";
+	return undefined;
+}
+
+/**
+ * Build the per-provider isolation roster: declared technology (authoritative) beside the probe's
+ * best-effort detected class. A `mismatch` is flagged only when the probe returned one of the three
+ * recognized classes ("gvisor"/"container"/"vm") that disagrees with the declared one — a detected
+ * "unknown" (the common case) or any unrecognized raw value never counts, so the declaration wins.
+ */
+function buildRoster(run: Run): ProviderRosterEntry[] {
+	return run.providers.map((provider): ProviderRosterEntry => {
+		const meta = getProvider(provider.providerId);
+		const declaredIsolation = meta?.isolation.technology;
+		const detectedIsolation = provider.observedSpecs.detectedIsolation;
+		const declaredClass = isolationClass(declaredIsolation);
+		// Flag a mismatch ONLY for the one contradiction the probe can tell apart reliably: gVisor
+		// (announced in /proc/version) vs a real VM hypervisor (systemd-detect-virt --vm). The probe's
+		// "container" signal is a cgroup-quota heuristic that a microVM (Daytona's LINUX_VM exposes a
+		// bounded vCPU quota) and gVisor both trip — and gVisor *is* a container runtime — so "container"
+		// cannot contradict a declared vm/gvisor without putting a false ⚠ on a correctly-baked provider
+		// (this PR's own run.ts note says a container and a microVM can't be separated). Any other value
+		// ("unknown", or a raw systemd-detect-virt string) never counts either.
+		const mismatch =
+			(declaredClass === "gvisor" && detectedIsolation === "vm") ||
+			(declaredClass === "vm" && detectedIsolation === "gvisor");
+		return {
+			providerId: provider.providerId,
+			displayName: meta?.displayName ?? provider.providerId,
+			declaredIsolation,
+			detectedIsolation,
+			mismatch,
+		};
+	});
+}
+
 /** Build the structured leaderboard from a validated Run. Pure — Run in, ranking out. */
 export function buildLeaderboard(run: Run): Leaderboard {
 	const dimensions: LeaderboardDimension[] = [];
@@ -432,6 +500,7 @@ export function buildLeaderboard(run: Run): Leaderboard {
 		generatedAt: run.generatedAt,
 		targetSpec: run.targetSpec,
 		dimensions,
+		roster: buildRoster(run),
 		comparabilityCaveats: run.providers.flatMap((provider): ComparabilityCaveat[] =>
 			provider.specMatched === false
 				? [
@@ -578,6 +647,44 @@ function formatSpec(spec: TargetSpec | ObservedSpecs): string {
 	return parts.length > 0 ? parts.join(" · ") : "allocation not observable";
 }
 
+/**
+ * The "Providers in this run" section: a table naming each measured provider's isolation technology,
+ * so the comparison discloses WHAT each provider runs — the declared technology (authoritative) beside
+ * the probe's best-effort detected class, with ⚠ where a known detected class contradicts the
+ * declaration. Empty (no lines) when the Run recorded no providers, so an empty run stays clean.
+ */
+function rosterSection(roster: readonly ProviderRosterEntry[]): string[] {
+	if (roster.length === 0) return [];
+	const anyMismatch = roster.some((entry) => entry.mismatch);
+	const lines = [
+		"## Providers in this run",
+		"",
+		"Each provider's isolation technology — the **declared** technology is authoritative; **detected**",
+		"is a best-effort in-sandbox probe that cannot separate every isolation type (a container and a",
+		"microVM can both read `kvm`; gVisor and a microVM can both read `unknown`), shown only as a",
+		"cross-check.",
+		"",
+		"| Provider | Isolation (declared) | Detected |",
+		"| --- | --- | --- |",
+	];
+	for (const entry of roster) {
+		// Em-dash (matching `detected`) when the provider isn't in the registry, so an unregistered id
+		// reads distinctly from the probe's "unknown" detection class rather than colliding with it.
+		const declared = entry.declaredIsolation ?? "—";
+		const detected = entry.detectedIsolation ?? "—";
+		const flag = entry.mismatch ? " ⚠" : "";
+		lines.push(`| ${entry.displayName} | ${declared} | ${detected}${flag} |`);
+	}
+	lines.push("");
+	if (anyMismatch) {
+		lines.push(
+			"> **⚠ Isolation mismatch:** a provider's detected isolation contradicts its declared technology — verify its bake/create configuration.",
+			"",
+		);
+	}
+	return lines;
+}
+
 /** Render a {@link Leaderboard} as a Markdown document — the committed comparison surface. */
 export function renderLeaderboardMarkdown(board: Leaderboard): string {
 	// Render the board's OWN target, not the global constant, so the header can never claim the pinned
@@ -612,6 +719,7 @@ export function renderLeaderboardMarkdown(board: Leaderboard): string {
 		"surfaced through coverage gaps, not part of the compute-match verdict.",
 		"",
 	];
+	lines.push(...rosterSection(board.roster));
 	for (const caveat of board.comparabilityCaveats) {
 		lines.push(
 			`> **Comparability warning:** ${caveat.displayName}'s observed compute did not match the requested CPU/RAM target; its observed allocation was **${formatSpec(caveat.observedSpecs)}**. Its measured ranks are not like-for-like with compute-matched providers.`,

--- a/packages/schema/src/run.ts
+++ b/packages/schema/src/run.ts
@@ -152,6 +152,13 @@ export const observedSpecsSchema = type({
 	"kernel?": "string",
 	"os?": "string",
 	"virtualization?": "string",
+	// A coarse, best-effort classification of the isolation boundary the in-sandbox probe could
+	// actually see — "gvisor" (kernel marker), "container" (a cgroup-limited quota under a much larger
+	// disclosed host), "vm" (a self-sized machine), or "unknown". Deliberately NOT authoritative:
+	// systemd-detect-virt cannot separate a container from a microVM (both read "kvm") or gVisor from a
+	// microVM (both read "unknown"), so the declared per-provider isolation stays the source of truth
+	// and this is only a cross-check the leaderboard flags when the two disagree.
+	"detectedIsolation?": "string",
 	"user?": "string",
 	// The distinct host CPU models when merged shards of one provider disclosed more than one — the
 	// aggregate-only heterogeneity disclosure (cpuModel is the key; cpuMicroarch is derived from it).


### PR DESCRIPTION
Isolation technology was declared per provider but rendered nowhere, so
a reader could not tell which isolation each measured provider used. Add
a "Providers in this run" roster table to the leaderboard: the declared
technology (authoritative) beside a best-effort detected class, with ⚠
where a known detected class contradicts the declaration.

- schema/run.ts: optional observedSpecs.detectedIsolation (populated by
  the probe in the next PR; renders as "—" until then).
- results/leaderboard.ts: ProviderRosterEntry + Leaderboard.roster,
  buildRoster (declared vs detected, mismatch only on a KNOWN
  contradiction so the unreliable probe never overrides the declaration),
  and the rosterSection renderer.
- regenerate LEADERBOARD.md (roster section; detected column all "—").

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a “Providers in this run” roster to the leaderboard showing each provider’s declared isolation beside a best‑effort detected class. Warns only on gVisor↔VM contradictions; detection never overrides declarations.

- New Features
  - Schema: add optional `observedSpecs.detectedIsolation` in `packages/schema`.
  - Results: add `ProviderRosterEntry`, compute `Leaderboard.roster`, and re‑export `ProviderRosterEntry` from `packages/results`.
  - Rendering: add a “Providers in this run” table; show "—" when detection is missing; show a mismatch banner when any gVisor↔VM contradiction exists.
  - Tests/docs: add unit tests and regenerate `LEADERBOARD.md`.

- Bug Fixes
  - Mismatch only for gVisor↔VM; treat `container` and `unknown` as non‑contradictory and ignore raw values like `kvm` or `docker`.
  - Use an em‑dash for an unregistered provider’s declared isolation to distinguish it from the probe’s `unknown`.

<sup>Written for commit 0dcc70ad7c06e4558121cfb6c0d6554ae3a77766. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/starslingdev/hpc-sandbox-benchmarks/pull/210?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

