### PR TITLE
feat: update Blaxel provider region from us-pdx-1 to us-was-1

### DIFF
--- a/packages/providers/src/lib/adapters.ts
+++ b/packages/providers/src/lib/adapters.ts
@@ -61,7 +61,7 @@ export const adapters: Record<ProviderId, ProviderAdapter> = {
 		// gate like the other runners (not part of the specMatched check). No pre-baked toolchain
 		// snapshot yet — setup steps run fallbacks.
 		createCompute: () =>
-			blaxelWithVolume(blaxel({ image: "blaxel/ts-app:latest", memory: 8192, region: "us-pdx-1" })),
+			blaxelWithVolume(blaxel({ image: "blaxel/ts-app:latest", memory: 8192, region: "us-was-1" })),
 		createOptions: {},
 	},
 	modal: {


### PR DESCRIPTION
## Summary
Curious if there are regional differences. Let's update the default region configuration for the Blaxel provider adapter from `us-pdx-1` to `us-was-1`. If we see different performance then we should benchmark all regions for blaxel in the results.

## Changes
- Changed the `region` parameter in the Blaxel compute configuration from `"us-pdx-1"` to `"us-was-1"`

## Details
This change updates the regional endpoint used when creating compute resources through the Blaxel provider. The region is now set to `us-was-1` instead of the previous `us-pdx-1` configuration.

https://claude.ai/code/session_015fbQz8cRjyCX4uq4L7wMBs

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Update the `Blaxel` provider to use the `us-was-1` region by default, replacing `us-pdx-1`. This ensures sandboxes and their attached 40 GiB volumes provision in the same `us-was-1` region.

<sup>Written for commit 7a7f3fb1a9ca7d78e1b937ed969736ecc4d60e28. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/starslingdev/hpc-sandbox-benchmarks/pull/216?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Configuration**
  * Updated sandbox creation to use a different AWS region.
  * No other adapter behavior or options were changed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->