### PR TITLE
feat(results): aggregate onto the mixtures instead of onto shard order

### DIFF
--- a/docs/adr/0005-host-vs-effective-spec-split.md
+++ b/docs/adr/0005-host-vs-effective-spec-split.md
@@ -21,17 +21,93 @@ shards scheduled on different hosts would average across hardware without anyone
 sandbox size (the cgroup quota where enforced); `hostVcpus`/`hostMemoryGb` disclose the underlying
 machine when probes see through the boundary. `cpuModel`/`cpuMicroarch`/`cpuMhz` and friends are
 HOST-side by construction — `cpuMicroarch` is a generation label derived from the host `cpuModel`,
-and **never reflects the effective spec**. The aggregate path sets `hostCpuModels` — the distinct host
-CPU models — when a provider's merged shards disclosed more than one, naming the scheduling confound the
-published Run must own. Every field is optional because providers differ in what their probes expose,
-and `specMatched` records whether the effective side honored the target.
+and **never reflects the effective spec**. Every field is optional because providers differ in what
+their probes expose, and `specMatched` records whether the effective side honored the target.
+
+**Amended (Run schema v4): the document describes itself.** Six facts a reader needed were present in
+the dataset but not expressible *from* it — each recoverable only by knowing something the file did not
+say. Run 30510718771 makes the cost concrete: modal-vm's 12 realworld replicates were spread over **ten**
+CPU models, Intel and AMD across five EPYC generations, under a single `specMatched: true` and a headline
+`cpuModel` that appears in 10 of its 78 host records. v4 records what was missing:
+
+- **[`ObservedMixtures`](../../packages/schema/src/run.ts)** — per provider, `sandboxes` (the
+  denominator) plus two maps from a stable content hash to `{ count, specs }`, one for **host hardware**
+  and one for **host network** (egress ASN/org + geo). `Object.keys(hostHardware).length` *is* the number
+  of distinct machine shapes observed; each `count` is how many sandboxes landed on it. The prior
+  mitigation, `hostCpuModels`, covered one field of one category and answered "were they different?"
+  rather than "how many, and how many sandboxes each?" — so it was REMOVED rather than kept beside the
+  mixtures: nothing ever read it, and arktype ignores undeclared keys, so published Runs carrying it
+  still validate.
+- **`MetricReplicate.hostHardwareId` / `hostNetworkId`** — the join from a sample cluster to the machine
+  that produced it. Both halves of "is the Intel leg slower than the EPYC leg?" were already in the
+  document with nothing connecting them. `providerRunSchema` narrows the ids to resolvable keys: a
+  dangling id and an absent one both read as `undefined` at the point of use, and only one is honest.
+  The same two ids also sit on **`MetricResult`** for a Metric measured on a SINGLE sandbox, because
+  `replicates` exists only at ≥2 clusters — without them the join went missing exactly where the
+  breakdown is absent, and a provider whose suites each landed one sandbox published its mixtures with
+  nothing pointing at any of them. The two levels are mutually exclusive: a Metric-level id claims one
+  machine for every Sample, which a breakdown contradicts.
+- **A dominant representative reading** — `observedSpecs` on an aggregate was "first defined value per
+  key wins", i.e. shard arrival order, which on a mixed fleet publishes a machine most sandboxes never
+  ran on. The hashed-category fields now come from the mixture the MOST sandboxes reported.
+- **`ResultGap.cause`** — a closed, discriminated taxonomy (`disk-shortfall`, `step-timeout`,
+  `sandbox-lost`, `metrics-unrecorded`, …) authored where the failure happens. `reason` had been the
+  machine interface as well as the human one, so the leaderboard classified disk skips with
+  `/^insufficient disk/i` against a string authored in another package — a coupling its own comment
+  warned about. There is deliberately no catch-all arm: an unclassifiable gap omits `cause`, which reads
+  as "unclassified" and cannot be mistaken for a diagnosis.
+- **`MetricResult.derived`** — `usd_per_hour` sat among the measurements looking like one, separable only
+  by a Metric Catalog lookup, and a Run outlives the catalog version that produced it. Mandatory from v4;
+  optional-in-practice would leave consumers keeping the lookup anyway.
+- **Host records folded and attributed** — each record carries `sandboxes` and its machine's mixture id.
+  The old dedupe kept byte-identical records only and every PTS record carries a wall-clock
+  `ci.timestamp`, so it never fired: host metadata was 54% of the committed dataset while describing a
+  handful of machines. Folding on the non-volatile fields cuts it by 54% (468 records → 203 on run
+  30510718771).
+- **Per-machine `specMatched`** — one boolean cannot cover a ten-machine fleet. Each host-hardware
+  mixture carries its own verdict, and a narrow enforces that the provider's fold is never kinder than
+  its parts. The network mixture type has no such field at all: the target spec says nothing about
+  egress, so a network mixture must not be able to claim a verdict.
+
+Two rules make the mixture categories trustworthy rather than merely present:
+
+- **`ObservedSpecs` is composed from the category field groups**, not written flat with the groups
+  listed separately. A new field must join a group to exist at all, so it cannot be silently absent
+  from every hash while the key lists still look complete.
+- **Per-sandbox identity fields are excluded from both hashes** (`publicIp`, `reverseDns`, `user`).
+  Hashing a unique-per-sandbox value would mint one "mixture" per sandbox and report every count as 1,
+  destroying the signal. `networkPrefix` carries the address-space dimension instead.
 
 ## Consequences
 
 - A reader can always tell the sold size from the silicon it ran on; price/performance uses the
   effective spec, while the host side explains a fast or noisy number.
