### PR TITLE
feat(results): author gap causes in the normalizer, read them in the leaderboard

### DIFF
--- a/packages/results/src/lib/leaderboard.ts
+++ b/packages/results/src/lib/leaderboard.ts
@@ -23,6 +23,7 @@
  */
 import type {
 	Dimension,
+	GapCause,
 	GapOutcome,
 	GapScope,
 	MedianInterval,
@@ -255,13 +256,34 @@ export interface Leaderboard {
 }
 
 /**
- * Whether a skip reason is a disk-capacity gap — i.e. the harness wrote its "Insufficient disk: …"
- * marker because the sandbox had less free disk than the suite's `minDiskGb`. Matched by prefix rather
- * than importing the harness so `results` stays SDK-free; kept in lockstep with `runSuiteOnSandbox`'s
- * reason string (the one place that phrasing is authored).
+ * Whether the Run's producer was able to classify gaps at all — true once ANY gap carries a structured
+ * cause. This is what decides whether an ABSENT cause is meaningful.
+ *
+ * Deliberately not `schemaVersion >= 4`. The version says which fields the document MAY carry, not
+ * whether its producer populated them, and the two come apart precisely where it matters: re-aggregating
+ * a historical run emits a v4 document whose gaps have no causes, because the shard markers it merges
+ * were written by a harness that predated the taxonomy. Gating on the version would strip the disk
+ * classification off every backfilled run in the committed series; gating on the evidence does not.
  */
-function isDiskGap(reason: string): boolean {
-	return /^insufficient disk/i.test(reason.trim());
+function producerClassifiesGaps(run: Run): boolean {
+	return run.providers.some((provider) => provider.gaps.some((gap) => gap.cause !== undefined));
+}
+
+/**
+ * Whether a gap is a disk-capacity skip — the sandbox had less free disk than the suite's `minDiskGb`.
+ *
+ * Reads the structured {@link ResultGap.cause} whenever the Run's producer classified anything. In that
+ * case an absent cause means "this gap is unclassified", and prose-matching it anyway would manufacture
+ * a confident diagnosis for an event the producer declined to diagnose — exactly what the taxonomy's
+ * no-catch-all rule forbids.
+ *
+ * The prose match survives only for Runs whose producer emitted no causes at all, where the English
+ * sentence is the sole record of the fact. A compatibility shim over a closed input set — not a parser
+ * to extend. A NEW fact belongs in the cause taxonomy.
+ */
+function isDiskGap(gap: { reason: string; cause?: GapCause }, classified: boolean): boolean {
+	if (gap.cause !== undefined) return gap.cause.kind === "disk-shortfall";
+	return !classified && /^insufficient disk/i.test(gap.reason.trim());
 }
 
 /** Rendering/sort precedence: the structural absences first, the merely-unreported last. */
@@ -311,6 +333,9 @@ function suitesExercised(run: Run): string[] {
  */
 function coverageGapsOf(run: Run): CoverageGap[] {
 	const exercised = suitesExercised(run);
+	// Computed once per Run, not per gap: whether an absent cause means "unclassified" or "this producer
+	// had no causes to give".
+	const classified = producerClassifiesGaps(run);
 
 	const gaps = run.providers.flatMap((provider): CoverageGap[] => {
 		// A zero-evidence registry row (never dispatched, or every cell lost before reporting) gets the
@@ -335,7 +360,7 @@ function coverageGapsOf(run: Run): CoverageGap[] {
 				// before the suite was attempted. A failure's reason is an error message, and one that merely
 				// happens to start with "insufficient disk" is the workload running out of space mid-flight —
 				// a different fact, and not the structural "cannot host this at all" the ❌ claims.
-				disk: gap.outcome === "skipped" && isDiskGap(gap.reason),
+				disk: gap.outcome === "skipped" && isDiskGap(gap, classified),
 			})),
 			...exercised
 				.filter((suite) => !accountedFor.has(suite))

--- a/packages/results/src/lib/normalize-tree.test.ts
+++ b/packages/results/src/lib/normalize-tree.test.ts
@@ -383,6 +383,11 @@ describe("normalizeProviderDir suite-shortfall gaps and leaf-marker folding", ()
 				outcome: "failed",
 				reason:
 					"PTS ran but every trial failed for 1 of 1 declared metrics: node_web_tooling_runs_per_s (cpu-node/pts_node-web-tooling.xml) — attempted, no value recorded",
+				cause: {
+					kind: "metrics-unrecorded",
+					metricIds: ["node_web_tooling_runs_per_s"],
+					declared: 1,
+				},
 			},
 		]);
 		expect(run.suitesCovered).toEqual([]);
@@ -449,6 +454,11 @@ describe("normalizeProviderDir suite-shortfall gaps and leaf-marker folding", ()
 				outcome: "failed",
 				reason:
 					"PTS ran but every trial failed for 1 of 3 declared metrics: pybench_milliseconds (system/pts_pybench.xml) — attempted, no value recorded",
+				cause: {
+					kind: "metrics-unrecorded",
+					metricIds: ["pybench_milliseconds"],
+					declared: 3,
+				},
 			},
 		]);
 	});
