### PR TITLE
Consolidate benchmark dispatch lanes into shared implementation

### DIFF
--- a/.github/actions/namespace-token/action.yml
+++ b/.github/actions/namespace-token/action.yml
@@ -14,7 +14,8 @@ description: >-
   wildcard action is rejected outright ("not allowed in revokable tokens"), and each wrong verb name
   (e.g. "read"/"delete" instead of "get"/"destroy") is named individually in the CLI's error. All of
   this requires a trust relationship (this repo -> the Namespace tenant) registered once on the
-  Namespace side.
+  Namespace side. The token expires after four hours: one hour beyond the caller's 180-minute cell
+  budget, and explicit here rather than inherited from the CLI's longer default.
 
   FAILURE POSTURE is deliberately left to the caller, as a property of the action AS A WHOLE: put
   `continue-on-error: true` on the `uses:` step, and any failure inside here degrades to "no token" —
@@ -67,6 +68,7 @@ runs:
       run: |
         nsc token create \
           --name "$NSC_TOKEN_NAME" \
+          --expires_in 4h \
           --grant '{"resource_type":"instance","resource_id":"*","actions":["create","list","get","destroy","exec"]}' \
           --token_file "$NSC_TOKEN_PATH"
         echo "token-file=$NSC_TOKEN_PATH" >> "$GITHUB_OUTPUT"

--- a/.github/actions/namespace-token/action.yml
+++ b/.github/actions/namespace-token/action.yml
@@ -16,12 +16,17 @@ description: >-
   this requires a trust relationship (this repo -> the Namespace tenant) registered once on the
   Namespace side.
 
-  FAILURE POSTURE is the caller's to choose, because a composite action's own steps cannot declare
-  `continue-on-error`. Put `continue-on-error: true` on the `uses:` step instead: the whole action
-  then degrades to "no token", `token-file` stays empty, and the harness records the standard
-  missing-credentials skip — the same shape every other provider gets from an absent secret — rather
-  than aborting the job with no Run document and no summary. Whether that skip is tolerated or fatal
-  is decided downstream by REQUIRE_PROVIDERS, not here.
+  FAILURE POSTURE is deliberately left to the caller, as a property of the action AS A WHOLE: put
+  `continue-on-error: true` on the `uses:` step, and any failure inside here degrades to "no token" —
+  `token-file` stays empty, and the harness records the standard missing-credentials skip, the same
+  shape every other provider gets from an absent secret, rather than aborting the job with no Run
+  document and no summary. Whether that skip is tolerated or fatal is decided downstream by
+  REQUIRE_PROVIDERS, not here.
+
+  Both steps below could take their own `continue-on-error` (composite steps do support it), and
+  deliberately don't: an asymmetric posture — say, masking a transient `nsc token create` while
+  letting a broken CLI install abort the cell — is a real option, but it is the caller's call to make,
+  and splitting it across two files would hide half of it here.
 
 inputs:
   token-name:

--- a/.github/actions/namespace-token/action.yml
+++ b/.github/actions/namespace-token/action.yml
@@ -1,0 +1,67 @@
+name: Mint a portable Namespace token
+description: >-
+  Log the `nsc` CLI into the workspace via GitHub OIDC federation, then mint a scoped, revocable
+  token file @computesdk/namespace can read through NSC_TOKEN_FILE. Namespace is the one provider
+  with no stored secret — it federates on the job's `id-token: write` identity, which the caller must
+  grant.
+
+  The login itself lives in the CLI's own local session store, not a discoverable file
+  (/var/run/nsc/token.json is only pre-populated on Namespace-hosted runners — confirmed by a live
+  smoke run: ENOENT on a regular GitHub-hosted runner), so a portable token file has to be minted
+  from that session. The grant below is the minimal permission set the harness needs against the
+  Compute API's instance resource: create (CreateInstance), list (ListInstances), get
+  (DescribeInstance), destroy (DestroyInstance), and exec (RunCommandSync) — found by live trial: a
+  wildcard action is rejected outright ("not allowed in revokable tokens"), and each wrong verb name
+  (e.g. "read"/"delete" instead of "get"/"destroy") is named individually in the CLI's error. All of
+  this requires a trust relationship (this repo -> the Namespace tenant) registered once on the
+  Namespace side.
+
+  FAILURE POSTURE is the caller's to choose, because a composite action's own steps cannot declare
+  `continue-on-error`. Put `continue-on-error: true` on the `uses:` step instead: the whole action
+  then degrades to "no token", `token-file` stays empty, and the harness records the standard
+  missing-credentials skip — the same shape every other provider gets from an absent secret — rather
+  than aborting the job with no Run document and no summary. Whether that skip is tolerated or fatal
+  is decided downstream by REQUIRE_PROVIDERS, not here.
+
+inputs:
+  token-name:
+    description: >-
+      Name recorded on the minted token, so a leaked one is traceable to the cell that minted it.
+      Include github.run_attempt as well as github.run_id: run_id is PRESERVED across re-runs, so
+      without it a retry collides with the first attempt's token — and a caller's
+      `continue-on-error` would turn that name clash into a silent namespace skip on exactly the
+      re-run where the run was wanted.
+    required: true
+
+outputs:
+  token-file:
+    description: >-
+      Path to the minted {"bearer_token": "…"} JSON file, or empty if the mint did not complete.
+      Wire it straight into NSC_TOKEN_FILE — empty reads as "unset" to the config gatekeeper.
+    value: ${{ steps.mint.outputs.token-file }}
+
+runs:
+  using: composite
+  steps:
+    # Third-party actions are pinned to a commit SHA (the tag comment is for humans) so a
+    # moved/compromised tag can't silently change what runs.
+    - name: Set up Namespace CLI
+      uses: namespacelabs/nscloud-setup@df198f982fcecfb8264bea3f1274b56a61b6dfdc # v0
+
+    # The token name reaches the shell through the environment, never interpolated into the run
+    # block, so a dispatch-controlled suite name inside it can't inject into the runner command
+    # (zizmor template-injection). The output is written only after the mint succeeds — the default
+    # `bash -e` shell aborts the step first otherwise — so an empty `token-file` always means "no
+    # usable token", never "a token that was never written".
+    - name: Mint a portable Namespace token
+      id: mint
+      shell: bash
+      env:
+        NSC_TOKEN_NAME: ${{ inputs.token-name }}
+        NSC_TOKEN_PATH: ${{ runner.temp }}/nsc-token.json
+      run: |
+        nsc token create \
+          --name "$NSC_TOKEN_NAME" \
+          --grant '{"resource_type":"instance","resource_id":"*","actions":["create","list","get","destroy","exec"]}' \
+          --token_file "$NSC_TOKEN_PATH"
+        echo "token-file=$NSC_TOKEN_PATH" >> "$GITHUB_OUTPUT"

--- a/.github/actions/plan-bench-axes/action.yml
+++ b/.github/actions/plan-bench-axes/action.yml
@@ -1,0 +1,62 @@
+name: Plan benchmark axes
+description: >-
+  Resolve the three benchmark axes — providers, suites, and the per-suite replicate index map — from
+  the schema registries, and expose them as step outputs. This is the ONE planning implementation
+  both live-benchmark dispatches share: bench-matrix.yml plans the full matrix, and bench-smoke.yml
+  plans the same axes narrowed to a single provider × suite, so a smoke run reaches the reusable
+  bench-suite.yml through exactly the code path a real matrix run does.
+
+  The three `plan-*` bins each write their axis to $GITHUB_OUTPUT via emitStepOutputs and log through
+  @actions/core (foldable groups + notices). An unregistered provider or suite name fails the step, so
+  a typo fails the plan instead of quietly publishing a dataset with it missing — or running nothing.
+
+  NOTE: like ./.github/actions/setup-workspace, this composite runs no checkout and no install; the
+  caller does both (a local action is read from the already-checked-out workspace).
+
+inputs:
+  providers:
+    description: >-
+      Comma-separated providers to fan out over (blank = every registered provider). Rejected by
+      plan-providers if any name is not in the PROVIDERS registry.
+    default: ""
+  suites:
+    description: >-
+      Comma-separated suites to run (blank = every registered suite). Rejected by plan-suites if any
+      name is not in SUITE_NAMES. plan-replicates reads the SAME selection, so the replicate map is
+      keyed by exactly the emitted suite axis.
+    default: ""
+  replicas:
+    description: >-
+      Replicate sandboxes per (provider, suite) cell (blank = each suite's Suite.defaultReplicas; a
+      positive integer scales every suite). A non-positive or non-integer value fails the plan.
+    default: ""
+
+outputs:
+  providers:
+    description: JSON array of the selected provider ids, in registry order.
+    value: ${{ steps.plan.outputs.providers }}
+  suites:
+    description: JSON array of the selected suite names, in registry order.
+    value: ${{ steps.plan.outputs.suites }}
+  replicates:
+    description: >-
+      JSON object mapping each selected suite to its replicate index array (e.g.
+      {"cpu-node":[0,1,2],…}). A caller passes each suite its own slice down to bench-suite.yml.
+    value: ${{ steps.plan.outputs.replicates }}
+
+runs:
+  using: composite
+  steps:
+    # The dispatch inputs reach the planners through the environment, never interpolated into the
+    # shell, so a crafted input can't inject into the runner command.
+    - name: Plan
+      id: plan
+      shell: bash
+      env:
+        BENCH_PROVIDERS: ${{ inputs.providers }}
+        BENCH_SUITES: ${{ inputs.suites }}
+        BENCH_REPLICAS: ${{ inputs.replicas }}
+      run: |
+        bun apps/cli/src/bin/plan-providers.ts
+        bun apps/cli/src/bin/plan-suites.ts
+        bun apps/cli/src/bin/plan-replicates.ts

--- a/.github/actions/setup-toolchain/action.yml
+++ b/.github/actions/setup-toolchain/action.yml
@@ -4,6 +4,10 @@ description: >-
   after its checkout. Third-party tooling installs BEFORE any cloud credential is introduced, so a
   credentialed job's setup stays credential-free (the release's credential-minimization posture).
 
+  The Bun half is delegated to ./.github/actions/setup-workspace, the repo's single Bun pin + install
+  invocation (shared with the benchmark and dataset lanes); this action adds only what the toolchain
+  jobs need on top of it.
+
   NOTE: this composite deliberately does NOT run actions/checkout. A local action (`./.github/actions/…`)
   is read from the workspace, so the repo must already be checked out before this action can run — the
   caller keeps an explicit `actions/checkout` as its first step (which also keeps each job's
@@ -17,20 +21,15 @@ inputs:
 runs:
   using: composite
   steps:
-    # Third-party actions are pinned to a commit SHA (the tag comment is for humans) so a moved or
-    # compromised tag can't silently change what runs — the repo-wide supply-chain posture.
-    - name: Set up Bun
-      uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
+    - name: Set up Bun + dependencies
+      uses: ./.github/actions/setup-workspace
       with:
-        bun-version: 1.3.14
         # This runner's setup-bun cache restores without a working ~/.bun/bin/bun, so a cache hit
         # fails the "Set up Bun" step. Always download bun fresh instead of restoring the cache.
-        no-cache: true
+        no-cache: "true"
 
-    - name: Install dependencies
-      shell: bash
-      run: bun install --frozen-lockfile --ignore-scripts
-
+    # Third-party actions are pinned to a commit SHA (the tag comment is for humans) so a moved or
+    # compromised tag can't silently change what runs — the repo-wide supply-chain posture.
     - name: Set up Docker Buildx
       if: ${{ inputs.buildx == 'true' }}
       uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4.1.0

--- a/.github/actions/setup-workspace/action.yml
+++ b/.github/actions/setup-workspace/action.yml
@@ -1,0 +1,37 @@
+name: Set up workspace
+description: >-
+  Bun (repository-pinned version) + `bun install --frozen-lockfile --ignore-scripts` — the setup
+  preamble every benchmark, dataset and toolchain job shares, in ONE place. The Bun version and the
+  install flags are declared here for all of them, so a version bump or a change to the supply-chain
+  posture (frozen lockfile + no lifecycle scripts, matching bunfig.toml) is a one-line edit instead
+  of a hand-mirrored one across bench-matrix / bench-smoke / bench-suite / commit-dataset /
+  update-leaderboard / setup-toolchain. (ci.yml keeps its own inline setup: its gate job interleaves
+  the mise tool install between Bun and the dependency install.)
+
+  NOTE: this composite deliberately does NOT run actions/checkout. A local action
+  (`./.github/actions/…`) is read from the workspace, so the repo must already be checked out before
+  this action can run — the caller keeps an explicit `actions/checkout` as its first step (which also
+  keeps each job's persist-credentials posture visible to zizmor).
+
+inputs:
+  no-cache:
+    description: >-
+      Download Bun fresh instead of restoring setup-bun's cache. The self-hosted runners restore a
+      cache without a working ~/.bun/bin/bun, which fails the setup step outright, so the jobs that
+      target them pass "true"; hosted runners keep the cache.
+    default: "false"
+
+runs:
+  using: composite
+  steps:
+    # Third-party actions are pinned to a commit SHA (the tag comment is for humans) so a moved or
+    # compromised tag can't silently change what runs — the repo-wide supply-chain posture.
+    - name: Set up Bun
+      uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
+      with:
+        bun-version: 1.3.14
+        no-cache: ${{ inputs.no-cache }}
+
+    - name: Install dependencies
+      shell: bash
+      run: bun install --frozen-lockfile --ignore-scripts

--- a/.github/workflows/bench-matrix.yml
+++ b/.github/workflows/bench-matrix.yml
@@ -7,6 +7,11 @@ name: Bench matrix
 # Actions UI. Adding a suite is a schema change only: the suite axis is
 # `fromJSON(needs.plan.outputs.suites)`, kept in lockstep by the workflow-registry-sync gate.
 #
+# This file owns only the matrix's SHAPE and its publish phase. Planning the axes
+# (./.github/actions/plan-bench-axes) and running a cell (bench-suite.yml) are shared verbatim with
+# bench-smoke.yml, which is this same pipeline narrowed to one provider × suite and stopped before
+# `publish` — so a smoke run exercises the real benchmarking code path, minus the dataset commit.
+#
 # The THIRD axis, replicates, is deliberately NOT a runner axis: `plan` hands each suite's replicate
 # index array to its cells as data, and one runner drives that cell's whole replicate fleet
 # concurrently in-process (`bench-suite --replicates`). A bench runner is ~100% idle waiting on its
@@ -130,30 +135,19 @@ jobs:
         with:
           # Planning only reads code; don't persist the job token in .git/config.
           persist-credentials: false
-      - name: Set up Bun
-        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
-        with:
-          bun-version: 1.3.14
-      - name: Install dependencies
-        run: bun install --frozen-lockfile --ignore-scripts
-      # plan-providers / plan-suites each write their axis to $GITHUB_OUTPUT via emitStepOutputs and
-      # log through @actions/core (foldable groups + notices). An unregistered provider or suite name
-      # fails the step, so a typo fails the plan instead of quietly publishing a dataset with it
-      # missing or running nothing.
+      - name: Set up workspace
+        uses: ./.github/actions/setup-workspace
+      # The shared planner (also used by bench-smoke.yml's plan job, which narrows the same axes to one
+      # provider × suite). plan-replicates reads the SAME BENCH_SUITES selection as plan-suites, so its
+      # map is keyed by exactly the emitted suite axis; `replicas` scales the per-suite counts (blank =
+      # each suite's Suite.defaultReplicas).
       - name: Plan
         id: plan
-        # The dispatch inputs reach the planners through the environment, never interpolated into the
-        # shell, so a crafted input can't inject into the runner command. plan-replicates reads the SAME
-        # BENCH_SUITES selection as plan-suites, so its map is keyed by exactly the emitted suite axis;
-        # BENCH_REPLICAS scales the per-suite counts (blank = each suite's Suite.defaultReplicas).
-        env:
-          BENCH_PROVIDERS: ${{ inputs.providers }}
-          BENCH_SUITES: ${{ inputs.suites }}
-          BENCH_REPLICAS: ${{ inputs.replicas }}
-        run: |
-          bun apps/cli/src/bin/plan-providers.ts
-          bun apps/cli/src/bin/plan-suites.ts
-          bun apps/cli/src/bin/plan-replicates.ts
+        uses: ./.github/actions/plan-bench-axes
+        with:
+          providers: ${{ inputs.providers }}
+          suites: ${{ inputs.suites }}
+          replicas: ${{ inputs.replicas }}
 
   # One matrix cell per selected suite → reusable workflow call. GitHub nests the reusable's provider
   # matrix under each suite name, so the Actions UI shows expandable "<suite>" groups with "<provider>"

--- a/.github/workflows/bench-smoke.yml
+++ b/.github/workflows/bench-smoke.yml
@@ -1,27 +1,54 @@
 name: Bench smoke
 
-# Manually-dispatched live benchmark: spins up a real provider sandbox, runs one suite, normalizes
-# the result into a Run document, and uploads it as an artifact. Off the PR path (it costs real
-# sandbox time and needs provider credentials) — main is the default, while an explicit
-# `allow_branch` dispatch supports pre-merge validation of a change to the in-sandbox producer (the
-# sandbox clones this repo at the dispatched ref's SHA, so the mise tasks under test are the branch's
-# own). Mirrors bench-matrix.yml's opt-in rather than inventing a second spelling. Every dispatch
-# stays gated by Environment `privileged` (required reviewers + environment secrets — see
-# docs/ci-secrets.md); this workflow writes nothing back to the repo, so there is no publish step to
-# keep main-only.
+# A real benchmark run, narrowed to one provider × suite and stopped before the dataset is committed.
+#
+# This is bench-matrix.yml with two of its three phases: the same `plan` step
+# (./.github/actions/plan-bench-axes) with its axes narrowed to the dispatched provider and suite, then
+# the same suite-matrix job calling the same reusable bench-suite.yml — which spins up real sandboxes,
+# runs the suite, normalizes shard Run documents and uploads them as an artifact. What it does NOT do
+# is the third phase: no `publish` job, so nothing is aggregated, promoted or committed back to the
+# repo. That is the whole difference, and it is the point — a smoke run proves the live lane end to end
+# (credentials, runner routing, sandbox lifecycle, the in-sandbox producer, normalization, artifacts)
+# without moving the published dataset.
+#
+# Everything the run actually does therefore has exactly ONE implementation, shared with the matrix:
+# the credential wiring, the 180-minute cell budget, the microsandbox-local runner routing, the
+# Namespace OIDC mint, the replicate fan-out and the artifact contract all live in bench-suite.yml and
+# cannot drift between the lanes. Historically they were copy-pasted here and kept in sync by hand
+# (with a drift gate to catch the mistakes); now there is nothing to keep in sync.
+#
+# Two knobs differ in DEFAULT, not in kind:
+#   * `replicas` defaults to 1 — a smoke is a single sandbox per cell, where the matrix defaults to
+#     each suite's Suite.defaultReplicas (R=3 synthetic, R=12 realworld). Raise it to rehearse a real
+#     replicate fleet.
+#   * the dispatched provider is passed to bench-suite.yml as `require_providers`, so a missing or
+#     misnamed secret FAILS the job by name instead of being recorded as a skip. A green smoke must
+#     never hide that the provider was never actually smoked. The matrix deliberately leaves that
+#     blank so one unauthenticated cell doesn't sink a whole run.
+#
+# Off the PR path (it costs real sandbox time and needs provider credentials) — main is the default,
+# while an explicit `allow_branch` dispatch supports pre-merge validation of a change to the in-sandbox
+# producer (the sandbox clones this repo at the dispatched ref's SHA, so the mise tasks under test are
+# the branch's own). Every dispatch stays gated by Environment `privileged` (required reviewers +
+# environment secrets — see docs/ci-secrets.md), declared inside bench-suite.yml because a `uses:`
+# caller can't declare `environment:` itself.
 #
 # NOTE FOR OPERATORS — two things gate a branch dispatch besides the `if:` below:
 #   1. Environment `privileged` carries its own deployment-branch rule, so a branch dispatch is
 #      refused by GitHub ("Branch is not allowed to deploy to privileged") until that rule also
 #      admits the branch. See docs/ci-secrets.md → Environment `privileged`.
 #   2. GitHub reads the dispatch INPUT DEFINITIONS from the copy of this workflow on the default
-#      branch, so `allow_branch` is not offerable until this file is merged to `main` — the same
-#      constraint commit-dataset.yml carries. Merging it does not run anything; the input stays
+#      branch, so a newly added input is not offerable until this file is merged to `main` — the same
+#      constraint commit-dataset.yml carries. Merging it does not run anything; the inputs stay
 #      opt-in and the environment rule in (1) still has to admit the branch.
 on:
   workflow_dispatch:
     inputs:
       provider:
+        # Constrained to the PROVIDERS registry (packages/schema/src/providers.ts); the
+        # workflow-registry-sync drift gate keeps this list in lockstep, so a new provider must be
+        # added here too. The plan step re-validates it against the registry anyway, so a stale option
+        # fails the plan rather than running nothing.
         description: Provider to benchmark
         type: choice
         default: daytona-vm
@@ -41,9 +68,9 @@ on:
           ]
       suite:
         # Constrained to the SUITE_NAMES registry (packages/schema/src/suites.ts); the
-        # workflow-registry-sync drift gate (tooling/repo-checks) keeps this list in lockstep, so a
-        # new suite must be added here too. Still passed through the environment below (never
-        # interpolated into the shell) as defense-in-depth.
+        # workflow-registry-sync drift gate keeps this list in lockstep, so a new suite must be added
+        # here too. Still passed through the plan step (never interpolated into a shell) as
+        # defense-in-depth.
         # Defaults to `system` (PyBench + SQLite Speedtest + Git): a quick multi-probe suite that
         # exercises the broadest slice of the lane in a couple of minutes of benchmark on top of setup.
         # (`memory`/STREAM has a shorter budget but covers only a single dimension.)
@@ -62,12 +89,30 @@ on:
             realworld-better-auth,
             realworld-openclaw,
           ]
