### PR TITLE
feat(harness): best-effort isolation detection probe

### DIFF
--- a/docs/methodology.md
+++ b/docs/methodology.md
@@ -5,9 +5,19 @@ providers and over time.
 
 ## North star
 
-Compare sandbox **providers** (`e2b` / `daytona` / `modal`), not bare-metal hardware. Every provider
-is asked to run the same workloads on the same pinned spec, and the results are normalized into one
-schema-validated dataset.
+Compare sandbox **providers**, not bare-metal hardware. Every provider is asked to run the same
+workloads on the same pinned spec, and the results are normalized into one schema-validated dataset.
+
+Where a vendor exposes more than one **isolation technology**, each is a first-class provider variant
+so the comparison attributes results to the isolation the sandbox actually used: `daytona-vm` (a
+`SandboxClass.LINUX_VM` microVM) vs `daytona-container` (a Sysbox/OCI container), and `modal-gvisor`
+(Modal's default gVisor runtime) vs `modal-vm` (Modal's gVisor-free VM runtime). Each provider's
+declared isolation is the authoritative label and is shown in the leaderboard's **Providers in this
+run** roster, beside a best-effort **detected** class from an in-sandbox probe (gVisor kernel marker;
+a cgroup quota far below the disclosed host ⇒ container; a self-sized hypervisor ⇒ VM). The probe
+cannot separate every type — a container and a microVM can both report `kvm`; gVisor and a microVM can
+both report `unknown` — so it is only a cross-check that flags a declared/detected contradiction, never
+a source of truth.
 
 ## Target spec
 

--- a/packages/harness/src/lib/setup.ts
+++ b/packages/harness/src/lib/setup.ts
@@ -186,6 +186,18 @@ export const OBSERVED_SPECS_SCRIPT = [
 	"kernel=$(uname -r)",
 	`os=$(sed -n 's/^PRETTY_NAME=//p' /etc/os-release 2>/dev/null | tr -d '"' || true)`,
 	"virt=$(systemd-detect-virt 2>/dev/null || echo unknown)",
+	// Best-effort isolation classification — a cross-check on the declared per-provider isolation, never
+	// authoritative (see run.ts observedSpecs.detectedIsolation: the probe cannot separate every type).
+	// gVisor announces itself in /proc/version; a cgroup quota well below the disclosed host means we're
+	// seeing THROUGH a container to a bigger host; a named hypervisor sized to its own host reads as a VM.
+	"detected=unknown",
+	"if grep -qi gvisor /proc/version 2>/dev/null; then",
+	"  detected=gvisor",
+	`elif [ -n "$limited" ] && awk -v h="$host_vcpus" -v v="$vcpus" 'BEGIN { exit !(h > v + 0.5) }'; then`,
+	"  detected=container",
+	`elif [ "$virt" != unknown ] && [ "$virt" != none ]; then`,
+	"  detected=vm",
+	"fi",
 	"user=$(id -un)",
 	String.raw`esc() { printf '%s' "$1" | sed 's/["\\]/\\&/g'; }`,
 	"{",
@@ -193,7 +205,7 @@ export const OBSERVED_SPECS_SCRIPT = [
 	`  if [ -n "$disk_gb" ]; then printf ',"diskGb":%s' "$disk_gb"; fi`,
 	`  if [ -n "$limited" ]; then printf ',"hostVcpus":%s,"hostMemoryGb":%s' "$host_vcpus" "$host_memory_gb"; fi`,
 	`  if [ -n "$cpu_model" ]; then printf ',"cpuModel":"%s"' "$(esc "$cpu_model")"; fi`,
-	String.raw`  printf ',"kernel":"%s","os":"%s","virtualization":"%s","user":"%s"}\n' "$(esc "$kernel")" "$(esc "$os")" "$(esc "$virt")" "$(esc "$user")"`,
+	String.raw`  printf ',"kernel":"%s","os":"%s","virtualization":"%s","detectedIsolation":"%s","user":"%s"}\n' "$(esc "$kernel")" "$(esc "$os")" "$(esc "$virt")" "$(esc "$detected")" "$(esc "$user")"`,
 	"} > benchmark-results/observed-specs.json",
 	"cat benchmark-results/observed-specs.json",
 ].join("\n");

--- a/packages/harness/src/lib/setup.ts
+++ b/packages/harness/src/lib/setup.ts
@@ -189,13 +189,17 @@ export const OBSERVED_SPECS_SCRIPT = [
 	// Best-effort isolation classification — a cross-check on the declared per-provider isolation, never
 	// authoritative (see run.ts observedSpecs.detectedIsolation: the probe cannot separate every type).
 	// gVisor announces itself in /proc/version; a cgroup quota well below the disclosed host means we're
-	// seeing THROUGH a container to a bigger host; a named hypervisor sized to its own host reads as a VM.
+	// seeing THROUGH a container to a bigger host; `systemd-detect-virt --vm` confirms a real hypervisor.
+	// (`--vm` restricts detection to VM technologies — bare `systemd-detect-virt` also reports container
+	// types like docker/lxc/podman, which must NOT read as a VM here; `--quiet` gives just an exit status.)
 	"detected=unknown",
 	"if grep -qi gvisor /proc/version 2>/dev/null; then",
 	"  detected=gvisor",
-	`elif [ -n "$limited" ] && awk -v h="$host_vcpus" -v v="$vcpus" 'BEGIN { exit !(h > v + 0.5) }'; then`,
+	// `vcpus` only drops below `host_vcpus` in the cpu.max branch, which is also the only place that
+	// sets `limited` — so `host_vcpus > vcpus` already implies a limit; no separate `[ -n "$limited" ]`.
+	`elif awk -v h="$host_vcpus" -v v="$vcpus" 'BEGIN { exit !(h > v + 0.5) }'; then`,
 	"  detected=container",
-	`elif [ "$virt" != unknown ] && [ "$virt" != none ]; then`,
+	"elif systemd-detect-virt --vm --quiet 2>/dev/null; then",
 	"  detected=vm",
 	"fi",
 	"user=$(id -un)",

--- a/packages/results/src/lib/specs.test.ts
+++ b/packages/results/src/lib/specs.test.ts
@@ -47,6 +47,7 @@ describe("readObservedSpecs: observed-specs.json (harness-written, primary)", ()
 					kernel: "6.17.0-22-generic",
 					os: "Debian GNU/Linux 13 (trixie)",
 					virtualization: "kvm",
+					detectedIsolation: "container",
 					user: "root",
 				},
 			}),
