### PR TITLE
fix(fast-cli): gate settle on upload-phase stability, not bufferbloat alone

### DIFF
--- a/packages/schema/src/fast-cli-driver.test.ts
+++ b/packages/schema/src/fast-cli-driver.test.ts
@@ -1,0 +1,368 @@
+/**
+ * Subprocess gate for the fast-cli driver embedded in pts-profiles/fast-cli-1.0.0/install.sh (the
+ * fast-driver.mjs heredoc). The driver under test is extracted VERBATIM from the shipped install.sh --
+ * never a duplicate copy -- so these scenarios exercise exactly what runs on providers. Each scenario
+ * stages a temp dir holding the driver plus scripted mocks of the two fast-cli 5.2.0 modules the driver
+ * resolves relative to itself, spawns the driver, and asserts on its stdout JSON, its
+ * `fast-cli: stop=...` stderr line, and its exit code. No network, no Chrome.
+ *
+ * Pinned regression (P1, run 29799034615): fast.com renders #bufferbloat-value DURING the download
+ * phase, so a settle predicate gated on bufferbloat-hold alone finalized trials whose upload phase never
+ * started (uploadSpeed=0 labeled "settle" at the backstop ceiling) or was still ramping (banked mid-ramp
+ * garbage with exit 0). Settle may only fire once the upload max has been stable for SETTLE_MS, and
+ * never at/after the backstop instant.
+ *
+ * Timing notes: POLL_MS is hardcoded at 500ms in the driver, so the scaled-down SETTLE_MS must exceed
+ * one tick, and elapsed-time assertions carry generous slack. FAST_CLI_MEM_STOP_PCT=99 is REQUIRED: on
+ * Linux CI the /proc/meminfo fallback reports a real fraction of host memory (it is only inert on hosts
+ * without /proc/meminfo), so the 60% default could trip on a loaded runner and flake every scenario; 99
+ * keeps the watchdog armed but unreachable.
+ */
+
+import { afterAll, describe, expect, it } from "bun:test";
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+const INSTALL_SH = join(import.meta.dir, "pts-profiles/fast-cli-1.0.0/install.sh");
+
+// Scaled-down tunables preserving the production ordering (SETTLE_MS < MIN_MS < BACKSTOP_MS) while
+// keeping SETTLE_MS above the hardcoded 500ms poll tick.
+const MIN_MS = 1500;
+const SETTLE_MS = 700;
+const BACKSTOP_MS = 5000;
+const TEST_TIMEOUT_MS = 20000;
+
+function extractDriverSource(): string {
+	const lines = readFileSync(INSTALL_SH, "utf8").split("\n");
+	const begin = lines.indexOf("cat <<'DRIVER_EOF' >fast-driver.mjs");
+	const end = begin === -1 ? -1 : lines.indexOf("DRIVER_EOF", begin + 1);
+	if (begin === -1 || end === -1) {
+		throw new Error("install.sh no longer embeds the fast-driver.mjs heredoc");
+	}
+	return lines.slice(begin + 1, end).join("\n");
+}
+const DRIVER_SOURCE = extractDriverSource();
+
+// Scripted stand-in for fast-cli 5.2.0's default-export async generator (interface verified against the
+// real distribution: `api(options)[Symbol.asyncIterator]()` consumed by hand). Replays {delayMs, value}
+// entries from MOCK_SCRIPT, then either returns (natural convergence) or idles the way the real
+// generator does on a plateau -- it yields only on CHANGE, so iterator.next() blocks forever. The
+// keep-alive interval stands in for the live browser sockets that hold the real process's event loop
+// open while the driver's unref'd stop timers keep evaluating.
+const MOCK_API_JS = `import fs from "node:fs";
+export default async function* api() {
+	const script = JSON.parse(fs.readFileSync(process.env.MOCK_SCRIPT, "utf8"));
+	for (const step of script.steps) {
+		if (step.delayMs) await new Promise((resolve) => setTimeout(resolve, step.delayMs));
+		yield step.value;
+	}
+	if (script.done) return;
+	setInterval(() => {}, 2 ** 30);
+	await new Promise(() => {});
+}
+`;
+const MOCK_UTILITIES_JS = `export function convertToMbps(value, unit) {
+	return unit === "Gbps" ? value * 1000 : value;
+}
+`;
+
+/** The yield shape fast-cli 5.2.0's generator produces (what the driver destructures). */
+type MockValue = {
+	downloadSpeed: number;
+	uploadSpeed: number;
+	downloadUnit: string;
+	uploadUnit: string;
+	downloaded: number;
+	uploaded: number;
+	latency: number;
+	bufferBloat: number;
+	isDone: boolean;
+	userLocation: string;
+	serverLocations: string;
+	userIp: string;
+};
+type Step = { delayMs: number; value: MockValue };
+
+function value(partial: Partial<MockValue>): MockValue {
+	return {
+		downloadSpeed: 0,
+		uploadSpeed: 0,
+		downloadUnit: "Mbps",
+		uploadUnit: "Mbps",
+		downloaded: 0,
+		uploaded: 0,
+		latency: 0,
+		bufferBloat: 0,
+		isDone: false,
+		userLocation: "Test, TS",
+		serverLocations: "Mock, MO",
+		userIp: "203.0.113.7",
+		...partial,
+	};
+}
+
+const tempRoots: string[] = [];
+afterAll(() => {
+	for (const dir of tempRoots) rmSync(dir, { recursive: true, force: true });
+});
+
+function runDriver(script: { steps: Step[]; done?: boolean }) {
+	const dir = mkdtempSync(join(tmpdir(), "fast-cli-driver-"));
+	tempRoots.push(dir);
+	writeFileSync(join(dir, "fast-driver.mjs"), DRIVER_SOURCE);
+	const distribution = join(dir, "node_modules/fast-cli/distribution");
+	mkdirSync(distribution, { recursive: true });
+	writeFileSync(join(distribution, "api.js"), MOCK_API_JS);
+	writeFileSync(join(distribution, "utilities.js"), MOCK_UTILITIES_JS);
+	const scriptPath = join(dir, "scenario.json");
+	writeFileSync(scriptPath, JSON.stringify(script));
+	const startedAt = Date.now();
+	const proc = Bun.spawnSync([process.execPath, "fast-driver.mjs"], {
+		cwd: dir,
+		env: {
+			...process.env,
+			FAST_CLI_MIN_MS: String(MIN_MS),
+			FAST_CLI_SETTLE_MS: String(SETTLE_MS),
+			FAST_CLI_BACKSTOP_MS: String(BACKSTOP_MS),
+			FAST_CLI_MEM_STOP_PCT: "99",
+			MOCK_SCRIPT: scriptPath,
+		},
+		stdout: "pipe",
+		stderr: "pipe",
+	});
+	const elapsedMs = Date.now() - startedAt;
+	const stdout = proc.stdout.toString();
+	const stderr = proc.stderr.toString();
+	return {
+		exitCode: proc.exitCode,
+		elapsedMs,
+		stderr,
+		stopReason: stderr.match(/stop=(\w+)/)?.[1],
+		json: stdout.trim() ? JSON.parse(stdout) : null,
+	};
+}
+
+describe("fast-cli driver (extracted verbatim from install.sh)", () => {
+	it("imports exactly the two fast-cli modules the mocks replace", () => {
+		// If the driver's import specifiers drift, the mocks would silently stop intercepting.
+		expect(DRIVER_SOURCE).toContain('from "./node_modules/fast-cli/distribution/api.js"');
+		expect(DRIVER_SOURCE).toContain('from "./node_modules/fast-cli/distribution/utilities.js"');
+	});
+
+	it(
+		"backstops (never settles) when bufferbloat holds but the upload phase never starts",
+		() => {
+			// The P1 shape (e2b/novita): bufferbloat renders during the download phase and holds while
+			// uploadSpeed stays 0 for the whole run. Settle must NOT fire at ~MIN_MS -- the run must be
+			// bounded by BACKSTOP_MS, labeled backstop, and exit 1 so PTS records a failed trial.
+			const steps: Step[] = [];
+			for (let i = 0; i < 9; i++) {
+				steps.push({
+					delayMs: 250,
+					value: value({
+						downloadSpeed: 100 + i * 40,
+						downloaded: (i + 1) * 5,
+						latency: 12,
+						bufferBloat: 34,
+					}),
+				});
+			}
+			const result = runDriver({ steps });
+			expect(result.stopReason).toBe("backstop");
+			expect(result.exitCode).toBe(1);
+			expect(result.json?.uploadSpeed).toBe(0);
+			// Only the backstop timer can end this run, so it spans at least BACKSTOP_MS.
+			expect(result.elapsedMs).toBeGreaterThanOrEqual(BACKSTOP_MS - 100);
+		},
+		TEST_TIMEOUT_MS,
+	);
+
+	it(
+		"defers settle while the upload max is still ramping and labels a ceiling tie backstop",
+		() => {
+			// The modal-gvisor shape: upload goes positive but keeps strictly increasing (gaps well under
+			// SETTLE_MS) all the way to the ceiling. A positivity-hold would bank a mid-ramp value
+			// SETTLE_MS after the first byte with exit 0; the plateau-hold must defer until the max stops
+			// increasing -- which never happens here -- so the run ends at the backstop with exit 1.
+			const steps: Step[] = [
+				{ delayMs: 100, value: value({ downloadSpeed: 200, latency: 12, bufferBloat: 34 }) },
+			];
+			let upload = 0;
+			for (let at = 400; at <= 4650; at += 250) {
+				upload += 10;
+				steps.push({
+					delayMs: at === 400 ? 300 : 250,
+					value: value({
+						downloadSpeed: 200,
+						uploadSpeed: upload,
+						uploaded: upload,
+						latency: 12,
+						bufferBloat: 34,
+					}),
+				});
+			}
+			const result = runDriver({ steps });
+			expect(result.stopReason).toBe("backstop");
+			expect(result.exitCode).toBe(1);
+			expect(result.elapsedMs).toBeGreaterThanOrEqual(BACKSTOP_MS - 100);
+		},
+		TEST_TIMEOUT_MS,
+	);
+
+	it(
+		"settles only after the upload max has plateaued for SETTLE_MS, and banks the plateau value",
+		() => {
+			// Healthy-path shape: upload ramps (last increase ~1000ms), then the displayed max holds while
+			// only the uploaded-bytes counter keeps changing (the real generator yields on ANY change).
+			// The plateau yields continue until just before the backstop: if the stability stamp bumped on
+			// equal readings (>= instead of >), settle could never fire pre-ceiling here and the run would
+			// wrongly hit the backstop -- pinning the strict-increase rule without tight timing.
+			const steps: Step[] = [
+				{ delayMs: 100, value: value({ downloadSpeed: 500, latency: 12, bufferBloat: 34 }) },
+				{
+					delayMs: 300,
+					value: value({ uploadSpeed: 50, uploaded: 5, latency: 12, bufferBloat: 34 }),
+				},
+				{
+					delayMs: 300,
+					value: value({ uploadSpeed: 120, uploaded: 15, latency: 12, bufferBloat: 34 }),
+				},
+				{
+					delayMs: 300,
+					value: value({ uploadSpeed: 200, uploaded: 30, latency: 12, bufferBloat: 34 }),
+				},
+			];
+			for (let at = 1250; at <= 4800; at += 250) {
+				steps.push({
+					delayMs: 250,
+					value: value({
+						uploadSpeed: 200,
+						uploaded: 30 + (at - 1000) / 10,
+						latency: 12,
+						bufferBloat: 34,
+					}),
+				});
+			}
+			const result = runDriver({ steps });
+			expect(result.stopReason).toBe("settle");
+			expect(result.exitCode).toBe(0);
+			expect(result.json?.uploadSpeed).toBe(200);
+			// The download plateau was latched while upload was still 0, from the first yield.
+			expect(result.json?.downloadSpeed).toBe(500);
+			// No earlier than last max increase (~1000ms) + SETTLE_MS; comfortably before the backstop.
+			expect(result.elapsedMs).toBeGreaterThanOrEqual(1000 + SETTLE_MS - 100);
+			expect(result.elapsedMs).toBeLessThan(BACKSTOP_MS - 600);
+		},
+		TEST_TIMEOUT_MS,
+	);
+
+	it(
+		"classifies the generator returning as natural convergence (stop=done, exit 0)",
+		() => {
+			// fast-cli 5.2.0 RETURNS once fast.com reports success -- it never yields isDone=true.
+			const steps: Step[] = [
+				{ delayMs: 50, value: value({ downloadSpeed: 300, latency: 10, bufferBloat: 20 }) },
+				{
+					delayMs: 50,
+					value: value({
+						downloadSpeed: 300,
+						uploadSpeed: 150,
+						uploaded: 20,
+						latency: 10,
+						bufferBloat: 20,
+					}),
+				},
+			];
+			const result = runDriver({ steps, done: true });
+			expect(result.stopReason).toBe("done");
+			expect(result.exitCode).toBe(0);
+			expect(result.json?.downloadSpeed).toBe(300);
+			expect(result.json?.uploadSpeed).toBe(150);
+		},
+		TEST_TIMEOUT_MS,
+	);
+
+	it(
+		"restarts the bufferbloat hold window on a flap back to zero",
+		() => {
+			// A yielded bufferBloat drop to 0 must restart the hold: settle may only fire SETTLE_MS after
+			// the FINAL positive stretch began (~1800ms here), never off the stale first stamp (~100ms).
+			// Upload is stable from ~500ms and MIN_MS passes at 1500ms, so the bufferbloat restart is the
+			// binding constraint.
+			const steps: Step[] = [
+				{ delayMs: 100, value: value({ downloadSpeed: 400, latency: 11, bufferBloat: 30 }) },
+				{
+					delayMs: 200,
+					value: value({ uploadSpeed: 100, uploaded: 10, latency: 11, bufferBloat: 30 }),
+				},
+				{
+					delayMs: 200,
+					value: value({ uploadSpeed: 200, uploaded: 20, latency: 11, bufferBloat: 30 }),
+				},
+				{
+					delayMs: 200,
+					value: value({ uploadSpeed: 200, uploaded: 30, latency: 11, bufferBloat: 0 }),
+				},
+				{
+					delayMs: 1100,
+					value: value({ uploadSpeed: 200, uploaded: 60, latency: 11, bufferBloat: 25 }),
+				},
+			];
+			const result = runDriver({ steps });
+			expect(result.stopReason).toBe("settle");
+			expect(result.exitCode).toBe(0);
+			expect(result.json?.bufferBloat).toBe(25);
+			expect(result.elapsedMs).toBeGreaterThanOrEqual(1800 + SETTLE_MS - 100);
+		},
+		TEST_TIMEOUT_MS,
+	);
+
+	it(
+		"nudges exact value ties apart so PTS's value-dedup keeps all four metrics",
+		() => {
+			// PTS drops parser results whose numeric value duplicates an earlier one; loaded latency ==
+			// idle latency is the common tie. The later duplicate is nudged UP by 0.01.
+			const steps: Step[] = [
+				{ delayMs: 50, value: value({ downloadSpeed: 300, latency: 12, bufferBloat: 12 }) },
+				{
+					delayMs: 50,
+					value: value({
+						downloadSpeed: 300,
+						uploadSpeed: 150,
+						uploaded: 20,
+						latency: 12,
+						bufferBloat: 12,
+					}),
+				},
+			];
+			const result = runDriver({ steps, done: true });
+			expect(result.exitCode).toBe(0);
+			expect(result.json?.latency).toBe(12);
+			expect(result.json?.bufferBloat).toBe(12.01);
+			const four = [
+				result.json?.downloadSpeed,
+				result.json?.uploadSpeed,
+				result.json?.latency,
+				result.json?.bufferBloat,
+			];
+			expect(new Set(four).size).toBe(4);
+		},
+		TEST_TIMEOUT_MS,
+	);
+
+	it(
+		"decides completeness on the true values, before the nudge (upload 0 still exits 1)",
+		() => {
+			// The nudge perturbs only what PTS parses; a genuine zero must never become a passing metric.
+			const steps: Step[] = [
+				{ delayMs: 50, value: value({ downloadSpeed: 300, latency: 12, bufferBloat: 12 }) },
+			];
+			const result = runDriver({ steps, done: true });
+			expect(result.stopReason).toBe("done");
+			expect(result.exitCode).toBe(1);
+			expect(result.json?.uploadSpeed).toBe(0);
+		},
+		TEST_TIMEOUT_MS,
+	);
+});

