### PR TITLE
feat(bench): configurable replicate fan-out + PTS convergence inputs

### DIFF
--- a/.github/workflows/bench-matrix.yml
+++ b/.github/workflows/bench-matrix.yml
@@ -1,13 +1,23 @@
 name: Bench matrix
 
-# Fan the live benchmark out across the provider × suite matrix using GitHub's native reusable-workflow
-# nesting. `plan` emits both axes; a single suite-matrix job calls the reusable bench-suite.yml once per
-# suite (`name: ${{ matrix.suite }}`), and that reusable fans out providers (`name: ${{ matrix.provider
-# }}`) — so each cell displays as "<suite> / <provider>" (e.g. "system / e2b") and provider cells nest
-# under their suite in the Actions UI. Adding a suite is a schema change only: the suite axis is
-# `fromJSON(needs.plan.outputs.suites)`, kept in lockstep by the workflow-registry-sync gate. The
-# `suites` dispatch input narrows that axis to a subset (blank = every registered suite) — the
-# targeted/pre-merge knob, so a validation dispatch can run just one suite instead of the whole matrix.
+# Fan the live benchmark out across the provider × suite × replicate matrix using GitHub's native
+# reusable-workflow nesting. `plan` emits all three axes; a single suite-matrix job calls the reusable
+# bench-suite.yml once per suite (`name: ${{ matrix.suite }}`), and that reusable fans out
+# provider × replicate — so each cell displays as "<suite> / <provider> (replicate N)" (e.g.
+# "system / e2b (replicate 0)") and cells nest under their suite in the Actions UI. Adding a suite is a
+# schema change only: the suite axis is `fromJSON(needs.plan.outputs.suites)`, kept in lockstep by the
+# workflow-registry-sync gate.
+#
+# Three configurable inputs tune the statistics, all defaulting to the schema/per-suite config so a bare
+# dispatch reproduces the configured run:
+#   * `suites`   — narrow the suite axis to a subset (blank = every registered suite): the targeted/
+#     pre-merge knob, so a validation dispatch can run just one suite instead of the whole matrix.
+#   * `replicas` — replicate sandboxes per (provider, suite) cell, the BETWEEN-machine axis (blank = each
+#     suite's Suite.defaultReplicas; a number scales every suite). More replicates → tighter intervals on
+#     a provider's fleet variation, at proportional runner cost.
+#   * `pts_passes` — timed PTS passes per case INSIDE a sandbox, the WITHIN-machine axis (blank = each
+#     suite's fixed count; a number, or `converge` to let PTS's own statistical convergence decide).
+#
 # Off the PR path (real sandbox time + provider credentials); main is the default, while an explicit
 # allow_branch dispatch supports pre-merge validation. Every benchmark cell remains gated by Environment
 # `privileged` (required reviewers + environment secrets — see docs/ci-secrets.md, declared inside
@@ -35,6 +45,22 @@ on:
         # axis to just those suites — the pre-merge/targeted knob so a validation dispatch needn't spend
         # the whole matrix. `plan-suites` rejects any name that is not in the registry, so a typo fails
         # the plan.
+        default: ''
+      replicas:
+        description: 'Replicate sandboxes per provider × suite cell — the between-machine axis (captures a provider fleet''s variation). Blank = each suite''s configured default (Suite.defaultReplicas); a whole number overrides every suite. Higher = tighter intervals at proportional runner cost; 1 = a quick single-sandbox pass.'
+        required: false
+        type: string
+        # Blank keeps each suite's schema default (long-synthetic suites R=3, realworld R=5). A number
+        # scales ALL suites at once — this is the global override; per-category defaults live in the
+        # schema. plan-replicates rejects a non-positive/non-integer value, so a typo fails the plan.
+        default: ''
+      pts_passes:
+        description: 'Timed PTS passes per test INSIDE each sandbox — the within-machine axis. Blank = each suite''s configured fixed count; a whole number forces that many on every suite; "converge" lets PTS''s own statistical convergence decide (tighter within-machine intervals, variable/longer runtime).'
+        required: false
+        type: string
+        # Blank keeps each suite's fixed count (Suite.ptsTimesToRun: realworld k=1, long-synthetic k=2).
+        # "converge" removes the manual FORCE_TIMES_TO_RUN pin and hands the pass count to PTS's
+        # DynamicRunCount. The harness (resolvePtsPassPolicy) rejects any other non-numeric value.
         default: ''
       allow_branch:
         description: 'Allow benchmark cells on a non-main ref (publish remains main-only).'
@@ -66,6 +92,10 @@ jobs:
     outputs:
       providers: ${{ steps.plan.outputs.providers }}
       suites: ${{ steps.plan.outputs.suites }}
+      # A JSON object mapping each selected suite to its replicate index array (e.g.
+      # {"cpu-node":[0,1,2],...}). The suite-matrix job indexes it by matrix.suite to get that suite's
+      # own replicate axis, so per-category replicate counts stay registry-driven like the suite axis.
+      replicates: ${{ steps.plan.outputs.replicates }}
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -85,13 +115,17 @@ jobs:
       - name: Plan
         id: plan
         # The dispatch inputs reach the planners through the environment, never interpolated into the
-        # shell, so a crafted input can't inject into the runner command.
+        # shell, so a crafted input can't inject into the runner command. plan-replicates reads the SAME
+        # BENCH_SUITES selection as plan-suites, so its map is keyed by exactly the emitted suite axis;
+        # BENCH_REPLICAS scales the per-suite counts (blank = each suite's Suite.defaultReplicas).
         env:
           BENCH_PROVIDERS: ${{ inputs.providers }}
           BENCH_SUITES: ${{ inputs.suites }}
+          BENCH_REPLICAS: ${{ inputs.replicas }}
         run: |
           bun apps/cli/src/bin/plan-providers.ts
           bun apps/cli/src/bin/plan-suites.ts
+          bun apps/cli/src/bin/plan-replicates.ts
 
   # One matrix cell per selected suite → reusable workflow call. GitHub nests the reusable's provider
   # matrix under each suite name, so the Actions UI shows expandable "<suite>" groups with "<provider>"
@@ -115,6 +149,11 @@ jobs:
     with:
       providers: ${{ needs.plan.outputs.providers }}
       suite: ${{ matrix.suite }}
+      # Hand this suite its own replicate slice out of the plan's per-suite map (keyed by matrix.suite),
+      # re-serialized to the JSON string the reusable workflow's `replicate` axis parses with fromJSON.
+      replicates: ${{ toJSON(fromJSON(needs.plan.outputs.replicates)[matrix.suite]) }}
+      # Forward the PTS passes-per-case override unchanged (blank = suite default, a number, or converge).
+      pts_passes: ${{ inputs.pts_passes }}
     secrets: inherit
 
   # Collect every shard Run, aggregate into one candidate, gate it (promote), and commit the machine-

--- a/.github/workflows/bench-smoke.yml
+++ b/.github/workflows/bench-smoke.yml
@@ -35,6 +35,15 @@ on:
             realworld-better-auth,
             realworld-openclaw,
           ]
+      pts_passes:
+        # The within-machine axis, matched to bench-matrix.yml so convergence can be smoke-tested on one
+        # cell before spending the whole matrix. Blank keeps the suite's fixed count (Suite.ptsTimesToRun);
+        # a whole number forces that many timed passes; "converge" hands the count to PTS's own statistical
+        # convergence. Passed through the environment below (BENCH_PTS_PASSES); the harness validates it.
+        description: 'PTS passes per case: blank = suite default, a number, or "converge".'
+        required: false
+        type: string
+        default: ''
 
 # Least privilege: the job only reads the checked-out code and uploads an artifact.
 permissions:
