### PR TITLE
feat(results): record attempted-but-empty catalogued Results as evidence

### DIFF
--- a/packages/results/src/lib/extract.test.ts
+++ b/packages/results/src/lib/extract.test.ts
@@ -1,5 +1,6 @@
-import { describe, expect, it } from "bun:test";
-import { readFileSync } from "node:fs";
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { extractProviderDir } from "./extract.ts";
 import { parsePtsComposite, ptsResultToMetric } from "./pts.ts";
@@ -34,6 +35,10 @@ describe("extractProviderDir", () => {
 		expect(extraction.uncatalogued).toEqual([]);
 	});
 
+	it("records no attempted-empty evidence when every Result carried a value", () => {
+		expect(extraction.attemptedEmpty).toEqual([]);
+	});
+
 	it("carries appVersion and arguments provenance when the <Result> populates them", () => {
 		const dir = join(import.meta.dir, "__fixtures__/provenance");
 		expect(extractProviderDir(dir, "daytona").contributions).toEqual([
@@ -65,10 +70,13 @@ describe("extractProviderDir", () => {
 		// producer now writes beside it. The composite must parse (schema tolerance), the empty Result
 		// must be dropped (never a 0-valued straggler), and the marker must surface as a failed gap.
 		// NOTE: the gap id is the LEAF name at this layer — normalize-tree folds it into the suite.
+		// attemptedEmpty stays empty: the all-failed fio Result has an empty <Scale>, so it cannot match
+		// the scale-pinned fio catalog entries (uncatalogued empty Results record no evidence).
 		const dir = join(import.meta.dir, "__fixtures__/fio-all-failed");
 		const extraction = extractProviderDir(dir, "modal-gvisor");
 		expect(extraction.contributions).toEqual([]);
 		expect(extraction.uncatalogued).toEqual([]);
+		expect(extraction.attemptedEmpty).toEqual([]);
 		expect(extraction.gaps).toEqual([
 			{
 				scope: "suite",
@@ -105,6 +113,114 @@ describe("extractProviderDir", () => {
 			expect(contribution.samples.length).toBeGreaterThan(0);
 			for (const sample of contribution.samples) expect(sample).toBeGreaterThan(0);
 		}
+	});
+
+	describe("attempted-empty evidence (the suite-shortfall input)", () => {
+		let dir: string;
+		beforeEach(() => {
+			dir = mkdtempSync(join(tmpdir(), "extract-empty-"));
+		});
+		afterEach(() => {
+			rmSync(dir, { recursive: true, force: true });
+		});
+
+		const result = (identifier: string, scale: string, value: string): string => `  <Result>
+    <Identifier>${identifier}</Identifier><Title>T</Title>
+    <Scale>${scale}</Scale><Proportion>LIB</Proportion>
+    <Data><Entry><Value>${value}</Value></Entry></Data>
+  </Result>`;
+		const composite = (...results: string[]): string =>
+			`<?xml version="1.0"?>\n<PhoronixTestSuite>\n${results.join("\n")}\n</PhoronixTestSuite>`;
+
+		it("records a CATALOGUED empty Result as attempted-empty, with no contribution or straggler", () => {
+			writeFileSync(
+				join(dir, "pts_pybench.xml"),
+				composite(result("pts/pybench-1.1.3", "Milliseconds", "")),
+			);
+			const extraction = extractProviderDir(dir, "e2b");
+			expect(extraction.contributions).toEqual([]);
+			expect(extraction.uncatalogued).toEqual([]);
+			expect(extraction.attemptedEmpty).toEqual([
+				{ metricId: "pybench_milliseconds", sourceFile: "pts_pybench.xml" },
+			]);
+		});
+
+		it("records NOTHING for an uncatalogued empty Result (only declared ids join the diff)", () => {
+			writeFileSync(
+				join(dir, "pts_mystery.xml"),
+				composite(result("pts/not-in-catalog-1.0.0", "Seconds", "")),
+			);
+			const extraction = extractProviderDir(dir, "e2b");
+			expect(extraction.attemptedEmpty).toEqual([]);
+			expect(extraction.uncatalogued).toEqual([]);
+		});
+
+		it("splits a mixed composite: the valued Result contributes, the empty one is evidence", () => {
+			// The realworld shape: individual failed CI tasks post empty <Value> beside successful ones.
+			writeFileSync(
+				join(dir, "pts_mixed.xml"),
+				composite(
+					result("pts/pybench-1.1.3", "Milliseconds", ""),
+					result("pts/sqlite-speedtest-1.0.1", "Seconds", "45.1"),
+				),
+			);
+			const extraction = extractProviderDir(dir, "e2b");
+			expect(extraction.contributions.map((c) => c.metricId)).toEqual(["sqlite_speedtest_seconds"]);
+			expect(extraction.attemptedEmpty).toEqual([
+				{ metricId: "pybench_milliseconds", sourceFile: "pts_mixed.xml" },
+			]);
+		});
+
+		it("does not treat an empty leading Entry as attempted-empty when a later Entry has a value", () => {
+			writeFileSync(
+				join(dir, "pts_pybench.xml"),
+				`<?xml version="1.0"?>
+<PhoronixTestSuite>
+  <Result>
+    <Identifier>pts/pybench-1.1.3</Identifier><Title>T</Title>
+    <Scale>Milliseconds</Scale><Proportion>LIB</Proportion>
+    <Data>
+      <Entry><Value></Value></Entry>
+      <Entry><Value>475</Value><RawString>474:476</RawString></Entry>
+    </Data>
+  </Result>
+</PhoronixTestSuite>`,
+			);
+			const extraction = extractProviderDir(dir, "e2b");
+			expect(extraction.contributions).toEqual([
+				{
+					metricId: "pybench_milliseconds",
+					samples: [474, 476],
+					sourceFile: "pts_pybench.xml",
+				},
+			]);
+			expect(extraction.attemptedEmpty).toEqual([]);
+		});
+
+		it("keeps duplicate cross-file observations isolated by their containing-file provenance", () => {
+			// PTS TEST_RESULTS_NAME reuse can copy a stale Result into another composite. The extractor
+			// records what each file contains; the normalizer reconciles the duplicate by metricId.
+			writeFileSync(
+				join(dir, "pts_a-empty.xml"),
+				composite(result("pts/pybench-1.1.3", "Milliseconds", "")),
+			);
+			writeFileSync(
+				join(dir, "pts_z-contaminated.xml"),
+				composite(result("pts/pybench-1.1.3", "Milliseconds", "475")),
+			);
+
+			const extraction = extractProviderDir(dir, "e2b");
+			expect(extraction.contributions).toEqual([
+				{
+					metricId: "pybench_milliseconds",
+					samples: [475],
+					sourceFile: "pts_z-contaminated.xml",
+				},
+			]);
+			expect(extraction.attemptedEmpty).toEqual([
+				{ metricId: "pybench_milliseconds", sourceFile: "pts_a-empty.xml" },
+			]);
+		});
 	});
 
 	it("maps every realworld <Result> onto the catalog, including the 7 all-passes-failed ones", () => {

--- a/packages/results/src/lib/extract.ts
+++ b/packages/results/src/lib/extract.ts
@@ -21,12 +21,32 @@ export interface SampleContribution {
 	arguments?: string;
 }
 
+/** A catalogued Metric that was attempted but produced no measurement (every pass errored). */
+export interface AttemptedEmptyResult {
+	metricId: string;
+	/**
+	 * The composite that contained this Result. PTS result-name reuse can duplicate one metric across
+	 * composites, so this is provenance, not proof that the filename's leaf produced the Result;
+	 * consumers must reconcile attempted-empty and measured observations by metricId.
+	 */
+	sourceFile: string;
+}
+
 /** Everything one provider directory yields: catalogued samples, stragglers, and gap markers. */
 export interface ProviderExtraction {
 	contributions: SampleContribution[];
 	uncatalogued: UncataloguedResult[];
 	/** Suite-scoped gaps read from `*--skipped.json` / `*--failed.json` markers. */
 	gaps: ResultGap[];
+	/**
+	 * CATALOGUED `<Result>`s that were attempted and produced no measurement (the all-passes-failed
+	 * empty-`<Value>` shape). Evidence, not a gap yet: the normalizer diffs these against the suite's
+	 * declared metrics to emit its suite-shortfall gap. Deliberately restricted to catalogued ids —
+	 * an uncatalogued empty Result records nothing, because only declared metrics participate in the
+	 * shortfall diff (an expectation-based diff would fabricate gaps for disk's probe-dependent fio
+	 * variants and PTS's dropped-duplicate Results, which are legitimately absent, not lost).
+	 */
+	attemptedEmpty: AttemptedEmptyResult[];
 	/**
 	 * HOST-side specs read from a composite's `<System>` fingerprint (the underlying machine, not the
 	 * sandbox quota), when any composite in this directory carried one. The first composite with a
@@ -47,7 +67,12 @@ function readJson(text: string): unknown {
 
 /** Extract every catalogued/uncatalogued result and gap marker from one provider's raw directory. */
 export function extractProviderDir(dir: string, providerId: string): ProviderExtraction {
-	const out: ProviderExtraction = { contributions: [], uncatalogued: [], gaps: [] };
+	const out: ProviderExtraction = {
+		contributions: [],
+		uncatalogued: [],
+		gaps: [],
+		attemptedEmpty: [],
+	};
 
 	// `withFileTypes` so a subdirectory can't be fed to readFileSync (EISDIR); sort for determinism.
 	const entries = readdirSync(dir, { withFileTypes: true }).sort((a, b) =>
@@ -67,14 +92,22 @@ export function extractProviderDir(dir: string, providerId: string): ProviderExt
 				if (Object.keys(host).length > 0) out.observedHost = host;
 			}
 			for (const result of composite.PhoronixTestSuite.Result) {
-				// A <Result> with no <Entry>, or one whose every pass failed (empty <Value> — pts-schema.ts
+				const mapped = ptsResultToMetric(result);
+				// A <Result> with no measured <Entry>, or one whose every pass failed (empty <Value> — pts-schema.ts
 				// treats that as "no measurement", not a parse error; fio's all-failed shape additionally
 				// empties <Proportion> and <Scale>, tolerated the same way), carries no sample to aggregate
 				// and no headline value to report. Skip it rather than emit a zero-sample contribution
-				// (which would throw in the normalizer's aggregate([])) or fabricate a 0-valued straggler.
-				const headEntry = result.Data.Entry[0];
-				if (!headEntry || headEntry.Value === undefined) continue;
-				const mapped = ptsResultToMetric(result);
+				// (which would throw in the normalizer's aggregate([])) or fabricate a 0-valued straggler —
+				// but record a CATALOGUED skip as attempted-empty evidence first, so the normalizer's
+				// suite-shortfall gap can name the declared metrics that were attempted and lost. Inspect every
+				// Entry: PTS can preserve an empty entry before a later measured one.
+				const measuredEntry = result.Data.Entry.find((entry) => entry.Value !== undefined);
+				if (!measuredEntry || measuredEntry.Value === undefined) {
+					if (mapped.kind === "matched") {
+						out.attemptedEmpty.push({ metricId: mapped.def.id, sourceFile: filename });
+					}
+					continue;
+				}
 				switch (mapped.kind) {
 					case "matched":
 						// Carry the profile version + option arguments as provenance, but only when PTS actually
@@ -94,9 +127,8 @@ export function extractProviderDir(dir: string, providerId: string): ProviderExt
 							// `<Scale>` matched no pin collapse onto one id and the dedupe downstream
 							// (normalize-tree) silently drops the second measurement.
 							id: `${mapped.test}::${mapped.description || "default"}::${mapped.scale}`,
-							// Entry[0].Value is a guaranteed number — the schema parses it and we skipped the
-							// entry-less results above.
-							value: headEntry.Value,
+							// Value is a guaranteed number — the schema parses it and we selected a measured Entry.
+							value: measuredEntry.Value,
 							unit: result.Scale,
 							// The schema narrow makes a valued Result with an empty Proportion unrepresentable;
 							// this guard exists only to convince the type system and degrades to an omitted

--- a/packages/results/src/lib/pts.test.ts
+++ b/packages/results/src/lib/pts.test.ts
@@ -174,6 +174,19 @@ describe("resultSamples", () => {
 		expect(result && resultSamples(result)).toEqual([]);
 	});
 
+	it("uses a later measured Entry when PTS preserves an empty leading Entry", () => {
+		const xml = `<?xml version="1.0"?>
+<PhoronixTestSuite><Result>
+  <Identifier>pts/x-1.0</Identifier><Title>X</Title><Scale>Seconds</Scale><Proportion>LIB</Proportion>
+  <Data>
+    <Entry><Value></Value><RawString></RawString></Entry>
+    <Entry><Value>4.2</Value><RawString>4.1:4.3</RawString></Entry>
+  </Data>
+</Result></PhoronixTestSuite>`;
+		const result = parsePtsComposite(xml).PhoronixTestSuite.Result[0];
+		expect(result && resultSamples(result)).toEqual([4.1, 4.3]);
+	});
+
 	it("returns no samples for an entry-less result (nothing to aggregate)", () => {
 		// The schema permits Data.Entry: [] (`.array()`); resultSamples reports it honestly as []
 		// rather than fabricating a value, so the extractor can skip the measurement-less result.

--- a/packages/results/src/lib/pts.ts
+++ b/packages/results/src/lib/pts.ts
@@ -42,12 +42,13 @@ export function versionlessTest(identifier: string): string {
  * The per-pass samples behind a Result's headline value, falling back to the single reported value
  * when PTS emitted no per-pass samples. `RawString` is already a validated `number[]` (parsed at the
  * schema edge, pts-schema.ts) — a malformed token threw in `parsePtsComposite`, so nothing is
- * silently dropped here. One `<Entry>` per run (the harness writes one), so this reads the first.
- * `[]` when the option's every pass failed (`Value` undefined, pts-schema.ts) — no measurement, not
- * an error.
+ * silently dropped here. The harness normally writes one `<Entry>`, but PTS may preserve an empty
+ * entry before a later measured one; use the first entry that actually carries a value so that shape
+ * is not misclassified as an all-passes failure. `[]` when every entry is empty (`Value` undefined,
+ * pts-schema.ts) — no measurement, not an error.
  */
 export function resultSamples(result: PtsResult): number[] {
-	const entry = result.Data.Entry[0];
+	const entry = result.Data.Entry.find((candidate) => candidate.Value !== undefined);
 	if (!entry || entry.Value === undefined) return [];
 	return entry.RawString && entry.RawString.length > 0 ? entry.RawString : [entry.Value];
 }


### PR DESCRIPTION
**Bench-matrix green — every suite×provider cell measuring or honestly gapped**
Fixes the 10 root causes behind the failures and silent metric holes of runs [29799034615](https://github.com/starslingdev/hpc-sandbox-benchmarks/actions/runs/29799034615) and [29850811070](https://github.com/starslingdev/hpc-sandbox-benchmarks/actions/runs/29850811070). Shipped as a 13-PR stack (merge bottom-up, each branch independently green):
1. #229 — results: tolerate the all-failed PTS composite shape (empty Proportion)
2. #230 — results: record attempted-but-empty catalogued Results as evidence
3. #231 — results: suite-shortfall gaps + leaf-marker folding
4. #232 — results: gaps for PTS duplicate-value fio twin drops
5. #233 — leaderboard: no fabricated missing-rows for never-dispatched providers
6. #234 — realworld: per-task timeout + cgroup-v2 memory containment
7. #235 — harness: failed gap on sandbox-creation failure
8. #236 — harness: detached log read-back + collect retries
9. #237 — bench: loud PTS leaf guards; stream + pybench measure again
10. #238 — templates: pgbench bake fix (pkg-config), payload assertion, portable fio, v4
11. #239 — fast-cli: settle gated on upload-phase stability
12. #240 — providers: Daytona region pin actually reaches the API; both variants us-west-2
13. #241 — ci: dataset-PR PAT fallback; e2b disk-skip notes

↑ **This PR is #230 (2/13)**.

---

PTS exits 0 even when every trial of a test fails — the composite still
carries the <Result>, just with empty <Value>s. The extractor used to skip
those silently, which is how pgbench produced zero metrics on every
provider for its entire life without a single gap, straggler, or red job.

The extractor now records a skipped-but-CATALOGUED Result as
attempted-empty evidence (metricId + sourceFile). Deliberately restricted
to catalogued ids: an expectation-based diff would fabricate gaps for
disk's probe-dependent fio variants and PTS's dropped-duplicate Results,
which are legitimately absent rather than lost. Pure-additive carrier —
the next PR's suite-shortfall gap derivation is the consumer.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Record catalogued PTS results that were attempted but produced no measurement as evidence during extraction. This prevents silent drops and lets downstream suite-shortfall gaps name missing metrics.

- **New Features**
  - Added `attemptedEmpty` to `ProviderExtraction` (items are `{ metricId, sourceFile }`).
  - When a catalogued `<Result>` has no measured entry (every `<Entry>` lacks a `<Value>`), record it in `attemptedEmpty` and emit no contribution or straggler; if any later `<Entry>` has a value, treat it as measured (checks all entries, not just the first).
  - Ignore uncatalogued empty results (e.g., fio all-failed with empty `<Scale>`); evidence attribution is per-file for duplicate cross-file observations.

<sup>Written for commit 9f9cf87ac9539e42d117d20df4af58785af2ee66. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/starslingdev/hpc-sandbox-benchmarks/pull/230?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved extraction for PTS results that include leading empty entries or missing measurements.
  * Uses the first measured entry when available, avoiding incorrect all-fail handling.
  * Preserves catalogued metrics with no measurements as “attempted” evidence for more accurate reporting.
  * Ensures evidence attribution remains isolated per source file to prevent cross-file mixing.
* **Tests**
  * Expanded coverage for empty, mixed, duplicate/contaminated, and partially measured scenarios, including leading-empty composites.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->