### PR TITLE
fix(harness): retry detached log read-back and collect instead of discarding results

### DIFF
--- a/packages/harness/src/lib/collect.test.ts
+++ b/packages/harness/src/lib/collect.test.ts
@@ -7,7 +7,7 @@ import type { ProviderTransport } from "@sandbox-benchmarks/schema";
 import { harnessGapMarkerJson } from "@sandbox-benchmarks/schema";
 import { collectResults, writeGapMarker } from "./collect.ts";
 import type { SandboxHandle } from "./execute.ts";
-import { StepRunner } from "./execute.ts";
+import { MIN, StepRunner } from "./execute.ts";
 
 const work = mkdtempSync(join(tmpdir(), "harness-collect-"));
 afterAll(() => rmSync(work, { recursive: true, force: true }));
@@ -16,6 +16,9 @@ afterAll(() => rmSync(work, { recursive: true, force: true }));
 // fakes return their stdout for every command, which the detached cat-poll would misread as a done-file.
 // The detached collect path is covered by execute.test.ts and end-to-end in index.test.ts.
 const UNCAPPED: ProviderTransport = { streaming: false, syncCapMs: null, detachedPoll: false };
+// The LogReadbackError-retry test needs the real detached path (log-file read-back is where the
+// transport failure lives), so it runs capped with an fs-transport fake.
+const CAPPED: ProviderTransport = { streaming: false, syncCapMs: MIN, detachedPoll: true };
 
 // Build the exact stdout the in-sandbox collect command emits: markers around a base64'd tar of a
 // benchmark-results/ directory holding the given files (name → contents).
@@ -83,14 +86,114 @@ describe("collectResults", () => {
 		).rejects.toThrow(/no PTS result or gap marker/);
 	});
 
