### PR TITLE
fix(ci): let the dataset PR step use a PAT; correct e2b disk-skip notes

### DIFF
--- a/.github/workflows/commit-dataset.yml
+++ b/.github/workflows/commit-dataset.yml
@@ -134,8 +134,12 @@ jobs:
       # unreviewed. If auto-merge can't be armed (e.g. the repo hasn't enabled it), the PR stays open
       # for a maintainer to merge normally.
       - name: Commit the dataset via pull request
+        # Step-level env deliberately routes ALL the gh calls below (pr list, pr create, pr merge)
+        # through DATASET_PR_TOKEN when it is set, so the PR is authored by the PAT owner and its
+        # own checks (ci.yml) actually trigger. An unset secret evaluates to the empty string, so
+        # `||` falls back to the default job token.
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.DATASET_PR_TOKEN || secrets.GITHUB_TOKEN }}
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
@@ -154,11 +158,12 @@ jobs:
           git commit -m "chore(dataset): commit run ${RUN_ID}"
           git push -u --force origin "$branch"
           # Open the PR only if one isn't already open for this deterministic branch; a re-run reuses it
-          # (the force-push above already refreshed its content). `gh pr create` fails outright (GraphQL
-          # "GitHub Actions is not permitted to create or approve pull requests") when the repo's Settings →
-          # Actions → General → Workflow permissions → "Allow GitHub Actions to create and approve pull
-          # requests" toggle is off — see docs/ci-secrets.md. The dataset branch is already pushed at that
-          # point, so surface the fix instead of a bare GraphQL error before failing the job.
+          # (the force-push above already refreshed its content). Auth prefers the optional
+          # DATASET_PR_TOKEN (fine-grained PAT), falling back to GITHUB_TOKEN. With only GITHUB_TOKEN,
+          # `gh pr create` requires the repo/org "Allow GitHub Actions to create and approve pull
+          # requests" toggle and the resulting PR does not trigger ci.yml. See docs/ci-secrets.md.
+          # The dataset branch is already pushed at this point, so surface the fixes instead of a bare
+          # GraphQL error before failing the job.
           if [ -z "$(gh pr list --head "$branch" --state open --json number --jq '.[].number')" ]; then
             if ! gh pr create \
               --base main \
@@ -166,10 +171,13 @@ jobs:
               --title "chore(dataset): commit run ${RUN_ID}" \
               --body "Automated dataset commit for run [\`${RUN_ID}\`](${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${RUN_ID}). Biome was pre-flighted green on the promoted content; auto-merge lands it once branch protection is satisfied. The public LEADERBOARD.md is regenerated separately via the Update leaderboard workflow."; then
               echo "::error::gh pr create failed — branch '$branch' was pushed but no PR was opened." \
-                "This is almost always the repo's 'Allow GitHub Actions to create and approve pull" \
-                "requests' setting being off (Settings → Actions → General → Workflow permissions)." \
-                "A maintainer must either enable it and re-dispatch this workflow with run_id=$RUN_ID," \
-                "or open the PR for '$branch' manually. See docs/ci-secrets.md."
+                "Fix one of: (a) add a fine-grained PAT as environment secret DATASET_PR_TOKEN on the" \
+                "'privileged' environment (Contents + Pull requests read/write on this repo) — if" \
+                "DATASET_PR_TOKEN is already set, check it has not expired or been revoked; or (b)" \
+                "enable 'Allow GitHub Actions to create and approve pull requests' (Settings → Actions" \
+                "→ General → Workflow permissions; if the checkbox is greyed out an org admin must" \
+                "enable the org-level toggle first). Then re-dispatch Commit dataset with" \
+                "run_id=$RUN_ID, or open the PR for '$branch' manually. See docs/ci-secrets.md."
               exit 1
             fi
           fi

--- a/apps/cli/src/lib/bake/e2b.ts
+++ b/apps/cli/src/lib/bake/e2b.ts
@@ -87,10 +87,16 @@ export async function bakeE2bTemplate(name: string, baseImage: string, log: Log)
 			E2B_CONTEXT,
 			"--dockerfile",
 			E2B_DOCKERFILE_GENERATED,
