### PR TITLE
feat(cli): add the in-process replicate fan-out primitives

### DIFF
--- a/apps/cli/src/lib/replicates.test.ts
+++ b/apps/cli/src/lib/replicates.test.ts
@@ -1,0 +1,342 @@
+import { describe, expect, it } from "bun:test";
+import { WORKFLOW_TIMEOUT_MARGIN_MINUTES } from "@sandbox-benchmarks/schema";
+import {
+	fleetBudgetError,
+	fleetWaves,
+	lastFlagValue,
+	parseReplicatesFlag,
+	replicatePaths,
+	resolveCellBudgetMinutes,
+	resolveMaxConcurrency,
+	runPooled,
+} from "./replicates.ts";
+
+describe("lastFlagValue", () => {
+	it("reads both spellings and takes the last occurrence", () => {
+		expect(lastFlagValue(["--replicates", "0,1"], "replicates")).toBe("0,1");
+		expect(lastFlagValue(["--replicates=0,1"], "replicates")).toBe("0,1");
+		expect(lastFlagValue(["--replicates=0", "--replicates", "9"], "replicates")).toBe("9");
+	});
+
+	it("returns undefined when the flag is absent", () => {
+		expect(lastFlagValue(["e2b", "memory"], "replicates")).toBeUndefined();
+	});
+
+	// The singular and plural spellings must not consume each other's operands — a `--replicates`
+	// swallowed by `--replicate` would run one sandbox where the plan asked for R.
+	it("does not confuse the singular and plural spellings", () => {
+		expect(lastFlagValue(["--replicates", "0,1,2"], "replicate")).toBeUndefined();
+		expect(lastFlagValue(["--replicates=0,1,2"], "replicate")).toBeUndefined();
+		expect(lastFlagValue(["--replicate", "3"], "replicates")).toBeUndefined();
+	});
+
+	it("throws on a dangling flag rather than defaulting", () => {
+		expect(() => lastFlagValue(["--replicates"], "replicates")).toThrow(/requires an index/);
+	});
+});
+
+describe("parseReplicatesFlag", () => {
+	it("returns undefined when the flag is absent", () => {
+		expect(parseReplicatesFlag(["e2b", "memory", "run-1"])).toBeUndefined();
+	});
+
+	it("parses the JSON array plan-replicates emits", () => {
+		expect(parseReplicatesFlag(["--replicates", "[0,1,2]"])).toEqual([0, 1, 2]);
+		expect(parseReplicatesFlag(["--replicates=[0]"])).toEqual([0]);
+	});
+
+	it("parses the comma-separated spelling, tolerating whitespace", () => {
+		expect(parseReplicatesFlag(["--replicates", "0,1,2"])).toEqual([0, 1, 2]);
+		expect(parseReplicatesFlag(["--replicates", " 0 , 1 "])).toEqual([0, 1]);
+		expect(parseReplicatesFlag(["--replicates", "4"])).toEqual([4]);
+	});
+
+	it("preserves a non-contiguous axis rather than renumbering it", () => {
+		expect(parseReplicatesFlag(["--replicates", "[3,7]"])).toEqual([3, 7]);
+	});
+
+	// An empty fan-out would upload no shard and read downstream as "never scheduled"; a repeated index
+	// would fold two sandboxes into one replicate slot at aggregate time. Both must fail the cell.
+	it("rejects an empty axis and repeated indices", () => {
+		expect(() => parseReplicatesFlag(["--replicates", ""])).toThrow(/must not be blank/);
+		expect(() => parseReplicatesFlag(["--replicates", "[]"])).toThrow(/at least one index/);
+		expect(() => parseReplicatesFlag(["--replicates", "0,1,0"])).toThrow(/must not repeat/);
+	});
+
+	it("rejects malformed indices and non-array JSON", () => {
+		expect(() => parseReplicatesFlag(["--replicates", "0,,1"])).toThrow(/non-negative integer/);
+		expect(() => parseReplicatesFlag(["--replicates", "0,-1"])).toThrow(/non-negative integer/);
+		expect(() => parseReplicatesFlag(["--replicates", "0,1.5"])).toThrow(/non-negative integer/);
+		expect(() => parseReplicatesFlag(["--replicates", "[0,"])).toThrow(/JSON array/);
+	});
+
+	// `Number.isInteger` is true of both of these, and neither can name a real replicate slot: 1e21
+	// would spell its shard `<runId>-r1e+21.json`, and above 2^53 distinct operands stop being
+	// distinct numbers — so a pair that does not look repeated collides into one slot at aggregate time.
+	it("rejects indices outside the safe-integer range", () => {
+		expect(() => parseReplicatesFlag(["--replicates", "1e21"])).toThrow(/non-negative integer/);
+		expect(() =>
+			parseReplicatesFlag(["--replicates", "9007199254740992,9007199254740993"]),
+		).toThrow(/non-negative integer/);
+	});
+});
+
+describe("replicatePaths", () => {
+	// Every shard of one run carries the same `runId` FIELD, so only the filename keeps them apart —
+	// and commit-dataset.yml globs exactly this shape.
+	it("gives each replicate its own raw tree and a suffixed shard file", () => {
+		expect(replicatePaths("ci-1", 0)).toEqual({
+			rawRoot: "data/raw/ci-1/r0",
+			outFile: "data/runs/ci-1-r0.json",
+		});
+		expect(replicatePaths("ci-1", 11).outFile).toBe("data/runs/ci-1-r11.json");
+	});
+});
+
+describe("resolveMaxConcurrency", () => {
+	it("defaults to unbounded — the whole fleet at once, as R separate runners were", () => {
+		expect(resolveMaxConcurrency([], {})).toBe(Number.POSITIVE_INFINITY);
+		expect(resolveMaxConcurrency([], { BENCH_MAX_CONCURRENCY: "" })).toBe(Number.POSITIVE_INFINITY);
+	});
+
+	it("reads the flag and the env var, with the flag winning", () => {
+		expect(resolveMaxConcurrency(["--max-concurrency", "3"], {})).toBe(3);
+		expect(resolveMaxConcurrency([], { BENCH_MAX_CONCURRENCY: "2" })).toBe(2);
+		expect(resolveMaxConcurrency(["--max-concurrency=4"], { BENCH_MAX_CONCURRENCY: "2" })).toBe(4);
+	});
+
+	// A blank FLAG is a typo; a blank ENV is what CI sets whenever the dispatch input is left empty.
+	// Conflating them would let `--max-concurrency=` pick the widest fan-out AND mask a deliberate env cap.
+	it("rejects a blank flag operand but keeps a blank env meaning unbounded", () => {
+		expect(() => resolveMaxConcurrency(["--max-concurrency="], {})).toThrow(/must not be blank/);
+		expect(() => resolveMaxConcurrency(["--max-concurrency", ""], {})).toThrow(/must not be blank/);
+		// The production path: bench-suite.yml always sets the key, blank when the input is blank.
+		expect(resolveMaxConcurrency([], { BENCH_MAX_CONCURRENCY: "" })).toBe(Number.POSITIVE_INFINITY);
+		// A blank flag must not silently win over a real env cap either.
+		expect(() =>
+			resolveMaxConcurrency(["--max-concurrency="], { BENCH_MAX_CONCURRENCY: "4" }),
+		).toThrow(/must not be blank/);
+	});
+
+	it("rejects a non-positive or non-integer cap instead of silently serializing", () => {
+		expect(() => resolveMaxConcurrency(["--max-concurrency", "0"], {})).toThrow(/positive integer/);
+		expect(() => resolveMaxConcurrency([], { BENCH_MAX_CONCURRENCY: "1.5" })).toThrow(
+			/positive integer/,
+		);
+		expect(() => resolveMaxConcurrency([], { BENCH_MAX_CONCURRENCY: "lots" })).toThrow(
+			/positive integer/,
+		);
+	});
+});
+
+describe("resolveCellBudgetMinutes", () => {
+	// No budget is the honest local answer — nothing cancels a laptop run, so there is nothing the
+	// fan-out guard could meaningfully compare against.
+	it("is undefined when CI did not hand one down", () => {
+		expect(resolveCellBudgetMinutes({})).toBeUndefined();
+		expect(resolveCellBudgetMinutes({ BENCH_CELL_BUDGET_MINUTES: "" })).toBeUndefined();
+	});
+
+	it("reads the job budget the workflow advertises", () => {
+		expect(resolveCellBudgetMinutes({ BENCH_CELL_BUDGET_MINUTES: "180" })).toBe(180);
+	});
+
+	// A malformed budget must not read as "unbounded": that would disable the guard silently, which is
+	// the same outcome as not having it on the one run where it mattered.
+	it("rejects a malformed budget rather than falling back to no check", () => {
+		expect(() => resolveCellBudgetMinutes({ BENCH_CELL_BUDGET_MINUTES: "0" })).toThrow(
+			/positive integer/,
+		);
+		expect(() => resolveCellBudgetMinutes({ BENCH_CELL_BUDGET_MINUTES: "90.5" })).toThrow(
+			/positive integer/,
+		);
+		expect(() => resolveCellBudgetMinutes({ BENCH_CELL_BUDGET_MINUTES: "later" })).toThrow(
+			/positive integer/,
+		);
+	});
+});
+
+describe("fleetWaves", () => {
+	it("is one wave whenever the cap admits the whole fleet", () => {
+		expect(fleetWaves(12, Number.POSITIVE_INFINITY)).toBe(1);
+		expect(fleetWaves(12, 12)).toBe(1);
+		expect(fleetWaves(12, 99)).toBe(1);
+	});
+
+	it("rounds a partial final wave up", () => {
+		expect(fleetWaves(12, 6)).toBe(2);
+		expect(fleetWaves(12, 5)).toBe(3);
+		expect(fleetWaves(12, 1)).toBe(12);
+	});
+});
+
+describe("fleetBudgetError", () => {
+	// The shipped realworld cell: R=12, a 90-minute suite, the 180-minute job.
+	const realworld = { replicates: 12, suite: "realworld-mastra", suiteTimeoutMinutes: 90 };
+
+	it("passes an uncapped fan-out — one wave is the budget the job was sized for", () => {
+		expect(
+			fleetBudgetError({
+				...realworld,
+				maxConcurrency: Number.POSITIVE_INFINITY,
+				budgetMinutes: 180,
+			}),
+		).toBeUndefined();
+	});
+
+	it("passes a cap that admits the whole fleet in one wave", () => {
+		expect(
+			fleetBudgetError({ ...realworld, maxConcurrency: 12, budgetMinutes: 180 }),
+		).toBeUndefined();
+	});
+
+	// The margin is not optional slack. Two waves land on EXACTLY the 180-minute budget (2 x 90), so a
+	// guard comparing bare sandbox time would wave this through with nothing left for the checkout,
+	// teardown, normalization and upload the job still has to do — and the cell is cancelled with all
+	// 12 shards lost, which is the outcome this guard exists to refuse.
+	it("rejects a cap that lands on the budget with no host margin left", () => {
+		const error = fleetBudgetError({ ...realworld, maxConcurrency: 6, budgetMinutes: 180 });
+		expect(error).toContain("2 serial waves");
+		expect(error).toContain(`+ ${WORKFLOW_TIMEOUT_MARGIN_MINUTES} minutes of host margin`);
+		expect(error).toContain("up to 195 minutes");
+	});
+
+	// 3 waves x 90 + 15 = 285 > 180. Rejecting costs a dispatch; discovering it costs three hours and
+	// the cell.
+	it("rejects a cap that deterministically overruns, naming the smallest cap that fits", () => {
+		const error = fleetBudgetError({ ...realworld, maxConcurrency: 4, budgetMinutes: 180 });
+		expect(error).toContain("3 serial waves");
+		expect(error).toContain("up to 285 minutes");
+		expect(error).toContain("180-minute job budget");
+		// floor((180 - 15) / 90) = 1 affordable wave, so ceil(12 / 1) = 12 — at the shipped realworld
+		// defaults no cap below the full fleet fits, and the message says so rather than inventing one.
+		expect(error).toContain("at least 12");
+	});
+
+	// A suite that cannot fit the job even once is not a concurrency problem, and telling the operator
+	// to raise a cap they cannot raise far enough would send them in circles.
+	it("does not recommend a cap when even one wave overruns", () => {
+		const error = fleetBudgetError({
+			replicates: 3,
+			suite: "cpu-node",
+			suiteTimeoutMinutes: 200,
+			maxConcurrency: 2,
+			budgetMinutes: 180,
+		});
+		expect(error).toContain("leave --max-concurrency blank");
+		expect(error).not.toContain("at least");
+	});
+});
+
+describe("runPooled", () => {
+	const flush = (): Promise<void> => Bun.sleep(0);
+	/** For the cases that assert scheduling, not error handling: a throw here is a test bug. */
+	const throwOnError = (error: unknown): never => {
+		throw error;
+	};
+
+	it("returns results in input order regardless of completion order", async () => {
+		const results = await runPooled(
+			[30, 10, 20],
+			3,
+			async (ms) => {
+				await Bun.sleep(ms);
+				return ms;
+			},
+			throwOnError,
+		);
+		expect(results).toEqual([30, 10, 20]);
+	});
+
+	// THE isolation guarantee. A rejecting Promise.all would unwind the pool and abandon the peers
+	// mid-suite — sandboxes alive, shards unwritten, and the caller exiting before it can report.
+	it("never rejects: a throwing item becomes its own failure and peers still finish", async () => {
+		const finished: number[] = [];
+		const results = await runPooled(
+			[0, 1, 2, 3],
+			4,
+			async (i) => {
+				if (i === 1) {
+					await Bun.sleep(1);
+					throw new Error("replicate 1 exploded");
+				}
+				await Bun.sleep(20);
+				finished.push(i);
+				return `ok:${i}`;
+			},
+			(error, _item, index) => `failed:${index}:${(error as Error).message}`,
+		);
+		expect(results).toEqual(["ok:0", "failed:1:replicate 1 exploded", "ok:2", "ok:3"]);
+		// The peers ran to completion rather than being abandoned when their sibling threw.
+		expect(finished.toSorted()).toEqual([0, 2, 3]);
+	});
+
+	it("keeps the pool draining when every item throws", async () => {
+		const results = await runPooled(
+			[0, 1, 2],
+			2,
+			async (i) => {
+				throw new Error(`boom ${i}`);
+			},
+			(error) => (error as Error).message,
+		);
+		expect(results).toEqual(["boom 0", "boom 1", "boom 2"]);
+	});
+
+	/** The highest number of `fn` calls ever in flight at once, driving `count` items at `limit`. */
+	const peakConcurrency = async (count: number, limit: number): Promise<number> => {
+		let inFlight = 0;
+		let peak = 0;
+		await runPooled(
+			Array.from({ length: count }, (_, i) => i),
+			limit,
+			async () => {
+				inFlight++;
+				peak = Math.max(peak, inFlight);
+				await flush();
+				inFlight--;
+				return null;
+			},
+			throwOnError,
+		);
+		return peak;
+	};
+
+	it("never exceeds the concurrency limit", async () => {
+		expect(await peakConcurrency(6, 2)).toBe(2);
+	});
+
+	it("runs everything at once when the limit is unbounded", async () => {
+		expect(await peakConcurrency(4, Number.POSITIVE_INFINITY)).toBe(4);
+	});
+
+	it("returns [] for an empty item list", async () => {
+		expect(await runPooled([], 4, async () => "never", throwOnError)).toEqual([]);
+	});
+
+	// A throwing `onError` is a caller bug, but it must not become the thing the required `onError`
+	// exists to prevent: peers abandoned mid-flight. Every item still gets its turn, and the bug
+	// surfaces only once nothing is in flight.
+	it("drains every item before surfacing a throwing onError", async () => {
+		const started: number[] = [];
+		const finished: number[] = [];
+		const run = runPooled(
+			[0, 1, 2, 3],
+			2,
+			async (i) => {
+				started.push(i);
+				await flush();
+				finished.push(i);
+				// Items 1 and 2 fail, so onError runs mid-pool with peers still queued behind them.
+				if (i === 1 || i === 2) throw new Error(`boom ${i}`);
+				return i;
+			},
+			() => {
+				throw new Error("converter exploded");
+			},
+		);
+		await expect(run).rejects.toThrow(/onError threw .* results are incomplete/s);
+		expect(started.sort()).toEqual([0, 1, 2, 3]);
+		expect(finished.sort()).toEqual([0, 1, 2, 3]);
+	});
+});

