### PR TITLE
feat(ci): add deliberate leaderboard update workflow

### DIFF
--- a/.github/workflows/bench-matrix.yml
+++ b/.github/workflows/bench-matrix.yml
@@ -119,7 +119,7 @@ jobs:
 
   # Collect every shard Run, aggregate into one candidate, gate it (promote), and commit the machine-
   # readable dataset onto main. This job only commits the dataset JSON — regenerating the public
-  # LEADERBOARD.md is a deliberate, separate step, so a matrix run
+  # LEADERBOARD.md is a deliberate, separate step (the Update leaderboard workflow), so a matrix run
   # grows the dataset without churning the comparison surface. The logic lives in the reusable
   # commit-dataset.yml so a maintainer can also run it standalone (workflow_dispatch) to backfill a run
   # whose commit failed. Environment `privileged` (the dataset release surface, `contents: write`) is

--- a/.github/workflows/commit-dataset.yml
+++ b/.github/workflows/commit-dataset.yml
@@ -3,7 +3,7 @@ name: Commit dataset
 # Aggregate a Bench matrix run's per-cell shards into one candidate, gate it (promote), and commit the
 # promoted dataset JSON onto main. This is the purely-mechanical half of the old publish-dataset.yml:
 # it lands data/dataset/ (the machine-readable Run + newest-first index) and nothing human-facing — the
-# public LEADERBOARD.md is regenerated deliberately as a separate operation, so the dataset can
+# public LEADERBOARD.md is regenerated deliberately by update-leaderboard.yml, so the dataset can
 # accumulate one committed run per matrix run without churning the comparison surface every time.
 #
 # Two entry points:
@@ -164,7 +164,7 @@ jobs:
               --base main \
               --head "$branch" \
               --title "chore(dataset): commit run ${RUN_ID}" \
-              --body "Automated dataset commit for run [\`${RUN_ID}\`](${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${RUN_ID}). Biome was pre-flighted green on the promoted content; auto-merge lands it once branch protection is satisfied. The public LEADERBOARD.md is regenerated separately."; then
+              --body "Automated dataset commit for run [\`${RUN_ID}\`](${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${RUN_ID}). Biome was pre-flighted green on the promoted content; auto-merge lands it once branch protection is satisfied. The public LEADERBOARD.md is regenerated separately via the Update leaderboard workflow."; then
               echo "::error::gh pr create failed — branch '$branch' was pushed but no PR was opened." \
                 "This is almost always the repo's 'Allow GitHub Actions to create and approve pull" \
                 "requests' setting being off (Settings → Actions → General → Workflow permissions)." \

