### PR TITLE
feat(providers): split Modal into gVisor + VM isolation variants

### DIFF
--- a/.github/workflows/bench-matrix.yml
+++ b/.github/workflows/bench-matrix.yml
@@ -20,13 +20,13 @@ on:
         required: false
         type: string
         # The validated providers with a baked toolchain artifact and credentials in CI: e2b,
-        # daytona-vm (the LINUX_VM reference), modal, and novita (which boots its own pre-baked
-        # template, so it is comparable despite its "beta" maturity). The new isolation variant
-        # daytona-container — like blaxel (stock base image) — is excluded by default until a committed
-        # run validates it, rather than burning runner time on cells that can't yet produce a
-        # comparable result. Pass it explicitly to include it; `plan-providers` rejects any name that
-        # is not in the registry.
-        default: e2b,daytona-vm,modal,novita
+        # daytona-vm (the LINUX_VM reference), modal-gvisor (Modal's default runtime), and novita
+        # (which boots its own pre-baked template, so it is comparable despite its "beta" maturity).
+        # The new isolation variants daytona-container + modal-vm — like blaxel (stock base image) —
+        # are excluded by default until a committed run validates them, rather than burning runner time
+        # on cells that can't yet produce a comparable result. Pass any of them explicitly to include
+        # it; `plan-providers` rejects any name that is not in the registry.
+        default: e2b,daytona-vm,modal-gvisor,novita
       suites:
         description: 'Comma-separated suites to run (blank = every registered suite). E.g. "network" for a targeted pre-merge run.'
         required: false

--- a/.github/workflows/bench-smoke.yml
+++ b/.github/workflows/bench-smoke.yml
@@ -11,7 +11,7 @@ on:
         description: Provider to benchmark
         type: choice
         default: daytona-vm
-        options: [daytona-vm, daytona-container, e2b, modal, blaxel, novita]
+        options: [daytona-vm, daytona-container, e2b, modal-gvisor, modal-vm, blaxel, novita]
       suite:
         # Constrained to the SUITE_NAMES registry (packages/schema/src/suites.ts); the
         # workflow-registry-sync drift gate (tooling/repo-checks) keeps this list in lockstep, so a
@@ -106,8 +106,9 @@ jobs:
           DAYTONA_TARGET: ${{ inputs.provider == 'daytona-vm' && (secrets.DAYTONA_TARGET || 'us-west-2') || '' }}
           DAYTONA_CONTAINER_TARGET: ${{ inputs.provider == 'daytona-container' && (secrets.DAYTONA_CONTAINER_TARGET || 'us') || '' }}
           E2B_API_KEY: ${{ inputs.provider == 'e2b' && secrets.E2B_API_KEY || '' }}
-          MODAL_TOKEN_ID: ${{ inputs.provider == 'modal' && secrets.MODAL_TOKEN_ID || '' }}
-          MODAL_TOKEN_SECRET: ${{ inputs.provider == 'modal' && secrets.MODAL_TOKEN_SECRET || '' }}
+          # Both Modal variants share the account tokens; scope them to either being dispatched.
+          MODAL_TOKEN_ID: ${{ (inputs.provider == 'modal-gvisor' || inputs.provider == 'modal-vm') && secrets.MODAL_TOKEN_ID || '' }}
+          MODAL_TOKEN_SECRET: ${{ (inputs.provider == 'modal-gvisor' || inputs.provider == 'modal-vm') && secrets.MODAL_TOKEN_SECRET || '' }}
           BL_API_KEY: ${{ inputs.provider == 'blaxel' && secrets.BL_API_KEY || '' }}
           BL_WORKSPACE: ${{ inputs.provider == 'blaxel' && secrets.BL_WORKSPACE || '' }}
           NOVITA_API_KEY: ${{ inputs.provider == 'novita' && secrets.NOVITA_API_KEY || '' }}

--- a/.github/workflows/bench-suite.yml
+++ b/.github/workflows/bench-suite.yml
@@ -93,8 +93,9 @@ jobs:
           DAYTONA_TARGET: ${{ matrix.provider == 'daytona-vm' && (secrets.DAYTONA_TARGET || 'us-west-2') || '' }}
           DAYTONA_CONTAINER_TARGET: ${{ matrix.provider == 'daytona-container' && (secrets.DAYTONA_CONTAINER_TARGET || 'us') || '' }}
           E2B_API_KEY: ${{ matrix.provider == 'e2b' && secrets.E2B_API_KEY || '' }}
-          MODAL_TOKEN_ID: ${{ matrix.provider == 'modal' && secrets.MODAL_TOKEN_ID || '' }}
-          MODAL_TOKEN_SECRET: ${{ matrix.provider == 'modal' && secrets.MODAL_TOKEN_SECRET || '' }}
+          # Both Modal variants share the account tokens; scope them to either cell.
+          MODAL_TOKEN_ID: ${{ (matrix.provider == 'modal-gvisor' || matrix.provider == 'modal-vm') && secrets.MODAL_TOKEN_ID || '' }}
+          MODAL_TOKEN_SECRET: ${{ (matrix.provider == 'modal-gvisor' || matrix.provider == 'modal-vm') && secrets.MODAL_TOKEN_SECRET || '' }}
           BL_API_KEY: ${{ matrix.provider == 'blaxel' && secrets.BL_API_KEY || '' }}
           BL_WORKSPACE: ${{ matrix.provider == 'blaxel' && secrets.BL_WORKSPACE || '' }}
           NOVITA_API_KEY: ${{ matrix.provider == 'novita' && secrets.NOVITA_API_KEY || '' }}

--- a/.github/workflows/toolchain-image.yml
+++ b/.github/workflows/toolchain-image.yml
@@ -331,10 +331,10 @@ jobs:
           # default region and fail the bake at snapshot creation.
           DAYTONA_TARGET: ${{ matrix.provider == 'daytona-vm' && (secrets.DAYTONA_TARGET || 'us-west-2') || '' }}
           DAYTONA_CONTAINER_TARGET: ${{ matrix.provider == 'daytona-container' && (secrets.DAYTONA_CONTAINER_TARGET || 'us') || '' }}
-          # Modal's bake is a no-op (the image is pushed once and booted directly), but validate still
-          # boots it to prove reachability.
-          MODAL_TOKEN_ID: ${{ matrix.provider == 'modal' && secrets.MODAL_TOKEN_ID || '' }}
-          MODAL_TOKEN_SECRET: ${{ matrix.provider == 'modal' && secrets.MODAL_TOKEN_SECRET || '' }}
+          # Both Modal variants share the account tokens; the bake is a no-op for each (the image is
+          # pushed once and booted directly), but validate still boots each to prove reachability.
+          MODAL_TOKEN_ID: ${{ (matrix.provider == 'modal-gvisor' || matrix.provider == 'modal-vm') && secrets.MODAL_TOKEN_ID || '' }}
+          MODAL_TOKEN_SECRET: ${{ (matrix.provider == 'modal-gvisor' || matrix.provider == 'modal-vm') && secrets.MODAL_TOKEN_SECRET || '' }}
           # Optional: a missing NOVITA_API_KEY skips the novita bake without failing the release.
           NOVITA_API_KEY: ${{ matrix.provider == 'novita' && secrets.NOVITA_API_KEY || '' }}
         run: |

--- a/LEADERBOARD.md
+++ b/LEADERBOARD.md
@@ -28,7 +28,7 @@ _Blaxel leads · ~1.1× Novita on median (higher is better)._
 | 2 | Novita | 18.6 | 18.56 – 18.64 | 2 | n too small |
 | 3 | Daytona (VM) | 18.53 | 18.51 – 18.55 | 2 | n too small |
 | 4 | E2B | 11.81 | 11.77 – 11.85 | 2 | n too small |
-| 5 | Modal | 8.13 | 7.95 – 8.31 | 2 | n too small |
+| 5 | Modal (gVisor) | 8.13 | 7.95 – 8.31 | 2 | n too small |
 
 ## disk
 
@@ -216,17 +216,17 @@ _Blaxel leads · Daytona (VM) is ~1.3× higher (lower is better)._
 | 2 | Daytona (VM) | 5.305 | 4.964 – 5.646 | 2 | n too small |
 | 3 | Novita | 7.848 | 7.513 – 8.184 | 2 | n too small |
 | 4 | E2B | 8.68 | 8.495 – 8.866 | 2 | n too small |
-| 5 | Modal | 40.32 | 38 – 42.63 | 2 | n too small |
+| 5 | Modal (gVisor) | 40.32 | 38 – 42.63 | 2 | n too small |
 
 ### fast.com download
 
 Mbit/s · higher is better
 
-_Modal leads · ~5.6× Novita on median (higher is better)._
+_Modal (gVisor) leads · ~5.6× Novita on median (higher is better)._
 
 | Rank | Provider | fast.com download (Mbit/s) | 95% bootstrap interval | n | Note |
 | ---: | --- | ---: | ---: | ---: | --- |
-| 1 | Modal | 500 | 490 – 510 | 2 | — |
+| 1 | Modal (gVisor) | 500 | 490 – 510 | 2 | — |
 | 2 | Novita | 89 | 28 – 150 | 2 | n too small |
 | 3 | Blaxel | 3.3 | 3.3 – 3.3 | 2 | n too small |
 | 4 | E2B | 0.89 | 0.58 – 1.2 | 2 | n too small |
@@ -242,7 +242,7 @@ _Blaxel leads · E2B is ~3.0× higher (lower is better)._
 | 1 | Blaxel | 2 | 2 – 2 | 2 | — |
 | 2 | E2B | 6 | 6 – 6 | 2 | n too small |
 | 3 | Novita | 10.5 | 10 – 11 | 2 | n too small |
-| 4 | Modal | 79 | 79 – 79 | 2 | n too small |
+| 4 | Modal (gVisor) | 79 | 79 – 79 | 2 | n too small |
 
 ### fast.com loaded latency
 
@@ -255,7 +255,7 @@ _Blaxel leads · E2B is ~1.3× higher (lower is better)._
 | 1 | Blaxel | 7 | 7 – 7 | 2 | — |
 | 2 | E2B | 9 | — | 1 | — |
 | 3 | Novita | 10.5 | 10 – 11 | 2 | — |
