### PR TITLE
feat(providers): add Vercel Sandbox as a benchmarked provider

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -38,6 +38,17 @@ MICROSANDBOX_LOCAL_BENCH=
 MSB_API_KEY=
 MSB_API_URL=
 
+# --- Vercel Sandbox (https://vercel.com/docs/sandbox) ---
+# Short-lived project token consumed directly by the Vercel SDK. See the local validation flow in
+# packages/providers/README.md. Never put the long-lived VERCEL_TOKEN bootstrap credential here.
+VERCEL_OIDC_TOKEN=
+# Human-readable Vercel namespace the VCR image refs are built from. Leave unset to use the defaults
+# in packages/schema/src/toolchain.ts; set them to publish into a different team or project (a fork).
+# These are NAMES, not the team_*/prj_* API IDs the CLI reads as VERCEL_ORG_ID / VERCEL_PROJECT_ID —
+# passing an ID here is rejected, because these values become Docker registry path segments.
+# VERCEL_TEAM_SLUG=
+# VERCEL_PROJECT_NAME=
+
 # --- Optional overrides (leave unset for the pinned public toolchain) ---
 # Point the adapters at a specific toolchain image / template instead of the canonical published one.
 # Useful only when iterating on the toolchain locally; see packages/providers/src/lib/config.ts.

--- a/.github/workflows/bench-smoke.yml
+++ b/.github/workflows/bench-smoke.yml
@@ -20,6 +20,7 @@ on:
             modal-vm,
             blaxel,
             novita,
+            vercel,
             namespace,
             microsandbox-local,
             microsandbox-cloud,
@@ -151,6 +152,16 @@ jobs:
       - name: Install dependencies
         run: bun install --frozen-lockfile --ignore-scripts
 
+      - name: Authenticate with Vercel
+        if: inputs.provider == 'vercel'
+        continue-on-error: true
+        id: vercel-auth
+        uses: ./.github/actions/vercel-auth
+        with:
+          token: ${{ secrets.VERCEL_TOKEN }}
+          org-id: ${{ secrets.VERCEL_ORG_ID }}
+          project-id: ${{ secrets.VERCEL_PROJECT_ID }}
+
       # Drives the provider SDK to create a sandbox, run the suite, collect results, and normalize.
       # The sandbox clones THIS repo at the run's SHA so the in-sandbox producer matches the harness.
       - name: Run suite and normalize
@@ -196,6 +207,8 @@ jobs:
           # runs when inputs.provider == 'namespace'), which the harness reads as the standard
           # missing-credentials skip on every other dispatch.
           NSC_TOKEN_FILE: ${{ steps.nsc-token.outcome == 'success' && format('{0}/nsc-token.json', runner.temp) || '' }}
+          # @computesdk/vercel reads the short-lived token exported by the auth action.
+          VERCEL_OIDC_TOKEN: ${{ inputs.provider == 'vercel' && steps.vercel-auth.outcome == 'success' && env.VERCEL_OIDC_TOKEN || '' }}
           # Local is an explicit capability opt-in. Cloud needs only its API key; MSB_API_URL is an
           # optional override for staging or private deployments. Neither value enters the guest.
           MICROSANDBOX_LOCAL_BENCH: ${{ inputs.provider == 'microsandbox-local' && '1' || '' }}

--- a/.github/workflows/bench-suite.yml
+++ b/.github/workflows/bench-suite.yml
@@ -194,6 +194,16 @@ jobs:
       - name: Install dependencies
         run: bun install --frozen-lockfile --ignore-scripts
 
+      - name: Authenticate with Vercel
+        if: matrix.provider == 'vercel'
+        continue-on-error: true
+        id: vercel-auth
+        uses: ./.github/actions/vercel-auth
+        with:
+          token: ${{ secrets.VERCEL_TOKEN }}
+          org-id: ${{ secrets.VERCEL_ORG_ID }}
+          project-id: ${{ secrets.VERCEL_PROJECT_ID }}
+
       # Drive the provider SDK to create this cell's R replicate sandboxes, run the suite in each,
       # collect results, and normalize one shard Run per replicate. The cell's provider is a matrix value
       # and its suite + replicate array are reusable inputs, all passed through the environment (never
@@ -249,6 +259,8 @@ jobs:
           # (steps.nsc-token only runs when matrix.provider == 'namespace'), which the harness reads
           # as the standard missing-credentials skip on every other cell.
           NSC_TOKEN_FILE: ${{ steps.nsc-token.outcome == 'success' && format('{0}/nsc-token.json', runner.temp) || '' }}
+          # @computesdk/vercel reads the short-lived token exported by the auth action.
+          VERCEL_OIDC_TOKEN: ${{ matrix.provider == 'vercel' && steps.vercel-auth.outcome == 'success' && env.VERCEL_OIDC_TOKEN || '' }}
           # Local is an explicit capability opt-in. Cloud needs only its API key; MSB_API_URL is an
           # optional override for staging or private deployments. Neither value enters the guest.
           MICROSANDBOX_LOCAL_BENCH: ${{ matrix.provider == 'microsandbox-local' && '1' || '' }}

--- a/.github/workflows/toolchain-image.yml
+++ b/.github/workflows/toolchain-image.yml
@@ -63,6 +63,18 @@ env:
   # Only IMAGE_OWNER is consumed (ensure-package-public's `owner`). The former REGISTRY host is owned by
   # the ghcr-login composite default and imageRepo(), so it's not re-declared here.
   IMAGE_OWNER: starslingdev
+  # The human-readable Vercel namespace every VCR ref is built from. Repository VARIABLES, not secrets:
+  # a team slug and a project name are not credentials, and keeping them out of the secret store means
+  # they stay readable in job logs when a mirror lands in the wrong repository.
+  #
+  # Unset vars materialize as "", which the providers config gatekeeper treats as unset and falls back
+  # to the schema defaults — so this passthrough never has to repeat the default. That is deliberately
+  # the opposite of a `|| 'fallback'` expression here: one default, owned by
+  # packages/schema/src/toolchain.ts, instead of two that can drift.
+  #
+  # VERCEL_PROJECT_NAME must name the same project as the VERCEL_PROJECT_ID secret the CLI links with.
+  VERCEL_TEAM_SLUG: ${{ vars.VERCEL_TEAM_SLUG }}
+  VERCEL_PROJECT_NAME: ${{ vars.VERCEL_PROJECT_NAME }}
 
 jobs:
   # ── PR lane ──────────────────────────────────────────────────────────────────────────────────────
@@ -348,6 +360,37 @@ jobs:
             --name "sandbox-benchmarks-toolchain-bake-${{ github.run_id }}-${{ github.run_attempt }}" \
             --grant '{"resource_type":"instance","resource_id":"*","actions":["create","list","get","destroy","exec"]}' \
             --token_file "${{ runner.temp }}/nsc-token.json"
+      - name: Authenticate with Vercel and VCR
+        if: matrix.provider == 'vercel'
+        continue-on-error: true
+        id: vercel-auth
+        uses: ./.github/actions/vercel-auth
+        with:
+          token: ${{ secrets.VERCEL_TOKEN }}
+          org-id: ${{ secrets.VERCEL_ORG_ID }}
+          project-id: ${{ secrets.VERCEL_PROJECT_ID }}
+          vcr-login: "true"
+      - name: Mirror candidate into VCR
+        if: matrix.provider == 'vercel' && steps.vercel-auth.outcome == 'success'
+        id: vercel-vcr
+        run: |
+          set -euo pipefail
+          source_ref="$(bun -e 'import { config } from "@sandbox-benchmarks/providers"; console.log(config.vercelSourceImageCandidate)')"
+          target_ref="$(bun -e 'import { config } from "@sandbox-benchmarks/providers"; console.log(config.vercelImageCandidate)')"
+          project="$(bun -e 'import { config } from "@sandbox-benchmarks/providers"; console.log(config.vercelProjectName)')"
+          target_name="${target_ref##*/}"
+          docker pull "$source_ref"
+          docker tag "$source_ref" "$target_ref"
+          # --project pins the destination to the SAME resolved name the target ref was built from.
+          # Without it the push silently follows whatever project VERCEL_PROJECT_ID linked, so a
+          # mismatched VERCEL_PROJECT_NAME would tag one repository and publish into another — and the
+          # digest read back below would describe an image the providers never pull.
+          ./node_modules/.bin/vercel vcr push docker "$target_name" --project "$project"
+          digest="$(docker buildx imagetools inspect "$target_ref" --format '{{json .Manifest.Digest}}' | jq -er '.')"
+          echo "digest-ref=${target_ref%:*}@${digest}" >> "$GITHUB_OUTPUT"
+      - name: Log out of VCR after mirror
+        if: matrix.provider == 'vercel' && steps.vercel-vcr.outcome == 'success'
+        run: docker logout vcr.vercel.com
       - name: Bake + verify candidate
         id: bake
         # The cell's provider + required flag reach the script through the environment, never
@@ -391,6 +434,8 @@ jobs:
           MICROSANDBOX_LOCAL_BENCH: ${{ matrix.provider == 'microsandbox-local' && '1' || '' }}
           MSB_API_URL: ${{ matrix.provider == 'microsandbox-cloud' && secrets.MSB_API_URL || '' }}
           MSB_API_KEY: ${{ matrix.provider == 'microsandbox-cloud' && secrets.MSB_API_KEY || '' }}
+          VERCEL_OIDC_TOKEN: ${{ matrix.provider == 'vercel' && steps.vercel-auth.outcome == 'success' && env.VERCEL_OIDC_TOKEN || '' }}
+          VERCEL_CANDIDATE_IMAGE: ${{ steps.vercel-vcr.outcome == 'success' && steps.vercel-vcr.outputs.digest-ref || '' }}
         run: |
           set -euo pipefail
           args=(--provider "${PROVIDER}")
@@ -412,6 +457,10 @@ jobs:
             bun apps/cli/src/bin/bake.ts "${args[@]}" ||
               echo "::warning title=Non-required provider not validated::${PROVIDER} did not pass its bake/verify — reported, not blocking the release (best-effort variant)"
           fi
