### PR TITLE
fix(templates): unbreak the pgbench bake and stop half-installs shipping silently

### DIFF
--- a/packages/harness/src/lib/setup.ts
+++ b/packages/harness/src/lib/setup.ts
@@ -9,6 +9,7 @@
  *   BENCH_REPO_TOKEN  Token for cloning a private repo; stripped from the remote right after clone.
  */
 import type { Suite } from "@sandbox-benchmarks/schema";
+import { PTS_APT_DEPS } from "@sandbox-benchmarks/schema";
 import { MIN } from "./execute.ts";
 
 export const REPO_URL =
@@ -111,31 +112,13 @@ export function setupSteps(suite: Suite): SetupStep[] {
 		// image deliberately cleans /var/lib/apt/lists, while a stock-image provider must compile every
 		// profile locally; in either case PTS's own dependency install needs a usable package index.
 		// Best-effort lets a healthy baked image proceed when a provider cannot reach its distro mirror.
-		// Keep this set aligned with packages/templates/images/base/scripts/00-apt.sh.
-		//
-		// The fonts/GTK/X11 block is fast-cli's Puppeteer/Chrome runtime dependencies. Without them, a
-		// stock-image provider (e.g. modal, which takes this fallback path rather than the baked image)
-		// downloads a fresh Chrome via npm install that fails immediately with "error while loading
-		// shared libraries: libglib-2.0.so.0: cannot open shared object file" — a same-day-observed live
-		// failure (run 29587815350, modal/network) with zero fast-cli metrics produced. 00-apt.sh already
-		// bakes these for the pre-baked image path; this was the one runtime fallback that had drifted
-		// out of lockstep with it.
-		const ptsDeps =
-			"php-cli php-xml build-essential autoconf flex bison bc libelf-dev libssl-dev " +
-			// pkg-config rides with libicu-dev: postgres 17's configure discovers ICU exclusively via
-			// PKG_CHECK_MODULES, so without the binary pgbench's build aborts "ICU library not found".
-			"libaio-dev libicu-dev pkg-config dnsutils jq netcat-openbsd iputils-ping tcl stress-ng unzip procps " +
-			"fonts-liberation libasound2 libatk-bridge2.0-0 libatk1.0-0 " +
-			"libcairo2 libcups2 libdbus-1-3 libdrm2 libfontconfig1 libgbm1 libglib2.0-0 libgtk-3-0 " +
-			"libnspr4 libnss3 libpango-1.0-0 libpangocairo-1.0-0 " +
-			"libx11-6 libx11-xcb1 libxcb1 libxcomposite1 libxcursor1 libxdamage1 " +
-			"libxext6 libxfixes3 libxi6 libxkbcommon0 libxrandr2 libxrender1 libxss1 libxtst6 " +
-			"xdg-utils";
+		// The package list is the canonical PTS_APT_DEPS from the schema toolchain contract — the shell
+		// consumers (00-apt.sh, lib/bench.sh) are gated against the same constant by repo-checks.
 		steps.push({
 			label: "ensure PTS build deps + fresh apt index",
 			script:
 				"$SUDO apt-get -o Acquire::Retries=3 update -qq || true; " +
-				`$SUDO apt-get install -y -qq ${ptsDeps} || echo "WARNING: apt dep refresh failed (best-effort); relying on the baked image"`,
+				`$SUDO apt-get install -y -qq ${PTS_APT_DEPS} || echo "WARNING: apt dep refresh failed (best-effort); relying on the baked image"`,
 			timeoutMs: 15 * MIN,
 		});
 		steps.push({

--- a/packages/schema/src/toolchain.ts
+++ b/packages/schema/src/toolchain.ts
@@ -4,7 +4,33 @@
 // tag is immutable: a change to the toolchain image means bumping TOOLCHAIN_VERSION.
 
 export const TOOLCHAIN_IMAGE_NAME = "sandbox-benchmarks-toolchain";
-// v3: the 4 vCPU / 8 GiB target spec. The e2b/daytona/novita templates are version-scoped, so this
-// bump forces new artifacts to be baked+promoted at cpu_count=4 rather than silently reusing the
-// immutable v2 templates (baked at 2 vCPU). Re-bake all providers before the runs that consume v3.
-export const TOOLCHAIN_VERSION = "v3";
+// v4: image-content fix over v3 (which was the 4 vCPU / 8 GiB target-spec bump). Adds pkg-config so
+// PostgreSQL 17's configure can discover ICU via PKG_CHECK_MODULES — every v3 image shipped pgbench
+// as a launcher-only half-install (pg_/ payload missing; zero pgbench metrics ever recorded) — and
+// bakes fio with --disable-native so the binary survives reduced-ISA sandboxes (modal-gvisor exposes
+// only AVX2; the builder-native fio SIGILLed in ~30ms). Re-bake all providers before the runs that
+// consume v4.
+export const TOOLCHAIN_VERSION = "v4";
+
+// The apt packages PTS needs beyond a stock image — PTS's own php runtime, the compiler toolchain
+// for the source-built profiles, and fast-cli's Chrome runtime libs. ONE canonical list: the
+// per-run dep refresh (packages/harness setup.ts) interpolates it directly, while the two shell
+// consumers (the bake's 00-apt.sh and lib/bench.sh's stock-image ensure_pts) cannot import TS, so
+// tooling/repo-checks/src/pts-dep-alignment.test.ts gates their core set against this constant.
+//
+// The fonts/GTK/X11 block is fast-cli's Puppeteer/Chrome runtime dependencies. Without them, a
+// stock-image provider (e.g. modal, which takes the fallback path rather than the baked image)
+// downloads a fresh Chrome via npm install that fails immediately with "error while loading
+// shared libraries: libglib-2.0.so.0: cannot open shared object file" — a live-observed failure
+// (run 29587815350, modal/network) with zero fast-cli metrics produced.
+export const PTS_APT_DEPS =
+	"php-cli php-xml build-essential autoconf flex bison bc libelf-dev libssl-dev " +
+	// pkg-config rides with libicu-dev: postgres 17's configure discovers ICU exclusively via
+	// PKG_CHECK_MODULES, so without the binary pgbench's build aborts "ICU library not found".
+	"libaio-dev libicu-dev pkg-config dnsutils jq netcat-openbsd iputils-ping tcl stress-ng unzip procps " +
+	"fonts-liberation libasound2 libatk-bridge2.0-0 libatk1.0-0 " +
+	"libcairo2 libcups2 libdbus-1-3 libdrm2 libfontconfig1 libgbm1 libglib2.0-0 libgtk-3-0 " +
+	"libnspr4 libnss3 libpango-1.0-0 libpangocairo-1.0-0 " +
+	"libx11-6 libx11-xcb1 libxcb1 libxcomposite1 libxcursor1 libxdamage1 " +
+	"libxext6 libxfixes3 libxi6 libxkbcommon0 libxrandr2 libxrender1 libxss1 libxtst6 " +
+	"xdg-utils";

--- a/packages/templates/images/base/scripts/00-apt.sh
+++ b/packages/templates/images/base/scripts/00-apt.sh
@@ -23,6 +23,13 @@ apt-get update
 # > the set to exactly what the benchmark suites need.
 # > libaio-dev: fio's libaio engine (the disk suite's pinned scenarios) — needed at bake time, when
 # > 20-pts.sh pre-builds fio. libicu-dev: postgres's configure hard-requires ICU (pgbench pre-build).
+# > pkg-config: PostgreSQL 17's configure locates ICU exclusively via PKG_CHECK_MODULES(icu-uc
+# > icu-i18n), so libicu-dev is invisible to it without a pkg-config binary — configure aborts with
+# > "ICU library not found" while PTS still marks pgbench installed (its upstream install.sh has no
+# > set -e and writes the launcher unconditionally), which is how every image since #144 shipped
+# > pgbench without its pg_/ payload. On Debian 13 `pkg-config` resolves to pkgconf's transitional
+# > package; keep this name so the two runtime mirrors (lib/bench.sh ensure_pts, and the schema
+# > toolchain contract's PTS_APT_DEPS that setup.ts interpolates) stay aligned.
 # > dnsutils + jq: the benchmark:system:provider probe (Team Cymru DNS whois via dig, ipinfo JSON via
 # > jq). netcat-openbsd: the pts/network-loopback runner (`dd | nc`). iputils-ping: the
 # > benchmark:network:latency probe (slim base images ship no ping).
@@ -36,7 +43,7 @@ apt-get install -y --no-install-recommends \
 	curl git ca-certificates \
 	build-essential autoconf \
 	php-cli php-xml \
-	flex bison bc libelf-dev libssl-dev libaio-dev libicu-dev \
+	flex bison bc libelf-dev libssl-dev libaio-dev libicu-dev pkg-config \
 	dnsutils jq netcat-openbsd iputils-ping \
 	fonts-liberation libasound2 libatk-bridge2.0-0 libatk1.0-0 \
 	libcairo2 libcups2 libdbus-1-3 libdrm2 libfontconfig1 libgbm1 libglib2.0-0 libgtk-3-0 \

--- a/packages/templates/images/base/scripts/20-pts.sh
+++ b/packages/templates/images/base/scripts/20-pts.sh
@@ -45,6 +45,30 @@ read -ra pts_tests <<< "${PTS_INSTALL_TESTS}"
 # > future profiles: provider snapshot registries must import the complete compressed image.
 # > network-loopback has no downloads and no-ops here harmlessly.
 phoronix-test-suite make-download-cache "${pts_tests[@]}"
+
+# > fio's configure defaults to -march=native — native to the BAKE machine, which is wrong on both
+# > counts for a baked image: it is not the run machine's ISA and it is not portable. Modal's gVisor
+# > sandboxes expose only AVX2 (no avx512*), so a builder-native binary dies in ~30ms and the disk
+# > suite records empty fio results. Disk I/O measurement is ISA-insensitive, so pin the baked fio
+# > to the compiler's portable default. The fio profile version comes from PTS_INSTALL_TESTS (the
+# > single source of the pin), so a fio bump can never leave this patch pointing at a stale path —
+# > exactly one fio entry is expected; zero or several is a pin-list bug this bake refuses to guess
+# > around.
+fio_pin=""
+for t in "${pts_tests[@]}"; do
+	case "$t" in
+	fio-*)
+		[ -z "$fio_pin" ] || { echo "ERROR: multiple fio entries in PTS_INSTALL_TESTS (${PTS_INSTALL_TESTS})" >&2; exit 1; }
+		fio_pin="$t"
+		;;
+	esac
+done
+[ -n "$fio_pin" ] || { echo "ERROR: no fio entry in PTS_INSTALL_TESTS (${PTS_INSTALL_TESTS}) — the --disable-native patch has nothing to apply to" >&2; exit 1; }
+fio_install="/var/lib/phoronix-test-suite/test-profiles/pts/${fio_pin}/install.sh"
+[ -f "${fio_install}" ] || { echo "ERROR: fio profile not staged at ${fio_install}" >&2; exit 1; }
+sed -i 's|\./configure |./configure --disable-native |' "${fio_install}"
+grep -q -- '--disable-native' "${fio_install}" || { echo "ERROR: --disable-native patch did not land in fio install.sh" >&2; exit 1; }
+
 # > PTS exits 0 even when an install fails, so verify each requested profile actually reports installed.
 # > A versionless entry anchors on "<test>-<version>" (versions start with a digit); a version-pinned
 # > entry ("fio-2.1.0") already ends in its version, so it anchors on a following non-name character
@@ -54,6 +78,21 @@ phoronix-test-suite batch-install "${pts_tests[@]}"
 installed="$(phoronix-test-suite list-installed-tests)"
 for t in "${pts_tests[@]}"; do
 	echo "${installed}" | grep -qE "(^|/)${t}(-[0-9]|[[:space:]]|$)" || { echo "ERROR: pre-install of ${t} failed" >&2; exit 1; }
+done
+
+# > list-installed-tests only proves the launcher file a profile's install.sh wrote exists — and
+# > pgbench's upstream install.sh (plain sh, no set -e) writes it even when configure/make failed,
+# > so the 2026-07 ICU/pkg-config half-install (launcher present, pg_/ payload absent) passed the
+# > loop above and the image published. Assert the payload the generated launcher actually executes
+# > (its line 21 runs pg_/bin/pgbench), so a launcher-only half-install fails the bake loudly —
+# > this script runs under set -Eeuxo pipefail inside docker build.
+for t in "${pts_tests[@]}"; do
+	case "${t}" in
+	pgbench*)
+		[ -x "/var/lib/phoronix-test-suite/installed-tests/pts/${t}/pg_/bin/pgbench" ] ||
+			{ echo "ERROR: ${t} installed without its built postgres payload (pg_/bin/pgbench missing)" >&2; exit 1; }
+		;;
+	esac
 done
 
 # > batch-install copies each staged archive into its installed-test tree. Keeping the byte-identical
@@ -81,3 +120,21 @@ fi
 # > ephemeral benchmark state writable so that user can create batch config and result XML beside the
 # > read-mostly installed profiles. Provider isolation is the outer security boundary for this image.
 chmod -R a+rwX /var/lib/phoronix-test-suite
+
+# > That blanket chmod would ship pgbench broken: its install.sh initdb'd pg_/data/db as 0700, and
+# > postgres's checkDataDir() FATALs at startup when the data dir has any group/other mode bits (the
+# > profile's run-as-root patch strips the euid checks, not this one) — the launcher's pg_ctl start
+# > would fail and the leaf would record empty results, while the payload check above still passes
+# > (a+rwX never clears the x bit). Re-tighten the data dir AFTER the blanket chmod and assert the
+# > final mode, so a reorder of these steps fails the bake, not the sandbox run.
+for t in "${pts_tests[@]}"; do
+	case "${t}" in
+	pgbench*)
+		pgdata="/var/lib/phoronix-test-suite/installed-tests/pts/${t}/pg_/data/db"
+		[ -d "${pgdata}" ] || { echo "ERROR: ${t} has no initdb'd data dir at ${pgdata}" >&2; exit 1; }
+		chmod -R go-rwx "${pgdata}"
+		[ "$(stat -c '%a' "${pgdata}")" = "700" ] ||
+			{ echo "ERROR: ${t} data dir mode is $(stat -c '%a' "${pgdata}"), postgres requires 0700" >&2; exit 1; }
+		;;
+	esac
+done