--- a/.github/workflows/update-leaderboard.yml
+++ b/.github/workflows/update-leaderboard.yml
@@ -1,0 +1,159 @@
+name: Update leaderboard
+
+# Regenerate the public LEADERBOARD.md from an ALREADY-COMMITTED dataset run and land it on main via a
+# pull request. This is the deliberate, human-facing half of the old publish-dataset.yml: commit-dataset.yml
+# accumulates one machine-readable Run per matrix run under data/dataset/ automatically, and a maintainer
+# runs THIS workflow to point the comparison surface at a chosen dataset run (by default the newest one).
+# Splitting it out means the dataset can grow without churning LEADERBOARD.md, and the published table
+# only ever moves on a deliberate action.
+#
+# The Run must already be in the committed dataset (data/dataset/runs/<id>.json) — this workflow renders
+# from the published dataset, never from shard artifacts or the gitignored data/runs/ scratch tree (the
+# same source the leaderboard-artifact-sync gate enforces). If the run isn't committed yet, run the
+# Commit dataset workflow (or let a bench-matrix run commit it) first.
+#
+# Dispatch-only: a maintainer regenerates the leaderboard, optionally naming the run id. It is
+# deliberately NOT a reusable (`workflow_call`) workflow — the matrix never regenerates the leaderboard,
+# and a `workflow_call` entry point would evaluate the main-only `if:` below in the CALLER's ref context,
+# so a caller on a non-main ref would hit a silent job-skip. Keeping it dispatch-only removes that
+# footgun; the dispatcher always picks the ref (main), and Environment `privileged` gates it regardless.
+#
+# Environment `privileged` lives on the job here (the release surface, `contents: write`) so the approval
+# gate is enforced at this layer.
+on:
+  workflow_dispatch:
+    inputs:
+      run_id:
+        description: 'Committed dataset run id to render LEADERBOARD.md from (blank = newest committed run).'
+        required: false
+        type: string
+        default: ''
+
+# Least privilege at the top level; the update job elevates for exactly what it needs.
+permissions:
+  contents: read
+
+# One global group serializes all leaderboard updates so two dispatches can't race the same branch/push.
+# Unlike commit-dataset, this group is NOT keyed on run_id: run_id is optional and a blank dispatch
+# resolves to the newest committed run INSIDE the job, so a blank and an explicit-newest-id dispatch would
+# fall into different run_id-keyed groups yet target the same leaderboard/update-<id> branch — a race the
+# global group prevents. A pending update evicted by a newer one is harmless here: leaderboard renders are
+# idempotent and this workflow is maintainer-dispatched (low frequency), so the newer run supersedes it.
+concurrency:
+  group: update-leaderboard
+  cancel-in-progress: false
+
+jobs:
+  leaderboard:
+    name: Regenerate leaderboard
+    # Confine the release to this repo's main. (Environment `privileged`'s deployment-branch policy pins
+    # it to main too; this is defense in depth.)
+    if: >
+      github.ref == 'refs/heads/main' &&
+      github.repository == 'starslingdev/hpc-sandbox-benchmarks'
+    runs-on: ubuntu-24.04
+    environment: privileged
+    # contents: write to commit + push the leaderboard branch; pull-requests: write to open the PR. No
+    # actions: read here — the leaderboard renders from the committed dataset, not from run artifacts.
+    permissions:
+      contents: write
+      pull-requests: write
+    # The dispatch input reaches the shell only through the environment, never interpolated into a
+    # `run:` command.
+    env:
+      RUN_ID: ${{ inputs.run_id }}
+    steps:
+      # This job commits + `git push`es LEADERBOARD.md, so it keeps the default persisted job token
+      # (contents: write above authorizes it). Don't add persist-credentials: false here or the push at
+      # the end of the job loses its credentials.
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - name: Set up Bun
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
+        with:
+          bun-version: 1.3.14
+      - name: Install dependencies
+        run: bun install --frozen-lockfile --ignore-scripts
+
+      # Resolve which committed run to render: the explicit input when given, else the newest entry in
+      # the newest-first data/dataset/index.json. Fail loudly if the chosen run isn't in the committed
+      # dataset — the leaderboard must be rendered from data/dataset/runs/ (what promote writes), never
+      # from the gitignored data/runs/ scratch tree, which is exactly what leaderboard-artifact-sync
+      # guards. The resolved id is exported for the later steps (an env var, never interpolated as YAML).
+      - name: Resolve target run
+        run: |
+          # Resolve through the committed index so an explicit input can only ever name a run that exists
+          # in data/dataset/index.json with its canonical runs/<id>.json path — never a crafted value that
+          # path-traverses out of data/dataset/runs/. Blank RUN_ID → newest (first) index entry.
+          # String concatenation (no `${...}` template literals) keeps this single-quoted so the shell
+          # never expands it, without tripping shellcheck SC2016 (which flags ${...} inside single quotes).
+          target="$(bun -e 'const i = await Bun.file("data/dataset/index.json").json(); const requested = process.env.RUN_ID; const run = requested ? i.runs?.find((r) => String(r.runId) === requested) : i.runs?.[0]; if (!run || run.runId === undefined || run.runId === null || String(run.runId) === "") { console.error(requested ? "run " + requested + " is not in data/dataset/index.json" : "data/dataset/index.json lists no runs"); process.exit(1); } if (run.path !== "runs/" + run.runId + ".json") { console.error("index entry for " + run.runId + " has unexpected path " + run.path); process.exit(1); } process.stdout.write(String(run.runId));')"
+          if [ -z "$target" ]; then echo "could not resolve a target run id" >&2; exit 1; fi
+          if [ ! -f "data/dataset/runs/$target.json" ]; then
+            echo "::error::data/dataset/runs/$target.json is not committed — the leaderboard renders from the" \
+              "published dataset. Commit the run first (Commit dataset workflow, or a bench-matrix run)." >&2
+            exit 1
+          fi
+          echo "TARGET_RUN_ID=$target" >> "$GITHUB_ENV"
+
+      # Keep LEADERBOARD.md byte-identical to what the renderer produces from the chosen committed Run —
+      # the same command the leaderboard-artifact-sync gate names in its failure message.
+      - name: Regenerate leaderboard
+        run: bun apps/cli/src/bin/leaderboard.ts "data/dataset/runs/$TARGET_RUN_ID.json" LEADERBOARD.md
+
+      # Fast pre-flight of the same gate the PR runs (`biome check .`), scoped to the file this job
+      # writes. Biome leaves the rendered Markdown untouched, so this catches only a genuine formatting
+      # regression; fail here (before any PR is opened) rather than leave a doomed PR.
+      - name: Confirm the leaderboard passes Biome (the PR lint gate)
+        run: bunx biome check LEADERBOARD.md --error-on-warnings
+
+      # main is protected by a "changes must be made through a pull request" ruleset, so this job can't
+      # push LEADERBOARD.md straight to main — a direct push is rejected with GH013. Commit through a
+      # short-lived branch + pull request and enable GitHub-native auto-merge (`--auto`): the PR merges
+      # itself only once branch protection is satisfied — required status checks green and any required
+      # reviews in. `--auto` waits for those rules, it does not bypass them. If auto-merge can't be armed
+      # (e.g. the repo hasn't enabled it), the PR stays open for a maintainer to merge normally.
+      - name: Update the leaderboard via pull request
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add LEADERBOARD.md
+          if git diff --cached --quiet; then
+            echo "LEADERBOARD.md already reflects run $TARGET_RUN_ID; nothing to commit"
+            exit 0
+          fi
+          branch="leaderboard/update-${TARGET_RUN_ID}"
+          # Always (re)build the bot branch from the freshly rendered content and force-push FIRST, so a
+          # re-dispatch refreshes an already-open PR rather than leaving it stale (e.g. if the renderer or
+          # committed dataset changed since it was opened). `-C` resets the local branch to this run's HEAD;
+          # `--force` overwrites the bot-owned remote branch (a no-op when the content is unchanged).
+          git switch -C "$branch"
+          git commit -m "chore(leaderboard): update from run ${TARGET_RUN_ID}"
+          git push -u --force origin "$branch"
+          # Open the PR only if one isn't already open for this deterministic branch; a re-dispatch reuses
+          # it (the force-push above already refreshed its content). `gh pr create` fails outright (GraphQL
+          # "GitHub Actions is not permitted to create or approve pull requests") when the repo's Settings →
+          # Actions → General → Workflow permissions → "Allow GitHub Actions to create and approve pull
+          # requests" toggle is off — see docs/ci-secrets.md. The branch is already pushed at that point, so
+          # surface the fix instead of a bare GraphQL error before failing the job.
+          if [ -z "$(gh pr list --head "$branch" --state open --json number --jq '.[].number')" ]; then
+            if ! gh pr create \
+              --base main \
+              --head "$branch" \
+              --title "chore(leaderboard): update from run ${TARGET_RUN_ID}" \
+              --body "Automated LEADERBOARD.md regeneration from committed dataset run \`${TARGET_RUN_ID}\`. Biome was pre-flighted green; auto-merge lands it once branch protection is satisfied."; then
+              echo "::error::gh pr create failed — branch '$branch' was pushed but no PR was opened." \
+                "This is almost always the repo's 'Allow GitHub Actions to create and approve pull" \
+                "requests' setting being off (Settings → Actions → General → Workflow permissions)." \
+                "A maintainer must either enable it and re-dispatch this workflow with run_id=$TARGET_RUN_ID," \
+                "or open the PR for '$branch' manually. See docs/ci-secrets.md."
+              exit 1
+            fi
+          fi
+          # (Re-)arm GitHub-native auto-merge: it merges only after the PR's required checks pass (and any
+          # required reviews land), never bypassing branch protection. Best-effort — if the repo hasn't
+          # enabled auto-merge, leave the PR open for a maintainer.
+          gh pr merge "$branch" --squash --delete-branch --auto \
+            || echo "auto-merge not armed; leaderboard PR left open for a maintainer to merge"

