### PR TITLE
fix(ci): actually land bot dataset PRs when no checks are required

### DIFF
--- a/.github/workflows/commit-dataset.yml
+++ b/.github/workflows/commit-dataset.yml
@@ -135,12 +135,11 @@ jobs:
 
       # main is protected by a "changes must be made through a pull request" ruleset (the public-repo
       # hardening in #176/#177), so this job can't push the promoted dataset straight to main — a direct
-      # push is rejected with GH013. Commit through a short-lived branch + pull request and enable
-      # GitHub-native auto-merge (`--auto`): the PR merges itself only once branch protection is
-      # satisfied — required status checks (the PR's Biome/CI gate) green and any required reviews in.
-      # `--auto` waits for those rules, it does not bypass them, so the dataset never lands unlinted or
-      # unreviewed. If auto-merge can't be armed (e.g. the repo hasn't enabled it), the PR stays open
-      # for a maintainer to merge normally.
+      # push is rejected with GH013. Commit through a short-lived branch + pull request as the
+      # github-actions bot, then merge it. The merge never bypasses the ruleset: it succeeds only
+      # because the ruleset requires no status checks and code-owner review is its sole review
+      # requirement, with data/dataset/ intentionally unowned (see docs/ci-secrets.md operator setup);
+      # the in-job Biome pre-flight above already guarantees the content is clean.
       - name: Commit the dataset via pull request
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -161,6 +160,10 @@ jobs:
           git switch -C "$branch"
           git commit -m "chore(dataset): commit run ${RUN_ID}"
           git push -u --force origin "$branch"
+          # Pin the exact commit this run validated: the merge below passes it via --match-head-commit,
+          # so a concurrent push that swaps the branch head between now and the merge fails the merge
+          # instead of landing content this run never checked.
+          head_sha="$(git rev-parse HEAD)"
           # Open the PR only if one isn't already open for this deterministic branch; a re-run reuses it
           # (the force-push above already refreshed its content). `gh pr create` fails outright (GraphQL
           # "GitHub Actions is not permitted to create or approve pull requests") when the repo's Settings →
@@ -172,7 +175,7 @@ jobs:
               --base main \
               --head "$branch" \
               --title "chore(dataset): commit run ${RUN_ID}" \
-              --body "Automated dataset commit for run [\`${RUN_ID}\`](${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${RUN_ID}). Biome was pre-flighted green on the promoted content; auto-merge lands it once branch protection is satisfied. The public LEADERBOARD.md is regenerated separately via the Update leaderboard workflow."; then
+              --body "Automated dataset commit for run [\`${RUN_ID}\`](${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${RUN_ID}). Biome was pre-flighted green on the promoted content; the workflow merges this PR directly right after opening it (data/dataset/ is unowned, so no review rules apply — if this PR is still open, that merge failed and a maintainer must finish it). The public LEADERBOARD.md is regenerated separately via the Update leaderboard workflow."; then
               echo "::error::gh pr create failed — branch '$branch' was pushed but no PR was opened." \
                 "This is almost always the repo's 'Allow GitHub Actions to create and approve pull" \
                 "requests' setting being off (Settings → Actions → General → Workflow permissions)." \
@@ -181,8 +184,19 @@ jobs:
               exit 1
             fi
           fi
-          # Queue GitHub-native auto-merge: it merges only after the PR's required checks pass (and any
-          # required reviews land), never bypassing branch protection. Best-effort — if the repo hasn't
-          # enabled auto-merge, leave the PR open for a maintainer.
-          gh pr merge "$branch" --squash --delete-branch --auto \
-            || echo "auto-merge not armed; dataset PR left open for a maintainer to merge"
+          # Merge as the bot with a direct merge — deliberately NOT `gh pr merge --auto`. On a
+          # GITHUB_TOKEN-authored PR a required status check never runs, so if one were ever added,
+          # `--auto` would exit 0 after merely ARMING auto-merge for a merge that can never complete —
+          # a green publish job hiding a forever-open dataset PR. A direct merge either lands the PR
+          # right now (today's posture: no required checks, and data/dataset/ is unowned so no
+          # code-owner review applies) or fails this job red. GitHub still enforces the ruleset on the
+          # merge call — this is not a bypass.
+          if ! gh pr merge "$branch" --squash --delete-branch --match-head-commit "$head_sha"; then
+            echo "::error::could not merge '$branch'. The ruleset blocks it (unresolved review" \
+              "thread, a required review, or a required status check — which a GITHUB_TOKEN-authored" \
+              "PR can never run; landing bot PRs under required checks needs an App/PAT, see" \
+              "docs/ci-secrets.md). A maintainer must finish the merge. Do NOT add github-actions as" \
+              "a ruleset bypass — prefer: required approving review count 0 + Require review from" \
+              "Code Owners, with data/dataset/ unowned."
+            exit 1
+          fi

