### PR TITLE
fix(scripts): close the rename blind spot in the path allowlist fence

### DIFF
--- a/scripts/assert-paths-allowlisted.sh
+++ b/scripts/assert-paths-allowlisted.sh
@@ -5,11 +5,15 @@
 #   scripts/assert-paths-allowlisted.sh staged -- PATH [PATH...]
 #   scripts/assert-paths-allowlisted.sh pr <pr-number-or-url-or-branch> -- PATH [PATH...]
 #
-# `staged` inspects `git diff --cached --name-only` (the index about to be committed).
-# `pr` inspects `gh pr diff --name-only` for an open/closed PR reference `gh` accepts.
+# `staged` inspects `git diff --cached --name-only --no-renames` (the index about to be committed).
+# `--no-renames` matters: with rename detection a rename prints only its DESTINATION, so renaming a
+# sensitive file into an allowlisted path would hide the source; disabling it decomposes the rename
+# into a delete + add and the deleted source path fails the allowlist.
+# `pr` inspects the PR's file list via the pulls/files API and checks BOTH `filename` and
+# `previous_filename` — `gh pr diff --name-only` prints only destinations, same blind spot.
 #
-# Used by update-leaderboard.yml so a compromised or drifted release job cannot arm auto-merge for a
-# PR that touches anything beyond LEADERBOARD.md (in particular `.github/` workflows).
+# Used by update-leaderboard.yml so a compromised or drifted release job cannot merge a PR that
+# touches anything beyond LEADERBOARD.md (in particular `.github/` workflows).
 set -euo pipefail
 
 usage() {
@@ -63,21 +67,42 @@ for path in "$@"; do
   allow["$path"]=1
 done
 
-mapfile -t changed < <(
+# Collect the change set via command substitution, NOT `mapfile < <(...)`: a process substitution's
+# exit status is invisible to `set -e`, so a source command that fails mid-stream (e.g. a later
+# `--paginate` page erroring after earlier pages printed) would leave a PARTIAL list that the fence
+# then happily validates. With `$(...)` the assignment itself fails and `set -e` aborts — fail
+# closed on any collection error.
+changed_raw="$(
   case "$mode" in
     staged)
-      git diff --cached --name-only --diff-filter=ACDMRTUXB
+      git diff --cached --name-only --no-renames
       ;;
     pr)
-      gh pr diff "$pr_ref" --name-only
+      # Resolve whatever PR reference gh accepts (number, URL, branch) through its canonical URL,
+      # then list that exact PR's files through the API: unlike `gh pr diff --name-only`, this
+      # exposes `previous_filename`, so a rename's source path is checked too (fail-closed on
+      # renames of sensitive files into an allowlisted path). Deriving owner/repo from the resolved
+      # URL (not `{owner}/{repo}` placeholders, which name the current checkout) keeps the files
+      # listing bound to the same PR the reference resolved to, even for a cross-repo URL.
+      pr_url="$(gh pr view "$pr_ref" --json url --jq .url)"
+      pr_number="${pr_url##*/}"
+      repo_path="${pr_url#*://*/}"
+      repo_path="${repo_path%/pull/*}"
+      if [ -z "$pr_number" ] || [ -z "$repo_path" ] || [ "$repo_path" = "$pr_url" ]; then
+        echo "could not parse owner/repo and PR number from resolved PR url: $pr_url" >&2
+        exit 2
+      fi
+      gh api "repos/${repo_path}/pulls/${pr_number}/files" --paginate \
+        --jq '.[] | .filename, (.previous_filename // empty)'
       ;;
   esac
-)
+)"
 
-if [ "${#changed[@]}" -eq 0 ]; then
+if [ -z "$changed_raw" ]; then
   echo "change set is empty — nothing to allowlist-check" >&2
   exit 1
 fi
+mapfile -t changed <<< "$changed_raw"
 
 blocked=0
 for path in "${changed[@]}"; do