--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -4,12 +4,14 @@
 rules:
   artipacked:
     ignore:
-      # commit-dataset.yml's `commit` job is the one checkout that must keep its persisted job token:
-      # it commits the promoted dataset and `git push`es it back to the branch (the job grants
-      # `contents: write` for exactly this). Every other checkout in the repo sets
-      # persist-credentials: false; this one can't, by design. (Filename-scoped, not repo-wide — this
-      # reusable workflow's only checkout is the pushing one, so just its finding is accepted.)
+      # commit-dataset.yml's `commit` job and update-leaderboard.yml's `leaderboard` job are the two
+      # checkouts that must keep their persisted job token: each commits its output (the promoted dataset
+      # / the regenerated leaderboard) and `git push`es it back to the branch (both grant `contents: write`
+      # for exactly this). Every other checkout in the repo sets persist-credentials: false; these can't,
+      # by design. (Filename-scoped, not repo-wide — each of these workflows' only checkout is its pushing
+      # one, so just their findings are accepted.)
       - commit-dataset.yml
+      - update-leaderboard.yml
   secrets-inherit:
     ignore:
       # bench-matrix.yml's suite-matrix job calls the reusable bench-suite.yml with `secrets: inherit`.

--- a/apps/cli/README.md
+++ b/apps/cli/README.md
@@ -15,7 +15,7 @@
 - `normalize` — turn raw runs into normalized run documents.
 - `aggregate` — merge shard Runs into one candidate.
 - `promote` — promote normalized results to the published dataset. Used by the `commit-dataset` workflow.