@@ -496,6 +506,11 @@ describe("normalizeProviderDir suite-shortfall gaps and leaf-marker folding", ()
 				outcome: "failed",
 				reason:
 					"PTS ran but every trial failed for 1 of 3 declared metrics: pybench_milliseconds (system/pts_git.xml) — attempted, no value recorded",
+				cause: {
+					kind: "metrics-unrecorded",
+					metricIds: ["pybench_milliseconds"],
+					declared: 3,
+				},
 			},
 		]);
 	});
@@ -567,6 +582,11 @@ describe("normalizeProviderDir suite-shortfall gaps and leaf-marker folding", ()
 				outcome: "failed",
 				reason:
 					"PTS ran but every trial failed for 2 of 4 declared metrics: stream_type_add (memory/pts_stream.xml), stream_type_triad (memory/pts_stream.xml) — attempted, no value recorded",
+				cause: {
+					kind: "metrics-unrecorded",
+					metricIds: ["stream_type_add", "stream_type_triad"],
+					declared: 4,
+				},
 			},
 		]);
 	});
@@ -622,6 +642,11 @@ describe("normalizeProviderDir suite-shortfall gaps and leaf-marker folding", ()
 				outcome: "failed",
 				reason:
 					"PTS ran but every trial failed for 1 of 3 declared metrics: pybench_milliseconds (system/pts_pybench.xml) — attempted, no value recorded",
+				cause: {
+					kind: "metrics-unrecorded",
+					metricIds: ["pybench_milliseconds"],
+					declared: 3,
+				},
 			},
 		]);
 	});
@@ -644,6 +669,7 @@ describe("normalizeProviderDir suite-shortfall gaps and leaf-marker folding", ()
 				id: "disk",
 				outcome: "failed",
 				reason: `PTS duplicate-value dedup dropped 1 fio twin result (MB/s == IOPS at this block size, so the duplicate-valued <Result> was never written): ${SEQ_READ_DIRECT_YES}_mb_per_s (twin survived in disk/pts_fio-seq-read.xml)`,
+				cause: { kind: "duplicate-value-dedup", metricIds: [`${SEQ_READ_DIRECT_YES}_mb_per_s`] },
 			},
 		]);
 	});
@@ -786,6 +812,7 @@ describe("normalizeProviderDir suite-shortfall gaps and leaf-marker folding", ()
 				id: "disk",
 				outcome: "failed",
 				reason: `PTS duplicate-value dedup dropped 1 fio twin result (MB/s == IOPS at this block size, so the duplicate-valued <Result> was never written): ${SEQ_READ_DIRECT_YES}_mb_per_s (twin survived in disk/pts_fio-seq-read.xml)`,
+				cause: { kind: "duplicate-value-dedup", metricIds: [`${SEQ_READ_DIRECT_YES}_mb_per_s`] },
 			},
 		]);
 	});
@@ -817,6 +844,7 @@ describe("normalizeProviderDir suite-shortfall gaps and leaf-marker folding", ()
 				id: "disk",
 				outcome: "failed",
 				reason: `PTS duplicate-value dedup dropped 1 fio twin result (MB/s == IOPS at this block size, so the duplicate-valued <Result> was never written): ${SEQ_READ_DIRECT_YES}_mb_per_s (twin survived in disk/pts_fio-rand-read.xml)`,
+				cause: { kind: "duplicate-value-dedup", metricIds: [`${SEQ_READ_DIRECT_YES}_mb_per_s`] },
 			},
 		]);
 	});

