### PR TITLE
feat(bench): add the iperf3 localhost + WAN leaves and the network suite orchestrator

### DIFF
--- a/.mise/tasks/benchmark/network/pts/iperf-localhost
+++ b/.mise/tasks/benchmark/network/pts/iperf-localhost
@@ -1,0 +1,75 @@
+#!/usr/bin/env bash
+#MISE description="PTS: iperf3 localhost throughput (10s; TCP 1/10 streams + UDP 10G-objective)"
+# Measurement leaf: -e guards the scaffolding; the measured runs are isolated by run_pts_benchmark
+# (via run_pinned_pts, which owns the per-prefix skip markers and pins each variant's option
+# combination through PRESET_OPTIONS).
+#
+# Fully in-sandbox: the vendored profile's runner starts a local iperf3 server and the client
+# measures over localhost, so the number isolates the sandbox's network stack/virtualization
+# overhead (virtio/KVM vs gVisor netstack vs host namespaces) from Internet weather — the suite's
+# successor to the dd|nc network-loopback leaf (which stays runnable manually). Three variants from
+# one vendored install (the pgbench one-leaf precedent — a second leaf would re-stage the vendored
+# profile and pay the iperf build twice): TCP -P 1 is single-stream stack throughput, TCP -P 10
+# adds per-stream overhead scaling (iperf 3.14 is single-threaded, so this scales streams within
+# one process, not across cores), and UDP at the 10000Mbit objective exercises the datagram path —
+# the one UDP menu point that discriminates on localhost (KVM stacks saturate the objective while
+# gVisor's netstack undershoots; the lower objectives are constants everywhere and plain UDP
+# defaults to a meaningless 1 Mbit/s, so neither is pinned).
+set -euo pipefail
+REPO_ROOT="$(git -C "$(dirname "${BASH_SOURCE[0]}")" rev-parse --show-toplevel)"
+source "${REPO_ROOT}/lib/bench.sh"
+
+# install_vendored_pts_profile needs PTS on PATH before run_pinned_pts's own guard can run, so guard
+# here with a skip marker per prefix (the exact negatives of the three composites this leaf produces).
+if ! command -v phoronix-test-suite &>/dev/null; then
+	skip_result "phoronix-test-suite not installed" "pts_iperf-tcp-p1"
+	skip_result "phoronix-test-suite not installed" "pts_iperf-tcp-p10"
+	skip_result "phoronix-test-suite not installed" "pts_iperf-udp-10g"
+	exit 0
+fi
+
+# The vendored profile's test-definition.xml is BYTE-IDENTICAL to upstream (the fio precedent: the
+# full option matrix is catalogued, this leaf pins one combination per variant, unrun combinations
+# never receive samples); only install.sh carries repairs (build under the installed dir, generic
+# -O3 instead of -march=native, the runner's 2>&1/one-off-server/readiness fixes). Stage it and
+# discard the baked upstream install so run_pts_benchmark installs the override; the second pinned
+# run below reuses that install.
+install_vendored_pts_profile "iperf-1.2.0"
+
+# The v6-baked image ships iperf-3.14.tar.gz in the PTS download cache already; on stock images and
+# on a not-yet-rebaked toolchain, seed it ourselves with retries + a byte-identical mirror — PTS's
+# own downloader is single-shot, and run 29964910698 lost 4 of 6 providers' cells to one
+# downloads.es.net hiccup it would have retried through.
+seed_pts_download_cache "iperf-3.14.tar.gz" \
+	"723fcc430a027bc6952628fa2a3ac77584a1d0bd328275e573fc9b206c155004" \
+	"https://downloads.es.net/pub/iperf/iperf-3.14.tar.gz" \
+	"https://sources.buildroot.net/iperf3/iperf-3.14.tar.gz"
+
+# Preset values follow run_pinned_pts's contract against the UPSTREAM axes (PTS 10.8.4
+# pts_test_run_options.php / pts_test_option.php):
+#   * server-address and positive-number (Server Port) have no <Menu> — text-entry options, so the
+#     preset value passes through literally ("Using Pre-Set Run Option"): -c localhost, -p 5201.
+#   * duration "10 Seconds", test "TCP" and test "UDP - 10000Mbit Objective" are non-numeric → pin
+#     by entry NAME (4- and 5-entry menus). TCP's entry carries no <Value>, so it contributes no
+#     argument — TCP IS the absence of the -u UDP flags; the UDP entry contributes "-u -b 10000m".
+#   * parallel is the numeric-menu trap: the menu is 1,5,10,20,32,64,128,256 (8 entries), and a
+#     NUMERIC preset below the entry count reads as a 0-based INDEX. "1" would select index 1 =
+#     "5" (-P 5!), so -P 1 pins by INDEX 0 (the fio cpu-threads=0 precedent); "10" is >= 8 so it
+#     falls through to a NAME match on the "10" entry (-P 10).
+#
+# The three variants are independent measurements, so none aborts the others (`|| true` keeps each
+# variant's own recorded gap while letting the rest run); the assert loop below is the single
+# arbiter that reds the job.
+run_pinned_pts "pts/iperf-1.2.0" "pts_iperf-tcp-p1" \
+	"iperf.server-address=localhost;iperf.positive-number=5201;iperf.duration=10 Seconds;iperf.test=TCP;iperf.parallel=0" || true
+run_pinned_pts "pts/iperf-1.2.0" "pts_iperf-tcp-p10" \
+	"iperf.server-address=localhost;iperf.positive-number=5201;iperf.duration=10 Seconds;iperf.test=TCP;iperf.parallel=10" || true
+run_pinned_pts "pts/iperf-1.2.0" "pts_iperf-udp-10g" \
+	"iperf.server-address=localhost;iperf.positive-number=5201;iperf.duration=10 Seconds;iperf.test=UDP - 10000Mbit Objective;iperf.parallel=0" || true
+
+# PTS exits 0 and writes a composite even when every trial failed (empty <Value> elements): each
+# variant must post its one throughput result. A --skipped.json marker passes — an honest recorded
+# gap is the designed keep+warn shape.
+for prefix in pts_iperf-tcp-p1 pts_iperf-tcp-p10 pts_iperf-udp-10g; do
+	assert_pts_numeric_values "$prefix" 1
+done

