### PR TITLE
fix(leaderboard): stop deriving per-suite missing rows for never-dispatched providers

### DIFF
--- a/LEADERBOARD.md
+++ b/LEADERBOARD.md
@@ -24,12 +24,12 @@ cross-check.
 | Provider | Isolation (declared) | Detected |
 | --- | --- | --- |
 | Blaxel | microVM | vm |
-| Daytona (container) | container (Sysbox/OCI) | — |
 | Daytona (VM) | microVM (Linux VM) | vm |
 | E2B | Firecracker microVM | vm |
 | Modal (gVisor) | gVisor container | gvisor |
-| Modal (VM) | microVM (VM runtime) | — |
 | Novita | microVM | vm |
+
+_Not present in this run: Daytona (container), Modal (VM) — registered providers that reported no data (not dispatched, or every cell was lost before reporting anything)._
 
 ## cpu
 
@@ -567,7 +567,7 @@ _Novita is cheapest · Daytona (VM) is ~1.1× higher (lower is better)._
 
 ## Coverage gaps
 
-24 uncovered results across 6 providers (Daytona (container) 8, Daytona (VM) 1, E2B 3, Modal (gVisor) 3, Modal (VM) 8, Novita 1). A gap is a missing result — the provider **failing to cover** that workload — never a tie or a zero.
+8 uncovered results across 4 providers (Daytona (VM) 1, E2B 3, Modal (gVisor) 3, Novita 1). A gap is a missing result — the provider **failing to cover** that workload — never a tie or a zero.
 
 <details>
 <summary>Full coverage table</summary>
@@ -580,24 +580,8 @@ _Novita is cheapest · Daytona (VM) is ~1.1× higher (lower is better)._
 | E2B | network | **failed** | Step "mise run benchmark:network:all" failed with exit code 1 |
 | Modal (gVisor) | realworld-openclaw | **failed** | Step "mise run benchmark:realworld:pts:openclaw" timed out after 4800s |
 | Novita | network | **failed** | Step "mise run benchmark:network:all" failed with exit code 1 |
-| Daytona (container) | cpu-node | **missing** | No result and no marker — the suite never reported for this provider. |
-| Daytona (container) | disk | **missing** | No result and no marker — the suite never reported for this provider. |
-| Daytona (container) | memory | **missing** | No result and no marker — the suite never reported for this provider. |
-| Daytona (container) | network | **missing** | No result and no marker — the suite never reported for this provider. |
-| Daytona (container) | realworld-better-auth | **missing** | No result and no marker — the suite never reported for this provider. |
-| Daytona (container) | realworld-mastra | **missing** | No result and no marker — the suite never reported for this provider. |
-| Daytona (container) | realworld-openclaw | **missing** | No result and no marker — the suite never reported for this provider. |
-| Daytona (container) | system | **missing** | No result and no marker — the suite never reported for this provider. |
 | Modal (gVisor) | disk | **missing** | No result and no marker — the suite never reported for this provider. |
 | Modal (gVisor) | memory | **missing** | No result and no marker — the suite never reported for this provider. |
-| Modal (VM) | cpu-node | **missing** | No result and no marker — the suite never reported for this provider. |
-| Modal (VM) | disk | **missing** | No result and no marker — the suite never reported for this provider. |
-| Modal (VM) | memory | **missing** | No result and no marker — the suite never reported for this provider. |
-| Modal (VM) | network | **missing** | No result and no marker — the suite never reported for this provider. |
-| Modal (VM) | realworld-better-auth | **missing** | No result and no marker — the suite never reported for this provider. |
-| Modal (VM) | realworld-mastra | **missing** | No result and no marker — the suite never reported for this provider. |
-| Modal (VM) | realworld-openclaw | **missing** | No result and no marker — the suite never reported for this provider. |
-| Modal (VM) | system | **missing** | No result and no marker — the suite never reported for this provider. |
 
 **skipped** — a precondition said no before the benchmark was attempted. A ❌ **disk** skip is the
 loud one: the provider could not supply the disk the suite needs, so the workload does not run on

--- a/apps/cli/src/lib/actions-log.ts
+++ b/apps/cli/src/lib/actions-log.ts
@@ -6,6 +6,7 @@
 import type { AnnotationProperties } from "@actions/core";
 import * as core from "@actions/core";
 import type { Run } from "@sandbox-benchmarks/schema";
+import { providerStatusText } from "@sandbox-benchmarks/schema";
 
 export type CellKind = "plain" | "code";
 