--- a/packages/results/src/lib/normalize-tree.ts
+++ b/packages/results/src/lib/normalize-tree.ts
@@ -7,6 +7,7 @@
 import { readdirSync, readFileSync, statSync } from "node:fs";
 import { join } from "node:path";
 import type {
+	GapCause,
 	HostMetadataRecord,
 	MetricResult,
 	ObservedSpecs,
@@ -53,10 +54,10 @@ export function normalizeResultsTree(input: NormalizeInput): Run {
 		.map((meta) => normalizeProviderDir(input.rawRoot, meta.id));
 
 	const candidate = {
-		// Pinned at 4 so this producer is already emitting the version whose fields it is about to carry:
-		// `runSchema` gates each v4 field at v4-or-later, and a producer that stamps a lower version than
-		// the fields it writes fails `parseRun` at its own boundary. A shard may also carry a
-		// replicateIndex (v3+) the aggregate folds into MetricResult.replicates.
+		// Pinned at 4 because this function stamps a structured `cause` on suite gaps
+		// (`shortfallCause`/`twinDropCause`), which `runSchema` gates at v4-or-later — lowering this while
+		// still emitting causes fails `parseRun`. A shard may also carry a replicateIndex (v3+) the
+		// aggregate folds into MetricResult.replicates.
 		schemaVersion: "4" as const,
 		runId: input.runId,
 		sha: input.sha,
@@ -131,13 +132,32 @@ function suiteForLeaf(leaf: string): string | undefined {
  * across replicate shards instead of stacking one gap per replicate.
  */
 export function shortfallReason(suite: string, missing: readonly AttemptedEmptyResult[]): string {
-	// suiteDirs only ever contains registered names, so the lookup can't miss in production; the
-	// fallback keeps this pure-string helper total for tests and future callers.
-	const declared =
-		(SUITES as Partial<Record<string, { metrics: readonly string[] }>>)[suite]?.metrics.length ??
-		missing.length;
 	const list = missing.map((e) => `${e.metricId} (${e.sourceFile})`).join(", ");
-	return `PTS ran but every trial failed for ${missing.length} of ${declared} declared metrics: ${list} — attempted, no value recorded`;
+	return `PTS ran but every trial failed for ${missing.length} of ${declaredMetricCount(suite, missing.length)} declared metrics: ${list} — attempted, no value recorded`;
+}
+
+/**
+ * How many metrics the suite declares — the denominator in the shortfall wording and cause. suiteDirs
+ * only ever contains registered names, so the lookup can't miss in production; the fallback keeps the
+ * pure helpers total for tests and future callers.
+ */
+function declaredMetricCount(suite: string, fallback: number): number {
+	return (
+		(SUITES as Partial<Record<string, { metrics: readonly string[] }>>)[suite]?.metrics.length ??
+		fallback
+	);
+}
+
+/**
+ * The same shortfall as data. Emitted alongside {@link shortfallReason} so the two can never describe
+ * different facts: one call site builds both from one input.
+ */
+export function shortfallCause(suite: string, missing: readonly AttemptedEmptyResult[]): GapCause {
+	return {
+		kind: "metrics-unrecorded",
+		metricIds: missing.map((e) => e.metricId),
+		declared: declaredMetricCount(suite, missing.length),
+	};
 }
 
 /** A catalogued fio twin whose <Result> PTS omitted entirely; sourceFile carries the SURVIVING twin. */
@@ -155,6 +175,11 @@ export interface DroppedTwinResult {
 export function twinDropReason(dropped: readonly DroppedTwinResult[]): string {
 	const list = dropped.map((d) => `${d.metricId} (twin survived in ${d.sourceFile})`).join(", ");
 	return `PTS duplicate-value dedup dropped ${dropped.length} fio twin result${dropped.length === 1 ? "" : "s"} (MB/s == IOPS at this block size, so the duplicate-valued <Result> was never written): ${list}`;
+}
+
+/** The dropped-twin gap as data, built from the same input as {@link twinDropReason}. */
+export function twinDropCause(dropped: readonly DroppedTwinResult[]): GapCause {
+	return { kind: "duplicate-value-dedup", metricIds: dropped.map((d) => d.metricId) };
 }
 
 const TWIN_SUFFIXES = ["_mb_per_s", "_iops"] as const;
@@ -441,6 +466,7 @@ export function normalizeProviderDir(rawRoot: string, providerId: string): Provi
 			id: suite,
 			outcome: "failed",
 			reason: shortfallReason(suite, missing),
+			cause: shortfallCause(suite, missing),
 		});
 	}
 
@@ -468,6 +494,7 @@ export function normalizeProviderDir(rawRoot: string, providerId: string): Provi
 			id: suite,
 			outcome: "failed",
 			reason: twinDropReason(dropped),
+			cause: twinDropCause(dropped),
 		});
 	}
 


