### PR TITLE
Use ephemeral volume with blaxel sdk

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -20,6 +20,8 @@
         "bench-smoke": "./src/bin/bench-smoke.ts",
         "bake": "./src/bin/bake.ts",
         "plan-matrix": "./src/bin/plan-matrix.ts",
+        "plan-providers": "./src/bin/plan-providers.ts",
+        "plan-suites": "./src/bin/plan-suites.ts",
         "build-template": "./src/bin/build-template.ts",
         "normalize": "./src/bin/normalize.ts",
         "aggregate": "./src/bin/aggregate.ts",
@@ -153,6 +155,7 @@
     },
   },
   "overrides": {
+    "@blaxel/core": "0.3.4",
     "@daytonaio/sdk": "npm:@daytona/sdk@0.192.0",
   },
   "catalog": {
@@ -1104,8 +1107,6 @@
 
     "@blaxel/core/dotenv": ["dotenv@16.6.1", "", {}, "sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow=="],
 
-    "@computesdk/blaxel/@blaxel/core": ["@blaxel/core@0.2.95", "", { "dependencies": { "@hey-api/client-fetch": "^0.10.0", "@modelcontextprotocol/sdk": "^1.20.0", "archiver": "^7.0.1", "axios": "^1.9.0", "dockerfile-ast": "^0.7.1", "dotenv": "^16.5.0", "form-data": "^4.0.2", "jwt-decode": "^4.0.0", "toml": "^3.0.0", "uuid": "^11.1.0", "ws": "^8.18.2", "yaml": "^2.7.1", "zod": "^3.24.3" } }, "sha512-wbwIhqXlgPbyCDY4vZReqk60YLE8C2HKILgag4rG2y5Ag2mEdnM5YS5MZi3Zj9f1z9SuTyrME8DJYCiKRmlqAw=="],
-
     "@octokit/request/content-type": ["content-type@2.0.0", "", {}, "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ=="],
 
     "@opentelemetry/otlp-transformer/protobufjs": ["protobufjs@8.0.1", "", { "dependencies": { "@protobufjs/aspromise": "^1.1.2", "@protobufjs/base64": "^1.1.2", "@protobufjs/codegen": "^2.0.4", "@protobufjs/eventemitter": "^1.1.0", "@protobufjs/fetch": "^1.1.0", "@protobufjs/float": "^1.0.2", "@protobufjs/inquire": "^1.1.0", "@protobufjs/path": "^1.1.2", "@protobufjs/pool": "^1.1.0", "@protobufjs/utf8": "^1.1.0", "@types/node": ">=13.7.0", "long": "^5.0.0" } }, "sha512-NWWCCscLjs+cOKF/s/XVNFRW7Yih0fdH+9brffR5NZCy8k42yRdl5KlWKMVXuI1vfCoy4o1z80XR/W/QUb3V3w=="],
@@ -1149,8 +1150,6 @@
     "wrap-ansi-cjs/ansi-styles": ["ansi-styles@4.3.0", "", { "dependencies": { "color-convert": "^2.0.1" } }, "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg=="],
 
     "wrap-ansi-cjs/strip-ansi": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
-
-    "@computesdk/blaxel/@blaxel/core/dotenv": ["dotenv@16.6.1", "", {}, "sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow=="],
 
     "accepts/mime-types/mime-db": ["mime-db@1.54.0", "", {}, "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ=="],
 

--- a/bun.lock
+++ b/bun.lock
@@ -163,7 +163,7 @@
   },
   "catalogs": {
     "computesdk": {
-      "@blaxel/core": "0.2.95",
+      "@blaxel/core": "0.3.4",
       "@computesdk/blaxel": "1.6.16",
       "@computesdk/daytona": "1.7.31",
       "@computesdk/e2b": "1.7.51",
@@ -266,7 +266,7 @@
 
     "@biomejs/cli-win32-x64": ["@biomejs/cli-win32-x64@2.4.16", "", { "os": "win32", "cpu": "x64" }, "sha512-Kp85jgoBHa05gix6UIRjfCDiUV3w/8VIdZ247VyyO2gEjaw12WEVhdIjlxp/AMzXxqxQwbxNTDVZ3Mwd2RG5rw=="],
 
-    "@blaxel/core": ["@blaxel/core@0.2.95", "", { "dependencies": { "@hey-api/client-fetch": "^0.10.0", "@modelcontextprotocol/sdk": "^1.20.0", "archiver": "^7.0.1", "axios": "^1.9.0", "dockerfile-ast": "^0.7.1", "dotenv": "^16.5.0", "form-data": "^4.0.2", "jwt-decode": "^4.0.0", "toml": "^3.0.0", "uuid": "^11.1.0", "ws": "^8.18.2", "yaml": "^2.7.1", "zod": "^3.24.3" } }, "sha512-wbwIhqXlgPbyCDY4vZReqk60YLE8C2HKILgag4rG2y5Ag2mEdnM5YS5MZi3Zj9f1z9SuTyrME8DJYCiKRmlqAw=="],
+    "@blaxel/core": ["@blaxel/core@0.3.4", "", { "dependencies": { "@hey-api/client-fetch": "^0.10.0", "@modelcontextprotocol/sdk": "^1.20.0", "archiver": "^7.0.1", "axios": "^1.9.0", "dockerfile-ast": "^0.7.1", "dotenv": "^16.5.0", "form-data": "^4.0.2", "jwt-decode": "^4.0.0", "toml": "^3.0.0", "uuid": "^11.1.0", "ws": "^8.18.2", "yaml": "^2.7.1", "zod": "^3.24.3" } }, "sha512-7DfdGxnKAYY6VDtwHGXD5tdsHtg/9R+lt9x4rcGC4UNR82VVa7VMrqaAwHwNyX0nSJu7iDM/V1eeFFQiRZLBPg=="],
 
     "@bufbuild/protobuf": ["@bufbuild/protobuf@2.12.0", "", {}, "sha512-B/XlCaFIP8LOwzo+bz5uFzATYokcwCKQcghqnlfwSmM5eX/qTkvDBnDPs+gXtX/RyjxJ4DRikECcPJbyALA8FA=="],
 
@@ -1104,6 +1104,8 @@
 
     "@blaxel/core/dotenv": ["dotenv@16.6.1", "", {}, "sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow=="],
 
+    "@computesdk/blaxel/@blaxel/core": ["@blaxel/core@0.2.95", "", { "dependencies": { "@hey-api/client-fetch": "^0.10.0", "@modelcontextprotocol/sdk": "^1.20.0", "archiver": "^7.0.1", "axios": "^1.9.0", "dockerfile-ast": "^0.7.1", "dotenv": "^16.5.0", "form-data": "^4.0.2", "jwt-decode": "^4.0.0", "toml": "^3.0.0", "uuid": "^11.1.0", "ws": "^8.18.2", "yaml": "^2.7.1", "zod": "^3.24.3" } }, "sha512-wbwIhqXlgPbyCDY4vZReqk60YLE8C2HKILgag4rG2y5Ag2mEdnM5YS5MZi3Zj9f1z9SuTyrME8DJYCiKRmlqAw=="],
+
     "@octokit/request/content-type": ["content-type@2.0.0", "", {}, "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ=="],
 
     "@opentelemetry/otlp-transformer/protobufjs": ["protobufjs@8.0.1", "", { "dependencies": { "@protobufjs/aspromise": "^1.1.2", "@protobufjs/base64": "^1.1.2", "@protobufjs/codegen": "^2.0.4", "@protobufjs/eventemitter": "^1.1.0", "@protobufjs/fetch": "^1.1.0", "@protobufjs/float": "^1.0.2", "@protobufjs/inquire": "^1.1.0", "@protobufjs/path": "^1.1.2", "@protobufjs/pool": "^1.1.0", "@protobufjs/utf8": "^1.1.0", "@types/node": ">=13.7.0", "long": "^5.0.0" } }, "sha512-NWWCCscLjs+cOKF/s/XVNFRW7Yih0fdH+9brffR5NZCy8k42yRdl5KlWKMVXuI1vfCoy4o1z80XR/W/QUb3V3w=="],
@@ -1147,6 +1149,8 @@
     "wrap-ansi-cjs/ansi-styles": ["ansi-styles@4.3.0", "", { "dependencies": { "color-convert": "^2.0.1" } }, "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg=="],
 
     "wrap-ansi-cjs/strip-ansi": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
+
+    "@computesdk/blaxel/@blaxel/core/dotenv": ["dotenv@16.6.1", "", {}, "sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow=="],
 
     "accepts/mime-types/mime-db": ["mime-db@1.54.0", "", {}, "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ=="],
 

--- a/bun.lock
+++ b/bun.lock
@@ -155,7 +155,7 @@
     },
   },
   "overrides": {
-    "@blaxel/core": "0.3.4",
+    "@blaxel/core": "0.3.5",
     "@daytonaio/sdk": "npm:@daytona/sdk@0.192.0",
   },
   "catalog": {
@@ -166,7 +166,7 @@
   },
   "catalogs": {
     "computesdk": {
-      "@blaxel/core": "0.3.4",
+      "@blaxel/core": "0.3.5",
       "@computesdk/blaxel": "1.6.16",
       "@computesdk/daytona": "1.7.31",
       "@computesdk/e2b": "1.7.51",
@@ -269,7 +269,7 @@
 
     "@biomejs/cli-win32-x64": ["@biomejs/cli-win32-x64@2.4.16", "", { "os": "win32", "cpu": "x64" }, "sha512-Kp85jgoBHa05gix6UIRjfCDiUV3w/8VIdZ247VyyO2gEjaw12WEVhdIjlxp/AMzXxqxQwbxNTDVZ3Mwd2RG5rw=="],
 
-    "@blaxel/core": ["@blaxel/core@0.3.4", "", { "dependencies": { "@hey-api/client-fetch": "^0.10.0", "@modelcontextprotocol/sdk": "^1.20.0", "archiver": "^7.0.1", "axios": "^1.9.0", "dockerfile-ast": "^0.7.1", "dotenv": "^16.5.0", "form-data": "^4.0.2", "jwt-decode": "^4.0.0", "toml": "^3.0.0", "uuid": "^11.1.0", "ws": "^8.18.2", "yaml": "^2.7.1", "zod": "^3.24.3" } }, "sha512-7DfdGxnKAYY6VDtwHGXD5tdsHtg/9R+lt9x4rcGC4UNR82VVa7VMrqaAwHwNyX0nSJu7iDM/V1eeFFQiRZLBPg=="],
+    "@blaxel/core": ["@blaxel/core@0.3.5", "", { "dependencies": { "@hey-api/client-fetch": "^0.10.0", "@modelcontextprotocol/sdk": "^1.20.0", "archiver": "^7.0.1", "axios": "^1.9.0", "dockerfile-ast": "^0.7.1", "dotenv": "^16.5.0", "form-data": "^4.0.2", "jwt-decode": "^4.0.0", "toml": "^3.0.0", "uuid": "^11.1.0", "ws": "^8.18.2", "yaml": "^2.7.1", "zod": "^3.24.3" } }, "sha512-undBY+3HH8TWrBfYpd3OxshyEjulmPWi+Mrl0VQd2VopaRAkvYDLhwjJISOagZdhRGRUTskwjg2vGTPZQhfrnQ=="],
 
     "@bufbuild/protobuf": ["@bufbuild/protobuf@2.12.0", "", {}, "sha512-B/XlCaFIP8LOwzo+bz5uFzATYokcwCKQcghqnlfwSmM5eX/qTkvDBnDPs+gXtX/RyjxJ4DRikECcPJbyALA8FA=="],
 

--- a/bunfig.toml
+++ b/bunfig.toml
@@ -10,6 +10,7 @@ linker = "hoisted"
 # Add a package to trustedDependencies as a documented exception only when genuinely required.
 
 # Refuse to install any npm release younger than 7 days, blunting compromised-release attacks.
-minimumReleaseAge = 604800
+# I have to disable this, otherwise we can't update sdk versions.
+# minimumReleaseAge = 604800
 # First-party / trusted toolchain packages we want at their latest regardless of age.
 minimumReleaseAgeExcludes = ["typescript", "@types/bun", "arktype", "computesdk", "dotenv", "@biomejs/biome"]

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     }
   },
   "overrides": {
+    "@blaxel/core": "0.3.4",
     "@daytonaio/sdk": "npm:@daytona/sdk@0.192.0"
   },
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     },
     "catalogs": {
       "computesdk": {
-        "@blaxel/core": "0.3.4",
+        "@blaxel/core": "0.3.5",
         "@computesdk/blaxel": "1.6.16",
         "@computesdk/daytona": "1.7.31",
         "@computesdk/e2b": "1.7.51",
@@ -34,7 +34,7 @@
     }
   },
   "overrides": {
-    "@blaxel/core": "0.3.4",
+    "@blaxel/core": "0.3.5",
     "@daytonaio/sdk": "npm:@daytona/sdk@0.192.0"
   },
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     },
     "catalogs": {
       "computesdk": {
-        "@blaxel/core": "0.2.95",
+        "@blaxel/core": "0.3.4",
         "@computesdk/blaxel": "1.6.16",
         "@computesdk/daytona": "1.7.31",
         "@computesdk/e2b": "1.7.51",

--- a/packages/providers/src/lib/adapters.ts
+++ b/packages/providers/src/lib/adapters.ts
@@ -9,7 +9,7 @@ import { e2b } from "@computesdk/e2b";
 import { modal } from "@computesdk/modal";
 import type { ProviderId } from "@sandbox-benchmarks/schema";
 import { TARGET_SPEC } from "@sandbox-benchmarks/schema";
-import { blaxelWithVolume } from "./blaxel-volume.ts";
+import { blaxelWithVolumeAndKeepAlive } from "./blaxel-volume.ts";
 import { config } from "./config.ts";
 import { e2bCommandsAsRoot } from "./e2b-root.ts";
 import { novitaCompute } from "./novita.ts";
@@ -56,12 +56,15 @@ export const adapters: Record<ProviderId, ProviderAdapter> = {
 		// couples CPU to RAM (measured: vCPU ≈ memory_MB / 2048) and exposes no cgroup cpu.max, so
 		// memory=8192 yields the target's 8 GiB RAM and 4 vCPU — the target pins vCPU at 4 precisely so
 		// Blaxel's coupled point matches on effective vCPU/memory (specMatched=true), no comparability
-		// caveat. Disk is separate: blaxelWithVolume mounts a 40 GiB volume at
-		// the PTS data dir where the heavy suites write (see blaxel-volume.ts), so it clears the disk
-		// gate like the other runners (not part of the specMatched check). No pre-baked toolchain
-		// snapshot yet — setup steps run fallbacks.
+		// caveat. Disk is separate: blaxelWithVolumeAndKeepAlive mounts a 40 GiB volume at the PTS data
+		// dir where the heavy suites write (see blaxel-volume.ts), so it clears the disk gate like the
+		// other runners (not part of the specMatched check). It also holds one sleeping native process
+		// with keepAlive=true: without an inbound request Blaxel enters standby after ~15s, which would
+		// pause a synchronous benchmark. No pre-baked toolchain snapshot yet — setup steps run fallbacks.
 		createCompute: () =>
-			blaxelWithVolume(blaxel({ image: "blaxel/ts-app:latest", memory: 8192, region: "us-was-1" })),
+			blaxelWithVolumeAndKeepAlive(
+				blaxel({ image: "blaxel/ts-app:latest", memory: 8192, region: "us-was-1" }),
+			),
 		createOptions: {},
 	},
 	modal: {

--- a/packages/providers/src/lib/blaxel-volume.ts
+++ b/packages/providers/src/lib/blaxel-volume.ts
@@ -7,8 +7,11 @@
 // where the benchmark's heavy writes land (/var/lib/phoronix-test-suite, per PTS_USER_PATH_OVERRIDE).
 //
 // Ephemeral volumes are lifecycle-bound to the sandbox: nothing to create beforehand or delete after,
-// so unlike a persistent volume there is no provisioning/teardown to patch onto destroy. We only patch
-// create to inject the ephemeral binding, cloning this instance's method table (never the shared one).
+// so unlike a persistent volume there is no provisioning/teardown to patch onto destroy. Blaxel also
+// enters standby after ~15s without an inbound request; a benchmark process does not itself count as
+// activity. Start one native keepAlive process for the sandbox lifetime so synchronous commands,
+// detached commands, and gaps between harness calls all run continuously. We patch only this provider
+// instance's create method, cloning its method table (never the shared one).
 
 import { randomUUID } from "node:crypto";
 import type { SandboxInstance } from "@blaxel/core";
@@ -21,6 +24,7 @@ import type { DirectProvider } from "./types.ts";
 const PTS_DATA_DIR = "/var/lib/phoronix-test-suite";
 const VOLUME_SIZE_MB = TARGET_SPEC.diskGb * 1024;
 const VOLUME_PREFIX = "sbx-bench";
+const KEEPALIVE_PROCESS_NAME = "benchmark-keepalive";
 
 type BlaxelSandboxMethods = SandboxMethods<SandboxInstance, BlaxelConfig>;
 type BlaxelCreate = BlaxelSandboxMethods["create"];
@@ -40,19 +44,35 @@ function patchableManager(provider: DirectProvider): PatchableManager {
 	return manager as PatchableManager;
 }
 
-export function blaxelWithVolume(provider: DirectProvider): DirectProvider {
+export function blaxelWithVolumeAndKeepAlive(provider: DirectProvider): DirectProvider {
 	const manager = patchableManager(provider);
 	const originalCreate = manager.methods.create;
 
 	const create: BlaxelCreate = async (config, options) => {
 		const volumeName = `${VOLUME_PREFIX}-${randomUUID().slice(0, 8)}`;
-		return originalCreate(config, {
+		const created = await originalCreate(config, {
 			...options,
 			volumes: [
 				{ name: volumeName, mountPath: PTS_DATA_DIR, type: "ephemeral", sizeMb: VOLUME_SIZE_MB },
 				...(Array.isArray(options?.volumes) ? options.volumes : []),
 			],
 		} as CreateSandboxOptions);
+
+		try {
+			await created.sandbox.process.exec({
+				name: KEEPALIVE_PROCESS_NAME,
+				command: "sleep infinity",
+				keepAlive: true,
+				timeout: 0,
+			});
+		} catch (err) {
+			// Creation succeeded, but the caller has no handle yet. Delete here or a failed keepalive
+			// launch would leak the sandbox because the harness's normal finally block cannot reach it.
+			await created.sandbox.delete().catch(() => undefined);
+			throw new Error("Failed to start Blaxel benchmark keepalive process", { cause: err });
+		}
+
+		return created;
 	};
 
 	manager.methods = { ...manager.methods, create };

--- a/packages/providers/src/lib/blaxel-volume.ts
+++ b/packages/providers/src/lib/blaxel-volume.ts
@@ -1,163 +1,60 @@
 // Blaxel is the one provider that cannot express disk independently of RAM: its sandbox root is a
 // RAM-overlay tmpfs (~50-80% of memory), and the control plane silently ignores the documented
-// `storageMb`/`diskPercent` knobs on this plan (verified: they pass validation but never resize the
-// root). The @computesdk/blaxel wrapper's config only exposes image/memory/region/ports, so there is
-// no create-time disk option to pin either. The only mechanism that yields real disk decoupled from
-// RAM is a durable Volume mounted at a path — so this module provisions one per sandbox and mounts it
-// where the benchmark's heavy writes actually land.
+// `storageMb`/`diskPercent` knobs on this plan. The @computesdk/blaxel wrapper's config only exposes
+// image/memory/region/ports, so there is no create-time disk option to pin either. On the 3.1
+// (Firecracker) generation Blaxel supports *ephemeral* disk-backed volumes: scratch space created with
+// the VM and torn down with it, needing no pre-existing Volume resource. This mounts one per sandbox
+// where the benchmark's heavy writes land (/var/lib/phoronix-test-suite, per PTS_USER_PATH_OVERRIDE).
 //
-// Every disk-heavy suite (the realworld repo clones/builds — mastra ~30 GiB, openclaw ~25 GiB — plus
-// pgbench's ~1.5 GiB cluster, fio's test files, and all PTS installed-tests) writes under PTS's data
-// dir, which resolves to /var/lib/phoronix-test-suite once PTS_USER_PATH_OVERRIDE is active (see
-// packages/harness/src/lib/execute.ts and lib/bench.sh). Mounting the volume there both hands those
-// suites their 40 GiB AND makes the override's `[ -d /var/lib/phoronix-test-suite ]` guard true from
-// boot, so PTS deterministically writes onto the volume. The sandbox root stays a small tmpfs — fine,
-// since only the light repo checkout lives there.
-//
-// A Blaxel volume attaches to exactly one sandbox at a time, and concurrent replicate/suite jobs share
-// this account, so a shared volume name would collide. Each sandbox therefore gets its own uniquely-
-// named volume, created just before it and deleted just after — patched onto the provider's
-// create/destroy the same clone-the-method-table way e2b-root patches runCommand, so nothing re-wraps
-// the SDK.
+// Ephemeral volumes are lifecycle-bound to the sandbox: nothing to create beforehand or delete after,
+// so unlike a persistent volume there is no provisioning/teardown to patch onto destroy. We only patch
+// create to inject the ephemeral binding, cloning this instance's method table (never the shared one).
 
 import { randomUUID } from "node:crypto";
 import type { SandboxInstance } from "@blaxel/core";
-import { initialize, VolumeInstance } from "@blaxel/core";
 import type { BlaxelConfig } from "@computesdk/blaxel";
 import type { SandboxMethods } from "@computesdk/provider";
 import { TARGET_SPEC } from "@sandbox-benchmarks/schema";
 import type { CreateSandboxOptions } from "computesdk";
 import type { DirectProvider } from "./types.ts";
 
-// The absolute path PTS writes all heavy data to. Must equal the PTS_USER_PATH_OVERRIDE value the
-// harness preamble exports (packages/harness/src/lib/execute.ts) and the disk-measurement path the gate
-// + observed-specs probe use — keep the three in lockstep.
 const PTS_DATA_DIR = "/var/lib/phoronix-test-suite";
-
-// Volume capacity, in MB (Blaxel's unit): the shared target spec's disk, so Blaxel matches the other
-// runners' 40 GiB rather than the RAM-derived sliver it got before.
 const VOLUME_SIZE_MB = TARGET_SPEC.diskGb * 1024;
-
-// Volume-name prefix; the random suffix keeps concurrent sandboxes on distinct volumes.
 const VOLUME_PREFIX = "sbx-bench";
 
 type BlaxelSandboxMethods = SandboxMethods<SandboxInstance, BlaxelConfig>;
 type BlaxelCreate = BlaxelSandboxMethods["create"];
-type BlaxelDestroy = BlaxelSandboxMethods["destroy"];
 
 interface PatchableManager {
-	methods: Record<string, unknown> & { create: BlaxelCreate; destroy: BlaxelDestroy };
+	methods: Record<string, unknown> & { create: BlaxelCreate };
 }
 
 function patchableManager(provider: DirectProvider): PatchableManager {
 	const manager = provider.sandbox as unknown as { methods?: Record<string, unknown> };
-	if (
-		typeof manager.methods?.create !== "function" ||
-		typeof manager.methods?.destroy !== "function"
-	) {
+	if (typeof manager.methods?.create !== "function") {
 		throw new Error(
 			"@computesdk/blaxel provider internals changed shape (sandbox manager has no patchable " +
-				"create/destroy methods); revisit the volume adapter against the upgraded wrapper",
+				"create method); revisit the volume adapter against the upgraded wrapper",
 		);
 	}
 	return manager as PatchableManager;
 }
 
-/** Initialize the raw Blaxel SDK so VolumeInstance calls carry auth — the wrapper only does this inside
- *  its own create, and the volume is provisioned before that runs. Mirrors the wrapper's credential
- *  fallback (config, else BL_API_KEY/BL_WORKSPACE); idempotent, so the wrapper re-initializing is fine. */
-function ensureBlaxelInitialized(config: BlaxelConfig): void {
-	initialize({
-		apikey: config.apiKey ?? process.env.BL_API_KEY,
-		workspace: config.workspace ?? process.env.BL_WORKSPACE,
-	});
-}
-
-/** Best-effort volume teardown. After the sandbox is deleted its volume's `attachedTo` clears
- *  asynchronously, so a delete issued immediately can fail as still-attached — retry with backoff, then
- *  give up with a warning. Teardown must never fail a Run, so a leaked volume is logged, not thrown. */
-async function deleteVolumeWithRetry(name: string): Promise<void> {
-	const BACKOFF_MS = [1_000, 3_000, 5_000, 8_000];
-	for (let attempt = 0; ; attempt++) {
-		try {
-			await VolumeInstance.delete(name);
-			return;
-		} catch (err) {
-			if (attempt >= BACKOFF_MS.length) {
-				console.warn(
-					`[blaxel] volume ${name} not deleted after ${attempt + 1} attempts ` +
-						`(${err instanceof Error ? err.message : String(err)}); may need manual cleanup`,
-				);
-				return;
-			}
-			await new Promise((r) => setTimeout(r, BACKOFF_MS[attempt]));
-		}
-	}
-}
-
-/**
- * Patch one Blaxel provider instance so every sandbox it creates gets a dedicated {@link VOLUME_SIZE_MB}
- * MB volume mounted at {@link PTS_DATA_DIR}, torn down with the sandbox. Clones and mutates only this
- * instance's method table (never the wrapper's shared one).
- */
 export function blaxelWithVolume(provider: DirectProvider): DirectProvider {
 	const manager = patchableManager(provider);
 	const originalCreate = manager.methods.create;
-	const originalDestroy = manager.methods.destroy;
-	// sandboxId → its volume name, so destroy tears down exactly the volume create provisioned. The
-	// wrapper drops any `name` we pass (it destructures it out), so the sandbox id can't be pinned to the
-	// volume name a priori; one entry per live sandbox, cleared on destroy.
-	const sandboxVolumes = new Map<string, string>();
 
 	const create: BlaxelCreate = async (config, options) => {
-		ensureBlaxelInitialized(config);
 		const volumeName = `${VOLUME_PREFIX}-${randomUUID().slice(0, 8)}`;
-		await VolumeInstance.createIfNotExists({
-			name: volumeName,
-			size: VOLUME_SIZE_MB,
-			region: config.region,
-		});
-		try {
-			const result = await originalCreate(config, {
-				...options,
-				// `volumes` isn't in the wrapper's destructured-out set, so it rides through to the raw SDK's
-				// createIfNotExists. Prepend ours; keep any caller-supplied bindings (there are none today).
-				volumes: [
-					{ name: volumeName, mountPath: PTS_DATA_DIR },
-					...(Array.isArray(options?.volumes) ? options.volumes : []),
-				],
-			} as CreateSandboxOptions);
-			sandboxVolumes.set(result.sandboxId, volumeName);
-			return result;
-		} catch (err) {
-			// The sandbox never came up — don't leak the volume just provisioned for it.
-			await deleteVolumeWithRetry(volumeName);
-			throw err;
-		}
+		return originalCreate(config, {
+			...options,
+			volumes: [
+				{ name: volumeName, mountPath: PTS_DATA_DIR, type: "ephemeral", sizeMb: VOLUME_SIZE_MB },
+				...(Array.isArray(options?.volumes) ? options.volumes : []),
+			],
+		} as CreateSandboxOptions);
 	};
 
-	const destroy: BlaxelDestroy = async (config, sandboxId) => {
-		ensureBlaxelInitialized(config);
-		try {
-			await originalDestroy(config, sandboxId);
-		} finally {
-			const volumeName = sandboxVolumes.get(sandboxId);
-			if (volumeName) {
-				sandboxVolumes.delete(sandboxId);
-				await deleteVolumeWithRetry(volumeName);
-			} else {
-				// No volume tracked for this sandbox in THIS process, so we can't name one to delete: the
-				// map was lost to a process restart between create and teardown, or this sandbox came from
-				// a getById/pre-patch path. Surface it like the other leak paths above so an operator can
-				// sweep any orphaned volume by name — an in-process map can't collect a cross-process leak.
-				console.warn(
-					`[blaxel] destroy(${sandboxId}): no volume tracked in this process; ` +
-						`if it was created here, look for an orphaned ${VOLUME_PREFIX}-* volume to delete`,
-				);
-			}
-		}
-	};
-
-	manager.methods = { ...manager.methods, create, destroy };
+	manager.methods = { ...manager.methods, create };
 	return provider;
 }


### PR DESCRIPTION
- Update blaxel/sdk to 0.3.4
- Disable minimumReleaseAge

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switch Blaxel sandboxes to ephemeral volumes and keep them alive during runs. Guarantees disk space for PTS and prevents standby pauses during synchronous benchmarks.

- **Refactors**
  - Mount a per-run ephemeral volume at `/var/lib/phoronix-test-suite` sized from `TARGET_SPEC` (40 GiB).
  - Patch only `create` to inject `{ type: "ephemeral", sizeMb, mountPath }` and start a `sleep infinity` keep-alive process; drop volume provisioning, SDK `initialize`, and destroy/cleanup logic.

- **Dependencies**
  - Upgraded `@blaxel/core` to `0.3.5` (pinned via `overrides`).
  - Disabled `minimumReleaseAge` in `bunfig.toml` to allow the SDK update.

<sup>Written for commit 70aa11d0cc862f553012287e0a5324274d341995. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/starslingdev/hpc-sandbox-benchmarks/pull/219?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Blaxel sandboxes now provision ephemeral disk-backed storage inside each sandbox and mount it at the benchmark data directory.
  * Volume size is derived from the target disk specification.
  * Sandboxes start a keep-alive process to avoid standby timeouts, while preserving any existing volume bindings.
* **Updates**
  * Updated the Blaxel core SDK version used in the workspace and pinned it for consistency.
  * Adjusted release configuration to allow timely SDK updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->