+      replicas:
+        # The between-machine axis, same spelling as bench-matrix.yml's input — but defaulting to 1
+        # rather than to each suite's schema default, because a smoke exists to prove the lane, not to
+        # tighten an interval, and R=12 on a realworld suite would spend a matrix cell's worth of
+        # provider quota to do it. Set it higher to rehearse a real replicate fleet (the cell drives
+        # them concurrently from its one runner, exactly as in the matrix).
+        description: 'Replicate sandboxes for the cell — the between-machine axis. Default 1 (a single sandbox); blank = the suite''s configured default (Suite.defaultReplicas); a whole number overrides it.'
+        required: false
+        type: string
+        default: '1'
       pts_passes:
         # The within-machine axis, matched to bench-matrix.yml so a policy can be smoke-tested on one cell
         # before spending the whole matrix. Blank uses the suite's own policy (the cpu-node and memory
         # suites converge; every other suite keeps a fixed count); a whole number
-        # forces that many; "converge" forces PTS's convergence. Passed via BENCH_PTS_PASSES; harness-validated.
+        # forces that many; "converge" forces PTS's convergence. Forwarded verbatim; harness-validated.
         description: 'PTS passes per case: blank = suite default policy, a number, or "converge".'
+        required: false
+        type: string
+        default: ''
+      max_concurrency:
+        # Inert at the default replicas=1 (one sandbox can't exceed any cap), and forwarded verbatim so
+        # a raised `replicas` can still be held under a tight provider quota — the same knob, and the
+        # same up-front rejection of a cap whose serial waves cannot fit the cell budget, as the matrix.
+        description: 'Cap replicate sandboxes in flight (blank = unbounded, i.e. all at once). Only meaningful when replicas > 1.'
         required: false
         type: string
         default: ''
@@ -81,178 +126,103 @@ on:
         type: boolean
         default: false
 
-# Least privilege: the job only reads the checked-out code and uploads an artifact.
+# Least privilege, workflow default: the plan job only reads the checked-out code. `id-token: write` is
+# deliberately NOT granted here — only the `suite` fan-out needs it (it must pass the scope down to
+# bench-suite.yml's cell for Namespace's GitHub OIDC federation), so it is scoped to that job; zizmor
+# flags a workflow-level id-token: write as overly broad since `plan` never touches it.
 permissions:
   contents: read
 
+# Serialize smoke runs per (ref, provider, suite) so two dispatches of the same cell don't contend for
+# the same provider quota; different cells still run in parallel.
 concurrency:
   group: bench-smoke-${{ github.ref }}-${{ inputs.provider }}-${{ inputs.suite }}
   cancel-in-progress: false
 
 jobs:
-  smoke:
-    name: ${{ inputs.suite }} on ${{ inputs.provider }}
+  # The matrix's plan phase, narrowed to the dispatched cell: the same three planners re-validate the
+  # provider and suite against the registries (a stale dispatch option fails here rather than running
+  # nothing) and emit the replicate map. No secrets — plan stays off the privileged environment so
+  # approval isn't needed just to dry-run the axes. The suite job `needs: plan`, so this guard also
+  # gates the run: a skipped plan (fork, or a non-main run without allow_branch) skips the cell.
+  plan:
+    name: Plan smoke
     # The fork guard is unconditional; only the ref constraint is opt-out-able. A dispatch can only be
     # triggered by someone with write access, and `workflow_dispatch` resolves refs in THIS repository
     # (never a fork's branch), so widening the ref does not widen who can spend provider quota.
     if: >
       github.repository == 'starslingdev/hpc-sandbox-benchmarks' &&
       (github.ref == 'refs/heads/main' || inputs.allow_branch)
-    # Two constraints pull opposite ways here, so both are recorded. The hosted `ubuntu-24.04` runner is
-    # the default because the ephemeral self-hosted label is reaped after 70 minutes even while a step
-    # is healthy, while this dispatch exposes suites with a 155-minute sandbox budget. But
-    # microsandbox-local needs KVM, which only the self-hosted label has — so it is routed there and
-    # accepts the shorter lifetime, declared below as BENCH_RUNNER_LIFETIME_MINUTES so bench-suite
-    # refuses an over-budget suite up front instead of being reaped mid-run with no logs and no
-    # artifact. Cloud and every other provider keep the hosted runner and its full lifetime.
-    runs-on: ${{ inputs.provider == 'microsandbox-local' && 'starsling-ubuntu-24.04-2' || 'ubuntu-24.04' }}
-    environment: privileged
-    timeout-minutes: 180
-    # `id-token: write` is scoped to this job (not the workflow, which only has this one job today),
-    # matching bench-matrix.yml/toolchain-image.yml: a job added later must opt in explicitly rather
-    # than silently inheriting the ability to request OIDC tokens. Only Namespace uses it (GitHub
-    # OIDC federation, no stored secret); widened from the workflow default (contents: read).
-    permissions:
-      contents: read
-      id-token: write
+    runs-on: ubuntu-24.04
+    outputs:
+      providers: ${{ steps.plan.outputs.providers }}
+      suites: ${{ steps.plan.outputs.suites }}
+      # A JSON object mapping the selected suite to its replicate index array (e.g. {"system":[0]}).
+      # The suite job indexes it by matrix.suite and passes that slice down, exactly as the matrix does.
+      replicates: ${{ steps.plan.outputs.replicates }}
     steps:
       # Third-party actions are pinned to a commit SHA (the tag comment is for humans) so a
       # moved/compromised tag can't silently change what runs.
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
-          # The job only reads code (the sandbox clones via BENCH_REPO_TOKEN when set, not the
-          # checkout's credentials), so don't persist the job token in .git/config.
+          # Planning only reads code; don't persist the job token in .git/config.
           persist-credentials: false
-
-      # Namespace has no stored secret: it federates via GitHub's OIDC identity (id-token: write
-      # above), logging the `nsc` CLI into the workspace via `nsc auth exchange-github-token` under
-      # the hood. That login lives in the CLI's own local session store, not a discoverable file —
-      # /var/run/nsc/token.json is only pre-populated on Namespace-hosted runners (confirmed by a
-      # live smoke run: ENOENT on a regular GitHub-hosted runner) — so the next step mints a portable
-      # token file from that session for @computesdk/namespace to read. Requires a trust relationship
-      # (this repo -> the Namespace tenant) registered once on the Namespace side.
-      #
-      # continue-on-error buys a LEGIBLE failure, not a passing job. This lane sets
-      # `REQUIRE_PROVIDERS: ${{ inputs.provider }}`, so the one provider you dispatched is required by
-      # construction: a not-yet-registered trust relationship (or any transient mint failure) leaves
-      # NSC_TOKEN_FILE empty, the harness records the standard "missing credentials" skip, and the D1
-      # gate in bench-smoke.ts then fails the job by name ("required providers did not pass"). That is
-      # deliberate — a green smoke must never hide that the provider was never actually smoked. What
-      # continue-on-error avoids is the raw step abort, which would kill the job with no Run document
-      # and no summary to diagnose from. The genuinely graceful skip lives in the matrix lanes
-      # (bench-suite.yml), which set no REQUIRE_PROVIDERS, so one unauthenticated cell doesn't sink
-      # the run.
-      - name: Set up Namespace CLI
-        if: inputs.provider == 'namespace'
-        continue-on-error: true
-        id: nsc-setup
-        uses: namespacelabs/nscloud-setup@df198f982fcecfb8264bea3f1274b56a61b6dfdc # v0
-
-      # `nsc token create` mints a scoped, revocable token from the CLI session above and writes it as
-      # a {"bearer_token": "..."} JSON file @computesdk/namespace can read via NSC_TOKEN_FILE. The
-      # grant below is the minimal permission set the harness needs against the Compute API's
-      # instance resource: create (CreateInstance), list (ListInstances), get (DescribeInstance),
-      # destroy (DestroyInstance), and exec (RunCommandSync) — found by live trial: a wildcard action
-      # is rejected outright ("not allowed in revokable tokens"), and each wrong verb name (e.g.
-      # "read"/"delete" instead of "get"/"destroy") is named individually in the CLI's error.
-      # run_attempt is part of the name because run_id is PRESERVED across re-runs: without it a retry
-      # collides with the first attempt's token, and continue-on-error would turn that name clash into a
-      # silent namespace skip — on exactly the re-run where you wanted the smoke to run.
-      - name: Mint a portable Namespace token
-        if: inputs.provider == 'namespace' && steps.nsc-setup.outcome == 'success'
-        continue-on-error: true
-        id: nsc-token
-        run: |
-          nsc token create \
-            --name "sandbox-benchmarks-smoke-${{ github.run_id }}-${{ github.run_attempt }}" \
-            --grant '{"resource_type":"instance","resource_id":"*","actions":["create","list","get","destroy","exec"]}' \
-            --token_file "${{ runner.temp }}/nsc-token.json"
-
-      - name: Set up Bun
-        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
+      - name: Set up workspace
+        uses: ./.github/actions/setup-workspace
+      # Single-element axes: the dispatched provider and suite. They reach the planners through the
+      # action's inputs (never interpolated into a shell), and an unregistered name fails the step.
+      - name: Plan
+        id: plan
+        uses: ./.github/actions/plan-bench-axes
         with:
-          bun-version: 1.3.14
+          providers: ${{ inputs.provider }}
+          suites: ${{ inputs.suite }}
+          replicas: ${{ inputs.replicas }}
 
-      # Frozen lockfile + no lifecycle scripts, matching bunfig.toml's supply-chain posture.
-      - name: Install dependencies
-        run: bun install --frozen-lockfile --ignore-scripts
-
-      - name: Authenticate with Vercel
-        if: inputs.provider == 'vercel'
-        continue-on-error: true
-        id: vercel-auth
-        uses: ./.github/actions/vercel-auth
-        with:
-          token: ${{ secrets.VERCEL_TOKEN }}
-          org-id: ${{ secrets.VERCEL_ORG_ID }}
-          project-id: ${{ secrets.VERCEL_PROJECT_ID }}
-
-      # Drives the provider SDK to create a sandbox, run the suite, collect results, and normalize.
-      # The sandbox clones THIS repo at the run's SHA so the in-sandbox producer matches the harness.
-      - name: Run suite and normalize
-        env:
-          BENCH_REPO_REF: ${{ github.sha }}
-          # Optional once the repo is public (anonymous clone works). Still passed so private forks and
-          # rate-limited clones keep working via the short-lived job token.
-          BENCH_REPO_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          # Pass the dispatch inputs through the environment, never interpolated into the `run` script.
-          # `provider` and `suite` are both constrained choices, but env passthrough is kept as
-          # defense-in-depth so no input value can ever expand straight into the self-hosted runner
-          # shell. `$GITHUB_RUN_ID` is built-in.
-          BENCH_PROVIDER: ${{ inputs.provider }}
-          BENCH_SUITE: ${{ inputs.suite }}
-          # PTS passes-per-case policy (blank = suite default, a number, or "converge"); read by the
-          # harness preamble. A smoke run is single-sandbox, so there is no replicate axis here.
-          BENCH_PTS_PASSES: ${{ inputs.pts_passes }}
-          # The point of a smoke run is to prove the lane end to end. Without this, a missing or
-          # misnamed provider secret is recorded as a skip and the job still exits 0 having
-          # benchmarked nothing — assert the dispatched provider actually reached "validated".
-          REQUIRE_PROVIDERS: ${{ inputs.provider }}
-          # Scope every provider credential to the dispatched provider: this run receives ONLY the
-          # secret(s) for `inputs.provider`, so a compromised adapter or suite can't read another
-          # provider's credential out of the environment. A non-matching provider evaluates to '',
-          # which the config gatekeeper treats as unset (packages/providers/src/lib/config.ts:
-          # empty ⇒ unset), exactly like an unsynced secret — so blanking the others is inert.
-          # Both Daytona isolation variants share the account key; scope it to either being dispatched.
-          DAYTONA_API_KEY: ${{ (inputs.provider == 'daytona-vm' || inputs.provider == 'daytona-container') && secrets.DAYTONA_API_KEY || '' }}
-          # Each Daytona variant pins its region via a variant-specific secret so operators can
-          # retarget without editing the workflow: daytona-vm reads DAYTONA_TARGET (us-west-2
-          # default), daytona-container reads DAYTONA_CONTAINER_TARGET (us-west-2 default).
-          DAYTONA_TARGET: ${{ inputs.provider == 'daytona-vm' && (secrets.DAYTONA_TARGET || 'us-west-2') || '' }}
-          DAYTONA_CONTAINER_TARGET: ${{ inputs.provider == 'daytona-container' && (secrets.DAYTONA_CONTAINER_TARGET || 'us-west-2') || '' }}
-          E2B_API_KEY: ${{ inputs.provider == 'e2b' && secrets.E2B_API_KEY || '' }}
-          # Both Modal variants share the account tokens; scope them to either being dispatched.
-          MODAL_TOKEN_ID: ${{ (inputs.provider == 'modal-gvisor' || inputs.provider == 'modal-vm') && secrets.MODAL_TOKEN_ID || '' }}
-          MODAL_TOKEN_SECRET: ${{ (inputs.provider == 'modal-gvisor' || inputs.provider == 'modal-vm') && secrets.MODAL_TOKEN_SECRET || '' }}
-          BL_API_KEY: ${{ inputs.provider == 'blaxel' && secrets.BL_API_KEY || '' }}
-          BL_WORKSPACE: ${{ inputs.provider == 'blaxel' && secrets.BL_WORKSPACE || '' }}
-          NOVITA_API_KEY: ${{ inputs.provider == 'novita' && secrets.NOVITA_API_KEY || '' }}
-          # OIDC-federated per-run token file (see the Namespace CLI steps above). Not a stored secret:
-          # empty unless namespace was dispatched AND the mint above succeeded (steps.nsc-token only
-          # runs when inputs.provider == 'namespace'), which the harness reads as the standard
-          # missing-credentials skip on every other dispatch.
-          NSC_TOKEN_FILE: ${{ steps.nsc-token.outcome == 'success' && format('{0}/nsc-token.json', runner.temp) || '' }}
-          # @computesdk/vercel reads the short-lived token exported by the auth action.
-          VERCEL_OIDC_TOKEN: ${{ inputs.provider == 'vercel' && steps.vercel-auth.outcome == 'success' && env.VERCEL_OIDC_TOKEN || '' }}
-          # Local is an explicit capability opt-in. Cloud needs only its API key; MSB_API_URL is an
-          # optional override for staging or private deployments. Neither value enters the guest.
-          MICROSANDBOX_LOCAL_BENCH: ${{ inputs.provider == 'microsandbox-local' && '1' || '' }}
-          # Paired with the microsandbox-local runner route above: that self-hosted label is reaped at
-          # 70 minutes regardless of timeout-minutes, which no expression can encode (the workflow gate
-          # requires a literal). Declaring it here lets bench-suite reject a suite that cannot finish
-          # inside it, before any sandbox is created. Empty on the hosted runner, which outlives the job.
-          BENCH_RUNNER_LIFETIME_MINUTES: ${{ inputs.provider == 'microsandbox-local' && '70' || '' }}
-          MSB_API_URL: ${{ inputs.provider == 'microsandbox-cloud' && secrets.MSB_API_URL || '' }}
-          MSB_API_KEY: ${{ inputs.provider == 'microsandbox-cloud' && secrets.MSB_API_KEY || '' }}
-        run: bun apps/cli/src/bin/bench-suite.ts "$BENCH_PROVIDER" "$BENCH_SUITE" "$GITHUB_RUN_ID"
-
-      - name: Upload Run + raw results
-        if: always()
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
-        with:
-          name: bench-${{ inputs.suite }}-${{ inputs.provider }}-${{ github.run_id }}
-          path: data/
-          # A successful run always writes data/runs/<id>.json (even an all-skipped Run), so an empty
-          # data/ means the job is genuinely broken — fail the upload rather than bury a warning.
-          if-no-files-found: error
+  # The matrix's benchmark phase, over a one-element suite axis → one reusable-workflow call → one
+  # provider cell. Structurally identical to bench-matrix.yml's `suite` job (same job id, same nesting
+  # wiring, same reusable) so the Actions UI reads the same "<suite> / <provider>", and so the
+  # workflow-registry-sync gate can hold both callers to one set of invariants.
+  # The fork/branch guard is repeated here (not only inherited via `needs: plan`) so the job stays
+  # explicit when read in isolation — matching every other live-run job in the repo.
+  suite:
+    name: ${{ matrix.suite }}
+    needs: plan
+    if: >
+      github.repository == 'starslingdev/hpc-sandbox-benchmarks' &&
+      (github.ref == 'refs/heads/main' || inputs.allow_branch)
+    # A called workflow's token can never exceed its caller's, so the id-token: write that
+    # bench-suite.yml's cell needs for Namespace's GitHub OIDC federation has to be granted here too.
+    # Scoped to this job, not the workflow level, per zizmor's excessive-permissions audit; `contents`
+    # is restated because a job-level `permissions:` replaces the workflow default rather than adding
+    # to it.
+    permissions:
+      contents: read
+      id-token: write
+    strategy:
+      # A one-element axis today, kept as a matrix (rather than a bare call) so this caller is the same
+      # shape as the matrix lane's: `fromJSON(needs.plan.outputs.suites)` is what makes the suite axis
+      # registry-driven, and fail-fast off is what it means for a cell to own its own outcome.
+      fail-fast: false
+      matrix:
+        suite: ${{ fromJSON(needs.plan.outputs.suites) }}
+    # `secrets: inherit` keeps repository secrets / token context available to the callee; Environment
+    # secrets on `privileged` are resolved by the reusable job's own `environment:` declaration (a
+    # `uses:` caller can't set `environment:`).
+    uses: ./.github/workflows/bench-suite.yml
+    with:
+      providers: ${{ needs.plan.outputs.providers }}
+      suite: ${{ matrix.suite }}
+      # This suite's slice of the plan's per-suite map, re-serialized to the JSON array string the cell
+      # passes straight to `bench-suite --replicates` — the matrix expression, verbatim.
+      replicates: ${{ toJSON(fromJSON(needs.plan.outputs.replicates)[matrix.suite]) }}
+      # Forward the PTS passes-per-case override unchanged (blank = suite default, a number, or converge).
+      pts_passes: ${{ inputs.pts_passes }}
+      # Forward the replicate concurrency cap unchanged (blank = all replicates at once).
+      max_concurrency: ${{ inputs.max_concurrency }}
+      # The one input the matrix lane leaves blank: require the dispatched provider to reach
+      # "validated", so an absent or misnamed credential fails the job ("required providers did not
+      # pass") instead of being recorded as a skip on a job that still exits 0.
+      require_providers: ${{ inputs.provider }}
+    secrets: inherit

--- a/.github/workflows/bench-smoke.yml
+++ b/.github/workflows/bench-smoke.yml
@@ -95,7 +95,7 @@ on:
         # tighten an interval, and R=12 on a realworld suite would spend a matrix cell's worth of
         # provider quota to do it. Set it higher to rehearse a real replicate fleet (the cell drives
         # them concurrently from its one runner, exactly as in the matrix).
-        description: 'Replicate sandboxes for the cell — the between-machine axis. Default 1 (a single sandbox); blank = the suite''s configured default (Suite.defaultReplicas); a whole number overrides it.'
+        description: 'Replicate sandboxes for the cell — the between-machine axis. Default 1 (a single sandbox); a whole number raises it. Blank also means 1 in this lane, NOT the suite''s schema default.'
         required: false
         type: string
         default: '1'
@@ -178,7 +178,13 @@ jobs:
         with:
           providers: ${{ inputs.provider }}
           suites: ${{ inputs.suite }}
-          replicas: ${{ inputs.replicas }}
+          # `|| '1'` is load-bearing, not belt-and-braces: the `default:` above only applies when the
+          # field is ABSENT, and both the dispatch UI (clear the box) and an API dispatch can send an
+          # empty string. Blank reaches plan-replicates as an unset BENCH_REPLICAS, which means "each
+          # suite's Suite.defaultReplicas" — R=12 on every realworld suite. A cleared field would then
+          # quietly spend twelve real sandboxes on the lane whose entire premise is one. Blank means 1
+          # here; raising it is an explicit act. (workflow-registry-sync pins this expression.)
+          replicas: ${{ inputs.replicas || '1' }}
 
   # The matrix's benchmark phase, over a one-element suite axis → one reusable-workflow call → one
   # provider cell. Structurally identical to bench-matrix.yml's `suite` job (same job id, same nesting

--- a/.github/workflows/bench-suite.yml
+++ b/.github/workflows/bench-suite.yml
@@ -1,12 +1,20 @@
 name: Benchmark suite (reusable)
 