-| 4 | Modal | 81.5 | 81 – 82 | 2 | n too small |
+| 4 | Modal (gVisor) | 81.5 | 81 – 82 | 2 | n too small |
 
 ### fast.com upload
 
@@ -268,7 +268,7 @@ _Novita leads · ~1.4× Blaxel on median (higher is better)._
 | 1 | Novita | 2900 | 2800 – 3000 | 2 | — |
 | 2 | Blaxel | 2050 | 1900 – 2200 | 2 | n too small |
 | 3 | E2B | 925 | 850 – 1000 | 2 | n too small |
-| 4 | Modal | 235 | 190 – 280 | 2 | n too small |
+| 4 | Modal (gVisor) | 235 | 190 – 280 | 2 | n too small |
 
 ## system
 
@@ -294,7 +294,7 @@ _Daytona (VM) leads · Blaxel is ~1.2× higher (lower is better)._
 | 2 | Blaxel | 41.77 | 41.63 – 41.91 | 2 | n too small |
 | 3 | Novita | 43.62 | 43.54 – 43.7 | 2 | n too small |
 | 4 | E2B | 73.49 | 72.99 – 73.98 | 2 | n too small |
-| 5 | Modal | 79.43 | 78.16 – 80.69 | 2 | n too small |
+| 5 | Modal (gVisor) | 79.43 | 78.16 – 80.69 | 2 | n too small |
 
 ### SQLite Speedtest
 
@@ -308,7 +308,7 @@ _Daytona (VM) leads · Blaxel is ~1.2× higher (lower is better)._
 | 2 | Blaxel | 36.55 | 36.3 – 36.8 | 2 | n too small |
 | 3 | Novita | 39.71 | 39.17 – 40.24 | 2 | n too small |
 | 4 | E2B | 74.81 | 74.21 – 75.41 | 2 | n too small |
-| 5 | Modal | 466.1 | 445 – 487.2 | 2 | n too small |
+| 5 | Modal (gVisor) | 466.1 | 445 – 487.2 | 2 | n too small |
 
 ## realworld
 
@@ -323,7 +323,7 @@ _Blaxel leads on median (lower is better); see notes for how ranks are decided._
 | 1 | Blaxel | 24.38 | — | 1 |
 | 2 | Daytona (VM) | 24.47 | — | 1 |
 | 3 | Novita | 29.33 | — | 1 |
-| 4 | Modal | 64.55 | — | 1 |
+| 4 | Modal (gVisor) | 64.55 | — | 1 |
 
 ### Better-Auth: build
 
@@ -337,7 +337,7 @@ _Daytona (VM) leads on median (lower is better); see notes for how ranks are dec
 | 2 | Blaxel | 57.91 | — | 1 |
 | 3 | Novita | 65.61 | — | 1 |
 | 4 | E2B | 89.11 | — | 1 |
-| 5 | Modal | 141.6 | — | 1 |
+| 5 | Modal (gVisor) | 141.6 | — | 1 |
 
 ### Better-Auth: cold install
 
@@ -351,7 +351,7 @@ _Daytona (VM) leads on median (lower is better); see notes for how ranks are dec
 | 2 | Blaxel | 10.56 | — | 1 |
 | 3 | Novita | 10.71 | — | 1 |
 | 4 | E2B | 16.01 | — | 1 |
-| 5 | Modal | 29.2 | — | 1 |
+| 5 | Modal (gVisor) | 29.2 | — | 1 |
 
 ### Better-Auth: git clone
 
@@ -365,7 +365,7 @@ _Blaxel leads · Daytona (VM) is ~1.6× higher (lower is better)._
 | 2 | Daytona (VM) | 1.722 | — | 1 |
 | 3 | E2B | 1.877 | — | 1 |
 | 4 | Novita | 2.447 | — | 1 |
-| 5 | Modal | 2.528 | — | 1 |
+| 5 | Modal (gVisor) | 2.528 | — | 1 |
 
 ### Better-Auth: lint (Biome)
 
@@ -379,7 +379,7 @@ _Daytona (VM) leads · Blaxel is ~1.1× higher (lower is better)._
 | 2 | Blaxel | 3.153 | — | 1 |
 | 3 | Novita | 3.508 | — | 1 |
 | 4 | E2B | 5.162 | — | 1 |
-| 5 | Modal | 10.64 | — | 1 |
+| 5 | Modal (gVisor) | 10.64 | — | 1 |
 
 ### Better-Auth: lint deps (Knip)
 
@@ -393,7 +393,7 @@ _Daytona (VM) leads on median (lower is better); see notes for how ranks are dec
 | 2 | Blaxel | 10.11 | — | 1 |
 | 3 | Novita | 11.91 | — | 1 |
 | 4 | E2B | 18.11 | — | 1 |
-| 5 | Modal | 29.67 | — | 1 |
+| 5 | Modal (gVisor) | 29.67 | — | 1 |
 
 ### Better-Auth: lint format
 
@@ -407,7 +407,7 @@ _Daytona (VM) leads · Blaxel is ~1.1× higher (lower is better)._
 | 2 | Blaxel | 2.825 | — | 1 |
 | 3 | Novita | 3.044 | — | 1 |
 | 4 | E2B | 4.782 | — | 1 |
-| 5 | Modal | 6.316 | — | 1 |
+| 5 | Modal (gVisor) | 6.316 | — | 1 |
 
 ### Better-Auth: lint packages
 
@@ -421,7 +421,7 @@ _Blaxel leads on median (lower is better); see notes for how ranks are decided._
 | 2 | Daytona (VM) | 2.44 | — | 1 |
 | 3 | Novita | 2.869 | — | 1 |
 | 4 | E2B | 4.172 | — | 1 |
-| 5 | Modal | 9.239 | — | 1 |
+| 5 | Modal (gVisor) | 9.239 | — | 1 |
 
 ### Better-Auth: lint spell
 
@@ -435,7 +435,7 @@ _Daytona (VM) leads on median (lower is better); see notes for how ranks are dec
 | 2 | Blaxel | 6.67 | — | 1 |
 | 3 | Novita | 7.688 | — | 1 |
 | 4 | E2B | 12.57 | — | 1 |
-| 5 | Modal | 14.47 | — | 1 |
+| 5 | Modal (gVisor) | 14.47 | — | 1 |
 
 ### Better-Auth: lint types
 
@@ -449,7 +449,7 @@ _Blaxel leads on median (lower is better); see notes for how ranks are decided._
 | 2 | Daytona (VM) | 24.98 | — | 1 |
 | 3 | Novita | 35.6 | — | 1 |
 | 4 | E2B | 51.62 | — | 1 |
-| 5 | Modal | 104.4 | — | 1 |
+| 5 | Modal (gVisor) | 104.4 | — | 1 |
 
 ### Better-Auth: typecheck
 
@@ -463,7 +463,7 @@ _Daytona (VM) leads · Blaxel is ~1.1× higher (lower is better)._
 | 2 | Blaxel | 39.09 | — | 1 |
 | 3 | Novita | 44.13 | — | 1 |
 | 4 | E2B | 71.44 | — | 1 |
-| 5 | Modal | 80.7 | — | 1 |
+| 5 | Modal (gVisor) | 80.7 | — | 1 |
 
 ### Mastra: build:core
 
@@ -476,7 +476,7 @@ _Novita leads on median (lower is better); see notes for how ranks are decided._
 | 1 | Novita | 71.32 | — | 1 |
 | 2 | Daytona (VM) | 71.61 | — | 1 |
 | 3 | Blaxel | 71.77 | — | 1 |
-| 4 | Modal | 170.3 | — | 1 |
+| 4 | Modal (gVisor) | 170.3 | — | 1 |
 
 ### Mastra: git clone
 
@@ -489,7 +489,7 @@ _Blaxel leads · Daytona (VM) is ~1.1× higher (lower is better)._
 | 1 | Blaxel | 6.118 | — | 1 |
 | 2 | Daytona (VM) | 6.624 | — | 1 |
 | 3 | Novita | 6.998 | — | 1 |
-| 4 | Modal | 10.39 | — | 1 |
+| 4 | Modal (gVisor) | 10.39 | — | 1 |
 
 ### Mastra: lint:format
 
@@ -502,7 +502,7 @@ _Blaxel leads · Novita is ~1.1× higher (lower is better)._
 | 1 | Blaxel | 86.63 | — | 1 |
 | 2 | Novita | 93.62 | — | 1 |
 | 3 | Daytona (VM) | 95.52 | — | 1 |
-| 4 | Modal | 192.8 | — | 1 |
+| 4 | Modal (gVisor) | 192.8 | — | 1 |
 
 ## economics
 
@@ -517,11 +517,11 @@ _Novita is cheapest · Daytona (VM) is ~1.1× higher (lower is better)._
 | 1 | Novita | 0.2333 | — | 1 |
 | 2 | Daytona (VM) | 0.2502 | — | 1 |
 | 3 | E2B | 0.3312 | — | 1 |
-| 4 | Modal | 0.7612 | — | 1 |
+| 4 | Modal (gVisor) | 0.7612 | — | 1 |
 
 ## Coverage gaps
 
-9 uncovered results across 5 providers (Blaxel 1, Daytona (VM) 2, E2B 2, Modal 3, Novita 1). A gap is a missing result — the provider **failing to cover** that workload — never a tie or a zero.
+9 uncovered results across 5 providers (Blaxel 1, Daytona (VM) 2, E2B 2, Modal (gVisor) 3, Novita 1). A gap is a missing result — the provider **failing to cover** that workload — never a tie or a zero.
 
 <details>
 <summary>Full coverage table</summary>
@@ -532,11 +532,11 @@ _Novita is cheapest · Daytona (VM) is ~1.1× higher (lower is better)._
 | E2B | realworld-openclaw | ❌ **disk** (skipped) | Insufficient disk: 20.0 GiB free, suite needs 25 GiB |
 | Daytona (VM) | network | **failed** | Step "mise run benchmark:network:all" timed out after 2700s |
 | Daytona (VM) | realworld-openclaw | **failed** | Step "mise run benchmark:realworld:pts:openclaw" timed out after 4800s |
