### PR TITLE
feat(bench): power up default matrix — converge synthetics, realworld R=12, +modal-vm/blaxel

### DIFF
--- a/.github/workflows/bench-matrix.yml
+++ b/.github/workflows/bench-matrix.yml
@@ -16,8 +16,8 @@ name: Bench matrix
 #     suite's Suite.defaultReplicas — synthetic R=3, realworld R=12; a number scales every suite). More
 #     replicates → tighter intervals on a provider's fleet variation, at proportional runner cost.
 #   * `pts_passes` — timed PTS passes per case INSIDE a sandbox, the WITHIN-machine axis (blank = each
-#     suite's own policy: synthetic suites converge, realworld runs one fixed cold-start pass; a number or
-#     `converge` forces one policy across every suite).
+#     suite's own policy: the light synthetic suites system + memory converge, while the I/O/network suites
+#     and realworld keep a fixed count; a number or `converge` forces one policy across every suite).
 #
 # Off the PR path (real sandbox time + provider credentials); main is the default, while an explicit
 # allow_branch dispatch supports pre-merge validation. Every benchmark cell remains gated by Environment
@@ -57,14 +57,15 @@ on:
         # schema. plan-replicates rejects a non-positive/non-integer value, so a typo fails the plan.
         default: ''
       pts_passes:
-        description: 'Timed PTS passes per test INSIDE each sandbox — the within-machine axis. Blank = each suite''s default policy (synthetic suites converge; realworld run one fixed cold-start pass). A whole number forces that many on every suite; "converge" forces PTS''s own statistical convergence everywhere.'
+        description: 'Timed PTS passes per test INSIDE each sandbox — the within-machine axis. Blank = each suite''s default policy (the light synthetic suites system + memory converge; the I/O/network suites and realworld run a fixed count). A whole number forces that many on every suite; "converge" forces PTS''s own statistical convergence everywhere.'
         required: false
         type: string
-        # Blank uses each suite's declared policy: the synthetic suites converge (Suite.ptsConverge — let
-        # PTS's DynamicRunCount tighten the within-machine interval), while the realworld suites keep k=1
-        # (the cold install/build IS the metric; between-machine spread is the replicas axis, not repeats).
-        # A number or "converge" is the GLOBAL override applied to every suite. resolvePtsPassPolicy
-        # rejects any other non-numeric value.
+        # Blank uses each suite's declared policy: system + memory converge (Suite.ptsConverge — let PTS's
+        # DynamicRunCount tighten the within-machine interval, cheap+bounded there), while disk/pgbench/
+        # network + cpu-node + realworld keep a fixed count (convergence re-introduces fio's DynamicRunCount
+        # runaway, breaks iperf's fixed-trial rule, or overruns budgets sized for a fixed pass count; their
+        # spread is the replicas axis). A number or "converge" is the GLOBAL override applied to every
+        # suite. resolvePtsPassPolicy rejects any other non-numeric value.
         default: ''
       allow_branch:
         description: 'Allow benchmark cells on a non-main ref (publish remains main-only).'

--- a/.github/workflows/bench-matrix.yml
+++ b/.github/workflows/bench-matrix.yml
@@ -16,7 +16,7 @@ name: Bench matrix
 #     suite's Suite.defaultReplicas — synthetic R=3, realworld R=12; a number scales every suite). More
 #     replicates → tighter intervals on a provider's fleet variation, at proportional runner cost.
 #   * `pts_passes` — timed PTS passes per case INSIDE a sandbox, the WITHIN-machine axis (blank = each
-#     suite's own policy: only the memory suite converges, while every other suite (cpu-node, system, disk,
+#     suite's own policy: the cpu-node and memory suites converge, while every other suite (system, disk,
 #     pgbench, network, realworld) keeps a fixed count; a number or `converge` forces one policy across
 #     every suite).
 #
@@ -58,15 +58,16 @@ on:
         # schema. plan-replicates rejects a non-positive/non-integer value, so a typo fails the plan.
         default: ''
       pts_passes:
-        description: 'Timed PTS passes per test INSIDE each sandbox — the within-machine axis. Blank = each suite''s default policy (only the memory suite converges; every other suite — cpu-node, system, disk, pgbench, network, realworld — runs a fixed count). A whole number forces that many on every suite; "converge" forces PTS''s own statistical convergence everywhere.'
+        description: 'Timed PTS passes per test INSIDE each sandbox — the within-machine axis. Blank = each suite''s default policy (the cpu-node and memory suites converge; every other suite — system, disk, pgbench, network, realworld — runs a fixed count). A whole number forces that many on every suite; "converge" forces PTS''s own statistical convergence everywhere.'
         required: false
         type: string
-        # Blank uses each suite's declared policy: only memory converges (Suite.ptsConverge — STREAM is a
-        # cheap, bounded loop where DynamicRunCount tightens the within-machine interval safely), while
-        # every other suite keeps a fixed count (convergence re-introduces fio's DynamicRunCount runaway on
-        # disk, timed system out on modal-gvisor in run #49, breaks iperf's fixed-trial rule, or overruns
-        # budgets sized for a fixed pass count; their spread is the replicas axis). A number or "converge"
-        # is the GLOBAL override applied to every suite. resolvePtsPassPolicy rejects any other non-numeric value.
+        # Blank uses each suite's declared policy: cpu-node + memory converge (Suite.ptsConverge — both are
+        # cheap/stable enough that DynamicRunCount settles near its minimum and tightens the within-machine
+        # interval safely), while every other suite keeps a fixed count (convergence re-introduces fio's
+        # DynamicRunCount runaway on disk, timed system out on modal-gvisor in run #49, breaks iperf's
+        # fixed-trial rule, or overruns budgets sized for a fixed pass count; their spread is the replicas
+        # axis). A number or "converge" is the GLOBAL override applied to every suite. resolvePtsPassPolicy
+        # rejects any other non-numeric value.
         default: ''
       allow_branch:
         description: 'Allow benchmark cells on a non-main ref (publish remains main-only).'

--- a/.github/workflows/bench-matrix.yml
+++ b/.github/workflows/bench-matrix.yml
@@ -16,8 +16,9 @@ name: Bench matrix
 #     suite's Suite.defaultReplicas — synthetic R=3, realworld R=12; a number scales every suite). More
 #     replicates → tighter intervals on a provider's fleet variation, at proportional runner cost.
 #   * `pts_passes` — timed PTS passes per case INSIDE a sandbox, the WITHIN-machine axis (blank = each
-#     suite's own policy: the light synthetic suites system + memory converge, while the I/O/network suites
-#     and realworld keep a fixed count; a number or `converge` forces one policy across every suite).
+#     suite's own policy: the light synthetic suites system + memory converge, while every other suite
+#     (cpu-node, disk, pgbench, network, realworld) keeps a fixed count; a number or `converge` forces one
+#     policy across every suite).
 #
 # Off the PR path (real sandbox time + provider credentials); main is the default, while an explicit
 # allow_branch dispatch supports pre-merge validation. Every benchmark cell remains gated by Environment
@@ -57,7 +58,7 @@ on:
         # schema. plan-replicates rejects a non-positive/non-integer value, so a typo fails the plan.
         default: ''
       pts_passes:
-        description: 'Timed PTS passes per test INSIDE each sandbox — the within-machine axis. Blank = each suite''s default policy (the light synthetic suites system + memory converge; the I/O/network suites and realworld run a fixed count). A whole number forces that many on every suite; "converge" forces PTS''s own statistical convergence everywhere.'
+        description: 'Timed PTS passes per test INSIDE each sandbox — the within-machine axis. Blank = each suite''s default policy (the light synthetic suites system + memory converge; every other suite — cpu-node, disk, pgbench, network, realworld — runs a fixed count). A whole number forces that many on every suite; "converge" forces PTS''s own statistical convergence everywhere.'
         required: false
         type: string
         # Blank uses each suite's declared policy: system + memory converge (Suite.ptsConverge — let PTS's

--- a/.github/workflows/bench-matrix.yml
+++ b/.github/workflows/bench-matrix.yml
@@ -13,10 +13,11 @@ name: Bench matrix
 #   * `suites`   — narrow the suite axis to a subset (blank = every registered suite): the targeted/
 #     pre-merge knob, so a validation dispatch can run just one suite instead of the whole matrix.
 #   * `replicas` — replicate sandboxes per (provider, suite) cell, the BETWEEN-machine axis (blank = each
-#     suite's Suite.defaultReplicas; a number scales every suite). More replicates → tighter intervals on
-#     a provider's fleet variation, at proportional runner cost.
+#     suite's Suite.defaultReplicas — synthetic R=3, realworld R=12; a number scales every suite). More
+#     replicates → tighter intervals on a provider's fleet variation, at proportional runner cost.
 #   * `pts_passes` — timed PTS passes per case INSIDE a sandbox, the WITHIN-machine axis (blank = each
-#     suite's fixed count; a number, or `converge` to let PTS's own statistical convergence decide).
+#     suite's own policy: synthetic suites converge, realworld runs one fixed cold-start pass; a number or
+#     `converge` forces one policy across every suite).
 #
 # Off the PR path (real sandbox time + provider credentials); main is the default, while an explicit
 # allow_branch dispatch supports pre-merge validation. Every benchmark cell remains gated by Environment
@@ -29,14 +30,14 @@ on:
         description: 'Comma-separated providers to benchmark (blank = every registered provider).'
         required: false
         type: string
-        # The validated providers with a baked toolchain artifact and credentials in CI: e2b,
-        # daytona-vm (the LINUX_VM reference), modal-gvisor (Modal's default runtime), and novita
-        # (which boots its own pre-baked template, so it is comparable despite its "beta" maturity).
-        # The new isolation variants daytona-container + modal-vm — like blaxel (stock base image) —
-        # are excluded by default until a committed run validates them, rather than burning runner time
-        # on cells that can't yet produce a comparable result. Pass any of them explicitly to include
-        # it; `plan-providers` rejects any name that is not in the registry.
-        default: e2b,daytona-vm,modal-gvisor,novita
+        # The default set is every provider that has produced comparable committed results across
+        # isolation technologies: e2b, daytona-vm (the LINUX_VM reference), modal-gvisor (Modal's default
+        # gVisor runtime), modal-vm (Modal's gVisor-free microVM), blaxel (stock base image), and novita
+        # (its own pre-baked template). modal-vm + blaxel graduated into the default once committed runs
+        # validated them. daytona-container is the one registered variant still opt-in (pass it explicitly);
+        # `plan-providers` rejects any name that is not in the registry. Listed in registry order — the
+        # plan re-sorts to registry order regardless, so the spelling here is cosmetic.
+        default: e2b,daytona-vm,blaxel,modal-gvisor,modal-vm,novita
       suites:
         description: 'Comma-separated suites to run (blank = every registered suite). E.g. "network" for a targeted pre-merge run.'
         required: false
@@ -50,17 +51,20 @@ on:
         description: 'Replicate sandboxes per provider × suite cell — the between-machine axis (captures a provider fleet''s variation). Blank = each suite''s configured default (Suite.defaultReplicas); a whole number overrides every suite. Higher = tighter intervals at proportional runner cost; 1 = a quick single-sandbox pass.'
         required: false
         type: string
-        # Blank keeps each suite's schema default (long-synthetic suites R=3, realworld R=5). A number
+        # Blank keeps each suite's schema default (long-synthetic suites R=3, realworld R=12 — sized from
+        # the committed dataset's between-machine variance so realworld provider CIs separate). A number
         # scales ALL suites at once — this is the global override; per-category defaults live in the
         # schema. plan-replicates rejects a non-positive/non-integer value, so a typo fails the plan.
         default: ''
       pts_passes:
-        description: 'Timed PTS passes per test INSIDE each sandbox — the within-machine axis. Blank = each suite''s configured fixed count; a whole number forces that many on every suite; "converge" lets PTS''s own statistical convergence decide (tighter within-machine intervals, variable/longer runtime).'
+        description: 'Timed PTS passes per test INSIDE each sandbox — the within-machine axis. Blank = each suite''s default policy (synthetic suites converge; realworld run one fixed cold-start pass). A whole number forces that many on every suite; "converge" forces PTS''s own statistical convergence everywhere.'
         required: false
         type: string
-        # Blank keeps each suite's fixed count (Suite.ptsTimesToRun: realworld k=1, long-synthetic k=2).
-        # "converge" removes the manual FORCE_TIMES_TO_RUN pin and hands the pass count to PTS's
-        # DynamicRunCount. The harness (resolvePtsPassPolicy) rejects any other non-numeric value.
+        # Blank uses each suite's declared policy: the synthetic suites converge (Suite.ptsConverge — let
+        # PTS's DynamicRunCount tighten the within-machine interval), while the realworld suites keep k=1
+        # (the cold install/build IS the metric; between-machine spread is the replicas axis, not repeats).
+        # A number or "converge" is the GLOBAL override applied to every suite. resolvePtsPassPolicy
+        # rejects any other non-numeric value.
         default: ''
       allow_branch:
         description: 'Allow benchmark cells on a non-main ref (publish remains main-only).'

