### PR TITLE
fix(results): tolerate the all-failed PTS composite shape (empty Proportion)

### DIFF
--- a/packages/results/src/lib/__fixtures__/fio-all-failed/pts_fio-rand-read--failed.json
+++ b/packages/results/src/lib/__fixtures__/fio-all-failed/pts_fio-rand-read--failed.json
@@ -1,0 +1,5 @@
+{
+  "outcome": "failed",
+  "benchmark": "pts_fio-rand-read",
+  "reason": "PTS batch-run of pts/fio-2.1.0 completed but every trial errored (composite carries no values)"
+}

--- a/packages/results/src/lib/__fixtures__/fio-all-failed/pts_fio-rand-read.xml
+++ b/packages/results/src/lib/__fixtures__/fio-all-failed/pts_fio-rand-read.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0"?>
+<!--Phoronix Test Suite v10.8.4-->
+<!--
+  REAL output recorded 2026-07-21, GH run 29799034615, modal-gvisor disk suite - the fully-failed
+  shape that crashed normalization: every trial of the batch-run errored (the baked fio binary dies
+  instantly under gVisor's reduced ISA), so PTS never ran the result parser and wrote empty
+  <Scale>/<Proportion>/<Value>/<RawString> with the error in the Entry JSON. pts/fio has no
+  profile-level <Proportion> (its direction lives in parser-level <ResultProportion>), which is why
+  the empty Proportion appears here and not in the equally-failed stream shape. The <System> block
+  was removed (recording-host identity, not result data); the <Result> is verbatim.
+-->
+<PhoronixTestSuite>
+  <Generated>
+    <Title>benchmark-pts-fio-rand-read</Title>
+    <LastModified>2026-07-21 03:40:21</LastModified>
+    <TestClient>Phoronix Test Suite v10.8.4</TestClient>
+    <Description>container-other testing on Debian GNU/Linux 13 via the Phoronix Test Suite.</Description>
+  </Generated>
+  <Result>
+    <Identifier>pts/fio-2.1.0</Identifier>
+    <Title>Flexible IO Tester</Title>
+    <AppVersion>3.36</AppVersion>
+    <Arguments>randread libaio 1 4k 1</Arguments>
+    <Description>Type: Random Read - Engine: Linux AIO - Direct: Yes - Block Size: 4KB - Job Count: 1 - Disk Target: Default Test Directory</Description>
+    <Scale></Scale>
+    <Proportion></Proportion>
+    <DisplayFormat>BAR_GRAPH</DisplayFormat>
+    <Data>
+      <Entry>
+        <Identifier>ci</Identifier>
+        <Value></Value>
+        <RawString></RawString>
+        <JSON>{"compiler-options":{"compiler-type":"CC","compiler":"gcc","compiler-options":"-rdynamic -lz -lm -laio -lpthread -ldl -std=gnu99 -ffast-math -include -O3 -fcommon -march=native"},"test-run-times":"0.03:0.03","error":"The test quit with a non-zero exit status. The test quit with a non-zero exit status."}</JSON>
+      </Entry>
+    </Data>
+  </Result>
+</PhoronixTestSuite>

--- a/packages/results/src/lib/extract.test.ts
+++ b/packages/results/src/lib/extract.test.ts
@@ -59,6 +59,27 @@ describe("extractProviderDir", () => {
 		]);
 	});
 
