### PR TITLE
fix(toolchain): required-aware release gates + precise, honest job summaries

### DIFF
--- a/.github/actions/release-summary/action.yml
+++ b/.github/actions/release-summary/action.yml
@@ -4,7 +4,9 @@ description: >-
   a run annotation, via @actions/core (release-summary.ts). Every release job calls this with the same
   field vocabulary (mode, image, base, provider target, size tier, verify command, published pointer,
   diagnostics, elapsed) so an operator reads one shape across build/bake/promote. Rows with an empty
-  value are omitted, so each phase shows only its own facts.
+  value are omitted, so each phase shows only its own facts. When a phase report + the required set are
+  passed, the summary renders the PRECISE result — per-provider outcomes, blocking vs best-effort, and a
+  banner whenever job.status disagrees with the real result — so a green-but-failed phase is obvious.
 
 inputs:
   phase:
@@ -48,6 +50,17 @@ inputs:
   elapsed:
     description: Elapsed wall time for the phase.
     default: ""
+  required:
+    description: >-
+      Comma-separated required-provider ids (needs.plan.outputs.required). Lets the summary classify each
+      provider failure as blocking vs best-effort. Empty for phases with no provider matrix (plan/build).
+    default: ""
+  report:
+    description: >-
+      Path to the phase's bake/promote report JSON (bake-<provider>.json / promote-payload.json). When
+      set, the summary renders the per-provider result table and the precise Result. Omit for phases that
+      produce no such report.
+    default: ""
 
 runs:
   using: composite
@@ -55,7 +68,9 @@ runs:
     - name: Append phase summary
       shell: bash
       # Inputs reach the script as env (a composite `run` step gets no INPUT_* vars); the script owns the
-      # core.summary table + run annotation. RUN_URL links the diagnostics artifact to this run.
+      # core.summary table + run annotation. RUN_URL links the diagnostics artifact to this run. The job
+      # identity (JOB/RUN_ID/RUN_ATTEMPT/ACTOR/EVENT) is read from the github context HERE so no caller has
+      # to thread it — a composite step can reference github.* directly.
       env:
         PHASE: ${{ inputs.phase }}
         STATUS: ${{ inputs.status }}
@@ -70,5 +85,12 @@ runs:
         PUBLISHED: ${{ inputs.published }}
         DIAGNOSTICS: ${{ inputs.diagnostics }}
         ELAPSED: ${{ inputs.elapsed }}
+        REQUIRED: ${{ inputs.required }}
+        REPORT_FILE: ${{ inputs.report }}
+        JOB: ${{ github.job }}
+        RUN_ID: ${{ github.run_id }}
+        RUN_ATTEMPT: ${{ github.run_attempt }}
+        ACTOR: ${{ github.triggering_actor || github.actor }}
+        EVENT: ${{ github.event_name }}
         RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
       run: bun apps/cli/src/bin/release-summary.ts

--- a/.github/workflows/toolchain-image.yml
+++ b/.github/workflows/toolchain-image.yml
@@ -474,7 +474,7 @@ jobs:
         run: docker logout vcr.vercel.com
       - name: Bake + verify candidate
         id: bake
-        # The cell's provider + required flag reach the script through the environment, never
+        # The cell's provider + full required set reach the script through the environment, never
         # interpolated into the shell, so a matrix value can't inject into the runner command. Provider
         # creds are optional: a missing one SKIPS that provider (required cells fail instead — see
         # --require below). blaxel gets no creds here (its bake is a no-op booting the stock base), so
@@ -486,7 +486,7 @@ jobs:
         # them here is what makes the fan-out least-privilege rather than just concurrent.
         env:
           PROVIDER: ${{ matrix.provider }}
-          REQUIRED: ${{ matrix.required }}
+          REQUIRED_PROVIDERS: ${{ needs.plan.outputs.required }}
           # Pin every cell to the one base selected by the release plan. A full build supplies its
           # immutable output digest; a build-skipped scoped backfill supplies the published version,
           # never the mutable candidate that may already contain the next release's bytes.
@@ -521,25 +521,17 @@ jobs:
           VERCEL_CANDIDATE_IMAGE: ${{ steps.vercel-vcr.outcome == 'success' && steps.vercel-vcr.outputs.digest-ref || '' }}
         run: |
           set -euo pipefail
-          args=(--provider "${PROVIDER}" --base-image "${BASE_IMAGE_REF}")
-          # Required providers must not silently skip: --require fails the cell if this provider's
-          # secret is missing/misnamed or it fails to validate.
-          if [ "${REQUIRED}" = "true" ]; then args+=(--require "${PROVIDER}"); fi
           # Route the report JSON to a file via env (not a `> file` redirect): the provider CLIs inherit
           # stdout, so a redirect would splice their chatter into the report. bake.ts writes the file
           # even when it exits non-zero, so it's a clean diagnostic on failure too.
           export BAKE_REPORT_FILE="bake-${PROVIDER}.json"
-          # Only a REQUIRED provider blocks the release: a required cell passed --require above, so
-          # bake.ts exits non-zero (failing the cell) if it fails or skips. A NON-required cell — e.g.
-          # daytona-container / modal-vm, which share a required variant's credentials and so can never
-          # take the missing-creds skip path — still runs, but a failure is surfaced as a warning and
-          # must NOT block the publish (its outcome is in the uploaded bake report either way).
-          if [ "${REQUIRED}" = "true" ]; then
-            bun apps/cli/src/bin/bake.ts "${args[@]}"
-          else
-            bun apps/cli/src/bin/bake.ts "${args[@]}" ||
-              echo "::warning title=Non-required provider not validated::${PROVIDER} did not pass its bake/verify — reported, not blocking the release (best-effort variant)"
-          fi
+          # Every cell receives the same release policy. bake.ts scopes the missing-required check to
+          # this cell, emits a real Actions warning for a best-effort failure, and exits non-zero only
+          # for a blocking outcome. Keeping the policy in TypeScript avoids a shell-level exit swallow.
+          bun apps/cli/src/bin/bake.ts \
+            --provider "${PROVIDER}" \
+            --base-image "${BASE_IMAGE_REF}" \
+            --require "${REQUIRED_PROVIDERS}"
       # Failure-safe fallback for auth/mirror failures that skip the immediate post-mirror logout.
       - name: Ensure VCR logout
         if: always()
@@ -569,8 +561,10 @@ jobs:
           base-image: ${{ needs.build.outputs.base-digest-ref || needs.plan.outputs.image-source }}
           provider-target: ${{ matrix.provider }}
           size-tier: ${{ needs.plan.outputs.size-tier }}
-          verify: bun apps/cli/src/bin/bake.ts --provider ${{ matrix.provider }} --base-image ${{ needs.build.outputs.base-digest-ref || needs.plan.outputs.image-source }}${{ matrix.required && format(' --require {0}', matrix.provider) || '' }}
+          verify: bun apps/cli/src/bin/bake.ts --provider ${{ matrix.provider }} --base-image ${{ needs.build.outputs.base-digest-ref || needs.plan.outputs.image-source }} --require ${{ needs.plan.outputs.required }}
           diagnostics: bake-${{ matrix.provider }}-${{ github.run_id }}
+          required: ${{ needs.plan.outputs.required }}
+          report: bake-${{ matrix.provider }}.json
 
   # PROMOTE: the serialized publication barrier and the ONLY job that mutates the public :v1. Runs only
   # after every bake cell converges (a failed required cell fails `bake` and blocks this via `needs`).
@@ -744,3 +738,5 @@ jobs:
           verify: bun apps/cli/src/bin/bake.ts --promote --require ${{ needs.plan.outputs.required }} --provider ${{ needs.plan.outputs.providers }}${{ inputs.force_republish && ' --force' || '' }}
           published: ${{ needs.plan.outputs.publish-target }}
           diagnostics: promote-payload-${{ github.run_id }}
