### PR TITLE
feat(providers): add Microsandbox local and cloud

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -29,6 +29,15 @@ BL_WORKSPACE=
 # --- Novita (https://novita.ai) — E2B-protocol-compatible control plane ---
 NOVITA_API_KEY=
 
+# --- Microsandbox (https://microsandbox.dev) ---
+# Explicit opt-in for host-local libkrun runs. The host needs KVM on Linux or
+# Hypervisor.framework on macOS; keep unset on ordinary CI runners.
+MICROSANDBOX_LOCAL_BENCH=
+# Cloud runs require only MSB_API_KEY, which stays in the control-plane client and never enters the
+# benchmark guest. Set MSB_API_URL only to override the SDK default for staging or private deployments.
+MSB_API_KEY=
+MSB_API_URL=
+
 # --- Optional overrides (leave unset for the pinned public toolchain) ---
 # Point the adapters at a specific toolchain image / template instead of the canonical published one.
 # Useful only when iterating on the toolchain locally; see packages/providers/src/lib/config.ts.

--- a/.github/workflows/bench-smoke.yml
+++ b/.github/workflows/bench-smoke.yml
@@ -11,7 +11,19 @@ on:
         description: Provider to benchmark
         type: choice
         default: daytona-vm
-        options: [daytona-vm, daytona-container, e2b, modal-gvisor, modal-vm, blaxel, novita, namespace]
+        options:
+          [
+            daytona-vm,
+            daytona-container,
+            e2b,
+            modal-gvisor,
+            modal-vm,
+            blaxel,
+            novita,
+            namespace,
+            microsandbox-local,
+            microsandbox-cloud,
+          ]
       suite:
         # Constrained to the SUITE_NAMES registry (packages/schema/src/suites.ts); the
         # workflow-registry-sync drift gate (tooling/repo-checks) keeps this list in lockstep, so a
@@ -180,6 +192,11 @@ jobs:
           # runs when inputs.provider == 'namespace'), which the harness reads as the standard
           # missing-credentials skip on every other dispatch.
           NSC_TOKEN_FILE: ${{ steps.nsc-token.outcome == 'success' && format('{0}/nsc-token.json', runner.temp) || '' }}
+          # Local is an explicit capability opt-in. Cloud needs only its API key; MSB_API_URL is an
+          # optional override for staging or private deployments. Neither value enters the guest.
+          MICROSANDBOX_LOCAL_BENCH: ${{ inputs.provider == 'microsandbox-local' && '1' || '' }}
+          MSB_API_URL: ${{ inputs.provider == 'microsandbox-cloud' && secrets.MSB_API_URL || '' }}
+          MSB_API_KEY: ${{ inputs.provider == 'microsandbox-cloud' && secrets.MSB_API_KEY || '' }}
         run: bun apps/cli/src/bin/bench-suite.ts "$BENCH_PROVIDER" "$BENCH_SUITE" "$GITHUB_RUN_ID"
 
       - name: Upload Run + raw results

--- a/.github/workflows/bench-suite.yml
+++ b/.github/workflows/bench-suite.yml
@@ -186,6 +186,11 @@ jobs:
           # (steps.nsc-token only runs when matrix.provider == 'namespace'), which the harness reads
           # as the standard missing-credentials skip on every other cell.
           NSC_TOKEN_FILE: ${{ steps.nsc-token.outcome == 'success' && format('{0}/nsc-token.json', runner.temp) || '' }}
+          # Local is an explicit capability opt-in. Cloud needs only its API key; MSB_API_URL is an
+          # optional override for staging or private deployments. Neither value enters the guest.
+          MICROSANDBOX_LOCAL_BENCH: ${{ matrix.provider == 'microsandbox-local' && '1' || '' }}
+          MSB_API_URL: ${{ matrix.provider == 'microsandbox-cloud' && secrets.MSB_API_URL || '' }}
+          MSB_API_KEY: ${{ matrix.provider == 'microsandbox-cloud' && secrets.MSB_API_KEY || '' }}
         run: bun apps/cli/src/bin/bench-suite.ts "$BENCH_PROVIDER" "$BENCH_SUITE" "$GITHUB_RUN_ID" --replicate "$BENCH_REPLICATE"
 
       - name: Upload Run + raw results

--- a/.github/workflows/toolchain-image.yml
+++ b/.github/workflows/toolchain-image.yml
@@ -386,6 +386,11 @@ jobs:
           # the standard missing-credentials skip on every other cell. Best-effort like novita: namespace
           # is not in --require, so a skipped/failed mint skips its validate boot without failing publish.
           NSC_TOKEN_FILE: ${{ steps.nsc-token.outcome == 'success' && format('{0}/nsc-token.json', runner.temp) || '' }}
+          # Microsandbox backends boot the candidate OCI image directly. Local is an explicit runner
+          # capability opt-in. Cloud needs only its key; the URL is an optional deployment override.
+          MICROSANDBOX_LOCAL_BENCH: ${{ matrix.provider == 'microsandbox-local' && '1' || '' }}
+          MSB_API_URL: ${{ matrix.provider == 'microsandbox-cloud' && secrets.MSB_API_URL || '' }}
+          MSB_API_KEY: ${{ matrix.provider == 'microsandbox-cloud' && secrets.MSB_API_KEY || '' }}
         run: |
           set -euo pipefail
           args=(--provider "${PROVIDER}")
@@ -520,6 +525,11 @@ jobs:
           # steps above). Not a stored secret: empty when the exchange/mint was skipped/failed, which
           # skips namespace's re-validation without failing the promote (namespace is not in --require).
           NSC_TOKEN_FILE: ${{ steps.nsc-token.outcome == 'success' && format('{0}/nsc-token.json', runner.temp) || '' }}
+          # The promote transaction re-validates every provider. Microsandbox local uses the hosted
+          # runner's virtualization support; cloud uses its key and an optional endpoint override.
+          MICROSANDBOX_LOCAL_BENCH: "1"
+          MSB_API_URL: ${{ secrets.MSB_API_URL }}
+          MSB_API_KEY: ${{ secrets.MSB_API_KEY }}
         run: |
           set -euo pipefail
           args=(--promote --require "${REQUIRED}")

