### PR TITLE
feat(schema): add the local/iperf-wan-1.0.0 profile (closest-public-server WAN throughput)

### DIFF
--- a/packages/schema/src/pts-generated.ts
+++ b/packages/schema/src/pts-generated.ts
@@ -20089,6 +20089,30 @@ const chunk5: MetricDef[] = [
 		sourceUrl: "https://software.es.net/iperf/",
 	},
 	{
+		id: "iperf_wan_direction_download",
+		dimension: "network",
+		unit: "Mbits/sec",
+		direction: "HIB",
+		headline: false,
+		label: "iPerf WAN - Direction: Download",
+		description:
+			"Measures sustained WAN TCP throughput with iperf3 against the closest reachable server from a curated public list (servers.json, committed with this profile). The runner probes TCP-connect RTT to every listed server at run time, picks the lowest-RTT reachable non-backup server, retries across its port range on single-client busy collisions, and records the chosen server per trial as provenance. Eight parallel streams so high bandwidth-delay-product paths are not understated by a single TCP congestion window; the reported figure is receiver-side goodput.",
+		pts: { test: "local/iperf-wan", description: "Direction: Download" },
+		sourceUrl: "https://software.es.net/iperf/",
+	},
+	{
+		id: "iperf_wan_direction_upload",
+		dimension: "network",
+		unit: "Mbits/sec",
+		direction: "HIB",
+		headline: false,
+		label: "iPerf WAN - Direction: Upload",
+		description:
+			"Measures sustained WAN TCP throughput with iperf3 against the closest reachable server from a curated public list (servers.json, committed with this profile). The runner probes TCP-connect RTT to every listed server at run time, picks the lowest-RTT reachable non-backup server, retries across its port range on single-client busy collisions, and records the chosen server per trial as provenance. Eight parallel streams so high bandwidth-delay-product paths are not understated by a single TCP congestion window; the reported figure is receiver-side goodput.",
+		pts: { test: "local/iperf-wan", description: "Direction: Upload" },
+		sourceUrl: "https://software.es.net/iperf/",
+	},
+	{
 		id: "network_loopback_seconds",
 		dimension: "network",
 		unit: "Seconds",
@@ -21896,6 +21920,9 @@ const chunk5: MetricDef[] = [
 		},
 		sourceUrl: "https://www.postgresql.org/",
 	},
