### PR TITLE
feat(ci): stop billing one idle runner per replicate

### DIFF
--- a/.github/workflows/bench-matrix.yml
+++ b/.github/workflows/bench-matrix.yml
@@ -1,12 +1,18 @@
 name: Bench matrix
 
-# Fan the live benchmark out across the provider × suite × replicate matrix using GitHub's native
-# reusable-workflow nesting. `plan` emits all three axes; a single suite-matrix job calls the reusable
-# bench-suite.yml once per suite (`name: ${{ matrix.suite }}`), and that reusable fans out
-# provider × replicate — so each cell displays as "<suite> / <provider> (replicate N)" (e.g.
-# "system / e2b (replicate 0)") and cells nest under their suite in the Actions UI. Adding a suite is a
-# schema change only: the suite axis is `fromJSON(needs.plan.outputs.suites)`, kept in lockstep by the
-# workflow-registry-sync gate.
+# Fan the live benchmark out across the provider × suite matrix using GitHub's native reusable-workflow
+# nesting. `plan` emits all three axes; a single suite-matrix job calls the reusable bench-suite.yml
+# once per suite (`name: ${{ matrix.suite }}`), and that reusable fans out over providers — so each cell
+# displays as "<suite> / <provider>" (e.g. "system / e2b") and cells nest under their suite in the
+# Actions UI. Adding a suite is a schema change only: the suite axis is
+# `fromJSON(needs.plan.outputs.suites)`, kept in lockstep by the workflow-registry-sync gate.
+#
+# The THIRD axis, replicates, is deliberately NOT a runner axis: `plan` hands each suite's replicate
+# index array to its cells as data, and one runner drives that cell's whole replicate fleet
+# concurrently in-process (`bench-suite --replicates`). A bench runner is ~100% idle waiting on its
+# sandbox, so a runner per replicate billed R idle runners to do one runner's work — at the shipped
+# defaults that is 324 runners where 54 suffice, with identical sandbox load and wall clock. See
+# bench-suite.yml's header for the failure-isolation contract inside a cell.
 #
 # Three configurable inputs tune the statistics, all defaulting to the schema/per-suite config so a bare
 # dispatch reproduces the configured run:
@@ -14,7 +20,8 @@ name: Bench matrix
 #     pre-merge knob, so a validation dispatch can run just one suite instead of the whole matrix.
 #   * `replicas` — replicate sandboxes per (provider, suite) cell, the BETWEEN-machine axis (blank = each
 #     suite's Suite.defaultReplicas — synthetic R=3, realworld R=12; a number scales every suite). More
-#     replicates → tighter intervals on a provider's fleet variation, at proportional runner cost.
+#     replicates → tighter intervals on a provider's fleet variation, at proportional PROVIDER cost
+#     (sandbox minutes) but flat runner cost — the cell's runner drives them all concurrently.
 #   * `pts_passes` — timed PTS passes per case INSIDE a sandbox, the WITHIN-machine axis (blank = each
 #     suite's own policy: the cpu-node and memory suites converge, while every other suite (system, disk,
 #     pgbench, network, realworld) keeps a fixed count; a number or `converge` forces one policy across
@@ -69,6 +76,15 @@ on:
         # axis). A number or "converge" is the GLOBAL override applied to every suite. resolvePtsPassPolicy
         # rejects any other non-numeric value.
         default: ''
+      max_concurrency:
+        description: 'Cap replicate sandboxes in flight per (suite, provider) cell (blank = unbounded, i.e. all R at once). Set a number when a provider quota is smaller than R — an over-quota create retries for up to 60 min inside the cell, so an unbounded fan-out against a tight quota burns the job budget queueing. A cap serializes the cell into ceil(R / cap) waves, so wall clock grows proportionally; a cap whose waves cannot fit the cell job timeout (plus the host margin) is rejected before any sandbox is created, and the error names the smallest cap that would fit. Note the realworld suites leave no room to cap at all: R=12 over a 90-minute suite affords ONE wave inside a 180-minute job, so anything below 12 is refused — cap the synthetic suites, or raise the cell timeout first.'
+        required: false
+        type: string
+        # Blank preserves the old behaviour exactly: R separate runners each held one sandbox with
+        # nothing coordinating them, so the fan-out was already unbounded per provider. The difference
+        # now is that GitHub's concurrent-JOB limit no longer incidentally throttles it — see
+        # bench-suite.yml's header on peak provider concurrency.
+        default: ''
       allow_branch:
         description: 'Allow benchmark cells on a non-main ref (publish remains main-only).'
         required: false
@@ -104,8 +120,9 @@ jobs:
       providers: ${{ steps.plan.outputs.providers }}
       suites: ${{ steps.plan.outputs.suites }}
       # A JSON object mapping each selected suite to its replicate index array (e.g.
-      # {"cpu-node":[0,1,2],...}). The suite-matrix job indexes it by matrix.suite to get that suite's
-      # own replicate axis, so per-category replicate counts stay registry-driven like the suite axis.
+      # {"cpu-node":[0,1,2],...}). The suite-matrix job indexes it by matrix.suite and passes that
+      # suite's slice down for the cell to fan out over in-process, so per-category replicate counts
+      # stay registry-driven like the suite axis.
       replicates: ${{ steps.plan.outputs.replicates }}
     steps:
       - name: Checkout
@@ -140,7 +157,8 @@ jobs:
 
   # One matrix cell per selected suite → reusable workflow call. GitHub nests the reusable's provider
   # matrix under each suite name, so the Actions UI shows expandable "<suite>" groups with "<provider>"
-  # children (display: "<suite> / <provider>"). fail-fast stays off so one bad suite doesn't cancel peers.
+  # children (display: "<suite> / <provider>"); each of those children drives its own R replicate
+  # sandboxes. fail-fast stays off so one bad suite doesn't cancel peers.
   # The fork/branch guard is repeated here (not only inherited via `needs: plan`) so the job stays
   # explicit when read in isolation — matching every other live-run job in the repo.
   suite:
@@ -169,10 +187,12 @@ jobs:
       providers: ${{ needs.plan.outputs.providers }}
       suite: ${{ matrix.suite }}
       # Hand this suite its own replicate slice out of the plan's per-suite map (keyed by matrix.suite),
-      # re-serialized to the JSON string the reusable workflow's `replicate` axis parses with fromJSON.
+      # re-serialized to the JSON array string each cell passes straight to `bench-suite --replicates`.
       replicates: ${{ toJSON(fromJSON(needs.plan.outputs.replicates)[matrix.suite]) }}
       # Forward the PTS passes-per-case override unchanged (blank = suite default, a number, or converge).
       pts_passes: ${{ inputs.pts_passes }}
+      # Forward the per-cell replicate concurrency cap unchanged (blank = all R sandboxes at once).
+      max_concurrency: ${{ inputs.max_concurrency }}
     secrets: inherit
 
   # Collect every shard Run, aggregate into one candidate, gate it (promote), and commit the machine-

--- a/.github/workflows/bench-suite.yml
+++ b/.github/workflows/bench-suite.yml
@@ -1,19 +1,43 @@
 name: Benchmark suite (reusable)
 
-# One suite, fanned out across a provider × replicate matrix. bench-matrix.yml calls this once per suite
-# via its suite-matrix job (`name: ${{ matrix.suite }}`), passing the plan's selected provider list AND
-# that suite's replicate index array — so cells display as "<suite> / <provider> (replicate N)" and every
-# provider's replicate sandboxes nest under one suite label in the Actions UI. The replicate axis is the
-# BETWEEN-MACHINE knob: R sandboxes of one (provider, suite) capture a provider's fleet variation (two can
-# land on different host hardware), which the aggregate folds into per-metric replicate breakdowns.
+# One suite, fanned out across the provider matrix — ONE runner per (suite, provider) cell, which drives
+# that cell's whole replicate fleet itself. bench-matrix.yml calls this once per suite via its
+# suite-matrix job (`name: ${{ matrix.suite }}`), passing the plan's selected provider list AND that
+# suite's replicate index array — so cells display as "<suite> / <provider>" and nest under one suite
+# label in the Actions UI. The replicate axis is the BETWEEN-MACHINE knob: R sandboxes of one
+# (provider, suite) capture a provider's fleet variation (two can land on different host hardware),
+# which the aggregate folds into per-metric replicate breakdowns.
+#
+# Replicates are NOT a matrix axis. A bench runner spends effectively all of its wall time waiting on a
+# sandbox (create → poll a detached step → poll again), so a runner-per-replicate matrix billed R idle
+# runners to do one runner's work: at the shipped defaults (6 providers × 9 suites, R=3 synthetic /
+# R=12 realworld) that is 324 runners for 54 runners' worth of driving. `bench-suite --replicates` now
+# creates the same R sandboxes concurrently from one process, so the TOTAL sandbox count is unchanged
+# while the runner-minutes bill stops scaling with R.
+#
+# PEAK provider concurrency is NOT unchanged, and that is the one cost of this design. Under the old
+# axis the 324 jobs contended for GitHub's account-wide concurrent-job limit, which incidentally
+# rate-limited how many sandboxes existed at once. 54 jobs fit under any plan's cap, so a matrix run
+# can now hold all 54 of a provider's replicate sandboxes simultaneously. Providers answer an over-quota
+# create with a capacity error, which `createSuiteSandbox` retries patiently for up to 60 minutes — so
+# the degradation is queueing, not failure, but it spends the job budget. `max_concurrency` below is the
+# control; `strategy.max-parallel` on the caller's suite matrix is the coarser alternative.
+#
+# Replicate-level failure isolation is preserved inside the process: every replicate runs to completion
+# and writes its shard even when a peer throws, and the cell goes red at the end if any did. Note this
+# is NARROWER than the old `fail-fast: false`, which also isolated whole-cell events — a job timeout,
+# runner eviction, OOM, or a "re-run failed jobs" click now costs all R replicates of the cell rather
+# than one. Sizing `max_concurrency` against `timeout-minutes` below is what keeps that risk bounded.
+#
 # Factoring the shared cell here (checkout → run → upload, plus the per-provider credential wiring)
 # keeps that block in ONE place instead of copy-pasted into every suite job, mirroring
 # runner-benchmarking's reusable bench-suite.yml.
 #