-- `leaderboard` — render a committed Run as Markdown (`LEADERBOARD.md`) on demand.
+- `leaderboard` — render a Run as Markdown (`LEADERBOARD.md`); used by the `update-leaderboard` workflow.
 - `bake` / `bench-smoke` / `stability` — toolchain bake, single-cell smoke, cross-run stability gate.
 
 **Depends on:** all five packages (`workspace:*`) + `dotenv` (`catalog:`).

--- a/docs/ci-secrets.md
+++ b/docs/ci-secrets.md
@@ -15,6 +15,7 @@ and toolchain publish must not trigger on `push`.
 | `toolchain-image.yml` | `publish` | Provider bake secrets + `packages: write` (GHCR release) |
 | `bench-suite.yml` | `bench` | Provider API keys (reusable fan-out `bench-matrix.yml`'s suite-matrix job calls) |
 | `commit-dataset.yml` | `commit` | Dataset JSON commit (`contents: write` + `pull-requests: write`) |
+| `update-leaderboard.yml` | `leaderboard` | Public `LEADERBOARD.md` commit (`contents: write` + `pull-requests: write`) |
 | `bench-smoke.yml` | `smoke` | Provider API keys |
 
 Two of these are reusable workflows whose `privileged` gate lives on their own job, because a `uses:`
@@ -27,8 +28,11 @@ local caller):
   `secrets: inherit` for repository-level secrets / token context.
 - `commit-dataset.yml` commits the machine-readable dataset: `bench-matrix.yml`'s `publish` job calls it
   at the end of a matrix run, and a maintainer can dispatch it standalone to backfill (see rule 6). It
