### PR TITLE
Drive replicate fan-out from single process instead of matrix

### DIFF
--- a/.github/workflows/bench-matrix.yml
+++ b/.github/workflows/bench-matrix.yml
@@ -77,7 +77,7 @@ on:
         # rejects any other non-numeric value.
         default: ''
       max_concurrency:
-        description: 'Cap replicate sandboxes in flight per (suite, provider) cell (blank = unbounded, i.e. all R at once). Set a number when a provider quota is smaller than R — an over-quota create retries for up to 60 min inside the cell, so an unbounded fan-out against a tight quota burns the job budget queueing. A cap serializes the cell into ceil(R / cap) waves, so wall clock grows proportionally; a cap whose waves cannot fit the cell job timeout is rejected before any sandbox is created (at the realworld defaults, R=12 over a 90-minute suite, that floor is 6).'
+        description: 'Cap replicate sandboxes in flight per (suite, provider) cell (blank = unbounded, i.e. all R at once). Set a number when a provider quota is smaller than R — an over-quota create retries for up to 60 min inside the cell, so an unbounded fan-out against a tight quota burns the job budget queueing. A cap serializes the cell into ceil(R / cap) waves, so wall clock grows proportionally; a cap whose waves cannot fit the cell job timeout (plus the host margin) is rejected before any sandbox is created, and the error names the smallest cap that would fit. Note the realworld suites leave no room to cap at all: R=12 over a 90-minute suite affords ONE wave inside a 180-minute job, so anything below 12 is refused — cap the synthetic suites, or raise the cell timeout first.'
         required: false
         type: string
         # Blank preserves the old behaviour exactly: R separate runners each held one sandbox with

--- a/.github/workflows/bench-matrix.yml
+++ b/.github/workflows/bench-matrix.yml
@@ -1,12 +1,18 @@
 name: Bench matrix
 
-# Fan the live benchmark out across the provider × suite × replicate matrix using GitHub's native
-# reusable-workflow nesting. `plan` emits all three axes; a single suite-matrix job calls the reusable
-# bench-suite.yml once per suite (`name: ${{ matrix.suite }}`), and that reusable fans out
-# provider × replicate — so each cell displays as "<suite> / <provider> (replicate N)" (e.g.
-# "system / e2b (replicate 0)") and cells nest under their suite in the Actions UI. Adding a suite is a
-# schema change only: the suite axis is `fromJSON(needs.plan.outputs.suites)`, kept in lockstep by the
-# workflow-registry-sync gate.
+# Fan the live benchmark out across the provider × suite matrix using GitHub's native reusable-workflow
+# nesting. `plan` emits all three axes; a single suite-matrix job calls the reusable bench-suite.yml
+# once per suite (`name: ${{ matrix.suite }}`), and that reusable fans out over providers — so each cell
+# displays as "<suite> / <provider>" (e.g. "system / e2b") and cells nest under their suite in the
+# Actions UI. Adding a suite is a schema change only: the suite axis is
+# `fromJSON(needs.plan.outputs.suites)`, kept in lockstep by the workflow-registry-sync gate.
+#
+# The THIRD axis, replicates, is deliberately NOT a runner axis: `plan` hands each suite's replicate
+# index array to its cells as data, and one runner drives that cell's whole replicate fleet
+# concurrently in-process (`bench-suite --replicates`). A bench runner is ~100% idle waiting on its
+# sandbox, so a runner per replicate billed R idle runners to do one runner's work — at the shipped
+# defaults that is 324 runners where 54 suffice, with identical sandbox load and wall clock. See
+# bench-suite.yml's header for the failure-isolation contract inside a cell.
 #
 # Three configurable inputs tune the statistics, all defaulting to the schema/per-suite config so a bare
 # dispatch reproduces the configured run:
@@ -14,7 +20,8 @@ name: Bench matrix
 #     pre-merge knob, so a validation dispatch can run just one suite instead of the whole matrix.
 #   * `replicas` — replicate sandboxes per (provider, suite) cell, the BETWEEN-machine axis (blank = each
 #     suite's Suite.defaultReplicas — synthetic R=3, realworld R=12; a number scales every suite). More
-#     replicates → tighter intervals on a provider's fleet variation, at proportional runner cost.
+#     replicates → tighter intervals on a provider's fleet variation, at proportional PROVIDER cost
+#     (sandbox minutes) but flat runner cost — the cell's runner drives them all concurrently.
 #   * `pts_passes` — timed PTS passes per case INSIDE a sandbox, the WITHIN-machine axis (blank = each
 #     suite's own policy: the cpu-node and memory suites converge, while every other suite (system, disk,
 #     pgbench, network, realworld) keeps a fixed count; a number or `converge` forces one policy across
@@ -69,6 +76,15 @@ on:
         # axis). A number or "converge" is the GLOBAL override applied to every suite. resolvePtsPassPolicy
         # rejects any other non-numeric value.
         default: ''
+      max_concurrency:
+        description: 'Cap replicate sandboxes in flight per (suite, provider) cell (blank = unbounded, i.e. all R at once). Set a number when a provider quota is smaller than R — an over-quota create retries for up to 60 min inside the cell, so an unbounded fan-out against a tight quota burns the job budget queueing. A cap serializes the cell into ceil(R / cap) waves, so wall clock grows proportionally.'
+        required: false
+        type: string
+        # Blank preserves the old behaviour exactly: R separate runners each held one sandbox with
+        # nothing coordinating them, so the fan-out was already unbounded per provider. The difference
+        # now is that GitHub's concurrent-JOB limit no longer incidentally throttles it — see
+        # bench-suite.yml's header on peak provider concurrency.
+        default: ''
       allow_branch:
         description: 'Allow benchmark cells on a non-main ref (publish remains main-only).'
         required: false
@@ -104,8 +120,9 @@ jobs:
       providers: ${{ steps.plan.outputs.providers }}
       suites: ${{ steps.plan.outputs.suites }}
       # A JSON object mapping each selected suite to its replicate index array (e.g.
-      # {"cpu-node":[0,1,2],...}). The suite-matrix job indexes it by matrix.suite to get that suite's
-      # own replicate axis, so per-category replicate counts stay registry-driven like the suite axis.
+      # {"cpu-node":[0,1,2],...}). The suite-matrix job indexes it by matrix.suite and passes that
+      # suite's slice down for the cell to fan out over in-process, so per-category replicate counts
+      # stay registry-driven like the suite axis.
       replicates: ${{ steps.plan.outputs.replicates }}
     steps:
       - name: Checkout
@@ -140,7 +157,8 @@ jobs:
 
   # One matrix cell per selected suite → reusable workflow call. GitHub nests the reusable's provider
   # matrix under each suite name, so the Actions UI shows expandable "<suite>" groups with "<provider>"
-  # children (display: "<suite> / <provider>"). fail-fast stays off so one bad suite doesn't cancel peers.
+  # children (display: "<suite> / <provider>"); each of those children drives its own R replicate
+  # sandboxes. fail-fast stays off so one bad suite doesn't cancel peers.
   # The fork/branch guard is repeated here (not only inherited via `needs: plan`) so the job stays
   # explicit when read in isolation — matching every other live-run job in the repo.
   suite:
@@ -169,10 +187,12 @@ jobs:
       providers: ${{ needs.plan.outputs.providers }}
       suite: ${{ matrix.suite }}
       # Hand this suite its own replicate slice out of the plan's per-suite map (keyed by matrix.suite),
-      # re-serialized to the JSON string the reusable workflow's `replicate` axis parses with fromJSON.
+      # re-serialized to the JSON array string each cell passes straight to `bench-suite --replicates`.
       replicates: ${{ toJSON(fromJSON(needs.plan.outputs.replicates)[matrix.suite]) }}
       # Forward the PTS passes-per-case override unchanged (blank = suite default, a number, or converge).
       pts_passes: ${{ inputs.pts_passes }}
+      # Forward the per-cell replicate concurrency cap unchanged (blank = all R sandboxes at once).
+      max_concurrency: ${{ inputs.max_concurrency }}
     secrets: inherit
 
   # Collect every shard Run, aggregate into one candidate, gate it (promote), and commit the machine-

--- a/.github/workflows/bench-matrix.yml
+++ b/.github/workflows/bench-matrix.yml
@@ -77,7 +77,7 @@ on:
         # rejects any other non-numeric value.
         default: ''
       max_concurrency:
-        description: 'Cap replicate sandboxes in flight per (suite, provider) cell (blank = unbounded, i.e. all R at once). Set a number when a provider quota is smaller than R — an over-quota create retries for up to 60 min inside the cell, so an unbounded fan-out against a tight quota burns the job budget queueing. A cap serializes the cell into ceil(R / cap) waves, so wall clock grows proportionally.'
+        description: 'Cap replicate sandboxes in flight per (suite, provider) cell (blank = unbounded, i.e. all R at once). Set a number when a provider quota is smaller than R — an over-quota create retries for up to 60 min inside the cell, so an unbounded fan-out against a tight quota burns the job budget queueing. A cap serializes the cell into ceil(R / cap) waves, so wall clock grows proportionally; a cap whose waves cannot fit the cell job timeout is rejected before any sandbox is created (at the realworld defaults, R=12 over a 90-minute suite, that floor is 6).'
         required: false
         type: string
         # Blank preserves the old behaviour exactly: R separate runners each held one sandbox with

--- a/.github/workflows/bench-suite.yml
+++ b/.github/workflows/bench-suite.yml
@@ -212,9 +212,10 @@ jobs:
           # This job's `timeout-minutes`, handed to the CLI so it can REFUSE a cap that cannot fit rather
           # than be cancelled three hours in with every shard of the cell lost. A cap runs the fan-out in
           # ceil(R / cap) serial waves, so the cell's worst case is waves x the suite's own budget — and
-          # at the realworld defaults (R=12, a 90-minute suite) any cap below 6 already exceeds the 180
-          # below. A literal, not an expression: `timeout-minutes` cannot be read from an expression
-          # context, so workflow-sync's Invariant 5 asserts the two stay equal instead.
+          # at the realworld defaults (R=12, a 90-minute suite) the 180 below affords ONE wave once the
+          # host margin is set aside, so any cap short of the full 12 is refused. A literal, not an
+          # expression: `timeout-minutes` cannot be read from an expression context, so workflow-sync's
+          # Invariant 5 asserts the two stay equal instead.
           BENCH_CELL_BUDGET_MINUTES: '180'
           # PTS passes-per-case policy: blank = the suite's own policy (cpu-node + memory converge, the rest
           # fixed), a number or "converge" overrides every suite. Read by the harness preamble.
@@ -245,8 +246,36 @@ jobs:
           NSC_TOKEN_FILE: ${{ steps.nsc-token.outcome == 'success' && format('{0}/nsc-token.json', runner.temp) || '' }}
         run: bun apps/cli/src/bin/bench-suite.ts "$BENCH_PROVIDER" "$BENCH_SUITE" "$GITHUB_RUN_ID" --replicates "$BENCH_REPLICATES"
 
-      - name: Upload Run + raw results
+      # Did THIS attempt actually produce shard Runs? The upload below overwrites the cell's artifact,
+      # and overwriting is only safe when there is something to put in its place.
+      #
+      # `if-no-files-found: error` cannot answer this. The cell uploads `path: data/`, and `data/dataset/`
+      # is CHECKED IN — so data/ is non-empty from the moment of checkout, on every attempt, whatever the
+      # benchmark did. That guard has therefore never been able to fire, and combining it with `overwrite`
+      # would be actively harmful: a retry that dies before writing a single shard (runner eviction, a
+      # failed install, an early crash) would still upload the checked-out dataset files, delete the
+      # previous attempt's good shards, and leave commit-dataset.yml to drop this (suite, provider) cell
+      # from the published run entirely. Losing a healthy first attempt to a broken second one is worse
+      # than the duplicate-name rejection `overwrite` exists to avoid.
+      #
+      # So: gate on the shard files by name. A pass that wrote shards replaces the attempt it retried; a
+      # pass that wrote none leaves the previous attempt's artifact standing. The job's own red/green is
+      # unaffected — bench-suite already decided that — this only governs what gets published.
+      - name: Check this attempt wrote shard Runs
+        id: shards
         if: always()