-	it("throws when the payload markers are missing", async () => {
+	it("retries the collect step on a marker miss and succeeds when a later attempt delivers", async () => {
+		// Regression: collect was single-attempt, so ONE transient read-back failure (empty stdout from
+		// an alive sandbox — Blaxel, 2026-07-19) permanently discarded a completed suite's results even
+		// though re-running the idempotent tar|base64 step would have succeeded.
+		let calls = 0;
+		const payload = collectPayload({ "pts_node-web-tooling.xml": "<xml/>" });
+		const flaky: SandboxHandle = {
+			runCommand: async () => ({ exitCode: 0, stdout: ++calls === 1 ? "" : payload }),
+			destroy: async () => undefined,
+		};
+		const resultsDir = join(work, "flaky");
+		await collectResults(new StepRunner(flaky, UNCAPPED), resultsDir);
+		expect(calls).toBe(2);
+		expect(existsSync(join(resultsDir, "pts_node-web-tooling.xml"))).toBe(true);
+	});
+
+	it("throws the transport-failure diagnosis when every attempt returns empty stdout", async () => {
+		let calls = 0;
+		const empty: SandboxHandle = {
+			runCommand: async () => {
+				calls++;
+				return { exitCode: 0, stdout: "" };
+			},
+			destroy: async () => undefined,
+		};
+		await expect(
+			collectResults(new StepRunner(empty, UNCAPPED), join(work, "empty-stdout")),
+		).rejects.toThrow(/markers.*transport failure/s);
+		// Every attempt in the retry budget was spent before giving up.
+		expect(calls).toBe(3);
+	});
+
+	it("retries when the completed step's log read-back itself failed (LogReadbackError)", async () => {
+		// The transport-failure THROW from readCompletedLog must be retryable here — the transports
+		// can recover between attempts (the Blaxel shape) — while command failures and timeouts still
+		// propagate. First collect: every fs read fails AND the exec cat fails (exit 1, which must
+		// surface as failure, not as an empty successful read) -> LogReadbackError. Second collect:
+		// the fs API has recovered and delivers the payload.
+		const READBACK_ATTEMPTS = 5; // mirrors execute.ts — first collect burns exactly this many fs reads
+		let logReads = 0;
+		const payload = collectPayload({ "pts_node-web-tooling.xml": "<xml/>" });
+		const flakyFs: SandboxHandle = {
+			runCommand: async (command: string) => {
+				if (command.includes("cat ")) return { exitCode: 1, stdout: "" };
+				return { exitCode: 0, stdout: "launched" };
+			},
+			destroy: async () => undefined,
+			filesystem: {
+				exists: async (path) => path.endsWith(".done"),
+				readFile: async (path) => {
+					if (path.endsWith(".done")) return "0";
+					if (++logReads <= READBACK_ATTEMPTS) throw new Error("fs API down");
+					return payload;
+				},
+			},
+		};
+		const resultsDir = join(work, "flaky-readback");
+		await collectResults(new StepRunner(flakyFs, CAPPED, async () => undefined), resultsDir);
+		expect(logReads).toBeGreaterThan(READBACK_ATTEMPTS);
+		expect(existsSync(join(resultsDir, "pts_node-web-tooling.xml"))).toBe(true);
+	});
+
+	it("throws the truncation diagnosis when stdout is non-empty but markerless", async () => {
+		// A payload that came back but lost its markers is a different failure (truncated/malformed
+		// payload) from one that never came back at all — the error must not conflate them.
 		const noMarkers: SandboxHandle = {
 			runCommand: async () => ({ exitCode: 0, stdout: "no markers here" }),
 			destroy: async () => undefined,
 		};
 		await expect(
 			collectResults(new StepRunner(noMarkers, UNCAPPED), join(work, "x")),
-		).rejects.toThrow(/markers/);
+		).rejects.toThrow(/markers.*truncated or malformed/s);
+	});
+
+	it("retries when a marker-bounded payload fails to extract, then succeeds", async () => {
+		// A payload that arrived WITH both markers but is corrupt mid-stream (a cut that still landed
+		// END) must be retried like a marker miss — decode + tar extract live inside the retry boundary,
+		// so the idempotent re-collect can deliver an intact tar rather than aborting the suite on the
+		// host-side tar failure.
+		let calls = 0;
+		const good = collectPayload({ "pts_node-web-tooling.xml": "<xml/>" });
+		const corrupt = "noise\n__BENCH_RESULTS_TGZ_BEGIN__\nZZZnotarZZZ\n__BENCH_RESULTS_TGZ_END__\n";
+		const flaky: SandboxHandle = {
+			runCommand: async () => ({ exitCode: 0, stdout: ++calls === 1 ? corrupt : good }),
+			destroy: async () => undefined,
+		};
+		const resultsDir = join(work, "corrupt-then-good");
+		await collectResults(new StepRunner(flaky, UNCAPPED), resultsDir);
+		expect(calls).toBe(2);
+		expect(existsSync(join(resultsDir, "pts_node-web-tooling.xml"))).toBe(true);
+	});
+
+	it("does not retry a valid tree that simply has no PTS result or marker (deterministic)", async () => {
+		// The content gate is deterministic: a re-collect of the same in-sandbox tree can't conjure a
+		// result, so it must fail on the FIRST attempt rather than burn the whole retry budget on a
+		// re-run that cannot change the outcome.
+		let calls = 0;
+		const empty: SandboxHandle = {
+			runCommand: async () => {
+				calls++;
+				return { exitCode: 0, stdout: collectPayload({ "manifest.ndjson": "{}\n" }) };
+			},
+			destroy: async () => undefined,
+		};
+		await expect(
+			collectResults(new StepRunner(empty, UNCAPPED), join(work, "no-signal-once")),
+		).rejects.toThrow(/no PTS result or gap marker/);
+		expect(calls).toBe(1);
 	});
 });
 

--- a/packages/harness/src/lib/collect.ts
+++ b/packages/harness/src/lib/collect.ts
@@ -17,36 +17,123 @@ import {
 	sandboxGapMarkerFile,
 } from "@sandbox-benchmarks/schema";
 import type { StepRunner } from "./execute.ts";
-import { MIN } from "./execute.ts";
+import { LogReadbackError, MIN } from "./execute.ts";
 import { DIR } from "./setup.ts";
 
 const RESULTS_BEGIN = "__BENCH_RESULTS_TGZ_BEGIN__";
 const RESULTS_END = "__BENCH_RESULTS_TGZ_END__";