--- a/.mise/tasks/benchmark/network/pts/iperf-wan
+++ b/.mise/tasks/benchmark/network/pts/iperf-wan
@@ -1,0 +1,79 @@
+#!/usr/bin/env bash
+#MISE description="PTS: iperf3 WAN TCP throughput vs closest curated public server (10s, 8 streams, both directions)"
+# Measurement leaf: -e guards the scaffolding; the measured runs are isolated by run_pts_benchmark
+# (via run_pinned_pts, which owns the per-prefix skip markers and pins each direction through
+# PRESET_OPTIONS).
+#
+# The suite's successor to the fast-cli leaf (which stays runnable manually): run 29937467891 showed
+# the Chrome-driven fast.com measurement is structurally unreliable on fast datacenter paths (memory
+# watchdog killed every trial on daytona-vm/novita/blaxel; the surviving numbers were buffer-fill
+# transients). iperf3 against a curated public server measures WAN throughput with real byte
+# accounting. The profile's runner (local/iperf-wan-1.0.0/runner.sh) probes TCP-connect RTT to every
+# listed server, picks the closest reachable non-backup one, retries across its port range on
+# single-client busy collisions, and appends the per-trial choice to server-choices.ndjson — copied
+# into the results tree below, because WAN numbers are uninterpretable without the chosen server.
+set -euo pipefail
+REPO_ROOT="$(git -C "$(dirname "${BASH_SOURCE[0]}")" rev-parse --show-toplevel)"
+source "${REPO_ROOT}/lib/bench.sh"
+
+# install_local_pts_profile needs PTS on PATH before run_pinned_pts's own guard can run, so guard
+# here with a skip marker per prefix (the exact negatives of the two composites this leaf produces).
+if ! command -v phoronix-test-suite &>/dev/null; then
+	skip_result "phoronix-test-suite not installed" "pts_iperf-wan-download"
+	skip_result "phoronix-test-suite not installed" "pts_iperf-wan-upload"
+	exit 0
+fi
+# The runner parses servers.json and iperf3's JSON output with jq (baked; also in PTS_APT_DEPS).
+if ! command -v jq &>/dev/null; then
+	skip_result "jq not installed (required for iperf-wan server selection)" "pts_iperf-wan-download"
+	skip_result "jq not installed (required for iperf-wan server selection)" "pts_iperf-wan-upload"
+	exit 0
+fi
+
+install_local_pts_profile "iperf-wan-1.0.0"
+
+# Same iperf-3.14 source tarball as the localhost leaf (shared PTS download cache, so after that
+# leaf this is a verified no-op) — seeded for the same reason: PTS's single-shot downloader turns
+# one upstream hiccup into a whole-profile install failure and a suite-wide gap.
+seed_pts_download_cache "iperf-3.14.tar.gz" \
+	"723fcc430a027bc6952628fa2a3ac77584a1d0bd328275e573fc9b206c155004" \
+	"https://downloads.es.net/pub/iperf/iperf-3.14.tar.gz" \
+	"https://sources.buildroot.net/iperf3/iperf-3.14.tar.gz"
+
+# The runner's chosen-server cache pins BOTH directions of THIS leaf execution to one path, and its
+# NDJSON provenance must describe exactly the trials copied into this run's results tree — but both
+# files live in the persistent installed-profile dir, which survives suite re-runs in a long-lived
+# sandbox (fresh CI sandboxes never see this; manual re-runs do). Scope them to this execution:
+# clear both here, after install (which may re-stage the profile) and before the first trial.
+#
+# The results-tree COPY needs clearing for the same reason and is easy to miss: the copy below is
+# conditional on the runner having produced a file at all, so a re-run where every trial fails
+# would leave the PREVIOUS execution's provenance sitting in the results tree, describing trials
+# this run never made — the exact misattribution these two lines exist to prevent.
+profile_dir="$(pts_user_dir)/installed-tests/local/iperf-wan-1.0.0"
+rm -f "${profile_dir}/chosen-server" "${profile_dir}/server-choices.ndjson" \
+	"$(results_dir)/pts_iperf-wan--server-choices.ndjson"
+
+# Direction pins by entry NAME (non-numeric). The two directions are independent measurements, so
+# neither aborts the other (`|| true` keeps each direction's own recorded gap while letting the
+# other run); the assert loop below is the single arbiter that reds the job. Download first: -R is
+# the direction fast-cli's loss hurt most (provider ingress).
+run_pinned_pts "local/iperf-wan-1.0.0" "pts_iperf-wan-download" "iperf-wan.direction=Download" || true
+run_pinned_pts "local/iperf-wan-1.0.0" "pts_iperf-wan-upload" "iperf-wan.direction=Upload" || true
+
+# Server-choice provenance: the runner appends one NDJSON record per successful trial (host, port,
+# provider, site, probe RTT, figure). Best-effort copy — the composites are the metrics; a missing
+# file just means no trial succeeded and the asserts below already tell that story.
+choices="${profile_dir}/server-choices.ndjson"
+if [ -f "$choices" ]; then
+	cp "$choices" "$(results_dir)/pts_iperf-wan--server-choices.ndjson" 2>/dev/null || true
+	echo "Server-choice provenance: pts_iperf-wan--server-choices.ndjson"
+	cat "$choices"
+fi
+
+# PTS exits 0 and writes a composite even when every trial failed (empty <Value> elements): each
+# direction must post its one throughput result. A --skipped.json marker passes — an honest recorded
+# gap is the designed keep+warn shape.
+for prefix in pts_iperf-wan-download pts_iperf-wan-upload; do
+	assert_pts_numeric_values "$prefix" 1
+done