--- a/packages/schema/src/pts-profiles/fast-cli-1.0.0/install.sh
+++ b/packages/schema/src/pts-profiles/fast-cli-1.0.0/install.sh
@@ -46,11 +46,16 @@ fi
 #     so it exits nonzero and PTS records a failed trial instead of banking a truncated row.
 #   * The download plateau is latched WHILE the upload phase is still zero, so the end-of-run re-purposing
 #     of #speed-value can no longer zero it out.
-#   * Completion is fast.com's own `succeeded`/isDone signal OR a stability fallback: once loaded-latency
-#     (bufferbloat) has been present for SETTLE_MS past a minimum window, every phase (download -> upload
-#     -> loaded latency) has finished, so the readings are final. The fallback exists because on the
-#     fastest paths fast.com never flips the `succeeded` class, and gating on isDone alone would fail
-#     providers that are in fact measuring cleanly.
+#   * Completion is fast.com's own `succeeded`/isDone signal OR a stability fallback. The fallback exists
+#     because on the fastest paths fast.com never flips the `succeeded` class, and gating on isDone alone
+#     would fail providers that are in fact measuring cleanly. Bufferbloat-hold alone is NOT finality:
+#     fast.com renders #bufferbloat-value DURING the download phase, ~10s before the first upload byte on
+#     a healthy path (live probes 2026-07-21: bufferbloat positive at ~5-6s, upload first positive at
+#     ~15-17s; the 29799034615 trials showed bufferbloat 6-11 with uploaded:0). So the fallback requires
+#     the upload phase to have started AND its displayed max to have been stable for SETTLE_MS, on top of
+#     the bufferbloat hold and MIN_MS, and only before the backstop instant. A run whose upload never
+#     starts or never stabilizes runs to BACKSTOP_MS and exits 1 as a failed trial (the designed
+#     failed-measurement shape).
 #
 # The generator is read by hand (never `for await`, whose implicit break would call the generator's
 # .return() and trigger the hanging browser.close()); the driver then HARD-exits without closing the
