### PR TITLE
Replace OpenClaw build task with test-types, fix cold install store detection

### DIFF
--- a/lib/pts/realworld/install.sh
+++ b/lib/pts/realworld/install.sh
@@ -42,9 +42,15 @@ chmod +x "$EXE_NAME"
 # what the runner reads: a fresh COREPACK_HOME would otherwise make the first measured pnpm task
 # of a batch pay a pnpm-toolchain download inside its sample. The runner's cold_install branch
 # still wipes the store + XDG cache before measuring, so this never warms a cold-install sample.
+# XDG_DATA_HOME is load-bearing, not cosmetic: pnpm 11 ignores npm_config_store_dir and derives its
+# store from <XDG_DATA_HOME>/pnpm/store/v<n> (see the matching pins in realworld-runner.sh). Without
+# it this warm install would populate the shared $HOME store, which the runner's cold reset cannot
+# wipe (and must not, since it is not ours) -- every measured cold_install would then be a warm
+# store hit.
 export XDG_CACHE_HOME="${PWD}/.cache"
 export COREPACK_HOME="${PWD}/.corepack"
 export npm_config_store_dir="${PWD}/.pnpm-store"
+export XDG_DATA_HOME="${PWD}/.local-share"
 
 if ! command -v node >/dev/null 2>&1; then
 	echo "ERROR: node not found (the sandbox harness's setupNode step provisions it)" >&2

--- a/lib/pts/realworld/install.sh
+++ b/lib/pts/realworld/install.sh
@@ -42,14 +42,19 @@ chmod +x "$EXE_NAME"
 # what the runner reads: a fresh COREPACK_HOME would otherwise make the first measured pnpm task
 # of a batch pay a pnpm-toolchain download inside its sample. The runner's cold_install branch
 # still wipes the store + XDG cache before measuring, so this never warms a cold-install sample.
-# XDG_DATA_HOME is load-bearing, not cosmetic: pnpm 11 ignores npm_config_store_dir and derives its
-# store from <XDG_DATA_HOME>/pnpm/store/v<n> (see the matching pins in realworld-runner.sh). Without
-# it this warm install would populate the shared $HOME store, which the runner's cold reset cannot
-# wipe (and must not, since it is not ours) -- every measured cold_install would then be a warm
-# store hit.
+# The store pins are load-bearing, not cosmetic: pnpm 11 ignores npm_config_store_dir and resolves
+# its store from PNPM_HOME first, then <XDG_DATA_HOME>/pnpm/store/v<n> (see the matching pins and
+# the precedence note in realworld-runner.sh). Without BOTH, this warm install would populate the
+# shared $HOME store, which the runner's cold reset cannot wipe (and must not, since it is not
+# ours) -- every measured cold_install would then be a warm store hit. PNPM_HOME especially: images
+# that ship the `ENV PNPM_HOME=/pnpm` idiom would otherwise warm a store the reset never touches.
+# MISE_DATA_DIR is frozen before XDG_DATA_HOME moves, so mise's node/pnpm shims keep resolving on
+# stock images (the baked image already sets it).
 export XDG_CACHE_HOME="${PWD}/.cache"
 export COREPACK_HOME="${PWD}/.corepack"
 export npm_config_store_dir="${PWD}/.pnpm-store"
+export PNPM_HOME="${PWD}/.pnpm-home"
+export MISE_DATA_DIR="${MISE_DATA_DIR:-${HOME}/.local/share/mise}"
 export XDG_DATA_HOME="${PWD}/.local-share"
 
 if ! command -v node >/dev/null 2>&1; then

--- a/lib/pts/realworld/realworld-runner.sh
+++ b/lib/pts/realworld/realworld-runner.sh
@@ -21,7 +21,21 @@ WORK_DIR="${SCRIPT_DIR}/work"
 # handling) can't leak cache state across runs or providers.
 export XDG_CACHE_HOME="${SCRIPT_DIR}/.cache"
 export COREPACK_HOME="${SCRIPT_DIR}/.corepack"
+# pnpm's content-addressable STORE is what makes an install cold or warm, and pinning it is the
+# whole reason cold_install can claim to measure a cold install. Two knobs, because which one bites
+# depends on the pnpm each profile's packageManager field pins:
+#   * npm_config_store_dir -- the npm-style config key. pnpm 11 NO LONGER READS IT (verified against
+#     pnpm 11.2.2: `npm_config_store_dir=/tmp/x pnpm store path` still answers
+#     ~/.local/share/pnpm/store/v11). Kept for older pnpm, which does honour it.
+#   * XDG_DATA_HOME -- what pnpm 11 actually derives its default store from
+#     (<XDG_DATA_HOME>/pnpm/store/v<n>), so this is the knob that lands today.
+# Before this was pinned, every "cold" install on every realworld profile was a warm store hit: the
+# reset wiped ${SCRIPT_DIR}/.pnpm-store, a directory pnpm 11 never created, while the real 2.8 GB
+# store sat untouched in $HOME (openclaw cold_install: 10.7s, "reused 1129, downloaded 0").
+# Pinning it under SCRIPT_DIR also keeps the wipe inside the profile dir -- the runner must never
+# delete a developer's or provider image's shared $HOME store.
 export npm_config_store_dir="${SCRIPT_DIR}/.pnpm-store"
+export XDG_DATA_HOME="${SCRIPT_DIR}/.local-share"
 export CI=true
 export TZ=UTC
 export LC_ALL=C.UTF-8
@@ -231,9 +245,29 @@ cold_install)
 	cd "$WORK_DIR"
 	git checkout -f -q "$PIN_SHA"
 	git clean -xdff
-	rm -rf "$npm_config_store_dir" "$XDG_CACHE_HOME"
+	# Wiping XDG_DATA_HOME (not just the legacy .pnpm-store path) is what actually removes pnpm 11's
+	# store -- see the env pins above. Both are inside SCRIPT_DIR, so the blast radius is this
+	# profile's install dir and nothing else. Runs on EVERY invocation of this branch, so trial 2..N
+	# of a multi-run PTS batch are each as cold as trial 1 (verified locally, two consecutive trials
+	# per profile, all six reporting `reused 0`).
+	# This costs real wall time the warm-store bug used to hide -- measured here: openclaw 10.9s ->
+	# ~70s, better-auth ~60s, mastra ~170-265s, plus a full re-download of the store (2.3-5.2 GB) per
+	# trial. All well inside the suites' 80-minute command budgets, but it is why cold_install samples
+	# jump by roughly an order of magnitude against every dataset committed before this fix.
+	rm -rf "$npm_config_store_dir" "$XDG_DATA_HOME" "$XDG_CACHE_HOME"
 	if [ -d node_modules ]; then
 		echo "cold_install: node_modules survived the cold reset" >&2
+		exit 1
+	fi
+	# Absent node_modules alone never proved coldness: a surviving store repopulates it from local
+	# disk with zero downloads, which is exactly the bug the pins above fix. Ask pnpm where its store
+	# IS and refuse to measure if anything is still there, so a future change in pnpm's resolution
+	# fails loudly here instead of silently reporting warm installs as cold. Probe failure is not
+	# fatal (the selftest fixture and any pnpm-less profile must still run) -- this asserts only on
+	# positive proof of a surviving store, and runs before start_ns so it never enters the sample.
+	resolved_store="$(pnpm store path 2>/dev/null || true)"
+	if [ -n "$resolved_store" ] && [ -e "$resolved_store" ]; then
+		echo "cold_install: pnpm store survived the cold reset at ${resolved_store} — refusing to time a warm install" >&2
 		exit 1
 	fi
 	start_ns=$(date +%s%N)

--- a/lib/pts/realworld/realworld-runner.sh
+++ b/lib/pts/realworld/realworld-runner.sh
@@ -22,19 +22,33 @@ WORK_DIR="${SCRIPT_DIR}/work"
 export XDG_CACHE_HOME="${SCRIPT_DIR}/.cache"
 export COREPACK_HOME="${SCRIPT_DIR}/.corepack"
 # pnpm's content-addressable STORE is what makes an install cold or warm, and pinning it is the
-# whole reason cold_install can claim to measure a cold install. Two knobs, because which one bites
-# depends on the pnpm each profile's packageManager field pins:
+# whole reason cold_install can claim to measure a cold install. Three knobs, because which one
+# bites depends on the pnpm each profile's packageManager field pins. They are listed in pnpm's
+# PRECEDENCE order, and all three must point inside SCRIPT_DIR: pinning only a lower-precedence one
+# leaves the store wherever the higher-precedence knob says, which the wipe below then misses.
+#   * PNPM_HOME -- HIGHEST precedence on pnpm 11 (verified against 11.5.0:
+#     `PNPM_HOME=/tmp/ph XDG_DATA_HOME=/tmp/xdg pnpm store path` answers /tmp/ph/store/v11). Set by
+#     pnpm's own standalone installer and by the common `ENV PNPM_HOME=/pnpm` Node/corepack
+#     Dockerfile idiom, so on any such image an unpinned PNPM_HOME silently overrides the XDG pin.
+#   * XDG_DATA_HOME -- what pnpm 11 derives its default store from when PNPM_HOME is unset
+#     (<XDG_DATA_HOME>/pnpm/store/v<n>).
 #   * npm_config_store_dir -- the npm-style config key. pnpm 11 NO LONGER READS IT (verified against
 #     pnpm 11.2.2: `npm_config_store_dir=/tmp/x pnpm store path` still answers
 #     ~/.local/share/pnpm/store/v11). Kept for older pnpm, which does honour it.
-#   * XDG_DATA_HOME -- what pnpm 11 actually derives its default store from
-#     (<XDG_DATA_HOME>/pnpm/store/v<n>), so this is the knob that lands today.
 # Before this was pinned, every "cold" install on every realworld profile was a warm store hit: the
 # reset wiped ${SCRIPT_DIR}/.pnpm-store, a directory pnpm 11 never created, while the real 2.8 GB
 # store sat untouched in $HOME (openclaw cold_install: 10.7s, "reused 1129, downloaded 0").
-# Pinning it under SCRIPT_DIR also keeps the wipe inside the profile dir -- the runner must never
+# Pinning them under SCRIPT_DIR also keeps the wipe inside the profile dir -- the runner must never
 # delete a developer's or provider image's shared $HOME store.
 export npm_config_store_dir="${SCRIPT_DIR}/.pnpm-store"
+export PNPM_HOME="${SCRIPT_DIR}/.pnpm-home"
+# mise resolves its data dir -- and therefore the node/pnpm SHIMS the task commands run through --
+# from MISE_DATA_DIR, falling back to <XDG_DATA_HOME>/mise. The baked toolchain image sets
+# MISE_DATA_DIR explicitly, but the harness's stock-image fallback installs mise with only the XDG
+# default, where repointing XDG_DATA_HOME below would aim those shims at an empty dir and break
+# `node`/`pnpm` outright. Freeze the pre-pin value first, so pinning the store can never move
+# mise's data out from under the toolchain.
+export MISE_DATA_DIR="${MISE_DATA_DIR:-${HOME}/.local/share/mise}"
 export XDG_DATA_HOME="${SCRIPT_DIR}/.local-share"
 export CI=true
 export TZ=UTC
@@ -254,7 +268,7 @@ cold_install)
 	# ~70s, better-auth ~60s, mastra ~170-265s, plus a full re-download of the store (2.3-5.2 GB) per
 	# trial. All well inside the suites' 80-minute command budgets, but it is why cold_install samples
 	# jump by roughly an order of magnitude against every dataset committed before this fix.
-	rm -rf "$npm_config_store_dir" "$XDG_DATA_HOME" "$XDG_CACHE_HOME"
+	rm -rf "$npm_config_store_dir" "$PNPM_HOME" "$XDG_DATA_HOME" "$XDG_CACHE_HOME"
 	if [ -d node_modules ]; then
 		echo "cold_install: node_modules survived the cold reset" >&2
 		exit 1
@@ -265,7 +279,12 @@ cold_install)
 	# fails loudly here instead of silently reporting warm installs as cold. Probe failure is not
 	# fatal (the selftest fixture and any pnpm-less profile must still run) -- this asserts only on
 	# positive proof of a surviving store, and runs before start_ns so it never enters the sample.
-	resolved_store="$(pnpm store path 2>/dev/null || true)"
+	# Bounded like every other external command here: `pnpm` is the corepack shim, and install.sh
+	# warms COREPACK_HOME with failure tolerated, so a probe that lands on a cold corepack can reach
+	# for the registry. Unbounded, a blackholed connection would wedge the runner forever and PTS
+	# would never write composite.xml -- losing every already-measured sample in the batch, not just
+	# this one. Costs nothing on the happy path (it already runs before start_ns).
+	resolved_store="$(run_bounded pnpm store path 2>/dev/null || true)"
 	if [ -n "$resolved_store" ] && [ -e "$resolved_store" ]; then
 		echo "cold_install: pnpm store survived the cold reset at ${resolved_store} — refusing to time a warm install" >&2
 		exit 1