--- a/apps/cli/src/lib/replicates.ts
+++ b/apps/cli/src/lib/replicates.ts
@@ -1,0 +1,330 @@
+/**
+ * Replicate fan-out for a single (provider, suite) cell: flag parsing, per-replicate shard paths, and
+ * the bounded-concurrency pool that drives R sandboxes from ONE process.
+ *
+ * The between-machine axis used to be a GitHub Actions matrix axis — one runner per
+ * (provider, suite, replicate) — but a bench runner spends essentially all of its wall time *waiting*
+ * on a sandbox (create → poll a detached step → poll again), so R runners idled in lockstep while R
+ * sandboxes did the work. The runner-minutes bill scaled with R for no throughput gain: at the shipped
+ * defaults (6 providers × 9 suites, R=3 synthetic / R=12 realworld) that is 324 runners doing the work
+ * of 54. Driving all R replicates from one runner keeps the sandbox fan-out identical — the same R
+ * sandboxes are created concurrently against the same provider account, so provider load and wall
+ * clock are unchanged — and collapses the runner axis.
+ *
+ * Host-side concurrency was already safe: the harness names every temp archive/staging dir with a
+ * `randomUUID` precisely so concurrent collects can't collide (packages/harness/src/lib/collect.ts),
+ * and each replicate here gets its own raw tree + shard file, so nothing is shared but the process and
+ * its environment. The environment caveat is real but currently harmless: the Daytona adapter pins
+ * `DAYTONA_TARGET` process-globally around each client-constructing call
+ * (packages/providers/src/lib/daytona-target.ts), so concurrent replicates interleave those
+ * set/restore pairs. Every replicate of a cell is the SAME provider and suite and therefore pins the
+ * SAME value, so the interleaving can only leave the variable holding the value it was already going
+ * to hold; a cell that mixed targets in one process would need that pin reworked first.
+ */
+import { WORKFLOW_TIMEOUT_MARGIN_MINUTES } from "@sandbox-benchmarks/schema";
+
+/** Per-replicate shard paths inside the `data/` tree the cell uploads as one artifact. */
+export interface ReplicatePaths {
+	/** Raw results root for this replicate — `data/raw/<runId>/r<idx>`, normalized on its own. */
+	rawRoot: string;
+	/** Shard Run document — `data/runs/<runId>-r<idx>.json`. */
+	outFile: string;
+}
+
+/**
+ * Where replicate `index` of `runId` writes. The `-r<idx>` FILE suffix (not a per-replicate directory)
+ * is what keeps R shards distinct inside ONE artifact: every replicate's Run carries the same
+ * `runId` field, so they would otherwise all be `data/runs/<runId>.json`. commit-dataset.yml globs
+ * `runs/<runId>-r*.json` alongside the legacy `runs/<runId>.json`, so both layouts aggregate.
+ */
+export function replicatePaths(runId: string, index: number): ReplicatePaths {
+	return {
+		rawRoot: `data/raw/${runId}/r${index}`,
+		outFile: `data/runs/${runId}-r${index}.json`,
+	};
+}
+
+/**
+ * The last value given for `--<flag> <value>` / `--<flag>=<value>` in `argv`, or undefined when absent.
+ * A dangling space-separated flag throws (`operand` names what was expected) — a missing operand must
+ * fail the cell, never silently fall back to a default that changes what gets benchmarked.
+ *
+ * Prefix collisions are not possible between the singular and plural spellings: `--replicates` is not
+ * equal to `--replicate`, and `"--replicates=0,1".startsWith("--replicate=")` is false (the 's' sits
+ * where the '=' must be), so each flag only ever consumes its own operand.
+ */
+export function lastFlagValue(
+	argv: readonly string[],
+	flag: string,
+	operand = "an index argument",
+): string | undefined {
+	const prefix = `--${flag}=`;
+	let raw: string | undefined;
+	for (let i = 0; i < argv.length; i++) {
+		const arg = argv[i];
+		if (arg === `--${flag}`) {
+			raw = argv[i + 1];
+			if (raw === undefined) throw new Error(`--${flag} requires ${operand}`);
+		} else if (arg?.startsWith(prefix)) {
+			raw = arg.slice(prefix.length);
+		}
+	}
+	return raw;
+}
+
+/**
+ * A replicate index: a non-negative integer. Blank operands are rejected explicitly because
+ * `Number("")`/`Number("  ")` both coerce to 0 — which would silently collide two sandboxes into
+ * replicate slot 0 at aggregate time, exactly the corruption this validation exists to prevent.
+ *
+ * SAFE integer, not merely integer, for the same reason. `Number.isInteger` is true of `1e21` (whose
+ * shard file would be the nonsense `<runId>-r1e+21.json`) and of everything above 2^53, where
+ * DISTINCT operands stop being distinct numbers — `"9007199254740993"` and `"9007199254740992"` both
+ * parse to 9007199254740992, so two sandboxes would claim one replicate slot through a pair of
+ * indices that do not look repeated at all. Nothing legitimate is excluded: the axis is `[0..R-1]`.
+ */
+export function parseReplicateIndex(raw: string, what = "--replicate"): number {
+	const index = Number(raw);
+	if (raw.trim() === "" || !Number.isSafeInteger(index) || index < 0) {
+		throw new Error(`${what} must be a non-negative integer; got "${raw}"`);
+	}
+	return index;
+}
+
+/**
+ * Parse `--replicates` into the replicate index list this runner drives, or `undefined` when absent
+ * (the single-shard path). Accepts the JSON array the plan emits (`[0,1,2]` — passed straight through
+ * from `plan-replicates`' per-suite map, so the workflow never reshapes it) and the comma-separated
+ * spelling (`0,1,2`) for hand-typed local runs.
+ *
+ * An empty list throws rather than benchmarking nothing: a cell that silently ran zero sandboxes would
+ * upload no shard and read downstream as "this provider was never scheduled". Duplicates throw too —
+ * two shards claiming one replicate index would fold into a single slot in the aggregate, quietly
+ * discarding a sandbox's worth of data.
+ */
+export function parseReplicatesFlag(argv: readonly string[]): number[] | undefined {
+	const raw = lastFlagValue(argv, "replicates");
+	if (raw === undefined) return undefined;
+	const trimmed = raw.trim();
+	if (trimmed === "") throw new Error('--replicates must not be blank; got ""');
+
+	const tokens = trimmed.startsWith("[")
+		? parseJsonReplicateTokens(trimmed)
+		: trimmed.split(",").map((token) => token.trim());
+
+	const indices = tokens.map((token) => parseReplicateIndex(token, "--replicates"));
+	if (indices.length === 0) {
+		throw new Error(`--replicates must list at least one index; got "${raw}"`);
+	}
+	const repeated = indices.find((index, i) => indices.indexOf(index) !== i);
+	if (repeated !== undefined) {
+		throw new Error(`--replicates must not repeat an index; got "${raw}" (${repeated} twice)`);
+	}
+	return indices;
+}
+
+/** The elements of a JSON `--replicates` array as raw tokens, so one validator handles both spellings. */
+function parseJsonReplicateTokens(raw: string): string[] {
+	let parsed: unknown;
+	try {
+		parsed = JSON.parse(raw);
+	} catch {
+		// Left undefined so the array check below reports it. Malformed JSON (`[0,`) and well-formed
+		// non-array JSON (`5`, `{}`) are ONE operator mistake — a mistyped flag — and deserve one
+		// message; `JSON.parse`'s byte offset adds nothing when the whole operand is echoed anyway.
+	}
+	if (!Array.isArray(parsed)) {
+		throw new Error(`--replicates must be a JSON array or a comma-separated list; got "${raw}"`);
+	}
+	return parsed.map((value) => String(value));
+}
+
+/**
+ * How many replicate sandboxes may be in flight at once — `--max-concurrency <n>` or
+ * `BENCH_MAX_CONCURRENCY`, defaulting to unbounded (all R at once, matching what R separate runners
+ * did). The knob exists for a provider whose account quota makes a wide fan-out spend its create-retry
+ * budget queueing instead of benchmarking. CI reaches it through the env var only — bench-suite.yml
+ * puts the dispatch input in `BENCH_MAX_CONCURRENCY` and never passes the flag — so `argv` winning is
+ * for the operator debugging by hand, whose typed flag should beat an exported value they forgot about.
+ * A non-positive or non-integer value throws — a typo must fail the cell, not silently serialize (or
+ * unbound) the fan-out.
+ */
+export function resolveMaxConcurrency(
+	argv: readonly string[],
+	env: Record<string, string | undefined> = process.env,
+): number {
+	const flag = lastFlagValue(argv, "max-concurrency", "a positive integer argument");
+	// A blank FLAG is an operator typo and throws, matching how `--replicates ""` is treated; a blank
+	// ENV is the normal CI value and means unbounded. The distinction has to be made here, before the
+	// `??` below, because `""` is not nullish: `--max-concurrency=` would otherwise both pick the
+	// widest possible fan-out AND mask a BENCH_MAX_CONCURRENCY someone set deliberately — silently
+	// choosing "all R at once" from an operand that says nothing at all.
+	if (flag !== undefined && flag.trim() === "") {
+		throw new Error(
+			'--max-concurrency must not be blank; pass a positive integer, or omit the flag entirely for an unbounded fan-out (got "")',
+		);
+	}
+	const raw = flag ?? env.BENCH_MAX_CONCURRENCY;
+	if (raw === undefined || raw.trim() === "") return Number.POSITIVE_INFINITY;
+	const limit = Number(raw);
+	if (!Number.isInteger(limit) || limit < 1) {
+		throw new Error(`max concurrency must be a positive integer; got "${raw}"`);
+	}
+	return limit;
+}
+
+/**
+ * The cell's wall-clock budget in minutes — the `timeout-minutes` of the job driving this fan-out,
+ * handed down as `BENCH_CELL_BUDGET_MINUTES`. Absent/blank means "no budget", which is the honest
+ * answer for a local run: nothing cancels it, so there is nothing to check against. CI is the only
+ * caller that sets it (bench-suite.yml, kept in lockstep with the job's literal `timeout-minutes` by
+ * the workflow gate), so the guard below is inert exactly where it would be meaningless.
+ */
+export function resolveCellBudgetMinutes(
+	env: Record<string, string | undefined> = process.env,
+): number | undefined {
+	const raw = env.BENCH_CELL_BUDGET_MINUTES;
+	if (raw === undefined || raw.trim() === "") return undefined;
+	const minutes = Number(raw);
+	if (!Number.isInteger(minutes) || minutes < 1) {
+		throw new Error(`BENCH_CELL_BUDGET_MINUTES must be a positive integer; got "${raw}"`);
+	}
+	return minutes;
+}
+
+/** How many SERIAL waves a fan-out of `replicates` runs in under `maxConcurrency` in flight. */
+export function fleetWaves(replicates: number, maxConcurrency: number): number {
+	// `min` before the divide keeps an unbounded (Infinity) cap out of the arithmetic: a cap at or
+	// above R is one wave, which is the uncapped case and the only one this whole guard lets through.
+	return Math.ceil(replicates / Math.min(maxConcurrency, replicates));
+}
+
+/**
+ * Why the requested fan-out cannot fit the cell's job budget, or `undefined` when it can.
+ *
+ * A concurrency cap is not free: it makes the cell run `ceil(R / cap)` SERIAL waves, so the cell's
+ * wall clock stops being "the slowest replicate" and becomes "waves × the suite's own budget". That
+ * product is checked against the ONE job budget all R replicates share, because exceeding it is not a
+ * degraded run — the job is cancelled mid-flight and every shard of the cell is lost at once, which is
+ * precisely the whole-cell blast radius that driving R replicates from one runner introduced. At the
+ * shipped realworld defaults (R=12, a 90-minute suite, a 180-minute job) any cap below 6 is already in
+ * that state, so this is a reachable operator mistake and not a theoretical one.
+ *
+ * Deliberately worst-case: a suite's `timeoutMinutes` is the budget a replicate is ALLOWED to take, and
+ * a guard that assumed replicates finish early would pass configurations that die whenever they don't.
+ * Refusing up front costs a dispatch; discovering it costs three hours of runner time and the cell.
+ *
+ * The sandbox time is charged per wave, but {@link WORKFLOW_TIMEOUT_MARGIN_MINUTES} is charged ONCE:
+ * the checkout, teardown, normalization and upload it covers happen per JOB, not per wave. Counting
+ * it is what keeps this guard consistent with the workflow timeout gate rather than one notch looser
+ * than it — omitting it accepts a fan-out landing on EXACTLY the budget (R=12 capped at 6 is 2 x 90 =
+ * 180 against a 180-minute job), which has no room left for the host work and is cancelled with all
+ * R shards lost. That is the failure this function exists to refuse, so it must not be its own
+ * boundary case.
+ *
+ * Uncapped fan-outs can never trip this: they are one wave, so the comparison reduces to "the suite
+ * budget plus the margin fits the job budget", which the workflow timeout gate
+ * (`checkWorkflowTimeouts`) already guarantees using this same constant.
+ */
+export function fleetBudgetError(opts: {
+	replicates: number;
+	maxConcurrency: number;
+	suite: string;
+	suiteTimeoutMinutes: number;
+	budgetMinutes: number;
+}): string | undefined {
+	const { replicates, maxConcurrency, suite, suiteTimeoutMinutes, budgetMinutes } = opts;
+	const waves = fleetWaves(replicates, maxConcurrency);
+	const worstCase = waves * suiteTimeoutMinutes + WORKFLOW_TIMEOUT_MARGIN_MINUTES;
+	if (worstCase <= budgetMinutes) return undefined;
+
+	// The smallest cap that WOULD fit, so the message ends in a number the operator can act on rather
+	// than in "try a bigger one". `maxWaves` is how many suite budgets the job budget holds once the
+	// host margin is set aside; at 0 the suite cannot fit the job at all and no cap saves it, so
+	// recommend dropping the cap entirely and let the (separate) timeout gate own that mismatch.
+	const maxWaves = Math.floor(
+		(budgetMinutes - WORKFLOW_TIMEOUT_MARGIN_MINUTES) / suiteTimeoutMinutes,
+	);
+	const remedy =
+		maxWaves >= 1
+			? `raise --max-concurrency to at least ${Math.ceil(replicates / maxWaves)} (or leave it blank for all ${replicates} at once)`
+			: `leave --max-concurrency blank — suite "${suite}" alone does not fit the ${budgetMinutes}-minute job budget`;
+	return (
+		`--max-concurrency ${maxConcurrency} splits ${replicates} replicates of suite "${suite}" into ` +
+		`${waves} serial waves × ${suiteTimeoutMinutes} minutes + ${WORKFLOW_TIMEOUT_MARGIN_MINUTES} ` +
+		`minutes of host margin = up to ${worstCase} minutes, past the cell's ${budgetMinutes}-minute ` +
+		`job budget. The job would be cancelled mid-fan-out and ALL ${replicates} shards lost, so this ` +
+		`is rejected before any sandbox is created: ${remedy}.`
+	);
+}
+
+/**
+ * Run `fn` over every item with at most `limit` in flight, resolving to the results IN INPUT ORDER.
+ * A throw from `fn` can never reject this: it is handed to `onError`, whose return value takes that
+ * slot. (The one rejection left is a throw from `onError` itself — a caller bug, and one that is still
+ * raised only after every item has been drained, so it cannot strand a peer either.)
+ *
+ * `onError` is REQUIRED, not optional, and that is the whole point. An earlier version documented
+ * "`fn` must be total" and relied on the caller honouring it — which is not a guarantee, it is a
+ * hope. When it was violated the failure was maximally bad: `Promise.all` rejects on the first
+ * throw, the awaiting caller unwinds, and the R-1 peers still mid-flight are abandoned with their
+ * sandboxes alive and their shards unwritten — while the process exits BEFORE reporting, so nothing
+ * says what was lost. Downstream, `aggregate` accepts any non-empty shard set, so the run would
+ * publish quietly as a smaller experiment than the one dispatched. Making the failure path a typed
+ * parameter means a caller cannot forget it: the compiler asks what a failed item looks like.
+ *
+ * The old per-replicate matrix cells got this isolation from `fail-fast: false`; this is the
+ * in-process equivalent, and it must hold for the same reason.
+ */
+export async function runPooled<T, R>(
+	items: readonly T[],
+	limit: number,
+	fn: (item: T, index: number) => Promise<R>,
+	onError: (error: unknown, item: T, index: number) => R,
+): Promise<R[]> {
+	const results = new Array<R>(items.length);
+	let next = 0;
+	// A throw from `onError` ITSELF is a caller bug — but letting it propagate out of the catch below
+	// would reject this worker, and with it `Promise.all`, stranding the peers still mid-suite: the
+	// exact failure the required `onError` exists to make impossible, re-entered through the converter.
+	// So it is held here, every remaining item is still drained, and the bug is surfaced afterwards
+	// once nothing is in flight.
+	let converterError: { error: unknown } | undefined;
+	// The `max(1, …)` floor is the guard, not an optimisation: a `limit` below 1 reaching a generic pool
+	// would otherwise spawn zero workers and resolve immediately with a hole-filled array — silent data
+	// loss — rather than doing the work. (An empty `items` still costs one worker, which exits at once.)
+	const workers = Math.max(1, Math.min(items.length, limit));
+	await Promise.all(
+		Array.from({ length: workers }, async () => {
+			for (;;) {
+				const index = next++;
+				if (index >= items.length) return;
+				// Indexed inside the bounds check, so an item that is itself `undefined` (never the case
+				// for a replicate index, but the pool is generic) can't be read as "the queue is empty".
+				const item = items[index] as T;
+				try {
+					results[index] = await fn(item, index);
+				} catch (error) {
+					try {
+						results[index] = onError(error, item, index);
+					} catch (thrown) {
+						// First one wins; later converters fail for the same reason and the first is the
+						// one with the untruncated context. This slot stays a hole, which is sound only
+						// because the throw below stops any caller from reading the array at all.
+						converterError ??= { error: thrown };
+					}
+				}
+			}
+		}),
+	);
+	if (converterError) {
+		throw new Error(
+			`onError threw while converting a failed item, so the results are incomplete: ${
+				converterError.error instanceof Error
+					? (converterError.error.stack ?? converterError.error.message)
+					: String(converterError.error)
+			}`,
+		);
+	}
+	return results;
+}


