### PR TITLE
feat(network): move the network suite onto iperf3 localhost + WAN leaves

### DIFF
--- a/LEADERBOARD.md
+++ b/LEADERBOARD.md
@@ -221,20 +221,6 @@ _Daytona (VM) leads · ~1.2× Blaxel on median (higher is better)._
 
 ## network
 
-### Loopback TCP (10GB) _(headline)_
-
-Seconds · lower is better
-
-_Blaxel leads · Daytona (VM) is ~1.1× higher (lower is better)._
-
-| Rank | Provider | Loopback TCP (10GB) (Seconds) | 95% bootstrap interval | n | Note |
-| ---: | --- | ---: | ---: | ---: | --- |
-| 1 | Blaxel | 4.393 | 4.253 – 4.533 | 2 | — |
-| 2 | Daytona (VM) | 4.785 | 4.675 – 4.895 | 2 | n too small |
-| 3 | Novita | 8.637 | 8.39 – 8.884 | 2 | n too small |
-| 4 | E2B | 10.65 | 10.16 – 11.15 | 2 | n too small |
-| 5 | Modal (gVisor) | 43.16 | 41.41 – 44.9 | 2 | n too small |
-
 ### fast.com download
 
 Mbit/s · higher is better
@@ -282,6 +268,20 @@ _Modal (gVisor) leads · ~255.0× Daytona (VM) on median (higher is better)._
 | 1 | Modal (gVisor) | 25.5 | 18 – 33 | 2 |
 | 2 | Daytona (VM) | 0.1 | — | 1 |
 | 3 | Blaxel | 0.075 | 0.068 – 0.082 | 2 |
+
+### Loopback TCP (10GB)
+
+Seconds · lower is better
+
+_Blaxel leads · Daytona (VM) is ~1.1× higher (lower is better)._
+
+| Rank | Provider | Loopback TCP (10GB) (Seconds) | 95% bootstrap interval | n | Note |
+| ---: | --- | ---: | ---: | ---: | --- |
+| 1 | Blaxel | 4.393 | 4.253 – 4.533 | 2 | — |
+| 2 | Daytona (VM) | 4.785 | 4.675 – 4.895 | 2 | n too small |
+| 3 | Novita | 8.637 | 8.39 – 8.884 | 2 | n too small |
+| 4 | E2B | 10.65 | 10.16 – 11.15 | 2 | n too small |
+| 5 | Modal (gVisor) | 43.16 | 41.41 – 44.9 | 2 | n too small |
 
 ## system
 
@@ -697,11 +697,6 @@ correction is applied across providers or metrics.
 | memory | STREAM Scale | Blaxel | 0.33 (n too small) | 0.097 |
 | memory | STREAM Scale | Novita | 0.33 (n too small) | 0.097 |
 | memory | STREAM Scale | E2B | 0.33 (n too small) | 0.097 |
-| network | Loopback TCP (10GB) | Blaxel | — | — |
-| network | Loopback TCP (10GB) | Daytona (VM) | 0.33 (n too small) | 0.097 |
-| network | Loopback TCP (10GB) | Novita | 0.33 (n too small) | 0.097 |
-| network | Loopback TCP (10GB) | E2B | 0.33 (n too small) | 0.097 |
-| network | Loopback TCP (10GB) | Modal (gVisor) | 0.33 (n too small) | 0.097 |
 | network | fast.com download | Modal (gVisor) | — | — |
 | network | fast.com download | Daytona (VM) | — | — |
 | network | fast.com download | Blaxel | — | — |
@@ -714,6 +709,11 @@ correction is applied across providers or metrics.
 | network | fast.com upload | Modal (gVisor) | — | — |
 | network | fast.com upload | Daytona (VM) | — | — |
 | network | fast.com upload | Blaxel | — | — |