+      # Failure-safe fallback for auth/mirror failures that skip the immediate post-mirror logout.
+      - name: Ensure VCR logout
+        if: always()
+        run: docker logout vcr.vercel.com || true
       - name: Upload bake report
         if: always()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
@@ -503,6 +552,23 @@ jobs:
             --name "sandbox-benchmarks-toolchain-promote-${{ github.run_id }}-${{ github.run_attempt }}" \
             --grant '{"resource_type":"instance","resource_id":"*","actions":["create","list","get","destroy","exec"]}' \
             --token_file "${{ runner.temp }}/nsc-token.json"
+      - name: Authenticate with Vercel and VCR
+        continue-on-error: true
+        id: vercel-auth
+        uses: ./.github/actions/vercel-auth
+        with:
+          token: ${{ secrets.VERCEL_TOKEN }}
+          org-id: ${{ secrets.VERCEL_ORG_ID }}
+          project-id: ${{ secrets.VERCEL_PROJECT_ID }}
+          vcr-login: "true"
+      - name: Log in to VCR and pin candidate
+        if: steps.vercel-auth.outcome == 'success'
+        id: vercel-vcr
+        run: |
+          set -euo pipefail
+          candidate="$(bun -e 'import { config } from "@sandbox-benchmarks/providers"; console.log(config.vercelImageCandidate)')"
+          digest="$(docker buildx imagetools inspect "$candidate" --format '{{json .Manifest.Digest}}' | jq -er '.')"
+          echo "digest-ref=${candidate%:*}@${digest}" >> "$GITHUB_OUTPUT"
       - name: Promote candidate → version
         id: promote
         env:
@@ -535,6 +601,8 @@ jobs:
           MICROSANDBOX_LOCAL_BENCH: "1"
           MSB_API_URL: ${{ secrets.MSB_API_URL }}
           MSB_API_KEY: ${{ secrets.MSB_API_KEY }}
+          VERCEL_OIDC_TOKEN: ${{ steps.vercel-auth.outcome == 'success' && env.VERCEL_OIDC_TOKEN || '' }}
+          VERCEL_CANDIDATE_IMAGE: ${{ steps.vercel-vcr.outcome == 'success' && steps.vercel-vcr.outputs.digest-ref || '' }}
         run: |
           set -euo pipefail
           args=(--promote --require "${REQUIRED}")
@@ -542,6 +610,9 @@ jobs:
           # version; never set on the automated push path.
           if [ "${FORCE_REPUBLISH}" = "true" ]; then args+=(--force); fi
           bun apps/cli/src/bin/bake.ts "${args[@]}"
+      - name: Log out of VCR
+        if: always()
+        run: docker logout vcr.vercel.com || true
       - name: Upload promote payload
         if: always()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -51,8 +51,10 @@ bun run check:catalog-drift                                    # fail if the com
    one-sided provider is a compile error.
 3. **Template** — add a template builder under [`packages/templates`](./packages/templates) so the
    provider can be baked with the toolchain image.
-4. The provider now flows through the matrix, normalizer, leaderboard, and economics automatically — no
-   consumer edits. Bring it up live per the provider end-to-end issues (E2B/Modal/Daytona).
+4. **Exhaustive consumers** — update the CLI bake map, candidate create-options switch, release-plan
+   artifact switch, provider-id test oracles, and both benchmark workflows' synchronized credential
+   environment. Provider matrix fan-out, normalization, leaderboard, and economics remain automatic.
+5. Bring it up live with a single-provider branch dispatch before adding it to the default matrix list.
 
 ## Add a suite
 

--- a/apps/cli/src/bin/bake.ts
+++ b/apps/cli/src/bin/bake.ts
@@ -54,6 +54,9 @@ const bakers: Record<ProviderId, (image: string, log: Log) => Promise<void>> = {
 	namespace: async (_image, log) => {
 		log("namespace boots the candidate image directly — no candidate artifact to bake");
 	},
+	vercel: async (_image, log) => {
+		log("vercel boots the candidate image mirrored to VCR — no separate sandbox artifact to bake");
+	},
 };
 
 /**
@@ -173,6 +176,7 @@ if (import.meta.main) {
 		daytonaContainerSnapshotCandidate: config.daytonaContainerSnapshotCandidate,
 		novitaTemplateCandidate: config.novitaTemplateCandidate,
 		toolchainImageCandidate: pinnedCandidateImage,
+		vercelImageCandidate: config.vercelImageCandidate,
 		daytonaVmTarget: config.daytonaVm.target,
 		daytonaContainerTarget: config.daytonaContainer.target,
 	};

--- a/apps/cli/src/bin/release-plan.test.ts
+++ b/apps/cli/src/bin/release-plan.test.ts
@@ -38,6 +38,7 @@ describe("buildReleasePlan matrix", () => {
 			"modal-vm",
 			"novita",
 			"namespace",
+			"vercel",
 		]);
 	});
 
@@ -59,7 +60,7 @@ describe("planOutputs", () => {
 		expect(matrixLine).toBeDefined();
 		// The matrix value must be valid, single-line JSON (the fromJSON contract).
 		const parsed = JSON.parse((matrixLine as string).slice("matrix=".length));
-		expect(parsed.include).toHaveLength(10);
+		expect(parsed.include).toHaveLength(11);
 		expect((matrixLine as string).includes("\n")).toBe(false);
 	});
 });

--- a/apps/cli/src/bin/release-plan.ts
+++ b/apps/cli/src/bin/release-plan.ts
@@ -65,6 +65,8 @@ function providerArtifact(id: ProviderId): string {
 			// No template/snapshot system — pulls the candidate image straight into an instance at
 			// create time (same as modal), so there is no baked artifact to name.
 			return "boots the candidate image directly (no baked artifact)";
+		case "vercel":
+			return config.vercelImageCandidate;
 	}
 }
 

--- a/apps/cli/src/lib/bake/promote.ts
+++ b/apps/cli/src/lib/bake/promote.ts
@@ -93,6 +93,7 @@ export async function promoteAll(log: Log, force = false): Promise<BakeReport[]>
 		daytonaContainerSnapshotCandidate: config.daytonaContainerSnapshotCandidate,
 		novitaTemplateCandidate: config.novitaTemplateCandidate,
 		toolchainImageCandidate: pinnedCandidateImage,
+		vercelImageCandidate: config.vercelImageCandidate,
 		daytonaVmTarget: config.daytonaVm.target,
 		daytonaContainerTarget: config.daytonaContainer.target,
 	};
@@ -159,6 +160,9 @@ export async function promoteAll(log: Log, force = false): Promise<BakeReport[]>
 					break;
 				case "namespace":
 					log("    namespace pulls the published version image — nothing to build");
+					break;
+				case "vercel":
+					await promoteImage(log, config.vercelImageCandidate, config.vercelImageVersion);
 					break;
 				default: {
 					// Exhaustiveness: a new ProviderId must add a promote branch above (compile error here).

--- a/apps/cli/src/lib/bake/validate.test.ts
+++ b/apps/cli/src/lib/bake/validate.test.ts
@@ -9,6 +9,7 @@ const refs: CandidateRefs = {
 	// Distinct from the e2b value so the novita case fails if it ever reads the e2b field.
 	novitaTemplateCandidate: "tc-v1-novita-candidate",
 	toolchainImageCandidate: "ghcr.io/o/tc:v1-candidate",
+	vercelImageCandidate: "sandbox-benchmarks-toolchain-vercel:v1-candidate",
 	daytonaVmTarget: "us-west-2",
 	daytonaContainerTarget: "us-west-2",
 };
@@ -62,6 +63,12 @@ describe("candidateCreateOptions", () => {
 	it("points namespace directly at the candidate image", () => {
 		expect(candidateCreateOptions("namespace", refs)).toEqual({
 			image: "ghcr.io/o/tc:v1-candidate",
+		});
+	});
+
+	it("points Vercel at the digest-pinned VCR candidate image", () => {
+		expect(candidateCreateOptions("vercel", refs)).toEqual({
+			templateId: refs.vercelImageCandidate,
 		});
 	});
 

--- a/apps/cli/src/lib/bake/validate.ts
+++ b/apps/cli/src/lib/bake/validate.ts
@@ -12,6 +12,8 @@ export interface CandidateRefs {
 	/** Candidate template on Novita's E2B-compatible control plane (its own namespace). */
 	novitaTemplateCandidate: string;
 	toolchainImageCandidate: string;
+	/** Candidate image mirrored into the linked project's Vercel Container Registry. */
+	vercelImageCandidate: string;
 	/** daytona-vm runner target (us-west-2; undefined → account default). */
 	daytonaVmTarget?: string;
 	/** daytona-container runner target (us-west-2; undefined → account default). */
@@ -57,5 +59,7 @@ export function candidateCreateOptions(
 		case "namespace":
 			// No template/snapshot system — points create() at the candidate image directly, same as modal.
 			return { image: refs.toolchainImageCandidate };
+		case "vercel":
+			return { templateId: refs.vercelImageCandidate };
 	}
 }

--- a/apps/cli/src/lib/providers-run.test.ts
+++ b/apps/cli/src/lib/providers-run.test.ts
@@ -42,6 +42,7 @@ describe("forEachProviderWithCreds `only`", () => {
 			"modal-vm",
 			"novita",
 			"namespace",
+			"vercel",
 		]);
 	});
 

--- a/bun.lock
+++ b/bun.lock
@@ -92,6 +92,7 @@
         "@computesdk/namespace": "catalog:computesdk",
         "@computesdk/provider": "catalog:computesdk",
         "@sandbox-benchmarks/schema": "workspace:*",
+        "@vercel/sandbox": "catalog:computesdk",
         "arktype": "catalog:",
         "computesdk": "catalog:computesdk",
         "microsandbox": "catalog:computesdk",
@@ -199,6 +200,7 @@
       "@computesdk/provider": "2.1.3",
       "@daytona/api-client": "0.192.0",
       "@daytona/sdk": "0.192.0",
+      "@vercel/sandbox": "2.9.2",
       "computesdk": "4.1.3",
       "microsandbox": "0.6.8",
       "novita-sandbox": "2.0.6",
