### PR TITLE
feat(bench): add vercel and microsandbox-cloud to the default provider set

### DIFF
--- a/.github/workflows/bench-matrix.yml
+++ b/.github/workflows/bench-matrix.yml
@@ -40,12 +40,19 @@ on:
         type: string
         # The default set is every provider that has produced comparable committed results across
         # isolation technologies: e2b, daytona-vm (the LINUX_VM reference), modal-gvisor (Modal's default
-        # gVisor runtime), modal-vm (Modal's gVisor-free microVM), blaxel (stock base image), and novita
-        # (its own pre-baked template). modal-vm + blaxel graduated into the default once committed runs
-        # validated them. daytona-container is the one registered variant still opt-in (pass it explicitly);
+        # gVisor runtime), modal-vm (Modal's gVisor-free microVM), blaxel (stock base image), novita
+        # (its own pre-baked template), microsandbox-cloud, and vercel (the shared toolchain base
+        # mirrored into VCR). modal-vm + blaxel graduated into the default once committed runs validated
+        # them; microsandbox-cloud and vercel followed. daytona-container and microsandbox-local are the
+        # registered variants still opt-in (pass them explicitly);
         # `plan-providers` rejects any name that is not in the registry. Listed in registry order — the
         # plan re-sorts to registry order regardless, so the spelling here is cosmetic.
-        default: e2b,daytona-vm,blaxel,modal-gvisor,modal-vm,novita
+        #
+        # Vercel reports the fleet's smallest disk (~32 GB against the 40 GB target). That does not
+        # affect comparability — computeSpecMatched covers vCPUs and memory, the two axes providers are
+        # ranked on — but a disk-hungry suite will SKIP there and surface as a leaderboard coverage gap
+        # rather than a bad score. See packages/results/src/lib/specs.ts.
+        default: e2b,daytona-vm,blaxel,microsandbox-cloud,modal-gvisor,modal-vm,novita,vercel
       suites:
         description: 'Comma-separated suites to run (blank = every registered suite). E.g. "network" for a targeted pre-merge run.'
         required: false


### PR DESCRIPTION
## Summary

Adds `vercel` and `microsandbox-cloud` to the `bench-matrix` default provider set. Both have produced validated results at the pinned target spec — the bar the default set documents, and the same path `modal-vm` and `blaxel` took earlier.

```diff
- default: e2b,daytona-vm,blaxel,modal-gvisor,modal-vm,novita
+ default: e2b,daytona-vm,blaxel,microsandbox-cloud,modal-gvisor,modal-vm,novita,vercel
```

## Evidence

| Provider | PyBench p50 | Disk | Memory |
| --- | --- | --- | --- |
| microsandbox-cloud | 507 ms | 39.3 GB | 7.78 GiB |
| vercel | 766 ms | 31.9 GB | 8.21 GiB |

Vercel was validated on toolchain v7 in run [30729305848](https://github.com/starslingdev/hpc-sandbox-benchmarks/actions/runs/30729305848) — `validationStatus: validated`, `specMatched: true`, `suitesCovered: [system]`, `gaps: []`. Its numbers sit between modal-vm (672 ms) and e2b (802 ms): mid-fleet, no sign of a broken measurement.

## One caveat, documented in the comment

Vercel reports **~32 GB of disk against the 40 GB target** — the smallest in the fleet.

This does **not** affect comparability: `computeSpecMatched` deliberately covers only vCPUs and memory, the two axes providers are ranked on (`packages/results/src/lib/specs.ts:157-163`). But a disk-hungry suite will **skip** on Vercel and surface as an explicit leaderboard coverage gap rather than a bad score — worth knowing before anyone reads a sparse Vercel column as a regression.

The `system` suite runs fine in that space.

## Verification

- `actionlint` clean
- `@repo/repo-checks` drift gates: 203 pass / 0 fail
- `plan-providers` accepts the new list and resolves it in registry order

Ordering matches `PROVIDERS`; `plan-providers` re-sorts regardless, so it's cosmetic, but it keeps the diff readable against the registry.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add `vercel` and `microsandbox-cloud` to the default bench provider set so they run in default workflows. Both have validated results at the pinned target spec.

- **New Features**
  - Updated default providers to: `e2b,daytona-vm,blaxel,microsandbox-cloud,modal-gvisor,modal-vm,novita,vercel`.
  - Note: Vercel reports ~32 GB disk (vs 40 GB target). Comparability uses vCPUs and memory only; disk-heavy suites will skip on Vercel and show as coverage gaps.

<sup>Written for commit aa6d2f1e19e42a84083add3cd94c797d37e6bf7e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/starslingdev/hpc-sandbox-benchmarks/pull/332?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the default benchmark provider selection to include Microsandbox Cloud and Vercel.
  * Retained Daytona Container and Microsandbox Local as optional providers.
  * Documented Vercel’s smaller disk capacity and related benchmark coverage behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->