--- a/.mise/tasks/benchmark/network/suite
+++ b/.mise/tasks/benchmark/network/suite
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+#MISE description="Run the network suite (PTS iperf3 localhost + WAN + latency/DNS/download probes)"
+# Orchestrator: no -e — run_task isolates child failures and summary reports them at the end
+# (error-mode conventions: lib/bench.sh). This is the composition the network SUITE runs
+# (packages/schema suites.ts points at it); benchmark:network:all keeps the previous
+# fast-cli + network-loopback composition for manual runs.
+set -uo pipefail
+REPO_ROOT="$(git -C "$(dirname "${BASH_SOURCE[0]}")" rev-parse --show-toplevel)"
+source "${REPO_ROOT}/lib/bench.sh"
+
+echo "========================================"
+echo "  NETWORK BENCHMARKS (iperf composition)"
+echo "========================================"
+
+# The catalogued metrics: iperf3 against localhost isolates the sandbox's network stack (virtio vs
+# gVisor netstack vs host namespaces) from Internet weather, and iperf3 against the closest curated
+# public server measures WAN throughput with real byte accounting — the successors to the
+# network-loopback and fast-cli leaves (run 29937467891: the Chrome-driven fast.com measurement was
+# structurally unreliable on fast datacenter paths; both old leaves remain runnable manually via
+# benchmark:network:all).
+ensure_pts || true
+
+run_task benchmark:network:pts:iperf-localhost
+run_task benchmark:network:pts:iperf-wan
+
+# Tolerant probes (raw JSON provenance, no catalogued metrics): where does this sandbox's traffic
+# actually go, and how fast? Endpoint-specific connection timings and a small GitHub control
+# transfer for diagnosis.
+run_task benchmark:network:latency
+run_task benchmark:network:dns
+run_task benchmark:network:download
+
+summary

