### PR TITLE
feat(templates): bake iperf-1.2.0 into the toolchain images

### DIFF
--- a/packages/schema/src/toolchain.ts
+++ b/packages/schema/src/toolchain.ts
@@ -4,14 +4,14 @@
 // tag is immutable: a change to the toolchain image means bumping TOOLCHAIN_VERSION.
 
 export const TOOLCHAIN_IMAGE_NAME = "sandbox-benchmarks-toolchain";
-// v5: routine mise-managed toolchain pin refresh over v4 (packages/templates/src/lib/pins.ts —
-// unchanged since 2026-06-17). Bumps mise 2026.5.16 → 2026.7.11 (+ its per-arch binary sha256s,
-// re-sourced from the new release's SHASUMS256.txt; the CI mise-action pin in ci.yml/ci-lint.yml
-// moves in lockstep so build and checks share one mise), node 22.22.3 → 22.23.1, and pnpm
-// 10.34.3 → 10.34.5 (staying on the 10.x line — pnpm 11 is a major bump, out of scope here). jc
-// 1.25.6 → 1.25.7. hyperfine, quarto, python, warp, and the PTS pins were already current at their
-// latest upstream release and are unchanged. Re-bake all providers before the runs that consume v5.
-export const TOOLCHAIN_VERSION = "v5";
+// v6: the bake gains pts/iperf-1.2.0 (packages/templates/src/lib/pins.ts — ptsInstallTests 9 → 10
+// profiles) for the network suite's iperf composition. Pre-installing the upstream profile caches
+// its source tarball in the image, so the iperf-localhost leaf's vendored-subset re-install
+// rebuilds offline instead of re-downloading inside every cell's budget (bake↔leaf agreement is
+// gated by tooling/repo-checks pts-profile-pins.test.ts). Every mise-managed toolchain pin is
+// unchanged from v5 (mise 2026.7.11, node 22.23.1, pnpm 10.34.5, jc 1.25.7). Re-bake all providers
+// before the runs that consume v6.
+export const TOOLCHAIN_VERSION = "v6";
 
 // The apt packages PTS needs beyond a stock image — PTS's own php runtime, the compiler toolchain
 // for the source-built profiles, and fast-cli's Chrome runtime libs. ONE canonical list: the

--- a/packages/templates/src/lib/pins.ts
+++ b/packages/templates/src/lib/pins.ts
@@ -87,6 +87,10 @@ export const rawPins = {
 	// > results), and the drift gate skips versionless names by construction, so they were the one hole in
 	// > it. The catalog joins on a versionless key, so pinning the leaf changes nothing downstream.
 	// > (c-ray/compress-zstd were dropped with the cpu-generic suite; pyperformance likewise runs nowhere.)
+	// > iperf-1.2.0 joined for the network suite's iperf composition: the bake pre-installs the
+	// > upstream profile (and caches its tarball); the leaf stages the repo's vendored localhost
+	// > subset over it and rebuilds from the cached source at run time (the network-loopback
+	// > override pattern). fast-cli/network-loopback stay baked for the manual composition.
 	ptsInstallTests:
-		"node-web-tooling-1.0.1 pybench-1.1.3 sqlite-speedtest-1.0.1 fio-2.1.0 network-loopback-1.0.3 fast-cli-1.0.0 pgbench-1.15.0 git-1.1.0 stream-1.3.4",
+		"node-web-tooling-1.0.1 pybench-1.1.3 sqlite-speedtest-1.0.1 fio-2.1.0 network-loopback-1.0.3 fast-cli-1.0.0 iperf-1.2.0 pgbench-1.15.0 git-1.1.0 stream-1.3.4",
 } satisfies Record<keyof Pins, string>;

--- a/packages/templates/src/smoke.test.ts
+++ b/packages/templates/src/smoke.test.ts
@@ -28,20 +28,22 @@ describe("@sandbox-benchmarks/templates smoke", () => {
 		}
 	});
 
