### PR TITLE
feat(figures): derive a provider's isolation chip in the figure model

### DIFF
--- a/packages/figures/src/index.ts
+++ b/packages/figures/src/index.ts
@@ -40,6 +40,7 @@ export {
 export {
 	type BarSegment,
 	buildRealworldFigureModel,
+	type FigureIsolation,
 	type FigureModelInput,
 	type FigureProvider,
 	type PipelineBar,

--- a/packages/figures/src/model.test.ts
+++ b/packages/figures/src/model.test.ts
@@ -67,6 +67,81 @@ function build(providers: ProviderRun[]) {
 }
 
 describe("buildRealworldFigureModel", () => {
+	it("uses concise provider titles and exact aggregated isolation runtimes", () => {
+		const withIsolation = (providerId: string, runtime: string): ProviderRun =>
+			provider(providerId, [metric(CLONE, [1, 2]), metric(INSTALL, [30, 32])], {
+				hostMetadata: [
+					{
+						source: "mise/system-provider",
+						sourceFile: "system/system-provider.json",
+						fields: [
+							{ path: "isolation_runtime", value: runtime },
+							{ path: "machine_vmm", value: runtime },
+						],
+					},
+				],
+			});
+		const model = buildRealworldFigureModel({
+			run: run([
+				withIsolation("namespace", "firecracker"),
+				withIsolation("daytona-vm", "firecracker"),
+				withIsolation("modal-gvisor", "gvisor"),
+				withIsolation("microsandbox-cloud", "libkrun"),
+			]),
+			metrics: METRICS,
+			providers: [
+				{
+					id: "namespace",
+					displayName: "Namespace",
+					isolationTechnology: "microVM (dedicated instance)",
+				},
+				{
+					id: "daytona-vm",
+					displayName: "Daytona (VM)",
+					isolationTechnology: "microVM (Linux VM)",
+				},
+				{
+					id: "modal-gvisor",
+					displayName: "Modal (gVisor)",
+					isolationTechnology: "gVisor container",
+				},
+				{
+					id: "microsandbox-cloud",
+					displayName: "Microsandbox Cloud",
+					isolationTechnology: "libkrun microVM (cloud)",
+				},
+			],
+			suites: SUITES,
+		});
+
+		expect(model.providers).toEqual([
+			{
+				id: "namespace",
+				name: "Namespace",
+				specMatched: true,
+				isolation: { kind: "microVM", technology: "Firecracker" },
+			},
+			{
+				id: "daytona-vm",
+				name: "Daytona",
+				specMatched: true,
+				isolation: { kind: "microVM", technology: "Firecracker" },
+			},
+			{
+				id: "modal-gvisor",
+				name: "Modal",
+				specMatched: true,
+				isolation: { kind: "Userspace", technology: "gVisor" },
+			},
+			{
+				id: "microsandbox-cloud",
+				name: "microsandbox",
+				specMatched: true,
+				isolation: { kind: "microVM", technology: "libkrun" },
+			},
+		]);
+	});
+
 	it("charts a suite two environments completed, named from its task labels", () => {
 		const model = build([
 			provider("alpha", [metric(CLONE, [1, 2]), metric(INSTALL, [30, 32])]),

--- a/packages/figures/src/model.ts
+++ b/packages/figures/src/model.ts
@@ -64,6 +64,14 @@ export interface FigureProvider {
 	readonly name: string;
 	/** False when the run disclosed an off-target allocation — the chart daggers the label. */
 	readonly specMatched: boolean;
+	/** The isolation subtitle rendered beneath the provider title, when declared or detected. */
+	readonly isolation?: FigureIsolation;
+}
+
+/** The two segments shown in a provider row's isolation chip. */
+export interface FigureIsolation {
+	readonly kind: string;
+	readonly technology: string;
 }
 
 export interface RealworldFigureModel {
@@ -81,12 +89,95 @@ export interface FigureModelInput {
 	readonly metrics: readonly Pick<MetricDef, "id" | "label">[];
 	/** Provider display names. String-keyed on purpose: the run side carries provider ids as
 	 *  strings, and the registry's narrower `ProviderId` union assigns into this cleanly. */
-	readonly providers: readonly { readonly id: string; readonly displayName: string }[];
+	readonly providers: readonly {
+		readonly id: string;
+		readonly displayName: string;
+		/** Registry declaration; host metadata may provide a more specific observed runtime. */
+		readonly isolationTechnology?: string;
+	}[];
 	/** The suite registry: which dimension a suite measures, canonical task order, disk floors. */
 	readonly suites: Readonly<Record<string, Pick<Suite, "dimensions" | "metrics" | "minDiskGb">>>;
 }
 
 const round = (v: number, dp: number) => Number(v.toFixed(dp));
+
+/** The chart uses concise vendor names while the full registry names remain in the Markdown tables. */
+function figureProviderName(providerId: string, displayName: string): string {
+	if (providerId.startsWith("daytona")) return "Daytona";
+	if (providerId.startsWith("modal")) return "Modal";
+	if (providerId.startsWith("microsandbox")) return "microsandbox";
+	return displayName;
+}
+
+/** Map the isolation probe's stable runtime ids to the short, reader-facing chip vocabulary. */
+function isolationFromRuntime(runtime: string | undefined): FigureIsolation | undefined {
+	if (!runtime) return undefined;
+	const normalized = runtime.trim().toLowerCase();
+	if (!normalized || ["unknown", "none", "not-observable"].includes(normalized)) return undefined;
+	if (normalized.includes("firecracker")) return { kind: "microVM", technology: "Firecracker" };
+	if (normalized.includes("libkrun") || normalized === "krunvm") {
+		return { kind: "microVM", technology: "libkrun" };
+	}
+	if (normalized.includes("gvisor")) return { kind: "Userspace", technology: "gVisor" };
+	if (normalized.includes("kata")) return { kind: "microVM", technology: "Kata" };
+	if (normalized.includes("cloud-hypervisor")) {
+		return { kind: "microVM", technology: "Cloud Hypervisor" };
+	}
+	if (normalized.includes("crosvm")) return { kind: "microVM", technology: "crosvm" };
+	if (normalized.includes("sysbox")) return { kind: "Container", technology: "Sysbox" };
+	if (normalized.includes("lxc")) return { kind: "Container", technology: "LXC" };
+	if (normalized.includes("oci") || normalized.includes("container")) {
+		return { kind: "Container", technology: "OCI" };
+	}
+	if (normalized.includes("microvm") || normalized === "vm") {
+		return { kind: "microVM", technology: normalized === "vm" ? "VM" : "microVM" };
+	}
+	return undefined;
+}
+
+/** Turn a registry declaration into the same compact chip when no exact probe result is available. */
+function isolationFromDeclaration(declared: string | undefined): FigureIsolation | undefined {
+	if (!declared) return undefined;
+	const normalized = declared.toLowerCase();
+	if (normalized.includes("firecracker")) return { kind: "microVM", technology: "Firecracker" };
+	if (normalized.includes("libkrun")) return { kind: "microVM", technology: "libkrun" };
+	if (normalized.includes("gvisor")) return { kind: "Userspace", technology: "gVisor" };
+	if (normalized.includes("kata")) return { kind: "microVM", technology: "Kata" };
+	if (normalized.includes("microvm") || normalized.includes("vm")) {
+		const detail = declared.match(/\(([^)]+)\)/)?.[1];
+		return { kind: "microVM", technology: detail ?? "VM" };
+	}
+	if (normalized.includes("container")) return { kind: "Container", technology: "OCI" };
+	return undefined;
+}
+
+/** Read the dominant exact runtime from the aggregated mise/system-provider records. */
+function observedIsolationRuntime(provider: ProviderRun): string | undefined {
+	const paths = ["isolation_runtime", "machine_vmm", "container_runtime"];
+	for (const path of paths) {
+		const counts = new Map<string, number>();
+		for (const record of provider.hostMetadata ?? []) {
+			if (record.source !== "mise/system-provider") continue;
+			const value = record.fields.find((field) => field.path === path)?.value?.trim();
+			if (!value || ["unknown", "none", "not-observable"].includes(value.toLowerCase())) continue;
+			counts.set(value, (counts.get(value) ?? 0) + (record.sandboxes ?? 1));
+		}
+		const winner = [...counts.entries()].sort(
+			([valueA, countA], [valueB, countB]) => countB - countA || valueA.localeCompare(valueB, "en"),
+		)[0]?.[0];
+		if (winner) return winner;
+	}
+	return undefined;
+}
+
+function isolationFor(
+	provider: ProviderRun,
+	declared: string | undefined,
+): FigureIsolation | undefined {
+	return (
+		isolationFromRuntime(observedIsolationRuntime(provider)) ?? isolationFromDeclaration(declared)
+	);
+}
 
 export function buildRealworldFigureModel(input: FigureModelInput): RealworldFigureModel {
 	const { run, metrics, providers, suites } = input;
@@ -188,10 +279,17 @@ export function buildRealworldFigureModel(input: FigureModelInput): RealworldFig
 
 	return {
 		suites: chartable,
-		providers: rendered.map((p) => ({
-			id: p.providerId,
-			name: displayName.get(p.providerId) ?? p.providerId,
-			specMatched: p.specMatched !== false,
-		})),
+		providers: rendered.map((p) => {
+			const isolation = isolationFor(
+				p,
+				providers.find((meta) => meta.id === p.providerId)?.isolationTechnology,
+			);
+			return {
+				id: p.providerId,
+				name: figureProviderName(p.providerId, displayName.get(p.providerId) ?? p.providerId),
+				specMatched: p.specMatched !== false,
+				...(isolation ? { isolation } : {}),
+			};
+		}),
 	};
 }


### PR DESCRIPTION
**Provider isolation on the realworld figures — a chart should say what each bar was confined by.**

Shipped as a 5-PR stack (merge bottom-up, each branch independently green):
1. #321 — ci: run the Chrome-backed figures suite as its own step
2. #322 — precondition: pin that the probe's isolation fields survive shard aggregation
3. #323 — model: derive a provider's isolation chip (observed runtime, else registry declaration)
4. #324 — render: draw the chip under each provider's bar label
5. #325 — wiring: pass the registry declaration through, and commit the redrawn figures

Split out of `bench/provider-sandbox-detection`, whose probe half already landed as #319.

↑ **This PR is #323 (3/5)**, based on #322.

---

A realworld chart compares wall-clock across providers that are not confining code the
same way — a Firecracker microVM and a gVisor sandbox sit in the same bar chart with
nothing on the figure saying so. The isolation probe records the exact runtime per
sandbox, but the figure model had no place to put it.

Adds `FigureIsolation` (kind + technology) as an optional field on `FigureProvider`,
resolved per provider by preferring the observed runtime over the registry declaration:
the aggregated `mise/system-provider` records are read for `isolation_runtime`, then
`machine_vmm`, then `container_runtime`, taking the value covering the most sandboxes
and ignoring the probe's `unknown`/`none`/`not-observable` sentinels; the registry's
declared `isolationTechnology` is the fallback when no sandbox observed one. Both paths
map onto one short vocabulary so a chip reads the same whichever way it was resolved.

Also shortens the charted provider title to the vendor (Daytona, Modal, microsandbox) —
the variant is what the chip now disambiguates, and the full registry names stay in the
Markdown tables.

Nothing renders the field yet; `isolation` is optional, so existing chart output is
byte-identical. The chart layer consumes it in the next PR.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds isolation chip data to figure providers and shortens provider titles to vendor names. No rendering change; chart output stays identical.

- **New Features**
  - Adds optional `isolation` to `FigureProvider` as `FigureIsolation { kind, technology }`, resolved by preferring aggregated `mise/system-provider` fields (`isolation_runtime` → `machine_vmm` → `container_runtime`), ignoring `unknown`/`none`/`not-observable`, then falling back to registry `isolationTechnology`; both paths map to a small, consistent vocabulary.
  - Uses concise vendor titles in figures (Daytona, Modal, microsandbox) and exports `FigureIsolation`; full registry names remain in Markdown tables.

<sup>Written for commit 3d925529adb56ee437281d253245273a4d83e4d4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/starslingdev/hpc-sandbox-benchmarks/pull/323?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

