### PR TITLE
Use VM Sandboxes for Modal

### DIFF
--- a/packages/providers/src/index.test.ts
+++ b/packages/providers/src/index.test.ts
@@ -42,6 +42,7 @@ describe("@sandbox-benchmarks/providers", () => {
 			cpuLimit: TARGET_SPEC.vcpus,
 			memoryMiB: TARGET_SPEC.memoryGb * 1024,
 			memoryLimitMiB: TARGET_SPEC.memoryGb * 1024,
+			experimentalOptions: { vm_runtime: true },
 		});
 	});
 

--- a/packages/providers/src/lib/adapters.ts
+++ b/packages/providers/src/lib/adapters.ts
@@ -71,7 +71,7 @@ export const adapters: Record<ProviderId, ProviderAdapter> = {
 		// Boot sandboxes under this project's own Modal app (auto-created via apps.fromName on first
 		// create), not the wrapper's generic `computesdk-modal` default — so this project's sandboxes
 		// are namespaced/attributable in the Modal dashboard, separate from any other computesdk usage.
-		createCompute: () => modal({ scalableSandboxes: true, appName: MODAL_APP_NAME }),
+		createCompute: () => modal({ appName: MODAL_APP_NAME }),
 		createOptions: {
 			templateId: config.toolchainImage,
 			// Modal's docs call `cpu` physical cores ("this value corresponds to physical cores, not
@@ -87,6 +87,7 @@ export const adapters: Record<ProviderId, ProviderAdapter> = {
 			// converged. `memoryLimitMiB` is the hard cap that makes /proc/meminfo report the target spec.
 			memoryMiB: TARGET_SPEC.memoryGb * 1024,
 			memoryLimitMiB: TARGET_SPEC.memoryGb * 1024,
+			experimentalOptions: { vm_runtime: true },
 		},
 	},
 	novita: {

--- a/packages/schema/src/providers.ts
+++ b/packages/schema/src/providers.ts
@@ -259,8 +259,8 @@ const REGISTRY: Record<ProviderId, Omit<ProviderMeta, "id">> = {
 		sdkPackage: "@computesdk/modal",
 		requiredEnvVars: ["MODAL_TOKEN_ID", "MODAL_TOKEN_SECRET"],
 		isolation: {
-			technology: "gVisor container",
-			notes: "scalableSandboxes enabled in the harness; nproc tracks the requested cpu 1:1.",
+			technology: "VM",
+			notes: "VM Sandboxes",
 		},
 		pricing: {
 			model: "per_vcpu_hour",
@@ -277,7 +277,7 @@ const REGISTRY: Record<ProviderId, Omit<ProviderMeta, "id">> = {
 				"Sandbox non-preemptible rates (exact): CPU $0.00003942/s per requested cpu unit (observed to deliver 1 schedulable vCPU each, despite the docs calling it a physical core), memory $0.00000672/GiB-s. Regional multipliers (1.25×–2.5×) compound. Volumes: 1 TiB/mo free, then $0.09/GiB/mo.",
 			sourceUrl: "https://modal.com/pricing",
 		},
-		maturity: { status: "ga", notes: "scalableSandboxes enabled in the harness." },
+		maturity: { status: "beta", notes: "VM runtime is beta." },
 		specPinning: "settable",
 		transport: {
 			// `@computesdk/modal` runs `sandbox.exec([...])` and `process.wait()`s the result, with no


### PR DESCRIPTION
[VM Sandboxes ](https://modal.com/docs/guide/vm-sandboxes) are the best choice on Modal for performance-sensitive workloads. This PR enables their usage in hpc-sandbox-benchmarks.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switch the Modal provider to VM Sandboxes for the benchmarks to improve performance. This replaces gVisor containers and marks the runtime as beta.

- **Refactors**
  - Enable VM runtime with `experimentalOptions: { vm_runtime: true }` in create options.
  - Remove `scalableSandboxes` from `createCompute`; use app scoping only.
  - Update provider metadata: isolation set to "VM", notes "VM Sandboxes", maturity to beta.
  - Update tests to assert `vm_runtime: true`.

<sup>Written for commit 5d3778f66a57f8f0703d66853137c98060e0bfea. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/starslingdev/hpc-sandbox-benchmarks/pull/221?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Modal sandbox execution now uses the VM runtime for improved isolation.
* **Updates**
  * Updated Modal provider details to reflect VM-based isolation.
  * Modal VM runtime support is now labeled as beta.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->