### PR TITLE
docs(readme): fix stale target spec (4 vCPU) and refresh drifted sections

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,8 @@ docs/       methodology, ADRs, CI & secrets
 | `@repo/test-utils`          | schema                                          | —                                   |
 | `@repo/repo-checks`         | —                                               | —                                   |
 
-`results` deliberately depends on `schema` only — it must normalize without any provider SDK, and
+`results` deliberately depends on `schema` alone among workspace packages — it must normalize
+without any provider SDK, and
 `@repo/repo-checks` enforces that no package reaches across boundaries or into another package's
 private `lib/`.
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Compare top sandbox providers on the same pinned machine shape for real developer and CI/CD workloads.
 
-**Same target everywhere:** 2 vCPU · 8 GiB RAM · 40 GB disk. One headline metric per dimension, ranked with honest statistics.
+**Same target everywhere:** 4 vCPU · 8 GiB RAM · 40 GB disk. One headline metric per dimension, ranked with honest statistics.
 
 ## Why real-world workflows?
 
@@ -45,7 +45,7 @@ workspace sources natively. There is no compile step: `bun install` → `typeche
 packages/   importable libraries   — scope @sandbox-benchmarks/*
   schema/       shared types + arktype schemas (bottom of the DAG)
   providers/    provider adapters → schema + computesdk
-  templates/    per-provider template builders (one export subpath each)
+  templates/    per-provider template builders + toolchain Docker images (images/)
   harness/      benchmark timing → providers + schema
   results/      normalization → schema only (no provider SDKs)
 apps/
@@ -54,6 +54,10 @@ tooling/        dev-only            — scope @repo/*
   tsconfig/     shared source-first TS configs (config-only)
   test-utils/   provider conformance suite factory
   repo-checks/  boundary + package-meta invariant tests
+lib/        in-sandbox benchmark runner (bench.sh) + vendored PTS profiles
+data/       committed benchmark dataset (published run results)
+scripts/    maintainer scripts (dataset backfill, leaderboard update)
+docs/       methodology, ADRs, CI & secrets
 ```
 
 ## Dependency DAG (enforced)
