### PR TITLE
feat(schema): make the benchmark dataset self-describing (Run v4)

### DIFF
--- a/docs/adr/0005-host-vs-effective-spec-split.md
+++ b/docs/adr/0005-host-vs-effective-spec-split.md
@@ -21,17 +21,82 @@ shards scheduled on different hosts would average across hardware without anyone
 sandbox size (the cgroup quota where enforced); `hostVcpus`/`hostMemoryGb` disclose the underlying
 machine when probes see through the boundary. `cpuModel`/`cpuMicroarch`/`cpuMhz` and friends are
 HOST-side by construction — `cpuMicroarch` is a generation label derived from the host `cpuModel`,
-and **never reflects the effective spec**. The aggregate path sets `hostCpuModels` — the distinct host
-CPU models — when a provider's merged shards disclosed more than one, naming the scheduling confound the
-published Run must own. Every field is optional because providers differ in what their probes expose,
-and `specMatched` records whether the effective side honored the target.
+and **never reflects the effective spec**. Every field is optional because providers differ in what
+their probes expose, and `specMatched` records whether the effective side honored the target.
+
+**Amended (Run schema v4): the document describes itself.** Six facts a reader needed were present in
+the dataset but not expressible *from* it — each recoverable only by knowing something the file did not
+say. Run 30510718771 makes the cost concrete: modal-vm's 12 realworld replicates were spread over **ten**
+CPU models, Intel and AMD across five EPYC generations, under a single `specMatched: true` and a headline
+`cpuModel` that appears in 10 of its 78 host records. v4 records what was missing:
+
+- **[`ObservedMixtures`](../../packages/schema/src/run.ts)** — per provider, `sandboxes` (the
+  denominator) plus two maps from a stable content hash to `{ count, specs }`, one for **host hardware**
+  and one for **host network** (egress ASN/org + geo). `Object.keys(hostHardware).length` *is* the number
+  of distinct machine shapes observed; each `count` is how many sandboxes landed on it. The prior
+  mitigation, `hostCpuModels`, covered one field of one category and answered "were they different?"
+  rather than "how many, and how many sandboxes each?" — so it was REMOVED rather than kept beside the
+  mixtures: nothing ever read it, and arktype ignores undeclared keys, so published Runs carrying it
+  still validate.
+- **`MetricReplicate.hostHardwareId` / `hostNetworkId`** — the join from a sample cluster to the machine
+  that produced it. Both halves of "is the Intel leg slower than the EPYC leg?" were already in the
+  document with nothing connecting them. `providerRunSchema` narrows the ids to resolvable keys: a
+  dangling id and an absent one both read as `undefined` at the point of use, and only one is honest.
+- **A dominant representative reading** — `observedSpecs` on an aggregate was "first defined value per
+  key wins", i.e. shard arrival order, which on a mixed fleet publishes a machine most sandboxes never
+  ran on. The hashed-category fields now come from the mixture the MOST sandboxes reported.
+- **`ResultGap.cause`** — a closed, discriminated taxonomy (`disk-shortfall`, `step-timeout`,
+  `sandbox-lost`, `metrics-unrecorded`, …) authored where the failure happens. `reason` had been the
+  machine interface as well as the human one, so the leaderboard classified disk skips with
+  `/^insufficient disk/i` against a string authored in another package — a coupling its own comment
+  warned about. There is deliberately no catch-all arm: an unclassifiable gap omits `cause`, which reads
+  as "unclassified" and cannot be mistaken for a diagnosis.
+- **`MetricResult.derived`** — `usd_per_hour` sat among the measurements looking like one, separable only
+  by a Metric Catalog lookup, and a Run outlives the catalog version that produced it. Mandatory from v4;
+  optional-in-practice would leave consumers keeping the lookup anyway.
+- **Host records folded and attributed** — each record carries `sandboxes` and its machine's mixture id.
+  The old dedupe kept byte-identical records only and every PTS record carries a wall-clock
+  `ci.timestamp`, so it never fired: host metadata was 54% of the committed dataset while describing a
+  handful of machines. Folding on the non-volatile fields cuts it by 54% (468 records → 203 on run
+  30510718771).
+- **Per-machine `specMatched`** — one boolean cannot cover a ten-machine fleet. Each host-hardware
+  mixture carries its own verdict, and a narrow enforces that the provider's fold is never kinder than
+  its parts. The network mixture type has no such field at all: the target spec says nothing about
+  egress, so a network mixture must not be able to claim a verdict.
+
+Two rules make the mixture categories trustworthy rather than merely present:
+
+- **`ObservedSpecs` is composed from the category field groups**, not written flat with the groups
+  listed separately. A new field must join a group to exist at all, so it cannot be silently absent
+  from every hash while the key lists still look complete.
+- **Per-sandbox identity fields are excluded from both hashes** (`publicIp`, `reverseDns`, `user`).
+  Hashing a unique-per-sandbox value would mint one "mixture" per sandbox and report every count as 1,
+  destroying the signal. `networkPrefix` carries the address-space dimension instead.
 
 ## Consequences
 
 - A reader can always tell the sold size from the silicon it ran on; price/performance uses the
   effective spec, while the host side explains a fast or noisy number.
-- Heterogeneous scheduling is disclosed, not hidden: `hostCpuModels` names the distinct CPUs when a
-  provider's shards didn't all land on the same hardware, so the comparison stays honest about that confound.
+- Heterogeneous scheduling is counted, not just flagged: the mixture maps name every distinct machine
+  shape and egress network with a sandbox count each, so "how mixed was this provider" is arithmetic
+  rather than inference. Hash ids are content-addressed, so the same shape carries the same id across
+  runs and can be tracked through the dataset series.
+- The between-machine axis is decomposable: because every replicate names its mixture, a consumer can
+  group a metric's sample clusters by host and ask whether the spread is the provider's variance or the
+  hardware's. That question was unanswerable from a published Run before v4.
+- The provider-level `specMatched` is still one boolean, but it is now the FOLD of the per-machine
+  verdicts as well as the per-shard ones (a single `false` is sticky), and the schema refuses a provider
+  verdict kinder than its parts. "Which machine missed the target" is answered by the mixtures.
+- Pre-v4 unreachability is by construction, not by extra rules: a replicate id must resolve into
+  `observedMixtures` and a mixture's `specMatched` lives inside one, so the single v4 gate on
+  `observedMixtures` already refuses both. No redundant per-field gates to keep in sync.
+- The host-vs-effective split stays documented field-by-field, but the effective size shares the
+  hostHardware hash category: a provider handing out 4 vCPU on some sandboxes and 2 on others is
+  exactly the heterogeneity this disclosure exists to surface, so it belongs in "which machine did I
+  get". The two sides remain separately labelled within the group.
+- Counts sum to less than `sandboxes` when some sandbox's probe saw nothing, which is a visible partial
+  disclosure rather than a silent one — a category is omitted entirely rather than recording an empty
+  mixture nobody observed.
 - More fields to populate, and probes that can't see the host simply leave the host side absent (the
   effective side stands alone) — accepted in exchange for never conflating the two axes.
 - The split is encoded in the schema and documented field-by-field, so a new probe/provider must

--- a/packages/harness/src/index.test.ts
+++ b/packages/harness/src/index.test.ts
@@ -438,6 +438,12 @@ describe("createSuiteSandbox (creation-failure marker)", () => {
 			suite: "cpu-node",
 			outcome: "failed",
 			reason: "Failed to create sandbox: Snapshot toolchain-v3-container is not available",
+			// The classification the thrower knew, carried into the marker so consumers need not
+			// re-read the sentence above to learn it was a creation failure.
+			cause: {
+				kind: "sandbox-create-failed",
+				detail: "Snapshot toolchain-v3-container is not available",
+			},
 		});
 	});
 
@@ -456,6 +462,12 @@ describe("createSuiteSandbox (creation-failure marker)", () => {
 			suite: "cpu-node",
 			outcome: "failed",
 			reason: "Failed to create sandbox: provider config invalid: DAYTONA_REGION unset",
+			// The classification the thrower knew, carried into the marker so consumers need not
+			// re-read the sentence above to learn it was a creation failure.
+			cause: {
+				kind: "sandbox-create-failed",
+				detail: "provider config invalid: DAYTONA_REGION unset",
+			},
 		});
 	});
 
@@ -497,6 +509,9 @@ describe("createSuiteSandbox (creation-failure marker)", () => {
 			id: "cpu-node",
 			outcome: "failed",
 			reason: "Failed to create sandbox: boom",
+			// The classification the thrower knew, carried into the marker so consumers need not
+			// re-read the sentence above to learn it was a creation failure.
+			cause: { kind: "sandbox-create-failed", detail: "boom" },
 		});
 	});
 });

--- a/packages/harness/src/index.ts
+++ b/packages/harness/src/index.ts
@@ -8,6 +8,7 @@ import { HARNESS_METRIC_IDS, isPtsResultFile, SUITES } from "@sandbox-benchmarks
 import { collectResults, writeGapMarker } from "./lib/collect.ts";
 import type { SandboxHandle } from "./lib/execute.ts";
 import { MIN, resolvePtsPassPolicy, StepRunner, withTimeout } from "./lib/execute.ts";
+import { gapCauseOf } from "./lib/gap-cause.ts";
 import { time } from "./lib/internal.ts";
 import type { LifecycleAggregate, LifecycleCompute } from "./lib/lifecycle.ts";
 import { aggregateLifecycle, measureLifecycle } from "./lib/lifecycle.ts";
