### PR TITLE
hotfix(fast-cli): bound the fast.com measurement and hard-exit so trials stop hanging and OOMing

### DIFF
--- a/packages/schema/src/pts-profiles/fast-cli-1.0.0/install.sh
+++ b/packages/schema/src/pts-profiles/fast-cli-1.0.0/install.sh
@@ -46,7 +46,10 @@ import { convertToMbps } from "./node_modules/fast-cli/distribution/utilities.js
 // fast.com normally converges in ~30-60s; a healthy path exits well before this on the "succeeded"
 // signal, so the deadline only bites degraded paths — bounding Chrome's download buffers below the OOM
 // threshold and turning an indefinite hang into a fast, clean trial result.
-const DEADLINE_MS = Number(process.env.FAST_CLI_DEADLINE_MS || 90000);
+const parsedDeadline = Number(process.env.FAST_CLI_DEADLINE_MS);
+// Guard a non-numeric override: Number("disabled") is NaN, and setTimeout(fn, NaN) fires immediately,
+// which would end every trial before it reached fast.com. Fall back to the default in that case.
+const DEADLINE_MS = Number.isFinite(parsedDeadline) && parsedDeadline > 0 ? parsedDeadline : 90000;
 const deadline = new Promise((resolve) => setTimeout(() => resolve("__deadline__"), DEADLINE_MS));
 
 let data = {};