-			// No --disk-size-mb: @e2b/cli template create exposes only --cpu-count/--memory-mb (checked on
-			// the pinned 2.12.0), so e2b/novita disk is platform-fixed and can't be raised to
-			// TARGET_SPEC.diskGb the way Daytona's snapshot resources.disk is. The heavy realworld suites
-			// that need the disk therefore skip on e2b/novita — surfaced as a leaderboard coverage gap.
+			// No disk flag: E2B exposes no disk input anywhere — not on @e2b/cli 2.13.3 (latest as of
+			// 2026-07; its only diskSizeMB occurrence is a read-only `template list` column), not in the
+			// REST API's TemplateBuildRequestV3 (e2b SDK 2.27.1 — diskSizeMB is response-only), not at
+			// sandbox create (NewSandbox). Sandbox disk = image size + the team's tier storage allowance
+			// (E2B Pro includes 20 GiB), raiseable only via support@e2b.dev — so e2b alone sits below the
+			// realworld suite floors (novita's platform default, ~100 GB observed, clears every floor).
+			// After an E2B-side allowance change, re-dispatch toolchain-image.yml so the rebuilt template
+			// picks it up (the API records diskSizeMB per template build), then verify free disk >= 30 GiB
+			// via a bench-smoke e2b dispatch. If E2B ever ships a disk flag, pass TARGET_SPEC.diskGb * 1024
+			// here and mirror the field in pins.ts e2bToml().
 			"--cpu-count",
 			String(config.targetSpec.vcpus),
 			"--memory-mb",