@@ -84,7 +89,7 @@ const BACKSTOP_MS =
 		? Number(backstopRaw)
 		: 180000;
 const MIN_MS = positiveEnv("FAST_CLI_MIN_MS", 20000); // no settle before this much measuring has happened
-const SETTLE_MS = positiveEnv("FAST_CLI_SETTLE_MS", 5000); // bufferbloat must persist this long to settle
+const SETTLE_MS = positiveEnv("FAST_CLI_SETTLE_MS", 5000); // bufferbloat must hold AND upload max must be stable this long to settle
 const POLL_MS = 500; // memory sampling cadence
 
 // --- Memory accounting -----------------------------------------------------------------------------
@@ -164,6 +169,7 @@ let stopReason = null;
 let downloadPhaseMax = 0; // max download seen WHILE upload was still 0 (the true download plateau)
 let downloadAnyMax = 0; // fallback if the upload phase never begins
 let uploadMax = 0;
+let uploadMaxChangedAt = 0; // 0 = the upload phase never produced a positive reading
 let latencyLast = 0;
 let bufferBloatLast = 0;
 let bufferBloatSince = 0;
@@ -186,11 +192,25 @@ function stopWhen(reason, predicate) {
 	});
 }
 const memoryStop = stopWhen("__memory__", () => memoryUsedFraction() * 100 >= MEM_STOP_PCT);