+        run: |
+          shopt -s nullglob
+          shards=(data/runs/"$GITHUB_RUN_ID"*.json)
+          echo "count=${#shards[@]}" >> "$GITHUB_OUTPUT"
+          if [ ${#shards[@]} -eq 0 ]; then
+            echo "::warning title=No shards::this attempt wrote no shard Run; keeping any previous attempt's artifact"
+          else
+            echo "this attempt wrote ${#shards[@]} shard Run(s)"
+          fi
+
+      - name: Upload Run + raw results
+        if: always() && steps.shards.outputs.count != '0'
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           # Per-cell artifact name so every (provider, suite) cell uploads independently, carrying its R
@@ -258,15 +287,15 @@ jobs:
           name: bench-${{ inputs.suite }}-${{ matrix.provider }}-${{ github.run_id }}
           path: data/
           # A "Re-run failed jobs" keeps github.run_id and only bumps run_attempt, so this name is
-          # unchanged on the retry — and upload-artifact@v4+ REJECTS a duplicate name by default. Without
-          # this the retry's fleet would be computed and then thrown away at the upload boundary, leaving
-          # the run to aggregate the first attempt's stale shards (or, with `if-no-files-found: error`
-          # above already satisfied, to fail the cell a second time for a reason that has nothing to do
-          # with the benchmark). Overwrite so the replacement fleet supersedes the attempt it retried.
-          # Scope is exactly this cell: the name carries (suite, provider, run_id), so replacing it
-          # cannot disturb another cell's artifact. commit-dataset.yml's per-cell shard preference (see
-          # its "Aggregate + promote" step) then reads one shape per cell, never a mix.
+          # unchanged on the retry — and upload-artifact@v4+ REJECTS a duplicate name by default, which
+          # would compute the retry's whole fleet and then throw it away at the upload boundary. Overwrite
+          # so the replacement fleet supersedes the attempt it retried; the step condition above is what
+          # keeps that replacement from ever being an empty one. Scope is exactly this cell: the name
+          # carries (suite, provider, run_id), so replacing it cannot disturb another cell's artifact.
+          # commit-dataset.yml's per-cell shard preference (see its "Aggregate + promote" step) then
+          # reads one shape per cell, never a mix.
           overwrite: true
-          # A run always writes at least one shard (even an all-skipped Run), so an empty data/ means the
-          # job is genuinely broken — fail the upload rather than bury a warning.
+          # Kept as a backstop, though the step condition above now owns the "did this attempt produce
+          # anything" question — data/ also carries the checked-in data/dataset/ tree, so this alone can
+          # never see an empty upload.
           if-no-files-found: error

--- a/.github/workflows/bench-suite.yml
+++ b/.github/workflows/bench-suite.yml
@@ -71,7 +71,9 @@ on:
           Set a number when a provider's account quota is smaller than R: an over-quota create is retried
           for up to 60 minutes inside the cell, so an unbounded fan-out against a tight quota spends the
           job budget queueing. A cap makes the cell run in ceil(R / cap) SERIAL waves, so the wall clock
-          becomes waves x suite runtime — size it against the job's timeout-minutes.
+          becomes waves x suite runtime. A cap whose waves cannot fit the job's timeout-minutes is
+          REJECTED before any sandbox is created (BENCH_CELL_BUDGET_MINUTES below) — losing a whole
+          cell's fleet to a deterministic timeout is not a degradation worth discovering at 180 minutes.
         required: false
         type: string
         default: ''
@@ -207,6 +209,13 @@ jobs:
           # Blank = unbounded (all R sandboxes at once). See the max_concurrency input above: this is the
           # control for a provider whose quota is smaller than R, and it trades wall clock for peak load.
           BENCH_MAX_CONCURRENCY: ${{ inputs.max_concurrency }}
+          # This job's `timeout-minutes`, handed to the CLI so it can REFUSE a cap that cannot fit rather
+          # than be cancelled three hours in with every shard of the cell lost. A cap runs the fan-out in
+          # ceil(R / cap) serial waves, so the cell's worst case is waves x the suite's own budget — and
+          # at the realworld defaults (R=12, a 90-minute suite) any cap below 6 already exceeds the 180
+          # below. A literal, not an expression: `timeout-minutes` cannot be read from an expression
+          # context, so workflow-sync's Invariant 5 asserts the two stay equal instead.
+          BENCH_CELL_BUDGET_MINUTES: '180'
           # PTS passes-per-case policy: blank = the suite's own policy (cpu-node + memory converge, the rest
           # fixed), a number or "converge" overrides every suite. Read by the harness preamble.
           BENCH_PTS_PASSES: ${{ inputs.pts_passes }}
@@ -248,6 +257,16 @@ jobs:
           # goes red because ONE replicate failed still uploads every shard its healthy peers wrote.
           name: bench-${{ inputs.suite }}-${{ matrix.provider }}-${{ github.run_id }}
           path: data/
+          # A "Re-run failed jobs" keeps github.run_id and only bumps run_attempt, so this name is
+          # unchanged on the retry — and upload-artifact@v4+ REJECTS a duplicate name by default. Without
+          # this the retry's fleet would be computed and then thrown away at the upload boundary, leaving
+          # the run to aggregate the first attempt's stale shards (or, with `if-no-files-found: error`
+          # above already satisfied, to fail the cell a second time for a reason that has nothing to do
+          # with the benchmark). Overwrite so the replacement fleet supersedes the attempt it retried.
+          # Scope is exactly this cell: the name carries (suite, provider, run_id), so replacing it
+          # cannot disturb another cell's artifact. commit-dataset.yml's per-cell shard preference (see
+          # its "Aggregate + promote" step) then reads one shape per cell, never a mix.
+          overwrite: true
           # A run always writes at least one shard (even an all-skipped Run), so an empty data/ means the
           # job is genuinely broken — fail the upload rather than bury a warning.
           if-no-files-found: error

--- a/.github/workflows/bench-suite.yml
+++ b/.github/workflows/bench-suite.yml
@@ -1,19 +1,43 @@
 name: Benchmark suite (reusable)
 
-# One suite, fanned out across a provider × replicate matrix. bench-matrix.yml calls this once per suite
-# via its suite-matrix job (`name: ${{ matrix.suite }}`), passing the plan's selected provider list AND
-# that suite's replicate index array — so cells display as "<suite> / <provider> (replicate N)" and every
-# provider's replicate sandboxes nest under one suite label in the Actions UI. The replicate axis is the
-# BETWEEN-MACHINE knob: R sandboxes of one (provider, suite) capture a provider's fleet variation (two can
-# land on different host hardware), which the aggregate folds into per-metric replicate breakdowns.
+# One suite, fanned out across the provider matrix — ONE runner per (suite, provider) cell, which drives
+# that cell's whole replicate fleet itself. bench-matrix.yml calls this once per suite via its
+# suite-matrix job (`name: ${{ matrix.suite }}`), passing the plan's selected provider list AND that
+# suite's replicate index array — so cells display as "<suite> / <provider>" and nest under one suite
+# label in the Actions UI. The replicate axis is the BETWEEN-MACHINE knob: R sandboxes of one
+# (provider, suite) capture a provider's fleet variation (two can land on different host hardware),
+# which the aggregate folds into per-metric replicate breakdowns.
+#
+# Replicates are NOT a matrix axis. A bench runner spends effectively all of its wall time waiting on a
+# sandbox (create → poll a detached step → poll again), so a runner-per-replicate matrix billed R idle
+# runners to do one runner's work: at the shipped defaults (6 providers × 9 suites, R=3 synthetic /
+# R=12 realworld) that is 324 runners for 54 runners' worth of driving. `bench-suite --replicates` now
+# creates the same R sandboxes concurrently from one process, so the TOTAL sandbox count is unchanged
+# while the runner-minutes bill stops scaling with R.
+#
+# PEAK provider concurrency is NOT unchanged, and that is the one cost of this design. Under the old
+# axis the 324 jobs contended for GitHub's account-wide concurrent-job limit, which incidentally
+# rate-limited how many sandboxes existed at once. 54 jobs fit under any plan's cap, so a matrix run
+# can now hold all 54 of a provider's replicate sandboxes simultaneously. Providers answer an over-quota
+# create with a capacity error, which `createSuiteSandbox` retries patiently for up to 60 minutes — so
+# the degradation is queueing, not failure, but it spends the job budget. `max_concurrency` below is the
+# control; `strategy.max-parallel` on the caller's suite matrix is the coarser alternative.
+#
+# Replicate-level failure isolation is preserved inside the process: every replicate runs to completion
+# and writes its shard even when a peer throws, and the cell goes red at the end if any did. Note this
+# is NARROWER than the old `fail-fast: false`, which also isolated whole-cell events — a job timeout,
+# runner eviction, OOM, or a "re-run failed jobs" click now costs all R replicates of the cell rather
+# than one. Sizing `max_concurrency` against `timeout-minutes` below is what keeps that risk bounded.
+#
 # Factoring the shared cell here (checkout → run → upload, plus the per-provider credential wiring)
 # keeps that block in ONE place instead of copy-pasted into every suite job, mirroring
 # runner-benchmarking's reusable bench-suite.yml.
 #
-# The artifact name (bench-<suite>-<provider>-r<replicate>-<run_id>) is load-bearing: commit-dataset.yml
-# downloads the shards by the `bench-*-<run_id>` pattern and aggregates them — keep the two in lockstep.
-# The `-r<replicate>` segment keeps each replicate's shard a distinct artifact even though every shard of
-# one run shares the same runId file (data/runs/<run_id>.json); the aggregate keys them by --replicate.
+# The artifact name (bench-<suite>-<provider>-<run_id>) is load-bearing: commit-dataset.yml downloads
+# the shards by the `bench-*-<run_id>` pattern and aggregates them — keep the two in lockstep. One
+# artifact now carries the cell's R shards, each written to its own `data/runs/<run_id>-r<idx>.json`
+# (every shard of one run shares the same `runId` FIELD, so the `-r<idx>` filename suffix is what keeps
+# them distinct); the aggregate keys them by the --replicate index stamped on each Run.
 #
 # Environment `privileged` (required reviewers + environment secrets — see docs/ci-secrets.md) lives on
 # the fan-out job here: a `uses:` caller can't declare `environment:`, so the approval gate and the
@@ -35,10 +59,22 @@ on:
         description: >-
           JSON array of replicate sandbox indices for THIS suite, e.g. "[0,1,2]" — the between-machine
           fan-out axis. plan-replicates emits it per suite (Suite.defaultReplicas, or the BENCH_REPLICAS
-          override); the caller passes each suite its own slice. One matrix cell runs per (provider,
-          replicate), each tagged with `--replicate <idx>` so the aggregate folds them by index.
+          override); the caller passes each suite its own slice. Handed to `bench-suite --replicates`
+          VERBATIM: one matrix cell per provider drives every index in the array concurrently, each
+          sandbox tagged with its `--replicate <idx>` so the aggregate folds them by index.
         required: true
         type: string
+      max_concurrency:
+        description: >-
+          Cap on replicate sandboxes in flight per cell (BENCH_MAX_CONCURRENCY). Blank = unbounded, i.e.
+          all R at once — the fastest option and the one that matches what R separate runners used to do.
+          Set a number when a provider's account quota is smaller than R: an over-quota create is retried
+          for up to 60 minutes inside the cell, so an unbounded fan-out against a tight quota spends the
+          job budget queueing. A cap makes the cell run in ceil(R / cap) SERIAL waves, so the wall clock
+          becomes waves x suite runtime — size it against the job's timeout-minutes.
+        required: false
+        type: string
+        default: ''
       pts_passes:
         description: >-
           PTS passes-per-case override for the harness (BENCH_PTS_PASSES) — the within-machine axis.
@@ -59,28 +95,34 @@ permissions:
 
 jobs:
   bench:
-    # Display as "<caller suite job> / <provider> (replicate N)", e.g. "system / e2b (replicate 0)" —
-    # the replicate cells nest under their suite's job name in the Actions UI (GitHub-native
-    # reusable-workflow nesting). The replicate suffix keeps each of a provider's R sandboxes a
-    # distinct, legible cell (a bare `${{ matrix.provider }}` would render them all identically).
-    name: ${{ matrix.provider }} (replicate ${{ matrix.replicate }})
+    # Display as "<caller suite job> / <provider>", e.g. "system / e2b" — the provider cells nest under
+    # their suite's job name in the Actions UI (GitHub-native reusable-workflow nesting). One cell owns
+    # all R replicate sandboxes of that (suite, provider), so there is no replicate suffix to
+    # disambiguate; the per-replicate breakdown lives in the cell's job summary + `[r<idx>]` log tags.
+    name: ${{ matrix.provider }}
     environment: privileged
     # The ephemeral self-hosted label is reaped after 70 minutes even while a step is healthy. The
     # full CPU-generic and real-world matrices legitimately exceed that on slower providers, leaving
     # the step stuck `in_progress` with no logs/artifact. Hosted runners honor timeout-minutes below;
     # 180 minutes also leaves teardown/artifact margin around the longest 155-minute suite budget.
     # (workflow-registry-sync asserts this stays above the longest registered sandbox lifetime.)
+    #
+    # Driving R replicates from one runner does not need a bigger budget WHEN THEY RUN CONCURRENTLY: the
+    # cell's wall clock is then the slowest replicate, not their sum — the same bound a single-replicate
+    # cell had. Two things break that assumption and both consume this one shared budget:
+    #   * a `max_concurrency` cap, which makes the cell run ceil(R / cap) serial waves; and
+    #   * provider capacity errors, which `createSuiteSandbox` retries for up to 60 minutes per replicate
+    #     before giving up, so a fan-out wider than the account quota queues inside the budget.
+    # At R=12 against a suite budgeted near 90 minutes, either can exceed 180. Raise this, or lower the
+    # fan-out, rather than discovering it as a cancelled cell that loses all R replicates at once.
     runs-on: ubuntu-24.04
     timeout-minutes: 180
     strategy:
-      # One cell's failure (a flaky provider, or one bad replicate) must not cancel the rest of the matrix.
+      # One provider's failure (a flaky adapter, a dead account) must not cancel the rest of the matrix.
+      # Replicate-level isolation is handled INSIDE the cell — see the header note.
       fail-fast: false
       matrix:
         provider: ${{ fromJSON(inputs.providers) }}
-        # The between-machine axis: R replicate sandboxes per provider, expanded into provider × replicate
-        # cells. The array is this suite's slice of plan-replicates' map (Suite.defaultReplicas / the
-        # BENCH_REPLICAS override), so a suite runs exactly the replicate count its category configures.
-        replicate: ${{ fromJSON(inputs.replicates) }}
     steps:
       # Third-party actions are pinned to a commit SHA (the tag comment is for humans) so a
       # moved/compromised tag can't silently change what runs.
@@ -115,9 +157,11 @@ jobs:
       # is rejected outright ("not allowed in revokable tokens"), and each wrong verb name (e.g.
       # "read"/"delete" instead of "get"/"destroy") is named individually in the CLI's error.
       #
-      # The cell's suite/replicate name the token so a leaked one is traceable to the cell that minted
-      # it; both reach the shell through the environment, never interpolated into the run block, so a
+      # The cell's suite names the token so a leaked one is traceable to the cell that minted it; it
+      # reaches the shell through the environment, never interpolated into the run block, so a
       # dispatch-controlled suite name can't inject into the runner command (zizmor template-injection).
+      # One token per cell now covers all R of its replicate sandboxes (they share this process's
+      # credentials, exactly as they share every other provider secret in the run step below).
       # run_attempt is part of the name because run_id is PRESERVED across re-runs: without it a retry
       # collides with the first attempt's token, and continue-on-error would turn that name clash into a
       # silent namespace skip — on exactly the re-run where you wanted the validation.
@@ -127,11 +171,10 @@ jobs:
         id: nsc-token
         env:
           BENCH_SUITE: ${{ inputs.suite }}
-          BENCH_REPLICATE: ${{ matrix.replicate }}
           NSC_TOKEN_PATH: ${{ runner.temp }}/nsc-token.json
         run: |
           nsc token create \
-            --name "sandbox-benchmarks-${BENCH_SUITE}-r${BENCH_REPLICATE}-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}" \
+            --name "sandbox-benchmarks-${BENCH_SUITE}-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}" \
             --grant '{"resource_type":"instance","resource_id":"*","actions":["create","list","get","destroy","exec"]}' \
             --token_file "$NSC_TOKEN_PATH"
 
@@ -144,10 +187,11 @@ jobs:
       - name: Install dependencies
         run: bun install --frozen-lockfile --ignore-scripts
 
-      # Drive the provider SDK to create a sandbox, run the suite, collect results, and normalize. The
-      # cell's provider + replicate are matrix values and its suite the reusable input, all passed through
-      # the environment (never interpolated into the shell) so none can inject into the runner command.
-      # On success/failure the bin also writes a compact job summary + run annotation (clean Results).
+      # Drive the provider SDK to create this cell's R replicate sandboxes, run the suite in each,
+      # collect results, and normalize one shard Run per replicate. The cell's provider is a matrix value
+      # and its suite + replicate array are reusable inputs, all passed through the environment (never
+      # interpolated into the shell) so none can inject into the runner command. On success/failure the
+      # bin writes ONE job summary for the whole fleet (a row per replicate) + a run annotation.
       - name: Run suite and normalize
         env:
           BENCH_REPO_REF: ${{ github.sha }}
@@ -156,9 +200,13 @@ jobs:
           BENCH_REPO_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           BENCH_PROVIDER: ${{ matrix.provider }}
           BENCH_SUITE: ${{ inputs.suite }}
-          # The replicate index this shard represents — stamped onto its Run so the aggregate folds the R
-          # sandboxes of one (provider, suite) into per-metric replicate breakdowns rather than colliding.
-          BENCH_REPLICATE: ${{ matrix.replicate }}
+          # The replicate index array this cell drives (the plan's per-suite slice, verbatim). Each index
+          # gets its own sandbox and its own shard Run, stamped with that index so the aggregate folds the
+          # R sandboxes of one (provider, suite) into per-metric replicate breakdowns rather than colliding.
+          BENCH_REPLICATES: ${{ inputs.replicates }}
+          # Blank = unbounded (all R sandboxes at once). See the max_concurrency input above: this is the
+          # control for a provider whose quota is smaller than R, and it trades wall clock for peak load.
+          BENCH_MAX_CONCURRENCY: ${{ inputs.max_concurrency }}
           # PTS passes-per-case policy: blank = the suite's own policy (cpu-node + memory converge, the rest
           # fixed), a number or "converge" overrides every suite. Read by the harness preamble.
           BENCH_PTS_PASSES: ${{ inputs.pts_passes }}
@@ -186,17 +234,20 @@ jobs:
           # (steps.nsc-token only runs when matrix.provider == 'namespace'), which the harness reads
           # as the standard missing-credentials skip on every other cell.
           NSC_TOKEN_FILE: ${{ steps.nsc-token.outcome == 'success' && format('{0}/nsc-token.json', runner.temp) || '' }}
-        run: bun apps/cli/src/bin/bench-suite.ts "$BENCH_PROVIDER" "$BENCH_SUITE" "$GITHUB_RUN_ID" --replicate "$BENCH_REPLICATE"
+        run: bun apps/cli/src/bin/bench-suite.ts "$BENCH_PROVIDER" "$BENCH_SUITE" "$GITHUB_RUN_ID" --replicates "$BENCH_REPLICATES"
 
       - name: Upload Run + raw results
         if: always()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          # Per-cell artifact name so every (provider, suite, replicate) shard uploads independently — the
-          # `-r<replicate>` segment is what keeps R replicates of one cell from colliding on one name (they
-          # all write the same data/runs/<run_id>.json). commit-dataset.yml matches these by `bench-*-<run_id>`.
-          name: bench-${{ inputs.suite }}-${{ matrix.provider }}-r${{ matrix.replicate }}-${{ github.run_id }}
+          # Per-cell artifact name so every (provider, suite) cell uploads independently, carrying its R
+          # replicate shards (data/runs/<run_id>-r<idx>.json — the filename suffix keeps them distinct,
+          # since every shard's Run carries the same `runId` field). commit-dataset.yml matches these by
+          # `bench-*-<run_id>` and globs both the `-r<idx>` shards and the legacy un-suffixed name.
+          # `if: always()` is what preserves failure isolation across the upload boundary: a cell that
+          # goes red because ONE replicate failed still uploads every shard its healthy peers wrote.
+          name: bench-${{ inputs.suite }}-${{ matrix.provider }}-${{ github.run_id }}
           path: data/
-          # A successful run always writes data/runs/<id>.json (even an all-skipped Run), so an empty
-          # data/ means the job is genuinely broken — fail the upload rather than bury a warning.
+          # A run always writes at least one shard (even an all-skipped Run), so an empty data/ means the
+          # job is genuinely broken — fail the upload rather than bury a warning.
           if-no-files-found: error

--- a/.github/workflows/commit-dataset.yml
+++ b/.github/workflows/commit-dataset.yml
@@ -93,17 +93,40 @@ jobs:
       # Aggregate the shards' Run documents into one candidate, then promote (gate on >=1 validated
       # provider) and publish into the committed dataset at data/dataset/. The run-id matches the shards.
       #
-      # The glob names the Run document EXACTLY, `<runId>.json`, and must not gain a `data/` segment:
-      # the bench cell uploads `path: data/`, and upload-artifact roots the artifact at the least common
-      # ancestor of the matched files — so a shard unpacks as `shards/<artifact>/runs/<runId>.json`, with
-      # no `data/` prefix. Two decoys sit next to it that a `runs/*.json` wildcard would sweep in: the
-      # sibling `runs/index.json` (an index, not a Run), and `dataset/runs/<oldRunId>.json` (the committed
-      # dataset, which rides along because it lives under data/). Both would poison the aggregate.
+      # The globs name the Run documents EXACTLY and must not gain a `data/` segment: the bench cell
+      # uploads `path: data/`, and upload-artifact roots the artifact at the least common ancestor of the
+      # matched files — so a shard unpacks as `shards/<artifact>/runs/<runId>...json`, with no `data/`
+      # prefix. Two decoys sit next to them that a `runs/*.json` wildcard would sweep in: the sibling
+      # `runs/index.json` (an index, not a Run), and `dataset/runs/<oldRunId>.json` (the committed
+      # dataset, which rides along because it lives under data/, and which the `runs/` segment excludes).
+      # Both would poison the aggregate.
+      #
+      # TWO shard shapes exist, and they are selected with a PREFERENCE, never unioned:
+      #   * `<runId>-r<idx>.json` — the current per-replicate shards (one runner drives all R replicates
+      #     of a (suite, provider) cell, so they share an artifact and are told apart by the suffix).
+      #   * `<runId>.json` — the un-suffixed single-shard name written by a run that predates the
+      #     fan-out change. Keeping it is what lets a backfill dispatch re-aggregate an older run's
+      #     still-retained artifacts.
+      #
+      # Preference, not union, because run ids are PRESERVED across re-runs: a run whose first attempt
+      # predates the change and whose retry postdates it leaves BOTH shapes under one run id. Unioning
+      # them would hand `aggregate` two shards describing the SAME sandbox — a shard with no
+      # replicateIndex normalizes to index 0, colliding with `-r0` — and its documented first-wins
+      # rule would silently drop one sandbox's whole measured set while leaving no replicate breakdown,
+      # making the result indistinguishable from a genuine single-replicate run. Taking the
+      # per-replicate shards whenever ANY exist keeps the newer, complete attempt and never mixes the
+      # two vocabularies. The count is echoed so a short set is visible in the log rather than inferred.
       - name: Aggregate + promote
         run: |
           shopt -s nullglob
-          shards=(shards/*/runs/"$RUN_ID".json)
+          shards=(shards/*/runs/"$RUN_ID"-r*.json)
+          shape="per-replicate"
+          if [ ${#shards[@]} -eq 0 ]; then
+            shards=(shards/*/runs/"$RUN_ID".json)
+            shape="legacy single-shard"
+          fi
           if [ ${#shards[@]} -eq 0 ]; then echo "no shard Run documents found for run $RUN_ID" >&2; exit 1; fi
+          echo "aggregating ${#shards[@]} $shape shard(s) for run $RUN_ID"
           bun apps/cli/src/bin/aggregate.ts "$RUN_ID" data/candidate "${shards[@]}"
           bun apps/cli/src/bin/promote.ts "data/candidate/runs/$RUN_ID.json" data/dataset
 

--- a/.github/workflows/commit-dataset.yml
+++ b/.github/workflows/commit-dataset.yml
@@ -113,20 +113,51 @@ jobs:
       # them would hand `aggregate` two shards describing the SAME sandbox — a shard with no
       # replicateIndex normalizes to index 0, colliding with `-r0` — and its documented first-wins
       # rule would silently drop one sandbox's whole measured set while leaving no replicate breakdown,
-      # making the result indistinguishable from a genuine single-replicate run. Taking the
-      # per-replicate shards whenever ANY exist keeps the newer, complete attempt and never mixes the
-      # two vocabularies. The count is echoed so a short set is visible in the log rather than inferred.
+      # making the result indistinguishable from a genuine single-replicate run.
+      #
+      # The preference is applied PER CELL, never run-wide, because the collision it guards against is
+      # per-cell: the two shapes describe the same sandbox only when they came from the same
+      # (suite, provider) artifact. `merge-multiple: false` above unpacks each cell into its own
+      # `shards/<artifact>/` subdir, so that subdir IS the cell boundary — loop over it and ask each cell
+      # which shape it wrote. A run-wide preference reads the shapes as a single global choice, and a
+      # mixed-shape run (retry a cell that failed on the old code, and only that cell re-runs on the new)
+      # then publishes ONLY the retried cell: every other provider/suite of the run, still legacy-only,
+      # is silently discarded and the dataset is promoted a fraction of the size it should be. Per cell,
+      # the retried cell contributes its `-r<idx>` fleet and its untouched peers contribute their legacy
+      # shard, which is the union across cells and the preference within one — exactly the intent.
+      #
+      # (Both shapes under ONE cell needs `overwrite: true` on the cell's upload — see bench-suite.yml —
+      # to be reachable at all, since a re-run otherwise cannot claim the name. The per-cell preference
+      # is the belt to that suspenders: it stays correct for artifacts uploaded before that fix and for
+      # a backfill dispatch reaching back to any older run.)
+      #
+      # The per-shape cell counts are echoed so a short or lopsided set is visible in the log rather
+      # than inferred.
       - name: Aggregate + promote
         run: |
           shopt -s nullglob
-          shards=(shards/*/runs/"$RUN_ID"-r*.json)
-          shape="per-replicate"
-          if [ ${#shards[@]} -eq 0 ]; then
-            shards=(shards/*/runs/"$RUN_ID".json)
-            shape="legacy single-shard"
-          fi
+          shards=()
+          fanout_cells=0
+          legacy_cells=0
+          for cell in shards/*/; do
+            # The `-r*` probe is a real glob, so nullglob empties it when the cell wrote no fleet. The
+            # legacy name has NO wildcard left once "$cell" is an expanded literal, and nullglob only
+            # ever rewrites words that ARE patterns — so it must be probed with `-f`, or every cell
+            # would contribute a non-existent path and be miscounted as legacy.
+            cell_shards=("$cell"runs/"$RUN_ID"-r*.json)
+            if [ ${#cell_shards[@]} -gt 0 ]; then
+              fanout_cells=$((fanout_cells + 1))
+            elif [ -f "$cell"runs/"$RUN_ID".json ]; then
+              cell_shards=("$cell"runs/"$RUN_ID".json)
+              legacy_cells=$((legacy_cells + 1))
+            else
+              cell_shards=()
+            fi
+            shards+=("${cell_shards[@]}")
+          done
           if [ ${#shards[@]} -eq 0 ]; then echo "no shard Run documents found for run $RUN_ID" >&2; exit 1; fi
-          echo "aggregating ${#shards[@]} $shape shard(s) for run $RUN_ID"
+          echo "aggregating ${#shards[@]} shard(s) for run $RUN_ID" \
+            "from $fanout_cells per-replicate + $legacy_cells legacy single-shard cell(s)"
           bun apps/cli/src/bin/aggregate.ts "$RUN_ID" data/candidate "${shards[@]}"
           bun apps/cli/src/bin/promote.ts "data/candidate/runs/$RUN_ID.json" data/dataset
 

--- a/apps/cli/src/bin/aggregate.ts
+++ b/apps/cli/src/bin/aggregate.ts
@@ -1,6 +1,7 @@
 #!/usr/bin/env bun
 // `aggregate` — merge the per-shard Run documents of one benchmark run (the CI matrix emits one per
-// `(provider, suite)` cell) into a single candidate Run, written to a candidate dataset + index. This
+// `(provider, suite, replicate)` sandbox — one cell's runner drives all R of its replicates and writes
+// a shard each) into a single candidate Run, written to a candidate dataset + index. This
 // is the collect half of candidate→promote: `promote` then validates and publishes the candidate.
 // Uses @actions/core for foldable groups, debug metadata, annotations, and a job summary in CI.
 

--- a/apps/cli/src/bin/bench-suite.fleet.test.ts
+++ b/apps/cli/src/bin/bench-suite.fleet.test.ts
@@ -1,0 +1,157 @@
+// The fan-out cell's job-summary surface at the widths the `replicas` dispatch knob allows. The
+// shipped defaults are R=3/R=12, but `replicas` scales every suite at once, so the reporting has to
+// stay legible (and the annotation bounded) well past that — these pin it up to R=49.
+import { describe, expect, it } from "bun:test";
+import type { Run } from "@sandbox-benchmarks/schema";
+import type { ReplicateOutcome } from "./bench-suite.ts";
+import { fleetAnnotationMessage, fleetFailureDetail, replicateSummaryRows } from "./bench-suite.ts";
+
+const PROVIDER = "blaxel";
+
+/** A shard Run carrying one provider slice, enough for the summary row to read. */
+const runFor = (overrides: Partial<Run["providers"][number]> = {}): Run =>
+	({
+		providers: [
+			{
+				providerId: PROVIDER,
+				validationStatus: "validated",
+				observedSpecs: { cpuModel: "AMD EPYC" },
+				specMatched: true,
+				metrics: [{ metricId: "git_seconds" }, { metricId: "pybench_milliseconds" }],
+				suitesCovered: ["system"],
+				gaps: [],
+				uncatalogued: [],
+				...overrides,
+			},
+		],
+	}) as unknown as Run;
+
+/** N successful replicates, r0..r(N-1). */
+const fleet = (count: number): ReplicateOutcome[] =>
+	Array.from({ length: count }, (_, index) => ({
+		index,
+		outFile: `data/runs/ci-1-r${index}.json`,
+		run: runFor(),
+		failed: false,
+	}));
+
+describe("replicateSummaryRows at wide fan-outs", () => {
+	it("emits exactly one row per replicate plus a header, up to R=49", () => {
+		for (const count of [1, 5, 12, 49]) {
+			const rows = replicateSummaryRows(PROVIDER, fleet(count));
+			expect(rows).toHaveLength(count + 1);
+			// Every row carries the full column set, so no cell silently shifts under a wide fan-out.
+			expect(new Set(rows.map((row) => row.length))).toEqual(new Set([9]));
+		}
+	});
+
+	it("keeps rows in replicate order and labels each shard distinctly", () => {
+		const rows = replicateSummaryRows(PROVIDER, fleet(49)).slice(1);
+		expect(rows[0]?.[0]).toBe("<code>r0</code>");
+		expect(rows[48]?.[0]).toBe("<code>r48</code>");
+		// Distinct shard paths are what prove R replicates did not collide on one file.
+		expect(new Set(rows.map((row) => row[8])).size).toBe(49);
+	});
+
+	// The per-sandbox spec columns are the point of the fan-out: a replicate that landed on different
+	// host hardware is the first explanation to reach for when one is an outlier.
+	it("surfaces observed CPU and spec match per replicate", () => {
+		const rows = replicateSummaryRows(PROVIDER, [
+			{ index: 0, outFile: "a.json", run: runFor(), failed: false },
+			{
+				index: 1,
+				outFile: "b.json",
+				run: runFor({ observedSpecs: { cpuModel: "Intel Xeon" }, specMatched: false }),
+				failed: false,
+			},
+		]).slice(1);
+		expect(rows[0]?.slice(6, 8)).toEqual(["<code>AMD EPYC</code>", "true"]);
+		expect(rows[1]?.slice(6, 8)).toEqual(["<code>Intel Xeon</code>", "false"]);
+	});
+
+	it("shows an em-dash rather than an empty cell when a spec probe returned nothing", () => {
+		const rows = replicateSummaryRows(PROVIDER, [
+			{
+				index: 0,
+				outFile: "a.json",
+				run: runFor({ observedSpecs: {}, specMatched: undefined }),
+				failed: false,
+			},
+		]).slice(1);
+		expect(rows[0]?.slice(6, 8)).toEqual(["<code>—</code>", "—"]);
+	});
+
+	it("renders a two-digit index without confusing it for a single-digit one", () => {
+		const rows = replicateSummaryRows(PROVIDER, fleet(13)).slice(1);
+		expect(rows.map((row) => row[0])).toContain("<code>r12</code>");
+		expect(rows.map((row) => row[0])).not.toContain("<code>r1 2</code>");
+	});
+
+	it("reports a replicate that produced no Run without blanking the row", () => {
+		const rows = replicateSummaryRows(PROVIDER, [
+			{ index: 0, outFile: "data/runs/ci-1-r0.json", failed: true, detail: "boom" },
+		]).slice(1);
+		// Em-dashes, not empty cells: "we have no Run" must stay visibly different from "zero metrics".
+		expect(rows[0]).toEqual([
+			"<code>r0</code>",
+			"failure",
+			"—",
+			"—",
+			"—",
+			"—",
+			"<code>—</code>",
+			"—",
+			"<code>data/runs/ci-1-r0.json</code>",
+		]);
+	});
+
+	it("distinguishes a healthy replicate from a validated-but-empty one", () => {
+		const rows = replicateSummaryRows(PROVIDER, [
+			{ index: 0, outFile: "a.json", run: runFor(), failed: false },
+			{
+				index: 1,
+				outFile: "b.json",
+				run: runFor({ validationStatus: "pending", metrics: [] }),
+				failed: false,
+			},
+		]).slice(1);
+		expect(rows[0]?.slice(1, 4)).toEqual(["success", "validated", "2"]);
+		expect(rows[1]?.slice(1, 4)).toEqual(["success", "pending", "0"]);
+	});
+});
+
+describe("fleet annotation bounding", () => {
+	/** N failures whose reasons are as long as a real require-gate/suite-failure message. */
+	const failures = (count: number): ReplicateOutcome[] =>
+		Array.from({ length: count }, (_, index) => ({
+			index,
+			outFile: `data/runs/ci-1-r${index}.json`,
+			failed: true,
+			detail: `Required provider "${PROVIDER}" produced no metrics — system failed: ${"x".repeat(200)}`,
+		}));
+
+	it("names every failure in the job-summary detail, however wide the fan-out", () => {
+		const detail = fleetFailureDetail(failures(49));
+		expect(detail.split("\n")).toHaveLength(49);
+		expect(detail).toContain("r48:");
+	});
+
+	// GitHub truncates a long annotation, so an unbounded message would cut mid-reason and lose the
+	// count — the one fact a reader needs at a glance.
+	it("caps the annotation and points at the summary for the rest", () => {
+		const message = fleetAnnotationMessage(failures(49), 49, 0);
+		expect(message.startsWith("49/49 replicate(s) failed")).toBe(true);
+		expect(message).toContain("…and 46 more (see the job summary)");
+		expect(message.length).toBeLessThan(1000);
+	});
+
+	it("does not add a 'more' pointer when every failure fits", () => {
+		const message = fleetAnnotationMessage(failures(2), 12, 10);
+		expect(message).toContain("2/12 replicate(s) failed");
+		expect(message).not.toContain("more (see the job summary)");
+	});
+
+	it("reports the validated count when nothing failed", () => {
+		expect(fleetAnnotationMessage([], 49, 49)).toBe("49/49 replicate(s) validated");
+	});
+});

--- a/apps/cli/src/bin/bench-suite.test.ts
+++ b/apps/cli/src/bin/bench-suite.test.ts
@@ -1,5 +1,53 @@
 import { describe, expect, it } from "bun:test";
-import { parseReplicateFlag } from "./bench-suite.ts";
+import { PROVIDERS, SUITE_NAMES } from "@sandbox-benchmarks/schema";
+import { HELP, parseReplicateFlag } from "./bench-suite.ts";
+
+/** The ids `runSuite` actually matches on: it compares against the schema-joined adapter names
+ *  EXACTLY, so `LEGACY_PROVIDER_ALIASES` ("daytona", "modal") does not rescue a copied example.
+ *  Widened to `string[]` because the values under test are parsed out of the help text — the whole
+ *  point is to check an arbitrary string against the registry, which the literal union forbids. */
+const providerIds: string[] = PROVIDERS.map((p) => p.id);
+const suiteNames: string[] = [...SUITE_NAMES];
+
+describe("HELP", () => {
+	// The usage block is copy-paste surface: an operator (or an agent) runs an example verbatim. Every
+	// id it names must therefore be one the registry actually resolves. It drifted once already — the
+	// examples said "daytona"/"modal" while the registry had only `daytona-vm`, `daytona-container`,
+	// `modal-gvisor`, and `modal-vm`, so a copied line failed as an unknown provider. Pin the example
+	// lines against the registries rather than against a hardcoded list, so adding or renaming an id
+	// keeps this honest.
+	// Scoped to the `examples:` block: the prose headline and the `usage:` synopsis also begin with the
+	// binary name, but they carry placeholders ("[provider]"), not runnable ids.
+	const exampleArgs = HELP.slice(HELP.indexOf("\nexamples:"))
+		.split("\n")
+		.filter((line) => line.trim().startsWith("bench-suite "))
+		.map((line) =>
+			line
+				.trim()
+				.replace(/\s+#.*$/, "")
+				.split(/\s+/)
+				.slice(1),
+		)
+		.map((args) => args.filter((arg) => !arg.startsWith("-")));
+
+	it("names only registered providers and suites in its examples", () => {
+		expect(exampleArgs.length).toBeGreaterThan(0);
+		for (const args of exampleArgs) {
+			const [provider, suite] = args;
+			// A leading positional is always a provider id; the second, when present, is a suite. Later
+			// positionals are runIds and flag operands, which are free-form.
+			if (provider !== undefined) expect(providerIds).toContain(provider);
+			if (suite !== undefined) expect(suiteNames).toContain(suite);
+		}
+	});
+
+	// The documented default has to be the one the code actually takes, or `--help` teaches a provider
+	// that never runs.
+	it("documents the default provider the code falls back to", () => {
+		expect(HELP).toContain("(default: daytona-vm)");
+		expect(providerIds).toContain("daytona-vm");
+	});
+});
 
 describe("parseReplicateFlag", () => {
 	it("returns undefined when the flag is absent", () => {

--- a/apps/cli/src/bin/bench-suite.ts
+++ b/apps/cli/src/bin/bench-suite.ts
@@ -22,7 +22,8 @@ import {
 	unmetRequirements,
 } from "@sandbox-benchmarks/harness";
 import { writeNormalizedRun } from "@sandbox-benchmarks/results";
-import type { Run } from "@sandbox-benchmarks/schema";
+import type { Run, SuiteName } from "@sandbox-benchmarks/schema";
+import { SUITES } from "@sandbox-benchmarks/schema";
 import type { CellKind, SummaryRow } from "../lib/actions-log.ts";
 import {
 	escapeHtml,
@@ -40,10 +41,12 @@ import {
 import { handleDiscovery } from "../lib/discovery.ts";
 import { installLineTagging, withLineTag } from "../lib/log-prefix.ts";
 import {
+	fleetBudgetError,
 	lastFlagValue,
 	parseReplicateIndex,
 	parseReplicatesFlag,
 	replicatePaths,
+	resolveCellBudgetMinutes,
 	resolveMaxConcurrency,
 	runPooled,
 } from "../lib/replicates.ts";
@@ -68,13 +71,15 @@ function cellTitle(suite: string, provider: string): string {
 	return `${suite} / ${provider}`;
 }
 
-/** Agent-facing usage; bare invocation keeps the daytona/cpu-node local-dev default. */
+/** Agent-facing usage; bare invocation keeps the daytona-vm/cpu-node local-dev default. Every provider
+ *  named here is a canonical {@link ProviderId} — the positional argument is matched against the
+ *  registry exactly, so a copied example that said "daytona" or "modal" would fail as unknown. */
 export const HELP = `bench-suite — run a benchmark suite on a provider sandbox and normalize it into a Run document.
 
 usage: bench-suite [provider] [suite] [runId]
        bench-suite [--help] [--list-providers] [--list-suites] [--json]
 
-  provider                Provider to run on (default: daytona). See --list-providers.
+  provider                Provider to run on (default: daytona-vm). See --list-providers.
   suite                   Suite to run (default: cpu-node). See --list-suites.
   runId                   Run identifier for the data/ tree (default: local-<timestamp>).
   --replicates <indices>  Drive the whole replicate fan-out from THIS process: a JSON array
@@ -84,7 +89,9 @@ usage: bench-suite [provider] [suite] [runId]
                           is run to completion even if a peer fails. This is the CI matrix's form.
   --max-concurrency <n>   Cap the replicate sandboxes in flight (default: all at once). Also read from
                           BENCH_MAX_CONCURRENCY. Lower it when a provider's quota makes a wide fan-out
-                          spend its create-retry budget queueing.
+                          spend its create-retry budget queueing. A cap runs the fleet in ceil(R / n)
+                          serial waves; under CI (BENCH_CELL_BUDGET_MINUTES) a cap whose waves cannot
+                          fit the job budget is rejected up front rather than cancelled mid-fan-out.
   --replicate <idx>       Run ONE replicate (a non-negative integer), stamped onto the shard Run so
                           the aggregate folds ≥2 replicates of one suite together. Writes the
                           un-suffixed data/runs/<runId>.json — the single-sandbox/local form.
@@ -99,8 +106,8 @@ Missing provider credentials are recorded as a skip (the provider stays "pending
 runnable without secrets. Writes the shard Run(s) under data/runs/ and updates data/runs/index.json.
 
 examples:
-  bench-suite daytona cpu-node                    # one suite locally, auto runId
-  bench-suite modal memory ci-1234                # a specific cell + runId
+  bench-suite daytona-vm cpu-node                 # one suite locally, auto runId
+  bench-suite modal-vm memory ci-1234             # a specific cell + runId
   bench-suite e2b memory --require e2b            # fail (don't skip) if E2B_API_KEY is absent
   bench-suite e2b memory ci-1 --replicates 0,1,2  # 3 replicate sandboxes from this one process
   bench-suite --list-suites                       # discover the suite names first
@@ -508,9 +515,9 @@ if (import.meta.main) {
 	}
 
 	// Filter flags out before positional resolution so a trailing/misplaced flag (e.g.
-	// `bench-suite daytona cpu-node --json`) never gets captured as the runId. The VALUE_FLAGS above are
-	// the ones that take a separate operand, so consume that operand too — otherwise `--require daytona`
-	// would leave `daytona` behind to be read as the runId.
+	// `bench-suite daytona-vm cpu-node --json`) never gets captured as the runId. The VALUE_FLAGS above
+	// are the ones that take a separate operand, so consume that operand too — otherwise
+	// `--require daytona-vm` would leave `daytona-vm` behind to be read as the runId.
 	const positionals: string[] = [];
 	for (let i = 0; i < argv.length; i++) {
 		const arg = argv[i];
@@ -536,10 +543,12 @@ if (import.meta.main) {
 	let replicateIndices: number[] | undefined;
 	let maxConcurrency = Number.POSITIVE_INFINITY;
 	let singleReplicate: number | undefined;
+	let cellBudgetMinutes: number | undefined;
 	try {
 		replicateIndices = parseReplicatesFlag(argv);
 		maxConcurrency = resolveMaxConcurrency(argv);
 		singleReplicate = parseReplicateFlag(argv);
+		cellBudgetMinutes = resolveCellBudgetMinutes();
 	} catch (err) {
 		fail(err instanceof Error ? err.message : String(err), {
 			properties: { title: "bench-suite usage" },
@@ -551,6 +560,26 @@ if (import.meta.main) {
 			properties: { title: "bench-suite usage" },
 			exitCode: 2,
 		});
+	}
+
+	// A concurrency cap trades wall clock for peak provider load, and the cell has a FIXED job budget to
+	// pay that clock out of — so a cap can be small enough that the fan-out is cancelled mid-flight,
+	// losing every shard of the cell rather than just slowing it down. Reject that combination here,
+	// alongside the other malformed-axis guards and before a single sandbox exists. An unregistered
+	// suite is left alone: `describeSuiteTasks` below owns that error, and guessing a budget for a suite
+	// with no declared one would report the wrong problem.
+	const suiteBudget = suite in SUITES ? SUITES[suite as SuiteName].timeoutMinutes : undefined;
+	if (replicateIndices && cellBudgetMinutes !== undefined && suiteBudget !== undefined) {
+		const budgetError = fleetBudgetError({
+			replicates: replicateIndices.length,
+			maxConcurrency,
+			suite,
+			suiteTimeoutMinutes: suiteBudget,
+			budgetMinutes: cellBudgetMinutes,
+		});
+		if (budgetError) {
+			fail(budgetError, { properties: { title: "bench-suite usage" }, exitCode: 2 });
+		}
 	}
 
 	// The local newest-first Run index, shared by every replicate of this cell. It is keyed by runId and

--- a/apps/cli/src/bin/bench-suite.ts
+++ b/apps/cli/src/bin/bench-suite.ts
@@ -4,6 +4,13 @@
 // recorded as a skip (the provider stays `pending` in the Run), so this is runnable without secrets.
 // Logging and results go through @actions/core (groups, debug, annotations, job summary) so the
 // nested "<suite> / <provider>" cell is metadata-rich in the Actions UI.
+//
+// `--replicates <indices>` drives the WHOLE between-machine fan-out for this (provider, suite) cell
+// from one process: R sandboxes concurrently, one shard Run each. That is what lets a single GitHub
+// Actions runner own a cell — a bench runner is ~100% idle waiting on its sandbox, so the old
+// runner-per-replicate matrix billed R idle runners to do one runner's work (see ../lib/replicates.ts).
+// Every replicate is run to completion regardless of its peers' outcomes and its shard is written
+// either way, so one flaky sandbox can't discard the rest of the fleet's results.
 
 import { join } from "node:path";
 import * as core from "@actions/core";
@@ -16,17 +23,30 @@ import {
 } from "@sandbox-benchmarks/harness";
 import { writeNormalizedRun } from "@sandbox-benchmarks/results";
 import type { Run } from "@sandbox-benchmarks/schema";
+import type { CellKind, SummaryRow } from "../lib/actions-log.ts";
 import {
+	escapeHtml,
 	fail,
 	inActions,
 	logInfo,
 	logProviderStatuses,
 	logWarning,
 	providerSummaryRows,
+	renderCell,
+	setGroupingEnabled,
 	withGroup,
 	writeJobSummary,
 } from "../lib/actions-log.ts";
 import { handleDiscovery } from "../lib/discovery.ts";
+import { installLineTagging, withLineTag } from "../lib/log-prefix.ts";
+import {
+	lastFlagValue,
+	parseReplicateIndex,
+	parseReplicatesFlag,
+	replicatePaths,
+	resolveMaxConcurrency,
+	runPooled,
+} from "../lib/replicates.ts";
 import { suiteMetricSummaryRows, suiteTaskSummaryRows } from "../lib/suite-summary.ts";
 import type { SuiteTaskPlan } from "../lib/suite-tasks.ts";
 import { describeSuiteTasks } from "../lib/suite-tasks.ts";
@@ -42,72 +62,156 @@ function miseTaskSummary(plan: SuiteTaskPlan): string {
 	return `${plural(commands, "command")} → ${plural(leaves, "leaf task")}`;
 }
 
+/** The Actions-visible name of a (suite, provider) cell — the job-summary heading, the annotation
+ *  title, and the log line, all of which have to agree for a reader to connect them. */
+function cellTitle(suite: string, provider: string): string {
+	return `${suite} / ${provider}`;
+}
+
 /** Agent-facing usage; bare invocation keeps the daytona/cpu-node local-dev default. */
 export const HELP = `bench-suite — run a benchmark suite on a provider sandbox and normalize it into a Run document.
 
 usage: bench-suite [provider] [suite] [runId]
        bench-suite [--help] [--list-providers] [--list-suites] [--json]
 
-  provider           Provider to run on (default: daytona). See --list-providers.
-  suite              Suite to run (default: cpu-node). See --list-suites.
-  runId              Run identifier for the data/ tree (default: local-<timestamp>).
-  --replicate <idx>  Replicate sandbox index this shard represents (a non-negative integer). Stamped
-                     onto the shard Run so the aggregate folds ≥2 replicates of one suite together.
-  --require <ids>    Comma-separated providers that MUST reach "validated"; exit 1 otherwise.
-                     Also read from REQUIRE_PROVIDERS. CI sets this so a missing secret fails loudly.
-  --list-providers   List the registered providers.
-  --list-suites      List the registered suites and their dimensions/metrics.
-  --json             Emit --list-* output as JSON instead of human-readable lines.
-  --help, -h         Show this help.
+  provider                Provider to run on (default: daytona). See --list-providers.
+  suite                   Suite to run (default: cpu-node). See --list-suites.
+  runId                   Run identifier for the data/ tree (default: local-<timestamp>).
+  --replicates <indices>  Drive the whole replicate fan-out from THIS process: a JSON array
+                          ("[0,1,2]", what plan-replicates emits) or a comma-separated list ("0,1,2").
+                          Each index gets its own sandbox, raw tree (data/raw/<runId>/r<idx>/) and
+                          shard (data/runs/<runId>-r<idx>.json); they run concurrently and every one
+                          is run to completion even if a peer fails. This is the CI matrix's form.
+  --max-concurrency <n>   Cap the replicate sandboxes in flight (default: all at once). Also read from
+                          BENCH_MAX_CONCURRENCY. Lower it when a provider's quota makes a wide fan-out
+                          spend its create-retry budget queueing.
+  --replicate <idx>       Run ONE replicate (a non-negative integer), stamped onto the shard Run so
+                          the aggregate folds ≥2 replicates of one suite together. Writes the
+                          un-suffixed data/runs/<runId>.json — the single-sandbox/local form.
+  --require <ids>         Comma-separated providers that MUST reach "validated"; exit 1 otherwise.
+                          Also read from REQUIRE_PROVIDERS. CI sets this so a missing secret fails loudly.
+  --list-providers        List the registered providers.
+  --list-suites           List the registered suites and their dimensions/metrics.
+  --json                  Emit --list-* output as JSON instead of human-readable lines.
+  --help, -h              Show this help.
 
 Missing provider credentials are recorded as a skip (the provider stays "pending"), so this is
-runnable without secrets. Writes data/runs/<runId>.json and updates data/runs/index.json.
+runnable without secrets. Writes the shard Run(s) under data/runs/ and updates data/runs/index.json.
 
 examples:
-  bench-suite daytona cpu-node            # one suite locally, auto runId
-  bench-suite modal memory ci-1234        # a specific cell + runId
-  bench-suite e2b memory --require e2b    # fail (don't skip) if E2B_API_KEY is absent
-  bench-suite --list-suites               # discover the suite names first
+  bench-suite daytona cpu-node                    # one suite locally, auto runId
+  bench-suite modal memory ci-1234                # a specific cell + runId
+  bench-suite e2b memory --require e2b            # fail (don't skip) if E2B_API_KEY is absent
+  bench-suite e2b memory ci-1 --replicates 0,1,2  # 3 replicate sandboxes from this one process
+  bench-suite --list-suites                       # discover the suite names first
 
 Next: render the Run with \`leaderboard data/runs/<runId>.json\`.`;
 
-/** One exit path for every cell outcome — success, usage error, normalize failure, suite gap, require. */
-async function reportCell(opts: {
+/** What one replicate produced. Returned, never exited on: a replicate that dies must not take its
+ *  peers' sandboxes down with it, so the fleet driver decides the process exit code once, at the end. */
+export interface ReplicateOutcome {
+	/** The replicate index, or undefined for the single un-indexed run (local/smoke). */
+	index?: number;
+	/** Where this replicate's shard Run belongs. Always set — including on a failure that never got as
+	 *  far as writing it — so the fleet table can name the missing shard rather than blanking the cell. */
+	outFile: string;
+	/** The normalized shard Run, absent when normalization itself failed. */
+	run?: Run;
+	failed: boolean;
+	/** Why it failed (or a note about a recorded gap) — the annotation/summary text. */
+	detail?: string;
+}
+
+/** A short, stable label for one replicate in logs and summary tables. */
+function replicateLabel(index: number | undefined): string {
+	return index === undefined ? "single" : `r${index}`;
+}
+
+/**
+ * Parse `--replicate <idx>` / `--replicate=<idx>` into a non-negative integer, or `undefined` when the
+ * flag is absent. A dangling or non-integer value fails loudly rather than silently defaulting the shard
+ * to replicate 0 — a wrong index would collide two sandboxes into one replicate slot at aggregate time.
+ * Exported so the parsing is unit-testable without spawning a process. (The CI fan-out uses the plural
+ * `--replicates`; this is the single-sandbox spelling, sharing its validation.)
+ */
+export function parseReplicateFlag(argv: readonly string[]): number | undefined {
+	const raw = lastFlagValue(argv, "replicate");
+	if (raw === undefined) return undefined;
+	return parseReplicateIndex(raw);
+}
+
+/** Identity of the cell being reported, shared by both reporters below. */
+interface CellIdentity {
 	provider: string;
 	suite: string;
 	runId: string;
-	sha?: string;
-	outFile?: string;
-	run?: Run;
-	failed: boolean;
-	detail?: string;
+	sha: string;
+	/** The suite's resolved task plan, absent when discovery failed (the summary then omits it). */
 	taskPlan?: SuiteTaskPlan;
-}): Promise<void> {
-	const title = `${opts.suite} / ${opts.provider}`;
-	const status = opts.failed ? "failure" : "success";
-	const provider = opts.run?.providers.find((p) => p.providerId === opts.provider);
-	const annotationMessage =
-		opts.detail ??
-		(provider
-			? `${provider.providerId} ${provider.validationStatus} metrics=${provider.metrics.length}`
-			: title);
-	const taskTables = opts.taskPlan
-		? [
-				{ heading: "Mise tasks", rows: suiteTaskSummaryRows(opts.taskPlan) },
-				{ heading: "Declared metrics", rows: suiteMetricSummaryRows(opts.taskPlan) },
-			]
-		: [];
+}
+
+/**
+ * The half of a cell's job summary that does NOT depend on how many sandboxes ran: heading, cell
+ * identity, the suite's task plan, and the annotation wiring. `fields`/`tables` are appended to it —
+ * that is the only place the single-sandbox and fleet reports legitimately differ, so a change to the
+ * shared half can no longer land in one reporter and miss the other. (They drifted exactly that way
+ * once, when the fleet report shipped without the per-sandbox CPU/spec columns.)
+ */
+async function writeCellSummary(
+	opts: CellIdentity & {
+		failed: boolean;
+		/** Report-specific field rows, rendered after the cell identity. */
+		fields: Array<[label: string, value: string, kind: CellKind]>;
+		/** Report-specific tables, rendered before the task-plan tables. */
+		tables: Array<{ heading: string; rows: SummaryRow[] }>;
+		detail?: string;
+		annotationMessage: string;
+	},
+): Promise<void> {
+	const title = cellTitle(opts.suite, opts.provider);
+	const plan = opts.taskPlan;
 	await writeJobSummary({
 		heading: title,
 		fields: [
-			["Status", status, "plain"],
+			["Status", opts.failed ? "failure" : "success", "plain"],
 			["Suite", opts.suite, "code"],
 			["Provider", opts.provider, "code"],
 			["Run id", opts.runId, "code"],
-			["SHA", opts.sha ?? "", "code"],
-			["Artifact", opts.outFile ?? "", "code"],
-			["Harness commands", opts.taskPlan?.commands.join(" · ") ?? "", "code"],
-			["Mise tasks", opts.taskPlan ? miseTaskSummary(opts.taskPlan) : "", "plain"],
+			["SHA", opts.sha, "code"],
+			...opts.fields,
+			["Harness commands", plan?.commands.join(" · ") ?? "", "code"],
+			["Mise tasks", plan ? miseTaskSummary(plan) : "", "plain"],
+		],
+		tables: [
+			...opts.tables,
+			...(plan
+				? [
+						{ heading: "Mise tasks", rows: suiteTaskSummaryRows(plan) },
+						{ heading: "Declared metrics", rows: suiteMetricSummaryRows(plan) },
+					]
+				: []),
+		],
+		detail: opts.detail,
+		annotation: { failed: opts.failed, title, message: opts.annotationMessage },
+	});
+}
+
+/**
+ * The single-sandbox report: ONE cell, described in full. Deliberately richer per-provider than
+ * {@link reportFleet} rather than a special case of it — this is what a human reads after a manual
+ * bench-smoke dispatch or a local run, so it keeps the whole-Run provider table (every registered
+ * provider, with the skipped/failed gap split) that a fleet's one-row-per-replicate table has no room
+ * for, and names the target provider's validation state in the annotation itself.
+ */
+async function reportCell(
+	opts: CellIdentity & { outFile: string; run?: Run; failed: boolean; detail?: string },
+): Promise<void> {
+	const provider = opts.run?.providers.find((p) => p.providerId === opts.provider);
+	await writeCellSummary({
+		// Identity + failed/detail ride through as-is; `outFile`/`run` are spent on the rows below.
+		...opts,
+		fields: [
+			["Artifact", opts.outFile, "code"],
 			["Validation", provider?.validationStatus ?? (opts.run ? "absent" : ""), "plain"],
 			["Metrics", provider ? String(provider.metrics.length) : "", "plain"],
 			["Suites covered", provider ? String(provider.suitesCovered.length) : "", "plain"],
@@ -119,146 +223,159 @@ async function reportCell(opts: {
 				"plain",
 			],
 		],
-		tables: [
-			...taskTables,
-			...(opts.run ? [{ heading: "Provider status", rows: providerSummaryRows(opts.run) }] : []),
-		],
-		detail: opts.detail,
-		annotation: {
-			failed: opts.failed,
-			title,
-			message: annotationMessage,
-		},
+		tables: opts.run ? [{ heading: "Provider status", rows: providerSummaryRows(opts.run) }] : [],
+		annotationMessage:
+			opts.detail ??
+			(provider
+				? `${provider.providerId} ${provider.validationStatus} metrics=${provider.metrics.length}`
+				: cellTitle(opts.suite, opts.provider)),
 	});
-}
-
-type CellReport = Parameters<typeof reportCell>[0];
-
-/** Write the cell summary then fail without a second annotation. */
-async function failCell(opts: Omit<CellReport, "failed"> & { detail: string }): Promise<never> {
-	await reportCell({ ...opts, failed: true });
-	return fail(opts.detail, { annotate: false });
 }
 
 /**
- * Parse `--replicate <idx>` / `--replicate=<idx>` into a non-negative integer, or `undefined` when the
- * flag is absent. A dangling or non-integer value fails loudly rather than silently defaulting the shard
- * to replicate 0 — a wrong index would collide two sandboxes into one replicate slot at aggregate time.
- * Exported so the parsing is unit-testable without spawning a process.
+ * How many failing replicates the ANNOTATION names before deferring to the job summary. GitHub
+ * truncates a long annotation message, and the fan-out axis reaches R=12 today with the dispatch
+ * `replicas` knob able to push it far higher — pasting 40+ multi-sentence failure reasons into one
+ * annotation produces an unreadable wall that the runner may cut mid-reason anyway. The job summary
+ * keeps EVERY failure verbatim (it has a far larger budget and is the right place to read them), so
+ * this cap costs no information; it only decides how much the annotations panel previews.
  */
-export function parseReplicateFlag(argv: readonly string[]): number | undefined {
-	let raw: string | undefined;
-	for (let i = 0; i < argv.length; i++) {
-		const arg = argv[i];
-		if (arg === "--replicate") {
-			raw = argv[i + 1];
-			if (raw === undefined) throw new Error("--replicate requires an index argument");
-		} else if (arg?.startsWith("--replicate=")) {
-			raw = arg.slice("--replicate=".length);
-		}
-	}
-	if (raw === undefined) return undefined;
-	const idx = Number(raw);
-	// Number("")/Number("  ")/Number("\n") all coerce to 0, so `--replicate=` (or `--replicate ""`) would
-	// slip through as replicate 0 — guard the blank operand explicitly, else it silently collides two
-	// sandboxes into one replicate slot at aggregate time (the exact failure this function documents).
-	if (raw.trim() === "" || !Number.isInteger(idx) || idx < 0) {
-		throw new Error(`--replicate must be a non-negative integer; got "${raw}"`);
-	}
-	return idx;
+const ANNOTATION_FAILURE_LIMIT = 3;
+
+/** The complete, one-line-per-failure detail for the job summary — never truncated. */
+export function fleetFailureDetail(failures: readonly ReplicateOutcome[]): string {
+	return failures.map((o) => `${replicateLabel(o.index)}: ${o.detail ?? "failed"}`).join("\n");
 }
 
-if (import.meta.main) {
-	const argv = process.argv.slice(2);
-	// Flags that consume a separate operand — one source of truth so the discovery filter and the
-	// positional-skip loop below can never enumerate different sets.
-	const VALUE_FLAGS = ["--require", "--replicate"];
-	const discovery = handleDiscovery(argv, HELP, VALUE_FLAGS);
-	if (discovery !== null) {
-		if (discovery.ok) {
-			process.stdout.write(`${discovery.text}\n`);
-			process.exit(0);
-		}
-		fail(discovery.text, { properties: { title: "bench-suite discovery" }, exitCode: 2 });
-	}
+/**
+ * The annotation message for a fan-out cell: a count first (the fact a reader needs at a glance),
+ * then at most {@link ANNOTATION_FAILURE_LIMIT} failure reasons, then a pointer to the job summary
+ * for the rest. Bounded by design — see {@link ANNOTATION_FAILURE_LIMIT}.
+ */
+export function fleetAnnotationMessage(
+	failures: readonly ReplicateOutcome[],
+	total: number,
+	validated: number,
+): string {
+	if (failures.length === 0) return `${validated}/${total} replicate(s) validated`;
+	const shown = failures.slice(0, ANNOTATION_FAILURE_LIMIT);
+	const remaining = failures.length - shown.length;
+	return (
+		`${failures.length}/${total} replicate(s) failed — ${fleetFailureDetail(shown)}` +
+		(remaining > 0 ? `\n…and ${remaining} more (see the job summary)` : "")
+	);
+}
 
-	// Filter flags out before positional resolution so a trailing/misplaced flag (e.g.
-	// `bench-suite daytona cpu-node --json`) never gets captured as the runId. `--require` is the one
-	// flag that takes a separate operand, so consume that operand too — otherwise `--require daytona`
-	// would leave `daytona` behind to be read as the runId.
-	const positionals: string[] = [];
-	for (let i = 0; i < argv.length; i++) {
-		const arg = argv[i];
-		if (arg === undefined) continue;
-		// Only the space-separated spelling needs the skip: `--require=<ids>`/`--replicate=<idx>` are
-		// single tokens already dropped by the leading-`-` guard below. Both flags take a separate operand.
-		if (VALUE_FLAGS.includes(arg)) {
-			i++;
-			continue;
-		}
-		if (arg.startsWith("-")) continue;
-		positionals.push(arg);
-	}
-	const provider = positionals[0] ?? "daytona-vm";
-	const suite = positionals[1] ?? "cpu-node";
-	const runId = positionals[2] ?? `local-${Date.now()}`;
-	const sha = process.env.GITHUB_SHA ?? "local";
-	const cell = `${suite} / ${provider}`;
-	const replicateIndex = parseReplicateFlag(argv);
-
-	const rawRoot = join("data", "raw", runId);
-	const outFile = join("data", "runs", `${runId}.json`);
-	const indexFile = join("data", "runs", "index.json");
-
-	logInfo(`Benchmark cell ${cell}`);
-	if (inActions()) {
-		core.debug(
-			JSON.stringify({
-				provider,
-				suite,
-				runId,
-				sha,
-				rawRoot,
-				outFile,
-				require: requiredProviders(argv),
-			}),
-		);
-	}
-
-	// Resolve the precise mise tasks + PTS pins before the sandbox run so the job summary can name
-	// what this cell planned to execute (schema commands → mise task info → run_task leaves).
-	let taskPlan: SuiteTaskPlan | undefined;
-	await withGroup(`Discover suite tasks (${suite})`, async () => {
-		try {
-			taskPlan = await describeSuiteTasks(suite);
-			logInfo(`commands: ${taskPlan.commands.join(" · ")}`);
-			for (const task of taskPlan.tasks) {
-				const pts = task.ptsProfile ? ` pts=${task.ptsProfile}` : "";
-				const prefix = task.resultsPrefix ? ` prefix=${task.resultsPrefix}` : "";
-				logInfo(
-					`${task.role} ${task.task}${task.description ? ` — ${task.description}` : ""}${pts}${prefix}`,
-				);
-			}
-			if (inActions()) {
-				for (const metric of taskPlan.metrics) {
-					core.debug(
-						`metric ${metric.id} label=${metric.label}` +
-							(metric.ptsTest ? ` pts.test=${metric.ptsTest}` : ""),
-					);
-				}
-			}
-		} catch (err) {
-			const msg = `Could not describe suite tasks for "${suite}": ${err instanceof Error ? err.message : String(err)}`;
-			logWarning(msg, { title: cell });
-		}
+/** One row per replicate: what each sandbox produced, so a 12-way fan-out is legible at a glance
+ *  without opening 12 job logs (which is what the per-replicate matrix cells used to be). Exported
+ *  so the table is testable at the fan-out widths the `replicas` dispatch knob allows. */
+export function replicateSummaryRows(
+	provider: string,
+	outcomes: readonly ReplicateOutcome[],
+): SummaryRow[] {
+	const header: SummaryRow = [
+		{ data: "Replicate", header: true },
+		{ data: "Status", header: true },
+		{ data: "Validation", header: true },
+		{ data: "Metrics", header: true },
+		{ data: "Suites", header: true },
+		{ data: "Gaps", header: true },
+		// Per-SANDBOX, not per-cell, and that is the point: R replicates exist to measure a provider's
+		// fleet variation, and a replicate that landed on different host hardware (or off the target
+		// spec) is the single most likely explanation for an outlier. reportCell surfaces these for a
+		// single sandbox; dropping them here would have left the CI path — the one that feeds the
+		// dataset — unable to see per-replicate heterogeneity without downloading the shard artifacts.
+		// `specMatched` is also what drives the leaderboard's Comparability warning.
+		{ data: "Observed CPU", header: true },
+		{ data: "Spec", header: true },
+		{ data: "Shard", header: true },
+	];
+	const rows = outcomes.map((outcome) => {
+		const run = outcome.run?.providers.find((p) => p.providerId === provider);
+		return [
+			renderCell(replicateLabel(outcome.index), "code"),
+			escapeHtml(outcome.failed ? "failure" : "success"),
+			escapeHtml(run?.validationStatus ?? (outcome.run ? "absent" : "—")),
+			escapeHtml(run ? String(run.metrics.length) : "—"),
+			escapeHtml(run ? String(run.suitesCovered.length) : "—"),
+			escapeHtml(run ? String(run.gaps.length) : "—"),
+			renderCell(run?.observedSpecs.cpuModel || "—", "code"),
+			escapeHtml(run?.specMatched === undefined ? "—" : String(run.specMatched)),
+			renderCell(outcome.outFile, "code"),
+		];
 	});
+	return [header, ...rows];
+}
+
+/**
+ * The whole-fleet report for a `--replicates` run: ONE job summary + ONE annotation covering every
+ * replicate this runner drove. Deliberately not R separate reports — R annotations per cell would
+ * bury the run's annotation panel, and the failures a reader needs are the ones named in `detail`.
+ */
+async function reportFleet(
+	opts: CellIdentity & { outcomes: readonly ReplicateOutcome[] },
+): Promise<void> {
+	const failures = opts.outcomes.filter((o) => o.failed);
+	// Complete for the summary; the annotation gets the bounded preview from fleetAnnotationMessage.
+	const detail = fleetFailureDetail(failures);
+	const validated = opts.outcomes.filter(
+		(o) =>
+			o.run?.providers.find((p) => p.providerId === opts.provider)?.validationStatus ===
+			"validated",
+	).length;
+	await writeCellSummary({
+		// Identity rides through as-is; `outcomes` is spent on the counts and the table below.
+		...opts,
+		failed: failures.length > 0,
+		fields: [
+			["Replicates", String(opts.outcomes.length), "plain"],
+			["Validated replicates", `${validated}/${opts.outcomes.length}`, "plain"],
+			["Failed replicates", String(failures.length), "plain"],
+		],
+		tables: [{ heading: "Replicates", rows: replicateSummaryRows(opts.provider, opts.outcomes) }],
+		...(detail ? { detail } : {}),
+		annotationMessage: fleetAnnotationMessage(failures, opts.outcomes.length, validated),
+	});
+}
+
+/** Everything one replicate needs; `replicateIndex` undefined is the single un-indexed run. */
+interface ReplicateContext {
+	provider: string;
+	suite: string;
+	runId: string;
+	sha: string;
+	rawRoot: string;
+	outFile: string;
+	indexFile: string;
+	replicateIndex?: number;
+	/** Providers that must reach "validated" for this replicate to count as a success. */
+	required: readonly string[];
+}
+
+/**
+ * Run ONE replicate end to end — suite → normalize → gap verification → require gate — and report
+ * what happened. Total by construction: it never throws and never exits, because a `--replicates`
+ * fan-out has R of these in flight and one replicate's failure must not abort its peers or skip
+ * their shard writes (the per-replicate matrix cells had `fail-fast: false` for the same reason).
+ */
+export async function runReplicate(ctx: ReplicateContext): Promise<ReplicateOutcome> {
+	const { provider, suite, runId, sha, rawRoot, outFile, indexFile, replicateIndex } = ctx;
+	// Annotations are emitted as `::warning::` workflow commands, which bypass the `[rN]` line tagging
+	// by necessity (a tagged command stops being an annotation). So the replicate has to ride in the
+	// TITLE instead — otherwise a 12-way fan-out puts up to 12 byte-identical warnings in the panel
+	// with nothing saying which sandbox each came from.
+	const cell =
+		cellTitle(suite, provider) +
+		(replicateIndex === undefined ? "" : ` ${replicateLabel(replicateIndex)}`);
+	const base = { index: replicateIndex, outFile };
 
 	// A suite that RAN AND BROKE is a result — the harness has already written its `--failed.json` marker
 	// into the raw tree — so the error is held, not thrown. Normalizing anyway is what turns that marker
 	// into a recorded `failed` gap on this shard's Run document; rethrowing here would skip the write, the
 	// shard would contribute nothing for the aggregate to merge, and the only trace of the failure would
-	// die inside the CI artifact. The job still goes red at the bottom of this block.
+	// die inside the CI artifact. The replicate still reports failed at the bottom of this block.
 	let suiteError: unknown;
+	let usageError: string | undefined;
 	await withGroup(`Run suite ${suite} on ${provider}`, async () => {
 		try {
 			await runSuite({
@@ -274,15 +391,8 @@ if (import.meta.main) {
 			// A usage error (unknown provider/suite) produced no raw tree and no marker: there is nothing to
 			// normalize, and pretending otherwise would write an empty Run for a cell that never existed.
 			if (err instanceof SuiteUsageError) {
-				await failCell({
-					provider,
-					suite,
-					runId,
-					sha,
-					outFile,
-					detail: err.message,
-					taskPlan,
-				});
+				usageError = err.message;
+				return;
 			}
 			suiteError = err;
 			logWarning(
@@ -293,6 +403,7 @@ if (import.meta.main) {
 			);
 		}
 	});
+	if (usageError !== undefined) return { ...base, failed: true, detail: usageError };
 
 	let run: Run | undefined;
 	let normalizeError: unknown;
@@ -321,18 +432,7 @@ if (import.meta.main) {
 				: normalizeError
 					? String(normalizeError)
 					: "normalize produced no Run document";
-		await reportCell({
-			provider,
-			suite,
-			runId,
-			sha,
-			outFile,
-			failed: true,
-			detail,
-			taskPlan,
-		});
-		// Synchronous `never` so TypeScript narrows `run` for the paths below.
-		fail(detail, { annotate: false });
+		return { ...base, failed: true, detail };
 	}
 	const normalized = run;
 
@@ -361,31 +461,19 @@ if (import.meta.main) {
 			? `Suite "${suite}" failed on ${provider} — recorded as a failed gap in ${outFile}: ${message}`
 			: `Suite "${suite}" failed on ${provider} but no gap could be recorded in ${outFile} ` +
 				`(no failed marker survived into the raw tree; this job log is the only trace): ${message}`;
-		await failCell({
-			provider,
-			suite,
-			runId,
-			sha,
-			outFile,
-			run: normalized,
-			detail,
-			taskPlan,
-		});
+		return { ...base, run: normalized, failed: true, detail };
 	}
 
 	// Missing credentials (and an unusable sandbox) are recorded as a skip, not a throw — the lenient
 	// local-dev default. That would make a smoke run whose secret is missing/misnamed exit 0 having
 	// benchmarked nothing, so CI passes `--require <provider>` (or REQUIRE_PROVIDERS) to assert the
 	// provider actually reached `validated` — i.e. produced at least one catalogued metric.
-	// Pass the sliced argv explicitly rather than letting it default to `process.argv` (which also
-	// carries the bun executable and script path), so the flag this bin parses is the flag this gate reads.
-	const required = requiredProviders(argv);
-	if (required.length > 0) {
+	if (ctx.required.length > 0) {
 		const reports = normalized.providers.map((p) => ({
 			provider: p.providerId,
 			status: p.validationStatus === "validated" ? "ok" : p.validationStatus,
 		}));
-		const unmet = unmetRequirements(reports, required);
+		const unmet = unmetRequirements(reports, ctx.required);
 		if (unmet.length > 0) {
 			const details: string[] = [];
 			for (const providerId of unmet) {
@@ -397,28 +485,235 @@ if (import.meta.main) {
 				const line = `Required provider "${providerId}" produced no metrics${gapDetail ? ` — ${gapDetail}` : " and was absent from the Run"}`;
 				details.push(line);
 			}
-			await failCell({
+			return { ...base, run: normalized, failed: true, detail: details.join("\n") };
+		}
+	}
+
+	logInfo(`Cell ${cell} succeeded → ${outFile}`);
+	return { ...base, run: normalized, failed: false };
+}
+
+if (import.meta.main) {
+	const argv = process.argv.slice(2);
+	// Flags that consume a separate operand — one source of truth so the discovery filter and the
+	// positional-skip loop below can never enumerate different sets.
+	const VALUE_FLAGS = ["--require", "--replicate", "--replicates", "--max-concurrency"];
+	const discovery = handleDiscovery(argv, HELP, VALUE_FLAGS);
+	if (discovery !== null) {
+		if (discovery.ok) {
+			process.stdout.write(`${discovery.text}\n`);
+			process.exit(0);
+		}
+		fail(discovery.text, { properties: { title: "bench-suite discovery" }, exitCode: 2 });
+	}
+
+	// Filter flags out before positional resolution so a trailing/misplaced flag (e.g.
+	// `bench-suite daytona cpu-node --json`) never gets captured as the runId. The VALUE_FLAGS above are
+	// the ones that take a separate operand, so consume that operand too — otherwise `--require daytona`
+	// would leave `daytona` behind to be read as the runId.
+	const positionals: string[] = [];
+	for (let i = 0; i < argv.length; i++) {
+		const arg = argv[i];
+		if (arg === undefined) continue;
+		// Only the space-separated spelling needs the skip: `--require=<ids>`/`--replicates=<idx>` are
+		// single tokens already dropped by the leading-`-` guard below.
+		if (VALUE_FLAGS.includes(arg)) {
+			i++;
+			continue;
+		}
+		if (arg.startsWith("-")) continue;
+		positionals.push(arg);
+	}
+	const provider = positionals[0] ?? "daytona-vm";
+	const suite = positionals[1] ?? "cpu-node";
+	const runId = positionals[2] ?? `local-${Date.now()}`;
+	const sha = process.env.GITHUB_SHA ?? "local";
+	const cell = cellTitle(suite, provider);
+
+	// A malformed replicate axis must fail the cell before a single sandbox is created: a fan-out that
+	// silently collapsed to one sandbox (or to none) would publish a shard set the aggregate reads as a
+	// smaller, quieter experiment than the one that was dispatched.
+	let replicateIndices: number[] | undefined;
+	let maxConcurrency = Number.POSITIVE_INFINITY;
+	let singleReplicate: number | undefined;
+	try {
+		replicateIndices = parseReplicatesFlag(argv);
+		maxConcurrency = resolveMaxConcurrency(argv);
+		singleReplicate = parseReplicateFlag(argv);
+	} catch (err) {
+		fail(err instanceof Error ? err.message : String(err), {
+			properties: { title: "bench-suite usage" },
+			exitCode: 2,
+		});
+	}
+	if (replicateIndices && singleReplicate !== undefined) {
+		fail("pass either --replicates or --replicate, not both", {
+			properties: { title: "bench-suite usage" },
+			exitCode: 2,
+		});
+	}
+
+	// The local newest-first Run index, shared by every replicate of this cell. It is keyed by runId and
+	// all R shards carry the SAME runId, so the last replicate to normalize wins the entry — a local
+	// convenience only (`leaderboard data/runs/<id>.json` discovery). Nothing downstream reads it: the
+	// aggregate is handed explicit shard paths, and commit-dataset.yml globs the shard files directly.
+	// Writes are synchronous (writeNormalizedRun), so concurrent replicates cannot interleave a
+	// read-modify-write and corrupt it.
+	const indexFile = join("data", "runs", "index.json");
+	// Pass the sliced argv explicitly rather than letting it default to `process.argv` (which also
+	// carries the bun executable and script path), so the flag this bin parses is the flag the require
+	// gate inside every replicate reads.
+	const required = requiredProviders(argv);
+
+	logInfo(`Benchmark cell ${cell}`);
+	if (inActions()) {
+		core.debug(
+			JSON.stringify({
 				provider,
 				suite,
 				runId,
 				sha,
-				outFile,
-				run: normalized,
-				detail: details.join("\n"),
-				taskPlan,
-			});
-		}
+				replicates: replicateIndices ?? [singleReplicate ?? null],
+				maxConcurrency: Number.isFinite(maxConcurrency) ? maxConcurrency : "unbounded",
+				require: required,
+			}),
+		);
 	}
 
-	await reportCell({
+	// Resolve the precise mise tasks + PTS pins ONCE before any sandbox runs, so the job summary can
+	// name what this cell planned to execute (schema commands → mise task info → run_task leaves). It
+	// is a property of the suite, not of a replicate, so every replicate of this cell shares it.
+	let taskPlan: SuiteTaskPlan | undefined;
+	await withGroup(`Discover suite tasks (${suite})`, async () => {
+		try {
+			taskPlan = await describeSuiteTasks(suite);
+			logInfo(`commands: ${taskPlan.commands.join(" · ")}`);
+			for (const task of taskPlan.tasks) {
+				const pts = task.ptsProfile ? ` pts=${task.ptsProfile}` : "";
+				const prefix = task.resultsPrefix ? ` prefix=${task.resultsPrefix}` : "";
+				logInfo(
+					`${task.role} ${task.task}${task.description ? ` — ${task.description}` : ""}${pts}${prefix}`,
+				);
+			}
+			if (inActions()) {
+				for (const metric of taskPlan.metrics) {
+					core.debug(
+						`metric ${metric.id} label=${metric.label}` +
+							(metric.ptsTest ? ` pts.test=${metric.ptsTest}` : ""),
+					);
+				}
+			}
+		} catch (err) {
+			const msg = `Could not describe suite tasks for "${suite}": ${err instanceof Error ? err.message : String(err)}`;
+			logWarning(msg, { title: cell });
+		}
+	});
+
+	if (replicateIndices === undefined) {
+		// Single-sandbox path (local dev, bench-smoke, and an explicit `--replicate <idx>`): one shard at
+		// the un-suffixed `data/runs/<runId>.json`, which bench-smoke.yml and commit-dataset.yml's legacy
+		// glob both name directly — so the filename is a contract, not the `-r<idx>` convention minus a
+		// suffix.
+		//
+		// Kept as its own path rather than "the fan-out with one replicate", deliberately. The audience
+		// differs, and so does the useful report: this is a human reading ONE cell, who wants the
+		// whole-Run provider table (every registered provider, skipped/failed gaps split out) and the
+		// foldable `::group::` sections — neither of which a fleet report can give, because its table is
+		// one row per replicate and its grouping is off so R interleaved transcripts stay readable. Fan
+		// out to R=1 and you would have to special-case all of that back in, trading two honest paths for
+		// one path full of `length === 1` branches. What the two DO share — heading, cell identity, task
+		// plan, annotation wiring — is shared for real, in writeCellSummary.
+		const outcome = await runReplicate({
+			provider,
+			suite,
+			runId,
+			sha,
+			rawRoot: join("data", "raw", runId),
+			outFile: join("data", "runs", `${runId}.json`),
+			indexFile,
+			...(singleReplicate !== undefined ? { replicateIndex: singleReplicate } : {}),
+			required,
+		});
+		await reportCell({
+			provider,
+			suite,
+			runId,
+			sha,
+			outFile: outcome.outFile,
+			...(outcome.run ? { run: outcome.run } : {}),
+			failed: outcome.failed,
+			...(outcome.detail !== undefined ? { detail: outcome.detail } : {}),
+			...(taskPlan ? { taskPlan } : {}),
+		});
+		if (outcome.failed) fail(outcome.detail ?? `Cell ${cell} failed`, { annotate: false });
+		process.exit(0);
+	}
+
+	// Fan-out path: R replicate sandboxes, all from this process. Foldable groups are turned off and
+	// every line is tagged with its replicate instead — Actions groups are a single ordered stream, so
+	// R concurrent replicates opening and closing them produces folds containing other replicates'
+	// output. The tag is what keeps an interleaved 12-way transcript attributable.
+	setGroupingEnabled(false);
+	installLineTagging();
+	logInfo(
+		`Driving ${replicateIndices.length} replicate sandbox(es) [${replicateIndices.join(", ")}] ` +
+			`for ${cell}` +
+			(Number.isFinite(maxConcurrency) ? ` (max ${maxConcurrency} in flight)` : ""),
+	);
+
+	const outcomes = await runPooled(
+		replicateIndices,
+		maxConcurrency,
+		async (replicateIndex) => {
+			const paths = replicatePaths(runId, replicateIndex);
+			return withLineTag(`[${replicateLabel(replicateIndex)}] `, () =>
+				runReplicate({
+					provider,
+					suite,
+					runId,
+					sha,
+					rawRoot: paths.rawRoot,
+					outFile: paths.outFile,
+					indexFile,
+					replicateIndex,
+					required,
+				}),
+			);
+		},
+		// runReplicate is written to be total, but this is the backstop that makes that irrelevant: an
+		// unexpected throw becomes THIS replicate's failure instead of unwinding the pool and stranding
+		// its peers mid-suite with no report written. The peers keep running, every shard that can be
+		// written still is, and reportFleet names the thrower.
+		(error, replicateIndex) => ({
+			index: replicateIndex,
+			outFile: replicatePaths(runId, replicateIndex).outFile,
+			failed: true,
+			detail: `replicate threw outside the reporting path: ${
+				error instanceof Error ? (error.stack ?? error.message) : String(error)
+			}`,
+		}),
+	);
+
+	await reportFleet({
 		provider,
 		suite,
 		runId,
 		sha,
-		outFile,
-		run: normalized,
-		failed: false,
-		taskPlan,
+		outcomes,
+		...(taskPlan ? { taskPlan } : {}),
 	});
-	logInfo(`Cell ${cell} succeeded → ${outFile}`);
+
+	const failures = outcomes.filter((o) => o.failed);
+	if (failures.length > 0) {
+		// reportFleet already annotated with every failure's detail; exit non-zero without a second one.
+		fail(`${failures.length}/${outcomes.length} replicate(s) of ${cell} failed`, {
+			annotate: false,
+		});
+	}
+	logInfo(`Cell ${cell}: ${outcomes.length}/${outcomes.length} replicate(s) succeeded`);
+	// Exit explicitly, matching the single-sandbox path above. `createSuiteSandbox` deliberately leaves
+	// a floating `createPromise.then(destroySandbox)` behind for a create that resolved after its
+	// timeout was lost, and a provider SDK may hold a keep-alive socket; falling off the end would make
+	// the cell wait on those instead of finishing, turning an all-green fleet into a job-timeout red.
+	process.exit(0);
 }

--- a/apps/cli/src/bin/plan-replicates.ts
+++ b/apps/cli/src/bin/plan-replicates.ts
@@ -1,10 +1,11 @@
 #!/usr/bin/env bun
 // `plan-replicates` — emit the per-suite replicate index arrays as a SINGLE LINE of compact JSON object,
 // e.g. `{"cpu-node":[0,1,2],"realworld-mastra":[0,1,2,3,4]}`. This is a $GITHUB_OUTPUT contract the Bench
-// matrix reads: the suite-matrix job passes each suite its own slice as the reusable bench-suite.yml's
-// `replicate` axis (`fromJSON(needs.plan.outputs.replicates)[matrix.suite]`), so N replicate sandboxes
-// fan out per (provider, suite) cell — the BETWEEN-MACHINE axis that captures a provider's fleet
-// variation (two sandboxes can land on different host hardware).
+// matrix reads: the suite-matrix job passes each suite its own slice
+// (`fromJSON(needs.plan.outputs.replicates)[matrix.suite]`) to the reusable bench-suite.yml, which hands
+// it to `bench-suite --replicates` — so N replicate sandboxes run per (provider, suite) cell, all driven
+// concurrently by that cell's single runner. This is the BETWEEN-MACHINE axis that captures a provider's
+// fleet variation (two sandboxes can land on different host hardware).
 //
 // The count per suite is its schema-declared Suite.defaultReplicas, overridable for the whole run by the
 // BENCH_REPLICAS dispatch input (blank = each suite's default; a number scales every suite). The suite
@@ -54,7 +55,7 @@ examples:
   BENCH_REPLICAS=5 plan-replicates             # every suite fanned out to 5 replicate sandboxes
   BENCH_SUITES=network BENCH_REPLICAS=1 plan-replicates   # a single network sandbox (a quick pass)
 
-Next: run one replicate with  bench-suite <provider> <suite> <runId> --replicate <idx>`;
+Next: drive a suite's whole fleet with  bench-suite <provider> <suite> <runId> --replicates <indices>`;
 
 if (import.meta.main) {
 	const argv = process.argv.slice(2);

--- a/apps/cli/src/lib/actions-log.ts
+++ b/apps/cli/src/lib/actions-log.ts
@@ -138,11 +138,29 @@ export async function logProviderStatuses(
 }
 
 /**
+ * Whether {@link withGroup} may emit `::group::` markers. Disabled by the concurrent replicate driver:
+ * Actions groups are a flat, ordered stream, so R concurrent replicates opening and closing groups
+ * interleave into folds that contain other replicates' output — worse than no folding at all. Those
+ * runs tag every line with its replicate instead (see ./log-prefix.ts).
+ */
+let groupingEnabled = true;
+
+/** Turn foldable Actions groups on/off process-wide (see {@link groupingEnabled}). */
+export function setGroupingEnabled(enabled: boolean): void {
+	groupingEnabled = enabled;
+}
+
+/**
  * Run `fn` inside a foldable Actions group when in CI; otherwise just await `fn` so local stdout
  * stays free of `::group::` prefixes (needed for single-line JSON contracts).
  */
 export async function withGroup<T>(title: string, fn: () => Promise<T> | T): Promise<T> {
-	if (inActions()) return await core.group(title, async () => fn());
+	if (inActions()) {
+		if (groupingEnabled) return await core.group(title, async () => fn());
+		// Grouping off: keep the title as a plain line so the transcript still announces each phase
+		// (it is the only thing marking where a replicate's setup ends and its benchmark begins).
+		logInfo(`--- ${title} ---`);
+	}
 	return await fn();
 }
 
@@ -155,7 +173,11 @@ export interface JobSummaryOptions {
 	fields: Array<[label: string, value: string, kind: CellKind]>;
 	/** Optional extra tables (e.g. provider status). */
 	tables?: Array<{ heading: string; rows: SummaryRow[] }>;
-	/** Optional free-form detail paragraph. */
+	/**
+	 * Optional free-form detail, rendered PREFORMATTED (`<pre>`) — line breaks are preserved and the
+	 * text does not re-wrap. Suits a multi-line list (e.g. one line per failing replicate); a long
+	 * prose paragraph will render monospaced and scroll horizontally rather than wrapping.
+	 */
 	detail?: string;
 	/**
 	 * Annotation for the run's annotations panel. Failures always annotate; successes stay in the
@@ -183,7 +205,13 @@ export async function writeJobSummary(opts: JobSummaryOptions): Promise<void> {
 			core.summary.addHeading(escapeHtml(table.heading), 4).addTable(table.rows);
 		}
 		if (opts.detail) {
-			core.summary.addRaw(escapeHtml(opts.detail)).addEOL();
+			// `<pre>`, not bare text. `addTable` emits `</table>` followed by a single newline, and GFM
+			// keeps an HTML block open until a BLANK line — so raw detail appended after a table is
+			// swallowed into that block, where its newlines become insignificant whitespace. A fleet
+			// report's failure list (one line per failing replicate, up to R lines) rendered as a single
+			// run-on paragraph, which is exactly the text the annotation tells the reader to come here
+			// for. `<pre>` both terminates the ambiguity and preserves the line breaks.
+			core.summary.addRaw(`<pre>${escapeHtml(opts.detail)}</pre>`).addEOL();
 		}
 		await core.summary.write();
 	}

--- a/apps/cli/src/lib/log-prefix.test.ts
+++ b/apps/cli/src/lib/log-prefix.test.ts
@@ -1,0 +1,183 @@
+import { describe, expect, it } from "bun:test";
+import { createTaggedWriter, prefixChunk, withLineTag } from "./log-prefix.ts";
+
+const TAG = "[r3] ";
+
+describe("prefixChunk", () => {
+	it("tags a whole line and leaves the stream at a line start", () => {
+		const state = { atLineStart: true };
+		expect(prefixChunk("hello\n", TAG, state)).toBe("[r3] hello\n");
+		expect(state.atLineStart).toBe(true);
+	});
+
+	it("tags every line of a multi-line chunk without a dangling trailing tag", () => {
+		const state = { atLineStart: true };
+		expect(prefixChunk("a\nb\nc\n", TAG, state)).toBe("[r3] a\n[r3] b\n[r3] c\n");
+	});
+
+	// Every writer on the tagged path emits whole lines today, but the line cursor is shared across R
+	// concurrent replicates, so a partial write must not corrupt the continuation.
+	it("does not tag the continuation of a partial line", () => {
+		const state = { atLineStart: true };
+		expect(prefixChunk("exit ", TAG, state)).toBe("[r3] exit ");
+		expect(state.atLineStart).toBe(false);
+		expect(prefixChunk("0 in 4.1s\n", TAG, state)).toBe("0 in 4.1s\n");
+		expect(state.atLineStart).toBe(true);
+	});
+
+	// A tagged `::error::` stops being an annotation and renders as literal text, so workflow commands
+	// pass through untouched.
+	it("passes workflow commands through unprefixed", () => {
+		const state = { atLineStart: true };
+		expect(prefixChunk("::error title=x::boom\n", TAG, state)).toBe("::error title=x::boom\n");
+		expect(state.atLineStart).toBe(true);
+	});
+
+	// StepRunner.finishStep writes a step's WHOLE stdout in one call. A chunk-level `::` check made a
+	// step whose first line began with `::` (an IPv6 literal) lose the tag for its entire transcript.
+	it("only exempts the ::-leading LINE, still tagging the rest of the chunk", () => {
+		const state = { atLineStart: true };
+		expect(prefixChunk("::1 listening\nline2\nline3\n", TAG, state)).toBe(
+			"::1 listening\n[r3] line2\n[r3] line3\n",
+		);
+	});
+
+	// Without the forced break, a partial line from one replicate welds the next replicate's
+	// annotation onto its end, where GitHub will not parse it — losing the cell's only failure signal.
+	it("forces a line break so a mid-line workflow command still parses", () => {
+		const state = { atLineStart: true };
+		const partial = prefixChunk("progress: 42%", "[r1] ", state);
+		const command = prefixChunk("::error title=t::boom\n", "[r0] ", state);
+		expect(partial + command).toBe("[r1] progress: 42%\n::error title=t::boom\n");
+	});
+
+	it("still tags a line that merely contains :: away from the start", () => {
+		const state = { atLineStart: true };
+		expect(prefixChunk("see foo::bar\n", TAG, state)).toBe("[r3] see foo::bar\n");
+	});
+
+	it("leaves an empty chunk alone", () => {
+		const state = { atLineStart: true };
+		expect(prefixChunk("", TAG, state)).toBe("");
+		expect(state.atLineStart).toBe(true);
+	});
+});
+
+describe("createTaggedWriter + withLineTag", () => {
+	/** A writer plus the chunks it received, standing in for a real stream. */
+	const spyWriter = (): { write: ReturnType<typeof createTaggedWriter>; written: string[] } => {
+		const written: string[] = [];
+		const write = createTaggedWriter((chunk) => {
+			written.push(String(chunk));
+			return true;
+		});
+		return { write, written };
+	};
+
+	it("tags writes inside a tagged context and leaves untagged writes alone", async () => {
+		const { write, written } = spyWriter();
+		await withLineTag("[r1] ", async () => {
+			write("inside\n");
+		});
+		write("outside\n");
+		expect(written).toEqual(["[r1] inside\n", "outside\n"]);
+	});
+
+	// The whole point: R replicates interleave on one stream, and each line must name its sandbox.
+	it("tags each concurrent replicate's lines with its own tag", async () => {
+		const { write, written } = spyWriter();
+		await Promise.all(
+			["[r0] ", "[r1] "].map((tag) =>
+				withLineTag(tag, async () => {
+					write("start\n");
+					await Bun.sleep(0);
+					write("done\n");
+				}),
+			),
+		);
+		expect(written.toSorted()).toEqual([
+			"[r0] done\n",
+			"[r0] start\n",
+			"[r1] done\n",
+			"[r1] start\n",
+		]);
+	});
+
+	it("carries the tag across an await inside the harness's async call graph", async () => {
+		const { write, written } = spyWriter();
+		const deepInSomeOtherPackage = async (): Promise<void> => {
+			await Promise.resolve();
+			write("nested\n");
+		};
+		await withLineTag("[r7] ", deepInSomeOtherPackage);
+		expect(written).toEqual(["[r7] nested\n"]);
+	});
+});
+
+// Run in a SUBPROCESS, not in-process: the thing under test is that Bun's native `console.log` — which
+// writes to the fd directly instead of calling process.stdout.write — is routed through the tagging
+// patch. Any in-process spy would have to replace process.stdout.write and would therefore bypass the
+// very layer being asserted. A live three-replicate run is what surfaced this: the harness's own
+// `console.log` step banners came out untagged while the echoed step output around them was tagged.
+describe("installLineTagging end to end (subprocess)", () => {
+	const MODULE = new URL("./log-prefix.ts", import.meta.url).pathname;
+
+	const runScript = async (body: string): Promise<string> => {
+		const proc = Bun.spawn(
+			[
+				"bun",
+				"-e",
+				`import { installLineTagging, withLineTag } from ${JSON.stringify(MODULE)};\n` +
+					`installLineTagging();\n${body}`,
+			],
+			{ stdout: "pipe", stderr: "pipe" },
+		);
+		const [stdout, exitCode] = await Promise.all([new Response(proc.stdout).text(), proc.exited]);
+		expect(exitCode).toBe(0);
+		return stdout;
+	};
+
+	it("tags console.log and process.stdout.write alike inside a tagged context", async () => {
+		const stdout = await runScript(
+			`await withLineTag("[r5] ", async () => {\n` +
+				`  console.log("=== [step] ===");\n` +
+				`  process.stdout.write("echoed\\n");\n` +
+				`});`,
+		);
+		expect(stdout).toBe("[r5] === [step] ===\n[r5] echoed\n");
+	});
+
+	it("leaves console.log untouched outside a tagged context", async () => {
+		expect(await runScript(`console.log("plain %s", "value");`)).toBe("plain value\n");
+	});
+
+	// The shape the harness actually uses on the tagged path: a message plus an Error
+	// (`console.error(msg, err)` in withSandbox). Bun.inspect renders the Error, uncoloured.
+	it("renders a message plus a non-string argument", async () => {
+		const stdout = await runScript(
+			`await withLineTag("[r2] ", async () => console.log("destroy failed:", { code: 7 }));`,
+		);
+		expect(stdout).toBe("[r2] destroy failed: {\n[r2]   code: 7,\n[r2] }\n");
+	});
+
+	// Pinned, not incidental: dropping node:util.format for Bun.inspect costs printf substitution, and
+	// no call site in the repo uses one. If a tagged printf call is ever added, this test is the
+	// tripwire that says renderArg must grow a formatter.
+	it("does not substitute printf directives while tagged (documented Bun.inspect trade)", async () => {
+		const stdout = await runScript(
+			`await withLineTag("[r0] ", async () => console.log("plain %s", "value"));`,
+		);
+		expect(stdout).toBe("[r0] plain %s value\n");
+	});
+
+	// Asserted in the subprocess for the same reason as the rest of this block, plus one of its own: a
+	// real `installLineTagging()` in THIS process would replace process.stdout/stderr and console.* for
+	// every test file scheduled after it. `runScript` already installs once, so the call below is the
+	// second — a patch that wrapped the writer twice would emit `[r4] [r4] once`.
+	it("is idempotent — a second install must not double the tag", async () => {
+		const stdout = await runScript(
+			`installLineTagging();\nawait withLineTag("[r4] ", async () => console.log("once"));`,
+		);
+		expect(stdout).toBe("[r4] once\n");
+	});
+});

--- a/apps/cli/src/lib/log-prefix.test.ts
+++ b/apps/cli/src/lib/log-prefix.test.ts
@@ -103,6 +103,35 @@ describe("createTaggedWriter + withLineTag", () => {
 		]);
 	});
 
+	// The cell's failure annotation is written AFTER the pool resolves, so it is untagged — and it is
+	// the one line that must survive. If the untagged path skipped the line-state machine, a replicate
+	// whose last chunk had no trailing newline would leave the cursor mid-line and the `::error::`
+	// would weld onto it, where the runner never parses it: the cell fails with no annotation.
+	it("forces a newline before an UNTAGGED workflow command left mid-line by the fan-out", async () => {
+		const { write, written } = spyWriter();
+		await withLineTag("[r0] ", async () => {
+			write("collecting results... ");
+		});
+		write("::error title=cell::realworld-mastra / e2b failed\n");
+		expect(written).toEqual([
+			"[r0] collecting results... ",
+			"\n::error title=cell::realworld-mastra / e2b failed\n",
+		]);
+	});
+
+	// The untagged path runs the same state machine, so it must not start prefixing or double-breaking
+	// ordinary output — an empty tag has to be a genuine no-op on everything but the two behaviours above.
+	it("leaves ordinary untagged output byte-for-byte unchanged", async () => {
+		const { write, written } = spyWriter();
+		write("Benchmark cell realworld-mastra / e2b\n");
+		write("partial ");
+		write("continuation\n");
+		write("::notice::at a line start already\n");
+		expect(written.join("")).toBe(
+			"Benchmark cell realworld-mastra / e2b\npartial continuation\n::notice::at a line start already\n",
+		);
+	});
+
 	it("carries the tag across an await inside the harness's async call graph", async () => {
 		const { write, written } = spyWriter();
 		const deepInSomeOtherPackage = async (): Promise<void> => {

--- a/apps/cli/src/lib/log-prefix.ts
+++ b/apps/cli/src/lib/log-prefix.ts
@@ -85,11 +85,18 @@ export function prefixChunk(chunk: string, tag: string, state: StreamState): str
 export function createTaggedWriter(original: WriteFn): WriteFn {
 	const state: StreamState = { atLineStart: true };
 	return (chunk, encoding, callback) => {
-		const tag = tagStore.getStore();
+		// An UNTAGGED write still goes through prefixChunk, with an empty tag. Skipping it entirely
+		// looks equivalent — an empty tag prefixes nothing — but it is not: prefixChunk also owns
+		// `state.atLineStart` and the forced newline before a mid-line workflow command. The writes
+		// that matter most here are untagged, because they happen after `runPooled` resolves and the
+		// async-context tag is gone: `reportFleet`'s `core.error` annotation and `fail()`. Let a
+		// replicate's last chunk end without a newline and the skip would weld the cell's ONLY failure
+		// annotation onto that dangling line, where the runner never parses it — precisely the loss the
+		// tagged path forces a break to avoid, arriving through the one path that had no guard.
+		const tag = tagStore.getStore() ?? "";
 		// Buffers pass through untouched: nothing in this CLI writes binary to stdout, and decoding one
 		// to prefix it would risk corrupting a multi-byte character split across chunks.
-		const rewritten =
-			tag === undefined || typeof chunk !== "string" ? chunk : prefixChunk(chunk, tag, state);
+		const rewritten = typeof chunk !== "string" ? chunk : prefixChunk(chunk, tag, state);
 		return original(rewritten, encoding, callback);
 	};
 }

--- a/apps/cli/src/lib/log-prefix.ts
+++ b/apps/cli/src/lib/log-prefix.ts
@@ -1,0 +1,172 @@
+/**
+ * Per-replicate line prefixing for the concurrent bench-suite driver.
+ *
+ * One runner now drives R replicate sandboxes at once (see ./replicates.ts), and every layer below —
+ * the harness's step logs, PTS output echoed back from a collected step, `@actions/core` info lines —
+ * writes to one shared stdout. Without a prefix the R interleaved transcripts are unreadable, and the
+ * single most common CI question ("which sandbox died?") becomes unanswerable from the log.
+ *
+ * The tag is carried in an {@link AsyncLocalStorage}, not passed down through the harness API, because
+ * the writers are `console.log`/`process.stdout.write` calls several packages deep whose only shared
+ * context is the async task they run under. Patching the streams once and reading the tag from the
+ * ambient async context tags every line a replicate emits — including ones from code that knows
+ * nothing about replicates — without threading a logger through the whole call graph.
+ */
+// `node:async_hooks` is the sole import: AsyncLocalStorage has no `Bun.*` equivalent (Bun implements
+// this API natively rather than exposing its own). Everything else here is Bun-native — argument
+// rendering goes through `Bun.inspect`, the inspector Bun's own console uses.
+import { AsyncLocalStorage } from "node:async_hooks";
+
+const tagStore = new AsyncLocalStorage<string>();
+
+/** Node's stream write signature, in the two shapes callers actually use. */
+type WriteFn = (
+	chunk: unknown,
+	encoding?: unknown,
+	callback?: (err?: Error | null) => void,
+) => boolean;
+
+/**
+ * Whether the stream is currently at the start of a line.
+ *
+ * One per stream, NOT per replicate — the bytes of R concurrent replicates land on one shared fd, so
+ * "is the cursor mid-line" is a property of that fd and cannot be tracked per writer. Every writer on
+ * the tagged path emits whole lines today (`StepRunner.finishStep` normalises a missing trailing
+ * newline, `core.info` appends EOL, the console patch appends `\n`), so the mid-line case is an
+ * anomaly rather than routine — but {@link prefixChunk} still has to survive it, because when it does
+ * happen it lands on the shared cursor and would otherwise corrupt whatever writes next.
+ */
+interface StreamState {
+	atLineStart: boolean;
+}
+
+/** Workflow commands (`::error::`, `::group::`, …) are parsed by the runner ONLY at the start of a
+ *  line. Prefixing one turns an annotation into literal text, so they are never tagged. */
+function isWorkflowCommand(line: string): boolean {
+	return line.startsWith("::");
+}
+
+/**
+ * Prefix each line START in `chunk` with `tag`, advancing `state`. A trailing newline does NOT emit a
+ * dangling prefix — the next chunk's write does that — so a blank prefixed line never appears at the
+ * end of the transcript.
+ *
+ * Two properties this has to get right, both of which an earlier line-blind version got wrong:
+ *
+ *  - The workflow-command check is PER LINE, not per chunk. `StepRunner.finishStep` writes a step's
+ *    entire stdout in ONE call, so a chunk-level check meant a step whose first line happened to
+ *    begin with `::` (an IPv6 literal like `::1`, say) lost the `[rN]` tag for its whole transcript —
+ *    exactly the multi-hundred-line block an operator needs attributed when one sandbox misbehaves.
+ *  - A workflow command that arrives mid-line gets a newline forced in front of it. Otherwise a
+ *    partial-line write by one replicate silently welds the next replicate's `::error::` onto the end
+ *    of that line, where the runner will not parse it — losing the cell's only failure annotation on
+ *    precisely the runs that have one. A stray line break in already-interleaved output is a trivial
+ *    price for keeping the annotation.
+ */
+export function prefixChunk(chunk: string, tag: string, state: StreamState): string {
+	if (chunk === "") return chunk;
+	const endsWithNewline = chunk.endsWith("\n");
+	const body = endsWithNewline ? chunk.slice(0, -1) : chunk;
+	const rendered = body.split("\n").map((line, i) => {
+		// Only the first line of a chunk can be a continuation; every later one follows a newline.
+		const atLineStart = i === 0 ? state.atLineStart : true;
+		if (isWorkflowCommand(line)) return atLineStart ? line : `\n${line}`;
+		return atLineStart ? `${tag}${line}` : line;
+	});
+	state.atLineStart = endsWithNewline;
+	return `${rendered.join("\n")}${endsWithNewline ? "\n" : ""}`;
+}
+
+/**
+ * A `write` that delegates to `original`, prefixing string chunks written inside {@link withLineTag}.
+ * Exported (rather than only applied to the real streams) so the async-context wiring is testable
+ * without mutating process.stdout, which every other test in the run shares.
+ */
+export function createTaggedWriter(original: WriteFn): WriteFn {
+	const state: StreamState = { atLineStart: true };
+	return (chunk, encoding, callback) => {
+		const tag = tagStore.getStore();
+		// Buffers pass through untouched: nothing in this CLI writes binary to stdout, and decoding one
+		// to prefix it would risk corrupting a multi-byte character split across chunks.
+		const rewritten =
+			tag === undefined || typeof chunk !== "string" ? chunk : prefixChunk(chunk, tag, state);
+		return original(rewritten, encoding, callback);
+	};
+}
+
+/** Wrap one stream's `write` so string chunks written inside {@link withLineTag} are prefixed. */
+function patchStream(stream: NodeJS.WriteStream): void {
+	const patched = createTaggedWriter(stream.write.bind(stream) as WriteFn);
+	(stream as unknown as { write: WriteFn }).write = patched;
+}
+
+/**
+ * Render one console argument the way the console itself would, using Bun's own inspector.
+ *
+ * Strings print verbatim (console never quotes a top-level string, while `Bun.inspect("a")` yields
+ * `"a"` with ANSI colour); every other value goes through `Bun.inspect`, which is what Bun's console
+ * uses for objects and Errors. Colours are off because a CI log is not a TTY — and because an ANSI
+ * escape at the head of a line would sit in front of the `::` that {@link prefixChunk} checks for.
+ *
+ * Deliberately NOT `node:util.format`: this drops printf substitution (`console.log("%s", x)` renders
+ * as `%s x` while a tag is active). No call site in apps/, packages/, or tooling/ uses a format
+ * directive — the tagged path's real shapes are a template literal, or a message plus an Error, both
+ * of which this renders identically — so the trade buys a Bun-native module with no node builtin for
+ * formatting. A future printf-style call inside the fan-out would need this to grow a formatter.
+ */
+function renderArg(value: unknown): string {
+	return typeof value === "string" ? value : Bun.inspect(value, { colors: false });
+}
+
+/**
+ * Route `console.*` through the patched streams while a tag is active.
+ *
+ * Patching the streams alone is NOT enough: Bun's `console.log` writes to the file descriptor
+ * natively rather than calling `process.stdout.write`, so a live three-replicate run showed the
+ * harness's own step banners (`=== [capture observed specs] ===`, every `console.log` in
+ * packages/harness) untagged while the echoed step output around them was tagged — the interleaved
+ * lines that most need attribution were the ones missing it. Untagged calls delegate to the original
+ * console so ordinary single-sandbox runs keep Bun's exact formatting and fast path.
+ */
+function patchConsole(): void {
+	// Which stream each console method prints to — matching Node/Bun's own routing. The stream objects
+	// are captured directly (not by name): `patchStream` replaces `write` ON the object, so a reference
+	// taken here still routes through the patch regardless of install order.
+	const routes = [
+		["log", process.stdout],
+		["info", process.stdout],
+		["debug", process.stdout],
+		["warn", process.stderr],
+		["error", process.stderr],
+	] as const;
+	for (const [method, stream] of routes) {
+		const original = console[method].bind(console);
+		console[method] = (...args: unknown[]): void => {
+			if (tagStore.getStore() === undefined) {
+				original(...args);
+				return;
+			}
+			stream.write(`${args.map(renderArg).join(" ")}\n`);
+		};
+	}
+}
+
+let installed = false;
+
+/**
+ * Patch stdout/stderr (and `console.*`, which Bun does not route through them) so writes made inside
+ * {@link withLineTag} are line-prefixed. Idempotent, and a no-op for code outside a tagged context —
+ * so installing it is safe even on the single-replicate path, where nothing ever sets a tag.
+ */
+export function installLineTagging(): void {
+	if (installed) return;
+	installed = true;
+	patchStream(process.stdout);
+	patchStream(process.stderr);
+	patchConsole();
+}
+
+/** Run `fn` with every line it writes prefixed by `tag` (requires {@link installLineTagging}). */
+export function withLineTag<T>(tag: string, fn: () => Promise<T>): Promise<T> {
+	return tagStore.run(tag, fn);
+}

--- a/apps/cli/src/lib/matrix.ts
+++ b/apps/cli/src/lib/matrix.ts
@@ -105,8 +105,9 @@ export function parseReplicasOverride(raw: string | undefined): number | undefin
  * `{ "cpu-node": [0, 1, 2], "realworld-mastra": [0, 1, 2, 3, 4] }`. Each suite maps to `[0..R-1]`, where
  * R is the `BENCH_REPLICAS` override (`replicasRaw`) when set, else that suite's schema default. The
  * suite set matches {@link selectSuites} exactly (same `BENCH_SUITES` parsing), so the map is keyed by
- * precisely the suites the plan's suite axis emits — the reusable bench-suite.yml indexes it by
- * `matrix.suite` to get its own replicate axis. `suitesRaw`/`replicasRaw` are the raw dispatch strings.
+ * precisely the suites the plan's suite axis emits — bench-matrix.yml indexes it by `matrix.suite` and
+ * hands each cell its slice as `bench-suite --replicates` (the cell drives every index itself, in one
+ * process, rather than expanding them into runners). `suitesRaw`/`replicasRaw` are the raw dispatch strings.
  */
 export function planReplicateMap(
 	suitesRaw: string | undefined,

--- a/apps/cli/src/lib/replicates.test.ts
+++ b/apps/cli/src/lib/replicates.test.ts
@@ -1,0 +1,190 @@
+import { describe, expect, it } from "bun:test";
+import {
+	lastFlagValue,
+	parseReplicatesFlag,
+	replicatePaths,
+	resolveMaxConcurrency,
+	runPooled,
+} from "./replicates.ts";
+
+describe("lastFlagValue", () => {
+	it("reads both spellings and takes the last occurrence", () => {
+		expect(lastFlagValue(["--replicates", "0,1"], "replicates")).toBe("0,1");
+		expect(lastFlagValue(["--replicates=0,1"], "replicates")).toBe("0,1");
+		expect(lastFlagValue(["--replicates=0", "--replicates", "9"], "replicates")).toBe("9");
+	});
+
+	it("returns undefined when the flag is absent", () => {
+		expect(lastFlagValue(["e2b", "memory"], "replicates")).toBeUndefined();
+	});
+
+	// The singular and plural spellings must not consume each other's operands — a `--replicates`
+	// swallowed by `--replicate` would run one sandbox where the plan asked for R.
+	it("does not confuse the singular and plural spellings", () => {
+		expect(lastFlagValue(["--replicates", "0,1,2"], "replicate")).toBeUndefined();
+		expect(lastFlagValue(["--replicates=0,1,2"], "replicate")).toBeUndefined();
+		expect(lastFlagValue(["--replicate", "3"], "replicates")).toBeUndefined();
+	});
+
+	it("throws on a dangling flag rather than defaulting", () => {
+		expect(() => lastFlagValue(["--replicates"], "replicates")).toThrow(/requires an index/);
+	});
+});
+
+describe("parseReplicatesFlag", () => {
+	it("returns undefined when the flag is absent", () => {
+		expect(parseReplicatesFlag(["e2b", "memory", "run-1"])).toBeUndefined();
+	});
+
+	it("parses the JSON array plan-replicates emits", () => {
+		expect(parseReplicatesFlag(["--replicates", "[0,1,2]"])).toEqual([0, 1, 2]);
+		expect(parseReplicatesFlag(["--replicates=[0]"])).toEqual([0]);
+	});
+
+	it("parses the comma-separated spelling, tolerating whitespace", () => {
+		expect(parseReplicatesFlag(["--replicates", "0,1,2"])).toEqual([0, 1, 2]);
+		expect(parseReplicatesFlag(["--replicates", " 0 , 1 "])).toEqual([0, 1]);
+		expect(parseReplicatesFlag(["--replicates", "4"])).toEqual([4]);
+	});
+
+	it("preserves a non-contiguous axis rather than renumbering it", () => {
+		expect(parseReplicatesFlag(["--replicates", "[3,7]"])).toEqual([3, 7]);
+	});
+
+	// An empty fan-out would upload no shard and read downstream as "never scheduled"; a repeated index
+	// would fold two sandboxes into one replicate slot at aggregate time. Both must fail the cell.
+	it("rejects an empty axis and repeated indices", () => {
+		expect(() => parseReplicatesFlag(["--replicates", ""])).toThrow(/must not be blank/);
+		expect(() => parseReplicatesFlag(["--replicates", "[]"])).toThrow(/at least one index/);
+		expect(() => parseReplicatesFlag(["--replicates", "0,1,0"])).toThrow(/must not repeat/);
+	});
+
+	it("rejects malformed indices and non-array JSON", () => {
+		expect(() => parseReplicatesFlag(["--replicates", "0,,1"])).toThrow(/non-negative integer/);
+		expect(() => parseReplicatesFlag(["--replicates", "0,-1"])).toThrow(/non-negative integer/);
+		expect(() => parseReplicatesFlag(["--replicates", "0,1.5"])).toThrow(/non-negative integer/);
+		expect(() => parseReplicatesFlag(["--replicates", "[0,"])).toThrow(/JSON array/);
+	});
+});
+
+describe("replicatePaths", () => {
+	// Every shard of one run carries the same `runId` FIELD, so only the filename keeps them apart —
+	// and commit-dataset.yml globs exactly this shape.
+	it("gives each replicate its own raw tree and a suffixed shard file", () => {
+		expect(replicatePaths("ci-1", 0)).toEqual({
+			rawRoot: "data/raw/ci-1/r0",
+			outFile: "data/runs/ci-1-r0.json",
+		});
+		expect(replicatePaths("ci-1", 11).outFile).toBe("data/runs/ci-1-r11.json");
+	});
+});
+
+describe("resolveMaxConcurrency", () => {
+	it("defaults to unbounded — the whole fleet at once, as R separate runners were", () => {
+		expect(resolveMaxConcurrency([], {})).toBe(Number.POSITIVE_INFINITY);
+		expect(resolveMaxConcurrency([], { BENCH_MAX_CONCURRENCY: "" })).toBe(Number.POSITIVE_INFINITY);
+	});
+
+	it("reads the flag and the env var, with the flag winning", () => {
+		expect(resolveMaxConcurrency(["--max-concurrency", "3"], {})).toBe(3);
+		expect(resolveMaxConcurrency([], { BENCH_MAX_CONCURRENCY: "2" })).toBe(2);
+		expect(resolveMaxConcurrency(["--max-concurrency=4"], { BENCH_MAX_CONCURRENCY: "2" })).toBe(4);
+	});
+
+	it("rejects a non-positive or non-integer cap instead of silently serializing", () => {
+		expect(() => resolveMaxConcurrency(["--max-concurrency", "0"], {})).toThrow(/positive integer/);
+		expect(() => resolveMaxConcurrency([], { BENCH_MAX_CONCURRENCY: "1.5" })).toThrow(
+			/positive integer/,
+		);
+		expect(() => resolveMaxConcurrency([], { BENCH_MAX_CONCURRENCY: "lots" })).toThrow(
+			/positive integer/,
+		);
+	});
+});
+
+describe("runPooled", () => {
+	const flush = (): Promise<void> => Bun.sleep(0);
+	/** For the cases that assert scheduling, not error handling: a throw here is a test bug. */
+	const throwOnError = (error: unknown): never => {
+		throw error;
+	};
+
+	it("returns results in input order regardless of completion order", async () => {
+		const results = await runPooled(
+			[30, 10, 20],
+			3,
+			async (ms) => {
+				await Bun.sleep(ms);
+				return ms;
+			},
+			throwOnError,
+		);
+		expect(results).toEqual([30, 10, 20]);
+	});
+
+	// THE isolation guarantee. A rejecting Promise.all would unwind the pool and abandon the peers
+	// mid-suite — sandboxes alive, shards unwritten, and the caller exiting before it can report.
+	it("never rejects: a throwing item becomes its own failure and peers still finish", async () => {
+		const finished: number[] = [];
+		const results = await runPooled(
+			[0, 1, 2, 3],
+			4,
+			async (i) => {
+				if (i === 1) {
+					await Bun.sleep(1);
+					throw new Error("replicate 1 exploded");
+				}
+				await Bun.sleep(20);
+				finished.push(i);
+				return `ok:${i}`;
+			},
+			(error, _item, index) => `failed:${index}:${(error as Error).message}`,
+		);
+		expect(results).toEqual(["ok:0", "failed:1:replicate 1 exploded", "ok:2", "ok:3"]);
+		// The peers ran to completion rather than being abandoned when their sibling threw.
+		expect(finished.toSorted()).toEqual([0, 2, 3]);
+	});
+
+	it("keeps the pool draining when every item throws", async () => {
+		const results = await runPooled(
+			[0, 1, 2],
+			2,
+			async (i) => {
+				throw new Error(`boom ${i}`);
+			},
+			(error) => (error as Error).message,
+		);
+		expect(results).toEqual(["boom 0", "boom 1", "boom 2"]);
+	});
+
+	/** The highest number of `fn` calls ever in flight at once, driving `count` items at `limit`. */
+	const peakConcurrency = async (count: number, limit: number): Promise<number> => {
+		let inFlight = 0;
+		let peak = 0;
+		await runPooled(
+			Array.from({ length: count }, (_, i) => i),
+			limit,
+			async () => {
+				inFlight++;
+				peak = Math.max(peak, inFlight);
+				await flush();
+				inFlight--;
+				return null;
+			},
+			throwOnError,
+		);
+		return peak;
+	};
+
+	it("never exceeds the concurrency limit", async () => {
+		expect(await peakConcurrency(6, 2)).toBe(2);
+	});
+
+	it("runs everything at once when the limit is unbounded", async () => {
+		expect(await peakConcurrency(4, Number.POSITIVE_INFINITY)).toBe(4);
+	});
+
+	it("returns [] for an empty item list", async () => {
+		expect(await runPooled([], 4, async () => "never", throwOnError)).toEqual([]);
+	});
+});

--- a/apps/cli/src/lib/replicates.test.ts
+++ b/apps/cli/src/lib/replicates.test.ts
@@ -1,8 +1,11 @@
 import { describe, expect, it } from "bun:test";
 import {
+	fleetBudgetError,
+	fleetWaves,
 	lastFlagValue,
 	parseReplicatesFlag,
 	replicatePaths,
+	resolveCellBudgetMinutes,
 	resolveMaxConcurrency,
 	runPooled,
 } from "./replicates.ts";
@@ -99,6 +102,93 @@ describe("resolveMaxConcurrency", () => {
 		expect(() => resolveMaxConcurrency([], { BENCH_MAX_CONCURRENCY: "lots" })).toThrow(
 			/positive integer/,
 		);
+	});
+});
+
+describe("resolveCellBudgetMinutes", () => {
+	// No budget is the honest local answer — nothing cancels a laptop run, so there is nothing the
+	// fan-out guard could meaningfully compare against.
+	it("is undefined when CI did not hand one down", () => {
+		expect(resolveCellBudgetMinutes({})).toBeUndefined();
+		expect(resolveCellBudgetMinutes({ BENCH_CELL_BUDGET_MINUTES: "" })).toBeUndefined();
+	});
+
+	it("reads the job budget the workflow advertises", () => {
+		expect(resolveCellBudgetMinutes({ BENCH_CELL_BUDGET_MINUTES: "180" })).toBe(180);
+	});
+
+	// A malformed budget must not read as "unbounded": that would disable the guard silently, which is
+	// the same outcome as not having it on the one run where it mattered.
+	it("rejects a malformed budget rather than falling back to no check", () => {
+		expect(() => resolveCellBudgetMinutes({ BENCH_CELL_BUDGET_MINUTES: "0" })).toThrow(
+			/positive integer/,
+		);
+		expect(() => resolveCellBudgetMinutes({ BENCH_CELL_BUDGET_MINUTES: "90.5" })).toThrow(
+			/positive integer/,
+		);
+		expect(() => resolveCellBudgetMinutes({ BENCH_CELL_BUDGET_MINUTES: "later" })).toThrow(
+			/positive integer/,
+		);
+	});
+});
+
+describe("fleetWaves", () => {
+	it("is one wave whenever the cap admits the whole fleet", () => {
+		expect(fleetWaves(12, Number.POSITIVE_INFINITY)).toBe(1);
+		expect(fleetWaves(12, 12)).toBe(1);
+		expect(fleetWaves(12, 99)).toBe(1);
+	});
+
+	it("rounds a partial final wave up", () => {
+		expect(fleetWaves(12, 6)).toBe(2);
+		expect(fleetWaves(12, 5)).toBe(3);
+		expect(fleetWaves(12, 1)).toBe(12);
+	});
+});
+
+describe("fleetBudgetError", () => {
+	// The shipped realworld cell: R=12, a 90-minute suite, the 180-minute job.
+	const realworld = { replicates: 12, suite: "realworld-mastra", suiteTimeoutMinutes: 90 };
+
+	it("passes an uncapped fan-out — one wave is the budget the job was sized for", () => {
+		expect(
+			fleetBudgetError({
+				...realworld,
+				maxConcurrency: Number.POSITIVE_INFINITY,
+				budgetMinutes: 180,
+			}),
+		).toBeUndefined();
+	});
+
+	it("passes a cap whose waves still fit", () => {
+		expect(
+			fleetBudgetError({ ...realworld, maxConcurrency: 6, budgetMinutes: 180 }),
+		).toBeUndefined();
+	});
+
+	// This is the whole point: 3 waves x 90 = 270 > 180, so the job is cancelled mid-fan-out and all 12
+	// shards are lost. Rejecting costs a dispatch; discovering it costs three hours and the cell.
+	it("rejects a cap that deterministically overruns, naming the smallest cap that fits", () => {
+		const error = fleetBudgetError({ ...realworld, maxConcurrency: 4, budgetMinutes: 180 });
+		expect(error).toContain("3 serial waves");
+		expect(error).toContain("up to 270 minutes");
+		expect(error).toContain("180-minute job budget");
+		// floor(180 / 90) = 2 waves are affordable, so ceil(12 / 2) = 6 is the smallest cap that fits.
+		expect(error).toContain("at least 6");
+	});
+
+	// A suite that cannot fit the job even once is not a concurrency problem, and telling the operator
+	// to raise a cap they cannot raise far enough would send them in circles.
+	it("does not recommend a cap when even one wave overruns", () => {
+		const error = fleetBudgetError({
+			replicates: 3,
+			suite: "cpu-node",
+			suiteTimeoutMinutes: 200,
+			maxConcurrency: 2,
+			budgetMinutes: 180,
+		});
+		expect(error).toContain("leave --max-concurrency blank");
+		expect(error).not.toContain("at least");
 	});
 });
 

--- a/apps/cli/src/lib/replicates.test.ts
+++ b/apps/cli/src/lib/replicates.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "bun:test";
+import { WORKFLOW_TIMEOUT_MARGIN_MINUTES } from "@sandbox-benchmarks/schema";
 import {
 	fleetBudgetError,
 	fleetWaves,
@@ -160,21 +161,33 @@ describe("fleetBudgetError", () => {
 		).toBeUndefined();
 	});
 
-	it("passes a cap whose waves still fit", () => {
+	it("passes a cap that admits the whole fleet in one wave", () => {
 		expect(
-			fleetBudgetError({ ...realworld, maxConcurrency: 6, budgetMinutes: 180 }),
+			fleetBudgetError({ ...realworld, maxConcurrency: 12, budgetMinutes: 180 }),
 		).toBeUndefined();
 	});
 
-	// This is the whole point: 3 waves x 90 = 270 > 180, so the job is cancelled mid-fan-out and all 12
-	// shards are lost. Rejecting costs a dispatch; discovering it costs three hours and the cell.
+	// The margin is not optional slack. Two waves land on EXACTLY the 180-minute budget (2 x 90), so a
+	// guard comparing bare sandbox time would wave this through with nothing left for the checkout,
+	// teardown, normalization and upload the job still has to do — and the cell is cancelled with all
+	// 12 shards lost, which is the outcome this guard exists to refuse.
+	it("rejects a cap that lands on the budget with no host margin left", () => {
+		const error = fleetBudgetError({ ...realworld, maxConcurrency: 6, budgetMinutes: 180 });
+		expect(error).toContain("2 serial waves");
+		expect(error).toContain(`+ ${WORKFLOW_TIMEOUT_MARGIN_MINUTES} minutes of host margin`);
+		expect(error).toContain("up to 195 minutes");
+	});
+
+	// 3 waves x 90 + 15 = 285 > 180. Rejecting costs a dispatch; discovering it costs three hours and
+	// the cell.
 	it("rejects a cap that deterministically overruns, naming the smallest cap that fits", () => {
 		const error = fleetBudgetError({ ...realworld, maxConcurrency: 4, budgetMinutes: 180 });
 		expect(error).toContain("3 serial waves");
-		expect(error).toContain("up to 270 minutes");
+		expect(error).toContain("up to 285 minutes");
 		expect(error).toContain("180-minute job budget");
-		// floor(180 / 90) = 2 waves are affordable, so ceil(12 / 2) = 6 is the smallest cap that fits.
-		expect(error).toContain("at least 6");
+		// floor((180 - 15) / 90) = 1 affordable wave, so ceil(12 / 1) = 12 — at the shipped realworld
+		// defaults no cap below the full fleet fits, and the message says so rather than inventing one.
+		expect(error).toContain("at least 12");
 	});
 
 	// A suite that cannot fit the job even once is not a concurrency problem, and telling the operator

--- a/apps/cli/src/lib/replicates.ts
+++ b/apps/cli/src/lib/replicates.ts
@@ -13,8 +13,15 @@
  *
  * Host-side concurrency was already safe: the harness names every temp archive/staging dir with a
  * `randomUUID` precisely so concurrent collects can't collide (packages/harness/src/lib/collect.ts),
- * and each replicate here gets its own raw tree + shard file, so nothing is shared but the process.
+ * and each replicate here gets its own raw tree + shard file, so nothing is shared but the process and
+ * its environment. The environment caveat is real but currently harmless: the Daytona adapter pins
+ * `DAYTONA_TARGET` process-globally around each client-constructing call
+ * (packages/providers/src/lib/daytona-target.ts), so concurrent replicates interleave those
+ * set/restore pairs. Every replicate of a cell is the SAME provider and suite and therefore pins the
+ * SAME value, so the interleaving can only leave the variable holding the value it was already going
+ * to hold; a cell that mixed targets in one process would need that pin reworked first.
  */
+import { WORKFLOW_TIMEOUT_MARGIN_MINUTES } from "@sandbox-benchmarks/schema";
 
 /** Per-replicate shard paths inside the `data/` tree the cell uploads as one artifact. */
 export interface ReplicatePaths {
@@ -192,9 +199,17 @@ export function fleetWaves(replicates: number, maxConcurrency: number): number {
  * a guard that assumed replicates finish early would pass configurations that die whenever they don't.
  * Refusing up front costs a dispatch; discovering it costs three hours of runner time and the cell.
  *
+ * The sandbox time is charged per wave, but {@link WORKFLOW_TIMEOUT_MARGIN_MINUTES} is charged ONCE:
+ * the checkout, teardown, normalization and upload it covers happen per JOB, not per wave. Counting
+ * it is what keeps this guard consistent with the workflow timeout gate rather than one notch looser
+ * than it — omitting it accepts a fan-out landing on EXACTLY the budget (R=12 capped at 6 is 2 x 90 =
+ * 180 against a 180-minute job), which has no room left for the host work and is cancelled with all
+ * R shards lost. That is the failure this function exists to refuse, so it must not be its own
+ * boundary case.
+ *
  * Uncapped fan-outs can never trip this: they are one wave, so the comparison reduces to "the suite
- * budget fits the job budget", which the workflow timeout gate (`checkWorkflowTimeouts`) already
- * guarantees with margin.
+ * budget plus the margin fits the job budget", which the workflow timeout gate
+ * (`checkWorkflowTimeouts`) already guarantees using this same constant.
  */
 export function fleetBudgetError(opts: {
 	replicates: number;
@@ -205,23 +220,26 @@ export function fleetBudgetError(opts: {
 }): string | undefined {
 	const { replicates, maxConcurrency, suite, suiteTimeoutMinutes, budgetMinutes } = opts;
 	const waves = fleetWaves(replicates, maxConcurrency);
-	const worstCase = waves * suiteTimeoutMinutes;
+	const worstCase = waves * suiteTimeoutMinutes + WORKFLOW_TIMEOUT_MARGIN_MINUTES;
 	if (worstCase <= budgetMinutes) return undefined;
 
 	// The smallest cap that WOULD fit, so the message ends in a number the operator can act on rather
-	// than in "try a bigger one". `maxWaves` is how many suite budgets the job budget holds; at 0 the
-	// suite cannot fit the job at all and no cap saves it, so recommend dropping the cap entirely and
-	// let the (separate) timeout gate own that mismatch.
-	const maxWaves = Math.floor(budgetMinutes / suiteTimeoutMinutes);
+	// than in "try a bigger one". `maxWaves` is how many suite budgets the job budget holds once the
+	// host margin is set aside; at 0 the suite cannot fit the job at all and no cap saves it, so
+	// recommend dropping the cap entirely and let the (separate) timeout gate own that mismatch.
+	const maxWaves = Math.floor(
+		(budgetMinutes - WORKFLOW_TIMEOUT_MARGIN_MINUTES) / suiteTimeoutMinutes,
+	);
 	const remedy =
 		maxWaves >= 1
 			? `raise --max-concurrency to at least ${Math.ceil(replicates / maxWaves)} (or leave it blank for all ${replicates} at once)`
 			: `leave --max-concurrency blank — suite "${suite}" alone does not fit the ${budgetMinutes}-minute job budget`;
 	return (
 		`--max-concurrency ${maxConcurrency} splits ${replicates} replicates of suite "${suite}" into ` +
-		`${waves} serial waves × ${suiteTimeoutMinutes} minutes = up to ${worstCase} minutes, past the ` +
-		`cell's ${budgetMinutes}-minute job budget. The job would be cancelled mid-fan-out and ALL ` +
-		`${replicates} shards lost, so this is rejected before any sandbox is created: ${remedy}.`
+		`${waves} serial waves × ${suiteTimeoutMinutes} minutes + ${WORKFLOW_TIMEOUT_MARGIN_MINUTES} ` +
+		`minutes of host margin = up to ${worstCase} minutes, past the cell's ${budgetMinutes}-minute ` +
+		`job budget. The job would be cancelled mid-fan-out and ALL ${replicates} shards lost, so this ` +
+		`is rejected before any sandbox is created: ${remedy}.`
 	);
 }
 

--- a/apps/cli/src/lib/replicates.ts
+++ b/apps/cli/src/lib/replicates.ts
@@ -152,6 +152,80 @@ export function resolveMaxConcurrency(
 }
 
 /**
+ * The cell's wall-clock budget in minutes — the `timeout-minutes` of the job driving this fan-out,
+ * handed down as `BENCH_CELL_BUDGET_MINUTES`. Absent/blank means "no budget", which is the honest
+ * answer for a local run: nothing cancels it, so there is nothing to check against. CI is the only
+ * caller that sets it (bench-suite.yml, kept in lockstep with the job's literal `timeout-minutes` by
+ * the workflow gate), so the guard below is inert exactly where it would be meaningless.
+ */
+export function resolveCellBudgetMinutes(
+	env: Record<string, string | undefined> = process.env,
+): number | undefined {
+	const raw = env.BENCH_CELL_BUDGET_MINUTES;
+	if (raw === undefined || raw.trim() === "") return undefined;
+	const minutes = Number(raw);
+	if (!Number.isInteger(minutes) || minutes < 1) {
+		throw new Error(`BENCH_CELL_BUDGET_MINUTES must be a positive integer; got "${raw}"`);
+	}
+	return minutes;
+}
+
+/** How many SERIAL waves a fan-out of `replicates` runs in under `maxConcurrency` in flight. */
+export function fleetWaves(replicates: number, maxConcurrency: number): number {
+	// `min` before the divide keeps an unbounded (Infinity) cap out of the arithmetic: a cap at or
+	// above R is one wave, which is the uncapped case and the only one this whole guard lets through.
+	return Math.ceil(replicates / Math.min(maxConcurrency, replicates));
+}
+
+/**
+ * Why the requested fan-out cannot fit the cell's job budget, or `undefined` when it can.
+ *
+ * A concurrency cap is not free: it makes the cell run `ceil(R / cap)` SERIAL waves, so the cell's
+ * wall clock stops being "the slowest replicate" and becomes "waves × the suite's own budget". That
+ * product is checked against the ONE job budget all R replicates share, because exceeding it is not a
+ * degraded run — the job is cancelled mid-flight and every shard of the cell is lost at once, which is
+ * precisely the whole-cell blast radius that driving R replicates from one runner introduced. At the
+ * shipped realworld defaults (R=12, a 90-minute suite, a 180-minute job) any cap below 6 is already in
+ * that state, so this is a reachable operator mistake and not a theoretical one.
+ *
+ * Deliberately worst-case: a suite's `timeoutMinutes` is the budget a replicate is ALLOWED to take, and
+ * a guard that assumed replicates finish early would pass configurations that die whenever they don't.
+ * Refusing up front costs a dispatch; discovering it costs three hours of runner time and the cell.
+ *
+ * Uncapped fan-outs can never trip this: they are one wave, so the comparison reduces to "the suite
+ * budget fits the job budget", which the workflow timeout gate (`checkWorkflowTimeouts`) already
+ * guarantees with margin.
+ */
+export function fleetBudgetError(opts: {
+	replicates: number;
+	maxConcurrency: number;
+	suite: string;
+	suiteTimeoutMinutes: number;
+	budgetMinutes: number;
+}): string | undefined {
+	const { replicates, maxConcurrency, suite, suiteTimeoutMinutes, budgetMinutes } = opts;
+	const waves = fleetWaves(replicates, maxConcurrency);
+	const worstCase = waves * suiteTimeoutMinutes;
+	if (worstCase <= budgetMinutes) return undefined;
+
+	// The smallest cap that WOULD fit, so the message ends in a number the operator can act on rather
+	// than in "try a bigger one". `maxWaves` is how many suite budgets the job budget holds; at 0 the
+	// suite cannot fit the job at all and no cap saves it, so recommend dropping the cap entirely and
+	// let the (separate) timeout gate own that mismatch.
+	const maxWaves = Math.floor(budgetMinutes / suiteTimeoutMinutes);
+	const remedy =
+		maxWaves >= 1
+			? `raise --max-concurrency to at least ${Math.ceil(replicates / maxWaves)} (or leave it blank for all ${replicates} at once)`
+			: `leave --max-concurrency blank — suite "${suite}" alone does not fit the ${budgetMinutes}-minute job budget`;
+	return (
+		`--max-concurrency ${maxConcurrency} splits ${replicates} replicates of suite "${suite}" into ` +
+		`${waves} serial waves × ${suiteTimeoutMinutes} minutes = up to ${worstCase} minutes, past the ` +
+		`cell's ${budgetMinutes}-minute job budget. The job would be cancelled mid-fan-out and ALL ` +
+		`${replicates} shards lost, so this is rejected before any sandbox is created: ${remedy}.`
+	);
+}
+
+/**
  * Run `fn` over every item with at most `limit` in flight, resolving to the results IN INPUT ORDER.
  * NEVER rejects: a throw from `fn` is handed to `onError`, whose return value takes that slot.
  *

--- a/apps/cli/src/lib/replicates.ts
+++ b/apps/cli/src/lib/replicates.ts
@@ -1,0 +1,199 @@
+/**
+ * Replicate fan-out for a single (provider, suite) cell: flag parsing, per-replicate shard paths, and
+ * the bounded-concurrency pool that drives R sandboxes from ONE process.
+ *
+ * The between-machine axis used to be a GitHub Actions matrix axis — one runner per
+ * (provider, suite, replicate) — but a bench runner spends essentially all of its wall time *waiting*
+ * on a sandbox (create → poll a detached step → poll again), so R runners idled in lockstep while R
+ * sandboxes did the work. The runner-minutes bill scaled with R for no throughput gain: at the shipped
+ * defaults (6 providers × 9 suites, R=3 synthetic / R=12 realworld) that is 324 runners doing the work
+ * of 54. Driving all R replicates from one runner keeps the sandbox fan-out identical — the same R
+ * sandboxes are created concurrently against the same provider account, so provider load and wall
+ * clock are unchanged — and collapses the runner axis.
+ *
+ * Host-side concurrency was already safe: the harness names every temp archive/staging dir with a
+ * `randomUUID` precisely so concurrent collects can't collide (packages/harness/src/lib/collect.ts),
+ * and each replicate here gets its own raw tree + shard file, so nothing is shared but the process.
+ */
+
+/** Per-replicate shard paths inside the `data/` tree the cell uploads as one artifact. */
+export interface ReplicatePaths {
+	/** Raw results root for this replicate — `data/raw/<runId>/r<idx>`, normalized on its own. */
+	rawRoot: string;
+	/** Shard Run document — `data/runs/<runId>-r<idx>.json`. */
+	outFile: string;
+}
+
+/**
+ * Where replicate `index` of `runId` writes. The `-r<idx>` FILE suffix (not a per-replicate directory)
+ * is what keeps R shards distinct inside ONE artifact: every replicate's Run carries the same
+ * `runId` field, so they would otherwise all be `data/runs/<runId>.json`. commit-dataset.yml globs
+ * `runs/<runId>-r*.json` alongside the legacy `runs/<runId>.json`, so both layouts aggregate.
+ */
+export function replicatePaths(runId: string, index: number): ReplicatePaths {
+	return {
+		rawRoot: `data/raw/${runId}/r${index}`,
+		outFile: `data/runs/${runId}-r${index}.json`,
+	};
+}
+
+/**
+ * The last value given for `--<flag> <value>` / `--<flag>=<value>` in `argv`, or undefined when absent.
+ * A dangling space-separated flag throws (`operand` names what was expected) — a missing operand must
+ * fail the cell, never silently fall back to a default that changes what gets benchmarked.
+ *
+ * Prefix collisions are not possible between the singular and plural spellings: `--replicates` is not
+ * equal to `--replicate`, and `"--replicates=0,1".startsWith("--replicate=")` is false (the 's' sits
+ * where the '=' must be), so each flag only ever consumes its own operand.
+ */
+export function lastFlagValue(
+	argv: readonly string[],
+	flag: string,
+	operand = "an index argument",
+): string | undefined {
+	const prefix = `--${flag}=`;
+	let raw: string | undefined;
+	for (let i = 0; i < argv.length; i++) {
+		const arg = argv[i];
+		if (arg === `--${flag}`) {
+			raw = argv[i + 1];
+			if (raw === undefined) throw new Error(`--${flag} requires ${operand}`);
+		} else if (arg?.startsWith(prefix)) {
+			raw = arg.slice(prefix.length);
+		}
+	}
+	return raw;
+}
+
+/**
+ * A replicate index: a non-negative integer. Blank operands are rejected explicitly because
+ * `Number("")`/`Number("  ")` both coerce to 0 — which would silently collide two sandboxes into
+ * replicate slot 0 at aggregate time, exactly the corruption this validation exists to prevent.
+ */
+export function parseReplicateIndex(raw: string, what = "--replicate"): number {
+	const index = Number(raw);
+	if (raw.trim() === "" || !Number.isInteger(index) || index < 0) {
+		throw new Error(`${what} must be a non-negative integer; got "${raw}"`);
+	}
+	return index;
+}
+
+/**
+ * Parse `--replicates` into the replicate index list this runner drives, or `undefined` when absent
+ * (the single-shard path). Accepts the JSON array the plan emits (`[0,1,2]` — passed straight through
+ * from `plan-replicates`' per-suite map, so the workflow never reshapes it) and the comma-separated
+ * spelling (`0,1,2`) for hand-typed local runs.
+ *
+ * An empty list throws rather than benchmarking nothing: a cell that silently ran zero sandboxes would
+ * upload no shard and read downstream as "this provider was never scheduled". Duplicates throw too —
+ * two shards claiming one replicate index would fold into a single slot in the aggregate, quietly
+ * discarding a sandbox's worth of data.
+ */
+export function parseReplicatesFlag(argv: readonly string[]): number[] | undefined {
+	const raw = lastFlagValue(argv, "replicates");
+	if (raw === undefined) return undefined;
+	const trimmed = raw.trim();
+	if (trimmed === "") throw new Error('--replicates must not be blank; got ""');
+
+	const tokens = trimmed.startsWith("[")
+		? parseJsonReplicateTokens(trimmed)
+		: trimmed.split(",").map((token) => token.trim());
+
+	const indices = tokens.map((token) => parseReplicateIndex(token, "--replicates"));
+	if (indices.length === 0) {
+		throw new Error(`--replicates must list at least one index; got "${raw}"`);
+	}
+	const repeated = indices.find((index, i) => indices.indexOf(index) !== i);
+	if (repeated !== undefined) {
+		throw new Error(`--replicates must not repeat an index; got "${raw}" (${repeated} twice)`);
+	}
+	return indices;
+}
+
+/** The elements of a JSON `--replicates` array as raw tokens, so one validator handles both spellings. */
+function parseJsonReplicateTokens(raw: string): string[] {
+	let parsed: unknown;
+	try {
+		parsed = JSON.parse(raw);
+	} catch {
+		// Left undefined so the array check below reports it. Malformed JSON (`[0,`) and well-formed
+		// non-array JSON (`5`, `{}`) are ONE operator mistake — a mistyped flag — and deserve one
+		// message; `JSON.parse`'s byte offset adds nothing when the whole operand is echoed anyway.
+	}
+	if (!Array.isArray(parsed)) {
+		throw new Error(`--replicates must be a JSON array or a comma-separated list; got "${raw}"`);
+	}
+	return parsed.map((value) => String(value));
+}
+
+/**
+ * How many replicate sandboxes may be in flight at once — `--max-concurrency <n>` or
+ * `BENCH_MAX_CONCURRENCY`, defaulting to unbounded (all R at once, matching what R separate runners
+ * did). The knob exists for a provider whose account quota makes a wide fan-out spend its create-retry
+ * budget queueing instead of benchmarking. CI reaches it through the env var only — bench-suite.yml
+ * puts the dispatch input in `BENCH_MAX_CONCURRENCY` and never passes the flag — so `argv` winning is
+ * for the operator debugging by hand, whose typed flag should beat an exported value they forgot about.
+ * A non-positive or non-integer value throws — a typo must fail the cell, not silently serialize (or
+ * unbound) the fan-out.
+ */
+export function resolveMaxConcurrency(
+	argv: readonly string[],
+	env: Record<string, string | undefined> = process.env,
+): number {
+	const raw =
+		lastFlagValue(argv, "max-concurrency", "a positive integer argument") ??
+		env.BENCH_MAX_CONCURRENCY;
+	if (raw === undefined || raw.trim() === "") return Number.POSITIVE_INFINITY;
+	const limit = Number(raw);
+	if (!Number.isInteger(limit) || limit < 1) {
+		throw new Error(`max concurrency must be a positive integer; got "${raw}"`);
+	}
+	return limit;
+}
+
+/**
+ * Run `fn` over every item with at most `limit` in flight, resolving to the results IN INPUT ORDER.
+ * NEVER rejects: a throw from `fn` is handed to `onError`, whose return value takes that slot.
+ *
+ * `onError` is REQUIRED, not optional, and that is the whole point. An earlier version documented
+ * "`fn` must be total" and relied on the caller honouring it — which is not a guarantee, it is a
+ * hope. When it was violated the failure was maximally bad: `Promise.all` rejects on the first
+ * throw, the awaiting caller unwinds, and the R-1 peers still mid-flight are abandoned with their
+ * sandboxes alive and their shards unwritten — while the process exits BEFORE reporting, so nothing
+ * says what was lost. Downstream, `aggregate` accepts any non-empty shard set, so the run would
+ * publish quietly as a smaller experiment than the one dispatched. Making the failure path a typed
+ * parameter means a caller cannot forget it: the compiler asks what a failed item looks like.
+ *
+ * The old per-replicate matrix cells got this isolation from `fail-fast: false`; this is the
+ * in-process equivalent, and it must hold for the same reason.
+ */
+export async function runPooled<T, R>(
+	items: readonly T[],
+	limit: number,
+	fn: (item: T, index: number) => Promise<R>,
+	onError: (error: unknown, item: T, index: number) => R,
+): Promise<R[]> {
+	const results = new Array<R>(items.length);
+	let next = 0;
+	// The `max(1, …)` floor is the guard, not an optimisation: a `limit` below 1 reaching a generic pool
+	// would otherwise spawn zero workers and resolve immediately with a hole-filled array — silent data
+	// loss — rather than doing the work. (An empty `items` still costs one worker, which exits at once.)
+	const workers = Math.max(1, Math.min(items.length, limit));
+	await Promise.all(
+		Array.from({ length: workers }, async () => {
+			for (;;) {
+				const index = next++;
+				if (index >= items.length) return;
+				// Indexed inside the bounds check, so an item that is itself `undefined` (never the case
+				// for a replicate index, but the pool is generic) can't be read as "the queue is empty".
+				const item = items[index] as T;
+				try {
+					results[index] = await fn(item, index);
+				} catch (error) {
+					results[index] = onError(error, item, index);
+				}
+			}
+		}),
+	);
+	return results;
+}

--- a/docs/methodology.md
+++ b/docs/methodology.md
@@ -91,14 +91,22 @@ without being Daytona-specific.
 
 ## The dataset pipeline
 
-1. **Run** — `bench-suite <provider> <suite> <runId> --replicate <idx>` boots a sandbox, runs the
-   suite's mise tasks, pulls the raw tree (`data/raw/<runId>/<provider>/<suite>/`), and normalizes it
-   into a Run document stamped with its replicate index.
+1. **Run** — `bench-suite <provider> <suite> <runId> --replicates <indices>` boots one sandbox per
+   replicate index (concurrently, from one process), runs the suite's mise tasks in each, pulls the raw
+   trees (`data/raw/<runId>/r<idx>/<provider>/<suite>/`), and normalizes each into its own shard Run
+   document (`data/runs/<runId>-r<idx>.json`) stamped with that replicate index. `--replicate <idx>` is
+   the single-sandbox spelling, writing the un-suffixed `data/runs/<runId>.json`.
 2. **Matrix** — the `bench-matrix` workflow plans three axes (`plan-providers` / `plan-suites` /
    `plan-replicates`), then one suite-matrix job calls the reusable `bench-suite` workflow per suite
-   (GitHub-native nesting: `<suite> / <provider> (replicate N)`), fanning out over the selected
-   providers × that suite's replicate sandboxes; every `(provider, suite, replicate)` cell uploads its
-   shard Run as an artifact. Two axes are the statistical knobs, both defaulting to the per-suite schema
+   (GitHub-native nesting: `<suite> / <provider>`), fanning out over the selected providers; each
+   `(provider, suite)` cell drives that suite's whole replicate fleet itself and uploads all its shard
+   Runs as one artifact. **Replicates are not a runner axis.** A bench runner is idle for essentially
+   its whole life — it creates a sandbox and polls it — so a runner per replicate billed R idle runners
+   to do one runner's work (324 runners where 54 suffice, at the shipped defaults). Driving the fleet
+   in-process leaves the sandbox count, provider load, and wall clock unchanged (the cell's wall clock
+   is its slowest replicate, not their sum) while the runner bill stops scaling with R. Isolation is
+   preserved: every replicate runs to completion and writes its shard even when a peer dies, and the
+   cell goes red at the end if any did. Two axes are the statistical knobs, both defaulting to the per-suite schema
    config so a bare dispatch already carries the intended statistical power for separating providers
    (subject to the genuine near-tie limit noted below — no sample size resolves providers that are truly
    within a few percent):

--- a/packages/harness/src/index.test.ts
+++ b/packages/harness/src/index.test.ts
@@ -1,5 +1,4 @@
 import { afterAll, describe, expect, it } from "bun:test";
-import { execFileSync } from "node:child_process";
 import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
@@ -283,10 +282,15 @@ function collectPayload(files: Record<string, string>): string {
 	for (const [name, contents] of Object.entries(files)) {
 		writeFileSync(join(src, "benchmark-results", name), contents);
 	}
-	const b64 = execFileSync("bash", ["-c", "tar -czf - benchmark-results | base64 | tr -d '\\n'"], {
+	// Bun.spawnSync, not node:child_process — the fixture mirrors the in-sandbox collect command, and
+	// the harness runs entirely on Bun's own process API.
+	const tar = Bun.spawnSync(["bash", "-c", "tar -czf - benchmark-results | base64 | tr -d '\\n'"], {
 		cwd: src,
-		encoding: "utf8",
 	});
+	if (tar.exitCode !== 0) {
+		throw new Error(`fixture tar failed (${tar.exitCode}): ${tar.stderr.toString()}`);
+	}
+	const b64 = tar.stdout.toString();
 	rmSync(src, { recursive: true, force: true });
 	return `__BENCH_RESULTS_TGZ_BEGIN__\n${b64}\n__BENCH_RESULTS_TGZ_END__\n`;
 }

--- a/packages/harness/src/index.ts
+++ b/packages/harness/src/index.ts
@@ -155,7 +155,9 @@ export interface RunSuiteOptions {
 	providerName: string;
 	/** Suite to run — must be a key of SUITES. */
 	suiteName: string;
-	/** Host directory to extract results into (e.g. `data/raw/<runId>/<provider>`). */
+	/** Host directory to extract results into. The CI fan-out gives each replicate sandbox its own
+	 *  root, so this is `data/raw/<runId>/r<idx>/<provider>/<suite>` there and
+	 *  `data/raw/<runId>/<provider>/<suite>` for a single-sandbox run. */
 	resultsDir: string;
 	/** Credential source for the provider's required env vars (default: process.env). */
 	env?: Record<string, string | undefined>;

--- a/packages/harness/src/lib/collect.test.ts
+++ b/packages/harness/src/lib/collect.test.ts
@@ -1,5 +1,4 @@
 import { afterAll, describe, expect, it } from "bun:test";
-import { execFileSync } from "node:child_process";
 import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
@@ -28,10 +27,15 @@ function collectPayload(files: Record<string, string>): string {
 	for (const [name, contents] of Object.entries(files)) {
 		writeFileSync(join(src, "benchmark-results", name), contents);
 	}
-	const b64 = execFileSync("bash", ["-c", "tar -czf - benchmark-results | base64 | tr -d '\\n'"], {
+	// Bun.spawnSync, not node:child_process — the fixture mirrors the in-sandbox collect command, and
+	// the harness runs entirely on Bun's own process API.
+	const tar = Bun.spawnSync(["bash", "-c", "tar -czf - benchmark-results | base64 | tr -d '\\n'"], {
 		cwd: src,
-		encoding: "utf8",
 	});
+	if (tar.exitCode !== 0) {
+		throw new Error(`fixture tar failed (${tar.exitCode}): ${tar.stderr.toString()}`);
+	}
+	const b64 = tar.stdout.toString();
 	rmSync(src, { recursive: true, force: true });
 	return `noise\n__BENCH_RESULTS_TGZ_BEGIN__\n${b64}\n__BENCH_RESULTS_TGZ_END__\ntrailing\n`;
 }

--- a/packages/harness/src/lib/collect.ts
+++ b/packages/harness/src/lib/collect.ts
@@ -4,9 +4,9 @@
  * exactly when partial results matter), and writes harness skip markers. The pulled files are the
  * raw inputs the normalizer consumes — the committed raw tool output is the dataset's source of truth.
  */
-import { execFileSync } from "node:child_process";
 import { randomUUID } from "node:crypto";
-import { cpSync, mkdirSync, readdirSync, rmSync, statSync, writeFileSync } from "node:fs";
+import { mkdirSync, readdirSync, writeFileSync } from "node:fs";
+import { cp, mkdir, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join, resolve } from "node:path";
 import type { GapOutcome } from "@sandbox-benchmarks/schema";
@@ -85,7 +85,7 @@ export async function collectResults(runner: StepRunner, resultsDir: string): Pr
 			// the idempotent re-collect can fix, so treat it like a marker miss one stage later and retry
 			// rather than discard the suite. The content gate is the one thing that does NOT retry.
 			try {
-				const archiveKiB = decodeAndExtract(base64, resultsDir);
+				const archiveKiB = await decodeAndExtract(base64, resultsDir);
 				validateCollected(resultsDir);
 				console.log(`Results extracted to ${resultsDir} (${archiveKiB.toFixed(1)} KiB archive)`);
 				return;
@@ -129,31 +129,63 @@ export async function collectResults(runner: StepRunner, resultsDir: string): Pr
 }
 
 /**
+ * Untar `archive` into `stage` with `Bun.spawn`, throwing tar's own diagnostics on a non-zero exit.
+ *
+ * Async, not `Bun.spawnSync`/`execFileSync`: one process now drives R replicate sandboxes at once
+ * (apps/cli/src/lib/replicates.ts), and each one's detached step is kept alive by a poll loop on this
+ * same event loop. A synchronous extract stalls every PEER's polling for its whole duration — and a
+ * poll that cannot run is indistinguishable, to the loop's consecutive-failure guard, from a sandbox
+ * that stopped answering. Awaiting the child yields instead.
+ *
+ * tar's stderr is included in the error because it names the actual corruption ("unexpected EOF"),
+ * and unlike the collect stdout it carries none of the payload — the content-free diagnostics rule in
+ * {@link collectResults} is about the base64 archive, not about tar's complaints regarding it.
+ */
+async function extractArchive(archive: string, stage: string): Promise<void> {
+	const proc = Bun.spawn(["tar", "-xzf", archive, "-C", stage], {
+		stdout: "ignore",
+		stderr: "pipe",
+	});
+	const [stderr, exitCode] = await Promise.all([new Response(proc.stderr).text(), proc.exited]);
+	if (exitCode !== 0) {
+		throw new Error(
+			`tar exited ${exitCode} extracting the results archive: ${stderr.trim() || "(no stderr)"}`,
+		);
+	}
+}
+
+/**
  * Decode the marker-bounded base64 tar to disk and extract benchmark-results/ into `resultsDir`,
  * returning the archive size in KiB (for the success log). Throws on any decode/extract failure —
  * {@link collectResults} treats that as retryable stream corruption.
  */
-function decodeAndExtract(base64: string, resultsDir: string): number {
-	// Decode straight to disk via the "base64" write encoding — avoids a Node-only Buffer in the
-	// cross-runtime package code. A random suffix keeps concurrent collects from colliding.
+async function decodeAndExtract(base64: string, resultsDir: string): Promise<number> {
 	const archive = join(tmpdir(), `bench-results-${process.pid}-${randomUUID()}.tgz`);
 	try {
-		writeFileSync(archive, base64, "base64");
+		// The archive write and the tree copy yield, for the reason {@link extractArchive} documents:
+		// R replicates enter collect at roughly the same time, so whatever blocks here blocks R-1 peers'
+		// poll loops. Converting only the `tar` child would have left the multi-MB write and the
+		// recursive copy stalling them. `Uint8Array.fromBase64` itself is a synchronous decode with no
+		// async alternative, but it is ~0.2 ms/MB — three orders under the poll interval — so it stays.
+		// It is also the Bun-native spelling of the old `writeFileSync(…, "base64")`: no Node Buffer in
+		// package code, and it throws on a corrupt payload the old encoding would have silently dropped.
+		const bytes = Uint8Array.fromBase64(base64);
+		await Bun.write(archive, bytes);
 		const target = resolve(resultsDir);
 		// The tarball holds a top-level benchmark-results/ directory. Extract into a unique staging
 		// dir (not `parent`, which is shared across providers) so concurrent collects can't clobber
 		// each other, then copy its contents into the target (`<provider>`, not `benchmark-results`).
 		const stage = join(tmpdir(), `bench-extract-${process.pid}-${randomUUID()}`);
-		mkdirSync(stage, { recursive: true });
+		await mkdir(stage, { recursive: true });
 		try {
-			execFileSync("tar", ["-xzf", archive, "-C", stage]);
-			cpSync(join(stage, "benchmark-results"), target, { recursive: true });
+			await extractArchive(archive, stage);
+			await cp(join(stage, "benchmark-results"), target, { recursive: true });
 		} finally {
-			rmSync(stage, { recursive: true, force: true });
+			await rm(stage, { recursive: true, force: true });
 		}
-		return statSync(archive).size / 1024;
+		return Bun.file(archive).size / 1024;
 	} finally {
-		rmSync(archive, { force: true });
+		await rm(archive, { force: true });
 	}
 }
 

--- a/packages/results/src/lib/aggregate.ts
+++ b/packages/results/src/lib/aggregate.ts
@@ -113,8 +113,8 @@ function mergeProvider(providerId: string, entries: readonly ReplicateSlice[]): 
 	// silently drop whichever arrived second.
 	const gaps: ResultGap[] = [];
 	const seenGap = new Set<string>();
-	// Coverage unions across shards: the matrix fans out one job per (provider, suite), so each shard sees
-	// only its own cell. A suite is covered for this provider iff SOME shard produced a Metric for it.
+	// Coverage unions across shards: the matrix fans out one job per (provider, suite) and that job writes
+	// one shard per replicate sandbox, so each shard sees only its own cell+replicate. A suite is covered for this provider iff SOME shard produced a Metric for it.
 	const suitesCovered = new Set<string>();
 	const uncatalogued: UncataloguedResult[] = [];
 	const seenStraggler = new Set<string>();

--- a/packages/schema/src/raw-files.ts
+++ b/packages/schema/src/raw-files.ts
@@ -1,6 +1,7 @@
 /**
  * The raw-file naming contract — the ONE home for how files in a Run's curated raw tree
- * (`data/raw/<runId>/<provider>/<suite>/`) are named, and how gap markers are shaped. The in-sandbox
+ * (`data/raw/<runId>/[r<idx>/]<provider>/<suite>/` — the `r<idx>` level is present when one runner
+ * drove a replicate fan-out) are named, and how gap markers are shaped. The in-sandbox
  * producer and the harness collector (writers) and the results extractor (the single reader) all
  * route through this module, so a filename's spelling can never drift between them.
  *

--- a/packages/schema/src/suites.ts
+++ b/packages/schema/src/suites.ts
@@ -324,6 +324,20 @@ export type SuiteName = keyof typeof SUITES;
 export const SUITE_NAMES = Object.keys(SUITES) as SuiteName[];
 
 /**
+ * Host-side checkout/teardown/normalization/upload allowance beyond the sandbox lifetime — what a
+ * bench job needs ON TOP of the suite budgets it runs, charged ONCE per job rather than per suite.
+ *
+ * Owned here, next to the `timeoutMinutes` it is always added to, because two independent consumers
+ * must agree on it or the pair contradicts itself: the workflow gate (`checkWorkflowTimeouts`) uses
+ * it as the floor a job's `timeout-minutes` must clear, and `bench-suite`'s fan-out guard
+ * (`fleetBudgetError`) uses it to decide whether a capped fleet's serial waves fit that same budget.
+ * A guard using a smaller margin than the gate would admit a fan-out the gate considers unaffordable
+ * and let the cell be cancelled with every shard lost — which is the exact outcome both exist to
+ * prevent.
+ */
+export const WORKFLOW_TIMEOUT_MARGIN_MINUTES = 15;
+
+/**
  * The comma-padded token for one suite, e.g. `cpu-node` → `,cpu-node,`. GitHub Actions `if:`
  * expressions can't split strings, so the setup job emits the planned suites as a padded list
  * ({@link padSuiteList}) and each suite job matches its own token with `contains(..., ',<suite>,')`.

--- a/tooling/repo-checks/src/lib/workflow-nesting.ts
+++ b/tooling/repo-checks/src/lib/workflow-nesting.ts
@@ -1,6 +1,13 @@
 // Invariant 6: GitHub-native suite→provider nesting wiring for bench-matrix.yml + bench-suite.yml.
 // Kept out of workflow-sync.ts so credential/timeout gates and nesting gates don't grow as one file.
-import { asRecord, MATRIX_WORKFLOW, SUITE_JOB, SUITE_WORKFLOW } from "./workflow-yaml.ts";
+import {
+	asRecord,
+	MATRIX_WORKFLOW,
+	RUN_STEP,
+	SUITE_JOB,
+	SUITE_WORKFLOW,
+	stepByName,
+} from "./workflow-yaml.ts";
 
 /** A bench-matrix suite job is one that `uses` this reusable workflow (matched by path suffix). */
 const SUITE_WORKFLOW_USES_SUFFIX = "/bench-suite.yml";
@@ -14,6 +21,8 @@ export interface SuiteMatrixCaller {
 	jobId: string;
 	name: string;
 	suiteInput: string;
+	/** The `with.replicates` expression — this suite's slice of the plan's per-suite map. */
+	replicatesInput: string;
 	matrixSuiteExpr: string;
 	/** Job ids listed in `publish.needs` (empty when publish is missing or has no needs list). */
 	publishNeeds: string[];
@@ -25,16 +34,28 @@ export const EXPECTED_SUITE_MATRIX_EXPR = "${{ fromJSON(needs.plan.outputs.suite
 /** The expression that makes each caller cell's display name the suite id (native nesting parent). */
 // biome-ignore lint/suspicious/noTemplateCurlyInString: a GHA expression literal matched verbatim against the workflow, not a JS template.
 export const EXPECTED_SUITE_NAME_EXPR = "${{ matrix.suite }}";
-/** The provider id half of the fan-out cell's display name. */
+/** The expression that makes each reusable fan-out cell's display name the provider id (the nesting
+ *  child): "<suite> / <provider>". There is no replicate suffix — one cell owns all R replicate
+ *  sandboxes of its (suite, provider), driven concurrently from the single runner. */
 // biome-ignore lint/suspicious/noTemplateCurlyInString: a GHA expression literal matched verbatim against the workflow, not a JS template.
-const PROVIDER_NAME_EXPR = "${{ matrix.provider }}";
-/** The replicate-index suffix on the fan-out cell's display name. */
+export const EXPECTED_PROVIDER_NAME_EXPR = "${{ matrix.provider }}";
+
+/** The run-step env key that hands the cell its replicate index array. */
+export const REPLICATES_ENV_KEY = "BENCH_REPLICATES";
+/** The expression that key must carry: the reusable's own `replicates` input, verbatim. */
 // biome-ignore lint/suspicious/noTemplateCurlyInString: a GHA expression literal matched verbatim against the workflow, not a JS template.
-const REPLICATE_NAME_SUFFIX = " (replicate ${{ matrix.replicate }})";
-/** The expression that makes each reusable fan-out cell's display name the provider id + replicate index
- *  (the nesting child): "<provider> (replicate N)". The replicate suffix keeps each of a provider's R
- *  replicate sandboxes a distinct, legible cell — a bare `matrix.provider` would render them identically. */
-export const EXPECTED_PROVIDER_NAME_EXPR = `${PROVIDER_NAME_EXPR}${REPLICATE_NAME_SUFFIX}`;
+export const EXPECTED_REPLICATES_ENV_EXPR = "${{ inputs.replicates }}";
+/** The argument the run step must pass, so the env value is actually CONSUMED. Setting the env
+ *  without passing the flag leaves bench-suite on its single-sandbox default — a green matrix run
+ *  publishing R=1 — which is precisely what this invariant exists to prevent. */
+export const EXPECTED_REPLICATES_ARG = `--replicates "$${REPLICATES_ENV_KEY}"`;
+/** The expression the suite-matrix caller must hand down as `with.replicates`: this suite's slice of
+ *  the plan's per-suite map. Pinned because a hardcoded array here (`'[0]'`) would pass every other
+ *  nesting check while quietly running one sandbox per cell — the same R=1 outcome the callee-side
+ *  checks guard, entered from the caller instead. */
+export const EXPECTED_REPLICATES_INPUT_EXPR =
+	// biome-ignore lint/suspicious/noTemplateCurlyInString: a GHA expression literal matched verbatim against the workflow, not a JS template.
+	"${{ toJSON(fromJSON(needs.plan.outputs.replicates)[matrix.suite]) }}";
 
 /**
  * The bench-matrix suite-matrix caller — exactly one job whose `uses` targets the reusable
@@ -61,6 +82,10 @@ export function matrixSuiteCaller(
 		if (typeof suiteInput !== "string") {
 			throw new Error(`${label}: job "${jobId}" calls ${uses} without a string "suite" input`);
 		}
+		const replicatesInput = withMap.replicates;
+		if (typeof replicatesInput !== "string") {
+			throw new Error(`${label}: job "${jobId}" calls ${uses} without a string "replicates" input`);
+		}
 		const name = typeof job.name === "string" ? job.name : "";
 		const strategy = asRecord(
 			job.strategy,
@@ -76,7 +101,7 @@ export function matrixSuiteCaller(
 				`${label}: job "${jobId}" calls ${uses} without a string "strategy.matrix.suite" axis`,
 			);
 		}
-		callers.push({ jobId, name, suiteInput, matrixSuiteExpr });
+		callers.push({ jobId, name, suiteInput, replicatesInput, matrixSuiteExpr });
 	}
 	if (callers.length === 0) {
 		throw new Error(
@@ -128,6 +153,14 @@ export function checkSuiteMatrixCaller(
 				`matrix cell dispatches its own suite (got "${caller.suiteInput}")`,
 		);
 	}
+	if (caller.replicatesInput !== EXPECTED_REPLICATES_INPUT_EXPR) {
+		errors.push(
+			`${label}: job "${caller.jobId}" with.replicates must be "${EXPECTED_REPLICATES_INPUT_EXPR}" ` +
+				`so each cell receives its own suite's replicate axis from the plan — a literal or a ` +
+				`different suite's slice silently changes how many sandboxes the run measures ` +
+				`(got "${caller.replicatesInput}")`,
+		);
+	}
 	if (caller.matrixSuiteExpr !== EXPECTED_SUITE_MATRIX_EXPR) {
 		errors.push(
 			`${label}: job "${caller.jobId}" strategy.matrix.suite must be "${EXPECTED_SUITE_MATRIX_EXPR}" ` +
@@ -145,7 +178,16 @@ export function checkSuiteMatrixCaller(
 
 /**
  * Invariant 6 (callee half): the reusable bench-suite fan-out job display name is the provider id so
- * nested Actions UI cells read as "<suite> / <provider>".
+ * nested Actions UI cells read as "<suite> / <provider>", AND the replicate axis reaches the cell as
+ * data rather than as a matrix axis.
+ *
+ * The replicate check is the load-bearing half. The `replicates` input used to be consumed by
+ * `strategy.matrix.replicate`, so forgetting to wire it was impossible — the fan-out simply had no
+ * cells. Now the array is handed to one cell through the run step's environment, and a dropped or
+ * misspelled `BENCH_REPLICATES` would leave `bench-suite` on its single-sandbox default: a green
+ * matrix run that quietly published R=1 for every provider, with the dataset's between-machine
+ * intervals silently collapsing to within-machine ones. Assert both that the axis is gone from the
+ * matrix (so R runners are not re-introduced by accident) and that the input reaches the cell.
  */
 export function checkSuiteWorkflowNesting(doc: unknown, label: string = SUITE_WORKFLOW): string[] {
 	const root = asRecord(doc, `${label}: not a YAML mapping`);
@@ -155,12 +197,68 @@ export function checkSuiteWorkflowNesting(doc: unknown, label: string = SUITE_WO
 		return [`${label}: job "${SUITE_JOB}" is missing — the provider fan-out job is required`];
 	}
 	const bench = asRecord(job, `${label}: job "${SUITE_JOB}" is not a mapping`);
+	const errors: string[] = [];
+
 	const name = typeof bench.name === "string" ? bench.name : "";
 	if (name !== EXPECTED_PROVIDER_NAME_EXPR) {
-		return [
+		errors.push(
 			`${label}: job "${SUITE_JOB}" name must be "${EXPECTED_PROVIDER_NAME_EXPR}" for native ` +
 				`provider nesting under each suite (got ${name ? `"${name}"` : "no name"})`,
-		];
+		);
 	}
-	return [];
+
+	// A `replicate` matrix axis would restore one idle runner per replicate — the cost this fan-out
+	// was moved in-process to remove. `?? {}` reads an absent strategy/matrix as "no axis"; a present
+	// but malformed one still throws, matching how the rest of this module navigates.
+	const strategy = asRecord(
+		bench.strategy ?? {},
+		`${label}: job "${SUITE_JOB}" strategy is not a mapping`,
+	);
+	const matrix = asRecord(
+		strategy.matrix ?? {},
+		`${label}: job "${SUITE_JOB}" strategy.matrix is not a mapping`,
+	);
+	if (matrix.replicate !== undefined) {
+		errors.push(
+			`${label}: job "${SUITE_JOB}" must not have a "replicate" matrix axis — the cell drives ` +
+				`every replicate itself (bench-suite --replicates), so an axis here bills one idle ` +
+				`runner per replicate for no extra throughput`,
+		);
+	}
+
+	// Both remaining checks read the SAME step, so locate it once. `?? {}` again: a missing step or
+	// env block is drift this gate reports, not a parse error — the two checks below name it.
+	const step = stepByName(bench, RUN_STEP, label);
+	const env = asRecord(
+		step?.env ?? {},
+		`${label}: job "${SUITE_JOB}" step "${RUN_STEP}" env is not a mapping`,
+	);
+
+	// ...the array must actually reach it, or the cell silently falls back to a single sandbox...
+	const rawEnv = env[REPLICATES_ENV_KEY];
+	const replicatesEnv = typeof rawEnv === "string" ? rawEnv : undefined;
+	if (replicatesEnv !== EXPECTED_REPLICATES_ENV_EXPR) {
+		errors.push(
+			`${label}: job "${SUITE_JOB}" step "${RUN_STEP}" must set ${REPLICATES_ENV_KEY}: ` +
+				`"${EXPECTED_REPLICATES_ENV_EXPR}" so the cell fans out over the plan's replicate axis ` +
+				`(got ${replicatesEnv === undefined ? "no such env key" : `"${replicatesEnv}"`})`,
+		);
+	}
+
+	// ...AND the command must consume it. Checking only the env block left the invariant bypassable by
+	// its own stated failure mode: dropping the flag from the `run:` line keeps the env key present, so
+	// the gate stayed green while bench-suite took its single-sandbox default and the legacy
+	// `<runId>.json` glob in commit-dataset.yml collected the lone shard without complaint — a matrix
+	// run that publishes R=1 with the dataset's between-machine intervals collapsed to within-machine
+	// ones. A substring match is enough and matches how the rest of this module pins expressions.
+	const runCommand = typeof step?.run === "string" ? step.run : undefined;
+	if (runCommand === undefined || !runCommand.includes(EXPECTED_REPLICATES_ARG)) {
+		errors.push(
+			`${label}: job "${SUITE_JOB}" step "${RUN_STEP}" must pass ${EXPECTED_REPLICATES_ARG} to ` +
+				`bench-suite — setting ${REPLICATES_ENV_KEY} without consuming it silently runs ONE sandbox ` +
+				`per cell (got ${runCommand === undefined ? "no run: command" : `"${runCommand.trim()}"`})`,
+		);
+	}
+
+	return errors;
 }

--- a/tooling/repo-checks/src/lib/workflow-sync.ts
+++ b/tooling/repo-checks/src/lib/workflow-sync.ts
@@ -238,6 +238,42 @@ export function checkWorkflowTimeouts(timeoutByWorkflow: Record<string, number>)
 		);
 }
 
+/** The run-step env key carrying the cell's job budget down to `bench-suite`. */
+export const CELL_BUDGET_ENV_KEY = "BENCH_CELL_BUDGET_MINUTES";
+
+/**
+ * Invariant 5 (second half): the budget the cell's run step advertises equals the job's real
+ * `timeout-minutes`.
+ *
+ * `bench-suite` refuses a `--max-concurrency` cap whose serial waves cannot fit the cell's budget —
+ * the check that keeps a capped fan-out from being cancelled mid-flight with all R shards lost. It
+ * learns that budget from this env key, because `timeout-minutes` is not readable from an expression
+ * context, so the value is a hand-copied literal. Copied literals drift: raising the job timeout
+ * without raising the env would keep rejecting caps that now fit, and lowering it without lowering the
+ * env would wave through caps that no longer do — the exact failure the guard exists to prevent,
+ * re-entered through its own configuration. Assert them equal.
+ */
+export function checkCellBudgetEnv(
+	env: Record<string, string>,
+	timeoutMinutes: number,
+	workflow: string,
+): string[] {
+	const raw = env[CELL_BUDGET_ENV_KEY];
+	if (raw === undefined) {
+		return [
+			`${workflow}: run step must set ${CELL_BUDGET_ENV_KEY} so bench-suite can reject a ` +
+				`--max-concurrency cap that cannot fit the job's ${timeoutMinutes}-minute budget`,
+		];
+	}
+	if (Number(raw) !== timeoutMinutes) {
+		return [
+			`${workflow}: ${CELL_BUDGET_ENV_KEY} is "${raw}" but the job's timeout-minutes is ` +
+				`${timeoutMinutes} — the cell would size its fan-out against a budget it does not have`,
+		];
+	}
+	return [];
+}
+
 /**
  * The whole gate against the real workflow files under `root` — the single owner of which files feed
  * the gate, used by the real-file test in workflow-registry-sync.test.ts.
@@ -248,17 +284,22 @@ export function runCheck(root: string = findRepoRoot()): string[] {
 	// The matrix lane's credential block + run-job timeout live in the reusable bench-suite.yml that
 	// every suite job calls, so the "matrix side" of Invariants 3–5 reads that file.
 	const suiteWf = readWorkflow(SUITE_WORKFLOW, root);
+	// Read once and share: the suite run step's env feeds both the credential gate and the cell-budget
+	// gate, and its job timeout feeds both the margin gate and that same budget gate.
+	const suiteEnv = stepEnv(suiteWf, SUITE_JOB, RUN_STEP, SUITE_WORKFLOW);
+	const suiteTimeout = jobTimeoutMinutes(suiteWf, SUITE_JOB, SUITE_WORKFLOW);
 	return [
 		...checkProviderInput(dispatchInput(smoke, "provider", SMOKE_WORKFLOW)),
 		...checkSuiteInput(dispatchInput(smoke, "suite", SMOKE_WORKFLOW)),
 		...checkCredentialEnv({
 			[SMOKE_WORKFLOW]: stepEnv(smoke, SMOKE_JOB, RUN_STEP, SMOKE_WORKFLOW),
-			[SUITE_WORKFLOW]: stepEnv(suiteWf, SUITE_JOB, RUN_STEP, SUITE_WORKFLOW),
+			[SUITE_WORKFLOW]: suiteEnv,
 		}),
 		...checkWorkflowTimeouts({
 			[SMOKE_WORKFLOW]: jobTimeoutMinutes(smoke, SMOKE_JOB, SMOKE_WORKFLOW),
-			[SUITE_WORKFLOW]: jobTimeoutMinutes(suiteWf, SUITE_JOB, SUITE_WORKFLOW),
+			[SUITE_WORKFLOW]: suiteTimeout,
 		}),
+		...checkCellBudgetEnv(suiteEnv, suiteTimeout, SUITE_WORKFLOW),
 		...checkSuiteMatrixCaller(matrixSuiteCaller(matrix, MATRIX_WORKFLOW), MATRIX_WORKFLOW),
 		...checkSuiteWorkflowNesting(suiteWf, SUITE_WORKFLOW),
 	];

--- a/tooling/repo-checks/src/lib/workflow-sync.ts
+++ b/tooling/repo-checks/src/lib/workflow-sync.ts
@@ -25,7 +25,8 @@
 //   5. Both live-run jobs (smoke's job and the reusable fan-out) outlast the longest registered sandbox
 //      lifetime by a fixed margin, so a suite budget increase cannot leave an otherwise healthy job to
 //      be killed by Actions first.
-//   6. Nesting wiring (suite-matrix caller + reusable provider job name) — see workflow-nesting.ts.
+//   6. Nesting wiring (suite-matrix caller + reusable provider job name) and the replicate axis
+//      reaching the cell as BENCH_REPLICATES data rather than as a matrix axis — see workflow-nesting.ts.
 //
 // YAML navigation lives in workflow-yaml.ts; nesting checks in workflow-nesting.ts. This file owns
 // credential/timeout invariants plus runCheck orchestration, and re-exports the public surface the
@@ -57,9 +58,13 @@ export {
 	checkSuiteMatrixCaller,
 	checkSuiteWorkflowNesting,
 	EXPECTED_PROVIDER_NAME_EXPR,
+	EXPECTED_REPLICATES_ARG,
+	EXPECTED_REPLICATES_ENV_EXPR,
+	EXPECTED_REPLICATES_INPUT_EXPR,
 	EXPECTED_SUITE_MATRIX_EXPR,
 	EXPECTED_SUITE_NAME_EXPR,
 	matrixSuiteCaller,
+	REPLICATES_ENV_KEY,
 } from "./workflow-nesting.ts";
 export type { DispatchInput } from "./workflow-yaml.ts";
 export {

--- a/tooling/repo-checks/src/lib/workflow-yaml.ts
+++ b/tooling/repo-checks/src/lib/workflow-yaml.ts
@@ -94,6 +94,26 @@ export function jobTimeoutMinutes(doc: unknown, jobId: string, label: string): n
 }
 
 /**
+ * The step named `stepName` inside an already-resolved `job`, or undefined when the job has no steps
+ * list or no such step. LENIENT on purpose: the nesting gate (workflow-nesting.ts) accumulates error
+ * strings instead of throwing, so it needs "absent" as a value it can report. A step that is present
+ * but not a mapping still throws — that is malformed YAML, not drift. {@link stepEnv} layers the
+ * strict spelling on top for callers where a renamed job/step must fail the gate loudly.
+ */
+export function stepByName(
+	job: Record<string, unknown>,
+	stepName: string,
+	label: string,
+): Record<string, unknown> | undefined {
+	if (!Array.isArray(job.steps)) return undefined;
+	for (const value of job.steps) {
+		const step = asRecord(value, `${label}: malformed step`);
+		if (step.name === stepName) return step;
+	}
+	return undefined;
+}
+
+/**
  * The `env` mapping of a named step inside a job, as key -> value-expression entries. Throws if the
  * job, the step, or its env block is missing, or an env value is not a string — a renamed job/step
  * must fail the gate, not silently match nothing.
@@ -107,16 +127,12 @@ export function stepEnv(
 	const root = asRecord(doc, `${label}: not a YAML mapping`);
 	const jobs = asRecord(root.jobs, `${label}: no jobs mapping`);
 	const job = asRecord(jobs[jobId], `${label}: job "${jobId}" not found`);
-	const steps = job.steps;
-	if (!Array.isArray(steps)) throw new Error(`${label}: job "${jobId}" has no steps list`);
-	const step = steps.find((s) => asRecord(s, `${label}: malformed step`).name === stepName);
+	if (!Array.isArray(job.steps)) throw new Error(`${label}: job "${jobId}" has no steps list`);
+	const step = stepByName(job, stepName, label);
 	if (step === undefined) {
 		throw new Error(`${label}: job "${jobId}" has no step named "${stepName}"`);
 	}
-	const env = asRecord(
-		(step as Record<string, unknown>).env,
-		`${label}: step "${stepName}" has no env mapping`,
-	);
+	const env = asRecord(step.env, `${label}: step "${stepName}" has no env mapping`);
 	const entries: Record<string, string> = {};
 	for (const [key, value] of Object.entries(env)) {
 		if (typeof value !== "string") {

--- a/tooling/repo-checks/src/lib/workflow-yaml.ts
+++ b/tooling/repo-checks/src/lib/workflow-yaml.ts
@@ -3,6 +3,7 @@
 // owns one concern.
 import { readFileSync } from "node:fs";
 import { join } from "node:path";
+import { WORKFLOW_TIMEOUT_MARGIN_MINUTES } from "@sandbox-benchmarks/schema";
 import { type } from "arktype";
 import { findRepoRoot } from "./workspace.ts";
 
@@ -15,8 +16,10 @@ export const RUN_STEP = "Run suite and normalize";
 export const SMOKE_JOB = "smoke";
 /** The fan-out job inside the reusable bench-suite.yml (its credential env + timeout). */
 export const SUITE_JOB = "bench";
-/** Host-side checkout/teardown/normalization/upload allowance beyond the sandbox lifetime. */
-export const WORKFLOW_TIMEOUT_MARGIN_MINUTES = 15;
+/** Host-side checkout/teardown/normalization/upload allowance beyond the sandbox lifetime. Re-exported
+ *  from the schema, which owns it — `bench-suite`'s fan-out budget guard adds the SAME margin, and the
+ *  two must not drift (see the constant's own note). */
+export { WORKFLOW_TIMEOUT_MARGIN_MINUTES };
 
 // Single source of truth: this schema drives BOTH the runtime parse (coercions live in the morphs)
 // and the exported DispatchInput type (inferred below) — there is no hand-written interface or

--- a/tooling/repo-checks/src/workflow-registry-sync.test.ts
+++ b/tooling/repo-checks/src/workflow-registry-sync.test.ts
@@ -24,11 +24,15 @@ import {
 	checkWorkflowTimeouts,
 	dispatchInput,
 	EXPECTED_PROVIDER_NAME_EXPR,
+	EXPECTED_REPLICATES_ARG,
+	EXPECTED_REPLICATES_ENV_EXPR,
+	EXPECTED_REPLICATES_INPUT_EXPR,
 	EXPECTED_SUITE_MATRIX_EXPR,
 	EXPECTED_SUITE_NAME_EXPR,
 	jobTimeoutMinutes,
 	MATRIX_WORKFLOW,
 	matrixSuiteCaller,
+	REPLICATES_ENV_KEY,
 	RUN_STEP,
 	readWorkflow,
 	requiredCredentialKeys,
@@ -295,11 +299,39 @@ describe("checkSuiteMatrixCaller", () => {
 				a: {
 					name: EXPECTED_SUITE_NAME_EXPR,
 					uses: "./.github/workflows/bench-suite.yml",
-					with: { suite: EXPECTED_SUITE_NAME_EXPR },
+					with: { suite: EXPECTED_SUITE_NAME_EXPR, replicates: EXPECTED_REPLICATES_INPUT_EXPR },
 					strategy: { matrix: { suite: EXPECTED_SUITE_MATRIX_EXPR } },
 				},
 				b: {
 					name: EXPECTED_SUITE_NAME_EXPR,
+					uses: "./.github/workflows/bench-suite.yml",
+					with: { suite: EXPECTED_SUITE_NAME_EXPR, replicates: EXPECTED_REPLICATES_INPUT_EXPR },
+					strategy: { matrix: { suite: EXPECTED_SUITE_MATRIX_EXPR } },
+				},
+			},
+		});
+		expect(() => matrixSuiteCaller(Bun.YAML.parse(yaml), "synthetic.yml")).toThrow(
+			"expected exactly one suite-matrix caller",
+		);
+	});
+
+	// The caller-side twin of the run-step bypass: hardcoding the array here passes every other nesting
+	// check while quietly measuring one sandbox per cell.
+	test("flags a caller that hardcodes with.replicates instead of taking the plan's slice", () => {
+		const caller = {
+			...matrixSuiteCaller(matrix),
+			replicatesInput: "[0]",
+		};
+		const errors = checkSuiteMatrixCaller(caller, "synthetic.yml");
+		expect(errors).toHaveLength(1);
+		expect(errors[0]).toContain("with.replicates must be");
+		expect(errors[0]).toContain(EXPECTED_REPLICATES_INPUT_EXPR);
+	});
+
+	test("matrixSuiteCaller throws on a reusable-caller job with no string replicates", () => {
+		const yaml = Bun.YAML.stringify({
+			jobs: {
+				bad: {
 					uses: "./.github/workflows/bench-suite.yml",
 					with: { suite: EXPECTED_SUITE_NAME_EXPR },
 					strategy: { matrix: { suite: EXPECTED_SUITE_MATRIX_EXPR } },
@@ -307,7 +339,7 @@ describe("checkSuiteMatrixCaller", () => {
 			},
 		});
 		expect(() => matrixSuiteCaller(Bun.YAML.parse(yaml), "synthetic.yml")).toThrow(
-			"expected exactly one suite-matrix caller",
+			'without a string "replicates" input',
 		);
 	});
 
@@ -328,14 +360,96 @@ describe("checkSuiteWorkflowNesting", () => {
 		expect(checkSuiteWorkflowNesting(suiteWf)).toEqual([]);
 	});
 
+	/** A fan-out job that satisfies every nesting invariant; each drift test bends exactly one field. */
+	const wiredRunStep = {
+		name: RUN_STEP,
+		env: { [REPLICATES_ENV_KEY]: EXPECTED_REPLICATES_ENV_EXPR },
+		run: `bun apps/cli/src/bin/bench-suite.ts "$BENCH_PROVIDER" "$BENCH_SUITE" "$GITHUB_RUN_ID" ${EXPECTED_REPLICATES_ARG}`,
+	};
+	const wiredFanOut = {
+		name: EXPECTED_PROVIDER_NAME_EXPR,
+		"runs-on": "ubuntu-24.04",
+		steps: [wiredRunStep],
+	};
+	const nestingErrors = (job: object): string[] =>
+		checkSuiteWorkflowNesting(
+			Bun.YAML.parse(Bun.YAML.stringify({ jobs: { [SUITE_JOB]: job } })),
+			"synthetic.yml",
+		);
+
+	test("passes a fan-out job named matrix.provider that receives the replicate array", () => {
+		expect(nestingErrors(wiredFanOut)).toEqual([]);
+	});
+
 	test("flags a fan-out job whose display name is not matrix.provider", () => {
-		const yaml = Bun.YAML.stringify({
-			jobs: { [SUITE_JOB]: { name: "Run", "runs-on": "ubuntu-24.04" } },
-		});
-		const errors = checkSuiteWorkflowNesting(Bun.YAML.parse(yaml), "synthetic.yml");
+		const errors = nestingErrors({ ...wiredFanOut, name: "Run" });
 		expect(errors).toHaveLength(1);
 		expect(errors[0]).toContain("name must be");
 		expect(errors[0]).toContain(EXPECTED_PROVIDER_NAME_EXPR);
+	});
+
+	// Re-adding the axis is the exact regression the in-process fan-out exists to prevent: it would
+	// silently restore one idle runner per replicate.
+	test("flags a reinstated replicate matrix axis", () => {
+		const errors = nestingErrors({
+			...wiredFanOut,
+			strategy: { matrix: { provider: "[]", replicate: "[0,1]" } },
+		});
+		expect(errors).toHaveLength(1);
+		expect(errors[0]).toContain('must not have a "replicate" matrix axis');
+	});
+
+	test("accepts a provider-only matrix", () => {
+		expect(nestingErrors({ ...wiredFanOut, strategy: { matrix: { provider: "[]" } } })).toEqual([]);
+	});
+
+	// Without the env wiring the cell falls back to ONE sandbox — a green run that publishes R=1 while
+	// the plan asked for R=12, so the drift must fail the gate rather than the dataset.
+	test("flags a run step that never receives the replicate array", () => {
+		const errors = nestingErrors({
+			...wiredFanOut,
+			steps: [{ ...wiredRunStep, env: {} }],
+		});
+		expect(errors).toHaveLength(1);
+		expect(errors[0]).toContain(REPLICATES_ENV_KEY);
+		expect(errors[0]).toContain("no such env key");
+	});
+
+	// The bypass that made the env check alone insufficient: keep the env key, drop the flag. The cell
+	// then takes bench-suite's single-sandbox default and commit-dataset's legacy glob collects the one
+	// shard without complaint — a green matrix run publishing R=1.
+	test("flags a run step that sets the env but never passes --replicates", () => {
+		const errors = nestingErrors({
+			...wiredFanOut,
+			steps: [
+				{
+					...wiredRunStep,
+					run: 'bun apps/cli/src/bin/bench-suite.ts "$BENCH_PROVIDER" "$BENCH_SUITE" "$GITHUB_RUN_ID"',
+				},
+			],
+		});
+		expect(errors).toHaveLength(1);
+		expect(errors[0]).toContain(EXPECTED_REPLICATES_ARG);
+	});
+
+	test("flags a run step with no run: command at all", () => {
+		const { run: _dropped, ...noRun } = wiredRunStep;
+		const errors = nestingErrors({ ...wiredFanOut, steps: [noRun] });
+		expect(errors).toHaveLength(1);
+		expect(errors[0]).toContain("no run: command");
+	});
+
+	// `replicas` (the dispatch knob) vs `replicates` (the plan's index array) is the plausible typo:
+	// it's a live input name, so it resolves to a value rather than failing the workflow outright.
+	test("flags a replicate array wired to the wrong expression", () => {
+		// biome-ignore lint/suspicious/noTemplateCurlyInString: a GHA expression literal, not a JS template.
+		const wrongExpr = "${{ inputs.replicas }}";
+		const errors = nestingErrors({
+			...wiredFanOut,
+			steps: [{ ...wiredRunStep, env: { [REPLICATES_ENV_KEY]: wrongExpr } }],
+		});
+		expect(errors).toHaveLength(1);
+		expect(errors[0]).toContain(EXPECTED_REPLICATES_ENV_EXPR);
 	});
 });
 

--- a/tooling/repo-checks/src/workflow-registry-sync.test.ts
+++ b/tooling/repo-checks/src/workflow-registry-sync.test.ts
@@ -16,6 +16,8 @@
 import { describe, expect, test } from "bun:test";
 import { PROVIDERS, SUITE_NAMES } from "@sandbox-benchmarks/schema";
 import {
+	CELL_BUDGET_ENV_KEY,
+	checkCellBudgetEnv,
 	checkCredentialEnv,
 	checkProviderInput,
 	checkSuiteInput,
@@ -111,6 +113,37 @@ describe("checkWorkflowTimeouts", () => {
 		expect(errors).toHaveLength(1);
 		expect(errors[0]).toContain("smoke");
 		expect(errors[0]).toContain(`${WORKFLOW_TIMEOUT_MARGIN_MINUTES}-minute host margin`);
+	});
+});
+
+describe("checkCellBudgetEnv", () => {
+	// The real workflow: the literal the run step advertises must be the job's own timeout-minutes.
+	test("the real cell budget matches the real job timeout", () => {
+		expect(
+			checkCellBudgetEnv(
+				suiteEnv,
+				jobTimeoutMinutes(suiteWf, SUITE_JOB, SUITE_WORKFLOW),
+				SUITE_WORKFLOW,
+			),
+		).toEqual([]);
+	});
+
+	// Dropping the key disables the fan-out budget guard entirely — a capped cell would then be
+	// cancelled three hours in with every shard lost, which is what the guard exists to prevent.
+	test("flags a missing budget key", () => {
+		const errors = checkCellBudgetEnv({}, 180, SUITE_WORKFLOW);
+		expect(errors).toHaveLength(1);
+		expect(errors[0]).toContain(CELL_BUDGET_ENV_KEY);
+	});
+
+	// The drift that matters: raising `timeout-minutes` without raising the copied literal keeps
+	// rejecting caps that now fit; lowering it without lowering the literal waves through caps that
+	// no longer do.
+	test("flags a budget that has drifted from the job timeout", () => {
+		const errors = checkCellBudgetEnv({ [CELL_BUDGET_ENV_KEY]: "180" }, 240, SUITE_WORKFLOW);
+		expect(errors).toHaveLength(1);
+		expect(errors[0]).toContain('is "180"');
+		expect(errors[0]).toContain("timeout-minutes is 240");
 	});
 });
 


### PR DESCRIPTION
## Summary

Refactors the benchmark suite's replicate execution model from a GitHub Actions matrix axis (one runner per replicate) to a bounded-concurrency pool driven by a single process. This eliminates idle runner overhead while maintaining the same sandbox concurrency and provider load characteristics.

## Key Changes

- **New replicate driver infrastructure** (`apps/cli/src/lib/replicates.ts`):
  - `parseReplicatesFlag()` and `parseReplicateIndex()` for parsing `--replicates <indices>` (JSON array or comma-separated list) and `--replicate <idx>` (single replicate)
  - `runPooled()` function to drive R sandboxes concurrently with configurable max concurrency
  - `fleetWaves()` and `fleetBudgetError()` to validate that concurrent waves fit within CI job budget
  - `replicatePaths()` to generate per-replicate shard paths (`data/runs/<runId>-r<idx>.json`)

- **Per-replicate log prefixing** (`apps/cli/src/lib/log-prefix.ts`):
  - `installLineTagging()` and `withLineTag()` to tag concurrent replicate output with `[r<idx>]` prefixes
  - `prefixChunk()` to handle partial lines and preserve workflow commands (`::error::`, etc.)
  - Uses `AsyncLocalStorage` to carry tags through async contexts without threading through call graphs

- **Updated bench-suite CLI** (`apps/cli/src/bin/bench-suite.ts`):
  - New `--replicates <indices>` flag to drive whole fan-out from one process
  - New `--max-concurrency <n>` flag to cap concurrent sandboxes (with budget validation)
  - Kept `--replicate <idx>` for single-sandbox/local runs
  - `ReplicateOutcome` interface to track per-replicate results without exiting on failure
  - `replicateSummaryRows()` and `fleetAnnotationMessage()` for fleet-wide reporting
  - Fleet driver ensures every replicate runs to completion regardless of peer outcomes

- **Workflow updates** (`.github/workflows/bench-suite.yml`, `bench-matrix.yml`):
  - Removed replicate from matrix axis; now passed as `with.replicates` input
  - Single runner per (suite, provider) cell drives all R replicates concurrently
  - Updated `commit-dataset.yml` to glob `runs/<runId>-r*.json` shards alongside legacy `runs/<runId>.json`

- **Workflow validation** (`tooling/repo-checks/src/`):
  - New `checkCellBudgetEnv()` to validate `BENCH_CELL_BUDGET_MINUTES` matches job timeout
  - New `EXPECTED_REPLICATES_*` patterns to validate workflow expressions
  - Updated nesting checks to verify `replicates` input wiring

- **Test coverage**:
  - `replicates.test.ts`: Flag parsing, wave calculation, budget validation
  - `log-prefix.test.ts`: Line tagging with partial lines and workflow commands
  - `bench-suite.fleet.test.ts`: Fleet summary rendering at R=1..49

## Implementation Details

- **Concurrency model**: R sandboxes created concurrently against same provider account (same load/wall clock as matrix), but from one runner (eliminates idle runner billing)
- **Failure isolation**: One flaky sandbox cannot discard peers' results; fleet driver collects all outcomes before deciding exit code
- **Budget safety**: Capped concurrency validates upfront that ceil(R / cap) waves fit job budget, preventing mid-flight cancellation
- **Log readability**: Concurrent output tagged with `[r<idx>]` prefix; workflow commands pass through untouched
- **Shard naming**: `-r<idx>` file suffix keeps R shards distinct in single artifact; aggregate globs both new and legacy layouts

https://claude.ai/code/session_01TPSAc2QcPaHWGXCK3q8MpB

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Run all replicates for each (suite, provider) cell from one process using a bounded-concurrency pool instead of a per-replicate matrix. This cuts runner usage while keeping the same sandbox concurrency, provider load, and wall-clock, with clearer logs, upfront budget safety, and safer retry uploads.

- **New Features**
  - New CLI: `--replicates <indices>` to drive the whole fan-out; `--max-concurrency <n>` to cap concurrent sandboxes; `--replicate <idx>` still supported.
  - Pooled execution with budget validation: rejects caps that can’t finish within `BENCH_CELL_BUDGET_MINUTES` including host-side margin; shared margin constant lives in the schema; tests cover waves and errors.
  - Per-replicate log tagging `[rN]` via AsyncLocalStorage; groups disabled during pooled runs; workflow commands still parse with a forced newline if mid-line; untagged writes keep line-state for correct annotations.
  - Per-replicate shards `data/runs/<runId>-r<idx>.json`; aggregate and `commit-dataset.yml` prefer shards per cell; legacy shape still handled.
  - Workflows: remove replicate from the matrix; pass `with.replicates`, set `BENCH_REPLICATES`, and consume it via `--replicates "$BENCH_REPLICATES"`; allow artifact overwrite on reruns and gate uploads on shard presence to avoid clobbering good artifacts; new checks ensure inputs and that budget env matches the job timeout.
  - Collector moved to async Bun APIs to avoid blocking concurrent polls; help/examples now use canonical provider ids.

- **Migration**
  - CI now runs one runner per (suite, provider); set any provider-level cap via `max_concurrency`.
  - Ensure `BENCH_CELL_BUDGET_MINUTES` equals the job’s timeout-minutes; the gate enforces this.

<sup>Written for commit 7fa616ed93edb6cbc605258dbcacf95c68f72a9a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/starslingdev/hpc-sandbox-benchmarks/pull/279?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Benchmarks can now run multiple replicates within each suite/provider job, coordinated inside the job.
  * Added a configurable cap on in-flight replicate concurrency and improved fleet/job summary reporting with per-replicate status and tagged interleaved logs.
* **Bug Fixes**
  * Dataset aggregation now correctly merges both legacy and per-replicate shard filenames while avoiding accidental non-run matches.
  * Improved reliability and error details when extracting/collecting benchmark result archives.
* **Documentation**
  * Updated CI workflow and methodology guidance to match the new replicate fan-out and result layout.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->