--- a/docs/ci-secrets.md
+++ b/docs/ci-secrets.md
@@ -61,11 +61,11 @@ Ungated: `ci.yml`, `ci-lint.yml`, and the toolchain `pr-gate` (Docker smoke, no 
    (a `leaderboard/update-<run-id>` PR, Biome-preflighted, auto-merge armed).
 
    > **`GITHUB_TOKEN` caveat.** A PR opened with the default `GITHUB_TOKEN` does **not** trigger
-   > `ci.yml` (GitHub suppresses workflow events raised by the Actions token). So if the Biome/CI check
-   > is a *required* status, auto-merge waits for a check that never runs, and a maintainer completes
-   > the merge (their merge to `main` runs `ci.yml` normally); the in-job pre-flight guarantees the
-   > content is already clean. For fully hands-off auto-merge, open the PR with a GitHub App
-   > installation token or PAT instead of `GITHUB_TOKEN` so the PR's own checks run.
+   > `ci.yml` (GitHub suppresses workflow events raised by the Actions token). The dataset commit step
+   > therefore prefers the optional `DATASET_PR_TOKEN` environment secret (a fine-grained PAT — operator
+   > setup items 4 and 6), falling back to `GITHUB_TOKEN`. The PAT-authored PR triggers its own checks;
+   > with the fallback, a maintainer completes the merge and that merge to `main` runs `ci.yml` normally.
+   > The in-job Biome pre-flight guarantees the dataset content is already clean either way.
 6. **Backfilling a failed dataset commit.** The commit logic is the reusable `commit-dataset.yml`, so
    when a matrix run's dataset commit fails (or was never reached) a maintainer can re-run it standalone:
    **Actions → Commit dataset → Run workflow**, passing the original run's id — or, from a
@@ -118,15 +118,44 @@ Do this in the GitHub UI (Settings → Environments), then delete any matching *
    | `NOVITA_API_KEY` | optional for toolchain; bench matrix/smoke |
    | `BL_API_KEY` | bench matrix/smoke only |
    | `BL_WORKSPACE` | bench matrix/smoke only |
+   | `DATASET_PR_TOKEN` | optional; dataset commit only (fine-grained PAT — see below and item 6) |
+
+   `DATASET_PR_TOKEN` is a fine-grained PAT — machine-account owned preferred — scoped to
+   `starslingdev/hpc-sandbox-benchmarks` with **Contents: read/write** and **Pull requests:
+   read/write**; `commit-dataset.yml`'s `gh pr list`/`create`/`merge` calls prefer it, falling back to
+   `GITHUB_TOKEN`. It MUST be an **environment** secret on `privileged`: a repository-level copy
+   would violate the posture above AND would not reach the matrix-call path (repository secrets are
+   not passed to a called workflow without `secrets: inherit`; environment secrets resolve from the
+   commit job's own `environment:` declaration on both entry points). Note the expiry date when
+   creating it — an expired PAT degrades to the loud `GITHUB_TOKEN` failure in item 6.
 
 5. Confirm the GHCR package `sandbox-benchmarks-toolchain` is **public** so providers can pull
    the candidate base anonymously (Org → Packages → package settings).
-6. Enable **Settings → Actions → General → Workflow permissions → "Allow GitHub Actions to create
-   and approve pull requests"**. The `gh pr create` in `commit-dataset.yml` and `update-leaderboard.yml`
-   fails outright without it (`GraphQL: GitHub Actions is not permitted to create or approve pull
-   requests`) — the job pushes its branch (`dataset/publish-<run-id>` / `leaderboard/update-<run-id>`)
-   and then dies, so every matrix run's commit step needs a maintainer to open the PR by hand until this
-   is on.
+6. Give `commit-dataset.yml`'s `gh pr create` a token that may open PRs — one of:
+
+   - **Path A (recommended): add `DATASET_PR_TOKEN`** per the table in item 4. Works regardless of
+     the Actions toggle below, and the PAT-authored PR triggers `ci.yml` so reviewers see green
+     checks. Calendar-remind on the PAT's expiry: an expired PAT degrades to the loud fallback
+     failure below, whose error message says to check expiry.
+   - **Path B: enable Settings → Actions → General → Workflow permissions → "Allow GitHub Actions
+     to create and approve pull requests"** (currently off: `can_approve_pull_request_reviews=false`;
+     if the repo checkbox is greyed out, the org-level toggle forces it and only an org admin can
+     flip it — the org state was not readable with repo credentials). Strictly worse than Path A:
+     a `GITHUB_TOKEN`-opened PR never triggers `ci.yml` (rule 5 caveat), so reviewers see a
+     check-less PR.
+
+   With neither in place, `gh pr create` fails outright (`GraphQL: GitHub Actions is not permitted
+   to create or approve pull requests`): the dataset job pushes the `dataset/publish-<run-id>` branch,
+   then fails loudly with the remediation steps, and a maintainer must open the PR by hand.
+   `update-leaderboard.yml` still uses `GITHUB_TOKEN`, so its separate
+   `leaderboard/update-<run-id>` PR requires Path B or a manual open.
+
+   Current end state either way (so expectations are honest): repo "Allow auto-merge" is **off**
+   (`allow_auto_merge=false`), so `gh pr merge --auto` falls to its best-effort "PR left open for a
+   maintainer" echo; and `main`'s ruleset ("Require PR approval on main") has NO required status
+   checks — its gates are one approving review (repository-admin bypass: always) plus linear
+   history. So after the PAT fix the dataset PR opens automatically and an admin completes the
+   merge in one click; that human step is the designed second gate, not a bug.
 
 Optional bootstrap (creates the empty environment; reviewers/secrets still need a human):
 

--- a/docs/ci-secrets.md
+++ b/docs/ci-secrets.md
@@ -127,7 +127,9 @@ Do this in the GitHub UI (Settings → Environments), then delete any matching *
    would violate the posture above AND would not reach the matrix-call path (repository secrets are
    not passed to a called workflow without `secrets: inherit`; environment secrets resolve from the
    commit job's own `environment:` declaration on both entry points). Note the expiry date when
-   creating it — an expired PAT degrades to the loud `GITHUB_TOKEN` failure in item 6.
+   creating it — and calendar the rotation: an expired/revoked PAT does NOT fall back (the workflow's
+   `||` only engages when the secret is UNSET/empty; a set-but-dead PAT is still selected and
+   `gh pr create` fails with an authentication error). Rotate or delete the secret before expiry.
 
 5. Confirm the GHCR package `sandbox-benchmarks-toolchain` is **public** so providers can pull
    the candidate base anonymously (Org → Packages → package settings).
@@ -135,8 +137,11 @@ Do this in the GitHub UI (Settings → Environments), then delete any matching *
 
    - **Path A (recommended): add `DATASET_PR_TOKEN`** per the table in item 4. Works regardless of
      the Actions toggle below, and the PAT-authored PR triggers `ci.yml` so reviewers see green
-     checks. Calendar-remind on the PAT's expiry: an expired PAT degrades to the loud fallback
-     failure below, whose error message says to check expiry.
+     checks. Calendar-remind on the PAT's expiry and rotate BEFORE it lapses: an expired/revoked
+     PAT remains a non-empty secret, so the workflow still selects it (the `||` fallback engages
+     only when the secret is unset/empty) and `gh pr create` fails with an authentication error —
+     the error message names this case. Deleting the dead secret restores the `GITHUB_TOKEN`
+     fallback (and with it the Path B requirement).
    - **Path B: enable Settings → Actions → General → Workflow permissions → "Allow GitHub Actions
      to create and approve pull requests"** (currently off: `can_approve_pull_request_reviews=false`;
      if the repo checkbox is greyed out, the org-level toggle forces it and only an org admin can

--- a/packages/schema/src/providers.ts
+++ b/packages/schema/src/providers.ts
@@ -135,10 +135,14 @@ export interface ProviderMeta {
  * `resources.disk`); Modal has no disk knob but its gVisor root reports effectively unbounded disk,
  * so it clears the gate anyway. Blaxel's sandbox root is a RAM-derived tmpfs with no independent disk
  * knob, so it mounts a 40 GiB volume at the PTS data dir where the heavy suites write (see
- * packages/providers/src/lib/blaxel-volume.ts) — clearing the gate like the others. Only e2b/novita
- * still CANNOT express disk (the `@e2b/cli` `template create` takes only `--cpu-count`/`--memory-mb`):
- * they run with actuals recorded and the heavy suites skip there, surfaced as an explicit coverage gap
- * in the leaderboard, never silently dropped.
+ * packages/providers/src/lib/blaxel-volume.ts) — clearing the gate like the others. Novita has no
+ * disk knob either, but its control plane provisions ~100 GB by default (observed 103.5 GiB, run
+ * 29799034615), so ALL suites run there. e2b is the sole provider below the realworld floors: its
+ * sandbox disk = baked image size (~4 GiB) + the team's tier storage allowance (E2B Pro: 20 GiB
+ * included), and no template/create-time disk parameter exists anywhere (verified across @e2b/cli
+ * 2.13.3, e2b.toml, the API's TemplateBuildRequestV3, NewSandbox, and @computesdk/e2b) — the
+ * allowance is raiseable only via support@e2b.dev. Until that raise lands, mastra/openclaw skip on
+ * e2b with a recorded disk-capacity gap in the leaderboard (keep+warn), never silently dropped.
  */
 export const TARGET_SPEC = { vcpus: 4, memoryGb: 8, diskGb: 40 } as const;
 
@@ -235,7 +239,7 @@ const REGISTRY: Record<ProviderId, Omit<ProviderMeta, "id">> = {
 			usdPerVcpuHour: 0.0504,
 			usdPerGibHour: 0.0162,
 			notes:
-				"Published per-second rates (exact): $0.000014/vCPU-s, $0.0000045/GiB-s. Storage 10 GiB included (20 on Pro); no published overage rate.",
+				"Published per-second rates (exact): $0.000014/vCPU-s, $0.0000045/GiB-s. Storage: 10 GiB included on Hobby, 20 GiB on Pro; larger allowances via support@e2b.dev (no published overage rate — record the quoted rate here if E2B provides one).",
 			sourceUrl: "https://e2b.dev/pricing",
 		},
 		maturity: { status: "ga", notes: "Custom images via e2b template build." },

--- a/packages/schema/src/suites.test.ts
+++ b/packages/schema/src/suites.test.ts
@@ -1,5 +1,13 @@
 import { describe, expect, it } from "bun:test";
-import { METRIC_CATALOG, paddedSuiteToken, padSuiteList, SUITE_NAMES, SUITES } from "./index.ts";
+import type { Suite } from "./index.ts";
+import {
+	METRIC_CATALOG,
+	paddedSuiteToken,
+	padSuiteList,
+	SUITE_NAMES,
+	SUITES,
+	TARGET_SPEC,
+} from "./index.ts";
 // Not part of the public surface (curation is an implementation detail of the catalog merge); this
 // PR's pinned-subset test reaches in directly to compare its suite's declarations against curated keys.
 import { ptsOverrides } from "./pts-overrides.ts";
@@ -110,6 +118,17 @@ describe("suite registry", () => {
 	it("keeps command timeouts within the requested sandbox lifetime", () => {
 		for (const suite of Object.values(SUITES)) {
 			expect(suite.commandTimeoutMinutes).toBeLessThanOrEqual(suite.timeoutMinutes);
+		}
+	});
+
+	it("keeps every suite disk floor within the provisioned target spec", () => {
+		// minDiskGb floors are calibrated against the provisioned target disk (TARGET_SPEC.diskGb):
+		// a floor above it could never pass on any spec-pinned provider and would silently turn the
+		// suite into a universal skip. Observed free space also runs a few GiB below provisioned
+		// (fs overhead + the baked image), so floors approaching diskGb deserve scrutiny — the
+		// current max is 30 (realworld-mastra).
+		for (const suite of Object.values<Suite>(SUITES)) {
+			expect(suite.minDiskGb ?? 0).toBeLessThanOrEqual(TARGET_SPEC.diskGb);
 		}
 	});
 });


### PR DESCRIPTION
**Bench-matrix green — every suite×provider cell measuring or honestly gapped**
Fixes the 10 root causes behind the failures and silent metric holes of runs [29799034615](https://github.com/starslingdev/hpc-sandbox-benchmarks/actions/runs/29799034615) and [29850811070](https://github.com/starslingdev/hpc-sandbox-benchmarks/actions/runs/29850811070). #229–#232 have merged; the remaining fixes are **parallel PRs based directly on `main`** — reviewable and mergeable in any order, except #238, which stacks on #237:
- #233 — leaderboard: no fabricated missing-rows for never-dispatched providers
- #234 — realworld: per-task timeout + cgroup-v2 memory containment
- #235 — harness: failed gap on sandbox-creation failure
- #236 — harness: detached log read-back + collect retries
- #237 — bench: loud PTS leaf guards; stream + pybench measure again
- #238 — templates: pgbench bake fix (pkg-config), payload assertion, portable fio, v4 *(stacked on #237)*
- #239 — fast-cli: settle gated on upload-phase stability
- #240 — providers: Daytona region pin actually reaches the API; both variants us-west-2
- #241 — ci: dataset-PR PAT fallback; e2b disk-skip notes

↑ **This PR is #241 — independent: based on `main`, no merge-order dependency on the others.**

---
Every recent run's Aggregate job built and pushed the dataset branch, then
died at gh pr create: 'GitHub Actions is not permitted to create or
approve pull requests' (repo/org toggle off, verified via the API), so
datasets have been hand-merged. The PR step now prefers an optional
fine-grained PAT (DATASET_PR_TOKEN, an ENVIRONMENT secret on 'privileged'
— the same proven resolution path as the provider keys), falling back to
GITHUB_TOKEN with the existing loud failure extended to name PAT expiry.
The PAT path is documented as preferred in docs/ci-secrets.md: a
GITHUB_TOKEN-opened PR never triggers ci.yml, so the toggle alternative
produces check-less PRs.

e2b: sandbox disk is tier-governed with no settable knob anywhere in the
bake CLI, e2b.toml, template API, or SDK (verified exhaustively) — every
sandbox boots with 20.0 GiB free, below realworld-mastra's 30 and
openclaw's 25 GiB floors, so those cells are permanent recorded skips
until an E2B support grant (maintainer action). Two stale comments falsely
claiming novita shares the skip are corrected (novita's default is
~103 GiB and it covers both suites), and a new invariant test keeps every
suite disk floor within the provisioned target spec.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Dataset publish now prefers a fine‑grained PAT via `DATASET_PR_TOKEN` for all `gh` PR calls, falling back to `GITHUB_TOKEN` only when the secret is unset. Clarifies E2B vs Novita disk behavior and adds a guard test to keep suite disk floors within `TARGET_SPEC.diskGb`.

- **Bug Fixes**
  - CI: route `GH_TOKEN` to `${{ secrets.DATASET_PR_TOKEN || secrets.GITHUB_TOKEN }}` for `gh pr list/create/merge`. A set‑but‑expired or revoked PAT does not fall back; rotate or delete it to restore fallback. `DATASET_PR_TOKEN` must be an environment secret on `privileged`. PRs opened with `GITHUB_TOKEN` do not trigger `ci.yml`; `update-leaderboard.yml` still uses `GITHUB_TOKEN`.
  - Providers/docs: E2B has no disk knob across `@e2b/cli` 2.13.3/API/SDK; sandbox disk is tier‑limited (Pro 20 GiB), so heavy realworld suites skip on E2B until support raises the allowance. Novita defaults to ~100 GiB and runs all suites. Added a test ensuring every suite’s `minDiskGb` ≤ `TARGET_SPEC.diskGb`.

<sup>Written for commit e13a9dda00976ca316e93ca3de06bce06e5a9e1c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/starslingdev/hpc-sandbox-benchmarks/pull/241?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

---
**Maintainer actions:**
- [ ] Create a fine-grained PAT (machine-account preferred; Contents + Pull requests read/write on this repo) and add it as environment secret `DATASET_PR_TOKEN` on `privileged`. Until then the aggregate keeps its loud failure and dataset branches need hand-merging (as happened for `dataset/publish-29799034615`; `dataset/publish-29850811070` is still unmerged).
- [ ] Optionally enable repo auto-merge so the dataset PR can land without an admin (`allow_auto_merge` is currently off).
- [ ] Email support@e2b.dev requesting the per-sandbox storage allowance be raised to 40 GB (parity with daytona 39.1 / blaxel 39.9); sandboxes must boot with ≥30 GiB free for realworld-mastra. Record any quoted rate in the providers.ts pricing note.