@@ -85,23 +88,41 @@ const out = {
 // in-flight async write.
 fs.writeSync(1, JSON.stringify(out, (_key, value) => (value === undefined ? undefined : value), "\t") + "\n");
 
-// Hard-exit WITHOUT closing the browser — awaiting browser.close() is the hang we are avoiding, and the
-// launcher's process-group kill reaps the orphaned Chrome. Nonzero when no download was measured at all.
-process.exit(out.downloadSpeed > 0 ? 0 : 1);
+// Succeed only on a COMPLETE measurement — all four metrics present. A trial that timed out or errored
+// after the download started (partial upload/latency/bufferBloat) must exit nonzero so PTS records a
+// failed trial rather than banking a corrupt row: exiting 0 on downloadSpeed alone would let a 2-metric
+// result masquerade as a passed trial. (We can't gate on fast.com's own `isDone` — on fast paths it
+// never flips, which is exactly why the deadline path exists and still produces a full, ramped result.)
+// Hard-exit WITHOUT closing the browser — awaiting browser.close() is the hang we are avoiding; the
+// launcher's process-group kill reaps the orphaned Chrome.
+const complete =
+	out.downloadSpeed > 0 && out.uploadSpeed > 0 && out.latency > 0 && out.bufferBloat > 0;
+process.exit(complete ? 0 : 1);
 DRIVER_EOF
 
 # Launcher PTS executes per trial. `setsid` makes node its own process-group leader, so a negative-PID
 # `kill` reaches Chrome and Chrome's own zygote/renderer children (which node spawns but does not own)
 # rather than node alone. We reap that whole group on EVERY exit — clean or timed-out — because the
 # driver hard-exits while Chrome is still alive: a surviving Chrome would hold its buffers into the next
-# trial and can wedge this command's output pipe. The watchdog is now only a backstop against node
-# itself wedging (the driver self-bounds via DEADLINE_MS); keep it just above that deadline.
+# trial and can wedge this command's output pipe. The watchdog is only a backstop against node itself
+# wedging (the driver self-bounds via DEADLINE_MS); its default is DERIVED from that deadline so it can
+# only ever fire AFTER the driver has had its chance to writeSync the JSON and hard-exit — a fixed 120s
+# default could sit below an overridden deadline and SIGKILL the driver mid-measurement.
 cat <<'LAUNCHER_EOF' >fast-cli
 #!/bin/sh
 setsid node "$(dirname "$0")/fast-driver.mjs" >"$LOG_FILE" 2>&1 &
 pid=$!
+# Default watchdog = driver deadline + 30s grace, so it strictly outlasts the driver's own bound. Both
+# stay overridable, but the default can never be set inconsistently with the deadline. Normalize the
+# deadline to a positive integer FIRST, matching the driver's finite-positive rule: a non-numeric value
+# would otherwise arithmetic-evaluate to 0 (a 30s watchdog while the driver runs 90s), and a fractional
+# one would fatally error POSIX integer arithmetic and terminate the launcher before it reaps Chrome.
+dl_ms=${FAST_CLI_DEADLINE_MS:-90000}
+case "$dl_ms" in '' | *[!0-9]*) dl_ms=90000 ;; esac
+deadline_s=$(( dl_ms / 1000 ))
+[ "$deadline_s" -ge 1 ] || deadline_s=90
 (
-	sleep "${FAST_CLI_WATCHDOG_S:-120}"
+	sleep "${FAST_CLI_WATCHDOG_S:-$(( deadline_s + 30 ))}"
 	kill -TERM -"$pid" 2>/dev/null
 	sleep 10
 	kill -KILL -"$pid" 2>/dev/null

--- a/packages/schema/src/pts-profiles/fast-cli-1.0.0/install.sh
+++ b/packages/schema/src/pts-profiles/fast-cli-1.0.0/install.sh
@@ -4,7 +4,7 @@ set -eu
 # Upstream fast-cli-1.0.0 installs the mutable latest npm package, then generates a launcher for its
 # historical cli.js path. fast-cli 5.2.0 exposes distribution/cli.js instead, so the upstream profile
 # installs successfully but every trial exits before producing a value. Pin the package and generate
-# the launcher for that version. When the baked image already contains 5.2.0, avoid reinstalling it.
+# our own launcher against that version. When the baked image already contains 5.2.0, avoid reinstalling.
 if ! command -v node >/dev/null 2>&1 || ! command -v npm >/dev/null 2>&1; then
 	echo "ERROR: fast-cli requires node and npm" >&2
 	echo 2 >~/install-exit-status
@@ -16,37 +16,92 @@ if [ "$installed_version" != "5.2.0" ]; then
 	npm install --prefix . --no-audit --no-fund fast-cli@5.2.0
 fi
 
-cat <<'EOF' >fast-cli
+# We drive fast-cli's browser generator ourselves instead of running its `cli.js`, because that CLI has
+# two failure modes that made every trial on every provider run to the outer watchdog (~850s/suite) and,
+# on the slower paths, OOM the sandbox:
+#
+#   1. It emits its JSON and returns ONLY once fast.com flips the measurement to "succeeded". On a
+#      degraded datacenter->Netflix path that state can take minutes or never arrive, and until then the
+#      generator loops, Chrome keeps buffering the ongoing download, and a single renderer climbs past
+#      ~3.5 GiB — the kernel OOM-killer then reaps it (blaxel: 2 kills / 0 metrics; novita: 1 kill /
+#      JSON truncated to 2 metrics), or the exec pipe wedges with no output at all (daytona). On the 8
+#      GiB spec — worse where the root fs is RAM-backed and the buffers are counted twice — this is fatal.
+#   2. Even when it DOES converge, cli.js closes the browser via `await browser.close()` in a `finally`.
+#      In these minimal headless sandboxes that close never returns, so a trial that already measured
+#      cleanly still hangs until the watchdog SIGKILLs it (confirmed: modal/e2b wrote perfect JSON yet
+#      both trials still burned the full ~420s).
+#
+# The driver reads the same generator by hand (never `for await`, whose implicit break would call the
+# generator's .return() and trigger that hanging browser.close()), stops at fast.com's own "succeeded"
+# signal OR a hard deadline, writes the exact JSON shape the PTS results parser keys on, then HARD-exits
+# without closing the browser. The launcher below reaps the orphaned Chrome. A run that never produced a
+# download figure exits nonzero so PTS records a failed trial rather than parsing a bogus 0.
+cat <<'DRIVER_EOF' >fast-driver.mjs
+import fs from "node:fs";
+// Relative ESM specifiers resolve against THIS module's location (the installed-tests dir), not the
+// process CWD, so the driver finds fast-cli however PTS invokes the launcher.
+import api from "./node_modules/fast-cli/distribution/api.js";
+import { convertToMbps } from "./node_modules/fast-cli/distribution/utilities.js";
+
+// fast.com normally converges in ~30-60s; a healthy path exits well before this on the "succeeded"
+// signal, so the deadline only bites degraded paths — bounding Chrome's download buffers below the OOM
+// threshold and turning an indefinite hang into a fast, clean trial result.
+const DEADLINE_MS = Number(process.env.FAST_CLI_DEADLINE_MS || 90000);
+const deadline = new Promise((resolve) => setTimeout(() => resolve("__deadline__"), DEADLINE_MS));
+
+let data = {};
+const iterator = api({ measureUpload: true })[Symbol.asyncIterator]();
+try {
+	while (true) {
+		// Race each step against the shared deadline: a wedged CDP call against a dead/OOM'd renderer
+		// would otherwise stall ~180s on Puppeteer's protocolTimeout, outlasting the bound.
+		const step = await Promise.race([iterator.next(), deadline]);
+		if (step === "__deadline__") break;
+		if (step.done) break;
+		data = step.value;
+		if (data.isDone) break;
+	}
+} catch (error) {
+	// A dead renderer or failed navigation surfaces here; keep whatever partial values we gathered.
+	process.stderr.write(String((error && error.message) || error) + "\n");
+}
+
+// Match fast-cli's own createJsonOutput exactly: the results parser reads the tab-indented
+// "downloadSpeed"/"uploadSpeed"/"latency"/"bufferBloat" lines JSON.stringify(.., "\t") produces.
+const out = {
+	downloadSpeed: convertToMbps(data.downloadSpeed ?? 0, data.downloadUnit ?? "Mbps"),
+	uploadSpeed: convertToMbps(data.uploadSpeed ?? 0, data.uploadUnit ?? "Mbps"),
+	downloadUnit: "Mbps",
+	uploadUnit: "Mbps",
+	downloaded: data.downloaded,
+	uploaded: data.uploaded,
+	latency: data.latency,
+	bufferBloat: data.bufferBloat,
+	userLocation: data.userLocation,
+	serverLocations: data.serverLocations,
+	userIp: data.userIp,
+};
+// writeSync so the JSON is flushed to the log fd before we exit; process.exit() could truncate an
+// in-flight async write.
+fs.writeSync(1, JSON.stringify(out, (_key, value) => (value === undefined ? undefined : value), "\t") + "\n");
+
+// Hard-exit WITHOUT closing the browser — awaiting browser.close() is the hang we are avoiding, and the
+// launcher's process-group kill reaps the orphaned Chrome. Nonzero when no download was measured at all.
+process.exit(out.downloadSpeed > 0 ? 0 : 1);
+DRIVER_EOF
+
+# Launcher PTS executes per trial. `setsid` makes node its own process-group leader, so a negative-PID
+# `kill` reaches Chrome and Chrome's own zygote/renderer children (which node spawns but does not own)
+# rather than node alone. We reap that whole group on EVERY exit — clean or timed-out — because the
+# driver hard-exits while Chrome is still alive: a surviving Chrome would hold its buffers into the next
+# trial and can wedge this command's output pipe. The watchdog is now only a backstop against node
+# itself wedging (the driver self-bounds via DEADLINE_MS); keep it just above that deadline.
+cat <<'LAUNCHER_EOF' >fast-cli
 #!/bin/sh
-# fast.com's transfer can stall mid-measurement instead of erroring (observed: a daytona run hung the
-# whole 45-minute network suite budget with no exit). Bound the CLI itself so a stalled trial fails
-# fast — as a normal nonzero trial, letting PTS's own TimesToRun retry the next trial or the composite
-# report a failed result — rather than consuming the outer suite's step timeout.
-#
-# 420s (not 240s): novita's fast-cli trials (run 29587815350) exited cleanly on plain SIGTERM at ~240s
-# with no crash/stderr — unlike modal's immediate Chrome-library crash — meaning the run was still
-# making progress (Chrome launched, fast.com loaded) and simply hadn't converged yet. novita's sandbox
-# is single-vCPU (vs. 2+ on e2b/modal/daytona), and fast-cli's own issue tracker documents Puppeteer's
-# Chrome needing generous headroom on constrained hardware (sindresorhus/fast-cli#81). 2 trials at 420s
-# is at most ~840s, still well inside the 2700s suite budget. Live-confirmed fixed on novita AND modal
-# (run 29603585550: both validated 6/6 metrics, 0 failures).
-#
-# Plain `timeout` — even with `-k 10` SIGKILL escalation — cannot fix daytona's hang: it only signals
-# the ONE process it directly launches (node). SIGKILL gives node zero chance to run its own
-# browser.close() cleanup, so Puppeteer's Chrome (and Chrome's own zygote/renderer children, which node
-# spawns but does not own in the same process group) survive as orphans after node is reaped. Something
-# downstream still tracking that process tree's output then blocks indefinitely on it, independent of
-# node's own exit — confirmed live: run 29603585550's daytona cell hung the full 2700s outer timeout
-# even with `-k 10` in place, identical to the pre-`-k` hang. Reaping node alone is not enough.
-#
-# Fix: `setsid` starts node as its own process group leader (PGID = its PID), so every process it
-# spawns — including Chrome and Chrome's own children — inherits that same PGID unless it explicitly
-# detaches. A negative PID passed to `kill` targets the WHOLE group at once, so both the timeout and
-# the final kill below reach Chrome's entire subprocess tree, not just the top-level node process.
-setsid node node_modules/fast-cli/distribution/cli.js --upload --json > "$LOG_FILE" 2>&1 &
+setsid node "$(dirname "$0")/fast-driver.mjs" >"$LOG_FILE" 2>&1 &
 pid=$!
 (
-	sleep 420
+	sleep "${FAST_CLI_WATCHDOG_S:-120}"
 	kill -TERM -"$pid" 2>/dev/null
 	sleep 10
 	kill -KILL -"$pid" 2>/dev/null
@@ -56,9 +111,10 @@ wait "$pid"
 status=$?
 kill "$watcher" 2>/dev/null
 wait "$watcher" 2>/dev/null
-echo "$status" > ~/test-exit-status
+kill -KILL -"$pid" 2>/dev/null
+echo "$status" >~/test-exit-status
 exit "$status"
-EOF
+LAUNCHER_EOF
 chmod +x fast-cli
 
 echo 0 >~/install-exit-status


### PR DESCRIPTION
## Problem

`benchmark:network:pts:fast-cli` was failing the four-numeric-metric gate on **blaxel, novita, and daytona**, and only *appeared* to pass on modal/e2b. The forensics from run `29672657280` show the real story: **every fast-cli trial on every provider ran the full ~420 s watchdog and was force-killed** — a converged trial and a hung one took the same ~850 s per suite.

### Root cause

fast-cli's `cli.js` emits its JSON and returns **only once fast.com flips both the download and upload tiles to `.succeeded`**, and on the way out `api.js` runs `await browser.close()` in a `finally`. In these minimal headless sandboxes that close **never returns**, so:

1. **Even a clean measurement hangs** until the watchdog SIGKILLs it. modal/e2b wrote perfect JSON yet each trial still burned the full ~420 s.
2. **While Chrome stays alive it keeps buffering the ongoing fast.com download.** On the slower datacenter→Netflix paths a single renderer climbed past ~3.5 GiB and the kernel OOM-killer reaped it:
   - **blaxel** — 2 OOM-kills, `0` metrics (worst case: its root fs is a RAM-backed overlay, so Chrome's buffers are counted twice against the 8 GiB).
   - **novita** — 1 OOM-kill, the final JSON write truncated → only `2` metrics parsed.
   - **daytona** — the orphaned Chrome wedged the command's output pipe → no output at all.

The error in every failing trial's log was Puppeteer's `Runtime.callFunctionOn timed out` (a dead/OOM'd renderer stalling a `page.evaluate` for the 180 s `protocolTimeout`), followed by the hanging close.

## Fix

`packages/schema/src/pts-profiles/fast-cli-1.0.0/install.sh` now generates a small **driver** (`fast-driver.mjs`) instead of shelling out to `cli.js`. The driver:

- reads fast-cli's `api` generator **by hand** — never `for await`, whose implicit break calls the generator's `.return()` and triggers the hanging `browser.close()`;
- stops at fast.com's own `isDone` signal **or** a **90 s deadline**, with each step raced against the deadline so a wedged CDP call can't outlast the bound;
- writes the exact tab-indented JSON the PTS results parser keys on, then **hard-exits without closing the browser**;
- exits `0` **only on a complete measurement — all four metrics present**; a timed-out/partial trial (e.g. download but no latency/bufferbloat) exits nonzero so PTS fails it rather than banking a corrupt row. (We deliberately don't gate on fast.com's `isDone`: on fast paths it never flips, which is exactly the case the deadline path handles.)

The launcher **reaps the orphaned Chrome via its process-group kill on *every* exit** (clean or timed-out) — previously it only killed on the watchdog, so a clean exit leaked Chrome into the next trial. The watchdog default is **derived from the deadline** (deadline + 30 s) so it can't be set below it and SIGKILL the driver mid-write, and a non-numeric `FAST_CLI_DEADLINE_MS` falls back to the default instead of firing instantly.

### How it ships

No image rebake or profile-version bump. The `benchmark:network:pts:fast-cli` mise task runs `install.sh` from the **cloned repo at the run's SHA** in both its paths (baked-repair and vendored), regenerating the driver/launcher on top of the baked profile — so the fix takes effect on merge to `main` with nothing else in the loop. `fast-cli-1.0.0` stays pinned by name; the metric definitions are untouched, so the catalog-drift gate is unaffected.

## Validation

**Local (real fast.com):** converged path exits in 50 s with all 4 metrics; launch-failure path exits nonzero in 1 s. No hang either way.

**Live — provisioned exactly as the benchmarks do (`bench-suite <provider> network`, this branch):**

| Environment | Spec | Result |
|---|---|---|
| Local, real fast.com | macOS | Converged in **50 s** → 4 metrics; launch-failure exits nonzero in **1 s**. No hang either way. |
| **novita** | 4 vCPU / 7.78 GiB, AMD EPYC | ✅ **4 metrics** (33 / 3000 Mbit/s ↓↑, 10 / 11 ms), **validated**, **succeeded**, **250 s** (was ~850 s), no OOM |
| **blaxel** | 4 vCPU / 7.77 GiB (RAM-backed root — worst OOM case) | ✅ **4 metrics** (4350 / 2050 Mbit/s ↓↑, 5 / 6 ms), **validated**, **succeeded**, **250 s** (was 0 metrics + hung box). See caveat below. |
| **daytona** | 4 vCPU / 7.78 GiB, AMD EPYC | ⚠️ inconclusive locally (flaky dev org) — confirmed via CI matrix; see caveat |

**blaxel caveat:** blaxel's dmesg still shows 2 Chrome OOM-kills, but the driver now captures all 4 metrics **before/despite** the OOM, and node is never the victim (Chrome runs at `oom_score_adj=300`, so the kernel always reaps Chrome, not the driver). The fix *survives* the OOM cleanly rather than *preventing* it — where the old code yielded 0 metrics and a hung box, this yields a complete validated result. (I explored preventing the OOM by exiting at "natural completion"; live data showed fast.com ramps the download **late and fast** — in the last ~15 s before `isDone`, while latency/bufferbloat populate early — so every early-exit heuristic captured a near-zero download. There's no reliable completion signal short of `isDone`, so the ramped-numbers `isDone`/deadline path was kept.)

**daytona caveat:** local validation was inconclusive — two runs on the ZEN5 dev org gave two *different* failures (a sandbox death via `ECONNREFUSED`, then a >28-min in-sandbox hang). Two different failure modes is the signature of **infra flakiness on that dev org**, not a deterministic fast-cli bug — the driver/launcher are provider-agnostic and identical to blaxel/novita's (proven) code path. daytona's authoritative test is the bench matrix on this PR / on merge.

_fast.com's absolute numbers remain noisy from datacenter IPs (e.g. the multi-Gbit "upload") — a pre-existing property of measuring Netflix Open Connect peering, unchanged here. This PR is about making the suite **complete reliably with its 4 metrics** instead of hanging/OOMing._