+          required: ${{ needs.plan.outputs.required }}
+          report: promote-payload.json

--- a/apps/cli/src/bin/bake.ts
+++ b/apps/cli/src/bin/bake.ts
@@ -20,7 +20,12 @@ import { config } from "@sandbox-benchmarks/providers";
 import type { ProviderId } from "@sandbox-benchmarks/schema";
 import { PROVIDERS } from "@sandbox-benchmarks/schema";
 import { logWarning } from "../lib/actions-log.ts";
-import { blockingFailures, blockingReports, nonBlockingFailures } from "../lib/bake/gates.ts";
+import {
+	blockingFailures,
+	blockingReports,
+	nonBlockingFailures,
+	unknownProviderIds,
+} from "../lib/bake/gates.ts";
 import { buildAndPushCandidate, resolveImageDigestRef } from "../lib/bake/image.ts";
 import { effectivePromotionRequirements, promoteAll } from "../lib/bake/promote.ts";
 import {
@@ -142,6 +147,12 @@ if (import.meta.main) {
 		log(`error: ${err instanceof Error ? err.message : String(err)}`);
 		await exitAfterSandboxCleanup(2);
 	}
+	const configuredRequired = requiredProviders();
+	const unknownRequired = unknownProviderIds(configuredRequired);
+	if (unknownRequired.length > 0) {
+		log(`error: unknown required provider(s): ${unknownRequired.join(", ")}`);
+		await exitAfterSandboxCleanup(2);
+	}
 
 	// Promote is the release step: publish the already-validated candidate as the public version.
 	if (process.argv.includes("--promote")) {
@@ -176,7 +187,7 @@ if (import.meta.main) {
 			},
 			reports: promoted.reports,
 		});
-		const required = effectivePromotionRequirements(requiredProviders(), only);
+		const required = effectivePromotionRequirements(configuredRequired, only);
 		warnNonBlocking(promoted.reports, required, "promote");
 		if (!promoted.ok) {
 			const blocking = blockingReports(promoted.reports, required);
@@ -298,7 +309,7 @@ if (import.meta.main) {
 		reports,
 	});
 
-	const required = requiredProviders();
+	const required = configuredRequired;
 	warnNonBlocking(reports, required, "pass bake/verify");
 
 	// A required failure blocks; a best-effort failure warns and exits zero. With no explicit required

--- a/apps/cli/src/bin/bake.ts
+++ b/apps/cli/src/bin/bake.ts
@@ -3,8 +3,9 @@
 // by booting a sandbox from the just-baked artifact and running the shared smoke spec. This is the
 // iteration loop: edit Dockerfile/templates → `bake --build-push` → `bake` → repeat. Everything hits
 // the mutable candidate (`:v1-candidate`, `…-v1-candidate`); the public `:v1` is untouched until
-// `promote` (next PR). Providers without credentials are skipped; exits non-zero iff a baked provider
-// failed to validate. bun auto-loads .env, so local creds are picked up.
+// `promote` (next PR). Providers without credentials are skipped. In release CI, only required
+// providers block; best-effort failures stay visible as warnings. Locally, with no required set, any
+// failure remains fatal. bun auto-loads .env, so local creds are picked up.
 //
 // The provider loop + skip-vs-fail contract is shared with bench-smoke/promote (providers-run.ts);
 // the boot+smoke lifecycle (probe results captured before teardown) is shared too (smoke-run.ts).
@@ -18,8 +19,10 @@ import type { ProviderConfig } from "@sandbox-benchmarks/providers";
 import { config } from "@sandbox-benchmarks/providers";
 import type { ProviderId } from "@sandbox-benchmarks/schema";
 import { PROVIDERS } from "@sandbox-benchmarks/schema";
+import { logWarning } from "../lib/actions-log.ts";
+import { blockingFailures, blockingReports, nonBlockingFailures } from "../lib/bake/gates.ts";
 import { buildAndPushCandidate, resolveImageDigestRef } from "../lib/bake/image.ts";
