### PR TITLE
feat(results): emit suite-shortfall gaps and fold leaf markers under their suite

### DIFF
--- a/packages/results/src/index.test.ts
+++ b/packages/results/src/index.test.ts
@@ -37,9 +37,11 @@ describe("normalizeResultsTree", () => {
 		expect(daytona?.gaps).toEqual([
 			{
 				scope: "suite",
-				id: "pts_git",
+				// The fixture is the legacy flat leaf-marker layout; normalization recovers the registered
+				// suite from Git's catalog identity and preserves the leaf in the reason.
+				id: "system",
 				outcome: "skipped",
-				reason: "phoronix-test-suite not installed",
+				reason: "pts_git: phoronix-test-suite not installed",
 			},
 		]);
 		expect(daytona?.specMatched).toBe(true);

--- a/packages/results/src/lib/aggregate.test.ts
+++ b/packages/results/src/lib/aggregate.test.ts
@@ -281,3 +281,50 @@ describe("aggregateRuns", () => {
 		).toBe(true);
 	});
 });
+
+describe("aggregateRuns suite-shortfall gap folding", () => {
+	// The normalizer's shortfall reason is byte-deterministic exactly so this (scope, id, outcome,
+	// reason) fold collapses identical shortfalls across replicate shards to ONE recorded gap.
+	const shortfall = (reason: string) => ({
+		scope: "suite" as const,
+		id: "memory" as const,
+		outcome: "failed" as const,
+		reason,
+	});
+	const reason =
+		"PTS ran but every trial failed for 2 of 4 declared metrics: stream_type_add (memory/pts_stream.xml), stream_type_triad (memory/pts_stream.xml) — attempted, no value recorded";
+
+	it("folds byte-identical shortfall gaps across replicate shards into one", () => {
+		const r0 = shard(
+			[{ ...provider("daytona-vm", []), gaps: [shortfall(reason)] }],
+			"2026-06-01T00:00:00.000Z",
+			0,
+		);
+		const r1 = shard(
+			[{ ...provider("daytona-vm", []), gaps: [shortfall(reason)] }],
+			"2026-06-01T00:00:00.000Z",
+			1,
+		);
+		const daytona = aggregateRuns([r0, r1]).providers.find((p) => p.providerId === "daytona-vm");
+		expect(daytona?.gaps).toEqual([shortfall(reason)]);
+	});
+
+	it("keeps both gaps when replicate shards report divergent shortfall reasons", () => {
+		// Divergent replicates are two distinct facts (different metrics were lost in each sandbox);
+		// folding them would drop whichever arrived second — accepted keep+warn behavior.
+		const other =
+			"PTS ran but every trial failed for 1 of 4 declared metrics: stream_type_add (memory/pts_stream.xml) — attempted, no value recorded";
+		const r0 = shard(
+			[{ ...provider("daytona-vm", []), gaps: [shortfall(reason)] }],
+			"2026-06-01T00:00:00.000Z",
+			0,
+		);
+		const r1 = shard(
+			[{ ...provider("daytona-vm", []), gaps: [shortfall(other)] }],
+			"2026-06-01T00:00:00.000Z",
+			1,
+		);
+		const daytona = aggregateRuns([r0, r1]).providers.find((p) => p.providerId === "daytona-vm");
+		expect(daytona?.gaps).toEqual([shortfall(reason), shortfall(other)]);
+	});
+});

--- a/packages/results/src/lib/normalize-tree.test.ts
+++ b/packages/results/src/lib/normalize-tree.test.ts
@@ -5,6 +5,7 @@ import { join } from "node:path";
 import {
 	ECONOMICS_METRIC_IDS,
 	getProvider,
+	harnessGapMarkerJson,
 	hourlyCostAtTargetSpec,
 } from "@sandbox-benchmarks/schema";
 import { normalizeProviderDir } from "./normalize-tree.ts";
