### PR TITLE
feat(figures): realworld chart package (model -> HTML)

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -47,6 +47,22 @@
         "typescript": "catalog:",
       },
     },
+    "packages/figures": {
+      "name": "@sandbox-benchmarks/figures",
+      "version": "0.0.0",
+      "dependencies": {
+        "@fontsource-variable/afacad": "5.3.0",
+        "@fontsource/geist-mono": "5.3.0",
+        "@fontsource/geist-sans": "5.3.0",
+        "@sandbox-benchmarks/schema": "workspace:*",
+        "arktype": "catalog:",
+      },
+      "devDependencies": {
+        "@repo/tsconfig": "workspace:*",
+        "@types/bun": "catalog:",
+        "typescript": "catalog:",
+      },
+    },
     "packages/harness": {
       "name": "@sandbox-benchmarks/harness",
       "version": "0.0.0",
@@ -317,6 +333,12 @@
 
     "@fastify/busboy": ["@fastify/busboy@2.1.1", "", {}, "sha512-vBZP4NlzfOlerQTnba4aqZoMhE/a9HY7HRqoOPaETQcSQuWEIyZMHGfVu6w9wGtGK5fED5qRs2DteVCjOH60sA=="],
 
+    "@fontsource-variable/afacad": ["@fontsource-variable/afacad@5.3.0", "", {}, "sha512-CjK1q7s07a7c/LS93oLJMHkRHGvlVgQC9CIIp3M7qk9vvgDp8iTp4tymb7PcwBrGhz4jneTPUXJBd8xpXbuxtQ=="],
+
+    "@fontsource/geist-mono": ["@fontsource/geist-mono@5.3.0", "", {}, "sha512-UtJ1BBBCVpMYdIcW7nEB45UAoAw5M53ZXs2t0ciPW+IokuAAIc56M8+kW5tXbRJCTpDw4XTtU7proT6NdQAHTg=="],
+
+    "@fontsource/geist-sans": ["@fontsource/geist-sans@5.3.0", "", {}, "sha512-AmG7cE1AvE4NHROPaOl1sN+a02cB5xy6pA/ZV76HXqWTCsJTV2SCBc9DTFHfJqnVOODm7HhXIYtUIb75NP5QXQ=="],
+
     "@grpc/grpc-js": ["@grpc/grpc-js@1.14.4", "", { "dependencies": { "@grpc/proto-loader": "^0.8.0", "@js-sdsl/ordered-map": "^4.4.2" } }, "sha512-k9Dj3DV/itK9D06Y8f190Qgop7/Ui+D0njFV3LHMPwPT75DpXLQohE9Wmz0QElrJnzsjB7KPWiKJbOl7IPDArQ=="],
 
     "@grpc/proto-loader": ["@grpc/proto-loader@0.8.1", "", { "dependencies": { "lodash.camelcase": "^4.3.0", "long": "^5.0.0", "protobufjs": "^7.5.5", "yargs": "^17.7.2" }, "bin": { "proto-loader-gen-types": "build/bin/proto-loader-gen-types.js" } }, "sha512-wtF6h+DY6M3YaDBPAmvuuA6jV8Sif9MjtOI5euKFWRgCDl5PeDpPsHR9u2l6St5ceY8AZgoNDww5+HvEsXFsGg=="],
@@ -478,6 +500,8 @@
     "@repo/tsconfig": ["@repo/tsconfig@workspace:tooling/tsconfig"],
 
     "@sandbox-benchmarks/cli": ["@sandbox-benchmarks/cli@workspace:apps/cli"],
+
+    "@sandbox-benchmarks/figures": ["@sandbox-benchmarks/figures@workspace:packages/figures"],
 
     "@sandbox-benchmarks/harness": ["@sandbox-benchmarks/harness@workspace:packages/harness"],
 

--- a/packages/figures/README.md
+++ b/packages/figures/README.md
@@ -1,0 +1,74 @@
+# `@sandbox-benchmarks/figures`
+
+Turns a Run document into chart figures: `model.ts` derives the realworld figure model —
+exactly the three fields the charts consume (suites, providers, phase order) — and `chart/`
+builds a view-model per suite and marks it up as one self-contained HTML document, the input a
+headless-browser screenshot turns into a published PNG.
+
+**The document is the whole input.** Inline styles, `data:`-URI fonts, no script, no server,
+no external reference of any kind: whatever a browser draws is a function of one string. That
+is the deterministic half of the pipeline — model and HTML — and it is what the tests and
+gates hold onto; rasterising it (`./screenshot`, headless Chrome via `Bun.WebView`) is the one
+impure step, behind its own entry point so importing anything else never spawns a browser.
+
+## What it draws
+
+One chart per chartable realworld suite: a stacked bar per environment, one segment per task in
+execution order, every chart from the same run on a single shared time scale so a second is the
+same length in every one of them. These are the figures that lead `LEADERBOARD.md`'s `realworld`
+section.
+
+## Seams
+
+Inputs are typed by `@sandbox-benchmarks/schema` — the workspace's one Run contract and registry
+shapes — so this package re-describes nothing the workspace already owns. The registries still
+arrive as **arguments** (`buildRealworldFigureModel({ run, metrics, providers, suites })`);
+there is no module-level dataset, which is what lets every guard here run against a synthetic
+run instead of whatever the committed dataset contains. `packages/results` owns the seam that
+passes the real registries, the caption text, and the figure-file naming; every non-chart
+derivation over a Run (tables, coverage, economics) is its jurisdiction, not this package's.
+
+| `exports` | what it costs to import |
+|---|---|
+| `.` | nothing but string building — the model derivation, the view-model, the HTML template, the inlined fonts. |
+| `./screenshot` | a browser. Constructing a `Bun.WebView` spawns headless Chrome; import this only where a PNG is actually wanted. |
+
+## Layering
+
+| Path | Rule |
+|---|---|
+| `src/phases.ts` | The pipeline phase vocabulary: id, printed label and ramp colour defined ONCE per phase, ordered by execution. Colour order = execution order holds by construction. |
+| `src/model.ts` | Run + registries → `RealworldFigureModel`. Which suites are chartable is decided here (≥2 environments completing every exercised task), and nowhere else. |
+| `src/chart/model.ts` | The view-model. **Every decision the picture makes** — sort order, badge, shared scale, disclosure rows — as plain data a unit test can assert on. The bulk of the tests. |
+| `src/chart/html.ts` | The template. Dumb on purpose: it knows widths and styles, and the one piece of arithmetic in it is `scaleFraction × TRACK_WIDTH`. |
+| `src/chart/fonts.ts` | The faces, read from pinned npm packages (`@fontsource/*`) and inlined as `data:` URIs — the lockfile pins the glyphs like it pins code. Brand faces only: `assertCovered` fails the render on a character none of them can draw, rather than shipping a full Unicode fallback to hide it. |
+| `src/screenshot.ts` | The **only** impure module: `Bun.WebView` → CDP → PNG bytes. Returns bytes, never writes a file. |
+
+Asserting `bars[0].fastest === true` is a unit test; asserting on a PNG is not. That is why
+`chart/model.ts` exists and why the decisions live there rather than in the template.
+
+## Things that will bite you
+
+- **The raster is not deterministic across machines; the HTML is, everywhere.** A browser's
+  rasterisation depends on its version and platform (Skia, font hinting, antialiasing), so two
+  machines produce different pixels from identical HTML. Any gate that wants exactness must
+  compare the HTML, not the pixels — which is why every decision lives in the model and the
+  document, and nothing meaningful is decided at paint time.
+- **Chrome is discovered, not downloaded — and spawned ONCE per process.** `Bun.WebView`
+  searches `backend.path`, then `BUN_CHROME_PATH`, then `$PATH` and the standard install
+  locations, then Playwright's cache, and throws if none is found. The process's FIRST view's
+  spawn options win; a later `chromePath` is silently ignored. Pin via `BUN_CHROME_PATH` in the
+  environment (as the release workflow does); a laptop's installed Chrome is fine for previews.
+- **Escape everything interpolated.** The template pipes every model string through
+  `escapeHtml` before any markdown replacement, colours through a hex-only guard, and the one
+  bare number in a `style` attribute (`flex-grow`) through a finite-number guard. A provider
+  name or a failure reason is data from a run document, and a document must not be able to
+  inject markup — or a `url(…)` — into the figure.
+- **Brand faces only; refuse what they can't draw.** Geist Mono and Afacad lack `†` and `→`, but
+  the embedded Geist Sans subset has both, so every font stack ends on Geist and the fallback
+  glyph is still a brand glyph. Nothing carries a full Unicode face — `assertCovered` throws on
+  a character no embedded face can draw, because the alternative is Chrome silently reaching for
+  an installed font and the figure quietly becoming a function of the machine that rendered it.
+- **`TRACK_WIDTH` is the shared scale.** A bar's drawn length is its total over the run's
+  slowest charted total, times one constant. Scale a chart to its own maximum and the figures
+  stop being one comparison.

--- a/packages/figures/package.json
+++ b/packages/figures/package.json
@@ -1,0 +1,28 @@
+{
+  "name": "@sandbox-benchmarks/figures",
+  "version": "0.0.0",
+  "private": true,
+  "description": "Chart figures for the comparison surface: a Run document -> the realworld figure model -> one self-contained HTML document per chart -> PNG via headless Chrome (Bun.WebView). Everything but ./screenshot is pure, deterministic string building.",
+  "type": "module",
+  "sideEffects": false,
+  "exports": {
+    ".": "./src/index.ts",
+    "./package.json": "./package.json"
+  },
+  "scripts": {
+    "test": "bun test",
+    "typecheck": "tsc --noEmit"
+  },
+  "devDependencies": {
+    "@repo/tsconfig": "workspace:*",
+    "@types/bun": "catalog:",
+    "typescript": "catalog:"
+  },
+  "dependencies": {
+    "@fontsource-variable/afacad": "5.3.0",
+    "@fontsource/geist-mono": "5.3.0",
+    "@fontsource/geist-sans": "5.3.0",
+    "@sandbox-benchmarks/schema": "workspace:*",
+    "arktype": "catalog:"
+  }
+}

--- a/packages/figures/src/chart/__fixtures__/data.ts
+++ b/packages/figures/src/chart/__fixtures__/data.ts
@@ -1,0 +1,51 @@
+/**
+ * A synthetic figure model for the chart tests.
+ *
+ * Deliberately NOT derived from the committed run: it carries, on purpose, an off-spec
+ * provider (the slower bar gets the dagger), an environment disclosed as incomplete, a disk
+ * requirement — shapes the live dataset may not contain, which is exactly why guards tested
+ * only against the committed run would be worth nothing.
+ *
+ * `satisfies` rather than a cast: the compiler holds the fixture to the real model contract,
+ * which is the shape check the deleted runtime parse used to do.
+ */
+import type { RealworldFigureModel } from "../../model.ts";
+
+export const FIXTURE = {
+	providers: [
+		{ id: "alpha", name: "Alpha", specMatched: true },
+		{ id: "beta", name: "Beta", specMatched: false },
+		{ id: "gamma", name: "Gamma", specMatched: true },
+	],
+	suites: [
+		{
+			id: "realworld-demo",
+			name: "Demo",
+			minDiskGb: 30,
+			tasks: [
+				{ id: "realworld_demo_task_clone", phase: "clone" },
+				{ id: "realworld_demo_task_install", phase: "build" },
+			],
+			droppedTasks: [],
+			bars: [
+				{
+					provider: "beta",
+					totalS: 400,
+					segments: [
+						{ id: "realworld_demo_task_clone", phase: "clone", p50: 160, n: 3 },
+						{ id: "realworld_demo_task_install", phase: "build", p50: 240, n: 3 },
+					],
+				},
+				{
+					provider: "alpha",
+					totalS: 100,
+					segments: [
+						{ id: "realworld_demo_task_clone", phase: "clone", p50: 40, n: 3 },
+						{ id: "realworld_demo_task_install", phase: "build", p50: 60, n: 3 },
+					],
+				},
+			],
+			incomplete: [{ provider: "gamma", outcome: "failed", reason: "install exceeded stop" }],
+		},
+	],
+} satisfies RealworldFigureModel;

--- a/packages/figures/src/chart/fonts.ts
+++ b/packages/figures/src/chart/fonts.ts
@@ -1,0 +1,158 @@
+/**
+ * The chart faces, as `@font-face` rules with `data:` URIs — sourced from pinned npm
+ * packages, not vendored binaries.
+ *
+ * Inlined rather than referenced: the HTML a chart renders from is handed to a browser as a
+ * single document with no server behind it, so a `url(file: …)` would make the figure depend
+ * on the checkout's absolute path and an installed-font fallback would make it depend on the
+ * machine. With the faces inline, the document carries everything the rasteriser needs and
+ * the same HTML draws the same text wherever Chrome runs it.
+ *
+ * The bytes come out of `node_modules` (`@fontsource/*` woff2 subsets), resolved through the
+ * package resolver so the lockfile pins the glyphs exactly as it pins code. Weights the faces
+ * don't carry (the mono 600 totals) are the browser's synthetic bold.
+ *
+ * BRAND FACES ONLY, no Unicode fallback. The two characters the templates use that Geist Mono
+ * and Afacad lack — `†` and `→` — are both present in the Geist Sans subset already embedded
+ * here, so every font stack simply ends on Geist and the glyphs are drawn by the brand face
+ * rather than a foreign one. (`·` needs no fallback at all; every face has it.) What used to
+ * fill that role was the full 757 KB DejaVu Sans, which base64'd to 986 KB — 88% of every
+ * generated document — to supply two glyphs Geist already had. {@link assertCovered} is what
+ * makes dropping it safe: the coverage it insured against losing is now checked, not carried.
+ */
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+
+/** A file inside an installed package, located via Bun's own resolver (survives hoisting,
+ *  workspaces, and a relocated store) — `package.json` is always exported, so it anchors. */
+function packageFile(pkg: string, ...rel: string[]): string {
+	return join(dirname(Bun.resolveSync(`${pkg}/package.json`, import.meta.dir)), ...rel);
+}
+
+const FACES = [
+	{
+		family: "Geist",
+		weight: 400,
+		mime: "font/woff2",
+		format: "woff2",
+		file: packageFile("@fontsource/geist-sans", "files", "geist-sans-latin-400-normal.woff2"),
+	},
+	{
+		family: "Geist",
+		weight: 500,
+		mime: "font/woff2",
+		format: "woff2",
+		file: packageFile("@fontsource/geist-sans", "files", "geist-sans-latin-500-normal.woff2"),
+	},
+	{
+		family: "Geist Mono",
+		weight: 400,
+		mime: "font/woff2",
+		format: "woff2",
+		file: packageFile("@fontsource/geist-mono", "files", "geist-mono-latin-400-normal.woff2"),
+	},
+	{
+		family: "Afacad",
+		// A VARIABLE face: one file carries the whole wght axis, so the declaration is a
+		// range and the browser instances the exact weight the template asks for.
+		weight: "400 700",
+		mime: "font/woff2",
+		format: "woff2",
+		file: packageFile("@fontsource-variable/afacad", "files", "afacad-latin-wght-normal.woff2"),
+	},
+] as const;
+
+/**
+ * Every codepoint an embedded face is known to draw — the guard behind {@link assertCovered}.
+ *
+ * Not derived from the files: reading a cmap means decompressing woff2, which is a decoder this
+ * package would otherwise have no reason to carry. It is instead the ASCII the templates emit
+ * plus the punctuation VERIFIED present in the Geist Sans subset (checked against the shipped
+ * cmap), which is the fallback every stack ends on. The list is deliberately short — a character
+ * missing from it is not a crash, it is a prompt to check the subset actually has the glyph and
+ * add it here.
+ */
+const COVERED = new Set<number>([
+	// Printable ASCII — every face carries it.
+	...Array.from({ length: 0x7f - 0x20 }, (_, i) => 0x20 + i),
+	0x00a0, // no-break space
+	0x00b0, // °
+	0x00b1, // ±
+	0x00b7, // ·  the summary and disclosure separator
+	0x00d7, // ×
+	0x00a7, // §
+	0x2013, // –
+	0x2014, // —
+	0x2018, // '
+	0x2019, // '
+	0x201c, // "
+	0x201d, // "
+	0x2020, // †  the off-spec dagger
+	0x2021, // ‡
+	0x2022, // •
+	0x2026, // …
+	0x2192, // →  the phase-order arrow
+	0x2248, // ≈
+	0x2264, // ≤
+	0x2265, // ≥
+]);
+
+/**
+ * Fail the render on a character no embedded face can draw.
+ *
+ * The figure's whole determinism claim is that the document carries everything the rasteriser
+ * needs, so the same HTML draws the same pixels anywhere. An uncovered character breaks that
+ * SILENTLY: Chrome reaches past the embedded faces to whatever the machine has installed, and
+ * the figure becomes a function of the renderer's font directory — locally fine, tofu or a
+ * different face in a bare CI container. The note is authored text, so this is a live risk
+ * rather than a theoretical one (`µs` in a future note would do it).
+ *
+ * Carrying a 986 KB full Unicode fallback used to paper over this for the price of 88% of every
+ * document. Refusing to render is the same insurance at no bytes: a build error names the
+ * character, and the fix is a glyph the brand faces have or a deliberate addition to
+ * {@link COVERED}.
+ */
+/** Tab, LF and CR: the document's layout whitespace. They are not glyphs, so a face cannot
+ *  "cover" them — reporting one as an uncovered character would be a confusing lie. */
+const LAYOUT_WHITESPACE = new Set([0x09, 0x0a, 0x0d]);
+
+export function assertCovered(document: string): void {
+	for (const char of document) {
+		const cp = char.codePointAt(0);
+		if (cp !== undefined && !LAYOUT_WHITESPACE.has(cp) && !COVERED.has(cp)) {
+			throw new Error(
+				`no embedded face covers ${JSON.stringify(char)} (U+${cp.toString(16).toUpperCase().padStart(4, "0")}) — ` +
+					`the figure would fall back to an installed font and stop being reproducible`,
+			);
+		}
+	}
+}
+
+/**
+ * The notices the embedded faces' licences require to travel with copies of the fonts — and a
+ * document with the font bytes inlined IS a copy. The full licence texts ship inside the font
+ * packages themselves; this comment rides in every generated document so a figure distributed
+ * on its own still carries the attribution.
+ */
+const FONT_NOTICES = `/*
+ * Embedded fonts (full licences ship in their npm packages):
+ * Geist, Geist Mono - Copyright 2024 The Geist Project Authors
+ *   (https://github.com/vercel/geist-font.git), SIL Open Font License 1.1.
+ * Afacad - Copyright 2023 The Afacad Project Authors
+ *   (https://github.com/Dicotype/Afacad), SIL Open Font License 1.1.
+ */`;
+
+let cached: string | null = null;
+
+/** Every face as one `@font-face` block, led by the licence notices the embedded copies must
+ *  carry. Read lazily and once per process, then reused by every chart of a render. */
+export function fontFaceCss(): string {
+	if (cached === null) {
+		cached = `${FONT_NOTICES}\n${FACES.map(
+			(face) =>
+				`@font-face { font-family: "${face.family}"; font-weight: ${face.weight}; ` +
+				`src: url(data:${face.mime};base64,${readFileSync(face.file).toBase64()}) format("${face.format}"); }`,
+		).join("\n")}`;
+	}
+	return cached;
+}

--- a/packages/figures/src/chart/format.ts
+++ b/packages/figures/src/chart/format.ts
@@ -1,0 +1,5 @@
+/** One copy of the duration formatting, shared by everything that prints a total — two
+ *  implementations would let a chart round a number differently from the surface above it. */
+export function formatSeconds(s: number): string {
+	return `${s < 10 ? s.toFixed(2) : s.toFixed(1)} s`;
+}

--- a/packages/figures/src/chart/html.test.ts
+++ b/packages/figures/src/chart/html.test.ts
@@ -1,0 +1,100 @@
+import { describe, expect, it } from "bun:test";
+import { FIXTURE } from "./__fixtures__/data.ts";
+import { pipelineChartHtml } from "./html.ts";
+import { buildPipelineChartModel } from "./model.ts";
+
+const suite = FIXTURE.suites[0];
+if (!suite) throw new Error("fixture must carry a chartable suite");
+
+const html = pipelineChartHtml(buildPipelineChartModel(suite, FIXTURE, "note text"));
+
+describe("pipelineChartHtml", () => {
+	it("is deterministic — the same model renders the same bytes", () => {
+		expect(pipelineChartHtml(buildPipelineChartModel(suite, FIXTURE, "note text"))).toBe(html);
+	});
+
+	it("is self-contained — every face inline, no external reference", () => {
+		expect(html.match(/@font-face/g)?.length).toBe(4);
+		expect(html).toContain("data:font/woff2;base64,");
+		// The one URL scheme in the document is `data:`. An http(s) or file reference would
+		// make the figure depend on something other than this string.
+		expect(html).not.toMatch(/url\((?!data:)/);
+		expect(html).not.toContain("<script");
+	});
+
+	it("carries the embedded fonts' licence notices — an inlined font is a copy", () => {
+		expect(html).toContain("The Geist Project Authors");
+		expect(html).toContain("The Afacad Project Authors");
+		expect(html).toContain("SIL Open Font License");
+	});
+
+	it("carries brand faces only — no Unicode fallback face rides along", () => {
+		// The 986 KB DejaVu payload was 88% of the document and supplied two glyphs (`†`, `→`)
+		// the embedded Geist Sans subset already has. Every stack ends on Geist for that reason.
+		expect(html).not.toContain("DejaVu");
+		expect(html).toContain(`"Geist Mono", Geist, monospace`);
+		// The characters that motivated the fallback still render — they are drawn by a brand face.
+		expect(html).toContain("†");
+		expect(html).toContain("→");
+	});
+
+	it("refuses a character no embedded face can draw, rather than falling back silently", () => {
+		// `µ` is in DejaVu but not in the Geist subsets: exactly the case that used to slip
+		// through and make the figure depend on the rendering machine's installed fonts.
+		expect(() => pipelineChartHtml(buildPipelineChartModel(suite, FIXTURE, "median µs"))).toThrow(
+			/no embedded face covers "µ" \(U\+00B5\)/,
+		);
+	});
+
+	it("refuses a colour that is not hex — a style attribute must not be an injection point", () => {
+		const model = buildPipelineChartModel(suite, FIXTURE, "n");
+		const poisoned = {
+			...model,
+			legend: [{ label: "clone", color: 'red;" onload="alert(1)' }],
+		};
+		expect(() => pipelineChartHtml(poisoned)).toThrow(/not a hex colour/);
+	});
+
+	it("refuses a share that is not a finite number — `flex-grow` takes it unformatted", () => {
+		const model = buildPipelineChartModel(suite, FIXTURE, "n");
+		const bar = model.bars[0];
+		if (!bar) throw new Error("fixture must carry a bar");
+		// A CSS declaration smuggled through the one bare number in a style attribute: it would
+		// close `flex-grow` and give the document an external fetch.
+		const poisoned = {
+			...model,
+			bars: [
+				{
+					...bar,
+					segments: [{ ...bar.segments[0], share: "1; background: url(https://x/y)" }],
+				},
+				...model.bars.slice(1),
+			],
+		} as unknown as typeof model;
+		expect(() => pipelineChartHtml(poisoned)).toThrow(/not a finite non-negative number/);
+	});
+
+	it("draws the shared scale as track widths against one constant", () => {
+		// Beta is the run's slowest bar (scaleFraction 1) → the full 680 px track; Alpha is
+		// a quarter of it. The constant is the same in every chart, which is the claim.
+		expect(html).toContain("width: 680.00px");
+		expect(html).toContain("width: 170.00px");
+	});
+
+	it("badges exactly the fastest bar", () => {
+		expect(html.match(/class="badge"/g)?.length).toBe(1);
+	});
+
+	it("renders the incomplete disclosure under the bars", () => {
+		expect(html).toContain("failed · install exceeded stop");
+	});
+
+	it("escapes interpolated text and renders the note's inline markdown", () => {
+		const spiky = pipelineChartHtml(
+			buildPipelineChartModel(suite, FIXTURE, "a **sum of medians** of `p50 <& friends>`"),
+		);
+		expect(spiky).toContain("<strong>sum of medians</strong>");
+		expect(spiky).toContain("<code>p50 &lt;&amp; friends&gt;</code>");
+		expect(spiky).not.toContain("p50 <&");
+	});
+});

--- a/packages/figures/src/chart/html.ts
+++ b/packages/figures/src/chart/html.ts
@@ -1,0 +1,209 @@
+/**
+ * The pipeline chart, as one self-contained HTML document per suite.
+ *
+ * The document is the whole input to the screenshot: inline styles, `data:`-URI fonts, no
+ * script, no external reference of any kind. Whatever Chrome draws is a function of this
+ * string alone, which is what keeps the HTML — the deterministic half of the pipeline —
+ * inspectable on its own: render it, open it, read it.
+ *
+ * The template is deliberately dumb. Every decision the picture makes — sort order, badge,
+ * colours, disclosure rows, the shared scale — arrives already made in the
+ * {@link PipelineChartModel}; this file only knows how wide things are and what they look
+ * like. The one piece of arithmetic here is the track: a bar's drawn length is
+ * `scaleFraction × TRACK_WIDTH` with TRACK_WIDTH constant across every chart, which is the
+ * whole mechanism behind "a second is the same length in all of them". Within a bar the
+ * browser distributes the track by `flex-grow: share`, which reproduces the page's
+ * gap-then-proportion layout without any of the width bookkeeping the satori renderer
+ * needed — flexbox with `gap` IS that algorithm.
+ */
+import { pageColors } from "../page-theme.ts";
+import { assertCovered, fontFaceCss } from "./fonts.ts";
+import type { PipelineChartModel } from "./model.ts";
+
+/** Canvas width in CSS px, padding included — every chart, fixed, so the three figures sit
+ *  on the page as one column. 2× this is the committed PNG's pixel width. */
+export const FIGURE_WIDTH = 960;
+/** Margin around the content, matching the crops the old pipeline was calibrated against. */
+const PADDING = 24;
+/** `grid-cols-[8rem_1fr] gap-x-4` — the provider label column and the gutter after it. */
+const LABEL_COLUMN = 128;
+const COLUMN_GAP = 16;
+/**
+ * The full-scale bar's length. Fixed rather than solved from the content: with the label
+ * column, the gutter and the padding spoken for, 88 px remain for the total that follows
+ * the longest bar — enough for any `formatSeconds` string the domain produces. A total the
+ * canvas cannot fit would overflow INTO the padding and still be captured, not clipped;
+ * ugly beats silently sliced, and the eyeball pass catches ugly.
+ */
+const TRACK_WIDTH = 680;
+/** `h-5` bars with a `gap-[2px]` between task segments and `gap-2.5` before the total. */
+const BAR_HEIGHT = 20;
+const SEGMENT_GAP = 2;
+const TOTAL_GAP = 10;
+/** `space-y-3` between bar rows. */
+const ROW_GAP = 12;
+/** `max-w-2xl` on the authored note. */
+const NOTE_WIDTH = 672;
+
+// Every stack ends on Geist before the generic: Geist Mono and Afacad lack `†` and `→`, and the
+// embedded Geist Sans subset has both — so the fallback glyph is a brand glyph, not a foreign
+// face. The generic keyword is the last resort the coverage check exists to keep unreachable.
+const MONO = `"Geist Mono", Geist, monospace`;
+const SANS = `Geist, sans-serif`;
+const HEADING = `Afacad, Geist, sans-serif`;
+
+/** `Bun.escapeHTML`: native, single-pass, and escapes the full set (`& < > " '`) — apostrophes
+ *  too, which the hand-rolled version it replaced left raw in attribute values. */
+const escapeHtml = Bun.escapeHTML;
+
+/**
+ * The note's inline markdown, rendered rather than stripped. The satori pipeline stripped
+ * `**` and `` ` `` because it could not change weight or face mid-paragraph; a browser can,
+ * so the authored emphasis survives. Escaping happens FIRST — the markdown delimiters are
+ * matched in already-escaped text, so an author writing literal `<` or `&` gets a character,
+ * never markup.
+ */
+function inlineMarkdown(text: string): string {
+	// Code spans FIRST, then bold only OUTSIDE them — the order real markdown implies. Bold
+	// applied to the whole string would pair `**` ACROSS code spans (two glob patterns in
+	// backticks become one mangled <strong> run, backticks swallowed), and the corrupted text
+	// would render into the published figure.
+	return escapeHtml(text)
+		.split(/(`[^`]+`)/)
+		.map((chunk) =>
+			chunk.startsWith("`") && chunk.endsWith("`") && chunk.length > 1
+				? `<code>${chunk.slice(1, -1)}</code>`
+				: chunk.replace(/\*\*([^*]+)\*\*/g, "<strong>$1</strong>"),
+		)
+		.join("");
+}
+
+/** Fixed-point CSS px. Two decimals is beyond what a 2× rasteriser can draw, and a stable
+ *  formatting keeps the HTML byte-deterministic across runs. */
+function px(value: number): string {
+	return `${value.toFixed(2)}px`;
+}
+
+/**
+ * A colour is only ever interpolated into a `style` attribute after this check. Every colour in
+ * a real model comes from the package's own ramp, but the model is a public type, and a string
+ * like `red;" onload="…` inside an attribute is markup, not paint — `escapeHtml` cannot help
+ * because valid CSS (`url(...)`) can smuggle a fetch without any HTML metacharacter. Hex is the
+ * one format the theme uses, so hex is the one format the template accepts.
+ */
+function hexColor(value: string): string {
+	if (!/^#(?:[0-9a-fA-F]{3,4}|[0-9a-fA-F]{6}|[0-9a-fA-F]{8})$/.test(value)) {
+		throw new Error(
+			`chart colour ${JSON.stringify(value)} is not a hex colour — refusing to interpolate it into a style attribute`,
+		);
+	}
+	return value;
+}
+
+/**
+ * The same check for the one bare number that reaches a `style` attribute. `flex-grow` takes the
+ * share unformatted — no unit, no rounding — so unlike the lengths that pass through {@link px}
+ * (where `toFixed` alone forces digits) nothing about the interpolation constrains it to a number.
+ * The type says `number`, but {@link PipelineChartModel} is exported and TypeScript is not a
+ * runtime, so a JS caller's `"1; background: url(…)"` would land in the declaration intact and
+ * hand the document an external fetch — the exact hole `hexColor` closes for paint.
+ */
+function cssNumber(value: number, label: string): string {
+	if (typeof value !== "number" || !Number.isFinite(value) || value < 0) {
+		throw new Error(
+			`chart ${label} ${JSON.stringify(value)} is not a finite non-negative number — refusing to interpolate it into a style attribute`,
+		);
+	}
+	return String(value);
+}
+
+const STYLE = `
+* { box-sizing: border-box; }
+body { margin: 0; background: ${pageColors.bg}; }
+.figure { width: ${FIGURE_WIDTH}px; padding: ${PADDING}px; background: ${pageColors.bg}; }
+header { display: flex; align-items: baseline; gap: ${COLUMN_GAP}px; margin: 0 0 6px; }
+h1 { margin: 0; font: 500 24px/32px ${HEADING}; color: ${pageColors.fg}; }
+.summary { margin: 0; font: 400 11px/16.5px ${MONO}; letter-spacing: 0.14em; text-transform: uppercase; color: ${pageColors.muted70}; }
+.note { margin: 0 0 20px; max-width: ${NOTE_WIDTH}px; font: 400 14px/22.75px ${SANS}; color: ${pageColors.muted}; }
+.note code { font: 400 13px ${MONO}; }
+.note .disk { font: 400 11px ${MONO}; color: ${pageColors.muted40}; }
+.legend { display: flex; align-items: center; gap: ${COLUMN_GAP}px; margin: 0 0 ${COLUMN_GAP}px; padding: 0; list-style: none; font: 400 11px/16.5px ${MONO}; color: ${pageColors.muted}; }
+.legend li { display: flex; align-items: center; gap: 6px; }
+.swatch { width: 10px; height: 10px; border-radius: 2px; }
+.legend-note { font: 400 10px/15px ${MONO}; letter-spacing: 0.14em; text-transform: uppercase; color: ${pageColors.muted50}; }
+.row { display: flex; align-items: center; gap: ${COLUMN_GAP}px; min-height: ${BAR_HEIGHT}px; }
+.row + .row { margin-top: ${ROW_GAP}px; }
+.provider { flex: 0 0 ${LABEL_COLUMN}px; font: 400 12px/16px ${MONO}; color: ${pageColors.fg90}; }
+.bar { display: flex; align-items: center; gap: ${TOTAL_GAP}px; }
+.track { display: flex; gap: ${SEGMENT_GAP}px; height: ${BAR_HEIGHT}px; }
+.segment { flex-shrink: 1; flex-basis: 0; }
+.segment:first-child { border-top-left-radius: 1px; border-bottom-left-radius: 1px; }
+.segment:last-child { border-top-right-radius: 4px; border-bottom-right-radius: 4px; }
+.value { display: flex; align-items: center; gap: 8px; }
+.total { font: 600 13px/17.33px ${MONO}; color: ${pageColors.fg}; white-space: nowrap; }
+.badge { font: 400 9px/13.5px ${MONO}; letter-spacing: 0.14em; text-transform: uppercase; color: ${pageColors.teal}; border: 1px solid ${pageColors.tealBorder}; border-radius: 4px; padding: 1px 4px; white-space: nowrap; }
+.incomplete { align-items: flex-start; }
+.incomplete .provider { color: ${pageColors.muted50}; }
+.gap { font: 400 11px/16.5px ${MONO}; color: ${pageColors.muted50}; }
+`;
+
+export function pipelineChartHtml(model: PipelineChartModel): string {
+	const legend = model.legend
+		.map(
+			(entry) =>
+				`<li><span class="swatch" style="background: ${hexColor(entry.color)};"></span>${escapeHtml(entry.label)}</li>`,
+		)
+		.join("");
+
+	const barRows = model.bars.map((bar) => {
+		const segments = bar.segments
+			.map(
+				(segment) =>
+					`<span class="segment" style="flex-grow: ${cssNumber(segment.share, "segment share")}; background: ${hexColor(segment.color)};" title="${escapeHtml(segment.task)}"></span>`,
+			)
+			.join("");
+		const badge = bar.fastest ? `<span class="badge">fastest</span>` : "";
+		return (
+			`<div class="row"><span class="provider">${escapeHtml(bar.label)}</span>` +
+			`<div class="bar"><div class="track" style="width: ${px(bar.scaleFraction * TRACK_WIDTH)};">${segments}</div>` +
+			`<span class="value"><span class="total">${escapeHtml(bar.total)}</span>${badge}</span></div></div>`
+		);
+	});
+
+	const incompleteRows = model.incomplete.map(
+		(row) =>
+			`<div class="row incomplete"><span class="provider">${escapeHtml(row.label)}</span>` +
+			`<span class="gap">${escapeHtml(row.outcome)} · ${escapeHtml(row.reason)}</span></div>`,
+	);
+
+	const disk =
+		model.diskNote === null ? "" : ` <span class="disk">${escapeHtml(model.diskNote)}</span>`;
+
+	const document = `<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<title>${escapeHtml(model.suiteName)}</title>
+<style>
+${fontFaceCss()}
+${STYLE}
+</style>
+</head>
+<body>
+<main class="figure">
+<header><h1>${escapeHtml(model.suiteName)}</h1><p class="summary">${escapeHtml(model.summary)}</p></header>
+<p class="note">${inlineMarkdown(model.note)}${disk}</p>
+<ul class="legend">${legend}<li class="legend-note">${escapeHtml(model.legendNote)}</li></ul>
+<section>
+${[...barRows, ...incompleteRows].join("\n")}
+</section>
+</main>
+</body>
+</html>
+`;
+	// The WHOLE document, base64 and all — the font payload is ASCII, so scanning it costs one
+	// cheap pass and buys coverage over the stylesheet and the licence notice too, not just the
+	// interpolated text. Last thing before the string escapes: nothing downstream adds glyphs.
+	assertCovered(document);
+	return document;
+}

--- a/packages/figures/src/chart/model.test.ts
+++ b/packages/figures/src/chart/model.test.ts
@@ -1,0 +1,94 @@
+import { describe, expect, it } from "bun:test";
+import { PHASE_RAMP } from "../phases.ts";
+import { FIXTURE } from "./__fixtures__/data.ts";
+import { buildPipelineChartModel } from "./model.ts";
+
+const suite = FIXTURE.suites[0];
+if (!suite) throw new Error("fixture must carry a chartable suite");
+
+const model = buildPipelineChartModel(suite, FIXTURE, "note text");
+
+describe("buildPipelineChartModel", () => {
+	it("sorts bars fastest-first and flags only the best total", () => {
+		expect(model.bars.map((bar) => bar.label)).toEqual(["Alpha", "Beta †"]);
+		expect(model.bars.map((bar) => bar.fastest)).toEqual([true, false]);
+	});
+
+	it("carries the off-spec dagger on bar and incomplete labels alike", () => {
+		// Beta is off-spec and charted; Gamma is on-spec and incomplete. The dagger follows
+		// the provider, not the row kind.
+		expect(model.bars[1]?.label).toBe("Beta †");
+		expect(model.incomplete).toEqual([
+			{ label: "Gamma", outcome: "failed", reason: "install exceeded stop" },
+		]);
+	});
+
+	it("scales every bar against the run's slowest charted total", () => {
+		// Beta (400 s) is the run's slowest bar, so it IS the scale; Alpha (100 s) is a
+		// quarter of it. This ratio — not a per-chart maximum — is what makes a second the
+		// same length in every figure.
+		expect(model.bars[1]?.scaleFraction).toBe(1);
+		expect(model.bars[0]?.scaleFraction).toBe(0.25);
+	});
+
+	it("splits a bar into per-task shares that sum to the bar", () => {
+		for (const bar of model.bars) {
+			const total = bar.segments.reduce((sum, segment) => sum + segment.share, 0);
+			expect(total).toBeCloseTo(1, 10);
+		}
+		expect(model.bars[0]?.segments.map((s) => s.share)).toEqual([0.4, 0.6]);
+	});
+
+	it("colours segments ordinally by position in THIS suite's phase sequence", () => {
+		// Position in the suite being drawn, not a fixed phase→colour map: later-in-this-suite
+		// is darker-in-this-suite, which is what makes the printed "color order = execution
+		// order" claim true for every suite regardless of how its order differs from others'.
+		expect(model.bars[0]?.segments.map((s) => s.color)).toEqual([PHASE_RAMP[0], PHASE_RAMP[1]]);
+	});
+
+	it("legends the suite's phases in the suite's own execution order", () => {
+		expect(model.legend).toEqual([
+			{ label: "git clone", color: PHASE_RAMP[0] },
+			{ label: "build", color: PHASE_RAMP[1] },
+		]);
+	});
+
+	it("keeps the eyebrow count honest when declared tasks were dropped", () => {
+		const withDropped = buildPipelineChartModel(
+			{ ...suite, droppedTasks: ["test core"] },
+			FIXTURE,
+			"n",
+		);
+		expect(withDropped.summary).toBe("2 of 3 tasks · git clone → build");
+	});
+
+	it("summarises the suite as task count plus phase walk", () => {
+		expect(model.summary).toBe("2 tasks · git clone → build");
+	});
+
+	it("passes the authored note through and appends the disk aside separately", () => {
+		expect(model.note).toBe("note text");
+		expect(model.diskNote).toBe("Needs 30 GB free disk.");
+	});
+
+	it("omits the disk aside when the suite requires none", () => {
+		const noDisk = buildPipelineChartModel({ ...suite, minDiskGb: null }, FIXTURE, "n");
+		expect(noDisk.diskNote).toBeNull();
+	});
+
+	it("draws a schema-valid zero duration at zero width, never as NaN", () => {
+		// 0/0 is NaN, and CSS reads a NaN flex/width as broken layout — the bar would silently
+		// vanish. The dataset admits p50 = 0, so the arithmetic has to.
+		const zeroBar = {
+			provider: "alpha",
+			totalS: 0,
+			segments: [{ id: "realworld_demo_task_clone", phase: "clone" as const, p50: 0, n: 3 }],
+		};
+		const zeroed = buildPipelineChartModel({ ...suite, bars: [zeroBar] }, FIXTURE, "n");
+		expect(zeroed.bars[0]?.segments[0]?.share).toBe(0);
+		// The shared scale still comes from the whole run's bars (the fixture's slowest is
+		// 400 s), so the zero bar is 0 of it — and a run whose bars are ALL zero yields 0,
+		// not NaN.
+		expect(zeroed.bars[0]?.scaleFraction).toBe(0);
+	});
+});

--- a/packages/figures/src/chart/model.ts
+++ b/packages/figures/src/chart/model.ts
@@ -1,0 +1,170 @@
+/**
+ * `better-auth` / `mastra` / `openclaw` — the view-model for one stacked pipeline chart.
+ *
+ * One builder over the model's own suite list rather than three near-copies: a suite added
+ * upstream becomes a figure automatically and cannot be the one somebody forgot.
+ *
+ * This is the layer the tests hold onto. Everything the picture CLAIMS is decided here, as
+ * plain data a unit test can assert on — the template below it only turns these fields into
+ * markup, and the browser only rasterises what the template says:
+ *
+ *  - **Bars share ONE time scale across all charts** (`pipelineScaleMaxS`): a bar's
+ *    `scaleFraction` is its total over the slowest charted total in the RUN, not in the
+ *    suite. Scaling each chart to its own maximum would make three unrelated pictures out
+ *    of one comparison.
+ *  - **Segment order is the suite's real execution order**, one segment per task, coloured
+ *    on the ordinal ramp by the phase's position IN THIS SUITE — later here is darker here,
+ *    so "color order = execution order" is true by construction (a fixed phase→colour map
+ *    could not promise that: suites disagree about order — openclaw checks before it tests).
+ *  - **Rows are sorted fastest-first and the fastest is flagged.**
+ *  - **Environments that did not complete the suite are listed under the bars** with their
+ *    outcome and reason. Dropping them would turn a chart that discloses its gaps into one
+ *    that appears to have none.
+ */
+import type { FigureProvider, PipelineSuite, RealworldFigureModel } from "../model.ts";
+import type { PhaseId } from "../phases.ts";
+import { PHASE_RAMP, phaseOf } from "../phases.ts";
+import { formatSeconds } from "./format.ts";
+
+/** One task's slice of a bar. `share` is the task's fraction OF ITS OWN BAR (the p50 over
+ *  the bar's total), so a template can hand it straight to `flex-grow` and let the layout
+ *  engine distribute the track. */
+export interface ChartSegment {
+	/** The task's registry id, carried for the segment's `title` tooltip. */
+	readonly task: string;
+	readonly share: number;
+	readonly color: string;
+}
+
+/** One environment's whole pipeline, as one stacked bar. */
+export interface ChartBar {
+	/** Display label. Off-spec providers carry the report's dagger: `name †`. */
+	readonly label: string;
+	/** Formatted total, e.g. `61.9 s` — the sum of the segments' medians. */
+	readonly total: string;
+	/** This bar's length as a fraction of the SHARED scale (the run's slowest charted
+	 *  total), so a second is the same length in every chart drawn from the same run. */
+	readonly scaleFraction: number;
+	/** True on every bar whose total equals the suite's best — the page's badge rule. */
+	readonly fastest: boolean;
+	readonly segments: readonly ChartSegment[];
+}
+
+/** An environment disclosed as not having completed the suite: outcome and reason, no bar. */
+export interface ChartIncompleteRow {
+	readonly label: string;
+	readonly outcome: string;
+	readonly reason: string;
+}
+
+export interface PipelineChartModel {
+	/** The suite's registry id, e.g. `realworld-better-auth`. Names the output file. */
+	readonly suiteId: string;
+	/** Display name from the tasks' catalog labels, e.g. `Better-Auth`. */
+	readonly suiteName: string;
+	/** The eyebrow under the title: `10 tasks · git clone → cold install → …`. */
+	readonly summary: string;
+	/** The authored paragraph. May carry inline `**bold**` and `` `code` `` markdown, which
+	 *  the template renders. */
+	readonly note: string;
+	/** The disk-requirement aside appended to the note, or null when the suite has none. */
+	readonly diskNote: string | null;
+	/** One swatch per phase PRESENT in this suite, in execution order. */
+	readonly legend: readonly { readonly label: string; readonly color: string }[];
+	readonly legendNote: string;
+	/** Sorted fastest-first. */
+	readonly bars: readonly ChartBar[];
+	readonly incomplete: readonly ChartIncompleteRow[];
+}
+
+/**
+ * The provider a chart row names. The model builder maps rows and providers from the same
+ * validated set, so this cannot miss on its output — it throws rather than asserting because
+ * the alternative under `noUncheckedIndexedAccess` is a `!` that would read `undefined.name`
+ * and crash with no clue which row was at fault.
+ */
+function requireProvider(
+	byId: ReadonlyMap<string, FigureProvider>,
+	providerId: string,
+): FigureProvider {
+	const provider = byId.get(providerId);
+	if (!provider) {
+		throw new Error(`pipeline chart names provider "${providerId}", which the run does not list`);
+	}
+	return provider;
+}
+
+/** The off-spec badge on the provider name is a bordered pill on the page; the report and
+ *  these charts draw it as the plain dagger. The disclosure survives either way, which is
+ *  the part that matters. */
+function providerLabel(provider: FigureProvider): string {
+	return provider.specMatched ? provider.name : `${provider.name} †`;
+}
+
+/** Shared x-scale across the pipeline charts: the slowest charted total in the run — and 0,
+ *  not `Math.max()`'s -Infinity, for a model with nothing charted: a caller sizing an axis or
+ *  printing the scale must never see a sentinel that renders as "-Infinity". */
+export function pipelineScaleMaxSOf(model: RealworldFigureModel): number {
+	const totals = model.suites.flatMap((s) => s.bars.map((b) => b.totalS));
+	return totals.length === 0 ? 0 : Math.max(...totals);
+}
+
+export function buildPipelineChartModel(
+	suite: PipelineSuite,
+	model: RealworldFigureModel,
+	suiteNote: string,
+): PipelineChartModel {
+	const providerById = new Map(model.providers.map((p) => [p.id, p]));
+	const pipelineScaleMaxS = pipelineScaleMaxSOf(model);
+	const bars = [...suite.bars].sort((a, b) => a.totalS - b.totalS);
+	const bestTotal = bars[0]?.totalS ?? 0;
+	// THIS suite's phases, in THIS suite's execution order (first occurrence over its own
+	// tasks) — never a run-wide order, which another suite's sorting could have set and which
+	// would print an execution order this suite does not have.
+	const presentPhases: PhaseId[] = [];
+	for (const task of suite.tasks) {
+		if (!presentPhases.includes(task.phase)) presentPhases.push(task.phase);
+	}
+	// Ordinal colour: position in this suite's own phase sequence. PHASE_RAMP carries one
+	// shade per vocabulary entry, so the index cannot run off the end.
+	const colorOf = (phase: PhaseId): string => PHASE_RAMP[presentPhases.indexOf(phase)] as string;
+	// "4 of 5 tasks" when the suite declares tasks nobody completed — the drop itself is
+	// disclosed in the caption; the eyebrow keeps the count honest at a glance.
+	const declared = suite.tasks.length + suite.droppedTasks.length;
+	const taskCount =
+		suite.droppedTasks.length === 0
+			? `${suite.tasks.length} tasks`
+			: `${suite.tasks.length} of ${declared} tasks`;
+
+	return {
+		suiteId: suite.id,
+		suiteName: suite.name,
+		summary: `${taskCount} · ${presentPhases.map((p) => phaseOf(p).label).join(" → ")}`,
+		note: suiteNote,
+		diskNote: suite.minDiskGb === null ? null : `Needs ${suite.minDiskGb} GB free disk.`,
+		legend: presentPhases.map((phase) => ({
+			label: phaseOf(phase).label,
+			color: colorOf(phase),
+		})),
+		legendNote: "color order = execution order",
+		// The zero guards below are about arithmetic, not plausibility: a schema-valid 0 makes
+		// 0/0 NaN — which CSS reads as a broken flex/width, silently collapsing the bar. A
+		// zero-duration bar or segment draws at zero width instead.
+		bars: bars.map((bar) => ({
+			label: providerLabel(requireProvider(providerById, bar.provider)),
+			total: formatSeconds(bar.totalS),
+			scaleFraction: pipelineScaleMaxS > 0 ? bar.totalS / pipelineScaleMaxS : 0,
+			fastest: bar.totalS === bestTotal,
+			segments: bar.segments.map((segment) => ({
+				task: segment.id,
+				share: bar.totalS > 0 ? segment.p50 / bar.totalS : 0,
+				color: colorOf(segment.phase),
+			})),
+		})),
+		incomplete: suite.incomplete.map((row) => ({
+			label: providerLabel(requireProvider(providerById, row.provider)),
+			outcome: row.outcome,
+			reason: row.reason,
+		})),
+	};
+}

--- a/packages/figures/src/index.ts
+++ b/packages/figures/src/index.ts
@@ -1,0 +1,49 @@
+/**
+ * Public surface of the figure package: Run document → realworld figure model → one
+ * self-contained HTML document per chart.
+ *
+ * The input side is typed by `@sandbox-benchmarks/schema` — the workspace's one Run contract
+ * and registry shapes — so nothing here re-describes a contract the workspace already owns.
+ * The registries still arrive as ARGUMENTS (there is no module-level dataset), which is what
+ * lets every guard run against a synthetic run instead of whatever the committed dataset
+ * contains.
+ *
+ * Layering:
+ *
+ *   phases.ts       the pipeline phase vocabulary — id, label and ramp colour defined once.
+ *   model.ts        Run + registries → RealworldFigureModel: exactly the three fields the
+ *                   charts consume (suites, providers, phaseOrder). Every other derivation
+ *                   over a Run belongs to `packages/results`.
+ *   chart/          the view-model (every decision the picture makes, as plain data a unit
+ *                   test can assert on) and the HTML template that marks it up. Pure string
+ *                   building; fonts come from pinned npm packages, inlined as data: URIs.
+ *   screenshot.ts   the ONLY impure module: hands a document to headless Chrome via
+ *                   `Bun.WebView` and returns PNG bytes. Behind its own entry point,
+ *                   `@sandbox-benchmarks/figures/screenshot`, so importing anything above
+ *                   never spawns a browser.
+ *
+ * Everything on `.` is pure and deterministic: same model, same bytes. The rasterised PNG is
+ * NOT — Chrome's output depends on its version and platform — which is exactly why the split
+ * sits where it does: the deterministic half is what gates and tests hold onto, the browser
+ * half is a leaf with one job.
+ */
+
+export { FIGURE_WIDTH, pipelineChartHtml } from "./chart/html.ts";
+export {
+	buildPipelineChartModel,
+	type ChartBar,
+	type ChartIncompleteRow,
+	type ChartSegment,
+	type PipelineChartModel,
+	pipelineScaleMaxSOf,
+} from "./chart/model.ts";
+export {
+	type BarSegment,
+	buildRealworldFigureModel,
+	type FigureModelInput,
+	type FigureProvider,
+	type PipelineBar,
+	type PipelineSuite,
+	type RealworldFigureModel,
+} from "./model.ts";
+export { PHASES, type PhaseId, phaseOf, phaseOfTask } from "./phases.ts";

--- a/packages/figures/src/model.test.ts
+++ b/packages/figures/src/model.test.ts
@@ -1,0 +1,151 @@
+import { describe, expect, it } from "bun:test";
+import type { MetricResult, ProviderRun, Run } from "@sandbox-benchmarks/schema";
+import { aggregate } from "@sandbox-benchmarks/schema";
+import { buildRealworldFigureModel } from "./model.ts";
+
+/** Synthetic registries — the model takes them as arguments precisely so these tests never
+ *  depend on what the committed dataset happens to contain. */
+const METRICS = [
+	{ id: "realworld_demo_task_git_clone", label: "Demo: git clone" },
+	{ id: "realworld_demo_task_cold_install", label: "Demo: cold install" },
+];
+const PROVIDERS = [
+	{ id: "alpha", displayName: "Alpha" },
+	{ id: "beta", displayName: "Beta" },
+];
+const SUITES = {
+	"realworld-demo": {
+		dimensions: ["realworld" as const],
+		minDiskGb: 30,
+		metrics: ["realworld_demo_task_git_clone", "realworld_demo_task_cold_install"],
+	},
+	"cpu-demo": { dimensions: ["cpu" as const], metrics: ["cpu_bench"] },
+};
+
+function metric(metricId: string, samples: number[]): MetricResult {
+	return { metricId, samples, aggregates: aggregate(samples) };
+}
+
+function provider(
+	providerId: string,
+	metrics: MetricResult[],
+	over: Partial<ProviderRun> = {},
+): ProviderRun {
+	return {
+		providerId,
+		validationStatus: "validated",
+		observedSpecs: {},
+		metrics,
+		suitesCovered: ["realworld-demo"],
+		gaps: [],
+		uncatalogued: [],
+		...over,
+	};
+}
+
+function run(providers: ProviderRun[]): Run {
+	return {
+		schemaVersion: "2",
+		runId: "run-1",
+		sha: "abc123",
+		generatedAt: "2026-06-20T00:00:00.000Z",
+		targetSpec: { vcpus: 2, memoryGb: 8, diskGb: 20 },
+		providers,
+	};
+}
+
+const CLONE = "realworld_demo_task_git_clone";
+const INSTALL = "realworld_demo_task_cold_install";
+
+function build(providers: ProviderRun[]) {
+	return buildRealworldFigureModel({
+		run: run(providers),
+		metrics: METRICS,
+		providers: PROVIDERS,
+		suites: SUITES,
+	});
+}
+
+describe("buildRealworldFigureModel", () => {
+	it("charts a suite two environments completed, named from its task labels", () => {
+		const model = build([
+			provider("alpha", [metric(CLONE, [1, 2]), metric(INSTALL, [30, 32])]),
+			provider("beta", [metric(CLONE, [3, 4]), metric(INSTALL, [50, 52])]),
+		]);
+		expect(model.suites.map((s) => s.id)).toEqual(["realworld-demo"]);
+		expect(model.suites[0]?.name).toBe("Demo");
+		expect(model.suites[0]?.minDiskGb).toBe(30);
+		expect(model.suites[0]?.bars.map((b) => b.provider).sort()).toEqual(["alpha", "beta"]);
+	});
+
+	it("drops a suite with fewer than two completing environments — one bar is not a comparison", () => {
+		expect(build([provider("alpha", [metric(CLONE, [1, 2])])]).suites).toEqual([]);
+	});
+
+	it("does not chart an environment that ran only part of the pipeline, and discloses it", () => {
+		// Summing the tasks a provider DID run would show a fast bar for an environment that
+		// skipped the work. The partial provider lands under the bars with its gap's own words.
+		const model = build([
+			provider("alpha", [metric(CLONE, [1, 2]), metric(INSTALL, [30, 32])]),
+			provider("beta", [metric(CLONE, [3, 4]), metric(INSTALL, [50, 52])]),
+			provider("gamma", [metric(CLONE, [1, 1])], {
+				gaps: [{ scope: "suite", id: "realworld-demo", outcome: "failed", reason: "install died" }],
+			}),
+		]);
+		expect(model.suites[0]?.bars.length).toBe(2);
+		expect(model.suites[0]?.incomplete).toEqual([
+			{ provider: "gamma", outcome: "failed", reason: "install died" },
+		]);
+	});
+
+	it("covers validated providers only, and carries the run's own spec verdict", () => {
+		// A provider that reported nothing is `pending` — charting it would draw a data-less
+		// row; disclosing the absence is the published board's job, not a figure's.
+		const model = build([
+			provider("alpha", [metric(CLONE, [1, 2]), metric(INSTALL, [30, 32])]),
+			provider("beta", [metric(CLONE, [3, 4]), metric(INSTALL, [50, 52])], {
+				specMatched: false,
+			}),
+			provider("ghost", [], { validationStatus: "pending" }),
+		]);
+		expect(model.providers).toEqual([
+			{ id: "alpha", name: "Alpha", specMatched: true },
+			{ id: "beta", name: "Beta", specMatched: false },
+		]);
+	});
+
+	it("discloses a declared task that NO environment completed instead of silently dropping it", () => {
+		// The failure this guards happened in committed data: mastra's test_core failed in
+		// every environment, silently left the exercised set, and the published chart showed
+		// a universally-failed suite as a clean comparison. The suite still charts (the
+		// remaining columns are comparable across providers) but the drop must surface.
+		const SUITES_WITH_TEST = {
+			"realworld-demo": {
+				dimensions: ["realworld" as const],
+				minDiskGb: 30,
+				metrics: [CLONE, INSTALL, "realworld_demo_task_test_core"],
+			},
+		};
+		const model = buildRealworldFigureModel({
+			run: run([
+				provider("alpha", [metric(CLONE, [1, 2]), metric(INSTALL, [30, 32])]),
+				provider("beta", [metric(CLONE, [3, 4]), metric(INSTALL, [50, 52])]),
+			]),
+			metrics: [...METRICS, { id: "realworld_demo_task_test_core", label: "Demo: test core" }],
+			providers: PROVIDERS,
+			suites: SUITES_WITH_TEST,
+		});
+		expect(model.suites[0]?.tasks.length).toBe(2);
+		expect(model.suites[0]?.droppedTasks).toEqual(["test core"]);
+	});
+
+	it("totals a bar as the sum of its task medians, in canonical task order", () => {
+		const model = build([
+			provider("alpha", [metric(CLONE, [2, 2]), metric(INSTALL, [40, 40])]),
+			provider("beta", [metric(CLONE, [4, 4]), metric(INSTALL, [60, 60])]),
+		]);
+		const alpha = model.suites[0]?.bars.find((b) => b.provider === "alpha");
+		expect(alpha?.segments.map((s) => s.id)).toEqual([CLONE, INSTALL]);
+		expect(alpha?.totalS).toBe(42);
+	});
+});

--- a/packages/figures/src/model.ts
+++ b/packages/figures/src/model.ts
@@ -1,0 +1,197 @@
+/**
+ * Run document → the realworld figure model: exactly what the pipeline charts consume, and
+ * nothing else.
+ *
+ * The input is typed by `@sandbox-benchmarks/schema` — the workspace's one Run contract and
+ * its metric/suite registries — so there is no parallel hand-written copy of either to drift
+ * (the type-only imports cost nothing at runtime). The registries still arrive as ARGUMENTS
+ * rather than being imported as values: that is what lets every test below run against a
+ * synthetic run and a synthetic catalog instead of whatever the committed dataset contains.
+ *
+ * This replaced a vendored copy of an upstream site's whole data layer (a hand-written
+ * RunDoc shadow, a 449-line parse boundary for a document that never crosses a process
+ * boundary here, and derivations — metric tables, coverage gaps, environment flags,
+ * economics rows — that nothing in this repo renders). The model below is the ~20% that the
+ * charts actually read; `packages/results` owns every other derivation over a Run.
+ */
+import type { MetricDef, ProviderRun, Run, Suite } from "@sandbox-benchmarks/schema";
+import type { PhaseId } from "./phases.ts";
+import { phaseOfTask } from "./phases.ts";
+
+/** One task's slice of a bar: the run's median for that task, and how many trials back it. */
+export interface BarSegment {
+	readonly id: string;
+	readonly phase: PhaseId;
+	readonly p50: number;
+	readonly n: number;
+}
+
+/** One environment's whole pipeline, as one stacked bar. `totalS` is the sum of the
+ *  segments' medians — the cost of the pipeline, not the timing of any single run. */
+export interface PipelineBar {
+	readonly provider: string;
+	readonly totalS: number;
+	readonly segments: readonly BarSegment[];
+}
+
+export interface PipelineSuite {
+	/** The suite's registry id, e.g. `realworld-better-auth`. Names the output file. */
+	readonly id: string;
+	/** Display name from the tasks' catalog labels, e.g. `Better-Auth`. */
+	readonly name: string;
+	readonly minDiskGb: number | null;
+	/** The exercised tasks, in the suite's canonical (execution) order. */
+	readonly tasks: readonly { readonly id: string; readonly phase: PhaseId }[];
+	/**
+	 * DECLARED tasks that NO environment completed — dropped from every bar, as short labels.
+	 * A task that fails everywhere would otherwise vanish silently: the exercised set shrinks,
+	 * every bar looks complete, and a universally-failed suite publishes as a clean comparison
+	 * (this happened — mastra's `test_core`). The chart must disclose what it is not showing.
+	 */
+	readonly droppedTasks: readonly string[];
+	readonly bars: readonly PipelineBar[];
+	/** Environments that did not complete the suite: outcome and reason, no bar. */
+	readonly incomplete: readonly {
+		readonly provider: string;
+		readonly outcome: string;
+		readonly reason: string;
+	}[];
+}
+
+/** What a chart row needs to name an environment. */
+export interface FigureProvider {
+	readonly id: string;
+	readonly name: string;
+	/** False when the run disclosed an off-target allocation — the chart daggers the label. */
+	readonly specMatched: boolean;
+}
+
+export interface RealworldFigureModel {
+	/** Chartable suites only (≥2 completing environments), widest comparison first. */
+	readonly suites: readonly PipelineSuite[];
+	readonly providers: readonly FigureProvider[];
+}
+
+/** The registry slice the derivation needs, typed by the schema that owns it — `Pick`ed to
+ *  exactly the fields read, so the real registries satisfy it and a synthetic test registry
+ *  needs no cast. */
+export interface FigureModelInput {
+	readonly run: Run;
+	/** The metric catalog — task labels come from here. */
+	readonly metrics: readonly Pick<MetricDef, "id" | "label">[];
+	/** Provider display names. String-keyed on purpose: the run side carries provider ids as
+	 *  strings, and the registry's narrower `ProviderId` union assigns into this cleanly. */
+	readonly providers: readonly { readonly id: string; readonly displayName: string }[];
+	/** The suite registry: which dimension a suite measures, canonical task order, disk floors. */
+	readonly suites: Readonly<Record<string, Pick<Suite, "dimensions" | "metrics" | "minDiskGb">>>;
+}
+
+const round = (v: number, dp: number) => Number(v.toFixed(dp));
+
+export function buildRealworldFigureModel(input: FigureModelInput): RealworldFigureModel {
+	const { run, metrics, providers, suites } = input;
+	const labelOf = new Map(metrics.map((m) => [m.id, m.label]));
+	const displayName = new Map(providers.map((p) => [p.id, p.displayName]));
+
+	// The charts cover the run's VALIDATED providers — the dataset's own word for "a
+	// committed run carries real metrics for it". A provider the harness attempted that
+	// reported nothing is `pending`; charting it would add a data-less row. (The published
+	// board discloses those absences — that is `packages/results`' jurisdiction, not a
+	// figure's.)
+	const rendered = run.providers.filter((p) => p.validationStatus === "validated");
+	const metricsByProvider = new Map(
+		rendered.map((p) => [p.providerId, new Map(p.metrics.map((m) => [m.metricId, m]))]),
+	);
+	const aggregatesOf = (p: ProviderRun, id: string) =>
+		metricsByProvider.get(p.providerId)?.get(id)?.aggregates;
+
+	const requireLabel = (id: string): string => {
+		const label = labelOf.get(id);
+		if (!label) {
+			throw new Error(`metric "${id}" is in the run but not in the metric catalog`);
+		}
+		return label;
+	};
+
+	const chartable = Object.entries(suites)
+		// By declared dimension, not by id prefix: the registry already says what a suite
+		// measures, and a naming-convention filter would silently skip a renamed suite.
+		.filter(([, suite]) => suite.dimensions.includes("realworld"))
+		.map(([name, suite]) => {
+			// The run's own exercised task set for this suite, in the suite's canonical
+			// (execution) order — a task nobody emitted is not a column.
+			const exercised = suite.metrics.filter((id) =>
+				rendered.some((p) => aggregatesOf(p, id) !== undefined),
+			);
+			const firstTask = exercised[0];
+			if (firstTask === undefined) return null;
+			// Declared tasks nobody completed, as the short labels the disclosure prints.
+			// ("Better-Auth: test core" → "test core" — the chart names the repo once.)
+			const droppedTasks = suite.metrics
+				.filter((id) => !exercised.includes(id))
+				.map((id) => requireLabel(id).replace(/^[^:]+:\s*/, ""));
+
+			const bars: PipelineBar[] = rendered.flatMap((p) => {
+				// A bar requires EVERY exercised task: a partial pipeline would chart an
+				// understated total as if it were comparable.
+				const segments: BarSegment[] = [];
+				for (const id of exercised) {
+					const a = aggregatesOf(p, id);
+					if (a === undefined) return [];
+					segments.push({ id, phase: phaseOfTask(id), p50: a.p50, n: a.n });
+				}
+				return [
+					{
+						provider: p.providerId,
+						totalS: round(
+							segments.reduce((sum, s) => sum + s.p50, 0),
+							3,
+						),
+						segments,
+					},
+				];
+			});
+
+			// Chart a suite only when there is a comparison to draw.
+			if (bars.length < 2) return null;
+
+			const charted = new Set(bars.map((b) => b.provider));
+			const incomplete = rendered
+				.filter((p) => !charted.has(p.providerId))
+				.map((p) => {
+					const gap = p.gaps.find((g) => g.scope === "suite" && g.id === name);
+					return {
+						provider: p.providerId,
+						outcome: gap?.outcome ?? "missing",
+						// Wording matches packages/results' coverageGapsOf fallback for the same hole, so
+						// the figure's disclosure row and the board's coverage table cannot describe one
+						// fact in two voices.
+						reason:
+							gap?.reason ?? "No result and no marker: the suite never reported for this provider.",
+					};
+				});
+
+			return {
+				id: name,
+				// Suite display name from its tasks' catalog labels ("Better-Auth: …").
+				name: requireLabel(firstTask).split(":")[0] ?? name,
+				minDiskGb: suite.minDiskGb ?? null,
+				tasks: exercised.map((id) => ({ id, phase: phaseOfTask(id) })),
+				droppedTasks,
+				bars,
+				incomplete,
+			};
+		})
+		.filter((s): s is NonNullable<typeof s> => s !== null)
+		// Widest comparison first (most bars), suite id the deterministic tie-break.
+		.sort((a, b) => b.bars.length - a.bars.length || a.id.localeCompare(b.id, "en"));
+
+	return {
+		suites: chartable,
+		providers: rendered.map((p) => ({
+			id: p.providerId,
+			name: displayName.get(p.providerId) ?? p.providerId,
+			specMatched: p.specMatched !== false,
+		})),
+	};
+}

--- a/packages/figures/src/page-theme.ts
+++ b/packages/figures/src/page-theme.ts
@@ -1,0 +1,43 @@
+/**
+ * The page's own light-theme design tokens, resolved to opaque hex.
+ *
+ * These figures reproduce the charts of `/sandbox-benchmarks` as the browser draws them, so
+ * the colours are not a palette anyone chose here — they are what the site's CSS variables
+ * COMPUTE TO on that page, read out of `getComputedStyle` on the real rendered document and
+ * composited onto the surface each token sits on.
+ *
+ * WHY RESOLVED AND OPAQUE, rather than the authored expressions. The page writes
+ * `border-border/50`, `text-muted-foreground/70`, `bg-brand-teal/[0.08]` — alpha over a
+ * backdrop. An alpha token is only correct against the backdrop it was authored over, and
+ * the chart template sets no site chrome behind its boxes; compositing once, here, is also
+ * the only form in which these are checkable, because a hex can be compared against a pixel
+ * of a crop and an `oklab(... / 0.7)` cannot.
+ *
+ * The consequence is that a token here is only correct ON ITS OWN BACKDROP. Every one of
+ * these sits on white, which is why there is no dark variant: the published figures are cut
+ * from the light theme, and a dark chart would have nothing to be compared against.
+ *
+ * If the site's palette changes, these go stale silently — the figures would keep rendering,
+ * in last year's colours. The upstream repo's figure-diff pipeline (which crops the real
+ * rendered page) is what notices; it lives there because it needs the site.
+ */
+
+/** Text, surface and line colours, named for the page role they play. */
+export const pageColors = {
+	/** The figure surface. `--background` in the light theme. */
+	bg: "#ffffff",
+	/** `text-foreground`. */
+	fg: "#0a0a0a",
+	/** `text-foreground/90` — provider labels on the charts. */
+	fg90: "#222222",
+	/** `text-muted-foreground`. */
+	muted: "#737373",
+	/** `text-muted-foreground/70`, `/50`, `/40` — the tints the charts use. */
+	muted70: "#9d9d9d",
+	muted50: "#b9b9b9",
+	muted40: "#c7c7c7",
+	/** `text-brand-teal` — the "fastest" badge. */
+	teal: "#0990a6",
+	/** `border-brand-teal/35` — the "fastest" badge outline. */
+	tealBorder: "#a9d8e0",
+} as const;

--- a/packages/figures/src/phases.test.ts
+++ b/packages/figures/src/phases.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from "bun:test";
+import { SUITES } from "@sandbox-benchmarks/schema";
+import { PHASE_RAMP, PHASES, phaseOf, phaseOfTask } from "./phases.ts";
+
+describe("PHASES", () => {
+	it("gives every phase its own label, and the ramp a distinct shade per vocabulary slot", () => {
+		// The ramp is indexed by a phase's position in the suite being drawn, so it must carry
+		// at least one shade per vocabulary entry (the index can never run off the end) and no
+		// two shades may collide (two phases sharing a colour would draw the legend's
+		// "color order = execution order" claim false).
+		expect(PHASE_RAMP.length).toBeGreaterThanOrEqual(PHASES.length);
+		expect(new Set(PHASE_RAMP).size).toBe(PHASE_RAMP.length);
+		expect(new Set(PHASES.map((p) => p.label)).size).toBe(PHASES.length);
+	});
+
+	it("throws on an id outside the vocabulary", () => {
+		expect(() => phaseOf("warp" as never)).toThrow(/"warp"/);
+	});
+});
+
+describe("phaseOfTask", () => {
+	it("maps the known task-key conventions", () => {
+		expect(phaseOfTask("realworld_demo_task_git_clone")).toBe("clone");
+		expect(phaseOfTask("realworld_demo_task_cold_install")).toBe("install");
+		expect(phaseOfTask("realworld_demo_task_lint_oxlint")).toBe("lint");
+		expect(phaseOfTask("realworld_demo_task_typecheck")).toBe("typecheck");
+		expect(phaseOfTask("realworld_demo_task_build_core")).toBe("build");
+		expect(phaseOfTask("realworld_demo_task_test_unit_fast")).toBe("test");
+		expect(phaseOfTask("realworld_demo_task_shrinkwrap_check")).toBe("check");
+	});
+
+	it("classifies every realworld task id the real suite registry declares", () => {
+		// The classifier is pinned against the REAL ids: a new upstream task key either
+		// classifies or throws — it can never silently publish a miscoloured segment.
+		const realworldTasks = Object.entries(SUITES)
+			.filter(([name]) => name.startsWith("realworld-"))
+			.flatMap(([, suite]) => suite.metrics);
+		expect(realworldTasks.length).toBeGreaterThan(0);
+		for (const id of realworldTasks) {
+			expect(() => phaseOfTask(id)).not.toThrow();
+		}
+	});
+
+	it("throws on a task key outside the vocabulary, naming it", () => {
+		// The silent `check` fallthrough this replaced turned every unknown key into a
+		// published chart segment in the wrong colour. Unknown must mean loud.
+		expect(() => phaseOfTask("realworld_demo_task_docs_publish")).toThrow(/docs_publish/);
+	});
+});

--- a/packages/figures/src/phases.ts
+++ b/packages/figures/src/phases.ts
@@ -1,0 +1,86 @@
+/**
+ * The pipeline phase vocabulary — every phase defined ONCE, with its id and printed label —
+ * and the ordinal colour ramp the charts index into it.
+ *
+ * The colour is deliberately NOT a property of the phase: a suite's REAL execution order is
+ * its own (openclaw runs its `check` before its `test`s; better-auth has no `check` at all),
+ * so a fixed phase→colour map cannot keep "color order = execution order" true — a chart
+ * whose late phase wore an early phase's shade would draw that claim false. Instead the ramp
+ * is indexed by a phase's position IN THE SUITE BEING DRAWN: later-in-this-suite is always
+ * darker, so the legend's claim holds by construction, per chart, forever. The cost is that
+ * one phase may wear different shades in different charts — accepted, because every chart
+ * carries its own legend and no surface claims cross-chart colour identity (the shared TIME
+ * scale is the cross-chart claim, and it is unaffected).
+ *
+ * The ramp is one shade per vocabulary entry (the first five are the upstream site's
+ * `--bench-ramp-N` readings; the last two extend the same teal-to-deep-sea progression), so
+ * it can never run out: a suite cannot exercise more phases than the vocabulary names.
+ */
+import { match } from "arktype";
+
+export const PHASES = [
+	{ id: "clone", label: "git clone" },
+	{ id: "install", label: "cold install" },
+	{ id: "lint", label: "lint" },
+	{ id: "typecheck", label: "typecheck" },
+	{ id: "build", label: "build" },
+	{ id: "test", label: "test" },
+	{ id: "check", label: "check" },
+] as const;
+
+export type PhaseId = (typeof PHASES)[number]["id"];
+
+/** Ordinal shades, indexed by a phase's position in the suite being drawn — see above. */
+export const PHASE_RAMP = [
+	"#34c9bc",
+	"#16a8ac",
+	"#0b8794",
+	"#07687b",
+	"#054a5f",
+	"#033344",
+	"#02202e",
+] as const;
+
+const byId = new Map(PHASES.map((phase) => [phase.id, phase]));
+
+/** The vocabulary entry for a phase id — total, because `PhaseId` is the closed set above. */
+export function phaseOf(id: PhaseId): (typeof PHASES)[number] {
+	// The map lookup cannot miss on a well-typed id; the throw guards the untyped edges
+	// (a fixture cast, a future string-typed caller) with a named error instead of undefined.
+	const phase = byId.get(id);
+	if (!phase) throw new Error(`unknown pipeline phase "${id}"`);
+	return phase;
+}
+
+/**
+ * The task-key → phase classification, first-matching-case wins (arktype `match` respects
+ * case order). This is the one real INPUT boundary in the phase machinery: `parseRun` proves
+ * a metric id is a string, not that it belongs to the phase vocabulary — so an id minted by
+ * a newer suite registry crosses into the closed `PhaseId` set exactly here, and a key the
+ * table has never met must FAIL, loudly, naming itself. `default: "assert"` does that
+ * (a silent fallthrough once bucketed every unknown key into `check`, publishing a
+ * miscoloured segment instead of an error).
+ */
+const phaseOfKey = match.in<string>().match({
+	"'git_clone'": () => "clone" as const,
+	"'cold_install'": () => "install" as const,
+	"'typecheck'": () => "typecheck" as const,
+	"/^lint/": () => "lint" as const,
+	"/^build/": () => "build" as const,
+	"/^test/": () => "test" as const,
+	// The real `check` family: `shrinkwrap_check` today. Suffix-matched, not defaulted —
+	// `docs_build_check` would be a deliberate naming, `docs_publish` an error.
+	"/_check$/": () => "check" as const,
+	default: "assert",
+});
+
+/**
+ * Which phase a realworld task metric belongs to, from the id convention the schema's suite
+ * registry uses (`realworld_<repo>_task_<key>`). The catalog does not carry a phase field, so
+ * the derivation lives here, next to the vocabulary it maps into — and a test pins it against
+ * the real `SUITES` ids. If the prefix strip misses, the whole metric id flows into the
+ * classifier and the throw names it verbatim.
+ */
+export function phaseOfTask(metricId: string): PhaseId {
+	return phaseOfKey(metricId.replace(/^realworld_[a-z0-9_]+?_task_/, ""));
+}

--- a/packages/figures/tsconfig.json
+++ b/packages/figures/tsconfig.json
@@ -1,0 +1,4 @@
+{
+  "extends": "@repo/tsconfig/library.json",
+  "include": ["src"]
+}

--- a/tooling/repo-checks/src/package-meta.test.ts
+++ b/tooling/repo-checks/src/package-meta.test.ts
@@ -1,7 +1,7 @@
 // Invariant: every workspace member has the uniform package.json shape.
 
 import { describe, expect, it } from "bun:test";
-import { readFileSync } from "node:fs";
+import { existsSync, readFileSync } from "node:fs";
 import { join } from "node:path";
 import { Glob } from "bun";
 import type { PackageJson } from "./lib/workspace.ts";
@@ -27,6 +27,21 @@ function isInternal(depName: string): boolean {
 
 function allDeps(pkg: PackageJson): Record<string, string> {
 	return { ...(pkg.dependencies ?? {}), ...(pkg.devDependencies ?? {}) };
+}
+
+/**
+ * Every relative file target reachable in an `exports` map, at any nesting depth.
+ *
+ * Recursive because the field is: a subpath may hold a string, or a conditions object
+ * (`{ import, default }`), or an array of fallbacks. Walking it rather than assuming today's flat
+ * string form means the check keeps working the day a package needs conditions, instead of quietly
+ * matching nothing.
+ */
+function exportTargets(node: unknown): string[] {
+	if (typeof node === "string") return node.startsWith(".") ? [node] : [];
+	if (Array.isArray(node)) return node.flatMap(exportTargets);
+	if (node !== null && typeof node === "object") return Object.values(node).flatMap(exportTargets);
+	return [];
 }
 
 describe("package metadata invariants", () => {
@@ -69,6 +84,17 @@ describe("package metadata invariants", () => {
 			if (isLibraryPackage || member.name === "@repo/test-utils") {
 				it("exposes an exports map", () => {
 					expect(pkg.exports).toBeDefined();
+				});
+
+				it("every exports subpath points at a file that exists", () => {
+					// An exports map is the package's public surface, and in a source-first workspace a
+					// stale entry in one is invisible until someone imports that subpath: the resolver
+					// reports the specifier as unresolvable, which reads like the importer's mistake. Cheap
+					// to check, and it catches the move-a-file refactor that forgets the manifest.
+					const missing = exportTargets(pkg.exports ?? {}).filter(
+						(target) => !existsSync(join(member.dir, target)),
+					);
+					expect(missing).toEqual([]);
 				});
 			}
 


### PR DESCRIPTION
Introduce `@sandbox-benchmarks/figures`: Run document → realworld figure model → one
self-contained HTML document per chart. The package is typed by
`@sandbox-benchmarks/schema` — the workspace's one Run contract and registry shapes — so it
re-describes nothing the workspace already owns; the registries still arrive as arguments
(`buildRealworldFigureModel({ run, metrics, providers, suites })`), which is what keeps every
guard runnable against synthetic runs.

Shape of the package (consolidated after review — no vendored data layer, no parse boundary
for a document that never leaves the process, no derivations this repo doesn't render):

- `phases.ts` — the pipeline phase vocabulary: id, printed label and ramp colour defined once
  per phase, ordered by execution, so "color order = execution order" holds by construction.
- `model.ts` — Run + registries → exactly the three fields the charts consume (suites,
  providers, phaseOrder). Chartability (≥2 environments completing every exercised task) is
  decided here and nowhere else.
- `chart/` — the view-model (sort, badge, shared scale, disclosures — every decision as
  testable data) and the HTML template (inline CSS, escaped interpolation, hex-only colours).
- `chart/fonts.ts` — faces inlined as data: URIs from pinned npm packages
  (`@fontsource/geist-sans|geist-mono|afacad`) — the lockfile pins the glyphs like it pins
  code; no vendored binaries.

Rasterisation is a later, separate concern (next PR); this package's own surface is
deterministic string building.

### Brand faces only, and a check instead of a fallback

This started out carrying `dejavu-fonts-ttf` as a per-glyph Unicode fallback. Measured, that
was **986 KB of base64 — 88% of every generated document** — and the premise behind it was
wrong: the two characters it was there for (`†`, `→`) are missing from Geist Mono and Afacad,
but *present in the Geist Sans subset already embedded here*. (`·`, the third, is in every
face.) Ending each font stack on Geist draws them with a brand face and makes the dependency
unreachable, so it's gone. Documents drop from ~1119 KB to 133 KB.

What DejaVu genuinely insured against was authored text reaching for a character no embedded
face can draw — Chrome would silently fall back to an installed font and the figure would stop
being reproducible. `assertCovered` buys that back for no bytes: an uncovered codepoint fails
the render and names itself, so the failure is a build error rather than a machine-dependent
picture. Adding a character is a deliberate one-line edit after checking the subset has it.

### Interpolation guards

Every model string goes through `escapeHtml`, colours through a hex-only guard, and — new here
— the one bare number that reaches a `style` attribute (`flex-grow: ${share}`) through a
finite-non-negative guard. `flex-grow` takes the share unformatted, so unlike the lengths that
pass through `px()` nothing about the interpolation constrained it to a number; the model is an
exported type and TypeScript is not a runtime, so a caller's `"1; background: url(…)"` would
have landed in the declaration intact and given the document an external fetch.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `@sandbox-benchmarks/figures`, a pure Run→model→HTML pipeline that generates one self‑contained chart per realworld suite with a shared time scale. The HTML is deterministic, uses embedded brand fonts, renders inline markdown, and avoids any external references.

- **Bug Fixes**
  - Guard colors as hex before style interpolation to prevent CSS injection.
  - Validate segment shares for `flex-grow` as finite non‑negative numbers.

- **Refactors**
  - Drop `dejavu-fonts-ttf`; embed only `@fontsource-variable/afacad`, `@fontsource/geist-sans`, and `@fontsource/geist-mono`, and add `assertCovered` to fail on uncovered glyphs, reducing document size while keeping determinism.
  - Strengthen repo checks to ensure every `exports` subpath points to an existing file.

<sup>Written for commit b54468b2a0169de50d0ca75a6cbc022936a066a5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/starslingdev/hpc-sandbox-benchmarks/pull/309?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added deterministic pipeline chart generation with proportional timing bars, phase legends, totals, fastest-run indicators, and incomplete-run disclosures.
  * Added self-contained HTML output with embedded fonts, safe text handling, inline Markdown, and consistent scaling.
  * Added real-world figure models, standardized pipeline phases, duration formatting, and light-theme color tokens.

* **Documentation**
  * Added package documentation covering chart generation, output behavior, and rendering considerations.

* **Tests**
  * Added comprehensive coverage for chart modeling, rendering, formatting, phases, fonts, and data validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

