### PR TITLE
feat(harness): classify a failure where it happens

### DIFF
--- a/packages/harness/src/index.test.ts
+++ b/packages/harness/src/index.test.ts
@@ -438,6 +438,12 @@ describe("createSuiteSandbox (creation-failure marker)", () => {
 			suite: "cpu-node",
 			outcome: "failed",
 			reason: "Failed to create sandbox: Snapshot toolchain-v3-container is not available",
+			// The classification the thrower knew, carried into the marker so consumers need not
+			// re-read the sentence above to learn it was a creation failure.
+			cause: {
+				kind: "sandbox-create-failed",
+				detail: "Snapshot toolchain-v3-container is not available",
+			},
 		});
 	});
 
@@ -456,6 +462,12 @@ describe("createSuiteSandbox (creation-failure marker)", () => {
 			suite: "cpu-node",
 			outcome: "failed",
 			reason: "Failed to create sandbox: provider config invalid: DAYTONA_REGION unset",
+			// The classification the thrower knew, carried into the marker so consumers need not
+			// re-read the sentence above to learn it was a creation failure.
+			cause: {
+				kind: "sandbox-create-failed",
+				detail: "provider config invalid: DAYTONA_REGION unset",
+			},
 		});
 	});
 
@@ -497,6 +509,9 @@ describe("createSuiteSandbox (creation-failure marker)", () => {
 			id: "cpu-node",
 			outcome: "failed",
 			reason: "Failed to create sandbox: boom",
+			// The classification the thrower knew, carried into the marker so consumers need not
+			// re-read the sentence above to learn it was a creation failure.
+			cause: { kind: "sandbox-create-failed", detail: "boom" },
 		});
 	});
 });

--- a/packages/harness/src/index.ts
+++ b/packages/harness/src/index.ts
@@ -8,6 +8,7 @@ import { HARNESS_METRIC_IDS, isPtsResultFile, SUITES } from "@sandbox-benchmarks
 import { collectResults, writeGapMarker } from "./lib/collect.ts";
 import type { SandboxHandle } from "./lib/execute.ts";
 import { MIN, resolvePtsPassPolicy, StepRunner, withTimeout } from "./lib/execute.ts";
+import { gapCauseOf } from "./lib/gap-cause.ts";
 import { time } from "./lib/internal.ts";
 import type { LifecycleAggregate, LifecycleCompute } from "./lib/lifecycle.ts";
 import { aggregateLifecycle, measureLifecycle } from "./lib/lifecycle.ts";