@@ -805,7 +807,7 @@
 
     "@vercel/rust": ["@vercel/rust@1.4.0", "", { "dependencies": { "execa": "5", "get-port": "5.1.1", "smol-toml": "1.5.2" } }, "sha512-/zRJtaf3pvdxZ7+tShmIo8StdbkCSBDcY7Gy7LOwNTIxm6GU9vkS+BlCwJHkOu6qNkbcSRH6ZQIeo4vNmqzKdQ=="],
 
-    "@vercel/sandbox": ["@vercel/sandbox@2.4.0", "", { "dependencies": { "@vercel/oidc": "3.2.0", "@workflow/serde": "4.1.0-beta.2", "async-retry": "1.3.3", "jose": "6.2.3", "jsonlines": "0.1.1", "ms": "2.1.3", "picocolors": "^1.1.1", "tar-stream": "3.1.7", "undici": "^7.27.1", "xdg-app-paths": "5.1.0", "zod": "^4.1.1" } }, "sha512-pifnr8hex/rgQ3EPyLYHYwHyf0Kwmc4Vbya9kHGk4aERFVGj44P+742S8/SDdt2guMxBriXBOMkMLq1Kaiyyeg=="],
+    "@vercel/sandbox": ["@vercel/sandbox@2.9.2", "", { "dependencies": { "@vercel/oidc": "3.2.0", "@workflow/serde": "4.1.0-beta.2", "async-retry": "1.3.3", "jose": "6.2.3", "jsonlines": "0.1.1", "ms": "2.1.3", "picocolors": "^1.1.1", "tar-stream": "3.1.7", "undici": "^7.27.1", "xdg-app-paths": "5.1.0", "zod": "^4.1.1" } }, "sha512-tnPtCNL6MZKM9eRYvmyL0geA2Nifq+PSxVXBNhk/lQNeCWgMp/EYzCDOotKEWR/VH+c0Yv9HG4qk0w2I65xnLA=="],
 
     "@vercel/static-build": ["@vercel/static-build@2.11.13", "", { "dependencies": { "@vercel/gatsby-plugin-vercel-analytics": "1.0.11", "@vercel/gatsby-plugin-vercel-builder": "2.2.33", "@vercel/static-config": "3.4.0", "ts-morph": "12.0.0" } }, "sha512-FShOZZpebAcCJuF+XejFeSmw9htNFHne/iVtroXaZvj3PJ+SDbLN2VFIRFwFGg5CZgDsbSN9N5caDbOSgQ7m9Q=="],
 
@@ -1267,7 +1269,7 @@
 
     "mri": ["mri@1.2.0", "", {}, "sha512-tzzskb3bG8LvYGFF/mDTpq3jpI6Q9wc3LEmBaghu+DdCssd1FakN7Bc0hVNmEyGq1bq3RgfkCb3cmQLpNPOroA=="],
 
-    "ms": ["ms@2.1.1", "", {}, "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg=="],
+    "ms": ["ms@2.1.3", "", {}, "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="],
 
     "negotiator": ["negotiator@1.0.0", "", {}, "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg=="],
 
@@ -1339,7 +1341,7 @@
 
     "perfect-debounce": ["perfect-debounce@2.1.0", "", {}, "sha512-LjgdTytVFXeUgtHZr9WYViYSM/g8MkcTPYDlPa3cDqMirHjKiSZPYd6DoL7pK8AJQr+uWkQvCjHNdiMqsrJs+g=="],
 
-    "picocolors": ["picocolors@1.0.0", "", {}, "sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ=="],
+    "picocolors": ["picocolors@1.1.1", "", {}, "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA=="],
 
     "picomatch": ["picomatch@4.0.5", "", {}, "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A=="],
 
@@ -1475,7 +1477,7 @@
 
     "tar": ["tar@7.5.16", "", { "dependencies": { "@isaacs/fs-minipass": "^4.0.0", "chownr": "^3.0.0", "minipass": "^7.1.2", "minizlib": "^3.1.0", "yallist": "^5.0.0" } }, "sha512-56adEpPMouktRlBLXiaYFFzZ/3+JXa8P9n7WbR+ibIjtviN55mEaOkiysCnPnWm+7kkui1Dn8J9l+g6zV8731w=="],
 
-    "tar-stream": ["tar-stream@3.2.0", "", { "dependencies": { "b4a": "^1.6.4", "bare-fs": "^4.5.5", "fast-fifo": "^1.2.0", "streamx": "^2.15.0" } }, "sha512-ojzvCvVaNp6aOTFmG7jaRD0meowIAuPc3cMMhSgKiVWws1GyHbGd/xvnyuRKcKlMpt3qvxx6r0hreCNITP9hIg=="],
+    "tar-stream": ["tar-stream@3.1.7", "", { "dependencies": { "b4a": "^1.6.4", "fast-fifo": "^1.2.0", "streamx": "^2.15.0" } }, "sha512-qJj60CXt7IU1Ffyc3NJMjh6EkuCFej46zUqJ4J7pqYlThyd9bO0XBTmcOIhSzZJVWfsLks0+nle/j538YAW9RQ=="],
 
     "teex": ["teex@1.0.1", "", { "dependencies": { "streamx": "^2.12.5" } }, "sha512-eYE6iEI62Ni1H8oIa7KlDU6uQBtqr4Eajni3wX7rpfXD8ysFx8z0+dri+KWEPWpBsxXfxu58x/0jvTVT1ekOSg=="],
 
@@ -1557,7 +1559,7 @@
 
     "wsl-utils": ["wsl-utils@0.3.1", "", { "dependencies": { "is-wsl": "^3.1.0", "powershell-utils": "^0.1.0" } }, "sha512-g/eziiSUNBSsdDJtCLB8bdYEUMj4jR7AGeUo96p/3dTafgjHhpF4RiCFPiRILwjQoDXx5MqkBr4fwWtR3Ky4Wg=="],
 
-    "xdg-app-paths": ["xdg-app-paths@5.5.1", "", { "dependencies": { "os-paths": "^4.0.1", "xdg-portable": "^7.2.0" } }, "sha512-hI3flOB4PLZIy5prbtTpirobtPE2ZtZ52szO+2mM9Efp6ErM398La+C1lIpNWDfNoQk+6Lsi6nMcCwVB7pxeMQ=="],
+    "xdg-app-paths": ["xdg-app-paths@5.1.0", "", { "dependencies": { "xdg-portable": "^7.0.0" } }, "sha512-RAQ3WkPf4KTU1A8RtFx3gWywzVKe00tfOPFfl2NDGqbIFENQO4kqAJp7mhQjNj/33W5x5hiWWUdyfPq/5SU3QA=="],
 
     "xdg-portable": ["xdg-portable@7.3.0", "", { "dependencies": { "os-paths": "^4.0.1" } }, "sha512-sqMMuL1rc0FmMBOzCpd0yuy9trqF2yTTVe+E9ogwCSWQCdDEtQUwrZPT6AxqtsFGRNxycgncbP/xmOOSPw5ZUw=="],
 
@@ -1619,11 +1621,11 @@
 
     "@vercel/fun/async-listen": ["async-listen@1.2.0", "", {}, "sha512-CcEtRh/oc9Jc4uWeUwdpG/+Mb2YUHKmdaTf0gUr7Wa+bfp4xx70HOb3RuSTJMvqKNB1TkdTfjLdrcz2X4rkkZA=="],
 
+    "@vercel/fun/ms": ["ms@2.1.1", "", {}, "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg=="],
+
     "@vercel/fun/path-to-regexp": ["path-to-regexp@8.2.0", "", {}, "sha512-TdrF7fW9Rphjq4RjrW0Kp2AW0Ahwu9sRGTkS6bvDi0SCwZlEZYmcfDbEsTz8RVk0EHIS/Vd1bv3JhG+1xZuAyQ=="],
 
     "@vercel/fun/tar": ["tar@7.5.7", "", { "dependencies": { "@isaacs/fs-minipass": "^4.0.0", "chownr": "^3.0.0", "minipass": "^7.1.2", "minizlib": "^3.1.0", "yallist": "^5.0.0" } }, "sha512-fov56fJiRuThVFXD6o6/Q354S7pnWMJIVlDBYijsTNx6jKSE4pvrDTs6lUnmGvNyfJwFQQwWy3owKz1ucIhveQ=="],
-
-    "@vercel/fun/xdg-app-paths": ["xdg-app-paths@5.1.0", "", { "dependencies": { "xdg-portable": "^7.0.0" } }, "sha512-RAQ3WkPf4KTU1A8RtFx3gWywzVKe00tfOPFfl2NDGqbIFENQO4kqAJp7mhQjNj/33W5x5hiWWUdyfPq/5SU3QA=="],
 
     "@vercel/hono/zod": ["zod@3.22.4", "", {}, "sha512-iC+8Io04lddc+mVqQ9AZ7OQ2MrUKGN+oIQyq1vemgt46jwCwLfhq7/pwnBnNXXXZb8VTVLKwp9EDkx+ryxIWmg=="],
 
@@ -1655,21 +1657,17 @@
 
     "@vercel/sandbox/jose": ["jose@6.2.3", "", {}, "sha512-YYVDInQKFJfR/xa3ojUTl8c2KoTwiL1R5Wg9YCydwH0x0B9grbzlg5HC7mMjCtUJjbQ/YnGEZIhI5tCgfTb4Hw=="],
 
-    "@vercel/sandbox/ms": ["ms@2.1.3", "", {}, "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="],
-
-    "@vercel/sandbox/picocolors": ["picocolors@1.1.1", "", {}, "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA=="],
-
-    "@vercel/sandbox/tar-stream": ["tar-stream@3.1.7", "", { "dependencies": { "b4a": "^1.6.4", "fast-fifo": "^1.2.0", "streamx": "^2.15.0" } }, "sha512-qJj60CXt7IU1Ffyc3NJMjh6EkuCFej46zUqJ4J7pqYlThyd9bO0XBTmcOIhSzZJVWfsLks0+nle/j538YAW9RQ=="],
-
     "@vercel/sandbox/undici": ["undici@7.27.2", "", {}, "sha512-uZsKNuzQxDMUY6M3pIMvy5tvlGmtq8XJ2oLAkfRKGNu+1VQAIvLy2xIVG5ATZl5wDXl/tddByAWCizRbOme+TA=="],
 
