### PR TITLE
chore(dataset): publish run 29741364586

### DIFF
--- a/LEADERBOARD.md
+++ b/LEADERBOARD.md
@@ -1,10 +1,10 @@
 # Sandbox provider leaderboard
 
-Run `29692210375` · commit `81e641fed66fc981d1e2b4fedc6a646d318b361c` · generated 2026-07-19T16:29:20.252Z
+Run `29741364586` · commit `b5e93145866d53d9378fa70823fd7d770e8ee8ae` · generated 2026-07-20T12:28:37.898Z
 
-Requested target for every provider: **4 vCPU · 8 GiB RAM · 40 GB disk**. This run contains **163 metric records**
-backed by **247 retained trial observations**, across **40 metrics** and
-**5 providers**; every emitted, catalogued metric has a ranked table below
+Requested target for every provider: **4 vCPU · 8 GiB RAM · 40 GB disk**. This run contains **35 metric records**
+backed by **53 retained trial observations**, across **35 metrics** and
+**1 provider**; every emitted, catalogued metric has a ranked table below
 (median of retained trials), grouped by dimension with its headline first.
 Generated from the published Run dataset — do not edit by hand. Methodology:
 [`docs/methodology.md`](docs/methodology.md).
@@ -20,15 +20,11 @@ surfaced through coverage gaps, not part of the compute-match verdict.
 
 runs/s · higher is better
 
-_Daytona leads on median (higher is better); see notes for how ranks are decided._
+_Blaxel is the only ranked provider (20.48 runs/s; higher is better)._
 
-| Rank | Provider | Node.js web tooling (runs/s) | 95% bootstrap interval | n | Note |
-| ---: | --- | ---: | ---: | ---: | --- |
-| 1 | Daytona | 18.46 | 18.29 – 18.64 | 2 | — |
-| 2 | Novita | 17.8 | 17.63 – 17.97 | 2 | n too small |
-| 3 | Blaxel | 13.64 | 13.54 – 13.75 | 2 | n too small |
-| 4 | E2B | 11.38 | 11.26 – 11.5 | 2 | n too small |
-| 5 | Modal | 8.965 | 8.96 – 8.97 | 2 | n too small |
+| Rank | Provider | Node.js web tooling (runs/s) | 95% bootstrap interval | n |
+| ---: | --- | ---: | ---: | ---: |
+| 1 | Blaxel | 20.48 | 20.44 – 20.52 | 2 |
 
 ## disk
 
@@ -36,117 +32,81 @@ _Daytona leads on median (higher is better); see notes for how ranks are decided
 
 IOPS · higher is better
 
-_Blaxel leads on median (higher is better); see notes for how ranks are decided._
+_Blaxel is the only ranked provider (215500 IOPS; higher is better)._
 
-| Rank | Provider | fio rand read 4KB, O_DIRECT (IOPS) (IOPS) | 95% bootstrap interval | n | Note |
-| ---: | --- | ---: | ---: | ---: | --- |
-| 1 | Blaxel | 268000 | 264000 – 272000 | 2 | — |
-| 2 | Daytona | 264000 | 264000 – 264000 | 2 | n too small |
-| 3 | Novita | 75900 | 73800 – 78000 | 2 | n too small |
-| 4 | E2B | 45000 | 44100 – 45900 | 2 | n too small |
+| Rank | Provider | fio rand read 4KB, O_DIRECT (IOPS) (IOPS) | 95% bootstrap interval | n |
+| ---: | --- | ---: | ---: | ---: |
+| 1 | Blaxel | 215500 | 214000 – 217000 | 2 |
 
 ### fio rand read 4KB, O_DIRECT (MB/s)
 
 MB/s · higher is better
 
-_Blaxel leads on median (higher is better); see notes for how ranks are decided._
+_Blaxel is the only ranked provider (843 MB/s; higher is better)._
 
-| Rank | Provider | fio rand read 4KB, O_DIRECT (MB/s) (MB/s) | 95% bootstrap interval | n | Note |
-| ---: | --- | ---: | ---: | ---: | --- |
-| 1 | Blaxel | 1047 | 1030 – 1063 | 2 | — |
-| 2 | Daytona | 1031 | 1030 – 1032 | 2 | n too small |
-| 3 | Novita | 296.5 | 288 – 305 | 2 | n too small |
-| 4 | E2B | 175.5 | 172 – 179 | 2 | n too small |
+| Rank | Provider | fio rand read 4KB, O_DIRECT (MB/s) (MB/s) | 95% bootstrap interval | n |
+| ---: | --- | ---: | ---: | ---: |
+| 1 | Blaxel | 843 | 837 – 849 | 2 |
 
 ### fio rand write 4KB, O_DIRECT (IOPS)
 
 IOPS · higher is better
 
-_Blaxel leads · ~1.1× Daytona on median (higher is better)._
+_Blaxel is the only ranked provider (220500 IOPS; higher is better)._
 
-| Rank | Provider | fio rand write 4KB, O_DIRECT (IOPS) (IOPS) | 95% bootstrap interval | n | Note |
-| ---: | --- | ---: | ---: | ---: | --- |
-| 1 | Blaxel | 249000 | 248000 – 250000 | 2 | — |
-| 2 | Daytona | 228500 | 228000 – 229000 | 2 | n too small |
-| 3 | Novita | 78050 | 76900 – 79200 | 2 | n too small |
-| 4 | E2B | 45900 | 45700 – 46100 | 2 | n too small |
+| Rank | Provider | fio rand write 4KB, O_DIRECT (IOPS) (IOPS) | 95% bootstrap interval | n |
+| ---: | --- | ---: | ---: | ---: |
+| 1 | Blaxel | 220500 | 213000 – 228000 | 2 |
 
 ### fio rand write 4KB, O_DIRECT (MB/s)
 
 MB/s · higher is better
 
-_Blaxel leads · ~1.1× Daytona on median (higher is better)._
+_Blaxel is the only ranked provider (863 MB/s; higher is better)._
 
-| Rank | Provider | fio rand write 4KB, O_DIRECT (MB/s) (MB/s) | 95% bootstrap interval | n | Note |
-| ---: | --- | ---: | ---: | ---: | --- |
-| 1 | Blaxel | 973.5 | 970 – 977 | 2 | — |
-| 2 | Daytona | 894.5 | 893 – 896 | 2 | n too small |
-| 3 | Novita | 305 | 301 – 309 | 2 | n too small |
-| 4 | E2B | 179 | 178 – 180 | 2 | n too small |
+| Rank | Provider | fio rand write 4KB, O_DIRECT (MB/s) (MB/s) | 95% bootstrap interval | n |
+| ---: | --- | ---: | ---: | ---: |
+| 1 | Blaxel | 863 | 834 – 892 | 2 |
 
 ### fio seq read 1MB, O_DIRECT (IOPS)
 
 IOPS · higher is better
 
-_Novita leads · ~1.5× Daytona on median (higher is better)._
+_Blaxel is the only ranked provider (10450 IOPS; higher is better)._
 
-| Rank | Provider | fio seq read 1MB, O_DIRECT (IOPS) (IOPS) | 95% bootstrap interval | n | Note |
-| ---: | --- | ---: | ---: | ---: | --- |
-| 1 | Novita | 11000 | 10700 – 11300 | 2 | — |
-| 2 | Daytona | 7243 | 6765 – 7720 | 2 | n too small |
-| 3 | Blaxel | 3054 | 3030 – 3077 | 2 | n too small |
-| 4 | E2B | 599.5 | 599 – 600 | 2 | n too small |
-
-### fio seq read 1MB, O_DIRECT (MB/s)
-
-MB/s · higher is better
-
-_Daytona leads · ~2.4× Blaxel on median (higher is better)._
-
-| Rank | Provider | fio seq read 1MB, O_DIRECT (MB/s) (MB/s) | 95% bootstrap interval | n | Note |
-| ---: | --- | ---: | ---: | ---: | --- |
-| 1 | Daytona | 7245 | 6767 – 7722 | 2 | — |
-| 2 | Blaxel | 3055 | 3031 – 3079 | 2 | n too small |
-| 3 | E2B | 601 | 601 – 601 | 2 | n too small |
+| Rank | Provider | fio seq read 1MB, O_DIRECT (IOPS) (IOPS) | 95% bootstrap interval | n |
+| ---: | --- | ---: | ---: | ---: |
+| 1 | Blaxel | 10450 | 10300 – 10600 | 2 |
 
 ### fio seq write 1MB, O_DIRECT (IOPS)
 
 IOPS · higher is better
 
-_Novita leads · ~1.8× Daytona on median (higher is better)._
+_Blaxel is the only ranked provider (5513 IOPS; higher is better)._
 
-| Rank | Provider | fio seq write 1MB, O_DIRECT (IOPS) (IOPS) | 95% bootstrap interval | n | Note |
-| ---: | --- | ---: | ---: | ---: | --- |
-| 1 | Novita | 6580 | 6485 – 6675 | 2 | — |
-| 2 | Daytona | 3695 | 3660 – 3729 | 2 | n too small |
-| 3 | Blaxel | 2600 | 2562 – 2637 | 2 | n too small |
-| 4 | E2B | 599.5 | 599 – 600 | 2 | n too small |
+| Rank | Provider | fio seq write 1MB, O_DIRECT (IOPS) (IOPS) | 95% bootstrap interval | n |
+| ---: | --- | ---: | ---: | ---: |
+| 1 | Blaxel | 5513 | 5270 – 5756 | 2 |
 
 ### fio seq write 1MB, O_DIRECT (MB/s)
 
 MB/s · higher is better
 
-_Novita leads · ~1.8× Daytona on median (higher is better)._
+_Blaxel is the only ranked provider (5515 MB/s; higher is better)._
 
-| Rank | Provider | fio seq write 1MB, O_DIRECT (MB/s) (MB/s) | 95% bootstrap interval | n | Note |
-| ---: | --- | ---: | ---: | ---: | --- |
-| 1 | Novita | 6582 | 6486 – 6677 | 2 | — |
-| 2 | Daytona | 3696 | 3661 – 3731 | 2 | n too small |
-| 3 | Blaxel | 2601 | 2563 – 2639 | 2 | n too small |
-| 4 | E2B | 601 | 601 – 601 | 2 | n too small |
+| Rank | Provider | fio seq write 1MB, O_DIRECT (MB/s) (MB/s) | 95% bootstrap interval | n |
+| ---: | --- | ---: | ---: | ---: |
+| 1 | Blaxel | 5515 | 5272 – 5757 | 2 |
 
 ### Hardlink throughput
 
 bogo ops/s · higher is better
 
-_Daytona leads · ~1.4× Novita on median (higher is better)._
+_Blaxel is the only ranked provider (19.38 bogo ops/s; higher is better)._
 
-| Rank | Provider | Hardlink throughput (bogo ops/s) | 95% bootstrap interval | n | Note |
-| ---: | --- | ---: | ---: | ---: | --- |
-| 1 | Daytona | 26.23 | 26.06 – 26.39 | 2 | — |
-| 2 | Novita | 19.22 | 19.22 – 19.22 | 2 | n too small |
-| 3 | E2B | 1.445 | 1.43 – 1.46 | 2 | n too small |
-| 4 | Blaxel | 0.35 | 0.35 – 0.35 | 2 | n too small |
+| Rank | Provider | Hardlink throughput (bogo ops/s) | 95% bootstrap interval | n |
+| ---: | --- | ---: | ---: | ---: |
+| 1 | Blaxel | 19.38 | 19.36 – 19.39 | 2 |
 
 ## memory
 
@@ -154,53 +114,41 @@ _Daytona leads · ~1.4× Novita on median (higher is better)._
 
 MB/s · higher is better
 
-_Daytona leads · ~2.2× Blaxel on median (higher is better)._
+_Blaxel is the only ranked provider (125900 MB/s; higher is better)._
 
-| Rank | Provider | STREAM Triad (MB/s) | 95% bootstrap interval | n | Note |
-| ---: | --- | ---: | ---: | ---: | --- |
-| 1 | Daytona | 121600 | 113600 – 129600 | 2 | — |
-| 2 | Blaxel | 54290 | 53940 – 54640 | 2 | n too small |
-| 3 | Novita | 53320 | 53210 – 53420 | 2 | n too small |
-| 4 | E2B | 47210 | 46960 – 47470 | 2 | n too small |
+| Rank | Provider | STREAM Triad (MB/s) | 95% bootstrap interval | n |
+| ---: | --- | ---: | ---: | ---: |
+| 1 | Blaxel | 125900 | 124300 – 127600 | 2 |
 
 ### STREAM Add
 
 MB/s · higher is better
 
-_Daytona leads · ~2.2× Blaxel on median (higher is better)._
+_Blaxel is the only ranked provider (126470 MB/s; higher is better)._
 
-| Rank | Provider | STREAM Add (MB/s) | 95% bootstrap interval | n | Note |
-| ---: | --- | ---: | ---: | ---: | --- |
-| 1 | Daytona | 118300 | 115400 – 121172 | 2 | — |
-| 2 | Blaxel | 53580 | 53070 – 54100 | 2 | n too small |
-| 3 | Novita | 53440 | 53310 – 53580 | 2 | n too small |
-| 4 | E2B | 47680 | 47600 – 47760 | 2 | n too small |
+| Rank | Provider | STREAM Add (MB/s) | 95% bootstrap interval | n |
+| ---: | --- | ---: | ---: | ---: |
+| 1 | Blaxel | 126470 | 124800 – 128100 | 2 |
 
 ### STREAM Copy
 
 MB/s · higher is better
 
-_Daytona leads · ~1.5× Blaxel on median (higher is better)._
+_Blaxel is the only ranked provider (145221 MB/s; higher is better)._
 
-| Rank | Provider | STREAM Copy (MB/s) | 95% bootstrap interval | n | Note |
-| ---: | --- | ---: | ---: | ---: | --- |
-| 1 | Daytona | 141500 | 137100 – 145800 | 2 | — |
-| 2 | Blaxel | 91561 | 90900 – 92230 | 2 | n too small |
-| 3 | E2B | 81810 | 80415 – 83200 | 2 | n too small |
-| 4 | Novita | 58420 | 58330 – 58510 | 2 | n too small |
+| Rank | Provider | STREAM Copy (MB/s) | 95% bootstrap interval | n |
+| ---: | --- | ---: | ---: | ---: |
+| 1 | Blaxel | 145221 | 144400 – 146000 | 2 |
 
 ### STREAM Scale
 
 MB/s · higher is better
 
-_Daytona leads · ~2.2× Novita on median (higher is better)._
+_Blaxel is the only ranked provider (119600 MB/s; higher is better)._
 
-| Rank | Provider | STREAM Scale (MB/s) | 95% bootstrap interval | n | Note |
-| ---: | --- | ---: | ---: | ---: | --- |
-| 1 | Daytona | 110100 | 105300 – 114900 | 2 | — |
-| 2 | Novita | 50590 | 50540 – 50640 | 2 | n too small |
-| 3 | Blaxel | 48160 | 46790 – 49530 | 2 | n too small |
-| 4 | E2B | 42190 | 41957 – 42430 | 2 | n too small |
+| Rank | Provider | STREAM Scale (MB/s) | 95% bootstrap interval | n |
+| ---: | --- | ---: | ---: | ---: |
+| 1 | Blaxel | 119600 | 118400 – 120700 | 2 |
 
 ## network
 
