### PR TITLE
refactor(cli): report a replicate as an outcome instead of exiting from inside it

### DIFF
--- a/apps/cli/src/bin/bench-suite.test.ts
+++ b/apps/cli/src/bin/bench-suite.test.ts
@@ -1,5 +1,53 @@
 import { describe, expect, it } from "bun:test";
-import { parseReplicateFlag } from "./bench-suite.ts";
+import { PROVIDERS, SUITE_NAMES } from "@sandbox-benchmarks/schema";
+import { formatDuration, HELP, parseReplicateFlag } from "./bench-suite.ts";
+
+/** The ids `runSuite` actually matches on: it compares against the schema-joined adapter names
+ *  EXACTLY, so `LEGACY_PROVIDER_ALIASES` ("daytona", "modal") does not rescue a copied example.
+ *  Widened to `string[]` because the values under test are parsed out of the help text — the whole
+ *  point is to check an arbitrary string against the registry, which the literal union forbids. */
+const providerIds: string[] = PROVIDERS.map((p) => p.id);
+const suiteNames: string[] = [...SUITE_NAMES];
+
+describe("HELP", () => {
+	// The usage block is copy-paste surface: an operator (or an agent) runs an example verbatim. Every
+	// id it names must therefore be one the registry actually resolves. It drifted once already — the
+	// examples said "daytona"/"modal" while the registry had only `daytona-vm`, `daytona-container`,
+	// `modal-gvisor`, and `modal-vm`, so a copied line failed as an unknown provider. Pin the example
+	// lines against the registries rather than against a hardcoded list, so adding or renaming an id
+	// keeps this honest.
+	// Scoped to the `examples:` block: the prose headline and the `usage:` synopsis also begin with the
+	// binary name, but they carry placeholders ("[provider]"), not runnable ids.
+	const exampleArgs = HELP.slice(HELP.indexOf("\nexamples:"))
+		.split("\n")
+		.filter((line) => line.trim().startsWith("bench-suite "))
+		.map((line) =>
+			line
+				.trim()
+				.replace(/\s+#.*$/, "")
+				.split(/\s+/)
+				.slice(1),
+		)
+		.map((args) => args.filter((arg) => !arg.startsWith("-")));
+
+	it("names only registered providers and suites in its examples", () => {
+		expect(exampleArgs.length).toBeGreaterThan(0);
+		for (const args of exampleArgs) {
+			const [provider, suite] = args;
+			// A leading positional is always a provider id; the second, when present, is a suite. Later
+			// positionals are runIds and flag operands, which are free-form.
+			if (provider !== undefined) expect(providerIds).toContain(provider);
+			if (suite !== undefined) expect(suiteNames).toContain(suite);
+		}
+	});
+
+	// The documented default has to be the one the code actually takes, or `--help` teaches a provider
+	// that never runs.
+	it("documents the default provider the code falls back to", () => {
+		expect(HELP).toContain("(default: daytona-vm)");
+		expect(providerIds).toContain("daytona-vm");
+	});
+});
 
 describe("parseReplicateFlag", () => {
 	it("returns undefined when the flag is absent", () => {
@@ -24,5 +72,26 @@ describe("parseReplicateFlag", () => {
 		expect(() => parseReplicateFlag(["--replicate", "-1"])).toThrow(/non-negative integer/);
 		expect(() => parseReplicateFlag(["--replicate", "1.5"])).toThrow(/non-negative integer/);
 		expect(() => parseReplicateFlag(["--replicate", "x"])).toThrow(/non-negative integer/);
+	});
+});
+
+describe("formatDuration", () => {
+	// The unit switch matters: a cell's budget is quoted in minutes, so a straggler has to be
+	// comparable to it at a glance, while a fast replicate should not read as "0m".
+	it("keeps sub-minute elapsed in seconds", () => {
+		expect(formatDuration(0)).toBe("0s");
+		expect(formatDuration(1_499)).toBe("1s");
+		expect(formatDuration(59_400)).toBe("59s");
+	});
+
+	it("switches to minutes and zero-pads the seconds", () => {
+		expect(formatDuration(60_000)).toBe("1m00s");
+		expect(formatDuration(74_000)).toBe("1m14s");
+		expect(formatDuration(8 * 60_000 + 37_000)).toBe("8m37s");
+	});
+
+	// 59.6s rounds to 60 seconds, which must not render as "0m60s".
+	it("carries a rounded-up 60th second into the minute", () => {
+		expect(formatDuration(59_600)).toBe("1m00s");
 	});
 });

--- a/apps/cli/src/bin/bench-suite.ts
+++ b/apps/cli/src/bin/bench-suite.ts
@@ -4,6 +4,10 @@
 // recorded as a skip (the provider stays `pending` in the Run), so this is runnable without secrets.
 // Logging and results go through @actions/core (groups, debug, annotations, job summary) so the
 // nested "<suite> / <provider>" cell is metadata-rich in the Actions UI.
+//
+// One invocation runs ONE replicate sandbox and reports it as a {@link ReplicateOutcome} rather than
+// exiting from inside the run: the concurrent fan-out that lands on top of this drives R of them from
+// one process, where a replicate that dies must not take its peers' sandboxes down with it.
 
 import { join } from "node:path";
 import * as core from "@actions/core";
@@ -16,6 +20,7 @@ import {
 } from "@sandbox-benchmarks/harness";
 import { writeNormalizedRun } from "@sandbox-benchmarks/results";
 import type { Run } from "@sandbox-benchmarks/schema";
+import type { CellKind, SummaryRow } from "../lib/actions-log.ts";
 import {
 	fail,
 	inActions,
@@ -27,6 +32,7 @@ import {
 	writeJobSummary,
 } from "../lib/actions-log.ts";
 import { handleDiscovery } from "../lib/discovery.ts";
+import { lastFlagValue, parseReplicateIndex } from "../lib/replicates.ts";
 import { suiteMetricSummaryRows, suiteTaskSummaryRows } from "../lib/suite-summary.ts";
 import type { SuiteTaskPlan } from "../lib/suite-tasks.ts";
 import { describeSuiteTasks } from "../lib/suite-tasks.ts";
@@ -42,13 +48,21 @@ function miseTaskSummary(plan: SuiteTaskPlan): string {
 	return `${plural(commands, "command")} → ${plural(leaves, "leaf task")}`;
 }
 
-/** Agent-facing usage; bare invocation keeps the daytona/cpu-node local-dev default. */
+/** The Actions-visible name of a (suite, provider) cell — the job-summary heading, the annotation
+ *  title, and the log line, all of which have to agree for a reader to connect them. */
+function cellTitle(suite: string, provider: string): string {
+	return `${suite} / ${provider}`;
+}
+
+/** Agent-facing usage; bare invocation keeps the daytona-vm/cpu-node local-dev default. Every provider
+ *  named here is a canonical {@link ProviderId} — the positional argument is matched against the
+ *  registry exactly, so a copied example that said "daytona" or "modal" would fail as unknown. */
 export const HELP = `bench-suite — run a benchmark suite on a provider sandbox and normalize it into a Run document.
 
 usage: bench-suite [provider] [suite] [runId]
        bench-suite [--help] [--list-providers] [--list-suites] [--json]
 
-  provider           Provider to run on (default: daytona). See --list-providers.
+  provider           Provider to run on (default: daytona-vm). See --list-providers.
   suite              Suite to run (default: cpu-node). See --list-suites.
   runId              Run identifier for the data/ tree (default: local-<timestamp>).
   --replicate <idx>  Replicate sandbox index this shard represents (a non-negative integer). Stamped
@@ -64,50 +78,141 @@ Missing provider credentials are recorded as a skip (the provider stays "pending
 runnable without secrets. Writes data/runs/<runId>.json and updates data/runs/index.json.
 
 examples:
-  bench-suite daytona cpu-node            # one suite locally, auto runId
-  bench-suite modal memory ci-1234        # a specific cell + runId
+  bench-suite daytona-vm cpu-node         # one suite locally, auto runId
+  bench-suite modal-vm memory ci-1234     # a specific cell + runId
   bench-suite e2b memory --require e2b    # fail (don't skip) if E2B_API_KEY is absent
   bench-suite --list-suites               # discover the suite names first
 
 Next: render the Run with \`leaderboard data/runs/<runId>.json\`.`;
 
-/** One exit path for every cell outcome — success, usage error, normalize failure, suite gap, require. */
-async function reportCell(opts: {
+/** What one replicate produced. Returned, never exited on: a replicate that dies must not take a
+ *  concurrent peer's sandbox down with it, so the caller decides the process exit code once, at the end. */
+export interface ReplicateOutcome {
+	/** The replicate index, or undefined for the single un-indexed run (local/smoke). */
+	index?: number;
+	/** Where this replicate's shard Run belongs. Always set — including on a failure that never got as
+	 *  far as writing it — so a summary can name the missing shard rather than blanking the cell. */
+	outFile: string;
+	/** The normalized shard Run, absent when normalization itself failed. */
+	run?: Run;
+	failed: boolean;
+	/** Why it failed (or a note about a recorded gap) — the annotation/summary text. */
+	detail?: string;
+	/**
+	 * Wall-clock milliseconds this replicate took, end to end.
+	 *
+	 * Recorded because collapsing the runner axis DELETED it: when every replicate was its own job,
+	 * the Actions UI listed R durations for free, and a straggler was obvious. Driven from one runner
+	 * they share a single job duration, so without this a report cannot say which sandbox was slow —
+	 * and a straggler is precisely what puts the cell near its `timeout-minutes`, where the whole
+	 * fleet's shards are lost at once rather than one replicate's.
+	 */
+	durationMs: number;
+}
+
+/** Elapsed wall clock, rendered for a summary cell: sub-minute stays in seconds, longer reads as
+ *  `m` + `s` so a straggler is legible against a job budget quoted in minutes. */
+export function formatDuration(ms: number): string {
+	const totalSeconds = Math.round(ms / 1000);
+	if (totalSeconds < 60) return `${totalSeconds}s`;
+	return `${Math.floor(totalSeconds / 60)}m${String(totalSeconds % 60).padStart(2, "0")}s`;
+}
+
+/** A short, stable label for one replicate in logs and summary tables. */
+function replicateLabel(index: number | undefined): string {
+	return index === undefined ? "single" : `r${index}`;
+}
+
+/**
+ * Parse `--replicate <idx>` / `--replicate=<idx>` into a non-negative integer, or `undefined` when the
+ * flag is absent. A dangling or non-integer value fails loudly rather than silently defaulting the shard
+ * to replicate 0 — a wrong index would collide two sandboxes into one replicate slot at aggregate time.
+ * Exported so the parsing is unit-testable without spawning a process. (This is the single-sandbox
+ * spelling, sharing its validation with the plural `--replicates` in ../lib/replicates.ts.)
+ */
+export function parseReplicateFlag(argv: readonly string[]): number | undefined {
+	const raw = lastFlagValue(argv, "replicate");
+	if (raw === undefined) return undefined;
+	return parseReplicateIndex(raw);
+}
+
+/** Identity of the cell being reported. */
+interface CellIdentity {
 	provider: string;
 	suite: string;
 	runId: string;
-	sha?: string;
-	outFile?: string;
-	run?: Run;
-	failed: boolean;
-	detail?: string;
+	sha: string;
+	/** The suite's resolved task plan, absent when discovery failed (the summary then omits it). */
 	taskPlan?: SuiteTaskPlan;
-}): Promise<void> {
-	const title = `${opts.suite} / ${opts.provider}`;
-	const status = opts.failed ? "failure" : "success";
-	const provider = opts.run?.providers.find((p) => p.providerId === opts.provider);
-	const annotationMessage =
-		opts.detail ??
-		(provider
-			? `${provider.providerId} ${provider.validationStatus} metrics=${provider.metrics.length}`
-			: title);
-	const taskTables = opts.taskPlan
-		? [
-				{ heading: "Mise tasks", rows: suiteTaskSummaryRows(opts.taskPlan) },
-				{ heading: "Declared metrics", rows: suiteMetricSummaryRows(opts.taskPlan) },
-			]
-		: [];
+}
+
+/**
+ * The half of a cell's job summary that does NOT depend on how many sandboxes ran: heading, cell
+ * identity, the suite's task plan, and the annotation wiring. `fields`/`tables` are appended to it, so
+ * a report covering several sandboxes can reuse the shared half instead of restating it — and a change
+ * to that half cannot land in one reporter and miss the other.
+ */
+async function writeCellSummary(
+	opts: CellIdentity & {
+		failed: boolean;
+		/** Report-specific field rows, rendered after the cell identity. */
+		fields: Array<[label: string, value: string, kind: CellKind]>;
+		/** Report-specific tables, rendered before the task-plan tables. */
+		tables: Array<{ heading: string; rows: SummaryRow[] }>;
+		detail?: string;
+		annotationMessage: string;
+	},
+): Promise<void> {
+	const title = cellTitle(opts.suite, opts.provider);
+	const plan = opts.taskPlan;
 	await writeJobSummary({
 		heading: title,
 		fields: [
-			["Status", status, "plain"],
+			["Status", opts.failed ? "failure" : "success", "plain"],
 			["Suite", opts.suite, "code"],
 			["Provider", opts.provider, "code"],
 			["Run id", opts.runId, "code"],
-			["SHA", opts.sha ?? "", "code"],
-			["Artifact", opts.outFile ?? "", "code"],
-			["Harness commands", opts.taskPlan?.commands.join(" · ") ?? "", "code"],
-			["Mise tasks", opts.taskPlan ? miseTaskSummary(opts.taskPlan) : "", "plain"],
+			["SHA", opts.sha, "code"],
+			...opts.fields,
+			["Harness commands", plan?.commands.join(" · ") ?? "", "code"],
+			["Mise tasks", plan ? miseTaskSummary(plan) : "", "plain"],
+		],
+		tables: [
+			...opts.tables,
+			...(plan
+				? [
+						{ heading: "Mise tasks", rows: suiteTaskSummaryRows(plan) },
+						{ heading: "Declared metrics", rows: suiteMetricSummaryRows(plan) },
+					]
+				: []),
+		],
+		detail: opts.detail,
+		annotation: { failed: opts.failed, title, message: opts.annotationMessage },
+	});
+}
+
+/**
+ * The single-sandbox report: ONE cell, described in full. This is what a human reads after a manual
+ * bench-smoke dispatch or a local run, so it keeps the whole-Run provider table (every registered
+ * provider, with the skipped/failed gap split) and names the target provider's validation state in the
+ * annotation itself.
+ */
+async function reportCell(
+	opts: CellIdentity & {
+		outFile: string;
+		run?: Run;
+		failed: boolean;
+		detail?: string;
+		durationMs: number;
+	},
+): Promise<void> {
+	const provider = opts.run?.providers.find((p) => p.providerId === opts.provider);
+	await writeCellSummary({
+		// Identity + failed/detail ride through as-is; `outFile`/`run` are spent on the rows below.
+		...opts,
+		fields: [
+			["Artifact", opts.outFile, "code"],
+			["Duration", formatDuration(opts.durationMs), "plain"],
 			["Validation", provider?.validationStatus ?? (opts.run ? "absent" : ""), "plain"],
 			["Metrics", provider ? String(provider.metrics.length) : "", "plain"],
 			["Suites covered", provider ? String(provider.suitesCovered.length) : "", "plain"],
@@ -119,146 +224,61 @@ async function reportCell(opts: {
 				"plain",
 			],
 		],
-		tables: [
-			...taskTables,
-			...(opts.run ? [{ heading: "Provider status", rows: providerSummaryRows(opts.run) }] : []),
-		],
-		detail: opts.detail,
-		annotation: {
-			failed: opts.failed,
-			title,
-			message: annotationMessage,
-		},
+		tables: opts.run ? [{ heading: "Provider status", rows: providerSummaryRows(opts.run) }] : [],
+		annotationMessage:
+			opts.detail ??
+			(provider
+				? `${provider.providerId} ${provider.validationStatus} metrics=${provider.metrics.length}`
+				: cellTitle(opts.suite, opts.provider)),
 	});
 }
 
-type CellReport = Parameters<typeof reportCell>[0];
-
-/** Write the cell summary then fail without a second annotation. */
-async function failCell(opts: Omit<CellReport, "failed"> & { detail: string }): Promise<never> {
-	await reportCell({ ...opts, failed: true });
-	return fail(opts.detail, { annotate: false });
+/** Everything one replicate needs; `replicateIndex` undefined is the single un-indexed run. */
+interface ReplicateContext {
+	provider: string;
+	suite: string;
+	runId: string;
+	sha: string;
+	rawRoot: string;
+	outFile: string;
+	indexFile: string;
+	replicateIndex?: number;
+	/** Providers that must reach "validated" for this replicate to count as a success. */
+	required: readonly string[];
 }
 
 /**
- * Parse `--replicate <idx>` / `--replicate=<idx>` into a non-negative integer, or `undefined` when the
- * flag is absent. A dangling or non-integer value fails loudly rather than silently defaulting the shard
- * to replicate 0 — a wrong index would collide two sandboxes into one replicate slot at aggregate time.
- * Exported so the parsing is unit-testable without spawning a process.
+ * Run ONE replicate end to end — suite → normalize → gap verification → require gate — and report
+ * what happened. Total by construction: it never throws and never exits, so a concurrent driver can
+ * hold several in flight without one replicate's failure aborting its peers or skipping their shard
+ * writes (the per-replicate matrix cells had `fail-fast: false` for the same reason).
  */
-export function parseReplicateFlag(argv: readonly string[]): number | undefined {
-	let raw: string | undefined;
-	for (let i = 0; i < argv.length; i++) {
-		const arg = argv[i];
-		if (arg === "--replicate") {
-			raw = argv[i + 1];
-			if (raw === undefined) throw new Error("--replicate requires an index argument");
-		} else if (arg?.startsWith("--replicate=")) {
-			raw = arg.slice("--replicate=".length);
-		}
-	}
-	if (raw === undefined) return undefined;
-	const idx = Number(raw);
-	// Number("")/Number("  ")/Number("\n") all coerce to 0, so `--replicate=` (or `--replicate ""`) would
-	// slip through as replicate 0 — guard the blank operand explicitly, else it silently collides two
-	// sandboxes into one replicate slot at aggregate time (the exact failure this function documents).
-	if (raw.trim() === "" || !Number.isInteger(idx) || idx < 0) {
-		throw new Error(`--replicate must be a non-negative integer; got "${raw}"`);
-	}
-	return idx;
-}
-
-if (import.meta.main) {
-	const argv = process.argv.slice(2);
-	// Flags that consume a separate operand — one source of truth so the discovery filter and the
-	// positional-skip loop below can never enumerate different sets.
-	const VALUE_FLAGS = ["--require", "--replicate"];
-	const discovery = handleDiscovery(argv, HELP, VALUE_FLAGS);
-	if (discovery !== null) {
-		if (discovery.ok) {
-			process.stdout.write(`${discovery.text}\n`);
-			process.exit(0);
-		}
-		fail(discovery.text, { properties: { title: "bench-suite discovery" }, exitCode: 2 });
-	}
-
-	// Filter flags out before positional resolution so a trailing/misplaced flag (e.g.
-	// `bench-suite daytona cpu-node --json`) never gets captured as the runId. `--require` is the one
-	// flag that takes a separate operand, so consume that operand too — otherwise `--require daytona`
-	// would leave `daytona` behind to be read as the runId.
-	const positionals: string[] = [];
-	for (let i = 0; i < argv.length; i++) {
-		const arg = argv[i];
-		if (arg === undefined) continue;
-		// Only the space-separated spelling needs the skip: `--require=<ids>`/`--replicate=<idx>` are
-		// single tokens already dropped by the leading-`-` guard below. Both flags take a separate operand.
-		if (VALUE_FLAGS.includes(arg)) {
-			i++;
-			continue;
-		}
-		if (arg.startsWith("-")) continue;
-		positionals.push(arg);
-	}
-	const provider = positionals[0] ?? "daytona-vm";
-	const suite = positionals[1] ?? "cpu-node";
-	const runId = positionals[2] ?? `local-${Date.now()}`;
-	const sha = process.env.GITHUB_SHA ?? "local";
-	const cell = `${suite} / ${provider}`;
-	const replicateIndex = parseReplicateFlag(argv);
-
-	const rawRoot = join("data", "raw", runId);
-	const outFile = join("data", "runs", `${runId}.json`);
-	const indexFile = join("data", "runs", "index.json");
-
-	logInfo(`Benchmark cell ${cell}`);
-	if (inActions()) {
-		core.debug(
-			JSON.stringify({
-				provider,
-				suite,
-				runId,
-				sha,
-				rawRoot,
-				outFile,
-				require: requiredProviders(argv),
-			}),
-		);
-	}
-
-	// Resolve the precise mise tasks + PTS pins before the sandbox run so the job summary can name
-	// what this cell planned to execute (schema commands → mise task info → run_task leaves).
-	let taskPlan: SuiteTaskPlan | undefined;
-	await withGroup(`Discover suite tasks (${suite})`, async () => {
-		try {
-			taskPlan = await describeSuiteTasks(suite);
-			logInfo(`commands: ${taskPlan.commands.join(" · ")}`);
-			for (const task of taskPlan.tasks) {
-				const pts = task.ptsProfile ? ` pts=${task.ptsProfile}` : "";
-				const prefix = task.resultsPrefix ? ` prefix=${task.resultsPrefix}` : "";
-				logInfo(
-					`${task.role} ${task.task}${task.description ? ` — ${task.description}` : ""}${pts}${prefix}`,
-				);
-			}
-			if (inActions()) {
-				for (const metric of taskPlan.metrics) {
-					core.debug(
-						`metric ${metric.id} label=${metric.label}` +
-							(metric.ptsTest ? ` pts.test=${metric.ptsTest}` : ""),
-					);
-				}
-			}
-		} catch (err) {
-			const msg = `Could not describe suite tasks for "${suite}": ${err instanceof Error ? err.message : String(err)}`;
-			logWarning(msg, { title: cell });
-		}
-	});
+export async function runReplicate(ctx: ReplicateContext): Promise<ReplicateOutcome> {
+	const { provider, suite, runId, sha, rawRoot, outFile, indexFile, replicateIndex } = ctx;
+	// The replicate rides in the annotation TITLE: annotations are emitted as `::warning::` workflow
+	// commands, so once several replicates share a process there is nothing else in a warning saying
+	// which sandbox it came from.
+	const cell =
+		cellTitle(suite, provider) +
+		(replicateIndex === undefined ? "" : ` ${replicateLabel(replicateIndex)}`);
+	const startedAt = Bun.nanoseconds();
+	// A getter, so every `...base` spread below stamps the elapsed time AT ITS OWN return rather than
+	// freezing it here, before the suite has even started.
+	const base = {
+		index: replicateIndex,
+		outFile,
+		get durationMs() {
+			return Math.round((Bun.nanoseconds() - startedAt) / 1e6);
+		},
+	};
 
 	// A suite that RAN AND BROKE is a result — the harness has already written its `--failed.json` marker
 	// into the raw tree — so the error is held, not thrown. Normalizing anyway is what turns that marker
 	// into a recorded `failed` gap on this shard's Run document; rethrowing here would skip the write, the
 	// shard would contribute nothing for the aggregate to merge, and the only trace of the failure would
-	// die inside the CI artifact. The job still goes red at the bottom of this block.
+	// die inside the CI artifact. The replicate still reports failed at the bottom of this block.
 	let suiteError: unknown;
+	let usageError: string | undefined;
 	await withGroup(`Run suite ${suite} on ${provider}`, async () => {
 		try {
 			await runSuite({
@@ -274,15 +294,8 @@ if (import.meta.main) {
 			// A usage error (unknown provider/suite) produced no raw tree and no marker: there is nothing to
 			// normalize, and pretending otherwise would write an empty Run for a cell that never existed.
 			if (err instanceof SuiteUsageError) {
-				await failCell({
-					provider,
-					suite,
-					runId,
-					sha,
-					outFile,
-					detail: err.message,
-					taskPlan,
-				});
+				usageError = err.message;
+				return;
 			}
 			suiteError = err;
 			logWarning(
@@ -293,6 +306,7 @@ if (import.meta.main) {
 			);
 		}
 	});
+	if (usageError !== undefined) return { ...base, failed: true, detail: usageError };
 
 	let run: Run | undefined;
 	let normalizeError: unknown;
@@ -321,18 +335,7 @@ if (import.meta.main) {
 				: normalizeError
 					? String(normalizeError)
 					: "normalize produced no Run document";
-		await reportCell({
-			provider,
-			suite,
-			runId,
-			sha,
-			outFile,
-			failed: true,
-			detail,
-			taskPlan,
-		});
-		// Synchronous `never` so TypeScript narrows `run` for the paths below.
-		fail(detail, { annotate: false });
+		return { ...base, failed: true, detail };
 	}
 	const normalized = run;
 
@@ -361,31 +364,19 @@ if (import.meta.main) {
 			? `Suite "${suite}" failed on ${provider} — recorded as a failed gap in ${outFile}: ${message}`
 			: `Suite "${suite}" failed on ${provider} but no gap could be recorded in ${outFile} ` +
 				`(no failed marker survived into the raw tree; this job log is the only trace): ${message}`;
-		await failCell({
-			provider,
-			suite,
-			runId,
-			sha,
-			outFile,
-			run: normalized,
-			detail,
-			taskPlan,
-		});
+		return { ...base, run: normalized, failed: true, detail };
 	}
 
 	// Missing credentials (and an unusable sandbox) are recorded as a skip, not a throw — the lenient
 	// local-dev default. That would make a smoke run whose secret is missing/misnamed exit 0 having
 	// benchmarked nothing, so CI passes `--require <provider>` (or REQUIRE_PROVIDERS) to assert the
 	// provider actually reached `validated` — i.e. produced at least one catalogued metric.
-	// Pass the sliced argv explicitly rather than letting it default to `process.argv` (which also
-	// carries the bun executable and script path), so the flag this bin parses is the flag this gate reads.
-	const required = requiredProviders(argv);
-	if (required.length > 0) {
+	if (ctx.required.length > 0) {
 		const reports = normalized.providers.map((p) => ({
 			provider: p.providerId,
 			status: p.validationStatus === "validated" ? "ok" : p.validationStatus,
 		}));
-		const unmet = unmetRequirements(reports, required);
+		const unmet = unmetRequirements(reports, ctx.required);
 		if (unmet.length > 0) {
 			const details: string[] = [];
 			for (const providerId of unmet) {
@@ -397,28 +388,145 @@ if (import.meta.main) {
 				const line = `Required provider "${providerId}" produced no metrics${gapDetail ? ` — ${gapDetail}` : " and was absent from the Run"}`;
 				details.push(line);
 			}
-			await failCell({
+			return { ...base, run: normalized, failed: true, detail: details.join("\n") };
+		}
+	}
+
+	logInfo(`Cell ${cell} succeeded → ${outFile}`);
+	return { ...base, run: normalized, failed: false };
+}
+
+if (import.meta.main) {
+	const argv = process.argv.slice(2);
+	// Flags that consume a separate operand — one source of truth so the discovery filter and the
+	// positional-skip loop below can never enumerate different sets.
+	const VALUE_FLAGS = ["--require", "--replicate"];
+	const discovery = handleDiscovery(argv, HELP, VALUE_FLAGS);
+	if (discovery !== null) {
+		if (discovery.ok) {
+			process.stdout.write(`${discovery.text}\n`);
+			process.exit(0);
+		}
+		fail(discovery.text, { properties: { title: "bench-suite discovery" }, exitCode: 2 });
+	}
+
+	// Filter flags out before positional resolution so a trailing/misplaced flag (e.g.
+	// `bench-suite daytona-vm cpu-node --json`) never gets captured as the runId. The VALUE_FLAGS above
+	// are the ones that take a separate operand, so consume that operand too — otherwise
+	// `--require daytona-vm` would leave `daytona-vm` behind to be read as the runId.
+	const positionals: string[] = [];
+	for (let i = 0; i < argv.length; i++) {
+		const arg = argv[i];
+		if (arg === undefined) continue;
+		// Only the space-separated spelling needs the skip: `--require=<ids>`/`--replicate=<idx>` are
+		// single tokens already dropped by the leading-`-` guard below. Both flags take a separate operand.
+		if (VALUE_FLAGS.includes(arg)) {
+			i++;
+			continue;
+		}
+		if (arg.startsWith("-")) continue;
+		positionals.push(arg);
+	}
+	const provider = positionals[0] ?? "daytona-vm";
+	const suite = positionals[1] ?? "cpu-node";
+	const runId = positionals[2] ?? `local-${Date.now()}`;
+	const sha = process.env.GITHUB_SHA ?? "local";
+	const cell = cellTitle(suite, provider);
+
+	// A malformed replicate index must fail the cell before a sandbox is created: a shard stamped with
+	// the wrong index would collide two sandboxes into one replicate slot at aggregate time.
+	let replicateIndex: number | undefined;
+	try {
+		replicateIndex = parseReplicateFlag(argv);
+	} catch (err) {
+		fail(err instanceof Error ? err.message : String(err), {
+			properties: { title: "bench-suite usage" },
+			exitCode: 2,
+		});
+	}
+
+	// The local newest-first Run index — a local convenience only (`leaderboard data/runs/<id>.json`
+	// discovery). Nothing downstream reads it: the aggregate is handed explicit shard paths.
+	const indexFile = join("data", "runs", "index.json");
+	// Hoisted so the debug payload below can name them. They are the diagnostic an artifact-path
+	// failure is read with — "which tree did it pull into, which file did it normalize to" — and
+	// nothing else in the single-sandbox report carries rawRoot at all.
+	const rawRoot = join("data", "raw", runId);
+	const outFile = join("data", "runs", `${runId}.json`);
+	// Pass the sliced argv explicitly rather than letting it default to `process.argv` (which also
+	// carries the bun executable and script path), so the flag this bin parses is the flag the require
+	// gate inside the replicate reads.
+	const required = requiredProviders(argv);
+
+	logInfo(`Benchmark cell ${cell}`);
+	if (inActions()) {
+		core.debug(
+			JSON.stringify({
 				provider,
 				suite,
 				runId,
 				sha,
+				replicate: replicateIndex ?? null,
+				rawRoot,
 				outFile,
-				run: normalized,
-				detail: details.join("\n"),
-				taskPlan,
-			});
-		}
+				require: required,
+			}),
+		);
 	}
 
+	// Resolve the precise mise tasks + PTS pins before any sandbox runs, so the job summary can
+	// name what this cell planned to execute (schema commands → mise task info → run_task leaves). It
+	// is a property of the suite, not of a replicate, so it is resolved outside runReplicate.
+	let taskPlan: SuiteTaskPlan | undefined;
+	await withGroup(`Discover suite tasks (${suite})`, async () => {
+		try {
+			taskPlan = await describeSuiteTasks(suite);
+			logInfo(`commands: ${taskPlan.commands.join(" · ")}`);
+			for (const task of taskPlan.tasks) {
+				const pts = task.ptsProfile ? ` pts=${task.ptsProfile}` : "";
+				const prefix = task.resultsPrefix ? ` prefix=${task.resultsPrefix}` : "";
+				logInfo(
+					`${task.role} ${task.task}${task.description ? ` — ${task.description}` : ""}${pts}${prefix}`,
+				);
+			}
+			if (inActions()) {
+				for (const metric of taskPlan.metrics) {
+					core.debug(
+						`metric ${metric.id} label=${metric.label}` +
+							(metric.ptsTest ? ` pts.test=${metric.ptsTest}` : ""),
+					);
+				}
+			}
+		} catch (err) {
+			const msg = `Could not describe suite tasks for "${suite}": ${err instanceof Error ? err.message : String(err)}`;
+			logWarning(msg, { title: cell });
+		}
+	});
+
+	// One shard at the un-suffixed `data/runs/<runId>.json`, which bench-smoke.yml and
+	// commit-dataset.yml both name directly — so the filename is a contract.
+	const outcome = await runReplicate({
+		provider,
+		suite,
+		runId,
+		sha,
+		rawRoot,
+		outFile,
+		indexFile,
+		...(replicateIndex !== undefined ? { replicateIndex } : {}),
+		required,
+	});
 	await reportCell({
 		provider,
 		suite,
 		runId,
 		sha,
-		outFile,
-		run: normalized,
-		failed: false,
-		taskPlan,
+		outFile: outcome.outFile,
+		...(outcome.run ? { run: outcome.run } : {}),
+		failed: outcome.failed,
+		durationMs: outcome.durationMs,
+		...(outcome.detail !== undefined ? { detail: outcome.detail } : {}),
+		...(taskPlan ? { taskPlan } : {}),
 	});
-	logInfo(`Cell ${cell} succeeded → ${outFile}`);
+	if (outcome.failed) fail(outcome.detail ?? `Cell ${cell} failed`, { annotate: false });
 }


### PR DESCRIPTION
**REPLICATE FAN-OUT — drive a cell's whole replicate fan-out from ONE runner instead of R idle ones**

Shipped as a 7-PR stack (merge bottom-up, each branch independently green):

1. #282 — schema: own the workflow timeout margin next to the suite budgets
2. #283 — harness: make result collection non-blocking so peer polls keep running
3. #284 — cli lib: the replicate fan-out primitives — pool, flags, budget guard
4. #285 — cli lib: `[rN]` line tagging + a concurrency-safe Actions log layer
5. #286 — cli: report a replicate as an outcome instead of exiting from inside it ← **this PR**
6. #287 — cli: drive a cell's whole replicate fleet from one process
7. #288 — ci: retire the replicate matrix axis and gate the new wiring

↑ **This PR is #286 (5/7)**, based on #285.

---
bench-suite's cell logic lived in the `import.meta.main` block and reached its verdict by calling
`fail()` — i.e. `process.exit` — from wherever the verdict was reached: mid-suite on a usage error,
after normalize, inside the gap check, inside the require gate. That is fine for one sandbox per
process and fatal for several, which is where this is going: an exit taken by one replicate abandons
its peers with their sandboxes alive and their shards unwritten.

Restructure with no behavioural change to the single-sandbox run:

  * `runReplicate(ctx)` runs one replicate end to end — suite → normalize → gap verification →
    require gate — and RETURNS a `ReplicateOutcome` instead of exiting. It is total: it never throws
    and never exits, so several can be held in flight.
  * `writeCellSummary` owns the half of the job summary that does not depend on how many sandboxes
    ran (heading, cell identity, task plan, annotation wiring); `reportCell` supplies the
    single-sandbox fields and tables on top. A second report can now reuse the shared half rather
    than restate it, which is how the two halves stay from drifting.
  * `cellTitle` and `replicateLabel` replace the ad-hoc `${suite} / ${provider}` strings, so the
    heading, the annotation title, and the log line cannot disagree.
  * `parseReplicateFlag` keeps its exported signature and validation but delegates to the shared
    `lastFlagValue`/`parseReplicateIndex` primitives instead of hand-rolling the argv scan.
  * `main` is now parse → discover tasks → one `runReplicate` → one `reportCell` → exit once.

The help text also picks up the canonical provider ids. Its examples said "daytona" and "modal"
while the registry has only `daytona-vm`, `daytona-container`, `modal-gvisor` and `modal-vm`, and
`runSuite` matches the positional argument against the registry EXACTLY — so a copied example line
failed as an unknown provider. A new test pins every id named in the `examples:` block against the
provider and suite registries, and pins the documented default to the one the code falls back to, so
the drift cannot come back silently.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Refactor `bench-suite` so each replicate returns a `ReplicateOutcome` instead of exiting mid-run, and show per-replicate duration in the report. Help/examples now use canonical provider ids and defaults; tests pin them and duration formatting, and CI debug logs include raw paths and the replicate index.

- **Refactors**
  - Added `runReplicate(ctx)` that returns a `ReplicateOutcome` and never throws/exits.
  - Added per-replicate timing: `ReplicateOutcome.durationMs` and `formatDuration`; report shows a “Duration” field.
  - Split summary rendering into `writeCellSummary` (shared) and `reportCell` (single-run details); unified titles with `cellTitle`/`replicateLabel`.
  - `parseReplicateFlag` now delegates to shared `lastFlagValue`/`parseReplicateIndex`.
  - CLI flow: parse → discover tasks → `runReplicate` → `reportCell` → exit once. Single-sandbox behavior unchanged.

- **Bug Fixes**
  - Help shows canonical provider ids and correct default (`daytona-vm`); examples updated (e.g. `modal-vm`). Tests pin example ids/default to `PROVIDERS`/`SUITE_NAMES` and validate `formatDuration`.
  - Restored Actions debug payload to include `rawRoot`, `outFile`, and the replicate index.
  - Invalid `--replicate` fails early with exit code 2.

<sup>Written for commit c89b6592b47c5f459b63346c39bc62fa5e4b9f31. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/starslingdev/hpc-sandbox-benchmarks/pull/286?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

