### PR TITLE
fix(security): own everything by default, un-own only the bot-landed artifacts

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2,16 +2,14 @@
 # enables "Require review from Code Owners". See
 # https://docs.github.com/en/repositories/managing-your-repos-settings-and-features/customizing-your-repository/about-code-owners
 #
-# Deliberately NO blanket `*` owner: the update-leaderboard workflow (the github-actions bot) lands
-# only LEADERBOARD.md, and that path must stay unowned so its PR can merge without a human approving
-# review. Security-sensitive surfaces below still require @dbworku when code-owner review is enforced.
-# See docs/ci-secrets.md (operator setup — ruleset posture).
+# Everything is owned by default and the LAST matching entry wins; an entry with NO owner un-owns
+# its paths. Exactly two surfaces are deliberately unowned — the artifacts the github-actions bot
+# lands hands-off (docs/ci-secrets.md rules 5 and 7). A PR touching only those needs no code-owner
+# review; anything else — code, workflows, docs — requires @dbworku. In particular the leaderboard
+# renderer and its backing packages must stay owned: their output is committed by a job inside the
+# `privileged` environment, so unreviewed renderer changes would run with release credentials.
+* @dbworku
 
-# Security-sensitive surfaces — the CI/secrets posture and its enforcing gate. Changes here alter
-# what runs with credentials or what the hardening invariants allow, so they always want maintainer eyes.
-/.github/                                       @dbworku
-/tooling/repo-checks/                           @dbworku
-/scripts/setup-privileged-environment.sh        @dbworku
-/scripts/assert-paths-allowlisted.sh            @dbworku
-/SECURITY.md                                    @dbworku
-/docs/ci-secrets.md                             @dbworku
+# Bot-landed release artifacts — no owner, so the bot's direct merge needs no human review.
+/LEADERBOARD.md
+/data/dataset/

--- a/docs/ci-secrets.md
+++ b/docs/ci-secrets.md
@@ -160,11 +160,15 @@ Configure the `main` ruleset so the bot-authored dataset/leaderboard PRs can mer
      rule 5), so a required check would strand every bot PR on a maintainer merge. The bot-landed
      content is guarded instead by the in-job Biome pre-flights, the deterministic renderer, and the
      path allowlist.
-2. Keep [`.github/CODEOWNERS`](../.github/CODEOWNERS) owning `/.github/` (and the other sensitive
-   paths listed there) and **do not** add a blanket `*` owner — `LEADERBOARD.md` must stay unowned so
-   code-owner review is not required for leaderboard-only PRs.
+2. Keep [`.github/CODEOWNERS`](../.github/CODEOWNERS) owning **everything by default** (`*` owner)
+   with ownerless overrides for exactly the bot-landed artifacts (`/LEADERBOARD.md`,
+   `/data/dataset/` — a CODEOWNERS entry with no owner un-owns its paths; last match wins). Those
+   two must stay unowned so code-owner review is not required for the bot's PRs; everything else —
+   in particular the leaderboard renderer and its backing packages, whose output a `privileged` job
+   commits — must stay owned so no code change can merge without maintainer review.
 3. **Do not** add `github-actions` (or a broad actor) as a ruleset bypass. The bot does not need
-   bypass when code-owner review is the only review requirement and `LEADERBOARD.md` is unowned.
+   bypass when code-owner review is the only review requirement and its two landing paths are
+   unowned.
 4. **Settings → General → Pull Requests → Allow auto-merge** is not needed by these flows: the
    workflows use a direct `gh pr merge`, never `--auto` (arming auto-merge on a `GITHUB_TOKEN` PR
    whose required check can never run would strand it behind a green job).

--- a/scripts/setup-privileged-environment.sh
+++ b/scripts/setup-privileged-environment.sh
@@ -59,6 +59,7 @@ echo "  BL_API_KEY, BL_WORKSPACE"
 echo
 echo "Also required outside this Environment (see docs/ci-secrets.md):"
 echo "  - 'Allow GitHub Actions to create and approve pull requests' on"
-echo "  - main ruleset: code-owner review on, approving-review count 0, no blanket * code owner"
+echo "  - main ruleset: code-owner review on, approving-review count 0"
+echo "  - CODEOWNERS: '* @dbworku' + ownerless overrides for LEADERBOARD.md and data/dataset/ only"
 echo
 echo "Full runbook: docs/ci-secrets.md"


### PR DESCRIPTION
#250's review (greptile P1) caught that dropping the blanket * owner
left the leaderboard renderer and its backing packages unowned — with
the 0-approval + code-owner ruleset, a code PR touching only unowned
paths satisfies review rules with no human in the loop, and the
renderer's output is committed by a job inside the privileged
environment.

Restore '* @dbworku' and use CODEOWNERS' documented ownerless-override
pattern (last match wins; an entry with no owner un-owns its paths) to
leave exactly /LEADERBOARD.md and /data/dataset/ unowned — the two
paths the github-actions bot lands hands-off. The explicit
sensitive-path list collapses into the blanket owner.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restore default ownership so everything is owned by `@dbworku`, and un-own only the bot-landed artifacts (`/LEADERBOARD.md`, `/data/dataset/`). This closes a security gap where renderer packages were unowned, ensuring code changes need maintainer review while bot PRs still merge.

- **Bug Fixes**
  - Re-add blanket `* @dbworku` in `CODEOWNERS`; drop the explicit sensitive-path list.
  - Add ownerless overrides for `/LEADERBOARD.md` and `/data/dataset/` so `github-actions` PRs skip code-owner review.
  - Update `docs/ci-secrets.md` and `scripts/setup-privileged-environment.sh` to reflect the new default-ownership posture.

<sup>Written for commit 98b5bc5018e0ff611aabd1f0a114ac13e9acddbd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/starslingdev/hpc-sandbox-benchmarks/pull/275?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