--- a/lib/bench.sh
+++ b/lib/bench.sh
@@ -366,6 +366,50 @@ ensure_pts() {
 	return 0
 }
 
+# Seed PTS's download cache with one profile source file, fetched with retries and a SHA256-verified
+# mirror fallback. PTS's own downloader is single-shot per URL: one upstream hiccup during
+# `batch-install` fails the whole profile install, which the leaf then records as a suite-wide gap
+# (run 29964910698: downloads.es.net refused 4 of 6 providers' single-shot fetches within one
+# minute while the other 2 succeeded). A baked toolchain image already ships the file in this cache
+# (the bake pre-installs the profile), making this a verified no-op; the seed exists for stock-image
+# providers (blaxel installs every profile at run time) and for validation runs on a not-yet-rebaked
+# toolchain. Never fatal: on total failure PTS's own downloader still gets its chance, and the
+# leaf's existing skip/assert machinery owns the failure story.
+#
+# That "never fatal" promise is a TIME budget as much as an exit-code one, hence --retry-max-time.
+# curl resets --max-time on every retry ("the maximum time counter is reset each time the transfer
+# is retried" — curl(1)), so a per-attempt cap alone bounds nothing: 1+8 attempts at 300s plus the
+# retry delays is ~45m per URL, ~91m across a primary and one mirror, against the network suite's
+# 30-minute commandTimeoutMinutes. The leaf would be killed mid-seed and PTS's downloader — the
+# fallback this exists to preserve — would never run at all. The bound below is ~150s per URL
+# (retry window, plus one in-flight attempt that may start just under it), so a primary + mirror
+# costs at most ~5m. A small source tarball that cannot arrive in 60s is not going to arrive.
+# Usage: seed_pts_download_cache <file-name> <sha256> <url> [mirror-url...]
+seed_pts_download_cache() {
+	local filename="$1" sha256="$2" cache tmp url
+	shift 2
+	pts_init
+	cache="$(pts_user_dir)/download-cache"
+	mkdir -p "$cache"
+	if [ -f "${cache}/${filename}" ] && echo "${sha256}  ${cache}/${filename}" | sha256sum -c - &>/dev/null; then
+		echo "PTS download cache already holds ${filename} (sha256 verified)"
+		return 0
+	fi
+	tmp="${cache}/.${filename}.part"
+	for url in "$@"; do
+		if curl -fsSL --retry 3 --retry-all-errors --retry-delay 3 --retry-max-time 90 \
+			--connect-timeout 10 --max-time 60 -o "$tmp" "$url" &&
+			echo "${sha256}  ${tmp}" | sha256sum -c - &>/dev/null; then
+			mv "$tmp" "${cache}/${filename}"
+			echo "Seeded PTS download cache: ${filename} <- ${url}"
+			return 0
+		fi
+		rm -f "$tmp"
+		echo "WARNING: could not seed ${filename} from ${url} (trying next source, else PTS's own downloader)" >&2
+	done
+	return 0
+}
+
 # Install a repo-local PTS profile (packages/schema/src/pts-profiles/local/<name>) into PTS's
 # local-profile dir, so `phoronix-test-suite batch-install local/<name>` can find it — PTS won't fetch
 # a repo-local profile itself. The dir depends on the run user ($HOME/.phoronix-test-suite vs