+];
+
+const chunk6: MetricDef[] = [
 	{
 		id: "pgbench_scaling_factor_1_clients_50_mode_read_only",
 		dimension: "system",
@@ -21923,9 +21950,6 @@ const chunk5: MetricDef[] = [
 		},
 		sourceUrl: "https://www.postgresql.org/",
 	},
-];
-
-const chunk6: MetricDef[] = [
 	{
 		id: "pgbench_scaling_factor_1_clients_50_mode_read_write",
 		dimension: "system",

--- a/packages/schema/src/pts-profiles/local/iperf-wan-1.0.0/downloads.xml
+++ b/packages/schema/src/pts-profiles/local/iperf-wan-1.0.0/downloads.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0"?>
+<!--Phoronix Test Suite local profile: WAN throughput via iperf3 against curated public servers-->
+<PhoronixTestSuite>
+  <Downloads>
+    <Package>
+      <URL>https://downloads.es.net/pub/iperf/iperf-3.14.tar.gz</URL>
+      <MD5>2fcf9691a062e905204c1868686cb051</MD5>
+      <SHA256>723fcc430a027bc6952628fa2a3ac77584a1d0bd328275e573fc9b206c155004</SHA256>
+      <FileName>iperf-3.14.tar.gz</FileName>
+      <FileSize>647944</FileSize>
+      <PlatformSpecific>Linux</PlatformSpecific>
+    </Package>
+  </Downloads>
+</PhoronixTestSuite>

--- a/packages/schema/src/pts-profiles/local/iperf-wan-1.0.0/install.sh
+++ b/packages/schema/src/pts-profiles/local/iperf-wan-1.0.0/install.sh
@@ -1,0 +1,51 @@
+#!/bin/sh
+# PTS local-profile install script: builds iperf 3.14 from the PTS-fetched tarball and stages the
+# WAN runner + curated server list beside it. Same build conventions as the vendored pts/iperf-1.2.0
+# repair: install prefix under this profile's own installed-tests dir (never $HOME — blaxel's root
+# fs is RAM-backed and only the PTS data dir volume may take heavy writes), and generic -O3 instead
+# of upstream iperf's -march=native (binaries may run on different hardware than they were built on;
+# iperf's own CPU tuning is not the thing being benchmarked). CFLAGS_OVERRIDE still wins when set.
+set -eu
+
+# PTS decides an install succeeded by READING ~/install-exit-status, not from the process exit code
+# (lib/bench.sh: "PTS can exit 0 even when compilation failed"). The precondition check below writes
+# its own 1, but a tar/configure/make failure under `set -e` would exit with the file absent, which
+# reads as success. Report the real status on every exit path; guarded on non-zero so the explicit
+# `echo 0` at the end stays the single source of the success value. Same idiom as the sibling
+# pts/iperf-1.2.0 repair.
+report_install_status() {
+	rc=$?
+	[ "$rc" -eq 0 ] || echo "$rc" > ~/install-exit-status
+}
+trap report_install_status EXIT
+
+# shellcheck disable=SC1007 # CDPATH= (no value) is the idiom that disables CDPATH's cd-echoes-a-path behavior for this one invocation; shellcheck misreads it as a mistyped assignment.
+SRC_DIR="$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)"
+
+if [ ! -f "${SRC_DIR}/runner.sh" ] || [ ! -f "${SRC_DIR}/servers.json" ]; then
+	echo "ERROR: runner.sh or servers.json missing next to install.sh (${SRC_DIR})" >&2
+	echo 1 > ~/install-exit-status
+	exit 1
+fi
+
+prefix="$(pwd)/iperf-install"
+rm -rf iperf-3.14 "$prefix"
+tar -zxf iperf-3.14.tar.gz
+cd iperf-3.14
+if [ "${CFLAGS_OVERRIDE:-}" = "" ]; then
+	CFLAGS="${CFLAGS:-} -O3"
+else
+	CFLAGS="$CFLAGS_OVERRIDE"
+fi
+./configure --prefix="$prefix" CFLAGS="$CFLAGS"
+make -j "${NUM_CPU_CORES:-2}"
+make install
+cd ..
+rm -rf iperf-3.14
+
+cp "${SRC_DIR}/servers.json" .
+# The PTS executable convention: an executable named after the versionless profile dir.
+cp "${SRC_DIR}/runner.sh" iperf-wan
+chmod +x iperf-wan
+
+echo 0 > ~/install-exit-status

--- a/packages/schema/src/pts-profiles/local/iperf-wan-1.0.0/results-definition.xml
+++ b/packages/schema/src/pts-profiles/local/iperf-wan-1.0.0/results-definition.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0"?>
+<!--Phoronix Test Suite local profile: WAN throughput via iperf3 against curated public servers-->
+<PhoronixTestSuite>
+  <ResultsParser>
+    <OutputTemplate>IPERF WAN RESULT: #_RESULT_# Mbits/sec</OutputTemplate>
+    <LineHint>IPERF WAN RESULT</LineHint>
+  </ResultsParser>
+</PhoronixTestSuite>

--- a/packages/schema/src/pts-profiles/local/iperf-wan-1.0.0/runner.sh
+++ b/packages/schema/src/pts-profiles/local/iperf-wan-1.0.0/runner.sh
@@ -1,0 +1,197 @@
+#!/bin/bash
+# WAN throughput runner (installed by install.sh as the profile executable `iperf-wan`). PTS invokes
+# it per trial with the selected Direction option's value ("-R" for download, blank for upload).
+#
+# Selection: probe TCP-connect RTT to every server in the curated servers.json, order reachable
+# NON-backup servers by RTT (ROLE=backup entries only after every primary), and prefer the server a
+# previous trial of this run already used (cached in chosen-server) so both trials of both
+# directions measure one path. Public iperf3 servers accept a single client at a time, so "server is
+# busy" collisions are expected — six matrix jobs run concurrently — and each listed PORT range is
+# independent single-client instances: retry across the chosen server's ports with jitter, then fall
+# through to the next-closest server. Only after exhausting every server does the trial fail, honestly.
+#
+# Measurement: 10s, 8 parallel streams (a single TCP stream understates high bandwidth-delay-product
+# WAN paths — one congestion window against 30-100ms of RTT; 8 is the conventional multi-stream
+# saturation figure). The reported value is RECEIVER-side goodput (.end.sum_received of iperf3's
+# JSON) for both directions — bytes delivered end-to-end, not bytes offered. The chosen server, its
+# probe RTT, and the per-trial figure are appended to server-choices.ndjson, which the leaf copies
+# into the results tree as provenance — without it cross-provider WAN numbers are uninterpretable.
+set -u
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+BIN="${SCRIPT_DIR}/iperf-install/bin/iperf3"
+SERVERS_JSON="${SCRIPT_DIR}/servers.json"
+CHOICE_LOG="${SCRIPT_DIR}/server-choices.ndjson"
+CACHE="${SCRIPT_DIR}/chosen-server"
+ATTEMPT_BUDGET=40
+# Hard wall clock per iperf3 attempt. `-t 10` bounds a HEALTHY transfer and --connect-timeout
+# bounds the handshake, but neither covers a public server that accepts the connection and then
+# stalls mid-transfer — there the client can block indefinitely and, with 40 attempts available,
+# run the whole leaf into the harness watchdog. 45s leaves generous headroom over 10s of transfer
+# plus connect and JSON exchange; -k escalates to SIGKILL if iperf3 ignores the TERM.
+ATTEMPT_TIMEOUT_S=45
+
+: > "$LOG_FILE"
+log() { printf '%s\n' "$*" >> "$LOG_FILE"; }
+
+fail() {
+	log "IPERF WAN: $*"
+	echo 1 > ~/test-exit-status
+	exit 1
+}
+
+direction=upload
+extra_args=()
+for arg in "$@"; do
+	if [ "$arg" = "-R" ]; then
+		direction=download
+		extra_args+=("-R")
+	fi
+done
+
+command -v jq >/dev/null 2>&1 || fail "jq not available for server-list parsing"
+[ -x "$BIN" ] || fail "iperf3 binary missing at ${BIN}"
+[ -f "$SERVERS_JSON" ] || fail "servers.json missing at ${SERVERS_JSON}"
+
+# TCP-connect RTT in ms (bash /dev/tcp under a hard 3s timeout — no extra tooling). Two attempts,
+# min wins: the first connect pays DNS resolution inside the timed section (observed +2.3s on a cold
+# resolver, enough to misorder servers) and a single lost SYN would misreport a healthy server as
+# unreachable. rc 1 = both attempts failed.
+probe_rtt_ms() {
+	local host="$1" port="$2" best="" start end rtt
+	for _ in 1 2; do
+		start=$(date +%s%N)
+		if timeout 3 bash -c "exec 3<>/dev/tcp/${host}/${port}; exec 3>&-" 2>/dev/null; then
+			end=$(date +%s%N)
+			rtt=$(((end - start) / 1000000))
+			if [ -z "$best" ] || [ "$rtt" -lt "$best" ]; then best="$rtt"; fi
+		fi
+	done
+	[ -n "$best" ] && echo "$best"
+}
+
+entries=()
+while IFS= read -r line; do
+	entries+=("$line")
+done < <(jq -r \
+	'.servers[] | [."IP/HOST", .PORT, (.ROLE // "primary"), .PROVIDER, .SITE] | @tsv' "$SERVERS_JSON")
+[ "${#entries[@]}" -gt 0 ] || fail "servers.json lists no servers"
+
+candidates=() # rtt|host|ports|role|provider|site
+for entry in "${entries[@]}"; do
+	IFS=$'\t' read -r host ports role provider site <<<"$entry"
+	first_port="${ports%%-*}"
+	last_port="${ports##*-}"
+	# Probe the first port, and only if that fails the last one. A BUSY instance still completes the
+	# TCP handshake (it declines at the protocol level — which is exactly why the measurement loop
+	# below can retry across the range), so one probe is not fooled by the contention this list
+	# expects. What one probe cannot tell apart is a genuinely filtered first port on an otherwise
+	# healthy server, which would drop that server from selection for the whole run. Two probes at
+	# opposite ends of the range cover that, without paying a 3s timeout per port on a host that is
+	# simply down (the ranges here run up to 10 ports wide).
+	probe_port="$first_port"
+	if ! rtt=$(probe_rtt_ms "$host" "$first_port"); then
+		rtt=""
+		if [ "$last_port" != "$first_port" ]; then
+			probe_port="$last_port"
+			rtt=$(probe_rtt_ms "$host" "$last_port") || rtt=""
+		fi
+	fi
+	if [ -n "$rtt" ]; then
+		log "iperf-wan probe: host=${host} port=${probe_port} rtt_ms=${rtt} role=${role} provider=${provider} site=${site}"
+		candidates+=("${rtt}|${host}|${ports}|${role}|${provider}|${site}")
+	else
+		log "iperf-wan probe: host=${host} ports=${first_port},${last_port} UNREACHABLE role=${role}"
+	fi
+done
+[ "${#candidates[@]}" -gt 0 ] || fail "no listed iperf3 server reachable (all probes failed)"
+
+primaries=$(printf '%s\n' "${candidates[@]}" | awk -F'|' '$4 != "backup"' | sort -t'|' -k1,1n)
+backups=$(printf '%s\n' "${candidates[@]}" | awk -F'|' '$4 == "backup"' | sort -t'|' -k1,1n)
+ordered=$(printf '%s\n%s\n' "$primaries" "$backups" | sed '/^$/d')
+# Pin the whole run to one path when possible: a server an earlier trial measured goes first.
+if [ -f "$CACHE" ]; then
+	cached=$(cat "$CACHE")
+	ordered=$({
+		printf '%s\n' "$ordered" | grep -F "|${cached}|"
+		printf '%s\n' "$ordered" | grep -vF "|${cached}|"
+	} | sed '/^$/d')
+fi
+
+attempts=0
+while IFS='|' read -r rtt host ports role provider site; do
+	[ -n "$host" ] || continue
+	lo="${ports%%-*}"
+	hi="${ports##*-}"
+	for port in $(seq "$lo" "$hi"); do
+		attempts=$((attempts + 1))
+		if [ "$attempts" -gt "$ATTEMPT_BUDGET" ]; then
+			fail "exhausted the ${ATTEMPT_BUDGET}-attempt retry budget without a successful measurement"
+		fi
+		log "iperf-wan attempt ${attempts}: host=${host} port=${port} direction=${direction} (probe_rtt_ms=${rtt} provider=${provider} role=${role})"
+		json="${SCRIPT_DIR}/last-result.json"
+		if timeout -k 5 "$ATTEMPT_TIMEOUT_S" "$BIN" -c "$host" -p "$port" ${extra_args[@]+"${extra_args[@]}"} \
+			-t 10 -P 8 --connect-timeout 3000 -J >"$json" 2>>"$LOG_FILE"; then
+			mbps=$(jq -r '((.end.sum_received.bits_per_second // 0) / 1000000 * 100 | round) / 100' "$json")
+			case "$mbps" in
+			'' | null | 0) ;;
+			*)
+				echo "$host" > "$CACHE"
+				retransmits=$(jq -r '.end.sum_sent.retransmits // "null"' "$json")
+				# A -R (download) run reports no sender-side retransmits, and a truncated JSON body makes
+				# the extraction yield nothing at all. Normalize either to the JSON null this field already
+				# carries, so --argjson below can never be handed an empty string — which would fail the
+				# whole record over a cosmetic gap.
+				[ -n "$retransmits" ] || retransmits=null
+				# jq builds the record so host/provider/site are JSON-escaped — a printf-interpolated
+				# quote or backslash in a future servers.json entry would silently corrupt the NDJSON
+				# provenance this profile exists to keep trustworthy.
+				#
+				# The write is CHECKED. This script runs under `set -u`, not `set -e`, so an unchecked
+				# failure here (full disk, unwritable CHOICE_LOG) would fall straight through to the
+				# `echo 0 > ~/test-exit-status` below and bank a throughput figure with no record of which
+				# server produced it — the one thing the header says makes cross-provider WAN numbers
+				# uninterpretable. Fail the trial honestly instead.
+				if ! jq -cn \
+					--arg ts "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+					--arg direction "$direction" --arg host "$host" --arg provider "$provider" \
+					--arg site "$site" \
+					--argjson port "$port" --argjson rtt "$rtt" --argjson mbps "$mbps" \
+					--argjson retransmits "$retransmits" \
+					'{ts: $ts, direction: $direction, host: $host, port: $port, provider: $provider,
+						site: $site, probe_rtt_ms: $rtt, mbits_per_sec: $mbps, retransmits: $retransmits}' \
+					>> "$CHOICE_LOG"; then
+					fail "provenance write to ${CHOICE_LOG} failed; refusing to bank an unattributable ${mbps} Mbits/sec from ${host}:${port}"
+				fi
+				log "iperf-wan: server=${host} port=${port} provider=${provider} site=${site} probe_rtt_ms=${rtt} direction=${direction} attempts=${attempts}"
+				cat "$json" >> "$LOG_FILE"
+				log "IPERF WAN RESULT: ${mbps} Mbits/sec"
+				echo 0 > ~/test-exit-status
+				exit 0
+				;;
+			esac
+			log "iperf-wan: ${host}:${port} completed without a throughput figure; trying next"
+		else
+			rc=$?
+			err=$(jq -r '.error // empty' "$json" 2>/dev/null || true)
+			# 124 is timeout(1) reporting it killed the attempt — distinct from iperf3 declining.
+			if [ "$rc" -eq 124 ]; then
+				log "iperf-wan: ${host}:${port} -> exceeded the ${ATTEMPT_TIMEOUT_S}s wall clock (killed); trying next"
+			elif [ -n "$err" ]; then
+				log "iperf-wan: ${host}:${port} -> ${err}"
+			else
+				log "iperf-wan: ${host}:${port} -> iperf3 failed (no JSON error; see stderr above)"
+			fi
+			case "$err" in
+			*busy*)
+				# Single-client collision (another matrix job, or another tenant): jittered backoff so
+				# concurrent jobs don't stay in lockstep, then the next port in this server's range.
+				sleep $(((RANDOM % 3) + 1))
+				;;
+			*) ;;
+			esac
+		fi
+	done
+done <<<"$ordered"
+
+fail "every listed server (including backups) was exhausted without a successful measurement"