@@ -200,7 +201,10 @@ export async function runSuite(options: RunSuiteOptions): Promise<void> {
 	if (missingVars.length > 0) {
 		const reason = `Missing credentials: ${missingVars.join(", ")}`;
 		console.log(`SKIPPED ${providerName}/${suiteName}: ${reason}`);
-		writeGapMarker(resultsDir, providerName, suiteName, "skipped", reason);
+		writeGapMarker(resultsDir, providerName, suiteName, "skipped", reason, {
+			kind: "missing-credentials",
+			variables: missingVars,
+		});
 		return;
 	}
 
@@ -331,6 +335,7 @@ export async function createSuiteSandbox(
 						suiteName,
 						"failed",
 						`${CREATE_FAILURE_PREFIX}${message}`,
+						{ kind: "sandbox-create-failed", detail: message },
 					);
 				} catch (markerErr) {
 					console.error(
@@ -339,6 +344,10 @@ export async function createSuiteSandbox(
 						}); the sandbox-creation error below is unaffected`,
 					);
 				}
+				// The ORIGINAL error propagates, unwrapped: bench-suite matches on the provider's own message
+				// and `createSuiteSandbox` is called outside `runSuiteOnSandbox`, so this throw never reaches
+				// the suite-level marker writer that reads a classification. The marker written just above
+				// already carries the cause as a plain value, which is the only place it is read.
 				throw err;
 			}
 			console.log(
@@ -427,7 +436,11 @@ export async function runSuiteOnSandbox(
 			if (freeGb < suite.minDiskGb) {
 				const reason = `Insufficient disk: ${freeGb.toFixed(1)} GiB free, suite needs ${suite.minDiskGb} GiB`;
 				console.log(`SKIPPED ${providerName}/${suiteName}: ${reason}`);
-				writeGapMarker(resultsDir, providerName, suiteName, "skipped", reason);
+				writeGapMarker(resultsDir, providerName, suiteName, "skipped", reason, {
+					kind: "disk-shortfall",
+					freeGb,
+					requiredGb: suite.minDiskGb,
+				});
 				return;
 			}
 		}
@@ -503,7 +516,10 @@ export async function runSuiteOnSandbox(
 		// The leaderboard still derives a `missing` gap when even this marker is lost (the artifact upload
 		// is itself best-effort), but a marker that survives says WHY, and that is the whole difference.
 		const reason = suiteError instanceof Error ? suiteError.message : String(suiteError);
-		writeGapMarker(resultsDir, providerName, suiteName, "failed", reason);
+		// The thrower classified it (a step timeout knows its budget, a lost sandbox knows its step);
+		// this frame only knows a message. `gapCauseOf` returns undefined for anything unclassified,
+		// which records the gap exactly as before rather than inventing a kind from the prose.
+		writeGapMarker(resultsDir, providerName, suiteName, "failed", reason, gapCauseOf(suiteError));
 		throw suiteError;
 	}
 	console.log(`\nDone: ${suiteName} on ${providerName}`);

--- a/packages/harness/src/lib/collect.ts
+++ b/packages/harness/src/lib/collect.ts
@@ -9,7 +9,7 @@ import { mkdirSync, readdirSync, writeFileSync } from "node:fs";
 import { cp, mkdir, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join, resolve } from "node:path";
-import type { GapOutcome } from "@sandbox-benchmarks/schema";
+import type { GapCause, GapOutcome } from "@sandbox-benchmarks/schema";
 import {
 	harnessGapMarkerJson,
 	isGapMarkerFile,
@@ -220,10 +220,13 @@ export function writeGapMarker(
 	suite: string,
 	outcome: GapOutcome,
 	reason: string,
+	// The structured classification, when the caller has one. A marker written without it is not
+	// downgraded — `reason` still says what happened — but nothing downstream will guess a kind for it.
+	cause?: GapCause,
 ): void {
 	mkdirSync(resultsDir, { recursive: true });
 	writeFileSync(
 		join(resultsDir, sandboxGapMarkerFile(provider, suite, outcome)),
-		harnessGapMarkerJson(provider, suite, outcome, reason),
+		harnessGapMarkerJson(provider, suite, outcome, reason, cause),
 	);
 }

--- a/packages/harness/src/lib/execute.ts
+++ b/packages/harness/src/lib/execute.ts
@@ -182,7 +182,10 @@ export async function withTimeout<T>(
  * for the same reason.
  */
 function stepTimeout(label: string, timeoutMs: number): GapError {
-	const timeoutSeconds = Math.round(timeoutMs / 1000);
+	// Floored at 1: every real step budget is minute-scale, but `gapCauseSchema` requires
+	// `timeoutSeconds > 0`, and a sub-500ms budget would round to 0 and make the cause unparseable —
+	// turning a timed-out step into a Run that cannot be normalized at all.
+	const timeoutSeconds = Math.max(1, Math.round(timeoutMs / 1000));
 	return new GapError(`Step "${label}" timed out after ${timeoutSeconds}s`, {
 		kind: "step-timeout",
 		step: label,

--- a/packages/harness/src/lib/execute.ts
+++ b/packages/harness/src/lib/execute.ts
@@ -24,6 +24,7 @@
 
 import { randomUUID } from "node:crypto";
 import type { ProviderTransport } from "@sandbox-benchmarks/schema";
+import { GapError } from "./gap-cause.ts";
 
 export const MIN = 60_000;
 
@@ -149,18 +150,44 @@ function isUnsupportedFilesystem(err: unknown): boolean {
 }
 
 /** Race a promise against a timeout, clearing the timer either way. */
-export async function withTimeout<T>(promise: Promise<T>, ms: number, message: string): Promise<T> {
+export async function withTimeout<T>(
+	promise: Promise<T>,
+	ms: number,
+	// The message, or a factory for the error to reject with when the caller wants it classified. A
+	// factory rather than message+cause so the wording and its classification are built together and
+	// cannot describe different facts (see {@link stepTimeout}).
+	message: string | (() => Error),
+): Promise<T> {
 	let timer: ReturnType<typeof setTimeout> | undefined;
 	try {
 		return await Promise.race([
 			promise,
 			new Promise<never>((_, reject) => {
-				timer = setTimeout(() => reject(new Error(message)), ms);
+				timer = setTimeout(() => {
+					reject(typeof message === "string" ? new Error(message) : message());
+				}, ms);
 			}),
 		]);
 	} finally {
 		if (timer) clearTimeout(timer);
 	}
+}
+
+/**
+ * The step-timeout failure, worded and classified from one input.
+ *
+ * Both the synchronous and the detached step paths can time out, and each used to build the sentence and
+ * the cause itself — four copies of the same seconds rounding, and two chances for the prose and the
+ * data to disagree. This mirrors the `shortfallReason`/`shortfallCause` pairing the results package uses
+ * for the same reason.
+ */
+function stepTimeout(label: string, timeoutMs: number): GapError {
+	const timeoutSeconds = Math.round(timeoutMs / 1000);
+	return new GapError(`Step "${label}" timed out after ${timeoutSeconds}s`, {
+		kind: "step-timeout",
+		step: label,
+		timeoutSeconds,
+	});
 }
 
 /** Single-quote a script for safe embedding in `bash -c '<script>'`. */
@@ -459,7 +486,7 @@ export class StepRunner {
 			result = await withTimeout(
 				this.sandbox.runCommand(`bash -c ${shellQuote(`${this.preamble}; ${script}`)}`),
 				timeoutMs,
-				`Step "${label}" timed out after ${Math.round(timeoutMs / 1000)}s`,
+				() => stepTimeout(label, timeoutMs),
 			);
 		} finally {
 			stopHeartbeat();
@@ -528,9 +555,10 @@ export class StepRunner {
 					consecutivePollFailures++;
 					if (consecutivePollFailures >= MAX_CONSECUTIVE_POLL_FAILURES) {
 						const reason = err instanceof Error ? err.message : String(err);
-						throw new Error(
+						throw new GapError(
 							`Step "${label}" lost its sandbox: ${consecutivePollFailures} consecutive detached ` +
 								`polls failed (last: ${reason}) — the sandbox stopped responding, not a quiet long step`,
+							{ kind: "sandbox-lost", step: label, consecutivePollFailures },
 						);
 					}
 				}
@@ -567,7 +595,7 @@ export class StepRunner {
 					} else if (tail) {
 						console.log(`--- last output from "${label}" before timeout ---\n${tail}`);
 					}
-					throw new Error(`Step "${label}" timed out after ${Math.round(timeoutMs / 1000)}s`);
+					throw stepTimeout(label, timeoutMs);
 				}
 				await this.sleep(pollDelayMs);
 				pollDelayMs = Math.min(pollDelayMs * POLL_BACKOFF, POLL_CAP_MS);
@@ -745,7 +773,11 @@ export class StepRunner {
 				const tail = result.stderr || result.stdout;
 				if (tail) process.stderr.write(tail.endsWith("\n") ? tail : `${tail}\n`);
 			}
-			throw new Error(`Step "${label}" failed with exit code ${result.exitCode}`);
+			throw new GapError(`Step "${label}" failed with exit code ${result.exitCode}`, {
+				kind: "step-failed",
+				step: label,
+				exitCode: result.exitCode,
+			});
 		}
 		return result;
 	}

--- a/packages/harness/src/lib/execute.ts
+++ b/packages/harness/src/lib/execute.ts
@@ -183,7 +183,7 @@ export async function withTimeout<T>(
  */
 function stepTimeout(label: string, timeoutMs: number): GapError {
 	// Floored at 1: every real step budget is minute-scale, but `gapCauseSchema` requires
-	// `timeoutSeconds > 0`, and a sub-500ms budget would round to 0 and make the cause unparseable —
+	// `timeoutSeconds > 0`, and a sub-500ms budget would round to 0 — a cause the schema refuses,
 	// turning a timed-out step into a Run that cannot be normalized at all.
 	const timeoutSeconds = Math.max(1, Math.round(timeoutMs / 1000));
 	return new GapError(`Step "${label}" timed out after ${timeoutSeconds}s`, {

--- a/packages/harness/src/lib/gap-cause.ts
+++ b/packages/harness/src/lib/gap-cause.ts
@@ -1,0 +1,37 @@
+/**
+ * Carry a {@link GapCause} on the Error that caused it, so the classification survives the throw.
+ *
+ * The harness knows exactly what went wrong at the point it throws — which step, which budget, which
+ * exit code — but that knowledge reaches the dataset through a marker written several frames up, and an
+ * Error carries nothing but a message. Downstream then re-derived the fact by matching prose. Making the
+ * cause part of the error's TYPE lets the marker writer record what the thrower actually knew.
+ *
+ * A class rather than a side-channel property on arbitrary errors: every failure classified here is one
+ * the harness constructs itself ({@link StepRunner}'s timeout, lost-sandbox and non-zero-exit paths), so
+ * there is no pass-through case to accommodate. An error arriving from a provider SDK is simply
+ * unclassified, and {@link gapCauseOf} says so — which is the honest answer rather than a label invented
+ * for it.
+ */
+import type { GapCause } from "@sandbox-benchmarks/schema";
+
+/** An error the harness raised with its failure already classified. */
+export class GapError extends Error {
+	readonly gapCause: GapCause;
+
+	constructor(message: string, gapCause: GapCause) {
+		super(message);
+		this.name = "GapError";
+		this.gapCause = gapCause;
+	}
+}
+
+/**
+ * The classification an error was thrown with, or undefined when it carries none.
+ *
+ * Undefined is the honest answer for an unclassified failure and must stay one: a caller that cannot
+ * read a cause records a gap without one, rather than guessing a kind from the message. Guessing would
+ * reintroduce prose-parsing at the exact boundary this exists to remove it from.
+ */
+export function gapCauseOf(error: unknown): GapCause | undefined {
+	return error instanceof GapError ? error.gapCause : undefined;
+}

--- a/packages/harness/src/lib/lifecycle.ts
+++ b/packages/harness/src/lib/lifecycle.ts
@@ -18,8 +18,15 @@
  * `finally` and never throws out of it. Repeat the cycle for a cold-start distribution — that is what
  * {@link benchmarkLifecycle} (in index.ts) does.
  */
-import type { Aggregates, HarnessMetricId, RawRun, ResultGap } from "@sandbox-benchmarks/schema";
+import type {
+	Aggregates,
+	GapCause,
+	HarnessMetricId,
+	RawRun,
+	ResultGap,
+} from "@sandbox-benchmarks/schema";
 import { aggregate, HARNESS_METRIC_IDS } from "@sandbox-benchmarks/schema";
+import { gapCauseOf } from "./gap-cause.ts";
 import { now as defaultNow, time } from "./internal.ts";
 import { neverReadyReason, waitUntilReady } from "./readiness.ts";
 
@@ -45,6 +52,21 @@ const PAYLOAD_DISABLED = "64KiB payload exec disabled for this run";
 const NO_LIST_OP = "provider SDK exposes no sandbox list operation";
 const SNAPSHOT_DISABLED = "snapshot measurement disabled for this run";
 const NO_SNAPSHOT_OP = "provider SDK exposes no snapshot operation";
+/**
+ * A measurement this RUN turned off. Deliberately not `unsupported-operation`: the provider can do it,
+ * we chose not to time it, and publishing a config toggle as a missing capability would be a claim
+ * about the provider we have no evidence for.
+ */
+const DISABLED_CAUSE = { kind: "measurement-disabled" } as const satisfies GapCause;
+/** The provider's SDK exposes no such call — a capability statement, unlike {@link DISABLED_CAUSE}. */
+const NO_LIST_CAUSE = {
+	kind: "unsupported-operation",
+	detail: NO_LIST_OP,
+} as const satisfies GapCause;
+const NO_SNAPSHOT_CAUSE = {
+	kind: "unsupported-operation",
+	detail: NO_SNAPSHOT_OP,
+} as const satisfies GapCause;
 /** Writes exactly 64KiB (65536 bytes) to stdout — exec overhead including output streaming. Uses `tr`
  *  rather than `base64` so the stream is exactly 64KiB, matching the metric's name (base64 expands the
  *  input ~33%, overstating the payload). */
@@ -156,18 +178,30 @@ export async function measureLifecycle(
 	// about reliability. `fail` is an outage: the call was made and it threw. Recording a throw as a skip
 	// (as this did while both shared one helper) publishes a provider's control-plane failure as though
 	// we had chosen not to measure it, which is precisely backwards.
-	const skip = (operation: HarnessMetricId, reason: string): void => {
-		gaps.push({ scope: "operation", id: operation, outcome: "skipped", reason });
+	const skip = (operation: HarnessMetricId, reason: string, cause?: GapCause): void => {
+		gaps.push({
+			scope: "operation",
+			id: operation,
+			outcome: "skipped",
+			reason,
+			...(cause ? { cause } : {}),
+		});
 	};
-	const fail = (operation: HarnessMetricId, reason: string): void => {
-		gaps.push({ scope: "operation", id: operation, outcome: "failed", reason });
+	const fail = (operation: HarnessMetricId, reason: string, cause?: GapCause): void => {
+		gaps.push({
+			scope: "operation",
+			id: operation,
+			outcome: "failed",
+			reason,
+			...(cause ? { cause } : {}),
+		});
 	};
 	// A timed step that records a Sample on success and a FAILED gap (never a throw) on error.
 	const step = async (operation: HarnessMetricId, run: () => Promise<unknown>): Promise<void> => {
 		try {
 			sample(operation, (await time(run)).ms);
 		} catch (err) {
-			fail(operation, reasonOf(err));
+			fail(operation, reasonOf(err), gapCauseOf(err));
 		}
 	};
 
@@ -219,11 +253,12 @@ export async function measureLifecycle(
 			// no probe ran here and N copies of one fact is noise, not fidelity.
 			fail(HARNESS_METRIC_IDS.controlPlaneInfo, reason);
 			if (wantPayload) fail(HARNESS_METRIC_IDS.execPayload64k, reason);
-			else skip(HARNESS_METRIC_IDS.execPayload64k, PAYLOAD_DISABLED);
+			else skip(HARNESS_METRIC_IDS.execPayload64k, PAYLOAD_DISABLED, DISABLED_CAUSE);
 			if (compute.sandbox.list) fail(HARNESS_METRIC_IDS.controlPlaneList, reason);
-			else skip(HARNESS_METRIC_IDS.controlPlaneList, NO_LIST_OP);
-			if (!wantSnapshot) skip(HARNESS_METRIC_IDS.snapshot, SNAPSHOT_DISABLED);
-			else if (!compute.snapshot) skip(HARNESS_METRIC_IDS.snapshot, NO_SNAPSHOT_OP);
+			else skip(HARNESS_METRIC_IDS.controlPlaneList, NO_LIST_OP, NO_LIST_CAUSE);
+			if (!wantSnapshot) skip(HARNESS_METRIC_IDS.snapshot, SNAPSHOT_DISABLED, DISABLED_CAUSE);
+			else if (!compute.snapshot)
+				skip(HARNESS_METRIC_IDS.snapshot, NO_SNAPSHOT_OP, NO_SNAPSHOT_CAUSE);
 			else fail(HARNESS_METRIC_IDS.snapshot, reason);
 			return { samples, gaps };
 		} else {
@@ -238,7 +273,7 @@ export async function measureLifecycle(
 		if (wantPayload) {
 			await step(HARNESS_METRIC_IDS.execPayload64k, () => sandbox.runCommand(PAYLOAD_CMD));
 		} else {
-			skip(HARNESS_METRIC_IDS.execPayload64k, PAYLOAD_DISABLED);
+			skip(HARNESS_METRIC_IDS.execPayload64k, PAYLOAD_DISABLED, DISABLED_CAUSE);
 		}
 
 		// Control-plane read: getInfo, sampled within this one (cheap) sandbox to build a distribution
@@ -257,16 +292,16 @@ export async function measureLifecycle(
 				await step(HARNESS_METRIC_IDS.controlPlaneList, () => listSandboxes());
 			}
 		} else {
-			skip(HARNESS_METRIC_IDS.controlPlaneList, NO_LIST_OP);
+			skip(HARNESS_METRIC_IDS.controlPlaneList, NO_LIST_OP, NO_LIST_CAUSE);
 		}
 
 		// Snapshot: when requested and the SDK exposes a snapshot manager. Best-effort delete afterwards
 		// so a measured snapshot never leaks into the account.
 		const snapshots = compute.snapshot;
 		if (!wantSnapshot) {
-			skip(HARNESS_METRIC_IDS.snapshot, SNAPSHOT_DISABLED);
+			skip(HARNESS_METRIC_IDS.snapshot, SNAPSHOT_DISABLED, DISABLED_CAUSE);
 		} else if (!snapshots) {
-			skip(HARNESS_METRIC_IDS.snapshot, NO_SNAPSHOT_OP);
+			skip(HARNESS_METRIC_IDS.snapshot, NO_SNAPSHOT_OP, NO_SNAPSHOT_CAUSE);
 		} else {
 			try {
 				const snap = await time(() => snapshots.create(sandbox.sandboxId));

--- a/packages/results/src/index.test.ts
+++ b/packages/results/src/index.test.ts
@@ -16,7 +16,7 @@ describe("normalizeResultsTree", () => {
 	});
 
 	it("validates as a Run and includes every known provider", () => {
-		expect(run.schemaVersion).toBe("3");
+		expect(run.schemaVersion).toBe("4");
 		expect(run.providers.map((provider) => provider.providerId).sort()).toEqual(
 			PROVIDERS.map((provider) => provider.id).sort(),
 		);

--- a/packages/results/src/index.ts
+++ b/packages/results/src/index.ts
@@ -30,6 +30,14 @@ export {
 } from "./lib/leaderboard.ts";
 export { type NormalizeInput, normalizeResultsTree } from "./lib/normalize-tree.ts";
 export {
+	buildObservedMixtures,
+	foldHostMetadata,
+	type HostMetadataRecordInput,
+	type ObservedMixtureIds,
+	observedMixtureIds,
+	representativeSpecs,
+} from "./lib/observed-mixtures.ts";
+export {
 	type CompareRunsOptions,
 	compareRuns,
 	DEFAULT_THRESHOLD,

--- a/packages/results/src/lib/aggregate.test.ts
+++ b/packages/results/src/lib/aggregate.test.ts
@@ -1,11 +1,12 @@
 import { describe, expect, it } from "bun:test";
-import type { MetricResult, ProviderRun, Run } from "@sandbox-benchmarks/schema";
+import type { GapCause, MetricResult, ProviderRun, Run } from "@sandbox-benchmarks/schema";
 import {
 	aggregate,
 	ECONOMICS_METRIC_IDS,
 	getProvider,
 	HARNESS_METRIC_IDS,
 	hourlyCostAtTargetSpec,
+	TARGET_SPEC,
 } from "@sandbox-benchmarks/schema";
 import { aggregateRuns } from "./aggregate.ts";
 
@@ -80,8 +81,8 @@ describe("aggregateRuns", () => {
 		]);
 		expect(node?.samples).toEqual([10, 11, 20, 21]);
 		expect(node?.aggregates.n).toBe(4);
-		// The merged Run is v3 (replicate-aware); its Metric carries no single replicateIndex.
-		expect(merged.schemaVersion).toBe("3");
+		// The merged Run is v4 (replicate-aware, mixture-aware, attributed, self-describing).
+		expect(merged.schemaVersion).toBe("4");
 	});
 
 	it("keeps a single-replicate metric verbatim — no replicates field at R = 1", () => {
@@ -172,7 +173,9 @@ describe("aggregateRuns", () => {
 		expect(merged.generatedAt).toBe("2026-06-02T00:00:00.000Z");
 	});
 
-	it("discloses the conflicting host CPUs when a provider's shards saw differing models", () => {
+	it("discloses differing host CPUs as distinct mixtures, naming each and how many saw it", () => {
+		// Replaces the deleted `hostCpuModels` string array: it named the distinct models but not how many
+		// sandboxes each covered, and nothing ever read it — the mixtures answer both.
 		const a = shard([
 			{
 				...provider("daytona-vm", [metric("node_web_tooling_runs_per_s", [10])]),
@@ -185,26 +188,264 @@ describe("aggregateRuns", () => {
 				observedSpecs: { cpuModel: "AMD EPYC 9R45", cpuMicroarch: "Zen 5 (Turin)" },
 			},
 		]);
-		const merged = aggregateRuns([a, b]);
-		const daytona = merged.providers.find((p) => p.providerId === "daytona-vm");
-		// Sorted, distinct — names both machines rather than a bare "heterogeneous" flag.
-		expect(daytona?.observedSpecs.hostCpuModels).toEqual(["AMD EPYC 9R14", "AMD EPYC 9R45"]);
+		const daytona = aggregateRuns([a, b]).providers.find((p) => p.providerId === "daytona-vm");
+		// Sorted by name for the assertion only: both counts are 1, so the map's own order is the id
+		// tie-break, which is deliberately not alphabetical.
+		expect(
+			Object.values(daytona?.observedMixtures?.hostHardware ?? {})
+				.map((m) => [m.specs.cpuModel, m.count] as const)
+				.sort(([x], [y]) => String(x).localeCompare(String(y))),
+		).toEqual([
+			["AMD EPYC 9R14", 1],
+			["AMD EPYC 9R45", 1],
+		]);
 	});
 
-	it("does not disclose host CPUs when every shard saw the same host CPU", () => {
-		const same = { cpuModel: "AMD EPYC 9R45", cpuMicroarch: "Zen 5 (Turin)" };
-		const a = shard([
-			{
-				...provider("daytona-vm", [metric("node_web_tooling_runs_per_s", [10])]),
-				observedSpecs: same,
-			},
+	it("counts the distinct host-hardware and host-network mixtures its sandboxes reported", () => {
+		const genoa = {
+			cpuModel: "AMD EPYC 9R14",
+			cpuMicroarch: "Zen 4 (Genoa)",
+			vcpus: 2,
+			memoryGb: 8,
+		};
+		const turin = {
+			cpuModel: "AMD EPYC 9R45",
+			cpuMicroarch: "Zen 5 (Turin)",
+			vcpus: 2,
+			memoryGb: 8,
+		};
+		const ashburn = { egressAsn: "AS14618", egressOrg: "Amazon", city: "Ashburn", country: "US" };
+		const frankfurt = {
+			egressAsn: "AS16509",
+			egressOrg: "Amazon",
+			city: "Frankfurt",
+			country: "DE",
+		};
+		// Three sandboxes on Genoa/Ashburn, one on Turin, one of the Genoa three in Frankfurt. Each carries
+		// its OWN publicIp — a per-sandbox identity field that must not fragment the network mixtures.
+		const sandbox = (specs: Record<string, unknown>, index: number, ip: string) =>
+			shard(
+				[
+					{
+						...provider("daytona-vm", [metric("pybench_milliseconds", [900 + index])]),
+						observedSpecs: { ...specs, publicIp: ip },
+					},
+				],
+				"2026-06-01T00:00:00.000Z",
+				index,
+			);
+		const merged = aggregateRuns([
+			sandbox({ ...genoa, ...ashburn }, 0, "203.0.113.1"),
+			sandbox({ ...genoa, ...ashburn }, 1, "203.0.113.2"),
+			sandbox({ ...turin, ...ashburn }, 2, "203.0.113.3"),
+			sandbox({ ...genoa, ...frankfurt }, 3, "198.51.100.4"),
 		]);
-		const b = shard([
-			{ ...provider("daytona-vm", [metric("pybench_milliseconds", [900])]), observedSpecs: same },
-		]);
-		const merged = aggregateRuns([a, b]);
+		const mixtures = merged.providers.find((p) => p.providerId === "daytona-vm")?.observedMixtures;
+
+		// The denominator, and the two counts — no inference required to read the heterogeneity off this.
+		expect(mixtures?.sandboxes).toBe(4);
+		const hardware = Object.values(mixtures?.hostHardware ?? {});
+		const network = Object.values(mixtures?.hostNetwork ?? {});
+		expect(hardware.map((m) => m.count)).toEqual([3, 1]); // most-common mixture first
+		expect(network.map((m) => m.count)).toEqual([3, 1]);
+		expect(hardware[0]?.specs).toEqual(genoa);
+		expect(hardware[1]?.specs).toEqual(turin);
+		expect(network[1]?.specs).toEqual(frankfurt);
+		// Four distinct publicIps did NOT mint four network mixtures: identity fields are excluded from
+		// both hashes, without which every count would be 1 and the disclosure would carry no signal. The
+		// category types now make an identity field on a mixture unrepresentable, so the counts above are
+		// the assertion — four sandboxes collapsing to 3 + 1 is only possible if the ip was excluded.
+		expect(hardware.length + network.length).toBe(4);
+	});
+
+	it("keys mixtures by a stable hash that ignores shard arrival order", () => {
+		const specs = { cpuModel: "AMD EPYC 9R45", egressAsn: "AS16509" };
+		const sandbox = (index: number) =>
+			shard(
+				[
+					{
+						...provider("daytona-vm", [metric("pybench_milliseconds", [900 + index])]),
+						observedSpecs: specs,
+					},
+				],
+				"2026-06-01T00:00:00.000Z",
+				index,
+			);
+		const forward = aggregateRuns([sandbox(0), sandbox(1)]);
+		const reversed = aggregateRuns([sandbox(1), sandbox(0)]);
+		const of = (run: typeof forward) =>
+			run.providers.find((p) => p.providerId === "daytona-vm")?.observedMixtures;
+		// Byte-identical, so the committed dataset diff reflects real change rather than merge order — and
+		// an id can be compared across runs to ask "same machine shape as last week?".
+		expect(JSON.stringify(of(forward))).toBe(JSON.stringify(of(reversed)));
+		expect(Object.keys(of(forward)?.hostHardware ?? {})).toHaveLength(1);
+	});
+
+	it("omits mixtures for a provider that reported nothing, and ignores its placeholder slices", () => {
+		// The normalizer emits a zero-evidence ProviderRun for every registered provider in EVERY shard, so
+		// a naive per-slice count would credit a 2-sandbox provider with one blind sandbox per shard in the
+		// whole run — and would hand the never-dispatched provider a mixture block claiming sandboxes it
+		// never had.
+		const measured = (index: number) =>
+			shard(
+				[
+					{
+						...provider("daytona-vm", [metric("pybench_milliseconds", [900 + index])]),
+						observedSpecs: { cpuModel: "AMD EPYC 9R45" },
+					},
+					provider("daytona-container", []),
+				],
+				"2026-06-01T00:00:00.000Z",
+				index,
+			);
+		const merged = aggregateRuns([measured(0), measured(1)]);
+		expect(
+			merged.providers.find((p) => p.providerId === "daytona-vm")?.observedMixtures?.sandboxes,
+		).toBe(2);
+		expect(
+			merged.providers.find((p) => p.providerId === "daytona-container")?.observedMixtures,
+		).toBeUndefined();
+	});
+
+	it("names the machine behind each replicate, so a sample cluster resolves to its host", () => {
+		const genoa = { cpuModel: "AMD EPYC 9R14", cpuMicroarch: "Zen 4 (Genoa)" };
+		const xeon = { cpuModel: "Intel Xeon Platinum 8358", cpuMicroarch: "Ice Lake" };
+		const sandbox = (specs: Record<string, unknown>, index: number) =>
+			shard(
+				[
+					{
+						...provider("daytona-vm", [metric("pybench_milliseconds", [900 + index])]),
+						observedSpecs: specs,
+					},
+				],
+				"2026-06-01T00:00:00.000Z",
+				index,
+			);
+		const merged = aggregateRuns([sandbox(genoa, 0), sandbox(xeon, 1), sandbox(genoa, 2)]);
 		const daytona = merged.providers.find((p) => p.providerId === "daytona-vm");
-		expect(daytona?.observedSpecs.hostCpuModels).toBeUndefined();
+		const replicates =
+			daytona?.metrics.find((m) => m.metricId === "pybench_milliseconds")?.replicates ?? [];
+		expect(replicates).toHaveLength(3);
+
+		// Every id resolves into the provider's own mixtures — the join the schema narrow guarantees.
+		const hardware = daytona?.observedMixtures?.hostHardware ?? {};
+		for (const replicate of replicates) {
+			expect(replicate.hostHardwareId).toBeDefined();
+			expect(hardware[replicate.hostHardwareId as string]).toBeDefined();
+		}
+		// r0 and r2 ran on one machine, r1 on the other: the between-machine axis is now decodable rather
+		// than an anonymous set of clusters.
+		expect(replicates[0]?.hostHardwareId).toBe(replicates[2]?.hostHardwareId as string);
+		expect(replicates[1]?.hostHardwareId).not.toBe(replicates[0]?.hostHardwareId as string);
+		expect(hardware[replicates[1]?.hostHardwareId as string]?.specs.cpuModel).toBe(
+			"Intel Xeon Platinum 8358",
+		);
+		// No network probe ran, so no network id is invented for a mixture that does not exist.
+		for (const replicate of replicates) expect(replicate.hostNetworkId).toBeUndefined();
+	});
+
+	it("attributes each suite's replicate to its OWN sandbox, not another suite's same-index cell", () => {
+		// A replicate index is scoped to its (suite, provider) cell, so (system, r0) and (cpu-node, r0) are
+		// different sandboxes. A provider-wide index→machine map would credit one suite's samples to the
+		// other suite's host — a wrong attribution that reads exactly like a right one.
+		const genoa = { cpuModel: "AMD EPYC 9R14" };
+		const xeon = { cpuModel: "Intel Xeon Platinum 8358" };
+		const cell = (metricId: string, specs: Record<string, unknown>, index: number) =>
+			shard(
+				[
+					{
+						...provider("daytona-vm", [metric(metricId, [900 + index])]),
+						observedSpecs: specs,
+					},
+				],
+				"2026-06-01T00:00:00.000Z",
+				index,
+			);
+		const merged = aggregateRuns([
+			cell("pybench_milliseconds", genoa, 0),
+			cell("pybench_milliseconds", genoa, 1),
+			cell("node_web_tooling_runs_per_s", xeon, 0),
+			cell("node_web_tooling_runs_per_s", xeon, 1),
+		]);
+		const daytona = merged.providers.find((p) => p.providerId === "daytona-vm");
+		const hardware = daytona?.observedMixtures?.hostHardware ?? {};
+		const cpuOf = (metricId: string, index: number) => {
+			const id = daytona?.metrics
+				.find((m) => m.metricId === metricId)
+				?.replicates?.find((r) => r.index === index)?.hostHardwareId;
+			return hardware[id as string]?.specs.cpuModel;
+		};
+		expect(cpuOf("pybench_milliseconds", 0)).toBe("AMD EPYC 9R14");
+		expect(cpuOf("node_web_tooling_runs_per_s", 0)).toBe("Intel Xeon Platinum 8358");
+	});
+
+	it("seats the representative observedSpecs on the dominant machine, not the first shard's", () => {
+		// The failure this replaces: first-wins resolves to shard arrival order, so run 30510718771
+		// published modal-vm with a headline cpuModel of one machine out of ten its sandboxes used.
+		const rare = { cpuModel: "AMD EPYC 9J45 128-Core Processor" };
+		const common = { cpuModel: "Intel Xeon Platinum 8358" };
+		const sandbox = (specs: Record<string, unknown>, index: number) =>
+			shard(
+				[
+					{
+						...provider("daytona-vm", [metric("pybench_milliseconds", [900 + index])]),
+						observedSpecs: specs,
+					},
+				],
+				"2026-06-01T00:00:00.000Z",
+				index,
+			);
+		// The rare machine arrives FIRST — under first-wins it would have become the headline.
+		const merged = aggregateRuns([
+			sandbox(rare, 0),
+			sandbox(common, 1),
+			sandbox(common, 2),
+			sandbox(common, 3),
+		]);
+		const daytona = merged.providers.find((p) => p.providerId === "daytona-vm");
+		expect(daytona?.observedSpecs.cpuModel).toBe("Intel Xeon Platinum 8358");
+		// Both machines stay fully disclosed; only the single-value summary moved.
+		expect(Object.keys(daytona?.observedMixtures?.hostHardware ?? {})).toHaveLength(2);
+	});
+
+	it("counts a sandbox that only reported a gap — a failed sandbox is still a sandbox report", () => {
+		// A create failure or a disk skip produces no metric and no spec reading, but the provider was
+		// asked for that sandbox. Counting it keeps `sandboxes` the true denominator, so a category whose
+		// counts sum to less than it is visibly a partial disclosure rather than a complete one.
+		const withGap = shard(
+			[
+				{
+					...provider("daytona-vm", []),
+					gaps: [
+						{
+							scope: "suite" as const,
+							id: "realworld-mastra",
+							outcome: "failed" as const,
+							reason: "Failed to create sandbox",
+						},
+					],
+				},
+			],
+			"2026-06-01T00:00:00.000Z",
+			0,
+		);
+		const measured = shard(
+			[
+				{
+					...provider("daytona-vm", [metric("pybench_milliseconds", [900])]),
+					observedSpecs: { cpuModel: "AMD EPYC 9R45" },
+				},
+			],
+			"2026-06-01T00:00:00.000Z",
+			1,
+		);
+		const mixtures = aggregateRuns([withGap, measured]).providers.find(
+			(p) => p.providerId === "daytona-vm",
+		)?.observedMixtures;
+		expect(mixtures?.sandboxes).toBe(2);
+		// Two sandboxes, but only one disclosed hardware — the shortfall is readable from the counts.
+		expect(Object.values(mixtures?.hostHardware ?? {}).map((m) => m.count)).toEqual([1]);
+		expect(mixtures?.hostNetwork).toEqual({});
 	});
 
 	it("unions rich host metadata across shards and removes byte-identical duplicates", () => {
@@ -276,7 +517,7 @@ describe("aggregateRuns", () => {
 		).toBeUndefined();
 
 		const matchOnly = provider("daytona-vm", [metric("pybench_milliseconds", [900])]);
-		matchOnly.observedSpecs = { vcpus: 2, memoryGb: 8 };
+		matchOnly.observedSpecs = { vcpus: TARGET_SPEC.vcpus, memoryGb: TARGET_SPEC.memoryGb };
 		matchOnly.specMatched = true;
 		expect(
 			aggregateRuns([noProbe, shard([matchOnly])]).providers.find(
@@ -330,5 +571,69 @@ describe("aggregateRuns suite-shortfall gap folding", () => {
 		);
 		const daytona = aggregateRuns([r0, r1]).providers.find((p) => p.providerId === "daytona-vm");
 		expect(daytona?.gaps).toEqual([shortfall(reason), shortfall(other)]);
+	});
+});
+
+describe("aggregateRuns gap-cause folding", () => {
+	const gap = (cause?: GapCause) => ({
+		scope: "suite" as const,
+		id: "realworld-mastra" as const,
+		outcome: "skipped" as const,
+		reason: "Insufficient disk: 20.0 GiB free, suite needs 30 GiB",
+		...(cause ? { cause } : {}),
+	});
+	const withGap = (cause: GapCause | undefined, index: number) =>
+		shard(
+			[{ ...provider("e2b", [metric("pybench_milliseconds", [900 + index])]), gaps: [gap(cause)] }],
+			"2026-06-01T00:00:00.000Z",
+			index,
+		);
+	const disk = { kind: "disk-shortfall", freeGb: 20, requiredGb: 30 } as const satisfies GapCause;
+
+	it("keeps the classified gap when shards straddle a producer upgrade, in either order", () => {
+		// `cause` is not part of the dedupe key, so plain first-wins would let shard arrival order decide
+		// whether the published gap carries its classification.
+		for (const order of [
+			[withGap(undefined, 0), withGap(disk, 1)],
+			[withGap(disk, 0), withGap(undefined, 1)],
+		]) {
+			const gaps = aggregateRuns(order).providers.find((p) => p.providerId === "e2b")?.gaps ?? [];
+			expect(gaps).toHaveLength(1);
+			expect(gaps[0]?.cause).toEqual(disk);
+		}
+	});
+});
+
+describe("aggregateRuns derived-metric marking", () => {
+	it("marks the economics rows it re-derives, so the document says what is computed", () => {
+		// The guarantee the schema deliberately does NOT enforce (a published Run's validity must not track
+		// the live catalog) is pinned here instead, on the producer that owns catalog knowledge.
+		const merged = aggregateRuns([
+			shard([provider("daytona-vm", [metric(HARNESS_METRIC_IDS.spawn, [1000])])]),
+		]);
+		const metrics = merged.providers.find((p) => p.providerId === "daytona-vm")?.metrics ?? [];
+		const economics = metrics.filter((m) => m.metricId.startsWith("usd_"));
+		expect(economics.length).toBeGreaterThan(0);
+		for (const row of economics) expect(row.derived).toBe(true);
+		// And measurements stay unmarked — the marker means "computed", not "present".
+		expect(metrics.find((m) => m.metricId === HARNESS_METRIC_IDS.spawn)?.derived).toBeUndefined();
+	});
+
+	it("drops a shard's stale economics row even when the catalog no longer knows the id", () => {
+		// isDerivedMetric prefers the document's marker: a marked row is never re-admitted as a measurement
+		// and pooled into a ranking, which a catalog-only test would do for a renamed or retired id.
+		const stale = provider("daytona-vm", [metric("node_web_tooling_runs_per_s", [10])]);
+		stale.metrics.push({
+			metricId: "usd_per_retired_thing",
+			samples: [42],
+			aggregates: aggregate([42]),
+			derived: true,
+		});
+		const merged = aggregateRuns([shard([stale])]);
+		const ids =
+			merged.providers.find((p) => p.providerId === "daytona-vm")?.metrics.map((m) => m.metricId) ??
+			[];
+		expect(ids).not.toContain("usd_per_retired_thing");
+		expect(ids).toContain("node_web_tooling_runs_per_s");
 	});
 });

--- a/packages/results/src/lib/aggregate.test.ts
+++ b/packages/results/src/lib/aggregate.test.ts
@@ -637,3 +637,54 @@ describe("aggregateRuns derived-metric marking", () => {
 		expect(ids).toContain("node_web_tooling_runs_per_s");
 	});
 });
+
+describe("aggregateRuns gap-cause determinism", () => {
+	// One reason, two causes. Reachable because a reason can be lossier than its cause: the disk-shortfall
+	// sentence rounds free space with toFixed(1), so 20.04 and 20.049 GiB render one identical sentence.
+	const reason = "Insufficient disk: 20.0 GiB free, suite needs 30 GiB";
+	const cause = (freeGb: number) =>
+		({ kind: "disk-shortfall", freeGb, requiredGb: 30 }) as const satisfies GapCause;
+	const withCause = (freeGb: number | undefined, index: number) =>
+		shard(
+			[
+				{
+					...provider("e2b", [metric("pybench_milliseconds", [900 + index])]),
+					gaps: [
+						{
+							scope: "suite" as const,
+							id: "realworld-mastra" as const,
+							outcome: "skipped" as const,
+							reason,
+							...(freeGb === undefined ? {} : { cause: cause(freeGb) }),
+						},
+					],
+				},
+			],
+			"2026-06-01T00:00:00.000Z",
+			index,
+		);
+
+	it("resolves two different classified causes the same way in either arrival order", () => {
+		// Keeping whichever arrived first would make the published freeGb depend on shard order — churn in
+		// a committed dataset that a schema bump re-aggregates wholesale.
+		const causeOf = (order: ReturnType<typeof withCause>[]) => {
+			const gaps = aggregateRuns(order).providers.find((p) => p.providerId === "e2b")?.gaps ?? [];
+			expect(gaps).toHaveLength(1);
+			return gaps[0]?.cause;
+		};
+		const forward = causeOf([withCause(20.04, 0), withCause(20.049, 1)]);
+		const reversed = causeOf([withCause(20.049, 0), withCause(20.04, 1)]);
+		expect(forward).toEqual(reversed);
+	});
+
+	it("still upgrades an unclassified gap when another shard classified it, in either order", () => {
+		for (const order of [
+			[withCause(undefined, 0), withCause(20.04, 1)],
+			[withCause(20.04, 0), withCause(undefined, 1)],
+		]) {
+			const gaps = aggregateRuns(order).providers.find((p) => p.providerId === "e2b")?.gaps ?? [];
+			expect(gaps).toHaveLength(1);
+			expect(gaps[0]?.cause).toEqual(cause(20.04));
+		}
+	});
+});

--- a/packages/results/src/lib/aggregate.test.ts
+++ b/packages/results/src/lib/aggregate.test.ts
@@ -677,6 +677,39 @@ describe("aggregateRuns gap-cause determinism", () => {
 		expect(forward).toEqual(reversed);
 	});
 
+	it("compares causes by content, not by the key order a producer wrote them in", () => {
+		// The tie-break must not be re-decidable by reformatting a cause literal at its construction
+		// site: `{ requiredGb, freeGb, kind }` serializes to a different string than `{ kind, freeGb,
+		// requiredGb }` while describing the identical fact.
+		const scrambled = (freeGb: number, index: number) =>
+			shard(
+				[
+					{
+						...provider("e2b", [metric("pybench_milliseconds", [900 + index])]),
+						gaps: [
+							{
+								scope: "suite" as const,
+								id: "realworld-mastra" as const,
+								outcome: "skipped" as const,
+								reason,
+								cause: { requiredGb: 30, freeGb, kind: "disk-shortfall" } as GapCause,
+							},
+						],
+					},
+				],
+				"2026-06-01T00:00:00.000Z",
+				index,
+			);
+		// Same winner as the canonically-keyed pair above: the smaller freeGb, whichever literal it came in.
+		for (const order of [
+			[scrambled(20.04, 0), withCause(20.049, 1)],
+			[withCause(20.049, 0), scrambled(20.04, 1)],
+		]) {
+			const gaps = aggregateRuns(order).providers.find((p) => p.providerId === "e2b")?.gaps ?? [];
+			expect(gaps[0]?.cause).toEqual(cause(20.04));
+		}
+	});
+
 	it("still upgrades an unclassified gap when another shard classified it, in either order", () => {
 		for (const order of [
 			[withCause(undefined, 0), withCause(20.04, 1)],

--- a/packages/results/src/lib/aggregate.ts
+++ b/packages/results/src/lib/aggregate.ts
@@ -17,6 +17,7 @@
  * inconsistent merge fails here rather than reaching a consumer.
  */
 import type {
+	GapCause,
 	MetricReplicate,
 	MetricResult,
 	ObservedSpecs,
@@ -88,6 +89,15 @@ function mergeMetricReplicates(byReplicate: Map<number, ReplicateContribution>):
 		aggregates: aggregate(pooled),
 		replicates,
 	};
+}
+
+/**
+ * Whether `next` should replace `current` as a gap's cause: any classification beats none, and between
+ * two classifications the canonically smaller wins so the choice never depends on shard arrival order.
+ */
+function preferCause(current: GapCause | undefined, next: GapCause): boolean {
+	if (current === undefined) return true;
+	return JSON.stringify(next) < JSON.stringify(current);
 }
 
 /** One replicate's contribution to a metric, with the mixture ids of the sandbox that produced it. */
@@ -162,16 +172,23 @@ function mergeProvider(providerId: string, entries: readonly ReplicateSlice[]): 
 
 		// Gaps keyed by (scope, id, outcome, reason); `outcome` belongs in the key because one shard
 		// skipping a suite on a disk precondition while another attempted it and crashed are two distinct
-		// facts, and folding them would silently drop whichever arrived second. `cause` is NOT in the key —
-		// reason and cause are built from one input — but shards can straddle a producer upgrade, so a
-		// classified gap is merged over an unclassified one instead of letting arrival order decide. Merged
-		// into a NEW object: the gaps belong to the caller's shard Runs and must not be mutated.
+		// facts, and folding them would silently drop whichever arrived second. Merged into a NEW object:
+		// the gaps belong to the caller's shard Runs and must not be mutated.
+		//
+		// `cause` is not in the key, and the merge below is ORDER-INDEPENDENT for the two ways two shards
+		// can disagree about it. A classified cause beats an unclassified one (shards can straddle a
+		// producer upgrade). Two DIFFERENT classified causes under one key are reachable even though
+		// reason and cause are built from one input, because a reason can be lossier than its cause: the
+		// disk-shortfall sentence rounds with `toFixed(1)`, so 20.04 and 20.049 GiB free render one
+		// sentence carrying two `freeGb` values. Keeping whichever arrived first would make the published
+		// number depend on shard order, so the canonically smaller cause wins — arbitrary, but stable
+		// across re-aggregation, which is the property the committed dataset needs.
 		for (const gap of slice.gaps) {
 			const key = [gap.scope, gap.id, gap.outcome, gap.reason].join(NUL);
 			const existing = gapByKey.get(key);
 			if (existing === undefined) {
 				gapByKey.set(key, gap);
-			} else if (existing.cause === undefined && gap.cause !== undefined) {
+			} else if (gap.cause !== undefined && preferCause(existing.cause, gap.cause)) {
 				gapByKey.set(key, { ...existing, cause: gap.cause });
 			}
 		}
@@ -196,13 +213,13 @@ function mergeProvider(providerId: string, entries: readonly ReplicateSlice[]): 
 	// no sandbox report at all (the registry placeholder row), which has no mixture to disclose.
 	const observedMixtures = buildObservedMixtures(sandboxSpecReadings);
 
-	// The representative single-value summary, derived once from the mixtures plus a first-wins backfill
-	// rather than assembled by mutation order. Empty without mixtures, and provably so: `observedMixtures`
-	// is undefined only when NO slice carried participation evidence, and `providerReportedNothing`
-	// includes "no observed-spec reading" — so every excluded slice had empty specs and there is nothing to
-	// back-fill from. That is also why the backfill reads `sandboxSpecReadings` rather than every slice.
+	// The representative single-value summary: the dominant machine and network, derived from the mixtures
+	// alone so it cannot depend on shard arrival order. Empty without mixtures, and provably so —
+	// `observedMixtures` is undefined only when NO slice carried participation evidence, and
+	// `providerReportedNothing` includes "no observed-spec reading", so every excluded slice had empty
+	// specs and there was never anything to summarize.
 	const observedSpecs: ObservedSpecs = observedMixtures
-		? representativeSpecs(sandboxSpecReadings, observedMixtures)
+		? representativeSpecs(observedMixtures)
 		: {};
 
 	// Fold the PER-MACHINE verdicts in too. The two inputs are the same observations at different grains,

--- a/packages/results/src/lib/aggregate.ts
+++ b/packages/results/src/lib/aggregate.ts
@@ -17,7 +17,6 @@
  * inconsistent merge fails here rather than reaching a consumer.
  */
 import type {
-	HostMetadataRecord,
 	MetricReplicate,
 	MetricResult,
 	ObservedSpecs,
@@ -29,10 +28,18 @@ import type {
 import {
 	aggregate,
 	deriveEconomics,
-	getMetric,
 	getProvider,
+	isDerivedMetric,
 	parseRun,
+	providerReportedNothing,
 } from "@sandbox-benchmarks/schema";
+import type { HostMetadataRecordInput, ObservedMixtureIds } from "./observed-mixtures.ts";
+import {
+	buildObservedMixtures,
+	foldHostMetadata,
+	observedMixtureIds,
+	representativeSpecs,
+} from "./observed-mixtures.ts";
 
 /**
  * Field separator for the composite dedupe keys below. A NUL can't occur in a suite name, a reason, or
@@ -40,12 +47,6 @@ import {
  * rather than a literal control character in a template string (which makes git read the file as binary).
  */
 const NUL = "\u0000";
-
-/** A measured (non-derived) Metric: one a suite actually produced, vs. a derived economics Metric. */
-function isMeasured(metric: MetricResult): boolean {
-	// Derived metrics (economics) are recomputed post-merge; everything else is real measurement.
-	return getMetric(metric.metricId)?.derived !== true;
-}
 
 /** One provider's slice from one shard, tagged with the replicate sandbox the shard was measured under. */
 interface ReplicateSlice {
@@ -61,15 +62,21 @@ interface ReplicateSlice {
  * hierarchical-bootstrap inference while the pooled median stays the ranking value. Provenance
  * (`sourceFile`/`appVersion`/`arguments`) is carried from the lowest-index replicate.
  */
-function mergeMetricReplicates(byReplicate: Map<number, MetricResult>): MetricResult {
+function mergeMetricReplicates(byReplicate: Map<number, ReplicateContribution>): MetricResult {
 	const indices = [...byReplicate.keys()].sort((a, b) => a - b);
-	const first = byReplicate.get(indices[0] as number) as MetricResult;
+	const first = (byReplicate.get(indices[0] as number) as ReplicateContribution).metric;
 	if (indices.length === 1) return first;
 
-	const replicates: MetricReplicate[] = indices.map((index) => ({
-		index,
-		samples: [...(byReplicate.get(index) as MetricResult).samples],
-	}));
+	const replicates: MetricReplicate[] = indices.map((index) => {
+		const contribution = byReplicate.get(index) as ReplicateContribution;
+		return {
+			index,
+			samples: [...contribution.metric.samples],
+			// The join to observedMixtures: which machine and network produced THIS cluster. Spread so a
+			// category the sandbox disclosed nothing for stays absent rather than becoming a dangling key.
+			...contribution.ids,
+		};
+	});
 	const pooled = replicates.flatMap((r) => r.samples);
 	// Spread `first` so every provenance field (sourceFile/appVersion/arguments — and any future optional
 	// MetricResult field) is carried from the lowest-index replicate without re-listing the schema here,
@@ -83,92 +90,131 @@ function mergeMetricReplicates(byReplicate: Map<number, MetricResult>): MetricRe
 	};
 }
 
+/** One replicate's contribution to a metric, with the mixture ids of the sandbox that produced it. */
+interface ReplicateContribution {
+	metric: MetricResult;
+	ids: ObservedMixtureIds;
+}
+
+/**
+ * Fold across shards by the rule the whole merge uses for a verdict: a single `false` is sticky, a
+ * `true` stands only while nothing contradicts it, and all-undefined stays undefined ("refuse to judge
+ * on partial evidence", see computeSpecMatched).
+ *
+ * Order-independent by construction, which matters because shard arrival order is not deterministic —
+ * an earlier first-shard-wins version made ranking eligibility depend on it.
+ */
+function foldVerdict(current: boolean | undefined, next: boolean | undefined): boolean | undefined {
+	if (next === false || current === false) return false;
+	return next === true ? true : current;
+}
+
 /** Merge one provider's slices across every replicate shard that carried it. */
 function mergeProvider(providerId: string, entries: readonly ReplicateSlice[]): ProviderRun {
-	const slices = entries.map((entry) => entry.slice);
-	// Group measured metrics by id, then by the replicate that produced them. A metric id recurring across
-	// replicate shards is R distinct sandboxes (folded into the replicate structure below); a metric id
-	// recurring WITHIN one replicate is a duplicate (one <Result> owns a metric's samples — result-name
-	// contamination), so first-wins survives at the per-replicate level.
-	const byMetric = new Map<string, Map<number, MetricResult>>();
-	for (const { slice, replicateIndex } of entries) {
-		for (const metric of slice.metrics) {
-			if (!isMeasured(metric)) continue;
-			let byReplicate = byMetric.get(metric.metricId);
-			if (!byReplicate) {
-				byReplicate = new Map<number, MetricResult>();
-				byMetric.set(metric.metricId, byReplicate);
-			}
-			if (!byReplicate.has(replicateIndex)) byReplicate.set(replicateIndex, metric);
-		}
-	}
-	const measured = new Map<string, MetricResult>();
-	for (const [metricId, byReplicate] of byMetric) {
-		measured.set(metricId, mergeMetricReplicates(byReplicate));
-	}
-
-	// Gaps deduped by (scope, id, outcome, reason); uncatalogued stragglers by id — both can recur across
-	// shards. `outcome` belongs in the key: one shard skipping a suite on a disk precondition while another
-	// attempted it and crashed are two distinct facts about the provider, and folding them into one would
-	// silently drop whichever arrived second.
-	const gaps: ResultGap[] = [];
-	const seenGap = new Set<string>();
+	// Group measured metrics by id, then by the replicate that produced them, carrying that sandbox's
+	// mixture ids in the SAME record. A metric id recurring across replicate shards is R distinct
+	// sandboxes (folded into the replicate structure below); a metric id recurring WITHIN one replicate is
+	// a duplicate (one <Result> owns a metric's samples — result-name contamination), so first-wins
+	// survives at the per-replicate level. Keeping the ids alongside the metric rather than in a parallel
+	// map makes "the attribution describes the sandbox the samples came from" structural.
+	//
+	// Keyed per METRIC, not per provider: a replicate index is scoped to its cell, so (system, r0) and
+	// (disk, r0) are two different sandboxes that may well have landed on different machines. A
+	// provider-wide index→machine map would silently attribute one suite's samples to another suite's host.
+	const byMetric = new Map<string, Map<number, ReplicateContribution>>();
+	const gapByKey = new Map<string, ResultGap>();
 	// Coverage unions across shards: the matrix fans out one job per (provider, suite) and that job writes
-	// one shard per replicate sandbox, so each shard sees only its own cell+replicate. A suite is covered for this provider iff SOME shard produced a Metric for it.
+	// one shard per replicate sandbox, so each shard sees only its own cell+replicate. A suite is covered
+	// for this provider iff SOME shard produced a Metric for it.
 	const suitesCovered = new Set<string>();
 	const uncatalogued: UncataloguedResult[] = [];
 	const seenStraggler = new Set<string>();
-	// observed-specs: first non-undefined value per key wins (all shards of a provider ran the same spec).
-	const observedSpecs: ObservedSpecs = {};
 	let specMatched: boolean | undefined;
-	// Cross-shard hardware heterogeneity: shards of one provider are MEANT to be the same machine, so a
-	// divergent host cpuModel means the provider scheduled them onto different hardware — a confound the
-	// published Run must disclose. cpuModel is the key (cpuMicroarch is derived from it, so distinct
-	// microarchs can't arise without distinct models); collect the distinct disclosures, publish below.
-	const hostCpuModels = new Set<string>();
-	const hostMetadata: HostMetadataRecord[] = [];
-	const seenHostMetadata = new Set<string>();
+	// One reading per SANDBOX, for the mixture tally. Only slices carrying participation evidence count:
+	// the normalizer emits a zero-evidence placeholder ProviderRun for every registered provider in
+	// EVERY shard, so counting slices naively would set the denominator to "every shard in the run" and
+	// report a 3-sandbox provider as having 60-odd blind sandboxes. A slice with a gap but no metric IS a
+	// real report (a skipped or failed-to-create sandbox is a sandbox the provider was asked for), so the
+	// predicate is participation evidence, not measurement.
+	const sandboxSpecReadings: ObservedSpecs[] = [];
+	// One entry per (record, sandbox), folded below. Collected raw rather than deduped here because the
+	// fold needs the machine each record was read on, which only the slice knows.
+	const hostMetadataInputs: HostMetadataRecordInput[] = [];
 
-	for (const slice of slices) {
-		for (const record of slice.hostMetadata ?? []) {
-			const key = JSON.stringify(record);
-			if (seenHostMetadata.has(key)) continue;
-			seenHostMetadata.add(key);
-			hostMetadata.push(record);
-		}
+	// ONE pass over the slices. The mixture ids are two sha256 hashes per slice, and a real run merges
+	// ~470 slices per provider (the normalizer's placeholder rows included), so deriving them once here
+	// rather than once per consumer loop is the difference between ~940 hashes and ~2,800.
+	for (const { slice, replicateIndex } of entries) {
+		const ids = observedMixtureIds(slice.observedSpecs);
+		if (!providerReportedNothing(slice)) sandboxSpecReadings.push(slice.observedSpecs);
+		for (const record of slice.hostMetadata ?? []) hostMetadataInputs.push({ record, ids });
 		for (const suite of slice.suitesCovered) suitesCovered.add(suite);
+
+		for (const metric of slice.metrics) {
+			if (isDerivedMetric(metric)) continue;
+			let byReplicate = byMetric.get(metric.metricId);
+			if (!byReplicate) {
+				byReplicate = new Map<number, ReplicateContribution>();
+				byMetric.set(metric.metricId, byReplicate);
+			}
+			if (!byReplicate.has(replicateIndex)) byReplicate.set(replicateIndex, { metric, ids });
+		}
+
+		// Gaps keyed by (scope, id, outcome, reason); `outcome` belongs in the key because one shard
+		// skipping a suite on a disk precondition while another attempted it and crashed are two distinct
+		// facts, and folding them would silently drop whichever arrived second. `cause` is NOT in the key —
+		// reason and cause are built from one input — but shards can straddle a producer upgrade, so a
+		// classified gap is merged over an unclassified one instead of letting arrival order decide. Merged
+		// into a NEW object: the gaps belong to the caller's shard Runs and must not be mutated.
 		for (const gap of slice.gaps) {
 			const key = [gap.scope, gap.id, gap.outcome, gap.reason].join(NUL);
-			if (seenGap.has(key)) continue;
-			seenGap.add(key);
-			gaps.push(gap);
+			const existing = gapByKey.get(key);
+			if (existing === undefined) {
+				gapByKey.set(key, gap);
+			} else if (existing.cause === undefined && gap.cause !== undefined) {
+				gapByKey.set(key, { ...existing, cause: gap.cause });
+			}
 		}
+
 		for (const straggler of slice.uncatalogued) {
 			if (seenStraggler.has(straggler.id)) continue;
 			seenStraggler.add(straggler.id);
 			uncatalogued.push(straggler);
 		}
-		for (const [key, value] of Object.entries(slice.observedSpecs)) {
-			if (value !== undefined && !(key in observedSpecs)) {
-				(observedSpecs as Record<string, unknown>)[key] = value;
-			}
-		}
-		if (slice.observedSpecs.cpuModel) hostCpuModels.add(slice.observedSpecs.cpuModel);
-		// specMatched folds ORDER-INDEPENDENTLY across shards (was first-shard-wins, which made ranking
-		// eligibility depend on shard arrival order). The merged provider row shares one aggregate, so a
-		// single shard that ran off the target spec (specMatched === false) contaminates it and
-		// disqualifies the whole provider — false is sticky and always wins. An affirmative match stands
-		// only while no shard contradicts it; all-undefined stays undefined ("refuse to judge on partial
-		// evidence", see computeSpecMatched).
-		if (slice.specMatched === false) specMatched = false;
-		else if (slice.specMatched === true && specMatched !== false) specMatched = true;
+
+		specMatched = foldVerdict(specMatched, slice.specMatched);
 	}
 
-	// Disclose the distinct host CPUs when the shards saw more than one — names the confound rather than
-	// hiding it behind the "first-wins" cpuModel merged above. Sorted for deterministic output.
-	if (hostCpuModels.size > 1) {
-		observedSpecs.hostCpuModels = [...hostCpuModels].sort((a, b) => a.localeCompare(b));
+	const measured = new Map<string, MetricResult>();
+	for (const [metricId, byReplicate] of byMetric) {
+		measured.set(metricId, mergeMetricReplicates(byReplicate));
 	}
+	const gaps = [...gapByKey.values()];
+
+	// The counted disclosure: how many distinct host-hardware and host-network combinations the
+	// provider's sandboxes actually reported, and how many landed on each. Undefined for a provider with
+	// no sandbox report at all (the registry placeholder row), which has no mixture to disclose.
+	const observedMixtures = buildObservedMixtures(sandboxSpecReadings);
+
+	// The representative single-value summary, derived once from the mixtures plus a first-wins backfill
+	// rather than assembled by mutation order. Empty without mixtures, and provably so: `observedMixtures`
+	// is undefined only when NO slice carried participation evidence, and `providerReportedNothing`
+	// includes "no observed-spec reading" — so every excluded slice had empty specs and there is nothing to
+	// back-fill from. That is also why the backfill reads `sandboxSpecReadings` rather than every slice.
+	const observedSpecs: ObservedSpecs = observedMixtures
+		? representativeSpecs(sandboxSpecReadings, observedMixtures)
+		: {};
+
+	// Fold the PER-MACHINE verdicts in too. The two inputs are the same observations at different grains,
+	// so they cannot legitimately disagree — and this closes the case where a shard reported specs but no
+	// verdict of its own, which used to leave the provider undefined while its machines plainly answered
+	// the question. The schema refuses a provider verdict kinder than its parts, so this is load-bearing.
+	for (const mixture of Object.values(observedMixtures?.hostHardware ?? {})) {
+		specMatched = foldVerdict(specMatched, mixture.specMatched);
+	}
+
+	// Fold host records by (source, file, non-volatile fields, machine) with a sandbox count.
+	const hostMetadata = foldHostMetadata(hostMetadataInputs);
 
 	const metrics = [...measured.values()];
 	// Re-derive economics from the FULL merged measured set so $/lifecycle sums every suite's timings,
@@ -190,6 +236,7 @@ function mergeProvider(providerId: string, entries: readonly ReplicateSlice[]): 
 		validationStatus: metrics.length > 0 ? "validated" : "pending",
 		...(specMatched !== undefined ? { specMatched } : {}),
 		observedSpecs,
+		...(observedMixtures !== undefined ? { observedMixtures } : {}),
 		...(hostMetadata.length > 0 ? { hostMetadata } : {}),
 		metrics,
 		suitesCovered: [...suitesCovered].sort((a, b) => a.localeCompare(b)),
@@ -243,9 +290,12 @@ export function aggregateRuns(runs: readonly Run[]): Run {
 	const sourceRunUrl = runs.find((run) => run.sourceRunUrl !== undefined)?.sourceRunUrl;
 
 	// The merged Run spans every replicate, so it carries no single `replicateIndex` — that lived on the
-	// shards. Emit v3 (the replicate-aware schema); v2 shards read in above validate unchanged.
+	// shards. Emit v4: this is the only layer that sees every sandbox's reading at once, so it is the only
+	// one that can emit `observedMixtures`, join each replicate to the mixture its sandbox reported, and
+	// fold the host records. v2/v3 shards read in above validate unchanged, and the v4 document still
+	// carries the v3 replicate fold (version floors compare numerically in runSchema).
 	return parseRun({
-		schemaVersion: "3",
+		schemaVersion: "4",
 		runId: first.runId,
 		sha: first.sha,
 		generatedAt,

--- a/packages/results/src/lib/aggregate.ts
+++ b/packages/results/src/lib/aggregate.ts
@@ -92,12 +92,23 @@ function mergeMetricReplicates(byReplicate: Map<number, ReplicateContribution>):
 }
 
 /**
+ * A cause's comparison key, with its keys in a FIXED order rather than the order the producing site
+ * happened to write them in. Every `GapCause` arm is a flat record of scalars, so listing the sorted
+ * top-level keys canonicalizes it completely — the same discipline `observed-mixtures` applies before
+ * hashing, for the same reason: a key order that drifts at a construction site would otherwise put shard
+ * arrival order back into the published document through the tie-break below.
+ */
+function causeKey(cause: GapCause): string {
+	return JSON.stringify(cause, Object.keys(cause).sort());
+}
+
+/**
  * Whether `next` should replace `current` as a gap's cause: any classification beats none, and between
  * two classifications the canonically smaller wins so the choice never depends on shard arrival order.
  */
 function preferCause(current: GapCause | undefined, next: GapCause): boolean {
 	if (current === undefined) return true;
-	return JSON.stringify(next) < JSON.stringify(current);
+	return causeKey(next) < causeKey(current);
 }
 
 /** One replicate's contribution to a metric, with the mixture ids of the sandbox that produced it. */

--- a/packages/results/src/lib/host-metadata.ts
+++ b/packages/results/src/lib/host-metadata.ts
@@ -10,6 +10,31 @@ import type { HostMetadataField, HostMetadataRecord } from "@sandbox-benchmarks/
 
 const PTS_METADATA_FILE = /^pts_.+--metadata\.json$/;
 
+/**
+ * Field-path suffixes whose value changes on every sandbox even when nothing about the host does — a
+ * wall-clock stamp of when that particular run happened.
+ *
+ * They are excluded from a host record's IDENTITY when the aggregate folds duplicates, because
+ * including them defeated deduplication entirely: records were folded only when byte-identical, and the
+ * timestamp never repeats, so one provider's 21 distinct source files landed as 82 near-identical
+ * records. Host metadata was 54% of the committed dataset while describing a handful of machines.
+ *
+ * This lives beside the flattening that PRODUCES these paths, not in the Run schema. The schema
+ * deliberately does not know either source's evolving key vocabulary (see the module note above), and a
+ * `.timestamp` suffix heuristic is exactly that kind of source-specific knowledge — in the contract it
+ * would also make any upstream field whose flattened path happens to end in `.timestamp` unpublishable
+ * on a folded record.
+ *
+ * Matched by suffix rather than exact path because the path is prefixed by the PTS result identifier
+ * (`ci.timestamp`), which is not fixed.
+ */
+export const VOLATILE_HOST_METADATA_PATH_SUFFIXES = [".timestamp"] as const;
+
+/** Whether a host-metadata field path is a per-run stamp rather than a property of the host. */
+export function isVolatileHostMetadataPath(path: string): boolean {
+	return VOLATILE_HOST_METADATA_PATH_SUFFIXES.some((suffix) => path.endsWith(suffix));
+}
+
 function parseJson(path: string): unknown {
 	try {
 		return JSON.parse(readFileSync(path, "utf8"));

--- a/packages/results/src/lib/leaderboard.ts
+++ b/packages/results/src/lib/leaderboard.ts
@@ -23,6 +23,7 @@
  */
 import type {
 	Dimension,
+	GapCause,
 	GapOutcome,
 	GapScope,
 	MedianInterval,
@@ -255,13 +256,17 @@ export interface Leaderboard {
 }
 
 /**
- * Whether a skip reason is a disk-capacity gap — i.e. the harness wrote its "Insufficient disk: …"
- * marker because the sandbox had less free disk than the suite's `minDiskGb`. Matched by prefix rather
- * than importing the harness so `results` stays SDK-free; kept in lockstep with `runSuiteOnSandbox`'s
- * reason string (the one place that phrasing is authored).
+ * Whether a gap is a disk-capacity skip — the sandbox had less free disk than the suite's `minDiskGb`.
+ *
+ * Reads the structured {@link ResultGap.cause} when the Run carries one (v4+). The prose fallback is
+ * for ALREADY-PUBLISHED Runs only: every dataset before v4 recorded this fact solely as an English
+ * sentence, and the leaderboard is regenerated from any run in the committed series, so dropping the
+ * match would silently reclassify a decade of disk skips as generic ones. It is a compatibility
+ * shim with a closed input set — not a parser to extend. A NEW fact belongs in the cause taxonomy.
  */
-function isDiskGap(reason: string): boolean {
-	return /^insufficient disk/i.test(reason.trim());
+function isDiskGap(gap: { reason: string; cause?: GapCause }): boolean {
+	if (gap.cause !== undefined) return gap.cause.kind === "disk-shortfall";
+	return /^insufficient disk/i.test(gap.reason.trim());
 }
 
 /** Rendering/sort precedence: the structural absences first, the merely-unreported last. */
@@ -335,7 +340,7 @@ function coverageGapsOf(run: Run): CoverageGap[] {
 				// before the suite was attempted. A failure's reason is an error message, and one that merely
 				// happens to start with "insufficient disk" is the workload running out of space mid-flight —
 				// a different fact, and not the structural "cannot host this at all" the ❌ claims.
-				disk: gap.outcome === "skipped" && isDiskGap(gap.reason),
+				disk: gap.outcome === "skipped" && isDiskGap(gap),
 			})),
 			...exercised
 				.filter((suite) => !accountedFor.has(suite))

--- a/packages/results/src/lib/leaderboard.ts
+++ b/packages/results/src/lib/leaderboard.ts
@@ -256,17 +256,34 @@ export interface Leaderboard {
 }
 
 /**
+ * Whether the Run's producer was able to classify gaps at all — true once ANY gap carries a structured
+ * cause. This is what decides whether an ABSENT cause is meaningful.
+ *
+ * Deliberately not `schemaVersion >= 4`. The version says which fields the document MAY carry, not
+ * whether its producer populated them, and the two come apart precisely where it matters: re-aggregating
+ * a historical run emits a v4 document whose gaps have no causes, because the shard markers it merges
+ * were written by a harness that predated the taxonomy. Gating on the version would strip the disk
+ * classification off every backfilled run in the committed series; gating on the evidence does not.
+ */
+function producerClassifiesGaps(run: Run): boolean {
+	return run.providers.some((provider) => provider.gaps.some((gap) => gap.cause !== undefined));
+}
+
+/**
  * Whether a gap is a disk-capacity skip — the sandbox had less free disk than the suite's `minDiskGb`.
  *
- * Reads the structured {@link ResultGap.cause} when the Run carries one (v4+). The prose fallback is
- * for ALREADY-PUBLISHED Runs only: every dataset before v4 recorded this fact solely as an English
- * sentence, and the leaderboard is regenerated from any run in the committed series, so dropping the
- * match would silently reclassify a decade of disk skips as generic ones. It is a compatibility
- * shim with a closed input set — not a parser to extend. A NEW fact belongs in the cause taxonomy.
+ * Reads the structured {@link ResultGap.cause} whenever the Run's producer classified anything. In that
+ * case an absent cause means "this gap is unclassified", and prose-matching it anyway would manufacture
+ * a confident diagnosis for an event the producer declined to diagnose — exactly what the taxonomy's
+ * no-catch-all rule forbids.
+ *
+ * The prose match survives only for Runs whose producer emitted no causes at all, where the English
+ * sentence is the sole record of the fact. A compatibility shim over a closed input set — not a parser
+ * to extend. A NEW fact belongs in the cause taxonomy.
  */
-function isDiskGap(gap: { reason: string; cause?: GapCause }): boolean {
+function isDiskGap(gap: { reason: string; cause?: GapCause }, classified: boolean): boolean {
 	if (gap.cause !== undefined) return gap.cause.kind === "disk-shortfall";
-	return /^insufficient disk/i.test(gap.reason.trim());
+	return !classified && /^insufficient disk/i.test(gap.reason.trim());
 }
 
 /** Rendering/sort precedence: the structural absences first, the merely-unreported last. */
@@ -316,6 +333,9 @@ function suitesExercised(run: Run): string[] {
  */
 function coverageGapsOf(run: Run): CoverageGap[] {
 	const exercised = suitesExercised(run);
+	// Computed once per Run, not per gap: whether an absent cause means "unclassified" or "this producer
+	// had no causes to give".
+	const classified = producerClassifiesGaps(run);
 
 	const gaps = run.providers.flatMap((provider): CoverageGap[] => {
 		// A zero-evidence registry row (never dispatched, or every cell lost before reporting) gets the
@@ -340,7 +360,7 @@ function coverageGapsOf(run: Run): CoverageGap[] {
 				// before the suite was attempted. A failure's reason is an error message, and one that merely
 				// happens to start with "insufficient disk" is the workload running out of space mid-flight —
 				// a different fact, and not the structural "cannot host this at all" the ❌ claims.
-				disk: gap.outcome === "skipped" && isDiskGap(gap),
+				disk: gap.outcome === "skipped" && isDiskGap(gap, classified),
 			})),
 			...exercised
 				.filter((suite) => !accountedFor.has(suite))

--- a/packages/results/src/lib/normalize-tree.test.ts
+++ b/packages/results/src/lib/normalize-tree.test.ts
@@ -383,6 +383,11 @@ describe("normalizeProviderDir suite-shortfall gaps and leaf-marker folding", ()
 				outcome: "failed",
 				reason:
 					"PTS ran but every trial failed for 1 of 1 declared metrics: node_web_tooling_runs_per_s (cpu-node/pts_node-web-tooling.xml) — attempted, no value recorded",
+				cause: {
+					kind: "metrics-unrecorded",
+					metricIds: ["node_web_tooling_runs_per_s"],
+					declared: 1,
+				},
 			},
 		]);
 		expect(run.suitesCovered).toEqual([]);
@@ -449,6 +454,11 @@ describe("normalizeProviderDir suite-shortfall gaps and leaf-marker folding", ()
 				outcome: "failed",
 				reason:
 					"PTS ran but every trial failed for 1 of 3 declared metrics: pybench_milliseconds (system/pts_pybench.xml) — attempted, no value recorded",
+				cause: {
+					kind: "metrics-unrecorded",
+					metricIds: ["pybench_milliseconds"],
+					declared: 3,
+				},
 			},
 		]);
 	});
@@ -496,6 +506,11 @@ describe("normalizeProviderDir suite-shortfall gaps and leaf-marker folding", ()
 				outcome: "failed",
 				reason:
 					"PTS ran but every trial failed for 1 of 3 declared metrics: pybench_milliseconds (system/pts_git.xml) — attempted, no value recorded",
+				cause: {
+					kind: "metrics-unrecorded",
+					metricIds: ["pybench_milliseconds"],
+					declared: 3,
+				},
 			},
 		]);
 	});
@@ -567,6 +582,11 @@ describe("normalizeProviderDir suite-shortfall gaps and leaf-marker folding", ()
 				outcome: "failed",
 				reason:
 					"PTS ran but every trial failed for 2 of 4 declared metrics: stream_type_add (memory/pts_stream.xml), stream_type_triad (memory/pts_stream.xml) — attempted, no value recorded",
+				cause: {
+					kind: "metrics-unrecorded",
+					metricIds: ["stream_type_add", "stream_type_triad"],
+					declared: 4,
+				},
 			},
 		]);
 	});
@@ -622,6 +642,11 @@ describe("normalizeProviderDir suite-shortfall gaps and leaf-marker folding", ()
 				outcome: "failed",
 				reason:
 					"PTS ran but every trial failed for 1 of 3 declared metrics: pybench_milliseconds (system/pts_pybench.xml) — attempted, no value recorded",
+				cause: {
+					kind: "metrics-unrecorded",
+					metricIds: ["pybench_milliseconds"],
+					declared: 3,
+				},
 			},
 		]);
 	});