### PR DESCRIPTION
**RUN SCHEMA v4 — make the benchmark dataset self-describing**
Shipped as an 8-PR stack (merge bottom-up, each branch independently green):

1. #292 — schema: open Run v4 (numeric version floors) + the closed `GapCause` taxonomy
2. #293 — schema: carry a gap's cause on its on-disk marker
3. #294 — harness: `GapError` — classify a failure at the site that knows it
4. #295 — results: author causes in the normalizer, read them in the leaderboard
5. #296 — schema: `MetricResult.derived` — mark a computed row in the document
6. #297 — schema: `ObservedMixtures`, the replicate→machine join, per-machine verdicts
7. #298 — results: build the counted mixtures and fold host records onto them
8. #299 — results: aggregate onto the mixtures instead of onto shard order

↑ **This PR is #295 (4/8)**, based on #294.

---

The normalizer authors two gaps of its own — a suite whose declared metrics all failed
to record, and a fio twin PTS's duplicate-value dedup dropped — and until now the only
record of either was an English sentence. `shortfallCause` and `twinDropCause` sit
beside the reason builders and are constructed from the same input at the same call
site, so the prose and the data can never describe different facts. The shared
denominator moves into `declaredMetricCount` for the same reason.

The leaderboard stops re-parsing that prose. `isDiskGap` reads the structured cause,
and the `/^insufficient disk/i` match survives only for Runs whose producer emitted no
causes at all, where the sentence is the sole record of the fact — a compatibility shim
over a closed input set, not a parser to extend.

`producerClassifiesGaps` is what decides whether an ABSENT cause is meaningful, and it
gates on EVIDENCE rather than on `schemaVersion >= 4`. The version says which fields a
document MAY carry, not whether its producer populated them, and the two come apart
exactly where it matters: re-aggregating a historical run emits a v4 document whose
gaps have no causes, because the shard markers it merges were written by a harness that
predated the taxonomy. A version gate would strip the disk classification off every
backfilled run in the committed series.

Where a producer has classified, an absent cause now means "this gap is unclassified",
and prose-matching it anyway would manufacture a confident diagnosis for an event the
producer declined to diagnose — precisely what the taxonomy's no-catch-all rule
forbids. This sits above the harness PR so the disk skips the leaderboard cares about
already carry `disk-shortfall`, leaving no merge point where a fresh run loses its disk
classification.

All 15 committed runs parse and LEADERBOARD.md renders byte-identically.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds structured gap causes to the `results` normalizer and updates the leaderboard to use them. Disk-capacity skips use `GapCause` when present; we only match "Insufficient disk" if a run has no causes.

- **New Features**
  - Normalizer: emits `cause` for suite gaps — `metrics-unrecorded` (with `metricIds`, `declared`) and `duplicate-value-dedup` (with `metricIds`). Pins `schemaVersion` to `4`.
  - Leaderboard: reads `cause` to flag `disk-shortfall`; falls back to the "Insufficient disk" prefix only when a run has no causes. Gates via `producerClassifiesGaps()` (computed once per run).
  - Helpers: adds `shortfallCause()`, `twinDropCause()`, and `declaredMetricCount()`. `shortfallReason()` now shares the same denominator as the cause.

<sup>Written for commit 80fa27dba1e127267227fa4f3f0d1af74b6677dc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/starslingdev/hpc-sandbox-benchmarks/pull/295?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

