### PR TITLE
Reorganize leaderboard: lead with real-world workflows, collapse synthetics

### DIFF
--- a/LEADERBOARD.md
+++ b/LEADERBOARD.md
@@ -1,6 +1,7 @@
 # Sandbox provider leaderboard
 
-Run `30322186937` · commit `769743f75f2d0c55fd51b01ec5f026bdcdba774c` · generated 2026-07-28T05:35:57.390Z
+Run [`30322186937`](https://github.com/starslingdev/hpc-sandbox-benchmarks/actions/runs/30322186937) · commit [`769743f75f2d0c55fd51b01ec5f026bdcdba774c`](https://github.com/starslingdev/hpc-sandbox-benchmarks/commit/769743f75f2d0c55fd51b01ec5f026bdcdba774c) ·
+dataset [`data/dataset/runs/30322186937.json`](data/dataset/runs/30322186937.json) · generated 2026-07-28T05:35:57.390Z
 
 Requested target for every provider: **4 vCPU · 8 GiB RAM · 40 GB disk**. This run contains **298 metric records**
 backed by **2980 retained trial observations**, across **44 metrics** and
@@ -13,6 +14,11 @@ Generated from the published Run dataset — do not edit by hand. Methodology:
 when statistically indistinguishable or tied on the median (see details below) · a coverage gap means unmeasured, never a score of zero.
 CPU/RAM comparability uses observed vCPU and RAM (±10% RAM); disk is a workload-capacity gate
 surfaced through coverage gaps, not part of the compute-match verdict.
+
+**Document order:** the real-world developer workflows lead, because what a developer or a CI job
+actually waits on is what this benchmark exists to measure. The synthetic microbenchmarks (`cpu`, `disk`, `memory`, `network`, `system`)
+load one hardware axis in isolation — a real question, but a different one — so each is collapsed by
+default; expand a section to read its tables.
 
 ## Providers in this run
 
@@ -32,431 +38,6 @@ cross-check.
 | Novita | microVM | vm |
 
 _Not present in this run: Daytona (container) — registered providers that reported no data (not dispatched, or every cell was lost before reporting anything)._
-
-## cpu
-
-### Node.js web tooling _(headline)_
-
-runs/s · higher is better
-
-_Namespace leads · ~1.2× Blaxel on median (higher is better)._
-
-| Rank | Provider | Node.js web tooling (runs/s) | 95% bootstrap interval | n | Note |
-| ---: | --- | ---: | ---: | ---: | --- |
-| 1 | Namespace | 25.55 | 22.54 – 28.9 | 18 | — |
-| 2 | Blaxel | 20.89 | 20.6 – 21.22 | 33 | n too small |
-| 3 | Daytona (VM) | 18.53 | 18.22 – 18.62 | 9 | n too small |
-| 4 | Novita | 17.9 | 17.21 – 18.7 | 9 | n too small |
-| 5 | Modal (VM) | 15.43 | 15.22 – 21.01 | 27 | n too small |
-| 6 | E2B | 11.3 | 10.95 – 11.46 | 9 | n too small |
-| 7 | Modal (gVisor) | 9.33 | 8.9 – 9.64 | 21 | n too small |
-
-## disk
-
-### fio rand read 4KB, O_DIRECT (IOPS) _(headline)_
-
-IOPS · higher is better
-
-_Namespace leads on median (higher is better); see notes for how ranks are decided._
-
-| Rank | Provider | fio rand read 4KB, O_DIRECT (IOPS) (IOPS) | 95% bootstrap interval | n | Note |
-| ---: | --- | ---: | ---: | ---: | --- |
-| 1 | Namespace | 246500 | 241000 – 258000 | 6 | — |
-| 2 | Daytona (VM) | 245500 | 238000 – 276000 | 6 | n too small |
-| 3 | Blaxel | 233000 | 214800 – 378000 | 6 | n too small |
-| 4 | Modal (VM) | 227000 | 120000 – 427000 | 6 | n too small |
-| 5 | Novita | 80850 | 62900 – 88000 | 6 | n too small |
-| 6 | E2B | 47200 | 46800 – 48200 | 6 | n too small |
-| 7 | Modal (gVisor) | 33400 | 31700 – 34400 | 6 | n too small |
-
-### fio rand read 4KB, O_DIRECT (MB/s)
-
-MB/s · higher is better
-
-_Namespace leads on median (higher is better); see notes for how ranks are decided._
-
-| Rank | Provider | fio rand read 4KB, O_DIRECT (MB/s) (MB/s) | 95% bootstrap interval | n | Note |
-| ---: | --- | ---: | ---: | ---: | --- |
-| 1 | Namespace | 961.5 | 946.5 – 1004 | 6 | — |
-| 2 | Daytona (VM) | 960 | 931 – 1079 | 6 | n too small |
-| 3 | Blaxel | 911.5 | 809 – 1439 | 6 | n too small |
-| 4 | Modal (VM) | 885.5 | 664 – 1666 | 6 | n too small |
-| 5 | Novita | 316 | 246 – 344 | 6 | n too small |
-| 6 | E2B | 184.5 | 183 – 188 | 6 | n too small |
-| 7 | Modal (gVisor) | 130.5 | 124 – 134 | 6 | n too small |
-
-### fio rand write 4KB, O_DIRECT (IOPS)
-
-IOPS · higher is better
-
-_Modal (VM) leads · ~1.2× Namespace on median (higher is better)._
-
-| Rank | Provider | fio rand write 4KB, O_DIRECT (IOPS) (IOPS) | 95% bootstrap interval | n | Note |
-| ---: | --- | ---: | ---: | ---: | --- |
-| 1 | Modal (VM) | 287000 | 210000 – 375000 | 6 | — |
-| 2 | Namespace | 245500 | 239000 – 247500 | 6 | n too small |
-| 3 | Daytona (VM) | 222000 | 208000 – 233000 | 6 | n too small |
-| 4 | Blaxel | 218000 | 200000 – 285000 | 6 | n too small |
-| 5 | Novita | 79600 | 73400 – 82400 | 6 | n too small |
-| 6 | E2B | 48600 | 47100 – 50100 | 6 | n too small |
-| 7 | Modal (gVisor) | 28500 | 27000 – 29200 | 6 | n too small |
-
-### fio rand write 4KB, O_DIRECT (MB/s)
-
-MB/s · higher is better
-
-_Modal (VM) leads · ~1.2× Namespace on median (higher is better)._
-
-| Rank | Provider | fio rand write 4KB, O_DIRECT (MB/s) (MB/s) | 95% bootstrap interval | n | Note |
-| ---: | --- | ---: | ---: | ---: | --- |
-| 1 | Modal (VM) | 1121 | 821 – 1463 | 6 | — |
-| 2 | Namespace | 959.5 | 935 – 974 | 6 | n too small |
-| 3 | Daytona (VM) | 866.5 | 814 – 910 | 6 | n too small |
-| 4 | Blaxel | 851.5 | 783 – 1112 | 6 | n too small |
-| 5 | Novita | 311 | 287 – 322 | 6 | n too small |
-| 6 | E2B | 190 | 184 – 196 | 6 | n too small |
-| 7 | Modal (gVisor) | 111.5 | 105 – 114 | 6 | n too small |
-
-### fio seq read 1MB, O_DIRECT (IOPS)
-
-IOPS · higher is better
-
-_Modal (gVisor) leads · ~1.6× Daytona (VM) on median (higher is better)._
-
-| Rank | Provider | fio seq read 1MB, O_DIRECT (IOPS) (IOPS) | 95% bootstrap interval | n | Note |
-| ---: | --- | ---: | ---: | ---: | --- |
-| 1 | Modal (gVisor) | 18650 | 15800 – 21000 | 6 | — |
-| 2 | Daytona (VM) | 11550 | 8750 – 16800 | 6 | n too small |
-| 3 | Novita | 9521 | 7402 – 13000 | 6 | n too small |
-| 4 | Blaxel | 8016 | 5907 – 9900 | 6 | n too small |
-| 5 | Namespace | 3947 | 2133 – 4012 | 6 | n too small |
-| 6 | Modal (VM) | 2059 | 1712 – 4243 | 6 | n too small |
-| 7 | E2B | 600 | 599 – 600 | 6 | n too small |
-
-### fio seq read 1MB, O_DIRECT (MB/s)
-
-MB/s · higher is better
-
-_Daytona (VM) leads · ~1.1× Blaxel on median (higher is better)._
-
-| Rank | Provider | fio seq read 1MB, O_DIRECT (MB/s) (MB/s) | 95% bootstrap interval | n | Note |
-| ---: | --- | ---: | ---: | ---: | --- |
-| 1 | Daytona (VM) | 8752 | — | 1 | — |
-| 2 | Blaxel | 8018 | 5909 – 9285 | 6 | — |
-| 3 | Novita | 7576 | 7231 – 8942 | 3 | n too small |
-| 4 | Namespace | 3949 | 2131 – 4014 | 6 | n too small |
-| 5 | Modal (VM) | 2061 | 1757 – 4245 | 6 | n too small |
-| 6 | E2B | 601 | 601 – 601 | 6 | n too small |
-
-### fio seq write 1MB, O_DIRECT (IOPS)
-
-IOPS · higher is better
-
-_Novita leads on median (higher is better); see notes for how ranks are decided._
-
-| Rank | Provider | fio seq write 1MB, O_DIRECT (IOPS) (IOPS) | 95% bootstrap interval | n | Note |
-| ---: | --- | ---: | ---: | ---: | --- |
-| 1 | Novita | 6017 | 5614 – 6711 | 6 | — |
-| 2 | Blaxel | 5824 | 4395 – 6102 | 6 | n too small |
-| 3 | Daytona (VM) | 3985 | 3361 – 6726 | 6 | n too small |
-| 4 | Modal (VM) | 3204 | 2725 – 5434 | 6 | n too small |
-| 5 | Modal (gVisor) | 3119 | 2570 – 5499 | 6 | n too small |
-| 6 | Namespace | 2470 | 1365 – 2490 | 6 | n too small |
-| 7 | E2B | 599 | 599 – 600 | 6 | n too small |
-
-### fio seq write 1MB, O_DIRECT (MB/s)
-
-MB/s · higher is better
-
-_Novita leads on median (higher is better); see notes for how ranks are decided._
-
-| Rank | Provider | fio seq write 1MB, O_DIRECT (MB/s) (MB/s) | 95% bootstrap interval | n | Note |
-| ---: | --- | ---: | ---: | ---: | --- |
-| 1 | Novita | 6018 | 5616 – 6713 | 6 | — |
-| 2 | Blaxel | 5826 | 4196 – 6104 | 6 | n too small |
-| 3 | Daytona (VM) | 3986 | 3524 – 5824 | 6 | n too small |
-| 4 | Modal (VM) | 3205 | 2726 – 5435 | 6 | n too small |
-| 5 | Modal (gVisor) | 3121 | 2385 – 6214 | 6 | n too small |
-| 6 | Namespace | 2472 | 1367 – 2492 | 6 | n too small |
-| 7 | E2B | 601 | 600 – 602 | 6 | n too small |
-
-### Hardlink throughput
-
-bogo ops/s · higher is better
-
-_Daytona (VM) leads · ~1.3× Blaxel on median (higher is better)._
-
-| Rank | Provider | Hardlink throughput (bogo ops/s) | 95% bootstrap interval | n | Note |
-| ---: | --- | ---: | ---: | ---: | --- |
-| 1 | Daytona (VM) | 25.64 | 23.97 – 26.22 | 6 | — |
-| 2 | Blaxel | 19.66 | 19.56 – 20.05 | 6 | n too small |
-| 3 | Novita | 16.92 | 16.76 – 17.59 | 6 | n too small |
-| 4 | Modal (VM) | 15.87 | 8.05 – 31.75 | 6 | n too small |
-| 5 | Namespace | 5.18 | 4.42 – 5.22 | 6 | n too small |
-| 6 | Modal (gVisor) | 3.22 | 2.68 – 3.33 | 6 | n too small |
-| 7 | E2B | 1.36 | 1.36 – 1.4 | 6 | n too small |
-
-## memory
-
-### STREAM Triad _(headline)_
-
-MB/s · higher is better
-
-_Blaxel leads · ~1.3× Daytona (VM) on median (higher is better)._
-
-| Rank | Provider | STREAM Triad (MB/s) | 95% bootstrap interval | n | Note |
-| ---: | --- | ---: | ---: | ---: | --- |
-| 1 | Blaxel | 105900 | 100200 – 129900 | 15 | — |
-| 2 | Daytona (VM) | 80130 | 65360 – 185800 | 15 | n too small |
-| 3 | Modal (gVisor) | 72660 | 64990 – 75820 | 15 | n too small |
-| 4 | Modal (VM) | 56018 | 48810 – 76530 | 15 | n too small |
-| 5 | Novita | 53380 | 42150 – 92450 | 15 | n too small |
-| 6 | E2B | 52650 | 51420 – 54200 | 15 | n too small |
-| 7 | Namespace | 33230 | 30950 – 33754 | 15 | n too small |
-
-### STREAM Add
-
-MB/s · higher is better
-
-_Blaxel leads · ~1.3× Daytona (VM) on median (higher is better)._
-
-| Rank | Provider | STREAM Add (MB/s) | 95% bootstrap interval | n | Note |
-| ---: | --- | ---: | ---: | ---: | --- |
-| 1 | Blaxel | 105600 | 99340 – 130100 | 15 | — |
-| 2 | Daytona (VM) | 78930 | 64680 – 185400 | 15 | n too small |
-| 3 | Modal (gVisor) | 72390 | 63760 – 75010 | 15 | n too small |
-| 4 | Modal (VM) | 55540 | 49480 – 75820 | 15 | n too small |
-| 5 | Novita | 53370 | 42120 – 98190 | 15 | n too small |
-| 6 | E2B | 52460 | 51140 – 54100 | 15 | n too small |
-| 7 | Namespace | 33310 | 31020 – 33670 | 15 | n too small |
-
-### STREAM Copy
-
-MB/s · higher is better
-
-_Blaxel leads · ~1.2× Modal (gVisor) on median (higher is better)._
-
-| Rank | Provider | STREAM Copy (MB/s) | 95% bootstrap interval | n | Note |
-| ---: | --- | ---: | ---: | ---: | --- |
-| 1 | Blaxel | 119600 | 116300 – 143600 | 35 | — |
-| 2 | Modal (gVisor) | 97350 | 91160 – 101100 | 70 | n too small |
-| 3 | Modal (VM) | 86894 | 83000 – 93320 | 30 | n too small |
-| 4 | Daytona (VM) | 79770 | 75670 – 219900 | 55 | n too small |
-| 5 | E2B | 78540 | 77350 – 80340 | 65 | n too small |
-| 6 | Novita | 58150 | 51580 – 109800 | 17 | n too small |
-| 7 | Namespace | 44180 | 43730 – 44790 | 50 | n too small |
-
-### STREAM Scale
-
-MB/s · higher is better
-
-_Blaxel leads · ~1.4× Daytona (VM) on median (higher is better)._
-
-| Rank | Provider | STREAM Scale (MB/s) | 95% bootstrap interval | n | Note |
-| ---: | --- | ---: | ---: | ---: | --- |
-| 1 | Blaxel | 97810 | 91410 – 121360 | 15 | — |
-| 2 | Daytona (VM) | 70870 | 58760 – 177400 | 15 | n too small |
-| 3 | Modal (gVisor) | 63980 | 56340 – 67940 | 15 | n too small |
-| 4 | Novita | 50970 | 42220 – 93490 | 15 | n too small |
-| 5 | Modal (VM) | 48155 | 41800 – 72800 | 15 | n too small |
-| 6 | E2B | 46130 | 45770 – 46630 | 15 | n too small |
-| 7 | Namespace | 30250 | 29030 – 30590 | 15 | n too small |
-
-## network
-
-### iperf3 loopback TCP, 1 stream _(headline)_
-
-Mbits/sec · higher is better
-
-_Novita leads · ~1.5× Blaxel on median (higher is better)._
-
-| Rank | Provider | iperf3 loopback TCP, 1 stream (Mbits/sec) | 95% bootstrap interval | n | Note |
-| ---: | --- | ---: | ---: | ---: | --- |
-| 1 | Novita | 148400 | 131280 – 152811 | 6 | — |
-| 2 | Blaxel | 97840 | 87545 – 155461 | 6 | n too small |
-| 3 | Namespace | 74730 | 72100 – 140164 | 6 | n too small |
-| 4 | Daytona (VM) | 70244 | 67620 – 80855 | 6 | n too small |
-| 5 | E2B | 58134 | 53179 – 68194 | 6 | n too small |
-| 6 | Modal (VM) | 26070 | 16043 – 84307 | 6 | n too small |
-| 7 | Modal (gVisor) | 11830 | 9159 – 15959 | 6 | n too small |
-
-### iperf3 loopback TCP, 10 streams
-
-Mbits/sec · higher is better
-
-_Novita leads · ~1.1× Blaxel on median (higher is better)._
-
-| Rank | Provider | iperf3 loopback TCP, 10 streams (Mbits/sec) | 95% bootstrap interval | n | Note |
-| ---: | --- | ---: | ---: | ---: | --- |
-| 1 | Novita | 144870 | 129936 – 155766 | 6 | — |
-| 2 | Blaxel | 127000 | 112685 – 164136 | 6 | n too small |
-| 3 | Daytona (VM) | 97613 | 80570 – 102949 | 6 | n too small |
-| 4 | Namespace | 68580 | 63800 – 105620 | 6 | n too small |
-| 5 | E2B | 51598 | 46865 – 61072 | 6 | n too small |
-| 6 | Modal (VM) | 19863 | 13822 – 72964 | 6 | n too small |
-| 7 | Modal (gVisor) | 12147 | 11331 – 13068 | 6 | n too small |
-
-### iperf3 loopback UDP, 10G objective
-
-Mbits/sec · higher is better
-
-_Blaxel, Daytona (VM), E2B, Modal (VM), Namespace and Novita share the top on this metric (higher is better)._
-
-| Rank | Provider | iperf3 loopback UDP, 10G objective (Mbits/sec) | 95% bootstrap interval | n | Note |
-| ---: | --- | ---: | ---: | ---: | --- |
-| 1 | Blaxel | 9999 | 9999 – 9999 | 6 | — |
-| 1 | Daytona (VM) | 9999 | 9999 – 9999 | 6 | n too small, equal medians |
-| 1 | E2B | 9999 | 9999 – 9999 | 6 | n too small, equal medians |
-| 1 | Modal (VM) | 9999 | 9999 – 10000 | 6 | n too small, equal medians |
-| 1 | Namespace | 9999 | 9999 – 9999 | 6 | n too small, equal medians |
-| 1 | Novita | 9999 | 9999 – 9999 | 6 | n too small, equal medians |
-| 7 | Modal (gVisor) | 161.5 | 142 – 171 | 6 | n too small |
-
-### iperf3 WAN download
-
-Mbits/sec · higher is better
-
-_Modal (gVisor) leads · ~1.5× Novita on median (higher is better)._
-
-| Rank | Provider | iperf3 WAN download (Mbits/sec) | 95% bootstrap interval | n | Note |
-| ---: | --- | ---: | ---: | ---: | --- |
-| 1 | Modal (gVisor) | 7040 | 6409 – 10840 | 6 | — |
-| 2 | Novita | 4840 | 3588 – 6253 | 6 | n too small |
-| 3 | Daytona (VM) | 3642 | 2984 – 4557 | 6 | n too small |
-| 4 | Namespace | 3572 | 2198 – 11600 | 6 | n too small |
-| 5 | E2B | 3443 | 537.6 – 6102 | 6 | n too small |
-| 6 | Blaxel | 1443 | 982.7 – 1654 | 6 | n too small |
-| 7 | Modal (VM) | 1404 | 674.9 – 1657 | 6 | n too small |
-
-### iperf3 WAN upload
-
-Mbits/sec · higher is better
-
-_Modal (VM) leads · ~1.3× Daytona (VM) on median (higher is better)._
-
-| Rank | Provider | iperf3 WAN upload (Mbits/sec) | 95% bootstrap interval | n | Note |
-| ---: | --- | ---: | ---: | ---: | --- |
-| 1 | Modal (VM) | 5397 | 1327 – 9306 | 6 | — |
-| 2 | Daytona (VM) | 4312 | 3806 – 4799 | 6 | n too small |
-| 3 | Novita | 3269 | 498.2 – 4410 | 6 | n too small |
-| 4 | E2B | 3150 | 1025 – 3312 | 6 | n too small |
-| 5 | Namespace | 2742 | 955.8 – 3080 | 6 | n too small |
-| 6 | Blaxel | 1754 | 809.9 – 2376 | 6 | n too small |
-| 7 | Modal (gVisor) | 156.1 | 142.1 – 181.8 | 6 | n too small |
-
-## system
-
-### PyBench _(headline)_
-
-Milliseconds · lower is better
-
-_Namespace leads · Daytona (VM) is ~1.1× higher (lower is better)._
-
-| Rank | Provider | PyBench (Milliseconds) | 95% bootstrap interval | n | Note |
-| ---: | --- | ---: | ---: | ---: | --- |
-| 1 | Namespace | 361.5 | 358.5 – 366 | 6 | — |
-| 2 | Daytona (VM) | 404 | 400 – 443 | 6 | n too small |
-| 3 | Blaxel | 478 | 475 – 493 | 6 | n too small |
-| 4 | Novita | 484 | 480 – 485 | 6 | n too small |
-| 5 | Modal (VM) | 666.5 | 479 – 673 | 6 | n too small |
-| 6 | E2B | 803 | 802 – 807 | 6 | n too small |
-| 7 | Modal (gVisor) | 896 | 888 – 903 | 6 | n too small |
-
-### Git common operations
-
-Seconds · lower is better
-
-_Namespace leads · Daytona (VM) is ~1.2× higher (lower is better)._
-
-| Rank | Provider | Git common operations (Seconds) | 95% bootstrap interval | n | Note |
-| ---: | --- | ---: | ---: | ---: | --- |
-| 1 | Namespace | 31.77 | 31.5 – 32.42 | 6 | — |
-| 2 | Daytona (VM) | 36.64 | 36.21 – 39.32 | 6 | n too small |
-| 3 | Blaxel | 43.9 | 41.7 – 48.15 | 6 | n too small |
-| 4 | Novita | 44.82 | 44.05 – 44.96 | 6 | n too small |
-| 5 | Modal (VM) | 47.17 | 41.67 – 47.32 | 6 | n too small |
-| 6 | E2B | 65.36 | 63.97 – 66.24 | 6 | n too small |
-| 7 | Modal (gVisor) | 85.1 | 80.08 – 86.72 | 6 | n too small |
-
-### pgbench RO (s100, 50c)
-
-TPS · higher is better
-
-_Blaxel leads on median (higher is better); see notes for how ranks are decided._
-
-| Rank | Provider | pgbench RO (s100, 50c) (TPS) | 95% bootstrap interval | n | Note |
-| ---: | --- | ---: | ---: | ---: | --- |
-| 1 | Blaxel | 310200 | 274900 – 348700 | 6 | — |
-| 2 | Daytona (VM) | 299800 | 270300 – 302800 | 6 | n too small |
-| 3 | Namespace | 239900 | 218300 – 385400 | 6 | n too small |
-| 4 | Novita | 237800 | 217000 – 269400 | 6 | n too small |
-| 5 | Modal (VM) | 200200 | 196300 – 201900 | 6 | n too small |
-| 6 | E2B | 176800 | 174500 – 182500 | 6 | n too small |
-| 7 | Modal (gVisor) | 11770 | 11180 – 12230 | 6 | n too small |
-
-### pgbench RO latency (s100, 50c)
-
-ms · lower is better
-
-_Blaxel leads on median (lower is better); see notes for how ranks are decided._
-
-| Rank | Provider | pgbench RO latency (s100, 50c) (ms) | 95% bootstrap interval | n | Note |
-| ---: | --- | ---: | ---: | ---: | --- |
-| 1 | Blaxel | 0.161 | 0.143 – 0.182 | 6 | — |
-| 2 | Daytona (VM) | 0.167 | 0.165 – 0.185 | 6 | n too small |
-| 3 | Namespace | 0.2085 | 0.13 – 0.229 | 6 | n too small |
-| 4 | Novita | 0.2105 | 0.186 – 0.2305 | 6 | n too small |
-| 5 | Modal (VM) | 0.2495 | 0.248 – 0.255 | 6 | n too small |
-| 6 | E2B | 0.283 | 0.2745 – 0.289 | 6 | n too small |
-| 7 | Modal (gVisor) | 4.248 | 4.088 – 4.577 | 6 | n too small |
-
-### pgbench RW (s100, 50c)
-
-TPS · higher is better
-
-_Namespace leads · ~1.1× Blaxel on median (higher is better)._
-
-| Rank | Provider | pgbench RW (s100, 50c) (TPS) | 95% bootstrap interval | n | Note |
-| ---: | --- | ---: | ---: | ---: | --- |
-| 1 | Namespace | 24890 | 16100 – 41320 | 6 | — |
-| 2 | Blaxel | 23250 | 22270 – 24530 | 6 | n too small |
-| 3 | Novita | 17700 | 15740 – 21940 | 6 | n too small |
-| 4 | Daytona (VM) | 16000 | 15570 – 16570 | 6 | n too small |
-| 5 | Modal (VM) | 14240 | 13750 – 14410 | 6 | n too small |
-| 6 | E2B | 11880 | 10980 – 12530 | 6 | n too small |
-| 7 | Modal (gVisor) | 2067 | 1942 – 2107 | 6 | n too small |
-
-### pgbench RW latency (s100, 50c)
-
-ms · lower is better
-
-_Namespace leads · Blaxel is ~1.1× higher (lower is better)._
-
-| Rank | Provider | pgbench RW latency (s100, 50c) (ms) | 95% bootstrap interval | n | Note |
-| ---: | --- | ---: | ---: | ---: | --- |
-| 1 | Namespace | 2.018 | 1.21 – 3.105 | 6 | — |
-| 2 | Blaxel | 2.151 | 2.038 – 2.217 | 6 | n too small |
-| 3 | Novita | 2.828 | 2.279 – 3.045 | 6 | n too small |
-| 4 | Daytona (VM) | 3.124 | 3.042 – 3.212 | 6 | n too small |
-| 5 | Modal (VM) | 3.51 | 3.47 – 3.617 | 6 | n too small |
-| 6 | E2B | 4.208 | 3.989 – 4.555 | 6 | n too small |
-| 7 | Modal (gVisor) | 24.19 | 23.73 – 25.75 | 6 | n too small |
-
-### SQLite Speedtest
-
-Seconds · lower is better
-
-_Daytona (VM) leads · Blaxel is ~1.2× higher (lower is better)._
-
-| Rank | Provider | SQLite Speedtest (Seconds) | 95% bootstrap interval | n | Note |
-| ---: | --- | ---: | ---: | ---: | --- |
-| 1 | Daytona (VM) | 32.09 | 30.73 – 34.82 | 6 | — |
-| 2 | Blaxel | 38.42 | 37.02 – 42.7 | 6 | n too small |
-| 3 | Novita | 41.36 | 39.96 – 44.67 | 6 | n too small |
-| 4 | Namespace | 48.41 | 47.94 – 48.73 | 6 | n too small |
-| 5 | Modal (VM) | 62.39 | 35.6 – 63.32 | 6 | n too small |
-| 6 | E2B | 70.5 | 70.25 – 73.4 | 6 | n too small |
-| 7 | Modal (gVisor) | 410 | 391.1 – 443 | 6 | n too small |
 
 ## realworld
 
@@ -725,6 +306,456 @@ _Namespace leads · Daytona (VM) is ~1.1× higher (lower is better)._
 | 4 | Novita | 50.33 | 47.41 – 56.71 | 12 | tied |
 | 6 | Modal (gVisor) | 103.9 | 97.1 – 113.1 | 12 | — |
 
+## cpu
+
+<details>
+<summary><strong>1 synthetic metric</strong> · headline: Node.js web tooling</summary>
+
+### Node.js web tooling _(headline)_
+
+runs/s · higher is better
+
+_Namespace leads · ~1.2× Blaxel on median (higher is better)._
+
+| Rank | Provider | Node.js web tooling (runs/s) | 95% bootstrap interval | n | Note |
+| ---: | --- | ---: | ---: | ---: | --- |
+| 1 | Namespace | 25.55 | 22.54 – 28.9 | 18 | — |
+| 2 | Blaxel | 20.89 | 20.6 – 21.22 | 33 | n too small |
+| 3 | Daytona (VM) | 18.53 | 18.22 – 18.62 | 9 | n too small |
+| 4 | Novita | 17.9 | 17.21 – 18.7 | 9 | n too small |
+| 5 | Modal (VM) | 15.43 | 15.22 – 21.01 | 27 | n too small |
+| 6 | E2B | 11.3 | 10.95 – 11.46 | 9 | n too small |
+| 7 | Modal (gVisor) | 9.33 | 8.9 – 9.64 | 21 | n too small |
+
+</details>
+
+## disk
+
+<details>
+<summary><strong>9 synthetic metrics</strong> · headline: fio rand read 4KB, O_DIRECT (IOPS)</summary>
+
+### fio rand read 4KB, O_DIRECT (IOPS) _(headline)_
+
+IOPS · higher is better
+
+_Namespace leads on median (higher is better); see notes for how ranks are decided._
+
+| Rank | Provider | fio rand read 4KB, O_DIRECT (IOPS) (IOPS) | 95% bootstrap interval | n | Note |
+| ---: | --- | ---: | ---: | ---: | --- |
+| 1 | Namespace | 246500 | 241000 – 258000 | 6 | — |
+| 2 | Daytona (VM) | 245500 | 238000 – 276000 | 6 | n too small |
+| 3 | Blaxel | 233000 | 214800 – 378000 | 6 | n too small |
+| 4 | Modal (VM) | 227000 | 120000 – 427000 | 6 | n too small |
+| 5 | Novita | 80850 | 62900 – 88000 | 6 | n too small |
+| 6 | E2B | 47200 | 46800 – 48200 | 6 | n too small |
+| 7 | Modal (gVisor) | 33400 | 31700 – 34400 | 6 | n too small |
+
+### fio rand read 4KB, O_DIRECT (MB/s)
+
+MB/s · higher is better
+
+_Namespace leads on median (higher is better); see notes for how ranks are decided._
+
+| Rank | Provider | fio rand read 4KB, O_DIRECT (MB/s) (MB/s) | 95% bootstrap interval | n | Note |
+| ---: | --- | ---: | ---: | ---: | --- |
+| 1 | Namespace | 961.5 | 946.5 – 1004 | 6 | — |
+| 2 | Daytona (VM) | 960 | 931 – 1079 | 6 | n too small |
+| 3 | Blaxel | 911.5 | 809 – 1439 | 6 | n too small |
+| 4 | Modal (VM) | 885.5 | 664 – 1666 | 6 | n too small |
+| 5 | Novita | 316 | 246 – 344 | 6 | n too small |
+| 6 | E2B | 184.5 | 183 – 188 | 6 | n too small |
+| 7 | Modal (gVisor) | 130.5 | 124 – 134 | 6 | n too small |
+
+### fio rand write 4KB, O_DIRECT (IOPS)
+
+IOPS · higher is better
+
+_Modal (VM) leads · ~1.2× Namespace on median (higher is better)._
+
+| Rank | Provider | fio rand write 4KB, O_DIRECT (IOPS) (IOPS) | 95% bootstrap interval | n | Note |
+| ---: | --- | ---: | ---: | ---: | --- |
+| 1 | Modal (VM) | 287000 | 210000 – 375000 | 6 | — |
+| 2 | Namespace | 245500 | 239000 – 247500 | 6 | n too small |
+| 3 | Daytona (VM) | 222000 | 208000 – 233000 | 6 | n too small |
+| 4 | Blaxel | 218000 | 200000 – 285000 | 6 | n too small |
+| 5 | Novita | 79600 | 73400 – 82400 | 6 | n too small |
+| 6 | E2B | 48600 | 47100 – 50100 | 6 | n too small |
+| 7 | Modal (gVisor) | 28500 | 27000 – 29200 | 6 | n too small |
+
+### fio rand write 4KB, O_DIRECT (MB/s)
+
+MB/s · higher is better
+
+_Modal (VM) leads · ~1.2× Namespace on median (higher is better)._
+
+| Rank | Provider | fio rand write 4KB, O_DIRECT (MB/s) (MB/s) | 95% bootstrap interval | n | Note |
+| ---: | --- | ---: | ---: | ---: | --- |
+| 1 | Modal (VM) | 1121 | 821 – 1463 | 6 | — |
+| 2 | Namespace | 959.5 | 935 – 974 | 6 | n too small |
+| 3 | Daytona (VM) | 866.5 | 814 – 910 | 6 | n too small |
+| 4 | Blaxel | 851.5 | 783 – 1112 | 6 | n too small |
+| 5 | Novita | 311 | 287 – 322 | 6 | n too small |
+| 6 | E2B | 190 | 184 – 196 | 6 | n too small |
+| 7 | Modal (gVisor) | 111.5 | 105 – 114 | 6 | n too small |
+
+### fio seq read 1MB, O_DIRECT (IOPS)
+
+IOPS · higher is better
+
+_Modal (gVisor) leads · ~1.6× Daytona (VM) on median (higher is better)._
+
+| Rank | Provider | fio seq read 1MB, O_DIRECT (IOPS) (IOPS) | 95% bootstrap interval | n | Note |
+| ---: | --- | ---: | ---: | ---: | --- |
+| 1 | Modal (gVisor) | 18650 | 15800 – 21000 | 6 | — |
+| 2 | Daytona (VM) | 11550 | 8750 – 16800 | 6 | n too small |
+| 3 | Novita | 9521 | 7402 – 13000 | 6 | n too small |
+| 4 | Blaxel | 8016 | 5907 – 9900 | 6 | n too small |
+| 5 | Namespace | 3947 | 2133 – 4012 | 6 | n too small |
+| 6 | Modal (VM) | 2059 | 1712 – 4243 | 6 | n too small |
+| 7 | E2B | 600 | 599 – 600 | 6 | n too small |
+
+### fio seq read 1MB, O_DIRECT (MB/s)
+
+MB/s · higher is better
+
+_Daytona (VM) leads · ~1.1× Blaxel on median (higher is better)._
+
+| Rank | Provider | fio seq read 1MB, O_DIRECT (MB/s) (MB/s) | 95% bootstrap interval | n | Note |
+| ---: | --- | ---: | ---: | ---: | --- |
+| 1 | Daytona (VM) | 8752 | — | 1 | — |
+| 2 | Blaxel | 8018 | 5909 – 9285 | 6 | — |
+| 3 | Novita | 7576 | 7231 – 8942 | 3 | n too small |
+| 4 | Namespace | 3949 | 2131 – 4014 | 6 | n too small |
+| 5 | Modal (VM) | 2061 | 1757 – 4245 | 6 | n too small |
+| 6 | E2B | 601 | 601 – 601 | 6 | n too small |
+
+### fio seq write 1MB, O_DIRECT (IOPS)
+
+IOPS · higher is better
+
+_Novita leads on median (higher is better); see notes for how ranks are decided._
+
+| Rank | Provider | fio seq write 1MB, O_DIRECT (IOPS) (IOPS) | 95% bootstrap interval | n | Note |
+| ---: | --- | ---: | ---: | ---: | --- |
+| 1 | Novita | 6017 | 5614 – 6711 | 6 | — |
+| 2 | Blaxel | 5824 | 4395 – 6102 | 6 | n too small |
+| 3 | Daytona (VM) | 3985 | 3361 – 6726 | 6 | n too small |
+| 4 | Modal (VM) | 3204 | 2725 – 5434 | 6 | n too small |
+| 5 | Modal (gVisor) | 3119 | 2570 – 5499 | 6 | n too small |
+| 6 | Namespace | 2470 | 1365 – 2490 | 6 | n too small |
+| 7 | E2B | 599 | 599 – 600 | 6 | n too small |
+
+### fio seq write 1MB, O_DIRECT (MB/s)
+
+MB/s · higher is better
+
+_Novita leads on median (higher is better); see notes for how ranks are decided._
+
+| Rank | Provider | fio seq write 1MB, O_DIRECT (MB/s) (MB/s) | 95% bootstrap interval | n | Note |
+| ---: | --- | ---: | ---: | ---: | --- |
+| 1 | Novita | 6018 | 5616 – 6713 | 6 | — |
+| 2 | Blaxel | 5826 | 4196 – 6104 | 6 | n too small |
+| 3 | Daytona (VM) | 3986 | 3524 – 5824 | 6 | n too small |
+| 4 | Modal (VM) | 3205 | 2726 – 5435 | 6 | n too small |
+| 5 | Modal (gVisor) | 3121 | 2385 – 6214 | 6 | n too small |
+| 6 | Namespace | 2472 | 1367 – 2492 | 6 | n too small |
+| 7 | E2B | 601 | 600 – 602 | 6 | n too small |
+
+### Hardlink throughput
+
+bogo ops/s · higher is better
+
+_Daytona (VM) leads · ~1.3× Blaxel on median (higher is better)._
+
+| Rank | Provider | Hardlink throughput (bogo ops/s) | 95% bootstrap interval | n | Note |
+| ---: | --- | ---: | ---: | ---: | --- |
+| 1 | Daytona (VM) | 25.64 | 23.97 – 26.22 | 6 | — |
+| 2 | Blaxel | 19.66 | 19.56 – 20.05 | 6 | n too small |
+| 3 | Novita | 16.92 | 16.76 – 17.59 | 6 | n too small |
+| 4 | Modal (VM) | 15.87 | 8.05 – 31.75 | 6 | n too small |
+| 5 | Namespace | 5.18 | 4.42 – 5.22 | 6 | n too small |
+| 6 | Modal (gVisor) | 3.22 | 2.68 – 3.33 | 6 | n too small |
+| 7 | E2B | 1.36 | 1.36 – 1.4 | 6 | n too small |
+
+</details>
+
+## memory
+
+<details>
+<summary><strong>4 synthetic metrics</strong> · headline: STREAM Triad</summary>
+
+### STREAM Triad _(headline)_
+
+MB/s · higher is better
+
+_Blaxel leads · ~1.3× Daytona (VM) on median (higher is better)._
+
+| Rank | Provider | STREAM Triad (MB/s) | 95% bootstrap interval | n | Note |
+| ---: | --- | ---: | ---: | ---: | --- |
+| 1 | Blaxel | 105900 | 100200 – 129900 | 15 | — |
+| 2 | Daytona (VM) | 80130 | 65360 – 185800 | 15 | n too small |
+| 3 | Modal (gVisor) | 72660 | 64990 – 75820 | 15 | n too small |
+| 4 | Modal (VM) | 56018 | 48810 – 76530 | 15 | n too small |
+| 5 | Novita | 53380 | 42150 – 92450 | 15 | n too small |
+| 6 | E2B | 52650 | 51420 – 54200 | 15 | n too small |
+| 7 | Namespace | 33230 | 30950 – 33754 | 15 | n too small |
+
+### STREAM Add
+
+MB/s · higher is better
+
+_Blaxel leads · ~1.3× Daytona (VM) on median (higher is better)._
+
+| Rank | Provider | STREAM Add (MB/s) | 95% bootstrap interval | n | Note |
+| ---: | --- | ---: | ---: | ---: | --- |
+| 1 | Blaxel | 105600 | 99340 – 130100 | 15 | — |
+| 2 | Daytona (VM) | 78930 | 64680 – 185400 | 15 | n too small |
+| 3 | Modal (gVisor) | 72390 | 63760 – 75010 | 15 | n too small |
+| 4 | Modal (VM) | 55540 | 49480 – 75820 | 15 | n too small |
+| 5 | Novita | 53370 | 42120 – 98190 | 15 | n too small |
+| 6 | E2B | 52460 | 51140 – 54100 | 15 | n too small |
+| 7 | Namespace | 33310 | 31020 – 33670 | 15 | n too small |
+
+### STREAM Copy
+
+MB/s · higher is better
+
+_Blaxel leads · ~1.2× Modal (gVisor) on median (higher is better)._
+
+| Rank | Provider | STREAM Copy (MB/s) | 95% bootstrap interval | n | Note |
+| ---: | --- | ---: | ---: | ---: | --- |
+| 1 | Blaxel | 119600 | 116300 – 143600 | 35 | — |
+| 2 | Modal (gVisor) | 97350 | 91160 – 101100 | 70 | n too small |
+| 3 | Modal (VM) | 86894 | 83000 – 93320 | 30 | n too small |
+| 4 | Daytona (VM) | 79770 | 75670 – 219900 | 55 | n too small |
+| 5 | E2B | 78540 | 77350 – 80340 | 65 | n too small |
+| 6 | Novita | 58150 | 51580 – 109800 | 17 | n too small |
+| 7 | Namespace | 44180 | 43730 – 44790 | 50 | n too small |
+
+### STREAM Scale
+
+MB/s · higher is better
+
+_Blaxel leads · ~1.4× Daytona (VM) on median (higher is better)._
+
+| Rank | Provider | STREAM Scale (MB/s) | 95% bootstrap interval | n | Note |
+| ---: | --- | ---: | ---: | ---: | --- |
+| 1 | Blaxel | 97810 | 91410 – 121360 | 15 | — |
+| 2 | Daytona (VM) | 70870 | 58760 – 177400 | 15 | n too small |
+| 3 | Modal (gVisor) | 63980 | 56340 – 67940 | 15 | n too small |
+| 4 | Novita | 50970 | 42220 – 93490 | 15 | n too small |
+| 5 | Modal (VM) | 48155 | 41800 – 72800 | 15 | n too small |
+| 6 | E2B | 46130 | 45770 – 46630 | 15 | n too small |
+| 7 | Namespace | 30250 | 29030 – 30590 | 15 | n too small |
+
+</details>
+
+## network
+
+<details>
+<summary><strong>5 synthetic metrics</strong> · headline: iperf3 loopback TCP, 1 stream</summary>
+
+### iperf3 loopback TCP, 1 stream _(headline)_
+
+Mbits/sec · higher is better
+
+_Novita leads · ~1.5× Blaxel on median (higher is better)._
+
+| Rank | Provider | iperf3 loopback TCP, 1 stream (Mbits/sec) | 95% bootstrap interval | n | Note |
+| ---: | --- | ---: | ---: | ---: | --- |
+| 1 | Novita | 148400 | 131280 – 152811 | 6 | — |
+| 2 | Blaxel | 97840 | 87545 – 155461 | 6 | n too small |
+| 3 | Namespace | 74730 | 72100 – 140164 | 6 | n too small |
+| 4 | Daytona (VM) | 70244 | 67620 – 80855 | 6 | n too small |
+| 5 | E2B | 58134 | 53179 – 68194 | 6 | n too small |
+| 6 | Modal (VM) | 26070 | 16043 – 84307 | 6 | n too small |
+| 7 | Modal (gVisor) | 11830 | 9159 – 15959 | 6 | n too small |
+
+### iperf3 loopback TCP, 10 streams
+
+Mbits/sec · higher is better
+
+_Novita leads · ~1.1× Blaxel on median (higher is better)._
+
+| Rank | Provider | iperf3 loopback TCP, 10 streams (Mbits/sec) | 95% bootstrap interval | n | Note |
+| ---: | --- | ---: | ---: | ---: | --- |
+| 1 | Novita | 144870 | 129936 – 155766 | 6 | — |
+| 2 | Blaxel | 127000 | 112685 – 164136 | 6 | n too small |
+| 3 | Daytona (VM) | 97613 | 80570 – 102949 | 6 | n too small |
+| 4 | Namespace | 68580 | 63800 – 105620 | 6 | n too small |
+| 5 | E2B | 51598 | 46865 – 61072 | 6 | n too small |
+| 6 | Modal (VM) | 19863 | 13822 – 72964 | 6 | n too small |
+| 7 | Modal (gVisor) | 12147 | 11331 – 13068 | 6 | n too small |
+
+### iperf3 loopback UDP, 10G objective
+
+Mbits/sec · higher is better
+
+_Blaxel, Daytona (VM), E2B, Modal (VM), Namespace and Novita share the top on this metric (higher is better)._
+
+| Rank | Provider | iperf3 loopback UDP, 10G objective (Mbits/sec) | 95% bootstrap interval | n | Note |
+| ---: | --- | ---: | ---: | ---: | --- |
+| 1 | Blaxel | 9999 | 9999 – 9999 | 6 | — |
+| 1 | Daytona (VM) | 9999 | 9999 – 9999 | 6 | n too small, equal medians |
+| 1 | E2B | 9999 | 9999 – 9999 | 6 | n too small, equal medians |
+| 1 | Modal (VM) | 9999 | 9999 – 10000 | 6 | n too small, equal medians |
+| 1 | Namespace | 9999 | 9999 – 9999 | 6 | n too small, equal medians |
+| 1 | Novita | 9999 | 9999 – 9999 | 6 | n too small, equal medians |
+| 7 | Modal (gVisor) | 161.5 | 142 – 171 | 6 | n too small |
+
+### iperf3 WAN download
+
+Mbits/sec · higher is better
+
+_Modal (gVisor) leads · ~1.5× Novita on median (higher is better)._
+
+| Rank | Provider | iperf3 WAN download (Mbits/sec) | 95% bootstrap interval | n | Note |
+| ---: | --- | ---: | ---: | ---: | --- |
+| 1 | Modal (gVisor) | 7040 | 6409 – 10840 | 6 | — |
+| 2 | Novita | 4840 | 3588 – 6253 | 6 | n too small |
+| 3 | Daytona (VM) | 3642 | 2984 – 4557 | 6 | n too small |
+| 4 | Namespace | 3572 | 2198 – 11600 | 6 | n too small |
+| 5 | E2B | 3443 | 537.6 – 6102 | 6 | n too small |
+| 6 | Blaxel | 1443 | 982.7 – 1654 | 6 | n too small |
+| 7 | Modal (VM) | 1404 | 674.9 – 1657 | 6 | n too small |
+
+### iperf3 WAN upload
+
+Mbits/sec · higher is better
+
+_Modal (VM) leads · ~1.3× Daytona (VM) on median (higher is better)._
+
+| Rank | Provider | iperf3 WAN upload (Mbits/sec) | 95% bootstrap interval | n | Note |
+| ---: | --- | ---: | ---: | ---: | --- |
+| 1 | Modal (VM) | 5397 | 1327 – 9306 | 6 | — |
+| 2 | Daytona (VM) | 4312 | 3806 – 4799 | 6 | n too small |
+| 3 | Novita | 3269 | 498.2 – 4410 | 6 | n too small |
+| 4 | E2B | 3150 | 1025 – 3312 | 6 | n too small |
+| 5 | Namespace | 2742 | 955.8 – 3080 | 6 | n too small |
+| 6 | Blaxel | 1754 | 809.9 – 2376 | 6 | n too small |
+| 7 | Modal (gVisor) | 156.1 | 142.1 – 181.8 | 6 | n too small |
+
+</details>
+
+## system
+
+<details>
+<summary><strong>7 synthetic metrics</strong> · headline: PyBench</summary>
+
+### PyBench _(headline)_
+
+Milliseconds · lower is better
+
+_Namespace leads · Daytona (VM) is ~1.1× higher (lower is better)._
+
+| Rank | Provider | PyBench (Milliseconds) | 95% bootstrap interval | n | Note |
+| ---: | --- | ---: | ---: | ---: | --- |
+| 1 | Namespace | 361.5 | 358.5 – 366 | 6 | — |
+| 2 | Daytona (VM) | 404 | 400 – 443 | 6 | n too small |
+| 3 | Blaxel | 478 | 475 – 493 | 6 | n too small |
+| 4 | Novita | 484 | 480 – 485 | 6 | n too small |
+| 5 | Modal (VM) | 666.5 | 479 – 673 | 6 | n too small |
+| 6 | E2B | 803 | 802 – 807 | 6 | n too small |
+| 7 | Modal (gVisor) | 896 | 888 – 903 | 6 | n too small |
+
+### Git common operations
+
+Seconds · lower is better
+
+_Namespace leads · Daytona (VM) is ~1.2× higher (lower is better)._
+
+| Rank | Provider | Git common operations (Seconds) | 95% bootstrap interval | n | Note |
+| ---: | --- | ---: | ---: | ---: | --- |
+| 1 | Namespace | 31.77 | 31.5 – 32.42 | 6 | — |
+| 2 | Daytona (VM) | 36.64 | 36.21 – 39.32 | 6 | n too small |
+| 3 | Blaxel | 43.9 | 41.7 – 48.15 | 6 | n too small |
+| 4 | Novita | 44.82 | 44.05 – 44.96 | 6 | n too small |
+| 5 | Modal (VM) | 47.17 | 41.67 – 47.32 | 6 | n too small |
+| 6 | E2B | 65.36 | 63.97 – 66.24 | 6 | n too small |
+| 7 | Modal (gVisor) | 85.1 | 80.08 – 86.72 | 6 | n too small |
+
+### pgbench RO (s100, 50c)
+
+TPS · higher is better
+
+_Blaxel leads on median (higher is better); see notes for how ranks are decided._
+
+| Rank | Provider | pgbench RO (s100, 50c) (TPS) | 95% bootstrap interval | n | Note |
+| ---: | --- | ---: | ---: | ---: | --- |
+| 1 | Blaxel | 310200 | 274900 – 348700 | 6 | — |
+| 2 | Daytona (VM) | 299800 | 270300 – 302800 | 6 | n too small |
+| 3 | Namespace | 239900 | 218300 – 385400 | 6 | n too small |
+| 4 | Novita | 237800 | 217000 – 269400 | 6 | n too small |
+| 5 | Modal (VM) | 200200 | 196300 – 201900 | 6 | n too small |
+| 6 | E2B | 176800 | 174500 – 182500 | 6 | n too small |
+| 7 | Modal (gVisor) | 11770 | 11180 – 12230 | 6 | n too small |
+
+### pgbench RO latency (s100, 50c)
+
+ms · lower is better
+
+_Blaxel leads on median (lower is better); see notes for how ranks are decided._
+
+| Rank | Provider | pgbench RO latency (s100, 50c) (ms) | 95% bootstrap interval | n | Note |
+| ---: | --- | ---: | ---: | ---: | --- |
+| 1 | Blaxel | 0.161 | 0.143 – 0.182 | 6 | — |
+| 2 | Daytona (VM) | 0.167 | 0.165 – 0.185 | 6 | n too small |
+| 3 | Namespace | 0.2085 | 0.13 – 0.229 | 6 | n too small |
+| 4 | Novita | 0.2105 | 0.186 – 0.2305 | 6 | n too small |
+| 5 | Modal (VM) | 0.2495 | 0.248 – 0.255 | 6 | n too small |
+| 6 | E2B | 0.283 | 0.2745 – 0.289 | 6 | n too small |
+| 7 | Modal (gVisor) | 4.248 | 4.088 – 4.577 | 6 | n too small |
+
+### pgbench RW (s100, 50c)
+
+TPS · higher is better
+
+_Namespace leads · ~1.1× Blaxel on median (higher is better)._
+
+| Rank | Provider | pgbench RW (s100, 50c) (TPS) | 95% bootstrap interval | n | Note |
+| ---: | --- | ---: | ---: | ---: | --- |
+| 1 | Namespace | 24890 | 16100 – 41320 | 6 | — |
+| 2 | Blaxel | 23250 | 22270 – 24530 | 6 | n too small |
+| 3 | Novita | 17700 | 15740 – 21940 | 6 | n too small |
+| 4 | Daytona (VM) | 16000 | 15570 – 16570 | 6 | n too small |
+| 5 | Modal (VM) | 14240 | 13750 – 14410 | 6 | n too small |
+| 6 | E2B | 11880 | 10980 – 12530 | 6 | n too small |
+| 7 | Modal (gVisor) | 2067 | 1942 – 2107 | 6 | n too small |
+
+### pgbench RW latency (s100, 50c)
+
+ms · lower is better
+
+_Namespace leads · Blaxel is ~1.1× higher (lower is better)._
+
+| Rank | Provider | pgbench RW latency (s100, 50c) (ms) | 95% bootstrap interval | n | Note |
+| ---: | --- | ---: | ---: | ---: | --- |
+| 1 | Namespace | 2.018 | 1.21 – 3.105 | 6 | — |
+| 2 | Blaxel | 2.151 | 2.038 – 2.217 | 6 | n too small |
+| 3 | Novita | 2.828 | 2.279 – 3.045 | 6 | n too small |
+| 4 | Daytona (VM) | 3.124 | 3.042 – 3.212 | 6 | n too small |
+| 5 | Modal (VM) | 3.51 | 3.47 – 3.617 | 6 | n too small |
+| 6 | E2B | 4.208 | 3.989 – 4.555 | 6 | n too small |
+| 7 | Modal (gVisor) | 24.19 | 23.73 – 25.75 | 6 | n too small |
+
+### SQLite Speedtest
+
+Seconds · lower is better
+
+_Daytona (VM) leads · Blaxel is ~1.2× higher (lower is better)._
+
+| Rank | Provider | SQLite Speedtest (Seconds) | 95% bootstrap interval | n | Note |
+| ---: | --- | ---: | ---: | ---: | --- |
+| 1 | Daytona (VM) | 32.09 | 30.73 – 34.82 | 6 | — |
+| 2 | Blaxel | 38.42 | 37.02 – 42.7 | 6 | n too small |
+| 3 | Novita | 41.36 | 39.96 – 44.67 | 6 | n too small |
+| 4 | Namespace | 48.41 | 47.94 – 48.73 | 6 | n too small |
+| 5 | Modal (VM) | 62.39 | 35.6 – 63.32 | 6 | n too small |
+| 6 | E2B | 70.5 | 70.25 – 73.4 | 6 | n too small |
+| 7 | Modal (gVisor) | 410 | 391.1 – 443 | 6 | n too small |
+
+</details>
+
 ## economics
 
 ### Hourly cost _(headline)_
@@ -824,6 +855,118 @@ correction is applied across providers or metrics.
 
 | Dimension | Metric | Provider | p vs. above | p (KS) |
 | --- | --- | --- | ---: | ---: |
+| realworld | Mastra: cold install | Namespace | — | — |
+| realworld | Mastra: cold install | Daytona (VM) | <0.001 | <0.001 |
+| realworld | Mastra: cold install | Blaxel | 0.24 (tied) | 0.43 |
+| realworld | Mastra: cold install | Modal (VM) | <0.001 | <0.001 |
+| realworld | Mastra: cold install | Novita | 0.93 (tied) | 0.79 |
+| realworld | Mastra: cold install | Modal (gVisor) | <0.001 | <0.001 |
+| realworld | Better-Auth: build | Namespace | — | — |
+| realworld | Better-Auth: build | Daytona (VM) | <0.001 | <0.001 |
+| realworld | Better-Auth: build | Blaxel | <0.001 | <0.001 |
+| realworld | Better-Auth: build | Modal (VM) | <0.001 | <0.001 |
+| realworld | Better-Auth: build | Novita | 0.93 (tied) | 0.43 |
+| realworld | Better-Auth: build | E2B | <0.001 | <0.001 |
+| realworld | Better-Auth: build | Modal (gVisor) | <0.001 | <0.001 |
+| realworld | Better-Auth: cold install | Daytona (VM) | — | — |
+| realworld | Better-Auth: cold install | Blaxel | 0.052 (tied) | 0.019 |
+| realworld | Better-Auth: cold install | Namespace | 0.18 (tied) | 0.0046 |
+| realworld | Better-Auth: cold install | Novita | 0.0068 | 0.019 |
+| realworld | Better-Auth: cold install | E2B | <0.001 | <0.001 |
+| realworld | Better-Auth: cold install | Modal (VM) | 0.80 (tied) | 0.19 |
+| realworld | Better-Auth: cold install | Modal (gVisor) | <0.001 | <0.001 |
+| realworld | Better-Auth: git clone | Namespace | — | — |
+| realworld | Better-Auth: git clone | Blaxel | 0.0083 | 0.0046 |
+| realworld | Better-Auth: git clone | Modal (VM) | 0.043 | 0.066 |
+| realworld | Better-Auth: git clone | E2B | 0.0018 | <0.001 |
+| realworld | Better-Auth: git clone | Daytona (VM) | 0.34 (tied) | 0.43 |
+| realworld | Better-Auth: git clone | Novita | <0.001 | <0.001 |
+| realworld | Better-Auth: git clone | Modal (gVisor) | 0.0036 | 0.019 |
+| realworld | Better-Auth: lint (Biome) | Namespace | — | — |
+| realworld | Better-Auth: lint (Biome) | Daytona (VM) | <0.001 | <0.001 |
+| realworld | Better-Auth: lint (Biome) | Blaxel | <0.001 | <0.001 |
+| realworld | Better-Auth: lint (Biome) | Novita | <0.001 | <0.001 |
+| realworld | Better-Auth: lint (Biome) | Modal (VM) | 0.16 (tied) | 0.19 |
+| realworld | Better-Auth: lint (Biome) | E2B | <0.001 | <0.001 |
+| realworld | Better-Auth: lint (Biome) | Modal (gVisor) | <0.001 | <0.001 |
+| realworld | Better-Auth: lint deps (Knip) | Namespace | — | — |
+| realworld | Better-Auth: lint deps (Knip) | Blaxel | <0.001 | <0.001 |
+| realworld | Better-Auth: lint deps (Knip) | Daytona (VM) | 0.67 (tied) | 0.43 |
+| realworld | Better-Auth: lint deps (Knip) | Novita | <0.001 | <0.001 |
+| realworld | Better-Auth: lint deps (Knip) | Modal (VM) | 0.20 (tied) | 0.066 |
+| realworld | Better-Auth: lint deps (Knip) | E2B | <0.001 | <0.001 |
+| realworld | Better-Auth: lint deps (Knip) | Modal (gVisor) | <0.001 | <0.001 |
+| realworld | Better-Auth: lint format | Namespace | — | — |
+| realworld | Better-Auth: lint format | Daytona (VM) | <0.001 | <0.001 |
+| realworld | Better-Auth: lint format | Blaxel | 0.27 (tied) | 0.43 |
+| realworld | Better-Auth: lint format | Novita | <0.001 | <0.001 |
+| realworld | Better-Auth: lint format | Modal (VM) | 0.045 | 0.066 |
+| realworld | Better-Auth: lint format | E2B | <0.001 | <0.001 |
+| realworld | Better-Auth: lint format | Modal (gVisor) | <0.001 | <0.001 |
+| realworld | Better-Auth: lint packages | Namespace | — | — |
+| realworld | Better-Auth: lint packages | Daytona (VM) | <0.001 | <0.001 |
+| realworld | Better-Auth: lint packages | Blaxel | 0.078 (tied) | 0.19 |
+| realworld | Better-Auth: lint packages | Novita | <0.001 | <0.001 |
+| realworld | Better-Auth: lint packages | Modal (VM) | 0.10 (tied) | 0.066 |
+| realworld | Better-Auth: lint packages | E2B | <0.001 | <0.001 |
+| realworld | Better-Auth: lint packages | Modal (gVisor) | <0.001 | <0.001 |
+| realworld | Better-Auth: lint spell | Namespace | — | — |
+| realworld | Better-Auth: lint spell | Blaxel | <0.001 | <0.001 |
+| realworld | Better-Auth: lint spell | Daytona (VM) | 0.47 (tied) | 0.19 |
+| realworld | Better-Auth: lint spell | Novita | <0.001 | <0.001 |
+| realworld | Better-Auth: lint spell | Modal (VM) | 0.045 | 0.066 |
+| realworld | Better-Auth: lint spell | E2B | <0.001 | <0.001 |
+| realworld | Better-Auth: lint spell | Modal (gVisor) | <0.001 | <0.001 |
+| realworld | Better-Auth: lint types | Daytona (VM) | — | — |
+| realworld | Better-Auth: lint types | Namespace | 0.67 (tied) | 0.79 |
+| realworld | Better-Auth: lint types | Blaxel | <0.001 | <0.001 |
+| realworld | Better-Auth: lint types | Modal (VM) | <0.001 | <0.001 |
+| realworld | Better-Auth: lint types | Novita | 0.84 (tied) | 0.43 |
+| realworld | Better-Auth: lint types | E2B | <0.001 | <0.001 |
+| realworld | Better-Auth: lint types | Modal (gVisor) | <0.001 | <0.001 |
+| realworld | Better-Auth: typecheck | Namespace | — | — |
+| realworld | Better-Auth: typecheck | Daytona (VM) | <0.001 | <0.001 |
+| realworld | Better-Auth: typecheck | Blaxel | 0.0036 | 0.0046 |
+| realworld | Better-Auth: typecheck | Novita | <0.001 | <0.001 |
+| realworld | Better-Auth: typecheck | Modal (VM) | 0.11 (tied) | 0.066 |
+| realworld | Better-Auth: typecheck | E2B | <0.001 | <0.001 |
+| realworld | Better-Auth: typecheck | Modal (gVisor) | <0.001 | <0.001 |
+| realworld | Mastra: build:core | Namespace | — | — |
+| realworld | Mastra: build:core | Daytona (VM) | <0.001 | <0.001 |
+| realworld | Mastra: build:core | Blaxel | 0.017 | 0.019 |
+| realworld | Mastra: build:core | Novita | <0.001 | <0.001 |
+| realworld | Mastra: build:core | Modal (VM) | 0.045 | 0.019 |
+| realworld | Mastra: build:core | Modal (gVisor) | <0.001 | <0.001 |
+| realworld | Mastra: git clone | Blaxel | — | — |
+| realworld | Mastra: git clone | Modal (VM) | 0.28 (tied) | 0.19 |
+| realworld | Mastra: git clone | Novita | 0.024 | 0.0046 |
+| realworld | Mastra: git clone | Namespace | 0.80 (tied) | 0.79 |
+| realworld | Mastra: git clone | Daytona (VM) | 0.060 (tied) | 0.19 |
+| realworld | Mastra: git clone | Modal (gVisor) | 0.13 (tied) | 0.019 |
+| realworld | Mastra: lint:format | Namespace | — | — |
+| realworld | Mastra: lint:format | Blaxel | <0.001 | <0.001 |
+| realworld | Mastra: lint:format | Daytona (VM) | 0.017 | 0.0046 |
+| realworld | Mastra: lint:format | Novita | <0.001 | <0.001 |
+| realworld | Mastra: lint:format | Modal (VM) | 0.033 | 0.0046 |
+| realworld | Mastra: lint:format | Modal (gVisor) | <0.001 | <0.001 |
+| realworld | OpenClaw: cold install | Namespace | — | — |
+| realworld | OpenClaw: cold install | Blaxel | <0.001 | <0.001 |
+| realworld | OpenClaw: cold install | Daytona (VM) | <0.001 | <0.001 |
+| realworld | OpenClaw: cold install | Modal (VM) | <0.001 | <0.001 |
+| realworld | OpenClaw: cold install | Novita | 0.0036 | 0.0046 |
+| realworld | OpenClaw: cold install | Modal (gVisor) | <0.001 | <0.001 |
+| realworld | OpenClaw: git clone | Blaxel | — | — |
+| realworld | OpenClaw: git clone | Modal (VM) | <0.001 | <0.001 |
+| realworld | OpenClaw: git clone | Daytona (VM) | 0.76 (tied) | 0.43 |
+| realworld | OpenClaw: git clone | Novita | 0.16 (tied) | 0.019 |
+| realworld | OpenClaw: git clone | Namespace | 0.068 (tied) | 0.019 |
+| realworld | OpenClaw: git clone | Modal (gVisor) | 0.0014 | <0.001 |
+| realworld | OpenClaw: typecheck (tsgo) | Namespace | — | — |
+| realworld | OpenClaw: typecheck (tsgo) | Daytona (VM) | <0.001 | <0.001 |
+| realworld | OpenClaw: typecheck (tsgo) | Blaxel | <0.001 | <0.001 |
+| realworld | OpenClaw: typecheck (tsgo) | Modal (VM) | <0.001 | <0.001 |
+| realworld | OpenClaw: typecheck (tsgo) | Novita | 0.14 (tied) | 0.066 |
+| realworld | OpenClaw: typecheck (tsgo) | Modal (gVisor) | <0.001 | <0.001 |
 | cpu | Node.js web tooling | Namespace | — | — |
 | cpu | Node.js web tooling | Blaxel | <0.001 (n too small) | <0.001 |
 | cpu | Node.js web tooling | Daytona (VM) | <0.001 (n too small) | <0.001 |
@@ -1005,118 +1148,6 @@ correction is applied across providers or metrics.
 | system | SQLite Speedtest | Modal (VM) | 0.39 (n too small) | 0.077 |
 | system | SQLite Speedtest | E2B | 0.0022 (n too small) | 0.0013 |
 | system | SQLite Speedtest | Modal (gVisor) | 0.0022 (n too small) | 0.0013 |
-| realworld | Mastra: cold install | Namespace | — | — |
-| realworld | Mastra: cold install | Daytona (VM) | <0.001 | <0.001 |
-| realworld | Mastra: cold install | Blaxel | 0.24 (tied) | 0.43 |
-| realworld | Mastra: cold install | Modal (VM) | <0.001 | <0.001 |
-| realworld | Mastra: cold install | Novita | 0.93 (tied) | 0.79 |
-| realworld | Mastra: cold install | Modal (gVisor) | <0.001 | <0.001 |
-| realworld | Better-Auth: build | Namespace | — | — |
-| realworld | Better-Auth: build | Daytona (VM) | <0.001 | <0.001 |
-| realworld | Better-Auth: build | Blaxel | <0.001 | <0.001 |
-| realworld | Better-Auth: build | Modal (VM) | <0.001 | <0.001 |
-| realworld | Better-Auth: build | Novita | 0.93 (tied) | 0.43 |
-| realworld | Better-Auth: build | E2B | <0.001 | <0.001 |
-| realworld | Better-Auth: build | Modal (gVisor) | <0.001 | <0.001 |
-| realworld | Better-Auth: cold install | Daytona (VM) | — | — |
-| realworld | Better-Auth: cold install | Blaxel | 0.052 (tied) | 0.019 |
-| realworld | Better-Auth: cold install | Namespace | 0.18 (tied) | 0.0046 |
-| realworld | Better-Auth: cold install | Novita | 0.0068 | 0.019 |
-| realworld | Better-Auth: cold install | E2B | <0.001 | <0.001 |
-| realworld | Better-Auth: cold install | Modal (VM) | 0.80 (tied) | 0.19 |
-| realworld | Better-Auth: cold install | Modal (gVisor) | <0.001 | <0.001 |
-| realworld | Better-Auth: git clone | Namespace | — | — |
-| realworld | Better-Auth: git clone | Blaxel | 0.0083 | 0.0046 |
-| realworld | Better-Auth: git clone | Modal (VM) | 0.043 | 0.066 |
-| realworld | Better-Auth: git clone | E2B | 0.0018 | <0.001 |
-| realworld | Better-Auth: git clone | Daytona (VM) | 0.34 (tied) | 0.43 |
-| realworld | Better-Auth: git clone | Novita | <0.001 | <0.001 |
-| realworld | Better-Auth: git clone | Modal (gVisor) | 0.0036 | 0.019 |
-| realworld | Better-Auth: lint (Biome) | Namespace | — | — |
-| realworld | Better-Auth: lint (Biome) | Daytona (VM) | <0.001 | <0.001 |
-| realworld | Better-Auth: lint (Biome) | Blaxel | <0.001 | <0.001 |
-| realworld | Better-Auth: lint (Biome) | Novita | <0.001 | <0.001 |
-| realworld | Better-Auth: lint (Biome) | Modal (VM) | 0.16 (tied) | 0.19 |
-| realworld | Better-Auth: lint (Biome) | E2B | <0.001 | <0.001 |
-| realworld | Better-Auth: lint (Biome) | Modal (gVisor) | <0.001 | <0.001 |
-| realworld | Better-Auth: lint deps (Knip) | Namespace | — | — |
-| realworld | Better-Auth: lint deps (Knip) | Blaxel | <0.001 | <0.001 |
-| realworld | Better-Auth: lint deps (Knip) | Daytona (VM) | 0.67 (tied) | 0.43 |
-| realworld | Better-Auth: lint deps (Knip) | Novita | <0.001 | <0.001 |
-| realworld | Better-Auth: lint deps (Knip) | Modal (VM) | 0.20 (tied) | 0.066 |
-| realworld | Better-Auth: lint deps (Knip) | E2B | <0.001 | <0.001 |
-| realworld | Better-Auth: lint deps (Knip) | Modal (gVisor) | <0.001 | <0.001 |
-| realworld | Better-Auth: lint format | Namespace | — | — |
-| realworld | Better-Auth: lint format | Daytona (VM) | <0.001 | <0.001 |
-| realworld | Better-Auth: lint format | Blaxel | 0.27 (tied) | 0.43 |
-| realworld | Better-Auth: lint format | Novita | <0.001 | <0.001 |
-| realworld | Better-Auth: lint format | Modal (VM) | 0.045 | 0.066 |
-| realworld | Better-Auth: lint format | E2B | <0.001 | <0.001 |
-| realworld | Better-Auth: lint format | Modal (gVisor) | <0.001 | <0.001 |
-| realworld | Better-Auth: lint packages | Namespace | — | — |
-| realworld | Better-Auth: lint packages | Daytona (VM) | <0.001 | <0.001 |
-| realworld | Better-Auth: lint packages | Blaxel | 0.078 (tied) | 0.19 |
-| realworld | Better-Auth: lint packages | Novita | <0.001 | <0.001 |
-| realworld | Better-Auth: lint packages | Modal (VM) | 0.10 (tied) | 0.066 |
-| realworld | Better-Auth: lint packages | E2B | <0.001 | <0.001 |
-| realworld | Better-Auth: lint packages | Modal (gVisor) | <0.001 | <0.001 |
-| realworld | Better-Auth: lint spell | Namespace | — | — |
-| realworld | Better-Auth: lint spell | Blaxel | <0.001 | <0.001 |
-| realworld | Better-Auth: lint spell | Daytona (VM) | 0.47 (tied) | 0.19 |
-| realworld | Better-Auth: lint spell | Novita | <0.001 | <0.001 |
-| realworld | Better-Auth: lint spell | Modal (VM) | 0.045 | 0.066 |
-| realworld | Better-Auth: lint spell | E2B | <0.001 | <0.001 |
-| realworld | Better-Auth: lint spell | Modal (gVisor) | <0.001 | <0.001 |
-| realworld | Better-Auth: lint types | Daytona (VM) | — | — |
-| realworld | Better-Auth: lint types | Namespace | 0.67 (tied) | 0.79 |
-| realworld | Better-Auth: lint types | Blaxel | <0.001 | <0.001 |
-| realworld | Better-Auth: lint types | Modal (VM) | <0.001 | <0.001 |
-| realworld | Better-Auth: lint types | Novita | 0.84 (tied) | 0.43 |
-| realworld | Better-Auth: lint types | E2B | <0.001 | <0.001 |
-| realworld | Better-Auth: lint types | Modal (gVisor) | <0.001 | <0.001 |
-| realworld | Better-Auth: typecheck | Namespace | — | — |
-| realworld | Better-Auth: typecheck | Daytona (VM) | <0.001 | <0.001 |
-| realworld | Better-Auth: typecheck | Blaxel | 0.0036 | 0.0046 |
-| realworld | Better-Auth: typecheck | Novita | <0.001 | <0.001 |
-| realworld | Better-Auth: typecheck | Modal (VM) | 0.11 (tied) | 0.066 |
-| realworld | Better-Auth: typecheck | E2B | <0.001 | <0.001 |
-| realworld | Better-Auth: typecheck | Modal (gVisor) | <0.001 | <0.001 |
-| realworld | Mastra: build:core | Namespace | — | — |
-| realworld | Mastra: build:core | Daytona (VM) | <0.001 | <0.001 |
-| realworld | Mastra: build:core | Blaxel | 0.017 | 0.019 |
-| realworld | Mastra: build:core | Novita | <0.001 | <0.001 |
-| realworld | Mastra: build:core | Modal (VM) | 0.045 | 0.019 |
-| realworld | Mastra: build:core | Modal (gVisor) | <0.001 | <0.001 |
-| realworld | Mastra: git clone | Blaxel | — | — |
-| realworld | Mastra: git clone | Modal (VM) | 0.28 (tied) | 0.19 |
-| realworld | Mastra: git clone | Novita | 0.024 | 0.0046 |
-| realworld | Mastra: git clone | Namespace | 0.80 (tied) | 0.79 |
-| realworld | Mastra: git clone | Daytona (VM) | 0.060 (tied) | 0.19 |
-| realworld | Mastra: git clone | Modal (gVisor) | 0.13 (tied) | 0.019 |
-| realworld | Mastra: lint:format | Namespace | — | — |
-| realworld | Mastra: lint:format | Blaxel | <0.001 | <0.001 |
-| realworld | Mastra: lint:format | Daytona (VM) | 0.017 | 0.0046 |
-| realworld | Mastra: lint:format | Novita | <0.001 | <0.001 |
-| realworld | Mastra: lint:format | Modal (VM) | 0.033 | 0.0046 |
-| realworld | Mastra: lint:format | Modal (gVisor) | <0.001 | <0.001 |
-| realworld | OpenClaw: cold install | Namespace | — | — |
-| realworld | OpenClaw: cold install | Blaxel | <0.001 | <0.001 |
-| realworld | OpenClaw: cold install | Daytona (VM) | <0.001 | <0.001 |
-| realworld | OpenClaw: cold install | Modal (VM) | <0.001 | <0.001 |
-| realworld | OpenClaw: cold install | Novita | 0.0036 | 0.0046 |
-| realworld | OpenClaw: cold install | Modal (gVisor) | <0.001 | <0.001 |
-| realworld | OpenClaw: git clone | Blaxel | — | — |
-| realworld | OpenClaw: git clone | Modal (VM) | <0.001 | <0.001 |
-| realworld | OpenClaw: git clone | Daytona (VM) | 0.76 (tied) | 0.43 |
-| realworld | OpenClaw: git clone | Novita | 0.16 (tied) | 0.019 |
-| realworld | OpenClaw: git clone | Namespace | 0.068 (tied) | 0.019 |
-| realworld | OpenClaw: git clone | Modal (gVisor) | 0.0014 | <0.001 |
-| realworld | OpenClaw: typecheck (tsgo) | Namespace | — | — |
-| realworld | OpenClaw: typecheck (tsgo) | Daytona (VM) | <0.001 | <0.001 |
-| realworld | OpenClaw: typecheck (tsgo) | Blaxel | <0.001 | <0.001 |
-| realworld | OpenClaw: typecheck (tsgo) | Modal (VM) | <0.001 | <0.001 |
-| realworld | OpenClaw: typecheck (tsgo) | Novita | 0.14 (tied) | 0.066 |
-| realworld | OpenClaw: typecheck (tsgo) | Modal (gVisor) | <0.001 | <0.001 |
 | economics | Hourly cost | Novita | — | — |
 | economics | Hourly cost | Daytona (VM) | — | — |
 | economics | Hourly cost | E2B | — | — |

--- a/docs/methodology.md
+++ b/docs/methodology.md
@@ -34,8 +34,31 @@ observed allocation, so its ranks are never read as like-for-like with the compu
 Results land on a closed, ordered set of [`DIMENSIONS`](../packages/schema/src/metrics.ts): `lifecycle`,
 `control-plane`, `cpu`, `disk`, `memory`, `network`, `system`, `realworld`, `economics`. Each catalogued
 [`MetricDef`](../packages/schema/src/metrics.ts) declares its `dimension`, `unit`, `direction` (HIB =
-higher-is-better, LIB = lower-is-better), and whether it `headline`s its dimension. The leaderboard
-shows exactly one headline metric per dimension (enforced at catalog load).
+higher-is-better, LIB = lower-is-better), and whether it `headline`s its dimension. A dimension has at
+most one headline metric (enforced at catalog load); the leaderboard ranks *every* emitted metric and
+leads each dimension with its headline.
+
+### How the leaderboard is laid out
+
+Which sections exist is driven by the data — a dimension no provider emitted is simply absent — but the
+order and the emphasis are editorial, and they follow this document's argument:
+
+- **`realworld` leads.** Synthetic scores say what the hardware *can* do; the real-world suites say what
+  a developer or a CI job actually waits on, which is the question the benchmark exists to answer.
+- **The synthetic microbenchmarks collapse.** `cpu`, `disk`, `memory`, `network` and `system` each load
+  one hardware axis in isolation, so their tables render inside a collapsed `<details>`. The `##`
+  heading stays outside it: a measured axis must never look like one that never ran.
+- **Everything else stays expanded.** `lifecycle` and `control-plane` are harness-measured timings of
+  the provider's own API — a spawn a user waits on, not a synthetic load — and `economics` is the
+  provider's published price. None is a microbenchmark, so none is hidden.
+
+The header links each identifier to its primary source: the run id to the `bench-matrix` workflow run
+that produced the measurements, the commit to the tree they were measured against, and the dataset link
+to the committed Run document the tables were rendered from — so any number on the page can be traced
+back to its raw Samples. (A Run spliced from two CI runs — a composite `<runA>+<runB>` id, see
+[`data/dataset/index.json`](../data/dataset/index.json) — links each half separately; no single workflow
+run owns the pair.) The order, the collapse, and the links are all gated
+against the committed artifact by `tooling/repo-checks/src/leaderboard-artifact-sync.test.ts`.
 
 Metrics come from three sources:
 

