### PR TITLE
feat(figures): draw the isolation chip under each provider's bar label

### DIFF
--- a/packages/figures/src/chart/html.test.ts
+++ b/packages/figures/src/chart/html.test.ts
@@ -89,6 +89,30 @@ describe("pipelineChartHtml", () => {
 		expect(html).toContain("failed · install exceeded stop");
 	});
 
+	it("renders isolation as a segmented subtitle chip", () => {
+		const isolated = {
+			...FIXTURE,
+			providers: FIXTURE.providers.map((provider) =>
+				provider.id === "alpha"
+					? {
+							...provider,
+							name: "Namespace",
+							isolation: { kind: "microVM", technology: "Firecracker" },
+						}
+					: provider,
+			),
+		};
+		const rendered = pipelineChartHtml(
+			buildPipelineChartModel(
+				isolated.suites[0] as (typeof isolated.suites)[number],
+				isolated,
+				"n",
+			),
+		);
+		expect(rendered).toContain('class="isolation-chip"');
+		expect(rendered).toContain("<span>microVM</span><span>Firecracker</span>");
+	});
+
 	it("escapes interpolated text and renders the note's inline markdown", () => {
 		const spiky = pipelineChartHtml(
 			buildPipelineChartModel(suite, FIXTURE, "a **sum of medians** of `p50 <& friends>`"),

--- a/packages/figures/src/chart/html.ts
+++ b/packages/figures/src/chart/html.ts
@@ -133,7 +133,11 @@ h1 { margin: 0; font: 500 24px/32px ${HEADING}; color: ${pageColors.fg}; }
 .legend-note { font: 400 10px/15px ${MONO}; letter-spacing: 0.14em; text-transform: uppercase; color: ${pageColors.muted50}; }
 .row { display: flex; align-items: center; gap: ${COLUMN_GAP}px; min-height: ${BAR_HEIGHT}px; }
 .row + .row { margin-top: ${ROW_GAP}px; }
-.provider { flex: 0 0 ${LABEL_COLUMN}px; font: 400 12px/16px ${MONO}; color: ${pageColors.fg90}; }
+.provider { flex: 0 0 ${LABEL_COLUMN}px; display: flex; flex-direction: column; align-items: flex-start; gap: 3px; font: 400 12px/16px ${MONO}; color: ${pageColors.fg90}; }
+.provider-title { white-space: nowrap; }
+.isolation-chip { display: inline-flex; align-items: stretch; overflow: hidden; border: 1px solid ${pageColors.muted40}; border-radius: 4px; font: 400 9px/13.5px ${MONO}; color: ${pageColors.muted70}; white-space: nowrap; }
+.isolation-chip span { padding: 1px 4px; }
+.isolation-chip span + span { border-left: 1px solid ${pageColors.muted40}; color: ${pageColors.teal}; }
 .bar { display: flex; align-items: center; gap: ${TOTAL_GAP}px; }
 .track { display: flex; gap: ${SEGMENT_GAP}px; height: ${BAR_HEIGHT}px; }
 .segment { flex-shrink: 1; flex-basis: 0; }
@@ -148,6 +152,15 @@ h1 { margin: 0; font: 500 24px/32px ${HEADING}; color: ${pageColors.fg}; }
 `;
 
 export function pipelineChartHtml(model: PipelineChartModel): string {
+	const providerMarkup = (
+		label: string,
+		isolation: PipelineChartModel["bars"][number]["isolation"],
+	): string => {
+		const chip = isolation
+			? `<span class="isolation-chip"><span>${escapeHtml(isolation.kind)}</span><span>${escapeHtml(isolation.technology)}</span></span>`
+			: "";
+		return `<span class="provider"><span class="provider-title">${escapeHtml(label)}</span>${chip}</span>`;
+	};
 	const legend = model.legend
 		.map(
 			(entry) =>
@@ -164,7 +177,7 @@ export function pipelineChartHtml(model: PipelineChartModel): string {
 			.join("");
 		const badge = bar.fastest ? `<span class="badge">fastest</span>` : "";
 		return (
-			`<div class="row"><span class="provider">${escapeHtml(bar.label)}</span>` +
+			`<div class="row">${providerMarkup(bar.label, bar.isolation)}` +
 			`<div class="bar"><div class="track" style="width: ${px(bar.scaleFraction * TRACK_WIDTH)};">${segments}</div>` +
 			`<span class="value"><span class="total">${escapeHtml(bar.total)}</span>${badge}</span></div></div>`
 		);
@@ -172,7 +185,7 @@ export function pipelineChartHtml(model: PipelineChartModel): string {
 
 	const incompleteRows = model.incomplete.map(
 		(row) =>
-			`<div class="row incomplete"><span class="provider">${escapeHtml(row.label)}</span>` +
+			`<div class="row incomplete">${providerMarkup(row.label, row.isolation)}` +
 			`<span class="gap">${escapeHtml(row.outcome)} · ${escapeHtml(row.reason)}</span></div>`,
 	);
 

--- a/packages/figures/src/chart/model.test.ts
+++ b/packages/figures/src/chart/model.test.ts
@@ -23,6 +23,30 @@ describe("buildPipelineChartModel", () => {
 		]);
 	});
 
+	it("keeps the isolation chip separate from the concise provider title", () => {
+		const isolated = {
+			...FIXTURE,
+			providers: FIXTURE.providers.map((provider) =>
+				provider.id === "alpha"
+					? {
+							...provider,
+							name: "Daytona",
+							isolation: { kind: "microVM", technology: "Firecracker" },
+						}
+					: provider,
+			),
+		};
+		const chart = buildPipelineChartModel(
+			isolated.suites[0] as (typeof isolated.suites)[number],
+			isolated,
+			"n",
+		);
+		expect(chart.bars.find((bar) => bar.label === "Daytona")?.isolation).toEqual({
+			kind: "microVM",
+			technology: "Firecracker",
+		});
+	});
+
 	it("scales every bar against the run's slowest charted total", () => {
 		// Beta (400 s) is the run's slowest bar, so it IS the scale; Alpha (100 s) is a
 		// quarter of it. This ratio — not a per-chart maximum — is what makes a second the

--- a/packages/figures/src/chart/model.ts
+++ b/packages/figures/src/chart/model.ts
@@ -21,7 +21,12 @@
  *    outcome and reason. Dropping them would turn a chart that discloses its gaps into one
  *    that appears to have none.
  */
-import type { FigureProvider, PipelineSuite, RealworldFigureModel } from "../model.ts";
+import type {
+	FigureIsolation,
+	FigureProvider,
+	PipelineSuite,
+	RealworldFigureModel,
+} from "../model.ts";
 import type { PhaseId } from "../phases.ts";
 import { PHASE_RAMP, phaseOf } from "../phases.ts";
 import { formatSeconds } from "./format.ts";
@@ -40,6 +45,8 @@ export interface ChartSegment {
 export interface ChartBar {
 	/** Display label. Off-spec providers carry the report's dagger: `name †`. */
 	readonly label: string;
+	/** The provider's compact isolation chip, when metadata was available. */
+	readonly isolation?: FigureIsolation;
 	/** Formatted total, e.g. `61.9 s` — the sum of the segments' medians. */
 	readonly total: string;
 	/** This bar's length as a fraction of the SHARED scale (the run's slowest charted
@@ -53,6 +60,7 @@ export interface ChartBar {
 /** An environment disclosed as not having completed the suite: outcome and reason, no bar. */
 export interface ChartIncompleteRow {
 	readonly label: string;
+	readonly isolation?: FigureIsolation;
 	readonly outcome: string;
 	readonly reason: string;
 }
@@ -97,8 +105,14 @@ function requireProvider(
 /** The off-spec badge on the provider name is a bordered pill on the page; the report and
  *  these charts draw it as the plain dagger. The disclosure survives either way, which is
  *  the part that matters. */
-function providerLabel(provider: FigureProvider): string {
-	return provider.specMatched ? provider.name : `${provider.name} †`;
+function providerPresentation(provider: FigureProvider): {
+	label: string;
+	isolation?: FigureIsolation;
+} {
+	return {
+		label: provider.specMatched ? provider.name : `${provider.name} †`,
+		...(provider.isolation ? { isolation: provider.isolation } : {}),
+	};
 }
 
 /** Shared x-scale across the pipeline charts: the slowest charted total in the run — and 0,
@@ -151,7 +165,7 @@ export function buildPipelineChartModel(
 		// 0/0 NaN — which CSS reads as a broken flex/width, silently collapsing the bar. A
 		// zero-duration bar or segment draws at zero width instead.
 		bars: bars.map((bar) => ({
-			label: providerLabel(requireProvider(providerById, bar.provider)),
+			...providerPresentation(requireProvider(providerById, bar.provider)),
 			total: formatSeconds(bar.totalS),
 			scaleFraction: pipelineScaleMaxS > 0 ? bar.totalS / pipelineScaleMaxS : 0,
 			fastest: bar.totalS === bestTotal,
@@ -162,7 +176,7 @@ export function buildPipelineChartModel(
 			})),
 		})),
 		incomplete: suite.incomplete.map((row) => ({
-			label: providerLabel(requireProvider(providerById, row.provider)),
+			...providerPresentation(requireProvider(providerById, row.provider)),
 			outcome: row.outcome,
 			reason: row.reason,
 		})),


### PR DESCRIPTION
**Provider isolation on the realworld figures — a chart should say what each bar was confined by.**

Shipped as a 5-PR stack (merge bottom-up, each branch independently green):
1. #321 — ci: run the Chrome-backed figures suite as its own step
2. #322 — precondition: pin that the probe's isolation fields survive shard aggregation
3. #323 — model: derive a provider's isolation chip (observed runtime, else registry declaration)
4. #324 — render: draw the chip under each provider's bar label
5. #325 — wiring: pass the registry declaration through, and commit the redrawn figures

Split out of `bench/provider-sandbox-detection`, whose probe half already landed as #319.

↑ **This PR is #324 (4/5)**, based on #323.

---

Renders the isolation the model now resolves, so a reader can see that a chart's
fastest bar and its slowest are not running under the same boundary.

The provider label column becomes a two-line stack: the vendor title, and beneath it a
small segmented chip — kind on the left, exact technology on the right — bordered and
split so "microVM | Firecracker" reads as one fact in two parts rather than a run-on
string. Providers with no resolved isolation render exactly as before, since the chip is
omitted rather than drawn empty.

The chip is carried on both `ChartBar` and `ChartIncompleteRow`: an environment that
failed the suite is the case where knowing its isolation matters most, so the disclosure
rows get the same subtitle the completed bars do.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Draws a segmented isolation chip under each provider label in the pipeline chart to show isolation kind and technology. It renders on completed bars and incomplete rows, and is omitted when isolation isn’t available.

- **New Features**
  - Adds `isolation?: FigureIsolation` to `ChartBar` and `ChartIncompleteRow`.
  - Stacks the provider label as title + chip; renders kind/technology as two spans styled by `isolation-chip`.
  - Adds tests covering chip rendering and title/chip separation.

<sup>Written for commit b941f04b191aeb94215fb7a46edb661220622c0c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/starslingdev/hpc-sandbox-benchmarks/pull/324?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