-- Heterogeneous scheduling is disclosed, not hidden: `hostCpuModels` names the distinct CPUs when a
-  provider's shards didn't all land on the same hardware, so the comparison stays honest about that confound.
+- Heterogeneous scheduling is counted, not just flagged: the mixture maps name every distinct machine
+  shape and egress network with a sandbox count each, so "how mixed was this provider" is arithmetic
+  rather than inference. Hash ids are content-addressed, so the same shape carries the same id across
+  runs and can be tracked through the dataset series.
+- The between-machine axis is decomposable: because every replicate names its mixture, a consumer can
+  group a metric's sample clusters by host and ask whether the spread is the provider's variance or the
+  hardware's. That question was unanswerable from a published Run before v4. Below two clusters there is
+  no spread to decompose, but the Metric still names its machine, so "which host produced this number"
+  is answerable at every R.
+- The counts are bounded by their own denominator: a category's `count`s sum to at most `sandboxes`.
+  Falling short is a real, visible partial disclosure (a probe that saw nothing contributes no mixture);
+  exceeding it would describe a fleet that never existed, so the schema refuses it rather than leaving
+  every proportion a reader computes open to being arithmetic on a lie.
+- The provider-level `specMatched` is still one boolean, but it is now the FOLD of the per-machine
+  verdicts as well as the per-shard ones (a single `false` is sticky), and the schema refuses a provider
+  verdict kinder than its parts. "Which machine missed the target" is answered by the mixtures.
+- Pre-v4 unreachability is by construction, not by extra rules: a replicate id must resolve into
+  `observedMixtures` and a mixture's `specMatched` lives inside one, so the single v4 gate on
+  `observedMixtures` already refuses both. No redundant per-field gates to keep in sync.
+- The host-vs-effective split stays documented field-by-field, but the effective size shares the
+  hostHardware hash category: a provider handing out 4 vCPU on some sandboxes and 2 on others is
+  exactly the heterogeneity this disclosure exists to surface, so it belongs in "which machine did I
+  get". The two sides remain separately labelled within the group.
+- Counts sum to less than `sandboxes` when some sandbox's probe saw nothing, which is a visible partial
+  disclosure rather than a silent one — a category is omitted entirely rather than recording an empty
+  mixture nobody observed.
 - More fields to populate, and probes that can't see the host simply leave the host side absent (the
   effective side stands alone) — accepted in exchange for never conflating the two axes.
 - The split is encoded in the schema and documented field-by-field, so a new probe/provider must

--- a/packages/results/src/lib/aggregate.test.ts
+++ b/packages/results/src/lib/aggregate.test.ts
@@ -1,11 +1,12 @@
 import { describe, expect, it } from "bun:test";
-import type { MetricResult, ProviderRun, Run } from "@sandbox-benchmarks/schema";
+import type { GapCause, MetricResult, ProviderRun, Run } from "@sandbox-benchmarks/schema";
 import {
 	aggregate,
 	ECONOMICS_METRIC_IDS,
 	getProvider,
 	HARNESS_METRIC_IDS,
 	hourlyCostAtTargetSpec,
+	TARGET_SPEC,
 } from "@sandbox-benchmarks/schema";
 import { aggregateRuns } from "./aggregate.ts";
 
@@ -80,7 +81,7 @@ describe("aggregateRuns", () => {
 		]);
 		expect(node?.samples).toEqual([10, 11, 20, 21]);
 		expect(node?.aggregates.n).toBe(4);
-		// The merged Run is v4 (self-describing); its Metric carries no single replicateIndex.
+		// The merged Run is v4 (replicate-aware, mixture-aware, attributed, self-describing).
 		expect(merged.schemaVersion).toBe("4");
 	});
 
@@ -172,6 +173,353 @@ describe("aggregateRuns", () => {
 		expect(merged.generatedAt).toBe("2026-06-02T00:00:00.000Z");
 	});
 
