### PR TITLE
test(results): pin that the probe's isolation fields survive aggregation

### DIFF
--- a/packages/results/src/lib/aggregate.test.ts
+++ b/packages/results/src/lib/aggregate.test.ts
@@ -524,7 +524,14 @@ describe("aggregateRuns", () => {
 		const record = {
 			source: "mise/system-provider" as const,
 			sourceFile: "system/system-provider.json",
-			fields: [{ path: "asn", value: "AS64500" }],
+			fields: [
+				{ path: "asn", value: "AS64500" },
+				{ path: "isolation_runtime", value: "firecracker" },
+				{ path: "machine_vmm", value: "firecracker" },
+				{ path: "machine_confidence", value: "confirmed" },
+				{ path: "container_runtime", value: "none" },
+				{ path: "isolation_why", value: "ACPI names Firecracker" },
+			],
 		};
 		const a = shard([
 			{
@@ -554,6 +561,8 @@ describe("aggregateRuns", () => {
 			"mise/system-provider",
 			"phoronix/result-file-to-json",
 		]);
+		const isolation = metadata?.find((m) => m.source === "mise/system-provider");
+		expect(isolation?.fields).toEqual(record.fields);
 	});
 
 	it("throws on a shard-identity mismatch and on empty input", () => {

--- a/packages/results/src/lib/aggregate.ts
+++ b/packages/results/src/lib/aggregate.ts
@@ -174,6 +174,9 @@ function mergeProvider(providerId: string, entries: readonly ReplicateSlice[]): 
 	for (const { slice, replicateIndex } of entries) {
 		const ids = observedMixtureIds(slice.observedSpecs);
 		if (!providerReportedNothing(slice)) sandboxSpecReadings.push(slice.observedSpecs);
+		// Preserve the complete provider probe record here: foldHostMetadata removes only volatile
+		// timestamps, so exact isolation fields (runtime, VMM, confidence, scores, and evidence)
+		// remain available to figure generation after shards are merged.
 		for (const record of slice.hostMetadata ?? []) hostMetadataInputs.push({ record, ids });
 		for (const suite of slice.suitesCovered) suitesCovered.add(suite);
 


### PR DESCRIPTION
**Provider isolation on the realworld figures — a chart should say what each bar was confined by.**

Shipped as a 5-PR stack (merge bottom-up, each branch independently green):
1. #321 — ci: run the Chrome-backed figures suite as its own step
2. #322 — precondition: pin that the probe's isolation fields survive shard aggregation
3. #323 — model: derive a provider's isolation chip (observed runtime, else registry declaration)
4. #324 — render: draw the chip under each provider's bar label
5. #325 — wiring: pass the registry declaration through, and commit the redrawn figures

Split out of `bench/provider-sandbox-detection`, whose probe half already landed as #319.

↑ **This PR is #322 (2/5)**, based on #321.

---

The provider probe now publishes exact isolation facts (runtime, VMM, confidence,
evidence) in its `mise/system-provider` record, and figure generation is about to read
them out of the *aggregated* run. Nothing asserted they get that far: foldHostMetadata
strips volatile timestamps, and a future widening of that strip is the failure mode —
it would silently blank the isolation chip rather than break a build.

Extends the existing host-metadata merge test to carry the full isolation field set and
assert it round-trips unchanged, and records at the merge site why the record is kept
whole. Behaviour is unchanged; this only locks in the precondition the figures work
depends on.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Ensure the provider probe’s isolation fields survive shard aggregation unchanged so figures can read them from the merged run. Expands the host-metadata merge test to include the full field set and assert an exact round-trip, and adds a note in `aggregate.ts` to keep the full `mise/system-provider` record; no behavior change.

<sup>Written for commit 0b8bd74d0883edd37d3752b4431053543e95db93. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/starslingdev/hpc-sandbox-benchmarks/pull/322?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