@@ -251,5 +252,374 @@ describe("normalizeProviderDir reads the suite-tagged layout", () => {
 		} finally {
 			warn.mockRestore();
 		}
+	});
+});
+
+// A STREAM composite whose per-type Results can be individually valued or empty — the shape a
+// partially-failed memory suite writes (each Result maps to one stream_type_* metric).
+function streamComposite(entries: Array<[type: string, value: string]>): string {
+	const results = entries
+		.map(
+			([type, value]) => `  <Result>
+    <Identifier>pts/stream-1.3.4</Identifier>
+    <Title>Stream</Title>
+    <Description>Type: ${type}</Description>
+    <Scale>MB/s</Scale><Proportion>HIB</Proportion>
+    <Data><Entry><Value>${value}</Value></Entry></Data>
+  </Result>`,
+		)
+		.join("\n");
+	return `<?xml version="1.0"?>\n<PhoronixTestSuite>\n${results}\n</PhoronixTestSuite>`;
+}
+
+// An all-trials-failed node-web-tooling composite: the Result is present but carries no value.
+// An all-trials-failed pybench composite (system suite's second leaf in the leaf-dedupe tests).
+const emptyPybenchComposite = `<?xml version="1.0"?>
+<PhoronixTestSuite>
+  <Result>
+    <Identifier>pts/pybench-1.1.3</Identifier>
+    <Title>PyBench</Title>
+    <Scale>Milliseconds</Scale><Proportion>LIB</Proportion>
+    <Data><Entry><Value></Value><RawString></RawString></Entry></Data>
+  </Result>
+</PhoronixTestSuite>`;
+
+const emptyNodeComposite = `<?xml version="1.0"?>
+<PhoronixTestSuite>
+  <Result>
+    <Identifier>pts/node-web-tooling-1.0.1</Identifier>
+    <Title>Node.js V8 Web Tooling Benchmark</Title>
+    <Scale>runs/s</Scale><Proportion>HIB</Proportion>
+    <Data><Entry><Value></Value><RawString></RawString></Entry></Data>
+  </Result>
+</PhoronixTestSuite>`;
+
+describe("normalizeProviderDir suite-shortfall gaps and leaf-marker folding", () => {
+	let root: string;
+	let providerDir: string;
+	beforeEach(() => {
+		root = mkdtempSync(join(tmpdir(), "norm-shortfall-"));
+		providerDir = join(root, "daytona-vm");
+		mkdirSync(providerDir);
+	});
+	afterEach(() => {
+		rmSync(root, { recursive: true, force: true });
+	});
+
+	it("folds a leaf-named bash marker into its suite's gap id", () => {
+		// resultGapSchema's vocabulary: a suite-scoped gap's id IS the suite name. A bash fail_result
+		// marker carries the LEAF name, which — unfolded — would enter the leaderboard's missing-suite
+		// denominator as a bogus 'suite' and accuse every healthy provider of missing it. The fold keeps
+		// the leaf identity in the reason. The surviving hardlink metric keeps disk covered (keep+warn).
+		const suiteDir = join(providerDir, "disk");
+		mkdirSync(suiteDir);
+		writeFileSync(
+			join(suiteDir, "pts_fio-rand-read--failed.json"),
+			'{"outcome":"failed","benchmark":"pts_fio-rand-read","reason":"PTS batch-run of pts/fio-2.1.0 completed but every trial errored (composite carries no values)"}\n',
+		);
+		writeFileSync(
+			join(suiteDir, "pts_hardlink.xml"),
+			`<?xml version="1.0"?>
+<PhoronixTestSuite>
+  <Result>
+    <Identifier>local/hardlink-1.0.0</Identifier>
+    <Title>Hardlink Throughput</Title>
+    <Scale>bogo ops/s</Scale><Proportion>HIB</Proportion>
+    <Data><Entry><Value>2.46</Value><RawString>2.39:2.53</RawString></Entry></Data>
+  </Result>
+</PhoronixTestSuite>`,
+		);
+
+		const run = normalizeProviderDir(root, "daytona-vm");
+		expect(run.gaps).toEqual([
+			{
+				scope: "suite",
+				id: "disk",
+				outcome: "failed",
+				reason:
+					"pts_fio-rand-read: PTS batch-run of pts/fio-2.1.0 completed but every trial errored (composite carries no values)",
+			},
+		]);
+		expect(run.suitesCovered).toEqual(["disk"]);
+		expect(run.validationStatus).toBe("validated");
+	});
+
+	it("TOTAL LOSS: an all-empty catalogued composite becomes ONE suite/failed shortfall gap", () => {
+		// PTS exits 0 on this shape, so without the shortfall the suite would be a green job with no
+		// metric and no gap — the exact silence that made pgbench vanish from three published runs.
+		const suiteDir = join(providerDir, "cpu-node");
+		mkdirSync(suiteDir);
+		writeFileSync(join(suiteDir, "pts_node-web-tooling.xml"), emptyNodeComposite);
+
+		const run = normalizeProviderDir(root, "daytona-vm");
+		expect(run.gaps).toEqual([
+			{
+				scope: "suite",
+				id: "cpu-node",
+				outcome: "failed",
+				reason:
+					"PTS ran but every trial failed for 1 of 1 declared metrics: node_web_tooling_runs_per_s (cpu-node/pts_node-web-tooling.xml) — attempted, no value recorded",
+			},
+		]);
+		expect(run.suitesCovered).toEqual([]);
+		expect(run.validationStatus).toBe("pending");
+	});
+
+	it("MARKER DEDUPE: a harness whole-suite failed marker is not doubled by a shortfall gap", () => {
+		const suiteDir = join(providerDir, "cpu-node");
+		mkdirSync(suiteDir);
+		writeFileSync(join(suiteDir, "pts_node-web-tooling.xml"), emptyNodeComposite);
+		writeFileSync(
+			join(suiteDir, "sandbox-daytona-vm-cpu-node--failed.json"),
+			harnessGapMarkerJson("daytona-vm", "cpu-node", "failed", "PTS produced no result"),
+		);
+
+		const run = normalizeProviderDir(root, "daytona-vm");
+		// Exactly ONE cpu-node gap — the marker's reason wins; the shortfall stays suppressed.
+		expect(run.gaps).toEqual([
+			{ scope: "suite", id: "cpu-node", outcome: "failed", reason: "PTS produced no result" },
+		]);
+	});
+
+	it("FLAT MARKER DEDUPE: a legacy harness failure still mutes the suite shortfall", () => {
+		const suiteDir = join(providerDir, "cpu-node");
+		mkdirSync(suiteDir);
+		writeFileSync(join(suiteDir, "pts_node-web-tooling.xml"), emptyNodeComposite);
+		// Mixed-layout replay: the composite was already nested, but the harness marker still landed at
+		// provider root. Its registered suite id is enough to retain whole-suite suppression.
+		writeFileSync(
+			join(providerDir, "sandbox-daytona-vm-cpu-node--failed.json"),
+			harnessGapMarkerJson("daytona-vm", "cpu-node", "failed", "legacy flat failure"),
+		);
+
+		const run = normalizeProviderDir(root, "daytona-vm");
+		expect(run.gaps).toEqual([
+			{ scope: "suite", id: "cpu-node", outcome: "failed", reason: "legacy flat failure" },
+		]);
+	});
+
+	it("LEAF-SCOPED DEDUPE: a folded leaf failure mutes only its own leaf, not a sibling's loss", () => {
+		// system has two leaves here: git's failure is recorded by its own folded marker, while
+		// pybench was attempted-and-empty with NO marker. The git marker must not swallow pybench's
+		// loss — the shortfall gap still surfaces, naming only the sibling's metric.
+		const suiteDir = join(providerDir, "system");
+		mkdirSync(suiteDir);
+		writeFileSync(
+			join(suiteDir, "pts_git--failed.json"),
+			'{"outcome":"failed","benchmark":"pts_git","reason":"PTS batch-run of pts/git completed but every trial errored (composite carries no values)"}\n',
+		);
+		writeFileSync(join(suiteDir, "pts_pybench.xml"), emptyPybenchComposite);
+
+		const run = normalizeProviderDir(root, "daytona-vm");
+		expect(run.gaps).toEqual([
+			{
+				scope: "suite",
+				id: "system",
+				outcome: "failed",
+				reason:
+					"pts_git: PTS batch-run of pts/git completed but every trial errored (composite carries no values)",
+			},
+			{
+				scope: "suite",
+				id: "system",
+				outcome: "failed",
+				reason:
+					"PTS ran but every trial failed for 1 of 3 declared metrics: pybench_milliseconds (system/pts_pybench.xml) — attempted, no value recorded",
+			},
+		]);
+	});
+
+	it("LEAF-SCOPED DEDUPE: a folded leaf failure IS its own leaf's record — no doubled shortfall", () => {
+		// The bash guard writes the marker AND leaves the empty composite behind; the marker already
+		// names this leaf's loss, so a shortfall repeating the same leaf's metric would double-count.
+		const suiteDir = join(providerDir, "system");
+		mkdirSync(suiteDir);
+		writeFileSync(
+			join(suiteDir, "pts_pybench--failed.json"),
+			'{"outcome":"failed","benchmark":"pts_pybench","reason":"PTS batch-run of pts/pybench completed but every trial errored (composite carries no values)"}\n',
+		);
+		writeFileSync(join(suiteDir, "pts_pybench.xml"), emptyPybenchComposite);
+
+		const run = normalizeProviderDir(root, "daytona-vm");
+		expect(run.gaps).toEqual([
+			{
+				scope: "suite",
+				id: "system",
+				outcome: "failed",
+				reason:
+					"pts_pybench: PTS batch-run of pts/pybench completed but every trial errored (composite carries no values)",
+			},
+		]);
+	});
+
+	it("CONTAMINATION: a marker cannot mute a different test merely because its Result leaked into that filename", () => {
+		const suiteDir = join(providerDir, "system");
+		mkdirSync(suiteDir);
+		writeFileSync(
+			join(suiteDir, "pts_git--failed.json"),
+			'{"outcome":"failed","benchmark":"pts_git","reason":"git failed"}\n',
+		);
+		// PTS contamination can copy PyBench's Result under Git's result name. The metric's catalogued
+		// pts/pybench identity — not this misleading filename — decides which marker owns the loss.
+		writeFileSync(join(suiteDir, "pts_git.xml"), emptyPybenchComposite);
+
+		const run = normalizeProviderDir(root, "daytona-vm");
+		expect(run.gaps).toEqual([
+			{ scope: "suite", id: "system", outcome: "failed", reason: "pts_git: git failed" },
+			{
+				scope: "suite",
+				id: "system",
+				outcome: "failed",
+				reason:
+					"PTS ran but every trial failed for 1 of 3 declared metrics: pybench_milliseconds (system/pts_git.xml) — attempted, no value recorded",
+			},
+		]);
+	});
+
+	it("FLAT LEAF FOLD: a legacy pts_git marker maps to system instead of fabricating a suite", () => {
+		writeFileSync(
+			join(providerDir, "pts_git--failed.json"),
+			'{"outcome":"failed","benchmark":"pts_git","reason":"legacy git failure"}\n',
+		);
+
+		const run = normalizeProviderDir(root, "daytona-vm");
+		expect(run.gaps).toEqual([
+			{
+				scope: "suite",
+				id: "system",
+				outcome: "failed",
+				reason: "pts_git: legacy git failure",
+			},
+		]);
+	});
+
+	it("FLAT RESCUE: a metric the legacy flat layout produced is never claimed as a shortfall", () => {
+		// Mixed layout: the suite copy of pybench is empty but a legacy flat file carries the value.
+		// The dataset publishes that value, so a shortfall gap claiming it 'produced no value' would
+		// contradict the published metric — the flat contribution mutes the entry.
+		const suiteDir = join(providerDir, "system");
+		mkdirSync(suiteDir);
+		writeFileSync(join(suiteDir, "pts_pybench.xml"), emptyPybenchComposite);
+		writeFileSync(
+			join(providerDir, "pts_pybench.xml"),
+			`<?xml version="1.0"?>
+<PhoronixTestSuite>
+  <Result>
+    <Identifier>pts/pybench-1.1.3</Identifier>
+    <Title>PyBench</Title>
+    <Scale>Milliseconds</Scale><Proportion>LIB</Proportion>
+    <Data><Entry><Value>475</Value><RawString>474:476</RawString></Entry></Data>
+  </Result>
+</PhoronixTestSuite>`,
+		);
+
+		const run = normalizeProviderDir(root, "daytona-vm");
+		expect(run.gaps).toEqual([]);
+		expect(run.metrics.map((m) => m.metricId)).toContain("pybench_milliseconds");
+	});
+
+	it("PARTIAL SHORTFALL: a suite stays covered AND gapped when only some declared metrics report", () => {
+		// keep+warn: the metrics that did succeed keep ranking (memory is covered via Copy/Scale) while
+		// the attempted-and-lost Add/Triad are named in a recorded gap instead of silently vanishing.
+		const suiteDir = join(providerDir, "memory");
+		mkdirSync(suiteDir);
+		writeFileSync(
+			join(suiteDir, "pts_stream.xml"),
+			streamComposite([
+				["Copy", "66500"],
+				["Scale", "45000"],
+				["Add", ""],
+				["Triad", ""],
+			]),
+		);
+
+		const run = normalizeProviderDir(root, "daytona-vm");
+		expect(run.suitesCovered).toEqual(["memory"]);
+		expect(run.metrics.map((m) => m.metricId)).toContain("stream_type_copy");
+		expect(run.gaps).toEqual([
+			{
+				scope: "suite",
+				id: "memory",
+				outcome: "failed",
+				reason:
+					"PTS ran but every trial failed for 2 of 4 declared metrics: stream_type_add (memory/pts_stream.xml), stream_type_triad (memory/pts_stream.xml) — attempted, no value recorded",
+			},
+		]);
+	});
+
+	it("LEGIT ABSENCE: declared-but-unattempted metrics never gap (no Result element, no evidence)", () => {
+		// The disk O_DIRECT-variant rule and PTS's duplicate-value drop: a declared metric whose
+		// <Result> is absent entirely was never attempted here — an expectation-based diff would
+		// fabricate a gap for it, so the detection is evidence-based only.
+		const suiteDir = join(providerDir, "memory");
+		mkdirSync(suiteDir);
+		writeFileSync(
+			join(suiteDir, "pts_stream.xml"),
+			streamComposite([
+				["Copy", "66500"],
+				["Scale", "45000"],
+			]),
+		);
+
+		const run = normalizeProviderDir(root, "daytona-vm");
+		expect(run.suitesCovered).toEqual(["memory"]);
+		expect(run.gaps).toEqual([]);
+	});
+
+	it("LEAF MARKER + SHORTFALL COEXIST: a leaf SKIP never hides a different leaf's attempted loss", () => {
+		// One leaf was deliberately skipped (folded to the suite id, leaf kept in the reason) while a
+		// DIFFERENT declared metric was attempted and lost — both facts must survive: a skip is not a
+		// failure, so it must not suppress the shortfall the way a failed marker does.
+		const suiteDir = join(providerDir, "system");
+		mkdirSync(suiteDir);
+		writeFileSync(
+			join(suiteDir, "pts_git--skipped.json"),
+			'{"schema_version":"1.0","benchmark":"pts_git","skipped":true,"skip_reason":"PTS unavailable"}\n',
+		);
+		writeFileSync(
+			join(suiteDir, "pts_pybench.xml"),
+			`<?xml version="1.0"?>
+<PhoronixTestSuite>
+  <Result>
+    <Identifier>pts/pybench-1.1.3</Identifier>
+    <Title>PyBench</Title>
+    <Scale>Milliseconds</Scale><Proportion>LIB</Proportion>
+    <Data><Entry><Value></Value></Entry></Data>
+  </Result>
+</PhoronixTestSuite>`,
+		);
+
+		const run = normalizeProviderDir(root, "daytona-vm");
+		expect(run.gaps).toEqual([
+			{ scope: "suite", id: "system", outcome: "skipped", reason: "pts_git: PTS unavailable" },
+			{
+				scope: "suite",
+				id: "system",
+				outcome: "failed",
+				reason:
+					"PTS ran but every trial failed for 1 of 3 declared metrics: pybench_milliseconds (system/pts_pybench.xml) — attempted, no value recorded",
+			},
+		]);
+	});
+
+	it("emits byte-identical shortfall reasons across normalize runs (the aggregate dedupe key)", () => {
+		// The aggregate folds replicate shards' gaps by (scope, id, outcome, reason) — a timestamp or
+		// unstable ordering in the reason would stack one gap per replicate instead of one per suite.
+		const suiteDir = join(providerDir, "memory");
+		mkdirSync(suiteDir);
+		writeFileSync(
+			join(suiteDir, "pts_stream.xml"),
+			streamComposite([
+				["Triad", ""],
+				["Add", ""],
+			]),
+		);
+
+		const first = normalizeProviderDir(root, "daytona-vm");
+		const second = normalizeProviderDir(root, "daytona-vm");
+		expect(first.gaps).toEqual(second.gaps);
+		expect(first.gaps[0]?.reason).toBe(
+			"PTS ran but every trial failed for 2 of 4 declared metrics: stream_type_add (memory/pts_stream.xml), stream_type_triad (memory/pts_stream.xml) — attempted, no value recorded",
+		);
 	});
 });