--- a/packages/schema/src/pts-profiles/local/iperf-wan-1.0.0/servers.json
+++ b/packages/schema/src/pts-profiles/local/iperf-wan-1.0.0/servers.json
@@ -1,0 +1,56 @@
+{
+  "provenance": "Curated public iperf3 servers for the WAN throughput leaf, copied verbatim (entries unmodified) from listed_iperf3_servers_filtered.json (curated 2026-07-22 from the public iperf3 server registry; capacity/port/option columns as published there). PORT is an inclusive range of independent single-client iperf3 instances. OPTIONS lists supported extras (-R reverse/download is supported by every entry). ROLE=backup entries are fallback-only: the runner probes TCP-connect RTT to every entry at run time, picks the lowest-RTT reachable non-backup server, retries across its port range on busy collisions, then falls through to the next-closest server and finally the backups. The chosen server is recorded per trial in pts_iperf-wan--server-choices.ndjson.",
+  "servers": [
+    {
+      "IP/HOST": "speedtest.nocix.net",
+      "PORT": "5201-5205",
+      "OPTIONS": "-R,-6",
+      "GB/S": "200",
+      "CONTINENT": "North America",
+      "COUNTRY": "US",
+      "SITE": "Kansas City",
+      "PROVIDER": "NOCIX"
+    },
+    {
+      "IP/HOST": "dfw.speedtest.is.cc",
+      "PORT": "5203-5210",
+      "OPTIONS": "-R",
+      "GB/S": "100",
+      "CONTINENT": "North America",
+      "COUNTRY": "US",
+      "SITE": "Dallas",
+      "PROVIDER": "InterServer.net"
+    },
+    {
+      "IP/HOST": "37.19.206.20",
+      "PORT": "5201",
+      "OPTIONS": "-R,-u",
+      "GB/S": "2x10",
+      "CONTINENT": "North America",
+      "COUNTRY": "US",
+      "SITE": "Ashburn",
+      "PROVIDER": "DATAPACKET"
+    },
+    {
+      "IP/HOST": "t5.cscs.ch",
+      "PORT": "5201-5203",
+      "OPTIONS": "-R,-6",
+      "GB/S": "100",
+      "CONTINENT": "Europe",
+      "COUNTRY": "CH",
+      "SITE": "Zürich",
+      "PROVIDER": "CSCS"
+    },
+    {
+      "IP/HOST": "hil.proof.ovh.us",
+      "PORT": "5201-5210",
+      "OPTIONS": "-R,-6,-u",
+      "GB/S": "1",
+      "CONTINENT": "North America",
+      "COUNTRY": "US",
+      "SITE": "Hillsboro",
+      "PROVIDER": "OVHcloud",
+      "ROLE": "backup"
+    }
+  ]
+}