-import { promoteAll } from "../lib/bake/promote.ts";
+import { effectivePromotionRequirements, promoteAll } from "../lib/bake/promote.ts";
 import {
 	buildBakedProviderArtifact,
 	isBakedProviderId,
@@ -32,7 +35,7 @@ import {
 	candidateResolvedArtifact,
 } from "../lib/bake/validate.ts";
 import { isPartialScope, selectProviders } from "../lib/matrix.ts";
-import { anyFailed, forEachProviderWithCreds } from "../lib/providers-run.ts";
+import { forEachProviderWithCreds } from "../lib/providers-run.ts";
 import { bootAndSmoke, logChecks, smokeFailureReason, smokeOk } from "../lib/smoke-run.ts";
 
 /**
@@ -46,6 +49,20 @@ function writeReport(report: unknown): void {
 	const file = process.env.BAKE_REPORT_FILE;
 	if (file) writeFileSync(file, json);
 	else process.stdout.write(json);
+}
+
+/** Emit one real Actions warning per failed best-effort provider (stderr locally). */
+function warnNonBlocking(
+	reports: readonly BakeReport[],
+	required: readonly string[],
+	verb: string,
+): void {
+	for (const report of nonBlockingFailures(reports, required)) {
+		logWarning(
+			`${report.provider} did not ${verb} — recorded, not blocking the release: ${report.reason ?? "failed"}`,
+			{ title: `Non-required provider did not ${verb}` },
+		);
+	}
 }
 
 /**
@@ -159,6 +176,14 @@ if (import.meta.main) {
 			},
 			reports: promoted.reports,
 		});
+		const required = effectivePromotionRequirements(requiredProviders(), only);
+		warnNonBlocking(promoted.reports, required, "promote");
+		if (!promoted.ok) {
+			const blocking = blockingReports(promoted.reports, required);
+			log(
+				`error: promote failed${blocking.length > 0 ? ` — blocking: ${blocking.map((r) => r.provider).join(", ")}` : ""}`,
+			);
+		}
 		// The transaction outcome is separate from its diagnostics: an optional provider can fail and stay
 		// visible in the report without turning a successfully published shared version red after commit.
 		await exitAfterSandboxCleanup(promoted.ok ? 0 : 1);
@@ -273,14 +298,23 @@ if (import.meta.main) {
 		reports,
 	});
 
-	if (anyFailed(runs)) await exitAfterSandboxCleanup(1);
-
-	// D1: at the publish boundary (CI passes `--require e2b,daytona-vm,modal-gvisor`) a required provider that was
-	// skipped for a missing/misnamed secret — or failed to validate — must fail the bake loudly, so a
-	// candidate is never blessed while a provider was silently never built. Lenient locally (none required).
 	const required = requiredProviders();
-	const unmet = unmetRequirements(reports, required);
-	if (required.length > 0 && unmet.length > 0) {
+	warnNonBlocking(reports, required, "pass bake/verify");
+
+	// A required failure blocks; a best-effort failure warns and exits zero. With no explicit required
+	// set (the local default), every failure remains fatal as a hand-run safety net.
+	const blocking = blockingFailures(reports, required);
+	if (blocking.length > 0) {
+		log(`error: bake failed — blocking: ${blocking.map((r) => r.provider).join(", ")}`);
+		await exitAfterSandboxCleanup(1);
+	}
+
+	// D1: a required provider skipped for a missing/misnamed secret must fail loudly. CI hands every
+	// matrix cell the full required set, so scope the absence check to this invocation's provider(s): a
+	// cell is not responsible for required providers it never ran.
+	const scopedRequired = only ? required.filter((id) => only.includes(id as ProviderId)) : required;
+	const unmet = unmetRequirements(reports, scopedRequired);
+	if (scopedRequired.length > 0 && unmet.length > 0) {
 		log(
 			`error: required providers did not pass: ${unmet.join(", ")} (--require / REQUIRE_PROVIDERS)`,
 		);

--- a/apps/cli/src/bin/release-plan.ts
+++ b/apps/cli/src/bin/release-plan.ts
@@ -28,6 +28,7 @@ import {
 	REGISTRY,
 } from "@sandbox-benchmarks/schema/providers";
 import { validatedPins } from "@sandbox-benchmarks/templates/pins";
+import { fail, logWarning } from "../lib/actions-log.ts";
 import { imageExistsInRegistry, imageName, imageRepo, releaseBaseTag } from "../lib/bake/image.ts";
 import { emitStepOutputs } from "../lib/gha-output.ts";
 import { isPartialScope, selectProviders } from "../lib/matrix.ts";
@@ -314,9 +315,10 @@ if (import.meta.main) {
 		alreadyPublished = await imageExistsInRegistry(config.toolchainImageVersion);
 	} catch (err) {
 		probeConclusive = false;
-		console.error(
-			`::warning::could not probe whether ${config.toolchainImageVersion} is already published ` +
+		logWarning(
+			`could not probe whether ${config.toolchainImageVersion} is already published ` +
 				`(${err instanceof Error ? err.message : String(err)}); proceeding — promote does the authoritative guard.`,
+			{ title: "Published-version probe inconclusive" },
 		);
 	}
 
@@ -334,11 +336,12 @@ if (import.meta.main) {
 	// fail: the probe above is best-effort (an auth/network blip reads as "not published"), and promote
 	// does the authoritative refuse-on-uncertain check before anything is written.
 	if (plan.partial && !alreadyPublished && plan.promote) {
-		console.error(
-			`::warning::${config.toolchainImageVersion} does not look published yet, but this is a scoped ` +
+		logWarning(
+			`${config.toolchainImageVersion} does not look published yet, but this is a scoped ` +
 				`release (${plan.providers.map((p) => p.provider).join(", ")}) — a scoped promote backfills ` +
 				"providers onto an existing version and never writes the base, so it will refuse. Run a full " +
 				"release first, or dispatch with promote disabled to bake + verify only.",
+			{ title: "Scoped release has no published base" },
 		);
 	}
 
@@ -348,13 +351,13 @@ if (import.meta.main) {
 	// job ahead of the `privileged` approval the bake matrix would otherwise spend. Gated on a CONCLUSIVE
 	// probe, so a registry blip degrades to an honest downstream failure rather than a false refusal.
 	if (plan.partial && plan.build === "skip" && probeConclusive && !alreadyPublished) {
-		console.error(
-			`::error title=No published base to backfill onto::${config.toolchainImageVersion} is not ` +
-				"published, and a scoped `build: skip` release derives its artifacts from that base without " +
-				"building anything — there is nothing to derive from. Cut this version with a full release " +
-				"first; a scoped backfill adds a provider to a version that already shipped.",
+		fail(
+			`${config.toolchainImageVersion} is not published, and a scoped \`build: skip\` release ` +
+				"derives its artifacts from that base without building anything — there is nothing to derive " +
+				"from. Cut this version with a full release first; a scoped backfill adds a provider to a " +
+				"version that already shipped.",
+			{ properties: { title: "No published base to backfill onto" } },
 		);
-		process.exit(1);
 	}
 
 	// Optional first positional (flags filtered out): write the full plan JSON here for the

--- a/apps/cli/src/bin/release-summary.test.ts
+++ b/apps/cli/src/bin/release-summary.test.ts
@@ -200,6 +200,18 @@ describe("readReports", () => {
 			readReports(JSON.stringify({ reports: [{ provider: "e2b" }, { status: "ok" }] })),
 		).toEqual([]);
 	});
+
+	test("drops malformed optional fields instead of letting rendering throw", () => {
+		expect(
+			readReports(
+				JSON.stringify({
+					reports: [
+						{ provider: "e2b", status: "failed", reason: { nested: true }, durationMs: "slow" },
+					],
+				}),
+			),
+		).toEqual([{ provider: "e2b", status: "failed" }]);
+	});
 });
 
 describe("readReportFile", () => {

--- a/apps/cli/src/bin/release-summary.test.ts
+++ b/apps/cli/src/bin/release-summary.test.ts
@@ -1,5 +1,17 @@
 import { describe, expect, test } from "bun:test";
-import { escapeHtml, isFailure, renderCell } from "./release-summary.ts";
+import { rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+	classifyRelease,
+	escapeHtml,
+	isFailure,
+	readReportFile,
+	readReports,
+	renderCell,
+} from "./release-summary.ts";
+
+const REQUIRED = ["e2b", "daytona-vm", "modal-gvisor"];
 
 describe("isFailure", () => {
 	// Both spellings are in circulation (GitHub's job.status says `failure`; the bake report and the
@@ -40,5 +52,167 @@ describe("renderCell", () => {
 	test("leaves plain prose unwrapped (still escaped)", () => {
 		expect(renderCell("2 vCPU / 8 GiB", "plain")).toBe("2 vCPU / 8 GiB");
 		expect(renderCell("<b>", "plain")).toBe("&lt;b&gt;");
+	});
+});
+
+describe("classifyRelease", () => {
+	test("the run 29896891577 promote: green job, best-effort daytona-container failed → warning, no discrepancy", () => {
+		// After the exit-code fix this promote job is GREEN (it published :v5). The summary must still make
+		// the daytona-container failure obvious at a glance — a warning result, not a silent success.
+		const v = classifyRelease({
+			jobStatus: "success",
+			reports: [
+				{ provider: "e2b", status: "ok" },
+				{ provider: "daytona-vm", status: "ok" },
+				{ provider: "daytona-container", status: "failed" },
+				{ provider: "modal-gvisor", status: "ok" },
+				{ provider: "image", status: "ok" },
+			],
+			required: REQUIRED,
+		});
+		expect(v.kind).toBe("warning");
+		expect(v.result).toBe("Passed with non-blocking failure(s): daytona-container");
+		expect(v.blocking).toEqual([]);
+		expect(v.nonBlocking).toEqual(["daytona-container"]);
+		expect(v.discrepancy).toBeUndefined();
+	});
+
+	test("a required provider failure → failure result naming the blocker", () => {
+		const v = classifyRelease({
+			jobStatus: "failure",
+			reports: [
+				{ provider: "e2b", status: "ok" },
+				{ provider: "daytona-vm", status: "failed" },
+			],
+			required: REQUIRED,
+		});
+		expect(v.kind).toBe("failure");
+		expect(v.result).toBe("Failed — blocking: daytona-vm");
+		expect(v.discrepancy).toBeUndefined();
+	});
+
+	test("the `image` commit-point failure blocks even though it is not a required provider", () => {
+		const v = classifyRelease({
+			jobStatus: "failure",
+			reports: [{ provider: "image", status: "failed", reason: "v5 already exists" } as never],
+			required: REQUIRED,
+		});
+		expect(v.kind).toBe("failure");
+		expect(v.result).toBe("Failed — blocking: image");
+	});
+
+	test("green-but-failed: job status GREEN but a blocking failure recorded → escalates with a discrepancy banner", () => {
+		const v = classifyRelease({
+			jobStatus: "success",
+			reports: [{ provider: "daytona-vm", status: "failed" }],
+			required: REQUIRED,
+		});
+		expect(v.kind).toBe("failure");
+		expect(v.discrepancy).toContain("GREEN but a blocking outcome");
+	});
+
+	test("a required provider skip is blocking, even when the raw job status is green", () => {
+		const verdict = classifyRelease({
+			jobStatus: "success",
+			reports: [{ provider: "e2b", status: "skipped" }],
+			required: REQUIRED,
+		});
+		expect(verdict).toMatchObject({
+			kind: "failure",
+			result: "Failed — blocking: e2b",
+			blocking: ["e2b"],
+		});
+		expect(verdict.discrepancy).toContain("GREEN but a blocking outcome");
+	});
+
+	test("red-but-nothing-failed: job failed with no blocking report → points outside the provider reports", () => {
+		const v = classifyRelease({
+			jobStatus: "failure",
+			reports: [{ provider: "e2b", status: "ok" }],
+			required: REQUIRED,
+		});
+		expect(v.kind).toBe("failure");
+		expect(v.discrepancy).toContain("outside the provider reports");
+	});
+
+	test("all clean → OK; a skip is noted but not a failure", () => {
+		expect(
+			classifyRelease({
+				jobStatus: "success",
+				reports: [
+					{ provider: "e2b", status: "ok" },
+					{ provider: "blaxel", status: "skipped" },
+				],
+				required: REQUIRED,
+			}),
+		).toMatchObject({ kind: "ok", result: "OK (skipped: blaxel)" });
+	});
+
+	test("no report (plan/build phase) → mirrors the raw job status", () => {
+		expect(classifyRelease({ jobStatus: "success", reports: [], required: [] }).result).toBe("OK");
+		expect(classifyRelease({ jobStatus: "failure", reports: [], required: [] })).toMatchObject({
+			kind: "failure",
+			result: "Failed (failure)",
+			discrepancy: undefined,
+		});
+	});
+
+	test("a cancelled job is never summarized as OK", () => {
+		expect(classifyRelease({ jobStatus: "cancelled", reports: [], required: [] })).toMatchObject({
+			kind: "failure",
+			result: "Cancelled",
+		});
+		expect(
+			classifyRelease({
+				jobStatus: "cancelled",
+				reports: [{ provider: "e2b", status: "ok" }],
+				required: REQUIRED,
+			}),
+		).toMatchObject({
+			kind: "failure",
+			result: "Cancelled — no blocking provider outcome recorded; check the step log",
+		});
+	});
+});
+
+describe("readReports", () => {
+	test("extracts a well-formed reports array from a promote/bake payload", () => {
+		const json = JSON.stringify({
+			version: { image: "x" },
+			reports: [
+				{ provider: "e2b", status: "ok", durationMs: 12061 },
+				{ provider: "daytona-container", status: "failed", reason: "No runners…" },
+			],
+		});
+		expect(readReports(json)).toEqual([
+			{ provider: "e2b", status: "ok", durationMs: 12061 },
+			{ provider: "daytona-container", status: "failed", reason: "No runners…" },
+		]);
+	});
+
+	test("tolerates absence and malformed input (metadata still renders)", () => {
+		expect(readReports(undefined)).toEqual([]);
+		expect(readReports("")).toEqual([]);
+		expect(readReports("not json")).toEqual([]);
+		expect(readReports(JSON.stringify({ candidate: {} }))).toEqual([]);
+		// Drops entries missing the provider/status contract rather than throwing.
+		expect(
+			readReports(JSON.stringify({ reports: [{ provider: "e2b" }, { status: "ok" }] })),
+		).toEqual([]);
+	});
+});
+
+describe("readReportFile", () => {
+	test("falls back to an empty report for missing and malformed files", async () => {
+		const missing = join(tmpdir(), `missing-release-report-${crypto.randomUUID()}.json`);
+		expect(await readReportFile(missing)).toEqual([]);
+
+		const malformed = join(tmpdir(), `malformed-release-report-${crypto.randomUUID()}.json`);
+		try {
+			await Bun.write(malformed, "{not-json");
+			expect(await readReportFile(malformed)).toEqual([]);
+		} finally {
+			await rm(malformed, { force: true });
+		}
 	});
 });

--- a/apps/cli/src/bin/release-summary.ts
+++ b/apps/cli/src/bin/release-summary.ts
@@ -11,7 +11,7 @@ import {
 	isFailure,
 	renderCell,
 } from "../lib/actions-log.ts";
-import { blockingReports, isBlockingId, nonBlockingFailures } from "../lib/bake/gates.ts";
+import { blockingReports, isBlockingReport, nonBlockingFailures } from "../lib/bake/gates.ts";
 import type { BakeReport } from "../lib/bake/types.ts";
 
 // Re-export pure helpers so existing unit tests keep importing from this bin path.
@@ -90,15 +90,27 @@ export function readReports(json: string | undefined): BakeReport[] {
 	try {
 		const parsed = JSON.parse(json) as { reports?: unknown };
 		if (!Array.isArray(parsed.reports)) return [];
-		return parsed.reports.filter((report): report is BakeReport => {
-			if (typeof report !== "object" || report === null) return false;
+		return parsed.reports.flatMap((report): BakeReport[] => {
+			if (typeof report !== "object" || report === null) return [];
 			const candidate = report as Partial<BakeReport>;
-			return (
-				typeof candidate.provider === "string" &&
-				(candidate.status === "ok" ||
-					candidate.status === "skipped" ||
-					candidate.status === "failed")
-			);
+			if (
+				typeof candidate.provider !== "string" ||
+				(candidate.status !== "ok" &&
+					candidate.status !== "skipped" &&
+					candidate.status !== "failed")
+			) {
+				return [];
+			}
+			return [
+				{
+					provider: candidate.provider,
+					status: candidate.status,
+					...(typeof candidate.reason === "string" ? { reason: candidate.reason } : {}),
+					...(typeof candidate.durationMs === "number" && Number.isFinite(candidate.durationMs)
+						? { durationMs: candidate.durationMs }
+						: {}),
+				},
+			];
 		});
 	} catch {
 		return [];
@@ -137,15 +149,16 @@ function providerReportRows(
 		{ data: "Reason", header: true },
 	];
 	const rows: SummaryRow[] = reports.map((report) => {
-		const policy = isBlockingId(report.provider, required) ? "yes" : "best-effort";
+		const policy =
+			report.status === "ok" ? "—" : isBlockingReport(report, required) ? "yes" : "best-effort";
 		const duration =
-			report.durationMs !== undefined ? `${(report.durationMs / 1000).toFixed(1)}s` : "";
+			report.durationMs !== undefined ? `${(report.durationMs / 1000).toFixed(1)}s` : "—";
 		return [
 			renderCell(report.provider, "code"),
 			renderCell(report.status, "plain"),
-			renderCell(report.status === "ok" ? "" : policy, "plain"),
+			renderCell(policy, "plain"),
 			renderCell(duration, "plain"),
-			renderCell(report.reason ?? "", "plain"),
+			renderCell(report.reason || "—", "plain"),
 		];
 	});
 	return [header, ...rows];

--- a/apps/cli/src/bin/release-summary.ts
+++ b/apps/cli/src/bin/release-summary.ts
@@ -1,11 +1,9 @@
 #!/usr/bin/env bun
-// `release-summary` — the script behind the `release-summary` composite action. Renders a consistent
-// per-phase job summary and a run annotation via @actions/core (GitHub's Actions Toolkit) instead of
-// hand-rolled `>> "$GITHUB_STEP_SUMMARY"` bash: core.summary owns the Markdown/HTML table + link, and
-// core.notice/core.error surface the phase result in the run's annotations panel. Inputs arrive as env
-// (the composite maps its `with:` inputs), NOT via core.getInput (that only works for JS/Docker actions).
+// `release-summary` — the script behind the release-summary composite action. It combines the raw
+// GitHub job status with bake/promote reports and the release's required-provider set so summaries
+// distinguish blockers from best-effort failures instead of reducing every phase to one opaque word.
 import * as core from "@actions/core";
-import type { CellKind } from "../lib/actions-log.ts";
+import type { CellKind, SummaryRow } from "../lib/actions-log.ts";
 import {
 	canWriteSummary,
 	escapeHtml,
@@ -13,35 +11,189 @@ import {
 	isFailure,
 	renderCell,
 } from "../lib/actions-log.ts";
+import { blockingReports, isBlockingId, nonBlockingFailures } from "../lib/bake/gates.ts";
+import type { BakeReport } from "../lib/bake/types.ts";
 
 // Re-export pure helpers so existing unit tests keep importing from this bin path.
 export { escapeHtml, isFailure, renderCell };
+
+export interface ReleaseResult {
+	/** Drives the annotation channel: error (blocking/non-success), warning (best-effort), or notice. */
+	kind: "failure" | "warning" | "ok";
+	/** The one-line verdict shown as the summary's first row. */
+	result: string;
+	/** Provider/sentinel outcomes that block the release, including required skips. */
+	blocking: string[];
+	/** Failed providers that are best-effort (recorded, non-blocking). */
+	nonBlocking: string[];
+	/** Providers that skipped (missing credentials or another declared prerequisite). */
+	skipped: string[];
+	/** A mismatch between `job.status` and the report-derived result. */
+	discrepancy?: string;
+}
+
+const uniqueProviders = (reports: ReadonlyArray<{ provider: string }>): string[] => [
+	...new Set(reports.map((report) => report.provider)),
+];
+
+/** Classify a phase from GitHub's job status plus its structured provider outcomes. */
+export function classifyRelease(input: {
+	jobStatus: string;
+	reports: ReadonlyArray<{ provider: string; status: string }>;
+	required: readonly string[];
+}): ReleaseResult {
+	const { jobStatus, reports, required } = input;
+	const blocking = uniqueProviders(blockingReports(reports, required));
+	const nonBlocking = uniqueProviders(nonBlockingFailures(reports, required));
+	const skipped = uniqueProviders(reports.filter((report) => report.status === "skipped"));
+	const normalizedJobStatus = jobStatus.trim().toLowerCase();
+	const jobCancelled = normalizedJobStatus === "cancelled";
+	const jobNonSuccess = isFailure(jobStatus) || jobCancelled;
+
+	let kind: ReleaseResult["kind"];
+	let result: string;
+	if (blocking.length > 0) {
+		kind = "failure";
+		result = `Failed — blocking: ${blocking.join(", ")}`;
+	} else if (jobNonSuccess) {
+		kind = "failure";
+		const label = jobCancelled ? "Cancelled" : `Failed${jobStatus ? ` (${jobStatus})` : ""}`;
+		result =
+			reports.length > 0
+				? `${label} — no blocking provider outcome recorded; check the step log`
+				: label;
+	} else if (nonBlocking.length > 0) {
+		kind = "warning";
+		result = `Passed with non-blocking failure(s): ${nonBlocking.join(", ")}`;
+	} else {
+		kind = "ok";
+		result = skipped.length > 0 ? `OK (skipped: ${skipped.join(", ")})` : "OK";
+	}
+
+	let discrepancy: string | undefined;
+	if (!jobNonSuccess && blocking.length > 0) {
+		discrepancy =
+			`Job status "${jobStatus || "success"}" is GREEN but a blocking outcome was recorded ` +
+			`(${blocking.join(", ")}) — the green status is wrong.`;
+	} else if (jobNonSuccess && reports.length > 0 && blocking.length === 0) {
+		discrepancy =
+			`Job status "${jobStatus}" is non-success but no blocking provider outcome was recorded — ` +
+			"the cause is outside the provider reports (check earlier steps).";
+	}
+
+	return { kind, result, blocking, nonBlocking, skipped, discrepancy };
+}
+
+/** Parse the `reports` array out of a bake/promote payload; malformed data degrades to no reports. */
+export function readReports(json: string | undefined): BakeReport[] {
+	if (!json) return [];
+	try {
+		const parsed = JSON.parse(json) as { reports?: unknown };
+		if (!Array.isArray(parsed.reports)) return [];
+		return parsed.reports.filter((report): report is BakeReport => {
+			if (typeof report !== "object" || report === null) return false;
+			const candidate = report as Partial<BakeReport>;
+			return (
+				typeof candidate.provider === "string" &&
+				(candidate.status === "ok" ||
+					candidate.status === "skipped" ||
+					candidate.status === "failed")
+			);
+		});
+	} catch {
+		return [];
+	}
+}
+
+/** Read and parse a report in one guarded operation. Missing, unreadable, and malformed files are all
+ * valid fallbacks: plan/build phases have no report, and a failed phase may crash before writing one. */
+export async function readReportFile(path: string): Promise<BakeReport[]> {
+	if (!path.trim()) return [];
+	try {
+		return readReports(await Bun.file(path).text());
+	} catch {
+		return [];
+	}
+}
+
+/** Split the composite action's comma-separated required-provider input. */
+function splitList(raw: string): string[] {
+	return raw
+		.split(",")
+		.map((value) => value.trim())
+		.filter(Boolean);
+}
+
+/** One row per provider report: id, status, blocking policy, wall time, and reason. */
+function providerReportRows(
+	reports: readonly BakeReport[],
+	required: readonly string[],
+): SummaryRow[] {
+	const header: SummaryRow = [
+		{ data: "Provider", header: true },
+		{ data: "Status", header: true },
+		{ data: "Blocking", header: true },
+		{ data: "Duration", header: true },
+		{ data: "Reason", header: true },
+	];
+	const rows: SummaryRow[] = reports.map((report) => {
+		const policy = isBlockingId(report.provider, required) ? "yes" : "best-effort";
+		const duration =
+			report.durationMs !== undefined ? `${(report.durationMs / 1000).toFixed(1)}s` : "";
+		return [
+			renderCell(report.provider, "code"),
+			renderCell(report.status, "plain"),
+			renderCell(report.status === "ok" ? "" : policy, "plain"),
+			renderCell(duration, "plain"),
+			renderCell(report.reason ?? "", "plain"),
+		];
+	});
+	return [header, ...rows];
+}
 
 if (import.meta.main) {
 	const env = (key: string): string => process.env[key]?.trim() ?? "";
 	const phase = env("PHASE") || "release";
 	const status = env("STATUS");
+	const required = splitList(env("REQUIRED"));
+	const reports = await readReportFile(env("REPORT_FILE"));
+	const verdict = classifyRelease({ jobStatus: status, reports, required });
 
-	// The field vocabulary, in display order. `code` fields (refs, commands, pointers) render monospaced.
+	const runId = env("RUN_ID");
+	const runAttempt = env("RUN_ATTEMPT");
+	const jobLine = [env("JOB"), runId && `run ${runId}`, runAttempt && `attempt ${runAttempt}`]
+		.filter(Boolean)
+		.join(" · ");
+	const triggeredBy = [env("ACTOR"), env("EVENT")].filter(Boolean).join(" · ");
+
 	const fields: Array<[label: string, value: string, kind: CellKind]> = [
-		["Status", status, "plain"],
+		["Result", verdict.result, "plain"],
+		["Job status", status, "plain"],
+		["Phase", phase, "plain"],
 		["Mode", env("MODE"), "code"],
 		["Scope", env("SCOPE"), "plain"],
+		["Job", jobLine, "code"],
+		["Triggered by", triggeredBy, "plain"],
 		["Source ref", env("SOURCE_REF"), "code"],
 		["Image", env("IMAGE"), "code"],
 		["Base image", env("BASE_IMAGE"), "code"],
 		["Provider target", env("PROVIDER_TARGET"), "code"],
 		["Size tier", env("SIZE_TIER"), "plain"],
-		["Verify command", env("VERIFY"), "code"],
+		["Required providers", required.join(", "), "code"],
 		["Published", env("PUBLISHED"), "code"],
+		["Verify command", env("VERIFY"), "code"],
 		["Elapsed", env("ELAPSED"), "plain"],
 	];
 
-	// `addHeading`/`addLink`/`addRaw` do NOT escape — every value reaching those is escaped by hand.
 	if (canWriteSummary()) {
 		core.summary.addHeading(`Image release: ${escapeHtml(phase)}`, 3).addTable(fieldTable(fields));
+		if (verdict.discrepancy) {
+			core.summary.addRaw(`<strong>⚠ ${escapeHtml(verdict.discrepancy)}</strong>`).addEOL();
+		}
+		if (reports.length > 0) {
+			core.summary.addHeading("Providers", 4).addTable(providerReportRows(reports, required));
+		}
 
-		// Link the uploaded diagnostics artifact to the run's artifacts, so an operator can jump straight there.
 		const diagnostics = env("DIAGNOSTICS");
 		const runUrl = env("RUN_URL");
 		if (diagnostics) {
@@ -50,16 +202,19 @@ if (import.meta.main) {
 			else core.summary.addRaw(escapeHtml(diagnostics));
 			core.summary.addEOL();
 		}
-
 		await core.summary.write();
 	}
 
-	// Surface the phase result in the run's annotations panel (grouped/filterable), not just the log.
-	const title = `Image release: ${phase}${status ? ` — ${status}` : ""}`;
-	const detail =
-		[env("IMAGE") && `image=${env("IMAGE")}`, env("PUBLISHED") && `published=${env("PUBLISHED")}`]
-			.filter(Boolean)
-			.join(" · ") || phase;
-	if (isFailure(status)) core.error(detail, { title });
-	else core.notice(detail, { title });
+	const title = `Image release: ${phase} — ${verdict.result}`;
+	const detail = [
+		verdict.discrepancy,
+		env("IMAGE") && `image=${env("IMAGE")}`,
+		env("PUBLISHED") && `published=${env("PUBLISHED")}`,
+	]
+		.filter(Boolean)
+		.join(" · ");
+	const message = detail || verdict.result;
+	if (verdict.kind === "failure" || verdict.discrepancy) core.error(message, { title });
+	else if (verdict.kind === "warning") core.warning(message, { title });
+	else core.notice(message, { title });
 }

--- a/apps/cli/src/lib/bake/gates.test.ts
+++ b/apps/cli/src/lib/bake/gates.test.ts
@@ -6,6 +6,7 @@ import {
 	isBlockingId,
 	isBlockingReport,
 	nonBlockingFailures,
+	unknownProviderIds,
 } from "./gates.ts";
 
 const REQUIRED = ["e2b", "daytona-vm", "modal-gvisor"];
@@ -108,5 +109,11 @@ describe("isBlockingId (status-independent labelling for the summary)", () => {
 		expect(isBlockingId("daytona-vm", REQUIRED)).toBe(true);
 		expect(isBlockingId("image", REQUIRED)).toBe(true);
 		expect(isBlockingId("daytona-container", REQUIRED)).toBe(false);
+	});
+});
+
+describe("unknownProviderIds", () => {
+	test("returns unique unknown ids without filtering valid required providers", () => {
+		expect(unknownProviderIds(["e2b", "typo", "daytona-vm", "typo"])).toEqual(["typo"]);
 	});
 });