--- a/packages/templates/src/smoke.ts
+++ b/packages/templates/src/smoke.ts
@@ -67,6 +67,31 @@ export function ptsInstalledTestsSmokeCheck(installTests: string): SmokeCheck {
 }
 
 /**
+ * Build the pgbench payload probe from an install list, or null when no pgbench profile is pinned
+ * (mirrors ptsInstalledTestsSmokeCheck's expectedCount===0 handling — no speculative probe when the
+ * pin is gone). PTS marks a profile installed by the launcher file its install.sh writes, and
+ * pgbench's upstream install.sh (plain sh, no set -e) writes it even when configure/make failed —
+ * so the count probe above passed while the 2026-07 ICU/pkg-config half-install shipped without its
+ * pg_/ payload. Probe the exact binary the generated launcher executes, and the initdb'd data dir's
+ * mode: postgres's checkDataDir() refuses to start when the data dir carries any group/other bits,
+ * so the bake's blanket a+rwX (runtime-user writability) must leave pg_/data/db re-tightened to
+ * 0700 — a state a packaging step could silently undo while the binary stays executable. Exported
+ * for tests.
+ */
+export function pgbenchPayloadSmokeCheck(installTests: string): SmokeCheck | null {
+	const entry = installTests.split(/\s+/).find((test) => /^pgbench-/.test(test));
+	if (!entry) return null;
+	const installRoot = `/var/lib/phoronix-test-suite/installed-tests/pts/${entry}`;
+	return {
+		name: "pgbench-payload",
+		cmd: `test -x ${installRoot}/pg_/bin/pgbench && test "$(stat -c %a ${installRoot}/pg_/data/db)" = 700 && echo pgbench-payload-ok`,
+		expect: "pgbench-payload-ok",
+	};
+}
+
+const pgbenchPayloadCheck = pgbenchPayloadSmokeCheck(pins.ptsInstallTests);
+
+/**
  * The probes, in run order. Expects are pinned to the same pins.ts that built the image, so this
  * asserts the *exact* toolchain is present — not merely that "a" node/python exists.
  */
