### PR TITLE
feat(schema): open Run v4 with a closed gap-cause taxonomy

### DIFF
--- a/packages/results/src/index.test.ts
+++ b/packages/results/src/index.test.ts
@@ -16,7 +16,7 @@ describe("normalizeResultsTree", () => {
 	});
 
 	it("validates as a Run and includes every known provider", () => {
-		expect(run.schemaVersion).toBe("3");
+		expect(run.schemaVersion).toBe("4");
 		expect(run.providers.map((provider) => provider.providerId).sort()).toEqual(
 			PROVIDERS.map((provider) => provider.id).sort(),
 		);

--- a/packages/results/src/lib/aggregate.test.ts
+++ b/packages/results/src/lib/aggregate.test.ts
@@ -80,8 +80,8 @@ describe("aggregateRuns", () => {
 		]);
 		expect(node?.samples).toEqual([10, 11, 20, 21]);
 		expect(node?.aggregates.n).toBe(4);
-		// The merged Run is v3 (replicate-aware); its Metric carries no single replicateIndex.
-		expect(merged.schemaVersion).toBe("3");
+		// The merged Run is v4 (self-describing); its Metric carries no single replicateIndex.
+		expect(merged.schemaVersion).toBe("4");
 	});
 
 	it("keeps a single-replicate metric verbatim — no replicates field at R = 1", () => {

--- a/packages/results/src/lib/aggregate.ts
+++ b/packages/results/src/lib/aggregate.ts
@@ -243,9 +243,12 @@ export function aggregateRuns(runs: readonly Run[]): Run {
 	const sourceRunUrl = runs.find((run) => run.sourceRunUrl !== undefined)?.sourceRunUrl;
 
 	// The merged Run spans every replicate, so it carries no single `replicateIndex` — that lived on the
-	// shards. Emit v3 (the replicate-aware schema); v2 shards read in above validate unchanged.
+	// shards. Emit v4, the version whose self-description fields this layer is about to populate — it is
+	// the only one that sees every sandbox's reading at once. v2/v3 shards read in above validate
+	// unchanged, and a v4 document still carries the v3 replicate fold (version floors compare
+	// numerically in runSchema).
 	return parseRun({
-		schemaVersion: "3",
+		schemaVersion: "4",
 		runId: first.runId,
 		sha: first.sha,
 		generatedAt,

--- a/packages/results/src/lib/normalize-tree.ts
+++ b/packages/results/src/lib/normalize-tree.ts
@@ -53,8 +53,11 @@ export function normalizeResultsTree(input: NormalizeInput): Run {
 		.map((meta) => normalizeProviderDir(input.rawRoot, meta.id));
 
 	const candidate = {
-		// v3: a shard may carry a replicateIndex the aggregate folds into MetricResult.replicates.
-		schemaVersion: "3" as const,
+		// Pinned at 4 so this producer is already emitting the version whose fields it is about to carry:
+		// `runSchema` gates each v4 field at v4-or-later, and a producer that stamps a lower version than
+		// the fields it writes fails `parseRun` at its own boundary. A shard may also carry a
+		// replicateIndex (v3+) the aggregate folds into MetricResult.replicates.
+		schemaVersion: "4" as const,
 		runId: input.runId,
 		sha: input.sha,
 		generatedAt: input.generatedAt,

--- a/packages/schema/src/run.test.ts
+++ b/packages/schema/src/run.test.ts
@@ -42,17 +42,18 @@ describe("Run schema", () => {
 		expect(run.providers[0]?.validationStatus).toBe("validated");
 	});
 
-	it("accepts both the v2 and v3 schemaVersion", () => {
-		expect(parseRun({ ...validRun, schemaVersion: "2" }).schemaVersion).toBe("2");
-		expect(parseRun({ ...validRun, schemaVersion: "3" }).schemaVersion).toBe("3");
+	it("accepts every published schemaVersion from v2 through v4", () => {
+		for (const schemaVersion of ["2", "3", "4"] as const) {
+			expect(parseRun({ ...validRun, schemaVersion }).schemaVersion).toBe(schemaVersion);
+		}
 	});
 
 	it("rejects a v2 Run that carries a v3-only replicate field", () => {
-		// replicateIndex and MetricResult.replicates are v3-only; a v2 document that carries either is a
-		// producer that wrote a replicate field without bumping schemaVersion — rejected at the boundary so
-		// "v2 == the pre-replicate schema" stays a real guarantee.
+		// replicateIndex and MetricResult.replicates are v3-or-later; a v2 document that carries either is
+		// a producer that wrote a replicate field without bumping schemaVersion — rejected at the boundary
+		// so "v2 == the pre-replicate schema" stays a real guarantee.
 		expect(() => parseRun({ ...validRun, schemaVersion: "2", replicateIndex: 0 })).toThrow(
-			/v3 Run/,
+			/v3-or-later Run/,
 		);
 		const v2WithReplicates = structuredClone(validRun);
 		v2WithReplicates.schemaVersion = "2"; // stays v2 while carrying an otherwise-consistent breakdown
@@ -62,14 +63,145 @@ describe("Run schema", () => {
 				{ index: 0, samples: [16.19, 16.3] },
 				{ index: 1, samples: [16.08] },
 			];
-		expect(() => parseRun(v2WithReplicates)).toThrow(/v3 Run/);
+		expect(() => parseRun(v2WithReplicates)).toThrow(/v3-or-later Run/);
 		// A v3 shard legitimately carries the replicateIndex.
 		expect(parseRun({ ...validRun, schemaVersion: "3", replicateIndex: 2 }).replicateIndex).toBe(2);
 	});
 
+	it("keeps the v3 replicate fold legal at v4 — version floors are not equality checks", () => {
+		// The v4 aggregate carries the v3 replicate breakdown as well as its own new fields. An "=== '3'"
+		// gate would have rejected its own predecessor's field on every version bump, so the floors compare
+		// numerically; this pins that so a future v5 can't silently re-break v3 documents.
+		const v4WithReplicates = structuredClone(validRun);
+		v4WithReplicates.schemaVersion = "4";
+		const metric = v4WithReplicates.providers[0]?.metrics[0];
+		if (metric)
+			(metric as Record<string, unknown>).replicates = [
+				{ index: 0, samples: [16.19, 16.3] },
+				{ index: 1, samples: [16.08] },
+			];
+		expect(parseRun(v4WithReplicates).providers[0]?.metrics[0]?.replicates).toHaveLength(2);
+	});
+
+	it("pins a gap's cause to its outcome — a crash cannot be filed as a precondition", () => {
+		// A skip and a failure are different facts about a provider. Letting the cause disagree with the
+		// outcome inside one gap would leave a consumer to pick a side.
+		const withGap = (outcome: string, cause: Record<string, unknown>) => {
+			const run = structuredClone(validRun);
+			run.schemaVersion = "4";
+			const provider = run.providers[0] as Record<string, unknown>;
+			provider.gaps = [{ scope: "suite", id: "disk", outcome, reason: "x", cause }];
+			return run;
+		};
+		expect(() =>
+			parseRun(withGap("skipped", { kind: "step-timeout", step: "s", timeoutSeconds: 600 })),
+		).toThrow(/skipped gap whose cause describes one.*a failed cause/);
+		expect(() =>
+			parseRun(withGap("failed", { kind: "disk-shortfall", freeGb: 20, requiredGb: 30 })),
+		).toThrow(/failed gap whose cause describes one.*a skipped cause/);
+		// The coherent pairings are accepted.
+		expect(
+			parseRun(withGap("skipped", { kind: "disk-shortfall", freeGb: 20, requiredGb: 30 }))
+				.providers[0]?.gaps[0]?.cause?.kind,
+		).toBe("disk-shortfall");
+	});
+
+	it("keeps a structured cause out of a pre-v4 Run", () => {
+		// The version gate is what stops a pre-v4 consumer from being handed a field it will ignore and
+		// then re-deriving the same fact by parsing `reason` — a quietly wrong answer. Pinned separately
+		// from the pairing narrow above so removing or inverting the boundary cannot regress unnoticed.
+		const withCause = (schemaVersion: string) => {
+			const run = structuredClone(validRun);
+			run.schemaVersion = schemaVersion;
+			const provider = run.providers[0] as Record<string, unknown>;
+			provider.gaps = [
+				{
+					scope: "suite",
+					id: "disk",
+					outcome: "skipped",
+					reason: "x",
+					cause: { kind: "disk-shortfall", freeGb: 20, requiredGb: 30 },
+				},
+			];
+			return run;
+		};
+		for (const schemaVersion of ["2", "3"]) {
+			expect(() => parseRun(withCause(schemaVersion))).toThrow(
+				/v4-or-later Run when a ResultGap carries a structured cause/,
+			);
+		}
+		expect(parseRun(withCause("4")).providers[0]?.gaps[0]?.cause?.kind).toBe("disk-shortfall");
+	});
+
+	it("rejects a cause whose own numbers contradict it", () => {
+		// A structured diagnosis that disagrees with itself is worse than an absent one: consumers stopped
+		// re-reading the prose precisely because they trust this field.
+		const withCause = (cause: Record<string, unknown>, outcome = "skipped") => {
+			const run = structuredClone(validRun);
+			run.schemaVersion = "4";
+			const provider = run.providers[0] as Record<string, unknown>;
+			provider.gaps = [{ scope: "suite", id: "disk", outcome, reason: "x", cause }];
+			return run;
+		};
+		// A shortfall that is not short — the suite would have fit, so nothing was refused.
+		expect(() =>
+			parseRun(withCause({ kind: "disk-shortfall", freeGb: 30, requiredGb: 30 })),
+		).toThrow(/disk shortfall whose freeGb is below requiredGb/);
+		// A "failed" step that exited cleanly.
+		expect(() =>
+			parseRun(withCause({ kind: "step-failed", step: "s", exitCode: 0 }, "failed")),
+		).toThrow(/failed step whose exitCode is non-zero/);
+		// An absent exitCode stays legal — the producer may not have one to report.
+		expect(
+			parseRun(withCause({ kind: "step-failed", step: "s" }, "failed")).providers[0]?.gaps[0]?.cause
+				?.kind,
+		).toBe("step-failed");
+	});
+
+	it("keeps unsupported-operation scoped to an operation", () => {
+		// On a suite the cause would read as "this provider cannot run this benchmark at all" — a much
+		// larger claim than the producer made, which only ever says one SDK call is missing.
+		const withScope = (scope: string) => {
+			const run = structuredClone(validRun);
+			run.schemaVersion = "4";
+			const provider = run.providers[0] as Record<string, unknown>;
+			provider.gaps = [
+				{
+					scope,
+					id: scope === "suite" ? "disk" : "sandbox_snapshot_ms",
+					outcome: "skipped",
+					reason: "x",
+					cause: { kind: "unsupported-operation", detail: "no snapshot op" },
+				},
+			];
+			return run;
+		};
+		expect(() => parseRun(withScope("suite"))).toThrow(
+			/operation-scoped gap when its cause is "unsupported-operation"/,
+		);
+		expect(parseRun(withScope("operation")).providers[0]?.gaps[0]?.cause?.kind).toBe(
+			"unsupported-operation",
+		);
+		// measurement-disabled is deliberately NOT coupled to a scope: turning a whole suite off is a
+		// choice we could legitimately make, so pinning it would invent a rule rather than record one.
+		const suiteDisabled = structuredClone(validRun);
+		suiteDisabled.schemaVersion = "4";
+		const provider = suiteDisabled.providers[0] as Record<string, unknown>;
+		provider.gaps = [
+			{
+				scope: "suite",
+				id: "disk",
+				outcome: "skipped",
+				reason: "x",
+				cause: { kind: "measurement-disabled" },
+			},
+		];
+		expect(parseRun(suiteDisabled).providers[0]?.gaps[0]?.cause?.kind).toBe("measurement-disabled");
+	});
+
 	it("rejects an unknown schemaVersion", () => {
 		expect(() => parseRun({ ...validRun, schemaVersion: "1" })).toThrow();
-		expect(() => parseRun({ ...validRun, schemaVersion: "4" })).toThrow();
+		expect(() => parseRun({ ...validRun, schemaVersion: "5" })).toThrow();
 	});
 
 	it("accepts a v3 Metric carrying a consistent replicate breakdown", () => {

--- a/packages/schema/src/run.test.ts
+++ b/packages/schema/src/run.test.ts
@@ -156,6 +156,19 @@ describe("Run schema", () => {
 			parseRun(withCause({ kind: "step-failed", step: "s" }, "failed")).providers[0]?.gaps[0]?.cause
 				?.kind,
 		).toBe("step-failed");
+		// More metrics unrecorded than the suite ever declared — the unrecorded ones are by definition a
+		// subset of the declared ones, so a count above `declared` describes metrics that do not exist.
+		expect(() =>
+			parseRun(
+				withCause({ kind: "metrics-unrecorded", metricIds: ["a", "b"], declared: 1 }, "failed"),
+			),
+		).toThrow(/unrecorded metrics that are a subset of the declared ones/);
+		// All of them unrecorded is the ordinary total-miss case, not a contradiction.
+		expect(
+			parseRun(
+				withCause({ kind: "metrics-unrecorded", metricIds: ["a", "b"], declared: 2 }, "failed"),
+			).providers[0]?.gaps[0]?.cause?.kind,
+		).toBe("metrics-unrecorded");
 	});
 
 	it("keeps unsupported-operation scoped to an operation", () => {

--- a/packages/schema/src/run.ts
+++ b/packages/schema/src/run.ts
@@ -217,6 +217,87 @@ export const gapOutcomeSchema = type("'skipped' | 'failed'");
 export type GapOutcome = typeof gapOutcomeSchema.infer;
 
 /**
+ * WHY a benchmark produced no result, as data rather than prose.
+ *
+ * `reason` beside this is a human sentence, and for a long time it was also the machine interface:
+ * the leaderboard decided whether a skip was a disk shortfall with `/^insufficient disk/i` against a
+ * string authored in another package, a coupling its own comment had to warn about. Every question
+ * past that regex — how many GiB short, which step timed out and after how long, which declared
+ * metrics never recorded — was answerable only by re-parsing English that no test pinned.
+ *
+ * The taxonomy is closed and there is deliberately NO catch-all arm. A producer that cannot classify
+ * a gap omits `cause` entirely, which reads as "unclassified" and cannot be mistaken for a diagnosis;
+ * an `other` kind would let genuinely different failures accumulate behind one label that consumers
+ * would then have to re-parse `reason` to tell apart, reintroducing exactly what this replaces.
+ */
+export const gapCauseSchema = type({
+	// A precondition refused the suite: the sandbox had less free disk than `Suite.minDiskGb`.
+	kind: "'disk-shortfall'",
+	freeGb: "number >= 0",
+	requiredGb: "number > 0",
+})
+	// The provider's credentials were not present in the environment, so nothing was attempted.
+	.or({ kind: "'missing-credentials'", variables: "string[] >= 1" })
+	// `sandbox.create` never returned a usable sandbox (quota, region, provider-side error).
+	.or({ kind: "'sandbox-create-failed'", "detail?": "string" })
+	// The sandbox stopped answering mid-step — distinct from a step that ran and failed.
+	.or({
+		kind: "'sandbox-lost'",
+		step: "string >= 1",
+		"consecutivePollFailures?": "number.integer >= 1",
+	})
+	// A step exceeded its own budget. `timeoutSeconds` is the budget, not the elapsed time.
+	.or({ kind: "'step-timeout'", step: "string >= 1", timeoutSeconds: "number > 0" })
+	// A step ran to completion and exited non-zero.
+	.or({ kind: "'step-failed'", step: "string >= 1", "exitCode?": "number.integer" })
+	// The suite ran, but these declared metrics never recorded a value on any trial.
+	.or({ kind: "'metrics-unrecorded'", metricIds: "string[] >= 1", declared: "number.integer >= 1" })
+	// PTS's duplicate-value dedup dropped a result whose value collided with its twin's.
+	.or({ kind: "'duplicate-value-dedup'", metricIds: "string[] >= 1" })
+	// A lifecycle operation the provider's SDK does not expose (`scope: "operation"` skips).
+	.or({ kind: "'unsupported-operation'", "detail?": "string" })
+	// The run was configured not to measure this — a choice we made, never a provider limitation. Kept
+	// distinct from `unsupported-operation` precisely because collapsing them would let a config toggle
+	// read as a capability the provider lacks.
+	.or({ kind: "'measurement-disabled'", "detail?": "string" })
+	.narrow((cause, ctx) => {
+		// The arms carry numbers whose MEANING constrains them beyond their type, and a structured
+		// diagnosis that contradicts itself is worse than an absent one: a consumer trusts this field
+		// precisely because it stopped re-reading prose. Both invariants already hold at every producer
+		// (the disk precondition only fires below the threshold, and a step is only "failed" on a
+		// non-zero exit), so this pins them at the boundary for hand-edited and future producers.
+		if (cause.kind === "disk-shortfall" && cause.freeGb >= cause.requiredGb) {
+			return ctx.mustBe("a disk shortfall whose freeGb is below requiredGb");
+		}
+		if (cause.kind === "step-failed" && cause.exitCode === 0) {
+			return ctx.mustBe("a failed step whose exitCode is non-zero");
+		}
+		return true;
+	});
+export type GapCause = typeof gapCauseSchema.infer;
+
+/**
+ * The causes that describe a PRECONDITION refusing a benchmark, as opposed to one that was attempted and
+ * broke — the {@link GapOutcome} partition of {@link gapCauseSchema}, stated next to the taxonomy it
+ * partitions rather than buried in the narrow that enforces it (and allocated once, not per parsed gap).
+ */
+const SKIP_CAUSE_KINDS: ReadonlySet<GapCause["kind"]> = new Set<GapCause["kind"]>([
+	"disk-shortfall",
+	"missing-credentials",
+	"unsupported-operation",
+	"measurement-disabled",
+]);
+
+/**
+ * Which {@link GapOutcome} a cause belongs to — the partition above, exposed so a producer can CHECK the
+ * pairing before building a gap instead of discovering it as a parse failure. `resultGapSchema` is the
+ * enforcement; this is how a caller stays on the right side of it (see `parseGapMarker`).
+ */
+export function gapOutcomeOfCause(cause: GapCause): GapOutcome {
+	return SKIP_CAUSE_KINDS.has(cause.kind) ? "skipped" : "failed";
+}
+
+/**
  * One benchmark that produced no result for a provider, and why — the recorded half of a coverage
  * gap. The DERIVED half (a suite that ran elsewhere in the Run but never reported here at all, with
  * no marker of any kind) cannot live on a ProviderRun: it is a cross-provider fact, so the
@@ -228,8 +309,38 @@ export const resultGapSchema = type({
 	/** The suite name (`scope: "suite"`) or the harness Metric id (`scope: "operation"`). */
 	id: "string",
 	outcome: gapOutcomeSchema,
-	/** The producer's verbatim explanation — a disk shortfall's numbers, or the error's message. */
+	/**
+	 * The producer's human explanation. Still authored, still the thing a reader reads — but no longer
+	 * the machine interface: consumers branch on {@link ResultGap.cause}, and this is free to be prose.
+	 */
 	reason: "string",
+	/**
+	 * The same failure as structured data (v4+). Absent means the producer did not classify it — an
+	 * older Run, or a failure mode the taxonomy has no arm for. Never infer a cause by parsing `reason`
+	 * when this is absent: guessing produces a confident label for an unclassified event.
+	 */
+	"cause?": gapCauseSchema,
+}).narrow((gap, ctx) => {
+	// A skip and a failure are different facts (see gapOutcomeSchema), and so are their causes. Pinning
+	// the pairing here stops a producer from recording a crash as a skip — or a precondition as a
+	// failure — via the cause while the outcome says otherwise, which would make the two disagree
+	// inside one gap and leave a consumer to pick a side.
+	if (gap.cause === undefined) return true;
+	const causeOutcome = gapOutcomeOfCause(gap.cause);
+	if (causeOutcome !== gap.outcome) {
+		return ctx.mustBe(
+			`a ${gap.outcome} gap whose cause describes one (got "${gap.cause.kind}", a ${causeOutcome} cause)`,
+		);
+	}
+	// `unsupported-operation` names a call the provider's SDK does not expose, which is a statement
+	// about ONE lifecycle operation — the scope its own doc gives it. On a suite it would read as
+	// "this provider cannot run this benchmark at all", a much larger claim than the producer made.
+	// Only this arm is pinned: `measurement-disabled` is a choice we make and could legitimately turn
+	// off a whole suite one day, so coupling it to a scope would be inventing a rule, not recording one.
+	if (gap.cause.kind === "unsupported-operation" && gap.scope !== "operation") {
+		return ctx.mustBe('an operation-scoped gap when its cause is "unsupported-operation"');
+	}
+	return true;
 });
 export type ResultGap = typeof resultGapSchema.infer;
 
@@ -314,17 +425,23 @@ export function providerStatusText(p: ProviderRun): string {
 /**
  * A full benchmark Run: every provider measured against one pinned target spec at one SHA.
  *
- * `schemaVersion` accepts `"2"` and `"3"`. v1's `skips: { suite, reason }[]` could not say whether a
- * benchmark was deliberately not run or had crashed, and carried no positive record of what DID run —
- * so a suite that vanished (job died, artifact never uploaded) left no trace anywhere in the document.
- * v2 replaced it with {@link resultGapSchema} + {@link ProviderRun.suitesCovered}. v3 adds the
- * replicate model: a shard Run carries its {@link replicateIndex}, and the aggregate folds ≥2
- * replicate sandboxes of one (provider, suite) into {@link MetricResult.replicates}. Both versions
- * validate here — already-published v2 Runs (single replicate, no `replicates` field) are read
- * unchanged, and the parser never migrates them in place.
+ * `schemaVersion` accepts `"2"` through `"4"`. v1's `skips: { suite, reason }[]` could not say
+ * whether a benchmark was deliberately not run or had crashed, and carried no positive record of what
+ * DID run — so a suite that vanished (job died, artifact never uploaded) left no trace anywhere in the
+ * document. v2 replaced it with {@link resultGapSchema} + {@link ProviderRun.suitesCovered}. v3 adds
+ * the replicate model: a shard Run carries its {@link replicateIndex}, and the aggregate folds ≥2
+ * replicate sandboxes of one (provider, suite) into {@link MetricResult.replicates}.
+ *
+ * v4 makes the document SELF-DESCRIBING — every fact a reader needs is expressible from the file,
+ * rather than recoverable only by knowing something the file does not say. The first of those facts:
+ *
+ *  - {@link ResultGap.cause} classifies a failure as data rather than prose.
+ *
+ * Every version validates here — already-published Runs are read unchanged, and the parser never
+ * migrates them in place.
  */
 export const runSchema = type({
-	schemaVersion: "'2' | '3'",
+	schemaVersion: "'2' | '3' | '4'",
 	runId: "string",
 	sha: "string",
 	// ISO-8601 timestamp the Run was generated at — validated so the RunIndex sort key can't be a
@@ -338,18 +455,33 @@ export const runSchema = type({
 	targetSpec: targetSpecSchema,
 	providers: providerRunSchema.array(),
 }).narrow((run, ctx) => {
-	// The replicate fields (`replicateIndex`, `MetricResult.replicates`) are v3-only, so "v2 == the
+	// Version floors are compared NUMERICALLY, not by equality: a field introduced at v3 stays legal at
+	// v4 and beyond, so "=== '3'" would have made every version bump retroactively reject the previous
+	// version's own fields (the v4 aggregate below carries folded `replicates`).
+	const version = Number(run.schemaVersion);
+	// The replicate fields (`replicateIndex`, `MetricResult.replicates`) are v3-or-later, so "v2 == the
 	// pre-replicate schema" stays a real guarantee: a producer that writes a replicate field but forgets
 	// to bump schemaVersion is rejected here rather than silently read by a v3-gated consumer that then
 	// ignores the between-sandbox breakdown (reporting the anti-conservative pooled interval instead).
-	if (run.schemaVersion !== "3") {
+	if (version < 3) {
 		if (run.replicateIndex !== undefined) {
-			return ctx.mustBe("a v3 Run when it carries a replicateIndex");
+			return ctx.mustBe("a v3-or-later Run when it carries a replicateIndex");
 		}
 		if (
 			run.providers.some((provider) => provider.metrics.some((m) => m.replicates !== undefined))
 		) {
-			return ctx.mustBe("a v3 Run when a MetricResult carries replicates");
+			return ctx.mustBe("a v3-or-later Run when a MetricResult carries replicates");
+		}
+	}
+	// The v4 self-description fields. A pre-v4 consumer handed one would fall back to the pre-v4 reading
+	// of the same fact — here, re-parsing `reason` prose for a classification the document already
+	// carries — which is a quietly wrong answer, never a loud one. Reported by FIELD rather than as one
+	// blanket message, so the error names what to fix.
+	if (version < 4) {
+		for (const provider of run.providers) {
+			if (provider.gaps.some((gap) => gap.cause !== undefined)) {
+				return ctx.mustBe("a v4-or-later Run when a ResultGap carries a structured cause");
+			}
 		}
 	}
 	// `replicateIndex` marks a per-replicate SHARD (one sandbox, not yet folded); `MetricResult.replicates`

--- a/packages/schema/src/run.ts
+++ b/packages/schema/src/run.ts
@@ -263,14 +263,18 @@ export const gapCauseSchema = type({
 	.narrow((cause, ctx) => {
 		// The arms carry numbers whose MEANING constrains them beyond their type, and a structured
 		// diagnosis that contradicts itself is worse than an absent one: a consumer trusts this field
-		// precisely because it stopped re-reading prose. Both invariants already hold at every producer
-		// (the disk precondition only fires below the threshold, and a step is only "failed" on a
-		// non-zero exit), so this pins them at the boundary for hand-edited and future producers.
+		// precisely because it stopped re-reading prose. Every invariant here already holds at each
+		// producer (the disk precondition only fires below the threshold, a step is only "failed" on a
+		// non-zero exit, and the unrecorded metrics are a subset of the declared ones), so this pins
+		// them at the boundary for hand-edited and future producers.
 		if (cause.kind === "disk-shortfall" && cause.freeGb >= cause.requiredGb) {
 			return ctx.mustBe("a disk shortfall whose freeGb is below requiredGb");
 		}
 		if (cause.kind === "step-failed" && cause.exitCode === 0) {
 			return ctx.mustBe("a failed step whose exitCode is non-zero");
+		}
+		if (cause.kind === "metrics-unrecorded" && cause.metricIds.length > cause.declared) {
+			return ctx.mustBe("unrecorded metrics that are a subset of the declared ones");
 		}
 		return true;
 	});


### PR DESCRIPTION
**RUN SCHEMA v4 — make the benchmark dataset self-describing**
Shipped as an 8-PR stack (merge bottom-up, each branch independently green):

1. #292 — schema: open Run v4 (numeric version floors) + the closed `GapCause` taxonomy
2. #293 — schema: carry a gap's cause on its on-disk marker
3. #294 — harness: `GapError` — classify a failure at the site that knows it
4. #295 — results: author causes in the normalizer, read them in the leaderboard
5. #296 — schema: `MetricResult.derived` — mark a computed row in the document
6. #297 — schema: `ObservedMixtures`, the replicate→machine join, per-machine verdicts
7. #298 — results: build the counted mixtures and fold host records onto them
8. #299 — results: aggregate onto the mixtures instead of onto shard order

↑ **This PR is #292 (1/8)**, based on `main`.

---

`ResultGap.reason` was the human explanation and the machine interface at once: the
leaderboard decided whether a skip was a disk shortfall with `/^insufficient disk/i`
against a string authored in another package, a coupling its own comment had to warn
about. Every question past that regex — how many GiB short, which step timed out and
after how long — was answerable only by re-parsing English that no test pinned.

`GapCause` records the same failure as data: a closed discriminated union with
deliberately NO catch-all arm, so a producer that cannot classify a gap omits `cause`,
and "unclassified" can never be mistaken for a diagnosis. A narrow pins each cause to
the outcome half it belongs to — `gapOutcomeOfCause` is that partition, exported so a
producer can CHECK the pairing instead of discovering it as a parse failure — so a
crash cannot be filed as a precondition, or a precondition as a crash.

Two things ride along because they are what makes v4 admissible at all:

  * Version floors now compare NUMERICALLY. An `=== '3'` gate would make every future
    bump retroactively reject its predecessor's own fields, and a v4 document still
    carries the v3 replicate fold.

  * Both Run producers stamp `schemaVersion: "4"` here, BEFORE any v4 field flows
    through them. `runSchema` gates each v4 field at v4-or-later, so a producer that
    starts emitting causes while still stamping "3" fails `parseRun` at its own
    boundary. Bumping the stamp first means no merge point of this stack has that
    window.

Nothing emits a cause yet — the harness and the normalizer author them further up the
stack. Already-published v2/v3 Runs parse unchanged.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Introduce Run schema v4 with structured `ResultGap.cause`, numeric version floors, and stricter invariants. Producers now stamp `schemaVersion: "4"`; gaps are machine‑readable while v2/v3 Runs remain valid.

- **New Features**
  - `ResultGap.cause`: closed union classifying gaps; v4‑only (pre‑v4 Runs reject a `cause`).
  - Guardrails: enforce cause/outcome match; require `freeGb < requiredGb` for `disk-shortfall`; reject `exitCode: 0` for `step-failed`; require `metrics-unrecorded.metricIds.length <= declared`; restrict `unsupported-operation` to `operation` scope.
  - Exported `gapOutcomeOfCause` for producer pre‑checks.
  - `schemaVersion` accepts "2"–"4"; floors compare numerically so v3 fields remain legal at v4 (replicate fold preserved).

- **Migration**
  - Consumers should accept v4; v2/v3 files parse unchanged.
  - Prefer structured `cause` over parsing `reason` when present.
  - Gate by numeric floors (e.g., >=3 for replicates, >=4 for `cause`).
  - `packages/results` now stamps `"4"` in shards and aggregates; no causes are emitted yet.

<sup>Written for commit aaa2339c7dd55b4b5bb914f94e56d6a5aa8e9cc8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/starslingdev/hpc-sandbox-benchmarks/pull/292?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added/confirmed schema version 4 support for run/result data, including version-floor behavior during aggregation.
  - Enabled stricter structured gap cause handling with standardized taxonomy and outcome matching.

- **Bug Fixes**
  - Updated normalization and aggregation to consistently emit and validate schemaVersion 4.
  - Strengthened v4 validation for `metrics-unrecorded` (unrecorded metric IDs must be a subset of declared metrics) and improved gap cause/outcome and scoping enforcement.

- **Tests**
  - Expanded schema boundary and validation coverage across versions 2–4, including replicate merging and new gap/cause cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