@@ -61,11 +65,11 @@ tooling/        dev-only            — scope @repo/*
 | Member                      | Internal deps (`workspace:*`)                   | External (catalog)                  |
 |-----------------------------|-------------------------------------------------|-------------------------------------|
 | `@sandbox-benchmarks/schema`     | —                                               | `arktype`                           |
-| `@sandbox-benchmarks/providers`  | schema                                          | `computesdk` (`catalog:computesdk`) |
+| `@sandbox-benchmarks/providers`  | schema                                          | `arktype`, computesdk packages (`catalog:computesdk`) |
 | `@sandbox-benchmarks/templates`  | providers, schema                               | `computesdk` (`catalog:computesdk`) |
 | `@sandbox-benchmarks/harness`    | providers, schema                               | —                                   |
-| `@sandbox-benchmarks/results`    | schema                                          | —                                   |
-| `@sandbox-benchmarks/cli` (app)  | schema, providers, templates, harness, results  | `dotenv`                            |
+| `@sandbox-benchmarks/results`    | schema                                          | `arktype`, XML tooling (`catalog:xml`) |
+| `@sandbox-benchmarks/cli` (app)  | schema, providers, templates, harness, results  | `dotenv`, `@actions/core`, provider SDKs (`catalog:computesdk`) |
 | `@repo/tsconfig`            | —                                               | —                                   |
 | `@repo/test-utils`          | schema                                          | —                                   |
 | `@repo/repo-checks`         | —                                               | —                                   |
@@ -87,28 +91,37 @@ private `lib/`.
 | `bun run lint:fix:unsafe` | `biome check . --fix --unsafe` — also applies behavior-changing fixes; review the diff. |
 | `bun run spell`      | `typos` — source-code spell check (run it before pushing).              |
 | `bun run spell:fix`  | `typos --write-changes` — apply typos' suggested corrections.            |
+| `bun run lint:shell` | `shellcheck` on the repo's shell scripts (toolchain images, `lib/`, mise tasks). |
+| `bun run lint:docker`| `hadolint` on the toolchain-image Dockerfiles (`packages/templates/images`). |
+| `bun run smoke`      | Boot each provider's sandbox from the baked image and smoke-test it (providers without credentials are skipped). |
+| `bun run check:catalog-drift` | Fails if the generated PTS catalog drifted from the vendored profiles. |
 
 Run a single bin during development: `bun apps/cli/src/bin/plan-matrix.ts`.
 
 ## Toolchain (mise)
 
 Non-Bun tools are version-pinned in [`mise.toml`](mise.toml) and managed with
-[mise](https://mise.jdx.dev). Today that's [`typos`](https://github.com/crate-ci/typos), the
-spell checker behind `bun run spell`. After cloning, run `mise install` (and `mise trust` once) so
-the pinned binaries are available; `bun run spell` invokes typos through `mise exec`, so it always
-uses the pinned version. mise fetches from official release sources with checksum verification — no
-npm republisher and no install-time postinstall.
+[mise](https://mise.jdx.dev): [`typos`](https://github.com/crate-ci/typos) (spell check),
+`shellcheck` + `hadolint` (shell/Dockerfile lint for the toolchain images), and
+`actionlint` + `zizmor` (workflow lint + security audit, run by the `ci-lint` workflow). After
+cloning, run `mise install` (and `mise trust` once) so the pinned binaries are available; the
+`bun run` wrappers invoke these tools through `mise exec`, so they always use the pinned versions.
+mise fetches from official release sources with checksum verification — no npm republisher and no
+install-time postinstall.
 
 ## Continuous integration
 
 `.github/workflows/ci.yml` runs the command contract on every pull request and every push to
 `main`: `bun install --frozen-lockfile --ignore-scripts` → `bun run lint` (the Biome gate) →
-`bun run typecheck` → `bun run test` → `bun run spell` (typos, set up via
-[mise](https://mise.jdx.dev)). The same checks run locally, so green-on-your-machine means
-green-in-CI.
+`bun run lint:shell` → `bun run lint:docker` → `bun run typecheck` → `bun run test` →
+`bun run check:catalog-drift` → `bun run spell` (typos, set up via [mise](https://mise.jdx.dev)).
+A separate `ci-lint.yml` lints the workflows themselves (actionlint + zizmor). The same checks run
+locally, so green-on-your-machine means green-in-CI.
 
-Fork PRs get the hosted CI gate only. Self-hosted jobs and anything that needs provider credentials
-run only from this repository, on `main`, behind Environment [`privileged`](./docs/ci-secrets.md).
+CI runs on a maintainer-controlled runner, so it never executes fork-PR code — the gate runs only
+for pushes and same-repo pull requests. Anything that needs provider credentials additionally runs
+only from `main`, behind Environment [`privileged`](./docs/ci-secrets.md); pull requests never
+receive provider secrets.
 
 ## Git hooks (pre-commit)
 


### PR DESCRIPTION
## What

The README's headline claimed the benchmarks pin **2 vCPU**, but the actual target spec has been **4 vCPU / 8 GiB / 40 GB** since #208 (`TARGET_SPEC` in `packages/schema/src/providers.ts` — raised because Blaxel couples CPU to RAM, so 8 GiB forces exactly 4 vCPU).

While auditing the rest of the README against the repo, several other sections had drifted:

- **Command contract**: adds `smoke`, `lint:shell`, `lint:docker`, `check:catalog-drift`
- **Toolchain (mise)**: now lists shellcheck, hadolint, actionlint, zizmor alongside typos
- **Dependency DAG table**: `providers` also uses arktype; `results` uses the xml catalog (still no provider SDKs); `cli` also uses `@actions/core` + provider SDKs
- **Layout**: adds the missing top-level `lib/`, `data/`, `scripts/`, `docs/` and `packages/templates/images/`
- **CI**: full step list, mentions `ci-lint.yml`, and corrects the fork-PR claim — the gate runs on a maintainer-controlled runner and skips fork PRs; the old text claimed fork PRs get a hosted CI gate that doesn't exist

## Notes

- ADR 0005 still says 2 vCPU — left as-is since ADRs are historical records.
- The fork-PR wording now describes current behavior; whether fork PRs *should* get a hosted gate is a separate workflow decision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix README to reflect the actual benchmark target (4 vCPU · 8 GiB · 40 GB) and realign drifted sections with the current repo and CI.

- **Bug Fixes**
  - Correct headline target spec to 4 vCPU.
  - Sync command contract and `mise` toolchain: add `smoke`, `lint:shell`, `lint:docker`, `check:catalog-drift`; include `shellcheck`, `hadolint`, `actionlint`, `zizmor`.
  - Refresh dependency DAG, layout, and CI docs: table now shows providers `arktype` + `catalog:computesdk`; results `arktype` + `catalog:xml`; CLI `@actions/core` + provider SDKs. Qualify results dep prose to match the table. Add missing top-level folders and templates images. List full CI steps and `ci-lint.yml`; clarify the maintainer-run gate skips fork PRs.

<sup>Written for commit 7e934c2e72739c70f74ba8cb30fd4f981f5278a6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/starslingdev/hpc-sandbox-benchmarks/pull/265?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated benchmark hardware documentation to specify four vCPUs.
  * Clarified the repository layout and dependency relationships.
  * Documented additional development and CI commands.
  * Expanded the tooling and continuous integration documentation, including linting, smoke tests, catalog-drift checks, fork pull request behavior, and credential requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->