--- a/packages/schema/src/pts-profiles/local/iperf-wan-1.0.0/test-definition.xml
+++ b/packages/schema/src/pts-profiles/local/iperf-wan-1.0.0/test-definition.xml
@@ -1,0 +1,46 @@
+<?xml version="1.0"?>
+<!--Phoronix Test Suite local profile: WAN throughput via iperf3 against curated public servers-->
+<PhoronixTestSuite>
+  <TestInformation>
+    <Title>iPerf WAN</Title>
+    <AppVersion>3.14</AppVersion>
+    <Description>Measures sustained WAN TCP throughput with iperf3 against the closest reachable server from a curated public list (servers.json, committed with this profile). The runner probes TCP-connect RTT to every listed server at run time, picks the lowest-RTT reachable non-backup server, retries across its port range on single-client busy collisions, and records the chosen server per trial as provenance. Eight parallel streams so high bandwidth-delay-product paths are not understated by a single TCP congestion window; the reported figure is receiver-side goodput.</Description>
+    <ResultScale>Mbits/sec</ResultScale>
+    <Proportion>HIB</Proportion>
+    <TimesToRun>2</TimesToRun>
+  </TestInformation>
+  <TestProfile>
+    <Version>1.0.0</Version>
+    <SupportedPlatforms>Linux</SupportedPlatforms>
+    <SoftwareType>Benchmark</SoftwareType>
+    <TestType>Network</TestType>
+    <License>Free</License>
+    <Status>Verified</Status>
+    <!--The runner also needs jq (servers.json parsing + iperf3 -J output extraction). PTS has no
+        jq dependency name, so it is guaranteed out-of-band instead: baked into the toolchain image
+        via PTS_APT_DEPS (packages/schema/src/toolchain.ts) and hard-guarded by the iperf-wan leaf,
+        which records an honest skip marker when jq is absent rather than failing mid-runner.-->
+    <ExternalDependencies>build-utilities</ExternalDependencies>
+    <RequiresNetwork>TRUE</RequiresNetwork>
+    <RequiresInternet>TRUE</RequiresInternet>
+    <EnvironmentSize>6</EnvironmentSize>
+    <ProjectURL>https://software.es.net/iperf/</ProjectURL>
+    <Maintainer>StarSling</Maintainer>
+  </TestProfile>
+  <TestSettings>
+    <Option>
+      <DisplayName>Direction</DisplayName>
+      <Identifier>direction</Identifier>
+      <Menu>
+        <Entry>
+          <Name>Download</Name>
+          <Value>-R</Value>
+        </Entry>
+        <Entry>
+          <Name>Upload</Name>
+          <Value> </Value>
+        </Entry>
+      </Menu>
+    </Option>
+  </TestSettings>
+</PhoronixTestSuite>