@@ -89,6 +98,9 @@ jobs:
           # shell. `$GITHUB_RUN_ID` is built-in.
           BENCH_PROVIDER: ${{ inputs.provider }}
           BENCH_SUITE: ${{ inputs.suite }}
+          # PTS passes-per-case policy (blank = suite default, a number, or "converge"); read by the
+          # harness preamble. A smoke run is single-sandbox, so there is no replicate axis here.
+          BENCH_PTS_PASSES: ${{ inputs.pts_passes }}
           # The point of a smoke run is to prove the lane end to end. Without this, a missing or
           # misnamed provider secret is recorded as a skip and the job still exits 0 having
           # benchmarked nothing — assert the dispatched provider actually reached "validated".

--- a/.github/workflows/bench-suite.yml
+++ b/.github/workflows/bench-suite.yml
@@ -1,14 +1,19 @@
 name: Benchmark suite (reusable)
 
-# One suite, fanned out across a provider matrix. bench-matrix.yml calls this once per suite via its
-# suite-matrix job (`name: ${{ matrix.suite }}`), passing the plan's selected provider list — so N
-# providers nest under one suite label in the Actions UI and cells display as "<suite> / <provider>".
+# One suite, fanned out across a provider × replicate matrix. bench-matrix.yml calls this once per suite
+# via its suite-matrix job (`name: ${{ matrix.suite }}`), passing the plan's selected provider list AND
+# that suite's replicate index array — so cells display as "<suite> / <provider> (replicate N)" and every
+# provider's replicate sandboxes nest under one suite label in the Actions UI. The replicate axis is the
+# BETWEEN-MACHINE knob: R sandboxes of one (provider, suite) capture a provider's fleet variation (two can
+# land on different host hardware), which the aggregate folds into per-metric replicate breakdowns.
 # Factoring the shared cell here (checkout → run → upload, plus the per-provider credential wiring)
 # keeps that block in ONE place instead of copy-pasted into every suite job, mirroring
 # runner-benchmarking's reusable bench-suite.yml.
 #
-# The artifact name (bench-<suite>-<provider>-<run_id>) is load-bearing: commit-dataset.yml downloads
-# the shards by the `bench-*-<run_id>` pattern and aggregates them — keep the two in lockstep.
+# The artifact name (bench-<suite>-<provider>-r<replicate>-<run_id>) is load-bearing: commit-dataset.yml
+# downloads the shards by the `bench-*-<run_id>` pattern and aggregates them — keep the two in lockstep.
+# The `-r<replicate>` segment keeps each replicate's shard a distinct artifact even though every shard of
+# one run shares the same runId file (data/runs/<run_id>.json); the aggregate keys them by --replicate.
 #
 # Environment `privileged` (required reviewers + environment secrets — see docs/ci-secrets.md) lives on
 # the fan-out job here: a `uses:` caller can't declare `environment:`, so the approval gate and the
@@ -26,6 +31,22 @@ on:
         description: 'Suite to run — the bench-suite.ts arg and the artifact-name key. A registered SUITE_NAMES value.'
         required: true
         type: string
+      replicates:
+        description: >-
+          JSON array of replicate sandbox indices for THIS suite, e.g. "[0,1,2]" — the between-machine
+          fan-out axis. plan-replicates emits it per suite (Suite.defaultReplicas, or the BENCH_REPLICAS
+          override); the caller passes each suite its own slice. One matrix cell runs per (provider,
+          replicate), each tagged with `--replicate <idx>` so the aggregate folds them by index.
+        required: true
+        type: string
+      pts_passes:
+        description: >-
+          PTS passes-per-case override for the harness (BENCH_PTS_PASSES) — the within-machine axis.
+          Blank = each suite's configured fixed count; a positive integer forces that many timed passes
+          on every suite; "converge" lets PTS's own statistical convergence (DynamicRunCount) decide.
+        required: false
+        type: string
+        default: ''
 
 # Least privilege: the fan-out only reads the checked-out code and uploads artifacts.
 permissions:
@@ -33,9 +54,11 @@ permissions:
 
 jobs:
   bench:
-    # Display as "<caller suite job> / <provider>", e.g. "system / e2b" — the provider cells nest
-    # under their suite's job name in the Actions UI (GitHub-native reusable-workflow nesting).
-    name: ${{ matrix.provider }}
+    # Display as "<caller suite job> / <provider> (replicate N)", e.g. "system / e2b (replicate 0)" —
+    # the replicate cells nest under their suite's job name in the Actions UI (GitHub-native
+    # reusable-workflow nesting). The replicate suffix keeps each of a provider's R sandboxes a
+    # distinct, legible cell (a bare `${{ matrix.provider }}` would render them all identically).
+    name: ${{ matrix.provider }} (replicate ${{ matrix.replicate }})
     environment: privileged
     # The ephemeral self-hosted label is reaped after 70 minutes even while a step is healthy. The
     # full CPU-generic and real-world matrices legitimately exceed that on slower providers, leaving
@@ -45,10 +68,14 @@ jobs:
     runs-on: ubuntu-24.04
     timeout-minutes: 180
     strategy:
-      # One cell's failure (a flaky provider) must not cancel the rest of the matrix.
+      # One cell's failure (a flaky provider, or one bad replicate) must not cancel the rest of the matrix.
       fail-fast: false
       matrix:
         provider: ${{ fromJSON(inputs.providers) }}
+        # The between-machine axis: R replicate sandboxes per provider, expanded into provider × replicate
+        # cells. The array is this suite's slice of plan-replicates' map (Suite.defaultReplicas / the
+        # BENCH_REPLICAS override), so a suite runs exactly the replicate count its category configures.
+        replicate: ${{ fromJSON(inputs.replicates) }}
     steps:
       # Third-party actions are pinned to a commit SHA (the tag comment is for humans) so a
       # moved/compromised tag can't silently change what runs.
@@ -69,8 +96,8 @@ jobs:
         run: bun install --frozen-lockfile --ignore-scripts
 
       # Drive the provider SDK to create a sandbox, run the suite, collect results, and normalize. The
-      # cell's provider is a matrix value and its suite the reusable input, both passed through the
-      # environment (never interpolated into the shell) so neither can inject into the runner command.
+      # cell's provider + replicate are matrix values and its suite the reusable input, all passed through
+      # the environment (never interpolated into the shell) so none can inject into the runner command.
       # On success/failure the bin also writes a compact job summary + run annotation (clean Results).
       - name: Run suite and normalize
         env:
@@ -80,6 +107,12 @@ jobs:
           BENCH_REPO_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           BENCH_PROVIDER: ${{ matrix.provider }}
           BENCH_SUITE: ${{ inputs.suite }}
+          # The replicate index this shard represents — stamped onto its Run so the aggregate folds the R
+          # sandboxes of one (provider, suite) into per-metric replicate breakdowns rather than colliding.
+          BENCH_REPLICATE: ${{ matrix.replicate }}
+          # PTS passes-per-case policy: blank = the suite's fixed count, a number overrides it, or
+          # "converge" hands the count to PTS's convergence. Read by the harness preamble.
+          BENCH_PTS_PASSES: ${{ inputs.pts_passes }}
           # Scope every provider credential to the cell that actually uses it: a cell receives ONLY
           # the secret(s) for its own `matrix.provider`, so a compromised adapter or suite can't read
           # another provider's credential out of the environment. A non-matching provider evaluates to
@@ -99,14 +132,16 @@ jobs:
           BL_API_KEY: ${{ matrix.provider == 'blaxel' && secrets.BL_API_KEY || '' }}
           BL_WORKSPACE: ${{ matrix.provider == 'blaxel' && secrets.BL_WORKSPACE || '' }}
           NOVITA_API_KEY: ${{ matrix.provider == 'novita' && secrets.NOVITA_API_KEY || '' }}