--- a/packages/results/src/lib/normalize-tree.ts
+++ b/packages/results/src/lib/normalize-tree.ts
@@ -21,13 +21,15 @@ import {
 	deriveEconomics,
 	describeOffDimensionEmission,
 	getProvider,
+	METRIC_CATALOG,
 	offDimensionEmissions,
 	PROVIDERS,
 	parseRun,
 	SUITE_NAMES,
+	SUITES,
 	TARGET_SPEC,
 } from "@sandbox-benchmarks/schema";
-import type { SampleContribution } from "./extract.ts";
+import type { AttemptedEmptyResult, SampleContribution } from "./extract.ts";
 import { extractProviderDir } from "./extract.ts";
 import { readHostMetadata } from "./host-metadata.ts";
 import { computeSpecMatched, readObservedSpecs } from "./specs.ts";
@@ -76,6 +78,63 @@ export function normalizeResultsTree(input: NormalizeInput): Run {
 /** Element-wise sample equality — used to tell a benign duplicate from divergent contamination. */
 function sameSamples(a: readonly number[], b: readonly number[]): boolean {
 	return a.length === b.length && a.every((value, i) => value === b[i]);
+}
+
+/** The result-prefix base implied by a catalogued metric's PTS test (`pts/git` → `pts_git`). */
+function metricLeafBase(metricId: string): string | undefined {
+	const test = METRIC_CATALOG.find((metric) => metric.id === metricId)?.pts?.test;
+	const profile = test?.split("/").at(-1);
+	return profile ? `pts_${profile}` : undefined;
+}
+
+/** Whether a bash marker names the PTS test that owns a metric. Scenario suffixes (fio/pgbench)
+ *  still match their shared test base; the more exact ownership check below handles the suffix. */
+function leafMatchesMetricTest(leaf: string, metricId: string): boolean {
+	const base = metricLeafBase(metricId);
+	return base !== undefined && (leaf === base || leaf.startsWith(`${base}-`));
+}
+
+/** Whether a failed leaf marker already accounts for this exact metric. Use catalog identity first,
+ *  never the composite filename: PTS result-name contamination can put a PyBench Result in
+ *  `pts_git.xml`, and the filename must not let a Git marker silence PyBench's independent loss. */
+function leafOwnsMetric(leaf: string, metricId: string): boolean {
+	const base = metricLeafBase(metricId);
+	if (!base || !leafMatchesMetricTest(leaf, metricId)) return false;
+	if (leaf === base) return true;
+
+	// Multi-scenario leaves share one PTS profile. Match the leaf's scenario tokens against the stable
+	// metric id so one fio/pgbench marker suppresses only its own scenario, not every result of the test.
+	const aliases: Record<string, string> = { rand: "random", seq: "sequential" };
+	const scenario = leaf
+		.slice(base.length + 1)
+		.split("-")
+		.map((token) => aliases[token] ?? token);
+	return scenario.every((token) => metricId.includes(`_${token}`));
+}
+
+/** Recover a legacy flat leaf marker's suite from the catalog contract. A mapping must be unique;
+ *  unknown/ambiguous markers remain untouched rather than being guessed into the wrong suite. */
+function suiteForLeaf(leaf: string): string | undefined {
+	const matches = SUITE_NAMES.filter((suite) =>
+		SUITES[suite].metrics.some((metricId) => leafMatchesMetricTest(leaf, metricId)),
+	);
+	return matches.length === 1 ? matches[0] : undefined;
+}
+
+/**
+ * The single owner of the suite-shortfall gap wording: declared metrics that were attempted (PTS ran
+ * them) and produced no value in any trial. Byte-deterministic — sorted ids, stable filenames, no
+ * timestamps — so the aggregate's (scope, id, outcome, reason) dedupe key folds identical shortfalls
+ * across replicate shards instead of stacking one gap per replicate.
+ */
+export function shortfallReason(suite: string, missing: readonly AttemptedEmptyResult[]): string {
+	// suiteDirs only ever contains registered names, so the lookup can't miss in production; the
+	// fallback keeps this pure-string helper total for tests and future callers.
+	const declared =
+		(SUITES as Partial<Record<string, { metrics: readonly string[] }>>)[suite]?.metrics.length ??
+		missing.length;
+	const list = missing.map((e) => `${e.metricId} (${e.sourceFile})`).join(", ");
+	return `PTS ran but every trial failed for ${missing.length} of ${declared} declared metrics: ${list} — attempted, no value recorded`;
 }
 
 /** Parse a JSON file, returning undefined (never throwing) when it's absent or malformed. */
@@ -149,6 +208,15 @@ export function normalizeProviderDir(rawRoot: string, providerId: string): Provi
 	// Host fingerprint from a composite's <System>, first non-empty across the read order (all suites of
 	// one provider ran on the same machine). Merged UNDER the spec probe below so the probe always wins.
 	let systemHost: ObservedSpecs | undefined;
+	// Per-suite shortfall candidates: declared metrics that were attempted (an all-passes-failed
+	// <Result> is the evidence) and that no file in the suite produced a value for. Collected here,
+	// emitted as at most ONE suite gap AFTER the flat read below, once every marker is in `gaps`.
+	const suiteShortfalls = new Map<string, AttemptedEmptyResult[]>();
+	// Which failed markers each suite carries, split by kind (recorded while folding below): a HARNESS
+	// whole-suite marker mutes the suite's shortfall entirely, a folded LEAF marker mutes only its own
+	// leaf's entries — one leaf's recorded failure must not hide a DIFFERENT leaf's silent loss.
+	const foldedFailedLeaves = new Map<string, Set<string>>();
+	const harnessFailedSuites = new Set<string>();
 
 	for (const suite of suiteDirs) {
 		const ext = extractProviderDir(join(dir, suite), providerId);
@@ -170,7 +238,51 @@ export function normalizeProviderDir(rawRoot: string, providerId: string): Provi
 		for (const u of ext.uncatalogued)
 			rawUncatalogued.push({ ...u, sourceFile: `${suite}/${u.sourceFile}` });
 		if (ext.contributions.length > 0) suitesCovered.add(suite);
-		gaps.push(...ext.gaps);
+		// Bash leaf markers carry the LEAF name (pts_fio-rand-read) in `benchmark`; the Run vocabulary
+		// (resultGapSchema) says a suite-scoped gap's id is the SUITE. Fold the leaf into the reason so
+		// the leaderboard's missing-suite derivation (which treats suite-gap ids as suite names) can
+		// neither fabricate a bogus 'suite' nor accuse healthy providers of missing it. Harness-written
+		// markers already carry the suite name, so the fold is the identity for them. Which KIND of
+		// failed marker each suite carries is remembered for the shortfall emission below: a folded
+		// leaf failure must only mute that leaf's own shortfall entries, while a harness whole-suite
+		// failure mutes the suite's shortfall entirely.
+		for (const g of ext.gaps) {
+			if (g.scope === "suite" && g.id !== suite) {
+				if (g.outcome === "failed") {
+					const leaves = foldedFailedLeaves.get(suite) ?? new Set<string>();
+					leaves.add(g.id);
+					foldedFailedLeaves.set(suite, leaves);
+				}
+				gaps.push({ ...g, id: suite, reason: `${g.id}: ${g.reason}` });
+			} else {
+				if (g.scope === "suite" && g.outcome === "failed") harnessFailedSuites.add(suite);
+				gaps.push(g);
+			}
+		}
+		// Shortfall evidence: declared metrics attempted-and-empty here, minus the ones some file in
+		// this suite DID produce (a metric can fail in one composite and succeed in another). Unique by
+		// metricId (first file wins — extraction order is filename-sorted, so deterministic), sorted so
+		// the gap reason is byte-stable.
+		const produced = new Set(ext.contributions.map((c) => c.metricId));
+		const declared = new Set<string>(
+			(SUITES as Partial<Record<string, { metrics: readonly string[] }>>)[suite]?.metrics ?? [],
+		);
+		const missingById = new Map<string, AttemptedEmptyResult>();
+		for (const e of ext.attemptedEmpty) {
+			if (!declared.has(e.metricId) || produced.has(e.metricId)) continue;
+			if (!missingById.has(e.metricId)) {
+				missingById.set(e.metricId, {
+					metricId: e.metricId,
+					sourceFile: `${suite}/${e.sourceFile}`,
+				});
+			}
+		}
+		if (missingById.size > 0) {
+			suiteShortfalls.set(
+				suite,
+				[...missingById.values()].sort((a, b) => a.metricId.localeCompare(b.metricId, "en")),
+			);
+		}
 	}
 	// Reject at the boundary before any further work: a suite emitting a catalogued metric off its
 	// declared Dimensions is a producer/registry drift that would land a number under the wrong
@@ -191,8 +303,68 @@ export function normalizeProviderDir(rawRoot: string, providerId: string): Provi
 	hostMetadata.push(...readHostMetadata(dir));
 	contributions.push(...flat.contributions);
 	rawUncatalogued.push(...flat.uncatalogued);
-	gaps.push(...flat.gaps);
+	for (const g of flat.gaps) {
+		if (g.scope !== "suite") {
+			gaps.push(g);
+			continue;
+		}
+		// A flat HARNESS marker still names a registered suite and must suppress the suite directory's
+		// duplicate shortfall. A flat bash LEAF marker has no directory context, so recover its suite
+		// from the catalog's metric→PTS-test→suite contract and fold it exactly like a nested marker.
+		const suite = registered.has(g.id) ? g.id : suiteForLeaf(g.id);
+		if (!suite) {
+			gaps.push(g);
+			continue;
+		}
+		if (g.id === suite) {
+			if (g.outcome === "failed") harnessFailedSuites.add(suite);
+			gaps.push(g);
+			continue;
+		}
+		if (g.outcome === "failed") {
+			const leaves = foldedFailedLeaves.get(suite) ?? new Set<string>();
+			leaves.add(g.id);
+			foldedFailedLeaves.set(suite, leaves);
+		}
+		gaps.push({ ...g, id: suite, reason: `${g.id}: ${g.reason}` });
+	}
 	if (!systemHost && flat.observedHost) systemHost = flat.observedHost;
+	// (flat.attemptedEmpty is deliberately unused: a legacy flat file has no suite to diff against,
+	// exactly as it earns no suitesCovered credit above.)
+
+	// Suite-shortfall gaps: an all-trials-failed PTS test exits 0 and writes a value-less composite,
+	// which used to leave a green job with no metric AND no gap — an invisible hole (pgbench vanished
+	// from three consecutive published runs this way). Emit at most ONE failed gap per suite, from the
+	// EVIDENCE collected above (attempted-and-empty catalogued Results), never from expectations — so
+	// disk's legitimately-unrun O_DIRECT/buffered twins and PTS's dropped-duplicate Results produce no
+	// false gaps. Emitted after every marker is in `gaps`, with marker-kind-aware dedupe: a HARNESS
+	// whole-suite failed marker mutes the suite's shortfall (the loss is already recorded wholesale); a
+	// folded LEAF failed marker mutes only its OWN leaf's entries (its loss is recorded, but a
+	// different leaf's silent loss in the same suite must still surface); a SKIP marker never
+	// suppresses, because a deliberate non-run of one leaf must not hide that a different leaf was
+	// attempted and lost. Entries whose metric a LEGACY FLAT file produced are dropped too — the
+	// metric has a published value, so claiming it "produced no value" would contradict the dataset.
+	// This check only pushes gaps and must NEVER throw: a normalize-time throw loses the whole shard
+	// (how disk/modal-gvisor's valid hardlink metric was lost in run 29799034615).
+	const producedAnywhere = new Set(contributions.map((c) => c.metricId));
+	for (const suite of suiteDirs) {
+		const collected = suiteShortfalls.get(suite);
+		if (!collected) continue;
+		if (harnessFailedSuites.has(suite)) continue;
+		const mutedLeaves = foldedFailedLeaves.get(suite);
+		const missing = collected.filter((e) => {
+			if (producedAnywhere.has(e.metricId)) return false;
+			if (!mutedLeaves) return true;
+			return ![...mutedLeaves].some((leaf) => leafOwnsMetric(leaf, e.metricId));
+		});
+		if (missing.length === 0) continue;
+		gaps.push({
+			scope: "suite",
+			id: suite,
+			outcome: "failed",
+			reason: shortfallReason(suite, missing),
+		});
+	}
 
 	// De-dupe catalogued metrics by metricId across source files — keep the FIRST (deterministic file
 	// order). In our model one <Result> owns a metric's per-pass samples, so the same metricId in two


### PR DESCRIPTION
**Bench-matrix green — every suite×provider cell measuring or honestly gapped**
Fixes the 10 root causes behind the failures and silent metric holes of runs [29799034615](https://github.com/starslingdev/hpc-sandbox-benchmarks/actions/runs/29799034615) and [29850811070](https://github.com/starslingdev/hpc-sandbox-benchmarks/actions/runs/29850811070). Shipped as a 13-PR stack (merge bottom-up, each branch independently green):
1. #229 — results: tolerate the all-failed PTS composite shape (empty Proportion)
2. #230 — results: record attempted-but-empty catalogued Results as evidence
3. #231 — results: suite-shortfall gaps + leaf-marker folding
4. #232 — results: gaps for PTS duplicate-value fio twin drops
5. #233 — leaderboard: no fabricated missing-rows for never-dispatched providers
6. #234 — realworld: per-task timeout + cgroup-v2 memory containment
7. #235 — harness: failed gap on sandbox-creation failure
8. #236 — harness: detached log read-back + collect retries
9. #237 — bench: loud PTS leaf guards; stream + pybench measure again
10. #238 — templates: pgbench bake fix (pkg-config), payload assertion, portable fio, v4
11. #239 — fast-cli: settle gated on upload-phase stability
12. #240 — providers: Daytona region pin actually reaches the API; both variants us-west-2
13. #241 — ci: dataset-PR PAT fallback; e2b disk-skip notes

↑ **This PR is #231 (3/13)**.

---

Consumes the attempted-empty evidence from the previous PR: a suite whose
declared, catalogued metrics were attempted (PTS ran them) but produced no
value in any composite records at most ONE suite-scope failed gap listing
the lost metric ids — evidence-based, never expectation-based, so disk's
probe-dependent fio variants and PTS's dropped-duplicate Results
(legitimately absent) yield no false gaps. Dedupe is marker-kind-aware: a harness
whole-suite failed marker mutes the suite's shortfall, a folded LEAF
failed marker mutes only its own leaf's entries, and a SKIP marker never
suppresses (a deliberate non-run of one leaf must not hide a different
leaf's loss); metrics a legacy flat file produced are never claimed.
The pass never throws — a normalize-time throw is how disk/modal-gvisor's
valid hardlink samples were lost in run 29799034615.

Bash leaf markers (pts_fio-rand-read) also fold under their SUITE id with
the leaf kept in the reason: the leaderboard's missing-suite derivation
treats suite-gap ids as suite names, and an unfolded leaf id would
fabricate a bogus suite and accuse every healthy provider of missing it.
Shortfall reasons are byte-deterministic so the aggregate's (scope, id,
outcome, reason) dedupe folds replicate shards (aggregate.test.ts).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Emit suite-level shortfall gaps for attempted-but-empty metrics and fold leaf markers (including legacy flat) under their suite. Keeps leaderboard counts accurate and collapses identical gaps across replicate shards.

- **New Features**
  - Evidence-based suite shortfalls: at most one failed gap per suite listing missing metric ids. Reasons are byte-stable via `shortfallReason()` so `aggregateRuns` folds identical gaps; divergent reasons are kept.
  - Marker folding and suppression: fold bash and legacy flat leaf markers to the suite id (leaf kept in the reason). Harness suite failures suppress the suite gap; folded leaf failures mute only their own leaf; SKIP never suppresses. Ownership is catalog-driven (not filenames) to prevent contamination from muting other tests.
  - Safeguards: suites stay covered on partial failures. Never gap unattempted metrics or metrics produced by legacy flat files. Normalization never throws.

<sup>Written for commit 21f020dd9fe85ae49f979531b979ae3f10358d2b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/starslingdev/hpc-sandbox-benchmarks/pull/231?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