-  lands `data/dataset/` only, so the dataset can accumulate a run per matrix run without moving the
-  published comparison surface.
+  lands `data/dataset/` only — the public `LEADERBOARD.md` is regenerated separately (see rule 7), so the
+  dataset can accumulate a run per matrix run without moving the published comparison surface.
+- `update-leaderboard.yml` regenerates `LEADERBOARD.md` from a committed dataset run. It is
+  maintainer-dispatched (never called by the matrix), so the published table only moves on a deliberate
+  action — see rule 7.
 
 Ungated: `ci.yml`, `ci-lint.yml`, and the toolchain `pr-gate` (Docker smoke, no secrets).
 
@@ -53,7 +57,8 @@ Ungated: `ci.yml`, `ci-lint.yml`, and the toolchain `pr-gate` (Docker smoke, no 
    Biome gate on the generated dataset (`biome check data/dataset`, the same rules ci.yml runs) —
    Biome formats JSON, so an unformatted Run document would fail the PR — and aborts before opening a
    doomed PR on a miss. The push/PR step is idempotent: a re-run reuses the existing open PR instead of
-   colliding on the deterministic branch.
+   colliding on the deterministic branch. `update-leaderboard.yml` lands `LEADERBOARD.md` the same way
+   (a `leaderboard/update-<run-id>` PR, Biome-preflighted, auto-merge armed).
 
    > **`GITHUB_TOKEN` caveat.** A PR opened with the default `GITHUB_TOKEN` does **not** trigger
    > `ci.yml` (GitHub suppresses workflow events raised by the Actions token). So if the Biome/CI check
@@ -72,6 +77,18 @@ Ungated: `ci.yml`, `ci-lint.yml`, and the toolchain `pr-gate` (Docker smoke, no 
    required reviewer), so it is effectively maintainer-only. (`workflow_dispatch` is only offered for the
    copy of the workflow on the default branch, so `commit-dataset.yml` must be merged to `main` before
    it can be dispatched.)
+
+7. **Updating the public leaderboard.** `LEADERBOARD.md` is regenerated separately from the dataset
+   commit, on a deliberate maintainer action: **Actions → Update leaderboard → Run workflow** — or
+   `scripts/update-leaderboard.sh [run-id]` from a gh-authenticated clone. Leave `run_id` blank to render
+   from the newest committed dataset run (the first entry in `data/dataset/index.json`), or pass an
+   explicit run id to point the table at a specific run. The
+   workflow renders `LEADERBOARD.md` from `data/dataset/runs/<run-id>.json` — the **committed** dataset,
+   never the gitignored `data/runs/` scratch tree (what the `leaderboard-artifact-sync` gate enforces) —
+   so the run must already be committed (via a bench-matrix run or rule 6) before the leaderboard can
+   name it. It then opens the lint-gated `leaderboard/update-<run-id>` PR (rule 5). Because the render is
+   deterministic, the resulting `LEADERBOARD.md` is exactly what `leaderboard-artifact-sync` expects, so
+   the PR's own CI stays green.
 
 > **Two approval gates per bench-matrix run.** The suite-matrix fan-out (each cell calling
 > `bench-suite.yml` with `environment: privileged`) and the `publish` job both carry the environment
@@ -105,10 +122,11 @@ Do this in the GitHub UI (Settings → Environments), then delete any matching *
 5. Confirm the GHCR package `sandbox-benchmarks-toolchain` is **public** so providers can pull
    the candidate base anonymously (Org → Packages → package settings).
 6. Enable **Settings → Actions → General → Workflow permissions → "Allow GitHub Actions to create
-   and approve pull requests"**. The `gh pr create` in `commit-dataset.yml` fails outright without it
-   (`GraphQL: GitHub Actions is not permitted to create or approve pull requests`) — the job pushes its
-   `dataset/publish-<run-id>` branch and then dies, so every matrix run's commit step needs a maintainer
-   to open the PR by hand until this is on.
+   and approve pull requests"**. The `gh pr create` in `commit-dataset.yml` and `update-leaderboard.yml`
+   fails outright without it (`GraphQL: GitHub Actions is not permitted to create or approve pull
+   requests`) — the job pushes its branch (`dataset/publish-<run-id>` / `leaderboard/update-<run-id>`)
+   and then dies, so every matrix run's commit step needs a maintainer to open the PR by hand until this
+   is on.
 
 Optional bootstrap (creates the empty environment; reviewers/secrets still need a human):
 

--- a/docs/methodology.md
+++ b/docs/methodology.md
@@ -102,9 +102,11 @@ without being Daytona-specific.
    economics re-derived from the merged set), then `promote`s it (gate: ≥1 validated provider) into the
    committed dataset at `data/dataset/` with a newest-first index, and opens a PR to land it on `main`.
    This step commits only the machine-readable dataset — it never touches `LEADERBOARD.md`.