-# The artifact name (bench-<suite>-<provider>-r<replicate>-<run_id>) is load-bearing: commit-dataset.yml
-# downloads the shards by the `bench-*-<run_id>` pattern and aggregates them — keep the two in lockstep.
-# The `-r<replicate>` segment keeps each replicate's shard a distinct artifact even though every shard of
-# one run shares the same runId file (data/runs/<run_id>.json); the aggregate keys them by --replicate.
+# The artifact name (bench-<suite>-<provider>-<run_id>) is load-bearing: commit-dataset.yml downloads
+# the shards by the `bench-*-<run_id>` pattern and aggregates them — keep the two in lockstep. One
+# artifact now carries the cell's R shards, each written to its own `data/runs/<run_id>-r<idx>.json`
+# (every shard of one run shares the same `runId` FIELD, so the `-r<idx>` filename suffix is what keeps
+# them distinct); the aggregate keys them by the --replicate index stamped on each Run.
 #
 # Environment `privileged` (required reviewers + environment secrets — see docs/ci-secrets.md) lives on
 # the fan-out job here: a `uses:` caller can't declare `environment:`, so the approval gate and the
@@ -35,10 +59,24 @@ on:
         description: >-
           JSON array of replicate sandbox indices for THIS suite, e.g. "[0,1,2]" — the between-machine
           fan-out axis. plan-replicates emits it per suite (Suite.defaultReplicas, or the BENCH_REPLICAS
-          override); the caller passes each suite its own slice. One matrix cell runs per (provider,
-          replicate), each tagged with `--replicate <idx>` so the aggregate folds them by index.
+          override); the caller passes each suite its own slice. Handed to `bench-suite --replicates`
+          VERBATIM: one matrix cell per provider drives every index in the array concurrently, each
+          sandbox tagged with its `--replicate <idx>` so the aggregate folds them by index.
         required: true
         type: string
+      max_concurrency:
+        description: >-
+          Cap on replicate sandboxes in flight per cell (BENCH_MAX_CONCURRENCY). Blank = unbounded, i.e.
+          all R at once — the fastest option and the one that matches what R separate runners used to do.
+          Set a number when a provider's account quota is smaller than R: an over-quota create is retried
+          for up to 60 minutes inside the cell, so an unbounded fan-out against a tight quota spends the
+          job budget queueing. A cap makes the cell run in ceil(R / cap) SERIAL waves, so the wall clock
+          becomes waves x suite runtime. A cap whose waves cannot fit the job's timeout-minutes is
+          REJECTED before any sandbox is created (BENCH_CELL_BUDGET_MINUTES below) — losing a whole
+          cell's fleet to a deterministic timeout is not a degradation worth discovering at 180 minutes.
+        required: false
+        type: string
+        default: ''
       pts_passes:
         description: >-
           PTS passes-per-case override for the harness (BENCH_PTS_PASSES) — the within-machine axis.
@@ -59,28 +97,34 @@ permissions:
 
 jobs:
   bench:
-    # Display as "<caller suite job> / <provider> (replicate N)", e.g. "system / e2b (replicate 0)" —
-    # the replicate cells nest under their suite's job name in the Actions UI (GitHub-native
-    # reusable-workflow nesting). The replicate suffix keeps each of a provider's R sandboxes a
-    # distinct, legible cell (a bare `${{ matrix.provider }}` would render them all identically).
-    name: ${{ matrix.provider }} (replicate ${{ matrix.replicate }})
+    # Display as "<caller suite job> / <provider>", e.g. "system / e2b" — the provider cells nest under
+    # their suite's job name in the Actions UI (GitHub-native reusable-workflow nesting). One cell owns
+    # all R replicate sandboxes of that (suite, provider), so there is no replicate suffix to
+    # disambiguate; the per-replicate breakdown lives in the cell's job summary + `[r<idx>]` log tags.
+    name: ${{ matrix.provider }}
     environment: privileged
     # The ephemeral self-hosted label is reaped after 70 minutes even while a step is healthy. The
     # full CPU-generic and real-world matrices legitimately exceed that on slower providers, leaving
     # the step stuck `in_progress` with no logs/artifact. Hosted runners honor timeout-minutes below;
     # 180 minutes also leaves teardown/artifact margin around the longest 155-minute suite budget.
     # (workflow-registry-sync asserts this stays above the longest registered sandbox lifetime.)
+    #
+    # Driving R replicates from one runner does not need a bigger budget WHEN THEY RUN CONCURRENTLY: the
+    # cell's wall clock is then the slowest replicate, not their sum — the same bound a single-replicate
+    # cell had. Two things break that assumption and both consume this one shared budget:
+    #   * a `max_concurrency` cap, which makes the cell run ceil(R / cap) serial waves; and
+    #   * provider capacity errors, which `createSuiteSandbox` retries for up to 60 minutes per replicate
+    #     before giving up, so a fan-out wider than the account quota queues inside the budget.
+    # At R=12 against a suite budgeted near 90 minutes, either can exceed 180. Raise this, or lower the
+    # fan-out, rather than discovering it as a cancelled cell that loses all R replicates at once.
     runs-on: ubuntu-24.04
     timeout-minutes: 180
     strategy:
-      # One cell's failure (a flaky provider, or one bad replicate) must not cancel the rest of the matrix.
+      # One provider's failure (a flaky adapter, a dead account) must not cancel the rest of the matrix.
+      # Replicate-level isolation is handled INSIDE the cell — see the header note.
       fail-fast: false
       matrix:
         provider: ${{ fromJSON(inputs.providers) }}
-        # The between-machine axis: R replicate sandboxes per provider, expanded into provider × replicate
-        # cells. The array is this suite's slice of plan-replicates' map (Suite.defaultReplicas / the
-        # BENCH_REPLICAS override), so a suite runs exactly the replicate count its category configures.
-        replicate: ${{ fromJSON(inputs.replicates) }}
     steps:
       # Third-party actions are pinned to a commit SHA (the tag comment is for humans) so a
       # moved/compromised tag can't silently change what runs.
@@ -115,9 +159,11 @@ jobs:
       # is rejected outright ("not allowed in revokable tokens"), and each wrong verb name (e.g.
       # "read"/"delete" instead of "get"/"destroy") is named individually in the CLI's error.
       #
-      # The cell's suite/replicate name the token so a leaked one is traceable to the cell that minted
-      # it; both reach the shell through the environment, never interpolated into the run block, so a
+      # The cell's suite names the token so a leaked one is traceable to the cell that minted it; it
+      # reaches the shell through the environment, never interpolated into the run block, so a
       # dispatch-controlled suite name can't inject into the runner command (zizmor template-injection).
+      # One token per cell now covers all R of its replicate sandboxes (they share this process's
+      # credentials, exactly as they share every other provider secret in the run step below).
       # run_attempt is part of the name because run_id is PRESERVED across re-runs: without it a retry
       # collides with the first attempt's token, and continue-on-error would turn that name clash into a
       # silent namespace skip — on exactly the re-run where you wanted the validation.
@@ -127,11 +173,10 @@ jobs:
         id: nsc-token
         env:
           BENCH_SUITE: ${{ inputs.suite }}
-          BENCH_REPLICATE: ${{ matrix.replicate }}
           NSC_TOKEN_PATH: ${{ runner.temp }}/nsc-token.json
         run: |
           nsc token create \
-            --name "sandbox-benchmarks-${BENCH_SUITE}-r${BENCH_REPLICATE}-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}" \
+            --name "sandbox-benchmarks-${BENCH_SUITE}-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}" \
             --grant '{"resource_type":"instance","resource_id":"*","actions":["create","list","get","destroy","exec"]}' \
             --token_file "$NSC_TOKEN_PATH"
 
@@ -144,10 +189,11 @@ jobs:
       - name: Install dependencies
         run: bun install --frozen-lockfile --ignore-scripts
 
-      # Drive the provider SDK to create a sandbox, run the suite, collect results, and normalize. The
-      # cell's provider + replicate are matrix values and its suite the reusable input, all passed through
-      # the environment (never interpolated into the shell) so none can inject into the runner command.
-      # On success/failure the bin also writes a compact job summary + run annotation (clean Results).
+      # Drive the provider SDK to create this cell's R replicate sandboxes, run the suite in each,
+      # collect results, and normalize one shard Run per replicate. The cell's provider is a matrix value
+      # and its suite + replicate array are reusable inputs, all passed through the environment (never
+      # interpolated into the shell) so none can inject into the runner command. On success/failure the
+      # bin writes ONE job summary for the whole fleet (a row per replicate) + a run annotation.
       - name: Run suite and normalize
         env:
           BENCH_REPO_REF: ${{ github.sha }}
