### PR TITLE
fix(bench): fail PTS leaves loudly on empty results; make stream and pybench measure again

### DIFF
--- a/.mise/tasks/benchmark/memory/pts/stream
+++ b/.mise/tasks/benchmark/memory/pts/stream
@@ -41,11 +41,62 @@ fi
 # Compiling every provider down to a fixed baseline (e.g. -march=x86-64-v3) would *hide* a difference we
 # exist to measure. Caveat for readers of the leaderboard: STREAM is DRAM-bandwidth-bound, so once past
 # the L3 ceiling SIMD width contributes little — expect the ISA to show up as a small effect, if at all.
+#
+# gVisor is the one exception: gcc's -march=native feature-detects via CPUID, which gVisor does not
+# fully virtualize — it leaks HOST features (AVX-512) that gVisor's exposed CPU will not execute, so
+# the native binary dies with SIGILL on the first 512-bit instruction (run 29799034615: "Illegal
+# instruction", all four subtests, both trials, modal-gvisor). x86-64-v3 exactly matches modal-gvisor's
+# advertised flag set (avx/avx2/fma/bmi1/bmi2/f16c/movbe/abm/xsave present, zero avx512*) — it IS the
+# rentable ISA there, so compiling to it hides nothing. Same probe as setup.ts's detectedIsolation.
 STREAM_ARRAY_SIZE=150000000
-export CFLAGS_OVERRIDE="-O3 -march=native -DSTREAM_ARRAY_SIZE=${STREAM_ARRAY_SIZE}"
+march=native
+if grep -qi gvisor /proc/version 2>/dev/null; then
+	march=x86-64-v3
+fi
+export CFLAGS_OVERRIDE="-O3 -march=${march} -DSTREAM_ARRAY_SIZE=${STREAM_ARRAY_SIZE}"
+
+# Recompile the baked profile in place so the override above actually applies: run_pts_benchmark skips
+# reinstall for a profile PTS reports installed, so on baked images the bake-runner's binary ran —
+# compiled with upstream's default `-O3 -march=native` on the CI runner (AVX-512, the modal-gvisor
+# SIGILL) and a bake-host-derived array size (134217728, not the 150000000 pinned above). Mirrors the
+# fast-cli repair-in-place, with one deliberate difference: the vendored install.sh MUST run under
+# bash, not sh — it is #!/bin/bash, and dash aborts fatally at $((L3_CACHE_SIZE * 4)) when getconf
+# prints a non-number ("Illegal number: undefined", reproduced in the v3 image), silently leaving the
+# stale AVX-512 binary in place. Offline-safe: the tarball, stream.c, bzip2 and cc are all baked.
+# ~1.6s; the first cc fails on the 3.35GiB .bss and the script's built-in -mcmodel=medium retry lands.
+# If the recompile leaves a stale binary anyway, the count guard below turns the job red with a
+# recorded gap. The stock-image path (blaxel) is unchanged: run_pts_benchmark's not-installed branch
+# batch-installs with the same exported CFLAGS_OVERRIDE.
+profile="stream-1.3.4"
+pts_init
+if _pts_is_installed "pts/${profile}"; then
+	installed_dir="$(pts_user_dir)/installed-tests/pts/${profile}"
+	recompile_stamp="$(mktemp)"
+	(
+		cd "$installed_dir"
+		bash "${REPO_ROOT}/packages/schema/src/pts-profiles/${profile}/install.sh"
+	)
+	# The vendored script mirrors upstream, which exits 0 even when BOTH cc attempts fail — and a
+	# stale baked binary that still RUNS (native ISA on a compatible host) would pass the count
+	# guard while measuring the WRONG working set (the bake host's array size, not the 150e6 pin).
+	# The stamp is older than any binary cc just wrote, so not-newer == not rebuilt: refuse to
+	# measure rather than publish numbers for a configuration we did not compile.
+	if [ ! "${installed_dir}/stream-bin" -nt "$recompile_stamp" ]; then
+		rm -f "$recompile_stamp"
+		echo "ERROR: stream in-place recompile left a stale binary (stream-bin not rebuilt)" >&2
+		fail_result "stream in-place recompile failed; the stale baked binary would measure the wrong array size/ISA" "pts_stream"
+		exit 1
+	fi
+	rm -f "$recompile_stamp"
+fi
 
 # Version-pinned to the vendored catalog profile AND the toolchain bake (ptsInstallTests): a
 # versionless name resolves to whatever upstream's latest is at run time, which would bypass the
 # baked pre-install and rebuild STREAM in every sandbox (and could drift the option matrix from the
 # vendored stream-1.3.4 the catalog was generated from — versionless join is pts/stream either way).
 run_pts_benchmark "pts/stream-1.3.4" "pts_stream"