-| Modal | realworld-openclaw | **failed** | Step "mise run benchmark:realworld:pts:openclaw" timed out after 4800s |
+| Modal (gVisor) | realworld-openclaw | **failed** | Step "mise run benchmark:realworld:pts:openclaw" timed out after 4800s |
 | Novita | realworld-openclaw | **failed** | Step "mise run benchmark:realworld:pts:openclaw" lost its sandbox: 12 consecutive detached polls failed (last: done-file fs exists) — the sandbox stopped responding, not a quiet long step |
 | Blaxel | realworld-openclaw | **missing** | No result and no marker — the suite never reported for this provider. |
-| Modal | disk | **missing** | No result and no marker — the suite never reported for this provider. |
-| Modal | memory | **missing** | No result and no marker — the suite never reported for this provider. |
+| Modal (gVisor) | disk | **missing** | No result and no marker — the suite never reported for this provider. |
+| Modal (gVisor) | memory | **missing** | No result and no marker — the suite never reported for this provider. |
 
 **skipped** — a precondition said no before the benchmark was attempted. A ❌ **disk** skip is the
 loud one: the provider could not supply the disk the suite needs, so the workload does not run on
@@ -596,7 +596,7 @@ correction is applied across providers or metrics.
 | cpu | Node.js web tooling | Novita | 0.33 (n too small) | 0.097 |
 | cpu | Node.js web tooling | Daytona (VM) | 0.33 (n too small) | 0.097 |
 | cpu | Node.js web tooling | E2B | 0.33 (n too small) | 0.097 |
-| cpu | Node.js web tooling | Modal | 0.33 (n too small) | 0.097 |
+| cpu | Node.js web tooling | Modal (gVisor) | 0.33 (n too small) | 0.097 |
 | disk | fio rand read 4KB, O_DIRECT (IOPS) | Blaxel | — | — |
 | disk | fio rand read 4KB, O_DIRECT (IOPS) | Daytona (VM) | 1.0 (n too small) | 0.84 |
 | disk | fio rand read 4KB, O_DIRECT (IOPS) | Novita | 0.33 (n too small) | 0.097 |
@@ -652,104 +652,104 @@ correction is applied across providers or metrics.
 | network | Loopback TCP (10GB) | Daytona (VM) | 0.33 (n too small) | 0.097 |
 | network | Loopback TCP (10GB) | Novita | 0.33 (n too small) | 0.097 |
 | network | Loopback TCP (10GB) | E2B | 0.33 (n too small) | 0.097 |
-| network | Loopback TCP (10GB) | Modal | 0.33 (n too small) | 0.097 |
-| network | fast.com download | Modal | — | — |
+| network | Loopback TCP (10GB) | Modal (gVisor) | 0.33 (n too small) | 0.097 |
+| network | fast.com download | Modal (gVisor) | — | — |
 | network | fast.com download | Novita | 0.33 (n too small) | 0.097 |
 | network | fast.com download | Blaxel | 0.33 (n too small) | 0.097 |
 | network | fast.com download | E2B | 0.33 (n too small) | 0.097 |
 | network | fast.com latency | Blaxel | — | — |
 | network | fast.com latency | E2B | 0.33 (n too small) | 0.097 |
 | network | fast.com latency | Novita | 0.33 (n too small) | 0.097 |
-| network | fast.com latency | Modal | 0.33 (n too small) | 0.097 |
+| network | fast.com latency | Modal (gVisor) | 0.33 (n too small) | 0.097 |
 | network | fast.com loaded latency | Blaxel | — | — |
 | network | fast.com loaded latency | E2B | — | — |
 | network | fast.com loaded latency | Novita | — | — |
-| network | fast.com loaded latency | Modal | 0.33 (n too small) | 0.097 |
+| network | fast.com loaded latency | Modal (gVisor) | 0.33 (n too small) | 0.097 |
 | network | fast.com upload | Novita | — | — |
 | network | fast.com upload | Blaxel | 0.33 (n too small) | 0.097 |
 | network | fast.com upload | E2B | 0.33 (n too small) | 0.097 |
-| network | fast.com upload | Modal | 0.33 (n too small) | 0.097 |
+| network | fast.com upload | Modal (gVisor) | 0.33 (n too small) | 0.097 |
 | system | PyBench | Blaxel | — | — |
 | system | Git common operations | Daytona (VM) | — | — |
 | system | Git common operations | Blaxel | 0.33 (n too small) | 0.097 |
 | system | Git common operations | Novita | 0.33 (n too small) | 0.097 |
 | system | Git common operations | E2B | 0.33 (n too small) | 0.097 |
-| system | Git common operations | Modal | 0.33 (n too small) | 0.097 |
+| system | Git common operations | Modal (gVisor) | 0.33 (n too small) | 0.097 |
 | system | SQLite Speedtest | Daytona (VM) | — | — |
 | system | SQLite Speedtest | Blaxel | 0.33 (n too small) | 0.097 |
 | system | SQLite Speedtest | Novita | 0.33 (n too small) | 0.097 |
 | system | SQLite Speedtest | E2B | 0.33 (n too small) | 0.097 |
-| system | SQLite Speedtest | Modal | 0.33 (n too small) | 0.097 |
+| system | SQLite Speedtest | Modal (gVisor) | 0.33 (n too small) | 0.097 |
 | realworld | Mastra: cold install | Blaxel | — | — |
 | realworld | Mastra: cold install | Daytona (VM) | — | — |
 | realworld | Mastra: cold install | Novita | — | — |
-| realworld | Mastra: cold install | Modal | — | — |
+| realworld | Mastra: cold install | Modal (gVisor) | — | — |
 | realworld | Better-Auth: build | Daytona (VM) | — | — |
 | realworld | Better-Auth: build | Blaxel | — | — |
 | realworld | Better-Auth: build | Novita | — | — |
 | realworld | Better-Auth: build | E2B | — | — |
-| realworld | Better-Auth: build | Modal | — | — |
+| realworld | Better-Auth: build | Modal (gVisor) | — | — |
 | realworld | Better-Auth: cold install | Daytona (VM) | — | — |
 | realworld | Better-Auth: cold install | Blaxel | — | — |
 | realworld | Better-Auth: cold install | Novita | — | — |
 | realworld | Better-Auth: cold install | E2B | — | — |
-| realworld | Better-Auth: cold install | Modal | — | — |
+| realworld | Better-Auth: cold install | Modal (gVisor) | — | — |
 | realworld | Better-Auth: git clone | Blaxel | — | — |
 | realworld | Better-Auth: git clone | Daytona (VM) | — | — |
 | realworld | Better-Auth: git clone | E2B | — | — |
 | realworld | Better-Auth: git clone | Novita | — | — |
-| realworld | Better-Auth: git clone | Modal | — | — |
+| realworld | Better-Auth: git clone | Modal (gVisor) | — | — |
 | realworld | Better-Auth: lint (Biome) | Daytona (VM) | — | — |
 | realworld | Better-Auth: lint (Biome) | Blaxel | — | — |
 | realworld | Better-Auth: lint (Biome) | Novita | — | — |
 | realworld | Better-Auth: lint (Biome) | E2B | — | — |
-| realworld | Better-Auth: lint (Biome) | Modal | — | — |
+| realworld | Better-Auth: lint (Biome) | Modal (gVisor) | — | — |
 | realworld | Better-Auth: lint deps (Knip) | Daytona (VM) | — | — |
 | realworld | Better-Auth: lint deps (Knip) | Blaxel | — | — |
 | realworld | Better-Auth: lint deps (Knip) | Novita | — | — |
 | realworld | Better-Auth: lint deps (Knip) | E2B | — | — |
-| realworld | Better-Auth: lint deps (Knip) | Modal | — | — |
+| realworld | Better-Auth: lint deps (Knip) | Modal (gVisor) | — | — |
 | realworld | Better-Auth: lint format | Daytona (VM) | — | — |
 | realworld | Better-Auth: lint format | Blaxel | — | — |
 | realworld | Better-Auth: lint format | Novita | — | — |
 | realworld | Better-Auth: lint format | E2B | — | — |
-| realworld | Better-Auth: lint format | Modal | — | — |
+| realworld | Better-Auth: lint format | Modal (gVisor) | — | — |
 | realworld | Better-Auth: lint packages | Blaxel | — | — |
 | realworld | Better-Auth: lint packages | Daytona (VM) | — | — |
 | realworld | Better-Auth: lint packages | Novita | — | — |
 | realworld | Better-Auth: lint packages | E2B | — | — |
-| realworld | Better-Auth: lint packages | Modal | — | — |
+| realworld | Better-Auth: lint packages | Modal (gVisor) | — | — |
 | realworld | Better-Auth: lint spell | Daytona (VM) | — | — |
 | realworld | Better-Auth: lint spell | Blaxel | — | — |
 | realworld | Better-Auth: lint spell | Novita | — | — |
 | realworld | Better-Auth: lint spell | E2B | — | — |
-| realworld | Better-Auth: lint spell | Modal | — | — |
+| realworld | Better-Auth: lint spell | Modal (gVisor) | — | — |
 | realworld | Better-Auth: lint types | Blaxel | — | — |
 | realworld | Better-Auth: lint types | Daytona (VM) | — | — |
 | realworld | Better-Auth: lint types | Novita | — | — |
 | realworld | Better-Auth: lint types | E2B | — | — |
-| realworld | Better-Auth: lint types | Modal | — | — |
+| realworld | Better-Auth: lint types | Modal (gVisor) | — | — |
 | realworld | Better-Auth: typecheck | Daytona (VM) | — | — |
 | realworld | Better-Auth: typecheck | Blaxel | — | — |
 | realworld | Better-Auth: typecheck | Novita | — | — |
 | realworld | Better-Auth: typecheck | E2B | — | — |
-| realworld | Better-Auth: typecheck | Modal | — | — |
+| realworld | Better-Auth: typecheck | Modal (gVisor) | — | — |
 | realworld | Mastra: build:core | Novita | — | — |
 | realworld | Mastra: build:core | Daytona (VM) | — | — |
 | realworld | Mastra: build:core | Blaxel | — | — |
-| realworld | Mastra: build:core | Modal | — | — |
+| realworld | Mastra: build:core | Modal (gVisor) | — | — |
 | realworld | Mastra: git clone | Blaxel | — | — |
 | realworld | Mastra: git clone | Daytona (VM) | — | — |
 | realworld | Mastra: git clone | Novita | — | — |