--- a/apps/cli/src/lib/bake/gates.test.ts
+++ b/apps/cli/src/lib/bake/gates.test.ts
@@ -1,0 +1,112 @@
+import { describe, expect, test } from "bun:test";
+import {
+	blockingFailures,
+	blockingReports,
+	isBlockingFailure,
+	isBlockingId,
+	isBlockingReport,
+	nonBlockingFailures,
+} from "./gates.ts";
+
+const REQUIRED = ["e2b", "daytona-vm", "modal-gvisor"];
+
+describe("isBlockingFailure", () => {
+	test("a required provider's failure blocks", () => {
+		expect(isBlockingFailure({ provider: "daytona-vm", status: "failed" }, REQUIRED)).toBe(true);
+	});
+
+	test("a non-required provider's failure does NOT block (the promote-red-on-published bug)", () => {
+		// daytona-container failing must not fail a release whose required set (e2b/daytona-vm/modal-gvisor) passed.
+		expect(isBlockingFailure({ provider: "daytona-container", status: "failed" }, REQUIRED)).toBe(
+			false,
+		);
+		expect(isBlockingFailure({ provider: "modal-vm", status: "failed" }, REQUIRED)).toBe(false);
+		expect(isBlockingFailure({ provider: "novita", status: "failed" }, REQUIRED)).toBe(false);
+	});
+
+	test("the `image` commit-point sentinel ALWAYS blocks, even though it is not a required provider", () => {
+		// This is why the exit gate can't be `required.includes(provider)` alone: the base-retag / abort
+		// reports under `image`, and those must still fail the job.
+		expect(isBlockingFailure({ provider: "image", status: "failed" }, REQUIRED)).toBe(true);
+	});
+
+	test("any unknown/synthetic sentinel id blocks", () => {
+		expect(isBlockingFailure({ provider: "revalidate", status: "failed" }, REQUIRED)).toBe(true);
+	});
+
+	test("a non-failed status never blocks", () => {
+		expect(isBlockingFailure({ provider: "daytona-vm", status: "ok" }, REQUIRED)).toBe(false);
+		expect(isBlockingFailure({ provider: "image", status: "ok" }, REQUIRED)).toBe(false);
+		expect(isBlockingFailure({ provider: "daytona-container", status: "skipped" }, REQUIRED)).toBe(
+			false,
+		);
+	});
+
+	test("locally (nothing required) every provider failure blocks — the hand-run safety net", () => {
+		expect(isBlockingFailure({ provider: "daytona-container", status: "failed" }, [])).toBe(true);
+		expect(isBlockingFailure({ provider: "e2b", status: "failed" }, [])).toBe(true);
+	});
+});
+
+describe("isBlockingReport", () => {
+	test("a required provider skip blocks, while a best-effort skip does not", () => {
+		expect(isBlockingReport({ provider: "daytona-vm", status: "skipped" }, REQUIRED)).toBe(true);
+		expect(isBlockingReport({ provider: "daytona-container", status: "skipped" }, REQUIRED)).toBe(
+			false,
+		);
+	});
+
+	test("a local skip remains non-blocking when no provider was explicitly required", () => {
+		expect(isBlockingReport({ provider: "e2b", status: "skipped" }, [])).toBe(false);
+	});
+});
+
+describe("blockingFailures / nonBlockingFailures partition the failures", () => {
+	const reports = [
+		{ provider: "e2b", status: "ok" },
+		{ provider: "daytona-vm", status: "ok" },
+		{ provider: "daytona-container", status: "failed" },
+		{ provider: "modal-gvisor", status: "ok" },
+		{ provider: "novita", status: "skipped" },
+		{ provider: "image", status: "ok" },
+	];
+
+	test("only the non-required daytona-container failure is surfaced, and it is non-blocking", () => {
+		expect(blockingFailures(reports, REQUIRED)).toEqual([]);
+		expect(nonBlockingFailures(reports, REQUIRED).map((r) => r.provider)).toEqual([
+			"daytona-container",
+		]);
+	});
+
+	test("a required failure lands in blocking, a best-effort failure in non-blocking", () => {
+		const mixed = [
+			{ provider: "daytona-vm", status: "failed" },
+			{ provider: "daytona-container", status: "failed" },
+			{ provider: "image", status: "failed" },
+		];
+		expect(blockingFailures(mixed, REQUIRED).map((r) => r.provider)).toEqual([
+			"daytona-vm",
+			"image",
+		]);
+		expect(nonBlockingFailures(mixed, REQUIRED).map((r) => r.provider)).toEqual([
+			"daytona-container",
+		]);
+	});
+
+	test("blockingReports also includes required skips", () => {
+		const outcomes = [
+			{ provider: "e2b", status: "skipped" },
+			{ provider: "daytona-container", status: "skipped" },
+			{ provider: "image", status: "failed" },
+		];
+		expect(blockingReports(outcomes, REQUIRED).map((r) => r.provider)).toEqual(["e2b", "image"]);
+	});
+});
+
+describe("isBlockingId (status-independent labelling for the summary)", () => {
+	test("required provider and sentinel are blocking; best-effort provider is not", () => {
+		expect(isBlockingId("daytona-vm", REQUIRED)).toBe(true);
+		expect(isBlockingId("image", REQUIRED)).toBe(true);
+		expect(isBlockingId("daytona-container", REQUIRED)).toBe(false);
+	});
+});

