### PR TITLE
ci(update-leaderboard): pin the chart-rendering Chrome; document the drawn realworld section

### DIFF
--- a/.github/actions/setup-pinned-chrome/action.yml
+++ b/.github/actions/setup-pinned-chrome/action.yml
@@ -1,0 +1,56 @@
+name: Set up pinned headless Chrome
+description: >-
+  Provision the chromium-headless-shell build the lockfile's playwright-core pins, cached, and
+  export its path as BUN_CHROME_PATH — the variable that wins Bun.WebView's discovery (full search
+  order: packages/figures/README.md). This is what makes the chart-rendering browser a PINNED,
+  reviewable input rather than ambient runner state: without it the runner image's unpinned
+  google-chrome-stable would rasterise the published figures, changing their bytes whenever the
+  image updates. The download happens only here, explicitly — installs are --ignore-scripts
+  everywhere, so no postinstall ever fetches a browser.
+
+  Linux x64 hosted runners only, by design: this action serves exactly the update-leaderboard job.
+  NOTE: assumes the repo is checked out AND `bun install` has run (a local action is read from the
+  workspace, and the version detection below reads the installed playwright-core) — the caller
+  keeps its explicit checkout + install steps first.
+
+outputs:
+  chrome-path:
+    description: Absolute path of the pinned chrome-headless-shell executable (also exported as BUN_CHROME_PATH).
+    value: ${{ steps.provision.outputs.chrome-path }}
+
+runs:
+  using: composite
+  steps:
+    # The cache key is the LOCKED playwright-core version — each release pins exactly one
+    # chromium-headless-shell build, so the cache busts precisely when the pin changes and
+    # survives unrelated lockfile churn (a hashFiles(bun.lock) key would re-download ~100 MB on
+    # every dependency bump).
+    - name: Resolve the locked playwright-core version
+      id: version
+      shell: bash
+      run: |
+        version="$(bun -e 'console.log(require("playwright-core/package.json").version)')"
+        if [ -z "$version" ]; then
+          echo "could not read the installed playwright-core version — did bun install run?" >&2
+          exit 1
+        fi
+        echo "version=$version" >> "$GITHUB_OUTPUT"
+
+    # Third-party actions are pinned to a commit SHA (the tag comment is for humans) so a moved or
+    # compromised tag can't silently change what runs — the repo-wide supply-chain posture.
+    - name: Cache the pinned browser
+      uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
+      with:
+        path: ~/.cache/ms-playwright
+        key: chrome-headless-shell-${{ runner.os }}-${{ runner.arch }}-${{ steps.version.outputs.version }}
+
+    # pin-chrome.sh is the ONE provisioning mechanism, shared with pinned local renders — it
+    # installs the build (a no-op on cache hit) and resolves the executable from playwright-core
+    # itself, so a stale cache entry or relocated cache can never select the wrong browser.
+    - name: Provision pinned headless Chrome
+      id: provision
+      shell: bash
+      run: |
+        chrome="$(./scripts/pin-chrome.sh)"
+        echo "chrome-path=$chrome" >> "$GITHUB_OUTPUT"
+        echo "BUN_CHROME_PATH=$chrome" >> "$GITHUB_ENV"

--- a/.github/workflows/update-leaderboard.yml
+++ b/.github/workflows/update-leaderboard.yml
@@ -80,6 +80,14 @@ jobs:
       - name: Install dependencies
         run: bun install --frozen-lockfile --ignore-scripts
 
+      # The chart screenshots need a Chrome, and this is what makes the browser a PINNED input
+      # rather than ambient runner state (the image's unpinned google-chrome-stable would
+      # otherwise rasterise the figures — and defeat the "nothing to commit" early-exit below
+      # with pure pixel churn on every image update). The composite installs the build the
+      # lockfile's playwright-core pins, cached on that version, and exports BUN_CHROME_PATH.
+      - name: Set up pinned headless Chrome
+        uses: ./.github/actions/setup-pinned-chrome
+
       # Resolve which committed run to render: the explicit input when given, else the newest entry in
       # the newest-first data/dataset/index.json. Fail loudly if the chosen run isn't in the committed
       # dataset — the leaderboard must be rendered from data/dataset/runs/ (what promote writes), never

--- a/bun.lock
+++ b/bun.lock
@@ -8,6 +8,7 @@
         "@biomejs/biome": "2.4.16",
         "@types/bun": "catalog:",
         "lefthook": "2.1.9",
+        "playwright-core": "1.62.1",
         "typescript": "catalog:",
       },
     },
@@ -984,6 +985,8 @@
     "pkg-types": ["pkg-types@2.3.1", "", { "dependencies": { "confbox": "^0.2.4", "exsolve": "^1.0.8", "pathe": "^2.0.3" } }, "sha512-y+ichcgc2LrADuhLNAx8DFjVfgz91pRxfZdI3UDhxHvcVEZsenLO+7XaU5vOp0u/7V/wZ+plyuQxtrDlZJ+yeg=="],
 
     "platform": ["platform@1.3.6", "", {}, "sha512-fnWVljUchTro6RiCFvCXBbNhJc2NijN7oIQxbwsyL0buWJPG85v81ehlHI9fXrJsMNgTofEoWIQeClKpgxFLrg=="],
