### PR TITLE
hotfix(ci): drop Biome preflight that blocks leaderboard regeneration

### DIFF
--- a/.github/workflows/update-leaderboard.yml
+++ b/.github/workflows/update-leaderboard.yml
@@ -98,14 +98,11 @@ jobs:
 
       # Keep LEADERBOARD.md byte-identical to what the renderer produces from the chosen committed Run —
       # the same command the leaderboard-artifact-sync gate names in its failure message.
+      # No Biome pre-flight here: Biome does not process Markdown (`files.ignoreUnknown` + no markdown
+      # language), so `biome check LEADERBOARD.md` reports "No files were processed" and exits 1. The
+      # real content gate is leaderboard-artifact-sync on the PR (byte-identity with the renderer).
       - name: Regenerate leaderboard
         run: bun apps/cli/src/bin/leaderboard.ts "data/dataset/runs/$TARGET_RUN_ID.json" LEADERBOARD.md
-
-      # Fast pre-flight of the same gate the PR runs (`biome check .`), scoped to the file this job
-      # writes. Biome leaves the rendered Markdown untouched, so this catches only a genuine formatting
-      # regression; fail here (before any PR is opened) rather than leave a doomed PR.
-      - name: Confirm the leaderboard passes Biome (the PR lint gate)
-        run: bunx biome check LEADERBOARD.md --error-on-warnings
 
       # main is protected by a "changes must be made through a pull request" ruleset, so this job can't
       # push LEADERBOARD.md straight to main — a direct push is rejected with GH013. Commit through a
@@ -143,7 +140,7 @@ jobs:
               --base main \
               --head "$branch" \
               --title "chore(leaderboard): update from run ${TARGET_RUN_ID}" \
-              --body "Automated LEADERBOARD.md regeneration from committed dataset run \`${TARGET_RUN_ID}\`. Biome was pre-flighted green; auto-merge lands it once branch protection is satisfied."; then
+              --body "Automated LEADERBOARD.md regeneration from committed dataset run \`${TARGET_RUN_ID}\`. Auto-merge lands it once branch protection is satisfied."; then
               echo "::error::gh pr create failed — branch '$branch' was pushed but no PR was opened." \
                 "This is almost always the repo's 'Allow GitHub Actions to create and approve pull" \
                 "requests' setting being off (Settings → Actions → General → Workflow permissions)." \

--- a/docs/ci-secrets.md
+++ b/docs/ci-secrets.md
@@ -58,14 +58,17 @@ Ungated: `ci.yml`, `ci-lint.yml`, and the toolchain `pr-gate` (Docker smoke, no 
    Biome formats JSON, so an unformatted Run document would fail the PR — and aborts before opening a
    doomed PR on a miss. The push/PR step is idempotent: a re-run reuses the existing open PR instead of
    colliding on the deterministic branch. `update-leaderboard.yml` lands `LEADERBOARD.md` the same way
-   (a `leaderboard/update-<run-id>` PR, Biome-preflighted, auto-merge armed).
+   (a `leaderboard/update-<run-id>` PR, auto-merge armed). Biome is not pre-flighted on that path —
+   it does not process Markdown — so content correctness is the `leaderboard-artifact-sync` gate.
 
    > **`GITHUB_TOKEN` caveat.** A PR opened with the default `GITHUB_TOKEN` does **not** trigger
    > `ci.yml` (GitHub suppresses workflow events raised by the Actions token). So if the Biome/CI check
    > is a *required* status, auto-merge waits for a check that never runs, and a maintainer completes
-   > the merge (their merge to `main` runs `ci.yml` normally); the in-job pre-flight guarantees the
-   > content is already clean. For fully hands-off auto-merge, open the PR with a GitHub App
-   > installation token or PAT instead of `GITHUB_TOKEN` so the PR's own checks run.
+   > the merge (their merge to `main` runs `ci.yml` normally). For dataset PRs the in-job Biome
+   > pre-flight already guarantees the JSON is clean; for leaderboard PRs the renderer is deterministic
+   > and `leaderboard-artifact-sync` is what `ci.yml` enforces on merge. For fully hands-off auto-merge,
+   > open the PR with a GitHub App installation token or PAT instead of `GITHUB_TOKEN` so the PR's own
+   > checks run.
 6. **Backfilling a failed dataset commit.** The commit logic is the reusable `commit-dataset.yml`, so
    when a matrix run's dataset commit fails (or was never reached) a maintainer can re-run it standalone:
    **Actions → Commit dataset → Run workflow**, passing the original run's id — or, from a


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

`update-leaderboard.yml` failed before opening a PR because:

```text
bunx biome check LEADERBOARD.md --error-on-warnings
→ No files were processed in the specified paths.
→ These paths were provided but ignored: LEADERBOARD.md
```

Biome 2.4 does not process Markdown (`files.ignoreUnknown: true`, no markdown language), so a scoped check of only `LEADERBOARD.md` always exits 1. That made every Update leaderboard dispatch fail at the preflight step ([run 29947331163](https://github.com/starslingdev/hpc-sandbox-benchmarks/actions/runs/29947331163/job/89015935515), [run 29947265424](https://github.com/starslingdev/hpc-sandbox-benchmarks/actions/runs/29947265424/job/89015717161)).

## Fix

- Remove the dead Biome preflight from `update-leaderboard.yml` (and the PR body claim that Biome was pre-flighted).
- Document that leaderboard content is gated by the deterministic renderer + `leaderboard-artifact-sync`, not Biome. Dataset commits still keep their Biome JSON preflight.

## After merge

Re-dispatch **Actions → Update leaderboard** (optionally with `run_id=29937467891`) to regenerate `LEADERBOARD.md`.

CI on this PR is green.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-677197b3-885e-4cd2-b150-7ed249f780c4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-677197b3-885e-4cd2-b150-7ed249f780c4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed the failing `bunx biome check LEADERBOARD.md` preflight from `update-leaderboard.yml` so leaderboard updates can open PRs again. We now rely on the deterministic renderer and the `leaderboard-artifact-sync` gate for correctness.

- **Bug Fixes**
  - Dropped the `biome` Markdown preflight that always exited 1 and blocked PR creation.
  - Updated docs to clarify that Markdown isn’t linted by `biome`; correctness is enforced by the renderer + `leaderboard-artifact-sync`. Dataset JSON preflight stays.

- **Migration**
  - Re-run Actions → Update leaderboard to regenerate `LEADERBOARD.md`.

<sup>Written for commit 4f545d36fe8e86f77d18a0cea585fe25caaf9c2d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/starslingdev/hpc-sandbox-benchmarks/pull/247?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