--- a/apps/cli/src/lib/bake/gates.ts
+++ b/apps/cli/src/lib/bake/gates.ts
@@ -9,12 +9,14 @@
 //   • A failed report for a real provider blocks IFF that provider is `required`. Non-required
 //     ("best-effort") providers — daytona-container, modal-vm, novita, blaxel until a committed run
 //     proves them — are recorded and warned, but must never fail a release whose required set passed.
+//   • A required provider that SKIPS also blocks: a release cannot claim a required integration passed
+//     when missing credentials or another prerequisite prevented it from running.
 //   • Locally (nothing required) any failure blocks, as a safety net for a hand-run bake/promote.
 //
 // This is deliberately NOT `reports.some(r => r.status === "failed")`: that blunt check is what made
 // run 29896891577's promote job go red AFTER it had already published :v5 — a non-required
 // daytona-container failure was counted as fatal even though the release intentionally shipped without
-// it. Gate on `hasBlockingFailure` instead, everywhere the exit code is decided.
+// it. Gate on the helpers below instead, everywhere the exit code is decided.
 import { PROVIDER_IDS } from "@sandbox-benchmarks/schema/providers";
 
 /** Registered provider ids. A failed report whose provider is NOT one of these is a synthetic sentinel
@@ -23,6 +25,12 @@ const REGISTERED_PROVIDER_IDS: ReadonlySet<string> = new Set(PROVIDER_IDS);
 
 /** Synthetic id used for promotion's release-plumbing outcomes (including the image commit point). */
 export const IMAGE_REPORT = "image";
