### PR TITLE
perf(harness): make result collection non-blocking so peer polls keep running

### DIFF
--- a/packages/harness/src/index.test.ts
+++ b/packages/harness/src/index.test.ts
@@ -1,5 +1,4 @@
 import { afterAll, describe, expect, it } from "bun:test";
-import { execFileSync } from "node:child_process";
 import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
@@ -283,10 +282,15 @@ function collectPayload(files: Record<string, string>): string {
 	for (const [name, contents] of Object.entries(files)) {
 		writeFileSync(join(src, "benchmark-results", name), contents);
 	}
-	const b64 = execFileSync("bash", ["-c", "tar -czf - benchmark-results | base64 | tr -d '\\n'"], {
+	// Bun.spawnSync, not node:child_process — the fixture mirrors the in-sandbox collect command, and
+	// the harness runs entirely on Bun's own process API.
+	const tar = Bun.spawnSync(["bash", "-c", "tar -czf - benchmark-results | base64 | tr -d '\\n'"], {
 		cwd: src,
-		encoding: "utf8",
 	});
+	if (tar.exitCode !== 0) {
+		throw new Error(`fixture tar failed (${tar.exitCode}): ${tar.stderr.toString()}`);
+	}
+	const b64 = tar.stdout.toString();
 	rmSync(src, { recursive: true, force: true });
 	return `__BENCH_RESULTS_TGZ_BEGIN__\n${b64}\n__BENCH_RESULTS_TGZ_END__\n`;
 }

--- a/packages/harness/src/lib/collect.test.ts
+++ b/packages/harness/src/lib/collect.test.ts
@@ -1,5 +1,4 @@
 import { afterAll, describe, expect, it } from "bun:test";
-import { execFileSync } from "node:child_process";
 import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
@@ -28,10 +27,15 @@ function collectPayload(files: Record<string, string>): string {
 	for (const [name, contents] of Object.entries(files)) {
 		writeFileSync(join(src, "benchmark-results", name), contents);
 	}
-	const b64 = execFileSync("bash", ["-c", "tar -czf - benchmark-results | base64 | tr -d '\\n'"], {
+	// Bun.spawnSync, not node:child_process — the fixture mirrors the in-sandbox collect command, and
+	// the harness runs entirely on Bun's own process API.
+	const tar = Bun.spawnSync(["bash", "-c", "tar -czf - benchmark-results | base64 | tr -d '\\n'"], {
 		cwd: src,
-		encoding: "utf8",
 	});
+	if (tar.exitCode !== 0) {
+		throw new Error(`fixture tar failed (${tar.exitCode}): ${tar.stderr.toString()}`);
+	}
+	const b64 = tar.stdout.toString();
 	rmSync(src, { recursive: true, force: true });
 	return `noise\n__BENCH_RESULTS_TGZ_BEGIN__\n${b64}\n__BENCH_RESULTS_TGZ_END__\ntrailing\n`;
 }

--- a/packages/harness/src/lib/collect.ts
+++ b/packages/harness/src/lib/collect.ts
@@ -4,9 +4,9 @@
  * exactly when partial results matter), and writes harness skip markers. The pulled files are the
  * raw inputs the normalizer consumes — the committed raw tool output is the dataset's source of truth.
  */
-import { execFileSync } from "node:child_process";
 import { randomUUID } from "node:crypto";
-import { cpSync, mkdirSync, readdirSync, rmSync, statSync, writeFileSync } from "node:fs";
+import { mkdirSync, readdirSync, writeFileSync } from "node:fs";
+import { cp, mkdir, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join, resolve } from "node:path";
 import type { GapOutcome } from "@sandbox-benchmarks/schema";
@@ -85,7 +85,7 @@ export async function collectResults(runner: StepRunner, resultsDir: string): Pr
 			// the idempotent re-collect can fix, so treat it like a marker miss one stage later and retry
 			// rather than discard the suite. The content gate is the one thing that does NOT retry.
 			try {
-				const archiveKiB = decodeAndExtract(base64, resultsDir);
+				const archiveKiB = await decodeAndExtract(base64, resultsDir);
 				validateCollected(resultsDir);
 				console.log(`Results extracted to ${resultsDir} (${archiveKiB.toFixed(1)} KiB archive)`);
 				return;
@@ -129,31 +129,63 @@ export async function collectResults(runner: StepRunner, resultsDir: string): Pr
 }
 
 /**
+ * Untar `archive` into `stage` with `Bun.spawn`, throwing tar's own diagnostics on a non-zero exit.
+ *
+ * Async, not `Bun.spawnSync`/`execFileSync`: one process now drives R replicate sandboxes at once
+ * (apps/cli/src/lib/replicates.ts), and each one's detached step is kept alive by a poll loop on this
+ * same event loop. A synchronous extract stalls every PEER's polling for its whole duration — and a
+ * poll that cannot run is indistinguishable, to the loop's consecutive-failure guard, from a sandbox
+ * that stopped answering. Awaiting the child yields instead.
+ *
+ * tar's stderr is included in the error because it names the actual corruption ("unexpected EOF"),
+ * and unlike the collect stdout it carries none of the payload — the content-free diagnostics rule in
+ * {@link collectResults} is about the base64 archive, not about tar's complaints regarding it.
+ */
+async function extractArchive(archive: string, stage: string): Promise<void> {
+	const proc = Bun.spawn(["tar", "-xzf", archive, "-C", stage], {
+		stdout: "ignore",
+		stderr: "pipe",
+	});
+	const [stderr, exitCode] = await Promise.all([new Response(proc.stderr).text(), proc.exited]);
+	if (exitCode !== 0) {
+		throw new Error(
+			`tar exited ${exitCode} extracting the results archive: ${stderr.trim() || "(no stderr)"}`,
+		);
+	}
+}
+
+/**
  * Decode the marker-bounded base64 tar to disk and extract benchmark-results/ into `resultsDir`,
  * returning the archive size in KiB (for the success log). Throws on any decode/extract failure —
  * {@link collectResults} treats that as retryable stream corruption.
  */
-function decodeAndExtract(base64: string, resultsDir: string): number {
-	// Decode straight to disk via the "base64" write encoding — avoids a Node-only Buffer in the
-	// cross-runtime package code. A random suffix keeps concurrent collects from colliding.
+async function decodeAndExtract(base64: string, resultsDir: string): Promise<number> {
 	const archive = join(tmpdir(), `bench-results-${process.pid}-${randomUUID()}.tgz`);
 	try {
-		writeFileSync(archive, base64, "base64");
+		// The archive write and the tree copy yield, for the reason {@link extractArchive} documents:
+		// R replicates enter collect at roughly the same time, so whatever blocks here blocks R-1 peers'
+		// poll loops. Converting only the `tar` child would have left the multi-MB write and the
+		// recursive copy stalling them. `Uint8Array.fromBase64` itself is a synchronous decode with no
+		// async alternative, but it is ~0.2 ms/MB — three orders under the poll interval — so it stays.
+		// It is also the Bun-native spelling of the old `writeFileSync(…, "base64")`: no Node Buffer in
+		// package code, and it throws on a corrupt payload the old encoding would have silently dropped.
+		const bytes = Uint8Array.fromBase64(base64);
+		await Bun.write(archive, bytes);
 		const target = resolve(resultsDir);
 		// The tarball holds a top-level benchmark-results/ directory. Extract into a unique staging
 		// dir (not `parent`, which is shared across providers) so concurrent collects can't clobber
 		// each other, then copy its contents into the target (`<provider>`, not `benchmark-results`).
 		const stage = join(tmpdir(), `bench-extract-${process.pid}-${randomUUID()}`);
-		mkdirSync(stage, { recursive: true });
+		await mkdir(stage, { recursive: true });
 		try {
-			execFileSync("tar", ["-xzf", archive, "-C", stage]);
-			cpSync(join(stage, "benchmark-results"), target, { recursive: true });
+			await extractArchive(archive, stage);
+			await cp(join(stage, "benchmark-results"), target, { recursive: true });
 		} finally {
-			rmSync(stage, { recursive: true, force: true });
+			await rm(stage, { recursive: true, force: true });
 		}
-		return statSync(archive).size / 1024;
+		return Bun.file(archive).size / 1024;
 	} finally {
-		rmSync(archive, { force: true });
+		await rm(archive, { force: true });
 	}
 }
 


### PR DESCRIPTION
**REPLICATE FAN-OUT — drive a cell's whole replicate fan-out from ONE runner instead of R idle ones**

Shipped as a 7-PR stack (merge bottom-up, each branch independently green):

1. #282 — schema: own the workflow timeout margin next to the suite budgets
2. #283 — harness: make result collection non-blocking so peer polls keep running ← **this PR**
3. #284 — cli lib: the replicate fan-out primitives — pool, flags, budget guard
4. #285 — cli lib: `[rN]` line tagging + a concurrency-safe Actions log layer
5. #286 — cli: report a replicate as an outcome instead of exiting from inside it
6. #287 — cli: drive a cell's whole replicate fleet from one process
7. #288 — ci: retire the replicate matrix axis and gate the new wiring

↑ **This PR is #283 (2/7)**, based on #282.

---
collectResults extracted with synchronous fs + execFileSync calls: a multi-MB base64 write, a
blocking `tar` child, and a recursive cpSync. That was free while one process drove one sandbox.
It stops being free the moment one process drives several — each sandbox's detached step is kept
alive by a poll loop on this same event loop, so a synchronous extract stalls every peer's polling
for its whole duration, and a poll that cannot run is indistinguishable to the loop's
consecutive-failure guard from a sandbox that stopped answering.

Convert the whole path to awaited Bun/node:fs/promises APIs: `Bun.write`, `node:fs/promises`
cp/mkdir/rm, and a `Bun.spawn` tar whose stderr is now surfaced in the error (it names the actual
corruption — "unexpected EOF" — and unlike the collect stdout carries none of the payload).
Converting only the tar child would have left the write and the copy stalling peers.

The base64 decode moves to `Uint8Array.fromBase64`, the Bun-native spelling of the old
`writeFileSync(…, "base64")`: still synchronous, but ~0.2 ms/MB — three orders under the poll
interval — and it throws on a corrupt payload the old write encoding silently dropped. The two
test fixtures move off node:child_process onto Bun.spawnSync and now fail loudly if the fixture
tar itself fails.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make result collection non-blocking so peer sandbox polls keep running during concurrent runs. Replaces blocking fs/child-process calls with async `Bun` and `node:fs/promises`, and surfaces clearer `tar` errors.

- **Refactors**
  - Replaced sync fs and `execFileSync` with awaited `Bun.write` and `node:fs/promises` `cp`/`mkdir`/`rm`, plus async `tar` via `Bun.spawn` (captures stderr and exit code).
  - Switched base64 decode to `Uint8Array.fromBase64` (fast, throws on corrupt payload).
  - Updated tests to use `Bun.spawnSync` and fail loudly if the fixture `tar` fails.

<sup>Written for commit 656c0afb6b62770721aa243f89f21dad5a8f28f6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/starslingdev/hpc-sandbox-benchmarks/pull/283?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

