### PR TITLE
fix(ci): actually land bot dataset/leaderboard PRs when no checks are required

### DIFF
--- a/.github/workflows/commit-dataset.yml
+++ b/.github/workflows/commit-dataset.yml
@@ -135,12 +135,11 @@ jobs:
 
       # main is protected by a "changes must be made through a pull request" ruleset (the public-repo
       # hardening in #176/#177), so this job can't push the promoted dataset straight to main — a direct
-      # push is rejected with GH013. Commit through a short-lived branch + pull request and enable
-      # GitHub-native auto-merge (`--auto`): the PR merges itself only once branch protection is
-      # satisfied — required status checks (the PR's Biome/CI gate) green and any required reviews in.
-      # `--auto` waits for those rules, it does not bypass them, so the dataset never lands unlinted or
-      # unreviewed. If auto-merge can't be armed (e.g. the repo hasn't enabled it), the PR stays open
-      # for a maintainer to merge normally.
+      # push is rejected with GH013. Commit through a short-lived branch + pull request as the
+      # github-actions bot, then merge it. The merge never bypasses the ruleset: it succeeds only
+      # because the ruleset requires no status checks and code-owner review is its sole review
+      # requirement, with data/dataset/ intentionally unowned (see docs/ci-secrets.md operator setup);
+      # the in-job Biome pre-flight above already guarantees the content is clean.
       - name: Commit the dataset via pull request
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -172,7 +171,7 @@ jobs:
               --base main \
               --head "$branch" \
               --title "chore(dataset): commit run ${RUN_ID}" \
-              --body "Automated dataset commit for run [\`${RUN_ID}\`](${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${RUN_ID}). Biome was pre-flighted green on the promoted content; auto-merge lands it once branch protection is satisfied. The public LEADERBOARD.md is regenerated separately via the Update leaderboard workflow."; then
+              --body "Automated dataset commit for run [\`${RUN_ID}\`](${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${RUN_ID}). Biome was pre-flighted green on the promoted content; merged automatically once the ruleset's review rules are satisfied (data/dataset/ is unowned, so none apply). The public LEADERBOARD.md is regenerated separately via the Update leaderboard workflow."; then
               echo "::error::gh pr create failed — branch '$branch' was pushed but no PR was opened." \
                 "This is almost always the repo's 'Allow GitHub Actions to create and approve pull" \
                 "requests' setting being off (Settings → Actions → General → Workflow permissions)." \
@@ -181,8 +180,20 @@ jobs:
               exit 1
             fi
           fi
-          # Queue GitHub-native auto-merge: it merges only after the PR's required checks pass (and any
-          # required reviews land), never bypassing branch protection. Best-effort — if the repo hasn't
-          # enabled auto-merge, leave the PR open for a maintainer.
-          gh pr merge "$branch" --squash --delete-branch --auto \
-            || echo "auto-merge not armed; dataset PR left open for a maintainer to merge"
+          # Merge as the bot. Try GitHub-native auto-merge (`--auto`) first so that IF the repo later
+          # adds required checks or reviews the PR waits for them instead of failing here; `--auto`
+          # itself errors when the PR is already immediately mergeable ("clean status"), which is
+          # today's posture (no required status checks), so fall back to a direct merge — GitHub still
+          # enforces the ruleset on that call. Fail loudly if neither lands it (e.g. an unresolved
+          # review thread or a review requirement now applies) so a stranded dataset PR is a red
+          # publish job, never a silently forgotten branch.
+          if ! gh pr merge "$branch" --squash --delete-branch --auto 2>/dev/null; then
+            if ! gh pr merge "$branch" --squash --delete-branch; then
+              echo "::error::could not merge '$branch'. The ruleset blocks it (unresolved review" \
+                "thread, a required review, or a required status check a GITHUB_TOKEN-authored PR" \
+                "cannot run). A maintainer must finish the merge. Do NOT add github-actions as a" \
+                "ruleset bypass — prefer: required approving review count 0 + Require review from" \
+                "Code Owners, with data/dataset/ unowned. See docs/ci-secrets.md."
+              exit 1
+            fi
+          fi

--- a/docs/ci-secrets.md
+++ b/docs/ci-secrets.md
@@ -51,9 +51,10 @@ Ungated: `ci.yml`, `ci-lint.yml`, and the toolchain `pr-gate` (Docker smoke, no 
 5. **Dataset lands via PR, lint-gated.** `main` is protected by a "changes must be made through a
    pull request" ruleset, so `commit-dataset.yml`'s `commit` job cannot push the promoted dataset
    straight to `main` (a direct push is rejected with `GH013`). It opens a `dataset/publish-<run-id>`
-   PR instead (hence `pull-requests: write`) and arms GitHub-native auto-merge (`gh pr merge --auto`),
-   which merges only once branch protection is satisfied — required status checks green and any
-   required reviews in. It never bypasses those rules. As a fast pre-flight, the job first runs the
+   PR instead (hence `pull-requests: write`) and merges it the same way the leaderboard flow does
+   (rule 7): `gh pr merge --auto` first so a future required check would be waited on, then a direct
+   merge — today's ruleset has no required status checks, so the PR is immediately mergeable and
+   GitHub still enforces the ruleset on the merge call. As a fast pre-flight, the job first runs the
    Biome gate on the generated dataset (`biome check data/dataset`, the same rules ci.yml runs) —
    Biome formats JSON, so an unformatted Run document would fail the PR — and aborts before opening a
    doomed PR on a miss. The push/PR step is idempotent: a re-run reuses the existing open PR instead of


### PR DESCRIPTION
gh pr merge --auto errors on an already-mergeable PR ('clean status'),
and the main ruleset has no required status checks, so every dataset PR
hit commit-dataset.yml's best-effort fallback and was left open for a
maintainer. Mirror update-leaderboard.yml: try --auto (so a future
required check would be waited on), fall back to a direct merge (GitHub
still enforces the ruleset on that call), and fail the job loudly if
neither lands it so a stranded dataset PR is a red publish job instead
of a silently forgotten branch.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make bot-created dataset PRs actually merge when no required checks exist by trying `gh pr merge --auto` first and falling back to a direct merge; still respects the ruleset and fails loudly if blocked. Mirrors the leaderboard flow and clarifies that `data/dataset/` is unowned to avoid required reviews.

- **Bug Fixes**
  - In `commit-dataset.yml`, merge as the bot: try `gh pr merge --auto`; on “clean status” error, run `gh pr merge --squash --delete-branch` (ruleset still enforced).
  - If both fail (e.g., required review/check), emit a clear error and fail the job with guidance not to add a bypass and to keep Code Owner review off for `data/dataset/`.
  - Updated `docs/ci-secrets.md` and the PR body to document the auto-then-direct merge and rationale (matches the leaderboard workflow; Biome pre-flight ensures clean content).

<sup>Written for commit bd43e4fa869d14da2e0761043af088a7bac41e7b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/starslingdev/hpc-sandbox-benchmarks/pull/271?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

