### PR TITLE
feat(network): move the network suite onto iperf3 localhost + WAN leaves

### DIFF
--- a/.mise/tasks/benchmark/network/pts/iperf-localhost
+++ b/.mise/tasks/benchmark/network/pts/iperf-localhost
@@ -24,16 +24,25 @@ if ! command -v phoronix-test-suite &>/dev/null; then
 	exit 0
 fi
 
-# The upstream profile free-texts the server address/port and builds with -march=native; the
-# vendored copy pins the localhost subset and repairs the runner (see the profile's install.sh).
-# Stage it and discard the baked upstream install so run_pts_benchmark installs the override; the
-# second pinned run below reuses that install.
+# The vendored profile's test-definition.xml is BYTE-IDENTICAL to upstream (the fio precedent: the
+# full option matrix is catalogued, this leaf pins one combination per variant, unrun combinations
+# never receive samples); only install.sh carries repairs (build under the installed dir, generic
+# -O3 instead of -march=native, the runner's 2>&1/one-off-server/readiness fixes). Stage it and
+# discard the baked upstream install so run_pts_benchmark installs the override; the second pinned
+# run below reuses that install.
 install_vendored_pts_profile "iperf-1.2.0"
 
-# Preset values follow run_pinned_pts's contract: non-numeric values pin by entry NAME ("localhost",
-# "10 Seconds", "TCP"); "5201" and "10" exceed their menus' entry counts so they also pin by name;
-# but parallel "1" would read as a menu INDEX (1 < 2 entries → the "10" entry), so -P 1 pins by
-# INDEX 0 — the fio cpu-threads=0 precedent.
+# Preset values follow run_pinned_pts's contract against the UPSTREAM axes (PTS 10.8.4
+# pts_test_run_options.php / pts_test_option.php):
+#   * server-address and positive-number (Server Port) have no <Menu> — text-entry options, so the
+#     preset value passes through literally ("Using Pre-Set Run Option"): -c localhost, -p 5201.
+#   * duration "10 Seconds" and test "TCP" are non-numeric → pin by entry NAME (4- and 5-entry
+#     menus). TCP's entry carries no <Value>, so it contributes no argument — TCP IS the absence of
+#     the -u UDP flags.
+#   * parallel is the numeric-menu trap: the menu is 1,5,10,20,32,64,128,256 (8 entries), and a
+#     NUMERIC preset below the entry count reads as a 0-based INDEX. "1" would select index 1 =
+#     "5" (-P 5!), so -P 1 pins by INDEX 0 (the fio cpu-threads=0 precedent); "10" is >= 8 so it
+#     falls through to a NAME match on the "10" entry (-P 10).
 #
 # The two variants are independent measurements, so neither aborts the other (`|| true` keeps each
 # variant's own recorded gap while letting the other run); the assert loop below is the single

--- a/.mise/tasks/benchmark/network/pts/iperf-localhost
+++ b/.mise/tasks/benchmark/network/pts/iperf-localhost
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+#MISE description="PTS: iperf3 localhost TCP throughput (10s; 1 and 10 parallel streams)"
+# Measurement leaf: -e guards the scaffolding; the measured runs are isolated by run_pts_benchmark
+# (via run_pinned_pts, which owns the per-prefix skip markers and pins each variant's option
+# combination through PRESET_OPTIONS).
+#
+# Fully in-sandbox: the vendored profile's runner starts a local iperf3 server and the client
+# measures TCP over localhost, so the number isolates the sandbox's network stack/virtualization
+# overhead (virtio/KVM vs gVisor netstack vs host namespaces) from Internet weather — the suite's
+# successor to the dd|nc network-loopback leaf (which stays runnable manually). Two variants from
+# one vendored install (the pgbench one-leaf precedent — a second leaf would re-stage the vendored
+# profile and pay the iperf build twice): -P 1 is single-stream stack throughput, -P 10 adds
+# per-stream overhead scaling (iperf 3.14 is single-threaded, so this scales streams within one
+# process, not across cores).
+set -euo pipefail
+REPO_ROOT="$(git -C "$(dirname "${BASH_SOURCE[0]}")" rev-parse --show-toplevel)"
+source "${REPO_ROOT}/lib/bench.sh"
+
+# install_vendored_pts_profile needs PTS on PATH before run_pinned_pts's own guard can run, so guard
+# here with a skip marker per prefix (the exact negatives of the two composites this leaf produces).
+if ! command -v phoronix-test-suite &>/dev/null; then
+	skip_result "phoronix-test-suite not installed" "pts_iperf-tcp-p1"
+	skip_result "phoronix-test-suite not installed" "pts_iperf-tcp-p10"
+	exit 0
+fi
+
+# The upstream profile free-texts the server address/port and builds with -march=native; the
+# vendored copy pins the localhost subset and repairs the runner (see the profile's install.sh).
+# Stage it and discard the baked upstream install so run_pts_benchmark installs the override; the
+# second pinned run below reuses that install.
+install_vendored_pts_profile "iperf-1.2.0"
+
+# Preset values follow run_pinned_pts's contract: non-numeric values pin by entry NAME ("localhost",
+# "10 Seconds", "TCP"); "5201" and "10" exceed their menus' entry counts so they also pin by name;
+# but parallel "1" would read as a menu INDEX (1 < 2 entries → the "10" entry), so -P 1 pins by
+# INDEX 0 — the fio cpu-threads=0 precedent.
+#
+# The two variants are independent measurements, so neither aborts the other (`|| true` keeps each
+# variant's own recorded gap while letting the other run); the assert loop below is the single
+# arbiter that reds the job.
+run_pinned_pts "pts/iperf-1.2.0" "pts_iperf-tcp-p1" \
+	"iperf.server-address=localhost;iperf.positive-number=5201;iperf.duration=10 Seconds;iperf.test=TCP;iperf.parallel=0" || true
+run_pinned_pts "pts/iperf-1.2.0" "pts_iperf-tcp-p10" \
+	"iperf.server-address=localhost;iperf.positive-number=5201;iperf.duration=10 Seconds;iperf.test=TCP;iperf.parallel=10" || true
+
+# PTS exits 0 and writes a composite even when every trial failed (empty <Value> elements): each
+# variant must post its one throughput result. A --skipped.json marker passes — an honest recorded
+# gap is the designed keep+warn shape.
+for prefix in pts_iperf-tcp-p1 pts_iperf-tcp-p10; do
+	assert_pts_numeric_values "$prefix" 1
+done

--- a/.mise/tasks/benchmark/network/pts/iperf-wan
+++ b/.mise/tasks/benchmark/network/pts/iperf-wan
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+#MISE description="PTS: iperf3 WAN TCP throughput vs closest curated public server (10s, 8 streams, both directions)"
+# Measurement leaf: -e guards the scaffolding; the measured runs are isolated by run_pts_benchmark
+# (via run_pinned_pts, which owns the per-prefix skip markers and pins each direction through
+# PRESET_OPTIONS).
+#
+# The suite's successor to the fast-cli leaf (which stays runnable manually): run 29937467891 showed
+# the Chrome-driven fast.com measurement is structurally unreliable on fast datacenter paths (memory
+# watchdog killed every trial on daytona-vm/novita/blaxel; the surviving numbers were buffer-fill
+# transients). iperf3 against a curated public server measures WAN throughput with real byte
+# accounting. The profile's runner (local/iperf-wan-1.0.0/runner.sh) probes TCP-connect RTT to every
+# listed server, picks the closest reachable non-backup one, retries across its port range on
+# single-client busy collisions, and appends the per-trial choice to server-choices.ndjson — copied
+# into the results tree below, because WAN numbers are uninterpretable without the chosen server.
+set -euo pipefail
+REPO_ROOT="$(git -C "$(dirname "${BASH_SOURCE[0]}")" rev-parse --show-toplevel)"
+source "${REPO_ROOT}/lib/bench.sh"
+
+# install_local_pts_profile needs PTS on PATH before run_pinned_pts's own guard can run, so guard
+# here with a skip marker per prefix (the exact negatives of the two composites this leaf produces).
+if ! command -v phoronix-test-suite &>/dev/null; then
+	skip_result "phoronix-test-suite not installed" "pts_iperf-wan-download"
+	skip_result "phoronix-test-suite not installed" "pts_iperf-wan-upload"
+	exit 0
+fi
+# The runner parses servers.json and iperf3's JSON output with jq (baked; also in PTS_APT_DEPS).
+if ! command -v jq &>/dev/null; then
+	skip_result "jq not installed (required for iperf-wan server selection)" "pts_iperf-wan-download"
+	skip_result "jq not installed (required for iperf-wan server selection)" "pts_iperf-wan-upload"
+	exit 0
+fi
+
+install_local_pts_profile "iperf-wan-1.0.0"
+
+# Direction pins by entry NAME (non-numeric). The two directions are independent measurements, so
+# neither aborts the other (`|| true` keeps each direction's own recorded gap while letting the
+# other run); the assert loop below is the single arbiter that reds the job. Download first: -R is
+# the direction fast-cli's loss hurt most (provider ingress).
+run_pinned_pts "local/iperf-wan-1.0.0" "pts_iperf-wan-download" "iperf-wan.direction=Download" || true
+run_pinned_pts "local/iperf-wan-1.0.0" "pts_iperf-wan-upload" "iperf-wan.direction=Upload" || true
+
+# Server-choice provenance: the runner appends one NDJSON record per successful trial (host, port,
+# provider, site, probe RTT, figure). Best-effort copy — the composites are the metrics; a missing
+# file just means no trial succeeded and the asserts below already tell that story.
+choices="$(pts_user_dir)/installed-tests/local/iperf-wan-1.0.0/server-choices.ndjson"
+if [ -f "$choices" ]; then
+	cp "$choices" "$(results_dir)/pts_iperf-wan--server-choices.ndjson" 2>/dev/null || true
+	echo "Server-choice provenance: pts_iperf-wan--server-choices.ndjson"
+	cat "$choices"
+fi
+
+# PTS exits 0 and writes a composite even when every trial failed (empty <Value> elements): each
+# direction must post its one throughput result. A --skipped.json marker passes — an honest recorded
+# gap is the designed keep+warn shape.
+for prefix in pts_iperf-wan-download pts_iperf-wan-upload; do
+	assert_pts_numeric_values "$prefix" 1
+done

--- a/.mise/tasks/benchmark/network/pts/iperf-wan
+++ b/.mise/tasks/benchmark/network/pts/iperf-wan
@@ -32,6 +32,14 @@ fi
 
 install_local_pts_profile "iperf-wan-1.0.0"
 
+# The runner's chosen-server cache pins BOTH directions of THIS leaf execution to one path, and its
+# NDJSON provenance must describe exactly the trials copied into this run's results tree — but both
+# files live in the persistent installed-profile dir, which survives suite re-runs in a long-lived
+# sandbox (fresh CI sandboxes never see this; manual re-runs do). Scope them to this execution:
+# clear both here, after install (which may re-stage the profile) and before the first trial.
+profile_dir="$(pts_user_dir)/installed-tests/local/iperf-wan-1.0.0"
+rm -f "${profile_dir}/chosen-server" "${profile_dir}/server-choices.ndjson"
+
 # Direction pins by entry NAME (non-numeric). The two directions are independent measurements, so
 # neither aborts the other (`|| true` keeps each direction's own recorded gap while letting the
 # other run); the assert loop below is the single arbiter that reds the job. Download first: -R is
@@ -42,7 +50,7 @@ run_pinned_pts "local/iperf-wan-1.0.0" "pts_iperf-wan-upload" "iperf-wan.directi
 # Server-choice provenance: the runner appends one NDJSON record per successful trial (host, port,
 # provider, site, probe RTT, figure). Best-effort copy — the composites are the metrics; a missing
 # file just means no trial succeeded and the asserts below already tell that story.
-choices="$(pts_user_dir)/installed-tests/local/iperf-wan-1.0.0/server-choices.ndjson"
+choices="${profile_dir}/server-choices.ndjson"
 if [ -f "$choices" ]; then
 	cp "$choices" "$(results_dir)/pts_iperf-wan--server-choices.ndjson" 2>/dev/null || true
 	echo "Server-choice provenance: pts_iperf-wan--server-choices.ndjson"

--- a/.mise/tasks/benchmark/network/suite
+++ b/.mise/tasks/benchmark/network/suite
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+#MISE description="Run the network suite (PTS iperf3 localhost + WAN + latency/DNS/download probes)"
+# Orchestrator: no -e — run_task isolates child failures and summary reports them at the end
+# (error-mode conventions: lib/bench.sh). This is the composition the network SUITE runs
+# (packages/schema suites.ts points at it); benchmark:network:all keeps the previous
+# fast-cli + network-loopback composition for manual runs.
+set -uo pipefail
+REPO_ROOT="$(git -C "$(dirname "${BASH_SOURCE[0]}")" rev-parse --show-toplevel)"
+source "${REPO_ROOT}/lib/bench.sh"
+
+echo "========================================"
+echo "  NETWORK BENCHMARKS (iperf composition)"
+echo "========================================"
+
+# The catalogued metrics: iperf3 against localhost isolates the sandbox's network stack (virtio vs
+# gVisor netstack vs host namespaces) from Internet weather, and iperf3 against the closest curated
+# public server measures WAN throughput with real byte accounting — the successors to the
+# network-loopback and fast-cli leaves (run 29937467891: the Chrome-driven fast.com measurement was
+# structurally unreliable on fast datacenter paths; both old leaves remain runnable manually via
+# benchmark:network:all).
+ensure_pts || true
+
+run_task benchmark:network:pts:iperf-localhost
+run_task benchmark:network:pts:iperf-wan
+
+# Tolerant probes (raw JSON provenance, no catalogued metrics): where does this sandbox's traffic
+# actually go, and how fast? Endpoint-specific connection timings and a small GitHub control
+# transfer for diagnosis.
+run_task benchmark:network:latency
+run_task benchmark:network:dns
+run_task benchmark:network:download
+
+summary

--- a/LEADERBOARD.md
+++ b/LEADERBOARD.md
@@ -221,20 +221,6 @@ _Daytona (VM) leads · ~1.2× Blaxel on median (higher is better)._
 
 ## network
 
-### Loopback TCP (10GB) _(headline)_
-
-Seconds · lower is better
-
-_Blaxel leads · Daytona (VM) is ~1.1× higher (lower is better)._
-
-| Rank | Provider | Loopback TCP (10GB) (Seconds) | 95% bootstrap interval | n | Note |
-| ---: | --- | ---: | ---: | ---: | --- |
-| 1 | Blaxel | 4.393 | 4.253 – 4.533 | 2 | — |
-| 2 | Daytona (VM) | 4.785 | 4.675 – 4.895 | 2 | n too small |
-| 3 | Novita | 8.637 | 8.39 – 8.884 | 2 | n too small |
-| 4 | E2B | 10.65 | 10.16 – 11.15 | 2 | n too small |
-| 5 | Modal (gVisor) | 43.16 | 41.41 – 44.9 | 2 | n too small |
-
 ### fast.com download
 
 Mbit/s · higher is better
@@ -282,6 +268,20 @@ _Modal (gVisor) leads · ~255.0× Daytona (VM) on median (higher is better)._
 | 1 | Modal (gVisor) | 25.5 | 18 – 33 | 2 |
 | 2 | Daytona (VM) | 0.1 | — | 1 |
 | 3 | Blaxel | 0.075 | 0.068 – 0.082 | 2 |
+
+### Loopback TCP (10GB)
+
+Seconds · lower is better
+
+_Blaxel leads · Daytona (VM) is ~1.1× higher (lower is better)._
+
+| Rank | Provider | Loopback TCP (10GB) (Seconds) | 95% bootstrap interval | n | Note |
+| ---: | --- | ---: | ---: | ---: | --- |
+| 1 | Blaxel | 4.393 | 4.253 – 4.533 | 2 | — |
+| 2 | Daytona (VM) | 4.785 | 4.675 – 4.895 | 2 | n too small |
+| 3 | Novita | 8.637 | 8.39 – 8.884 | 2 | n too small |
+| 4 | E2B | 10.65 | 10.16 – 11.15 | 2 | n too small |
+| 5 | Modal (gVisor) | 43.16 | 41.41 – 44.9 | 2 | n too small |
 
 ## system
 
@@ -697,11 +697,6 @@ correction is applied across providers or metrics.
 | memory | STREAM Scale | Blaxel | 0.33 (n too small) | 0.097 |
 | memory | STREAM Scale | Novita | 0.33 (n too small) | 0.097 |
 | memory | STREAM Scale | E2B | 0.33 (n too small) | 0.097 |
-| network | Loopback TCP (10GB) | Blaxel | — | — |
-| network | Loopback TCP (10GB) | Daytona (VM) | 0.33 (n too small) | 0.097 |
-| network | Loopback TCP (10GB) | Novita | 0.33 (n too small) | 0.097 |
-| network | Loopback TCP (10GB) | E2B | 0.33 (n too small) | 0.097 |
-| network | Loopback TCP (10GB) | Modal (gVisor) | 0.33 (n too small) | 0.097 |
 | network | fast.com download | Modal (gVisor) | — | — |
 | network | fast.com download | Daytona (VM) | — | — |
 | network | fast.com download | Blaxel | — | — |
@@ -714,6 +709,11 @@ correction is applied across providers or metrics.
 | network | fast.com upload | Modal (gVisor) | — | — |
 | network | fast.com upload | Daytona (VM) | — | — |
 | network | fast.com upload | Blaxel | — | — |
+| network | Loopback TCP (10GB) | Blaxel | — | — |
+| network | Loopback TCP (10GB) | Daytona (VM) | 0.33 (n too small) | 0.097 |
+| network | Loopback TCP (10GB) | Novita | 0.33 (n too small) | 0.097 |
+| network | Loopback TCP (10GB) | E2B | 0.33 (n too small) | 0.097 |
+| network | Loopback TCP (10GB) | Modal (gVisor) | 0.33 (n too small) | 0.097 |
 | system | PyBench | Blaxel | — | — |
 | system | Git common operations | Daytona (VM) | — | — |
 | system | Git common operations | Blaxel | 0.33 (n too small) | 0.097 |