-| realworld | Mastra: git clone | Modal | — | — |
+| realworld | Mastra: git clone | Modal (gVisor) | — | — |
 | realworld | Mastra: lint:format | Blaxel | — | — |
 | realworld | Mastra: lint:format | Novita | — | — |
 | realworld | Mastra: lint:format | Daytona (VM) | — | — |
-| realworld | Mastra: lint:format | Modal | — | — |
+| realworld | Mastra: lint:format | Modal (gVisor) | — | — |
 | economics | Hourly cost | Novita | — | — |
 | economics | Hourly cost | Daytona (VM) | — | — |
 | economics | Hourly cost | E2B | — | — |
-| economics | Hourly cost | Modal | — | — |
+| economics | Hourly cost | Modal (gVisor) | — | — |
 
 </details>
 

--- a/apps/cli/src/bin/bake.test.ts
+++ b/apps/cli/src/bin/bake.test.ts
@@ -12,7 +12,7 @@ describe("requestedProviders", () => {
 	});
 
 	test("a comma-separated list returns registry order, not request order", () => {
-		expect(requestedProviders(["--provider", "modal,e2b"])).toEqual(["e2b", "modal"]);
+		expect(requestedProviders(["--provider", "modal-gvisor,e2b"])).toEqual(["e2b", "modal-gvisor"]);
 	});
 
 	test("an unknown id throws, naming the registered providers", () => {

--- a/apps/cli/src/bin/bake.ts
+++ b/apps/cli/src/bin/bake.ts
@@ -32,7 +32,9 @@ const bakers: Record<ProviderId, (image: string, log: Log) => Promise<void>> = {
 	"daytona-vm": (image, log) => bakeDaytonaVmSnapshot(config.daytonaSnapshotCandidate, image, log),
 	"daytona-container": (image, log) =>
 		bakeDaytonaContainerSnapshot(config.daytonaContainerSnapshotCandidate, image, log),
-	modal: bakeModalImage,
+	// Both Modal variants boot the same pushed image via Image.fromRegistry — no per-variant artifact.
+	"modal-gvisor": bakeModalImage,
+	"modal-vm": bakeModalImage,
 	blaxel: async (_image, log) => {
 		log("blaxel boots the stock base image — no candidate artifact to bake");
 	},
@@ -107,7 +109,7 @@ if (import.meta.main) {
 			},
 			reports: promoted,
 		});
-		// promoteAll is self-gating: the D1 required-providers gate (CI passes `--require e2b,daytona-vm,modal`)
+		// promoteAll is self-gating: the D1 required-providers gate (CI passes `--require e2b,daytona-vm,modal-gvisor`)
 		// runs INSIDE promoteAll before the immutable base is written, and every abort path (version already
 		// published, candidate re-validation failed, artifact failed, unmet requirements) pushes a structured
 		// `{ status: "failed" }` report. So a single `some(failed)` is the whole exit contract — re-deriving
@@ -216,7 +218,7 @@ if (import.meta.main) {
 
 	if (anyFailed(runs)) process.exit(1);
 
-	// D1: at the publish boundary (CI passes `--require e2b,daytona-vm,modal`) a required provider that was
+	// D1: at the publish boundary (CI passes `--require e2b,daytona-vm,modal-gvisor`) a required provider that was
 	// skipped for a missing/misnamed secret — or failed to validate — must fail the bake loudly, so a
 	// candidate is never blessed while a provider was silently never built. Lenient locally (none required).
 	const required = requiredProviders();

--- a/apps/cli/src/bin/plan-matrix.ts
+++ b/apps/cli/src/bin/plan-matrix.ts
@@ -25,7 +25,7 @@ usage: plan-matrix [--help] [--list-providers] [--list-suites] [--json]
   --help, -h         Show this help.
 
 environment:
-  BENCH_PROVIDERS    Comma-separated providers to include (e.g. "e2b,daytona-vm,modal"). Unset or
+  BENCH_PROVIDERS    Comma-separated providers to include (e.g. "e2b,daytona-vm,modal-gvisor"). Unset or
                      blank includes every registered provider. An unregistered name is an error,
                      never a silently smaller matrix.
 

--- a/apps/cli/src/bin/plan-providers.ts
+++ b/apps/cli/src/bin/plan-providers.ts
@@ -32,7 +32,7 @@ usage: plan-providers [--help] [--list-providers] [--list-suites] [--json]
   --help, -h         Show this help.
 
 environment:
-  BENCH_PROVIDERS    Comma-separated providers to fan out over (e.g. "e2b,daytona-vm,modal"). Unset or
+  BENCH_PROVIDERS    Comma-separated providers to fan out over (e.g. "e2b,daytona-vm,modal-gvisor"). Unset or
                      blank selects every registered provider. An unregistered name is an error,
                      never a silently smaller matrix.
   GITHUB_OUTPUT      When set (Actions), write providers= step output instead of printing on stdout.

--- a/apps/cli/src/bin/release-plan.test.ts
+++ b/apps/cli/src/bin/release-plan.test.ts
@@ -32,7 +32,8 @@ describe("buildReleasePlan matrix", () => {
 			"daytona-vm",
 			"daytona-container",
 			"blaxel",
-			"modal",
+			"modal-gvisor",
+			"modal-vm",
 			"novita",
 		]);
 	});
@@ -55,7 +56,7 @@ describe("planOutputs", () => {
 		expect(matrixLine).toBeDefined();
 		// The matrix value must be valid, single-line JSON (the fromJSON contract).
 		const parsed = JSON.parse((matrixLine as string).slice("matrix=".length));
-		expect(parsed.include).toHaveLength(6);
+		expect(parsed.include).toHaveLength(7);
 		expect((matrixLine as string).includes("\n")).toBe(false);
 	});
 });

--- a/apps/cli/src/bin/release-plan.ts
+++ b/apps/cli/src/bin/release-plan.ts
@@ -25,13 +25,17 @@ import { emitStepOutputs } from "../lib/gha-output.ts";
 /**
  * Providers the release is REQUIRED to bake + validate before the public version is published — the
  * same set CI passes to `bake --promote --require …`, single-sourced here so the matrix's per-cell
- * `required` flags and promote's gate can't drift. e2b/daytona-vm bake a real artifact; modal is
+ * `required` flags and promote's gate can't drift. e2b/daytona-vm bake a real artifact; modal-gvisor is
  * required because its `Image.fromRegistry` boot validates the published image the same way. The new
- * isolation variant (daytona-container) is best-effort until a committed run validates it — like
- * blaxel (a no-op bake booting the stock base) and novita (optional control plane), a missing secret
- * or an unproven variant skips without failing the release.
+ * isolation variants (daytona-container, modal-vm) are best-effort until a committed run validates
+ * them — like blaxel (a no-op bake booting the stock base) and novita (optional control plane), a
+ * missing secret or an unproven variant skips without failing the release.
  */