--- a/packages/schema/src/pts-generated.ts
+++ b/packages/schema/src/pts-generated.ts
@@ -22709,18 +22709,6 @@ const chunk6: MetricDef[] = [
 		sourceUrl: "https://github.com/mastra-ai/mastra",
 	},
 	{
-		id: "realworld_openclaw_task_build",
-		dimension: "system",
-		unit: "Seconds",
-		direction: "LIB",
-		headline: false,
-		label: "OpenClaw CI Tasks - Task: Build",
-		description:
-			"Runs the CI tasks openclaw/openclaw's own pipeline runs -- clone, cold install (its exact CI invocation), lint (Oxlint), format check, typecheck (tsgo), shrinkwrap check, fast unit tests, build -- against a pinned main-HEAD checkout, timing each phase per sandbox provider.",
-		pts: { test: "local/realworld-openclaw", description: "Task: Build" },
-		sourceUrl: "https://github.com/openclaw/openclaw",
-	},
-	{
 		id: "realworld_openclaw_task_cold_install",
 		dimension: "system",
 		unit: "Seconds",
@@ -22728,7 +22716,7 @@ const chunk6: MetricDef[] = [
 		headline: false,
 		label: "OpenClaw CI Tasks - Task: Cold Install",
 		description:
-			"Runs the CI tasks openclaw/openclaw's own pipeline runs -- clone, cold install (its exact CI invocation), lint (Oxlint), format check, typecheck (tsgo), shrinkwrap check, fast unit tests, build -- against a pinned main-HEAD checkout, timing each phase per sandbox provider.",
+			"Runs the CI tasks openclaw/openclaw's own pipeline runs -- clone, cold install (its exact CI invocation), lint (Oxlint), format check, typecheck (tsgo), shrinkwrap check, fast unit tests, test-tree typecheck (tsgo) -- against a pinned main-HEAD checkout, timing each phase per sandbox provider.",
 		pts: { test: "local/realworld-openclaw", description: "Task: Cold Install" },
 		sourceUrl: "https://github.com/openclaw/openclaw",
 	},
@@ -22740,7 +22728,7 @@ const chunk6: MetricDef[] = [
 		headline: false,
 		label: "OpenClaw CI Tasks - Task: Git Clone",
 		description:
-			"Runs the CI tasks openclaw/openclaw's own pipeline runs -- clone, cold install (its exact CI invocation), lint (Oxlint), format check, typecheck (tsgo), shrinkwrap check, fast unit tests, build -- against a pinned main-HEAD checkout, timing each phase per sandbox provider.",
+			"Runs the CI tasks openclaw/openclaw's own pipeline runs -- clone, cold install (its exact CI invocation), lint (Oxlint), format check, typecheck (tsgo), shrinkwrap check, fast unit tests, test-tree typecheck (tsgo) -- against a pinned main-HEAD checkout, timing each phase per sandbox provider.",
 		pts: { test: "local/realworld-openclaw", description: "Task: Git Clone" },
 		sourceUrl: "https://github.com/openclaw/openclaw",
 	},
@@ -22752,7 +22740,7 @@ const chunk6: MetricDef[] = [
 		headline: false,
 		label: "OpenClaw CI Tasks - Task: Lint Format",
 		description:
-			"Runs the CI tasks openclaw/openclaw's own pipeline runs -- clone, cold install (its exact CI invocation), lint (Oxlint), format check, typecheck (tsgo), shrinkwrap check, fast unit tests, build -- against a pinned main-HEAD checkout, timing each phase per sandbox provider.",
+			"Runs the CI tasks openclaw/openclaw's own pipeline runs -- clone, cold install (its exact CI invocation), lint (Oxlint), format check, typecheck (tsgo), shrinkwrap check, fast unit tests, test-tree typecheck (tsgo) -- against a pinned main-HEAD checkout, timing each phase per sandbox provider.",
 		pts: { test: "local/realworld-openclaw", description: "Task: Lint Format" },
 		sourceUrl: "https://github.com/openclaw/openclaw",
 	},
@@ -22764,7 +22752,7 @@ const chunk6: MetricDef[] = [
 		headline: false,
 		label: "OpenClaw CI Tasks - Task: Lint Oxlint",
 		description:
-			"Runs the CI tasks openclaw/openclaw's own pipeline runs -- clone, cold install (its exact CI invocation), lint (Oxlint), format check, typecheck (tsgo), shrinkwrap check, fast unit tests, build -- against a pinned main-HEAD checkout, timing each phase per sandbox provider.",
+			"Runs the CI tasks openclaw/openclaw's own pipeline runs -- clone, cold install (its exact CI invocation), lint (Oxlint), format check, typecheck (tsgo), shrinkwrap check, fast unit tests, test-tree typecheck (tsgo) -- against a pinned main-HEAD checkout, timing each phase per sandbox provider.",
 		pts: { test: "local/realworld-openclaw", description: "Task: Lint Oxlint" },
 		sourceUrl: "https://github.com/openclaw/openclaw",
 	},
@@ -22776,8 +22764,20 @@ const chunk6: MetricDef[] = [
 		headline: false,
 		label: "OpenClaw CI Tasks - Task: Shrinkwrap Check",
 		description:
-			"Runs the CI tasks openclaw/openclaw's own pipeline runs -- clone, cold install (its exact CI invocation), lint (Oxlint), format check, typecheck (tsgo), shrinkwrap check, fast unit tests, build -- against a pinned main-HEAD checkout, timing each phase per sandbox provider.",
+			"Runs the CI tasks openclaw/openclaw's own pipeline runs -- clone, cold install (its exact CI invocation), lint (Oxlint), format check, typecheck (tsgo), shrinkwrap check, fast unit tests, test-tree typecheck (tsgo) -- against a pinned main-HEAD checkout, timing each phase per sandbox provider.",
 		pts: { test: "local/realworld-openclaw", description: "Task: Shrinkwrap Check" },
+		sourceUrl: "https://github.com/openclaw/openclaw",
+	},
+	{
+		id: "realworld_openclaw_task_test_types",
+		dimension: "system",
+		unit: "Seconds",
+		direction: "LIB",
+		headline: false,
+		label: "OpenClaw CI Tasks - Task: Test Types",
+		description:
+			"Runs the CI tasks openclaw/openclaw's own pipeline runs -- clone, cold install (its exact CI invocation), lint (Oxlint), format check, typecheck (tsgo), shrinkwrap check, fast unit tests, test-tree typecheck (tsgo) -- against a pinned main-HEAD checkout, timing each phase per sandbox provider.",
+		pts: { test: "local/realworld-openclaw", description: "Task: Test Types" },
 		sourceUrl: "https://github.com/openclaw/openclaw",
 	},
 	{
@@ -22788,7 +22788,7 @@ const chunk6: MetricDef[] = [
 		headline: false,
 		label: "OpenClaw CI Tasks - Task: Test Unit Fast",
 		description:
-			"Runs the CI tasks openclaw/openclaw's own pipeline runs -- clone, cold install (its exact CI invocation), lint (Oxlint), format check, typecheck (tsgo), shrinkwrap check, fast unit tests, build -- against a pinned main-HEAD checkout, timing each phase per sandbox provider.",
+			"Runs the CI tasks openclaw/openclaw's own pipeline runs -- clone, cold install (its exact CI invocation), lint (Oxlint), format check, typecheck (tsgo), shrinkwrap check, fast unit tests, test-tree typecheck (tsgo) -- against a pinned main-HEAD checkout, timing each phase per sandbox provider.",
 		pts: { test: "local/realworld-openclaw", description: "Task: Test Unit Fast" },
 		sourceUrl: "https://github.com/openclaw/openclaw",
 	},
@@ -22800,7 +22800,7 @@ const chunk6: MetricDef[] = [
 		headline: false,
 		label: "OpenClaw CI Tasks - Task: Typecheck",
 		description:
-			"Runs the CI tasks openclaw/openclaw's own pipeline runs -- clone, cold install (its exact CI invocation), lint (Oxlint), format check, typecheck (tsgo), shrinkwrap check, fast unit tests, build -- against a pinned main-HEAD checkout, timing each phase per sandbox provider.",
+			"Runs the CI tasks openclaw/openclaw's own pipeline runs -- clone, cold install (its exact CI invocation), lint (Oxlint), format check, typecheck (tsgo), shrinkwrap check, fast unit tests, test-tree typecheck (tsgo) -- against a pinned main-HEAD checkout, timing each phase per sandbox provider.",
 		pts: { test: "local/realworld-openclaw", description: "Task: Typecheck" },
 		sourceUrl: "https://github.com/openclaw/openclaw",
 	},

--- a/packages/schema/src/pts-generated.ts
+++ b/packages/schema/src/pts-generated.ts
@@ -22716,7 +22716,7 @@ const chunk6: MetricDef[] = [
 		headline: false,
 		label: "OpenClaw CI Tasks - Task: Cold Install",
 		description:
-			"Runs the CI tasks openclaw/openclaw's own pipeline runs -- clone, cold install (its exact CI invocation), lint (Oxlint), format check, extension-channel lint (type-aware Oxlint), typecheck (tsgo), shrinkwrap check, fast unit tests, test-tree typecheck (tsgo) -- against a pinned main-HEAD checkout, timing each phase per sandbox provider.",
+			"Runs a selected set of openclaw/openclaw development tasks -- clone, cold install (its exact CI invocation), lint (Oxlint), format check, extension-channel lint (type-aware Oxlint), typecheck (tsgo), shrinkwrap check, fast unit tests, test-tree typecheck (tsgo) -- against a pinned main-HEAD checkout, timing each phase per sandbox provider. Most mirror openclaw's own CI pipeline; format check is not run by it at this pin (see target.env).",
 		pts: { test: "local/realworld-openclaw", description: "Task: Cold Install" },
 		sourceUrl: "https://github.com/openclaw/openclaw",
 	},
@@ -22728,7 +22728,7 @@ const chunk6: MetricDef[] = [
 		headline: false,
 		label: "OpenClaw CI Tasks - Task: Git Clone",
 		description:
-			"Runs the CI tasks openclaw/openclaw's own pipeline runs -- clone, cold install (its exact CI invocation), lint (Oxlint), format check, extension-channel lint (type-aware Oxlint), typecheck (tsgo), shrinkwrap check, fast unit tests, test-tree typecheck (tsgo) -- against a pinned main-HEAD checkout, timing each phase per sandbox provider.",
+			"Runs a selected set of openclaw/openclaw development tasks -- clone, cold install (its exact CI invocation), lint (Oxlint), format check, extension-channel lint (type-aware Oxlint), typecheck (tsgo), shrinkwrap check, fast unit tests, test-tree typecheck (tsgo) -- against a pinned main-HEAD checkout, timing each phase per sandbox provider. Most mirror openclaw's own CI pipeline; format check is not run by it at this pin (see target.env).",
 		pts: { test: "local/realworld-openclaw", description: "Task: Git Clone" },
 		sourceUrl: "https://github.com/openclaw/openclaw",
 	},
@@ -22740,7 +22740,7 @@ const chunk6: MetricDef[] = [
 		headline: false,
 		label: "OpenClaw CI Tasks - Task: Lint Extensions",
 		description:
-			"Runs the CI tasks openclaw/openclaw's own pipeline runs -- clone, cold install (its exact CI invocation), lint (Oxlint), format check, extension-channel lint (type-aware Oxlint), typecheck (tsgo), shrinkwrap check, fast unit tests, test-tree typecheck (tsgo) -- against a pinned main-HEAD checkout, timing each phase per sandbox provider.",
+			"Runs a selected set of openclaw/openclaw development tasks -- clone, cold install (its exact CI invocation), lint (Oxlint), format check, extension-channel lint (type-aware Oxlint), typecheck (tsgo), shrinkwrap check, fast unit tests, test-tree typecheck (tsgo) -- against a pinned main-HEAD checkout, timing each phase per sandbox provider. Most mirror openclaw's own CI pipeline; format check is not run by it at this pin (see target.env).",
 		pts: { test: "local/realworld-openclaw", description: "Task: Lint Extensions" },
 		sourceUrl: "https://github.com/openclaw/openclaw",
 	},
@@ -22752,7 +22752,7 @@ const chunk6: MetricDef[] = [
 		headline: false,
 		label: "OpenClaw CI Tasks - Task: Lint Format",
 		description:
-			"Runs the CI tasks openclaw/openclaw's own pipeline runs -- clone, cold install (its exact CI invocation), lint (Oxlint), format check, extension-channel lint (type-aware Oxlint), typecheck (tsgo), shrinkwrap check, fast unit tests, test-tree typecheck (tsgo) -- against a pinned main-HEAD checkout, timing each phase per sandbox provider.",
+			"Runs a selected set of openclaw/openclaw development tasks -- clone, cold install (its exact CI invocation), lint (Oxlint), format check, extension-channel lint (type-aware Oxlint), typecheck (tsgo), shrinkwrap check, fast unit tests, test-tree typecheck (tsgo) -- against a pinned main-HEAD checkout, timing each phase per sandbox provider. Most mirror openclaw's own CI pipeline; format check is not run by it at this pin (see target.env).",
 		pts: { test: "local/realworld-openclaw", description: "Task: Lint Format" },
 		sourceUrl: "https://github.com/openclaw/openclaw",
 	},
@@ -22764,7 +22764,7 @@ const chunk6: MetricDef[] = [
 		headline: false,
 		label: "OpenClaw CI Tasks - Task: Lint Oxlint",
 		description:
-			"Runs the CI tasks openclaw/openclaw's own pipeline runs -- clone, cold install (its exact CI invocation), lint (Oxlint), format check, extension-channel lint (type-aware Oxlint), typecheck (tsgo), shrinkwrap check, fast unit tests, test-tree typecheck (tsgo) -- against a pinned main-HEAD checkout, timing each phase per sandbox provider.",
+			"Runs a selected set of openclaw/openclaw development tasks -- clone, cold install (its exact CI invocation), lint (Oxlint), format check, extension-channel lint (type-aware Oxlint), typecheck (tsgo), shrinkwrap check, fast unit tests, test-tree typecheck (tsgo) -- against a pinned main-HEAD checkout, timing each phase per sandbox provider. Most mirror openclaw's own CI pipeline; format check is not run by it at this pin (see target.env).",
 		pts: { test: "local/realworld-openclaw", description: "Task: Lint Oxlint" },
 		sourceUrl: "https://github.com/openclaw/openclaw",
 	},
@@ -22776,7 +22776,7 @@ const chunk6: MetricDef[] = [
 		headline: false,
 		label: "OpenClaw CI Tasks - Task: Shrinkwrap Check",
 		description:
-			"Runs the CI tasks openclaw/openclaw's own pipeline runs -- clone, cold install (its exact CI invocation), lint (Oxlint), format check, extension-channel lint (type-aware Oxlint), typecheck (tsgo), shrinkwrap check, fast unit tests, test-tree typecheck (tsgo) -- against a pinned main-HEAD checkout, timing each phase per sandbox provider.",
+			"Runs a selected set of openclaw/openclaw development tasks -- clone, cold install (its exact CI invocation), lint (Oxlint), format check, extension-channel lint (type-aware Oxlint), typecheck (tsgo), shrinkwrap check, fast unit tests, test-tree typecheck (tsgo) -- against a pinned main-HEAD checkout, timing each phase per sandbox provider. Most mirror openclaw's own CI pipeline; format check is not run by it at this pin (see target.env).",
 		pts: { test: "local/realworld-openclaw", description: "Task: Shrinkwrap Check" },
 		sourceUrl: "https://github.com/openclaw/openclaw",
 	},
@@ -22788,7 +22788,7 @@ const chunk6: MetricDef[] = [
 		headline: false,
 		label: "OpenClaw CI Tasks - Task: Test Types",
 		description:
-			"Runs the CI tasks openclaw/openclaw's own pipeline runs -- clone, cold install (its exact CI invocation), lint (Oxlint), format check, extension-channel lint (type-aware Oxlint), typecheck (tsgo), shrinkwrap check, fast unit tests, test-tree typecheck (tsgo) -- against a pinned main-HEAD checkout, timing each phase per sandbox provider.",
+			"Runs a selected set of openclaw/openclaw development tasks -- clone, cold install (its exact CI invocation), lint (Oxlint), format check, extension-channel lint (type-aware Oxlint), typecheck (tsgo), shrinkwrap check, fast unit tests, test-tree typecheck (tsgo) -- against a pinned main-HEAD checkout, timing each phase per sandbox provider. Most mirror openclaw's own CI pipeline; format check is not run by it at this pin (see target.env).",
 		pts: { test: "local/realworld-openclaw", description: "Task: Test Types" },
 		sourceUrl: "https://github.com/openclaw/openclaw",
 	},
@@ -22800,7 +22800,7 @@ const chunk6: MetricDef[] = [
 		headline: false,
 		label: "OpenClaw CI Tasks - Task: Test Unit Fast",
 		description:
-			"Runs the CI tasks openclaw/openclaw's own pipeline runs -- clone, cold install (its exact CI invocation), lint (Oxlint), format check, extension-channel lint (type-aware Oxlint), typecheck (tsgo), shrinkwrap check, fast unit tests, test-tree typecheck (tsgo) -- against a pinned main-HEAD checkout, timing each phase per sandbox provider.",
+			"Runs a selected set of openclaw/openclaw development tasks -- clone, cold install (its exact CI invocation), lint (Oxlint), format check, extension-channel lint (type-aware Oxlint), typecheck (tsgo), shrinkwrap check, fast unit tests, test-tree typecheck (tsgo) -- against a pinned main-HEAD checkout, timing each phase per sandbox provider. Most mirror openclaw's own CI pipeline; format check is not run by it at this pin (see target.env).",
 		pts: { test: "local/realworld-openclaw", description: "Task: Test Unit Fast" },
 		sourceUrl: "https://github.com/openclaw/openclaw",
 	},
@@ -22812,7 +22812,7 @@ const chunk6: MetricDef[] = [
 		headline: false,
 		label: "OpenClaw CI Tasks - Task: Typecheck",
 		description:
-			"Runs the CI tasks openclaw/openclaw's own pipeline runs -- clone, cold install (its exact CI invocation), lint (Oxlint), format check, extension-channel lint (type-aware Oxlint), typecheck (tsgo), shrinkwrap check, fast unit tests, test-tree typecheck (tsgo) -- against a pinned main-HEAD checkout, timing each phase per sandbox provider.",
+			"Runs a selected set of openclaw/openclaw development tasks -- clone, cold install (its exact CI invocation), lint (Oxlint), format check, extension-channel lint (type-aware Oxlint), typecheck (tsgo), shrinkwrap check, fast unit tests, test-tree typecheck (tsgo) -- against a pinned main-HEAD checkout, timing each phase per sandbox provider. Most mirror openclaw's own CI pipeline; format check is not run by it at this pin (see target.env).",
 		pts: { test: "local/realworld-openclaw", description: "Task: Typecheck" },
 		sourceUrl: "https://github.com/openclaw/openclaw",
 	},

--- a/packages/schema/src/pts-generated.ts
+++ b/packages/schema/src/pts-generated.ts
@@ -22716,7 +22716,7 @@ const chunk6: MetricDef[] = [
 		headline: false,
 		label: "OpenClaw CI Tasks - Task: Cold Install",
 		description:
-			"Runs a selected set of openclaw/openclaw development tasks -- clone, cold install (its exact CI invocation), lint (Oxlint), format check, extension-channel lint (type-aware Oxlint), typecheck (tsgo), shrinkwrap check, fast unit tests, test-tree typecheck (tsgo) -- against a pinned main-HEAD checkout, timing each phase per sandbox provider. Most mirror openclaw's own CI pipeline; format check is not run by it at this pin (see target.env).",
+			"Runs the CI tasks openclaw/openclaw's own pipeline runs -- clone, cold install (its exact CI invocation), lint (Oxlint), extension-channel lint (type-aware Oxlint), typecheck (tsgo), shrinkwrap check, fast unit tests, test-tree typecheck (tsgo) -- against a pinned main-HEAD checkout, timing each phase per sandbox provider.",
 		pts: { test: "local/realworld-openclaw", description: "Task: Cold Install" },
 		sourceUrl: "https://github.com/openclaw/openclaw",
 	},
@@ -22728,7 +22728,7 @@ const chunk6: MetricDef[] = [
 		headline: false,
 		label: "OpenClaw CI Tasks - Task: Git Clone",
 		description:
-			"Runs a selected set of openclaw/openclaw development tasks -- clone, cold install (its exact CI invocation), lint (Oxlint), format check, extension-channel lint (type-aware Oxlint), typecheck (tsgo), shrinkwrap check, fast unit tests, test-tree typecheck (tsgo) -- against a pinned main-HEAD checkout, timing each phase per sandbox provider. Most mirror openclaw's own CI pipeline; format check is not run by it at this pin (see target.env).",
+			"Runs the CI tasks openclaw/openclaw's own pipeline runs -- clone, cold install (its exact CI invocation), lint (Oxlint), extension-channel lint (type-aware Oxlint), typecheck (tsgo), shrinkwrap check, fast unit tests, test-tree typecheck (tsgo) -- against a pinned main-HEAD checkout, timing each phase per sandbox provider.",
 		pts: { test: "local/realworld-openclaw", description: "Task: Git Clone" },
 		sourceUrl: "https://github.com/openclaw/openclaw",
 	},
@@ -22740,20 +22740,8 @@ const chunk6: MetricDef[] = [
 		headline: false,
 		label: "OpenClaw CI Tasks - Task: Lint Extensions",
 		description:
-			"Runs a selected set of openclaw/openclaw development tasks -- clone, cold install (its exact CI invocation), lint (Oxlint), format check, extension-channel lint (type-aware Oxlint), typecheck (tsgo), shrinkwrap check, fast unit tests, test-tree typecheck (tsgo) -- against a pinned main-HEAD checkout, timing each phase per sandbox provider. Most mirror openclaw's own CI pipeline; format check is not run by it at this pin (see target.env).",
+			"Runs the CI tasks openclaw/openclaw's own pipeline runs -- clone, cold install (its exact CI invocation), lint (Oxlint), extension-channel lint (type-aware Oxlint), typecheck (tsgo), shrinkwrap check, fast unit tests, test-tree typecheck (tsgo) -- against a pinned main-HEAD checkout, timing each phase per sandbox provider.",
 		pts: { test: "local/realworld-openclaw", description: "Task: Lint Extensions" },
-		sourceUrl: "https://github.com/openclaw/openclaw",
-	},
-	{
-		id: "realworld_openclaw_task_lint_format",
-		dimension: "system",
-		unit: "Seconds",
-		direction: "LIB",
-		headline: false,
-		label: "OpenClaw CI Tasks - Task: Lint Format",
-		description:
-			"Runs a selected set of openclaw/openclaw development tasks -- clone, cold install (its exact CI invocation), lint (Oxlint), format check, extension-channel lint (type-aware Oxlint), typecheck (tsgo), shrinkwrap check, fast unit tests, test-tree typecheck (tsgo) -- against a pinned main-HEAD checkout, timing each phase per sandbox provider. Most mirror openclaw's own CI pipeline; format check is not run by it at this pin (see target.env).",
-		pts: { test: "local/realworld-openclaw", description: "Task: Lint Format" },
 		sourceUrl: "https://github.com/openclaw/openclaw",
 	},
 	{
@@ -22764,7 +22752,7 @@ const chunk6: MetricDef[] = [
 		headline: false,
 		label: "OpenClaw CI Tasks - Task: Lint Oxlint",
 		description:
-			"Runs a selected set of openclaw/openclaw development tasks -- clone, cold install (its exact CI invocation), lint (Oxlint), format check, extension-channel lint (type-aware Oxlint), typecheck (tsgo), shrinkwrap check, fast unit tests, test-tree typecheck (tsgo) -- against a pinned main-HEAD checkout, timing each phase per sandbox provider. Most mirror openclaw's own CI pipeline; format check is not run by it at this pin (see target.env).",
+			"Runs the CI tasks openclaw/openclaw's own pipeline runs -- clone, cold install (its exact CI invocation), lint (Oxlint), extension-channel lint (type-aware Oxlint), typecheck (tsgo), shrinkwrap check, fast unit tests, test-tree typecheck (tsgo) -- against a pinned main-HEAD checkout, timing each phase per sandbox provider.",
 		pts: { test: "local/realworld-openclaw", description: "Task: Lint Oxlint" },
 		sourceUrl: "https://github.com/openclaw/openclaw",
 	},
@@ -22776,7 +22764,7 @@ const chunk6: MetricDef[] = [
 		headline: false,
 		label: "OpenClaw CI Tasks - Task: Shrinkwrap Check",
 		description:
-			"Runs a selected set of openclaw/openclaw development tasks -- clone, cold install (its exact CI invocation), lint (Oxlint), format check, extension-channel lint (type-aware Oxlint), typecheck (tsgo), shrinkwrap check, fast unit tests, test-tree typecheck (tsgo) -- against a pinned main-HEAD checkout, timing each phase per sandbox provider. Most mirror openclaw's own CI pipeline; format check is not run by it at this pin (see target.env).",
+			"Runs the CI tasks openclaw/openclaw's own pipeline runs -- clone, cold install (its exact CI invocation), lint (Oxlint), extension-channel lint (type-aware Oxlint), typecheck (tsgo), shrinkwrap check, fast unit tests, test-tree typecheck (tsgo) -- against a pinned main-HEAD checkout, timing each phase per sandbox provider.",
 		pts: { test: "local/realworld-openclaw", description: "Task: Shrinkwrap Check" },
 		sourceUrl: "https://github.com/openclaw/openclaw",
 	},
@@ -22788,7 +22776,7 @@ const chunk6: MetricDef[] = [
 		headline: false,
 		label: "OpenClaw CI Tasks - Task: Test Types",
 		description:
-			"Runs a selected set of openclaw/openclaw development tasks -- clone, cold install (its exact CI invocation), lint (Oxlint), format check, extension-channel lint (type-aware Oxlint), typecheck (tsgo), shrinkwrap check, fast unit tests, test-tree typecheck (tsgo) -- against a pinned main-HEAD checkout, timing each phase per sandbox provider. Most mirror openclaw's own CI pipeline; format check is not run by it at this pin (see target.env).",
+			"Runs the CI tasks openclaw/openclaw's own pipeline runs -- clone, cold install (its exact CI invocation), lint (Oxlint), extension-channel lint (type-aware Oxlint), typecheck (tsgo), shrinkwrap check, fast unit tests, test-tree typecheck (tsgo) -- against a pinned main-HEAD checkout, timing each phase per sandbox provider.",
 		pts: { test: "local/realworld-openclaw", description: "Task: Test Types" },
 		sourceUrl: "https://github.com/openclaw/openclaw",
 	},
@@ -22800,7 +22788,7 @@ const chunk6: MetricDef[] = [
 		headline: false,
 		label: "OpenClaw CI Tasks - Task: Test Unit Fast",
 		description:
-			"Runs a selected set of openclaw/openclaw development tasks -- clone, cold install (its exact CI invocation), lint (Oxlint), format check, extension-channel lint (type-aware Oxlint), typecheck (tsgo), shrinkwrap check, fast unit tests, test-tree typecheck (tsgo) -- against a pinned main-HEAD checkout, timing each phase per sandbox provider. Most mirror openclaw's own CI pipeline; format check is not run by it at this pin (see target.env).",
+			"Runs the CI tasks openclaw/openclaw's own pipeline runs -- clone, cold install (its exact CI invocation), lint (Oxlint), extension-channel lint (type-aware Oxlint), typecheck (tsgo), shrinkwrap check, fast unit tests, test-tree typecheck (tsgo) -- against a pinned main-HEAD checkout, timing each phase per sandbox provider.",
 		pts: { test: "local/realworld-openclaw", description: "Task: Test Unit Fast" },
 		sourceUrl: "https://github.com/openclaw/openclaw",
 	},
@@ -22812,7 +22800,7 @@ const chunk6: MetricDef[] = [
 		headline: false,
 		label: "OpenClaw CI Tasks - Task: Typecheck",
 		description:
-			"Runs a selected set of openclaw/openclaw development tasks -- clone, cold install (its exact CI invocation), lint (Oxlint), format check, extension-channel lint (type-aware Oxlint), typecheck (tsgo), shrinkwrap check, fast unit tests, test-tree typecheck (tsgo) -- against a pinned main-HEAD checkout, timing each phase per sandbox provider. Most mirror openclaw's own CI pipeline; format check is not run by it at this pin (see target.env).",
+			"Runs the CI tasks openclaw/openclaw's own pipeline runs -- clone, cold install (its exact CI invocation), lint (Oxlint), extension-channel lint (type-aware Oxlint), typecheck (tsgo), shrinkwrap check, fast unit tests, test-tree typecheck (tsgo) -- against a pinned main-HEAD checkout, timing each phase per sandbox provider.",
 		pts: { test: "local/realworld-openclaw", description: "Task: Typecheck" },
 		sourceUrl: "https://github.com/openclaw/openclaw",
 	},

--- a/packages/schema/src/pts-generated.ts
+++ b/packages/schema/src/pts-generated.ts
@@ -22716,7 +22716,7 @@ const chunk6: MetricDef[] = [
 		headline: false,
 		label: "OpenClaw CI Tasks - Task: Cold Install",
 		description:
-			"Runs the CI tasks openclaw/openclaw's own pipeline runs -- clone, cold install (its exact CI invocation), lint (Oxlint), format check, typecheck (tsgo), shrinkwrap check, fast unit tests, test-tree typecheck (tsgo) -- against a pinned main-HEAD checkout, timing each phase per sandbox provider.",
+			"Runs the CI tasks openclaw/openclaw's own pipeline runs -- clone, cold install (its exact CI invocation), lint (Oxlint), format check, extension-channel lint (type-aware Oxlint), typecheck (tsgo), shrinkwrap check, fast unit tests, test-tree typecheck (tsgo) -- against a pinned main-HEAD checkout, timing each phase per sandbox provider.",
 		pts: { test: "local/realworld-openclaw", description: "Task: Cold Install" },
 		sourceUrl: "https://github.com/openclaw/openclaw",
 	},
@@ -22728,8 +22728,20 @@ const chunk6: MetricDef[] = [
 		headline: false,
 		label: "OpenClaw CI Tasks - Task: Git Clone",
 		description:
-			"Runs the CI tasks openclaw/openclaw's own pipeline runs -- clone, cold install (its exact CI invocation), lint (Oxlint), format check, typecheck (tsgo), shrinkwrap check, fast unit tests, test-tree typecheck (tsgo) -- against a pinned main-HEAD checkout, timing each phase per sandbox provider.",
+			"Runs the CI tasks openclaw/openclaw's own pipeline runs -- clone, cold install (its exact CI invocation), lint (Oxlint), format check, extension-channel lint (type-aware Oxlint), typecheck (tsgo), shrinkwrap check, fast unit tests, test-tree typecheck (tsgo) -- against a pinned main-HEAD checkout, timing each phase per sandbox provider.",
 		pts: { test: "local/realworld-openclaw", description: "Task: Git Clone" },
+		sourceUrl: "https://github.com/openclaw/openclaw",
+	},
+	{
+		id: "realworld_openclaw_task_lint_extensions",
+		dimension: "system",
+		unit: "Seconds",
+		direction: "LIB",
+		headline: false,
+		label: "OpenClaw CI Tasks - Task: Lint Extensions",
+		description:
+			"Runs the CI tasks openclaw/openclaw's own pipeline runs -- clone, cold install (its exact CI invocation), lint (Oxlint), format check, extension-channel lint (type-aware Oxlint), typecheck (tsgo), shrinkwrap check, fast unit tests, test-tree typecheck (tsgo) -- against a pinned main-HEAD checkout, timing each phase per sandbox provider.",
+		pts: { test: "local/realworld-openclaw", description: "Task: Lint Extensions" },
 		sourceUrl: "https://github.com/openclaw/openclaw",
 	},
 	{
@@ -22740,7 +22752,7 @@ const chunk6: MetricDef[] = [
 		headline: false,
 		label: "OpenClaw CI Tasks - Task: Lint Format",
 		description:
-			"Runs the CI tasks openclaw/openclaw's own pipeline runs -- clone, cold install (its exact CI invocation), lint (Oxlint), format check, typecheck (tsgo), shrinkwrap check, fast unit tests, test-tree typecheck (tsgo) -- against a pinned main-HEAD checkout, timing each phase per sandbox provider.",
+			"Runs the CI tasks openclaw/openclaw's own pipeline runs -- clone, cold install (its exact CI invocation), lint (Oxlint), format check, extension-channel lint (type-aware Oxlint), typecheck (tsgo), shrinkwrap check, fast unit tests, test-tree typecheck (tsgo) -- against a pinned main-HEAD checkout, timing each phase per sandbox provider.",
 		pts: { test: "local/realworld-openclaw", description: "Task: Lint Format" },
 		sourceUrl: "https://github.com/openclaw/openclaw",
 	},
@@ -22752,7 +22764,7 @@ const chunk6: MetricDef[] = [
 		headline: false,
 		label: "OpenClaw CI Tasks - Task: Lint Oxlint",
 		description:
-			"Runs the CI tasks openclaw/openclaw's own pipeline runs -- clone, cold install (its exact CI invocation), lint (Oxlint), format check, typecheck (tsgo), shrinkwrap check, fast unit tests, test-tree typecheck (tsgo) -- against a pinned main-HEAD checkout, timing each phase per sandbox provider.",
+			"Runs the CI tasks openclaw/openclaw's own pipeline runs -- clone, cold install (its exact CI invocation), lint (Oxlint), format check, extension-channel lint (type-aware Oxlint), typecheck (tsgo), shrinkwrap check, fast unit tests, test-tree typecheck (tsgo) -- against a pinned main-HEAD checkout, timing each phase per sandbox provider.",
 		pts: { test: "local/realworld-openclaw", description: "Task: Lint Oxlint" },
 		sourceUrl: "https://github.com/openclaw/openclaw",
 	},
@@ -22764,7 +22776,7 @@ const chunk6: MetricDef[] = [
 		headline: false,
 		label: "OpenClaw CI Tasks - Task: Shrinkwrap Check",
 		description:
-			"Runs the CI tasks openclaw/openclaw's own pipeline runs -- clone, cold install (its exact CI invocation), lint (Oxlint), format check, typecheck (tsgo), shrinkwrap check, fast unit tests, test-tree typecheck (tsgo) -- against a pinned main-HEAD checkout, timing each phase per sandbox provider.",
+			"Runs the CI tasks openclaw/openclaw's own pipeline runs -- clone, cold install (its exact CI invocation), lint (Oxlint), format check, extension-channel lint (type-aware Oxlint), typecheck (tsgo), shrinkwrap check, fast unit tests, test-tree typecheck (tsgo) -- against a pinned main-HEAD checkout, timing each phase per sandbox provider.",
 		pts: { test: "local/realworld-openclaw", description: "Task: Shrinkwrap Check" },
 		sourceUrl: "https://github.com/openclaw/openclaw",
 	},
@@ -22776,7 +22788,7 @@ const chunk6: MetricDef[] = [
 		headline: false,
 		label: "OpenClaw CI Tasks - Task: Test Types",
 		description:
-			"Runs the CI tasks openclaw/openclaw's own pipeline runs -- clone, cold install (its exact CI invocation), lint (Oxlint), format check, typecheck (tsgo), shrinkwrap check, fast unit tests, test-tree typecheck (tsgo) -- against a pinned main-HEAD checkout, timing each phase per sandbox provider.",
+			"Runs the CI tasks openclaw/openclaw's own pipeline runs -- clone, cold install (its exact CI invocation), lint (Oxlint), format check, extension-channel lint (type-aware Oxlint), typecheck (tsgo), shrinkwrap check, fast unit tests, test-tree typecheck (tsgo) -- against a pinned main-HEAD checkout, timing each phase per sandbox provider.",
 		pts: { test: "local/realworld-openclaw", description: "Task: Test Types" },
 		sourceUrl: "https://github.com/openclaw/openclaw",
 	},
@@ -22788,7 +22800,7 @@ const chunk6: MetricDef[] = [
 		headline: false,
 		label: "OpenClaw CI Tasks - Task: Test Unit Fast",
 		description:
-			"Runs the CI tasks openclaw/openclaw's own pipeline runs -- clone, cold install (its exact CI invocation), lint (Oxlint), format check, typecheck (tsgo), shrinkwrap check, fast unit tests, test-tree typecheck (tsgo) -- against a pinned main-HEAD checkout, timing each phase per sandbox provider.",
+			"Runs the CI tasks openclaw/openclaw's own pipeline runs -- clone, cold install (its exact CI invocation), lint (Oxlint), format check, extension-channel lint (type-aware Oxlint), typecheck (tsgo), shrinkwrap check, fast unit tests, test-tree typecheck (tsgo) -- against a pinned main-HEAD checkout, timing each phase per sandbox provider.",
 		pts: { test: "local/realworld-openclaw", description: "Task: Test Unit Fast" },
 		sourceUrl: "https://github.com/openclaw/openclaw",
 	},
@@ -22800,7 +22812,7 @@ const chunk6: MetricDef[] = [
 		headline: false,
 		label: "OpenClaw CI Tasks - Task: Typecheck",
 		description:
-			"Runs the CI tasks openclaw/openclaw's own pipeline runs -- clone, cold install (its exact CI invocation), lint (Oxlint), format check, typecheck (tsgo), shrinkwrap check, fast unit tests, test-tree typecheck (tsgo) -- against a pinned main-HEAD checkout, timing each phase per sandbox provider.",
+			"Runs the CI tasks openclaw/openclaw's own pipeline runs -- clone, cold install (its exact CI invocation), lint (Oxlint), format check, extension-channel lint (type-aware Oxlint), typecheck (tsgo), shrinkwrap check, fast unit tests, test-tree typecheck (tsgo) -- against a pinned main-HEAD checkout, timing each phase per sandbox provider.",
 		pts: { test: "local/realworld-openclaw", description: "Task: Typecheck" },
 		sourceUrl: "https://github.com/openclaw/openclaw",
 	},

--- a/packages/schema/src/pts-overrides.ts
+++ b/packages/schema/src/pts-overrides.ts
@@ -179,6 +179,10 @@ export const ptsOverrides: Record<string, MetricOverride> = {
 	realworld_openclaw_task_cold_install: { dimension: "realworld", label: "OpenClaw: cold install" },
 	realworld_openclaw_task_lint_oxlint: { dimension: "realworld", label: "OpenClaw: lint (Oxlint)" },
 	realworld_openclaw_task_lint_format: { dimension: "realworld", label: "OpenClaw: lint format" },
+	realworld_openclaw_task_lint_extensions: {
+		dimension: "realworld",
+		label: "OpenClaw: lint (extension channels)",
+	},
 	realworld_openclaw_task_typecheck: {
 		dimension: "realworld",
 		label: "OpenClaw: typecheck (tsgo)",

--- a/packages/schema/src/pts-overrides.ts
+++ b/packages/schema/src/pts-overrides.ts
@@ -191,5 +191,8 @@ export const ptsOverrides: Record<string, MetricOverride> = {
 		dimension: "realworld",
 		label: "OpenClaw: test (unit, fast)",
 	},
-	realworld_openclaw_task_build: { dimension: "realworld", label: "OpenClaw: build" },
+	realworld_openclaw_task_test_types: {
+		dimension: "realworld",
+		label: "OpenClaw: typecheck (test tree)",
+	},
 };

--- a/packages/schema/src/pts-overrides.ts
+++ b/packages/schema/src/pts-overrides.ts
@@ -178,7 +178,6 @@ export const ptsOverrides: Record<string, MetricOverride> = {
 	realworld_openclaw_task_git_clone: { dimension: "realworld", label: "OpenClaw: git clone" },
 	realworld_openclaw_task_cold_install: { dimension: "realworld", label: "OpenClaw: cold install" },
 	realworld_openclaw_task_lint_oxlint: { dimension: "realworld", label: "OpenClaw: lint (Oxlint)" },
-	realworld_openclaw_task_lint_format: { dimension: "realworld", label: "OpenClaw: lint format" },
 	realworld_openclaw_task_lint_extensions: {
 		dimension: "realworld",
 		label: "OpenClaw: lint (extension channels)",

--- a/packages/schema/src/pts-profiles/local/realworld-openclaw-1.0.0/target.env
+++ b/packages/schema/src/pts-profiles/local/realworld-openclaw-1.0.0/target.env
@@ -34,6 +34,19 @@ TASK_CMD_lint_oxlint="pnpm lint --threads=8"
 # reasons, both pin-scoped: revisit when the pin advances, and either drop the task or repoint it at
 # a check upstream's pipeline actually gates on.
 TASK_CMD_lint_format="pnpm format:check"
+# The `extension-channels` task of CI's check-additional-shard job. Restores a WORKING lint metric:
+# lint_oxlint above is the same type-aware Oxlint machinery but over the whole monorepo, where
+# tsgolint exceeds the target spec and has never posted a sample. Scoped to the extension channels
+# it fits with room to spare -- measured on a 4 vCPU host with the task capped at 7.28 GB (the
+# tightest cap an 8 GiB sandbox computes): pass, 142.7s, 1.58/4 cores busy, 4.42 GB peak RSS.
+# DELIBERATELY NOT the sibling `extension-bundled` task (pnpm lint:extensions:bundled) from the same
+# shard: measured under the same cap it pegs the cgroup at 7.28 GB with tsgolint reclaim-thrashing
+# (4.8M failcnt, killed at 260s), i.e. the identical out-of-spec failure as lint_oxlint. Adding it
+# would only buy a second metric that can never produce a sample. Re-test it if the spec grows or
+# the pin advances.
+# End-to-end through realworld-runner.sh at that same cap (warm-up pass + measured pass): exit 0,
+# REALWORLD_RESULT_SECONDS 163.560, 4.61 GB peak, zero cgroup OOM events.
+TASK_CMD_lint_extensions="pnpm lint:extensions:channels"
 # tsgo:prod (tsgo:core && tsgo:extensions) is the gate openclaw's own CI runs; bare `pnpm tsgo` is
 # only tsgo:core -- roughly half the typecheck workload the metric claims to measure.
 TASK_CMD_typecheck="pnpm tsgo:prod"

--- a/packages/schema/src/pts-profiles/local/realworld-openclaw-1.0.0/target.env
+++ b/packages/schema/src/pts-profiles/local/realworld-openclaw-1.0.0/target.env
@@ -99,8 +99,18 @@ TASK_CMD_test_unit_fast="pnpm test:unit:fast"
 # Go (GOGC=100, no memory-derived sizing like tsdown's) and its checker count follows the 4 vCPU the
 # spec pins, so the figure should carry to the fleet -- but if a provider ever lands under ~7.3 GB
 # of usable RAM this is the first task that will start OOMing. Watch it on the next matrix run.
-# The throttle path in scripts/lib/local-heavy-check-runtime.mjs (--singleThreaded --checkers 1,
-# GOGC=30, GOMEMLIMIT=3GiB) is gated on the local-check env and stays OFF under CI=true, exactly as
-# in upstream's own runner -- do not enable it to buy headroom, it would erase the core saturation
-# this task exists to measure.
+# THROTTLE CAVEAT, and an earlier claim in this file corrected: the throttle path in
+# scripts/lib/local-heavy-check-runtime.mjs (--singleThreaded --checkers 1, GOGC=30,
+# GOMEMLIMIT=3GiB) is NOT gated on CI, and it is ON for every tsgo/oxlint task here.
+# isLocalCheckEnabled() defaults TRUE unless OPENCLAW_LOCAL_CHECK is "0"/"false", and auto mode then
+# throttles whenever the HOST reports <48 GiB RAM or <12 CPUs -- true of every 4 vCPU / 8 GiB
+# sandbox, and of any machine this profile realistically runs on. Upstream's check-shard job turns
+# it OFF explicitly (OPENCLAW_LOCAL_CHECK: "0", .github/workflows/ci.yml), this profile does not, so
+# typecheck / test_types / lint_oxlint currently time a THROTTLED workload upstream never runs.
+# Measured on 4 vCPU at the 7.28 GB cap, same checkout, tsgo:prod:
+#   throttled (as shipped)    -> 120.5s, 1.80 mean / 1.39 median cores, 4.52 GB peak
+#   OPENCLAW_LOCAL_CHECK=0    ->  40.2s, 3.22 mean / 3.74 median cores, 6.03 GB peak
+# i.e. 3x slower and half the core saturation. Prefixing the tsgo/lint commands with
+# OPENCLAW_LOCAL_CHECK=0 is the fidelity fix; it is deliberately NOT applied here because it
+# revalues those metrics against every dataset committed before it. Decide before the next matrix.
 TASK_CMD_test_types="pnpm check:test-types"

--- a/packages/schema/src/pts-profiles/local/realworld-openclaw-1.0.0/target.env
+++ b/packages/schema/src/pts-profiles/local/realworld-openclaw-1.0.0/target.env
@@ -27,12 +27,48 @@ TASK_CMD_cold_install="CI=true pnpm install --prefer-offline --ignore-scripts=fa
 # CI's check-shard job pins the thread count (`pnpm lint --threads=8`); mirroring it keeps the
 # workload identical across providers instead of scaling with nproc.
 TASK_CMD_lint_oxlint="pnpm lint --threads=8"
+# NOT ACTUALLY A CI TASK at this pin, and permanently red besides: neither `format:check` nor
+# `oxfmt` appears anywhere under openclaw's .github/ (120 files, grepped), and `oxfmt --check`
+# (0.57.0, resolved from the pinned lockfile) reports 187 unformatted files against the clean pinned
+# checkout -- so the command exits 1 and this metric can never post a sample. Two independent
+# reasons, both pin-scoped: revisit when the pin advances, and either drop the task or repoint it at
+# a check upstream's pipeline actually gates on.
 TASK_CMD_lint_format="pnpm format:check"
 # tsgo:prod (tsgo:core && tsgo:extensions) is the gate openclaw's own CI runs; bare `pnpm tsgo` is
 # only tsgo:core -- roughly half the typecheck workload the metric claims to measure.
 TASK_CMD_typecheck="pnpm tsgo:prod"
+# Permanently red at this pin: run against the clean pinned checkout the check reports
+# "npm-shrinkwrap.json is stale. Run `pnpm deps:shrinkwrap:generate`." and exits 1, so no sample is
+# ever posted. Pin-scoped, not provider-scoped -- nothing the harness does can make it pass.
 TASK_CMD_shrinkwrap_check="pnpm deps:shrinkwrap:check"
+# Red in local reproduction, cause NOT yet confirmed for the fleet: vitest dies with EMFILE ("too
+# many open files") writing node_modules/.experimental-vitest-cache at ulimit -n 4096 -- 11039 tests
+# pass but 44 files error out and the run exits 1. Whether each provider trips the same wall depends
+# on its own fd limit, which has not been checked per provider.
 TASK_CMD_test_unit_fast="pnpm test:unit:fast"
 # build:ci-artifacts is what CI's build-artifacts job runs; plain `pnpm build` only appears in a
 # node-compat check job.
+# KNOWN INCOMPATIBILITY at this pin, same shape as lint_oxlint above: the task IS declared and PTS
+# does attempt it every run, but it has never produced a sample on any provider because the build
+# does not fit the 4 vCPU / 8 GiB target spec. The whole cost is rolldown-plugin-dts's declaration
+# build -- with declarations off the tsdown step is 7.9s; with them on it is 292s and holds a
+# >5.5 GB V8 live set. Upstream absorbs that by handing the job
+# NODE_OPTIONS=--max-old-space-size=8192 on a runner with more than 8 GiB of RAM
+# (.github/workflows/ci.yml at this pin), but scripts/tsdown-build.mjs discards that value and
+# re-derives the heap itself as min(12288, max(2048, limitMb - 768)) from the ROOT cgroup limit or
+# /proc/meminfo -- so an 8 GiB sandbox resolves a 7424 MB heap inside a box this runner has already
+# capped at MemTotal-1GiB, and the kernel SIGKILLs tsdown mid-build.
+# No in-pin workaround. Verified on a 4 vCPU host with the task cgroup capped at 7.0 GiB (more
+# generous than the ~6.8 GiB an 8 GiB sandbox computes), sweeping the heap ceiling through
+# upstream's own OPENCLAW_TSDOWN_MAX_OLD_SPACE_MB knob for constrained runners:
+#   7424 MB, 6144 MB -> SIGKILL, cgroup peak pegged at the cap
+#   5632 MB, 5120 MB, 4096 MB -> V8 "Reached heap limit" FATAL, live set 5.53/5.04/4.03 GB after
+#     mark-compact -- the live set tracks the ceiling, so no smaller ceiling wins either
+#   uncapped 12288 MB heap on the same 4 vCPU -> succeeds in 311s at ~10.8 GB peak RSS
+# The knob only moves the failure between those two modes. OPENCLAW_RUN_NODE_SKIP_DTS_BUILD is not
+# an escape either: build-all's BUILD_ALL_PROFILE_STEP_ENV pins it to "0" for the ciArtifacts
+# profile (a step env that overrides the ambient one), and forcing it on through the `full` profile
+# instead fails the later write-plugin-sdk-entry-dts step ("Missing canonical plugin SDK
+# declaration"). Expect a per-run metric-scoped gap until the target spec grows or the pin advances.
+# (Do not raise TimesToRun; do not drop the task -- keep+warn.)
 TASK_CMD_build="pnpm build:ci-artifacts"

--- a/packages/schema/src/pts-profiles/local/realworld-openclaw-1.0.0/target.env
+++ b/packages/schema/src/pts-profiles/local/realworld-openclaw-1.0.0/target.env
@@ -41,34 +41,50 @@ TASK_CMD_typecheck="pnpm tsgo:prod"
 # "npm-shrinkwrap.json is stale. Run `pnpm deps:shrinkwrap:generate`." and exits 1, so no sample is
 # ever posted. Pin-scoped, not provider-scoped -- nothing the harness does can make it pass.
 TASK_CMD_shrinkwrap_check="pnpm deps:shrinkwrap:check"
-# Red in local reproduction, cause NOT yet confirmed for the fleet: vitest dies with EMFILE ("too
-# many open files") writing node_modules/.experimental-vitest-cache at ulimit -n 4096 -- 11039 tests
-# pass but 44 files error out and the run exits 1. Whether each provider trips the same wall depends
-# on its own fd limit, which has not been checked per provider.
+# Red everywhere, and the fleet's cause differs from the local one -- do NOT assume they are the
+# same bug. Locally vitest dies with EMFILE ("too many open files") writing
+# node_modules/.experimental-vitest-cache at ulimit -n 4096: 11039 tests pass, 44 files error,
+# exit 1.
+# On the fleet PTS echoes a different failure for this task (blaxel r3, run 30019301067):
+# "E: [openclaw] Failed to resolve version: Error: version resolution failed". Neither has been run
+# down to a fix; the forensics tarball under data/raw/<runId>/<provider>/realworld-openclaw holds
+# the full task log if someone wants the rest of the story.
 TASK_CMD_test_unit_fast="pnpm test:unit:fast"
-# build:ci-artifacts is what CI's build-artifacts job runs; plain `pnpm build` only appears in a
-# node-compat check job.
-# KNOWN INCOMPATIBILITY at this pin, same shape as lint_oxlint above: the task IS declared and PTS
-# does attempt it every run, but it has never produced a sample on any provider because the build
-# does not fit the 4 vCPU / 8 GiB target spec. The whole cost is rolldown-plugin-dts's declaration
-# build -- with declarations off the tsdown step is 7.9s; with them on it is 292s and holds a
-# >5.5 GB V8 live set. Upstream absorbs that by handing the job
-# NODE_OPTIONS=--max-old-space-size=8192 on a runner with more than 8 GiB of RAM
-# (.github/workflows/ci.yml at this pin), but scripts/tsdown-build.mjs discards that value and
-# re-derives the heap itself as min(12288, max(2048, limitMb - 768)) from the ROOT cgroup limit or
-# /proc/meminfo -- so an 8 GiB sandbox resolves a 7424 MB heap inside a box this runner has already
-# capped at MemTotal-1GiB, and the kernel SIGKILLs tsdown mid-build.
-# No in-pin workaround. Verified on a 4 vCPU host with the task cgroup capped at 7.0 GiB (more
-# generous than the ~6.8 GiB an 8 GiB sandbox computes), sweeping the heap ceiling through
-# upstream's own OPENCLAW_TSDOWN_MAX_OLD_SPACE_MB knob for constrained runners:
-#   7424 MB, 6144 MB -> SIGKILL, cgroup peak pegged at the cap
-#   5632 MB, 5120 MB, 4096 MB -> V8 "Reached heap limit" FATAL, live set 5.53/5.04/4.03 GB after
-#     mark-compact -- the live set tracks the ceiling, so no smaller ceiling wins either
-#   uncapped 12288 MB heap on the same 4 vCPU -> succeeds in 311s at ~10.8 GB peak RSS
-# The knob only moves the failure between those two modes. OPENCLAW_RUN_NODE_SKIP_DTS_BUILD is not
-# an escape either: build-all's BUILD_ALL_PROFILE_STEP_ENV pins it to "0" for the ciArtifacts
-# profile (a step env that overrides the ambient one), and forcing it on through the `full` profile
-# instead fails the later write-plugin-sdk-entry-dts step ("Missing canonical plugin SDK
-# declaration"). Expect a per-run metric-scoped gap until the target spec grows or the pin advances.
-# (Do not raise TimesToRun; do not drop the task -- keep+warn.)
-TASK_CMD_build="pnpm build:ci-artifacts"
+# Replaces the former `build` task (pnpm build:ci-artifacts), which was dropped: at this pin that
+# build cannot complete inside the 4 vCPU / 8 GiB target spec and never produced a sample on any
+# provider. Its cost is entirely rolldown-plugin-dts's declaration build -- tsdown is 7.9s with
+# declarations off and 292s with them on, holding a >5.5 GB V8 live set. Upstream absorbs that with
+# NODE_OPTIONS=--max-old-space-size=8192 on a runner larger than 8 GiB, but scripts/tsdown-build.mjs
+# discards that value and re-derives the heap as min(12288, max(2048, limitMb - 768)) from the ROOT
+# cgroup limit or /proc/meminfo -- so an 8 GiB sandbox picks a 7424 MB heap inside a box this runner
+# has already capped at MemTotal-1GiB and the kernel SIGKILLs tsdown. Sweeping upstream's
+# OPENCLAW_TSDOWN_MAX_OLD_SPACE_MB knob only moves the failure between cgroup SIGKILL (>=6144 MB)
+# and V8's own "Reached heap limit" FATAL (<=5632 MB, live set tracking the ceiling); the same
+# 4 vCPU succeeds only with an uncapped 12288 MB heap at ~10.8 GB peak RSS. Skipping declarations is
+# unreachable too -- BUILD_ALL_PROFILE_STEP_ENV pins OPENCLAW_RUN_NODE_SKIP_DTS_BUILD to "0" for the
+# ciArtifacts profile, and forcing it through the `full` profile fails write-plugin-sdk-entry-dts.
+# Corroborated on the fleet: in run 30019301067 (blaxel r3) PTS lists "Task: Build" under "The
+# following tests failed to properly run", with its single run starting at 15:47:53 and the whole
+# batch ending at 15:48:47 -- under a minute, nowhere near the ~292s a build that actually
+# completes takes, exactly the shape of an early kill.
+#
+# check:test-types (tsgo:core:test && tsgo:extensions:test) is the `test-types` task of the SAME
+# check-shard job this profile already mirrors for lint_oxlint, so it keeps the "run what upstream's
+# pipeline runs" contract. It was picked over the other check-shard tasks because it is the only one
+# that both fits the spec and actually loads the machine. Measured on a 4 vCPU host with the task
+# capped at 7.28 GB (the tightest cap an 8 GiB sandbox computes -- MemTotal-1GiB across the observed
+# 7.77-8.00 GiB providers), each run cold:
+#   check:test-types  -> pass, 189-201s, 3.60/4 cores busy, 6.91 GB peak RSS
+#   tsgo:prod         -> pass,      75s, 2.52/4 cores busy, 4.16 GB peak (this profile's typecheck)
+#   check:architecture-> pass,     134s, 1.23/4 cores busy, 0.62 GB peak
+#   deadcode:ci       -> pass,      32s, 1.41/4 cores busy, 2.07 GB peak
+# NOTE the headroom: 6.91 GB peak against a 7.28 GB worst-case cap is ~5%. It passed twice at that
+# cap and fails at 6.0 GB, so the peak is real anonymous memory, not reclaimable page cache. tsgo is
+# Go (GOGC=100, no memory-derived sizing like tsdown's) and its checker count follows the 4 vCPU the
+# spec pins, so the figure should carry to the fleet -- but if a provider ever lands under ~7.3 GB
+# of usable RAM this is the first task that will start OOMing. Watch it on the next matrix run.
+# The throttle path in scripts/lib/local-heavy-check-runtime.mjs (--singleThreaded --checkers 1,
+# GOGC=30, GOMEMLIMIT=3GiB) is gated on the local-check env and stays OFF under CI=true, exactly as
+# in upstream's own runner -- do not enable it to buy headroom, it would erase the core saturation
+# this task exists to measure.
+TASK_CMD_test_types="pnpm check:test-types"

--- a/packages/schema/src/pts-profiles/local/realworld-openclaw-1.0.0/target.env
+++ b/packages/schema/src/pts-profiles/local/realworld-openclaw-1.0.0/target.env
@@ -79,13 +79,23 @@ TASK_CMD_cold_install="CI=true pnpm install --prefer-offline --ignore-scripts=fa
 # --type-aware off-switch. Expect a per-run metric-scoped gap until the workload fits the spec or
 # the pin advances. (Do not raise TimesToRun; do not drop the task.)
 TASK_CMD_lint_oxlint="OPENCLAW_LOCAL_CHECK=0 pnpm lint --threads=8"
-# NOT ACTUALLY A CI TASK at this pin, and permanently red besides: neither `format:check` nor
-# `oxfmt` appears anywhere under openclaw's .github/ (120 files, grepped), and `oxfmt --check`
-# (0.57.0, resolved from the pinned lockfile) reports 187 unformatted files against the clean pinned
-# checkout -- so the command exits 1 and this metric can never post a sample. Two independent
-# reasons, both pin-scoped: revisit when the pin advances, and either drop the task or repoint it at
-# a check upstream's pipeline actually gates on.
-TASK_CMD_lint_format="pnpm format:check"
+# REMOVED: lint_format (`pnpm format:check`). Dropped for the same reason as build -- a declared
+# metric that can never post a sample -- but on firmer ground, verified against a clean checkout of
+# the pin:
+#   * Not a CI task. Neither `format:check` nor `oxfmt` appears in ANY of the 120 files under
+#     openclaw's .github/. `pnpm check` (the one aggregate CI does run, in openclaw-npm-release.yml)
+#     is guard preflights + typecheck + lint only -- scripts/check.mjs has no format step. Upstream
+#     gates no JS/TS formatting at this pin, so there is nothing to repoint the task at.
+#   * Permanently red. `oxfmt --check --threads=1` (0.57.0, from the pinned lockfile) exits 1 with
+#     "Format issues found in above 187 files" on the clean pinned checkout, in 15.6s over 19195
+#     files. The repo simply is not oxfmt-clean at this SHA.
+#   * Never sampled. Zero values across all 14 committed dataset runs.
+# The distinction from lint_oxlint, which STAYS despite also never sampling: lint_oxlint is a real
+# CI task whose failure is provider signal (it is memory-bound, so whether a sandbox survives it
+# says something about the sandbox). lint_format failed identically everywhere for a reason that has
+# nothing to do with the provider, so its gap carried no comparative information -- noise in the
+# dataset, not a keep+warn comparability gap. Revisit only if the pin advances to a formatted tree
+# AND upstream starts gating format in CI.
 # The `extension-channels` task of CI's check-additional-shard job, and the profile's only WORKING
 # lint metric -- lint_oxlint is the same type-aware Oxlint machinery over the whole monorepo, which
 # never posts a sample. Scoped to the extension channels it fits with room to spare: pass, 142.7s,

--- a/packages/schema/src/pts-profiles/local/realworld-openclaw-1.0.0/target.env
+++ b/packages/schema/src/pts-profiles/local/realworld-openclaw-1.0.0/target.env
@@ -78,6 +78,9 @@ TASK_CMD_test_unit_fast="pnpm test:unit:fast"
 #   tsgo:prod         -> pass,      75s, 2.52/4 cores busy, 4.16 GB peak (this profile's typecheck)
 #   check:architecture-> pass,     134s, 1.23/4 cores busy, 0.62 GB peak
 #   deadcode:ci       -> pass,      32s, 1.41/4 cores busy, 2.07 GB peak
+# End-to-end through realworld-runner.sh at that same cap (warm-up pass + measured pass, the
+# no-prep path this task takes): exit 0, REALWORLD_RESULT_SECONDS 194.490, 6.92 GB peak, zero
+# cgroup OOM events -- so the task posts a sample, which is the whole point of the swap.
 # NOTE the headroom: 6.91 GB peak against a 7.28 GB worst-case cap is ~5%. It passed twice at that
 # cap and fails at 6.0 GB, so the peak is real anonymous memory, not reclaimable page cache. tsgo is
 # Go (GOGC=100, no memory-derived sizing like tsdown's) and its checker count follows the 4 vCPU the

--- a/packages/schema/src/pts-profiles/local/realworld-openclaw-1.0.0/target.env
+++ b/packages/schema/src/pts-profiles/local/realworld-openclaw-1.0.0/target.env
@@ -1,35 +1,83 @@
-# openclaw/openclaw (ENG-138) -- consumed by lib/pts/realworld/realworld-runner.sh. One TASK_CMD_<value> per
-# <Option>/<Menu>/<Entry>/<Value> in test-definition.xml (packages/schema/src/pts-profiles.test.ts
-# asserts the two stay in lockstep). git_clone has no shell command: the runner measures it via a
-# fixed git-fetch algorithm, not a package script. engines.node requires >=22.19.
+# openclaw/openclaw (ENG-138) -- consumed by lib/pts/realworld/realworld-runner.sh. One
+# TASK_CMD_<value> per <Option>/<Menu>/<Entry>/<Value> in test-definition.xml
+# (packages/schema/src/pts-profiles.test.ts asserts the two stay in lockstep). git_clone has no
+# shell command: the runner measures it via a fixed git-fetch algorithm, not a package script.
+# engines.node requires >=22.19.
+#
+# Every measurement quoted in this file was taken on a 4 vCPU host with the task in a cgroup capped
+# at 7.28 GB -- the tightest cap an 8 GiB sandbox computes (MemTotal-1GiB across the observed
+# 7.77-8.00 GiB providers) -- with the workspace reset cold first, as realworld-runner.sh does.
 REPO_URL="https://github.com/openclaw/openclaw.git"
 PIN_SHA="623534400684eca7c451cf587189fae714f2abe2"
 NODE_VERSION="22.19"
+
+# === TOOLCHAIN THROTTLE — read this before touching any tsgo/oxlint task below =================
+# openclaw ships a "local heavy check" throttle (scripts/lib/local-heavy-check-runtime.mjs) that
+# runs tsgo as --singleThreaded --checkers 1 and Go tools under GOGC=30 / GOMEMLIMIT=3GiB. It is
+# NOT gated on CI, which is the trap: isLocalCheckEnabled() defaults TRUE unless
+# OPENCLAW_LOCAL_CHECK is "0"/"false", and auto mode then throttles whenever the HOST reports
+# <48 GiB RAM or <12 CPUs. Every 4 vCPU / 8 GiB sandbox in the fleet is below both thresholds, so
+# the throttle is ON by default here and a throttled metric cannot separate providers on CPU
+# throughput -- the whole point of the dimension.
+# Upstream's check-shard job sets OPENCLAW_LOCAL_CHECK: "0" (.github/workflows/ci.yml), so tasks
+# mirroring THAT job carry the same env. check-additional-shard does not set it, so tasks mirroring
+# that job must NOT -- matching upstream per job is the rule, not blanket-setting the variable.
+# Measured impact, pnpm tsgo:prod, same checkout:
+#   throttled   -> 120.5s, 1.80 mean / 1.39 median cores, 4.52 GB peak
+#   unthrottled ->  40.2s, 3.22 mean / 3.74 median cores, 6.03 GB peak
+# Unthrottling costs memory as well as buying speed; test_types is the one task that cannot afford
+# it (see its block). Per-task state today:
+#   lint_oxlint       OPENCLAW_LOCAL_CHECK=0   (check-shard)
+#   typecheck         OPENCLAW_LOCAL_CHECK=0   (check-shard)
+#   shrinkwrap_check  OPENCLAW_LOCAL_CHECK=0   (check-shard, behaviourally inert)
+#   lint_extensions   throttled                (check-additional-shard does not set it)
+#   test_types        throttled                (check-shard, but OOMs unthrottled -- deliberate)
+# ==============================================================================================
+
+# === DROPPED TASK: build (pnpm build:ci-artifacts) ============================================
+# Not in the menu, and this is why -- so nobody re-adds it without new evidence. At this pin the
+# build cannot complete inside the 4 vCPU / 8 GiB target spec and never produced a sample on any
+# provider. The cost is entirely rolldown-plugin-dts's declaration build: tsdown is 7.9s with
+# declarations off and 292s with them on, holding a >5.5 GB V8 live set. Upstream absorbs that with
+# NODE_OPTIONS=--max-old-space-size=8192 on a runner larger than 8 GiB, but scripts/tsdown-build.mjs
+# discards that value and re-derives the heap as min(12288, max(2048, limitMb - 768)) from the ROOT
+# cgroup limit or /proc/meminfo -- so an 8 GiB sandbox picks a 7424 MB heap inside a box the runner
+# has already capped at MemTotal-1GiB, and the kernel SIGKILLs tsdown. Sweeping upstream's
+# OPENCLAW_TSDOWN_MAX_OLD_SPACE_MB knob only moves the failure between cgroup SIGKILL (>=6144 MB)
+# and V8's own "Reached heap limit" FATAL (<=5632 MB, live set tracking the ceiling); the same
+# 4 vCPU succeeds only with an uncapped 12288 MB heap at ~10.8 GB peak RSS. Skipping declarations is
+# unreachable too -- BUILD_ALL_PROFILE_STEP_ENV pins OPENCLAW_RUN_NODE_SKIP_DTS_BUILD to "0" for the
+# ciArtifacts profile, and forcing it through the `full` profile fails write-plugin-sdk-entry-dts
+# ("Missing canonical plugin SDK declaration").
+# Corroborated on the fleet: in run 30019301067 (blaxel r3) PTS lists "Task: Build" under "The
+# following tests failed to properly run", its single run starting at 15:47:53 with the whole batch
+# ending at 15:48:47 -- under a minute against the ~292s a completing build takes, the shape of an
+# early kill. test_types replaced it in the menu.
+# ==============================================================================================
 
 TASK_CMD_git_clone=""
 # Same invocation as openclaw's .github/actions/setup-node-env composite action's "Install
 # dependencies" step (mirrors the legacy runner-benchmarking capture). No retry-on-failure here,
 # unlike that CI step -- a retried install would corrupt the cold-install timing being measured.
+# Coldness is enforced by the runner, not by this command: see the store pins in
+# realworld-runner.sh, which wipe pnpm 11's real store between trials.
 TASK_CMD_cold_install="CI=true pnpm install --prefer-offline --ignore-scripts=false --config.engine-strict=false --config.enable-pre-post-scripts=true --config.side-effects-cache=true --frozen-lockfile"
-# KNOWN INCOMPATIBILITY at this pin: openclaw's lint wrapper unconditionally injects --type-aware
-# (scripts/lib/local-heavy-check-runtime.mjs:102 at pin 6235344), spawning the Go tsgolint binary
-# (oxlint-tsgolint 0.24.0) with GOGC=30/GOMEMLIMIT=3GiB via the default-on throttle policy; on
-# this monorepo tsgolint exceeds the 8 GB target spec (oxc's docs list large-monorepo
-# OOM/deadlock as a known tsgolint limitation). On real-kernel providers the OOM killer usually
-# SIGKILLs tsgolint and the task fails fast (blaxel + novita, run 29799034615); under gVisor
-# (modal-gvisor, kernel 4.19.0-gvisor) no in-sandbox OOM kill occurs and Modal's memoryLimitMiB
-# cap did not kill either, so without the runner's per-command timeout the sandbox thrashed for
-# the full 80-min step budget (runs 29799034615, 29743570333, 29692210375). No in-pin workaround:
-# versions are frozen by the pinned lockfile and the wrapper has no --type-aware off-switch; this
-# metric has never produced a sample on any provider and is expected to surface as a per-run
-# metric-scoped gap until the workload fits the spec or the pin advances. (Do not raise
-# TimesToRun; do not drop the task — keep+warn.)
-# CI's check-shard job pins the thread count (`pnpm lint --threads=8`); mirroring it keeps the
-# workload identical across providers instead of scaling with nproc. OPENCLAW_LOCAL_CHECK=0 is the
-# same job's step env (see the THROTTLE block below) -- without it this ran under openclaw's local
-# throttle, which upstream disables. It does not rescue the task: measured under the 7.28 GB cap it
-# pegs the cgroup either way (throttled, and unthrottled at 363k+ reclaim events), so the keep+warn
-# verdict above is unchanged. Kept for job fidelity so the recorded command is the one CI runs.
+# KNOWN INCOMPATIBILITY at this pin -- keep+warn: declared, attempted every run, never a sample on
+# any provider. openclaw's lint wrapper unconditionally injects --type-aware
+# (scripts/lib/local-heavy-check-runtime.mjs:102), spawning the Go tsgolint binary
+# (oxlint-tsgolint 0.24.0), which on this monorepo exceeds the 8 GB target spec -- oxc's docs list
+# large-monorepo OOM/deadlock as a known tsgolint limitation. On real-kernel providers the OOM
+# killer SIGKILLs tsgolint and the task fails fast (blaxel + novita, run 29799034615); under gVisor
+# (modal-gvisor, kernel 4.19.0-gvisor) no in-sandbox OOM kill occurs and Modal's memoryLimitMiB cap
+# did not kill either, so without the runner's per-command timeout the sandbox thrashed for the full
+# 80-min step budget (runs 29799034615, 29743570333, 29692210375).
+# The throttle state does not rescue it: measured under the cap it pegs the cgroup BOTH throttled
+# and unthrottled (the latter at 363k+ reclaim events), so OPENCLAW_LOCAL_CHECK=0 is carried purely
+# so the recorded command matches the CI step. --threads=8 mirrors check-shard's own pin, which
+# keeps the workload identical across providers instead of scaling with nproc.
+# No in-pin workaround: versions are frozen by the pinned lockfile and the wrapper has no
+# --type-aware off-switch. Expect a per-run metric-scoped gap until the workload fits the spec or
+# the pin advances. (Do not raise TimesToRun; do not drop the task.)
 TASK_CMD_lint_oxlint="OPENCLAW_LOCAL_CHECK=0 pnpm lint --threads=8"
 # NOT ACTUALLY A CI TASK at this pin, and permanently red besides: neither `format:check` nor
 # `oxfmt` appears anywhere under openclaw's .github/ (120 files, grepped), and `oxfmt --check`
@@ -38,34 +86,30 @@ TASK_CMD_lint_oxlint="OPENCLAW_LOCAL_CHECK=0 pnpm lint --threads=8"
 # reasons, both pin-scoped: revisit when the pin advances, and either drop the task or repoint it at
 # a check upstream's pipeline actually gates on.
 TASK_CMD_lint_format="pnpm format:check"
-# The `extension-channels` task of CI's check-additional-shard job. Restores a WORKING lint metric:
-# lint_oxlint above is the same type-aware Oxlint machinery but over the whole monorepo, where
-# tsgolint exceeds the target spec and has never posted a sample. Scoped to the extension channels
-# it fits with room to spare -- measured on a 4 vCPU host with the task capped at 7.28 GB (the
-# tightest cap an 8 GiB sandbox computes): pass, 142.7s, 1.58/4 cores busy, 4.42 GB peak RSS.
+# The `extension-channels` task of CI's check-additional-shard job, and the profile's only WORKING
+# lint metric -- lint_oxlint is the same type-aware Oxlint machinery over the whole monorepo, which
+# never posts a sample. Scoped to the extension channels it fits with room to spare: pass, 142.7s,
+# 1.58 mean / 1.63 median cores, 4.42 GB peak. End-to-end through realworld-runner.sh (warm-up +
+# measured pass): exit 0, REALWORLD_RESULT_SECONDS 163.560, 4.61 GB peak, zero cgroup OOM events.
+# Stays throttled on purpose: check-additional-shard does not set OPENCLAW_LOCAL_CHECK (see the
+# THROTTLE section), so neither does this task.
 # DELIBERATELY NOT the sibling `extension-bundled` task (pnpm lint:extensions:bundled) from the same
-# shard: measured under the same cap it pegs the cgroup at 7.28 GB with tsgolint reclaim-thrashing
-# (4.8M failcnt, killed at 260s), i.e. the identical out-of-spec failure as lint_oxlint. Adding it
-# would only buy a second metric that can never produce a sample. Re-test it if the spec grows or
-# the pin advances.
-# End-to-end through realworld-runner.sh at that same cap (warm-up pass + measured pass): exit 0,
-# REALWORLD_RESULT_SECONDS 163.560, 4.61 GB peak, zero cgroup OOM events.
+# shard: measured under the same cap it pegs the cgroup with tsgolint reclaim-thrashing (4.8M
+# failcnt, killed at 260s), the identical out-of-spec failure as lint_oxlint. Adding it would only
+# buy a second metric that can never produce a sample. Re-test if the spec grows or the pin
+# advances.
 TASK_CMD_lint_extensions="pnpm lint:extensions:channels"
 # tsgo:prod (tsgo:core && tsgo:extensions) is the gate openclaw's own CI runs; bare `pnpm tsgo` is
 # only tsgo:core -- roughly half the typecheck workload the metric claims to measure.
-# OPENCLAW_LOCAL_CHECK=0 mirrors check-shard's step env and is load-bearing here: without it tsgo
-# ran --singleThreaded --checkers 1 under openclaw's local throttle, so this metric timed a
-# serialised workload upstream never runs and could not separate providers on CPU throughput.
-# Measured on 4 vCPU at the 7.28 GB cap, same checkout:
-#   throttled (before) -> 120.5s, 1.80 mean / 1.39 median cores, 4.52 GB peak
-#   unthrottled (now)  ->  40.2s, 3.22 mean / 3.74 median cores, 6.03 GB peak
-# 3x faster, twice the core saturation, and still 17% under the cap.
-# End-to-end through realworld-runner.sh at that cap (warm-up + measured pass, throttle
-# confirmed off in the live tsgo argv): exit 0, REALWORLD_RESULT_SECONDS 57.703, 6.51 GB peak
-# for the whole task, zero cgroup OOM events. The full-suite PTS run recorded 71.7s throttled
-# for comparison.
+# OPENCLAW_LOCAL_CHECK=0 mirrors check-shard's step env and is load-bearing: it is the difference
+# between 120.5s at 1.39 median cores and 40.2s at 3.74 (see the THROTTLE section for the full A/B),
+# and it still leaves 17% headroom under the cap at 6.03 GB peak.
+# End-to-end through realworld-runner.sh (warm-up + measured pass, throttle confirmed absent from
+# the live tsgo argv): exit 0, REALWORLD_RESULT_SECONDS 57.703, 6.51 GB peak for the whole task,
+# zero cgroup OOM events. The full-suite PTS run recorded 71.7s while still throttled.
+# NOTE: typecheck samples are NOT comparable to any dataset committed before the unthrottling.
 TASK_CMD_typecheck="OPENCLAW_LOCAL_CHECK=0 pnpm tsgo:prod"
-# Permanently red at this pin: run against the clean pinned checkout the check reports
+# Permanently red at this pin: against the clean pinned checkout the check reports
 # "npm-shrinkwrap.json is stale. Run `pnpm deps:shrinkwrap:generate`." and exits 1, so no sample is
 # ever posted. Pin-scoped, not provider-scoped -- nothing the harness does can make it pass.
 # OPENCLAW_LOCAL_CHECK=0 for job fidelity (check-shard sets it for every task in the step); inert
@@ -74,64 +118,36 @@ TASK_CMD_shrinkwrap_check="OPENCLAW_LOCAL_CHECK=0 pnpm deps:shrinkwrap:check"
 # Red everywhere, and the fleet's cause differs from the local one -- do NOT assume they are the
 # same bug. Locally vitest dies with EMFILE ("too many open files") writing
 # node_modules/.experimental-vitest-cache at ulimit -n 4096: 11039 tests pass, 44 files error,
-# exit 1.
-# On the fleet PTS echoes a different failure for this task (blaxel r3, run 30019301067):
+# exit 1. Whether raising the fd limit fixes it is UNTESTED -- the container used for that
+# reproduction caps the fd hard limit at 4096 and denies prlimit even as root.
+# On the fleet PTS echoes a different failure (blaxel r3, run 30019301067):
 # "E: [openclaw] Failed to resolve version: Error: version resolution failed". Neither has been run
 # down to a fix; the forensics tarball under data/raw/<runId>/<provider>/realworld-openclaw holds
 # the full task log if someone wants the rest of the story.
 TASK_CMD_test_unit_fast="pnpm test:unit:fast"
-# Replaces the former `build` task (pnpm build:ci-artifacts), which was dropped: at this pin that
-# build cannot complete inside the 4 vCPU / 8 GiB target spec and never produced a sample on any
-# provider. Its cost is entirely rolldown-plugin-dts's declaration build -- tsdown is 7.9s with
-# declarations off and 292s with them on, holding a >5.5 GB V8 live set. Upstream absorbs that with
-# NODE_OPTIONS=--max-old-space-size=8192 on a runner larger than 8 GiB, but scripts/tsdown-build.mjs
-# discards that value and re-derives the heap as min(12288, max(2048, limitMb - 768)) from the ROOT
-# cgroup limit or /proc/meminfo -- so an 8 GiB sandbox picks a 7424 MB heap inside a box this runner
-# has already capped at MemTotal-1GiB and the kernel SIGKILLs tsdown. Sweeping upstream's
-# OPENCLAW_TSDOWN_MAX_OLD_SPACE_MB knob only moves the failure between cgroup SIGKILL (>=6144 MB)
-# and V8's own "Reached heap limit" FATAL (<=5632 MB, live set tracking the ceiling); the same
-# 4 vCPU succeeds only with an uncapped 12288 MB heap at ~10.8 GB peak RSS. Skipping declarations is
-# unreachable too -- BUILD_ALL_PROFILE_STEP_ENV pins OPENCLAW_RUN_NODE_SKIP_DTS_BUILD to "0" for the
-# ciArtifacts profile, and forcing it through the `full` profile fails write-plugin-sdk-entry-dts.
-# Corroborated on the fleet: in run 30019301067 (blaxel r3) PTS lists "Task: Build" under "The
-# following tests failed to properly run", with its single run starting at 15:47:53 and the whole
-# batch ending at 15:48:47 -- under a minute, nowhere near the ~292s a build that actually
-# completes takes, exactly the shape of an early kill.
+# check:test-types (tsgo:core:test && tsgo:extensions:test) is the `test-types` task of CI's
+# check-shard job, and replaced the dropped build task (see the DROPPED TASK section). It was picked
+# over the other in-spec check-shard candidates because it is the only one that both fits and
+# actually loads the machine:
+#   check:test-types   -> pass, 219.4s, 3.49 mean / 3.80 median cores, 6.97 GB peak
+#   tsgo:prod          -> pass,  40.2s, 3.22 mean / 3.74 median cores, 6.03 GB peak (= typecheck)
+#   check:architecture -> pass, 134.0s, 1.23 mean cores,               0.62 GB peak
+#   deadcode:ci        -> pass,  32.0s, 1.41 mean cores,               2.07 GB peak
+# End-to-end through realworld-runner.sh (warm-up + measured pass, the no-prep path this task
+# takes): exit 0, REALWORLD_RESULT_SECONDS 194.490, 6.92 GB peak, zero cgroup OOM events.
 #
-# check:test-types (tsgo:core:test && tsgo:extensions:test) is the `test-types` task of the SAME
-# check-shard job this profile already mirrors for lint_oxlint, so it keeps the "run what upstream's
-# pipeline runs" contract. It was picked over the other check-shard tasks because it is the only one
-# that both fits the spec and actually loads the machine. Measured on a 4 vCPU host with the task
-# capped at 7.28 GB (the tightest cap an 8 GiB sandbox computes -- MemTotal-1GiB across the observed
-# 7.77-8.00 GiB providers), each run cold:
-#   check:test-types  -> pass, 189-201s, 3.60/4 cores busy, 6.91 GB peak RSS
-#   tsgo:prod         -> pass,      75s, 2.52/4 cores busy, 4.16 GB peak (this profile's typecheck)
-#   check:architecture-> pass,     134s, 1.23/4 cores busy, 0.62 GB peak
-#   deadcode:ci       -> pass,      32s, 1.41/4 cores busy, 2.07 GB peak
-# End-to-end through realworld-runner.sh at that same cap (warm-up pass + measured pass, the
-# no-prep path this task takes): exit 0, REALWORLD_RESULT_SECONDS 194.490, 6.92 GB peak, zero
-# cgroup OOM events -- so the task posts a sample, which is the whole point of the swap.
-# NOTE the headroom: 6.91 GB peak against a 7.28 GB worst-case cap is ~5%. It passed twice at that
-# cap and fails at 6.0 GB, so the peak is real anonymous memory, not reclaimable page cache. tsgo is
-# Go (GOGC=100, no memory-derived sizing like tsdown's) and its checker count follows the 4 vCPU the
-# spec pins, so the figure should carry to the fleet -- but if a provider ever lands under ~7.3 GB
-# of usable RAM this is the first task that will start OOMing. Watch it on the next matrix run.
-# THE ONE TASK THAT CANNOT TAKE THE OPENCLAW_LOCAL_CHECK=0 FIDELITY FIX -- deliberate, measured.
-# openclaw's throttle (scripts/lib/local-heavy-check-runtime.mjs: --singleThreaded --checkers 1,
-# GOGC=30, GOMEMLIMIT=3GiB) is NOT gated on CI: isLocalCheckEnabled() defaults TRUE unless
-# OPENCLAW_LOCAL_CHECK is "0"/"false", and auto mode throttles whenever the HOST reports <48 GiB RAM
-# or <12 CPUs -- true of every 4 vCPU / 8 GiB sandbox. check-shard disables it, so lint_oxlint,
-# typecheck and shrinkwrap_check above now pass OPENCLAW_LOCAL_CHECK=0 to match. This task is from
-# that same shard and by rights should too, but it does not fit unthrottled. Measured on 4 vCPU at
-# the 7.28 GB cap, same checkout:
+# THE ONE TASK THAT CANNOT TAKE THE OPENCLAW_LOCAL_CHECK=0 FIX -- deliberate, measured. It is from
+# check-shard and by rights should carry the env like its siblings, but unthrottled it does not fit:
 #   throttled (as shipped) -> PASS, 219.4s, 3.49 mean / 3.80 median cores, 6.97 GB peak
-#   OPENCLAW_LOCAL_CHECK=0 -> OOM-KILLED at 80.6s, cgroup pegged at the cap (536k reclaim events),
-#                             silent SIGKILL mid tsgo:core:test, no sample
-# Unthrottling raises tsgo's parallel checker memory past a cap this task already sits 4% under, so
+#   OPENCLAW_LOCAL_CHECK=0 -> OOM-KILLED at 80.6s, cgroup pegged (536k reclaim events), silent
+#                             SIGKILL mid tsgo:core:test, no sample
+# Unthrottling raises tsgo's parallel-checker memory past a cap this task already sits ~4% under, so
 # the fidelity fix would convert a working metric into a permanently empty one -- the exact trade
 # that got the build task dropped. Throttled it still saturates 3.8/4 cores, which is what this
 # metric exists to measure, so the throttle is kept HERE and only here.
 # CONSEQUENCE, do not lose this: test_types is the most fragile metric in the profile. 6.97 GB
-# against a 7.28 GB cap is ~4% headroom, and it is not comparable to upstream's own test-types
-# timing. If a provider lands under ~7.3 GB usable this is the first task that starts OOMing.
+# against a 7.28 GB cap is ~4% headroom (it fails outright at a 6.0 GB cap, so that peak is real
+# anonymous memory, not reclaimable page cache), and its timing is not comparable to upstream's own
+# test-types job. If a provider lands under ~7.3 GB usable this is the first task that starts
+# OOMing. Watch it on the next matrix run.
 TASK_CMD_test_types="pnpm check:test-types"

--- a/packages/schema/src/pts-profiles/local/realworld-openclaw-1.0.0/target.env
+++ b/packages/schema/src/pts-profiles/local/realworld-openclaw-1.0.0/target.env
@@ -25,8 +25,12 @@ TASK_CMD_cold_install="CI=true pnpm install --prefer-offline --ignore-scripts=fa
 # metric-scoped gap until the workload fits the spec or the pin advances. (Do not raise
 # TimesToRun; do not drop the task — keep+warn.)
 # CI's check-shard job pins the thread count (`pnpm lint --threads=8`); mirroring it keeps the
-# workload identical across providers instead of scaling with nproc.
-TASK_CMD_lint_oxlint="pnpm lint --threads=8"
+# workload identical across providers instead of scaling with nproc. OPENCLAW_LOCAL_CHECK=0 is the
+# same job's step env (see the THROTTLE block below) -- without it this ran under openclaw's local
+# throttle, which upstream disables. It does not rescue the task: measured under the 7.28 GB cap it
+# pegs the cgroup either way (throttled, and unthrottled at 363k+ reclaim events), so the keep+warn
+# verdict above is unchanged. Kept for job fidelity so the recorded command is the one CI runs.
+TASK_CMD_lint_oxlint="OPENCLAW_LOCAL_CHECK=0 pnpm lint --threads=8"
 # NOT ACTUALLY A CI TASK at this pin, and permanently red besides: neither `format:check` nor
 # `oxfmt` appears anywhere under openclaw's .github/ (120 files, grepped), and `oxfmt --check`
 # (0.57.0, resolved from the pinned lockfile) reports 187 unformatted files against the clean pinned
@@ -49,11 +53,24 @@ TASK_CMD_lint_format="pnpm format:check"
 TASK_CMD_lint_extensions="pnpm lint:extensions:channels"
 # tsgo:prod (tsgo:core && tsgo:extensions) is the gate openclaw's own CI runs; bare `pnpm tsgo` is
 # only tsgo:core -- roughly half the typecheck workload the metric claims to measure.
-TASK_CMD_typecheck="pnpm tsgo:prod"
+# OPENCLAW_LOCAL_CHECK=0 mirrors check-shard's step env and is load-bearing here: without it tsgo
+# ran --singleThreaded --checkers 1 under openclaw's local throttle, so this metric timed a
+# serialised workload upstream never runs and could not separate providers on CPU throughput.
+# Measured on 4 vCPU at the 7.28 GB cap, same checkout:
+#   throttled (before) -> 120.5s, 1.80 mean / 1.39 median cores, 4.52 GB peak
+#   unthrottled (now)  ->  40.2s, 3.22 mean / 3.74 median cores, 6.03 GB peak
+# 3x faster, twice the core saturation, and still 17% under the cap.
+# End-to-end through realworld-runner.sh at that cap (warm-up + measured pass, throttle
+# confirmed off in the live tsgo argv): exit 0, REALWORLD_RESULT_SECONDS 57.703, 6.51 GB peak
+# for the whole task, zero cgroup OOM events. The full-suite PTS run recorded 71.7s throttled
+# for comparison.
+TASK_CMD_typecheck="OPENCLAW_LOCAL_CHECK=0 pnpm tsgo:prod"
 # Permanently red at this pin: run against the clean pinned checkout the check reports
 # "npm-shrinkwrap.json is stale. Run `pnpm deps:shrinkwrap:generate`." and exits 1, so no sample is
 # ever posted. Pin-scoped, not provider-scoped -- nothing the harness does can make it pass.
-TASK_CMD_shrinkwrap_check="pnpm deps:shrinkwrap:check"
+# OPENCLAW_LOCAL_CHECK=0 for job fidelity (check-shard sets it for every task in the step); inert
+# here since this check is a plain node script with no tsgo/oxlint throttle path.
+TASK_CMD_shrinkwrap_check="OPENCLAW_LOCAL_CHECK=0 pnpm deps:shrinkwrap:check"
 # Red everywhere, and the fleet's cause differs from the local one -- do NOT assume they are the
 # same bug. Locally vitest dies with EMFILE ("too many open files") writing
 # node_modules/.experimental-vitest-cache at ulimit -n 4096: 11039 tests pass, 44 files error,
@@ -99,18 +116,22 @@ TASK_CMD_test_unit_fast="pnpm test:unit:fast"
 # Go (GOGC=100, no memory-derived sizing like tsdown's) and its checker count follows the 4 vCPU the
 # spec pins, so the figure should carry to the fleet -- but if a provider ever lands under ~7.3 GB
 # of usable RAM this is the first task that will start OOMing. Watch it on the next matrix run.
-# THROTTLE CAVEAT, and an earlier claim in this file corrected: the throttle path in
-# scripts/lib/local-heavy-check-runtime.mjs (--singleThreaded --checkers 1, GOGC=30,
-# GOMEMLIMIT=3GiB) is NOT gated on CI, and it is ON for every tsgo/oxlint task here.
-# isLocalCheckEnabled() defaults TRUE unless OPENCLAW_LOCAL_CHECK is "0"/"false", and auto mode then
-# throttles whenever the HOST reports <48 GiB RAM or <12 CPUs -- true of every 4 vCPU / 8 GiB
-# sandbox, and of any machine this profile realistically runs on. Upstream's check-shard job turns
-# it OFF explicitly (OPENCLAW_LOCAL_CHECK: "0", .github/workflows/ci.yml), this profile does not, so
-# typecheck / test_types / lint_oxlint currently time a THROTTLED workload upstream never runs.
-# Measured on 4 vCPU at the 7.28 GB cap, same checkout, tsgo:prod:
-#   throttled (as shipped)    -> 120.5s, 1.80 mean / 1.39 median cores, 4.52 GB peak
-#   OPENCLAW_LOCAL_CHECK=0    ->  40.2s, 3.22 mean / 3.74 median cores, 6.03 GB peak
-# i.e. 3x slower and half the core saturation. Prefixing the tsgo/lint commands with
-# OPENCLAW_LOCAL_CHECK=0 is the fidelity fix; it is deliberately NOT applied here because it
-# revalues those metrics against every dataset committed before it. Decide before the next matrix.
+# THE ONE TASK THAT CANNOT TAKE THE OPENCLAW_LOCAL_CHECK=0 FIDELITY FIX -- deliberate, measured.
+# openclaw's throttle (scripts/lib/local-heavy-check-runtime.mjs: --singleThreaded --checkers 1,
+# GOGC=30, GOMEMLIMIT=3GiB) is NOT gated on CI: isLocalCheckEnabled() defaults TRUE unless
+# OPENCLAW_LOCAL_CHECK is "0"/"false", and auto mode throttles whenever the HOST reports <48 GiB RAM
+# or <12 CPUs -- true of every 4 vCPU / 8 GiB sandbox. check-shard disables it, so lint_oxlint,
+# typecheck and shrinkwrap_check above now pass OPENCLAW_LOCAL_CHECK=0 to match. This task is from
+# that same shard and by rights should too, but it does not fit unthrottled. Measured on 4 vCPU at
+# the 7.28 GB cap, same checkout:
+#   throttled (as shipped) -> PASS, 219.4s, 3.49 mean / 3.80 median cores, 6.97 GB peak
+#   OPENCLAW_LOCAL_CHECK=0 -> OOM-KILLED at 80.6s, cgroup pegged at the cap (536k reclaim events),
+#                             silent SIGKILL mid tsgo:core:test, no sample
+# Unthrottling raises tsgo's parallel checker memory past a cap this task already sits 4% under, so
+# the fidelity fix would convert a working metric into a permanently empty one -- the exact trade
+# that got the build task dropped. Throttled it still saturates 3.8/4 cores, which is what this
+# metric exists to measure, so the throttle is kept HERE and only here.
+# CONSEQUENCE, do not lose this: test_types is the most fragile metric in the profile. 6.97 GB
+# against a 7.28 GB cap is ~4% headroom, and it is not comparable to upstream's own test-types
+# timing. If a provider lands under ~7.3 GB usable this is the first task that starts OOMing.
 TASK_CMD_test_types="pnpm check:test-types"

--- a/packages/schema/src/pts-profiles/local/realworld-openclaw-1.0.0/test-definition.xml
+++ b/packages/schema/src/pts-profiles/local/realworld-openclaw-1.0.0/test-definition.xml
@@ -4,7 +4,7 @@
   <TestInformation>
     <Title>OpenClaw CI Tasks</Title>
     <AppVersion>623534400684eca7c451cf587189fae714f2abe2</AppVersion>
-    <Description>Runs a selected set of openclaw/openclaw development tasks -- clone, cold install (its exact CI invocation), lint (Oxlint), format check, extension-channel lint (type-aware Oxlint), typecheck (tsgo), shrinkwrap check, fast unit tests, test-tree typecheck (tsgo) -- against a pinned main-HEAD checkout, timing each phase per sandbox provider. Most mirror openclaw's own CI pipeline; format check is not run by it at this pin (see target.env).</Description>
+    <Description>Runs the CI tasks openclaw/openclaw's own pipeline runs -- clone, cold install (its exact CI invocation), lint (Oxlint), extension-channel lint (type-aware Oxlint), typecheck (tsgo), shrinkwrap check, fast unit tests, test-tree typecheck (tsgo) -- against a pinned main-HEAD checkout, timing each phase per sandbox provider.</Description>
     <ResultScale>Seconds</ResultScale>
     <Proportion>LIB</Proportion>
     <Executable>realworld-run</Executable>
@@ -38,10 +38,6 @@
         <Entry>
           <Name>Lint Oxlint</Name>
           <Value>lint_oxlint</Value>
-        </Entry>
-        <Entry>
-          <Name>Lint Format</Name>
-          <Value>lint_format</Value>
         </Entry>
         <Entry>
           <Name>Lint Extensions</Name>

--- a/packages/schema/src/pts-profiles/local/realworld-openclaw-1.0.0/test-definition.xml
+++ b/packages/schema/src/pts-profiles/local/realworld-openclaw-1.0.0/test-definition.xml
@@ -4,7 +4,7 @@
   <TestInformation>
     <Title>OpenClaw CI Tasks</Title>
     <AppVersion>623534400684eca7c451cf587189fae714f2abe2</AppVersion>
-    <Description>Runs the CI tasks openclaw/openclaw's own pipeline runs -- clone, cold install (its exact CI invocation), lint (Oxlint), format check, typecheck (tsgo), shrinkwrap check, fast unit tests, build -- against a pinned main-HEAD checkout, timing each phase per sandbox provider.</Description>
+    <Description>Runs the CI tasks openclaw/openclaw's own pipeline runs -- clone, cold install (its exact CI invocation), lint (Oxlint), format check, typecheck (tsgo), shrinkwrap check, fast unit tests, test-tree typecheck (tsgo) -- against a pinned main-HEAD checkout, timing each phase per sandbox provider.</Description>
     <ResultScale>Seconds</ResultScale>
     <Proportion>LIB</Proportion>
     <Executable>realworld-run</Executable>
@@ -56,8 +56,8 @@
           <Value>test_unit_fast</Value>
         </Entry>
         <Entry>
-          <Name>Build</Name>
-          <Value>build</Value>
+          <Name>Test Types</Name>
+          <Value>test_types</Value>
         </Entry>
       </Menu>
     </Option>

--- a/packages/schema/src/pts-profiles/local/realworld-openclaw-1.0.0/test-definition.xml
+++ b/packages/schema/src/pts-profiles/local/realworld-openclaw-1.0.0/test-definition.xml
@@ -4,7 +4,7 @@
   <TestInformation>
     <Title>OpenClaw CI Tasks</Title>
     <AppVersion>623534400684eca7c451cf587189fae714f2abe2</AppVersion>
-    <Description>Runs the CI tasks openclaw/openclaw's own pipeline runs -- clone, cold install (its exact CI invocation), lint (Oxlint), format check, extension-channel lint (type-aware Oxlint), typecheck (tsgo), shrinkwrap check, fast unit tests, test-tree typecheck (tsgo) -- against a pinned main-HEAD checkout, timing each phase per sandbox provider.</Description>
+    <Description>Runs a selected set of openclaw/openclaw development tasks -- clone, cold install (its exact CI invocation), lint (Oxlint), format check, extension-channel lint (type-aware Oxlint), typecheck (tsgo), shrinkwrap check, fast unit tests, test-tree typecheck (tsgo) -- against a pinned main-HEAD checkout, timing each phase per sandbox provider. Most mirror openclaw's own CI pipeline; format check is not run by it at this pin (see target.env).</Description>
     <ResultScale>Seconds</ResultScale>
     <Proportion>LIB</Proportion>
     <Executable>realworld-run</Executable>

--- a/packages/schema/src/pts-profiles/local/realworld-openclaw-1.0.0/test-definition.xml
+++ b/packages/schema/src/pts-profiles/local/realworld-openclaw-1.0.0/test-definition.xml
@@ -4,7 +4,7 @@
   <TestInformation>
     <Title>OpenClaw CI Tasks</Title>
     <AppVersion>623534400684eca7c451cf587189fae714f2abe2</AppVersion>
-    <Description>Runs the CI tasks openclaw/openclaw's own pipeline runs -- clone, cold install (its exact CI invocation), lint (Oxlint), format check, typecheck (tsgo), shrinkwrap check, fast unit tests, test-tree typecheck (tsgo) -- against a pinned main-HEAD checkout, timing each phase per sandbox provider.</Description>
+    <Description>Runs the CI tasks openclaw/openclaw's own pipeline runs -- clone, cold install (its exact CI invocation), lint (Oxlint), format check, extension-channel lint (type-aware Oxlint), typecheck (tsgo), shrinkwrap check, fast unit tests, test-tree typecheck (tsgo) -- against a pinned main-HEAD checkout, timing each phase per sandbox provider.</Description>
     <ResultScale>Seconds</ResultScale>
     <Proportion>LIB</Proportion>
     <Executable>realworld-run</Executable>
@@ -42,6 +42,10 @@
         <Entry>
           <Name>Lint Format</Name>
           <Value>lint_format</Value>
+        </Entry>
+        <Entry>
+          <Name>Lint Extensions</Name>
+          <Value>lint_extensions</Value>
         </Entry>
         <Entry>
           <Name>Typecheck</Name>

--- a/packages/schema/src/suites.ts
+++ b/packages/schema/src/suites.ts
@@ -308,6 +308,7 @@ export const SUITES = {
 			"realworld_openclaw_task_cold_install",
 			"realworld_openclaw_task_lint_oxlint",
 			"realworld_openclaw_task_lint_format",
+			"realworld_openclaw_task_lint_extensions",
 			"realworld_openclaw_task_typecheck",
 			"realworld_openclaw_task_shrinkwrap_check",
 			"realworld_openclaw_task_test_unit_fast",

--- a/packages/schema/src/suites.ts
+++ b/packages/schema/src/suites.ts
@@ -311,7 +311,7 @@ export const SUITES = {
 			"realworld_openclaw_task_typecheck",
 			"realworld_openclaw_task_shrinkwrap_check",
 			"realworld_openclaw_task_test_unit_fast",
-			"realworld_openclaw_task_build",
+			"realworld_openclaw_task_test_types",
 		],
 		commands: ["mise run benchmark:realworld:pts:openclaw"],
 	},

--- a/packages/schema/src/suites.ts
+++ b/packages/schema/src/suites.ts
@@ -307,7 +307,6 @@ export const SUITES = {
 			"realworld_openclaw_task_git_clone",
 			"realworld_openclaw_task_cold_install",
 			"realworld_openclaw_task_lint_oxlint",
-			"realworld_openclaw_task_lint_format",
 			"realworld_openclaw_task_lint_extensions",
 			"realworld_openclaw_task_typecheck",
 			"realworld_openclaw_task_shrinkwrap_check",


### PR DESCRIPTION
## Summary

This PR updates the OpenClaw realworld benchmark profile to replace the non-functional `build` task with `test_types`, adds a new `lint_extensions` task, and fixes cold install measurement by properly detecting and wiping pnpm 11's content-addressable store.

## Key Changes

- **Task Replacement**: Removed `build` task (which consistently OOMed at this pin) and replaced it with `test_types` (pnpm check:test-types), which fits the 8 GiB spec and provides meaningful CPU load measurement
- **New Lint Task**: Added `lint_extensions` task (pnpm lint:extensions:channels) as a working alternative to the type-aware Oxlint that OOMs on the full monorepo
- **Cold Install Fix**: 
  - Added `XDG_DATA_HOME` environment variable pinning in realworld-runner.sh and install.sh to properly target pnpm 11's store location (pnpm 11 no longer reads `npm_config_store_dir`)
  - Added store existence validation after cold reset to prevent silent warm-install measurements
  - Updated reset logic to wipe both legacy and new store paths
- **Environment Variables**: Added `OPENCLAW_LOCAL_CHECK=0` to lint_oxlint, typecheck, and shrinkwrap_check tasks to match CI job configurations and disable throttling where needed
- **Documentation**: Extensive comments explaining:
  - Throttle policy and per-task state (which tasks are throttled vs unthrottled)
  - Why build task was dropped and memory constraints
  - Why test_types cannot be unthrottled despite being from check-shard
  - Known incompatibilities and permanently-red tasks (lint_format, shrinkwrap_check)
  - Cold install store detection and pnpm 11 behavior

## Notable Implementation Details

- The test_types task is deliberately kept throttled despite being from check-shard, as unthrottling causes OOM (6.97 GB peak vs 7.28 GB cap = ~4% headroom)
- Cold install timing will increase by ~10x due to fixing the warm-store bug (10.9s → ~70s for openclaw)
- All metric descriptions updated to reflect new task list
- Metric definitions and overrides updated to add lint_extensions and test_types, remove build

https://claude.ai/code/session_01WXser7SpNiP6ro2pTSRTFA

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaced the OpenClaw `build` task with `test_types`, added `lint_extensions`, and removed `lint_format`. Made `cold_install` truly cold across providers and aligned throttling with CI for the tasks that support it.

- **New Features**
  - Swapped `build` for `test_types` (`pnpm check:test-types`); kept throttled to avoid OOM.
  - Added `lint_extensions` (`pnpm lint:extensions:channels`) as a working type-aware Oxlint task.
  - Dropped `lint_format` (not a CI task and permanently red at this pin).
  - Ran check-shard tasks unthrottled to match CI: set `OPENCLAW_LOCAL_CHECK=0` for `lint_oxlint`, `typecheck`, and `shrinkwrap_check`; left `test_types` throttled.
  - Updated test menu, metric IDs/labels, suites, and catalog descriptions to reflect the new task set.

- **Bug Fixes**
  - Made `cold_install` actually cold by pinning `PNPM_HOME` and `XDG_DATA_HOME`, wiping both, and asserting the resolved `pnpm` store is absent; bounded the `pnpm store path` probe.
  - Froze `MISE_DATA_DIR` before moving `XDG_DATA_HOME` to keep Node/`pnpm` shims working during install.

<sup>Written for commit c2213842205f0a6a6dae10aedd47868b760d98ba. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/starslingdev/hpc-sandbox-benchmarks/pull/276?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added “Lint Extensions” and “Test Types” tasks to the OpenClaw realworld test profile.
  * Added metrics and selectable options for the new tasks.

* **Bug Fixes**
  * Improved cold-install isolation by pinning package-manager storage and clearing cached state more comprehensively.
  * Added safeguards to detect unexpectedly retained package stores.

* **Updates**
  * Refined task definitions and CI phase descriptions.
  * Removed the unavailable Build task and updated related profile metadata.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->