-4. **Leaderboard** — `leaderboard` renders a chosen committed Run into a ranked Markdown table per
-   dimension. Updating `LEADERBOARD.md` is a deliberate operation, so the dataset can grow a run per
-   matrix run without moving the public comparison surface automatically.
+4. **Leaderboard** — the `update-leaderboard` workflow renders a chosen committed Run into a ranked
+   Markdown table per dimension (`leaderboard`) and opens a PR to update `LEADERBOARD.md`. It is a
+   deliberate, maintainer-dispatched step (default: the newest committed run), so the dataset can grow a
+   run per matrix run while the public comparison surface only moves when someone updates it. See
+   [CI & secrets](./ci-secrets.md) rule 7.
 5. **Stability gate** — `stability <prev> <cur>` flags any provider metric that shifted beyond the noise
    threshold across Runs, comparing only provenance-matched (same `appVersion` + `arguments`) metrics.
 

--- a/scripts/backfill-dataset.sh
+++ b/scripts/backfill-dataset.sh
@@ -71,4 +71,4 @@ echo "  gh run list --repo ${REPO} --workflow ${WORKFLOW}"
 echo "On success it opens (or re-arms) the dataset/publish-${RUN_ID} pull request. If run ${RUN_ID} is"
 echo "already committed, the job is a clean no-op ('dataset unchanged; nothing to commit')."
 echo
-echo "The public LEADERBOARD.md is updated separately from a committed dataset run."
+echo "The public LEADERBOARD.md is updated separately — see scripts/update-leaderboard.sh."

--- a/scripts/update-leaderboard.sh
+++ b/scripts/update-leaderboard.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+# Regenerate the public LEADERBOARD.md from a committed dataset run by dispatching update-leaderboard.yml.
+#
+# The dataset accumulates one committed Run per matrix run automatically (commit-dataset.yml); moving the
+# published comparison surface is a deliberate codeowner action. This is a thin wrapper over
+# `gh workflow run` so the dispatch is one command instead of a hand-assembled API call; the same thing
+# is doable from the Actions UI (Actions → Update leaderboard → Run workflow). See docs/ci-secrets.md
+# rule 7.
+#
+# Requires `gh` authenticated with rights to dispatch workflows on this repo. The dispatch is gated by
+# Environment `privileged` (main-only + required reviewer), so it parks for maintainer approval.
+#
+# Usage: scripts/update-leaderboard.sh [run-id]
+#   [run-id]   Committed dataset run id to render from. Omit to render from the newest committed run.
+set -euo pipefail
+
+# update-leaderboard.yml only runs on main (its job `if:` pins to refs/heads/main), and workflow_dispatch
+# is only offered for workflows present on the default branch — so always dispatch the main copy.
+WORKFLOW="update-leaderboard.yml"
+REF="main"
+
+RUN_ID="${1:-}"
+# Optional, but if given it must be a numeric GitHub run id (blank = newest committed run).
+if [ -n "$RUN_ID" ] && ! printf '%s' "$RUN_ID" | grep -qE '^[0-9]+$'; then
+  echo "run-id must be a numeric GitHub run id when provided (got '${RUN_ID}')" >&2
+  echo "Usage: scripts/update-leaderboard.sh [run-id]   (omit to render from the newest committed run)" >&2
+  exit 2
+fi
+
+if ! command -v gh >/dev/null 2>&1; then
+  echo "gh is required (https://cli.github.com/)" >&2
+  exit 1
+fi
+
+# Prefer the repo gh is pointed at; GITHUB_REPOSITORY wins. Fail closed rather than default to a
+# hardcoded repo.
+if [ -n "${GITHUB_REPOSITORY:-}" ]; then
+  REPO="$GITHUB_REPOSITORY"
+elif REPO="$(gh repo view --json nameWithOwner -q .nameWithOwner 2>/dev/null)" && [ -n "$REPO" ]; then
+  :
+else
+  echo "Could not determine the repository. Set GITHUB_REPOSITORY, or run inside a gh-authenticated clone." >&2
+  exit 1
+fi
+
+if [ -n "$RUN_ID" ]; then
+  echo "Dispatching ${WORKFLOW} on ${REF} of ${REPO} to render the leaderboard from run ${RUN_ID}…"
+  gh workflow run "$WORKFLOW" --repo "$REPO" --ref "$REF" -f "run_id=${RUN_ID}"
+else
+  echo "Dispatching ${WORKFLOW} on ${REF} of ${REPO} to render the leaderboard from the newest committed run…"
+  gh workflow run "$WORKFLOW" --repo "$REPO" --ref "$REF"
+fi
+
+echo
+echo "Dispatched. The run is gated by Environment 'privileged' — it waits for a required reviewer to"
+echo "approve. On success it opens the leaderboard/update-<run-id> pull request. Watch it:"
+echo "  gh run list --repo ${REPO} --workflow ${WORKFLOW}"