--- a/.github/workflows/bench-matrix.yml
+++ b/.github/workflows/bench-matrix.yml
@@ -16,9 +16,9 @@ name: Bench matrix
 #     suite's Suite.defaultReplicas — synthetic R=3, realworld R=12; a number scales every suite). More
 #     replicates → tighter intervals on a provider's fleet variation, at proportional runner cost.
 #   * `pts_passes` — timed PTS passes per case INSIDE a sandbox, the WITHIN-machine axis (blank = each
-#     suite's own policy: the light synthetic suites system + memory converge, while every other suite
-#     (cpu-node, disk, pgbench, network, realworld) keeps a fixed count; a number or `converge` forces one
-#     policy across every suite).
+#     suite's own policy: only the memory suite converges, while every other suite (cpu-node, system, disk,
+#     pgbench, network, realworld) keeps a fixed count; a number or `converge` forces one policy across
+#     every suite).
 #
 # Off the PR path (real sandbox time + provider credentials); main is the default, while an explicit
 # allow_branch dispatch supports pre-merge validation. Every benchmark cell remains gated by Environment
@@ -58,15 +58,15 @@ on:
         # schema. plan-replicates rejects a non-positive/non-integer value, so a typo fails the plan.
         default: ''
       pts_passes:
-        description: 'Timed PTS passes per test INSIDE each sandbox — the within-machine axis. Blank = each suite''s default policy (the light synthetic suites system + memory converge; every other suite — cpu-node, disk, pgbench, network, realworld — runs a fixed count). A whole number forces that many on every suite; "converge" forces PTS''s own statistical convergence everywhere.'
+        description: 'Timed PTS passes per test INSIDE each sandbox — the within-machine axis. Blank = each suite''s default policy (only the memory suite converges; every other suite — cpu-node, system, disk, pgbench, network, realworld — runs a fixed count). A whole number forces that many on every suite; "converge" forces PTS''s own statistical convergence everywhere.'
         required: false
         type: string
-        # Blank uses each suite's declared policy: system + memory converge (Suite.ptsConverge — let PTS's
-        # DynamicRunCount tighten the within-machine interval, cheap+bounded there), while disk/pgbench/
-        # network + cpu-node + realworld keep a fixed count (convergence re-introduces fio's DynamicRunCount
-        # runaway, breaks iperf's fixed-trial rule, or overruns budgets sized for a fixed pass count; their
-        # spread is the replicas axis). A number or "converge" is the GLOBAL override applied to every
-        # suite. resolvePtsPassPolicy rejects any other non-numeric value.
+        # Blank uses each suite's declared policy: only memory converges (Suite.ptsConverge — STREAM is a
+        # cheap, bounded loop where DynamicRunCount tightens the within-machine interval safely), while
+        # every other suite keeps a fixed count (convergence re-introduces fio's DynamicRunCount runaway on
+        # disk, timed system out on modal-gvisor in run #49, breaks iperf's fixed-trial rule, or overruns
+        # budgets sized for a fixed pass count; their spread is the replicas axis). A number or "converge"
+        # is the GLOBAL override applied to every suite. resolvePtsPassPolicy rejects any other non-numeric value.
         default: ''
       allow_branch:
         description: 'Allow benchmark cells on a non-main ref (publish remains main-only).'

--- a/.github/workflows/bench-smoke.yml
+++ b/.github/workflows/bench-smoke.yml
@@ -36,11 +36,11 @@ on:
             realworld-openclaw,
           ]
       pts_passes:
-        # The within-machine axis, matched to bench-matrix.yml so convergence can be smoke-tested on one
-        # cell before spending the whole matrix. Blank keeps the suite's fixed count (Suite.ptsTimesToRun);
-        # a whole number forces that many timed passes; "converge" hands the count to PTS's own statistical
-        # convergence. Passed through the environment below (BENCH_PTS_PASSES); the harness validates it.
-        description: 'PTS passes per case: blank = suite default, a number, or "converge".'
+        # The within-machine axis, matched to bench-matrix.yml so a policy can be smoke-tested on one cell
+        # before spending the whole matrix. Blank uses the suite's own policy (synthetic suites converge,
+        # realworld runs one fixed cold-start pass); a whole number forces that many passes; "converge"
+        # forces PTS's convergence. Passed through the environment below (BENCH_PTS_PASSES); harness-validated.
+        description: 'PTS passes per case: blank = suite default policy, a number, or "converge".'
         required: false
         type: string
         default: ''

--- a/.github/workflows/bench-smoke.yml
+++ b/.github/workflows/bench-smoke.yml
@@ -37,8 +37,8 @@ on:
           ]
       pts_passes:
         # The within-machine axis, matched to bench-matrix.yml so a policy can be smoke-tested on one cell
-        # before spending the whole matrix. Blank uses the suite's own policy (only the memory suite
-        # converges; every other suite keeps a fixed count); a whole number
+        # before spending the whole matrix. Blank uses the suite's own policy (the cpu-node and memory
+        # suites converge; every other suite keeps a fixed count); a whole number
         # forces that many; "converge" forces PTS's convergence. Passed via BENCH_PTS_PASSES; harness-validated.
         description: 'PTS passes per case: blank = suite default policy, a number, or "converge".'
         required: false

--- a/.github/workflows/bench-smoke.yml
+++ b/.github/workflows/bench-smoke.yml
@@ -37,9 +37,9 @@ on:
           ]
       pts_passes:
         # The within-machine axis, matched to bench-matrix.yml so a policy can be smoke-tested on one cell
-        # before spending the whole matrix. Blank uses the suite's own policy (synthetic suites converge,
-        # realworld runs one fixed cold-start pass); a whole number forces that many passes; "converge"
-        # forces PTS's convergence. Passed through the environment below (BENCH_PTS_PASSES); harness-validated.
+        # before spending the whole matrix. Blank uses the suite's own policy (the light synthetic suites
+        # system + memory converge; the I/O/network suites and realworld keep a fixed count); a whole number
+        # forces that many; "converge" forces PTS's convergence. Passed via BENCH_PTS_PASSES; harness-validated.
         description: 'PTS passes per case: blank = suite default policy, a number, or "converge".'
         required: false
         type: string

--- a/.github/workflows/bench-smoke.yml
+++ b/.github/workflows/bench-smoke.yml
@@ -37,8 +37,8 @@ on:
           ]
       pts_passes:
         # The within-machine axis, matched to bench-matrix.yml so a policy can be smoke-tested on one cell
-        # before spending the whole matrix. Blank uses the suite's own policy (the light synthetic suites
-        # system + memory converge; every other suite keeps a fixed count); a whole number
+        # before spending the whole matrix. Blank uses the suite's own policy (only the memory suite
+        # converges; every other suite keeps a fixed count); a whole number
         # forces that many; "converge" forces PTS's convergence. Passed via BENCH_PTS_PASSES; harness-validated.
         description: 'PTS passes per case: blank = suite default policy, a number, or "converge".'
         required: false

--- a/.github/workflows/bench-smoke.yml
+++ b/.github/workflows/bench-smoke.yml
@@ -38,7 +38,7 @@ on:
       pts_passes:
         # The within-machine axis, matched to bench-matrix.yml so a policy can be smoke-tested on one cell
         # before spending the whole matrix. Blank uses the suite's own policy (the light synthetic suites
-        # system + memory converge; the I/O/network suites and realworld keep a fixed count); a whole number
+        # system + memory converge; every other suite keeps a fixed count); a whole number
         # forces that many; "converge" forces PTS's convergence. Passed via BENCH_PTS_PASSES; harness-validated.
         description: 'PTS passes per case: blank = suite default policy, a number, or "converge".'
         required: false

--- a/.github/workflows/bench-suite.yml
+++ b/.github/workflows/bench-suite.yml
@@ -111,8 +111,8 @@ jobs:
           # The replicate index this shard represents — stamped onto its Run so the aggregate folds the R
           # sandboxes of one (provider, suite) into per-metric replicate breakdowns rather than colliding.
           BENCH_REPLICATE: ${{ matrix.replicate }}
-          # PTS passes-per-case policy: blank = the suite's fixed count, a number overrides it, or
-          # "converge" hands the count to PTS's convergence. Read by the harness preamble.
+          # PTS passes-per-case policy: blank = the suite's own policy (system/memory converge, the rest
+          # fixed), a number or "converge" overrides every suite. Read by the harness preamble.
           BENCH_PTS_PASSES: ${{ inputs.pts_passes }}
           # Scope every provider credential to the cell that actually uses it: a cell receives ONLY
           # the secret(s) for its own `matrix.provider`, so a compromised adapter or suite can't read

--- a/.github/workflows/bench-suite.yml
+++ b/.github/workflows/bench-suite.yml
@@ -42,9 +42,9 @@ on:
       pts_passes:
         description: >-
           PTS passes-per-case override for the harness (BENCH_PTS_PASSES) — the within-machine axis.
-          Blank = each suite's own policy (the light synthetic suites system + memory converge; the
-          I/O/network suites and realworld keep a fixed count); a positive integer forces that many passes
-          on every suite; "converge" forces PTS's own convergence (DynamicRunCount) on every suite.
+          Blank = each suite's own policy (the light synthetic suites system + memory converge; every
+          other suite keeps a fixed count); a positive integer forces that many passes on every suite;
+          "converge" forces PTS's own convergence (DynamicRunCount) on every suite.
         required: false
         type: string
         default: ''

--- a/.github/workflows/bench-suite.yml
+++ b/.github/workflows/bench-suite.yml
@@ -42,9 +42,9 @@ on:
       pts_passes:
         description: >-
           PTS passes-per-case override for the harness (BENCH_PTS_PASSES) — the within-machine axis.
-          Blank = each suite's own policy (synthetic suites converge, realworld runs one fixed cold-start
-          pass); a positive integer forces that many passes on every suite; "converge" forces PTS's own
-          statistical convergence (DynamicRunCount) on every suite.
+          Blank = each suite's own policy (the light synthetic suites system + memory converge; the
+          I/O/network suites and realworld keep a fixed count); a positive integer forces that many passes
+          on every suite; "converge" forces PTS's own convergence (DynamicRunCount) on every suite.
         required: false
         type: string
         default: ''

--- a/.github/workflows/bench-suite.yml
+++ b/.github/workflows/bench-suite.yml
@@ -42,8 +42,9 @@ on:
       pts_passes:
         description: >-
           PTS passes-per-case override for the harness (BENCH_PTS_PASSES) — the within-machine axis.
-          Blank = each suite's configured fixed count; a positive integer forces that many timed passes
-          on every suite; "converge" lets PTS's own statistical convergence (DynamicRunCount) decide.
+          Blank = each suite's own policy (synthetic suites converge, realworld runs one fixed cold-start
+          pass); a positive integer forces that many passes on every suite; "converge" forces PTS's own
+          statistical convergence (DynamicRunCount) on every suite.
         required: false
         type: string
         default: ''

--- a/.github/workflows/bench-suite.yml
+++ b/.github/workflows/bench-suite.yml
@@ -42,8 +42,8 @@ on:
       pts_passes:
         description: >-
           PTS passes-per-case override for the harness (BENCH_PTS_PASSES) — the within-machine axis.
-          Blank = each suite's own policy (only the `memory` suite converges; every other suite keeps a
-          fixed count); a positive integer forces that many passes on every suite; "converge" forces PTS's
+          Blank = each suite's own policy (the cpu-node and memory suites converge; every other suite keeps
+          a fixed count); a positive integer forces that many passes on every suite; "converge" forces PTS's
           own convergence (DynamicRunCount) on every suite.
         required: false
         type: string
@@ -111,7 +111,7 @@ jobs:
           # The replicate index this shard represents — stamped onto its Run so the aggregate folds the R
           # sandboxes of one (provider, suite) into per-metric replicate breakdowns rather than colliding.
           BENCH_REPLICATE: ${{ matrix.replicate }}
-          # PTS passes-per-case policy: blank = the suite's own policy (only memory converges, the rest
+          # PTS passes-per-case policy: blank = the suite's own policy (cpu-node + memory converge, the rest
           # fixed), a number or "converge" overrides every suite. Read by the harness preamble.
           BENCH_PTS_PASSES: ${{ inputs.pts_passes }}
           # Scope every provider credential to the cell that actually uses it: a cell receives ONLY

--- a/.github/workflows/bench-suite.yml
+++ b/.github/workflows/bench-suite.yml
@@ -42,9 +42,9 @@ on:
       pts_passes:
         description: >-
           PTS passes-per-case override for the harness (BENCH_PTS_PASSES) — the within-machine axis.