+
+    "playwright-core": ["playwright-core@1.62.1", "", { "bin": { "playwright-core": "cli.js" } }, "sha512-wPYSwEBJY9GHraISXqyqtx0na0LpO3XEX7jNDhntbex7tzUS7kLnZsOlFruFJB4Hi/rhDMjXGqHewDZ68nYZVw=="],
 
     "powershell-utils": ["powershell-utils@0.1.0", "", {}, "sha512-dM0jVuXJPsDN6DvRpea484tCUaMiXWjuCn++HGTqUWzGDjv5tZkEZldAJ/UMlqRYGFrD/etByo4/xOuC/snX2A=="],
 

--- a/docs/methodology.md
+++ b/docs/methodology.md
@@ -96,8 +96,9 @@ matters for what can be checked where: the HTML is byte-deterministic everywhere
 that set, that each committed WebP has the promised geometry, and that the chart HTML renders the same
 bytes twice — all without a browser. The pixels themselves are Chrome's, and Chrome's rasterisation is
 not byte-stable across machines, so they are authored in one place: the *Update leaderboard* workflow,
-which installs the browser build its lockfile pins (`playwright-core`'s `chromium-headless-shell`),
-rasterises every chart twice, and fails on a byte mismatch. A raster cannot be reviewed as a diff —
+which provisions the browser build its lockfile pins via `scripts/pin-chrome.sh` (the same script a
+maintainer can use for a pinned local render), rasterises every chart twice, and fails on a byte
+mismatch. A raster cannot be reviewed as a diff —
 which is exactly why the per-task tables stay one click below the charts as the auditable receipts.
 
 Metrics come from three sources:

--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
   "devDependencies": {
     "@biomejs/biome": "2.4.16",
     "lefthook": "2.1.9",
+    "playwright-core": "1.62.1",
     "typescript": "catalog:",
     "@types/bun": "catalog:"
   }

--- a/scripts/pin-chrome.sh
+++ b/scripts/pin-chrome.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+# Install the headless Chrome build the lockfile pins, and print its executable path.
+#
+# ONE mechanism for the release workflow and a maintainer regenerating figures locally, so "the
+# pinned browser" is not a CI-only special case: the Update-leaderboard job exports the printed
+# path as BUN_CHROME_PATH, and a local render can do the same
+# (`BUN_CHROME_PATH="$(./scripts/pin-chrome.sh)" bun apps/cli/src/bin/leaderboard.ts …`).
+#
+# The pin is the locked `playwright-core` version: `bunx` resolves the workspace's installed copy,
+# and each playwright-core release pins one chromium-headless-shell build. The install location is
+# then asked OF PLAYWRIGHT-CORE ITSELF (`install --dry-run`) rather than globbed out of the cache
+# directory, because the cache is shared state: it moves with PLAYWRIGHT_BROWSERS_PATH, its layout
+# differs by platform/arch, and it can hold stale revisions from earlier versions — a
+# `find ~/.cache/ms-playwright | head -1` can silently pick a browser the lockfile does not pin.
+# Searching only the resolved revision directory makes that impossible.
+set -euo pipefail
+
+# Idempotent: playwright skips the ~100 MB download when the revision is already installed
+# (e.g. restored from the workflow's cache). Progress goes to stderr; stdout is the path.
+bunx playwright-core install chromium-headless-shell >&2
+
+dir="$(bunx playwright-core install --dry-run chromium-headless-shell | sed -n 's/^ *Install location: *//p' | head -1)"
+if [ -z "$dir" ] || [ ! -d "$dir" ]; then
+  echo "could not resolve the chromium-headless-shell install location (got: '${dir}')" >&2
+  exit 1
+fi
+
+# The executable's name is the one platform-dependent part (`chrome-headless-shell` in the
+# Chrome-for-Testing layouts, `headless_shell` in some arm64 chromium layouts) — search for
+# either, but only inside the exact revision directory resolved above.
+shell="$(find "$dir" -type f \( -name chrome-headless-shell -o -name headless_shell \) | head -1)"
+if [ -z "$shell" ]; then
+  echo "no headless-shell executable under $dir" >&2
+  exit 1
+fi
+printf '%s\n' "$shell"


### PR DESCRIPTION
The runner image ships an unpinned google-chrome-stable that Bun.WebView's discovery would find
first, making the published figures depend on whatever the image shipped this week — and
defeating the "nothing to commit" early-exit with pure pixel churn on every image update.

`scripts/pin-chrome.sh` is the one mechanism for CI and local renders alike: it installs the
chromium-headless-shell build the lockfile's playwright-core pins and prints its executable
path, resolving the install location from playwright-core itself (`install --dry-run`) rather
than globbing the shared cache — so a relocated cache (PLAYWRIGHT_BROWSERS_PATH), a different
platform layout (arm64's binary name), or a stale sibling revision can never select the wrong
browser. The workflow exports the printed path as BUN_CHROME_PATH and caches
~/.cache/ms-playwright keyed on the lockfile (SHA-pinned actions/cache), so the ~100 MB
download happens only on a playwright-core bump. Installs stay --ignore-scripts everywhere: no
postinstall ever downloads a browser, and PR CI needs no browser at all.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Pins the chart-rendering browser by provisioning `playwright-core@1.62.1`’s `chromium-headless-shell` via `scripts/pin-chrome.sh` and a local CI composite action, so leaderboard PNGs only change on a browser bump. Exports `BUN_CHROME_PATH`, caches `~/.cache/ms-playwright` by the locked `playwright-core` version (SHA-pinned `actions/cache`), keeps installs `--ignore-scripts`, supports pinned local renders, and updates docs on the drawn “realworld” section and where determinism ends (HTML is byte-checked; pixels are authored by the workflow).

<sup>Written for commit f24e95d23dce513cb41474b2a983758d3715a963. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/starslingdev/hpc-sandbox-benchmarks/pull/312?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