--- a/.github/workflows/update-leaderboard.yml
+++ b/.github/workflows/update-leaderboard.yml
@@ -143,6 +143,10 @@ jobs:
           git switch -C "$branch"
           git commit -m "chore(leaderboard): update from run ${TARGET_RUN_ID}"
           git push -u --force origin "$branch"
+          # Pin the exact commit this run validated: the merge below passes it via --match-head-commit,
+          # so a concurrent push that swaps the branch head between now and the merge fails the merge
+          # instead of landing content this run never checked.
+          head_sha="$(git rev-parse HEAD)"
           # Open the PR only if one isn't already open for this deterministic branch; a re-dispatch reuses
           # it (the force-push above already refreshed its content). `gh pr create` fails outright (GraphQL
           # "GitHub Actions is not permitted to create or approve pull requests") when the repo's Settings →
@@ -154,7 +158,7 @@ jobs:
               --base main \
               --head "$branch" \
               --title "chore(leaderboard): update from run ${TARGET_RUN_ID}" \
-              --body "Automated LEADERBOARD.md regeneration from committed dataset run \`${TARGET_RUN_ID}\`. Biome was pre-flighted green; merged automatically once the ruleset's review rules are satisfied (LEADERBOARD.md is unowned, so none apply)."; then
+              --body "Automated LEADERBOARD.md regeneration from committed dataset run \`${TARGET_RUN_ID}\`. Biome was pre-flighted green; the workflow merges this PR directly right after opening it (LEADERBOARD.md is unowned, so no review rules apply — if this PR is still open, that merge failed and a maintainer must finish it)."; then
               echo "::error::gh pr create failed — branch '$branch' was pushed but no PR was opened." \
                 "This is almost always the repo's 'Allow GitHub Actions to create and approve pull" \
                 "requests' setting being off (Settings → Actions → General → Workflow permissions)." \
@@ -166,21 +170,19 @@ jobs:
           # Re-check the PR file list (not just the local index) before merging, so a raced push that
           # added other paths cannot slip through.
           ./scripts/assert-paths-allowlisted.sh pr "$branch" -- LEADERBOARD.md
-          # Merge as the bot. The main ruleset requires no status checks and code-owner review is its only
-          # review requirement, so a leaderboard-only PR (LEADERBOARD.md is unowned) is immediately
-          # mergeable and the direct merge lands it; GitHub still enforces the ruleset on this call — it
-          # is not a bypass. Try GitHub-native auto-merge (`--auto`) first so that IF the repo later adds
-          # required checks or reviews the PR waits for them instead of failing here; `--auto` itself
-          # errors when the PR is already clean or the repo hasn't enabled auto-merge, in which case the
-          # direct merge covers today's posture. Fail loudly if neither lands it (e.g. an unresolved
-          # review thread or a review requirement now applies) so the update is never silently stranded.
-          if ! gh pr merge "$branch" --squash --delete-branch --auto 2>/dev/null; then
-            if ! gh pr merge "$branch" --squash --delete-branch; then
-              echo "::error::could not merge '$branch'. The ruleset blocks it (unresolved review thread," \
-                "a required review, or a required status check a GITHUB_TOKEN-authored PR cannot run)." \
-                "A maintainer must finish the merge. Do NOT add github-actions as a ruleset bypass —" \
-                "prefer: required approving review count 0 + Require review from Code Owners, with" \
-                "LEADERBOARD.md unowned. See docs/ci-secrets.md."
-              exit 1
-            fi
+          # Merge as the bot with a direct merge — deliberately NOT `gh pr merge --auto`. On a
+          # GITHUB_TOKEN-authored PR a required status check never runs, so if one were ever added,
+          # `--auto` would exit 0 after merely ARMING auto-merge for a merge that can never complete —
+          # a green job hiding a forever-open leaderboard PR. A direct merge either lands the PR right
+          # now (today's posture: no required checks, and LEADERBOARD.md is unowned so no code-owner
+          # review applies) or fails this job red. GitHub still enforces the ruleset on the merge
+          # call — this is not a bypass.
+          if ! gh pr merge "$branch" --squash --delete-branch --match-head-commit "$head_sha"; then
+            echo "::error::could not merge '$branch'. The ruleset blocks it (unresolved review thread," \
+              "a required review, or a required status check — which a GITHUB_TOKEN-authored PR can" \
+              "never run; landing bot PRs under required checks needs an App/PAT, see" \
+              "docs/ci-secrets.md). A maintainer must finish the merge. Do NOT add github-actions as a" \
+              "ruleset bypass — prefer: required approving review count 0 + Require review from Code" \
+              "Owners, with LEADERBOARD.md unowned."
+            exit 1
           fi