@@ -200,7 +201,10 @@ export async function runSuite(options: RunSuiteOptions): Promise<void> {
 	if (missingVars.length > 0) {
 		const reason = `Missing credentials: ${missingVars.join(", ")}`;
 		console.log(`SKIPPED ${providerName}/${suiteName}: ${reason}`);
-		writeGapMarker(resultsDir, providerName, suiteName, "skipped", reason);
+		writeGapMarker(resultsDir, providerName, suiteName, "skipped", reason, {
+			kind: "missing-credentials",
+			variables: missingVars,
+		});
 		return;
 	}
 
@@ -331,6 +335,7 @@ export async function createSuiteSandbox(
 						suiteName,
 						"failed",
 						`${CREATE_FAILURE_PREFIX}${message}`,
+						{ kind: "sandbox-create-failed", detail: message },
 					);
 				} catch (markerErr) {
 					console.error(
@@ -339,6 +344,10 @@ export async function createSuiteSandbox(
 						}); the sandbox-creation error below is unaffected`,
 					);
 				}
+				// The ORIGINAL error propagates, unwrapped: bench-suite matches on the provider's own message
+				// and `createSuiteSandbox` is called outside `runSuiteOnSandbox`, so this throw never reaches
+				// the suite-level marker writer that reads a classification. The marker written just above
+				// already carries the cause as a plain value, which is the only place it is read.
 				throw err;
 			}
 			console.log(
@@ -427,7 +436,11 @@ export async function runSuiteOnSandbox(
 			if (freeGb < suite.minDiskGb) {
 				const reason = `Insufficient disk: ${freeGb.toFixed(1)} GiB free, suite needs ${suite.minDiskGb} GiB`;
 				console.log(`SKIPPED ${providerName}/${suiteName}: ${reason}`);
-				writeGapMarker(resultsDir, providerName, suiteName, "skipped", reason);
+				writeGapMarker(resultsDir, providerName, suiteName, "skipped", reason, {
+					kind: "disk-shortfall",
+					freeGb,
+					requiredGb: suite.minDiskGb,
+				});
 				return;
 			}
 		}
@@ -503,7 +516,10 @@ export async function runSuiteOnSandbox(
 		// The leaderboard still derives a `missing` gap when even this marker is lost (the artifact upload
 		// is itself best-effort), but a marker that survives says WHY, and that is the whole difference.
 		const reason = suiteError instanceof Error ? suiteError.message : String(suiteError);
-		writeGapMarker(resultsDir, providerName, suiteName, "failed", reason);
+		// The thrower classified it (a step timeout knows its budget, a lost sandbox knows its step);
+		// this frame only knows a message. `gapCauseOf` returns undefined for anything unclassified,
+		// which records the gap exactly as before rather than inventing a kind from the prose.
+		writeGapMarker(resultsDir, providerName, suiteName, "failed", reason, gapCauseOf(suiteError));
 		throw suiteError;
 	}
 	console.log(`\nDone: ${suiteName} on ${providerName}`);

--- a/packages/harness/src/lib/collect.ts
+++ b/packages/harness/src/lib/collect.ts
@@ -9,7 +9,7 @@ import { mkdirSync, readdirSync, writeFileSync } from "node:fs";
 import { cp, mkdir, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join, resolve } from "node:path";
-import type { GapOutcome } from "@sandbox-benchmarks/schema";
+import type { GapCause, GapOutcome } from "@sandbox-benchmarks/schema";
 import {
 	harnessGapMarkerJson,
 	isGapMarkerFile,
@@ -220,10 +220,13 @@ export function writeGapMarker(
 	suite: string,
 	outcome: GapOutcome,
 	reason: string,
+	// The structured classification, when the caller has one. A marker written without it is not
+	// downgraded — `reason` still says what happened — but nothing downstream will guess a kind for it.
+	cause?: GapCause,
 ): void {
 	mkdirSync(resultsDir, { recursive: true });
 	writeFileSync(
 		join(resultsDir, sandboxGapMarkerFile(provider, suite, outcome)),
-		harnessGapMarkerJson(provider, suite, outcome, reason),
+		harnessGapMarkerJson(provider, suite, outcome, reason, cause),
 	);
 }

--- a/packages/harness/src/lib/execute.ts
+++ b/packages/harness/src/lib/execute.ts
@@ -24,6 +24,7 @@
 
 import { randomUUID } from "node:crypto";
 import type { ProviderTransport } from "@sandbox-benchmarks/schema";
+import { GapError } from "./gap-cause.ts";
 
 export const MIN = 60_000;
 
@@ -149,18 +150,47 @@ function isUnsupportedFilesystem(err: unknown): boolean {
 }
 
 /** Race a promise against a timeout, clearing the timer either way. */
-export async function withTimeout<T>(promise: Promise<T>, ms: number, message: string): Promise<T> {
+export async function withTimeout<T>(
+	promise: Promise<T>,
+	ms: number,
+	// The message, or a factory for the error to reject with when the caller wants it classified. A
+	// factory rather than message+cause so the wording and its classification are built together and
+	// cannot describe different facts (see {@link stepTimeout}).
+	message: string | (() => Error),
+): Promise<T> {
 	let timer: ReturnType<typeof setTimeout> | undefined;
 	try {
 		return await Promise.race([
 			promise,
 			new Promise<never>((_, reject) => {
-				timer = setTimeout(() => reject(new Error(message)), ms);
+				timer = setTimeout(() => {
+					reject(typeof message === "string" ? new Error(message) : message());
+				}, ms);
 			}),
 		]);
 	} finally {
 		if (timer) clearTimeout(timer);
 	}
+}
+
+/**
+ * The step-timeout failure, worded and classified from one input.
+ *
+ * Both the synchronous and the detached step paths can time out, and each used to build the sentence and
+ * the cause itself — four copies of the same seconds rounding, and two chances for the prose and the
+ * data to disagree. This mirrors the `shortfallReason`/`shortfallCause` pairing the results package uses
+ * for the same reason.
+ */
+function stepTimeout(label: string, timeoutMs: number): GapError {
+	// Floored at 1: every real step budget is minute-scale, but `gapCauseSchema` requires
+	// `timeoutSeconds > 0`, and a sub-500ms budget would round to 0 — a cause the schema refuses,
+	// turning a timed-out step into a Run that cannot be normalized at all.
+	const timeoutSeconds = Math.max(1, Math.round(timeoutMs / 1000));
+	return new GapError(`Step "${label}" timed out after ${timeoutSeconds}s`, {
+		kind: "step-timeout",
+		step: label,
+		timeoutSeconds,
+	});
 }
 
 /** Single-quote a script for safe embedding in `bash -c '<script>'`. */
@@ -459,7 +489,7 @@ export class StepRunner {
 			result = await withTimeout(
 				this.sandbox.runCommand(`bash -c ${shellQuote(`${this.preamble}; ${script}`)}`),
 				timeoutMs,
-				`Step "${label}" timed out after ${Math.round(timeoutMs / 1000)}s`,
+				() => stepTimeout(label, timeoutMs),
 			);
 		} finally {
 			stopHeartbeat();
@@ -528,9 +558,10 @@ export class StepRunner {
 					consecutivePollFailures++;
 					if (consecutivePollFailures >= MAX_CONSECUTIVE_POLL_FAILURES) {
 						const reason = err instanceof Error ? err.message : String(err);
-						throw new Error(
+						throw new GapError(
 							`Step "${label}" lost its sandbox: ${consecutivePollFailures} consecutive detached ` +
 								`polls failed (last: ${reason}) — the sandbox stopped responding, not a quiet long step`,
+							{ kind: "sandbox-lost", step: label, consecutivePollFailures },
 						);
 					}
 				}
@@ -567,7 +598,7 @@ export class StepRunner {
 					} else if (tail) {
 						console.log(`--- last output from "${label}" before timeout ---\n${tail}`);
 					}
-					throw new Error(`Step "${label}" timed out after ${Math.round(timeoutMs / 1000)}s`);
+					throw stepTimeout(label, timeoutMs);
 				}
 				await this.sleep(pollDelayMs);
 				pollDelayMs = Math.min(pollDelayMs * POLL_BACKOFF, POLL_CAP_MS);
@@ -745,7 +776,11 @@ export class StepRunner {
 				const tail = result.stderr || result.stdout;
 				if (tail) process.stderr.write(tail.endsWith("\n") ? tail : `${tail}\n`);
 			}
-			throw new Error(`Step "${label}" failed with exit code ${result.exitCode}`);
+			throw new GapError(`Step "${label}" failed with exit code ${result.exitCode}`, {
+				kind: "step-failed",
+				step: label,
+				exitCode: result.exitCode,
+			});
 		}
 		return result;
 	}

--- a/packages/harness/src/lib/gap-cause.ts
+++ b/packages/harness/src/lib/gap-cause.ts
@@ -1,0 +1,37 @@
+/**
+ * Carry a {@link GapCause} on the Error that caused it, so the classification survives the throw.
+ *
+ * The harness knows exactly what went wrong at the point it throws — which step, which budget, which
+ * exit code — but that knowledge reaches the dataset through a marker written several frames up, and an
+ * Error carries nothing but a message. Downstream then re-derived the fact by matching prose. Making the
+ * cause part of the error's TYPE lets the marker writer record what the thrower actually knew.
+ *
+ * A class rather than a side-channel property on arbitrary errors: every failure classified here is one
+ * the harness constructs itself ({@link StepRunner}'s timeout, lost-sandbox and non-zero-exit paths), so
+ * there is no pass-through case to accommodate. An error arriving from a provider SDK is simply
+ * unclassified, and {@link gapCauseOf} says so — which is the honest answer rather than a label invented
+ * for it.
+ */
+import type { GapCause } from "@sandbox-benchmarks/schema";
+
+/** An error the harness raised with its failure already classified. */
+export class GapError extends Error {
+	readonly gapCause: GapCause;
+
+	constructor(message: string, gapCause: GapCause) {
+		super(message);
+		this.name = "GapError";
+		this.gapCause = gapCause;
+	}
+}
+
+/**
+ * The classification an error was thrown with, or undefined when it carries none.
+ *
+ * Undefined is the honest answer for an unclassified failure and must stay one: a caller that cannot
+ * read a cause records a gap without one, rather than guessing a kind from the message. Guessing would
+ * reintroduce prose-parsing at the exact boundary this exists to remove it from.
+ */
+export function gapCauseOf(error: unknown): GapCause | undefined {
+	return error instanceof GapError ? error.gapCause : undefined;
+}

--- a/packages/harness/src/lib/lifecycle.test.ts
+++ b/packages/harness/src/lib/lifecycle.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "bun:test";
-import type { RawRun, ResultGap } from "@sandbox-benchmarks/schema";
+import type { GapCause, RawRun, ResultGap } from "@sandbox-benchmarks/schema";
 import { HARNESS_METRIC_IDS } from "@sandbox-benchmarks/schema";
+import { GapError } from "./gap-cause.ts";
 import type { LifecycleCompute, LifecycleSandbox } from "./lifecycle.ts";
 import { aggregateLifecycle, measureLifecycle } from "./lifecycle.ts";
 
@@ -14,6 +15,8 @@ interface FakeOptions {
 	withList?: boolean;
 	failCreate?: boolean;
 	failExec?: boolean;
+	/** Make the measured exec throw a CLASSIFIED error, to check the cause survives the throw. */
+	failExecWithCause?: GapCause;
 	failInfo?: boolean;
 	failDestroy?: boolean;
 	failSnapshotCreate?: boolean;
@@ -49,6 +52,9 @@ function fakeCompute(opts: FakeOptions = {}): { compute: LifecycleCompute; calls
 				return {
 					exitCode: opts.notReadyFor && readinessProbes <= opts.notReadyFor ? 1 : 0,
 				};
+			}
+			if (opts.failExecWithCause) {
+				throw new GapError("exec boom", opts.failExecWithCause);
 			}
 			if (opts.failExec) throw new Error("exec boom");
 			return { exitCode: 0 };
@@ -106,6 +112,7 @@ const gapFor = (gaps: ResultGap[], op: string): ResultGap | undefined =>
 	gaps.find((g) => g.id === op);
 const reasonFor = (gaps: ResultGap[], op: string): string | undefined => gapFor(gaps, op)?.reason;
 const outcomeFor = (gaps: ResultGap[], op: string): string | undefined => gapFor(gaps, op)?.outcome;
+const causeFor = (gaps: ResultGap[], op: string): GapCause | undefined => gapFor(gaps, op)?.cause;
 
 describe("measureLifecycle", () => {
 	it("times the full spawn→readiness→exec→payload→info→list→snapshot→teardown chain in order", async () => {
@@ -209,8 +216,13 @@ describe("measureLifecycle", () => {
 		expect(calls.order.some((c) => c.includes("/dev/zero | tr"))).toBe(false);
 		expect(countByOp(samples)[HARNESS_METRIC_IDS.execPayload64k]).toBeUndefined();
 		expect(reasonFor(gaps, HARNESS_METRIC_IDS.execPayload64k)).toMatch(/disabled/);
-		// Never attempted (the run turned it off) — a decision, not a reliability fact.
+		// Never attempted (the run turned it off) — a decision, not a reliability fact. The cause says so
+		// in data: `measurement-disabled`, never `unsupported-operation`, which would publish a config
+		// toggle as a capability e2b lacks.
 		expect(outcomeFor(gaps, HARNESS_METRIC_IDS.execPayload64k)).toBe("skipped");
+		expect(causeFor(gaps, HARNESS_METRIC_IDS.execPayload64k)).toEqual({
+			kind: "measurement-disabled",
+		});
 	});
 
 	it("honors a custom exec command", async () => {
@@ -238,9 +250,19 @@ describe("measureLifecycle", () => {
 		expect(reasonFor(gaps, HARNESS_METRIC_IDS.controlPlaneList)).toMatch(
 			/no sandbox list operation/,
 		);
-		// The SDK exposes no such call, so neither was ever attempted — a skip, not an outage.
+		// The SDK exposes no such call, so neither was ever attempted — a skip, not an outage. And the
+		// cause is `unsupported-operation`: a statement about the PROVIDER, the opposite half of the
+		// distinction `measurement-disabled` carries.
 		expect(outcomeFor(gaps, HARNESS_METRIC_IDS.snapshot)).toBe("skipped");
 		expect(outcomeFor(gaps, HARNESS_METRIC_IDS.controlPlaneList)).toBe("skipped");
+		expect(causeFor(gaps, HARNESS_METRIC_IDS.snapshot)).toEqual({
+			kind: "unsupported-operation",
+			detail: "provider SDK exposes no snapshot operation",
+		});
+		expect(causeFor(gaps, HARNESS_METRIC_IDS.controlPlaneList)).toEqual({
+			kind: "unsupported-operation",
+			detail: "provider SDK exposes no sandbox list operation",
+		});
 	});
 
 	it("records a skip when snapshot measurement is disabled, without calling the SDK", async () => {
@@ -253,6 +275,9 @@ describe("measureLifecycle", () => {
 		expect(countByOp(samples)[HARNESS_METRIC_IDS.snapshot]).toBeUndefined();
 		expect(reasonFor(gaps, HARNESS_METRIC_IDS.snapshot)).toMatch(/disabled/);
 		expect(outcomeFor(gaps, HARNESS_METRIC_IDS.snapshot)).toBe("skipped");
+		// The SDK HAS a snapshot manager here — only the run turned it off, so the cause must not claim
+		// the provider cannot do it.
+		expect(causeFor(gaps, HARNESS_METRIC_IDS.snapshot)).toEqual({ kind: "measurement-disabled" });
 	});
 
 	it("turns a mid-chain exec failure into a failed gap and still tears down", async () => {
@@ -268,6 +293,9 @@ describe("measureLifecycle", () => {
 		expect(countByOp(samples)[HARNESS_METRIC_IDS.exec]).toBeUndefined();
 		expect(reasonFor(gaps, HARNESS_METRIC_IDS.exec)).toBe("exec boom");
 		expect(outcomeFor(gaps, HARNESS_METRIC_IDS.exec)).toBe("failed");
+		// A provider SDK's own error carries no classification, and none is invented from its message —
+		// guessing a kind from prose is the coupling the taxonomy exists to remove.
+		expect(causeFor(gaps, HARNESS_METRIC_IDS.exec)).toBeUndefined();
 		// Readiness succeeded here, so the cold-start Metrics are real Samples, not gaps.
 		expect(countByOp(samples)[HARNESS_METRIC_IDS.coldStart]).toBe(1);
 		// Teardown still ran and was sampled.
@@ -312,6 +340,22 @@ describe("measureLifecycle", () => {
 		expect(countByOp(samples)[HARNESS_METRIC_IDS.teardown]).toBe(1);
 	});
 
+	it("carries a classified throw from a measured step onto its gap", async () => {
+		// The `step()` error path is the one place a gap's cause comes from the ERROR rather than from a
+		// constant beside the call. An unclassified throw must stay unclassified (the test above pins
+		// that), and a classified one must arrive intact — otherwise `GapError` buys nothing here and the
+		// classification silently dies at the frame that catches it.
+		const cause: GapCause = { kind: "step-timeout", step: "exec", timeoutSeconds: 30 };
+		const { compute } = fakeCompute({ failExecWithCause: cause });
+		const { gaps } = await measureLifecycle(compute, {
+			provider: "e2b",
+			now: fastClock(),
+			delay: noDelay,
+		});
+		expect(outcomeFor(gaps, HARNESS_METRIC_IDS.exec)).toBe("failed");
+		expect(causeFor(gaps, HARNESS_METRIC_IDS.exec)).toEqual(cause);
+	});
+
 	it("keeps disabled and unsupported operations SKIPPED on a never-ready sandbox", async () => {
 		// A readiness outage must not relabel decisions as provider failures. Payload is off, and this fake
 		// exposes neither list nor snapshot — none of those calls was ever going to happen, so reporting
@@ -326,13 +370,16 @@ describe("measureLifecycle", () => {
 			now: fastClock(),
 			delay: noDelay,
 		});
-		for (const [metricId, pattern] of [
-			[HARNESS_METRIC_IDS.execPayload64k, /disabled/],
-			[HARNESS_METRIC_IDS.controlPlaneList, /no sandbox list operation/],
-			[HARNESS_METRIC_IDS.snapshot, /disabled/],
+		for (const [metricId, pattern, kind] of [
+			[HARNESS_METRIC_IDS.execPayload64k, /disabled/, "measurement-disabled"],
+			[HARNESS_METRIC_IDS.controlPlaneList, /no sandbox list operation/, "unsupported-operation"],
+			[HARNESS_METRIC_IDS.snapshot, /disabled/, "measurement-disabled"],
 		] as const) {
 			expect(outcomeFor(gaps, metricId)).toBe("skipped");
 			expect(reasonFor(gaps, metricId)).toMatch(pattern);
+			// The classification has to survive the outage too — this is the path where a skip is most
+			// easily relabelled, and a swapped kind here is exactly the regression prose cannot catch.
+			expect(causeFor(gaps, metricId)?.kind).toBe(kind);
 		}
 		// The genuinely-prevented ops are still failures — the outage is not swallowed either.
 		expect(outcomeFor(gaps, HARNESS_METRIC_IDS.exec)).toBe("failed");

--- a/packages/harness/src/lib/lifecycle.ts
+++ b/packages/harness/src/lib/lifecycle.ts
@@ -18,8 +18,15 @@
  * `finally` and never throws out of it. Repeat the cycle for a cold-start distribution — that is what
  * {@link benchmarkLifecycle} (in index.ts) does.
  */
-import type { Aggregates, HarnessMetricId, RawRun, ResultGap } from "@sandbox-benchmarks/schema";
+import type {
+	Aggregates,
+	GapCause,
+	HarnessMetricId,
+	RawRun,
+	ResultGap,
+} from "@sandbox-benchmarks/schema";
 import { aggregate, HARNESS_METRIC_IDS } from "@sandbox-benchmarks/schema";
+import { gapCauseOf } from "./gap-cause.ts";
 import { now as defaultNow, time } from "./internal.ts";
 import { neverReadyReason, waitUntilReady } from "./readiness.ts";
 
@@ -45,6 +52,21 @@ const PAYLOAD_DISABLED = "64KiB payload exec disabled for this run";
 const NO_LIST_OP = "provider SDK exposes no sandbox list operation";
 const SNAPSHOT_DISABLED = "snapshot measurement disabled for this run";
 const NO_SNAPSHOT_OP = "provider SDK exposes no snapshot operation";
+/**
+ * A measurement this RUN turned off. Deliberately not `unsupported-operation`: the provider can do it,
+ * we chose not to time it, and publishing a config toggle as a missing capability would be a claim
+ * about the provider we have no evidence for.
+ */
+const DISABLED_CAUSE = { kind: "measurement-disabled" } as const satisfies GapCause;
+/** The provider's SDK exposes no such call — a capability statement, unlike {@link DISABLED_CAUSE}. */
+const NO_LIST_CAUSE = {
+	kind: "unsupported-operation",
+	detail: NO_LIST_OP,
+} as const satisfies GapCause;
+const NO_SNAPSHOT_CAUSE = {
+	kind: "unsupported-operation",
+	detail: NO_SNAPSHOT_OP,
+} as const satisfies GapCause;
 /** Writes exactly 64KiB (65536 bytes) to stdout — exec overhead including output streaming. Uses `tr`
  *  rather than `base64` so the stream is exactly 64KiB, matching the metric's name (base64 expands the
  *  input ~33%, overstating the payload). */
@@ -156,18 +178,30 @@ export async function measureLifecycle(
 	// about reliability. `fail` is an outage: the call was made and it threw. Recording a throw as a skip
 	// (as this did while both shared one helper) publishes a provider's control-plane failure as though
 	// we had chosen not to measure it, which is precisely backwards.
-	const skip = (operation: HarnessMetricId, reason: string): void => {
-		gaps.push({ scope: "operation", id: operation, outcome: "skipped", reason });
+	const skip = (operation: HarnessMetricId, reason: string, cause?: GapCause): void => {
+		gaps.push({
+			scope: "operation",
+			id: operation,
+			outcome: "skipped",
+			reason,
+			...(cause ? { cause } : {}),
+		});
 	};
-	const fail = (operation: HarnessMetricId, reason: string): void => {
-		gaps.push({ scope: "operation", id: operation, outcome: "failed", reason });
+	const fail = (operation: HarnessMetricId, reason: string, cause?: GapCause): void => {
+		gaps.push({
+			scope: "operation",
+			id: operation,
+			outcome: "failed",
+			reason,
+			...(cause ? { cause } : {}),
+		});
 	};
 	// A timed step that records a Sample on success and a FAILED gap (never a throw) on error.
 	const step = async (operation: HarnessMetricId, run: () => Promise<unknown>): Promise<void> => {
 		try {
 			sample(operation, (await time(run)).ms);
 		} catch (err) {
-			fail(operation, reasonOf(err));
+			fail(operation, reasonOf(err), gapCauseOf(err));
 		}
 	};
 
@@ -219,11 +253,12 @@ export async function measureLifecycle(
 			// no probe ran here and N copies of one fact is noise, not fidelity.
 			fail(HARNESS_METRIC_IDS.controlPlaneInfo, reason);
 			if (wantPayload) fail(HARNESS_METRIC_IDS.execPayload64k, reason);
-			else skip(HARNESS_METRIC_IDS.execPayload64k, PAYLOAD_DISABLED);
+			else skip(HARNESS_METRIC_IDS.execPayload64k, PAYLOAD_DISABLED, DISABLED_CAUSE);
 			if (compute.sandbox.list) fail(HARNESS_METRIC_IDS.controlPlaneList, reason);
-			else skip(HARNESS_METRIC_IDS.controlPlaneList, NO_LIST_OP);
-			if (!wantSnapshot) skip(HARNESS_METRIC_IDS.snapshot, SNAPSHOT_DISABLED);
-			else if (!compute.snapshot) skip(HARNESS_METRIC_IDS.snapshot, NO_SNAPSHOT_OP);
+			else skip(HARNESS_METRIC_IDS.controlPlaneList, NO_LIST_OP, NO_LIST_CAUSE);
+			if (!wantSnapshot) skip(HARNESS_METRIC_IDS.snapshot, SNAPSHOT_DISABLED, DISABLED_CAUSE);
+			else if (!compute.snapshot)
+				skip(HARNESS_METRIC_IDS.snapshot, NO_SNAPSHOT_OP, NO_SNAPSHOT_CAUSE);
 			else fail(HARNESS_METRIC_IDS.snapshot, reason);
 			return { samples, gaps };
 		} else {
@@ -238,7 +273,7 @@ export async function measureLifecycle(
 		if (wantPayload) {
 			await step(HARNESS_METRIC_IDS.execPayload64k, () => sandbox.runCommand(PAYLOAD_CMD));
 		} else {
-			skip(HARNESS_METRIC_IDS.execPayload64k, PAYLOAD_DISABLED);
+			skip(HARNESS_METRIC_IDS.execPayload64k, PAYLOAD_DISABLED, DISABLED_CAUSE);
 		}
 
 		// Control-plane read: getInfo, sampled within this one (cheap) sandbox to build a distribution
@@ -257,16 +292,16 @@ export async function measureLifecycle(
 				await step(HARNESS_METRIC_IDS.controlPlaneList, () => listSandboxes());
 			}
 		} else {
-			skip(HARNESS_METRIC_IDS.controlPlaneList, NO_LIST_OP);
+			skip(HARNESS_METRIC_IDS.controlPlaneList, NO_LIST_OP, NO_LIST_CAUSE);
 		}
 
 		// Snapshot: when requested and the SDK exposes a snapshot manager. Best-effort delete afterwards
 		// so a measured snapshot never leaks into the account.
 		const snapshots = compute.snapshot;
 		if (!wantSnapshot) {
-			skip(HARNESS_METRIC_IDS.snapshot, SNAPSHOT_DISABLED);
+			skip(HARNESS_METRIC_IDS.snapshot, SNAPSHOT_DISABLED, DISABLED_CAUSE);
 		} else if (!snapshots) {
-			skip(HARNESS_METRIC_IDS.snapshot, NO_SNAPSHOT_OP);
+			skip(HARNESS_METRIC_IDS.snapshot, NO_SNAPSHOT_OP, NO_SNAPSHOT_CAUSE);
 		} else {
 			try {
 				const snap = await time(() => snapshots.create(sandbox.sandboxId));


### PR DESCRIPTION
**RUN SCHEMA v4 — make the benchmark dataset self-describing**
Shipped as an 8-PR stack (merge bottom-up, each branch independently green):

1. #292 — schema: open Run v4 (numeric version floors) + the closed `GapCause` taxonomy
2. #293 — schema: carry a gap's cause on its on-disk marker
3. #294 — harness: `GapError` — classify a failure at the site that knows it
4. #295 — results: author causes in the normalizer, read them in the leaderboard
5. #296 — schema: `MetricResult.derived` — mark a computed row in the document
6. #297 — schema: `ObservedMixtures`, the replicate→machine join, per-machine verdicts
7. #298 — results: build the counted mixtures and fold host records onto them
8. #299 — results: aggregate onto the mixtures instead of onto shard order

↑ **This PR is #294 (3/8)**, based on #293.

---

The harness knows exactly what went wrong at the point it throws — which step, which
budget, which exit code — but that knowledge reached the dataset through a marker
written several frames up, and an Error carries nothing but a message. Downstream then
re-derived the fact by matching prose.

`GapError` makes the cause part of the error's TYPE, so the marker writer can record
what the thrower actually knew. A class rather than a side-channel property on
arbitrary errors: every failure classified here is one the harness constructs itself,
so there is no pass-through case to accommodate. An error arriving from a provider SDK
is simply unclassified, and `gapCauseOf` says so — the honest answer rather than a
label invented for it.

Classified at the sites that know:

  * `StepRunner` — a non-zero exit (`step-failed` with the code), a lost sandbox
    (`sandbox-lost` with the poll-failure count), and both timeout paths.
  * `runSuite`/`runSuiteOnSandbox` — missing credentials (with the variable names) and
    a disk shortfall (with the free and required GiB, unrounded).
  * `createSuiteSandbox` — `sandbox-create-failed`, written straight onto the marker;
    the original error still propagates unwrapped, because bench-suite matches on the
    provider's own message and this frame is outside `runSuiteOnSandbox`.
  * `measureLifecycle` — the operation skips, which is where the taxonomy earns its
    keep: `measurement-disabled` (we chose not to time it) stays distinct from
    `unsupported-operation` (the SDK exposes no such call), because collapsing them
    would publish a config toggle as a capability the provider lacks.

`stepTimeout` builds the sentence and the cause from one input, replacing four copies
of the same seconds rounding across the synchronous and detached paths — the same
pairing discipline `shortfallReason`/`shortfallCause` use in the results package. Its
seconds floor at 1: every real step budget is minute-scale, but `gapCauseSchema`
requires `timeoutSeconds > 0`, and a sub-500ms budget would round to 0 — a cause the
schema refuses, turning a timed-out step into a Run that cannot be normalized at all.

`withTimeout` takes a message OR a factory for the error, not message-plus-cause, so
the wording and its classification are built together and cannot describe different
facts.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Classifies harness failures at the throw site and records structured causes on gap markers and lifecycle gaps. Adds `GapError`/`gapCauseOf` so exact causes travel with the error instead of parsing messages.

- **New Features**
  - Added `GapError` and `gapCauseOf` to attach a `GapCause`; unclassified errors stay as-is.
  - `StepRunner`: classifies `step-timeout` (seconds floored to 1 via shared helper), `step-failed` (exit code), and `sandbox-lost` (poll-failure count). `withTimeout` now accepts a message or error factory.
  - Suite markers: classify `missing-credentials` and `disk-shortfall`; `createSuiteSandbox` writes `sandbox-create-failed` with provider detail and rethrows; failed suites include a cause via `gapCauseOf` when available.
  - Lifecycle: measured-step failures carry their classified cause; skips carry `measurement-disabled` or `unsupported-operation` (with detail for list/snapshot).
  - `writeGapMarker` accepts an optional `cause` and forwards it to `harnessGapMarkerJson` in `@sandbox-benchmarks/schema`.

- **Migration**
  - No action required; existing markers remain valid. Consumers can read `cause` when present.
  - Provider SDK errors remain intentionally unclassified.

<sup>Written for commit 2d20144be4b6491ce4e4d49bbf8a0635eb4edf7b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/starslingdev/hpc-sandbox-benchmarks/pull/294?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

