### PR TITLE
feat(schema): count a provider's fleet instead of implying it

### DIFF
--- a/packages/results/src/lib/aggregate.test.ts
+++ b/packages/results/src/lib/aggregate.test.ts
@@ -172,41 +172,6 @@ describe("aggregateRuns", () => {
 		expect(merged.generatedAt).toBe("2026-06-02T00:00:00.000Z");
 	});
 
-	it("discloses the conflicting host CPUs when a provider's shards saw differing models", () => {
-		const a = shard([
-			{
-				...provider("daytona-vm", [metric("node_web_tooling_runs_per_s", [10])]),
-				observedSpecs: { cpuModel: "AMD EPYC 9R14", cpuMicroarch: "Zen 4 (Genoa)" },
-			},
-		]);
-		const b = shard([
-			{
-				...provider("daytona-vm", [metric("pybench_milliseconds", [900])]),
-				observedSpecs: { cpuModel: "AMD EPYC 9R45", cpuMicroarch: "Zen 5 (Turin)" },
-			},
-		]);
-		const merged = aggregateRuns([a, b]);
-		const daytona = merged.providers.find((p) => p.providerId === "daytona-vm");
-		// Sorted, distinct — names both machines rather than a bare "heterogeneous" flag.
-		expect(daytona?.observedSpecs.hostCpuModels).toEqual(["AMD EPYC 9R14", "AMD EPYC 9R45"]);
-	});
-
-	it("does not disclose host CPUs when every shard saw the same host CPU", () => {
-		const same = { cpuModel: "AMD EPYC 9R45", cpuMicroarch: "Zen 5 (Turin)" };
-		const a = shard([
-			{
-				...provider("daytona-vm", [metric("node_web_tooling_runs_per_s", [10])]),
-				observedSpecs: same,
-			},
-		]);
-		const b = shard([
-			{ ...provider("daytona-vm", [metric("pybench_milliseconds", [900])]), observedSpecs: same },
-		]);
-		const merged = aggregateRuns([a, b]);
-		const daytona = merged.providers.find((p) => p.providerId === "daytona-vm");
-		expect(daytona?.observedSpecs.hostCpuModels).toBeUndefined();
-	});
-
 	it("unions rich host metadata across shards and removes byte-identical duplicates", () => {
 		const record = {
 			source: "mise/system-provider" as const,

--- a/packages/results/src/lib/aggregate.ts
+++ b/packages/results/src/lib/aggregate.ts
@@ -115,11 +115,6 @@ function mergeProvider(providerId: string, entries: readonly ReplicateSlice[]): 
 	// observed-specs: first non-undefined value per key wins (all shards of a provider ran the same spec).
 	const observedSpecs: ObservedSpecs = {};
 	let specMatched: boolean | undefined;
-	// Cross-shard hardware heterogeneity: shards of one provider are MEANT to be the same machine, so a
-	// divergent host cpuModel means the provider scheduled them onto different hardware — a confound the
-	// published Run must disclose. cpuModel is the key (cpuMicroarch is derived from it, so distinct
-	// microarchs can't arise without distinct models); collect the distinct disclosures, publish below.
-	const hostCpuModels = new Set<string>();
 	const hostMetadata: HostMetadataRecord[] = [];
 	const seenHostMetadata = new Set<string>();
 
@@ -147,7 +142,6 @@ function mergeProvider(providerId: string, entries: readonly ReplicateSlice[]): 
 				(observedSpecs as Record<string, unknown>)[key] = value;
 			}
 		}
-		if (slice.observedSpecs.cpuModel) hostCpuModels.add(slice.observedSpecs.cpuModel);
 		// specMatched folds ORDER-INDEPENDENTLY across shards (was first-shard-wins, which made ranking
 		// eligibility depend on shard arrival order). The merged provider row shares one aggregate, so a
 		// single shard that ran off the target spec (specMatched === false) contaminates it and
@@ -156,12 +150,6 @@ function mergeProvider(providerId: string, entries: readonly ReplicateSlice[]): 
 		// evidence", see computeSpecMatched).
 		if (slice.specMatched === false) specMatched = false;
 		else if (slice.specMatched === true && specMatched !== false) specMatched = true;
-	}
-
-	// Disclose the distinct host CPUs when the shards saw more than one — names the confound rather than
-	// hiding it behind the "first-wins" cpuModel merged above. Sorted for deterministic output.
-	if (hostCpuModels.size > 1) {
-		observedSpecs.hostCpuModels = [...hostCpuModels].sort((a, b) => a.localeCompare(b));
 	}
 
 	const metrics = [...measured.values()];

