### PR TITLE
ci: run the Chrome-backed figures suite as its own step

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,7 +1,8 @@
 name: CI
 
-# Runs the README's "command contract" on every PR (and every push to main): the same Biome
-# lint, typecheck, tests, and spell check a developer runs locally must pass before code can merge.
+# Runs the README's command contract on every PR (and every push to main): the browser-free local
+# checks must pass before code can merge, alongside a `figures` job that runs the Chrome-backed
+# screenshot suite on a hosted runner with the pinned browser.
 on:
   push:
     branches: [main]
@@ -85,3 +86,39 @@ jobs:
       # Spelling gate — typos (pinned in mise.toml); misspellings fail the build.
       - name: Spell (typos)
         run: bun run spell
+
+  # The Chrome-backed figures suite, kept out of `check` because it cannot share that job's runner:
+  # `starsling-ubuntu-24.04-2` runs the job as root, and Chrome refuses to start its sandbox as root
+  # ("Running as root without --no-sandbox is not supported"). Dropping the sandbox to fit the runner
+  # is the one thing setup-pinned-chrome exists to prevent, so the suite runs on the same HOSTED
+  # ubuntu-24.04 image update-leaderboard renders on — the environment that action is written for,
+  # and the one whose pinned browser produces the committed figures' bytes.
+  figures:
+    name: Figures screenshot (pinned Chrome)
+    runs-on: ubuntu-24.04
+    # Same fork-PR posture as `check`: this gate runs only for pushes and same-repo pull requests.
+    if: >-
+      github.event_name == 'push' ||
+      github.event.pull_request.head.repo.full_name == github.repository
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Set up Bun
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
+        with:
+          bun-version: 1.3.14
+
+      # setup-pinned-chrome reads the installed playwright-core to resolve its pin, so the install
+      # must precede it. --ignore-scripts keeps CI's zero-lifecycle-script posture: the browser is
+      # downloaded by the action, explicitly, and never by a postinstall.
+      - name: Install dependencies
+        run: bun install --frozen-lockfile --ignore-scripts
+
+      - name: Set up pinned headless Chrome
+        uses: ./.github/actions/setup-pinned-chrome
+
+      - name: Test figures screenshot
+        run: bun run test:figures

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,17 +19,22 @@ For local benches, copy [`.env.example`](./.env.example) to a gitignored `.env`.
 keys or paste them into issues/PRs — the repo-checks secret-hygiene gate fails CI if a credential
 file or secret token is tracked ([SECURITY.md](./SECURITY.md)).
 
-## Local checks (the gate)
+## Local checks (the browser-free gate)
 
-Green-on-your-machine means green-in-CI — the same command contract runs in both:
+The browser-free checks below are the shared local/CI baseline. CI runs the figures screenshot suite
+in a separate job that provisions pinned headless Chrome.
 
 ```sh
 bun install          # resolve the graph (frozen lockfile in CI)
 bun run typecheck    # tsc --noEmit per member
-bun run test         # bun test per member, incl. repo-checks invariants
+bun run test         # browser-free bun test per member, incl. repo-checks invariants
 bun run lint         # biome check; warnings fail
 bun run spell        # typos (via mise)
 ```
+
+The Chrome-backed figures screenshot suite is intentionally separate from the normal local gate:
+CI's `figures` job provisions its pinned headless Chrome on a hosted runner and runs
+`bun run test:figures` explicitly.
 
 PTS-catalog changes also have a drift gate:
 

--- a/README.md
+++ b/README.md
@@ -95,7 +95,8 @@ the Run model or builds a document never spawns a browser.
 |----------------------|-------------------------------------------------------------------------|
 | `bun install`        | Resolve the graph, symlink workspaces, install catalogs (≥7-day-old releases). |
 | `bun run typecheck`  | `tsc --noEmit` per member — proof of source-first/no-build.             |
-| `bun run test`       | `bun test` per member, including the repo-checks invariants.            |
+| `bun run test`       | Browser-free `bun test` per member, including repo-checks invariants, excluding the Chrome-backed figures suite. |
+| `bun run test:figures` | Chrome-backed figures screenshot tests; CI's `figures` job runs this on a hosted runner with pinned headless Chrome. |
 | `bun run lint`       | `biome check . --error-on-warnings` — CI gate; warnings fail (root-only Biome config). |
 | `bun run format`     | `biome format . --write` — formatting only (no import sorting / lint fixes). |
 | `bun run lint:fix`   | `biome check . --write` — formatting + import sorting + safe lint fixes. |
