### PR TITLE
fix(ci): lift the Biome size cap for generated dataset Run documents

### DIFF
--- a/.github/workflows/commit-dataset.yml
+++ b/.github/workflows/commit-dataset.yml
@@ -114,6 +114,14 @@ jobs:
       # the mechanical formatting here is exactly what a developer's `bun run lint:fix` would do. Scope
       # the write to data/dataset (JSON only): this job never touches LEADERBOARD.md, and Biome leaves
       # any rendered Markdown untouched anyway.
+      #
+      # A Run document grows with every provider x suite x metric the matrix gains, and Biome SKIPS any
+      # file over `files.maxSize` — emitting a warning that `--error-on-warnings` below turns into a job
+      # failure (run 30322186937 died this way at 2.2 MiB against the 2 MiB project cap, and the autofix
+      # silently no-op'd on the very file it exists to format). `biome.json` therefore carries a
+      # `data/dataset/runs/*.json` override raising the cap to 16 MiB for these generated documents only;
+      # hand-written source keeps the strict project-wide cap. Note biome.json cannot hold comments —
+      # Biome silently discards a commented config and falls back to its defaults — hence this note here.
       - name: Autofix the promoted dataset formatting (Biome)
         run: bunx biome check data/dataset --write
 

--- a/biome.json
+++ b/biome.json
@@ -71,6 +71,12 @@
       }
     },
     {
+      "includes": ["data/dataset/runs/*.json"],
+      "files": {
+        "maxSize": 16777216
+      }
+    },
+    {
       "includes": ["packages/**/src/**"],
       "linter": {
         "rules": {


### PR DESCRIPTION
**Unbreak the dataset publish path, then land the run it dropped**
Shipped as a 2-PR stack (merge bottom-up, each branch independently green).

1. #268 — `biome.json`: size-cap headroom for generated Run documents
2. #269 — `data/dataset`: backfill run `30322186937`, the run this bug dropped

↑ **This PR is #268 (1/2), based on main**.

---

[Job 90189331540](https://github.com/starslingdev/hpc-sandbox-benchmarks/actions/runs/30322186937/job/90189331540) failed the `Commit dataset` step `Confirm the promoted dataset passes Biome (the PR lint gate)`, after every benchmark in the matrix had already succeeded:

```
data/dataset/runs/30322186937.json check ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
  ! The size of the file is 2.2 MiB, which exceeds the configured maximum of 2.0 MiB for this project.
Checked 15 files in 6s. No fixes applied.
Found 1 warning.
```

The promoted Run document crossed `files.maxSize`, and **Biome skips an oversized file rather than checking it**. That broke both dataset steps at once, one of them silently:

| step | intended | actual |
|---|---|---|
| `biome check data/dataset --write` | canonicalize the Run doc to Biome's shape | skipped it — `No fixes applied`, no error |
| `biome check data/dataset --error-on-warnings` | confirm the PR lint gate passes | skip warning → exit 1, job dies before any PR opens |

So the autofix silently no-op'd on the very file it exists to format, and the gate then failed on the consequence. Note the cap was last raised in #251 (1 → 2 MiB) for the generated catalog module; the dataset outgrew it three runs later.

### The change

Run documents grow with every provider × suite × metric the matrix gains, so the headroom is scoped to them rather than lifting the project-wide cap again:

```jsonc
{ "includes": ["data/dataset/runs/*.json"], "files": { "maxSize": 16777216 } }
```

Hand-written source keeps the strict 2 MiB cap, which is what that cap exists to guard. `packages/schema/src/pts-generated.ts` (~1.0 MiB today) is the next likely tripwire and is deliberately left under the strict cap for now.

### Verification

End-to-end on the real artifact, not a fixture — the 2.16 MiB document `promote.ts` produces from run `30322186937`'s 378 shards (it lands in #269):

| | before | after |
|---|---|---|
| `--write` autofix | skipped, `No fixes applied` | `Fixed 1 file` — 2.16 MiB → 2.05 MiB via Biome's array inlining |
| `--error-on-warnings` gate | exit 1 | exit 0 |

#269 is the live proof: it commits that 2.05 MiB document — still over the 2 MiB cap — and its `Lint, typecheck, test & spell` job passes only because this PR is in its base.

<details>
<summary>Two review bots flagged the override's position; measured, and it is live where it sits</summary>

Both claimed Biome applies only the *first* matching override, which would make this entry dead config. Three-way control on the same 2.05 MiB document, Biome 2.4.16, only the `overrides` array differing:

| config | result |
|---|---|
| override removed | file skipped entirely — the failure above |
| override second, after `**/*.json` (as committed) | `Checked 1 file in 69ms. No fixes applied.` exit 0 |
| override first (as suggested) | `Checked 1 file in 69ms. No fixes applied.` exit 0 |

The middle row refutes the premise: the file is checked *and* still carries the 2-space indent from the broad `**/*.json` override, so both matching overrides apply at once. Biome merges every matching override (later wins per key). The reorder is a no-op, so the order stands.

</details>

### Why the rationale lives in `commit-dataset.yml`

`biome.json` cannot hold it: a `//` comment does not error, it makes Biome **silently discard the whole config and fall back to its defaults** (verified — the cap reverted to the 1.0 MiB default). So the explanation sits in the workflow that consumes it.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Raised Biome `files.maxSize` to 16 MiB for generated `data/dataset/runs/*.json` so CI can format and validate large Run documents instead of skipping them. The 2 MiB project cap stays for hand-written source; added a short rationale in `.github/workflows/commit-dataset.yml` because `biome.json` cannot hold comments.

<sup>Written for commit 20cd489da7675a9195251ac9eb64898274540ee6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/starslingdev/hpc-sandbox-benchmarks/pull/268?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved formatting support for generated dataset run files up to 16 MiB, preventing oversized files from being incorrectly rejected or reformatted.

* **Documentation**
  * Added guidance explaining the formatting configuration for generated dataset files and its limitations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