### PR DESCRIPTION
**REPLICATE FAN-OUT — drive a cell's whole replicate fan-out from ONE runner instead of R idle ones**

Shipped as a 7-PR stack (merge bottom-up, each branch independently green):

1. #282 — schema: own the workflow timeout margin next to the suite budgets
2. #283 — harness: make result collection non-blocking so peer polls keep running
3. #284 — cli lib: the replicate fan-out primitives — pool, flags, budget guard ← **this PR**
4. #285 — cli lib: `[rN]` line tagging + a concurrency-safe Actions log layer
5. #286 — cli: report a replicate as an outcome instead of exiting from inside it
6. #287 — cli: drive a cell's whole replicate fleet from one process
7. #288 — ci: retire the replicate matrix axis and gate the new wiring

↑ **This PR is #284 (3/7)**, based on #283.

---
The between-machine axis (R sandboxes of one (provider, suite), the knob that captures a
provider's fleet variation) is a GitHub Actions matrix axis today: one runner per
(provider, suite, replicate). But a bench runner spends essentially all of its wall time WAITING on
its sandbox — create, poll a detached step, poll again — so R runners idle in lockstep while R
sandboxes do the work, and the runner-minutes bill scales with R for no throughput gain. At the
shipped defaults (6 providers x 9 suites, R=3 synthetic / R=12 realworld) that is 324 runners doing
54 runners' worth of driving.

This adds the library half of driving all R from one process, with nothing consuming it yet:

  * `parseReplicatesFlag` / `parseReplicateIndex` / `lastFlagValue` — the `--replicates` axis in
    both spellings (the JSON array plan-replicates already emits, and a comma-separated list for
    hand-typed runs). Blank, empty, non-integer and REPEATED indices all throw: a fan-out that
    silently collapsed to one sandbox, to none, or to two shards claiming one replicate slot would
    publish quietly as a smaller experiment than the one dispatched.
  * `replicatePaths` — each replicate's own raw tree plus a `-r<idx>`-suffixed shard file. The
    suffix is on the FILE, not a directory, because every shard of one run carries the same `runId`
    field and would otherwise collide on one name inside the cell's single artifact.
  * `resolveMaxConcurrency` / `resolveCellBudgetMinutes` / `fleetWaves` / `fleetBudgetError` — the
    optional cap for a provider whose quota is smaller than R, and the guard that refuses a cap
    up front when its ceil(R / cap) serial waves plus the host margin cannot fit the cell's job
    budget. Exceeding that budget is not a degraded run: the job is cancelled mid-fan-out and ALL R
    shards are lost at once, which is the whole-cell blast radius this design introduces.
  * `runPooled` — bounded concurrency, results in input order, and a REQUIRED `onError` so a
    throwing item cannot unwind the pool and strand its peers mid-suite. This is the in-process
    equivalent of the per-replicate matrix cells' `fail-fast: false`, and it has to hold for the
    same reason.

Host-side concurrency was already safe: the harness names every temp archive and staging dir with a
randomUUID so concurrent collects cannot collide, and each replicate gets its own raw tree and
shard. The module header records the one environment caveat (the Daytona adapter's process-global
DAYTONA_TARGET pin) and why it is currently harmless — every replicate of a cell pins the same
value.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds in-process replicate fan-out so one CLI process can drive all R replicates for a (provider, suite), cutting runner usage without changing provider-side concurrency. Adds a budget guard to block caps that would cancel the job mid-run and tightens flag parsing.

- **New Features**
  - Replicate selection parsing: `parseReplicatesFlag`/`parseReplicateIndex`/`lastFlagValue` support JSON array and comma-separated forms, disambiguate `--replicate` vs `--replicates`, and reject blanks, negatives, unsafe integers, and duplicates.
  - Per-replicate outputs: `replicatePaths` gives each replicate its own raw tree and a `-r<idx>`-suffixed shard file to avoid collisions.
  - Concurrency and budget guard: `resolveMaxConcurrency` (flag/env), `resolveCellBudgetMinutes`, `fleetWaves`, and `fleetBudgetError` refuse caps that would overrun the job budget, including `WORKFLOW_TIMEOUT_MARGIN_MINUTES` from `@sandbox-benchmarks/schema`.
  - Pooled execution: `runPooled` runs with bounded concurrency, returns results in input order, never rejects on item errors (requires `onError`), and only throws if `onError` itself throws after draining all work.

- **Bug Fixes**
  - `--max-concurrency=` now throws instead of silently unbounding the fleet; a blank `BENCH_MAX_CONCURRENCY` still means unbounded. Prevents masking a deliberate env cap.

<sup>Written for commit 84be90763fd785404fb29223ec92c65e7a655668. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/starslingdev/hpc-sandbox-benchmarks/pull/284?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