+| network | Loopback TCP (10GB) | Blaxel | — | — |
+| network | Loopback TCP (10GB) | Daytona (VM) | 0.33 (n too small) | 0.097 |
+| network | Loopback TCP (10GB) | Novita | 0.33 (n too small) | 0.097 |
+| network | Loopback TCP (10GB) | E2B | 0.33 (n too small) | 0.097 |
+| network | Loopback TCP (10GB) | Modal (gVisor) | 0.33 (n too small) | 0.097 |
 | system | PyBench | Blaxel | — | — |
 | system | Git common operations | Daytona (VM) | — | — |
 | system | Git common operations | Blaxel | 0.33 (n too small) | 0.097 |

--- a/packages/schema/src/catalog.test.ts
+++ b/packages/schema/src/catalog.test.ts
@@ -119,12 +119,47 @@ describe("metric catalog", () => {
 		expect(getMetric("not_a_metric")).toBeUndefined();
 	});
 
-	it("keeps the controlled Loopback TCP measurement as the network headline", () => {
+	it("keeps the controlled localhost iperf3 measurement as the network headline", () => {
 		const metric = headlineMetric("network");
-		expect(metric.id).toBe("network_loopback_seconds");
-		expect(metric.label).toBe("Loopback TCP (10GB)");
-		expect(metric.direction).toBe("LIB");
-		expect(metric.pts).toEqual({ test: "pts/network-loopback" });
+		expect(metric.id).toBe(
+			"iperf_server_address_localhost_server_port_5201_duration_10_seconds_test_tcp_parallel_1",
+		);
+		expect(metric.label).toBe("iperf3 loopback TCP, 1 stream");
+		expect(metric.direction).toBe("HIB");
+		// The vendored subset's pinned axes travel in the runtime description the catalog joins on.
+		expect(metric.pts).toEqual({
+			test: "pts/iperf",
+			description:
+				"Server Address: localhost - Server Port: 5201 - Duration: 10 Seconds - Test: TCP - Parallel: 1",
+		});
+		// The third pinned localhost combination — the UDP datagram-path discriminator — resolves
+		// through the same full-matrix enumeration with its curated label.
+		const udp = getMetric(
+			"iperf_server_address_localhost_server_port_5201_duration_10_seconds_test_udp_10000mbit_objective_parallel_1",
+		);
+		expect(udp?.label).toBe("iperf3 loopback UDP, 10G objective");
+		expect(udp?.pts?.description).toBe(
+			"Server Address: localhost - Server Port: 5201 - Duration: 10 Seconds - Test: UDP - 10000Mbit Objective - Parallel: 1",
+		);
+	});
+
+	it("resolves the WAN iperf3 pair via the local/ join key with per-direction descriptions", () => {
+		const download = getMetric("iperf_wan_direction_download");
+		const upload = getMetric("iperf_wan_direction_upload");
+		expect(download?.pts).toEqual({ test: "local/iperf-wan", description: "Direction: Download" });
+		expect(upload?.pts).toEqual({ test: "local/iperf-wan", description: "Direction: Upload" });
+		expect(download?.direction).toBe("HIB");
+		expect(upload?.label).toBe("iperf3 WAN upload");
+	});
+
+	it("keeps the retired-from-suite network profiles catalogued for manual runs (sans headline)", () => {
+		// fast-cli and network-loopback left the SUITE, not the repo: their profiles stay vendored and
+		// manually runnable, so their metrics stay catalogued — but the network headline moved to the
+		// localhost iperf3 metric above.
+		const loopback = getMetric("network_loopback_seconds");
+		expect(loopback?.label).toBe("Loopback TCP (10GB)");
+		expect(loopback?.headline).toBe(false);
+		expect(getMetric("fast_cli_internet_download_speed")?.label).toBe("fast.com download");
 	});
 
 	it("resolves fio's scale-pinned twin metrics for one description (disk dimension)", () => {

--- a/packages/schema/src/pts-overrides.ts
+++ b/packages/schema/src/pts-overrides.ts
@@ -84,13 +84,38 @@ export const ptsOverrides: Record<string, MetricOverride> = {
 	fio_type_random_write_engine_linux_aio_direct_no_block_size_4kb_job_count_1_disk_target_default_test_directory_mb_per_s:
 		{ label: "fio rand write 4KB, buffered (MB/s)" },
 
-	// Network dimension: loopback remains the stable headline that separates sandbox network-stack
-	// overhead from Internet/CDN weather; fast.com adds sustained real-world transfer measurements.
+	// Network dimension. The suite's composition is the five iperf metrics: localhost isolates
+	// sandbox network-stack/virtualization overhead (virtio/KVM vs gVisor netstack) with no Internet
+	// path — single-stream is the dimension's headline (it took the slot from network_loopback when
+	// the suite moved off the dd|nc leaf; the catalog allows one headline per dimension), and the
+	// 10-stream variant captures per-stream overhead scaling (iperf 3.14 is single-threaded, so it
+	// multiplexes streams in one process rather than across cores). pts/iperf is vendored
+	// byte-identical to upstream, so the generator enumerates its full option matrix (fio-style);
+	// only the three combinations the producer pins are curated here — the rest keep draft labels and
+	// never receive samples. The WAN pair measures both directions against the closest curated
+	// public iperf3 server (chosen per run by RTT probe, recorded in
+	// pts_iperf-wan--server-choices.ndjson provenance).
+	iperf_server_address_localhost_server_port_5201_duration_10_seconds_test_tcp_parallel_1: {
+		headline: true,
+		label: "iperf3 loopback TCP, 1 stream",
+	},
+	iperf_server_address_localhost_server_port_5201_duration_10_seconds_test_tcp_parallel_10: {
+		label: "iperf3 loopback TCP, 10 streams",
+	},
+	// UDP at the 10000Mbit objective is the one UDP menu point that discriminates on localhost: KVM
+	// stacks saturate the objective while gVisor's netstack undershoots. The lower objectives read
+	// as constants on every provider and plain UDP defaults to 1 Mbit/s, so neither is pinned.
+	iperf_server_address_localhost_server_port_5201_duration_10_seconds_test_udp_10000mbit_objective_parallel_1:
+		{ label: "iperf3 loopback UDP, 10G objective" },
+	iperf_wan_direction_download: { label: "iperf3 WAN download" },
+	iperf_wan_direction_upload: { label: "iperf3 WAN upload" },
+	// Retained profiles the suite no longer runs (manual benchmark:network:all composition): labels
+	// kept so manual results stay readable; loopback's former headline moved to iperf above.
 	fast_cli_internet_download_speed: { label: "fast.com download" },
 	fast_cli_internet_upload_speed: { label: "fast.com upload" },
 	fast_cli_internet_latency: { label: "fast.com latency" },
 	fast_cli_internet_loaded_latency_bufferbloat: { label: "fast.com loaded latency" },
-	network_loopback_seconds: { headline: true, label: "Loopback TCP (10GB)" },
+	network_loopback_seconds: { label: "Loopback TCP (10GB)" },
 
 	// System dimension: the synthetic Git profile complements the realworld repo tasks by isolating a
 	// fixed command sequence over a fixed GTK corpus.

--- a/packages/schema/src/suites.test.ts
+++ b/packages/schema/src/suites.test.ts
@@ -64,14 +64,13 @@ describe("suite registry", () => {
 	});
 
 	it("mirrors the unpinned suites' metrics from the generated catalog (no hand-drift)", () => {
-		// These suites batch-run their profiles WITHOUT PRESET_OPTIONS, so whatever the catalog lists for
-		// the test is exactly what the suite emits — pin the declared list to it in BOTH directions (a
-		// profile bump that adds/renames a combination fails here instead of silently stranding the
-		// list). stream's Type axis and fast-cli's four results are the matrix cases; pybench, sqlite,
-		// git and network-loopback declare no <Option> axes, so the pin holds over their wildcard result.
-		// (pgbench is preset-pinned and now its own suite — gated by the subset test below.)
+		// These suites' declared metrics are exactly what the catalog lists for their profiles — pin the
+		// declared list to it in BOTH directions (a profile bump that adds/renames a combination fails
+		// here instead of silently stranding the list). stream's Type axis is the matrix case; pybench,
+		// sqlite and git declare no <Option> axes, so the pin holds over their wildcard result.
+		// (pgbench and network/iperf are preset-pinned against full upstream matrices — gated by the
+		// subset test below.)
 		const profilesOf = {
-			network: ["pts/network-loopback", "pts/fast-cli"],
 			memory: ["pts/stream"],
 			system: ["pts/pybench", "pts/sqlite-speedtest", "pts/git"],
 		} as const;
@@ -88,16 +87,18 @@ describe("suite registry", () => {
 	});
 
 	it("pins the PINNED-subset suites to their curated override keys", () => {
-		// disk (fio) and system (pgbench) deliberately declare a SUBSET of their profile's catalogued
-		// combinations — the ones the producer tasks pin via PRESET_OPTIONS — so a catalog mirror
-		// can't gate them. Every declared subset id is also a curated pts-overrides key (only the
-		// producible combinations get short labels), so equality against the override keys catches a
-		// wrong-axis id here: with the full matrix catalogued, a typo'd engine, block size or scale
-		// would otherwise pass the suite contract and just never receive samples.
+		// disk (fio), pgbench, and network (iperf, vendored byte-identical to upstream's full matrix)
+		// deliberately declare a SUBSET of their profile's catalogued combinations — the ones the
+		// producer tasks pin via PRESET_OPTIONS — so a catalog mirror can't gate them. Every declared
+		// subset id is also a curated pts-overrides key (only the producible combinations get short
+		// labels), so equality against the override keys catches a wrong-axis id here: with the full
+		// matrix catalogued, a typo'd engine, block size, parallel count or scale would otherwise pass
+		// the suite contract and just never receive samples.
 		const overrideKeys = Object.keys(ptsOverrides);
 		const subsets = [
 			{ suite: "disk", prefix: "fio_" },
 			{ suite: "pgbench", prefix: "pgbench_" },
+			{ suite: "network", prefix: "iperf_" },
 		] as const;
 		for (const { suite, prefix } of subsets) {
 			const declared: string[] = SUITES[suite].metrics.filter((id) => id.startsWith(prefix)).sort();

--- a/packages/schema/src/suites.ts
+++ b/packages/schema/src/suites.ts
@@ -169,28 +169,32 @@ export const SUITES = {
 		],
 		commands: ["mise run benchmark:disk:all"],
 	},
-	// The network dimension: fast-cli performs sustained real-world download/upload transfers through
-	// Netflix's fast.com CDN and reports idle/loaded latency; loopback TCP (10GB via nc) is the paired
-	// self-contained synthetic that isolates the sandbox's network stack from Internet weather. The
-	// suite task also runs latency/DNS and a small GitHub control-download probe as raw provenance.
-	// setupNode installs the fast.com CLI. Long-synthetic tier (k=2, R=3): replicate sandboxes capture the
-	// placement/peering variance a single fast.com transfer can't.
+	// The network dimension, iperf composition (benchmark:network:suite): iperf3 over localhost
+	// isolates the sandbox's network stack/virtualization overhead (virtio/KVM vs gVisor netstack vs
+	// host namespaces) from Internet weather, and iperf3 against the closest curated public server
+	// (local/iperf-wan; chosen at run time by TCP-connect RTT probe, recorded as provenance)
+	// measures WAN throughput both directions with real byte accounting. These supersede the
+	// fast-cli + dd|nc loopback leaves IN THE SUITE (run 29937467891: Chrome's page-scrape
+	// measurement was structurally unreliable on fast datacenter paths — every trial on
+	// daytona-vm/novita/blaxel died in the memory watchdog and the surviving numbers were
+	// buffer-fill transients); the old leaves and profiles stay runnable manually via
+	// benchmark:network:all. The suite task also runs latency/DNS and a small GitHub
+	// control-download probe as raw provenance. Long-synthetic tier (k=2, R=3).
 	network: {
 		setupPts: true,
-		setupNode: true,
-		commandTimeoutMinutes: 45,
-		timeoutMinutes: 55,
+		commandTimeoutMinutes: 30,
+		timeoutMinutes: 40,
 		ptsTimesToRun: 2,
 		defaultReplicas: 3,
 		dimensions: ["network"],
 		metrics: [
-			"fast_cli_internet_download_speed",
-			"fast_cli_internet_upload_speed",
-			"fast_cli_internet_latency",
-			"fast_cli_internet_loaded_latency_bufferbloat",
-			"network_loopback_seconds",
+			"iperf_server_address_localhost_server_port_5201_duration_10_seconds_test_tcp_parallel_1",
+			"iperf_server_address_localhost_server_port_5201_duration_10_seconds_test_tcp_parallel_10",
+			"iperf_server_address_localhost_server_port_5201_duration_10_seconds_test_udp_10000mbit_objective_parallel_1",
+			"iperf_wan_direction_download",
+			"iperf_wan_direction_upload",
 		],
-		commands: ["mise run benchmark:network:all"],
+		commands: ["mise run benchmark:network:suite"],
 	},
 	// The realworld dimension (ENG-135/136/137/138): real OSS repos run through their own CI tasks,
 	// each a repo-local PTS profile with a Task option axis. Real-world tier: k=1 in-sandbox pass (the


### PR DESCRIPTION
**Network suite → iperf3 — retire fast-cli/dd|nc from the suite; measure localhost + WAN with iperf3**
Shipped as a 6-PR stack (merge bottom-up, each branch independently green). Supersedes #249.
1. #251 — schema: vendor `pts/iperf-1.2.0` byte-identical + catalog generator support
2. #252 — schema: add `local/iperf-wan-1.0.0` (closest-public-server WAN throughput)
3. #253 — templates: bake iperf-1.2.0 into the toolchain images, `TOOLCHAIN_VERSION` v5 → v6
4. #254 — bench: iperf3 localhost + WAN producer leaves and the suite orchestrator
5. #255 — network: flip the suite to the iperf composition (headline moves)
6. #256 — dataset: publish the composite Run for the stack and refresh `LEADERBOARD.md`

Post-merge sequencing: dispatch `toolchain-image.yml` on main to publish the v6 images/snapshots **before** the first main `bench-matrix` run that consumes them.

↑ **This PR is #255 (5/6), based on #254**.

---

The wiring flip, on top of the vendored profiles, producer leaves and bake
below in this stack. Run 29937467891 showed the Chrome-driven fast.com
measurement is structurally unreliable on fast datacenter paths: the memory
watchdog killed every trial on daytona-vm/novita/blaxel and the surviving
numbers were buffer-fill transients. The suite's composition becomes the four
iperf metrics — localhost single-stream (the dimension's new headline) and
10-stream isolate sandbox network-stack/virtualization overhead with no
Internet path; the WAN pair measures both directions against the closest
curated public iperf3 server (chosen per run by RTT probe, recorded as
provenance).

- suites.ts: network points at benchmark:network:suite, declares the five
  iperf metrics (TCP -P1/-P10 + the UDP 10G-objective datagram discriminator), and drops setupNode (no fast-cli npm install); timeouts
  tighten 45/55 -> 30/40. The old fast-cli + dd|nc leaves and profiles stay
  runnable manually via benchmark:network:all.
- pts-overrides.ts: the headline moves atomically from network_loopback_seconds
  to the localhost single-stream metric (the catalog allows exactly one
  headline per dimension); only the five producible combinations get curated
  labels — the rest of the vendored matrix keeps draft labels and never
  receives samples. Retired profiles keep labels so manual results stay
  readable.
- suites.test.ts: network moves from the full-catalog mirror to the
  PINNED-subset gate (the fio/pgbench pattern, prefix iperf_).
- catalog.test.ts: headline + WAN join-key expectations; the retired profiles
  stay catalogued sans headline.
- LEADERBOARD.md: regenerated — loopback loses the headline tag and reorders
  after the curated-label sections (the artifact-sync gate re-derives this).


### Live pre-merge validation — bench-matrix run [29967667026](https://github.com/starslingdev/hpc-sandbox-benchmarks/actions/runs/29967667026)

All **6 providers × network suite** on the final composition (TCP −P1/−P10 + UDP 10G-objective localhost + WAN pair), dispatched with `allow_branch` on [`network-iperf-validate`](https://github.com/starslingdev/hpc-sandbox-benchmarks/tree/network-iperf-validate) = **this stack's tip plus one validation-only commit** pinning `TOOLCHAIN_VERSION` back to `v5` (v6 images cannot exist pre-merge — the toolchain publish lane is main-gated — so cells boot the existing v5 snapshots and the leaves install iperf from the retried, SHA256-verified seeded download cache; every measured code path is byte-identical to this stack).

Every cell **succeeded**, and artifact-level verification confirmed for each provider: `validationStatus: "validated"`, `gaps: []`, `uncatalogued: 0`, exactly the five declared iperf metrics with **k=2 samples each**, **zero `--skipped.json`/`--failed.json` markers**, and complete per-trial WAN provenance (`pts_iperf-wan--server-choices.ndjson`: ts, direction, host, port, provider, site, probe RTT, throughput, retransmits — 2 down + 2 up records per provider).

### Suite metric contract (what #255 declares, and where each number comes from)

| metric id (`suites.ts`) | curated label | pinned iperf3 arguments | isolates | composite in artifacts |
|---|---|---|---|---|
| `iperf_…_test_tcp_parallel_1` | iperf3 loopback TCP, 1 stream _(headline)_ | `-c localhost -p 5201 -t 10 -P 1` | single-stream network-stack/virtualization overhead, no Internet path | `pts_iperf-tcp-p1.xml` |
| `iperf_…_test_tcp_parallel_10` | iperf3 loopback TCP, 10 streams | `-c localhost -p 5201 -t 10 -P 10` | per-stream overhead scaling (iperf 3.14 multiplexes in one process) | `pts_iperf-tcp-p10.xml` |
| `iperf_…_test_udp_10000mbit_objective_parallel_1` | iperf3 loopback UDP, 10G objective | `-c localhost -p 5201 -t 10 -u -b 10000m -P 1` | datagram-path capability: KVM saturates the objective, gVisor netstack undershoots | `pts_iperf-udp-10g.xml` |
| `iperf_wan_direction_download` | iperf3 WAN download | `-R` (8 streams, 10s, closest curated server) | provider ingress with real byte accounting | `pts_iperf-wan-download.xml` |
| `iperf_wan_direction_upload` | iperf3 WAN upload | (8 streams, 10s, closest curated server) | provider egress with real byte accounting | `pts_iperf-wan-upload.xml` |

Full ids elide the shared `server_address_localhost_server_port_5201_duration_10_seconds` axes. WAN rows additionally record the chosen server per trial in `pts_iperf-wan--server-choices.ndjson`.

| provider | loopback TCP −P1 (p50) | loopback TCP −P10 (p50) | loopback UDP 10G-obj (p50) | WAN ↓ (p50) | WAN ↑ (p50) | WAN server (RTT probe) |
|---|---:|---:|---:|---:|---:|---|
| novita | 145.8 Gbit/s | 135.9 Gbit/s | 9,999 Mbit/s | 4,063 Mbit/s | 4,308 Mbit/s | InterServer Dallas `dfw.speedtest.is.cc:5205` (3 ms) |
| blaxel | 86.4 Gbit/s | 107.4 Gbit/s | 9,999 Mbit/s | 1,095 Mbit/s | 1,295 Mbit/s | NOCIX Kansas City `speedtest.nocix.net:5201` (41 ms) |
| e2b | 66.5 Gbit/s | 52.4 Gbit/s | 9,999 Mbit/s | 3,058 Mbit/s | 2,925 Mbit/s | NOCIX Kansas City `speedtest.nocix.net:5202` (6 ms) |
| daytona-vm | 66.2 Gbit/s | 79.7 Gbit/s | 9,999 Mbit/s | 3,066 Mbit/s | 4,718 Mbit/s | InterServer Dallas `dfw.speedtest.is.cc:5203` (46 ms) |
| modal-vm | 14.2 Gbit/s | 16.0 Gbit/s | 10,000 Mbit/s | 1,426 Mbit/s | 5,035 Mbit/s | NOCIX Kansas City `speedtest.nocix.net:5201` (29 ms) |
| modal-gvisor | 12.6 Gbit/s | 11.8 Gbit/s | **149.5 Mbit/s** | 6,896 Mbit/s | 1,448 Mbit/s | InterServer Dallas `dfw.speedtest.is.cc:5203` (45 ms) |

Why this reads as *accurate*, not merely green:

- Each metric record carries the **iperf3 arguments PTS actually ran** — `-c localhost -p 5201 -t 10 -P 1`, `-P 10`, and `-u -b 10000m -P 1` — so the preset pins (including the numeric-menu index trap and the name-pinned `UDP - 10000Mbit Objective` entry) provably reached the client.
- The new UDP 10G-objective metric does exactly what it was added for: **every KVM stack saturates the objective (9999–10000) while gVisor's netstack delivers ~150 Mbit/s of datagram throughput** — an isolation-technology discriminator TCP bulk transfer alone can't expose. (This is also why the 100M/1000M objectives and plain UDP, a 1 Mbit/s default, are deliberately not pinned: constants on every provider.)
- TCP numbers split isolation tech as before (KVM 52–146 Gbit/s vs gVisor ~12 Gbit/s); modal-gvisor's WAN upload trial pair (155/2741 Mbit/s) shows its known egress trait in the raw samples.
- Per-provider InterServer ports differ (`5203/5205`) — the busy-collision retry across the server's port range working live; per-trial raw values ride in `samples` and the composite XMLs (artifacts `bench-network-<provider>-29967667026`).

Audit trail: run [29964371658](https://github.com/starslingdev/hpc-sandbox-benchmarks/actions/runs/29964371658) (all cells failed at the in-sandbox clone — branch restacked while the dispatch sat queued, orphaning its SHA; procedural), run [29964910698](https://github.com/starslingdev/hpc-sandbox-benchmarks/actions/runs/29964910698) (4/6 cells lost to PTS's single-shot `downloads.es.net` fetch → motivated `seed_pts_download_cache` in #254), run [29965515835](https://github.com/starslingdev/hpc-sandbox-benchmarks/actions/runs/29965515835) (6/6 green on the earlier 4-metric composition). This run validates the final 5-metric composition including the review-driven runner changes (server reaped via traps, `jq`-built NDJSON provenance).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switch the network suite to `iperf3` for localhost and WAN, replacing `fast-cli` and `dd|nc`. Adds five metrics, makes localhost TCP 1‑stream the headline, tightens timeouts, and updates tests and the leaderboard.

- **New Features**
  - Five `iperf3` metrics: localhost TCP (P1 headline, P10), localhost UDP 10G, WAN download/upload to the closest curated server (RTT‑probed, recorded).
  - `suites.ts`: use `benchmark:network:suite`; remove `setupNode`; timeouts 30/40; metrics pinned to `iperf_*` IDs.
  - `pts-overrides.ts`: headline on localhost TCP P1; labels for TCP P10, UDP 10G, WAN; keep `fast-cli`/`network_loopback_seconds` labels (not headline) for manual runs.
  - Tests/Docs: gate network by PINNED‑subset (`iperf_*`); assert new headline and WAN join keys; regenerate `LEADERBOARD.md` to drop the old headline and reorder.

- **Migration**
  - Run the suite: `mise run benchmark:network:suite`.
  - Old `fast-cli` and loopback leaves: `mise run benchmark:network:all`.

<sup>Written for commit b3d59fb52b5bad1b1e651be5b8a9dee5d029fc4b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/starslingdev/hpc-sandbox-benchmarks/pull/255?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