@@ -208,106 +156,51 @@ _Daytona leads · ~2.2× Novita on median (higher is better)._
 
 Seconds · lower is better
 
-_Daytona leads · Blaxel is ~1.1× higher (lower is better)._
+_Blaxel is the only ranked provider (2.771 Seconds; lower is better)._
 
-| Rank | Provider | Loopback TCP (10GB) (Seconds) | 95% bootstrap interval | n | Note |
-| ---: | --- | ---: | ---: | ---: | --- |
-| 1 | Daytona | 4.96 | 4.855 – 5.066 | 2 | — |
-| 2 | Blaxel | 5.657 | 5.469 – 5.845 | 2 | n too small |
-| 3 | Novita | 7.949 | 7.777 – 8.121 | 2 | n too small |
-| 4 | E2B | 9.771 | 9.272 – 10.27 | 2 | n too small |
-| 5 | Modal | 42.22 | 40.95 – 43.49 | 2 | n too small |
+| Rank | Provider | Loopback TCP (10GB) (Seconds) | 95% bootstrap interval | n |
+| ---: | --- | ---: | ---: | ---: |
+| 1 | Blaxel | 2.771 | 2.157 – 3.385 | 2 |
 
 ### fast.com download
 
 Mbit/s · higher is better
 
-_Blaxel leads · ~6.3× Modal on median (higher is better)._
+_Blaxel is the only ranked provider (4.5 Mbit/s; higher is better)._
 
-| Rank | Provider | fast.com download (Mbit/s) | 95% bootstrap interval | n | Note |
-| ---: | --- | ---: | ---: | ---: | --- |
-| 1 | Blaxel | 3650 | 3500 – 3800 | 2 | — |
-| 2 | Modal | 575 | 400 – 750 | 2 | n too small |
-| 3 | Novita | 122 | 14 – 230 | 2 | n too small |
-| 4 | E2B | 1.235 | 0.67 – 1.8 | 2 | n too small |
+| Rank | Provider | fast.com download (Mbit/s) | 95% bootstrap interval | n |
+| ---: | --- | ---: | ---: | ---: |
+| 1 | Blaxel | 4.5 | 3.3 – 5.7 | 2 |
 
 ### fast.com latency
 
 ms · lower is better
 
-_Blaxel leads · E2B is ~1.2× higher (lower is better)._
+_Blaxel is the only ranked provider (3.5 ms; lower is better)._
 
-| Rank | Provider | fast.com latency (ms) | 95% bootstrap interval | n | Note |
-| ---: | --- | ---: | ---: | ---: | --- |
-| 1 | Blaxel | 6 | 6 – 6 | 2 | — |
-| 2 | E2B | 7 | 7 – 7 | 2 | n too small |
-| 3 | Novita | 10 | 9 – 11 | 2 | n too small |
-| 4 | Modal | 79.5 | 78 – 81 | 2 | n too small |
+| Rank | Provider | fast.com latency (ms) | 95% bootstrap interval | n |
+| ---: | --- | ---: | ---: | ---: |
+| 1 | Blaxel | 3.5 | 3 – 4 | 2 |
 
 ### fast.com loaded latency
 
 ms · lower is better
 
-_E2B leads · Novita is ~1.3× higher (lower is better)._
+_Blaxel is the only ranked provider (7 ms; lower is better)._
 
 | Rank | Provider | fast.com loaded latency (ms) | 95% bootstrap interval | n |
 | ---: | --- | ---: | ---: | ---: |
-| 1 | E2B | 8 | — | 1 |
-| 2 | Novita | 10 | — | 1 |
-| 3 | Modal | 80 | — | 1 |
+| 1 | Blaxel | 7 | 7 – 7 | 2 |
 
 ### fast.com upload
 
 Mbit/s · higher is better
 
-_Novita leads · ~2.0× Blaxel on median (higher is better)._
+_Blaxel is the only ranked provider (2050 Mbit/s; higher is better)._
 
-| Rank | Provider | fast.com upload (Mbit/s) | 95% bootstrap interval | n | Note |
-| ---: | --- | ---: | ---: | ---: | --- |
-| 1 | Novita | 2900 | 2700 – 3100 | 2 | — |
-| 2 | Blaxel | 1450 | 1400 – 1500 | 2 | n too small |
-| 3 | E2B | 965 | 830 – 1100 | 2 | n too small |
-| 4 | Modal | 245 | 220 – 270 | 2 | n too small |
-
-## system
-
-### PyBench _(headline)_
-
-Milliseconds · lower is better
-
-_Blaxel is the only ranked provider (841 Milliseconds; lower is better)._
-
-| Rank | Provider | PyBench (Milliseconds) | 95% bootstrap interval | n |
+| Rank | Provider | fast.com upload (Mbit/s) | 95% bootstrap interval | n |
 | ---: | --- | ---: | ---: | ---: |
-| 1 | Blaxel | 841 | 837 – 845 | 2 |
-
-### Git common operations
-
-Seconds · lower is better
-
-_Daytona leads · Novita is ~1.2× higher (lower is better)._
-
-| Rank | Provider | Git common operations (Seconds) | 95% bootstrap interval | n | Note |
-| ---: | --- | ---: | ---: | ---: | --- |
-| 1 | Daytona | 36.07 | 35.8 – 36.35 | 2 | — |
-| 2 | Novita | 43.32 | 43.23 – 43.4 | 2 | n too small |
-| 3 | E2B | 64.34 | 63.92 – 64.77 | 2 | n too small |
-| 4 | Blaxel | 71.15 | 70.76 – 71.53 | 2 | n too small |
-| 5 | Modal | 89.35 | 86.9 – 91.8 | 2 | n too small |
-
-### SQLite Speedtest
-
-Seconds · lower is better
-
-_Daytona leads · Novita is ~1.3× higher (lower is better)._
-
-| Rank | Provider | SQLite Speedtest (Seconds) | 95% bootstrap interval | n | Note |
-| ---: | --- | ---: | ---: | ---: | --- |
-| 1 | Daytona | 30.72 | 30.58 – 30.86 | 2 | — |
-| 2 | Novita | 39.01 | 38.85 – 39.17 | 2 | n too small |
-| 3 | Blaxel | 68.08 | 66.68 – 69.48 | 2 | n too small |
-| 4 | E2B | 71.16 | 69.36 – 72.95 | 2 | n too small |
-| 5 | Modal | 493.6 | 481.6 – 505.7 | 2 | n too small |
+| 1 | Blaxel | 2050 | 2000 – 2100 | 2 |
 
 ## realworld
 
@@ -315,266 +208,209 @@ _Daytona leads · Novita is ~1.3× higher (lower is better)._
 
 Seconds · lower is better
 
-_Daytona leads · Novita is ~1.3× higher (lower is better)._
+_Blaxel is the only ranked provider (25.1 Seconds; lower is better)._
 
 | Rank | Provider | Mastra: cold install (Seconds) | 95% bootstrap interval | n |
 | ---: | --- | ---: | ---: | ---: |
-| 1 | Daytona | 25.41 | — | 1 |
-| 2 | Novita | 32.93 | — | 1 |
-| 3 | Blaxel | 41.65 | — | 1 |
-| 4 | Modal | 63.26 | — | 1 |
+| 1 | Blaxel | 25.1 | — | 1 |
 
 ### Better-Auth: build
 
 Seconds · lower is better
 
-_Daytona leads · Novita is ~1.1× higher (lower is better)._
+_Blaxel is the only ranked provider (56.97 Seconds; lower is better)._
 
 | Rank | Provider | Better-Auth: build (Seconds) | 95% bootstrap interval | n |
 | ---: | --- | ---: | ---: | ---: |
-| 1 | Daytona | 56.23 | — | 1 |
-| 2 | Novita | 63.5 | — | 1 |
-| 3 | Blaxel | 97.76 | — | 1 |
-| 4 | E2B | 110.2 | — | 1 |
-| 5 | Modal | 141.5 | — | 1 |
+| 1 | Blaxel | 56.97 | — | 1 |
 
 ### Better-Auth: cold install
 
 Seconds · lower is better
 
-_Daytona leads on median (lower is better); see notes for how ranks are decided._
+_Blaxel is the only ranked provider (10.82 Seconds; lower is better)._
 
 | Rank | Provider | Better-Auth: cold install (Seconds) | 95% bootstrap interval | n |
 | ---: | --- | ---: | ---: | ---: |
-| 1 | Daytona | 10.47 | — | 1 |
-| 2 | Novita | 10.79 | — | 1 |
-| 3 | E2B | 18.78 | — | 1 |
-| 4 | Modal | 29.84 | — | 1 |
-| 5 | Blaxel | 31.24 | — | 1 |
+| 1 | Blaxel | 10.82 | — | 1 |
 
 ### Better-Auth: git clone
 
 Seconds · lower is better
 
-_E2B leads · Daytona is ~1.1× higher (lower is better)._
+_Blaxel is the only ranked provider (1.354 Seconds; lower is better)._
 
 | Rank | Provider | Better-Auth: git clone (Seconds) | 95% bootstrap interval | n |
 | ---: | --- | ---: | ---: | ---: |
-| 1 | E2B | 1.697 | — | 1 |
-| 2 | Daytona | 1.787 | — | 1 |
-| 3 | Novita | 2.354 | — | 1 |
-| 4 | Modal | 2.706 | — | 1 |
-| 5 | Blaxel | 3.505 | — | 1 |
+| 1 | Blaxel | 1.354 | — | 1 |
 
 ### Better-Auth: lint (Biome)
 
 Seconds · lower is better
 
-_Daytona leads · Novita is ~1.1× higher (lower is better)._
+_Blaxel is the only ranked provider (3.173 Seconds; lower is better)._
 
 | Rank | Provider | Better-Auth: lint (Biome) (Seconds) | 95% bootstrap interval | n |
 | ---: | --- | ---: | ---: | ---: |
-| 1 | Daytona | 2.909 | — | 1 |
-| 2 | Novita | 3.173 | — | 1 |
-| 3 | E2B | 6.168 | — | 1 |
-| 4 | Blaxel | 7.247 | — | 1 |
-| 5 | Modal | 11.19 | — | 1 |
+| 1 | Blaxel | 3.173 | — | 1 |
 
 ### Better-Auth: lint deps (Knip)
 
 Seconds · lower is better
 
-_Daytona leads · Novita is ~1.1× higher (lower is better)._
+_Blaxel is the only ranked provider (9.902 Seconds; lower is better)._
 
 | Rank | Provider | Better-Auth: lint deps (Knip) (Seconds) | 95% bootstrap interval | n |
 | ---: | --- | ---: | ---: | ---: |
-| 1 | Daytona | 9.632 | — | 1 |
-| 2 | Novita | 10.5 | — | 1 |
-| 3 | E2B | 20.02 | — | 1 |
-| 4 | Blaxel | 23.05 | — | 1 |
-| 5 | Modal | 30.08 | — | 1 |
+| 1 | Blaxel | 9.902 | — | 1 |
 
 ### Better-Auth: lint format
 
 Seconds · lower is better
 
-_Daytona leads · Novita is ~1.1× higher (lower is better)._
+_Blaxel is the only ranked provider (2.93 Seconds; lower is better)._
 
 | Rank | Provider | Better-Auth: lint format (Seconds) | 95% bootstrap interval | n |
 | ---: | --- | ---: | ---: | ---: |
-| 1 | Daytona | 2.62 | — | 1 |
-| 2 | Novita | 2.815 | — | 1 |
-| 3 | Blaxel | 5.146 | — | 1 |
-| 4 | E2B | 5.485 | — | 1 |
-| 5 | Modal | 6.694 | — | 1 |
+| 1 | Blaxel | 2.93 | — | 1 |
 
 ### Better-Auth: lint packages
 
 Seconds · lower is better
 
-_Daytona leads on median (lower is better); see notes for how ranks are decided._
+_Blaxel is the only ranked provider (2.536 Seconds; lower is better)._
 
 | Rank | Provider | Better-Auth: lint packages (Seconds) | 95% bootstrap interval | n |
 | ---: | --- | ---: | ---: | ---: |
-| 1 | Daytona | 2.466 | — | 1 |
-| 2 | Novita | 2.58 | — | 1 |
-| 3 | Blaxel | 4.542 | — | 1 |
-| 4 | E2B | 4.644 | — | 1 |
-| 5 | Modal | 11.65 | — | 1 |
+| 1 | Blaxel | 2.536 | — | 1 |
 
 ### Better-Auth: lint spell
 
 Seconds · lower is better
 
-_Daytona leads · Novita is ~1.1× higher (lower is better)._
+_Blaxel is the only ranked provider (6.771 Seconds; lower is better)._
 
 | Rank | Provider | Better-Auth: lint spell (Seconds) | 95% bootstrap interval | n |
 | ---: | --- | ---: | ---: | ---: |
-| 1 | Daytona | 6.559 | — | 1 |
-| 2 | Novita | 7.3 | — | 1 |
-| 3 | Blaxel | 12.56 | — | 1 |
-| 4 | E2B | 14.86 | — | 1 |
-| 5 | Modal | 17.09 | — | 1 |
+| 1 | Blaxel | 6.771 | — | 1 |
 
 ### Better-Auth: lint types
 
 Seconds · lower is better
 
-_Daytona leads · Novita is ~1.2× higher (lower is better)._
+_Blaxel is the only ranked provider (25.27 Seconds; lower is better)._
 
 | Rank | Provider | Better-Auth: lint types (Seconds) | 95% bootstrap interval | n |
 | ---: | --- | ---: | ---: | ---: |
-| 1 | Daytona | 25.14 | — | 1 |
-| 2 | Novita | 29.19 | — | 1 |
-| 3 | Blaxel | 55.6 | — | 1 |
-| 4 | E2B | 56.49 | — | 1 |
-| 5 | Modal | 108.5 | — | 1 |
+| 1 | Blaxel | 25.27 | — | 1 |
 
 ### Better-Auth: typecheck
 
 Seconds · lower is better
 
-_Daytona leads · Novita is ~1.1× higher (lower is better)._
+_Blaxel is the only ranked provider (41.11 Seconds; lower is better)._
 
 | Rank | Provider | Better-Auth: typecheck (Seconds) | 95% bootstrap interval | n |
 | ---: | --- | ---: | ---: | ---: |
-| 1 | Daytona | 39.74 | — | 1 |
-| 2 | Novita | 43.39 | — | 1 |
-| 3 | Blaxel | 66.09 | — | 1 |
-| 4 | E2B | 83.5 | — | 1 |
-| 5 | Modal | 87.87 | — | 1 |
+| 1 | Blaxel | 41.11 | — | 1 |
 
 ### Mastra: build:core
 
 Seconds · lower is better
 
-_Daytona leads · Novita is ~1.2× higher (lower is better)._
+_Blaxel is the only ranked provider (69.48 Seconds; lower is better)._
 
 | Rank | Provider | Mastra: build:core (Seconds) | 95% bootstrap interval | n |
 | ---: | --- | ---: | ---: | ---: |
-| 1 | Daytona | 68.77 | — | 1 |
-| 2 | Novita | 85.56 | — | 1 |
-| 3 | Blaxel | 122.6 | — | 1 |
-| 4 | Modal | 171 | — | 1 |
+| 1 | Blaxel | 69.48 | — | 1 |
 
 ### Mastra: git clone
 
 Seconds · lower is better
 