-export const RELEASE_REQUIRED_PROVIDERS: readonly ProviderId[] = ["e2b", "daytona-vm", "modal"];
+export const RELEASE_REQUIRED_PROVIDERS: readonly ProviderId[] = [
+	"e2b",
+	"daytona-vm",
+	"modal-gvisor",
+];
 
 /** Every provider the release fans out over, derived from the registry (never a hand-maintained
  *  literal) so adding a provider grows the matrix automatically — in registry order, matching the
@@ -50,7 +54,8 @@ function providerArtifact(id: ProviderId): string {
 			return config.daytonaContainerSnapshotCandidate;
 		case "novita":
 			return config.novitaTemplateCandidate;
-		case "modal":
+		case "modal-gvisor":
+		case "modal-vm":
 			return "boots the candidate image directly (no baked artifact)";
 		case "blaxel":
 			return "boots the stock base image (no baked artifact)";

--- a/apps/cli/src/lib/bake/promote.ts
+++ b/apps/cli/src/lib/bake/promote.ts
@@ -141,8 +141,9 @@ export async function promoteAll(log: Log, force = false): Promise<BakeReport[]>
 						(m) => log(`    ${m}`),
 					);
 					break;
-				case "modal":
-					log("    modal boots the published version image — nothing to build");
+				case "modal-gvisor":
+				case "modal-vm":
+					log(`    ${provider.name} boots the published version image — nothing to build`);
 					break;
 				case "blaxel":
 					log("    blaxel boots the stock base image — nothing to promote");
@@ -201,7 +202,7 @@ export async function promoteAll(log: Log, force = false): Promise<BakeReport[]>
 	}
 
 	// Required-providers gate (D1), enforced HERE — before step 4 writes the immutable base — not
-	// post-hoc in bake.ts. At the publish boundary CI passes `--require e2b,daytona-vm,modal`; a required
+	// post-hoc in bake.ts. At the publish boundary CI passes `--require e2b,daytona-vm,modal-gvisor`; a required
 	// provider whose version artifact was skipped (missing/misnamed secret) or failed is `skipped`/
 	// `failed`, so the artifact-failed check above does NOT catch a pure skip. Were the base published
 	// first and the gap detected only in bake.ts, the immutable `:v1` would already be tagged and a

--- a/apps/cli/src/lib/bake/validate.test.ts
+++ b/apps/cli/src/lib/bake/validate.test.ts
@@ -44,8 +44,17 @@ describe("candidateCreateOptions", () => {
 		});
 	});
 
-	it("points modal at the candidate image via templateId", () => {
-		expect(candidateCreateOptions("modal", refs)).toEqual({
+	it("points modal-gvisor at the candidate image via templateId", () => {
+		expect(candidateCreateOptions("modal-gvisor", refs)).toEqual({
+			templateId: "ghcr.io/o/tc:v1-candidate",
+		});
+	});
+
+	it("points modal-vm at the same candidate image (VM runtime stays on the adapter base)", () => {
+		// candidateCreateOptions returns only the candidate override; the vm_runtime flag lives in the
+		// adapter's base createOptions and is preserved by validate-run.ts's spread, so it isn't repeated
+		// here (matching modal-gvisor).
+		expect(candidateCreateOptions("modal-vm", refs)).toEqual({
 			templateId: "ghcr.io/o/tc:v1-candidate",
 		});
 	});

--- a/apps/cli/src/lib/bake/validate.ts
+++ b/apps/cli/src/lib/bake/validate.ts
@@ -37,7 +37,12 @@ export function candidateCreateOptions(
 				snapshotId: refs.daytonaContainerSnapshotCandidate,
 				...(refs.daytonaContainerTarget ? { target: refs.daytonaContainerTarget } : {}),
 			};
-		case "modal":
+		case "modal-gvisor":
+			return { templateId: refs.toolchainImageCandidate };
+		case "modal-vm":
+			// Same candidate image as modal-gvisor; the VM runtime is selected by the adapter's base
+			// createOptions (experimentalOptions:{vm_runtime:true}), which validate-run.ts preserves
+			// through the spread — so this candidate override, like modal-gvisor's, is only the templateId.
 			return { templateId: refs.toolchainImageCandidate };
 		case "blaxel":
 			// Stock base image — no candidate artifact to point at.

--- a/apps/cli/src/lib/providers-run.test.ts
+++ b/apps/cli/src/lib/providers-run.test.ts
@@ -36,7 +36,8 @@ describe("forEachProviderWithCreds `only`", () => {
 			"daytona-vm",
 			"daytona-container",
 			"blaxel",
-			"modal",
+			"modal-gvisor",
+			"modal-vm",
 			"novita",
 		]);
 	});

--- a/apps/cli/src/plan-matrix.test.ts
+++ b/apps/cli/src/plan-matrix.test.ts
@@ -75,10 +75,10 @@ describe("selectProviders", () => {
 
 	it("collapses duplicates and orders by the registry, not by the request", () => {
 		// Cells are a set: a dispatch can neither double-run one nor reorder the CI job list.
-		expect(selectProviders("modal,e2b,modal")).toEqual(["e2b", "modal"]);
+		expect(selectProviders("modal-gvisor,e2b,modal-gvisor")).toEqual(["e2b", "modal-gvisor"]);
 	});
 
 	it("tolerates whitespace and mixed casing around names, as a hand-typed dispatch input has", () => {
-		expect(selectProviders(" E2b , MODAL ")).toEqual(["e2b", "modal"]);
+		expect(selectProviders(" E2b , MODAL-GVISOR ")).toEqual(["e2b", "modal-gvisor"]);
 	});
 });

--- a/packages/harness/src/index.test.ts
+++ b/packages/harness/src/index.test.ts
@@ -115,12 +115,12 @@ describe("@sandbox-benchmarks/harness", () => {
 		expect(calls).toEqual(["create", "destroy"]);
 	});
 
-	// Named "modal", so it carries modal's real (uncapped) transport rather than the capped
+	// Named "modal-gvisor", so it carries modal's real (uncapped) transport rather than the capped
 	// fixtureTransport — these creds tests never read transport, but keeping the fixture faithful to
 	// the name stops a future transport-aware test from exercising E2B/Daytona semantics under a
 	// modal-named config.
 	const credsCfg: ProviderConfig = {
-		name: "modal",
+		name: "modal-gvisor",
 		requiredEnvVars: ["A", "B"],
 		transport: { streaming: false, syncCapMs: null, detachedPoll: true },
 		createCompute: () => {

--- a/packages/harness/src/index.ts
+++ b/packages/harness/src/index.ts
@@ -427,7 +427,7 @@ export function hasRequiredCreds(
  * The providers a run is *required* to exercise — parsed from `--require <ids>` (or `--require=<ids>`)
  * in `argv`, falling back to the `REQUIRE_PROVIDERS` env var; both a comma-separated id list. Empty
  * when neither is set, which is the lenient local-dev default (missing creds simply skip). CI passes
- * `--require e2b,daytona-vm,modal` at the publish boundary so a missing/misnamed secret fails loudly
+ * `--require e2b,daytona-vm,modal-gvisor` at the publish boundary so a missing/misnamed secret fails loudly
  * instead of silently shipping a version whose provider artifacts were never built/validated. Tokens
  * are returned verbatim (not filtered to known ids) so a typo'd id surfaces as unmet rather than being
  * dropped. `argv`/`env` are injectable to keep this unit-testable.

--- a/packages/providers/src/index.test.ts
+++ b/packages/providers/src/index.test.ts
@@ -29,21 +29,28 @@ describe("@sandbox-benchmarks/providers", () => {
 		}
 	});
 
-	it("pins modal's create-time spec from the shared TARGET_SPEC", () => {
-		const modal = providers.find((p) => p.name === "modal");
-		expect(modal).toBeDefined();
+	it("pins both Modal variants' create-time spec from the shared TARGET_SPEC", () => {
+		const gvisor = providers.find((p) => p.name === "modal-gvisor");
+		const vm = providers.find((p) => p.name === "modal-vm");
+		expect(gvisor).toBeDefined();
+		expect(vm).toBeDefined();
 		// Modal's `cpu` unit delivers one schedulable vCPU (nproc tracks it 1:1 and throughput scales
 		// with it — measured 2026-07-10), so the pinned vCPU count passes through unhalved; halving it
 		// benchmarked Modal on half the CPU of every other provider.
 		// `memoryLimitMiB` is the hard cap (memoryMiB alone is only a reservation, and the guest then
 		// still sees the host's RAM) — assert it, or the memory fix has no regression guard at all.
-		expect(modal?.createOptions).toMatchObject({
+		const spec = {
 			cpu: TARGET_SPEC.vcpus,
 			cpuLimit: TARGET_SPEC.vcpus,
 			memoryMiB: TARGET_SPEC.memoryGb * 1024,
 			memoryLimitMiB: TARGET_SPEC.memoryGb * 1024,
-			experimentalOptions: { vm_runtime: true },
-		});
+		};
+		expect(gvisor?.createOptions).toMatchObject(spec);
+		expect(vm?.createOptions).toMatchObject(spec);
+		// The variants differ only in isolation: modal-vm selects the VM runtime via experimentalOptions,
+		// modal-gvisor (the default) carries none.
+		expect(vm?.createOptions?.experimentalOptions).toEqual({ vm_runtime: true });
+		expect(gvisor?.createOptions?.experimentalOptions).toBeUndefined();
 	});
 
 	it("re-points the e2b wrapper at Novita without the e2b_ key-format guard", () => {

--- a/packages/providers/src/lib/adapters.ts
+++ b/packages/providers/src/lib/adapters.ts
@@ -9,6 +9,7 @@ import { e2b } from "@computesdk/e2b";
 import { modal } from "@computesdk/modal";
 import type { ProviderId } from "@sandbox-benchmarks/schema";
 import { TARGET_SPEC } from "@sandbox-benchmarks/schema";
+import type { CreateSandboxOptions } from "computesdk";
 import { blaxelWithVolumeAndKeepAlive } from "./blaxel-volume.ts";
 import type { DaytonaConfig } from "./config.ts";
 import { config } from "./config.ts";
@@ -38,6 +39,41 @@ function daytonaAdapter(cfg: DaytonaConfig): ProviderAdapter {
 		},
 	};
 }
+
+/**
+ * Shared Modal create-time options. Both Modal variants boot the SAME pushed toolchain image at the
+ * target spec via `Image.fromRegistry`; the only difference is that `modal-vm` adds
+ * `experimentalOptions {vm_runtime:true}` to select Modal's VM runtime (a gVisor-free microVM). The
+ * `@computesdk/modal` wrapper spreads any option key it doesn't recognise straight through to
+ * `experimentalCreate`, so `experimentalOptions` reaches the native Modal SDK unchanged.
+ */
+function modalCreateOptions(experimentalOptions?: Record<string, unknown>): CreateSandboxOptions {
+	return {
+		templateId: config.toolchainImage,
+		// Modal's docs call `cpu` physical cores ("this value corresponds to physical cores, not
+		// vCPUs" — modal.com/docs/guide/resources), but measured behavior contradicts that reading:
+		// cpu=1/cpuLimit=1 exposes nproc=1 and delivers exactly half the dual-worker throughput of
+		// cpu=2/cpuLimit=2 (probed 2026-07-10: 264 vs 512 MB hashed/worker/8s). In practice `cpu` is
+		// the schedulable-CPU count the guest sees, so halving TARGET_SPEC.vcpus benchmarked Modal on
+		// half the CPU of every other provider (which all expose nproc=2). Pass the vCPU spec through.
+		cpu: TARGET_SPEC.vcpus,
+		cpuLimit: TARGET_SPEC.vcpus,
+		// `memoryMiB` is only a RESERVATION — on its own the guest still sees the host's RAM (a live
+		// sandbox reported 464 GB), and PTS sizes STREAM's arrays from that, so the memory suite never
+		// converged. `memoryLimitMiB` is the hard cap that makes /proc/meminfo report the target spec.
+		memoryMiB: TARGET_SPEC.memoryGb * 1024,
+		memoryLimitMiB: TARGET_SPEC.memoryGb * 1024,
+		...(experimentalOptions ? { experimentalOptions } : {}),
+	};
+}
+
+/** Boot sandboxes under this project's own Modal app (auto-created via apps.fromName on first
+ *  create), not the wrapper's generic `computesdk-modal` default — so this project's sandboxes are
+ *  namespaced/attributable in the Modal dashboard, separate from any other computesdk usage. The two
+ *  variants differ in one client flag: modal-gvisor enables scalableSandboxes (the gVisor path);
+ *  modal-vm omits it to match the VM-runtime config validated in #221 (VM sandboxes drop it). */
+const modalGvisorCompute = () => modal({ scalableSandboxes: true, appName: MODAL_APP_NAME });
+const modalVmCompute = () => modal({ appName: MODAL_APP_NAME });
 
 /**
  * Harness adapters, keyed by the schema {@link ProviderId}. The `Record<ProviderId, …>` type is what
@@ -75,28 +111,16 @@ export const adapters: Record<ProviderId, ProviderAdapter> = {
 			),
 		createOptions: {},
 	},
-	modal: {
-		// Boot sandboxes under this project's own Modal app (auto-created via apps.fromName on first
-		// create), not the wrapper's generic `computesdk-modal` default — so this project's sandboxes
-		// are namespaced/attributable in the Modal dashboard, separate from any other computesdk usage.
-		createCompute: () => modal({ appName: MODAL_APP_NAME }),
-		createOptions: {
-			templateId: config.toolchainImage,
-			// Modal's docs call `cpu` physical cores ("this value corresponds to physical cores, not
-			// vCPUs" — modal.com/docs/guide/resources), but measured behavior contradicts that reading:
-			// cpu=1/cpuLimit=1 exposes nproc=1 and delivers exactly half the dual-worker throughput of
-			// cpu=2/cpuLimit=2 (probed 2026-07-10: 264 vs 512 MB hashed/worker/8s). In practice `cpu` is
-			// the schedulable-CPU count the guest sees, so halving TARGET_SPEC.vcpus benchmarked Modal on
-			// half the CPU of every other provider (which all expose nproc=2). Pass the vCPU spec through.
-			cpu: TARGET_SPEC.vcpus,
-			cpuLimit: TARGET_SPEC.vcpus,
-			// `memoryMiB` is only a RESERVATION — on its own the guest still sees the host's RAM (a live
-			// sandbox reported 464 GB), and PTS sizes STREAM's arrays from that, so the memory suite never
-			// converged. `memoryLimitMiB` is the hard cap that makes /proc/meminfo report the target spec.
-			memoryMiB: TARGET_SPEC.memoryGb * 1024,
-			memoryLimitMiB: TARGET_SPEC.memoryGb * 1024,
-			experimentalOptions: { vm_runtime: true },
-		},
+	// Modal's default runtime = gVisor. Both variants boot the same pushed image; modal-vm adds the
+	// vm_runtime experimental flag to select Modal's gVisor-free VM runtime and drops scalableSandboxes
+	// to match the VM config validated in #221 (see modalGvisorCompute/modalVmCompute above).
+	"modal-gvisor": {
+		createCompute: modalGvisorCompute,
+		createOptions: modalCreateOptions(),
+	},
+	"modal-vm": {
+		createCompute: modalVmCompute,
+		createOptions: modalCreateOptions({ vm_runtime: true }),
 	},
 	novita: {
 		// The e2b wrapper re-pointed at Novita's E2B-compatible control plane (sandbox.novita.ai) —

--- a/packages/results/src/lib/leaderboard.test.ts
+++ b/packages/results/src/lib/leaderboard.test.ts
@@ -53,7 +53,7 @@ describe("buildLeaderboard", () => {
 			run([
 				provider("daytona-vm", [metric("node_web_tooling_runs_per_s", [10])]),
 				provider("e2b", [metric("node_web_tooling_runs_per_s", [12])]),
-				provider("modal", []), // no metric → excluded from the row set
+				provider("modal-gvisor", []), // no metric → excluded from the row set
 			]),
 		);
 		const cpu = board.dimensions.find((d) => d.dimension === "cpu");
@@ -68,13 +68,13 @@ describe("buildLeaderboard", () => {
 	it("ranks an economics (LIB) dimension cheapest-first and uses display names", () => {
 		const board = buildLeaderboard(
 			run([
-				provider("modal", [metric(ECONOMICS_METRIC_IDS.usdPerHour, [0.37])]),
+				provider("modal-gvisor", [metric(ECONOMICS_METRIC_IDS.usdPerHour, [0.37])]),
 				provider("e2b", [metric(ECONOMICS_METRIC_IDS.usdPerHour, [0.23])]),
 			]),
 		);
 		const econ = board.dimensions.find((d) => d.dimension === "economics");
 		// LIB: cheapest first.
-		expect(econ?.rows.map((r) => r.providerId)).toEqual(["e2b", "modal"]);
+		expect(econ?.rows.map((r) => r.providerId)).toEqual(["e2b", "modal-gvisor"]);
 		expect(econ?.rows[0]?.displayName).toBe("E2B"); // resolved from the provider registry
 	});
 
@@ -96,12 +96,12 @@ describe("buildLeaderboard", () => {
 		// share a rank — an exact tie is not a ranking win for whoever sorts first.
 		const board = buildLeaderboard(
 			run([
-				provider("modal", [metric("node_web_tooling_runs_per_s", [10])]),
+				provider("modal-gvisor", [metric("node_web_tooling_runs_per_s", [10])]),
 				provider("daytona-vm", [metric("node_web_tooling_runs_per_s", [10])]),
 			]),
 		);
 		const cpu = board.dimensions.find((d) => d.dimension === "cpu");
-		expect(cpu?.rows.map((r) => r.providerId)).toEqual(["daytona-vm", "modal"]);
+		expect(cpu?.rows.map((r) => r.providerId)).toEqual(["daytona-vm", "modal-gvisor"]);
 		expect(cpu?.rows.map((r) => r.rank)).toEqual([1, 1]);
 	});
 
@@ -117,7 +117,7 @@ describe("buildLeaderboard", () => {
 					metric("node_web_tooling_runs_per_s", [10]),
 					metric("sqlite_speedtest_seconds", [20]),
 				]),
-				provider("modal", [metric("sqlite_speedtest_seconds", [15])]),
+				provider("modal-gvisor", [metric("sqlite_speedtest_seconds", [15])]),
 			]),
 		);
 		expect(board.dimensions.map(({ dimension }) => dimension)).toEqual(["cpu", "system"]);
@@ -171,12 +171,12 @@ describe("buildLeaderboard statistical ranking", () => {
 		const board = buildLeaderboard(
 			run([
 				provider("daytona-vm", [metric(HEADLINE, DAYTONA_COPY)]),
-				provider("modal", [metric(HEADLINE, MODAL_COPY)]),
+				provider("modal-gvisor", [metric(HEADLINE, MODAL_COPY)]),
 			]),
 		);
 		const rows = board.dimensions.find((d) => d.dimension === "cpu")?.rows ?? [];
 		const daytona = rows.find((r) => r.providerId === "daytona-vm");
-		const modal = rows.find((r) => r.providerId === "modal");
+		const modal = rows.find((r) => r.providerId === "modal-gvisor");
 
 		expect(daytona?.interval.level).toBe(0.95);
 		expect(daytona?.interval.resamples).toBeGreaterThan(0);
@@ -192,7 +192,7 @@ describe("buildLeaderboard statistical ranking", () => {
 				buildLeaderboard(
 					run([
 						provider("daytona-vm", [metric(HEADLINE, DAYTONA_COPY)]),
-						provider("modal", [metric(HEADLINE, MODAL_COPY)]),
+						provider("modal-gvisor", [metric(HEADLINE, MODAL_COPY)]),
 					]),
 				),
 			);
@@ -203,13 +203,13 @@ describe("buildLeaderboard statistical ranking", () => {
 		const board = buildLeaderboard(
 			run([
 				provider("daytona-vm", [metric(HEADLINE, DAYTONA_COPY)]),
-				provider("modal", [metric(HEADLINE, MODAL_COPY)]),
+				provider("modal-gvisor", [metric(HEADLINE, MODAL_COPY)]),
 			]),
 		);
 		const rows = board.dimensions.find((d) => d.dimension === "cpu")?.rows ?? [];
 		expect(rows.map((r) => [r.rank, r.providerId])).toEqual([
 			[1, "daytona-vm"],
-			[2, "modal"],
+			[2, "modal-gvisor"],
 		]);
 		const modal = rows[1];
 		expect(modal?.verdict).toBe("separated");
@@ -244,12 +244,12 @@ describe("buildLeaderboard statistical ranking", () => {
 		const board = buildLeaderboard(
 			run([
 				provider("daytona-vm", [metric(ECONOMICS_METRIC_IDS.usdPerHour, [0.2])]),
-				provider("modal", [metric(ECONOMICS_METRIC_IDS.usdPerHour, [0.1])]),
+				provider("modal-gvisor", [metric(ECONOMICS_METRIC_IDS.usdPerHour, [0.1])]),
 			]),
 		);
 		const rows = board.dimensions.find((d) => d.dimension === "economics")?.rows ?? [];
 		expect(rows.map((r) => [r.rank, r.providerId])).toEqual([
-			[1, "modal"],
+			[1, "modal-gvisor"],
 			[2, "daytona-vm"],
 		]);
 		expect(rows[1]?.verdict).toBe("untested");
@@ -263,7 +263,7 @@ describe("buildLeaderboard statistical ranking", () => {
 		const board = buildLeaderboard(
 			run([
 				provider("daytona-vm", [metric(ECONOMICS_METRIC_IDS.usdPerHour, [0.1])]),
-				provider("modal", [metric(ECONOMICS_METRIC_IDS.usdPerHour, [0.1])]),
+				provider("modal-gvisor", [metric(ECONOMICS_METRIC_IDS.usdPerHour, [0.1])]),
 			]),
 		);
 		const rows = board.dimensions.find((d) => d.dimension === "economics")?.rows ?? [];
@@ -276,7 +276,7 @@ describe("buildLeaderboard statistical ranking", () => {
 			run([
 				provider("daytona-vm", [metric(ECONOMICS_METRIC_IDS.usdPerHour, [0.1])]),
 				provider("e2b", [metric(ECONOMICS_METRIC_IDS.usdPerHour, [0.1])]),
-				provider("modal", [metric(ECONOMICS_METRIC_IDS.usdPerHour, [0.1])]),
+				provider("modal-gvisor", [metric(ECONOMICS_METRIC_IDS.usdPerHour, [0.1])]),
 			]),
 		);
 		const rows = board.dimensions.find((d) => d.dimension === "economics")?.rows ?? [];
@@ -284,7 +284,7 @@ describe("buildLeaderboard statistical ranking", () => {
 		const md = renderLeaderboardMarkdown(board);
 		// All three display names appear in the "share the top" takeaway, joined as a list.
 		expect(md).toMatch(/[^,|]+, [^,|]+ and [^,|]+ share the top on this metric/);
-		for (const name of ["Daytona (VM)", "E2B", "Modal"]) expect(md).toContain(name);
+		for (const name of ["Daytona (VM)", "E2B", "Modal (gVisor)"]) expect(md).toContain(name);
 	});
 });
 
@@ -319,7 +319,7 @@ describe("buildLeaderboard with replicate sandboxes (R>1)", () => {
 		const board = buildLeaderboard(
 			run([
 				provider("daytona-vm", [replicatedMetric(HEADLINE, [[100], [101], [102]])]),
-				provider("modal", [replicatedMetric(HEADLINE, [[1], [2], [3]])]),
+				provider("modal-gvisor", [replicatedMetric(HEADLINE, [[1], [2], [3]])]),
 			]),
 		);
 		const rows = board.dimensions[0]?.metrics[0]?.rows ?? [];
@@ -334,7 +334,7 @@ describe("buildLeaderboard with replicate sandboxes (R>1)", () => {
 		const board = buildLeaderboard(
 			run([
 				provider("daytona-vm", [replicatedMetric(HEADLINE, [[100], [101], [102], [103], [104]])]),
-				provider("modal", [replicatedMetric(HEADLINE, [[1], [2], [3], [4], [5]])]),
+				provider("modal-gvisor", [replicatedMetric(HEADLINE, [[1], [2], [3], [4], [5]])]),
 			]),
 		);
 		const rows = board.dimensions[0]?.metrics[0]?.rows ?? [];
@@ -351,7 +351,7 @@ describe("buildLeaderboard with replicate sandboxes (R>1)", () => {
 		const board = buildLeaderboard(
 			run([
 				provider("daytona-vm", [replicatedMetric(HEADLINE, [[100], [101], [102]])]),
-				provider("modal", [metric(HEADLINE, [1, 2, 3])]),
+				provider("modal-gvisor", [metric(HEADLINE, [1, 2, 3])]),
 			]),
 		);
 		const rows = board.dimensions[0]?.metrics[0]?.rows ?? [];
@@ -365,7 +365,7 @@ describe("buildLeaderboard with replicate sandboxes (R>1)", () => {
 		const board = buildLeaderboard(
 			run([
 				provider("daytona-vm", [replicatedMetric(HEADLINE, [[10], [30], [50], [70], [90]])]),
-				provider("modal", [replicatedMetric(HEADLINE, [[20], [40], [60], [80], [100]])]),
+				provider("modal-gvisor", [replicatedMetric(HEADLINE, [[20], [40], [60], [80], [100]])]),
 			]),
 		);
 		const rows = board.dimensions[0]?.metrics[0]?.rows ?? [];
@@ -443,7 +443,7 @@ describe("renderLeaderboardMarkdown statistics", () => {
 			buildLeaderboard(
 				run([
 					provider("daytona-vm", [metric(HEADLINE, [1, 2, 3, 4, 5, 6, 7, 8])]),
-					provider("modal", [metric(HEADLINE, [90, 91, 92, 93, 94, 95, 96, 97])]),
+					provider("modal-gvisor", [metric(HEADLINE, [90, 91, 92, 93, 94, 95, 96, 97])]),
 				]),
 			),
 		);
@@ -461,13 +461,13 @@ describe("underpowered comparisons", () => {
 		const board = buildLeaderboard(
 			run([
 				provider("daytona-vm", [metric(HEADLINE, [19.63, 19.72, 19.96])]),
-				provider("modal", [metric(HEADLINE, [9.79, 9.52, 9.59])]),
+				provider("modal-gvisor", [metric(HEADLINE, [9.79, 9.52, 9.59])]),
 			]),
 		);
 		const rows = board.dimensions.find((d) => d.dimension === "cpu")?.rows ?? [];
 		expect(rows.map((r) => [r.displayName, r.rank, r.verdict, r.tiedWithAbove])).toEqual([
 			["Daytona (VM)", 1, null, null],
-			["Modal", 2, "underpowered", null],
+			["Modal (gVisor)", 2, "underpowered", null],
 		]);
 		const md = renderLeaderboardMarkdown(board);
 		expect(md).toContain("n too small");
@@ -482,7 +482,7 @@ describe("underpowered comparisons", () => {
 			buildLeaderboard(
 				run([
 					provider("daytona-vm", [metric(HEADLINE, [19.6, 19.7, 19.9, 20.1])]),
-					provider("modal", [metric(HEADLINE, [9.5, 9.6, 9.8])]),
+					provider("modal-gvisor", [metric(HEADLINE, [9.5, 9.6, 9.8])]),
 				]),
 			),
 		);
@@ -495,7 +495,7 @@ describe("underpowered comparisons", () => {
 			buildLeaderboard(
 				run([
 					provider("daytona-vm", [metric(HEADLINE, [10, 11, 12, 13, 14])]),
-					provider("modal", [metric(HEADLINE, [1, 2, 3, 4, 5])]),
+					provider("modal-gvisor", [metric(HEADLINE, [1, 2, 3, 4, 5])]),
 				]),
 			),
 		);
@@ -511,14 +511,14 @@ describe("underpowered comparisons", () => {
 		// gave them the same rank; now the two agree because the basis is a field, not a footnote.
 		const board = buildLeaderboard(
 			run([
-				provider("modal", [metric(HEADLINE, [9, 10, 11])]),
+				provider("modal-gvisor", [metric(HEADLINE, [9, 10, 11])]),
 				provider("daytona-vm", [metric(HEADLINE, [8, 10, 12])]),
 			]),
 		);
 		const rows = board.dimensions.find((d) => d.dimension === "cpu")?.rows ?? [];
 		expect(rows.map((r) => [r.providerId, r.value, r.rank])).toEqual([
 			["daytona-vm", 10, 1],
-			["modal", 10, 1],
+			["modal-gvisor", 10, 1],
 		]);
 		expect(rows[1]?.verdict).toBe("underpowered");
 		expect(rows[1]?.tiedWithAbove).toBe("identical-value");
@@ -533,7 +533,7 @@ describe("underpowered comparisons", () => {
 		const board = buildLeaderboard(
 			run([
 				provider("daytona-vm", [metric(ECONOMICS_METRIC_IDS.usdPerHour, [0.2])]),
-				provider("modal", [metric(ECONOMICS_METRIC_IDS.usdPerHour, [0.2])]),
+				provider("modal-gvisor", [metric(ECONOMICS_METRIC_IDS.usdPerHour, [0.2])]),
 			]),
 		);
 		const rows = board.dimensions.find((d) => d.dimension === "economics")?.rows ?? [];
@@ -550,7 +550,7 @@ describe("underpowered comparisons", () => {
 			run([
 				provider("daytona-vm", [metric(ECONOMICS_METRIC_IDS.usdPerHour, [0.1])]),
 				provider("e2b", [metric(ECONOMICS_METRIC_IDS.usdPerHour, [0.1])]),
-				provider("modal", [metric(ECONOMICS_METRIC_IDS.usdPerHour, [0.1])]),
+				provider("modal-gvisor", [metric(ECONOMICS_METRIC_IDS.usdPerHour, [0.1])]),
 			]),
 		);
 		const rows = board.dimensions.find((d) => d.dimension === "economics")?.rows ?? [];
@@ -559,7 +559,7 @@ describe("underpowered comparisons", () => {
 		// Match the common phrasing across branches (the takeaway says "…this headline" here and
 		// "…this metric" once the per-metric renderer lands) so this test survives the flow up-stack.
 		expect(md).toMatch(/[^,|]+, [^,|]+ and [^,|]+ share the top on this/);
-		for (const name of ["Daytona (VM)", "E2B", "Modal"]) expect(md).toContain(name);
+		for (const name of ["Daytona (VM)", "E2B", "Modal (gVisor)"]) expect(md).toContain(name);
 	});
 
 	it("never marks a row `tied` unless the test could have separated it", () => {
@@ -568,7 +568,7 @@ describe("underpowered comparisons", () => {
 		const board = buildLeaderboard(
 			run([
 				provider("daytona-vm", [metric(HEADLINE, [19.63, 19.72, 19.96])]),
-				provider("modal", [metric(HEADLINE, [9.79, 9.52, 9.59])]),
+				provider("modal-gvisor", [metric(HEADLINE, [9.79, 9.52, 9.59])]),
 				provider("e2b", [metric(HEADLINE, [9.79, 9.52, 9.59])]),
 			]),
 		);
@@ -587,7 +587,7 @@ describe("underpowered comparisons", () => {
 		const board = buildLeaderboard(
 			run([
 				provider("daytona-vm", [metric(HEADLINE, near)]),
-				provider("modal", [
+				provider("modal-gvisor", [
 					metric(
 						HEADLINE,
 						near.map((v) => v - 0.01),
@@ -611,7 +611,7 @@ describe("underpowered comparisons", () => {
 		const board = buildLeaderboard(
 			run([
 				provider("daytona-vm", [metric(HEADLINE, [2, 2, 2])]),
-				provider("modal", [metric(HEADLINE, [1, 1, 1])]),
+				provider("modal-gvisor", [metric(HEADLINE, [1, 1, 1])]),
 			]),
 		);
 		const rows = board.dimensions.find((d) => d.dimension === "cpu")?.rows ?? [];

--- a/packages/schema/src/economics.test.ts
+++ b/packages/schema/src/economics.test.ts
@@ -76,7 +76,7 @@ describe("deriveEconomics", () => {
 	});
 
 	it("omits usd_per_lifecycle when no lifecycle Metric was measured", () => {
-		const econ = deriveEconomics(getProvider("modal"), [
+		const econ = deriveEconomics(getProvider("modal-gvisor"), [
 			{ metricId: HARNESS_METRIC_IDS.controlPlaneInfo, mean: 42 },
 		]);
 		// control-plane timings are not lifecycle runtime, so no per-lifecycle cost.

--- a/packages/schema/src/providers.test.ts
+++ b/packages/schema/src/providers.test.ts
@@ -26,7 +26,8 @@ describe("@sandbox-benchmarks/schema providers", () => {
 			"daytona-container",
 			"daytona-vm",
 			"e2b",
-			"modal",
+			"modal-gvisor",
+			"modal-vm",
 			"novita",
 		]);
 	});
@@ -107,9 +108,9 @@ describe("@sandbox-benchmarks/schema providers", () => {
 		// Guards the economics constants against accidental regressions (PR #15 review). Daytona's
 		// first 5 GiB of memory are free; e2b bills all memory at the same vCPU/GiB rates.
 		const expected: Record<string, number> = {
-			// Daytona's two variants bill identically — assert one here, and the shared-pricing invariant
-			// across a vendor's variants is checked separately below.
-			modal: 0.141912 * TARGET_SPEC.vcpus + 0.024192 * TARGET_SPEC.memoryGb,
+			// Modal's two variants bill identically; likewise Daytona's — assert one of each here, and
+			// the shared-pricing invariant across a vendor's variants is checked separately below.
+			"modal-gvisor": 0.141912 * TARGET_SPEC.vcpus + 0.024192 * TARGET_SPEC.memoryGb,
 			e2b: 0.0504 * TARGET_SPEC.vcpus + 0.0162 * TARGET_SPEC.memoryGb,
 			"daytona-vm": 0.0504 * TARGET_SPEC.vcpus + 0.0162 * Math.max(0, TARGET_SPEC.memoryGb - 5),
 			novita: 0.03528 * TARGET_SPEC.vcpus + 0.01152 * TARGET_SPEC.memoryGb,
@@ -128,20 +129,22 @@ describe("@sandbox-benchmarks/schema providers", () => {
 			return pricing?.model === "per_vcpu_hour" ? pricing.usdPerGibDiskHour : undefined;
 		};
 		expect(diskRate("daytona-vm")).toBeCloseTo(0.000108); // $0.00000003/GiB-s × 3600
-		expect(diskRate("modal")).toBe(0); // volumes free under the 1 TiB/mo tier
+		expect(diskRate("modal-gvisor")).toBe(0); // volumes free under the 1 TiB/mo tier
 		expect(diskRate("e2b")).toBeUndefined(); // no published overage rate
 		expect(diskRate("novita")).toBe(0); // 20 GB target spec inside the 60 GB free tier
 	});
 
 	it("resolves retired provider ids through the legacy aliases", () => {
-		// Pre-split committed runs carry `daytona`; getProvider must still resolve it to the variant
-		// that subsumed it so a historical leaderboard keeps its display names + economics.
+		// Pre-split committed runs carry `modal`/`daytona`; getProvider must still resolve them to the
+		// variant that subsumed each so a historical leaderboard keeps its display names + economics.
+		expect(getProvider("modal")?.id).toBe("modal-gvisor");
 		expect(getProvider("daytona")?.id).toBe("daytona-vm");
 	});
 
 	it("keeps a vendor's isolation variants on identical pricing", () => {
-		// Daytona's two variants differ only in isolation, never billing — a drift here would misrank one
-		// against the other, so pin that they share a pricing object.
+		// The two Modal variants (and the two Daytona variants) differ only in isolation, never billing —
+		// a drift here would misrank one against the other, so pin that they share a pricing object.
+		expect(getProvider("modal-vm")?.pricing).toEqual(getProvider("modal-gvisor")?.pricing);
 		expect(getProvider("daytona-container")?.pricing).toEqual(getProvider("daytona-vm")?.pricing);
 	});
 

--- a/packages/schema/src/providers.ts
+++ b/packages/schema/src/providers.ts
@@ -11,7 +11,14 @@
  * matching {@link REGISTRY} entry (the Record type below makes a missing or extra id a compile
  * error) and, downstream, a harness adapter in @sandbox-benchmarks/providers.
  */