+
+# PTS exits 0 and writes a composite even when every trial failed — the modal-gvisor SIGILL above ran
+# green with zero metrics for exactly that reason. suites.ts declares 4 memory metrics
+# (Copy/Scale/Add/Triad); a recorded skip marker passes (keep+warn).
+assert_pts_numeric_values pts_stream 4

--- a/.mise/tasks/benchmark/network/pts/fast-cli
+++ b/.mise/tasks/benchmark/network/pts/fast-cli
@@ -31,15 +31,7 @@ run_pts_benchmark "pts/fast-cli-1.0.0" "pts_fast-cli"
 
 # PTS returns zero and writes a composite even when every trial failed. Treat the suite as successful
 # only when its four result parsers each emitted a numeric value; this caught missing Chrome libraries
-# that would otherwise turn into an apparently green job with no usable metrics.
-result_xml="$(results_dir)/pts_fast-cli.xml"
-if [ ! -s "$result_xml" ] || ! awk '
-	match($0, /<Value>[^<]*<\/Value>/) {
-		value = substr($0, RSTART + 7, RLENGTH - 15)
-		if (value ~ /^[0-9]+([.][0-9]+)?$/) numeric++
-	}
-	END { exit numeric == 4 ? 0 : 1 }
-' "$result_xml"; then
-	echo "ERROR: pts/fast-cli did not produce four numeric metrics" >&2
-	exit 1
-fi
+# that would otherwise turn into an apparently green job with no usable metrics. The shared helper adds
+# skip-marker tolerance the old inline awk lacked: a leaf whose run_pts_benchmark recorded an honest
+# --skipped.json gap stays green-with-recorded-skip instead of hard-failing.
+assert_pts_numeric_values pts_fast-cli 4

--- a/.mise/tasks/benchmark/pgbench/pts/pgbench
+++ b/.mise/tasks/benchmark/pgbench/pts/pgbench
@@ -19,7 +19,26 @@ source "${REPO_ROOT}/lib/bench.sh"
 # Version-pinned to the vendored profile (and its recorded fixture) so an upstream pgbench release
 # can't silently unmap the catalogued descriptions. "100"/"50" pin by NAME (they exceed the menus'
 # entry counts, so the numeric-index trap in run_pinned_pts's contract doesn't bite).
+#
+# The two modes are independent measurements, so neither aborts the other: run_pinned_pts now
+# propagates run_pts_benchmark's non-zero all-empty result, and under this script's `set -e` an
+# unguarded read-only failure would exit before read-write ran — dropping a mode that may well have
+# measured, and leaving read-write with no marker at all. `|| true` keeps each mode's own recorded
+# gap (run_pts_benchmark already wrote its --failed.json before returning) while letting the other
+# mode run; the assert loop below is the single arbiter that then reds the job.
 run_pinned_pts "pts/pgbench-1.15.0" "pts_pgbench-read-only" \
-	"pgbench.scaling-factor=100;pgbench.clients=50;pgbench.run-mode=Read Only"
+	"pgbench.scaling-factor=100;pgbench.clients=50;pgbench.run-mode=Read Only" || true
 run_pinned_pts "pts/pgbench-1.15.0" "pts_pgbench-read-write" \