--- a/tooling/repo-checks/src/lib/workflow-hardening.ts
+++ b/tooling/repo-checks/src/lib/workflow-hardening.ts
@@ -36,6 +36,11 @@ export const CREDENTIALED_CHECKOUTS: Readonly<Record<string, string>> = {
 	// branch (it grants `contents: write` for exactly this), so it must keep the persisted token. It is
 	// the reusable workflow bench-matrix.yml's publish job calls, and a maintainer dispatches to backfill.
 	"commit-dataset.yml::commit": "commits + pushes the promoted dataset back to the branch",
+	// update-leaderboard.yml's leaderboard job regenerates LEADERBOARD.md and `git push`es it back to the
+	// branch (also `contents: write`), so it too must keep the persisted token. A maintainer dispatches it
+	// to move the public comparison surface to a chosen committed dataset run.
+	"update-leaderboard.yml::leaderboard":
+		"commits + pushes the regenerated leaderboard back to the branch",
 };
 
 /** Built-in / non-environment tokens that may appear as `${{ secrets.* }}` without requiring the


### PR DESCRIPTION
## Summary

Add the deliberate, maintainer-dispatched path for moving the public leaderboard after a dataset run has been committed.

- Add `update-leaderboard.yml`, which selects an optional run through `data/dataset/index.json`, renders `LEADERBOARD.md`, refreshes a deterministic bot branch, and opens or re-arms its lint-gated PR.
- Reject unknown or non-canonical run paths before rendering.
- Add `scripts/update-leaderboard.sh` as a thin dispatch helper.
- Extend credential-hardening allowlists and operator documentation for the leaderboard job.

## Stack

2 of 2. Depends on #242, which isolates dataset commits and backfill from leaderboard publishing.

## Verification

- `bun --filter '@repo/repo-checks' test` — 145 passed
- `bun run lint`
- `mise exec -- actionlint -no-color`
- `bash -n scripts/backfill-dataset.sh`
- `bash -n scripts/update-leaderboard.sh`

The stacked tip is tree-identical to the original unsplit PR tip.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a manually triggered workflow to regenerate and publish the leaderboard from a selected dataset run.
  * Added scripts for updating the leaderboard and backfilling committed dataset runs.
  * Leaderboard changes are validated and proposed through pull requests.

* **Documentation**
  * Updated CI, methodology, CLI, and workflow guidance to describe the separate dataset and leaderboard processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->