--- a/docs/ci-secrets.md
+++ b/docs/ci-secrets.md
@@ -51,9 +51,11 @@ Ungated: `ci.yml`, `ci-lint.yml`, and the toolchain `pr-gate` (Docker smoke, no 
 5. **Dataset lands via PR, lint-gated.** `main` is protected by a "changes must be made through a
    pull request" ruleset, so `commit-dataset.yml`'s `commit` job cannot push the promoted dataset
    straight to `main` (a direct push is rejected with `GH013`). It opens a `dataset/publish-<run-id>`
-   PR instead (hence `pull-requests: write`) and arms GitHub-native auto-merge (`gh pr merge --auto`),
-   which merges only once branch protection is satisfied — required status checks green and any
-   required reviews in. It never bypasses those rules. As a fast pre-flight, the job first runs the
+   PR instead (hence `pull-requests: write`) and merges it the same way the leaderboard flow does
+   (rule 7): a direct `gh pr merge` — GitHub still enforces the ruleset on that call; it succeeds
+   because the ruleset has no required status checks and `data/dataset/` is unowned. Deliberately not
+   `--auto`: arming auto-merge on a `GITHUB_TOKEN` PR whose required check will never run would leave
+   the PR stranded behind a green job. As a fast pre-flight, the job first runs the
    Biome gate on the generated dataset (`biome check data/dataset`, the same rules ci.yml runs) —
    Biome formats JSON, so an unformatted Run document would fail the PR — and aborts before opening a
    doomed PR on a miss. The push/PR step is idempotent: a re-run reuses the existing open PR instead of
@@ -62,13 +64,13 @@ Ungated: `ci.yml`, `ci-lint.yml`, and the toolchain `pr-gate` (Docker smoke, no 
 
    > **`GITHUB_TOKEN` caveat.** A PR opened with the default `GITHUB_TOKEN` does **not** trigger
    > `ci.yml` (GitHub suppresses workflow events raised by the Actions token). So if the Biome/CI
-   > check ever becomes a *required* status on the main ruleset, auto-merge waits for a check that
-   > never runs, and a maintainer completes the merge (their merge to `main` runs `ci.yml` normally).
-   > Today the ruleset requires no status checks, so this caveat only bites if one is added — the
-   > in-job Biome pre-flights already guarantee the generated content is clean either way. For fully
-   > hands-off merging *with* required checks, the PR would need to be opened with a GitHub App
-   > installation token or PAT instead of `GITHUB_TOKEN`; we deliberately avoid provisioning one until
-   > that trade-off is actually needed.
+   > check ever becomes a *required* status on the main ruleset, the direct merge fails and the
+   > publish job goes red — a maintainer completes the merge (their merge to `main` runs `ci.yml`
+   > normally). Today the ruleset requires no status checks, so this caveat only bites if one is
+   > added — the in-job Biome pre-flights already guarantee the generated content is clean either
+   > way. For fully hands-off merging *with* required checks, the PR would need to be opened with a
+   > GitHub App installation token or PAT instead of `GITHUB_TOKEN`; we deliberately avoid
+   > provisioning one until that trade-off is actually needed.
 6. **Backfilling a failed dataset commit.** The commit logic is the reusable `commit-dataset.yml`, so
    when a matrix run's dataset commit fails (or was never reached) a maintainer can re-run it standalone:
    **Actions → Commit dataset → Run workflow**, passing the original run's id — or, from a
@@ -96,11 +98,11 @@ Ungated: `ci.yml`, `ci-lint.yml`, and the toolchain `pr-gate` (Docker smoke, no 
       pull requests" toggle, see operator setup).
    2. Runs `scripts/assert-paths-allowlisted.sh` on the staged index **and** the PR file list; anything
       other than `LEADERBOARD.md` aborts before any merge is attempted.
-   3. Merges the PR (`gh pr merge --auto` first so a future required check would be waited on, then a
-      direct `gh pr merge` — today's ruleset has no required status checks, so the PR is immediately
-      mergeable). GitHub still enforces the ruleset on the merge call; this is not a bypass — it
-      succeeds only because code-owner review is the sole review requirement and `LEADERBOARD.md` is
-      intentionally unowned.
+   3. Merges the PR with a direct `gh pr merge` (deliberately not `--auto`: on a `GITHUB_TOKEN` PR a
+      required check never runs, so arming auto-merge could only ever strand the PR behind a green
+      job). GitHub still enforces the ruleset on the merge call; this is not a bypass — it succeeds
+      only because the ruleset has no required status checks, code-owner review is the sole review
+      requirement, and `LEADERBOARD.md` is intentionally unowned.
 
    Because the render is deterministic, the resulting `LEADERBOARD.md` is exactly what
    `leaderboard-artifact-sync` expects, so subsequent CI stays green. The job also pre-flights the
@@ -163,9 +165,9 @@ Configure the `main` ruleset so the bot-authored dataset/leaderboard PRs can mer
    code-owner review is not required for leaderboard-only PRs.
 3. **Do not** add `github-actions` (or a broad actor) as a ruleset bypass. The bot does not need
    bypass when code-owner review is the only review requirement and `LEADERBOARD.md` is unowned.
-4. Optional: **Settings → General → Pull Requests → Allow auto-merge** — on. The workflow tries
-   `gh pr merge --auto` first and falls back to a direct merge, so this only matters if a required
-   check is ever (re)introduced.
+4. **Settings → General → Pull Requests → Allow auto-merge** is not needed by these flows: the
+   workflows use a direct `gh pr merge`, never `--auto` (arming auto-merge on a `GITHUB_TOKEN` PR
+   whose required check can never run would strand it behind a green job).
 
 With that posture: a fork/public PR that touches `/.github/` still needs `@dbworku`; a
 `leaderboard/update-*` PR that only changes `LEADERBOARD.md` merges as soon as the workflow opens it.


### PR DESCRIPTION
Replaces #271 (auto-closed when its stacked base merged as #250).

`gh pr merge --auto` errors on an already-mergeable PR ("clean status"), and the main ruleset has no required status checks, so every dataset PR hit `commit-dataset.yml`'s best-effort fallback and was left open for a maintainer. This mirrors the pattern #250 landed in `update-leaderboard.yml`: try `--auto` first (so a future required check would be waited on), fall back to a direct merge (GitHub still enforces the ruleset on that call), and fail the job loudly if neither lands it — a stranded dataset PR becomes a red publish job instead of a silently forgotten branch.

## Test plan
- [x] `actionlint` / `zizmor` on `commit-dataset.yml` (no findings)
- [x] `bun test tooling/repo-checks` (152 pass)
- [ ] Next bench-matrix run from main (or a dataset backfill dispatch) merges its dataset PR hands-off

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Merge dataset and leaderboard bot PRs directly with `gh pr merge` using `--match-head-commit` (never `--auto`) so they land immediately and aren’t stranded behind non-running required checks. If the ruleset blocks the merge, the job fails with clear guidance.

- **Bug Fixes**
  - `.github/workflows/commit-dataset.yml` and `.github/workflows/update-leaderboard.yml`: switch to direct `--squash --delete-branch --match-head-commit` merges; pin the validated commit to avoid races; keep the leaderboard allowlisted-path check; improve failure messaging and PR text.
  - `docs/ci-secrets.md`: document the direct-merge flow; remove auto-merge steps; explain the `GITHUB_TOKEN` required-check caveat; note that “Allow auto-merge” isn’t needed and clarify operator/rules setup.

<sup>Written for commit 435b6e2d1632d3187ef527d67863d10cb8a0e063. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/starslingdev/hpc-sandbox-benchmarks/pull/272?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated dataset and leaderboard publishing to use direct squash merges (with branch deletion) instead of relying on auto-merge behavior.
  * Improved failure handling: when ruleset review/status requirements block the merge for token-created PRs, the workflow now stops with clearer, maintainer-actionable guidance.

* **Documentation**
  * Refreshed CI/release rules to match the new direct-merge flow, including updated guidance on when manual merge completion may be required.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->