--- a/packages/schema/src/run.test.ts
+++ b/packages/schema/src/run.test.ts
@@ -69,8 +69,8 @@ describe("Run schema", () => {
 	});
 
 	it("keeps the v3 replicate fold legal at v4 — version floors are not equality checks", () => {
-		// The v4 aggregate carries the v3 replicate breakdown as well as its own new fields. An "=== '3'"
-		// gate would have rejected its own predecessor's field on every version bump, so the floors compare
+		// The v4 aggregate carries BOTH observedMixtures and the v3 replicate breakdown. An "=== '3'" gate
+		// would have rejected its own predecessor's field on every version bump, so the floors compare
 		// numerically; this pins that so a future v5 can't silently re-break v3 documents.
 		const v4WithReplicates = structuredClone(validRun);
 		v4WithReplicates.schemaVersion = "4";
@@ -81,6 +81,172 @@ describe("Run schema", () => {
 				{ index: 1, samples: [16.08] },
 			];
 		expect(parseRun(v4WithReplicates).providers[0]?.metrics[0]?.replicates).toHaveLength(2);
+	});
+
+	it("rejects a pre-v4 Run that carries observedMixtures", () => {
+		// A pre-v4 consumer handed a Run with mixtures would fall back to the single representative
+		// observedSpecs reading and report a heterogeneous fleet as homogeneous — so the producer must bump
+		// the version rather than smuggle the field into a v3 document.
+		const mixtures = {
+			sandboxes: 2,
+			hostHardware: { abc0123456789def: { count: 2, specs: { cpuModel: "AMD EPYC 9R14" } } },
+			hostNetwork: {},
+		};
+		for (const schemaVersion of ["2", "3"]) {
+			const run = structuredClone(validRun);
+			run.schemaVersion = schemaVersion;
+			const provider = run.providers[0];
+			if (provider) (provider as Record<string, unknown>).observedMixtures = mixtures;
+			expect(() => parseRun(run)).toThrow(/v4-or-later Run/);
+		}
+		const v4 = structuredClone(validRun);
+		v4.schemaVersion = "4";
+		const provider = v4.providers[0];
+		if (provider) (provider as Record<string, unknown>).observedMixtures = mixtures;
+		expect(parseRun(v4).providers[0]?.observedMixtures?.sandboxes).toBe(2);
+	});
+
+	it("rejects a replicate mixture id that resolves to nothing", () => {
+		// A dangling id is worse than an absent one: both read as `undefined` at the point of use, so a
+		// consumer cannot tell "this sandbox disclosed nothing" from "this machine cannot be looked up".
+		const withDangling = structuredClone(validRun);
+		withDangling.schemaVersion = "4";
+		const provider = withDangling.providers[0] as Record<string, unknown>;
+		provider.observedMixtures = {
+			sandboxes: 2,
+			hostHardware: { aaaaaaaaaaaaaaaa: { count: 2, specs: { cpuModel: "AMD EPYC 9R14" } } },
+			hostNetwork: {},
+		};
+		const metric = (provider.metrics as Array<Record<string, unknown>>)[0];
+		if (metric)
+			metric.replicates = [
+				{ index: 0, samples: [16.19, 16.3], hostHardwareId: "aaaaaaaaaaaaaaaa" },
+				{ index: 1, samples: [16.08], hostHardwareId: "bbbbbbbbbbbbbbbb" }, // no such mixture
+			];
+		expect(() => parseRun(withDangling)).toThrow(/hostHardwareId resolves in observedMixtures/);
+
+		// The same document with both ids resolving is accepted.
+		const replicates = metric?.replicates as Array<Record<string, unknown>>;
+		if (replicates[1]) replicates[1].hostHardwareId = "aaaaaaaaaaaaaaaa";
+		expect(parseRun(withDangling).providers[0]?.metrics[0]?.replicates?.[1]?.hostHardwareId).toBe(
+			"aaaaaaaaaaaaaaaa",
+		);
+	});
+
+	it("names the machine on a single-sandbox metric, and refuses both attribution levels at once", () => {
+		// `replicates` only exists at ≥2 clusters, so without a Metric-level id a provider whose suites each
+		// landed one sandbox published its mixtures with nothing pointing at any of them.
+		const withIds = (ids: Record<string, unknown>, replicates?: unknown) => {
+			const run = structuredClone(validRun);
+			run.schemaVersion = "4";
+			const provider = run.providers[0] as Record<string, unknown>;
+			provider.observedMixtures = {
+				sandboxes: 1,
+				hostHardware: { aaaaaaaaaaaaaaaa: { count: 1, specs: { cpuModel: "AMD EPYC 9R14" } } },
+				hostNetwork: {},
+			};
+			const metric = (provider.metrics as Array<Record<string, unknown>>)[0] as Record<
+				string,
+				unknown
+			>;
+			Object.assign(metric, ids);
+			if (replicates) metric.replicates = replicates;
+			return run;
+		};
+		expect(
+			parseRun(withIds({ hostHardwareId: "aaaaaaaaaaaaaaaa" })).providers[0]?.metrics[0]
+				?.hostHardwareId,
+		).toBe("aaaaaaaaaaaaaaaa");
+		// The same referential-integrity rule as every other reference into observedMixtures.
+		expect(() => parseRun(withIds({ hostHardwareId: "bbbbbbbbbbbbbbbb" }))).toThrow(
+			/metric hostHardwareId resolves in observedMixtures/,
+		);
+		// A Metric-level id claims ONE machine for every Sample, which a replicate breakdown contradicts.
+		// Carrying both would let the two levels disagree and leave a consumer to pick one.
+		expect(() =>
+			parseRun(
+				withIds({ hostHardwareId: "aaaaaaaaaaaaaaaa" }, [
+					{ index: 0, samples: [16.19, 16.3] },
+					{ index: 1, samples: [16.08] },
+				]),
+			),
+		).toThrow(/host attribution is per-replicate when it has a replicate breakdown/);
+	});
+
+	it("refuses mixture counts that outrun their own denominator", () => {
+		// `sandboxes` is the whole reason the counts mean anything. Falling short is a real, visible
+		// partial disclosure (a probe saw nothing); exceeding it describes a fleet that never existed,
+		// and every proportion a reader computes from it is arithmetic on a lie.
+		const withMixtures = (sandboxes: number, counts: number[]) => {
+			const run = structuredClone(validRun);
+			run.schemaVersion = "4";
+			const provider = run.providers[0] as Record<string, unknown>;
+			provider.observedMixtures = {
+				sandboxes,
+				hostHardware: Object.fromEntries(
+					counts.map((count, i) => [
+						`${"abcdef0123456789".slice(i, i + 1).repeat(16)}`,
+						{ count, specs: { cpuModel: `cpu-${i}` } },
+					]),
+				),
+				hostNetwork: {},
+			};
+			return run;
+		};
+		expect(() => parseRun(withMixtures(4, [3, 3]))).toThrow(
+			/hostHardware counts sum to at most sandboxes \(got 6 of 4\)/,
+		);
+		// Summing to exactly the denominator, and falling short of it, are both fine.
+		expect(parseRun(withMixtures(4, [3, 1])).providers[0]?.observedMixtures?.sandboxes).toBe(4);
+		expect(parseRun(withMixtures(4, [1])).providers[0]?.observedMixtures?.sandboxes).toBe(4);
+	});
+
+	it("refuses a mixture that discloses nothing", () => {
+		// A category the sandbox saw nothing for is represented by NO mixture and no id, so the counts
+		// visibly fall short of `sandboxes`. An empty mixture would launder that shortfall into a phantom
+		// machine every reader can join to.
+		const run = structuredClone(validRun);
+		run.schemaVersion = "4";
+		const provider = run.providers[0] as Record<string, unknown>;
+		provider.observedMixtures = {
+			sandboxes: 1,
+			hostHardware: { aaaaaaaaaaaaaaaa: { count: 1, specs: {} } },
+			hostNetwork: {},
+		};
+		expect(() => parseRun(run)).toThrow(/mixture whose specs disclose at least one field/);
+	});
+
+	it("rejects a pre-v4 Run whose replicate names a mixture, without needing its own version gate", () => {
+		// A replicate id is unreachable pre-v4 by CONSTRUCTION, not by a second rule: it must resolve into
+		// observedMixtures, and observedMixtures is itself v4-gated. Both routes are pinned here so the
+		// absent gate stays absent for the right reason rather than by oversight.
+		const withIds = (mixtures?: Record<string, unknown>) => {
+			const run = structuredClone(validRun);
+			run.schemaVersion = "3";
+			const provider = run.providers[0] as Record<string, unknown>;
+			if (mixtures) provider.observedMixtures = mixtures;
+			const metric = (provider.metrics as Array<Record<string, unknown>>)[0] as Record<
+				string,
+				unknown
+			>;
+			metric.replicates = [
+				{ index: 0, samples: [16.19, 16.3], hostHardwareId: "aaaaaaaaaaaaaaaa" },
+				{ index: 1, samples: [16.08] },
+			];
+			return run;
+		};
+		// No mixtures to resolve against: referential integrity refuses it.
+		expect(() => parseRun(withIds())).toThrow(/hostHardwareId resolves in observedMixtures/);
+		// Mixtures present so the id resolves — now the version gate on observedMixtures refuses it.
+		expect(() =>
+			parseRun(
+				withIds({
+					sandboxes: 2,
+					hostHardware: { aaaaaaaaaaaaaaaa: { count: 2, specs: { cpuModel: "AMD EPYC 9R14" } } },
+					hostNetwork: {},
+				}),
+			),
+		).toThrow(/v4-or-later Run when a ProviderRun carries observedMixtures/);
 	});
 
 	it("pins a gap's cause to its outcome — a crash cannot be filed as a precondition", () => {
@@ -244,6 +410,26 @@ describe("Run schema", () => {
 		expect(() => parseRun(run)).toThrow(/derived MetricResult without a replicate breakdown/);
 	});
 
+	it("rejects a provider verdict kinder than its per-machine verdicts", () => {
+		// The provider fold cannot be kinder than its parts: one machine off-spec contaminates the shared
+		// aggregate. Checking it here makes the fold rule a property of the document.
+		const run = structuredClone(validRun);
+		run.schemaVersion = "4";
+		const provider = run.providers[0] as Record<string, unknown>;
+		provider.specMatched = true;
+		provider.observedMixtures = {
+			sandboxes: 2,
+			hostHardware: {
+				aaaaaaaaaaaaaaaa: { count: 1, specs: { vcpus: 4 }, specMatched: true },
+				bbbbbbbbbbbbbbbb: { count: 1, specs: { vcpus: 1 }, specMatched: false },
+			},
+			hostNetwork: {},
+		};
+		expect(() => parseRun(run)).toThrow(/specMatched false when any host-hardware mixture failed/);
+		provider.specMatched = false;
+		expect(parseRun(run).providers[0]?.specMatched).toBe(false);
+	});
+
 	it("rejects an unknown schemaVersion", () => {
 		expect(() => parseRun({ ...validRun, schemaVersion: "1" })).toThrow();
 		expect(() => parseRun({ ...validRun, schemaVersion: "5" })).toThrow();
@@ -387,5 +573,41 @@ describe("Run schema", () => {
 				],
 			}),
 		).toThrow();
+	});
+});
+
+describe("mixture category partition", () => {
+	const mixtures = (specs: Record<string, unknown>) => {
+		const run = structuredClone(validRun);
+		run.schemaVersion = "4";
+		const provider = run.providers[0] as Record<string, unknown>;
+		provider.observedMixtures = {
+			sandboxes: 1,
+			hostHardware: { aaaaaaaaaaaaaaaa: { count: 1, specs } },
+			hostNetwork: {},
+		};
+		return run;
+	};
+
+	it("rejects a cross-category or identity field inside a mixture's specs", () => {
+		// arktype IGNORES undeclared keys by default, so without onUndeclaredKey("reject") the partition
+		// was only a producer convention: a hostHardware mixture could carry `egressAsn`, or the `publicIp`
+		// whose inclusion the design says destroys the signal, and still validate.
+		expect(() => parseRun(mixtures({ cpuModel: "AMD EPYC 9R14", egressAsn: "AS14618" }))).toThrow(
+			/must be removed/,
+		);
+		expect(() =>
+			parseRun(mixtures({ cpuModel: "AMD EPYC 9R14", publicIp: "203.0.113.1" })),
+		).toThrow(/must be removed/);
+		expect(parseRun(mixtures({ cpuModel: "AMD EPYC 9R14" })).schemaVersion).toBe("4");
+	});
+
+	it("still ignores undeclared keys on observedSpecs, so published Runs keep parsing", () => {
+		// The rejection is scoped to the category schemas ALONE. observedSpecs must stay permissive: every
+		// committed Run predating this change carries `hostCpuModels`, a field since deleted from the schema.
+		const legacy = structuredClone(validRun);
+		const provider = legacy.providers[0] as Record<string, unknown>;
+		(provider.observedSpecs as Record<string, unknown>).hostCpuModels = ["AMD EPYC 9R14"];
+		expect(parseRun(legacy).providers[0]?.observedSpecs.cpuModel).toBeUndefined();
 	});
 });