-_Novita leads · Daytona is ~1.1× higher (lower is better)._
+_Blaxel is the only ranked provider (9.148 Seconds; lower is better)._
 
 | Rank | Provider | Mastra: git clone (Seconds) | 95% bootstrap interval | n |
 | ---: | --- | ---: | ---: | ---: |
-| 1 | Novita | 7.021 | — | 1 |
-| 2 | Daytona | 7.665 | — | 1 |
-| 3 | Modal | 9.662 | — | 1 |
-| 4 | Blaxel | 11.86 | — | 1 |
+| 1 | Blaxel | 9.148 | — | 1 |
 
 ### Mastra: lint:format
 
 Seconds · lower is better
 
-_Daytona leads · Novita is ~1.2× higher (lower is better)._
+_Blaxel is the only ranked provider (87.78 Seconds; lower is better)._
 
 | Rank | Provider | Mastra: lint:format (Seconds) | 95% bootstrap interval | n |
 | ---: | --- | ---: | ---: | ---: |
-| 1 | Daytona | 84.33 | — | 1 |
-| 2 | Novita | 98.22 | — | 1 |
-| 3 | Blaxel | 142.1 | — | 1 |
-| 4 | Modal | 190.5 | — | 1 |
+| 1 | Blaxel | 87.78 | — | 1 |
 
 ### OpenClaw: cold install
 
 Seconds · lower is better
 
-_Novita leads · Blaxel is ~2.5× higher (lower is better)._
+_Blaxel is the only ranked provider (4.635 Seconds; lower is better)._
 
 | Rank | Provider | OpenClaw: cold install (Seconds) | 95% bootstrap interval | n |
 | ---: | --- | ---: | ---: | ---: |
-| 1 | Novita | 5.201 | — | 1 |
-| 2 | Blaxel | 13.15 | — | 1 |
+| 1 | Blaxel | 4.635 | — | 1 |
 
 ### OpenClaw: git clone
 
 Seconds · lower is better
 
-_Novita leads · Blaxel is ~2.1× higher (lower is better)._
+_Blaxel is the only ranked provider (9.027 Seconds; lower is better)._
 
 | Rank | Provider | OpenClaw: git clone (Seconds) | 95% bootstrap interval | n |
 | ---: | --- | ---: | ---: | ---: |
-| 1 | Novita | 9.333 | — | 1 |
-| 2 | Blaxel | 20.02 | — | 1 |
+| 1 | Blaxel | 9.027 | — | 1 |
 
 ### OpenClaw: typecheck (tsgo)
 
 Seconds · lower is better
 
-_Novita leads · Blaxel is ~1.6× higher (lower is better)._
+_Blaxel is the only ranked provider (39.21 Seconds; lower is better)._
 
 | Rank | Provider | OpenClaw: typecheck (tsgo) (Seconds) | 95% bootstrap interval | n |
 | ---: | --- | ---: | ---: | ---: |
-| 1 | Novita | 42.1 | — | 1 |
-| 2 | Blaxel | 67.41 | — | 1 |
-
-## economics
-
-### Hourly cost _(headline)_
-
-USD/hr · lower is better
-
-_Novita is cheapest · Daytona is ~1.1× higher (lower is better)._
-
-| Rank | Provider | Hourly cost (USD/hr) | 95% bootstrap interval | n |
-| ---: | --- | ---: | ---: | ---: |
-| 1 | Novita | 0.2333 | — | 1 |
-| 2 | Daytona | 0.2502 | — | 1 |
-| 3 | E2B | 0.3312 | — | 1 |
-| 4 | Modal | 0.7612 | — | 1 |
+| 1 | Blaxel | 39.21 | — | 1 |
 
 ## Coverage gaps
 
-8 uncovered results across 4 providers (Blaxel 1, Daytona 2, E2B 2, Modal 3). A gap is a missing result — the provider **failing to cover** that workload — never a tie or a zero.
+28 uncovered results across 4 providers (Daytona 7, E2B 7, Modal 7, Novita 7). A gap is a missing result — the provider **failing to cover** that workload — never a tie or a zero.
 
 <details>
 <summary>Full coverage table</summary>
 
 | Provider | Benchmark | Outcome | Detail |
 | --- | --- | --- | --- |
-| E2B | realworld-mastra | ❌ **disk** (skipped) | Insufficient disk: 20.0 GiB free, suite needs 30 GiB |
-| E2B | realworld-openclaw | ❌ **disk** (skipped) | Insufficient disk: 20.0 GiB free, suite needs 25 GiB |
-| Blaxel | network | **failed** | Step "mise run benchmark:network:all" failed with exit code 1 |
-| Daytona | network | **failed** | Step "mise run benchmark:network:all" timed out after 2700s |
-| Daytona | realworld-openclaw | **failed** | Step "mise run benchmark:realworld:pts:openclaw" timed out after 4800s |
-| Modal | realworld-openclaw | **failed** | Step "mise run benchmark:realworld:pts:openclaw" timed out after 4800s |
+| Daytona | cpu-node | **missing** | No result and no marker — the suite never reported for this provider. |
+| Daytona | disk | **missing** | No result and no marker — the suite never reported for this provider. |
+| Daytona | memory | **missing** | No result and no marker — the suite never reported for this provider. |
+| Daytona | network | **missing** | No result and no marker — the suite never reported for this provider. |
+| Daytona | realworld-better-auth | **missing** | No result and no marker — the suite never reported for this provider. |
+| Daytona | realworld-mastra | **missing** | No result and no marker — the suite never reported for this provider. |
+| Daytona | realworld-openclaw | **missing** | No result and no marker — the suite never reported for this provider. |
+| E2B | cpu-node | **missing** | No result and no marker — the suite never reported for this provider. |
+| E2B | disk | **missing** | No result and no marker — the suite never reported for this provider. |
+| E2B | memory | **missing** | No result and no marker — the suite never reported for this provider. |
+| E2B | network | **missing** | No result and no marker — the suite never reported for this provider. |
+| E2B | realworld-better-auth | **missing** | No result and no marker — the suite never reported for this provider. |
+| E2B | realworld-mastra | **missing** | No result and no marker — the suite never reported for this provider. |
+| E2B | realworld-openclaw | **missing** | No result and no marker — the suite never reported for this provider. |
+| Modal | cpu-node | **missing** | No result and no marker — the suite never reported for this provider. |
 | Modal | disk | **missing** | No result and no marker — the suite never reported for this provider. |
 | Modal | memory | **missing** | No result and no marker — the suite never reported for this provider. |
-
-**skipped** — a precondition said no before the benchmark was attempted. A ❌ **disk** skip is the
-loud one: the provider could not supply the disk the suite needs, so the workload does not run on
-its current allocation at all. That is a structural absence, not a slow result.
-
-**failed** — the benchmark was attempted and broke: it threw, timed out, or died with the sandbox.
-Unlike a skip, this is a reliability fact about the provider, not a decision made on its behalf.
+| Modal | network | **missing** | No result and no marker — the suite never reported for this provider. |
+| Modal | realworld-better-auth | **missing** | No result and no marker — the suite never reported for this provider. |
+| Modal | realworld-mastra | **missing** | No result and no marker — the suite never reported for this provider. |
+| Modal | realworld-openclaw | **missing** | No result and no marker — the suite never reported for this provider. |
+| Novita | cpu-node | **missing** | No result and no marker — the suite never reported for this provider. |
+| Novita | disk | **missing** | No result and no marker — the suite never reported for this provider. |
+| Novita | memory | **missing** | No result and no marker — the suite never reported for this provider. |
+| Novita | network | **missing** | No result and no marker — the suite never reported for this provider. |
+| Novita | realworld-better-auth | **missing** | No result and no marker — the suite never reported for this provider. |
+| Novita | realworld-mastra | **missing** | No result and no marker — the suite never reported for this provider. |
+| Novita | realworld-openclaw | **missing** | No result and no marker — the suite never reported for this provider. |
 
 **missing** — nothing was reported at all: no result, and no marker explaining why. The suite ran
 elsewhere in this run, so it was part of the comparison, and this provider is simply absent from
@@ -604,188 +440,6 @@ is imprecise.
 
 At the small `n` this suite produces, a non-significant result means *not enough evidence to
 separate*, never *the providers are equal*.
