### PR TITLE
feat(cli): tag concurrent replicate output and make the Actions log layer safe for it

### DIFF
--- a/apps/cli/src/lib/actions-log.ts
+++ b/apps/cli/src/lib/actions-log.ts
@@ -138,11 +138,29 @@ export async function logProviderStatuses(
 }
 
 /**
+ * Whether {@link withGroup} may emit `::group::` markers. Disabled by the concurrent replicate driver:
+ * Actions groups are a flat, ordered stream, so R concurrent replicates opening and closing groups
+ * interleave into folds that contain other replicates' output — worse than no folding at all. Those
+ * runs tag every line with its replicate instead (see ./log-prefix.ts).
+ */
+let groupingEnabled = true;
+
+/** Turn foldable Actions groups on/off process-wide (see {@link groupingEnabled}). */
+export function setGroupingEnabled(enabled: boolean): void {
+	groupingEnabled = enabled;
+}
+
+/**
  * Run `fn` inside a foldable Actions group when in CI; otherwise just await `fn` so local stdout
  * stays free of `::group::` prefixes (needed for single-line JSON contracts).
  */
 export async function withGroup<T>(title: string, fn: () => Promise<T> | T): Promise<T> {
-	if (inActions()) return await core.group(title, async () => fn());
+	if (inActions()) {
+		if (groupingEnabled) return await core.group(title, async () => fn());
+		// Grouping off: keep the title as a plain line so the transcript still announces each phase
+		// (it is the only thing marking where a replicate's setup ends and its benchmark begins).
+		logInfo(`--- ${title} ---`);
+	}
 	return await fn();
 }
 