@@ -156,9 +202,21 @@ jobs:
           BENCH_REPO_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           BENCH_PROVIDER: ${{ matrix.provider }}
           BENCH_SUITE: ${{ inputs.suite }}
-          # The replicate index this shard represents — stamped onto its Run so the aggregate folds the R
-          # sandboxes of one (provider, suite) into per-metric replicate breakdowns rather than colliding.
-          BENCH_REPLICATE: ${{ matrix.replicate }}
+          # The replicate index array this cell drives (the plan's per-suite slice, verbatim). Each index
+          # gets its own sandbox and its own shard Run, stamped with that index so the aggregate folds the
+          # R sandboxes of one (provider, suite) into per-metric replicate breakdowns rather than colliding.
+          BENCH_REPLICATES: ${{ inputs.replicates }}
+          # Blank = unbounded (all R sandboxes at once). See the max_concurrency input above: this is the
+          # control for a provider whose quota is smaller than R, and it trades wall clock for peak load.
+          BENCH_MAX_CONCURRENCY: ${{ inputs.max_concurrency }}
+          # This job's `timeout-minutes`, handed to the CLI so it can REFUSE a cap that cannot fit rather
+          # than be cancelled three hours in with every shard of the cell lost. A cap runs the fan-out in
+          # ceil(R / cap) serial waves, so the cell's worst case is waves x the suite's own budget — and
+          # at the realworld defaults (R=12, a 90-minute suite) the 180 below affords ONE wave once the
+          # host margin is set aside, so any cap short of the full 12 is refused. A literal, not an
+          # expression: `timeout-minutes` cannot be read from an expression context, so workflow-sync's
+          # Invariant 5 asserts the two stay equal instead.
+          BENCH_CELL_BUDGET_MINUTES: '180'
           # PTS passes-per-case policy: blank = the suite's own policy (cpu-node + memory converge, the rest
           # fixed), a number or "converge" overrides every suite. Read by the harness preamble.
           BENCH_PTS_PASSES: ${{ inputs.pts_passes }}
@@ -186,17 +244,58 @@ jobs:
           # (steps.nsc-token only runs when matrix.provider == 'namespace'), which the harness reads
           # as the standard missing-credentials skip on every other cell.
           NSC_TOKEN_FILE: ${{ steps.nsc-token.outcome == 'success' && format('{0}/nsc-token.json', runner.temp) || '' }}
