### PR TITLE
fix(harness): gate the suite on sandbox readiness, and record pre-benchmark failures

### DIFF
--- a/packages/harness/src/index.test.ts
+++ b/packages/harness/src/index.test.ts
@@ -5,7 +5,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import type { DirectProvider, ProviderConfig } from "@sandbox-benchmarks/providers";
 import type { Suite } from "@sandbox-benchmarks/schema";
-import { parseGapMarker } from "@sandbox-benchmarks/schema";
+import { parseGapMarker, sandboxFailureMarkerFile } from "@sandbox-benchmarks/schema";
 import {
 	benchmarkLifecycle,
 	createSuiteSandbox,
@@ -21,6 +21,7 @@ import {
 } from "./index.ts";
 import type { CommandResult, SandboxHandle } from "./lib/execute.ts";
 import type { LifecycleCompute } from "./lib/lifecycle.ts";
+import { READINESS_CMD } from "./lib/readiness.ts";
 
 // A transport capability for the test fixtures — capped-with-detach, matching a single-round-trip
 // provider; none of these tests exercise real exec, so the exact values are inert here.
@@ -300,6 +301,8 @@ function makeSandbox(opts: {
 	benchmarkFails?: boolean;
 	collectFails?: boolean;
 	collectFiles?: Record<string, string>;
+	/** Never answer the readiness probe — a sandbox whose image never finishes pulling. */
+	neverReady?: boolean;
 	destroyed: { hit: boolean };
 }): SandboxHandle {
 	// Results of detached steps, keyed by their /tmp/<tag> so the cat-polls can read them back.
@@ -320,6 +323,8 @@ function makeSandbox(opts: {
 		command.match(new RegExp(`/tmp/(bench-[0-9a-f-]+)\\.${ext}`))?.[1];
 	return {
 		async runCommand(command) {
+			// Readiness probe: issued raw (not through StepRunner), so it arrives unwrapped by the preamble.
+			if (command === READINESS_CMD) return { exitCode: opts.neverReady ? 1 : 0 };
 			// Detached launch (double-fork, so it carries nohup): compute the wrapped step's result and
 			// stash it under its tag for the cat-polls. The launch itself just acknowledges.
 			if (command.includes("nohup")) {
@@ -503,6 +508,35 @@ describe("runSuiteOnSandbox (orchestration + teardown)", () => {
 		await runSuiteOnSandbox(sandbox, ctx(suite({ setupPts: true }), resultsDir));
 		expect(existsSync(join(resultsDir, "pts_node-web-tooling.xml"))).toBe(true);
 		expect(destroyed.hit).toBe(true);
+	});
+
+	it("fails a sandbox that never becomes ready, before charging the wait to the first step", async () => {
+		// The namespace regression: create() resolves while the image is still pulling, so the FIRST step
+		// absorbed the wait and reported it as its own timeout ("check free disk timed out after 60s" —
+		// nothing to do with disk). The readiness gate must own that wait and name it, and a sandbox that
+		// never answers must still be torn down and recorded as a failed cell, not a disk skip.
+		const resultsDir = freshDir();
+		const destroyed = { hit: false };
+		const sandbox = makeSandbox({ destroyed, neverReady: true });
+		await expect(
+			runSuiteOnSandbox(sandbox, {
+				...ctx(suite({}), resultsDir),
+				readiness: {
+					maxAttempts: 3,
+					retryDelayMs: 0,
+					probeTimeoutMs: 5,
+					delay: () => Promise.resolve(),
+				},
+			}),
+		).rejects.toThrow(/never ready/);
+		expect(destroyed.hit).toBe(true);
+		const marker = join(resultsDir, sandboxFailureMarkerFile("daytona-vm", "cpu-node"));
+		expect(parseGapMarker(marker, JSON.parse(readFileSync(marker, "utf8")), "daytona-vm")).toEqual({
+			scope: "suite",
+			id: "cpu-node",
+			outcome: "failed",
+			reason: expect.stringMatching(/never ready/),
+		});
 	});
 
 	it("tears the sandbox down when an invalid ptsTimesToRun (k < 1) fails preamble construction", async () => {

--- a/packages/harness/src/index.ts
+++ b/packages/harness/src/index.ts
@@ -404,10 +404,8 @@ export async function runSuiteOnSandbox(
 		// hangs instead of erroring. Without this gate the pull is charged to whatever step happens to run
 		// first, which reports the pull as that step's timeout — a 60s "check free disk" failure that had
 		// nothing to do with disk. Pre-baked providers answer the first probe and pay one round-trip.
-		const readiness = ctx.readiness ?? SUITE_READINESS;
-		if (!(await waitUntilReady(sandbox, readiness))) {
-			throw new Error(neverReadyReason(readiness.maxAttempts ?? SUITE_READINESS.maxAttempts));
-		}
+		const readiness = await waitUntilReady(sandbox, ctx.readiness ?? SUITE_READINESS);
+		if (!readiness.ready) throw new Error(neverReadyReason(readiness.attempts));
 		if (suite.minDiskGb) {
 			// Measure free space where the disk-heavy suites actually write, not the sandbox root. The
 			// heavy PTS data (realworld clones/builds, pgbench cluster, fio test files, installed-tests)

--- a/packages/harness/src/index.ts
+++ b/packages/harness/src/index.ts
@@ -11,6 +11,8 @@ import { MIN, resolvePtsPassPolicy, StepRunner, withTimeout } from "./lib/execut
 import { time } from "./lib/internal.ts";
 import type { LifecycleAggregate, LifecycleCompute } from "./lib/lifecycle.ts";
 import { aggregateLifecycle, measureLifecycle } from "./lib/lifecycle.ts";
+import type { WaitUntilReadyOptions } from "./lib/readiness.ts";
+import { neverReadyReason, waitUntilReady } from "./lib/readiness.ts";
 import { DIR, OBSERVED_SPECS_SCRIPT, REPO_REF, REPO_URL, setupSteps } from "./lib/setup.ts";
 
 // Re-export the lifecycle measurement surface so consumers import it from the package root, never
@@ -346,6 +348,20 @@ export async function createSuiteSandbox(
 	}
 }
 
+/**
+ * Readiness budget for the suite path, which must cover a COLD IMAGE PULL and not just a container
+ * handshake: the toolchain image is ~1.5 GiB compressed across 7 layers, and a provider that pulls it
+ * at create time (Namespace) is fetching all of it while the harness holds a resolved handle. Sized
+ * generously in wall time because the alternative is a false failure on a sandbox that was merely slow
+ * to arrive, and it costs a ready provider exactly one probe. The lifecycle driver keeps its own
+ * tighter default — there, how long readiness takes is the measurement, not an obstacle.
+ */
+const SUITE_READINESS = {
+	maxAttempts: 30,
+	retryDelayMs: 2_000,
+	probeTimeoutMs: 20_000,
+} as const;
+
 /** The already-resolved context {@link runSuiteOnSandbox} runs against. */
 export interface SuiteRunContext {
 	suite: Suite;
@@ -354,6 +370,9 @@ export interface SuiteRunContext {
 	resultsDir: string;
 	/** The provider's exec transport capability — drives the per-step sync/detached choice. */
 	transport: ProviderTransport;
+	/** Readiness budget override. Defaults to {@link SUITE_READINESS}; tests inject a fast one so a
+	 *  never-ready case doesn't really sleep out the live budget. */
+	readiness?: WaitUntilReadyOptions;
 }
 
 /**
@@ -378,6 +397,17 @@ export async function runSuiteOnSandbox(
 		// a throw before the try would leak the already-created sandbox.
 		const runner = new StepRunner(sandbox, transport, undefined, resolvePtsPassPolicy(suite));
 		runner.phase = "setup";
+		// Wait for the sandbox to become usable before the first real step. `create()` resolving means
+		// ALLOCATED, not ready: a provider that cold-pulls its image at create time (Namespace takes the
+		// toolchain OCI ref straight through `options.image` — it has no template to pre-bake) is still
+		// fetching image layers when its handle resolves, and an exec against a not-yet-running container
+		// hangs instead of erroring. Without this gate the pull is charged to whatever step happens to run
+		// first, which reports the pull as that step's timeout — a 60s "check free disk" failure that had
+		// nothing to do with disk. Pre-baked providers answer the first probe and pay one round-trip.
+		const readiness = ctx.readiness ?? SUITE_READINESS;
+		if (!(await waitUntilReady(sandbox, readiness))) {
+			throw new Error(neverReadyReason(readiness.maxAttempts ?? SUITE_READINESS.maxAttempts));
+		}
 		if (suite.minDiskGb) {
 			// Measure free space where the disk-heavy suites actually write, not the sandbox root. The
 			// heavy PTS data (realworld clones/builds, pgbench cluster, fio test files, installed-tests)
@@ -454,6 +484,14 @@ export async function runSuiteOnSandbox(
 				`Suite "${suiteName}" on ${providerName} produced no pts_*.xml — PTS likely failed silently`,
 			);
 		}
+	} catch (err) {
+		// Everything before the benchmark — the readiness gate, the disk probe, every setup step — used to
+		// throw straight past the marker-writing exit below, because only the benchmark and collect blocks
+		// recorded into `suiteError`. A cell that died in setup therefore left NO trace in the raw tree:
+		// the published Run could not tell "this provider broke during setup" from "never scheduled", and
+		// the job log was the only evidence. Route those throws through the same single exit; the disk
+		// gate's deliberate `return` (a skip, already marked) is untouched.
+		suiteError = err;
 	} finally {
 		await destroySandbox(sandbox);
 	}

--- a/packages/harness/src/lib/lifecycle.test.ts
+++ b/packages/harness/src/lib/lifecycle.test.ts
@@ -280,6 +280,8 @@ describe("measureLifecycle", () => {
 		// sandbox that never answered the first of them can hang forever — undoing the bounded readiness
 		// gate. The driver must bail out instead. Accounting still has to be complete: an abandoned Metric
 		// with no Sample AND no gap reads downstream as "never scheduled", not "the sandbox never came up".
+		// Snapshot + list present and payload on by default, so every abandoned op is one this config
+		// WOULD have attempted — the all-failed case. The skip-preserving case is the test below.
 		const { compute, calls } = fakeCompute({ notReadyFor: 99, withSnapshot: true, withList: true });
 		const { samples, gaps } = await measureLifecycle(compute, {
 			provider: "e2b",
@@ -308,6 +310,34 @@ describe("measureLifecycle", () => {
 		expect(countByOp(samples)[HARNESS_METRIC_IDS.spawn]).toBe(1);
 		expect(calls.order).toContain("destroy");
 		expect(countByOp(samples)[HARNESS_METRIC_IDS.teardown]).toBe(1);
+	});
+
+	it("keeps disabled and unsupported operations SKIPPED on a never-ready sandbox", async () => {
+		// A readiness outage must not relabel decisions as provider failures. Payload is off, and this fake
+		// exposes neither list nor snapshot — none of those calls was ever going to happen, so reporting
+		// them as failures would publish a control-plane outage that did not occur, and the leaderboard
+		// would read it as provider unreliability.
+		const { compute } = fakeCompute({ notReadyFor: 99 });
+		const { gaps } = await measureLifecycle(compute, {
+			provider: "e2b",
+			payload: false,
+			snapshot: false,
+			readinessMaxAttempts: 2,
+			now: fastClock(),
+			delay: noDelay,
+		});
+		for (const [metricId, pattern] of [
+			[HARNESS_METRIC_IDS.execPayload64k, /disabled/],
+			[HARNESS_METRIC_IDS.controlPlaneList, /no sandbox list operation/],
+			[HARNESS_METRIC_IDS.snapshot, /disabled/],
+		] as const) {
+			expect(outcomeFor(gaps, metricId)).toBe("skipped");
+			expect(reasonFor(gaps, metricId)).toMatch(pattern);
+		}
+		// The genuinely-prevented ops are still failures — the outage is not swallowed either.
+		expect(outcomeFor(gaps, HARNESS_METRIC_IDS.exec)).toBe("failed");
+		expect(outcomeFor(gaps, HARNESS_METRIC_IDS.controlPlaneInfo)).toBe("failed");
+		expect(outcomeFor(gaps, HARNESS_METRIC_IDS.coldStart)).toBe("failed");
 	});
 
 	it("fails every failed control-plane probe but keeps measuring", async () => {

--- a/packages/harness/src/lib/lifecycle.test.ts
+++ b/packages/harness/src/lib/lifecycle.test.ts
@@ -40,13 +40,17 @@ function fakeCompute(opts: FakeOptions = {}): { compute: LifecycleCompute; calls
 		sandboxId: "sb-1",
 		async runCommand(command) {
 			calls.order.push(`exec:${command}`);
-			if (opts.failExec) throw new Error("exec boom");
-			// The readiness loop probes "echo ok"; report it not-ready (exitCode 1) for the first
-			// `notReadyFor` attempts so the cold-start retry path is exercised without a real SDK.
+			// Readiness is resolved BEFORE failExec so the two are independently controllable: the driver
+			// now stops at an unready sandbox, so "ready, but the measured exec throws" (failExec) and
+			// "never became ready" (notReadyFor) are different scenarios and a fake that conflated them
+			// could not express the first at all.
 			if (command === "echo ok") {
 				readinessProbes += 1;
-				if (opts.notReadyFor && readinessProbes <= opts.notReadyFor) return { exitCode: 1 };
+				return {
+					exitCode: opts.notReadyFor && readinessProbes <= opts.notReadyFor ? 1 : 0,
+				};
 			}
+			if (opts.failExec) throw new Error("exec boom");
 			return { exitCode: 0 };
 		},
 		async getInfo() {
@@ -252,12 +256,11 @@ describe("measureLifecycle", () => {
 	});
 
 	it("turns a mid-chain exec failure into a failed gap and still tears down", async () => {
-		// A throwing runCommand also fails every readiness probe, so cap attempts + inject a no-op delay
-		// to keep the retry loop fast.
+		// A READY sandbox whose measured exec throws — the mid-chain best-effort contract. (A sandbox that
+		// never goes ready is the separate case below; the driver stops there rather than probing on.)
 		const { compute, calls } = fakeCompute({ failExec: true });
 		const { samples, gaps } = await measureLifecycle(compute, {
 			provider: "e2b",
-			readinessMaxAttempts: 2,
 			now: fastClock(),
 			delay: noDelay,
 		});
@@ -265,10 +268,44 @@ describe("measureLifecycle", () => {
 		expect(countByOp(samples)[HARNESS_METRIC_IDS.exec]).toBeUndefined();
 		expect(reasonFor(gaps, HARNESS_METRIC_IDS.exec)).toBe("exec boom");
 		expect(outcomeFor(gaps, HARNESS_METRIC_IDS.exec)).toBe("failed");
-		// A never-ready sandbox fails both readiness Metrics.
-		expect(reasonFor(gaps, HARNESS_METRIC_IDS.coldStart)).toMatch(/never ready/);
-		expect(outcomeFor(gaps, HARNESS_METRIC_IDS.coldStart)).toBe("failed");
+		// Readiness succeeded here, so the cold-start Metrics are real Samples, not gaps.
+		expect(countByOp(samples)[HARNESS_METRIC_IDS.coldStart]).toBe(1);
 		// Teardown still ran and was sampled.
+		expect(calls.order).toContain("destroy");
+		expect(countByOp(samples)[HARNESS_METRIC_IDS.teardown]).toBe(1);
+	});
+
+	it("stops probing an unready sandbox, but still fails every abandoned Metric and tears down", async () => {
+		// Every probe below readiness execs against the sandbox and those calls are unbounded, so on a
+		// sandbox that never answered the first of them can hang forever — undoing the bounded readiness
+		// gate. The driver must bail out instead. Accounting still has to be complete: an abandoned Metric
+		// with no Sample AND no gap reads downstream as "never scheduled", not "the sandbox never came up".
+		const { compute, calls } = fakeCompute({ notReadyFor: 99, withSnapshot: true, withList: true });
+		const { samples, gaps } = await measureLifecycle(compute, {
+			provider: "e2b",
+			readinessMaxAttempts: 2,
+			now: fastClock(),
+			delay: noDelay,
+		});
+		// Bailed out: only the readiness probes ran — no exec, no getInfo, no list, no snapshot.
+		expect(calls.order.filter((c) => c === "exec:echo ok").length).toBe(2);
+		expect(calls.order.some((c) => c === "getInfo" || c === "list")).toBe(false);
+		expect(calls.order.some((c) => c.startsWith("snapshot:"))).toBe(false);
+		// ...yet every Metric it abandoned carries a FAILED gap naming the readiness outage.
+		for (const metricId of [
+			HARNESS_METRIC_IDS.coldStart,
+			HARNESS_METRIC_IDS.firstExec,
+			HARNESS_METRIC_IDS.exec,
+			HARNESS_METRIC_IDS.execPayload64k,
+			HARNESS_METRIC_IDS.controlPlaneInfo,
+			HARNESS_METRIC_IDS.controlPlaneList,
+			HARNESS_METRIC_IDS.snapshot,
+		]) {
+			expect(outcomeFor(gaps, metricId)).toBe("failed");
+			expect(reasonFor(gaps, metricId)).toMatch(/never ready/);
+		}
+		// The bookends survive the early return: spawn was sampled before it, teardown by the `finally`.
+		expect(countByOp(samples)[HARNESS_METRIC_IDS.spawn]).toBe(1);
 		expect(calls.order).toContain("destroy");
 		expect(countByOp(samples)[HARNESS_METRIC_IDS.teardown]).toBe(1);
 	});

--- a/packages/harness/src/lib/lifecycle.ts
+++ b/packages/harness/src/lib/lifecycle.ts
@@ -23,6 +23,18 @@ import { aggregate, HARNESS_METRIC_IDS } from "@sandbox-benchmarks/schema";
 import { now as defaultNow, time } from "./internal.ts";
 import { neverReadyReason, waitUntilReady } from "./readiness.ts";
 
+/**
+ * Per-probe ceiling for THIS driver's readiness loop, deliberately far tighter than the suite path's.
+ *
+ * The two callers want opposite things. The suite path must absorb a cold multi-GiB image pull, so it
+ * accepts a long per-probe wait. Here, how long readiness takes IS the measurement, over
+ * `readinessMaxAttempts` (40) × `readinessRetryDelayMs` (250ms) ≈ a 10s window — and this driver runs
+ * once per cold-start iteration (5 by default). Inheriting the readiness module's generous default
+ * would let an all-hanging probe run turn one iteration into ~13.5 minutes and a default benchmark into
+ * over an hour before producing any result. A healthy probe answers in tens of ms, so 2s is slack
+ * enough to be sure the sandbox isn't up while keeping the pathological case ~90s per iteration.
+ */
+const READINESS_PROBE_TIMEOUT_MS = 2_000;
 /** Writes exactly 64KiB (65536 bytes) to stdout — exec overhead including output streaming. Uses `tr`
  *  rather than `base64` so the stream is exactly 64KiB, matching the metric's name (base64 expands the
  *  input ~33%, overstating the payload). */
@@ -168,6 +180,7 @@ export async function measureLifecycle(
 		const readiness = await waitUntilReady(sandbox, {
 			maxAttempts: readinessMaxAttempts,
 			retryDelayMs: readinessRetryDelayMs,
+			probeTimeoutMs: READINESS_PROBE_TIMEOUT_MS,
 			delay,
 		});
 		const readyAt = readiness.ready ? clock() : undefined;
@@ -179,6 +192,22 @@ export async function measureLifecycle(
 			const reason = neverReadyReason(readiness.attempts);
 			fail(HARNESS_METRIC_IDS.firstExec, reason);
 			fail(HARNESS_METRIC_IDS.coldStart, reason);
+			// Stop here. Every probe below execs against this sandbox, and those calls are UNBOUNDED — on a
+			// sandbox that never answered, the first of them can hang indefinitely and undo the bounded gate
+			// above. Bail out, but keep the accounting honest: each Metric this abandons gets a FAILED gap
+			// naming the readiness outage, because the alternative (no Sample, no gap) reads downstream as
+			// "never scheduled" rather than "the sandbox never came up". `finally` still tears down and
+			// still samples teardown — the returned arrays are the same references it appends to.
+			for (const metricId of [
+				HARNESS_METRIC_IDS.exec,
+				HARNESS_METRIC_IDS.execPayload64k,
+				HARNESS_METRIC_IDS.controlPlaneInfo,
+				HARNESS_METRIC_IDS.controlPlaneList,
+				HARNESS_METRIC_IDS.snapshot,
+			]) {
+				fail(metricId, reason);
+			}
+			return { samples, gaps };
 		} else {
 			sample(HARNESS_METRIC_IDS.firstExec, floor(readyAt - createdAt));
 			sample(HARNESS_METRIC_IDS.coldStart, floor(readyAt - t0));

--- a/packages/harness/src/lib/lifecycle.ts
+++ b/packages/harness/src/lib/lifecycle.ts
@@ -35,6 +35,16 @@ import { neverReadyReason, waitUntilReady } from "./readiness.ts";
  * enough to be sure the sandbox isn't up while keeping the pathological case ~90s per iteration.
  */
 const READINESS_PROBE_TIMEOUT_MS = 2_000;
+/**
+ * Reasons an operation produced no Sample by DECISION rather than by outage — the `skip` arm's wording.
+ * Named because two paths file them now (the live chain and the never-ready bail-out), and a probe
+ * filed under the wrong arm, or under drifted wording, is exactly the misreport the skip/fail split
+ * exists to prevent.
+ */
+const PAYLOAD_DISABLED = "64KiB payload exec disabled for this run";
+const NO_LIST_OP = "provider SDK exposes no sandbox list operation";
+const SNAPSHOT_DISABLED = "snapshot measurement disabled for this run";
+const NO_SNAPSHOT_OP = "provider SDK exposes no snapshot operation";
 /** Writes exactly 64KiB (65536 bytes) to stdout — exec overhead including output streaming. Uses `tr`
  *  rather than `base64` so the stream is exactly 64KiB, matching the metric's name (base64 expands the
  *  input ~33%, overstating the payload). */
@@ -194,19 +204,27 @@ export async function measureLifecycle(
 			fail(HARNESS_METRIC_IDS.coldStart, reason);
 			// Stop here. Every probe below execs against this sandbox, and those calls are UNBOUNDED — on a
 			// sandbox that never answered, the first of them can hang indefinitely and undo the bounded gate
-			// above. Bail out, but keep the accounting honest: each Metric this abandons gets a FAILED gap
+			// above. Bail out, but keep the accounting honest: a Metric this abandons gets a FAILED gap
 			// naming the readiness outage, because the alternative (no Sample, no gap) reads downstream as
 			// "never scheduled" rather than "the sandbox never came up". `finally` still tears down and
 			// still samples teardown — the returned arrays are the same references it appends to.
-			for (const metricId of [
-				HARNESS_METRIC_IDS.exec,
-				HARNESS_METRIC_IDS.execPayload64k,
-				HARNESS_METRIC_IDS.controlPlaneInfo,
-				HARNESS_METRIC_IDS.controlPlaneList,
-				HARNESS_METRIC_IDS.snapshot,
-			]) {
-				fail(metricId, reason);
-			}
+			//
+			// Crucially, only for what this configuration WOULD have attempted. A disabled payload, an SDK
+			// with no list, an absent snapshot manager: those are the same decisions they always were, and
+			// the readiness outage doesn't turn them into provider failures. Blanket-failing them would
+			// publish a control-plane outage for calls that were never going to happen — the exact
+			// skip/fail inversion the two helpers above exist to prevent.
+			fail(HARNESS_METRIC_IDS.exec, reason);
+			// One gap, not `controlPlaneSamples` of them: the live path records a gap per failed probe, but
+			// no probe ran here and N copies of one fact is noise, not fidelity.
+			fail(HARNESS_METRIC_IDS.controlPlaneInfo, reason);
+			if (wantPayload) fail(HARNESS_METRIC_IDS.execPayload64k, reason);
+			else skip(HARNESS_METRIC_IDS.execPayload64k, PAYLOAD_DISABLED);
+			if (compute.sandbox.list) fail(HARNESS_METRIC_IDS.controlPlaneList, reason);
+			else skip(HARNESS_METRIC_IDS.controlPlaneList, NO_LIST_OP);
+			if (!wantSnapshot) skip(HARNESS_METRIC_IDS.snapshot, SNAPSHOT_DISABLED);
+			else if (!compute.snapshot) skip(HARNESS_METRIC_IDS.snapshot, NO_SNAPSHOT_OP);
+			else fail(HARNESS_METRIC_IDS.snapshot, reason);
 			return { samples, gaps };
 		} else {
 			sample(HARNESS_METRIC_IDS.firstExec, floor(readyAt - createdAt));
@@ -220,7 +238,7 @@ export async function measureLifecycle(
 		if (wantPayload) {
 			await step(HARNESS_METRIC_IDS.execPayload64k, () => sandbox.runCommand(PAYLOAD_CMD));
 		} else {
-			skip(HARNESS_METRIC_IDS.execPayload64k, "64KiB payload exec disabled for this run");
+			skip(HARNESS_METRIC_IDS.execPayload64k, PAYLOAD_DISABLED);
 		}
 
 		// Control-plane read: getInfo, sampled within this one (cheap) sandbox to build a distribution
@@ -239,16 +257,16 @@ export async function measureLifecycle(
 				await step(HARNESS_METRIC_IDS.controlPlaneList, () => listSandboxes());
 			}
 		} else {
-			skip(HARNESS_METRIC_IDS.controlPlaneList, "provider SDK exposes no sandbox list operation");
+			skip(HARNESS_METRIC_IDS.controlPlaneList, NO_LIST_OP);
 		}
 
 		// Snapshot: when requested and the SDK exposes a snapshot manager. Best-effort delete afterwards
 		// so a measured snapshot never leaks into the account.
 		const snapshots = compute.snapshot;
 		if (!wantSnapshot) {
-			skip(HARNESS_METRIC_IDS.snapshot, "snapshot measurement disabled for this run");
+			skip(HARNESS_METRIC_IDS.snapshot, SNAPSHOT_DISABLED);
 		} else if (!snapshots) {
-			skip(HARNESS_METRIC_IDS.snapshot, "provider SDK exposes no snapshot operation");
+			skip(HARNESS_METRIC_IDS.snapshot, NO_SNAPSHOT_OP);
 		} else {
 			try {
 				const snap = await time(() => snapshots.create(sandbox.sandboxId));

--- a/packages/harness/src/lib/lifecycle.ts
+++ b/packages/harness/src/lib/lifecycle.ts
@@ -165,18 +165,18 @@ export async function measureLifecycle(
 		// Readiness: retry a trivial exec until it returns exitCode 0 — the FIRST success marks a usable
 		// sandbox. cold_start (t0→ready) is the honest cold start spawn alone can't see; first_exec
 		// (create→ready) isolates the readiness wait. A probe that throws counts as not-ready and retries.
-		const ready = await waitUntilReady(sandbox, {
+		const readiness = await waitUntilReady(sandbox, {
 			maxAttempts: readinessMaxAttempts,
 			retryDelayMs: readinessRetryDelayMs,
 			delay,
 		});
-		const readyAt = ready ? clock() : undefined;
+		const readyAt = readiness.ready ? clock() : undefined;
 		if (readyAt === undefined) {
 			// Never went ready: record both readiness Metrics as FAILURES rather than fabricate a timing.
 			// The sandbox was spawned and probed to exhaustion and never came up — that is the loudest
 			// reliability signal this harness can produce, and calling it a "skip" would file it as a
 			// deliberate omission.
-			const reason = neverReadyReason(readinessMaxAttempts);
+			const reason = neverReadyReason(readiness.attempts);
 			fail(HARNESS_METRIC_IDS.firstExec, reason);
 			fail(HARNESS_METRIC_IDS.coldStart, reason);
 		} else {

--- a/packages/harness/src/lib/lifecycle.ts
+++ b/packages/harness/src/lib/lifecycle.ts
@@ -21,9 +21,8 @@
 import type { Aggregates, HarnessMetricId, RawRun, ResultGap } from "@sandbox-benchmarks/schema";
 import { aggregate, HARNESS_METRIC_IDS } from "@sandbox-benchmarks/schema";
 import { now as defaultNow, time } from "./internal.ts";
+import { neverReadyReason, waitUntilReady } from "./readiness.ts";
 
-/** The trivial command whose first successful (exitCode 0) return marks the sandbox ready. */
-const READINESS_CMD = "echo ok";
 /** Writes exactly 64KiB (65536 bytes) to stdout — exec overhead including output streaming. Uses `tr`
  *  rather than `base64` so the stream is exactly 64KiB, matching the metric's name (base64 expands the
  *  input ~33%, overstating the payload). */
@@ -166,26 +165,18 @@ export async function measureLifecycle(
 		// Readiness: retry a trivial exec until it returns exitCode 0 — the FIRST success marks a usable
 		// sandbox. cold_start (t0→ready) is the honest cold start spawn alone can't see; first_exec
 		// (create→ready) isolates the readiness wait. A probe that throws counts as not-ready and retries.
-		let readyAt: number | undefined;
-		for (let attempt = 1; attempt <= readinessMaxAttempts; attempt++) {
-			let ready = false;
-			try {
-				ready = (await sandbox.runCommand(READINESS_CMD)).exitCode === 0;
-			} catch {
-				ready = false;
-			}
-			if (ready) {
-				readyAt = clock();
-				break;
-			}
-			if (attempt < readinessMaxAttempts) await delay(readinessRetryDelayMs);
-		}
+		const ready = await waitUntilReady(sandbox, {
+			maxAttempts: readinessMaxAttempts,
+			retryDelayMs: readinessRetryDelayMs,
+			delay,
+		});
+		const readyAt = ready ? clock() : undefined;
 		if (readyAt === undefined) {
 			// Never went ready: record both readiness Metrics as FAILURES rather than fabricate a timing.
 			// The sandbox was spawned and probed to exhaustion and never came up — that is the loudest
 			// reliability signal this harness can produce, and calling it a "skip" would file it as a
 			// deliberate omission.
-			const reason = `sandbox never ready: no successful "${READINESS_CMD}" in ${readinessMaxAttempts} attempts`;
+			const reason = neverReadyReason(readinessMaxAttempts);
 			fail(HARNESS_METRIC_IDS.firstExec, reason);
 			fail(HARNESS_METRIC_IDS.coldStart, reason);
 		} else {

--- a/packages/harness/src/lib/readiness.test.ts
+++ b/packages/harness/src/lib/readiness.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from "bun:test";
+import { neverReadyReason, READINESS_CMD, waitUntilReady } from "./readiness.ts";
+
+/** A fake whose probes resolve/hang/fail on demand, recording every command it was asked to run. */
+function fakeSandbox(outcomes: Array<"ok" | "fail" | "throw" | "hang">) {
+	const commands: string[] = [];
+	let probe = 0;
+	return {
+		commands,
+		sandbox: {
+			runCommand: (command: string) => {
+				commands.push(command);
+				const outcome = outcomes[probe++] ?? "ok";
+				if (outcome === "throw") return Promise.reject(new Error("sandbox not up"));
+				// Never settles — what an exec against a still-pulling container actually does.
+				if (outcome === "hang") return new Promise<{ exitCode: number }>(() => {});
+				return Promise.resolve({ exitCode: outcome === "ok" ? 0 : 1 });
+			},
+		},
+	};
+}
+
+// Tests must never really sleep, and a bounded probe must not really wait out its ceiling.
+const noDelay = () => Promise.resolve();
+
+describe("waitUntilReady", () => {
+	it("probes once when the sandbox is already up", async () => {
+		const { sandbox, commands } = fakeSandbox(["ok"]);
+		expect(await waitUntilReady(sandbox, { delay: noDelay })).toBe(true);
+		expect(commands).toEqual([READINESS_CMD]);
+	});
+
+	it("retries a non-zero or throwing probe until the sandbox answers", async () => {
+		const { sandbox, commands } = fakeSandbox(["fail", "throw", "ok"]);
+		expect(await waitUntilReady(sandbox, { delay: noDelay })).toBe(true);
+		expect(commands.length).toBe(3);
+	});
+
+	it("gives up at maxAttempts rather than spinning", async () => {
+		const { sandbox, commands } = fakeSandbox(["fail", "fail", "fail", "fail"]);
+		expect(await waitUntilReady(sandbox, { maxAttempts: 3, delay: noDelay })).toBe(false);
+		expect(commands.length).toBe(3);
+	});
+
+	it("bounds a HANGING probe and retries it — the namespace image-pull failure mode", async () => {
+		// The regression this module exists for: an exec issued against a not-yet-running container hangs
+		// instead of erroring (Namespace's RunCommandSync blocks server-side for the whole image pull).
+		// An unbounded probe would wait forever on attempt 1; a bounded one must cut it and try again.
+		const { sandbox, commands } = fakeSandbox(["hang", "hang", "ok"]);
+		expect(
+			await waitUntilReady(sandbox, { probeTimeoutMs: 5, retryDelayMs: 0, delay: noDelay }),
+		).toBe(true);
+		expect(commands.length).toBe(3);
+	});
+
+	it("reports never-ready as a bounded, self-describing reason", async () => {
+		const { sandbox } = fakeSandbox(["hang"]);
+		expect(await waitUntilReady(sandbox, { maxAttempts: 1, probeTimeoutMs: 5 })).toBe(false);
+		expect(neverReadyReason(1)).toContain(READINESS_CMD);
+		expect(neverReadyReason(1)).toMatch(/never ready/);
+	});
+
+	it("falls back to a finite bound when handed a non-finite one", async () => {
+		const { sandbox, commands } = fakeSandbox(["fail", "fail", "ok"]);
+		expect(await waitUntilReady(sandbox, { maxAttempts: Number.NaN, delay: noDelay })).toBe(true);
+		expect(commands.length).toBe(3);
+	});
+});

--- a/packages/harness/src/lib/readiness.test.ts
+++ b/packages/harness/src/lib/readiness.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, it } from "bun:test";
-import { neverReadyReason, READINESS_CMD, waitUntilReady } from "./readiness.ts";
+import {
+	DEFAULT_READINESS_ATTEMPTS,
+	neverReadyReason,
+	READINESS_CMD,
+	waitUntilReady,
+} from "./readiness.ts";
 
 /** A fake whose probes resolve/hang/fail on demand, recording every command it was asked to run. */
 function fakeSandbox(outcomes: Array<"ok" | "fail" | "throw" | "hang">) {
@@ -26,19 +31,19 @@ const noDelay = () => Promise.resolve();
 describe("waitUntilReady", () => {
 	it("probes once when the sandbox is already up", async () => {
 		const { sandbox, commands } = fakeSandbox(["ok"]);
-		expect(await waitUntilReady(sandbox, { delay: noDelay })).toBe(true);
+		expect((await waitUntilReady(sandbox, { delay: noDelay })).ready).toBe(true);
 		expect(commands).toEqual([READINESS_CMD]);
 	});
 
 	it("retries a non-zero or throwing probe until the sandbox answers", async () => {
 		const { sandbox, commands } = fakeSandbox(["fail", "throw", "ok"]);
-		expect(await waitUntilReady(sandbox, { delay: noDelay })).toBe(true);
+		expect((await waitUntilReady(sandbox, { delay: noDelay })).ready).toBe(true);
 		expect(commands.length).toBe(3);
 	});
 
 	it("gives up at maxAttempts rather than spinning", async () => {
 		const { sandbox, commands } = fakeSandbox(["fail", "fail", "fail", "fail"]);
-		expect(await waitUntilReady(sandbox, { maxAttempts: 3, delay: noDelay })).toBe(false);
+		expect((await waitUntilReady(sandbox, { maxAttempts: 3, delay: noDelay })).ready).toBe(false);
 		expect(commands.length).toBe(3);
 	});
 
@@ -48,21 +53,37 @@ describe("waitUntilReady", () => {
 		// An unbounded probe would wait forever on attempt 1; a bounded one must cut it and try again.
 		const { sandbox, commands } = fakeSandbox(["hang", "hang", "ok"]);
 		expect(
-			await waitUntilReady(sandbox, { probeTimeoutMs: 5, retryDelayMs: 0, delay: noDelay }),
+			(await waitUntilReady(sandbox, { probeTimeoutMs: 5, retryDelayMs: 0, delay: noDelay })).ready,
 		).toBe(true);
 		expect(commands.length).toBe(3);
 	});
 
 	it("reports never-ready as a bounded, self-describing reason", async () => {
 		const { sandbox } = fakeSandbox(["hang"]);
-		expect(await waitUntilReady(sandbox, { maxAttempts: 1, probeTimeoutMs: 5 })).toBe(false);
+		expect((await waitUntilReady(sandbox, { maxAttempts: 1, probeTimeoutMs: 5 })).ready).toBe(
+			false,
+		);
 		expect(neverReadyReason(1)).toContain(READINESS_CMD);
 		expect(neverReadyReason(1)).toMatch(/never ready/);
 	});
 
 	it("falls back to a finite bound when handed a non-finite one", async () => {
 		const { sandbox, commands } = fakeSandbox(["fail", "fail", "ok"]);
-		expect(await waitUntilReady(sandbox, { maxAttempts: Number.NaN, delay: noDelay })).toBe(true);
+		const result = await waitUntilReady(sandbox, { maxAttempts: Number.NaN, delay: noDelay });
+		expect(result.ready).toBe(true);
 		expect(commands.length).toBe(3);
+		// The reported bound is the NORMALIZED one, not the caller's: a diagnostic that says "in NaN
+		// attempts" (or "in 0 attempts" for a clamped 0) describes a probe run that never happened.
+		expect(result.attempts).toBe(DEFAULT_READINESS_ATTEMPTS);
+		expect(neverReadyReason(result.attempts)).not.toMatch(/NaN/);
+	});
+
+	it("reports the clamped bound when asked for fewer than one attempt", async () => {
+		const { sandbox, commands } = fakeSandbox(["fail"]);
+		const result = await waitUntilReady(sandbox, { maxAttempts: 0, delay: noDelay });
+		expect(result.ready).toBe(false);
+		// Clamped to a single real probe — so the reason must say 1, matching what was actually tried.
+		expect(commands.length).toBe(1);
+		expect(result.attempts).toBe(1);
 	});
 });

--- a/packages/harness/src/lib/readiness.ts
+++ b/packages/harness/src/lib/readiness.ts
@@ -69,16 +69,29 @@ export function neverReadyReason(maxAttempts: number): string {
 	return `sandbox never ready: no successful "${READINESS_CMD}" in ${maxAttempts} attempts`;
 }
 
+/** The outcome of a readiness wait, including the bound actually probed. */
+export interface ReadinessResult {
+	ready: boolean;
+	/**
+	 * The EFFECTIVE attempt bound — post-normalization, so it is what was really probed rather than
+	 * what the caller asked for. Callers report this in {@link neverReadyReason}: a raw override would
+	 * let the diagnostic claim "in 0 attempts" (clamped to 1) or "in NaN attempts" (defaulted to
+	 * {@link DEFAULT_READINESS_ATTEMPTS}), which is exactly the wrong thing for the one string whose
+	 * whole job is to say what was tried.
+	 */
+	attempts: number;
+}
+
 /**
- * Probe until the sandbox answers. Resolves `true` on the first successful probe, `false` once the
- * attempts are exhausted — never throws, so a caller decides whether not-ready is a failed metric (the
- * lifecycle driver) or a dead cell (the suite runner). A probe that throws, or that outlasts
+ * Probe until the sandbox answers. Resolves `ready: true` on the first successful probe, `false` once
+ * the attempts are exhausted — never throws, so a caller decides whether not-ready is a failed metric
+ * (the lifecycle driver) or a dead cell (the suite runner). A probe that throws, or that outlasts
  * `probeTimeoutMs`, counts as not-ready and is retried.
  */
 export async function waitUntilReady(
 	sandbox: ReadinessProbeSandbox,
 	options: WaitUntilReadyOptions = {},
-): Promise<boolean> {
+): Promise<ReadinessResult> {
 	const maxAttempts = finiteOr(options.maxAttempts, DEFAULT_READINESS_ATTEMPTS, 1);
 	const retryDelayMs = finiteOr(options.retryDelayMs, DEFAULT_READINESS_RETRY_DELAY_MS, 0);
 	const probeTimeoutMs = finiteOr(options.probeTimeoutMs, DEFAULT_READINESS_PROBE_TIMEOUT_MS, 1);
@@ -95,11 +108,11 @@ export async function waitUntilReady(
 				probeTimeoutMs,
 				`readiness probe timed out after ${Math.round(probeTimeoutMs / 1000)}s`,
 			);
-			if (result.exitCode === 0) return true;
+			if (result.exitCode === 0) return { ready: true, attempts: maxAttempts };
 		} catch {
 			// Not ready — fall through to the retry.
 		}
 		if (attempt < maxAttempts) await delay(retryDelayMs);
 	}
-	return false;
+	return { ready: false, attempts: maxAttempts };
 }

--- a/packages/harness/src/lib/readiness.ts
+++ b/packages/harness/src/lib/readiness.ts
@@ -1,0 +1,105 @@
+/**
+ * Sandbox readiness — the wait between `create()` resolving and the sandbox actually being able to run
+ * a command.
+ *
+ * `create()` resolves when the provider has ALLOCATED the sandbox, which is not the same as the sandbox
+ * being able to execute anything. A provider that boots a pre-baked artifact answers its first exec
+ * immediately (the image is already resident on their side: e2b/novita templates, Daytona snapshots,
+ * Modal's pushed image), so for years the harness got away with treating create-resolve as ready. A
+ * provider that cold-pulls an OCI ref AT create time does not: Namespace has no template/snapshot
+ * system and takes the toolchain ref straight through `options.image`, so when its handle resolves
+ * (~320ms, measured) it is still fetching ~1.5 GiB of image layers from GHCR.
+ *
+ * Nothing in that SDK can be asked instead of probed — `create` returns as soon as CreateInstance
+ * answers, and `getInfo` hardcodes `status: "running"` — so readiness is measured the only way that
+ * generalizes: retry a trivial command until the sandbox answers.
+ *
+ * Each probe is bounded ({@link DEFAULT_READINESS_PROBE_TIMEOUT_MS}) because an exec issued against a
+ * not-yet-running container HANGS rather than erroring — Namespace's RunCommandSync blocks server-side
+ * for as long as the pull takes — and an unbounded probe would wait out the whole step budget on its
+ * first attempt instead of retrying. That is exactly how this surfaced: a 60s `check free disk` timeout
+ * that read like a disk problem and was really the image pull.
+ *
+ * A provider that is ready on the first probe pays one round-trip, so the gate costs the pre-baked
+ * providers nothing.
+ */
+import { withTimeout } from "./execute.ts";
+
+/** The trivial command whose first successful (exitCode 0) return marks the sandbox ready. */
+export const READINESS_CMD = "echo ok";
+
+/** Probes per readiness wait before giving up. */
+export const DEFAULT_READINESS_ATTEMPTS = 40;
+/** Delay between failed probes. */
+export const DEFAULT_READINESS_RETRY_DELAY_MS = 250;
+/**
+ * Per-probe ceiling. Sized to be comfortably longer than a healthy exec round-trip (tens of ms) while
+ * still cutting a probe that hangs on a not-yet-running container, so the loop actually gets to retry.
+ */
+export const DEFAULT_READINESS_PROBE_TIMEOUT_MS = 20_000;
+
+/** Real wall-clock delay between readiness retries; swapped for a no-op in tests. */
+const realDelay = (ms: number): Promise<void> => new Promise((resolve) => setTimeout(resolve, ms));
+
+/** Clamp a caller-supplied bound: a NaN/Infinity would make the loop never run (or never stop). */
+const finiteOr = (value: number | undefined, fallback: number, min: number): number => {
+	const raw = value ?? fallback;
+	return Number.isFinite(raw) ? Math.max(min, Math.floor(raw)) : fallback;
+};
+
+/** The slice of a sandbox a readiness probe needs — structural, so both the suite runner's
+ *  `SandboxHandle` and the lifecycle driver's `LifecycleSandbox` satisfy it without a cast. */
+export interface ReadinessProbeSandbox {
+	runCommand(command: string, options?: { background?: boolean }): Promise<{ exitCode: number }>;
+}
+
+export interface WaitUntilReadyOptions {
+	/** Probes before giving up. Default {@link DEFAULT_READINESS_ATTEMPTS}. */
+	maxAttempts?: number;
+	/** Delay between failed probes, in ms. Default {@link DEFAULT_READINESS_RETRY_DELAY_MS}. */
+	retryDelayMs?: number;
+	/** Per-probe ceiling, in ms. Default {@link DEFAULT_READINESS_PROBE_TIMEOUT_MS}. */
+	probeTimeoutMs?: number;
+	/** Injectable delay so tests never really sleep. Default real `setTimeout`. */
+	delay?: (ms: number) => Promise<void>;
+}
+
+/** Why a readiness wait gave up — one phrasing, so both callers report the same thing. */
+export function neverReadyReason(maxAttempts: number): string {
+	return `sandbox never ready: no successful "${READINESS_CMD}" in ${maxAttempts} attempts`;
+}
+
+/**
+ * Probe until the sandbox answers. Resolves `true` on the first successful probe, `false` once the
+ * attempts are exhausted — never throws, so a caller decides whether not-ready is a failed metric (the
+ * lifecycle driver) or a dead cell (the suite runner). A probe that throws, or that outlasts
+ * `probeTimeoutMs`, counts as not-ready and is retried.
+ */
+export async function waitUntilReady(
+	sandbox: ReadinessProbeSandbox,
+	options: WaitUntilReadyOptions = {},
+): Promise<boolean> {
+	const maxAttempts = finiteOr(options.maxAttempts, DEFAULT_READINESS_ATTEMPTS, 1);
+	const retryDelayMs = finiteOr(options.retryDelayMs, DEFAULT_READINESS_RETRY_DELAY_MS, 0);
+	const probeTimeoutMs = finiteOr(options.probeTimeoutMs, DEFAULT_READINESS_PROBE_TIMEOUT_MS, 1);
+	const delay = options.delay ?? realDelay;
+
+	for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+		try {
+			const probe = sandbox.runCommand(READINESS_CMD);
+			// A timed-out probe leaves its exec dangling: swallow a late rejection here so an abandoned
+			// attempt can't surface as an unhandled rejection while the loop is still retrying.
+			probe.catch(() => {});
+			const result = await withTimeout(
+				probe,
+				probeTimeoutMs,
+				`readiness probe timed out after ${Math.round(probeTimeoutMs / 1000)}s`,
+			);
+			if (result.exitCode === 0) return true;
+		} catch {
+			// Not ready — fall through to the retry.
+		}
+		if (attempt < maxAttempts) await delay(retryDelayMs);
+	}
+	return false;
+}


### PR DESCRIPTION
Fixes the namespace smoke, which failed in [run 30311046810](https://github.com/starslingdev/hpc-sandbox-benchmarks/actions/runs/30311046810) on `Step "check free disk" timed out after 60s` — a message that had nothing to do with disk.

## What actually happened

Namespace's OIDC trust relationship is registered and `create()` works — the failure was downstream of both. `create()` resolved in ~320ms (measured from the job log) and the harness immediately issued its first exec. But `create()` resolving means **allocated**, not ready: Namespace has no template/snapshot system, so it takes the toolchain OCI ref straight through `options.image` and was still pulling ~1.5 GiB of layers (7 layers, compressed) from GHCR. An exec against a not-yet-running container **hangs** rather than erroring — `RunCommandSync` blocks server-side — so the pull was charged to whichever step happened to run first and surfaced as that step's timeout.

Every other provider masks this by booting something already resident on the provider side (e2b/novita templates, Daytona snapshots, Modal's pushed image). Namespace is the first provider that cold-pulls at create time — precisely because it has no bake artifact.

Nothing in `@computesdk/namespace` can be asked instead of probed: `create` returns as soon as `CreateInstance` answers, and `getInfo` hardcodes `status: "running"`.

## Changes

**1. Record pre-benchmark suite failures** (`ea32b70a`) — `runSuiteOnSandbox` only captured `suiteError` from the benchmark and collect blocks, so a throw from the disk probe or any setup step escaped past the marker-writing exit. That is the log's other line: *"no failed marker survived into the raw tree; this job log is the only trace"*. Independently valid — it applies to every provider, and it is why this failure was undiagnosable from the Run document.

**2. Readiness gate** (`265031c4`) — a shared `waitUntilReady` that probes until the sandbox answers, with each probe **bounded** so a hanging exec is cut and retried instead of eating the whole step budget on attempt one. Wired into the suite path (generous wall-clock budget, since it must cover a cold image pull) and onto the lifecycle driver's existing readiness loop, which had the same unbounded-probe hang latent.

One mechanism, both call sites, no per-provider special case. A provider that is ready on the first probe pays a single round-trip.

## Verification

- `bun test` — 940 pass, 0 fail (7 new: 6 in `readiness.test.ts`, 1 suite-path never-ready case)
- `bun run typecheck`, `bunx biome check packages/ apps/`, `bun run spell`, `bun run check:catalog-drift` — all clean
- The new suite-path test reproduces the exact live failure shape: a sandbox that never answers must be torn down and recorded as a **failed** cell, not a disk skip

Not yet validated live — that needs a `bench-smoke` dispatch on merge, which also finally exercises #263's egress ASN/geo fix (it sits downstream of setup, so it never ran).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Gate the harness suite on sandbox readiness and bound per-probe execs to prevent hangs; record pre-benchmark/setup failures and stop the lifecycle driver at unready sandboxes while keeping disabled/unsupported metrics skipped.

- **Bug Fixes**
  - Added shared `waitUntilReady` with per-probe timeouts; used in the suite path and lifecycle driver.
  - Suite readiness budget: 30 attempts, 2s delay, 20s per-probe; ready providers pay one probe.
  - Lifecycle driver: 2s per-probe ceiling, bail out when not ready, fail only metrics that would have run with the readiness reason; keep disabled/unsupported ops skipped; prevent falling through to unbounded execs.
  - Routed pre-benchmark/setup throws through the failure marker and ensured teardown; never-ready messages report the effective attempt count.

<sup>Written for commit a5c904f558bb847845590e39c93fbad481e10d67. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/starslingdev/hpc-sandbox-benchmarks/pull/266?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved suite execution reliability by requiring sandbox readiness before disk checks, setup, benchmarking, and result collection.
  * Added stronger readiness retry behavior with per-probe timeouts to safely handle probe errors and hang scenarios.
  * Suites now fail early with a consistent “never ready” reason, reliably recording the appropriate failure gaps and still performing teardown.

* **Tests**
  * Expanded harness coverage for readiness success/failure, hang/timeout handling, accurate “never ready” messaging, and lifecycle/suite behavior when readiness never resolves.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->