### PR TITLE
fix(realworld): bound every task with a timeout and a cgroup-v2 memory cap

### DIFF
--- a/.mise/tasks/benchmark/realworld/selftest
+++ b/.mise/tasks/benchmark/realworld/selftest
@@ -14,7 +14,10 @@ OUT_DIR="${REPO_ROOT}/.scratch/selftest-out"
 # /out and mask a regression (the whole point of the selftest is a hermetic pass/fail).
 rm -rf "$OUT_DIR"
 mkdir -p "$OUT_DIR"
+# SYS_ADMIN (not --privileged): the payload's cgroup dance remounts /sys/fs/cgroup read-write —
+# Docker Desktop mounts cgroup2 read-only even under the default private cgroupns.
 exec docker run --rm \
+	--cap-add SYS_ADMIN \
 	-v "${REPO_ROOT}:/repo:ro" \
 	-v "${OUT_DIR}:/out" \
 	node:22-bookworm@sha256:a25c9934ff6382cd4f08b6bc26c82bf4ea69b1e6f8dabfb2ead457374127c365 \

--- a/lib/pts/realworld/realworld-runner.sh
+++ b/lib/pts/realworld/realworld-runner.sh
@@ -31,6 +31,163 @@ export TURBO_TELEMETRY_DISABLED=1
 export TURBO_FORCE=true
 export COREPACK_ENABLE_DOWNLOAD_PROMPT=0
 