-export type ProviderId = "e2b" | "daytona-vm" | "daytona-container" | "modal" | "blaxel" | "novita";
+export type ProviderId =
+	| "e2b"
+	| "daytona-vm"
+	| "daytona-container"
+	| "modal-gvisor"
+	| "modal-vm"
+	| "blaxel"
+	| "novita";
 
 /** Can the SDK request a pinned target spec (vCPU / memory) at create() time? */
 export type SpecPinning = "settable" | "fixed" | "unknown";
@@ -315,17 +322,37 @@ const REGISTRY: Record<ProviderId, Omit<ProviderMeta, "id">> = {
 			detachedPoll: true,
 		},
 	},
-	modal: {
-		displayName: "Modal",
+	"modal-gvisor": {
+		displayName: "Modal (gVisor)",
 		website: "https://modal.com",
 		sdkPackage: "@computesdk/modal",
 		requiredEnvVars: ["MODAL_TOKEN_ID", "MODAL_TOKEN_SECRET"],
 		isolation: {
-			technology: "VM",
-			notes: "VM Sandboxes",
+			technology: "gVisor container",
+			notes:
+				"Modal's default sandbox runtime. scalableSandboxes enabled in the harness; nproc tracks the requested cpu 1:1.",
 		},
 		pricing: modalPricing,
-		maturity: { status: "beta", notes: "VM runtime is beta." },
+		maturity: { status: "ga", notes: "scalableSandboxes enabled in the harness." },
+		specPinning: "settable",
+		transport: modalTransport,
+	},
+	"modal-vm": {
+		displayName: "Modal (VM)",
+		website: "https://modal.com",
+		sdkPackage: "@computesdk/modal",
+		requiredEnvVars: ["MODAL_TOKEN_ID", "MODAL_TOKEN_SECRET"],
+		isolation: {
+			technology: "microVM (VM runtime)",
+			notes:
+				"Modal's experimental VM runtime — a gVisor-free KVM microVM, selected per-create via experimentalOptions {vm_runtime:true} (no separate image; same pushed toolchain image as modal-gvisor).",
+		},
+		pricing: modalPricing,
+		maturity: {
+			status: "beta",
+			notes:
+				"New isolation variant sharing Modal credentials/pricing with modal-gvisor; adds experimentalOptions {vm_runtime:true} at create. Not yet a committed run.",
+		},
 		specPinning: "settable",
 		transport: modalTransport,
 	},
@@ -409,6 +436,12 @@ export const PROVIDERS: readonly ProviderMeta[] = deepFreeze(
  * old data.
  */
 export const LEGACY_PROVIDER_ALIASES: Readonly<Record<string, ProviderId>> = Object.freeze({
+	// `modal` → modal-gvisor, NOT modal-vm: pre-split `modal` ran Modal's default gVisor runtime
+	// (scalableSandboxes, no vm_runtime); the VM runtime is a later, separate variant. Every committed
+	// `modal` run predates that switch, so its data is gVisor. (The single `modal` entry on the base
+	// branch shows "VM" only because this stack sits on top of that later change — that is the current
+	// adapter config, not the runtime the historical runs were collected under.)
+	modal: "modal-gvisor",
 	daytona: "daytona-vm",
 });
 

--- a/tooling/repo-checks/src/workflow-registry-sync.test.ts
+++ b/tooling/repo-checks/src/workflow-registry-sync.test.ts
@@ -118,11 +118,11 @@ describe("checkProviderInput", () => {
 	test("flags a registry provider dropped from the options", () => {
 		const drifted = {
 			...providerInput,
-			options: providerInput.options?.filter((o) => o !== "modal"),
+			options: providerInput.options?.filter((o) => o !== "modal-gvisor"),
 		};
 		const errors = checkProviderInput(drifted);
 		expect(errors).toHaveLength(1);
-		expect(errors[0]).toContain('missing "modal"');
+		expect(errors[0]).toContain('missing "modal-gvisor"');
 		expect(errors[0]).toContain("PROVIDERS");
 	});
 
@@ -198,8 +198,8 @@ describe("checkCredentialEnv", () => {
 	test("requiredCredentialKeys records provenance per provider", () => {
 		const required = requiredCredentialKeys();
 		expect(required.get("E2B_API_KEY")).toEqual(["e2b"]);
-		expect(required.get("MODAL_TOKEN_ID")).toEqual(["modal"]);
 		// A credential shared by a vendor's isolation variants records every owner, in registry order.
+		expect(required.get("MODAL_TOKEN_ID")).toEqual(["modal-gvisor", "modal-vm"]);
 		expect(required.get("DAYTONA_API_KEY")).toEqual(["daytona-vm", "daytona-container"]);
 	});
 


### PR DESCRIPTION
**Split of #209 — daytona/modal isolation variants, shipped bottom-up** (each branch is one hermetic concept and independently green; merge from the bottom):

1. #223 — schema: extract shared per-vendor pricing/transport consts
2. #224 — providers: Daytona VM + container variants
3. **#225 — providers: Modal gVisor + VM variants ← you are here (3/5)**
4. #210 — results: surface per-provider isolation in the leaderboard
5. #211 — harness: best-effort isolation detection probe

_Based on #224. This branch reproduces the original #209 change byte-for-byte at the top of the split._

---

Fan Modal out into `modal-gvisor` (scalableSandboxes, gVisor container — Modal's default runtime, ga) and `modal-vm` (`experimentalOptions {vm_runtime:true}`, a gVisor-free KVM microVM, beta). Both boot the same pushed toolchain image and share Modal's credentials/pricing/transport (the consts from #223); `modal-vm` drops `scalableSandboxes` to match the VM config validated in #221.

Blast radius (all here so the branch is green): the adapters Record + `modalGvisorCompute`/`modalVmCompute` + `modalCreateOptions` helper, the bake/release-plan/promote/validate exhaustive switches, the CI matrices + workflow-registry-sync gate, and `getProvider`'s `modal` → `modal-gvisor` legacy alias so pre-split runs still resolve. `LEADERBOARD.md` regenerated from the committed run (autogenerated via `apps/cli/src/bin/leaderboard.ts`).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Split Modal into two isolation variants: `modal-gvisor` (gVisor, GA) and `modal-vm` (KVM microVM, beta). CI/release now default to and require `modal-gvisor`; legacy `modal` ids resolve to `modal-gvisor`.

- New Features
  - Added providers `modal-gvisor` (scalableSandboxes) and `modal-vm` (`experimentalOptions { vm_runtime: true }`, no scalableSandboxes).
  - Both share the same pushed image, credentials, pricing, and transport; vCPUs and `memoryLimitMiB` match the target spec; no per-variant bake artifact.
  - CI/workflows updated: options list both variants; defaults include `modal-gvisor`; `MODAL_TOKEN_*` scoped to either; release required providers set to `e2b,daytona-vm,modal-gvisor`. Leaderboard labels “Modal (gVisor)”.

- Migration
  - Replace `modal` with `modal-gvisor` or `modal-vm` in `BENCH_PROVIDERS`, CLI flags, and workflows.
  - Required providers: `e2b,daytona-vm,modal-gvisor`; env vars unchanged (`MODAL_TOKEN_ID`, `MODAL_TOKEN_SECRET`).

<sup>Written for commit b36386a9264fe2fd81427ae4541b9fcce25508e3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/starslingdev/hpc-sandbox-benchmarks/pull/225?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

