### PR TITLE
refactor(schema): own the workflow timeout margin next to the suite budgets

### DIFF
--- a/packages/schema/src/suites.ts
+++ b/packages/schema/src/suites.ts
@@ -324,6 +324,20 @@ export type SuiteName = keyof typeof SUITES;
 export const SUITE_NAMES = Object.keys(SUITES) as SuiteName[];
 
 /**
+ * Host-side checkout/teardown/normalization/upload allowance beyond the sandbox lifetime — what a
+ * bench job needs ON TOP of the suite budgets it runs, charged ONCE per job rather than per suite.
+ *
+ * Owned here, next to the `timeoutMinutes` it is always added to, because two independent consumers
+ * must agree on it or the pair contradicts itself: the workflow gate (`checkWorkflowTimeouts`) uses
+ * it as the floor a job's `timeout-minutes` must clear, and `bench-suite`'s fan-out guard
+ * (`fleetBudgetError`) uses it to decide whether a capped fleet's serial waves fit that same budget.
+ * A guard using a smaller margin than the gate would admit a fan-out the gate considers unaffordable
+ * and let the cell be cancelled with every shard lost — which is the exact outcome both exist to
+ * prevent.
+ */
+export const WORKFLOW_TIMEOUT_MARGIN_MINUTES = 15;
+
+/**
  * The comma-padded token for one suite, e.g. `cpu-node` → `,cpu-node,`. GitHub Actions `if:`
  * expressions can't split strings, so the setup job emits the planned suites as a padded list
  * ({@link padSuiteList}) and each suite job matches its own token with `contains(..., ',<suite>,')`.

--- a/tooling/repo-checks/src/lib/workflow-yaml.ts
+++ b/tooling/repo-checks/src/lib/workflow-yaml.ts
@@ -3,6 +3,7 @@
 // owns one concern.
 import { readFileSync } from "node:fs";
 import { join } from "node:path";
+import { WORKFLOW_TIMEOUT_MARGIN_MINUTES } from "@sandbox-benchmarks/schema";
 import { type } from "arktype";
 import { findRepoRoot } from "./workspace.ts";
 
@@ -15,8 +16,10 @@ export const RUN_STEP = "Run suite and normalize";
 export const SMOKE_JOB = "smoke";
 /** The fan-out job inside the reusable bench-suite.yml (its credential env + timeout). */
 export const SUITE_JOB = "bench";
-/** Host-side checkout/teardown/normalization/upload allowance beyond the sandbox lifetime. */
-export const WORKFLOW_TIMEOUT_MARGIN_MINUTES = 15;
+/** Host-side checkout/teardown/normalization/upload allowance beyond the sandbox lifetime. Re-exported
+ *  from the schema, which owns it — `bench-suite`'s fan-out budget guard adds the SAME margin, and the
+ *  two must not drift (see the constant's own note). */
+export { WORKFLOW_TIMEOUT_MARGIN_MINUTES };
 
 // Single source of truth: this schema drives BOTH the runtime parse (coercions live in the morphs)
 // and the exported DispatchInput type (inferred below) — there is no hand-written interface or


### PR DESCRIPTION
**REPLICATE FAN-OUT — drive a cell's whole replicate fan-out from ONE runner instead of R idle ones**

Shipped as a 7-PR stack (merge bottom-up, each branch independently green):

1. #282 — schema: own the workflow timeout margin next to the suite budgets ← **this PR**
2. #283 — harness: make result collection non-blocking so peer polls keep running
3. #284 — cli lib: the replicate fan-out primitives — pool, flags, budget guard
4. #285 — cli lib: `[rN]` line tagging + a concurrency-safe Actions log layer
5. #286 — cli: report a replicate as an outcome instead of exiting from inside it
6. #287 — cli: drive a cell's whole replicate fleet from one process
7. #288 — ci: retire the replicate matrix axis and gate the new wiring

↑ **This PR is #282 (1/7)**, based on `main`.

---
The host-side margin (checkout, teardown, normalization, upload) that a bench job needs on top
of the suite budget it runs lived in tooling/repo-checks, where only the workflow timeout gate
could see it. A second consumer is about to need the same number: a cell that drives its whole
replicate fleet in one process has to decide whether the fleet's serial waves fit that job budget,
and a guard using a smaller margin than the gate would admit a fan-out the gate considers
unaffordable — then watch the cell be cancelled with every shard lost.

Move the constant to packages/schema, next to the `timeoutMinutes` it is always added to, and
re-export it from workflow-yaml.ts so the gate's public surface is unchanged. No behavioural
change: same value, same single definition, now reachable by both consumers.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Moved the workflow timeout margin to `@sandbox-benchmarks/schema` next to suite budgets, and re-exported it from `workflow-yaml.ts`. This keeps a single source of truth for the workflow timeout gate and the fan-out budget guard, with no behavior change.

- **Refactors**
  - Added `WORKFLOW_TIMEOUT_MARGIN_MINUTES = 15` in `packages/schema/src/suites.ts`, and imported/re-exported it from `tooling/repo-checks/src/lib/workflow-yaml.ts` to keep the gate API unchanged.
  - Both the workflow timeout gate and `bench-suite` fan-out budget guard now read the same margin.

<sup>Written for commit 7156aee37fed73f18d692a91549e4f640d2f7f7c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/starslingdev/hpc-sandbox-benchmarks/pull/282?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Standardized workflow timeout handling around a shared 15-minute margin.
  * Ensured timeout checks and budget safeguards use the same configuration value, reducing the risk of inconsistent behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