-
-`n too small` is the extreme of that: Mann-Whitney's best attainable p already exceeds α for those
-Samples, so the test could not have separated the rows at any effect size (here 2 v 2 floors at p ≈ 0.33).
-Such rows are ranked on their observed medians and are **not** claimed to be tied — read the gap
-between the values, and treat the p-value as unable to settle them either way. Where such a row
-nevertheless shares the rank above it, the note reads `equal medians`: the two values are simply
-identical, which is the ranking having nothing to order them by — never a finding that the
-providers are alike.
-
-### Pairwise tests (vs. row above)
-
-`p vs. above` is Mann-Whitney (drives rank). `p (KS)` is Kolmogorov-Smirnov on distribution
-*shape* — it does not drive the ranking. A tied Mann-Whitney beside a small KS often means the
-same typical speed with different behaviour (e.g. bimodal stalls).
-These are unadjusted, exploratory per-comparison p-values; no family-wise or false-discovery-rate
-correction is applied across providers or metrics.
-
-| Dimension | Metric | Provider | p vs. above | p (KS) |
-| --- | --- | --- | ---: | ---: |
-| cpu | Node.js web tooling | Daytona | — | — |
-| cpu | Node.js web tooling | Novita | 0.33 (n too small) | 0.097 |
-| cpu | Node.js web tooling | Blaxel | 0.33 (n too small) | 0.097 |
-| cpu | Node.js web tooling | E2B | 0.33 (n too small) | 0.097 |
-| cpu | Node.js web tooling | Modal | 0.33 (n too small) | 0.097 |
-| disk | fio rand read 4KB, O_DIRECT (IOPS) | Blaxel | — | — |
-| disk | fio rand read 4KB, O_DIRECT (IOPS) | Daytona | 1.0 (n too small) | 0.84 |
-| disk | fio rand read 4KB, O_DIRECT (IOPS) | Novita | 0.33 (n too small) | 0.097 |
-| disk | fio rand read 4KB, O_DIRECT (IOPS) | E2B | 0.33 (n too small) | 0.097 |
-| disk | fio rand read 4KB, O_DIRECT (MB/s) | Blaxel | — | — |
-| disk | fio rand read 4KB, O_DIRECT (MB/s) | Daytona | 1.0 (n too small) | 0.84 |
-| disk | fio rand read 4KB, O_DIRECT (MB/s) | Novita | 0.33 (n too small) | 0.097 |
-| disk | fio rand read 4KB, O_DIRECT (MB/s) | E2B | 0.33 (n too small) | 0.097 |
-| disk | fio rand write 4KB, O_DIRECT (IOPS) | Blaxel | — | — |
-| disk | fio rand write 4KB, O_DIRECT (IOPS) | Daytona | 0.33 (n too small) | 0.097 |
-| disk | fio rand write 4KB, O_DIRECT (IOPS) | Novita | 0.33 (n too small) | 0.097 |
-| disk | fio rand write 4KB, O_DIRECT (IOPS) | E2B | 0.33 (n too small) | 0.097 |
-| disk | fio rand write 4KB, O_DIRECT (MB/s) | Blaxel | — | — |
-| disk | fio rand write 4KB, O_DIRECT (MB/s) | Daytona | 0.33 (n too small) | 0.097 |
-| disk | fio rand write 4KB, O_DIRECT (MB/s) | Novita | 0.33 (n too small) | 0.097 |
-| disk | fio rand write 4KB, O_DIRECT (MB/s) | E2B | 0.33 (n too small) | 0.097 |
-| disk | fio seq read 1MB, O_DIRECT (IOPS) | Novita | — | — |
-| disk | fio seq read 1MB, O_DIRECT (IOPS) | Daytona | 0.33 (n too small) | 0.097 |
-| disk | fio seq read 1MB, O_DIRECT (IOPS) | Blaxel | 0.33 (n too small) | 0.097 |
-| disk | fio seq read 1MB, O_DIRECT (IOPS) | E2B | 0.33 (n too small) | 0.097 |
-| disk | fio seq read 1MB, O_DIRECT (MB/s) | Daytona | — | — |
-| disk | fio seq read 1MB, O_DIRECT (MB/s) | Blaxel | 0.33 (n too small) | 0.097 |
-| disk | fio seq read 1MB, O_DIRECT (MB/s) | E2B | 0.33 (n too small) | 0.097 |
-| disk | fio seq write 1MB, O_DIRECT (IOPS) | Novita | — | — |
-| disk | fio seq write 1MB, O_DIRECT (IOPS) | Daytona | 0.33 (n too small) | 0.097 |
-| disk | fio seq write 1MB, O_DIRECT (IOPS) | Blaxel | 0.33 (n too small) | 0.097 |
-| disk | fio seq write 1MB, O_DIRECT (IOPS) | E2B | 0.33 (n too small) | 0.097 |
-| disk | fio seq write 1MB, O_DIRECT (MB/s) | Novita | — | — |
-| disk | fio seq write 1MB, O_DIRECT (MB/s) | Daytona | 0.33 (n too small) | 0.097 |
-| disk | fio seq write 1MB, O_DIRECT (MB/s) | Blaxel | 0.33 (n too small) | 0.097 |
-| disk | fio seq write 1MB, O_DIRECT (MB/s) | E2B | 0.33 (n too small) | 0.097 |
-| disk | Hardlink throughput | Daytona | — | — |
-| disk | Hardlink throughput | Novita | 0.33 (n too small) | 0.097 |
-| disk | Hardlink throughput | E2B | 0.33 (n too small) | 0.097 |
-| disk | Hardlink throughput | Blaxel | 0.33 (n too small) | 0.097 |
-| memory | STREAM Triad | Daytona | — | — |
-| memory | STREAM Triad | Blaxel | 0.33 (n too small) | 0.097 |
-| memory | STREAM Triad | Novita | 0.33 (n too small) | 0.097 |
-| memory | STREAM Triad | E2B | 0.33 (n too small) | 0.097 |
-| memory | STREAM Add | Daytona | — | — |
-| memory | STREAM Add | Blaxel | 0.33 (n too small) | 0.097 |
-| memory | STREAM Add | Novita | 1.0 (n too small) | 0.84 |
-| memory | STREAM Add | E2B | 0.33 (n too small) | 0.097 |
-| memory | STREAM Copy | Daytona | — | — |
-| memory | STREAM Copy | Blaxel | 0.33 (n too small) | 0.097 |
-| memory | STREAM Copy | E2B | 0.33 (n too small) | 0.097 |
-| memory | STREAM Copy | Novita | 0.33 (n too small) | 0.097 |
-| memory | STREAM Scale | Daytona | — | — |
-| memory | STREAM Scale | Novita | 0.33 (n too small) | 0.097 |
-| memory | STREAM Scale | Blaxel | 0.33 (n too small) | 0.097 |
-| memory | STREAM Scale | E2B | 0.33 (n too small) | 0.097 |
-| network | Loopback TCP (10GB) | Daytona | — | — |
-| network | Loopback TCP (10GB) | Blaxel | 0.33 (n too small) | 0.097 |
-| network | Loopback TCP (10GB) | Novita | 0.33 (n too small) | 0.097 |
-| network | Loopback TCP (10GB) | E2B | 0.33 (n too small) | 0.097 |
-| network | Loopback TCP (10GB) | Modal | 0.33 (n too small) | 0.097 |
-| network | fast.com download | Blaxel | — | — |
-| network | fast.com download | Modal | 0.33 (n too small) | 0.097 |
-| network | fast.com download | Novita | 0.33 (n too small) | 0.097 |
-| network | fast.com download | E2B | 0.33 (n too small) | 0.097 |
-| network | fast.com latency | Blaxel | — | — |
-| network | fast.com latency | E2B | 0.33 (n too small) | 0.097 |
-| network | fast.com latency | Novita | 0.33 (n too small) | 0.097 |
-| network | fast.com latency | Modal | 0.33 (n too small) | 0.097 |
-| network | fast.com loaded latency | E2B | — | — |
-| network | fast.com loaded latency | Novita | — | — |
-| network | fast.com loaded latency | Modal | — | — |
-| network | fast.com upload | Novita | — | — |
-| network | fast.com upload | Blaxel | 0.33 (n too small) | 0.097 |
-| network | fast.com upload | E2B | 0.33 (n too small) | 0.097 |
-| network | fast.com upload | Modal | 0.33 (n too small) | 0.097 |
-| system | PyBench | Blaxel | — | — |
-| system | Git common operations | Daytona | — | — |
-| system | Git common operations | Novita | 0.33 (n too small) | 0.097 |
-| system | Git common operations | E2B | 0.33 (n too small) | 0.097 |
-| system | Git common operations | Blaxel | 0.33 (n too small) | 0.097 |
-| system | Git common operations | Modal | 0.33 (n too small) | 0.097 |
-| system | SQLite Speedtest | Daytona | — | — |
-| system | SQLite Speedtest | Novita | 0.33 (n too small) | 0.097 |
-| system | SQLite Speedtest | Blaxel | 0.33 (n too small) | 0.097 |
-| system | SQLite Speedtest | E2B | 0.67 (n too small) | 0.84 |
-| system | SQLite Speedtest | Modal | 0.33 (n too small) | 0.097 |
-| realworld | Mastra: cold install | Daytona | — | — |
-| realworld | Mastra: cold install | Novita | — | — |
-| realworld | Mastra: cold install | Blaxel | — | — |
-| realworld | Mastra: cold install | Modal | — | — |
-| realworld | Better-Auth: build | Daytona | — | — |
-| realworld | Better-Auth: build | Novita | — | — |
-| realworld | Better-Auth: build | Blaxel | — | — |
-| realworld | Better-Auth: build | E2B | — | — |
-| realworld | Better-Auth: build | Modal | — | — |
-| realworld | Better-Auth: cold install | Daytona | — | — |
-| realworld | Better-Auth: cold install | Novita | — | — |
-| realworld | Better-Auth: cold install | E2B | — | — |
-| realworld | Better-Auth: cold install | Modal | — | — |
-| realworld | Better-Auth: cold install | Blaxel | — | — |
-| realworld | Better-Auth: git clone | E2B | — | — |
-| realworld | Better-Auth: git clone | Daytona | — | — |
-| realworld | Better-Auth: git clone | Novita | — | — |
-| realworld | Better-Auth: git clone | Modal | — | — |
-| realworld | Better-Auth: git clone | Blaxel | — | — |
-| realworld | Better-Auth: lint (Biome) | Daytona | — | — |
-| realworld | Better-Auth: lint (Biome) | Novita | — | — |
-| realworld | Better-Auth: lint (Biome) | E2B | — | — |
-| realworld | Better-Auth: lint (Biome) | Blaxel | — | — |
-| realworld | Better-Auth: lint (Biome) | Modal | — | — |
-| realworld | Better-Auth: lint deps (Knip) | Daytona | — | — |
-| realworld | Better-Auth: lint deps (Knip) | Novita | — | — |
-| realworld | Better-Auth: lint deps (Knip) | E2B | — | — |
-| realworld | Better-Auth: lint deps (Knip) | Blaxel | — | — |
-| realworld | Better-Auth: lint deps (Knip) | Modal | — | — |
-| realworld | Better-Auth: lint format | Daytona | — | — |
-| realworld | Better-Auth: lint format | Novita | — | — |
-| realworld | Better-Auth: lint format | Blaxel | — | — |
-| realworld | Better-Auth: lint format | E2B | — | — |
-| realworld | Better-Auth: lint format | Modal | — | — |
-| realworld | Better-Auth: lint packages | Daytona | — | — |
-| realworld | Better-Auth: lint packages | Novita | — | — |
-| realworld | Better-Auth: lint packages | Blaxel | — | — |
-| realworld | Better-Auth: lint packages | E2B | — | — |
-| realworld | Better-Auth: lint packages | Modal | — | — |
-| realworld | Better-Auth: lint spell | Daytona | — | — |
-| realworld | Better-Auth: lint spell | Novita | — | — |
-| realworld | Better-Auth: lint spell | Blaxel | — | — |
-| realworld | Better-Auth: lint spell | E2B | — | — |
-| realworld | Better-Auth: lint spell | Modal | — | — |
-| realworld | Better-Auth: lint types | Daytona | — | — |
-| realworld | Better-Auth: lint types | Novita | — | — |
-| realworld | Better-Auth: lint types | Blaxel | — | — |
-| realworld | Better-Auth: lint types | E2B | — | — |
-| realworld | Better-Auth: lint types | Modal | — | — |
-| realworld | Better-Auth: typecheck | Daytona | — | — |
-| realworld | Better-Auth: typecheck | Novita | — | — |
-| realworld | Better-Auth: typecheck | Blaxel | — | — |
-| realworld | Better-Auth: typecheck | E2B | — | — |
-| realworld | Better-Auth: typecheck | Modal | — | — |
-| realworld | Mastra: build:core | Daytona | — | — |
-| realworld | Mastra: build:core | Novita | — | — |
-| realworld | Mastra: build:core | Blaxel | — | — |
-| realworld | Mastra: build:core | Modal | — | — |
-| realworld | Mastra: git clone | Novita | — | — |
-| realworld | Mastra: git clone | Daytona | — | — |
-| realworld | Mastra: git clone | Modal | — | — |
-| realworld | Mastra: git clone | Blaxel | — | — |
-| realworld | Mastra: lint:format | Daytona | — | — |
-| realworld | Mastra: lint:format | Novita | — | — |
-| realworld | Mastra: lint:format | Blaxel | — | — |
-| realworld | Mastra: lint:format | Modal | — | — |
-| realworld | OpenClaw: cold install | Novita | — | — |
-| realworld | OpenClaw: cold install | Blaxel | — | — |
-| realworld | OpenClaw: git clone | Novita | — | — |
-| realworld | OpenClaw: git clone | Blaxel | — | — |
-| realworld | OpenClaw: typecheck (tsgo) | Novita | — | — |
-| realworld | OpenClaw: typecheck (tsgo) | Blaxel | — | — |
-| economics | Hourly cost | Novita | — | — |
-| economics | Hourly cost | Daytona | — | — |
-| economics | Hourly cost | E2B | — | — |
-| economics | Hourly cost | Modal | — | — |
 
 </details>
 

