### PR TITLE
feat(schema): mark a computed Metric in the document itself

### DIFF
--- a/packages/results/src/lib/aggregate.test.ts
+++ b/packages/results/src/lib/aggregate.test.ts
@@ -332,3 +332,37 @@ describe("aggregateRuns suite-shortfall gap folding", () => {
 		expect(daytona?.gaps).toEqual([shortfall(reason), shortfall(other)]);
 	});
 });
+
+describe("aggregateRuns derived-metric marking", () => {
+	it("marks the economics rows it re-derives, so the document says what is computed", () => {
+		// The guarantee the schema deliberately does NOT enforce (a published Run's validity must not track
+		// the live catalog) is pinned here instead, on the producer that owns catalog knowledge.
+		const merged = aggregateRuns([
+			shard([provider("daytona-vm", [metric(HARNESS_METRIC_IDS.spawn, [1000])])]),
+		]);
+		const metrics = merged.providers.find((p) => p.providerId === "daytona-vm")?.metrics ?? [];
+		const economics = metrics.filter((m) => m.metricId.startsWith("usd_"));
+		expect(economics.length).toBeGreaterThan(0);
+		for (const row of economics) expect(row.derived).toBe(true);
+		// And measurements stay unmarked — the marker means "computed", not "present".
+		expect(metrics.find((m) => m.metricId === HARNESS_METRIC_IDS.spawn)?.derived).toBeUndefined();
+	});
+
+	it("drops a shard's stale economics row even when the catalog no longer knows the id", () => {
+		// isDerivedMetric prefers the document's marker: a marked row is never re-admitted as a measurement
+		// and pooled into a ranking, which a catalog-only test would do for a renamed or retired id.
+		const stale = provider("daytona-vm", [metric("node_web_tooling_runs_per_s", [10])]);
+		stale.metrics.push({
+			metricId: "usd_per_retired_thing",
+			samples: [42],
+			aggregates: aggregate([42]),
+			derived: true,
+		});
+		const merged = aggregateRuns([shard([stale])]);
+		const ids =
+			merged.providers.find((p) => p.providerId === "daytona-vm")?.metrics.map((m) => m.metricId) ??
+			[];
+		expect(ids).not.toContain("usd_per_retired_thing");
+		expect(ids).toContain("node_web_tooling_runs_per_s");
+	});
+});