-	// The count (9) and sample profile names are hardcoded on purpose: this is a drift tripwire, not a
+	// The count (10) and sample profile names are hardcoded on purpose: this is a drift tripwire, not a
 	// derived assertion. Deriving them from pins.ptsInstallTests would make the test a tautology that
 	// tracks the generator instead of pinning it — the exact failure this guards against (a mutable-tag
 	// cache once validated an old two-profile image against a nine-profile candidate). When the pin list
-	// changes, update these literals deliberately.
+	// changes, update these literals deliberately. (10 = the nine long-standing profiles + iperf-1.2.0,
+	// added for the network suite's iperf composition.)
 	it("requires every pinned PTS profile, so a stale partial image cannot pass smoke", () => {
 		const pts = smokeChecks.find((check) => check.name === "pts-installed-tests");
-		expect(pts?.expect).toBe("pts-profile-count=9");
+		expect(pts?.expect).toBe("pts-profile-count=10");
 		expect(pts?.cmd).toContain("phoronix-test-suite list-installed-tests");
 		expect(pts?.cmd).toContain("PTS_USER_PATH_OVERRIDE=/var/lib/phoronix-test-suite/");
 		expect(pts?.cmd).toContain("node-web-tooling-1.0.1");
 		expect(pts?.cmd).toContain("fast-cli-1.0.0");
+		expect(pts?.cmd).toContain("iperf-1.2.0");
 		expect(pts?.cmd).toContain("git-1.1.0");
-		expect(pts?.cmd).toContain('[ "$actual" -eq 9 ]');
+		expect(pts?.cmd).toContain('[ "$actual" -eq 10 ]');
 		expect(pts?.cmd).toContain('echo "pts-profile-count=$actual"');
 	});
 


### PR DESCRIPTION
**Network suite → iperf3 — retire fast-cli/dd|nc from the suite; measure localhost + WAN with iperf3**
Shipped as a 6-PR stack (merge bottom-up, each branch independently green). Supersedes #249.
1. #251 — schema: vendor `pts/iperf-1.2.0` byte-identical + catalog generator support
2. #252 — schema: add `local/iperf-wan-1.0.0` (closest-public-server WAN throughput)
3. #253 — templates: bake iperf-1.2.0 into the toolchain images
4. #254 — bench: iperf3 localhost + WAN producer leaves and the suite orchestrator
5. #255 — network: flip the suite to the iperf composition (headline moves)
6. #256 — dataset: publish the composite Run for the stack and refresh `LEADERBOARD.md`

↑ **This PR is #253 (3/6), based on #252**.

---

iperf-1.2.0 joins ptsInstallTests for the network suite's iperf composition:
the bake pre-installs the upstream profile (and caches its tarball); the
iperf-localhost leaf above this in the stack stages the repo's vendored subset
over it and rebuilds from the cached source at run time (the network-loopback
override pattern). The repo-check gate (pts-profile-pins: bake<->leaf
agreement) makes this a hard prerequisite of the leaf — an unbaked referenced
profile would re-download and rebuild inside every cell's budget.
fast-cli/network-loopback stay baked for the manual composition.

smoke.test.ts's deliberately hardcoded drift tripwire moves 9 -> 10 in the
same change (the literals are the gate — deriving them from the pin list would
make the test a tautology).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bake `iperf-1.2.0` into the toolchain images and bump `TOOLCHAIN_VERSION` to `v6` to support the iperf-based network suite and avoid per‑cell rebuilds. Update the smoke tripwire to enforce 10 installed PTS profiles, including `iperf-1.2.0`.

- **New Features**
  - Adds `iperf-1.2.0` to `ptsInstallTests`; pre-installs the upstream profile and caches its tarball so the `iperf-localhost` leaf can rebuild offline.
  - Keeps `fast-cli` and `network-loopback` baked for the manual composition.
  - Bumps `TOOLCHAIN_VERSION` to `v6`; `mise`/`node`/`pnpm`/`jc` pins are unchanged from `v5`.

- **Migration**
  - Rebuild and publish the `v6` toolchain images before any runs that consume them.

<sup>Written for commit 48f82c8acd9ca32209e469bb90763d8fc4315337. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/starslingdev/hpc-sandbox-benchmarks/pull/253?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

