### PR TITLE
feat(results): record a gap when PTS duplicate-value dedup drops a fio twin

### DIFF
--- a/packages/results/src/lib/extract.ts
+++ b/packages/results/src/lib/extract.ts
@@ -32,10 +32,20 @@ export interface AttemptedEmptyResult {
 	sourceFile: string;
 }
 
+/** A PTS Result that was present in a composite but did not match any catalog Metric. */
+export interface UnmappedPtsResult {
+	test: string;
+	description: string;
+	scale: string;
+	sourceFile: string;
+}
+
 /** Everything one provider directory yields: catalogued samples, stragglers, and gap markers. */
 export interface ProviderExtraction {
 	contributions: SampleContribution[];
 	uncatalogued: UncataloguedResult[];
+	/** Internal evidence that a Result existed even when it carried no publishable measurement. */
+	unmappedPts: UnmappedPtsResult[];
 	/** Suite-scoped gaps read from `*--skipped.json` / `*--failed.json` markers. */
 	gaps: ResultGap[];
 	/**
@@ -70,6 +80,7 @@ export function extractProviderDir(dir: string, providerId: string): ProviderExt
 	const out: ProviderExtraction = {
 		contributions: [],
 		uncatalogued: [],
+		unmappedPts: [],
 		gaps: [],
 		attemptedEmpty: [],
 	};
@@ -93,6 +104,16 @@ export function extractProviderDir(dir: string, providerId: string): ProviderExt
 			}
 			for (const result of composite.PhoronixTestSuite.Result) {
 				const mapped = ptsResultToMetric(result);
+				if (mapped.kind === "uncatalogued") {
+					// Keep existence evidence even when the Result is empty. Consumers that infer a Result
+					// was omitted must distinguish true absence from a present-but-unmapped Result.
+					out.unmappedPts.push({
+						test: mapped.test,
+						description: mapped.description,
+						scale: mapped.scale,
+						sourceFile: filename,
+					});
+				}
 				// A <Result> with no measured <Entry>, or one whose every pass failed (empty <Value> — pts-schema.ts
 				// treats that as "no measurement", not a parse error; fio's all-failed shape additionally
 				// empties <Proportion> and <Scale>, tolerated the same way), carries no sample to aggregate

--- a/packages/results/src/lib/normalize-tree.test.ts
+++ b/packages/results/src/lib/normalize-tree.test.ts
@@ -272,6 +272,30 @@ function streamComposite(entries: Array<[type: string, value: string]>): string 
 	return `<?xml version="1.0"?>\n<PhoronixTestSuite>\n${results}\n</PhoronixTestSuite>`;
 }
 
+// The catalogued twin-pair base for fio seq-read 1MB O_DIRECT (suffixes _mb_per_s/_iops complete it).
+const SEQ_READ_DIRECT_YES =
+	"fio_type_sequential_read_engine_linux_aio_direct_yes_block_size_1mb_job_count_1_disk_target_default_test_directory";
+
+// A fio composite for that scenario: twin Results share one <Description> and differ only in
+// <Scale> — the caller passes whichever twins PTS actually wrote (its duplicate-value dedup drops
+// a twin ENTIRELY when the numeric values collide, so a one-entry composite is the real artifact).
+function fioSeqReadComposite(entries: Array<[scale: string, value: string]>): string {
+	const description =
+		"Type: Sequential Read - Engine: Linux AIO - Direct: Yes - Block Size: 1MB - Job Count: 1 - Disk Target: Default Test Directory";
+	const results = entries
+		.map(
+			([scale, value]) => `  <Result>
+    <Identifier>pts/fio-2.1.0</Identifier>
+    <Title>Flexible IO Tester</Title>
+    <Description>${description}</Description>
+    <Scale>${scale}</Scale><Proportion>HIB</Proportion>
+    <Data><Entry><Value>${value}</Value></Entry></Data>
+  </Result>`,
+		)
+		.join("\n");
+	return `<?xml version="1.0"?>\n<PhoronixTestSuite>\n${results}\n</PhoronixTestSuite>`;
+}
+
 // An all-trials-failed node-web-tooling composite: the Result is present but carries no value.
 // An all-trials-failed pybench composite (system suite's second leaf in the leaf-dedupe tests).
 const emptyPybenchComposite = `<?xml version="1.0"?>
@@ -598,6 +622,221 @@ describe("normalizeProviderDir suite-shortfall gaps and leaf-marker folding", ()
 				outcome: "failed",
 				reason:
 					"PTS ran but every trial failed for 1 of 3 declared metrics: pybench_milliseconds (system/pts_pybench.xml) — attempted, no value recorded",
+			},
+		]);
+	});
+
+	it("DROPPED TWIN: one fio twin present, its pair absent ENTIRELY -> gap naming the dropped twin", () => {
+		// PTS's result-parser drops a <Result> whose numeric values duplicate an earlier result's —
+		// with 1MB blocks MB/s == IOPS, so the MB/s twin is ABSENT (not empty) and attemptedEmpty
+		// never sees it. The surviving IOPS twin is the evidence the scenario ran (keep+warn: it
+		// stays ranked, disk stays covered, the loss is named).
+		const suiteDir = join(providerDir, "disk");
+		mkdirSync(suiteDir);
+		writeFileSync(join(suiteDir, "pts_fio-seq-read.xml"), fioSeqReadComposite([["IOPS", "11650"]]));
+
+		const run = normalizeProviderDir(root, "daytona-vm");
+		expect(run.suitesCovered).toEqual(["disk"]);
+		expect(run.metrics.map((m) => m.metricId)).toContain(`${SEQ_READ_DIRECT_YES}_iops`);
+		expect(run.gaps).toEqual([
+			{
+				scope: "suite",
+				id: "disk",
+				outcome: "failed",
+				reason: `PTS duplicate-value dedup dropped 1 fio twin result (MB/s == IOPS at this block size, so the duplicate-valued <Result> was never written): ${SEQ_READ_DIRECT_YES}_mb_per_s (twin survived in disk/pts_fio-seq-read.xml)`,
+			},
+		]);
+	});
+
+	it("BOTH TWINS PRESENT: rounding-distinct MB/s and IOPS both survive -> no twin gap", () => {
+		// The counter-case from the same real run: modal-vm seq-read posted 1731 vs 1729 — equality
+		// is a per-run coin flip, and a full pair must never gap.
+		const suiteDir = join(providerDir, "disk");
+		mkdirSync(suiteDir);
+		writeFileSync(
+			join(suiteDir, "pts_fio-seq-read.xml"),
+			fioSeqReadComposite([
+				["MB/s", "1731"],
+				["IOPS", "1729"],
+			]),
+		);
+
+		const run = normalizeProviderDir(root, "daytona-vm");
+		const ids = run.metrics.map((m) => m.metricId);
+		expect(ids).toContain(`${SEQ_READ_DIRECT_YES}_mb_per_s`);
+		expect(ids).toContain(`${SEQ_READ_DIRECT_YES}_iops`);
+		expect(run.gaps).toEqual([]);
+	});
+
+	it("UNMAPPED SIBLING: a written Result that misses the catalog is not called a dropped twin", () => {
+		const suiteDir = join(providerDir, "disk");
+		mkdirSync(suiteDir);
+		writeFileSync(
+			join(suiteDir, "pts_fio-seq-read.xml"),
+			fioSeqReadComposite([
+				["IOPS", "11650"],
+				["Megabytes/s", "11650"],
+			]),
+		);
+
+		const run = normalizeProviderDir(root, "daytona-vm");
+		expect(run.metrics.map((m) => m.metricId)).toContain(`${SEQ_READ_DIRECT_YES}_iops`);
+		expect(run.uncatalogued).toHaveLength(1);
+		expect(run.gaps).toEqual([]);
+	});
+
+	it("FLAT RESCUE: a legacy flat measurement suppresses a suite-local twin candidate", () => {
+		const suiteDir = join(providerDir, "disk");
+		mkdirSync(suiteDir);
+		writeFileSync(join(suiteDir, "pts_fio-seq-read.xml"), fioSeqReadComposite([["IOPS", "11650"]]));
+		writeFileSync(
+			join(providerDir, "pts_fio-seq-read.xml"),
+			fioSeqReadComposite([["MB/s", "11650"]]),
+		);
+
+		const run = normalizeProviderDir(root, "daytona-vm");
+		const ids = run.metrics.map((m) => m.metricId);
+		expect(ids).toContain(`${SEQ_READ_DIRECT_YES}_mb_per_s`);
+		expect(ids).toContain(`${SEQ_READ_DIRECT_YES}_iops`);
+		expect(run.gaps).toEqual([]);
+	});
+
+	it("BOTH TWINS ABSENT: an un-probed scenario stays gap-free (the probe-subset rule)", () => {
+		// disk covered via hardlink alone; every fio pair has BOTH members absent — the direct_no
+		// variants are legitimately never probed, and a pair with no survivor carries no evidence.
+		const suiteDir = join(providerDir, "disk");
+		mkdirSync(suiteDir);
+		writeFileSync(
+			join(suiteDir, "pts_hardlink.xml"),
+			`<?xml version="1.0"?>
+<PhoronixTestSuite>
+  <Result>
+    <Identifier>local/hardlink-1.0.0</Identifier>
+    <Title>Hardlink Throughput</Title>
+    <Scale>bogo ops/s</Scale><Proportion>HIB</Proportion>
+    <Data><Entry><Value>2.62</Value></Entry></Data>
+  </Result>
+</PhoronixTestSuite>`,
+		);
+
+		const run = normalizeProviderDir(root, "daytona-vm");
+		expect(run.suitesCovered).toEqual(["disk"]);
+		expect(run.gaps).toEqual([]);
+	});
+
+	it("4KB SIBLING ABSENT: no twin gap — MB/s and IOPS cannot collide at 4KB", () => {
+		// PTS's duplicate-value drop needs numeric equality, which only 1MB blocks produce (1 op ==
+		// 1 MB). A missing 4KB sibling is some other pathology; labeling it "duplicate-value dedup"
+		// would publish a false explanation, so 4KB pairs are excluded from twin detection.
+		const suiteDir = join(providerDir, "disk");
+		mkdirSync(suiteDir);
+		writeFileSync(
+			join(suiteDir, "pts_fio-rand-read.xml"),
+			`<?xml version="1.0"?>
+<PhoronixTestSuite>
+  <Result>
+    <Identifier>pts/fio-2.1.0</Identifier>
+    <Title>Flexible IO Tester</Title>
+    <Description>Type: Random Read - Engine: Linux AIO - Direct: Yes - Block Size: 4KB - Job Count: 1 - Disk Target: Default Test Directory</Description>
+    <Scale>IOPS</Scale><Proportion>HIB</Proportion>
+    <Data><Entry><Value>11650</Value></Entry></Data>
+  </Result>
+</PhoronixTestSuite>`,
+		);
+
+		const run = normalizeProviderDir(root, "daytona-vm");
+		expect(run.suitesCovered).toEqual(["disk"]);
+		expect(run.gaps).toEqual([]);
+	});
+
+	it("TWIN GAP SUPPRESSED: an existing suite-scope failed gap wins over the twin gap (no doubling)", () => {
+		const suiteDir = join(providerDir, "disk");
+		mkdirSync(suiteDir);
+		writeFileSync(join(suiteDir, "pts_fio-seq-read.xml"), fioSeqReadComposite([["IOPS", "11650"]]));
+		writeFileSync(
+			join(suiteDir, "sandbox-daytona-vm-disk--failed.json"),
+			harnessGapMarkerJson("daytona-vm", "disk", "failed", "fio timed out mid-suite"),
+		);
+
+		const run = normalizeProviderDir(root, "daytona-vm");
+		expect(run.gaps).toEqual([
+			{ scope: "suite", id: "disk", outcome: "failed", reason: "fio timed out mid-suite" },
+		]);
+	});
+
+	it("DIFFERENT LEAF FAILURE: its folded marker coexists with a seq-read twin loss", () => {
+		const suiteDir = join(providerDir, "disk");
+		mkdirSync(suiteDir);
+		writeFileSync(join(suiteDir, "pts_fio-seq-read.xml"), fioSeqReadComposite([["IOPS", "11650"]]));
+		writeFileSync(
+			join(suiteDir, "pts_fio-rand-read--failed.json"),
+			'{"outcome":"failed","benchmark":"pts_fio-rand-read","reason":"random read failed"}\n',
+		);
+
+		const run = normalizeProviderDir(root, "daytona-vm");
+		expect(run.gaps).toEqual([
+			{
+				scope: "suite",
+				id: "disk",
+				outcome: "failed",
+				reason: "pts_fio-rand-read: random read failed",
+			},
+			{
+				scope: "suite",
+				id: "disk",
+				outcome: "failed",
+				reason: `PTS duplicate-value dedup dropped 1 fio twin result (MB/s == IOPS at this block size, so the duplicate-valued <Result> was never written): ${SEQ_READ_DIRECT_YES}_mb_per_s (twin survived in disk/pts_fio-seq-read.xml)`,
+			},
+		]);
+	});
+
+	it("CONTAMINATED FILENAME: a rand-read marker cannot hide a seq-read twin loss", () => {
+		const suiteDir = join(providerDir, "disk");
+		mkdirSync(suiteDir);
+		// PTS can leak a Result under another leaf's result name. The seq-read metric identity must win
+		// over this rand-read filename when deciding whether the rand-read marker owns the loss.
+		writeFileSync(
+			join(suiteDir, "pts_fio-rand-read.xml"),
+			fioSeqReadComposite([["IOPS", "11650"]]),
+		);
+		writeFileSync(
+			join(suiteDir, "pts_fio-rand-read--failed.json"),
+			'{"outcome":"failed","benchmark":"pts_fio-rand-read","reason":"random read failed"}\n',
+		);
+
+		const run = normalizeProviderDir(root, "daytona-vm");
+		expect(run.gaps).toEqual([
+			{
+				scope: "suite",
+				id: "disk",
+				outcome: "failed",
+				reason: "pts_fio-rand-read: random read failed",
+			},
+			{
+				scope: "suite",
+				id: "disk",
+				outcome: "failed",
+				reason: `PTS duplicate-value dedup dropped 1 fio twin result (MB/s == IOPS at this block size, so the duplicate-valued <Result> was never written): ${SEQ_READ_DIRECT_YES}_mb_per_s (twin survived in disk/pts_fio-rand-read.xml)`,
+			},
+		]);
+	});
+
+	it("SAME LEAF FAILURE: its folded marker suppresses the duplicate twin-loss gap", () => {
+		const suiteDir = join(providerDir, "disk");
+		mkdirSync(suiteDir);
+		writeFileSync(join(suiteDir, "pts_fio-seq-read.xml"), fioSeqReadComposite([["IOPS", "11650"]]));
+		writeFileSync(
+			join(suiteDir, "pts_fio-seq-read--failed.json"),
+			'{"outcome":"failed","benchmark":"pts_fio-seq-read","reason":"sequential read failed"}\n',
+		);
+
+		const run = normalizeProviderDir(root, "daytona-vm");
+		expect(run.gaps).toEqual([
+			{
+				scope: "suite",
+				id: "disk",
+				outcome: "failed",
+				reason: "pts_fio-seq-read: sequential read failed",
 			},
 		]);
 	});

--- a/packages/results/src/lib/normalize-tree.ts
+++ b/packages/results/src/lib/normalize-tree.ts
@@ -137,6 +137,50 @@ export function shortfallReason(suite: string, missing: readonly AttemptedEmptyR
 	return `PTS ran but every trial failed for ${missing.length} of ${declared} declared metrics: ${list} — attempted, no value recorded`;
 }
 
+/** A catalogued fio twin whose <Result> PTS omitted entirely; sourceFile carries the SURVIVING twin. */
+export interface DroppedTwinResult {
+	metricId: string;
+	sourceFile: string;
+}
+
+/**
+ * The single owner of the dropped-twin gap wording: a fio MB/s↔IOPS twin whose <Result> PTS's
+ * result-parser silently dropped because its numeric values duplicated the surviving twin's
+ * (MB/s == IOPS at this block size). Byte-deterministic — sorted ids, stable filenames — for the
+ * same aggregate (scope, id, outcome, reason) dedupe reason as shortfallReason above.
+ */
+export function twinDropReason(dropped: readonly DroppedTwinResult[]): string {
+	const list = dropped.map((d) => `${d.metricId} (twin survived in ${d.sourceFile})`).join(", ");
+	return `PTS duplicate-value dedup dropped ${dropped.length} fio twin result${dropped.length === 1 ? "" : "s"} (MB/s == IOPS at this block size, so the duplicate-valued <Result> was never written): ${list}`;
+}
+
+const TWIN_SUFFIXES = ["_mb_per_s", "_iops"] as const;
+/**
+ * PTS's duplicate-value drop requires the twins to be numerically EQUAL, which is structural only at
+ * a 1MB block size (1 op == 1 MB, so MB/s == IOPS). At 4KB the two scales differ by 256x and can
+ * never collide, so an absent 4KB sibling is some other pathology — inferring "duplicate-value
+ * dedup" there would publish a false explanation.
+ */
+const TWIN_EQUALITY_MARKER = "_block_size_1mb_";
+
+/**
+ * fio twin pairs among a suite's declared metrics: two ids identical up to the _mb_per_s/_iops
+ * suffix (one scenario+direct-mode measured on two scales), restricted to the 1MB block size where
+ * the two scales are numerically equal and PTS's duplicate-value drop can actually fire. Derived
+ * from the declaration — never a hardcoded pair list — so catalog changes (new scenarios, retired
+ * probes) keep the check in sync. Sorted for a byte-stable gap reason.
+ */
+function twinPairs(declared: ReadonlySet<string>): Array<readonly [string, string]> {
+	const [mbSuffix, iopsSuffix] = TWIN_SUFFIXES;
+	const pairs: Array<readonly [string, string]> = [];
+	for (const id of [...declared].sort((a, b) => a.localeCompare(b, "en"))) {
+		if (!id.endsWith(mbSuffix) || !id.includes(TWIN_EQUALITY_MARKER)) continue;
+		const iops = `${id.slice(0, -mbSuffix.length)}${iopsSuffix}`;
+		if (declared.has(iops)) pairs.push([id, iops]);
+	}
+	return pairs;
+}
+
 /** Parse a JSON file, returning undefined (never throwing) when it's absent or malformed. */
 function readJsonFile(path: string): unknown {
 	try {
@@ -217,6 +261,10 @@ export function normalizeProviderDir(rawRoot: string, providerId: string): Provi
 	// leaf's entries — one leaf's recorded failure must not hide a DIFFERENT leaf's silent loss.
 	const foldedFailedLeaves = new Map<string, Set<string>>();
 	const harnessFailedSuites = new Set<string>();
+	// Per-suite dropped-twin candidates: declared fio twins whose <Result> is ABSENT (not empty)
+	// while the other member of the pair produced a value — PTS's duplicate-value dedup signature.
+	// Collected here, emitted as at most ONE suite gap after the loop, same as the shortfalls.
+	const suiteTwinDrops = new Map<string, DroppedTwinResult[]>();
 
 	for (const suite of suiteDirs) {
 		const ext = extractProviderDir(join(dir, suite), providerId);
@@ -281,6 +329,33 @@ export function normalizeProviderDir(rawRoot: string, providerId: string): Provi
 			suiteShortfalls.set(
 				suite,
 				[...missingById.values()].sort((a, b) => a.metricId.localeCompare(b.metricId, "en")),
+			);
+		}
+		// Dropped-twin evidence: PTS's result-parser drops a <Result> whose numeric values duplicate an
+		// earlier result's, and with 1MB blocks a fio scenario's MB/s equals its IOPS — so one twin
+		// vanishes ENTIRELY (absent, not empty) and the attempted-and-empty evidence above never sees
+		// it. The surviving twin IS the proof the scenario ran: exactly one member with a value, the
+		// other with neither a value nor an empty Result, means dropped — not un-probed. BOTH twins
+		// absent stays gap-free: that scenario was legitimately never run (the probe-subset rule).
+		const attempted = new Set(ext.attemptedEmpty.map((e) => e.metricId));
+		const dropped: DroppedTwinResult[] = [];
+		for (const pair of twinPairs(declared)) {
+			for (const [survivor, missing] of [pair, [pair[1], pair[0]]] as const) {
+				if (!produced.has(survivor) || produced.has(missing) || attempted.has(missing)) continue;
+				const source = ext.contributions.find((c) => c.metricId === survivor);
+				// `produced` implies a contribution exists; the guard keeps this pass total (never throw).
+				if (!source) continue;
+				// A Result that failed catalog mapping is PRESENT, not a PTS duplicate-value omission. Be
+				// conservative at the composite boundary: any unmapped Result beside the survivor makes the
+				// exact cause ambiguous, so do not publish the stronger dedup explanation.
+				if (ext.unmappedPts.some((result) => result.sourceFile === source.sourceFile)) continue;
+				dropped.push({ metricId: missing, sourceFile: `${suite}/${source.sourceFile}` });
+			}
+		}
+		if (dropped.length > 0) {
+			suiteTwinDrops.set(
+				suite,
+				dropped.sort((a, b) => a.metricId.localeCompare(b.metricId, "en")),
 			);
 		}
 	}
@@ -363,6 +438,33 @@ export function normalizeProviderDir(rawRoot: string, providerId: string): Provi
 			id: suite,
 			outcome: "failed",
 			reason: shortfallReason(suite, missing),
+		});
+	}
+
+	// Dropped-twin gaps: same shape as the shortfall above, but the lost <Result> is ABSENT rather
+	// than empty, so it needs its own evidence (the surviving twin, collected per suite above). Same
+	// suppression rules mirror shortfalls: a harness whole-suite failure mutes the suite, while a
+	// folded leaf failure mutes only candidates from that same leaf. A different leaf's marker or
+	// shortfall remains independent. Legacy flat-layout measurements also rescue a candidate because
+	// the supposedly missing metric is present in the published output. This pass only pushes gaps.
+	for (const suite of suiteDirs) {
+		const collected = suiteTwinDrops.get(suite);
+		if (!collected || harnessFailedSuites.has(suite)) continue;
+		const mutedLeaves = foldedFailedLeaves.get(suite);
+		const dropped = collected.filter((candidate) => {
+			if (producedAnywhere.has(candidate.metricId)) return false;
+			if (!mutedLeaves) return true;
+			// Use the missing twin's catalogued test/scenario identity, not the survivor composite's
+			// filename: result-name contamination can put a sequential Result in a random-read file, and
+			// that misleading filename must not let the random-read marker hide a sequential twin loss.
+			return ![...mutedLeaves].some((leaf) => leafOwnsMetric(leaf, candidate.metricId));
+		});
+		if (dropped.length === 0) continue;
+		gaps.push({
+			scope: "suite",
+			id: suite,
+			outcome: "failed",
+			reason: twinDropReason(dropped),
 		});
 	}
 