@@ -644,6 +669,7 @@ describe("normalizeProviderDir suite-shortfall gaps and leaf-marker folding", ()
 				id: "disk",
 				outcome: "failed",
 				reason: `PTS duplicate-value dedup dropped 1 fio twin result (MB/s == IOPS at this block size, so the duplicate-valued <Result> was never written): ${SEQ_READ_DIRECT_YES}_mb_per_s (twin survived in disk/pts_fio-seq-read.xml)`,
+				cause: { kind: "duplicate-value-dedup", metricIds: [`${SEQ_READ_DIRECT_YES}_mb_per_s`] },
 			},
 		]);
 	});
@@ -786,6 +812,7 @@ describe("normalizeProviderDir suite-shortfall gaps and leaf-marker folding", ()
 				id: "disk",
 				outcome: "failed",
 				reason: `PTS duplicate-value dedup dropped 1 fio twin result (MB/s == IOPS at this block size, so the duplicate-valued <Result> was never written): ${SEQ_READ_DIRECT_YES}_mb_per_s (twin survived in disk/pts_fio-seq-read.xml)`,
+				cause: { kind: "duplicate-value-dedup", metricIds: [`${SEQ_READ_DIRECT_YES}_mb_per_s`] },
 			},
 		]);
 	});
@@ -817,6 +844,7 @@ describe("normalizeProviderDir suite-shortfall gaps and leaf-marker folding", ()
 				id: "disk",
 				outcome: "failed",
 				reason: `PTS duplicate-value dedup dropped 1 fio twin result (MB/s == IOPS at this block size, so the duplicate-valued <Result> was never written): ${SEQ_READ_DIRECT_YES}_mb_per_s (twin survived in disk/pts_fio-rand-read.xml)`,
+				cause: { kind: "duplicate-value-dedup", metricIds: [`${SEQ_READ_DIRECT_YES}_mb_per_s`] },
 			},
 		]);
 	});