-    "@vercel/sandbox/xdg-app-paths": ["xdg-app-paths@5.1.0", "", { "dependencies": { "xdg-portable": "^7.0.0" } }, "sha512-RAQ3WkPf4KTU1A8RtFx3gWywzVKe00tfOPFfl2NDGqbIFENQO4kqAJp7mhQjNj/33W5x5hiWWUdyfPq/5SU3QA=="],
+    "@vercel/sandbox/zod": ["zod@4.4.3", "", {}, "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ=="],
 
     "@vercel/static-config/ajv": ["ajv@8.6.3", "", { "dependencies": { "fast-deep-equal": "^3.1.1", "json-schema-traverse": "^1.0.0", "require-from-string": "^2.0.2", "uri-js": "^4.2.2" } }, "sha512-SMJOdDP6LqTkD0Uq8qLi+gMwSt0imXLSV080qFVwJCpH9U6Mb+SUGHAXM0KNbcBPguytWyvFxcHgMLe2D2XSpw=="],
 
     "accepts/mime-types": ["mime-types@3.0.2", "", { "dependencies": { "mime-db": "^1.54.0" } }, "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A=="],
 
     "agent-base/debug": ["debug@4.4.3", "", { "dependencies": { "ms": "^2.1.3" }, "peerDependencies": { "supports-color": "*" }, "optionalPeers": ["supports-color"] }, "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA=="],
+
+    "archiver/tar-stream": ["tar-stream@3.2.0", "", { "dependencies": { "b4a": "^1.6.4", "bare-fs": "^4.5.5", "fast-fifo": "^1.2.0", "streamx": "^2.15.0" } }, "sha512-ojzvCvVaNp6aOTFmG7jaRD0meowIAuPc3cMMhSgKiVWws1GyHbGd/xvnyuRKcKlMpt3qvxx6r0hreCNITP9hIg=="],
 
     "archiver-utils/glob": ["glob@10.5.0", "", { "dependencies": { "foreground-child": "^3.1.0", "jackspeak": "^3.1.2", "minimatch": "^9.0.4", "minipass": "^7.1.2", "package-json-from-dist": "^1.0.0", "path-scurry": "^1.11.1" }, "bin": { "glob": "dist/esm/bin.mjs" } }, "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg=="],
 
@@ -1688,6 +1686,8 @@
     "e2b/undici": ["undici@7.27.2", "", {}, "sha512-uZsKNuzQxDMUY6M3pIMvy5tvlGmtq8XJ2oLAkfRKGNu+1VQAIvLy2xIVG5ATZl5wDXl/tddByAWCizRbOme+TA=="],
 
     "edge-runtime/async-listen": ["async-listen@3.0.1", "", {}, "sha512-cWMaNwUJnf37C/S5TfCkk/15MwbPRwVYALA2jtjkbHjCmAPiDXyNJy2q3p1KAZzDLHAWyarUWSujUoHR4pEgrA=="],
+
+    "edge-runtime/picocolors": ["picocolors@1.0.0", "", {}, "sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ=="],
 
     "edge-runtime/signal-exit": ["signal-exit@4.0.2", "", {}, "sha512-MY2/qGx4enyjprQnFaZsHib3Yadh3IXyV2C321GY0pjGfVBu4un0uDJkwgdxqO+Rdx8JMT8IfJIRwbYVz3Ob3Q=="],
 
@@ -1721,8 +1721,6 @@
 
     "path-scurry/lru-cache": ["lru-cache@11.5.1", "", {}, "sha512-RPimw/7aMdv2oqRrxKwvZXcPfwBrn/JZ2xYcY9Hus/6LaS3VOAKVWKWgNLCFSiOm1ESXinjsDlidVU7JlnCN2A=="],
 
-    "pump/end-of-stream": ["end-of-stream@1.4.5", "", { "dependencies": { "once": "^1.4.0" } }, "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg=="],
-
     "readable-stream/buffer": ["buffer@6.0.3", "", { "dependencies": { "base64-js": "^1.3.1", "ieee754": "^1.2.1" } }, "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA=="],
 
     "readdir-glob/minimatch": ["minimatch@5.1.9", "", { "dependencies": { "brace-expansion": "^2.0.1" } }, "sha512-7o1wEA2RyMP7Iu7GNba9vc0RWWGACJOCZBJX2GJWip0ikV+wcOsgVuY9uE8CPiyQhkGFSlhuSkZPavN7u1c2Fw=="],
@@ -1733,13 +1731,15 @@
 
     "router/path-to-regexp": ["path-to-regexp@8.4.2", "", {}, "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA=="],
 
+    "sandbox/@vercel/sandbox": ["@vercel/sandbox@2.4.0", "", { "dependencies": { "@vercel/oidc": "3.2.0", "@workflow/serde": "4.1.0-beta.2", "async-retry": "1.3.3", "jose": "6.2.3", "jsonlines": "0.1.1", "ms": "2.1.3", "picocolors": "^1.1.1", "tar-stream": "3.1.7", "undici": "^7.27.1", "xdg-app-paths": "5.1.0", "zod": "^4.1.1" } }, "sha512-pifnr8hex/rgQ3EPyLYHYwHyf0Kwmc4Vbya9kHGk4aERFVGj44P+742S8/SDdt2guMxBriXBOMkMLq1Kaiyyeg=="],
+
     "sandbox/debug": ["debug@4.4.3", "", { "dependencies": { "ms": "^2.1.3" }, "peerDependencies": { "supports-color": "*" }, "optionalPeers": ["supports-color"] }, "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA=="],
+
+    "sandbox/zod": ["zod@4.4.3", "", {}, "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ=="],
 
     "send/debug": ["debug@4.4.3", "", { "dependencies": { "ms": "^2.1.3" }, "peerDependencies": { "supports-color": "*" }, "optionalPeers": ["supports-color"] }, "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA=="],
 
     "send/mime-types": ["mime-types@3.0.2", "", { "dependencies": { "mime-db": "^1.54.0" } }, "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A=="],
-
-    "send/ms": ["ms@2.1.3", "", {}, "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="],
 
     "stream-browserify/readable-stream": ["readable-stream@3.6.2", "", { "dependencies": { "inherits": "^2.0.3", "string_decoder": "^1.1.1", "util-deprecate": "^1.0.1" } }, "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA=="],
 
@@ -1779,15 +1779,11 @@
 
     "accepts/mime-types/mime-db": ["mime-db@1.54.0", "", {}, "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ=="],
 
-    "agent-base/debug/ms": ["ms@2.1.3", "", {}, "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="],
-
     "archiver-utils/glob/jackspeak": ["jackspeak@3.4.3", "", { "dependencies": { "@isaacs/cliui": "^8.0.2" }, "optionalDependencies": { "@pkgjs/parseargs": "^0.11.0" } }, "sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw=="],
 
     "archiver-utils/glob/minimatch": ["minimatch@9.0.9", "", { "dependencies": { "brace-expansion": "^2.0.2" } }, "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg=="],
 
     "archiver-utils/glob/path-scurry": ["path-scurry@1.11.1", "", { "dependencies": { "lru-cache": "^10.2.0", "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0" } }, "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA=="],
-
-    "body-parser/debug/ms": ["ms@2.1.3", "", {}, "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="],
 
     "c12/chokidar/readdirp": ["readdirp@5.0.0", "", {}, "sha512-9u/XQ1pvrQtYyMpZe7DXKv2p5CNvyVwzUB6uhLAnQwHMSgKMBR62lc7AHljaeteeHXn11XTAaLLUVZYVZyuRBQ=="],
 
@@ -1795,13 +1791,7 @@
 
     "cliui/wrap-ansi/ansi-styles": ["ansi-styles@4.3.0", "", { "dependencies": { "color-convert": "^2.0.1" } }, "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg=="],
 
-    "express/debug/ms": ["ms@2.1.3", "", {}, "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="],
-
     "express/mime-types/mime-db": ["mime-db@1.54.0", "", {}, "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ=="],
-
-    "finalhandler/debug/ms": ["ms@2.1.3", "", {}, "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="],
-
-    "https-proxy-agent/debug/ms": ["ms@2.1.3", "", {}, "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="],
 
     "lazystream/readable-stream/safe-buffer": ["safe-buffer@5.1.2", "", {}, "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="],
 
@@ -1815,11 +1805,9 @@
 
     "readdir-glob/minimatch/brace-expansion": ["brace-expansion@2.1.1", "", { "dependencies": { "balanced-match": "^1.0.0" } }, "sha512-WR1cURNjuvBLMZBMbqM0UoE+WAfdUcEV1ccD8PVBVOI+Z3ND4+SZbN8RsfT2bMuG1qwz5RFvPukSZm5fF2D5eA=="],
 
-    "require-in-the-middle/debug/ms": ["ms@2.1.3", "", {}, "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="],
+    "sandbox/@vercel/sandbox/jose": ["jose@6.2.3", "", {}, "sha512-YYVDInQKFJfR/xa3ojUTl8c2KoTwiL1R5Wg9YCydwH0x0B9grbzlg5HC7mMjCtUJjbQ/YnGEZIhI5tCgfTb4Hw=="],
 
-    "router/debug/ms": ["ms@2.1.3", "", {}, "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="],
-
-    "sandbox/debug/ms": ["ms@2.1.3", "", {}, "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="],
+    "sandbox/@vercel/sandbox/undici": ["undici@7.27.2", "", {}, "sha512-uZsKNuzQxDMUY6M3pIMvy5tvlGmtq8XJ2oLAkfRKGNu+1VQAIvLy2xIVG5ATZl5wDXl/tddByAWCizRbOme+TA=="],
 
     "send/mime-types/mime-db": ["mime-db@1.54.0", "", {}, "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ=="],
 
@@ -1832,8 +1820,6 @@
     "wrap-ansi-cjs/strip-ansi/ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
 
     "wrap-ansi/string-width/emoji-regex": ["emoji-regex@9.2.2", "", {}, "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg=="],
-
-    "@mapbox/node-pre-gyp/https-proxy-agent/debug/ms": ["ms@2.1.3", "", {}, "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="],
 
     "@ts-morph/common/minimatch/brace-expansion/balanced-match": ["balanced-match@1.0.2", "", {}, "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="],
 