--- a/apps/cli/src/bin/bake.ts
+++ b/apps/cli/src/bin/bake.ts
@@ -35,6 +35,14 @@ const bakers: Record<ProviderId, (image: string, log: Log) => Promise<void>> = {
 	// Both Modal variants boot the same pushed image via Image.fromRegistry — no per-variant artifact.
 	"modal-gvisor": bakeModalImage,
 	"modal-vm": bakeModalImage,
+	// Both Microsandbox variants boot the candidate OCI image directly. Local and cloud remain separate
+	// validation cells because they exercise different control planes and virtualization hosts.
+	"microsandbox-local": async (_image, log) => {
+		log("microsandbox-local boots the candidate image directly — no candidate artifact to bake");
+	},
+	"microsandbox-cloud": async (_image, log) => {
+		log("microsandbox-cloud boots the candidate image directly — no candidate artifact to bake");
+	},
 	blaxel: async (_image, log) => {
 		log("blaxel boots the stock base image — no candidate artifact to bake");
 	},

--- a/apps/cli/src/bin/release-plan.test.ts
+++ b/apps/cli/src/bin/release-plan.test.ts
@@ -32,6 +32,8 @@ describe("buildReleasePlan matrix", () => {
 			"daytona-vm",
 			"daytona-container",
 			"blaxel",
+			"microsandbox-local",
+			"microsandbox-cloud",
 			"modal-gvisor",
 			"modal-vm",
 			"novita",
@@ -57,7 +59,7 @@ describe("planOutputs", () => {
 		expect(matrixLine).toBeDefined();
 		// The matrix value must be valid, single-line JSON (the fromJSON contract).
 		const parsed = JSON.parse((matrixLine as string).slice("matrix=".length));
-		expect(parsed.include).toHaveLength(8);
+		expect(parsed.include).toHaveLength(10);
 		expect((matrixLine as string).includes("\n")).toBe(false);
 	});
 });

--- a/apps/cli/src/bin/release-plan.ts
+++ b/apps/cli/src/bin/release-plan.ts
@@ -56,6 +56,8 @@ function providerArtifact(id: ProviderId): string {
 			return config.novitaTemplateCandidate;
 		case "modal-gvisor":
 		case "modal-vm":
+		case "microsandbox-local":
+		case "microsandbox-cloud":
 			return "boots the candidate image directly (no baked artifact)";
 		case "blaxel":
 			return "boots the stock base image (no baked artifact)";

--- a/apps/cli/src/lib/bake/promote.ts
+++ b/apps/cli/src/lib/bake/promote.ts
@@ -145,6 +145,10 @@ export async function promoteAll(log: Log, force = false): Promise<BakeReport[]>
 				case "modal-vm":
 					log(`    ${provider.name} boots the published version image — nothing to build`);
 					break;
+				case "microsandbox-local":
+				case "microsandbox-cloud":
+					log(`    ${provider.name} boots the published version image — nothing to build`);
+					break;
 				case "blaxel":
 					log("    blaxel boots the stock base image — nothing to promote");
 					break;

--- a/apps/cli/src/lib/bake/validate.test.ts
+++ b/apps/cli/src/lib/bake/validate.test.ts
@@ -64,4 +64,13 @@ describe("candidateCreateOptions", () => {
 			image: "ghcr.io/o/tc:v1-candidate",
 		});
 	});
+
+	it("points both Microsandbox backends at the same candidate OCI image", () => {
+		expect(candidateCreateOptions("microsandbox-local", refs)).toEqual({
+			templateId: "ghcr.io/o/tc:v1-candidate",
+		});
+		expect(candidateCreateOptions("microsandbox-cloud", refs)).toEqual({
+			templateId: "ghcr.io/o/tc:v1-candidate",
+		});
+	});
 });