+/** Attempts for the in-sandbox collect step. A marker miss can be a transient read-back hiccup, not
+ *  a dead sandbox (Blaxel, 2026-07-19: a completed suite's 4 valid samples were discarded over one),
+ *  and the tar|base64 emit is idempotent while the sandbox is destroyed only after collection — so
+ *  re-running the whole step is safe and beats throwing finished results away. */
+const COLLECT_MAX_ATTEMPTS = 3;
+
+/** The in-sandbox collect command: emit a marker-bounded, newline-stripped base64 tar of
+ *  benchmark-results/ on stdout. No temp file in the sandbox, so it works even when the sandbox disk
+ *  is full; the tar|base64 emit is idempotent, so re-running it on a transient failure is safe. */
+const COLLECT_SCRIPT =
+	`cd ${DIR} && mkdir -p benchmark-results && ` +
+	`echo ${RESULTS_BEGIN} && tar -czf - benchmark-results | base64 | tr -d '\\n' && echo && echo ${RESULTS_END}`;
+
+/**
+ * A collected results tree that carries no PTS result or gap marker — the suite produced nothing
+ * usable. Deterministic across re-collects (the in-sandbox tree does not change between collect
+ * steps), so {@link collectResults} fails on it immediately instead of burning retries on a re-run
+ * that cannot change the outcome. Distinguished from the RETRYABLE decode/extract failures.
+ */
+class CollectedResultsEmptyError extends Error {}
 
 /** Pull the sandbox's benchmark-results/ into `resultsDir` on the host. */
 export async function collectResults(runner: StepRunner, resultsDir: string): Promise<void> {
 	runner.phase = "collect";
-	// Capability-driven transport: on a capped provider the tar|base64 payload lands in the step's log
-	// file and is read back, so a large or slow collect can't 408 the synchronous exec mid-stream; on an
-	// uncapped provider it streams straight back over a direct exec. Both populate `result.stdout`, and
-	// the BEGIN/END markers bound the base64 within that captured output either way.
-	const result = await runner.step(
-		"collect benchmark-results",
-		`cd ${DIR} && mkdir -p benchmark-results && ` +
-			`echo ${RESULTS_BEGIN} && tar -czf - benchmark-results | base64 | tr -d '\\n' && echo && echo ${RESULTS_END}`,
-		5 * MIN,
-		// Silent: the step's stdout IS the base64 tarball — echoing it would flood the CI log.
-		{ silent: true },
-	);
+	// One retry boundary wraps the ENTIRE idempotent collect — the in-sandbox tar|base64 step, the
+	// marker scan, AND the host-side decode + tar extract. A read-back transport failure, a marker
+	// miss, or a marker-bounded-but-corrupt payload are all transient conditions a re-run can fix
+	// while the sandbox is still alive (it is destroyed only after collection), so each retries here
+	// rather than discarding a finished suite's results. Command failures and timeouts are real and
+	// propagate unchanged; the content gate (no PTS result / marker) is deterministic and does not retry.
+	for (let attempt = 1; ; attempt++) {
+		// Capability-driven transport: on a capped provider the tar|base64 payload lands in the step's log
+		// file and is read back, so a large or slow collect can't 408 the synchronous exec mid-stream; on an
+		// uncapped provider it streams straight back over a direct exec. Both populate `result.stdout`, and
+		// the BEGIN/END markers bound the base64 within that captured output either way.
+		let stdout: string;
+		try {
+			const result = await runner.step("collect benchmark-results", COLLECT_SCRIPT, 5 * MIN, {
+				// Silent: the step's stdout IS the base64 tarball — echoing it would flood the CI log.
+				silent: true,
+			});
+			stdout = result.stdout || "";
+		} catch (err) {
+			// A completed step whose log no transport could read is RETRYABLE here — the transport can
+			// recover between attempts and tar|base64 is idempotent. Command failures and timeouts are
+			// not: they propagate unchanged.
+			if (!(err instanceof LogReadbackError) || attempt >= COLLECT_MAX_ATTEMPTS) throw err;
+			console.log(
+				`[collect benchmark-results] attempt ${attempt}/${COLLECT_MAX_ATTEMPTS} lost the step log ` +
+					`to a read-back transport failure; re-running the collect step`,
+			);
+			continue;
+		}
 
-	const stdout = result.stdout || "";
-	const begin = stdout.indexOf(RESULTS_BEGIN);
-	const end = stdout.indexOf(RESULTS_END);
-	if (begin === -1 || end === -1 || end <= begin) {
-		throw new Error("Could not locate results payload markers in sandbox output");
+		const begin = stdout.indexOf(RESULTS_BEGIN);
+		const end = stdout.indexOf(RESULTS_END);
+		if (begin !== -1 && end !== -1 && end > begin) {
+			const base64 = stdout.slice(begin + RESULTS_BEGIN.length, end).trim();
+			// Decode + tar extract live INSIDE the retry boundary: a marker-bounded payload that won't
+			// base64-decode or untar is transient stream corruption (a cut mid-stream can still land END)
+			// the idempotent re-collect can fix, so treat it like a marker miss one stage later and retry
+			// rather than discard the suite. The content gate is the one thing that does NOT retry.
+			try {
+				const archiveKiB = decodeAndExtract(base64, resultsDir);
+				validateCollected(resultsDir);
+				console.log(`Results extracted to ${resultsDir} (${archiveKiB.toFixed(1)} KiB archive)`);
+				return;
+			} catch (err) {
+				if (err instanceof CollectedResultsEmptyError || attempt >= COLLECT_MAX_ATTEMPTS) throw err;
+				const reason = err instanceof Error ? err.message : String(err);
+				console.log(
+					`[collect benchmark-results] attempt ${attempt}/${COLLECT_MAX_ATTEMPTS} decoded a payload ` +
+						`that failed to extract (${reason}); re-running the collect step`,
+				);
+				continue;
+			}
+		}
+
+		// Empty stdout means the step's output never came back at all (a read-back transport failure);
+		// non-empty-but-markerless means a truncated or malformed payload — different failures, so name
+		// the right one, both here and in the final throw.
+		const diagnosis =
+			stdout.length === 0
+				? "stdout was empty — the step's output never came back (transport failure)"
+				: `stdout had ${stdout.length} chars but no usable markers (truncated or malformed payload)`;
+		// Diagnostics stay CONTENT-FREE: the stdout is (possibly a complete) base64 archive of the
+		// suite's results, and an excerpt of a short payload would publish the whole thing into the CI
+		// log. Marker presence + lengths pin down the failure shape (e.g. BEGIN-without-END is a
+		// truncated stream) without disclosing a byte of payload.
+		console.log(
+			`[collect benchmark-results] attempt ${attempt}/${COLLECT_MAX_ATTEMPTS} found no payload: ${diagnosis}` +
+				(stdout.length === 0
+					? ""
+					: ` [markers: BEGIN=${begin !== -1} END=${end !== -1}${
+							begin !== -1 && end !== -1 ? ` order-inverted=${end <= begin}` : ""
+						}]`),
+		);
+		if (attempt >= COLLECT_MAX_ATTEMPTS) {
+			throw new Error(
+				`Could not locate results payload markers in sandbox output after ` +
+					`${COLLECT_MAX_ATTEMPTS} attempts: ${diagnosis}`,
+			);
+		}
 	}
-	const base64 = stdout.slice(begin + RESULTS_BEGIN.length, end).trim();
+}
 
+/**
+ * Decode the marker-bounded base64 tar to disk and extract benchmark-results/ into `resultsDir`,
+ * returning the archive size in KiB (for the success log). Throws on any decode/extract failure —
+ * {@link collectResults} treats that as retryable stream corruption.
+ */
+function decodeAndExtract(base64: string, resultsDir: string): number {
 	// Decode straight to disk via the "base64" write encoding — avoids a Node-only Buffer in the
 	// cross-runtime package code. A random suffix keeps concurrent collects from colliding.
 	const archive = join(tmpdir(), `bench-results-${process.pid}-${randomUUID()}.tgz`);
@@ -64,22 +151,26 @@ export async function collectResults(runner: StepRunner, resultsDir: string): Pr
 		} finally {
 			rmSync(stage, { recursive: true, force: true });
 		}
-		// Validate the collected tree carries real signal: at least one PTS result or skip marker
-		// (the #39 naming contract). A suite that produced neither — the benchmark crashed before
-		// writing anything AND no marker was recorded — is silent data loss; fail loudly here rather
-		// than let an empty results directory upload and report as a green run.
-		const collected = readdirSync(target);
-		if (!collected.some((name) => isPtsResultFile(name) || isGapMarkerFile(name))) {
-			throw new Error(
-				`Collected results for ${resultsDir} contain no PTS result or gap marker ` +
-					`(found: ${collected.join(", ") || "nothing"}); the suite produced no usable output`,
-			);
-		}
-		console.log(
-			`Results extracted to ${resultsDir} (${(statSync(archive).size / 1024).toFixed(1)} KiB archive)`,
-		);
+		return statSync(archive).size / 1024;
 	} finally {
 		rmSync(archive, { force: true });
+	}
+}
+
+/**
+ * Validate the collected tree carries real signal: at least one PTS result or skip marker (the #39
+ * naming contract). A suite that produced neither — the benchmark crashed before writing anything
+ * AND no marker was recorded — is silent data loss; fail loudly rather than let an empty results
+ * directory upload and report as a green run. Throws {@link CollectedResultsEmptyError} so the caller
+ * knows this is deterministic (a re-collect of the same tree can't help) and must NOT retry.
+ */
+function validateCollected(resultsDir: string): void {
+	const collected = readdirSync(resolve(resultsDir));
+	if (!collected.some((name) => isPtsResultFile(name) || isGapMarkerFile(name))) {
+		throw new CollectedResultsEmptyError(
+			`Collected results for ${resultsDir} contain no PTS result or gap marker ` +
+				`(found: ${collected.join(", ") || "nothing"}); the suite produced no usable output`,
+		);
 	}
 }
 