--- a/packages/results/src/index.ts
+++ b/packages/results/src/index.ts
@@ -14,12 +14,19 @@ export {
 	// cannot name the type of `leaderboard.coverageGaps` can't write a function that takes one.
 	type CoverageGap,
 	type CoverageOutcome,
+	// The rendered document's provenance and layout contract. Exported because the artifact gate
+	// (tooling/repo-checks) re-derives the committed LEADERBOARD.md from these rather than hardcoding a
+	// second copy of the dataset path, the dimension order, or which dimensions collapse.
+	DATASET_RUNS_DIR,
+	LEADERBOARD_DIMENSION_ORDER,
 	type Leaderboard,
 	type LeaderboardDimension,
 	type LeaderboardMetric,
 	type LeaderboardRow,
 	type ProviderRosterEntry,
+	REPO_URL,
 	renderLeaderboardMarkdown,
+	SYNTHETIC_DIMENSIONS,
 } from "./lib/leaderboard.ts";
 export { type NormalizeInput, normalizeResultsTree } from "./lib/normalize-tree.ts";
 export {

--- a/packages/results/src/lib/leaderboard.test.ts
+++ b/packages/results/src/lib/leaderboard.test.ts
@@ -1,7 +1,13 @@
 import { describe, expect, it } from "bun:test";
 import type { MetricResult, ProviderRun, Run } from "@sandbox-benchmarks/schema";
 import { aggregate, ECONOMICS_METRIC_IDS } from "@sandbox-benchmarks/schema";
-import { buildLeaderboard, renderLeaderboardMarkdown } from "./leaderboard.ts";
+import {
+	buildLeaderboard,
+	DATASET_RUNS_DIR,
+	LEADERBOARD_DIMENSION_ORDER,
+	REPO_URL,
+	renderLeaderboardMarkdown,
+} from "./leaderboard.ts";
 
 function metric(metricId: string, samples: number[]): MetricResult {
 	return { metricId, samples, aggregates: aggregate(samples) };
@@ -36,14 +42,18 @@ function provider(
 	};
 }
 
-function run(providers: ProviderRun[]): Run {
+function run(providers: ProviderRun[], provenance: Partial<Pick<Run, "runId" | "sha">> = {}): Run {
 	return {
 		schemaVersion: "2",
+		// Deliberately NOT a workflow run id / commit sha: the default fixture is a locally-produced Run,
+		// which is exactly the case the header must render without inventing a link. Tests that exercise
+		// the provenance links pass real-shaped ids in.
 		runId: "run-1",
 		sha: "abc123",
 		generatedAt: "2026-06-20T00:00:00.000Z",
 		targetSpec: { vcpus: 2, memoryGb: 8, diskGb: 20 },
 		providers,
+		...provenance,
 	};
 }
 
@@ -1136,5 +1146,147 @@ describe("absent providers (zero-evidence registry rows) and the registered-suit
 		expect(board.coverageGaps.map((g) => `${g.providerId}/${g.id}/${g.outcome}`)).toEqual([
 			"e2b/pts_fast-cli/failed",
 		]);
+	});
+});
+
+describe("header provenance links", () => {
+	const cpu = () => provider("daytona-vm", [metric("node_web_tooling_runs_per_s", [10])]);
+
+	it("links the run id to its workflow run, the sha to its commit, and the dataset file it rendered", () => {
+		const md = renderLeaderboardMarkdown(
+			buildLeaderboard(
+				run([cpu()], { runId: "30322186937", sha: "769743f75f2d0c55fd51b01ec5f026bdcdba774c" }),
+			),
+		);
+		expect(md).toContain(`[\`30322186937\`](${REPO_URL}/actions/runs/30322186937)`);
+		expect(md).toContain(
+			`[\`769743f75f2d0c55fd51b01ec5f026bdcdba774c\`](${REPO_URL}/commit/769743f75f2d0c55fd51b01ec5f026bdcdba774c)`,
+		);
+		expect(md).toContain(
+			`[\`${DATASET_RUNS_DIR}/30322186937.json\`](${DATASET_RUNS_DIR}/30322186937.json)`,
+		);
+	});
+
+	it("links each half of a COMPOSITE run id separately — no single workflow run owns the pair", () => {
+		const md = renderLeaderboardMarkdown(
+			buildLeaderboard(run([cpu()], { runId: "29937467891+29967667026" })),
+		);
+		expect(md).toContain(
+			`Run [\`29937467891\`](${REPO_URL}/actions/runs/29937467891) + ` +
+				`[\`29967667026\`](${REPO_URL}/actions/runs/29967667026)`,
+		);
+		// The dataset link keeps the WHOLE composite id — it names a real file — with `+` percent-encoded
+		// in the target so no renderer can decode it back to a space and point the link at nothing.
+		expect(md).toContain(
+			`[\`${DATASET_RUNS_DIR}/29937467891+29967667026.json\`]` +
+				`(${DATASET_RUNS_DIR}/29937467891%2B29967667026.json)`,
+		);
+	});
+
+	it("leaves a locally-produced Run's id and sha as bare code rather than inventing a dead link", () => {
+		// A link that 404s is worse than no link: it asserts a primary source that was never published.
+		const md = renderLeaderboardMarkdown(buildLeaderboard(run([cpu()])));
+		expect(md).toContain("Run `run-1` · commit `abc123` ·");
+		expect(md).not.toContain(`${REPO_URL}/actions/runs/run-1`);
+		expect(md).not.toContain(`${REPO_URL}/commit/abc123`);
+		// The dataset link is unconditional — the file is named by the run id whether or not CI produced it.
+		expect(md).toContain(`[\`${DATASET_RUNS_DIR}/run-1.json\`](${DATASET_RUNS_DIR}/run-1.json)`);
+	});
+});
+
+describe("document order: realworld leads, synthetics collapse", () => {
+	/**
+	 * The dimension sections alone — everything before the board's trailing Coverage gaps and statistics
+	 * blocks. Those carry `<details>` of their own, which would otherwise be attributed to whichever
+	 * dimension happens to render last and make this suite pass or fail on section order.
+	 */
+	function dimensionBody(markdown: string): string {
+		const ends = [
+			"\n## Coverage gaps\n",
+			"\n<details>\n<summary>How rankings are decided</summary>",
+		]
+			.map((marker) => markdown.indexOf(marker))
+			.filter((index) => index >= 0);
+		return ends.length > 0 ? markdown.slice(0, Math.min(...ends)) : markdown;
+	}
+
+	/** The `## <dimension>` headings, in rendered order. */
+	function dimensionHeadings(markdown: string): string[] {
+		return markdown
+			.split("\n")
+			.filter((line) => line.startsWith("## "))
+			.map((line) => line.slice(3))
+			.filter((heading) => (LEADERBOARD_DIMENSION_ORDER as readonly string[]).includes(heading));
+	}
+
+	const mixed = () =>
+		run([
+			provider("daytona-vm", [
+				metric("node_web_tooling_runs_per_s", [10]),
+				metric("stream_type_triad", [100]),
+				metric("realworld_mastra_task_cold_install", [30]),
+				metric(ECONOMICS_METRIC_IDS.usdPerHour, [0.23]),
+			]),
+		]);
+
+	it("hoists realworld above the catalog's order and leaves the rest of that order intact", () => {
+		const board = buildLeaderboard(mixed());
+		// Catalog order is cpu, memory, realworld, economics; realworld leads and the others keep it.
+		expect(board.dimensions.map(({ dimension }) => dimension)).toEqual([
+			"realworld",
+			"cpu",
+			"memory",
+			"economics",
+		]);
+		expect(dimensionHeadings(renderLeaderboardMarkdown(board))).toEqual([
+			"realworld",
+			"cpu",
+			"memory",
+			"economics",
+		]);
+	});
+
+	it("wraps only the synthetic sections in <details>, leaving realworld and economics expanded", () => {
+		const md = dimensionBody(renderLeaderboardMarkdown(buildLeaderboard(mixed())));
+		const sectionOf = (dimension: string): string =>
+			(md.split(`\n## ${dimension}\n`)[1] ?? "").split("\n## ")[0] as string;
+
+		for (const dimension of ["cpu", "memory"]) {
+			expect(sectionOf(dimension), dimension).toContain("<details>");
+			expect(sectionOf(dimension), dimension).toContain("</details>");
+		}
+		for (const dimension of ["realworld", "economics"]) {
+			// Neither is a microbenchmark: realworld is the point of the board, economics is a published
+			// price. Hiding either behind a triangle would be an editorial claim the data doesn't make.
+			expect(sectionOf(dimension), dimension).not.toContain("<details>");
+		}
+	});
+
+	it("names the metric count and headline in the summary, so a shut section still says what it holds", () => {
+		const md = renderLeaderboardMarkdown(buildLeaderboard(mixed()));
+		expect(md).toContain(
+			"<summary><strong>1 synthetic metric</strong> · headline: Node.js web tooling</summary>",
+		);
+		expect(md).toContain(
+			"<summary><strong>1 synthetic metric</strong> · headline: STREAM Triad</summary>",
+		);
+	});
+
+	it("keeps the ## heading OUTSIDE the collapse so a measured axis is never mistaken for an absent one", () => {
+		const md = renderLeaderboardMarkdown(buildLeaderboard(mixed()));
+		expect(md).toContain("## cpu\n\n<details>\n<summary>");
+	});
+
+	it("explains the collapse only when a synthetic dimension was actually rendered", () => {
+		const withSynthetic = renderLeaderboardMarkdown(buildLeaderboard(mixed()));
+		expect(withSynthetic).toContain("**Document order:**");
+		expect(withSynthetic).toContain("(`cpu`, `memory`)");
+
+		const realworldOnly = renderLeaderboardMarkdown(
+			buildLeaderboard(
+				run([provider("daytona-vm", [metric("realworld_mastra_task_cold_install", [30])])]),
+			),
+		);
+		expect(realworldOnly).not.toContain("**Document order:**");
 	});
 });