--- a/packages/results/src/lib/aggregate.ts
+++ b/packages/results/src/lib/aggregate.ts
@@ -29,8 +29,8 @@ import type {
 import {
 	aggregate,
 	deriveEconomics,
-	getMetric,
 	getProvider,
+	isDerivedMetric,
 	parseRun,
 } from "@sandbox-benchmarks/schema";
 
@@ -40,12 +40,6 @@ import {
  * rather than a literal control character in a template string (which makes git read the file as binary).
  */
 const NUL = "\u0000";
-
-/** A measured (non-derived) Metric: one a suite actually produced, vs. a derived economics Metric. */
-function isMeasured(metric: MetricResult): boolean {
-	// Derived metrics (economics) are recomputed post-merge; everything else is real measurement.
-	return getMetric(metric.metricId)?.derived !== true;
-}
 
 /** One provider's slice from one shard, tagged with the replicate sandbox the shard was measured under. */
 interface ReplicateSlice {
@@ -93,7 +87,7 @@ function mergeProvider(providerId: string, entries: readonly ReplicateSlice[]): 
 	const byMetric = new Map<string, Map<number, MetricResult>>();
 	for (const { slice, replicateIndex } of entries) {
 		for (const metric of slice.metrics) {
-			if (!isMeasured(metric)) continue;
+			if (isDerivedMetric(metric)) continue;
 			let byReplicate = byMetric.get(metric.metricId);
 			if (!byReplicate) {
 				byReplicate = new Map<number, MetricResult>();

--- a/packages/results/src/lib/stability.test.ts
+++ b/packages/results/src/lib/stability.test.ts
@@ -91,6 +91,33 @@ describe("compareRuns", () => {
 		expect(shifts).toHaveLength(0);
 	});
 
+	it("excludes a metric either Run marks derived, even when the catalog has forgotten it", () => {
+		// A comparison spans two Runs, and the classification can differ between them: an economics id
+		// that was renamed or retired leaves the catalog, so `isDerivedMetric` falls back to each
+		// document's own marker — and only the older Run has one. Checking the current row alone would
+		// diff a computed PRICE against a measured baseline and publish a 350% regression on a number no
+		// sandbox ever measured.
+		const retired = "usd_per_retired_thing"; // not in the catalog, so only the markers can classify
+		const marked = (value: number): MetricResult => ({ ...metric(retired, value), derived: true });
+
+		// Previous Run marks it, current Run does not (the marker arrived after that Run was published).
+		expect(
+			compareRuns(run("daytona", [marked(0.2)]), run("daytona", [metric(retired, 0.9)])),
+		).toHaveLength(0);
+		// And the mirror case, so neither side is privileged.
+		expect(
+			compareRuns(run("daytona", [metric(retired, 0.2)]), run("daytona", [marked(0.9)])),
+		).toHaveLength(0);
+		// A genuinely measured id the catalog also does not know is still compared — the exclusion keys on
+		// the derived marker, never on catalog absence.
+		expect(
+			compareRuns(
+				run("daytona", [metric("stranger_metric", 0.2)]),
+				run("daytona", [metric("stranger_metric", 0.9)]),
+			),
+		).toHaveLength(1);
+	});
+
 	it("reports a zero-baseline metric as incomparable, not an Infinity regression", () => {
 		// Previous p50 of 0 has no ratio; the pair is surfaced but never gates.
 		const shifts = compareRuns(

--- a/packages/results/src/lib/stability.ts
+++ b/packages/results/src/lib/stability.ts
@@ -12,7 +12,7 @@
  * SDK-free: the Run model + the Catalog (for each metric's Direction) only.
  */
 import type { Direction, Run } from "@sandbox-benchmarks/schema";
-import { getMetric, LEGACY_PROVIDER_ALIASES } from "@sandbox-benchmarks/schema";
+import { getMetric, isDerivedMetric, LEGACY_PROVIDER_ALIASES } from "@sandbox-benchmarks/schema";
 import { type } from "arktype";
 
 /** The default noise threshold (relative): movements within ±10% are treated as stable. */
@@ -93,13 +93,22 @@ export function compareRuns(
 		const prevMetrics = new Map(prev.metrics.map((m) => [m.metricId, m]));
 
 		for (const curMetric of cur.metrics) {
-			const def = getMetric(curMetric.metricId);
-			// Derived metrics (economics) carry no provenance and mirror a measured shift — skip them.
-			if (def?.derived === true) continue;
 			const prevMetric = prevMetrics.get(curMetric.metricId);
 			if (!prevMetric) continue;
+			// Derived metrics (economics) carry no provenance and mirror a measured shift — skip them.
+			// The document's own marker is preferred over the catalog (see isDerivedMetric): a catalog-only
+			// test re-classifies a renamed or retired derived metric as measured and reports a regression on
+			// a price.
+			//
+			// BOTH rows are tested, because each carries its own marker and each falls back to the catalog
+			// independently. A comparison spans two Runs and the classification can differ between them:
+			// the previous Run marks the id derived, the current one predates the marker (or the id has
+			// since left the catalog), and checking only the current row diffs a computed PRICE against a
+			// measured baseline — a fabricated shift on a number no sandbox ever measured, and one that can
+			// fail the stability gate.
+			if (isDerivedMetric(curMetric) || isDerivedMetric(prevMetric)) continue;
 
-			const direction: Direction = def?.direction ?? "HIB";
+			const direction: Direction = getMetric(curMetric.metricId)?.direction ?? "HIB";
 			const base = {
 				providerId: cur.providerId,
 				metricId: curMetric.metricId,

--- a/packages/schema/src/catalog.ts
+++ b/packages/schema/src/catalog.ts
@@ -158,6 +158,19 @@ export function getMetric(id: string): MetricDef | undefined {
 	return byId.get(id);
 }
 
+/**
+ * Whether a Metric result is a COMPUTED row (economics) rather than a measurement.
+ *
+ * Prefers the document's own `derived` marker and falls back to the Catalog only for pre-v4 Runs, which
+ * carry none. That order is the point: a Run outlives the Catalog version that produced it, so a
+ * Catalog-only test re-classifies a renamed or retired derived metric as measured — and it would then be
+ * pooled into a ranking or reported as a regression on a price. Authored once here because the same
+ * decision was previously re-made at three call sites, one of which had it wrong.
+ */
+export function isDerivedMetric(metric: { metricId: string; derived?: true }): boolean {
+	return metric.derived === true || getMetric(metric.metricId)?.derived === true;
+}
+
 /** Every Metric belonging to a Dimension, in Catalog order. */
 export function metricsForDimension(dimension: Dimension): MetricDef[] {
 	return METRIC_CATALOG.filter((metric) => metric.dimension === dimension);

--- a/packages/schema/src/economics.ts
+++ b/packages/schema/src/economics.ts
@@ -179,7 +179,13 @@ export function amortizationBreakEvenRunsPerMonth(
 	return burst > 0 ? monthlyUsd / burst : Number.POSITIVE_INFINITY;
 }
 
-/** A derived economics Metric as a single-Sample MetricResult (n=1, stdev=0). */
+/**
+ * A derived economics Metric as a single-Sample MetricResult (n=1, stdev=0).
+ *
+ * `derived: true` is set HERE, at the one place economics rows are constructed, so the marker cannot
+ * be forgotten by a caller — every consumer of `deriveEconomics` gets correctly-marked rows, and
+ * `metricResultSchema`'s catalog cross-check would reject them at the boundary if it ever were.
+ */
 function economicsResult(metricId: EconomicsMetricId, value: number): MetricResult {
-	return { metricId, samples: [value], aggregates: aggregate([value]) };
+	return { metricId, samples: [value], aggregates: aggregate([value]), derived: true };
 }

--- a/packages/schema/src/run.test.ts
+++ b/packages/schema/src/run.test.ts
@@ -212,6 +212,38 @@ describe("Run schema", () => {
 		expect(parseRun(suiteDisabled).providers[0]?.gaps[0]?.cause?.kind).toBe("measurement-disabled");
 	});
 
+	it("keeps the derived marker out of a pre-v4 Run, and says nothing about the catalog", () => {
+		// The marker is version-gated, which is a property of the DOCUMENT. Whether it agrees with the
+		// Metric Catalog is deliberately NOT checked here: `parseRun` must not make an already-published
+		// Run's validity a function of the current catalog, or reclassifying one metric would retroactively
+		// invalidate the whole committed series. That agreement is a producer-side gate (see isDerivedMetric).
+		const withMarker = (schemaVersion: string) => {
+			const run = structuredClone(validRun);
+			run.schemaVersion = schemaVersion;
+			const metric = run.providers[0]?.metrics[0] as Record<string, unknown>;
+			metric.derived = true;
+			return run;
+		};
+		expect(() => parseRun(withMarker("3"))).toThrow(/v4-or-later Run/);
+		// At v4 the marker is legal on any metric — including one the catalog calls measured, because the
+		// catalog is not consulted. The value is the document's own claim about itself.
+		expect(parseRun(withMarker("4")).providers[0]?.metrics[0]?.derived).toBe(true);
+	});
+
+	it("rejects a replicate breakdown on a derived Metric", () => {
+		// A computed row is one value derived from the merged measured set, so per-sandbox clusters would
+		// claim a between-machine spread nobody measured. Document-internal, so it needs no catalog.
+		const run = structuredClone(validRun);
+		run.schemaVersion = "4";
+		const metric = run.providers[0]?.metrics[0] as Record<string, unknown>;
+		metric.derived = true;
+		metric.replicates = [
+			{ index: 0, samples: [16.19, 16.3] },
+			{ index: 1, samples: [16.08] },
+		];
+		expect(() => parseRun(run)).toThrow(/derived MetricResult without a replicate breakdown/);
+	});
+
 	it("rejects an unknown schemaVersion", () => {
 		expect(() => parseRun({ ...validRun, schemaVersion: "1" })).toThrow();
 		expect(() => parseRun({ ...validRun, schemaVersion: "5" })).toThrow();

--- a/packages/schema/src/run.ts
+++ b/packages/schema/src/run.ts
@@ -48,6 +48,20 @@ export const metricResultSchema = type({
 	// the clusters distinct so render-time inference can resample the between-sandbox level. Absent at
 	// R = 1, so a single-replicate Run is byte-identical to the pre-replicate schema.
 	"replicates?": metricReplicateSchema.array(),
+	/**
+	 * Marks a COMPUTED Metric (v4+): the economics rows, which are derived from other Metrics plus the
+	 * provider's published price rather than measured in any sandbox.
+	 *
+	 * Without it the document could not tell the two apart — `usd_per_hour` sat in `metrics` looking
+	 * exactly like a measurement, and only a Metric Catalog lookup (`getMetric(id)?.derived`) separated
+	 * them. That made a dataset non-self-describing: a consumer validating the JSON on its own would
+	 * rank a price alongside measured throughput, and a Run outlives the catalog version that produced
+	 * it. The narrow below keeps document and catalog in agreement rather than merely hoping.
+	 *
+	 * A literal `true`, not a boolean: the flag is a marker, so `derived: false` on a derived Metric is
+	 * unrepresentable rather than merely wrong. Absent means measured.
+	 */
+	"derived?": "true",
 }).narrow((metric, ctx) => {
 	// `aggregate()` already guarantees these at the producer; enforce them at the dataset boundary too,
 	// so a hand-edited/corrupt persisted Run can't carry NaN/Infinity samples or a sample count that
@@ -57,6 +71,12 @@ export const metricResultSchema = type({
 	}
 	if (metric.aggregates.n !== metric.samples.length) {
 		return ctx.mustBe("a MetricResult whose aggregates.n equals samples.length");
+	}
+	// A derived Metric is computed from the merged measured set as a single value, so it has no
+	// per-sandbox clusters to break out — a replicate breakdown on one would claim a between-machine
+	// spread that was never measured.
+	if (metric.derived === true && metric.replicates !== undefined) {
+		return ctx.mustBe("a derived MetricResult without a replicate breakdown");
 	}
 	if (metric.replicates !== undefined) {
 		// The replicate structure only exists to hold ≥2 clusters; a lone replicate is just `samples`.
@@ -437,9 +457,10 @@ export function providerStatusText(p: ProviderRun): string {
  * replicate sandboxes of one (provider, suite) into {@link MetricResult.replicates}.
  *
  * v4 makes the document SELF-DESCRIBING — every fact a reader needs is expressible from the file,
- * rather than recoverable only by knowing something the file does not say. The first of those facts:
+ * rather than recoverable only by knowing something the file does not say:
  *
  *  - {@link ResultGap.cause} classifies a failure as data rather than prose.
+ *  - {@link MetricResult.derived} separates a computed row from a measured one without a catalog lookup.
  *
  * Every version validates here — already-published Runs are read unchanged, and the parser never
  * migrates them in place.
@@ -477,14 +498,17 @@ export const runSchema = type({
 			return ctx.mustBe("a v3-or-later Run when a MetricResult carries replicates");
 		}
 	}
-	// The v4 self-description fields. A pre-v4 consumer handed one would fall back to the pre-v4 reading
-	// of the same fact — here, re-parsing `reason` prose for a classification the document already
-	// carries — which is a quietly wrong answer, never a loud one. Reported by FIELD rather than as one
-	// blanket message, so the error names what to fix.
+	// The v4 self-description fields, gated together because they arrived together. A pre-v4 consumer
+	// handed one would fall back to the pre-v4 reading of the same fact — re-parsed `reason` prose, a
+	// price treated as a measurement — each a quietly wrong answer, never a loud one. Reported by FIELD
+	// rather than as one blanket message, so the error names what to fix.
 	if (version < 4) {
 		for (const provider of run.providers) {
 			if (provider.gaps.some((gap) => gap.cause !== undefined)) {
 				return ctx.mustBe("a v4-or-later Run when a ResultGap carries a structured cause");
+			}
+			if (provider.metrics.some((metric) => metric.derived !== undefined)) {
+				return ctx.mustBe("a v4-or-later Run when a MetricResult carries the derived marker");
 			}
 		}
 	}


### PR DESCRIPTION
**RUN SCHEMA v4 — make the benchmark dataset self-describing**
Shipped as an 8-PR stack (merge bottom-up, each branch independently green):

1. #292 — schema: open Run v4 (numeric version floors) + the closed `GapCause` taxonomy
2. #293 — schema: carry a gap's cause on its on-disk marker
3. #294 — harness: `GapError` — classify a failure at the site that knows it
4. #295 — results: author causes in the normalizer, read them in the leaderboard
5. #296 — schema: `MetricResult.derived` — mark a computed row in the document
6. #297 — schema: `ObservedMixtures`, the replicate→machine join, per-machine verdicts
7. #298 — results: build the counted mixtures and fold host records onto them
8. #299 — results: aggregate onto the mixtures instead of onto shard order

↑ **This PR is #296 (5/8)**, based on #295.

---

`usd_per_hour` sat among the measurements looking exactly like one, separable only by a
Metric Catalog lookup — and a Run outlives the catalog version that produced it. A
consumer validating the JSON on its own would rank a price alongside measured
throughput.

`MetricResult.derived` is a literal `true`, not a boolean: the flag is a marker, so
`derived: false` on a derived Metric is unrepresentable rather than merely wrong, and
absent means measured. Mandatory from v4 — optional-in-practice would leave consumers
keeping the lookup anyway, so the field would buy nothing.

It is set in `economicsResult`, the one place economics rows are constructed, so no
caller of `deriveEconomics` can forget it. A narrow rejects a replicate breakdown on a
derived Metric: a computed row is one value derived from the merged measured set, so
per-sandbox clusters would claim a between-machine spread nobody measured.

`parseRun` deliberately does NOT check the marker against the catalog. An
already-published Run's validity must not be a function of the current catalog, or
reclassifying one metric would retroactively invalidate the whole committed series.
That agreement belongs on the producer, and `isDerivedMetric` is where it now lives:
the document's own marker first, the catalog only as the fallback for pre-v4 Runs that
carry none. The order is the point — a catalog-only test re-classifies a renamed or
retired derived metric as measured, and it would then be pooled into a ranking or
reported as a regression on a price. Authored once because the same decision was
previously re-made at three call sites, one of which had it wrong (`compareRuns`).

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a v4 schema marker (`derived: true`) to flag computed economics in Run documents, making Runs self‑describing and independent of the live catalog. Aggregation and stability use a shared `isDerivedMetric` that prefers the document marker and falls back to the catalog for pre‑v4 Runs.

- **New Features**
  - Schema: add `MetricResult.derived` (literal `true`), gated to v4+; reject replicate breakdowns on derived rows; `parseRun` does not consult the catalog.
  - Economics: set `derived: true` in `economicsResult`; export `isDerivedMetric` from `@sandbox-benchmarks/schema`.
  - Results: `aggregateRuns` skips derived rows, re‑derives economics, marks computed rows, and drops stale derived IDs even if the catalog no longer lists them.

- **Bug Fixes**
  - Stability: `compareRuns` uses `isDerivedMetric` on both current and previous rows, excluding metrics marked derived on either side so renamed/retired economics IDs don’t trigger false price regressions.

<sup>Written for commit 40a1c137c14957dcf1115b167b621efe4f92653c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/starslingdev/hpc-sandbox-benchmarks/pull/296?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