@@ -62,6 +63,7 @@ describe("readObservedSpecs: observed-specs.json (harness-written, primary)", ()
 			kernel: "6.17.0-22-generic",
 			os: "Debian GNU/Linux 13 (trixie)",
 			virtualization: "kvm",
+			detectedIsolation: "container",
 			user: "root",
 		});
 	});

--- a/packages/results/src/lib/specs.ts
+++ b/packages/results/src/lib/specs.ts
@@ -23,7 +23,14 @@ const NUMERIC_FIELDS = [
 	"hostMemoryGb",
 	"cpuMhz",
 ] as const;
-const STRING_FIELDS = ["cpuModel", "kernel", "os", "virtualization", "user"] as const;
+const STRING_FIELDS = [
+	"cpuModel",
+	"kernel",
+	"os",
+	"virtualization",
+	"detectedIsolation",
+	"user",
+] as const;
 
 const PROVIDER_STRING_FIELDS = {
 	public_ip: "publicIp",


### PR DESCRIPTION
Populate observedSpecs.detectedIsolation (added in the previous PR) from
the in-sandbox specs probe, filling the leaderboard roster's "detected"
column as a cross-check on each provider's declared isolation.

The classification is deliberately conservative — the probe cannot
separate every isolation type, so it returns "unknown" rather than guess:
- "gvisor" when /proc/version carries the gVisor marker;
- "container" when a cgroup quota sits well below the disclosed host
  (the probe is seeing THROUGH a container to a bigger machine);
- "vm" when a named hypervisor is present and the sandbox is sized to its
  own host;
- "unknown" otherwise.

- harness/setup.ts: emit detectedIsolation from OBSERVED_SPECS_SCRIPT.
- results/specs.ts: carry it through fromObservedSpecsFile.
- specs.test.ts: verbatim-passthrough coverage.
- docs/methodology.md: document the isolation variants + detection.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a best-effort in-sandbox probe that sets `observedSpecs.detectedIsolation` to power the leaderboard’s Detected column. Tightens VM detection to avoid container false positives; this is a cross-check, not a source of truth.

- **New Features**
  - `packages/harness`: extend `OBSERVED_SPECS_SCRIPT` to emit `detectedIsolation` (gVisor marker in `/proc/version` ⇒ `gvisor`; host vCPUs > observed vCPUs ⇒ `container`; `systemd-detect-virt --vm` ⇒ `vm`; else `unknown`).
  - `packages/results` + docs: carry `detectedIsolation` through read/parse and tests; document provider variants and the declared vs detected cross-check.

- **Bug Fixes**
  - `packages/harness`: gate VM detection on `systemd-detect-virt --vm --quiet` to prevent container misclassification; still emit raw `virtualization`.

<sup>Written for commit 5f467c43bd41cd4cd75fd69c92c2f23944717f62. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/starslingdev/hpc-sandbox-benchmarks/pull/211?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