+	it("survives the real fio all-failed bytes: no throw, no results, one recorded failed gap", () => {
+		// The exact shape that crashed disk/modal-gvisor in run 29799034615: a composite whose ONE
+		// Result carries empty <Scale>/<Proportion>/<Value> plus the bench.sh fail_result marker the
+		// producer now writes beside it. The composite must parse (schema tolerance), the empty Result
+		// must be dropped (never a 0-valued straggler), and the marker must surface as a failed gap.
+		// NOTE: the gap id is the LEAF name at this layer — normalize-tree folds it into the suite.
+		const dir = join(import.meta.dir, "__fixtures__/fio-all-failed");
+		const extraction = extractProviderDir(dir, "modal-gvisor");
+		expect(extraction.contributions).toEqual([]);
+		expect(extraction.uncatalogued).toEqual([]);
+		expect(extraction.gaps).toEqual([
+			{
+				scope: "suite",
+				id: "pts_fio-rand-read",
+				outcome: "failed",
+				reason:
+					"PTS batch-run of pts/fio-2.1.0 completed but every trial errored (composite carries no values)",
+			},
+		]);
+	});
+
 	it("extracts every realworld task from a real end-to-end smoke composite.xml, none uncatalogued", () => {
 		// Captured from a real Docker run of the actual install.sh + realworld-runner.sh + mise task
 		// (packages/results/src/lib/__fixtures__/realworld-smoke/ -- see its header comment for

--- a/packages/results/src/lib/extract.ts
+++ b/packages/results/src/lib/extract.ts
@@ -68,9 +68,10 @@ export function extractProviderDir(dir: string, providerId: string): ProviderExt
 			}
 			for (const result of composite.PhoronixTestSuite.Result) {
 				// A <Result> with no <Entry>, or one whose every pass failed (empty <Value> — pts-schema.ts
-				// treats that as "no measurement", not a parse error), carries no sample to aggregate and no
-				// headline value to report. Skip it rather than emit a zero-sample contribution (which would
-				// throw in the normalizer's aggregate([])) or fabricate a 0-valued straggler.
+				// treats that as "no measurement", not a parse error; fio's all-failed shape additionally
+				// empties <Proportion> and <Scale>, tolerated the same way), carries no sample to aggregate
+				// and no headline value to report. Skip it rather than emit a zero-sample contribution
+				// (which would throw in the normalizer's aggregate([])) or fabricate a 0-valued straggler.
 				const headEntry = result.Data.Entry[0];
 				if (!headEntry || headEntry.Value === undefined) continue;
 				const mapped = ptsResultToMetric(result);
@@ -97,7 +98,10 @@ export function extractProviderDir(dir: string, providerId: string): ProviderExt
 							// entry-less results above.
 							value: headEntry.Value,
 							unit: result.Scale,
-							direction: result.Proportion,
+							// The schema narrow makes a valued Result with an empty Proportion unrepresentable;
+							// this guard exists only to convince the type system and degrades to an omitted
+							// (optional) direction if that invariant ever regresses.
+							...(result.Proportion !== "" ? { direction: result.Proportion } : {}),
 							sourceFile: filename,
 						});
 						break;