-        run: bun apps/cli/src/bin/bench-suite.ts "$BENCH_PROVIDER" "$BENCH_SUITE" "$GITHUB_RUN_ID" --replicate "$BENCH_REPLICATE"
+        run: bun apps/cli/src/bin/bench-suite.ts "$BENCH_PROVIDER" "$BENCH_SUITE" "$GITHUB_RUN_ID" --replicates "$BENCH_REPLICATES"
+
+      # Did THIS attempt actually produce shard Runs? The upload below overwrites the cell's artifact,
+      # and overwriting is only safe when there is something to put in its place.
+      #
+      # `if-no-files-found: error` cannot answer this. The cell uploads `path: data/`, and `data/dataset/`
+      # is CHECKED IN — so data/ is non-empty from the moment of checkout, on every attempt, whatever the
+      # benchmark did. That guard has therefore never been able to fire, and combining it with `overwrite`
+      # would be actively harmful: a retry that dies before writing a single shard (runner eviction, a
+      # failed install, an early crash) would still upload the checked-out dataset files, delete the
+      # previous attempt's good shards, and leave commit-dataset.yml to drop this (suite, provider) cell
+      # from the published run entirely. Losing a healthy first attempt to a broken second one is worse
+      # than the duplicate-name rejection `overwrite` exists to avoid.
+      #
+      # So: gate on the shard files by name. A pass that wrote shards replaces the attempt it retried; a
+      # pass that wrote none leaves the previous attempt's artifact standing. The job's own red/green is
+      # unaffected — bench-suite already decided that — this only governs what gets published.
+      - name: Check this attempt wrote shard Runs
+        id: shards
+        if: always()
+        run: |
+          shopt -s nullglob
+          shards=(data/runs/"$GITHUB_RUN_ID"*.json)
+          echo "count=${#shards[@]}" >> "$GITHUB_OUTPUT"
+          if [ ${#shards[@]} -eq 0 ]; then
+            echo "::warning title=No shards::this attempt wrote no shard Run; keeping any previous attempt's artifact"
+          else
+            echo "this attempt wrote ${#shards[@]} shard Run(s)"
+          fi
 
       - name: Upload Run + raw results
-        if: always()
+        if: always() && steps.shards.outputs.count != '0'
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          # Per-cell artifact name so every (provider, suite, replicate) shard uploads independently — the
-          # `-r<replicate>` segment is what keeps R replicates of one cell from colliding on one name (they
-          # all write the same data/runs/<run_id>.json). commit-dataset.yml matches these by `bench-*-<run_id>`.
-          name: bench-${{ inputs.suite }}-${{ matrix.provider }}-r${{ matrix.replicate }}-${{ github.run_id }}
+          # Per-cell artifact name so every (provider, suite) cell uploads independently, carrying its R
+          # replicate shards (data/runs/<run_id>-r<idx>.json — the filename suffix keeps them distinct,
+          # since every shard's Run carries the same `runId` field). commit-dataset.yml matches these by
+          # `bench-*-<run_id>` and globs both the `-r<idx>` shards and the legacy un-suffixed name.
+          # `if: always()` is what preserves failure isolation across the upload boundary: a cell that
+          # goes red because ONE replicate failed still uploads every shard its healthy peers wrote.
+          name: bench-${{ inputs.suite }}-${{ matrix.provider }}-${{ github.run_id }}
           path: data/
-          # A successful run always writes data/runs/<id>.json (even an all-skipped Run), so an empty
-          # data/ means the job is genuinely broken — fail the upload rather than bury a warning.
+          # A "Re-run failed jobs" keeps github.run_id and only bumps run_attempt, so this name is
+          # unchanged on the retry — and upload-artifact@v4+ REJECTS a duplicate name by default, which
+          # would compute the retry's whole fleet and then throw it away at the upload boundary. Overwrite
+          # so the replacement fleet supersedes the attempt it retried; the step condition above is what
+          # keeps that replacement from ever being an empty one. Scope is exactly this cell: the name
+          # carries (suite, provider, run_id), so replacing it cannot disturb another cell's artifact.
+          # commit-dataset.yml's per-cell shard preference (see its "Aggregate + promote" step) then
+          # reads one shape per cell, never a mix.
+          overwrite: true
+          # Kept as a backstop, though the step condition above now owns the "did this attempt produce
+          # anything" question — data/ also carries the checked-in data/dataset/ tree, so this alone can
+          # never see an empty upload.
           if-no-files-found: error

--- a/.github/workflows/commit-dataset.yml
+++ b/.github/workflows/commit-dataset.yml
@@ -93,17 +93,71 @@ jobs:
       # Aggregate the shards' Run documents into one candidate, then promote (gate on >=1 validated
       # provider) and publish into the committed dataset at data/dataset/. The run-id matches the shards.
       #
-      # The glob names the Run document EXACTLY, `<runId>.json`, and must not gain a `data/` segment:
-      # the bench cell uploads `path: data/`, and upload-artifact roots the artifact at the least common
-      # ancestor of the matched files — so a shard unpacks as `shards/<artifact>/runs/<runId>.json`, with
-      # no `data/` prefix. Two decoys sit next to it that a `runs/*.json` wildcard would sweep in: the
-      # sibling `runs/index.json` (an index, not a Run), and `dataset/runs/<oldRunId>.json` (the committed
-      # dataset, which rides along because it lives under data/). Both would poison the aggregate.
+      # The globs name the Run documents EXACTLY and must not gain a `data/` segment: the bench cell
+      # uploads `path: data/`, and upload-artifact roots the artifact at the least common ancestor of the
+      # matched files — so a shard unpacks as `shards/<artifact>/runs/<runId>...json`, with no `data/`
+      # prefix. Two decoys sit next to them that a `runs/*.json` wildcard would sweep in: the sibling
+      # `runs/index.json` (an index, not a Run), and `dataset/runs/<oldRunId>.json` (the committed
+      # dataset, which rides along because it lives under data/, and which the `runs/` segment excludes).
+      # Both would poison the aggregate.
+      #
+      # TWO shard shapes exist, and they are selected with a PREFERENCE, never unioned:
+      #   * `<runId>-r<idx>.json` — the current per-replicate shards (one runner drives all R replicates
+      #     of a (suite, provider) cell, so they share an artifact and are told apart by the suffix).
+      #   * `<runId>.json` — the un-suffixed single-shard name written by a run that predates the
+      #     fan-out change. Keeping it is what lets a backfill dispatch re-aggregate an older run's
+      #     still-retained artifacts.
+      #
+      # Preference, not union, because run ids are PRESERVED across re-runs: a run whose first attempt
+      # predates the change and whose retry postdates it leaves BOTH shapes under one run id. Unioning
+      # them would hand `aggregate` two shards describing the SAME sandbox — a shard with no
+      # replicateIndex normalizes to index 0, colliding with `-r0` — and its documented first-wins
+      # rule would silently drop one sandbox's whole measured set while leaving no replicate breakdown,
+      # making the result indistinguishable from a genuine single-replicate run.
+      #
+      # The preference is applied PER CELL, never run-wide, because the collision it guards against is
+      # per-cell: the two shapes describe the same sandbox only when they came from the same
+      # (suite, provider) artifact. `merge-multiple: false` above unpacks each cell into its own
+      # `shards/<artifact>/` subdir, so that subdir IS the cell boundary — loop over it and ask each cell
+      # which shape it wrote. A run-wide preference reads the shapes as a single global choice, and a
+      # mixed-shape run (retry a cell that failed on the old code, and only that cell re-runs on the new)
+      # then publishes ONLY the retried cell: every other provider/suite of the run, still legacy-only,
+      # is silently discarded and the dataset is promoted a fraction of the size it should be. Per cell,
+      # the retried cell contributes its `-r<idx>` fleet and its untouched peers contribute their legacy
+      # shard, which is the union across cells and the preference within one — exactly the intent.
+      #
+      # (Both shapes under ONE cell needs `overwrite: true` on the cell's upload — see bench-suite.yml —
+      # to be reachable at all, since a re-run otherwise cannot claim the name. The per-cell preference
+      # is the belt to that suspenders: it stays correct for artifacts uploaded before that fix and for
+      # a backfill dispatch reaching back to any older run.)
+      #
+      # The per-shape cell counts are echoed so a short or lopsided set is visible in the log rather
+      # than inferred.
       - name: Aggregate + promote
         run: |
           shopt -s nullglob
-          shards=(shards/*/runs/"$RUN_ID".json)
+          shards=()
+          fanout_cells=0
+          legacy_cells=0
+          for cell in shards/*/; do
+            # The `-r*` probe is a real glob, so nullglob empties it when the cell wrote no fleet. The
+            # legacy name has NO wildcard left once "$cell" is an expanded literal, and nullglob only
+            # ever rewrites words that ARE patterns — so it must be probed with `-f`, or every cell
+            # would contribute a non-existent path and be miscounted as legacy.
+            cell_shards=("$cell"runs/"$RUN_ID"-r*.json)
+            if [ ${#cell_shards[@]} -gt 0 ]; then
+              fanout_cells=$((fanout_cells + 1))
+            elif [ -f "$cell"runs/"$RUN_ID".json ]; then
+              cell_shards=("$cell"runs/"$RUN_ID".json)
+              legacy_cells=$((legacy_cells + 1))
+            else
+              cell_shards=()
+            fi
+            shards+=("${cell_shards[@]}")
+          done
           if [ ${#shards[@]} -eq 0 ]; then echo "no shard Run documents found for run $RUN_ID" >&2; exit 1; fi
+          echo "aggregating ${#shards[@]} shard(s) for run $RUN_ID" \
+            "from $fanout_cells per-replicate + $legacy_cells legacy single-shard cell(s)"
           bun apps/cli/src/bin/aggregate.ts "$RUN_ID" data/candidate "${shards[@]}"
           bun apps/cli/src/bin/promote.ts "data/candidate/runs/$RUN_ID.json" data/dataset
 

--- a/apps/cli/src/bin/aggregate.ts
+++ b/apps/cli/src/bin/aggregate.ts
@@ -1,6 +1,7 @@
 #!/usr/bin/env bun
 // `aggregate` — merge the per-shard Run documents of one benchmark run (the CI matrix emits one per
-// `(provider, suite)` cell) into a single candidate Run, written to a candidate dataset + index. This
+// `(provider, suite, replicate)` sandbox — one cell's runner drives all R of its replicates and writes
+// a shard each) into a single candidate Run, written to a candidate dataset + index. This
 // is the collect half of candidate→promote: `promote` then validates and publishes the candidate.
 // Uses @actions/core for foldable groups, debug metadata, annotations, and a job summary in CI.
 

--- a/apps/cli/src/lib/matrix.ts
+++ b/apps/cli/src/lib/matrix.ts
@@ -105,8 +105,9 @@ export function parseReplicasOverride(raw: string | undefined): number | undefin
  * `{ "cpu-node": [0, 1, 2], "realworld-mastra": [0, 1, 2, 3, 4] }`. Each suite maps to `[0..R-1]`, where
  * R is the `BENCH_REPLICAS` override (`replicasRaw`) when set, else that suite's schema default. The
  * suite set matches {@link selectSuites} exactly (same `BENCH_SUITES` parsing), so the map is keyed by
- * precisely the suites the plan's suite axis emits — the reusable bench-suite.yml indexes it by
- * `matrix.suite` to get its own replicate axis. `suitesRaw`/`replicasRaw` are the raw dispatch strings.
+ * precisely the suites the plan's suite axis emits — bench-matrix.yml indexes it by `matrix.suite` and
+ * hands each cell its slice as `bench-suite --replicates` (the cell drives every index itself, in one
+ * process, rather than expanding them into runners). `suitesRaw`/`replicasRaw` are the raw dispatch strings.
  */
 export function planReplicateMap(
 	suitesRaw: string | undefined,

--- a/docs/methodology.md
+++ b/docs/methodology.md
@@ -114,14 +114,22 @@ without being Daytona-specific.
 
 ## The dataset pipeline
 
-1. **Run** — `bench-suite <provider> <suite> <runId> --replicate <idx>` boots a sandbox, runs the
-   suite's mise tasks, pulls the raw tree (`data/raw/<runId>/<provider>/<suite>/`), and normalizes it
-   into a Run document stamped with its replicate index.
+1. **Run** — `bench-suite <provider> <suite> <runId> --replicates <indices>` boots one sandbox per
+   replicate index (concurrently, from one process), runs the suite's mise tasks in each, pulls the raw
+   trees (`data/raw/<runId>/r<idx>/<provider>/<suite>/`), and normalizes each into its own shard Run
+   document (`data/runs/<runId>-r<idx>.json`) stamped with that replicate index. `--replicate <idx>` is
+   the single-sandbox spelling, writing the un-suffixed `data/runs/<runId>.json`.
 2. **Matrix** — the `bench-matrix` workflow plans three axes (`plan-providers` / `plan-suites` /
    `plan-replicates`), then one suite-matrix job calls the reusable `bench-suite` workflow per suite
-   (GitHub-native nesting: `<suite> / <provider> (replicate N)`), fanning out over the selected
-   providers × that suite's replicate sandboxes; every `(provider, suite, replicate)` cell uploads its
-   shard Run as an artifact. Two axes are the statistical knobs, both defaulting to the per-suite schema
+   (GitHub-native nesting: `<suite> / <provider>`), fanning out over the selected providers; each
+   `(provider, suite)` cell drives that suite's whole replicate fleet itself and uploads all its shard
+   Runs as one artifact. **Replicates are not a runner axis.** A bench runner is idle for essentially
+   its whole life — it creates a sandbox and polls it — so a runner per replicate billed R idle runners
+   to do one runner's work (324 runners where 54 suffice, at the shipped defaults). Driving the fleet
+   in-process leaves the sandbox count, provider load, and wall clock unchanged (the cell's wall clock
+   is its slowest replicate, not their sum) while the runner bill stops scaling with R. Isolation is
+   preserved: every replicate runs to completion and writes its shard even when a peer dies, and the
+   cell goes red at the end if any did. Two axes are the statistical knobs, both defaulting to the per-suite schema
    config so a bare dispatch already carries the intended statistical power for separating providers
    (subject to the genuine near-tie limit noted below — no sample size resolves providers that are truly
    within a few percent):

--- a/packages/results/src/lib/aggregate.ts
+++ b/packages/results/src/lib/aggregate.ts
@@ -113,8 +113,8 @@ function mergeProvider(providerId: string, entries: readonly ReplicateSlice[]): 
 	// silently drop whichever arrived second.
 	const gaps: ResultGap[] = [];
 	const seenGap = new Set<string>();
-	// Coverage unions across shards: the matrix fans out one job per (provider, suite), so each shard sees
-	// only its own cell. A suite is covered for this provider iff SOME shard produced a Metric for it.
+	// Coverage unions across shards: the matrix fans out one job per (provider, suite) and that job writes
+	// one shard per replicate sandbox, so each shard sees only its own cell+replicate. A suite is covered for this provider iff SOME shard produced a Metric for it.
 	const suitesCovered = new Set<string>();
 	const uncatalogued: UncataloguedResult[] = [];
 	const seenStraggler = new Set<string>();

--- a/packages/schema/src/raw-files.ts
+++ b/packages/schema/src/raw-files.ts
@@ -1,6 +1,7 @@
 /**
  * The raw-file naming contract — the ONE home for how files in a Run's curated raw tree
- * (`data/raw/<runId>/<provider>/<suite>/`) are named, and how gap markers are shaped. The in-sandbox
+ * (`data/raw/<runId>/[r<idx>/]<provider>/<suite>/` — the `r<idx>` level is present when one runner
+ * drove a replicate fan-out) are named, and how gap markers are shaped. The in-sandbox
  * producer and the harness collector (writers) and the results extractor (the single reader) all
  * route through this module, so a filename's spelling can never drift between them.
  *

--- a/tooling/repo-checks/src/lib/workflow-nesting.ts
+++ b/tooling/repo-checks/src/lib/workflow-nesting.ts
@@ -1,6 +1,13 @@
 // Invariant 6: GitHub-native suite→provider nesting wiring for bench-matrix.yml + bench-suite.yml.
 // Kept out of workflow-sync.ts so credential/timeout gates and nesting gates don't grow as one file.
-import { asRecord, MATRIX_WORKFLOW, SUITE_JOB, SUITE_WORKFLOW } from "./workflow-yaml.ts";
+import {
+	asRecord,
+	MATRIX_WORKFLOW,
+	RUN_STEP,
+	SUITE_JOB,
+	SUITE_WORKFLOW,
+	stepByName,
+} from "./workflow-yaml.ts";
 
 /** A bench-matrix suite job is one that `uses` this reusable workflow (matched by path suffix). */
 const SUITE_WORKFLOW_USES_SUFFIX = "/bench-suite.yml";
@@ -14,6 +21,8 @@ export interface SuiteMatrixCaller {
 	jobId: string;
 	name: string;
 	suiteInput: string;
+	/** The `with.replicates` expression — this suite's slice of the plan's per-suite map. */
+	replicatesInput: string;
 	matrixSuiteExpr: string;
 	/** Job ids listed in `publish.needs` (empty when publish is missing or has no needs list). */
 	publishNeeds: string[];
@@ -25,16 +34,28 @@ export const EXPECTED_SUITE_MATRIX_EXPR = "${{ fromJSON(needs.plan.outputs.suite
 /** The expression that makes each caller cell's display name the suite id (native nesting parent). */
 // biome-ignore lint/suspicious/noTemplateCurlyInString: a GHA expression literal matched verbatim against the workflow, not a JS template.
 export const EXPECTED_SUITE_NAME_EXPR = "${{ matrix.suite }}";
-/** The provider id half of the fan-out cell's display name. */
+/** The expression that makes each reusable fan-out cell's display name the provider id (the nesting
+ *  child): "<suite> / <provider>". There is no replicate suffix — one cell owns all R replicate
+ *  sandboxes of its (suite, provider), driven concurrently from the single runner. */
 // biome-ignore lint/suspicious/noTemplateCurlyInString: a GHA expression literal matched verbatim against the workflow, not a JS template.
-const PROVIDER_NAME_EXPR = "${{ matrix.provider }}";
-/** The replicate-index suffix on the fan-out cell's display name. */
+export const EXPECTED_PROVIDER_NAME_EXPR = "${{ matrix.provider }}";
+
+/** The run-step env key that hands the cell its replicate index array. */
+export const REPLICATES_ENV_KEY = "BENCH_REPLICATES";
+/** The expression that key must carry: the reusable's own `replicates` input, verbatim. */
 // biome-ignore lint/suspicious/noTemplateCurlyInString: a GHA expression literal matched verbatim against the workflow, not a JS template.
-const REPLICATE_NAME_SUFFIX = " (replicate ${{ matrix.replicate }})";
-/** The expression that makes each reusable fan-out cell's display name the provider id + replicate index
- *  (the nesting child): "<provider> (replicate N)". The replicate suffix keeps each of a provider's R
- *  replicate sandboxes a distinct, legible cell — a bare `matrix.provider` would render them identically. */
-export const EXPECTED_PROVIDER_NAME_EXPR = `${PROVIDER_NAME_EXPR}${REPLICATE_NAME_SUFFIX}`;
+export const EXPECTED_REPLICATES_ENV_EXPR = "${{ inputs.replicates }}";
+/** The argument the run step must pass, so the env value is actually CONSUMED. Setting the env
+ *  without passing the flag leaves bench-suite on its single-sandbox default — a green matrix run
+ *  publishing R=1 — which is precisely what this invariant exists to prevent. */
+export const EXPECTED_REPLICATES_ARG = `--replicates "$${REPLICATES_ENV_KEY}"`;
+/** The expression the suite-matrix caller must hand down as `with.replicates`: this suite's slice of
+ *  the plan's per-suite map. Pinned because a hardcoded array here (`'[0]'`) would pass every other
+ *  nesting check while quietly running one sandbox per cell — the same R=1 outcome the callee-side
+ *  checks guard, entered from the caller instead. */
+export const EXPECTED_REPLICATES_INPUT_EXPR =
+	// biome-ignore lint/suspicious/noTemplateCurlyInString: a GHA expression literal matched verbatim against the workflow, not a JS template.
+	"${{ toJSON(fromJSON(needs.plan.outputs.replicates)[matrix.suite]) }}";
 
 /**
  * The bench-matrix suite-matrix caller — exactly one job whose `uses` targets the reusable
@@ -61,6 +82,10 @@ export function matrixSuiteCaller(
 		if (typeof suiteInput !== "string") {
 			throw new Error(`${label}: job "${jobId}" calls ${uses} without a string "suite" input`);
 		}
+		const replicatesInput = withMap.replicates;
+		if (typeof replicatesInput !== "string") {
+			throw new Error(`${label}: job "${jobId}" calls ${uses} without a string "replicates" input`);
+		}
 		const name = typeof job.name === "string" ? job.name : "";
 		const strategy = asRecord(
 			job.strategy,
@@ -76,7 +101,7 @@ export function matrixSuiteCaller(
 				`${label}: job "${jobId}" calls ${uses} without a string "strategy.matrix.suite" axis`,
 			);
 		}
-		callers.push({ jobId, name, suiteInput, matrixSuiteExpr });
+		callers.push({ jobId, name, suiteInput, replicatesInput, matrixSuiteExpr });
 	}
 	if (callers.length === 0) {
 		throw new Error(
@@ -128,6 +153,14 @@ export function checkSuiteMatrixCaller(
 				`matrix cell dispatches its own suite (got "${caller.suiteInput}")`,
 		);
 	}
+	if (caller.replicatesInput !== EXPECTED_REPLICATES_INPUT_EXPR) {
+		errors.push(
+			`${label}: job "${caller.jobId}" with.replicates must be "${EXPECTED_REPLICATES_INPUT_EXPR}" ` +
+				`so each cell receives its own suite's replicate axis from the plan — a literal or a ` +
+				`different suite's slice silently changes how many sandboxes the run measures ` +
+				`(got "${caller.replicatesInput}")`,
+		);
+	}
 	if (caller.matrixSuiteExpr !== EXPECTED_SUITE_MATRIX_EXPR) {
 		errors.push(
 			`${label}: job "${caller.jobId}" strategy.matrix.suite must be "${EXPECTED_SUITE_MATRIX_EXPR}" ` +
@@ -145,7 +178,16 @@ export function checkSuiteMatrixCaller(
 
 /**
  * Invariant 6 (callee half): the reusable bench-suite fan-out job display name is the provider id so
- * nested Actions UI cells read as "<suite> / <provider>".
+ * nested Actions UI cells read as "<suite> / <provider>", AND the replicate axis reaches the cell as
+ * data rather than as a matrix axis.
+ *
+ * The replicate check is the load-bearing half. The `replicates` input used to be consumed by
+ * `strategy.matrix.replicate`, so forgetting to wire it was impossible — the fan-out simply had no
+ * cells. Now the array is handed to one cell through the run step's environment, and a dropped or
+ * misspelled `BENCH_REPLICATES` would leave `bench-suite` on its single-sandbox default: a green
+ * matrix run that quietly published R=1 for every provider, with the dataset's between-machine
+ * intervals silently collapsing to within-machine ones. Assert both that the axis is gone from the
+ * matrix (so R runners are not re-introduced by accident) and that the input reaches the cell.
  */
 export function checkSuiteWorkflowNesting(doc: unknown, label: string = SUITE_WORKFLOW): string[] {
 	const root = asRecord(doc, `${label}: not a YAML mapping`);
@@ -155,12 +197,68 @@ export function checkSuiteWorkflowNesting(doc: unknown, label: string = SUITE_WO
 		return [`${label}: job "${SUITE_JOB}" is missing — the provider fan-out job is required`];
 	}
 	const bench = asRecord(job, `${label}: job "${SUITE_JOB}" is not a mapping`);
+	const errors: string[] = [];
+
 	const name = typeof bench.name === "string" ? bench.name : "";
 	if (name !== EXPECTED_PROVIDER_NAME_EXPR) {
-		return [
+		errors.push(
 			`${label}: job "${SUITE_JOB}" name must be "${EXPECTED_PROVIDER_NAME_EXPR}" for native ` +
 				`provider nesting under each suite (got ${name ? `"${name}"` : "no name"})`,
-		];
+		);
 	}
-	return [];
+
+	// A `replicate` matrix axis would restore one idle runner per replicate — the cost this fan-out
+	// was moved in-process to remove. `?? {}` reads an absent strategy/matrix as "no axis"; a present
+	// but malformed one still throws, matching how the rest of this module navigates.
+	const strategy = asRecord(
+		bench.strategy ?? {},
+		`${label}: job "${SUITE_JOB}" strategy is not a mapping`,
+	);
+	const matrix = asRecord(
+		strategy.matrix ?? {},
+		`${label}: job "${SUITE_JOB}" strategy.matrix is not a mapping`,
+	);
+	if (matrix.replicate !== undefined) {
+		errors.push(
+			`${label}: job "${SUITE_JOB}" must not have a "replicate" matrix axis — the cell drives ` +
+				`every replicate itself (bench-suite --replicates), so an axis here bills one idle ` +
+				`runner per replicate for no extra throughput`,
+		);
+	}
+
+	// Both remaining checks read the SAME step, so locate it once. `?? {}` again: a missing step or
+	// env block is drift this gate reports, not a parse error — the two checks below name it.
+	const step = stepByName(bench, RUN_STEP, label);
+	const env = asRecord(
+		step?.env ?? {},
+		`${label}: job "${SUITE_JOB}" step "${RUN_STEP}" env is not a mapping`,
+	);
+
+	// ...the array must actually reach it, or the cell silently falls back to a single sandbox...
+	const rawEnv = env[REPLICATES_ENV_KEY];
+	const replicatesEnv = typeof rawEnv === "string" ? rawEnv : undefined;
+	if (replicatesEnv !== EXPECTED_REPLICATES_ENV_EXPR) {
+		errors.push(
+			`${label}: job "${SUITE_JOB}" step "${RUN_STEP}" must set ${REPLICATES_ENV_KEY}: ` +
+				`"${EXPECTED_REPLICATES_ENV_EXPR}" so the cell fans out over the plan's replicate axis ` +
+				`(got ${replicatesEnv === undefined ? "no such env key" : `"${replicatesEnv}"`})`,
+		);
+	}
+
+	// ...AND the command must consume it. Checking only the env block left the invariant bypassable by
+	// its own stated failure mode: dropping the flag from the `run:` line keeps the env key present, so
+	// the gate stayed green while bench-suite took its single-sandbox default and the legacy
+	// `<runId>.json` glob in commit-dataset.yml collected the lone shard without complaint — a matrix
+	// run that publishes R=1 with the dataset's between-machine intervals collapsed to within-machine
+	// ones. A substring match is enough and matches how the rest of this module pins expressions.
+	const runCommand = typeof step?.run === "string" ? step.run : undefined;
+	if (runCommand === undefined || !runCommand.includes(EXPECTED_REPLICATES_ARG)) {
+		errors.push(
+			`${label}: job "${SUITE_JOB}" step "${RUN_STEP}" must pass ${EXPECTED_REPLICATES_ARG} to ` +
+				`bench-suite — setting ${REPLICATES_ENV_KEY} without consuming it silently runs ONE sandbox ` +
+				`per cell (got ${runCommand === undefined ? "no run: command" : `"${runCommand.trim()}"`})`,
+		);
+	}
+
+	return errors;
 }

--- a/tooling/repo-checks/src/lib/workflow-sync.ts
+++ b/tooling/repo-checks/src/lib/workflow-sync.ts
@@ -25,7 +25,8 @@
 //   5. Both live-run jobs (smoke's job and the reusable fan-out) outlast the longest registered sandbox
 //      lifetime by a fixed margin, so a suite budget increase cannot leave an otherwise healthy job to
 //      be killed by Actions first.
-//   6. Nesting wiring (suite-matrix caller + reusable provider job name) — see workflow-nesting.ts.
+//   6. Nesting wiring (suite-matrix caller + reusable provider job name) and the replicate axis
+//      reaching the cell as BENCH_REPLICATES data rather than as a matrix axis — see workflow-nesting.ts.
 //
 // YAML navigation lives in workflow-yaml.ts; nesting checks in workflow-nesting.ts. This file owns
 // credential/timeout invariants plus runCheck orchestration, and re-exports the public surface the
@@ -57,9 +58,13 @@ export {
 	checkSuiteMatrixCaller,
 	checkSuiteWorkflowNesting,
 	EXPECTED_PROVIDER_NAME_EXPR,
+	EXPECTED_REPLICATES_ARG,
+	EXPECTED_REPLICATES_ENV_EXPR,
+	EXPECTED_REPLICATES_INPUT_EXPR,
 	EXPECTED_SUITE_MATRIX_EXPR,
 	EXPECTED_SUITE_NAME_EXPR,
 	matrixSuiteCaller,
+	REPLICATES_ENV_KEY,
 } from "./workflow-nesting.ts";
 export type { DispatchInput } from "./workflow-yaml.ts";
 export {
@@ -233,6 +238,42 @@ export function checkWorkflowTimeouts(timeoutByWorkflow: Record<string, number>)
 		);
 }
 
+/** The run-step env key carrying the cell's job budget down to `bench-suite`. */
+export const CELL_BUDGET_ENV_KEY = "BENCH_CELL_BUDGET_MINUTES";
+
+/**
+ * Invariant 5 (second half): the budget the cell's run step advertises equals the job's real
+ * `timeout-minutes`.
+ *
+ * `bench-suite` refuses a `--max-concurrency` cap whose serial waves cannot fit the cell's budget —
+ * the check that keeps a capped fan-out from being cancelled mid-flight with all R shards lost. It
+ * learns that budget from this env key, because `timeout-minutes` is not readable from an expression
+ * context, so the value is a hand-copied literal. Copied literals drift: raising the job timeout
+ * without raising the env would keep rejecting caps that now fit, and lowering it without lowering the
+ * env would wave through caps that no longer do — the exact failure the guard exists to prevent,
+ * re-entered through its own configuration. Assert them equal.
+ */
+export function checkCellBudgetEnv(
+	env: Record<string, string>,
+	timeoutMinutes: number,
+	workflow: string,
+): string[] {
+	const raw = env[CELL_BUDGET_ENV_KEY];
+	if (raw === undefined) {
+		return [
+			`${workflow}: run step must set ${CELL_BUDGET_ENV_KEY} so bench-suite can reject a ` +
+				`--max-concurrency cap that cannot fit the job's ${timeoutMinutes}-minute budget`,
+		];
+	}
+	if (Number(raw) !== timeoutMinutes) {
+		return [
+			`${workflow}: ${CELL_BUDGET_ENV_KEY} is "${raw}" but the job's timeout-minutes is ` +
+				`${timeoutMinutes} — the cell would size its fan-out against a budget it does not have`,
+		];
+	}
+	return [];
+}
+
 /**
  * The whole gate against the real workflow files under `root` — the single owner of which files feed
  * the gate, used by the real-file test in workflow-registry-sync.test.ts.
@@ -243,17 +284,22 @@ export function runCheck(root: string = findRepoRoot()): string[] {
 	// The matrix lane's credential block + run-job timeout live in the reusable bench-suite.yml that
 	// every suite job calls, so the "matrix side" of Invariants 3–5 reads that file.
 	const suiteWf = readWorkflow(SUITE_WORKFLOW, root);
+	// Read once and share: the suite run step's env feeds both the credential gate and the cell-budget
+	// gate, and its job timeout feeds both the margin gate and that same budget gate.
+	const suiteEnv = stepEnv(suiteWf, SUITE_JOB, RUN_STEP, SUITE_WORKFLOW);
+	const suiteTimeout = jobTimeoutMinutes(suiteWf, SUITE_JOB, SUITE_WORKFLOW);
 	return [
 		...checkProviderInput(dispatchInput(smoke, "provider", SMOKE_WORKFLOW)),
 		...checkSuiteInput(dispatchInput(smoke, "suite", SMOKE_WORKFLOW)),
 		...checkCredentialEnv({
 			[SMOKE_WORKFLOW]: stepEnv(smoke, SMOKE_JOB, RUN_STEP, SMOKE_WORKFLOW),
-			[SUITE_WORKFLOW]: stepEnv(suiteWf, SUITE_JOB, RUN_STEP, SUITE_WORKFLOW),
+			[SUITE_WORKFLOW]: suiteEnv,
 		}),
 		...checkWorkflowTimeouts({
 			[SMOKE_WORKFLOW]: jobTimeoutMinutes(smoke, SMOKE_JOB, SMOKE_WORKFLOW),
-			[SUITE_WORKFLOW]: jobTimeoutMinutes(suiteWf, SUITE_JOB, SUITE_WORKFLOW),
+			[SUITE_WORKFLOW]: suiteTimeout,
 		}),
+		...checkCellBudgetEnv(suiteEnv, suiteTimeout, SUITE_WORKFLOW),
 		...checkSuiteMatrixCaller(matrixSuiteCaller(matrix, MATRIX_WORKFLOW), MATRIX_WORKFLOW),
 		...checkSuiteWorkflowNesting(suiteWf, SUITE_WORKFLOW),
 	];

--- a/tooling/repo-checks/src/lib/workflow-yaml.ts
+++ b/tooling/repo-checks/src/lib/workflow-yaml.ts
@@ -97,6 +97,26 @@ export function jobTimeoutMinutes(doc: unknown, jobId: string, label: string): n
 }
 
 /**
+ * The step named `stepName` inside an already-resolved `job`, or undefined when the job has no steps
+ * list or no such step. LENIENT on purpose: the nesting gate (workflow-nesting.ts) accumulates error
+ * strings instead of throwing, so it needs "absent" as a value it can report. A step that is present
+ * but not a mapping still throws — that is malformed YAML, not drift. {@link stepEnv} layers the
+ * strict spelling on top for callers where a renamed job/step must fail the gate loudly.
+ */
+export function stepByName(
+	job: Record<string, unknown>,
+	stepName: string,
+	label: string,
+): Record<string, unknown> | undefined {
+	if (!Array.isArray(job.steps)) return undefined;
+	for (const value of job.steps) {
+		const step = asRecord(value, `${label}: malformed step`);
+		if (step.name === stepName) return step;
+	}
+	return undefined;
+}
+
+/**
  * The `env` mapping of a named step inside a job, as key -> value-expression entries. Throws if the
  * job, the step, or its env block is missing, or an env value is not a string — a renamed job/step
  * must fail the gate, not silently match nothing.
@@ -110,16 +130,12 @@ export function stepEnv(
 	const root = asRecord(doc, `${label}: not a YAML mapping`);
 	const jobs = asRecord(root.jobs, `${label}: no jobs mapping`);
 	const job = asRecord(jobs[jobId], `${label}: job "${jobId}" not found`);
-	const steps = job.steps;
-	if (!Array.isArray(steps)) throw new Error(`${label}: job "${jobId}" has no steps list`);
-	const step = steps.find((s) => asRecord(s, `${label}: malformed step`).name === stepName);
+	if (!Array.isArray(job.steps)) throw new Error(`${label}: job "${jobId}" has no steps list`);
+	const step = stepByName(job, stepName, label);
 	if (step === undefined) {
 		throw new Error(`${label}: job "${jobId}" has no step named "${stepName}"`);
 	}
-	const env = asRecord(
-		(step as Record<string, unknown>).env,
-		`${label}: step "${stepName}" has no env mapping`,
-	);
+	const env = asRecord(step.env, `${label}: step "${stepName}" has no env mapping`);
 	const entries: Record<string, string> = {};
 	for (const [key, value] of Object.entries(env)) {
 		if (typeof value !== "string") {

--- a/tooling/repo-checks/src/workflow-registry-sync.test.ts
+++ b/tooling/repo-checks/src/workflow-registry-sync.test.ts
@@ -16,6 +16,8 @@
 import { describe, expect, test } from "bun:test";
 import { PROVIDERS, SUITE_NAMES } from "@sandbox-benchmarks/schema";
 import {
+	CELL_BUDGET_ENV_KEY,
+	checkCellBudgetEnv,
 	checkCredentialEnv,
 	checkProviderInput,
 	checkSuiteInput,
@@ -24,11 +26,15 @@ import {
 	checkWorkflowTimeouts,
 	dispatchInput,
 	EXPECTED_PROVIDER_NAME_EXPR,
+	EXPECTED_REPLICATES_ARG,
+	EXPECTED_REPLICATES_ENV_EXPR,
+	EXPECTED_REPLICATES_INPUT_EXPR,
 	EXPECTED_SUITE_MATRIX_EXPR,
 	EXPECTED_SUITE_NAME_EXPR,
 	jobTimeoutMinutes,
 	MATRIX_WORKFLOW,
 	matrixSuiteCaller,
+	REPLICATES_ENV_KEY,
 	RUN_STEP,
 	readWorkflow,
 	requiredCredentialKeys,
@@ -107,6 +113,37 @@ describe("checkWorkflowTimeouts", () => {
 		expect(errors).toHaveLength(1);
 		expect(errors[0]).toContain("smoke");
 		expect(errors[0]).toContain(`${WORKFLOW_TIMEOUT_MARGIN_MINUTES}-minute host margin`);
+	});
+});
+
+describe("checkCellBudgetEnv", () => {
+	// The real workflow: the literal the run step advertises must be the job's own timeout-minutes.
+	test("the real cell budget matches the real job timeout", () => {
+		expect(
+			checkCellBudgetEnv(
+				suiteEnv,
+				jobTimeoutMinutes(suiteWf, SUITE_JOB, SUITE_WORKFLOW),
+				SUITE_WORKFLOW,
+			),
+		).toEqual([]);
+	});
+
+	// Dropping the key disables the fan-out budget guard entirely — a capped cell would then be
+	// cancelled three hours in with every shard lost, which is what the guard exists to prevent.
+	test("flags a missing budget key", () => {
+		const errors = checkCellBudgetEnv({}, 180, SUITE_WORKFLOW);
+		expect(errors).toHaveLength(1);
+		expect(errors[0]).toContain(CELL_BUDGET_ENV_KEY);
+	});
+
+	// The drift that matters: raising `timeout-minutes` without raising the copied literal keeps
+	// rejecting caps that now fit; lowering it without lowering the literal waves through caps that
+	// no longer do.
+	test("flags a budget that has drifted from the job timeout", () => {
+		const errors = checkCellBudgetEnv({ [CELL_BUDGET_ENV_KEY]: "180" }, 240, SUITE_WORKFLOW);
+		expect(errors).toHaveLength(1);
+		expect(errors[0]).toContain('is "180"');
+		expect(errors[0]).toContain("timeout-minutes is 240");
 	});
 });
 
@@ -295,11 +332,39 @@ describe("checkSuiteMatrixCaller", () => {
 				a: {
 					name: EXPECTED_SUITE_NAME_EXPR,
 					uses: "./.github/workflows/bench-suite.yml",
-					with: { suite: EXPECTED_SUITE_NAME_EXPR },
+					with: { suite: EXPECTED_SUITE_NAME_EXPR, replicates: EXPECTED_REPLICATES_INPUT_EXPR },
 					strategy: { matrix: { suite: EXPECTED_SUITE_MATRIX_EXPR } },
 				},
 				b: {
 					name: EXPECTED_SUITE_NAME_EXPR,
+					uses: "./.github/workflows/bench-suite.yml",
+					with: { suite: EXPECTED_SUITE_NAME_EXPR, replicates: EXPECTED_REPLICATES_INPUT_EXPR },
+					strategy: { matrix: { suite: EXPECTED_SUITE_MATRIX_EXPR } },
+				},
+			},
+		});
+		expect(() => matrixSuiteCaller(Bun.YAML.parse(yaml), "synthetic.yml")).toThrow(
+			"expected exactly one suite-matrix caller",
+		);
+	});
+
+	// The caller-side twin of the run-step bypass: hardcoding the array here passes every other nesting
+	// check while quietly measuring one sandbox per cell.
+	test("flags a caller that hardcodes with.replicates instead of taking the plan's slice", () => {
+		const caller = {
+			...matrixSuiteCaller(matrix),
+			replicatesInput: "[0]",
+		};
+		const errors = checkSuiteMatrixCaller(caller, "synthetic.yml");
+		expect(errors).toHaveLength(1);
+		expect(errors[0]).toContain("with.replicates must be");
+		expect(errors[0]).toContain(EXPECTED_REPLICATES_INPUT_EXPR);
+	});
+
+	test("matrixSuiteCaller throws on a reusable-caller job with no string replicates", () => {
+		const yaml = Bun.YAML.stringify({
+			jobs: {
+				bad: {
 					uses: "./.github/workflows/bench-suite.yml",
 					with: { suite: EXPECTED_SUITE_NAME_EXPR },
 					strategy: { matrix: { suite: EXPECTED_SUITE_MATRIX_EXPR } },
@@ -307,7 +372,7 @@ describe("checkSuiteMatrixCaller", () => {
 			},
 		});
 		expect(() => matrixSuiteCaller(Bun.YAML.parse(yaml), "synthetic.yml")).toThrow(
-			"expected exactly one suite-matrix caller",
+			'without a string "replicates" input',
 		);
 	});
 
@@ -328,14 +393,96 @@ describe("checkSuiteWorkflowNesting", () => {
 		expect(checkSuiteWorkflowNesting(suiteWf)).toEqual([]);
 	});
 
+	/** A fan-out job that satisfies every nesting invariant; each drift test bends exactly one field. */
+	const wiredRunStep = {
+		name: RUN_STEP,
+		env: { [REPLICATES_ENV_KEY]: EXPECTED_REPLICATES_ENV_EXPR },
+		run: `bun apps/cli/src/bin/bench-suite.ts "$BENCH_PROVIDER" "$BENCH_SUITE" "$GITHUB_RUN_ID" ${EXPECTED_REPLICATES_ARG}`,
+	};
+	const wiredFanOut = {
+		name: EXPECTED_PROVIDER_NAME_EXPR,
+		"runs-on": "ubuntu-24.04",
+		steps: [wiredRunStep],
+	};
+	const nestingErrors = (job: object): string[] =>
+		checkSuiteWorkflowNesting(
+			Bun.YAML.parse(Bun.YAML.stringify({ jobs: { [SUITE_JOB]: job } })),
+			"synthetic.yml",
+		);
+
+	test("passes a fan-out job named matrix.provider that receives the replicate array", () => {
+		expect(nestingErrors(wiredFanOut)).toEqual([]);
+	});
+
 	test("flags a fan-out job whose display name is not matrix.provider", () => {
-		const yaml = Bun.YAML.stringify({
-			jobs: { [SUITE_JOB]: { name: "Run", "runs-on": "ubuntu-24.04" } },
-		});
-		const errors = checkSuiteWorkflowNesting(Bun.YAML.parse(yaml), "synthetic.yml");
+		const errors = nestingErrors({ ...wiredFanOut, name: "Run" });
 		expect(errors).toHaveLength(1);
 		expect(errors[0]).toContain("name must be");
 		expect(errors[0]).toContain(EXPECTED_PROVIDER_NAME_EXPR);
+	});
+
+	// Re-adding the axis is the exact regression the in-process fan-out exists to prevent: it would
+	// silently restore one idle runner per replicate.
+	test("flags a reinstated replicate matrix axis", () => {
+		const errors = nestingErrors({
+			...wiredFanOut,
+			strategy: { matrix: { provider: "[]", replicate: "[0,1]" } },
+		});
+		expect(errors).toHaveLength(1);
+		expect(errors[0]).toContain('must not have a "replicate" matrix axis');
+	});
+
+	test("accepts a provider-only matrix", () => {
+		expect(nestingErrors({ ...wiredFanOut, strategy: { matrix: { provider: "[]" } } })).toEqual([]);
+	});
+
+	// Without the env wiring the cell falls back to ONE sandbox — a green run that publishes R=1 while
+	// the plan asked for R=12, so the drift must fail the gate rather than the dataset.
+	test("flags a run step that never receives the replicate array", () => {
+		const errors = nestingErrors({
+			...wiredFanOut,
+			steps: [{ ...wiredRunStep, env: {} }],
+		});
+		expect(errors).toHaveLength(1);
+		expect(errors[0]).toContain(REPLICATES_ENV_KEY);
+		expect(errors[0]).toContain("no such env key");
+	});
+
+	// The bypass that made the env check alone insufficient: keep the env key, drop the flag. The cell
+	// then takes bench-suite's single-sandbox default and commit-dataset's legacy glob collects the one
+	// shard without complaint — a green matrix run publishing R=1.
+	test("flags a run step that sets the env but never passes --replicates", () => {
+		const errors = nestingErrors({
+			...wiredFanOut,
+			steps: [
+				{
+					...wiredRunStep,
+					run: 'bun apps/cli/src/bin/bench-suite.ts "$BENCH_PROVIDER" "$BENCH_SUITE" "$GITHUB_RUN_ID"',
+				},
+			],
+		});
+		expect(errors).toHaveLength(1);
+		expect(errors[0]).toContain(EXPECTED_REPLICATES_ARG);
+	});
+
+	test("flags a run step with no run: command at all", () => {
+		const { run: _dropped, ...noRun } = wiredRunStep;
+		const errors = nestingErrors({ ...wiredFanOut, steps: [noRun] });
+		expect(errors).toHaveLength(1);
+		expect(errors[0]).toContain("no run: command");
+	});
+
+	// `replicas` (the dispatch knob) vs `replicates` (the plan's index array) is the plausible typo:
+	// it's a live input name, so it resolves to a value rather than failing the workflow outright.
+	test("flags a replicate array wired to the wrong expression", () => {
+		// biome-ignore lint/suspicious/noTemplateCurlyInString: a GHA expression literal, not a JS template.
+		const wrongExpr = "${{ inputs.replicas }}";
+		const errors = nestingErrors({
+			...wiredFanOut,
+			steps: [{ ...wiredRunStep, env: { [REPLICATES_ENV_KEY]: wrongExpr } }],
+		});
+		expect(errors).toHaveLength(1);
+		expect(errors[0]).toContain(EXPECTED_REPLICATES_ENV_EXPR);
 	});
 });
 


### PR DESCRIPTION
**REPLICATE FAN-OUT — drive a cell's whole replicate fan-out from ONE runner instead of R idle ones**

Shipped as a 7-PR stack (merge bottom-up, each branch independently green):

1. #282 — schema: own the workflow timeout margin next to the suite budgets
2. #283 — harness: make result collection non-blocking so peer polls keep running
3. #284 — cli lib: the replicate fan-out primitives — pool, flags, budget guard
4. #285 — cli lib: `[rN]` line tagging + a concurrency-safe Actions log layer
5. #286 — cli: report a replicate as an outcome instead of exiting from inside it
6. #287 — cli: drive a cell's whole replicate fleet from one process
7. #288 — ci: retire the replicate matrix axis and gate the new wiring ← **this PR**

↑ **This PR is #288 (7/7)**, based on #287.

---
Wire the in-process fan-out into CI and retire the replicate matrix axis. `plan` still emits all
three axes, but the replicate array now travels to each (suite, provider) cell as DATA
(`with.replicates` -> `BENCH_REPLICATES` -> `bench-suite --replicates`) instead of expanding into
runners. Cells display as "<suite> / <provider>" and each drives its own R sandboxes concurrently.
At the shipped defaults that is 54 runners where 324 ran, with the same sandbox count, the same
provider load, and the same wall clock (a cell's clock is its slowest replicate, not their sum).

Two honest costs, both documented in the workflows themselves:

  * PEAK provider concurrency is no longer incidentally throttled. The old 324 jobs contended for
    GitHub's account-wide concurrent-job limit, which capped how many sandboxes existed at once; 54
    jobs fit under any plan's cap, so a run can now hold all 54 of a provider's sandboxes at once.
    Providers answer over-quota with a capacity error that `createSuiteSandbox` retries for up to 60
    minutes, so the degradation is queueing, not failure — the new `max_concurrency` dispatch input
    is the control, and `strategy.max-parallel` on the suite matrix is the coarser alternative.
  * Failure isolation is NARROWER than `fail-fast: false` was. Replicate-level isolation is
    preserved inside the process, but a whole-cell event — job timeout, runner eviction, OOM, a
    "re-run failed jobs" click — now costs all R replicates of the cell rather than one.

The artifact upload is hardened for exactly that re-run case. One cell's artifact now carries its R
shards, and a re-run keeps `github.run_id`, so the name is unchanged on the retry and
upload-artifact rejects the duplicate by default — computing a whole fleet and discarding it at the
upload boundary. `overwrite: true` fixes that, but overwriting is only safe when there is something
to put in its place: `if-no-files-found: error` cannot tell, because the cell uploads `path: data/`
and `data/dataset/` is CHECKED IN, so data/ is non-empty from checkout on every attempt. So the
upload is gated on a step that globs for this run's shard files by name: a pass that wrote shards
replaces the attempt it retried, a pass that died before writing one leaves the previous attempt's
good shards standing.

commit-dataset.yml selects between the two shard shapes (`<runId>-r<idx>.json` and the legacy
un-suffixed `<runId>.json`) with a PREFERENCE applied PER CELL, never a union and never run-wide.
Not a union because run ids are preserved across re-runs, so one run id can hold both shapes for the
same sandbox — an un-suffixed shard normalizes to replicate 0 and collides with `-r0`, and
`aggregate`'s first-wins rule would silently drop one sandbox's whole measured set. Per cell because
the collision is per cell: a run-wide choice would publish ONLY the retried cell and silently discard
every legacy-only peer, promoting a dataset a fraction of the size it should be.

The gate grows with the wiring, because the wiring lost its structural safety net: the `replicates`
input used to be consumed by `strategy.matrix.replicate`, so forgetting to wire it was impossible —
the fan-out simply had no cells. Now a dropped env key or a dropped flag leaves bench-suite on its
single-sandbox default: a GREEN matrix run publishing R=1 for every provider, with the dataset's
between-machine intervals silently collapsed to within-machine ones, and commit-dataset's legacy glob
collecting the lone shard without complaint. So Invariant 6 now asserts the `replicate` matrix axis
is GONE (an axis re-added by accident restores the idle runners), that `BENCH_REPLICATES` carries
`inputs.replicates`, that the run command actually PASSES `--replicates` (checking only the env left
the invariant bypassable by its own stated failure mode), and that the caller hands down the plan's
per-suite slice rather than a hardcoded array. Invariant 5 gains `checkCellBudgetEnv`: the cell's
`BENCH_CELL_BUDGET_MINUTES` is a hand-copied literal (`timeout-minutes` is not readable from an
expression context), and drift in either direction re-enters the exact failure the fan-out budget
guard exists to prevent.

Docs and comments describing the old runner axis are updated to match — methodology's pipeline
section, plan-replicates/matrix's plan contract, aggregate's shard shape, and the raw-tree naming
contract.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Run all replicates in-process per (suite, provider) cell and remove the `replicate` matrix axis. This keeps sandbox count and wall clock the same while cutting runner usage at defaults from 324 to 54.

- **New Features**
  - Replicates travel as data: `with.replicates` → `BENCH_REPLICATES` → `bench-suite --replicates`. Cells display as "<suite> / <provider>".
  - Added `max_concurrency` to cap per-cell replicate fan-out; caps that can’t fit the job budget are rejected early using `BENCH_CELL_BUDGET_MINUTES` (must equal `timeout-minutes`).
  - One artifact per cell carries all shard Runs (`<runId>-r<idx>.json`). Upload uses `overwrite: true` only when shards exist to fix re-run duplicate-name failures without clobbering good shards.
  - `commit-dataset.yml` prefers per-replicate shards per cell and falls back to legacy `<runId>.json`, with per-shape cell counts logged.
  - Workflow gate updates: assert no `replicate` matrix axis; ensure `BENCH_REPLICATES` is wired to `inputs.replicates` and `--replicates` is passed; verify the caller forwards the plan’s per-suite slice; assert `BENCH_CELL_BUDGET_MINUTES` matches `timeout-minutes`.

- **Migration**
  - No changes for typical runs; published data stays consistent.
  - If provider quotas are tight, set `max_concurrency` or lower suite `strategy.max-parallel`.
  - For long suites (realworld R=12), raise the cell timeout or avoid capping; waves must fit the budget.
  - Do not re-add a `replicate` matrix axis; it would restore one idle runner per replicate.

<sup>Written for commit 4c63e8e7223b0952bbc28a9b7a2f9c17da4bf08d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/starslingdev/hpc-sandbox-benchmarks/pull/288?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

