### PR TITLE
fix(bench): restore real HOME and mise Node for realworld PTS hard failures

### DIFF
--- a/lib/bench.sh
+++ b/lib/bench.sh
@@ -640,9 +640,9 @@ run_fio_pts() {
 }
 
 # Run one realworld suite end to end: gate on the toolchain, install the repo-local profile with
-# the SHARED install.sh + runner overlaid from lib/pts/realworld/ (the profiles vendor only
-# XML + target.env — no per-profile scripts to drift), then batch-run it. The single body behind
-# every benchmark:realworld:pts:<repo> mise leaf.
+# the SHARED install.sh + runner + realworld-env.sh overlaid from lib/pts/realworld/ (the profiles
+# vendor only XML + target.env — no per-profile scripts to drift), then batch-run it. The single
+# body behind every benchmark:realworld:pts:<repo> mise leaf.
 # Usage: run_realworld_pts <repo>   (repo = mastra | better-auth | openclaw)
 run_realworld_pts() {
 	local repo="$1"
@@ -660,7 +660,8 @@ run_realworld_pts() {
 
 	install_local_pts_profile "$profile" \
 		"${REPO_ROOT}/lib/pts/realworld/install.sh" \
-		"${REPO_ROOT}/lib/pts/realworld/realworld-runner.sh"
+		"${REPO_ROOT}/lib/pts/realworld/realworld-runner.sh" \
+		"${REPO_ROOT}/lib/pts/realworld/realworld-env.sh"
 
 	run_pts_benchmark "local/${profile}" "$prefix"
 }

--- a/lib/pts/realworld/install.sh
+++ b/lib/pts/realworld/install.sh
@@ -18,13 +18,14 @@ SRC_DIR="$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)"
 # wrapper name is a fixed constant -- no versionless-dir derivation.
 EXE_NAME="realworld-run"
 
-if [ ! -f "${SRC_DIR}/target.env" ] || [ ! -f "${SRC_DIR}/realworld-runner.sh" ]; then
-	echo "ERROR: target.env or realworld-runner.sh missing next to install.sh (${SRC_DIR})" >&2
+if [ ! -f "${SRC_DIR}/target.env" ] || [ ! -f "${SRC_DIR}/realworld-runner.sh" ] || [ ! -f "${SRC_DIR}/realworld-env.sh" ]; then
+	echo "ERROR: target.env, realworld-runner.sh, or realworld-env.sh missing next to install.sh (${SRC_DIR})" >&2
 	echo 1 > ~/install-exit-status
 	exit 1
 fi
 cp "${SRC_DIR}/target.env" .
 cp "${SRC_DIR}/realworld-runner.sh" .
+cp "${SRC_DIR}/realworld-env.sh" .
 chmod +x realworld-runner.sh
 
 cat <<EOF > "$EXE_NAME"
@@ -45,6 +46,14 @@ chmod +x "$EXE_NAME"
 export XDG_CACHE_HOME="${PWD}/.cache"
 export COREPACK_HOME="${PWD}/.corepack"
 export npm_config_store_dir="${PWD}/.pnpm-store"
+
+# Make the harness-provisioned mise Node win over ambient nvm/distro nodes: PTS may invoke
+# install.sh with an older nvm Node first on PATH and often strips MISE_*. Shared with
+# realworld-runner.sh via realworld-env.sh (single source of truth — see it for the full
+# rationale). install.sh deliberately keeps PTS's HOME as-is; only the mise/PATH side effects
+# are needed here so the node-version gate below sees the right Node.
+# shellcheck source=/dev/null
+. ./realworld-env.sh
 
 if ! command -v node >/dev/null 2>&1; then
 	echo "ERROR: node not found (the sandbox harness's setupNode step provisions it)" >&2

--- a/lib/pts/realworld/realworld-env.sh
+++ b/lib/pts/realworld/realworld-env.sh
@@ -1,0 +1,52 @@
+#!/bin/sh
+# Shared environment setup for the realworld PTS scripts (ENG-135/136/137/138), SOURCED by both
+# install.sh and realworld-runner.sh — never executed on its own. install.sh copies it next to
+# target.env + the runner into the PTS install dir (exactly as it copies realworld-runner.sh), and
+# both scripts `.` it, so the HOME/mise/Node fix lives in ONE place instead of drifting across two
+# near-identical copies.
+#
+# Why it exists: PTS invokes install.sh and the generated executable wrapper with HOME pointed at
+# the installed-test dir (often with a trailing slash) and frequently strips MISE_*, so mise shims
+# fall through to an ambient nvm/distro Node instead of the harness-provisioned one — which broke
+# mastra's tilde tests, openclaw's path-normalization unit tests, and openclaw's engines gate.
+#
+# Effect of sourcing (under the callers' `set -eu`):
+#   - REALWORLD_HOME -> the real user home, trailing slash stripped (resolved from the passwd db,
+#     never from $HOME, which PTS owns and mangles).
+#   - MISE_DATA_DIR / MISE_CONFIG_DIR / MISE_CACHE_DIR -> the real user's mise (or the container
+#     image's /mise), so `mise which node` resolves the harness toolchain.
+#   - PATH -> mise shims + the resolved node dir prepended, so the intended Node wins.
+# It deliberately does NOT touch HOME: install.sh leaves PTS's HOME as-is (no tests run at install
+# time), and realworld-runner.sh resets HOME to REALWORLD_HOME itself — only the runner needs it,
+# for the upstream suites' tilde-path assertions.
+
+# Real user home. PTS points HOME at the install dir, so resolve it from the passwd db, not $HOME.
+REALWORLD_HOME="$(getent passwd "$(id -un)" 2>/dev/null | cut -d: -f6 || true)"
+if [ -z "${REALWORLD_HOME}" ] || [ ! -d "${REALWORLD_HOME}" ]; then
+	REALWORLD_HOME="/home/$(id -un)"
+fi
+REALWORLD_HOME="${REALWORLD_HOME%/}"
+
+# Point mise at the real user's data/config (PTS strips MISE_*), or the container image's /mise if
+# present, and put its shims first on PATH.
+if [ -d "${REALWORLD_HOME}/.local/share/mise" ]; then
+	export MISE_DATA_DIR="${REALWORLD_HOME}/.local/share/mise"
+	export MISE_CONFIG_DIR="${REALWORLD_HOME}/.config/mise"
+	export MISE_CACHE_DIR="${REALWORLD_HOME}/.cache/mise"
+fi
+if [ -d /mise ]; then
+	export MISE_DATA_DIR=/mise MISE_CONFIG_DIR=/mise MISE_CACHE_DIR=/mise/cache
+	PATH="/mise/shims:${PATH}"
+elif [ -d "${REALWORLD_HOME}/.local/share/mise/shims" ]; then
+	PATH="${REALWORLD_HOME}/.local/share/mise/shims:${REALWORLD_HOME}/.local/bin:${PATH}"
+fi
+# Resolve the concrete node binary — shims alone still resolve the wrong binary if mise is missing
+# from PATH under PTS's sanitized env.
+if command -v mise >/dev/null 2>&1; then
+	_node_bin="$(mise which node 2>/dev/null || true)"
+	if [ -n "${_node_bin}" ] && [ -x "${_node_bin}" ]; then
+		PATH="$(dirname "${_node_bin}"):${PATH}"
+	fi
+fi
+export PATH
+unset _node_bin

--- a/lib/pts/realworld/realworld-env.sh
+++ b/lib/pts/realworld/realworld-env.sh
@@ -26,6 +26,12 @@ if [ -z "${REALWORLD_HOME}" ] || [ ! -d "${REALWORLD_HOME}" ]; then
 	REALWORLD_HOME="/home/$(id -un)"
 fi
 REALWORLD_HOME="${REALWORLD_HOME%/}"
+# Rootless/distroless images often have no passwd entry and no /home/<user>. Without a warning the
+# mise directory guards below all skip silently and PATH keeps ambient nvm Node — the exact failure
+# this helper exists to prevent. Prefer /mise when present; still surface the missing home.
+if [ ! -d "${REALWORLD_HOME}" ]; then
+	echo "WARNING: realworld-env: REALWORLD_HOME=${REALWORLD_HOME} does not exist (no passwd home for $(id -un)); mise under that path will be skipped" >&2
+fi
 
 # Point mise at the real user's data/config (PTS strips MISE_*), or the container image's /mise if
 # present, and put its shims first on PATH.

--- a/lib/pts/realworld/realworld-runner.sh
+++ b/lib/pts/realworld/realworld-runner.sh
@@ -22,6 +22,20 @@ WORK_DIR="${SCRIPT_DIR}/work"
 export XDG_CACHE_HOME="${SCRIPT_DIR}/.cache"
 export COREPACK_HOME="${SCRIPT_DIR}/.corepack"
 export npm_config_store_dir="${SCRIPT_DIR}/.pnpm-store"
+# PTS points HOME at the installed-test dir (often with a trailing slash) for the executable
+# wrapper and strips MISE_*. realworld-env.sh resolves the real user home into REALWORLD_HOME and
+# makes the harness mise Node win on PATH — shared with install.sh so the two can't drift.
+# shellcheck source=/dev/null
+. "${SCRIPT_DIR}/realworld-env.sh"
+# Reset HOME to the real user home (no trailing slash). Upstream suites call os.homedir() and then
+# build tilde paths via `path.join(home, name).replace(home, '~')` — a trailing-slash HOME makes
+# that replace produce `~.name` instead of `~/.name`, and openclaw's path-normalization tests
+# compare `os.homedir()` to `path.resolve`-normalized forms that strip the slash. Caches stay
+# pinned to SCRIPT_DIR (above). The PTS wrapper still writes ~/test-exit-status under PTS's HOME in
+# the parent shell; this export only affects the runner and its children.
+# shellcheck disable=SC2154 # REALWORLD_HOME is set by the sourced realworld-env.sh above.
+HOME="${REALWORLD_HOME}"
+export HOME
 export CI=true
 export TZ=UTC
 export LC_ALL=C.UTF-8

--- a/packages/schema/src/pts-profiles/local/realworld-openclaw-1.0.0/target.env
+++ b/packages/schema/src/pts-profiles/local/realworld-openclaw-1.0.0/target.env
@@ -1,10 +1,10 @@
 # openclaw/openclaw (ENG-138) -- consumed by lib/pts/realworld/realworld-runner.sh. One TASK_CMD_<value> per
 # <Option>/<Menu>/<Entry>/<Value> in test-definition.xml (packages/schema/src/pts-profiles.test.ts
 # asserts the two stay in lockstep). git_clone has no shell command: the runner measures it via a
-# fixed git-fetch algorithm, not a package script. engines.node requires >=22.19.
+# fixed git-fetch algorithm, not a package script. engines.node requires >=22.22.3.
 REPO_URL="https://github.com/openclaw/openclaw.git"
-PIN_SHA="623534400684eca7c451cf587189fae714f2abe2"
-NODE_VERSION="22.19"
+PIN_SHA="ec01949d86281746f6c2e1c1ba3c8b63b0b18298"
+NODE_VERSION="22.22.3"
 
 TASK_CMD_git_clone=""
 # Same invocation as openclaw's .github/actions/setup-node-env composite action's "Install

--- a/packages/schema/src/pts-profiles/local/realworld-openclaw-1.0.0/test-definition.xml
+++ b/packages/schema/src/pts-profiles/local/realworld-openclaw-1.0.0/test-definition.xml
@@ -3,7 +3,7 @@
 <PhoronixTestSuite>
   <TestInformation>
     <Title>OpenClaw CI Tasks</Title>
-    <AppVersion>623534400684eca7c451cf587189fae714f2abe2</AppVersion>
+    <AppVersion>ec01949d86281746f6c2e1c1ba3c8b63b0b18298</AppVersion>
     <Description>Runs the CI tasks openclaw/openclaw's own pipeline runs -- clone, cold install (its exact CI invocation), lint (Oxlint), format check, typecheck (tsgo), shrinkwrap check, fast unit tests, build -- against a pinned main-HEAD checkout, timing each phase per sandbox provider.</Description>
     <ResultScale>Seconds</ResultScale>
     <Proportion>LIB</Proportion>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes hard failures in the realworld PTS suite caused by PTS mangling `HOME` and stripping `MISE_*`, which broke mastra tilde-path tests, openclaw path-normalization unit tests, and openclaw's engines Node gate.

### Root causes
- PTS points `HOME` at the install dir (often with a trailing `/`), so upstream suites that do `path.join(home, …).replace(home, '~')` or compare `os.homedir()` to `path.resolve` forms fail.
- PTS strips `MISE_*`, so mise shims fall through to ambient nvm Node (e.g. 22.22.2) instead of the harness-provisioned Node (≥22.22.3 for openclaw).

### Changes
- Add shared `lib/pts/realworld/realworld-env.sh` (sourced by install + runner) that resolves `REALWORLD_HOME` from the passwd DB and restores mise/Node on `PATH`.
- Runner sets `HOME=$REALWORLD_HOME`; install keeps PTS `HOME` but still gets the mise/PATH fix.
- **Warn** when `REALWORLD_HOME` resolves to a non-existent directory (rootless/distroless), so mise skip is no longer silent (Greptile review).
- Bump openclaw pin and require Node 22.22.3.

### Verified
- mastra Test Core: PASS
- openclaw Lint Format / Test Unit Fast: PASS
- openclaw Shrinkwrap: still fails upstream (stale shrinkwrap after frozen install) — not fixable in-runner

### Review
- Duplicated mise block → shared helper (resolved)
- Silent missing HOME → stderr warning in `realworld-env.sh` (resolved)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c3b49072-ba0c-41ed-9503-0659ca3d3a50"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c3b49072-ba0c-41ed-9503-0659ca3d3a50"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restores the real HOME and prefers `mise`’s Node for realworld PTS tasks, fixing hard failures in `mastra` and `openclaw`. Previously PTS set HOME to the install dir and stripped `MISE_*`, which broke tilde/path tests and selected an older Node; now the runner resets HOME and both scripts resolve the harness `mise` Node, with a warning when no real home is found.

- Add `realworld-env.sh` and overlay it with profiles; both `install.sh` and `realworld-runner.sh` source it to centralize HOME/`mise`/PATH logic and prepend the resolved Node bin.
- Runner: set HOME to the real user home (no trailing slash); keep caches under the working dir.
- Install: keep PTS’s HOME but source `realworld-env.sh` so the engines gate sees the intended Node.
- Emit a stderr warning if REALWORLD_HOME cannot be resolved and prefer `/mise` when present to avoid falling back to ambient Node.
- Bump `openclaw` pin and require `NODE_VERSION=22.22.3` (AppVersion updated); other behavior unchanged. Note: `openclaw` shrinkwrap check still fails due to an upstream stale lockfile.

<sup>Written for commit fdc8657598cdcf3c9157972a81fa48d99a643658. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/starslingdev/hpc-sandbox-benchmarks/pull/213?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved real-world test setup to consistently apply the required runtime environment and home-directory configuration.
  - Added clearer validation and error reporting when required test components are unavailable.
  - Ensured runner processes inherit the correct Node.js and path settings.

- **Maintenance**
  - Updated the OpenClaw test profile to use Node.js 22.22.3 and a refreshed pinned source revision.
  - Standardized environment configuration across local test installations and executions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->