@@ -88,7 +89,7 @@ export function providerSummaryRows(run: Run): SummaryRow[] {
 		const failed = provider.gaps.filter((g) => g.outcome === "failed").length;
 		return [
 			renderCell(provider.providerId, "code"),
-			escapeHtml(provider.validationStatus),
+			escapeHtml(providerStatusText(provider)),
 			escapeHtml(String(provider.metrics.length)),
 			escapeHtml(String(provider.suitesCovered.length)),
 			escapeHtml(String(skipped)),
@@ -109,7 +110,7 @@ export async function logProviderStatuses(
 			const skipped = provider.gaps.filter((g) => g.outcome === "skipped").length;
 			const failed = provider.gaps.filter((g) => g.outcome === "failed").length;
 			const line =
-				`${provider.providerId} status=${provider.validationStatus} ` +
+				`${provider.providerId} status=${providerStatusText(provider)} ` +
 				`metrics=${provider.metrics.length} suites=${provider.suitesCovered.length} ` +
 				`skipped=${skipped} failed=${failed} uncatalogued=${provider.uncatalogued.length}`;
 			logInfo(line);

--- a/packages/results/src/index.test.ts
+++ b/packages/results/src/index.test.ts
@@ -54,7 +54,12 @@ describe("normalizeResultsTree", () => {
 		expect(e2b?.metrics).toEqual([]);
 	});
 
-	it("summarizes one line per provider", () => {
-		expect(summarizeRun(run)).toHaveLength(PROVIDERS.length);
+	it("summarizes one line per provider, tagging zero-evidence rows", () => {
+		const lines = summarizeRun(run);
+		expect(lines).toHaveLength(PROVIDERS.length);
+		// Same status text the CI job summary prints (shared providerStatusText): a never-dispatched
+		// provider must not read like a freshly-attempted shard that also shows `pending metrics=0`.
+		expect(lines.find((l) => l.startsWith("e2b"))).toContain("pending (no shard data)");
+		expect(lines.find((l) => l.startsWith("daytona-vm"))).not.toContain("(no shard data)");
 	});
 });

--- a/packages/results/src/index.ts
+++ b/packages/results/src/index.ts
@@ -7,6 +7,7 @@
 // normalize a raw tree, write the Run, and summarize it.
 export { aggregateRuns } from "./lib/aggregate.ts";
 export {
+	type AbsentProvider,
 	buildLeaderboard,
 	type ComparabilityCaveat,
 	// Every type reachable from `Leaderboard` is exported with it: a consumer that can hold the value but

--- a/packages/results/src/lib/aggregate.test.ts
+++ b/packages/results/src/lib/aggregate.test.ts
@@ -251,9 +251,12 @@ describe("aggregateRuns", () => {
 	});
 
 	it("disqualifies a provider whose specMatched fold has any mismatched shard, regardless of order", () => {
+		// A verdict must ride on observations (schema narrow), as the real probe always produces.
 		const matched = provider("daytona-vm", [metric("node_web_tooling_runs_per_s", [10])]);
+		matched.observedSpecs = { vcpus: 2, memoryGb: 8 };
 		matched.specMatched = true;
 		const mismatched = provider("daytona-vm", [metric("pybench_milliseconds", [900])]);
+		mismatched.observedSpecs = { vcpus: 1, memoryGb: 8 };
 		mismatched.specMatched = false;
 
 		// false is sticky no matter which shard arrives first.
@@ -273,6 +276,7 @@ describe("aggregateRuns", () => {
 		).toBeUndefined();
 
 		const matchOnly = provider("daytona-vm", [metric("pybench_milliseconds", [900])]);
+		matchOnly.observedSpecs = { vcpus: 2, memoryGb: 8 };
 		matchOnly.specMatched = true;
 		expect(
 			aggregateRuns([noProbe, shard([matchOnly])]).providers.find(

--- a/packages/results/src/lib/leaderboard.test.ts
+++ b/packages/results/src/lib/leaderboard.test.ts
@@ -796,11 +796,12 @@ describe("coverage gaps: the holes nobody recorded", () => {
 		// The case the whole derivation exists for, and the one that was previously invisible: e2b produced
 		// no result AND left no marker, so it appears in no ranked table (no value) and in no recorded gap
 		// (no marker). Without deriving it, a provider that contributed nothing to the run reads as absent
-		// from the comparison rather than as failing to cover it.
+		// from the comparison rather than as failing to cover it. The spec-probe reading is what keeps e2b
+		// a PARTICIPANT here — a row with zero evidence of any kind is "not present in this run" instead.
 		const board = buildLeaderboard(
 			run([
 				provider("daytona-vm", [metric(HEADLINE, [10, 11])], [], ["cpu-node", "disk"]),
-				provider("e2b", []),
+				{ ...provider("e2b", []), observedSpecs: { vcpus: 2 } },
 			]),
 		);
 		expect(board.coverageGaps).toEqual([
@@ -925,7 +926,8 @@ describe("coverage gaps: the holes nobody recorded", () => {
 			buildLeaderboard(
 				run([
 					provider("daytona-vm", [metric(HEADLINE, [10, 11])], [], ["cpu-node"]),
-					provider("e2b", []),
+					// The spec probe keeps e2b in the derivation (a zero-evidence row would be "not present").
+					{ ...provider("e2b", []), observedSpecs: { vcpus: 2 } },
 				]),
 			),
 		);
@@ -959,6 +961,104 @@ describe("coverage gaps: the holes nobody recorded", () => {
 			"disk/skipped", // ❌ disk leads: a structural absence
 			"cpu-node/failed", // then what broke
 			"pgbench/missing", // then what never said anything at all
+		]);
+	});
+});
+
+describe("absent providers (zero-evidence registry rows) and the registered-suite denominator", () => {
+	const HEADLINE = "node_web_tooling_runs_per_s";
+
+	it("collapses a zero-evidence provider into ONE not-present note, out of gaps and the roster", () => {
+		// The dataset keeps one pending row per registry provider (first-class), but a provider the run
+		// never dispatched has not "failed to cover" anything — per-suite `missing` rows for it once
+		// buried the two real holes under 16 phantom ones in the committed LEADERBOARD.md.
+		const board = buildLeaderboard(
+			run([
+				provider("daytona-vm", [metric(HEADLINE, [10, 11])], [], ["cpu-node", "disk"]),
+				provider("modal-vm", []),
+			]),
+		);
+		expect(board.coverageGaps.filter((g) => g.providerId === "modal-vm")).toEqual([]);
+		expect(board.absentProviders).toEqual([{ providerId: "modal-vm", displayName: "Modal (VM)" }]);
+		expect(board.roster.map((r) => r.providerId)).toEqual(["daytona-vm"]);
+		const md = renderLeaderboardMarkdown(board);
+		expect(md).toContain(
+			"_Not present in this run: Modal (VM) — registered providers that reported no data (not dispatched, or every cell was lost before reporting anything)._",
+		);
+	});
+
+	it("keeps a provider with ANY participation evidence in the missing-suite derivation", () => {
+		// A recorded gap (and equally a straggler or a spec probe) proves the provider was part of the
+		// run, so its other holes are real derived-missing rows, not a "not present" note.
+		const board = buildLeaderboard(
+			run([
+				provider("daytona-vm", [metric(HEADLINE, [10, 11])], [], ["cpu-node", "disk"]),
+				provider(
+					"e2b",
+					[],
+					[{ scope: "suite", id: "cpu-node", outcome: "failed", reason: "PTS died" }],
+				),
+			]),
+		);
+		expect(board.absentProviders).toEqual([]);
+		expect(board.coverageGaps.map((g) => `${g.providerId}/${g.id}/${g.outcome}`)).toEqual([
+			"e2b/cpu-node/failed",
+			"e2b/disk/missing",
+		]);
+	});
+
+	it("does not double a recorded suite-shortfall gap with a derived missing row", () => {
+		// The normalizer's shortfall gap carries id === suite, so accountedFor suppresses the derived
+		// row for that suite — the provider stays covered (keep+warn), warned exactly once.
+		const shortfall = {
+			scope: "suite" as const,
+			id: "memory",
+			outcome: "failed" as const,
+			reason:
+				"PTS ran but every trial failed for 2 of 4 declared metrics: stream_type_add (memory/pts_stream.xml), stream_type_triad (memory/pts_stream.xml) — attempted, no value recorded",
+		};
+		const board = buildLeaderboard(
+			run([
+				provider("daytona-vm", [metric(HEADLINE, [10, 11])], [shortfall], ["cpu-node", "memory"]),
+				provider("e2b", [metric(HEADLINE, [12, 13])], [], ["cpu-node", "memory"]),
+			]),
+		);
+		expect(board.coverageGaps.map((g) => `${g.providerId}/${g.id}/${g.outcome}`)).toEqual([
+			"daytona-vm/memory/failed",
+		]);
+	});
+
+	it("keeps a non-registered suitesCovered name out of the denominator", () => {
+		// A published Run outlives the registry that validated it: a suite covered then but
+		// deregistered since must not accuse every current provider of missing a suite nobody can
+		// run anymore — same rule the gap-id side already enforces.
+		const board = buildLeaderboard(
+			run([
+				provider("daytona-vm", [metric(HEADLINE, [10, 11])], [], ["cpu-node", "retired-suite"]),
+				provider("e2b", [metric(HEADLINE, [12, 13])], [], ["cpu-node"]),
+			]),
+		);
+		expect(board.coverageGaps).toEqual([]);
+	});
+
+	it("keeps a non-registered gap id out of every OTHER provider's derived-missing rows", () => {
+		// A legacy bash leaf marker's pseudo-suite id ("pts_fast-cli") is a real recorded gap for its
+		// own provider, but it is not a suite — folding it into the denominator would accuse every
+		// other provider of missing a nonexistent one.
+		const board = buildLeaderboard(
+			run([
+				provider("daytona-vm", [metric(HEADLINE, [10, 11])], [], ["cpu-node"]),
+				provider(
+					"e2b",
+					[metric(HEADLINE, [12, 13])],
+					[{ scope: "suite", id: "pts_fast-cli", outcome: "failed", reason: "no numeric value" }],
+					["cpu-node"],
+				),
+			]),
+		);
+		// The recorded gap itself still renders for e2b; daytona is accused of nothing.
+		expect(board.coverageGaps.map((g) => `${g.providerId}/${g.id}/${g.outcome}`)).toEqual([
+			"e2b/pts_fast-cli/failed",
 		]);
 	});
 });

--- a/packages/results/src/lib/leaderboard.ts
+++ b/packages/results/src/lib/leaderboard.ts
@@ -36,6 +36,8 @@ import {
 	kolmogorovSmirnov,
 	METRIC_CATALOG,
 	mannWhitneyU,
+	providerReportedNothing,
+	SUITE_NAMES,
 } from "@sandbox-benchmarks/schema";
 
 /** One provider's standing on one Metric. */
@@ -172,6 +174,12 @@ export interface CoverageGap {
 	disk: boolean;
 }
 
+/** A registered provider whose Run row carries no evidence at all — never dispatched, or lost whole. */
+export interface AbsentProvider {
+	providerId: string;
+	displayName: string;
+}
+
 /** The full comparison surface derived from one Run. */
 export interface Leaderboard {
 	runId: string;
@@ -186,6 +194,14 @@ export interface Leaderboard {
 	comparabilityCaveats: ComparabilityCaveat[];
 	/** Every benchmark that produced no result somewhere, disk gaps first. Empty when coverage is complete. */
 	coverageGaps: CoverageGap[];
+	/**
+	 * Registered providers whose Run row is a zero-evidence pending placeholder (the dataset keeps one
+	 * row per registry provider). Surfaced as one "not present in this run" note rather than per-suite
+	 * `missing` rows: a provider the run never dispatched has not "failed to cover" anything, and its
+	 * phantom rows would bury the real holes (16 of 24 committed coverage rows once accused two
+	 * never-dispatched providers).
+	 */
+	absentProviders: AbsentProvider[];
 }
 
 /**
@@ -201,18 +217,34 @@ function isDiskGap(reason: string): boolean {
 /** Rendering/sort precedence: the structural absences first, the merely-unreported last. */
 const OUTCOME_ORDER: Record<CoverageOutcome, number> = { skipped: 0, failed: 1, missing: 2 };
 
+/** The registry's suite names — the only ids a suite-scope gap may fold into the derivation below. */
+const REGISTERED_SUITES = new Set<string>(SUITE_NAMES);
+
 /**
  * The suites this Run actually exercised — every suite that produced a Metric for SOME provider, or
  * that some provider left a marker for. This is the denominator the missing-suite gaps are derived
  * against, and it is deliberately the Run's OWN evidence rather than the registry's `SUITE_NAMES`: a
  * Run that only ever ran the disk suite has not "failed to cover" the other five, and accusing every
  * provider of five holes would bury the one real gap in noise the reader must then learn to ignore.
+ *
+ * Only REGISTERED suite names fold in, from either source. Gap ids: a legacy bash leaf marker's
+ * pseudo-suite id (e.g. "pts_fast-cli" — the marker body's `benchmark` becomes the gap id) is a
+ * real recorded gap, but it is not a suite, and admitting it here would accuse every OTHER provider
+ * of missing a nonexistent one. (The normalizer now folds leaf ids into their suite; this filter
+ * keeps already-published Runs that predate the fold from corrupting the denominator.)
+ * `suitesCovered`: today's producer only records catalogued suites, but an already-published Run
+ * outlives the registry that validated it — a suite deregistered later would otherwise re-enter the
+ * denominator and accuse every current provider of missing a suite nobody can run anymore.
  */
 function suitesExercised(run: Run): string[] {
 	const suites = new Set<string>();
 	for (const provider of run.providers) {
-		for (const suite of provider.suitesCovered) suites.add(suite);
-		for (const gap of provider.gaps) if (gap.scope === "suite") suites.add(gap.id);
+		for (const suite of provider.suitesCovered) {
+			if (REGISTERED_SUITES.has(suite)) suites.add(suite);
+		}
+		for (const gap of provider.gaps) {
+			if (gap.scope === "suite" && REGISTERED_SUITES.has(gap.id)) suites.add(gap.id);
+		}
 	}
 	return [...suites].sort((a, b) => a.localeCompare(b, "en"));
 }
@@ -231,6 +263,11 @@ function coverageGapsOf(run: Run): CoverageGap[] {
 	const exercised = suitesExercised(run);
 
 	const gaps = run.providers.flatMap((provider): CoverageGap[] => {
+		// A zero-evidence registry row (never dispatched, or every cell lost before reporting) gets the
+		// single "not present in this run" note instead of one derived `missing` row per exercised
+		// suite. Any participation evidence — a gap, a straggler, a spec probe — keeps the provider in
+		// the derivation: it WAS part of the run, so its holes are real.
+		if (providerReportedNothing(provider)) return [];
 		const displayName = getProvider(provider.providerId)?.displayName ?? provider.providerId;
 		const accountedFor = new Set([
 			...provider.suitesCovered,
@@ -449,7 +486,10 @@ function isolationClass(declared: string | undefined): "gvisor" | "container" | 
  * "unknown" (the common case) or any unrecognized raw value never counts, so the declaration wins.
  */
 function buildRoster(run: Run): ProviderRosterEntry[] {
-	return run.providers.map((provider): ProviderRosterEntry => {
+	// "Every provider measured in this Run": a zero-evidence registry placeholder was not measured —
+	// it lands in the absent-providers note instead of a roster row claiming an isolation nobody probed.
+	const measured = run.providers.filter((p) => !providerReportedNothing(p));
+	return measured.map((provider): ProviderRosterEntry => {
 		const meta = getProvider(provider.providerId);
 		const declaredIsolation = meta?.isolation.technology;
 		const detectedIsolation = provider.observedSpecs.detectedIsolation;
@@ -501,6 +541,10 @@ export function buildLeaderboard(run: Run): Leaderboard {
 		targetSpec: run.targetSpec,
 		dimensions,
 		roster: buildRoster(run),
+		absentProviders: run.providers.filter(providerReportedNothing).map((provider) => ({
+			providerId: provider.providerId,
+			displayName: getProvider(provider.providerId)?.displayName ?? provider.providerId,
+		})),
 		comparabilityCaveats: run.providers.flatMap((provider): ComparabilityCaveat[] =>
 			provider.specMatched === false
 				? [
@@ -720,6 +764,16 @@ export function renderLeaderboardMarkdown(board: Leaderboard): string {
 		"",
 	];
 	lines.push(...rosterSection(board.roster));
+	if (board.absentProviders.length > 0) {
+		// One line, not per-suite `missing` rows: the Run does not record the dispatch plan
+		// (BENCH_PROVIDERS), so "never dispatched" and "every cell lost before reporting anything" are
+		// indistinguishable here — the wording deliberately covers both.
+		const names = board.absentProviders.map((p) => p.displayName).join(", ");
+		lines.push(
+			`_Not present in this run: ${names} — registered providers that reported no data (not dispatched, or every cell was lost before reporting anything)._`,
+			"",
+		);
+	}
 	for (const caveat of board.comparabilityCaveats) {
 		lines.push(
 			`> **Comparability warning:** ${caveat.displayName}'s observed compute did not match the requested CPU/RAM target; its observed allocation was **${formatSpec(caveat.observedSpecs)}**. Its measured ranks are not like-for-like with compute-matched providers.`,

--- a/packages/results/src/lib/write-run.ts
+++ b/packages/results/src/lib/write-run.ts
@@ -5,7 +5,7 @@
 import { mkdirSync, readFileSync, renameSync, writeFileSync } from "node:fs";
 import { dirname, relative, resolve } from "node:path";
 import type { Run, RunIndex } from "@sandbox-benchmarks/schema";
-import { parseRunIndex } from "@sandbox-benchmarks/schema";
+import { parseRunIndex, providerStatusText } from "@sandbox-benchmarks/schema";
 import { normalizeResultsTree } from "./normalize-tree.ts";
 
 /**
@@ -99,7 +99,7 @@ export function summarizeRun(run: Run): string[] {
 		const skipped = provider.gaps.filter((g) => g.outcome === "skipped").length;
 		const failed = provider.gaps.filter((g) => g.outcome === "failed").length;
 		return (
-			`${provider.providerId.padEnd(12)} ${provider.validationStatus.padEnd(10)} ` +
+			`${provider.providerId.padEnd(12)} ${providerStatusText(provider).padEnd(10)} ` +
 			`metrics=${provider.metrics.length} suites=${provider.suitesCovered.length} ` +
 			`skipped=${skipped} failed=${failed} uncatalogued=${provider.uncatalogued.length}`
 		);

--- a/packages/schema/src/raw-files.test.ts
+++ b/packages/schema/src/raw-files.test.ts
@@ -1,11 +1,14 @@
 import { describe, expect, it } from "bun:test";
+import type { ProviderRun } from "./index.ts";
 import {
+	aggregate,
 	harnessGapMarkerJson,
 	isPtsForensicsFile,
 	isPtsResultFile,
 	isSkipMarkerFile,
 	parseGapMarker,
 	parseResultsArtifactName,
+	providerReportedNothing,
 	ptsForensicsFile,
 	resultsArtifactName,
 	sandboxSkipMarkerFile,
@@ -147,6 +150,39 @@ describe("parseGapMarker", () => {
 		});
 	});
 
+	it("reads the bench.sh fail_result shape (a leaf that RAN and errored on every trial)", () => {
+		// The exact body run_pts_benchmark writes beside a value-less composite. The --failed.json
+		// suffix decides the outcome, the body's outcome agrees, and `benchmark` becomes the gap id —
+		// the LEAF name at this layer (the normalizer folds it into the suite).
+		const marker = parseGapMarker(
+			"pts_fio-rand-read--failed.json",
+			{
+				outcome: "failed",
+				benchmark: "pts_fio-rand-read",
+				reason:
+					"PTS batch-run of pts/fio-2.1.0 completed but every trial errored (composite carries no values)",
+			},
+			"modal-gvisor",
+		);
+		expect(marker).toEqual({
+			scope: "suite",
+			id: "pts_fio-rand-read",
+			outcome: "failed",
+			reason:
+				"PTS batch-run of pts/fio-2.1.0 completed but every trial errored (composite carries no values)",
+		});
+	});
+
+	it("rejects the fail_result body under a --skipped.json filename (suffix/body contradiction)", () => {
+		expect(
+			parseGapMarker(
+				"pts_fio-rand-read--skipped.json",
+				{ outcome: "failed", benchmark: "pts_fio-rand-read", reason: "every trial errored" },
+				"modal-gvisor",
+			),
+		).toBeUndefined();
+	});
+
 	it("rejects a marker whose body outcome contradicts the filename suffix (literal trap)", () => {
 		// The two halves disagree, so the marker is corrupt: guessing which to believe is how a crashed
 		// suite gets published as a deliberate skip. Neither direction is resolved by precedence.
@@ -168,5 +204,53 @@ describe("parseGapMarker", () => {
 
 	it("returns undefined when the filename is not a gap marker", () => {
 		expect(parseGapMarker("results.json", { skipped: true }, "daytona")).toBeUndefined();
+	});
+});
+
+// Colocated with the marker tests (both sides of "did this provider report anything?"): the marker
+// files are the evidence trail, and this predicate is what consumers use when NO trail exists.
+describe("providerReportedNothing", () => {
+	const empty = (): ProviderRun => ({
+		providerId: "modal-vm",
+		validationStatus: "pending",
+		observedSpecs: {},
+		metrics: [],
+		suitesCovered: [],
+		gaps: [],
+		uncatalogued: [],
+	});
+
+	it("is true for the zero-evidence placeholder the normalizer emits for an absent raw dir", () => {
+		expect(providerReportedNothing(empty())).toBe(true);
+	});
+
+	it("flips false on EACH single piece of participation evidence", () => {
+		expect(
+			providerReportedNothing({
+				...empty(),
+				validationStatus: "validated",
+				metrics: [{ metricId: "m", samples: [1], aggregates: aggregate([1]) }],
+			}),
+		).toBe(false);
+		expect(providerReportedNothing({ ...empty(), suitesCovered: ["cpu-node"] })).toBe(false);
+		expect(
+			providerReportedNothing({
+				...empty(),
+				gaps: [{ scope: "suite", id: "cpu-node", outcome: "failed", reason: "died" }],
+			}),
+		).toBe(false);
+		expect(
+			providerReportedNothing({
+				...empty(),
+				uncatalogued: [{ id: "pts/x::default::s", value: 1, sourceFile: "pts_x.xml" }],
+			}),
+		).toBe(false);
+		expect(providerReportedNothing({ ...empty(), observedSpecs: { vcpus: 2 } })).toBe(false);
+		expect(
+			providerReportedNothing({
+				...empty(),
+				hostMetadata: [{ source: "mise/system-provider", sourceFile: "s.json", fields: [] }],
+			}),
+		).toBe(false);
 	});
 });

--- a/packages/schema/src/run.test.ts
+++ b/packages/schema/src/run.test.ts
@@ -155,6 +155,28 @@ describe("Run schema", () => {
 		expect(parseRun(pending).providers[0]?.validationStatus).toBe("pending");
 	});
 
+	it("rejects a specMatched verdict on a ProviderRun that observed nothing", () => {
+		// specMatched is computed FROM observations; a row carrying a verdict with an empty
+		// observedSpecs would render both as "not present in this run" and under a comparability
+		// warning about measured ranks it doesn't have. Unrepresentable beats contradictory.
+		const bad = structuredClone(validRun);
+		const provider = bad.providers[0];
+		if (provider) {
+			provider.validationStatus = "pending";
+			provider.metrics = [];
+			(provider as Record<string, unknown>).observedSpecs = {};
+			(provider as Record<string, unknown>).specMatched = false;
+		}
+		expect(() => parseRun(bad)).toThrow(/observedSpecs when specMatched/);
+	});
+
+	it("accepts a specMatched verdict backed by observations", () => {
+		const good = structuredClone(validRun);
+		const provider = good.providers[0];
+		if (provider) (provider as Record<string, unknown>).specMatched = true;
+		expect(parseRun(good).providers[0]?.specMatched).toBe(true);
+	});
+
 	it("rejects a non-finite sample", () => {
 		const bad = structuredClone(validRun);
 		const metric = bad.providers[0]?.metrics[0];

--- a/packages/schema/src/run.ts
+++ b/packages/schema/src/run.ts
@@ -235,9 +235,13 @@ export type ResultGap = typeof resultGapSchema.infer;
 
 /**
  * One provider's slice of a Run: its catalogued Metrics, observed specs, coverage gaps and stragglers.
- * The `.narrow` enforces the cross-field invariant documented on {@link validationStatusSchema}: a
- * `validated` ProviderRun must carry at least one Metric, so `{ validationStatus: "validated",
- * metrics: [] }` is rejected at the boundary rather than reaching a consumer that branches on it.
+ * The `.narrow`s enforce two cross-field invariants: a `validated` ProviderRun must carry at least
+ * one Metric (see {@link validationStatusSchema}), so `{ validationStatus: "validated", metrics: [] }`
+ * is rejected at the boundary rather than reaching a consumer that branches on it; and a defined
+ * `specMatched` requires a non-empty `observedSpecs` — the verdict is computed FROM observations, so
+ * a row carrying one without any is a hand-authored contradiction that would otherwise render both as
+ * "not present in this run" ({@link providerReportedNothing}) and under a comparability warning about
+ * measured ranks it doesn't have.
  */
 export const providerRunSchema = type({
 	providerId: "string",
@@ -259,13 +263,53 @@ export const providerRunSchema = type({
 	/** Benchmarks that reported no result here, each tagged with WHY (see {@link resultGapSchema}). */
 	gaps: resultGapSchema.array(),
 	uncatalogued: uncataloguedResultSchema.array(),
-}).narrow(
-	(run, ctx) =>
-		run.validationStatus !== "validated" ||
-		run.metrics.length > 0 ||
-		ctx.mustBe('a ProviderRun with at least one metric when validationStatus is "validated"'),
-);
+})
+	.narrow(
+		(run, ctx) =>
+			run.validationStatus !== "validated" ||
+			run.metrics.length > 0 ||
+			ctx.mustBe('a ProviderRun with at least one metric when validationStatus is "validated"'),
+	)
+	.narrow(
+		(run, ctx) =>
+			run.specMatched === undefined ||
+			Object.keys(run.observedSpecs).length > 0 ||
+			ctx.mustBe("a ProviderRun with observedSpecs when specMatched carries a verdict"),
+	);
 export type ProviderRun = typeof providerRunSchema.infer;
+
+/**
+ * True when a ProviderRun carries NO evidence of participation at all: no metric, no coverage, no
+ * gap, no uncatalogued straggler, no observed-spec reading, no host-metadata record. This is exactly
+ * the shape the normalizer emits for an absent raw directory — a registered provider the run never
+ * dispatched (or whose every cell was lost before reporting anything). It is deliberately stricter
+ * than "no metrics": a straggler, a spec probe, or a host record IS participation evidence, and a
+ * provider that reported any of them belongs in the coverage derivation, not in the absent list.
+ * Consumers (the leaderboard's coverage derivation, the CLI status logs) use it to keep the pending
+ * dataset row first-class while not accusing a never-dispatched provider of per-suite holes.
+ * `specMatched` needs no clause of its own: the schema narrow rejects a verdict without
+ * observations, and observations already count via `observedSpecs`.
+ */
+export function providerReportedNothing(p: ProviderRun): boolean {
+	return (
+		p.metrics.length === 0 &&
+		p.suitesCovered.length === 0 &&
+		p.gaps.length === 0 &&
+		p.uncatalogued.length === 0 &&
+		Object.keys(p.observedSpecs).length === 0 &&
+		(p.hostMetadata?.length ?? 0) === 0
+	);
+}
+
+/**
+ * Display status for a ProviderRun row: the validation status, tagged "(no shard data)" when the
+ * row is a zero-evidence registry placeholder — so a never-dispatched provider stops printing
+ * indistinguishably from a freshly-attempted shard that also reads `pending metrics=0`. Shared by
+ * every human-facing status line (CI job summaries, `summarizeRun`) so the two views can't drift.
+ */
+export function providerStatusText(p: ProviderRun): string {
+	return providerReportedNothing(p) ? `${p.validationStatus} (no shard data)` : p.validationStatus;
+}
 
 /**
  * A full benchmark Run: every provider measured against one pinned target spec at one SHA.


### PR DESCRIPTION
**Bench-matrix green — every suite×provider cell measuring or honestly gapped**
Fixes the 10 root causes behind the failures and silent metric holes of runs [29799034615](https://github.com/starslingdev/hpc-sandbox-benchmarks/actions/runs/29799034615) and [29850811070](https://github.com/starslingdev/hpc-sandbox-benchmarks/actions/runs/29850811070). #229–#232 have merged; the remaining fixes are **parallel PRs based directly on `main`** — reviewable and mergeable in any order, except #238, which stacks on #237:
- #233 — leaderboard: no fabricated missing-rows for never-dispatched providers
- #234 — realworld: per-task timeout + cgroup-v2 memory containment
- #235 — harness: failed gap on sandbox-creation failure
- #236 — harness: detached log read-back + collect retries
- #237 — bench: loud PTS leaf guards; stream + pybench measure again
- #238 — templates: pgbench bake fix (pkg-config), payload assertion, portable fio, v4 *(stacked on #237)*
- #239 — fast-cli: settle gated on upload-phase stability
- #240 — providers: Daytona region pin actually reaches the API; both variants us-west-2
- #241 — ci: dataset-PR PAT fallback; e2b disk-skip notes

↑ **This PR is #233 — independent: based on `main`, no merge-order dependency on the others.**

---
The provider registry enumerates every known provider, so a run dispatched
with a narrowed BENCH_PROVIDERS (run 29799034615: 5 of 7) published a
LEADERBOARD.md accusing daytona-container and modal-vm of 16 per-suite
'missing' holes they were never asked to fill.

providerReportedNothing (schema) defines zero-participation precisely — no
metric, coverage, gap, straggler, spec reading, or host-metadata record;
any one of those IS participation and keeps the provider in the coverage
derivation. The leaderboard now lists zero-evidence providers in one 'not
present in this run' note instead of fabricating rows, the coverage
denominator folds only REGISTERED suite names (a stray gap id can never
accuse every other provider of missing a nonexistent suite), and the CLI
status log tags such rows '(no shard data)'. LEADERBOARD.md regenerated
from the same committed Run it already rendered — the diff is exactly the
16 fabricated rows collapsing into the note (autogenerated file).



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Leaderboards now clearly identify registered providers that reported no data.
  - Coverage calculations exclude providers with no participation evidence and ignore unregistered suites.
  - Provider status summaries now include clearer “no shard data” indicators.
  - Run results expose improved provider status and specification-matching information.

- **Bug Fixes**
  - Corrected leaderboard missing-coverage reporting and prevented duplicate or misleading gaps.
  - Improved validation for specification-matching results and failed or skipped suite records.
  - Refined provider status formatting across summaries and command-line output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->