### PR TITLE
chore(toolchain): bump TOOLCHAIN_VERSION v4 → v5, refresh stale pins

### DIFF
--- a/.github/workflows/ci-lint.yml
+++ b/.github/workflows/ci-lint.yml
@@ -52,7 +52,7 @@ jobs:
       - name: Set up mise tools
         uses: jdx/mise-action@e6a8b3978addb5a52f2b4cd9d91eafa7f0ab959d # v4.2.0
         with:
-          version: 2026.5.16
+          version: 2026.7.11
           install: true
           cache: true
 
@@ -78,7 +78,7 @@ jobs:
       - name: Set up mise tools
         uses: jdx/mise-action@e6a8b3978addb5a52f2b4cd9d91eafa7f0ab959d # v4.2.0
         with:
-          version: 2026.5.16
+          version: 2026.7.11
           install: true
           cache: true
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,7 +48,7 @@ jobs:
       - name: Set up mise tools
         uses: jdx/mise-action@e6a8b3978addb5a52f2b4cd9d91eafa7f0ab959d # v4.2.0
         with:
-          version: 2026.5.16
+          version: 2026.7.11
           install: true
           cache: true
 

--- a/packages/schema/src/toolchain.ts
+++ b/packages/schema/src/toolchain.ts
@@ -4,13 +4,14 @@
 // tag is immutable: a change to the toolchain image means bumping TOOLCHAIN_VERSION.
 
 export const TOOLCHAIN_IMAGE_NAME = "sandbox-benchmarks-toolchain";
-// v4: image-content fix over v3 (which was the 4 vCPU / 8 GiB target-spec bump). Adds pkg-config so
-// PostgreSQL 17's configure can discover ICU via PKG_CHECK_MODULES — every v3 image shipped pgbench
-// as a launcher-only half-install (pg_/ payload missing; zero pgbench metrics ever recorded) — and
-// bakes fio with --disable-native so the binary survives reduced-ISA sandboxes (modal-gvisor exposes
-// only AVX2; the builder-native fio SIGILLed in ~30ms). Re-bake all providers before the runs that
-// consume v4.
-export const TOOLCHAIN_VERSION = "v4";
+// v5: routine mise-managed toolchain pin refresh over v4 (packages/templates/src/lib/pins.ts —
+// unchanged since 2026-06-17). Bumps mise 2026.5.16 → 2026.7.11 (+ its per-arch binary sha256s,
+// re-sourced from the new release's SHASUMS256.txt; the CI mise-action pin in ci.yml/ci-lint.yml
+// moves in lockstep so build and checks share one mise), node 22.22.3 → 22.23.1, and pnpm
+// 10.34.3 → 10.34.5 (staying on the 10.x line — pnpm 11 is a major bump, out of scope here). jc
+// 1.25.6 → 1.25.7. hyperfine, quarto, python, warp, and the PTS pins were already current at their
+// latest upstream release and are unchanged. Re-bake all providers before the runs that consume v5.
+export const TOOLCHAIN_VERSION = "v5";
 
 // The apt packages PTS needs beyond a stock image — PTS's own php runtime, the compiler toolchain
 // for the source-built profiles, and fast-cli's Chrome runtime libs. ONE canonical list: the

--- a/packages/templates/src/lib/pins.ts
+++ b/packages/templates/src/lib/pins.ts
@@ -42,7 +42,7 @@ export type Pins = typeof pinsSchema.infer;
  * forgotten pin fails the build loudly rather than silently. `satisfies` keeps every key present and
  * typed.
  *
