### PR TITLE
fix(ci): bot-landed leaderboard figures PR merge

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -20,4 +20,18 @@
 # Rendered by the leaderboard job alongside LEADERBOARD.md. Scoped to the generated `.webp` files at
 # one level, matching the job's `docs/figures/*.webp` fence — a hand-written doc or script added
 # under docs/figures/ stays owned.
+#
+# CODEOWNERS matches on path alone, so this cannot tell renderer output from a hand-authored WebP at
+# the same path. That residual is bounded and accepted rather than unnoticed:
+#   - ADDING one is already blocked — `leaderboard-artifact-sync` ("the figure directory holds
+#     exactly the charts the document links") fails CI on any file in docs/figures/ that
+#     LEADERBOARD.md does not link, so a new image cannot squat here.
+#   - REPLACING a linked chart with an image of the same pixel width is what remains: the gate
+#     verifies each file is a WebP of the promised geometry, not that Chrome produced it.
+#   - Landing that still needs repo WRITE access — the ruleset governs what may merge, not who may
+#     press merge, so this opens nothing to fork or drive-by PRs.
+# Do NOT "fix" this by listing the three charts literally: how many exist is a property of the
+# dataset, and hard-coding them is exactly what broke every leaderboard dispatch when #311 added a
+# fourth artifact. Tightening it properly means verifying raster provenance in the gate (re-render
+# under the pinned Chrome and compare), which is a separate change.
 /docs/figures/*.webp

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -3,13 +3,21 @@
 # https://docs.github.com/en/repositories/managing-your-repos-settings-and-features/customizing-your-repository/about-code-owners
 #
 # Everything is owned by default and the LAST matching entry wins; an entry with NO owner un-owns
-# its paths. Exactly two surfaces are deliberately unowned — the artifacts the github-actions bot
-# lands hands-off (docs/ci-secrets.md rules 5 and 7). A PR touching only those needs no code-owner
-# review; anything else — code, workflows, docs — requires @dbworku. In particular the leaderboard
+# its paths. Only the artifacts the github-actions bot lands hands-off are deliberately unowned
+# (docs/ci-secrets.md rules 5 and 7). A PR touching only those needs no code-owner review; anything
+# else — code, workflows, docs — requires @dbworku. In particular the leaderboard
 # renderer and its backing packages must stay owned: their output is committed by a job inside the
 # `privileged` environment, so unreviewed renderer changes would run with release credentials.
 * @dbworku
 
 # Bot-landed release artifacts — no owner, so the bot's direct merge needs no human review.
+# These must stay in lockstep with the path allowlists the landing jobs assert against
+# (`assert-paths-allowlisted.sh` in commit-dataset.yml and update-leaderboard.yml): an artifact the
+# bot commits but CODEOWNERS still owns requests a review from @dbworku, and the direct merge dies
+# on "the base branch policy prohibits the merge".
 /LEADERBOARD.md
 /data/dataset/
+# Rendered by the leaderboard job alongside LEADERBOARD.md. Scoped to the generated `.webp` files at
+# one level, matching the job's `docs/figures/*.webp` fence — a hand-written doc or script added
+# under docs/figures/ stays owned.
+/docs/figures/*.webp

--- a/docs/ci-secrets.md
+++ b/docs/ci-secrets.md
@@ -62,7 +62,7 @@ Ungated: `ci.yml`, `ci-lint.yml`, and the toolchain `pr-gate` (Docker smoke, no 
    Biome formats JSON, so an unformatted Run document would fail the PR — and aborts before opening a
    doomed PR on a miss. The push/PR step is idempotent: a re-run reuses the existing open PR instead of
    colliding on the deterministic branch. Leaderboard landing follows the same `GITHUB_TOKEN` + PR
-   pattern, path-fenced to exactly `LEADERBOARD.md` (rule 7).
+   pattern, path-fenced to exactly `LEADERBOARD.md` and `docs/figures/*.webp` (rule 7).
 
    > **`GITHUB_TOKEN` caveat.** A PR opened with the default `GITHUB_TOKEN` does **not** trigger
    > `ci.yml` (GitHub suppresses workflow events raised by the Actions token). So if the Biome/CI
@@ -259,10 +259,17 @@ Configure the `main` ruleset so the bot-authored dataset/leaderboard PRs can mer
      path allowlist.
 2. Keep [`.github/CODEOWNERS`](../.github/CODEOWNERS) owning **everything by default** (`*` owner)
    with ownerless overrides for exactly the bot-landed artifacts (`/LEADERBOARD.md`,
-   `/data/dataset/` — a CODEOWNERS entry with no owner un-owns its paths; last match wins). Those
-   two must stay unowned so code-owner review is not required for the bot's PRs; everything else —
-   in particular the leaderboard renderer and its backing packages, whose output a `privileged` job
-   commits — must stay owned so no code change can merge without maintainer review.
+   `/data/dataset/`, `/docs/figures/*.webp` — a CODEOWNERS entry with no owner un-owns its paths;
+   last match wins). Those must stay unowned so code-owner review is not required for the bot's PRs;
+   everything else — in particular the leaderboard renderer and its backing packages, whose output a
+   `privileged` job commits — must stay owned so no code change can merge without maintainer review.
+
+   > **Keep this list in lockstep with the landing jobs' path allowlists.** The un-owned set must be
+   > a superset of everything `assert-paths-allowlisted.sh` permits the bot to commit. Widening a
+   > job's fence without un-owning the new path is a silent break: the PR still opens, GitHub
+   > requests a code-owner review, and the direct merge fails with *"the base branch policy
+   > prohibits the merge"* — a red job on an otherwise-correct PR. This is exactly how #311 broke
+   > the leaderboard flow: it started committing `docs/figures/*.webp`, which `*` still owned.
 3. **Do not** add `github-actions` (or a broad actor) as a ruleset bypass. The bot does not need
    bypass when code-owner review is the only review requirement and its two landing paths are
    unowned.
@@ -271,7 +278,8 @@ Configure the `main` ruleset so the bot-authored dataset/leaderboard PRs can mer
    whose required check can never run would strand it behind a green job).
 
 With that posture: a fork/public PR that touches `/.github/` still needs `@dbworku`; a
-`leaderboard/update-*` PR that only changes `LEADERBOARD.md` merges as soon as the workflow opens it.
+`leaderboard/update-*` PR that only changes `LEADERBOARD.md` and its rendered `docs/figures/*.webp`
+merges as soon as the workflow opens it.
 
 ### Other Actions settings
 

--- a/docs/ci-secrets.md
+++ b/docs/ci-secrets.md
@@ -99,7 +99,7 @@ Ungated: `ci.yml`, `ci-lint.yml`, and the toolchain `pr-gate` (Docker smoke, no 
       (`GITHUB_TOKEN` — no extra App or PAT; requires the "Allow GitHub Actions to create and approve
       pull requests" toggle, see operator setup).
    2. Runs `scripts/assert-paths-allowlisted.sh` on the staged index **and** the PR file list; anything
-      other than `LEADERBOARD.md` aborts before any merge is attempted.
+      other than `LEADERBOARD.md` and `docs/figures/*.webp` aborts before any merge is attempted.
    3. Merges the PR with a direct `gh pr merge` (deliberately not `--auto`: on a `GITHUB_TOKEN` PR a
       required check never runs, so arming auto-merge could only ever strand the PR behind a green
       job). GitHub still enforces the ruleset on the merge call; this is not a bypass — it succeeds


### PR DESCRIPTION
`update-leaderboard.yml` has failed at its merge step on every run since #311 (runs [30712422375](https://github.com/starslingdev/hpc-sandbox-benchmarks/actions/runs/30712422375), [30737558605](https://github.com/starslingdev/hpc-sandbox-benchmarks/actions/runs/30737558605)). The PR opens fine; `gh pr merge` then dies with *"the base branch policy prohibits the merge"*.

Cause: #311 started committing `docs/figures/*.webp` alongside `LEADERBOARD.md` and widened the job's path fence to match, but CODEOWNERS still un-owned only `/LEADERBOARD.md` and `/data/dataset/`. The figures fell through to `* @dbworku`, so the ruleset's *Require review from Code Owners* requested a review from a human and blocked the bot's direct merge.

Fix is CODEOWNERS-only — **no repo setting or ruleset change**. The 0-review + code-owner posture and the no-bypass rule are unchanged; the figures are generated release artifacts exactly like `LEADERBOARD.md`, and the renderer that produces them stays owned. Scoped to `/docs/figures/*.webp` (not the whole directory) so it matches the job's fence exactly and any hand-written file added under `docs/figures/` stays owned.

Also documents the lockstep invariant between the un-owned set and the jobs' path allowlists, since widening a fence without un-owning the path is a silent break.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Un-owns the generated leaderboard figure files so the bot’s leaderboard PR can self-merge again. Scope matches the job fence; review posture stays the same.

- **Bug Fixes**
  - Added ownerless `docs/figures/*.webp` to `.github/CODEOWNERS` to prevent code-owner review from blocking `gh pr merge`.
  - Updated `docs/ci-secrets.md`: fixed the stale rule‑7 path sentence to include `docs/figures/*.webp`, documented lockstep with job allowlists, and noted the bounded residual of an ownerless glob (and why listing charts literally is the wrong fix).

<sup>Written for commit d64a15bdfda0d03e3f0a5167d21f0820ff2ff668. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/starslingdev/hpc-sandbox-benchmarks/pull/335?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified ownership guidance for generated leaderboard figure files.
  * Documented that rendered figure files are permitted in leaderboard automation pull requests.
  * Updated CI secret guidance to keep automated artifact paths aligned with repository ownership rules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->