--- a/apps/cli/src/lib/bake/validate.ts
+++ b/apps/cli/src/lib/bake/validate.ts
@@ -44,6 +44,10 @@ export function candidateCreateOptions(
 			// createOptions (experimentalOptions:{vm_runtime:true}), which validate-run.ts preserves
 			// through the spread — so this candidate override, like modal-gvisor's, is only the templateId.
 			return { templateId: refs.toolchainImageCandidate };
+		case "microsandbox-local":
+		case "microsandbox-cloud":
+			// Both backends consume the same OCI image reference; only their SDK backend differs.
+			return { templateId: refs.toolchainImageCandidate };
 		case "blaxel":
 			// Stock base image — no candidate artifact to point at.
 			return {};

--- a/apps/cli/src/lib/providers-run.test.ts
+++ b/apps/cli/src/lib/providers-run.test.ts
@@ -36,6 +36,8 @@ describe("forEachProviderWithCreds `only`", () => {
 			"daytona-vm",
 			"daytona-container",
 			"blaxel",
+			"microsandbox-local",
+			"microsandbox-cloud",
 			"modal-gvisor",
 			"modal-vm",
 			"novita",

--- a/bun.lock
+++ b/bun.lock
@@ -74,6 +74,7 @@
         "@sandbox-benchmarks/schema": "workspace:*",
         "arktype": "catalog:",
         "computesdk": "catalog:computesdk",
+        "microsandbox": "catalog:computesdk",
         "novita-sandbox": "catalog:computesdk",
       },
       "devDependencies": {
@@ -177,6 +178,7 @@
       "@daytona/api-client": "0.192.0",
       "@daytona/sdk": "0.192.0",
       "computesdk": "4.1.3",
+      "microsandbox": "0.6.8",
       "novita-sandbox": "2.0.6",
     },
     "xml": {
@@ -504,6 +506,16 @@
     "@smithy/util-buffer-from": ["@smithy/util-buffer-from@2.2.0", "", { "dependencies": { "@smithy/is-array-buffer": "^2.2.0", "tslib": "^2.6.2" } }, "sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA=="],
 
     "@smithy/util-utf8": ["@smithy/util-utf8@2.3.0", "", { "dependencies": { "@smithy/util-buffer-from": "^2.2.0", "tslib": "^2.6.2" } }, "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A=="],
+
+    "@superradcompany/microsandbox-darwin-arm64": ["@superradcompany/microsandbox-darwin-arm64@0.6.8", "", { "os": "darwin", "cpu": "arm64" }, "sha512-SbPo2mb5sEWY7Sry9lxlh762oX5G4RI4Xq2i6U9covTe+4MIFznNSCPIntoCcpzVwt4VNIukvEdyTsI9kITJLw=="],
+
+    "@superradcompany/microsandbox-linux-arm64-gnu": ["@superradcompany/microsandbox-linux-arm64-gnu@0.6.8", "", { "os": "linux", "cpu": "arm64" }, "sha512-cMgS/pE6N2LTbdGYMNiSzfxlsD0F1fhVuCFuIULxGfGyK+zmrYHgTgV0K6n9UQY+PjseOvNn//T7FJQ7SwyJ3g=="],
+
+    "@superradcompany/microsandbox-linux-x64-gnu": ["@superradcompany/microsandbox-linux-x64-gnu@0.6.8", "", { "os": "linux", "cpu": "x64" }, "sha512-JCYgBsCf00bX2RA7YhdFdNOQHsWJFXYM3WJi1ONx3jLdUpiMKAVRZxCSPJe/UrFoRiqfj49AmgIBNtvs+2Ns9g=="],
+
+    "@superradcompany/microsandbox-win32-arm64-msvc": ["@superradcompany/microsandbox-win32-arm64-msvc@0.6.8", "", { "os": "win32", "cpu": "arm64" }, "sha512-cWXaHBleVZbTddVYiUSuChNbHWhzTnNkgBqhisSDcFa1FBa0g5sBzTBlcC0RAseMzs4F+6YqLbD040QOe/6deQ=="],
+
+    "@superradcompany/microsandbox-win32-x64-msvc": ["@superradcompany/microsandbox-win32-x64-msvc@0.6.8", "", { "os": "win32", "cpu": "x64" }, "sha512-Asfn+8+CplKh05MyJIoRJzLCl1Z05B/n6Lc6+tpfFKmHjMkQw976L67AqqBQq4AxfkakBcpZYVHZQqUDxl5Fow=="],
 
     "@types/bun": ["@types/bun@1.3.14", "", { "dependencies": { "bun-types": "1.3.14" } }, "sha512-h1hFqFVcvAvD9j9K7ZW7vd82aSA+rTdznZa+5bwvCwqSB1jmmfLcbIWhOLx1/+boy/xmjgCs/OMUL8hRJSmnPw=="],
 
@@ -872,6 +884,8 @@
     "merge2": ["merge2@1.4.1", "", {}, "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg=="],
 
     "micromatch": ["micromatch@4.0.8", "", { "dependencies": { "braces": "^3.0.3", "picomatch": "^2.3.1" } }, "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA=="],
+
+    "microsandbox": ["microsandbox@0.6.8", "", { "optionalDependencies": { "@superradcompany/microsandbox-darwin-arm64": "0.6.8", "@superradcompany/microsandbox-linux-arm64-gnu": "0.6.8", "@superradcompany/microsandbox-linux-x64-gnu": "0.6.8", "@superradcompany/microsandbox-win32-arm64-msvc": "0.6.8", "@superradcompany/microsandbox-win32-x64-msvc": "0.6.8" }, "bin": { "microsandbox": "bin/microsandbox.cjs", "msb": "bin/microsandbox.cjs" } }, "sha512-N9sqwUFjeRisBJPyu3uV0f+BFsWQmrxogGoZw0jXuLY9+ey0cgPTzQBLhjKyCbe6rq8joGtefvyS3J4vEW7DBQ=="],
 
     "mime-db": ["mime-db@1.52.0", "", {}, "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg=="],
 

--- a/docs/ci-secrets.md
+++ b/docs/ci-secrets.md
@@ -146,6 +146,9 @@ Do this in the GitHub UI (Settings → Environments / Rules / Actions), then del
    | `NOVITA_API_KEY` | optional for toolchain; bench matrix/smoke |
    | `BL_API_KEY` | bench matrix/smoke only |
    | `BL_WORKSPACE` | bench matrix/smoke only |
+   | `MSB_API_KEY` | Microsandbox Cloud toolchain validation and bench matrix/smoke |
+
+   `MSB_API_URL` is an optional Microsandbox Cloud endpoint override for staging or private deployments. Leave it unset to use the SDK's `https://api.microsandbox.dev` default.
 
 ### Main ruleset (public-safe bot merges)
 
@@ -196,6 +199,8 @@ Optional bootstrap (creates the empty environment; reviewers/secrets still need 
 Copy [`.env.example`](../.env.example) to a gitignored `.env` and fill in the providers you have
 (Bun auto-loads `.env` when you run a bin). A missing credential is a skip, not a failure. Never
 commit them; never paste them into issues or pull requests. See [SECURITY.md](../SECURITY.md).
+
+`microsandbox-local` uses `MICROSANDBOX_LOCAL_BENCH=1` as an explicit capability opt-in rather than a credential. The runner must provide KVM on Linux or Hypervisor.framework on macOS. `microsandbox-cloud` needs `MSB_API_KEY`; `MSB_API_URL` is an optional endpoint override. The cloud adapter keeps the key in the SDK control-plane backend and never adds it to sandbox metadata, create-time environment variables, or guest commands.
 
 The `tooling/repo-checks` secret-hygiene gate enforces this: it fails CI if any tracked file is a
 credential file (`.env`, `*.pem`, `id_rsa`, …) or contains a high-signal secret token.

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
         "@daytona/api-client": "0.192.0",
         "@daytona/sdk": "0.192.0",
         "computesdk": "4.1.3",
+        "microsandbox": "0.6.8",
         "novita-sandbox": "2.0.6"
       },
       "xml": {

--- a/packages/providers/package.json
+++ b/packages/providers/package.json
@@ -21,6 +21,7 @@
     "@sandbox-benchmarks/schema": "workspace:*",
     "arktype": "catalog:",
     "computesdk": "catalog:computesdk",
+    "microsandbox": "catalog:computesdk",
     "novita-sandbox": "catalog:computesdk"
   },
   "devDependencies": {

--- a/packages/providers/src/index.test.ts
+++ b/packages/providers/src/index.test.ts
@@ -3,7 +3,15 @@ import { describe, expect, it } from "bun:test";
 // actually REPLACED (identity inequality against an unpatched instance's methods table).
 import { e2b } from "@computesdk/e2b";
 import { PROVIDERS, TARGET_SPEC } from "@sandbox-benchmarks/schema";
-import { config, NOVITA_E2B_DOMAIN, novitaCompute, novitaConnection, providers } from "./index.ts";
+import {
+	config,
+	microsandboxCloudCompute,
+	microsandboxLocalCompute,
+	NOVITA_E2B_DOMAIN,
+	novitaCompute,
+	novitaConnection,
+	providers,
+} from "./index.ts";
 import { runE2bCommandAsRoot } from "./lib/e2b-root.ts";
 import { assertProviderJoin } from "./lib/join.ts";
 
@@ -149,6 +157,53 @@ describe("@sandbox-benchmarks/providers", () => {
 		const daytonaMeta = PROVIDERS.find((m) => m.id === "daytona-vm");
 		expect(daytonaMeta?.requiredEnvVars).toEqual(["DAYTONA_API_KEY"]);
 		expect(daytona?.requiredEnvVars).toEqual(daytonaMeta?.requiredEnvVars);
+	});
+
+	it("keeps Microsandbox local and cloud as separate, capability-accurate providers", () => {
+		const base = {
+			image: config.toolchainImage,
+			cpus: TARGET_SPEC.vcpus,
+			memoryMib: TARGET_SPEC.memoryGb * 1024,
+			rootDiskMib: TARGET_SPEC.diskGb * 1024,
+			maxDurationSecs: 10_800,
+			namePrefix: "test-msb-",
+			timeoutMs: 10_800_000,
+		} as const;
+		const local = microsandboxLocalCompute({
+			...base,
+			variant: "microsandbox-local",
+			backend: "local",
+		});
+		const cloud = microsandboxCloudCompute({
+			...base,
+			variant: "microsandbox-cloud",
+			backend: { kind: "cloud", url: "https://msb.invalid", apiKey: "unit-test-key" },
+		});
+
+		expect(local.name).toBe("microsandbox-local");
+		expect(local.snapshot).toBeDefined();
+		expect(cloud.name).toBe("microsandbox-cloud");
+		// Cloud snapshots are not implemented by msb-cloud yet. Omitting the manager makes the lifecycle
+		// harness record an explicit skipped capability instead of attempting a knowingly invalid call.
+		expect(cloud.snapshot).toBeUndefined();
+
+		const localAdapter = providers.find((provider) => provider.name === "microsandbox-local");
+		const cloudAdapter = providers.find((provider) => provider.name === "microsandbox-cloud");
+		expect(localAdapter?.requiredEnvVars).toEqual(["MICROSANDBOX_LOCAL_BENCH"]);
+		expect(cloudAdapter?.requiredEnvVars).toEqual(["MSB_API_KEY"]);
+		expect(localAdapter?.createOptions).toEqual({ templateId: config.toolchainImage });
+		expect(cloudAdapter?.createOptions).toEqual({ templateId: config.toolchainImage });
+		// The control-plane credential belongs only to the SDK backend config; it must never enter the
+		// universal create options because those can be translated into guest-visible provider fields.
+		expect(JSON.stringify(cloudAdapter?.createOptions)).not.toContain("unit-test-key");
+	});
+
+	it("defers missing Microsandbox Cloud credentials until that provider is selected", () => {
+		const cloud = providers.find((provider) => provider.name === "microsandbox-cloud");
+		expect(cloud).toBeDefined();
+		if (!process.env.MSB_API_KEY) {
+			expect(() => cloud?.createCompute()).toThrow(/MSB_API_KEY/);
+		}
 	});
 
 	it("passes E2B-compatible cwd and env options through envd's structured root channel", async () => {

--- a/packages/providers/src/index.ts
+++ b/packages/providers/src/index.ts
@@ -9,6 +9,14 @@ import type { ProviderConfig } from "./lib/types.ts";
 
 // The runtime configuration gatekeeper — the single validated config object consumers import.
 export { config } from "./lib/config.ts";
+export type {
+	MicrosandboxCloudConfig,
+	MicrosandboxConfig,
+	MicrosandboxHandle,
+	MicrosandboxLocalConfig,
+	MicrosandboxVariant,
+} from "./lib/microsandbox.ts";
+export { microsandboxCloudCompute, microsandboxLocalCompute } from "./lib/microsandbox.ts";
 // Novita's E2B-compat surface: the pinned regional domain + connection the bake pipeline reuses,
 // and the compat factory (exported for tests and for anyone driving Novita outside the harness join).
 export { NOVITA_E2B_DOMAIN, novitaCompute, novitaConnection } from "./lib/novita.ts";

--- a/packages/providers/src/lib/adapters.ts
+++ b/packages/providers/src/lib/adapters.ts
@@ -16,6 +16,7 @@ import type { DaytonaConfig } from "./config.ts";
 import { config } from "./config.ts";
 import { daytonaClientTarget } from "./daytona-target.ts";
 import { e2bCommandsAsRoot } from "./e2b-root.ts";
+import { microsandboxCloudCompute, microsandboxLocalCompute } from "./microsandbox.ts";
 import { novitaCompute } from "./novita.ts";
 import type { ProviderAdapter } from "./types.ts";
 
@@ -80,6 +81,20 @@ function modalCreateOptions(experimentalOptions?: Record<string, unknown>): Crea
 const modalGvisorCompute = () => modal({ scalableSandboxes: true, appName: MODAL_APP_NAME });
 const modalVmCompute = () => modal({ appName: MODAL_APP_NAME });
 
+/** The longest suite has a 155-minute budget. Give Microsandbox enough lifetime for setup and
+ * teardown as well, while keeping leaked benchmark sandboxes self-expiring. */
+const MICROSANDBOX_MAX_DURATION_SECS = 3 * 60 * 60;
+
+function microsandboxCloudCredentials(): { kind: "cloud"; url?: string; apiKey: string } {
+	const { apiUrl, apiKey } = config.microsandboxCloud;
+	if (!apiKey) {
+		throw new Error("microsandbox-cloud requires MSB_API_KEY");
+	}
+	// Omitting the URL intentionally delegates to the SDK's api.microsandbox.dev default. Keeping the
+	// property absent, instead of passing undefined, also makes the backend selection shape explicit.
+	return apiUrl ? { kind: "cloud", url: apiUrl, apiKey } : { kind: "cloud", apiKey };
+}
+
 /**
  * Harness adapters, keyed by the schema {@link ProviderId}. The `Record<ProviderId, …>` type is what
  * keeps the two registries honest: it forces exactly one adapter per schema provider, so a provider
@@ -115,6 +130,40 @@ export const adapters: Record<ProviderId, ProviderAdapter> = {
 				blaxel({ image: "blaxel/ts-app:latest", memory: 8192, region: "us-was-1" }),
 			),
 		createOptions: {},
+	},
+	"microsandbox-local": {
+		// Explicit local selection is important: a developer can have MSB_API_* configured globally and
+		// still request a true host-local benchmark without the SDK auto-selecting cloud.
+		createCompute: () =>
+			microsandboxLocalCompute({
+				variant: "microsandbox-local",
+				backend: "local",
+				image: config.toolchainImage,
+				cpus: TARGET_SPEC.vcpus,
+				memoryMib: TARGET_SPEC.memoryGb * 1024,
+				rootDiskMib: TARGET_SPEC.diskGb * 1024,
+				maxDurationSecs: MICROSANDBOX_MAX_DURATION_SECS,
+				namePrefix: "bench-local-",
+				timeoutMs: MICROSANDBOX_MAX_DURATION_SECS * 1000,
+			}),
+		createOptions: { templateId: config.toolchainImage },
+	},
+	"microsandbox-cloud": {
+		// The API key remains in the CloudBackend HTTP/WebSocket client. It is never forwarded through
+		// createOptions, metadata, or the benchmark's in-guest environment.
+		createCompute: () =>
+			microsandboxCloudCompute({
+				variant: "microsandbox-cloud",
+				backend: microsandboxCloudCredentials(),
+				image: config.toolchainImage,
+				cpus: TARGET_SPEC.vcpus,
+				memoryMib: TARGET_SPEC.memoryGb * 1024,
+				rootDiskMib: TARGET_SPEC.diskGb * 1024,
+				maxDurationSecs: MICROSANDBOX_MAX_DURATION_SECS,
+				namePrefix: "bench-cloud-",
+				timeoutMs: MICROSANDBOX_MAX_DURATION_SECS * 1000,
+			}),
+		createOptions: { templateId: config.toolchainImage },
 	},
 	// Modal's default runtime = gVisor. Both variants boot the same pushed image; modal-vm adds the
 	// vm_runtime experimental flag to select Modal's gVisor-free VM runtime and drops scalableSandboxes

--- a/packages/providers/src/lib/config.ts
+++ b/packages/providers/src/lib/config.ts
@@ -21,6 +21,8 @@ const envSchema = type({
 	"DAYTONA_CONTAINER_SNAPSHOT?": "string >= 1",
 	"NOVITA_API_KEY?": "string >= 1",
 	"NOVITA_TEMPLATE?": "string >= 1",
+	"MSB_API_URL?": "string >= 1",
+	"MSB_API_KEY?": "string >= 1",
 });
 
 const ENV_KEYS = [
@@ -33,6 +35,8 @@ const ENV_KEYS = [
 	"DAYTONA_CONTAINER_SNAPSHOT",
 	"NOVITA_API_KEY",
 	"NOVITA_TEMPLATE",
+	"MSB_API_URL",
+	"MSB_API_KEY",
 ] as const;
 
 // 2. Startup gatekeeper — validate the environment once, fail fast with a clear message. Only the
@@ -71,6 +75,13 @@ export interface DaytonaConfig {
 	target?: string;
 	/** Snapshot to boot from (the pre-baked toolchain snapshot for this variant). */
 	snapshot: string;
+}
+
+/** Connection settings for the remote Microsandbox backend. The API URL is an optional override;
+ * the SDK uses its production endpoint when it is absent. */
+export interface MicrosandboxCloudConfig {
+	apiUrl?: string;
+	apiKey?: string;
 }
 
 // Candidate↔version naming. The public version (`:v1`, `…-v1`) is immutable and written only by
@@ -155,4 +166,10 @@ export const config = {
 	novita: {
 		apiKey: env.NOVITA_API_KEY,
 	} satisfies NovitaConfig,
+	/** Microsandbox Cloud connection. The provider gate requires the key before construction, while
+	 * the URL stays optional so the SDK can use its production default. */
+	microsandboxCloud: {
+		apiUrl: env.MSB_API_URL,
+		apiKey: env.MSB_API_KEY,
+	} satisfies MicrosandboxCloudConfig,
 } as const;

--- a/packages/providers/src/lib/microsandbox.ts
+++ b/packages/providers/src/lib/microsandbox.ts
@@ -1,0 +1,490 @@
+// ComputeSDK adapters for Microsandbox's two execution backends. Both variants use the same
+// public SDK surface; the backend selection is explicit so a process with cloud credentials can
+// still benchmark the local runtime without accidentally routing that run to the control plane.
+// Requires microsandbox >=0.6.8: that is the first release carrying the unified cloud backend,
+// paginated list API, cloud agent tunnel, and create-until-running contract used below.
+import { randomUUID } from "node:crypto";
+import { posix as posixPath } from "node:path";
+import type {
+	CommandResult,
+	CreateSandboxOptions,
+	FileEntry,
+	RunCommandOptions,
+	SandboxInfo,
+	SandboxMethods,
+	SnapshotMethods,
+} from "@computesdk/provider";
+import { defineProvider } from "@computesdk/provider";
+import type { DefaultBackend, SandboxHandle as MsbSandboxHandle } from "microsandbox";
+import {
+	Sandbox as MsbSandbox,
+	Snapshot as MsbSnapshot,
+	SandboxNotFoundError,
+	withDefaultBackend,
+} from "microsandbox";
+
+type MsbSandboxBuilder = ReturnType<typeof MsbSandbox.builder>;
+
+/** Marker shared by both variants; the value distinguishes local and cloud benchmark sandboxes. */
+const LABEL_MARKER = "sandbox-benchmarks.provider";
+/** Label prefix under which ComputeSDK metadata is persisted. */
+const LABEL_META_PREFIX = "sandbox-benchmarks.meta.";
+
+export type MicrosandboxVariant = "microsandbox-local" | "microsandbox-cloud";
+
+interface MicrosandboxBaseConfig {
+	variant: MicrosandboxVariant;
+	backend: DefaultBackend;
+	/** OCI image to boot when create() receives no templateId. */
+	image: string;
+	/** Guest vCPUs. */
+	cpus: number;
+	/** Guest memory in MiB. */
+	memoryMib: number;
+	/** Writable managed root disk in MiB. */
+	rootDiskMib: number;
+	/** Maximum sandbox lifetime in seconds. */
+	maxDurationSecs: number;
+	/** Working directory inside the guest. */
+	workdir?: string;
+	/** Prefix for generated sandbox names. */
+	namePrefix: string;
+	/** Informational timeout surfaced through ComputeSDK getInfo(). */
+	timeoutMs: number;
+	/** Optional image pull policy forwarded to Microsandbox. */
+	pullPolicy?: string;
+}
+
+export interface MicrosandboxLocalConfig extends MicrosandboxBaseConfig {
+	variant: "microsandbox-local";
+	backend: "local";
+	/** TCP port maps declared at boot; only the local backend supports published ports. */
+	ports?: Array<{ host: number; guest: number }>;
+}
+
+export interface MicrosandboxCloudConfig extends MicrosandboxBaseConfig {
+	variant: "microsandbox-cloud";
+	backend: Extract<DefaultBackend, { kind: "cloud" }>;
+}
+
+export type MicrosandboxConfig = MicrosandboxLocalConfig | MicrosandboxCloudConfig;
+
+/** The native sandbox plus enough immutable context to reconnect it safely. */
+export interface MicrosandboxHandle {
+	name: string;
+	sandbox: InstanceType<typeof MsbSandbox> | null;
+	backend: DefaultBackend;
+	variant: MicrosandboxVariant;
+	createdAt: Date;
+	timeoutMs: number;
+	metadata: Record<string, unknown>;
+	/** guestPort -> hostPort, local only. */
+	ports: Map<number, number>;
+}
+
+/** POSIX single-quote shell escaping for commands sent to the guest shell. */
+function shellQuote(value: string): string {
+	return `'${value.replace(/'/g, `'\\''`)}'`;
+}
+
+function errorMessage(error: unknown): string {
+	return error instanceof Error ? error.message : String(error);
+}
+
+function isNotFound(error: unknown): boolean {
+	return error instanceof SandboxNotFoundError;
+}
+
+function mapStatus(status: string): SandboxInfo["status"] {
+	switch (status) {
+		case "running":
+		case "draining":
+			return "running";
+		case "stopped":
+			return "stopped";
+		default:
+			return "error";
+	}
+}
+
+function recoverFromConfig(configJson: string): {
+	labels: Record<string, string>;
+	metadata: Record<string, unknown>;
+	ports: Map<number, number>;
+} {
+	const labels: Record<string, string> = {};
+	const metadata: Record<string, unknown> = {};
+	const ports = new Map<number, number>();
+	try {
+		const config = JSON.parse(configJson) as Record<string, unknown>;
+		const rawLabels = config.labels;
+		if (rawLabels && typeof rawLabels === "object") {
+			for (const [key, value] of Object.entries(rawLabels as Record<string, unknown>)) {
+				labels[key] = String(value);
+				if (key.startsWith(LABEL_META_PREFIX)) {
+					metadata[key.slice(LABEL_META_PREFIX.length)] = String(value);
+				}
+			}
+		}
+
+		// `configJson` is the raw Rust serde form (host_port/guest_port), while older JS-facing
+		// projections used host/guest or hostPort/guestPort. Accept every emitted spelling so a handle
+		// recovered by get/list keeps local getUrl() functional across SDK upgrades.
+		const network = config.network as { ports?: unknown } | undefined;
+		if (Array.isArray(network?.ports)) {
+			for (const entry of network.ports as Array<Record<string, unknown>>) {
+				const host = Number(entry.host_port ?? entry.host ?? entry.hostPort);
+				const guest = Number(entry.guest_port ?? entry.guest ?? entry.guestPort);
+				if (Number.isFinite(host) && Number.isFinite(guest)) ports.set(guest, host);
+			}
+		}
+	} catch {
+		// A malformed legacy config must not make list/get unusable; the name prefix remains a fallback.
+	}
+	return { labels, metadata, ports };
+}
+
+function handleFromMsb(
+	config: MicrosandboxConfig,
+	msbHandle: MsbSandboxHandle,
+): MicrosandboxHandle {
+	const { metadata, ports } = recoverFromConfig(msbHandle.configJson);
+	return {
+		name: msbHandle.name,
+		sandbox: null,
+		backend: config.backend,
+		variant: config.variant,
+		createdAt: msbHandle.createdAt ?? new Date(),
+		timeoutMs: config.timeoutMs,
+		metadata,
+		ports,
+	};
+}
+
+function isOurs(config: MicrosandboxConfig, handle: MsbSandboxHandle): boolean {
+	const { labels } = recoverFromConfig(handle.configJson);
+	if (labels[LABEL_MARKER] === config.variant) return true;
+	return handle.name.startsWith(config.namePrefix);
+}
+
+async function withBackend<T>(config: MicrosandboxConfig, operation: () => Promise<T>): Promise<T> {
+	return withDefaultBackend(config.backend, operation);
+}
+
+/** Connect lazily; handles created by the SDK already retain their backend after this lookup. */
+async function ensureConnected(
+	handle: MicrosandboxHandle,
+): Promise<InstanceType<typeof MsbSandbox>> {
+	if (handle.sandbox) return handle.sandbox;
+	const sandbox = await withDefaultBackend(handle.backend, async () => {
+		const current = await MsbSandbox.get(handle.name);
+		return current.status === "running" ? current.connect() : current.startDetached();
+	});
+	handle.sandbox = sandbox;
+	return sandbox;
+}
+
+async function execOnce(
+	sandbox: InstanceType<typeof MsbSandbox>,
+	command: string,
+	options?: RunCommandOptions,
+): Promise<{ stdout: string; stderr: string; exitCode: number }> {
+	const script = options?.background
+		? `nohup sh -c ${shellQuote(command)} >/dev/null 2>&1 &`
+		: command;
+	const output = await sandbox.execWith("/bin/sh", (builder) => {
+		let configured = builder.args(["-c", script]);
+		if (options?.cwd) configured = configured.cwd(options.cwd);
+		if (options?.env && Object.keys(options.env).length > 0) {
+			configured = configured.envs(options.env);
+		}
+		if (options?.timeout) configured = configured.timeout(options.timeout);
+		return configured;
+	});
+	return { stdout: output.stdout(), stderr: output.stderr(), exitCode: output.code };
+}
+
+async function runShell(
+	handle: MicrosandboxHandle,
+	command: string,
+	options?: RunCommandOptions,
+): Promise<CommandResult> {
+	const started = Date.now();
+	const hadCachedConnection = handle.sandbox !== null;
+	try {
+		const sandbox = await ensureConnected(handle);
+		try {
+			return { ...(await execOnce(sandbox, command, options)), durationMs: Date.now() - started };
+		} catch (error) {
+			// A stop/start cycle invalidates an old agent connection. Reconnect once before surfacing it.
+			if (!hadCachedConnection) throw error;
+			handle.sandbox = null;
+			return {
+				...(await execOnce(await ensureConnected(handle), command, options)),
+				durationMs: Date.now() - started,
+			};
+		}
+	} catch (error) {
+		return {
+			stdout: "",
+			stderr: errorMessage(error),
+			exitCode: 127,
+			durationMs: Date.now() - started,
+		};
+	}
+}
+
+/** Drain every page for this provider marker; ComputeSDK's list contract is not paginated. */
+async function listAll(config: MicrosandboxConfig): Promise<MsbSandboxHandle[]> {
+	return withBackend(config, async () => {
+		let page = await MsbSandbox.listWith((list) =>
+			list.limit(100).label(LABEL_MARKER, config.variant),
+		);
+		const all = [...page.sandboxes];
+		while (page.nextCursor) {
+			const cursor = page.nextCursor;
+			page = await MsbSandbox.listWith((list) =>
+				list.limit(100).cursor(cursor).label(LABEL_MARKER, config.variant),
+			);
+			all.push(...page.sandboxes);
+		}
+		return all;
+	});
+}
+
+const sandboxMethods: SandboxMethods<MicrosandboxHandle, MicrosandboxConfig> = {
+	create: async (config, options?: CreateSandboxOptions) => {
+		const name = options?.name ?? `${config.namePrefix}${randomUUID()}`;
+		const timeoutMs = options?.timeout ?? config.timeoutMs;
+		const metadata: Record<string, unknown> = options?.metadata ?? {};
+		const requestedPorts =
+			(options?.ports as Array<{ host: number; guest: number }> | undefined) ?? [];
+		const ports =
+			config.variant === "microsandbox-local" ? [...(config.ports ?? []), ...requestedPorts] : [];
+		if (config.variant === "microsandbox-cloud" && requestedPorts.length > 0) {
+			throw new Error("Microsandbox cloud does not support published host ports");
+		}
+
+		try {
+			const sandbox = await withBackend(config, async () => {
+				let builder: MsbSandboxBuilder = MsbSandbox.builder(name);
+				if (options?.snapshotId) {
+					if (config.variant === "microsandbox-cloud") {
+						throw new Error("Microsandbox cloud snapshots are not supported");
+					}
+					builder = builder.fromSnapshot(options.snapshotId);
+				} else {
+					builder = builder.image(options?.templateId ?? config.image).rootDisk(config.rootDiskMib);
+				}
+
+				builder = builder
+					.cpus(config.cpus)
+					.memory(config.memoryMib)
+					.maxDuration(config.maxDurationSecs)
+					.detached(true)
+					.label(LABEL_MARKER, config.variant);
+				for (const [key, value] of Object.entries(metadata)) {
+					builder = builder.label(`${LABEL_META_PREFIX}${key}`, String(value));
+				}
+				if (options?.envs && Object.keys(options.envs).length > 0)
+					builder = builder.envs(options.envs);
+				if (config.workdir) builder = builder.workdir(config.workdir);
+				if (config.pullPolicy) builder = builder.pullPolicy(config.pullPolicy);
+				for (const { host, guest } of ports) builder = builder.port(host, guest);
+				return builder.create();
+			});
+
+			return {
+				sandbox: {
+					name,
+					sandbox,
+					backend: config.backend,
+					variant: config.variant,
+					createdAt: new Date(),
+					timeoutMs,
+					metadata,
+					ports: new Map(ports.map(({ host, guest }) => [guest, host])),
+				},
+				sandboxId: name,
+			};
+		} catch (error) {
+			const location =
+				config.variant === "microsandbox-local" ? "local libkrun runtime" : "cloud control plane";
+			throw new Error(
+				`Failed to create ${config.variant} sandbox "${name}" through the ${location}: ${errorMessage(error)}`,
+			);
+		}
+	},
+
+	getById: async (config, sandboxId) => {
+		try {
+			const handle = await withBackend(config, () => MsbSandbox.get(sandboxId));
+			return { sandbox: handleFromMsb(config, handle), sandboxId };
+		} catch (error) {
+			if (isNotFound(error)) return null;
+			throw error;
+		}
+	},
+
+	list: async (config) =>
+		(await listAll(config))
+			.filter((handle) => isOurs(config, handle))
+			.map((handle) => ({ sandbox: handleFromMsb(config, handle), sandboxId: handle.name })),
+
+	destroy: async (config, sandboxId) => {
+		await withBackend(config, async () => {
+			try {
+				const handle = await MsbSandbox.get(sandboxId);
+				if (handle.status === "running" || handle.status === "draining") await handle.stop();
+			} catch (error) {
+				if (isNotFound(error)) return;
+				throw error;
+			}
+			await MsbSandbox.remove(sandboxId);
+		});
+	},
+
+	runCommand: runShell,
+
+	getInfo: async (handle): Promise<SandboxInfo> => {
+		let status: SandboxInfo["status"] = "running";
+		let createdAt = handle.createdAt;
+		try {
+			const current = await withDefaultBackend(handle.backend, () => MsbSandbox.get(handle.name));
+			status = mapStatus(current.status);
+			createdAt = current.createdAt ?? createdAt;
+		} catch (error) {
+			if (!isNotFound(error)) throw error;
+			status = "stopped";
+		}
+		return {
+			id: handle.name,
+			provider: handle.variant,
+			status,
+			createdAt,
+			timeout: handle.timeoutMs,
+			metadata: {
+				...handle.metadata,
+				isolation: "microVM (libkrun)",
+				backend: handle.variant === "microsandbox-local" ? "local" : "cloud",
+			},
+		};
+	},
+
+	getUrl: async (handle, options): Promise<string> => {
+		if (handle.variant === "microsandbox-cloud") {
+			throw new Error("Microsandbox cloud does not expose published sandbox ports");
+		}
+		const hostPort = handle.ports.get(options.port);
+		if (!hostPort) {
+			throw new Error(`No local host port is mapped to guest port ${options.port}`);
+		}
+		return `${options.protocol ?? "http"}://127.0.0.1:${hostPort}`;
+	},
+
+	filesystem: {
+		readFile: async (handle, path): Promise<string> =>
+			(await ensureConnected(handle)).fs().readToString(path),
+		writeFile: async (handle, path, content, runCommand): Promise<void> => {
+			const parent = posixPath.dirname(path);
+			if (parent && parent !== "/" && parent !== ".")
+				await runCommand(handle, `mkdir -p ${shellQuote(parent)}`);
+			await (await ensureConnected(handle)).fs().write(path, content);
+		},
+		mkdir: async (handle, path, runCommand): Promise<void> => {
+			const result = await runCommand(handle, `mkdir -p ${shellQuote(path)}`);
+			if (result.exitCode !== 0) throw new Error(`mkdir failed for ${path}: ${result.stderr}`);
+		},
+		readdir: async (handle, path, runCommand): Promise<FileEntry[]> => {
+			const result = await runCommand(handle, `ls -1Ap ${shellQuote(path)}`);
+			if (result.exitCode !== 0) throw new Error(`readdir failed for ${path}: ${result.stderr}`);
+			return result.stdout
+				.split("\n")
+				.map((line) => line.trim())
+				.filter(Boolean)
+				.map((line) => ({
+					name: line.endsWith("/") ? line.slice(0, -1) : line,
+					type: line.endsWith("/") ? ("directory" as const) : ("file" as const),
+				}));
+		},
+		exists: async (handle, path): Promise<boolean> =>
+			(await ensureConnected(handle)).fs().exists(path),
+		remove: async (handle, path, runCommand): Promise<void> => {
+			const result = await runCommand(handle, `rm -rf ${shellQuote(path)}`);
+			if (result.exitCode !== 0) throw new Error(`remove failed for ${path}: ${result.stderr}`);
+		},
+	},
+};
+
+const localSnapshotMethods: SnapshotMethods<unknown, MicrosandboxLocalConfig> = {
+	create: async (config, sandboxId, options) =>
+		withBackend(config, async () => {
+			const name = options?.name ?? `${sandboxId}-snap-${Date.now().toString(36)}`;
+			const current = await MsbSandbox.get(sandboxId);
+			const wasRunning = current.status === "running" || current.status === "draining";
+			if (wasRunning) await current.stop();
+
+			let snapshotError: unknown;
+			try {
+				let builder = MsbSnapshot.builder(name).fromSandbox(sandboxId);
+				for (const [key, value] of Object.entries(options?.metadata ?? {})) {
+					builder = builder.label(key, String(value));
+				}
+				await builder.create();
+			} catch (error) {
+				snapshotError = error;
+			}
+
+			if (wasRunning) {
+				try {
+					await (await MsbSandbox.get(sandboxId)).startDetached();
+				} catch (restartError) {
+					if (!snapshotError) {
+						throw new Error(
+							`Snapshot "${name}" succeeded but restart failed: ${errorMessage(restartError)}`,
+						);
+					}
+				}
+			}
+			if (snapshotError) throw snapshotError;
+			return {
+				id: name,
+				snapshotId: name,
+				sandboxId,
+				name,
+				createdAt: new Date(),
+				metadata: options?.metadata,
+			};
+		}),
+	list: async (config) =>
+		withBackend(config, async () =>
+			(await MsbSnapshot.list()).map((snapshot) => ({
+				snapshotId: snapshot.name ?? snapshot.digest,
+				name: snapshot.name ?? undefined,
+				createdAt: snapshot.createdAt,
+				imageRef: snapshot.imageRef,
+			})),
+		),
+	delete: async (config, snapshotId) => withBackend(config, () => MsbSnapshot.remove(snapshotId)),
+};
+
+/** Local libkrun provider, including local snapshot support. */
+export const microsandboxLocalCompute = defineProvider<MicrosandboxHandle, MicrosandboxLocalConfig>(
+	{
+		name: "microsandbox-local",
+		methods: {
+			sandbox: sandboxMethods as SandboxMethods<MicrosandboxHandle, MicrosandboxLocalConfig>,
+			snapshot: localSnapshotMethods,
+		},
+	},
+);
+
+/** Cloud provider. Snapshot methods are intentionally absent so the lifecycle harness records a gap. */
+export const microsandboxCloudCompute = defineProvider<MicrosandboxHandle, MicrosandboxCloudConfig>(
+	{
+		name: "microsandbox-cloud",
+		methods: {
+			sandbox: sandboxMethods as SandboxMethods<MicrosandboxHandle, MicrosandboxCloudConfig>,
+		},
+	},
+);

--- a/packages/schema/src/providers.test.ts
+++ b/packages/schema/src/providers.test.ts
@@ -26,6 +26,8 @@ describe("@sandbox-benchmarks/schema providers", () => {
 			"daytona-container",
 			"daytona-vm",
 			"e2b",
+			"microsandbox-cloud",
+			"microsandbox-local",
 			"modal-gvisor",
 			"modal-vm",
 			"namespace",

--- a/packages/schema/src/providers.ts
+++ b/packages/schema/src/providers.ts
@@ -18,6 +18,8 @@ export type ProviderId =
 	| "modal-gvisor"
 	| "modal-vm"
 	| "blaxel"
+	| "microsandbox-local"
+	| "microsandbox-cloud"
 	| "novita"
 	| "namespace";
 
@@ -327,6 +329,70 @@ const REGISTRY: Record<ProviderId, Omit<ProviderMeta, "id">> = {
 			// `@computesdk/blaxel` execs through the sandbox gateway; long synchronous execs are not
 			// validated, so apply the conservative 60s policy bound and use the detached+poll path
 			// (background nohup + pollable filesystem, both supported by the wrapper) for long steps.
+			streaming: false,
+			syncCapMs: 60_000,
+			detachedPoll: true,
+		},
+	},
+	"microsandbox-local": {
+		displayName: "Microsandbox (local)",
+		website: "https://microsandbox.dev",
+		sdkPackage: "microsandbox",
+		// This is an explicit capability opt-in rather than a credential. Local runs require a host
+		// with KVM on Linux or Hypervisor.framework on macOS and should skip everywhere else.
+		requiredEnvVars: ["MICROSANDBOX_LOCAL_BENCH"],
+		isolation: {
+			technology: "libkrun microVM (local)",
+			notes:
+				"Runs on the benchmark harness machine itself with no control-plane or network hop. Results measure that host's hardware and are identified separately from Microsandbox Cloud.",
+		},
+		pricing: {
+			model: "unknown",
+			notes:
+				"Self-hosted execution has no vendor compute rate; infrastructure cost depends on the machine running the harness.",
+			sourceUrl: "https://microsandbox.dev",
+		},
+		maturity: {
+			status: "beta",
+			notes:
+				"Direct SDK adapter with exec, filesystem, lifecycle, list, and local snapshots. Opt-in until a comparable committed run exists.",
+		},
+		specPinning: "settable",
+		transport: {
+			// Native in-process control has no gateway timeout. Streaming callbacks are not adapted, but
+			// background exec plus the agent filesystem provides the durable detached+poll path.
+			streaming: false,
+			syncCapMs: null,
+			detachedPoll: true,
+		},
+	},
+	"microsandbox-cloud": {
+		displayName: "Microsandbox Cloud",
+		website: "https://microsandbox.dev",
+		sdkPackage: "microsandbox",
+		// MSB_API_URL is only an override for staging/private deployments. The SDK defaults to
+		// api.microsandbox.dev, so the key alone is the cloud-selection and credential gate.
+		requiredEnvVars: ["MSB_API_KEY"],
+		isolation: {
+			technology: "libkrun microVM (cloud)",
+			notes:
+				"The Microsandbox SDK talks to msb-cloud; Nomad schedules the same libkrun microVM runtime on remote hosts. Kept distinct from local runs so datasets never mix host-local and cloud measurements.",
+		},
+		pricing: {
+			model: "unknown",
+			notes:
+				"Cloud pricing is not public yet; no economics are emitted until a stable product rate is published.",
+			sourceUrl: "https://microsandbox.dev",
+		},
+		maturity: {
+			status: "beta",
+			notes:
+				"Create, readiness, exec, filesystem, list, and graceful teardown are supported. Cloud snapshots and published ports are not yet available.",
+		},
+		specPinning: "settable",
+		transport: {
+			// The adapter does not expose streaming callbacks. Use detached+filesystem polling for any
+			// benchmark-length step so a long-lived remote WebSocket is not the durability boundary.
 			streaming: false,
 			syncCapMs: 60_000,
 			detachedPoll: true,

--- a/scripts/setup-privileged-environment.sh
+++ b/scripts/setup-privileged-environment.sh
@@ -55,6 +55,7 @@ echo
 echo "Secret checklist:"
 echo "  E2B_API_KEY, DAYTONA_API_KEY, DAYTONA_TARGET,"
 echo "  MODAL_TOKEN_ID, MODAL_TOKEN_SECRET, NOVITA_API_KEY,"
+echo "  MSB_API_KEY (and optional MSB_API_URL),"
 echo "  BL_API_KEY, BL_WORKSPACE"
 echo
 echo "Also required outside this Environment (see docs/ci-secrets.md):"


### PR DESCRIPTION
## TL;DR
Add Microsandbox as separate local and cloud benchmark providers through one ComputeSDK-compatible adapter, with the configuration, workflow, and capability metadata needed to benchmark either backend without mixing their results.

## Description
- Register `microsandbox-local` and `microsandbox-cloud` as distinct providers so host-local and managed-cloud measurements remain comparable and independently attributable.
- Add a shared adapter for create, get, list, destroy, command execution, detached execution, filesystem operations, and reconnecting handles, with local snapshots exposed and unsupported cloud snapshots and ports reported honestly.
- Pin both backends to the benchmark target of 4 vCPU, 8 GiB memory, and 40 GiB root disk, with a three-hour maximum sandbox lifetime for the longest suites.
- Keep local benchmarking behind the explicit `MICROSANDBOX_LOCAL_BENCH` capability opt-in and keep cloud credentials inside the SDK backend rather than guest-visible create options.
- Require only `MSB_API_KEY` for cloud runs, while accepting `MSB_API_URL` as an optional staging or private-deployment override and otherwise using the SDK default endpoint.
- Wire both providers into CLI discovery, smoke and suite workflows, candidate-image validation, release planning, credential documentation, and registry drift checks.
- Pin and lock the published `microsandbox@0.6.8` package and its platform-native bindings.

```bash
# Local backend on a host with KVM or Hypervisor.framework
MICROSANDBOX_LOCAL_BENCH=1 bun run smoke

# Cloud backend using the SDK's default API endpoint
MSB_API_KEY=your-key bun run smoke

# Cloud backend using a staging or private endpoint
MSB_API_KEY=your-key MSB_API_URL=https://api.msbx.fyi bun run smoke
```

## Test Plan
- [x] `bun install --frozen-lockfile --ignore-scripts` installs the published SDK from the committed lockfile
- [x] `bun run lint`, `bun run typecheck`, and `bun run check:catalog-drift` pass
- [x] Provider, release-plan, provider-run, candidate-image, and schema tests covering the changed integration pass
- [x] `bun run spell`, `bun run lint:shell`, `bun run lint:docker`, actionlint, and zizmor pass
- [ ] `bun run test` passes on Linux (maintainer/CI; the changed tests pass locally, while the full macOS run hits six upstream Bash 3.2 associative-array failures and one mise task-description mismatch)
- [ ] Local and cloud `bun run smoke` complete against real sandboxes (requires a virtualization-capable host and provider credentials)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds Microsandbox as two separate providers, `microsandbox-local` and `microsandbox-cloud`, via a shared ComputeSDK-compatible adapter to keep local and cloud results distinct and comparable.

- **New Features**
  - Register `microsandbox-local` and `microsandbox-cloud` with separate capability metadata and CLI/workflow integration.
  - Shared adapter supports create/get/list/destroy, foreground/background exec, filesystem ops, and reconnects; local snapshots supported, cloud snapshots and published ports are not exposed.
  - Bench target pinned to 4 vCPU, 8 GiB RAM, 40 GiB disk, with a 3-hour max lifetime.
  - Boots the candidate OCI image directly (no baking/promote artifacts).
  - Cloud API key stays in the SDK backend and never enters guest metadata/env. Pinned `microsandbox@0.6.8`.

- **Migration**
  - Local: set MICROSANDBOX_LOCAL_BENCH=1 on a host with KVM (Linux) or Hypervisor.framework (macOS).
  - Cloud: set MSB_API_KEY; MSB_API_URL is optional for staging/private endpoints.

<sup>Written for commit 0b2c467aec94711d353836acd2c88bb19fdf9b02. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/starslingdev/hpc-sandbox-benchmarks/pull/281?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