-        run: bun apps/cli/src/bin/bench-suite.ts "$BENCH_PROVIDER" "$BENCH_SUITE" "$GITHUB_RUN_ID"
+        run: bun apps/cli/src/bin/bench-suite.ts "$BENCH_PROVIDER" "$BENCH_SUITE" "$GITHUB_RUN_ID" --replicate "$BENCH_REPLICATE"
 
       - name: Upload Run + raw results
         if: always()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          # Per-cell artifact name so every (provider, suite) shard uploads independently.
-          name: bench-${{ inputs.suite }}-${{ matrix.provider }}-${{ github.run_id }}
+          # Per-cell artifact name so every (provider, suite, replicate) shard uploads independently — the
+          # `-r<replicate>` segment is what keeps R replicates of one cell from colliding on one name (they
+          # all write the same data/runs/<run_id>.json). commit-dataset.yml matches these by `bench-*-<run_id>`.
+          name: bench-${{ inputs.suite }}-${{ matrix.provider }}-r${{ matrix.replicate }}-${{ github.run_id }}
           path: data/
           # A successful run always writes data/runs/<id>.json (even an all-skipped Run), so an empty
           # data/ means the job is genuinely broken — fail the upload rather than bury a warning.

--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -11,6 +11,7 @@
     "plan-matrix": "./src/bin/plan-matrix.ts",
     "plan-providers": "./src/bin/plan-providers.ts",
     "plan-suites": "./src/bin/plan-suites.ts",
+    "plan-replicates": "./src/bin/plan-replicates.ts",
     "build-template": "./src/bin/build-template.ts",
     "normalize": "./src/bin/normalize.ts",
     "aggregate": "./src/bin/aggregate.ts",

--- a/apps/cli/src/bin/plan-replicates.ts
+++ b/apps/cli/src/bin/plan-replicates.ts
@@ -1,0 +1,99 @@
+#!/usr/bin/env bun
+// `plan-replicates` — emit the per-suite replicate index arrays as a SINGLE LINE of compact JSON object,
+// e.g. `{"cpu-node":[0,1,2],"realworld-mastra":[0,1,2,3,4]}`. This is a $GITHUB_OUTPUT contract the Bench
+// matrix reads: the suite-matrix job passes each suite its own slice as the reusable bench-suite.yml's
+// `replicate` axis (`fromJSON(needs.plan.outputs.replicates)[matrix.suite]`), so N replicate sandboxes
+// fan out per (provider, suite) cell — the BETWEEN-MACHINE axis that captures a provider's fleet
+// variation (two sandboxes can land on different host hardware).
+//
+// The count per suite is its schema-declared Suite.defaultReplicas, overridable for the whole run by the
+// BENCH_REPLICAS dispatch input (blank = each suite's default; a number scales every suite). The suite
+// KEYS match plan-suites' selection exactly (both parse BENCH_SUITES via selectSuites), so the map covers
+// precisely the suites the suite axis emits and never desynchronizes from it.
+//
+// In Actions ($GITHUB_OUTPUT set) the bin writes `replicates=` via emitStepOutputs and logs through
+// @actions/core — no bash capture that could splice diagnostics into the outputs file. Mirrors
+// plan-providers / plan-suites; the replicate map is an object (not a string[]) so it emits directly
+// rather than through the shared string-axis runner in plan-axis.ts.
+import * as core from "@actions/core";
+import { fail, inActions, logInfo, withGroup } from "../lib/actions-log.ts";
+import { handleDiscovery } from "../lib/discovery.ts";
+import { emitStepOutputs } from "../lib/gha-output.ts";
+import { planReplicateMap } from "../lib/matrix.ts";
+
+/** The per-suite replicate-index map for `suitesRaw` × `replicasRaw` as one line of compact JSON. Takes
+ *  the raw strings rather than reading `process.env` itself, so it stays pure — the bin owns the env read,
+ *  and a test can't be perturbed by an ambient value. */
+export function planReplicatesJson(suitesRaw?: string, replicasRaw?: string): string {
+	return JSON.stringify(planReplicateMap(suitesRaw, replicasRaw));
+}
+
+/** Agent-facing usage; the bare invocation stays the $GITHUB_OUTPUT replicates contract. */
+export const HELP = `plan-replicates — emit the per-suite replicate index arrays as one line of compact JSON object.
+
+usage: plan-replicates [--help] [--list-providers] [--list-suites] [--json]
+
+  (no args)          Print {"cpu-node":[0,1,2], …} on a single line (local), or write replicates= to
+                     $GITHUB_OUTPUT when set (the Bench matrix plan step). Each suite maps to [0..R-1].
+  --list-providers   List the registered providers each replicate cell runs on.
+  --list-suites      List the registered suites and their dimensions/metrics.
+  --json             Emit --list-* output as JSON instead of human-readable lines.
+  --help, -h         Show this help.
+
+environment:
+  BENCH_SUITES       Comma-separated suites to plan replicates for (same selection as plan-suites). Unset
+                     or blank selects every registered suite. An unregistered name is an error.
+  BENCH_REPLICAS     Replicate sandboxes per (provider, suite) cell. Unset or blank keeps each suite's
+                     schema default (Suite.defaultReplicas); a positive integer overrides every suite —
+                     higher for tighter between-machine intervals, 1 for a quick single-sandbox pass. A
+                     non-positive or non-integer value is an error, never a silently empty fan-out.
+  GITHUB_OUTPUT      When set (Actions), write replicates= step output instead of printing on stdout.
+
+examples:
+  plan-replicates                              # local: each suite at its schema default replicate count
+  BENCH_REPLICAS=5 plan-replicates             # every suite fanned out to 5 replicate sandboxes
+  BENCH_SUITES=network BENCH_REPLICAS=1 plan-replicates   # a single network sandbox (a quick pass)
+
+Next: run one replicate with  bench-suite <provider> <suite> <runId> --replicate <idx>`;
+
+if (import.meta.main) {
+	const argv = process.argv.slice(2);
+	const discovery = handleDiscovery(argv, HELP);
+	if (discovery !== null) {
+		if (discovery.ok) {
+			process.stdout.write(`${discovery.text}\n`);
+			process.exit(0);
+		}
+		fail(discovery.text, { properties: { title: "plan-replicates discovery" }, exitCode: 2 });
+	}
+
+	// A bad selection/override must fail the step, not print a diagnostic onto stdout: stdout here IS the
+	// replicates value local callers capture, so an error message there would be parsed as the map.
+	try {
+		const json = planReplicatesJson(process.env.BENCH_SUITES, process.env.BENCH_REPLICAS);
+		const map = JSON.parse(json) as Record<string, number[]>;
+
+		if (process.env.GITHUB_OUTPUT) {
+			await withGroup("Plan replicate axis", async () => {
+				for (const [suite, indices] of Object.entries(map)) {
+					logInfo(`suite ${suite}: ${indices.length} replicate(s)`);
+				}
+				if (inActions()) core.debug(`replicates=${json}`);
+			});
+			emitStepOutputs(`replicates=${json}`);
+			if (inActions()) {
+				core.notice(`Planned replicates for ${Object.keys(map).length} suite(s)`, {
+					title: "Plan replicates",
+				});
+			}
+		} else {
+			// Local / test capture: keep the single-line replicates stdout contract pristine.
+			process.stdout.write(`${json}\n`);
+		}
+	} catch (err) {
+		fail(`plan-replicates: ${err instanceof Error ? err.message : String(err)}`, {
+			properties: { title: "plan-replicates" },
+			exitCode: 2,
+		});
+	}
+}