-	"pgbench.scaling-factor=100;pgbench.clients=50;pgbench.run-mode=Read Write"
+	"pgbench.scaling-factor=100;pgbench.clients=50;pgbench.run-mode=Read Write" || true
+
+# PTS exits 0 and writes a composite even when every trial failed (empty <Value> elements): each mode
+# must post its TPS + Average Latency pair — 2 numeric values per prefix, totalling the 4 pgbench
+# metrics suites.ts declares. Guard-only, deliberately NO fast-cli-style vendored install.sh
+# repair-in-place: rebuilding postgres in-sandbox costs multiple minutes per replica across providers
+# (pins.ts bakes it for exactly that reason) — this only converts the ICU/pkg-config half-install's
+# silence (launcher present, pg_/ payload absent, green job with zero metrics) into a loud, recorded
+# failure; the bake-side pkg-config fix restores the metrics. A --skipped.json marker passes: an
+# honest recorded gap is the designed keep+warn shape.
+for prefix in pts_pgbench-read-only pts_pgbench-read-write; do
+	assert_pts_numeric_values "$prefix" 2
+done

--- a/.mise/tasks/benchmark/system/pts/git
+++ b/.mise/tasks/benchmark/system/pts/git
@@ -13,3 +13,8 @@ fi
 # The matrix used to carry only an old pts_git skip fixture: no registered suite actually invoked
 # the profile. Pin the vendored version so its GTK corpus and command sequence cannot drift.
 run_pts_benchmark "pts/git-1.1.0" "pts_git"
+
+# PTS exits 0 and writes a composite even when every trial failed — the silent-green shape that hid
+# pybench/pgbench for three runs. suites.ts declares one git metric (git_seconds); a recorded skip
+# marker passes (keep+warn).
+assert_pts_numeric_values pts_git 1

--- a/.mise/tasks/benchmark/system/pts/pybench
+++ b/.mise/tasks/benchmark/system/pts/pybench
@@ -11,3 +11,9 @@ if ! command -v phoronix-test-suite &>/dev/null; then
 fi
 
 run_pts_benchmark "pts/pybench-1.1.3" "pts_pybench"
+
+# PTS exits 0 and writes a composite even when every trial failed — the harness's former
+# MISE_DISABLE_TOOLS=python export broke `python3` on every baked provider ("mise ERROR python3 is
+# not a valid shim") and pybench ran green with zero metrics for three runs. suites.ts declares one
+# pybench metric (pybench_milliseconds); a recorded skip marker passes (keep+warn).
+assert_pts_numeric_values pts_pybench 1

--- a/.mise/tasks/benchmark/system/pts/sqlite-speedtest
+++ b/.mise/tasks/benchmark/system/pts/sqlite-speedtest
@@ -11,3 +11,8 @@ if ! command -v phoronix-test-suite &>/dev/null; then
 fi
 
 run_pts_benchmark "pts/sqlite-speedtest-1.0.1" "pts_sqlite-speedtest"
+
+# PTS exits 0 and writes a composite even when every trial failed — the silent-green shape that hid
+# pybench/pgbench for three runs. suites.ts declares one sqlite metric (sqlite_speedtest_seconds); a
+# recorded skip marker passes (keep+warn).
+assert_pts_numeric_values pts_sqlite-speedtest 1

--- a/lib/bench.sh
+++ b/lib/bench.sh
@@ -77,6 +77,21 @@ skip_result() {
 	echo "SKIPPED: ${reason}"
 }
 