### PR DESCRIPTION
**Network suite → iperf3 — retire fast-cli/dd|nc from the suite; measure localhost + WAN with iperf3**
Shipped as a 6-PR stack (merge bottom-up, each branch independently green). Supersedes #249.
1. #251 — schema: vendor `pts/iperf-1.2.0` byte-identical + catalog generator support
2. #252 — schema: add `local/iperf-wan-1.0.0` (closest-public-server WAN throughput)
3. #253 — templates: bake iperf-1.2.0 into the toolchain images, `TOOLCHAIN_VERSION` v5 → v6
4. #254 — bench: iperf3 localhost + WAN producer leaves and the suite orchestrator
5. #255 — network: flip the suite to the iperf composition (headline moves)
6. #256 — dataset: publish the composite Run for the stack and refresh `LEADERBOARD.md`

Post-merge sequencing: dispatch `toolchain-image.yml` on main to publish the v6 images/snapshots **before** the first main `bench-matrix` run that consumes them.

↑ **This PR is #254 (4/6), based on #253**.

---

Pure-additive producer layer — nothing invokes benchmark:network:suite yet (the
suite registry still points at benchmark:network:all; the flip is the top of
this stack).

benchmark:network:pts:iperf-localhost stages the vendored pts/iperf-1.2.0
subset over the baked install and runs two pinned variants from one install
(the pgbench one-leaf precedent): -P 1 is the single-stream stack/
virtualization number, -P 10 adds per-stream overhead scaling (iperf 3.14 is
single-threaded). Preset semantics are verified against PTS 10.8.4: the
free-text axes pass through literally (-c localhost, -p 5201), duration/test
pin by entry NAME (TCP's entry has no <Value> — TCP IS the absence of the -u
flags), and parallel is the numeric-menu trap: a numeric preset below the
8-entry count reads as a 0-based INDEX, so -P 1 pins by INDEX 0 ("1" would
select entry 1 = "5"!) while "10" falls through to a NAME match.

benchmark:network:pts:iperf-wan runs local/iperf-wan-1.0.0 in both directions,
scopes the runner's chosen-server cache and NDJSON provenance to one leaf
execution (long-lived sandboxes survive suite re-runs; fresh CI sandboxes never
see this), and copies the per-trial server choices into the results tree —
WAN numbers are uninterpretable without the chosen server.
Both leaves seed PTS's download cache with the iperf-3.14 source tarball before
install (lib/bench.sh seed_pts_download_cache: curl with retries + a
byte-identical buildroot mirror, SHA256-verified). PTS's own downloader is
single-shot per URL — run 29964910698 lost 4 of 6 providers' cells to one
downloads.es.net hiccup — and the seed is a verified no-op once the v6 bake
ships the tarball in the image; it exists for stock-image providers (blaxel)
and validation runs on a not-yet-rebaked toolchain.

benchmark:network:suite is the composition the network suite will run: both
iperf leaves plus the tolerant latency/DNS/download probes.
benchmark:network:all keeps the previous fast-cli + network-loopback
composition for manual runs. Each leaf posts exactly one numeric value per
composite or records an honest gap (assert_pts_numeric_values; keep+warn).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds iperf3 localhost and WAN benchmark leaves and a network suite orchestrator to produce stable, comparable throughput metrics with clear provenance. Also bounds PTS cache seeding time and clears stale WAN provenance to avoid misleading results.

- **New Features**
  - `benchmark:network:pts:iperf-localhost`: Runs PTS `iperf-1.2.0` over localhost (10s). TCP `-P 1` and `-P 10`, plus UDP at 10 Gbit. Pins presets. Skips if `phoronix-test-suite` is missing.
  - `benchmark:network:pts:iperf-wan`: Runs `local/iperf-wan-1.0.0` (10s, 8 streams) in Download and Upload vs the closest curated server (RTT probe). Retries ports, scopes cache/provenance per run, and copies `server-choices.ndjson`. Requires `jq`.
  - `benchmark:network:suite`: Orchestrates `iperf-localhost`, `iperf-wan`, then `latency`, `dns`, and `download` probes. Prints a summary. Pure additive; the suite registry still points to `benchmark:network:all`.
  - Each leaf posts one numeric metric per variant/direction, or records a gap if skipped.

- **Bug Fixes**
  - Bounded PTS download-cache seeding with `--retry-max-time` and tighter timeouts (~5m cap across primary+mirror). Non-fatal; falls back to PTS’s downloader.
  - Cleared stale WAN provenance by also removing the results copy `pts_iperf-wan--server-choices.ndjson` before runs.

<sup>Written for commit 6413fef5adca6308508593320f3f5690a7b9bd62. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/starslingdev/hpc-sandbox-benchmarks/pull/254?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