-// Stability fallback for the fastest paths, where `succeeded` never flips: bufferbloat is the last phase
-// fast.com measures, so once it has held for SETTLE_MS past a minimum window the run is final.
+// Stability fallback for the fastest paths, where `succeeded` never flips. fast.com renders
+// #bufferbloat-value DURING the download phase (~10s before the first upload byte on a healthy path;
+// live probes 2026-07-21, and the 29799034615 trials showed bufferbloat 6-11 with uploaded:0), so a
+// bufferbloat hold alone is NOT finality — it can finalize with uploadSpeed=0 before the upload phase
+// was given a chance. Settle therefore also requires the upload phase to have STARTED and its displayed
+// max to have STOPPED INCREASING for SETTLE_MS (mere positivity would bank an early-ramp value: the
+// display keeps ramping for 2-10s after the first positive byte), and it can never fire at/after the
+// backstop instant, so a timer tie at the ceiling is labeled backstop, honestly. A run whose upload
+// never starts or never stabilizes runs to BACKSTOP_MS and exits 1 as a failed trial.
 const settleStop = stopWhen("__settle__", () => {
 	const now = Date.now();
-	return bufferBloatSince && now - start >= MIN_MS && now - bufferBloatSince >= SETTLE_MS;
+	return (
+		now - start < BACKSTOP_MS &&
+		uploadMaxChangedAt !== 0 &&
+		now - uploadMaxChangedAt >= SETTLE_MS &&
+		bufferBloatSince &&
+		now - start >= MIN_MS &&
+		now - bufferBloatSince >= SETTLE_MS
+	);
 });
 const backstop = new Promise((resolve) => {
 	setTimeout(() => resolve("__backstop__"), BACKSTOP_MS).unref?.();
@@ -223,7 +243,13 @@ try {
 		last = step.value;
 		const download = convertToMbps(step.value.downloadSpeed ?? 0, step.value.downloadUnit ?? "Mbps");
 		const upload = convertToMbps(step.value.uploadSpeed ?? 0, step.value.uploadUnit ?? "Mbps");
-		uploadMax = Math.max(uploadMax, upload);
+		// Stamp the stability clock ONLY on a strict increase of the displayed max: yields where just the
+		// uploaded-bytes counter changes, fluctuations at/below the max, or a late 0 reading (the page
+		// re-purposes and clears elements) must not extend the settle window, and uploadMax stays monotone.
+		if (upload > uploadMax) {
+			uploadMax = upload;
+			uploadMaxChangedAt = Date.now();
+		}
 		// Latch the download plateau only while the upload phase hasn't started (uploadMax still 0); once
 		// it has, fast.com re-purposes #speed-value so later download readings are noise.
 		if (uploadMax === 0) downloadPhaseMax = Math.max(downloadPhaseMax, download);


### PR DESCRIPTION
**Bench-matrix green — every suite×provider cell measuring or honestly gapped**
Fixes the 10 root causes behind the failures and silent metric holes of runs [29799034615](https://github.com/starslingdev/hpc-sandbox-benchmarks/actions/runs/29799034615) and [29850811070](https://github.com/starslingdev/hpc-sandbox-benchmarks/actions/runs/29850811070). #229–#232 have merged; the remaining fixes are **parallel PRs based directly on `main`** — reviewable and mergeable in any order, except #238, which stacks on #237:
- #233 — leaderboard: no fabricated missing-rows for never-dispatched providers
- #234 — realworld: per-task timeout + cgroup-v2 memory containment
- #235 — harness: failed gap on sandbox-creation failure
- #236 — harness: detached log read-back + collect retries
- #237 — bench: loud PTS leaf guards; stream + pybench measure again
- #238 — templates: pgbench bake fix (pkg-config), payload assertion, portable fio, v4 *(stacked on #237)*
- #239 — fast-cli: settle gated on upload-phase stability
- #240 — providers: Daytona region pin actually reaches the API; both variants us-west-2
- #241 — ci: dataset-PR PAT fallback; e2b disk-skip notes

↑ **This PR is #239 — independent: based on `main`, no merge-order dependency on the others.**

---
The settle fallback (#218) declared a trial converged once bufferbloat
held for SETTLE_MS — but fast.com renders #bufferbloat-value DURING the
download phase, 11s before the first upload byte (live-probed twice). On
the degraded fast.com paths of runs 29799034615/29850811070 it labeled
backstop-length runs 'settle' with uploadSpeed=0 (e2b/novita: honest red)
and BANKED mid-ramp or near-zero uploads as converged (blaxel 0.082 Mbps,
modal-gvisor 33/18 — ranked garbage); on a healthy path it could fire at
MIN_MS and bank an early-ramp value.

Settle now additionally requires: upload phase started, its displayed max
stable for SETTLE_MS (not merely positive — early-ramp values keep
climbing), and now-start < BACKSTOP_MS so a race tie at the ceiling is
labeled backstop honestly. Upload-never-starts runs hit the backstop,
exit 1, and become a failed trial -> four-metric guard -> job red with a
recorded gap: the designed failed-measurement shape. No new env tunables;
BACKSTOP/MIN/SETTLE values unchanged; no rebake needed (the leaf re-runs
the vendored install.sh in place on baked images).

The new subprocess test extracts the shipped driver heredoc VERBATIM and
drives it with scripted mocks of fast-cli 5.2.0's generator: both failure
shapes from the runs are pinned (the pre-fix driver fails exactly those
two scenarios), plus plateau-settle, generator-return, bufferbloat-flap,
and the dedup-nudge completeness gate. 368 of this diff's lines are that
test harness.

---
**Context for reviewers:** 368 of the 404 lines are the new subprocess test harness. The fast.com degradation itself (uploads collapsed from every provider egress on Jul 21) is external — this fix only makes such runs fail honestly instead of banking garbage. Two keep+warn follow-ups for maintainers: whether fast.com stays viable as the throughput source if the degradation persists, and whether to annotate run 29799034615's banked upload numbers (blaxel 0.082 Mbps, modal-gvisor 33/18) with a comparability warning.