--- a/packages/results/src/lib/pts-golden.test.ts
+++ b/packages/results/src/lib/pts-golden.test.ts
@@ -80,6 +80,9 @@ describe("golden composite byte-match (design §3.7)", () => {
 			// Surface the offending test+description (not just a count) so a byte-mismatch points straight
 			// at the synthesized id that drifted from the recorded <Description>.
 			const uncatalogued = results.flatMap((result) => {
+				// A fully-failed Result never ran the result parser, so it carries no parser-produced
+				// Scale/Description to byte-match — the extractor skips it (extract.ts) and so does this gate.
+				if (result.Data.Entry.every((e) => e.Value === undefined)) return [];
 				const mapping = ptsResultToMetric(result);
 				return mapping.kind === "uncatalogued"
 					? [`${mapping.test} | "${mapping.description}"`]
@@ -129,6 +132,9 @@ describe("recorded fio fixtures pin the DECLARED disk-suite subset", () => {
 		expect(fioComposites.length).toBeGreaterThan(0);
 		const offenders = fioComposites.flatMap(([name, xml]) =>
 			parsePtsComposite(xml).PhoronixTestSuite.Result.flatMap((result) => {
+				// A fully-failed Result never ran the result parser, so it carries no parser-produced
+				// Scale/Description to byte-match — the extractor skips it (extract.ts) and so does this gate.
+				if (result.Data.Entry.every((e) => e.Value === undefined)) return [];
 				const mapping = ptsResultToMetric(result);
 				if (mapping.kind !== "matched") return [`${name}: uncatalogued "${result.Description}"`];
 				return declared.has(mapping.def.id) ? [] : [`${name}: undeclared ${mapping.def.id}`];

--- a/packages/results/src/lib/pts-schema.ts
+++ b/packages/results/src/lib/pts-schema.ts
@@ -32,7 +32,9 @@ const sampleList = type("string").pipe((raw, ctx) => {
 // every pass of a `<Result>` fails (a real command erroring — expected for realworld CI tasks, not
 // just synthetic PTS microbenchmarks), PTS still emits the `<Result>` but with an empty `<Value>`
 // rather than omitting it. Treated as "no measurement" (undefined), not a parse failure, so one failed
-// option can't throw away every other `<Result>` in the same composite.xml.
+// option can't throw away every other `<Result>` in the same composite.xml. A profile whose Scale and
+// direction come only from the parser level (pts/fio) writes empty `<Scale>`/`<Proportion>` alongside
+// that empty `<Value>` — tolerated the same way (see `ptsResult`'s Proportion union + narrow).
 const numericParse = type("string.numeric.parse");
 const entryValue = type("string").pipe((raw, ctx) => {
 	if (raw.trim() === "") return undefined;
@@ -58,9 +60,21 @@ const ptsResult = type({
 	// Sub-result label; disambiguates multi-result tests when mapping onto the Catalog.
 	"Description?": "string",
 	Scale: "string",
-	Proportion: directionSchema,
+	// "" appears when every pass of a test errored: PTS never runs the result parser, so a profile
+	// whose direction comes only from parser-level <ResultProportion> (pts/fio — no profile-level
+	// <Proportion>) writes <Proportion></Proportion> (and an empty <Scale> alongside). Legal ONLY on
+	// a no-measurement Result (narrow below); any other non-HIB/LIB value is rejected by the union.
+	Proportion: directionSchema.or("''"),
 	Data: { Entry: ptsEntry.array() },
-});
+}).narrow(
+	(result, ctx) =>
+		result.Proportion !== "" ||
+		result.Data.Entry.every((entry) => entry.Value === undefined) ||
+		ctx.reject({
+			path: ["Proportion"],
+			expected: '"HIB" or "LIB" on a Result that carries a measured <Value>',
+		}),
+);
 
 /** Provenance from the `<Generated>` header — which PTS client wrote the file, and when. */
 const ptsGenerated = type({

--- a/packages/results/src/lib/pts.test.ts
+++ b/packages/results/src/lib/pts.test.ts
@@ -76,6 +76,61 @@ describe("parsePtsComposite", () => {
 		expect(result?.Data.Entry[0]?.Value).toBeUndefined();
 	});
 
+	it("tolerates fio's fully-failed shape (empty Proportion AND Scale on a valueless Result)", () => {
+		// pts/fio has no profile-level <Proportion> (its direction lives in parser-level
+		// <ResultProportion>, applied only when a value is parsed), so a fully-failed run writes
+		// <Proportion></Proportion> and <Scale></Scale> beside the empty <Value>. The composite must
+		// still parse — this exact shape crashed disk/modal-gvisor's normalization (run 29799034615) —
+		// and the valued sibling Result must survive untouched.
+		const xml = `<?xml version="1.0"?>
+<PhoronixTestSuite>
+  <Result>
+    <Identifier>pts/node-web-tooling-1.0.1</Identifier><Title>OK</Title>
+    <Scale>runs/s</Scale><Proportion>HIB</Proportion>
+    <Data><Entry><Value>20.5</Value></Entry></Data>
+  </Result>
+  <Result>
+    <Identifier>pts/fio-2.1.0</Identifier><Title>Flexible IO Tester</Title>
+    <Scale></Scale><Proportion></Proportion>
+    <Data><Entry><Value></Value><RawString></RawString></Entry></Data>
+  </Result>
+</PhoronixTestSuite>`;
+		const results = parsePtsComposite(xml).PhoronixTestSuite.Result;
+		expect(results[0]?.Data.Entry[0]?.Value).toBe(20.5);
+		expect(results[1]?.Proportion).toBe("");
+		expect(results[1]?.Data.Entry[0]?.Value).toBeUndefined();
+	});
+
+	it("rejects a valued Result with an empty Proportion", () => {
+		// The tolerance is scoped to no-measurement Results only: a real value with no direction cannot
+		// be ranked, so it must fail loudly rather than parse into an undirected measurement.
+		const xml = `<?xml version="1.0"?>
+<PhoronixTestSuite><Result>
+  <Identifier>pts/x-1.0</Identifier><Title>X</Title><Scale>Seconds</Scale><Proportion></Proportion>
+  <Data><Entry><Value>4.2</Value></Entry></Data>
+</Result></PhoronixTestSuite>`;
+		expect(() => parsePtsComposite(xml)).toThrow(/invalid PTS composite\.xml/);
+		expect(() => parsePtsComposite(xml)).toThrow(/Proportion/);
+	});
+
+	it("rejects a garbage Proportion regardless of values", () => {
+		const xml = `<?xml version="1.0"?>
+<PhoronixTestSuite><Result>
+  <Identifier>pts/x-1.0</Identifier><Title>X</Title><Scale></Scale><Proportion>FOO</Proportion>
+  <Data><Entry><Value></Value></Entry></Data>
+</Result></PhoronixTestSuite>`;
+		expect(() => parsePtsComposite(xml)).toThrow(/invalid PTS composite\.xml/);
+	});
+
+	it("rejects an empty Proportion when ANY entry carries a measured value (mixed entries)", () => {
+		const xml = `<?xml version="1.0"?>
+<PhoronixTestSuite><Result>
+  <Identifier>pts/x-1.0</Identifier><Title>X</Title><Scale>runs/s</Scale><Proportion></Proportion>
+  <Data><Entry><Value>5</Value></Entry><Entry><Value></Value></Entry></Data>
+</Result></PhoronixTestSuite>`;
+		expect(() => parsePtsComposite(xml)).toThrow(/Proportion/);
+	});
+
 	it("rejects a malformed RawString sample token at the schema boundary", () => {
 		// A non-numeric per-pass token fails the schema's sampleList morph, so the whole composite is
 		// rejected loudly here rather than the bad token silently vanishing during aggregation.


### PR DESCRIPTION
**Bench-matrix green — every suite×provider cell measuring or honestly gapped**
Fixes the 10 root causes behind the failures and silent metric holes of runs [29799034615](https://github.com/starslingdev/hpc-sandbox-benchmarks/actions/runs/29799034615) and [29850811070](https://github.com/starslingdev/hpc-sandbox-benchmarks/actions/runs/29850811070). Shipped as a 13-PR stack (merge bottom-up, each branch independently green):
1. #229 — results: tolerate the all-failed PTS composite shape (empty Proportion)
2. #230 — results: record attempted-but-empty catalogued Results as evidence
3. #231 — results: suite-shortfall gaps + leaf-marker folding
4. #232 — results: gaps for PTS duplicate-value fio twin drops
5. #233 — leaderboard: no fabricated missing-rows for never-dispatched providers
6. #234 — realworld: per-task timeout + cgroup-v2 memory containment
7. #235 — harness: failed gap on sandbox-creation failure
8. #236 — harness: detached log read-back + collect retries
9. #237 — bench: loud PTS leaf guards; stream + pybench measure again
10. #238 — templates: pgbench bake fix (pkg-config), payload assertion, portable fio, v4
11. #239 — fast-cli: settle gated on upload-phase stability
12. #240 — providers: Daytona region pin actually reaches the API; both variants us-west-2
13. #241 — ci: dataset-PR PAT fallback; e2b disk-skip notes

↑ **This PR is #229 (1/13)**.

---

An all-trials-failed fio composite carries <Proportion></Proportion> next to
its empty <Value>s (fio-2.1.0 has no profile-level Proportion; its HIB
direction lives in parser-level ResultProportion, applied only when a value
parses). The strict HIB|LIB schema rejected the whole composite, so
disk/modal-gvisor died at the Normalize step with NO recorded gap and lost
hardlink's valid samples (runs 29799034615, 29850811070).

The one schema now admits an empty Proportion ONLY on a Result carrying no
measured Value (arktype .or + .narrow); a valued Result with an empty
Proportion still rejects. The extractor's existing empty-Value skip then
drops the tolerated Result. Fixture is the real disk/modal-gvisor bytes,
including the leaf failed-marker a later PR teaches bench.sh to write
beside it (the marker parser already exists; its gap id is folded into the
suite by the normalizer two PRs up).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Tolerates fully-failed PTS fio composites (empty Proportion/Scale with empty Value) so parsing and normalization don’t crash, and we record a failed suite gap instead of losing other results.

- **Bug Fixes**
  - Relaxed `pts-schema.ts` to allow `Proportion=""` only when all entries have no measured `Value`; valued or mixed entries still reject, and non-HIB/LIB values reject.
  - Kept extractor logic to skip valueless results and guarded direction mapping in `extract.ts` (omit `direction` when `Proportion=""`).
  - Added real fio-all-failed fixtures and tests: parser tolerance, extraction records a failed gap, and golden checks ignore fully-failed results.

<sup>Written for commit d73cc3323ce95f43940588612c5f919f52ee02ef. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/starslingdev/hpc-sandbox-benchmarks/pull/229?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of fully failed benchmark runs with no measurement values.
  * Prevented empty or invalid measurement directions from appearing in extracted results.
  * Ensured failed runs are recorded as failures rather than zero-valued results.

* **Tests**
  * Added coverage for failed benchmark fixtures and validation of empty measurement data.
  * Expanded checks for invalid result combinations and failure reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->