### PR DESCRIPTION
**Network suite → iperf3 — retire fast-cli/dd|nc from the suite; measure localhost + WAN with iperf3**
Shipped as a 6-PR stack (merge bottom-up, each branch independently green). Supersedes #249.
1. #251 — schema: vendor `pts/iperf-1.2.0` byte-identical + catalog generator support
2. #252 — schema: add `local/iperf-wan-1.0.0` (closest-public-server WAN throughput)
3. #253 — templates: bake iperf-1.2.0 into the toolchain images, `TOOLCHAIN_VERSION` v5 → v6
4. #254 — bench: iperf3 localhost + WAN producer leaves and the suite orchestrator
5. #255 — network: flip the suite to the iperf composition (headline moves)
6. #256 — dataset: publish the composite Run for the stack and refresh `LEADERBOARD.md`

Post-merge sequencing: dispatch `toolchain-image.yml` on main to publish the v6 images/snapshots **before** the first main `bench-matrix` run that consumes them.

↑ **This PR is #252 (2/6), based on #251**.

---

A repo-local PTS profile (the local/hardlink precedent) that drives iperf3
against curated public servers: runner.sh parses servers.json, probes
TCP-connect RTT to every listed server, picks the closest reachable non-backup
one, retries across its port range on single-client busy collisions, and
appends one NDJSON provenance record per successful trial (host, port,
provider, site, probe RTT, figure) — WAN numbers are uninterpretable without
the chosen server. A per-execution chosen-server cache pins both directions of
one leaf run to the same path.