+# Per-command hard bound. A wedged task (openclaw's oxlint --type-aware spawns tsgolint, which
+# needs >8GB and thrashes forever under gVisor where no in-sandbox OOM killer exists) must fail
+# ALONE after a bounded wait instead of eating the harness's whole 4800s step budget — PTS only
+# writes composite.xml when the batch completes, so an unbounded hang loses every already-measured
+# sample. Default 1200s gives 1.7x headroom over the slowest legitimate sample ever observed
+# (708s, novita openclaw git_clone). Overridable via env or target.env; do NOT add per-profile
+# knobs beyond that.
+TASK_TIMEOUT_SECONDS="${REALWORLD_TASK_TIMEOUT_SECONDS:-1200}"
+# GNU timeout treats 0 as "no timer at all" — the exact unbounded hang this bound exists to
+# prevent — so anything but a positive integer count of seconds is a misconfiguration, answered
+# loudly here instead of with a silently unbounded batch.
+case "$TASK_TIMEOUT_SECONDS" in
+'' | *[!0-9]*)
+	echo "REALWORLD_TASK_TIMEOUT_SECONDS must be a positive integer (seconds), got '${TASK_TIMEOUT_SECONDS}'" >&2
+	exit 1
+	;;
+esac
+if [ "$TASK_TIMEOUT_SECONDS" -eq 0 ]; then
+	echo "REALWORLD_TASK_TIMEOUT_SECONDS=0 would disable the timer (GNU timeout semantics), refusing" >&2
+	exit 1
+fi
+
+# Memory containment: task commands run inside a cgroup-v2 child capped below MemTotal so a task
+# that exhausts RAM is OOM-killed ALONE instead of driving a VM guest into global OOM — on
+# daytona-vm that killed the in-guest Daytona daemon and the whole benchmark tree ("lost its
+# sandbox"). Container providers are unchanged: the outer container limit already contains the
+# kill; the guarded writes below no-op without a writable cgroup fs and run_task falls back to
+# oom_score_adj-only victim biasing.
+if [ -n "${REALWORLD_TASK_MEM_MAX_BYTES:-}" ]; then
+	# Escape hatch, set per-profile in target.env (sourced above — a guaranteed transport, unlike
+	# assuming PTS passes arbitrary env through to the test wrapper). The selftest pins 256 MiB to
+	# exercise the OOM path deterministically; production profiles leave it unset.
+	cap_bytes="$REALWORLD_TASK_MEM_MAX_BYTES"
+else
+	mem_total_kb="$(awk '/^MemTotal:/ { print $2; exit }' /proc/meminfo 2>/dev/null || echo 0)"
+	# MemTotal minus 1 GiB headroom keeps the sandbox agent/kernel alive through a task OOM. On a
+	# host small enough that this leaves under 1 GiB, take HALF of MemTotal instead — a fixed floor
+	# at or above visible RAM would hand the task the very headroom the reserve exists to protect.
+	# memory.max also counts page cache, so a task whose working set lands inside the headroom band
+	# would reclaim instead of using all RAM — no currently-passing task does;
+	# REALWORLD_TASK_MEM_MAX_BYTES is the escape hatch if one ever appears. An unreadable
+	# /proc/meminfo (mem_total_kb=0) yields cap 0, which the setup below treats as
+	# cap-unavailable rather than writing a kill-everything memory.max=0.
+	cap_bytes=$((mem_total_kb * 1024 - 1073741824))
+	[ "$cap_bytes" -ge 1073741824 ] || cap_bytes=$((mem_total_kb * 1024 / 2))
+fi
+[ "${cap_bytes:-0}" -gt 0 ] || cap_bytes=""
+BENCH_CG=""
+if [ -n "$cap_bytes" ] && [ -f /sys/fs/cgroup/cgroup.controllers ] &&
+	grep -qw memory /sys/fs/cgroup/cgroup.controllers 2>/dev/null; then
+	# Idempotent on a real root cgroup (root is exempt from the no-internal-processes rule, and
+	# systemd guests already have it enabled); fails EBUSY on a namespaced root that still holds
+	# processes, which the fallback below tolerates.
+	# 2>/dev/null must come FIRST: redirections apply left to right, so a failed open of the
+	# target (ro cgroup fs on container providers) would otherwise print shell noise into every
+	# task log before the stderr redirect takes effect.
+	echo +memory 2>/dev/null > /sys/fs/cgroup/cgroup.subtree_control || true
+	bench_cg="/sys/fs/cgroup/bench-task-$$"
+	# memory.swap.max=0 only where the knob exists (load-bearing for measurement fidelity when the
+	# guest has swap: an uncapped-swap task would thrash instead of OOM-ing).
+	if mkdir "$bench_cg" 2>/dev/null &&
+		echo "$cap_bytes" 2>/dev/null > "$bench_cg/memory.max" &&
+		{ [ ! -f "$bench_cg/memory.swap.max" ] || echo 0 2>/dev/null > "$bench_cg/memory.swap.max"; } &&
+		# Writable knobs alone do not prove a child can MIGRATE (delegated setups can lack
+		# common-ancestor cgroup.procs permission — the writes above would succeed while every task
+		# silently ran uncontained). Prove the join with a probe child before advertising the cap.
+		BENCH_CG="$bench_cg" sh -ec 'echo $$ 2>/dev/null >"$BENCH_CG/cgroup.procs" &&
+			grep -q "bench-task" /proc/self/cgroup' 2>/dev/null; then
+		BENCH_CG="$bench_cg"
+	else
+		rmdir "$bench_cg" 2>/dev/null || true
+	fi
+fi
+if [ -n "$BENCH_CG" ]; then
+	export BENCH_CG # the contained child shell in run_task reads it
+	trap 'rmdir "$BENCH_CG" 2>/dev/null || true' EXIT
+	# Exactly ONE diagnostic line, on STDERR (stdout carries the REALWORLD_RESULT_SECONDS sentinel
+	# parsed by results-definition.xml). The selftest asserts on it to prove the cap path — not
+	# the fallback — engaged.
+	echo "bench-cgroup: capped at ${cap_bytes} bytes" >&2
+else
+	echo "bench-cgroup: unavailable (oom_score_adj only)" >&2
+fi
+
+# Time-bound an execution. Composition order matters: timeout sits OUTSIDE the cgroup exec of
+# run_task, so a memory-stalled task (reclaim-thrashing at the cap) is still time-bounded. A
+# non-zero return in statement position aborts the runner via set -e exactly as a bare eval does
+# today, so PTS records a missing sample for this Task option and the batch continues.
+run_bounded() {
+	status=0
+	timeout --kill-after=30 "$TASK_TIMEOUT_SECONDS" "$@" || status=$?
+	if [ "$status" -eq 124 ] || [ "$status" -eq 137 ]; then
+		echo "task '${TASK}' command timed out or was killed after ${TASK_TIMEOUT_SECONDS}s (exit ${status})" >&2
+		# Terminal-state snapshot into the (already-redirected) task log so the forensics tarball
+		# can settle thrash-vs-deadlock for a hung provider.
+		head -3 /proc/meminfo >&2 2>/dev/null || true
+		ps -eo pid,ppid,pgid,rss,etime,comm --sort=-rss 2>/dev/null | head -15 >&2 || true
+		# The cap's own verdict, for the same tarball: a real cgroup OOM increments oom_kill in
+		# memory.events, which exit 137 alone cannot distinguish from timeout's kill-after
+		# escalation. The selftest asserts on the oom_kill line to prove the cap KILLED, not
+		# merely engaged.
+		if [ -n "${BENCH_CG:-}" ] && [ -f "$BENCH_CG/memory.events" ]; then
+			sed 's/^/bench-cgroup: memory.events /' "$BENCH_CG/memory.events" >&2 2>/dev/null || true
+		fi
+		# timeout signals its own process group, but children that made a NEW group (openclaw's
+		# run-oxlint-shards spawns shards detached) survive — and an escapee need not carry the
+		# workspace path in its argv at all, so a leaked memory hog is swept three ways before it
+		# can poison the remaining tasks. 137 also matches a kernel OOM-SIGKILL of the direct
+		# child, where the sweep is equally correct; 125/126/127 are not timeout kills and pass
+		# through as plain failures without it.
+		# (1) argv: safe because the runner/wrapper/PTS cmdlines never contain the .../work suffix.
+		pkill -KILL -f "$WORK_DIR" 2>/dev/null || true
+		# (2) cgroup membership: inherited through detach/setpgid, so this reaps a child that
+		# scrubbed or never had the path in its argv. cgroup.kill (5.14+) takes the whole subtree
+		# atomically; older kernels fall back to signalling each listed member. Only task
+		# descendants ever join BENCH_CG — the runner itself never migrates.
+		if [ -n "${BENCH_CG:-}" ] && ! echo 1 2>/dev/null > "$BENCH_CG/cgroup.kill"; then
+			while IFS= read -r cg_pid; do
+				kill -KILL "$cg_pid" 2>/dev/null || true
+			done 2>/dev/null < "$BENCH_CG/cgroup.procs" || true
+		fi
+		# (3) cwd: the no-cgroup fallback for a relative-argv child that inherited the workspace
+		# cwd without ever naming it. $$ is excluded — the runner cd's into the workspace itself
+		# and must survive to return non-zero (see the run_task trailer contract).
+		for proc_dir in /proc/[0-9]*; do
+			escapee="${proc_dir#/proc/}"
+			[ "$escapee" != "$$" ] || continue
+			case "$(readlink "$proc_dir/cwd" 2>/dev/null || true)" in
+			"$WORK_DIR" | "$WORK_DIR"/*) kill -KILL "$escapee" 2>/dev/null || true ;;
+			esac
+		done
+	fi
+	return "$status"
+}
+
+# Time-bound AND memory-contain a task command string. CRITICAL: no subshell + `echo $$` here —
+# POSIX $$ inside a subshell is the PARENT shell's PID, which would move the runner itself into
+# the capped cgroup and defeat the survive-to-exit-nonzero contract (the failing command must
+# abort the still-alive runner, see the trailer comment). A child sh's own $$ is correct.
+# oom_score_adj=1000 applies unconditionally and is inherited by the task subtree, so even
+# without a usable cgroup fs the task is the kernel's preferred OOM victim, never the agent.
+run_task() {
+	# shellcheck disable=SC2016 # single quotes are the point: $$/"$1"/BENCH_CG must expand in the
+	# CHILD sh, not here.
+	run_bounded sh -ec '
+		echo 1000 2>/dev/null >/proc/self/oom_score_adj || true
+		# Setup verified migration with a probe child, so a failed join here is unexpected — say so
+		# on stderr (the task log) instead of silently running uncontained; the task still runs
+		# under the oom_score_adj biasing above.
+		if [ -n "${BENCH_CG:-}" ]; then
+			echo $$ 2>/dev/null >"$BENCH_CG/cgroup.procs" ||
+				echo "bench-cgroup: task join failed — running uncontained (oom_score_adj only)" >&2
+		fi
+		eval "$1"
+	' contained-task "$1"
+}
+
 start_ns=""
 end_ns=""
 
@@ -56,7 +213,10 @@ git_clone)
 	start_ns=$(date +%s%N)
 	git init -q .
 	git remote add origin "$REPO_URL"
-	git fetch --depth 1 origin "$PIN_SHA"
+	# Only the fetch gets the bound (the 708s legitimate outlier WAS this fetch); init/remote/
+	# checkout stay bare — local and instant — and no memory containment here, keeping the timed
+	# window byte-identical apart from timeout's single fork.
+	run_bounded git fetch --depth 1 origin "$PIN_SHA"
 	git checkout -q FETCH_HEAD
 	end_ns=$(date +%s%N)
 	head_sha="$(git rev-parse HEAD)"
@@ -79,7 +239,7 @@ cold_install)
 	start_ns=$(date +%s%N)
 	# shellcheck disable=SC2154 # sourced dynamically from target.env (per-profile config, not
 	# assigned in this file).
-	eval "$TASK_CMD_cold_install"
+	run_task "$TASK_CMD_cold_install"
 	end_ns=$(date +%s%N)
 	;;
 *)
@@ -99,9 +259,9 @@ cold_install)
 		git clean -xdff -e node_modules -e dist -e .turbo
 		wipe_tool_caches
 		if [ ! -d node_modules ]; then
-			eval "$TASK_CMD_cold_install"
+			run_task "$TASK_CMD_cold_install"
 		fi
-		(unset TURBO_FORCE && eval "$prep")
+		(unset TURBO_FORCE && run_task "$prep")
 		# Prep may restore turbo outputs under per-package node_modules/.cache; clear them so the
 		# timed command keeps dist warm but does not inherit incremental TS/vitest caches.
 		wipe_tool_caches
@@ -116,7 +276,7 @@ cold_install)
 		if [ ! -d node_modules ]; then
 			# Recovery install: output stays on the (already-redirected) log — discarding it would
 			# hide the one diagnostic that explains a subsequent task failure.
-			eval "$TASK_CMD_cold_install"
+			run_task "$TASK_CMD_cold_install"
 		fi
 	fi
 	cmd_var="TASK_CMD_${TASK}"
@@ -129,7 +289,7 @@ cold_install)
 		# Steady-state warm-up (fio's ramp_time, adapted): one unmeasured execution, then the same
 		# cold-artifact reset again so every sample is warm-toolchain + cold-artifact. Artifact
 		# caches (including per-package node_modules/.cache/ts) must be wiped here.
-		eval "$cmd"
+		run_task "$cmd"
 		# Same PRESERVING reset as above — the old destructive form here wiped the turbo cache the
 		# measured build had written, killing the replay for any prep task downstream of a no-prep
 		# task's warm-up cycle.
@@ -137,7 +297,7 @@ cold_install)
 		wipe_tool_caches
 	fi
 	start_ns=$(date +%s%N)
-	eval "$cmd"
+	run_task "$cmd"
 	end_ns=$(date +%s%N)
 	;;
 esac

--- a/lib/pts/realworld/selftest-payload.sh
+++ b/lib/pts/realworld/selftest-payload.sh
@@ -34,7 +34,9 @@ trap 'export_artifacts' EXIT
 echo "=== [selftest] install PTS + php ==="
 export DEBIAN_FRONTEND=noninteractive
 apt-get update -qq
-apt-get install -y -qq php-cli php-xml >/dev/null
+# procps: the runner's timeout sweep (pkill/ps) and this payload's leak assertion (pgrep) need it;
+# installed explicitly instead of trusting the base image's package set.
+apt-get install -y -qq php-cli php-xml procps >/dev/null
 curl -fsSL --retry 3 -o /tmp/pts.deb \
 	"https://github.com/phoronix-test-suite/phoronix-test-suite/releases/download/v${PTS_VERSION}/phoronix-test-suite_${PTS_VERSION}_all.deb"
 dpkg -i /tmp/pts.deb >/dev/null 2>&1 || apt-get install -y -qq -f >/dev/null
@@ -46,6 +48,8 @@ corepack enable
 mkdir -p "$COUNTS" "$FIXTURE" "$RESULTS"
 cd "$FIXTURE"
 cp "$SELFTEST_SRC/fixture-package.json" package.json
+mkdir -p scripts
+cp "$SELFTEST_SRC/fixture-hang.mjs" scripts/hang.mjs
 printf 'node_modules/\ndist/\n' > .gitignore
 pnpm install --silent
 git init -q .
@@ -68,6 +72,36 @@ sed -e "s|@PIN_SHA@|${PIN_SHA}|g" -e "s|@FIXTURE@|${FIXTURE}|g" "$SELFTEST_SRC/t
 # production profiles ship.
 cp /repo/packages/schema/src/pts-profiles/local/realworld-mastra-1.0.0/results-definition.xml \
 	"$PROFILE/results-definition.xml"
+
+echo "=== [selftest] cgroup v2 init-leaf dance ==="
+# The runner's memory-cap path needs +memory enabled in this container's cgroup subtree. Two
+# blockers, handled in order: (1) the mount may be read-only (Docker Desktop; native-Linux Docker
+# with a private cgroupns mounts it rw) — remounted below; (2) the no-internal-processes rule:
+# enabling +memory in the namespaced root's subtree_control fails EBUSY while processes sit in
+# that root (--privileged does NOT fix this). Move every root-cgroup process into an init leaf
+# first, then enable. Hard-fail when impossible: this selftest is a local dev tool, and silently
+# skipping the containment assertion would make it worthless.
+if [ ! -f /sys/fs/cgroup/cgroup.controllers ]; then
+	echo "FAIL: /sys/fs/cgroup is not cgroup v2 — the selftest needs Docker with cgroup v2 (default on modern Linux and Docker Desktop)" >&2
+	exit 1
+fi
+if ! mkdir -p /sys/fs/cgroup/init 2>/dev/null; then
+	# Docker Desktop (macOS/Windows) mounts cgroup2 READ-ONLY even with a private cgroupns
+	# (verified on Docker Desktop 29.3.1); native-Linux Docker mounts it rw. The remount needs
+	# CAP_SYS_ADMIN in the container.
+	mount -o remount,rw /sys/fs/cgroup 2>/dev/null || {
+		echo "FAIL: /sys/fs/cgroup is read-only and remount was denied — run the selftest container with --cap-add SYS_ADMIN (Docker Desktop mounts cgroup2 ro; the remount needs the cap)" >&2
+		exit 1
+	}
+	mkdir -p /sys/fs/cgroup/init
+fi
+while read -r pid; do
+	echo "$pid" > /sys/fs/cgroup/init/cgroup.procs 2>/dev/null || true # tolerate per-PID races
+done < /sys/fs/cgroup/cgroup.procs
+echo +memory > /sys/fs/cgroup/cgroup.subtree_control || {
+	echo "FAIL: could not enable the memory controller in the container's cgroup root" >&2
+	exit 1
+}
 
 echo "=== [selftest] run the production path ==="
 export REPO_ROOT="$WORK"
@@ -104,4 +138,42 @@ count() { if [ -f "$COUNTS/$1" ]; then wc -l < "$COUNTS/$1" | tr -d ' '; else ec
 	exit 1
 }
 echo "execution-count assertions OK (build=3 lint=2 test=1 build-cache=0 turbo-survived=2)"
+
+# Containment proofs (per-command timeout + cgroup memory cap):
+#   hang: warm-up runs once, timeout kills it, set -e aborts before the measured pass = 1.
+[ "$(count hang)" = "1" ] || {
+	echo "FAIL: hang executed $(count hang)x, expected 1 (timeout must abort after the warm-up)" >&2
+	exit 1
+}
+# The hang fixture's detached grandchild escapes timeout's process-group kill AND carries no
+# workspace path in its argv, so the runner's argv-matching pkill cannot see it — only the
+# cgroup-membership / cwd sweep layers can reap it, and this asserts one of them did. Explicit
+# if — a bare `! pgrep` is exempt from set -e and would assert nothing.
+if pgrep -f 'setInterval' >/dev/null; then
+	echo "FAIL: a hang-fixture process survived (group kill + pkill sweep both missed it):" >&2
+	pgrep -af 'setInterval' >&2 || true
+	exit 1
+fi
+# Prove the cap path — not the oom_score_adj fallback — engaged: the runner emits exactly one
+# bench-cgroup stderr line per invocation, which lands in $LOG_FILE and is saved by PTS under
+# test-results/*/test-logs.
+grep -rq "bench-cgroup: capped at 268435456 bytes" /var/lib/phoronix-test-suite/test-results || {
+	echo "FAIL: no 'bench-cgroup: capped at 268435456 bytes' line in PTS test logs — the cgroup cap path never engaged" >&2
+	exit 1
+}
+# ...and that the OOM probe actually RAN inside the cgroup: the probe verifies its own membership
+# before allocating and prints this marker when placement failed. Capped-but-not-placed would
+# otherwise pass every assertion above while proving nothing about task containment.
+if grep -rq "OOM-PROBE-NOT-CONTAINED" /var/lib/phoronix-test-suite/test-results; then
+	echo "FAIL: the OOM probe ran OUTSIDE the bench-task cgroup — cap engaged but task placement is broken" >&2
+	exit 1
+fi
+# ...and that the cap KILLED, not merely engaged: the runner dumps the bench cgroup's
+# memory.events on a killed task, and only a genuine cgroup OOM increments oom_kill — exit 137
+# alone cannot distinguish the cgroup OOM killer from timeout's kill-after escalation.
+grep -rEq "bench-cgroup: memory\.events oom_kill [1-9]" /var/lib/phoronix-test-suite/test-results || {
+	echo "FAIL: no oom_kill increment in the bench cgroup's memory.events — the 256 MiB cap never actually OOM-killed the probe" >&2
+	exit 1
+}
+echo "containment assertions OK (hang=1, no leaked processes, cgroup cap engaged + probe placed + oom_kill observed)"
 echo "SELFTEST PASS"

--- a/lib/pts/realworld/selftest/assert-composite.mjs
+++ b/lib/pts/realworld/selftest/assert-composite.mjs
@@ -4,11 +4,13 @@ import { readFileSync } from "node:fs";
 
 const xml = readFileSync(process.argv[2], "utf8");
 // Scope to <Result> blocks: the composite header carries its own <Description> which must not
-// shift the pairing, and a failed task's <Value> is empty.
+// shift the pairing. Values stay RAW STRINGS here — a failed task's block IS PRESENT with an
+// EMPTY <Value> (production-verified shape, blaxel openclaw composite run 29799034615), and
+// Number("") === 0 would let an empty value slip through a numeric check.
 const results = [...xml.matchAll(/<Result>[\s\S]*?<\/Result>/g)].map(([block]) => {
 	const desc = block.match(/<Description>([^<]*)<\/Description>/)?.[1];
-	const value = block.match(/<Value>([^<]*)<\/Value>/)?.[1] ?? "";
-	return [desc, Number(value)];
+	const raw = block.match(/<Value>([^<]*)<\/Value>/)?.[1] ?? "";
+	return [desc, raw];
 });
 const byDesc = Object.fromEntries(results);
 const fail = (msg) => {
@@ -16,30 +18,43 @@ const fail = (msg) => {
 	process.exit(1);
 };
 
-const expected = [
+// Full Task-menu order, including the two deliberately-failing containment fixtures.
+const menu = [
 	"Task: Git Clone",
 	"Task: Cold Install",
 	"Task: Build",
+	"Task: Hang",
 	"Task: Plain",
+	"Task: OOM Probe",
 	"Task: Prepped",
 ];
-for (const d of expected) {
+const passing = menu.filter((d) => d !== "Task: Hang" && d !== "Task: OOM Probe");
+const num = (d) => Number(byDesc[d]);
+for (const d of passing) {
 	if (!(d in byDesc)) fail(`missing result for "${d}"`);
-	if (!Number.isFinite(byDesc[d]) || byDesc[d] <= 0)
-		fail(`non-numeric value for "${d}": ${byDesc[d]}`);
+	if (byDesc[d] === "" || !Number.isFinite(num(d)) || num(d) <= 0)
+		fail(`non-numeric value for "${d}": ${JSON.stringify(byDesc[d])}`);
 }
-// Execution order == menu order (TEST_EXECUTION_SORT=none). The composite preserves run order.
-const order = results.map(([d]) => d).filter((d) => expected.includes(d));
-if (JSON.stringify(order) !== JSON.stringify(expected))
-	fail(`execution order ${order} != menu order`);
+// Containment contract: Hang (per-command timeout + pkill sweep) and OOM Probe (cgroup memory
+// cap) must fail ALONE — Result block present with an empty <Value> — while every passing task,
+// including the two ordered after them, still carries its numeric sample (the batch survived).
+for (const d of ["Task: Hang", "Task: OOM Probe"]) {
+	if (!(d in byDesc)) fail(`missing result block for failed task "${d}"`);
+	if (byDesc[d] !== "") fail(`failed task "${d}" produced a value: ${JSON.stringify(byDesc[d])}`);
+}
+// Execution order == menu order (TEST_EXECUTION_SORT=none). The composite preserves run order;
+// the failed fixtures keep their mid-menu slots, proving the batch continued past them.
+const order = results.map(([d]) => d).filter((d) => menu.includes(d));
+if (JSON.stringify(order) !== JSON.stringify(menu)) fail(`execution order ${order} != menu order`);
 // Timing windows. build sleeps 2s, lint 0.5s, test 1s. Lower bounds are hard (a too-fast sample
 // means the command didn't really run); upper bounds are loose for loaded hosts — EXCEPT Prepped's,
 // which must stay below the 3.0s leak floor (2s prep + 1s test) to keep the core assertion sound.
-const inWindow = (d, lo, hi) => byDesc[d] >= lo && byDesc[d] <= hi;
+const inWindow = (d, lo, hi) => num(d) >= lo && num(d) <= hi;
 if (!inWindow("Task: Build", 1.9, 6.0)) fail(`Build ${byDesc["Task: Build"]}s outside [1.9, 6.0]`);
 if (!inWindow("Task: Plain", 0.4, 2.5)) fail(`Plain ${byDesc["Task: Plain"]}s outside [0.4, 2.5]`);
 // THE core assertion: Prepped measures only its 1s test — the 2s prep must be excluded. A leak
-// lands at >= 3.0s, so the ceiling stays strictly below that.
+// lands at >= 3.0s, so the ceiling stays strictly below that. Holding this window AFTER the two
+// failed fixtures upstream is also the no-semantics-drift proof for run_task/run_bounded.
 if (!inWindow("Task: Prepped", 0.9, 2.7))
 	fail(
 		`Prepped ${byDesc["Task: Prepped"]}s outside [0.9, 2.7] — prep time leaked into the measured window?`,

--- a/lib/pts/realworld/selftest/fixture-hang.mjs
+++ b/lib/pts/realworld/selftest/fixture-hang.mjs
@@ -1,0 +1,18 @@
+// Hang fixture (Task: Hang) — proves a wedged task is time-BOUNDED and fails alone. Appends one
+// line to /tmp/counts/hang (the payload asserts exactly one execution: the warm-up; set -e aborts
+// the runner before the measured pass), spawns a DETACHED grandchild that escapes timeout's
+// process-group kill — mirroring openclaw's run-oxlint-shards detached:true shards — then blocks
+// forever itself. The grandchild's argv deliberately contains NO workspace path: it inherits the
+// workspace cwd and the bench cgroup without ever naming either, so the runner's argv-matching
+// pkill alone cannot reap it — only the cgroup-membership / cwd sweep layers can, and the
+// payload's leak assertion proves one of them did. selftest-payload.sh copies this into the
+// fixture repo as scripts/hang.mjs before the fixture commit.
+import { spawn } from "node:child_process";
+import { appendFileSync } from "node:fs";
+
+appendFileSync("/tmp/counts/hang", "x\n");
+spawn(process.execPath, ["-e", "setInterval(() => {}, 1000)"], {
+	detached: true,
+	stdio: "ignore",
+}).unref();
+setInterval(() => {}, 1000);

--- a/lib/pts/realworld/selftest/target.env
+++ b/lib/pts/realworld/selftest/target.env
@@ -4,9 +4,25 @@
 REPO_URL="file://@FIXTURE@"
 PIN_SHA="@PIN_SHA@"
 NODE_VERSION="22"
+# Containment knobs, selftest ONLY (production profiles leave both unset). Transported via
+# target.env — the runner provably sources it — rather than assuming PTS passes arbitrary env
+# through to the test wrapper. 30s (not 5) keeps the hang task's warm-up short without going
+# flaky against measured cold pnpm installs on a loaded docker host; 256 MiB deterministically
+# exercises the cgroup cap regardless of host RAM.
+REALWORLD_TASK_TIMEOUT_SECONDS=30
+REALWORLD_TASK_MEM_MAX_BYTES=268435456
 TASK_CMD_git_clone=""
 TASK_CMD_cold_install="pnpm install --frozen-lockfile"
 TASK_CMD_build="pnpm run build"
+TASK_CMD_hang="node scripts/hang.mjs"
 TASK_CMD_plain="pnpm run lint"
+# SELF-BOUNDING OOM probe: asserts it is actually INSIDE a bench-task cgroup before touching any
+# memory — a broken task placement prints OOM-PROBE-NOT-CONTAINED and exits 3 without allocating,
+# so a memory-constrained docker host can never be pushed toward global OOM by a failed cap path
+# (the payload greps that marker into a hard FAIL). Contained, it touches at most 1 GiB (16 x
+# 64 MiB, filled so pages commit) then exits 1; the 256 MiB cap SIGKILLs it long before its own
+# bound, which is the only remaining exit — the kill is therefore attributable to the cap. NEVER
+# use an unbounded allocator here.
+TASK_CMD_oom_probe="node -e 'const cg=require(\"fs\").readFileSync(\"/proc/self/cgroup\",\"utf8\");if(!cg.includes(\"bench-task\")){console.error(\"OOM-PROBE-NOT-CONTAINED\");process.exit(3)}const b=[];for(let i=0;i<16;i++)b.push(Buffer.alloc(1<<26,1));process.exit(1)'"
 TASK_PREP_prepped="pnpm run build"
 TASK_CMD_prepped="pnpm run test"

--- a/lib/pts/realworld/selftest/test-definition.xml
+++ b/lib/pts/realworld/selftest/test-definition.xml
@@ -29,10 +29,15 @@ copies a real profile's, so the selftest exercises the actual parser definition.
       <DisplayName>Task</DisplayName>
       <Identifier>task</Identifier>
       <Menu>
+        <!--Hang and OOM Probe fail BY DESIGN (per-command timeout / cgroup memory cap): both sit
+        mid-menu so later tasks — including Prepped's prep-exclusion window, the suite's strongest
+        assertion — must survive a preceding failure, proving batch continuation.-->
         <Entry><Name>Git Clone</Name><Value>git_clone</Value></Entry>
         <Entry><Name>Cold Install</Name><Value>cold_install</Value></Entry>
         <Entry><Name>Build</Name><Value>build</Value></Entry>
+        <Entry><Name>Hang</Name><Value>hang</Value></Entry>
         <Entry><Name>Plain</Name><Value>plain</Value></Entry>
+        <Entry><Name>OOM Probe</Name><Value>oom_probe</Value></Entry>
         <Entry><Name>Prepped</Name><Value>prepped</Value></Entry>
       </Menu>
     </Option>

--- a/packages/schema/src/pts-profiles/local/realworld-openclaw-1.0.0/target.env
+++ b/packages/schema/src/pts-profiles/local/realworld-openclaw-1.0.0/target.env
@@ -11,6 +11,19 @@ TASK_CMD_git_clone=""
 # dependencies" step (mirrors the legacy runner-benchmarking capture). No retry-on-failure here,
 # unlike that CI step -- a retried install would corrupt the cold-install timing being measured.
 TASK_CMD_cold_install="CI=true pnpm install --prefer-offline --ignore-scripts=false --config.engine-strict=false --config.enable-pre-post-scripts=true --config.side-effects-cache=true --frozen-lockfile"
+# KNOWN INCOMPATIBILITY at this pin: openclaw's lint wrapper unconditionally injects --type-aware
+# (scripts/lib/local-heavy-check-runtime.mjs:102 at pin 6235344), spawning the Go tsgolint binary
+# (oxlint-tsgolint 0.24.0) with GOGC=30/GOMEMLIMIT=3GiB via the default-on throttle policy; on
+# this monorepo tsgolint exceeds the 8 GB target spec (oxc's docs list large-monorepo
+# OOM/deadlock as a known tsgolint limitation). On real-kernel providers the OOM killer usually
+# SIGKILLs tsgolint and the task fails fast (blaxel + novita, run 29799034615); under gVisor
+# (modal-gvisor, kernel 4.19.0-gvisor) no in-sandbox OOM kill occurs and Modal's memoryLimitMiB
+# cap did not kill either, so without the runner's per-command timeout the sandbox thrashed for
+# the full 80-min step budget (runs 29799034615, 29743570333, 29692210375). No in-pin workaround:
+# versions are frozen by the pinned lockfile and the wrapper has no --type-aware off-switch; this
+# metric has never produced a sample on any provider and is expected to surface as a per-run
+# metric-scoped gap until the workload fits the spec or the pin advances. (Do not raise
+# TimesToRun; do not drop the task — keep+warn.)
 # CI's check-shard job pins the thread count (`pnpm lint --threads=8`); mirroring it keeps the
 # workload identical across providers instead of scaling with nproc.
 TASK_CMD_lint_oxlint="pnpm lint --threads=8"


### PR DESCRIPTION
**Bench-matrix green — every suite×provider cell measuring or honestly gapped**
Fixes the 10 root causes behind the failures and silent metric holes of runs [29799034615](https://github.com/starslingdev/hpc-sandbox-benchmarks/actions/runs/29799034615) and [29850811070](https://github.com/starslingdev/hpc-sandbox-benchmarks/actions/runs/29850811070). #229–#232 have merged; the remaining fixes are **parallel PRs based directly on `main`** — reviewable and mergeable in any order, except #238, which stacks on #237:
- #233 — leaderboard: no fabricated missing-rows for never-dispatched providers
- #234 — realworld: per-task timeout + cgroup-v2 memory containment
- #235 — harness: failed gap on sandbox-creation failure
- #236 — harness: detached log read-back + collect retries
- #237 — bench: loud PTS leaf guards; stream + pybench measure again
- #238 — templates: pgbench bake fix (pkg-config), payload assertion, portable fio, v4 *(stacked on #237)*
- #239 — fast-cli: settle gated on upload-phase stability
- #240 — providers: Daytona region pin actually reaches the API; both variants us-west-2
- #241 — ci: dataset-PR PAT fallback; e2b disk-skip notes

↑ **This PR is #234 — independent: based on `main`, no merge-order dependency on the others.**

---
Two chronic openclaw failure modes torched whole suites and burned 80-min
job timeouts: oxlint's --type-aware tsgolint exceeds the 8 GB spec and
either stalls forever under gVisor (modal-gvisor, quiet hang to the 4800s
step timeout in three consecutive runs) or drives the daytona-vm KVM guest
into a global OOM that kills the in-guest daemon ('12 consecutive detached
polls failed' — the sandbox dies, not the task).

Every TASK_CMD/TASK_PREP/warm-up/recovery execution now runs under
coreutils timeout (default 1200s, kill-after 30s, REALWORLD_TASK_TIMEOUT_SECONDS
override) with a workspace-scoped pkill sweep for detached survivors, and
inside a cgroup-v2 child capped at MemTotal-1GiB when the cgroup fs is
usable (the VM/root case; REALWORLD_TASK_MEM_MAX_BYTES escape hatch), with
oom_score_adj=1000 victim-biasing everywhere else (containers keep their
outer limit). Timeout sits OUTSIDE the cgroup so a memory-stalled task is
also time-bounded. A hung/OOM task now fails alone; the remaining tasks
still measure and PTS writes the composite.

Selftest grows Hang and OOM-probe fixture tasks proving both bounds
end-to-end in Docker (--cap-add SYS_ADMIN for the cgroup remount — Docker
Desktop mounts cgroup2 read-only). The runner is overlaid from the repo at
run time, so no template rebake is needed. openclaw's lint_oxlint carries
a known-incompatibility note (no in-pin workaround; upstream pin decision
tracked in the PR). TimesToRun untouched.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds per-command timeouts and a cgroup v2 memory cap so hung/OOM tasks fail alone and the suite still completes. The selftest proves time bounds, correct cgroup placement, and a real cgroup OOM, with no leaked processes.

- **New Features**
  - Timeout: bound all task/prep/warm-up/recovery with `timeout` (default 1200s, kill-after 30; override `REALWORLD_TASK_TIMEOUT_SECONDS`). Reject non-integer or 0. On timeout, dump mem/ps, print cgroup `memory.events`, then sweep survivors via argv pkill, cgroup membership (`cgroup.kill`/`cgroup.procs`), and a `/proc` cwd scan. Only `git fetch` is bounded in `git_clone`. Timeout wraps outside the cgroup.
  - Memory cap: run tasks in a cgroup v2 child capped at MemTotal−1 GiB, or half of MemTotal on small hosts (override `REALWORLD_TASK_MEM_MAX_BYTES`). Disable swap when available. Enable `+memory` and prove migration with a probe before advertising the cap; runtime join failures log an explicit uncontained line and fall back to `oom_score_adj=1000`.
  - Selftest: add Hang and a placement-proof OOM Probe. Remount cgroup v2 rw and move procs to an init leaf to enable `+memory` (needs Docker `--cap-add SYS_ADMIN`); install `procps`. Assert one Hang warm-up run, no leaked detached child, the “bench-cgroup: capped at 268435456 bytes” line, probe refuses to allocate if not placed, and `memory.events` shows `oom_kill` increment.

- **Migration**
  - No action for providers. For local selftest, use Docker with cgroup v2 and `--cap-add SYS_ADMIN`. Optional per-profile overrides: `REALWORLD_TASK_TIMEOUT_SECONDS`, `REALWORLD_TASK_MEM_MAX_BYTES`.

<sup>Written for commit 773be6331f18017fac650ad4200b6dff3d8cacd5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/starslingdev/hpc-sandbox-benchmarks/pull/234?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

---
**Follow-ups tracked, not implemented here:** openclaw at pin `6235344` cannot produce 5 of its 8 task metrics at the 8 GB spec on ANY provider (tsgolint OOM, stale shrinkwrap, failing unit tests) — either re-pin to a healthier SHA or accept 3/8 coverage as permanent recorded gaps. Optionally report to Daytona (guest OOM starves their in-guest daemon) and oxc/tsgolint (large-monorepo OOM/deadlock).