--- a/packages/results/src/lib/normalize-tree.ts
+++ b/packages/results/src/lib/normalize-tree.ts
@@ -54,7 +54,10 @@ export function normalizeResultsTree(input: NormalizeInput): Run {
 		.map((meta) => normalizeProviderDir(input.rawRoot, meta.id));
 
 	const candidate = {
-		// A shard may carry a replicateIndex the aggregate folds into MetricResult.replicates (v3+).
+		// Pinned at 4 because this function stamps a structured `cause` on suite gaps
+		// (`shortfallCause`/`twinDropCause`), which `runSchema` gates at v4-or-later — lowering this while
+		// still emitting causes fails `parseRun`. A shard may also carry a replicateIndex (v3+) the
+		// aggregate folds into MetricResult.replicates.
 		schemaVersion: "4" as const,
 		runId: input.runId,
 		sha: input.sha,

--- a/packages/results/src/lib/normalize-tree.ts
+++ b/packages/results/src/lib/normalize-tree.ts
@@ -54,7 +54,7 @@ export function normalizeResultsTree(input: NormalizeInput): Run {
 		.map((meta) => normalizeProviderDir(input.rawRoot, meta.id));
 
 	const candidate = {
-		// v3: a shard may carry a replicateIndex the aggregate folds into MetricResult.replicates.
+		// A shard may carry a replicateIndex the aggregate folds into MetricResult.replicates (v3+).
 		schemaVersion: "4" as const,
 		runId: input.runId,
 		sha: input.sha,

--- a/packages/results/src/lib/normalize-tree.ts
+++ b/packages/results/src/lib/normalize-tree.ts
@@ -7,6 +7,7 @@
 import { readdirSync, readFileSync, statSync } from "node:fs";
 import { join } from "node:path";
 import type {
+	GapCause,
 	HostMetadataRecord,
 	MetricResult,
 	ObservedSpecs,
@@ -54,7 +55,7 @@ export function normalizeResultsTree(input: NormalizeInput): Run {
 
 	const candidate = {
 		// v3: a shard may carry a replicateIndex the aggregate folds into MetricResult.replicates.
-		schemaVersion: "3" as const,
+		schemaVersion: "4" as const,
 		runId: input.runId,
 		sha: input.sha,
 		generatedAt: input.generatedAt,
@@ -128,13 +129,32 @@ function suiteForLeaf(leaf: string): string | undefined {
  * across replicate shards instead of stacking one gap per replicate.
  */
 export function shortfallReason(suite: string, missing: readonly AttemptedEmptyResult[]): string {
-	// suiteDirs only ever contains registered names, so the lookup can't miss in production; the
-	// fallback keeps this pure-string helper total for tests and future callers.
-	const declared =
-		(SUITES as Partial<Record<string, { metrics: readonly string[] }>>)[suite]?.metrics.length ??
-		missing.length;
 	const list = missing.map((e) => `${e.metricId} (${e.sourceFile})`).join(", ");
-	return `PTS ran but every trial failed for ${missing.length} of ${declared} declared metrics: ${list} — attempted, no value recorded`;
+	return `PTS ran but every trial failed for ${missing.length} of ${declaredMetricCount(suite, missing.length)} declared metrics: ${list} — attempted, no value recorded`;
+}
+
+/**
+ * How many metrics the suite declares — the denominator in the shortfall wording and cause. suiteDirs
+ * only ever contains registered names, so the lookup can't miss in production; the fallback keeps the
+ * pure helpers total for tests and future callers.
+ */
+function declaredMetricCount(suite: string, fallback: number): number {
+	return (
+		(SUITES as Partial<Record<string, { metrics: readonly string[] }>>)[suite]?.metrics.length ??
+		fallback
+	);
+}
+
+/**
+ * The same shortfall as data. Emitted alongside {@link shortfallReason} so the two can never describe
+ * different facts: one call site builds both from one input.
+ */
+export function shortfallCause(suite: string, missing: readonly AttemptedEmptyResult[]): GapCause {
+	return {
+		kind: "metrics-unrecorded",
+		metricIds: missing.map((e) => e.metricId),
+		declared: declaredMetricCount(suite, missing.length),
+	};
 }
 
 /** A catalogued fio twin whose <Result> PTS omitted entirely; sourceFile carries the SURVIVING twin. */
@@ -152,6 +172,11 @@ export interface DroppedTwinResult {
 export function twinDropReason(dropped: readonly DroppedTwinResult[]): string {
 	const list = dropped.map((d) => `${d.metricId} (twin survived in ${d.sourceFile})`).join(", ");
 	return `PTS duplicate-value dedup dropped ${dropped.length} fio twin result${dropped.length === 1 ? "" : "s"} (MB/s == IOPS at this block size, so the duplicate-valued <Result> was never written): ${list}`;
+}
+
+/** The dropped-twin gap as data, built from the same input as {@link twinDropReason}. */
+export function twinDropCause(dropped: readonly DroppedTwinResult[]): GapCause {
+	return { kind: "duplicate-value-dedup", metricIds: dropped.map((d) => d.metricId) };
 }
 
 const TWIN_SUFFIXES = ["_mb_per_s", "_iops"] as const;
@@ -438,6 +463,7 @@ export function normalizeProviderDir(rawRoot: string, providerId: string): Provi
 			id: suite,
 			outcome: "failed",
 			reason: shortfallReason(suite, missing),
+			cause: shortfallCause(suite, missing),
 		});
 	}
 
@@ -465,6 +491,7 @@ export function normalizeProviderDir(rawRoot: string, providerId: string): Provi
 			id: suite,
 			outcome: "failed",
 			reason: twinDropReason(dropped),
+			cause: twinDropCause(dropped),
 		});
 	}
 

--- a/packages/results/src/lib/observed-mixtures.test.ts
+++ b/packages/results/src/lib/observed-mixtures.test.ts
@@ -1,0 +1,239 @@
+import { describe, expect, it } from "bun:test";
+import type { HostMetadataRecord, ObservedSpecs } from "@sandbox-benchmarks/schema";
+import {
+	hostHardwareSpecsSchema,
+	hostNetworkSpecsSchema,
+	observedMixturesSchema,
+	TARGET_SPEC,
+} from "@sandbox-benchmarks/schema";
+import {
+	buildObservedMixtures,
+	foldHostMetadata,
+	observedMixtureIds,
+	representativeSpecs,
+} from "./observed-mixtures.ts";
+
+const GENOA: ObservedSpecs = { cpuModel: "AMD EPYC 9R14", cpuMicroarch: "Zen 4 (Genoa)" };
+const TURIN: ObservedSpecs = { cpuModel: "AMD EPYC 9R45", cpuMicroarch: "Zen 5 (Turin)" };
+const ASHBURN: ObservedSpecs = { egressAsn: "AS14618", city: "Ashburn", country: "US" };
+const FRANKFURT: ObservedSpecs = { egressAsn: "AS16509", city: "Frankfurt", country: "DE" };
+
+describe("buildObservedMixtures", () => {
+	it("returns undefined with no readings — a provider with no sandbox has no mixture to disclose", () => {
+		expect(buildObservedMixtures([])).toBeUndefined();
+	});
+
+	it("collapses identical readings into one mixture carrying the sandbox count", () => {
+		const mixtures = buildObservedMixtures([
+			{ ...GENOA, ...ASHBURN },
+			{ ...GENOA, ...ASHBURN },
+			{ ...GENOA, ...ASHBURN },
+		]);
+		expect(mixtures?.sandboxes).toBe(3);
+		expect(Object.values(mixtures?.hostHardware ?? {})).toEqual([{ count: 3, specs: GENOA }]);
+		expect(Object.values(mixtures?.hostNetwork ?? {})).toEqual([{ count: 3, specs: ASHBURN }]);
+	});
+
+	it("separates the two categories — hardware heterogeneity does not fragment the network tally", () => {
+		// Two machines behind ONE egress network. A single combined hash would report two mixtures for both
+		// categories and imply the network moved when only the silicon did.
+		const mixtures = buildObservedMixtures([
+			{ ...GENOA, ...ASHBURN },
+			{ ...TURIN, ...ASHBURN },
+		]);
+		expect(Object.keys(mixtures?.hostHardware ?? {})).toHaveLength(2);
+		expect(Object.values(mixtures?.hostNetwork ?? {})).toEqual([{ count: 2, specs: ASHBURN }]);
+	});
+
+	it("orders mixtures by descending count so the fleet's typical machine leads", () => {
+		const mixtures = buildObservedMixtures([GENOA, TURIN, TURIN]);
+		expect(Object.values(mixtures?.hostHardware ?? {}).map((m) => m.count)).toEqual([2, 1]);
+		expect(Object.values(mixtures?.hostHardware ?? {})[0]?.specs).toEqual(TURIN);
+	});
+
+	it("hashes independently of property insertion order", () => {
+		// The same machine read by two probes that filled the fields in different orders must be ONE
+		// mixture. Without the canonical key sort it would split in two and overstate heterogeneity.
+		const forward: ObservedSpecs = { cpuModel: "AMD EPYC 9R45", cpuMicroarch: "Zen 5 (Turin)" };
+		const backward: ObservedSpecs = { cpuMicroarch: "Zen 5 (Turin)", cpuModel: "AMD EPYC 9R45" };
+		const mixtures = buildObservedMixtures([forward, backward]);
+		expect(Object.values(mixtures?.hostHardware ?? {})).toEqual([{ count: 2, specs: forward }]);
+	});
+
+	it("gives one combination the same id in independent builds, so ids compare across runs", () => {
+		const a = buildObservedMixtures([GENOA]);
+		const b = buildObservedMixtures([GENOA, TURIN]);
+		const idA = Object.keys(a?.hostHardware ?? {})[0];
+		expect(idA).toBeDefined();
+		expect(Object.keys(b?.hostHardware ?? {})).toContain(idA as string);
+	});
+
+	it("excludes per-sandbox identity fields from both hashes", () => {
+		// publicIp/reverseDns/user identify the sandbox, not its machine or network. Hashing them would
+		// mint one mixture per sandbox and report every count as 1 — the disclosure would be noise.
+		const mixtures = buildObservedMixtures([
+			{ ...GENOA, ...ASHBURN, publicIp: "203.0.113.1", reverseDns: "a.example", user: "root" },
+			{ ...GENOA, ...ASHBURN, publicIp: "203.0.113.2", reverseDns: "b.example", user: "root" },
+		]);
+		expect(Object.values(mixtures?.hostHardware ?? {})).toEqual([{ count: 2, specs: GENOA }]);
+		expect(Object.values(mixtures?.hostNetwork ?? {})).toEqual([{ count: 2, specs: ASHBURN }]);
+	});
+
+	it("omits a category entirely when no sandbox disclosed any of its fields", () => {
+		// An empty object is not an observed mixture. Recording one would invent a machine shape nobody
+		// saw; leaving it out keeps `sandboxes` visibly larger than the summed counts instead.
+		const mixtures = buildObservedMixtures([GENOA, GENOA]);
+		expect(mixtures?.sandboxes).toBe(2);
+		expect(mixtures?.hostNetwork).toEqual({});
+	});
+
+	it("counts a blind sandbox in the denominator but in no mixture", () => {
+		const mixtures = buildObservedMixtures([GENOA, {}, {}]);
+		expect(mixtures?.sandboxes).toBe(3);
+		expect(Object.values(mixtures?.hostHardware ?? {}).map((m) => m.count)).toEqual([1]);
+	});
+
+	it("keeps the two hash categories disjoint", () => {
+		// The partition is structural — observedSpecsSchema is COMPOSED from the groups, and each mixture
+		// kind is typed by its own group — so a key that is not a field of its group is now unspellable. The
+		// one thing types cannot catch is a field spelled into BOTH groups: the object spread would accept
+		// it silently and both categories would hash it.
+		const hardware = new Set(hostHardwareSpecsSchema.props.map((prop) => String(prop.key)));
+		const shared = hostNetworkSpecsSchema.props
+			.map((prop) => String(prop.key))
+			.filter((key) => hardware.has(key));
+		expect(shared).toEqual([]);
+	});
+
+	it("emits ids that are keys of the map built from the same readings", () => {
+		// This is what lets providerRunSchema demand every replicate id resolve: the id function and the
+		// map builder share one projection and one hash, so agreement is structural, not coincidental.
+		const readings = [
+			{ ...GENOA, ...ASHBURN },
+			{ ...TURIN, ...FRANKFURT },
+			{ ...GENOA, ...FRANKFURT },
+		];
+		const mixtures = buildObservedMixtures(readings);
+		for (const reading of readings) {
+			const ids = observedMixtureIds(reading);
+			expect(Object.keys(mixtures?.hostHardware ?? {})).toContain(ids.hostHardwareId as string);
+			expect(Object.keys(mixtures?.hostNetwork ?? {})).toContain(ids.hostNetworkId as string);
+		}
+	});
+
+	it("emits no id for a category the sandbox disclosed nothing for", () => {
+		const ids = observedMixtureIds(GENOA);
+		expect(ids.hostHardwareId).toBeDefined();
+		expect(ids.hostNetworkId).toBeUndefined();
+		expect(observedMixtureIds({})).toEqual({});
+	});
+
+	it("picks the dominant mixture's specs, not the first-seen one", () => {
+		const readings = [
+			{ ...GENOA, ...FRANKFURT },
+			{ ...TURIN, ...ASHBURN },
+			{ ...TURIN, ...ASHBURN },
+		];
+		const mixtures = buildObservedMixtures(readings);
+		expect(mixtures).toBeDefined();
+		if (!mixtures) return;
+		expect(representativeSpecs(readings, mixtures)).toEqual({ ...TURIN, ...ASHBURN });
+	});
+
+	it("breaks a dominance tie by id so the representative reading is deterministic", () => {
+		const readings = [GENOA, TURIN];
+		const mixtures = buildObservedMixtures(readings);
+		expect(mixtures).toBeDefined();
+		if (!mixtures) return;
+		// Both count 1; the pick must not depend on iteration luck, and must be one of the two observed
+		// machines rather than a blend of them.
+		const picked = representativeSpecs(readings, mixtures);
+		expect([GENOA, TURIN]).toContainEqual(picked);
+		expect(representativeSpecs(readings, mixtures)).toEqual(picked);
+	});
+
+	it("emits a document that validates against the schema", () => {
+		const built = buildObservedMixtures([
+			{ ...GENOA, ...ASHBURN },
+			{ ...TURIN, ...FRANKFURT },
+		]);
+		expect(built).toBeDefined();
+		if (!built) return;
+		expect(observedMixturesSchema(built)).toEqual(built);
+	});
+});
+
+describe("foldHostMetadata", () => {
+	const record = (sourceFile: string, cpu: string, timestamp: string): HostMetadataRecord => ({
+		source: "phoronix/result-file-to-json",
+		sourceFile,
+		fields: [
+			{ path: "ci.hardware.Processor", value: cpu },
+			{ path: "ci.timestamp", value: timestamp },
+		],
+	});
+	const ids = (cpu: string) => observedMixtureIds({ cpuModel: cpu });
+
+	it("folds records that differ only by a per-run stamp, counting the sandboxes", () => {
+		// The old fold was "drop byte-identical duplicates", which never fired because ci.timestamp
+		// differs on every sandbox — the reason host metadata grew to 54% of the committed dataset.
+		const folded = foldHostMetadata([
+			{ record: record("a.json", "EPYC", "2026-07-30 03:17:44"), ids: ids("EPYC") },
+			{ record: record("a.json", "EPYC", "2026-07-30 03:20:41"), ids: ids("EPYC") },
+			{ record: record("a.json", "EPYC", "2026-07-30 03:27:00"), ids: ids("EPYC") },
+		]);
+		expect(folded).toHaveLength(1);
+		expect(folded[0]?.sandboxes).toBe(3);
+		// The stamp is dropped rather than kept from an arbitrary member: one sandbox's clock reading
+		// must not be published as though all three shared it.
+		expect(folded[0]?.fields.map((f) => f.path)).toEqual(["ci.hardware.Processor"]);
+	});
+
+	it("keeps a singleton record verbatim, per-run stamp included", () => {
+		// Nothing was folded away, so nothing is dropped: the volatile field is still true of the one
+		// sandbox this record describes.
+		const folded = foldHostMetadata([
+			{ record: record("a.json", "EPYC", "2026-07-30 03:17:44"), ids: ids("EPYC") },
+		]);
+		expect(folded[0]?.sandboxes).toBe(1);
+		expect(folded[0]?.fields.map((f) => f.path)).toEqual(["ci.hardware.Processor", "ci.timestamp"]);
+	});
+
+	it("never folds records read on different machines", () => {
+		// Same source file, two machines. Folding them would attribute one machine's record to the
+		// other's sandboxes — the attribution would be confidently wrong rather than merely absent.
+		const folded = foldHostMetadata([
+			{ record: record("a.json", "EPYC", "t1"), ids: ids("EPYC") },
+			{ record: record("a.json", "Xeon", "t2"), ids: ids("Xeon") },
+		]);
+		expect(folded).toHaveLength(2);
+		expect(new Set(folded.map((r) => r.hostHardwareId)).size).toBe(2);
+	});
+
+	it("attributes every record to the machine it was read on", () => {
+		const folded = foldHostMetadata([{ record: record("a.json", "EPYC", "t1"), ids: ids("EPYC") }]);
+		expect(folded[0]?.hostHardwareId).toBe(ids("EPYC").hostHardwareId as string);
+	});
+});
+
+describe("per-machine spec verdicts", () => {
+	it("judges each machine against the target, not just the provider as a whole", () => {
+		// One boolean for a ten-machine fleet cannot say WHICH machine missed. Per mixture it can.
+		const onSpec = { vcpus: TARGET_SPEC.vcpus, memoryGb: TARGET_SPEC.memoryGb, cpuModel: "A" };
+		const offSpec = { vcpus: TARGET_SPEC.vcpus - 1, memoryGb: TARGET_SPEC.memoryGb, cpuModel: "B" };
+		const mixtures = buildObservedMixtures([onSpec, onSpec, offSpec]);
+		const verdicts = Object.values(mixtures?.hostHardware ?? {}).map((m) => [
+			m.specs.cpuModel,
+			m.specMatched,
+		]);
+		expect(verdicts).toEqual([
+			["A", true],
+			["B", false],
+		]);
+	});
+
+	it("leaves a machine unjudged when its probes saw too little", () => {
+		const mixtures = buildObservedMixtures([{ cpuModel: "A" }]);
+		expect(Object.values(mixtures?.hostHardware ?? {})[0]?.specMatched).toBeUndefined();
+	});
+});

--- a/packages/results/src/lib/observed-mixtures.test.ts
+++ b/packages/results/src/lib/observed-mixtures.test.ts
@@ -129,27 +129,42 @@ describe("buildObservedMixtures", () => {
 	});
 
 	it("picks the dominant mixture's specs, not the first-seen one", () => {
-		const readings = [
+		const mixtures = buildObservedMixtures([
 			{ ...GENOA, ...FRANKFURT },
 			{ ...TURIN, ...ASHBURN },
 			{ ...TURIN, ...ASHBURN },
-		];
-		const mixtures = buildObservedMixtures(readings);
+		]);
 		expect(mixtures).toBeDefined();
 		if (!mixtures) return;
-		expect(representativeSpecs(readings, mixtures)).toEqual({ ...TURIN, ...ASHBURN });
+		expect(representativeSpecs(mixtures)).toEqual({ ...TURIN, ...ASHBURN });
+	});
+
+	it("omits per-sandbox identity, so re-aggregating in another order emits the same document", () => {
+		// publicIp/reverseDns/user used to be back-filled from whichever shard arrived first, which made a
+		// re-aggregation of the SAME shards produce a different document — churn in a committed dataset that
+		// a schema bump re-aggregates wholesale. One sandbox's IP was never a property of the provider, and
+		// hostMetadata still carries every per-sandbox record.
+		const forward = [
+			{ ...GENOA, ...ASHBURN, publicIp: "203.0.113.1", reverseDns: "a.example", user: "root" },
+			{ ...GENOA, ...ASHBURN, publicIp: "203.0.113.2", reverseDns: "b.example", user: "root" },
+		];
+		const specsOf = (readings: ObservedSpecs[]) => {
+			const mixtures = buildObservedMixtures(readings);
+			return mixtures ? representativeSpecs(mixtures) : undefined;
+		};
+		expect(specsOf(forward)).toEqual({ ...GENOA, ...ASHBURN });
+		expect(specsOf([...forward].reverse())).toEqual(specsOf(forward));
 	});
 
 	it("breaks a dominance tie by id so the representative reading is deterministic", () => {
-		const readings = [GENOA, TURIN];
-		const mixtures = buildObservedMixtures(readings);
+		const mixtures = buildObservedMixtures([GENOA, TURIN]);
 		expect(mixtures).toBeDefined();
 		if (!mixtures) return;
 		// Both count 1; the pick must not depend on iteration luck, and must be one of the two observed
 		// machines rather than a blend of them.
-		const picked = representativeSpecs(readings, mixtures);
+		const picked = representativeSpecs(mixtures);
 		expect([GENOA, TURIN]).toContainEqual(picked);
-		expect(representativeSpecs(readings, mixtures)).toEqual(picked);
+		expect(representativeSpecs(mixtures)).toEqual(picked);
 	});
 
 	it("emits a document that validates against the schema", () => {

--- a/packages/results/src/lib/observed-mixtures.ts
+++ b/packages/results/src/lib/observed-mixtures.ts
@@ -1,0 +1,280 @@
+/**
+ * Build the counted heterogeneity disclosure for one provider: the distinct host-hardware and
+ * host-network combinations its sandboxes observed, keyed by a stable content hash, each with the
+ * number of sandboxes that reported exactly that combination — plus the two derivations that read it
+ * back, {@link representativeSpecs} and {@link foldHostMetadata}.
+ *
+ * This replaces inference with arithmetic. A single {@link ObservedSpecs} on an aggregated ProviderRun
+ * is one sandbox's reading wearing the provider's name, so a fleet spread over three CPU generations
+ * and two regions serialized identically to one that never moved — and the only hint was the
+ * `hostCpuModels` array, which covered one field of one category. Here the count of keys in a category
+ * IS the number of distinct mixtures, and each entry carries how many sandboxes landed on it.
+ *
+ * The hash is content-addressed and canonical (sorted keys, defined values only), so the same machine
+ * shape or egress network yields the same id in every run and can be tracked across the dataset series
+ * without diffing whole objects.
+ *
+ * SDK-free — schema + node:crypto only.
+ */
+import { createHash } from "node:crypto";
+import type {
+	HostHardwareSpecs,
+	HostMetadataRecord,
+	HostNetworkSpecs,
+	ObservedHardwareMixture,
+	ObservedMixture,
+	ObservedMixtures,
+	ObservedSpecs,
+} from "@sandbox-benchmarks/schema";
+import { hostHardwareSpecsSchema, hostNetworkSpecsSchema } from "@sandbox-benchmarks/schema";
+import { isVolatileHostMetadataPath } from "./host-metadata.ts";
+import { computeSpecMatched } from "./specs.ts";
+
+/**
+ * Hash id width in hex characters. 16 hex = 64 bits, which is enormous headroom against the handful of
+ * mixtures a provider produces — and {@link buildObservedMixtures} still fails loudly on a collision
+ * rather than trusting the arithmetic, because a silent collision would MERGE two distinct machine
+ * shapes into one entry with a summed count: a wrong answer that looks exactly like a right one.
+ *
+ * Do not shrink below 10: at 9 or fewer characters an all-digit id becomes a canonical array index, and
+ * JS reorders integer-like keys ahead of the rest — which would break the descending-count key order
+ * the serialized document is written in.
+ */
+const HASH_ID_LENGTH = 16;
+
+/**
+ * Each category's field names, read off the category schema itself. Taken from arktype's own `props`
+ * rather than a hand-kept list, so a field added to a group joins its hash automatically and a name that
+ * is not a field of the group cannot be spelled at all.
+ */
+const HOST_HARDWARE_SPEC_KEYS = hostHardwareSpecsSchema.props.map((prop) => String(prop.key));
+const HOST_NETWORK_SPEC_KEYS = hostNetworkSpecsSchema.props.map((prop) => String(prop.key));
+
+/** One category's projection of a sandbox reading, with the content hash that identifies it. */
+interface Category<S> {
+	specs: S;
+	/** The exact bytes hashed — retained so a truncation collision can be told from a true repeat. */
+	canonical: string;
+	id: string;
+}
+
+/**
+ * Project a reading onto one category and hash it, or undefined when the sandbox disclosed nothing for
+ * that category. The single place the projection and the hash are sequenced, so an id computed for a
+ * lookup is by construction the same id the tally used — which is what lets `providerRunSchema` demand
+ * every reference resolve.
+ *
+ * Keys are sorted before hashing so two readings that differ only in property insertion order hash
+ * identically; without it the id would depend on which probe file happened to fill a field first, and
+ * one machine would split across several "distinct" mixtures. The cast is the one unavoidable boundary
+ * between a dynamic key list and a static category type, and the key lists come from the category
+ * schemas' own `props`, so it cannot drift.
+ */
+function categoryOf<S>(specs: ObservedSpecs, keys: readonly string[]): Category<S> | undefined {
+	const entries: [string, unknown][] = [];
+	for (const key of keys) {
+		const value = (specs as Record<string, unknown>)[key];
+		if (value !== undefined) entries.push([key, value]);
+	}
+	if (entries.length === 0) return undefined;
+	entries.sort(([a], [b]) => (a < b ? -1 : a > b ? 1 : 0));
+	const canonical = JSON.stringify(entries);
+	return {
+		specs: Object.fromEntries(entries) as S,
+		canonical,
+		id: createHash("sha256").update(canonical).digest("hex").slice(0, HASH_ID_LENGTH),
+	};
+}
+
+/**
+ * Dominance order: most-common mixture first (the fleet's typical machine leads), ties broken by id.
+ *
+ * Authored ONCE and used both to order the serialized map and to pick the representative reading. Two
+ * copies of this rule could disagree, and then `representativeSpecs` would name a machine other than
+ * the one the document leads with.
+ */
+function byDominance<M extends { count: number }>(a: [string, M], b: [string, M]): number {
+	return b[1].count - a[1].count || (a[0] < b[0] ? -1 : a[0] > b[0] ? 1 : 0);
+}
+
+/**
+ * Tally one category across a provider's per-sandbox readings, in dominance order. A reading that
+ * disclosed nothing for the category contributes no entry at all — counting it as an "empty mixture"
+ * would invent a machine shape nobody observed, and the shortfall stays visible because the counts then
+ * sum to less than {@link ObservedMixtures.sandboxes}.
+ *
+ * Returns entries rather than a record so the caller can attach per-entry fields (the hardware
+ * verdict) while building the single output record, instead of materialising it twice.
+ */
+function tallyCategory<S>(
+	readings: readonly ObservedSpecs[],
+	keys: readonly string[],
+): [string, { count: number; specs: S }][] {
+	const byId = new Map<string, { canonical: string; count: number; specs: S }>();
+	for (const reading of readings) {
+		const category = categoryOf<S>(reading, keys);
+		if (!category) continue;
+		const existing = byId.get(category.id);
+		if (existing) {
+			// Same id from different content is a truncation collision. Refuse rather than merge: the
+			// merged entry would report one machine shape with both sandboxes' count, which is precisely
+			// the "looks complete, quietly isn't" claim this whole structure exists to eliminate.
+			if (existing.canonical !== category.canonical) {
+				throw new Error(
+					`observed-mixtures hash collision on id ${category.id}: ${existing.canonical} vs ${category.canonical}`,
+				);
+			}
+			existing.count += 1;
+			continue;
+		}
+		byId.set(category.id, { canonical: category.canonical, count: 1, specs: category.specs });
+	}
+	return [...byId.entries()]
+		.map(([id, { count, specs }]): [string, { count: number; specs: S }] => [id, { count, specs }])
+		.sort(byDominance);
+}
+
+/**
+ * Build one provider's {@link ObservedMixtures} from the per-sandbox {@link ObservedSpecs} readings the
+ * aggregate merged — ONE reading per sandbox, which is one per shard slice (a `(suite, replicate)`
+ * cell). Passing a provider's merged/representative specs instead would report a single mixture of
+ * count 1 and defeat the purpose, so callers must pass the unmerged readings.
+ *
+ * Returns undefined when there are no readings at all: `sandboxes` is a positive integer in the schema,
+ * and a provider with nothing observed has no mixtures to disclose (it is the `pending` placeholder
+ * row, which carries no spec evidence by definition).
+ */
+export function buildObservedMixtures(
+	readings: readonly ObservedSpecs[],
+): ObservedMixtures | undefined {
+	if (readings.length === 0) return undefined;
+	// Each machine gets its OWN spec verdict, attached while the record is built. The provider-level
+	// `specMatched` is one boolean folded across every shard, which on a mixed fleet cannot say WHICH
+	// machine missed the target — a provider honoring it on nine shapes and missing on the tenth reads
+	// the same as one that honored it everywhere.
+	const hostHardware: Record<string, ObservedHardwareMixture> = {};
+	for (const [id, mixture] of tallyCategory<HostHardwareSpecs>(readings, HOST_HARDWARE_SPEC_KEYS)) {
+		const specMatched = computeSpecMatched(mixture.specs);
+		hostHardware[id] = { ...mixture, ...(specMatched !== undefined ? { specMatched } : {}) };
+	}
+	const hostNetwork: Record<string, ObservedMixture> = {};
+	for (const [id, mixture] of tallyCategory<HostNetworkSpecs>(readings, HOST_NETWORK_SPEC_KEYS)) {
+		hostNetwork[id] = mixture;
+	}
+	return { sandboxes: readings.length, hostHardware, hostNetwork };
+}
+
+/** The mixture ids ONE sandbox's reading falls under — the join key from a replicate to its machine. */
+export interface ObservedMixtureIds {
+	hostHardwareId?: string;
+	hostNetworkId?: string;
+}
+
+/**
+ * Which mixtures a single sandbox reading belongs to. Shares {@link categoryOf} with the tally, so an
+ * id computed here is by construction a key of the map built from the same readings.
+ *
+ * A category the reading disclosed nothing for yields no id at all rather than a placeholder: the
+ * schema narrow would reject a key that resolves to nothing, and "absent" is the honest statement.
+ */
+export function observedMixtureIds(specs: ObservedSpecs): ObservedMixtureIds {
+	const hardware = categoryOf(specs, HOST_HARDWARE_SPEC_KEYS);
+	const network = categoryOf(specs, HOST_NETWORK_SPEC_KEYS);
+	return {
+		...(hardware ? { hostHardwareId: hardware.id } : {}),
+		...(network ? { hostNetworkId: network.id } : {}),
+	};
+}
+
+/**
+ * The single representative reading an aggregated ProviderRun publishes beside its mixtures: the specs
+ * of the mixture the MOST sandboxes reported in each category, over a first-wins backfill of everything
+ * a mixture cannot speak for (per-sandbox identity, and any hashed field the dominant sandbox happened
+ * not to disclose).
+ *
+ * One derivation rather than three resolved by mutation order. What it replaces was "first defined
+ * value per key wins", which resolves to whichever shard arrived first and on a mixed fleet publishes a
+ * machine most sandboxes never ran on: in run 30510718771 that gave modal-vm a headline `cpuModel` of
+ * "AMD EPYC 9J45 128-Core Processor" while its sandboxes were spread over ten CPU models, Intel and AMD
+ * alike. A modal value can still under-describe a fleet — that is what the mixtures are for — but it
+ * cannot be a machine the fleet mostly did not use, and it does not change with shard arrival order.
+ */
+export function representativeSpecs(
+	readings: readonly ObservedSpecs[],
+	mixtures: ObservedMixtures,
+): ObservedSpecs {
+	const backfill: Record<string, unknown> = {};
+	for (const reading of readings) {
+		for (const key in reading) {
+			const value = (reading as Record<string, unknown>)[key];
+			if (value !== undefined && !(key in backfill)) backfill[key] = value;
+		}
+	}
+	// Dominance order is the map's own key order (tallyCategory sorted it), so the leading entry is the
+	// dominant one — but selected with the shared comparator rather than by reading the first key, so
+	// the result never depends on JS property-order rules.
+	const dominant = <M extends { count: number }>(category: Readonly<Record<string, M>>) =>
+		Object.entries(category).sort(byDominance)[0]?.[1];
+	return {
+		...backfill,
+		...dominant(mixtures.hostHardware)?.specs,
+		...dominant(mixtures.hostNetwork)?.specs,
+	};
+}
+
+/** One shard's host record together with the mixture ids of the sandbox that produced it. */
+export interface HostMetadataRecordInput {
+	record: HostMetadataRecord;
+	ids: ObservedMixtureIds;
+}
+
+/**
+ * Fold one provider's host-metadata records so a record is the set of fields a machine reported, with a
+ * count of the sandboxes that reported it — rather than one near-duplicate entry per sandbox.
+ *
+ * The old fold was "drop byte-identical duplicates", which never fired: every PTS record carries a
+ * wall-clock `ci.timestamp` that differs on every sandbox, so one provider's 21 distinct source files
+ * landed as 82 records, each re-serializing multi-hundred-character fields (the security-mitigations
+ * list, the compiler configuration). Host metadata was 54% of the committed dataset while describing a
+ * handful of machines.
+ *
+ * Volatile fields are dropped from a FOLDED record rather than kept from an arbitrary member: keeping
+ * one sandbox's stamp on a record that speaks for several would publish a specific claim from a general
+ * one. A record seen exactly once keeps its fields verbatim — nothing was folded away, so no
+ * information is lost where there was no duplication to exploit.
+ */
+export function foldHostMetadata(
+	records: readonly HostMetadataRecordInput[],
+): HostMetadataRecord[] {
+	const byKey = new Map<string, HostMetadataRecord>();
+	for (const { record, ids } of records) {
+		const stable = record.fields.filter((field) => !isVolatileHostMetadataPath(field.path));
+		// Identity is source + file + the machine it was read on + the non-volatile fields, HASHED rather
+		// than retained: the raw key averages 1.7 KB per record (a security-mitigations list and a
+		// compiler configuration are single fields of several hundred characters), so keeping ~500 of them
+		// alive to dedupe ~200 records costs about a megabyte for nothing. The mixture ids belong in the
+		// key because the same source file read on two machines is two facts — folding them would
+		// attribute one machine's record to the other's sandboxes.
+		const key = createHash("sha256")
+			.update(
+				JSON.stringify([
+					record.source,
+					record.sourceFile,
+					ids.hostHardwareId ?? null,
+					ids.hostNetworkId ?? null,
+					stable.map((field) => [field.path, field.value]),
+				]),
+			)
+			.digest("hex");
+		const existing = byKey.get(key);
+		if (existing) {
+			existing.sandboxes = (existing.sandboxes ?? 1) + 1;
+			// Now that it speaks for more than one sandbox, the per-run stamp it inherited from the first
+			// member stops being true of the record and is dropped.
+			existing.fields = stable;
+			continue;
+		}
+		byKey.set(key, { ...record, sandboxes: 1, ...ids });
+	}
+	return [...byKey.values()];
+}

--- a/packages/results/src/lib/observed-mixtures.ts
+++ b/packages/results/src/lib/observed-mixtures.ts
@@ -22,8 +22,8 @@ import type {
 	HostMetadataRecord,
 	HostNetworkSpecs,
 	ObservedHardwareMixture,
-	ObservedMixture,
 	ObservedMixtures,
+	ObservedNetworkMixture,
 	ObservedSpecs,
 } from "@sandbox-benchmarks/schema";
 import { hostHardwareSpecsSchema, hostNetworkSpecsSchema } from "@sandbox-benchmarks/schema";
@@ -157,7 +157,7 @@ export function buildObservedMixtures(
 		const specMatched = computeSpecMatched(mixture.specs);
 		hostHardware[id] = { ...mixture, ...(specMatched !== undefined ? { specMatched } : {}) };
 	}
-	const hostNetwork: Record<string, ObservedMixture> = {};
+	const hostNetwork: Record<string, ObservedNetworkMixture> = {};
 	for (const [id, mixture] of tallyCategory<HostNetworkSpecs>(readings, HOST_NETWORK_SPEC_KEYS)) {
 		hostNetwork[id] = mixture;
 	}
@@ -188,35 +188,30 @@ export function observedMixtureIds(specs: ObservedSpecs): ObservedMixtureIds {
 
 /**
  * The single representative reading an aggregated ProviderRun publishes beside its mixtures: the specs
- * of the mixture the MOST sandboxes reported in each category, over a first-wins backfill of everything
- * a mixture cannot speak for (per-sandbox identity, and any hashed field the dominant sandbox happened
- * not to disclose).
+ * of the mixture the MOST sandboxes reported, in each category.
  *
- * One derivation rather than three resolved by mutation order. What it replaces was "first defined
- * value per key wins", which resolves to whichever shard arrived first and on a mixed fleet publishes a
- * machine most sandboxes never ran on: in run 30510718771 that gave modal-vm a headline `cpuModel` of
- * "AMD EPYC 9J45 128-Core Processor" while its sandboxes were spread over ten CPU models, Intel and AMD
- * alike. A modal value can still under-describe a fleet — that is what the mixtures are for — but it
- * cannot be a machine the fleet mostly did not use, and it does not change with shard arrival order.
+ * Exactly the dominant machine and the dominant egress network — no blending, no backfill. What this
+ * replaces was "first defined value per key wins" across every shard, which had two order dependencies.
+ * The obvious one: on a mixed fleet it published a machine most sandboxes never ran on (run 30510718771
+ * gave modal-vm a headline `cpuModel` of "AMD EPYC 9J45 128-Core Processor" while its sandboxes spread
+ * over ten CPU models, Intel and AMD alike). The subtler one: per-sandbox identity — `publicIp`,
+ * `reverseDns`, `user` — was backfilled from whichever shard arrived first, so re-aggregating the same
+ * shards in a different order emitted a different document. The committed dataset is re-aggregated (a
+ * schema bump backfills the whole series), so a value that moves with arrival order is churn.
+ *
+ * Identity is now simply ABSENT from an aggregate. One sandbox's IP was never a property of the
+ * provider, and the full per-sandbox records are still in `hostMetadata`, so nothing is lost — the same
+ * reasoning that deleted `hostCpuModels`. A field the dominant machine did not disclose is absent too,
+ * which is honest: this reading describes that machine, and `observedMixtures` remains the exact record
+ * of every other one.
  */
-export function representativeSpecs(
-	readings: readonly ObservedSpecs[],
-	mixtures: ObservedMixtures,
-): ObservedSpecs {
-	const backfill: Record<string, unknown> = {};
-	for (const reading of readings) {
-		for (const key in reading) {
-			const value = (reading as Record<string, unknown>)[key];
-			if (value !== undefined && !(key in backfill)) backfill[key] = value;
-		}
-	}
-	// Dominance order is the map's own key order (tallyCategory sorted it), so the leading entry is the
-	// dominant one — but selected with the shared comparator rather than by reading the first key, so
-	// the result never depends on JS property-order rules.
+export function representativeSpecs(mixtures: ObservedMixtures): ObservedSpecs {
+	// Dominance order is the map's own key order (tallyCategory sorted it), but the leading entry is
+	// selected with the shared comparator rather than by reading the first key, so the result never
+	// depends on JS property-order rules.
 	const dominant = <M extends { count: number }>(category: Readonly<Record<string, M>>) =>
 		Object.entries(category).sort(byDominance)[0]?.[1];
 	return {
-		...backfill,
 		...dominant(mixtures.hostHardware)?.specs,
 		...dominant(mixtures.hostNetwork)?.specs,
 	};
@@ -254,7 +249,9 @@ export function foldHostMetadata(
 		// compiler configuration are single fields of several hundred characters), so keeping ~500 of them
 		// alive to dedupe ~200 records costs about a megabyte for nothing. The mixture ids belong in the
 		// key because the same source file read on two machines is two facts — folding them would
-		// attribute one machine's record to the other's sandboxes.
+		// attribute one machine's record to the other's sandboxes. Fields are sorted into the key (never
+		// into the record) for the same reason the mixture hash sorts its object keys: two readings of the
+		// same facts are the same fact, and a content hash that depends on emission order would split them.
 		const key = createHash("sha256")
 			.update(
 				JSON.stringify([
@@ -262,7 +259,9 @@ export function foldHostMetadata(
 					record.sourceFile,
 					ids.hostHardwareId ?? null,
 					ids.hostNetworkId ?? null,
-					stable.map((field) => [field.path, field.value]),
+					[...stable]
+						.sort((a, b) => a.path.localeCompare(b.path))
+						.map((field) => [field.path, field.value]),
 				]),
 			)
 			.digest("hex");

--- a/packages/results/src/lib/stability.ts
+++ b/packages/results/src/lib/stability.ts
@@ -12,7 +12,7 @@
  * SDK-free: the Run model + the Catalog (for each metric's Direction) only.
  */
 import type { Direction, Run } from "@sandbox-benchmarks/schema";
-import { getMetric, LEGACY_PROVIDER_ALIASES } from "@sandbox-benchmarks/schema";
+import { getMetric, isDerivedMetric, LEGACY_PROVIDER_ALIASES } from "@sandbox-benchmarks/schema";
 import { type } from "arktype";
 
 /** The default noise threshold (relative): movements within ±10% are treated as stable. */
@@ -93,13 +93,15 @@ export function compareRuns(
 		const prevMetrics = new Map(prev.metrics.map((m) => [m.metricId, m]));
 
 		for (const curMetric of cur.metrics) {
-			const def = getMetric(curMetric.metricId);
 			// Derived metrics (economics) carry no provenance and mirror a measured shift — skip them.
-			if (def?.derived === true) continue;
+			// The document's own marker is preferred over the catalog (see isDerivedMetric): a catalog-only
+			// test re-classifies a renamed or retired derived metric as measured and reports a regression on
+			// a price.
+			if (isDerivedMetric(curMetric)) continue;
 			const prevMetric = prevMetrics.get(curMetric.metricId);
 			if (!prevMetric) continue;
 
-			const direction: Direction = def?.direction ?? "HIB";
+			const direction: Direction = getMetric(curMetric.metricId)?.direction ?? "HIB";
 			const base = {
 				providerId: cur.providerId,
 				metricId: curMetric.metricId,

--- a/packages/schema/src/catalog.ts
+++ b/packages/schema/src/catalog.ts
@@ -158,6 +158,19 @@ export function getMetric(id: string): MetricDef | undefined {
 	return byId.get(id);
 }
 
+/**
+ * Whether a Metric result is a COMPUTED row (economics) rather than a measurement.
+ *
+ * Prefers the document's own `derived` marker and falls back to the Catalog only for pre-v4 Runs, which
+ * carry none. That order is the point: a Run outlives the Catalog version that produced it, so a
+ * Catalog-only test re-classifies a renamed or retired derived metric as measured — and it would then be
+ * pooled into a ranking or reported as a regression on a price. Authored once here because the same
+ * decision was previously re-made at three call sites, one of which had it wrong.
+ */
+export function isDerivedMetric(metric: { metricId: string; derived?: true }): boolean {
+	return metric.derived === true || getMetric(metric.metricId)?.derived === true;
+}
+
 /** Every Metric belonging to a Dimension, in Catalog order. */
 export function metricsForDimension(dimension: Dimension): MetricDef[] {
 	return METRIC_CATALOG.filter((metric) => metric.dimension === dimension);

--- a/packages/schema/src/economics.ts
+++ b/packages/schema/src/economics.ts
@@ -179,7 +179,13 @@ export function amortizationBreakEvenRunsPerMonth(
 	return burst > 0 ? monthlyUsd / burst : Number.POSITIVE_INFINITY;
 }
 
-/** A derived economics Metric as a single-Sample MetricResult (n=1, stdev=0). */
+/**
+ * A derived economics Metric as a single-Sample MetricResult (n=1, stdev=0).
+ *
+ * `derived: true` is set HERE, at the one place economics rows are constructed, so the marker cannot
+ * be forgotten by a caller — every consumer of `deriveEconomics` gets correctly-marked rows, and
+ * `metricResultSchema`'s catalog cross-check would reject them at the boundary if it ever were.
+ */
 function economicsResult(metricId: EconomicsMetricId, value: number): MetricResult {
-	return { metricId, samples: [value], aggregates: aggregate([value]) };
+	return { metricId, samples: [value], aggregates: aggregate([value]), derived: true };
 }

--- a/packages/schema/src/raw-files.test.ts
+++ b/packages/schema/src/raw-files.test.ts
@@ -173,6 +173,59 @@ describe("parseGapMarker", () => {
 		});
 	});
 
+	it("drops a cause from the wrong side of the skip/failure partition, keeping the gap", () => {
+		// Unlike a contradicting `outcome`, a contradicting cause leaves the outcome knowable (the
+		// filename said it), so only the classification is lost. Keeping it would fail resultGapSchema's
+		// narrow — and a Run parses whole, so one bad marker would take the entire Run down.
+		const marker = parseGapMarker(
+			"sandbox-daytona-cpu-node--skipped.json",
+			{
+				outcome: "skipped",
+				suite: "cpu-node",
+				reason: "Missing credentials",
+				cause: { kind: "step-timeout", step: "install", timeoutSeconds: 600 },
+			},
+			"daytona",
+		);
+		expect(marker).toEqual({
+			scope: "suite",
+			id: "cpu-node",
+			outcome: "skipped",
+			reason: "Missing credentials",
+		});
+		// A coherent pairing survives.
+		expect(
+			parseGapMarker(
+				"sandbox-daytona-cpu-node--skipped.json",
+				{
+					suite: "cpu-node",
+					reason: "no creds",
+					cause: { kind: "missing-credentials", variables: ["E2B_API_KEY"] },
+				},
+				"daytona",
+			)?.cause,
+		).toEqual({ kind: "missing-credentials", variables: ["E2B_API_KEY"] });
+	});
+
+	it("never writes a marker whose cause contradicts its outcome", () => {
+		// The same rule on the producer side, so the bytes in a CI artifact are self-consistent and a
+		// human reading one does not have to know which half the reader believes.
+		const bytes = harnessGapMarkerJson("daytona", "cpu-node", "skipped", "Missing credentials", {
+			kind: "step-failed",
+			step: "install",
+			exitCode: 1,
+		});
+		expect(JSON.parse(bytes).cause).toBeUndefined();
+		expect(
+			JSON.parse(
+				harnessGapMarkerJson("daytona", "cpu-node", "skipped", "Missing credentials", {
+					kind: "missing-credentials",
+					variables: ["E2B_API_KEY"],
+				}),
+			).cause,
+		).toEqual({ kind: "missing-credentials", variables: ["E2B_API_KEY"] });
+	});
+
 	it("rejects the fail_result body under a --skipped.json filename (suffix/body contradiction)", () => {
 		expect(
 			parseGapMarker(

--- a/packages/schema/src/raw-files.ts
+++ b/packages/schema/src/raw-files.ts
@@ -125,7 +125,18 @@ export function harnessGapMarkerJson(
 	// `cause` is written last and omitted when absent, so a marker from a producer that could not
 	// classify the failure is byte-identical to what the pre-cause harness wrote — the field's presence
 	// means "classified", never "this build knows about causes".
-	return `${JSON.stringify({ provider, suite, outcome, reason, ...(cause ? { cause } : {}) }, null, 2)}\n`;
+	return `${JSON.stringify({ provider, suite, outcome, reason, ...matchingCause(cause, outcome) }, null, 2)}\n`;
+}
+
+/**
+ * The marker's `cause` field — present only when the classification sits on the same side of the
+ * skip/failure partition as the outcome. Applied on BOTH sides of the file: the writer never emits a
+ * self-contradictory marker (a human reading one out of a CI artifact should not have to know which half
+ * to believe), and the reader drops one anyway, because a marker on disk may have been written by a
+ * build this one does not control.
+ */
+function matchingCause(cause: GapCause | undefined, outcome: GapOutcome): { cause?: GapCause } {
+	return cause !== undefined && gapOutcomeOfCause(cause) === outcome ? { cause } : {};
 }
 
 /**
@@ -196,11 +207,12 @@ const gapMarkerBody = type({
  * to believe is how a crashed suite comes to be published as a deliberate skip. Undefined for any
  * filename outside the naming contract, whatever the body claims.
  *
- * A `cause` on the wrong side of the skip/failure partition is dropped instead, not escalated: unlike a
- * contradicting `outcome` it leaves the outcome itself knowable (the filename said it), so only the
- * CLASSIFICATION is untrustworthy, and "unclassified" is a shape the schema already accepts. Keeping it
- * would make `resultGapSchema`'s narrow reject the gap — and since a Run parses as a whole, one
- * mislabelled marker in one provider's directory would take the entire Run's normalization down with it.
+ * A `cause` on the wrong side of the skip/failure partition is dropped instead ({@link matchingCause}),
+ * not escalated: unlike a contradicting `outcome` it leaves the outcome itself knowable (the filename
+ * said it), so only the CLASSIFICATION is untrustworthy, and "unclassified" is a shape the schema already
+ * accepts. Keeping it would make `resultGapSchema`'s narrow reject the gap — and since a Run parses as a
+ * whole, one mislabelled marker in one provider's directory would take the entire Run's normalization
+ * down with it.
  */
 export function parseGapMarker(
 	filename: string,
@@ -216,14 +228,12 @@ export function parseGapMarker(
 	const body = gapMarkerBody(data);
 	if (body instanceof type.errors) return undefined;
 	if (body.outcome !== undefined && body.outcome !== outcome) return undefined;
-	const cause =
-		body.cause && gapOutcomeOfCause(body.cause) === outcome ? { cause: body.cause } : {};
 	return {
 		scope: "suite",
 		id: body.suite ?? suiteFromGapMarkerFilename(filename, providerId) ?? filename,
 		outcome,
 		reason: body.reason,
-		...cause,
+		...matchingCause(body.cause, outcome),
 	};
 }
 

--- a/packages/schema/src/raw-files.ts
+++ b/packages/schema/src/raw-files.ts
@@ -25,8 +25,8 @@
  * lifecycle timing files (`<name>_ms.txt`, `<name>-exit-code.txt`) land with the lifecycle path.
  */
 import { type } from "arktype";
-import type { GapOutcome, ResultGap } from "./run.ts";
-import { gapOutcomeSchema } from "./run.ts";
+import type { GapCause, GapOutcome, ResultGap } from "./run.ts";
+import { gapCauseSchema, gapOutcomeSchema } from "./run.ts";
 
 const SKIP_SUFFIX = "--skipped.json";
 const FAILURE_SUFFIX = "--failed.json";
@@ -120,8 +120,12 @@ export function harnessGapMarkerJson(
 	suite: string,
 	outcome: GapOutcome,
 	reason: string,
+	cause?: GapCause,
 ): string {
-	return `${JSON.stringify({ provider, suite, outcome, reason }, null, 2)}\n`;
+	// `cause` is written last and omitted when absent, so a marker from a producer that could not
+	// classify the failure is byte-identical to what the pre-cause harness wrote — the field's presence
+	// means "classified", never "this build knows about causes".
+	return `${JSON.stringify({ provider, suite, outcome, reason, ...(cause ? { cause } : {}) }, null, 2)}\n`;
 }
 
 /**
@@ -169,6 +173,10 @@ const gapMarkerBody = type({
 	"benchmark?": "string",
 	"reason?": "string",
 	"skip_reason?": "string",
+	// The structured classification, when the producing harness could make one. Optional forever: every
+	// already-written marker predates it, and a producer that cannot classify a failure must be able to
+	// stay silent rather than invent a label.
+	"cause?": gapCauseSchema,
 }).pipe((d) => ({
 	outcome: d.outcome,
 	// `|| undefined` (not `??`) so an empty-string `suite`/`benchmark` is treated as absent — suite is
@@ -176,6 +184,7 @@ const gapMarkerBody = type({
 	// `parseGapMarker`, exactly as a missing field does (mirrors `suiteFromGapMarkerFilename`).
 	suite: d.suite || d.benchmark || undefined,
 	reason: d.reason ?? d.skip_reason ?? "unknown",
+	cause: d.cause,
 }));
 
 /**
@@ -206,6 +215,7 @@ export function parseGapMarker(
 		id: body.suite ?? suiteFromGapMarkerFilename(filename, providerId) ?? filename,
 		outcome,
 		reason: body.reason,
+		...(body.cause ? { cause: body.cause } : {}),
 	};
 }
 

--- a/packages/schema/src/raw-files.ts
+++ b/packages/schema/src/raw-files.ts
@@ -26,7 +26,7 @@
  */
 import { type } from "arktype";
 import type { GapCause, GapOutcome, ResultGap } from "./run.ts";
-import { gapCauseSchema, gapOutcomeSchema } from "./run.ts";
+import { gapCauseSchema, gapOutcomeOfCause, gapOutcomeSchema } from "./run.ts";
 
 const SKIP_SUFFIX = "--skipped.json";
 const FAILURE_SUFFIX = "--failed.json";
@@ -195,6 +195,12 @@ const gapMarkerBody = type({
  * than resolved by precedence: a marker whose two halves disagree is corrupt, and guessing which half
  * to believe is how a crashed suite comes to be published as a deliberate skip. Undefined for any
  * filename outside the naming contract, whatever the body claims.
+ *
+ * A `cause` on the wrong side of the skip/failure partition is dropped instead, not escalated: unlike a
+ * contradicting `outcome` it leaves the outcome itself knowable (the filename said it), so only the
+ * CLASSIFICATION is untrustworthy, and "unclassified" is a shape the schema already accepts. Keeping it
+ * would make `resultGapSchema`'s narrow reject the gap — and since a Run parses as a whole, one
+ * mislabelled marker in one provider's directory would take the entire Run's normalization down with it.
  */
 export function parseGapMarker(
 	filename: string,
@@ -210,12 +216,14 @@ export function parseGapMarker(
 	const body = gapMarkerBody(data);
 	if (body instanceof type.errors) return undefined;
 	if (body.outcome !== undefined && body.outcome !== outcome) return undefined;
+	const cause =
+		body.cause && gapOutcomeOfCause(body.cause) === outcome ? { cause: body.cause } : {};
 	return {
 		scope: "suite",
 		id: body.suite ?? suiteFromGapMarkerFilename(filename, providerId) ?? filename,
 		outcome,
 		reason: body.reason,
-		...(body.cause ? { cause: body.cause } : {}),
+		...cause,
 	};
 }
 

--- a/packages/schema/src/run.test.ts
+++ b/packages/schema/src/run.test.ts
@@ -42,17 +42,18 @@ describe("Run schema", () => {
 		expect(run.providers[0]?.validationStatus).toBe("validated");
 	});
 
-	it("accepts both the v2 and v3 schemaVersion", () => {
-		expect(parseRun({ ...validRun, schemaVersion: "2" }).schemaVersion).toBe("2");
-		expect(parseRun({ ...validRun, schemaVersion: "3" }).schemaVersion).toBe("3");
+	it("accepts every published schemaVersion from v2 through v4", () => {
+		for (const schemaVersion of ["2", "3", "4"] as const) {
+			expect(parseRun({ ...validRun, schemaVersion }).schemaVersion).toBe(schemaVersion);
+		}
 	});
 
 	it("rejects a v2 Run that carries a v3-only replicate field", () => {
-		// replicateIndex and MetricResult.replicates are v3-only; a v2 document that carries either is a
-		// producer that wrote a replicate field without bumping schemaVersion — rejected at the boundary so
-		// "v2 == the pre-replicate schema" stays a real guarantee.
+		// replicateIndex and MetricResult.replicates are v3-or-later; a v2 document that carries either is
+		// a producer that wrote a replicate field without bumping schemaVersion — rejected at the boundary
+		// so "v2 == the pre-replicate schema" stays a real guarantee.
 		expect(() => parseRun({ ...validRun, schemaVersion: "2", replicateIndex: 0 })).toThrow(
-			/v3 Run/,
+			/v3-or-later Run/,
 		);
 		const v2WithReplicates = structuredClone(validRun);
 		v2WithReplicates.schemaVersion = "2"; // stays v2 while carrying an otherwise-consistent breakdown
@@ -62,14 +63,187 @@ describe("Run schema", () => {
 				{ index: 0, samples: [16.19, 16.3] },
 				{ index: 1, samples: [16.08] },
 			];
-		expect(() => parseRun(v2WithReplicates)).toThrow(/v3 Run/);
+		expect(() => parseRun(v2WithReplicates)).toThrow(/v3-or-later Run/);
 		// A v3 shard legitimately carries the replicateIndex.
 		expect(parseRun({ ...validRun, schemaVersion: "3", replicateIndex: 2 }).replicateIndex).toBe(2);
 	});
 
+	it("keeps the v3 replicate fold legal at v4 — version floors are not equality checks", () => {
+		// The v4 aggregate carries BOTH observedMixtures and the v3 replicate breakdown. An "=== '3'" gate
+		// would have rejected its own predecessor's field on every version bump, so the floors compare
+		// numerically; this pins that so a future v5 can't silently re-break v3 documents.
+		const v4WithReplicates = structuredClone(validRun);
+		v4WithReplicates.schemaVersion = "4";
+		const metric = v4WithReplicates.providers[0]?.metrics[0];
+		if (metric)
+			(metric as Record<string, unknown>).replicates = [
+				{ index: 0, samples: [16.19, 16.3] },
+				{ index: 1, samples: [16.08] },
+			];
+		expect(parseRun(v4WithReplicates).providers[0]?.metrics[0]?.replicates).toHaveLength(2);
+	});
+
+	it("rejects a pre-v4 Run that carries observedMixtures", () => {
+		// A pre-v4 consumer handed a Run with mixtures would fall back to the single representative
+		// observedSpecs reading and report a heterogeneous fleet as homogeneous — so the producer must bump
+		// the version rather than smuggle the field into a v3 document.
+		const mixtures = {
+			sandboxes: 2,
+			hostHardware: { abc0123456789def: { count: 2, specs: { cpuModel: "AMD EPYC 9R14" } } },
+			hostNetwork: {},
+		};
+		for (const schemaVersion of ["2", "3"]) {
+			const run = structuredClone(validRun);
+			run.schemaVersion = schemaVersion;
+			const provider = run.providers[0];
+			if (provider) (provider as Record<string, unknown>).observedMixtures = mixtures;
+			expect(() => parseRun(run)).toThrow(/v4-or-later Run/);
+		}
+		const v4 = structuredClone(validRun);
+		v4.schemaVersion = "4";
+		const provider = v4.providers[0];
+		if (provider) (provider as Record<string, unknown>).observedMixtures = mixtures;
+		expect(parseRun(v4).providers[0]?.observedMixtures?.sandboxes).toBe(2);
+	});
+
+	it("rejects a replicate mixture id that resolves to nothing", () => {
+		// A dangling id is worse than an absent one: both read as `undefined` at the point of use, so a
+		// consumer cannot tell "this sandbox disclosed nothing" from "this machine cannot be looked up".
+		const withDangling = structuredClone(validRun);
+		withDangling.schemaVersion = "4";
+		const provider = withDangling.providers[0] as Record<string, unknown>;
+		provider.observedMixtures = {
+			sandboxes: 2,
+			hostHardware: { aaaaaaaaaaaaaaaa: { count: 2, specs: { cpuModel: "AMD EPYC 9R14" } } },
+			hostNetwork: {},
+		};
+		const metric = (provider.metrics as Array<Record<string, unknown>>)[0];
+		if (metric)
+			metric.replicates = [
+				{ index: 0, samples: [16.19, 16.3], hostHardwareId: "aaaaaaaaaaaaaaaa" },
+				{ index: 1, samples: [16.08], hostHardwareId: "bbbbbbbbbbbbbbbb" }, // no such mixture
+			];
+		expect(() => parseRun(withDangling)).toThrow(/hostHardwareId resolves in observedMixtures/);
+
+		// The same document with both ids resolving is accepted.
+		const replicates = metric?.replicates as Array<Record<string, unknown>>;
+		if (replicates[1]) replicates[1].hostHardwareId = "aaaaaaaaaaaaaaaa";
+		expect(parseRun(withDangling).providers[0]?.metrics[0]?.replicates?.[1]?.hostHardwareId).toBe(
+			"aaaaaaaaaaaaaaaa",
+		);
+	});
+
+	it("rejects a pre-v4 Run whose replicate names a mixture, without needing its own version gate", () => {
+		// A replicate id is unreachable pre-v4 by CONSTRUCTION, not by a second rule: it must resolve into
+		// observedMixtures, and observedMixtures is itself v4-gated. Both routes are pinned here so the
+		// absent gate stays absent for the right reason rather than by oversight.
+		const withIds = (mixtures?: Record<string, unknown>) => {
+			const run = structuredClone(validRun);
+			run.schemaVersion = "3";
+			const provider = run.providers[0] as Record<string, unknown>;
+			if (mixtures) provider.observedMixtures = mixtures;
+			const metric = (provider.metrics as Array<Record<string, unknown>>)[0] as Record<
+				string,
+				unknown
+			>;
+			metric.replicates = [
+				{ index: 0, samples: [16.19, 16.3], hostHardwareId: "aaaaaaaaaaaaaaaa" },
+				{ index: 1, samples: [16.08] },
+			];
+			return run;
+		};
+		// No mixtures to resolve against: referential integrity refuses it.
+		expect(() => parseRun(withIds())).toThrow(/hostHardwareId resolves in observedMixtures/);
+		// Mixtures present so the id resolves — now the version gate on observedMixtures refuses it.
+		expect(() =>
+			parseRun(
+				withIds({
+					sandboxes: 2,
+					hostHardware: { aaaaaaaaaaaaaaaa: { count: 2, specs: { cpuModel: "AMD EPYC 9R14" } } },
+					hostNetwork: {},
+				}),
+			),
+		).toThrow(/v4-or-later Run when a ProviderRun carries observedMixtures/);
+	});
+
+	it("pins a gap's cause to its outcome — a crash cannot be filed as a precondition", () => {
+		// A skip and a failure are different facts about a provider. Letting the cause disagree with the
+		// outcome inside one gap would leave a consumer to pick a side.
+		const withGap = (outcome: string, cause: Record<string, unknown>) => {
+			const run = structuredClone(validRun);
+			run.schemaVersion = "4";
+			const provider = run.providers[0] as Record<string, unknown>;
+			provider.gaps = [{ scope: "suite", id: "disk", outcome, reason: "x", cause }];
+			return run;
+		};
+		expect(() =>
+			parseRun(withGap("skipped", { kind: "step-timeout", step: "s", timeoutSeconds: 600 })),
+		).toThrow(/skipped gap with a precondition cause/);
+		expect(() =>
+			parseRun(withGap("failed", { kind: "disk-shortfall", freeGb: 20, requiredGb: 30 })),
+		).toThrow(/failed gap with an attempted-and-broke cause/);
+		// The coherent pairings are accepted.
+		expect(
+			parseRun(withGap("skipped", { kind: "disk-shortfall", freeGb: 20, requiredGb: 30 }))
+				.providers[0]?.gaps[0]?.cause?.kind,
+		).toBe("disk-shortfall");
+	});
+
+	it("keeps the derived marker out of a pre-v4 Run, and says nothing about the catalog", () => {
+		// The marker is version-gated, which is a property of the DOCUMENT. Whether it agrees with the
+		// Metric Catalog is deliberately NOT checked here: `parseRun` must not make an already-published
+		// Run's validity a function of the current catalog, or reclassifying one metric would retroactively
+		// invalidate the whole committed series. That agreement is a producer-side gate (see isDerivedMetric).
+		const withMarker = (schemaVersion: string) => {
+			const run = structuredClone(validRun);
+			run.schemaVersion = schemaVersion;
+			const metric = run.providers[0]?.metrics[0] as Record<string, unknown>;
+			metric.derived = true;
+			return run;
+		};
+		expect(() => parseRun(withMarker("3"))).toThrow(/v4-or-later Run/);
+		// At v4 the marker is legal on any metric — including one the catalog calls measured, because the
+		// catalog is not consulted. The value is the document's own claim about itself.
+		expect(parseRun(withMarker("4")).providers[0]?.metrics[0]?.derived).toBe(true);
+	});
+
+	it("rejects a replicate breakdown on a derived Metric", () => {
+		// A computed row is one value derived from the merged measured set, so per-sandbox clusters would
+		// claim a between-machine spread nobody measured. Document-internal, so it needs no catalog.
+		const run = structuredClone(validRun);
+		run.schemaVersion = "4";
+		const metric = run.providers[0]?.metrics[0] as Record<string, unknown>;
+		metric.derived = true;
+		metric.replicates = [
+			{ index: 0, samples: [16.19, 16.3] },
+			{ index: 1, samples: [16.08] },
+		];
+		expect(() => parseRun(run)).toThrow(/derived MetricResult without a replicate breakdown/);
+	});
+
+	it("rejects a provider verdict kinder than its per-machine verdicts", () => {
+		// The provider fold cannot be kinder than its parts: one machine off-spec contaminates the shared
+		// aggregate. Checking it here makes the fold rule a property of the document.
+		const run = structuredClone(validRun);
+		run.schemaVersion = "4";
+		const provider = run.providers[0] as Record<string, unknown>;
+		provider.specMatched = true;
+		provider.observedMixtures = {
+			sandboxes: 2,
+			hostHardware: {
+				aaaaaaaaaaaaaaaa: { count: 1, specs: { vcpus: 4 }, specMatched: true },
+				bbbbbbbbbbbbbbbb: { count: 1, specs: { vcpus: 1 }, specMatched: false },
+			},
+			hostNetwork: {},
+		};
+		expect(() => parseRun(run)).toThrow(/specMatched false when any host-hardware mixture failed/);
+		provider.specMatched = false;
+		expect(parseRun(run).providers[0]?.specMatched).toBe(false);
+	});
+
 	it("rejects an unknown schemaVersion", () => {
 		expect(() => parseRun({ ...validRun, schemaVersion: "1" })).toThrow();
-		expect(() => parseRun({ ...validRun, schemaVersion: "4" })).toThrow();
+		expect(() => parseRun({ ...validRun, schemaVersion: "5" })).toThrow();
 	});
 
 	it("accepts a v3 Metric carrying a consistent replicate breakdown", () => {

--- a/packages/schema/src/run.test.ts
+++ b/packages/schema/src/run.test.ts
@@ -178,10 +178,10 @@ describe("Run schema", () => {
 		};
 		expect(() =>
 			parseRun(withGap("skipped", { kind: "step-timeout", step: "s", timeoutSeconds: 600 })),
-		).toThrow(/skipped gap with a precondition cause/);
+		).toThrow(/skipped gap whose cause describes one.*a failed cause/);
 		expect(() =>
 			parseRun(withGap("failed", { kind: "disk-shortfall", freeGb: 20, requiredGb: 30 })),
-		).toThrow(/failed gap with an attempted-and-broke cause/);
+		).toThrow(/failed gap whose cause describes one.*a skipped cause/);
 		// The coherent pairings are accepted.
 		expect(
 			parseRun(withGap("skipped", { kind: "disk-shortfall", freeGb: 20, requiredGb: 30 }))
@@ -384,5 +384,41 @@ describe("Run schema", () => {
 				],
 			}),
 		).toThrow();
+	});
+});
+
+describe("mixture category partition", () => {
+	const mixtures = (specs: Record<string, unknown>) => {
+		const run = structuredClone(validRun);
+		run.schemaVersion = "4";
+		const provider = run.providers[0] as Record<string, unknown>;
+		provider.observedMixtures = {
+			sandboxes: 1,
+			hostHardware: { aaaaaaaaaaaaaaaa: { count: 1, specs } },
+			hostNetwork: {},
+		};
+		return run;
+	};
+
+	it("rejects a cross-category or identity field inside a mixture's specs", () => {
+		// arktype IGNORES undeclared keys by default, so without onUndeclaredKey("reject") the partition
+		// was only a producer convention: a hostHardware mixture could carry `egressAsn`, or the `publicIp`
+		// whose inclusion the design says destroys the signal, and still validate.
+		expect(() => parseRun(mixtures({ cpuModel: "AMD EPYC 9R14", egressAsn: "AS14618" }))).toThrow(
+			/must be removed/,
+		);
+		expect(() =>
+			parseRun(mixtures({ cpuModel: "AMD EPYC 9R14", publicIp: "203.0.113.1" })),
+		).toThrow(/must be removed/);
+		expect(parseRun(mixtures({ cpuModel: "AMD EPYC 9R14" })).schemaVersion).toBe("4");
+	});
+
+	it("still ignores undeclared keys on observedSpecs, so published Runs keep parsing", () => {
+		// The rejection is scoped to the category schemas ALONE. observedSpecs must stay permissive: every
+		// committed Run predating this change carries `hostCpuModels`, a field since deleted from the schema.
+		const legacy = structuredClone(validRun);
+		const provider = legacy.providers[0] as Record<string, unknown>;
+		(provider.observedSpecs as Record<string, unknown>).hostCpuModels = ["AMD EPYC 9R14"];
+		expect(parseRun(legacy).providers[0]?.observedSpecs.cpuModel).toBeUndefined();
 	});
 });

--- a/packages/schema/src/run.ts
+++ b/packages/schema/src/run.ts
@@ -256,12 +256,19 @@ const sandboxIdentitySpecFields = {
 /**
  * The hostHardware mixture category as its own Type — the `specs` of a hardware mixture, so a mixture
  * carrying a network or identity field is rejected at the boundary rather than merely discouraged.
+ *
+ * `onUndeclaredKey("reject")` is what makes that true: arktype IGNORES undeclared keys by default, so
+ * without it a serialized `hostNetwork` mixture carrying `cpuModel` — or either category carrying the
+ * `publicIp` whose inclusion the design says destroys the signal — validated cleanly and the partition
+ * was only a producer convention. Scoped to the category schemas alone, NOT to
+ * {@link observedSpecsSchema}: that one must keep ignoring undeclared keys so already-published Runs
+ * carrying since-deleted fields (`hostCpuModels`) still parse.
  */
-export const hostHardwareSpecsSchema = type(hostHardwareSpecFields);
+export const hostHardwareSpecsSchema = type(hostHardwareSpecFields).onUndeclaredKey("reject");
 export type HostHardwareSpecs = typeof hostHardwareSpecsSchema.infer;
 
 /** The hostNetwork mixture category as its own Type; see {@link hostHardwareSpecsSchema}. */
-export const hostNetworkSpecsSchema = type(hostNetworkSpecFields);
+export const hostNetworkSpecsSchema = type(hostNetworkSpecFields).onUndeclaredKey("reject");
 export type HostNetworkSpecs = typeof hostNetworkSpecsSchema.infer;
 
 /**
@@ -275,10 +282,10 @@ export type HostNetworkSpecs = typeof hostNetworkSpecsSchema.infer;
  * mixture hash, which is exactly the "looks complete, quietly isn't" failure the categories exist to
  * remove. See {@link ObservedMixtures}.
  *
- * On an AGGREGATED Run this carries one representative reading (first defined value per key across the
- * merged shards), which is a summary, NOT a claim that every sandbox saw it. `observedMixtures` is the
- * complete, countable disclosure; prefer it whenever the question is "how many distinct X did this
- * provider actually put us on".
+ * On an AGGREGATED Run this carries one representative reading — the DOMINANT mixture per category, i.e.
+ * the one the most sandboxes reported — which is a summary, NOT a claim that every sandbox saw it.
+ * `observedMixtures` is the complete, countable disclosure; prefer it whenever the question is "how many
+ * distinct X did this provider actually put us on".
  */
 export const observedSpecsSchema = type({
 	...hostHardwareSpecFields,
@@ -288,16 +295,20 @@ export const observedSpecsSchema = type({
 export type ObservedSpecs = typeof observedSpecsSchema.infer;
 
 /**
- * One observed mixture: a distinct combination of one category's fields, plus how many of the
- * provider's sandboxes reported exactly that combination. `count` is a sandbox count, so the counts
+ * One observed HOST-NETWORK mixture: a distinct combination of the egress/geo fields, plus how many of
+ * the provider's sandboxes reported exactly that combination. `count` is a sandbox count, so the counts
  * within a category sum to the number of sandboxes that disclosed at least one of its fields — which
  * is ≤ {@link ObservedMixtures.sandboxes} whenever some sandbox's probe saw nothing.
+ *
+ * Named for its category rather than left generic: the two mixture types are deliberately NOT the same
+ * shape (see {@link observedHardwareMixtureSchema}), so a category-neutral name would read as the shared
+ * base of both and invite the verdict field to be added here too.
  */
-export const observedMixtureSchema = type({
+export const observedNetworkMixtureSchema = type({
 	count: "number.integer >= 1",
 	specs: hostNetworkSpecsSchema,
 });
-export type ObservedMixture = typeof observedMixtureSchema.infer;
+export type ObservedNetworkMixture = typeof observedNetworkMixtureSchema.infer;
 
 /**
  * A host-hardware mixture, which additionally carries its OWN spec verdict (v4+).
@@ -340,7 +351,7 @@ export type ObservedHardwareMixture = typeof observedHardwareMixtureSchema.infer
 export const observedMixturesSchema = type({
 	sandboxes: "number.integer >= 1",
 	hostHardware: type({ "[string]": observedHardwareMixtureSchema }),
-	hostNetwork: type({ "[string]": observedMixtureSchema }),
+	hostNetwork: type({ "[string]": observedNetworkMixtureSchema }),
 });
 export type ObservedMixtures = typeof observedMixturesSchema.infer;
 
@@ -435,6 +446,15 @@ const SKIP_CAUSE_KINDS: ReadonlySet<GapCause["kind"]> = new Set<GapCause["kind"]
 ]);
 
 /**
+ * Which {@link GapOutcome} a cause belongs to — the partition above, exposed so a producer can CHECK the
+ * pairing before building a gap instead of discovering it as a parse failure. `resultGapSchema` is the
+ * enforcement; this is how a caller stays on the right side of it (see `parseGapMarker`).
+ */
+export function gapOutcomeOfCause(cause: GapCause): GapOutcome {
+	return SKIP_CAUSE_KINDS.has(cause.kind) ? "skipped" : "failed";
+}
+
+/**
  * One benchmark that produced no result for a provider, and why — the recorded half of a coverage
  * gap. The DERIVED half (a suite that ran elsewhere in the Run but never reported here at all, with
  * no marker of any kind) cannot live on a ProviderRun: it is a cross-provider fact, so the
@@ -463,12 +483,11 @@ export const resultGapSchema = type({
 	// failure — via the cause while the outcome says otherwise, which would make the two disagree
 	// inside one gap and leave a consumer to pick a side.
 	if (gap.cause === undefined) return true;
-	const isSkipCause = SKIP_CAUSE_KINDS.has(gap.cause.kind);
-	if (gap.outcome === "skipped" && !isSkipCause) {
-		return ctx.mustBe(`a skipped gap with a precondition cause (got "${gap.cause.kind}")`);
-	}
-	if (gap.outcome === "failed" && isSkipCause) {
-		return ctx.mustBe(`a failed gap with an attempted-and-broke cause (got "${gap.cause.kind}")`);
+	const causeOutcome = gapOutcomeOfCause(gap.cause);
+	if (causeOutcome !== gap.outcome) {
+		return ctx.mustBe(
+			`a ${gap.outcome} gap whose cause describes one (got "${gap.cause.kind}", a ${causeOutcome} cause)`,
+		);
 	}
 	return true;
 });

--- a/packages/schema/src/run.ts
+++ b/packages/schema/src/run.ts
@@ -26,6 +26,22 @@ export const metricReplicateSchema = type({
 	index: "number.integer >= 0",
 	// This replicate's retained per-pass Samples (>= 1, all finite — enforced by the parent narrow).
 	samples: "number[] >= 1",
+	/**
+	 * WHICH machine and network these Samples were measured on: keys into the provider's
+	 * {@link ObservedMixtures}. Absent when that sandbox's probes disclosed nothing for the category.
+	 *
+	 * Without this the between-machine axis is undecodable. A replicate breakdown says a provider's
+	 * numbers varied across R sandboxes, and `observedMixtures` says the fleet held N distinct machine
+	 * shapes — but nothing joined them, so "is the Intel leg slower than the EPYC leg?" was
+	 * unanswerable from a published Run even though both halves of the answer were in it. The dataset
+	 * already pays R× the provider cost to sample between machines; discarding which machine each
+	 * cluster came from threw away most of what that spend bought.
+	 *
+	 * {@link providerRunSchema} narrows these to real keys of the provider's own mixtures, so an id can
+	 * never dangle.
+	 */
+	"hostHardwareId?": "string >= 1",
+	"hostNetworkId?": "string >= 1",
 });
 export type MetricReplicate = typeof metricReplicateSchema.infer;
 
@@ -48,6 +64,20 @@ export const metricResultSchema = type({
 	// the clusters distinct so render-time inference can resample the between-sandbox level. Absent at
 	// R = 1, so a single-replicate Run is byte-identical to the pre-replicate schema.
 	"replicates?": metricReplicateSchema.array(),
+	/**
+	 * Marks a COMPUTED Metric (v4+): the economics rows, which are derived from other Metrics plus the
+	 * provider's published price rather than measured in any sandbox.
+	 *
+	 * Without it the document could not tell the two apart — `usd_per_hour` sat in `metrics` looking
+	 * exactly like a measurement, and only a Metric Catalog lookup (`getMetric(id)?.derived`) separated
+	 * them. That made a dataset non-self-describing: a consumer validating the JSON on its own would
+	 * rank a price alongside measured throughput, and a Run outlives the catalog version that produced
+	 * it. The narrow below keeps document and catalog in agreement rather than merely hoping.
+	 *
+	 * A literal `true`, not a boolean: the flag is a marker, so `derived: false` on a derived Metric is
+	 * unrepresentable rather than merely wrong. Absent means measured.
+	 */
+	"derived?": "true",
 }).narrow((metric, ctx) => {
 	// `aggregate()` already guarantees these at the producer; enforce them at the dataset boundary too,
 	// so a hand-edited/corrupt persisted Run can't carry NaN/Infinity samples or a sample count that
@@ -57,6 +87,12 @@ export const metricResultSchema = type({
 	}
 	if (metric.aggregates.n !== metric.samples.length) {
 		return ctx.mustBe("a MetricResult whose aggregates.n equals samples.length");
+	}
+	// A derived Metric is computed from the merged measured set as a single value, so it has no
+	// per-sandbox clusters to break out — a replicate breakdown on one would claim a between-machine
+	// spread that was never measured.
+	if (metric.derived === true && metric.replicates !== undefined) {
+		return ctx.mustBe("a derived MetricResult without a replicate breakdown");
 	}
 	if (metric.replicates !== undefined) {
 		// The replicate structure only exists to hold ≥2 clusters; a lone replicate is just `samples`.
@@ -121,25 +157,40 @@ export type HostMetadataField = typeof hostMetadataFieldSchema.infer;
  * One rich host record retained from an in-sandbox producer. `mise/system-provider` is the repo's
  * ASN/geo/DMI probe; `phoronix/result-file-to-json` is PTS's native structured System export. The
  * generic flattened field list deliberately preserves new upstream keys without a Run schema bump.
+ *
+ * On an AGGREGATED Run (v4+) a record is the FOLD of every sandbox that reported these same
+ * non-volatile fields: `sandboxes` counts them, and `hostHardwareId`/`hostNetworkId` name the machine
+ * and network they were on. Before that a record was an anonymous member of a flat bag — so the ten
+ * distinct CPUs modal-vm ran on were present in the file yet attributable to nothing, which is the
+ * same defect {@link ObservedMixtures} fixed one level up.
  */
 export const hostMetadataRecordSchema = type({
 	source: "'mise/system-provider' | 'phoronix/result-file-to-json'",
 	sourceFile: "string >= 1",
 	fields: hostMetadataFieldSchema.array(),
+	/** How many sandboxes reported this record (v4+); absent on a per-shard Run, where it is always 1. */
+	"sandboxes?": "number.integer >= 1",
+	/** The machine and network this record was read on — keys into the provider's mixtures (v4+). */
+	"hostHardwareId?": "string >= 1",
+	"hostNetworkId?": "string >= 1",
 });
 export type HostMetadataRecord = typeof hostMetadataRecordSchema.infer;
 
 /**
- * Observed actuals recorded per Run — what in-sandbox probes actually saw, versus the requested
- * {@link TargetSpec}. All optional: providers differ in what in-sandbox
- * probes can see. `vcpus`/`memoryGb` are the EFFECTIVE Sandbox size (cgroup quota where enforced);
+ * HOST HARDWARE fields — the machine a sandbox landed on, as the sandbox could see it. This is one of
+ * the two {@link ObservedMixtures} hash categories: a provider that scheduled its sandboxes across
+ * more than one machine shape produces more than one hostHardware mixture, and the count on each says
+ * how many sandboxes landed there.
+ *
+ * `vcpus`/`memoryGb`/`diskGb` are the EFFECTIVE sandbox size (the cgroup quota where enforced) while
  * `hostVcpus`/`hostMemoryGb` disclose the underlying machine when probes see through the container
- * boundary (e.g. Daytona: a 4-vCPU quota on a 48-thread host). `cpuMicroarch` is a HOST-side
- * generation/microarch label derived from `cpuModel` (e.g. "Zen 5 (Turin)"). `hostCpuModels` is set
- * only by the aggregate path — the distinct host CPU models a provider's shards disclosed, present
- * only when there was more than one (a scheduling confound the published Run names rather than hides).
+ * boundary (e.g. Daytona: a 4-vCPU quota on a 48-thread host) — the host-vs-effective split of
+ * ADR 0005, which the field docs keep explicit. They share ONE hash category on purpose: a provider
+ * handing out 4 vCPU on some sandboxes and 2 on others is exactly the heterogeneity this disclosure
+ * exists to make impossible to miss, so the effective size is part of "which machine did I get".
+ * `cpuMicroarch` is a HOST-side generation label derived from `cpuModel` (e.g. "Zen 5 (Turin)").
  */
-export const observedSpecsSchema = type({
+const hostHardwareSpecFields = {
 	"vcpus?": "number",
 	"memoryGb?": "number",
 	"diskGb?": "number",
@@ -159,30 +210,139 @@ export const observedSpecsSchema = type({
 	// microVM (both read "unknown"), so the declared per-provider isolation stays the source of truth
 	// and this is only a cross-check the leaderboard flags when the two disagree.
 	"detectedIsolation?": "string",
-	"user?": "string",
-	// The distinct host CPU models when merged shards of one provider disclosed more than one — the
-	// aggregate-only heterogeneity disclosure (cpuModel is the key; cpuMicroarch is derived from it).
-	"hostCpuModels?": "string[]",
-	// Rich identity from benchmark:system:provider. ASN/org describe public egress; DMI describes the
-	// machine/hypervisor. Full source records also live in ProviderRun.hostMetadata.
-	"publicIp?": "string",
+	// DMI, from benchmark:system:provider — describes the machine/hypervisor the sandbox ran on.
+	"manufacturer?": "string",
+	"productName?": "string",
+	"biosVendor?": "string",
+} as const;
+
+/**
+ * HOST NETWORK fields — which network a sandbox egressed through, and from where. The second
+ * {@link ObservedMixtures} hash category, from benchmark:system:provider's ASN/geo lookup.
+ *
+ * `publicIp` and `reverseDns` are deliberately NOT here: they identify the individual sandbox rather
+ * than its network, so hashing them would mint one "mixture" per sandbox and report every count as 1 —
+ * destroying the very signal the categories exist to carry. They live in
+ * {@link sandboxIdentitySpecFields} instead, and `networkPrefix` (the announced prefix) is what
+ * carries the address-space dimension into the hash.
+ */
+const hostNetworkSpecFields = {
 	"egressOrg?": "string",
 	"egressAsn?": "string",
 	"egressOrgName?": "string",
-	"reverseDns?": "string",
+	"networkPrefix?": "string",
 	"city?": "string",
 	"region?": "string",
 	"country?": "string",
 	"location?": "string",
 	"timezone?": "string",
-	"manufacturer?": "string",
-	"productName?": "string",
-	"biosVendor?": "string",
-	"networkPrefix?": "string",
+	// Which lookup answered — a mixture whose geo came from a different source is a different
+	// observation, not a silently comparable one.
 	"asnSource?": "string",
 	"geoSource?": "string",
+} as const;
+
+/**
+ * Per-sandbox IDENTITY fields — true observations, but unique (or near-unique) to a single sandbox,
+ * so they are excluded from both mixture hashes. Full source records live in
+ * {@link ProviderRun.hostMetadata} when the individual value is what a reader wants.
+ */
+const sandboxIdentitySpecFields = {
+	"publicIp?": "string",
+	"reverseDns?": "string",
+	"user?": "string",
+} as const;
+
+/**
+ * The hostHardware mixture category as its own Type — the `specs` of a hardware mixture, so a mixture
+ * carrying a network or identity field is rejected at the boundary rather than merely discouraged.
+ */
+export const hostHardwareSpecsSchema = type(hostHardwareSpecFields);
+export type HostHardwareSpecs = typeof hostHardwareSpecsSchema.infer;
+
+/** The hostNetwork mixture category as its own Type; see {@link hostHardwareSpecsSchema}. */
+export const hostNetworkSpecsSchema = type(hostNetworkSpecFields);
+export type HostNetworkSpecs = typeof hostNetworkSpecsSchema.infer;
+
+/**
+ * Observed actuals recorded per Run — what in-sandbox probes actually saw, versus the requested
+ * {@link TargetSpec}. All optional: providers differ in what in-sandbox probes can see.
+ *
+ * COMPOSED from the three field groups above rather than written out flat, and that composition is
+ * load-bearing: the two mixture categories are literally groups this type is built from, so a field
+ * added to ObservedSpecs must be added to one of them and therefore cannot end up unclassified. A flat
+ * list plus a separate key list would let the two drift — a new field silently absent from every
+ * mixture hash, which is exactly the "looks complete, quietly isn't" failure the categories exist to
+ * remove. See {@link ObservedMixtures}.
+ *
+ * On an AGGREGATED Run this carries one representative reading (first defined value per key across the
+ * merged shards), which is a summary, NOT a claim that every sandbox saw it. `observedMixtures` is the
+ * complete, countable disclosure; prefer it whenever the question is "how many distinct X did this
+ * provider actually put us on".
+ */
+export const observedSpecsSchema = type({
+	...hostHardwareSpecFields,
+	...hostNetworkSpecFields,
+	...sandboxIdentitySpecFields,
 });
 export type ObservedSpecs = typeof observedSpecsSchema.infer;
+
+/**
+ * One observed mixture: a distinct combination of one category's fields, plus how many of the
+ * provider's sandboxes reported exactly that combination. `count` is a sandbox count, so the counts
+ * within a category sum to the number of sandboxes that disclosed at least one of its fields — which
+ * is ≤ {@link ObservedMixtures.sandboxes} whenever some sandbox's probe saw nothing.
+ */
+export const observedMixtureSchema = type({
+	count: "number.integer >= 1",
+	specs: hostNetworkSpecsSchema,
+});
+export type ObservedMixture = typeof observedMixtureSchema.infer;
+
+/**
+ * A host-hardware mixture, which additionally carries its OWN spec verdict (v4+).
+ *
+ * `ProviderRun.specMatched` is one boolean folded across every shard, and on a mixed fleet that is too
+ * coarse to act on: run 30510718771 put modal-vm's sandboxes on ten different machines under a single
+ * `specMatched: true`, so a provider honoring the target on nine shapes and missing it on the tenth
+ * reads identically to one that honored it everywhere. Per machine, the verdict is answerable —
+ * `vcpus`/`memoryGb` are hostHardware-category fields, so each mixture carries what the check needs.
+ *
+ * Deliberately absent from the NETWORK mixture type rather than optional-and-always-undefined there:
+ * the target spec says nothing about egress, so a network mixture has no verdict to give and should
+ * not be able to claim one.
+ */
+export const observedHardwareMixtureSchema = type({
+	count: "number.integer >= 1",
+	specs: hostHardwareSpecsSchema,
+	/** Whether THIS machine honored the pinned target; absent when its probes saw too little to judge. */
+	"specMatched?": "boolean",
+});
+export type ObservedHardwareMixture = typeof observedHardwareMixtureSchema.infer;
+
+/**
+ * The precise, countable answer to "how heterogeneous was this provider in this run" — keyed by a
+ * stable content hash of the combination, so the same machine shape or egress network carries the same
+ * id in every run and can be tracked across the dataset series.
+ *
+ * This exists because a single {@link ObservedSpecs} on an aggregated ProviderRun reads like a
+ * property of the provider while actually being one sandbox's reading: a provider spread across three
+ * CPU generations and two regions rendered identically to one that never moved. A reader could not
+ * tell, and nothing in the document disclosed the mixture. Here, `Object.keys(hostHardware).length` IS
+ * the number of distinct machine shapes observed, and each `count` says how many sandboxes landed on
+ * it — no inference required.
+ *
+ * `sandboxes` is the denominator: how many sandboxes (one per merged shard, i.e. per
+ * `(suite, replicate)` cell) the provider contributed. Without it a category's counts are
+ * uninterpretable — "one hardware mixture, count 10" cannot be told apart from a homogeneous fleet
+ * (10 of 10) or a mostly-blind one (10 of 30).
+ */
+export const observedMixturesSchema = type({
+	sandboxes: "number.integer >= 1",
+	hostHardware: type({ "[string]": observedHardwareMixtureSchema }),
+	hostNetwork: type({ "[string]": observedMixtureSchema }),
+});
+export type ObservedMixtures = typeof observedMixturesSchema.infer;
 
 /** The pinned size every provider is asked to match; compared against each provider's {@link ObservedSpecs}. */
 export const targetSpecSchema = type({
@@ -217,6 +377,64 @@ export const gapOutcomeSchema = type("'skipped' | 'failed'");
 export type GapOutcome = typeof gapOutcomeSchema.infer;
 
 /**
+ * WHY a benchmark produced no result, as data rather than prose.
+ *
+ * `reason` beside this is a human sentence, and for a long time it was also the machine interface:
+ * the leaderboard decided whether a skip was a disk shortfall with `/^insufficient disk/i` against a
+ * string authored in another package, a coupling its own comment had to warn about. Every question
+ * past that regex — how many GiB short, which step timed out and after how long, which declared
+ * metrics never recorded — was answerable only by re-parsing English that no test pinned.
+ *
+ * The taxonomy is closed and there is deliberately NO catch-all arm. A producer that cannot classify
+ * a gap omits `cause` entirely, which reads as "unclassified" and cannot be mistaken for a diagnosis;
+ * an `other` kind would let genuinely different failures accumulate behind one label that consumers
+ * would then have to re-parse `reason` to tell apart, reintroducing exactly what this replaces.
+ */
+export const gapCauseSchema = type({
+	// A precondition refused the suite: the sandbox had less free disk than `Suite.minDiskGb`.
+	kind: "'disk-shortfall'",
+	freeGb: "number >= 0",
+	requiredGb: "number > 0",
+})
+	// The provider's credentials were not present in the environment, so nothing was attempted.
+	.or({ kind: "'missing-credentials'", variables: "string[] >= 1" })
+	// `sandbox.create` never returned a usable sandbox (quota, region, provider-side error).
+	.or({ kind: "'sandbox-create-failed'", "detail?": "string" })
+	// The sandbox stopped answering mid-step — distinct from a step that ran and failed.
+	.or({
+		kind: "'sandbox-lost'",
+		step: "string >= 1",
+		"consecutivePollFailures?": "number.integer >= 1",
+	})
+	// A step exceeded its own budget. `timeoutSeconds` is the budget, not the elapsed time.
+	.or({ kind: "'step-timeout'", step: "string >= 1", timeoutSeconds: "number > 0" })
+	// A step ran to completion and exited non-zero.
+	.or({ kind: "'step-failed'", step: "string >= 1", "exitCode?": "number.integer" })
+	// The suite ran, but these declared metrics never recorded a value on any trial.
+	.or({ kind: "'metrics-unrecorded'", metricIds: "string[] >= 1", declared: "number.integer >= 1" })
+	// PTS's duplicate-value dedup dropped a result whose value collided with its twin's.
+	.or({ kind: "'duplicate-value-dedup'", metricIds: "string[] >= 1" })
+	// A lifecycle operation the provider's SDK does not expose (`scope: "operation"` skips).
+	.or({ kind: "'unsupported-operation'", "detail?": "string" })
+	// The run was configured not to measure this — a choice we made, never a provider limitation. Kept
+	// distinct from `unsupported-operation` precisely because collapsing them would let a config toggle
+	// read as a capability the provider lacks.
+	.or({ kind: "'measurement-disabled'", "detail?": "string" });
+export type GapCause = typeof gapCauseSchema.infer;
+
+/**
+ * The causes that describe a PRECONDITION refusing a benchmark, as opposed to one that was attempted and
+ * broke — the {@link GapOutcome} partition of {@link gapCauseSchema}, stated next to the taxonomy it
+ * partitions rather than buried in the narrow that enforces it (and allocated once, not per parsed gap).
+ */
+const SKIP_CAUSE_KINDS: ReadonlySet<GapCause["kind"]> = new Set<GapCause["kind"]>([
+	"disk-shortfall",
+	"missing-credentials",
+	"unsupported-operation",
+	"measurement-disabled",
+]);
+
+/**
  * One benchmark that produced no result for a provider, and why — the recorded half of a coverage
  * gap. The DERIVED half (a suite that ran elsewhere in the Run but never reported here at all, with
  * no marker of any kind) cannot live on a ProviderRun: it is a cross-provider fact, so the
@@ -228,8 +446,31 @@ export const resultGapSchema = type({
 	/** The suite name (`scope: "suite"`) or the harness Metric id (`scope: "operation"`). */
 	id: "string",
 	outcome: gapOutcomeSchema,
-	/** The producer's verbatim explanation — a disk shortfall's numbers, or the error's message. */
+	/**
+	 * The producer's human explanation. Still authored, still the thing a reader reads — but no longer
+	 * the machine interface: consumers branch on {@link ResultGap.cause}, and this is free to be prose.
+	 */
 	reason: "string",
+	/**
+	 * The same failure as structured data (v4+). Absent means the producer did not classify it — an
+	 * older Run, or a failure mode the taxonomy has no arm for. Never infer a cause by parsing `reason`
+	 * when this is absent: guessing produces a confident label for an unclassified event.
+	 */
+	"cause?": gapCauseSchema,
+}).narrow((gap, ctx) => {
+	// A skip and a failure are different facts (see gapOutcomeSchema), and so are their causes. Pinning
+	// the pairing here stops a producer from recording a crash as a skip — or a precondition as a
+	// failure — via the cause while the outcome says otherwise, which would make the two disagree
+	// inside one gap and leave a consumer to pick a side.
+	if (gap.cause === undefined) return true;
+	const isSkipCause = SKIP_CAUSE_KINDS.has(gap.cause.kind);
+	if (gap.outcome === "skipped" && !isSkipCause) {
+		return ctx.mustBe(`a skipped gap with a precondition cause (got "${gap.cause.kind}")`);
+	}
+	if (gap.outcome === "failed" && isSkipCause) {
+		return ctx.mustBe(`a failed gap with an attempted-and-broke cause (got "${gap.cause.kind}")`);
+	}
+	return true;
 });
 export type ResultGap = typeof resultGapSchema.infer;
 
@@ -249,6 +490,14 @@ export const providerRunSchema = type({
 	// Whether observed specs honored the pinned target spec; absent when probes saw too little to judge.
 	"specMatched?": "boolean",
 	observedSpecs: observedSpecsSchema,
+	/**
+	 * The countable heterogeneity disclosure — distinct host-hardware and host-network combinations with
+	 * a sandbox count each. Set by the AGGREGATE path only (a single shard is one sandbox, so its
+	 * mixtures would be a tautology) and therefore v4-only, gated in {@link runSchema}'s narrow. Absent
+	 * on shards and on every Run published before v4; `observedSpecs` remains the representative
+	 * single-value summary beside it.
+	 */
+	"observedMixtures?": observedMixturesSchema,
 	/** Rich, source-attributed host records; optional for historical Runs predating capture. */
 	"hostMetadata?": hostMetadataRecordSchema.array(),
 	metrics: metricResultSchema.array(),
@@ -275,7 +524,66 @@ export const providerRunSchema = type({
 			run.specMatched === undefined ||
 			Object.keys(run.observedSpecs).length > 0 ||
 			ctx.mustBe("a ProviderRun with observedSpecs when specMatched carries a verdict"),
-	);
+	)
+	.narrow((run, ctx) => {
+		// Referential integrity for the replicate→machine join. A dangling id is worse than an absent
+		// one: absent reads as "this sandbox disclosed nothing", while dangling reads as a real machine
+		// that simply cannot be looked up — and the natural consumer (`mixtures[replicate.hostHardwareId]`)
+		// yields undefined for both, so the two failure modes are indistinguishable at the point of use.
+		// Rejecting here keeps "an id resolves" a guarantee rather than a hope.
+		// `Object.hasOwn` against the maps directly rather than materialising two key Sets: a provider has
+		// at most a handful of mixtures, and the common case by far — a shard, or any pre-v4 Run — has none
+		// at all, where building Sets from `{}` would allocate on every provider row of every parse.
+		const hardware = run.observedMixtures?.hostHardware;
+		const network = run.observedMixtures?.hostNetwork;
+		const resolves = (map: object | undefined, id: string): boolean =>
+			map !== undefined && Object.hasOwn(map, id);
+		for (const metric of run.metrics) {
+			for (const replicate of metric.replicates ?? []) {
+				if (
+					replicate.hostHardwareId !== undefined &&
+					!resolves(hardware, replicate.hostHardwareId)
+				) {
+					return ctx.mustBe(
+						`a ProviderRun whose replicate hostHardwareId resolves in observedMixtures (${metric.metricId} r${replicate.index} → ${replicate.hostHardwareId})`,
+					);
+				}
+				if (replicate.hostNetworkId !== undefined && !resolves(network, replicate.hostNetworkId)) {
+					return ctx.mustBe(
+						`a ProviderRun whose replicate hostNetworkId resolves in observedMixtures (${metric.metricId} r${replicate.index} → ${replicate.hostNetworkId})`,
+					);
+				}
+			}
+		}
+		// Host records join the same way and get the same guarantee — one rule for every reference into
+		// observedMixtures, so "an id resolves" holds document-wide rather than per-field.
+		for (const record of run.hostMetadata ?? []) {
+			if (record.hostHardwareId !== undefined && !resolves(hardware, record.hostHardwareId)) {
+				return ctx.mustBe(
+					`a ProviderRun whose hostMetadata hostHardwareId resolves in observedMixtures (${record.sourceFile} → ${record.hostHardwareId})`,
+				);
+			}
+			if (record.hostNetworkId !== undefined && !resolves(network, record.hostNetworkId)) {
+				return ctx.mustBe(
+					`a ProviderRun whose hostMetadata hostNetworkId resolves in observedMixtures (${record.sourceFile} → ${record.hostNetworkId})`,
+				);
+			}
+		}
+		return true;
+	})
+	.narrow((run, ctx) => {
+		// The provider verdict is the fold of the per-machine ones, so it cannot be kinder than its
+		// parts: one machine off-spec contaminates the shared aggregate and disqualifies the provider.
+		// Checking it here makes the fold rule a property of the document rather than a convention of
+		// whichever code last wrote it.
+		const mixtures = Object.values(run.observedMixtures?.hostHardware ?? {});
+		if (mixtures.some((mixture) => mixture.specMatched === false) && run.specMatched !== false) {
+			return ctx.mustBe(
+				"a ProviderRun with specMatched false when any host-hardware mixture failed the target spec",
+			);
+		}
+		return true;
+	});
 export type ProviderRun = typeof providerRunSchema.infer;
 
 /**
@@ -314,17 +622,31 @@ export function providerStatusText(p: ProviderRun): string {
 /**
  * A full benchmark Run: every provider measured against one pinned target spec at one SHA.
  *
- * `schemaVersion` accepts `"2"` and `"3"`. v1's `skips: { suite, reason }[]` could not say whether a
- * benchmark was deliberately not run or had crashed, and carried no positive record of what DID run —
- * so a suite that vanished (job died, artifact never uploaded) left no trace anywhere in the document.
- * v2 replaced it with {@link resultGapSchema} + {@link ProviderRun.suitesCovered}. v3 adds the
- * replicate model: a shard Run carries its {@link replicateIndex}, and the aggregate folds ≥2
- * replicate sandboxes of one (provider, suite) into {@link MetricResult.replicates}. Both versions
- * validate here — already-published v2 Runs (single replicate, no `replicates` field) are read
- * unchanged, and the parser never migrates them in place.
+ * `schemaVersion` accepts `"2"` through `"4"`. v1's `skips: { suite, reason }[]` could not say
+ * whether a benchmark was deliberately not run or had crashed, and carried no positive record of what
+ * DID run — so a suite that vanished (job died, artifact never uploaded) left no trace anywhere in the
+ * document. v2 replaced it with {@link resultGapSchema} + {@link ProviderRun.suitesCovered}. v3 adds
+ * the replicate model: a shard Run carries its {@link replicateIndex}, and the aggregate folds ≥2
+ * replicate sandboxes of one (provider, suite) into {@link MetricResult.replicates}.
+ *
+ * v4 makes the document SELF-DESCRIBING — every fact a reader needs is expressible from the file,
+ * rather than recoverable only by knowing something the file does not say:
+ *
+ *  - {@link ProviderRun.observedMixtures} counts the distinct host-hardware and host-network
+ *    combinations a provider's sandboxes reported, which one representative `observedSpecs` reading
+ *    could only imply.
+ *  - {@link MetricReplicate} names the mixture its sandbox reported, joining a sample cluster to the
+ *    machine that produced it instead of to an anonymous index.
+ *  - {@link ResultGap.cause} classifies a failure as data rather than prose.
+ *  - {@link MetricResult.derived} separates a computed row from a measured one without a catalog lookup.
+ *  - Host records are folded and attributed to their machine.
+ *  - Each host-hardware mixture carries its own spec verdict.
+ *
+ * Every version validates here — already-published Runs are read unchanged, and the parser never
+ * migrates them in place.
  */
 export const runSchema = type({
-	schemaVersion: "'2' | '3'",
+	schemaVersion: "'2' | '3' | '4'",
 	runId: "string",
 	sha: "string",
 	// ISO-8601 timestamp the Run was generated at — validated so the RunIndex sort key can't be a
@@ -338,18 +660,56 @@ export const runSchema = type({
 	targetSpec: targetSpecSchema,
 	providers: providerRunSchema.array(),
 }).narrow((run, ctx) => {
-	// The replicate fields (`replicateIndex`, `MetricResult.replicates`) are v3-only, so "v2 == the
+	// Version floors are compared NUMERICALLY, not by equality: a field introduced at v3 stays legal at
+	// v4 and beyond, so "=== '3'" would have made every version bump retroactively reject the previous
+	// version's own fields (the v4 aggregate below carries folded `replicates`).
+	const version = Number(run.schemaVersion);
+	// The replicate fields (`replicateIndex`, `MetricResult.replicates`) are v3-or-later, so "v2 == the
 	// pre-replicate schema" stays a real guarantee: a producer that writes a replicate field but forgets
 	// to bump schemaVersion is rejected here rather than silently read by a v3-gated consumer that then
 	// ignores the between-sandbox breakdown (reporting the anti-conservative pooled interval instead).
-	if (run.schemaVersion !== "3") {
+	if (version < 3) {
 		if (run.replicateIndex !== undefined) {
-			return ctx.mustBe("a v3 Run when it carries a replicateIndex");
+			return ctx.mustBe("a v3-or-later Run when it carries a replicateIndex");
 		}
 		if (
 			run.providers.some((provider) => provider.metrics.some((m) => m.replicates !== undefined))
 		) {
-			return ctx.mustBe("a v3 Run when a MetricResult carries replicates");
+			return ctx.mustBe("a v3-or-later Run when a MetricResult carries replicates");
+		}
+	}
+	// The v4 self-description fields, gated together because they arrived together. A pre-v4 consumer
+	// handed any of them would fall back to the pre-v4 reading of the same fact — a heterogeneous fleet
+	// read as homogeneous, an anonymous replicate cluster, re-parsed `reason` prose, a price treated as a
+	// measurement, a folded host record read as one sandbox's — each a quietly wrong answer, never a loud
+	// one. Reported by FIELD rather than as one blanket message, so the error names what to fix.
+	if (version < 4) {
+		for (const provider of run.providers) {
+			if (provider.observedMixtures !== undefined) {
+				return ctx.mustBe("a v4-or-later Run when a ProviderRun carries observedMixtures");
+			}
+			// No separate check for a replicate's mixture ids, or for a mixture's own `specMatched`: both
+			// are unreachable pre-v4 by construction rather than by a second rule. A replicate id must
+			// RESOLVE (the ProviderRun narrow, which runs before this one), and `specMatched` lives inside
+			// a mixture — so each requires `observedMixtures`, which the check above has already refused.
+			// Restating them here would read as defence-in-depth while actually being dead branches that
+			// no test can reach and that a later reader would have to re-derive as unreachable.
+			if (provider.gaps.some((gap) => gap.cause !== undefined)) {
+				return ctx.mustBe("a v4-or-later Run when a ResultGap carries a structured cause");
+			}
+			if (provider.metrics.some((metric) => metric.derived !== undefined)) {
+				return ctx.mustBe("a v4-or-later Run when a MetricResult carries the derived marker");
+			}
+			if (
+				provider.hostMetadata?.some(
+					(record) =>
+						record.sandboxes !== undefined ||
+						record.hostHardwareId !== undefined ||
+						record.hostNetworkId !== undefined,
+				)
+			) {
+				return ctx.mustBe("a v4-or-later Run when a HostMetadataRecord is folded or attributed");
+			}
 		}
 	}
 	// `replicateIndex` marks a per-replicate SHARD (one sandbox, not yet folded); `MetricResult.replicates`


### PR DESCRIPTION
Six facts a reader needs were present in the dataset but not expressible FROM
it — each recoverable only by knowing something the file did not say. Run
30510718771 makes the cost concrete: modal-vm's 12 realworld replicates were
spread over TEN CPU models, Intel Xeon Platinum alongside five EPYC generations,
published under a single `specMatched: true` and a headline `cpuModel` that
appears in 10 of its 78 host records. Nothing in the document said so.

v4 records what was missing:

  * ObservedMixtures — per provider, `sandboxes` (the denominator) plus two maps
    from a stable content hash to `{count, specs}`, one for host hardware and one
    for host network. `Object.keys(hostHardware).length` IS the number of distinct
    machine shapes observed; each `count` is how many sandboxes landed on it. The
    prior mitigation, `hostCpuModels`, covered one field of one category and
    answered "were they different?" rather than "how many, and how many each?".

  * MetricReplicate.hostHardwareId / hostNetworkId — the join from a sample
    cluster to the machine that produced it. Both halves of "is the Intel leg
    slower than the EPYC leg?" were already in the document with nothing
    connecting them. The dataset pays R× the provider cost to sample between
    machines; discarding which machine each cluster came from threw away most of
    what that spend bought.

  * A dominant representative reading — `observedSpecs` on an aggregate was
    "first defined value per key wins", i.e. shard arrival order, which on a mixed
    fleet publishes a machine most sandboxes never ran on.

  * ResultGap.cause — a closed discriminated taxonomy authored where the failure
    happens. `reason` had been the machine interface as well as the human one, so
    the leaderboard classified disk skips with `/^insufficient disk/i` against a
    string authored in another package, a coupling its own comment warned about.
    No catch-all arm: an unclassifiable gap omits `cause`, which reads as
    "unclassified" and cannot be mistaken for a diagnosis.

  * MetricResult.derived — `usd_per_hour` sat among the measurements looking like
    one, separable only by a catalog lookup, and a Run outlives the catalog
    version that produced it. Mandatory from v4; optional-in-practice would leave
    consumers keeping the lookup anyway, so the field would buy nothing.

  * Host records folded and attributed — the old dedupe kept byte-identical
    records only and every PTS record carries a wall-clock `ci.timestamp`, so it
    never fired: host metadata was 54% of the dataset while describing a handful
    of machines. Folding on the non-volatile fields gives 468 records -> 203, 54%
    smaller, ~28% off the whole document.

  * Per-machine specMatched — one boolean cannot cover a ten-machine fleet. The
    NETWORK mixture type has no such field at all rather than an
    optional-and-always-undefined one: the target spec says nothing about egress.
    A narrow enforces that the provider fold is never kinder than its parts, and
    writing it caught that the aggregate was not folding them in at all.

Three design rules keep this trustworthy rather than merely present. ObservedSpecs
is COMPOSED from the mixture category field groups, so a new field must join a
group to exist and cannot end up unclassified. Per-sandbox identity fields
(publicIp, reverseDns, user) are excluded from both hashes — hashing a
unique-per-sandbox value would mint one "mixture" per sandbox and report every
count as 1, destroying the signal. And every reference into observedMixtures is
narrowed to a resolvable key: dangling and absent both read as `undefined` at the
point of use, and only one is honest.

Version floors compare NUMERICALLY. An `=== '3'` gate would have rejected the v4
aggregate's own v3 replicate fold, so every future bump would retroactively break
its predecessor's fields. Pre-v4 unreachability is then by construction rather
than by extra rules: a replicate id must resolve into observedMixtures and a
mixture's specMatched lives inside one, so the single gate on observedMixtures
refuses both without redundant per-field checks.

v2 and v3 documents parse unchanged (all 15 committed runs verified), and the
leaderboard renders byte-identically — reading the structured cause where present
and falling back to the prose match for the pre-v4 series, a compatibility shim
over a closed input set rather than a parser to extend.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_0182wDGU1KSzCFqx321qiFpN

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Introduces Run v4 to make the dataset self-describing: providers publish counted host/network mixtures, replicates link to the machine/network that ran them, gaps carry typed causes, and economics rows are marked as derived. v2/v3 still parse; leaderboard output stays the same. Shard schemaVersion is pinned at "4" (documented) to allow structured causes in normalized runs.

- **New Features**
  - Counted mixtures per provider with per-mixture `specMatched` for hardware; network omits it by design.
  - Replicate attribution via `MetricReplicate.hostHardwareId`/`hostNetworkId`.
  - Representative specs now publish the dominant reading instead of “first defined wins”.
  - Structured gaps: `ResultGap.cause` replaces prose matching; the harness attaches causes at source.
  - Derived metrics: economics rows include `derived: true` and can be filtered with `isDerivedMetric`.
  - Host metadata folded on non-volatile fields to shrink files.

- **Bug Fixes**
  - Category schemas reject cross-category keys; hardware/network specs can’t be mixed.
  - Disk-gap classification reads `cause` when present; regex fallback only if the producer emitted none.
  - Gap causes are symmetric and order-proof: the writer won’t emit a cause on the wrong side of skip/fail, the reader drops any mismatched cause, and merges prefer canonicalized (content-equal) causes so shard order can’t affect results.
  - Timeouts are correctly classified: `stepTimeout` floors at 1s; `withTimeout` supports an error factory; `GapError` preserves the `cause`.
  - Representative specs omit per-sandbox identity; the network mixture type is clearly named; host-metadata fold sorts fields in its hash key.

<sup>Written for commit 2c75e5ed52d507a2ed9cb98c960b9ccd8ab34e1f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/starslingdev/hpc-sandbox-benchmarks/pull/291?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Run schema version **4**, including enriched observed hardware/network mixture reporting and stronger per-machine/spec attribution.
  * Expanded results exports for observed-mixtures utilities.
  * Added structured, typed **cause** metadata for skipped/failed gaps and marked derived metrics explicitly.
* **Bug Fixes**
  * Improved gap classification/merging order-independence, including disk-shortfall and other structured skip/fail causes.
  * Refined representative-spec selection and timeout/step failure reporting behavior.
* **Documentation**
  * Updated the architecture document to describe the host vs effective split and the new mixture-based model.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->