@@ -155,7 +173,11 @@ export interface JobSummaryOptions {
 	fields: Array<[label: string, value: string, kind: CellKind]>;
 	/** Optional extra tables (e.g. provider status). */
 	tables?: Array<{ heading: string; rows: SummaryRow[] }>;
-	/** Optional free-form detail paragraph. */
+	/**
+	 * Optional free-form detail, rendered PREFORMATTED (`<pre>`) — line breaks are preserved and the
+	 * text does not re-wrap. Suits a multi-line list (e.g. one line per failing replicate); a long
+	 * prose paragraph will render monospaced and scroll horizontally rather than wrapping.
+	 */
 	detail?: string;
 	/**
 	 * Annotation for the run's annotations panel. Failures always annotate; successes stay in the
@@ -183,7 +205,13 @@ export async function writeJobSummary(opts: JobSummaryOptions): Promise<void> {
 			core.summary.addHeading(escapeHtml(table.heading), 4).addTable(table.rows);
 		}
 		if (opts.detail) {
-			core.summary.addRaw(escapeHtml(opts.detail)).addEOL();
+			// `<pre>`, not bare text. `addTable` emits `</table>` followed by a single newline, and GFM
+			// keeps an HTML block open until a BLANK line — so raw detail appended after a table is
+			// swallowed into that block, where its newlines become insignificant whitespace. A fleet
+			// report's failure list (one line per failing replicate, up to R lines) rendered as a single
+			// run-on paragraph, which is exactly the text the annotation tells the reader to come here
+			// for. `<pre>` both terminates the ambiguity and preserves the line breaks.
+			core.summary.addRaw(`<pre>${escapeHtml(opts.detail)}</pre>`).addEOL();
 		}
 		await core.summary.write();
 	}

--- a/apps/cli/src/lib/log-prefix.test.ts
+++ b/apps/cli/src/lib/log-prefix.test.ts
@@ -1,0 +1,212 @@
+import { describe, expect, it } from "bun:test";
+import { createTaggedWriter, prefixChunk, withLineTag } from "./log-prefix.ts";
+
+const TAG = "[r3] ";
+
+describe("prefixChunk", () => {
+	it("tags a whole line and leaves the stream at a line start", () => {
+		const state = { atLineStart: true };
+		expect(prefixChunk("hello\n", TAG, state)).toBe("[r3] hello\n");
+		expect(state.atLineStart).toBe(true);
+	});
+
+	it("tags every line of a multi-line chunk without a dangling trailing tag", () => {
+		const state = { atLineStart: true };
+		expect(prefixChunk("a\nb\nc\n", TAG, state)).toBe("[r3] a\n[r3] b\n[r3] c\n");
+	});
+
+	// Every writer on the tagged path emits whole lines today, but the line cursor is shared across R
+	// concurrent replicates, so a partial write must not corrupt the continuation.
+	it("does not tag the continuation of a partial line", () => {
+		const state = { atLineStart: true };
+		expect(prefixChunk("exit ", TAG, state)).toBe("[r3] exit ");
+		expect(state.atLineStart).toBe(false);
+		expect(prefixChunk("0 in 4.1s\n", TAG, state)).toBe("0 in 4.1s\n");
+		expect(state.atLineStart).toBe(true);
+	});
+
+	// A tagged `::error::` stops being an annotation and renders as literal text, so workflow commands
+	// pass through untouched.
+	it("passes workflow commands through unprefixed", () => {
+		const state = { atLineStart: true };
+		expect(prefixChunk("::error title=x::boom\n", TAG, state)).toBe("::error title=x::boom\n");
+		expect(state.atLineStart).toBe(true);
+	});
+
+	// StepRunner.finishStep writes a step's WHOLE stdout in one call. A chunk-level `::` check made a
+	// step whose first line began with `::` (an IPv6 literal) lose the tag for its entire transcript.
+	it("only exempts the ::-leading LINE, still tagging the rest of the chunk", () => {
+		const state = { atLineStart: true };
+		expect(prefixChunk("::1 listening\nline2\nline3\n", TAG, state)).toBe(
+			"::1 listening\n[r3] line2\n[r3] line3\n",
+		);
+	});
+
+	// Without the forced break, a partial line from one replicate welds the next replicate's
+	// annotation onto its end, where GitHub will not parse it — losing the cell's only failure signal.
+	it("forces a line break so a mid-line workflow command still parses", () => {
+		const state = { atLineStart: true };
+		const partial = prefixChunk("progress: 42%", "[r1] ", state);
+		const command = prefixChunk("::error title=t::boom\n", "[r0] ", state);
+		expect(partial + command).toBe("[r1] progress: 42%\n::error title=t::boom\n");
+	});
+
+	it("still tags a line that merely contains :: away from the start", () => {
+		const state = { atLineStart: true };
+		expect(prefixChunk("see foo::bar\n", TAG, state)).toBe("[r3] see foo::bar\n");
+	});
+
+	it("leaves an empty chunk alone", () => {
+		const state = { atLineStart: true };
+		expect(prefixChunk("", TAG, state)).toBe("");
+		expect(state.atLineStart).toBe(true);
+	});
+});
+
+describe("createTaggedWriter + withLineTag", () => {
+	/** A writer plus the chunks it received, standing in for a real stream. */
+	const spyWriter = (): { write: ReturnType<typeof createTaggedWriter>; written: string[] } => {
+		const written: string[] = [];
+		const write = createTaggedWriter((chunk) => {
+			written.push(String(chunk));
+			return true;
+		});
+		return { write, written };
+	};
+
+	it("tags writes inside a tagged context and leaves untagged writes alone", async () => {
+		const { write, written } = spyWriter();
+		await withLineTag("[r1] ", async () => {
+			write("inside\n");
+		});
+		write("outside\n");
+		expect(written).toEqual(["[r1] inside\n", "outside\n"]);
+	});
+
+	// The whole point: R replicates interleave on one stream, and each line must name its sandbox.
+	it("tags each concurrent replicate's lines with its own tag", async () => {
+		const { write, written } = spyWriter();
+		await Promise.all(
+			["[r0] ", "[r1] "].map((tag) =>
+				withLineTag(tag, async () => {
+					write("start\n");
+					await Bun.sleep(0);
+					write("done\n");
+				}),
+			),
+		);
+		expect(written.toSorted()).toEqual([
+			"[r0] done\n",
+			"[r0] start\n",
+			"[r1] done\n",
+			"[r1] start\n",
+		]);
+	});
+
+	// The cell's failure annotation is written AFTER the pool resolves, so it is untagged — and it is
+	// the one line that must survive. If the untagged path skipped the line-state machine, a replicate
+	// whose last chunk had no trailing newline would leave the cursor mid-line and the `::error::`
+	// would weld onto it, where the runner never parses it: the cell fails with no annotation.
+	it("forces a newline before an UNTAGGED workflow command left mid-line by the fan-out", async () => {
+		const { write, written } = spyWriter();
+		await withLineTag("[r0] ", async () => {
+			write("collecting results... ");
+		});
+		write("::error title=cell::realworld-mastra / e2b failed\n");
+		expect(written).toEqual([
+			"[r0] collecting results... ",
+			"\n::error title=cell::realworld-mastra / e2b failed\n",
+		]);
+	});
+
+	// The untagged path runs the same state machine, so it must not start prefixing or double-breaking
+	// ordinary output — an empty tag has to be a genuine no-op on everything but the two behaviours above.
+	it("leaves ordinary untagged output byte-for-byte unchanged", async () => {
+		const { write, written } = spyWriter();
+		write("Benchmark cell realworld-mastra / e2b\n");
+		write("partial ");
+		write("continuation\n");
+		write("::notice::at a line start already\n");
+		expect(written.join("")).toBe(
+			"Benchmark cell realworld-mastra / e2b\npartial continuation\n::notice::at a line start already\n",
+		);
+	});
+
+	it("carries the tag across an await inside the harness's async call graph", async () => {
+		const { write, written } = spyWriter();
+		const deepInSomeOtherPackage = async (): Promise<void> => {
+			await Promise.resolve();
+			write("nested\n");
+		};
+		await withLineTag("[r7] ", deepInSomeOtherPackage);
+		expect(written).toEqual(["[r7] nested\n"]);
+	});
+});
+
+// Run in a SUBPROCESS, not in-process: the thing under test is that Bun's native `console.log` — which
+// writes to the fd directly instead of calling process.stdout.write — is routed through the tagging
+// patch. Any in-process spy would have to replace process.stdout.write and would therefore bypass the
+// very layer being asserted. A live three-replicate run is what surfaced this: the harness's own
+// `console.log` step banners came out untagged while the echoed step output around them was tagged.
+describe("installLineTagging end to end (subprocess)", () => {
+	const MODULE = new URL("./log-prefix.ts", import.meta.url).pathname;
+
+	const runScript = async (body: string): Promise<string> => {
+		const proc = Bun.spawn(
+			[
+				"bun",
+				"-e",
+				`import { installLineTagging, withLineTag } from ${JSON.stringify(MODULE)};\n` +
+					`installLineTagging();\n${body}`,
+			],
+			{ stdout: "pipe", stderr: "pipe" },
+		);
+		const [stdout, exitCode] = await Promise.all([new Response(proc.stdout).text(), proc.exited]);
+		expect(exitCode).toBe(0);
+		return stdout;
+	};
+
+	it("tags console.log and process.stdout.write alike inside a tagged context", async () => {
+		const stdout = await runScript(
+			`await withLineTag("[r5] ", async () => {\n` +
+				`  console.log("=== [step] ===");\n` +
+				`  process.stdout.write("echoed\\n");\n` +
+				`});`,
+		);
+		expect(stdout).toBe("[r5] === [step] ===\n[r5] echoed\n");
+	});
+
+	it("leaves console.log untouched outside a tagged context", async () => {
+		expect(await runScript(`console.log("plain %s", "value");`)).toBe("plain value\n");
+	});
+
+	// The shape the harness actually uses on the tagged path: a message plus an Error
+	// (`console.error(msg, err)` in withSandbox). Bun.inspect renders the Error, uncoloured.
+	it("renders a message plus a non-string argument", async () => {
+		const stdout = await runScript(
+			`await withLineTag("[r2] ", async () => console.log("destroy failed:", { code: 7 }));`,
+		);
+		expect(stdout).toBe("[r2] destroy failed: {\n[r2]   code: 7,\n[r2] }\n");
+	});
+
+	// Pinned, not incidental: dropping node:util.format for Bun.inspect costs printf substitution, and
+	// no call site in the repo uses one. If a tagged printf call is ever added, this test is the
+	// tripwire that says renderArg must grow a formatter.
+	it("does not substitute printf directives while tagged (documented Bun.inspect trade)", async () => {
+		const stdout = await runScript(
+			`await withLineTag("[r0] ", async () => console.log("plain %s", "value"));`,
+		);
+		expect(stdout).toBe("[r0] plain %s value\n");
+	});
+
+	// Asserted in the subprocess for the same reason as the rest of this block, plus one of its own: a
+	// real `installLineTagging()` in THIS process would replace process.stdout/stderr and console.* for
+	// every test file scheduled after it. `runScript` already installs once, so the call below is the
+	// second — a patch that wrapped the writer twice would emit `[r4] [r4] once`.
+	it("is idempotent — a second install must not double the tag", async () => {
+		const stdout = await runScript(
+			`installLineTagging();\nawait withLineTag("[r4] ", async () => console.log("once"));`,
+		);
+		expect(stdout).toBe("[r4] once\n");
+	});
+});

