### PR TITLE
fix(toolchain): give the VCR mirror step its own CLI credentials

### DIFF
--- a/.github/workflows/toolchain-image.yml
+++ b/.github/workflows/toolchain-image.yml
@@ -461,6 +461,11 @@ jobs:
         id: vercel-vcr
         env:
           SOURCE_REF: ${{ needs.plan.outputs.image-source }}
+          # `vercel vcr push` is a CLI call, so it needs CLI credentials of its own — the vercel-auth
+          # composite's docker login covers the REGISTRY, not the CLI, and its `--token` lives in that
+          # composite's step env, which does not carry across steps. Without this the push dies with
+          # "No existing credentials found", after the multi-GB pull above has already run.
+          VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
         run: |
           set -euo pipefail
           target_ref="$(bun -e 'import { config } from "@sandbox-benchmarks/providers"; console.log(config.vercelImageCandidate)')"
@@ -473,7 +478,9 @@ jobs:
           # Without it the push silently follows whatever project VERCEL_PROJECT_ID linked, so a
           # mismatched VERCEL_PROJECT_NAME would tag one repository and publish into another — and the
           # digest read back below would describe an image the providers never pull.
-          ./node_modules/.bin/vercel vcr push docker "$target_name" --project "$project"
+          # --token explicitly rather than relying on the CLI's env pickup: one documented contract,
+          # and it fails loudly here rather than silently falling back to some ambient session.
+          ./node_modules/.bin/vercel vcr push docker "$target_name" --project "$project" --token="$VERCEL_TOKEN"
           digest="$(docker buildx imagetools inspect "$target_ref" --format '{{json .Manifest.Digest}}' | jq -er '.')"
           echo "digest-ref=${target_ref%:*}@${digest}" >> "$GITHUB_OUTPUT"
       - name: Log out of VCR after mirror


### PR DESCRIPTION
## The failure

Run [30728792855](https://github.com/starslingdev/hpc-sandbox-benchmarks/actions/runs/30728792855) — the first release run to get past Vercel auth — died in the bake cell:

```
>>> mirroring ghcr.io/starslingdev/sandbox-benchmarks-toolchain:v7 into VCR as …-vercel:v7-candidate
Error: No existing credentials found. Please run `vercel login` or pass "--token"
```

…after the multi-GB `docker pull` above it had already run.

## Cause

`vercel vcr push` is a **Vercel CLI** call and needs CLI credentials of its own. Two things were conflated:

- `vercel-auth`'s `vcr login docker` authenticates **Docker** to the registry.
- The `--token` that composite passes lives in **that composite's step env**, and GitHub does not carry step env across steps.

So the mirror step ran with no credentials at all.

The CI run is its own proof — same job, same runner, two steps:

| Step | `VERCEL_TOKEN` in step env? | Result |
|---|---|---|
| `auth.sh` → `vercel vcr login docker` (no `--token`) | ✅ set by the composite's `env:` | succeeded |
| Mirror step → `vercel vcr push docker` (no `--token`) | ❌ only `SOURCE_REF` | "No existing credentials found" |

## Not a regression

This is latent from #315 — the step has **never** had a token. It stayed invisible because `vercel-auth` itself always failed first, on a project-scoped `VERCEL_TOKEN`. (A `vcp_` token pinned to a single project authenticates and reads the project over REST — `/v9/projects/<id>` → 200 — but has no user identity, `/v2/user` → 404, so every CLI command fails. The prefix is not the tell: a working team-scoped token is also `vcp_` and also 60 chars; only the scope breadth differs.) With a team-scoped token in place, auth now succeeds and the real defect surfaced.

## The fix

Add `VERCEL_TOKEN` to the mirror step's env and pass `--token` **explicitly** rather than relying on the CLI's environment pickup — one documented contract, and it fails loudly instead of silently falling back to whatever ambient session a runner might have.

## Verification

Ran the exact fixed command form against the live registry:

```
vercel vcr push docker sandbox-benchmarks-toolchain-vercel:v7-candidate \
  --project hpc-sandbox-benchmarks --token=…
> Success! Pushed …/sandbox-benchmarks-toolchain-vercel:v7-candidate
  digest: sha256:c1af6468d9ac2a7cd34feae4a81d448feeb612ffdca3e01bf726af900de1c090
```

That digest is identical to the published GHCR `:v7` index — Vercel runs the same bytes as the rest of the fleet.

`actionlint` and `zizmor` clean. Grepped for the same defect at every other `vercel` CLI call site outside the auth composite; this is the only one.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the CI VCR mirror by giving `vercel vcr push` its own CLI credentials. Prevents the “No existing credentials found” failure and avoids wasting time after the multi‑GB pull.

- **Bug Fixes**
  - Add `VERCEL_TOKEN` to the mirror step env and pass `--token` to `vercel vcr push` (CLI needs its own creds; `vercel-auth` only logs Docker to the registry).
  - Verified against the live registry: push succeeds and the digest matches the GHCR base.

<sup>Written for commit b822b253e37e0cc93039763f1eb58cdc77515ecb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/starslingdev/hpc-sandbox-benchmarks/pull/330?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