+
+/** Required ids that are not registered providers. Keep this check separate from per-cell scoping so
+ * a typo cannot disappear merely because the current matrix cell runs a different provider. */
+export function unknownProviderIds(ids: readonly string[]): string[] {
+	return [...new Set(ids.filter((id) => !REGISTERED_PROVIDER_IDS.has(id)))];
+}
 
 /** The minimal report shape the gate reads — structural so both a bake/promote {@link
  *  import("./types.ts").BakeReport} and a raw provider-run fit without coupling. */

--- a/apps/cli/src/lib/bake/gates.ts
+++ b/apps/cli/src/lib/bake/gates.ts
@@ -21,6 +21,9 @@ import { PROVIDER_IDS } from "@sandbox-benchmarks/schema/providers";
  *  (e.g. `image`) that always blocks — it can only mean the release plumbing failed. */
 const REGISTERED_PROVIDER_IDS: ReadonlySet<string> = new Set(PROVIDER_IDS);
 
+/** Synthetic id used for promotion's release-plumbing outcomes (including the image commit point). */
+export const IMAGE_REPORT = "image";
+
 /** The minimal report shape the gate reads — structural so both a bake/promote {@link
  *  import("./types.ts").BakeReport} and a raw provider-run fit without coupling. */
 export interface GateReport {
@@ -30,11 +33,7 @@ export interface GateReport {
 
 /** True when this report is a failure that must fail the job (block the release). See the module note. */
 export function isBlockingFailure(report: GateReport, required: readonly string[]): boolean {
-	if (report.status !== "failed") return false;
-	// A synthetic sentinel (not a registered provider) is the release itself — always blocking.
-	if (!REGISTERED_PROVIDER_IDS.has(report.provider)) return true;
-	// A real provider blocks iff required — or, in the lenient local default (nothing required), always.
-	return required.length === 0 || required.includes(report.provider);
+	return report.status === "failed" && isBlockingId(report.provider, required);
 }
 
 /** True when a report outcome blocks the release. In addition to blocking failures, an explicitly
@@ -69,12 +68,7 @@ export function nonBlockingFailures<T extends GateReport>(
 	reports: readonly T[],
 	required: readonly string[],
 ): T[] {
-	return reports.filter(
-		(r) =>
-			r.status === "failed" &&
-			REGISTERED_PROVIDER_IDS.has(r.provider) &&
-			!isBlockingFailure(r, required),
-	);
+	return reports.filter((r) => r.status === "failed" && !isBlockingFailure(r, required));
 }
 
 /** Whether a failure of this report's id WOULD block — independent of its current status. Lets the

--- a/apps/cli/src/lib/bake/gates.ts
+++ b/apps/cli/src/lib/bake/gates.ts
@@ -1,0 +1,85 @@
+// The single source of truth for "does this bake/promote report block the release?" — shared by the
+// candidate bake loop, the promote transaction, and the job-summary renderer so the three can never
+// disagree about what a red build means.
+//
+// The rule the whole release lane turns on:
+//   • A failed report for a NON-provider sentinel (the `image` base-retag commit point, or any
+//     pre-publish abort that reports under a synthetic id) ALWAYS blocks — those are the release
+//     itself failing, never a best-effort provider.
+//   • A failed report for a real provider blocks IFF that provider is `required`. Non-required
+//     ("best-effort") providers — daytona-container, modal-vm, novita, blaxel until a committed run
+//     proves them — are recorded and warned, but must never fail a release whose required set passed.
+//   • Locally (nothing required) any failure blocks, as a safety net for a hand-run bake/promote.
+//
+// This is deliberately NOT `reports.some(r => r.status === "failed")`: that blunt check is what made
+// run 29896891577's promote job go red AFTER it had already published :v5 — a non-required
+// daytona-container failure was counted as fatal even though the release intentionally shipped without
+// it. Gate on `hasBlockingFailure` instead, everywhere the exit code is decided.
+import { PROVIDER_IDS } from "@sandbox-benchmarks/schema/providers";
+
+/** Registered provider ids. A failed report whose provider is NOT one of these is a synthetic sentinel
+ *  (e.g. `image`) that always blocks — it can only mean the release plumbing failed. */
+const REGISTERED_PROVIDER_IDS: ReadonlySet<string> = new Set(PROVIDER_IDS);
+
+/** The minimal report shape the gate reads — structural so both a bake/promote {@link
+ *  import("./types.ts").BakeReport} and a raw provider-run fit without coupling. */
+export interface GateReport {
+	provider: string;
+	status: string;
+}
+
+/** True when this report is a failure that must fail the job (block the release). See the module note. */
+export function isBlockingFailure(report: GateReport, required: readonly string[]): boolean {
+	if (report.status !== "failed") return false;
+	// A synthetic sentinel (not a registered provider) is the release itself — always blocking.
+	if (!REGISTERED_PROVIDER_IDS.has(report.provider)) return true;
+	// A real provider blocks iff required — or, in the lenient local default (nothing required), always.
+	return required.length === 0 || required.includes(report.provider);
+}
+
+/** True when a report outcome blocks the release. In addition to blocking failures, an explicitly
+ * required provider that skipped (normally because credentials were unavailable) must fail closed. */
+export function isBlockingReport(report: GateReport, required: readonly string[]): boolean {
+	return (
+		isBlockingFailure(report, required) ||
+		(report.status === "skipped" && required.includes(report.provider))
+	);
+}
+
+/** The failed reports that block the release (see {@link isBlockingFailure}). Empty ⇒ safe to exit 0. */
+export function blockingFailures<T extends GateReport>(
+	reports: readonly T[],
+	required: readonly string[],
+): T[] {
+	return reports.filter((r) => isBlockingFailure(r, required));
+}
+
+/** All report outcomes that block: blocking failures plus skips by explicitly required providers. */
+export function blockingReports<T extends GateReport>(
+	reports: readonly T[],
+	required: readonly string[],
+): T[] {
+	return reports.filter((r) => isBlockingReport(r, required));
+}
+
+/** The failed PROVIDER reports that are best-effort (non-blocking): a real provider that failed but is
+ *  not required. These are surfaced as warnings, never as a job failure. Excludes sentinels (which
+ *  always block) and — in the local default — is empty, since there every failure blocks. */
+export function nonBlockingFailures<T extends GateReport>(
+	reports: readonly T[],
+	required: readonly string[],
+): T[] {
+	return reports.filter(
+		(r) =>
+			r.status === "failed" &&
+			REGISTERED_PROVIDER_IDS.has(r.provider) &&
+			!isBlockingFailure(r, required),
+	);
+}
+
+/** Whether a failure of this report's id WOULD block — independent of its current status. Lets the
+ *  summary label an `ok`/`skipped` row as "blocking" vs "best-effort" the same way a failure is judged. */
+export function isBlockingId(provider: string, required: readonly string[]): boolean {
+	if (!REGISTERED_PROVIDER_IDS.has(provider)) return true;
+	return required.length === 0 || required.includes(provider);
+}

--- a/apps/cli/src/lib/bake/promote.ts
+++ b/apps/cli/src/lib/bake/promote.ts
@@ -35,7 +35,7 @@ import { PROVIDERS } from "@sandbox-benchmarks/schema";
 import { isPartialScope } from "../matrix.ts";
 import type { ProviderRun } from "../providers-run.ts";
 import { forEachProviderWithCreds } from "../providers-run.ts";
-import { isBlockingFailure } from "./gates.ts";
+import { IMAGE_REPORT, isBlockingFailure } from "./gates.ts";
 import {
 	imageDigest,
 	imageExistsInRegistry,
@@ -93,8 +93,8 @@ export function fullPromotionResult(reports: BakeReport[]): PromoteResult {
 	return {
 		reports,
 		ok:
-			reports.some((report) => report.provider === "image" && report.status === "ok") &&
-			!reports.some((report) => report.provider === "image" && report.status === "failed"),
+			reports.some((report) => report.provider === IMAGE_REPORT && report.status === "ok") &&
+			!reports.some((report) => report.provider === IMAGE_REPORT && report.status === "failed"),
 	};
 }
 
@@ -146,7 +146,7 @@ export async function promoteAll(log: Log, options: PromoteOptions = {}): Promis
 	 *  below returns, so the refusal contract is written once. */
 	const refuse = (reason: string, verb = "refused"): PromoteResult => {
 		log(`<<< promote ${verb} — ${reason}`);
-		reports.push({ provider: "image", status: "failed", reason });
+		reports.push({ provider: IMAGE_REPORT, status: "failed", reason });
 		return { reports, ok: false };
 	};
 	// Only a REQUIRED provider gates the release (Option 1): a best-effort variant that shares a required
@@ -376,7 +376,7 @@ export async function promoteAll(log: Log, options: PromoteOptions = {}): Promis
 		log(`!!! promote aborted before publish: ${reason}; ${baseUntouched} ${rerunHint}`);
 		// Push a structured failure (like the step-1 and step-4 aborts) so the emitted JSON is
 		// self-describing — a consumer sees the failed promote without re-deriving it from `--require`.
-		reports.push({ provider: "image", status: "failed", reason });
+		reports.push({ provider: IMAGE_REPORT, status: "failed", reason });
 		return { reports, ok: false };
 	}
 
@@ -395,12 +395,16 @@ export async function promoteAll(log: Log, options: PromoteOptions = {}): Promis
 	const imageStart = performance.now();
 	try {
 		await promoteImage(log, pinnedBaseImage);
-		reports.push({ provider: "image", status: "ok", durationMs: performance.now() - imageStart });
+		reports.push({
+			provider: IMAGE_REPORT,
+			status: "ok",
+			durationMs: performance.now() - imageStart,
+		});
 	} catch (err) {
 		const reason = err instanceof Error ? err.message : String(err);
 		log(`<<< image: promote failed — ${reason}`);
 		reports.push({
-			provider: "image",
+			provider: IMAGE_REPORT,
 			status: "failed",
 			reason,
 			durationMs: performance.now() - imageStart,

--- a/apps/cli/src/lib/bake/promote.ts
+++ b/apps/cli/src/lib/bake/promote.ts
@@ -35,6 +35,7 @@ import { PROVIDERS } from "@sandbox-benchmarks/schema";
 import { isPartialScope } from "../matrix.ts";
 import type { ProviderRun } from "../providers-run.ts";
 import { forEachProviderWithCreds } from "../providers-run.ts";
+import { isBlockingFailure } from "./gates.ts";
 import {
 	imageDigest,
 	imageExistsInRegistry,
@@ -154,8 +155,8 @@ export async function promoteAll(log: Log, options: PromoteOptions = {}): Promis
 	// A scoped backfill is inherently strict: every provider explicitly named is required even if a
 	// direct local caller omitted the redundant `--require` flag.
 	const required = effectivePromotionRequirements(requiredProviders(), only);
-	const blocks = (r: { provider: string; status: string }): boolean =>
-		r.status === "failed" && (required.length === 0 || required.includes(r.provider));
+	const blocks = (report: { provider: string; status: string }): boolean =>
+		isBlockingFailure(report, required);
 
 	// 1. Refuse to overwrite the immutable public version (D2b). Checked first, before any mutation, so
 	//    a refused promote leaves everything untouched. A registry error here (auth/network) is NOT


### PR DESCRIPTION
## Why

[Toolchain release run 29896891577](https://github.com/starslingdev/hpc-sandbox-benchmarks/actions/runs/29896891577) published its immutable base successfully, then reported the job as failed because one best-effort provider did not validate. The release gate and the job summary disagreed about what had actually shipped.

This remains a real issue on current `main`: candidate bake still treats every provider failure as fatal, while the workflow works around optional failures by swallowing the shell exit code. The summary only reports the scalar job status, so it cannot explain required versus best-effort outcomes.

## What changed

- Added one shared release-gate policy for candidate bake, promote, and summary rendering:
  - required-provider failures and skips block;
  - synthetic release failures such as the image commit point always block;
  - best-effort provider failures are recorded and warned without turning a valid release red;
  - local runs with no required set retain the fail-safe behavior that any failure is fatal.
- Passed the full required-provider set to every bake matrix cell and removed the shell-level `|| echo` exit-code swallow. `bake.ts` scopes absence checks to the provider in that cell and emits real `@actions/core` warnings.
- Preserved current `main`'s provider-artifact, digest-pinned base-image, scoped-backfill, and transactional `PromoteResult` architecture while applying the shared gate to promote decisions.
- Made release summaries report the precise result, provider outcomes, blocking policy, duration/reason, scope, run identity, actor/event, and rerunnable verification command.
- Added discrepancy banners when GitHub's job status disagrees with the structured report.
- Replaced handwritten workflow-command warnings in `release-plan.ts` with the shared Actions logger.

## Review fixes and hardening

- Required skips are named as blockers in both the verdict and provider table.
- Cancelled jobs can no longer render as successful.
- Report loading is one guarded read; missing, removed, unreadable, malformed, or partially malformed report data falls back safely instead of crashing the `if: always()` summary step.
- Unknown `--require` provider IDs fail fast before a per-cell scope can filter out the typo.
- The rendered provider table uses explicit placeholders for absent values, avoiding malformed-looking empty toolkit cells.
- The obsolete `build-candidate.ts` change from the old branch was dropped because current `main` already returns a digest-pinned staged base.

## Verification

- `bun run lint`
- `bun run typecheck`
- `bun run test`
- `bun run lint:shell`
- `bun run lint:docker`
- `bun run check:catalog-drift`
- `bun run check:provider-registry-drift`
- `bun run check:provider-wiring`
- `bun run spell`
- `mise exec -- actionlint -no-color`
- `mise exec -- zizmor --no-progress --persona regular --min-severity medium --min-confidence high .github/workflows/`
- End-to-end invocation of `release-summary.ts` with a real report and `$GITHUB_STEP_SUMMARY`, confirming the warning annotation and rendered provider table.