-          Blank = each suite's own policy (the light synthetic suites system + memory converge; every
-          other suite keeps a fixed count); a positive integer forces that many passes on every suite;
-          "converge" forces PTS's own convergence (DynamicRunCount) on every suite.
+          Blank = each suite's own policy (only the `memory` suite converges; every other suite keeps a
+          fixed count); a positive integer forces that many passes on every suite; "converge" forces PTS's
+          own convergence (DynamicRunCount) on every suite.
         required: false
         type: string
         default: ''
@@ -111,7 +111,7 @@ jobs:
           # The replicate index this shard represents — stamped onto its Run so the aggregate folds the R
           # sandboxes of one (provider, suite) into per-metric replicate breakdowns rather than colliding.
           BENCH_REPLICATE: ${{ matrix.replicate }}
-          # PTS passes-per-case policy: blank = the suite's own policy (system/memory converge, the rest
+          # PTS passes-per-case policy: blank = the suite's own policy (only memory converges, the rest
           # fixed), a number or "converge" overrides every suite. Read by the harness preamble.
           BENCH_PTS_PASSES: ${{ inputs.pts_passes }}
           # Scope every provider credential to the cell that actually uses it: a cell receives ONLY

--- a/apps/cli/src/plan-replicates.test.ts
+++ b/apps/cli/src/plan-replicates.test.ts
@@ -76,7 +76,7 @@ describe("parseReplicasOverride", () => {
 
 describe("replicaCountForSuite", () => {
 	it("uses the suite's schema default when no override is given", () => {
-		expect(replicaCountForSuite("realworld-mastra")).toBe(5);
+		expect(replicaCountForSuite("realworld-mastra")).toBe(12);
 		expect(replicaCountForSuite("cpu-node")).toBe(3);
 	});
 

--- a/docs/methodology.md
+++ b/docs/methodology.md
@@ -103,13 +103,13 @@ without being Daytona-specific.
    - **replicates** — R sandboxes per cell, the between-machine axis (`replicas` blank = each suite's
      `Suite.defaultReplicas`: synthetic R=3, realworld **R=12**, sized from the committed dataset's
      observed between-machine variance so realworld provider CIs separate; a number overrides every suite).
-   - **PTS passes** — the within-machine axis (`pts_passes` blank = each suite's own policy). The light,
-     budget-safe synthetic suites (`system`, `memory`) **converge** via PTS's `DynamicRunCount`; the I/O and
-     network suites (`disk`, `pgbench`, `network`) and the heavy `cpu-node` build keep a **fixed** pass
-     count — convergence there re-introduces fio's runaway (20–40 runs), breaks iperf's fixed-trial rule, or
-     overruns budgets sized for fixed passes — and the realworld suites run one fixed cold-start pass (the
-     install/build IS the metric). Everything with a fixed count carries its spread via replicates, not
-     in-sandbox repeats; a number or `converge` forces one policy across every suite.
+   - **PTS passes** — the within-machine axis (`pts_passes` blank = each suite's own policy). Only the
+     `memory` suite (STREAM — a cheap, bounded loop) **converges** via PTS's `DynamicRunCount`; every other
+     suite keeps a **fixed** pass count, because convergence there re-introduces fio's runaway (20–40 runs)
+     on `disk`, timed `system` out at its budget on modal-gvisor (SQLite's I/O variance) in a converge run,
+     breaks `iperf`'s fixed-trial rule on `network`, is a heavy per-pass build on `cpu-node`, or is a k=1
+     cold-start whose install/build IS the metric (realworld). Everything fixed carries its spread via
+     replicates, not in-sandbox repeats; a number or `converge` forces one policy across every suite.
 3. **Aggregate → promote → commit** — the `commit-dataset` workflow (the matrix's `publish` job calls
    it) collects every shard, `aggregate`s them into one candidate Run (measured metrics unioned, the ≥2
    replicate sandboxes of one `(provider, suite)` folded into per-metric replicate breakdowns, economics

--- a/docs/methodology.md
+++ b/docs/methodology.md
@@ -103,13 +103,14 @@ without being Daytona-specific.
    - **replicates** — R sandboxes per cell, the between-machine axis (`replicas` blank = each suite's
      `Suite.defaultReplicas`: synthetic R=3, realworld **R=12**, sized from the committed dataset's
      observed between-machine variance so realworld provider CIs separate; a number overrides every suite).
-   - **PTS passes** — the within-machine axis (`pts_passes` blank = each suite's own policy). Only the
-     `memory` suite (STREAM — a cheap, bounded loop) **converges** via PTS's `DynamicRunCount`; every other
-     suite keeps a **fixed** pass count, because convergence there re-introduces fio's runaway (20–40 runs)
-     on `disk`, timed `system` out at its budget on modal-gvisor (SQLite's I/O variance) in a converge run,
-     breaks `iperf`'s fixed-trial rule on `network`, is a heavy per-pass build on `cpu-node`, or is a k=1
-     cold-start whose install/build IS the metric (realworld). Everything fixed carries its spread via
-     replicates, not in-sandbox repeats; a number or `converge` forces one policy across every suite.
+   - **PTS passes** — the within-machine axis (`pts_passes` blank = each suite's own policy). The `memory`
+     and `cpu-node` suites **converge** via PTS's `DynamicRunCount` — both are cheap or CPU-bound enough that
+     convergence settles near its ~3-pass minimum without a runaway. Every other suite keeps a **fixed** pass
+     count, because convergence there re-introduces fio's runaway (20–40 runs) on `disk`, timed `system` out
+     at its budget on modal-gvisor (SQLite's I/O variance) in a converge run, breaks `iperf`'s fixed-trial
+     rule on `network`, or is a k=1 cold-start whose install/build IS the metric (realworld). Everything
+     fixed carries its spread via replicates, not in-sandbox repeats; a number or `converge` forces one
+     policy across every suite.
 3. **Aggregate → promote → commit** — the `commit-dataset` workflow (the matrix's `publish` job calls
    it) collects every shard, `aggregate`s them into one candidate Run (measured metrics unioned, the ≥2
    replicate sandboxes of one `(provider, suite)` folded into per-metric replicate breakdowns, economics

--- a/docs/methodology.md
+++ b/docs/methodology.md
@@ -98,11 +98,15 @@ without being Daytona-specific.
    `plan-replicates`), then one suite-matrix job calls the reusable `bench-suite` workflow per suite
    (GitHub-native nesting: `<suite> / <provider> (replicate N)`), fanning out over the selected
    providers × that suite's replicate sandboxes; every `(provider, suite, replicate)` cell uploads its
-   shard Run as an artifact. Two axes are the statistical knobs — **replicates** (R sandboxes per cell,
-   the between-machine axis: `replicas` blank = each suite's `Suite.defaultReplicas`, or a number to
-   override every suite) and **PTS passes** (the within-machine axis: `pts_passes` blank = each suite's
-   fixed count, a number, or `converge` to let PTS's own statistical convergence decide). Both default
-   to the per-suite schema config, so a bare dispatch reproduces the configured run.
+   shard Run as an artifact. Two axes are the statistical knobs, both defaulting to the per-suite schema
+   config so a bare dispatch is already powered for tight, non-overlapping intervals:
+   - **replicates** — R sandboxes per cell, the between-machine axis (`replicas` blank = each suite's
+     `Suite.defaultReplicas`: synthetic R=3, realworld **R=12**, sized from the committed dataset's
+     observed between-machine variance so realworld provider CIs separate; a number overrides every suite).
+   - **PTS passes** — the within-machine axis (`pts_passes` blank = each suite's own policy: the synthetic
+     suites **converge** via PTS's `DynamicRunCount`, while the realworld suites run one fixed cold-start
+     pass — the install/build IS the metric, so their spread is carried by replicates, not in-sandbox
+     repeats; a number or `converge` forces one policy across every suite).
 3. **Aggregate → promote → commit** — the `commit-dataset` workflow (the matrix's `publish` job calls
    it) collects every shard, `aggregate`s them into one candidate Run (measured metrics unioned, the ≥2
    replicate sandboxes of one `(provider, suite)` folded into per-metric replicate breakdowns, economics

--- a/docs/methodology.md
+++ b/docs/methodology.md
@@ -103,10 +103,13 @@ without being Daytona-specific.
    - **replicates** — R sandboxes per cell, the between-machine axis (`replicas` blank = each suite's
      `Suite.defaultReplicas`: synthetic R=3, realworld **R=12**, sized from the committed dataset's
      observed between-machine variance so realworld provider CIs separate; a number overrides every suite).
-   - **PTS passes** — the within-machine axis (`pts_passes` blank = each suite's own policy: the synthetic
-     suites **converge** via PTS's `DynamicRunCount`, while the realworld suites run one fixed cold-start
-     pass — the install/build IS the metric, so their spread is carried by replicates, not in-sandbox
-     repeats; a number or `converge` forces one policy across every suite).
+   - **PTS passes** — the within-machine axis (`pts_passes` blank = each suite's own policy). The light,
+     budget-safe synthetic suites (`system`, `memory`) **converge** via PTS's `DynamicRunCount`; the I/O and
+     network suites (`disk`, `pgbench`, `network`) and the heavy `cpu-node` build keep a **fixed** pass
+     count — convergence there re-introduces fio's runaway (20–40 runs), breaks iperf's fixed-trial rule, or
+     overruns budgets sized for fixed passes — and the realworld suites run one fixed cold-start pass (the
+     install/build IS the metric). Everything with a fixed count carries its spread via replicates, not
+     in-sandbox repeats; a number or `converge` forces one policy across every suite.
 3. **Aggregate → promote → commit** — the `commit-dataset` workflow (the matrix's `publish` job calls
    it) collects every shard, `aggregate`s them into one candidate Run (measured metrics unioned, the ≥2
    replicate sandboxes of one `(provider, suite)` folded into per-metric replicate breakdowns, economics

--- a/docs/methodology.md
+++ b/docs/methodology.md
@@ -99,7 +99,9 @@ without being Daytona-specific.
    (GitHub-native nesting: `<suite> / <provider> (replicate N)`), fanning out over the selected
    providers × that suite's replicate sandboxes; every `(provider, suite, replicate)` cell uploads its
    shard Run as an artifact. Two axes are the statistical knobs, both defaulting to the per-suite schema
-   config so a bare dispatch is already powered for tight, non-overlapping intervals:
+   config so a bare dispatch already carries the intended statistical power for separating providers
+   (subject to the genuine near-tie limit noted below — no sample size resolves providers that are truly
+   within a few percent):
    - **replicates** — R sandboxes per cell, the between-machine axis (`replicas` blank = each suite's
      `Suite.defaultReplicas`: synthetic R=3, realworld **R=12**, sized from the committed dataset's
      observed between-machine variance so realworld provider CIs separate; a number overrides every suite).

--- a/packages/harness/src/index.ts
+++ b/packages/harness/src/index.ts
@@ -372,8 +372,8 @@ export async function runSuiteOnSandbox(
 	const { suite, suiteName, providerName, resultsDir, transport } = ctx;
 	let suiteError: unknown;
 	try {
-		// Resolve the PTS pass policy from the suite's own default (converge only on `memory`; a fixed count
-		// on every other suite) and the BENCH_PTS_PASSES override. Constructed inside the
+		// Resolve the PTS pass policy from the suite's own default (converge on cpu-node + memory; a fixed
+		// count on every other suite) and the BENCH_PTS_PASSES override. Constructed inside the
 		// try so a bad policy (buildPreamble rejects a fixed k < 1) is still torn down by the finally below;
 		// a throw before the try would leak the already-created sandbox.
 		const runner = new StepRunner(sandbox, transport, undefined, resolvePtsPassPolicy(suite));

--- a/packages/harness/src/index.ts
+++ b/packages/harness/src/index.ts
@@ -372,8 +372,8 @@ export async function runSuiteOnSandbox(
 	const { suite, suiteName, providerName, resultsDir, transport } = ctx;
 	let suiteError: unknown;
 	try {
-		// Resolve the PTS pass policy from the suite's own default (converge only on the light system/memory
-		// suites; a fixed count everywhere else) and the BENCH_PTS_PASSES override. Constructed inside the
+		// Resolve the PTS pass policy from the suite's own default (converge only on `memory`; a fixed count
+		// on every other suite) and the BENCH_PTS_PASSES override. Constructed inside the
 		// try so a bad policy (buildPreamble rejects a fixed k < 1) is still torn down by the finally below;
 		// a throw before the try would leak the already-created sandbox.
 		const runner = new StepRunner(sandbox, transport, undefined, resolvePtsPassPolicy(suite));

--- a/packages/harness/src/index.ts
+++ b/packages/harness/src/index.ts
@@ -372,16 +372,11 @@ export async function runSuiteOnSandbox(
 	const { suite, suiteName, providerName, resultsDir, transport } = ctx;
 	let suiteError: unknown;
 	try {
-		// Resolve the PTS pass policy from the suite's configured count and the BENCH_PTS_PASSES override
-		// (a fixed count, or `converge` to let PTS's own convergence decide). Constructed inside the try so
+		// Resolve the PTS pass policy from the suite's own default (converge for the synthetic suites, a
+		// fixed single pass for realworld) and the BENCH_PTS_PASSES override. Constructed inside the try so
 		// a bad policy (buildPreamble rejects a fixed k < 1) is still torn down by the finally below; a
 		// throw before the try would leak the already-created sandbox.
-		const runner = new StepRunner(
-			sandbox,
-			transport,
-			undefined,
-			resolvePtsPassPolicy(suite.ptsTimesToRun),
-		);
+		const runner = new StepRunner(sandbox, transport, undefined, resolvePtsPassPolicy(suite));
 		runner.phase = "setup";
 		if (suite.minDiskGb) {
 			// Measure free space where the disk-heavy suites actually write, not the sandbox root. The

--- a/packages/harness/src/index.ts
+++ b/packages/harness/src/index.ts
@@ -372,10 +372,10 @@ export async function runSuiteOnSandbox(
 	const { suite, suiteName, providerName, resultsDir, transport } = ctx;
 	let suiteError: unknown;
 	try {
-		// Resolve the PTS pass policy from the suite's own default (converge for the synthetic suites, a
-		// fixed single pass for realworld) and the BENCH_PTS_PASSES override. Constructed inside the try so
-		// a bad policy (buildPreamble rejects a fixed k < 1) is still torn down by the finally below; a
-		// throw before the try would leak the already-created sandbox.
+		// Resolve the PTS pass policy from the suite's own default (converge only on the light system/memory
+		// suites; a fixed count everywhere else) and the BENCH_PTS_PASSES override. Constructed inside the
+		// try so a bad policy (buildPreamble rejects a fixed k < 1) is still torn down by the finally below;
+		// a throw before the try would leak the already-created sandbox.
 		const runner = new StepRunner(sandbox, transport, undefined, resolvePtsPassPolicy(suite));
 		runner.phase = "setup";
 		if (suite.minDiskGb) {

--- a/packages/harness/src/lib/execute.test.ts
+++ b/packages/harness/src/lib/execute.test.ts
@@ -103,34 +103,52 @@ describe("sandbox preamble", () => {
 
 describe("resolvePtsPassPolicy", () => {
 	it("defaults to the suite's fixed count, or the harness default when the suite pins none", () => {
-		expect(resolvePtsPassPolicy(3, {})).toEqual({ mode: "fixed", times: 3 });
-		expect(resolvePtsPassPolicy(undefined, {})).toEqual({
+		expect(resolvePtsPassPolicy({ ptsTimesToRun: 3 }, {})).toEqual({ mode: "fixed", times: 3 });
+		expect(resolvePtsPassPolicy({}, {})).toEqual({
 			mode: "fixed",
 			times: DEFAULT_PTS_TIMES_TO_RUN,
 		});
 		// A blank/whitespace override is treated as unset, not an error.
-		expect(resolvePtsPassPolicy(2, { BENCH_PTS_PASSES: "  " })).toEqual({
+		expect(resolvePtsPassPolicy({ ptsTimesToRun: 2 }, { BENCH_PTS_PASSES: "  " })).toEqual({
 			mode: "fixed",
 			times: 2,
 		});
 	});
 
-	it("honors a converge override (any casing), ignoring the suite's fixed count", () => {
-		expect(resolvePtsPassPolicy(2, { BENCH_PTS_PASSES: "converge" })).toEqual({ mode: "converge" });
-		expect(resolvePtsPassPolicy(5, { BENCH_PTS_PASSES: "Converge" })).toEqual({ mode: "converge" });
+	it("converges by default for a suite that declares ptsConverge", () => {
+		// The synthetic suites carry ptsConverge — a bare run hands their pass count to PTS's convergence.
+		expect(resolvePtsPassPolicy({ ptsConverge: true, ptsTimesToRun: 2 }, {})).toEqual({
+			mode: "converge",
+		});
 	});
 
-	it("honors a numeric override, overriding every suite's configured count", () => {
-		expect(resolvePtsPassPolicy(2, { BENCH_PTS_PASSES: "10" })).toEqual({
+	it("honors a converge override (any casing), forcing it even on a fixed suite", () => {
+		expect(resolvePtsPassPolicy({ ptsTimesToRun: 2 }, { BENCH_PTS_PASSES: "converge" })).toEqual({
+			mode: "converge",
+		});
+		expect(resolvePtsPassPolicy({ ptsTimesToRun: 5 }, { BENCH_PTS_PASSES: "Converge" })).toEqual({
+			mode: "converge",
+		});
+	});
+
+	it("honors a numeric override, overriding a suite's converge default", () => {
+		// A dispatch pinning a fixed count wins over the suite's own converge policy.
+		expect(resolvePtsPassPolicy({ ptsConverge: true }, { BENCH_PTS_PASSES: "10" })).toEqual({
 			mode: "fixed",
 			times: 10,
 		});
 	});
 
 	it("throws on an override that is neither converge nor a positive integer", () => {
-		expect(() => resolvePtsPassPolicy(2, { BENCH_PTS_PASSES: "lots" })).toThrow(/BENCH_PTS_PASSES/);
-		expect(() => resolvePtsPassPolicy(2, { BENCH_PTS_PASSES: "0" })).toThrow(/positive integer/);
-		expect(() => resolvePtsPassPolicy(2, { BENCH_PTS_PASSES: "2.5" })).toThrow(/positive integer/);
+		expect(() => resolvePtsPassPolicy({ ptsTimesToRun: 2 }, { BENCH_PTS_PASSES: "lots" })).toThrow(
+			/BENCH_PTS_PASSES/,
+		);
+		expect(() => resolvePtsPassPolicy({ ptsTimesToRun: 2 }, { BENCH_PTS_PASSES: "0" })).toThrow(
+			/positive integer/,
+		);
+		expect(() => resolvePtsPassPolicy({ ptsTimesToRun: 2 }, { BENCH_PTS_PASSES: "2.5" })).toThrow(
+			/positive integer/,
+		);
 	});
 });
 

--- a/packages/harness/src/lib/execute.ts
+++ b/packages/harness/src/lib/execute.ts
@@ -177,8 +177,9 @@ export const DEFAULT_PTS_TIMES_TO_RUN = 2;
  *    PTS's own cap. This is the "let PTS decide" mode that buys tighter within-machine intervals on noisy
  *    cases at the cost of a variable (and potentially long) runtime.
  *
- * Resolved per run by {@link resolvePtsPassPolicy}: a suite's configured `Suite.ptsTimesToRun` is the
- * default, and the `BENCH_PTS_PASSES` dispatch input overrides it (a number, or `converge`).
+ * Resolved per run by {@link resolvePtsPassPolicy}: each suite's own default (converge where it declares
+ * `Suite.ptsConverge` — the light system/memory suites — else fixed at `Suite.ptsTimesToRun`), which the
+ * `BENCH_PTS_PASSES` dispatch input overrides (a number, or `converge`).
  */
 export type PtsPassPolicy =
 	| { readonly mode: "fixed"; readonly times: number }
@@ -209,12 +210,12 @@ export interface SuitePassConfig {
  *  - `BENCH_PTS_PASSES=converge` (any casing) → converge, forced on EVERY suite (the global override).
  *  - `BENCH_PTS_PASSES=<n>` (a positive integer) → fixed at that many passes, forced on every suite.
  *  - unset/blank → the suite's OWN default: `converge` where the suite declares {@link SuitePassConfig.ptsConverge}
- *    (the synthetic suites), else fixed at its `ptsTimesToRun` (or {@link DEFAULT_PTS_TIMES_TO_RUN}).
+ *    (the light synthetic suites — system, memory), else fixed at its `ptsTimesToRun` (or {@link DEFAULT_PTS_TIMES_TO_RUN}).
  *
- * So a bare run converges the suites built to converge (synthetic) while the realworld suites keep their
- * single fixed cold-start pass, and a dispatch can still force one policy across the board. A non-empty
- * override that is neither `converge` nor a positive integer THROWS, so a typo'd dispatch input fails the
- * run loudly instead of silently reverting.
+ * So a bare run converges the suites built to converge (the light, budget-safe synthetic suites) while
+ * the I/O, network, and realworld suites keep their fixed pass count, and a dispatch can still force one
+ * policy across the board. A non-empty override that is neither `converge` nor a positive integer THROWS,
+ * so a typo'd dispatch input fails the run loudly instead of silently reverting.
  */
 export function resolvePtsPassPolicy(
 	suite: SuitePassConfig,

--- a/packages/harness/src/lib/execute.ts
+++ b/packages/harness/src/lib/execute.ts
@@ -194,36 +194,51 @@ export const DEFAULT_PTS_PASS_POLICY: PtsPassPolicy = {
 /** The literal token the `BENCH_PTS_PASSES` override uses to request PTS's convergence logic. */
 export const PTS_CONVERGE_TOKEN = "converge";
 
+/** The slice of a suite {@link resolvePtsPassPolicy} reads to pick its pass policy — its fixed count and
+ *  whether it converges by default. Structural so the harness needn't import the whole `Suite` type. */
+export interface SuitePassConfig {
+	readonly ptsTimesToRun?: number;
+	readonly ptsConverge?: boolean;
+}
+
 /**
- * Resolve the {@link PtsPassPolicy} for a run from the suite's configured fixed count and the
+ * Resolve the {@link PtsPassPolicy} for a run from the suite's own default policy and the
  * `BENCH_PTS_PASSES` override (read from `env`, defaulting to `process.env` — the same env-driven seam
  * {@link buildPreamble} uses for `BENCH_PASSES`). Precedence, most specific first:
  *
- *  - `BENCH_PTS_PASSES=converge` (any casing) → converge mode (let PTS's DynamicRunCount decide).
- *  - `BENCH_PTS_PASSES=<n>` (a positive integer) → fixed at that many passes, overriding every suite.
- *  - unset/blank → the suite's own `ptsTimesToRun` (fixed), or {@link DEFAULT_PTS_TIMES_TO_RUN}.
+ *  - `BENCH_PTS_PASSES=converge` (any casing) → converge, forced on EVERY suite (the global override).
+ *  - `BENCH_PTS_PASSES=<n>` (a positive integer) → fixed at that many passes, forced on every suite.
+ *  - unset/blank → the suite's OWN default: `converge` where the suite declares {@link SuitePassConfig.ptsConverge}
+ *    (the synthetic suites), else fixed at its `ptsTimesToRun` (or {@link DEFAULT_PTS_TIMES_TO_RUN}).
  *
- * A non-empty override that is neither `converge` nor a positive integer THROWS, so a typo'd dispatch
- * input fails the run loudly instead of silently reverting to the default pass count.
+ * So a bare run converges the suites built to converge (synthetic) while the realworld suites keep their
+ * single fixed cold-start pass, and a dispatch can still force one policy across the board. A non-empty
+ * override that is neither `converge` nor a positive integer THROWS, so a typo'd dispatch input fails the
+ * run loudly instead of silently reverting.
  */
 export function resolvePtsPassPolicy(
-	suiteTimesToRun: number | undefined,
+	suite: SuitePassConfig,
 	env: Record<string, string | undefined> = process.env,
 ): PtsPassPolicy {
 	const raw = (env.BENCH_PTS_PASSES ?? "").trim();
-	if (raw === "") {
-		return { mode: "fixed", times: suiteTimesToRun ?? DEFAULT_PTS_TIMES_TO_RUN };
+	if (raw !== "") {
+		// The dispatch override wins over the suite's own default policy, on every suite.
+		if (raw.toLowerCase() === PTS_CONVERGE_TOKEN) {
+			return { mode: "converge" };
+		}
+		const times = Number(raw);
+		if (!Number.isInteger(times) || times < 1) {
+			throw new Error(
+				`BENCH_PTS_PASSES must be a positive integer or "${PTS_CONVERGE_TOKEN}"; got "${raw}"`,
+			);
+		}
+		return { mode: "fixed", times };
 	}
-	if (raw.toLowerCase() === PTS_CONVERGE_TOKEN) {
+	// No override: the suite's own policy.
+	if (suite.ptsConverge) {
 		return { mode: "converge" };
 	}
-	const times = Number(raw);
-	if (!Number.isInteger(times) || times < 1) {
-		throw new Error(
-			`BENCH_PTS_PASSES must be a positive integer or "${PTS_CONVERGE_TOKEN}"; got "${raw}"`,
-		);
-	}
-	return { mode: "fixed", times };
+	return { mode: "fixed", times: suite.ptsTimesToRun ?? DEFAULT_PTS_TIMES_TO_RUN };
 }
 
 /**

--- a/packages/harness/src/lib/execute.ts
+++ b/packages/harness/src/lib/execute.ts
@@ -213,9 +213,9 @@ export interface SuitePassConfig {
  *    (the light synthetic suites — system, memory), else fixed at its `ptsTimesToRun` (or {@link DEFAULT_PTS_TIMES_TO_RUN}).
  *
  * So a bare run converges the suites built to converge (the light, budget-safe synthetic suites) while
- * the I/O, network, and realworld suites keep their fixed pass count, and a dispatch can still force one
- * policy across the board. A non-empty override that is neither `converge` nor a positive integer THROWS,
- * so a typo'd dispatch input fails the run loudly instead of silently reverting.
+ * every other suite (cpu-node, the I/O + network suites, and realworld) keeps its fixed pass count, and a
+ * dispatch can still force one policy across the board. A non-empty override that is neither `converge` nor
+ * a positive integer THROWS, so a typo'd dispatch input fails the run loudly instead of silently reverting.
  */
 export function resolvePtsPassPolicy(
 	suite: SuitePassConfig,

--- a/packages/harness/src/lib/execute.ts
+++ b/packages/harness/src/lib/execute.ts
@@ -178,8 +178,8 @@ export const DEFAULT_PTS_TIMES_TO_RUN = 2;
  *    cases at the cost of a variable (and potentially long) runtime.
  *
  * Resolved per run by {@link resolvePtsPassPolicy}: each suite's own default (converge where it declares
- * `Suite.ptsConverge` — only `memory` — else fixed at `Suite.ptsTimesToRun`), which the `BENCH_PTS_PASSES`
- * dispatch input overrides (a number, or `converge`).
+ * `Suite.ptsConverge` — cpu-node and memory — else fixed at `Suite.ptsTimesToRun`), which the
+ * `BENCH_PTS_PASSES` dispatch input overrides (a number, or `converge`).
  */
 export type PtsPassPolicy =
 	| { readonly mode: "fixed"; readonly times: number }
@@ -210,12 +210,12 @@ export interface SuitePassConfig {
  *  - `BENCH_PTS_PASSES=converge` (any casing) → converge, forced on EVERY suite (the global override).
  *  - `BENCH_PTS_PASSES=<n>` (a positive integer) → fixed at that many passes, forced on every suite.
  *  - unset/blank → the suite's OWN default: `converge` where the suite declares {@link SuitePassConfig.ptsConverge}
- *    (only `memory`), else fixed at its `ptsTimesToRun` (or {@link DEFAULT_PTS_TIMES_TO_RUN}).
+ *    (cpu-node and memory), else fixed at its `ptsTimesToRun` (or {@link DEFAULT_PTS_TIMES_TO_RUN}).
  *
- * So a bare run converges only `memory` (the one budget-safe suite) while every other suite (cpu-node, the
- * system + I/O + network suites, and realworld) keeps its fixed pass count, and a dispatch can still force
- * one policy across the board. A non-empty override that is neither `converge` nor a positive integer
- * THROWS, so a typo'd dispatch input fails the run loudly instead of silently reverting.
+ * So a bare run converges cpu-node + memory (the budget-safe, quick-to-settle suites) while every other
+ * suite (the system + I/O + network suites, and realworld) keeps its fixed pass count, and a dispatch can
+ * still force one policy across the board. A non-empty override that is neither `converge` nor a positive
+ * integer THROWS, so a typo'd dispatch input fails the run loudly instead of silently reverting.
  */
 export function resolvePtsPassPolicy(
 	suite: SuitePassConfig,

--- a/packages/harness/src/lib/execute.ts
+++ b/packages/harness/src/lib/execute.ts
@@ -178,8 +178,8 @@ export const DEFAULT_PTS_TIMES_TO_RUN = 2;
  *    cases at the cost of a variable (and potentially long) runtime.
  *
  * Resolved per run by {@link resolvePtsPassPolicy}: each suite's own default (converge where it declares
- * `Suite.ptsConverge` — the light system/memory suites — else fixed at `Suite.ptsTimesToRun`), which the
- * `BENCH_PTS_PASSES` dispatch input overrides (a number, or `converge`).
+ * `Suite.ptsConverge` — only `memory` — else fixed at `Suite.ptsTimesToRun`), which the `BENCH_PTS_PASSES`
+ * dispatch input overrides (a number, or `converge`).
  */
 export type PtsPassPolicy =
 	| { readonly mode: "fixed"; readonly times: number }
@@ -210,12 +210,12 @@ export interface SuitePassConfig {
  *  - `BENCH_PTS_PASSES=converge` (any casing) → converge, forced on EVERY suite (the global override).
  *  - `BENCH_PTS_PASSES=<n>` (a positive integer) → fixed at that many passes, forced on every suite.
  *  - unset/blank → the suite's OWN default: `converge` where the suite declares {@link SuitePassConfig.ptsConverge}
- *    (the light synthetic suites — system, memory), else fixed at its `ptsTimesToRun` (or {@link DEFAULT_PTS_TIMES_TO_RUN}).
+ *    (only `memory`), else fixed at its `ptsTimesToRun` (or {@link DEFAULT_PTS_TIMES_TO_RUN}).
  *
- * So a bare run converges the suites built to converge (the light, budget-safe synthetic suites) while
- * every other suite (cpu-node, the I/O + network suites, and realworld) keeps its fixed pass count, and a
- * dispatch can still force one policy across the board. A non-empty override that is neither `converge` nor
- * a positive integer THROWS, so a typo'd dispatch input fails the run loudly instead of silently reverting.
+ * So a bare run converges only `memory` (the one budget-safe suite) while every other suite (cpu-node, the
+ * system + I/O + network suites, and realworld) keeps its fixed pass count, and a dispatch can still force
+ * one policy across the board. A non-empty override that is neither `converge` nor a positive integer
+ * THROWS, so a typo'd dispatch input fails the run loudly instead of silently reverting.
  */
 export function resolvePtsPassPolicy(
 	suite: SuitePassConfig,

--- a/packages/schema/src/providers.ts
+++ b/packages/schema/src/providers.ts
@@ -305,7 +305,7 @@ const REGISTRY: Record<ProviderId, Omit<ProviderMeta, "id">> = {
 		maturity: {
 			status: "beta",
 			notes:
-				"Local e2e validation wiring; not yet a committed run. memory=8192 hits the 4 vCPU / 8 GiB target (specMatched=true is that vCPU/memory check only); the 40 GiB volume (mounted at the PTS data dir) separately lets the realworld suites (mastra 30, openclaw 25) clear the disk gate instead of skipping.",
+				"Now carries committed runs and is in the default matrix set. memory=8192 hits the 4 vCPU / 8 GiB target (specMatched=true is that vCPU/memory check only); the 40 GiB volume (mounted at the PTS data dir) separately lets the realworld suites (mastra 30, openclaw 25) clear the disk gate instead of skipping.",
 		},
 		// memory=8192 lands on the target's 8 GiB / 4 vCPU point because the target's vCPU was chosen to
 		// sit on Blaxel's RAM/CPU coupling curve (specMatched only judges that pair). The 40 GiB volume
@@ -351,7 +351,7 @@ const REGISTRY: Record<ProviderId, Omit<ProviderMeta, "id">> = {
 		maturity: {
 			status: "beta",
 			notes:
-				"New isolation variant sharing Modal credentials/pricing with modal-gvisor; adds experimentalOptions {vm_runtime:true} at create. Not yet a committed run.",
+				"Isolation variant sharing Modal credentials/pricing with modal-gvisor; adds experimentalOptions {vm_runtime:true} at create. Now carries committed runs and is in the default matrix set.",
 		},
 		specPinning: "settable",
 		transport: modalTransport,

--- a/packages/schema/src/suites.test.ts
+++ b/packages/schema/src/suites.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "bun:test";
+import type { Suite } from "./index.ts";
 import { METRIC_CATALOG, paddedSuiteToken, padSuiteList, SUITE_NAMES, SUITES } from "./index.ts";
 // Not part of the public surface (curation is an implementation detail of the catalog merge); this
 // PR's pinned-subset test reaches in directly to compare its suite's declarations against curated keys.
@@ -32,12 +33,24 @@ describe("suite registry", () => {
 		]);
 	});
 
-	it("declares the per-tier in-sandbox repeat count (k) and replicate count (R)", () => {
-		// Real-world captures cold-start once (k=1) across more sandboxes (R=5); the long synthetics take
-		// two in-sandbox passes (k=2) across R=3. cpu-generic is retired; pgbench is split out of system.
-		expect(SUITES["realworld-mastra"].ptsTimesToRun).toBe(1);
-		expect(SUITES["realworld-mastra"].defaultReplicas).toBe(5);
+	it("declares the per-tier pass policy and replicate count (R)", () => {
+		// Real-world captures cold-start once (k=1, no in-sandbox convergence) across many sandboxes
+		// (R=12, data-informed so the between-machine CIs separate providers); the long synthetics let PTS
+		// converge the in-sandbox passes across R=3. cpu-generic is retired; pgbench is split out of system.
+		for (const name of [
+			"realworld-mastra",
+			"realworld-better-auth",
+			"realworld-openclaw",
+		] as const) {
+			// Suite-typed view: the realworld literals omit ptsConverge entirely (satisfies narrows the
+			// const), so read it through the interface to assert it stays off — realworld does NOT converge.
+			const suite: Suite = SUITES[name];
+			expect(suite.ptsTimesToRun).toBe(1);
+			expect(suite.ptsConverge).toBeUndefined();
+			expect(suite.defaultReplicas).toBe(12);
+		}
 		for (const name of ["cpu-node", "system", "pgbench", "memory", "disk", "network"] as const) {
+			expect(SUITES[name].ptsConverge).toBe(true);
 			expect(SUITES[name].ptsTimesToRun).toBe(2);
 			expect(SUITES[name].defaultReplicas).toBe(3);
 		}

--- a/packages/schema/src/suites.test.ts
+++ b/packages/schema/src/suites.test.ts
@@ -36,10 +36,11 @@ describe("suite registry", () => {
 	it("declares the per-tier pass policy and replicate count (R)", () => {
 		// Real-world captures cold-start once (k=1, no in-sandbox convergence) across many sandboxes
 		// (R=12, data-informed so the between-machine CIs separate providers). The synthetics run k=2 fixed
-		// across R=3, and PTS convergence is enabled ONLY on the light, budget-safe suites (system, memory);
-		// the I/O + network suites and the heavy cpu-node build keep a fixed count (convergence there
-		// re-introduces fio's DynamicRunCount runaway, breaks iperf's fixed-trial rule, or overruns the
-		// budget). cpu-generic is retired; pgbench is split out of system.
+		// across R=3, and PTS convergence is enabled ONLY on `memory` (STREAM is a tiny, budget-safe loop);
+		// every other synthetic keeps a fixed count — convergence there re-introduces fio's DynamicRunCount
+		// runaway (disk), overran the budget live on modal-gvisor (system/SQLite, run #49), breaks iperf's
+		// fixed-trial rule (network), or is a heavy per-pass build (cpu-node). cpu-generic is retired;
+		// pgbench is split out of system.
 		for (const name of [
 			"realworld-mastra",
 			"realworld-better-auth",
@@ -56,9 +57,9 @@ describe("suite registry", () => {
 			expect(SUITES[name].ptsTimesToRun).toBe(2);
 			expect(SUITES[name].defaultReplicas).toBe(3);
 		}
-		// Convergence is enabled only where it is cheap, stable, and budget-safe.
+		// Convergence is enabled only on memory — the one suite proven cheap, stable, and budget-safe.
 		const converging: string[] = SUITE_NAMES.filter((name) => (SUITES[name] as Suite).ptsConverge);
-		expect(converging.sort()).toEqual(["memory", "system"]);
+		expect(converging).toEqual(["memory"]);
 	});
 
 	it("mirrors each realworld suite's metrics from the generated catalog (no hand-drift)", () => {

--- a/packages/schema/src/suites.test.ts
+++ b/packages/schema/src/suites.test.ts
@@ -35,12 +35,12 @@ describe("suite registry", () => {
 
 	it("declares the per-tier pass policy and replicate count (R)", () => {
 		// Real-world captures cold-start once (k=1, no in-sandbox convergence) across many sandboxes
-		// (R=12, data-informed so the between-machine CIs separate providers). The synthetics run k=2 fixed
-		// across R=3, and PTS convergence is enabled ONLY on `memory` (STREAM is a tiny, budget-safe loop);
-		// every other synthetic keeps a fixed count — convergence there re-introduces fio's DynamicRunCount
-		// runaway (disk), overran the budget live on modal-gvisor (system/SQLite, run #49), breaks iperf's
-		// fixed-trial rule (network), or is a heavy per-pass build (cpu-node). cpu-generic is retired;
-		// pgbench is split out of system.
+		// (R=12, data-informed so the between-machine CIs separate providers). The synthetics run R=3, and
+		// PTS convergence is enabled on the two suites that converge cheaply and predictably: `memory`
+		// (STREAM, a tiny budget-safe loop) and `cpu-node` (CPU-bound, so DynamicRunCount settles near its
+		// ~3-pass minimum — no runaway). The rest keep a fixed count — convergence there re-introduces fio's
+		// runaway (disk), overran the budget live on modal-gvisor (system/SQLite, run #49), or breaks iperf's
+		// fixed-trial rule (network). cpu-generic is retired; pgbench is split out of system.
 		for (const name of [
 			"realworld-mastra",
 			"realworld-better-auth",
@@ -57,9 +57,9 @@ describe("suite registry", () => {
 			expect(SUITES[name].ptsTimesToRun).toBe(2);
 			expect(SUITES[name].defaultReplicas).toBe(3);
 		}
-		// Convergence is enabled only on memory — the one suite proven cheap, stable, and budget-safe.
+		// Convergence is enabled on the two suites that converge cheaply and predictably: cpu-node + memory.
 		const converging: string[] = SUITE_NAMES.filter((name) => (SUITES[name] as Suite).ptsConverge);
-		expect(converging).toEqual(["memory"]);
+		expect(converging.sort()).toEqual(["cpu-node", "memory"]);
 	});
 
 	it("mirrors each realworld suite's metrics from the generated catalog (no hand-drift)", () => {

--- a/packages/schema/src/suites.test.ts
+++ b/packages/schema/src/suites.test.ts
@@ -35,8 +35,11 @@ describe("suite registry", () => {
 
 	it("declares the per-tier pass policy and replicate count (R)", () => {
 		// Real-world captures cold-start once (k=1, no in-sandbox convergence) across many sandboxes
-		// (R=12, data-informed so the between-machine CIs separate providers); the long synthetics let PTS
-		// converge the in-sandbox passes across R=3. cpu-generic is retired; pgbench is split out of system.
+		// (R=12, data-informed so the between-machine CIs separate providers). The synthetics run k=2 fixed
+		// across R=3, and PTS convergence is enabled ONLY on the light, budget-safe suites (system, memory);
+		// the I/O + network suites and the heavy cpu-node build keep a fixed count (convergence there
+		// re-introduces fio's DynamicRunCount runaway, breaks iperf's fixed-trial rule, or overruns the
+		// budget). cpu-generic is retired; pgbench is split out of system.
 		for (const name of [
 			"realworld-mastra",
 			"realworld-better-auth",
@@ -50,10 +53,12 @@ describe("suite registry", () => {
 			expect(suite.defaultReplicas).toBe(12);
 		}
 		for (const name of ["cpu-node", "system", "pgbench", "memory", "disk", "network"] as const) {
-			expect(SUITES[name].ptsConverge).toBe(true);
 			expect(SUITES[name].ptsTimesToRun).toBe(2);
 			expect(SUITES[name].defaultReplicas).toBe(3);
 		}
+		// Convergence is enabled only where it is cheap, stable, and budget-safe.
+		const converging: string[] = SUITE_NAMES.filter((name) => (SUITES[name] as Suite).ptsConverge);
+		expect(converging.sort()).toEqual(["memory", "system"]);
 	});
 
 	it("mirrors each realworld suite's metrics from the generated catalog (no hand-drift)", () => {

--- a/packages/schema/src/suites.ts
+++ b/packages/schema/src/suites.ts
@@ -42,15 +42,16 @@ export interface Suite {
 	 * Let PTS's own statistical convergence (DynamicRunCount) choose the in-sandbox pass count instead of
 	 * pinning it to {@link ptsTimesToRun}: run a minimum, then keep going while the standard deviation
 	 * across passes exceeds PTS's threshold, up to PTS's cap. This is the WITHIN-machine tightening knob,
-	 * set only on the light, bounded synthetic suites whose passes are cheap and stable (system, memory) —
-	 * there convergence settles fast and stays well inside the budget. It is deliberately LEFT OFF wherever
+	 * set only on `memory` — STREAM is a tiny, tight bandwidth loop, so DynamicRunCount settles fast and
+	 * even a long convergence fits its 30-min budget many times over. It is deliberately LEFT OFF wherever
 	 * a variable pass count is unsafe or wrong: the I/O suites (disk — fio's DynamicRunCount blew up to
 	 * 20-40 runs and exhausted the suite historically; pgbench — each pass re-runs an expensive scale-100
-	 * init), the network suite (a documented "trial count stays 2" rule + per-run WAN server reselection),
-	 * the heavy cpu-node build, and the realworld suites (k=1 — the cold install/build IS the metric). Those
-	 * take their tightness from {@link defaultReplicas} replicate sandboxes instead. The `pts_passes`
-	 * dispatch input (BENCH_PTS_PASSES) overrides this per run — a fixed number, or `converge` to force
-	 * convergence on every suite (accepting the budget risk on the I/O suites).
+	 * init), the system suite (SQLite's I/O variance timed convergence out at its 55-min budget on
+	 * modal-gvisor in run #49), the network suite (a documented "trial count stays 2" rule + per-run WAN
+	 * server reselection), the heavy cpu-node build, and the realworld suites (k=1 — the cold install/build
+	 * IS the metric). Those take their tightness from {@link defaultReplicas} replicate sandboxes instead.
+	 * The `pts_passes` dispatch input (BENCH_PTS_PASSES) overrides this per run — a fixed number, or
+	 * `converge` to force convergence on every suite (accepting the budget risk on the I/O + system suites).
 	 */
 	ptsConverge?: boolean;
 	/**
@@ -104,18 +105,17 @@ export const SUITES = {
 	// The system dimension (pybench + sqlite + git): PyBench (Python interpreter) + SQLite Speedtest
 	// (single-result wildcards) + common Git operations over a fixed GTK checkout. PostgreSQL (pgbench)
 	// is its own leg below — split out so its ~1.5 GB dataset and long runtime don't gate the quick
-	// system probes. Long-synthetic tier, PTS CONVERGES in-sandbox (R=3): pybench and git are light and
-	// stable. SQLite Speedtest touches I/O, so on a noisy provider its variance can add a few DynamicRunCount
-	// passes — but each pass is short and the 55-min budget (sized for k=2) has multiples of headroom, so
-	// convergence stays inside it; a converge-enabled calibration dispatch should confirm this on slow
-	// providers before the bare default is fully trusted (budgets are provisional ceilings anyway).
+	// system probes. Long-synthetic tier: k=2 FIXED (R=3). Convergence is OFF: pybench and git are stable,
+	// but SQLite Speedtest touches I/O — a converge run (#49) drove DynamicRunCount past the 55-min command
+	// budget and timed the whole system suite out on modal-gvisor (gVisor's slower I/O). So system keeps a
+	// fixed count and takes its tightness from the R=3 replicates, like the other I/O-touching suites; a
+	// calibration dispatch that re-derives a converge-safe budget could re-enable it later.
 	system: {
 		setupPts: true,
 		commandTimeoutMinutes: 55,
 		timeoutMinutes: 65,
 		minDiskGb: 5,
 		ptsTimesToRun: 2,
-		ptsConverge: true,
 		defaultReplicas: 3,
 		dimensions: ["system"],
 		metrics: ["pybench_milliseconds", "sqlite_speedtest_seconds", "git_seconds"],
@@ -146,8 +146,9 @@ export const SUITES = {
 		commands: ["mise run benchmark:pgbench:all"],
 	},
 	// The memory dimension: STREAM (Copy/Scale/Add/Triad). Short — STREAM runs in a couple of minutes.
-	// Long-synthetic tier, PTS CONVERGES in-sandbox (R=3): STREAM is a tight, cheap bandwidth loop, so
-	// DynamicRunCount settles fast and even a long convergence fits the 30-min budget many times over.
+	// Long-synthetic tier, and the ONLY suite that PTS CONVERGES in-sandbox by default (R=3): STREAM is a
+	// tight, cheap bandwidth loop, so DynamicRunCount settles fast and even a long convergence fits the
+	// 30-min budget many times over (unlike system, whose SQLite leg timed convergence out in run #49).
 	// Three replicate sandboxes capture the between-machine bandwidth spread STREAM Copy is notorious for
 	// under noisy virtualization (STREAM's between-machine CV is the highest of the synthetics, so R=3
 	// leaves it the widest-interval headline — convergence tightens within-machine, replicas the rest).

--- a/packages/schema/src/suites.ts
+++ b/packages/schema/src/suites.ts
@@ -41,12 +41,16 @@ export interface Suite {
 	/**
 	 * Let PTS's own statistical convergence (DynamicRunCount) choose the in-sandbox pass count instead of
 	 * pinning it to {@link ptsTimesToRun}: run a minimum, then keep going while the standard deviation
-	 * across passes exceeds PTS's threshold, up to PTS's cap. This is the WITHIN-machine tightening knob —
-	 * the default for the synthetic suites, where repeating a fixed workload converges cheaply. The
-	 * realworld suites deliberately leave this off: their measured phase is a cold install/build (k=1, the
-	 * cold-start IS the metric), so between-machine spread is captured by {@link defaultReplicas} replicate
-	 * sandboxes, not by re-running the install inside one sandbox. The `pts_passes` dispatch input
-	 * (BENCH_PTS_PASSES) overrides this per run — a fixed number, or `converge` to force it everywhere.
+	 * across passes exceeds PTS's threshold, up to PTS's cap. This is the WITHIN-machine tightening knob,
+	 * set only on the light, bounded synthetic suites whose passes are cheap and stable (system, memory) —
+	 * there convergence settles fast and stays well inside the budget. It is deliberately LEFT OFF wherever
+	 * a variable pass count is unsafe or wrong: the I/O suites (disk — fio's DynamicRunCount blew up to
+	 * 20-40 runs and exhausted the suite historically; pgbench — each pass re-runs an expensive scale-100
+	 * init), the network suite (a documented "trial count stays 2" rule + per-run WAN server reselection),
+	 * the heavy cpu-node build, and the realworld suites (k=1 — the cold install/build IS the metric). Those
+	 * take their tightness from {@link defaultReplicas} replicate sandboxes instead. The `pts_passes`
+	 * dispatch input (BENCH_PTS_PASSES) overrides this per run — a fixed number, or `converge` to force
+	 * convergence on every suite (accepting the budget risk on the I/O suites).
 	 */
 	ptsConverge?: boolean;
 	/**
@@ -83,13 +87,14 @@ export const SUITES = {
 	"cpu-node": {
 		setupPts: true,
 		setupNode: true,
-		// Long-synthetic tier: PTS converges the in-sandbox passes (within-machine) × R=3 replicate
-		// sandboxes (between-machine). Budgets are provisional ceilings re-derived after a calibration
-		// dispatch; ptsTimesToRun (k=2) is the documented fixed fallback if convergence is turned off.
+		// Long-synthetic tier: k=2 FIXED in-sandbox passes × R=3 replicate sandboxes (between-machine).
+		// Convergence is deliberately OFF: node-web-tooling is a heavy multi-minute build per pass, so the
+		// 60-min command budget is sized for a fixed k=2 — letting PTS's DynamicRunCount add passes could
+		// overrun it. Its between-machine spread rides the R=3 replicates; a calibration dispatch can
+		// re-derive a converge-safe budget before enabling it. Budgets are provisional ceilings.
 		commandTimeoutMinutes: 60,
 		timeoutMinutes: 70,
 		ptsTimesToRun: 2,
-		ptsConverge: true,
 		defaultReplicas: 3,
 		// cpu-node runs only `benchmark:cpu:node` (node-web-tooling); it is the sole cpu-dimension suite.
 		dimensions: ["cpu"],
@@ -99,7 +104,8 @@ export const SUITES = {
 	// The system dimension (pybench + sqlite + git): PyBench (Python interpreter) + SQLite Speedtest
 	// (single-result wildcards) + common Git operations over a fixed GTK checkout. PostgreSQL (pgbench)
 	// is its own leg below — split out so its ~1.5 GB dataset and long runtime don't gate the quick
-	// system probes. Long-synthetic tier (PTS converges in-sandbox; R=3).
+	// system probes. Long-synthetic tier, PTS CONVERGES in-sandbox (R=3): pybench/sqlite/git are light,
+	// stable, few-minute passes, so DynamicRunCount settles quickly and stays well inside the 55-min budget.
 	system: {
 		setupPts: true,
 		commandTimeoutMinutes: 55,
@@ -117,14 +123,15 @@ export const SUITES = {
 	// (same topology on every provider). At k=2 it makes four timed passes (two per mode), each with its
 	// own scale-100 `pgbench -i`; that and the ~1.5 GB dataset set the budget and disk floor. Requires the
 	// baked image (postgres pre-built, libicu-dev present); on a stock image the from-source postgres
-	// build lands inside this budget too. Long-synthetic tier (PTS converges in-sandbox; R=3).
+	// build lands inside this budget too. Long-synthetic tier: k=2 FIXED (R=3). Convergence is OFF —
+	// each timed pass re-runs an expensive scale-100 `pgbench -i`, so a variable DynamicRunCount count
+	// would blow the 75-min budget the four fixed passes already fill; R=3 replicates carry the spread.
 	pgbench: {
 		setupPts: true,
 		commandTimeoutMinutes: 75,
 		timeoutMinutes: 85,
 		minDiskGb: 5,
 		ptsTimesToRun: 2,
-		ptsConverge: true,
 		defaultReplicas: 3,
 		dimensions: ["system"],
 		metrics: [
@@ -136,9 +143,11 @@ export const SUITES = {
 		commands: ["mise run benchmark:pgbench:all"],
 	},
 	// The memory dimension: STREAM (Copy/Scale/Add/Triad). Short — STREAM runs in a couple of minutes.
-	// Long-synthetic tier (PTS converges in-sandbox; R=3): three replicate sandboxes capture the
-	// between-machine bandwidth spread STREAM Copy is notorious for under noisy virtualization (STREAM's
-	// between-machine CV is the highest of the synthetics, so R=3 leaves it the widest-interval headline).
+	// Long-synthetic tier, PTS CONVERGES in-sandbox (R=3): STREAM is a tight, cheap bandwidth loop, so
+	// DynamicRunCount settles fast and even a long convergence fits the 30-min budget many times over.
+	// Three replicate sandboxes capture the between-machine bandwidth spread STREAM Copy is notorious for
+	// under noisy virtualization (STREAM's between-machine CV is the highest of the synthetics, so R=3
+	// leaves it the widest-interval headline — convergence tightens within-machine, replicas the rest).
 	memory: {
 		setupPts: true,
 		commandTimeoutMinutes: 30,
@@ -158,14 +167,15 @@ export const SUITES = {
 	// exactly one of the two and the mode travels in the metric identity (the contract allows declared-
 	// but-unrun combinations). At k=2 the budget covers two timed passes of each of the four 60s scenarios
 	// plus the hardlink profile; fio writes 1 GiB test files, hence the raised disk floor. Long-synthetic
-	// tier (k=2, R=3).
+	// tier: k=2 FIXED (R=3). Convergence is OFF here for a hard-won reason — PTS's DynamicRunCount expanded
+	// noisy fio cases to 20-40 runs and exhausted the suite (lib/bench.sh), the exact blowup the fixed pin
+	// was introduced to prevent; the between-machine spread rides the R=3 replicates instead.
 	disk: {
 		setupPts: true,
 		commandTimeoutMinutes: 65,
 		timeoutMinutes: 75,
 		minDiskGb: 4,
 		ptsTimesToRun: 2,
-		ptsConverge: true,
 		defaultReplicas: 3,
 		dimensions: ["disk"],
 		metrics: [
@@ -199,13 +209,15 @@ export const SUITES = {
 	// daytona-vm/novita/blaxel died in the memory watchdog and the surviving numbers were
 	// buffer-fill transients); the old leaves and profiles stay runnable manually via
 	// benchmark:network:all. The suite task also runs latency/DNS and a small GitHub
-	// control-download probe as raw provenance. Long-synthetic tier (PTS converges in-sandbox; R=3).
+	// control-download probe as raw provenance. Long-synthetic tier: k=2 FIXED (R=3). Convergence is OFF —
+	// the vendored iperf profile carries a documented "trial count stays 2" repo rule (its install.sh), and
+	// the WAN leg reselects the closest public server per run, so repeated in-sandbox passes aren't
+	// like-for-like; the between-machine spread rides the R=3 replicates instead.
 	network: {
 		setupPts: true,
 		commandTimeoutMinutes: 30,
 		timeoutMinutes: 40,
 		ptsTimesToRun: 2,
-		ptsConverge: true,
 		defaultReplicas: 3,
 		dimensions: ["network"],
 		metrics: [

--- a/packages/schema/src/suites.ts
+++ b/packages/schema/src/suites.ts
@@ -104,8 +104,11 @@ export const SUITES = {
 	// The system dimension (pybench + sqlite + git): PyBench (Python interpreter) + SQLite Speedtest
 	// (single-result wildcards) + common Git operations over a fixed GTK checkout. PostgreSQL (pgbench)
 	// is its own leg below — split out so its ~1.5 GB dataset and long runtime don't gate the quick
-	// system probes. Long-synthetic tier, PTS CONVERGES in-sandbox (R=3): pybench/sqlite/git are light,
-	// stable, few-minute passes, so DynamicRunCount settles quickly and stays well inside the 55-min budget.
+	// system probes. Long-synthetic tier, PTS CONVERGES in-sandbox (R=3): pybench and git are light and
+	// stable. SQLite Speedtest touches I/O, so on a noisy provider its variance can add a few DynamicRunCount
+	// passes — but each pass is short and the 55-min budget (sized for k=2) has multiples of headroom, so
+	// convergence stays inside it; a converge-enabled calibration dispatch should confirm this on slow
+	// providers before the bare default is fully trusted (budgets are provisional ceilings anyway).
 	system: {
 		setupPts: true,
 		commandTimeoutMinutes: 55,
@@ -235,8 +238,8 @@ export const SUITES = {
 	// isn't a cold install) × R=12 replicate sandboxes (n = 12 per case) — replicas, not repeats, carry
 	// the between-machine variance users actually experience. R was raised 5→12 from the committed
 	// dataset's between-run variance: at R=5 the headline cold-install/build metrics' 95% CI half-width
-	// ran ~8% (median) to ~18% (p75 of metric×provider series); R=12 brings that to ~5%/~11%, separating
-	// providers that differ by more than ~12% (near-ties under ~5% stay ties at any practical R). Budgets
+	// ran ~8% (median) to ~18% (p75 of metric×provider series); R=12 brings that to ~5%/~12% (√(5/12)≈0.65×),
+	// separating providers that differ by more than ~12% (near-ties under ~5% stay ties at any practical R). Budgets
 	// are provisional ceilings re-derived after a calibration dispatch. mastra's task matrix is the narrowest (scoped to
 	// packages/core) but its monorepo has the largest install/build footprint — hence the biggest
 	// minDiskGb. better-auth and openclaw run their full task matrices including a cold pnpm install

--- a/packages/schema/src/suites.ts
+++ b/packages/schema/src/suites.ts
@@ -42,16 +42,17 @@ export interface Suite {
 	 * Let PTS's own statistical convergence (DynamicRunCount) choose the in-sandbox pass count instead of
 	 * pinning it to {@link ptsTimesToRun}: run a minimum, then keep going while the standard deviation
 	 * across passes exceeds PTS's threshold, up to PTS's cap. This is the WITHIN-machine tightening knob,
-	 * set only on `memory` — STREAM is a tiny, tight bandwidth loop, so DynamicRunCount settles fast and
-	 * even a long convergence fits its 30-min budget many times over. It is deliberately LEFT OFF wherever
-	 * a variable pass count is unsafe or wrong: the I/O suites (disk — fio's DynamicRunCount blew up to
-	 * 20-40 runs and exhausted the suite historically; pgbench — each pass re-runs an expensive scale-100
-	 * init), the system suite (SQLite's I/O variance timed convergence out at its 55-min budget on
+	 * set on the two suites whose passes converge cheaply and predictably: `memory` (STREAM is a tiny,
+	 * tight bandwidth loop) and `cpu-node` (CPU-bound, so low within-machine variance settles DynamicRunCount
+	 * near its ~3-pass minimum — no runaway, and its budget is bumped for headroom). It is deliberately LEFT
+	 * OFF wherever a variable pass count is unsafe or wrong: the I/O suites (disk — fio's DynamicRunCount
+	 * blew up to 20-40 runs and exhausted the suite historically; pgbench — each pass re-runs an expensive
+	 * scale-100 init), the system suite (SQLite's I/O variance timed convergence out at its 55-min budget on
 	 * modal-gvisor in run #49), the network suite (a documented "trial count stays 2" rule + per-run WAN
-	 * server reselection), the heavy cpu-node build, and the realworld suites (k=1 — the cold install/build
-	 * IS the metric). Those take their tightness from {@link defaultReplicas} replicate sandboxes instead.
-	 * The `pts_passes` dispatch input (BENCH_PTS_PASSES) overrides this per run — a fixed number, or
-	 * `converge` to force convergence on every suite (accepting the budget risk on the I/O + system suites).
+	 * server reselection), and the realworld suites (k=1 — the cold install/build IS the metric). Those take
+	 * their tightness from {@link defaultReplicas} replicate sandboxes instead. The `pts_passes` dispatch
+	 * input (BENCH_PTS_PASSES) overrides this per run — a fixed number, or `converge` to force convergence
+	 * on every suite (accepting the budget risk on the I/O + system suites).
 	 */
 	ptsConverge?: boolean;
 	/**
@@ -88,14 +89,17 @@ export const SUITES = {
 	"cpu-node": {
 		setupPts: true,
 		setupNode: true,
-		// Long-synthetic tier: k=2 FIXED in-sandbox passes × R=3 replicate sandboxes (between-machine).
-		// Convergence is deliberately OFF: node-web-tooling is a heavy multi-minute build per pass, so the
-		// 60-min command budget is sized for a fixed k=2 — letting PTS's DynamicRunCount add passes could
-		// overrun it. Its between-machine spread rides the R=3 replicates; a calibration dispatch can
-		// re-derive a converge-safe budget before enabling it. Budgets are provisional ceilings.
-		commandTimeoutMinutes: 60,
-		timeoutMinutes: 70,
+		// Long-synthetic tier, PTS CONVERGES in-sandbox (R=3): node-web-tooling is CPU-bound, so its
+		// within-machine variance is low and DynamicRunCount settles near its ~3-pass minimum rather than
+		// expanding toward a runaway tail (the I/O suites' failure mode) — and ~3 passes is exactly what
+		// cpu-node ran before PR #129 lowered it to k=2, so the budget has handled it. The command/sandbox
+		// budgets are bumped 60→75 / 70→85 (still under realworld's 90) for headroom on the extra
+		// convergence pass on slower providers; gVisor taxes I/O, not CPU, so cpu-node isn't exposed to
+		// the SQLite-style overrun that timed `system` out. Between-machine spread still rides R=3.
+		commandTimeoutMinutes: 75,
+		timeoutMinutes: 85,
 		ptsTimesToRun: 2,
+		ptsConverge: true,
 		defaultReplicas: 3,
 		// cpu-node runs only `benchmark:cpu:node` (node-web-tooling); it is the sole cpu-dimension suite.
 		dimensions: ["cpu"],
@@ -146,9 +150,9 @@ export const SUITES = {
 		commands: ["mise run benchmark:pgbench:all"],
 	},
 	// The memory dimension: STREAM (Copy/Scale/Add/Triad). Short — STREAM runs in a couple of minutes.
-	// Long-synthetic tier, and the ONLY suite that PTS CONVERGES in-sandbox by default (R=3): STREAM is a
-	// tight, cheap bandwidth loop, so DynamicRunCount settles fast and even a long convergence fits the
-	// 30-min budget many times over (unlike system, whose SQLite leg timed convergence out in run #49).
+	// Long-synthetic tier, PTS CONVERGES in-sandbox (R=3) — one of the two converging suites (with cpu-node):
+	// STREAM is a tight, cheap bandwidth loop, so DynamicRunCount settles fast and even a long convergence
+	// fits the 30-min budget many times over (unlike system, whose SQLite leg timed convergence out in run #49).
 	// Three replicate sandboxes capture the between-machine bandwidth spread STREAM Copy is notorious for
 	// under noisy virtualization (STREAM's between-machine CV is the highest of the synthetics, so R=3
 	// leaves it the widest-interval headline — convergence tightens within-machine, replicas the rest).

--- a/packages/schema/src/suites.ts
+++ b/packages/schema/src/suites.ts
@@ -34,8 +34,21 @@ export interface Suite {
 	 * In-sandbox repeat count (k): how many timed PTS passes each case runs (FORCE_TIMES_TO_RUN), threaded
 	 * into the harness preamble. Absent → the harness default ({@link DEFAULT_PTS_TIMES_TO_RUN}, k=2).
 	 * Captures WITHIN-machine noise cheaply; between-machine variance is the {@link defaultReplicas} axis.
+	 * Ignored when {@link ptsConverge} is set (convergence chooses the count itself); still the documented
+	 * fixed fallback the suite would use if convergence were turned off.
 	 */
 	ptsTimesToRun?: number;
+	/**
+	 * Let PTS's own statistical convergence (DynamicRunCount) choose the in-sandbox pass count instead of
+	 * pinning it to {@link ptsTimesToRun}: run a minimum, then keep going while the standard deviation
+	 * across passes exceeds PTS's threshold, up to PTS's cap. This is the WITHIN-machine tightening knob —
+	 * the default for the synthetic suites, where repeating a fixed workload converges cheaply. The
+	 * realworld suites deliberately leave this off: their measured phase is a cold install/build (k=1, the
+	 * cold-start IS the metric), so between-machine spread is captured by {@link defaultReplicas} replicate
+	 * sandboxes, not by re-running the install inside one sandbox. The `pts_passes` dispatch input
+	 * (BENCH_PTS_PASSES) overrides this per run — a fixed number, or `converge` to force it everywhere.
+	 */
+	ptsConverge?: boolean;
 	/**
 	 * Replicate sandboxes (R) to run per (provider, suite) — the between-sandbox axis the CI matrix fans
 	 * out. R replicates capture host placement / noisy-neighbour variance the in-sandbox repeats can't.
@@ -70,11 +83,13 @@ export const SUITES = {
 	"cpu-node": {
 		setupPts: true,
 		setupNode: true,
-		// Long-synthetic tier: k=2 in-sandbox passes × R=3 replicate sandboxes (n = 6 per case). Budgets
-		// are provisional ceilings re-derived after a calibration dispatch.
+		// Long-synthetic tier: PTS converges the in-sandbox passes (within-machine) × R=3 replicate
+		// sandboxes (between-machine). Budgets are provisional ceilings re-derived after a calibration
+		// dispatch; ptsTimesToRun (k=2) is the documented fixed fallback if convergence is turned off.
 		commandTimeoutMinutes: 60,
 		timeoutMinutes: 70,
 		ptsTimesToRun: 2,
+		ptsConverge: true,
 		defaultReplicas: 3,
 		// cpu-node runs only `benchmark:cpu:node` (node-web-tooling); it is the sole cpu-dimension suite.
 		dimensions: ["cpu"],
@@ -84,13 +99,14 @@ export const SUITES = {
 	// The system dimension (pybench + sqlite + git): PyBench (Python interpreter) + SQLite Speedtest
 	// (single-result wildcards) + common Git operations over a fixed GTK checkout. PostgreSQL (pgbench)
 	// is its own leg below — split out so its ~1.5 GB dataset and long runtime don't gate the quick
-	// system probes. Long-synthetic tier (k=2, R=3).
+	// system probes. Long-synthetic tier (PTS converges in-sandbox; R=3).
 	system: {
 		setupPts: true,
 		commandTimeoutMinutes: 55,
 		timeoutMinutes: 65,
 		minDiskGb: 5,
 		ptsTimesToRun: 2,
+		ptsConverge: true,
 		defaultReplicas: 3,
 		dimensions: ["system"],
 		metrics: ["pybench_milliseconds", "sqlite_speedtest_seconds", "git_seconds"],
@@ -101,13 +117,14 @@ export const SUITES = {
 	// (same topology on every provider). At k=2 it makes four timed passes (two per mode), each with its
 	// own scale-100 `pgbench -i`; that and the ~1.5 GB dataset set the budget and disk floor. Requires the
 	// baked image (postgres pre-built, libicu-dev present); on a stock image the from-source postgres
-	// build lands inside this budget too. Long-synthetic tier (k=2, R=3).
+	// build lands inside this budget too. Long-synthetic tier (PTS converges in-sandbox; R=3).
 	pgbench: {
 		setupPts: true,
 		commandTimeoutMinutes: 75,
 		timeoutMinutes: 85,
 		minDiskGb: 5,
 		ptsTimesToRun: 2,
+		ptsConverge: true,
 		defaultReplicas: 3,
 		dimensions: ["system"],
 		metrics: [
@@ -119,13 +136,15 @@ export const SUITES = {
 		commands: ["mise run benchmark:pgbench:all"],
 	},
 	// The memory dimension: STREAM (Copy/Scale/Add/Triad). Short — STREAM runs in a couple of minutes.
-	// Long-synthetic tier (k=2, R=3): three replicate sandboxes capture the between-machine bandwidth
-	// spread STREAM Copy is notorious for under noisy virtualization.
+	// Long-synthetic tier (PTS converges in-sandbox; R=3): three replicate sandboxes capture the
+	// between-machine bandwidth spread STREAM Copy is notorious for under noisy virtualization (STREAM's
+	// between-machine CV is the highest of the synthetics, so R=3 leaves it the widest-interval headline).
 	memory: {
 		setupPts: true,
 		commandTimeoutMinutes: 30,
 		timeoutMinutes: 40,
 		ptsTimesToRun: 2,
+		ptsConverge: true,
 		defaultReplicas: 3,
 		dimensions: ["memory"],
 		metrics: ["stream_type_copy", "stream_type_scale", "stream_type_add", "stream_type_triad"],
@@ -146,6 +165,7 @@ export const SUITES = {
 		timeoutMinutes: 75,
 		minDiskGb: 4,
 		ptsTimesToRun: 2,
+		ptsConverge: true,
 		defaultReplicas: 3,
 		dimensions: ["disk"],
 		metrics: [
@@ -179,12 +199,13 @@ export const SUITES = {
 	// daytona-vm/novita/blaxel died in the memory watchdog and the surviving numbers were
 	// buffer-fill transients); the old leaves and profiles stay runnable manually via
 	// benchmark:network:all. The suite task also runs latency/DNS and a small GitHub
-	// control-download probe as raw provenance. Long-synthetic tier (k=2, R=3).
+	// control-download probe as raw provenance. Long-synthetic tier (PTS converges in-sandbox; R=3).
 	network: {
 		setupPts: true,
 		commandTimeoutMinutes: 30,
 		timeoutMinutes: 40,
 		ptsTimesToRun: 2,
+		ptsConverge: true,
 		defaultReplicas: 3,
 		dimensions: ["network"],
 		metrics: [
@@ -198,9 +219,13 @@ export const SUITES = {
 	},
 	// The realworld dimension (ENG-135/136/137/138): real OSS repos run through their own CI tasks,
 	// each a repo-local PTS profile with a Task option axis. Real-world tier: k=1 in-sandbox pass (the
-	// cold-start IS the metric) × R=5 replicate sandboxes (n = 5 per case) — replicas, not repeats,
-	// carry the between-machine variance users actually experience. Budgets are provisional ceilings
-	// re-derived after a calibration dispatch. mastra's task matrix is the narrowest (scoped to
+	// cold-start IS the metric — NO in-sandbox convergence; re-running the install inside one sandbox
+	// isn't a cold install) × R=12 replicate sandboxes (n = 12 per case) — replicas, not repeats, carry
+	// the between-machine variance users actually experience. R was raised 5→12 from the committed
+	// dataset's between-run variance: at R=5 the headline cold-install/build metrics' 95% CI half-width
+	// ran ~8% (median) to ~18% (p75 of metric×provider series); R=12 brings that to ~5%/~11%, separating
+	// providers that differ by more than ~12% (near-ties under ~5% stay ties at any practical R). Budgets
+	// are provisional ceilings re-derived after a calibration dispatch. mastra's task matrix is the narrowest (scoped to
 	// packages/core) but its monorepo has the largest install/build footprint — hence the biggest
 	// minDiskGb. better-auth and openclaw run their full task matrices including a cold pnpm install
 	// and a full build.
@@ -211,7 +236,7 @@ export const SUITES = {
 		timeoutMinutes: 90,
 		minDiskGb: 30,
 		ptsTimesToRun: 1,
-		defaultReplicas: 5,
+		defaultReplicas: 12,
 		dimensions: ["realworld"],
 		metrics: [
 			"realworld_mastra_task_git_clone",
@@ -233,7 +258,7 @@ export const SUITES = {
 		timeoutMinutes: 90,
 		minDiskGb: 10,
 		ptsTimesToRun: 1,
-		defaultReplicas: 5,
+		defaultReplicas: 12,
 		dimensions: ["realworld"],
 		metrics: [
 			"realworld_better_auth_task_git_clone",
@@ -256,7 +281,7 @@ export const SUITES = {
 		timeoutMinutes: 90,
 		minDiskGb: 25,
 		ptsTimesToRun: 1,
-		defaultReplicas: 5,
+		defaultReplicas: 12,
 		dimensions: ["realworld"],
 		metrics: [
 			"realworld_openclaw_task_git_clone",


### PR DESCRIPTION
## What & why

Builds on the configurable-inputs PR (#260) by raising the **defaults** so a bare `bench-matrix` dispatch is already statistically powered for tight, non-overlapping confidence intervals — no per-run flags required. Defaults-only change: the run shape a bare dispatch produces is the only behavior that moves.

### 1. Default provider set gains `modal-vm` + `blaxel`
New default: `e2b, daytona-vm, blaxel, modal-gvisor, modal-vm, novita` (was `e2b, daytona-vm, modal-gvisor, novita`). Both `modal-vm` (Modal's gVisor-free microVM) and `blaxel` have produced comparable committed results, so they graduate from opt-in. `daytona-container` stays opt-in.

### 2. Realworld replicates 5 → 12 (data-informed)
Mined the committed dataset (`data/dataset/runs/*.json`). Those runs are all `n=1`, so between-machine variance is estimated from **run-to-run** spread (each run is a fresh sandbox — a proxy for host/fleet variation). For the realworld headline metrics (`cold_install`, `build`):

| R | median metric CI half-width | p75 metric CI half-width |
|---|---|---|
| 5 (old) | ~8% | ~18% |
| **12 (new)** | **~5%** | **~12%** |

(√(5/12) ≈ 0.65×.) R=12 separates providers differing by more than ~12%. Two honest limits baked into the code: **genuine near-ties (< ~5% apart) stay ties at any practical R** (e.g. modal vs e2b on better-auth build differ by 0.8%), and **network-bound `git_clone` is pathological** (100–230% CV, unseparable, not a headline). Synthetic suites stay **R=3** (between-run CV ~7% median).

### 3. PTS converges by default — only where it settles safely (`cpu-node` + `memory`)
New per-suite `Suite.ptsConverge`. Convergence (`DynamicRunCount`) is enabled on the two suites whose passes converge cheaply and predictably:

- **`memory`** — STREAM is a tiny, bounded bandwidth loop that settles fast and fits its 30-min budget many times over.
- **`cpu-node`** — node-web-tooling is CPU-bound, so within-machine variance is low and `DynamicRunCount` settles near its ~3-pass minimum (exactly what cpu-node ran before PR #129 lowered it to k=2) rather than expanding toward a runaway tail. Budget bumped 60→75 / 70→85 min for headroom (still under realworld's 90, so the timeout gate is unchanged); gVisor taxes I/O not CPU, so it isn't exposed to the SQLite-style overrun below.

It is **withheld** from every other suite, because a variable pass count there is unsafe, wrong, or budget-breaking — a scope tightened under review + live evidence:

- **`disk` (fio)** — `DynamicRunCount` historically expanded noisy fio cases to **20–40 runs** and exhausted the suite (`lib/bench.sh`).
- **`system`** — its **SQLite Speedtest** is I/O-touching; a converge run (**live run #49**) drove `DynamicRunCount` past the **55-min budget** and **timed `system` out on `modal-gvisor`**. A default must not fail on a default provider, so `system` stays fixed.
- **`pgbench`** — each pass re-runs an expensive scale-100 `pgbench -i`; its 75-min budget fits exactly four fixed passes.
- **`network` (iperf)** — documented **"trial count stays 2"** rule (`iperf-1.2.0/install.sh`) + per-run WAN server reselection.
- **realworld** — k=1; the cold install/build IS the metric.

Everything fixed takes its tightness from replicates, not in-sandbox repeats. `resolvePtsPassPolicy` reads the per-suite policy; the `pts_passes`/`BENCH_PTS_PASSES` dispatch input is a global override (a number, or `converge`, forced on every suite — as live run #49 exercised). A calibration dispatch that re-derives converge-safe budgets could re-enable `system` (or others) later.

## Testing & review
- `typecheck`, `lint` (`--error-on-warnings`), and all touched suites green: `execute.test.ts` (per-suite converge default + override precedence), `suites.test.ts` (R=12, converging set = `{cpu-node, memory}`), `plan-replicates.test.ts`, and the workflow drift gates (incl. the timeout gate — cpu-node's 85-min budget stays under realworld's 90).
- Two adversarial review passes (correctness/ops-risk + statistics/docs) confirmed the GHA matrix limits (72 cells/matrix ≪ 256), drift gates, and `resolvePtsPassPolicy` edge cases; a **live matrix run** then confirmed the `system` timeout, driving the converge scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)