--- a/apps/cli/src/lib/log-prefix.ts
+++ b/apps/cli/src/lib/log-prefix.ts
@@ -1,0 +1,189 @@
+/**
+ * Per-replicate line prefixing for the concurrent bench-suite driver.
+ *
+ * One runner now drives R replicate sandboxes at once (see ./replicates.ts), and every layer below —
+ * the harness's step logs, PTS output echoed back from a collected step, `@actions/core` info lines —
+ * writes to one shared stdout. Without a prefix the R interleaved transcripts are unreadable, and the
+ * single most common CI question ("which sandbox died?") becomes unanswerable from the log.
+ *
+ * The tag is carried in an {@link AsyncLocalStorage}, not passed down through the harness API, because
+ * the writers are `console.log`/`process.stdout.write` calls several packages deep whose only shared
+ * context is the async task they run under. Patching the streams once and reading the tag from the
+ * ambient async context tags every line a replicate emits — including ones from code that knows
+ * nothing about replicates — without threading a logger through the whole call graph.
+ */
+// `node:async_hooks` is the sole import: AsyncLocalStorage has no `Bun.*` equivalent (Bun implements
+// this API natively rather than exposing its own). Everything else here is Bun-native — argument
+// rendering goes through `Bun.inspect`, the inspector Bun's own console uses.
+import { AsyncLocalStorage } from "node:async_hooks";
+
+const tagStore = new AsyncLocalStorage<string>();
+
+/** Node's stream write signature, in the two shapes callers actually use. */
+type WriteFn = (
+	chunk: unknown,
+	encoding?: unknown,
+	callback?: (err?: Error | null) => void,
+) => boolean;
+
+/**
+ * Whether the stream is currently at the start of a line.
+ *
+ * One per stream, NOT per replicate — the bytes of R concurrent replicates land on one shared fd, so
+ * "is the cursor mid-line" is a property of that fd and cannot be tracked per writer. Every writer on
+ * the tagged path emits whole lines today (`StepRunner.finishStep` normalises a missing trailing
+ * newline, `core.info` appends EOL, the console patch appends `\n`), so the mid-line case is an
+ * anomaly rather than routine — but {@link prefixChunk} still has to survive it, because when it does
+ * happen it lands on the shared cursor and would otherwise corrupt whatever writes next.
+ */
+interface StreamState {
+	atLineStart: boolean;
+}
+
+/** Workflow commands (`::error::`, `::group::`, …) are parsed by the runner ONLY at the start of a
+ *  line. Prefixing one turns an annotation into literal text, so they are never tagged. */
+function isWorkflowCommand(line: string): boolean {
+	return line.startsWith("::");
+}
+
+/**
+ * Prefix each line START in `chunk` with `tag`, advancing `state`. A trailing newline does NOT emit a
+ * dangling prefix — the next chunk's write does that — so a blank prefixed line never appears at the
+ * end of the transcript.
+ *
+ * Two properties this has to get right, both of which an earlier line-blind version got wrong:
+ *
+ *  - The workflow-command check is PER LINE, not per chunk. `StepRunner.finishStep` writes a step's
+ *    entire stdout in ONE call, so a chunk-level check meant a step whose first line happened to
+ *    begin with `::` (an IPv6 literal like `::1`, say) lost the `[rN]` tag for its whole transcript —
+ *    exactly the multi-hundred-line block an operator needs attributed when one sandbox misbehaves.
+ *  - A workflow command that arrives mid-line gets a newline forced in front of it. Otherwise a
+ *    partial-line write by one replicate silently welds the next replicate's `::error::` onto the end
+ *    of that line, where the runner will not parse it — losing the cell's only failure annotation on
+ *    precisely the runs that have one. A stray line break in already-interleaved output is a trivial
+ *    price for keeping the annotation.
+ */
+export function prefixChunk(chunk: string, tag: string, state: StreamState): string {
+	if (chunk === "") return chunk;
+	const endsWithNewline = chunk.endsWith("\n");
+	const body = endsWithNewline ? chunk.slice(0, -1) : chunk;
+	const rendered = body.split("\n").map((line, i) => {
+		// Only the first line of a chunk can be a continuation; every later one follows a newline.
+		const atLineStart = i === 0 ? state.atLineStart : true;
+		if (isWorkflowCommand(line)) return atLineStart ? line : `\n${line}`;
+		return atLineStart ? `${tag}${line}` : line;
+	});
+	state.atLineStart = endsWithNewline;
+	return `${rendered.join("\n")}${endsWithNewline ? "\n" : ""}`;
+}
+
+/**
+ * A `write` that delegates to `original`, prefixing string chunks written inside {@link withLineTag}.
+ * Exported (rather than only applied to the real streams) so the async-context wiring is testable
+ * without mutating process.stdout, which every other test in the run shares.
+ */
+export function createTaggedWriter(original: WriteFn): WriteFn {
+	const state: StreamState = { atLineStart: true };
+	return (chunk, encoding, callback) => {
+		// An UNTAGGED write still goes through prefixChunk, with an empty tag. Skipping it entirely
+		// looks equivalent — an empty tag prefixes nothing — but it is not: prefixChunk also owns
+		// `state.atLineStart` and the forced newline before a mid-line workflow command. The writes
+		// that matter most here are untagged, because they happen after `runPooled` resolves and the
+		// async-context tag is gone: `reportFleet`'s `core.error` annotation and `fail()`. Let a
+		// replicate's last chunk end without a newline and the skip would weld the cell's ONLY failure
+		// annotation onto that dangling line, where the runner never parses it — precisely the loss the
+		// tagged path forces a break to avoid, arriving through the one path that had no guard.
+		const tag = tagStore.getStore() ?? "";
+		// Buffers pass through untouched: nothing in this CLI writes binary to stdout, and decoding one
+		// to prefix it would risk corrupting a multi-byte character split across chunks.
+		const rewritten = typeof chunk !== "string" ? chunk : prefixChunk(chunk, tag, state);
+		return original(rewritten, encoding, callback);
+	};
+}
+
+/** Wrap one stream's `write` so string chunks written inside {@link withLineTag} are prefixed. */
+function patchStream(stream: NodeJS.WriteStream): void {
+	const patched = createTaggedWriter(stream.write.bind(stream) as WriteFn);
+	(stream as unknown as { write: WriteFn }).write = patched;
+}
+
+/**
+ * Render one console argument the way the console itself would, using Bun's own inspector.
+ *
+ * Strings print verbatim (console never quotes a top-level string, while `Bun.inspect("a")` yields
+ * `"a"` with ANSI colour); every other value goes through `Bun.inspect`, which is what Bun's console
+ * uses for objects and Errors. Colours are off because a CI log is not a TTY — and because an ANSI
+ * escape at the head of a line would sit in front of the `::` that {@link prefixChunk} checks for.
+ *
+ * Deliberately NOT `node:util.format`: this drops printf substitution (`console.log("%s", x)` renders
+ * as `%s x` while a tag is active). No call site in apps/, packages/, or tooling/ uses a format
+ * directive — the tagged path's real shapes are a template literal, or a message plus an Error, both
+ * of which this renders identically — so the trade buys a Bun-native module with no node builtin for
+ * formatting. A future printf-style call inside the fan-out would need this to grow a formatter.
+ */
+function renderArg(value: unknown): string {
+	return typeof value === "string" ? value : Bun.inspect(value, { colors: false });
+}
+
+/**
+ * Route `console.*` through the patched streams while a tag is active.
+ *
+ * Patching the streams alone is NOT enough: Bun's `console.log` writes to the file descriptor
+ * natively rather than calling `process.stdout.write`, so a live three-replicate run showed the
+ * harness's own step banners (`=== [capture observed specs] ===`, every `console.log` in
+ * packages/harness) untagged while the echoed step output around them was tagged — the interleaved
+ * lines that most need attribution were the ones missing it. Untagged calls delegate to the original
+ * console so ordinary single-sandbox runs keep Bun's exact formatting and fast path.
+ */
+function patchConsole(): void {
+	// Which stream each console method prints to — matching Node/Bun's own routing. The stream objects
+	// are captured directly (not by name): `patchStream` replaces `write` ON the object, so a reference
+	// taken here still routes through the patch regardless of install order.
+	const routes = [
+		["log", process.stdout],
+		["info", process.stdout],
+		["debug", process.stdout],
+		["warn", process.stderr],
+		["error", process.stderr],
+	] as const;
+	for (const [method, stream] of routes) {
+		const original = console[method].bind(console);
+		console[method] = (...args: unknown[]): void => {
+			if (tagStore.getStore() === undefined) {
+				// Deliberately the NATIVE console, which writes to the fd without going through the
+				// patched `write` — so it does not update that stream's `atLineStart`. The known
+				// consequence: were an untagged console call to land while a tagged write had left the
+				// cursor mid-line, the next tagged line would be read as a continuation and lose its
+				// prefix. It cannot happen as this is wired, because the pool wraps each replicate's
+				// ENTIRE execution in withLineTag and AsyncLocalStorage carries that tag across every
+				// await and .then — so nothing untagged runs concurrently with a tagged write. Routing
+				// this branch through the patched stream instead would fix the desync at the cost of
+				// Bun's native formatting (and printf substitution) on every untagged line. If a future
+				// change ever emits untagged console output DURING a fan-out, revisit that trade.
+				original(...args);
+				return;
+			}
+			stream.write(`${args.map(renderArg).join(" ")}\n`);
+		};
+	}
+}
+
+let installed = false;
+
+/**
+ * Patch stdout/stderr (and `console.*`, which Bun does not route through them) so writes made inside
+ * {@link withLineTag} are line-prefixed. Idempotent, and a no-op for code outside a tagged context —
+ * so installing it is safe even on the single-replicate path, where nothing ever sets a tag.
+ */
+export function installLineTagging(): void {
+	if (installed) return;
+	installed = true;
+	patchStream(process.stdout);
+	patchStream(process.stderr);
+	patchConsole();
+}
+
+/** Run `fn` with every line it writes prefixed by `tag` (requires {@link installLineTagging}). */
+export function withLineTag<T>(tag: string, fn: () => Promise<T>): Promise<T> {
+	return tagStore.run(tag, fn);
+}