--- a/docs/methodology.md
+++ b/docs/methodology.md
@@ -29,6 +29,10 @@ runs with its actuals recorded and the mismatch disclosed (`specMatched`). Its m
 rankings, but the leaderboard flags the provider with an explicit **Comparability warning** naming its
 observed allocation, so its ranks are never read as like-for-like with the compute-matched providers.
 
+Vercel exposes only a vCPU resource knob and derives memory at 2048 MB per vCPU, so requesting four
+vCPU reaches the 8 GiB target as a coupled point. Its SDK does not expose a disk-size knob; available
+disk is measured in the guest and disk-gated suites skip honestly when the observed mount is too small.
+
 ## Dimensions and metrics
 
 Results land on a closed, ordered set of [`DIMENSIONS`](../packages/schema/src/metrics.ts): `lifecycle`,
@@ -148,10 +152,11 @@ provider) and its empty-`<Identifier>` `<Result>` nodes would abort extraction â
 
 Providers differ in how their `@computesdk/*` adapter executes a command. Each declares a
 [`ProviderTransport`](../packages/schema/src/providers.ts) capability (`streaming`, `syncCapMs`,
-`detachedPoll`), and the harness selects a transport per step: a step that could outlast the provider's
-synchronous cap runs **detached + poll** where supported, everything else runs directly. This is why a
-multi-minute suite completes on a single-round-trip-capped provider (e.g. Daytona's server-side HTTP 408)
-without being Daytona-specific.
+`detachedPoll`), and the harness selects a transport per step: a step that could reach the integration's
+synchronous durability threshold runs **detached + poll** where supported, everything else runs directly.
+That threshold may be a measured/vendor limit (for example Daytona's server-side HTTP 408) or a
+conservative policy where one long connection is unvalidated. Vercel uses a 60-second policy threshold,
+so 20â€“80-minute suites such as Mastra launch detached and remain observable through short polls.
 
 ## The dataset pipeline
 

--- a/package.json
+++ b/package.json
@@ -27,7 +27,8 @@
         "@daytona/sdk": "0.192.0",
         "computesdk": "4.1.3",
         "microsandbox": "0.6.8",
-        "novita-sandbox": "2.0.6"
+        "novita-sandbox": "2.0.6",
+        "@vercel/sandbox": "2.9.2"
       },
       "xml": {
         "@nodable/compact-builder": "1.0.9",

--- a/packages/harness/src/lib/execute.test.ts
+++ b/packages/harness/src/lib/execute.test.ts
@@ -57,6 +57,15 @@ describe("selectTransport", () => {
 		expect(selectTransport(transport, 55 * MIN)).toBe("detached");
 		expect(selectTransport(transport, MIN)).toBe("sync");
 	});
+
+	it("detaches 20+ minute Vercel suites instead of holding one synchronous connection", () => {
+		const { transport } = getProvider("vercel");
+		for (const minutes of [20, 30]) {
+			expect(selectTransport(transport, minutes * MIN)).toBe("detached");
+		}
+		expect(selectTransport(transport, MIN)).toBe("detached");
+		expect(selectTransport(transport, MIN - 1)).toBe("sync");
+	});
 });
 
 describe("sandbox preamble", () => {

--- a/packages/providers/README.md
+++ b/packages/providers/README.md
@@ -7,17 +7,68 @@ assembled `providers` registry, and the toolchain image constants (`TOOLCHAIN_IM
 `TOOLCHAIN_VERSION`, `DAYTONA_SNAPSHOT_DEFAULT`).
 
 **Depends on:** `@sandbox-benchmarks/schema` (provider identity / `PROVIDERS`), `computesdk` and the
-`@computesdk/{e2b,daytona,modal}` wrappers (the unified provider runtime), plus the raw vendor SDK
-each wrapper peers on (`e2b`, `@daytonaio/sdk`, `modal`).
+`@computesdk/*` wrappers where they preserve the required surface, plus focused compatibility
+adapters over raw vendor SDKs only where required.
 
-**What lives here:** _not_ SDK wrappers. The `@computesdk/*` packages already adapt each raw vendor
-SDK to computesdk's universal sandbox (runCommand with daemon-backed streaming, filesystem,
-destroy). This package only holds what the framework can't infer: which factory builds each
-provider, and the benchmark's create-time policy — the pinned `TARGET_SPEC` and toolchain image
-(ADR-0003). The assembled `providers` registry joins the schema `PROVIDERS` metadata with the adapter
+**What lives here:** provider factories and focused compatibility adapters. Most `@computesdk/*`
+packages adapt their vendor SDK directly; Microsandbox uses a local `defineProvider` implementation.
+Vercel's local provider starts from ComputeSDK's upstream adapter but uses pinned `@vercel/sandbox`
+v2, because the published wrapper still pins a pre-VCR SDK. The package also
+owns benchmark create-time policy — the pinned `TARGET_SPEC` and toolchain image. The assembled
+`providers` registry joins the schema `PROVIDERS` metadata with the adapter
 map by id; both are keyed by `ProviderId`, so a one-sided provider is a compile error rather than a
 runtime check. Private glue lives in `src/lib/` and is never imported across a package boundary.
 
 The join also carries each provider's schema-owned `transport` capability (`ProviderTransport`:
 streaming, synchronous cap, detached+poll) onto the `ProviderConfig`, so the harness selects a
 per-step exec transport from the declared capability instead of hardcoding one provider's quirks.
+
+## Validate Vercel locally
+
+Vercel uses a project-issued OIDC token at runtime; do not pass a long-lived `VERCEL_TOKEN` to the
+benchmark process. Enable OIDC Federation in the linked project's Security settings, then run from a
+Vercel-authenticated checkout:
+
+Use the repository-pinned CLI (`./node_modules/.bin/vercel`), not a globally installed one: `vcr` is a
+recent subcommand, and an older global `vercel` fails with `"vcr" is not a valid subcommand`.
+
+```sh
+# Link the checkout and create the VCR repository once.
+./node_modules/.bin/vercel login
+./node_modules/.bin/vercel link
+./node_modules/.bin/vercel vcr add sandbox-benchmarks-toolchain-vercel
+./node_modules/.bin/vercel vcr login docker
+
+# Read the namespace back from the resolved config so this flow and CI cannot drift. Override the
+# defaults with VERCEL_TEAM_SLUG / VERCEL_PROJECT_NAME to publish into a fork's team or project.
+read -r vcr_owner vcr_project vcr_image <<<"$(bun -e 'import { config } from "@sandbox-benchmarks/providers";
+  console.log(`${config.vercelTeamSlug}/${config.vercelProjectName}`, config.vercelProjectName, config.vercelImage)')"
+
+# Build and publish the shared Vercel variant into that namespace.
+REGISTRY=vcr.vercel.com IMAGE_OWNER="$vcr_owner" packages/templates/images/build.sh
+./node_modules/.bin/vercel vcr push docker "${vcr_image##*/}" --project "$vcr_project"
+
+# Pull a short-lived project OIDC token. The Vercel SDK discovers it directly from the environment.
+./node_modules/.bin/vercel pull --yes
+./node_modules/.bin/vercel env pull .env.vercel.local
+set -a; . ./.env.vercel.local; set +a
+trap 'rm -f .env.vercel.local; docker logout vcr.vercel.com >/dev/null 2>&1 || true' EXIT
+unset VERCEL_TOKEN
+
+# Other providers skip when their credentials are absent; Vercel is required to boot and pass.
+REQUIRE_PROVIDERS=vercel bun apps/cli/src/bin/bench-smoke.ts
+```
+
+`vercel link` writes `.vercel/project.json` (the `team_*` / `prj_*` API IDs); CI supplies the same two
+values as `VERCEL_ORG_ID` / `VERCEL_PROJECT_ID` secrets instead, so no Git integration between the
+GitHub repository and the Vercel project is required. `VERCEL_PROJECT_NAME` must name the project that
+`prj_*` identifies — `vcr push --project` uses the name, so a mismatch fails loudly rather than
+publishing where nothing pulls from.
+
+The VCR path is rooted at the configured human-readable namespace. The `EXIT` trap removes the
+temporary environment file and Docker credential even if validation fails. The local ComputeSDK
+provider uses the v2 SDK's name-keyed lifecycle, detached current-session execution, non-resuming
+reconnects, and permanent delete cleanup. A conservative 60-second synchronous policy cap routes
+longer setup and suite steps through native detached execution. Filesystem methods are intentionally
+omitted because Vercel's high-level filesystem wrapper can auto-resume a stopped sandbox; the harness
+observes detached completion with short `cat` polls through the same non-resuming current session.

--- a/packages/providers/package.json
+++ b/packages/providers/package.json
@@ -22,7 +22,8 @@
     "arktype": "catalog:",
     "computesdk": "catalog:computesdk",
     "microsandbox": "catalog:computesdk",
-    "novita-sandbox": "catalog:computesdk"
+    "novita-sandbox": "catalog:computesdk",
+    "@vercel/sandbox": "catalog:computesdk"
   },
   "devDependencies": {
     "@repo/tsconfig": "workspace:*",

--- a/packages/providers/src/index.test.ts
+++ b/packages/providers/src/index.test.ts
@@ -61,6 +61,13 @@ describe("@sandbox-benchmarks/providers", () => {
 		expect(gvisor?.createOptions?.experimentalOptions).toBeUndefined();
 	});
 
+	it("configures Vercel through its custom provider factory", () => {
+		const adapter = providers.find((provider) => provider.name === "vercel");
+		expect(adapter?.requiredEnvVars).toEqual(["VERCEL_OIDC_TOKEN"]);
+		expect(adapter?.createOptions).toEqual({});
+		expect(adapter?.createCompute().name).toBe("vercel");
+	});
+
 	it("re-points the e2b wrapper at Novita without the e2b_ key-format guard", () => {
 		// Construction must accept an nvta_-prefixed key and still expose the universal manager surface
 		// the harness drives, with the mispointed snapshot/template managers removed (their every call

--- a/packages/providers/src/lib/adapters.ts
+++ b/packages/providers/src/lib/adapters.ts
@@ -1,8 +1,7 @@
-// The whole adapter layer: each schema provider id mapped to its computesdk factory plus the
-// benchmark's create-time policy. The @computesdk/* wrappers already adapt each raw vendor SDK to
-// computesdk's universal sandbox (runCommand with daemon-backed streaming, filesystem, destroy), so
-// nothing here re-wraps an SDK — these are pure config. Credentials are read from each provider's
-// env vars by its factory.
+// Each schema provider id maps to a ComputeSDK factory plus benchmark create-time policy. Prefer the
+// maintained @computesdk wrappers; Vercel is the deliberate exception because its published wrapper
+// still pins Sandbox v1 and cannot boot the shared VCR image supported by the latest native SDK.
+
 import { blaxel } from "@computesdk/blaxel";
 import { daytona } from "@computesdk/daytona";
 import { e2b } from "@computesdk/e2b";
@@ -19,6 +18,7 @@ import { e2bCommandsAsRoot } from "./e2b-root.ts";
 import { microsandboxCloudCompute, microsandboxLocalCompute } from "./microsandbox.ts";
 import { novitaCompute } from "./novita.ts";
 import type { ProviderAdapter } from "./types.ts";
+import { vercelCompute } from "./vercel.ts";
 
 // This project's dedicated Modal app — the namespace all sandbox-benchmarks sandboxes boot under.
 const MODAL_APP_NAME = "sandbox-benchmarks";
@@ -211,5 +211,11 @@ export const adapters: Record<ProviderId, ProviderAdapter> = {
 		// from `options.image` (computesdk's open CreateSandboxOptions passthrough), so, like modal's
 		// fromRegistry boot, this points directly at the published toolchain image; nothing to bake.
 		createOptions: { image: config.toolchainImage },
+	},
+	vercel: {
+		// @computesdk/vercel still targets Sandbox v1. Keep its defineProvider shape, but use the latest
+		// native SDK so the shared VCR image and v2 lifecycle/filesystem APIs remain available.
+		createCompute: () => vercelCompute({ image: config.vercelImage, vcpus: TARGET_SPEC.vcpus }),
+		createOptions: {},
 	},
 };

--- a/packages/providers/src/lib/vercel.test.ts
+++ b/packages/providers/src/lib/vercel.test.ts
@@ -1,0 +1,277 @@
+import { afterEach, describe, expect, it, spyOn } from "bun:test";
+import { APIError, Sandbox } from "@vercel/sandbox";
+import { VercelTransportError, vercelCompute } from "./vercel.ts";
+
+const config = {
+	image: `vcr.vercel.com/starsling-dev/sandbox-benchmarks/toolchain@sha256:${"a".repeat(64)}`,
+	vcpus: 4,
+};
+
+function nativeSandbox(overrides: Record<string, unknown> = {}): Sandbox {
+	return {
+		name: "sandbox-benchmarks-test",
+		status: "running",
+		createdAt: new Date("2026-07-31T00:00:00Z"),
+		timeout: 60_000,
+		tags: { "sandbox-benchmarks": "vercel" },
+		image: config.image,
+		region: "iad1",
+		vcpus: 4,
+		memory: 8192,
+		...overrides,
+	} as unknown as Sandbox;
+}
+
+const restores: Array<() => void> = [];
+afterEach(() => {
+	for (const restore of restores.reverse()) restore();
+	restores.length = 0;
+});
+
+function restore<T extends { mockRestore(): void }>(mock: T): T {
+	restores.push(() => mock.mockRestore());
+	return mock;
+}
+
+function mockCreate(native: Sandbox, capture?: (input: Record<string, unknown>) => void) {
+	return restore(
+		spyOn(Sandbox, "create").mockImplementation((async (input) => {
+			capture?.(input as unknown as Record<string, unknown>);
+			return native;
+		}) as typeof Sandbox.create),
+	);
+}
+
+function notFound(): APIError<unknown> {
+	return new APIError(new Response(null, { status: 404 }), { message: "not found" });
+}
+
+describe("Vercel ComputeSDK adapter", () => {
+	it("forwards image, timeout, env, resources, persistence, and at most five tags", async () => {
+		let params: Record<string, unknown> | undefined;
+		const native = nativeSandbox();
+		mockCreate(native, (input) => {
+			params = input;
+		});
+
+		const provider = vercelCompute(config);
+		const sandbox = await provider.sandbox.create({
+			name: native.name,
+			timeout: 123_456,
+			envs: { BENCH: "1" },
+			metadata: { a: 1, b: 2, c: 3, d: 4, ignored: 5 },
+		});
+
+		expect(sandbox.sandboxId).toBe(native.name);
+		expect(params).toMatchObject({
+			name: native.name,
+			image: config.image,
+			timeout: 123_456,
+			persistent: false,
+			resources: { vcpus: 4 },
+			env: { BENCH: "1" },
+			tags: {
+				"sandbox-benchmarks": "vercel",
+				"meta.a": "1",
+				"meta.b": "2",
+				"meta.c": "3",
+				"meta.d": "4",
+			},
+		});
+		expect(Object.keys(params?.tags as object)).toHaveLength(5);
+		expect(params?.tags).not.toHaveProperty("meta.ignored");
+		expect(params).not.toHaveProperty("token");
+		expect(params).not.toHaveProperty("teamId");
+		expect(params).not.toHaveProperty("projectId");
+		expect(provider.snapshot).toBeUndefined();
+	});
+
+	it("gets by name with resume explicitly disabled", async () => {
+		let params: Record<string, unknown> | undefined;
+		restore(
+			spyOn(Sandbox, "get").mockImplementation((async (input) => {
+				params = input as unknown as Record<string, unknown>;
+				return nativeSandbox();
+			}) as typeof Sandbox.get),
+		);
+		const found = await vercelCompute(config).sandbox.getById("sandbox-benchmarks-test");
+		expect(found?.sandboxId).toBe("sandbox-benchmarks-test");
+		expect(params).toEqual({
+			name: "sandbox-benchmarks-test",
+			resume: false,
+		});
+	});
+
+	it("uses a candidate VCR templateId as the native image override", async () => {
+		let params: Record<string, unknown> | undefined;
+		mockCreate(nativeSandbox(), (input) => {
+			params = input;
+		});
+		const candidate = `vcr.vercel.com/starsling-dev/sandbox-benchmarks/toolchain@sha256:${"b".repeat(64)}`;
+		await vercelCompute(config).sandbox.create({ templateId: candidate });
+		expect(params?.image).toBe(candidate);
+	});
+
+	it("lists the authoritative name prefix and reconnects every record with resume false", async () => {
+		let listParams: Record<string, unknown> | undefined;
+		const getParams: Record<string, unknown>[] = [];
+		restore(
+			spyOn(Sandbox, "list").mockImplementation((async (input) => {
+				listParams = input as Record<string, unknown>;
+				return {
+					toArray: async () => [
+						{ name: "sandbox-benchmarks-one" },
+						{ name: "sandbox-benchmarks-two" },
+					],
+				};
+			}) as typeof Sandbox.list),
+		);
+		restore(
+			spyOn(Sandbox, "get").mockImplementation((async (input) => {
+				getParams.push(input as unknown as Record<string, unknown>);
+				return nativeSandbox({ name: (input as { name: string }).name });
+			}) as typeof Sandbox.get),
+		);
+		const listed = await vercelCompute(config).sandbox.list();
+		expect(listParams).toMatchObject({ namePrefix: "sandbox-benchmarks-" });
+		expect(listed.map((sandbox) => sandbox.sandboxId)).toEqual([
+			"sandbox-benchmarks-one",
+			"sandbox-benchmarks-two",
+		]);
+		expect(getParams).toHaveLength(2);
+		for (const params of getParams) expect(params.resume).toBe(false);
+	});
+
+	it("permanently deletes running and stopped sandboxes, and treats 404 as clean", async () => {
+		let deleteCalls = 0;
+		const natives = [
+			nativeSandbox({ delete: async () => deleteCalls++ }),
+			nativeSandbox({ status: "stopped", delete: async () => deleteCalls++ }),
+		];
+		restore(
+			spyOn(Sandbox, "get").mockImplementation((async () => {
+				const next = natives.shift();
+				if (next) return next;
+				throw notFound();
+			}) as typeof Sandbox.get),
+		);
+		const provider = vercelCompute(config);
+		await provider.sandbox.destroy("running");
+		await provider.sandbox.destroy("stopped");
+		await expect(provider.sandbox.destroy("gone")).resolves.toBeUndefined();
+		expect(deleteCalls).toBe(2);
+	});
+
+	it("maps real getInfo fields and refreshes with resume false", async () => {
+		mockCreate(nativeSandbox());
+		let getParams: Record<string, unknown> | undefined;
+		restore(
+			spyOn(Sandbox, "get").mockImplementation((async (input) => {
+				getParams = input as unknown as Record<string, unknown>;
+				return nativeSandbox({ status: "stopped", timeout: undefined });
+			}) as typeof Sandbox.get),
+		);
+		const sandbox = await vercelCompute(config).sandbox.create();
+		expect(await sandbox.getInfo()).toEqual({
+			id: "sandbox-benchmarks-test",
+			provider: "vercel",
+			status: "stopped",
+			createdAt: new Date("2026-07-31T00:00:00Z"),
+			timeout: 0,
+			metadata: {
+				"sandbox-benchmarks": "vercel",
+				image: config.image,
+				region: "iad1",
+				vcpus: 4,
+				memoryMb: 8192,
+			},
+		});
+		expect(getParams?.resume).toBe(false);
+	});
+
+	it("maps command options and results through the current session without auto-resume", async () => {
+		let commandParams: Record<string, unknown> | undefined;
+		let outerCommandCalls = 0;
+		const provider = vercelCompute(config);
+		mockCreate(
+			nativeSandbox({
+				runCommand: async () => outerCommandCalls++,
+				currentSession: () => ({
+					runCommand: async (input: Record<string, unknown>) => {
+						commandParams = input;
+						return {
+							stdout: async () => "out",
+							stderr: async () => "err",
+							exitCode: 7,
+							durationMs: 42,
+						};
+					},
+				}),
+			}),
+		);
+		const sandbox = await provider.sandbox.create();
+		await expect(
+			sandbox.runCommand("printf test", {
+				cwd: "/work",
+				env: { BENCH: "1" },
+				timeout: 1234,
+			}),
+		).resolves.toEqual({
+			stdout: "out",
+			stderr: "err",
+			exitCode: 7,
+			durationMs: 42,
+		});
+		expect(commandParams).toMatchObject({
+			cmd: "/bin/sh",
+			args: ["-lc", "printf test"],
+			cwd: "/work",
+			env: { BENCH: "1" },
+			timeoutMs: 1234,
+		});
+		expect(outerCommandCalls).toBe(0);
+	});
+
+	it("maps detached execution and throws when launch transport fails", async () => {
+		let commandParams: Record<string, unknown> | undefined;
+		const provider = vercelCompute(config);
+		mockCreate(
+			nativeSandbox({
+				currentSession: () => ({
+					runCommand: async (input: Record<string, unknown>) => {
+						commandParams = input;
+						return {};
+					},
+				}),
+			}),
+		);
+		const sandbox = await provider.sandbox.create();
+		await expect(sandbox.runCommand("sleep 10", { background: true })).resolves.toMatchObject({
+			exitCode: 0,
+		});
+		expect(commandParams).toMatchObject({
+			cmd: "/bin/sh",
+			args: ["-lc", "sleep 10"],
+			detached: true,
+		});
+		mockCreate(
+			nativeSandbox({
+				currentSession: () => ({
+					runCommand: async () => Promise.reject(new Error("offline")),
+				}),
+			}),
+		);
+		const failedSandbox = await provider.sandbox.create();
+		await expect(failedSandbox.runCommand("true", { background: true })).rejects.toBeInstanceOf(
+			VercelTransportError,
+		);
+	});
+
+	it("exposes the unsupported-filesystem stub used by detached exec polling fallback", async () => {
+		mockCreate(nativeSandbox());
+		const sandbox = await vercelCompute(config).sandbox.create();
+		await expect(sandbox.filesystem.exists("/tmp/result")).rejects.toThrow(
+			"Filesystem operations are not supported by vercel's sandbox environment",
+		);
+	});
+});

--- a/packages/providers/src/lib/vercel.ts
+++ b/packages/providers/src/lib/vercel.ts
@@ -1,0 +1,183 @@
+// ComputeSDK provider based on packages/vercel/src/index.ts upstream, adapted to the latest
+// @vercel/sandbox. Vercel v2 is name-keyed, so its native name is the universal sandboxId. Reconnects
+// opt out of automatic resume: replacing a sandbox that died mid-benchmark would hide the loss.
+import { randomUUID } from "node:crypto";
+import type {
+	CommandResult,
+	CreateSandboxOptions,
+	RunCommandOptions,
+	SandboxInfo,
+	SandboxMethods,
+} from "@computesdk/provider";
+import { defineProvider } from "@computesdk/provider";
+import { APIError, Sandbox } from "@vercel/sandbox";
+
+const NAME_PREFIX = "sandbox-benchmarks-";
+const OWNER_TAG = "sandbox-benchmarks";
+const OWNER_VALUE = "vercel";
+const MAX_METADATA_TAGS = 4;
+
+export interface VercelConfig {
+	image: string;
+	vcpus: number;
+}
+
+export class VercelTransportError extends Error {
+	constructor(sandboxName: string, cause: unknown) {
+		super(
+			`Vercel command did not reach sandbox "${sandboxName}": ${cause instanceof Error ? cause.message : String(cause)}`,
+			{ cause },
+		);
+		this.name = "VercelTransportError";
+	}
+}
+
+function isNotFound(error: unknown): boolean {
+	return error instanceof APIError && error.response.status === 404;
+}
+
+function tags(metadata: Record<string, unknown> = {}): Record<string, string> {
+	return Object.fromEntries([
+		[OWNER_TAG, OWNER_VALUE],
+		...Object.entries(metadata)
+			.slice(0, MAX_METADATA_TAGS)
+			.map(([key, value]) => [`meta.${key}`, String(value)]),
+	]);
+}
+
+function mapStatus(status: Sandbox["status"]): SandboxInfo["status"] {
+	if (status === "running") return "running";
+	if (status === "stopped" || status === "aborted") return "stopped";
+	return "error";
+}
+
+function ensureRunning(sandbox: Sandbox): Sandbox {
+	if (sandbox.status !== "running") {
+		throw new Error(
+			`Vercel sandbox "${sandbox.name}" is ${sandbox.status}, not running; refusing to resume or replace it`,
+		);
+	}
+	return sandbox;
+}
+
+async function getNative(name: string): Promise<Sandbox> {
+	// resume defaults to true in v2. This explicit false is required for benchmark lifecycle honesty.
+	return Sandbox.get({ name, resume: false });
+}
+
+async function runShell(
+	sandbox: Sandbox,
+	command: string,
+	options?: RunCommandOptions,
+): Promise<CommandResult> {
+	const started = Date.now();
+	try {
+		ensureRunning(sandbox);
+		// Use the current session directly. Sandbox.runCommand() wraps this call in withResume(), which
+		// can silently boot a replacement VM after loss and invalidate the benchmark filesystem.
+		const result = await sandbox.currentSession().runCommand({
+			cmd: "/bin/sh",
+			args: ["-lc", command],
+			...(options?.cwd ? { cwd: options.cwd } : {}),
+			...(options?.env ? { env: options.env } : {}),
+			...(options?.timeout ? { timeoutMs: options.timeout } : {}),
+			...(options?.background ? { detached: true as const } : {}),
+		});
+
+		// A detached native command has been accepted by the guest. Do not wait: ComputeSDK's detached
+		// path observes completion through the done file while this command remains independent.
+		if (options?.background) {
+			return { stdout: "", stderr: "", exitCode: 0, durationMs: Date.now() - started };
+		}
+		const [stdout, stderr] = await Promise.all([result.stdout(), result.stderr()]);
+		return {
+			stdout,
+			stderr,
+			exitCode: result.exitCode ?? 1,
+			durationMs: result.durationMs ?? Date.now() - started,
+		};
+	} catch (error) {
+		// Never synthesize exit 127. Detached launch results are discarded by the harness, so only a
+		// thrown transport error can stop it from polling a done file for a command that never started.
+		throw new VercelTransportError(sandbox.name, error);
+	}
+}
+
+const methods: SandboxMethods<Sandbox, VercelConfig> = {
+	create: async (config, options?: CreateSandboxOptions) => {
+		if (options?.snapshotId) throw new Error("Vercel snapshots are not supported by this adapter");
+		const name = options?.name ?? `${NAME_PREFIX}${randomUUID()}`;
+		const sandbox = await Sandbox.create({
+			name,
+			image: options?.templateId ?? options?.image ?? config.image,
+			resources: { vcpus: config.vcpus },
+			persistent: false,
+			...(options?.timeout ? { timeout: options.timeout } : {}),
+			...(options?.envs ? { env: options.envs } : {}),
+			tags: tags(options?.metadata),
+		});
+		return { sandbox, sandboxId: sandbox.name };
+	},
+
+	getById: async (_config, sandboxId) => {
+		try {
+			const sandbox = await getNative(sandboxId);
+			return { sandbox, sandboxId: sandbox.name };
+		} catch (error) {
+			if (isNotFound(error)) return null;
+			throw error;
+		}
+	},
+
+	list: async (_config) => {
+		const listed = await Sandbox.list({ namePrefix: NAME_PREFIX });
+		const records = await listed.toArray();
+		return Promise.all(
+			records.map(async (record) => {
+				const sandbox = await getNative(record.name);
+				return { sandbox, sandboxId: record.name };
+			}),
+		);
+	},
+
+	destroy: async (_config, sandboxId) => {
+		try {
+			const sandbox = await getNative(sandboxId);
+			// ComputeSDK destroy means permanent resource cleanup. Vercel stop() only terminates the
+			// current VM session and leaves the named sandbox addressable; delete() removes the sandbox
+			// and all of its sessions/snapshots, including when its current session is already stopped.
+			await sandbox.delete();
+		} catch (error) {
+			if (isNotFound(error)) return;
+			throw error;
+		}
+	},
+
+	runCommand: runShell,
+
+	getInfo: async (sandbox) => {
+		const current = await getNative(sandbox.name);
+		return {
+			id: current.name,
+			provider: "vercel",
+			status: mapStatus(current.status),
+			createdAt: current.createdAt,
+			timeout: current.timeout ?? 0,
+			metadata: {
+				...(current.tags ?? {}),
+				image: current.image,
+				region: current.region,
+				vcpus: current.vcpus,
+				memoryMb: current.memory,
+			},
+		};
+	},
+
+	getUrl: async (sandbox, options) => ensureRunning(sandbox).currentSession().domain(options.port),
+};
+
+/** Build a ComputeSDK provider directly over @vercel/sandbox v2. No snapshot manager is declared. */
+export const vercelCompute = defineProvider<Sandbox, VercelConfig>({
+	name: "vercel",
+	methods: { sandbox: methods },
+});

--- a/packages/schema/src/providers.test.ts
+++ b/packages/schema/src/providers.test.ts
@@ -32,6 +32,7 @@ describe("@sandbox-benchmarks/schema providers", () => {
 			"modal-vm",
 			"namespace",
 			"novita",
+			"vercel",
 		]);
 	});
 

--- a/packages/schema/src/providers.ts
+++ b/packages/schema/src/providers.ts
@@ -21,7 +21,8 @@ export type ProviderId =
 	| "microsandbox-local"
 	| "microsandbox-cloud"
 	| "novita"
-	| "namespace";
+	| "namespace"
+	| "vercel";
 
 /** Can the SDK request a pinned target spec (vCPU / memory) at create() time? */
 export type SpecPinning = "settable" | "fixed" | "unknown";
@@ -40,9 +41,11 @@ export type SpecPinning = "settable" | "fixed" | "unknown";
  *     `onStdout`/`onStderr`)? All three shipped adapters drop those callbacks, so a long synchronous
  *     exec buffers silently. Modeled because a streaming path keeps a connection productive past an
  *     idle gateway cap; today it is uniformly `false`, so it does not yet tip the harness's choice.
- *   - `syncCapMs` — the longest a single *synchronous* exec round-trip is safe before the provider
- *     caps it, or `null` when uncapped. The conservative policy bound the harness compares a step's
- *     timeout budget against: a step that could run past it must not go synchronous. Daytona returns a
+ *   - `syncCapMs` — the configured durability threshold for a single *synchronous* exec round-trip,
+ *     or `null` when validated as uncapped. It may encode a vendor-enforced limit or a conservative
+ *     repository policy where long-lived synchronous transport has not been validated. The harness
+ *     compares each step's timeout budget against it: a step that could reach it must not go
+ *     synchronous. Daytona returns a
  *     server-side HTTP 408 on multi-minute synchronous execs while the process keeps running
  *     (`docs/evidence/daytona-exec-transport.md`); E2B's `commands.run` defaults to a 60s command
  *     timeout the computesdk wrapper never overrides.
@@ -147,8 +150,9 @@ export interface ProviderMeta {
  * so it clears the gate anyway. Blaxel's sandbox root is a RAM-derived tmpfs with no independent disk
  * knob, so it mounts a 40 GiB volume at the PTS data dir where the heavy suites write (see
  * packages/providers/src/lib/blaxel-volume.ts) — clearing the gate like the others. Only e2b/novita
- * (the `@e2b/cli` `template create` takes only `--cpu-count`/`--memory-mb`) and namespace
- * (`NamespaceConfig` has no disk field at all) still CANNOT express disk:
+ * (the `@e2b/cli` `template create` takes only `--cpu-count`/`--memory-mb`), namespace
+ * (`NamespaceConfig` has no disk field at all), and Vercel (resources exposes only vCPUs) still
+ * CANNOT express disk:
  * they run with actuals recorded and the heavy suites skip there, surfaced as an explicit coverage gap
  * in the leaderboard, never silently dropped.
  */
@@ -531,6 +535,38 @@ const REGISTRY: Record<ProviderId, Omit<ProviderMeta, "id">> = {
 			// this adapter gets — so this declaration depends on that degradation path (isUnsupportedFilesystem).
 			// Each poll is a sub-second exec far under the cap, so a multi-minute benchmark survives as a
 			// sequence of short calls.
+			detachedPoll: true,
+		},
+	},
+	vercel: {
+		displayName: "Vercel Sandbox",
+		website: "https://vercel.com/docs/sandbox",
+		sdkPackage: "@vercel/sandbox",
+		requiredEnvVars: ["VERCEL_OIDC_TOKEN"],
+		isolation: {
+			technology: "Firecracker microVM",
+			notes:
+				"Runs on Vercel's Hive build infrastructure and boots the shared Debian toolchain image mirrored into Vercel Container Registry.",
+		},
+		pricing: {
+			model: "unknown",
+			notes:
+				"Vercel bills active CPU separately from provisioned memory. The registry cannot model utilization-dependent active-CPU cost honestly, so economics remain unknown.",
+			sourceUrl: "https://vercel.com/docs/sandbox/pricing",
+		},
+		maturity: {
+			status: "beta",
+			notes:
+				"Custom ComputeSDK provider based on the upstream adapter and updated for the latest Vercel SDK; opt-in until a committed validation run exists.",
+		},
+		// Only vCPU is requested; Vercel derives memory at a fixed 2048 MB/vCPU ratio. Four vCPU
+		// therefore reaches this benchmark's 8 GiB target, but the dimensions are not independent.
+		specPinning: "fixed",
+		transport: {
+			// No hard vendor cap is claimed: long synchronous transport is unvalidated, so the repository's
+			// conservative 60s durability policy routes longer work to current-session detach + exec polling.
+			streaming: false,
+			syncCapMs: 60_000,
 			detachedPoll: true,
 		},
 	},

--- a/tooling/repo-checks/src/workflow-hardening.test.ts
+++ b/tooling/repo-checks/src/workflow-hardening.test.ts
@@ -6,6 +6,8 @@
 // (same precedent as workflow-registry-sync.test.ts); the rest is unit coverage of the pure checks
 // on synthetic drift so a regression names the offender. See ./lib/workflow-hardening.ts.
 import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
 import type { CheckoutStep } from "./lib/workflow-hardening.ts";
 import {
 	CI_LINT_WORKFLOW,
@@ -23,6 +25,7 @@ import {
 	TOOLCHAIN_WORKFLOW,
 	WORKFLOWS_DIR,
 } from "./lib/workflow-hardening.ts";
+import { findRepoRoot } from "./lib/workspace.ts";
 
 /** A no-op step — the body for fixtures whose step content is irrelevant to what they assert. */
 const NOOP_STEP = { run: "true" };
@@ -146,6 +149,50 @@ describe("checkCiLintGate", () => {
 		const errors = checkCiLintGate(loosened);
 		expect(errors).toHaveLength(1);
 		expect(errors[0]).toContain("--min-confidence high");
+	});
+});
+
+describe("Vercel CLI authentication", () => {
+	test("all Vercel jobs use the shared action without raw token minting", () => {
+		const root = findRepoRoot();
+		const workflowText = ["bench-smoke.yml", "bench-suite.yml", "toolchain-image.yml"]
+			.map((file) => readFileSync(join(root, WORKFLOWS_DIR, file), "utf8"))
+			.join("\n");
+		expect(workflowText.match(/uses: \.\/\.github\/actions\/vercel-auth/g)).toHaveLength(4);
+		expect(workflowText).not.toContain("api.vercel.com/v1/projects");
+		expect(workflowText).not.toContain("VERCEL_OIDC_TOKEN_FILE");
+		expect(workflowText).not.toContain("docker login vcr.vercel.com");
+		// Two best-effort `always()` fallbacks remain; the immediate post-mirror logout is fail-closed.
+		expect(workflowText.match(/docker logout vcr\.vercel\.com \|\| true/g)).toHaveLength(2);
+		expect(workflowText).toContain('vercel vcr push docker "$target_name"');
+		const toolchain = readFileSync(join(root, WORKFLOWS_DIR, "toolchain-image.yml"), "utf8");
+		expect(toolchain.indexOf("- name: Log out of VCR after mirror")).toBeGreaterThan(
+			toolchain.indexOf("- name: Mirror candidate into VCR"),
+		);
+		expect(toolchain.indexOf("- name: Log out of VCR after mirror")).toBeLessThan(
+			toolchain.indexOf("- name: Bake + verify candidate"),
+		);
+		expect(toolchain).toContain(
+			"- name: Log out of VCR after mirror\n        if: matrix.provider == 'vercel' && steps.vercel-vcr.outcome == 'success'\n        run: docker logout vcr.vercel.com\n",
+		);
+		expect(toolchain).not.toContain(
+			"- name: Log out of VCR after mirror\n        if: matrix.provider == 'vercel' && steps.vercel-vcr.outcome == 'success'\n        run: docker logout vcr.vercel.com || true",
+		);
+		expect(toolchain).toContain("- name: Ensure VCR logout\n        if: always()");
+	});
+
+	test("the composite masks the OIDC token and deletes its temporary env file before export", () => {
+		const root = join(findRepoRoot(), ".github/actions/vercel-auth");
+		const action = readFileSync(join(root, "action.yml"), "utf8");
+		const script = readFileSync(join(root, "auth.sh"), "utf8");
+		expect(action).toContain(`run: "\${GITHUB_ACTION_PATH}/auth.sh"`);
+		expect(script).toContain("pull --yes --non-interactive");
+		expect(script).toContain('env pull "$env_file" --yes --non-interactive');
+		expect(script).toContain("vcr login docker");
+		expect(script.indexOf('rm -f "$env_file" "$pull_env_file"')).toBeLessThan(
+			script.indexOf("printf '::add-mask::%s\\n'"),
+		);
+		expect(script.indexOf("printf '::add-mask::%s\\n'")).toBeLessThan(script.indexOf("GITHUB_ENV"));
 	});
 });
 


### PR DESCRIPTION
**ENG-226 — benchmark Vercel Sandbox, on a toolchain image VCR will actually accept**

Shipped as a 3-PR stack (merge bottom-up, each branch independently green):
1. #314 — toolchain: split the base image so every compressed layer is under 500 MB (v7)
2. #315 — toolchain: build + publish the Vercel variant to VCR
3. #316 — providers: register Vercel and run the benchmarks against it

↑ **This PR is #316 (3/3)**, based on #315.

**What landing this PR lets you check:** Vercel boots the newly built VCR image and runs benchmarks end to end. Dispatch `Toolchain image` to mirror + bake the Vercel cell, then run `bench-smoke` with Vercel credentials. Vercel is registered opt-in, so a missing credential skips rather than blocking a release.

---
Registers Vercel in the provider registry and wires it through the release and
benchmark lanes, so the VCR image published by the PR below is actually booted
and measured.

The adapter is built directly over @vercel/sandbox v2 rather than the published
@computesdk/vercel wrapper, which still pins Sandbox v1 and cannot boot a VCR
image. It keeps defineProvider's shape, so the harness sees the same universal
surface as every other provider.

Three lifecycle choices are deliberate, and all three exist to keep a lost
sandbox visible as a failed benchmark rather than a silently replaced one:
reconnects pass resume:false, commands run on the current session instead of
Sandbox.runCommand's withResume wrapper, and destroy uses delete() rather than
stop(). Filesystem methods are omitted for the same reason — the high-level
wrapper can auto-resume a stopped sandbox — so the harness observes detached
completion with short cat polls through the same non-resuming session.

A transport error never synthesizes exit 127: the harness discards detached
launch results, so only a thrown error stops it polling a done file for a command
that never started.

Adding vercel to ProviderId is what forces the size of this PR. REGISTRY and
adapters are Record<ProviderId, …> and the bake/promote/release-plan switches are
exhaustive over it, so the id, the adapter and every call site have to land in
one commit or the branch does not compile.

Vercel is registered as opt-in (beta, not release-required): a missing credential
skips its cell rather than blocking a release, until a committed run validates it.

Spec pinning is 'fixed' because only vCPU is requestable — memory follows at
2048 MB/vCPU — and disk is not expressible at all, so the heavy suites skip there
and that gap is surfaced in the leaderboard rather than hidden.
