### PR TITLE
feat(schema): carry a gap's cause on its on-disk marker

### DIFF
--- a/packages/schema/src/raw-files.test.ts
+++ b/packages/schema/src/raw-files.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "bun:test";
-import type { ProviderRun } from "./index.ts";
+import type { ProviderRun, ResultGap } from "./index.ts";
 import {
 	aggregate,
 	harnessGapMarkerJson,
@@ -171,6 +171,98 @@ describe("parseGapMarker", () => {
 			reason:
 				"PTS batch-run of pts/fio-2.1.0 completed but every trial errored (composite carries no values)",
 		});
+	});
+
+	it("drops an unparsable cause, keeping the gap — a newer producer must not erase one", () => {
+		// The raw tree is re-normalized retroactively, so this build reads markers written by builds it
+		// does not control. If an uninterpretable `cause` failed the whole body, `parseGapMarker` would
+		// answer `undefined` and the gap would vanish — a benchmark that reads as never attempted, which
+		// is strictly worse than one recorded without a diagnosis.
+		const unclassified: ResultGap = {
+			scope: "suite",
+			id: "cpu-node",
+			outcome: "skipped",
+			reason: "Insufficient disk: 3.0 GiB free, suite needs 20 GiB",
+		};
+		const body = (cause: unknown) => ({
+			outcome: "skipped",
+			suite: "cpu-node",
+			reason: "Insufficient disk: 3.0 GiB free, suite needs 20 GiB",
+			cause,
+		});
+		// A kind from a future taxonomy this build has no arm for.
+		expect(
+			parseGapMarker(
+				"sandbox-daytona-cpu-node--skipped.json",
+				body({ kind: "quota-exceeded" }),
+				"daytona",
+			),
+		).toEqual(unclassified);
+		// A known kind whose payload is malformed (a shortfall that is not short).
+		expect(
+			parseGapMarker(
+				"sandbox-daytona-cpu-node--skipped.json",
+				body({ kind: "disk-shortfall", freeGb: 30, requiredGb: 20 }),
+				"daytona",
+			),
+		).toEqual(unclassified);
+		// Outright garbage in the field.
+		expect(
+			parseGapMarker("sandbox-daytona-cpu-node--skipped.json", body("disk"), "daytona"),
+		).toEqual(unclassified);
+	});
+
+	it("drops a cause from the wrong side of the skip/failure partition, keeping the gap", () => {
+		// Unlike a contradicting `outcome`, a contradicting cause leaves the outcome knowable (the
+		// filename said it), so only the classification is lost. Keeping it would fail resultGapSchema's
+		// narrow — and a Run parses whole, so one bad marker would take the entire Run down.
+		const marker = parseGapMarker(
+			"sandbox-daytona-cpu-node--skipped.json",
+			{
+				outcome: "skipped",
+				suite: "cpu-node",
+				reason: "Missing credentials",
+				cause: { kind: "step-timeout", step: "install", timeoutSeconds: 600 },
+			},
+			"daytona",
+		);
+		expect(marker).toEqual({
+			scope: "suite",
+			id: "cpu-node",
+			outcome: "skipped",
+			reason: "Missing credentials",
+		});
+		// A coherent pairing survives.
+		expect(
+			parseGapMarker(
+				"sandbox-daytona-cpu-node--skipped.json",
+				{
+					suite: "cpu-node",
+					reason: "no creds",
+					cause: { kind: "missing-credentials", variables: ["E2B_API_KEY"] },
+				},
+				"daytona",
+			)?.cause,
+		).toEqual({ kind: "missing-credentials", variables: ["E2B_API_KEY"] });
+	});
+
+	it("never writes a marker whose cause contradicts its outcome", () => {
+		// The same rule on the producer side, so the bytes in a CI artifact are self-consistent and a
+		// human reading one does not have to know which half the reader believes.
+		const bytes = harnessGapMarkerJson("daytona", "cpu-node", "skipped", "Missing credentials", {
+			kind: "step-failed",
+			step: "install",
+			exitCode: 1,
+		});
+		expect(JSON.parse(bytes).cause).toBeUndefined();
+		expect(
+			JSON.parse(
+				harnessGapMarkerJson("daytona", "cpu-node", "skipped", "Missing credentials", {
+					kind: "missing-credentials",
+					variables: ["E2B_API_KEY"],
+				}),
+			).cause,
+		).toEqual({ kind: "missing-credentials", variables: ["E2B_API_KEY"] });
 	});
 
 	it("rejects the fail_result body under a --skipped.json filename (suffix/body contradiction)", () => {

--- a/packages/schema/src/raw-files.ts
+++ b/packages/schema/src/raw-files.ts
@@ -25,8 +25,8 @@
  * lifecycle timing files (`<name>_ms.txt`, `<name>-exit-code.txt`) land with the lifecycle path.
  */
 import { type } from "arktype";
-import type { GapOutcome, ResultGap } from "./run.ts";
-import { gapOutcomeSchema } from "./run.ts";
+import type { GapCause, GapOutcome, ResultGap } from "./run.ts";
+import { gapCauseSchema, gapOutcomeOfCause, gapOutcomeSchema } from "./run.ts";
 
 const SKIP_SUFFIX = "--skipped.json";
 const FAILURE_SUFFIX = "--failed.json";
@@ -120,8 +120,23 @@ export function harnessGapMarkerJson(
 	suite: string,
 	outcome: GapOutcome,
 	reason: string,
+	cause?: GapCause,
 ): string {
-	return `${JSON.stringify({ provider, suite, outcome, reason }, null, 2)}\n`;
+	// `cause` is written last and omitted when absent, so a marker from a producer that could not
+	// classify the failure is byte-identical to what the pre-cause harness wrote — the field's presence
+	// means "classified", never "this build knows about causes".
+	return `${JSON.stringify({ provider, suite, outcome, reason, ...matchingCause(cause, outcome) }, null, 2)}\n`;
+}
+
+/**
+ * The marker's `cause` field — present only when the classification sits on the same side of the
+ * skip/failure partition as the outcome. Applied on BOTH sides of the file: the writer never emits a
+ * self-contradictory marker (a human reading one out of a CI artifact should not have to know which half
+ * to believe), and the reader drops one anyway, because a marker on disk may have been written by a
+ * build this one does not control.
+ */
+function matchingCause(cause: GapCause | undefined, outcome: GapOutcome): { cause?: GapCause } {
+	return cause !== undefined && gapOutcomeOfCause(cause) === outcome ? { cause } : {};
 }
 
 /**
@@ -169,6 +184,17 @@ const gapMarkerBody = type({
 	"benchmark?": "string",
 	"reason?": "string",
 	"skip_reason?": "string",
+	// The structured classification, when the producing harness could make one. Optional forever: every
+	// already-written marker predates it, and a producer that cannot classify a failure must be able to
+	// stay silent rather than invent a label.
+	//
+	// Typed `unknown` and validated separately below, NOT as `gapCauseSchema` inline: a body schema that
+	// embeds the taxonomy makes an unparsable cause fail the WHOLE body, and `parseGapMarker` answers a
+	// failed body with `undefined` — which drops the gap itself. That is the outcome the rules below
+	// exist to prevent, arrived at through the type system instead of through a partition mistake. A
+	// marker written by a newer harness (a cause kind this build has no arm for) is exactly the case:
+	// its gap is still perfectly knowable from the filename and `reason`.
+	"cause?": "unknown",
 }).pipe((d) => ({
 	outcome: d.outcome,
 	// `|| undefined` (not `??`) so an empty-string `suite`/`benchmark` is treated as absent — suite is
@@ -176,7 +202,21 @@ const gapMarkerBody = type({
 	// `parseGapMarker`, exactly as a missing field does (mirrors `suiteFromGapMarkerFilename`).
 	suite: d.suite || d.benchmark || undefined,
 	reason: d.reason ?? d.skip_reason ?? "unknown",
+	cause: parsedCause(d.cause),
 }));
+
+/**
+ * A marker's `cause` if it is one this build understands, and undefined otherwise — never an error.
+ *
+ * "Unclassified" is a shape the schema accepts, so an uninterpretable classification costs only the
+ * classification. Refusing it would cost the gap, and a lost gap is a benchmark that reads as though it
+ * was never attempted — strictly worse than one recorded without a diagnosis.
+ */
+function parsedCause(cause: unknown): GapCause | undefined {
+	if (cause === undefined) return undefined;
+	const parsed = gapCauseSchema(cause);
+	return parsed instanceof type.errors ? undefined : parsed;
+}
 
 /**
  * Parse a `*--skipped.json` / `*--failed.json` body into a suite-scoped {@link ResultGap}.
@@ -186,6 +226,13 @@ const gapMarkerBody = type({
  * than resolved by precedence: a marker whose two halves disagree is corrupt, and guessing which half
  * to believe is how a crashed suite comes to be published as a deliberate skip. Undefined for any
  * filename outside the naming contract, whatever the body claims.
+ *
+ * A `cause` this build cannot use is DROPPED, never escalated — whether it sits on the wrong side of the
+ * skip/failure partition ({@link matchingCause}) or does not parse at all ({@link parsedCause}). Unlike a
+ * contradicting `outcome`, neither leaves the outcome in doubt: the filename said it, so only the
+ * CLASSIFICATION is untrustworthy, and "unclassified" is a shape the schema already accepts. Refusing
+ * either would make `resultGapSchema`'s narrow reject the gap — and since a Run parses as a whole, one
+ * mislabelled marker in one provider's directory would take the entire Run's normalization down with it.
  */
 export function parseGapMarker(
 	filename: string,
@@ -206,6 +253,7 @@ export function parseGapMarker(
 		id: body.suite ?? suiteFromGapMarkerFilename(filename, providerId) ?? filename,
 		outcome,
 		reason: body.reason,
+		...matchingCause(body.cause, outcome),
 	};
 }
 


### PR DESCRIPTION
**RUN SCHEMA v4 — make the benchmark dataset self-describing**
Shipped as an 8-PR stack (merge bottom-up, each branch independently green):

1. #292 — schema: open Run v4 (numeric version floors) + the closed `GapCause` taxonomy
2. #293 — schema: carry a gap's cause on its on-disk marker
3. #294 — harness: `GapError` — classify a failure at the site that knows it
4. #295 — results: author causes in the normalizer, read them in the leaderboard
5. #296 — schema: `MetricResult.derived` — mark a computed row in the document
6. #297 — schema: `ObservedMixtures`, the replicate→machine join, per-machine verdicts
7. #298 — results: build the counted mixtures and fold host records onto them
8. #299 — results: aggregate onto the mixtures instead of onto shard order

↑ **This PR is #293 (2/8)**, based on #292.

---

The classification is authored in the sandbox and read back in the normalizer, and the
only thing that crosses that boundary is the `--skipped.json`/`--failed.json` marker
file. `harnessGapMarkerJson` now takes an optional `GapCause` and `parseGapMarker`
returns it, so what the producer knew survives the trip instead of being re-derived
from prose one package away.

Written last and omitted when absent, so a marker from a producer that could not
classify the failure is byte-identical to what the pre-cause harness wrote: the field's
presence means "classified", never "this build knows about causes".

One predicate, `matchingCause`, guards BOTH sides of the file. The writer never emits a
marker whose cause sits on the wrong side of the skip/failure partition — a human
reading one out of a CI artifact should not have to know which half to believe — and the
reader drops a contradicting cause anyway, because a marker on disk may have been
written by a build this one does not control. Dropping rather than escalating is
deliberate: the filename still decides the outcome, so only the CLASSIFICATION is
untrustworthy, and "unclassified" is a shape the schema accepts. Keeping it would make
`resultGapSchema`'s narrow reject the gap, and since a Run parses as a whole, one
mislabelled marker in one provider's directory would take the entire Run's
normalization down with it.

Nothing writes a cause into a marker yet; the harness does that in the next PR.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Persist gap causes in `--skipped.json`/`--failed.json` so the producer’s classification reaches the normalizer. Invalid or wrong-side causes are ignored to keep files consistent and to never lose a gap.

- **New Features**
  - `harnessGapMarkerJson` accepts an optional `GapCause`; writes `cause` last and only when it matches `outcome` (otherwise omitted).
  - `parseGapMarker` returns `cause` when valid; the filename still decides `outcome`.
  - Shared `matchingCause` applies on write and read to enforce the same rule.

- **Bug Fixes**
  - Never drop a gap due to an unreadable `cause`: the body’s `cause` is `unknown` and validated via `parsedCause`/`gapCauseSchema`; unparsable kinds, malformed payloads, or wrong-side causes are ignored.
  - Tests cover ignoring unparsable/contradicting causes and ensuring the writer omits mismatched causes.

<sup>Written for commit b8893f981ed6c75a78381158685b24712c6015af. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/starslingdev/hpc-sandbox-benchmarks/pull/293?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