- * Sourced 2026-06-17 from current upstream releases (`mise latest <tool>` for the mise-managed tools;
+ * Sourced 2026-07-21 from current upstream releases (`mise latest <tool>` for the mise-managed tools;
  * the PTS .deb sha256 self-computed — PTS ships none). To refresh: bump the version, and for PTS
  * re-run `curl -fsSL .../phoronix-test-suite_<ver>_all.deb | sha256sum`; for mise pull the per-arch
  * lines from `.../releases/download/v<ver>/SHASUMS256.txt`. Tool versions are exact (not floating
@@ -52,22 +52,24 @@ export const rawPins = {
 	// > mise release version (installed from its immutable GitHub release in 00-apt.sh — mise's apt
 	// > repo is rolling and only serves the latest, so we pin the release). Matches the CI mise-action
 	// > pin for a single mise across build + checks.
-	miseVersion: "2026.5.16",
+	miseVersion: "2026.7.11",
 	// > sha256 of the mise release binary per arch (from the release's SHASUMS256.txt): the asset is
 	// > arch-specific, so 00-apt.sh verifies the download against the line matching the build arch.
-	miseSha256X64: "fb2d7bf1a3751398a5c336a3565cd3c60af9b41952abe6fd62e2f2f0d5f06b60",
-	miseSha256Arm64: "a068f29d8821ab0707f1a006721b5ab0baa80acaafc5a7b71e04371287108b92",
+	miseSha256X64: "d31578a16ae2708385249b439c95533068e04b9507a118e905aa6768905671fc",
+	miseSha256Arm64: "e3cb3bf4795f494a0e9be3f69ee1464de9d12a991589f126035eebd973c17796",
 	// > node 22 LTS (exact).
-	nodeVersion: "22.22.3",
+	nodeVersion: "22.23.1",
 	// > python 3.13 (exact; mise-managed standalone build, not distro python).
 	pythonVersion: "3.13.14",
-	// > pnpm 10 (exact).
-	pnpmVersion: "10.34.3",
+	// > pnpm 10 (exact; staying on the 10.x line — pnpm 11 is a major bump out of scope for a routine
+	// > pin refresh).
+	pnpmVersion: "10.34.5",
 	hyperfineVersion: "1.20.0",
 	// > minio/warp (mise ubi backend → github releases). Pinned to 1.3.1: minio stopped attaching
-	// > binaries to warp's GitHub releases at 1.4.0+, so newer tags have no asset ubi can install.
+	// > binaries to warp's GitHub releases at 1.4.0+ (still true through 1.5.0), so newer tags have no
+	// > asset ubi can install.
 	warpVersion: "1.3.1",
-	jcVersion: "1.25.6",
+	jcVersion: "1.25.7",
 	// > quarto-cli (mise aqua backend).
 	quartoVersion: "1.9.38",
 	// > Phoronix Test Suite release + self-computed sha256 of phoronix-test-suite_10.8.4_all.deb.


### PR DESCRIPTION
## Summary
- Pins in `packages/templates/src/lib/pins.ts` hadn't moved since 2026-06-17. Bumps the mise-managed toolchain to current upstream releases and moves `TOOLCHAIN_VERSION` v4 → v5 to match (per repo convention: the version tag is immutable, so any image-content change bumps it).
- `mise` `2026.5.16` → `2026.7.11` (+ re-sourced per-arch binary sha256s from the new release's `SHASUMS256.txt`)
- CI's `mise-action` pin (`ci.yml`, `ci-lint.yml`) moves in lockstep so build and checks share one mise version, per the existing pin comment
- `node` `22.22.3` → `22.23.1`
- `pnpm` `10.34.3` → `10.34.5` (staying on the 10.x line — pnpm 11 is a major bump, out of scope for a routine refresh)
- `jc` `1.25.6` → `1.25.7`
- `hyperfine`, `quarto`, `python`, `warp`, and the PTS pins were already at their latest available upstream release (warp stays pinned to 1.3.1 — confirmed minio still isn't attaching release binaries past 1.3.1, through 1.5.0) — left unchanged

## Maintainer action after merge
Per the workflow's own convention, this bump is inert until someone re-runs `toolchain-image.yml` via `workflow_dispatch` on `main` to bake + promote `v5`, then refreshes each provider template.

## Test plan
- [x] `bun test packages/templates/src/pins.test.ts packages/schema` — pins schema + toolchain constant tests pass
- [x] `bun test tooling/repo-checks/src/pts-profile-pins.test.ts` — pin drift gate passes
- [x] `bun run typecheck` — all packages pass
- [x] `bunx biome check` on changed files — clean
- [ ] CI `pr-gate` job (base image build + docker smoke) — will run on this PR
- [ ] Actual `v5` bake/promote — maintainer action after merge, per above

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bump toolchain `TOOLCHAIN_VERSION` v4 → v5 and refresh pins to current upstream releases; CI now uses the same `mise` version. This keeps builds and checks consistent and prepares the v5 image bake.

- **Dependencies**
  - `mise` 2026.5.16 → 2026.7.11 (per-arch SHA256s refreshed)
  - CI `jdx/mise-action` aligned to `2026.7.11` in `ci.yml` and `ci-lint.yml`
  - `node` 22.22.3 → 22.23.1; `pnpm` 10.34.3 → 10.34.5 (stay on 10.x); `jc` 1.25.6 → 1.25.7
  - No changes: `hyperfine`, `quarto`, `python`, `warp` (1.3.1), `PTS`

- **Migration**
  - Re-run `toolchain-image.yml` via `workflow_dispatch` on `main` to bake and promote `v5`.
  - Refresh each provider template after the image is promoted.

<sup>Written for commit edd216156d70cca76dbc59e9705ab64117b9ba90. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/starslingdev/hpc-sandbox-benchmarks/pull/243?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