--- a/packages/results/src/lib/leaderboard.ts
+++ b/packages/results/src/lib/leaderboard.ts
@@ -8,6 +8,12 @@
  * its Direction (HIB → highest first, LIB → lowest first). A Metric with no provider value is omitted.
  * The representative value is the Samples' p50 (median) — robust to a single slow pass.
  *
+ * The document leads with `realworld` and collapses the synthetic microbenchmarks, because that is the
+ * claim this benchmark makes: a synthetic score says what the hardware CAN do, and the real-world
+ * workflows say what a developer or a CI job actually waits on. See {@link LEADERBOARD_DIMENSION_ORDER}
+ * and {@link SYNTHETIC_DIMENSIONS}. Which sections exist stays driven by the data — a Dimension no
+ * provider emitted is absent, collapsed or not.
+ *
  * Ranking is INFERENTIAL, not a bare sort. A provider's Samples are repeated trials inside one sandbox,
  * so their spread is environmental noise, and ordering on the median alone would let a lucky draw buy a
  * position: a live run had modal's STREAM Copy span 9.7k–65k MB/s against daytona's 66.5k ±0.14%. Each
@@ -39,6 +45,50 @@ import {
 	providerReportedNothing,
 	SUITE_NAMES,
 } from "@sandbox-benchmarks/schema";