--- a/tooling/repo-checks/src/assert-paths-allowlisted.test.ts
+++ b/tooling/repo-checks/src/assert-paths-allowlisted.test.ts
@@ -1,8 +1,8 @@
 // Drift gate for scripts/assert-paths-allowlisted.sh — the path fence update-leaderboard.yml uses
-// before arming auto-merge. A silent widen (or a broken argv parser) would let a release PR touch
+// before merging. A silent widen (or a broken argv parser) would let a release PR touch
 // `.github/` and still merge.
 import { afterEach, describe, expect, test } from "bun:test";
-import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { chmodSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { findRepoRoot } from "./lib/workspace.ts";
@@ -29,16 +29,49 @@ function tempGitRepo(): string {
 	return dir;
 }
 
-function runAssert(cwd: string, args: string[]): { exitCode: number; stderr: string } {
+function runAssert(
+	cwd: string,
+	args: string[],
+	env?: Record<string, string>,
+): { exitCode: number; stderr: string } {
 	const result = Bun.spawnSync(["bash", SCRIPT, ...args], {
 		cwd,
 		stdout: "pipe",
 		stderr: "pipe",
+		env: { ...process.env, ...env },
 	});
 	return {
 		exitCode: result.exitCode,
 		stderr: new TextDecoder().decode(result.stderr),
 	};
+}
+
+/** Put a stub `gh` on PATH that answers `gh pr view … --json url` with PR 123's canonical URL and
+ * `gh api repos/acme/widgets/pulls/123/files` with the given newline-separated path list
+ * (mimicking the script's `--jq '.[] | .filename, (.previous_filename // empty)'` output). Any
+ * other invocation — including an `api` call that doesn't target the URL-derived owner/repo —
+ * fails loudly, so the test breaks if the production script's gh calls drift (e.g. back to
+ * `{owner}/{repo}` placeholders that name the current checkout instead of the resolved PR's
+ * repository). With `failMidStream` the api branch emits its paths and then exits non-zero,
+ * simulating a --paginate request dying after earlier pages printed. */
+function stubGh(paths: string[], opts?: { failMidStream?: boolean }): string {
+	const dir = mkdtempSync(join(tmpdir(), "stub-gh-"));
+	temps.push(dir);
+	const body = [
+		"#!/usr/bin/env bash",
+		'if [ "$1" = "pr" ] && [ "$2" = "view" ]; then',
+		'  echo "https://github.com/acme/widgets/pull/123"',
+		'elif [ "$1" = "api" ] && [ "$2" = "repos/acme/widgets/pulls/123/files" ]; then',
+		...paths.map((p) => `  echo "${p}"`),
+		...(opts?.failMidStream ? ["  exit 1"] : []),
+		"else",
+		'  echo "unexpected gh invocation: $*" >&2',
+		"  exit 1",
+		"fi",
+	].join("\n");
+	writeFileSync(join(dir, "gh"), `${body}\n`);
+	chmodSync(join(dir, "gh"), 0o755);
+	return dir;
 }
 
 describe("scripts/assert-paths-allowlisted.sh", () => {
@@ -66,5 +99,52 @@ describe("scripts/assert-paths-allowlisted.sh", () => {
 		const { exitCode, stderr } = runAssert(dir, ["staged", "--", "LEADERBOARD.md"]);
 		expect(exitCode).toBe(1);
 		expect(stderr).toContain("change set is empty");
+	});
+
+	test("rejects a staged rename of a sensitive file into the allowlisted path", () => {
+		const dir = tempGitRepo();
+		const git = (args: string[]) =>
+			Bun.spawnSync(["git", ...args], { cwd: dir, stdout: "pipe", stderr: "pipe" });
+		writeFileSync(join(dir, "secret.yml"), "credentials: yes\n");
+		expect(git(["add", "secret.yml"]).exitCode).toBe(0);
+		expect(git(["commit", "-q", "-m", "seed"]).exitCode).toBe(0);
+		// A rename's staged diff must expose the SOURCE path (delete), not just the destination —
+		// otherwise renaming a sensitive file into LEADERBOARD.md would slip through the fence.
+		expect(git(["mv", "secret.yml", "LEADERBOARD.md"]).exitCode).toBe(0);
+		const { exitCode, stderr } = runAssert(dir, ["staged", "--", "LEADERBOARD.md"]);
+		expect(exitCode).toBe(1);
+		expect(stderr).toContain("path not allowlisted: secret.yml");
+	});
+
+	test("pr mode accepts a PR file list that is exactly the allowlist", () => {
+		const dir = tempGitRepo();
+		const stub = stubGh(["LEADERBOARD.md"]);
+		const { exitCode, stderr } = runAssert(dir, ["pr", "123", "--", "LEADERBOARD.md"], {
+			PATH: `${stub}:${process.env.PATH}`,
+		});
+		expect(stderr).toBe("");
+		expect(exitCode).toBe(0);
+	});
+
+	test("pr mode rejects a rename source path surfaced via previous_filename", () => {
+		const dir = tempGitRepo();
+		// The API-side view of a rename attack: filename is allowlisted, previous_filename is not.
+		const stub = stubGh(["LEADERBOARD.md", ".github/workflows/ci.yml"]);
+		const { exitCode, stderr } = runAssert(dir, ["pr", "123", "--", "LEADERBOARD.md"], {
+			PATH: `${stub}:${process.env.PATH}`,
+		});
+		expect(exitCode).toBe(1);
+		expect(stderr).toContain("path not allowlisted: .github/workflows/ci.yml");
+	});
+
+	test("pr mode fails closed when the file listing dies mid-stream", () => {
+		const dir = tempGitRepo();
+		// A --paginate request erroring after earlier pages printed must NOT validate the partial
+		// (allowlisted-so-far) list — the collection failure itself has to fail the fence.
+		const stub = stubGh(["LEADERBOARD.md"], { failMidStream: true });
+		const { exitCode } = runAssert(dir, ["pr", "123", "--", "LEADERBOARD.md"], {
+			PATH: `${stub}:${process.env.PATH}`,
+		});
+		expect(exitCode).not.toBe(0);
 	});
 });


### PR DESCRIPTION
Both change-set sources printed only a rename's destination path:
git's rename detection collapses delete+add into one R entry, and
'gh pr diff --name-only' lists destinations only. Renaming a sensitive
file into LEADERBOARD.md would therefore pass the fence while deleting
the source out of sight.

- staged mode: add --no-renames so a rename decomposes into delete+add
  and the deleted source path fails the allowlist (this also retires
  the --diff-filter=ACDMRTUXB no-op flagged in #250's review).
- pr mode: list files via the pulls/files API and check BOTH filename
  and previous_filename instead of 'gh pr diff --name-only'.
- tests: staged-rename attack case, plus pr-mode coverage through a
  stubbed gh on PATH (also requested in #250's review).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Closes a rename blind spot in the path allowlist fence and makes PR file collection fail-closed, so renames or partial listings can’t bypass the gate. Keeps `update-leaderboard.yml` merge-safe when only `LEADERBOARD.md` is expected.

- **Bug Fixes**
  - Staged mode: use `git diff --cached --name-only --no-renames`; drop the no-op `--diff-filter`.
  - PR mode: resolve the PR via `gh pr view`, then list files with `gh api repos/{owner}/{repo}/pulls/{number}/files`, checking both `filename` and `previous_filename`.
  - Change collection: use command substitution so any `gh` error (incl. `--paginate` mid-stream) aborts; empty or partial lists fail closed.
  - Tests: cover staged renames, PR rename sources, exact-allowlist acceptance, and mid-stream failure via a stubbed `gh`.

<sup>Written for commit aafd85d96f31dde44818da060a0858e6833b2d7a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/starslingdev/hpc-sandbox-benchmarks/pull/274?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Strengthened path allowlist checks to detect renamed sensitive files in both staged changes and pull requests.
  * Prevented renamed files from bypassing security checks when moved to an approved path.
  * Improved pull request file scanning to validate both current and previous filenames.

* **Tests**
  * Added coverage for staged renames, pull request renames, and valid allowlisted changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->