### PR TITLE
fix(providers): configure Microsandbox lifecycle

### DIFF
--- a/packages/providers/src/index.test.ts
+++ b/packages/providers/src/index.test.ts
@@ -172,11 +172,13 @@ describe("@sandbox-benchmarks/providers", () => {
 			...base,
 			variant: "microsandbox-local",
 			backend: "local",
+			ephemeral: false,
 		});
 		const cloud = microsandboxCloudCompute({
 			...base,
 			variant: "microsandbox-cloud",
 			backend: { kind: "cloud", url: "https://msb.invalid", apiKey: "unit-test-key" },
+			ephemeral: true,
 		});
 
 		expect(local.name).toBe("microsandbox-local");

--- a/packages/providers/src/lib/adapters.ts
+++ b/packages/providers/src/lib/adapters.ts
@@ -148,6 +148,7 @@ export const adapters: Record<ProviderId, ProviderAdapter> = {
 			microsandboxLocalCompute({
 				variant: "microsandbox-local",
 				backend: "local",
+				ephemeral: false,
 				image: config.toolchainImage,
 				cpus: TARGET_SPEC.vcpus,
 				memoryMib: TARGET_SPEC.memoryGb * 1024,
@@ -165,6 +166,7 @@ export const adapters: Record<ProviderId, ProviderAdapter> = {
 			microsandboxCloudCompute({
 				variant: "microsandbox-cloud",
 				backend: microsandboxCloudCredentials(),
+				ephemeral: true,
 				image: config.toolchainImage,
 				cpus: TARGET_SPEC.vcpus,
 				memoryMib: TARGET_SPEC.memoryGb * 1024,

--- a/packages/providers/src/lib/microsandbox.test.ts
+++ b/packages/providers/src/lib/microsandbox.test.ts
@@ -17,6 +17,8 @@ let builtName = "";
 let getNames: string[] = [];
 let removedNames: string[] = [];
 let stopCalls = 0;
+let requestStopCalls = 0;
+let waitUntilStoppedCalls = 0;
 let cleanupGetError: Error | undefined;
 let cleanupRemoveError: Error | undefined;
 let residueStatus = "error";
@@ -42,6 +44,7 @@ function cloudProvider() {
 	return microsandboxCloudCompute({
 		variant: "microsandbox-cloud",
 		backend: { kind: "cloud", apiKey: "offline-test-key" },
+		ephemeral: true,
 		image: "alpine:3.20",
 		cpus: 1,
 		memoryMib: 512,
@@ -55,6 +58,7 @@ function localProvider() {
 	return microsandboxLocalCompute({
 		variant: "microsandbox-local",
 		backend: "local",
+		ephemeral: false,
 		image: "alpine:3.20",
 		cpus: 1,
 		memoryMib: 512,
@@ -72,6 +76,8 @@ describe("Microsandbox failed-create cleanup", () => {
 		getNames = [];
 		removedNames = [];
 		stopCalls = 0;
+		requestStopCalls = 0;
+		waitUntilStoppedCalls = 0;
 		cleanupGetError = undefined;
 		cleanupRemoveError = undefined;
 		residueStatus = "error";
@@ -85,6 +91,13 @@ describe("Microsandbox failed-create cleanup", () => {
 				status: residueStatus,
 				stop: async () => {
 					stopCalls++;
+				},
+				requestStop: async () => {
+					requestStopCalls++;
+				},
+				waitUntilStopped: async () => {
+					waitUntilStoppedCalls++;
+					return { name, status: "stopped" };
 				},
 			} as unknown as Awaited<ReturnType<typeof MsbSandbox.get>>;
 		}) as typeof MsbSandbox.get);
@@ -109,14 +122,18 @@ describe("Microsandbox failed-create cleanup", () => {
 		expect(removedNames).toEqual([builtName]);
 		// status=error is not "stopped", so it is stopped first: remove() is documented as removing a
 		// STOPPED sandbox, and skipping the stop for a status outside the mapped set made it reject.
-		expect(stopCalls).toBe(1);
+		expect(stopCalls).toBe(0);
+		expect(requestStopCalls).toBe(1);
+		expect(waitUntilStoppedCalls).toBe(1);
 	});
 
 	it("stops a running partial sandbox before removing its record", async () => {
 		residueStatus = "running";
 		await expect(cloudProvider().sandbox.create()).rejects.toThrow(/simulated create failure/);
 
-		expect(stopCalls).toBe(1);
+		expect(stopCalls).toBe(0);
+		expect(requestStopCalls).toBe(1);
+		expect(waitUntilStoppedCalls).toBe(1);
 		expect(removedNames).toEqual([builtName]);
 	});
 
@@ -125,6 +142,8 @@ describe("Microsandbox failed-create cleanup", () => {
 		await expect(cloudProvider().sandbox.create()).rejects.toThrow(/simulated create failure/);
 
 		expect(stopCalls).toBe(0);
+		expect(requestStopCalls).toBe(0);
+		expect(waitUntilStoppedCalls).toBe(0);
 		expect(removedNames).toEqual([builtName]);
 	});
 
@@ -135,7 +154,9 @@ describe("Microsandbox failed-create cleanup", () => {
 		residueStatus = "crashed";
 		await expect(cloudProvider().sandbox.create()).rejects.toThrow(/simulated create failure/);
 
-		expect(stopCalls).toBe(1);
+		expect(stopCalls).toBe(0);
+		expect(requestStopCalls).toBe(1);
+		expect(waitUntilStoppedCalls).toBe(1);
 		expect(removedNames).toEqual([builtName]);
 	});
 
@@ -183,6 +204,7 @@ describe("Microsandbox provider edge cases", () => {
 
 	it("uses the per-create timeout as the native sandbox lifetime", async () => {
 		let maxDurationSecs = 0;
+		let ephemeral: boolean | undefined;
 		let builder: Record<PropertyKey, unknown>;
 		builder = new Proxy(
 			{},
@@ -191,6 +213,12 @@ describe("Microsandbox provider edge cases", () => {
 					if (property === "maxDuration") {
 						return (seconds: number) => {
 							maxDurationSecs = seconds;
+							return builder;
+						};
+					}
+					if (property === "ephemeral") {
+						return (enabled: boolean) => {
+							ephemeral = enabled;
 							return builder;
 						};
 					}
@@ -219,7 +247,37 @@ describe("Microsandbox provider edge cases", () => {
 		const sandbox = await cloudProvider().sandbox.create({ timeout: 12_345 });
 
 		expect(maxDurationSecs).toBe(13);
+		expect(ephemeral).toBe(true);
 		expect((await sandbox.getInfo()).timeout).toBe(12_345);
+	});
+
+	it("keeps local snapshot qualification persistent", async () => {
+		let ephemeral: boolean | undefined;
+		let builder: Record<PropertyKey, unknown>;
+		builder = new Proxy(
+			{},
+			{
+				get: (_target, property) => {
+					if (property === "ephemeral") {
+						return (enabled: boolean) => {
+							ephemeral = enabled;
+							return builder;
+						};
+					}
+					if (property === "create") return async () => ({});
+					return () => builder;
+				},
+			},
+		);
+		restore(
+			spyOn(MsbSandbox, "builder").mockImplementation(
+				(() => builder) as unknown as typeof MsbSandbox.builder,
+			),
+		);
+
+		await localProvider().sandbox.create();
+
+		expect(ephemeral).toBe(false);
 	});
 
 	it("throws instead of replaying a command after an ambiguous agent failure", async () => {

--- a/packages/providers/src/lib/microsandbox.ts
+++ b/packages/providers/src/lib/microsandbox.ts
@@ -43,6 +43,8 @@ export type MicrosandboxVariant = "microsandbox-local" | "microsandbox-cloud";
 interface MicrosandboxBaseConfig {
 	variant: MicrosandboxVariant;
 	backend: DefaultBackend;
+	/** Whether the provider should delete sandbox state when the sandbox stops. */
+	ephemeral: boolean;
 	/** OCI image to boot when create() receives no templateId. */
 	image: string;
 	/** Guest vCPUs. */
@@ -231,7 +233,17 @@ async function removeSandboxIfPresent(
 			// precisely because transitional/unknown statuses (a cloud record still booting, `crashed`) do
 			// occur — skipping the stop for those made remove() reject and leaked the microVM until its
 			// maxDuration expired.
-			if (handle.status !== "stopped") await handle.stop();
+			if (handle.status !== "stopped") {
+				if (config.variant === "microsandbox-cloud") {
+					// Cloud stop can legitimately take longer than the SDK's 10-second graceful window.
+					// Requesting and observing it separately avoids stop() escalating to kill(), which the
+					// cloud backend intentionally does not support.
+					await handle.requestStop();
+					await handle.waitUntilStopped();
+				} else {
+					await handle.stop();
+				}
+			}
 			await MsbSandbox.remove(sandboxId);
 		} catch (error) {
 			if (isNotFound(error)) return;
@@ -403,6 +415,7 @@ const sandboxMethods: SandboxMethods<MicrosandboxHandle, MicrosandboxConfig> = {
 					.memory(config.memoryMib)
 					.maxDuration(maxDurationSecs)
 					.detached(true)
+					.ephemeral(config.ephemeral)
 					.label(LABEL_MARKER, config.variant);
 				for (const [key, value] of Object.entries(metadata)) {
 					builder = builder.label(`${LABEL_META_PREFIX}${key}`, String(value));


### PR DESCRIPTION
## Summary

- make Microsandbox lifecycle explicit in provider configuration
- create cloud benchmark sandboxes as ephemeral while keeping local snapshot qualification persistent
- stop cloud sandboxes with `requestStop()` plus `waitUntilStopped()` before removal, avoiding `stop()` escalation to the cloud-unsupported kill operation
- cover failed-create cleanup and local/cloud lifecycle behavior with tests

## Why

The full upstream matrix run [#30589436441](https://github.com/starslingdev/hpc-sandbox-benchmarks/actions/runs/30589436441) exposed two cloud-specific lifecycle problems: benchmark sandboxes defaulted to persistent, and cleanup could time out after ten seconds before escalating to an unsupported cloud kill. This caused leaked state and obscured qualification failures.

The lifecycle choice is an explicit adapter option rather than a variant check inside the provider, so another backend can select ephemeral behavior without being hardcoded by name.

## Validation

- `bun run lint`
- `bun run typecheck`
- `bun test packages/providers/src/lib/microsandbox.test.ts packages/providers/src/index.test.ts` — 36 tests passed
- [Full Microsandbox Cloud matrix #30629097514](https://github.com/superradcompany/hpc-sandbox-benchmarks/actions/runs/30629097514): all 9 suites passed; 54/54 expected shards uploaded; 54/54 sandbox results validated with matching specs; no port, relay, socket, file-descriptor, teardown, or leaked-sandbox errors

The live qualification used the standard suite defaults: 3 replicas for each synthetic suite and 12 replicas for each real-world suite.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Makes Microsandbox lifecycle explicit and fixes cloud cleanup to prevent leaked sandboxes. Cloud sandboxes are ephemeral with graceful stop; local snapshot qualification remains persistent.

- **New Features**
  - Added `ephemeral` to Microsandbox config; set to true for cloud and false for local in `adapters`.
  - Propagated `ephemeral` to the native builder and used per-create timeout as the native lifetime (`maxDuration`).

- **Bug Fixes**
  - Cloud cleanup now uses `requestStop()` + `waitUntilStopped()` before removal, avoiding unsupported kill escalation and timeouts.
  - Covered failed-create cleanup and local/cloud lifecycle behavior with tests.

<sup>Written for commit da5e0c62f3bfdbf8c4c881b331e7d458d749d2a0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/starslingdev/hpc-sandbox-benchmarks/pull/306?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved sandbox cleanup to reliably stop cloud sandboxes and wait for shutdown completion.
  - Preserved local sandbox workflows, including persistent snapshot behavior.
  - Cloud sandboxes are now removed after stopping, while local sandboxes remain available as configured.

- **Tests**
  - Added coverage for ephemeral cloud sandboxes, persistent local sandboxes, and cleanup behavior for stopped and running sandboxes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->