### PR TITLE
Add scoped backfill releases for adding providers to published versions

### DIFF
--- a/.github/actions/ensure-package-public/action.yml
+++ b/.github/actions/ensure-package-public/action.yml
@@ -1,18 +1,21 @@
 name: Ensure GHCR package is public
 description: >-
-  Fail fast (with @actions/core annotations, via release-ensure-public.ts) if the candidate base package
-  is not public. e2b builds its template on E2B's REMOTE builder (FROM the ghcr candidate base) and
-  daytona/modal/novita pull it to snapshot/boot — none are handed ghcr pull credentials, so the candidate
-  package MUST be public. GHCR packages are created PRIVATE on first push with no API to flip visibility,
-  so making it public is a one-time manual bootstrap; this guard surfaces that plainly instead of an
-  opaque provider "unauthorized" pull error.
+  Fail fast (with @actions/core annotations, via release-ensure-public.ts) if a candidate package is not
+  public. e2b builds its template on E2B's REMOTE builder (FROM the ghcr candidate base) and
+  daytona/modal/novita pull it to snapshot/boot; the vercel bake cell pulls the staged variant with no
+  ghcr login of its own — none are handed ghcr pull credentials, so every candidate package MUST be
+  public. GHCR packages are created PRIVATE on first push with no API to flip visibility, so making one
+  public is a one-time manual bootstrap; this guard surfaces that plainly instead of an opaque provider
+  "unauthorized" pull error.
 
 inputs:
   owner:
     description: The GHCR package owner (org).
     required: true
   package:
-    description: The container package name.
+    description: >-
+      The container package name(s) — comma-separated, so one step covers every package a provider
+      pulls anonymously (the base plus each registry-served variant).
     required: true
   token:
     description: A token with read:packages for the GHCR package API.
@@ -21,7 +24,7 @@ inputs:
 runs:
   using: composite
   steps:
-    - name: Ensure candidate package is public
+    - name: Ensure candidate packages are public
       shell: bash
       # Inputs reach the script as env (a composite `run` step gets no INPUT_* vars). The script does a
       # real fetch + JSON parse and reports via core.setFailed/warning so the outcome is a run annotation.

--- a/.github/actions/release-summary/action.yml
+++ b/.github/actions/release-summary/action.yml
@@ -14,7 +14,12 @@ inputs:
     description: Phase status (ok / failed / skipped / success / failure).
     default: ""
   mode:
-    description: Release mode (build / republish).
+    description: Release mode (build / republish / backfill).
+    default: ""
+  scope:
+    description: >-
+      The providers this release covers — the resolved list, so a scoped backfill reads as one at a
+      glance instead of having to be inferred from which matrix cells ran.
     default: ""
   source-ref:
     description: The source ref the release is cut from (github.sha).
@@ -55,6 +60,7 @@ runs:
         PHASE: ${{ inputs.phase }}
         STATUS: ${{ inputs.status }}
         MODE: ${{ inputs.mode }}
+        SCOPE: ${{ inputs.scope }}
         SOURCE_REF: ${{ inputs.source-ref }}
         IMAGE: ${{ inputs.image }}
         BASE_IMAGE: ${{ inputs.base-image }}

--- a/.github/actions/release-validate-inputs/action.yml
+++ b/.github/actions/release-validate-inputs/action.yml
@@ -3,19 +3,35 @@ description: >-
   The credential-free fail-fast gate (release-validate.ts): validate the toolchain pins and the dispatch
   inputs BEFORE any registry/provider credential is introduced, reporting failures as @actions/core
   annotations (a pin failure is annotated ON the pins source file). Runs after setup-toolchain (needs
-  Bun + deps) but before ghcr-login, so a bad pin or a malformed input fails the release without creds.
+  Bun + deps) but before ghcr-login, so a bad pin, a malformed input, or a contradictory combination of
+  inputs fails the release without creds — and before the plan spends a registry round trip.
 
 inputs:
   force-republish:
     description: The force_republish dispatch input (regenerate an already-published version in place).
     default: "false"
+  providers:
+    description: >-
+      The providers dispatch input — a comma-separated provider id list scoping the release, or blank
+      for every registered provider. Ids are resolved against the provider registry here so a typo
+      fails as an annotation instead of silently shrinking the release.
+    default: ""
+  build:
+    description: The build dispatch input (full / variants / skip).
+    default: "full"
+  promote:
+    description: The promote dispatch input (run the publish phase, or bake + verify only).
+    default: "true"
 
 runs:
   using: composite
   steps:
     - name: Validate pins and dispatch inputs
       shell: bash
-      # Input reaches the script as env (a composite `run` step gets no INPUT_* vars).
+      # Inputs reach the script as env (a composite `run` step gets no INPUT_* vars).
       env:
         FORCE_REPUBLISH: ${{ inputs.force-republish }}
+        RELEASE_PROVIDERS: ${{ inputs.providers }}
+        BUILD_MODE: ${{ inputs.build }}
+        PROMOTE: ${{ inputs.promote }}
       run: bun apps/cli/src/bin/release-validate.ts

--- a/.github/workflows/toolchain-image.yml
+++ b/.github/workflows/toolchain-image.yml
@@ -21,6 +21,24 @@ name: Toolchain image
 #         the plan (mode, refs, provider matrix, gates) rather    │
 #         than re-reading the raw workflow inputs. ───────────────┘
 #
+# The plan also decides WHICH of those phases run, so a dispatch pays only for what it asked for. All
+# four dispatch inputs are optional and their defaults reproduce the full release exactly:
+#
+#   providers  scope the whole lane to a subset (`vercel`). Only those matrix cells exist, and promote
+#              becomes a BACKFILL: it publishes just those providers' version artifacts onto the
+#              already-published version and never rewrites the public base or anyone else's artifact.
+#              A scoped dispatch names what it wants, so every provider it names is REQUIRED.
+#   build      `full` rebuilds the base (the default; what a version bump needs). `variants` restages
+#              only the registry-served provider variants on top of the PUBLISHED base — minutes, and
+#              the new provider gets the same bytes the fleet already runs (the toolchain build is not
+#              reproducible, so a rebuild would quietly hand it a different `:vN`). `skip` skips the
+#              build job outright and reuses what the registry already holds.
+#   promote    off ⇒ the publish job is skipped: bake + verify, look at the report, promote later.
+#
+# The canonical use is adding a provider to a version everyone else already runs — e.g. Vercel on v7:
+#   1. providers=vercel, build=variants, promote=false  → stage + verify the candidate, nothing public
+#   2. providers=vercel, build=skip,     promote=true   → publish just the Vercel v7 artifact
+#
 # Cross-cutting GitHub Actions mechanics live in .github/actions/* composites (setup, ghcr login,
 # input validation, package-visibility guard, summaries); provider bake/verify/promote logic lives in
 # the package scripts under apps/cli (thin YAML, fat scripts). GHCR auth is the job's GITHUB_TOKEN; the
@@ -34,6 +52,19 @@ on:
   # plan phase unless force_republish is set.
   workflow_dispatch:
     inputs:
+      providers:
+        description: "Providers to build, verify and promote (comma-separated; blank = all)"
+        type: string
+        default: ""
+      build:
+        description: "Build phase: full (rebuild the base) / variants (restage variants on the published base) / skip"
+        type: choice
+        options: [full, variants, skip]
+        default: full
+      promote:
+        description: "Run the promote phase (uncheck to bake + verify only)"
+        type: boolean
+        default: true
       force_republish:
         description: "Regenerate the current version, overwriting it if already published (dev only)"
         type: boolean
@@ -157,6 +188,14 @@ jobs:
       mode: ${{ steps.plan.outputs.mode }}
       matrix: ${{ steps.plan.outputs.matrix }}
       required: ${{ steps.plan.outputs.required }}
+      # The RESOLVED provider scope (a blank `providers` input becomes the whole registry here), so the
+      # jobs below read one shape: the promote `--provider` list, and the `contains()` guards that keep
+      # a scoped run from doing a provider's credential dance for a provider it isn't releasing.
+      providers: ${{ steps.plan.outputs.providers }}
+      # The two dynamic job-skipping gates — see `build`'s and `publish`'s `if:` below.
+      build-mode: ${{ steps.plan.outputs.build-mode }}
+      run-build: ${{ steps.plan.outputs.run-build }}
+      run-publish: ${{ steps.plan.outputs.run-publish }}
       size-tier: ${{ steps.plan.outputs.size-tier }}
       image-candidate: ${{ steps.plan.outputs.image-candidate }}
       toolchain-version: ${{ steps.plan.outputs.toolchain-version }}
@@ -174,6 +213,9 @@ jobs:
         uses: ./.github/actions/release-validate-inputs
         with:
           force-republish: ${{ inputs.force_republish }}
+          providers: ${{ inputs.providers }}
+          build: ${{ inputs.build }}
+          promote: ${{ inputs.promote }}
       # The one privileged step in plan: the immutability probe (`docker manifest inspect`) needs a
       # GHCR session. GITHUB_TOKEN with packages: read suffices.
       - name: GHCR session
@@ -184,6 +226,9 @@ jobs:
         id: plan
         env:
           FORCE_REPUBLISH: ${{ inputs.force_republish }}
+          RELEASE_PROVIDERS: ${{ inputs.providers }}
+          BUILD_MODE: ${{ inputs.build }}
+          PROMOTE: ${{ inputs.promote }}
         # release-plan.ts validates pins again, probes whether :v1 is already published (best-effort —
         # promote does the authoritative guard), writes release-plan.json, and prints the key=value
         # outputs the downstream jobs read.
@@ -191,13 +236,16 @@ jobs:
         # redirect), so a child process's stdout can never corrupt the outputs file.
         run: bun apps/cli/src/bin/release-plan.ts release-plan.json
       # Guard the candidate package visibility so providers can pull it anonymously (see the composite).
+      # The plan lists EVERY anonymously-pulled package — the base plus each registry-served variant (the
+      # vercel bake cell pulls its staged variant from GHCR with no login of its own) — so a variant
+      # package that is still private surfaces here rather than as an opaque pull failure mid-bake.
       # Skipped when the release itself is skipped (version already published).
-      - name: Ensure candidate package is public
+      - name: Ensure candidate packages are public
         if: steps.plan.outputs.skip != 'true'
         uses: ./.github/actions/ensure-package-public
         with:
           owner: ${{ env.IMAGE_OWNER }}
-          package: ${{ steps.plan.outputs.image-name }}
+          package: ${{ steps.plan.outputs.packages }}
           token: ${{ secrets.GITHUB_TOKEN }}
       - name: Upload release plan
         if: always()
@@ -217,6 +265,7 @@ jobs:
           phase: plan
           status: ${{ job.status }}
           mode: ${{ steps.plan.outputs.mode }}
+          scope: ${{ steps.plan.outputs.providers }}
           source-ref: ${{ github.sha }}
           image: ${{ steps.plan.outputs.image-candidate }}
           size-tier: ${{ steps.plan.outputs.size-tier }}
@@ -225,12 +274,19 @@ jobs:
 
   # BUILD: build the base image (+ variants) and push the mutable candidate base to GHCR ONCE, then
   # record its immutable digest. The providers below all fan out from this single pushed candidate.
+  #
+  # Dynamic job skipping #1: `build: skip` drops this job entirely (`run-build` is false), so a re-verify
+  # or a promote of an already-staged candidate spends no build at all. `build: variants` still runs the
+  # job, but build-candidate.ts takes the cheap path — no base rebuild, just the registry-served variants
+  # restaged on the published base. Everything downstream tolerates this job being skipped (see `bake`).
   build:
-    name: Build + push candidate
+    name: Build + push candidate (${{ needs.plan.outputs.build-mode }})
     needs: plan
-    if: needs.plan.outputs.skip != 'true'
+    if: needs.plan.outputs.skip != 'true' && needs.plan.outputs.run-build == 'true'
     # 8 vCPUs — the same compile-bound base-image build as pr-gate (see the note there), and it sits on
-    # the critical path of every release: nothing bakes until the candidate is pushed.
+    # the critical path of every release: nothing bakes until the candidate is pushed. A `variants` build
+    # does not need the cores (it composes one thin layer on a pulled base), but it is minutes long
+    # either way, so it keeps the same label rather than making runs-on an expression.
     runs-on: starsling-ubuntu-24.04-8
     # The heavy phase: a full base-image build (apt, mise, the PTS install) plus the push.
     timeout-minutes: 60
@@ -260,6 +316,8 @@ jobs:
         env:
           BUILD_REF: ${{ github.sha }}
           BUILD_VERSION: ${{ needs.plan.outputs.toolchain-version }}
+          # `full` or `variants` — the plan already rejected anything else, and `skip` never gets here.
+          BUILD_MODE: ${{ needs.plan.outputs.build-mode }}
           # Same mise rate-limit fix as pr-gate: the release build runs the identical build.sh, so give
           # it the authenticated GitHub API limit too. Built-in token; this job is already privileged.
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -289,6 +347,7 @@ jobs:
           phase: build
           status: ${{ job.status }}
           mode: ${{ needs.plan.outputs.mode }}
+          scope: ${{ needs.plan.outputs.providers }}
           source-ref: ${{ github.sha }}
           image: ${{ steps.build.outputs.candidate-digest-ref }}
           size-tier: ${{ needs.plan.outputs.size-tier }}
@@ -301,10 +360,22 @@ jobs:
   # that RAN and failed still fails this job (and, being a `needs`, blocks promote). Required cells
   # (plan `required`) additionally pass `--require`, so a missing/misnamed secret fails the cell instead
   # of silently skipping a provider the release must ship.
+  #
+  # The matrix comes from the plan, so a scoped dispatch simply produces fewer cells — there is no
+  # per-cell `if:` to keep in sync with the scope, and an out-of-scope provider's job never exists.
   bake:
     name: Bake + verify (${{ matrix.provider }})
     needs: [plan, build]
-    if: needs.plan.outputs.skip != 'true'
+    # `build` is skippable (`build: skip`), and a skipped `needs` would normally skip this job too — so
+    # the condition is spelled out rather than left to the default. `!cancelled()` re-enables the job
+    # after a skipped dependency, which then makes plan's own success something we must assert (a FAILED
+    # plan emits no outputs, and `'' != 'true'` would have read as "don't skip"). build must have either
+    # succeeded or been skipped on purpose; anything else means there is no candidate to bake.
+    if: >
+      !cancelled() &&
+      needs.plan.result == 'success' &&
+      needs.plan.outputs.skip != 'true' &&
+      contains(fromJSON('["success", "skipped"]'), needs.build.result)
     runs-on: starsling-ubuntu-24.04-2
     # Each cell boots a provider sandbox with that provider's secret — a credentialed job, so it runs
     # behind Environment `privileged` like the rest of the release lane.
@@ -478,8 +549,11 @@ jobs:
           phase: ${{ matrix.provider }}/bake
           status: ${{ job.status }}
           mode: ${{ needs.plan.outputs.mode }}
+          scope: ${{ needs.plan.outputs.providers }}
           source-ref: ${{ github.sha }}
-          image: ${{ needs.build.outputs.candidate-digest-ref }}
+          # The build job may have been skipped (`build: skip`), leaving its outputs empty — fall back
+          # to the candidate tag the plan resolved, which is the ref this cell baked against anyway.
+          image: ${{ needs.build.outputs.candidate-digest-ref || needs.plan.outputs.image-candidate }}
           base-image: ${{ needs.plan.outputs.image-candidate }}
           provider-target: ${{ matrix.provider }}
           size-tier: ${{ needs.plan.outputs.size-tier }}
@@ -492,21 +566,35 @@ jobs:
   # version-named artifact FROM the revalidated bytes, then retags the base → :v1 LAST as the commit
   # point. `--require` (from the plan) fails the promote before publish if a required provider's version
   # artifact was skipped/failed. `--force` (force_republish only) regenerates an existing version.
+  # `--provider` (from the plan) scopes the transaction; a SUBSET makes it a backfill that publishes only
+  # those providers' version artifacts onto the existing version and never writes the base at all.
   # The release job (named `publish` — the drift gate requires this name for the GHCR release lane).
+  #
+  # Dynamic job skipping #2: `promote: false` drops this job (`run-publish`), so a dispatch can stage and
+  # verify a candidate, leave the public surface untouched, and promote from a later dispatch.
   publish:
     name: Promote candidate → version
     needs: [plan, build, bake]
     # The only job that mutates the public :v1. Confine it to a manual dispatch on main of this repo
     # (redundant with plan's gate, but the hardening gate asserts this literally on the publish job).
+    # Same `!cancelled()` shape as `bake` (build is skippable), so each dependency is asserted by hand:
+    # plan must have succeeded, bake must be green (a failed required cell blocks the release), and
+    # build must have either succeeded or been deliberately skipped.
     if: >
+      !cancelled() &&
+      needs.plan.result == 'success' &&
+      needs.bake.result == 'success' &&
+      contains(fromJSON('["success", "skipped"]'), needs.build.result) &&
       needs.plan.outputs.skip != 'true' &&
+      needs.plan.outputs.run-publish == 'true' &&
       github.event_name == 'workflow_dispatch' &&
       github.ref == 'refs/heads/main' &&
       github.repository == 'starslingdev/hpc-sandbox-benchmarks'
     runs-on: starsling-ubuntu-24.04-2
     environment: privileged
-    # Re-validates the candidate and promotes across all eight providers SERIALLY (it is a transaction,
-    # not a fan-out), so it is the longest-running credentialed job.
+    # Re-validates and promotes every in-scope provider SERIALLY (it is a transaction, not a fan-out),
+    # so at full scope it is the longest-running credentialed job. Sized for that worst case; a scoped
+    # backfill finishes in a fraction of it.
     timeout-minutes: 60
     # packages: write retags the base → public :v1. id-token: write is Namespace's OIDC federation for
     # the re-validation boot (no stored secret) — scoped here, not at the workflow level (zizmor).
@@ -530,11 +618,14 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
       # Namespace federates via GitHub's OIDC identity (id-token: write on this job), so promote's
       # re-validation boot can reach the Compute API with no stored secret. Unlike the bake matrix there
-      # is no per-provider cell here (promote is a serial transaction over all providers), so the mint
-      # runs unconditionally — continue-on-error keeps a not-yet-registered trust relationship (or any
-      # transient failure) from failing the release: namespace is best-effort (not in --require), so its
-      # re-validation simply skips when the token is absent, exactly like a missing optional secret.
+      # is no per-provider cell here (promote is a serial transaction over its providers), so the mint
+      # runs for the whole job — gated only on namespace actually being in scope, so a scoped release
+      # doesn't mint a token it will never use. continue-on-error keeps a not-yet-registered trust
+      # relationship (or any transient failure) from failing the release: namespace is best-effort (not
+      # in --require), so its re-validation simply skips when the token is absent, exactly like a
+      # missing optional secret — and a skipped step leaves `outcome` != 'success', the same path.
       - name: Set up Namespace CLI
+        if: contains(needs.plan.outputs.providers, 'namespace')
         continue-on-error: true
         id: nsc-setup
         uses: namespacelabs/nscloud-setup@df198f982fcecfb8264bea3f1274b56a61b6dfdc # v0
@@ -552,7 +643,10 @@ jobs:
             --name "sandbox-benchmarks-toolchain-promote-${{ github.run_id }}-${{ github.run_attempt }}" \
             --grant '{"resource_type":"instance","resource_id":"*","actions":["create","list","get","destroy","exec"]}' \
             --token_file "${{ runner.temp }}/nsc-token.json"
+      # Same scope gate as the Namespace mint above: a release that isn't promoting vercel has no reason
+      # to pull a project OIDC token or log docker into VCR.
       - name: Authenticate with Vercel and VCR
+        if: contains(needs.plan.outputs.providers, 'vercel')
         continue-on-error: true
         id: vercel-auth
         uses: ./.github/actions/vercel-auth
@@ -573,6 +667,11 @@ jobs:
         id: promote
         env:
           REQUIRED: ${{ needs.plan.outputs.required }}
+          # The resolved scope, always passed (never the raw dispatch input): for a full release it is
+          # simply every registered provider and `--provider` is a no-op, and for a scoped one it is what
+          # makes the promote a backfill. bake.ts derives "partial" from the list length, so the
+          # subset-vs-everything decision has exactly one owner.
+          RELEASE_PROVIDERS: ${{ needs.plan.outputs.providers }}
           FORCE_REPUBLISH: ${{ inputs.force_republish }}
           # Route the promote payload JSON to a file via env (not a `> file` redirect): the provider
           # CLIs inherit stdout, so a redirect would splice their chatter into the payload. bake.ts
@@ -591,7 +690,7 @@ jobs:
           # steps above). Not a stored secret: empty when the exchange/mint was skipped/failed, which
           # skips namespace's re-validation without failing the promote (namespace is not in --require).
           NSC_TOKEN_FILE: ${{ steps.nsc-token.outcome == 'success' && format('{0}/nsc-token.json', runner.temp) || '' }}
-          # The promote transaction re-validates every provider. Unlike every credential around it, this
+          # The promote transaction re-validates every in-scope provider. Unlike every credential around it, this
           # is a literal rather than a `secrets.*` reference, so it has no missing-value skip path — it
           # is safe only because this job is PINNED to `starsling-ubuntu-24.04-2` (see runs-on above),
           # the same virtualization-capable label the bake matrix uses. Moving promote to a runner
@@ -605,9 +704,10 @@ jobs:
           VERCEL_CANDIDATE_IMAGE: ${{ steps.vercel-vcr.outcome == 'success' && steps.vercel-vcr.outputs.digest-ref || '' }}
         run: |
           set -euo pipefail
-          args=(--promote --require "${REQUIRED}")
+          args=(--promote --require "${REQUIRED}" --provider "${RELEASE_PROVIDERS}")
           # --force (manual force_republish dispatch only) republishes over an existing immutable
-          # version; never set on the automated push path.
+          # version; never set on the automated push path. bake.ts refuses --force on a scoped promote,
+          # and release-validate rejects the combination before the release spends anything.
           if [ "${FORCE_REPUBLISH}" = "true" ]; then args+=(--force); fi
           bun apps/cli/src/bin/bake.ts "${args[@]}"
       - name: Log out of VCR
@@ -630,10 +730,12 @@ jobs:
           phase: publish
           status: ${{ job.status }}
           mode: ${{ needs.plan.outputs.mode }}
+          scope: ${{ needs.plan.outputs.providers }}
           source-ref: ${{ github.sha }}
-          image: ${{ needs.build.outputs.candidate-digest-ref }}
+          # Empty when the build job was skipped (`build: skip`) — fall back to the planned candidate tag.
+          image: ${{ needs.build.outputs.candidate-digest-ref || needs.plan.outputs.image-candidate }}
           base-image: ${{ needs.plan.outputs.image-candidate }}
           size-tier: ${{ needs.plan.outputs.size-tier }}