--- a/packages/harness/src/lib/execute.test.ts
+++ b/packages/harness/src/lib/execute.test.ts
@@ -188,6 +188,18 @@ describe("StepRunner.runDetached", () => {
 		expect(runner.stepLog[0]).toMatchObject({ label: "bench", exitCode: 0 });
 	});
 
+	it("deletes the detached log + done files after reading them back", async () => {
+		// Each retried collect starts a fresh detached step whose log holds the entire base64 results
+		// tar; without cleanup those large files pile up in the sandbox's /tmp across retries, exactly
+		// when the disk is tight. The completed step must rm both files once their contents are in hand.
+		const { sandbox, commands } = detachedSandbox({ log: "done", exitCode: "0" });
+		const runner = new StepRunner(sandbox);
+		await runner.runDetached("bench", "mise run benchmark", 60_000);
+		const cleanup = commands.find((c) => c.command.includes("rm -f") && c.command.includes(".log"));
+		expect(cleanup).toBeDefined();
+		expect(cleanup?.command).toContain(".done");
+	});
+
 	it("propagates a non-zero detached exit code as a failure", async () => {
 		const { sandbox } = detachedSandbox({ exitCode: "42" });
 		const runner = new StepRunner(sandbox);
@@ -390,6 +402,80 @@ describe("StepRunner.runDetached", () => {
 		const result = await runner.runDetached("bench", "mise run benchmark", 60_000);
 		expect(result.exitCode).toBe(0);
 		expect(result.stdout).toBe("recovered fine");
+	});
+
+	it("retries the completed step's log read-back through transient fs blips", async () => {
+		// Regression: the completion read-back was ONE fs attempt with the error folded into stdout ""
+		// (Blaxel, 2026-07-19) — a transient fs-API slowdown silently discarded a finished suite's
+		// results. A blip must be retried, not swallowed.
+		let logReads = 0;
+		const sandbox: SandboxHandle = {
+			runCommand: async () => ({ exitCode: 0, stdout: "launched" }),
+			destroy: async () => undefined,
+			filesystem: {
+				exists: async (path) => path.endsWith(".done"),
+				readFile: async (path) => {
+					if (path.endsWith(".done")) return "0";
+					if (++logReads < 3) throw new Error("fs API slow");
+					return "read back on attempt 3";
+				},
+			},
+		};
+		const runner = new StepRunner(sandbox, CAPPED, async () => undefined);
+		const result = await runner.runDetached("bench", "mise run benchmark", 60_000);
+		expect(result.exitCode).toBe(0);
+		expect(result.stdout).toBe("read back on attempt 3");
+		expect(logReads).toBe(3);
+	});
+
+	it("falls back to the exec transport when the fs log read-back keeps failing", async () => {
+		// The fs API can be wedged while plain exec still answers — the log must come back over `cat`
+		// rather than the whole completed step failing.
+		const commands: string[] = [];
+		const sandbox: SandboxHandle = {
+			runCommand: async (command) => {
+				commands.push(command);
+				if (command.includes("cat")) return { exitCode: 0, stdout: "read back over exec" };
+				return { exitCode: 0, stdout: "launched" };
+			},
+			destroy: async () => undefined,
+			filesystem: {
+				exists: async (path) => path.endsWith(".done"),
+				readFile: async (path) => {
+					if (path.endsWith(".done")) return "0";
+					throw new Error("fs API down"); // every .log read
+				},
+			},
+		};
+		const runner = new StepRunner(sandbox, CAPPED, async () => undefined);
+		const result = await runner.runDetached("bench", "mise run benchmark", 60_000);
+		expect(result.exitCode).toBe(0);
+		expect(result.stdout).toBe("read back over exec");
+		expect(commands.some((c) => c.includes("cat") && c.includes(".log"))).toBe(true);
+	});
+
+	it("throws a distinct transport-failure error when the completed log is unreachable everywhere", async () => {
+		// Regression: with every transport dead this returned stdout "" — collectResults then threw a
+		// misleading marker error and a fully-valid suite run was discarded. The step must fail with a
+		// diagnosis that says the step COMPLETED but its output could not be fetched.
+		const sandbox: SandboxHandle = {
+			runCommand: async (command) => {
+				if (command.includes("cat")) throw new Error("exec transport down too");
+				return { exitCode: 0, stdout: "launched" };
+			},
+			destroy: async () => undefined,
+			filesystem: {
+				exists: async (path) => path.endsWith(".done"),
+				readFile: async (path) => {
+					if (path.endsWith(".done")) return "0";
+					throw new Error("fs API down");
+				},
+			},
+		};
+		const runner = new StepRunner(sandbox, CAPPED, async () => undefined);
+		await expect(runner.runDetached("bench", "mise run benchmark", 60_000)).rejects.toThrow(
+			/completed but its log could not be read back \(transport failure\)/,
+		);
 	});
 
 	it("distinguishes a wedged from a quiet sandbox on the no-filesystem path too", async () => {

--- a/packages/harness/src/lib/execute.ts
+++ b/packages/harness/src/lib/execute.ts
@@ -45,6 +45,12 @@ const POLL_CAP_MS = 10_000;
 const MAX_CONSECUTIVE_POLL_FAILURES = 12;
 /** How much of a timed-out detached step's log to surface — enough to diagnose, not enough to flood. */
 const TIMEOUT_LOG_TAIL_LINES = 50;
+/** Retry budget for reading a COMPLETED detached step's log — the step's only output. One swallowed
+ *  transient fs-API error (Blaxel, 2026-07-19) once turned a finished suite's results into stdout ""
+ *  and the run's 4 valid samples were discarded, so mirror the poll loop's philosophy
+ *  ({@link MAX_CONSECUTIVE_POLL_FAILURES}): tolerate a blip, fail loudly only on a run of failures. */
+const READBACK_ATTEMPTS = 5;
+const READBACK_DELAY_MS = 2_000;
 /** Done-file sentinel for the no-filesystem cat-poll fallback: printed while the file isn't there yet. */
 const RUNNING_SENTINEL = "__RUNNING__";
 const delay = (ms: number): Promise<void> => new Promise((resolve) => setTimeout(resolve, ms));
@@ -242,6 +248,13 @@ function startHeartbeat(label: string, startedAt: number, timeoutMs: number): ()
  * Runs suite steps against one sandbox, charging each step's elapsed wall time to the current Phase
  * (`phase` is mutated by the orchestrator as the job progresses). One instance per sandbox/suite job.
  */
+/**
+ * A completed detached step whose log no transport could read back. Typed so callers that can
+ * usefully re-run the whole step (collectResults — tar|base64 is idempotent) can tell this
+ * RETRYABLE transport condition apart from a command failure or timeout, which must propagate.
+ */
+export class LogReadbackError extends Error {}
+
 export class StepRunner {
 	/** The phase subsequent steps are charged to. */
 	phase: Phase = "setup";
@@ -382,10 +395,17 @@ export class StepRunner {
 					}
 				}
 				if (exitCode !== undefined) {
-					const stdout = fs
-						? await withTimeout(fs.readFile(logPath), POLL_CAP_MS, "log fs read").catch(() => "")
-						: await this.catFile(logPath);
-					return this.finishStep(label, started, { exitCode, stdout }, opts);
+					try {
+						const stdout = await this.readCompletedLog(fs, logPath, label);
+						return this.finishStep(label, started, { exitCode, stdout }, opts);
+					} finally {
+						// The read-back is done — its contents are in memory — so drop the log/done files
+						// now. collectResults re-runs the WHOLE detached step on a transient read-back
+						// failure, and each attempt's log holds the entire base64 results tar; leaving stale
+						// ones behind would pile large files into the sandbox's /tmp across retries, exactly
+						// when the sandbox disk is tight (the case the stdout-streamed collect exists for).
+						await this.removeDetachedFiles(logPath, donePath);
+					}
 				}
 				if (performance.now() > deadline) {
 					// Recover the detached job's own output BEFORE killing it and tearing the sandbox down.
@@ -480,28 +500,76 @@ export class StepRunner {
 		return lines.slice(-TIMEOUT_LOG_TAIL_LINES).join("\n");
 	}
 
-	/** `cat` the log for {@link readLogTail}, preserving a read failure as `null`. Deliberately NOT
-	 *  {@link catFile}: that one folds every failure into `""`, which is right for the poll loop (an
-	 *  absent done-file is not an error) but would make a wedged sandbox indistinguishable from a step
-	 *  that simply printed nothing — the one distinction this diagnostic exists to draw. */
+	/**
+	 * Read a COMPLETED detached step's log back — the step's entire output. The primary transport (fs
+	 * when exposed, else the exec `cat`) is retried through transient blips ({@link READBACK_ATTEMPTS});
+	 * a filesystem API that stays down falls back to the exec transport, which can be healthy while the
+	 * fs API is not (observed on Blaxel). When every transport fails, THROW: folding the failure into
+	 * stdout `""` handed callers that parse the output (collectResults) an empty string, silently
+	 * discarding a finished suite's results while the sandbox was alive and still holding them.
+	 */
+	private async readCompletedLog(
+		fs: SandboxFilesystem | undefined,
+		logPath: string,
+		label: string,
+	): Promise<string> {
+		let lastFailure = "";
+		for (let attempt = 1; attempt <= READBACK_ATTEMPTS; attempt++) {
+			if (fs) {
+				try {
+					return await withTimeout(fs.readFile(logPath), POLL_CAP_MS, "log fs read");
+				} catch (err) {
+					lastFailure = err instanceof Error ? err.message : String(err);
+				}
+			} else {
+				const text = await this.catLogOrNull(logPath);
+				if (text !== null) return text;
+				lastFailure = "log cat read failed";
+			}
+			if (attempt < READBACK_ATTEMPTS) await this.sleep(READBACK_DELAY_MS);
+		}
+		// Cross-transport fallback: the fs API can be freshly wedged while plain exec still answers —
+		// try the other transport before declaring the log unreachable. (No-fs sandboxes already spent
+		// every attempt on exec; there is no other transport to try.)
+		if (fs) {
+			const text = await this.catLogOrNull(logPath);
+			if (text !== null) return text;
+			lastFailure = `${lastFailure}; exec fallback also failed`;
+		}
+		throw new LogReadbackError(
+			`Step "${label}" completed but its log could not be read back (transport failure): ` +
+				`${READBACK_ATTEMPTS} reads failed (last: ${lastFailure}) — the step's output still exists ` +
+				`in the sandbox but no transport could reach it`,
+		);
+	}
+
+	/** `cat` the log over exec for {@link readLogTail} and {@link readCompletedLog}, preserving a read
+	 *  failure as `null` rather than folding it into `""` — an unreadable log (wedged sandbox, dead
+	 *  transport) must stay distinguishable from a step that simply printed nothing. */
 	private async catLogOrNull(logPath: string): Promise<string | null> {
+		// No `|| true`: a failing cat (unreadable/absent log) must surface as null, not as a
+		// successful empty read — `|| true` once collapsed exec-transport failure into stdout "",
+		// which readCompletedLog then accepted as the step's real (empty) output. Exit 0 with empty
+		// stdout remains a legitimate read of a genuinely empty log.
 		return withTimeout(
-			this.sandbox.runCommand(`bash -c ${shellQuote(`cat ${logPath} 2>/dev/null || true`)}`),
+			this.sandbox.runCommand(`bash -c ${shellQuote(`cat ${logPath} 2>/dev/null`)}`),
 			POLL_CAP_MS,
 			"log cat read",
 		)
-			.then((res) => res.stdout ?? "")
+			.then((res) => ((res.exitCode ?? 0) === 0 ? (res.stdout ?? "") : null))
 			.catch(() => null);
 	}
 
-	/** Read the detached step's log over `exec` — the output transport for the no-filesystem path. */
-	private async catFile(logPath: string): Promise<string> {
-		const res = await withTimeout(
-			this.sandbox.runCommand(`bash -c ${shellQuote(`cat ${logPath} 2>/dev/null || true`)}`),
+	/** Best-effort delete a completed detached step's log + done files once their contents have been
+	 *  read back. Bounded so a hung fs can't stall teardown, and it NEVER throws: cleanup must not mask
+	 *  the step's real result, and a sandbox on its way to `destroy()` may already be unreachable — a
+	 *  failed rm just leaves the same orphaned files the sandbox teardown reclaims anyway. */
+	private async removeDetachedFiles(logPath: string, donePath: string): Promise<void> {
+		await withTimeout(
+			this.sandbox.runCommand(`bash -c ${shellQuote(`rm -f ${logPath} ${donePath}`)}`),
 			POLL_CAP_MS,
-			"log cat read",
+			"detached file cleanup",
 		).catch(() => undefined);
-		return res?.stdout ?? "";
 	}
 
 	/** Shared post-step bookkeeping: record the step, echo output (unless silent), enforce exit code. */


### PR DESCRIPTION
**Bench-matrix green — every suite×provider cell measuring or honestly gapped**
Fixes the 10 root causes behind the failures and silent metric holes of runs [29799034615](https://github.com/starslingdev/hpc-sandbox-benchmarks/actions/runs/29799034615) and [29850811070](https://github.com/starslingdev/hpc-sandbox-benchmarks/actions/runs/29850811070). #229–#232 have merged; the remaining fixes are **parallel PRs based directly on `main`** — reviewable and mergeable in any order, except #238, which stacks on #237:
- #233 — leaderboard: no fabricated missing-rows for never-dispatched providers
- #234 — realworld: per-task timeout + cgroup-v2 memory containment
- #235 — harness: failed gap on sandbox-creation failure
- #236 — harness: detached log read-back + collect retries
- #237 — bench: loud PTS leaf guards; stream + pybench measure again
- #238 — templates: pgbench bake fix (pkg-config), payload assertion, portable fio, v4 *(stacked on #237)*
- #239 — fast-cli: settle gated on upload-phase stability
- #240 — providers: Daytona region pin actually reaches the API; both variants us-west-2
- #241 — ci: dataset-PR PAT fallback; e2b disk-skip notes

↑ **This PR is #236 — independent: based on `main`, no merge-order dependency on the others.**

---
realworld-mastra/blaxel (run 29850811070) finished its PTS batch with 4
valid measured samples, then lost all of them: the detached completion
read-back was ONE fs.readFile attempt with the error folded to stdout ''
(.catch(() => "")), so a transient Blaxel fs-API slowdown turned into
'Could not locate results payload markers' and the whole suite was
discarded from an alive sandbox.

The completion read-back now retries the fs read with backoff, falls back
to the exec transport (cat), and if every transport fails throws a
distinct 'log could not be read back (transport failure)' error instead of
silently returning ''. collectResults distinguishes transport failure from
a truncated payload in its error, logs bounded head/tail diagnostics
(never the full base64), and retries the whole collect step twice —
tar|base64 is idempotent and the sandbox is only destroyed later.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents finished suite results from being lost to flaky detached log read-back or corrupt collect payloads. Retries read-back with backoff, retries the idempotent collect step, falls back to exec `cat`, cleans up detached `.log/.done` files, and fails fast on deterministic empty results via `CollectedResultsEmptyError`.

- **Bug Fixes**
  - Detached read-back: retry fs log reads with backoff; fall back to exec `cat`; treat a failing `cat` as an error (no `|| true`); on total failure throw `LogReadbackError`; after read-back, best-effort `rm -f` of the step’s `.log` and `.done` files.
  - `collectResults`: retry the whole `tar|base64` collect on `LogReadbackError`, marker miss, and decode/extract errors; distinguish empty stdout (transport failure) from non-empty markerless output (truncated/malformed); fail immediately on no PTS result or gap marker via `CollectedResultsEmptyError`; diagnostics stay content-free (marker presence and lengths only).

<sup>Written for commit d5cc91919e856929ec2569eff19029aeaf98cb2b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/starslingdev/hpc-sandbox-benchmarks/pull/236?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability when collecting results from detached steps by retrying transient output and log-readback failures.
  * Added fallback handling when completed logs cannot be read through the primary method.
  * Added clearer diagnostics for transport failures, malformed output, and corrupted result payloads.
  * Prevented unnecessary retries when collected results are deterministically empty.
  * Automatically cleans up detached-step log and completion files after processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->