--- a/biome.json
+++ b/biome.json
@@ -7,7 +7,8 @@
     "useIgnoreFile": true
   },
   "files": {
-    "ignoreUnknown": true
+    "ignoreUnknown": true,
+    "maxSize": 2097152
   },
   "formatter": {
     "enabled": true,

--- a/packages/schema/scripts/catalog/parse.ts
+++ b/packages/schema/scripts/catalog/parse.ts
@@ -19,8 +19,13 @@ const outputBuilder = new CompactBuilderFactory({
 }) as unknown as X2jOptions["OutputBuilder"];
 const parser = new XMLParser({ OutputBuilder: outputBuilder });
 
-/** One `<Option>/<Menu>/<Entry>`: a selectable benchmark argument value. `Message` is advisory. */
-export const entrySchema = type({ Name: "string", Value: "string", "Message?": "string" });
+/**
+ * One `<Option>/<Menu>/<Entry>`: a selectable benchmark argument value. `Message` is advisory.
+ * `Value` is optional, matching PTS: an entry may carry no `<Value>` at all (iperf's `TCP` entry —
+ * the choice contributes NO argument, unlike its `-u` UDP siblings), and PTS still selects it by
+ * name. Synthesis treats a missing value as `""` wherever it needs the argument text.
+ */
+export const entrySchema = type({ Name: "string", "Value?": "string", "Message?": "string" });
 export type PtsEntry = typeof entrySchema.infer;
 
 /** One `<TestSettings>/<Option>`: a tunable axis (e.g. Resolution) with its menu of `<Entry>` values. */

--- a/packages/schema/scripts/catalog/synthesize.ts
+++ b/packages/schema/scripts/catalog/synthesize.ts
@@ -44,16 +44,33 @@ export function cartesian<T>(groups: readonly (readonly T[])[]): T[][] {
 }
 
 /**
- * The deterministic runtime default for a menu-less virtual axis. PTS expands these axes from the
- * machine at run time (pts_test_run_options.php); the only entry that exists on EVERY machine — and
- * the one our producer tasks pin via PRESET_OPTIONS — is the axis's default: `auto-disk-mount-points`
- * always lists `Default Test Directory` (value ``) first. Any other menu-less identifier is
- * machine-dependent with no stable default, so it throws rather than guessing (silently enumerating a
- * host's mount points would generate machine-dependent catalog bytes and break the drift gate).
+ * The deterministic runtime entry for a menu-less axis. Two shapes land here:
+ *
+ *   * PTS virtual axes expanded from the machine at run time (pts_test_run_options.php): the only
+ *     entry that exists on EVERY machine — and the one our producer tasks pin via PRESET_OPTIONS —
+ *     is the axis's default: `auto-disk-mount-points` always lists `Default Test Directory`
+ *     (value ``) first.
+ *   * Free-TEXT options (iperf's Server Address / Server Port prompt for arbitrary text; the
+ *     runtime `<Description>` embeds whatever was typed). Free text cannot be enumerated, so the
+ *     catalogued entry is the ONE value the producer task pins via PRESET_OPTIONS — `localhost`
+ *     (the network leaf's self-contained topology) and `5201` (iperf3's default port, the same
+ *     leaf's pin). Exactly the fio Disk Target contract: a run pinned to any other value simply
+ *     lands uncatalogued instead of silently mismapping.
+ *
+ * Any other menu-less identifier is machine-dependent with no stable default, so it throws rather
+ * than guessing (silently enumerating a host's mount points would generate machine-dependent
+ * catalog bytes and break the drift gate).
  */
 function virtualEntries(option: PtsOption): readonly PtsEntry[] {
 	if (option.Identifier === "auto-disk-mount-points") {
 		return [{ Name: "Default Test Directory", Value: "" }];
+	}
+	if (option.Identifier === "server-address") {
+		return [{ Name: "localhost", Value: "localhost" }];
+	}
+	// iperf's Server Port axis (upstream reuses the generic `positive-number` identifier for it).
+	if (option.Identifier === "positive-number" && option.DisplayName === "Server Port") {
+		return [{ Name: "5201", Value: "5201" }];
 	}
 	throw new Error(
 		`option "${option.DisplayName}" has no <Menu> and no known runtime default (identifier "${option.Identifier ?? "(absent)"}") — teach virtualEntries its expansion`,
@@ -138,7 +155,9 @@ export function synthesizeResults(profile: PtsProfile): SynthesizedMetric[] {
 		const base = combination
 			.map(({ option, entry }) => `${option.DisplayName}: ${entry.Name}`)
 			.join(" - ");
-		const values = combination.map(({ entry }) => entry.Value);
+		// A `<Value>`-less entry (iperf's TCP) contributes no argument text; normalize to "" so the
+		// MatchToTestArguments inverse check below never sees undefined.
+		const values = combination.map(({ entry }) => entry.Value ?? "");
 		for (const parser of candidateParsers(profile.parsers, values)) {
 			const description = describe(base, parser);
 			const effectiveScale = parser.ResultScale ?? profile.info.ResultScale;

--- a/packages/schema/scripts/fetch-profiles.ts
+++ b/packages/schema/scripts/fetch-profiles.ts
@@ -54,10 +54,20 @@ const PROFILES = [
 	// Network dimension — single-result (sys.time monitor, no <Option> matrix), so it generates one
 	// description-less wildcard entry (zero byte-match risk). 1.0.3 carries the repo's deterministic
 	// netcat-openbsd runner override (install.sh) — the upstream dd|nc runner races its listener.
+	// Retained for manual runs; the network SUITE now measures the localhost stack via iperf below.
 	"network-loopback-1.0.3",
 	// Network dimension — a real Internet transfer through Netflix's fast.com CDN. The profile emits
-	// download/upload throughput plus idle/loaded latency from fast-cli's JSON output.
+	// download/upload throughput plus idle/loaded latency from fast-cli's JSON output. Retained for
+	// manual runs; the network SUITE now measures WAN throughput via local/iperf-wan (run 29937467891:
+	// the Chrome-driven fast.com measurement was structurally unreliable on fast datacenter paths).
 	"fast-cli-1.0.0",
+	// Network dimension — iperf3 driven as a client against a runner-local server. The vendored copy
+	// is a deliberate LOCALHOST SUBSET of upstream (see IPERF_LOCALHOST_TEST_SETTINGS below): the
+	// free-text server-address/port axes become pinned single-entry menus (the catalog synthesizer
+	// cannot enumerate free text, and the pinned menus make the localhost topology part of the metric
+	// identity) and the duration/test/parallel menus are trimmed to the two combinations the network
+	// suite runs (TCP 10s, -P 1 and -P 10).
+	"iperf-1.2.0",
 	// System dimension — PostgreSQL via its integrated pgbench, fully in-sandbox (the profile builds
 	// postgres 17.0 and runs server + client locally, so every provider measures the same topology).
 	// The producer pins one (Scaling Factor, Clients) point per mode via PRESET_OPTIONS; two parsers
@@ -78,8 +88,115 @@ const TWO_TRIAL_PROFILES = new Set([
 	"pybench-1.1.3",
 	"sqlite-speedtest-1.0.1",
 	"fast-cli-1.0.0",
+	"iperf-1.2.0",
 	"git-1.1.0",
 ]);
+
+// The pinned <TestSettings> block for the vendored iperf localhost subset. Kept in the vendoring
+// tool (like the TimesToRun patch) so a refresh stays byte-for-byte idempotent instead of silently
+// restoring upstream's free-text server axes and full duration/test/parallel matrix. Every entry
+// carries an explicit <Value> (the catalog parser requires one; " " is the pgbench precedent for a
+// no-argument entry).
+const IPERF_LOCALHOST_TEST_SETTINGS = `  <TestSettings>
+    <Default>
+      <PostArguments>-V -f m </PostArguments>
+    </Default>
+    <Option>
+      <DisplayName>Server Address</DisplayName>
+      <Identifier>server-address</Identifier>
+      <ArgumentPrefix>-c </ArgumentPrefix>
+      <Menu>
+        <Entry>
+          <Name>localhost</Name>
+          <Value>localhost</Value>
+        </Entry>
+      </Menu>
+    </Option>
+    <Option>
+      <DisplayName>Server Port</DisplayName>
+      <Identifier>positive-number</Identifier>
+      <ArgumentPrefix>-p </ArgumentPrefix>
+      <Menu>
+        <Entry>
+          <Name>5201</Name>
+          <Value>5201</Value>
+        </Entry>
+      </Menu>
+    </Option>
+    <Option>
+      <DisplayName>Duration</DisplayName>
+      <Identifier>duration</Identifier>
+      <ArgumentPrefix>-t </ArgumentPrefix>
+      <Menu>
+        <Entry>
+          <Name>10 Seconds</Name>
+          <Value>10</Value>
+        </Entry>
+      </Menu>
+    </Option>
+    <Option>
+      <DisplayName>Test</DisplayName>
+      <Identifier>test</Identifier>
+      <Menu>
+        <Entry>
+          <Name>TCP</Name>
+          <Value> </Value>
+        </Entry>
+      </Menu>
+    </Option>
+    <Option>
+      <DisplayName>Parallel</DisplayName>
+      <Identifier>parallel</Identifier>
+      <ArgumentPrefix>-P </ArgumentPrefix>
+      <Menu>
+        <Entry>
+          <Name>1</Name>
+          <Value>1</Value>
+        </Entry>
+        <Entry>
+          <Name>10</Name>
+          <Value>10</Value>
+        </Entry>
+      </Menu>
+    </Option>
+  </TestSettings>`;
+
+// Vendored-subset description: upstream's "requires you have access to an iperf server" is wrong for
+// the self-hosted localhost runner, and the Description feeds the catalog verbatim.
+const IPERF_LOCALHOST_DESCRIPTION =
+	"iPerf is a network bandwidth throughput testing software. This vendored subset benchmarks the " +
+	"sandbox's own network stack: the profile's runner starts a local iperf3 server and the client " +
+	"measures TCP throughput over localhost, so the result isolates virtualization/network-stack " +
+	"overhead from Internet weather.";
+
+/**
+ * Rewrite upstream iperf-1.2.0 into the repo's localhost subset (see the PROFILES entry). Applied
+ * after the TimesToRun patch; each replacement is anchored so a silent upstream reshape fails loudly
+ * here rather than vendoring a half-patched profile.
+ */
+function patchIperfLocalhostSubset(contents: string): string {
+	const patched = contents
+		.replace(/<Description>[\s\S]*?<\/Description>/, () => {
+			return `<Description>${IPERF_LOCALHOST_DESCRIPTION}</Description>`;
+		})
+		// The self-hosted runner makes upstream's "ensure you have a server running" prompt noise.
+		.replace(/\n\s*<PreInstallMessage>[\s\S]*?<\/PreInstallMessage>/, "")
+		.replace(/ {2}<TestSettings>[\s\S]*?<\/TestSettings>/, () => IPERF_LOCALHOST_TEST_SETTINGS);
+	for (const marker of [IPERF_LOCALHOST_DESCRIPTION, "<Name>10 Seconds</Name>"]) {
+		if (!patched.includes(marker)) {
+			throw new Error(`iperf-1.2.0 subset patch did not land (missing ${JSON.stringify(marker)})`);
+		}
+	}
+	if (patched.includes("PreInstallMessage")) {
+		throw new Error("iperf-1.2.0 subset patch left the PreInstallMessage behind");
+	}
+	return patched;
+}
+
+// Repo-local test-definition transforms beyond the TimesToRun patch, keyed by profile.
+const TEST_DEFINITION_PATCHES: Record<string, (contents: string) => string> = {
+	"iperf-1.2.0": patchIperfLocalhostSubset,
+};
 
 // Only these definition files feed the generator; siblings (downloads.xml, install.sh) are ignored.
 // `required` distinguishes the essential `test-definition.xml` (a missing one is a hard failure, not
@@ -151,6 +268,9 @@ async function vendorProfile(commitSha: string, profile: string): Promise<void> 
 			let contents = await fetchBlobText(sha);
 			if (name === "test-definition.xml" && TWO_TRIAL_PROFILES.has(profile)) {
 				contents = contents.replace(/<TimesToRun>\d+<\/TimesToRun>/, "<TimesToRun>2</TimesToRun>");
+			}
+			if (name === "test-definition.xml") {
+				contents = TEST_DEFINITION_PATCHES[profile]?.(contents) ?? contents;
 			}
 			await Bun.write(`${OUT_DIR}/${profile}/${name}`, contents);
 			console.log(`✓ ${profile}/${name}`);

--- a/packages/schema/scripts/fetch-profiles.ts
+++ b/packages/schema/scripts/fetch-profiles.ts
@@ -61,12 +61,14 @@ const PROFILES = [
 	// manual runs; the network SUITE now measures WAN throughput via local/iperf-wan (run 29937467891:
 	// the Chrome-driven fast.com measurement was structurally unreliable on fast datacenter paths).
 	"fast-cli-1.0.0",
-	// Network dimension — iperf3 driven as a client against a runner-local server. The vendored copy
-	// is a deliberate LOCALHOST SUBSET of upstream (see IPERF_LOCALHOST_TEST_SETTINGS below): the
-	// free-text server-address/port axes become pinned single-entry menus (the catalog synthesizer
-	// cannot enumerate free text, and the pinned menus make the localhost topology part of the metric
-	// identity) and the duration/test/parallel menus are trimmed to the two combinations the network
-	// suite runs (TCP 10s, -P 1 and -P 10).
+	// Network dimension — iperf3 driven as a client against a runner-local server (the localhost
+	// leaf) and, via local/iperf-wan, against curated public servers. Vendored BYTE-IDENTICAL to
+	// upstream (the fio-2.1.0 precedent: full option matrix enumerated into the catalog, the
+	// producer pins one combination per scenario via PRESET_OPTIONS, unrun combinations never
+	// receive samples). The free-text server-address/port axes are catalogued through
+	// virtualEntries' deterministic pins (scripts/catalog/synthesize.ts); TimesToRun stays
+	// upstream's 3 — inert for published runs, where the harness preamble pins FORCE_TIMES_TO_RUN
+	// from Suite.ptsTimesToRun (k=2) and lib/bench.sh pins 1 for bare runs.
 	"iperf-1.2.0",
 	// System dimension — PostgreSQL via its integrated pgbench, fully in-sandbox (the profile builds
 	// postgres 17.0 and runs server + client locally, so every provider measures the same topology).
@@ -88,115 +90,8 @@ const TWO_TRIAL_PROFILES = new Set([
 	"pybench-1.1.3",
 	"sqlite-speedtest-1.0.1",
 	"fast-cli-1.0.0",
-	"iperf-1.2.0",
 	"git-1.1.0",
 ]);
-
-// The pinned <TestSettings> block for the vendored iperf localhost subset. Kept in the vendoring
-// tool (like the TimesToRun patch) so a refresh stays byte-for-byte idempotent instead of silently
-// restoring upstream's free-text server axes and full duration/test/parallel matrix. Every entry
-// carries an explicit <Value> (the catalog parser requires one; " " is the pgbench precedent for a
-// no-argument entry).
-const IPERF_LOCALHOST_TEST_SETTINGS = `  <TestSettings>
-    <Default>
-      <PostArguments>-V -f m </PostArguments>
-    </Default>
-    <Option>
-      <DisplayName>Server Address</DisplayName>
-      <Identifier>server-address</Identifier>
-      <ArgumentPrefix>-c </ArgumentPrefix>
-      <Menu>
-        <Entry>
-          <Name>localhost</Name>
-          <Value>localhost</Value>
-        </Entry>
-      </Menu>
-    </Option>
-    <Option>
-      <DisplayName>Server Port</DisplayName>
-      <Identifier>positive-number</Identifier>
-      <ArgumentPrefix>-p </ArgumentPrefix>
-      <Menu>
-        <Entry>
-          <Name>5201</Name>
-          <Value>5201</Value>
-        </Entry>
-      </Menu>
-    </Option>
-    <Option>
-      <DisplayName>Duration</DisplayName>
-      <Identifier>duration</Identifier>
-      <ArgumentPrefix>-t </ArgumentPrefix>
-      <Menu>
-        <Entry>
-          <Name>10 Seconds</Name>
-          <Value>10</Value>
-        </Entry>
-      </Menu>
-    </Option>
-    <Option>
-      <DisplayName>Test</DisplayName>
-      <Identifier>test</Identifier>
-      <Menu>
-        <Entry>
-          <Name>TCP</Name>
-          <Value> </Value>
-        </Entry>
-      </Menu>
-    </Option>
-    <Option>
-      <DisplayName>Parallel</DisplayName>
-      <Identifier>parallel</Identifier>
-      <ArgumentPrefix>-P </ArgumentPrefix>
-      <Menu>
-        <Entry>
-          <Name>1</Name>
-          <Value>1</Value>
-        </Entry>
-        <Entry>
-          <Name>10</Name>
-          <Value>10</Value>
-        </Entry>
-      </Menu>
-    </Option>
-  </TestSettings>`;
-
-// Vendored-subset description: upstream's "requires you have access to an iperf server" is wrong for
-// the self-hosted localhost runner, and the Description feeds the catalog verbatim.
-const IPERF_LOCALHOST_DESCRIPTION =
-	"iPerf is a network bandwidth throughput testing software. This vendored subset benchmarks the " +
-	"sandbox's own network stack: the profile's runner starts a local iperf3 server and the client " +
-	"measures TCP throughput over localhost, so the result isolates virtualization/network-stack " +
-	"overhead from Internet weather.";
-
-/**
- * Rewrite upstream iperf-1.2.0 into the repo's localhost subset (see the PROFILES entry). Applied
- * after the TimesToRun patch; each replacement is anchored so a silent upstream reshape fails loudly
- * here rather than vendoring a half-patched profile.
- */
-function patchIperfLocalhostSubset(contents: string): string {
-	const patched = contents
-		.replace(/<Description>[\s\S]*?<\/Description>/, () => {
-			return `<Description>${IPERF_LOCALHOST_DESCRIPTION}</Description>`;
-		})
-		// The self-hosted runner makes upstream's "ensure you have a server running" prompt noise.
-		.replace(/\n\s*<PreInstallMessage>[\s\S]*?<\/PreInstallMessage>/, "")
-		.replace(/ {2}<TestSettings>[\s\S]*?<\/TestSettings>/, () => IPERF_LOCALHOST_TEST_SETTINGS);
-	for (const marker of [IPERF_LOCALHOST_DESCRIPTION, "<Name>10 Seconds</Name>"]) {
-		if (!patched.includes(marker)) {
-			throw new Error(`iperf-1.2.0 subset patch did not land (missing ${JSON.stringify(marker)})`);
-		}
-	}
-	if (patched.includes("PreInstallMessage")) {
-		throw new Error("iperf-1.2.0 subset patch left the PreInstallMessage behind");
-	}
-	return patched;
-}
-
-// Repo-local test-definition transforms beyond the TimesToRun patch, keyed by profile.
-const TEST_DEFINITION_PATCHES: Record<string, (contents: string) => string> = {
-	"iperf-1.2.0": patchIperfLocalhostSubset,
-};
 
 // Only these definition files feed the generator; siblings (downloads.xml, install.sh) are ignored.
 // `required` distinguishes the essential `test-definition.xml` (a missing one is a hard failure, not
@@ -268,9 +163,6 @@ async function vendorProfile(commitSha: string, profile: string): Promise<void> 
 			let contents = await fetchBlobText(sha);
 			if (name === "test-definition.xml" && TWO_TRIAL_PROFILES.has(profile)) {
 				contents = contents.replace(/<TimesToRun>\d+<\/TimesToRun>/, "<TimesToRun>2</TimesToRun>");
-			}
-			if (name === "test-definition.xml") {
-				contents = TEST_DEFINITION_PATCHES[profile]?.(contents) ?? contents;
 			}
 			await Bun.write(`${OUT_DIR}/${profile}/${name}`, contents);
 			console.log(`✓ ${profile}/${name}`);

--- a/packages/schema/src/catalog.test.ts
+++ b/packages/schema/src/catalog.test.ts
@@ -119,12 +119,38 @@ describe("metric catalog", () => {
 		expect(getMetric("not_a_metric")).toBeUndefined();
 	});
 
-	it("keeps the controlled Loopback TCP measurement as the network headline", () => {
+	it("keeps the controlled localhost iperf3 measurement as the network headline", () => {
 		const metric = headlineMetric("network");
-		expect(metric.id).toBe("network_loopback_seconds");
-		expect(metric.label).toBe("Loopback TCP (10GB)");
-		expect(metric.direction).toBe("LIB");
-		expect(metric.pts).toEqual({ test: "pts/network-loopback" });
+		expect(metric.id).toBe(
+			"iperf_server_address_localhost_server_port_5201_duration_10_seconds_test_tcp_parallel_1",
+		);
+		expect(metric.label).toBe("iperf3 loopback TCP, 1 stream");
+		expect(metric.direction).toBe("HIB");
+		// The vendored subset's pinned axes travel in the runtime description the catalog joins on.
+		expect(metric.pts).toEqual({
+			test: "pts/iperf",
+			description:
+				"Server Address: localhost - Server Port: 5201 - Duration: 10 Seconds - Test: TCP - Parallel: 1",
+		});
+	});
+
+	it("resolves the WAN iperf3 pair via the local/ join key with per-direction descriptions", () => {
+		const download = getMetric("iperf_wan_direction_download");
+		const upload = getMetric("iperf_wan_direction_upload");
+		expect(download?.pts).toEqual({ test: "local/iperf-wan", description: "Direction: Download" });
+		expect(upload?.pts).toEqual({ test: "local/iperf-wan", description: "Direction: Upload" });
+		expect(download?.direction).toBe("HIB");
+		expect(upload?.label).toBe("iperf3 WAN upload");
+	});
+
+	it("keeps the retired-from-suite network profiles catalogued for manual runs (sans headline)", () => {
+		// fast-cli and network-loopback left the SUITE, not the repo: their profiles stay vendored and
+		// manually runnable, so their metrics stay catalogued — but the network headline moved to the
+		// localhost iperf3 metric above.
+		const loopback = getMetric("network_loopback_seconds");
+		expect(loopback?.label).toBe("Loopback TCP (10GB)");
+		expect(loopback?.headline).toBe(false);
+		expect(getMetric("fast_cli_internet_download_speed")?.label).toBe("fast.com download");
 	});
 
 	it("resolves fio's scale-pinned twin metrics for one description (disk dimension)", () => {

--- a/packages/schema/src/pts-generated.ts
+++ b/packages/schema/src/pts-generated.ts
@@ -17366,6 +17366,64 @@ const chunk4: MetricDef[] = [
 		sourceUrl: "https://github.com/ColinIanKing/stress-ng",
 	},
 	{
+		id: "iperf_server_address_localhost_server_port_5201_duration_10_seconds_test_tcp_parallel_1",
+		dimension: "network",
+		unit: "Mbits/sec",
+		direction: "HIB",
+		headline: false,
+		label:
+			"iPerf - Server Address: localhost - Server Port: 5201 - Duration: 10 Seconds - Test: TCP - Parallel: 1",
+		description:
+			"iPerf is a network bandwidth throughput testing software. This vendored subset benchmarks the sandbox's own network stack: the profile's runner starts a local iperf3 server and the client measures TCP throughput over localhost, so the result isolates virtualization/network-stack overhead from Internet weather.",
+		pts: {
+			test: "pts/iperf",
+			description:
+				"Server Address: localhost - Server Port: 5201 - Duration: 10 Seconds - Test: TCP - Parallel: 1",
+		},
+		sourceUrl: "https://software.es.net/iperf/",
+	},
+	{
+		id: "iperf_server_address_localhost_server_port_5201_duration_10_seconds_test_tcp_parallel_10",
+		dimension: "network",
+		unit: "Mbits/sec",
+		direction: "HIB",
+		headline: false,
+		label:
+			"iPerf - Server Address: localhost - Server Port: 5201 - Duration: 10 Seconds - Test: TCP - Parallel: 10",
+		description:
+			"iPerf is a network bandwidth throughput testing software. This vendored subset benchmarks the sandbox's own network stack: the profile's runner starts a local iperf3 server and the client measures TCP throughput over localhost, so the result isolates virtualization/network-stack overhead from Internet weather.",
+		pts: {
+			test: "pts/iperf",
+			description:
+				"Server Address: localhost - Server Port: 5201 - Duration: 10 Seconds - Test: TCP - Parallel: 10",
+		},
+		sourceUrl: "https://software.es.net/iperf/",
+	},
+	{
+		id: "iperf_wan_direction_download",
+		dimension: "network",
+		unit: "Mbits/sec",
+		direction: "HIB",
+		headline: false,
+		label: "iPerf WAN - Direction: Download",
+		description:
+			"Measures sustained WAN TCP throughput with iperf3 against the closest reachable server from a curated public list (servers.json, committed with this profile). The runner probes TCP-connect RTT to every listed server at run time, picks the lowest-RTT reachable non-backup server, retries across its port range on single-client busy collisions, and records the chosen server per trial as provenance. Eight parallel streams so high bandwidth-delay-product paths are not understated by a single TCP congestion window; the reported figure is receiver-side goodput.",
+		pts: { test: "local/iperf-wan", description: "Direction: Download" },
+		sourceUrl: "https://software.es.net/iperf/",
+	},
+	{
+		id: "iperf_wan_direction_upload",
+		dimension: "network",
+		unit: "Mbits/sec",
+		direction: "HIB",
+		headline: false,
+		label: "iPerf WAN - Direction: Upload",
+		description:
+			"Measures sustained WAN TCP throughput with iperf3 against the closest reachable server from a curated public list (servers.json, committed with this profile). The runner probes TCP-connect RTT to every listed server at run time, picks the lowest-RTT reachable non-backup server, retries across its port range on single-client busy collisions, and records the chosen server per trial as provenance. Eight parallel streams so high bandwidth-delay-product paths are not understated by a single TCP congestion window; the reported figure is receiver-side goodput.",
+		pts: { test: "local/iperf-wan", description: "Direction: Upload" },
+		sourceUrl: "https://software.es.net/iperf/",
+	},
+	{
 		id: "network_loopback_seconds",
 		dimension: "network",
 		unit: "Seconds",
@@ -17811,6 +17869,9 @@ const chunk4: MetricDef[] = [
 		},
 		sourceUrl: "https://www.postgresql.org/",
 	},
+];
+
+const chunk5: MetricDef[] = [
 	{
 		id: "pgbench_scaling_factor_10000_clients_800_mode_read_only",
 		dimension: "system",
@@ -17871,9 +17932,6 @@ const chunk4: MetricDef[] = [
 		},
 		sourceUrl: "https://www.postgresql.org/",
 	},
-];
-
-const chunk5: MetricDef[] = [
 	{
 		id: "pgbench_scaling_factor_1000_clients_1000_mode_read_only",
 		dimension: "system",

--- a/packages/schema/src/pts-generated.ts
+++ b/packages/schema/src/pts-generated.ts
@@ -17374,7 +17374,7 @@ const chunk4: MetricDef[] = [
 		label:
 			"iPerf - Server Address: localhost - Server Port: 5201 - Duration: 10 Seconds - Test: TCP - Parallel: 1",
 		description:
-			"iPerf is a network bandwidth throughput testing software. This vendored subset benchmarks the sandbox's own network stack: the profile's runner starts a local iperf3 server and the client measures TCP throughput over localhost, so the result isolates virtualization/network-stack overhead from Internet weather.",
+			"iPerf is a network bandwidth throughput testing software. This test profile is used for automated testing of an iperf client and requires you have access to an iperf server.",
 		pts: {
 			test: "pts/iperf",
 			description:
@@ -17391,11 +17391,2700 @@ const chunk4: MetricDef[] = [
 		label:
 			"iPerf - Server Address: localhost - Server Port: 5201 - Duration: 10 Seconds - Test: TCP - Parallel: 10",
 		description:
-			"iPerf is a network bandwidth throughput testing software. This vendored subset benchmarks the sandbox's own network stack: the profile's runner starts a local iperf3 server and the client measures TCP throughput over localhost, so the result isolates virtualization/network-stack overhead from Internet weather.",
+			"iPerf is a network bandwidth throughput testing software. This test profile is used for automated testing of an iperf client and requires you have access to an iperf server.",
 		pts: {
 			test: "pts/iperf",
 			description:
 				"Server Address: localhost - Server Port: 5201 - Duration: 10 Seconds - Test: TCP - Parallel: 10",
+		},
+		sourceUrl: "https://software.es.net/iperf/",
+	},
+	{
+		id: "iperf_server_address_localhost_server_port_5201_duration_10_seconds_test_tcp_parallel_128",
+		dimension: "network",
+		unit: "Mbits/sec",
+		direction: "HIB",
+		headline: false,
+		label:
+			"iPerf - Server Address: localhost - Server Port: 5201 - Duration: 10 Seconds - Test: TCP - Parallel: 128",
+		description:
+			"iPerf is a network bandwidth throughput testing software. This test profile is used for automated testing of an iperf client and requires you have access to an iperf server.",
+		pts: {
+			test: "pts/iperf",
+			description:
+				"Server Address: localhost - Server Port: 5201 - Duration: 10 Seconds - Test: TCP - Parallel: 128",
+		},
+		sourceUrl: "https://software.es.net/iperf/",
+	},
+	{
+		id: "iperf_server_address_localhost_server_port_5201_duration_10_seconds_test_tcp_parallel_20",
+		dimension: "network",
+		unit: "Mbits/sec",
+		direction: "HIB",
+		headline: false,
+		label:
+			"iPerf - Server Address: localhost - Server Port: 5201 - Duration: 10 Seconds - Test: TCP - Parallel: 20",
+		description:
+			"iPerf is a network bandwidth throughput testing software. This test profile is used for automated testing of an iperf client and requires you have access to an iperf server.",
+		pts: {
+			test: "pts/iperf",
+			description:
+				"Server Address: localhost - Server Port: 5201 - Duration: 10 Seconds - Test: TCP - Parallel: 20",
+		},
+		sourceUrl: "https://software.es.net/iperf/",
+	},
+	{
+		id: "iperf_server_address_localhost_server_port_5201_duration_10_seconds_test_tcp_parallel_256",
+		dimension: "network",
+		unit: "Mbits/sec",
+		direction: "HIB",
+		headline: false,
+		label:
+			"iPerf - Server Address: localhost - Server Port: 5201 - Duration: 10 Seconds - Test: TCP - Parallel: 256",
+		description:
+			"iPerf is a network bandwidth throughput testing software. This test profile is used for automated testing of an iperf client and requires you have access to an iperf server.",
+		pts: {
+			test: "pts/iperf",
+			description:
+				"Server Address: localhost - Server Port: 5201 - Duration: 10 Seconds - Test: TCP - Parallel: 256",
+		},
+		sourceUrl: "https://software.es.net/iperf/",
+	},
+	{
+		id: "iperf_server_address_localhost_server_port_5201_duration_10_seconds_test_tcp_parallel_32",
+		dimension: "network",
+		unit: "Mbits/sec",
+		direction: "HIB",
+		headline: false,
+		label:
+			"iPerf - Server Address: localhost - Server Port: 5201 - Duration: 10 Seconds - Test: TCP - Parallel: 32",
+		description:
+			"iPerf is a network bandwidth throughput testing software. This test profile is used for automated testing of an iperf client and requires you have access to an iperf server.",
+		pts: {
+			test: "pts/iperf",
+			description:
+				"Server Address: localhost - Server Port: 5201 - Duration: 10 Seconds - Test: TCP - Parallel: 32",
+		},
+		sourceUrl: "https://software.es.net/iperf/",
+	},
+	{
+		id: "iperf_server_address_localhost_server_port_5201_duration_10_seconds_test_tcp_parallel_5",
+		dimension: "network",
+		unit: "Mbits/sec",
+		direction: "HIB",
+		headline: false,
+		label:
+			"iPerf - Server Address: localhost - Server Port: 5201 - Duration: 10 Seconds - Test: TCP - Parallel: 5",
+		description:
+			"iPerf is a network bandwidth throughput testing software. This test profile is used for automated testing of an iperf client and requires you have access to an iperf server.",
+		pts: {
+			test: "pts/iperf",
+			description:
+				"Server Address: localhost - Server Port: 5201 - Duration: 10 Seconds - Test: TCP - Parallel: 5",
+		},
+		sourceUrl: "https://software.es.net/iperf/",
+	},
+	{
+		id: "iperf_server_address_localhost_server_port_5201_duration_10_seconds_test_tcp_parallel_64",
+		dimension: "network",
+		unit: "Mbits/sec",
+		direction: "HIB",
+		headline: false,
+		label:
+			"iPerf - Server Address: localhost - Server Port: 5201 - Duration: 10 Seconds - Test: TCP - Parallel: 64",
+		description:
+			"iPerf is a network bandwidth throughput testing software. This test profile is used for automated testing of an iperf client and requires you have access to an iperf server.",
+		pts: {
+			test: "pts/iperf",
+			description:
+				"Server Address: localhost - Server Port: 5201 - Duration: 10 Seconds - Test: TCP - Parallel: 64",
+		},
+		sourceUrl: "https://software.es.net/iperf/",
+	},
+	{
+		id: "iperf_server_address_localhost_server_port_5201_duration_10_seconds_test_udp_10000mbit_objective_parallel_1",
+		dimension: "network",
+		unit: "Mbits/sec",
+		direction: "HIB",
+		headline: false,
+		label:
+			"iPerf - Server Address: localhost - Server Port: 5201 - Duration: 10 Seconds - Test: UDP - 10000Mbit Objective - Parallel: 1",
+		description:
+			"iPerf is a network bandwidth throughput testing software. This test profile is used for automated testing of an iperf client and requires you have access to an iperf server.",
+		pts: {
+			test: "pts/iperf",
+			description:
+				"Server Address: localhost - Server Port: 5201 - Duration: 10 Seconds - Test: UDP - 10000Mbit Objective - Parallel: 1",
+		},
+		sourceUrl: "https://software.es.net/iperf/",
+	},
+	{
+		id: "iperf_server_address_localhost_server_port_5201_duration_10_seconds_test_udp_10000mbit_objective_parallel_10",
+		dimension: "network",
+		unit: "Mbits/sec",
+		direction: "HIB",
+		headline: false,
+		label:
+			"iPerf - Server Address: localhost - Server Port: 5201 - Duration: 10 Seconds - Test: UDP - 10000Mbit Objective - Parallel: 10",
+		description:
+			"iPerf is a network bandwidth throughput testing software. This test profile is used for automated testing of an iperf client and requires you have access to an iperf server.",
+		pts: {
+			test: "pts/iperf",
+			description:
+				"Server Address: localhost - Server Port: 5201 - Duration: 10 Seconds - Test: UDP - 10000Mbit Objective - Parallel: 10",
+		},
+		sourceUrl: "https://software.es.net/iperf/",
+	},
+	{
+		id: "iperf_server_address_localhost_server_port_5201_duration_10_seconds_test_udp_10000mbit_objective_parallel_128",
+		dimension: "network",
+		unit: "Mbits/sec",
+		direction: "HIB",
+		headline: false,
+		label:
+			"iPerf - Server Address: localhost - Server Port: 5201 - Duration: 10 Seconds - Test: UDP - 10000Mbit Objective - Parallel: 128",
+		description:
+			"iPerf is a network bandwidth throughput testing software. This test profile is used for automated testing of an iperf client and requires you have access to an iperf server.",
+		pts: {
+			test: "pts/iperf",
+			description:
+				"Server Address: localhost - Server Port: 5201 - Duration: 10 Seconds - Test: UDP - 10000Mbit Objective - Parallel: 128",
+		},
+		sourceUrl: "https://software.es.net/iperf/",
+	},
+	{
+		id: "iperf_server_address_localhost_server_port_5201_duration_10_seconds_test_udp_10000mbit_objective_parallel_20",
+		dimension: "network",
+		unit: "Mbits/sec",
+		direction: "HIB",
+		headline: false,
+		label:
+			"iPerf - Server Address: localhost - Server Port: 5201 - Duration: 10 Seconds - Test: UDP - 10000Mbit Objective - Parallel: 20",
+		description:
+			"iPerf is a network bandwidth throughput testing software. This test profile is used for automated testing of an iperf client and requires you have access to an iperf server.",
+		pts: {
+			test: "pts/iperf",
+			description:
+				"Server Address: localhost - Server Port: 5201 - Duration: 10 Seconds - Test: UDP - 10000Mbit Objective - Parallel: 20",
+		},
+		sourceUrl: "https://software.es.net/iperf/",
+	},
+	{
+		id: "iperf_server_address_localhost_server_port_5201_duration_10_seconds_test_udp_10000mbit_objective_parallel_256",
+		dimension: "network",
+		unit: "Mbits/sec",
+		direction: "HIB",
+		headline: false,
+		label:
+			"iPerf - Server Address: localhost - Server Port: 5201 - Duration: 10 Seconds - Test: UDP - 10000Mbit Objective - Parallel: 256",
+		description:
+			"iPerf is a network bandwidth throughput testing software. This test profile is used for automated testing of an iperf client and requires you have access to an iperf server.",
+		pts: {
+			test: "pts/iperf",
+			description:
+				"Server Address: localhost - Server Port: 5201 - Duration: 10 Seconds - Test: UDP - 10000Mbit Objective - Parallel: 256",
+		},
+		sourceUrl: "https://software.es.net/iperf/",
+	},
+	{
+		id: "iperf_server_address_localhost_server_port_5201_duration_10_seconds_test_udp_10000mbit_objective_parallel_32",
+		dimension: "network",
+		unit: "Mbits/sec",
+		direction: "HIB",
+		headline: false,
+		label:
+			"iPerf - Server Address: localhost - Server Port: 5201 - Duration: 10 Seconds - Test: UDP - 10000Mbit Objective - Parallel: 32",
+		description:
+			"iPerf is a network bandwidth throughput testing software. This test profile is used for automated testing of an iperf client and requires you have access to an iperf server.",
+		pts: {
+			test: "pts/iperf",
+			description:
+				"Server Address: localhost - Server Port: 5201 - Duration: 10 Seconds - Test: UDP - 10000Mbit Objective - Parallel: 32",
+		},
+		sourceUrl: "https://software.es.net/iperf/",
+	},
+	{
+		id: "iperf_server_address_localhost_server_port_5201_duration_10_seconds_test_udp_10000mbit_objective_parallel_5",
+		dimension: "network",
+		unit: "Mbits/sec",
+		direction: "HIB",
+		headline: false,
+		label:
+			"iPerf - Server Address: localhost - Server Port: 5201 - Duration: 10 Seconds - Test: UDP - 10000Mbit Objective - Parallel: 5",
+		description:
+			"iPerf is a network bandwidth throughput testing software. This test profile is used for automated testing of an iperf client and requires you have access to an iperf server.",
+		pts: {
+			test: "pts/iperf",
+			description:
+				"Server Address: localhost - Server Port: 5201 - Duration: 10 Seconds - Test: UDP - 10000Mbit Objective - Parallel: 5",
+		},
+		sourceUrl: "https://software.es.net/iperf/",
+	},
+	{
+		id: "iperf_server_address_localhost_server_port_5201_duration_10_seconds_test_udp_10000mbit_objective_parallel_64",
+		dimension: "network",
+		unit: "Mbits/sec",
+		direction: "HIB",
+		headline: false,
+		label:
+			"iPerf - Server Address: localhost - Server Port: 5201 - Duration: 10 Seconds - Test: UDP - 10000Mbit Objective - Parallel: 64",
+		description:
+			"iPerf is a network bandwidth throughput testing software. This test profile is used for automated testing of an iperf client and requires you have access to an iperf server.",
+		pts: {
+			test: "pts/iperf",
+			description:
+				"Server Address: localhost - Server Port: 5201 - Duration: 10 Seconds - Test: UDP - 10000Mbit Objective - Parallel: 64",
+		},
+		sourceUrl: "https://software.es.net/iperf/",
+	},
+	{
+		id: "iperf_server_address_localhost_server_port_5201_duration_10_seconds_test_udp_1000mbit_objective_parallel_1",
+		dimension: "network",
+		unit: "Mbits/sec",
+		direction: "HIB",
+		headline: false,
+		label:
+			"iPerf - Server Address: localhost - Server Port: 5201 - Duration: 10 Seconds - Test: UDP - 1000Mbit Objective - Parallel: 1",
+		description:
+			"iPerf is a network bandwidth throughput testing software. This test profile is used for automated testing of an iperf client and requires you have access to an iperf server.",
+		pts: {
+			test: "pts/iperf",
+			description:
+				"Server Address: localhost - Server Port: 5201 - Duration: 10 Seconds - Test: UDP - 1000Mbit Objective - Parallel: 1",
+		},
+		sourceUrl: "https://software.es.net/iperf/",
+	},
+	{
+		id: "iperf_server_address_localhost_server_port_5201_duration_10_seconds_test_udp_1000mbit_objective_parallel_10",
+		dimension: "network",
+		unit: "Mbits/sec",
+		direction: "HIB",
+		headline: false,
+		label:
+			"iPerf - Server Address: localhost - Server Port: 5201 - Duration: 10 Seconds - Test: UDP - 1000Mbit Objective - Parallel: 10",
+		description:
+			"iPerf is a network bandwidth throughput testing software. This test profile is used for automated testing of an iperf client and requires you have access to an iperf server.",
+		pts: {
+			test: "pts/iperf",
+			description:
+				"Server Address: localhost - Server Port: 5201 - Duration: 10 Seconds - Test: UDP - 1000Mbit Objective - Parallel: 10",
+		},
+		sourceUrl: "https://software.es.net/iperf/",
+	},
+	{
+		id: "iperf_server_address_localhost_server_port_5201_duration_10_seconds_test_udp_1000mbit_objective_parallel_128",
+		dimension: "network",
+		unit: "Mbits/sec",
+		direction: "HIB",
+		headline: false,
+		label:
+			"iPerf - Server Address: localhost - Server Port: 5201 - Duration: 10 Seconds - Test: UDP - 1000Mbit Objective - Parallel: 128",
+		description:
+			"iPerf is a network bandwidth throughput testing software. This test profile is used for automated testing of an iperf client and requires you have access to an iperf server.",
+		pts: {
+			test: "pts/iperf",
+			description:
+				"Server Address: localhost - Server Port: 5201 - Duration: 10 Seconds - Test: UDP - 1000Mbit Objective - Parallel: 128",
+		},
+		sourceUrl: "https://software.es.net/iperf/",
+	},
+	{
+		id: "iperf_server_address_localhost_server_port_5201_duration_10_seconds_test_udp_1000mbit_objective_parallel_20",
+		dimension: "network",
+		unit: "Mbits/sec",
+		direction: "HIB",
+		headline: false,
+		label:
+			"iPerf - Server Address: localhost - Server Port: 5201 - Duration: 10 Seconds - Test: UDP - 1000Mbit Objective - Parallel: 20",
+		description:
+			"iPerf is a network bandwidth throughput testing software. This test profile is used for automated testing of an iperf client and requires you have access to an iperf server.",
+		pts: {
+			test: "pts/iperf",
+			description:
+				"Server Address: localhost - Server Port: 5201 - Duration: 10 Seconds - Test: UDP - 1000Mbit Objective - Parallel: 20",
+		},
+		sourceUrl: "https://software.es.net/iperf/",
+	},
+	{
+		id: "iperf_server_address_localhost_server_port_5201_duration_10_seconds_test_udp_1000mbit_objective_parallel_256",
+		dimension: "network",
+		unit: "Mbits/sec",
+		direction: "HIB",
+		headline: false,
+		label:
+			"iPerf - Server Address: localhost - Server Port: 5201 - Duration: 10 Seconds - Test: UDP - 1000Mbit Objective - Parallel: 256",
+		description:
+			"iPerf is a network bandwidth throughput testing software. This test profile is used for automated testing of an iperf client and requires you have access to an iperf server.",
+		pts: {
+			test: "pts/iperf",
+			description:
+				"Server Address: localhost - Server Port: 5201 - Duration: 10 Seconds - Test: UDP - 1000Mbit Objective - Parallel: 256",
+		},
+		sourceUrl: "https://software.es.net/iperf/",
+	},
+	{
+		id: "iperf_server_address_localhost_server_port_5201_duration_10_seconds_test_udp_1000mbit_objective_parallel_32",
+		dimension: "network",
+		unit: "Mbits/sec",
+		direction: "HIB",
+		headline: false,
+		label:
+			"iPerf - Server Address: localhost - Server Port: 5201 - Duration: 10 Seconds - Test: UDP - 1000Mbit Objective - Parallel: 32",
+		description:
+			"iPerf is a network bandwidth throughput testing software. This test profile is used for automated testing of an iperf client and requires you have access to an iperf server.",
+		pts: {
+			test: "pts/iperf",
+			description:
+				"Server Address: localhost - Server Port: 5201 - Duration: 10 Seconds - Test: UDP - 1000Mbit Objective - Parallel: 32",
+		},
+		sourceUrl: "https://software.es.net/iperf/",
+	},
+	{
+		id: "iperf_server_address_localhost_server_port_5201_duration_10_seconds_test_udp_1000mbit_objective_parallel_5",
+		dimension: "network",
+		unit: "Mbits/sec",
+		direction: "HIB",
+		headline: false,
+		label:
+			"iPerf - Server Address: localhost - Server Port: 5201 - Duration: 10 Seconds - Test: UDP - 1000Mbit Objective - Parallel: 5",
+		description:
+			"iPerf is a network bandwidth throughput testing software. This test profile is used for automated testing of an iperf client and requires you have access to an iperf server.",
+		pts: {
+			test: "pts/iperf",
+			description:
+				"Server Address: localhost - Server Port: 5201 - Duration: 10 Seconds - Test: UDP - 1000Mbit Objective - Parallel: 5",
+		},
+		sourceUrl: "https://software.es.net/iperf/",
+	},
+	{
+		id: "iperf_server_address_localhost_server_port_5201_duration_10_seconds_test_udp_1000mbit_objective_parallel_64",
+		dimension: "network",
+		unit: "Mbits/sec",
+		direction: "HIB",
+		headline: false,
+		label:
+			"iPerf - Server Address: localhost - Server Port: 5201 - Duration: 10 Seconds - Test: UDP - 1000Mbit Objective - Parallel: 64",
+		description:
+			"iPerf is a network bandwidth throughput testing software. This test profile is used for automated testing of an iperf client and requires you have access to an iperf server.",
+		pts: {
+			test: "pts/iperf",
+			description:
+				"Server Address: localhost - Server Port: 5201 - Duration: 10 Seconds - Test: UDP - 1000Mbit Objective - Parallel: 64",
+		},
+		sourceUrl: "https://software.es.net/iperf/",
+	},
+	{
+		id: "iperf_server_address_localhost_server_port_5201_duration_10_seconds_test_udp_100mbit_objective_parallel_1",
+		dimension: "network",
+		unit: "Mbits/sec",
+		direction: "HIB",
+		headline: false,
+		label:
+			"iPerf - Server Address: localhost - Server Port: 5201 - Duration: 10 Seconds - Test: UDP - 100Mbit Objective - Parallel: 1",
+		description:
+			"iPerf is a network bandwidth throughput testing software. This test profile is used for automated testing of an iperf client and requires you have access to an iperf server.",
+		pts: {
+			test: "pts/iperf",
+			description:
+				"Server Address: localhost - Server Port: 5201 - Duration: 10 Seconds - Test: UDP - 100Mbit Objective - Parallel: 1",
+		},
+		sourceUrl: "https://software.es.net/iperf/",
+	},
+	{
+		id: "iperf_server_address_localhost_server_port_5201_duration_10_seconds_test_udp_100mbit_objective_parallel_10",
+		dimension: "network",
+		unit: "Mbits/sec",
+		direction: "HIB",
+		headline: false,
+		label:
+			"iPerf - Server Address: localhost - Server Port: 5201 - Duration: 10 Seconds - Test: UDP - 100Mbit Objective - Parallel: 10",
+		description:
+			"iPerf is a network bandwidth throughput testing software. This test profile is used for automated testing of an iperf client and requires you have access to an iperf server.",
+		pts: {
+			test: "pts/iperf",
+			description:
+				"Server Address: localhost - Server Port: 5201 - Duration: 10 Seconds - Test: UDP - 100Mbit Objective - Parallel: 10",
+		},
+		sourceUrl: "https://software.es.net/iperf/",
+	},
+	{
+		id: "iperf_server_address_localhost_server_port_5201_duration_10_seconds_test_udp_100mbit_objective_parallel_128",
+		dimension: "network",
+		unit: "Mbits/sec",
+		direction: "HIB",
+		headline: false,
+		label:
+			"iPerf - Server Address: localhost - Server Port: 5201 - Duration: 10 Seconds - Test: UDP - 100Mbit Objective - Parallel: 128",
+		description:
+			"iPerf is a network bandwidth throughput testing software. This test profile is used for automated testing of an iperf client and requires you have access to an iperf server.",
+		pts: {
+			test: "pts/iperf",
+			description:
+				"Server Address: localhost - Server Port: 5201 - Duration: 10 Seconds - Test: UDP - 100Mbit Objective - Parallel: 128",
+		},
+		sourceUrl: "https://software.es.net/iperf/",
+	},
+	{
+		id: "iperf_server_address_localhost_server_port_5201_duration_10_seconds_test_udp_100mbit_objective_parallel_20",
+		dimension: "network",
+		unit: "Mbits/sec",
+		direction: "HIB",
+		headline: false,
+		label:
+			"iPerf - Server Address: localhost - Server Port: 5201 - Duration: 10 Seconds - Test: UDP - 100Mbit Objective - Parallel: 20",
+		description:
+			"iPerf is a network bandwidth throughput testing software. This test profile is used for automated testing of an iperf client and requires you have access to an iperf server.",
+		pts: {
+			test: "pts/iperf",
+			description:
+				"Server Address: localhost - Server Port: 5201 - Duration: 10 Seconds - Test: UDP - 100Mbit Objective - Parallel: 20",
+		},
+		sourceUrl: "https://software.es.net/iperf/",
+	},
+	{
+		id: "iperf_server_address_localhost_server_port_5201_duration_10_seconds_test_udp_100mbit_objective_parallel_256",
+		dimension: "network",
+		unit: "Mbits/sec",
+		direction: "HIB",
+		headline: false,
+		label:
+			"iPerf - Server Address: localhost - Server Port: 5201 - Duration: 10 Seconds - Test: UDP - 100Mbit Objective - Parallel: 256",
+		description:
+			"iPerf is a network bandwidth throughput testing software. This test profile is used for automated testing of an iperf client and requires you have access to an iperf server.",
+		pts: {
+			test: "pts/iperf",
+			description:
+				"Server Address: localhost - Server Port: 5201 - Duration: 10 Seconds - Test: UDP - 100Mbit Objective - Parallel: 256",
+		},
+		sourceUrl: "https://software.es.net/iperf/",
+	},
+	{
+		id: "iperf_server_address_localhost_server_port_5201_duration_10_seconds_test_udp_100mbit_objective_parallel_32",
+		dimension: "network",
+		unit: "Mbits/sec",
+		direction: "HIB",
+		headline: false,
+		label:
+			"iPerf - Server Address: localhost - Server Port: 5201 - Duration: 10 Seconds - Test: UDP - 100Mbit Objective - Parallel: 32",
+		description:
+			"iPerf is a network bandwidth throughput testing software. This test profile is used for automated testing of an iperf client and requires you have access to an iperf server.",
+		pts: {
+			test: "pts/iperf",
+			description:
+				"Server Address: localhost - Server Port: 5201 - Duration: 10 Seconds - Test: UDP - 100Mbit Objective - Parallel: 32",
+		},
+		sourceUrl: "https://software.es.net/iperf/",
+	},
+	{
+		id: "iperf_server_address_localhost_server_port_5201_duration_10_seconds_test_udp_100mbit_objective_parallel_5",
+		dimension: "network",
+		unit: "Mbits/sec",
+		direction: "HIB",
+		headline: false,
+		label:
+			"iPerf - Server Address: localhost - Server Port: 5201 - Duration: 10 Seconds - Test: UDP - 100Mbit Objective - Parallel: 5",
+		description:
+			"iPerf is a network bandwidth throughput testing software. This test profile is used for automated testing of an iperf client and requires you have access to an iperf server.",
+		pts: {
+			test: "pts/iperf",
+			description:
+				"Server Address: localhost - Server Port: 5201 - Duration: 10 Seconds - Test: UDP - 100Mbit Objective - Parallel: 5",
+		},
+		sourceUrl: "https://software.es.net/iperf/",
+	},
+	{
+		id: "iperf_server_address_localhost_server_port_5201_duration_10_seconds_test_udp_100mbit_objective_parallel_64",
+		dimension: "network",
+		unit: "Mbits/sec",
+		direction: "HIB",
+		headline: false,
+		label:
+			"iPerf - Server Address: localhost - Server Port: 5201 - Duration: 10 Seconds - Test: UDP - 100Mbit Objective - Parallel: 64",
+		description:
+			"iPerf is a network bandwidth throughput testing software. This test profile is used for automated testing of an iperf client and requires you have access to an iperf server.",
+		pts: {
+			test: "pts/iperf",
+			description:
+				"Server Address: localhost - Server Port: 5201 - Duration: 10 Seconds - Test: UDP - 100Mbit Objective - Parallel: 64",
+		},
+		sourceUrl: "https://software.es.net/iperf/",
+	},
+	{
+		id: "iperf_server_address_localhost_server_port_5201_duration_10_seconds_test_udp_parallel_1",
+		dimension: "network",
+		unit: "Mbits/sec",
+		direction: "HIB",
+		headline: false,
+		label:
+			"iPerf - Server Address: localhost - Server Port: 5201 - Duration: 10 Seconds - Test: UDP - Parallel: 1",
+		description:
+			"iPerf is a network bandwidth throughput testing software. This test profile is used for automated testing of an iperf client and requires you have access to an iperf server.",
+		pts: {
+			test: "pts/iperf",
+			description:
+				"Server Address: localhost - Server Port: 5201 - Duration: 10 Seconds - Test: UDP - Parallel: 1",
+		},
+		sourceUrl: "https://software.es.net/iperf/",
+	},
+	{
+		id: "iperf_server_address_localhost_server_port_5201_duration_10_seconds_test_udp_parallel_10",
+		dimension: "network",
+		unit: "Mbits/sec",
+		direction: "HIB",
+		headline: false,
+		label:
+			"iPerf - Server Address: localhost - Server Port: 5201 - Duration: 10 Seconds - Test: UDP - Parallel: 10",
+		description:
+			"iPerf is a network bandwidth throughput testing software. This test profile is used for automated testing of an iperf client and requires you have access to an iperf server.",
+		pts: {
+			test: "pts/iperf",
+			description:
+				"Server Address: localhost - Server Port: 5201 - Duration: 10 Seconds - Test: UDP - Parallel: 10",
+		},
+		sourceUrl: "https://software.es.net/iperf/",
+	},
+];
+
+const chunk5: MetricDef[] = [
+	{
+		id: "iperf_server_address_localhost_server_port_5201_duration_10_seconds_test_udp_parallel_128",
+		dimension: "network",
+		unit: "Mbits/sec",
+		direction: "HIB",
+		headline: false,
+		label:
+			"iPerf - Server Address: localhost - Server Port: 5201 - Duration: 10 Seconds - Test: UDP - Parallel: 128",
+		description:
+			"iPerf is a network bandwidth throughput testing software. This test profile is used for automated testing of an iperf client and requires you have access to an iperf server.",
+		pts: {
+			test: "pts/iperf",
+			description:
+				"Server Address: localhost - Server Port: 5201 - Duration: 10 Seconds - Test: UDP - Parallel: 128",
+		},
+		sourceUrl: "https://software.es.net/iperf/",
+	},
+	{
+		id: "iperf_server_address_localhost_server_port_5201_duration_10_seconds_test_udp_parallel_20",
+		dimension: "network",
+		unit: "Mbits/sec",
+		direction: "HIB",
+		headline: false,
+		label:
+			"iPerf - Server Address: localhost - Server Port: 5201 - Duration: 10 Seconds - Test: UDP - Parallel: 20",
+		description:
+			"iPerf is a network bandwidth throughput testing software. This test profile is used for automated testing of an iperf client and requires you have access to an iperf server.",
+		pts: {
+			test: "pts/iperf",
+			description:
+				"Server Address: localhost - Server Port: 5201 - Duration: 10 Seconds - Test: UDP - Parallel: 20",
+		},
+		sourceUrl: "https://software.es.net/iperf/",
+	},
+	{
+		id: "iperf_server_address_localhost_server_port_5201_duration_10_seconds_test_udp_parallel_256",
+		dimension: "network",
+		unit: "Mbits/sec",
+		direction: "HIB",
+		headline: false,
+		label:
+			"iPerf - Server Address: localhost - Server Port: 5201 - Duration: 10 Seconds - Test: UDP - Parallel: 256",
+		description:
+			"iPerf is a network bandwidth throughput testing software. This test profile is used for automated testing of an iperf client and requires you have access to an iperf server.",
+		pts: {
+			test: "pts/iperf",
+			description:
+				"Server Address: localhost - Server Port: 5201 - Duration: 10 Seconds - Test: UDP - Parallel: 256",
+		},
+		sourceUrl: "https://software.es.net/iperf/",
+	},
+	{
+		id: "iperf_server_address_localhost_server_port_5201_duration_10_seconds_test_udp_parallel_32",
+		dimension: "network",
+		unit: "Mbits/sec",
+		direction: "HIB",
+		headline: false,
+		label:
+			"iPerf - Server Address: localhost - Server Port: 5201 - Duration: 10 Seconds - Test: UDP - Parallel: 32",
+		description:
+			"iPerf is a network bandwidth throughput testing software. This test profile is used for automated testing of an iperf client and requires you have access to an iperf server.",
+		pts: {
+			test: "pts/iperf",
+			description:
+				"Server Address: localhost - Server Port: 5201 - Duration: 10 Seconds - Test: UDP - Parallel: 32",
+		},
+		sourceUrl: "https://software.es.net/iperf/",
+	},
+	{
+		id: "iperf_server_address_localhost_server_port_5201_duration_10_seconds_test_udp_parallel_5",
+		dimension: "network",
+		unit: "Mbits/sec",
+		direction: "HIB",
+		headline: false,
+		label:
+			"iPerf - Server Address: localhost - Server Port: 5201 - Duration: 10 Seconds - Test: UDP - Parallel: 5",
+		description:
+			"iPerf is a network bandwidth throughput testing software. This test profile is used for automated testing of an iperf client and requires you have access to an iperf server.",
+		pts: {
+			test: "pts/iperf",
+			description:
+				"Server Address: localhost - Server Port: 5201 - Duration: 10 Seconds - Test: UDP - Parallel: 5",
+		},
+		sourceUrl: "https://software.es.net/iperf/",
+	},
+	{
+		id: "iperf_server_address_localhost_server_port_5201_duration_10_seconds_test_udp_parallel_64",
+		dimension: "network",
+		unit: "Mbits/sec",
+		direction: "HIB",
+		headline: false,
+		label:
+			"iPerf - Server Address: localhost - Server Port: 5201 - Duration: 10 Seconds - Test: UDP - Parallel: 64",
+		description:
+			"iPerf is a network bandwidth throughput testing software. This test profile is used for automated testing of an iperf client and requires you have access to an iperf server.",
+		pts: {
+			test: "pts/iperf",
+			description:
+				"Server Address: localhost - Server Port: 5201 - Duration: 10 Seconds - Test: UDP - Parallel: 64",
+		},
+		sourceUrl: "https://software.es.net/iperf/",
+	},
+	{
+		id: "iperf_server_address_localhost_server_port_5201_duration_30_seconds_test_tcp_parallel_1",
+		dimension: "network",
+		unit: "Mbits/sec",
+		direction: "HIB",
+		headline: false,
+		label:
+			"iPerf - Server Address: localhost - Server Port: 5201 - Duration: 30 Seconds - Test: TCP - Parallel: 1",
+		description:
+			"iPerf is a network bandwidth throughput testing software. This test profile is used for automated testing of an iperf client and requires you have access to an iperf server.",
+		pts: {
+			test: "pts/iperf",
+			description:
+				"Server Address: localhost - Server Port: 5201 - Duration: 30 Seconds - Test: TCP - Parallel: 1",
+		},
+		sourceUrl: "https://software.es.net/iperf/",
+	},
+	{
+		id: "iperf_server_address_localhost_server_port_5201_duration_30_seconds_test_tcp_parallel_10",
+		dimension: "network",
+		unit: "Mbits/sec",
+		direction: "HIB",
+		headline: false,
+		label:
+			"iPerf - Server Address: localhost - Server Port: 5201 - Duration: 30 Seconds - Test: TCP - Parallel: 10",
+		description:
+			"iPerf is a network bandwidth throughput testing software. This test profile is used for automated testing of an iperf client and requires you have access to an iperf server.",
+		pts: {
+			test: "pts/iperf",
+			description:
+				"Server Address: localhost - Server Port: 5201 - Duration: 30 Seconds - Test: TCP - Parallel: 10",
+		},
+		sourceUrl: "https://software.es.net/iperf/",
+	},
+	{
+		id: "iperf_server_address_localhost_server_port_5201_duration_30_seconds_test_tcp_parallel_128",
+		dimension: "network",
+		unit: "Mbits/sec",
+		direction: "HIB",
+		headline: false,
+		label:
+			"iPerf - Server Address: localhost - Server Port: 5201 - Duration: 30 Seconds - Test: TCP - Parallel: 128",
+		description:
+			"iPerf is a network bandwidth throughput testing software. This test profile is used for automated testing of an iperf client and requires you have access to an iperf server.",
+		pts: {
+			test: "pts/iperf",
+			description:
+				"Server Address: localhost - Server Port: 5201 - Duration: 30 Seconds - Test: TCP - Parallel: 128",
+		},
+		sourceUrl: "https://software.es.net/iperf/",
+	},
+	{
+		id: "iperf_server_address_localhost_server_port_5201_duration_30_seconds_test_tcp_parallel_20",
+		dimension: "network",
+		unit: "Mbits/sec",
+		direction: "HIB",
+		headline: false,
+		label:
+			"iPerf - Server Address: localhost - Server Port: 5201 - Duration: 30 Seconds - Test: TCP - Parallel: 20",
+		description:
+			"iPerf is a network bandwidth throughput testing software. This test profile is used for automated testing of an iperf client and requires you have access to an iperf server.",
+		pts: {
+			test: "pts/iperf",
+			description:
+				"Server Address: localhost - Server Port: 5201 - Duration: 30 Seconds - Test: TCP - Parallel: 20",
+		},
+		sourceUrl: "https://software.es.net/iperf/",
+	},
+	{
+		id: "iperf_server_address_localhost_server_port_5201_duration_30_seconds_test_tcp_parallel_256",
+		dimension: "network",
+		unit: "Mbits/sec",
+		direction: "HIB",
+		headline: false,
+		label:
+			"iPerf - Server Address: localhost - Server Port: 5201 - Duration: 30 Seconds - Test: TCP - Parallel: 256",
+		description:
+			"iPerf is a network bandwidth throughput testing software. This test profile is used for automated testing of an iperf client and requires you have access to an iperf server.",
+		pts: {
+			test: "pts/iperf",
+			description:
+				"Server Address: localhost - Server Port: 5201 - Duration: 30 Seconds - Test: TCP - Parallel: 256",
+		},
+		sourceUrl: "https://software.es.net/iperf/",
+	},
+	{
+		id: "iperf_server_address_localhost_server_port_5201_duration_30_seconds_test_tcp_parallel_32",
+		dimension: "network",
+		unit: "Mbits/sec",
+		direction: "HIB",
+		headline: false,
+		label:
+			"iPerf - Server Address: localhost - Server Port: 5201 - Duration: 30 Seconds - Test: TCP - Parallel: 32",
+		description:
+			"iPerf is a network bandwidth throughput testing software. This test profile is used for automated testing of an iperf client and requires you have access to an iperf server.",
+		pts: {
+			test: "pts/iperf",
+			description:
+				"Server Address: localhost - Server Port: 5201 - Duration: 30 Seconds - Test: TCP - Parallel: 32",
+		},
+		sourceUrl: "https://software.es.net/iperf/",
+	},
+	{
+		id: "iperf_server_address_localhost_server_port_5201_duration_30_seconds_test_tcp_parallel_5",
+		dimension: "network",
+		unit: "Mbits/sec",
+		direction: "HIB",
+		headline: false,
+		label:
+			"iPerf - Server Address: localhost - Server Port: 5201 - Duration: 30 Seconds - Test: TCP - Parallel: 5",
+		description:
+			"iPerf is a network bandwidth throughput testing software. This test profile is used for automated testing of an iperf client and requires you have access to an iperf server.",
+		pts: {
+			test: "pts/iperf",
+			description:
+				"Server Address: localhost - Server Port: 5201 - Duration: 30 Seconds - Test: TCP - Parallel: 5",
+		},
+		sourceUrl: "https://software.es.net/iperf/",
+	},
+	{
+		id: "iperf_server_address_localhost_server_port_5201_duration_30_seconds_test_tcp_parallel_64",
+		dimension: "network",
+		unit: "Mbits/sec",
+		direction: "HIB",
+		headline: false,
+		label:
+			"iPerf - Server Address: localhost - Server Port: 5201 - Duration: 30 Seconds - Test: TCP - Parallel: 64",
+		description:
+			"iPerf is a network bandwidth throughput testing software. This test profile is used for automated testing of an iperf client and requires you have access to an iperf server.",
+		pts: {
+			test: "pts/iperf",
+			description:
+				"Server Address: localhost - Server Port: 5201 - Duration: 30 Seconds - Test: TCP - Parallel: 64",
+		},
+		sourceUrl: "https://software.es.net/iperf/",
+	},
+	{
+		id: "iperf_server_address_localhost_server_port_5201_duration_30_seconds_test_udp_10000mbit_objective_parallel_1",
+		dimension: "network",
+		unit: "Mbits/sec",
+		direction: "HIB",
+		headline: false,
+		label:
+			"iPerf - Server Address: localhost - Server Port: 5201 - Duration: 30 Seconds - Test: UDP - 10000Mbit Objective - Parallel: 1",
+		description:
+			"iPerf is a network bandwidth throughput testing software. This test profile is used for automated testing of an iperf client and requires you have access to an iperf server.",
+		pts: {
+			test: "pts/iperf",
+			description:
+				"Server Address: localhost - Server Port: 5201 - Duration: 30 Seconds - Test: UDP - 10000Mbit Objective - Parallel: 1",
+		},
+		sourceUrl: "https://software.es.net/iperf/",
+	},
+	{
+		id: "iperf_server_address_localhost_server_port_5201_duration_30_seconds_test_udp_10000mbit_objective_parallel_10",
+		dimension: "network",
+		unit: "Mbits/sec",
+		direction: "HIB",
+		headline: false,
+		label:
+			"iPerf - Server Address: localhost - Server Port: 5201 - Duration: 30 Seconds - Test: UDP - 10000Mbit Objective - Parallel: 10",
+		description:
+			"iPerf is a network bandwidth throughput testing software. This test profile is used for automated testing of an iperf client and requires you have access to an iperf server.",
+		pts: {
+			test: "pts/iperf",
+			description:
+				"Server Address: localhost - Server Port: 5201 - Duration: 30 Seconds - Test: UDP - 10000Mbit Objective - Parallel: 10",
+		},
+		sourceUrl: "https://software.es.net/iperf/",
+	},
+	{
+		id: "iperf_server_address_localhost_server_port_5201_duration_30_seconds_test_udp_10000mbit_objective_parallel_128",
+		dimension: "network",
+		unit: "Mbits/sec",
+		direction: "HIB",
+		headline: false,
+		label:
+			"iPerf - Server Address: localhost - Server Port: 5201 - Duration: 30 Seconds - Test: UDP - 10000Mbit Objective - Parallel: 128",
+		description:
+			"iPerf is a network bandwidth throughput testing software. This test profile is used for automated testing of an iperf client and requires you have access to an iperf server.",
+		pts: {
+			test: "pts/iperf",
+			description:
+				"Server Address: localhost - Server Port: 5201 - Duration: 30 Seconds - Test: UDP - 10000Mbit Objective - Parallel: 128",
+		},
+		sourceUrl: "https://software.es.net/iperf/",
+	},
+	{
+		id: "iperf_server_address_localhost_server_port_5201_duration_30_seconds_test_udp_10000mbit_objective_parallel_20",
+		dimension: "network",
+		unit: "Mbits/sec",
+		direction: "HIB",
+		headline: false,
+		label:
+			"iPerf - Server Address: localhost - Server Port: 5201 - Duration: 30 Seconds - Test: UDP - 10000Mbit Objective - Parallel: 20",
+		description:
+			"iPerf is a network bandwidth throughput testing software. This test profile is used for automated testing of an iperf client and requires you have access to an iperf server.",
+		pts: {
+			test: "pts/iperf",
+			description:
+				"Server Address: localhost - Server Port: 5201 - Duration: 30 Seconds - Test: UDP - 10000Mbit Objective - Parallel: 20",
+		},
+		sourceUrl: "https://software.es.net/iperf/",
+	},
+	{
+		id: "iperf_server_address_localhost_server_port_5201_duration_30_seconds_test_udp_10000mbit_objective_parallel_256",
+		dimension: "network",
+		unit: "Mbits/sec",
+		direction: "HIB",
+		headline: false,
+		label:
+			"iPerf - Server Address: localhost - Server Port: 5201 - Duration: 30 Seconds - Test: UDP - 10000Mbit Objective - Parallel: 256",
+		description:
+			"iPerf is a network bandwidth throughput testing software. This test profile is used for automated testing of an iperf client and requires you have access to an iperf server.",
+		pts: {
+			test: "pts/iperf",
+			description:
+				"Server Address: localhost - Server Port: 5201 - Duration: 30 Seconds - Test: UDP - 10000Mbit Objective - Parallel: 256",
+		},
+		sourceUrl: "https://software.es.net/iperf/",
+	},
+	{
+		id: "iperf_server_address_localhost_server_port_5201_duration_30_seconds_test_udp_10000mbit_objective_parallel_32",
+		dimension: "network",
+		unit: "Mbits/sec",
+		direction: "HIB",
+		headline: false,
+		label:
+			"iPerf - Server Address: localhost - Server Port: 5201 - Duration: 30 Seconds - Test: UDP - 10000Mbit Objective - Parallel: 32",
+		description:
+			"iPerf is a network bandwidth throughput testing software. This test profile is used for automated testing of an iperf client and requires you have access to an iperf server.",
+		pts: {
+			test: "pts/iperf",
+			description:
+				"Server Address: localhost - Server Port: 5201 - Duration: 30 Seconds - Test: UDP - 10000Mbit Objective - Parallel: 32",
+		},
+		sourceUrl: "https://software.es.net/iperf/",
+	},
+	{
+		id: "iperf_server_address_localhost_server_port_5201_duration_30_seconds_test_udp_10000mbit_objective_parallel_5",
+		dimension: "network",
+		unit: "Mbits/sec",
+		direction: "HIB",
+		headline: false,
+		label:
+			"iPerf - Server Address: localhost - Server Port: 5201 - Duration: 30 Seconds - Test: UDP - 10000Mbit Objective - Parallel: 5",
+		description:
+			"iPerf is a network bandwidth throughput testing software. This test profile is used for automated testing of an iperf client and requires you have access to an iperf server.",
+		pts: {
+			test: "pts/iperf",
+			description:
+				"Server Address: localhost - Server Port: 5201 - Duration: 30 Seconds - Test: UDP - 10000Mbit Objective - Parallel: 5",
+		},
+		sourceUrl: "https://software.es.net/iperf/",
+	},
+	{
+		id: "iperf_server_address_localhost_server_port_5201_duration_30_seconds_test_udp_10000mbit_objective_parallel_64",
+		dimension: "network",
+		unit: "Mbits/sec",
+		direction: "HIB",
+		headline: false,
+		label:
+			"iPerf - Server Address: localhost - Server Port: 5201 - Duration: 30 Seconds - Test: UDP - 10000Mbit Objective - Parallel: 64",
+		description:
+			"iPerf is a network bandwidth throughput testing software. This test profile is used for automated testing of an iperf client and requires you have access to an iperf server.",
+		pts: {
+			test: "pts/iperf",
+			description:
+				"Server Address: localhost - Server Port: 5201 - Duration: 30 Seconds - Test: UDP - 10000Mbit Objective - Parallel: 64",
+		},
+		sourceUrl: "https://software.es.net/iperf/",
+	},
+	{
+		id: "iperf_server_address_localhost_server_port_5201_duration_30_seconds_test_udp_1000mbit_objective_parallel_1",
+		dimension: "network",
+		unit: "Mbits/sec",
+		direction: "HIB",
+		headline: false,
+		label:
+			"iPerf - Server Address: localhost - Server Port: 5201 - Duration: 30 Seconds - Test: UDP - 1000Mbit Objective - Parallel: 1",
+		description:
+			"iPerf is a network bandwidth throughput testing software. This test profile is used for automated testing of an iperf client and requires you have access to an iperf server.",
+		pts: {
+			test: "pts/iperf",
+			description:
+				"Server Address: localhost - Server Port: 5201 - Duration: 30 Seconds - Test: UDP - 1000Mbit Objective - Parallel: 1",
+		},
+		sourceUrl: "https://software.es.net/iperf/",
+	},
+	{
+		id: "iperf_server_address_localhost_server_port_5201_duration_30_seconds_test_udp_1000mbit_objective_parallel_10",
+		dimension: "network",
+		unit: "Mbits/sec",
+		direction: "HIB",
+		headline: false,
+		label:
+			"iPerf - Server Address: localhost - Server Port: 5201 - Duration: 30 Seconds - Test: UDP - 1000Mbit Objective - Parallel: 10",
+		description:
+			"iPerf is a network bandwidth throughput testing software. This test profile is used for automated testing of an iperf client and requires you have access to an iperf server.",
+		pts: {
+			test: "pts/iperf",
+			description:
+				"Server Address: localhost - Server Port: 5201 - Duration: 30 Seconds - Test: UDP - 1000Mbit Objective - Parallel: 10",
+		},
+		sourceUrl: "https://software.es.net/iperf/",
+	},
+	{
+		id: "iperf_server_address_localhost_server_port_5201_duration_30_seconds_test_udp_1000mbit_objective_parallel_128",
+		dimension: "network",
+		unit: "Mbits/sec",
+		direction: "HIB",
+		headline: false,
+		label:
+			"iPerf - Server Address: localhost - Server Port: 5201 - Duration: 30 Seconds - Test: UDP - 1000Mbit Objective - Parallel: 128",
+		description:
+			"iPerf is a network bandwidth throughput testing software. This test profile is used for automated testing of an iperf client and requires you have access to an iperf server.",
+		pts: {
+			test: "pts/iperf",
+			description:
+				"Server Address: localhost - Server Port: 5201 - Duration: 30 Seconds - Test: UDP - 1000Mbit Objective - Parallel: 128",
+		},
+		sourceUrl: "https://software.es.net/iperf/",
+	},
+	{
+		id: "iperf_server_address_localhost_server_port_5201_duration_30_seconds_test_udp_1000mbit_objective_parallel_20",
+		dimension: "network",
+		unit: "Mbits/sec",
+		direction: "HIB",
+		headline: false,
+		label:
+			"iPerf - Server Address: localhost - Server Port: 5201 - Duration: 30 Seconds - Test: UDP - 1000Mbit Objective - Parallel: 20",
+		description:
+			"iPerf is a network bandwidth throughput testing software. This test profile is used for automated testing of an iperf client and requires you have access to an iperf server.",
+		pts: {
+			test: "pts/iperf",
+			description:
+				"Server Address: localhost - Server Port: 5201 - Duration: 30 Seconds - Test: UDP - 1000Mbit Objective - Parallel: 20",
+		},
+		sourceUrl: "https://software.es.net/iperf/",
+	},
+	{
+		id: "iperf_server_address_localhost_server_port_5201_duration_30_seconds_test_udp_1000mbit_objective_parallel_256",
+		dimension: "network",
+		unit: "Mbits/sec",
+		direction: "HIB",
+		headline: false,
+		label:
+			"iPerf - Server Address: localhost - Server Port: 5201 - Duration: 30 Seconds - Test: UDP - 1000Mbit Objective - Parallel: 256",
+		description:
+			"iPerf is a network bandwidth throughput testing software. This test profile is used for automated testing of an iperf client and requires you have access to an iperf server.",
+		pts: {
+			test: "pts/iperf",
+			description:
+				"Server Address: localhost - Server Port: 5201 - Duration: 30 Seconds - Test: UDP - 1000Mbit Objective - Parallel: 256",
+		},
+		sourceUrl: "https://software.es.net/iperf/",
+	},
+	{
+		id: "iperf_server_address_localhost_server_port_5201_duration_30_seconds_test_udp_1000mbit_objective_parallel_32",
+		dimension: "network",
+		unit: "Mbits/sec",
+		direction: "HIB",
+		headline: false,
+		label:
+			"iPerf - Server Address: localhost - Server Port: 5201 - Duration: 30 Seconds - Test: UDP - 1000Mbit Objective - Parallel: 32",
+		description:
+			"iPerf is a network bandwidth throughput testing software. This test profile is used for automated testing of an iperf client and requires you have access to an iperf server.",
+		pts: {
+			test: "pts/iperf",
+			description:
+				"Server Address: localhost - Server Port: 5201 - Duration: 30 Seconds - Test: UDP - 1000Mbit Objective - Parallel: 32",
+		},
+		sourceUrl: "https://software.es.net/iperf/",
+	},
+	{
+		id: "iperf_server_address_localhost_server_port_5201_duration_30_seconds_test_udp_1000mbit_objective_parallel_5",
+		dimension: "network",
+		unit: "Mbits/sec",
+		direction: "HIB",
+		headline: false,
+		label:
+			"iPerf - Server Address: localhost - Server Port: 5201 - Duration: 30 Seconds - Test: UDP - 1000Mbit Objective - Parallel: 5",
+		description:
+			"iPerf is a network bandwidth throughput testing software. This test profile is used for automated testing of an iperf client and requires you have access to an iperf server.",
+		pts: {
+			test: "pts/iperf",
+			description:
+				"Server Address: localhost - Server Port: 5201 - Duration: 30 Seconds - Test: UDP - 1000Mbit Objective - Parallel: 5",
+		},
+		sourceUrl: "https://software.es.net/iperf/",
+	},
+	{
+		id: "iperf_server_address_localhost_server_port_5201_duration_30_seconds_test_udp_1000mbit_objective_parallel_64",
+		dimension: "network",
+		unit: "Mbits/sec",
+		direction: "HIB",
+		headline: false,
+		label:
+			"iPerf - Server Address: localhost - Server Port: 5201 - Duration: 30 Seconds - Test: UDP - 1000Mbit Objective - Parallel: 64",
+		description:
+			"iPerf is a network bandwidth throughput testing software. This test profile is used for automated testing of an iperf client and requires you have access to an iperf server.",
+		pts: {
+			test: "pts/iperf",
+			description:
+				"Server Address: localhost - Server Port: 5201 - Duration: 30 Seconds - Test: UDP - 1000Mbit Objective - Parallel: 64",
+		},
+		sourceUrl: "https://software.es.net/iperf/",
+	},
+	{
+		id: "iperf_server_address_localhost_server_port_5201_duration_30_seconds_test_udp_100mbit_objective_parallel_1",
+		dimension: "network",
+		unit: "Mbits/sec",
+		direction: "HIB",
+		headline: false,
+		label:
+			"iPerf - Server Address: localhost - Server Port: 5201 - Duration: 30 Seconds - Test: UDP - 100Mbit Objective - Parallel: 1",
+		description:
+			"iPerf is a network bandwidth throughput testing software. This test profile is used for automated testing of an iperf client and requires you have access to an iperf server.",
+		pts: {
+			test: "pts/iperf",
+			description:
+				"Server Address: localhost - Server Port: 5201 - Duration: 30 Seconds - Test: UDP - 100Mbit Objective - Parallel: 1",
+		},
+		sourceUrl: "https://software.es.net/iperf/",
+	},
+	{
+		id: "iperf_server_address_localhost_server_port_5201_duration_30_seconds_test_udp_100mbit_objective_parallel_10",
+		dimension: "network",
+		unit: "Mbits/sec",
+		direction: "HIB",
+		headline: false,
+		label:
+			"iPerf - Server Address: localhost - Server Port: 5201 - Duration: 30 Seconds - Test: UDP - 100Mbit Objective - Parallel: 10",
+		description:
+			"iPerf is a network bandwidth throughput testing software. This test profile is used for automated testing of an iperf client and requires you have access to an iperf server.",
+		pts: {
+			test: "pts/iperf",
+			description:
+				"Server Address: localhost - Server Port: 5201 - Duration: 30 Seconds - Test: UDP - 100Mbit Objective - Parallel: 10",
+		},
+		sourceUrl: "https://software.es.net/iperf/",
+	},
+	{
+		id: "iperf_server_address_localhost_server_port_5201_duration_30_seconds_test_udp_100mbit_objective_parallel_128",
+		dimension: "network",
+		unit: "Mbits/sec",
+		direction: "HIB",
+		headline: false,
+		label:
+			"iPerf - Server Address: localhost - Server Port: 5201 - Duration: 30 Seconds - Test: UDP - 100Mbit Objective - Parallel: 128",
+		description:
+			"iPerf is a network bandwidth throughput testing software. This test profile is used for automated testing of an iperf client and requires you have access to an iperf server.",
+		pts: {
+			test: "pts/iperf",
+			description:
+				"Server Address: localhost - Server Port: 5201 - Duration: 30 Seconds - Test: UDP - 100Mbit Objective - Parallel: 128",
+		},
+		sourceUrl: "https://software.es.net/iperf/",
+	},
+	{
+		id: "iperf_server_address_localhost_server_port_5201_duration_30_seconds_test_udp_100mbit_objective_parallel_20",
+		dimension: "network",
+		unit: "Mbits/sec",
+		direction: "HIB",
+		headline: false,
+		label:
+			"iPerf - Server Address: localhost - Server Port: 5201 - Duration: 30 Seconds - Test: UDP - 100Mbit Objective - Parallel: 20",
+		description:
+			"iPerf is a network bandwidth throughput testing software. This test profile is used for automated testing of an iperf client and requires you have access to an iperf server.",
+		pts: {
+			test: "pts/iperf",
+			description:
+				"Server Address: localhost - Server Port: 5201 - Duration: 30 Seconds - Test: UDP - 100Mbit Objective - Parallel: 20",
+		},
+		sourceUrl: "https://software.es.net/iperf/",
+	},
+	{
+		id: "iperf_server_address_localhost_server_port_5201_duration_30_seconds_test_udp_100mbit_objective_parallel_256",
+		dimension: "network",
+		unit: "Mbits/sec",
+		direction: "HIB",
+		headline: false,
+		label:
+			"iPerf - Server Address: localhost - Server Port: 5201 - Duration: 30 Seconds - Test: UDP - 100Mbit Objective - Parallel: 256",
+		description:
+			"iPerf is a network bandwidth throughput testing software. This test profile is used for automated testing of an iperf client and requires you have access to an iperf server.",
+		pts: {
+			test: "pts/iperf",
+			description:
+				"Server Address: localhost - Server Port: 5201 - Duration: 30 Seconds - Test: UDP - 100Mbit Objective - Parallel: 256",
+		},
+		sourceUrl: "https://software.es.net/iperf/",
+	},
+	{
+		id: "iperf_server_address_localhost_server_port_5201_duration_30_seconds_test_udp_100mbit_objective_parallel_32",
+		dimension: "network",
+		unit: "Mbits/sec",
+		direction: "HIB",
+		headline: false,
+		label:
+			"iPerf - Server Address: localhost - Server Port: 5201 - Duration: 30 Seconds - Test: UDP - 100Mbit Objective - Parallel: 32",
+		description:
+			"iPerf is a network bandwidth throughput testing software. This test profile is used for automated testing of an iperf client and requires you have access to an iperf server.",
+		pts: {
+			test: "pts/iperf",
+			description:
+				"Server Address: localhost - Server Port: 5201 - Duration: 30 Seconds - Test: UDP - 100Mbit Objective - Parallel: 32",
+		},
+		sourceUrl: "https://software.es.net/iperf/",
+	},
+	{
+		id: "iperf_server_address_localhost_server_port_5201_duration_30_seconds_test_udp_100mbit_objective_parallel_5",
+		dimension: "network",
+		unit: "Mbits/sec",
+		direction: "HIB",
+		headline: false,
+		label:
+			"iPerf - Server Address: localhost - Server Port: 5201 - Duration: 30 Seconds - Test: UDP - 100Mbit Objective - Parallel: 5",
+		description:
+			"iPerf is a network bandwidth throughput testing software. This test profile is used for automated testing of an iperf client and requires you have access to an iperf server.",
+		pts: {
+			test: "pts/iperf",
+			description:
+				"Server Address: localhost - Server Port: 5201 - Duration: 30 Seconds - Test: UDP - 100Mbit Objective - Parallel: 5",
+		},
+		sourceUrl: "https://software.es.net/iperf/",
+	},
+	{
+		id: "iperf_server_address_localhost_server_port_5201_duration_30_seconds_test_udp_100mbit_objective_parallel_64",
+		dimension: "network",
+		unit: "Mbits/sec",
+		direction: "HIB",
+		headline: false,
+		label:
+			"iPerf - Server Address: localhost - Server Port: 5201 - Duration: 30 Seconds - Test: UDP - 100Mbit Objective - Parallel: 64",
+		description:
+			"iPerf is a network bandwidth throughput testing software. This test profile is used for automated testing of an iperf client and requires you have access to an iperf server.",
+		pts: {
+			test: "pts/iperf",
+			description:
+				"Server Address: localhost - Server Port: 5201 - Duration: 30 Seconds - Test: UDP - 100Mbit Objective - Parallel: 64",
+		},
+		sourceUrl: "https://software.es.net/iperf/",
+	},
+	{
+		id: "iperf_server_address_localhost_server_port_5201_duration_30_seconds_test_udp_parallel_1",
+		dimension: "network",
+		unit: "Mbits/sec",
+		direction: "HIB",
+		headline: false,
+		label:
+			"iPerf - Server Address: localhost - Server Port: 5201 - Duration: 30 Seconds - Test: UDP - Parallel: 1",
+		description:
+			"iPerf is a network bandwidth throughput testing software. This test profile is used for automated testing of an iperf client and requires you have access to an iperf server.",
+		pts: {
+			test: "pts/iperf",
+			description:
+				"Server Address: localhost - Server Port: 5201 - Duration: 30 Seconds - Test: UDP - Parallel: 1",
+		},
+		sourceUrl: "https://software.es.net/iperf/",
+	},
+	{
+		id: "iperf_server_address_localhost_server_port_5201_duration_30_seconds_test_udp_parallel_10",
+		dimension: "network",
+		unit: "Mbits/sec",
+		direction: "HIB",
+		headline: false,
+		label:
+			"iPerf - Server Address: localhost - Server Port: 5201 - Duration: 30 Seconds - Test: UDP - Parallel: 10",
+		description:
+			"iPerf is a network bandwidth throughput testing software. This test profile is used for automated testing of an iperf client and requires you have access to an iperf server.",
+		pts: {
+			test: "pts/iperf",
+			description:
+				"Server Address: localhost - Server Port: 5201 - Duration: 30 Seconds - Test: UDP - Parallel: 10",
+		},
+		sourceUrl: "https://software.es.net/iperf/",
+	},
+	{
+		id: "iperf_server_address_localhost_server_port_5201_duration_30_seconds_test_udp_parallel_128",
+		dimension: "network",
+		unit: "Mbits/sec",
+		direction: "HIB",
+		headline: false,
+		label:
+			"iPerf - Server Address: localhost - Server Port: 5201 - Duration: 30 Seconds - Test: UDP - Parallel: 128",
+		description:
+			"iPerf is a network bandwidth throughput testing software. This test profile is used for automated testing of an iperf client and requires you have access to an iperf server.",
+		pts: {
+			test: "pts/iperf",
+			description:
+				"Server Address: localhost - Server Port: 5201 - Duration: 30 Seconds - Test: UDP - Parallel: 128",
+		},
+		sourceUrl: "https://software.es.net/iperf/",
+	},
+	{
+		id: "iperf_server_address_localhost_server_port_5201_duration_30_seconds_test_udp_parallel_20",
+		dimension: "network",
+		unit: "Mbits/sec",
+		direction: "HIB",
+		headline: false,
+		label:
+			"iPerf - Server Address: localhost - Server Port: 5201 - Duration: 30 Seconds - Test: UDP - Parallel: 20",
+		description:
+			"iPerf is a network bandwidth throughput testing software. This test profile is used for automated testing of an iperf client and requires you have access to an iperf server.",
+		pts: {
+			test: "pts/iperf",
+			description:
+				"Server Address: localhost - Server Port: 5201 - Duration: 30 Seconds - Test: UDP - Parallel: 20",
+		},
+		sourceUrl: "https://software.es.net/iperf/",
+	},
+	{
+		id: "iperf_server_address_localhost_server_port_5201_duration_30_seconds_test_udp_parallel_256",
+		dimension: "network",
+		unit: "Mbits/sec",
+		direction: "HIB",
+		headline: false,
+		label:
+			"iPerf - Server Address: localhost - Server Port: 5201 - Duration: 30 Seconds - Test: UDP - Parallel: 256",
+		description:
+			"iPerf is a network bandwidth throughput testing software. This test profile is used for automated testing of an iperf client and requires you have access to an iperf server.",
+		pts: {
+			test: "pts/iperf",
+			description:
+				"Server Address: localhost - Server Port: 5201 - Duration: 30 Seconds - Test: UDP - Parallel: 256",
+		},
+		sourceUrl: "https://software.es.net/iperf/",
+	},
+	{
+		id: "iperf_server_address_localhost_server_port_5201_duration_30_seconds_test_udp_parallel_32",
+		dimension: "network",
+		unit: "Mbits/sec",
+		direction: "HIB",
+		headline: false,
+		label:
+			"iPerf - Server Address: localhost - Server Port: 5201 - Duration: 30 Seconds - Test: UDP - Parallel: 32",
+		description:
+			"iPerf is a network bandwidth throughput testing software. This test profile is used for automated testing of an iperf client and requires you have access to an iperf server.",
+		pts: {
+			test: "pts/iperf",
+			description:
+				"Server Address: localhost - Server Port: 5201 - Duration: 30 Seconds - Test: UDP - Parallel: 32",
+		},
+		sourceUrl: "https://software.es.net/iperf/",
+	},
+	{
+		id: "iperf_server_address_localhost_server_port_5201_duration_30_seconds_test_udp_parallel_5",
+		dimension: "network",
+		unit: "Mbits/sec",
+		direction: "HIB",
+		headline: false,
+		label:
+			"iPerf - Server Address: localhost - Server Port: 5201 - Duration: 30 Seconds - Test: UDP - Parallel: 5",
+		description:
+			"iPerf is a network bandwidth throughput testing software. This test profile is used for automated testing of an iperf client and requires you have access to an iperf server.",
+		pts: {
+			test: "pts/iperf",
+			description:
+				"Server Address: localhost - Server Port: 5201 - Duration: 30 Seconds - Test: UDP - Parallel: 5",
+		},
+		sourceUrl: "https://software.es.net/iperf/",
+	},
+	{
+		id: "iperf_server_address_localhost_server_port_5201_duration_30_seconds_test_udp_parallel_64",
+		dimension: "network",
+		unit: "Mbits/sec",
+		direction: "HIB",
+		headline: false,
+		label:
+			"iPerf - Server Address: localhost - Server Port: 5201 - Duration: 30 Seconds - Test: UDP - Parallel: 64",
+		description:
+			"iPerf is a network bandwidth throughput testing software. This test profile is used for automated testing of an iperf client and requires you have access to an iperf server.",
+		pts: {
+			test: "pts/iperf",
+			description:
+				"Server Address: localhost - Server Port: 5201 - Duration: 30 Seconds - Test: UDP - Parallel: 64",
+		},
+		sourceUrl: "https://software.es.net/iperf/",
+	},
+	{
+		id: "iperf_server_address_localhost_server_port_5201_duration_360_seconds_test_tcp_parallel_1",
+		dimension: "network",
+		unit: "Mbits/sec",
+		direction: "HIB",
+		headline: false,
+		label:
+			"iPerf - Server Address: localhost - Server Port: 5201 - Duration: 360 Seconds - Test: TCP - Parallel: 1",
+		description:
+			"iPerf is a network bandwidth throughput testing software. This test profile is used for automated testing of an iperf client and requires you have access to an iperf server.",
+		pts: {
+			test: "pts/iperf",
+			description:
+				"Server Address: localhost - Server Port: 5201 - Duration: 360 Seconds - Test: TCP - Parallel: 1",
+		},
+		sourceUrl: "https://software.es.net/iperf/",
+	},
+	{
+		id: "iperf_server_address_localhost_server_port_5201_duration_360_seconds_test_tcp_parallel_10",
+		dimension: "network",
+		unit: "Mbits/sec",
+		direction: "HIB",
+		headline: false,
+		label:
+			"iPerf - Server Address: localhost - Server Port: 5201 - Duration: 360 Seconds - Test: TCP - Parallel: 10",
+		description:
+			"iPerf is a network bandwidth throughput testing software. This test profile is used for automated testing of an iperf client and requires you have access to an iperf server.",
+		pts: {
+			test: "pts/iperf",
+			description:
+				"Server Address: localhost - Server Port: 5201 - Duration: 360 Seconds - Test: TCP - Parallel: 10",
+		},
+		sourceUrl: "https://software.es.net/iperf/",
+	},
+	{
+		id: "iperf_server_address_localhost_server_port_5201_duration_360_seconds_test_tcp_parallel_128",
+		dimension: "network",
+		unit: "Mbits/sec",
+		direction: "HIB",
+		headline: false,
+		label:
+			"iPerf - Server Address: localhost - Server Port: 5201 - Duration: 360 Seconds - Test: TCP - Parallel: 128",
+		description:
+			"iPerf is a network bandwidth throughput testing software. This test profile is used for automated testing of an iperf client and requires you have access to an iperf server.",
+		pts: {
+			test: "pts/iperf",
+			description:
+				"Server Address: localhost - Server Port: 5201 - Duration: 360 Seconds - Test: TCP - Parallel: 128",
+		},
+		sourceUrl: "https://software.es.net/iperf/",
+	},
+	{
+		id: "iperf_server_address_localhost_server_port_5201_duration_360_seconds_test_tcp_parallel_20",
+		dimension: "network",
+		unit: "Mbits/sec",
+		direction: "HIB",
+		headline: false,
+		label:
+			"iPerf - Server Address: localhost - Server Port: 5201 - Duration: 360 Seconds - Test: TCP - Parallel: 20",
+		description:
+			"iPerf is a network bandwidth throughput testing software. This test profile is used for automated testing of an iperf client and requires you have access to an iperf server.",
+		pts: {
+			test: "pts/iperf",
+			description:
+				"Server Address: localhost - Server Port: 5201 - Duration: 360 Seconds - Test: TCP - Parallel: 20",
+		},
+		sourceUrl: "https://software.es.net/iperf/",
+	},
+	{
+		id: "iperf_server_address_localhost_server_port_5201_duration_360_seconds_test_tcp_parallel_256",
+		dimension: "network",
+		unit: "Mbits/sec",
+		direction: "HIB",
+		headline: false,
+		label:
+			"iPerf - Server Address: localhost - Server Port: 5201 - Duration: 360 Seconds - Test: TCP - Parallel: 256",
+		description:
+			"iPerf is a network bandwidth throughput testing software. This test profile is used for automated testing of an iperf client and requires you have access to an iperf server.",
+		pts: {
+			test: "pts/iperf",
+			description:
+				"Server Address: localhost - Server Port: 5201 - Duration: 360 Seconds - Test: TCP - Parallel: 256",
+		},
+		sourceUrl: "https://software.es.net/iperf/",
+	},
+	{
+		id: "iperf_server_address_localhost_server_port_5201_duration_360_seconds_test_tcp_parallel_32",
+		dimension: "network",
+		unit: "Mbits/sec",
+		direction: "HIB",
+		headline: false,
+		label:
+			"iPerf - Server Address: localhost - Server Port: 5201 - Duration: 360 Seconds - Test: TCP - Parallel: 32",
+		description:
+			"iPerf is a network bandwidth throughput testing software. This test profile is used for automated testing of an iperf client and requires you have access to an iperf server.",
+		pts: {
+			test: "pts/iperf",
+			description:
+				"Server Address: localhost - Server Port: 5201 - Duration: 360 Seconds - Test: TCP - Parallel: 32",
+		},
+		sourceUrl: "https://software.es.net/iperf/",
+	},
+	{
+		id: "iperf_server_address_localhost_server_port_5201_duration_360_seconds_test_tcp_parallel_5",
+		dimension: "network",
+		unit: "Mbits/sec",
+		direction: "HIB",
+		headline: false,
+		label:
+			"iPerf - Server Address: localhost - Server Port: 5201 - Duration: 360 Seconds - Test: TCP - Parallel: 5",
+		description:
+			"iPerf is a network bandwidth throughput testing software. This test profile is used for automated testing of an iperf client and requires you have access to an iperf server.",
+		pts: {
+			test: "pts/iperf",
+			description:
+				"Server Address: localhost - Server Port: 5201 - Duration: 360 Seconds - Test: TCP - Parallel: 5",
+		},
+		sourceUrl: "https://software.es.net/iperf/",
+	},
+	{
+		id: "iperf_server_address_localhost_server_port_5201_duration_360_seconds_test_tcp_parallel_64",
+		dimension: "network",
+		unit: "Mbits/sec",
+		direction: "HIB",
+		headline: false,
+		label:
+			"iPerf - Server Address: localhost - Server Port: 5201 - Duration: 360 Seconds - Test: TCP - Parallel: 64",
+		description:
+			"iPerf is a network bandwidth throughput testing software. This test profile is used for automated testing of an iperf client and requires you have access to an iperf server.",
+		pts: {
+			test: "pts/iperf",
+			description:
+				"Server Address: localhost - Server Port: 5201 - Duration: 360 Seconds - Test: TCP - Parallel: 64",
+		},
+		sourceUrl: "https://software.es.net/iperf/",
+	},
+	{
+		id: "iperf_server_address_localhost_server_port_5201_duration_360_seconds_test_udp_10000mbit_objective_parallel_1",
+		dimension: "network",
+		unit: "Mbits/sec",
+		direction: "HIB",
+		headline: false,
+		label:
+			"iPerf - Server Address: localhost - Server Port: 5201 - Duration: 360 Seconds - Test: UDP - 10000Mbit Objective - Parallel: 1",
+		description:
+			"iPerf is a network bandwidth throughput testing software. This test profile is used for automated testing of an iperf client and requires you have access to an iperf server.",
+		pts: {
+			test: "pts/iperf",
+			description:
+				"Server Address: localhost - Server Port: 5201 - Duration: 360 Seconds - Test: UDP - 10000Mbit Objective - Parallel: 1",
+		},
+		sourceUrl: "https://software.es.net/iperf/",
+	},
+	{
+		id: "iperf_server_address_localhost_server_port_5201_duration_360_seconds_test_udp_10000mbit_objective_parallel_10",
+		dimension: "network",
+		unit: "Mbits/sec",
+		direction: "HIB",
+		headline: false,
+		label:
+			"iPerf - Server Address: localhost - Server Port: 5201 - Duration: 360 Seconds - Test: UDP - 10000Mbit Objective - Parallel: 10",
+		description:
+			"iPerf is a network bandwidth throughput testing software. This test profile is used for automated testing of an iperf client and requires you have access to an iperf server.",
+		pts: {
+			test: "pts/iperf",
+			description:
+				"Server Address: localhost - Server Port: 5201 - Duration: 360 Seconds - Test: UDP - 10000Mbit Objective - Parallel: 10",
+		},
+		sourceUrl: "https://software.es.net/iperf/",
+	},
+	{
+		id: "iperf_server_address_localhost_server_port_5201_duration_360_seconds_test_udp_10000mbit_objective_parallel_128",
+		dimension: "network",
+		unit: "Mbits/sec",
+		direction: "HIB",
+		headline: false,
+		label:
+			"iPerf - Server Address: localhost - Server Port: 5201 - Duration: 360 Seconds - Test: UDP - 10000Mbit Objective - Parallel: 128",
+		description:
+			"iPerf is a network bandwidth throughput testing software. This test profile is used for automated testing of an iperf client and requires you have access to an iperf server.",
+		pts: {
+			test: "pts/iperf",
+			description:
+				"Server Address: localhost - Server Port: 5201 - Duration: 360 Seconds - Test: UDP - 10000Mbit Objective - Parallel: 128",
+		},
+		sourceUrl: "https://software.es.net/iperf/",
+	},
+	{
+		id: "iperf_server_address_localhost_server_port_5201_duration_360_seconds_test_udp_10000mbit_objective_parallel_20",
+		dimension: "network",
+		unit: "Mbits/sec",
+		direction: "HIB",
+		headline: false,
+		label:
+			"iPerf - Server Address: localhost - Server Port: 5201 - Duration: 360 Seconds - Test: UDP - 10000Mbit Objective - Parallel: 20",
+		description:
+			"iPerf is a network bandwidth throughput testing software. This test profile is used for automated testing of an iperf client and requires you have access to an iperf server.",
+		pts: {
+			test: "pts/iperf",
+			description:
+				"Server Address: localhost - Server Port: 5201 - Duration: 360 Seconds - Test: UDP - 10000Mbit Objective - Parallel: 20",
+		},
+		sourceUrl: "https://software.es.net/iperf/",
+	},
+	{
+		id: "iperf_server_address_localhost_server_port_5201_duration_360_seconds_test_udp_10000mbit_objective_parallel_256",
+		dimension: "network",
+		unit: "Mbits/sec",
+		direction: "HIB",
+		headline: false,
+		label:
+			"iPerf - Server Address: localhost - Server Port: 5201 - Duration: 360 Seconds - Test: UDP - 10000Mbit Objective - Parallel: 256",
+		description:
+			"iPerf is a network bandwidth throughput testing software. This test profile is used for automated testing of an iperf client and requires you have access to an iperf server.",
+		pts: {
+			test: "pts/iperf",
+			description:
+				"Server Address: localhost - Server Port: 5201 - Duration: 360 Seconds - Test: UDP - 10000Mbit Objective - Parallel: 256",
+		},
+		sourceUrl: "https://software.es.net/iperf/",
+	},
+	{
+		id: "iperf_server_address_localhost_server_port_5201_duration_360_seconds_test_udp_10000mbit_objective_parallel_32",
+		dimension: "network",
+		unit: "Mbits/sec",
+		direction: "HIB",
+		headline: false,
+		label:
+			"iPerf - Server Address: localhost - Server Port: 5201 - Duration: 360 Seconds - Test: UDP - 10000Mbit Objective - Parallel: 32",
+		description:
+			"iPerf is a network bandwidth throughput testing software. This test profile is used for automated testing of an iperf client and requires you have access to an iperf server.",
+		pts: {
+			test: "pts/iperf",
+			description:
+				"Server Address: localhost - Server Port: 5201 - Duration: 360 Seconds - Test: UDP - 10000Mbit Objective - Parallel: 32",
+		},
+		sourceUrl: "https://software.es.net/iperf/",
+	},
+	{
+		id: "iperf_server_address_localhost_server_port_5201_duration_360_seconds_test_udp_10000mbit_objective_parallel_5",
+		dimension: "network",
+		unit: "Mbits/sec",
+		direction: "HIB",
+		headline: false,
+		label:
+			"iPerf - Server Address: localhost - Server Port: 5201 - Duration: 360 Seconds - Test: UDP - 10000Mbit Objective - Parallel: 5",
+		description:
+			"iPerf is a network bandwidth throughput testing software. This test profile is used for automated testing of an iperf client and requires you have access to an iperf server.",
+		pts: {
+			test: "pts/iperf",
+			description:
+				"Server Address: localhost - Server Port: 5201 - Duration: 360 Seconds - Test: UDP - 10000Mbit Objective - Parallel: 5",
+		},
+		sourceUrl: "https://software.es.net/iperf/",
+	},
+	{
+		id: "iperf_server_address_localhost_server_port_5201_duration_360_seconds_test_udp_10000mbit_objective_parallel_64",
+		dimension: "network",
+		unit: "Mbits/sec",
+		direction: "HIB",
+		headline: false,
+		label:
+			"iPerf - Server Address: localhost - Server Port: 5201 - Duration: 360 Seconds - Test: UDP - 10000Mbit Objective - Parallel: 64",
+		description:
+			"iPerf is a network bandwidth throughput testing software. This test profile is used for automated testing of an iperf client and requires you have access to an iperf server.",
+		pts: {
+			test: "pts/iperf",
+			description:
+				"Server Address: localhost - Server Port: 5201 - Duration: 360 Seconds - Test: UDP - 10000Mbit Objective - Parallel: 64",
+		},
+		sourceUrl: "https://software.es.net/iperf/",
+	},
+	{
+		id: "iperf_server_address_localhost_server_port_5201_duration_360_seconds_test_udp_1000mbit_objective_parallel_1",
+		dimension: "network",
+		unit: "Mbits/sec",
+		direction: "HIB",
+		headline: false,
+		label:
+			"iPerf - Server Address: localhost - Server Port: 5201 - Duration: 360 Seconds - Test: UDP - 1000Mbit Objective - Parallel: 1",
+		description:
+			"iPerf is a network bandwidth throughput testing software. This test profile is used for automated testing of an iperf client and requires you have access to an iperf server.",
+		pts: {
+			test: "pts/iperf",
+			description:
+				"Server Address: localhost - Server Port: 5201 - Duration: 360 Seconds - Test: UDP - 1000Mbit Objective - Parallel: 1",
+		},
+		sourceUrl: "https://software.es.net/iperf/",
+	},
+	{
+		id: "iperf_server_address_localhost_server_port_5201_duration_360_seconds_test_udp_1000mbit_objective_parallel_10",
+		dimension: "network",
+		unit: "Mbits/sec",
+		direction: "HIB",
+		headline: false,
+		label:
+			"iPerf - Server Address: localhost - Server Port: 5201 - Duration: 360 Seconds - Test: UDP - 1000Mbit Objective - Parallel: 10",
+		description:
+			"iPerf is a network bandwidth throughput testing software. This test profile is used for automated testing of an iperf client and requires you have access to an iperf server.",
+		pts: {
+			test: "pts/iperf",
+			description:
+				"Server Address: localhost - Server Port: 5201 - Duration: 360 Seconds - Test: UDP - 1000Mbit Objective - Parallel: 10",
+		},
+		sourceUrl: "https://software.es.net/iperf/",
+	},
+	{
+		id: "iperf_server_address_localhost_server_port_5201_duration_360_seconds_test_udp_1000mbit_objective_parallel_128",
+		dimension: "network",
+		unit: "Mbits/sec",
+		direction: "HIB",
+		headline: false,
+		label:
+			"iPerf - Server Address: localhost - Server Port: 5201 - Duration: 360 Seconds - Test: UDP - 1000Mbit Objective - Parallel: 128",
+		description:
+			"iPerf is a network bandwidth throughput testing software. This test profile is used for automated testing of an iperf client and requires you have access to an iperf server.",
+		pts: {
+			test: "pts/iperf",
+			description:
+				"Server Address: localhost - Server Port: 5201 - Duration: 360 Seconds - Test: UDP - 1000Mbit Objective - Parallel: 128",
+		},
+		sourceUrl: "https://software.es.net/iperf/",
+	},
+	{
+		id: "iperf_server_address_localhost_server_port_5201_duration_360_seconds_test_udp_1000mbit_objective_parallel_20",
+		dimension: "network",
+		unit: "Mbits/sec",
+		direction: "HIB",
+		headline: false,
+		label:
+			"iPerf - Server Address: localhost - Server Port: 5201 - Duration: 360 Seconds - Test: UDP - 1000Mbit Objective - Parallel: 20",
+		description:
+			"iPerf is a network bandwidth throughput testing software. This test profile is used for automated testing of an iperf client and requires you have access to an iperf server.",
+		pts: {
+			test: "pts/iperf",
+			description:
+				"Server Address: localhost - Server Port: 5201 - Duration: 360 Seconds - Test: UDP - 1000Mbit Objective - Parallel: 20",
+		},
+		sourceUrl: "https://software.es.net/iperf/",
+	},
+	{
+		id: "iperf_server_address_localhost_server_port_5201_duration_360_seconds_test_udp_1000mbit_objective_parallel_256",
+		dimension: "network",
+		unit: "Mbits/sec",
+		direction: "HIB",
+		headline: false,
+		label:
+			"iPerf - Server Address: localhost - Server Port: 5201 - Duration: 360 Seconds - Test: UDP - 1000Mbit Objective - Parallel: 256",
+		description:
+			"iPerf is a network bandwidth throughput testing software. This test profile is used for automated testing of an iperf client and requires you have access to an iperf server.",
+		pts: {
+			test: "pts/iperf",
+			description:
+				"Server Address: localhost - Server Port: 5201 - Duration: 360 Seconds - Test: UDP - 1000Mbit Objective - Parallel: 256",
+		},
+		sourceUrl: "https://software.es.net/iperf/",
+	},
+	{
+		id: "iperf_server_address_localhost_server_port_5201_duration_360_seconds_test_udp_1000mbit_objective_parallel_32",
+		dimension: "network",
+		unit: "Mbits/sec",
+		direction: "HIB",
+		headline: false,
+		label:
+			"iPerf - Server Address: localhost - Server Port: 5201 - Duration: 360 Seconds - Test: UDP - 1000Mbit Objective - Parallel: 32",
+		description:
+			"iPerf is a network bandwidth throughput testing software. This test profile is used for automated testing of an iperf client and requires you have access to an iperf server.",
+		pts: {
+			test: "pts/iperf",
+			description:
+				"Server Address: localhost - Server Port: 5201 - Duration: 360 Seconds - Test: UDP - 1000Mbit Objective - Parallel: 32",
+		},
+		sourceUrl: "https://software.es.net/iperf/",
+	},
+	{
+		id: "iperf_server_address_localhost_server_port_5201_duration_360_seconds_test_udp_1000mbit_objective_parallel_5",
+		dimension: "network",
+		unit: "Mbits/sec",
+		direction: "HIB",
+		headline: false,
+		label:
+			"iPerf - Server Address: localhost - Server Port: 5201 - Duration: 360 Seconds - Test: UDP - 1000Mbit Objective - Parallel: 5",
+		description:
+			"iPerf is a network bandwidth throughput testing software. This test profile is used for automated testing of an iperf client and requires you have access to an iperf server.",
+		pts: {
+			test: "pts/iperf",
+			description:
+				"Server Address: localhost - Server Port: 5201 - Duration: 360 Seconds - Test: UDP - 1000Mbit Objective - Parallel: 5",
+		},
+		sourceUrl: "https://software.es.net/iperf/",
+	},
+	{
+		id: "iperf_server_address_localhost_server_port_5201_duration_360_seconds_test_udp_1000mbit_objective_parallel_64",
+		dimension: "network",
+		unit: "Mbits/sec",
+		direction: "HIB",
+		headline: false,
+		label:
+			"iPerf - Server Address: localhost - Server Port: 5201 - Duration: 360 Seconds - Test: UDP - 1000Mbit Objective - Parallel: 64",
+		description:
+			"iPerf is a network bandwidth throughput testing software. This test profile is used for automated testing of an iperf client and requires you have access to an iperf server.",
+		pts: {
+			test: "pts/iperf",
+			description:
+				"Server Address: localhost - Server Port: 5201 - Duration: 360 Seconds - Test: UDP - 1000Mbit Objective - Parallel: 64",
+		},
+		sourceUrl: "https://software.es.net/iperf/",
+	},
+	{
+		id: "iperf_server_address_localhost_server_port_5201_duration_360_seconds_test_udp_100mbit_objective_parallel_1",
+		dimension: "network",
+		unit: "Mbits/sec",
+		direction: "HIB",
+		headline: false,
+		label:
+			"iPerf - Server Address: localhost - Server Port: 5201 - Duration: 360 Seconds - Test: UDP - 100Mbit Objective - Parallel: 1",
+		description:
+			"iPerf is a network bandwidth throughput testing software. This test profile is used for automated testing of an iperf client and requires you have access to an iperf server.",
+		pts: {
+			test: "pts/iperf",
+			description:
+				"Server Address: localhost - Server Port: 5201 - Duration: 360 Seconds - Test: UDP - 100Mbit Objective - Parallel: 1",
+		},
+		sourceUrl: "https://software.es.net/iperf/",
+	},
+	{
+		id: "iperf_server_address_localhost_server_port_5201_duration_360_seconds_test_udp_100mbit_objective_parallel_10",
+		dimension: "network",
+		unit: "Mbits/sec",
+		direction: "HIB",
+		headline: false,
+		label:
+			"iPerf - Server Address: localhost - Server Port: 5201 - Duration: 360 Seconds - Test: UDP - 100Mbit Objective - Parallel: 10",
+		description:
+			"iPerf is a network bandwidth throughput testing software. This test profile is used for automated testing of an iperf client and requires you have access to an iperf server.",
+		pts: {
+			test: "pts/iperf",
+			description:
+				"Server Address: localhost - Server Port: 5201 - Duration: 360 Seconds - Test: UDP - 100Mbit Objective - Parallel: 10",
+		},
+		sourceUrl: "https://software.es.net/iperf/",
+	},
+	{
+		id: "iperf_server_address_localhost_server_port_5201_duration_360_seconds_test_udp_100mbit_objective_parallel_128",
+		dimension: "network",
+		unit: "Mbits/sec",
+		direction: "HIB",
+		headline: false,
+		label:
+			"iPerf - Server Address: localhost - Server Port: 5201 - Duration: 360 Seconds - Test: UDP - 100Mbit Objective - Parallel: 128",
+		description:
+			"iPerf is a network bandwidth throughput testing software. This test profile is used for automated testing of an iperf client and requires you have access to an iperf server.",
+		pts: {
+			test: "pts/iperf",
+			description:
+				"Server Address: localhost - Server Port: 5201 - Duration: 360 Seconds - Test: UDP - 100Mbit Objective - Parallel: 128",
+		},
+		sourceUrl: "https://software.es.net/iperf/",
+	},
+	{
+		id: "iperf_server_address_localhost_server_port_5201_duration_360_seconds_test_udp_100mbit_objective_parallel_20",
+		dimension: "network",
+		unit: "Mbits/sec",
+		direction: "HIB",
+		headline: false,
+		label:
+			"iPerf - Server Address: localhost - Server Port: 5201 - Duration: 360 Seconds - Test: UDP - 100Mbit Objective - Parallel: 20",
+		description:
+			"iPerf is a network bandwidth throughput testing software. This test profile is used for automated testing of an iperf client and requires you have access to an iperf server.",
+		pts: {
+			test: "pts/iperf",
+			description:
+				"Server Address: localhost - Server Port: 5201 - Duration: 360 Seconds - Test: UDP - 100Mbit Objective - Parallel: 20",
+		},
+		sourceUrl: "https://software.es.net/iperf/",
+	},
+	{
+		id: "iperf_server_address_localhost_server_port_5201_duration_360_seconds_test_udp_100mbit_objective_parallel_256",
+		dimension: "network",
+		unit: "Mbits/sec",
+		direction: "HIB",
+		headline: false,
+		label:
+			"iPerf - Server Address: localhost - Server Port: 5201 - Duration: 360 Seconds - Test: UDP - 100Mbit Objective - Parallel: 256",
+		description:
+			"iPerf is a network bandwidth throughput testing software. This test profile is used for automated testing of an iperf client and requires you have access to an iperf server.",
+		pts: {
+			test: "pts/iperf",
+			description:
+				"Server Address: localhost - Server Port: 5201 - Duration: 360 Seconds - Test: UDP - 100Mbit Objective - Parallel: 256",
+		},
+		sourceUrl: "https://software.es.net/iperf/",
+	},
+	{
+		id: "iperf_server_address_localhost_server_port_5201_duration_360_seconds_test_udp_100mbit_objective_parallel_32",
+		dimension: "network",
+		unit: "Mbits/sec",
+		direction: "HIB",
+		headline: false,
+		label:
+			"iPerf - Server Address: localhost - Server Port: 5201 - Duration: 360 Seconds - Test: UDP - 100Mbit Objective - Parallel: 32",
+		description:
+			"iPerf is a network bandwidth throughput testing software. This test profile is used for automated testing of an iperf client and requires you have access to an iperf server.",
+		pts: {
+			test: "pts/iperf",
+			description:
+				"Server Address: localhost - Server Port: 5201 - Duration: 360 Seconds - Test: UDP - 100Mbit Objective - Parallel: 32",
+		},
+		sourceUrl: "https://software.es.net/iperf/",
+	},
+	{
+		id: "iperf_server_address_localhost_server_port_5201_duration_360_seconds_test_udp_100mbit_objective_parallel_5",
+		dimension: "network",
+		unit: "Mbits/sec",
+		direction: "HIB",
+		headline: false,
+		label:
+			"iPerf - Server Address: localhost - Server Port: 5201 - Duration: 360 Seconds - Test: UDP - 100Mbit Objective - Parallel: 5",
+		description:
+			"iPerf is a network bandwidth throughput testing software. This test profile is used for automated testing of an iperf client and requires you have access to an iperf server.",
+		pts: {
+			test: "pts/iperf",
+			description:
+				"Server Address: localhost - Server Port: 5201 - Duration: 360 Seconds - Test: UDP - 100Mbit Objective - Parallel: 5",
+		},
+		sourceUrl: "https://software.es.net/iperf/",
+	},
+	{
+		id: "iperf_server_address_localhost_server_port_5201_duration_360_seconds_test_udp_100mbit_objective_parallel_64",
+		dimension: "network",
+		unit: "Mbits/sec",
+		direction: "HIB",
+		headline: false,
+		label:
+			"iPerf - Server Address: localhost - Server Port: 5201 - Duration: 360 Seconds - Test: UDP - 100Mbit Objective - Parallel: 64",
+		description:
+			"iPerf is a network bandwidth throughput testing software. This test profile is used for automated testing of an iperf client and requires you have access to an iperf server.",
+		pts: {
+			test: "pts/iperf",
+			description:
+				"Server Address: localhost - Server Port: 5201 - Duration: 360 Seconds - Test: UDP - 100Mbit Objective - Parallel: 64",
+		},
+		sourceUrl: "https://software.es.net/iperf/",
+	},
+	{
+		id: "iperf_server_address_localhost_server_port_5201_duration_360_seconds_test_udp_parallel_1",
+		dimension: "network",
+		unit: "Mbits/sec",
+		direction: "HIB",
+		headline: false,
+		label:
+			"iPerf - Server Address: localhost - Server Port: 5201 - Duration: 360 Seconds - Test: UDP - Parallel: 1",
+		description:
+			"iPerf is a network bandwidth throughput testing software. This test profile is used for automated testing of an iperf client and requires you have access to an iperf server.",
+		pts: {
+			test: "pts/iperf",
+			description:
+				"Server Address: localhost - Server Port: 5201 - Duration: 360 Seconds - Test: UDP - Parallel: 1",
+		},
+		sourceUrl: "https://software.es.net/iperf/",
+	},
+	{
+		id: "iperf_server_address_localhost_server_port_5201_duration_360_seconds_test_udp_parallel_10",
+		dimension: "network",
+		unit: "Mbits/sec",
+		direction: "HIB",
+		headline: false,
+		label:
+			"iPerf - Server Address: localhost - Server Port: 5201 - Duration: 360 Seconds - Test: UDP - Parallel: 10",
+		description:
+			"iPerf is a network bandwidth throughput testing software. This test profile is used for automated testing of an iperf client and requires you have access to an iperf server.",
+		pts: {
+			test: "pts/iperf",
+			description:
+				"Server Address: localhost - Server Port: 5201 - Duration: 360 Seconds - Test: UDP - Parallel: 10",
+		},
+		sourceUrl: "https://software.es.net/iperf/",
+	},
+	{
+		id: "iperf_server_address_localhost_server_port_5201_duration_360_seconds_test_udp_parallel_128",
+		dimension: "network",
+		unit: "Mbits/sec",
+		direction: "HIB",
+		headline: false,
+		label:
+			"iPerf - Server Address: localhost - Server Port: 5201 - Duration: 360 Seconds - Test: UDP - Parallel: 128",
+		description:
+			"iPerf is a network bandwidth throughput testing software. This test profile is used for automated testing of an iperf client and requires you have access to an iperf server.",
+		pts: {
+			test: "pts/iperf",
+			description:
+				"Server Address: localhost - Server Port: 5201 - Duration: 360 Seconds - Test: UDP - Parallel: 128",
+		},
+		sourceUrl: "https://software.es.net/iperf/",
+	},
+	{
+		id: "iperf_server_address_localhost_server_port_5201_duration_360_seconds_test_udp_parallel_20",
+		dimension: "network",
+		unit: "Mbits/sec",
+		direction: "HIB",
+		headline: false,
+		label:
+			"iPerf - Server Address: localhost - Server Port: 5201 - Duration: 360 Seconds - Test: UDP - Parallel: 20",
+		description:
+			"iPerf is a network bandwidth throughput testing software. This test profile is used for automated testing of an iperf client and requires you have access to an iperf server.",
+		pts: {
+			test: "pts/iperf",
+			description:
+				"Server Address: localhost - Server Port: 5201 - Duration: 360 Seconds - Test: UDP - Parallel: 20",
+		},
+		sourceUrl: "https://software.es.net/iperf/",
+	},
+	{
+		id: "iperf_server_address_localhost_server_port_5201_duration_360_seconds_test_udp_parallel_256",
+		dimension: "network",
+		unit: "Mbits/sec",
+		direction: "HIB",
+		headline: false,
+		label:
+			"iPerf - Server Address: localhost - Server Port: 5201 - Duration: 360 Seconds - Test: UDP - Parallel: 256",
+		description:
+			"iPerf is a network bandwidth throughput testing software. This test profile is used for automated testing of an iperf client and requires you have access to an iperf server.",
+		pts: {
+			test: "pts/iperf",
+			description:
+				"Server Address: localhost - Server Port: 5201 - Duration: 360 Seconds - Test: UDP - Parallel: 256",
+		},
+		sourceUrl: "https://software.es.net/iperf/",
+	},
+	{
+		id: "iperf_server_address_localhost_server_port_5201_duration_360_seconds_test_udp_parallel_32",
+		dimension: "network",
+		unit: "Mbits/sec",
+		direction: "HIB",
+		headline: false,
+		label:
+			"iPerf - Server Address: localhost - Server Port: 5201 - Duration: 360 Seconds - Test: UDP - Parallel: 32",
+		description:
+			"iPerf is a network bandwidth throughput testing software. This test profile is used for automated testing of an iperf client and requires you have access to an iperf server.",
+		pts: {
+			test: "pts/iperf",
+			description:
+				"Server Address: localhost - Server Port: 5201 - Duration: 360 Seconds - Test: UDP - Parallel: 32",
+		},
+		sourceUrl: "https://software.es.net/iperf/",
+	},
+	{
+		id: "iperf_server_address_localhost_server_port_5201_duration_360_seconds_test_udp_parallel_5",
+		dimension: "network",
+		unit: "Mbits/sec",
+		direction: "HIB",
+		headline: false,
+		label:
+			"iPerf - Server Address: localhost - Server Port: 5201 - Duration: 360 Seconds - Test: UDP - Parallel: 5",
+		description:
+			"iPerf is a network bandwidth throughput testing software. This test profile is used for automated testing of an iperf client and requires you have access to an iperf server.",
+		pts: {
+			test: "pts/iperf",
+			description:
+				"Server Address: localhost - Server Port: 5201 - Duration: 360 Seconds - Test: UDP - Parallel: 5",
+		},
+		sourceUrl: "https://software.es.net/iperf/",
+	},
+	{
+		id: "iperf_server_address_localhost_server_port_5201_duration_360_seconds_test_udp_parallel_64",
+		dimension: "network",
+		unit: "Mbits/sec",
+		direction: "HIB",
+		headline: false,
+		label:
+			"iPerf - Server Address: localhost - Server Port: 5201 - Duration: 360 Seconds - Test: UDP - Parallel: 64",
+		description:
+			"iPerf is a network bandwidth throughput testing software. This test profile is used for automated testing of an iperf client and requires you have access to an iperf server.",
+		pts: {
+			test: "pts/iperf",
+			description:
+				"Server Address: localhost - Server Port: 5201 - Duration: 360 Seconds - Test: UDP - Parallel: 64",
+		},
+		sourceUrl: "https://software.es.net/iperf/",
+	},
+	{
+		id: "iperf_server_address_localhost_server_port_5201_duration_60_seconds_test_tcp_parallel_1",
+		dimension: "network",
+		unit: "Mbits/sec",
+		direction: "HIB",
+		headline: false,
+		label:
+			"iPerf - Server Address: localhost - Server Port: 5201 - Duration: 60 Seconds - Test: TCP - Parallel: 1",
+		description:
+			"iPerf is a network bandwidth throughput testing software. This test profile is used for automated testing of an iperf client and requires you have access to an iperf server.",
+		pts: {
+			test: "pts/iperf",
+			description:
+				"Server Address: localhost - Server Port: 5201 - Duration: 60 Seconds - Test: TCP - Parallel: 1",
+		},
+		sourceUrl: "https://software.es.net/iperf/",
+	},
+	{
+		id: "iperf_server_address_localhost_server_port_5201_duration_60_seconds_test_tcp_parallel_10",
+		dimension: "network",
+		unit: "Mbits/sec",
+		direction: "HIB",
+		headline: false,
+		label:
+			"iPerf - Server Address: localhost - Server Port: 5201 - Duration: 60 Seconds - Test: TCP - Parallel: 10",
+		description:
+			"iPerf is a network bandwidth throughput testing software. This test profile is used for automated testing of an iperf client and requires you have access to an iperf server.",
+		pts: {
+			test: "pts/iperf",
+			description:
+				"Server Address: localhost - Server Port: 5201 - Duration: 60 Seconds - Test: TCP - Parallel: 10",
+		},
+		sourceUrl: "https://software.es.net/iperf/",
+	},
+	{
+		id: "iperf_server_address_localhost_server_port_5201_duration_60_seconds_test_tcp_parallel_128",
+		dimension: "network",
+		unit: "Mbits/sec",
+		direction: "HIB",
+		headline: false,
+		label:
+			"iPerf - Server Address: localhost - Server Port: 5201 - Duration: 60 Seconds - Test: TCP - Parallel: 128",
+		description:
+			"iPerf is a network bandwidth throughput testing software. This test profile is used for automated testing of an iperf client and requires you have access to an iperf server.",
+		pts: {
+			test: "pts/iperf",
+			description:
+				"Server Address: localhost - Server Port: 5201 - Duration: 60 Seconds - Test: TCP - Parallel: 128",
+		},
+		sourceUrl: "https://software.es.net/iperf/",
+	},
+	{
+		id: "iperf_server_address_localhost_server_port_5201_duration_60_seconds_test_tcp_parallel_20",
+		dimension: "network",
+		unit: "Mbits/sec",
+		direction: "HIB",
+		headline: false,
+		label:
+			"iPerf - Server Address: localhost - Server Port: 5201 - Duration: 60 Seconds - Test: TCP - Parallel: 20",
+		description:
+			"iPerf is a network bandwidth throughput testing software. This test profile is used for automated testing of an iperf client and requires you have access to an iperf server.",
+		pts: {
+			test: "pts/iperf",
+			description:
+				"Server Address: localhost - Server Port: 5201 - Duration: 60 Seconds - Test: TCP - Parallel: 20",
+		},
+		sourceUrl: "https://software.es.net/iperf/",
+	},
+	{
+		id: "iperf_server_address_localhost_server_port_5201_duration_60_seconds_test_tcp_parallel_256",
+		dimension: "network",
+		unit: "Mbits/sec",
+		direction: "HIB",
+		headline: false,
+		label:
+			"iPerf - Server Address: localhost - Server Port: 5201 - Duration: 60 Seconds - Test: TCP - Parallel: 256",
+		description:
+			"iPerf is a network bandwidth throughput testing software. This test profile is used for automated testing of an iperf client and requires you have access to an iperf server.",
+		pts: {
+			test: "pts/iperf",
+			description:
+				"Server Address: localhost - Server Port: 5201 - Duration: 60 Seconds - Test: TCP - Parallel: 256",
+		},
+		sourceUrl: "https://software.es.net/iperf/",
+	},
+	{
+		id: "iperf_server_address_localhost_server_port_5201_duration_60_seconds_test_tcp_parallel_32",
+		dimension: "network",
+		unit: "Mbits/sec",
+		direction: "HIB",
+		headline: false,
+		label:
+			"iPerf - Server Address: localhost - Server Port: 5201 - Duration: 60 Seconds - Test: TCP - Parallel: 32",
+		description:
+			"iPerf is a network bandwidth throughput testing software. This test profile is used for automated testing of an iperf client and requires you have access to an iperf server.",
+		pts: {
+			test: "pts/iperf",
+			description:
+				"Server Address: localhost - Server Port: 5201 - Duration: 60 Seconds - Test: TCP - Parallel: 32",
+		},
+		sourceUrl: "https://software.es.net/iperf/",
+	},
+	{
+		id: "iperf_server_address_localhost_server_port_5201_duration_60_seconds_test_tcp_parallel_5",
+		dimension: "network",
+		unit: "Mbits/sec",
+		direction: "HIB",
+		headline: false,
+		label:
+			"iPerf - Server Address: localhost - Server Port: 5201 - Duration: 60 Seconds - Test: TCP - Parallel: 5",
+		description:
+			"iPerf is a network bandwidth throughput testing software. This test profile is used for automated testing of an iperf client and requires you have access to an iperf server.",
+		pts: {
+			test: "pts/iperf",
+			description:
+				"Server Address: localhost - Server Port: 5201 - Duration: 60 Seconds - Test: TCP - Parallel: 5",
+		},
+		sourceUrl: "https://software.es.net/iperf/",
+	},
+	{
+		id: "iperf_server_address_localhost_server_port_5201_duration_60_seconds_test_tcp_parallel_64",
+		dimension: "network",
+		unit: "Mbits/sec",
+		direction: "HIB",
+		headline: false,
+		label:
+			"iPerf - Server Address: localhost - Server Port: 5201 - Duration: 60 Seconds - Test: TCP - Parallel: 64",
+		description:
+			"iPerf is a network bandwidth throughput testing software. This test profile is used for automated testing of an iperf client and requires you have access to an iperf server.",
+		pts: {
+			test: "pts/iperf",
+			description:
+				"Server Address: localhost - Server Port: 5201 - Duration: 60 Seconds - Test: TCP - Parallel: 64",
+		},
+		sourceUrl: "https://software.es.net/iperf/",
+	},
+	{
+		id: "iperf_server_address_localhost_server_port_5201_duration_60_seconds_test_udp_10000mbit_objective_parallel_1",
+		dimension: "network",
+		unit: "Mbits/sec",
+		direction: "HIB",
+		headline: false,
+		label:
+			"iPerf - Server Address: localhost - Server Port: 5201 - Duration: 60 Seconds - Test: UDP - 10000Mbit Objective - Parallel: 1",
+		description:
+			"iPerf is a network bandwidth throughput testing software. This test profile is used for automated testing of an iperf client and requires you have access to an iperf server.",
+		pts: {
+			test: "pts/iperf",
+			description:
+				"Server Address: localhost - Server Port: 5201 - Duration: 60 Seconds - Test: UDP - 10000Mbit Objective - Parallel: 1",
+		},
+		sourceUrl: "https://software.es.net/iperf/",
+	},
+	{
+		id: "iperf_server_address_localhost_server_port_5201_duration_60_seconds_test_udp_10000mbit_objective_parallel_10",
+		dimension: "network",
+		unit: "Mbits/sec",
+		direction: "HIB",
+		headline: false,
+		label:
+			"iPerf - Server Address: localhost - Server Port: 5201 - Duration: 60 Seconds - Test: UDP - 10000Mbit Objective - Parallel: 10",
+		description:
+			"iPerf is a network bandwidth throughput testing software. This test profile is used for automated testing of an iperf client and requires you have access to an iperf server.",
+		pts: {
+			test: "pts/iperf",
+			description:
+				"Server Address: localhost - Server Port: 5201 - Duration: 60 Seconds - Test: UDP - 10000Mbit Objective - Parallel: 10",
+		},
+		sourceUrl: "https://software.es.net/iperf/",
+	},
+	{
+		id: "iperf_server_address_localhost_server_port_5201_duration_60_seconds_test_udp_10000mbit_objective_parallel_128",
+		dimension: "network",
+		unit: "Mbits/sec",
+		direction: "HIB",
+		headline: false,
+		label:
+			"iPerf - Server Address: localhost - Server Port: 5201 - Duration: 60 Seconds - Test: UDP - 10000Mbit Objective - Parallel: 128",
+		description:
+			"iPerf is a network bandwidth throughput testing software. This test profile is used for automated testing of an iperf client and requires you have access to an iperf server.",
+		pts: {
+			test: "pts/iperf",
+			description:
+				"Server Address: localhost - Server Port: 5201 - Duration: 60 Seconds - Test: UDP - 10000Mbit Objective - Parallel: 128",
+		},
+		sourceUrl: "https://software.es.net/iperf/",
+	},
+	{
+		id: "iperf_server_address_localhost_server_port_5201_duration_60_seconds_test_udp_10000mbit_objective_parallel_20",
+		dimension: "network",
+		unit: "Mbits/sec",
+		direction: "HIB",
+		headline: false,
+		label:
+			"iPerf - Server Address: localhost - Server Port: 5201 - Duration: 60 Seconds - Test: UDP - 10000Mbit Objective - Parallel: 20",
+		description:
+			"iPerf is a network bandwidth throughput testing software. This test profile is used for automated testing of an iperf client and requires you have access to an iperf server.",
+		pts: {
+			test: "pts/iperf",
+			description:
+				"Server Address: localhost - Server Port: 5201 - Duration: 60 Seconds - Test: UDP - 10000Mbit Objective - Parallel: 20",
+		},
+		sourceUrl: "https://software.es.net/iperf/",
+	},
+	{
+		id: "iperf_server_address_localhost_server_port_5201_duration_60_seconds_test_udp_10000mbit_objective_parallel_256",
+		dimension: "network",
+		unit: "Mbits/sec",
+		direction: "HIB",
+		headline: false,
+		label:
+			"iPerf - Server Address: localhost - Server Port: 5201 - Duration: 60 Seconds - Test: UDP - 10000Mbit Objective - Parallel: 256",
+		description:
+			"iPerf is a network bandwidth throughput testing software. This test profile is used for automated testing of an iperf client and requires you have access to an iperf server.",
+		pts: {
+			test: "pts/iperf",
+			description:
+				"Server Address: localhost - Server Port: 5201 - Duration: 60 Seconds - Test: UDP - 10000Mbit Objective - Parallel: 256",
+		},
+		sourceUrl: "https://software.es.net/iperf/",
+	},
+	{
+		id: "iperf_server_address_localhost_server_port_5201_duration_60_seconds_test_udp_10000mbit_objective_parallel_32",
+		dimension: "network",
+		unit: "Mbits/sec",
+		direction: "HIB",
+		headline: false,
+		label:
+			"iPerf - Server Address: localhost - Server Port: 5201 - Duration: 60 Seconds - Test: UDP - 10000Mbit Objective - Parallel: 32",
+		description:
+			"iPerf is a network bandwidth throughput testing software. This test profile is used for automated testing of an iperf client and requires you have access to an iperf server.",
+		pts: {
+			test: "pts/iperf",
+			description:
+				"Server Address: localhost - Server Port: 5201 - Duration: 60 Seconds - Test: UDP - 10000Mbit Objective - Parallel: 32",
+		},
+		sourceUrl: "https://software.es.net/iperf/",
+	},
+	{
+		id: "iperf_server_address_localhost_server_port_5201_duration_60_seconds_test_udp_10000mbit_objective_parallel_5",
+		dimension: "network",
+		unit: "Mbits/sec",
+		direction: "HIB",
+		headline: false,
+		label:
+			"iPerf - Server Address: localhost - Server Port: 5201 - Duration: 60 Seconds - Test: UDP - 10000Mbit Objective - Parallel: 5",
+		description:
+			"iPerf is a network bandwidth throughput testing software. This test profile is used for automated testing of an iperf client and requires you have access to an iperf server.",
+		pts: {
+			test: "pts/iperf",
+			description:
+				"Server Address: localhost - Server Port: 5201 - Duration: 60 Seconds - Test: UDP - 10000Mbit Objective - Parallel: 5",
+		},
+		sourceUrl: "https://software.es.net/iperf/",
+	},
+	{
+		id: "iperf_server_address_localhost_server_port_5201_duration_60_seconds_test_udp_10000mbit_objective_parallel_64",
+		dimension: "network",
+		unit: "Mbits/sec",
+		direction: "HIB",
+		headline: false,
+		label:
+			"iPerf - Server Address: localhost - Server Port: 5201 - Duration: 60 Seconds - Test: UDP - 10000Mbit Objective - Parallel: 64",
+		description:
+			"iPerf is a network bandwidth throughput testing software. This test profile is used for automated testing of an iperf client and requires you have access to an iperf server.",
+		pts: {
+			test: "pts/iperf",
+			description:
+				"Server Address: localhost - Server Port: 5201 - Duration: 60 Seconds - Test: UDP - 10000Mbit Objective - Parallel: 64",
+		},
+		sourceUrl: "https://software.es.net/iperf/",
+	},
+	{
+		id: "iperf_server_address_localhost_server_port_5201_duration_60_seconds_test_udp_1000mbit_objective_parallel_1",
+		dimension: "network",
+		unit: "Mbits/sec",
+		direction: "HIB",
+		headline: false,
+		label:
+			"iPerf - Server Address: localhost - Server Port: 5201 - Duration: 60 Seconds - Test: UDP - 1000Mbit Objective - Parallel: 1",
+		description:
+			"iPerf is a network bandwidth throughput testing software. This test profile is used for automated testing of an iperf client and requires you have access to an iperf server.",
+		pts: {
+			test: "pts/iperf",
+			description:
+				"Server Address: localhost - Server Port: 5201 - Duration: 60 Seconds - Test: UDP - 1000Mbit Objective - Parallel: 1",
+		},
+		sourceUrl: "https://software.es.net/iperf/",
+	},
+	{
+		id: "iperf_server_address_localhost_server_port_5201_duration_60_seconds_test_udp_1000mbit_objective_parallel_10",
+		dimension: "network",
+		unit: "Mbits/sec",
+		direction: "HIB",
+		headline: false,
+		label:
+			"iPerf - Server Address: localhost - Server Port: 5201 - Duration: 60 Seconds - Test: UDP - 1000Mbit Objective - Parallel: 10",
+		description:
+			"iPerf is a network bandwidth throughput testing software. This test profile is used for automated testing of an iperf client and requires you have access to an iperf server.",
+		pts: {
+			test: "pts/iperf",
+			description:
+				"Server Address: localhost - Server Port: 5201 - Duration: 60 Seconds - Test: UDP - 1000Mbit Objective - Parallel: 10",
+		},
+		sourceUrl: "https://software.es.net/iperf/",
+	},
+	{
+		id: "iperf_server_address_localhost_server_port_5201_duration_60_seconds_test_udp_1000mbit_objective_parallel_128",
+		dimension: "network",
+		unit: "Mbits/sec",
+		direction: "HIB",
+		headline: false,
+		label:
+			"iPerf - Server Address: localhost - Server Port: 5201 - Duration: 60 Seconds - Test: UDP - 1000Mbit Objective - Parallel: 128",
+		description:
+			"iPerf is a network bandwidth throughput testing software. This test profile is used for automated testing of an iperf client and requires you have access to an iperf server.",
+		pts: {
+			test: "pts/iperf",
+			description:
+				"Server Address: localhost - Server Port: 5201 - Duration: 60 Seconds - Test: UDP - 1000Mbit Objective - Parallel: 128",
+		},
+		sourceUrl: "https://software.es.net/iperf/",
+	},
+	{
+		id: "iperf_server_address_localhost_server_port_5201_duration_60_seconds_test_udp_1000mbit_objective_parallel_20",
+		dimension: "network",
+		unit: "Mbits/sec",
+		direction: "HIB",
+		headline: false,
+		label:
+			"iPerf - Server Address: localhost - Server Port: 5201 - Duration: 60 Seconds - Test: UDP - 1000Mbit Objective - Parallel: 20",
+		description:
+			"iPerf is a network bandwidth throughput testing software. This test profile is used for automated testing of an iperf client and requires you have access to an iperf server.",
+		pts: {
+			test: "pts/iperf",
+			description:
+				"Server Address: localhost - Server Port: 5201 - Duration: 60 Seconds - Test: UDP - 1000Mbit Objective - Parallel: 20",
+		},
+		sourceUrl: "https://software.es.net/iperf/",
+	},
+	{
+		id: "iperf_server_address_localhost_server_port_5201_duration_60_seconds_test_udp_1000mbit_objective_parallel_256",
+		dimension: "network",
+		unit: "Mbits/sec",
+		direction: "HIB",
+		headline: false,
+		label:
+			"iPerf - Server Address: localhost - Server Port: 5201 - Duration: 60 Seconds - Test: UDP - 1000Mbit Objective - Parallel: 256",
+		description:
+			"iPerf is a network bandwidth throughput testing software. This test profile is used for automated testing of an iperf client and requires you have access to an iperf server.",
+		pts: {
+			test: "pts/iperf",
+			description:
+				"Server Address: localhost - Server Port: 5201 - Duration: 60 Seconds - Test: UDP - 1000Mbit Objective - Parallel: 256",
+		},
+		sourceUrl: "https://software.es.net/iperf/",
+	},
+	{
+		id: "iperf_server_address_localhost_server_port_5201_duration_60_seconds_test_udp_1000mbit_objective_parallel_32",
+		dimension: "network",
+		unit: "Mbits/sec",
+		direction: "HIB",
+		headline: false,
+		label:
+			"iPerf - Server Address: localhost - Server Port: 5201 - Duration: 60 Seconds - Test: UDP - 1000Mbit Objective - Parallel: 32",
+		description:
+			"iPerf is a network bandwidth throughput testing software. This test profile is used for automated testing of an iperf client and requires you have access to an iperf server.",
+		pts: {
+			test: "pts/iperf",
+			description:
+				"Server Address: localhost - Server Port: 5201 - Duration: 60 Seconds - Test: UDP - 1000Mbit Objective - Parallel: 32",
+		},
+		sourceUrl: "https://software.es.net/iperf/",
+	},
+	{
+		id: "iperf_server_address_localhost_server_port_5201_duration_60_seconds_test_udp_1000mbit_objective_parallel_5",
+		dimension: "network",
+		unit: "Mbits/sec",
+		direction: "HIB",
+		headline: false,
+		label:
+			"iPerf - Server Address: localhost - Server Port: 5201 - Duration: 60 Seconds - Test: UDP - 1000Mbit Objective - Parallel: 5",
+		description:
+			"iPerf is a network bandwidth throughput testing software. This test profile is used for automated testing of an iperf client and requires you have access to an iperf server.",
+		pts: {
+			test: "pts/iperf",
+			description:
+				"Server Address: localhost - Server Port: 5201 - Duration: 60 Seconds - Test: UDP - 1000Mbit Objective - Parallel: 5",
+		},
+		sourceUrl: "https://software.es.net/iperf/",
+	},
+	{
+		id: "iperf_server_address_localhost_server_port_5201_duration_60_seconds_test_udp_1000mbit_objective_parallel_64",
+		dimension: "network",
+		unit: "Mbits/sec",
+		direction: "HIB",
+		headline: false,
+		label:
+			"iPerf - Server Address: localhost - Server Port: 5201 - Duration: 60 Seconds - Test: UDP - 1000Mbit Objective - Parallel: 64",
+		description:
+			"iPerf is a network bandwidth throughput testing software. This test profile is used for automated testing of an iperf client and requires you have access to an iperf server.",
+		pts: {
+			test: "pts/iperf",
+			description:
+				"Server Address: localhost - Server Port: 5201 - Duration: 60 Seconds - Test: UDP - 1000Mbit Objective - Parallel: 64",
+		},
+		sourceUrl: "https://software.es.net/iperf/",
+	},
+	{
+		id: "iperf_server_address_localhost_server_port_5201_duration_60_seconds_test_udp_100mbit_objective_parallel_1",
+		dimension: "network",
+		unit: "Mbits/sec",
+		direction: "HIB",
+		headline: false,
+		label:
+			"iPerf - Server Address: localhost - Server Port: 5201 - Duration: 60 Seconds - Test: UDP - 100Mbit Objective - Parallel: 1",
+		description:
+			"iPerf is a network bandwidth throughput testing software. This test profile is used for automated testing of an iperf client and requires you have access to an iperf server.",
+		pts: {
+			test: "pts/iperf",
+			description:
+				"Server Address: localhost - Server Port: 5201 - Duration: 60 Seconds - Test: UDP - 100Mbit Objective - Parallel: 1",
+		},
+		sourceUrl: "https://software.es.net/iperf/",
+	},
+	{
+		id: "iperf_server_address_localhost_server_port_5201_duration_60_seconds_test_udp_100mbit_objective_parallel_10",
+		dimension: "network",
+		unit: "Mbits/sec",
+		direction: "HIB",
+		headline: false,
+		label:
+			"iPerf - Server Address: localhost - Server Port: 5201 - Duration: 60 Seconds - Test: UDP - 100Mbit Objective - Parallel: 10",
+		description:
+			"iPerf is a network bandwidth throughput testing software. This test profile is used for automated testing of an iperf client and requires you have access to an iperf server.",
+		pts: {
+			test: "pts/iperf",
+			description:
+				"Server Address: localhost - Server Port: 5201 - Duration: 60 Seconds - Test: UDP - 100Mbit Objective - Parallel: 10",
+		},
+		sourceUrl: "https://software.es.net/iperf/",
+	},
+	{
+		id: "iperf_server_address_localhost_server_port_5201_duration_60_seconds_test_udp_100mbit_objective_parallel_128",
+		dimension: "network",
+		unit: "Mbits/sec",
+		direction: "HIB",
+		headline: false,
+		label:
+			"iPerf - Server Address: localhost - Server Port: 5201 - Duration: 60 Seconds - Test: UDP - 100Mbit Objective - Parallel: 128",
+		description:
+			"iPerf is a network bandwidth throughput testing software. This test profile is used for automated testing of an iperf client and requires you have access to an iperf server.",
+		pts: {
+			test: "pts/iperf",
+			description:
+				"Server Address: localhost - Server Port: 5201 - Duration: 60 Seconds - Test: UDP - 100Mbit Objective - Parallel: 128",
+		},
+		sourceUrl: "https://software.es.net/iperf/",
+	},
+	{
+		id: "iperf_server_address_localhost_server_port_5201_duration_60_seconds_test_udp_100mbit_objective_parallel_20",
+		dimension: "network",
+		unit: "Mbits/sec",
+		direction: "HIB",
+		headline: false,
+		label:
+			"iPerf - Server Address: localhost - Server Port: 5201 - Duration: 60 Seconds - Test: UDP - 100Mbit Objective - Parallel: 20",
+		description:
+			"iPerf is a network bandwidth throughput testing software. This test profile is used for automated testing of an iperf client and requires you have access to an iperf server.",
+		pts: {
+			test: "pts/iperf",
+			description:
+				"Server Address: localhost - Server Port: 5201 - Duration: 60 Seconds - Test: UDP - 100Mbit Objective - Parallel: 20",
+		},
+		sourceUrl: "https://software.es.net/iperf/",
+	},
+	{
+		id: "iperf_server_address_localhost_server_port_5201_duration_60_seconds_test_udp_100mbit_objective_parallel_256",
+		dimension: "network",
+		unit: "Mbits/sec",
+		direction: "HIB",
+		headline: false,
+		label:
+			"iPerf - Server Address: localhost - Server Port: 5201 - Duration: 60 Seconds - Test: UDP - 100Mbit Objective - Parallel: 256",
+		description:
+			"iPerf is a network bandwidth throughput testing software. This test profile is used for automated testing of an iperf client and requires you have access to an iperf server.",
+		pts: {
+			test: "pts/iperf",
+			description:
+				"Server Address: localhost - Server Port: 5201 - Duration: 60 Seconds - Test: UDP - 100Mbit Objective - Parallel: 256",
+		},
+		sourceUrl: "https://software.es.net/iperf/",
+	},
+	{
+		id: "iperf_server_address_localhost_server_port_5201_duration_60_seconds_test_udp_100mbit_objective_parallel_32",
+		dimension: "network",
+		unit: "Mbits/sec",
+		direction: "HIB",
+		headline: false,
+		label:
+			"iPerf - Server Address: localhost - Server Port: 5201 - Duration: 60 Seconds - Test: UDP - 100Mbit Objective - Parallel: 32",
+		description:
+			"iPerf is a network bandwidth throughput testing software. This test profile is used for automated testing of an iperf client and requires you have access to an iperf server.",
+		pts: {
+			test: "pts/iperf",
+			description:
+				"Server Address: localhost - Server Port: 5201 - Duration: 60 Seconds - Test: UDP - 100Mbit Objective - Parallel: 32",
+		},
+		sourceUrl: "https://software.es.net/iperf/",
+	},
+	{
+		id: "iperf_server_address_localhost_server_port_5201_duration_60_seconds_test_udp_100mbit_objective_parallel_5",
+		dimension: "network",
+		unit: "Mbits/sec",
+		direction: "HIB",
+		headline: false,
+		label:
+			"iPerf - Server Address: localhost - Server Port: 5201 - Duration: 60 Seconds - Test: UDP - 100Mbit Objective - Parallel: 5",
+		description:
+			"iPerf is a network bandwidth throughput testing software. This test profile is used for automated testing of an iperf client and requires you have access to an iperf server.",
+		pts: {
+			test: "pts/iperf",
+			description:
+				"Server Address: localhost - Server Port: 5201 - Duration: 60 Seconds - Test: UDP - 100Mbit Objective - Parallel: 5",
+		},
+		sourceUrl: "https://software.es.net/iperf/",
+	},
+	{
+		id: "iperf_server_address_localhost_server_port_5201_duration_60_seconds_test_udp_100mbit_objective_parallel_64",
+		dimension: "network",
+		unit: "Mbits/sec",
+		direction: "HIB",
+		headline: false,
+		label:
+			"iPerf - Server Address: localhost - Server Port: 5201 - Duration: 60 Seconds - Test: UDP - 100Mbit Objective - Parallel: 64",
+		description:
+			"iPerf is a network bandwidth throughput testing software. This test profile is used for automated testing of an iperf client and requires you have access to an iperf server.",
+		pts: {
+			test: "pts/iperf",
+			description:
+				"Server Address: localhost - Server Port: 5201 - Duration: 60 Seconds - Test: UDP - 100Mbit Objective - Parallel: 64",
+		},
+		sourceUrl: "https://software.es.net/iperf/",
+	},
+	{
+		id: "iperf_server_address_localhost_server_port_5201_duration_60_seconds_test_udp_parallel_1",
+		dimension: "network",
+		unit: "Mbits/sec",
+		direction: "HIB",
+		headline: false,
+		label:
+			"iPerf - Server Address: localhost - Server Port: 5201 - Duration: 60 Seconds - Test: UDP - Parallel: 1",
+		description:
+			"iPerf is a network bandwidth throughput testing software. This test profile is used for automated testing of an iperf client and requires you have access to an iperf server.",
+		pts: {
+			test: "pts/iperf",
+			description:
+				"Server Address: localhost - Server Port: 5201 - Duration: 60 Seconds - Test: UDP - Parallel: 1",
+		},
+		sourceUrl: "https://software.es.net/iperf/",
+	},
+	{
+		id: "iperf_server_address_localhost_server_port_5201_duration_60_seconds_test_udp_parallel_10",
+		dimension: "network",
+		unit: "Mbits/sec",
+		direction: "HIB",
+		headline: false,
+		label:
+			"iPerf - Server Address: localhost - Server Port: 5201 - Duration: 60 Seconds - Test: UDP - Parallel: 10",
+		description:
+			"iPerf is a network bandwidth throughput testing software. This test profile is used for automated testing of an iperf client and requires you have access to an iperf server.",
+		pts: {
+			test: "pts/iperf",
+			description:
+				"Server Address: localhost - Server Port: 5201 - Duration: 60 Seconds - Test: UDP - Parallel: 10",
+		},
+		sourceUrl: "https://software.es.net/iperf/",
+	},
+	{
+		id: "iperf_server_address_localhost_server_port_5201_duration_60_seconds_test_udp_parallel_128",
+		dimension: "network",
+		unit: "Mbits/sec",
+		direction: "HIB",
+		headline: false,
+		label:
+			"iPerf - Server Address: localhost - Server Port: 5201 - Duration: 60 Seconds - Test: UDP - Parallel: 128",
+		description:
+			"iPerf is a network bandwidth throughput testing software. This test profile is used for automated testing of an iperf client and requires you have access to an iperf server.",
+		pts: {
+			test: "pts/iperf",
+			description:
+				"Server Address: localhost - Server Port: 5201 - Duration: 60 Seconds - Test: UDP - Parallel: 128",
+		},
+		sourceUrl: "https://software.es.net/iperf/",
+	},
+	{
+		id: "iperf_server_address_localhost_server_port_5201_duration_60_seconds_test_udp_parallel_20",
+		dimension: "network",
+		unit: "Mbits/sec",
+		direction: "HIB",
+		headline: false,
+		label:
+			"iPerf - Server Address: localhost - Server Port: 5201 - Duration: 60 Seconds - Test: UDP - Parallel: 20",
+		description:
+			"iPerf is a network bandwidth throughput testing software. This test profile is used for automated testing of an iperf client and requires you have access to an iperf server.",
+		pts: {
+			test: "pts/iperf",
+			description:
+				"Server Address: localhost - Server Port: 5201 - Duration: 60 Seconds - Test: UDP - Parallel: 20",
+		},
+		sourceUrl: "https://software.es.net/iperf/",
+	},
+	{
+		id: "iperf_server_address_localhost_server_port_5201_duration_60_seconds_test_udp_parallel_256",
+		dimension: "network",
+		unit: "Mbits/sec",
+		direction: "HIB",
+		headline: false,
+		label:
+			"iPerf - Server Address: localhost - Server Port: 5201 - Duration: 60 Seconds - Test: UDP - Parallel: 256",
+		description:
+			"iPerf is a network bandwidth throughput testing software. This test profile is used for automated testing of an iperf client and requires you have access to an iperf server.",
+		pts: {
+			test: "pts/iperf",
+			description:
+				"Server Address: localhost - Server Port: 5201 - Duration: 60 Seconds - Test: UDP - Parallel: 256",
+		},
+		sourceUrl: "https://software.es.net/iperf/",
+	},
+	{
+		id: "iperf_server_address_localhost_server_port_5201_duration_60_seconds_test_udp_parallel_32",
+		dimension: "network",
+		unit: "Mbits/sec",
+		direction: "HIB",
+		headline: false,
+		label:
+			"iPerf - Server Address: localhost - Server Port: 5201 - Duration: 60 Seconds - Test: UDP - Parallel: 32",
+		description:
+			"iPerf is a network bandwidth throughput testing software. This test profile is used for automated testing of an iperf client and requires you have access to an iperf server.",
+		pts: {
+			test: "pts/iperf",
+			description:
+				"Server Address: localhost - Server Port: 5201 - Duration: 60 Seconds - Test: UDP - Parallel: 32",
+		},
+		sourceUrl: "https://software.es.net/iperf/",
+	},
+	{
+		id: "iperf_server_address_localhost_server_port_5201_duration_60_seconds_test_udp_parallel_5",
+		dimension: "network",
+		unit: "Mbits/sec",
+		direction: "HIB",
+		headline: false,
+		label:
+			"iPerf - Server Address: localhost - Server Port: 5201 - Duration: 60 Seconds - Test: UDP - Parallel: 5",
+		description:
+			"iPerf is a network bandwidth throughput testing software. This test profile is used for automated testing of an iperf client and requires you have access to an iperf server.",
+		pts: {
+			test: "pts/iperf",
+			description:
+				"Server Address: localhost - Server Port: 5201 - Duration: 60 Seconds - Test: UDP - Parallel: 5",
+		},
+		sourceUrl: "https://software.es.net/iperf/",
+	},
+	{
+		id: "iperf_server_address_localhost_server_port_5201_duration_60_seconds_test_udp_parallel_64",
+		dimension: "network",
+		unit: "Mbits/sec",
+		direction: "HIB",
+		headline: false,
+		label:
+			"iPerf - Server Address: localhost - Server Port: 5201 - Duration: 60 Seconds - Test: UDP - Parallel: 64",
+		description:
+			"iPerf is a network bandwidth throughput testing software. This test profile is used for automated testing of an iperf client and requires you have access to an iperf server.",
+		pts: {
+			test: "pts/iperf",
+			description:
+				"Server Address: localhost - Server Port: 5201 - Duration: 60 Seconds - Test: UDP - Parallel: 64",
 		},
 		sourceUrl: "https://software.es.net/iperf/",
 	},
@@ -17869,9 +20558,6 @@ const chunk4: MetricDef[] = [
 		},
 		sourceUrl: "https://www.postgresql.org/",
 	},
-];
-
-const chunk5: MetricDef[] = [
 	{
 		id: "pgbench_scaling_factor_10000_clients_800_mode_read_only",
 		dimension: "system",
@@ -19234,6 +21920,9 @@ const chunk5: MetricDef[] = [
 		},
 		sourceUrl: "https://www.postgresql.org/",
 	},
+];
+
+const chunk6: MetricDef[] = [
 	{
 		id: "pgbench_scaling_factor_1_clients_50_mode_read_only",
 		dimension: "system",
@@ -20173,4 +22862,11 @@ const chunk5: MetricDef[] = [
 	},
 ];
 
-export const ptsGenerated: MetricDef[] = [...chunk1, ...chunk2, ...chunk3, ...chunk4, ...chunk5];
+export const ptsGenerated: MetricDef[] = [
+	...chunk1,
+	...chunk2,
+	...chunk3,
+	...chunk4,
+	...chunk5,
+	...chunk6,
+];

--- a/packages/schema/src/pts-overrides.ts
+++ b/packages/schema/src/pts-overrides.ts
@@ -89,9 +89,12 @@ export const ptsOverrides: Record<string, MetricOverride> = {
 	// path — single-stream is the dimension's headline (it took the slot from network_loopback when
 	// the suite moved off the dd|nc leaf; the catalog allows one headline per dimension), and the
 	// 10-stream variant captures per-stream overhead scaling (iperf 3.14 is single-threaded, so it
-	// multiplexes streams in one process rather than across cores). The WAN pair measures both
-	// directions against the closest curated public iperf3 server (chosen per run by RTT probe,
-	// recorded in pts_iperf-wan--server-choices.ndjson provenance).
+	// multiplexes streams in one process rather than across cores). pts/iperf is vendored
+	// byte-identical to upstream, so the generator enumerates its full option matrix (fio-style);
+	// only the two combinations the producer pins are curated here — the rest keep draft labels and
+	// never receive samples. The WAN pair measures both directions against the closest curated
+	// public iperf3 server (chosen per run by RTT probe, recorded in
+	// pts_iperf-wan--server-choices.ndjson provenance).
 	iperf_server_address_localhost_server_port_5201_duration_10_seconds_test_tcp_parallel_1: {
 		headline: true,
 		label: "iperf3 loopback TCP, 1 stream",

--- a/packages/schema/src/pts-overrides.ts
+++ b/packages/schema/src/pts-overrides.ts
@@ -84,13 +84,30 @@ export const ptsOverrides: Record<string, MetricOverride> = {
 	fio_type_random_write_engine_linux_aio_direct_no_block_size_4kb_job_count_1_disk_target_default_test_directory_mb_per_s:
 		{ label: "fio rand write 4KB, buffered (MB/s)" },
 
-	// Network dimension: loopback remains the stable headline that separates sandbox network-stack
-	// overhead from Internet/CDN weather; fast.com adds sustained real-world transfer measurements.
+	// Network dimension. The suite's composition is the four iperf metrics: localhost isolates
+	// sandbox network-stack/virtualization overhead (virtio/KVM vs gVisor netstack) with no Internet
+	// path — single-stream is the dimension's headline (it took the slot from network_loopback when
+	// the suite moved off the dd|nc leaf; the catalog allows one headline per dimension), and the
+	// 10-stream variant captures per-stream overhead scaling (iperf 3.14 is single-threaded, so it
+	// multiplexes streams in one process rather than across cores). The WAN pair measures both
+	// directions against the closest curated public iperf3 server (chosen per run by RTT probe,
+	// recorded in pts_iperf-wan--server-choices.ndjson provenance).
+	iperf_server_address_localhost_server_port_5201_duration_10_seconds_test_tcp_parallel_1: {
+		headline: true,
+		label: "iperf3 loopback TCP, 1 stream",
+	},
+	iperf_server_address_localhost_server_port_5201_duration_10_seconds_test_tcp_parallel_10: {
+		label: "iperf3 loopback TCP, 10 streams",
+	},
+	iperf_wan_direction_download: { label: "iperf3 WAN download" },
+	iperf_wan_direction_upload: { label: "iperf3 WAN upload" },
+	// Retained profiles the suite no longer runs (manual benchmark:network:all composition): labels
+	// kept so manual results stay readable; loopback's former headline moved to iperf above.
 	fast_cli_internet_download_speed: { label: "fast.com download" },
 	fast_cli_internet_upload_speed: { label: "fast.com upload" },
 	fast_cli_internet_latency: { label: "fast.com latency" },
 	fast_cli_internet_loaded_latency_bufferbloat: { label: "fast.com loaded latency" },
-	network_loopback_seconds: { headline: true, label: "Loopback TCP (10GB)" },
+	network_loopback_seconds: { label: "Loopback TCP (10GB)" },
 
 	// System dimension: the synthetic Git profile complements the realworld repo tasks by isolating a
 	// fixed command sequence over a fixed GTK corpus.

--- a/packages/schema/src/pts-profiles.test.ts
+++ b/packages/schema/src/pts-profiles.test.ts
@@ -64,7 +64,9 @@ describe("realworld profiles: Task Option <-> target.env consistency", () => {
 				const values = new Set(
 					profile.settings
 						.find((option) => option.DisplayName === "Task")
-						?.Menu?.Entry.map((e) => e.Value) ?? [],
+						// `<Value>` is optional in the schema (iperf's TCP entry); realworld Task entries always
+						// carry one, and a missing value maps to "" here so the key-set equality still fails loudly.
+						?.Menu?.Entry.map((e) => e.Value ?? "") ?? [],
 				);
 				const taskCmdKeys = new Set(
 					Object.keys(env)
@@ -84,7 +86,9 @@ describe("realworld profiles: Task Option <-> target.env consistency", () => {
 				const values = new Set(
 					profile.settings
 						.find((option) => option.DisplayName === "Task")
-						?.Menu?.Entry.map((e) => e.Value) ?? [],
+						// `<Value>` is optional in the schema (iperf's TCP entry); realworld Task entries always
+						// carry one, and a missing value maps to "" here so the key-set equality still fails loudly.
+						?.Menu?.Entry.map((e) => e.Value ?? "") ?? [],
 				);
 				const prepKeys = Object.keys(env)
 					.filter((key) => key.startsWith("TASK_PREP_"))

--- a/packages/schema/src/pts-profiles/iperf-1.2.0/downloads.xml
+++ b/packages/schema/src/pts-profiles/iperf-1.2.0/downloads.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0"?>
+<!--Phoronix Test Suite v10.8.4-->
+<PhoronixTestSuite>
+  <Downloads>
+    <Package>
+      <URL>https://downloads.es.net/pub/iperf/iperf-3.14.tar.gz</URL>
+      <MD5>2fcf9691a062e905204c1868686cb051</MD5>
+      <SHA256>723fcc430a027bc6952628fa2a3ac77584a1d0bd328275e573fc9b206c155004</SHA256>
+      <FileName>iperf-3.14.tar.gz</FileName>
+      <FileSize>647944</FileSize>
+      <PlatformSpecific>Linux, BSD, Solaris, MacOSX</PlatformSpecific>
+    </Package>
+  </Downloads>
+</PhoronixTestSuite>

--- a/packages/schema/src/pts-profiles/iperf-1.2.0/install.sh
+++ b/packages/schema/src/pts-profiles/iperf-1.2.0/install.sh
@@ -23,8 +23,11 @@ set -eu
 #     `sleep 3` with a bounded readiness poll on /proc/net/tcp{,6} (the deleted vendored
 #     network-loopback runner's proven pattern) that falls through after ~10s and lets the client
 #     fail honestly.
-#   * The vendored test-definition.xml pins TimesToRun to 2 (repo rule: trial count stays 2) and
-#     the option matrix to the localhost subset the network suite actually runs.
+#   * The vendored test-definition.xml is BYTE-IDENTICAL to upstream at the pinned REF (the fio
+#     precedent: full option matrix catalogued; the producer leaf pins its combinations via
+#     PRESET_OPTIONS). Its TimesToRun=3 is inert: the harness preamble pins FORCE_TIMES_TO_RUN from
+#     Suite.ptsTimesToRun (k=2 — repo rule: trial count stays 2) and lib/bench.sh pins 1 for bare
+#     runs.
 
 prefix="$(pwd)/iperf-install"
 rm -rf iperf-3.14 "$prefix"

--- a/packages/schema/src/pts-profiles/iperf-1.2.0/install.sh
+++ b/packages/schema/src/pts-profiles/iperf-1.2.0/install.sh
@@ -1,0 +1,70 @@
+#!/bin/sh
+set -eu
+
+# Vendored repair of upstream pts/iperf-1.2.0's install.sh, kept under the same `pts/` identifier
+# (the catalog join key). Deltas vs upstream, each deliberate:
+#
+#   * Install prefix: the profile's own installed-tests dir (cwd at install time), spelled from
+#     $(pwd) instead of upstream's $HOME/iperf-install. PTS points HOME at the installed dir during
+#     install/run, so upstream lands in the same place — but deriving the prefix from cwd keeps
+#     every heavy write inside the PTS data dir even if a provider's HOME handling drifts. On blaxel
+#     the root fs is RAM-backed and only /var/lib/phoronix-test-suite (the volume) may take heavy
+#     writes; the PTS data dir lives there.
+#   * CFLAGS: generic -O3, dropping upstream's -march=native. Native-to-the-build-machine binaries
+#     are exactly the class the toolchain bake already patches fio for (modal's gVisor exposes no
+#     AVX-512, so a builder-native binary can die at run time), and iperf's own CPU tuning is not
+#     the thing being benchmarked. CFLAGS_OVERRIDE still wins when a caller sets it, as upstream.
+#   * The generated runner fixes upstream's `2>1` typo (client stderr went to a file literally
+#     named "1" instead of the log), detaches the local server's stdio from the runner's pipe (PTS
+#     reads the runner's stdout to EOF, so an inherited fd on a lingering listener would pin every
+#     trial to the harness watchdog — the exact pipe-hold that burned ~213s/trial on fast-cli in
+#     run 29937467891), runs the server one-off (-1: it exits after serving the single client run,
+#     so a missed kill cannot leak a listener into the next trial), and replaces the fixed
+#     `sleep 3` with a bounded readiness poll on /proc/net/tcp{,6} (the deleted vendored
+#     network-loopback runner's proven pattern) that falls through after ~10s and lets the client
+#     fail honestly.
+#   * The vendored test-definition.xml pins TimesToRun to 2 (repo rule: trial count stays 2) and
+#     the option matrix to the localhost subset the network suite actually runs.
+
+prefix="$(pwd)/iperf-install"
+rm -rf iperf-3.14 "$prefix"
+tar -zxf iperf-3.14.tar.gz
+cd iperf-3.14
+if [ "${CFLAGS_OVERRIDE:-}" = "" ]; then
+	CFLAGS="${CFLAGS:-} -O3"
+else
+	CFLAGS="$CFLAGS_OVERRIDE"
+fi
+./configure --prefix="$prefix" CFLAGS="$CFLAGS"
+make -j "${NUM_CPU_CORES:-2}"
+make install
+cd ..
+rm -rf iperf-3.14
+
+cat <<'EOF' > iperf
+#!/bin/sh
+# Runner for the localhost subset: self-hosts the server, so the trial is fully in-sandbox.
+bin="$(dirname "$0")/iperf-install/bin"
+"$bin/iperf3" -s -1 >/dev/null 2>&1 </dev/null &
+IPERF_SERVER_PID=$!
+# Wait (bounded) for the listener to reach LISTEN (state 0A) on port 5201 (0x1451) before starting
+# the client; fall through after ~10s so a broken server surfaces as an honest client failure
+# rather than a hang. Checks tcp6 too: iperf3 -s binds the v6 wildcard on dual-stack kernels.
+attempt=0
+while ! cat /proc/net/tcp /proc/net/tcp6 2>/dev/null | awk '$2 ~ /:1451$/ && $4 == "0A" { found=1 } END { exit !found }'; do
+	attempt=$((attempt + 1))
+	if [ "$attempt" -ge 100 ] || ! kill -0 "$IPERF_SERVER_PID" 2>/dev/null; then
+		break
+	fi
+	sleep 0.1
+done
+"$bin/iperf3" "$@" > "$LOG_FILE" 2>&1
+status=$?
+echo "$status" > ~/test-exit-status
+kill "$IPERF_SERVER_PID" 2>/dev/null
+wait "$IPERF_SERVER_PID" 2>/dev/null
+exit "$status"
+EOF
+chmod +x iperf
+
+echo 0 > ~/install-exit-status

--- a/packages/schema/src/pts-profiles/iperf-1.2.0/results-definition.xml
+++ b/packages/schema/src/pts-profiles/iperf-1.2.0/results-definition.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0"?>
+<!--Phoronix Test Suite v10.8.4-->
+<PhoronixTestSuite>
+  <ResultsParser>
+    <OutputTemplate>[  7]   0.00-10.00  sec   298 MBytes   #_RESULT_# Mbits/sec    0             sender</OutputTemplate>
+    <MatchToTestArguments>-P 1 </MatchToTestArguments>
+    <LineHint>sender</LineHint>
+    <DeleteOutputBefore>Test Complete. Summary Results:</DeleteOutputBefore>
+  </ResultsParser>
+  <ResultsParser>
+    <OutputTemplate>[SUM]   0.00-10.00  sec   314 MBytes   #_RESULT_# Mbits/sec    0             sender</OutputTemplate>
+    <LineHint>SUM</LineHint>
+    <DeleteOutputBefore>Test Complete. Summary Results:</DeleteOutputBefore>
+  </ResultsParser>
+</PhoronixTestSuite>

--- a/packages/schema/src/pts-profiles/iperf-1.2.0/test-definition.xml
+++ b/packages/schema/src/pts-profiles/iperf-1.2.0/test-definition.xml
@@ -1,0 +1,89 @@
+<?xml version="1.0"?>
+<!--Phoronix Test Suite v10.8.4-->
+<PhoronixTestSuite>
+  <TestInformation>
+    <Title>iPerf</Title>
+    <AppVersion>3.14</AppVersion>
+    <Description>iPerf is a network bandwidth throughput testing software. This vendored subset benchmarks the sandbox's own network stack: the profile's runner starts a local iperf3 server and the client measures TCP throughput over localhost, so the result isolates virtualization/network-stack overhead from Internet weather.</Description>
+    <ResultScale>Mbits/sec</ResultScale>
+    <Proportion>HIB</Proportion>
+    <TimesToRun>2</TimesToRun>
+  </TestInformation>
+  <TestProfile>
+    <Version>1.2.0</Version>
+    <SupportedPlatforms>Linux, BSD, Solaris, MacOSX, Windows</SupportedPlatforms>
+    <SoftwareType>Benchmark</SoftwareType>
+    <TestType>Network</TestType>
+    <License>Free</License>
+    <Status>Verified</Status>
+    <ExternalDependencies>build-utilities</ExternalDependencies>
+    <RequiresNetwork>TRUE</RequiresNetwork>
+    <EnvironmentSize>6</EnvironmentSize>
+    <ProjectURL>https://software.es.net/iperf/</ProjectURL>
+    <RepositoryURL>https://github.com/esnet/iperf</RepositoryURL>
+    <Maintainer>Michael Larabel</Maintainer>
+  </TestProfile>
+  <TestSettings>
+    <Default>
+      <PostArguments>-V -f m </PostArguments>
+    </Default>
+    <Option>
+      <DisplayName>Server Address</DisplayName>
+      <Identifier>server-address</Identifier>
+      <ArgumentPrefix>-c </ArgumentPrefix>
+      <Menu>
+        <Entry>
+          <Name>localhost</Name>
+          <Value>localhost</Value>
+        </Entry>
+      </Menu>
+    </Option>
+    <Option>
+      <DisplayName>Server Port</DisplayName>
+      <Identifier>positive-number</Identifier>
+      <ArgumentPrefix>-p </ArgumentPrefix>
+      <Menu>
+        <Entry>
+          <Name>5201</Name>
+          <Value>5201</Value>
+        </Entry>
+      </Menu>
+    </Option>
+    <Option>
+      <DisplayName>Duration</DisplayName>
+      <Identifier>duration</Identifier>
+      <ArgumentPrefix>-t </ArgumentPrefix>
+      <Menu>
+        <Entry>
+          <Name>10 Seconds</Name>
+          <Value>10</Value>
+        </Entry>
+      </Menu>
+    </Option>
+    <Option>
+      <DisplayName>Test</DisplayName>
+      <Identifier>test</Identifier>
+      <Menu>
+        <Entry>
+          <Name>TCP</Name>
+          <Value> </Value>
+        </Entry>
+      </Menu>
+    </Option>
+    <Option>
+      <DisplayName>Parallel</DisplayName>
+      <Identifier>parallel</Identifier>
+      <ArgumentPrefix>-P </ArgumentPrefix>
+      <Menu>
+        <Entry>
+          <Name>1</Name>
+          <Value>1</Value>
+        </Entry>
+        <Entry>
+          <Name>10</Name>
+          <Value>10</Value>
+        </Entry>
+      </Menu>
+    </Option>
+  </TestSettings>
+</PhoronixTestSuite>

--- a/packages/schema/src/pts-profiles/iperf-1.2.0/test-definition.xml
+++ b/packages/schema/src/pts-profiles/iperf-1.2.0/test-definition.xml
@@ -4,10 +4,11 @@
   <TestInformation>
     <Title>iPerf</Title>
     <AppVersion>3.14</AppVersion>
-    <Description>iPerf is a network bandwidth throughput testing software. This vendored subset benchmarks the sandbox's own network stack: the profile's runner starts a local iperf3 server and the client measures TCP throughput over localhost, so the result isolates virtualization/network-stack overhead from Internet weather.</Description>
+    <Description>iPerf is a network bandwidth throughput testing software. This test profile is used for automated testing of an iperf client and requires you have access to an iperf server.</Description>
     <ResultScale>Mbits/sec</ResultScale>
     <Proportion>HIB</Proportion>
-    <TimesToRun>2</TimesToRun>
+    <TimesToRun>3</TimesToRun>
+    <PreInstallMessage>This test profile automates the testing of a iperf3 client. Ensure you have a suitable iPerf server running on your network prior to running this test.</PreInstallMessage>
   </TestInformation>
   <TestProfile>
     <Version>1.2.0</Version>
@@ -31,23 +32,13 @@
       <DisplayName>Server Address</DisplayName>
       <Identifier>server-address</Identifier>
       <ArgumentPrefix>-c </ArgumentPrefix>
-      <Menu>
-        <Entry>
-          <Name>localhost</Name>
-          <Value>localhost</Value>
-        </Entry>
-      </Menu>
+      <Message>Use 'localhost' if wishing to benchmark the local system/server performance.</Message>
     </Option>
     <Option>
       <DisplayName>Server Port</DisplayName>
       <Identifier>positive-number</Identifier>
       <ArgumentPrefix>-p </ArgumentPrefix>
-      <Menu>
-        <Entry>
-          <Name>5201</Name>
-          <Value>5201</Value>
-        </Entry>
-      </Menu>
+      <Message>The default iperf3 server port is 5201.</Message>
     </Option>
     <Option>
       <DisplayName>Duration</DisplayName>
@@ -58,6 +49,18 @@
           <Name>10 Seconds</Name>
           <Value>10</Value>
         </Entry>
+        <Entry>
+          <Name>30 Seconds</Name>
+          <Value>30</Value>
+        </Entry>
+        <Entry>
+          <Name>60 Seconds</Name>
+          <Value>60</Value>
+        </Entry>
+        <Entry>
+          <Name>360 Seconds</Name>
+          <Value>360</Value>
+        </Entry>
       </Menu>
     </Option>
     <Option>
@@ -66,7 +69,22 @@
       <Menu>
         <Entry>
           <Name>TCP</Name>
-          <Value> </Value>
+        </Entry>
+        <Entry>
+          <Name>UDP</Name>
+          <Value>-u</Value>
+        </Entry>
+        <Entry>
+          <Name>UDP - 100Mbit Objective</Name>
+          <Value>-u -b 100m</Value>
+        </Entry>
+        <Entry>
+          <Name>UDP - 1000Mbit Objective</Name>
+          <Value>-u -b 1000m</Value>
+        </Entry>
+        <Entry>
+          <Name>UDP - 10000Mbit Objective</Name>
+          <Value>-u -b 10000m</Value>
         </Entry>
       </Menu>
     </Option>
@@ -80,8 +98,32 @@
           <Value>1</Value>
         </Entry>
         <Entry>
+          <Name>5</Name>
+          <Value>5</Value>
+        </Entry>
+        <Entry>
           <Name>10</Name>
           <Value>10</Value>
+        </Entry>
+        <Entry>
+          <Name>20</Name>
+          <Value>20</Value>
+        </Entry>
+        <Entry>
+          <Name>32</Name>
+          <Value>32</Value>
+        </Entry>
+        <Entry>
+          <Name>64</Name>
+          <Value>64</Value>
+        </Entry>
+        <Entry>
+          <Name>128</Name>
+          <Value>128</Value>
+        </Entry>
+        <Entry>
+          <Name>256</Name>
+          <Value>256</Value>
         </Entry>
       </Menu>
     </Option>

--- a/packages/schema/src/pts-profiles/local/iperf-wan-1.0.0/downloads.xml
+++ b/packages/schema/src/pts-profiles/local/iperf-wan-1.0.0/downloads.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0"?>
+<!--Phoronix Test Suite local profile: WAN throughput via iperf3 against curated public servers-->
+<PhoronixTestSuite>
+  <Downloads>
+    <Package>
+      <URL>https://downloads.es.net/pub/iperf/iperf-3.14.tar.gz</URL>
+      <MD5>2fcf9691a062e905204c1868686cb051</MD5>
+      <SHA256>723fcc430a027bc6952628fa2a3ac77584a1d0bd328275e573fc9b206c155004</SHA256>
+      <FileName>iperf-3.14.tar.gz</FileName>
+      <FileSize>647944</FileSize>
+      <PlatformSpecific>Linux</PlatformSpecific>
+    </Package>
+  </Downloads>
+</PhoronixTestSuite>

--- a/packages/schema/src/pts-profiles/local/iperf-wan-1.0.0/install.sh
+++ b/packages/schema/src/pts-profiles/local/iperf-wan-1.0.0/install.sh
@@ -1,0 +1,39 @@
+#!/bin/sh
+# PTS local-profile install script: builds iperf 3.14 from the PTS-fetched tarball and stages the
+# WAN runner + curated server list beside it. Same build conventions as the vendored pts/iperf-1.2.0
+# repair: install prefix under this profile's own installed-tests dir (never $HOME — blaxel's root
+# fs is RAM-backed and only the PTS data dir volume may take heavy writes), and generic -O3 instead
+# of upstream iperf's -march=native (binaries may run on different hardware than they were built on;
+# iperf's own CPU tuning is not the thing being benchmarked). CFLAGS_OVERRIDE still wins when set.
+set -eu
+
+# shellcheck disable=SC1007 # CDPATH= (no value) is the idiom that disables CDPATH's cd-echoes-a-path behavior for this one invocation; shellcheck misreads it as a mistyped assignment.
+SRC_DIR="$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)"
+
+if [ ! -f "${SRC_DIR}/runner.sh" ] || [ ! -f "${SRC_DIR}/servers.json" ]; then
+	echo "ERROR: runner.sh or servers.json missing next to install.sh (${SRC_DIR})" >&2
+	echo 1 > ~/install-exit-status
+	exit 1
+fi
+
+prefix="$(pwd)/iperf-install"
+rm -rf iperf-3.14 "$prefix"
+tar -zxf iperf-3.14.tar.gz
+cd iperf-3.14
+if [ "${CFLAGS_OVERRIDE:-}" = "" ]; then
+	CFLAGS="${CFLAGS:-} -O3"
+else
+	CFLAGS="$CFLAGS_OVERRIDE"
+fi
+./configure --prefix="$prefix" CFLAGS="$CFLAGS"
+make -j "${NUM_CPU_CORES:-2}"
+make install
+cd ..
+rm -rf iperf-3.14
+
+cp "${SRC_DIR}/servers.json" .
+# The PTS executable convention: an executable named after the versionless profile dir.
+cp "${SRC_DIR}/runner.sh" iperf-wan
+chmod +x iperf-wan
+
+echo 0 > ~/install-exit-status

--- a/packages/schema/src/pts-profiles/local/iperf-wan-1.0.0/results-definition.xml
+++ b/packages/schema/src/pts-profiles/local/iperf-wan-1.0.0/results-definition.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0"?>
+<!--Phoronix Test Suite local profile: WAN throughput via iperf3 against curated public servers-->
+<PhoronixTestSuite>
+  <ResultsParser>
+    <OutputTemplate>IPERF WAN RESULT: #_RESULT_# Mbits/sec</OutputTemplate>
+    <LineHint>IPERF WAN RESULT</LineHint>
+  </ResultsParser>
+</PhoronixTestSuite>

--- a/packages/schema/src/pts-profiles/local/iperf-wan-1.0.0/runner.sh
+++ b/packages/schema/src/pts-profiles/local/iperf-wan-1.0.0/runner.sh
@@ -1,0 +1,149 @@
+#!/bin/bash
+# WAN throughput runner (installed by install.sh as the profile executable `iperf-wan`). PTS invokes
+# it per trial with the selected Direction option's value ("-R" for download, blank for upload).
+#
+# Selection: probe TCP-connect RTT to every server in the curated servers.json, order reachable
+# NON-backup servers by RTT (ROLE=backup entries only after every primary), and prefer the server a
+# previous trial of this run already used (cached in chosen-server) so both trials of both
+# directions measure one path. Public iperf3 servers accept a single client at a time, so "server is
+# busy" collisions are expected — six matrix jobs run concurrently — and each listed PORT range is
+# independent single-client instances: retry across the chosen server's ports with jitter, then fall
+# through to the next-closest server. Only after exhausting every server does the trial fail, honestly.
+#
+# Measurement: 10s, 8 parallel streams (a single TCP stream understates high bandwidth-delay-product
+# WAN paths — one congestion window against 30-100ms of RTT; 8 is the conventional multi-stream
+# saturation figure). The reported value is RECEIVER-side goodput (.end.sum_received of iperf3's
+# JSON) for both directions — bytes delivered end-to-end, not bytes offered. The chosen server, its
+# probe RTT, and the per-trial figure are appended to server-choices.ndjson, which the leaf copies
+# into the results tree as provenance — without it cross-provider WAN numbers are uninterpretable.
+set -u
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+BIN="${SCRIPT_DIR}/iperf-install/bin/iperf3"
+SERVERS_JSON="${SCRIPT_DIR}/servers.json"
+CHOICE_LOG="${SCRIPT_DIR}/server-choices.ndjson"
+CACHE="${SCRIPT_DIR}/chosen-server"
+ATTEMPT_BUDGET=40
+
+: > "$LOG_FILE"
+log() { printf '%s\n' "$*" >> "$LOG_FILE"; }
+
+fail() {
+	log "IPERF WAN: $*"
+	echo 1 > ~/test-exit-status
+	exit 1
+}
+
+direction=upload
+extra_args=()
+for arg in "$@"; do
+	if [ "$arg" = "-R" ]; then
+		direction=download
+		extra_args+=("-R")
+	fi
+done
+
+command -v jq >/dev/null 2>&1 || fail "jq not available for server-list parsing"
+[ -x "$BIN" ] || fail "iperf3 binary missing at ${BIN}"
+[ -f "$SERVERS_JSON" ] || fail "servers.json missing at ${SERVERS_JSON}"
+
+# TCP-connect RTT in ms (bash /dev/tcp under a hard 3s timeout — no extra tooling). Two attempts,
+# min wins: the first connect pays DNS resolution inside the timed section (observed +2.3s on a cold
+# resolver, enough to misorder servers) and a single lost SYN would misreport a healthy server as
+# unreachable. rc 1 = both attempts failed.
+probe_rtt_ms() {
+	local host="$1" port="$2" best="" start end rtt
+	for _ in 1 2; do
+		start=$(date +%s%N)
+		if timeout 3 bash -c "exec 3<>/dev/tcp/${host}/${port}; exec 3>&-" 2>/dev/null; then
+			end=$(date +%s%N)
+			rtt=$(((end - start) / 1000000))
+			if [ -z "$best" ] || [ "$rtt" -lt "$best" ]; then best="$rtt"; fi
+		fi
+	done
+	[ -n "$best" ] && echo "$best"
+}
+
+entries=()
+while IFS= read -r line; do
+	entries+=("$line")
+done < <(jq -r \
+	'.servers[] | [."IP/HOST", .PORT, (.ROLE // "primary"), .PROVIDER, .SITE] | @tsv' "$SERVERS_JSON")
+[ "${#entries[@]}" -gt 0 ] || fail "servers.json lists no servers"
+
+candidates=() # rtt|host|ports|role|provider|site
+for entry in "${entries[@]}"; do
+	IFS=$'\t' read -r host ports role provider site <<<"$entry"
+	first_port="${ports%%-*}"
+	if rtt=$(probe_rtt_ms "$host" "$first_port"); then
+		log "iperf-wan probe: host=${host} port=${first_port} rtt_ms=${rtt} role=${role} provider=${provider} site=${site}"
+		candidates+=("${rtt}|${host}|${ports}|${role}|${provider}|${site}")
+	else
+		log "iperf-wan probe: host=${host} port=${first_port} UNREACHABLE role=${role}"
+	fi
+done
+[ "${#candidates[@]}" -gt 0 ] || fail "no listed iperf3 server reachable (all probes failed)"
+
+primaries=$(printf '%s\n' "${candidates[@]}" | awk -F'|' '$4 != "backup"' | sort -t'|' -k1,1n)
+backups=$(printf '%s\n' "${candidates[@]}" | awk -F'|' '$4 == "backup"' | sort -t'|' -k1,1n)
+ordered=$(printf '%s\n%s\n' "$primaries" "$backups" | sed '/^$/d')
+# Pin the whole run to one path when possible: a server an earlier trial measured goes first.
+if [ -f "$CACHE" ]; then
+	cached=$(cat "$CACHE")
+	ordered=$({
+		printf '%s\n' "$ordered" | grep -F "|${cached}|"
+		printf '%s\n' "$ordered" | grep -vF "|${cached}|"
+	} | sed '/^$/d')
+fi
+
+attempts=0
+while IFS='|' read -r rtt host ports role provider site; do
+	[ -n "$host" ] || continue
+	lo="${ports%%-*}"
+	hi="${ports##*-}"
+	for port in $(seq "$lo" "$hi"); do
+		attempts=$((attempts + 1))
+		if [ "$attempts" -gt "$ATTEMPT_BUDGET" ]; then
+			fail "exhausted the ${ATTEMPT_BUDGET}-attempt retry budget without a successful measurement"
+		fi
+		log "iperf-wan attempt ${attempts}: host=${host} port=${port} direction=${direction} (probe_rtt_ms=${rtt} provider=${provider} role=${role})"
+		json="${SCRIPT_DIR}/last-result.json"
+		if "$BIN" -c "$host" -p "$port" ${extra_args[@]+"${extra_args[@]}"} \
+			-t 10 -P 8 --connect-timeout 3000 -J >"$json" 2>>"$LOG_FILE"; then
+			mbps=$(jq -r '((.end.sum_received.bits_per_second // 0) / 1000000 * 100 | round) / 100' "$json")
+			case "$mbps" in
+			'' | null | 0) ;;
+			*)
+				echo "$host" > "$CACHE"
+				retransmits=$(jq -r '.end.sum_sent.retransmits // "null"' "$json")
+				printf '{"ts":"%s","direction":"%s","host":"%s","port":%s,"provider":"%s","site":"%s","probe_rtt_ms":%s,"mbits_per_sec":%s,"retransmits":%s}\n' \
+					"$(date -u +%Y-%m-%dT%H:%M:%SZ)" "$direction" "$host" "$port" "$provider" "$site" \
+					"$rtt" "$mbps" "$retransmits" >> "$CHOICE_LOG"
+				log "iperf-wan: server=${host} port=${port} provider=${provider} site=${site} probe_rtt_ms=${rtt} direction=${direction} attempts=${attempts}"
+				cat "$json" >> "$LOG_FILE"
+				log "IPERF WAN RESULT: ${mbps} Mbits/sec"
+				echo 0 > ~/test-exit-status
+				exit 0
+				;;
+			esac
+			log "iperf-wan: ${host}:${port} completed without a throughput figure; trying next"
+		else
+			err=$(jq -r '.error // empty' "$json" 2>/dev/null || true)
+			if [ -n "$err" ]; then
+				log "iperf-wan: ${host}:${port} -> ${err}"
+			else
+				log "iperf-wan: ${host}:${port} -> iperf3 failed (no JSON error; see stderr above)"
+			fi
+			case "$err" in
+			*busy*)
+				# Single-client collision (another matrix job, or another tenant): jittered backoff so
+				# concurrent jobs don't stay in lockstep, then the next port in this server's range.
+				sleep $(((RANDOM % 3) + 1))
+				;;
+			*) ;;
+			esac
+		fi
+	done
+done <<<"$ordered"
+
+fail "every listed server (including backups) was exhausted without a successful measurement"

--- a/packages/schema/src/pts-profiles/local/iperf-wan-1.0.0/servers.json
+++ b/packages/schema/src/pts-profiles/local/iperf-wan-1.0.0/servers.json
@@ -1,0 +1,56 @@
+{
+  "provenance": "Curated public iperf3 servers for the WAN throughput leaf, copied verbatim (entries unmodified) from listed_iperf3_servers_filtered.json (curated 2026-07-22 from the public iperf3 server registry; capacity/port/option columns as published there). PORT is an inclusive range of independent single-client iperf3 instances. OPTIONS lists supported extras (-R reverse/download is supported by every entry). ROLE=backup entries are fallback-only: the runner probes TCP-connect RTT to every entry at run time, picks the lowest-RTT reachable non-backup server, retries across its port range on busy collisions, then falls through to the next-closest server and finally the backups. The chosen server is recorded per trial in pts_iperf-wan--server-choices.ndjson.",
+  "servers": [
+    {
+      "IP/HOST": "speedtest.nocix.net",
+      "PORT": "5201-5205",
+      "OPTIONS": "-R,-6",
+      "GB/S": "200",
+      "CONTINENT": "North America",
+      "COUNTRY": "US",
+      "SITE": "Kansas City",
+      "PROVIDER": "NOCIX"
+    },
+    {
+      "IP/HOST": "dfw.speedtest.is.cc",
+      "PORT": "5203-5210",
+      "OPTIONS": "-R",
+      "GB/S": "100",
+      "CONTINENT": "North America",
+      "COUNTRY": "US",
+      "SITE": "Dallas",
+      "PROVIDER": "InterServer.net"
+    },
+    {
+      "IP/HOST": "37.19.206.20",
+      "PORT": "5201",
+      "OPTIONS": "-R,-u",
+      "GB/S": "2x10",
+      "CONTINENT": "North America",
+      "COUNTRY": "US",
+      "SITE": "Ashburn",
+      "PROVIDER": "DATAPACKET"
+    },
+    {
+      "IP/HOST": "t5.cscs.ch",
+      "PORT": "5201-5203",
+      "OPTIONS": "-R,-6",
+      "GB/S": "100",
+      "CONTINENT": "Europe",
+      "COUNTRY": "CH",
+      "SITE": "Zürich",
+      "PROVIDER": "CSCS"
+    },
+    {
+      "IP/HOST": "hil.proof.ovh.us",
+      "PORT": "5201-5210",
+      "OPTIONS": "-R,-6,-u",
+      "GB/S": "1",
+      "CONTINENT": "North America",
+      "COUNTRY": "US",
+      "SITE": "Hillsboro",
+      "PROVIDER": "OVHcloud",
+      "ROLE": "backup"
+    }
+  ]
+}

--- a/packages/schema/src/pts-profiles/local/iperf-wan-1.0.0/test-definition.xml
+++ b/packages/schema/src/pts-profiles/local/iperf-wan-1.0.0/test-definition.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0"?>
+<!--Phoronix Test Suite local profile: WAN throughput via iperf3 against curated public servers-->
+<PhoronixTestSuite>
+  <TestInformation>
+    <Title>iPerf WAN</Title>
+    <AppVersion>3.14</AppVersion>
+    <Description>Measures sustained WAN TCP throughput with iperf3 against the closest reachable server from a curated public list (servers.json, committed with this profile). The runner probes TCP-connect RTT to every listed server at run time, picks the lowest-RTT reachable non-backup server, retries across its port range on single-client busy collisions, and records the chosen server per trial as provenance. Eight parallel streams so high bandwidth-delay-product paths are not understated by a single TCP congestion window; the reported figure is receiver-side goodput.</Description>
+    <ResultScale>Mbits/sec</ResultScale>
+    <Proportion>HIB</Proportion>
+    <TimesToRun>2</TimesToRun>
+  </TestInformation>
+  <TestProfile>
+    <Version>1.0.0</Version>
+    <SupportedPlatforms>Linux</SupportedPlatforms>
+    <SoftwareType>Benchmark</SoftwareType>
+    <TestType>Network</TestType>
+    <License>Free</License>
+    <Status>Verified</Status>
+    <ExternalDependencies>build-utilities</ExternalDependencies>
+    <RequiresNetwork>TRUE</RequiresNetwork>
+    <RequiresInternet>TRUE</RequiresInternet>
+    <EnvironmentSize>6</EnvironmentSize>
+    <ProjectURL>https://software.es.net/iperf/</ProjectURL>
+    <Maintainer>StarSling</Maintainer>
+  </TestProfile>
+  <TestSettings>
+    <Option>
+      <DisplayName>Direction</DisplayName>
+      <Identifier>direction</Identifier>
+      <Menu>
+        <Entry>
+          <Name>Download</Name>
+          <Value>-R</Value>
+        </Entry>
+        <Entry>
+          <Name>Upload</Name>
+          <Value> </Value>
+        </Entry>
+      </Menu>
+    </Option>
+  </TestSettings>
+</PhoronixTestSuite>

--- a/packages/schema/src/suites.test.ts
+++ b/packages/schema/src/suites.test.ts
@@ -64,14 +64,15 @@ describe("suite registry", () => {
 	});
 
 	it("mirrors the unpinned suites' metrics from the generated catalog (no hand-drift)", () => {
-		// These suites batch-run their profiles WITHOUT PRESET_OPTIONS, so whatever the catalog lists for
-		// the test is exactly what the suite emits — pin the declared list to it in BOTH directions (a
-		// profile bump that adds/renames a combination fails here instead of silently stranding the
-		// list). stream's Type axis and fast-cli's four results are the matrix cases; pybench, sqlite,
-		// git and network-loopback declare no <Option> axes, so the pin holds over their wildcard result.
-		// (pgbench is preset-pinned and now its own suite — gated by the subset test below.)
+		// These suites' declared metrics are exactly what the catalog lists for their profiles — pin the
+		// declared list to it in BOTH directions (a profile bump that adds/renames a combination fails
+		// here instead of silently stranding the list). stream's Type axis and iperf's Parallel axis are
+		// the matrix cases (iperf is preset-pinned, but its vendored subset IS the two combinations the
+		// leaf runs, so the full-catalog mirror still holds); pybench, sqlite and git declare no
+		// <Option> axes, so the pin holds over their wildcard result. (pgbench is preset-pinned against
+		// a full upstream matrix and now its own suite — gated by the subset test below.)
 		const profilesOf = {
-			network: ["pts/network-loopback", "pts/fast-cli"],
+			network: ["pts/iperf", "local/iperf-wan"],
 			memory: ["pts/stream"],
 			system: ["pts/pybench", "pts/sqlite-speedtest", "pts/git"],
 		} as const;

--- a/packages/schema/src/suites.test.ts
+++ b/packages/schema/src/suites.test.ts
@@ -66,13 +66,11 @@ describe("suite registry", () => {
 	it("mirrors the unpinned suites' metrics from the generated catalog (no hand-drift)", () => {
 		// These suites' declared metrics are exactly what the catalog lists for their profiles — pin the
 		// declared list to it in BOTH directions (a profile bump that adds/renames a combination fails
-		// here instead of silently stranding the list). stream's Type axis and iperf's Parallel axis are
-		// the matrix cases (iperf is preset-pinned, but its vendored subset IS the two combinations the
-		// leaf runs, so the full-catalog mirror still holds); pybench, sqlite and git declare no
-		// <Option> axes, so the pin holds over their wildcard result. (pgbench is preset-pinned against
-		// a full upstream matrix and now its own suite — gated by the subset test below.)
+		// here instead of silently stranding the list). stream's Type axis is the matrix case; pybench,
+		// sqlite and git declare no <Option> axes, so the pin holds over their wildcard result.
+		// (pgbench and network/iperf are preset-pinned against full upstream matrices — gated by the
+		// subset test below.)
 		const profilesOf = {
-			network: ["pts/iperf", "local/iperf-wan"],
 			memory: ["pts/stream"],
 			system: ["pts/pybench", "pts/sqlite-speedtest", "pts/git"],
 		} as const;
@@ -89,16 +87,18 @@ describe("suite registry", () => {
 	});
 
 	it("pins the PINNED-subset suites to their curated override keys", () => {
-		// disk (fio) and system (pgbench) deliberately declare a SUBSET of their profile's catalogued
-		// combinations — the ones the producer tasks pin via PRESET_OPTIONS — so a catalog mirror
-		// can't gate them. Every declared subset id is also a curated pts-overrides key (only the
-		// producible combinations get short labels), so equality against the override keys catches a
-		// wrong-axis id here: with the full matrix catalogued, a typo'd engine, block size or scale
-		// would otherwise pass the suite contract and just never receive samples.
+		// disk (fio), pgbench, and network (iperf, vendored byte-identical to upstream's full matrix)
+		// deliberately declare a SUBSET of their profile's catalogued combinations — the ones the
+		// producer tasks pin via PRESET_OPTIONS — so a catalog mirror can't gate them. Every declared
+		// subset id is also a curated pts-overrides key (only the producible combinations get short
+		// labels), so equality against the override keys catches a wrong-axis id here: with the full
+		// matrix catalogued, a typo'd engine, block size, parallel count or scale would otherwise pass
+		// the suite contract and just never receive samples.
 		const overrideKeys = Object.keys(ptsOverrides);
 		const subsets = [
 			{ suite: "disk", prefix: "fio_" },
 			{ suite: "pgbench", prefix: "pgbench_" },
+			{ suite: "network", prefix: "iperf_" },
 		] as const;
 		for (const { suite, prefix } of subsets) {
 			const declared: string[] = SUITES[suite].metrics.filter((id) => id.startsWith(prefix)).sort();

--- a/packages/schema/src/suites.ts
+++ b/packages/schema/src/suites.ts
@@ -169,28 +169,31 @@ export const SUITES = {
 		],
 		commands: ["mise run benchmark:disk:all"],
 	},
-	// The network dimension: fast-cli performs sustained real-world download/upload transfers through
-	// Netflix's fast.com CDN and reports idle/loaded latency; loopback TCP (10GB via nc) is the paired
-	// self-contained synthetic that isolates the sandbox's network stack from Internet weather. The
-	// suite task also runs latency/DNS and a small GitHub control-download probe as raw provenance.
-	// setupNode installs the fast.com CLI. Long-synthetic tier (k=2, R=3): replicate sandboxes capture the
-	// placement/peering variance a single fast.com transfer can't.
+	// The network dimension, iperf composition (benchmark:network:suite): iperf3 over localhost
+	// isolates the sandbox's network stack/virtualization overhead (virtio/KVM vs gVisor netstack vs
+	// host namespaces) from Internet weather, and iperf3 against the closest curated public server
+	// (local/iperf-wan; chosen at run time by TCP-connect RTT probe, recorded as provenance)
+	// measures WAN throughput both directions with real byte accounting. These supersede the
+	// fast-cli + dd|nc loopback leaves IN THE SUITE (run 29937467891: Chrome's page-scrape
+	// measurement was structurally unreliable on fast datacenter paths — every trial on
+	// daytona-vm/novita/blaxel died in the memory watchdog and the surviving numbers were
+	// buffer-fill transients); the old leaves and profiles stay runnable manually via
+	// benchmark:network:all. The suite task also runs latency/DNS and a small GitHub
+	// control-download probe as raw provenance. Long-synthetic tier (k=2, R=3).
 	network: {
 		setupPts: true,
-		setupNode: true,
-		commandTimeoutMinutes: 45,
-		timeoutMinutes: 55,
+		commandTimeoutMinutes: 30,
+		timeoutMinutes: 40,
 		ptsTimesToRun: 2,
 		defaultReplicas: 3,
 		dimensions: ["network"],
 		metrics: [
-			"fast_cli_internet_download_speed",
-			"fast_cli_internet_upload_speed",
-			"fast_cli_internet_latency",
-			"fast_cli_internet_loaded_latency_bufferbloat",
-			"network_loopback_seconds",
+			"iperf_server_address_localhost_server_port_5201_duration_10_seconds_test_tcp_parallel_1",
+			"iperf_server_address_localhost_server_port_5201_duration_10_seconds_test_tcp_parallel_10",
+			"iperf_wan_direction_download",
+			"iperf_wan_direction_upload",
 		],
-		commands: ["mise run benchmark:network:all"],
+		commands: ["mise run benchmark:network:suite"],
 	},
 	// The realworld dimension (ENG-135/136/137/138): real OSS repos run through their own CI tasks,
 	// each a repo-local PTS profile with a Task option axis. Real-world tier: k=1 in-sandbox pass (the

--- a/packages/templates/src/lib/pins.ts
+++ b/packages/templates/src/lib/pins.ts
@@ -87,6 +87,10 @@ export const rawPins = {
 	// > results), and the drift gate skips versionless names by construction, so they were the one hole in
 	// > it. The catalog joins on a versionless key, so pinning the leaf changes nothing downstream.
 	// > (c-ray/compress-zstd were dropped with the cpu-generic suite; pyperformance likewise runs nowhere.)
+	// > iperf-1.2.0 joined for the network suite's iperf composition: the bake pre-installs the
+	// > upstream profile (and caches its tarball); the leaf stages the repo's vendored localhost
+	// > subset over it and rebuilds from the cached source at run time (the network-loopback
+	// > override pattern). fast-cli/network-loopback stay baked for the manual composition.
 	ptsInstallTests:
-		"node-web-tooling-1.0.1 pybench-1.1.3 sqlite-speedtest-1.0.1 fio-2.1.0 network-loopback-1.0.3 fast-cli-1.0.0 pgbench-1.15.0 git-1.1.0 stream-1.3.4",
+		"node-web-tooling-1.0.1 pybench-1.1.3 sqlite-speedtest-1.0.1 fio-2.1.0 network-loopback-1.0.3 fast-cli-1.0.0 iperf-1.2.0 pgbench-1.15.0 git-1.1.0 stream-1.3.4",
 } satisfies Record<keyof Pins, string>;

--- a/packages/templates/src/smoke.test.ts
+++ b/packages/templates/src/smoke.test.ts
@@ -28,20 +28,22 @@ describe("@sandbox-benchmarks/templates smoke", () => {
 		}
 	});
 
-	// The count (9) and sample profile names are hardcoded on purpose: this is a drift tripwire, not a
+	// The count (10) and sample profile names are hardcoded on purpose: this is a drift tripwire, not a
 	// derived assertion. Deriving them from pins.ptsInstallTests would make the test a tautology that
 	// tracks the generator instead of pinning it — the exact failure this guards against (a mutable-tag
 	// cache once validated an old two-profile image against a nine-profile candidate). When the pin list
-	// changes, update these literals deliberately.
+	// changes, update these literals deliberately. (10 = the nine long-standing profiles + iperf-1.2.0,
+	// added for the network suite's iperf composition.)
 	it("requires every pinned PTS profile, so a stale partial image cannot pass smoke", () => {
 		const pts = smokeChecks.find((check) => check.name === "pts-installed-tests");
-		expect(pts?.expect).toBe("pts-profile-count=9");
+		expect(pts?.expect).toBe("pts-profile-count=10");
 		expect(pts?.cmd).toContain("phoronix-test-suite list-installed-tests");
 		expect(pts?.cmd).toContain("PTS_USER_PATH_OVERRIDE=/var/lib/phoronix-test-suite/");
 		expect(pts?.cmd).toContain("node-web-tooling-1.0.1");
 		expect(pts?.cmd).toContain("fast-cli-1.0.0");
+		expect(pts?.cmd).toContain("iperf-1.2.0");
 		expect(pts?.cmd).toContain("git-1.1.0");
-		expect(pts?.cmd).toContain('[ "$actual" -eq 9 ]');
+		expect(pts?.cmd).toContain('[ "$actual" -eq 10 ]');
 		expect(pts?.cmd).toContain('echo "pts-profile-count=$actual"');
 	});
 


### PR DESCRIPTION
# feat(network): move the network suite onto iperf3 localhost + WAN leaves

## Root cause (run 29937467891)

The network suite's fast-cli leaf failed on daytona-vm, novita and blaxel (and was marginal on
e2b): every failed trial ended with the driver's designed `stop=memory` failure. On a fast
datacenter→Netflix path, Chrome buffers generated upload payload in renderer memory faster than the
network drains it, so the page's displayed uploadSpeed is a buffer-fill transient (2.2–5.1 Gbps
shown while the `uploaded` byte counter works out to <100 Mbps average), the download reading is
garbage by the time the upload phase repurposes the page (0.64–6.1 Mbps next to "multi-Gbps"
uploads), and memory crosses the watchdog's stop threshold before the settle condition can fire.
PTS then banks zero values and the four-metric gate correctly fails the job. Only modal-gvisor —
whose path to fast.com is slow enough that Chrome never buffers ahead — measured cleanly. This is
structural: any number scraped off fast.com's DOM while Chrome is buffering is fiction, so the fix
direction was to stop measuring through a browser, not to relabel the failure.

## What changed

The network SUITE now measures with iperf3; fast-cli and the dd|nc loopback profile remain vendored
and manually runnable (`mise run benchmark:network:all`), but the suite runs
`benchmark:network:suite`:

- **pts/iperf-1.2.0 (vendored byte-identical to upstream)** — `benchmark:network:pts:iperf-localhost`,
  one leaf, two pinned runs (pgbench precedent; a second leaf would re-stage the profile and pay the
  build twice): TCP 10s over localhost with `-P 1` (`pts_iperf-tcp-p1`) and `-P 10`
  (`pts_iperf-tcp-p10`). The vendored test-definition.xml is byte-for-byte upstream at the pinned
  REF (git blob `10f4b5dc01f5` — the fio precedent: the full option matrix is catalogued, the leaf
  pins its combinations via PRESET_OPTIONS, unrun combinations never receive samples; the menu-less
  free-text server/port axes are catalogued through the generator's deterministic `localhost`/`5201`
  pins, and upstream's `TimesToRun=3` is inert because the harness preamble pins
  `FORCE_TIMES_TO_RUN` from `Suite.ptsTimesToRun`, k=2). The preset pins are verified against PTS
  10.8.4 source — notably `parallel=0` index-pins entry "1" on the 8-entry menu (a literal "1"
  would index-select "5") while `parallel=10` name-pins. The install.sh repair (unchanged): build
  under the installed dir (never $HOME — blaxel's root fs is RAM-backed), generic `-O3` instead of
  `-march=native` (the fio/gVisor lesson), upstream's `2>1` runner typo fixed, the local server
  runs one-off (`-s -1`) with stdio detached from the runner's pipe (the fast-cli pipe-hold lesson)
  and a bounded /proc-based readiness poll replaces `sleep 3`.
- **local/iperf-wan-1.0.0 (repo-local)** — `benchmark:network:pts:iperf-wan`: WAN TCP throughput
  against the closest reachable server from the committed curated list
  (`packages/schema/src/pts-profiles/local/iperf-wan-1.0.0/servers.json`, entries copied verbatim
  from the curated registry export with a provenance note). The runner probes TCP-connect RTT to
  every listed server (min of two probes; the first pays DNS), prefers non-backup servers by RTT
  (OVHcloud `ROLE=backup` only as fallback), pins the whole run to one server via a cache once a
  trial succeeds, and on single-client "server is busy" collisions retries across the server's
  advertised port range with jittered backoff before falling through to the next server. 10s,
  8 parallel streams (single-stream TCP understates high-BDP WAN paths), and the banked figure is
  receiver-side goodput from iperf3's JSON (`end.sum_received`) for both directions
  (`pts_iperf-wan-download`, `pts_iperf-wan-upload`). Only after exhausting every server does a
  trial fail, honestly (exit 1 → failed trial → per-prefix gate). The chosen server, probe RTT,
  port, figure and retransmit count are recorded per trial in
  `pts_iperf-wan--server-choices.ndjson` — WAN numbers are uninterpretable without the endpoint.
- **Catalog/schema** — metric ids `iperf_server_address_localhost_..._parallel_1|10` (generated
  from the vendored subset; `fetch-profiles.ts` carries the subset patch so re-vendoring stays
  idempotent) and `iperf_wan_direction_download|upload`. The network headline moves from
  `network_loopback_seconds` to the localhost single-stream metric (one headline per dimension);
  fast-cli/loopback entries stay catalogued with their labels for manual runs. LEADERBOARD.md
  re-rendered (headline section move only — no ranked values changed).
- **Bake config** — `iperf-1.2.0` added to `ptsInstallTests` (existing entries untouched); the
  current v5 images predate it, so the leaf installs in-sandbox from the vendored profile
  (~40s build) until the next toolchain bake; docker-smoke literals updated (10 profiles).
- **suites.ts** — network suite: 4 metrics, `setupNode` dropped (fast-cli was the only node
  consumer in this suite), command/sandbox budgets trimmed 45/55 → 30/40 min (measured suite wall
  time is ~8–12 min).

Deliberate scope: `PTS_APT_DEPS` (Chrome libs, netcat-openbsd) is untouched — fast-cli/loopback
remain manually runnable; fold any dep trim into the next toolchain release alongside the bake.

## Validation

Every run below: suite exits 0, all four iperf composites carry a numeric value with BOTH trials in
the RawString, zero uncatalogued results, zero gaps, and the provider normalizes to `validated`.
Values are Mbit/s, shown as `trial1:trial2`.

**Local branch runs** (bench-suite.ts per provider, BENCH_REPO_REF=network-suite-iperf):

| provider | loopback -P 1 | loopback -P 10 | WAN download | WAN upload | WAN server (per provenance) | suite wall |
| --- | --- | --- | --- | --- | --- | --- |
| novita | 82131:91584 | 86670:91221 | 2642:3775 | 6606:5463 | DATAPACKET Ashburn → InterServer Dallas (busy fallback) | ~200s |
| e2b | 62090:44925 | 54768:49016 | 1921:2467 | 3773:3448 | InterServer Dallas | 212s |
| modal-vm | 20328:13742 | 16583:36957 | 1428:1414 | 6596:5974 | NOCIX Kansas City | 197s |
| modal-gvisor | 13595:13735 | 13702:13290 | 8630:10421 | 170:152 | InterServer Dallas (one busy-retry onto port 5205) | 305s |
| blaxel | 93463:83028 | 97134:128354 | 2020:1013 | 885:2419 | NOCIX Kansas City | 195s |

Notes on plausibility: loopback separates the KVM VMs (20–128 Gbit/s) from gVisor's netstack
(13.5 Gbit/s, remarkably stable) — exactly the signal the localhost leaf exists for. WAN figures are
datacenter-plausible (0.9–10 Gbit/s) with real retransmit counts; modal-gvisor's asymmetric upload
(~160 Mbit/s at zero retransmits) reads as egress pacing and is honestly recorded either way. The
busy-retry path fired in the wild: concurrent cells collided on InterServer 5203 and the runner
moved to 5205 / fell through to the next server as designed. daytona-vm has no local credentials
(the local org's snapshots predate the current toolchain), so its validation is CI-only below.

**CI matrix passes** (bench-matrix.yml dispatched on the branch, all six providers × network; every
cell `success`, every provider `validated`, zero gaps/uncatalogued, both trials per metric):

_Pass 1 — run 29948290403:_

| provider | loopback -P 1 | loopback -P 10 | WAN download | WAN upload |
| --- | --- | --- | --- | --- |
| daytona-vm | 82126:77713 | 94656:78260 | 3011:3352 | 4788:4799 |
| e2b | 65518:65784 | 50572:54954 | 2867:3087 | 3709:3312 |
| modal-gvisor | 13561:12879 | 11145:11107 | 5718:4911 | 161:167 |
| modal-vm | 14599:14392 | 13790:14081 | 1477:1504 | 9213:9300 |
| blaxel | 122355:103462 | 95761:110819 | 1562:964 | 961:507 |
| novita | 148449:150729 | 149255:149346 | 4837:4237 | 6608:1855 |

The six cells ran concurrently and the WAN busy-retry proved itself live: daytona-vm's download
trial 2 moved to port 5205 and novita's upload trials landed on 5205/5210 after "server is busy"
collisions on InterServer Dallas 5203, all recorded in each shard's
`pts_iperf-wan--server-choices.ndjson`.

_Pass 2 — run 29948837956:_

| provider | loopback -P 1 | loopback -P 10 | WAN download | WAN upload |
| --- | --- | --- | --- | --- |
| daytona-vm | 74603:68844 | 66297:52059 | 2728:3215 | 4795:4725 |
| e2b | 52937:55264 | 47268:48658 | 2914:3852 | 3016:3308 |
| modal-gvisor | 8963:10215 | 10055:9771 | 3232:4606 | 141:179 |
| modal-vm | 82449:81694 | 59894:72759 | 2028:2058 | 3421:3883 |
| blaxel | 93342:103254 | 144625:124852 | 865:1303 | 1953:739 |
| novita | 139270:134247 | 143762:119790 | 3865:3709 | 2615:4211 |

12/12 green cells across the two passes; every provider `validated` with zero gaps and zero
uncatalogued results in both. Between-pass spread is real between-sandbox variance (e.g. modal-vm's
loopback moved from ~14 to ~82 Gbit/s between placements — host heterogeneity the R=3 replicate
design exists to capture), while within-run trial pairs stay in the same order of magnitude.

## Residual risks / follow-ups

- The WAN leaf depends on public server availability; the committed list has four primaries across
  two continents plus a backup, busy-retry across each port range, and an honest per-direction gap
  when everything is exhausted (keep+warn — never a fabricated number).
- iperf 3.14 is single-threaded: `-P 10` scales streams inside one process (per-stream syscall and
  netstack overhead), not across cores — labeled as such in the catalog notes.
- Next toolchain bake picks up the iperf pre-install (and may drop the Chrome/netcat deps if
  fast-cli/loopback are ever fully retired).


## Independent validation (2026-07-22, post-implementation)

A second, independent pass beyond the CI matrices above:

- **Parser-accuracy chain proven on all six providers**: every composite `<Value>` equals the mean of its `RawString` trials, which equal iperf3's own `-J` figures in the provenance NDJSON, byte-for-byte (checked against run 29948837956 artifacts + two fresh blaxel sandboxes).
- **Two fresh blaxel sandboxes**: both `validated`, 4 metrics, 0 gaps; localhost stable sandbox-to-sandbox (88.6/94.4 Gbit/s @ -P 1); caught the designed fallback live — IPv4-only Ashburn probes reachable but iperf3 gets ENETUNREACH on blaxel's IPv6-first egress, runner fell through to Kansas City with full provenance.
- **Constrained Docker run** (8 GB / 4 vCPU, toolchain image, clean branch clone): suite exit 0, all leaves green. Note: bare `mise run` executes bench.sh's single-trial contract-verification mode (`FORCE_TIMES_TO_RUN=1`); the harness sets k=2 for published runs.
- **Failure paths (4/4, doctored server lists)**: unreachable-server skip; live busy-collision → jittered retry → next port; `-R` direction provenance; total exhaustion exits 1 honestly; backups only after all primaries.

Follow-up candidates (non-blocking): honor the server list's `-6` metadata on IPv6-first sandboxes; WAN trial pairs on contended public servers can vary ~3× — label comparisons rather than raise trials.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Moves the network suite from fast.com to iperf3 localhost and WAN for accurate, reproducible throughput; updates catalog, headline, and orchestration. Also scopes the WAN server cache and provenance to one execution to avoid stale selections across re-runs. Aligns vendored `pts/iperf-1.2.0` with upstream and updates the catalog to handle `<Value>`-less entries and free-text axes.

- **Refactors**
  - Re-vendored `pts/iperf-1.2.0` test-definition byte-for-byte with upstream; dropped subset patching. Upstream `TimesToRun=3` remains inert (harness pins k=2).
  - Catalog/parser: `<Entry><Value>` is now optional; synthesis treats missing as "". Added deterministic virtual entries for `server-address` (`localhost`) and `Server Port` (`5201`).
  - Tests/suites: network moves to the pinned-subset gate (`iperf_` prefix); preset semantics for `parallel` re-verified (index vs name pin).
  - Tooling: `biome.json` `files.maxSize` increased to 2 MiB for the larger generated catalog; bake pins and smoke updated to include `iperf-1.2.0`.

<sup>Written for commit 4db9464ad0bc7893f8a319212030329524237a66. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/starslingdev/hpc-sandbox-benchmarks/pull/249?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->