### PR DESCRIPTION
**REPLICATE FAN-OUT — drive a cell's whole replicate fan-out from ONE runner instead of R idle ones**

Shipped as a 7-PR stack (merge bottom-up, each branch independently green):

1. #282 — schema: own the workflow timeout margin next to the suite budgets
2. #283 — harness: make result collection non-blocking so peer polls keep running
3. #284 — cli lib: the replicate fan-out primitives — pool, flags, budget guard
4. #285 — cli lib: `[rN]` line tagging + a concurrency-safe Actions log layer ← **this PR**
5. #286 — cli: report a replicate as an outcome instead of exiting from inside it
6. #287 — cli: drive a cell's whole replicate fleet from one process
7. #288 — ci: retire the replicate matrix axis and gate the new wiring

↑ **This PR is #285 (4/7)**, based on #284.

---
One runner is about to drive R replicate sandboxes at once, and every layer below — the harness's
step banners, PTS output echoed back from a collected step, @actions/core info lines — writes to one
shared stdout. Without attribution the R interleaved transcripts are unreadable and the single most
common CI question ("which sandbox died?") is unanswerable from the log. Nothing consumes any of
this yet; the driver lands on top.

log-prefix.ts carries the tag in an AsyncLocalStorage rather than threading a logger through the
harness API, because the writers are console.log/process.stdout.write calls several packages deep
whose only shared context is the async task they run under. Patching the streams once and reading
the ambient tag prefixes every line a replicate emits, including lines from code that knows nothing
about replicates. Bun's console writes to the fd natively rather than through process.stdout.write,
so console.* is patched too — otherwise exactly the interleaved lines that most need attribution
(the harness's own banners) come out untagged.

Two properties prefixChunk has to get right, both of which a line-blind version got wrong:

  * The workflow-command check is PER LINE, not per chunk. StepRunner.finishStep writes a step's
    entire stdout in one call, so a chunk-level check meant a step whose first line happened to
    start with `::` (an IPv6 literal, say) lost its tag for the whole transcript.
  * A `::`-command arriving mid-line gets a newline forced in front of it. Otherwise one
    replicate's partial line welds the next replicate's `::error::` onto its end, where the runner
    will not parse it — losing the cell's only failure annotation on precisely the runs that have
    one. Untagged writes go through the same path for this reason: the writes that matter most here
    happen after the pool resolves, when the tag is gone.

actions-log.ts gains the two changes that same interleaving forces. `setGroupingEnabled(false)`
suppresses `::group::` markers, because Actions groups are a flat ordered stream and R concurrent
replicates opening and closing them produce folds containing other replicates' output — worse than
no folding; the title stays as a plain line so the transcript still marks each phase. And a job
summary's `detail` now renders inside `<pre>`: addTable emits `</table>` plus a single newline,
and GFM keeps an HTML block open until a BLANK line, so raw detail appended after a table was
swallowed into it with its newlines turned into insignificant whitespace — a one-line-per-failure
list rendered as a run-on paragraph, which is exactly the text an annotation sends a reader there
to read.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds per-line replicate tags across stdout/stderr and `console.*` for concurrent runs, and makes GitHub Actions logging safe so interleaved output stays readable and workflow commands still parse.

- New Features
  - Adds `installLineTagging()` and `withLineTag(tag, fn)`; carries tags via `AsyncLocalStorage`, and patches `process.stdout`, `process.stderr`, and `console.*` (idempotent; buffers untouched).
  - Per-line rules: skip lines that start with `::`; if `::` appears mid-line, insert a newline first. Applied to untagged writes too so post-fan-out annotations still parse.
  - Adds `setGroupingEnabled()` to toggle Actions groups; when off, `withGroup` prints `--- title ---` instead of `::group::`.

- Bug Fixes
  - Wraps job summary `detail` in `<pre>` to preserve line breaks after tables in `@actions/core` summaries.

<sup>Written for commit 28d0af7e48cbf0d849f2515df82853dd0e35eadc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/starslingdev/hpc-sandbox-benchmarks/pull/285?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