--- a/apps/cli/src/lib/matrix.ts
+++ b/apps/cli/src/lib/matrix.ts
@@ -3,7 +3,7 @@
 // SUITES) are the single source of truth — the matrix can never name a provider or suite that isn't
 // registered.
 import type { ProviderId, SuiteName } from "@sandbox-benchmarks/schema";
-import { PROVIDERS, SUITE_NAMES } from "@sandbox-benchmarks/schema";
+import { PROVIDERS, SUITE_NAMES, SUITES } from "@sandbox-benchmarks/schema";
 
 /** One CI cell: a single (provider, suite) benchmark run. */
 export interface MatrixEntry {
@@ -66,6 +66,59 @@ export function selectProviders(raw: string | undefined): ProviderId[] {
  */
 export function selectSuites(raw: string | undefined): SuiteName[] {
 	return selectRegistryIds(raw, SUITE_NAMES, "suite");
+}
+
+/**
+ * The replicate count a suite runs when a dispatch gives no override: its schema-declared
+ * {@link Suite.defaultReplicas} (the between-machine axis, configurable per test category), or a single
+ * sandbox when the suite declares none. Replicates capture a provider's fleet variation — two sandboxes
+ * of one (provider, suite) can land on different host hardware — which the in-sandbox PTS passes can't see.
+ */
+export const SINGLE_REPLICATE = 1;
+
+/** The replicate count for one suite: the `BENCH_REPLICAS` override when set, else the suite's default. */
+export function replicaCountForSuite(suite: SuiteName, override?: number): number {
+	if (override !== undefined) return override;
+	return SUITES[suite].defaultReplicas ?? SINGLE_REPLICATE;
+}
+
+/**
+ * Parse the `BENCH_REPLICAS` dispatch override into a positive integer, or `undefined` when blank/unset
+ * (each suite then keeps its own {@link Suite.defaultReplicas}). A non-positive or non-integer value
+ * THROWS — a typo'd `--replicas 0` would otherwise fan out zero sandboxes (a silently empty run), and a
+ * fractional one is meaningless — so the plan fails loudly instead of guessing. This is the single global
+ * knob that scales EVERY suite's replicate count up (tighter between-machine intervals) or down (a quick
+ * pass) without editing each suite's schema default.
+ */
+export function parseReplicasOverride(raw: string | undefined): number | undefined {
+	const trimmed = (raw ?? "").trim();
+	if (trimmed === "") return undefined;
+	const count = Number(trimmed);
+	if (!Number.isInteger(count) || count < 1) {
+		throw new Error(`replicas override must be a positive integer; got "${raw}"`);
+	}
+	return count;
+}
+
+/**
+ * The per-suite replicate index arrays the CI matrix fans out over, keyed by suite name — e.g.
+ * `{ "cpu-node": [0, 1, 2], "realworld-mastra": [0, 1, 2, 3, 4] }`. Each suite maps to `[0..R-1]`, where
+ * R is the `BENCH_REPLICAS` override (`replicasRaw`) when set, else that suite's schema default. The
+ * suite set matches {@link selectSuites} exactly (same `BENCH_SUITES` parsing), so the map is keyed by
+ * precisely the suites the plan's suite axis emits — the reusable bench-suite.yml indexes it by
+ * `matrix.suite` to get its own replicate axis. `suitesRaw`/`replicasRaw` are the raw dispatch strings.
+ */
+export function planReplicateMap(
+	suitesRaw: string | undefined,
+	replicasRaw: string | undefined,
+): Record<string, number[]> {
+	const override = parseReplicasOverride(replicasRaw);
+	const map: Record<string, number[]> = {};
+	for (const suite of selectSuites(suitesRaw)) {
+		const count = replicaCountForSuite(suite, override);
+		map[suite] = Array.from({ length: count }, (_, index) => index);
+	}
+	return map;
 }
 
 /**

--- a/apps/cli/src/plan-replicates.test.ts
+++ b/apps/cli/src/plan-replicates.test.ts
@@ -1,0 +1,96 @@
+import { describe, expect, it } from "bun:test";
+import { PROVIDERS, SUITE_NAMES, SUITES } from "@sandbox-benchmarks/schema";
+import { HELP, planReplicatesJson } from "./bin/plan-replicates.ts";
+import { handleDiscovery } from "./lib/discovery.ts";
+import {
+	parseReplicasOverride,
+	planReplicateMap,
+	replicaCountForSuite,
+	SINGLE_REPLICATE,
+} from "./lib/matrix.ts";
+
+describe("plan-replicates", () => {
+	it("emits a single line of compact JSON object (the $GITHUB_OUTPUT contract)", () => {
+		const out = planReplicatesJson();
+		expect(out).not.toContain("\n");
+		expect(out).not.toMatch(/\n\s+/);
+		const map = JSON.parse(out) as Record<string, number[]>;
+		// Keyed by every registered suite, each at its schema-declared replicate count as [0..R-1].
+		expect(Object.keys(map)).toEqual([...SUITE_NAMES]);
+		for (const name of SUITE_NAMES) {
+			const count = SUITES[name].defaultReplicas ?? SINGLE_REPLICATE;
+			expect(map[name]).toEqual(Array.from({ length: count }, (_, i) => i));
+		}
+	});
+
+	it("narrows to the suites a dispatch names, still one line of JSON", () => {
+		const out = planReplicatesJson("network");
+		expect(out).not.toContain("\n");
+		expect(JSON.parse(out)).toEqual({ network: [0, 1, 2] });
+	});
+
+	it("scales every suite by the BENCH_REPLICAS override", () => {
+		const map = JSON.parse(planReplicatesJson(undefined, "5")) as Record<string, number[]>;
+		for (const name of SUITE_NAMES) {
+			expect(map[name]).toEqual([0, 1, 2, 3, 4]);
+		}
+	});
+
+	it("throws on an unregistered suite rather than silently running nothing", () => {
+		expect(() => planReplicatesJson("network,netwrk")).toThrow(/unknown suite\(s\): netwrk/);
+	});
+
+	it("throws on a non-positive replicas override rather than fanning out zero sandboxes", () => {
+		expect(() => planReplicatesJson(undefined, "0")).toThrow(/positive integer/);
+	});
+
+	it("exposes agent-friendly discovery: --help and --list-* listings the bin wires", () => {
+		expect(handleDiscovery(["--help"], HELP)).toEqual({ text: HELP, ok: true });
+		expect(HELP).toContain("plan-replicates");
+		expect(HELP).toContain("examples:");
+		const listed = handleDiscovery(["--list-providers"], HELP)?.text ?? "";
+		for (const meta of PROVIDERS) expect(listed).toContain(meta.id);
+		expect(handleDiscovery([], HELP)).toBeNull();
+	});
+});
+
+describe("parseReplicasOverride", () => {
+	it("returns undefined for a blank/unset override (each suite keeps its schema default)", () => {
+		expect(parseReplicasOverride(undefined)).toBeUndefined();
+		expect(parseReplicasOverride("")).toBeUndefined();
+		expect(parseReplicasOverride("  ")).toBeUndefined();
+	});
+
+	it("parses a positive integer override", () => {
+		expect(parseReplicasOverride("1")).toBe(1);
+		expect(parseReplicasOverride(" 8 ")).toBe(8);
+	});
+
+	it("throws on a non-positive or non-integer override", () => {
+		expect(() => parseReplicasOverride("0")).toThrow(/positive integer/);
+		expect(() => parseReplicasOverride("-2")).toThrow(/positive integer/);
+		expect(() => parseReplicasOverride("2.5")).toThrow(/positive integer/);
+		expect(() => parseReplicasOverride("lots")).toThrow(/positive integer/);
+	});
+});
+
+describe("replicaCountForSuite", () => {
+	it("uses the suite's schema default when no override is given", () => {
+		expect(replicaCountForSuite("realworld-mastra")).toBe(5);
+		expect(replicaCountForSuite("cpu-node")).toBe(3);
+	});
+
+	it("the override wins over every suite's default", () => {
+		expect(replicaCountForSuite("realworld-mastra", 2)).toBe(2);
+		expect(replicaCountForSuite("cpu-node", 10)).toBe(10);
+	});
+});
+
+describe("planReplicateMap", () => {
+	it("keys exactly the selected suites (matching the suite axis), each as [0..R-1]", () => {
+		expect(planReplicateMap("cpu-node,network", undefined)).toEqual({
+			"cpu-node": [0, 1, 2],
+			network: [0, 1, 2],
+		});
+	});
+});

--- a/docs/methodology.md
+++ b/docs/methodology.md
@@ -91,17 +91,24 @@ without being Daytona-specific.
 
 ## The dataset pipeline
 
-1. **Run** — `bench-suite <provider> <suite>` boots a sandbox, runs the suite's mise tasks, pulls the
-   raw tree (`data/raw/<runId>/<provider>/<suite>/`), and normalizes it into a Run document.
-2. **Matrix** — the `bench-matrix` workflow plans both axes, then one suite-matrix job calls the
-   reusable `bench-suite` workflow per suite (GitHub-native nesting: `<suite> / <provider>`), fanning
-   out over the providers `plan-providers` selects; every (provider, suite) cell uploads its shard Run
-   as an artifact.
+1. **Run** — `bench-suite <provider> <suite> <runId> --replicate <idx>` boots a sandbox, runs the
+   suite's mise tasks, pulls the raw tree (`data/raw/<runId>/<provider>/<suite>/`), and normalizes it
+   into a Run document stamped with its replicate index.
+2. **Matrix** — the `bench-matrix` workflow plans three axes (`plan-providers` / `plan-suites` /
+   `plan-replicates`), then one suite-matrix job calls the reusable `bench-suite` workflow per suite
+   (GitHub-native nesting: `<suite> / <provider> (replicate N)`), fanning out over the selected
+   providers × that suite's replicate sandboxes; every `(provider, suite, replicate)` cell uploads its
+   shard Run as an artifact. Two axes are the statistical knobs — **replicates** (R sandboxes per cell,
+   the between-machine axis: `replicas` blank = each suite's `Suite.defaultReplicas`, or a number to
+   override every suite) and **PTS passes** (the within-machine axis: `pts_passes` blank = each suite's
+   fixed count, a number, or `converge` to let PTS's own statistical convergence decide). Both default
+   to the per-suite schema config, so a bare dispatch reproduces the configured run.
 3. **Aggregate → promote → commit** — the `commit-dataset` workflow (the matrix's `publish` job calls
-   it) collects every shard, `aggregate`s them into one candidate Run (measured metrics unioned,
-   economics re-derived from the merged set), then `promote`s it (gate: ≥1 validated provider) into the
-   committed dataset at `data/dataset/` with a newest-first index, and opens a PR to land it on `main`.
-   This step commits only the machine-readable dataset — it never touches `LEADERBOARD.md`.
+   it) collects every shard, `aggregate`s them into one candidate Run (measured metrics unioned, the ≥2
+   replicate sandboxes of one `(provider, suite)` folded into per-metric replicate breakdowns, economics
+   re-derived from the merged set), then `promote`s it (gate: ≥1 validated provider) into the committed
+   dataset at `data/dataset/` with a newest-first index, and opens a PR to land it on `main`. This step
+   commits only the machine-readable dataset — it never touches `LEADERBOARD.md`.
 4. **Leaderboard** — the `update-leaderboard` workflow renders a chosen committed Run into a ranked
    Markdown table per dimension (`leaderboard`) and opens a PR to update `LEADERBOARD.md`. It is a
    deliberate, maintainer-dispatched step (default: the newest committed run), so the dataset can grow a

--- a/lib/bench.sh
+++ b/lib/bench.sh
@@ -283,12 +283,18 @@ _configure_pts_batch() {
 	# name would let a failed later leaf collect an earlier leaf's merged composite as its own.
 	export TEST_RESULTS_DESCRIPTION=ci
 	export TEST_RESULTS_IDENTIFIER=ci
-	# FORCE_TIMES_TO_RUN=1 pins contract-verification runs to a single pass. Published sandbox runs
-	# export PTS_RESPECT_TIMES_TO_RUN=1 plus a per-suite FORCE_TIMES_TO_RUN (k) in the harness preamble
-	# (Suite.ptsTimesToRun: realworld k=1, long synthetic k=2), while disabling PTS's adaptive
-	# variance policy (which otherwise expanded noisy fio cases to 20-40 runs and exhausted the suite).
+	# Pass-count policy, set by the harness preamble (buildPreamble → ptsTrialVars):
+	#   * Fixed count (published runs): the preamble exports PTS_RESPECT_TIMES_TO_RUN=1 plus a per-suite
+	#     FORCE_TIMES_TO_RUN (k) — a pinned pass count with PTS's adaptive variance policy disabled (it
+	#     otherwise expanded noisy fio cases to 20-40 runs and exhausted the suite). Nothing to do here.
+	#   * Convergence (BENCH_PTS_CONVERGE=1): let PTS's own DynamicRunCount decide the pass count — run a
+	#     minimum, then keep going while the standard deviation exceeds PTS's threshold. Clear any forced
+	#     count / respect flag so neither pins it, and DynamicRunCount (on by PTS default) governs.
+	#   * Neither set (contract-verification / bare host runs): force a single pass.
 	# Between-sandbox variance is captured by REPLICATE sandboxes, not by more in-sandbox passes.
-	if [ -z "${PTS_RESPECT_TIMES_TO_RUN:-}" ]; then
+	if [ -n "${BENCH_PTS_CONVERGE:-}" ]; then
+		unset FORCE_TIMES_TO_RUN PTS_RESPECT_TIMES_TO_RUN
+	elif [ -z "${PTS_RESPECT_TIMES_TO_RUN:-}" ]; then
 		export FORCE_TIMES_TO_RUN=1
 	fi
 	# batch-setup answers: SaveResults, OpenBrowser, UploadResults, PromptForTestIdentifier,

--- a/packages/harness/src/index.ts
+++ b/packages/harness/src/index.ts
@@ -7,7 +7,7 @@ import type { ProviderTransport, RawRun, ResultGap, Suite } from "@sandbox-bench
 import { HARNESS_METRIC_IDS, isPtsResultFile, SUITES } from "@sandbox-benchmarks/schema";
 import { collectResults, writeGapMarker } from "./lib/collect.ts";
 import type { SandboxHandle } from "./lib/execute.ts";
-import { MIN, StepRunner, withTimeout } from "./lib/execute.ts";
+import { MIN, resolvePtsPassPolicy, StepRunner, withTimeout } from "./lib/execute.ts";
 import { time } from "./lib/internal.ts";
 import type { LifecycleAggregate, LifecycleCompute } from "./lib/lifecycle.ts";
 import { aggregateLifecycle, measureLifecycle } from "./lib/lifecycle.ts";
@@ -372,10 +372,16 @@ export async function runSuiteOnSandbox(
 	const { suite, suiteName, providerName, resultsDir, transport } = ctx;
 	let suiteError: unknown;
 	try {
-		// Thread the suite's in-sandbox repeat count (k) into the preamble; absent → the harness default.
-		// Constructed inside the try so a bad k (buildPreamble rejects k < 1) is still torn down by the
-		// finally below; a throw before the try would leak the already-created sandbox.
-		const runner = new StepRunner(sandbox, transport, undefined, suite.ptsTimesToRun);
+		// Resolve the PTS pass policy from the suite's configured count and the BENCH_PTS_PASSES override
+		// (a fixed count, or `converge` to let PTS's own convergence decide). Constructed inside the try so
+		// a bad policy (buildPreamble rejects a fixed k < 1) is still torn down by the finally below; a
+		// throw before the try would leak the already-created sandbox.
+		const runner = new StepRunner(
+			sandbox,
+			transport,
+			undefined,
+			resolvePtsPassPolicy(suite.ptsTimesToRun),
+		);
 		runner.phase = "setup";
 		if (suite.minDiskGb) {
 			// Measure free space where the disk-heavy suites actually write, not the sandbox root. The

--- a/packages/harness/src/lib/execute.test.ts
+++ b/packages/harness/src/lib/execute.test.ts
@@ -3,8 +3,10 @@ import type { ProviderTransport } from "@sandbox-benchmarks/schema";
 import type { SandboxHandle } from "./execute.ts";
 import {
 	buildPreamble,
+	DEFAULT_PTS_TIMES_TO_RUN,
 	MIN,
 	PREAMBLE,
+	resolvePtsPassPolicy,
 	StepRunner,
 	selectTransport,
 	shellQuote,
@@ -72,18 +74,63 @@ describe("sandbox preamble", () => {
 	it.skipIf(process.env.BENCH_PASSES === "1")(
 		"pins the PTS repeat count (k) a suite requests",
 		() => {
-			expect(buildPreamble(1)).toContain("FORCE_TIMES_TO_RUN=1");
-			expect(buildPreamble(3)).toContain("FORCE_TIMES_TO_RUN=3");
+			expect(buildPreamble({ mode: "fixed", times: 1 })).toContain("FORCE_TIMES_TO_RUN=1");
+			expect(buildPreamble({ mode: "fixed", times: 3 })).toContain("FORCE_TIMES_TO_RUN=3");
 			// The variance-driven policy stays disabled at every k so a noisy provider can't stretch a suite.
-			expect(buildPreamble(3)).toContain("PTS_RESPECT_TIMES_TO_RUN=1");
+			expect(buildPreamble({ mode: "fixed", times: 3 })).toContain("PTS_RESPECT_TIMES_TO_RUN=1");
 		},
 	);
 
-	it("rejects a non-positive or fractional k (would emit an empty/bogus FORCE_TIMES_TO_RUN)", () => {
+	it.skipIf(process.env.BENCH_PASSES === "1")(
+		"hands the pass count to PTS's convergence in converge mode (no forced/respect pins)",
+		() => {
+			const preamble = buildPreamble({ mode: "converge" });
+			// The marker tells lib/bench.sh not to fall back to forcing a single pass.
+			expect(preamble).toContain("BENCH_PTS_CONVERGE=1");
+			// Neither pin is set, so PTS's DynamicRunCount governs the pass count.
+			expect(preamble).not.toContain("FORCE_TIMES_TO_RUN");
+			expect(preamble).not.toContain("PTS_RESPECT_TIMES_TO_RUN");
+		},
+	);
+
+	it("rejects a non-positive or fractional fixed k (would emit an empty/bogus FORCE_TIMES_TO_RUN)", () => {
 		// Throws before touching the env, so this holds in every mode including BENCH_PASSES=1.
-		expect(() => buildPreamble(0)).toThrow(/positive integer/);
-		expect(() => buildPreamble(-1)).toThrow(/positive integer/);
-		expect(() => buildPreamble(1.5)).toThrow(/positive integer/);
+		expect(() => buildPreamble({ mode: "fixed", times: 0 })).toThrow(/positive integer/);
+		expect(() => buildPreamble({ mode: "fixed", times: -1 })).toThrow(/positive integer/);
+		expect(() => buildPreamble({ mode: "fixed", times: 1.5 })).toThrow(/positive integer/);
+	});
+});
+
+describe("resolvePtsPassPolicy", () => {
+	it("defaults to the suite's fixed count, or the harness default when the suite pins none", () => {
+		expect(resolvePtsPassPolicy(3, {})).toEqual({ mode: "fixed", times: 3 });
+		expect(resolvePtsPassPolicy(undefined, {})).toEqual({
+			mode: "fixed",
+			times: DEFAULT_PTS_TIMES_TO_RUN,
+		});
+		// A blank/whitespace override is treated as unset, not an error.
+		expect(resolvePtsPassPolicy(2, { BENCH_PTS_PASSES: "  " })).toEqual({
+			mode: "fixed",
+			times: 2,
+		});
+	});
+
+	it("honors a converge override (any casing), ignoring the suite's fixed count", () => {
+		expect(resolvePtsPassPolicy(2, { BENCH_PTS_PASSES: "converge" })).toEqual({ mode: "converge" });
+		expect(resolvePtsPassPolicy(5, { BENCH_PTS_PASSES: "Converge" })).toEqual({ mode: "converge" });
+	});
+
+	it("honors a numeric override, overriding every suite's configured count", () => {
+		expect(resolvePtsPassPolicy(2, { BENCH_PTS_PASSES: "10" })).toEqual({
+			mode: "fixed",
+			times: 10,
+		});
+	});
+
+	it("throws on an override that is neither converge nor a positive integer", () => {
+		expect(() => resolvePtsPassPolicy(2, { BENCH_PTS_PASSES: "lots" })).toThrow(/BENCH_PTS_PASSES/);
+		expect(() => resolvePtsPassPolicy(2, { BENCH_PTS_PASSES: "0" })).toThrow(/positive integer/);
+		expect(() => resolvePtsPassPolicy(2, { BENCH_PTS_PASSES: "2.5" })).toThrow(/positive integer/);
 	});
 });
 
@@ -127,7 +174,7 @@ describe("StepRunner", () => {
 				},
 				destroy: async () => undefined,
 			};
-			const runner = new StepRunner(sandbox, undefined, undefined, 3);
+			const runner = new StepRunner(sandbox, undefined, undefined, { mode: "fixed", times: 3 });
 			await runner.run("echo", "echo hi", 5_000);
 			expect(commands[0]).toContain("FORCE_TIMES_TO_RUN=3");
 			expect(commands[0]).not.toContain("FORCE_TIMES_TO_RUN=2");

--- a/packages/harness/src/lib/execute.ts
+++ b/packages/harness/src/lib/execute.ts
@@ -168,6 +168,65 @@ function parseExitCode(raw: string): number {
 export const DEFAULT_PTS_TIMES_TO_RUN = 2;
 
 /**
+ * How many timed PTS passes each test case runs INSIDE one sandbox (the within-machine axis). Two modes:
+ *
+ *  - `fixed` — force exactly `times` passes and disable PTS's own variance policy (the historical
+ *    default; a noisy provider can't stretch a suite to 20-40 passes). `times` is a positive integer.
+ *  - `converge` — hand the pass count to PTS's built-in statistical convergence (DynamicRunCount): run a
+ *    minimum, then keep going while the standard deviation across passes exceeds PTS's threshold, up to
+ *    PTS's own cap. This is the "let PTS decide" mode that buys tighter within-machine intervals on noisy
+ *    cases at the cost of a variable (and potentially long) runtime.
+ *
+ * Resolved per run by {@link resolvePtsPassPolicy}: a suite's configured `Suite.ptsTimesToRun` is the
+ * default, and the `BENCH_PTS_PASSES` dispatch input overrides it (a number, or `converge`).
+ */
+export type PtsPassPolicy =
+	| { readonly mode: "fixed"; readonly times: number }
+	| { readonly mode: "converge" };
+
+/** The fixed default policy (k = {@link DEFAULT_PTS_TIMES_TO_RUN}) — the {@link buildPreamble} /
+ *  {@link StepRunner} default and the value the preamble tests pin. */
+export const DEFAULT_PTS_PASS_POLICY: PtsPassPolicy = {
+	mode: "fixed",
+	times: DEFAULT_PTS_TIMES_TO_RUN,
+};
+
+/** The literal token the `BENCH_PTS_PASSES` override uses to request PTS's convergence logic. */
+export const PTS_CONVERGE_TOKEN = "converge";
+
+/**
+ * Resolve the {@link PtsPassPolicy} for a run from the suite's configured fixed count and the
+ * `BENCH_PTS_PASSES` override (read from `env`, defaulting to `process.env` — the same env-driven seam
+ * {@link buildPreamble} uses for `BENCH_PASSES`). Precedence, most specific first:
+ *
+ *  - `BENCH_PTS_PASSES=converge` (any casing) → converge mode (let PTS's DynamicRunCount decide).
+ *  - `BENCH_PTS_PASSES=<n>` (a positive integer) → fixed at that many passes, overriding every suite.
+ *  - unset/blank → the suite's own `ptsTimesToRun` (fixed), or {@link DEFAULT_PTS_TIMES_TO_RUN}.
+ *
+ * A non-empty override that is neither `converge` nor a positive integer THROWS, so a typo'd dispatch
+ * input fails the run loudly instead of silently reverting to the default pass count.
+ */
+export function resolvePtsPassPolicy(
+	suiteTimesToRun: number | undefined,
+	env: Record<string, string | undefined> = process.env,
+): PtsPassPolicy {
+	const raw = (env.BENCH_PTS_PASSES ?? "").trim();
+	if (raw === "") {
+		return { mode: "fixed", times: suiteTimesToRun ?? DEFAULT_PTS_TIMES_TO_RUN };
+	}
+	if (raw.toLowerCase() === PTS_CONVERGE_TOKEN) {
+		return { mode: "converge" };
+	}
+	const times = Number(raw);
+	if (!Number.isInteger(times) || times < 1) {
+		throw new Error(
+			`BENCH_PTS_PASSES must be a positive integer or "${PTS_CONVERGE_TOKEN}"; got "${raw}"`,
+		);
+	}
+	return { mode: "fixed", times };
+}
+
+/**
  * The static head of the in-sandbox preamble: env + PATH re-established on every step (each runCommand is
  * a fresh shell). `$SUDO` covers both root images (no prefix) and non-root images with sudo. The
  * toolchain image (packages/templates/images) installs mise globally under /mise, so prefer it when
@@ -204,32 +263,47 @@ const PREAMBLE_HEAD = [
 ];
 
 /**
- * The full preamble string for a step, pinning `ptsTimesToRun` (k) timed PTS passes per case. PTS's
- * variance-driven policy is disabled (PTS_RESPECT_TIMES_TO_RUN=1) so a noisy provider can't stretch a
- * suite to 20-40 passes; between-sandbox variance is captured by REPLICATE sandboxes (aggregate.ts), not
- * more in-sandbox passes, and the leaderboard LABELS underpowered comparisons rather than buying
- * significance with extra runs. BENCH_PASSES=1 keeps contract-verification runs at one pass via
- * lib/bench.sh. Suites pin k per tier (realworld k=1, long synthetic k=2).
+ * The trial-count env exports for a step's preamble, chosen by the {@link PtsPassPolicy}:
+ *
+ *  - contract-verification (`BENCH_PASSES=1`) → nothing; lib/bench.sh forces a single pass. This wins
+ *    over any policy so a smoke run stays one pass regardless of the dispatch inputs.
+ *  - `converge` → export the `BENCH_PTS_CONVERGE` marker and set NEITHER `FORCE_TIMES_TO_RUN` nor
+ *    `PTS_RESPECT_TIMES_TO_RUN`, so PTS's DynamicRunCount governs the pass count. The marker tells
+ *    lib/bench.sh's `_configure_pts_batch` NOT to fall back to forcing one pass.
+ *  - `fixed` → the historical pins: `PTS_RESPECT_TIMES_TO_RUN=1` (disable PTS's variance policy so a
+ *    noisy provider can't stretch a suite to 20-40 passes) + `FORCE_TIMES_TO_RUN=<k>`.
  */
-export function buildPreamble(ptsTimesToRun: number = DEFAULT_PTS_TIMES_TO_RUN): string {
-	// A non-positive or fractional k would emit `FORCE_TIMES_TO_RUN=0` (a silently empty benchmark) or a
-	// bogus value into the shell — fail loudly instead, the same fail-fast posture analysis.ts takes.
-	if (!Number.isInteger(ptsTimesToRun) || ptsTimesToRun < 1) {
-		throw new Error(
-			`buildPreamble() requires ptsTimesToRun to be a positive integer; got ${ptsTimesToRun}`,
-		);
+function ptsTrialVars(policy: PtsPassPolicy): string[] {
+	if (process.env.BENCH_PASSES === "1") return [];
+	if (policy.mode === "converge") {
+		return ["export BENCH_PTS_CONVERGE=1"];
+	}
+	return ["export PTS_RESPECT_TIMES_TO_RUN=1", `export FORCE_TIMES_TO_RUN=${policy.times}`];
+}
+
+/**
+ * The full preamble string for a step, applying a {@link PtsPassPolicy} for the timed PTS passes per
+ * case. Between-sandbox variance is captured by REPLICATE sandboxes (aggregate.ts), not by more
+ * in-sandbox passes, and the leaderboard LABELS underpowered comparisons rather than buying significance
+ * silently. Suites pin a fixed k per tier (realworld k=1, long synthetic k=2); a dispatch can override
+ * to a different fixed count or to `converge` (see {@link resolvePtsPassPolicy}).
+ */
+export function buildPreamble(policy: PtsPassPolicy = DEFAULT_PTS_PASS_POLICY): string {
+	// A non-positive or fractional fixed k would emit `FORCE_TIMES_TO_RUN=0` (a silently empty benchmark)
+	// or a bogus value into the shell — fail loudly instead, the same fail-fast posture analysis.ts takes.
+	// Validate before the BENCH_PASSES short-circuit so a bad policy is rejected in every mode.
+	if (policy.mode === "fixed" && (!Number.isInteger(policy.times) || policy.times < 1)) {
+		throw new Error(`buildPreamble() requires a positive integer pass count; got ${policy.times}`);
 	}
 	return [
 		...PREAMBLE_HEAD,
-		...(process.env.BENCH_PASSES === "1"
-			? []
-			: ["export PTS_RESPECT_TIMES_TO_RUN=1", `export FORCE_TIMES_TO_RUN=${ptsTimesToRun}`]),
+		...ptsTrialVars(policy),
 		'if [ "$(id -u)" = 0 ]; then SUDO=""; elif command -v sudo >/dev/null 2>&1; then SUDO="sudo -E"; else SUDO=""; fi',
 	].join("; ");
 }
 
-/** The preamble at the default repeat count (k = 2) — the StepRunner default and the value the preamble
- *  tests pin; a per-suite k is threaded through {@link StepRunner}. */
+/** The preamble at the default fixed repeat count (k = 2) — the StepRunner default and the value the
+ *  preamble tests pin; a per-suite policy is threaded through {@link StepRunner}. */
 export const PREAMBLE = buildPreamble();
 
 /** Print liveness every 2 min while a long step runs — exec transports buffer output, so without
@@ -260,7 +334,7 @@ export class StepRunner {
 	phase: Phase = "setup";
 	/** Every executed step with its phase, elapsed ms, and exit code. */
 	readonly stepLog: StepLogEntry[] = [];
-	/** The in-sandbox preamble prepended to every step, pinned to this suite's PTS repeat count (k). */
+	/** The in-sandbox preamble prepended to every step, carrying this run's PTS pass policy. */
 	private readonly preamble: string;
 
 	constructor(
@@ -270,11 +344,12 @@ export class StepRunner {
 		/** The inter-poll sleep used by {@link runDetached}; injectable so tests can assert the backoff
 		 *  schedule without real waiting. */
 		private readonly sleep: (ms: number) => Promise<void> = delay,
-		/** The suite's in-sandbox repeat count (k) — how many timed PTS passes each case runs. Omitted →
-		 *  {@link DEFAULT_PTS_TIMES_TO_RUN}, so a StepRunner built without one keeps the old behaviour. */
-		ptsTimesToRun: number = DEFAULT_PTS_TIMES_TO_RUN,
+		/** How many timed PTS passes each case runs, or `converge` for PTS's own convergence. Omitted →
+		 *  {@link DEFAULT_PTS_PASS_POLICY} (fixed k=2), so a StepRunner built without one keeps the old
+		 *  behaviour. Resolved from the suite + `BENCH_PTS_PASSES` by {@link resolvePtsPassPolicy}. */
+		passPolicy: PtsPassPolicy = DEFAULT_PTS_PASS_POLICY,
 	) {
-		this.preamble = buildPreamble(ptsTimesToRun);
+		this.preamble = buildPreamble(passPolicy);
 	}
 
 	/**

--- a/tooling/repo-checks/src/lib/workflow-nesting.ts
+++ b/tooling/repo-checks/src/lib/workflow-nesting.ts
@@ -25,9 +25,16 @@ export const EXPECTED_SUITE_MATRIX_EXPR = "${{ fromJSON(needs.plan.outputs.suite
 /** The expression that makes each caller cell's display name the suite id (native nesting parent). */
 // biome-ignore lint/suspicious/noTemplateCurlyInString: a GHA expression literal matched verbatim against the workflow, not a JS template.
 export const EXPECTED_SUITE_NAME_EXPR = "${{ matrix.suite }}";
-/** The expression that makes each reusable fan-out cell's display name the provider id (nesting child). */
+/** The provider id half of the fan-out cell's display name. */
 // biome-ignore lint/suspicious/noTemplateCurlyInString: a GHA expression literal matched verbatim against the workflow, not a JS template.
-export const EXPECTED_PROVIDER_NAME_EXPR = "${{ matrix.provider }}";
+const PROVIDER_NAME_EXPR = "${{ matrix.provider }}";
+/** The replicate-index suffix on the fan-out cell's display name. */
+// biome-ignore lint/suspicious/noTemplateCurlyInString: a GHA expression literal matched verbatim against the workflow, not a JS template.
+const REPLICATE_NAME_SUFFIX = " (replicate ${{ matrix.replicate }})";
+/** The expression that makes each reusable fan-out cell's display name the provider id + replicate index
+ *  (the nesting child): "<provider> (replicate N)". The replicate suffix keeps each of a provider's R
+ *  replicate sandboxes a distinct, legible cell — a bare `matrix.provider` would render them identically. */
+export const EXPECTED_PROVIDER_NAME_EXPR = `${PROVIDER_NAME_EXPR}${REPLICATE_NAME_SUFFIX}`;
 
 /**
  * The bench-matrix suite-matrix caller — exactly one job whose `uses` targets the reusable


### PR DESCRIPTION
## What & why

Adds dispatch-time knobs to the live benchmark matrix so a run can trade runner time for **tighter confidence intervals**, all defaulting to the per-suite schema config so a bare dispatch reproduces today's configured run.

### `pts_passes` — remove the manual PTS run limiting (within-machine axis)
Previously the harness always forced `FORCE_TIMES_TO_RUN=k` and set `PTS_RESPECT_TIMES_TO_RUN=1`, which *disables* PTS's own convergence. Now:
- **blank** = each suite's fixed count (unchanged),
- a **number** = force that many timed passes on every suite,
- **`converge`** = drop the pin entirely and let PTS's `DynamicRunCount` run until its standard deviation is under threshold.

Threaded harness-side via `resolvePtsPassPolicy` (`BENCH_PTS_PASSES`) → `buildPreamble`, with `lib/bench.sh` honoring a new `BENCH_PTS_CONVERGE` marker instead of forcing a single pass.

### `replicas` — fan out to replicate sandboxes per test category (between-machine axis)
`Suite.defaultReplicas` (3 for synthetic, 5 for realworld) was declared and tested but **never consumed** — every cell ran a single sandbox, so we were blind to a provider's fleet variation. Now the CI matrix actually fans out R replicate sandboxes per `(provider, suite)` cell:
- new `plan-replicates` bin emits a per-suite `[0..R-1]` index map,
- `bench-suite.yml` fans out **provider × replicate**, tagging each shard with `--replicate` so the aggregate folds them into per-metric replicate breakdowns,
- `BENCH_REPLICAS` overrides every suite at once (e.g. `2` for a quick multi-machine pass, `5` for tighter intervals, `1` for a single sandbox).

### Supporting
Cells now display as `<suite> / <provider> (replicate N)`; shard artifacts gain a `-r<idx>` segment so replicates don't collide on one name. The workflow nesting drift gate, `methodology.md`, and a matching `pts_passes` knob on the smoke lane follow.

## Testing
- `typecheck`, `lint` (`--error-on-warnings`), and every touched test suite are green, including new coverage in `execute.test.ts` (converge mode + `resolvePtsPassPolicy`), `plan-replicates.test.ts`, and the workflow drift gates.
- Verified the matrix fan-out end to end on a dispatch of this branch: the plan emitted the three axes and every `(provider, suite, replicate)` cell was created and correctly named. (The cells themselves can only execute from `main`, since the `privileged` environment's deployment-branch policy blocks non-`main` refs — which is why this needs to land before a live run.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01K4fhoTnPgQsv43PGPppKoH)_

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add configurable replicate fan-out and PTS convergence controls to the live benchmark, letting runs trade runner time for tighter confidence intervals while keeping defaults the same. Cells now fan out as provider × suite × replicate, and PTS passes can use fixed counts or convergence.

- New Features
  - Replicate fan-out (between-machine): `replicas` input → `BENCH_REPLICAS`; defaults to each suite’s `Suite.defaultReplicas`. New `plan-replicates` emits per-suite index maps; `bench-suite.yml` runs provider × replicate and tags `--replicate`. Artifacts add `-r<idx>` to avoid name collisions.
  - PTS passes (within-machine): `pts_passes` input → `BENCH_PTS_PASSES`. Blank = suite fixed count, a number forces that many passes, `converge` hands off to PTS’s DynamicRunCount. Implemented via `resolvePtsPassPolicy` → preamble; `lib/bench.sh` honors `BENCH_PTS_CONVERGE`.
  - Supporting: Smoke workflow accepts `pts_passes`; docs updated; workflow nesting gate updated; tests added for replicate planning and PTS policy. Defaults preserve current behavior (per-suite `Suite.defaultReplicas` and `Suite.ptsTimesToRun`).

<sup>Written for commit e952acb2b0a97cc5677ff30bd73f8f7c8b3c4f30. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/starslingdev/hpc-sandbox-benchmarks/pull/260?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Benchmark runs now support configurable sandbox replication for more granular results.
  * Added configurable PTS passes per test, including fixed counts and convergence mode.
  * Benchmark workflow displays replicate-specific jobs and preserves separate results for each replicate.
  * Added the `plan-replicates` command for generating replicate plans.

* **Documentation**
  * Updated benchmarking methodology to describe replicate-aware execution, aggregation, and pass configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->