### PR DESCRIPTION
**Bench-matrix green — every suite×provider cell measuring or honestly gapped**
Fixes the 10 root causes behind the failures and silent metric holes of runs [29799034615](https://github.com/starslingdev/hpc-sandbox-benchmarks/actions/runs/29799034615) and [29850811070](https://github.com/starslingdev/hpc-sandbox-benchmarks/actions/runs/29850811070). Shipped as a 13-PR stack (merge bottom-up, each branch independently green):
1. #229 — results: tolerate the all-failed PTS composite shape (empty Proportion)
2. #230 — results: record attempted-but-empty catalogued Results as evidence
3. #231 — results: suite-shortfall gaps + leaf-marker folding
4. #232 — results: gaps for PTS duplicate-value fio twin drops
5. #233 — leaderboard: no fabricated missing-rows for never-dispatched providers
6. #234 — realworld: per-task timeout + cgroup-v2 memory containment
7. #235 — harness: failed gap on sandbox-creation failure
8. #236 — harness: detached log read-back + collect retries
9. #237 — bench: loud PTS leaf guards; stream + pybench measure again
10. #238 — templates: pgbench bake fix (pkg-config), payload assertion, portable fio, v4
11. #239 — fast-cli: settle gated on upload-phase stability
12. #240 — providers: Daytona region pin actually reaches the API; both variants us-west-2
13. #241 — ci: dataset-PR PAT fallback; e2b disk-skip notes

↑ **This PR is #232 (4/13)**.

---

With 1MB blocks a fio scenario's MB/s numerically equals its IOPS, and
PTS's result-parser drops a <Result> whose values duplicate an earlier
one's — so one twin vanishes ENTIRELY (absent, not empty; a per-run coin
flip that hit daytona-vm, novita, and blaxel in run 29850811070 while
modal-vm survived on a rounding difference). The attempted-empty evidence
never sees an absent Result, so this needs its own detection: twin pairs
are derived from the suite's declared metrics (ids identical up to the
_mb_per_s/_iops suffix — programmatic, no hardcoded list), and exactly one
member producing a value while the other has neither value nor empty
Result means dropped, not un-probed. BOTH absent stays gap-free (the
probe-subset rule). Detection is restricted to the 1MB pairs where MB/s == IOPS is
structural (a missing 4KB sibling can never be a duplicate-value drop);
same suppression and never-throw rules as the shortfall pass;
producer-side value nudging was rejected — it would alter measured
values.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Detect and record a suite-scoped gap when PTS drops one `fio` MB/s↔IOPS twin at 1MB due to duplicate-value dedup. Uses the surviving twin as evidence and names its source file while avoiding false positives.

- **New Features**
  - Derives twin pairs from declared metric IDs (`_mb_per_s` ↔ `_iops`), no hardcoded list.
  - Restricts detection to 1MB; excludes 4KB.
  - Emits one failed suite gap when exactly one twin produced a value and the other is absent (not empty); both-present and both-absent stay gap-free.
  - Suppresses the twin gap if a suite-level failed gap exists; also mutes candidates from the same leaf while allowing gaps for other leaves.
  - Avoids false positives by recording unmapped PTS `Result`s during extraction and skipping those composites, rescuing via legacy flat measurements, and using metric identity (not filenames) for leaf ownership; byte-stable reasons.

<sup>Written for commit e07d3b6bd6e68bcf95abdef8fa3d920646e53a38. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/starslingdev/hpc-sandbox-benchmarks/pull/232?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