+	it("discloses differing host CPUs as distinct mixtures, naming each and how many saw it", () => {
+		// Replaces the deleted `hostCpuModels` string array: it named the distinct models but not how many
+		// sandboxes each covered, and nothing ever read it — the mixtures answer both.
+		const a = shard([
+			{
+				...provider("daytona-vm", [metric("node_web_tooling_runs_per_s", [10])]),
+				observedSpecs: { cpuModel: "AMD EPYC 9R14", cpuMicroarch: "Zen 4 (Genoa)" },
+			},
+		]);
+		const b = shard([
+			{
+				...provider("daytona-vm", [metric("pybench_milliseconds", [900])]),
+				observedSpecs: { cpuModel: "AMD EPYC 9R45", cpuMicroarch: "Zen 5 (Turin)" },
+			},
+		]);
+		const daytona = aggregateRuns([a, b]).providers.find((p) => p.providerId === "daytona-vm");
+		// Sorted by name for the assertion only: both counts are 1, so the map's own order is the id
+		// tie-break, which is deliberately not alphabetical.
+		expect(
+			Object.values(daytona?.observedMixtures?.hostHardware ?? {})
+				.map((m) => [m.specs.cpuModel, m.count] as const)
+				.sort(([x], [y]) => String(x).localeCompare(String(y))),
+		).toEqual([
+			["AMD EPYC 9R14", 1],
+			["AMD EPYC 9R45", 1],
+		]);
+	});
+
+	it("counts the distinct host-hardware and host-network mixtures its sandboxes reported", () => {
+		const genoa = {
+			cpuModel: "AMD EPYC 9R14",
+			cpuMicroarch: "Zen 4 (Genoa)",
+			vcpus: 2,
+			memoryGb: 8,
+		};
+		const turin = {
+			cpuModel: "AMD EPYC 9R45",
+			cpuMicroarch: "Zen 5 (Turin)",
+			vcpus: 2,
+			memoryGb: 8,
+		};
+		const ashburn = { egressAsn: "AS14618", egressOrg: "Amazon", city: "Ashburn", country: "US" };
+		const frankfurt = {
+			egressAsn: "AS16509",
+			egressOrg: "Amazon",
+			city: "Frankfurt",
+			country: "DE",
+		};
+		// Three sandboxes on Genoa/Ashburn, one on Turin, one of the Genoa three in Frankfurt. Each carries
+		// its OWN publicIp — a per-sandbox identity field that must not fragment the network mixtures.
+		const sandbox = (specs: Record<string, unknown>, index: number, ip: string) =>
+			shard(
+				[
+					{
+						...provider("daytona-vm", [metric("pybench_milliseconds", [900 + index])]),
+						observedSpecs: { ...specs, publicIp: ip },
+					},
+				],
+				"2026-06-01T00:00:00.000Z",
+				index,
+			);
+		const merged = aggregateRuns([
+			sandbox({ ...genoa, ...ashburn }, 0, "203.0.113.1"),
+			sandbox({ ...genoa, ...ashburn }, 1, "203.0.113.2"),
+			sandbox({ ...turin, ...ashburn }, 2, "203.0.113.3"),
+			sandbox({ ...genoa, ...frankfurt }, 3, "198.51.100.4"),
+		]);
+		const mixtures = merged.providers.find((p) => p.providerId === "daytona-vm")?.observedMixtures;
+
+		// The denominator, and the two counts — no inference required to read the heterogeneity off this.
+		expect(mixtures?.sandboxes).toBe(4);
+		const hardware = Object.values(mixtures?.hostHardware ?? {});
+		const network = Object.values(mixtures?.hostNetwork ?? {});
+		expect(hardware.map((m) => m.count)).toEqual([3, 1]); // most-common mixture first
+		expect(network.map((m) => m.count)).toEqual([3, 1]);
+		expect(hardware[0]?.specs).toEqual(genoa);
+		expect(hardware[1]?.specs).toEqual(turin);
+		expect(network[1]?.specs).toEqual(frankfurt);
+		// Four distinct publicIps did NOT mint four network mixtures: identity fields are excluded from
+		// both hashes, without which every count would be 1 and the disclosure would carry no signal. The
+		// category types now make an identity field on a mixture unrepresentable, so the counts above are
+		// the assertion — four sandboxes collapsing to 3 + 1 is only possible if the ip was excluded.
+		expect(hardware.length + network.length).toBe(4);
+	});
+
+	it("keys mixtures by a stable hash that ignores shard arrival order", () => {
+		const specs = { cpuModel: "AMD EPYC 9R45", egressAsn: "AS16509" };
+		const sandbox = (index: number) =>
+			shard(
+				[
+					{
+						...provider("daytona-vm", [metric("pybench_milliseconds", [900 + index])]),
+						observedSpecs: specs,
+					},
+				],
+				"2026-06-01T00:00:00.000Z",
+				index,
+			);
+		const forward = aggregateRuns([sandbox(0), sandbox(1)]);
+		const reversed = aggregateRuns([sandbox(1), sandbox(0)]);
+		const of = (run: typeof forward) =>
+			run.providers.find((p) => p.providerId === "daytona-vm")?.observedMixtures;
+		// Byte-identical, so the committed dataset diff reflects real change rather than merge order — and
+		// an id can be compared across runs to ask "same machine shape as last week?".
+		expect(JSON.stringify(of(forward))).toBe(JSON.stringify(of(reversed)));
+		expect(Object.keys(of(forward)?.hostHardware ?? {})).toHaveLength(1);
+	});
+
+	it("omits mixtures for a provider that reported nothing, and ignores its placeholder slices", () => {
+		// The normalizer emits a zero-evidence ProviderRun for every registered provider in EVERY shard, so
+		// a naive per-slice count would credit a 2-sandbox provider with one blind sandbox per shard in the
+		// whole run — and would hand the never-dispatched provider a mixture block claiming sandboxes it
+		// never had.
+		const measured = (index: number) =>
+			shard(
+				[
+					{
+						...provider("daytona-vm", [metric("pybench_milliseconds", [900 + index])]),
+						observedSpecs: { cpuModel: "AMD EPYC 9R45" },
+					},
+					provider("daytona-container", []),
+				],
+				"2026-06-01T00:00:00.000Z",
+				index,
+			);
+		const merged = aggregateRuns([measured(0), measured(1)]);
+		expect(
+			merged.providers.find((p) => p.providerId === "daytona-vm")?.observedMixtures?.sandboxes,
+		).toBe(2);
+		expect(
+			merged.providers.find((p) => p.providerId === "daytona-container")?.observedMixtures,
+		).toBeUndefined();
+	});
+
+	it("names the machine behind each replicate, so a sample cluster resolves to its host", () => {
+		const genoa = { cpuModel: "AMD EPYC 9R14", cpuMicroarch: "Zen 4 (Genoa)" };
+		const xeon = { cpuModel: "Intel Xeon Platinum 8358", cpuMicroarch: "Ice Lake" };
+		const sandbox = (specs: Record<string, unknown>, index: number) =>
+			shard(
+				[
+					{
+						...provider("daytona-vm", [metric("pybench_milliseconds", [900 + index])]),
+						observedSpecs: specs,
+					},
+				],
+				"2026-06-01T00:00:00.000Z",
+				index,
+			);
+		const merged = aggregateRuns([sandbox(genoa, 0), sandbox(xeon, 1), sandbox(genoa, 2)]);
+		const daytona = merged.providers.find((p) => p.providerId === "daytona-vm");
+		const replicates =
+			daytona?.metrics.find((m) => m.metricId === "pybench_milliseconds")?.replicates ?? [];
+		expect(replicates).toHaveLength(3);
+
+		// Every id resolves into the provider's own mixtures — the join the schema narrow guarantees.
+		const hardware = daytona?.observedMixtures?.hostHardware ?? {};
+		for (const replicate of replicates) {
+			expect(replicate.hostHardwareId).toBeDefined();
+			expect(hardware[replicate.hostHardwareId as string]).toBeDefined();
+		}
+		// r0 and r2 ran on one machine, r1 on the other: the between-machine axis is now decodable rather
+		// than an anonymous set of clusters.
+		expect(replicates[0]?.hostHardwareId).toBe(replicates[2]?.hostHardwareId as string);
+		expect(replicates[1]?.hostHardwareId).not.toBe(replicates[0]?.hostHardwareId as string);
+		expect(hardware[replicates[1]?.hostHardwareId as string]?.specs.cpuModel).toBe(
+			"Intel Xeon Platinum 8358",
+		);
+		// No network probe ran, so no network id is invented for a mixture that does not exist.
+		for (const replicate of replicates) expect(replicate.hostNetworkId).toBeUndefined();
+	});
+
+	it("names the machine on a single-replicate metric, where there is no breakdown to hold it", () => {
+		// The R = 1 hole: `replicates` exists only at ≥2 clusters, so a provider whose suites each landed
+		// one sandbox would publish its mixtures with nothing pointing at any of them. One sandbox
+		// produced every Sample here, so naming one machine on the Metric is exactly true.
+		const genoa = { cpuModel: "AMD EPYC 9R14", vcpus: 2, memoryGb: 8 };
+		const turin = { cpuModel: "AMD EPYC 9R45", vcpus: 2, memoryGb: 8 };
+		const cpu = shard(
+			[
+				{
+					...provider("daytona-vm", [metric("node_web_tooling_runs_per_s", [10])]),
+					observedSpecs: genoa,
+				},
+			],
+			"2026-06-01T00:00:00.000Z",
+			0,
+		);
+		const sys = shard(
+			[
+				{
+					...provider("daytona-vm", [metric("pybench_milliseconds", [900])]),
+					observedSpecs: turin,
+				},
+			],
+			"2026-06-01T00:00:00.000Z",
+			0,
+		);
+		const daytona = aggregateRuns([cpu, sys]).providers.find((p) => p.providerId === "daytona-vm");
+		const idFor = (metricId: string) =>
+			daytona?.metrics.find((m) => m.metricId === metricId)?.hostHardwareId;
+		const specsFor = (metricId: string) => {
+			const id = idFor(metricId);
+			return id ? daytona?.observedMixtures?.hostHardware[id]?.specs.cpuModel : undefined;
+		};
+		// Each metric resolves to the machine ITS sandbox ran on — the two suites landed differently.
+		expect(specsFor("node_web_tooling_runs_per_s")).toBe("AMD EPYC 9R14");
+		expect(specsFor("pybench_milliseconds")).toBe("AMD EPYC 9R45");
+		// And neither carries a breakdown; the ids are the whole attribution at R = 1.
+		expect(daytona?.metrics.find((m) => m.metricId === "pybench_milliseconds")?.replicates).toBe(
+			undefined,
+		);
+	});
+
+	it("keeps the attribution per-replicate once there IS a breakdown", () => {
+		// At ≥2 clusters a Metric-level id would have to name one machine for Samples spanning several,
+		// so the schema refuses both levels at once and the merge must put them only on the replicates.
+		const r0 = shard(
+			[
+				{
+					...provider("daytona-vm", [metric("node_web_tooling_runs_per_s", [10])]),
+					observedSpecs: { cpuModel: "AMD EPYC 9R14" },
+				},
+			],
+			"2026-06-01T00:00:00.000Z",
+			0,
+		);
+		const r1 = shard(
+			[
+				{
+					...provider("daytona-vm", [metric("node_web_tooling_runs_per_s", [20])]),
+					observedSpecs: { cpuModel: "AMD EPYC 9R45" },
+				},
+			],
+			"2026-06-01T00:00:00.000Z",
+			1,
+		);
+		const node = aggregateRuns([r0, r1])
+			.providers.find((p) => p.providerId === "daytona-vm")
+			?.metrics.find((m) => m.metricId === "node_web_tooling_runs_per_s");
+		expect(node?.hostHardwareId).toBeUndefined();
+		expect(node?.replicates?.every((r) => r.hostHardwareId !== undefined)).toBe(true);
+	});
+
+	it("attributes each suite's replicate to its OWN sandbox, not another suite's same-index cell", () => {
+		// A replicate index is scoped to its (suite, provider) cell, so (system, r0) and (cpu-node, r0) are
+		// different sandboxes. A provider-wide index→machine map would credit one suite's samples to the
+		// other suite's host — a wrong attribution that reads exactly like a right one.
+		const genoa = { cpuModel: "AMD EPYC 9R14" };
+		const xeon = { cpuModel: "Intel Xeon Platinum 8358" };
+		const cell = (metricId: string, specs: Record<string, unknown>, index: number) =>
+			shard(
+				[
+					{
+						...provider("daytona-vm", [metric(metricId, [900 + index])]),
+						observedSpecs: specs,
+					},
+				],
+				"2026-06-01T00:00:00.000Z",
+				index,
+			);
+		const merged = aggregateRuns([
+			cell("pybench_milliseconds", genoa, 0),
+			cell("pybench_milliseconds", genoa, 1),
+			cell("node_web_tooling_runs_per_s", xeon, 0),
+			cell("node_web_tooling_runs_per_s", xeon, 1),
+		]);
+		const daytona = merged.providers.find((p) => p.providerId === "daytona-vm");
+		const hardware = daytona?.observedMixtures?.hostHardware ?? {};
+		const cpuOf = (metricId: string, index: number) => {
+			const id = daytona?.metrics
+				.find((m) => m.metricId === metricId)
+				?.replicates?.find((r) => r.index === index)?.hostHardwareId;
+			return hardware[id as string]?.specs.cpuModel;
+		};
+		expect(cpuOf("pybench_milliseconds", 0)).toBe("AMD EPYC 9R14");
+		expect(cpuOf("node_web_tooling_runs_per_s", 0)).toBe("Intel Xeon Platinum 8358");
+	});
+
+	it("seats the representative observedSpecs on the dominant machine, not the first shard's", () => {
+		// The failure this replaces: first-wins resolves to shard arrival order, so run 30510718771
+		// published modal-vm with a headline cpuModel of one machine out of ten its sandboxes used.
+		const rare = { cpuModel: "AMD EPYC 9J45 128-Core Processor" };
+		const common = { cpuModel: "Intel Xeon Platinum 8358" };
+		const sandbox = (specs: Record<string, unknown>, index: number) =>
+			shard(
+				[
+					{
+						...provider("daytona-vm", [metric("pybench_milliseconds", [900 + index])]),
+						observedSpecs: specs,
+					},
+				],
+				"2026-06-01T00:00:00.000Z",
+				index,
+			);
+		// The rare machine arrives FIRST — under first-wins it would have become the headline.
+		const merged = aggregateRuns([
+			sandbox(rare, 0),
+			sandbox(common, 1),
+			sandbox(common, 2),
+			sandbox(common, 3),
+		]);
+		const daytona = merged.providers.find((p) => p.providerId === "daytona-vm");
+		expect(daytona?.observedSpecs.cpuModel).toBe("Intel Xeon Platinum 8358");
+		// Both machines stay fully disclosed; only the single-value summary moved.
+		expect(Object.keys(daytona?.observedMixtures?.hostHardware ?? {})).toHaveLength(2);
+	});
+
+	it("counts a sandbox that only reported a gap — a failed sandbox is still a sandbox report", () => {
+		// A create failure or a disk skip produces no metric and no spec reading, but the provider was
+		// asked for that sandbox. Counting it keeps `sandboxes` the true denominator, so a category whose
+		// counts sum to less than it is visibly a partial disclosure rather than a complete one.
+		const withGap = shard(
+			[
+				{
+					...provider("daytona-vm", []),
+					gaps: [
+						{
+							scope: "suite" as const,
+							id: "realworld-mastra",
+							outcome: "failed" as const,
+							reason: "Failed to create sandbox",
+						},
+					],
+				},
+			],
+			"2026-06-01T00:00:00.000Z",
+			0,
+		);
+		const measured = shard(
+			[
+				{
+					...provider("daytona-vm", [metric("pybench_milliseconds", [900])]),
+					observedSpecs: { cpuModel: "AMD EPYC 9R45" },
+				},
+			],
+			"2026-06-01T00:00:00.000Z",
+			1,
+		);
+		const mixtures = aggregateRuns([withGap, measured]).providers.find(
+			(p) => p.providerId === "daytona-vm",
+		)?.observedMixtures;
+		expect(mixtures?.sandboxes).toBe(2);
+		// Two sandboxes, but only one disclosed hardware — the shortfall is readable from the counts.
+		expect(Object.values(mixtures?.hostHardware ?? {}).map((m) => m.count)).toEqual([1]);
+		expect(mixtures?.hostNetwork).toEqual({});
+	});
+
 	it("unions rich host metadata across shards and removes byte-identical duplicates", () => {
 		const record = {
 			source: "mise/system-provider" as const,
@@ -241,7 +589,7 @@ describe("aggregateRuns", () => {
 		).toBeUndefined();
 
 		const matchOnly = provider("daytona-vm", [metric("pybench_milliseconds", [900])]);
-		matchOnly.observedSpecs = { vcpus: 2, memoryGb: 8 };
+		matchOnly.observedSpecs = { vcpus: TARGET_SPEC.vcpus, memoryGb: TARGET_SPEC.memoryGb };
 		matchOnly.specMatched = true;
 		expect(
 			aggregateRuns([noProbe, shard([matchOnly])]).providers.find(
@@ -298,6 +646,36 @@ describe("aggregateRuns suite-shortfall gap folding", () => {
 	});
 });
 
+describe("aggregateRuns gap-cause folding", () => {
+	const gap = (cause?: GapCause) => ({
+		scope: "suite" as const,
+		id: "realworld-mastra" as const,
+		outcome: "skipped" as const,
+		reason: "Insufficient disk: 20.0 GiB free, suite needs 30 GiB",
+		...(cause ? { cause } : {}),
+	});
+	const withGap = (cause: GapCause | undefined, index: number) =>
+		shard(
+			[{ ...provider("e2b", [metric("pybench_milliseconds", [900 + index])]), gaps: [gap(cause)] }],
+			"2026-06-01T00:00:00.000Z",
+			index,
+		);
+	const disk = { kind: "disk-shortfall", freeGb: 20, requiredGb: 30 } as const satisfies GapCause;
+
+	it("keeps the classified gap when shards straddle a producer upgrade, in either order", () => {
+		// `cause` is not part of the dedupe key, so plain first-wins would let shard arrival order decide
+		// whether the published gap carries its classification.
+		for (const order of [
+			[withGap(undefined, 0), withGap(disk, 1)],
+			[withGap(disk, 0), withGap(undefined, 1)],
+		]) {
+			const gaps = aggregateRuns(order).providers.find((p) => p.providerId === "e2b")?.gaps ?? [];
+			expect(gaps).toHaveLength(1);
+			expect(gaps[0]?.cause).toEqual(disk);
+		}
+	});
+});
+
 describe("aggregateRuns derived-metric marking", () => {
 	it("marks the economics rows it re-derives, so the document says what is computed", () => {
 		// The guarantee the schema deliberately does NOT enforce (a published Run's validity must not track
@@ -329,5 +707,89 @@ describe("aggregateRuns derived-metric marking", () => {
 			[];
 		expect(ids).not.toContain("usd_per_retired_thing");
 		expect(ids).toContain("node_web_tooling_runs_per_s");
+	});
+});
+
+describe("aggregateRuns gap-cause determinism", () => {
+	// One reason, two causes. Reachable because a reason can be lossier than its cause: the disk-shortfall
+	// sentence rounds free space with toFixed(1), so 20.04 and 20.049 GiB render one identical sentence.
+	const reason = "Insufficient disk: 20.0 GiB free, suite needs 30 GiB";
+	const cause = (freeGb: number) =>
+		({ kind: "disk-shortfall", freeGb, requiredGb: 30 }) as const satisfies GapCause;
+	const withCause = (freeGb: number | undefined, index: number) =>
+		shard(
+			[
+				{
+					...provider("e2b", [metric("pybench_milliseconds", [900 + index])]),
+					gaps: [
+						{
+							scope: "suite" as const,
+							id: "realworld-mastra" as const,
+							outcome: "skipped" as const,
+							reason,
+							...(freeGb === undefined ? {} : { cause: cause(freeGb) }),
+						},
+					],
+				},
+			],
+			"2026-06-01T00:00:00.000Z",
+			index,
+		);
+
+	it("resolves two different classified causes the same way in either arrival order", () => {
+		// Keeping whichever arrived first would make the published freeGb depend on shard order — churn in
+		// a committed dataset that a schema bump re-aggregates wholesale.
+		const causeOf = (order: ReturnType<typeof withCause>[]) => {
+			const gaps = aggregateRuns(order).providers.find((p) => p.providerId === "e2b")?.gaps ?? [];
+			expect(gaps).toHaveLength(1);
+			return gaps[0]?.cause;
+		};
+		const forward = causeOf([withCause(20.04, 0), withCause(20.049, 1)]);
+		const reversed = causeOf([withCause(20.049, 0), withCause(20.04, 1)]);
+		expect(forward).toEqual(reversed);
+	});
+
+	it("compares causes by content, not by the key order a producer wrote them in", () => {
+		// The tie-break must not be re-decidable by reformatting a cause literal at its construction
+		// site: `{ requiredGb, freeGb, kind }` serializes to a different string than `{ kind, freeGb,
+		// requiredGb }` while describing the identical fact.
+		const scrambled = (freeGb: number, index: number) =>
+			shard(
+				[
+					{
+						...provider("e2b", [metric("pybench_milliseconds", [900 + index])]),
+						gaps: [
+							{
+								scope: "suite" as const,
+								id: "realworld-mastra" as const,
+								outcome: "skipped" as const,
+								reason,
+								cause: { requiredGb: 30, freeGb, kind: "disk-shortfall" } as GapCause,
+							},
+						],
+					},
+				],
+				"2026-06-01T00:00:00.000Z",
+				index,
+			);
+		// Same winner as the canonically-keyed pair above: the smaller freeGb, whichever literal it came in.
+		for (const order of [
+			[scrambled(20.04, 0), withCause(20.049, 1)],
+			[withCause(20.049, 0), scrambled(20.04, 1)],
+		]) {
+			const gaps = aggregateRuns(order).providers.find((p) => p.providerId === "e2b")?.gaps ?? [];
+			expect(gaps[0]?.cause).toEqual(cause(20.04));
+		}
+	});
+
+	it("still upgrades an unclassified gap when another shard classified it, in either order", () => {
+		for (const order of [
+			[withCause(undefined, 0), withCause(20.04, 1)],
+			[withCause(20.04, 0), withCause(undefined, 1)],
+		]) {
+			const gaps = aggregateRuns(order).providers.find((p) => p.providerId === "e2b")?.gaps ?? [];
+			expect(gaps).toHaveLength(1);
+			expect(gaps[0]?.cause).toEqual(cause(20.04));
+		}
 	});
 });

--- a/packages/results/src/lib/aggregate.ts
+++ b/packages/results/src/lib/aggregate.ts
@@ -17,7 +17,7 @@
  * inconsistent merge fails here rather than reaching a consumer.
  */
 import type {
-	HostMetadataRecord,
+	GapCause,
 	MetricReplicate,
 	MetricResult,
 	ObservedSpecs,
@@ -32,7 +32,15 @@ import {
 	getProvider,
 	isDerivedMetric,
 	parseRun,
+	providerReportedNothing,
 } from "@sandbox-benchmarks/schema";
+import type { HostMetadataRecordInput, ObservedMixtureIds } from "./observed-mixtures.ts";
+import {
+	buildObservedMixtures,
+	foldHostMetadata,
+	observedMixtureIds,
+	representativeSpecs,
+} from "./observed-mixtures.ts";
 
 /**
  * Field separator for the composite dedupe keys below. A NUL can't occur in a suite name, a reason, or
@@ -55,15 +63,27 @@ interface ReplicateSlice {
  * hierarchical-bootstrap inference while the pooled median stays the ranking value. Provenance
  * (`sourceFile`/`appVersion`/`arguments`) is carried from the lowest-index replicate.
  */
-function mergeMetricReplicates(byReplicate: Map<number, MetricResult>): MetricResult {
+function mergeMetricReplicates(byReplicate: Map<number, ReplicateContribution>): MetricResult {
 	const indices = [...byReplicate.keys()].sort((a, b) => a - b);
-	const first = byReplicate.get(indices[0] as number) as MetricResult;
-	if (indices.length === 1) return first;
+	const only = byReplicate.get(indices[0] as number) as ReplicateContribution;
+	const first = only.metric;
+	// R = 1: no replicate structure to hold the attribution (the schema keeps `replicates` for ≥2
+	// clusters), so the ids go on the Metric itself — one sandbox produced every Sample, so naming one
+	// machine is exactly true. Without this the join went missing precisely where the breakdown is
+	// absent, and a provider whose suites each landed a single sandbox published its mixtures with
+	// nothing pointing at any of them. Spread into a NEW object: `first` belongs to the caller's shard.
+	if (indices.length === 1) return { ...first, ...only.ids };
 
-	const replicates: MetricReplicate[] = indices.map((index) => ({
-		index,
-		samples: [...(byReplicate.get(index) as MetricResult).samples],
-	}));
+	const replicates: MetricReplicate[] = indices.map((index) => {
+		const contribution = byReplicate.get(index) as ReplicateContribution;
+		return {
+			index,
+			samples: [...contribution.metric.samples],
+			// The join to observedMixtures: which machine and network produced THIS cluster. Spread so a
+			// category the sandbox disclosed nothing for stays absent rather than becoming a dangling key.
+			...contribution.ids,
+		};
+	});
 	const pooled = replicates.flatMap((r) => r.samples);
 	// Spread `first` so every provenance field (sourceFile/appVersion/arguments — and any future optional
 	// MetricResult field) is carried from the lowest-index replicate without re-listing the schema here,
@@ -77,80 +97,158 @@ function mergeMetricReplicates(byReplicate: Map<number, MetricResult>): MetricRe
 	};
 }
 
+/**
+ * A cause's comparison key, with its keys in a FIXED order rather than the order the producing site
+ * happened to write them in. Every `GapCause` arm is a flat record of scalars, so listing the sorted
+ * top-level keys canonicalizes it completely — the same discipline `observed-mixtures` applies before
+ * hashing, for the same reason: a key order that drifts at a construction site would otherwise put shard
+ * arrival order back into the published document through the tie-break below.
+ */
+function causeKey(cause: GapCause): string {
+	return JSON.stringify(cause, Object.keys(cause).sort());
+}
+
+/**
+ * Whether `next` should replace `current` as a gap's cause: any classification beats none, and between
+ * two classifications the canonically smaller wins so the choice never depends on shard arrival order.
+ */
+function preferCause(current: GapCause | undefined, next: GapCause): boolean {
+	if (current === undefined) return true;
+	return causeKey(next) < causeKey(current);
+}
+
+/** One replicate's contribution to a metric, with the mixture ids of the sandbox that produced it. */
+interface ReplicateContribution {
+	metric: MetricResult;
+	ids: ObservedMixtureIds;
+}
+
+/**
+ * Fold across shards by the rule the whole merge uses for a verdict: a single `false` is sticky, a
+ * `true` stands only while nothing contradicts it, and all-undefined stays undefined ("refuse to judge
+ * on partial evidence", see computeSpecMatched).
+ *
+ * Order-independent by construction, which matters because shard arrival order is not deterministic —
+ * an earlier first-shard-wins version made ranking eligibility depend on it.
+ */
+function foldVerdict(current: boolean | undefined, next: boolean | undefined): boolean | undefined {
+	if (next === false || current === false) return false;
+	return next === true ? true : current;
+}
+
 /** Merge one provider's slices across every replicate shard that carried it. */
 function mergeProvider(providerId: string, entries: readonly ReplicateSlice[]): ProviderRun {
-	const slices = entries.map((entry) => entry.slice);
-	// Group measured metrics by id, then by the replicate that produced them. A metric id recurring across
-	// replicate shards is R distinct sandboxes (folded into the replicate structure below); a metric id
-	// recurring WITHIN one replicate is a duplicate (one <Result> owns a metric's samples — result-name
-	// contamination), so first-wins survives at the per-replicate level.
-	const byMetric = new Map<string, Map<number, MetricResult>>();
+	// Group measured metrics by id, then by the replicate that produced them, carrying that sandbox's
+	// mixture ids in the SAME record. A metric id recurring across replicate shards is R distinct
+	// sandboxes (folded into the replicate structure below); a metric id recurring WITHIN one replicate is
+	// a duplicate (one <Result> owns a metric's samples — result-name contamination), so first-wins
+	// survives at the per-replicate level. Keeping the ids alongside the metric rather than in a parallel
+	// map makes "the attribution describes the sandbox the samples came from" structural.
+	//
+	// Keyed per METRIC, not per provider: a replicate index is scoped to its cell, so (system, r0) and
+	// (disk, r0) are two different sandboxes that may well have landed on different machines. A
+	// provider-wide index→machine map would silently attribute one suite's samples to another suite's host.
+	const byMetric = new Map<string, Map<number, ReplicateContribution>>();
+	const gapByKey = new Map<string, ResultGap>();
+	// Coverage unions across shards: the matrix fans out one job per (provider, suite) and that job writes
+	// one shard per replicate sandbox, so each shard sees only its own cell+replicate. A suite is covered
+	// for this provider iff SOME shard produced a Metric for it.
+	const suitesCovered = new Set<string>();
+	const uncatalogued: UncataloguedResult[] = [];
+	const seenStraggler = new Set<string>();
+	let specMatched: boolean | undefined;
+	// One reading per SANDBOX, for the mixture tally. Only slices carrying participation evidence count:
+	// the normalizer emits a zero-evidence placeholder ProviderRun for every registered provider in
+	// EVERY shard, so counting slices naively would set the denominator to "every shard in the run" and
+	// report a 3-sandbox provider as having 60-odd blind sandboxes. A slice with a gap but no metric IS a
+	// real report (a skipped or failed-to-create sandbox is a sandbox the provider was asked for), so the
+	// predicate is participation evidence, not measurement.
+	const sandboxSpecReadings: ObservedSpecs[] = [];
+	// One entry per (record, sandbox), folded below. Collected raw rather than deduped here because the
+	// fold needs the machine each record was read on, which only the slice knows.
+	const hostMetadataInputs: HostMetadataRecordInput[] = [];
+
+	// ONE pass over the slices. The mixture ids are two sha256 hashes per slice, and a real run merges
+	// ~470 slices per provider (the normalizer's placeholder rows included), so deriving them once here
+	// rather than once per consumer loop is the difference between ~940 hashes and ~2,800.
 	for (const { slice, replicateIndex } of entries) {
+		const ids = observedMixtureIds(slice.observedSpecs);
+		if (!providerReportedNothing(slice)) sandboxSpecReadings.push(slice.observedSpecs);
+		for (const record of slice.hostMetadata ?? []) hostMetadataInputs.push({ record, ids });
+		for (const suite of slice.suitesCovered) suitesCovered.add(suite);
+
 		for (const metric of slice.metrics) {
 			if (isDerivedMetric(metric)) continue;
 			let byReplicate = byMetric.get(metric.metricId);
 			if (!byReplicate) {
-				byReplicate = new Map<number, MetricResult>();
+				byReplicate = new Map<number, ReplicateContribution>();
 				byMetric.set(metric.metricId, byReplicate);
 			}
-			if (!byReplicate.has(replicateIndex)) byReplicate.set(replicateIndex, metric);
+			if (!byReplicate.has(replicateIndex)) byReplicate.set(replicateIndex, { metric, ids });
 		}
-	}
-	const measured = new Map<string, MetricResult>();
-	for (const [metricId, byReplicate] of byMetric) {
-		measured.set(metricId, mergeMetricReplicates(byReplicate));
-	}
 
-	// Gaps deduped by (scope, id, outcome, reason); uncatalogued stragglers by id — both can recur across
-	// shards. `outcome` belongs in the key: one shard skipping a suite on a disk precondition while another
-	// attempted it and crashed are two distinct facts about the provider, and folding them into one would
-	// silently drop whichever arrived second.
-	const gaps: ResultGap[] = [];
-	const seenGap = new Set<string>();
-	// Coverage unions across shards: the matrix fans out one job per (provider, suite) and that job writes
-	// one shard per replicate sandbox, so each shard sees only its own cell+replicate. A suite is covered for this provider iff SOME shard produced a Metric for it.
-	const suitesCovered = new Set<string>();
-	const uncatalogued: UncataloguedResult[] = [];
-	const seenStraggler = new Set<string>();
-	// observed-specs: first non-undefined value per key wins (all shards of a provider ran the same spec).
-	const observedSpecs: ObservedSpecs = {};
-	let specMatched: boolean | undefined;
-	const hostMetadata: HostMetadataRecord[] = [];
-	const seenHostMetadata = new Set<string>();
-
-	for (const slice of slices) {
-		for (const record of slice.hostMetadata ?? []) {
-			const key = JSON.stringify(record);
-			if (seenHostMetadata.has(key)) continue;
-			seenHostMetadata.add(key);
-			hostMetadata.push(record);
-		}
-		for (const suite of slice.suitesCovered) suitesCovered.add(suite);
+		// Gaps keyed by (scope, id, outcome, reason); `outcome` belongs in the key because one shard
+		// skipping a suite on a disk precondition while another attempted it and crashed are two distinct
+		// facts, and folding them would silently drop whichever arrived second. Merged into a NEW object:
+		// the gaps belong to the caller's shard Runs and must not be mutated.
+		//
+		// `cause` is not in the key, and the merge below is ORDER-INDEPENDENT for the two ways two shards
+		// can disagree about it. A classified cause beats an unclassified one (shards can straddle a
+		// producer upgrade). Two DIFFERENT classified causes under one key are reachable even though
+		// reason and cause are built from one input, because a reason can be lossier than its cause: the
+		// disk-shortfall sentence rounds with `toFixed(1)`, so 20.04 and 20.049 GiB free render one
+		// sentence carrying two `freeGb` values. Keeping whichever arrived first would make the published
+		// number depend on shard order, so the canonically smaller cause wins — arbitrary, but stable
+		// across re-aggregation, which is the property the committed dataset needs.
 		for (const gap of slice.gaps) {
 			const key = [gap.scope, gap.id, gap.outcome, gap.reason].join(NUL);
-			if (seenGap.has(key)) continue;
-			seenGap.add(key);
-			gaps.push(gap);
+			const existing = gapByKey.get(key);
+			if (existing === undefined) {
+				gapByKey.set(key, gap);
+			} else if (gap.cause !== undefined && preferCause(existing.cause, gap.cause)) {
+				gapByKey.set(key, { ...existing, cause: gap.cause });
+			}
 		}
+
 		for (const straggler of slice.uncatalogued) {
 			if (seenStraggler.has(straggler.id)) continue;
 			seenStraggler.add(straggler.id);
 			uncatalogued.push(straggler);
 		}
-		for (const [key, value] of Object.entries(slice.observedSpecs)) {
-			if (value !== undefined && !(key in observedSpecs)) {
-				(observedSpecs as Record<string, unknown>)[key] = value;
-			}
-		}
-		// specMatched folds ORDER-INDEPENDENTLY across shards (was first-shard-wins, which made ranking
-		// eligibility depend on shard arrival order). The merged provider row shares one aggregate, so a
-		// single shard that ran off the target spec (specMatched === false) contaminates it and
-		// disqualifies the whole provider — false is sticky and always wins. An affirmative match stands
-		// only while no shard contradicts it; all-undefined stays undefined ("refuse to judge on partial
-		// evidence", see computeSpecMatched).
-		if (slice.specMatched === false) specMatched = false;
-		else if (slice.specMatched === true && specMatched !== false) specMatched = true;
+
+		specMatched = foldVerdict(specMatched, slice.specMatched);
 	}
+
+	const measured = new Map<string, MetricResult>();
+	for (const [metricId, byReplicate] of byMetric) {
+		measured.set(metricId, mergeMetricReplicates(byReplicate));
+	}
+	const gaps = [...gapByKey.values()];
+
+	// The counted disclosure: how many distinct host-hardware and host-network combinations the
+	// provider's sandboxes actually reported, and how many landed on each. Undefined for a provider with
+	// no sandbox report at all (the registry placeholder row), which has no mixture to disclose.
+	const observedMixtures = buildObservedMixtures(sandboxSpecReadings);
+
+	// The representative single-value summary: the dominant machine and network, derived from the mixtures
+	// alone so it cannot depend on shard arrival order. Empty without mixtures, and provably so —
+	// `observedMixtures` is undefined only when NO slice carried participation evidence, and
+	// `providerReportedNothing` includes "no observed-spec reading", so every excluded slice had empty
+	// specs and there was never anything to summarize.
+	const observedSpecs: ObservedSpecs = observedMixtures
+		? representativeSpecs(observedMixtures)
+		: {};
+
+	// Fold the PER-MACHINE verdicts in too. The two inputs are the same observations at different grains,
+	// so they cannot legitimately disagree — and this closes the case where a shard reported specs but no
+	// verdict of its own, which used to leave the provider undefined while its machines plainly answered
+	// the question. The schema refuses a provider verdict kinder than its parts, so this is load-bearing.
+	for (const mixture of Object.values(observedMixtures?.hostHardware ?? {})) {
+		specMatched = foldVerdict(specMatched, mixture.specMatched);
+	}
+
+	// Fold host records by (source, file, non-volatile fields, machine) with a sandbox count.
+	const hostMetadata = foldHostMetadata(hostMetadataInputs);
 
 	const metrics = [...measured.values()];
 	// Re-derive economics from the FULL merged measured set so $/lifecycle sums every suite's timings,
@@ -172,6 +270,7 @@ function mergeProvider(providerId: string, entries: readonly ReplicateSlice[]): 
 		validationStatus: metrics.length > 0 ? "validated" : "pending",
 		...(specMatched !== undefined ? { specMatched } : {}),
 		observedSpecs,
+		...(observedMixtures !== undefined ? { observedMixtures } : {}),
 		...(hostMetadata.length > 0 ? { hostMetadata } : {}),
 		metrics,
 		suitesCovered: [...suitesCovered].sort((a, b) => a.localeCompare(b)),
@@ -225,10 +324,10 @@ export function aggregateRuns(runs: readonly Run[]): Run {
 	const sourceRunUrl = runs.find((run) => run.sourceRunUrl !== undefined)?.sourceRunUrl;
 
 	// The merged Run spans every replicate, so it carries no single `replicateIndex` — that lived on the
-	// shards. Emit v4, the version whose self-description fields this layer is about to populate — it is
-	// the only one that sees every sandbox's reading at once. v2/v3 shards read in above validate
-	// unchanged, and a v4 document still carries the v3 replicate fold (version floors compare
-	// numerically in runSchema).
+	// shards. Emit v4: this is the only layer that sees every sandbox's reading at once, so it is the only
+	// one that can emit `observedMixtures`, join each replicate to the mixture its sandbox reported, and
+	// fold the host records. v2/v3 shards read in above validate unchanged, and the v4 document still
+	// carries the v3 replicate fold (version floors compare numerically in runSchema).
 	return parseRun({
 		schemaVersion: "4",
 		runId: first.runId,


### PR DESCRIPTION
**RUN SCHEMA v4 — make the benchmark dataset self-describing**
Shipped as an 8-PR stack (merge bottom-up, each branch independently green):

1. #292 — schema: open Run v4 (numeric version floors) + the closed `GapCause` taxonomy
2. #293 — schema: carry a gap's cause on its on-disk marker
3. #294 — harness: `GapError` — classify a failure at the site that knows it
4. #295 — results: author causes in the normalizer, read them in the leaderboard
5. #296 — schema: `MetricResult.derived` — mark a computed row in the document
6. #297 — schema: `ObservedMixtures`, the replicate→machine join, per-machine verdicts
7. #298 — results: build the counted mixtures and fold host records onto them
8. #299 — results: aggregate onto the mixtures instead of onto shard order

↑ **This PR is #299 (8/8)**, based on #298.

---

The layer below can count a fleet; this is where the aggregate stops discarding what it
counts. It is the only layer that sees every sandbox's reading at once, so it is the only
one that can emit `observedMixtures`, join each replicate to the mixture its sandbox
reported, and fold the host records.

The merge becomes ONE pass over the slices. The mixture ids are two sha256 hashes per
slice and a real run merges ~470 slices per provider (the normalizer's placeholder rows
included), so deriving them once here rather than once per consumer loop is the
difference between ~940 hashes and ~2,800. Each metric's per-replicate map now carries
the ids alongside the metric, which makes "the attribution describes the sandbox the
samples came from" structural rather than a parallel-map convention — and the map is
keyed per METRIC, not per provider, because a replicate index is scoped to its cell:
(system, r0) and (disk, r0) are two different sandboxes that may well have landed on
different machines.

`observedSpecs` is now derived from the mixtures alone, so it cannot depend on shard
arrival order. The denominator counts only slices carrying participation evidence: the
normalizer emits a zero-evidence placeholder ProviderRun for every registered provider
in EVERY shard, so counting slices naively would report a 3-sandbox provider as having
60-odd blind sandboxes. A slice with a gap but no metric IS a real report — a sandbox
that was asked for and failed is still a sandbox.

Two order-dependencies are closed with it:

  * `foldVerdict` replaces the inlined sticky-false fold and now also folds the
    PER-MACHINE verdicts in. That closes the case where a shard reported specs but no
    verdict of its own, leaving the provider undefined while its machines plainly
    answered the question — and the schema refuses a provider verdict kinder than its
    parts, so it is load-bearing rather than tidy.
  * Gap-cause resolution. Two shards can report the same gap with different causes: the
    disk-shortfall sentence rounds `freeGb` with `toFixed(1)`, so 20.04 and 20.049 GiB
    free render one sentence carrying two `freeGb` values. First-wins made the published
    number depend on shard order, so a classified cause beats an unclassified one and the
    canonically smaller cause wins between two classifications. `causeKey` sorts the
    top-level keys before comparing, so reformatting a cause literal at a construction
    site cannot flip the tie-break — every `GapCause` arm is a flat record of scalars, so
    a sorted key list canonicalizes it completely.

ADR 0005 is amended with all six v4 facts, the two rules that make the mixture
categories trustworthy, and the consequences — including why the effective sandbox size
shares the hostHardware hash category (a provider handing out 4 vCPU on some sandboxes
and 2 on others is exactly the heterogeneity this exists to surface).

On the committed dataset: all 15 runs parse, LEADERBOARD.md renders byte-identically,
and re-aggregating run 30510718771 folds 468 host records to 203 — 54% smaller, ~28% off
the whole document.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Aggregate providers by stable host/network mixtures instead of shard order. Adds mixture-aware attribution (incl. single-replicate metrics), folds host metadata by machine, and makes gap causes and verdicts deterministic.

- **New Features**
  - Emit `observedMixtures` per provider with `sandboxes` and counts for `hostHardware`/`hostNetwork`; stable hashes exclude per-sandbox identity and omit mixtures for providers with no participation; removes `hostCpuModels`.
  - Attribute metrics to machines: add `hostHardwareId`/`hostNetworkId` on each replicate; for R=1 set ids on the `MetricResult`; derive `observedSpecs` from the dominant mixture.
  - Fold host metadata by non-volatile fields and mixture with per-record `sandboxes`, reducing duplicates.

- **Bug Fixes**
  - Deterministic gap-cause merge: prefer classified over unclassified; between two classified causes choose the canonical smaller by sorted-key comparison.
  - Order-independent `specMatched` fold and include per-machine verdicts; provider verdict can’t be kinder than its parts.
  - Correct mixture counts and denominators: increment `sandboxes` only on participation; count gap-only sandboxes; category counts may be less than `sandboxes`.

<sup>Written for commit 8467242c8770778a867d742e38ea5e9aebf42a2f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/starslingdev/hpc-sandbox-benchmarks/pull/299?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