@@ -124,10 +125,12 @@ install-time postinstall.
 
 `.github/workflows/ci.yml` runs the command contract on every pull request and every push to
 `main`: `bun install --frozen-lockfile --ignore-scripts` → `bun run lint` (the Biome gate) →
-`bun run lint:shell` → `bun run lint:docker` → `bun run typecheck` → `bun run test` →
+`bun run lint:shell` → `bun run lint:docker` → `bun run typecheck` → browser-free `bun run test` →
 `bun run check:catalog-drift` → `bun run spell` (typos, set up via [mise](https://mise.jdx.dev)).
-A separate `ci-lint.yml` lints the workflows themselves (actionlint + zizmor). The same checks run
-locally, so green-on-your-machine means green-in-CI.
+A second `figures` job runs pinned-Chrome `bun run test:figures` on a hosted `ubuntu-24.04` runner —
+the same image that renders the committed figures, and the one where Chrome can keep its sandbox.
+A separate `ci-lint.yml` lints the workflows themselves (actionlint + zizmor). The browser-free
+checks run locally; CI additionally exercises the Chrome-backed figures suite with its pinned browser.
 
 CI runs on a maintainer-controlled runner, so it never executes fork-PR code — the gate runs only
 for pushes and same-repo pull requests. Anything that needs provider credentials additionally runs

--- a/package.json
+++ b/package.json
@@ -42,7 +42,8 @@
   },
   "scripts": {
     "typecheck": "bun --filter '!./' --filter '*' --if-present typecheck",
-    "test": "bun --filter '!./' --filter '*' --if-present test",
+    "test": "bun --filter '!@sandbox-benchmarks/figures' --if-present test",
+    "test:figures": "bun --filter @sandbox-benchmarks/figures test",
     "smoke": "bun --filter @sandbox-benchmarks/cli smoke",
     "format": "biome format . --write",
     "lint": "biome check . --error-on-warnings",


### PR DESCRIPTION
**Provider isolation on the realworld figures — a chart should say what each bar was confined by.**

Shipped as a 5-PR stack (merge bottom-up, each branch independently green):
1. #321 — ci: run the Chrome-backed figures suite as its own step
2. #322 — precondition: pin that the probe's isolation fields survive shard aggregation
3. #323 — model: derive a provider's isolation chip (observed runtime, else registry declaration)
4. #324 — render: draw the chip under each provider's bar label
5. #325 — wiring: pass the registry declaration through, and commit the redrawn figures

Split out of `bench/provider-sandbox-detection`, whose probe half already landed as #319.

↑ **This PR is #321 (1/5)**, based on `main`.

---

`bun run test` launched the developer's system Chrome, because the figures package's
screenshot suite rode along in the default gate. That made the local command contract
depend on a browser the contract never provisions.

Splits the browser-free tests from the Chrome-backed ones: `bun run test` now excludes
@sandbox-benchmarks/figures, and `bun run test:figures` runs it explicitly. CI keeps
full coverage by provisioning its pinned headless Chrome and running the new script as a
separate step, so nothing stops being tested — it just stops being tested by accident.

README and CONTRIBUTING are updated to describe the gate as browser-free with the
figures suite named separately.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Split browser-free tests from the Chrome-backed figures suite so local runs never launch system Chrome. CI keeps full coverage by running the figures tests in a separate hosted job with pinned headless Chrome.

- **Refactors**
  - `test` now excludes `@sandbox-benchmarks/figures`; added `test:figures`.
  - New `figures` job on hosted `ubuntu-24.04` using `./.github/actions/setup-pinned-chrome`, installs with `--ignore-scripts`, and runs only on pushes and same-repo PRs.
  - README and CONTRIBUTING updated to call out the browser-free gate and the separate figures suite.

<sup>Written for commit 5bbe5125352b4a3b8987e9d533e8e68d7a63cc1b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/starslingdev/hpc-sandbox-benchmarks/pull/321?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Testing**
  * Separated browser-free checks from Chrome-based figure screenshot tests.
  * Added a dedicated command for running figure tests with headless Chrome.
  * CI now runs figure tests in a dedicated hosted Ubuntu job.

* **Documentation**
  * Clarified local testing, CI behavior, workflow checks, and available test commands.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->