+# Record that a leaf RAN and errored — the failure sibling of skip_result, writing the
+# `--failed.json` marker the normalizer folds into a suite-scope failed gap (the filename suffix
+# decides the outcome; the body carries the leaf identity and reason). Best-effort write: the marker
+# is the paper trail for a failure the caller is about to propagate anyway, so a results-dir hiccup
+# must not replace that failure with a filesystem error.
+# Usage: fail_result <reason> [name]
+fail_result() {
+	local reason="$1" name="${2:-}"
+	[ -n "$name" ] || name="$(task_result_name)"
+	printf '{"schema_version":"1.0","outcome":"failed","benchmark":"%s","reason":"%s"}\n' \
+		"$(_json_escape "$name")" "$(_json_escape "$reason")" \
+		>"$(results_dir)/${name}--failed.json" 2>/dev/null || true
+	echo "FAILED: ${reason}"
+}
+
 # Append one measurement to manifest.ndjson — a uniform machine-readable log every timing helper
 # writes, independent of the tool-specific output the benchmark itself produces.
 _manifest_record() {
@@ -330,12 +345,15 @@ ensure_pts() {
 			# ensure_pts's contract is to return 1 gracefully so the caller can skip. This is the
 			# last-resort stock-image path; keep the package set aligned with setup.ts and 00-apt.sh.
 			# php for PTS itself, the build toolchain for the source-built profiles, libaio-dev (fio's
-			# Linux AIO engine), libicu-dev (postgres), tcl (sqlite), stress-ng (hardlink), and probes.
+			# Linux AIO engine), libicu-dev + pkg-config (postgres — 17's configure discovers ICU
+			# exclusively via PKG_CHECK_MODULES, so without a pkg-config binary the headers are
+			# invisible and the build aborts "ICU library not found"), tcl (sqlite), stress-ng
+			# (hardlink), and probes.
 			(curl -fsSL "$deb_url" -o "$tmp_deb" &&
 				${SUDO:-} apt-get -o Acquire::Retries=3 update -qq &&
 				${SUDO:-} apt-get install -y -qq php-cli php-xml build-essential autoconf flex bison bc \
-					libelf-dev libssl-dev libaio-dev libicu-dev dnsutils jq netcat-openbsd iputils-ping \
-					tcl stress-ng unzip procps &&
+					libelf-dev libssl-dev libaio-dev libicu-dev pkg-config dnsutils jq netcat-openbsd \
+					iputils-ping tcl stress-ng unzip procps &&
 				${SUDO:-} dpkg -i "$tmp_deb") || true
 			rm -f "$tmp_deb"
 		fi
@@ -428,6 +446,46 @@ install_vendored_pts_profile() {
 	echo "Staged vendored PTS override: ${profile_dst} (removed ${installed_dst})"
 }
 
+# Count the <Value> elements in a PTS composite whose content is a plain number. Failed PTS trials
+# leave empty <Value></Value> elements behind while batch-run still exits 0, so this count is the
+# only in-sandbox signal separating a measured composite from an all-trials-failed one. Always
+# succeeds; an unreadable/missing file counts as 0 (callers gate on -s separately).
+_pts_numeric_value_count() {
+	awk '
+		match($0, /<Value>[^<]*<\/Value>/) {
+			value = substr($0, RSTART + 7, RLENGTH - 15)
+			if (value ~ /^[0-9]+([.][0-9]+)?$/) numeric++
+		}
+		END { print numeric + 0 }
+	' "$1" 2>/dev/null || echo 0
+}
+
+# Exact-count result guard for single-test leaves: the copied composite must carry exactly
+# <expected> numeric values (per-leaf counts mirror packages/schema/src/suites.ts metrics[]). A
+# recorded --skipped.json marker passes — run_pts_benchmark/run_pinned_pts already recorded an
+# honest gap (PTS missing, batch-setup failed, install failed, no composite), and
+# green-with-recorded-skip is the designed keep+warn shape. Any other shortfall records a per-leaf
+# --failed.json marker and fails the leaf (non-zero) so the job goes red with a recorded gap that
+# names THIS prefix — not just the whole-suite failure the harness derives from the exit code —
+# instead of silently green with partial metrics (the missing-Chrome-libs incident fast-cli's
+# original inline guard caught, generalized). The marker mirrors run_pts_benchmark's all-empty
+# path so a shortfall caught here and one caught there leave the same shape of evidence.
+# Usage: assert_pts_numeric_values <results-prefix> <expected-count>
+assert_pts_numeric_values() {
+	local prefix="$1" expected="$2"
+	local dir
+	dir="$(results_dir)"
+	if [ -f "${dir}/${prefix}--skipped.json" ]; then
+		return 0
+	fi
+	local xml="${dir}/${prefix}.xml"
+	if [ ! -s "$xml" ] || [ "$(_pts_numeric_value_count "$xml")" -ne "$expected" ]; then
+		echo "ERROR: ${prefix} did not produce ${expected} numeric metric value(s)" >&2
+		fail_result "${prefix} did not produce ${expected} numeric metric value(s)" "$prefix"
+		return 1
+	fi
+}
+
 # Install and run one PTS test, capturing timing via bench_cmd and copying the result XML to
 # benchmark-results/<prefix>.xml (the contract the results extractor reads).
 # Usage: run_pts_benchmark <test-name> <results-prefix>
@@ -476,8 +534,18 @@ run_pts_benchmark() {
 	# nothing, silently copy the PREVIOUS leaf's composite under this leaf's prefix — masking the
 	# failure AND suppressing the skip marker. (A merged-into result dir still matches: PTS rewrites
 	# composite.xml, updating its mtime past the stamp.)
+	# errexit does not protect this scaffolding: run_pts_benchmark is reached through run_pinned_pts's
+	# `run_pts_benchmark ... || rc=$?`, and bash disables errexit for the whole dynamic extent of a
+	# function invoked in a `||`/`if` condition. So a failed mktemp would NOT abort here — run_stamp
+	# would be empty, `find … -newer ""` would error out to no match, and the leaf would record a benign
+	# "produced no composite.xml" skip for what is really a broken sandbox. Guard it explicitly and fail
+	# the leaf loudly (red job + recorded gap) instead.
 	local run_stamp
-	run_stamp="$(mktemp)"
+	if ! run_stamp="$(mktemp)"; then
+		echo "ERROR: could not create pre-run stamp for ${test_name} (mktemp failed)" >&2
+		fail_result "mktemp failed before PTS run of ${test_name}" "$prefix"
+		return 1
+	fi
 
 	bench_cmd "PTS: ${test_name}" "$prefix" phoronix-test-suite batch-run "$test_name"
 
@@ -497,7 +565,9 @@ run_pts_benchmark() {
 	fi
 	rm -f "$run_stamp"
 	if [ -n "$xml_found" ] && [ -f "$xml_found" ]; then
-		cp "$xml_found" "$(results_dir)/${prefix}.xml" 2>/dev/null || true
+		local copied_xml
+		copied_xml="$(results_dir)/${prefix}.xml"
+		cp "$xml_found" "$copied_xml" 2>/dev/null || true
 		echo "Structured result: ${prefix}.xml (from $(dirname "$xml_found"))"
 		# Preserve PTS's own structured system record too. composite.xml carries Hardware/Software as
 		# comma-delimited prose; result-file-to-json expands those into component maps and also retains
@@ -520,6 +590,23 @@ run_pts_benchmark() {
 		# matches). `|| true` so a /var/lib perms hiccup can't abort this `set -e` measurement leaf.
 		tar -czf "$(results_dir)/${prefix}--forensics.tar.gz" \
 			-C "$(dirname "$result_dir")" "$(basename "$result_dir")" 2>/dev/null || true
+		# PTS batch-run exits 0 and still writes a composite even when EVERY trial failed — the
+		# <Value> elements are simply empty, the extractor drops them without record, and the job
+		# stays green with zero metrics (pgbench shipped that shape for three consecutive runs).
+		# TOTAL loss fails the leaf loudly: the harness then writes the sandbox failed marker and the
+		# job goes red with a recorded gap, the designed shape. A PARTIAL shortfall must NOT fail
+		# here — realworld suites legitimately post empty Values for individual failed tasks (the
+		# normalizer's shortfall cross-check records those as gaps); single-test leaves layer the
+		# stricter assert_pts_numeric_values on top. A failed cp lands here too: a composite that
+		# never reached results_dir is the same silent hole.
+		if [ ! -s "$copied_xml" ] || [ "$(_pts_numeric_value_count "$copied_xml")" -eq 0 ]; then
+			echo "ERROR: ${test_name} wrote a composite but no Result carries a numeric value (all trials failed)" >&2
+			# The per-leaf marker keeps the LEAF identity in the recorded gap (the normalizer folds it
+			# under the suite with the leaf in the reason) even when the harness also records the
+			# whole-suite failure this non-zero return triggers.
+			fail_result "PTS batch-run of ${test_name} completed but every trial errored (composite carries no values)" "$prefix"
+			return 1
+		fi
 	else
 		echo "No PTS composite.xml found under ${pts_base}/"
 		ls -la "$pts_base"/ 2>/dev/null || true
@@ -613,8 +700,13 @@ run_pinned_pts() {
 		return 0
 	fi
 
-	run_pts_benchmark "$test_name" "$prefix"
+	# run_pts_benchmark now fails on an all-empty composite. Capture its status so the pin vars are
+	# unset on BOTH paths (a bare call would leak them past a failure in a non-errexit caller — and
+	# the unset returning 0 would swallow the failure entirely).
+	local rc=0
+	run_pts_benchmark "$test_name" "$prefix" || rc=$?
 	unset PRESET_OPTIONS PTS_RUN_ALL_TEST_COMBINATIONS
+	return "$rc"
 }
 
 # Run ONE pinned pts/fio scenario; Direct comes from fio_direct_choice above.

--- a/packages/harness/src/lib/execute.test.ts
+++ b/packages/harness/src/lib/execute.test.ts
@@ -52,6 +52,13 @@ describe("sandbox preamble", () => {
 		expect(PREAMBLE).toContain("PTS_USER_PATH_OVERRIDE=/var/lib/phoronix-test-suite/");
 	});
 
+	it("never disables the mise python — baked images have no distro python3 to fall back to", () => {
+		// Regression pin: MISE_DISABLE_TOOLS=python turned every python3 on a baked image into
+		// "mise ERROR python3 is not a valid shim" (pybench ran green with zero metrics on every
+		// baked provider) because the images ship only the mise-shimmed python, no distro python3.
+		expect(PREAMBLE).not.toContain("MISE_DISABLE_TOOLS");
+	});
+
 	// buildPreamble omits the trial vars entirely under BENCH_PASSES=1 (contract-verification mode), so
 	// these trial-count assertions only hold outside it — skip in that mode rather than fail a contract run.
 	it.skipIf(process.env.BENCH_PASSES === "1")(

--- a/packages/harness/src/lib/execute.ts
+++ b/packages/harness/src/lib/execute.ts
@@ -182,8 +182,13 @@ const PREAMBLE_HEAD = [
 	// lookups exhaust GitHub's anonymous API quota before a benchmark starts. Suite runtime tools are
 	// installed explicitly by setupSteps (node/pnpm/PTS) or by the base-package fallback instead.
 	"export MISE_TASK_RUN_AUTO_INSTALL=0",
-	// The precompiled-python index is jdx.dev-only (no GitHub fallback) — use the distro python3.
-	"export MISE_DISABLE_TOOLS=python",
+	// No MISE_DISABLE_TOOLS=python here: baked images ship NO distro python3 — 10-mise.sh symlinks the
+	// mise shims into /usr/local/bin, so python3 resolves to the baked mise python (pinned 3.13.14,
+	// pre-installed, offline; MISE_DATA_DIR/MISE_CONFIG_DIR are Dockerfile ENV). Disabling the tool
+	// turned every python3 into "mise ERROR python3 is not a valid shim" (pybench: zero metrics on
+	// every baked provider, green jobs). Stock images resolve distro python3 (installed by setup.ts's
+	// base-package fallback), with no jdx.dev download risk — python appears in no active mise config
+	// there (the repo mise.toml pins only dev linters) and MISE_TASK_RUN_AUTO_INSTALL=0 stays set.
 	// Distro pythons are PEP 668 externally-managed, but PTS profiles pip-install their harness —
 	// fine in a throwaway sandbox; the baked image sets the same.
 	"export PIP_BREAK_SYSTEM_PACKAGES=1",

--- a/packages/harness/src/lib/setup.ts
+++ b/packages/harness/src/lib/setup.ts
@@ -122,7 +122,9 @@ export function setupSteps(suite: Suite): SetupStep[] {
 		// out of lockstep with it.
 		const ptsDeps =
 			"php-cli php-xml build-essential autoconf flex bison bc libelf-dev libssl-dev " +
-			"libaio-dev libicu-dev dnsutils jq netcat-openbsd iputils-ping tcl stress-ng unzip procps " +
+			// pkg-config rides with libicu-dev: postgres 17's configure discovers ICU exclusively via
+			// PKG_CHECK_MODULES, so without the binary pgbench's build aborts "ICU library not found".
+			"libaio-dev libicu-dev pkg-config dnsutils jq netcat-openbsd iputils-ping tcl stress-ng unzip procps " +
 			"fonts-liberation libasound2 libatk-bridge2.0-0 libatk1.0-0 " +
 			"libcairo2 libcups2 libdbus-1-3 libdrm2 libfontconfig1 libgbm1 libglib2.0-0 libgtk-3-0 " +
 			"libnspr4 libnss3 libpango-1.0-0 libpangocairo-1.0-0 " +

--- a/packages/schema/src/pts-profiles/stream-1.3.4/install.sh
+++ b/packages/schema/src/pts-profiles/stream-1.3.4/install.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+# Vendored VERBATIM from upstream phoronix-test-suite/test-profiles pts/stream-1.3.4/install.sh
+# (fetched 2026-07-21) so the memory leaf can recompile the baked stream-bin in place with its own
+# CFLAGS_OVERRIDE (see .mise/tasks/benchmark/memory/pts/stream) — the bake-time binary carries the
+# bake runner's -march=native ISA (AVX-512 → SIGILL under gVisor) and L3-derived array size. Only
+# this header and its shellcheck directive were added; every executable line is untouched upstream.
+# MUST be invoked with bash, never sh: dash aborts fatally at $((L3_CACHE_SIZE * 4)) when getconf
+# prints a non-number ("Illegal number: undefined"), dying before cc and leaving the stale binary.
+# Inert to the catalog tooling: fetch-profiles.ts ignores siblings of test-definition.xml.
+# shellcheck disable=SC2006,SC2086,SC2268
+tar -jxf stream-2013-01-17.tar.bz2
+if [ "X$CFLAGS_OVERRIDE" = "X" ]
+then
+          CFLAGS="$CFLAGS -O3 -march=native"
+else
+          CFLAGS="$CFLAGS_OVERRIDE"
+fi
+
+STREAM_ARRAY_SIZE=100000000
+L3_CACHE_SIZE=`getconf LEVEL3_CACHE_SIZE`
+SIZE_BASED_ON_L3=$((L3_CACHE_SIZE * 4))
+if [ $SIZE_BASED_ON_L3 -gt $STREAM_ARRAY_SIZE ]
+then
+     STREAM_ARRAY_SIZE=$SIZE_BASED_ON_L3
+fi
+cc stream.c -DSTREAM_ARRAY_SIZE=$STREAM_ARRAY_SIZE -DNTIMES=100 $CFLAGS -fopenmp -o stream-bin
+CC_EXIT_STATUS=$?
+if [ $CC_EXIT_STATUS -gt 0 ]
+then
+    # Retry compiling with -mcmodel=medium set
+    cc stream.c -DSTREAM_ARRAY_SIZE=$STREAM_ARRAY_SIZE -DNTIMES=100 -mcmodel=medium $CFLAGS -fopenmp -o stream-bin
+    CC_EXIT_STATUS=$?
+fi
+echo $CC_EXIT_STATUS > ~/install-exit-status
+echo "#!/bin/sh
+export OMP_NUM_THREADS=\$NUM_CPU_CORES
+./stream-bin > \$LOG_FILE 2>&1
+echo \$? > ~/test-exit-status" > stream
+chmod +x stream


### PR DESCRIPTION
**Bench-matrix green — every suite×provider cell measuring or honestly gapped**
Fixes the 10 root causes behind the failures and silent metric holes of runs [29799034615](https://github.com/starslingdev/hpc-sandbox-benchmarks/actions/runs/29799034615) and [29850811070](https://github.com/starslingdev/hpc-sandbox-benchmarks/actions/runs/29850811070). #229–#232 have merged; the remaining fixes are **parallel PRs based directly on `main`** — reviewable and mergeable in any order, except #238, which stacks on #237:
- #233 — leaderboard: no fabricated missing-rows for never-dispatched providers
- #234 — realworld: per-task timeout + cgroup-v2 memory containment
- #235 — harness: failed gap on sandbox-creation failure
- #236 — harness: detached log read-back + collect retries
- #237 — bench: loud PTS leaf guards; stream + pybench measure again
- #238 — templates: pgbench bake fix (pkg-config), payload assertion, portable fio, v4 *(stacked on #237)*
- #239 — fast-cli: settle gated on upload-phase stability
- #240 — providers: Daytona region pin actually reaches the API; both variants us-west-2
- #241 — ci: dataset-PR PAT fallback; e2b disk-skip notes

↑ **This PR is #237 — based on `main`; #238 stacks on top (the bake-side half of the pgbench pkg-config fix).**

---
PTS exits 0 even when every trial fails, and only fast-cli guarded
against it — pgbench, stream-on-gvisor, and pybench-on-4-of-5-providers
ran green with zero metrics across every published run. Three changes:

- run_pts_benchmark writes a '<prefix>--failed.json' marker AND returns
  non-zero when the copied composite carries no numeric value at all
  (job red with a recorded gap — the designed failed-measurement shape);
  'some values present' never fails there, realworld suites legitimately
  post empty per-task Values. fast-cli's inline awk guard is factored
  into a shared assert_pts_numeric_values helper, now also applied to
  stream (4), pybench (1), git (1), sqlite-speedtest (1), and pgbench
  (2 per mode; guard-only — a runtime postgres rebuild would cost
  minutes per sandbox, the bake fix lands separately).
- MISE_DISABLE_TOOLS=python is removed from the preamble: baked Debian 13
  images ship NO distro python3, so the disabled shim turned every python3
  into 'mise ERROR python3 is not a valid shim' (pybench: zero metrics on
  every baked provider; blaxel only worked via its stock-image distro
  python). Baked images now benchmark the baked mise python 3.13.14.
- stream recompiles in place on baked images via the vendored upstream
  install.sh (invoked with bash — dash dies fatally on its arithmetic when
  getconf returns a non-number), with -march=x86-64-v3 under gVisor (the
  bake runner's -march=native embedded AVX-512; gVisor exposes AVX2 only,
  so every trial died with 'Illegal instruction') and -march=native
  elsewhere, making the documented 150000000 array pin real everywhere.
  pkg-config joins the runtime dep lists (postgres 17 ICU discovery).

Vendored stream-1.3.4/install.sh is byte-identical to upstream except a
provenance header + shellcheck directives (CI shellchecks pts-profiles).