-          verify: bun apps/cli/src/bin/bake.ts --promote --require ${{ needs.plan.outputs.required }}${{ inputs.force_republish && ' --force' || '' }}
+          verify: bun apps/cli/src/bin/bake.ts --promote --require ${{ needs.plan.outputs.required }} --provider ${{ needs.plan.outputs.providers }}${{ inputs.force_republish && ' --force' || '' }}
           published: ${{ needs.plan.outputs.publish-target }}
           diagnostics: promote-payload-${{ github.run_id }}

--- a/.github/workflows/toolchain-image.yml
+++ b/.github/workflows/toolchain-image.yml
@@ -624,8 +624,13 @@ jobs:
       # relationship (or any transient failure) from failing the release: namespace is best-effort (not
       # in --require), so its re-validation simply skips when the token is absent, exactly like a
       # missing optional secret — and a skipped step leaves `outcome` != 'success', the same path.
+      #
+      # The scope test reads the plan's matrix rather than its `providers` CSV: `contains(array, item)`
+      # is element EQUALITY, while `contains(string, substring)` would also match a future id that
+      # merely contains this one (this registry already splits providers into `-vm`/`-container`/
+      # `-local`/`-cloud` variants, so that is not hypothetical).
       - name: Set up Namespace CLI
-        if: contains(needs.plan.outputs.providers, 'namespace')
+        if: contains(fromJSON(needs.plan.outputs.matrix).include.*.provider, 'namespace')
         continue-on-error: true
         id: nsc-setup
         uses: namespacelabs/nscloud-setup@df198f982fcecfb8264bea3f1274b56a61b6dfdc # v0
@@ -646,7 +651,7 @@ jobs:
       # Same scope gate as the Namespace mint above: a release that isn't promoting vercel has no reason
       # to pull a project OIDC token or log docker into VCR.
       - name: Authenticate with Vercel and VCR
-        if: contains(needs.plan.outputs.providers, 'vercel')
+        if: contains(fromJSON(needs.plan.outputs.matrix).include.*.provider, 'vercel')
         continue-on-error: true
         id: vercel-auth
         uses: ./.github/actions/vercel-auth

--- a/.github/workflows/toolchain-image.yml
+++ b/.github/workflows/toolchain-image.yml
@@ -296,7 +296,12 @@ jobs:
       packages: write
     outputs:
       digest: ${{ steps.build.outputs.digest }}
+      # Two different facts, deliberately not one: `candidate-digest-ref` is what this phase STAGED
+      # (the new candidate base on a `full` build, the variant candidates on a `variants` one), while
+      # `base-digest-ref` is the base every downstream phase pins — which a `variants` build leaves as
+      # the published version it composed on, having never touched the candidate base.
       candidate-digest-ref: ${{ steps.build.outputs.candidate-digest-ref }}
+      base-digest-ref: ${{ steps.build.outputs.base-digest-ref }}
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -318,6 +323,11 @@ jobs:
           BUILD_VERSION: ${{ needs.plan.outputs.toolchain-version }}
           # `full` or `variants` — the plan already rejected anything else, and `skip` never gets here.
           BUILD_MODE: ${{ needs.plan.outputs.build-mode }}
+          # The resolved scope, so the build stages only the registry-served variants this release is
+          # actually publishing. Without it a scoped release would rewrite an out-of-scope provider's
+          # candidate tag — a mutation nobody asked for, on an image the plan dropped from the
+          # visibility guard, so nothing would even check it is still pullable afterwards.
+          RELEASE_PROVIDERS: ${{ needs.plan.outputs.providers }}
           # Same mise rate-limit fix as pr-gate: the release build runs the identical build.sh, so give
           # it the authenticated GitHub API limit too. Built-in token; this job is already privileged.
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -350,6 +360,7 @@ jobs:
           scope: ${{ needs.plan.outputs.providers }}
           source-ref: ${{ github.sha }}
           image: ${{ steps.build.outputs.candidate-digest-ref }}
+          base-image: ${{ steps.build.outputs.base-digest-ref }}
           size-tier: ${{ needs.plan.outputs.size-tier }}
           verify: bun apps/cli/src/bin/build-candidate.ts
           diagnostics: build-metadata-${{ github.run_id }}
@@ -554,7 +565,7 @@ jobs:
           # The build job may have been skipped (`build: skip`), leaving its outputs empty — fall back
           # to the candidate tag the plan resolved, which is the ref this cell baked against anyway.
           image: ${{ needs.build.outputs.candidate-digest-ref || needs.plan.outputs.image-candidate }}
-          base-image: ${{ needs.plan.outputs.image-candidate }}
+          base-image: ${{ needs.build.outputs.base-digest-ref || needs.plan.outputs.image-candidate }}
           provider-target: ${{ matrix.provider }}
           size-tier: ${{ needs.plan.outputs.size-tier }}
           verify: bun apps/cli/src/bin/bake.ts --provider ${{ matrix.provider }}${{ matrix.required && format(' --require {0}', matrix.provider) || '' }}
@@ -739,7 +750,7 @@ jobs:
           source-ref: ${{ github.sha }}
           # Empty when the build job was skipped (`build: skip`) — fall back to the planned candidate tag.
           image: ${{ needs.build.outputs.candidate-digest-ref || needs.plan.outputs.image-candidate }}
-          base-image: ${{ needs.plan.outputs.image-candidate }}
+          base-image: ${{ needs.build.outputs.base-digest-ref || needs.plan.outputs.image-candidate }}
           size-tier: ${{ needs.plan.outputs.size-tier }}
           verify: bun apps/cli/src/bin/bake.ts --promote --require ${{ needs.plan.outputs.required }} --provider ${{ needs.plan.outputs.providers }}${{ inputs.force_republish && ' --force' || '' }}
           published: ${{ needs.plan.outputs.publish-target }}

--- a/apps/cli/src/bin/bake.ts
+++ b/apps/cli/src/bin/bake.ts
@@ -21,7 +21,7 @@ import { bakeModalImage } from "../lib/bake/modal.ts";
 import { bakeNovitaTemplate } from "../lib/bake/novita.ts";
 import { promoteAll } from "../lib/bake/promote.ts";
 import type { BakeReport, Log } from "../lib/bake/types.ts";
-import { candidateCreateOptions } from "../lib/bake/validate.ts";
+import { baseImageUse, candidateCreateOptions } from "../lib/bake/validate.ts";
 import { isPartialScope, selectProviders } from "../lib/matrix.ts";
 import { anyFailed, forEachProviderWithCreds } from "../lib/providers-run.ts";
 import { bootAndSmoke, logChecks, smokeFailureReason, smokeOk } from "../lib/smoke-run.ts";