-# One suite, fanned out across the provider matrix — ONE runner per (suite, provider) cell, which drives
-# that cell's whole replicate fleet itself. bench-matrix.yml calls this once per suite via its
-# suite-matrix job (`name: ${{ matrix.suite }}`), passing the plan's selected provider list AND that
-# suite's replicate index array — so cells display as "<suite> / <provider>" and nest under one suite
-# label in the Actions UI. The replicate axis is the BETWEEN-MACHINE knob: R sandboxes of one
-# (provider, suite) capture a provider's fleet variation (two can land on different host hardware),
-# which the aggregate folds into per-metric replicate breakdowns.
+# THE benchmark cell — the one implementation of "create real sandboxes, run a suite in them, collect
+# the raw results, normalize them into shard Run documents, upload them". Both live-benchmark
+# dispatches call it and neither has a second copy: bench-matrix.yml fans it out over the whole
+# provider × suite matrix and then commits the aggregated dataset, and bench-smoke.yml calls it with a
+# single provider × suite and stops after the upload. A smoke run is therefore the same code path as a
+# published run minus the commit phase — the credential wiring, the runner routing, the budget guard,
+# the artifact contract and the failure isolation below cannot drift between the two lanes, because
+# there is only one of each.
+#
+# ONE runner per (suite, provider) cell, which drives that cell's whole replicate fleet itself.
+# bench-matrix.yml calls this once per suite via its suite-matrix job (`name: ${{ matrix.suite }}`),
+# passing the plan's selected provider list AND that suite's replicate index array — so cells display
+# as "<suite> / <provider>" and nest under one suite label in the Actions UI. The replicate axis is the
+# BETWEEN-MACHINE knob: R sandboxes of one (provider, suite) capture a provider's fleet variation (two
+# can land on different host hardware), which the aggregate folds into per-metric replicate breakdowns.
 #
 # Replicates are NOT a matrix axis. A bench runner spends effectively all of its wall time waiting on a
 # sandbox (create → poll a detached step → poll again), so a runner-per-replicate matrix billed R idle
@@ -29,20 +37,17 @@ name: Benchmark suite (reusable)
 # runner eviction, OOM, or a "re-run failed jobs" click now costs all R replicates of the cell rather
 # than one. Sizing `max_concurrency` against `timeout-minutes` below is what keeps that risk bounded.
 #
-# Factoring the shared cell here (checkout → run → upload, plus the per-provider credential wiring)
-# keeps that block in ONE place instead of copy-pasted into every suite job, mirroring
-# runner-benchmarking's reusable bench-suite.yml.
-#
 # The artifact name (bench-<suite>-<provider>-<run_id>) is load-bearing: commit-dataset.yml downloads
 # the shards by the `bench-*-<run_id>` pattern and aggregates them — keep the two in lockstep. One
 # artifact now carries the cell's R shards, each written to its own `data/runs/<run_id>-r<idx>.json`
 # (every shard of one run shares the same `runId` FIELD, so the `-r<idx>` filename suffix is what keeps
-# them distinct); the aggregate keys them by the --replicate index stamped on each Run.
+# them distinct); the aggregate keys them by the --replicate index stamped on each Run. A smoke run
+# produces exactly the same shapes; nothing downstream aggregates them, which is the whole difference.
 #
 # Environment `privileged` (required reviewers + environment secrets — see docs/ci-secrets.md) lives on
 # the fan-out job here: a `uses:` caller can't declare `environment:`, so the approval gate and the
-# provider secrets are enforced at this layer. Environment secrets resolve from this job's
-# `environment:` declaration; the caller may still pass `secrets: inherit` for repository-level
+# provider secrets are enforced at this layer for BOTH lanes. Environment secrets resolve from this
+# job's `environment:` declaration; the caller may still pass `secrets: inherit` for repository-level
 # secrets / token context.
 on:
   workflow_call:
@@ -86,11 +91,23 @@ on:
         required: false
         type: string
         default: ''
+      require_providers:
+        description: >-
+          Comma-separated provider ids that MUST reach "validated" in this cell, or the cell fails
+          (REQUIRE_PROVIDERS). Blank — the MATRIX default — is the graceful posture: a provider whose
+          secret is absent or misnamed is recorded as a skip, so one unauthenticated cell doesn't sink a
+          whole matrix run. bench-smoke.yml sets its dispatched provider here instead, because the entire
+          point of a smoke run is to prove that one lane end to end: without it a missing credential
+          exits 0 having benchmarked nothing, and a green smoke would hide that the provider was never
+          actually smoked.
+        required: false
+        type: string
+        default: ''
 
 # Least privilege: the fan-out only reads the checked-out code and uploads artifacts, plus the OIDC
-# id-token the namespace cell exchanges for a Namespace login (no stored secret — see the CLI steps
-# below). The caller must grant `id-token: write` too: a called workflow's token can never exceed its
-# caller's.
+# id-token the namespace cell exchanges for a Namespace login (no stored secret — see the
+# ./.github/actions/namespace-token step below). The caller must grant `id-token: write` too: a called
+# workflow's token can never exceed its caller's.
 permissions:
   contents: read
   id-token: write
@@ -140,59 +157,30 @@ jobs:
           # checkout's credentials), so don't persist the job token in .git/config.
           persist-credentials: false
 
-      # Namespace has no stored secret: it federates via GitHub's OIDC identity (id-token: write
-      # above), logging the `nsc` CLI into the workspace via `nsc auth exchange-github-token` under
-      # the hood. That login lives in the CLI's own local session store, not a discoverable file —
-      # /var/run/nsc/token.json is only pre-populated on Namespace-hosted runners (confirmed by a
-      # live smoke run: ENOENT on a regular GitHub-hosted runner) — so the next step mints a portable
-      # token file from that session for @computesdk/namespace to read. Requires a trust relationship
-      # (this repo -> the Namespace tenant) registered once on the Namespace side — continue-on-error
-      # so a not-yet-registered trust relationship (or any transient failure) degrades to the same
-      # "missing credentials" skip every other provider gets from an absent secret, rather than
-      # failing the whole cell.
-      - name: Set up Namespace CLI
+      # Bun + `bun install --frozen-lockfile --ignore-scripts` (bunfig.toml's supply-chain posture),
+      # from the repo's single setup action. Runs before any credential is introduced.
+      - name: Set up workspace
+        uses: ./.github/actions/setup-workspace
+
+      # Namespace is the one provider with no stored secret: it federates on this job's OIDC identity
+      # (id-token: write above) and mints a portable token file from the resulting CLI session — see
+      # the action for the grant and why a file is needed at all. The cell's suite + run attempt name
+      # the token, through the action's input rather than the shell.
+      #
+      # continue-on-error buys a LEGIBLE failure, not a passing job — and it has to live here because a
+      # composite action's own steps can't declare it. A not-yet-registered trust relationship (or any
+      # transient mint failure) leaves `token-file` empty and the harness records the standard
+      # "missing credentials" skip, which is graceful in the matrix lane (no REQUIRE_PROVIDERS, so one
+      # unauthenticated cell doesn't sink the run) and fatal in the smoke lane (which requires its
+      # dispatched provider by name). What it avoids in both is the raw step abort, which would kill the
+      # cell with no Run document and no summary to diagnose from.
+      - name: Set up Namespace credentials
         if: matrix.provider == 'namespace'
         continue-on-error: true
-        id: nsc-setup
-        uses: namespacelabs/nscloud-setup@df198f982fcecfb8264bea3f1274b56a61b6dfdc # v0
-
-      # `nsc token create` mints a scoped, revocable token from the CLI session above and writes it as
-      # a {"bearer_token": "..."} JSON file @computesdk/namespace can read via NSC_TOKEN_FILE. The
-      # grant below is the minimal permission set the harness needs against the Compute API's
-      # instance resource: create (CreateInstance), list (ListInstances), get (DescribeInstance),
-      # destroy (DestroyInstance), and exec (RunCommandSync) — found by live trial: a wildcard action
-      # is rejected outright ("not allowed in revokable tokens"), and each wrong verb name (e.g.
-      # "read"/"delete" instead of "get"/"destroy") is named individually in the CLI's error.
-      #
-      # The cell's suite names the token so a leaked one is traceable to the cell that minted it; it
-      # reaches the shell through the environment, never interpolated into the run block, so a
-      # dispatch-controlled suite name can't inject into the runner command (zizmor template-injection).
-      # One token per cell now covers all R of its replicate sandboxes (they share this process's
-      # credentials, exactly as they share every other provider secret in the run step below).
-      # run_attempt is part of the name because run_id is PRESERVED across re-runs: without it a retry
-      # collides with the first attempt's token, and continue-on-error would turn that name clash into a
-      # silent namespace skip — on exactly the re-run where you wanted the validation.
-      - name: Mint a portable Namespace token
-        if: matrix.provider == 'namespace' && steps.nsc-setup.outcome == 'success'
-        continue-on-error: true
-        id: nsc-token
-        env:
-          BENCH_SUITE: ${{ inputs.suite }}
-          NSC_TOKEN_PATH: ${{ runner.temp }}/nsc-token.json
-        run: |
-          nsc token create \
-            --name "sandbox-benchmarks-${BENCH_SUITE}-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}" \
-            --grant '{"resource_type":"instance","resource_id":"*","actions":["create","list","get","destroy","exec"]}' \
-            --token_file "$NSC_TOKEN_PATH"
-
-      - name: Set up Bun
-        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
+        id: namespace
+        uses: ./.github/actions/namespace-token
         with:
-          bun-version: 1.3.14
-
-      # Frozen lockfile + no lifecycle scripts, matching bunfig.toml's supply-chain posture.
-      - name: Install dependencies
-        run: bun install --frozen-lockfile --ignore-scripts
+          token-name: sandbox-benchmarks-${{ inputs.suite }}-${{ github.run_id }}-${{ github.run_attempt }}
 
       - name: Authenticate with Vercel
         if: matrix.provider == 'vercel'
@@ -235,6 +223,10 @@ jobs:
           # PTS passes-per-case policy: blank = the suite's own policy (cpu-node + memory converge, the rest
           # fixed), a number or "converge" overrides every suite. Read by the harness preamble.
           BENCH_PTS_PASSES: ${{ inputs.pts_passes }}
+          # Blank in the matrix lane (a skipped provider stays a skip); the smoke lane names its dispatched
+          # provider so a missing/misnamed secret fails the job by name instead of exiting 0 having
+          # benchmarked nothing. See the require_providers input above.
+          REQUIRE_PROVIDERS: ${{ inputs.require_providers }}
           # Scope every provider credential to the cell that actually uses it: a cell receives ONLY
           # the secret(s) for its own `matrix.provider`, so a compromised adapter or suite can't read
           # another provider's credential out of the environment. A non-matching provider evaluates to
@@ -254,11 +246,11 @@ jobs:
           BL_API_KEY: ${{ matrix.provider == 'blaxel' && secrets.BL_API_KEY || '' }}
           BL_WORKSPACE: ${{ matrix.provider == 'blaxel' && secrets.BL_WORKSPACE || '' }}
           NOVITA_API_KEY: ${{ matrix.provider == 'novita' && secrets.NOVITA_API_KEY || '' }}
-          # OIDC-federated per-cell token file (see the Namespace CLI steps above). Not a stored
-          # secret: it is empty unless THIS cell is the namespace cell AND the mint above succeeded
-          # (steps.nsc-token only runs when matrix.provider == 'namespace'), which the harness reads
-          # as the standard missing-credentials skip on every other cell.
-          NSC_TOKEN_FILE: ${{ steps.nsc-token.outcome == 'success' && format('{0}/nsc-token.json', runner.temp) || '' }}
+          # OIDC-federated per-cell token file (see the Namespace step above). Not a stored secret: it is
+          # empty unless THIS cell is the namespace cell AND the mint succeeded (the step only runs when
+          # matrix.provider == 'namespace', and only writes the output once `nsc token create` returned),
+          # which the harness reads as the standard missing-credentials skip on every other cell.
+          NSC_TOKEN_FILE: ${{ steps.namespace.outputs.token-file }}
           # @computesdk/vercel reads the short-lived token exported by the auth action.
           VERCEL_OIDC_TOKEN: ${{ matrix.provider == 'vercel' && steps.vercel-auth.outcome == 'success' && env.VERCEL_OIDC_TOKEN || '' }}
           # Local is an explicit capability opt-in. Cloud needs only its API key; MSB_API_URL is an

--- a/.github/workflows/bench-suite.yml
+++ b/.github/workflows/bench-suite.yml
@@ -159,16 +159,26 @@ jobs:
 
       # Bun + `bun install --frozen-lockfile --ignore-scripts` (bunfig.toml's supply-chain posture),
       # from the repo's single setup action. Runs before any credential is introduced.
+      #
+      # no-cache is tied to the runner route above, not to a preference: the self-hosted label restores
+      # a setup-bun cache without a working ~/.bun/bin/bun, which fails the setup step outright — so the
+      # microsandbox-local cell, the one cell that lands there, must download Bun fresh. A hosted cell
+      # keeps the cache. (The cache is repo-scoped and OS/arch-keyed, so the entry a hosted cell saves
+      # is exactly what the self-hosted one would restore; ci.yml and setup-toolchain opt out for the
+      # same reason.)
       - name: Set up workspace
         uses: ./.github/actions/setup-workspace
+        with:
+          no-cache: ${{ matrix.provider == 'microsandbox-local' && 'true' || 'false' }}
 
       # Namespace is the one provider with no stored secret: it federates on this job's OIDC identity
       # (id-token: write above) and mints a portable token file from the resulting CLI session — see
       # the action for the grant and why a file is needed at all. The cell's suite + run attempt name
       # the token, through the action's input rather than the shell.
       #
-      # continue-on-error buys a LEGIBLE failure, not a passing job — and it has to live here because a
-      # composite action's own steps can't declare it. A not-yet-registered trust relationship (or any
+      # continue-on-error buys a LEGIBLE failure, not a passing job. It lives on the `uses:` step so the
+      # whole action degrades as a UNIT (the action's steps could each carry their own, and deliberately
+      # don't — see its header). A not-yet-registered trust relationship (or any
       # transient mint failure) leaves `token-file` empty and the harness records the standard
       # "missing credentials" skip, which is graceful in the matrix lane (no REQUIRE_PROVIDERS, so one
       # unauthenticated cell doesn't sink the run) and fatal in the smoke lane (which requires its
@@ -280,6 +290,14 @@ jobs:
       # So: gate on the shard files by name. A pass that wrote shards replaces the attempt it retried; a
       # pass that wrote none leaves the previous attempt's artifact standing. The job's own red/green is
       # unaffected — bench-suite already decided that — this only governs what gets published.
+      #
+      # ...EXCEPT on the first attempt, where there is nothing to protect. The guard exists to stop a
+      # broken retry from deleting a healthy predecessor; at run_attempt 1 no predecessor exists, so
+      # applying it there is pure loss — a cell that dies before normalization (a failed install, a
+      # create that never succeeded, an early crash) would upload nothing at all, discarding the raw
+      # tree and the harness's failure markers. That is the diagnostic the smoke lane exists to
+      # produce, and it is what the old bench-smoke.yml's unconditional `if: always()` upload gave.
+      # Upload on attempt 1 regardless; from attempt 2 on, the shard gate rules.
       - name: Check this attempt wrote shard Runs
         id: shards
         if: always()
@@ -294,7 +312,7 @@ jobs:
           fi
 
       - name: Upload Run + raw results
-        if: always() && steps.shards.outputs.count != '0'
+        if: always() && (steps.shards.outputs.count != '0' || github.run_attempt == '1')
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           # Per-cell artifact name so every (provider, suite) cell uploads independently, carrying its R

--- a/.github/workflows/commit-dataset.yml
+++ b/.github/workflows/commit-dataset.yml
@@ -70,12 +70,8 @@ jobs:
       # persist-credentials: false here or the push at the end of the job loses its credentials.
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-      - name: Set up Bun
-        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
-        with:
-          bun-version: 1.3.14
-      - name: Install dependencies
-        run: bun install --frozen-lockfile --ignore-scripts
+      - name: Set up workspace
+        uses: ./.github/actions/setup-workspace
 
       # Pull every per-cell shard artifact for the target run into ./shards (each in its own subdir).
       # run-id + github-token make this work across runs: for a matrix call run-id is the current run,

--- a/.github/workflows/toolchain-actions-smoke.yml
+++ b/.github/workflows/toolchain-actions-smoke.yml
@@ -1,0 +1,57 @@
+name: Toolchain actions smoke
+
+# Runtime coverage for the three local composites the toolchain PR lane actually executes. These
+# actions own only host setup + reporting, not image contents, so prove their contract directly on the
+# standard self-hosted runner instead of compiling the PTS-heavy base image for 6-8 minutes.
+on:
+  pull_request:
+    paths:
+      - ".github/actions/setup-toolchain/**"
+      - ".github/actions/setup-workspace/**"
+      - ".github/actions/release-summary/**"
+      - ".github/workflows/toolchain-actions-smoke.yml"
+
+# One in-flight smoke per PR ref. The full PR diff keeps this workflow eligible after a setup-action
+# edit, but superseded runs are cheap and should not queue behind one another.
+concurrency:
+  group: toolchain-actions-smoke-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  smoke:
+    name: Set up toolchain + summary
+    # This job checks out and executes the PR's local composites on a self-hosted runner. Keep the
+    # same-repository boundary used by ci.yml and the full toolchain PR gate.
+    if: github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: starsling-ubuntu-24.04-2
+    timeout-minutes: 5
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Set up toolchain
+        uses: ./.github/actions/setup-toolchain
+        with:
+          buildx: "true"
+
+      - name: Probe toolchain setup outputs
+        run: |
+          set -euo pipefail
+          test "$(bun --version)" = "1.3.14"
+          bun packages/templates/src/pins.ts >/dev/null
+          docker buildx inspect --bootstrap
+
+      - name: Release summary
+        if: always()
+        uses: ./.github/actions/release-summary
+        with:
+          phase: toolchain-actions-smoke
+          status: ${{ job.status }}
+          mode: pr-gate
+          source-ref: ${{ github.sha }}
+          verify: bun packages/templates/src/pins.ts && docker buildx inspect --bootstrap

--- a/.github/workflows/toolchain-image.yml
+++ b/.github/workflows/toolchain-image.yml
@@ -70,11 +70,13 @@ on:
         type: boolean
         default: false
   pull_request:
+    # Composite-action changes are exercised by toolchain-actions-smoke.yml on the standard
+    # 2-vCPU runner. Keeping them out of this list matters: PR path filters use the whole PR diff,
+    # so one setup-action edit would otherwise rebuild the PTS-heavy base after every later push.
     paths:
       - "packages/templates/**"
       - "packages/schema/src/toolchain.ts"
       - ".github/workflows/toolchain-image.yml"
-      - ".github/actions/**"
 
 # Serialize publishes by ref: concurrent dispatches on the same ref must not race on the version tag.
 # PR runs key off their own head ref (separate group) and may cancel superseded runs; a publish is

--- a/.github/workflows/update-leaderboard.yml
+++ b/.github/workflows/update-leaderboard.yml
@@ -73,12 +73,8 @@ jobs:
       # the end of the job loses its credentials.
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-      - name: Set up Bun
-        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
-        with:
-          bun-version: 1.3.14
-      - name: Install dependencies
-        run: bun install --frozen-lockfile --ignore-scripts
+      - name: Set up workspace
+        uses: ./.github/actions/setup-workspace
 
       # The chart screenshots need a Chrome, and this is what makes the browser a PINNED input
       # rather than ambient runner state (the image's unpinned google-chrome-stable would

--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -14,7 +14,9 @@ rules:
       - update-leaderboard.yml
   secrets-inherit:
     ignore:
-      # bench-matrix.yml's suite-matrix job calls the reusable bench-suite.yml with `secrets: inherit`.
+      # bench-matrix.yml's and bench-smoke.yml's suite-matrix jobs both call the reusable
+      # bench-suite.yml with `secrets: inherit` (the smoke lane is the same pipeline narrowed to one
+      # provider × suite and stopped before the dataset commit, so it reaches the cell the same way).
       # The reusable's fan-out job declares `environment: privileged`, which raises the approval gate and
       # scopes the provider ENVIRONMENT secrets (docs/ci-secrets.md) to that job, where it re-scopes each
       # credential to its own provider cell (`matrix.provider == 'daytona' && secrets.DAYTONA_API_KEY ||
@@ -23,3 +25,4 @@ rules:
       # environment to resolve them itself). The workflow-hardening drift gate independently verifies the
       # callee self-gates on `privileged`. (Filename-scoped, not repo-wide.)
       - bench-matrix.yml
+      - bench-smoke.yml

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -57,8 +57,11 @@ bun run check:catalog-drift                                    # fail if the com
 3. **Template** — add a template builder under [`packages/templates`](./packages/templates) so the
    provider can be baked with the toolchain image.
 4. **Exhaustive consumers** — update the CLI bake map, candidate create-options switch, release-plan
-   artifact switch, provider-id test oracles, and both benchmark workflows' synchronized credential
-   environment. Provider matrix fan-out, normalization, leaderboard, and economics remain automatic.
+   artifact switch, provider-id test oracles, the credential environment in
+   [`bench-suite.yml`](./.github/workflows/bench-suite.yml) (the one benchmark cell both dispatch lanes
+   call, so there is a single block to edit), and the `provider` dispatch options in
+   [`bench-smoke.yml`](./.github/workflows/bench-smoke.yml). Provider matrix fan-out, normalization,
+   leaderboard, and economics remain automatic.
 5. Bring it up live with a single-provider branch dispatch before adding it to the default matrix list.
 
 ## Add a suite
@@ -79,8 +82,9 @@ bun run check:catalog-drift                                    # fail if the com
 3. **No matrix job edit** — `bench-matrix.yml` matrices over `plan.outputs.suites` (from `SUITE_NAMES`
    via `plan-suites`), so a new suite is picked up automatically and nests as `<suite> / <provider>` in
    the Actions UI; a dispatch can still narrow to a subset with the `suites` input. The