--- a/data/dataset/index.json
+++ b/data/dataset/index.json
@@ -2,6 +2,11 @@
   "schemaVersion": "1",
   "runs": [
     {
+      "runId": "29741364586",
+      "generatedAt": "2026-07-20T12:28:37.898Z",
+      "path": "runs/29741364586.json"
+    },
+    {
       "runId": "29692210375",
       "generatedAt": "2026-07-19T16:29:20.252Z",
       "path": "runs/29692210375.json"

--- a/data/dataset/runs/29741364586.json
+++ b/data/dataset/runs/29741364586.json
@@ -1,0 +1,1700 @@
+{
+  "schemaVersion": "3",
+  "runId": "29741364586",
+  "sha": "b5e93145866d53d9378fa70823fd7d770e8ee8ae",
+  "generatedAt": "2026-07-20T12:28:37.898Z",
+  "targetSpec": {
+    "vcpus": 4,
+    "memoryGb": 8,
+    "diskGb": 40
+  },
+  "providers": [
+    {
+      "providerId": "blaxel",
+      "validationStatus": "validated",
+      "specMatched": true,
+      "observedSpecs": {
+        "cpuModel": "AMD EPYC",
+        "hostVcpus": 4,
+        "hostMemoryGb": 8,
+        "os": "Debian GNU/Linux 12 (bookworm)",
+        "kernel": "6.1.166",
+        "virtualization": "kvm",
+        "user": "root",
+        "vcpus": 4,
+        "memoryGb": 7.78,
+        "diskGb": 39.9
+      },
+      "hostMetadata": [
+        {
+          "source": "phoronix/result-file-to-json",
+          "sourceFile": "cpu-node/pts_node-web-tooling--metadata.json",
+          "fields": [
+            {
+              "path": "ci.client_version",
+              "value": "10.8.4"
+            },
+            {
+              "path": "ci.data.cpu-microcode",
+              "value": "0x1000065"
+            },
+            {
+              "path": "ci.data.environment-variables",
+              "value": "BL_DEBUG_TELEMETRY=false"
+            },
+            {
+              "path": "ci.data.kernel-extra-details",
+              "value": "Transparent Huge Pages: madvise"
+            },
+            {
+              "path": "ci.data.security",
+              "value": "gather_data_sampling: Not affected + indirect_target_selection: Not affected + itlb_multihit: Not affected + l1tf: Not affected + mds: Not affected + meltdown: Not affected + mmio_stale_data: Not affected + reg_file_data_sampling: Not affected + retbleed: Not affected + spec_rstack_overflow: Not affected + spec_store_bypass: Mitigation of SSB disabled via prctl + spectre_v1: Mitigation of usercopy/swapgs barriers and __user pointer sanitization + spectre_v2: Mitigation of Retpolines; IBPB: conditional; IBRS_FW; STIBP: always-on; RSB filling; PBRSB-eIBRS: Not affected; BHI: Not affected + srbds: Not affected + tsa: Not affected + tsx_async_abort: Not affected + vmscape: Not affected"
+            },
+            {
+              "path": "ci.hardware.Disk",
+              "value": "40GB"
+            },
+            {
+              "path": "ci.hardware.Memory",
+              "value": "8GB"
+            },
+            {
+              "path": "ci.hardware.Processor",
+              "value": "AMD EPYC (2 Cores / 4 Threads)"
+            },
+            {
+              "path": "ci.identifier",
+              "value": "ci"
+            },
+            {
+              "path": "ci.software.Compiler",
+              "value": "GCC 12.2.0"
+            },
+            {
+              "path": "ci.software.File-System",
+              "value": "xfs"
+            },
+            {
+              "path": "ci.software.Kernel",
+              "value": "6.1.166 (x86_64)"
+            },
+            {
+              "path": "ci.software.OS",
+              "value": "Debian GNU/Linux 12"
+            },
+            {
+              "path": "ci.software.System Layer",
+              "value": "KVM"
+            },
+            {
+              "path": "ci.timestamp",
+              "value": "2026-07-20 12:15:03"
+            },
+            {
+              "path": "ci.user",
+              "value": "root"
+            }
+          ]
+        },
+        {
+          "source": "phoronix/result-file-to-json",
+          "sourceFile": "disk/pts_fio-rand-read--metadata.json",
+          "fields": [
+            {
+              "path": "ci.client_version",
+              "value": "10.8.4"
+            },
+            {
+              "path": "ci.data.compiler-configuration",
+              "value": "--build=x86_64-linux-gnu --disable-vtable-verify --disable-werror --enable-cet --enable-checking=release --enable-clocale=gnu --enable-default-pie --enable-gnu-unique-object --enable-languages=c,ada,c++,go,d,fortran,objc,obj-c++,m2 --enable-libphobos-checking=release --enable-libstdcxx-debug --enable-libstdcxx-time=yes --enable-multiarch --enable-multilib --enable-nls --enable-objc-gc=auto --enable-offload-defaulted --enable-offload-targets=nvptx-none=/build/reproducible-path/gcc-12-12.2.0/debian/tmp-nvptx/usr,amdgcn-amdhsa=/build/reproducible-path/gcc-12-12.2.0/debian/tmp-gcn/usr --enable-plugin --enable-shared --enable-threads=posix --host=x86_64-linux-gnu --program-prefix=x86_64-linux-gnu- --target=x86_64-linux-gnu --with-abi=m64 --with-arch-32=i686 --with-default-libstdcxx-abi=new --with-gcc-major-version-only --with-multilib-list=m32,m64,mx32 --with-target-system-zlib=auto --with-tune=generic --without-cuda-driver -v"
+            },
+            {
+              "path": "ci.data.cpu-microcode",
+              "value": "0x1000065"
+            },
+            {
+              "path": "ci.data.disk-details",
+              "value": "Block Size: 4096"
+            },
+            {
+              "path": "ci.data.disk-mount-options",
+              "value": "allocsize=64k,attr2,inode64,lazytime,logbsize=256k,logbufs=8,noatime,nodiratime,noquota,rw"
+            },
+            {
+              "path": "ci.data.disk-scheduler",
+              "value": "MQ-DEADLINE"
+            },
+            {
+              "path": "ci.data.environment-variables",
+              "value": "BL_DEBUG_TELEMETRY=false"
+            },
+            {
+              "path": "ci.data.kernel-extra-details",
+              "value": "Transparent Huge Pages: madvise"
+            },
+            {
+              "path": "ci.data.security",
+              "value": "gather_data_sampling: Not affected + indirect_target_selection: Not affected + itlb_multihit: Not affected + l1tf: Not affected + mds: Not affected + meltdown: Not affected + mmio_stale_data: Not affected + reg_file_data_sampling: Not affected + retbleed: Not affected + spec_rstack_overflow: Not affected + spec_store_bypass: Mitigation of SSB disabled via prctl + spectre_v1: Mitigation of usercopy/swapgs barriers and __user pointer sanitization + spectre_v2: Mitigation of Retpolines; IBPB: conditional; IBRS_FW; STIBP: always-on; RSB filling; PBRSB-eIBRS: Not affected; BHI: Not affected + srbds: Not affected + tsa: Not affected + tsx_async_abort: Not affected + vmscape: Not affected"
+            },
+            {
+              "path": "ci.hardware.Disk",
+              "value": "40GB"
+            },
+            {
+              "path": "ci.hardware.Memory",
+              "value": "8GB"
+            },
+            {
+              "path": "ci.hardware.Processor",
+              "value": "AMD EPYC (2 Cores / 4 Threads)"
+            },
+            {
+              "path": "ci.identifier",
+              "value": "ci"
+            },
+            {
+              "path": "ci.software.Compiler",
+              "value": "GCC 12.2.0"
+            },
+            {
+              "path": "ci.software.File-System",
+              "value": "xfs"
+            },
+            {
+              "path": "ci.software.Kernel",
+              "value": "6.1.166 (x86_64)"
+            },
+            {
+              "path": "ci.software.OS",
+              "value": "Debian GNU/Linux 12"
+            },
+            {
+              "path": "ci.software.System Layer",
+              "value": "KVM"
+            },
+            {
+              "path": "ci.timestamp",
+              "value": "2026-07-20 12:21:00"
+            },
+            {
+              "path": "ci.user",
+              "value": "root"
+            }
+          ]
+        },
+        {
+          "source": "phoronix/result-file-to-json",
+          "sourceFile": "disk/pts_fio-rand-write--metadata.json",
+          "fields": [
+            {
+              "path": "ci.client_version",
+              "value": "10.8.4"
+            },
+            {
+              "path": "ci.data.compiler-configuration",
+              "value": "--build=x86_64-linux-gnu --disable-vtable-verify --disable-werror --enable-cet --enable-checking=release --enable-clocale=gnu --enable-default-pie --enable-gnu-unique-object --enable-languages=c,ada,c++,go,d,fortran,objc,obj-c++,m2 --enable-libphobos-checking=release --enable-libstdcxx-debug --enable-libstdcxx-time=yes --enable-multiarch --enable-multilib --enable-nls --enable-objc-gc=auto --enable-offload-defaulted --enable-offload-targets=nvptx-none=/build/reproducible-path/gcc-12-12.2.0/debian/tmp-nvptx/usr,amdgcn-amdhsa=/build/reproducible-path/gcc-12-12.2.0/debian/tmp-gcn/usr --enable-plugin --enable-shared --enable-threads=posix --host=x86_64-linux-gnu --program-prefix=x86_64-linux-gnu- --target=x86_64-linux-gnu --with-abi=m64 --with-arch-32=i686 --with-default-libstdcxx-abi=new --with-gcc-major-version-only --with-multilib-list=m32,m64,mx32 --with-target-system-zlib=auto --with-tune=generic --without-cuda-driver -v"
+            },
+            {
+              "path": "ci.data.cpu-microcode",
+              "value": "0x1000065"
+            },
+            {
+              "path": "ci.data.disk-details",
+              "value": "Block Size: 4096"
+            },
+            {
+              "path": "ci.data.disk-mount-options",
+              "value": "allocsize=64k,attr2,inode64,lazytime,logbsize=256k,logbufs=8,noatime,nodiratime,noquota,rw"
+            },
+            {
+              "path": "ci.data.disk-scheduler",
+              "value": "MQ-DEADLINE"
+            },
+            {
+              "path": "ci.data.environment-variables",
+              "value": "BL_DEBUG_TELEMETRY=false"
+            },
+            {
+              "path": "ci.data.kernel-extra-details",
+              "value": "Transparent Huge Pages: madvise"
+            },
+            {
+              "path": "ci.data.security",
+              "value": "gather_data_sampling: Not affected + indirect_target_selection: Not affected + itlb_multihit: Not affected + l1tf: Not affected + mds: Not affected + meltdown: Not affected + mmio_stale_data: Not affected + reg_file_data_sampling: Not affected + retbleed: Not affected + spec_rstack_overflow: Not affected + spec_store_bypass: Mitigation of SSB disabled via prctl + spectre_v1: Mitigation of usercopy/swapgs barriers and __user pointer sanitization + spectre_v2: Mitigation of Retpolines; IBPB: conditional; IBRS_FW; STIBP: always-on; RSB filling; PBRSB-eIBRS: Not affected; BHI: Not affected + srbds: Not affected + tsa: Not affected + tsx_async_abort: Not affected + vmscape: Not affected"
+            },
+            {
+              "path": "ci.hardware.Disk",
+              "value": "40GB"
+            },
+            {
+              "path": "ci.hardware.Memory",
+              "value": "8GB"
+            },
+            {
+              "path": "ci.hardware.Processor",
+              "value": "AMD EPYC (2 Cores / 4 Threads)"
+            },
+            {
+              "path": "ci.identifier",
+              "value": "ci"
+            },
+            {
+              "path": "ci.software.Compiler",
+              "value": "GCC 12.2.0"
+            },
+            {
+              "path": "ci.software.File-System",
+              "value": "xfs"
+            },
+            {
+              "path": "ci.software.Kernel",
+              "value": "6.1.166 (x86_64)"
+            },
+            {
+              "path": "ci.software.OS",
+              "value": "Debian GNU/Linux 12"
+            },
+            {
+              "path": "ci.software.System Layer",
+              "value": "KVM"
+            },
+            {
+              "path": "ci.timestamp",
+              "value": "2026-07-20 12:24:10"
+            },
+            {
+              "path": "ci.user",
+              "value": "root"
+            }
+          ]
+        },
+        {
+          "source": "phoronix/result-file-to-json",
+          "sourceFile": "disk/pts_fio-seq-read--metadata.json",
+          "fields": [
+            {
+              "path": "ci.client_version",
+              "value": "10.8.4"
+            },
+            {
+              "path": "ci.data.compiler-configuration",
+              "value": "--build=x86_64-linux-gnu --disable-vtable-verify --disable-werror --enable-cet --enable-checking=release --enable-clocale=gnu --enable-default-pie --enable-gnu-unique-object --enable-languages=c,ada,c++,go,d,fortran,objc,obj-c++,m2 --enable-libphobos-checking=release --enable-libstdcxx-debug --enable-libstdcxx-time=yes --enable-multiarch --enable-multilib --enable-nls --enable-objc-gc=auto --enable-offload-defaulted --enable-offload-targets=nvptx-none=/build/reproducible-path/gcc-12-12.2.0/debian/tmp-nvptx/usr,amdgcn-amdhsa=/build/reproducible-path/gcc-12-12.2.0/debian/tmp-gcn/usr --enable-plugin --enable-shared --enable-threads=posix --host=x86_64-linux-gnu --program-prefix=x86_64-linux-gnu- --target=x86_64-linux-gnu --with-abi=m64 --with-arch-32=i686 --with-default-libstdcxx-abi=new --with-gcc-major-version-only --with-multilib-list=m32,m64,mx32 --with-target-system-zlib=auto --with-tune=generic --without-cuda-driver -v"
+            },
+            {
+              "path": "ci.data.cpu-microcode",
+              "value": "0x1000065"
+            },
+            {
+              "path": "ci.data.disk-details",
+              "value": "Block Size: 4096"
+            },
+            {
+              "path": "ci.data.disk-mount-options",
+              "value": "allocsize=64k,attr2,inode64,lazytime,logbsize=256k,logbufs=8,noatime,nodiratime,noquota,rw"
+            },
+            {
+              "path": "ci.data.disk-scheduler",
+              "value": "MQ-DEADLINE"
+            },
+            {
+              "path": "ci.data.environment-variables",
+              "value": "BL_DEBUG_TELEMETRY=false"
+            },
+            {
+              "path": "ci.data.kernel-extra-details",
+              "value": "Transparent Huge Pages: madvise"
+            },
+            {
+              "path": "ci.data.security",
+              "value": "gather_data_sampling: Not affected + indirect_target_selection: Not affected + itlb_multihit: Not affected + l1tf: Not affected + mds: Not affected + meltdown: Not affected + mmio_stale_data: Not affected + reg_file_data_sampling: Not affected + retbleed: Not affected + spec_rstack_overflow: Not affected + spec_store_bypass: Mitigation of SSB disabled via prctl + spectre_v1: Mitigation of usercopy/swapgs barriers and __user pointer sanitization + spectre_v2: Mitigation of Retpolines; IBPB: conditional; IBRS_FW; STIBP: always-on; RSB filling; PBRSB-eIBRS: Not affected; BHI: Not affected + srbds: Not affected + tsa: Not affected + tsx_async_abort: Not affected + vmscape: Not affected"
+            },
+            {
+              "path": "ci.hardware.Disk",
+              "value": "40GB"
+            },
+            {
+              "path": "ci.hardware.Memory",
+              "value": "8GB"
+            },
+            {
+              "path": "ci.hardware.Processor",
+              "value": "AMD EPYC (2 Cores / 4 Threads)"
+            },
+            {
+              "path": "ci.identifier",
+              "value": "ci"
+            },
+            {
+              "path": "ci.software.Compiler",
+              "value": "GCC 12.2.0"
+            },
+            {
+              "path": "ci.software.File-System",
+              "value": "xfs"
+            },
+            {
+              "path": "ci.software.Kernel",
+              "value": "6.1.166 (x86_64)"
+            },
+            {
+              "path": "ci.software.OS",
+              "value": "Debian GNU/Linux 12"
+            },
+            {
+              "path": "ci.software.System Layer",
+              "value": "KVM"
+            },
+            {
+              "path": "ci.timestamp",
+              "value": "2026-07-20 12:14:41"
+            },
+            {
+              "path": "ci.user",
+              "value": "root"
+            }
+          ]
+        },
+        {
+          "source": "phoronix/result-file-to-json",
+          "sourceFile": "disk/pts_fio-seq-write--metadata.json",
+          "fields": [
+            {
+              "path": "ci.client_version",
+              "value": "10.8.4"
+            },
+            {
+              "path": "ci.data.compiler-configuration",
+              "value": "--build=x86_64-linux-gnu --disable-vtable-verify --disable-werror --enable-cet --enable-checking=release --enable-clocale=gnu --enable-default-pie --enable-gnu-unique-object --enable-languages=c,ada,c++,go,d,fortran,objc,obj-c++,m2 --enable-libphobos-checking=release --enable-libstdcxx-debug --enable-libstdcxx-time=yes --enable-multiarch --enable-multilib --enable-nls --enable-objc-gc=auto --enable-offload-defaulted --enable-offload-targets=nvptx-none=/build/reproducible-path/gcc-12-12.2.0/debian/tmp-nvptx/usr,amdgcn-amdhsa=/build/reproducible-path/gcc-12-12.2.0/debian/tmp-gcn/usr --enable-plugin --enable-shared --enable-threads=posix --host=x86_64-linux-gnu --program-prefix=x86_64-linux-gnu- --target=x86_64-linux-gnu --with-abi=m64 --with-arch-32=i686 --with-default-libstdcxx-abi=new --with-gcc-major-version-only --with-multilib-list=m32,m64,mx32 --with-target-system-zlib=auto --with-tune=generic --without-cuda-driver -v"
+            },
+            {
+              "path": "ci.data.cpu-microcode",
+              "value": "0x1000065"
+            },
+            {
+              "path": "ci.data.disk-details",
+              "value": "Block Size: 4096"
+            },
+            {
+              "path": "ci.data.disk-mount-options",
+              "value": "allocsize=64k,attr2,inode64,lazytime,logbsize=256k,logbufs=8,noatime,nodiratime,noquota,rw"
+            },
+            {
+              "path": "ci.data.disk-scheduler",
+              "value": "MQ-DEADLINE"
+            },
+            {
+              "path": "ci.data.environment-variables",
+              "value": "BL_DEBUG_TELEMETRY=false"
+            },
+            {
+              "path": "ci.data.kernel-extra-details",
+              "value": "Transparent Huge Pages: madvise"
+            },
+            {
+              "path": "ci.data.security",
+              "value": "gather_data_sampling: Not affected + indirect_target_selection: Not affected + itlb_multihit: Not affected + l1tf: Not affected + mds: Not affected + meltdown: Not affected + mmio_stale_data: Not affected + reg_file_data_sampling: Not affected + retbleed: Not affected + spec_rstack_overflow: Not affected + spec_store_bypass: Mitigation of SSB disabled via prctl + spectre_v1: Mitigation of usercopy/swapgs barriers and __user pointer sanitization + spectre_v2: Mitigation of Retpolines; IBPB: conditional; IBRS_FW; STIBP: always-on; RSB filling; PBRSB-eIBRS: Not affected; BHI: Not affected + srbds: Not affected + tsa: Not affected + tsx_async_abort: Not affected + vmscape: Not affected"
+            },
+            {
+              "path": "ci.hardware.Disk",
+              "value": "40GB"
+            },
+            {
+              "path": "ci.hardware.Memory",
+              "value": "8GB"
+            },
+            {
+              "path": "ci.hardware.Processor",
+              "value": "AMD EPYC (2 Cores / 4 Threads)"
+            },
+            {
+              "path": "ci.identifier",
+              "value": "ci"
+            },
+            {
+              "path": "ci.software.Compiler",
+              "value": "GCC 12.2.0"
+            },
+            {
+              "path": "ci.software.File-System",
+              "value": "xfs"
+            },
+            {
+              "path": "ci.software.Kernel",
+              "value": "6.1.166 (x86_64)"
+            },
+            {
+              "path": "ci.software.OS",
+              "value": "Debian GNU/Linux 12"
+            },
+            {
+              "path": "ci.software.System Layer",
+              "value": "KVM"
+            },
+            {
+              "path": "ci.timestamp",
+              "value": "2026-07-20 12:17:51"
+            },
+            {
+              "path": "ci.user",
+              "value": "root"
+            }
+          ]
+        },
+        {
+          "source": "phoronix/result-file-to-json",
+          "sourceFile": "disk/pts_hardlink--metadata.json",
+          "fields": [
+            {
+              "path": "ci.client_version",
+              "value": "10.8.4"
+            },
+            {
+              "path": "ci.data.compiler-configuration",
+              "value": "--build=x86_64-linux-gnu --disable-vtable-verify --disable-werror --enable-cet --enable-checking=release --enable-clocale=gnu --enable-default-pie --enable-gnu-unique-object --enable-languages=c,ada,c++,go,d,fortran,objc,obj-c++,m2 --enable-libphobos-checking=release --enable-libstdcxx-debug --enable-libstdcxx-time=yes --enable-multiarch --enable-multilib --enable-nls --enable-objc-gc=auto --enable-offload-defaulted --enable-offload-targets=nvptx-none=/build/reproducible-path/gcc-12-12.2.0/debian/tmp-nvptx/usr,amdgcn-amdhsa=/build/reproducible-path/gcc-12-12.2.0/debian/tmp-gcn/usr --enable-plugin --enable-shared --enable-threads=posix --host=x86_64-linux-gnu --program-prefix=x86_64-linux-gnu- --target=x86_64-linux-gnu --with-abi=m64 --with-arch-32=i686 --with-default-libstdcxx-abi=new --with-gcc-major-version-only --with-multilib-list=m32,m64,mx32 --with-target-system-zlib=auto --with-tune=generic --without-cuda-driver -v"
+            },
+            {
+              "path": "ci.data.cpu-microcode",
+              "value": "0x1000065"
+            },
+            {
+              "path": "ci.data.disk-details",
+              "value": "Block Size: 4096"
+            },
+            {
+              "path": "ci.data.disk-mount-options",
+              "value": "allocsize=64k,attr2,inode64,lazytime,logbsize=256k,logbufs=8,noatime,nodiratime,noquota,rw"
+            },
+            {
+              "path": "ci.data.disk-scheduler",
+              "value": "MQ-DEADLINE"
+            },
+            {
+              "path": "ci.data.environment-variables",
+              "value": "BL_DEBUG_TELEMETRY=false"
+            },
+            {
+              "path": "ci.data.kernel-extra-details",
+              "value": "Transparent Huge Pages: madvise"
+            },
+            {
+              "path": "ci.data.security",
+              "value": "gather_data_sampling: Not affected + indirect_target_selection: Not affected + itlb_multihit: Not affected + l1tf: Not affected + mds: Not affected + meltdown: Not affected + mmio_stale_data: Not affected + reg_file_data_sampling: Not affected + retbleed: Not affected + spec_rstack_overflow: Not affected + spec_store_bypass: Mitigation of SSB disabled via prctl + spectre_v1: Mitigation of usercopy/swapgs barriers and __user pointer sanitization + spectre_v2: Mitigation of Retpolines; IBPB: conditional; IBRS_FW; STIBP: always-on; RSB filling; PBRSB-eIBRS: Not affected; BHI: Not affected + srbds: Not affected + tsa: Not affected + tsx_async_abort: Not affected + vmscape: Not affected"
+            },
+            {
+              "path": "ci.hardware.Disk",
+              "value": "40GB"
+            },
+            {
+              "path": "ci.hardware.Memory",
+              "value": "8GB"
+            },
+            {
+              "path": "ci.hardware.Processor",
+              "value": "AMD EPYC (2 Cores / 4 Threads)"
+            },
+            {
+              "path": "ci.identifier",
+              "value": "ci"
+            },
+            {
+              "path": "ci.software.Compiler",
+              "value": "GCC 12.2.0"
+            },
+            {
+              "path": "ci.software.File-System",
+              "value": "xfs"
+            },
+            {
+              "path": "ci.software.Kernel",
+              "value": "6.1.166 (x86_64)"
+            },
+            {
+              "path": "ci.software.OS",
+              "value": "Debian GNU/Linux 12"
+            },
+            {
+              "path": "ci.software.System Layer",
+              "value": "KVM"
+            },
+            {
+              "path": "ci.timestamp",
+              "value": "2026-07-20 12:27:22"
+            },
+            {
+              "path": "ci.user",
+              "value": "root"
+            }
+          ]
+        },
+        {
+          "source": "phoronix/result-file-to-json",
+          "sourceFile": "memory/pts_stream--metadata.json",
+          "fields": [
+            {
+              "path": "ci.client_version",
+              "value": "10.8.4"
+            },
+            {
+              "path": "ci.data.compiler-configuration",
+              "value": "--build=x86_64-linux-gnu --disable-vtable-verify --disable-werror --enable-cet --enable-checking=release --enable-clocale=gnu --enable-default-pie --enable-gnu-unique-object --enable-languages=c,ada,c++,go,d,fortran,objc,obj-c++,m2 --enable-libphobos-checking=release --enable-libstdcxx-debug --enable-libstdcxx-time=yes --enable-multiarch --enable-multilib --enable-nls --enable-objc-gc=auto --enable-offload-defaulted --enable-offload-targets=nvptx-none=/build/reproducible-path/gcc-12-12.2.0/debian/tmp-nvptx/usr,amdgcn-amdhsa=/build/reproducible-path/gcc-12-12.2.0/debian/tmp-gcn/usr --enable-plugin --enable-shared --enable-threads=posix --host=x86_64-linux-gnu --program-prefix=x86_64-linux-gnu- --target=x86_64-linux-gnu --with-abi=m64 --with-arch-32=i686 --with-default-libstdcxx-abi=new --with-gcc-major-version-only --with-multilib-list=m32,m64,mx32 --with-target-system-zlib=auto --with-tune=generic --without-cuda-driver -v"
+            },
+            {
+              "path": "ci.data.cpu-microcode",
+              "value": "0x1000065"
+            },
+            {
+              "path": "ci.data.environment-variables",
+              "value": "CFLAGS_OVERRIDE=\"-O3 -march=native -DSTREAM_ARRAY_SIZE=150000000\" BL_DEBUG_TELEMETRY=false"
+            },
+            {
+              "path": "ci.data.kernel-extra-details",
+              "value": "Transparent Huge Pages: madvise"
+            },
+            {
+              "path": "ci.data.security",
+              "value": "gather_data_sampling: Not affected + indirect_target_selection: Not affected + itlb_multihit: Not affected + l1tf: Not affected + mds: Not affected + meltdown: Not affected + mmio_stale_data: Not affected + reg_file_data_sampling: Not affected + retbleed: Not affected + spec_rstack_overflow: Not affected + spec_store_bypass: Mitigation of SSB disabled via prctl + spectre_v1: Mitigation of usercopy/swapgs barriers and __user pointer sanitization + spectre_v2: Mitigation of Retpolines; IBPB: conditional; IBRS_FW; STIBP: always-on; RSB filling; PBRSB-eIBRS: Not affected; BHI: Not affected + srbds: Not affected + tsa: Not affected + tsx_async_abort: Not affected + vmscape: Not affected"
+            },
+            {
+              "path": "ci.hardware.Disk",
+              "value": "40GB"
+            },
+            {
+              "path": "ci.hardware.Memory",
+              "value": "8GB"
+            },
+            {
+              "path": "ci.hardware.Processor",
+              "value": "AMD EPYC (2 Cores / 4 Threads)"
+            },
+            {
+              "path": "ci.identifier",
+              "value": "ci"
+            },
+            {
+              "path": "ci.software.Compiler",
+              "value": "GCC 12.2.0"
+            },
+            {
+              "path": "ci.software.File-System",
+              "value": "xfs"
+            },
+            {
+              "path": "ci.software.Kernel",
+              "value": "6.1.166 (x86_64)"
+            },
+            {
+              "path": "ci.software.OS",
+              "value": "Debian GNU/Linux 12"
+            },
+            {
+              "path": "ci.software.System Layer",
+              "value": "KVM"
+            },
+            {
+              "path": "ci.timestamp",
+              "value": "2026-07-20 12:14:31"
+            },
+            {
+              "path": "ci.user",
+              "value": "root"
+            }
+          ]
+        },
+        {
+          "source": "phoronix/result-file-to-json",
+          "sourceFile": "network/pts_fast-cli--metadata.json",
+          "fields": [
+            {
+              "path": "ci.client_version",
+              "value": "10.8.4"
+            },
+            {
+              "path": "ci.data.cpu-microcode",
+              "value": "0x1000065"
+            },
+            {
+              "path": "ci.data.environment-variables",
+              "value": "BL_DEBUG_TELEMETRY=false"
+            },
+            {
+              "path": "ci.data.kernel-extra-details",
+              "value": "Transparent Huge Pages: madvise"
+            },
+            {
+              "path": "ci.data.security",
+              "value": "gather_data_sampling: Not affected + indirect_target_selection: Not affected + itlb_multihit: Not affected + l1tf: Not affected + mds: Not affected + meltdown: Not affected + mmio_stale_data: Not affected + reg_file_data_sampling: Not affected + retbleed: Not affected + spec_rstack_overflow: Not affected + spec_store_bypass: Mitigation of SSB disabled via prctl + spectre_v1: Mitigation of usercopy/swapgs barriers and __user pointer sanitization + spectre_v2: Mitigation of Retpolines; IBPB: conditional; IBRS_FW; STIBP: always-on; RSB filling; PBRSB-eIBRS: Not affected; BHI: Not affected + srbds: Not affected + tsa: Not affected + tsx_async_abort: Not affected + vmscape: Not affected"
+            },
+            {
+              "path": "ci.hardware.Disk",
+              "value": "40GB"
+            },
+            {
+              "path": "ci.hardware.Memory",
+              "value": "8GB"
+            },
+            {
+              "path": "ci.hardware.Processor",
+              "value": "AMD EPYC (2 Cores / 4 Threads)"
+            },
+            {
+              "path": "ci.identifier",
+              "value": "ci"
+            },
+            {
+              "path": "ci.software.Compiler",
+              "value": "GCC 12.2.0"
+            },
+            {
+              "path": "ci.software.File-System",
+              "value": "xfs"
+            },
+            {
+              "path": "ci.software.Kernel",
+              "value": "6.1.166 (x86_64)"
+            },
+            {
+              "path": "ci.software.OS",
+              "value": "Debian GNU/Linux 12"
+            },
+            {
+              "path": "ci.software.System Layer",
+              "value": "KVM"
+            },
+            {
+              "path": "ci.timestamp",
+              "value": "2026-07-20 12:15:15"
+            },
+            {
+              "path": "ci.user",
+              "value": "root"
+            }
+          ]
+        },
+        {
+          "source": "phoronix/result-file-to-json",
+          "sourceFile": "network/pts_network-loopback--metadata.json",
+          "fields": [
+            {
+              "path": "ci.client_version",
+              "value": "10.8.4"
+            },
+            {
+              "path": "ci.data.cpu-microcode",
+              "value": "0x1000065"
+            },
+            {
+              "path": "ci.data.environment-variables",
+              "value": "BL_DEBUG_TELEMETRY=false"
+            },
+            {
+              "path": "ci.data.kernel-extra-details",
+              "value": "Transparent Huge Pages: madvise"
+            },
+            {
+              "path": "ci.data.security",
+              "value": "gather_data_sampling: Not affected + indirect_target_selection: Not affected + itlb_multihit: Not affected + l1tf: Not affected + mds: Not affected + meltdown: Not affected + mmio_stale_data: Not affected + reg_file_data_sampling: Not affected + retbleed: Not affected + spec_rstack_overflow: Not affected + spec_store_bypass: Mitigation of SSB disabled via prctl + spectre_v1: Mitigation of usercopy/swapgs barriers and __user pointer sanitization + spectre_v2: Mitigation of Retpolines; IBPB: conditional; IBRS_FW; STIBP: always-on; RSB filling; PBRSB-eIBRS: Not affected; BHI: Not affected + srbds: Not affected + tsa: Not affected + tsx_async_abort: Not affected + vmscape: Not affected"
+            },
+            {
+              "path": "ci.hardware.Disk",
+              "value": "40GB"
+            },
+            {
+              "path": "ci.hardware.Memory",
+              "value": "8GB"
+            },
+            {
+              "path": "ci.hardware.Processor",
+              "value": "AMD EPYC (2 Cores / 4 Threads)"
+            },
+            {
+              "path": "ci.identifier",
+              "value": "ci"
+            },
+            {
+              "path": "ci.software.Compiler",
+              "value": "GCC 12.2.0"
+            },
+            {
+              "path": "ci.software.File-System",
+              "value": "xfs"
+            },
+            {
+              "path": "ci.software.Kernel",
+              "value": "6.1.166 (x86_64)"
+            },
+            {
+              "path": "ci.software.OS",
+              "value": "Debian GNU/Linux 12"
+            },
+            {
+              "path": "ci.software.System Layer",
+              "value": "KVM"
+            },
+            {
+              "path": "ci.timestamp",
+              "value": "2026-07-20 12:14:41"
+            },
+            {
+              "path": "ci.user",
+              "value": "root"
+            }
+          ]
+        },
+        {
+          "source": "phoronix/result-file-to-json",
+          "sourceFile": "pgbench/pts_pgbench-read-only--metadata.json",
+          "fields": [
+            {
+              "path": "ci.client_version",
+              "value": "10.8.4"
+            },
+            {
+              "path": "ci.data.compiler-configuration",
+              "value": "--build=x86_64-linux-gnu --disable-vtable-verify --disable-werror --enable-cet --enable-checking=release --enable-clocale=gnu --enable-default-pie --enable-gnu-unique-object --enable-languages=c,ada,c++,go,d,fortran,objc,obj-c++,m2 --enable-libphobos-checking=release --enable-libstdcxx-debug --enable-libstdcxx-time=yes --enable-multiarch --enable-multilib --enable-nls --enable-objc-gc=auto --enable-offload-defaulted --enable-offload-targets=nvptx-none=/build/reproducible-path/gcc-12-12.2.0/debian/tmp-nvptx/usr,amdgcn-amdhsa=/build/reproducible-path/gcc-12-12.2.0/debian/tmp-gcn/usr --enable-plugin --enable-shared --enable-threads=posix --host=x86_64-linux-gnu --program-prefix=x86_64-linux-gnu- --target=x86_64-linux-gnu --with-abi=m64 --with-arch-32=i686 --with-default-libstdcxx-abi=new --with-gcc-major-version-only --with-multilib-list=m32,m64,mx32 --with-target-system-zlib=auto --with-tune=generic --without-cuda-driver -v"
+            },
+            {
+              "path": "ci.data.cpu-microcode",
+              "value": "0x1000065"
+            },
+            {
+              "path": "ci.data.environment-variables",
+              "value": "BL_DEBUG_TELEMETRY=false"
+            },
+            {
+              "path": "ci.data.kernel-extra-details",
+              "value": "Transparent Huge Pages: madvise"
+            },
+            {
+              "path": "ci.data.security",
+              "value": "gather_data_sampling: Not affected + indirect_target_selection: Not affected + itlb_multihit: Not affected + l1tf: Not affected + mds: Not affected + meltdown: Not affected + mmio_stale_data: Not affected + reg_file_data_sampling: Not affected + retbleed: Not affected + spec_rstack_overflow: Not affected + spec_store_bypass: Mitigation of SSB disabled via prctl + spectre_v1: Mitigation of usercopy/swapgs barriers and __user pointer sanitization + spectre_v2: Mitigation of Retpolines; IBPB: conditional; IBRS_FW; STIBP: always-on; RSB filling; PBRSB-eIBRS: Not affected; BHI: Not affected + srbds: Not affected + tsa: Not affected + tsx_async_abort: Not affected + vmscape: Not affected"
+            },
+            {
+              "path": "ci.hardware.Disk",
+              "value": "40GB"
+            },
+            {
+              "path": "ci.hardware.Memory",
+              "value": "8GB"
+            },
+            {
+              "path": "ci.hardware.Processor",
+              "value": "AMD EPYC (2 Cores / 4 Threads)"
+            },
+            {
+              "path": "ci.identifier",
+              "value": "ci"
+            },
+            {
+              "path": "ci.software.Compiler",
+              "value": "GCC 12.2.0"
+            },
+            {
+              "path": "ci.software.File-System",
+              "value": "xfs"
+            },
+            {
+              "path": "ci.software.Kernel",
+              "value": "6.1.166 (x86_64)"
+            },
+            {
+              "path": "ci.software.OS",
+              "value": "Debian GNU/Linux 12"
+            },
+            {
+              "path": "ci.software.System Layer",
+              "value": "KVM"
+            },
+            {
+              "path": "ci.timestamp",
+              "value": "2026-07-20 12:14:32"
+            },
+            {
+              "path": "ci.user",
+              "value": "root"
+            }
+          ]
+        },
+        {
+          "source": "phoronix/result-file-to-json",
+          "sourceFile": "pgbench/pts_pgbench-read-write--metadata.json",
+          "fields": [
+            {
+              "path": "ci.client_version",
+              "value": "10.8.4"
+            },
+            {
+              "path": "ci.data.compiler-configuration",
+              "value": "--build=x86_64-linux-gnu --disable-vtable-verify --disable-werror --enable-cet --enable-checking=release --enable-clocale=gnu --enable-default-pie --enable-gnu-unique-object --enable-languages=c,ada,c++,go,d,fortran,objc,obj-c++,m2 --enable-libphobos-checking=release --enable-libstdcxx-debug --enable-libstdcxx-time=yes --enable-multiarch --enable-multilib --enable-nls --enable-objc-gc=auto --enable-offload-defaulted --enable-offload-targets=nvptx-none=/build/reproducible-path/gcc-12-12.2.0/debian/tmp-nvptx/usr,amdgcn-amdhsa=/build/reproducible-path/gcc-12-12.2.0/debian/tmp-gcn/usr --enable-plugin --enable-shared --enable-threads=posix --host=x86_64-linux-gnu --program-prefix=x86_64-linux-gnu- --target=x86_64-linux-gnu --with-abi=m64 --with-arch-32=i686 --with-default-libstdcxx-abi=new --with-gcc-major-version-only --with-multilib-list=m32,m64,mx32 --with-target-system-zlib=auto --with-tune=generic --without-cuda-driver -v"
+            },
+            {
+              "path": "ci.data.cpu-microcode",
+              "value": "0x1000065"
+            },
+            {
+              "path": "ci.data.environment-variables",
+              "value": "BL_DEBUG_TELEMETRY=false"
+            },
+            {
+              "path": "ci.data.kernel-extra-details",
+              "value": "Transparent Huge Pages: madvise"
+            },
+            {
+              "path": "ci.data.security",
+              "value": "gather_data_sampling: Not affected + indirect_target_selection: Not affected + itlb_multihit: Not affected + l1tf: Not affected + mds: Not affected + meltdown: Not affected + mmio_stale_data: Not affected + reg_file_data_sampling: Not affected + retbleed: Not affected + spec_rstack_overflow: Not affected + spec_store_bypass: Mitigation of SSB disabled via prctl + spectre_v1: Mitigation of usercopy/swapgs barriers and __user pointer sanitization + spectre_v2: Mitigation of Retpolines; IBPB: conditional; IBRS_FW; STIBP: always-on; RSB filling; PBRSB-eIBRS: Not affected; BHI: Not affected + srbds: Not affected + tsa: Not affected + tsx_async_abort: Not affected + vmscape: Not affected"
+            },
+            {
+              "path": "ci.hardware.Disk",
+              "value": "40GB"
+            },
+            {
+              "path": "ci.hardware.Memory",
+              "value": "8GB"
+            },
+            {
+              "path": "ci.hardware.Processor",
+              "value": "AMD EPYC (2 Cores / 4 Threads)"
+            },
+            {
+              "path": "ci.identifier",
+              "value": "ci"
+            },
+            {
+              "path": "ci.software.Compiler",
+              "value": "GCC 12.2.0"
+            },
+            {
+              "path": "ci.software.File-System",
+              "value": "xfs"
+            },
+            {
+              "path": "ci.software.Kernel",
+              "value": "6.1.166 (x86_64)"
+            },
+            {
+              "path": "ci.software.OS",
+              "value": "Debian GNU/Linux 12"
+            },
+            {
+              "path": "ci.software.System Layer",
+              "value": "KVM"
+            },
+            {
+              "path": "ci.timestamp",
+              "value": "2026-07-20 12:15:10"
+            },
+            {
+              "path": "ci.user",
+              "value": "root"
+            }
+          ]
+        },
+        {
+          "source": "phoronix/result-file-to-json",
+          "sourceFile": "realworld-better-auth/pts_realworld-better-auth--metadata.json",
+          "fields": [
+            {
+              "path": "ci.client_version",
+              "value": "10.8.4"
+            },
+            {
+              "path": "ci.data.cpu-microcode",
+              "value": "0x1000065"
+            },
+            {
+              "path": "ci.data.environment-variables",
+              "value": "BL_DEBUG_TELEMETRY=false"
+            },
+            {
+              "path": "ci.data.kernel-extra-details",
+              "value": "Transparent Huge Pages: madvise"
+            },
+            {
+              "path": "ci.data.security",
+              "value": "gather_data_sampling: Not affected + indirect_target_selection: Not affected + itlb_multihit: Not affected + l1tf: Not affected + mds: Not affected + meltdown: Not affected + mmio_stale_data: Not affected + reg_file_data_sampling: Not affected + retbleed: Not affected + spec_rstack_overflow: Not affected + spec_store_bypass: Mitigation of SSB disabled via prctl + spectre_v1: Mitigation of usercopy/swapgs barriers and __user pointer sanitization + spectre_v2: Mitigation of Retpolines; IBPB: conditional; IBRS_FW; STIBP: always-on; RSB filling; PBRSB-eIBRS: Not affected; BHI: Not affected + srbds: Not affected + tsa: Not affected + tsx_async_abort: Not affected + vmscape: Not affected"
+            },
+            {
+              "path": "ci.hardware.Disk",
+              "value": "40GB"
+            },
+            {
+              "path": "ci.hardware.Memory",
+              "value": "8GB"
+            },
+            {
+              "path": "ci.hardware.Processor",
+              "value": "AMD EPYC (2 Cores / 4 Threads)"
+            },
+            {
+              "path": "ci.identifier",
+              "value": "ci"
+            },
+            {
+              "path": "ci.software.Compiler",
+              "value": "GCC 12.2.0"
+            },
+            {
+              "path": "ci.software.File-System",
+              "value": "xfs"
+            },
+            {
+              "path": "ci.software.Kernel",
+              "value": "6.1.166 (x86_64)"
+            },
+            {
+              "path": "ci.software.OS",
+              "value": "Debian GNU/Linux 12"
+            },
+            {
+              "path": "ci.software.System Layer",
+              "value": "KVM"
+            },
+            {
+              "path": "ci.timestamp",
+              "value": "2026-07-20 12:14:43"
+            },
+            {
+              "path": "ci.user",
+              "value": "root"
+            }
+          ]
+        },
+        {
+          "source": "phoronix/result-file-to-json",
+          "sourceFile": "realworld-mastra/pts_realworld-mastra--metadata.json",
+          "fields": [
+            {
+              "path": "ci.client_version",
+              "value": "10.8.4"
+            },
+            {
+              "path": "ci.data.cpu-microcode",
+              "value": "0x1000065"
+            },
+            {
+              "path": "ci.data.environment-variables",
+              "value": "BL_DEBUG_TELEMETRY=false"
+            },
+            {
+              "path": "ci.data.kernel-extra-details",
+              "value": "Transparent Huge Pages: madvise"
+            },
+            {
+              "path": "ci.data.security",
+              "value": "gather_data_sampling: Not affected + indirect_target_selection: Not affected + itlb_multihit: Not affected + l1tf: Not affected + mds: Not affected + meltdown: Not affected + mmio_stale_data: Not affected + reg_file_data_sampling: Not affected + retbleed: Not affected + spec_rstack_overflow: Not affected + spec_store_bypass: Mitigation of SSB disabled via prctl + spectre_v1: Mitigation of usercopy/swapgs barriers and __user pointer sanitization + spectre_v2: Mitigation of Retpolines; IBPB: conditional; IBRS_FW; STIBP: always-on; RSB filling; PBRSB-eIBRS: Not affected; BHI: Not affected + srbds: Not affected + tsa: Not affected + tsx_async_abort: Not affected + vmscape: Not affected"
+            },
+            {
+              "path": "ci.hardware.Disk",
+              "value": "40GB"
+            },
+            {
+              "path": "ci.hardware.Memory",
+              "value": "8GB"
+            },
+            {
+              "path": "ci.hardware.Processor",
+              "value": "AMD EPYC (2 Cores / 4 Threads)"
+            },
+            {
+              "path": "ci.identifier",
+              "value": "ci"
+            },
+            {
+              "path": "ci.software.Compiler",
+              "value": "GCC 12.2.0"
+            },
+            {
+              "path": "ci.software.File-System",
+              "value": "xfs"
+            },
+            {
+              "path": "ci.software.Kernel",
+              "value": "6.1.166 (x86_64)"
+            },
+            {
+              "path": "ci.software.OS",
+              "value": "Debian GNU/Linux 12"
+            },
+            {
+              "path": "ci.software.System Layer",
+              "value": "KVM"
+            },
+            {
+              "path": "ci.timestamp",
+              "value": "2026-07-20 12:15:18"
+            },
+            {
+              "path": "ci.user",
+              "value": "root"
+            }
+          ]
+        },
+        {
+          "source": "phoronix/result-file-to-json",
+          "sourceFile": "realworld-openclaw/pts_realworld-openclaw--metadata.json",
+          "fields": [
+            {
+              "path": "ci.client_version",
+              "value": "10.8.4"
+            },
+            {
+              "path": "ci.data.cpu-microcode",
+              "value": "0x1000065"
+            },
+            {
+              "path": "ci.data.environment-variables",
+              "value": "BL_DEBUG_TELEMETRY=false"
+            },
+            {
+              "path": "ci.data.kernel-extra-details",
+              "value": "Transparent Huge Pages: madvise"
+            },
+            {
+              "path": "ci.data.security",
+              "value": "gather_data_sampling: Not affected + indirect_target_selection: Not affected + itlb_multihit: Not affected + l1tf: Not affected + mds: Not affected + meltdown: Not affected + mmio_stale_data: Not affected + reg_file_data_sampling: Not affected + retbleed: Not affected + spec_rstack_overflow: Not affected + spec_store_bypass: Mitigation of SSB disabled via prctl + spectre_v1: Mitigation of usercopy/swapgs barriers and __user pointer sanitization + spectre_v2: Mitigation of Retpolines; IBPB: conditional; IBRS_FW; STIBP: always-on; RSB filling; PBRSB-eIBRS: Not affected; BHI: Not affected + srbds: Not affected + tsa: Not affected + tsx_async_abort: Not affected + vmscape: Not affected"
+            },
+            {
+              "path": "ci.hardware.Disk",
+              "value": "40GB"
+            },
+            {
+              "path": "ci.hardware.Memory",
+              "value": "8GB"
+            },
+            {
+              "path": "ci.hardware.Processor",
+              "value": "AMD EPYC (2 Cores / 4 Threads)"
+            },
+            {
+              "path": "ci.identifier",
+              "value": "ci"
+            },
+            {
+              "path": "ci.software.Compiler",
+              "value": "GCC 12.2.0"
+            },
+            {
+              "path": "ci.software.File-System",
+              "value": "xfs"
+            },
+            {
+              "path": "ci.software.Kernel",
+              "value": "6.1.166 (x86_64)"
+            },
+            {
+              "path": "ci.software.OS",
+              "value": "Debian GNU/Linux 12"
+            },
+            {
+              "path": "ci.software.System Layer",
+              "value": "KVM"
+            },
+            {
+              "path": "ci.timestamp",
+              "value": "2026-07-20 12:14:57"
+            },
+            {
+              "path": "ci.user",
+              "value": "root"
+            }
+          ]
+        }
+      ],
+      "metrics": [
+        {
+          "metricId": "fast_cli_internet_download_speed",
+          "samples": [3.3, 5.7],
+          "aggregates": {
+            "p50": 4.5,
+            "p95": 5.58,
+            "mean": 4.5,
+            "stdev": 1.6970562748477143,
+            "min": 3.3,
+            "max": 5.7,
+            "n": 2
+          },
+          "sourceFile": "network/pts_fast-cli.xml"
+        },
+        {
+          "metricId": "fast_cli_internet_latency",
+          "samples": [3, 4],
+          "aggregates": {
+            "p50": 3.5,
+            "p95": 3.95,
+            "mean": 3.5,
+            "stdev": 0.7071067811865476,
+            "min": 3,
+            "max": 4,
+            "n": 2
+          },
+          "sourceFile": "network/pts_fast-cli.xml"
+        },
+        {
+          "metricId": "fast_cli_internet_loaded_latency_bufferbloat",
+          "samples": [7, 7],
+          "aggregates": {
+            "p50": 7,
+            "p95": 7,
+            "mean": 7,
+            "stdev": 0,
+            "min": 7,
+            "max": 7,
+            "n": 2
+          },
+          "sourceFile": "network/pts_fast-cli.xml"
+        },
+        {
+          "metricId": "fast_cli_internet_upload_speed",
+          "samples": [2100, 2000],
+          "aggregates": {
+            "p50": 2050,
+            "p95": 2095,
+            "mean": 2050,
+            "stdev": 70.71067811865476,
+            "min": 2000,
+            "max": 2100,
+            "n": 2
+          },
+          "sourceFile": "network/pts_fast-cli.xml"
+        },
+        {
+          "metricId": "fio_type_random_read_engine_linux_aio_direct_yes_block_size_4kb_job_count_1_disk_target_default_test_directory_iops",
+          "samples": [214000, 217000],
+          "aggregates": {
+            "p50": 215500,
+            "p95": 216850,
+            "mean": 215500,
+            "stdev": 2121.3203435596424,
+            "min": 214000,
+            "max": 217000,
+            "n": 2
+          },
+          "sourceFile": "disk/pts_fio-rand-read.xml",
+          "appVersion": "3.36",
+          "arguments": "randread libaio 1 4k 1"
+        },
+        {
+          "metricId": "fio_type_random_read_engine_linux_aio_direct_yes_block_size_4kb_job_count_1_disk_target_default_test_directory_mb_per_s",
+          "samples": [837, 849],
+          "aggregates": {
+            "p50": 843,
+            "p95": 848.4,
+            "mean": 843,
+            "stdev": 8.48528137423857,
+            "min": 837,
+            "max": 849,
+            "n": 2
+          },
+          "sourceFile": "disk/pts_fio-rand-read.xml",
+          "appVersion": "3.36",
+          "arguments": "randread libaio 1 4k 1"
+        },
+        {
+          "metricId": "fio_type_random_write_engine_linux_aio_direct_yes_block_size_4kb_job_count_1_disk_target_default_test_directory_iops",
+          "samples": [228000, 213000],
+          "aggregates": {
+            "p50": 220500,
+            "p95": 227250,
+            "mean": 220500,
+            "stdev": 10606.601717798212,
+            "min": 213000,
+            "max": 228000,
+            "n": 2
+          },
+          "sourceFile": "disk/pts_fio-rand-write.xml",
+          "appVersion": "3.36",
+          "arguments": "randwrite libaio 1 4k 1"
+        },
+        {
+          "metricId": "fio_type_random_write_engine_linux_aio_direct_yes_block_size_4kb_job_count_1_disk_target_default_test_directory_mb_per_s",
+          "samples": [892, 834],
+          "aggregates": {
+            "p50": 863,
+            "p95": 889.1,
+            "mean": 863,
+            "stdev": 41.012193308819754,
+            "min": 834,
+            "max": 892,
+            "n": 2
+          },
+          "sourceFile": "disk/pts_fio-rand-write.xml",
+          "appVersion": "3.36",
+          "arguments": "randwrite libaio 1 4k 1"
+        },
+        {
+          "metricId": "fio_type_sequential_read_engine_linux_aio_direct_yes_block_size_1mb_job_count_1_disk_target_default_test_directory_iops",
+          "samples": [10300, 10600],
+          "aggregates": {
+            "p50": 10450,
+            "p95": 10585,
+            "mean": 10450,
+            "stdev": 212.13203435596427,
+            "min": 10300,
+            "max": 10600,
+            "n": 2
+          },
+          "sourceFile": "disk/pts_fio-seq-read.xml",
+          "appVersion": "3.36",
+          "arguments": "read libaio 1 1m 1"
+        },
+        {
+          "metricId": "fio_type_sequential_write_engine_linux_aio_direct_yes_block_size_1mb_job_count_1_disk_target_default_test_directory_iops",
+          "samples": [5756, 5270],
+          "aggregates": {
+            "p50": 5513,
+            "p95": 5731.7,
+            "mean": 5513,
+            "stdev": 343.6538956566621,
+            "min": 5270,
+            "max": 5756,
+            "n": 2
+          },
+          "sourceFile": "disk/pts_fio-seq-write.xml",
+          "appVersion": "3.36",
+          "arguments": "write libaio 1 1m 1"
+        },
+        {
+          "metricId": "fio_type_sequential_write_engine_linux_aio_direct_yes_block_size_1mb_job_count_1_disk_target_default_test_directory_mb_per_s",
+          "samples": [5757, 5272],
+          "aggregates": {
+            "p50": 5514.5,
+            "p95": 5732.75,
+            "mean": 5514.5,
+            "stdev": 342.94678887547553,
+            "min": 5272,
+            "max": 5757,
+            "n": 2
+          },
+          "sourceFile": "disk/pts_fio-seq-write.xml",
+          "appVersion": "3.36",
+          "arguments": "write libaio 1 1m 1"
+        },
+        {
+          "metricId": "hardlink_bogo_ops_per_s",
+          "samples": [19.39, 19.36],
+          "aggregates": {
+            "p50": 19.375,
+            "p95": 19.3885,
+            "mean": 19.375,
+            "stdev": 0.02121320343559723,
+            "min": 19.36,
+            "max": 19.39,
+            "n": 2
+          },
+          "sourceFile": "disk/pts_hardlink.xml",
+          "appVersion": "0.16"
+        },
+        {
+          "metricId": "network_loopback_seconds",
+          "samples": [2.157, 3.385],
+          "aggregates": {
+            "p50": 2.771,
+            "p95": 3.3236,
+            "mean": 2.771,
+            "stdev": 0.8683271272970802,
+            "min": 2.157,
+            "max": 3.385,
+            "n": 2
+          },
+          "sourceFile": "network/pts_network-loopback.xml"
+        },
+        {
+          "metricId": "node_web_tooling_runs_per_s",
+          "samples": [20.52, 20.44],
+          "aggregates": {
+            "p50": 20.48,
+            "p95": 20.516,
+            "mean": 20.48,
+            "stdev": 0.056568542494922595,
+            "min": 20.44,
+            "max": 20.52,
+            "n": 2
+          },
+          "sourceFile": "cpu-node/pts_node-web-tooling.xml"
+        },
+        {
+          "metricId": "realworld_better_auth_task_build",
+          "samples": [56.971],
+          "aggregates": {
+            "p50": 56.971,
+            "p95": 56.971,
+            "mean": 56.971,
+            "stdev": 0,
+            "min": 56.971,
+            "max": 56.971,
+            "n": 1
+          },
+          "sourceFile": "realworld-better-auth/pts_realworld-better-auth.xml",
+          "appVersion": "6f3ba45639579da152b69e8e5342e02f28288670",
+          "arguments": "build"
+        },
+        {
+          "metricId": "realworld_better_auth_task_cold_install",
+          "samples": [10.821],
+          "aggregates": {
+            "p50": 10.821,
+            "p95": 10.821,
+            "mean": 10.821,
+            "stdev": 0,
+            "min": 10.821,
+            "max": 10.821,
+            "n": 1
+          },
+          "sourceFile": "realworld-better-auth/pts_realworld-better-auth.xml",
+          "appVersion": "6f3ba45639579da152b69e8e5342e02f28288670",
+          "arguments": "cold_install"
+        },
+        {
+          "metricId": "realworld_better_auth_task_git_clone",
+          "samples": [1.354],
+          "aggregates": {
+            "p50": 1.354,
+            "p95": 1.354,
+            "mean": 1.354,
+            "stdev": 0,
+            "min": 1.354,
+            "max": 1.354,
+            "n": 1
+          },
+          "sourceFile": "realworld-better-auth/pts_realworld-better-auth.xml",
+          "appVersion": "6f3ba45639579da152b69e8e5342e02f28288670",
+          "arguments": "git_clone"
+        },
+        {
+          "metricId": "realworld_better_auth_task_lint_biome",
+          "samples": [3.173],
+          "aggregates": {
+            "p50": 3.173,
+            "p95": 3.173,
+            "mean": 3.173,
+            "stdev": 0,
+            "min": 3.173,
+            "max": 3.173,
+            "n": 1
+          },
+          "sourceFile": "realworld-better-auth/pts_realworld-better-auth.xml",
+          "appVersion": "6f3ba45639579da152b69e8e5342e02f28288670",
+          "arguments": "lint_biome"
+        },
+        {
+          "metricId": "realworld_better_auth_task_lint_deps_knip",
+          "samples": [9.902],
+          "aggregates": {
+            "p50": 9.902,
+            "p95": 9.902,
+            "mean": 9.902,
+            "stdev": 0,
+            "min": 9.902,
+            "max": 9.902,
+            "n": 1
+          },
+          "sourceFile": "realworld-better-auth/pts_realworld-better-auth.xml",
+          "appVersion": "6f3ba45639579da152b69e8e5342e02f28288670",
+          "arguments": "lint_deps"
+        },
+        {
+          "metricId": "realworld_better_auth_task_lint_format",
+          "samples": [2.93],
+          "aggregates": {
+            "p50": 2.93,
+            "p95": 2.93,
+            "mean": 2.93,
+            "stdev": 0,
+            "min": 2.93,
+            "max": 2.93,
+            "n": 1
+          },
+          "sourceFile": "realworld-better-auth/pts_realworld-better-auth.xml",
+          "appVersion": "6f3ba45639579da152b69e8e5342e02f28288670",
+          "arguments": "lint_format"
+        },
+        {
+          "metricId": "realworld_better_auth_task_lint_packages",
+          "samples": [2.536],
+          "aggregates": {
+            "p50": 2.536,
+            "p95": 2.536,
+            "mean": 2.536,
+            "stdev": 0,
+            "min": 2.536,
+            "max": 2.536,
+            "n": 1
+          },
+          "sourceFile": "realworld-better-auth/pts_realworld-better-auth.xml",
+          "appVersion": "6f3ba45639579da152b69e8e5342e02f28288670",
+          "arguments": "lint_packages"
+        },
+        {
+          "metricId": "realworld_better_auth_task_lint_spell",
+          "samples": [6.771],
+          "aggregates": {
+            "p50": 6.771,
+            "p95": 6.771,
+            "mean": 6.771,
+            "stdev": 0,
+            "min": 6.771,
+            "max": 6.771,
+            "n": 1
+          },
+          "sourceFile": "realworld-better-auth/pts_realworld-better-auth.xml",
+          "appVersion": "6f3ba45639579da152b69e8e5342e02f28288670",
+          "arguments": "lint_spell"
+        },
+        {
+          "metricId": "realworld_better_auth_task_lint_types",
+          "samples": [25.272],
+          "aggregates": {
+            "p50": 25.272,
+            "p95": 25.272,
+            "mean": 25.272,
+            "stdev": 0,
+            "min": 25.272,
+            "max": 25.272,
+            "n": 1
+          },
+          "sourceFile": "realworld-better-auth/pts_realworld-better-auth.xml",
+          "appVersion": "6f3ba45639579da152b69e8e5342e02f28288670",
+          "arguments": "lint_types"
+        },
+        {
+          "metricId": "realworld_better_auth_task_typecheck",
+          "samples": [41.11],
+          "aggregates": {
+            "p50": 41.11,
+            "p95": 41.11,
+            "mean": 41.11,
+            "stdev": 0,
+            "min": 41.11,
+            "max": 41.11,
+            "n": 1
+          },
+          "sourceFile": "realworld-better-auth/pts_realworld-better-auth.xml",
+          "appVersion": "6f3ba45639579da152b69e8e5342e02f28288670",
+          "arguments": "typecheck"
+        },
+        {
+          "metricId": "realworld_mastra_task_build_core",
+          "samples": [69.485],
+          "aggregates": {
+            "p50": 69.485,
+            "p95": 69.485,
+            "mean": 69.485,
+            "stdev": 0,
+            "min": 69.485,
+            "max": 69.485,
+            "n": 1
+          },
+          "sourceFile": "realworld-mastra/pts_realworld-mastra.xml",
+          "appVersion": "b6eeb9d08ebeaf27bc6fd16b6b88087040aaf767",
+          "arguments": "build_core"
+        },
+        {
+          "metricId": "realworld_mastra_task_cold_install",
+          "samples": [25.096],
+          "aggregates": {
+            "p50": 25.096,
+            "p95": 25.096,
+            "mean": 25.096,
+            "stdev": 0,
+            "min": 25.096,
+            "max": 25.096,
+            "n": 1
+          },
+          "sourceFile": "realworld-mastra/pts_realworld-mastra.xml",
+          "appVersion": "b6eeb9d08ebeaf27bc6fd16b6b88087040aaf767",
+          "arguments": "cold_install"
+        },
+        {
+          "metricId": "realworld_mastra_task_git_clone",
+          "samples": [9.148],
+          "aggregates": {
+            "p50": 9.148,
+            "p95": 9.148,
+            "mean": 9.148,
+            "stdev": 0,
+            "min": 9.148,
+            "max": 9.148,
+            "n": 1
+          },
+          "sourceFile": "realworld-mastra/pts_realworld-mastra.xml",
+          "appVersion": "b6eeb9d08ebeaf27bc6fd16b6b88087040aaf767",
+          "arguments": "git_clone"
+        },
+        {
+          "metricId": "realworld_mastra_task_lint_format",
+          "samples": [87.781],
+          "aggregates": {
+            "p50": 87.781,
+            "p95": 87.781,
+            "mean": 87.781,
+            "stdev": 0,
+            "min": 87.781,
+            "max": 87.781,
+            "n": 1
+          },
+          "sourceFile": "realworld-mastra/pts_realworld-mastra.xml",
+          "appVersion": "b6eeb9d08ebeaf27bc6fd16b6b88087040aaf767",
+          "arguments": "lint_format"
+        },
+        {
+          "metricId": "realworld_openclaw_task_cold_install",
+          "samples": [4.635],
+          "aggregates": {
+            "p50": 4.635,
+            "p95": 4.635,
+            "mean": 4.635,
+            "stdev": 0,
+            "min": 4.635,
+            "max": 4.635,
+            "n": 1
+          },
+          "sourceFile": "realworld-openclaw/pts_realworld-openclaw.xml",
+          "appVersion": "623534400684eca7c451cf587189fae714f2abe2",
+          "arguments": "cold_install"
+        },
+        {
+          "metricId": "realworld_openclaw_task_git_clone",
+          "samples": [9.027],
+          "aggregates": {
+            "p50": 9.027,
+            "p95": 9.027,
+            "mean": 9.027,
+            "stdev": 0,
+            "min": 9.027,
+            "max": 9.027,
+            "n": 1
+          },
+          "sourceFile": "realworld-openclaw/pts_realworld-openclaw.xml",
+          "appVersion": "623534400684eca7c451cf587189fae714f2abe2",
+          "arguments": "git_clone"
+        },
+        {
+          "metricId": "realworld_openclaw_task_typecheck",
+          "samples": [39.206],
+          "aggregates": {
+            "p50": 39.206,
+            "p95": 39.206,
+            "mean": 39.206,
+            "stdev": 0,
+            "min": 39.206,
+            "max": 39.206,
+            "n": 1
+          },
+          "sourceFile": "realworld-openclaw/pts_realworld-openclaw.xml",
+          "appVersion": "623534400684eca7c451cf587189fae714f2abe2",
+          "arguments": "typecheck"
+        },
+        {
+          "metricId": "stream_type_add",
+          "samples": [124830.5, 128109.5],
+          "aggregates": {
+            "p50": 126470,
+            "p95": 127945.55,
+            "mean": 126470,
+            "stdev": 2318.6031355106893,
+            "min": 124830.5,
+            "max": 128109.5,
+            "n": 2
+          },
+          "sourceFile": "memory/pts_stream.xml",
+          "appVersion": "2013-01-17",
+          "arguments": "Add"
+        },
+        {
+          "metricId": "stream_type_copy",
+          "samples": [144402.9, 146039.1],
+          "aggregates": {
+            "p50": 145221,
+            "p95": 145957.29,
+            "mean": 145221,
+            "stdev": 1156.9681153774372,
+            "min": 144402.9,
+            "max": 146039.1,
+            "n": 2
+          },
+          "sourceFile": "memory/pts_stream.xml",
+          "appVersion": "2013-01-17",
+          "arguments": "Copy"
+        },
+        {
+          "metricId": "stream_type_scale",
+          "samples": [118413.5, 120712.4],
+          "aggregates": {
+            "p50": 119562.95,
+            "p95": 120597.45499999999,
+            "mean": 119562.95,
+            "stdev": 1625.56777926975,
+            "min": 118413.5,
+            "max": 120712.4,
+            "n": 2
+          },
+          "sourceFile": "memory/pts_stream.xml",
+          "appVersion": "2013-01-17",
+          "arguments": "Scale"
+        },
+        {
+          "metricId": "stream_type_triad",
+          "samples": [124283.9, 127559.7],
+          "aggregates": {
+            "p50": 125921.79999999999,
+            "p95": 127395.91,
+            "mean": 125921.79999999999,
+            "stdev": 2316.3403938108995,
+            "min": 124283.9,
+            "max": 127559.7,
+            "n": 2
+          },
+          "sourceFile": "memory/pts_stream.xml",
+          "appVersion": "2013-01-17",
+          "arguments": "Triad"
+        }
+      ],
+      "suitesCovered": [
+        "cpu-node",
+        "disk",
+        "memory",
+        "network",
+        "realworld-better-auth",
+        "realworld-mastra",
+        "realworld-openclaw"
+      ],
+      "gaps": [],
+      "uncatalogued": []
+    },
+    {
+      "providerId": "daytona",
+      "validationStatus": "pending",
+      "observedSpecs": {},
+      "metrics": [],
+      "suitesCovered": [],
+      "gaps": [],
+      "uncatalogued": []
+    },
+    {
+      "providerId": "e2b",
+      "validationStatus": "pending",
+      "observedSpecs": {},
+      "metrics": [],
+      "suitesCovered": [],
+      "gaps": [],
+      "uncatalogued": []
+    },
+    {
+      "providerId": "modal",
+      "validationStatus": "pending",
+      "observedSpecs": {},
+      "metrics": [],
+      "suitesCovered": [],
+      "gaps": [],
+      "uncatalogued": []
+    },
+    {
+      "providerId": "novita",
+      "validationStatus": "pending",
+      "observedSpecs": {},
+      "metrics": [],
+      "suitesCovered": [],
+      "gaps": [],
+      "uncatalogued": []
+    }
+  ]
+}


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Publishes benchmark run 29741364586 and regenerates the sandbox provider leaderboard. Adds data/dataset/runs/29741364586.json and updates data/dataset/index.json; the leaderboard now shows 35 metrics from 53 observations for 1 provider (blaxel) at 4 vCPU, 8 GiB RAM, 40 GB disk.

<sup>Written for commit defa2869e27ec88bea67aa675bfb083b3a460539. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/starslingdev/hpc-sandbox-benchmarks/pull/220?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a new benchmark run with performance results across CPU, memory, disk, network, and real-world workloads.
  - Added expanded benchmark data covering 35 metrics and 53 retained trial observations.

- **Documentation**
  - Updated the leaderboard with refreshed rankings, measurements, and confidence intervals.
  - Clarified coverage gaps and identified workloads without available results from other providers.
  - Streamlined ranking methodology and coverage explanations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->