The Direction axis (Download/Upload) enumerates through the generator like any
menu axis; pts-generated.ts is regenerated and the drift gate holds. The two
iperf_wan_* metrics keep draft labels and no suite declares them yet — the
producer leaf, curation and the suite flip land above this in the stack.


### Provenance

Everything under `pts-profiles/local/iperf-wan-1.0.0/` is hand-authored (repo-local profile, `local/` namespace — no upstream counterpart, same model as `local/hardlink` and the realworld profiles). The only generated file in this PR is `src/pts-generated.ts`, regenerated with `bun run --filter @sandbox-benchmarks/schema generate-catalog` and gated by CI's `check:catalog-drift`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds the `local/iperf-wan-1.0.0` PTS profile to measure sustained WAN TCP throughput against the closest reachable public `iperf3` server, and registers draft WAN metrics. Hardened selection, retries, timeouts, and provenance for reliable, attributable runs.

- **New Features**
  - Adds `local/iperf-wan-1.0.0`: 10s, 8 streams, receiver-side goodput; Direction menu (Download `-R`, Upload).
  - Builds `iperf` 3.14 from the PTS tarball inside the profile; curated `servers.json` included.
  - Selection and provenance: probe RTT to all, pick lowest-RTT reachable primary; jittered port retries; per-run cache pins both directions; NDJSON provenance; registers `iperf_wan_direction_{download,upload}` in `pts-generated.ts`.

- **Bug Fixes**
  - Fail the trial if the provenance append fails; normalize missing retransmits to JSON null.
  - Bound each attempt with `timeout -k 5 45` and a 40-attempt budget; log timeouts and iperf3 errors.
  - Probe the last port when the first is filtered; `install.sh` reports real status via an EXIT trap and avoids `-march=native`.

<sup>Written for commit dd4000403e3854e897aaee1b57878e5669d10bd5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/starslingdev/hpc-sandbox-benchmarks/pull/252?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