@@ -171,7 +171,7 @@ if (import.meta.main) {
 	if (process.argv.includes("--build-push")) {
 		log(">>> building + pushing candidate image…");
 		try {
-			await buildAndPushCandidate(log);
+			await buildAndPushCandidate(log, only);
 		} catch (err) {
 			log(`<<< build/push failed — ${err instanceof Error ? err.message : String(err)}`);
 			process.exit(1);
@@ -181,15 +181,25 @@ if (import.meta.main) {
 	// Modal's registry importer, like the remote E2B-compatible builders, may cache a mutable tag.
 	// Resolve once after the push and validate the exact candidate bytes by immutable digest. This also
 	// makes a tag change between provider bakes unable to redirect Modal's validation to different bytes.
-	let pinnedCandidateImage: string;
-	try {
-		pinnedCandidateImage = await resolveImageDigestRef(config.toolchainImageCandidate);
-		log(`>>> candidate image pinned for validation: ${pinnedCandidateImage}`);
-	} catch (err) {
-		log(
-			`<<< could not resolve candidate image digest — ${err instanceof Error ? err.message : String(err)}`,
-		);
-		process.exit(1);
+	//
+	// Only providers that actually reference the base need it: vercel boots its own VCR mirror and
+	// blaxel the vendor's stock image, so a cell restricted to those must not die on a base candidate it
+	// never reads — under `build: variants`/`skip` that ref may legitimately be stale or absent, and
+	// failing there would break the one flow the scoped release exists for.
+	const needsBase = (only ?? PROVIDERS.map((p) => p.id)).some((id) => baseImageUse(id) !== "none");
+	let pinnedCandidateImage: string = config.toolchainImageCandidate;
+	if (needsBase) {
+		try {
+			pinnedCandidateImage = await resolveImageDigestRef(config.toolchainImageCandidate);
+			log(`>>> candidate image pinned for validation: ${pinnedCandidateImage}`);
+		} catch (err) {
+			log(
+				`<<< could not resolve candidate image digest — ${err instanceof Error ? err.message : String(err)}`,
+			);
+			process.exit(1);
+		}
+	} else {
+		log(`>>> no provider in scope reads ${config.toolchainImageCandidate} — not resolving it`);
 	}
 	const candidateRefs = {
 		e2bTemplateCandidate: config.e2bTemplateCandidate,

--- a/apps/cli/src/bin/bake.ts
+++ b/apps/cli/src/bin/bake.ts
@@ -22,7 +22,7 @@ import { bakeNovitaTemplate } from "../lib/bake/novita.ts";
 import { promoteAll } from "../lib/bake/promote.ts";
 import type { BakeReport, Log } from "../lib/bake/types.ts";
 import { candidateCreateOptions } from "../lib/bake/validate.ts";
-import { selectProviders } from "../lib/matrix.ts";
+import { isPartialScope, selectProviders } from "../lib/matrix.ts";
 import { anyFailed, forEachProviderWithCreds } from "../lib/providers-run.ts";
 import { bootAndSmoke, logChecks, smokeFailureReason, smokeOk } from "../lib/smoke-run.ts";
 
@@ -133,8 +133,7 @@ if (import.meta.main) {
 		// A scoped promote is a backfill onto an existing version, which is the opposite of what --force
 		// does (regenerate the whole version in place, destructively for daytona). Refuse the combination
 		// rather than pick a winner: whichever we picked would silently not be what the operator asked for.
-		const partial = only !== undefined && only.length < PROVIDERS.length;
-		if (partial && force) {
+		if (isPartialScope(only) && force) {
 			log(
 				"error: --force cannot be combined with a scoped --provider promote — a scoped promote " +
 					"backfills providers onto an already-published version, while --force regenerates the " +
@@ -142,13 +141,13 @@ if (import.meta.main) {
 			);
 			process.exit(2);
 		}
-		const promoted = await promoteAll(log, { force, only, partial });
+		const promoted = await promoteAll(log, { force, only });
 		writeReport({
 			// The scope is recorded alongside the version names because those names are the FULL set the
 			// version owns — on a partial promote most of them were not touched, and the payload has to
 			// say which run this was rather than leave a reader to infer it from `reports`.
-			scope: only ? [...only] : "all",
-			partial,
+			scope: only ?? PROVIDERS.map((p) => p.id),
+			partial: isPartialScope(only),
 			version: {
 				image: config.toolchainImageVersion,
 				e2bTemplate: config.e2bTemplateVersion,

--- a/apps/cli/src/bin/bake.ts
+++ b/apps/cli/src/bin/bake.ts
@@ -13,6 +13,7 @@ import { requiredProviders, unmetRequirements } from "@sandbox-benchmarks/harnes
 import type { ProviderConfig } from "@sandbox-benchmarks/providers";
 import { config } from "@sandbox-benchmarks/providers";
 import type { ProviderId } from "@sandbox-benchmarks/schema";
+import { PROVIDERS } from "@sandbox-benchmarks/schema";
 import { bakeDaytonaContainerSnapshot, bakeDaytonaVmSnapshot } from "../lib/bake/daytona.ts";
 import { bakeE2bTemplate } from "../lib/bake/e2b.ts";
 import { buildAndPushCandidate, resolveImageDigestRef } from "../lib/bake/image.ts";
@@ -79,7 +80,8 @@ function writeReport(report: unknown): void {
  * default). The argv scan mirrors `--require` (harness `requiredProviders`); the CSV is split and
  * validated against the registry by the shared {@link selectProviders} (which dedups, is
  * case-insensitive, returns registry order, and throws a registry-derived message on an unknown id).
- * The flag applies only to the candidate bake loop; `--promote` is always all-providers (a transaction).
+ * It restricts `--promote` too: a scoped promote publishes only those providers' version artifacts,
+ * onto an already-published version, and leaves the public base alone (see promote.ts, PromoteOptions).
  *
  * A PRESENT-but-valueless flag (`--provider`, `--provider=`, `--provider --force`) THROWS rather than
  * falling through to the all-providers default. `selectProviders` treats a blank list as "every
@@ -112,12 +114,41 @@ export function requestedProviders(argv: string[]): ProviderId[] | undefined {
 if (import.meta.main) {
 	const log: Log = (m) => console.error(m);
 
+	// Optional per-provider restriction. On the bake path it is the CI matrix fan-out (one cell per
+	// provider); on the promote path it scopes the transaction to a backfill. Parsed before any build
+	// or registry call so a typo'd id fails fast (clean message, no stack) before anything is touched.
+	let only: ProviderId[] | undefined;
+	try {
+		only = requestedProviders(process.argv);
+	} catch (err) {
+		log(`error: ${err instanceof Error ? err.message : String(err)}`);
+		process.exit(2);
+	}
+
 	// Promote is the release step: publish the already-validated candidate as the public version.
 	if (process.argv.includes("--promote")) {
 		// `--force` republishes over an existing (immutable) version — dev regeneration, set only by a
 		// manual toolchain-image.yml dispatch. Automated pushes never pass it, so :v1 stays immutable there.
-		const promoted = await promoteAll(log, process.argv.includes("--force"));
+		const force = process.argv.includes("--force");
+		// A scoped promote is a backfill onto an existing version, which is the opposite of what --force
+		// does (regenerate the whole version in place, destructively for daytona). Refuse the combination
+		// rather than pick a winner: whichever we picked would silently not be what the operator asked for.
+		const partial = only !== undefined && only.length < PROVIDERS.length;
+		if (partial && force) {
+			log(
+				"error: --force cannot be combined with a scoped --provider promote — a scoped promote " +
+					"backfills providers onto an already-published version, while --force regenerates the " +
+					"whole version in place. Pick one.",
+			);
+			process.exit(2);
+		}
+		const promoted = await promoteAll(log, { force, only, partial });
 		writeReport({
+			// The scope is recorded alongside the version names because those names are the FULL set the
+			// version owns — on a partial promote most of them were not touched, and the payload has to
+			// say which run this was rather than leave a reader to infer it from `reports`.
+			scope: only ? [...only] : "all",
+			partial,
 			version: {
 				image: config.toolchainImageVersion,
 				e2bTemplate: config.e2bTemplateVersion,
@@ -136,15 +167,6 @@ if (import.meta.main) {
 		process.exit(promoted.some((r) => r.status === "failed") ? 1 : 0);
 	}
 
-	// Optional per-provider restriction for the CI matrix fan-out (one cell per provider). Parsed before
-	// any build so a typo'd id fails the cell fast (clean message, no stack), before the candidate is touched.
-	let only: ProviderId[] | undefined;
-	try {
-		only = requestedProviders(process.argv);
-	} catch (err) {
-		log(`error: ${err instanceof Error ? err.message : String(err)}`);
-		process.exit(2);
-	}
 	if (only) log(`>>> restricting bake+validate to: ${only.join(", ")}`);
 
 	if (process.argv.includes("--build-push")) {

--- a/apps/cli/src/bin/build-candidate.test.ts
+++ b/apps/cli/src/bin/build-candidate.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, test } from "bun:test";
+import { buildMode } from "./build-candidate.ts";
+
+describe("buildMode", () => {
+	test("blank or unset means the full base rebuild (the default release path)", () => {
+		expect(buildMode(undefined)).toBe("full");
+		expect(buildMode("")).toBe("full");
+		expect(buildMode("  ")).toBe("full");
+	});
+
+	test("accepts the two modes this script implements", () => {
+		expect(buildMode("full")).toBe("full");
+		expect(buildMode("variants")).toBe("variants");
+	});
+
+	// Defaulting an unrecognized value to `full` would spend an hour rebuilding the base — and, because
+	// the toolchain build is not reproducible, overwrite the candidate with different bytes — on a
+	// dispatch that explicitly asked not to touch it.
+	test("an unrecognized mode throws instead of falling back to a base rebuild", () => {
+		// `skip` is a real dispatch value, but the plan handles it by skipping the job — the script
+		// itself must not silently treat it as "rebuild everything".
+		expect(() => buildMode("skip")).toThrow(/BUILD_MODE/);
+		expect(() => buildMode("base")).toThrow(/BUILD_MODE/);
+	});
+});

--- a/apps/cli/src/bin/build-candidate.ts
+++ b/apps/cli/src/bin/build-candidate.ts
@@ -23,31 +23,31 @@ import { config } from "@sandbox-benchmarks/providers";
 import {
 	buildAndPushCandidate,
 	buildAndPushVariantCandidates,
+	imageDigest,
 	imageRepo,
 	PUBLISHED_VARIANTS,
 	resolveImageDigest,
 } from "../lib/bake/image.ts";
 import type { Log } from "../lib/bake/types.ts";
 import { emitStepOutputs } from "../lib/gha-output.ts";
-
-/** The build phases this script implements (`skip` is handled by the workflow, not here). */
-const BUILD_MODES = ["full", "variants"] as const;
-type BuildMode = (typeof BUILD_MODES)[number];
+import type { BuilderBuildMode } from "../lib/release-inputs.ts";
+import { BUILDER_BUILD_MODES, isBuilderBuildMode } from "../lib/release-inputs.ts";
 
 /** Parse `BUILD_MODE`; blank → `full`. An unrecognized value THROWS rather than defaulting: silently
- *  falling back to `full` would spend an hour rebuilding a base the operator asked us not to touch. */
-export function buildMode(raw: string | undefined): BuildMode {
+ *  falling back to `full` would spend an hour rebuilding a base the operator asked us not to touch —
+ *  which includes `skip`, a real dispatch value that the plan resolves by skipping this job entirely. */
+export function buildMode(raw: string | undefined): BuilderBuildMode {
 	const value = (raw ?? "").trim() || "full";
-	if (!(BUILD_MODES as readonly string[]).includes(value)) {
-		throw new Error(`BUILD_MODE must be one of ${BUILD_MODES.join(", ")} (got '${value}')`);
+	if (!isBuilderBuildMode(value)) {
+		throw new Error(`BUILD_MODE must be one of ${BUILDER_BUILD_MODES.join(", ")} (got '${value}')`);
 	}
-	return value as BuildMode;
+	return value;
 }
 
 if (import.meta.main) {
 	const log: Log = (m) => console.error(m);
 
-	let mode: BuildMode;
+	let mode: BuilderBuildMode;
 	try {
 		mode = buildMode(process.env.BUILD_MODE);
 	} catch (err) {
@@ -63,7 +63,7 @@ if (import.meta.main) {
 	let pinnedBase: string | undefined;
 	try {
 		if (mode === "variants") {
-			pinnedBase = await buildAndPushVariantCandidates(log, config.toolchainImageVersion);
+			pinnedBase = await buildAndPushVariantCandidates(log);
 		} else {
 			await buildAndPushCandidate(log);
 		}
@@ -83,7 +83,7 @@ if (import.meta.main) {
 	// `variants` already resolved the digest to pin the build — reuse it rather than inspecting twice.
 	if (pinnedBase) {
 		digestRef = pinnedBase;
-		digest = pinnedBase.slice(pinnedBase.indexOf("@") + 1);
+		digest = imageDigest(pinnedBase);
 	} else {
 		try {
 			digest = await resolveImageDigest(baseTag);

--- a/apps/cli/src/bin/build-candidate.ts
+++ b/apps/cli/src/bin/build-candidate.ts
@@ -20,16 +20,16 @@
 //     GitHub would reject it. stdout is left to carry the (inherited) build log, and
 //   • argv[1] (optional): a build-metadata.json diagnostic artifact with the same facts.
 import { config } from "@sandbox-benchmarks/providers";
+import type { ProviderId } from "@sandbox-benchmarks/schema";
+import type { StagedCandidates } from "../lib/bake/image.ts";
 import {
 	buildAndPushCandidate,
 	buildAndPushVariantCandidates,
 	imageDigest,
-	imageRepo,
-	PUBLISHED_VARIANTS,
-	resolveImageDigest,
 } from "../lib/bake/image.ts";
 import type { Log } from "../lib/bake/types.ts";
 import { emitStepOutputs } from "../lib/gha-output.ts";
+import { selectProviders } from "../lib/matrix.ts";
 import type { BuilderBuildMode } from "../lib/release-inputs.ts";
 import { BUILDER_BUILD_MODES, isBuilderBuildMode } from "../lib/release-inputs.ts";
 
@@ -55,53 +55,46 @@ if (import.meta.main) {
 		process.exit(2);
 	}
 
+	// The release's provider scope, so a scoped build stages only the variants it is releasing rather
+	// than rewriting an out-of-scope provider's candidate tag. Blank/absent → every provider.
+	let scope: ProviderId[] | undefined;
+	try {
+		const raw = (process.env.RELEASE_PROVIDERS ?? "").trim();
+		scope = raw === "" ? undefined : selectProviders(raw);
+	} catch (err) {
+		log(`error: ${err instanceof Error ? err.message : String(err)}`);
+		process.exit(2);
+	}
+
 	// In `variants` mode the base the variants compose on is the PUBLISHED version, not the candidate:
 	// the whole point is to derive the new artifact from the bytes already in production.
 	// A failed build/push is the phase failing: report it as one line on stderr (where the job summary
 	// and the run log read it) and exit non-zero, rather than letting an unhandled rejection print a
 	// stack trace. Mirrors the `--build-push` path in bake.ts.
-	let pinnedBase: string | undefined;
+	let staged: StagedCandidates;
 	try {
-		if (mode === "variants") {
-			pinnedBase = await buildAndPushVariantCandidates(log);
-		} else {
-			await buildAndPushCandidate(log);
-		}
+		staged =
+			mode === "variants"
+				? await buildAndPushVariantCandidates(log, scope)
+				: await buildAndPushCandidate(log, scope);
 	} catch (err) {
 		log(`<<< build/push failed — ${err instanceof Error ? err.message : String(err)}`);
 		process.exit(1);
 	}
 
-	// The ref this phase pinned: the candidate base it just pushed (`full`), or the published version
-	// base the variants were rebuilt on (`variants`). Downstream phases record it as provenance.
-	const baseTag =
-		mode === "variants" ? config.toolchainImageVersion : config.toolchainImageCandidate;
-	// The digest is recorded provenance, not a release gate (promote re-validates the mutable tag), so a
-	// registry-inspect quirk must not block a candidate that pushed fine: fall back to the tag on failure.
-	let digest = "unknown";
-	let digestRef: string = baseTag;
-	// `variants` already resolved the digest to pin the build — reuse it rather than inspecting twice.
-	if (pinnedBase) {
-		digestRef = pinnedBase;
-		digest = imageDigest(pinnedBase);
-	} else {
-		try {
-			digest = await resolveImageDigest(baseTag);
-			digestRef = `${imageRepo(baseTag)}@${digest}`;
-		} catch (err) {
-			log(
-				`::warning::could not resolve candidate digest (${err instanceof Error ? err.message : String(err)}); recording the tag instead.`,
-			);
-		}
-	}
+	// What this phase PRODUCED, which is what the downstream summaries label as the release's image:
+	// a `full` build pushed a new candidate base, while a `variants` build left the base alone and
+	// pushed only the variant candidates — naming the untouched public base there would read as though
+	// the base had been rebuilt. Both are recorded separately in the metadata artifact either way.
+	const digestRef = mode === "variants" ? staged.variants.join(", ") : staged.base;
 
 	const metadata = {
 		mode,
-		base: baseTag,
-		digest,
-		digestRef,
-		// The registry-served variant candidates this run staged (both modes push them).
-		variantCandidates: PUBLISHED_VARIANTS.map((entry) => entry.candidate),
+		/** The digest-pinned base this phase's artifacts derive from. */
+		base: staged.base,
+		/** Digest-pinned refs of the registry-served variant candidates this run actually staged. */
+		variantCandidates: staged.variants,
+		scope: scope ?? "all",
 		version: config.toolchainVersion,
 		buildRef: process.env.GITHUB_SHA ?? null,
 	};
@@ -109,7 +102,14 @@ if (import.meta.main) {
 	const metaPath = process.argv.slice(2).find((a) => !a.startsWith("-"));
 	if (metaPath) await Bun.write(metaPath, `${JSON.stringify(metadata, null, 2)}\n`);
 
-	log(`<<< ${mode} build complete: ${digestRef}`);
+	log(`<<< ${mode} build complete: ${digestRef || staged.base}`);
 	// Straight to $GITHUB_OUTPUT (not stdout) — build.sh's inherited stdout must not reach the outputs.
-	emitStepOutputs([`digest=${digest}`, `candidate-digest-ref=${digestRef}`].join("\n"));
+	// `base-digest-ref` is what downstream phases PIN; `candidate-digest-ref` is what this phase staged.
+	emitStepOutputs(
+		[
+			`digest=${imageDigest(staged.base)}`,
+			`base-digest-ref=${staged.base}`,
+			`candidate-digest-ref=${digestRef || staged.base}`,
+		].join("\n"),
+	);
 }

--- a/apps/cli/src/bin/build-candidate.ts
+++ b/apps/cli/src/bin/build-candidate.ts
@@ -5,48 +5,103 @@
 // from the already-pushed candidate ref (build once, fan out). The local iteration loop still uses
 // `bake --build-push` (which build-pushes AND bakes in one process); CI splits the two.
 //
+// Two modes, chosen by `BUILD_MODE` (the workflow's `build` dispatch input, via the release plan):
+//   • `full` (default) — the above: rebuild the base and push a new mutable candidate base.
+//   • `variants` — do NOT rebuild the base. Restage only the registry-served provider variants (the
+//     Vercel VCR source image today) on top of the ALREADY-PUBLISHED version base. This is the build
+//     phase of a scoped backfill: it adds a provider to a version the rest of the fleet already runs,
+//     on the same bytes they run, in minutes instead of an hour. See buildAndPushVariantCandidates.
+// (`skip` is the third dispatch value, and never reaches this script — the plan skips the job.)
+//
 // Emits, in one invocation:
-//   • the `key=value` step outputs (candidate digest + digest-pinned ref) straight to $GITHUB_OUTPUT
+//   • the `key=value` step outputs (base digest + digest-pinned ref) straight to $GITHUB_OUTPUT
 //     via emitStepOutputs — NOT to stdout: build.sh runs with inherited stdout, so a
 //     `bun … >> "$GITHUB_OUTPUT"` redirect would splice build.sh's progress into the outputs file and
 //     GitHub would reject it. stdout is left to carry the (inherited) build log, and
 //   • argv[1] (optional): a build-metadata.json diagnostic artifact with the same facts.
 import { config } from "@sandbox-benchmarks/providers";
-import { buildAndPushCandidate, imageRepo, resolveImageDigest } from "../lib/bake/image.ts";
+import {
+	buildAndPushCandidate,
+	buildAndPushVariantCandidates,
+	imageRepo,
+	PUBLISHED_VARIANTS,
+	resolveImageDigest,
+} from "../lib/bake/image.ts";
 import type { Log } from "../lib/bake/types.ts";
 import { emitStepOutputs } from "../lib/gha-output.ts";
+
+/** The build phases this script implements (`skip` is handled by the workflow, not here). */
+const BUILD_MODES = ["full", "variants"] as const;
+type BuildMode = (typeof BUILD_MODES)[number];
+
+/** Parse `BUILD_MODE`; blank → `full`. An unrecognized value THROWS rather than defaulting: silently
+ *  falling back to `full` would spend an hour rebuilding a base the operator asked us not to touch. */
+export function buildMode(raw: string | undefined): BuildMode {
+	const value = (raw ?? "").trim() || "full";
+	if (!(BUILD_MODES as readonly string[]).includes(value)) {
+		throw new Error(`BUILD_MODE must be one of ${BUILD_MODES.join(", ")} (got '${value}')`);
+	}
+	return value as BuildMode;
+}
 
 if (import.meta.main) {
 	const log: Log = (m) => console.error(m);
 
+	let mode: BuildMode;
+	try {
+		mode = buildMode(process.env.BUILD_MODE);
+	} catch (err) {
+		log(`error: ${err instanceof Error ? err.message : String(err)}`);
+		process.exit(2);
+	}
+
+	// In `variants` mode the base the variants compose on is the PUBLISHED version, not the candidate:
+	// the whole point is to derive the new artifact from the bytes already in production.
 	// A failed build/push is the phase failing: report it as one line on stderr (where the job summary
 	// and the run log read it) and exit non-zero, rather than letting an unhandled rejection print a
 	// stack trace. Mirrors the `--build-push` path in bake.ts.
+	let pinnedBase: string | undefined;
 	try {
-		await buildAndPushCandidate(log);
+		if (mode === "variants") {
+			pinnedBase = await buildAndPushVariantCandidates(log, config.toolchainImageVersion);
+		} else {
+			await buildAndPushCandidate(log);
+		}
 	} catch (err) {
 		log(`<<< build/push failed — ${err instanceof Error ? err.message : String(err)}`);
 		process.exit(1);
 	}
 
+	// The ref this phase pinned: the candidate base it just pushed (`full`), or the published version
+	// base the variants were rebuilt on (`variants`). Downstream phases record it as provenance.
+	const baseTag =
+		mode === "variants" ? config.toolchainImageVersion : config.toolchainImageCandidate;
 	// The digest is recorded provenance, not a release gate (promote re-validates the mutable tag), so a
 	// registry-inspect quirk must not block a candidate that pushed fine: fall back to the tag on failure.
-	const repo = imageRepo(config.toolchainImageCandidate);
 	let digest = "unknown";
-	let digestRef: string = config.toolchainImageCandidate;
-	try {
-		digest = await resolveImageDigest(config.toolchainImageCandidate);
-		digestRef = `${repo}@${digest}`;
-	} catch (err) {
-		log(
-			`::warning::could not resolve candidate digest (${err instanceof Error ? err.message : String(err)}); recording the tag instead.`,
-		);
+	let digestRef: string = baseTag;
+	// `variants` already resolved the digest to pin the build — reuse it rather than inspecting twice.
+	if (pinnedBase) {
+		digestRef = pinnedBase;
+		digest = pinnedBase.slice(pinnedBase.indexOf("@") + 1);
+	} else {
+		try {
+			digest = await resolveImageDigest(baseTag);
+			digestRef = `${imageRepo(baseTag)}@${digest}`;
+		} catch (err) {
+			log(
+				`::warning::could not resolve candidate digest (${err instanceof Error ? err.message : String(err)}); recording the tag instead.`,
+			);
+		}
 	}
 
 	const metadata = {
-		candidate: config.toolchainImageCandidate,
+		mode,
+		base: baseTag,
 		digest,
 		digestRef,
+		// The registry-served variant candidates this run staged (both modes push them).
+		variantCandidates: PUBLISHED_VARIANTS.map((entry) => entry.candidate),
 		version: config.toolchainVersion,
 		buildRef: process.env.GITHUB_SHA ?? null,
 	};
@@ -54,7 +109,7 @@ if (import.meta.main) {
 	const metaPath = process.argv.slice(2).find((a) => !a.startsWith("-"));
 	if (metaPath) await Bun.write(metaPath, `${JSON.stringify(metadata, null, 2)}\n`);
 
-	log(`<<< candidate pushed: ${digestRef}`);
+	log(`<<< ${mode} build complete: ${digestRef}`);
 	// Straight to $GITHUB_OUTPUT (not stdout) — build.sh's inherited stdout must not reach the outputs.
 	emitStepOutputs([`digest=${digest}`, `candidate-digest-ref=${digestRef}`].join("\n"));
 }

--- a/apps/cli/src/bin/release-ensure-public.ts
+++ b/apps/cli/src/bin/release-ensure-public.ts
@@ -1,17 +1,22 @@
 #!/usr/bin/env bun
 // `release-ensure-public` — the script behind the `ensure-package-public` composite action. Fails fast
-// (with rich @actions/core annotations) if the candidate base package is not public. e2b builds its
-// template on E2B's REMOTE builder (FROM the ghcr candidate base) and daytona/modal/novita pull it to
-// snapshot/boot — none are handed ghcr pull credentials, so the candidate package MUST be public. GHCR
-// packages are created PRIVATE on first push with no API to flip visibility, so making it public is a
-// one-time manual bootstrap; this guard surfaces that plainly instead of an opaque provider pull error.
+// (with rich @actions/core annotations) if a candidate package is not public. e2b builds its template
+// on E2B's REMOTE builder (FROM the ghcr candidate base) and daytona/modal/novita pull it to
+// snapshot/boot; the vercel bake cell pulls the staged variant with no ghcr login of its own — none are
+// handed ghcr pull credentials, so every candidate package MUST be public. GHCR packages are created
+// PRIVATE on first push with no API to flip visibility, so making one public is a one-time manual
+// bootstrap; this guard surfaces that plainly instead of an opaque provider pull error.
+//
+// `PACKAGE` is a comma-separated list (the plan emits every anonymously-pulled package: the base plus
+// each registry-served variant). EVERY name is checked before the gate reports, so one run tells the
+// operator about all the packages needing the bootstrap rather than one per re-dispatch.
 //
 // Inputs arrive as env (the composite maps its `with:` inputs). Uses Bun's fetch + a real JSON parse
 // (not a curl+grep), and core.setFailed/warning so the outcome renders as a run annotation.
 import * as core from "@actions/core";
 
 const owner = process.env.OWNER?.trim() ?? "";
-const pkg = process.env.PACKAGE?.trim() ?? "";
+const packageList = process.env.PACKAGE?.trim() ?? "";
 const token = process.env.GH_TOKEN?.trim() ?? "";
 
 // Refuse to run on a missing input rather than probing a malformed URL. With an empty OWNER/PACKAGE the
@@ -20,7 +25,7 @@ const token = process.env.GH_TOKEN?.trim() ?? "";
 // unwired composite input would make a SECURITY GATE pass silently while checking nothing at all.
 const inputs: Array<[name: string, value: string]> = [
 	["OWNER", owner],
-	["PACKAGE", pkg],
+	["PACKAGE", packageList],
 	["GH_TOKEN", token],
 ];
 const missing = inputs.filter(([, value]) => value.length === 0).map(([name]) => name);
@@ -31,48 +36,68 @@ if (missing.length > 0) {
 	process.exit(1);
 }
 
-const label = `${owner}/${pkg}`;
-const api = `https://api.github.com/orgs/${owner}/packages/container/${encodeURIComponent(pkg)}`;
+// Same reasoning as the empty-input guard above: a list that parses to nothing (e.g. ",,") would run
+// zero checks and let the gate pass green.
+const packages = packageList
+	.split(",")
+	.map((name) => name.trim())
+	.filter((name) => name.length > 0);
+if (packages.length === 0) {
+	core.setFailed(
+		`release-ensure-public: PACKAGE ('${packageList}') names no packages. Refusing to run — an empty list would let the public-package gate pass without checking anything.`,
+	);
+	process.exit(1);
+}
 
-await core.group(`Ensure GHCR package ${label} is public`, async () => {
-	let res: Response;
-	try {
-		// Distinguish a real transport failure (throws) from an HTTP status (a 404/403 does NOT throw) —
-		// the whole point of the guard is not to publish blind on a swallowed error.
-		res = await fetch(api, {
-			headers: {
-				Authorization: `Bearer ${token}`,
-				Accept: "application/vnd.github+json",
-				"User-Agent": "sandbox-benchmarks-release",
-			},
-			signal: AbortSignal.timeout(30_000),
-		});
-	} catch (err) {
-		core.setFailed(
-			`Could not reach the GHCR package API (network/transport error) — refusing to publish blind: ${err instanceof Error ? err.message : String(err)}`,
-		);
-		return;
-	}
+/** Check one package's visibility, reporting via annotations. Never throws. */
+async function ensurePublic(pkg: string): Promise<void> {
+	const label = `${owner}/${pkg}`;
+	const api = `https://api.github.com/orgs/${owner}/packages/container/${encodeURIComponent(pkg)}`;
 
-	if (res.status === 200) {
-		const body = (await res.json().catch(() => ({}))) as { visibility?: string };
-		if (body.visibility === "public") {
-			core.info(`GHCR package ${label} is public — providers can pull the candidate.`);
-		} else {
-			core.error(
-				`GHCR package ${label} is ${body.visibility ?? "not public"}. e2b/daytona/modal/novita pull the candidate base anonymously, so set it Public once (org package settings or link it to this repo), then re-run.`,
-				{ title: "GHCR candidate package is not public" },
+	await core.group(`Ensure GHCR package ${label} is public`, async () => {
+		let res: Response;
+		try {
+			// Distinguish a real transport failure (throws) from an HTTP status (a 404/403 does NOT throw) —
+			// the whole point of the guard is not to publish blind on a swallowed error.
+			res = await fetch(api, {
+				headers: {
+					Authorization: `Bearer ${token}`,
+					Accept: "application/vnd.github+json",
+					"User-Agent": "sandbox-benchmarks-release",
+				},
+				signal: AbortSignal.timeout(30_000),
+			});
+		} catch (err) {
+			core.setFailed(
+				`Could not reach the GHCR package API for ${label} (network/transport error) — refusing to publish blind: ${err instanceof Error ? err.message : String(err)}`,
 			);
-			core.setFailed(`GHCR package ${label} is not public.`);
+			return;
 		}
-	} else if (res.status === 404) {
-		core.warning(
-			`GHCR package ${label} not found yet — the build below creates it PRIVATE. After this run, set it Public once so the candidate validate and the providers can pull it; this run's bake will fail until then.`,
-			{ title: "GHCR candidate package not found yet" },
-		);
-	} else {
-		core.setFailed(
-			`GHCR package API returned HTTP ${res.status} (expected 200 or 404) — likely a token-scope gap or org SSO enforcement, not a missing package. Resolve and re-run instead of publishing blind.`,
-		);
-	}
-});
+
+		if (res.status === 200) {
+			const body = (await res.json().catch(() => ({}))) as { visibility?: string };
+			if (body.visibility === "public") {
+				core.info(`GHCR package ${label} is public — providers can pull the candidate.`);
+			} else {
+				core.error(
+					`GHCR package ${label} is ${body.visibility ?? "not public"}. The providers pull the candidate anonymously, so set it Public once (org package settings or link it to this repo), then re-run.`,
+					{ title: "GHCR candidate package is not public" },
+				);
+				core.setFailed(`GHCR package ${label} is not public.`);
+			}
+		} else if (res.status === 404) {
+			core.warning(
+				`GHCR package ${label} not found yet — the build below creates it PRIVATE. After this run, set it Public once so the candidate validate and the providers can pull it; this run's bake will fail until then.`,
+				{ title: "GHCR candidate package not found yet" },
+			);
+		} else {
+			core.setFailed(
+				`GHCR package API returned HTTP ${res.status} for ${label} (expected 200 or 404) — likely a token-scope gap or org SSO enforcement, not a missing package. Resolve and re-run instead of publishing blind.`,
+			);
+		}
+	});
+}
+
+// Sequential, not Promise.all: core.group nests its log output, so concurrent groups would interleave
+// into one unreadable block — and the list is two entries long.
+for (const pkg of packages) await ensurePublic(pkg);

--- a/apps/cli/src/bin/release-plan.test.ts
+++ b/apps/cli/src/bin/release-plan.test.ts
@@ -1,7 +1,9 @@
 import { describe, expect, test } from "bun:test";
+import { PROVIDERS } from "@sandbox-benchmarks/schema";
 import { buildReleasePlan, planOutputs, RELEASE_REQUIRED_PROVIDERS } from "./release-plan.ts";
 
 const base = { sourceRef: "abc123", forceRepublish: false, alreadyPublished: false };
+const ALL_PROVIDERS = PROVIDERS.map((p) => p.id);
 
 describe("buildReleasePlan mode + skip", () => {
 	test("a fresh build of an unpublished version runs (mode build, skip false)", () => {
@@ -21,6 +23,15 @@ describe("buildReleasePlan mode + skip", () => {
 		expect(plan.mode).toBe("republish");
 		expect(plan.skip).toBe(false);
 		expect(plan.gates.forceRepublish).toBe(true);
+	});
+
+	// The reason the scoped path exists: v7 was published for every provider except the one being added,
+	// so the early skip would otherwise kill the run before it could backfill anything.
+	test("a scoped release runs against an already-published version (mode backfill, skip false)", () => {
+		const plan = buildReleasePlan({ ...base, alreadyPublished: true, providers: "vercel" });
+		expect(plan.mode).toBe("backfill");
+		expect(plan.partial).toBe(true);
+		expect(plan.skip).toBe(false);
 	});
 });
 
@@ -48,6 +59,54 @@ describe("buildReleasePlan matrix", () => {
 		expect(required).toEqual([...RELEASE_REQUIRED_PROVIDERS]);
 		expect(plan.required).toEqual([...RELEASE_REQUIRED_PROVIDERS]);
 	});
+
+	test("a scoped dispatch emits only its own cells", () => {
+		const plan = buildReleasePlan({ ...base, providers: "vercel" });
+		expect(plan.matrix.include).toEqual([{ provider: "vercel", required: true }]);
+		expect(plan.providers.map((p) => p.provider)).toEqual(["vercel"]);
+	});
+
+	// A named provider that could still skip on a missing secret would report a green release that
+	// published nothing — the exact failure the scoped path is meant to make impossible.
+	test("every provider a scoped dispatch names is required, even a normally best-effort one", () => {
+		const plan = buildReleasePlan({ ...base, providers: "blaxel,novita" });
+		expect(plan.required).toEqual(["blaxel", "novita"]);
+		expect(plan.matrix.include.every((c) => c.required)).toBe(true);
+	});
+
+	test("naming the whole registry is a full release, not a partial one", () => {
+		const plan = buildReleasePlan({ ...base, providers: ALL_PROVIDERS.join(",") });
+		expect(plan.partial).toBe(false);
+		expect(plan.mode).toBe("build");
+	});
+
+	test("an unknown provider id throws instead of silently shrinking the release", () => {
+		expect(() => buildReleasePlan({ ...base, providers: "vercelly" })).toThrow(/vercelly/);
+	});
+});
+
+describe("buildReleasePlan phases", () => {
+	test("defaults to a full build that promotes", () => {
+		const plan = buildReleasePlan(base);
+		expect(plan.build).toBe("full");
+		expect(plan.promote).toBe(true);
+	});
+
+	test("carries the build mode and promote toggle through to the plan", () => {
+		const plan = buildReleasePlan({ ...base, build: "variants", promote: false });
+		expect(plan.build).toBe("variants");
+		expect(plan.promote).toBe(false);
+	});
+});
+
+describe("buildReleasePlan packages", () => {
+	// The vercel bake cell pulls its staged variant from GHCR with no login, so the variant package has
+	// to be covered by the visibility guard too — the base alone is not enough.
+	test("lists the base package and every registry-served variant package", () => {
+		const plan = buildReleasePlan(base);
+		expect(plan.packages[0]).toBe(plan.image.name);
+		expect(plan.packages).toContain(`${plan.image.name}-vercel`);
+	});
 });
 
 describe("planOutputs", () => {
@@ -62,5 +121,30 @@ describe("planOutputs", () => {
 		const parsed = JSON.parse((matrixLine as string).slice("matrix=".length));
 		expect(parsed.include).toHaveLength(11);
 		expect((matrixLine as string).includes("\n")).toBe(false);
+	});
+
+	// The workflow's `if:` conditions compare against these literal strings, so the booleans have to
+	// render as `true`/`false` — not `True`, not empty.
+	test("emits the job-skipping gates as the strings the workflow compares against", () => {
+		const lines = planOutputs(buildReleasePlan({ ...base, build: "skip", promote: false })).split(
+			"\n",
+		);
+		expect(lines).toContain("build-mode=skip");
+		expect(lines).toContain("run-build=false");
+		expect(lines).toContain("run-publish=false");
+	});
+
+	test("emits the RESOLVED provider scope, so a blank input becomes the whole registry", () => {
+		expect(planOutputs(buildReleasePlan(base)).split("\n")).toContain(
+			`providers=${ALL_PROVIDERS.join(",")}`,
+		);
+		expect(planOutputs(buildReleasePlan({ ...base, providers: "vercel" })).split("\n")).toContain(
+			"providers=vercel",
+		);
+	});
+
+	test("emits every package the visibility guard must check, comma-separated", () => {
+		const plan = buildReleasePlan(base);
+		expect(planOutputs(plan).split("\n")).toContain(`packages=${plan.packages.join(",")}`);
 	});
 });

--- a/apps/cli/src/bin/release-plan.test.ts
+++ b/apps/cli/src/bin/release-plan.test.ts
@@ -68,16 +68,20 @@ describe("buildReleasePlan matrix", () => {
 
 	// A named provider that could still skip on a missing secret would report a green release that
 	// published nothing — the exact failure the scoped path is meant to make impossible.
-	test("every provider a scoped dispatch names is required, even a normally best-effort one", () => {
+	test("every provider a partial dispatch names is required, even a normally best-effort one", () => {
 		const plan = buildReleasePlan({ ...base, providers: "blaxel,novita" });
 		expect(plan.required).toEqual(["blaxel", "novita"]);
 		expect(plan.matrix.include.every((c) => c.required)).toBe(true);
 	});
 
-	test("naming the whole registry is a full release, not a partial one", () => {
+	// Everything keys off `partial`, never "did the operator type a list" — otherwise spelling out the
+	// registry would quietly make every best-effort provider gating, and force_republish (rejected only
+	// for a partial release) would land on a release whose required set had silently grown.
+	test("naming the whole registry is an ordinary full release", () => {
 		const plan = buildReleasePlan({ ...base, providers: ALL_PROVIDERS.join(",") });
 		expect(plan.partial).toBe(false);
 		expect(plan.mode).toBe("build");
+		expect(plan.required).toEqual([...RELEASE_REQUIRED_PROVIDERS]);
 	});
 
 	test("an unknown provider id throws instead of silently shrinking the release", () => {
@@ -106,6 +110,18 @@ describe("buildReleasePlan packages", () => {
 		const plan = buildReleasePlan(base);
 		expect(plan.packages[0]).toBe(plan.image.name);
 		expect(plan.packages).toContain(`${plan.image.name}-vercel`);
+	});
+
+	// The guard FAILS the release on a package that isn't public yet, so listing a variant no in-scope
+	// provider pulls would block a release over an image it never reads.
+	test("omits a variant package no provider in scope pulls", () => {
+		const plan = buildReleasePlan({ ...base, providers: "e2b" });
+		expect(plan.packages).toEqual([plan.image.name]);
+	});
+
+	test("keeps the variant package when its own provider is in scope", () => {
+		const plan = buildReleasePlan({ ...base, providers: "vercel" });
+		expect(plan.packages).toEqual([plan.image.name, `${plan.image.name}-vercel`]);
 	});
 });
 

--- a/apps/cli/src/bin/release-plan.test.ts
+++ b/apps/cli/src/bin/release-plan.test.ts
@@ -38,6 +38,20 @@ describe("buildReleasePlan mode + skip", () => {
 		expect(plan.partial).toBe(true);
 		expect(plan.skip).toBe(false);
 	});
+
+	// The early skip spares a release that would only re-publish a version already in the registry. A
+	// dispatch that is not publishing has nothing to spare — it asked to bake and verify against the
+	// current version — so skipping it would turn the whole run into a silent no-op.
+	test("promote: false still runs against an already-published version", () => {
+		const plan = buildReleasePlan({ ...base, alreadyPublished: true, promote: false });
+		expect(plan.partial).toBe(false);
+		expect(plan.promote).toBe(false);
+		expect(plan.skip).toBe(false);
+	});
+
+	test("...but a promoting full release of the same version still skips", () => {
+		expect(buildReleasePlan({ ...base, alreadyPublished: true, promote: true }).skip).toBe(true);
+	});
 });
 
 describe("buildReleasePlan matrix", () => {

--- a/apps/cli/src/bin/release-plan.test.ts
+++ b/apps/cli/src/bin/release-plan.test.ts
@@ -1,6 +1,11 @@
 import { describe, expect, test } from "bun:test";
 import { PROVIDERS } from "@sandbox-benchmarks/schema";
-import { buildReleasePlan, planOutputs, RELEASE_REQUIRED_PROVIDERS } from "./release-plan.ts";
+import {
+	buildReleasePlan,
+	planOutputs,
+	RELEASE_REQUIRED_PROVIDERS,
+	RELEASE_UNSCOPABLE_PROVIDERS,
+} from "./release-plan.ts";
 
 const base = { sourceRef: "abc123", forceRepublish: false, alreadyPublished: false };
 const ALL_PROVIDERS = PROVIDERS.map((p) => p.id);
@@ -69,9 +74,28 @@ describe("buildReleasePlan matrix", () => {
 	// A named provider that could still skip on a missing secret would report a green release that
 	// published nothing — the exact failure the scoped path is meant to make impossible.
 	test("every provider a partial dispatch names is required, even a normally best-effort one", () => {
-		const plan = buildReleasePlan({ ...base, providers: "blaxel,novita" });
-		expect(plan.required).toEqual(["blaxel", "novita"]);
+		const plan = buildReleasePlan({ ...base, providers: "daytona-container,novita" });
+		expect(plan.required).toEqual(["daytona-container", "novita"]);
 		expect(plan.matrix.include.every((c) => c.required)).toBe(true);
+	});
+
+	// The flip side of "everything you name is required": a provider the lane carries no credentials
+	// for would fail its cell deterministically, after a privileged approval and (on `build: full`) an
+	// hour of rebuild. The plan refuses instead, naming the reason.
+	test("refuses a scope naming a provider the release lane cannot ship", () => {
+		expect(() => buildReleasePlan({ ...base, providers: "blaxel" })).toThrow(/blaxel/);
+		expect(() => buildReleasePlan({ ...base, providers: "e2b,blaxel" })).toThrow(
+			/BL_API_KEY|cannot ship/,
+		);
+	});
+
+	// Unscoped, the same provider is simply skipped — it is not in the required set, so a missing
+	// credential is a skip and the release proceeds. Only a scope makes it a demand.
+	test("the same provider is fine in an unscoped release", () => {
+		const plan = buildReleasePlan(base);
+		expect(plan.matrix.include.map((c) => c.provider)).toContain("blaxel");
+		expect(plan.required).not.toContain("blaxel");
+		expect(Object.keys(RELEASE_UNSCOPABLE_PROVIDERS)).toEqual(["blaxel"]);
 	});
 
 	// Everything keys off `partial`, never "did the operator type a list" — otherwise spelling out the

--- a/apps/cli/src/bin/release-plan.ts
+++ b/apps/cli/src/bin/release-plan.ts
@@ -44,6 +44,25 @@ export const RELEASE_REQUIRED_PROVIDERS: readonly ProviderId[] = [
 	"modal-gvisor",
 ];
 
+/**
+ * Providers a SCOPED release cannot name, with the reason. An unscoped release simply skips these (a
+ * missing credential is a skip, and they are not in {@link RELEASE_REQUIRED_PROVIDERS}); naming one in
+ * `providers` says "make this ship", which the lane then cannot do — and every provider a scoped
+ * dispatch names is required, so the cell fails on missing credentials AFTER a `privileged` approval
+ * and, on a `build: full` dispatch, an hour of rebuild. Refusing in the plan turns that into a
+ * fail-fast with an explanation.
+ *
+ * Keyed by provider so the reason travels with the refusal. Blaxel is the only entry: its bake is a
+ * no-op (it boots the vendor's stock image, not our toolchain) and its promote publishes nothing, so
+ * the release lane deliberately injects no BL_API_KEY/BL_WORKSPACE — those live in the bench lane
+ * only (docs/ci-secrets.md). Adding credentials to the bake matrix is what would remove an entry here.
+ */
+export const RELEASE_UNSCOPABLE_PROVIDERS: Readonly<Partial<Record<ProviderId, string>>> = {
+	blaxel:
+		"it boots the vendor's stock image rather than the toolchain, so the release lane carries no " +
+		"BL_API_KEY/BL_WORKSPACE and has no artifact to publish for it",
+};
+
 /** Per-provider baked artifact name (what a cell produces), or a note for the providers that bake none. */
 function providerArtifact(id: ProviderId): string {
 	switch (id) {
@@ -150,6 +169,19 @@ export function buildReleasePlan(inputs: ReleasePlanInputs): ReleasePlan {
 	// spelling out the whole registry stays an ordinary full release, matching what promote will do.
 	const scope = selectProviders(inputs.providers);
 	const partial = isPartialScope(scope);
+
+	// Refuse a scope naming a provider the lane cannot ship, before the release spends an approval and
+	// a build on a cell that is guaranteed to fail (see RELEASE_UNSCOPABLE_PROVIDERS).
+	if (partial) {
+		const unscopable = scope.filter((id) => RELEASE_UNSCOPABLE_PROVIDERS[id]);
+		if (unscopable.length > 0) {
+			throw new Error(
+				`the release lane cannot ship ${unscopable.join(", ")}: ${unscopable
+					.map((id) => `${id} — ${RELEASE_UNSCOPABLE_PROVIDERS[id]}`)
+					.join("; ")}. Drop it from \`providers\` (an unscoped release skips it).`,
+			);
+		}
+	}
 
 	// A partial dispatch names exactly the providers it wants, so every one of them is REQUIRED: the
 	// point of `providers: vercel` is to make that provider ship, and a "best-effort" cell would let it

--- a/apps/cli/src/bin/release-plan.ts
+++ b/apps/cli/src/bin/release-plan.ts
@@ -19,8 +19,11 @@ import { config } from "@sandbox-benchmarks/providers";
 import type { ProviderId } from "@sandbox-benchmarks/schema";
 import { PROVIDERS } from "@sandbox-benchmarks/schema";
 import { validatedPins } from "@sandbox-benchmarks/templates/pins";
-import { imageExistsInRegistry, imageRepo } from "../lib/bake/image.ts";
+import { imageExistsInRegistry, imageRepo, PUBLISHED_VARIANTS } from "../lib/bake/image.ts";
 import { emitStepOutputs } from "../lib/gha-output.ts";
+import { selectProviders } from "../lib/matrix.ts";
+import type { ReleaseBuildMode } from "../lib/release-inputs.ts";
+import { isBuildMode } from "../lib/release-inputs.ts";
 
 /**
  * Providers the release is REQUIRED to bake + validate before the public version is published — the
@@ -37,11 +40,12 @@ export const RELEASE_REQUIRED_PROVIDERS: readonly ProviderId[] = [
 	"modal-gvisor",
 ];
 
-/** Every provider the release fans out over, derived from the registry (never a hand-maintained
- *  literal) so adding a provider grows the matrix automatically — in registry order, matching the
- *  matrix cell order. `providerArtifact` below is exhaustive over `ProviderId`, so a new provider is a
- *  compile error there until it's handled. */
-const RELEASE_PROVIDERS: readonly ProviderId[] = PROVIDERS.map((p) => p.id);
+/** Every provider the release CAN fan out over, derived from the registry (never a hand-maintained
+ *  literal) so adding a provider grows the default matrix automatically — in registry order, matching
+ *  the matrix cell order. `providerArtifact` below is exhaustive over `ProviderId`, so a new provider
+ *  is a compile error there until it's handled. The list a given release actually covers is this one
+ *  narrowed by the `providers` dispatch input; comparing the two lengths is what makes it `partial`. */
+const REGISTERED_PROVIDERS: readonly ProviderId[] = PROVIDERS.map((p) => p.id);
 
 /** Per-provider baked artifact name (what a cell produces), or a note for the providers that bake none. */
 function providerArtifact(id: ProviderId): string {
@@ -77,6 +81,13 @@ export interface ReleasePlanInputs {
 	forceRepublish: boolean;
 	/** Whether the immutable public version already exists in the registry (the early-skip probe). */
 	alreadyPublished: boolean;
+	/** `providers` dispatch input: a comma-separated id list the release is restricted to. Blank/absent
+	 *  → every registered provider (the default full release). An unknown id throws. */
+	providers?: string;
+	/** `build` dispatch input; blank/absent → `full`. */
+	build?: ReleaseBuildMode;
+	/** `promote` dispatch input; absent → true (the publish phase runs). */
+	promote?: boolean;
 }
 
 export interface ReleaseProviderPlan {
@@ -86,10 +97,22 @@ export interface ReleaseProviderPlan {
 }
 
 export interface ReleasePlan {
-	/** `build` for a fresh release; `republish` when force_republish regenerates an existing version. */
-	mode: "build" | "republish";
-	/** Skip the whole release: the version is already published and this is not a forced republish. */
+	/** `build` for a fresh release; `republish` when force_republish regenerates an existing version;
+	 *  `backfill` when a scoped dispatch adds a subset of providers to an already-published version. */
+	mode: "build" | "republish" | "backfill";
+	/** Skip the whole release: the version is already published and this is not a forced republish
+	 *  or a scoped backfill (both of which deliberately target an existing version). */
 	skip: boolean;
+	/** How the BUILD phase runs. `full` rebuilds the base and pushes a new mutable candidate base;
+	 *  `variants` leaves the base alone and restages only the registry-served provider variants on top
+	 *  of the already-published version base (the backfill path — same bytes as the running fleet);
+	 *  `skip` runs no build job at all and reuses whatever candidates the registry already holds. */
+	build: ReleaseBuildMode;
+	/** Whether the publish (promote) phase runs at all — false bakes and verifies, then stops. */
+	promote: boolean;
+	/** True when this release covers a strict SUBSET of the registry. A partial release never rewrites
+	 *  the public base: it publishes only its own providers' version artifacts onto the existing one. */
+	partial: boolean;
 	sourceRef: string;
 	/** The single cross-provider size tier (this benchmark pins exactly one — no size-tier fan-out). */
 	sizeTier: string;
@@ -101,6 +124,9 @@ export interface ReleasePlan {
 		candidate: string;
 		toolchainVersion: string;
 	};
+	/** Every GHCR package a provider pulls anonymously, so the visibility guard covers all of them —
+	 *  the base plus each registry-served variant (see PUBLISHED_VARIANTS in lib/bake/image.ts). */
+	packages: string[];
 	providers: ReleaseProviderPlan[];
 	/** The providers that must pass before publish (single-sourced for the matrix + promote gate). */
 	required: ProviderId[];
@@ -110,7 +136,7 @@ export interface ReleasePlan {
 		/** The immutable pointer promote advances — the only mutation the release makes public. */
 		publishTarget: string;
 	};
-	/** The `strategy.matrix` contract the bake fan-out reads: one cell per provider. */
+	/** The `strategy.matrix` contract the bake fan-out reads: one cell per provider IN SCOPE. */
 	matrix: { include: Array<{ provider: ProviderId; required: boolean }> };
 }
 
@@ -120,41 +146,70 @@ export interface ReleasePlan {
  * `config`-derived values below.
  */
 export function buildReleasePlan(inputs: ReleasePlanInputs): ReleasePlan {
-	const mode = inputs.forceRepublish ? "republish" : "build";
-	// force_republish deliberately regenerates the version in place, so "already published" never skips
-	// it; a plain build skips once the immutable version exists (bump TOOLCHAIN_VERSION to publish anew).
-	const skip = inputs.alreadyPublished && !inputs.forceRepublish;
+	// A blank `providers` input means "every provider" (the default full release); a non-blank one is
+	// resolved against the registry by selectProviders, which throws on an unknown id rather than
+	// silently shrinking the release. `scoped` is about what the OPERATOR asked for, so spelling out
+	// the whole registry still counts as a full release below.
+	const scoped = (inputs.providers ?? "").trim() !== "";
+	const scope = selectProviders(inputs.providers);
+	const partial = scope.length < REGISTERED_PROVIDERS.length;
 
-	const providers: ReleaseProviderPlan[] = RELEASE_PROVIDERS.map((provider) => ({
+	// A scoped dispatch names exactly the providers it wants, so every one of them is REQUIRED: the
+	// point of `providers: vercel` is to make that provider ship, and a "best-effort" cell would let it
+	// skip on a missing secret and still report a green release that published nothing. The default
+	// (unscoped) release keeps the standing required set, where best-effort variants are expected.
+	const required: ProviderId[] = scoped ? [...scope] : [...RELEASE_REQUIRED_PROVIDERS];
+
+	// force_republish deliberately regenerates the version in place and a partial release deliberately
+	// backfills onto it, so "already published" never skips either; a plain build skips once the
+	// immutable version exists (bump TOOLCHAIN_VERSION to publish anew).
+	const mode = partial ? "backfill" : inputs.forceRepublish ? "republish" : "build";
+	const skip = inputs.alreadyPublished && !inputs.forceRepublish && !partial;
+
+	const providers: ReleaseProviderPlan[] = scope.map((provider) => ({
 		provider,
-		required: RELEASE_REQUIRED_PROVIDERS.includes(provider),
+		required: required.includes(provider),
 		artifact: providerArtifact(provider),
 	}));
 
 	const { vcpus, memoryGb, diskGb } = config.targetSpec;
 	const repo = imageRepo(config.toolchainImageVersion);
+	const packageName = (ref: string): string => {
+		const packageRepo = imageRepo(ref);
+		return packageRepo.split("/").pop() ?? packageRepo;
+	};
 
 	return {
 		mode,
 		skip,
+		build: inputs.build ?? "full",
+		promote: inputs.promote ?? true,
+		partial,
 		sourceRef: inputs.sourceRef,
 		sizeTier: `${vcpus} vCPU / ${memoryGb} GiB / ${diskGb} GB`,
 		image: {
 			repo,
-			name: repo.split("/").pop() ?? repo,
+			name: packageName(config.toolchainImageVersion),
 			version: config.toolchainImageVersion,
 			candidate: config.toolchainImageCandidate,
 			toolchainVersion: config.toolchainVersion,
 		},
+		packages: [
+			packageName(config.toolchainImageVersion),
+			...PUBLISHED_VARIANTS.map((entry) => packageName(entry.version)),
+		],
 		providers,
-		required: [...RELEASE_REQUIRED_PROVIDERS],
+		required,
 		gates: {
 			alreadyPublished: inputs.alreadyPublished,
 			forceRepublish: inputs.forceRepublish,
 			publishTarget: config.toolchainImageVersion,
 		},
 		matrix: {
-			include: providers.map(({ provider, required }) => ({ provider, required })),
+			include: providers.map(({ provider, required: cellRequired }) => ({
+				provider,
+				required: cellRequired,
+			})),
 		},
 	};
 }
@@ -166,11 +221,20 @@ export function planOutputs(plan: ReleasePlan): string {
 	return [
 		`mode=${plan.mode}`,
 		`skip=${plan.skip}`,
-		`image-name=${plan.image.name}`,
+		`packages=${plan.packages.join(",")}`,
 		`image-candidate=${plan.image.candidate}`,
 		`toolchain-version=${plan.image.toolchainVersion}`,
 		`size-tier=${plan.sizeTier}`,
+		// The RESOLVED scope, never the raw dispatch input: a blank input becomes the full registry list
+		// here, so every consumer (the promote `--provider`, the per-provider setup steps' `contains()`
+		// guards) reads one shape and none of them has to re-encode "blank means everything".
+		`providers=${plan.providers.map((p) => p.provider).join(",")}`,
 		`required=${plan.required.join(",")}`,
+		// The two dynamic job-skipping gates: `build` is skipped outright in `skip` mode, `publish` when
+		// the dispatch asked to bake + verify only.
+		`build-mode=${plan.build}`,
+		`run-build=${plan.build !== "skip"}`,
+		`run-publish=${plan.promote}`,
 		`publish-target=${plan.gates.publishTarget}`,
 		// The matrix must be a single line of compact JSON — it becomes `fromJSON(needs.plan.outputs.matrix)`.
 		`matrix=${JSON.stringify(plan.matrix)}`,
@@ -184,6 +248,14 @@ if (import.meta.main) {
 
 	const forceRepublish = process.env.FORCE_REPUBLISH === "true";
 	const sourceRef = process.env.GITHUB_SHA ?? "unknown";
+	const providers = process.env.RELEASE_PROVIDERS ?? "";
+	// The dispatch inputs are already validated (shape and combination) by release-validate.ts, which
+	// runs before this in the same job. Re-derive rather than re-check: an out-of-range value can only
+	// get here if that gate was bypassed, and `build`/`promote` fall back to the safe full-release
+	// default while `providers` still throws through selectProviders on an unknown id.
+	const rawBuild = (process.env.BUILD_MODE ?? "").trim();
+	const build: ReleaseBuildMode = isBuildMode(rawBuild) ? rawBuild : "full";
+	const promote = process.env.PROMOTE !== "false";
 
 	// Best-effort immutability probe: an inconclusive result (auth/network) proceeds — promote does the
 	// authoritative, refuse-on-uncertain check before it writes the immutable base.
@@ -197,7 +269,27 @@ if (import.meta.main) {
 		);
 	}
 
-	const plan = buildReleasePlan({ sourceRef, forceRepublish, alreadyPublished });
+	const plan = buildReleasePlan({
+		sourceRef,
+		forceRepublish,
+		alreadyPublished,
+		providers,
+		build,
+		promote,
+	});
+
+	// A partial release BACKFILLS providers onto an already-published version, so a version that isn't
+	// published yet means the operator scoped a release that has no base to attach to. Warn rather than
+	// fail: the probe above is best-effort (an auth/network blip reads as "not published"), and promote
+	// does the authoritative refuse-on-uncertain check before anything is written.
+	if (plan.partial && !alreadyPublished && plan.promote) {
+		console.error(
+			`::warning::${config.toolchainImageVersion} does not look published yet, but this is a scoped ` +
+				`release (${plan.providers.map((p) => p.provider).join(", ")}) — a scoped promote backfills ` +
+				"providers onto an existing version and never writes the base, so it will refuse. Run a full " +
+				"release first, or dispatch with promote disabled to bake + verify only.",
+		);
+	}
 
 	// Optional first positional (flags filtered out): write the full plan JSON here for the
 	// release-plan.json diagnostic artifact.

--- a/apps/cli/src/bin/release-plan.ts
+++ b/apps/cli/src/bin/release-plan.ts
@@ -17,11 +17,15 @@
 // REFUSES on an uncertain check), so an inconclusive probe here proceeds rather than blocks.
 import { config } from "@sandbox-benchmarks/providers";
 import type { ProviderId } from "@sandbox-benchmarks/schema";
-import { PROVIDERS } from "@sandbox-benchmarks/schema";
 import { validatedPins } from "@sandbox-benchmarks/templates/pins";
-import { imageExistsInRegistry, imageRepo, PUBLISHED_VARIANTS } from "../lib/bake/image.ts";
+import {
+	imageExistsInRegistry,
+	imageName,
+	imageRepo,
+	PUBLISHED_VARIANTS,
+} from "../lib/bake/image.ts";
 import { emitStepOutputs } from "../lib/gha-output.ts";
-import { selectProviders } from "../lib/matrix.ts";
+import { isPartialScope, selectProviders } from "../lib/matrix.ts";
 import type { ReleaseBuildMode } from "../lib/release-inputs.ts";
 import { isBuildMode } from "../lib/release-inputs.ts";
 
@@ -39,13 +43,6 @@ export const RELEASE_REQUIRED_PROVIDERS: readonly ProviderId[] = [
 	"daytona-vm",
 	"modal-gvisor",
 ];
-
-/** Every provider the release CAN fan out over, derived from the registry (never a hand-maintained
- *  literal) so adding a provider grows the default matrix automatically — in registry order, matching
- *  the matrix cell order. `providerArtifact` below is exhaustive over `ProviderId`, so a new provider
- *  is a compile error there until it's handled. The list a given release actually covers is this one
- *  narrowed by the `providers` dispatch input; comparing the two lengths is what makes it `partial`. */
-const REGISTERED_PROVIDERS: readonly ProviderId[] = PROVIDERS.map((p) => p.id);
 
 /** Per-provider baked artifact name (what a cell produces), or a note for the providers that bake none. */
 function providerArtifact(id: ProviderId): string {
@@ -124,8 +121,9 @@ export interface ReleasePlan {
 		candidate: string;
 		toolchainVersion: string;
 	};
-	/** Every GHCR package a provider pulls anonymously, so the visibility guard covers all of them —
-	 *  the base plus each registry-served variant (see PUBLISHED_VARIANTS in lib/bake/image.ts). */
+	/** Every GHCR package an IN-SCOPE provider pulls anonymously, so the visibility guard covers all of
+	 *  them — the base plus each registry-served variant whose provider this release covers (see
+	 *  PUBLISHED_VARIANTS in lib/bake/image.ts). */
 	packages: string[];
 	providers: ReleaseProviderPlan[];
 	/** The providers that must pass before publish (single-sourced for the matrix + promote gate). */
@@ -148,17 +146,16 @@ export interface ReleasePlan {
 export function buildReleasePlan(inputs: ReleasePlanInputs): ReleasePlan {
 	// A blank `providers` input means "every provider" (the default full release); a non-blank one is
 	// resolved against the registry by selectProviders, which throws on an unknown id rather than
-	// silently shrinking the release. `scoped` is about what the OPERATOR asked for, so spelling out
-	// the whole registry still counts as a full release below.
-	const scoped = (inputs.providers ?? "").trim() !== "";
+	// silently shrinking the release. Everything below keys off `partial` — a STRICT subset — so
+	// spelling out the whole registry stays an ordinary full release, matching what promote will do.
 	const scope = selectProviders(inputs.providers);
-	const partial = scope.length < REGISTERED_PROVIDERS.length;
+	const partial = isPartialScope(scope);
 
-	// A scoped dispatch names exactly the providers it wants, so every one of them is REQUIRED: the
+	// A partial dispatch names exactly the providers it wants, so every one of them is REQUIRED: the
 	// point of `providers: vercel` is to make that provider ship, and a "best-effort" cell would let it
-	// skip on a missing secret and still report a green release that published nothing. The default
-	// (unscoped) release keeps the standing required set, where best-effort variants are expected.
-	const required: ProviderId[] = scoped ? [...scope] : [...RELEASE_REQUIRED_PROVIDERS];
+	// skip on a missing secret and still report a green release that published nothing. A full release
+	// keeps the standing required set, where best-effort variants are expected.
+	const required: ProviderId[] = partial ? [...scope] : [...RELEASE_REQUIRED_PROVIDERS];
 
 	// force_republish deliberately regenerates the version in place and a partial release deliberately
 	// backfills onto it, so "already published" never skips either; a plain build skips once the
@@ -173,11 +170,6 @@ export function buildReleasePlan(inputs: ReleasePlanInputs): ReleasePlan {
 	}));
 
 	const { vcpus, memoryGb, diskGb } = config.targetSpec;
-	const repo = imageRepo(config.toolchainImageVersion);
-	const packageName = (ref: string): string => {
-		const packageRepo = imageRepo(ref);
-		return packageRepo.split("/").pop() ?? packageRepo;
-	};
 
 	return {
 		mode,
@@ -188,15 +180,20 @@ export function buildReleasePlan(inputs: ReleasePlanInputs): ReleasePlan {
 		sourceRef: inputs.sourceRef,
 		sizeTier: `${vcpus} vCPU / ${memoryGb} GiB / ${diskGb} GB`,
 		image: {
-			repo,
-			name: packageName(config.toolchainImageVersion),
+			repo: imageRepo(config.toolchainImageVersion),
+			name: imageName(config.toolchainImageVersion),
 			version: config.toolchainImageVersion,
 			candidate: config.toolchainImageCandidate,
 			toolchainVersion: config.toolchainVersion,
 		},
+		// Scoped to what this release actually pulls: the guard FAILS a release whose package is still
+		// private, so listing a variant no in-scope provider touches would block a release over a
+		// package it never reads.
 		packages: [
-			packageName(config.toolchainImageVersion),
-			...PUBLISHED_VARIANTS.map((entry) => packageName(entry.version)),
+			imageName(config.toolchainImageVersion),
+			...PUBLISHED_VARIANTS.filter((entry) => scope.includes(entry.provider)).map((entry) =>
+				imageName(entry.version),
+			),
 		],
 		providers,
 		required,
@@ -206,10 +203,7 @@ export function buildReleasePlan(inputs: ReleasePlanInputs): ReleasePlan {
 			publishTarget: config.toolchainImageVersion,
 		},
 		matrix: {
-			include: providers.map(({ provider, required: cellRequired }) => ({
-				provider,
-				required: cellRequired,
-			})),
+			include: providers.map((p) => ({ provider: p.provider, required: p.required })),
 		},
 	};
 }
@@ -251,10 +245,11 @@ if (import.meta.main) {
 	const providers = process.env.RELEASE_PROVIDERS ?? "";
 	// The dispatch inputs are already validated (shape and combination) by release-validate.ts, which
 	// runs before this in the same job. Re-derive rather than re-check: an out-of-range value can only
-	// get here if that gate was bypassed, and `build`/`promote` fall back to the safe full-release
-	// default while `providers` still throws through selectProviders on an unknown id.
+	// get here if that gate was bypassed, and an unrecognized `build` is passed through as `undefined`
+	// so buildReleasePlan applies the one full-release default (rather than a second copy of it here);
+	// `providers` still throws through selectProviders on an unknown id.
 	const rawBuild = (process.env.BUILD_MODE ?? "").trim();
-	const build: ReleaseBuildMode = isBuildMode(rawBuild) ? rawBuild : "full";
+	const build: ReleaseBuildMode | undefined = isBuildMode(rawBuild) ? rawBuild : undefined;
 	const promote = process.env.PROMOTE !== "false";
 
 	// Best-effort immutability probe: an inconclusive result (auth/network) proceeds — promote does the

--- a/apps/cli/src/bin/release-plan.ts
+++ b/apps/cli/src/bin/release-plan.ts
@@ -192,8 +192,15 @@ export function buildReleasePlan(inputs: ReleasePlanInputs): ReleasePlan {
 	// force_republish deliberately regenerates the version in place and a partial release deliberately
 	// backfills onto it, so "already published" never skips either; a plain build skips once the
 	// immutable version exists (bump TOOLCHAIN_VERSION to publish anew).
+	//
+	// `promote: false` is the third exception, and for a different reason than the other two: the early
+	// skip exists to spare a release that would only re-publish a version already sitting in the
+	// registry. A dispatch that is not publishing has nothing to be spared — it asked to bake and verify
+	// against the current version, which is exactly what you do BEFORE deciding to cut a new one — so
+	// letting "already published" skip it would silently turn the whole run into a no-op.
+	const promote = inputs.promote ?? true;
 	const mode = partial ? "backfill" : inputs.forceRepublish ? "republish" : "build";
-	const skip = inputs.alreadyPublished && !inputs.forceRepublish && !partial;
+	const skip = inputs.alreadyPublished && !inputs.forceRepublish && !partial && promote;
 
 	const providers: ReleaseProviderPlan[] = scope.map((provider) => ({
 		provider,
@@ -207,7 +214,7 @@ export function buildReleasePlan(inputs: ReleasePlanInputs): ReleasePlan {
 		mode,
 		skip,
 		build: inputs.build ?? "full",
-		promote: inputs.promote ?? true,
+		promote,
 		partial,
 		sourceRef: inputs.sourceRef,
 		sizeTier: `${vcpus} vCPU / ${memoryGb} GiB / ${diskGb} GB`,
@@ -285,11 +292,15 @@ if (import.meta.main) {
 	const promote = process.env.PROMOTE !== "false";
 
 	// Best-effort immutability probe: an inconclusive result (auth/network) proceeds — promote does the
-	// authoritative, refuse-on-uncertain check before it writes the immutable base.
+	// authoritative, refuse-on-uncertain check before it writes the immutable base. `probeConclusive`
+	// records whether the answer is evidence or just the default, so the gate below can tell a real
+	// "not published" from a registry blip.
 	let alreadyPublished = false;
+	let probeConclusive = true;
 	try {
 		alreadyPublished = await imageExistsInRegistry(config.toolchainImageVersion);
 	} catch (err) {
+		probeConclusive = false;
 		console.error(
 			`::warning::could not probe whether ${config.toolchainImageVersion} is already published ` +
 				`(${err instanceof Error ? err.message : String(err)}); proceeding — promote does the authoritative guard.`,
@@ -316,6 +327,21 @@ if (import.meta.main) {
 				"providers onto an existing version and never writes the base, so it will refuse. Run a full " +
 				"release first, or dispatch with promote disabled to bake + verify only.",
 		);
+	}
+
+	// `build: variants` composes the provider variants ON the published version base, so it cannot run
+	// before that version exists — the build job would die resolving it, after a `privileged` approval
+	// this (unprivileged) job can refuse ahead of. Unlike the warning above this is a hard failure: there
+	// is no path where the phase works without that base. It is gated on a CONCLUSIVE probe, though, so a
+	// registry blip degrades to the opaque-but-honest failure in the build job rather than a false refusal.
+	if (plan.build === "variants" && probeConclusive && !alreadyPublished) {
+		console.error(
+			`::error title=No published base to compose variants on::${config.toolchainImageVersion} is not ` +
+				"published, and `build: variants` rebuilds only the provider variants ON TOP of it — there is " +
+				"nothing to compose against. Use `build: full` to cut this version first; `variants` is for " +
+				"adding a provider to a version that already shipped.",
+		);
+		process.exit(1);
 	}
 
 	// Optional first positional (flags filtered out): write the full plan JSON here for the

--- a/apps/cli/src/bin/release-summary.ts
+++ b/apps/cli/src/bin/release-summary.ts
@@ -26,6 +26,7 @@ if (import.meta.main) {
 	const fields: Array<[label: string, value: string, kind: CellKind]> = [
 		["Status", status, "plain"],
 		["Mode", env("MODE"), "code"],
+		["Scope", env("SCOPE"), "plain"],
 		["Source ref", env("SOURCE_REF"), "code"],
 		["Image", env("IMAGE"), "code"],
 		["Base image", env("BASE_IMAGE"), "code"],

--- a/apps/cli/src/bin/release-validate.ts
+++ b/apps/cli/src/bin/release-validate.ts
@@ -6,18 +6,67 @@
 // Inputs arrive as env (the composite maps its `with:` inputs).
 import * as core from "@actions/core";
 import { validatedPins } from "@sandbox-benchmarks/templates/pins";
+import { selectProviders } from "../lib/matrix.ts";
+import { BUILD_MODES, isBuildMode } from "../lib/release-inputs.ts";
 
 // The arktype pin gatekeeper lives here; annotate failures on it so the run links straight to the pins.
 const PINS_FILE = "packages/templates/src/lib/pins.ts";
 
-// A dispatch input reaches the release as an env var; still, reject anything but the two booleans so a
-// hand-typed dispatch value can't slip through as a surprise "truthy" string downstream.
-const forceRepublish = process.env.FORCE_REPUBLISH ?? "";
-if (!["true", "false", ""].includes(forceRepublish)) {
-	core.error(`force_republish must be true or false (got '${forceRepublish}').`, {
+/** A dispatch boolean reaches the release as an env var; reject anything but the two spellings (and
+ *  unset) so a hand-typed value can't slip through as a surprise "truthy" string downstream. */
+function validateBoolean(name: string, value: string): boolean {
+	if (["true", "false", ""].includes(value)) return true;
+	core.error(`${name} must be true or false (got '${value}').`, {
 		title: "Invalid dispatch input",
 	});
-	core.setFailed("Invalid force_republish input.");
+	core.setFailed(`Invalid ${name} input.`);
+	return false;
+}
+
+const forceRepublish = process.env.FORCE_REPUBLISH?.trim() ?? "";
+const promote = process.env.PROMOTE?.trim() ?? "";
+const buildMode = process.env.BUILD_MODE?.trim() ?? "";
+const providers = process.env.RELEASE_PROVIDERS?.trim() ?? "";
+
+validateBoolean("force_republish", forceRepublish);
+validateBoolean("promote", promote);
+
+// `build` is a `type: choice` input, so the dispatch UI can only offer the three modes — but a
+// re-dispatch via the API can send anything, and an unrecognized value would fall back to `full` in
+// the plan and spend an hour rebuilding a base the operator asked us to leave alone.
+if (buildMode !== "" && !isBuildMode(buildMode)) {
+	core.error(`build must be one of ${BUILD_MODES.join(", ")} (got '${buildMode}').`, {
+		title: "Invalid dispatch input",
+	});
+	core.setFailed("Invalid build input.");
+}
+
+// Resolve the provider scope against the registry here, before the release spends anything: a typo'd
+// id would otherwise silently shrink the release (selectProviders throws, but only once `plan` runs —
+// after the GHCR login, and with a stack trace instead of an annotation).
+if (providers !== "") {
+	try {
+		const scope = selectProviders(providers);
+		core.info(`Scoped release: ${scope.join(", ")}`);
+	} catch (err) {
+		core.error(err instanceof Error ? err.message : String(err), {
+			title: "Invalid providers input",
+		});
+		core.setFailed("Invalid providers input.");
+	}
+	// A scoped release BACKFILLS providers onto an already-published version and never rewrites the
+	// base; force_republish regenerates the whole version in place, destructively for daytona (it
+	// deletes each snapshot before recreating it). Refusing the combination is not pedantry: either
+	// interpretation silently does something the operator did not ask for.
+	if (forceRepublish === "true") {
+		core.error(
+			"force_republish cannot be combined with a scoped `providers` list — a scoped release " +
+				"backfills onto the published version, while force_republish regenerates that whole version " +
+				"in place (deleting and rebuilding every provider's artifact). Dispatch one or the other.",
+			{ title: "Conflicting dispatch inputs" },
+		);
+		core.setFailed("force_republish is not valid for a scoped release.");
+	}
 }
 
 // Re-run the arktype pin gatekeeper (hex sha256s, non-empty versions); an unfilled/invalid pin fails the

--- a/apps/cli/src/bin/release-validate.ts
+++ b/apps/cli/src/bin/release-validate.ts
@@ -6,7 +6,7 @@
 // Inputs arrive as env (the composite maps its `with:` inputs).
 import * as core from "@actions/core";
 import { validatedPins } from "@sandbox-benchmarks/templates/pins";
-import { selectProviders } from "../lib/matrix.ts";
+import { isPartialScope, selectProviders } from "../lib/matrix.ts";
 import { BUILD_MODES, isBuildMode } from "../lib/release-inputs.ts";
 
 // The arktype pin gatekeeper lives here; annotate failures on it so the run links straight to the pins.
@@ -14,13 +14,12 @@ const PINS_FILE = "packages/templates/src/lib/pins.ts";
 
 /** A dispatch boolean reaches the release as an env var; reject anything but the two spellings (and
  *  unset) so a hand-typed value can't slip through as a surprise "truthy" string downstream. */
-function validateBoolean(name: string, value: string): boolean {
-	if (["true", "false", ""].includes(value)) return true;
+function validateBoolean(name: string, value: string): void {
+	if (["true", "false", ""].includes(value)) return;
 	core.error(`${name} must be true or false (got '${value}').`, {
 		title: "Invalid dispatch input",
 	});
 	core.setFailed(`Invalid ${name} input.`);
-	return false;
 }
 
 const forceRepublish = process.env.FORCE_REPUBLISH?.trim() ?? "";
@@ -48,24 +47,26 @@ if (providers !== "") {
 	try {
 		const scope = selectProviders(providers);
 		core.info(`Scoped release: ${scope.join(", ")}`);
+		// A PARTIAL release backfills providers onto an already-published version and never rewrites the
+		// base; force_republish regenerates the whole version in place, destructively for daytona (it
+		// deletes each snapshot before recreating it). Refusing the combination is not pedantry: either
+		// interpretation silently does something the operator did not ask for. Gated on the same
+		// `isPartialScope` the promote transaction uses, so this gate can't reject a dispatch the
+		// transaction would have accepted — a list naming every provider is just a full release.
+		if (isPartialScope(scope) && forceRepublish === "true") {
+			core.error(
+				"force_republish cannot be combined with a scoped `providers` list — a scoped release " +
+					"backfills onto the published version, while force_republish regenerates that whole version " +
+					"in place (deleting and rebuilding every provider's artifact). Dispatch one or the other.",
+				{ title: "Conflicting dispatch inputs" },
+			);
+			core.setFailed("force_republish is not valid for a scoped release.");
+		}
 	} catch (err) {
 		core.error(err instanceof Error ? err.message : String(err), {
 			title: "Invalid providers input",
 		});
 		core.setFailed("Invalid providers input.");
-	}
-	// A scoped release BACKFILLS providers onto an already-published version and never rewrites the
-	// base; force_republish regenerates the whole version in place, destructively for daytona (it
-	// deletes each snapshot before recreating it). Refusing the combination is not pedantry: either
-	// interpretation silently does something the operator did not ask for.
-	if (forceRepublish === "true") {
-		core.error(
-			"force_republish cannot be combined with a scoped `providers` list — a scoped release " +
-				"backfills onto the published version, while force_republish regenerates that whole version " +
-				"in place (deleting and rebuilding every provider's artifact). Dispatch one or the other.",
-			{ title: "Conflicting dispatch inputs" },
-		);
-		core.setFailed("force_republish is not valid for a scoped release.");
 	}
 }
 

--- a/apps/cli/src/lib/bake/image.ts
+++ b/apps/cli/src/lib/bake/image.ts
@@ -122,6 +122,17 @@ export async function buildAndPushVariantCandidates(
 	scope?: readonly ProviderId[],
 ): Promise<StagedCandidates> {
 	const staged = variantsInScope(scope);
+	// This mode has one hard prerequisite — the published base it composes on. The plan refuses the
+	// combination up front when it can see the version is absent, but that probe is best-effort, so this
+	// is the authoritative check. It is spelled out here rather than left to `resolveImageDigestRef`
+	// because that would surface as a raw `imagetools inspect exited 1`, which reads like a registry
+	// outage rather than "you asked for the wrong build mode".
+	if (!(await imageExistsInRegistry(config.toolchainImageVersion))) {
+		throw new Error(
+			`${config.toolchainImageVersion} is not published, so there is no base to rebuild the variants on — ` +
+				"`build: variants` adds a provider to a version that already shipped; use `build: full` to cut it first",
+		);
+	}
 	const pinnedBase = await resolveImageDigestRef(config.toolchainImageVersion);
 	if (staged.length === 0) {
 		// Nothing to do rather than a no-op build.sh run: with no registry-served variant in scope there

--- a/apps/cli/src/lib/bake/image.ts
+++ b/apps/cli/src/lib/bake/image.ts
@@ -4,6 +4,8 @@
 // The public `:v1` is never pushed here — that is promote's job.
 import { join } from "node:path";
 import { config } from "@sandbox-benchmarks/providers";
+import type { ProviderId } from "@sandbox-benchmarks/schema";
+import type { templateProviders } from "@sandbox-benchmarks/templates";
 import type { Log } from "./types.ts";
 
 // Anchored to this file (not cwd): the `bake` package script runs from apps/cli, where a
@@ -21,28 +23,35 @@ async function run(cmd: string[], log: Log, extraEnv: Record<string, string> = {
 	if (code !== 0) throw new Error(`${cmd[0]} exited ${code}`);
 }
 
+/** One provider variant that is PUSHED to a registry (see {@link PUBLISHED_VARIANTS}). */
+interface PublishedVariant {
+	/** The build.sh variant name — its directory under packages/templates/images. Typed against the
+	 *  templates registry so a typo is a compile error here, not an "unknown variant" at release time. */
+	variant: (typeof templateProviders)[number];
+	/** The provider whose bake cell consumes it — how the release scopes the visibility guard. */
+	provider: ProviderId;
+	version: string;
+	candidate: string;
+}
+
 /**
  * The provider variants that are PUSHED to a registry, and so have candidate/version tags of their
  * own. Every other variant build.sh produces is consumed locally or rebuilt remotely (e2b builds its
  * template on E2B's builder FROM the base digest; daytona/modal boot the base itself), so it has no
  * registry copy to stage. Today only Vercel needs one: VCR is a separate registry the sandbox pulls
  * from, so the variant has to exist in GHCR first for the bake cell to mirror it across.
- *
- * `variant` is the build.sh variant name (its directory under packages/templates/images).
  */
-export const PUBLISHED_VARIANTS = [
+export const PUBLISHED_VARIANTS: readonly PublishedVariant[] = [
 	{
 		variant: "vercel",
+		provider: "vercel",
 		version: config.vercelSourceImageVersion,
 		candidate: config.vercelSourceImageCandidate,
 	},
-] as const;
+];
 
 /** Retag a freshly built variant to its mutable candidate tag and push it (normalized, as below). */
-async function stagePublishedVariant(
-	entry: (typeof PUBLISHED_VARIANTS)[number],
-	log: Log,
-): Promise<void> {
+async function stagePublishedVariant(entry: PublishedVariant, log: Log): Promise<void> {
 	await run(["docker", "tag", entry.version, entry.candidate], log);
 	await run(["docker", "push", entry.candidate], log);
 	await run(imagetoolsNormalizeCmd(entry.candidate), log);
@@ -78,8 +87,8 @@ export async function buildAndPushCandidate(log: Log): Promise<void> {
  * toolchain exists to remove. Composing the thin variant layer on the PUBLISHED base keeps the
  * comparison honest — and the base is pinned by digest, so "the published base" can't drift mid-build.
  */
-export async function buildAndPushVariantCandidates(log: Log, base: string): Promise<string> {
-	const pinnedBase = await resolveImageDigestRef(base);
+export async function buildAndPushVariantCandidates(log: Log): Promise<string> {
+	const pinnedBase = await resolveImageDigestRef(config.toolchainImageVersion);
 	log(`>>> rebuilding variants on the published base ${pinnedBase} (no base build)`);
 	await run(["bash", BUILD_SH], log, {
 		BASE_IMAGE: pinnedBase,
@@ -165,6 +174,22 @@ export function imageRepo(ref: string): string {
 	const lastColon = withoutDigest.lastIndexOf(":");
 	const lastSlash = withoutDigest.lastIndexOf("/");
 	return lastColon > lastSlash ? withoutDigest.slice(0, lastColon) : withoutDigest;
+}
+
+/** The bare package name of an image ref — `ghcr.io/org/image:v1` → `image`. This is the identifier
+ *  the GHCR package API (and so the public-package guard) addresses a package by. Built on
+ *  {@link imageRepo} so ref parsing stays in this one module rather than being re-derived by a caller. */
+export function imageName(ref: string): string {
+	const repo = imageRepo(ref);
+	return repo.split("/").pop() ?? repo;
+}
+
+/** The digest of an already-pinned ref — `repo@sha256:…` → `sha256:…`; empty when `ref` carries no
+ *  digest. The inverse of {@link digestPinnedRef}, for callers holding a ref that was pinned earlier
+ *  and needing the bare digest back without a second registry lookup. */
+export function imageDigest(ref: string): string {
+	const at = ref.lastIndexOf("@");
+	return at === -1 ? "" : ref.slice(at + 1);
 }
 
 /** Resolve a pushed `ref` to its immutable registry digest (`sha256:…`) via a registry-side inspect —

--- a/apps/cli/src/lib/bake/image.ts
+++ b/apps/cli/src/lib/bake/image.ts
@@ -50,35 +50,65 @@ export const PUBLISHED_VARIANTS: readonly PublishedVariant[] = [
 	},
 ];
 
-/** Retag a freshly built variant to its mutable candidate tag and push it (normalized, as below). */
-async function stagePublishedVariant(entry: PublishedVariant, log: Log): Promise<void> {
+/**
+ * The variants this release is allowed to stage: those whose provider is in `scope` (omitted → every
+ * one, the unscoped default). A scoped release must not rewrite an out-of-scope provider's candidate
+ * tag — that is a mutation outside what the dispatch asked for, on an image the plan has deliberately
+ * dropped from the public-package guard, so nothing would even check it is still pullable.
+ */
+function variantsInScope(scope?: readonly ProviderId[]): readonly PublishedVariant[] {
+	if (!scope) return PUBLISHED_VARIANTS;
+	return PUBLISHED_VARIANTS.filter((entry) => scope.includes(entry.provider));
+}
+
+/** Retag a freshly built variant to its mutable candidate tag and push it (normalized, as below),
+ *  returning the pushed candidate's digest-pinned ref. */
+async function stagePublishedVariant(entry: PublishedVariant, log: Log): Promise<string> {
 	await run(["docker", "tag", entry.version, entry.candidate], log);
 	await run(["docker", "push", entry.candidate], log);
 	await run(imagetoolsNormalizeCmd(entry.candidate), log);
+	return resolveImageDigestRef(entry.candidate);
+}
+
+/** What a build phase staged: the digest-pinned base it pins, plus each registry-served variant
+ *  candidate it pushed (empty when no in-scope provider has one). */
+export interface StagedCandidates {
+	/** The base ref every downstream phase pins — the candidate base for a full build, the published
+	 *  version base for a variants-only build (which does not touch the candidate base at all). */
+	base: string;
+	/** Digest-pinned refs of the variant candidates this run actually pushed. */
+	variants: string[];
 }
 
 /** build.sh (base + variants, tagged `:dev` and `:v1`) → retag base `:v1`→`:v1-candidate` → push the
- *  candidate. Idempotent: the candidate tag is mutable and simply overwritten each run.
+ *  candidate. Idempotent: the candidate tag is mutable and simply overwritten each run. `scope`
+ *  restricts which registry-served variants are staged (see {@link variantsInScope}).
  *
  *  A plain `docker push` publishes a bare image manifest, while the public version is a one-platform
  *  image index produced by `imagetools create`. Daytona's registry importer rejects the bare
  *  candidate with an opaque inspection error even when its total compressed size is below the
  *  accepted public image. Normalize the mutable candidate to the same envelope before providers
  *  consume it; the config and layers stay byte-identical. */
-export async function buildAndPushCandidate(log: Log): Promise<void> {
+export async function buildAndPushCandidate(
+	log: Log,
+	scope?: readonly ProviderId[],
+): Promise<StagedCandidates> {
 	await run(["bash", BUILD_SH], log);
 	await run(["docker", "tag", config.toolchainImageVersion, config.toolchainImageCandidate], log);
 	await run(["docker", "push", config.toolchainImageCandidate], log);
 	await run(imagetoolsNormalizeCmd(config.toolchainImageCandidate), log);
 	// The thin Vercel variant is staged in GHCR so the separate Vercel matrix cell can mirror the
 	// exact bytes into VCR after obtaining its short-lived OIDC registry login.
-	for (const entry of PUBLISHED_VARIANTS) await stagePublishedVariant(entry, log);
+	const variants: string[] = [];
+	for (const entry of variantsInScope(scope))
+		variants.push(await stagePublishedVariant(entry, log));
+	return { base: await resolveImageDigestRef(config.toolchainImageCandidate), variants };
 }
 
 /**
  * Variants-only rebuild: restage the registry-served provider variants FROM an already-published base,
- * without rebuilding the base or touching its candidate tag. Returns the digest-pinned base ref the
- * variants were built on.
+ * without rebuilding the base or touching its candidate tag. `scope` restricts which variants are
+ * staged (see {@link variantsInScope}).
  *
  * This is the build phase of a scoped backfill — adding a provider to a version the rest of the fleet
  * already runs. The alternative (a full rebuild) would take an hour AND produce different base bytes:
@@ -87,15 +117,26 @@ export async function buildAndPushCandidate(log: Log): Promise<void> {
  * toolchain exists to remove. Composing the thin variant layer on the PUBLISHED base keeps the
  * comparison honest — and the base is pinned by digest, so "the published base" can't drift mid-build.
  */
-export async function buildAndPushVariantCandidates(log: Log): Promise<string> {
+export async function buildAndPushVariantCandidates(
+	log: Log,
+	scope?: readonly ProviderId[],
+): Promise<StagedCandidates> {
+	const staged = variantsInScope(scope);
 	const pinnedBase = await resolveImageDigestRef(config.toolchainImageVersion);
+	if (staged.length === 0) {
+		// Nothing to do rather than a no-op build.sh run: with no registry-served variant in scope there
+		// is no image for this phase to stage — `build: variants` on such a scope is a dispatch mistake.
+		log(`>>> no registry-served variant is in scope — nothing to stage on ${pinnedBase}`);
+		return { base: pinnedBase, variants: [] };
+	}
 	log(`>>> rebuilding variants on the published base ${pinnedBase} (no base build)`);
 	await run(["bash", BUILD_SH], log, {
 		BASE_IMAGE: pinnedBase,
-		VARIANTS: PUBLISHED_VARIANTS.map((entry) => entry.variant).join(","),
+		VARIANTS: staged.map((entry) => entry.variant).join(","),
 	});
-	for (const entry of PUBLISHED_VARIANTS) await stagePublishedVariant(entry, log);
-	return pinnedBase;
+	const variants: string[] = [];
+	for (const entry of staged) variants.push(await stagePublishedVariant(entry, log));
+	return { base: pinnedBase, variants };
 }
 
 /** Pure: the buildx command that retags one pushed image ref to another registry-side (no pull). */

--- a/apps/cli/src/lib/bake/image.ts
+++ b/apps/cli/src/lib/bake/image.ts
@@ -10,11 +10,42 @@ import type { Log } from "./types.ts";
 // repo-relative path would resolve to the non-existent apps/cli/packages/... and fail in bash.
 const BUILD_SH = join(import.meta.dir, "../../../../../packages/templates/images/build.sh");
 
-async function run(cmd: string[], log: Log): Promise<void> {
+async function run(cmd: string[], log: Log, extraEnv: Record<string, string> = {}): Promise<void> {
 	log(`$ ${cmd.join(" ")}`);
-	const proc = Bun.spawn(cmd, { stdout: "inherit", stderr: "inherit", env: process.env });
+	const proc = Bun.spawn(cmd, {
+		stdout: "inherit",
+		stderr: "inherit",
+		env: { ...process.env, ...extraEnv },
+	});
 	const code = await proc.exited;
 	if (code !== 0) throw new Error(`${cmd[0]} exited ${code}`);
+}
+
+/**
+ * The provider variants that are PUSHED to a registry, and so have candidate/version tags of their
+ * own. Every other variant build.sh produces is consumed locally or rebuilt remotely (e2b builds its
+ * template on E2B's builder FROM the base digest; daytona/modal boot the base itself), so it has no
+ * registry copy to stage. Today only Vercel needs one: VCR is a separate registry the sandbox pulls
+ * from, so the variant has to exist in GHCR first for the bake cell to mirror it across.
+ *
+ * `variant` is the build.sh variant name (its directory under packages/templates/images).
+ */
+export const PUBLISHED_VARIANTS = [
+	{
+		variant: "vercel",
+		version: config.vercelSourceImageVersion,
+		candidate: config.vercelSourceImageCandidate,
+	},
+] as const;
+
+/** Retag a freshly built variant to its mutable candidate tag and push it (normalized, as below). */
+async function stagePublishedVariant(
+	entry: (typeof PUBLISHED_VARIANTS)[number],
+	log: Log,
+): Promise<void> {
+	await run(["docker", "tag", entry.version, entry.candidate], log);
+	await run(["docker", "push", entry.candidate], log);
+	await run(imagetoolsNormalizeCmd(entry.candidate), log);
 }
 
 /** build.sh (base + variants, tagged `:dev` and `:v1`) → retag base `:v1`→`:v1-candidate` → push the
@@ -32,12 +63,30 @@ export async function buildAndPushCandidate(log: Log): Promise<void> {
 	await run(imagetoolsNormalizeCmd(config.toolchainImageCandidate), log);
 	// The thin Vercel variant is staged in GHCR so the separate Vercel matrix cell can mirror the
 	// exact bytes into VCR after obtaining its short-lived OIDC registry login.
-	await run(
-		["docker", "tag", config.vercelSourceImageVersion, config.vercelSourceImageCandidate],
-		log,
-	);
-	await run(["docker", "push", config.vercelSourceImageCandidate], log);
-	await run(imagetoolsNormalizeCmd(config.vercelSourceImageCandidate), log);
+	for (const entry of PUBLISHED_VARIANTS) await stagePublishedVariant(entry, log);
+}
+
+/**
+ * Variants-only rebuild: restage the registry-served provider variants FROM an already-published base,
+ * without rebuilding the base or touching its candidate tag. Returns the digest-pinned base ref the
+ * variants were built on.
+ *
+ * This is the build phase of a scoped backfill — adding a provider to a version the rest of the fleet
+ * already runs. The alternative (a full rebuild) would take an hour AND produce different base bytes:
+ * the toolchain build is not reproducible (apt/mise resolve at build time), so the new provider would
+ * end up benchmarking a different `:vN` than everyone else, which is precisely the confound the pinned
+ * toolchain exists to remove. Composing the thin variant layer on the PUBLISHED base keeps the
+ * comparison honest — and the base is pinned by digest, so "the published base" can't drift mid-build.
+ */
+export async function buildAndPushVariantCandidates(log: Log, base: string): Promise<string> {
+	const pinnedBase = await resolveImageDigestRef(base);
+	log(`>>> rebuilding variants on the published base ${pinnedBase} (no base build)`);
+	await run(["bash", BUILD_SH], log, {
+		BASE_IMAGE: pinnedBase,
+		VARIANTS: PUBLISHED_VARIANTS.map((entry) => entry.variant).join(","),
+	});
+	for (const entry of PUBLISHED_VARIANTS) await stagePublishedVariant(entry, log);
+	return pinnedBase;
 }
 
 /** Pure: the buildx command that retags one pushed image ref to another registry-side (no pull). */

--- a/apps/cli/src/lib/bake/promote.ts
+++ b/apps/cli/src/lib/bake/promote.ts
@@ -30,14 +30,21 @@
 import { requiredProviders, unmetRequirements } from "@sandbox-benchmarks/harness";
 import { config } from "@sandbox-benchmarks/providers";
 import type { ProviderId } from "@sandbox-benchmarks/schema";
+import { PROVIDERS } from "@sandbox-benchmarks/schema";
 import { isPartialScope } from "../matrix.ts";
 import { forEachProviderWithCreds } from "../providers-run.ts";
 import { bakeDaytonaContainerSnapshot, bakeDaytonaVmSnapshot } from "./daytona.ts";
 import { bakeE2bTemplate } from "./e2b.ts";
-import { imageExistsInRegistry, promoteImage, resolveImageDigestRef } from "./image.ts";
+import {
+	imageDigest,
+	imageExistsInRegistry,
+	promoteImage,
+	resolveImageDigestRef,
+} from "./image.ts";
 import { bakeNovitaTemplate } from "./novita.ts";
 import type { BakeReport, Log } from "./types.ts";
 import type { CandidateRefs } from "./validate.ts";
+import { baseImageUse } from "./validate.ts";
 import { validateCandidates } from "./validate-run.ts";
 
 export interface PromoteOptions {
@@ -146,6 +153,35 @@ export async function promoteAll(log: Log, options: PromoteOptions = {}): Promis
 			`could not resolve immutable digest for ${baseTag}: ${err instanceof Error ? err.message : String(err)} (nothing published)`,
 			"aborted",
 		);
+	}
+
+	// 2b. A backfill verifies each provider's CANDIDATE artifact (step 2) but builds its version artifact
+	//     from the PUBLISHED base (step 3). For a provider that BAKES its artifact from the base —
+	//     e2b/novita templates, daytona snapshots — those are the same bytes only while the candidate
+	//     base still IS the published version; if a later `build: full` moved the candidate on, the run
+	//     would verify one image and publish an artifact built from another. Require that identity when
+	//     such a provider is in scope. The rest don't bake from the base at all (vercel's version artifact
+	//     is a retag of the exact candidate step 2 just booted; modal/namespace/microsandbox boot the
+	//     published base directly), so a drifted candidate tag is simply irrelevant to them.
+	const bakesFromBase = (only ?? PROVIDERS.map((p) => p.id)).filter(
+		(id) => baseImageUse(id) === "bakes",
+	);
+	if (partial && bakesFromBase.length > 0) {
+		let pinnedCandidate: string;
+		try {
+			pinnedCandidate = await resolveImageDigestRef(config.toolchainImageCandidate);
+		} catch (err) {
+			return refuse(
+				`could not resolve immutable digest for ${config.toolchainImageCandidate}, which ${bakesFromBase.join(", ")} bake their version artifact from: ${err instanceof Error ? err.message : String(err)}`,
+				"aborted",
+			);
+		}
+		if (imageDigest(pinnedCandidate) !== imageDigest(pinnedBaseImage)) {
+			return refuse(
+				`the candidate base has drifted from the published version (${pinnedCandidate} vs ${pinnedBaseImage}), so a backfill of ${bakesFromBase.join(", ")} would verify one image and publish an artifact built from another. Re-stage the candidate from the published base (\`build: variants\`), or bump TOOLCHAIN_VERSION and cut a full release`,
+				"aborted",
+			);
+		}
 	}
 	const candidateRefs: CandidateRefs = {
 		e2bTemplateCandidate: config.e2bTemplateCandidate,

--- a/apps/cli/src/lib/bake/promote.ts
+++ b/apps/cli/src/lib/bake/promote.ts
@@ -30,6 +30,7 @@
 import { requiredProviders, unmetRequirements } from "@sandbox-benchmarks/harness";
 import { config } from "@sandbox-benchmarks/providers";
 import type { ProviderId } from "@sandbox-benchmarks/schema";
+import { isPartialScope } from "../matrix.ts";
 import { forEachProviderWithCreds } from "../providers-run.ts";
 import { bakeDaytonaContainerSnapshot, bakeDaytonaVmSnapshot } from "./daytona.ts";
 import { bakeE2bTemplate } from "./e2b.ts";
@@ -41,12 +42,12 @@ import { validateCandidates } from "./validate-run.ts";
 
 export interface PromoteOptions {
 	/** `--force`: deliberately regenerate an already-published version in place (see step 1). Manual
-	 *  force_republish dispatch only, and never valid together with `partial`. */
+	 *  force_republish dispatch only, and never valid together with a partial scope. */
 	force?: boolean;
-	/** Restrict the transaction to these providers (`--provider`). Omitted → every registered provider. */
-	only?: readonly ProviderId[];
 	/**
-	 * PARTIAL promote — `only` is a strict subset of the registry, so this run BACKFILLS those
+	 * Restrict the transaction to these providers (`--provider`). Omitted → every registered provider.
+	 *
+	 * A STRICT SUBSET (see {@link isPartialScope}) makes this a PARTIAL promote: it BACKFILLS those
 	 * providers' version artifacts onto a version the rest of the fleet already runs. Two inversions
 	 * follow from that, both handled below:
 	 *
@@ -58,15 +59,24 @@ export interface PromoteOptions {
 	 *     candidate tag may have moved on since the version was cut.
 	 *
 	 * Step 4 (the base retag) is then skipped entirely: the base is already published and correct, and
-	 * rewriting it is exactly the blast radius a scoped release exists to avoid.
+	 * rewriting it is exactly the blast radius a scoped release exists to avoid. Partial is DERIVED
+	 * here rather than passed alongside `only`, so the two can never describe different releases.
 	 */
-	partial?: boolean;
+	only?: readonly ProviderId[];
 }
 
 export async function promoteAll(log: Log, options: PromoteOptions = {}): Promise<BakeReport[]> {
-	const { force = false, only, partial = false } = options;
+	const { force = false, only } = options;
+	const partial = isPartialScope(only);
 	const reports: BakeReport[] = [];
 	const scope = only ? only.join(", ") : "every provider";
+	/** Record a refusal/abort as a structured `image` failure and stop — the shape every early exit
+	 *  below returns, so the refusal contract is written once. */
+	const refuse = (reason: string, verb = "refused"): BakeReport[] => {
+		log(`<<< promote ${verb} — ${reason}`);
+		reports.push({ provider: "image", status: "failed", reason });
+		return reports;
+	};
 	// Only a REQUIRED provider gates the release (Option 1): a best-effort variant that shares a required
 	// variant's credentials — daytona-container ↔ daytona-vm, modal-vm ↔ modal-gvisor — runs rather than
 	// skips, so its re-validation or artifact failure is recorded but must NOT abort the publish. Locally
@@ -85,30 +95,10 @@ export async function promoteAll(log: Log, options: PromoteOptions = {}): Promis
 	//    snapshot before creating, so a forced republish drops the published snapshot for the length
 	//    of the rebuild, and leaves it absent if the rebuild fails. Forced republish is therefore a
 	//    destructive regenerate, and is why `force` is manual-dispatch-only.
-	if (partial) {
-		// A backfill attaches to an existing version instead of creating one, so the guard inverts: the
-		// public base MUST already be there. Same refuse-on-uncertain posture as the full path — an
-		// unreadable registry is not evidence either way, so we decline rather than publish blind.
-		let publishedBase: boolean;
-		try {
-			publishedBase = await imageExistsInRegistry(config.toolchainImageVersion);
-		} catch (err) {
-			const reason = `could not verify whether ${config.toolchainImageVersion} is published, so refusing to backfill onto it: ${err instanceof Error ? err.message : String(err)}`;
-			log(`<<< promote refused — ${reason}`);
-			reports.push({ provider: "image", status: "failed", reason });
-			return reports;
-		}
-		if (!publishedBase) {
-			const reason = `${config.toolchainImageVersion} is not published, so there is nothing to backfill ${scope} onto — a scoped promote adds providers to an existing version and never writes the base; run a full release first`;
-			log(`<<< promote refused — ${reason}`);
-			reports.push({ provider: "image", status: "failed", reason });
-			return reports;
-		}
-		log(
-			`>>> partial promote: backfilling ${scope} onto the published ${config.toolchainImageVersion}; ` +
-				"the public base is NOT rewritten and no other provider's artifact is touched",
-		);
-	} else if (force) {
+	//    A PARTIAL promote inverts the same probe: it attaches to an existing version instead of
+	//    creating one, so the base MUST already be there. Both polarities share the refuse-on-uncertain
+	//    posture — an unreadable registry is not evidence either way, so we decline rather than act blind.
+	if (force) {
 		log(
 			`>>> force-republish: regenerating ${config.toolchainImageVersion}, overwriting if present ` +
 				`(daytona: both ${config.daytonaSnapshotDefault} and ${config.daytonaContainerSnapshotDefault} ` +
@@ -119,16 +109,27 @@ export async function promoteAll(log: Log, options: PromoteOptions = {}): Promis
 		try {
 			alreadyPublished = await imageExistsInRegistry(config.toolchainImageVersion);
 		} catch (err) {
-			const reason = `could not verify whether ${config.toolchainImageVersion} is already published, so refusing to publish: ${err instanceof Error ? err.message : String(err)}`;
-			log(`<<< promote refused — ${reason}`);
-			reports.push({ provider: "image", status: "failed", reason });
-			return reports;
+			return refuse(
+				`could not verify whether ${config.toolchainImageVersion} is published, so refusing to ` +
+					`${partial ? "backfill onto it" : "publish"}: ${err instanceof Error ? err.message : String(err)}`,
+			);
 		}
-		if (alreadyPublished) {
-			const reason = `${config.toolchainImageVersion} already exists — the public version is immutable; bump the version or dispatch with force_republish to publish again`;
-			log(`<<< promote refused — ${reason}`);
-			reports.push({ provider: "image", status: "failed", reason });
-			return reports;
+		// A full release needs the version ABSENT (it is about to create it); a backfill needs it PRESENT
+		// (it is attaching to it). One probe, opposite expectations — named so the comparison below
+		// reads as intent rather than as a bare inequality between two unrelated-looking booleans.
+		const expectsPublishedBase = partial;
+		if (alreadyPublished !== expectsPublishedBase) {
+			return refuse(
+				partial
+					? `${config.toolchainImageVersion} is not published, so there is nothing to backfill ${scope} onto — a scoped promote adds providers to an existing version and never writes the base; run a full release first`
+					: `${config.toolchainImageVersion} already exists — the public version is immutable; bump the version or dispatch with force_republish to publish again`,
+			);
+		}
+		if (partial) {
+			log(
+				`>>> partial promote: backfilling ${scope} onto the published ${config.toolchainImageVersion}; ` +
+					"the public base is NOT rewritten and no other provider's artifact is touched",
+			);
 		}
 	}
 
@@ -141,10 +142,10 @@ export async function promoteAll(log: Log, options: PromoteOptions = {}): Promis
 	try {
 		pinnedBaseImage = await resolveImageDigestRef(baseTag);
 	} catch (err) {
-		const reason = `could not resolve immutable digest for ${baseTag}: ${err instanceof Error ? err.message : String(err)}`;
-		log(`<<< promote aborted — ${reason} (nothing published)`);
-		reports.push({ provider: "image", status: "failed", reason });
-		return reports;
+		return refuse(
+			`could not resolve immutable digest for ${baseTag}: ${err instanceof Error ? err.message : String(err)} (nothing published)`,
+			"aborted",
+		);
 	}
 	const candidateRefs: CandidateRefs = {
 		e2bTemplateCandidate: config.e2bTemplateCandidate,
@@ -251,8 +252,10 @@ export async function promoteAll(log: Log, options: PromoteOptions = {}): Promis
 	// After a forced republish aborts, the previous version's base image is still tagged, so step 1 would
 	// refuse a plain rerun — recovery has to re-force. A partial promote is already re-runnable as-is
 	// (it never wrote the base, and its step 1 wants the version to exist). Shared by both aborts below.
+	// `scope` (not `only`) so the hint can't render "undefined": partial is derived FROM `only`, but only
+	// the value is proof of that, not the type. `--provider` trims around commas, so it pastes as-is.
 	const rerunHint = partial
-		? `Fix the cause and rerun the scoped release (\`--provider ${only?.join(",")}\`); nothing needs unwinding.`
+		? `Fix the cause and rerun the scoped release (\`--provider "${scope}"\`); nothing needs unwinding.`
 		: force
 			? "Fix the cause and rerun with force_republish — a plain rerun is refused because the base image already exists."
 			: "Fix the cause and rerun `bake --promote`.";

--- a/apps/cli/src/lib/bake/promote.ts
+++ b/apps/cli/src/lib/bake/promote.ts
@@ -14,6 +14,12 @@
 //      gap can't be detected only post-hoc in bake.ts after the immutable base is already tagged.
 //   4. LAST: retag the candidate base → the public version (registry-side). Reached only when every
 //      prior step succeeded, so a failure never leaves a published version with missing/stale artifacts.
+//
+// A PARTIAL promote (`--provider <subset>`, the scoped backfill a dispatch asks for when it adds one
+// provider to a version the rest of the fleet already runs) reshapes the same four steps: step 1 wants
+// the version to ALREADY exist, steps 2–3 work from the published version base rather than the mutable
+// candidate, and step 4 does not happen at all. See {@link PromoteOptions.partial}.
+//
 // A rerun after a mid-promote failure is clean (the version tag was never written); once published it
 // is refused at step 1 — bump the version, or force_republish, to publish again. Under `--force` the
 // version's artifacts already exist, and step 3 regenerates them in place: the image retag and e2b
@@ -23,6 +29,7 @@
 // (a plain rerun is refused at step 1, since the base image is still there).
 import { requiredProviders, unmetRequirements } from "@sandbox-benchmarks/harness";
 import { config } from "@sandbox-benchmarks/providers";
+import type { ProviderId } from "@sandbox-benchmarks/schema";
 import { forEachProviderWithCreds } from "../providers-run.ts";
 import { bakeDaytonaContainerSnapshot, bakeDaytonaVmSnapshot } from "./daytona.ts";
 import { bakeE2bTemplate } from "./e2b.ts";
@@ -32,8 +39,34 @@ import type { BakeReport, Log } from "./types.ts";
 import type { CandidateRefs } from "./validate.ts";
 import { validateCandidates } from "./validate-run.ts";
 
-export async function promoteAll(log: Log, force = false): Promise<BakeReport[]> {
+export interface PromoteOptions {
+	/** `--force`: deliberately regenerate an already-published version in place (see step 1). Manual
+	 *  force_republish dispatch only, and never valid together with `partial`. */
+	force?: boolean;
+	/** Restrict the transaction to these providers (`--provider`). Omitted → every registered provider. */
+	only?: readonly ProviderId[];
+	/**
+	 * PARTIAL promote — `only` is a strict subset of the registry, so this run BACKFILLS those
+	 * providers' version artifacts onto a version the rest of the fleet already runs. Two inversions
+	 * follow from that, both handled below:
+	 *
+	 *   • Step 1 flips from "refuse if the version exists" to "refuse UNLESS it exists": nothing here
+	 *     overwrites the immutable base, and a backfill with no published base to attach to would
+	 *     publish a provider artifact for a version that doesn't exist.
+	 *   • The base every version artifact is built from is the PUBLISHED version, not the mutable
+	 *     candidate — the new provider must get the same bytes the others are already running, and the
+	 *     candidate tag may have moved on since the version was cut.
+	 *
+	 * Step 4 (the base retag) is then skipped entirely: the base is already published and correct, and
+	 * rewriting it is exactly the blast radius a scoped release exists to avoid.
+	 */
+	partial?: boolean;
+}
+
+export async function promoteAll(log: Log, options: PromoteOptions = {}): Promise<BakeReport[]> {
+	const { force = false, only, partial = false } = options;
 	const reports: BakeReport[] = [];
+	const scope = only ? only.join(", ") : "every provider";
 	// Only a REQUIRED provider gates the release (Option 1): a best-effort variant that shares a required
 	// variant's credentials — daytona-container ↔ daytona-vm, modal-vm ↔ modal-gvisor — runs rather than
 	// skips, so its re-validation or artifact failure is recorded but must NOT abort the publish. Locally
@@ -52,7 +85,30 @@ export async function promoteAll(log: Log, force = false): Promise<BakeReport[]>
 	//    snapshot before creating, so a forced republish drops the published snapshot for the length
 	//    of the rebuild, and leaves it absent if the rebuild fails. Forced republish is therefore a
 	//    destructive regenerate, and is why `force` is manual-dispatch-only.
-	if (force) {
+	if (partial) {
+		// A backfill attaches to an existing version instead of creating one, so the guard inverts: the
+		// public base MUST already be there. Same refuse-on-uncertain posture as the full path — an
+		// unreadable registry is not evidence either way, so we decline rather than publish blind.
+		let publishedBase: boolean;
+		try {
+			publishedBase = await imageExistsInRegistry(config.toolchainImageVersion);
+		} catch (err) {
+			const reason = `could not verify whether ${config.toolchainImageVersion} is published, so refusing to backfill onto it: ${err instanceof Error ? err.message : String(err)}`;
+			log(`<<< promote refused — ${reason}`);
+			reports.push({ provider: "image", status: "failed", reason });
+			return reports;
+		}
+		if (!publishedBase) {
+			const reason = `${config.toolchainImageVersion} is not published, so there is nothing to backfill ${scope} onto — a scoped promote adds providers to an existing version and never writes the base; run a full release first`;
+			log(`<<< promote refused — ${reason}`);
+			reports.push({ provider: "image", status: "failed", reason });
+			return reports;
+		}
+		log(
+			`>>> partial promote: backfilling ${scope} onto the published ${config.toolchainImageVersion}; ` +
+				"the public base is NOT rewritten and no other provider's artifact is touched",
+		);
+	} else if (force) {
 		log(
 			`>>> force-republish: regenerating ${config.toolchainImageVersion}, overwriting if present ` +
 				`(daytona: both ${config.daytonaSnapshotDefault} and ${config.daytonaContainerSnapshotDefault} ` +
@@ -78,11 +134,14 @@ export async function promoteAll(log: Log, force = false): Promise<BakeReport[]>
 
 	// 2. Re-validate the candidate immediately before publishing, so the bytes we promote are verified
 	//    again (the candidate tag is mutable). Abort the whole promote if any provider fails to validate.
-	let pinnedCandidateImage: string;
+	//    A PARTIAL promote pins the PUBLISHED version instead: it is not cutting a new version, it is
+	//    attaching a provider to the one already live, so the base under test must be that one.
+	const baseTag = partial ? config.toolchainImageVersion : config.toolchainImageCandidate;
+	let pinnedBaseImage: string;
 	try {
-		pinnedCandidateImage = await resolveImageDigestRef(config.toolchainImageCandidate);
+		pinnedBaseImage = await resolveImageDigestRef(baseTag);
 	} catch (err) {
-		const reason = `could not resolve immutable digest for ${config.toolchainImageCandidate}: ${err instanceof Error ? err.message : String(err)}`;
+		const reason = `could not resolve immutable digest for ${baseTag}: ${err instanceof Error ? err.message : String(err)}`;
 		log(`<<< promote aborted — ${reason} (nothing published)`);
 		reports.push({ provider: "image", status: "failed", reason });
 		return reports;
@@ -92,13 +151,13 @@ export async function promoteAll(log: Log, force = false): Promise<BakeReport[]>
 		daytonaSnapshotCandidate: config.daytonaSnapshotCandidate,
 		daytonaContainerSnapshotCandidate: config.daytonaContainerSnapshotCandidate,
 		novitaTemplateCandidate: config.novitaTemplateCandidate,
-		toolchainImageCandidate: pinnedCandidateImage,
+		toolchainImageCandidate: pinnedBaseImage,
 		vercelImageCandidate: config.vercelImageCandidate,
 		daytonaVmTarget: config.daytonaVm.target,
 		daytonaContainerTarget: config.daytonaContainer.target,
 	};
-	log(`>>> re-validating candidate ${pinnedCandidateImage} before promote…`);
-	const validateRuns = await validateCandidates(candidateRefs, log);
+	log(`>>> re-validating ${scope} against ${pinnedBaseImage} before promote…`);
+	const validateRuns = await validateCandidates(candidateRefs, log, only);
 	if (validateRuns.some(blocks)) {
 		log(
 			"<<< promote aborted — a required provider's candidate re-validation failed (nothing published)",
@@ -114,31 +173,30 @@ export async function promoteAll(log: Log, force = false): Promise<BakeReport[]>
 		return reports;
 	}
 
-	// 3. Build each provider's version-named artifact FROM the candidate base (the bytes we just
-	//    revalidated). Built BEFORE the base retag, so a failure here leaves the version base unwritten
-	//    and a rerun is clean. Shares the skip-vs-fail loop with bake.
+	// 3. Build each in-scope provider's version-named artifact FROM the base we just revalidated (the
+	//    candidate base, or the published version base on a partial promote). Built BEFORE the base
+	//    retag, so a failure here leaves the version base unwritten and a rerun is clean. Shares the
+	//    skip-vs-fail loop with bake.
 	//    Under `--force` these names already exist and are live. e2b/image replace on success; daytona
 	//    deletes first (no snapshot overwrite in the SDK), so a failed daytona create removes the
 	//    published snapshot — `bakeDaytonaSnapshot` says so in its error, which lands in the report's
 	//    `reason`. The base is still never written, so the version tag itself stays consistent.
 	const runs = await forEachProviderWithCreds(
 		async (provider) => {
-			log(`>>> ${provider.name}: building version artifact from candidate…`);
+			log(`>>> ${provider.name}: building version artifact from ${pinnedBaseImage}…`);
 			switch (provider.name) {
 				case "e2b":
-					await bakeE2bTemplate(config.e2bTemplateVersion, pinnedCandidateImage, (m) =>
-						log(`    ${m}`),
-					);
+					await bakeE2bTemplate(config.e2bTemplateVersion, pinnedBaseImage, (m) => log(`    ${m}`));
 					break;
 				case "daytona-vm":
-					await bakeDaytonaVmSnapshot(config.daytonaSnapshotDefault, pinnedCandidateImage, (m) =>
+					await bakeDaytonaVmSnapshot(config.daytonaSnapshotDefault, pinnedBaseImage, (m) =>
 						log(`    ${m}`),
 					);
 					break;
 				case "daytona-container":
 					await bakeDaytonaContainerSnapshot(
 						config.daytonaContainerSnapshotDefault,
-						pinnedCandidateImage,
+						pinnedBaseImage,
 						(m) => log(`    ${m}`),
 					);
 					break;
@@ -154,7 +212,7 @@ export async function promoteAll(log: Log, force = false): Promise<BakeReport[]>
 					log("    blaxel boots the stock base image — nothing to promote");
 					break;
 				case "novita":
-					await bakeNovitaTemplate(config.novitaTemplateVersion, pinnedCandidateImage, (m) =>
+					await bakeNovitaTemplate(config.novitaTemplateVersion, pinnedBaseImage, (m) =>
 						log(`    ${m}`),
 					);
 					break;
@@ -173,6 +231,7 @@ export async function promoteAll(log: Log, force = false): Promise<BakeReport[]>
 		},
 		{
 			log,
+			only,
 			onComplete: (run) => {
 				const time = run.durationMs !== undefined ? ` (${run.durationMs.toFixed(0)}ms)` : "";
 				log(`<<< ${run.provider}: ${run.status}${time}${run.reason ? ` — ${run.reason}` : ""}`);
@@ -190,10 +249,18 @@ export async function promoteAll(log: Log, force = false): Promise<BakeReport[]>
 	}
 
 	// After a forced republish aborts, the previous version's base image is still tagged, so step 1 would
-	// refuse a plain rerun — recovery has to re-force. Shared by both pre-publish aborts below.
-	const rerunHint = force
-		? "Fix the cause and rerun with force_republish — a plain rerun is refused because the base image already exists."
-		: "Fix the cause and rerun `bake --promote`.";
+	// refuse a plain rerun — recovery has to re-force. A partial promote is already re-runnable as-is
+	// (it never wrote the base, and its step 1 wants the version to exist). Shared by both aborts below.
+	const rerunHint = partial
+		? `Fix the cause and rerun the scoped release (\`--provider ${only?.join(",")}\`); nothing needs unwinding.`
+		: force
+			? "Fix the cause and rerun with force_republish — a plain rerun is refused because the base image already exists."
+			: "Fix the cause and rerun `bake --promote`.";
+	// Both aborts below stop before step 4. On a partial promote there is no step 4 to stop before, so
+	// say what is actually true rather than implying the base was about to move.
+	const baseUntouched = partial
+		? `the public base ${config.toolchainImageVersion} is untouched (a scoped promote never writes it).`
+		: "the public base was NOT written.";
 
 	// A REQUIRED provider's artifact failed → do NOT publish the base. The version tag stays unwritten,
 	// so a rerun (after fixing the cause) reconciles cleanly. Nothing public was half-written — EXCEPT
@@ -202,7 +269,7 @@ export async function promoteAll(log: Log, force = false): Promise<BakeReport[]>
 	if (reports.some(blocks)) {
 		log(
 			`!!! promote aborted before publish: a required ${config.toolchainImageVersion} provider artifact failed; ` +
-				"the public base was NOT written. " +
+				`${baseUntouched} ` +
 				(force
 					? "This was a forced republish, so the failed provider's already-published artifact may have " +
 						"been regenerated — or, for daytona, deleted and not recreated (see its reason above). "
@@ -224,20 +291,28 @@ export async function promoteAll(log: Log, force = false): Promise<BakeReport[]>
 		const reason = `required providers did not promote: ${unmet.join(", ")} (--require / REQUIRE_PROVIDERS)`;
 		// A required provider that merely *skipped* never built anything, so unlike the artifact-failed
 		// abort above there is no half-regenerated artifact to warn about — only the rerun differs.
-		log(
-			`!!! promote aborted before publish: ${reason}; the public base was NOT written. ${rerunHint}`,
-		);
+		log(`!!! promote aborted before publish: ${reason}; ${baseUntouched} ${rerunHint}`);
 		// Push a structured failure (like the step-1 and step-4 aborts) so the emitted JSON is
 		// self-describing — a consumer sees the failed promote without re-deriving it from `--require`.
 		reports.push({ provider: "image", status: "failed", reason });
 		return reports;
 	}
 
-	// 4. LAST: publish the candidate base as the immutable public version — the commit point.
-	log(`>>> promoting image ${pinnedCandidateImage} → ${config.toolchainImageVersion}…`);
+	// 4. LAST: publish the candidate base as the immutable public version — the commit point. A partial
+	//    promote has none: the version it backfilled onto is already published, and its providers'
+	//    artifacts (step 3) were the whole transaction. Returning here is what keeps a scoped release
+	//    from touching the fleet everyone else is already running on.
+	if (partial) {
+		log(
+			`>>> partial promote complete: ${scope} now published for ${config.toolchainImageVersion}; ` +
+				"the public base and every other provider's artifact are unchanged",
+		);
+		return reports;
+	}
+	log(`>>> promoting image ${pinnedBaseImage} → ${config.toolchainImageVersion}…`);
 	const imageStart = performance.now();
 	try {
-		await promoteImage(log, pinnedCandidateImage);
+		await promoteImage(log, pinnedBaseImage);
 		reports.push({ provider: "image", status: "ok", durationMs: performance.now() - imageStart });
 	} catch (err) {
 		const reason = err instanceof Error ? err.message : String(err);

--- a/apps/cli/src/lib/bake/validate-run.ts
+++ b/apps/cli/src/lib/bake/validate-run.ts
@@ -4,6 +4,7 @@
 // mutable, so it could have changed since `bake` last validated it). Distinct from `bake`'s loop,
 // which bakes AND validates each candidate in one pass; this only validates an already-baked candidate.
 import type { ProviderConfig } from "@sandbox-benchmarks/providers";
+import type { ProviderId } from "@sandbox-benchmarks/schema";
 import type { ProviderRun } from "../providers-run.ts";
 import { forEachProviderWithCreds } from "../providers-run.ts";
 import type { SmokeOutcome } from "../smoke-run.ts";
@@ -13,10 +14,13 @@ import type { CandidateRefs } from "./validate.ts";
 import { candidateCreateOptions } from "./validate.ts";
 
 /** Validate every provider's candidate artifact (boot + smoke), sharing the skip-vs-fail contract. A
- *  provider with no creds skips; one that boots and fails its smoke is `failed`. Never throws. */
+ *  provider with no creds skips; one that boots and fails its smoke is `failed`. Never throws.
+ *  `only` restricts the pass to a subset (a scoped promote re-validates only the providers it is
+ *  about to publish); omitted → every registered provider. */
 export function validateCandidates(
 	refs: CandidateRefs,
 	log: Log,
+	only?: readonly ProviderId[],
 ): Promise<ProviderRun<SmokeOutcome>[]> {
 	return forEachProviderWithCreds(
 		(provider) => {
@@ -33,6 +37,7 @@ export function validateCandidates(
 		},
 		{
 			log,
+			only,
 			ok: smokeOk,
 			failureReason: smokeFailureReason,
 			onComplete: (run) => {

--- a/apps/cli/src/lib/bake/validate.test.ts
+++ b/apps/cli/src/lib/bake/validate.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "bun:test";
+import { PROVIDERS } from "@sandbox-benchmarks/schema";
 import type { CandidateRefs } from "./validate.ts";
-import { candidateCreateOptions } from "./validate.ts";
+import { baseImageUse, candidateCreateOptions } from "./validate.ts";
 
 const refs: CandidateRefs = {
 	e2bTemplateCandidate: "tc-v1-candidate",
@@ -79,5 +80,43 @@ describe("candidateCreateOptions", () => {
 		expect(candidateCreateOptions("microsandbox-cloud", refs)).toEqual({
 			templateId: "ghcr.io/o/tc:v1-candidate",
 		});
+	});
+});
+
+// Two release decisions read this classification, and both fail QUIETLY if it is wrong: a bake cell
+// resolves the candidate base only when some in-scope provider reads it, and a partial promote demands
+// candidate/published identity only when some in-scope provider BAKES its artifact from the base.
+describe("baseImageUse", () => {
+	it("marks the providers that bake their own artifact from the base", () => {
+		const bakes = PROVIDERS.map((p) => p.id).filter((id) => baseImageUse(id) === "bakes");
+		expect(bakes).toEqual(["e2b", "daytona-vm", "daytona-container", "novita"]);
+	});
+
+	it("marks the providers that boot the base image directly", () => {
+		const boots = PROVIDERS.map((p) => p.id).filter((id) => baseImageUse(id) === "boots");
+		expect(boots).toEqual([
+			"microsandbox-local",
+			"microsandbox-cloud",
+			"modal-gvisor",
+			"modal-vm",
+			"namespace",
+		]);
+	});
+
+	// The two that make a vercel-only release able to run without the candidate base existing at all.
+	it("marks the providers that never reference the toolchain base", () => {
+		const none = PROVIDERS.map((p) => p.id).filter((id) => baseImageUse(id) === "none");
+		expect(none).toEqual(["blaxel", "vercel"]);
+	});
+
+	// Anything that reads the base ref in candidateCreateOptions must not be classified "none", or the
+	// bake cell would skip resolving a digest that provider then boots.
+	it("agrees with candidateCreateOptions about who reads the base image ref", () => {
+		for (const { id } of PROVIDERS) {
+			const readsBase = JSON.stringify(candidateCreateOptions(id, refs)).includes(
+				refs.toolchainImageCandidate,
+			);
+			expect(`${id}:${readsBase}`).toBe(`${id}:${baseImageUse(id) === "boots"}`);
+		}
 	});
 });

--- a/apps/cli/src/lib/bake/validate.ts
+++ b/apps/cli/src/lib/bake/validate.ts
@@ -20,6 +20,39 @@ export interface CandidateRefs {
 	daytonaContainerTarget?: string;
 }
 
+/**
+ * How a provider relates to the shared toolchain BASE image — the classification the scoped release
+ * needs, kept beside {@link candidateCreateOptions} because it is the same per-provider knowledge and
+ * must stay exhaustive over `ProviderId` in the same way.
+ *
+ *   • `bakes` — builds its own artifact FROM the base (an e2b/novita template, a daytona snapshot), so
+ *     the artifact's bytes are decided at bake time by whichever base it was handed.
+ *   • `boots` — no artifact of its own; it boots the base image by ref at create time.
+ *   • `none`  — never references the base at all: blaxel boots the vendor's stock image, and vercel
+ *     boots its own VCR mirror (staged from the base by the build phase, not by this ref).
+ */
+export type BaseImageUse = "bakes" | "boots" | "none";
+
+/** {@link BaseImageUse} for one provider. */
+export function baseImageUse(id: ProviderId): BaseImageUse {
+	switch (id) {
+		case "e2b":
+		case "daytona-vm":
+		case "daytona-container":
+		case "novita":
+			return "bakes";
+		case "modal-gvisor":
+		case "modal-vm":
+		case "microsandbox-local":
+		case "microsandbox-cloud":
+		case "namespace":
+			return "boots";
+		case "blaxel":
+		case "vercel":
+			return "none";
+	}
+}
+
 /** Create-options overrides that point a provider at its candidate artifact for the validate boot. */
 export function candidateCreateOptions(
 	id: ProviderId,

--- a/apps/cli/src/lib/matrix.test.ts
+++ b/apps/cli/src/lib/matrix.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, test } from "bun:test";
+import { PROVIDERS } from "@sandbox-benchmarks/schema";
+import { isPartialScope, selectProviders } from "./matrix.ts";
+
+const ALL_PROVIDERS = PROVIDERS.map((p) => p.id);
+
+// The one predicate the scoped-release path turns on: the plan (mode/skip/required), the
+// credential-free validate gate (force_republish conflict), and `bake --promote` (base retag or not)
+// all call this. They must agree exactly — a gate reading "the operator typed a list" while the
+// transaction reads "strict subset" would reject dispatches the transaction would have accepted.
+describe("isPartialScope", () => {
+	test("no selection at all is a full release (the local `bake --promote` default)", () => {
+		expect(isPartialScope(undefined)).toBe(false);
+	});
+
+	test("a strict subset is partial", () => {
+		expect(isPartialScope(["vercel"])).toBe(true);
+		expect(isPartialScope(selectProviders("blaxel,novita"))).toBe(true);
+	});
+
+	test("naming every registered provider is NOT partial — it is just a full release", () => {
+		expect(isPartialScope(ALL_PROVIDERS)).toBe(false);
+		expect(isPartialScope(selectProviders(ALL_PROVIDERS.join(",")))).toBe(false);
+	});
+
+	test("a blank list resolves to every provider, so it is not partial", () => {
+		expect(isPartialScope(selectProviders(""))).toBe(false);
+		expect(isPartialScope(selectProviders(undefined))).toBe(false);
+	});
+});

--- a/apps/cli/src/lib/matrix.ts
+++ b/apps/cli/src/lib/matrix.ts
@@ -60,6 +60,22 @@ export function selectProviders(raw: string | undefined): ProviderId[] {
 }
 
 /**
+ * Whether a provider selection covers a strict SUBSET of the registry — the one predicate the whole
+ * scoped-release path turns on. A partial selection means the run is a backfill onto an existing
+ * toolchain version: promote publishes only these providers' artifacts and never rewrites the public
+ * base (see lib/bake/promote.ts), the plan reports `mode: backfill` and refuses to early-skip an
+ * already-published version, and `force_republish` is rejected as the opposite operation.
+ *
+ * It lives here, beside {@link selectProviders}, because three call sites decide on it — the plan, the
+ * credential-free validate gate, and `bake --promote` — and they must not disagree: a gate that reads
+ * "scoped" while the transaction reads "strict subset" would reject dispatches the transaction would
+ * have accepted (and, worse, the reverse). Absent/undefined (the local default) is never partial.
+ */
+export function isPartialScope(selection: readonly ProviderId[] | undefined): boolean {
+	return selection !== undefined && selection.length < PROVIDERS.length;
+}
+
+/**
  * The suites a dispatch asks the matrix to run, parsed from a comma-separated list (the `BENCH_SUITES`
  * dispatch input). Absent or blank → every registered suite. This is the pre-merge/targeted-run knob:
  * `BENCH_SUITES=network` runs only the network suite's jobs.

--- a/apps/cli/src/lib/release-inputs.ts
+++ b/apps/cli/src/lib/release-inputs.ts
@@ -1,0 +1,31 @@
+// The vocabulary of the toolchain release's `workflow_dispatch` inputs, shared by the two bins that
+// read them: `release-validate` (the credential-free gate that rejects a bad dispatch with an
+// annotation) and `release-plan` (which turns them into the plan every downstream job consumes).
+//
+// It lives in its own module, rather than in release-plan.ts, so the validate gate can import the
+// vocabulary WITHOUT importing the env-backed provider `config` that release-plan pulls in — the whole
+// point of that gate is to report a malformed input as a clean annotation, which it could not do if
+// loading it could itself throw a config error first.
+
+/**
+ * How the BUILD phase runs — the `build` dispatch input.
+ *
+ *   • `full`     — rebuild the base image and push a new mutable candidate base (the default; what a
+ *                  version bump does).
+ *   • `variants` — leave the base alone and restage only the registry-served provider variants on top
+ *                  of the ALREADY-PUBLISHED version base. The backfill path: it gives a newly added
+ *                  provider the same bytes the rest of the fleet already runs, in minutes rather than
+ *                  the hour a base rebuild costs — and, because the toolchain build is not
+ *                  reproducible, without silently producing a *different* `:vN` for that provider.
+ *   • `skip`     — build nothing; reuse whatever candidates the registry already holds. The build job
+ *                  is skipped outright (dynamic job skipping), so a re-verify or a promote of an
+ *                  already-staged candidate costs no build at all.
+ */
+export const BUILD_MODES = ["full", "variants", "skip"] as const;
+export type ReleaseBuildMode = (typeof BUILD_MODES)[number];
+
+/** Whether `value` names one of the three build modes (a `type: choice` input in the dispatch UI, but
+ *  an API dispatch can send anything). */
+export function isBuildMode(value: string): value is ReleaseBuildMode {
+	return (BUILD_MODES as readonly string[]).includes(value);
+}

--- a/apps/cli/src/lib/release-inputs.ts
+++ b/apps/cli/src/lib/release-inputs.ts
@@ -29,3 +29,16 @@ export type ReleaseBuildMode = (typeof BUILD_MODES)[number];
 export function isBuildMode(value: string): value is ReleaseBuildMode {
 	return (BUILD_MODES as readonly string[]).includes(value);
 }
+
+/** The modes the build job's script actually implements: `skip` is resolved a phase earlier, by the
+ *  plan skipping the job outright, so it never reaches `build-candidate`. DERIVED from the full list
+ *  rather than retyped, so a new mode can't be added to one list and forgotten in the other. */
+export type BuilderBuildMode = Exclude<ReleaseBuildMode, "skip">;
+export const BUILDER_BUILD_MODES = BUILD_MODES.filter(
+	(mode): mode is BuilderBuildMode => mode !== "skip",
+);
+
+/** Whether `value` is a mode `build-candidate` can run (see {@link BUILDER_BUILD_MODES}). */
+export function isBuilderBuildMode(value: string): value is BuilderBuildMode {
+	return (BUILDER_BUILD_MODES as readonly string[]).includes(value);
+}

--- a/docs/ci-secrets.md
+++ b/docs/ci-secrets.md
@@ -131,7 +131,18 @@ Ungated: `ci.yml`, `ci-lint.yml`, and the toolchain `pr-gate` (Docker smoke, no 
    `force_republish` is rejected together with a `providers` list — they are opposite operations, and
    silently picking one would do something the operator did not ask for. A scoped promote also refuses
    if the version is **not** yet published: there is nothing to backfill onto, so run a full release
-   first.
+   first. Two more refusals keep a scoped release honest, both fail-fast in the plan or before the
+   public base moves:
+
+   - **`providers: blaxel` is refused.** Blaxel boots the vendor's stock image rather than the
+     toolchain, so the release lane carries no `BL_API_KEY`/`BL_WORKSPACE` (they are bench-lane only,
+     see the table above) and has no artifact to publish for it. An *unscoped* release just skips it.
+   - **A drifted candidate base is refused** when the scope contains a provider that bakes its artifact
+     *from* the base (e2b, daytona, novita). Those providers' candidates are verified but their version
+     artifacts are rebuilt, so the two are the same bytes only while `:vN-candidate` still is `:vN` —
+     re-stage with `build: variants`, or bump `TOOLCHAIN_VERSION` and cut a full release. Providers
+     that don't bake from the base (vercel, modal, namespace, microsandbox) are unaffected: their
+     version artifact is a retag of the exact candidate that was just booted.
 
    The Vercel-on-v7 flow, as an example — two dispatches, neither of which touches another provider:
 

--- a/docs/ci-secrets.md
+++ b/docs/ci-secrets.md
@@ -115,6 +115,40 @@ Ungated: `ci.yml`, `ci-lint.yml`, and the toolchain `pr-gate` (Docker smoke, no 
    itself is gated by Environment `privileged` (main-only + required reviewer), so fork PRs can never
    drive this flow.
 
+8. **Adding one provider to a version everyone else already runs (scoped backfill).** A provider added
+   after a toolchain version was cut has no artifact for it, and the two obvious recoveries are both
+   wrong: a version bump re-benches the whole fleet, and `force_republish` regenerates *every*
+   provider's artifact in place — destructively for Daytona, which deletes each snapshot before
+   recreating it. `toolchain-image.yml` therefore takes three optional dispatch inputs that narrow the
+   release instead (all default to the full release, so a normal version bump is unchanged):
+
+   | Input | Effect |
+   | --- | --- |
+   | `providers` | Comma-separated provider ids the release covers; blank = all. Scoping produces only those bake cells, and makes promote a **backfill**: it publishes just those providers' version artifacts onto the already-published version and never rewrites the public base or anyone else's artifact. Every provider a scoped dispatch names is **required** — you asked for it, so it must ship. |
+   | `build` | `full` rebuilds the base (the default). `variants` restages only the registry-served provider variants on top of the **published** base — minutes instead of an hour, and the new provider gets the same bytes the fleet already runs (the toolchain build is not reproducible, so a rebuild would quietly hand it a different `:vN`). `skip` skips the build job outright and reuses what the registry holds. |
+   | `promote` | Uncheck to bake + verify only; the publish job is skipped. |
+
+   `force_republish` is rejected together with a `providers` list — they are opposite operations, and
+   silently picking one would do something the operator did not ask for. A scoped promote also refuses
+   if the version is **not** yet published: there is nothing to backfill onto, so run a full release
+   first.
+
+   The Vercel-on-v7 flow, as an example — two dispatches, neither of which touches another provider:
+
+   1. **Actions → Toolchain image → Run workflow** with `providers=vercel`, `build=variants`,
+      `promote` unchecked. Stages `…-vercel:v7-candidate` in GHCR from the published `:v7`, mirrors it
+      into VCR, boots it and runs the smoke spec. Nothing public moves.
+   2. Same dispatch with `build=skip` and `promote` checked. Re-validates the VCR candidate and
+      publishes it as the Vercel `v7` image. The GHCR base `:v7` is never rewritten.
+
+   Each registry-served variant is its own GHCR package (`sandbox-benchmarks-toolchain-vercel`), and the
+   bake cell pulls it **anonymously**, so it needs the same one-time Public bootstrap as the base
+   package — GHCR creates a package private on first push and offers no API to flip it. The plan's
+   visibility guard checks every package the release needs and warns when one does not exist yet, so on
+   the very first dispatch expect: build pushes the variant (creating it private) → the bake cell's pull
+   fails → set the package Public in the org package settings → re-run the same dispatch. Every dispatch
+   after that is clean.
+
 > **Two approval gates per bench-matrix run.** The suite-matrix fan-out (each cell calling
 > `bench-suite.yml` with `environment: privileged`) and the `publish` job both carry the environment
 > and run sequentially. Every suite × provider cell becomes pending together the moment `plan`

--- a/packages/templates/images/build.sh
+++ b/packages/templates/images/build.sh
@@ -24,8 +24,15 @@ PINS_TS="${HERE}/../src/pins.ts"
 REGISTRY="${REGISTRY:-ghcr.io}"
 IMAGE_OWNER="${IMAGE_OWNER:-starslingdev}"
 
-# > Every provider variant this script knows how to build (each has a <name>/Dockerfile beside it).
-ALL_VARIANTS=(e2b daytona modal vercel)
+# > Every provider variant this script builds, DERIVED from the directories beside it rather than
+# > hand-listed: a variant is exactly an `images/<name>/Dockerfile` that isn't the base. Adding one is
+# > then a directory, not a directory plus a literal someone has to remember to update — and the list
+# > is now load-bearing twice over (the build loop and the VARIANTS validation below).
+ALL_VARIANTS=()
+for dockerfile in "${HERE}"/*/Dockerfile; do
+	variant_name="$(basename "$(dirname "${dockerfile}")")"
+	[ "${variant_name}" = "base" ] || ALL_VARIANTS+=("${variant_name}")
+done
 
 # > Validate the pins and collect them as KEY=VALUE lines. `bun` exits non-zero (and set -e aborts)
 # > if arktype rejects any pin, so a bad/unfilled pin fails the build before docker is even invoked.
@@ -54,13 +61,8 @@ base_dev_tag="${image_name}:dev"
 # > The variant subset to build. Commas are accepted so the caller can pass one CSV env value.
 IFS=', ' read -r -a variants <<< "${VARIANTS:-${ALL_VARIANTS[*]}}"
 for provider in "${variants[@]}"; do
-	case " ${ALL_VARIANTS[*]} " in
-		*" ${provider} "*) ;;
-		*)
-			echo "unknown variant '${provider}' — known variants: ${ALL_VARIANTS[*]}" >&2
-			exit 1
-			;;
-	esac
+	[[ " ${ALL_VARIANTS[*]} " == *" ${provider} "* ]] ||
+		{ echo "unknown variant '${provider}' — known variants: ${ALL_VARIANTS[*]}" >&2; exit 1; }
 done
 
 # > OCI label inputs — empty on local builds, real values passed by CI. Applied to every image.

--- a/packages/templates/images/build.sh
+++ b/packages/templates/images/build.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Build the toolchain base image and all provider variants. The pins come from the arktype-validated
+# Build the toolchain base image and its provider variants. The pins come from the arktype-validated
 # TypeScript source of truth (packages/templates/src/pins.ts) — there is no versions.env. This script
 # validates that config (via bun), passes the image/PTS pins to `docker build` as --build-args, and
 # generates the mise.toml (tool versions) + e2b.toml from the same source. Single source of build
@@ -7,6 +7,15 @@
 #
 # Usage: packages/templates/images/build.sh
 # Honors env overrides: REGISTRY, IMAGE_OWNER, BUILD_DATE, BUILD_REF, BUILD_VERSION.
+#
+# Two more overrides drive the "variants-only" rebuild the scoped release uses (see
+# apps/cli/src/lib/bake/image.ts, buildAndPushVariantCandidates):
+#   BASE_IMAGE — build the variants FROM this already-published base ref instead of building a base
+#                here. The ref is pulled first, so the variant layer composes on exactly those bytes
+#                (pass a `repo@sha256:…` digest to make that exact).
+#   VARIANTS   — comma/space-separated subset of the provider variants to build (default: all of
+#                them). An unknown name is rejected rather than silently building nothing.
+# Both default to the full build, so the release lane's normal path is byte-for-byte unchanged.
 set -Eeuxo pipefail
 
 HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" # packages/templates/images
@@ -14,6 +23,9 @@ PINS_TS="${HERE}/../src/pins.ts"
 
 REGISTRY="${REGISTRY:-ghcr.io}"
 IMAGE_OWNER="${IMAGE_OWNER:-starslingdev}"
+
+# > Every provider variant this script knows how to build (each has a <name>/Dockerfile beside it).
+ALL_VARIANTS=(e2b daytona modal vercel)
 
 # > Validate the pins and collect them as KEY=VALUE lines. `bun` exits non-zero (and set -e aborts)
 # > if arktype rejects any pin, so a bad/unfilled pin fails the build before docker is even invoked.
@@ -39,6 +51,18 @@ base_ref="${base_repo}:${image_version}"
 # > Local tag the variants build against (matches each variant Dockerfile's BASE_IMAGE default).
 base_dev_tag="${image_name}:dev"
 
+# > The variant subset to build. Commas are accepted so the caller can pass one CSV env value.
+IFS=', ' read -r -a variants <<< "${VARIANTS:-${ALL_VARIANTS[*]}}"
+for provider in "${variants[@]}"; do
+	case " ${ALL_VARIANTS[*]} " in
+		*" ${provider} "*) ;;
+		*)
+			echo "unknown variant '${provider}' — known variants: ${ALL_VARIANTS[*]}" >&2
+			exit 1
+			;;
+	esac
+done
+
 # > OCI label inputs — empty on local builds, real values passed by CI. Applied to every image.
 meta_args=(
 	--build-arg "BUILD_DATE=${BUILD_DATE:-}"
@@ -54,19 +78,30 @@ bun "${PINS_TS}" --mise-toml > "${HERE}/base/mise.toml"
 bun "${PINS_TS}" --e2b-toml > "${HERE}/e2b/e2b.toml"
 bun "${HERE}/../src/manifest.ts" > "${HERE}/base/toolchain-manifest.json"
 
-echo ">>> building base: ${base_dev_tag} (+ ${base_ref})"
-docker build "${base_build_args[@]}" "${meta_args[@]}" \
-	-t "${base_dev_tag}" -t "${base_ref}" \
-	"${HERE}/base"
+# > With BASE_IMAGE set, the base is NOT rebuilt: the variants compose on the published bytes named by
+# > that ref (pulled first so the build resolves it locally, and so the OCI base.name label records the
+# > exact ref). This is what lets a scoped release restage one provider's variant against the SAME base
+# > every other provider on this version already runs — a rebuild would silently produce different bytes.
+if [ -n "${BASE_IMAGE:-}" ]; then
+	echo ">>> reusing published base: ${BASE_IMAGE} (no base build)"
+	docker pull "${BASE_IMAGE}"
+	variant_base="${BASE_IMAGE}"
+else
+	echo ">>> building base: ${base_dev_tag} (+ ${base_ref})"
+	docker build "${base_build_args[@]}" "${meta_args[@]}" \
+		-t "${base_dev_tag}" -t "${base_ref}" \
+		"${HERE}/base"
+	variant_base="${base_dev_tag}"
+fi
 
-# > Each variant composes on the just-built base via --build-arg BASE_IMAGE, with the images/
-# > directory as context so it can COPY the shared _shared/validate-base.sh. Variants take only the
-# > base ref + build metadata (their Dockerfiles declare no toolchain pins).
-for provider in e2b daytona modal vercel; do
+# > Each variant composes on the base via --build-arg BASE_IMAGE, with the images/ directory as
+# > context so it can COPY the shared _shared/validate-base.sh. Variants take only the base ref +
+# > build metadata (their Dockerfiles declare no toolchain pins).
+for provider in "${variants[@]}"; do
 	ref="${base_repo}-${provider}:${image_version}"
 	echo ">>> building ${provider} variant: ${ref}"
 	docker build "${meta_args[@]}" \
-		--build-arg "BASE_IMAGE=${base_dev_tag}" \
+		--build-arg "BASE_IMAGE=${variant_base}" \
 		-t "${ref}" \
 		-f "${HERE}/${provider}/Dockerfile" \
 		"${HERE}"


### PR DESCRIPTION
## Summary

This PR adds support for **scoped backfill releases** — a new release mode that allows adding a single provider (or subset of providers) to an already-published toolchain version without regenerating artifacts for other providers or rewriting the public base image.

## Problem

Previously, if a provider was added after a toolchain version was cut, there were only two recovery options, both problematic:
1. Bump the version and re-bench the entire fleet
2. Use `force_republish` to regenerate every provider's artifact in place (destructive for Daytona, which deletes snapshots before recreating them)

## Solution

The release workflow now accepts three optional dispatch inputs (all default to full release behavior):

- **`providers`**: Comma-separated provider IDs to release (blank = all). When a strict subset is specified, the release becomes a **backfill** that:
  - Publishes only those providers' version artifacts
  - Attaches to an already-published version (never rewrites the public base)
  - Makes every named provider required (you asked for it, so it must ship)

- **`build`**: Controls the build phase:
  - `full` (default): Rebuild the base image
  - `variants`: Restage only registry-served provider variants on the published base (minutes instead of an hour, same bytes as running fleet)
  - `skip`: Reuse existing candidates

- **`promote`**: Boolean to skip the publish phase (bake + verify only)

## Key Changes

### Core Release Logic
- **`promote.ts`**: Added `PromoteOptions` interface with `force` and `only` fields. Inverted step 1 logic for partial promotes (require version exists instead of refusing if it exists). Skip step 4 (base retag) for partial releases.
- **`release-plan.ts`**: Added provider selection, build mode, and promote toggle to plan inputs. Introduced `backfill` mode alongside `build`/`republish`. Compute `partial` flag and scope-aware required providers.
- **`matrix.ts`**: Added `isPartialScope()` predicate to detect strict subsets (the single predicate the scoped path turns on).

### Build System
- **`build-candidate.ts`**: Added `BuilderBuildMode` support with `full`/`variants` modes. `variants` mode rebuilds only published variants on the published base.
- **`image.ts`**: Extracted `PUBLISHED_VARIANTS` array (currently Vercel VCR source image). Added `buildAndPushVariantCandidates()` for variants-only rebuilds.
- **`build.sh`**: Added `BASE_IMAGE` and `VARIANTS` env overrides to support variants-only builds from published base.

### Workflow & Validation
- **`toolchain-image.yml`**: Added three dispatch inputs with defaults. Updated job outputs to include resolved provider scope and build/publish gates. Updated package visibility guard to check all anonymously-pulled packages (base + variants).
- **`release-validate.ts`**: Added validation for new dispatch inputs before any credentials are introduced.
- **`release-inputs.ts`**: New module defining `ReleaseBuildMode` vocabulary shared by validate and plan.

### Testing & Documentation
- Added comprehensive tests for scoped releases, partial detection, and build modes
- Updated `ci-secrets.md` with canonical use case: adding Vercel to v7 with `providers=vercel, build=variants, promote=false` then `build=skip, promote=true`
- Updated action descriptions and release summary to include scope information

## Implementation Details

- **Partial detection is derived, not passed**: The plan computes `partial` from the provider selection, ensuring the two can never describe different releases
- **Strict subset semantics**: Naming every registered provider is treated as a full release, not a partial one
- **Reproducibility**: Variants mode uses the published base digest to ensure new providers get identical bytes to the running fleet
- **Credential efficiency**: Scoped runs only perform credential dances for providers being released
- **Immutability guarantees**: Partial releases never rewrite the public base, maintaining the blast radius reduction that scoped releases exist to provide

https://claude.ai/code/session_01NmTGSazJtXVUCxec5nR8Sg

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds scoped backfill releases to add one or more providers to an already‑published toolchain version without rebuilding the base or touching other providers. Also fixes verify‑only runs and gates variants on a published base.

- New Features
  - Adds `providers`, `build`, and `promote` inputs; defaults match full releases.
  - Backfill mode publishes only the selected providers and never retags the public base.
  - `build=variants` restages only in‑scope provider variants on the published base; `build=skip` reuses candidates.
  - Validation resolves provider ids, rejects invalid combos (e.g., scoped + `force_republish`), and surfaces mode/scope in the summary; the matrix only includes selected providers.
  - Visibility guard checks only the anonymously pulled packages used by the scope (base + variants).

- Bug Fixes
  - Partial promote now requires candidate==published base only when any in‑scope provider bakes from the base; providers that don’t touch the base aren’t blocked by drift.
  - Build stages variants only for in‑scope providers; bake cells no longer resolve the candidate base when nothing in scope uses it.
  - Plan rejects unscopable providers early (e.g., missing creds or no artifact to publish).
  - Build outputs clarify what was staged and the published base used.
  - Verify‑only runs (`promote=false`) no longer skip when the version is already published; they bake and validate against the current version.
  - `build=variants` is refused unless the version is already published, with a clear, conclusive registry check.

<sup>Written for commit 0af83071ed683ed1e48da882f3783ec855e11d95. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/starslingdev/hpc-sandbox-benchmarks/pull/326?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added provider-scoped releases and backfills.
  * Added full, variants-only, or skipped build modes.
  * Added optional promotion controls for release workflows.
  * Release summaries now show the selected scope.
  * Supports checking visibility for multiple container packages.
* **Bug Fixes**
  * Improved validation for provider selections, build options, promotion settings, and published base images.
  * Prevents conflicting or unsupported release configurations.
* **Documentation**
  * Added guidance for scoped backfills, workflow options, and package visibility requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->