### PR TITLE
feat(results): build the counted mixtures and fold host records onto them

### DIFF
--- a/packages/results/src/index.ts
+++ b/packages/results/src/index.ts
@@ -30,6 +30,14 @@ export {
 } from "./lib/leaderboard.ts";
 export { type NormalizeInput, normalizeResultsTree } from "./lib/normalize-tree.ts";
 export {
+	buildObservedMixtures,
+	foldHostMetadata,
+	type HostMetadataRecordInput,
+	type ObservedMixtureIds,
+	observedMixtureIds,
+	representativeSpecs,
+} from "./lib/observed-mixtures.ts";
+export {
 	type CompareRunsOptions,
 	compareRuns,
 	DEFAULT_THRESHOLD,

--- a/packages/results/src/lib/host-metadata.ts
+++ b/packages/results/src/lib/host-metadata.ts
@@ -10,6 +10,31 @@ import type { HostMetadataField, HostMetadataRecord } from "@sandbox-benchmarks/
 
 const PTS_METADATA_FILE = /^pts_.+--metadata\.json$/;
 
+/**
+ * Field-path suffixes whose value changes on every sandbox even when nothing about the host does — a
+ * wall-clock stamp of when that particular run happened.
+ *
+ * They are excluded from a host record's IDENTITY when the aggregate folds duplicates, because
+ * including them defeated deduplication entirely: records were folded only when byte-identical, and the
+ * timestamp never repeats, so one provider's 21 distinct source files landed as 82 near-identical
+ * records. Host metadata was 54% of the committed dataset while describing a handful of machines.
+ *
+ * This lives beside the flattening that PRODUCES these paths, not in the Run schema. The schema
+ * deliberately does not know either source's evolving key vocabulary (see the module note above), and a
+ * `.timestamp` suffix heuristic is exactly that kind of source-specific knowledge — in the contract it
+ * would also make any upstream field whose flattened path happens to end in `.timestamp` unpublishable
+ * on a folded record.
+ *
+ * Matched by suffix rather than exact path because the path is prefixed by the PTS result identifier
+ * (`ci.timestamp`), which is not fixed.
+ */
+export const VOLATILE_HOST_METADATA_PATH_SUFFIXES = [".timestamp"] as const;
+
+/** Whether a host-metadata field path is a per-run stamp rather than a property of the host. */
+export function isVolatileHostMetadataPath(path: string): boolean {
+	return VOLATILE_HOST_METADATA_PATH_SUFFIXES.some((suffix) => path.endsWith(suffix));
+}
+
 function parseJson(path: string): unknown {
 	try {
 		return JSON.parse(readFileSync(path, "utf8"));

--- a/packages/results/src/lib/observed-mixtures.test.ts
+++ b/packages/results/src/lib/observed-mixtures.test.ts
@@ -1,0 +1,254 @@
+import { describe, expect, it } from "bun:test";
+import type { HostMetadataRecord, ObservedSpecs } from "@sandbox-benchmarks/schema";
+import {
+	hostHardwareSpecsSchema,
+	hostNetworkSpecsSchema,
+	observedMixturesSchema,
+	TARGET_SPEC,
+} from "@sandbox-benchmarks/schema";
+import {
+	buildObservedMixtures,
+	foldHostMetadata,
+	observedMixtureIds,
+	representativeSpecs,
+} from "./observed-mixtures.ts";
+
+const GENOA: ObservedSpecs = { cpuModel: "AMD EPYC 9R14", cpuMicroarch: "Zen 4 (Genoa)" };
+const TURIN: ObservedSpecs = { cpuModel: "AMD EPYC 9R45", cpuMicroarch: "Zen 5 (Turin)" };
+const ASHBURN: ObservedSpecs = { egressAsn: "AS14618", city: "Ashburn", country: "US" };
+const FRANKFURT: ObservedSpecs = { egressAsn: "AS16509", city: "Frankfurt", country: "DE" };
+
+describe("buildObservedMixtures", () => {
+	it("returns undefined with no readings — a provider with no sandbox has no mixture to disclose", () => {
+		expect(buildObservedMixtures([])).toBeUndefined();
+	});
+
+	it("collapses identical readings into one mixture carrying the sandbox count", () => {
+		const mixtures = buildObservedMixtures([
+			{ ...GENOA, ...ASHBURN },
+			{ ...GENOA, ...ASHBURN },
+			{ ...GENOA, ...ASHBURN },
+		]);
+		expect(mixtures?.sandboxes).toBe(3);
+		expect(Object.values(mixtures?.hostHardware ?? {})).toEqual([{ count: 3, specs: GENOA }]);
+		expect(Object.values(mixtures?.hostNetwork ?? {})).toEqual([{ count: 3, specs: ASHBURN }]);
+	});
+
+	it("separates the two categories — hardware heterogeneity does not fragment the network tally", () => {
+		// Two machines behind ONE egress network. A single combined hash would report two mixtures for both
+		// categories and imply the network moved when only the silicon did.
+		const mixtures = buildObservedMixtures([
+			{ ...GENOA, ...ASHBURN },
+			{ ...TURIN, ...ASHBURN },
+		]);
+		expect(Object.keys(mixtures?.hostHardware ?? {})).toHaveLength(2);
+		expect(Object.values(mixtures?.hostNetwork ?? {})).toEqual([{ count: 2, specs: ASHBURN }]);
+	});
+
+	it("orders mixtures by descending count so the fleet's typical machine leads", () => {
+		const mixtures = buildObservedMixtures([GENOA, TURIN, TURIN]);
+		expect(Object.values(mixtures?.hostHardware ?? {}).map((m) => m.count)).toEqual([2, 1]);
+		expect(Object.values(mixtures?.hostHardware ?? {})[0]?.specs).toEqual(TURIN);
+	});
+
+	it("hashes independently of property insertion order", () => {
+		// The same machine read by two probes that filled the fields in different orders must be ONE
+		// mixture. Without the canonical key sort it would split in two and overstate heterogeneity.
+		const forward: ObservedSpecs = { cpuModel: "AMD EPYC 9R45", cpuMicroarch: "Zen 5 (Turin)" };
+		const backward: ObservedSpecs = { cpuMicroarch: "Zen 5 (Turin)", cpuModel: "AMD EPYC 9R45" };
+		const mixtures = buildObservedMixtures([forward, backward]);
+		expect(Object.values(mixtures?.hostHardware ?? {})).toEqual([{ count: 2, specs: forward }]);
+	});
+
+	it("gives one combination the same id in independent builds, so ids compare across runs", () => {
+		const a = buildObservedMixtures([GENOA]);
+		const b = buildObservedMixtures([GENOA, TURIN]);
+		const idA = Object.keys(a?.hostHardware ?? {})[0];
+		expect(idA).toBeDefined();
+		expect(Object.keys(b?.hostHardware ?? {})).toContain(idA as string);
+	});
+
+	it("excludes per-sandbox identity fields from both hashes", () => {
+		// publicIp/reverseDns/user identify the sandbox, not its machine or network. Hashing them would
+		// mint one mixture per sandbox and report every count as 1 — the disclosure would be noise.
+		const mixtures = buildObservedMixtures([
+			{ ...GENOA, ...ASHBURN, publicIp: "203.0.113.1", reverseDns: "a.example", user: "root" },
+			{ ...GENOA, ...ASHBURN, publicIp: "203.0.113.2", reverseDns: "b.example", user: "root" },
+		]);
+		expect(Object.values(mixtures?.hostHardware ?? {})).toEqual([{ count: 2, specs: GENOA }]);
+		expect(Object.values(mixtures?.hostNetwork ?? {})).toEqual([{ count: 2, specs: ASHBURN }]);
+	});
+
+	it("omits a category entirely when no sandbox disclosed any of its fields", () => {
+		// An empty object is not an observed mixture. Recording one would invent a machine shape nobody
+		// saw; leaving it out keeps `sandboxes` visibly larger than the summed counts instead.
+		const mixtures = buildObservedMixtures([GENOA, GENOA]);
+		expect(mixtures?.sandboxes).toBe(2);
+		expect(mixtures?.hostNetwork).toEqual({});
+	});
+
+	it("counts a blind sandbox in the denominator but in no mixture", () => {
+		const mixtures = buildObservedMixtures([GENOA, {}, {}]);
+		expect(mixtures?.sandboxes).toBe(3);
+		expect(Object.values(mixtures?.hostHardware ?? {}).map((m) => m.count)).toEqual([1]);
+	});
+
+	it("keeps the two hash categories disjoint", () => {
+		// The partition is structural — observedSpecsSchema is COMPOSED from the groups, and each mixture
+		// kind is typed by its own group — so a key that is not a field of its group is now unspellable. The
+		// one thing types cannot catch is a field spelled into BOTH groups: the object spread would accept
+		// it silently and both categories would hash it.
+		const hardware = new Set(hostHardwareSpecsSchema.props.map((prop) => String(prop.key)));
+		const shared = hostNetworkSpecsSchema.props
+			.map((prop) => String(prop.key))
+			.filter((key) => hardware.has(key));
+		expect(shared).toEqual([]);
+	});
+
+	it("emits ids that are keys of the map built from the same readings", () => {
+		// This is what lets providerRunSchema demand every replicate id resolve: the id function and the
+		// map builder share one projection and one hash, so agreement is structural, not coincidental.
+		const readings = [
+			{ ...GENOA, ...ASHBURN },
+			{ ...TURIN, ...FRANKFURT },
+			{ ...GENOA, ...FRANKFURT },
+		];
+		const mixtures = buildObservedMixtures(readings);
+		for (const reading of readings) {
+			const ids = observedMixtureIds(reading);
+			expect(Object.keys(mixtures?.hostHardware ?? {})).toContain(ids.hostHardwareId as string);
+			expect(Object.keys(mixtures?.hostNetwork ?? {})).toContain(ids.hostNetworkId as string);
+		}
+	});
+
+	it("emits no id for a category the sandbox disclosed nothing for", () => {
+		const ids = observedMixtureIds(GENOA);
+		expect(ids.hostHardwareId).toBeDefined();
+		expect(ids.hostNetworkId).toBeUndefined();
+		expect(observedMixtureIds({})).toEqual({});
+	});
+
+	it("picks the dominant mixture's specs, not the first-seen one", () => {
+		const mixtures = buildObservedMixtures([
+			{ ...GENOA, ...FRANKFURT },
+			{ ...TURIN, ...ASHBURN },
+			{ ...TURIN, ...ASHBURN },
+		]);
+		expect(mixtures).toBeDefined();
+		if (!mixtures) return;
+		expect(representativeSpecs(mixtures)).toEqual({ ...TURIN, ...ASHBURN });
+	});
+
+	it("omits per-sandbox identity, so re-aggregating in another order emits the same document", () => {
+		// publicIp/reverseDns/user used to be back-filled from whichever shard arrived first, which made a
+		// re-aggregation of the SAME shards produce a different document — churn in a committed dataset that
+		// a schema bump re-aggregates wholesale. One sandbox's IP was never a property of the provider, and
+		// hostMetadata still carries every per-sandbox record.
+		const forward = [
+			{ ...GENOA, ...ASHBURN, publicIp: "203.0.113.1", reverseDns: "a.example", user: "root" },
+			{ ...GENOA, ...ASHBURN, publicIp: "203.0.113.2", reverseDns: "b.example", user: "root" },
+		];
+		const specsOf = (readings: ObservedSpecs[]) => {
+			const mixtures = buildObservedMixtures(readings);
+			return mixtures ? representativeSpecs(mixtures) : undefined;
+		};
+		expect(specsOf(forward)).toEqual({ ...GENOA, ...ASHBURN });
+		expect(specsOf([...forward].reverse())).toEqual(specsOf(forward));
+	});
+
+	it("breaks a dominance tie by id so the representative reading is deterministic", () => {
+		const mixtures = buildObservedMixtures([GENOA, TURIN]);
+		expect(mixtures).toBeDefined();
+		if (!mixtures) return;
+		// Both count 1; the pick must not depend on iteration luck, and must be one of the two observed
+		// machines rather than a blend of them.
+		const picked = representativeSpecs(mixtures);
+		expect([GENOA, TURIN]).toContainEqual(picked);
+		expect(representativeSpecs(mixtures)).toEqual(picked);
+	});
+
+	it("emits a document that validates against the schema", () => {
+		const built = buildObservedMixtures([
+			{ ...GENOA, ...ASHBURN },
+			{ ...TURIN, ...FRANKFURT },
+		]);
+		expect(built).toBeDefined();
+		if (!built) return;
+		expect(observedMixturesSchema(built)).toEqual(built);
+	});
+});
+
+describe("foldHostMetadata", () => {
+	const record = (sourceFile: string, cpu: string, timestamp: string): HostMetadataRecord => ({
+		source: "phoronix/result-file-to-json",
+		sourceFile,
+		fields: [
+			{ path: "ci.hardware.Processor", value: cpu },
+			{ path: "ci.timestamp", value: timestamp },
+		],
+	});
+	const ids = (cpu: string) => observedMixtureIds({ cpuModel: cpu });
+
+	it("folds records that differ only by a per-run stamp, counting the sandboxes", () => {
+		// The old fold was "drop byte-identical duplicates", which never fired because ci.timestamp
+		// differs on every sandbox — the reason host metadata grew to 54% of the committed dataset.
+		const folded = foldHostMetadata([
+			{ record: record("a.json", "EPYC", "2026-07-30 03:17:44"), ids: ids("EPYC") },
+			{ record: record("a.json", "EPYC", "2026-07-30 03:20:41"), ids: ids("EPYC") },
+			{ record: record("a.json", "EPYC", "2026-07-30 03:27:00"), ids: ids("EPYC") },
+		]);
+		expect(folded).toHaveLength(1);
+		expect(folded[0]?.sandboxes).toBe(3);
+		// The stamp is dropped rather than kept from an arbitrary member: one sandbox's clock reading
+		// must not be published as though all three shared it.
+		expect(folded[0]?.fields.map((f) => f.path)).toEqual(["ci.hardware.Processor"]);
+	});
+
+	it("keeps a singleton record verbatim, per-run stamp included", () => {
+		// Nothing was folded away, so nothing is dropped: the volatile field is still true of the one
+		// sandbox this record describes.
+		const folded = foldHostMetadata([
+			{ record: record("a.json", "EPYC", "2026-07-30 03:17:44"), ids: ids("EPYC") },
+		]);
+		expect(folded[0]?.sandboxes).toBe(1);
+		expect(folded[0]?.fields.map((f) => f.path)).toEqual(["ci.hardware.Processor", "ci.timestamp"]);
+	});
+
+	it("never folds records read on different machines", () => {
+		// Same source file, two machines. Folding them would attribute one machine's record to the
+		// other's sandboxes — the attribution would be confidently wrong rather than merely absent.
+		const folded = foldHostMetadata([
+			{ record: record("a.json", "EPYC", "t1"), ids: ids("EPYC") },
+			{ record: record("a.json", "Xeon", "t2"), ids: ids("Xeon") },
+		]);
+		expect(folded).toHaveLength(2);
+		expect(new Set(folded.map((r) => r.hostHardwareId)).size).toBe(2);
+	});
+
+	it("attributes every record to the machine it was read on", () => {
+		const folded = foldHostMetadata([{ record: record("a.json", "EPYC", "t1"), ids: ids("EPYC") }]);
+		expect(folded[0]?.hostHardwareId).toBe(ids("EPYC").hostHardwareId as string);
+	});
+});
+
+describe("per-machine spec verdicts", () => {
+	it("judges each machine against the target, not just the provider as a whole", () => {
+		// One boolean for a ten-machine fleet cannot say WHICH machine missed. Per mixture it can.
+		const onSpec = { vcpus: TARGET_SPEC.vcpus, memoryGb: TARGET_SPEC.memoryGb, cpuModel: "A" };
+		const offSpec = { vcpus: TARGET_SPEC.vcpus - 1, memoryGb: TARGET_SPEC.memoryGb, cpuModel: "B" };
+		const mixtures = buildObservedMixtures([onSpec, onSpec, offSpec]);
+		const verdicts = Object.values(mixtures?.hostHardware ?? {}).map((m) => [
+			m.specs.cpuModel,
+			m.specMatched,
+		]);
+		expect(verdicts).toEqual([
+			["A", true],
+			["B", false],
+		]);
+	});
+
+	it("leaves a machine unjudged when its probes saw too little", () => {
+		const mixtures = buildObservedMixtures([{ cpuModel: "A" }]);
+		expect(Object.values(mixtures?.hostHardware ?? {})[0]?.specMatched).toBeUndefined();
+	});
+});

--- a/packages/results/src/lib/observed-mixtures.ts
+++ b/packages/results/src/lib/observed-mixtures.ts
@@ -1,0 +1,279 @@
+/**
+ * Build the counted heterogeneity disclosure for one provider: the distinct host-hardware and
+ * host-network combinations its sandboxes observed, keyed by a stable content hash, each with the
+ * number of sandboxes that reported exactly that combination — plus the two derivations that read it
+ * back, {@link representativeSpecs} and {@link foldHostMetadata}.
+ *
+ * This replaces inference with arithmetic. A single {@link ObservedSpecs} on an aggregated ProviderRun
+ * is one sandbox's reading wearing the provider's name, so a fleet spread over three CPU generations
+ * and two regions serialized identically to one that never moved — and the only hint was the
+ * `hostCpuModels` array, which covered one field of one category. Here the count of keys in a category
+ * IS the number of distinct mixtures, and each entry carries how many sandboxes landed on it.
+ *
+ * The hash is content-addressed and canonical (sorted keys, defined values only), so the same machine
+ * shape or egress network yields the same id in every run and can be tracked across the dataset series
+ * without diffing whole objects.
+ *
+ * SDK-free — schema + node:crypto only.
+ */
+import { createHash } from "node:crypto";
+import type {
+	HostHardwareSpecs,
+	HostMetadataRecord,
+	HostNetworkSpecs,
+	ObservedHardwareMixture,
+	ObservedMixtures,
+	ObservedNetworkMixture,
+	ObservedSpecs,
+} from "@sandbox-benchmarks/schema";
+import { hostHardwareSpecsSchema, hostNetworkSpecsSchema } from "@sandbox-benchmarks/schema";
+import { isVolatileHostMetadataPath } from "./host-metadata.ts";
+import { computeSpecMatched } from "./specs.ts";
+
+/**
+ * Hash id width in hex characters. 16 hex = 64 bits, which is enormous headroom against the handful of
+ * mixtures a provider produces — and {@link buildObservedMixtures} still fails loudly on a collision
+ * rather than trusting the arithmetic, because a silent collision would MERGE two distinct machine
+ * shapes into one entry with a summed count: a wrong answer that looks exactly like a right one.
+ *
+ * Do not shrink below 10: at 9 or fewer characters an all-digit id becomes a canonical array index, and
+ * JS reorders integer-like keys ahead of the rest — which would break the descending-count key order
+ * the serialized document is written in.
+ */
+const HASH_ID_LENGTH = 16;
+
+/**
+ * Each category's field names, read off the category schema itself. Taken from arktype's own `props`
+ * rather than a hand-kept list, so a field added to a group joins its hash automatically and a name that
+ * is not a field of the group cannot be spelled at all.
+ */
+const HOST_HARDWARE_SPEC_KEYS = hostHardwareSpecsSchema.props.map((prop) => String(prop.key));
+const HOST_NETWORK_SPEC_KEYS = hostNetworkSpecsSchema.props.map((prop) => String(prop.key));
+
+/** One category's projection of a sandbox reading, with the content hash that identifies it. */
+interface Category<S> {
+	specs: S;
+	/** The exact bytes hashed — retained so a truncation collision can be told from a true repeat. */
+	canonical: string;
+	id: string;
+}
+
+/**
+ * Project a reading onto one category and hash it, or undefined when the sandbox disclosed nothing for
+ * that category. The single place the projection and the hash are sequenced, so an id computed for a
+ * lookup is by construction the same id the tally used — which is what lets `providerRunSchema` demand
+ * every reference resolve.
+ *
+ * Keys are sorted before hashing so two readings that differ only in property insertion order hash
+ * identically; without it the id would depend on which probe file happened to fill a field first, and
+ * one machine would split across several "distinct" mixtures. The cast is the one unavoidable boundary
+ * between a dynamic key list and a static category type, and the key lists come from the category
+ * schemas' own `props`, so it cannot drift.
+ */
+function categoryOf<S>(specs: ObservedSpecs, keys: readonly string[]): Category<S> | undefined {
+	const entries: [string, unknown][] = [];
+	for (const key of keys) {
+		const value = (specs as Record<string, unknown>)[key];
+		if (value !== undefined) entries.push([key, value]);
+	}
+	if (entries.length === 0) return undefined;
+	entries.sort(([a], [b]) => (a < b ? -1 : a > b ? 1 : 0));
+	const canonical = JSON.stringify(entries);
+	return {
+		specs: Object.fromEntries(entries) as S,
+		canonical,
+		id: createHash("sha256").update(canonical).digest("hex").slice(0, HASH_ID_LENGTH),
+	};
+}
+
+/**
+ * Dominance order: most-common mixture first (the fleet's typical machine leads), ties broken by id.
+ *
+ * Authored ONCE and used both to order the serialized map and to pick the representative reading. Two
+ * copies of this rule could disagree, and then `representativeSpecs` would name a machine other than
+ * the one the document leads with.
+ */
+function byDominance<M extends { count: number }>(a: [string, M], b: [string, M]): number {
+	return b[1].count - a[1].count || (a[0] < b[0] ? -1 : a[0] > b[0] ? 1 : 0);
+}
+
+/**
+ * Tally one category across a provider's per-sandbox readings, in dominance order. A reading that
+ * disclosed nothing for the category contributes no entry at all — counting it as an "empty mixture"
+ * would invent a machine shape nobody observed, and the shortfall stays visible because the counts then
+ * sum to less than {@link ObservedMixtures.sandboxes}.
+ *
+ * Returns entries rather than a record so the caller can attach per-entry fields (the hardware
+ * verdict) while building the single output record, instead of materialising it twice.
+ */
+function tallyCategory<S>(
+	readings: readonly ObservedSpecs[],
+	keys: readonly string[],
+): [string, { count: number; specs: S }][] {
+	const byId = new Map<string, { canonical: string; count: number; specs: S }>();
+	for (const reading of readings) {
+		const category = categoryOf<S>(reading, keys);
+		if (!category) continue;
+		const existing = byId.get(category.id);
+		if (existing) {
+			// Same id from different content is a truncation collision. Refuse rather than merge: the
+			// merged entry would report one machine shape with both sandboxes' count, which is precisely
+			// the "looks complete, quietly isn't" claim this whole structure exists to eliminate.
+			if (existing.canonical !== category.canonical) {
+				throw new Error(
+					`observed-mixtures hash collision on id ${category.id}: ${existing.canonical} vs ${category.canonical}`,
+				);
+			}
+			existing.count += 1;
+			continue;
+		}
+		byId.set(category.id, { canonical: category.canonical, count: 1, specs: category.specs });
+	}
+	return [...byId.entries()]
+		.map(([id, { count, specs }]): [string, { count: number; specs: S }] => [id, { count, specs }])
+		.sort(byDominance);
+}
+
+/**
+ * Build one provider's {@link ObservedMixtures} from the per-sandbox {@link ObservedSpecs} readings the
+ * aggregate merged — ONE reading per sandbox, which is one per shard slice (a `(suite, replicate)`
+ * cell). Passing a provider's merged/representative specs instead would report a single mixture of
+ * count 1 and defeat the purpose, so callers must pass the unmerged readings.
+ *
+ * Returns undefined when there are no readings at all: `sandboxes` is a positive integer in the schema,
+ * and a provider with nothing observed has no mixtures to disclose (it is the `pending` placeholder
+ * row, which carries no spec evidence by definition).
+ */
+export function buildObservedMixtures(
+	readings: readonly ObservedSpecs[],
+): ObservedMixtures | undefined {
+	if (readings.length === 0) return undefined;
+	// Each machine gets its OWN spec verdict, attached while the record is built. The provider-level
+	// `specMatched` is one boolean folded across every shard, which on a mixed fleet cannot say WHICH
+	// machine missed the target — a provider honoring it on nine shapes and missing on the tenth reads
+	// the same as one that honored it everywhere.
+	const hostHardware: Record<string, ObservedHardwareMixture> = {};
+	for (const [id, mixture] of tallyCategory<HostHardwareSpecs>(readings, HOST_HARDWARE_SPEC_KEYS)) {
+		const specMatched = computeSpecMatched(mixture.specs);
+		hostHardware[id] = { ...mixture, ...(specMatched !== undefined ? { specMatched } : {}) };
+	}
+	const hostNetwork: Record<string, ObservedNetworkMixture> = {};
+	for (const [id, mixture] of tallyCategory<HostNetworkSpecs>(readings, HOST_NETWORK_SPEC_KEYS)) {
+		hostNetwork[id] = mixture;
+	}
+	return { sandboxes: readings.length, hostHardware, hostNetwork };
+}
+
+/** The mixture ids ONE sandbox's reading falls under — the join key from a replicate to its machine. */
+export interface ObservedMixtureIds {
+	hostHardwareId?: string;
+	hostNetworkId?: string;
+}
+
+/**
+ * Which mixtures a single sandbox reading belongs to. Shares {@link categoryOf} with the tally, so an
+ * id computed here is by construction a key of the map built from the same readings.
+ *
+ * A category the reading disclosed nothing for yields no id at all rather than a placeholder: the
+ * schema narrow would reject a key that resolves to nothing, and "absent" is the honest statement.
+ */
+export function observedMixtureIds(specs: ObservedSpecs): ObservedMixtureIds {
+	const hardware = categoryOf(specs, HOST_HARDWARE_SPEC_KEYS);
+	const network = categoryOf(specs, HOST_NETWORK_SPEC_KEYS);
+	return {
+		...(hardware ? { hostHardwareId: hardware.id } : {}),
+		...(network ? { hostNetworkId: network.id } : {}),
+	};
+}
+
+/**
+ * The single representative reading an aggregated ProviderRun publishes beside its mixtures: the specs
+ * of the mixture the MOST sandboxes reported, in each category.
+ *
+ * Exactly the dominant machine and the dominant egress network — no blending, no backfill. What this
+ * replaces was "first defined value per key wins" across every shard, which had two order dependencies.
+ * The obvious one: on a mixed fleet it published a machine most sandboxes never ran on (run 30510718771
+ * gave modal-vm a headline `cpuModel` of "AMD EPYC 9J45 128-Core Processor" while its sandboxes spread
+ * over ten CPU models, Intel and AMD alike). The subtler one: per-sandbox identity — `publicIp`,
+ * `reverseDns`, `user` — was backfilled from whichever shard arrived first, so re-aggregating the same
+ * shards in a different order emitted a different document. The committed dataset is re-aggregated (a
+ * schema bump backfills the whole series), so a value that moves with arrival order is churn.
+ *
+ * Identity is now simply ABSENT from an aggregate. One sandbox's IP was never a property of the
+ * provider, and the full per-sandbox records are still in `hostMetadata`, so nothing is lost — the same
+ * reasoning that deleted `hostCpuModels`. A field the dominant machine did not disclose is absent too,
+ * which is honest: this reading describes that machine, and `observedMixtures` remains the exact record
+ * of every other one.
+ */
+export function representativeSpecs(mixtures: ObservedMixtures): ObservedSpecs {
+	// Dominance order is the map's own key order (tallyCategory sorted it), but the leading entry is
+	// selected with the shared comparator rather than by reading the first key, so the result never
+	// depends on JS property-order rules.
+	const dominant = <M extends { count: number }>(category: Readonly<Record<string, M>>) =>
+		Object.entries(category).sort(byDominance)[0]?.[1];
+	return {
+		...dominant(mixtures.hostHardware)?.specs,
+		...dominant(mixtures.hostNetwork)?.specs,
+	};
+}
+
+/** One shard's host record together with the mixture ids of the sandbox that produced it. */
+export interface HostMetadataRecordInput {
+	record: HostMetadataRecord;
+	ids: ObservedMixtureIds;
+}
+
+/**
+ * Fold one provider's host-metadata records so a record is the set of fields a machine reported, with a
+ * count of the sandboxes that reported it — rather than one near-duplicate entry per sandbox.
+ *
+ * The old fold was "drop byte-identical duplicates", which never fired: every PTS record carries a
+ * wall-clock `ci.timestamp` that differs on every sandbox, so one provider's 21 distinct source files
+ * landed as 82 records, each re-serializing multi-hundred-character fields (the security-mitigations
+ * list, the compiler configuration). Host metadata was 54% of the committed dataset while describing a
+ * handful of machines.
+ *
+ * Volatile fields are dropped from a FOLDED record rather than kept from an arbitrary member: keeping
+ * one sandbox's stamp on a record that speaks for several would publish a specific claim from a general
+ * one. A record seen exactly once keeps its fields verbatim — nothing was folded away, so no
+ * information is lost where there was no duplication to exploit.
+ */
+export function foldHostMetadata(
+	records: readonly HostMetadataRecordInput[],
+): HostMetadataRecord[] {
+	const byKey = new Map<string, HostMetadataRecord>();
+	for (const { record, ids } of records) {
+		const stable = record.fields.filter((field) => !isVolatileHostMetadataPath(field.path));
+		// Identity is source + file + the machine it was read on + the non-volatile fields, HASHED rather
+		// than retained: the raw key averages 1.7 KB per record (a security-mitigations list and a
+		// compiler configuration are single fields of several hundred characters), so keeping ~500 of them
+		// alive to dedupe ~200 records costs about a megabyte for nothing. The mixture ids belong in the
+		// key because the same source file read on two machines is two facts — folding them would
+		// attribute one machine's record to the other's sandboxes. Fields are sorted into the key (never
+		// into the record) for the same reason the mixture hash sorts its object keys: two readings of the
+		// same facts are the same fact, and a content hash that depends on emission order would split them.
+		const key = createHash("sha256")
+			.update(
+				JSON.stringify([
+					record.source,
+					record.sourceFile,
+					ids.hostHardwareId ?? null,
+					ids.hostNetworkId ?? null,
+					[...stable]
+						.sort((a, b) => a.path.localeCompare(b.path))
+						.map((field) => [field.path, field.value]),
+				]),
+			)
+			.digest("hex");
+		const existing = byKey.get(key);
+		if (existing) {
+			existing.sandboxes = (existing.sandboxes ?? 1) + 1;
+			// Now that it speaks for more than one sandbox, the per-run stamp it inherited from the first
+			// member stops being true of the record and is dropped.
+			existing.fields = stable;
+			continue;
+		}
+		byKey.set(key, { ...record, sandboxes: 1, ...ids });
+	}
+	return [...byKey.values()];
+}


### PR DESCRIPTION
**RUN SCHEMA v4 — make the benchmark dataset self-describing**
Shipped as an 8-PR stack (merge bottom-up, each branch independently green):

1. #292 — schema: open Run v4 (numeric version floors) + the closed `GapCause` taxonomy
2. #293 — schema: carry a gap's cause on its on-disk marker
3. #294 — harness: `GapError` — classify a failure at the site that knows it
4. #295 — results: author causes in the normalizer, read them in the leaderboard
5. #296 — schema: `MetricResult.derived` — mark a computed row in the document
6. #297 — schema: `ObservedMixtures`, the replicate→machine join, per-machine verdicts
7. #298 — results: build the counted mixtures and fold host records onto them
8. #299 — results: aggregate onto the mixtures instead of onto shard order

↑ **This PR is #298 (7/8)**, based on #297.

---

The schema below this PR can express a counted fleet; this is what computes one.
Pure-additive — nothing calls it yet, so it is unit-tested directly against readings
rather than through the aggregate.

`buildObservedMixtures` tallies a provider's per-sandbox `ObservedSpecs` into the two
hash categories. The hash is content-addressed and canonical — sorted keys, defined
values only — so the same machine shape or egress network yields the same id in every
run and can be tracked across the dataset series without diffing whole objects. Keys
are sorted BEFORE hashing because otherwise the id would depend on which probe file
happened to fill a field first, and one machine would split across several "distinct"
mixtures.

Details that are load-bearing rather than incidental:

  * The category key lists come from the category schemas' own `props`, not a
    hand-kept list, so a field added to a group joins its hash automatically.
  * A truncation collision THROWS rather than merging. A merged entry would report one
    machine shape carrying both sandboxes' count — a wrong answer that looks exactly
    like a right one, which is the failure this whole structure exists to eliminate.
    The exact hashed bytes are retained so a collision can be told from a true repeat.
  * `HASH_ID_LENGTH` must not drop below 10: at 9 or fewer characters an all-digit id
    becomes a canonical array index, and JS reorders integer-like keys ahead of the
    rest, breaking the descending-count key order the document is written in.
  * A reading that disclosed nothing for a category contributes no entry at all, so the
    counts sum to less than `sandboxes` — a visible partial disclosure rather than an
    invented empty mixture.
  * Dominance order is authored ONCE (`byDominance`) and used both to order the
    serialized map and to pick the representative reading, because two copies could
    disagree and then `representativeSpecs` would name a machine other than the one the
    document leads with.

`representativeSpecs` takes the mixtures it summarizes and returns the dominant machine
and dominant network — no blending, no backfill. Per-sandbox identity (`publicIp`,
`reverseDns`, `user`) is simply ABSENT from an aggregate now: it was previously
backfilled from whichever shard arrived first, so re-aggregating the same shards in a
different order emitted a different document, and one sandbox's IP was never a property
of the provider. The full per-sandbox records are still in `hostMetadata`.

`foldHostMetadata` folds records by (source, file, machine, non-volatile fields) with a
sandbox count. The old fold kept byte-identical records only and never fired, because
every PTS record carries a wall-clock `ci.timestamp`: one provider's 21 distinct source
files landed as 82 near-identical records, and host metadata was 54% of the committed
dataset while describing a handful of machines. The volatile-path predicate lives beside
the flattening that PRODUCES those paths, not in the Run schema, which deliberately does
not know either source's evolving key vocabulary. The fold key is HASHED because the raw
key averages ~1.7 KB per record, and the mixture ids belong in it because the same
source file read on two machines is two facts.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Builds counted hardware and network “observed mixtures” with stable content-hash ids and folds host metadata by machine to cut duplication while keeping attribution correct. Exposes `buildObservedMixtures`, `representativeSpecs`, `observedMixtureIds`, `foldHostMetadata`, and types `HostMetadataRecordInput`, `ObservedMixtureIds` from `packages/results` with tests.

- **New Features**
  - Tallies per-sandbox `ObservedSpecs` into separate hardware/network maps keyed by a canonical hash (sorted keys, defined values only). Ids are stable across runs; collisions throw.
  - Orders mixtures by dominance (count desc, id tie-break). `representativeSpecs` picks the dominant hardware and network only; excludes `publicIp`, `reverseDns`, `user`.
  - Attaches per-hardware `specMatched` when computable. Sandboxes that disclose nothing for a category are counted in `sandboxes` but omitted from that category.
  - Adds `observedMixtureIds` to join a sandbox to its mixture ids, sharing the same projection and hash as the tally so ids always resolve.
  - Adds `foldHostMetadata` to group by source, file, mixture ids, and non-volatile fields; drops volatile `.timestamp` when folded (kept for singletons). Keys come from schema `props`; the fold key is hashed.

<sup>Written for commit 46d94e7c9901edb62460921ffa19306314d24ec5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/starslingdev/hpc-sandbox-benchmarks/pull/298?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