-   workflow-registry-sync drift gate keeps that nesting wiring honest. Add it to the `bench-smoke` suite
-   `options` too so it stays dispatchable on its own.
+   workflow-registry-sync drift gate keeps that nesting wiring honest. `bench-smoke.yml` runs the same
+   plan → `bench-suite.yml` pipeline, so it needs no edit either — except adding the name to its `suite`
+   dispatch `options`, which is what makes the suite selectable for a single-cell smoke.
 
 ## Add a metric
 

--- a/apps/cli/src/bin/bench-suite.ts
+++ b/apps/cli/src/bin/bench-suite.ts
@@ -225,10 +225,11 @@ async function writeCellSummary(
 
 /**
  * The single-sandbox report: ONE cell, described in full. Deliberately richer per-provider than
- * {@link reportFleet} rather than a special case of it — this is what a human reads after a manual
- * bench-smoke dispatch or a local run, so it keeps the whole-Run provider table (every registered
+ * {@link reportFleet} rather than a special case of it — this is what a human reads after a local run
+ * or an explicit `--replicate <idx>`, so it keeps the whole-Run provider table (every registered
  * provider, with the skipped/failed gap split) that a fleet's one-row-per-replicate table has no room
- * for, and names the target provider's validation state in the annotation itself.
+ * for, and names the target provider's validation state in the annotation itself. CI no longer reaches
+ * it: both dispatch lanes go through the reusable cell, which always passes `--replicates`.
  */
 async function reportCell(
 	opts: CellIdentity & {
@@ -725,19 +726,25 @@ if (import.meta.main) {
 	});
 
 	if (replicateIndices === undefined) {
-		// Single-sandbox path (local dev, bench-smoke, and an explicit `--replicate <idx>`): one shard at
-		// the un-suffixed `data/runs/<runId>.json`, which bench-smoke.yml and commit-dataset.yml's legacy
-		// glob both name directly — so the filename is a contract, not the `-r<idx>` convention minus a
-		// suffix.
+		// Single-sandbox path (local dev and an explicit `--replicate <idx>`): one shard at the
+		// un-suffixed `data/runs/<runId>.json`, which commit-dataset.yml's legacy glob names directly —
+		// so the filename is a contract, not the `-r<idx>` convention minus a suffix. No CI lane takes
+		// this path any more: both dispatch lanes go through the reusable cell, which always passes
+		// `--replicates`, so a smoke is `[0]` on the fan-out path rather than a bare single run.
 		//
 		// Kept as its own path rather than "the fan-out with one replicate", deliberately. The audience
 		// differs, and so does the useful report: this is a human reading ONE cell, who wants the
-		// whole-Run provider table (every registered provider, skipped/failed gaps split out) and the
-		// foldable `::group::` sections — neither of which a fleet report can give, because its table is
-		// one row per replicate and its grouping is off so R interleaved transcripts stay readable. Fan
-		// out to R=1 and you would have to special-case all of that back in, trading two honest paths for
-		// one path full of `length === 1` branches. What the two DO share — heading, cell identity, task
-		// plan, annotation wiring — is shared for real, in writeCellSummary.
+		// whole-Run provider table (every registered provider, skipped/failed gaps split out), which a
+		// fleet report has no room for — its table is one row per replicate. What the two DO share —
+		// heading, cell identity, task plan, annotation wiring — is shared for real, in writeCellSummary.
+		//
+		// The fan-out path DOES carry one `length === 1` branch: it keeps foldable groups and skips line
+		// tagging at R=1, because those exist purely to disentangle concurrent replicates and a lone one
+		// has nothing to disentangle. That is the whole special case, and it is worth it — a smoke
+		// dispatch lands on the fan-out path at R=1 and would otherwise read as an untagged-problem's
+		// tagged transcript. The summary shape is deliberately NOT special-cased back: a required
+		// provider that skipped still names its gaps verbatim in the fleet failure detail and the
+		// annotation, which is the diagnostic that actually matters when a cell produces nothing.
 		const outcome = await runReplicate({
 			provider,
 			suite,
@@ -769,8 +776,16 @@ if (import.meta.main) {
 	// every line is tagged with its replicate instead — Actions groups are a single ordered stream, so
 	// R concurrent replicates opening and closing them produces folds containing other replicates'
 	// output. The tag is what keeps an interleaved 12-way transcript attributable.
-	setGroupingEnabled(false);
-	installLineTagging();
+	//
+	// Neither applies at R=1: one replicate cannot interleave with itself, so turning groups off and
+	// tagging every line would cost a readable transcript to solve a problem that doesn't exist. This
+	// is not hypothetical tidiness — bench-smoke.yml reaches this path with `--replicates "[0]"` (the
+	// reusable cell always passes the flag), so the lane whose whole output is read by a human would
+	// otherwise lose its foldable sections to a fan-out concern it never has.
+	if (replicateIndices.length > 1) {
+		setGroupingEnabled(false);
+		installLineTagging();
+	}
 	logInfo(
 		`Driving ${replicateIndices.length} replicate sandbox(es) [${replicateIndices.join(", ")}] ` +
 			`for ${cell}` +

--- a/docs/ci-secrets.md
+++ b/docs/ci-secrets.md
@@ -18,9 +18,11 @@ and toolchain publish must not trigger on `push`.
 | `update-leaderboard.yml` | `leaderboard` | Public `LEADERBOARD.md` commit (`contents: write` + `pull-requests: write`) |
 
 `bench-matrix.yml` and `bench-smoke.yml` are **not** listed: neither reads a provider secret itself.
-Both are a `plan` job plus a suite-matrix job that calls `bench-suite.yml`, so every credential — and
-the approval gate that protects it — is enforced once, at that callee. A smoke dispatch is therefore
-gated exactly as a matrix cell is; it simply stops before the dataset commit.
+`bench-smoke.yml` is a `plan` job plus a suite-matrix job that calls `bench-suite.yml`;
+`bench-matrix.yml` is the same, plus a `publish` job that calls `commit-dataset.yml`. Both callees are
+in the table above and carry their own `privileged` gate, so a dispatch lane's jobs only plan and
+orchestrate. A smoke dispatch is gated exactly as a matrix cell is — same approval, same Environment
+secrets, same callee — it simply has no third phase to gate.
 
 Two of these are reusable workflows whose `privileged` gate lives on their own job, because a `uses:`
 caller can't declare `environment:` (the workflow-hardening drift gate checks the callee and passes the

--- a/docs/ci-secrets.md
+++ b/docs/ci-secrets.md
@@ -13,19 +13,24 @@ and toolchain publish must not trigger on `push`.
 | Workflow | Job | Why |
 | --- | --- | --- |
 | `toolchain-image.yml` | `publish` | Provider bake secrets + `packages: write` (GHCR release) |
-| `bench-suite.yml` | `bench` | Provider API keys (reusable fan-out `bench-matrix.yml`'s suite-matrix job calls) |
+| `bench-suite.yml` | `bench` | Provider API keys (the reusable benchmark cell BOTH `bench-matrix.yml` and `bench-smoke.yml` call) |
 | `commit-dataset.yml` | `commit` | Dataset JSON commit (`contents: write` + `pull-requests: write`) |
 | `update-leaderboard.yml` | `leaderboard` | Public `LEADERBOARD.md` commit (`contents: write` + `pull-requests: write`) |
-| `bench-smoke.yml` | `smoke` | Provider API keys |
+
+`bench-matrix.yml` and `bench-smoke.yml` are **not** listed: neither reads a provider secret itself.
+Both are a `plan` job plus a suite-matrix job that calls `bench-suite.yml`, so every credential — and
+the approval gate that protects it — is enforced once, at that callee. A smoke dispatch is therefore
+gated exactly as a matrix cell is; it simply stops before the dataset commit.
 
 Two of these are reusable workflows whose `privileged` gate lives on their own job, because a `uses:`
 caller can't declare `environment:` (the workflow-hardening drift gate checks the callee and passes the
 local caller):
 
-- `bench-suite.yml` runs one suite across a provider matrix; `bench-matrix.yml`'s suite-matrix job
-  calls it once per suite. Environment secrets on `privileged` resolve from the reusable job's own
-  `environment:` declaration (a `uses:` caller can't set `environment:`). The caller still passes
-  `secrets: inherit` for repository-level secrets / token context.
+- `bench-suite.yml` runs one suite across a provider matrix. It is the single benchmark-cell
+  implementation: `bench-matrix.yml`'s suite-matrix job calls it once per planned suite, and
+  `bench-smoke.yml`'s calls it once for the dispatched suite. Environment secrets on `privileged`
+  resolve from the reusable job's own `environment:` declaration (a `uses:` caller can't set
+  `environment:`). Both callers pass `secrets: inherit` for repository-level secrets / token context.
 - `commit-dataset.yml` commits the machine-readable dataset: `bench-matrix.yml`'s `publish` job calls it
   at the end of a matrix run, and a maintainer can dispatch it standalone to backfill (see rule 6). It
   lands `data/dataset/` only — the public `LEADERBOARD.md` is regenerated separately (see rule 7), so the

--- a/docs/methodology.md
+++ b/docs/methodology.md
@@ -190,6 +190,13 @@ so 20–80-minute suites such as Mastra launch detached and remain observable th
      rule on `network`, or is a k=1 cold-start whose install/build IS the metric (realworld). Everything
      fixed carries its spread via replicates, not in-sandbox repeats; a number or `converge` forces one
      policy across every suite.
+
+   The `bench-smoke` workflow is this same step, narrowed: the same plan action over a single
+   dispatched provider and suite, calling the same reusable `bench-suite` workflow, defaulting to one
+   replicate — and then stopping. It has no step 3, so a smoke run exercises the live lane end to end
+   (credentials, sandbox lifecycle, the in-sandbox producer, normalization, artifacts) without moving
+   the published dataset. Its one behavioural difference is that it *requires* its dispatched provider
+   to reach `validated`, so a missing credential fails the run rather than being recorded as a skip.
 3. **Aggregate → promote → commit** — the `commit-dataset` workflow (the matrix's `publish` job calls
    it) collects every shard, `aggregate`s them into one candidate Run (measured metrics unioned, the ≥2
    replicate sandboxes of one `(provider, suite)` folded into per-metric replicate breakdowns, economics

--- a/tooling/repo-checks/src/lib/workflow-hardening.ts
+++ b/tooling/repo-checks/src/lib/workflow-hardening.ts
@@ -15,6 +15,8 @@
 //      A reusable-workflow caller (`uses:` job) can't declare `environment:`; a LOCAL call defers the
 //      gate to the called file (checked here in its own right), a REMOTE one is flagged (unverifiable).
 //   4. Toolchain publish is dispatch-only — toolchain-image.yml must not fire a release on push/merge.
+//   5. Toolchain PR ownership stays split — image inputs run the expensive docker smoke, while the
+//      three setup/reporting composites run a lightweight smoke on the standard 2-vCPU runner.
 //
 // Bun.YAML.parse is built into bun >= 1.3 (no new dependency).
 import { readFileSync } from "node:fs";
@@ -25,6 +27,22 @@ import { findRepoRoot } from "./workspace.ts";
 export const WORKFLOWS_DIR = ".github/workflows";
 export const CI_LINT_WORKFLOW = ".github/workflows/ci-lint.yml";
 export const TOOLCHAIN_WORKFLOW = "toolchain-image.yml";
+export const TOOLCHAIN_ACTION_SMOKE_WORKFLOW = "toolchain-actions-smoke.yml";
+
+/** Inputs that can alter the toolchain image and therefore own the expensive PR docker smoke. */
+export const TOOLCHAIN_IMAGE_PR_PATHS = [
+	"packages/templates/**",
+	"packages/schema/src/toolchain.ts",
+	".github/workflows/toolchain-image.yml",
+] as const;
+
+/** Local composites executed by the toolchain PR lane, plus the lightweight smoke itself. */
+export const TOOLCHAIN_ACTION_SMOKE_PR_PATHS = [
+	".github/actions/setup-toolchain/**",
+	".github/actions/setup-workspace/**",
+	".github/actions/release-summary/**",
+	".github/workflows/toolchain-actions-smoke.yml",
+] as const;
 
 /** GitHub Environment name that holds provider secrets and gates releases. See docs/ci-secrets.md. */
 export const PRIVILEGED_ENVIRONMENT = "privileged";
@@ -489,6 +507,110 @@ export function checkToolchainDispatchOnly(
 	return errors;
 }
 
+function pullRequestPaths(doc: unknown, file: string): string[] {
+	const root = asRecord(doc, `${file}: not a YAML mapping`);
+	const triggers = asRecord(root.on, `${file}: missing or malformed \`on:\` trigger map`);
+	const pullRequest = asRecord(
+		triggers.pull_request,
+		`${file}: missing or malformed \`pull_request:\` trigger`,
+	);
+	if (
+		!Array.isArray(pullRequest.paths) ||
+		!pullRequest.paths.every((path) => typeof path === "string")
+	) {
+		throw new Error(`${file}: \`pull_request.paths\` must be a string list`);
+	}
+	return pullRequest.paths;
+}
+
+function exactSetError(
+	actual: readonly string[],
+	expected: readonly string[],
+	label: string,
+): string | undefined {
+	const sortedActual = [...actual].sort();
+	const sortedExpected = [...expected].sort();
+	if (JSON.stringify(sortedActual) === JSON.stringify(sortedExpected)) return undefined;
+	return `${label} must be exactly [${expected.join(", ")}], got [${actual.join(", ")}]`;
+}
+
+/**
+ * Invariant 5: image inputs own the expensive toolchain PR smoke; the setup/reporting composites
+ * own a bounded smoke on the standard runner. This prevents a broad action glob from turning every
+ * later push in an action-touching PR into another PTS-heavy image build.
+ */
+export function checkToolchainPrScope(
+	toolchainDoc: unknown,
+	actionSmokeDoc: unknown,
+	toolchainFile: string = TOOLCHAIN_WORKFLOW,
+	actionSmokeFile: string = TOOLCHAIN_ACTION_SMOKE_WORKFLOW,
+): string[] {
+	const errors: string[] = [];
+	const imagePathError = exactSetError(
+		pullRequestPaths(toolchainDoc, toolchainFile),
+		TOOLCHAIN_IMAGE_PR_PATHS,
+		`${toolchainFile}: \`pull_request.paths\``,
+	);
+	if (imagePathError !== undefined) errors.push(imagePathError);
+
+	const actionPathError = exactSetError(
+		pullRequestPaths(actionSmokeDoc, actionSmokeFile),
+		TOOLCHAIN_ACTION_SMOKE_PR_PATHS,
+		`${actionSmokeFile}: \`pull_request.paths\``,
+	);
+	if (actionPathError !== undefined) errors.push(actionPathError);
+
+	const root = asRecord(actionSmokeDoc, `${actionSmokeFile}: not a YAML mapping`);
+	const jobs = asRecord(root.jobs, `${actionSmokeFile}: no jobs mapping`);
+	const smoke = asRecord(jobs.smoke, `${actionSmokeFile}: missing or malformed "smoke" job`);
+	const jobLabel = `${actionSmokeFile}::smoke`;
+	if (smoke["runs-on"] !== "starsling-ubuntu-24.04-2") {
+		errors.push(`${jobLabel}: must use the standard 2-vCPU runner \`starsling-ubuntu-24.04-2\``);
+	}
+	if (smoke["timeout-minutes"] !== 5) {
+		errors.push(`${jobLabel}: must keep \`timeout-minutes: 5\` to bound runner spend`);
+	}
+	if (smoke.if !== "github.event.pull_request.head.repo.full_name == github.repository") {
+		errors.push(`${jobLabel}: must keep the same-repository guard before executing PR code`);
+	}
+
+	if (!Array.isArray(smoke.steps)) {
+		throw new Error(`${jobLabel}: steps must be a list`);
+	}
+	const steps = smoke.steps.map((step) => asRecord(step, `${jobLabel}: malformed step`));
+	const setup = steps.find((step) => step.uses === "./.github/actions/setup-toolchain");
+	if (setup === undefined) {
+		errors.push(`${jobLabel}: must execute ./.github/actions/setup-toolchain`);
+	} else {
+		const withBlock = asRecord(setup.with, `${jobLabel}: setup-toolchain has malformed \`with:\``);
+		if (withBlock.buildx !== "true") {
+			errors.push(`${jobLabel}: setup-toolchain must pass \`buildx: "true"\``);
+		}
+	}
+	const summary = steps.find((step) => step.uses === "./.github/actions/release-summary");
+	if (summary === undefined) {
+		errors.push(`${jobLabel}: must execute ./.github/actions/release-summary`);
+	} else if (summary.if !== "always()") {
+		errors.push(`${jobLabel}: release-summary must use \`if: always()\` so failures are reported`);
+	}
+
+	const runText = steps
+		.map((step) => step.run)
+		.filter((run): run is string => typeof run === "string")
+		.join("\n");
+	for (const probe of [
+		"bun --version",
+		"1.3.14",
+		"bun packages/templates/src/pins.ts",
+		"docker buildx inspect --bootstrap",
+	] as const) {
+		if (!runText.includes(probe)) {
+			errors.push(`${jobLabel}: runtime probe is missing \`${probe}\``);
+		}
+	}
+	return errors;
+}
+
 /** The whole gate against the real .github files under `root`. */
 export function runHardeningCheck(root: string = findRepoRoot()): string[] {
 	const files = listWorkflowFiles(root);
@@ -526,6 +648,19 @@ export function runHardeningCheck(root: string = findRepoRoot()): string[] {
 		errors.push(`${TOOLCHAIN_WORKFLOW}: missing from ${WORKFLOWS_DIR}`);
 	} else {
 		errors.push(...checkToolchainDispatchOnly(toolchainDoc, TOOLCHAIN_WORKFLOW));
+		const actionSmokeDoc = docs.get(TOOLCHAIN_ACTION_SMOKE_WORKFLOW);
+		if (actionSmokeDoc === undefined) {
+			errors.push(`${TOOLCHAIN_ACTION_SMOKE_WORKFLOW}: missing from ${WORKFLOWS_DIR}`);
+		} else {
+			errors.push(
+				...checkToolchainPrScope(
+					toolchainDoc,
+					actionSmokeDoc,
+					TOOLCHAIN_WORKFLOW,
+					TOOLCHAIN_ACTION_SMOKE_WORKFLOW,
+				),
+			);
+		}
 	}
 	return errors;
 }

--- a/tooling/repo-checks/src/lib/workflow-nesting.ts
+++ b/tooling/repo-checks/src/lib/workflow-nesting.ts
@@ -92,8 +92,14 @@ export function matrixSuiteCaller(doc: unknown, label: string): SuiteMatrixCalle
 			throw new Error(`${label}: job "${jobId}" calls ${uses} without a string "replicates" input`);
 		}
 		// Optional by design: absent IS the matrix lane's posture (no provider is required, so a
-		// credential-less cell skips). A non-string present value is malformed YAML, so drop it to
-		// undefined and let the smoke-side check report the miss rather than throwing here.
+		// credential-less cell skips). A present non-string value is malformed YAML and must not read
+		// as absent: GitHub coerces it into a real workflow input, bypassing the matrix lane's absence
+		// assertion below.
+		if ("require_providers" in withMap && typeof withMap.require_providers !== "string") {
+			throw new Error(
+				`${label}: job "${jobId}" calls ${uses} with a non-string "require_providers" input`,
+			);
+		}
 		const requireProvidersInput =
 			typeof withMap.require_providers === "string" ? withMap.require_providers : undefined;
 		const name = typeof job.name === "string" ? job.name : "";

--- a/tooling/repo-checks/src/lib/workflow-nesting.ts
+++ b/tooling/repo-checks/src/lib/workflow-nesting.ts
@@ -1,14 +1,7 @@
 // Invariant 6: GitHub-native suite→provider nesting wiring for the two dispatch lanes
 // (bench-matrix.yml, bench-smoke.yml) + the reusable bench-suite.yml they share. Kept out of
 // workflow-sync.ts so credential/timeout gates and nesting gates don't grow as one file.
-import {
-	asRecord,
-	MATRIX_WORKFLOW,
-	RUN_STEP,
-	SUITE_JOB,
-	SUITE_WORKFLOW,
-	stepByName,
-} from "./workflow-yaml.ts";
+import { asRecord, RUN_STEP, SUITE_JOB, SUITE_WORKFLOW, stepByName } from "./workflow-yaml.ts";
 
 /** A suite-matrix job is one that `uses` this reusable workflow (matched by path suffix). */
 const SUITE_WORKFLOW_USES_SUFFIX = "/bench-suite.yml";
@@ -78,10 +71,7 @@ export const EXPECTED_REQUIRE_PROVIDERS_INPUT_EXPR = "${{ inputs.provider }}";
  * except that `publish.needs` is captured for the dependency check. Used for both bench-matrix.yml
  * and bench-smoke.yml; `label` names the lane in error messages.
  */
-export function matrixSuiteCaller(
-	doc: unknown,
-	label: string = MATRIX_WORKFLOW,
-): SuiteMatrixCaller {
+export function matrixSuiteCaller(doc: unknown, label: string): SuiteMatrixCaller {
 	const root = asRecord(doc, `${label}: not a YAML mapping`);
 	const jobs = asRecord(root.jobs, `${label}: no jobs mapping`);
 	const callers: Array<Omit<SuiteMatrixCaller, "publishNeeds">> = [];
@@ -157,7 +147,13 @@ export function matrixSuiteCaller(
 	return { ...caller, publishNeeds };
 }
 
-/** Options for {@link checkSuiteMatrixCaller}, so one check covers both dispatch lanes. */
+/**
+ * The two ways the dispatch lanes are ALLOWED to differ, declared per lane. Both fields are required
+ * on purpose: a partial object would replace a defaulted one wholesale, so `{ requireProviderAssertion:
+ * true }` would silently read as `requirePublishNeeds: undefined` and switch off an assertion the
+ * caller never meant to waive. Making every call site state both flags means the complete list of
+ * permitted differences is written out at each lane, which is the point of the invariant.
+ */
 export interface SuiteMatrixCallerOptions {
 	/**
 	 * Require a `publish` job that needs the caller. True for bench-matrix.yml, where aggregation must
@@ -165,26 +161,28 @@ export interface SuiteMatrixCallerOptions {
 	 * phase at all — that missing third phase is the entire difference between the lanes, so demanding
 	 * it there would be demanding the smoke commit a dataset.
 	 */
-	requirePublishNeeds?: boolean;
+	requirePublishNeeds: boolean;
 	/**
 	 * Require `with.require_providers` to be {@link EXPECTED_REQUIRE_PROVIDERS_INPUT_EXPR}. True for
-	 * bench-smoke.yml (a smoke must fail when its dispatched provider never ran); false for the matrix,
-	 * whose lenient default lets one unauthenticated cell skip without sinking the run.
+	 * bench-smoke.yml (a smoke must fail when its dispatched provider never ran). When false the input
+	 * must be ABSENT, not merely different: the matrix's lenient posture is a property worth pinning,
+	 * since a stray value there would fail every cell whose provider it names.
 	 */
-	requireProviderAssertion?: boolean;
+	requireProviderAssertion: boolean;
 }
 
 /**
  * Invariant 6: a dispatch lane's suite-matrix caller is wired for GitHub-native nesting and depends on
  * the plan's suite axis — display name and `with.suite` are `${{ matrix.suite }}`, `with.replicates` is
  * the plan's per-suite slice, and the matrix axis is `fromJSON(needs.plan.outputs.suites)`. The two
- * per-lane differences (a `publish` job that needs the caller; a `require_providers` assertion) are
- * opt-in via {@link SuiteMatrixCallerOptions}. `label` names the workflow in error messages.
+ * per-lane differences are declared explicitly via {@link SuiteMatrixCallerOptions}. `label` names the
+ * workflow in error messages and is required — with two lanes sharing this check, a defaulted label
+ * would misattribute the smoke lane's drift to bench-matrix.yml.
  */
 export function checkSuiteMatrixCaller(
 	caller: SuiteMatrixCaller,
-	label: string = MATRIX_WORKFLOW,
-	options: SuiteMatrixCallerOptions = { requirePublishNeeds: true },
+	label: string,
+	options: SuiteMatrixCallerOptions,
 ): string[] {
 	const errors: string[] = [];
 	if (caller.name !== EXPECTED_SUITE_NAME_EXPR) {
@@ -219,18 +217,91 @@ export function checkSuiteMatrixCaller(
 				`matrix cell (publish.needs=${JSON.stringify(caller.publishNeeds)})`,
 		);
 	}
-	if (
-		options.requireProviderAssertion &&
-		caller.requireProvidersInput !== EXPECTED_REQUIRE_PROVIDERS_INPUT_EXPR
-	) {
+	if (options.requireProviderAssertion) {
+		if (caller.requireProvidersInput !== EXPECTED_REQUIRE_PROVIDERS_INPUT_EXPR) {
+			errors.push(
+				`${label}: job "${caller.jobId}" with.require_providers must be ` +
+					`"${EXPECTED_REQUIRE_PROVIDERS_INPUT_EXPR}" so a missing or misnamed credential fails the ` +
+					`run instead of being recorded as a skip on a job that still exits 0 (got ` +
+					`${caller.requireProvidersInput === undefined ? "no such input" : `"${caller.requireProvidersInput}"`})`,
+			);
+		}
+	} else if (caller.requireProvidersInput !== undefined) {
+		// The lenient posture is a property too. A value here fails every cell whose provider it names —
+		// loudly, but across a whole matrix run's worth of provider quota before anyone reads the error.
 		errors.push(
-			`${label}: job "${caller.jobId}" with.require_providers must be ` +
-				`"${EXPECTED_REQUIRE_PROVIDERS_INPUT_EXPR}" so a missing or misnamed credential fails the ` +
-				`run instead of being recorded as a skip on a job that still exits 0 (got ` +
-				`${caller.requireProvidersInput === undefined ? "no such input" : `"${caller.requireProvidersInput}"`})`,
+			`${label}: job "${caller.jobId}" must not pass with.require_providers (got ` +
+				`"${caller.requireProvidersInput}") — this lane's posture is that a provider with no ` +
+				`credential SKIPS, so one unauthenticated cell cannot sink the run`,
 		);
 	}
 	return errors;
+}
+
+/** The bin a benchmark cell runs. A lane job whose `run:` mentions it is driving sandboxes itself,
+ *  whatever the step is called. */
+const CELL_DRIVER_BIN = "bench-suite.ts";
+
+/** The step in a lane's `plan` job that resolves the axes (the shared plan-bench-axes action). */
+export const PLAN_STEP = "Plan";
+/** The expression bench-smoke's plan step must pass as `with.replicas`.
+ *
+ *  A smoke is one sandbox, and `default: '1'` alone does NOT guarantee that: a dispatch `default:`
+ *  applies only when the field is ABSENT, while both the Actions UI (clear the box) and an API
+ *  dispatch can send an empty string. Blank reaches plan-replicates as an unset BENCH_REPLICAS, which
+ *  means "each suite's Suite.defaultReplicas" — R=12 on every realworld suite. So the fallback is what
+ *  actually holds the property, and it is pinned here rather than left to a comment: losing it turns a
+ *  cleared text field into twelve real sandboxes with no error anywhere. */
+export const EXPECTED_SMOKE_REPLICAS_INPUT_EXPR =
+	// biome-ignore lint/suspicious/noTemplateCurlyInString: a GHA expression literal matched verbatim against the workflow, not a JS template.
+	"${{ inputs.replicas || '1' }}";
+
+/**
+ * Invariant 7: a smoke dispatch measures ONE sandbox unless an operator explicitly asks for more —
+ * both halves of it, the dispatch `default:` and the blank-value fallback (see
+ * {@link EXPECTED_SMOKE_REPLICAS_INPUT_EXPR} for why the default alone is not enough).
+ */
+export function checkSmokeSingleSandboxDefault(doc: unknown, label: string): string[] {
+	const root = asRecord(doc, `${label}: not a YAML mapping`);
+	const jobs = asRecord(root.jobs, `${label}: no jobs mapping`);
+	const plan = jobs.plan;
+	if (plan === undefined) {
+		return [`${label}: job "plan" is missing — the smoke lane resolves its axes there`];
+	}
+	const step = stepByName(
+		asRecord(plan, `${label}: job "plan" is not a mapping`),
+		PLAN_STEP,
+		label,
+	);
+	if (step === undefined) {
+		return [`${label}: job "plan" has no step named "${PLAN_STEP}"`];
+	}
+	const withMap = asRecord(step.with ?? {}, `${label}: step "${PLAN_STEP}" with is not a mapping`);
+	const replicas = withMap.replicas;
+	if (replicas === EXPECTED_SMOKE_REPLICAS_INPUT_EXPR) return [];
+	return [
+		`${label}: job "plan" step "${PLAN_STEP}" must pass replicas: ` +
+			`"${EXPECTED_SMOKE_REPLICAS_INPUT_EXPR}" so a CLEARED replicas field still means one sandbox ` +
+			`(blank falls through to each suite's Suite.defaultReplicas — R=12 on every realworld suite — ` +
+			`with no error raised anywhere) (got ` +
+			`${replicas === undefined ? "no replicas input" : `"${String(replicas)}"`})`,
+	];
+}
+
+/** Every `env:` key a job could carry, step-level or job-level, as one flat list. Job-level `env` is
+ *  included deliberately: it is inherited by every step, so hanging provider credentials there is a way
+ *  to build a cell that no per-step scan would ever see. */
+function jobEnvKeys(job: Record<string, unknown>, label: string): string[] {
+	const keys: string[] = [];
+	const collect = (value: unknown): void => {
+		if (value === undefined || value === null) return;
+		keys.push(...Object.keys(asRecord(value, `${label}: env is not a mapping`)));
+	};
+	collect(job.env);
+	if (Array.isArray(job.steps)) {
+		for (const rawStep of job.steps) collect(asRecord(rawStep, `${label}: malformed step`).env);
+	}
+	return keys;
 }
 
 /**
@@ -242,25 +313,53 @@ export function checkSuiteMatrixCaller(
  * honest took a cross-lane credential gate (Invariant 4) and still let everything the gate did not
  * compare — the runner routing, the cell budget, the shard-gated upload, the replicate fan-out — drift
  * silently, so a smoke run could pass while exercising a different pipeline than the one it was meant
- * to rehearse. Now both lanes call the reusable, and the way to re-enter that failure mode is to add
- * the {@link RUN_STEP} step back into a lane. Reject it here: a lane's jobs may plan, publish and
- * orchestrate, but the step that drives a provider SDK exists once, in {@link SUITE_WORKFLOW}.
+ * to rehearse. Now both lanes call the reusable, and this rejects the ways back in.
+ *
+ * THREE probes, because one is not enough. Matching {@link RUN_STEP} by name alone catches the literal
+ * copy-paste and nothing else: a re-grown cell under a fresh step name, or provider credentials hung
+ * off a job-level `env:`, would both sail through — and those are the shapes someone re-adding a cell
+ * by hand actually writes. So also reject a `run:` that invokes the cell driver, and any provider
+ * credential appearing anywhere in a lane's env at all. `credentialKeys` is passed in (rather than
+ * imported) to keep this module free of the schema dependency; runCheck hands it the registry's
+ * requiredEnvVars, so the probe widens automatically when a provider is added.
  */
-export function checkLaneDelegates(doc: unknown, label: string): string[] {
+export function checkLaneDelegates(
+	doc: unknown,
+	label: string,
+	credentialKeys: Iterable<string>,
+): string[] {
 	const root = asRecord(doc, `${label}: not a YAML mapping`);
 	const jobs = asRecord(root.jobs, `${label}: no jobs mapping`);
-	const offenders: string[] = [];
+	const credentials = new Set(credentialKeys);
+	const errors: string[] = [];
+	const cell =
+		`the benchmark cell (credentials, runner routing, cell budget, replicate fan-out, artifact ` +
+		`upload) must live only in ${SUITE_WORKFLOW}, which both dispatch lanes call; a second copy is ` +
+		`exactly the drift this consolidation removed`;
 	for (const [jobId, rawJob] of Object.entries(jobs)) {
 		const job = asRecord(rawJob, `${label}: job "${jobId}" is not a mapping`);
-		if (stepByName(job, RUN_STEP, label) !== undefined) offenders.push(jobId);
+		if (stepByName(job, RUN_STEP, label) !== undefined) {
+			errors.push(`${label}: job "${jobId}" declares a "${RUN_STEP}" step — ${cell}`);
+		}
+		const steps = Array.isArray(job.steps) ? job.steps : [];
+		for (const rawStep of steps) {
+			const step = asRecord(rawStep, `${label}: malformed step`);
+			if (typeof step.run === "string" && step.run.includes(CELL_DRIVER_BIN)) {
+				errors.push(
+					`${label}: job "${jobId}" has a step whose run: invokes ${CELL_DRIVER_BIN} — ${cell}`,
+				);
+			}
+		}
+		const leaked = [...new Set(jobEnvKeys(job, label))].filter((k) => credentials.has(k)).sort();
+		if (leaked.length > 0) {
+			errors.push(
+				`${label}: job "${jobId}" puts provider credential(s) ${leaked.join(", ")} in its env — ` +
+					`${cell}. A lane never needs a provider secret: it passes none down, and the cell resolves ` +
+					`its own from Environment "privileged"`,
+			);
+		}
 	}
-	if (offenders.length === 0) return [];
-	return [
-		`${label}: job(s) ${offenders.join(", ")} declare a "${RUN_STEP}" step — the benchmark cell ` +
-			`(credentials, runner routing, cell budget, replicate fan-out, artifact upload) must live only ` +
-			`in ${SUITE_WORKFLOW}, which both dispatch lanes call; a second copy is exactly the drift this ` +
-			`consolidation removed`,
-	];
+	return errors;
 }
 
 /**

--- a/tooling/repo-checks/src/lib/workflow-nesting.ts
+++ b/tooling/repo-checks/src/lib/workflow-nesting.ts
@@ -1,5 +1,6 @@
-// Invariant 6: GitHub-native suite→provider nesting wiring for bench-matrix.yml + bench-suite.yml.
-// Kept out of workflow-sync.ts so credential/timeout gates and nesting gates don't grow as one file.
+// Invariant 6: GitHub-native suite→provider nesting wiring for the two dispatch lanes
+// (bench-matrix.yml, bench-smoke.yml) + the reusable bench-suite.yml they share. Kept out of
+// workflow-sync.ts so credential/timeout gates and nesting gates don't grow as one file.
 import {
 	asRecord,
 	MATRIX_WORKFLOW,
@@ -9,13 +10,15 @@ import {
 	stepByName,
 } from "./workflow-yaml.ts";
 
-/** A bench-matrix suite job is one that `uses` this reusable workflow (matched by path suffix). */
+/** A suite-matrix job is one that `uses` this reusable workflow (matched by path suffix). */
 const SUITE_WORKFLOW_USES_SUFFIX = "/bench-suite.yml";
 
 /**
- * The single bench-matrix suite-matrix caller: the job that `uses` the reusable bench-suite.yml and
- * expands `strategy.matrix.suite` from the plan's suite axis. Native nesting depends on
- * `name` / `with.suite` both resolving to `matrix.suite`.
+ * The single suite-matrix caller of a dispatch lane: the job that `uses` the reusable bench-suite.yml
+ * and expands `strategy.matrix.suite` from the plan's suite axis. Native nesting depends on
+ * `name` / `with.suite` both resolving to `matrix.suite`. Both lanes have exactly one — bench-matrix
+ * over every planned suite, bench-smoke over the single dispatched one — and they are held to the same
+ * wiring so the smoke lane cannot quietly become a different pipeline.
  */
 export interface SuiteMatrixCaller {
 	jobId: string;
@@ -23,6 +26,9 @@ export interface SuiteMatrixCaller {
 	suiteInput: string;
 	/** The `with.replicates` expression — this suite's slice of the plan's per-suite map. */
 	replicatesInput: string;
+	/** The `with.require_providers` expression, or undefined when the caller omits it (the matrix
+	 *  lane's graceful default: a provider with no credential skips rather than sinking the run). */
+	requireProvidersInput?: string;
 	matrixSuiteExpr: string;
 	/** Job ids listed in `publish.needs` (empty when publish is missing or has no needs list). */
 	publishNeeds: string[];
@@ -56,12 +62,21 @@ export const EXPECTED_REPLICATES_ARG = `--replicates "$${REPLICATES_ENV_KEY}"`;
 export const EXPECTED_REPLICATES_INPUT_EXPR =
 	// biome-ignore lint/suspicious/noTemplateCurlyInString: a GHA expression literal matched verbatim against the workflow, not a JS template.
 	"${{ toJSON(fromJSON(needs.plan.outputs.replicates)[matrix.suite]) }}";
+/** The expression bench-smoke's caller must hand down as `with.require_providers`: the dispatched
+ *  provider. Pinned because the whole point of a smoke run is to prove ONE lane end to end — without
+ *  it a missing or misnamed credential is recorded as a skip and the job still exits 0 having
+ *  benchmarked nothing, which is a green run that hides the provider never being smoked. Everything
+ *  else about the two lanes is now literally the same file, so this is the one behavioural difference
+ *  a gate still has to hold in place. */
+// biome-ignore lint/suspicious/noTemplateCurlyInString: a GHA expression literal matched verbatim against the workflow, not a JS template.
+export const EXPECTED_REQUIRE_PROVIDERS_INPUT_EXPR = "${{ inputs.provider }}";
 
 /**
- * The bench-matrix suite-matrix caller — exactly one job whose `uses` targets the reusable
+ * A dispatch lane's suite-matrix caller — exactly one job whose `uses` targets the reusable
  * bench-suite.yml, with its nesting wiring extracted. Zero or multiple callers throw (Invariant 6
  * must fail loudly, not pick one). Jobs that don't call the reusable (plan, publish) are ignored
- * except that `publish.needs` is captured for the dependency check.
+ * except that `publish.needs` is captured for the dependency check. Used for both bench-matrix.yml
+ * and bench-smoke.yml; `label` names the lane in error messages.
  */
 export function matrixSuiteCaller(
 	doc: unknown,
@@ -86,6 +101,11 @@ export function matrixSuiteCaller(
 		if (typeof replicatesInput !== "string") {
 			throw new Error(`${label}: job "${jobId}" calls ${uses} without a string "replicates" input`);
 		}
+		// Optional by design: absent IS the matrix lane's posture (no provider is required, so a
+		// credential-less cell skips). A non-string present value is malformed YAML, so drop it to
+		// undefined and let the smoke-side check report the miss rather than throwing here.
+		const requireProvidersInput =
+			typeof withMap.require_providers === "string" ? withMap.require_providers : undefined;
 		const name = typeof job.name === "string" ? job.name : "";
 		const strategy = asRecord(
 			job.strategy,
@@ -101,7 +121,14 @@ export function matrixSuiteCaller(
 				`${label}: job "${jobId}" calls ${uses} without a string "strategy.matrix.suite" axis`,
 			);
 		}
-		callers.push({ jobId, name, suiteInput, replicatesInput, matrixSuiteExpr });
+		callers.push({
+			jobId,
+			name,
+			suiteInput,
+			replicatesInput,
+			...(requireProvidersInput !== undefined ? { requireProvidersInput } : {}),
+			matrixSuiteExpr,
+		});
 	}
 	if (callers.length === 0) {
 		throw new Error(
@@ -130,15 +157,34 @@ export function matrixSuiteCaller(
 	return { ...caller, publishNeeds };
 }
 
+/** Options for {@link checkSuiteMatrixCaller}, so one check covers both dispatch lanes. */
+export interface SuiteMatrixCallerOptions {
+	/**
+	 * Require a `publish` job that needs the caller. True for bench-matrix.yml, where aggregation must
+	 * wait for every suite matrix cell. FALSE for bench-smoke.yml, which deliberately has no publish
+	 * phase at all — that missing third phase is the entire difference between the lanes, so demanding
+	 * it there would be demanding the smoke commit a dataset.
+	 */
+	requirePublishNeeds?: boolean;
+	/**
+	 * Require `with.require_providers` to be {@link EXPECTED_REQUIRE_PROVIDERS_INPUT_EXPR}. True for
+	 * bench-smoke.yml (a smoke must fail when its dispatched provider never ran); false for the matrix,
+	 * whose lenient default lets one unauthenticated cell skip without sinking the run.
+	 */
+	requireProviderAssertion?: boolean;
+}
+
 /**
- * Invariant 6: the bench-matrix suite-matrix caller is wired for GitHub-native nesting and depends on
- * the plan's suite axis — display name and `with.suite` are `${{ matrix.suite }}`, the matrix axis is
- * `fromJSON(needs.plan.outputs.suites)`, and `publish` needs the caller job. `label` names the
- * workflow in error messages.
+ * Invariant 6: a dispatch lane's suite-matrix caller is wired for GitHub-native nesting and depends on
+ * the plan's suite axis — display name and `with.suite` are `${{ matrix.suite }}`, `with.replicates` is
+ * the plan's per-suite slice, and the matrix axis is `fromJSON(needs.plan.outputs.suites)`. The two
+ * per-lane differences (a `publish` job that needs the caller; a `require_providers` assertion) are
+ * opt-in via {@link SuiteMatrixCallerOptions}. `label` names the workflow in error messages.
  */
 export function checkSuiteMatrixCaller(
 	caller: SuiteMatrixCaller,
 	label: string = MATRIX_WORKFLOW,
+	options: SuiteMatrixCallerOptions = { requirePublishNeeds: true },
 ): string[] {
 	const errors: string[] = [];
 	if (caller.name !== EXPECTED_SUITE_NAME_EXPR) {
@@ -167,13 +213,54 @@ export function checkSuiteMatrixCaller(
 				`so the suite axis stays registry-driven via plan.outputs.suites (got "${caller.matrixSuiteExpr}")`,
 		);
 	}
-	if (!caller.publishNeeds.includes(caller.jobId)) {
+	if (options.requirePublishNeeds && !caller.publishNeeds.includes(caller.jobId)) {
 		errors.push(
 			`${label}: job "publish" must need "${caller.jobId}" so aggregation waits for every suite ` +
 				`matrix cell (publish.needs=${JSON.stringify(caller.publishNeeds)})`,
 		);
 	}
+	if (
+		options.requireProviderAssertion &&
+		caller.requireProvidersInput !== EXPECTED_REQUIRE_PROVIDERS_INPUT_EXPR
+	) {
+		errors.push(
+			`${label}: job "${caller.jobId}" with.require_providers must be ` +
+				`"${EXPECTED_REQUIRE_PROVIDERS_INPUT_EXPR}" so a missing or misnamed credential fails the ` +
+				`run instead of being recorded as a skip on a job that still exits 0 (got ` +
+				`${caller.requireProvidersInput === undefined ? "no such input" : `"${caller.requireProvidersInput}"`})`,
+		);
+	}
 	return errors;
+}
+
+/**
+ * Invariant 3b (the consolidation invariant): a dispatch lane owns no benchmark cell of its own — it
+ * reaches sandboxes only through the reusable bench-suite.yml.
+ *
+ * bench-smoke.yml used to carry a hand-mirrored copy of the cell: its own checkout, its own Namespace
+ * mint, its own per-provider credential block, its own timeout and its own upload. Keeping that copy
+ * honest took a cross-lane credential gate (Invariant 4) and still let everything the gate did not
+ * compare — the runner routing, the cell budget, the shard-gated upload, the replicate fan-out — drift
+ * silently, so a smoke run could pass while exercising a different pipeline than the one it was meant
+ * to rehearse. Now both lanes call the reusable, and the way to re-enter that failure mode is to add
+ * the {@link RUN_STEP} step back into a lane. Reject it here: a lane's jobs may plan, publish and
+ * orchestrate, but the step that drives a provider SDK exists once, in {@link SUITE_WORKFLOW}.
+ */
+export function checkLaneDelegates(doc: unknown, label: string): string[] {
+	const root = asRecord(doc, `${label}: not a YAML mapping`);
+	const jobs = asRecord(root.jobs, `${label}: no jobs mapping`);
+	const offenders: string[] = [];
+	for (const [jobId, rawJob] of Object.entries(jobs)) {
+		const job = asRecord(rawJob, `${label}: job "${jobId}" is not a mapping`);
+		if (stepByName(job, RUN_STEP, label) !== undefined) offenders.push(jobId);
+	}
+	if (offenders.length === 0) return [];
+	return [
+		`${label}: job(s) ${offenders.join(", ")} declare a "${RUN_STEP}" step — the benchmark cell ` +
+			`(credentials, runner routing, cell budget, replicate fan-out, artifact upload) must live only ` +
+			`in ${SUITE_WORKFLOW}, which both dispatch lanes call; a second copy is exactly the drift this ` +
+			`consolidation removed`,
+	];
 }
 
 /**

--- a/tooling/repo-checks/src/lib/workflow-sync.ts
+++ b/tooling/repo-checks/src/lib/workflow-sync.ts
@@ -4,35 +4,40 @@
 // the truth from PROVIDERS + SUITE_NAMES (packages/schema) and compares. It mirrors
 // runner-benchmarking's check-workflow-{env,suite}-sync.ts, adapted to this repo's workflows.
 //
-// Two workflows dispatch live benchmarks: bench-smoke.yml (one dispatched suite × provider) and
-// bench-matrix.yml (one suite-matrix job that calls the reusable bench-suite.yml once per suite, which
-// then fans out over the selected providers). The credential block + the run job's timeout therefore
-// live in bench-suite.yml for the matrix lane, so the "matrix side" of the credential/timeout checks
-// reads that reusable workflow, not bench-matrix.yml itself.
+// Two workflows dispatch live benchmarks — bench-matrix.yml (the full provider × suite matrix, ending
+// in a dataset commit) and bench-smoke.yml (the same pipeline narrowed to one dispatched provider ×
+// suite and stopped before that commit) — and they are now the SAME implementation: each is a `plan`
+// job over ./.github/actions/plan-bench-axes plus one suite-matrix job calling the reusable
+// bench-suite.yml. The credential block, the run-step env and the live-run timeout therefore exist
+// exactly once, in that reusable, which is what the credential/timeout checks read.
 //
 // Invariants (each maps to a real "added X, forgot the workflow" failure mode):
 //   1. bench-smoke.yml's `provider` dispatch input options == the PROVIDERS id set, and its default
 //      is one of them — a new provider must be dispatchable, a removed one must not linger.
 //   2. bench-smoke.yml's `suite` dispatch input options == SUITE_NAMES, with a valid default.
 //   3. Every provider's requiredEnvVars (schema) is present in the "Run suite and normalize" step env
-//      of BOTH bench-smoke.yml and the reusable bench-suite.yml — the secret a new provider needs must
-//      be wired into both the smoke lane and the matrix fan-out, or the live run silently skips it.
-//   4. A credential key shared across the two lanes maps to the same value expression — both must hand
-//      the suite the same secret, not plan one and run the other. Each lane scopes its secrets to the
-//      selected provider (so a cell only sees its own credential), and the two lanes pick that provider
-//      differently — `inputs.provider` in smoke, `matrix.provider` in the fan-out — so the comparison
-//      folds those two selector tokens together before checking.
-//   5. Both live-run jobs (smoke's job and the reusable fan-out) outlast the longest registered sandbox
-//      lifetime by a fixed margin, so a suite budget increase cannot leave an otherwise healthy job to
-//      be killed by Actions first.
-//   6. Nesting wiring (suite-matrix caller + reusable provider job name) and the replicate axis
-//      reaching the cell as BENCH_REPLICATES data rather than as a matrix axis — see workflow-nesting.ts.
+//      of the reusable bench-suite.yml — the secret a new provider needs must be wired into the one
+//      cell implementation, or every live run silently skips that provider.
+//  3b. NEITHER dispatch lane declares a "Run suite and normalize" step of its own: the cell is the
+//      reusable's, not a copy (see checkLaneDelegates — this is the invariant that replaces the old
+//      cross-lane credential comparison, by removing the second lane's copy rather than diffing it).
+//   4. checkCredentialEnv still compares a key's value expression ACROSS whatever workflows it is
+//      handed, folding each lane's provider selector. With one lane left it degenerates to a presence
+//      check; it stays cross-workflow so a future third caller is compared, not assumed.
+//   5. The live-run job (the reusable's fan-out) outlasts the longest registered sandbox lifetime by a
+//      fixed margin, so a suite budget increase cannot leave an otherwise healthy job to be killed by
+//      Actions first; and the budget literal it advertises equals that timeout.
+//   6. Nesting wiring for BOTH lanes' suite-matrix callers (they are held to one shape, with the two
+//      deliberate per-lane differences — the matrix's publish dependency, the smoke's
+//      require_providers assertion — declared explicitly) plus the reusable's provider job name and
+//      the replicate axis reaching the cell as BENCH_REPLICATES data — see workflow-nesting.ts.
 //
 // YAML navigation lives in workflow-yaml.ts; nesting checks in workflow-nesting.ts. This file owns
 // credential/timeout invariants plus runCheck orchestration, and re-exports the public surface the
 // gate's tests import.
 import { PROVIDERS, SUITE_NAMES, SUITES } from "@sandbox-benchmarks/schema";
 import {
+	checkLaneDelegates,
 	checkSuiteMatrixCaller,
 	checkSuiteWorkflowNesting,
 	matrixSuiteCaller,
@@ -44,7 +49,6 @@ import {
 	MATRIX_WORKFLOW,
 	RUN_STEP,
 	readWorkflow,
-	SMOKE_JOB,
 	SMOKE_WORKFLOW,
 	SUITE_JOB,
 	SUITE_WORKFLOW,
@@ -53,14 +57,16 @@ import {
 } from "./workflow-yaml.ts";
 import { findRepoRoot } from "./workspace.ts";
 
-export type { SuiteMatrixCaller } from "./workflow-nesting.ts";
+export type { SuiteMatrixCaller, SuiteMatrixCallerOptions } from "./workflow-nesting.ts";
 export {
+	checkLaneDelegates,
 	checkSuiteMatrixCaller,
 	checkSuiteWorkflowNesting,
 	EXPECTED_PROVIDER_NAME_EXPR,
 	EXPECTED_REPLICATES_ARG,
 	EXPECTED_REPLICATES_ENV_EXPR,
 	EXPECTED_REPLICATES_INPUT_EXPR,
+	EXPECTED_REQUIRE_PROVIDERS_INPUT_EXPR,
 	EXPECTED_SUITE_MATRIX_EXPR,
 	EXPECTED_SUITE_NAME_EXPR,
 	matrixSuiteCaller,
@@ -73,7 +79,6 @@ export {
 	MATRIX_WORKFLOW,
 	RUN_STEP,
 	readWorkflow,
-	SMOKE_JOB,
 	SMOKE_WORKFLOW,
 	SUITE_JOB,
 	SUITE_WORKFLOW,
@@ -174,12 +179,13 @@ export function checkSuiteInput(input: DispatchInput, label: string = SMOKE_WORK
 }
 
 /**
- * Fold a credential value expression to its lane-independent form for cross-lane comparison. Each
- * lane scopes a secret to the selected provider so a cell receives only its own credential, but the
- * two lanes name that selector differently — `inputs.provider` (the smoke dispatch input) vs
- * `matrix.provider` (the matrix cell) — so both selector tokens collapse to one placeholder. A
- * genuine drift (a secret guarded on a different provider id, or a different secret entirely)
- * survives the fold and still fails Invariant 4.
+ * Fold a credential value expression to its lane-independent form for cross-workflow comparison. A
+ * lane scopes a secret to the selected provider so a cell receives only its own credential, and a
+ * caller may name that selector either way — `inputs.provider` (a dispatch input) or `matrix.provider`
+ * (a matrix cell) — so both selector tokens collapse to one placeholder. A genuine drift (a secret
+ * guarded on a different provider id, or a different secret entirely) survives the fold and still
+ * fails Invariant 4. Only the reusable declares the block today; the fold is kept so that if a second
+ * workflow ever declares one, the two are compared rather than assumed equal.
  */
 function canonicalCredentialExpr(value: string): string {
 	return value.replace(/\b(?:inputs|matrix)\.provider\b/g, "<provider>");
@@ -281,8 +287,9 @@ export function checkCellBudgetEnv(
 export function runCheck(root: string = findRepoRoot()): string[] {
 	const smoke = readWorkflow(SMOKE_WORKFLOW, root);
 	const matrix = readWorkflow(MATRIX_WORKFLOW, root);
-	// The matrix lane's credential block + run-job timeout live in the reusable bench-suite.yml that
-	// every suite job calls, so the "matrix side" of Invariants 3–5 reads that file.
+	// Both lanes' credential block + live-run timeout live in the one reusable bench-suite.yml they
+	// call, so Invariants 3–5 read that file — and Invariant 3b (checkLaneDelegates) is what keeps that
+	// true by rejecting a lane that grows a cell of its own again.
 	const suiteWf = readWorkflow(SUITE_WORKFLOW, root);
 	// Read once and share: the suite run step's env feeds both the credential gate and the cell-budget
 	// gate, and its job timeout feeds both the margin gate and that same budget gate.
@@ -291,16 +298,20 @@ export function runCheck(root: string = findRepoRoot()): string[] {
 	return [
 		...checkProviderInput(dispatchInput(smoke, "provider", SMOKE_WORKFLOW)),
 		...checkSuiteInput(dispatchInput(smoke, "suite", SMOKE_WORKFLOW)),
-		...checkCredentialEnv({
-			[SMOKE_WORKFLOW]: stepEnv(smoke, SMOKE_JOB, RUN_STEP, SMOKE_WORKFLOW),
-			[SUITE_WORKFLOW]: suiteEnv,
-		}),
-		...checkWorkflowTimeouts({
-			[SMOKE_WORKFLOW]: jobTimeoutMinutes(smoke, SMOKE_JOB, SMOKE_WORKFLOW),
-			[SUITE_WORKFLOW]: suiteTimeout,
-		}),
+		...checkCredentialEnv({ [SUITE_WORKFLOW]: suiteEnv }),
+		...checkLaneDelegates(smoke, SMOKE_WORKFLOW),
+		...checkLaneDelegates(matrix, MATRIX_WORKFLOW),
+		...checkWorkflowTimeouts({ [SUITE_WORKFLOW]: suiteTimeout }),
 		...checkCellBudgetEnv(suiteEnv, suiteTimeout, SUITE_WORKFLOW),
-		...checkSuiteMatrixCaller(matrixSuiteCaller(matrix, MATRIX_WORKFLOW), MATRIX_WORKFLOW),
+		// Both lanes are held to one caller shape. The matrix additionally owns the publish dependency;
+		// the smoke additionally asserts its dispatched provider actually ran. Those two flags are the
+		// complete, declared list of ways the lanes are allowed to differ.
+		...checkSuiteMatrixCaller(matrixSuiteCaller(matrix, MATRIX_WORKFLOW), MATRIX_WORKFLOW, {
+			requirePublishNeeds: true,
+		}),
+		...checkSuiteMatrixCaller(matrixSuiteCaller(smoke, SMOKE_WORKFLOW), SMOKE_WORKFLOW, {
+			requireProviderAssertion: true,
+		}),
 		...checkSuiteWorkflowNesting(suiteWf, SUITE_WORKFLOW),
 	];
 }

--- a/tooling/repo-checks/src/lib/workflow-sync.ts
+++ b/tooling/repo-checks/src/lib/workflow-sync.ts
@@ -18,9 +18,12 @@
 //   3. Every provider's requiredEnvVars (schema) is present in the "Run suite and normalize" step env
 //      of the reusable bench-suite.yml — the secret a new provider needs must be wired into the one
 //      cell implementation, or every live run silently skips that provider.
-//  3b. NEITHER dispatch lane declares a "Run suite and normalize" step of its own: the cell is the
-//      reusable's, not a copy (see checkLaneDelegates — this is the invariant that replaces the old
-//      cross-lane credential comparison, by removing the second lane's copy rather than diffing it).
+//  3b. NEITHER dispatch lane owns a benchmark cell: no "Run suite and normalize" step, no `run:` that
+//      invokes the cell driver, and no provider credential in any job- or step-level env (see
+//      checkLaneDelegates). This is the invariant that replaces the old cross-lane credential
+//      comparison — by removing the second lane's copy rather than diffing it. All three probes are
+//      needed: a name match alone misses a cell re-grown under a fresh step name, and a step-level
+//      scan alone misses credentials hung off a job-level env that every step inherits.
 //   4. checkCredentialEnv still compares a key's value expression ACROSS whatever workflows it is
 //      handed, folding each lane's provider selector. With one lane left it degenerates to a presence
 //      check; it stays cross-workflow so a future third caller is compared, not assumed.
@@ -29,8 +32,11 @@
 //      Actions first; and the budget literal it advertises equals that timeout.
 //   6. Nesting wiring for BOTH lanes' suite-matrix callers (they are held to one shape, with the two
 //      deliberate per-lane differences — the matrix's publish dependency, the smoke's
-//      require_providers assertion — declared explicitly) plus the reusable's provider job name and
-//      the replicate axis reaching the cell as BENCH_REPLICATES data — see workflow-nesting.ts.
+//      require_providers assertion — stated explicitly at each lane, in both directions) plus the
+//      reusable's provider job name and the replicate axis reaching the cell as BENCH_REPLICATES data.
+//   7. A smoke dispatch measures ONE sandbox unless asked otherwise — the dispatch default AND the
+//      blank-value fallback, since `default:` alone does not survive a cleared field and blank means
+//      "each suite's Suite.defaultReplicas" (R=12 on realworld). See workflow-nesting.ts.
 //
 // YAML navigation lives in workflow-yaml.ts; nesting checks in workflow-nesting.ts. This file owns
 // credential/timeout invariants plus runCheck orchestration, and re-exports the public surface the
@@ -38,6 +44,7 @@
 import { PROVIDERS, SUITE_NAMES, SUITES } from "@sandbox-benchmarks/schema";
 import {
 	checkLaneDelegates,
+	checkSmokeSingleSandboxDefault,
 	checkSuiteMatrixCaller,
 	checkSuiteWorkflowNesting,
 	matrixSuiteCaller,
@@ -60,6 +67,7 @@ import { findRepoRoot } from "./workspace.ts";
 export type { SuiteMatrixCaller, SuiteMatrixCallerOptions } from "./workflow-nesting.ts";
 export {
 	checkLaneDelegates,
+	checkSmokeSingleSandboxDefault,
 	checkSuiteMatrixCaller,
 	checkSuiteWorkflowNesting,
 	EXPECTED_PROVIDER_NAME_EXPR,
@@ -67,9 +75,11 @@ export {
 	EXPECTED_REPLICATES_ENV_EXPR,
 	EXPECTED_REPLICATES_INPUT_EXPR,
 	EXPECTED_REQUIRE_PROVIDERS_INPUT_EXPR,
+	EXPECTED_SMOKE_REPLICAS_INPUT_EXPR,
 	EXPECTED_SUITE_MATRIX_EXPR,
 	EXPECTED_SUITE_NAME_EXPR,
 	matrixSuiteCaller,
+	PLAN_STEP,
 	REPLICATES_ENV_KEY,
 } from "./workflow-nesting.ts";
 export type { DispatchInput } from "./workflow-yaml.ts";
@@ -295,23 +305,30 @@ export function runCheck(root: string = findRepoRoot()): string[] {
 	// gate, and its job timeout feeds both the margin gate and that same budget gate.
 	const suiteEnv = stepEnv(suiteWf, SUITE_JOB, RUN_STEP, SUITE_WORKFLOW);
 	const suiteTimeout = jobTimeoutMinutes(suiteWf, SUITE_JOB, SUITE_WORKFLOW);
+	const credentialKeys = [...requiredCredentialKeys().keys()];
 	return [
 		...checkProviderInput(dispatchInput(smoke, "provider", SMOKE_WORKFLOW)),
 		...checkSuiteInput(dispatchInput(smoke, "suite", SMOKE_WORKFLOW)),
 		...checkCredentialEnv({ [SUITE_WORKFLOW]: suiteEnv }),
-		...checkLaneDelegates(smoke, SMOKE_WORKFLOW),
-		...checkLaneDelegates(matrix, MATRIX_WORKFLOW),
+		// The credential keys are what make Invariant 3b more than a step-name match: a lane that hangs
+		// any of them off a job- or step-level env is building a cell, whatever it calls the step.
+		...checkLaneDelegates(smoke, SMOKE_WORKFLOW, credentialKeys),
+		...checkLaneDelegates(matrix, MATRIX_WORKFLOW, credentialKeys),
 		...checkWorkflowTimeouts({ [SUITE_WORKFLOW]: suiteTimeout }),
 		...checkCellBudgetEnv(suiteEnv, suiteTimeout, SUITE_WORKFLOW),
-		// Both lanes are held to one caller shape. The matrix additionally owns the publish dependency;
-		// the smoke additionally asserts its dispatched provider actually ran. Those two flags are the
-		// complete, declared list of ways the lanes are allowed to differ.
+		// Both lanes are held to one caller shape, and each states BOTH flags: the matrix owns the
+		// publish dependency and must not require a provider; the smoke is the mirror image. Spelling
+		// out both at each lane is what makes this the complete, declared list of permitted differences
+		// rather than a default someone can drift past.
 		...checkSuiteMatrixCaller(matrixSuiteCaller(matrix, MATRIX_WORKFLOW), MATRIX_WORKFLOW, {
 			requirePublishNeeds: true,
+			requireProviderAssertion: false,
 		}),
 		...checkSuiteMatrixCaller(matrixSuiteCaller(smoke, SMOKE_WORKFLOW), SMOKE_WORKFLOW, {
+			requirePublishNeeds: false,
 			requireProviderAssertion: true,
 		}),
+		...checkSmokeSingleSandboxDefault(smoke, SMOKE_WORKFLOW),
 		...checkSuiteWorkflowNesting(suiteWf, SUITE_WORKFLOW),
 	];
 }

--- a/tooling/repo-checks/src/lib/workflow-yaml.ts
+++ b/tooling/repo-checks/src/lib/workflow-yaml.ts
@@ -9,11 +9,11 @@ import { findRepoRoot } from "./workspace.ts";
 
 export const SMOKE_WORKFLOW = ".github/workflows/bench-smoke.yml";
 export const MATRIX_WORKFLOW = ".github/workflows/bench-matrix.yml";
-/** The reusable workflow each bench-matrix suite job calls; it owns the credential block + run timeout. */
+/** The reusable workflow BOTH dispatch lanes call; it owns the credential block + run timeout. */
 export const SUITE_WORKFLOW = ".github/workflows/bench-suite.yml";
-/** The step (in bench-smoke.yml and bench-suite.yml) that drives the provider SDK; it owns the env. */
+/** The step that drives the provider SDK; it owns the credential env. It exists exactly once, in the
+ *  reusable bench-suite.yml — a copy in either dispatch lane is the drift Invariant 3b rejects. */
 export const RUN_STEP = "Run suite and normalize";
-export const SMOKE_JOB = "smoke";
 /** The fan-out job inside the reusable bench-suite.yml (its credential env + timeout). */
 export const SUITE_JOB = "bench";
 /** Host-side checkout/teardown/normalization/upload allowance beyond the sandbox lifetime. Re-exported

--- a/tooling/repo-checks/src/workflow-hardening.test.ts
+++ b/tooling/repo-checks/src/workflow-hardening.test.ts
@@ -1,10 +1,11 @@
 // Invariant: the GitHub Actions layer stays hardened. (1) every actions/checkout opts out of
 // credential persistence unless it is an allowlisted pushing checkout, (2) ci-lint.yml runs
 // actionlint + zizmor at the agreed gate threshold, (3) custom-secret / write jobs declare
-// environment: privileged, and (4) toolchain publish is workflow_dispatch-only. The
-// runHardeningCheck() test against the real .github files IS the gate's CI enforcement point
-// (same precedent as workflow-registry-sync.test.ts); the rest is unit coverage of the pure checks
-// on synthetic drift so a regression names the offender. See ./lib/workflow-hardening.ts.
+// environment: privileged, (4) toolchain publish is workflow_dispatch-only, and (5) toolchain PR
+// smoke keeps expensive image inputs separate from lightweight setup-action coverage. The
+// runHardeningCheck() test against the real .github files IS the gate's CI enforcement point (same
+// precedent as workflow-registry-sync.test.ts); the rest is unit coverage of the pure checks on
+// synthetic drift so a regression names the offender. See ./lib/workflow-hardening.ts.
 import { describe, expect, test } from "bun:test";
 import { readFileSync } from "node:fs";
 import { join } from "node:path";
@@ -17,11 +18,15 @@ import {
 	checkPersistCredentials,
 	checkPrivilegedEnvironment,
 	checkToolchainDispatchOnly,
+	checkToolchainPrScope,
 	customSecretsIn,
 	listWorkflowFiles,
 	PRIVILEGED_ENVIRONMENT,
 	readWorkflow,
 	runHardeningCheck,
+	TOOLCHAIN_ACTION_SMOKE_PR_PATHS,
+	TOOLCHAIN_ACTION_SMOKE_WORKFLOW,
+	TOOLCHAIN_IMAGE_PR_PATHS,
 	TOOLCHAIN_WORKFLOW,
 	WORKFLOWS_DIR,
 } from "./lib/workflow-hardening.ts";
@@ -511,6 +516,72 @@ describe("checkToolchainDispatchOnly", () => {
 			jobs: { publish: gatedPublish },
 		};
 		expect(checkToolchainDispatchOnly(arrayForm, TOOLCHAIN_WORKFLOW)).toEqual([]);
+	});
+});
+
+describe("checkToolchainPrScope", () => {
+	const imageDoc = (paths: readonly string[] = TOOLCHAIN_IMAGE_PR_PATHS) => ({
+		on: { pull_request: { paths: [...paths] } },
+	});
+	const actionSmokeDoc = ({
+		paths = TOOLCHAIN_ACTION_SMOKE_PR_PATHS,
+		buildx = "true",
+		summaryIf = "always()",
+		run = `test "$(bun --version)" = "1.3.14"
+bun packages/templates/src/pins.ts >/dev/null
+docker buildx inspect --bootstrap`,
+	}: {
+		paths?: readonly string[];
+		buildx?: string;
+		summaryIf?: string;
+		run?: string;
+	} = {}) => ({
+		on: { pull_request: { paths: [...paths] } },
+		jobs: {
+			smoke: {
+				if: "github.event.pull_request.head.repo.full_name == github.repository",
+				"runs-on": "starsling-ubuntu-24.04-2",
+				"timeout-minutes": 5,
+				steps: [
+					{ uses: "./.github/actions/setup-toolchain", with: { buildx } },
+					{ run },
+					{ uses: "./.github/actions/release-summary", if: summaryIf },
+				],
+			},
+		},
+	});
+
+	test("passes the real expensive and lightweight toolchain workflows", () => {
+		expect(
+			checkToolchainPrScope(
+				readWorkflow(`${WORKFLOWS_DIR}/${TOOLCHAIN_WORKFLOW}`),
+				readWorkflow(`${WORKFLOWS_DIR}/${TOOLCHAIN_ACTION_SMOKE_WORKFLOW}`),
+			),
+		).toEqual([]);
+	});
+
+	test("rejects a broad action glob on the expensive image workflow", () => {
+		const errors = checkToolchainPrScope(
+			imageDoc([...TOOLCHAIN_IMAGE_PR_PATHS, ".github/actions/**"]),
+			actionSmokeDoc(),
+		);
+		expect(errors).toHaveLength(1);
+		expect(errors[0]).toContain(".github/actions/**");
+	});
+
+	test("rejects missing transitive action ownership and weakened runtime coverage", () => {
+		const paths = TOOLCHAIN_ACTION_SMOKE_PR_PATHS.filter(
+			(path) => path !== ".github/actions/setup-workspace/**",
+		);
+		const errors = checkToolchainPrScope(
+			imageDoc(),
+			actionSmokeDoc({ paths, buildx: "false", summaryIf: "success()", run: "bun --version" }),
+		);
+		expect(errors.some((error) => error.includes("setup-workspace/**"))).toBe(true);
+		expect(errors.some((error) => error.includes('buildx: "true"'))).toBe(true);
+		expect(errors.some((error) => error.includes("if: always()"))).toBe(true);
+		expect(errors.some((error) => error.includes("packages/templates/src/pins.ts"))).toBe(true);
+		expect(errors.some((error) => error.includes("docker buildx inspect --bootstrap"))).toBe(true);
 	});
 });
 

--- a/tooling/repo-checks/src/workflow-hardening.test.ts
+++ b/tooling/repo-checks/src/workflow-hardening.test.ts
@@ -200,6 +200,17 @@ describe("Vercel CLI authentication", () => {
 	});
 });
 
+describe("Namespace token authentication", () => {
+	test("the composite explicitly bounds each minted token to the benchmark cell window", () => {
+		const action = readFileSync(
+			join(findRepoRoot(), ".github/actions/namespace-token/action.yml"),
+			"utf8",
+		);
+		expect(action).toContain("--expires_in 4h");
+		expect(action).not.toContain("--no_expiry");
+	});
+});
+
 describe("customSecretsIn", () => {
 	test("ignores GITHUB_TOKEN and extracts provider secrets in dot and bracket notation", () => {
 		expect(

--- a/tooling/repo-checks/src/workflow-hardening.test.ts
+++ b/tooling/repo-checks/src/workflow-hardening.test.ts
@@ -158,7 +158,11 @@ describe("Vercel CLI authentication", () => {
 		const workflowText = ["bench-smoke.yml", "bench-suite.yml", "toolchain-image.yml"]
 			.map((file) => readFileSync(join(root, WORKFLOWS_DIR, file), "utf8"))
 			.join("\n");
-		expect(workflowText.match(/uses: \.\/\.github\/actions\/vercel-auth/g)).toHaveLength(4);
+		// Three call sites: the reusable benchmark cell (bench-suite.yml) plus toolchain-image.yml's two.
+		// bench-smoke.yml is still read here — not because it authenticates (it reaches Vercel only
+		// through the reusable cell now) but so the "no hand-minted token" assertions below still cover
+		// it if a lane ever grows its own credential handling again.
+		expect(workflowText.match(/uses: \.\/\.github\/actions\/vercel-auth/g)).toHaveLength(3);
 		expect(workflowText).not.toContain("api.vercel.com/v1/projects");
 		expect(workflowText).not.toContain("VERCEL_OIDC_TOKEN_FILE");
 		expect(workflowText).not.toContain("docker login vcr.vercel.com");

--- a/tooling/repo-checks/src/workflow-registry-sync.test.ts
+++ b/tooling/repo-checks/src/workflow-registry-sync.test.ts
@@ -17,12 +17,14 @@
 // failure messages on synthetic drift, so a future regression names the offending file + key.
 import { describe, expect, test } from "bun:test";
 import { PROVIDERS, SUITE_NAMES } from "@sandbox-benchmarks/schema";
+import type { SuiteMatrixCaller } from "./lib/workflow-sync.ts";
 import {
 	CELL_BUDGET_ENV_KEY,
 	checkCellBudgetEnv,
 	checkCredentialEnv,
 	checkLaneDelegates,
 	checkProviderInput,
+	checkSmokeSingleSandboxDefault,
 	checkSuiteInput,
 	checkSuiteMatrixCaller,
 	checkSuiteWorkflowNesting,
@@ -33,11 +35,13 @@ import {
 	EXPECTED_REPLICATES_ENV_EXPR,
 	EXPECTED_REPLICATES_INPUT_EXPR,
 	EXPECTED_REQUIRE_PROVIDERS_INPUT_EXPR,
+	EXPECTED_SMOKE_REPLICAS_INPUT_EXPR,
 	EXPECTED_SUITE_MATRIX_EXPR,
 	EXPECTED_SUITE_NAME_EXPR,
 	jobTimeoutMinutes,
 	MATRIX_WORKFLOW,
 	matrixSuiteCaller,
+	PLAN_STEP,
 	REPLICATES_ENV_KEY,
 	RUN_STEP,
 	readWorkflow,
@@ -292,39 +296,140 @@ describe("checkCredentialEnv", () => {
 });
 
 describe("checkLaneDelegates", () => {
+	const CREDENTIALS = [...requiredCredentialKeys().keys()];
+	const lane = (doc: unknown, label = "synthetic.yml"): string[] =>
+		checkLaneDelegates(doc, label, CREDENTIALS);
+	const laneYaml = (jobs: object): string[] => lane(Bun.YAML.parse(Bun.YAML.stringify({ jobs })));
+
 	// Invariant 3b: the consolidation itself. Both dispatch lanes must reach sandboxes only through the
 	// reusable — a re-introduced cell in either is the copy-paste this change removed.
 	test("the real dispatch lanes own no benchmark cell", () => {
-		expect(checkLaneDelegates(smoke, SMOKE_WORKFLOW)).toEqual([]);
-		expect(checkLaneDelegates(matrix, MATRIX_WORKFLOW)).toEqual([]);
+		expect(lane(smoke, SMOKE_WORKFLOW)).toEqual([]);
+		expect(lane(matrix, MATRIX_WORKFLOW)).toEqual([]);
 	});
 
 	test("the reusable itself is where the cell lives (so it would NOT pass this lane check)", () => {
-		const errors = checkLaneDelegates(suiteWf, SUITE_WORKFLOW);
-		expect(errors).toHaveLength(1);
-		expect(errors[0]).toContain(SUITE_JOB);
+		const errors = lane(suiteWf, SUITE_WORKFLOW);
+		// All three probes fire on the real cell: the step name, the run: that drives it, and its
+		// credential block. That is the shape the lanes must never have.
+		expect(errors.length).toBeGreaterThanOrEqual(3);
+		for (const error of errors) expect(error).toContain(SUITE_JOB);
 	});
 
 	test("flags a lane that re-grows its own run step, naming the job", () => {
+		const errors = laneYaml({
+			plan: { "runs-on": "ubuntu-24.04", steps: [{ name: "Plan" }] },
+			smoke: { "runs-on": "ubuntu-24.04", steps: [{ name: RUN_STEP }] },
+		});
+		expect(errors).toHaveLength(1);
+		expect(errors[0]).toContain('job "smoke"');
+		expect(errors[0]).toContain(RUN_STEP);
+	});
+
+	// The bypass a name-only check misses: same cell, fresh step name. This is the shape someone
+	// re-adding a cell by hand writes — they do not copy the reusable's step name along with it.
+	test("flags a re-grown cell hiding under a different step name", () => {
+		const errors = laneYaml({
+			smoke: {
+				"runs-on": "ubuntu-24.04",
+				steps: [
+					{ name: "Benchmark the cell", run: "bun apps/cli/src/bin/bench-suite.ts e2b system" },
+				],
+			},
+		});
+		expect(errors).toHaveLength(1);
+		expect(errors[0]).toContain("bench-suite.ts");
+	});
+
+	// The other bypass: credentials on a JOB-level env, which every step inherits, so no per-step scan
+	// would ever see them.
+	test("flags provider credentials hung off a job-level env", () => {
+		const errors = laneYaml({
+			smoke: {
+				"runs-on": "ubuntu-24.04",
+				env: { E2B_API_KEY: "x", DAYTONA_API_KEY: "y", SOME_RUNTIME_CONTEXT: "z" },
+				steps: [{ name: "Something else" }],
+			},
+		});
+		expect(errors).toHaveLength(1);
+		expect(errors[0]).toContain("DAYTONA_API_KEY, E2B_API_KEY");
+		// Non-credential env is not the lane's business.
+		expect(errors[0]).not.toContain("SOME_RUNTIME_CONTEXT");
+	});
+
+	test("flags provider credentials on a step env too", () => {
+		const errors = laneYaml({
+			smoke: { "runs-on": "ubuntu-24.04", steps: [{ name: "x", env: { NOVITA_API_KEY: "k" } }] },
+		});
+		expect(errors).toHaveLength(1);
+		expect(errors[0]).toContain("NOVITA_API_KEY");
+	});
+
+	// A lane legitimately runs bun bins (the planners) and carries non-credential env; neither is a cell.
+	test("passes a lane that plans and orchestrates without touching a credential", () => {
+		expect(
+			laneYaml({
+				plan: {
+					"runs-on": "ubuntu-24.04",
+					steps: [
+						{
+							name: "Plan",
+							run: "bun apps/cli/src/bin/plan-suites.ts",
+							env: { BENCH_SUITES: "s" },
+						},
+					],
+				},
+				suite: { uses: "./.github/workflows/bench-suite.yml", with: { suite: "system" } },
+			}),
+		).toEqual([]);
+	});
+});
+
+describe("checkSmokeSingleSandboxDefault", () => {
+	// Invariant 7. `default: '1'` does NOT hold this on its own — a cleared dispatch field sends "",
+	// which means "each suite's Suite.defaultReplicas" (R=12 on realworld). The fallback is the guard.
+	test("the real smoke lane pins one sandbox against a cleared field", () => {
+		expect(checkSmokeSingleSandboxDefault(smoke, SMOKE_WORKFLOW)).toEqual([]);
+		expect(dispatchInput(smoke, "replicas", SMOKE_WORKFLOW).default).toBe("1");
+	});
+
+	test("flags a plan step that forwards replicas without the blank fallback", () => {
 		const yaml = Bun.YAML.stringify({
 			jobs: {
-				plan: { "runs-on": "ubuntu-24.04", steps: [{ name: "Plan" }] },
-				smoke: {
-					"runs-on": "ubuntu-24.04",
-					steps: [{ name: RUN_STEP, run: "bun bench-suite.ts" }],
+				plan: {
+					steps: [
+						// biome-ignore lint/suspicious/noTemplateCurlyInString: a GHA expression literal, not a JS template.
+						{ name: PLAN_STEP, with: { replicas: "${{ inputs.replicas }}" } },
+					],
 				},
 			},
 		});
-		const errors = checkLaneDelegates(Bun.YAML.parse(yaml), "synthetic.yml");
+		const errors = checkSmokeSingleSandboxDefault(Bun.YAML.parse(yaml), "synthetic.yml");
 		expect(errors).toHaveLength(1);
-		expect(errors[0]).toContain("smoke");
-		expect(errors[0]).toContain(RUN_STEP);
-		expect(errors[0]).not.toContain("plan,");
+		expect(errors[0]).toContain(EXPECTED_SMOKE_REPLICAS_INPUT_EXPR);
+		expect(errors[0]).toContain("R=12");
+	});
+
+	test("flags a missing plan job or plan step rather than passing vacuously", () => {
+		const noJob = Bun.YAML.stringify({ jobs: { suite: {} } });
+		expect(checkSmokeSingleSandboxDefault(Bun.YAML.parse(noJob), "synthetic.yml")[0]).toContain(
+			'job "plan" is missing',
+		);
+		const noStep = Bun.YAML.stringify({ jobs: { plan: { steps: [{ name: "Checkout" }] } } });
+		expect(checkSmokeSingleSandboxDefault(Bun.YAML.parse(noStep), "synthetic.yml")[0]).toContain(
+			`no step named "${PLAN_STEP}"`,
+		);
 	});
 });
 
 describe("checkSuiteMatrixCaller", () => {
-	const realCaller = matrixSuiteCaller(matrix);
+	const realCaller = matrixSuiteCaller(matrix, MATRIX_WORKFLOW);
+	// The matrix lane's complete, declared posture: it owns the publish dependency and must NOT require
+	// a provider. Every call states both — a partial object would silently waive the flag it omits,
+	// which is exactly why the options type has no optional fields.
+	const MATRIX_LANE = { requirePublishNeeds: true, requireProviderAssertion: false } as const;
+	const check = (caller: SuiteMatrixCaller, label = MATRIX_WORKFLOW): string[] =>
+		checkSuiteMatrixCaller(caller, label, MATRIX_LANE);
 
 	test("matrixSuiteCaller extracts the real suite-matrix nesting wiring", () => {
 		expect(realCaller.jobId).toBe("suite");
@@ -335,24 +440,24 @@ describe("checkSuiteMatrixCaller", () => {
 	});
 
 	test("the real suite-matrix caller is wired for native nesting", () => {
-		expect(checkSuiteMatrixCaller(realCaller)).toEqual([]);
+		expect(check(realCaller)).toEqual([]);
 	});
 
 	test("flags a caller whose display name is not matrix.suite", () => {
-		const errors = checkSuiteMatrixCaller({ ...realCaller, name: "Bench suites" });
+		const errors = check({ ...realCaller, name: "Bench suites" });
 		expect(errors).toHaveLength(1);
 		expect(errors[0]).toContain("name must be");
 		expect(errors[0]).toContain(EXPECTED_SUITE_NAME_EXPR);
 	});
 
 	test("flags a caller whose with.suite is not matrix.suite", () => {
-		const errors = checkSuiteMatrixCaller({ ...realCaller, suiteInput: "cpu-node" });
+		const errors = check({ ...realCaller, suiteInput: "cpu-node" });
 		expect(errors).toHaveLength(1);
 		expect(errors[0]).toContain("with.suite must be");
 	});
 
 	test("flags a caller whose suite axis is not plan.outputs.suites", () => {
-		const errors = checkSuiteMatrixCaller({
+		const errors = check({
 			...realCaller,
 			// biome-ignore lint/suspicious/noTemplateCurlyInString: a GHA expression literal (wrong axis), not a JS template.
 			matrixSuiteExpr: "${{ fromJSON(needs.plan.outputs.providers) }}",
@@ -363,7 +468,7 @@ describe("checkSuiteMatrixCaller", () => {
 	});
 
 	test("flags publish that does not need the suite-matrix caller", () => {
-		const errors = checkSuiteMatrixCaller({ ...realCaller, publishNeeds: ["plan"] });
+		const errors = check({ ...realCaller, publishNeeds: ["plan"] });
 		expect(errors).toHaveLength(1);
 		expect(errors[0]).toContain('publish" must need "suite"');
 	});
@@ -401,10 +506,10 @@ describe("checkSuiteMatrixCaller", () => {
 	// check while quietly measuring one sandbox per cell.
 	test("flags a caller that hardcodes with.replicates instead of taking the plan's slice", () => {
 		const caller = {
-			...matrixSuiteCaller(matrix),
+			...matrixSuiteCaller(matrix, MATRIX_WORKFLOW),
 			replicatesInput: "[0]",
 		};
-		const errors = checkSuiteMatrixCaller(caller, "synthetic.yml");
+		const errors = check(caller, "synthetic.yml");
 		expect(errors).toHaveLength(1);
 		expect(errors[0]).toContain("with.replicates must be");
 		expect(errors[0]).toContain(EXPECTED_REPLICATES_INPUT_EXPR);
@@ -437,12 +542,14 @@ describe("checkSuiteMatrixCaller", () => {
 
 describe("checkSuiteMatrixCaller on the smoke lane", () => {
 	const smokeCaller = matrixSuiteCaller(smoke, SMOKE_WORKFLOW);
+	// The smoke lane's complete, declared posture — the exact mirror of MATRIX_LANE above.
+	const SMOKE_LANE = { requirePublishNeeds: false, requireProviderAssertion: true } as const;
 
 	// The consolidation in one assertion: the smoke lane's caller is the matrix lane's caller, down to
 	// the job id and every nesting expression. If these diverge, "a smoke is a real run minus the
 	// commit" has stopped being true.
 	test("the smoke caller is wired identically to the matrix caller", () => {
-		const matrixCaller = matrixSuiteCaller(matrix);
+		const matrixCaller = matrixSuiteCaller(matrix, MATRIX_WORKFLOW);
 		expect(smokeCaller.jobId).toBe(matrixCaller.jobId);
 		expect(smokeCaller.name).toBe(matrixCaller.name);
 		expect(smokeCaller.suiteInput).toBe(matrixCaller.suiteInput);
@@ -452,18 +559,14 @@ describe("checkSuiteMatrixCaller on the smoke lane", () => {
 
 	test("the real smoke caller passes its dispatched provider as require_providers", () => {
 		expect(smokeCaller.requireProvidersInput).toBe(EXPECTED_REQUIRE_PROVIDERS_INPUT_EXPR);
-		expect(
-			checkSuiteMatrixCaller(smokeCaller, SMOKE_WORKFLOW, { requireProviderAssertion: true }),
-		).toEqual([]);
+		expect(checkSuiteMatrixCaller(smokeCaller, SMOKE_WORKFLOW, SMOKE_LANE)).toEqual([]);
 	});
 
 	// Dropping it is the silent regression: every nesting check still passes, the job still goes green,
 	// and a missing credential is recorded as a skip on a run that benchmarked nothing.
 	test("flags a smoke caller that stopped requiring its provider", () => {
 		const { requireProvidersInput: _dropped, ...caller } = smokeCaller;
-		const errors = checkSuiteMatrixCaller(caller, SMOKE_WORKFLOW, {
-			requireProviderAssertion: true,
-		});
+		const errors = checkSuiteMatrixCaller(caller, SMOKE_WORKFLOW, SMOKE_LANE);
 		expect(errors).toHaveLength(1);
 		expect(errors[0]).toContain("with.require_providers must be");
 		expect(errors[0]).toContain("no such input");
@@ -473,16 +576,20 @@ describe("checkSuiteMatrixCaller on the smoke lane", () => {
 	// between the lanes — so the publish dependency must not be demanded of it.
 	test("does not demand a publish dependency of the smoke lane", () => {
 		expect(smokeCaller.publishNeeds).toEqual([]);
-		expect(
-			checkSuiteMatrixCaller(smokeCaller, SMOKE_WORKFLOW, { requireProviderAssertion: true }),
-		).toEqual([]);
+		expect(checkSuiteMatrixCaller(smokeCaller, SMOKE_WORKFLOW, SMOKE_LANE)).toEqual([]);
 	});
 
-	// ...and the matrix lane must not be let off its own assertion by the shared default.
-	test("still demands a publish dependency by default", () => {
-		const errors = checkSuiteMatrixCaller({ ...smokeCaller, publishNeeds: [] }, SMOKE_WORKFLOW);
+	// The mirror image, and the reason `requireProviderAssertion: false` asserts ABSENCE rather than
+	// merely not-checking: a stray value on the matrix lane fails every cell whose provider it names —
+	// loudly, but only after a whole matrix run's worth of provider quota is committed.
+	test("flags a matrix-lane caller that grew a require_providers input", () => {
+		const errors = checkSuiteMatrixCaller(
+			{ ...matrixSuiteCaller(matrix, MATRIX_WORKFLOW), requireProvidersInput: "e2b" },
+			MATRIX_WORKFLOW,
+			{ requirePublishNeeds: true, requireProviderAssertion: false },
+		);
 		expect(errors).toHaveLength(1);
-		expect(errors[0]).toContain('publish" must need');
+		expect(errors[0]).toContain("must not pass with.require_providers");
 	});
 });
 

--- a/tooling/repo-checks/src/workflow-registry-sync.test.ts
+++ b/tooling/repo-checks/src/workflow-registry-sync.test.ts
@@ -1,11 +1,13 @@
 // Invariant: the GitHub workflows that dispatch live benchmarks stay in lockstep with the schema
 // registries (PROVIDERS + SUITE_NAMES). GHA can't import TypeScript, so the provider/suite choices and
-// the per-provider credential env block are hand-mirrored across .github/workflows/bench-*.yml; this
-// gate re-derives the truth from the registries and fails if someone adds a provider/suite (or its
-// required secret) without updating the workflows. bench-matrix.yml has one suite-matrix job that calls
-// the reusable bench-suite.yml (native nesting: suite / provider) — so the credential block + run-job
-// timeout live in the reusable (the "matrix side" of the credential/timeout checks reads it), and a
-// separate invariant asserts the suite-matrix caller stays wired to plan.outputs.suites. Mirrors
+// the per-provider credential env block are hand-written YAML; this gate re-derives the truth from the
+// registries and fails if someone adds a provider/suite (or its required secret) without updating the
+// workflows. Both dispatch lanes — bench-matrix.yml (the full matrix, ending in a dataset commit) and
+// bench-smoke.yml (the same pipeline narrowed to one provider × suite and stopped before that commit) —
+// are one `plan` job plus one suite-matrix job calling the reusable bench-suite.yml (native nesting:
+// suite / provider). The credential block + run-job timeout live in that single reusable, so the
+// credential/timeout checks read it; separate invariants assert both callers stay wired to
+// plan.outputs.suites and that neither lane grows a benchmark cell of its own again. Mirrors
 // runner-benchmarking's test/workflow-{env,suite}-sync.test.ts. See ./lib/workflow-sync.ts for the
 // parsers + pure checks. Nesting (invariant 6) lives in ./lib/workflow-nesting.ts; YAML helpers in
 // ./lib/workflow-yaml.ts — workflow-sync.ts re-exports the public surface.
@@ -19,6 +21,7 @@ import {
 	CELL_BUDGET_ENV_KEY,
 	checkCellBudgetEnv,
 	checkCredentialEnv,
+	checkLaneDelegates,
 	checkProviderInput,
 	checkSuiteInput,
 	checkSuiteMatrixCaller,
@@ -29,6 +32,7 @@ import {
 	EXPECTED_REPLICATES_ARG,
 	EXPECTED_REPLICATES_ENV_EXPR,
 	EXPECTED_REPLICATES_INPUT_EXPR,
+	EXPECTED_REQUIRE_PROVIDERS_INPUT_EXPR,
 	EXPECTED_SUITE_MATRIX_EXPR,
 	EXPECTED_SUITE_NAME_EXPR,
 	jobTimeoutMinutes,
@@ -39,7 +43,6 @@ import {
 	readWorkflow,
 	requiredCredentialKeys,
 	runCheck,
-	SMOKE_JOB,
 	SMOKE_WORKFLOW,
 	SUITE_JOB,
 	SUITE_WORKFLOW,
@@ -52,7 +55,6 @@ const matrix = readWorkflow(MATRIX_WORKFLOW);
 const suiteWf = readWorkflow(SUITE_WORKFLOW);
 const providerInput = dispatchInput(smoke, "provider", SMOKE_WORKFLOW);
 const suiteInput = dispatchInput(smoke, "suite", SMOKE_WORKFLOW);
-const smokeEnv = stepEnv(smoke, SMOKE_JOB, RUN_STEP, SMOKE_WORKFLOW);
 const suiteEnv = stepEnv(suiteWf, SUITE_JOB, RUN_STEP, SUITE_WORKFLOW);
 
 describe("parsers against the real workflow files", () => {
@@ -68,16 +70,14 @@ describe("parsers against the real workflow files", () => {
 		expect(suiteInput.type).toBe("choice");
 	});
 
-	test("stepEnv extracts a realistic credential block from both lanes", () => {
-		expect(smokeEnv).toContainKey("DAYTONA_API_KEY");
-		// The matrix lane's credential block lives in the reusable bench-suite.yml.
+	test("stepEnv extracts the one real credential block, in the reusable cell", () => {
 		expect(suiteEnv).toContainKey("E2B_API_KEY");
+		expect(suiteEnv).toContainKey("DAYTONA_API_KEY");
 		// A real block (credentials + runtime context), not a parse fragment.
-		expect(Object.keys(smokeEnv).length).toBeGreaterThanOrEqual(8);
+		expect(Object.keys(suiteEnv).length).toBeGreaterThanOrEqual(8);
 	});
 
-	test("both live-run jobs reserve host margin beyond the longest suite", () => {
-		expect(jobTimeoutMinutes(smoke, SMOKE_JOB, SMOKE_WORKFLOW)).toBe(180);
+	test("the live-run job reserves host margin beyond the longest suite", () => {
 		expect(jobTimeoutMinutes(suiteWf, SUITE_JOB, SUITE_WORKFLOW)).toBe(180);
 	});
 
@@ -88,10 +88,10 @@ describe("parsers against the real workflow files", () => {
 	});
 
 	test("stepEnv throws on a missing job, step, or env mapping", () => {
-		expect(() => stepEnv(smoke, "no-such-job", RUN_STEP, SMOKE_WORKFLOW)).toThrow(
+		expect(() => stepEnv(suiteWf, "no-such-job", RUN_STEP, SUITE_WORKFLOW)).toThrow(
 			'job "no-such-job" not found',
 		);
-		expect(() => stepEnv(smoke, SMOKE_JOB, "No Such Step", SMOKE_WORKFLOW)).toThrow(
+		expect(() => stepEnv(suiteWf, SUITE_JOB, "No Such Step", SUITE_WORKFLOW)).toThrow(
 			'has no step named "No Such Step"',
 		);
 		const yaml = Bun.YAML.stringify({ jobs: { j: { steps: [{ name: "bare" }] } } });
@@ -103,7 +103,7 @@ describe("parsers against the real workflow files", () => {
 
 describe("checkWorkflowTimeouts", () => {
 	test("passes timeouts with the required host margin", () => {
-		expect(checkWorkflowTimeouts({ smoke: 180, matrix: 180 })).toEqual([]);
+		expect(checkWorkflowTimeouts({ bench: 180 })).toEqual([]);
 	});
 
 	test("flags a job cap that cannot outlast the longest suite", () => {
@@ -232,6 +232,16 @@ describe("checkSuiteInput", () => {
 });
 
 describe("checkCredentialEnv", () => {
+	// A hypothetical second lane declaring its own block, spelled with the OTHER provider selector —
+	// the shape the fold exists for. The real repo has exactly one block (Invariant 3b keeps it that
+	// way), so the cross-workflow half of this check is exercised synthetically.
+	const laneEnv = Object.fromEntries(
+		Object.entries(suiteEnv).map(([key, value]) => [
+			key,
+			value.replaceAll("matrix.provider", "inputs.provider"),
+		]),
+	);
+
 	test("requiredCredentialKeys records provenance per provider", () => {
 		const required = requiredCredentialKeys();
 		expect(required.get("E2B_API_KEY")).toEqual(["e2b"]);
@@ -240,37 +250,76 @@ describe("checkCredentialEnv", () => {
 		expect(required.get("DAYTONA_API_KEY")).toEqual(["daytona-vm", "daytona-container"]);
 	});
 
-	test("flags a required key dropped from the matrix (reusable) block, naming key and file", () => {
+	test("the real reusable block covers every registered provider's credentials", () => {
+		expect(checkCredentialEnv({ [SUITE_WORKFLOW]: suiteEnv })).toEqual([]);
+	});
+
+	test("flags a required key dropped from the reusable block, naming key and file", () => {
 		const { E2B_API_KEY: _, ...drifted } = suiteEnv;
-		const errors = checkCredentialEnv({
-			[SMOKE_WORKFLOW]: smokeEnv,
-			[SUITE_WORKFLOW]: drifted,
-		});
+		const errors = checkCredentialEnv({ [SUITE_WORKFLOW]: drifted });
 		expect(errors).toHaveLength(1);
 		expect(errors[0]).toContain("E2B_API_KEY");
 		expect(errors[0]).toContain("required by provider e2b");
 		expect(errors[0]).toContain(SUITE_WORKFLOW);
-		expect(errors[0]).not.toContain(SMOKE_WORKFLOW);
 	});
 
-	test("flags a shared key whose value expression differs across the two lanes", () => {
+	// The selector fold: the same secret guarded on `inputs.provider` rather than `matrix.provider` is
+	// the same wiring, not drift, so two lanes spelling it either way must still agree.
+	test("folds the two provider selectors together across workflows", () => {
+		expect(checkCredentialEnv({ [SMOKE_WORKFLOW]: laneEnv, [SUITE_WORKFLOW]: suiteEnv })).toEqual(
+			[],
+		);
+	});
+
+	test("flags a shared key whose value expression differs across two workflows", () => {
 		const drifted = { ...suiteEnv, DAYTONA_API_KEY: `\${{ secrets.DAYTONA_API_KEY_OTHER }}` };
 		const errors = checkCredentialEnv({
-			[SMOKE_WORKFLOW]: smokeEnv,
+			[SMOKE_WORKFLOW]: laneEnv,
 			[SUITE_WORKFLOW]: drifted,
 		});
 		expect(errors).toHaveLength(1);
 		expect(errors[0]).toContain("DAYTONA_API_KEY:");
-		expect(errors[0]).toContain(smokeEnv.DAYTONA_API_KEY);
+		expect(errors[0]).toContain(laneEnv.DAYTONA_API_KEY);
 		expect(errors[0]).toContain("DAYTONA_API_KEY_OTHER");
 	});
 
 	test("tolerates extra runtime-context vars beyond the required credentials", () => {
 		const errors = checkCredentialEnv({
-			[SMOKE_WORKFLOW]: { ...smokeEnv, SOME_RUNTIME_CONTEXT: "x" },
-			[SUITE_WORKFLOW]: suiteEnv,
+			[SUITE_WORKFLOW]: { ...suiteEnv, SOME_RUNTIME_CONTEXT: "x" },
 		});
 		expect(errors).toEqual([]);
+	});
+});
+
+describe("checkLaneDelegates", () => {
+	// Invariant 3b: the consolidation itself. Both dispatch lanes must reach sandboxes only through the
+	// reusable — a re-introduced cell in either is the copy-paste this change removed.
+	test("the real dispatch lanes own no benchmark cell", () => {
+		expect(checkLaneDelegates(smoke, SMOKE_WORKFLOW)).toEqual([]);
+		expect(checkLaneDelegates(matrix, MATRIX_WORKFLOW)).toEqual([]);
+	});
+
+	test("the reusable itself is where the cell lives (so it would NOT pass this lane check)", () => {
+		const errors = checkLaneDelegates(suiteWf, SUITE_WORKFLOW);
+		expect(errors).toHaveLength(1);
+		expect(errors[0]).toContain(SUITE_JOB);
+	});
+
+	test("flags a lane that re-grows its own run step, naming the job", () => {
+		const yaml = Bun.YAML.stringify({
+			jobs: {
+				plan: { "runs-on": "ubuntu-24.04", steps: [{ name: "Plan" }] },
+				smoke: {
+					"runs-on": "ubuntu-24.04",
+					steps: [{ name: RUN_STEP, run: "bun bench-suite.ts" }],
+				},
+			},
+		});
+		const errors = checkLaneDelegates(Bun.YAML.parse(yaml), "synthetic.yml");
+		expect(errors).toHaveLength(1);
+		expect(errors[0]).toContain("smoke");
+		expect(errors[0]).toContain(RUN_STEP);
+		expect(errors[0]).not.toContain("plan,");
 	});
 });
 
@@ -383,6 +432,57 @@ describe("checkSuiteMatrixCaller", () => {
 		expect(() => matrixSuiteCaller(Bun.YAML.parse(yaml), "synthetic.yml")).toThrow(
 			'without a string "suite" input',
 		);
+	});
+});
+
+describe("checkSuiteMatrixCaller on the smoke lane", () => {
+	const smokeCaller = matrixSuiteCaller(smoke, SMOKE_WORKFLOW);
+
+	// The consolidation in one assertion: the smoke lane's caller is the matrix lane's caller, down to
+	// the job id and every nesting expression. If these diverge, "a smoke is a real run minus the
+	// commit" has stopped being true.
+	test("the smoke caller is wired identically to the matrix caller", () => {
+		const matrixCaller = matrixSuiteCaller(matrix);
+		expect(smokeCaller.jobId).toBe(matrixCaller.jobId);
+		expect(smokeCaller.name).toBe(matrixCaller.name);
+		expect(smokeCaller.suiteInput).toBe(matrixCaller.suiteInput);
+		expect(smokeCaller.replicatesInput).toBe(matrixCaller.replicatesInput);
+		expect(smokeCaller.matrixSuiteExpr).toBe(matrixCaller.matrixSuiteExpr);
+	});
+
+	test("the real smoke caller passes its dispatched provider as require_providers", () => {
+		expect(smokeCaller.requireProvidersInput).toBe(EXPECTED_REQUIRE_PROVIDERS_INPUT_EXPR);
+		expect(
+			checkSuiteMatrixCaller(smokeCaller, SMOKE_WORKFLOW, { requireProviderAssertion: true }),
+		).toEqual([]);
+	});
+
+	// Dropping it is the silent regression: every nesting check still passes, the job still goes green,
+	// and a missing credential is recorded as a skip on a run that benchmarked nothing.
+	test("flags a smoke caller that stopped requiring its provider", () => {
+		const { requireProvidersInput: _dropped, ...caller } = smokeCaller;
+		const errors = checkSuiteMatrixCaller(caller, SMOKE_WORKFLOW, {
+			requireProviderAssertion: true,
+		});
+		expect(errors).toHaveLength(1);
+		expect(errors[0]).toContain("with.require_providers must be");
+		expect(errors[0]).toContain("no such input");
+	});
+
+	// The smoke lane deliberately has NO publish job — that missing third phase IS the difference
+	// between the lanes — so the publish dependency must not be demanded of it.
+	test("does not demand a publish dependency of the smoke lane", () => {
+		expect(smokeCaller.publishNeeds).toEqual([]);
+		expect(
+			checkSuiteMatrixCaller(smokeCaller, SMOKE_WORKFLOW, { requireProviderAssertion: true }),
+		).toEqual([]);
+	});
+
+	// ...and the matrix lane must not be let off its own assertion by the shared default.
+	test("still demands a publish dependency by default", () => {
+		const errors = checkSuiteMatrixCaller({ ...smokeCaller, publishNeeds: [] }, SMOKE_WORKFLOW);
+		expect(errors).toHaveLength(1);
+		expect(errors[0]).toContain('publish" must need');
 	});
 });
 

--- a/tooling/repo-checks/src/workflow-registry-sync.test.ts
+++ b/tooling/repo-checks/src/workflow-registry-sync.test.ts
@@ -538,6 +538,26 @@ describe("checkSuiteMatrixCaller", () => {
 			'without a string "suite" input',
 		);
 	});
+
+	test("matrixSuiteCaller rejects a present non-string require_providers input", () => {
+		const yaml = Bun.YAML.stringify({
+			jobs: {
+				bad: {
+					name: EXPECTED_SUITE_NAME_EXPR,
+					uses: "./.github/workflows/bench-suite.yml",
+					with: {
+						suite: EXPECTED_SUITE_NAME_EXPR,
+						replicates: EXPECTED_REPLICATES_INPUT_EXPR,
+						require_providers: true,
+					},
+					strategy: { matrix: { suite: EXPECTED_SUITE_MATRIX_EXPR } },
+				},
+			},
+		});
+		expect(() => matrixSuiteCaller(Bun.YAML.parse(yaml), "synthetic.yml")).toThrow(
+			'with a non-string "require_providers" input',
+		);
+	});
 });
 
 describe("checkSuiteMatrixCaller on the smoke lane", () => {


### PR DESCRIPTION
## Summary

Refactor `bench-smoke.yml` and `bench-matrix.yml` to share a single implementation of the benchmark cell execution, eliminating code duplication and drift risks. Both workflows now use identical planning and cell-execution logic, differing only in scope (single provider×suite vs. full matrix) and whether they commit the dataset.

## Key Changes

- **Unified cell implementation**: Both dispatch lanes now call the same `bench-suite.yml` reusable workflow through a shared `plan-bench-axes` action, eliminating the copy-pasted credential wiring and run-step logic that previously existed in `bench-smoke.yml`.

- **New shared actions**:
  - `.github/actions/plan-bench-axes`: Resolves provider/suite/replicate axes from schema registries; used by both `bench-matrix.yml` and `bench-smoke.yml`
  - `.github/actions/setup-workspace`: Centralizes Bun setup and dependency installation (replaces inline setup in multiple workflows)
  - `.github/actions/namespace-token`: Mints portable Namespace tokens via GitHub OIDC federation (extracted from inline cell logic)

- **Smoke-specific inputs**: Added `replicas` and `max_concurrency` inputs to `bench-smoke.yml` to allow rehearsing multi-replica scenarios while defaulting to single-sandbox runs.

- **Provider assertion**: Added `require_providers` input to `bench-suite.yml` so smoke runs can enforce that their dispatched provider actually ran (fails the job if credentials are missing), while matrix runs gracefully skip unauthenticated providers.

- **Invariant enforcement**: Updated `workflow-registry-sync` tests to verify:
  - Neither dispatch lane owns a benchmark cell (Invariant 3b)
  - Both lanes delegate to the same reusable via identical nesting wiring (Invariant 6)
  - Credential blocks are consolidated in one place
  - Provider/suite inputs stay synchronized with schema registries

## Implementation Details

- The `bench-smoke.yml` workflow now has a `plan` job (matching `bench-matrix.yml`) that validates inputs before the suite-matrix fan-out, ensuring typos fail early rather than silently skipping providers.

- Smoke runs serialize per `(ref, provider, suite)` to prevent quota contention while allowing different cells to run in parallel.

- The `require_providers` parameter is the sole behavioral difference between lanes: smoke sets it to the dispatched provider (fail if missing), matrix leaves it blank (skip if missing).

- All documentation and comments updated to reflect the single-implementation model, removing references to "two lanes" maintaining separate credential blocks.

https://claude.ai/code/session_01Mi19mEZFMQ1JPe52fDTzrg

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Unifies smoke and matrix benchmark lanes behind one reusable cell, removes duplicated setup/credential logic, tightens drift gates, and adds a lightweight PR smoke for toolchain composites to avoid unnecessary image rebuilds.

- **Refactors**
  - Both lanes call the same reusable `bench-suite.yml` via shared `plan-bench-axes`; matrix publishes, smoke stops before publish, and the credential env/run step now live only in the reusable cell.
  - New shared actions: `plan-bench-axes`, `setup-workspace`, `namespace-token`; adopted `setup-workspace` in `commit-dataset.yml` and `update-leaderboard.yml`; `setup-toolchain` now delegates to it.
  - Smoke inputs: `replicas` (defaults to 1 even when blank) and `max_concurrency`; `require_providers` added to the reusable cell to fail smoke if its provider is unauthenticated.
  - Added `toolchain-actions-smoke.yml` to exercise `setup-toolchain`, `setup-workspace`, and `release-summary` on PRs; narrowed `toolchain-image.yml` PR paths to avoid rebuilding the image on action-only changes.

- **Bug Fixes**
  - Treat blank `replicas` as 1 to avoid accidental multi-sandbox fleets.
  - Upload shard artifacts on first attempt even if normalization fails.
  - Disable Bun cache on the microsandbox self-hosted label to avoid setup failures.
  - Simplify logs for single-replicate runs (no fan-out grouping).
  - Stronger drift gates: reject duplicated cell logic or job-level creds in lanes; require explicit `SuiteMatrixCaller` options.

<sup>Written for commit 5d87b0ef25c92699cc70418f0f5ac3b76f74676c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/starslingdev/hpc-sandbox-benchmarks/pull/329?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added configurable smoke benchmark replicas and concurrency controls.
  - Added provider validation requirements for smoke runs.
  - Added reusable automation for benchmark planning, execution, workspace setup, and secure temporary access tokens.

- **Bug Fixes**
  - Improved benchmark workflow consistency and replicate handling.
  - Preserved diagnostic artifacts for initial failed attempts.

- **Documentation**
  - Clarified benchmark workflows, contribution steps, CI secrets, and methodology.
  - Updated local and CI replicate-output behavior documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->