@@ -88,6 +113,12 @@ export const smokeChecks: readonly SmokeCheck[] = [
 	// Exact count is deliberate: a mutable-tag cache once made E2B/Novita validate an old two-profile
 	// image while the current candidate held nine. The sentinel also avoids substring false positives.
 	ptsInstalledTestsSmokeCheck(pins.ptsInstallTests),
+	// The installed-count probe above trusts PTS's own install bookkeeping, which a launcher-only
+	// pgbench half-install satisfies. This one asserts the built postgres payload itself — in BOTH
+	// consumers, so the docker-level smoke proves the bake built it and the in-sandbox smoke proves
+	// it survived provider packaging (e2b envd injection / daytona snapshot / modal fromRegistry —
+	// the same drift class that dropped fast-cli's Chrome libs).
+	...(pgbenchPayloadCheck ? [pgbenchPayloadCheck] : []),
 	// The enforced verification manifest is present (proves the base build's 99-manifest step ran)…
 	{ name: "manifest", cmd: "cat /toolchain-manifest.json", expect: TOOLCHAIN_IMAGE_NAME },
 	// …and declares the expected toolchain version, so a stale/wrong-version manifest fails loudly.

--- a/tooling/repo-checks/src/pts-dep-alignment.test.ts
+++ b/tooling/repo-checks/src/pts-dep-alignment.test.ts
@@ -1,0 +1,103 @@
+// Drift gate: the PTS build/runtime apt dependencies are needed in THREE places — the toolchain
+// bake (packages/templates/images/base/scripts/00-apt.sh), the stock-image fallback (lib/bench.sh
+// ensure_pts), and the per-run refresh (packages/harness setup.ts). Comment-only alignment drifted
+// twice for real: fast-cli's Chrome libs were missing from the runtime refresh (run 29587815350 —
+// zero fast-cli metrics on modal), and pkg-config was missing everywhere, so PostgreSQL 17's ICU
+// discovery failed and every image since #144 shipped pgbench as a launcher-only half-install with
+// zero metrics ever recorded.
+//
+// The runtime refresh now interpolates the canonical PTS_APT_DEPS from the schema toolchain
+// contract, so its alignment holds by construction (a wiring tripwire below keeps it honest). The
+// two shell consumers cannot import TS, so like the profile-pins gate they are read as text and
+// flattened — line-anchored extraction, deliberately not shell parsing.
+//
+// SUBSET assertion, deliberately not equality: the lists legitimately differ (ensure_pts omits the
+// fonts/GTK block, and 00-apt.sh alone carries image plumbing like curl/ca-certificates). What
+// must never drift is the core PTS build-dep set below — the packages the source-built profiles
+// need at compile time plus PTS's own php runtime.
+import { describe, expect, it } from "bun:test";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { PTS_APT_DEPS } from "@sandbox-benchmarks/schema";
+import { findRepoRoot } from "./lib/workspace.ts";
+
+const root = findRepoRoot();
+
+// The invariant: every member must appear in all three apt lists. php for PTS itself, the compiler
+// toolchain for the source-built profiles, libaio-dev (fio's Linux AIO engine), libicu-dev +
+// pkg-config (postgres 17's ICU discovery via PKG_CHECK_MODULES), tcl (sqlite's opcode generator).
+const CORE_PTS_BUILD_DEPS = [
+	"php-cli",
+	"php-xml",
+	"build-essential",
+	"autoconf",
+	"flex",
+	"bison",
+	"bc",
+	"libelf-dev",
+	"libssl-dev",
+	"libaio-dev",
+	"libicu-dev",
+	"pkg-config",
+	"tcl",
+];
+
+/**
+ * Flatten the `\`-continued shell command starting at the first line matching `start` into its
+ * whitespace-separated tokens. Command words and flags ride along harmlessly — no core dep collides
+ * with `apt-get`/`install`/`-y`-style tokens, and a subset check ignores extras by construction.
+ */
+function shellInstallTokens(path: string, start: RegExp): string[] {
+	const lines = readFileSync(join(root, path), "utf8").split("\n");
+	const index = lines.findIndex((line) => start.test(line));
+	if (index === -1) throw new Error(`${path}: no line matches ${start}`);
+	const collected: string[] = [];
+	for (let i = index; i < lines.length; i++) {
+		const line = lines[i] as string;
+		const continued = /\\\s*$/.test(line);
+		collected.push(line.replace(/\\\s*$/, ""));
+		if (!continued) break;
+	}
+	return collected.join(" ").split(/\s+/).filter(Boolean);
+}
+
+const sources: { path: string; tokens: () => string[] }[] = [
+	{
+		path: "packages/templates/images/base/scripts/00-apt.sh",
+		tokens: (): string[] =>
+			shellInstallTokens(
+				"packages/templates/images/base/scripts/00-apt.sh",
+				/^apt-get install -y --no-install-recommends/,
+			),
+	},
+	{
+		path: "lib/bench.sh",
+		tokens: (): string[] => shellInstallTokens("lib/bench.sh", /apt-get install -y -qq /),
+	},
+	{
+		// The canonical constant itself, imported — not re-parsed from source. The runtime refresh
+		// interpolates this exact value, so checking it here covers setup.ts by construction.
+		path: "packages/schema/src/toolchain.ts (PTS_APT_DEPS)",
+		tokens: (): string[] => PTS_APT_DEPS.split(/\s+/).filter(Boolean),
+	},
+];
+
+describe("PTS apt dep alignment", () => {
+	for (const source of sources) {
+		it(`keeps every core PTS build dep in ${source.path}`, () => {
+			const tokens = source.tokens();
+			expect(tokens.length).toBeGreaterThan(0);
+			// Reported as `<pkg> missing from <path>` so a red run names the drift directly.
+			const missing = CORE_PTS_BUILD_DEPS.filter((dep) => !tokens.includes(dep));
+			expect(missing.map((dep) => `${dep} missing from ${source.path}`)).toEqual([]);
+		});
+	}
+
+	// The by-construction claim holds only while setup.ts actually interpolates the constant — a
+	// re-inlined literal would pass the subset check against the constant while drifting in the
+	// sandbox. Cheap text tripwire, same spirit as the shell extraction above.
+	it("keeps the runtime refresh wired to the canonical PTS_APT_DEPS constant", () => {
+		const text = readFileSync(join(root, "packages/harness/src/lib/setup.ts"), "utf8");
+		expect(text).toContain(`\${PTS_APT_DEPS}`);
+	});
+});


### PR DESCRIPTION
**Bench-matrix green — every suite×provider cell measuring or honestly gapped**
Fixes the 10 root causes behind the failures and silent metric holes of runs [29799034615](https://github.com/starslingdev/hpc-sandbox-benchmarks/actions/runs/29799034615) and [29850811070](https://github.com/starslingdev/hpc-sandbox-benchmarks/actions/runs/29850811070). #229–#232 have merged; the remaining fixes are **parallel PRs based directly on `main`** — reviewable and mergeable in any order, except #238, which stacks on #237:
- #233 — leaderboard: no fabricated missing-rows for never-dispatched providers
- #234 — realworld: per-task timeout + cgroup-v2 memory containment
- #235 — harness: failed gap on sandbox-creation failure
- #236 — harness: detached log read-back + collect retries
- #237 — bench: loud PTS leaf guards; stream + pybench measure again
- #238 — templates: pgbench bake fix (pkg-config), payload assertion, portable fio, v4 *(stacked on #237)*
- #239 — fast-cli: settle gated on upload-phase stability
- #240 — providers: Daytona region pin actually reaches the API; both variants us-west-2
- #241 — ci: dataset-PR PAT fallback; e2b disk-skip notes

↑ **This PR is #238 — stacked on #237 (merge #237 first): its pts-dep-alignment repo-check requires the runtime-side pkg-config that #237 adds to `lib/bench.sh` and `setup.ts`.**

---
pgbench has produced zero metrics in every run since it shipped: the bake
installs libicu-dev but not pkg-config, PostgreSQL 17's configure
discovers ICU exclusively via PKG_CHECK_MODULES, so the build aborts
('ICU library not found' — preserved in the run artifacts' bake-time
install logs) and upstream's guard-less install.sh still writes the
launcher. PTS then reports the profile installed, and every image since
#144 shipped a launcher-only half-install ('./pgbench: 21: pg_/bin/pgbench:
not found' on every trial, exit 0).

The bake adds pkg-config, asserts the pgbench payload (pg_/bin/pgbench)
exists after install so an unrunnable profile fails the bake loudly, and
patches the fetched fio profile to configure with --disable-native (the
bake runner's -march=native embedded AVX-512 zmm instructions that SIGILL
under gVisor's AVX2-only ISA; disk I/O measurement is ISA-insensitive).
The smoke spec gains docker-level + in-sandbox pgbench payload probes.
A new repo-check pins the three PTS apt dep lists (bake, ensure_pts
fallback, harness refresh) to the shared core-dep invariant — the
comment-only alignment that let pkg-config drift is now a red test.

TOOLCHAIN_VERSION bumps to v4: rebake + provider template refresh is a
maintainer action (PR description); baked providers keep the pgbench hole
until it lands, surfaced meanwhile by the leaf guard + shortfall gaps.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes `pgbench` by adding `pkg-config` and enforcing the built payload + 0700 data-dir perms so half-installs fail the bake. Makes `fio` portable with `--disable-native`, bumps the toolchain to `v4`, and adds a canonical `PTS_APT_DEPS` with a repo-check to prevent apt-dep drift.

- **Bug Fixes**
  - Add `pkg-config` so PostgreSQL 17 finds ICU; `pgbench` builds.
  - Guard against launcher-only installs: assert `pg_/bin/pgbench` exists and `pg_/data/db` is 0700; verified in bake and smoke (docker + in-sandbox).
  - Patch `fio` with `--disable-native` (path derived from `PTS_INSTALL_TESTS`).
  - Canonicalize PTS apt deps as `PTS_APT_DEPS` in `@schema`; `setup.ts` interpolates it. Add a repo-check that gates `00-apt.sh` and `lib/bench.sh` against the same core set and trips if `setup.ts` stops using the constant.

- **Migration**
  - `TOOLCHAIN_VERSION` → `v4`. Re-bake all providers and refresh templates before runs using `v4`.

<sup>Written for commit a7b248f4198c9d55fb0ac0a42439bb21fd5984fc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/starslingdev/hpc-sandbox-benchmarks/pull/238?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

---
**Maintainer actions after merge (this PR's fixes are inert until then):**
- [ ] Re-run `toolchain-image.yml` to bake + promote `v4` (pgbench payload, portable fio), then refresh every provider template (e2b rebuild, daytona snapshot imports, modal registry pull, novita). Blaxel (stock-image runtime install) is fixed by the merge alone.
- [ ] First green pgbench run establishes the TPS/latency baseline — no prior run ever recorded one.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Bumped the toolchain version to v4.
  * Added an additional smoke check to verify the baked PostgreSQL benchmark payload is present, executable, and has correct data-directory permissions.

* **Bug Fixes**
  * Improved PostgreSQL benchmark installation reliability with stricter staged checks and enforced build configuration.
  * Added explicit installation of `pkg-config` to support PostgreSQL ICU detection during builds.

* **Tests**
  * Added a drift-gate test to keep core PTS build apt dependencies aligned across build scripts and setup logic.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->