+
+/**
+ * The repository the published leaderboard lives in — the base for every provenance link in the header.
+ * A constant rather than `GITHUB_REPOSITORY`: this renderer is pure, and its output is gated
+ * byte-identical against a fresh render (tooling/repo-checks/leaderboard-artifact-sync.test.ts), so a
+ * link that varied with the environment would make a local regeneration differ from CI's for no reason
+ * a reader could see. The artifact is published here; the links point here.
+ */
+export const REPO_URL = "https://github.com/starslingdev/hpc-sandbox-benchmarks";
+
+/** The committed dataset tree — one Run document per run id, written by `promote`. */
+export const DATASET_RUNS_DIR = "data/dataset/runs";
+
+/**
+ * The SYNTHETIC Dimensions: microbenchmarks that load one hardware axis in isolation (PTS profiles for
+ * `cpu`/`disk`/`memory`/`network`/`system`). They answer "what can this machine do", which is a real
+ * question but not the one this benchmark is FOR — so their sections render collapsed and the
+ * real-world workflows lead. See {@link LEADERBOARD_DIMENSION_ORDER}.
+ *
+ * Deliberately not "everything except realworld". `lifecycle` and `control-plane` are harness-measured
+ * timings of the provider's own API — a spawn a user waits on, not a synthetic load — and `economics`
+ * is the provider's published price. Neither is a microbenchmark, so neither is hidden behind a
+ * disclosure triangle.
+ */
+export const SYNTHETIC_DIMENSIONS: ReadonlySet<Dimension> = new Set<Dimension>([
+	"cpu",
+	"disk",
+	"memory",
+	"network",
+	"system",
+]);
+
+/**
+ * Dimension render order: `realworld` first, then the Catalog's own order for the rest. Only the hoist
+ * is editorial — everything else keeps {@link DIMENSIONS}' ordering so a new Dimension lands where the
+ * schema says it belongs, without a second ordering to keep in sync.
+ *
+ * This is presentation priority, never a filter: {@link buildLeaderboard} still emits a Dimension only
+ * when some provider produced a catalogued Metric in it.
+ */
+export const LEADERBOARD_DIMENSION_ORDER: readonly Dimension[] = [
+	"realworld",
+	...DIMENSIONS.filter((dimension) => dimension !== "realworld"),
+];
 
 /** One provider's standing on one Metric. */
 export interface LeaderboardRow {
@@ -518,7 +568,7 @@ function buildRoster(run: Run): ProviderRosterEntry[] {
 export function buildLeaderboard(run: Run): Leaderboard {
 	const dimensions: LeaderboardDimension[] = [];
 
-	for (const dimension of DIMENSIONS) {
+	for (const dimension of LEADERBOARD_DIMENSION_ORDER) {
 		// Catalog order is the stable display order, except the dimension's editorial headline leads.
 		// Crucially, every emitted Metric gets a table: headline is presentation priority, not a filter.
 		const catalogued = METRIC_CATALOG.filter((metric) => metric.dimension === dimension).sort(
@@ -584,16 +634,26 @@ function underpoweredFloors(board: Leaderboard): string[] {
 }
 
 /**
+ * Neutralize the HTML-significant characters. GitHub renders raw HTML inside Markdown, so any text
+ * that reaches markup passes through here first — a gap reason carrying an upstream error page
+ * (`<HTML>`, `<PRE>`, `<HR>` from a CloudFront/proxy diagnostic) would otherwise inject live markup
+ * instead of showing as a plain diagnostic. `&` goes first so the entities emitted for `<`/`>` aren't
+ * themselves re-encoded.
+ */
+function escapeHtml(text: string): string {
+	return text.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
+}
+
+/**
  * Make free-form text safe inside a Markdown table cell. Skip reasons are the harness's verbatim
- * strings — a `|` would end the cell and a newline would end the row, silently corrupting the table,
- * and GitHub renders raw HTML inside Markdown, so a reason carrying an upstream error page (`<HTML>`,
- * `<PRE>`, `<HR>` from a CloudFront/proxy diagnostic) would inject live markup instead of showing as
- * a plain diagnostic.
+ * strings — a `|` would end the cell and a newline would end the row, silently corrupting the table —
+ * on top of the raw-HTML hazard {@link escapeHtml} handles.
  *
- * Order matters: escape each escape-introducing character before the character it guards. `&` goes
- * first so the HTML entities we emit for `<`/`>` aren't themselves re-encoded, and the backslash is
- * doubled before we backslash-escape `|` — otherwise a reason containing `\|` would leave a lone `\`
- * in front of our escape, unescaping the pipe and breaking the cell anyway.
+ * Order matters: escape each escape-introducing character before the character it guards. The
+ * backslash is doubled before we backslash-escape `|` — otherwise a reason containing `\|` would leave
+ * a lone `\` in front of our escape, unescaping the pipe and breaking the cell anyway. HTML escaping
+ * runs first for the same reason it does inside {@link escapeHtml}: the `&` of an emitted entity must
+ * not be re-encoded, and the entities it emits contain no `\` or `|` for the later passes to mangle.
  *
  * The final pass folds any whitespace run that spans a newline down to a single space (a newline
  * would otherwise end the table row). It scans each maximal `\s+` run once rather than matching
@@ -601,13 +661,60 @@ function underpoweredFloors(board: Leaderboard): string[] {
  * newline-free whitespace stretch in an attacker-influenced reason.
  */
 function escapeCell(text: string): string {
-	return text
-		.replace(/&/g, "&amp;")
-		.replace(/</g, "&lt;")
-		.replace(/>/g, "&gt;")
+	return escapeHtml(text)
 		.replace(/\\/g, "\\\\")
 		.replace(/\|/g, "\\|")
 		.replace(/\s+/g, (ws) => (ws.includes("\n") ? " " : ws));
+}
+
+/**
+ * The GitHub Actions run(s) behind a Run id, as GFM links straight to the workflow run — the primary
+ * source for the matrix legs, the job logs, and the uploaded artifacts every number below is derived
+ * from. A Run id IS a bench-matrix run id, so it resolves to `/actions/runs/<id>` with nothing to look up.
+ *
+ * A COMPOSITE id (`<runA>+<runB>` — a Run spliced from two CI runs, see data/dataset/index.json) names
+ * no single workflow run, so each component is linked separately rather than emitting one dead link to
+ * an id GitHub has never issued.
+ *
+ * A component that is not a run id at all — a locally-produced Run named `local-1`, say — renders as
+ * bare code. A provenance link that 404s is worse than no link: it asserts a primary source exists.
+ */
+function runSourceLinks(runId: string): string {
+	return runId
+		.split("+")
+		.map((id) => (/^\d+$/.test(id) ? `[\`${id}\`](${REPO_URL}/actions/runs/${id})` : `\`${id}\``))
+		.join(" + ");
+}
+
+/** The Run's commit, linked to the tree the measurement was taken against. Bare code for a non-sha
+ *  (a fixture, a placeholder) — see {@link runSourceLinks} on why a dead link is worse than none. */
+function commitSourceLink(sha: string): string {
+	return /^[0-9a-f]{7,40}$/.test(sha) ? `[\`${sha}\`](${REPO_URL}/commit/${sha})` : `\`${sha}\``;
+}
+
+/**
+ * The committed Run document this board was rendered from, as a repo-relative GFM link: the reader can
+ * go from any table straight to the raw Samples behind it. Relative so it resolves on whatever ref the
+ * file is being viewed at, rather than pinning every reader to `main`.
+ *
+ * `+` is percent-encoded for a composite id: it is legal in a URL path segment, but it is the one
+ * character a renderer may still decode as a space, and the link would then point at no file at all.
+ */
+function datasetSourceLink(runId: string): string {
+	const path = `${DATASET_RUNS_DIR}/${runId}.json`;
+	return `[\`${path}\`](${path.replace(/\+/g, "%2B")})`;
+}
+
+/**
+ * The `<summary>` line of a collapsed synthetic Dimension — how many Metrics are inside and which one
+ * headlines them, so a shut section still says what it holds instead of reading as an empty triangle.
+ * Escaped: catalogued labels are trusted, but this is the one place a label is emitted into markup
+ * rather than into a table cell, and the two escapes are not the same.
+ */
+function syntheticSummary(metrics: readonly LeaderboardMetric[]): string {
+	const count = `<strong>${metrics.length} synthetic metric${metrics.length === 1 ? "" : "s"}</strong>`;
+	const headline = metrics.find(({ metric }) => metric.headline);
+	return headline ? `${count} · headline: ${escapeHtml(headline.metric.label)}` : count;
 }
 
 /** Format a metric value compactly: integers as-is, otherwise up to 4 significant digits, trimmed. */
@@ -764,10 +871,14 @@ export function renderLeaderboardMarkdown(board: Leaderboard): string {
 	const providerCount = new Set(rows.map((row) => row.providerId)).size;
 	const metricNoun = metricCount === 1 ? "metric" : "metrics";
 	const providerNoun = providerCount === 1 ? "provider" : "providers";
+	// Header provenance: every identifier links to the thing it names, so a reader can audit any number
+	// on this page without being told where to look — the workflow run that produced it, the commit it
+	// was measured against, and the committed Run document it was rendered from.
 	const lines: string[] = [
 		"# Sandbox provider leaderboard",
 		"",
-		`Run \`${board.runId}\` · commit \`${board.sha}\` · generated ${board.generatedAt}`,
+		`Run ${runSourceLinks(board.runId)} · commit ${commitSourceLink(board.sha)} ·`,
+		`dataset ${datasetSourceLink(board.runId)} · generated ${board.generatedAt}`,
 		"",
 		`Requested target for every provider: **${spec}**. This run contains **${rows.length} metric records**`,
 		`backed by **${observationCount} retained trial observations**, across **${metricCount} ${metricNoun}** and`,
@@ -782,6 +893,22 @@ export function renderLeaderboardMarkdown(board: Leaderboard): string {
 		"surfaced through coverage gaps, not part of the compute-match verdict.",
 		"",
 	];
+
+	// Name the layout only when it is actually in play — the note lists the synthetic dimensions THIS
+	// run rendered, so a board with none never explains a collapse the reader cannot see.
+	const syntheticRendered = board.dimensions.filter(({ dimension }) =>
+		SYNTHETIC_DIMENSIONS.has(dimension),
+	);
+	if (syntheticRendered.length > 0) {
+		const names = syntheticRendered.map(({ dimension }) => `\`${dimension}\``).join(", ");
+		lines.push(
+			"**Document order:** the real-world developer workflows lead, because what a developer or a CI job",
+			`actually waits on is what this benchmark exists to measure. The synthetic microbenchmarks (${names})`,
+			"load one hardware axis in isolation — a real question, but a different one — so each is collapsed by",
+			"default; expand a section to read its tables.",
+			"",
+		);
+	}
 	lines.push(...rosterSection(board.roster));
 	if (board.absentProviders.length > 0) {
 		// One line, not per-suite `missing` rows: the Run does not record the dispatch plan
@@ -806,6 +933,13 @@ export function renderLeaderboardMarkdown(board: Leaderboard): string {
 
 	for (const { dimension, metrics } of board.dimensions) {
 		lines.push(`## ${dimension}`, "");
+		// A synthetic dimension collapses its TABLES, never its heading: the heading stays in the rendered
+		// document outline so the board still discloses which hardware axes were measured — collapsing it
+		// too would make a measured dimension indistinguishable from one that never ran.
+		const collapsed = SYNTHETIC_DIMENSIONS.has(dimension);
+		if (collapsed) {
+			lines.push("<details>", `<summary>${syntheticSummary(metrics)}</summary>`, "");
+		}
 		for (const { metric, rows: metricRows } of metrics) {
 			const better = metric.direction === "HIB" ? "higher is better" : "lower is better";
 			const notes = metricRows.map(rowNote);
@@ -831,6 +965,7 @@ export function renderLeaderboardMarkdown(board: Leaderboard): string {
 				"",
 			);
 		}
+		if (collapsed) lines.push("</details>", "");
 	}
 
 	// Coverage gaps: summary first; full table + legends inside <details> so unfinished providers

--- a/tooling/repo-checks/src/leaderboard-artifact-sync.test.ts
+++ b/tooling/repo-checks/src/leaderboard-artifact-sync.test.ts
@@ -10,7 +10,14 @@
 import { describe, expect, it, setDefaultTimeout } from "bun:test";
 import { readFileSync } from "node:fs";
 import { join } from "node:path";
-import { buildLeaderboard, renderLeaderboardMarkdown } from "@sandbox-benchmarks/results";
+import {
+	buildLeaderboard,
+	DATASET_RUNS_DIR,
+	LEADERBOARD_DIMENSION_ORDER,
+	REPO_URL,
+	renderLeaderboardMarkdown,
+	SYNTHETIC_DIMENSIONS,
+} from "@sandbox-benchmarks/results";
 import type { MetricDef, Run } from "@sandbox-benchmarks/schema";
 import {
 	canSeparate,
@@ -30,9 +37,9 @@ const ARTIFACT = join(ROOT, "LEADERBOARD.md");
  *  `promote` writes. `data/runs/` is a gitignored raw scratch tree: it exists on a dev machine, is
  *  absent in CI, and can hold a stale/partial Run — rendering from it once silently dropped the whole
  *  `economics` dimension from this file. */
-const runFile = (runId: string) => join(ROOT, "data", "dataset", "runs", `${runId}.json`);
+const runFile = (runId: string) => join(ROOT, ...DATASET_RUNS_DIR.split("/"), `${runId}.json`);
 const regenCmd = (runId: string) =>
-	`bun apps/cli/src/bin/leaderboard.ts data/dataset/runs/${runId}.json LEADERBOARD.md`;
+	`bun apps/cli/src/bin/leaderboard.ts ${DATASET_RUNS_DIR}/${runId}.json LEADERBOARD.md`;
 
 /** Independent R-7 percentile implementation for auditing the persisted Aggregates and displayed p50. */
 function auditPercentile(samples: readonly number[], p: number): number {
@@ -341,15 +348,24 @@ function parseMetricTables(markdown: string, emitted: Map<string, MetricDef>) {
 	return { rows, pairwise };
 }
 
-/** The Run id the committed artifact was generated from, read out of its own header line:
- *  "Run `<id>` · commit `<sha>` · generated <iso>". Parsed rather than hardcoded so regenerating the
- *  leaderboard from a newer Run doesn't require editing this gate too. */
+/**
+ * The Run id the committed artifact was generated from, read out of the header's DATASET link
+ * (`[…](data/dataset/runs/<id>.json)`). Parsed rather than hardcoded so regenerating the leaderboard
+ * from a newer Run doesn't require editing this gate too.
+ *
+ * The dataset link is the right anchor rather than the `Run` identifier beside it: the identifier is
+ * now rendered as one Actions link per component, so a COMPOSITE id (`<runA>+<runB>`) appears there
+ * only in pieces, while the dataset link always carries the whole id — it has to, since it names the
+ * file on disk. `+` is percent-encoded in the link target, so decode before returning the id.
+ */
 function runIdOf(markdown: string): string {
-	const match = markdown.match(/^Run `([^`]+)`/m);
+	const match = markdown.match(new RegExp(`\\(${DATASET_RUNS_DIR}/([^)]+)\\.json\\)`));
 	if (!match?.[1]) {
-		throw new Error("LEADERBOARD.md has no `Run <id>` header line — cannot locate its source Run");
+		throw new Error(
+			`LEADERBOARD.md has no ${DATASET_RUNS_DIR}/<id>.json link in its header — cannot locate its source Run`,
+		);
 	}
-	return match[1];
+	return decodeURIComponent(match[1]);
 }
 
 /**
@@ -390,6 +406,107 @@ function loadCommittedRun(): {
 // is wrong, so give the file a generous ceiling — high enough to absorb further dataset growth, still low
 // enough to catch a genuine non-terminating bootstrap.
 setDefaultTimeout(120_000);
+
+describe("LEADERBOARD.md publishes auditable provenance", () => {
+	// The header's identifiers are the reader's only route from a number back to the thing that produced
+	// it. A stale or malformed link is invisible in a rendered page — it just goes nowhere — so assert
+	// each one resolves to the artifact it claims, against the SOURCE Run rather than the header's own
+	// text (which is what a broken renderer would get wrong in the first place).
+	it("links the run id to its workflow run, the sha to its commit, and names the dataset file it rendered", () => {
+		const { committed, runId, run } = loadCommittedRun();
+		// A composite id (`<runA>+<runB>`) names no single workflow run, so each component links separately.
+		for (const component of run.runId.split("+")) {
+			expect(committed, `run ${component} workflow link`).toContain(
+				`[\`${component}\`](${REPO_URL}/actions/runs/${component})`,
+			);
+		}
+		expect(committed).toContain(`[\`${run.sha}\`](${REPO_URL}/commit/${run.sha})`);
+
+		const dataset = `${DATASET_RUNS_DIR}/${runId}.json`;
+		expect(committed).toContain(`[\`${dataset}\`](${dataset.replace(/\+/g, "%2B")})`);
+		// …and the file that link points at is the one this artifact was actually rendered from.
+		expect(readFileSync(runFile(runId), "utf8").length).toBeGreaterThan(0);
+	});
+});
+
+describe("LEADERBOARD.md leads with the real-world workflows", () => {
+	// The layout is the board's editorial claim: synthetic scores say what the hardware CAN do, the
+	// realworld suites say what a developer waits on. A renderer change that quietly buried `realworld`
+	// below five synthetic sections, or left one expanded, would invert that claim while every number on
+	// the page stayed correct — so the ORDER and the collapse are gated, not just the tables.
+	/**
+	 * The dimension sections alone — everything before the trailing Coverage gaps and statistics blocks,
+	 * which carry `<details>` of their own. Without this cut those would be attributed to whichever
+	 * dimension renders last, so the collapse assertion below would pass or fail on section order.
+	 */
+	const dimensionBody = (markdown: string): string => {
+		const ends = [
+			"\n## Coverage gaps\n",
+			"\n<details>\n<summary>How rankings are decided</summary>",
+		]
+			.map((marker) => markdown.indexOf(marker))
+			.filter((index) => index >= 0);
+		return ends.length > 0 ? markdown.slice(0, Math.min(...ends)) : markdown;
+	};
+
+	const dimensionHeadings = (markdown: string): string[] =>
+		markdown
+			.split("\n")
+			.filter((line) => line.startsWith("## "))
+			.map((line) => line.slice(3))
+			.filter((heading) => (LEADERBOARD_DIMENSION_ORDER as readonly string[]).includes(heading));
+
+	it("orders the dimension sections realworld-first, then by catalog order", () => {
+		const { committed } = loadCommittedRun();
+		const rendered = dimensionHeadings(committed);
+		expect(rendered.length).toBeGreaterThan(0);
+		expect(rendered[0]).toBe("realworld");
+		// Data-driven: only the dimensions this run emitted appear, but in the declared relative order.
+		expect(rendered).toEqual(
+			LEADERBOARD_DIMENSION_ORDER.filter((dimension) => rendered.includes(dimension)),
+		);
+	});
+
+	it("collapses every synthetic dimension and leaves every other one expanded", () => {
+		const { committed } = loadCommittedRun();
+		// Read each `## <dimension>` section's body and ask whether it opens a disclosure block. Parsed
+		// from the committed text, not from the renderer's intent, so this catches an unclosed <details>
+		// swallowing the section after it just as readily as a missing one.
+		const sections = new Map<string, string[]>();
+		let current: string | undefined;
+		for (const line of dimensionBody(committed).split("\n")) {
+			if (line.startsWith("## ")) {
+				const heading = line.slice(3);
+				current = (LEADERBOARD_DIMENSION_ORDER as readonly string[]).includes(heading)
+					? heading
+					: undefined;
+				if (current) sections.set(current, []);
+				continue;
+			}
+			if (current) sections.get(current)?.push(line);
+		}
+		expect(sections.size).toBeGreaterThan(0);
+
+		for (const [dimension, body] of sections) {
+			const synthetic = SYNTHETIC_DIMENSIONS.has(dimension as never);
+			const opens = body.filter((line) => line === "<details>").length;
+			const closes = body.filter((line) => line === "</details>").length;
+			expect(opens, `${dimension} <details> count`).toBe(synthetic ? 1 : 0);
+			expect(closes, `${dimension} </details> count`).toBe(synthetic ? 1 : 0);
+			if (synthetic) {
+				// The heading itself stays OUTSIDE the collapse (it is above this body), and the summary
+				// names what is hidden — a shut section must still disclose that the axis was measured.
+				expect(
+					body.some((line) => line.startsWith("<summary>")),
+					`${dimension} summary`,
+				).toBe(true);
+				expect(body.indexOf("<details>")).toBeLessThan(
+					body.findIndex((line) => line.startsWith("### ")),
+				);
+			}
+		}
+	});
+});
 
 describe("LEADERBOARD.md stays in sync with the renderer", () => {
 	it("stores internally consistent Aggregates for every raw Sample distribution", () => {


### PR DESCRIPTION
## Summary

Restructures the leaderboard document to prioritize real-world developer workflows over synthetic microbenchmarks, making the benchmark's actual purpose clearer to readers. Synthetic metrics (cpu, disk, memory, network, system) are now collapsed behind disclosure triangles, while real-world metrics lead the document.

## Key Changes

- **Document reordering**: Moved `realworld` dimension to the front via new `LEADERBOARD_DIMENSION_ORDER` constant; synthetic dimensions follow in catalog order
- **Synthetic metrics collapsing**: Wrapped cpu, disk, memory, network, and system sections in `<details>` elements with summary headers, controlled by new `SYNTHETIC_DIMENSIONS` set
- **Improved provenance links**: Enhanced header to include:
  - Clickable links to GitHub Actions runs and commits (when run id is numeric)
  - Direct link to the dataset JSON file that generated the leaderboard
  - Graceful fallback to bare code for locally-produced runs (no dead links)
  - Support for composite run ids (`<runA>+<runB>`) with proper percent-encoding
- **Editorial documentation**: Added explanatory text in the leaderboard header clarifying why real-world workflows lead and synthetic benchmarks are collapsed
- **Constants extraction**: Exported `REPO_URL`, `DATASET_RUNS_DIR`, `LEADERBOARD_DIMENSION_ORDER`, and `SYNTHETIC_DIMENSIONS` for reuse across the codebase
- **HTML escaping**: Added `escapeHtml()` function to prevent injection of raw HTML from upstream error diagnostics in gap reasons

## Implementation Details

- The dimension ordering is presentation-only; filtering still respects data availability (dimensions with no provider metrics are omitted)
- Composite run ids are properly handled: the Actions links show each component separately, while the dataset link preserves the full id with `+` percent-encoded
- The `runIdOf()` parser was updated to extract the run id from the dataset link rather than the Run identifier, making it robust to the new link format
- All provenance links are validated in tests against the actual source Run object to ensure they resolve correctly

https://claude.ai/code/session_01RkWwyayetg3A4haT7MBhbo

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reorganizes the leaderboard to lead with real-world workflows and collapse synthetic microbenchmarks, making the intent clearer. Adds direct provenance links to the workflow run, commit, and dataset JSON, plus small hardening and test updates.

- **New Features**
  - Leads with `realworld`; collapses `cpu`, `disk`, `memory`, `network`, `system` behind details. Sections remain data-driven.
  - Header now links to the GitHub Actions run, commit, and dataset JSON. Supports composite run ids and clean fallback for local runs. `runIdOf()` now parses from the dataset URL.
  - Exports `REPO_URL`, `DATASET_RUNS_DIR`, `LEADERBOARD_DIMENSION_ORDER`, and `SYNTHETIC_DIMENSIONS` for reuse. The artifact gate derives layout and links from these.
  - Escapes upstream HTML in gap reasons via `escapeHtml()`. Adds tests that validate provenance links resolve.
  - Ranks and metrics are unchanged; this is a presentation update only.

<sup>Written for commit c90df56707c9a5a0edb46f95a5f33d8c5a598122. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/starslingdev/hpc-sandbox-benchmarks/pull/289?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Leaderboard entries now include direct links to the originating workflow run, commit, and dataset.
  - Synthetic benchmark sections are collapsible, making the leaderboard easier to scan.
  - Added a “Document order” guide explaining ranking and section layout.

- **Documentation**
  - Expanded methodology guidance for leaderboard ordering, collapsed sections, and provenance links.
  - Updated real-world benchmark results, statistical comparisons, and economics notes.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->