--- a/packages/schema/src/run.ts
+++ b/packages/schema/src/run.ts
@@ -26,6 +26,22 @@ export const metricReplicateSchema = type({
 	index: "number.integer >= 0",
 	// This replicate's retained per-pass Samples (>= 1, all finite — enforced by the parent narrow).
 	samples: "number[] >= 1",
+	/**
+	 * WHICH machine and network these Samples were measured on: keys into the provider's
+	 * {@link ObservedMixtures}. Absent when that sandbox's probes disclosed nothing for the category.
+	 *
+	 * Without this the between-machine axis is undecodable. A replicate breakdown says a provider's
+	 * numbers varied across R sandboxes, and `observedMixtures` says the fleet held N distinct machine
+	 * shapes — but nothing joined them, so "is the Intel leg slower than the EPYC leg?" was
+	 * unanswerable from a published Run even though both halves of the answer were in it. The dataset
+	 * already pays R× the provider cost to sample between machines; discarding which machine each
+	 * cluster came from threw away most of what that spend bought.
+	 *
+	 * {@link providerRunSchema} narrows these to real keys of the provider's own mixtures, so an id can
+	 * never dangle.
+	 */
+	"hostHardwareId?": "string >= 1",
+	"hostNetworkId?": "string >= 1",
 });
 export type MetricReplicate = typeof metricReplicateSchema.infer;
 
@@ -48,6 +64,21 @@ export const metricResultSchema = type({
 	// the clusters distinct so render-time inference can resample the between-sandbox level. Absent at
 	// R = 1, so a single-replicate Run is byte-identical to the pre-replicate schema.
 	"replicates?": metricReplicateSchema.array(),
+	/**
+	 * WHICH machine and network produced these Samples, when a single sandbox produced all of them
+	 * (v4+): keys into the provider's {@link ObservedMixtures}, exactly as on {@link MetricReplicate}.
+	 *
+	 * Set only when this Metric came from ONE sandbox — a shard, or an aggregate that merged a single
+	 * replicate for this id. With ≥2 clusters the attribution lives per-replicate, where it is honest;
+	 * one id here would have to name a single machine for samples that may span several.
+	 *
+	 * Without this the join had a hole exactly where the replicate structure is absent. `replicates`
+	 * only exists at ≥2 clusters, so a provider whose suites each landed one sandbox published its
+	 * mixtures with nothing pointing at any of them — the fleet was counted and the numbers were
+	 * unattributable. A metric measured on one machine can always say which.
+	 */
+	"hostHardwareId?": "string >= 1",
+	"hostNetworkId?": "string >= 1",
 	/**
 	 * Marks a COMPUTED Metric (v4+): the economics rows, which are derived from other Metrics plus the
 	 * provider's published price rather than measured in any sandbox.
@@ -77,6 +108,17 @@ export const metricResultSchema = type({
 	// spread that was never measured.
 	if (metric.derived === true && metric.replicates !== undefined) {
 		return ctx.mustBe("a derived MetricResult without a replicate breakdown");
+	}
+	// The two attribution levels are mutually exclusive by construction: a Metric-level id claims ONE
+	// machine for every Sample, which is only true when one sandbox produced them all. Carrying both
+	// would let the levels disagree, and a consumer would have to pick which to believe.
+	if (
+		metric.replicates !== undefined &&
+		(metric.hostHardwareId !== undefined || metric.hostNetworkId !== undefined)
+	) {
+		return ctx.mustBe(
+			"a MetricResult whose host attribution is per-replicate when it has a replicate breakdown",
+		);
 	}
 	if (metric.replicates !== undefined) {
 		// The replicate structure only exists to hold ≥2 clusters; a lone replicate is just `samples`.
@@ -141,25 +183,40 @@ export type HostMetadataField = typeof hostMetadataFieldSchema.infer;
  * One rich host record retained from an in-sandbox producer. `mise/system-provider` is the repo's
  * ASN/geo/DMI probe; `phoronix/result-file-to-json` is PTS's native structured System export. The
  * generic flattened field list deliberately preserves new upstream keys without a Run schema bump.
+ *
+ * On an AGGREGATED Run (v4+) a record is the FOLD of every sandbox that reported these same
+ * non-volatile fields: `sandboxes` counts them, and `hostHardwareId`/`hostNetworkId` name the machine
+ * and network they were on. Before that a record was an anonymous member of a flat bag — so the ten
+ * distinct CPUs modal-vm ran on were present in the file yet attributable to nothing, which is the
+ * same defect {@link ObservedMixtures} fixed one level up.
  */
 export const hostMetadataRecordSchema = type({
 	source: "'mise/system-provider' | 'phoronix/result-file-to-json'",
 	sourceFile: "string >= 1",
 	fields: hostMetadataFieldSchema.array(),
+	/** How many sandboxes reported this record (v4+); absent on a per-shard Run, where it is always 1. */
+	"sandboxes?": "number.integer >= 1",
+	/** The machine and network this record was read on — keys into the provider's mixtures (v4+). */
+	"hostHardwareId?": "string >= 1",
+	"hostNetworkId?": "string >= 1",
 });
 export type HostMetadataRecord = typeof hostMetadataRecordSchema.infer;
 
 /**
- * Observed actuals recorded per Run — what in-sandbox probes actually saw, versus the requested
- * {@link TargetSpec}. All optional: providers differ in what in-sandbox
- * probes can see. `vcpus`/`memoryGb` are the EFFECTIVE Sandbox size (cgroup quota where enforced);
+ * HOST HARDWARE fields — the machine a sandbox landed on, as the sandbox could see it. This is one of
+ * the two {@link ObservedMixtures} hash categories: a provider that scheduled its sandboxes across
+ * more than one machine shape produces more than one hostHardware mixture, and the count on each says
+ * how many sandboxes landed there.
+ *
+ * `vcpus`/`memoryGb`/`diskGb` are the EFFECTIVE sandbox size (the cgroup quota where enforced) while
  * `hostVcpus`/`hostMemoryGb` disclose the underlying machine when probes see through the container
- * boundary (e.g. Daytona: a 4-vCPU quota on a 48-thread host). `cpuMicroarch` is a HOST-side
- * generation/microarch label derived from `cpuModel` (e.g. "Zen 5 (Turin)"). `hostCpuModels` is set
- * only by the aggregate path — the distinct host CPU models a provider's shards disclosed, present
- * only when there was more than one (a scheduling confound the published Run names rather than hides).
+ * boundary (e.g. Daytona: a 4-vCPU quota on a 48-thread host) — the host-vs-effective split of
+ * ADR 0005, which the field docs keep explicit. They share ONE hash category on purpose: a provider
+ * handing out 4 vCPU on some sandboxes and 2 on others is exactly the heterogeneity this disclosure
+ * exists to make impossible to miss, so the effective size is part of "which machine did I get".
+ * `cpuMicroarch` is a HOST-side generation label derived from `cpuModel` (e.g. "Zen 5 (Turin)").
  */
-export const observedSpecsSchema = type({
+const hostHardwareSpecFields = {
 	"vcpus?": "number",
 	"memoryGb?": "number",
 	"diskGb?": "number",
@@ -179,30 +236,187 @@ export const observedSpecsSchema = type({
 	// microVM (both read "unknown"), so the declared per-provider isolation stays the source of truth
 	// and this is only a cross-check the leaderboard flags when the two disagree.
 	"detectedIsolation?": "string",
-	"user?": "string",
-	// The distinct host CPU models when merged shards of one provider disclosed more than one — the
-	// aggregate-only heterogeneity disclosure (cpuModel is the key; cpuMicroarch is derived from it).
-	"hostCpuModels?": "string[]",
-	// Rich identity from benchmark:system:provider. ASN/org describe public egress; DMI describes the
-	// machine/hypervisor. Full source records also live in ProviderRun.hostMetadata.
-	"publicIp?": "string",
+	// DMI, from benchmark:system:provider — describes the machine/hypervisor the sandbox ran on.
+	"manufacturer?": "string",
+	"productName?": "string",
+	"biosVendor?": "string",
+} as const;
+
+/**
+ * HOST NETWORK fields — which network a sandbox egressed through, and from where. The second
+ * {@link ObservedMixtures} hash category, from benchmark:system:provider's ASN/geo lookup.
+ *
+ * `publicIp` and `reverseDns` are deliberately NOT here: they identify the individual sandbox rather
+ * than its network, so hashing them would mint one "mixture" per sandbox and report every count as 1 —
+ * destroying the very signal the categories exist to carry. They live in
+ * {@link sandboxIdentitySpecFields} instead, and `networkPrefix` (the announced prefix) is what
+ * carries the address-space dimension into the hash.
+ */
+const hostNetworkSpecFields = {
 	"egressOrg?": "string",
 	"egressAsn?": "string",
 	"egressOrgName?": "string",
-	"reverseDns?": "string",
+	"networkPrefix?": "string",
 	"city?": "string",
 	"region?": "string",
 	"country?": "string",
 	"location?": "string",
 	"timezone?": "string",
-	"manufacturer?": "string",
-	"productName?": "string",
-	"biosVendor?": "string",
-	"networkPrefix?": "string",
+	// Which lookup answered — a mixture whose geo came from a different source is a different
+	// observation, not a silently comparable one.
 	"asnSource?": "string",
 	"geoSource?": "string",
+} as const;
+
+/**
+ * Per-sandbox IDENTITY fields — true observations, but unique (or near-unique) to a single sandbox,
+ * so they are excluded from both mixture hashes. Full source records live in
+ * {@link ProviderRun.hostMetadata} when the individual value is what a reader wants.
+ */
+const sandboxIdentitySpecFields = {
+	"publicIp?": "string",
+	"reverseDns?": "string",
+	"user?": "string",
+} as const;
+
+/**
+ * The hostHardware mixture category as its own Type — the `specs` of a hardware mixture, so a mixture
+ * carrying a network or identity field is rejected at the boundary rather than merely discouraged.
+ *
+ * `onUndeclaredKey("reject")` is what makes that true: arktype IGNORES undeclared keys by default, so
+ * without it a serialized `hostNetwork` mixture carrying `cpuModel` — or either category carrying the
+ * `publicIp` whose inclusion the design says destroys the signal — validated cleanly and the partition
+ * was only a producer convention. Scoped to the category schemas alone, NOT to
+ * {@link observedSpecsSchema}: that one must keep ignoring undeclared keys so already-published Runs
+ * carrying since-deleted fields (`hostCpuModels`) still parse.
+ */
+export const hostHardwareSpecsSchema = type(hostHardwareSpecFields).onUndeclaredKey("reject");
+export type HostHardwareSpecs = typeof hostHardwareSpecsSchema.infer;
+
+/** The hostNetwork mixture category as its own Type; see {@link hostHardwareSpecsSchema}. */
+export const hostNetworkSpecsSchema = type(hostNetworkSpecFields).onUndeclaredKey("reject");
+export type HostNetworkSpecs = typeof hostNetworkSpecsSchema.infer;
+
+/**
+ * Observed actuals recorded per Run — what in-sandbox probes actually saw, versus the requested
+ * {@link TargetSpec}. All optional: providers differ in what in-sandbox probes can see.
+ *
+ * COMPOSED from the three field groups above rather than written out flat, and that composition is
+ * load-bearing: the two mixture categories are literally groups this type is built from, so a field
+ * added to ObservedSpecs must be added to one of them and therefore cannot end up unclassified. A flat
+ * list plus a separate key list would let the two drift — a new field silently absent from every
+ * mixture hash, which is exactly the "looks complete, quietly isn't" failure the categories exist to
+ * remove. See {@link ObservedMixtures}.
+ *
+ * On an AGGREGATED Run this carries one representative reading — the DOMINANT mixture per category, i.e.
+ * the one the most sandboxes reported — which is a summary, NOT a claim that every sandbox saw it.
+ * `observedMixtures` is the complete, countable disclosure; prefer it whenever the question is "how many
+ * distinct X did this provider actually put us on".
+ */
+export const observedSpecsSchema = type({
+	...hostHardwareSpecFields,
+	...hostNetworkSpecFields,
+	...sandboxIdentitySpecFields,
 });
 export type ObservedSpecs = typeof observedSpecsSchema.infer;
+
+/**
+ * A mixture must DESCRIBE something. All category fields are optional, so `specs: {}` is structurally
+ * legal — and it would be a counted, referenceable "machine shape" built from a probe that disclosed
+ * nothing, which inverts the contract: a category the sandbox saw nothing for is represented by no
+ * mixture and no id at all, so the counts visibly fall short of `sandboxes`. An empty mixture would
+ * launder that shortfall into a phantom machine every reader can join to.
+ */
+function nonEmptySpecs(
+	mixture: { specs: object },
+	ctx: { mustBe: (expected: string) => false },
+): boolean {
+	return (
+		Object.keys(mixture.specs).length > 0 ||
+		ctx.mustBe("a mixture whose specs disclose at least one field")
+	);
+}
+
+/**
+ * One observed HOST-NETWORK mixture: a distinct combination of the egress/geo fields, plus how many of
+ * the provider's sandboxes reported exactly that combination. `count` is a sandbox count, so the counts
+ * within a category sum to the number of sandboxes that disclosed at least one of its fields — which
+ * is ≤ {@link ObservedMixtures.sandboxes} whenever some sandbox's probe saw nothing.
+ *
+ * Named for its category rather than left generic: the two mixture types are deliberately NOT the same
+ * shape (see {@link observedHardwareMixtureSchema}), so a category-neutral name would read as the shared
+ * base of both and invite the verdict field to be added here too.
+ */
+export const observedNetworkMixtureSchema = type({
+	count: "number.integer >= 1",
+	specs: hostNetworkSpecsSchema,
+}).narrow(nonEmptySpecs);
+export type ObservedNetworkMixture = typeof observedNetworkMixtureSchema.infer;
+
+/**
+ * A host-hardware mixture, which additionally carries its OWN spec verdict (v4+).
+ *
+ * `ProviderRun.specMatched` is one boolean folded across every shard, and on a mixed fleet that is too
+ * coarse to act on: run 30510718771 put modal-vm's sandboxes on ten different machines under a single
+ * `specMatched: true`, so a provider honoring the target on nine shapes and missing it on the tenth
+ * reads identically to one that honored it everywhere. Per machine, the verdict is answerable —
+ * `vcpus`/`memoryGb` are hostHardware-category fields, so each mixture carries what the check needs.
+ *
+ * Deliberately absent from the NETWORK mixture type rather than optional-and-always-undefined there:
+ * the target spec says nothing about egress, so a network mixture has no verdict to give and should
+ * not be able to claim one.
+ */
+export const observedHardwareMixtureSchema = type({
+	count: "number.integer >= 1",
+	specs: hostHardwareSpecsSchema,
+	/** Whether THIS machine honored the pinned target; absent when its probes saw too little to judge. */
+	"specMatched?": "boolean",
+}).narrow(nonEmptySpecs);
+export type ObservedHardwareMixture = typeof observedHardwareMixtureSchema.infer;
+
+/**
+ * The precise, countable answer to "how heterogeneous was this provider in this run" — keyed by a
+ * stable content hash of the combination, so the same machine shape or egress network carries the same
+ * id in every run and can be tracked across the dataset series.
+ *
+ * This exists because a single {@link ObservedSpecs} on an aggregated ProviderRun reads like a
+ * property of the provider while actually being one sandbox's reading: a provider spread across three
+ * CPU generations and two regions rendered identically to one that never moved. A reader could not
+ * tell, and nothing in the document disclosed the mixture. Here, `Object.keys(hostHardware).length` IS
+ * the number of distinct machine shapes observed, and each `count` says how many sandboxes landed on
+ * it — no inference required.
+ *
+ * `sandboxes` is the denominator: how many sandboxes (one per merged shard, i.e. per
+ * `(suite, replicate)` cell) the provider contributed. Without it a category's counts are
+ * uninterpretable — "one hardware mixture, count 10" cannot be told apart from a homogeneous fleet
+ * (10 of 10) or a mostly-blind one (10 of 30).
+ */
+export const observedMixturesSchema = type({
+	sandboxes: "number.integer >= 1",
+	hostHardware: type({ "[string]": observedHardwareMixtureSchema }),
+	hostNetwork: type({ "[string]": observedNetworkMixtureSchema }),
+}).narrow((mixtures, ctx) => {
+	// A category's counts are sandbox counts drawn from ONE reading per sandbox, so their sum cannot
+	// exceed the denominator. It may fall short — that is the visible partial disclosure a category
+	// records when some sandbox's probe saw nothing — but a sum ABOVE `sandboxes` describes a fleet
+	// that never existed, and every proportion a reader computes from it ("6 of 4 sandboxes were on
+	// Zen 5") is then arithmetic on a lie. The denominator is the whole reason the counts mean
+	// anything, so it is enforced rather than documented.
+	for (const [category, entries] of [
+		["hostHardware", mixtures.hostHardware],
+		["hostNetwork", mixtures.hostNetwork],
+	] as const) {
+		let total = 0;
+		for (const mixture of Object.values(entries)) total += mixture.count;
+		if (total > mixtures.sandboxes) {
+			return ctx.mustBe(
+				`ObservedMixtures whose ${category} counts sum to at most sandboxes (got ${total} of ${mixtures.sandboxes})`,
+			);
+		}
+	}
+	return true;
+});
+export type ObservedMixtures = typeof observedMixturesSchema.infer;
 
 /** The pinned size every provider is asked to match; compared against each provider's {@link ObservedSpecs}. */
 export const targetSpecSchema = type({
@@ -384,6 +598,14 @@ export const providerRunSchema = type({
 	// Whether observed specs honored the pinned target spec; absent when probes saw too little to judge.
 	"specMatched?": "boolean",
 	observedSpecs: observedSpecsSchema,
+	/**
+	 * The countable heterogeneity disclosure — distinct host-hardware and host-network combinations with
+	 * a sandbox count each. Set by the AGGREGATE path only (a single shard is one sandbox, so its
+	 * mixtures would be a tautology) and therefore v4-only, gated in {@link runSchema}'s narrow. Absent
+	 * on shards and on every Run published before v4; `observedSpecs` remains the representative
+	 * single-value summary beside it.
+	 */
+	"observedMixtures?": observedMixturesSchema,
 	/** Rich, source-attributed host records; optional for historical Runs predating capture. */
 	"hostMetadata?": hostMetadataRecordSchema.array(),
 	metrics: metricResultSchema.array(),
@@ -410,7 +632,76 @@ export const providerRunSchema = type({
 			run.specMatched === undefined ||
 			Object.keys(run.observedSpecs).length > 0 ||
 			ctx.mustBe("a ProviderRun with observedSpecs when specMatched carries a verdict"),
-	);
+	)
+	.narrow((run, ctx) => {
+		// Referential integrity for the replicate→machine join. A dangling id is worse than an absent
+		// one: absent reads as "this sandbox disclosed nothing", while dangling reads as a real machine
+		// that simply cannot be looked up — and the natural consumer (`mixtures[replicate.hostHardwareId]`)
+		// yields undefined for both, so the two failure modes are indistinguishable at the point of use.
+		// Rejecting here keeps "an id resolves" a guarantee rather than a hope.
+		// `Object.hasOwn` against the maps directly rather than materialising two key Sets: a provider has
+		// at most a handful of mixtures, and the common case by far — a shard, or any pre-v4 Run — has none
+		// at all, where building Sets from `{}` would allocate on every provider row of every parse.
+		const hardware = run.observedMixtures?.hostHardware;
+		const network = run.observedMixtures?.hostNetwork;
+		const resolves = (map: object | undefined, id: string): boolean =>
+			map !== undefined && Object.hasOwn(map, id);
+		for (const metric of run.metrics) {
+			if (metric.hostHardwareId !== undefined && !resolves(hardware, metric.hostHardwareId)) {
+				return ctx.mustBe(
+					`a ProviderRun whose metric hostHardwareId resolves in observedMixtures (${metric.metricId} → ${metric.hostHardwareId})`,
+				);
+			}
+			if (metric.hostNetworkId !== undefined && !resolves(network, metric.hostNetworkId)) {
+				return ctx.mustBe(
+					`a ProviderRun whose metric hostNetworkId resolves in observedMixtures (${metric.metricId} → ${metric.hostNetworkId})`,
+				);
+			}
+			for (const replicate of metric.replicates ?? []) {
+				if (
+					replicate.hostHardwareId !== undefined &&
+					!resolves(hardware, replicate.hostHardwareId)
+				) {
+					return ctx.mustBe(
+						`a ProviderRun whose replicate hostHardwareId resolves in observedMixtures (${metric.metricId} r${replicate.index} → ${replicate.hostHardwareId})`,
+					);
+				}
+				if (replicate.hostNetworkId !== undefined && !resolves(network, replicate.hostNetworkId)) {
+					return ctx.mustBe(
+						`a ProviderRun whose replicate hostNetworkId resolves in observedMixtures (${metric.metricId} r${replicate.index} → ${replicate.hostNetworkId})`,
+					);
+				}
+			}
+		}
+		// Host records join the same way and get the same guarantee — one rule for every reference into
+		// observedMixtures, so "an id resolves" holds document-wide rather than per-field.
+		for (const record of run.hostMetadata ?? []) {
+			if (record.hostHardwareId !== undefined && !resolves(hardware, record.hostHardwareId)) {
+				return ctx.mustBe(
+					`a ProviderRun whose hostMetadata hostHardwareId resolves in observedMixtures (${record.sourceFile} → ${record.hostHardwareId})`,
+				);
+			}
+			if (record.hostNetworkId !== undefined && !resolves(network, record.hostNetworkId)) {
+				return ctx.mustBe(
+					`a ProviderRun whose hostMetadata hostNetworkId resolves in observedMixtures (${record.sourceFile} → ${record.hostNetworkId})`,
+				);
+			}
+		}
+		return true;
+	})
+	.narrow((run, ctx) => {
+		// The provider verdict is the fold of the per-machine ones, so it cannot be kinder than its
+		// parts: one machine off-spec contaminates the shared aggregate and disqualifies the provider.
+		// Checking it here makes the fold rule a property of the document rather than a convention of
+		// whichever code last wrote it.
+		const mixtures = Object.values(run.observedMixtures?.hostHardware ?? {});
+		if (mixtures.some((mixture) => mixture.specMatched === false) && run.specMatched !== false) {
+			return ctx.mustBe(
+				"a ProviderRun with specMatched false when any host-hardware mixture failed the target spec",
+			);
+		}
+		return true;
+	});
 export type ProviderRun = typeof providerRunSchema.infer;
 
 /**
@@ -459,8 +750,16 @@ export function providerStatusText(p: ProviderRun): string {
  * v4 makes the document SELF-DESCRIBING — every fact a reader needs is expressible from the file,
  * rather than recoverable only by knowing something the file does not say:
  *
+ *  - {@link ProviderRun.observedMixtures} counts the distinct host-hardware and host-network
+ *    combinations a provider's sandboxes reported, which one representative `observedSpecs` reading
+ *    could only imply.
+ *  - {@link MetricReplicate} names the mixture its sandbox reported, joining a sample cluster to the
+ *    machine that produced it instead of to an anonymous index; a single-sandbox
+ *    {@link MetricResult} names its own, so the join has no hole below two clusters.
  *  - {@link ResultGap.cause} classifies a failure as data rather than prose.
  *  - {@link MetricResult.derived} separates a computed row from a measured one without a catalog lookup.
+ *  - Host records are folded and attributed to their machine.
+ *  - Each host-hardware mixture carries its own spec verdict.
  *
  * Every version validates here — already-published Runs are read unchanged, and the parser never
  * migrates them in place.
@@ -499,16 +798,36 @@ export const runSchema = type({
 		}
 	}
 	// The v4 self-description fields, gated together because they arrived together. A pre-v4 consumer
-	// handed one would fall back to the pre-v4 reading of the same fact — re-parsed `reason` prose, a
-	// price treated as a measurement — each a quietly wrong answer, never a loud one. Reported by FIELD
-	// rather than as one blanket message, so the error names what to fix.
+	// handed any of them would fall back to the pre-v4 reading of the same fact — a heterogeneous fleet
+	// read as homogeneous, an anonymous replicate cluster, re-parsed `reason` prose, a price treated as a
+	// measurement, a folded host record read as one sandbox's — each a quietly wrong answer, never a loud
+	// one. Reported by FIELD rather than as one blanket message, so the error names what to fix.
 	if (version < 4) {
 		for (const provider of run.providers) {
+			if (provider.observedMixtures !== undefined) {
+				return ctx.mustBe("a v4-or-later Run when a ProviderRun carries observedMixtures");
+			}
+			// No separate check for a replicate's mixture ids, or for a mixture's own `specMatched`: both
+			// are unreachable pre-v4 by construction rather than by a second rule. A replicate id must
+			// RESOLVE (the ProviderRun narrow, which runs before this one), and `specMatched` lives inside
+			// a mixture — so each requires `observedMixtures`, which the check above has already refused.
+			// Restating them here would read as defence-in-depth while actually being dead branches that
+			// no test can reach and that a later reader would have to re-derive as unreachable.
 			if (provider.gaps.some((gap) => gap.cause !== undefined)) {
 				return ctx.mustBe("a v4-or-later Run when a ResultGap carries a structured cause");
 			}
 			if (provider.metrics.some((metric) => metric.derived !== undefined)) {
 				return ctx.mustBe("a v4-or-later Run when a MetricResult carries the derived marker");
+			}
+			if (
+				provider.hostMetadata?.some(
+					(record) =>
+						record.sandboxes !== undefined ||
+						record.hostHardwareId !== undefined ||
+						record.hostNetworkId !== undefined,
+				)
+			) {
+				return ctx.mustBe("a v4-or-later Run when a HostMetadataRecord is folded or attributed");
 			}
 		}
 	}


### PR DESCRIPTION
**RUN SCHEMA v4 — make the benchmark dataset self-describing**
Shipped as an 8-PR stack (merge bottom-up, each branch independently green):

1. #292 — schema: open Run v4 (numeric version floors) + the closed `GapCause` taxonomy
2. #293 — schema: carry a gap's cause on its on-disk marker
3. #294 — harness: `GapError` — classify a failure at the site that knows it
4. #295 — results: author causes in the normalizer, read them in the leaderboard
5. #296 — schema: `MetricResult.derived` — mark a computed row in the document
6. #297 — schema: `ObservedMixtures`, the replicate→machine join, per-machine verdicts
7. #298 — results: build the counted mixtures and fold host records onto them
8. #299 — results: aggregate onto the mixtures instead of onto shard order

↑ **This PR is #297 (6/8)**, based on #296.

---

Run 30510718771 makes the cost concrete: modal-vm's 12 realworld replicates were spread
over TEN CPU models, Intel Xeon Platinum alongside five EPYC generations, published
under a single `specMatched: true` and a headline `cpuModel` that appears in 10 of its
78 host records. Nothing in the document said so. A single `ObservedSpecs` on an
aggregated ProviderRun reads like a property of the provider while actually being one
sandbox's reading.

`ObservedMixtures` replaces that inference with arithmetic: per provider, `sandboxes`
(the denominator) plus two maps from a stable content hash to `{count, specs}`, one for
host hardware and one for host network. `Object.keys(hostHardware).length` IS the
number of distinct machine shapes observed; each `count` is how many sandboxes landed
on it.

Around it, four things the shape alone would not guarantee:

  * `MetricReplicate.hostHardwareId`/`hostNetworkId` join a sample cluster to the
    machine that produced it. Both halves of "is the Intel leg slower than the EPYC
    leg?" were already in the document with nothing connecting them.
  * `HostMetadataRecord` gains `sandboxes` and the same two ids, so a folded record
    says how many sandboxes it speaks for and which machine it describes.
  * Each host-hardware mixture carries its OWN `specMatched`. One boolean cannot cover
    a ten-machine fleet. The NETWORK mixture type has no such field at all rather than
    an optional-and-always-undefined one: the target spec says nothing about egress, so
    a network mixture must not be able to claim a verdict. A narrow enforces that the
    provider fold is never kinder than its parts.
  * Every reference into `observedMixtures` is narrowed to a RESOLVABLE key. A dangling
    id and an absent one both read as `undefined` at the point of use, and only one is
    honest.

Two design rules make the categories trustworthy rather than merely present.
`ObservedSpecs` is COMPOSED from the category field groups, so a new field must join a
group to exist and cannot end up unclassified. And the category schemas
`onUndeclaredKey("reject")` — arktype ignores undeclared keys by default, so without it
a `hostNetwork` mixture carrying `cpuModel` validated cleanly and the partition was
only a producer convention. Scoped to the category schemas ALONE: `observedSpecs` must
stay permissive so published Runs carrying the removed `hostCpuModels` still parse.

Pre-v4 unreachability is by construction rather than by extra rules: a replicate id
must resolve into `observedMixtures`, and a mixture's `specMatched` lives inside one,
so the single gate on `observedMixtures` refuses both without redundant per-field
checks.

BLAST RADIUS: `hostCpuModels` is deleted from the schema, which forces its only
producer — the aggregate's cross-shard CPU-model Set — and that producer's two tests to
go with it in this branch. The counted replacement lands two PRs up, so the results
suite dips by two tests here; nothing read the field (the ADR is the only other mention,
amended at the top of the stack), and already-published Runs carrying it still validate
because `observedSpecs` ignores undeclared keys.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Count and disclose each provider’s fleet with `observedMixtures`, replacing implied heterogeneity and joining both replicates and single-sandbox metrics to concrete machines and networks. Enforces v4-only gating, strict id resolution, non-empty/partitioned specs, and per-category counts ≤ sandboxes.

- **New Features**
  - Added `ProviderRun.observedMixtures` (aggregate-only): `sandboxes` plus `hostHardware`/`hostNetwork` maps keyed by stable hash with `{count, specs}`; hardware mixtures carry `specMatched`, and the provider verdict cannot be kinder than its parts.
  - Host attribution: `MetricReplicate.hostHardwareId`/`hostNetworkId`; single-sandbox `MetricResult`-level ids; mutually exclusive with `replicates`. `HostMetadataRecord` gains `sandboxes` and the same ids. All ids must resolve in the provider’s mixtures.
  - Partition and integrity: `ObservedSpecs` is composed from host-hardware, host-network, and sandbox-identity groups; mixture categories reject undeclared keys; mixtures must disclose ≥1 field; per-category counts may not exceed `sandboxes`.

- **Migration**
  - Emit these fields only at schemaVersion "4": `observedMixtures`, metric/replicate mixture ids, per-machine verdicts, and folded/attributed `HostMetadata`.
  - Remove `observedSpecs.hostCpuModels` and its aggregation in `packages/results`; use `observedMixtures` for heterogeneity.
  - Ensure all `hostHardwareId`/`hostNetworkId` values (metrics, replicates, host metadata) resolve to `observedMixtures`; unresolved ids fail parsing.

<sup>Written for commit 8454e225c3d720916471cb9ced14633710dc40ec. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/starslingdev/hpc-sandbox-benchmarks/pull/297?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

