### PR TITLE
Add run.cloud as a sandbox provider

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -38,6 +38,9 @@ MICROSANDBOX_LOCAL_BENCH=
 MSB_API_KEY=
 MSB_API_URL=
 
+# --- run.cloud (https://run.cloud) ---
+RUN_CLOUD_API_KEY=
+
 # --- Vercel Sandbox (https://vercel.com/docs/sandbox) ---
 # Short-lived project token consumed directly by the Vercel SDK. See the local validation flow in
 # packages/providers/README.md. Never put the long-lived VERCEL_TOKEN bootstrap credential here.

--- a/.github/workflows/bench-smoke.yml
+++ b/.github/workflows/bench-smoke.yml
@@ -65,6 +65,7 @@ on:
             namespace,
             microsandbox-local,
             microsandbox-cloud,
+            runcloud,
           ]
       suite:
         # Constrained to the SUITE_NAMES registry (packages/schema/src/suites.ts); the

--- a/.github/workflows/bench-suite.yml
+++ b/.github/workflows/bench-suite.yml
@@ -256,6 +256,7 @@ jobs:
           BL_API_KEY: ${{ matrix.provider == 'blaxel' && secrets.BL_API_KEY || '' }}
           BL_WORKSPACE: ${{ matrix.provider == 'blaxel' && secrets.BL_WORKSPACE || '' }}
           NOVITA_API_KEY: ${{ matrix.provider == 'novita' && secrets.NOVITA_API_KEY || '' }}
+          RUN_CLOUD_API_KEY: ${{ matrix.provider == 'runcloud' && secrets.RUN_CLOUD_API_KEY || '' }}
           # OIDC-federated per-cell token file (see the Namespace step above). Not a stored secret: it is
           # empty unless THIS cell is the namespace cell AND the mint succeeded (the step only runs when
           # matrix.provider == 'namespace', and only writes the output once `nsc token create` returned),

--- a/.github/workflows/toolchain-image.yml
+++ b/.github/workflows/toolchain-image.yml
@@ -719,7 +719,9 @@ jobs:
           MODAL_TOKEN_ID: ${{ secrets.MODAL_TOKEN_ID }}
           MODAL_TOKEN_SECRET: ${{ secrets.MODAL_TOKEN_SECRET }}
           NOVITA_API_KEY: ${{ secrets.NOVITA_API_KEY }}
-          RUN_CLOUD_API_KEY: ${{ secrets.RUN_CLOUD_API_KEY }}
+          # A scoped promote imports every provider module in one process. Keep the run.cloud key out
+          # of that process unless the resolved release plan will actually re-validate runcloud.
+          RUN_CLOUD_API_KEY: ${{ contains(fromJSON(needs.plan.outputs.matrix).include.*.provider, 'runcloud') && secrets.RUN_CLOUD_API_KEY || '' }}
           # Namespace's re-validation boot reads this OIDC-federated token file (see the Namespace CLI
           # steps above). Not a stored secret: empty when the exchange/mint was skipped/failed, which
           # skips namespace's re-validation without failing the promote (namespace is not in --require).

--- a/.github/workflows/toolchain-image.yml
+++ b/.github/workflows/toolchain-image.yml
@@ -454,16 +454,16 @@ jobs:
       # the fleet runs — Vercel injects its own session agent at boot, so there is no provider delta to
       # bake in and no separate GHCR image to keep in step.
       #
-      # SOURCE_REF comes from the plan, not from `config` or the build job, and that is load-bearing: on
-      # a backfill it names the PUBLISHED version, while the mutable candidate tag may already have moved
-      # on toward the next one. Mirroring the candidate there would verify one image and ship another,
-      # and nothing downstream would catch it — promote's drift check exempts vercel precisely because
-      # its version artifact is a retag of whatever was mirrored here. See releaseBaseTag().
+      # SOURCE_REF follows the same resolved source as every bake cell. A full build uses that job's
+      # immutable output digest; a build-skipped backfill uses the plan's PUBLISHED version, while the
+      # mutable candidate may already have moved toward the next release. Mirroring any other ref would
+      # verify one image and ship another, and promote cannot catch it because Vercel's version artifact
+      # is a retag of whatever was mirrored here. See releaseBaseTag().
       - name: Mirror the toolchain base into VCR
         if: matrix.provider == 'vercel' && steps.vercel-auth.outcome == 'success'
         id: vercel-vcr
         env:
-          SOURCE_REF: ${{ needs.plan.outputs.image-source }}
+          SOURCE_REF: ${{ needs.build.outputs.base-digest-ref || needs.plan.outputs.image-source }}
           # `vercel vcr push` is a CLI call, so it needs CLI credentials of its own — the vercel-auth
           # composite's docker login covers the REGISTRY, not the CLI, and its `--token` lives in that
           # composite's step env, which does not carry across steps. Without this the push dies with

--- a/.github/workflows/toolchain-image.yml
+++ b/.github/workflows/toolchain-image.yml
@@ -29,10 +29,10 @@ name: Toolchain image
 #              already-published version and never rewrites the public base or anyone else's artifact.
 #              A scoped dispatch names what it wants, so every provider it names is REQUIRED.
 #   build      `full` rebuilds the base (the default; what a version bump needs). `skip` skips the
-#              build job outright and derives everything from what the registry already holds — which
-#              for a scoped backfill is the PUBLISHED base, so the new provider gets exactly the bytes
-#              the fleet already runs (the toolchain build is not reproducible, so a rebuild would
-#              quietly hand it a different `:vN`).
+#              build job outright and derives everything from what the registry already holds. A
+#              scoped release is a backfill and therefore REQUIRES `skip`: its source is the PUBLISHED
+#              base, so the new provider gets exactly the bytes the fleet already runs (the toolchain
+#              build is not reproducible, so a rebuild would quietly hand it a different `:vN`).
 #   promote    off ⇒ the publish job is skipped: bake + verify, look at the report, promote later.
 #
 # The canonical use is adding a provider to a version everyone else already runs — e.g. Vercel on v7:
@@ -59,7 +59,7 @@ on:
         type: string
         default: ""
       build:
-        description: "Build phase: full (rebuild the base) / skip (reuse what the registry holds)"
+        description: "Build: full (rebuild base) / skip (reuse registry; required when providers is scoped)"
         type: choice
         options: [full, skip]
         default: full

--- a/.github/workflows/toolchain-image.yml
+++ b/.github/workflows/toolchain-image.yml
@@ -520,6 +520,8 @@ jobs:
           MODAL_TOKEN_SECRET: ${{ (matrix.provider == 'modal-gvisor' || matrix.provider == 'modal-vm') && secrets.MODAL_TOKEN_SECRET || '' }}
           # Optional: a missing NOVITA_API_KEY skips the novita bake without failing the release.
           NOVITA_API_KEY: ${{ matrix.provider == 'novita' && secrets.NOVITA_API_KEY || '' }}
+          # run.cloud boots the candidate OCI image directly; the key is needed only for its validate boot.
+          RUN_CLOUD_API_KEY: ${{ matrix.provider == 'runcloud' && secrets.RUN_CLOUD_API_KEY || '' }}
           # Namespace pulls the candidate image directly (no bake artifact) — its validate boot reads
           # this OIDC-federated token file (see the Namespace CLI steps above). Not a stored secret:
           # empty unless THIS is the namespace cell AND the mint succeeded, which the harness reads as
@@ -717,6 +719,7 @@ jobs:
           MODAL_TOKEN_ID: ${{ secrets.MODAL_TOKEN_ID }}
           MODAL_TOKEN_SECRET: ${{ secrets.MODAL_TOKEN_SECRET }}
           NOVITA_API_KEY: ${{ secrets.NOVITA_API_KEY }}
+          RUN_CLOUD_API_KEY: ${{ secrets.RUN_CLOUD_API_KEY }}
           # Namespace's re-validation boot reads this OIDC-federated token file (see the Namespace CLI
           # steps above). Not a stored secret: empty when the exchange/mint was skipped/failed, which
           # skips namespace's re-validation without failing the promote (namespace is not in --require).

--- a/.github/workflows/toolchain-image.yml
+++ b/.github/workflows/toolchain-image.yml
@@ -362,8 +362,9 @@ jobs:
           diagnostics: build-metadata-${{ github.run_id }}
 
   # BAKE + verify: one matrix cell per provider (from the plan). Each cell bakes its candidate artifact
-  # from the pushed candidate base and validates it by booting a sandbox and running the shared smoke
-  # spec. fail-fast: false so a flaky provider doesn't cancel the others' diagnostics — but ANY cell
+  # from the plan-selected base (the pushed candidate for a full release, published version for a
+  # backfill) and validates it by booting a sandbox and running the shared smoke spec. fail-fast: false
+  # so a flaky provider doesn't cancel the others' diagnostics — but ANY cell
   # that RAN and failed still fails this job (and, being a `needs`, blocks promote). Required cells
   # (plan `required`) additionally pass `--require`, so a missing/misnamed secret fails the cell instead
   # of silently skipping a provider the release must ship.
@@ -504,6 +505,10 @@ jobs:
         env:
           PROVIDER: ${{ matrix.provider }}
           REQUIRED: ${{ matrix.required }}
+          # Pin every cell to the one base selected by the release plan. A full build supplies its
+          # immutable output digest; a build-skipped scoped backfill supplies the published version,
+          # never the mutable candidate that may already contain the next release's bytes.
+          BASE_IMAGE_REF: ${{ needs.build.outputs.base-digest-ref || needs.plan.outputs.image-source }}
           E2B_API_KEY: ${{ matrix.provider == 'e2b' && secrets.E2B_API_KEY || '' }}
           # Both Daytona isolation variants share the account key and bake in their own region.
           DAYTONA_API_KEY: ${{ (matrix.provider == 'daytona-vm' || matrix.provider == 'daytona-container') && secrets.DAYTONA_API_KEY || '' }}
@@ -537,7 +542,7 @@ jobs:
           VERCEL_CANDIDATE_IMAGE: ${{ steps.vercel-vcr.outcome == 'success' && steps.vercel-vcr.outputs.digest-ref || '' }}
         run: |
           set -euo pipefail
-          args=(--provider "${PROVIDER}")
+          args=(--provider "${PROVIDER}" --base-image "${BASE_IMAGE_REF}")
           # Required providers must not silently skip: --require fails the cell if this provider's
           # secret is missing/misnamed or it fails to validate.
           if [ "${REQUIRED}" = "true" ]; then args+=(--require "${PROVIDER}"); fi
@@ -580,12 +585,12 @@ jobs:
           scope: ${{ needs.plan.outputs.providers }}
           source-ref: ${{ github.sha }}
           # The build job may have been skipped (`build: skip`), leaving its outputs empty — fall back
-          # to the candidate tag the plan resolved, which is the ref this cell baked against anyway.
-          image: ${{ needs.build.outputs.base-digest-ref || needs.plan.outputs.image-candidate }}
-          base-image: ${{ needs.build.outputs.base-digest-ref || needs.plan.outputs.image-candidate }}
+          # to the plan's source (the published version for a scoped backfill, candidate otherwise).
+          image: ${{ needs.build.outputs.base-digest-ref || needs.plan.outputs.image-source }}
+          base-image: ${{ needs.build.outputs.base-digest-ref || needs.plan.outputs.image-source }}
           provider-target: ${{ matrix.provider }}
           size-tier: ${{ needs.plan.outputs.size-tier }}
-          verify: bun apps/cli/src/bin/bake.ts --provider ${{ matrix.provider }}${{ matrix.required && format(' --require {0}', matrix.provider) || '' }}
+          verify: bun apps/cli/src/bin/bake.ts --provider ${{ matrix.provider }} --base-image ${{ needs.build.outputs.base-digest-ref || needs.plan.outputs.image-source }}${{ matrix.required && format(' --require {0}', matrix.provider) || '' }}
           diagnostics: bake-${{ matrix.provider }}-${{ github.run_id }}
 
   # PROMOTE: the serialized publication barrier and the ONLY job that mutates the public :v1. Runs only
@@ -768,9 +773,10 @@ jobs:
           mode: ${{ needs.plan.outputs.mode }}
           scope: ${{ needs.plan.outputs.providers }}
           source-ref: ${{ github.sha }}
-          # Empty when the build job was skipped (`build: skip`) — fall back to the planned candidate tag.
-          image: ${{ needs.build.outputs.base-digest-ref || needs.plan.outputs.image-candidate }}
-          base-image: ${{ needs.build.outputs.base-digest-ref || needs.plan.outputs.image-candidate }}
+          # Empty when the build job was skipped (`build: skip`) — fall back to the same plan-selected
+          # source the partial promote re-validates (published version for a backfill, candidate otherwise).
+          image: ${{ needs.build.outputs.base-digest-ref || needs.plan.outputs.image-source }}
+          base-image: ${{ needs.build.outputs.base-digest-ref || needs.plan.outputs.image-source }}
           size-tier: ${{ needs.plan.outputs.size-tier }}
           verify: bun apps/cli/src/bin/bake.ts --promote --require ${{ needs.plan.outputs.required }} --provider ${{ needs.plan.outputs.providers }}${{ inputs.force_republish && ' --force' || '' }}
           published: ${{ needs.plan.outputs.publish-target }}

--- a/apps/cli/src/bin/bake.test.ts
+++ b/apps/cli/src/bin/bake.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { requestedProviders } from "./bake.ts";
+import { requestedBaseImage, requestedProviders } from "./bake.ts";
 
 describe("requestedProviders", () => {
 	test("no flag → undefined (drive every registered provider, the local default)", () => {
@@ -28,5 +28,26 @@ describe("requestedProviders", () => {
 			/requires at least one provider/,
 		);
 		expect(() => requestedProviders(["--provider", " "])).toThrow(/requires at least one provider/);
+	});
+});
+
+describe("requestedBaseImage", () => {
+	test("defaults to undefined so local bakes keep the configured candidate", () => {
+		expect(requestedBaseImage(["--provider", "runcloud"])).toBeUndefined();
+	});
+
+	test("accepts the release plan's base as a separate or equals-form argument", () => {
+		expect(requestedBaseImage(["--base-image", "ghcr.io/o/tc@sha256:abc"])).toBe(
+			"ghcr.io/o/tc@sha256:abc",
+		);
+		expect(requestedBaseImage(["--base-image=ghcr.io/o/tc:v1"])).toBe("ghcr.io/o/tc:v1");
+	});
+
+	test("rejects a present-but-empty base ref", () => {
+		expect(() => requestedBaseImage(["--base-image"])).toThrow(/non-empty image reference/);
+		expect(() => requestedBaseImage(["--base-image="])).toThrow(/non-empty image reference/);
+		expect(() => requestedBaseImage(["--base-image", "--provider", "runcloud"])).toThrow(
+			/non-empty image reference/,
+		);
 	});
 });

--- a/apps/cli/src/bin/bake.ts
+++ b/apps/cli/src/bin/bake.ts
@@ -11,7 +11,7 @@
 import { writeFileSync } from "node:fs";
 import { requiredProviders, unmetRequirements } from "@sandbox-benchmarks/harness";
 import type { ProviderConfig } from "@sandbox-benchmarks/providers";
-import { config } from "@sandbox-benchmarks/providers";
+import { config, drainRuncloudBackgroundWork } from "@sandbox-benchmarks/providers";
 import type { ProviderId } from "@sandbox-benchmarks/schema";
 import { PROVIDERS } from "@sandbox-benchmarks/schema";
 import { bakeDaytonaContainerSnapshot, bakeDaytonaVmSnapshot } from "../lib/bake/daytona.ts";
@@ -192,6 +192,7 @@ if (import.meta.main) {
 		// `{ status: "failed" }` report. So a single `some(failed)` is the whole exit contract — re-deriving
 		// `unmet` here would mislabel an early abort (e.g. "version already exists") as a provider-credentials
 		// failure, since the early `reports` carry no provider "ok" entries.
+		await drainRuncloudBackgroundWork();
 		process.exit(promoted.some((r) => r.status === "failed") ? 1 : 0);
 	}
 
@@ -294,6 +295,10 @@ if (import.meta.main) {
 		},
 		reports,
 	});
+
+	// Candidate validation can exercise run.cloud. Its retained failed-create cleanup must finish before
+	// either explicit failure exit below terminates the process.
+	await drainRuncloudBackgroundWork();
 
 	if (anyFailed(runs)) process.exit(1);
 

--- a/apps/cli/src/bin/bake.ts
+++ b/apps/cli/src/bin/bake.ts
@@ -114,6 +114,30 @@ export function requestedProviders(argv: string[]): ProviderId[] | undefined {
 	return selectProviders(raw);
 }
 
+/**
+ * Optional immutable/shared base ref for the bake phase. CI always supplies the release plan's
+ * resolved source: the just-built candidate digest for a full release, or the published version for
+ * a scoped backfill. Local runs omit it and retain the mutable candidate default.
+ */
+export function requestedBaseImage(argv: string[]): string | undefined {
+	let raw: string | undefined;
+	const eq = argv.find((arg) => arg.startsWith("--base-image="));
+	if (eq) {
+		raw = eq.slice("--base-image=".length);
+	} else {
+		const i = argv.indexOf("--base-image");
+		if (i !== -1) {
+			const next = argv[i + 1];
+			raw = next !== undefined && !next.startsWith("-") ? next : "";
+		}
+	}
+	if (raw === undefined) return undefined;
+	if (raw.trim() === "") {
+		throw new Error("--base-image requires a non-empty image reference");
+	}
+	return raw;
+}
+
 if (import.meta.main) {
 	const log: Log = (m) => console.error(m);
 
@@ -121,8 +145,10 @@ if (import.meta.main) {
 	// provider); on the promote path it scopes the transaction to a backfill. Parsed before any build
 	// or registry call so a typo'd id fails fast (clean message, no stack) before anything is touched.
 	let only: ProviderId[] | undefined;
+	let baseImageRef: string;
 	try {
 		only = requestedProviders(process.argv);
+		baseImageRef = requestedBaseImage(process.argv) ?? config.toolchainImageCandidate;
 	} catch (err) {
 		log(`error: ${err instanceof Error ? err.message : String(err)}`);
 		process.exit(2);
@@ -190,26 +216,26 @@ if (import.meta.main) {
 	// never reads — under `build: skip` that ref may legitimately be stale or absent, and failing there
 	// would break the one flow the scoped release exists for.
 	const needsBase = (only ?? PROVIDERS.map((p) => p.id)).some((id) => baseImageUse(id) !== "none");
-	let pinnedCandidateImage: string = config.toolchainImageCandidate;
+	let pinnedBaseImage = baseImageRef;
 	if (needsBase) {
 		try {
-			pinnedCandidateImage = await resolveImageDigestRef(config.toolchainImageCandidate);
-			log(`>>> candidate image pinned for validation: ${pinnedCandidateImage}`);
+			pinnedBaseImage = await resolveImageDigestRef(baseImageRef);
+			log(`>>> base image pinned for validation: ${pinnedBaseImage}`);
 		} catch (err) {
 			log(
-				`<<< could not resolve candidate image digest — ${err instanceof Error ? err.message : String(err)}`,
+				`<<< could not resolve base image digest for ${baseImageRef} — ${err instanceof Error ? err.message : String(err)}`,
 			);
 			process.exit(1);
 		}
 	} else {
-		log(`>>> no provider in scope reads ${config.toolchainImageCandidate} — not resolving it`);
+		log(`>>> no provider in scope reads ${baseImageRef} — not resolving it`);
 	}
 	const candidateRefs = {
 		e2bTemplateCandidate: config.e2bTemplateCandidate,
 		daytonaSnapshotCandidate: config.daytonaSnapshotCandidate,
 		daytonaContainerSnapshotCandidate: config.daytonaContainerSnapshotCandidate,
 		novitaTemplateCandidate: config.novitaTemplateCandidate,
-		toolchainImageCandidate: pinnedCandidateImage,
+		toolchainImageCandidate: pinnedBaseImage,
 		vercelImageCandidate: config.vercelImageCandidate,
 		daytonaVmTarget: config.daytonaVm.target,
 		daytonaContainerTarget: config.daytonaContainer.target,
@@ -218,7 +244,7 @@ if (import.meta.main) {
 	const runs = await forEachProviderWithCreds(
 		async (provider) => {
 			log(`>>> ${provider.name}: baking candidate…`);
-			await bakers[provider.name](pinnedCandidateImage, (m) => log(`    ${m}`));
+			await bakers[provider.name](pinnedBaseImage, (m) => log(`    ${m}`));
 
 			log(`>>> ${provider.name}: validating (boot + smoke)…`);
 			// Boot the just-baked candidate (override the registry adapter's version create-options).
@@ -260,7 +286,7 @@ if (import.meta.main) {
 
 	writeReport({
 		candidate: {
-			image: pinnedCandidateImage,
+			image: pinnedBaseImage,
 			e2bTemplate: config.e2bTemplateCandidate,
 			daytonaSnapshot: config.daytonaSnapshotCandidate,
 			daytonaContainerSnapshot: config.daytonaContainerSnapshotCandidate,

--- a/apps/cli/src/bin/bake.ts
+++ b/apps/cli/src/bin/bake.ts
@@ -58,6 +58,9 @@ const bakers: Record<ProviderId, (image: string, log: Log) => Promise<void>> = {
 	vercel: async (_image, log) => {
 		log("vercel boots the candidate image mirrored to VCR — no separate sandbox artifact to bake");
 	},
+	runcloud: async (_image, log) => {
+		log("runcloud boots the candidate image directly — no candidate artifact to bake");
+	},
 };
 
 /**

--- a/apps/cli/src/bin/bake.ts
+++ b/apps/cli/src/bin/bake.ts
@@ -170,29 +170,35 @@ if (import.meta.main) {
 			);
 			process.exit(2);
 		}
-		const promoted = await promoteAll(log, { force, only });
-		writeReport({
-			// The scope is recorded alongside the version names because those names are the FULL set the
-			// version owns — on a partial promote most of them were not touched, and the payload has to
-			// say which run this was rather than leave a reader to infer it from `reports`.
-			scope: only ?? PROVIDERS.map((p) => p.id),
-			partial: isPartialScope(only),
-			version: {
-				image: config.toolchainImageVersion,
-				e2bTemplate: config.e2bTemplateVersion,
-				daytonaSnapshot: config.daytonaSnapshotDefault,
-				daytonaContainerSnapshot: config.daytonaContainerSnapshotDefault,
-				novitaTemplate: config.novitaTemplateVersion,
-			},
-			reports: promoted,
-		});
+		let promoted: Awaited<ReturnType<typeof promoteAll>>;
+		try {
+			promoted = await promoteAll(log, { force, only });
+			writeReport({
+				// The scope is recorded alongside the version names because those names are the FULL set the
+				// version owns — on a partial promote most of them were not touched, and the payload has to
+				// say which run this was rather than leave a reader to infer it from `reports`.
+				scope: only ?? PROVIDERS.map((p) => p.id),
+				partial: isPartialScope(only),
+				version: {
+					image: config.toolchainImageVersion,
+					e2bTemplate: config.e2bTemplateVersion,
+					daytonaSnapshot: config.daytonaSnapshotDefault,
+					daytonaContainerSnapshot: config.daytonaContainerSnapshotDefault,
+					novitaTemplate: config.novitaTemplateVersion,
+				},
+				reports: promoted,
+			});
+		} finally {
+			// Promotion can validate run.cloud before writing its report. Preserve teardown even if either
+			// operation throws instead of returning a structured failed report.
+			await drainRuncloudBackgroundWork();
+		}
 		// promoteAll is self-gating: the D1 required-providers gate (CI passes `--require e2b,daytona-vm,modal-gvisor`)
 		// runs INSIDE promoteAll before the immutable base is written, and every abort path (version already
 		// published, candidate re-validation failed, artifact failed, unmet requirements) pushes a structured
 		// `{ status: "failed" }` report. So a single `some(failed)` is the whole exit contract — re-deriving
 		// `unmet` here would mislabel an early abort (e.g. "version already exists") as a provider-credentials
 		// failure, since the early `reports` carry no provider "ok" entries.
-		await drainRuncloudBackgroundWork();
 		process.exit(promoted.some((r) => r.status === "failed") ? 1 : 0);
 	}
 
@@ -285,20 +291,22 @@ if (import.meta.main) {
 		...(run.value && run.value.checks.length > 0 ? { checks: run.value.checks } : {}),
 	}));
 
-	writeReport({
-		candidate: {
-			image: pinnedBaseImage,
-			e2bTemplate: config.e2bTemplateCandidate,
-			daytonaSnapshot: config.daytonaSnapshotCandidate,
-			daytonaContainerSnapshot: config.daytonaContainerSnapshotCandidate,
-			novitaTemplate: config.novitaTemplateCandidate,
-		},
-		reports,
-	});
-
-	// Candidate validation can exercise run.cloud. Its retained failed-create cleanup must finish before
-	// either explicit failure exit below terminates the process.
-	await drainRuncloudBackgroundWork();
+	try {
+		writeReport({
+			candidate: {
+				image: pinnedBaseImage,
+				e2bTemplate: config.e2bTemplateCandidate,
+				daytonaSnapshot: config.daytonaSnapshotCandidate,
+				daytonaContainerSnapshot: config.daytonaContainerSnapshotCandidate,
+				novitaTemplate: config.novitaTemplateCandidate,
+			},
+			reports,
+		});
+	} finally {
+		// Candidate validation can exercise run.cloud. Its retained failed-create cleanup must finish even
+		// when report output throws, and before either explicit failure exit below terminates the process.
+		await drainRuncloudBackgroundWork();
+	}
 
 	if (anyFailed(runs)) process.exit(1);
 

--- a/apps/cli/src/bin/bench-lifecycle.ts
+++ b/apps/cli/src/bin/bench-lifecycle.ts
@@ -14,6 +14,7 @@ import {
 	requiredProviders,
 	unmetRequirements,
 } from "@sandbox-benchmarks/harness";
+import { drainRuncloudBackgroundWork } from "@sandbox-benchmarks/providers";
 import type { LifecycleMetricSummary } from "../lib/lifecycle-summary.ts";
 import {
 	formatLifecycleLines,
@@ -86,6 +87,10 @@ if (import.meta.main) {
 			: {}),
 	}));
 	console.log(JSON.stringify({ summary }, null, 2));
+
+	// A timed-out run.cloud create can return a handle during teardown. Do not let the explicit failure
+	// exits below terminate that tracked cleanup while the billable sandbox is still being destroyed.
+	await drainRuncloudBackgroundWork();
 
 	// Skips (missing creds) never fail the run; only a provider that ran and broke does.
 	if (anyFailed(runs)) process.exit(1);

--- a/apps/cli/src/bin/bench-lifecycle.ts
+++ b/apps/cli/src/bin/bench-lifecycle.ts
@@ -86,11 +86,13 @@ if (import.meta.main) {
 				}
 			: {}),
 	}));
-	console.log(JSON.stringify({ summary }, null, 2));
-
-	// A timed-out run.cloud create can return a handle during teardown. Do not let the explicit failure
-	// exits below terminate that tracked cleanup while the billable sandbox is still being destroyed.
-	await drainRuncloudBackgroundWork();
+	try {
+		console.log(JSON.stringify({ summary }, null, 2));
+	} finally {
+		// A timed-out run.cloud create can return a handle during teardown. Output/reporting failures and
+		// the explicit exits below must not terminate cleanup while the sandbox is still being destroyed.
+		await drainRuncloudBackgroundWork();
+	}
 
 	// Skips (missing creds) never fail the run; only a provider that ran and broke does.
 	if (anyFailed(runs)) process.exit(1);

--- a/apps/cli/src/bin/bench-smoke.ts
+++ b/apps/cli/src/bin/bench-smoke.ts
@@ -11,6 +11,7 @@
 // captured output); the machine-readable summary is the JSON on stdout. bun auto-loads .env, so
 // local creds in a .env file are picked up.
 import { requiredProviders, unmetRequirements } from "@sandbox-benchmarks/harness";
+import { drainRuncloudBackgroundWork } from "@sandbox-benchmarks/providers";
 import { anyFailed, forEachProviderWithCreds } from "../lib/providers-run.ts";
 import { bootAndSmoke, logChecks, smokeFailureReason, smokeOk } from "../lib/smoke-run.ts";
 
@@ -45,6 +46,10 @@ if (import.meta.main) {
 		...(run.value && run.value.checks.length > 0 ? { checks: run.value.checks } : {}),
 	}));
 	console.log(JSON.stringify({ summary }, null, 2));
+
+	// A timed-out run.cloud create can return a handle during teardown. Do not let the explicit failure
+	// exits below terminate that tracked cleanup while the billable sandbox is still being destroyed.
+	await drainRuncloudBackgroundWork();
 
 	// Skips never fail the run; only a provider that ran and broke does.
 	if (anyFailed(runs)) process.exit(1);

--- a/apps/cli/src/bin/bench-smoke.ts
+++ b/apps/cli/src/bin/bench-smoke.ts
@@ -45,11 +45,13 @@ if (import.meta.main) {
 		...(run.durationMs !== undefined ? { durationMs: run.durationMs } : {}),
 		...(run.value && run.value.checks.length > 0 ? { checks: run.value.checks } : {}),
 	}));
-	console.log(JSON.stringify({ summary }, null, 2));
-
-	// A timed-out run.cloud create can return a handle during teardown. Do not let the explicit failure
-	// exits below terminate that tracked cleanup while the billable sandbox is still being destroyed.
-	await drainRuncloudBackgroundWork();
+	try {
+		console.log(JSON.stringify({ summary }, null, 2));
+	} finally {
+		// A timed-out run.cloud create can return a handle during teardown. Output/reporting failures and
+		// the explicit exits below must not terminate cleanup while the sandbox is still being destroyed.
+		await drainRuncloudBackgroundWork();
+	}
 
 	// Skips never fail the run; only a provider that ran and broke does.
 	if (anyFailed(runs)) process.exit(1);

--- a/apps/cli/src/bin/bench-suite.ts
+++ b/apps/cli/src/bin/bench-suite.ts
@@ -757,21 +757,24 @@ if (import.meta.main) {
 			...(singleReplicate !== undefined ? { replicateIndex: singleReplicate } : {}),
 			required,
 		});
-		await reportCell({
-			provider,
-			suite,
-			runId,
-			sha,
-			outFile: outcome.outFile,
-			...(outcome.run ? { run: outcome.run } : {}),
-			failed: outcome.failed,
-			durationMs: outcome.durationMs,
-			...(outcome.detail !== undefined ? { detail: outcome.detail } : {}),
-			...(taskPlan ? { taskPlan } : {}),
-		});
-		// run.cloud may still be destroying an allocation whose create response lost a deadline race.
-		// Drain that tracked work before fail()/process.exit() can terminate its promise continuation.
-		await drainRuncloudBackgroundWork();
+		try {
+			await reportCell({
+				provider,
+				suite,
+				runId,
+				sha,
+				outFile: outcome.outFile,
+				...(outcome.run ? { run: outcome.run } : {}),
+				failed: outcome.failed,
+				durationMs: outcome.durationMs,
+				...(outcome.detail !== undefined ? { detail: outcome.detail } : {}),
+				...(taskPlan ? { taskPlan } : {}),
+			});
+		} finally {
+			// run.cloud may still be destroying an allocation whose create response lost a deadline race.
+			// A failed summary write must not bypass that work on its way out of the process.
+			await drainRuncloudBackgroundWork();
+		}
 		if (outcome.failed) fail(outcome.detail ?? `Cell ${cell} failed`, { annotate: false });
 		process.exit(0);
 	}
@@ -838,16 +841,19 @@ if (import.meta.main) {
 		}),
 	);
 
-	await reportFleet({
-		provider,
-		suite,
-		runId,
-		sha,
-		outcomes,
-		...(taskPlan ? { taskPlan } : {}),
-	});
-	// See the single-sandbox path above. This is a no-op unless run.cloud retained a late response.
-	await drainRuncloudBackgroundWork();
+	try {
+		await reportFleet({
+			provider,
+			suite,
+			runId,
+			sha,
+			outcomes,
+			...(taskPlan ? { taskPlan } : {}),
+		});
+	} finally {
+		// See the single-sandbox path above. This is a no-op unless run.cloud retained a late response.
+		await drainRuncloudBackgroundWork();
+	}
 
 	const failures = outcomes.filter((o) => o.failed);
 	if (failures.length > 0) {

--- a/apps/cli/src/bin/bench-suite.ts
+++ b/apps/cli/src/bin/bench-suite.ts
@@ -21,6 +21,7 @@ import {
 	SuiteUsageError,
 	unmetRequirements,
 } from "@sandbox-benchmarks/harness";
+import { drainRuncloudBackgroundWork } from "@sandbox-benchmarks/providers";
 import { writeNormalizedRun } from "@sandbox-benchmarks/results";
 import type { Run, SuiteName } from "@sandbox-benchmarks/schema";
 import { SUITES } from "@sandbox-benchmarks/schema";
@@ -768,6 +769,9 @@ if (import.meta.main) {
 			...(outcome.detail !== undefined ? { detail: outcome.detail } : {}),
 			...(taskPlan ? { taskPlan } : {}),
 		});
+		// run.cloud may still be destroying an allocation whose create response lost a deadline race.
+		// Drain that tracked work before fail()/process.exit() can terminate its promise continuation.
+		await drainRuncloudBackgroundWork();
 		if (outcome.failed) fail(outcome.detail ?? `Cell ${cell} failed`, { annotate: false });
 		process.exit(0);
 	}
@@ -842,6 +846,8 @@ if (import.meta.main) {
 		outcomes,
 		...(taskPlan ? { taskPlan } : {}),
 	});
+	// See the single-sandbox path above. This is a no-op unless run.cloud retained a late response.
+	await drainRuncloudBackgroundWork();
 
 	const failures = outcomes.filter((o) => o.failed);
 	if (failures.length > 0) {

--- a/apps/cli/src/bin/release-plan.test.ts
+++ b/apps/cli/src/bin/release-plan.test.ts
@@ -8,6 +8,7 @@ import {
 } from "./release-plan.ts";
 
 const base = { sourceRef: "abc123", forceRepublish: false, alreadyPublished: false };
+const backfillBase = { ...base, build: "skip" as const };
 const ALL_PROVIDERS = PROVIDERS.map((p) => p.id);
 
 describe("buildReleasePlan mode + skip", () => {
@@ -33,7 +34,11 @@ describe("buildReleasePlan mode + skip", () => {
 	// The reason the scoped path exists: v7 was published for every provider except the one being added,
 	// so the early skip would otherwise kill the run before it could backfill anything.
 	test("a scoped release runs against an already-published version (mode backfill, skip false)", () => {
-		const plan = buildReleasePlan({ ...base, alreadyPublished: true, providers: "vercel" });
+		const plan = buildReleasePlan({
+			...backfillBase,
+			alreadyPublished: true,
+			providers: "vercel",
+		});
 		expect(plan.mode).toBe("backfill");
 		expect(plan.partial).toBe(true);
 		expect(plan.skip).toBe(false);
@@ -81,7 +86,7 @@ describe("buildReleasePlan matrix", () => {
 	});
 
 	test("a scoped dispatch emits only its own cells", () => {
-		const plan = buildReleasePlan({ ...base, providers: "vercel" });
+		const plan = buildReleasePlan({ ...backfillBase, providers: "vercel" });
 		expect(plan.matrix.include).toEqual([{ provider: "vercel", required: true }]);
 		expect(plan.providers.map((p) => p.provider)).toEqual(["vercel"]);
 	});
@@ -89,7 +94,10 @@ describe("buildReleasePlan matrix", () => {
 	// A named provider that could still skip on a missing secret would report a green release that
 	// published nothing — the exact failure the scoped path is meant to make impossible.
 	test("every provider a partial dispatch names is required, even a normally best-effort one", () => {
-		const plan = buildReleasePlan({ ...base, providers: "daytona-container,novita" });
+		const plan = buildReleasePlan({
+			...backfillBase,
+			providers: "daytona-container,novita",
+		});
 		expect(plan.required).toEqual(["daytona-container", "novita"]);
 		expect(plan.matrix.include.every((c) => c.required)).toBe(true);
 	});
@@ -140,6 +148,15 @@ describe("buildReleasePlan phases", () => {
 		expect(plan.build).toBe("skip");
 		expect(plan.promote).toBe(false);
 	});
+
+	test("refuses to rebuild an unrelated candidate during a scoped backfill", () => {
+		expect(() => buildReleasePlan({ ...base, providers: "runcloud" })).toThrow(
+			/scoped release.*requires `build: skip`/,
+		);
+		expect(() =>
+			buildReleasePlan({ ...base, providers: "runcloud", build: "full", promote: false }),
+		).toThrow(/scoped release.*requires `build: skip`/);
+	});
 });
 
 describe("buildReleasePlan packages", () => {
@@ -149,7 +166,7 @@ describe("buildReleasePlan packages", () => {
 	// no API to automate it, for bytes that are already published.
 	test("lists the shared base package, whatever the scope", () => {
 		expect(buildReleasePlan(base).packages).toEqual([buildReleasePlan(base).image.name]);
-		const scoped = buildReleasePlan({ ...base, providers: "vercel" });
+		const scoped = buildReleasePlan({ ...backfillBase, providers: "vercel" });
 		expect(scoped.packages).toEqual([scoped.image.name]);
 	});
 });
@@ -164,7 +181,7 @@ describe("buildReleasePlan image source", () => {
 	});
 
 	test("a scoped backfill mirrors the published version instead", () => {
-		const plan = buildReleasePlan({ ...base, providers: "vercel" });
+		const plan = buildReleasePlan({ ...backfillBase, providers: "vercel" });
 		expect(plan.partial).toBe(true);
 		expect(plan.image.source).toBe(plan.image.version);
 	});
@@ -206,9 +223,9 @@ describe("planOutputs", () => {
 		expect(planOutputs(buildReleasePlan(base)).split("\n")).toContain(
 			`providers=${ALL_PROVIDERS.join(",")}`,
 		);
-		expect(planOutputs(buildReleasePlan({ ...base, providers: "vercel" })).split("\n")).toContain(
-			"providers=vercel",
-		);
+		expect(
+			planOutputs(buildReleasePlan({ ...backfillBase, providers: "vercel" })).split("\n"),
+		).toContain("providers=vercel");
 	});
 
 	test("emits every package the visibility guard must check, comma-separated", () => {

--- a/apps/cli/src/bin/release-plan.test.ts
+++ b/apps/cli/src/bin/release-plan.test.ts
@@ -69,6 +69,7 @@ describe("buildReleasePlan matrix", () => {
 			"novita",
 			"namespace",
 			"vercel",
+			"runcloud",
 		]);
 	});
 
@@ -186,7 +187,7 @@ describe("planOutputs", () => {
 		expect(matrixLine).toBeDefined();
 		// The matrix value must be valid, single-line JSON (the fromJSON contract).
 		const parsed = JSON.parse((matrixLine as string).slice("matrix=".length));
-		expect(parsed.include).toHaveLength(11);
+		expect(parsed.include).toHaveLength(12);
 		expect((matrixLine as string).includes("\n")).toBe(false);
 	});
 

--- a/apps/cli/src/bin/release-plan.ts
+++ b/apps/cli/src/bin/release-plan.ts
@@ -198,6 +198,17 @@ export function buildReleasePlan(inputs: ReleasePlanInputs): ReleasePlan {
 	// against the current version, which is exactly what you do BEFORE deciding to cut a new one — so
 	// letting "already published" skip it would silently turn the whole run into a no-op.
 	const promote = inputs.promote ?? true;
+	const build = inputs.build ?? "full";
+	// A scoped release is a BACKFILL onto bytes that are already immutable. Rebuilding the shared base
+	// would move the mutable candidate, while the partial promote correctly re-validates and derives
+	// artifacts from the published version; the bake phase would therefore validate unrelated bytes.
+	// Refuse that contradictory request instead of spending a build and silently ignoring its output.
+	if (partial && build === "full") {
+		throw new Error(
+			"a scoped release is a backfill onto the published version and requires `build: skip`; " +
+				"run an unscoped `build: full` release to rebuild the shared candidate",
+		);
+	}
 	const mode = partial ? "backfill" : inputs.forceRepublish ? "republish" : "build";
 	const skip = inputs.alreadyPublished && !inputs.forceRepublish && !partial && promote;
 
@@ -212,7 +223,7 @@ export function buildReleasePlan(inputs: ReleasePlanInputs): ReleasePlan {
 	return {
 		mode,
 		skip,
-		build: inputs.build ?? "full",
+		build,
 		promote,
 		partial,
 		sourceRef: inputs.sourceRef,

--- a/apps/cli/src/bin/release-plan.ts
+++ b/apps/cli/src/bin/release-plan.ts
@@ -80,6 +80,8 @@ function providerArtifact(id: ProviderId): string {
 			// No template/snapshot system — pulls the candidate image straight into an instance at
 			// create time (same as modal), so there is no baked artifact to name.
 			return "boots the candidate image directly (no baked artifact)";
+		case "runcloud":
+			return "boots the candidate image directly (no baked artifact)";
 		case "vercel":
 			return config.vercelImageCandidate;
 	}

--- a/apps/cli/src/bin/release-validate.ts
+++ b/apps/cli/src/bin/release-validate.ts
@@ -47,6 +47,18 @@ if (providers !== "") {
 	try {
 		const scope = selectProviders(providers);
 		core.info(`Scoped release: ${scope.join(", ")}`);
+		// A scoped release backfills artifacts onto an existing immutable base. Rebuilding the mutable
+		// candidate in the same dispatch would make bake validate different bytes from the published base
+		// that promote must use. Fail before registry login/build rather than waste the rebuild or silently
+		// ignore it.
+		if (isPartialScope(scope) && (buildMode === "" || buildMode === "full")) {
+			core.error(
+				"A scoped release is a backfill onto the published version and requires build=skip. " +
+					"Use an unscoped build=full release to rebuild the shared candidate.",
+				{ title: "Conflicting dispatch inputs" },
+			);
+			core.setFailed("build=full is not valid for a scoped release.");
+		}
 		// A PARTIAL release backfills providers onto an already-published version and never rewrites the
 		// base; force_republish regenerates the whole version in place, destructively for daytona (it
 		// deletes each snapshot before recreating it). Refusing the combination is not pedantry: either

--- a/apps/cli/src/lib/bake/promote.ts
+++ b/apps/cli/src/lib/bake/promote.ts
@@ -257,6 +257,9 @@ export async function promoteAll(log: Log, options: PromoteOptions = {}): Promis
 				case "namespace":
 					log("    namespace pulls the published version image — nothing to build");
 					break;
+				case "runcloud":
+					log("    runcloud pulls the published version image — nothing to build");
+					break;
 				case "vercel":
 					await promoteImage(log, config.vercelImageCandidate, config.vercelImageVersion);
 					break;

--- a/apps/cli/src/lib/bake/validate.test.ts
+++ b/apps/cli/src/lib/bake/validate.test.ts
@@ -67,6 +67,12 @@ describe("candidateCreateOptions", () => {
 		});
 	});
 
+	it("points run.cloud directly at the candidate image", () => {
+		expect(candidateCreateOptions("runcloud", refs)).toEqual({
+			image: "ghcr.io/o/tc:v1-candidate",
+		});
+	});
+
 	it("points Vercel at the digest-pinned VCR candidate image", () => {
 		expect(candidateCreateOptions("vercel", refs)).toEqual({
 			templateId: refs.vercelImageCandidate,
@@ -100,6 +106,7 @@ describe("baseImageUse", () => {
 			"modal-gvisor",
 			"modal-vm",
 			"namespace",
+			"runcloud",
 		]);
 	});
 

--- a/apps/cli/src/lib/bake/validate.ts
+++ b/apps/cli/src/lib/bake/validate.ts
@@ -46,6 +46,7 @@ export function baseImageUse(id: ProviderId): BaseImageUse {
 		case "microsandbox-local":
 		case "microsandbox-cloud":
 		case "namespace":
+		case "runcloud":
 			return "boots";
 		case "blaxel":
 		case "vercel":
@@ -91,6 +92,9 @@ export function candidateCreateOptions(
 			return { snapshotId: refs.novitaTemplateCandidate };
 		case "namespace":
 			// No template/snapshot system — points create() at the candidate image directly, same as modal.
+			return { image: refs.toolchainImageCandidate };
+		case "runcloud":
+			// The native SDK boots an arbitrary OCI image directly; there is no template to bake.
 			return { image: refs.toolchainImageCandidate };
 		case "vercel":
 			return { templateId: refs.vercelImageCandidate };

--- a/apps/cli/src/lib/providers-run.test.ts
+++ b/apps/cli/src/lib/providers-run.test.ts
@@ -43,6 +43,7 @@ describe("forEachProviderWithCreds `only`", () => {
 			"novita",
 			"namespace",
 			"vercel",
+			"runcloud",
 		]);
 	});
 

--- a/bun.lock
+++ b/bun.lock
@@ -91,6 +91,7 @@
         "@computesdk/modal": "catalog:computesdk",
         "@computesdk/namespace": "catalog:computesdk",
         "@computesdk/provider": "catalog:computesdk",
+        "@run-cloud/sdk": "catalog:computesdk",
         "@sandbox-benchmarks/schema": "workspace:*",
         "@vercel/sandbox": "catalog:computesdk",
         "arktype": "catalog:",
@@ -200,6 +201,7 @@
       "@computesdk/provider": "2.1.3",
       "@daytona/api-client": "0.192.0",
       "@daytona/sdk": "0.192.0",
+      "@run-cloud/sdk": "0.9.0",
       "@vercel/sandbox": "2.9.2",
       "computesdk": "4.1.3",
       "microsandbox": "0.6.8",
@@ -684,6 +686,8 @@
     "@rolldown/pluginutils": ["@rolldown/pluginutils@1.0.0-rc.1", "", {}, "sha512-UTBjtTxVOhodhzFVp/ayITaTETRHPUPYZPXQe0WU0wOgxghMojXxYjOiPOauKIYNWJAWS2fd7gJgGQK8GU8vDA=="],
 
     "@rollup/pluginutils": ["@rollup/pluginutils@5.4.0", "", { "dependencies": { "@types/estree": "^1.0.0", "estree-walker": "^2.0.2", "picomatch": "^4.0.2" }, "peerDependencies": { "rollup": "^1.20.0||^2.0.0||^3.0.0||^4.0.0" }, "optionalPeers": ["rollup"] }, "sha512-MfPp06CjRLfXQ3wY0R8vJDYBy/MvVcc9OulEfR0B8Iv9ko+GCNaRZ+EpJYFl27LhKsZK0o420sYCRHCjfCgeUg=="],
+
+    "@run-cloud/sdk": ["@run-cloud/sdk@0.9.0", "", { "dependencies": { "ws": "^8.21.0" } }, "sha512-wBVUs3wZJzbcJBnNMxpJevn9TchWvzE+Z8iHjHfFDSyjGOLyR8cIj6eW/rDRsupXr6KzpKOmFDG4vPkemM9uYA=="],
 
     "@sandbox-benchmarks/cli": ["@sandbox-benchmarks/cli@workspace:apps/cli"],
 

--- a/docs/ci-secrets.md
+++ b/docs/ci-secrets.md
@@ -218,6 +218,7 @@ Do this in the GitHub UI (Settings → Environments / Rules / Actions), then del
    | `BL_API_KEY` | bench matrix/smoke only |
    | `BL_WORKSPACE` | bench matrix/smoke only |
    | `MSB_API_KEY` | Microsandbox Cloud toolchain validation and bench matrix/smoke |
+   | `RUN_CLOUD_API_KEY` | optional for toolchain validation; bench matrix/smoke |
    | `VERCEL_TOKEN` | Bootstrap only: Vercel CLI pulls a short-lived project OIDC token |
    | `VERCEL_ORG_ID` | Links the Vercel CLI to the repository's organization (`team_*`) |
    | `VERCEL_PROJECT_ID` | Links the Vercel CLI to the repository's project (`prj_*`) |
@@ -310,6 +311,8 @@ Copy [`.env.example`](../.env.example) to a gitignored `.env` and fill in the pr
 commit them; never paste them into issues or pull requests. See [SECURITY.md](../SECURITY.md).
 
 `microsandbox-local` uses `MICROSANDBOX_LOCAL_BENCH=1` as an explicit capability opt-in rather than a credential. The runner must provide KVM on Linux or Hypervisor.framework on macOS. `microsandbox-cloud` needs `MSB_API_KEY`; `MSB_API_URL` is an optional endpoint override. The cloud adapter keeps the key in the SDK control-plane backend and never adds it to sandbox metadata, create-time environment variables, or guest commands.
+
+run.cloud needs `RUN_CLOUD_API_KEY`. Its SDK reads the key directly from the benchmark process; the adapter never adds it to sandbox metadata, create-time environment variables, or guest commands.
 
 The `tooling/repo-checks` secret-hygiene gate enforces this: it fails CI if any tracked file is a
 credential file (`.env`, `*.pem`, `id_rsa`, …) or contains a high-signal secret token.

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
         "@computesdk/modal": "1.9.3",
         "@computesdk/namespace": "1.6.12",
         "@computesdk/provider": "2.1.3",
+        "@run-cloud/sdk": "0.9.0",
         "@daytona/api-client": "0.192.0",
         "@daytona/sdk": "0.192.0",
         "computesdk": "4.1.3",

--- a/packages/harness/src/index.test.ts
+++ b/packages/harness/src/index.test.ts
@@ -403,7 +403,7 @@ describe("runSuite (resolution + credential gate)", () => {
 describe("createSuiteSandbox (creation-failure marker)", () => {
 	// The daytona-container incident shape: creation itself throws, so no sandbox — and no result —
 	// ever exists for the cell. The marker is the shard's ONLY record of the failure.
-	const createCtx = (resultsDir: string, overrides: { createTimeoutMs?: number } = {}) => ({
+	const createCtx = (resultsDir: string, overrides: { createTimeoutMs?: number | null } = {}) => ({
 		suite: suite({}),
 		suiteName: "cpu-node",
 		providerName: "daytona-container",
@@ -489,6 +489,22 @@ describe("createSuiteSandbox (creation-failure marker)", () => {
 		// Let the late create settle and the attached cleanup run.
 		await new Promise((r) => setTimeout(r, 60));
 		expect(destroyed.hit).toBe(true);
+	});
+
+	it("does not abandon an adapter-owned create/cleanup promise when its timeout is disabled", async () => {
+		const resultsDir = freshDir();
+		const handle = makeSandbox({ destroyed: { hit: false } });
+		const compute = {
+			sandbox: {
+				create: (): Promise<SandboxHandle> =>
+					new Promise((resolve) => setTimeout(() => resolve(handle), 30)),
+			},
+		};
+
+		await expect(
+			createSuiteSandbox(() => compute, createCtx(resultsDir, { createTimeoutMs: null })),
+		).resolves.toBe(handle);
+		expect(existsSync(join(resultsDir, MARKER))).toBe(false);
 	});
 
 	it("folds into a suite-scope FAILED gap through the extractor's marker reader", async () => {

--- a/packages/harness/src/index.ts
+++ b/packages/harness/src/index.ts
@@ -252,7 +252,8 @@ const CREATE_RETRY_DELAY_MS = 2 * MIN;
  *  destroyed). Generous: a cold provider image can take minutes to provision. Adequate only for
  *  providers whose `create` returns once the control plane ACCEPTS the sandbox, with the image pull
  *  absorbed by a readiness probe afterwards; one that boots the image inline needs its own budget via
- *  {@link ProviderConfig.createTimeoutMs}. */
+ *  {@link ProviderConfig.createTimeoutMs}, or `null` when its adapter owns readiness + cleanup and its
+ *  create promise must never be abandoned. */
 const CREATE_ATTEMPT_TIMEOUT_MS = 5 * MIN;
 
 /**
@@ -274,9 +275,9 @@ export interface CreateSuiteSandboxContext {
 	createOptions?: SandboxCreateOptions;
 	/** Per-attempt create timeout, ms. Defaults to {@link CREATE_ATTEMPT_TIMEOUT_MS}; set per provider
 	 *  (see {@link ProviderConfig.createTimeoutMs}) for adapters whose `create` boots the image inline,
-	 *  and injectable so the timeout-leak path (a create that resolves after the race is lost) is
-	 *  exercisable in tests. */
-	createTimeoutMs?: number;
+	 *  or `null` when the adapter owns readiness + failed-allocation cleanup and abandoning its promise
+	 *  would terminate that cleanup. Injectable so both paths are exercisable in tests. */
+	createTimeoutMs?: number | null;
 }
 
 /**
@@ -299,7 +300,8 @@ export async function createSuiteSandbox(
 	ctx: CreateSuiteSandboxContext,
 ): Promise<SandboxHandle> {
 	const { suite, suiteName, providerName, resultsDir, createOptions } = ctx;
-	const createTimeoutMs = ctx.createTimeoutMs ?? CREATE_ATTEMPT_TIMEOUT_MS;
+	const createTimeoutMs =
+		ctx.createTimeoutMs === undefined ? CREATE_ATTEMPT_TIMEOUT_MS : ctx.createTimeoutMs;
 	const createDeadline = Date.now() + CREATE_RETRY_BUDGET_MS;
 	for (let attempt = 1; ; attempt++) {
 		// Undefined until `sandbox.create` is actually invoked: a factory throw leaves it unset (nothing
@@ -315,7 +317,9 @@ export async function createSuiteSandbox(
 					timeout: suite.timeoutMinutes * MIN,
 				}),
 			);
-			return await withTimeout(createPromise, createTimeoutMs, "Sandbox creation timed out");
+			return createTimeoutMs === null
+				? await createPromise
+				: await withTimeout(createPromise, createTimeoutMs, "Sandbox creation timed out");
 		} catch (err) {
 			// `withTimeout` only RACES the create — it cannot cancel it. A create that resolves after the
 			// timeout (or after a capacity error on a later attempt) leaves a live sandbox no one awaits, and

--- a/packages/harness/src/lib/execute.ts
+++ b/packages/harness/src/lib/execute.ts
@@ -104,9 +104,8 @@ export const DEFAULT_TRANSPORT: ProviderTransport = Object.freeze({
  * not `>`: when `syncCapMs` equals a provider's hard limit (E2B's `syncCapMs` *is* its SDK
  * `defaultProcessConnectionTimeout`), a step budgeted at exactly the cap could run right up to it and
  * drop the connection with no margin — so a budget that *reaches* the cap detaches, not just one that
- * exceeds it. `streaming` is modeled on the capability but does not tip this decision today: no shipped
- * `@computesdk/*` adapter delivers incremental output, so there is no streaming transport to prefer —
- * when one lands, it is selected here.
+ * exceeds it. `streaming` is modeled on the capability but does not tip this decision today: run.cloud
+ * delivers incremental output, while the selector still uses the same conservative synchronous cap.
  */
 export function selectTransport(transport: ProviderTransport, timeoutMs: number): TransportKind {
 	const couldExceedSyncCap = transport.syncCapMs !== null && timeoutMs >= transport.syncCapMs;

--- a/packages/providers/README.md
+++ b/packages/providers/README.md
@@ -13,7 +13,8 @@ adapters over raw vendor SDKs only where required.
 **What lives here:** provider factories and focused compatibility adapters. Most `@computesdk/*`
 packages adapt their vendor SDK directly; Microsandbox uses a local `defineProvider` implementation.
 Vercel's local provider starts from ComputeSDK's upstream adapter but uses pinned `@vercel/sandbox`
-v2, because the published wrapper still pins a pre-VCR SDK. The package also
+v2, because the published wrapper still pins a pre-VCR SDK. run.cloud also uses a local
+`defineProvider` adapter over `@run-cloud/sdk`, for which no `@computesdk/*` wrapper is published. The package also
 owns benchmark create-time policy — the pinned `TARGET_SPEC` and toolchain image. The assembled
 `providers` registry joins the schema `PROVIDERS` metadata with the adapter
 map by id; both are keyed by `ProviderId`, so a one-sided provider is a compile error rather than a

--- a/packages/providers/package.json
+++ b/packages/providers/package.json
@@ -18,6 +18,7 @@
     "@computesdk/modal": "catalog:computesdk",
     "@computesdk/namespace": "catalog:computesdk",
     "@computesdk/provider": "catalog:computesdk",
+    "@run-cloud/sdk": "catalog:computesdk",
     "@sandbox-benchmarks/schema": "workspace:*",
     "arktype": "catalog:",
     "computesdk": "catalog:computesdk",

--- a/packages/providers/src/index.test.ts
+++ b/packages/providers/src/index.test.ts
@@ -14,6 +14,7 @@ import {
 } from "./index.ts";
 import { runE2bCommandAsRoot } from "./lib/e2b-root.ts";
 import { assertProviderJoin } from "./lib/join.ts";
+import { RUNCLOUD_CREATE_TIMEOUT_MS, RUNCLOUD_READY_TIMEOUT_MS } from "./lib/runcloud.ts";
 
 describe("@sandbox-benchmarks/providers", () => {
 	it("wires every schema provider through to a computesdk factory", () => {
@@ -77,6 +78,8 @@ describe("@sandbox-benchmarks/providers", () => {
 			memory: TARGET_SPEC.memoryGb * 1024,
 			disk: TARGET_SPEC.diskGb,
 		});
+		expect(adapter?.createTimeoutMs).toBe(RUNCLOUD_CREATE_TIMEOUT_MS);
+		expect(adapter?.createTimeoutMs).toBeGreaterThan(RUNCLOUD_READY_TIMEOUT_MS);
 		expect(adapter?.createCompute().name).toBe("runcloud");
 	});
 

--- a/packages/providers/src/index.test.ts
+++ b/packages/providers/src/index.test.ts
@@ -14,7 +14,6 @@ import {
 } from "./index.ts";
 import { runE2bCommandAsRoot } from "./lib/e2b-root.ts";
 import { assertProviderJoin } from "./lib/join.ts";
-import { RUNCLOUD_CREATE_TIMEOUT_MS, RUNCLOUD_READY_TIMEOUT_MS } from "./lib/runcloud.ts";
 
 describe("@sandbox-benchmarks/providers", () => {
 	it("wires every schema provider through to a computesdk factory", () => {
@@ -78,8 +77,9 @@ describe("@sandbox-benchmarks/providers", () => {
 			memory: TARGET_SPEC.memoryGb * 1024,
 			disk: TARGET_SPEC.diskGb,
 		});
-		expect(adapter?.createTimeoutMs).toBe(RUNCLOUD_CREATE_TIMEOUT_MS);
-		expect(adapter?.createTimeoutMs).toBeGreaterThan(RUNCLOUD_READY_TIMEOUT_MS);
+		// The adapter waits for readiness and cleans up failed allocations itself. A harness timeout would
+		// abandon that non-cancellable promise and bench-suite's process exit could kill the cleanup.
+		expect(adapter?.createTimeoutMs).toBeNull();
 		expect(adapter?.createCompute().name).toBe("runcloud");
 	});
 

--- a/packages/providers/src/index.test.ts
+++ b/packages/providers/src/index.test.ts
@@ -68,6 +68,18 @@ describe("@sandbox-benchmarks/providers", () => {
 		expect(adapter?.createCompute().name).toBe("vercel");
 	});
 
+	it("pins run.cloud to the shared image and target spec", () => {
+		const adapter = providers.find((provider) => provider.name === "runcloud");
+		expect(adapter?.requiredEnvVars).toEqual(["RUN_CLOUD_API_KEY"]);
+		expect(adapter?.createOptions).toMatchObject({
+			image: config.toolchainImage,
+			cpu: TARGET_SPEC.vcpus,
+			memory: TARGET_SPEC.memoryGb * 1024,
+			disk: TARGET_SPEC.diskGb,
+		});
+		expect(adapter?.createCompute().name).toBe("runcloud");
+	});
+
 	it("re-points the e2b wrapper at Novita without the e2b_ key-format guard", () => {
 		// Construction must accept an nvta_-prefixed key and still expose the universal manager surface
 		// the harness drives, with the mispointed snapshot/template managers removed (their every call

--- a/packages/providers/src/index.ts
+++ b/packages/providers/src/index.ts
@@ -20,6 +20,7 @@ export { microsandboxCloudCompute, microsandboxLocalCompute } from "./lib/micros
 // Novita's E2B-compat surface: the pinned regional domain + connection the bake pipeline reuses,
 // and the compat factory (exported for tests and for anyone driving Novita outside the harness join).
 export { NOVITA_E2B_DOMAIN, novitaCompute, novitaConnection } from "./lib/novita.ts";
+export { drainRuncloudBackgroundWork } from "./lib/runcloud.ts";
 export type { DirectProvider, ProviderAdapter, ProviderConfig } from "./lib/types.ts";
 
 /**

--- a/packages/providers/src/lib/adapters.ts
+++ b/packages/providers/src/lib/adapters.ts
@@ -17,7 +17,7 @@ import { daytonaClientTarget } from "./daytona-target.ts";
 import { e2bCommandsAsRoot } from "./e2b-root.ts";
 import { microsandboxCloudCompute, microsandboxLocalCompute } from "./microsandbox.ts";
 import { novitaCompute } from "./novita.ts";
-import { runcloudCompute } from "./runcloud.ts";
+import { RUNCLOUD_CREATE_TIMEOUT_MS, runcloudCompute } from "./runcloud.ts";
 import type { ProviderAdapter } from "./types.ts";
 import { vercelCompute } from "./vercel.ts";
 
@@ -224,8 +224,8 @@ export const adapters: Record<ProviderId, ProviderAdapter> = {
 		// run.cloud boots the OCI image directly and exposes independent CPU, memory, and writable-disk
 		// knobs. Keep both its lifetime and idle-pause window above the longest 155-minute suite so a
 		// detached benchmark is not paused while the harness is polling its done file. create() polls
-		// until the sandbox is running, so the toolchain pull lives inside create — same budget as
-		// Microsandbox's cold-pull path.
+		// until the sandbox is running, so the toolchain pull lives inside create. Its outer harness
+		// budget includes margin beyond the adapter's readiness deadline for allocation and cleanup.
 		createCompute: runcloudCompute,
 		createOptions: {
 			image: config.toolchainImage,
@@ -235,6 +235,6 @@ export const adapters: Record<ProviderId, ProviderAdapter> = {
 			idlePauseSeconds: RUNCLOUD_MAX_DURATION_SECS,
 			timeoutSeconds: RUNCLOUD_MAX_DURATION_SECS,
 		},
-		createTimeoutMs: 20 * 60 * 1000,
+		createTimeoutMs: RUNCLOUD_CREATE_TIMEOUT_MS,
 	},
 };

--- a/packages/providers/src/lib/adapters.ts
+++ b/packages/providers/src/lib/adapters.ts
@@ -1,6 +1,6 @@
 // Each schema provider id maps to a ComputeSDK factory plus benchmark create-time policy. Prefer the
-// maintained @computesdk wrappers; Vercel is the deliberate exception because its published wrapper
-// still pins Sandbox v1 and cannot boot the shared VCR image supported by the latest native SDK.
+// maintained @computesdk wrappers. Vercel uses its native SDK because the published wrapper still
+// pins Sandbox v1; run.cloud also uses its native SDK because no @computesdk wrapper is published.
 
 import { blaxel } from "@computesdk/blaxel";
 import { daytona } from "@computesdk/daytona";
@@ -17,6 +17,7 @@ import { daytonaClientTarget } from "./daytona-target.ts";
 import { e2bCommandsAsRoot } from "./e2b-root.ts";
 import { microsandboxCloudCompute, microsandboxLocalCompute } from "./microsandbox.ts";
 import { novitaCompute } from "./novita.ts";
+import { runcloudCompute } from "./runcloud.ts";
 import type { ProviderAdapter } from "./types.ts";
 import { vercelCompute } from "./vercel.ts";
 
@@ -84,6 +85,7 @@ const modalVmCompute = () => modal({ appName: MODAL_APP_NAME });
 /** The longest suite has a 155-minute budget. Give Microsandbox enough lifetime for setup and
  * teardown as well, while keeping leaked benchmark sandboxes self-expiring. */
 const MICROSANDBOX_MAX_DURATION_SECS = 3 * 60 * 60;
+const RUNCLOUD_MAX_DURATION_SECS = 3 * 60 * 60;
 
 /**
  * Microsandbox's `create` does not return until the sandbox is RUNNING, so the toolchain image pull
@@ -217,5 +219,19 @@ export const adapters: Record<ProviderId, ProviderAdapter> = {
 		// native SDK so the shared VCR image and v2 lifecycle/filesystem APIs remain available.
 		createCompute: () => vercelCompute({ image: config.vercelImage, vcpus: TARGET_SPEC.vcpus }),
 		createOptions: {},
+	},
+	runcloud: {
+		// run.cloud boots the OCI image directly and exposes independent CPU, memory, and writable-disk
+		// knobs. Keep both its lifetime and idle-pause window above the longest 155-minute suite so a
+		// detached benchmark is not paused while the harness is polling its done file.
+		createCompute: runcloudCompute,
+		createOptions: {
+			image: config.toolchainImage,
+			cpu: TARGET_SPEC.vcpus,
+			memory: TARGET_SPEC.memoryGb * 1024,
+			disk: TARGET_SPEC.diskGb,
+			idlePauseSeconds: RUNCLOUD_MAX_DURATION_SECS,
+			timeoutSeconds: RUNCLOUD_MAX_DURATION_SECS,
+		},
 	},
 };

--- a/packages/providers/src/lib/adapters.ts
+++ b/packages/providers/src/lib/adapters.ts
@@ -226,7 +226,9 @@ export const adapters: Record<ProviderId, ProviderAdapter> = {
 		// detached benchmark is not paused while the harness is polling its done file. create() polls
 		// until the sandbox is running and owns failed-allocation cleanup. Disable the harness's
 		// non-cancellable outer race: abandoning create while it is cleaning up would let bench-suite's
-		// explicit process exit terminate that teardown and strand the billable sandbox.
+		// explicit process exit terminate that teardown and strand the billable sandbox. The adapter
+		// independently bounds each native control-plane call, so awaiting its ownership does not turn a
+		// wedged SDK request into an unbounded create.
 		createCompute: runcloudCompute,
 		createOptions: {
 			image: config.toolchainImage,

--- a/packages/providers/src/lib/adapters.ts
+++ b/packages/providers/src/lib/adapters.ts
@@ -223,7 +223,9 @@ export const adapters: Record<ProviderId, ProviderAdapter> = {
 	runcloud: {
 		// run.cloud boots the OCI image directly and exposes independent CPU, memory, and writable-disk
 		// knobs. Keep both its lifetime and idle-pause window above the longest 155-minute suite so a
-		// detached benchmark is not paused while the harness is polling its done file.
+		// detached benchmark is not paused while the harness is polling its done file. create() polls
+		// until the sandbox is running, so the toolchain pull lives inside create — same budget as
+		// Microsandbox's cold-pull path.
 		createCompute: runcloudCompute,
 		createOptions: {
 			image: config.toolchainImage,
@@ -233,5 +235,6 @@ export const adapters: Record<ProviderId, ProviderAdapter> = {
 			idlePauseSeconds: RUNCLOUD_MAX_DURATION_SECS,
 			timeoutSeconds: RUNCLOUD_MAX_DURATION_SECS,
 		},
+		createTimeoutMs: 20 * 60 * 1000,
 	},
 };

--- a/packages/providers/src/lib/adapters.ts
+++ b/packages/providers/src/lib/adapters.ts
@@ -17,7 +17,7 @@ import { daytonaClientTarget } from "./daytona-target.ts";
 import { e2bCommandsAsRoot } from "./e2b-root.ts";
 import { microsandboxCloudCompute, microsandboxLocalCompute } from "./microsandbox.ts";
 import { novitaCompute } from "./novita.ts";
-import { RUNCLOUD_CREATE_TIMEOUT_MS, runcloudCompute } from "./runcloud.ts";
+import { runcloudCompute } from "./runcloud.ts";
 import type { ProviderAdapter } from "./types.ts";
 import { vercelCompute } from "./vercel.ts";
 
@@ -224,8 +224,9 @@ export const adapters: Record<ProviderId, ProviderAdapter> = {
 		// run.cloud boots the OCI image directly and exposes independent CPU, memory, and writable-disk
 		// knobs. Keep both its lifetime and idle-pause window above the longest 155-minute suite so a
 		// detached benchmark is not paused while the harness is polling its done file. create() polls
-		// until the sandbox is running, so the toolchain pull lives inside create. Its outer harness
-		// budget includes margin beyond the adapter's readiness deadline for allocation and cleanup.
+		// until the sandbox is running and owns failed-allocation cleanup. Disable the harness's
+		// non-cancellable outer race: abandoning create while it is cleaning up would let bench-suite's
+		// explicit process exit terminate that teardown and strand the billable sandbox.
 		createCompute: runcloudCompute,
 		createOptions: {
 			image: config.toolchainImage,
@@ -235,6 +236,6 @@ export const adapters: Record<ProviderId, ProviderAdapter> = {
 			idlePauseSeconds: RUNCLOUD_MAX_DURATION_SECS,
 			timeoutSeconds: RUNCLOUD_MAX_DURATION_SECS,
 		},
-		createTimeoutMs: RUNCLOUD_CREATE_TIMEOUT_MS,
+		createTimeoutMs: null,
 	},
 };

--- a/packages/providers/src/lib/runcloud.test.ts
+++ b/packages/providers/src/lib/runcloud.test.ts
@@ -247,6 +247,40 @@ describe("run.cloud ComputeSDK adapter", () => {
 		expect(new Set(idempotencyKeys).size).toBe(1);
 	});
 
+	it("retains cleanup for a create response that arrives after recovery exhaustion", async () => {
+		let resolveInitial: ((sandbox: Sandbox) => void) | undefined;
+		let createCalls = 0;
+		const destroyed: string[] = [];
+		const client = nativeClient({
+			create: () => {
+				createCalls++;
+				if (createCalls === 1) {
+					return new Promise<Sandbox>((resolve) => {
+						resolveInitial = resolve;
+					});
+				}
+				return new Promise<Sandbox>(() => {});
+			},
+			destroy: async (id) => {
+				destroyed.push(id);
+			},
+		});
+
+		await expect(
+			runcloudCompute({
+				client,
+				controlPlaneTimeoutMs: 5,
+				createRecoveryAttempts: 1,
+				cleanupAttempts: 1,
+			}).sandbox.create(),
+		).rejects.toThrow(/idempotent allocation could not be recovered/);
+		expect(destroyed).toEqual([]);
+		expect(resolveInitial).toBeDefined();
+		resolveInitial?.(nativeSandbox("building_image"));
+		await new Promise((resolve) => setTimeout(resolve, 10));
+		expect(destroyed).toEqual(["sb-test"]);
+	});
+
 	it("retries a transient failed-create cleanup before preserving the readiness error", async () => {
 		let destroyCalls = 0;
 		const client = nativeClient({

--- a/packages/providers/src/lib/runcloud.test.ts
+++ b/packages/providers/src/lib/runcloud.test.ts
@@ -1,0 +1,258 @@
+import { describe, expect, it, spyOn } from "bun:test";
+import type { SandboxMethods } from "@computesdk/provider";
+import type { ExecOptions, Sandbox, SandboxState } from "@run-cloud/sdk";
+import { RunCloudError } from "@run-cloud/sdk";
+import {
+	RUNCLOUD_CREATE_TIMEOUT_MS,
+	RUNCLOUD_READY_TIMEOUT_MS,
+	runcloudCompute,
+} from "./runcloud.ts";
+
+type ComputeOptions = NonNullable<Parameters<typeof runcloudCompute>[0]>;
+type NativeClient = NonNullable<ComputeOptions["client"]>;
+
+function nativeSandbox(state: SandboxState = "running", overrides: Partial<Sandbox> = {}): Sandbox {
+	return {
+		id: "sb-test",
+		state,
+		image: "ghcr.io/starslingdev/toolchain:test",
+		region: "us-west",
+		sizeClass: "custom",
+		milliCpu: 4_000,
+		memMb: 8_192,
+		warmStart: false,
+		timeoutSeconds: 10_800,
+		createdAt: "2026-08-03T00:00:00.000Z",
+		...overrides,
+	};
+}
+
+function nativeClient(overrides: Partial<NativeClient> = {}): NativeClient {
+	return {
+		create: async () => nativeSandbox(),
+		get: async (id) => nativeSandbox("running", { id }),
+		list: async () => [],
+		destroy: async () => {},
+		exec: async () => ({ stdout: "", stderr: "", exit_code: 0, exitCode: 0 }),
+		openTunnel: async (id, port) => ({
+			id: "tunnel-test",
+			sandboxId: id,
+			hostname: "tunnel.invalid",
+			url: `https://tunnel.invalid:${port}`,
+			port,
+			expiresAt: "2026-08-03T01:00:00.000Z",
+			createdAt: "2026-08-03T00:00:00.000Z",
+		}),
+		...overrides,
+	} as NativeClient;
+}
+
+describe("run.cloud ComputeSDK adapter", () => {
+	it("keeps the harness create timeout beyond the adapter readiness window", () => {
+		expect(RUNCLOUD_CREATE_TIMEOUT_MS).toBeGreaterThan(RUNCLOUD_READY_TIMEOUT_MS);
+		expect(RUNCLOUD_CREATE_TIMEOUT_MS - RUNCLOUD_READY_TIMEOUT_MS).toBe(5 * 60 * 1000);
+	});
+
+	it("forwards create policy and waits through a transitional state", async () => {
+		let createInput: Record<string, unknown> | undefined;
+		const states = [nativeSandbox("building_image"), nativeSandbox("running")];
+		let destroyCalls = 0;
+		const client = nativeClient({
+			create: async (input) => {
+				createInput = input as Record<string, unknown>;
+				return nativeSandbox("building_image");
+			},
+			get: async () => states.shift() ?? nativeSandbox("running"),
+			destroy: async () => {
+				destroyCalls++;
+			},
+		});
+		const provider = runcloudCompute({ client, readyPollMs: 0, sleep: async () => {} });
+		const sandbox = await provider.sandbox.create({
+			image: "ghcr.io/starslingdev/toolchain:candidate",
+			cpu: 4,
+			memory: 8_192,
+			disk: 40,
+			idlePauseSeconds: 10_800,
+			timeoutSeconds: 10_800,
+			region: "us-west",
+			name: "benchmark",
+		});
+
+		expect(sandbox.sandboxId).toBe("sb-test");
+		expect(createInput).toEqual({
+			image: "ghcr.io/starslingdev/toolchain:candidate",
+			cpu: 4,
+			memory: 8_192,
+			disk: 40,
+			idlePauseSeconds: 10_800,
+			timeoutSeconds: 10_800,
+			region: "us-west",
+			name: "benchmark",
+		});
+		expect(destroyCalls).toBe(0);
+	});
+
+	it("destroys the allocation when readiness enters a terminal state", async () => {
+		const destroyed: string[] = [];
+		const client = nativeClient({
+			create: async () => nativeSandbox("building_image"),
+			get: async () => nativeSandbox("failed"),
+			destroy: async (id) => {
+				destroyed.push(id);
+			},
+		});
+
+		await expect(runcloudCompute({ client }).sandbox.create()).rejects.toThrow(
+			'entered terminal state "failed"',
+		);
+		expect(destroyed).toEqual(["sb-test"]);
+	});
+
+	it("destroys the allocation when a readiness poll throws", async () => {
+		const destroyed: string[] = [];
+		const client = nativeClient({
+			create: async () => nativeSandbox("building_image"),
+			get: async () => {
+				throw new Error("control plane unavailable");
+			},
+			destroy: async (id) => {
+				destroyed.push(id);
+			},
+		});
+
+		await expect(runcloudCompute({ client }).sandbox.create()).rejects.toThrow(
+			"control plane unavailable",
+		);
+		expect(destroyed).toEqual(["sb-test"]);
+	});
+
+	it("destroys the allocation when readiness reaches its own timeout", async () => {
+		const destroyed: string[] = [];
+		let getCalls = 0;
+		const client = nativeClient({
+			create: async () => nativeSandbox("building_image"),
+			get: async () => {
+				getCalls++;
+				return nativeSandbox("building_image");
+			},
+			destroy: async (id) => {
+				destroyed.push(id);
+			},
+		});
+
+		await expect(runcloudCompute({ client, readyTimeoutMs: 0 }).sandbox.create()).rejects.toThrow(
+			"not running after 0ms",
+		);
+		expect(getCalls).toBe(0);
+		expect(destroyed).toEqual(["sb-test"]);
+	});
+
+	it("preserves the readiness error when best-effort cleanup also fails", async () => {
+		const consoleError = spyOn(console, "error").mockImplementation(() => {});
+		try {
+			const client = nativeClient({
+				create: async () => nativeSandbox("building_image"),
+				get: async () => {
+					throw new Error("readiness failed");
+				},
+				destroy: async () => {
+					throw new Error("cleanup failed");
+				},
+			});
+
+			await expect(runcloudCompute({ client }).sandbox.create()).rejects.toThrow(
+				"readiness failed",
+			);
+			expect(consoleError).toHaveBeenCalledTimes(1);
+			expect(String(consoleError.mock.calls[0]?.[0])).toContain("after readiness failure");
+		} finally {
+			consoleError.mockRestore();
+		}
+	});
+
+	it("filters destroyed and destroying tombstones from list", async () => {
+		const client = nativeClient({
+			list: async () => [
+				nativeSandbox("running", { id: "running" }),
+				nativeSandbox("paused", { id: "paused" }),
+				nativeSandbox("stopped", { id: "stopped" }),
+				nativeSandbox("failed", { id: "failed" }),
+				nativeSandbox("destroying", { id: "destroying" }),
+				nativeSandbox("destroyed", { id: "destroyed" }),
+			],
+		});
+
+		expect((await runcloudCompute({ client }).sandbox.list()).map((s) => s.sandboxId)).toEqual([
+			"running",
+			"paused",
+			"stopped",
+			"failed",
+		]);
+	});
+
+	it("maps command options, streaming callbacks, detached launch, info, and tunnels", async () => {
+		const execCalls: Array<{ command: string; options: ExecOptions }> = [];
+		const client = nativeClient({
+			exec: async (_id, command, options = {}) => {
+				execCalls.push({ command: String(command), options });
+				options.onStdout?.(new TextEncoder().encode("out"));
+				options.onStderr?.(new TextEncoder().encode("err"));
+				return { stdout: "out", stderr: "err", exit_code: 7, exitCode: 7 };
+			},
+		});
+		const provider = runcloudCompute({ client });
+		const methods = (
+			provider as unknown as { sandbox: { methods: SandboxMethods<Sandbox, undefined> } }
+		).sandbox.methods;
+		const sandbox = nativeSandbox();
+		let stdout = "";
+		let stderr = "";
+		expect(
+			await methods.runCommand(sandbox, "printf test", {
+				cwd: "/work",
+				env: { BENCH: "1" },
+				timeout: 1_234,
+				onStdout: (chunk) => (stdout += chunk),
+				onStderr: (chunk) => (stderr += chunk),
+			}),
+		).toMatchObject({ stdout: "out", stderr: "err", exitCode: 7 });
+		expect(stdout).toBe("out");
+		expect(stderr).toBe("err");
+		expect(execCalls[0]).toMatchObject({
+			command: "printf test",
+			options: { cwd: "/work", env: { BENCH: "1" }, timeoutSeconds: 2 },
+		});
+
+		expect(await methods.runCommand(sandbox, "printf done", { background: true })).toMatchObject({
+			stdout: "",
+			stderr: "",
+			exitCode: 7,
+		});
+		expect(execCalls[1]?.command).toContain("nohup /bin/sh -lc 'printf done'");
+		expect(execCalls[1]?.options).not.toHaveProperty("onStdout");
+
+		expect(await methods.getInfo(sandbox)).toMatchObject({
+			id: "sb-test",
+			provider: "runcloud",
+			status: "running",
+			timeout: 10_800_000,
+			metadata: { milliCpu: 4_000, memoryMb: 8_192 },
+		});
+		expect(await methods.getUrl(sandbox, { port: 8_080 })).toBe("https://tunnel.invalid:8080");
+	});
+
+	it("treats native 404s as absent or already destroyed", async () => {
+		const client = nativeClient({
+			get: async () => {
+				throw new RunCloudError(404, "gone");
+			},
+			destroy: async () => {
+				throw new RunCloudError(404, "gone");
+			},
+		});
+		const provider = runcloudCompute({ client });
+		await expect(provider.sandbox.getById("gone")).resolves.toBeNull();
+		await expect(provider.sandbox.destroy("gone")).resolves.toBeUndefined();
+	});
+});

--- a/packages/providers/src/lib/runcloud.test.ts
+++ b/packages/providers/src/lib/runcloud.test.ts
@@ -224,6 +224,57 @@ describe("run.cloud ComputeSDK adapter", () => {
 		expect(destroyed).toEqual(["sb-test"]);
 	});
 
+	it("recovers and destroys after an ambiguous create 5xx", async () => {
+		const initialError = new RunCloudError(503, "response lost after allocation");
+		const idempotencyKeys: Array<string | undefined> = [];
+		const destroyed: string[] = [];
+		let createCalls = 0;
+		const client = nativeClient({
+			create: async (input) => {
+				createCalls++;
+				idempotencyKeys.push(input?.idempotencyKey);
+				if (createCalls === 1) throw initialError;
+				return nativeSandbox("building_image");
+			},
+			destroy: async (id) => {
+				destroyed.push(id);
+			},
+		});
+
+		try {
+			await runcloudCompute({
+				client,
+				createRecoveryAttempts: 1,
+				cleanupAttempts: 1,
+			}).sandbox.create();
+			expect.unreachable();
+		} catch (error) {
+			expect(error).toBe(initialError);
+		}
+		expect(createCalls).toBe(2);
+		expect(idempotencyKeys[1]).toBe(idempotencyKeys[0]);
+		expect(destroyed).toEqual(["sb-test"]);
+	});
+
+	it("rethrows definitive create 4xx responses without replaying", async () => {
+		const clientError = new RunCloudError(422, "invalid image");
+		let createCalls = 0;
+		const client = nativeClient({
+			create: async () => {
+				createCalls++;
+				throw clientError;
+			},
+		});
+
+		try {
+			await runcloudCompute({ client }).sandbox.create();
+			expect.unreachable();
+		} catch (error) {
+			expect(error).toBe(clientError);
+		}
+		expect(createCalls).toBe(1);
+	});
+
 	it("fails within bounded recovery attempts when a timed-out create cannot be recovered", async () => {
 		const idempotencyKeys: Array<string | undefined> = [];
 		const client = nativeClient({

--- a/packages/providers/src/lib/runcloud.test.ts
+++ b/packages/providers/src/lib/runcloud.test.ts
@@ -71,6 +71,7 @@ describe("run.cloud ComputeSDK adapter", () => {
 
 		expect(sandbox.sandboxId).toBe("sb-test");
 		expect(createInput).toEqual({
+			idempotencyKey: expect.stringMatching(/^sandbox-benchmarks-[0-9a-f-]+$/),
 			image: "ghcr.io/starslingdev/toolchain:candidate",
 			cpu: 4,
 			memory: 8_192,
@@ -136,6 +137,114 @@ describe("run.cloud ComputeSDK adapter", () => {
 		);
 		expect(getCalls).toBe(0);
 		expect(destroyed).toEqual(["sb-test"]);
+	});
+
+	it("bounds a hung readiness request and still awaits cleanup", async () => {
+		const destroyed: string[] = [];
+		const client = nativeClient({
+			create: async () => nativeSandbox("building_image"),
+			get: () => new Promise<Sandbox>(() => {}),
+			destroy: async (id) => {
+				destroyed.push(id);
+			},
+		});
+
+		await expect(
+			runcloudCompute({
+				client,
+				controlPlaneTimeoutMs: 5,
+				cleanupAttempts: 1,
+			}).sandbox.create(),
+		).rejects.toThrow(/readiness get for sandbox sb-test did not settle within 5ms/);
+		expect(destroyed).toEqual(["sb-test"]);
+	});
+
+	it("bounds hung cleanup calls, retries, and surfaces both failures", async () => {
+		let getCalls = 0;
+		let destroyCalls = 0;
+		const client = nativeClient({
+			create: async () => nativeSandbox("building_image"),
+			get: async () => {
+				getCalls++;
+				if (getCalls === 1) throw new Error("readiness failed");
+				return nativeSandbox("running");
+			},
+			destroy: () => {
+				destroyCalls++;
+				return new Promise<void>(() => {});
+			},
+		});
+
+		try {
+			await runcloudCompute({
+				client,
+				controlPlaneTimeoutMs: 5,
+				cleanupAttempts: 2,
+				sleep: async () => {},
+			}).sandbox.create();
+			expect.unreachable();
+		} catch (error) {
+			expect(error).toBeInstanceOf(AggregateError);
+			expect((error as AggregateError).errors[0]).toEqual(new Error("readiness failed"));
+			expect((error as AggregateError).errors[1]).toMatchObject({
+				message: "run.cloud destroy sandbox sb-test did not settle within 5ms",
+			});
+		}
+		expect(destroyCalls).toBe(2);
+		expect(getCalls).toBe(3);
+	});
+
+	it("recovers and destroys an allocation whose create response timed out", async () => {
+		const idempotencyKeys: Array<string | undefined> = [];
+		const destroyed: string[] = [];
+		let createCalls = 0;
+		const client = nativeClient({
+			create: (input) => {
+				createCalls++;
+				idempotencyKeys.push(input?.idempotencyKey);
+				if (createCalls === 1) return new Promise<Sandbox>(() => {});
+				return Promise.resolve(nativeSandbox("building_image"));
+			},
+			destroy: async (id) => {
+				destroyed.push(id);
+			},
+		});
+
+		await expect(
+			runcloudCompute({
+				client,
+				controlPlaneTimeoutMs: 5,
+				createRecoveryAttempts: 1,
+				cleanupAttempts: 1,
+			}).sandbox.create(),
+		).rejects.toThrow("run.cloud create did not settle within 5ms");
+		expect(createCalls).toBe(2);
+		expect(idempotencyKeys[0]).toBeDefined();
+		expect(idempotencyKeys[1]).toBe(idempotencyKeys[0]);
+		expect(destroyed).toEqual(["sb-test"]);
+	});
+
+	it("fails within bounded recovery attempts when a timed-out create cannot be recovered", async () => {
+		const idempotencyKeys: Array<string | undefined> = [];
+		const client = nativeClient({
+			create: (input) => {
+				idempotencyKeys.push(input?.idempotencyKey);
+				return new Promise<Sandbox>(() => {});
+			},
+		});
+
+		await expect(
+			runcloudCompute({
+				client,
+				controlPlaneTimeoutMs: 5,
+				createRecoveryAttempts: 2,
+				sleep: async () => {},
+			}).sandbox.create(),
+		).rejects.toThrow(
+			/idempotent allocation could not be recovered; manual cleanup may be required/,
+		);
+		expect(idempotencyKeys).toHaveLength(3);
+		expect(new Set(idempotencyKeys).size).toBe(1);
 	});
 
 	it("retries a transient failed-create cleanup before preserving the readiness error", async () => {

--- a/packages/providers/src/lib/runcloud.test.ts
+++ b/packages/providers/src/lib/runcloud.test.ts
@@ -1,11 +1,11 @@
-import { describe, expect, it, spyOn } from "bun:test";
-import type { SandboxMethods } from "@computesdk/provider";
+import { describe, expect, it } from "bun:test";
 import type { ExecOptions, Sandbox, SandboxState } from "@run-cloud/sdk";
 import { RunCloudError } from "@run-cloud/sdk";
 import {
 	RUNCLOUD_CREATE_TIMEOUT_MS,
 	RUNCLOUD_READY_TIMEOUT_MS,
 	runcloudCompute,
+	sandboxMethods,
 } from "./runcloud.ts";
 
 type ComputeOptions = NonNullable<Parameters<typeof runcloudCompute>[0]>;
@@ -148,27 +148,77 @@ describe("run.cloud ComputeSDK adapter", () => {
 		expect(destroyed).toEqual(["sb-test"]);
 	});
 
-	it("preserves the readiness error when best-effort cleanup also fails", async () => {
-		const consoleError = spyOn(console, "error").mockImplementation(() => {});
-		try {
-			const client = nativeClient({
-				create: async () => nativeSandbox("building_image"),
-				get: async () => {
-					throw new Error("readiness failed");
-				},
-				destroy: async () => {
-					throw new Error("cleanup failed");
-				},
-			});
+	it("retries a transient failed-create cleanup before preserving the readiness error", async () => {
+		let destroyCalls = 0;
+		const client = nativeClient({
+			create: async () => nativeSandbox("building_image"),
+			get: async () => {
+				throw new Error("readiness failed");
+			},
+			destroy: async () => {
+				destroyCalls++;
+				if (destroyCalls === 1) throw new Error("transient cleanup failure");
+			},
+		});
 
-			await expect(runcloudCompute({ client }).sandbox.create()).rejects.toThrow(
-				"readiness failed",
-			);
-			expect(consoleError).toHaveBeenCalledTimes(1);
-			expect(String(consoleError.mock.calls[0]?.[0])).toContain("after readiness failure");
-		} finally {
-			consoleError.mockRestore();
+		await expect(
+			runcloudCompute({ client, cleanupAttempts: 2, sleep: async () => {} }).sandbox.create(),
+		).rejects.toThrow("readiness failed");
+		expect(destroyCalls).toBe(2);
+	});
+
+	it("accepts a destroying confirmation after an ambiguous cleanup response", async () => {
+		let getCalls = 0;
+		let destroyCalls = 0;
+		const client = nativeClient({
+			create: async () => nativeSandbox("building_image"),
+			get: async () => {
+				getCalls++;
+				if (getCalls === 1) throw new Error("readiness failed");
+				return nativeSandbox("destroying");
+			},
+			destroy: async () => {
+				destroyCalls++;
+				throw new Error("response lost after request");
+			},
+		});
+
+		await expect(
+			runcloudCompute({ client, cleanupAttempts: 3, sleep: async () => {} }).sandbox.create(),
+		).rejects.toThrow("readiness failed");
+		expect(destroyCalls).toBe(1);
+		expect(getCalls).toBe(2);
+	});
+
+	it("surfaces the sandbox id and both failures when failed-create cleanup exhausts retries", async () => {
+		let destroyCalls = 0;
+		const readinessError = new Error("readiness failed");
+		const cleanupError = new Error("cleanup failed");
+		const client = nativeClient({
+			create: async () => nativeSandbox("building_image"),
+			get: async () => {
+				throw readinessError;
+			},
+			destroy: async () => {
+				destroyCalls++;
+				throw cleanupError;
+			},
+		});
+
+		try {
+			await runcloudCompute({
+				client,
+				cleanupAttempts: 3,
+				sleep: async () => {},
+			}).sandbox.create();
+			expect.unreachable();
+		} catch (error) {
+			expect(error).toBeInstanceOf(AggregateError);
+			expect((error as AggregateError).errors).toEqual([readinessError, cleanupError]);
+			expect((error as Error).message).toContain("sandbox sb-test");
+			expect((error as Error).message).toContain("manual cleanup may be required");
 		}
+		expect(destroyCalls).toBe(3);
 	});
 
 	it("filters destroyed and destroying tombstones from list", async () => {
@@ -201,10 +251,7 @@ describe("run.cloud ComputeSDK adapter", () => {
 				return { stdout: "out", stderr: "err", exit_code: 7, exitCode: 7 };
 			},
 		});
-		const provider = runcloudCompute({ client });
-		const methods = (
-			provider as unknown as { sandbox: { methods: SandboxMethods<Sandbox, undefined> } }
-		).sandbox.methods;
+		const methods = sandboxMethods({ client });
 		const sandbox = nativeSandbox();
 		let stdout = "";
 		let stderr = "";

--- a/packages/providers/src/lib/runcloud.test.ts
+++ b/packages/providers/src/lib/runcloud.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "bun:test";
+import { describe, expect, it, spyOn } from "bun:test";
 import type { ExecOptions, Sandbox, SandboxState } from "@run-cloud/sdk";
 import { RunCloudError } from "@run-cloud/sdk";
 import { drainRuncloudBackgroundWork, runcloudCompute, sandboxMethods } from "./runcloud.ts";
@@ -292,6 +292,8 @@ describe("run.cloud ComputeSDK adapter", () => {
 				client,
 				controlPlaneTimeoutMs: 5,
 				createRecoveryAttempts: 2,
+				cleanupAttempts: 1,
+				cleanupRetryMs: 0,
 				sleep: async () => {},
 			}).sandbox.create(),
 		).rejects.toThrow(
@@ -299,8 +301,17 @@ describe("run.cloud ComputeSDK adapter", () => {
 		);
 		expect(idempotencyKeys).toHaveLength(3);
 		expect(new Set(idempotencyKeys).size).toBe(1);
-		// Let the retained Promise.any settle so this deliberately hung fake cannot pollute later drain
-		// assertions in the same process. Real SDK fetches reject themselves through the abort signal.
+		const consoleError = spyOn(console, "error").mockImplementation(() => {});
+		try {
+			await drainRuncloudBackgroundWork();
+			expect(consoleError).toHaveBeenCalledWith(
+				expect.stringContaining("late-create cleanup task(s) unfinished"),
+			);
+		} finally {
+			consoleError.mockRestore();
+		}
+		// Let the retained Promise.any settle after proving the drain is bounded, so this deliberately
+		// hung fake cannot pollute later assertions. Real SDK fetches reject through the abort signal.
 		for (const reject of rejectAttempts) reject(new Error("test request cancelled"));
 		await drainRuncloudBackgroundWork();
 	});

--- a/packages/providers/src/lib/runcloud.test.ts
+++ b/packages/providers/src/lib/runcloud.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from "bun:test";
 import type { ExecOptions, Sandbox, SandboxState } from "@run-cloud/sdk";
 import { RunCloudError } from "@run-cloud/sdk";
-import { runcloudCompute, sandboxMethods } from "./runcloud.ts";
+import { drainRuncloudBackgroundWork, runcloudCompute, sandboxMethods } from "./runcloud.ts";
 
 type ComputeOptions = NonNullable<Parameters<typeof runcloudCompute>[0]>;
 type NativeClient = NonNullable<ComputeOptions["client"]>;
@@ -277,10 +277,13 @@ describe("run.cloud ComputeSDK adapter", () => {
 
 	it("fails within bounded recovery attempts when a timed-out create cannot be recovered", async () => {
 		const idempotencyKeys: Array<string | undefined> = [];
+		const rejectAttempts: Array<(error: Error) => void> = [];
 		const client = nativeClient({
 			create: (input) => {
 				idempotencyKeys.push(input?.idempotencyKey);
-				return new Promise<Sandbox>(() => {});
+				return new Promise<Sandbox>((_resolve, reject) => {
+					rejectAttempts.push(reject);
+				});
 			},
 		});
 
@@ -296,9 +299,13 @@ describe("run.cloud ComputeSDK adapter", () => {
 		);
 		expect(idempotencyKeys).toHaveLength(3);
 		expect(new Set(idempotencyKeys).size).toBe(1);
+		// Let the retained Promise.any settle so this deliberately hung fake cannot pollute later drain
+		// assertions in the same process. Real SDK fetches reject themselves through the abort signal.
+		for (const reject of rejectAttempts) reject(new Error("test request cancelled"));
+		await drainRuncloudBackgroundWork();
 	});
 
-	it("retains cleanup for a create response that arrives after recovery exhaustion", async () => {
+	it("drains cleanup for a create response that arrives after recovery exhaustion", async () => {
 		let resolveInitial: ((sandbox: Sandbox) => void) | undefined;
 		let createCalls = 0;
 		const destroyed: string[] = [];
@@ -327,9 +334,16 @@ describe("run.cloud ComputeSDK adapter", () => {
 		).rejects.toThrow(/idempotent allocation could not be recovered/);
 		expect(destroyed).toEqual([]);
 		expect(resolveInitial).toBeDefined();
+		let drained = false;
+		const drain = drainRuncloudBackgroundWork().then(() => {
+			drained = true;
+		});
+		await new Promise((resolve) => setTimeout(resolve, 1));
+		expect(drained).toBe(false);
 		resolveInitial?.(nativeSandbox("building_image"));
-		await new Promise((resolve) => setTimeout(resolve, 10));
+		await drain;
 		expect(destroyed).toEqual(["sb-test"]);
+		expect(drained).toBe(true);
 	});
 
 	it("retries a transient failed-create cleanup before preserving the readiness error", async () => {

--- a/packages/providers/src/lib/runcloud.test.ts
+++ b/packages/providers/src/lib/runcloud.test.ts
@@ -1,12 +1,7 @@
 import { describe, expect, it } from "bun:test";
 import type { ExecOptions, Sandbox, SandboxState } from "@run-cloud/sdk";
 import { RunCloudError } from "@run-cloud/sdk";
-import {
-	RUNCLOUD_CREATE_TIMEOUT_MS,
-	RUNCLOUD_READY_TIMEOUT_MS,
-	runcloudCompute,
-	sandboxMethods,
-} from "./runcloud.ts";
+import { runcloudCompute, sandboxMethods } from "./runcloud.ts";
 
 type ComputeOptions = NonNullable<Parameters<typeof runcloudCompute>[0]>;
 type NativeClient = NonNullable<ComputeOptions["client"]>;
@@ -48,11 +43,6 @@ function nativeClient(overrides: Partial<NativeClient> = {}): NativeClient {
 }
 
 describe("run.cloud ComputeSDK adapter", () => {
-	it("keeps the harness create timeout beyond the adapter readiness window", () => {
-		expect(RUNCLOUD_CREATE_TIMEOUT_MS).toBeGreaterThan(RUNCLOUD_READY_TIMEOUT_MS);
-		expect(RUNCLOUD_CREATE_TIMEOUT_MS - RUNCLOUD_READY_TIMEOUT_MS).toBe(5 * 60 * 1000);
-	});
-
 	it("forwards create policy and waits through a transitional state", async () => {
 		let createInput: Record<string, unknown> | undefined;
 		const states = [nativeSandbox("building_image"), nativeSandbox("running")];

--- a/packages/providers/src/lib/runcloud.ts
+++ b/packages/providers/src/lib/runcloud.ts
@@ -23,6 +23,10 @@ export const RUNCLOUD_READY_TIMEOUT_MS = 20 * 60 * 1000;
 /** The harness's outer create race starts before the allocation request, while the readiness clock
  * starts after it. Keep five minutes of headroom for allocation latency and cleanup. */
 export const RUNCLOUD_CREATE_TIMEOUT_MS = RUNCLOUD_READY_TIMEOUT_MS + 5 * 60 * 1000;
+/** A destroy request can fail transiently after allocation succeeded. Retry inside create(), because
+ * the harness has no sandbox handle (and therefore no generic cleanup path) until create resolves. */
+const CREATE_FAILURE_CLEANUP_ATTEMPTS = 5;
+const CREATE_FAILURE_CLEANUP_RETRY_MS = 2_000;
 
 type RuncloudSandboxClient = Pick<
 	Client["sandboxes"],
@@ -34,6 +38,8 @@ interface RuncloudComputeOptions {
 	client?: RuncloudSandboxClient;
 	readyPollMs?: number;
 	readyTimeoutMs?: number;
+	cleanupAttempts?: number;
+	cleanupRetryMs?: number;
 	sleep?: (ms: number) => Promise<void>;
 	now?: () => number;
 }
@@ -49,12 +55,14 @@ function isNotFound(error: unknown): boolean {
 	return error instanceof RunCloudError && error.status === 404;
 }
 
-function mapStatus(state: string): SandboxInfo["status"] {
+function mapStatus(state: Sandbox["state"]): SandboxInfo["status"] {
 	if (state === "running") return "running";
 	// Interrupted / failed are hard errors (not a clean stop); match the official SDK adapter.
 	if (state === "interrupted" || state === "failed") return "error";
 	// Clean stops and transitional boot states (building_image / starting) report as stopped —
-	// create() waits for running before returning, so getInfo rarely sees a transitional state.
+	// create() waits for running before returning, so getInfo rarely sees a transitional state. The SDK
+	// intentionally ends SandboxState with `| string`, so unknown future/control-plane states cannot be
+	// made compile-time exhaustive and must retain a safe fallback.
 	return "stopped";
 }
 
@@ -63,7 +71,7 @@ function sleep(ms: number): Promise<void> {
 }
 
 /** Terminal states that mean boot failed and we should stop waiting. */
-function isTerminalBootFailure(state: string): boolean {
+function isTerminalBootFailure(state: Sandbox["state"]): boolean {
 	return ["failed", "interrupted", "destroyed", "destroying", "stopped"].includes(state);
 }
 
@@ -104,6 +112,47 @@ async function destroySandbox(native: RuncloudSandboxClient, sandboxId: string):
 		if (isNotFound(error)) return;
 		throw error;
 	}
+}
+
+/**
+ * Tear down an allocation whose readiness wait failed. A rejected destroy is ambiguous: the request
+ * may have reached the control plane before the response was lost. Confirm an accepted teardown via
+ * get(), otherwise retry. Exhaustion is surfaced together with the readiness error by create().
+ */
+async function cleanupFailedCreate(
+	native: RuncloudSandboxClient,
+	sandboxId: string,
+	options: RuncloudComputeOptions,
+): Promise<void> {
+	const attempts = Math.max(
+		1,
+		Math.floor(options.cleanupAttempts ?? CREATE_FAILURE_CLEANUP_ATTEMPTS),
+	);
+	const retryMs = Math.max(0, options.cleanupRetryMs ?? CREATE_FAILURE_CLEANUP_RETRY_MS);
+	const wait = options.sleep ?? sleep;
+	let lastError: unknown;
+	for (let attempt = 1; attempt <= attempts; attempt++) {
+		try {
+			await destroySandbox(native, sandboxId);
+			return;
+		} catch (error) {
+			lastError = error;
+			// A lost response after an accepted destroy must not turn into a false leak report. Both states
+			// mean the control plane owns the remaining teardown; 404 means it has already completed.
+			try {
+				const current = await native.get(sandboxId);
+				if (current.state === "destroying" || current.state === "destroyed") return;
+			} catch (confirmError) {
+				if (isNotFound(confirmError)) return;
+			}
+			if (attempt < attempts) await wait(retryMs);
+		}
+	}
+	throw lastError;
+}
+
+function errorMessage(error: unknown): string {
+	return error instanceof Error ? error.message : String(error);
 }
 
 function createdAt(value: string | undefined): Date {
@@ -159,7 +208,7 @@ async function runCommand(
 	};
 }
 
-function sandboxMethods(
+export function sandboxMethods(
 	adapterOptions: RuncloudComputeOptions,
 ): SandboxMethods<Sandbox, undefined> {
 	const native = () => adapterOptions.client ?? defaultClient().sandboxes;
@@ -191,14 +240,16 @@ function sandboxMethods(
 				const sandbox = await waitUntilRunning(sdk, created.id, adapterOptions);
 				return { sandbox, sandboxId: sandbox.id };
 			} catch (error) {
-				// Allocation already succeeded, but the harness has no handle until create() resolves. Clean up
-				// here so a terminal boot, transient poll failure, or readiness timeout cannot leak a sandbox.
+				// Allocation already succeeded, but the harness has no handle until create() resolves. Own the
+				// cleanup (including transient destroy retries) here rather than reducing it to one best-effort
+				// request that can silently strand a billable sandbox.
 				try {
-					await destroySandbox(sdk, created.id);
+					await cleanupFailedCreate(sdk, created.id, adapterOptions);
 				} catch (destroyError) {
-					console.error(
-						`run.cloud: failed to destroy sandbox ${created.id} after readiness failure:`,
-						destroyError,
+					throw new AggregateError(
+						[error, destroyError],
+						`run.cloud sandbox ${created.id} failed readiness (${errorMessage(error)}) and ` +
+							`could not be destroyed after retries (${errorMessage(destroyError)}); manual cleanup may be required`,
 					);
 				}
 				throw error;

--- a/packages/providers/src/lib/runcloud.ts
+++ b/packages/providers/src/lib/runcloud.ts
@@ -1,6 +1,7 @@
 // ComputeSDK provider built directly over run.cloud's native SDK. The SDK reads
 // RUN_CLOUD_API_KEY itself; construction stays lazy so importing the provider registry never needs
 // credentials. One benchmark cell drives one provider, so a process-local client is sufficient.
+import { randomUUID } from "node:crypto";
 import type {
 	CommandResult,
 	CreateSandboxOptions,
@@ -24,6 +25,12 @@ export const RUNCLOUD_READY_TIMEOUT_MS = 20 * 60 * 1000;
  * the harness has no sandbox handle (and therefore no generic cleanup path) until create resolves. */
 const CREATE_FAILURE_CLEANUP_ATTEMPTS = 5;
 const CREATE_FAILURE_CLEANUP_RETRY_MS = 2_000;
+/** Bound each REST control-plane call independently. The adapter owns the longer readiness window,
+ * but a fetch that never settles must not suspend its deadline check or failed-create cleanup. */
+const CONTROL_PLANE_REQUEST_TIMEOUT_MS = 30_000;
+/** A timed-out create response is ambiguous: the server may have allocated the sandbox. Retry the
+ * same idempotent request to recover its handle so cleanup can be awaited before returning. */
+const CREATE_RECOVERY_ATTEMPTS = 3;
 
 type RuncloudSandboxClient = Pick<
 	Client["sandboxes"],
@@ -37,15 +44,76 @@ interface RuncloudComputeOptions {
 	readyTimeoutMs?: number;
 	cleanupAttempts?: number;
 	cleanupRetryMs?: number;
+	controlPlaneTimeoutMs?: number;
+	createRecoveryAttempts?: number;
 	sleep?: (ms: number) => Promise<void>;
 	now?: () => number;
 }
 
 let cachedClient: Client | undefined;
 
+const controlPlaneFetch: typeof fetch = Object.assign(
+	(...args: Parameters<typeof fetch>) =>
+		fetch(args[0], {
+			...args[1],
+			signal: AbortSignal.timeout(CONTROL_PLANE_REQUEST_TIMEOUT_MS),
+		}),
+	{ preconnect: fetch.preconnect },
+);
+
 function defaultClient(): Client {
-	cachedClient ??= new Client();
+	// Promise deadlines below bound every adapter call, while the fetch signal also cancels the actual
+	// socket so a timed-out request does not remain as floating work until process exit.
+	cachedClient ??= new Client({ fetch: controlPlaneFetch });
 	return cachedClient;
+}
+
+class NativeCallTimeoutError extends Error {
+	constructor(
+		readonly operation: string,
+		readonly timeoutMs: number,
+	) {
+		super(`run.cloud ${operation} did not settle within ${timeoutMs}ms`);
+		this.name = "NativeCallTimeoutError";
+	}
+}
+
+function isNativeCallTimeout(error: unknown): boolean {
+	return (
+		error instanceof NativeCallTimeoutError ||
+		(error instanceof DOMException && error.name === "TimeoutError")
+	);
+}
+
+/**
+ * Race one native control-plane operation with a local deadline. Production's fetch signal cancels
+ * the underlying HTTP request too; the race remains necessary for injected clients and runtimes whose
+ * fetch ignores abort. Promise.race attaches a rejection handler to late promises, so they cannot
+ * become unhandled rejections after the deadline wins.
+ */
+async function boundedNativeCall<T>(
+	operation: string,
+	call: () => Promise<T>,
+	options: RuncloudComputeOptions,
+): Promise<T> {
+	const timeoutMs = Math.max(
+		1,
+		Math.floor(options.controlPlaneTimeoutMs ?? CONTROL_PLANE_REQUEST_TIMEOUT_MS),
+	);
+	let timer: ReturnType<typeof setTimeout> | undefined;
+	try {
+		return await Promise.race([
+			Promise.resolve().then(call),
+			new Promise<never>((_, reject) => {
+				timer = setTimeout(
+					() => reject(new NativeCallTimeoutError(operation, timeoutMs)),
+					timeoutMs,
+				);
+			}),
+		]);
+	} finally {
+		if (timer !== undefined) clearTimeout(timer);
+	}
 }
 
 function isNotFound(error: unknown): boolean {
@@ -88,7 +156,11 @@ async function waitUntilRunning(
 	const deadline = now() + timeoutMs;
 	let last: Sandbox | undefined;
 	while (now() < deadline) {
-		last = await native.get(sandboxId);
+		last = await boundedNativeCall(
+			`readiness get for sandbox ${sandboxId}`,
+			() => native.get(sandboxId),
+			options,
+		);
 		if (last.state === "running") return last;
 		if (isTerminalBootFailure(last.state)) {
 			throw new Error(
@@ -102,9 +174,17 @@ async function waitUntilRunning(
 	);
 }
 
-async function destroySandbox(native: RuncloudSandboxClient, sandboxId: string): Promise<void> {
+async function destroySandbox(
+	native: RuncloudSandboxClient,
+	sandboxId: string,
+	options: RuncloudComputeOptions,
+): Promise<void> {
 	try {
-		await native.destroy(sandboxId);
+		await boundedNativeCall(
+			`destroy sandbox ${sandboxId}`,
+			() => native.destroy(sandboxId),
+			options,
+		);
 	} catch (error) {
 		if (isNotFound(error)) return;
 		throw error;
@@ -130,18 +210,55 @@ async function cleanupFailedCreate(
 	let lastError: unknown;
 	for (let attempt = 1; attempt <= attempts; attempt++) {
 		try {
-			await destroySandbox(native, sandboxId);
+			await destroySandbox(native, sandboxId, options);
 			return;
 		} catch (error) {
 			lastError = error;
 			// A lost response after an accepted destroy must not turn into a false leak report. Both states
 			// mean the control plane owns the remaining teardown; 404 means it has already completed.
 			try {
-				const current = await native.get(sandboxId);
+				const current = await boundedNativeCall(
+					`confirm cleanup for sandbox ${sandboxId}`,
+					() => native.get(sandboxId),
+					options,
+				);
 				if (current.state === "destroying" || current.state === "destroyed") return;
 			} catch (confirmError) {
 				if (isNotFound(confirmError)) return;
 			}
+			if (attempt < attempts) await wait(retryMs);
+		}
+	}
+	throw lastError;
+}
+
+/**
+ * Recover the handle for an ambiguous timed-out create by replaying the SAME idempotent request. The
+ * original promise participates too: if its delayed response arrives during recovery, its sandbox is
+ * cleaned up without waiting for another API response. Every recovery attempt has its own deadline.
+ */
+async function recoverTimedOutCreate(
+	native: RuncloudSandboxClient,
+	createInput: NonNullable<Parameters<RuncloudSandboxClient["create"]>[0]>,
+	original: Promise<Sandbox>,
+	options: RuncloudComputeOptions,
+): Promise<Sandbox> {
+	const attempts = Math.max(
+		1,
+		Math.floor(options.createRecoveryAttempts ?? CREATE_RECOVERY_ATTEMPTS),
+	);
+	const retryMs = Math.max(0, options.cleanupRetryMs ?? CREATE_FAILURE_CLEANUP_RETRY_MS);
+	const wait = options.sleep ?? sleep;
+	let lastError: unknown;
+	for (let attempt = 1; attempt <= attempts; attempt++) {
+		try {
+			return await boundedNativeCall(
+				`create recovery attempt ${attempt}`,
+				() => Promise.any([original, native.create(createInput)]),
+				options,
+			);
+		} catch (error) {
+			lastError = error;
 			if (attempt < attempts) await wait(retryMs);
 		}
 	}
@@ -215,7 +332,10 @@ export function sandboxMethods(
 				throw new Error("run.cloud snapshots are not supported by this adapter");
 			}
 			const sdk = native();
-			const created = await sdk.create({
+			// The stable key makes a timed-out response recoverable: replaying create returns the original
+			// allocation instead of creating a second sandbox, so we can await its teardown before rejecting.
+			const createInput = {
+				idempotencyKey: `sandbox-benchmarks-${randomUUID()}`,
 				...(createOptions?.templateId || createOptions?.image
 					? { image: createOptions.templateId ?? createOptions.image }
 					: {}),
@@ -230,7 +350,34 @@ export function sandboxMethods(
 					: {}),
 				...(createOptions?.region ? { region: createOptions.region } : {}),
 				...(createOptions?.name ? { name: createOptions.name } : {}),
-			});
+			};
+			const createPromise = Promise.resolve().then(() => sdk.create(createInput));
+			let created: Sandbox;
+			try {
+				created = await boundedNativeCall("create", () => createPromise, adapterOptions);
+			} catch (error) {
+				if (!isNativeCallTimeout(error)) throw error;
+				let recovered: Sandbox;
+				try {
+					recovered = await recoverTimedOutCreate(sdk, createInput, createPromise, adapterOptions);
+				} catch (recoveryError) {
+					throw new AggregateError(
+						[error, recoveryError],
+						`run.cloud create timed out and its idempotent allocation could not be recovered; ` +
+							`manual cleanup may be required (idempotency key: ${createInput.idempotencyKey})`,
+					);
+				}
+				try {
+					await cleanupFailedCreate(sdk, recovered.id, adapterOptions);
+				} catch (cleanupError) {
+					throw new AggregateError(
+						[error, cleanupError],
+						`run.cloud create timed out, recovered sandbox ${recovered.id}, and could not destroy it ` +
+							`after retries (${errorMessage(cleanupError)}); manual cleanup may be required`,
+					);
+				}
+				throw error;
+			}
 			// Do not return until the guest can accept commands — cold image pulls leave the sandbox in
 			// `building_image` for minutes, and exec during that window fails with API 4409.
 			try {
@@ -255,7 +402,11 @@ export function sandboxMethods(
 
 		getById: async (_config, sandboxId) => {
 			try {
-				const sandbox = await native().get(sandboxId);
+				const sandbox = await boundedNativeCall(
+					`get sandbox ${sandboxId}`,
+					() => native().get(sandboxId),
+					adapterOptions,
+				);
 				return { sandbox, sandboxId: sandbox.id };
 			} catch (error) {
 				if (isNotFound(error)) return null;
@@ -264,19 +415,23 @@ export function sandboxMethods(
 		},
 
 		list: async () =>
-			(await native().list())
+			(await boundedNativeCall("list sandboxes", () => native().list(), adapterOptions))
 				// The native API retains destroyed tombstones. ComputeSDK's list contract is active sandboxes;
 				// keep paused/stopped/failed records available for recovery, but omit irreversible teardown.
 				.filter((sandbox) => sandbox.state !== "destroyed" && sandbox.state !== "destroying")
 				.map((sandbox) => ({ sandbox, sandboxId: sandbox.id })),
 
-		destroy: async (_config, sandboxId) => destroySandbox(native(), sandboxId),
+		destroy: async (_config, sandboxId) => destroySandbox(native(), sandboxId, adapterOptions),
 
 		runCommand: (sandbox, command, runOptions) =>
 			runCommand(native(), sandbox, command, runOptions),
 
 		getInfo: async (sandbox) => {
-			const current = await native().get(sandbox.id);
+			const current = await boundedNativeCall(
+				`get sandbox ${sandbox.id}`,
+				() => native().get(sandbox.id),
+				adapterOptions,
+			);
 			return {
 				id: current.id,
 				provider: PROVIDER,
@@ -294,7 +449,14 @@ export function sandboxMethods(
 			};
 		},
 
-		getUrl: async (sandbox, options) => (await native().openTunnel(sandbox.id, options.port)).url,
+		getUrl: async (sandbox, options) =>
+			(
+				await boundedNativeCall(
+					`open tunnel for sandbox ${sandbox.id}`,
+					() => native().openTunnel(sandbox.id, options.port),
+					adapterOptions,
+				)
+			).url,
 	};
 }
 

--- a/packages/providers/src/lib/runcloud.ts
+++ b/packages/providers/src/lib/runcloud.ts
@@ -1,0 +1,164 @@
+// ComputeSDK provider built directly over run.cloud's native SDK. The SDK reads
+// RUN_CLOUD_API_KEY itself; construction stays lazy so importing the provider registry never needs
+// credentials. One benchmark cell drives one provider, so a process-local client is sufficient.
+import type {
+	CommandResult,
+	CreateSandboxOptions,
+	RunCommandOptions,
+	SandboxInfo,
+	SandboxMethods,
+} from "@computesdk/provider";
+import { defineProvider } from "@computesdk/provider";
+import type { Sandbox } from "@run-cloud/sdk";
+import { Client, RunCloudError } from "@run-cloud/sdk";
+
+const PROVIDER = "runcloud";
+
+let cachedClient: Client | undefined;
+
+function client(): Client {
+	cachedClient ??= new Client();
+	return cachedClient;
+}
+
+function isNotFound(error: unknown): boolean {
+	return error instanceof RunCloudError && error.status === 404;
+}
+
+function mapStatus(state: Sandbox["state"]): SandboxInfo["status"] {
+	if (state === "running") return "running";
+	if (["paused", "stopped", "destroying", "interrupted", "destroyed"].includes(state)) {
+		return "stopped";
+	}
+	return "error";
+}
+
+function createdAt(value: string | undefined): Date {
+	if (!value) return new Date(0);
+	const parsed = new Date(value);
+	return Number.isNaN(parsed.getTime()) ? new Date(0) : parsed;
+}
+
+function shellQuote(value: string): string {
+	return `'${value.replace(/'/g, `'\\''`)}'`;
+}
+
+function streamCallback(
+	callback: ((data: string) => void) | undefined,
+): ((chunk: Uint8Array) => void) | undefined {
+	if (!callback) return undefined;
+	const decoder = new TextDecoder();
+	return (chunk) => {
+		const text = decoder.decode(chunk, { stream: true });
+		if (text) callback(text);
+	};
+}
+
+async function runCommand(
+	sandbox: Sandbox,
+	command: string,
+	options?: RunCommandOptions,
+): Promise<CommandResult> {
+	const started = Date.now();
+	// The native SDK does not have a detached exec flag. Its command endpoint does run a shell, so
+	// daemonize explicitly and return once that short launch command exits. StepRunner observes the
+	// actual job through its done file, exactly as it does for native-background providers.
+	const executable = options?.background
+		? `nohup /bin/sh -lc ${shellQuote(command)} </dev/null >/dev/null 2>&1 &`
+		: command;
+	const result = await client().sandboxes.exec(sandbox.id, executable, {
+		...(options?.cwd ? { cwd: options.cwd } : {}),
+		...(options?.env ? { env: options.env } : {}),
+		...(options?.timeout ? { timeoutSeconds: Math.max(1, Math.ceil(options.timeout / 1000)) } : {}),
+		...(options?.background
+			? {}
+			: {
+					onStdout: streamCallback(options?.onStdout),
+					onStderr: streamCallback(options?.onStderr),
+				}),
+	});
+	return {
+		stdout: options?.background ? "" : result.stdout,
+		stderr: options?.background ? "" : result.stderr,
+		exitCode: result.exitCode,
+		durationMs: Date.now() - started,
+	};
+}
+
+const methods: SandboxMethods<Sandbox, undefined> = {
+	create: async (_config, options?: CreateSandboxOptions) => {
+		if (options?.snapshotId) {
+			throw new Error("run.cloud snapshots are not supported by this adapter");
+		}
+		const sandbox = await client().sandboxes.create({
+			...(options?.templateId || options?.image
+				? { image: options.templateId ?? options.image }
+				: {}),
+			...(options?.cpu !== undefined ? { cpu: options.cpu } : {}),
+			...(options?.memory !== undefined ? { memory: options.memory } : {}),
+			...(options?.disk !== undefined ? { disk: options.disk } : {}),
+			...(options?.idlePauseSeconds !== undefined
+				? { idlePauseSeconds: options.idlePauseSeconds }
+				: {}),
+			...(options?.timeoutSeconds !== undefined ? { timeoutSeconds: options.timeoutSeconds } : {}),
+			...(options?.region ? { region: options.region } : {}),
+			...(options?.name ? { name: options.name } : {}),
+		});
+		return { sandbox, sandboxId: sandbox.id };
+	},
+
+	getById: async (_config, sandboxId) => {
+		try {
+			const sandbox = await client().sandboxes.get(sandboxId);
+			return { sandbox, sandboxId: sandbox.id };
+		} catch (error) {
+			if (isNotFound(error)) return null;
+			throw error;
+		}
+	},
+
+	list: async () =>
+		(await client().sandboxes.list()).map((sandbox) => ({ sandbox, sandboxId: sandbox.id })),
+
+	destroy: async (_config, sandboxId) => {
+		try {
+			await client().sandboxes.destroy(sandboxId);
+		} catch (error) {
+			if (isNotFound(error)) return;
+			throw error;
+		}
+	},
+
+	runCommand,
+
+	getInfo: async (sandbox) => {
+		const current = await client().sandboxes.get(sandbox.id);
+		return {
+			id: current.id,
+			provider: PROVIDER,
+			status: mapStatus(current.state),
+			createdAt: createdAt(current.createdAt),
+			timeout: (current.timeoutSeconds ?? 0) * 1000,
+			metadata: {
+				image: current.image,
+				region: current.region,
+				sizeClass: current.sizeClass,
+				milliCpu: current.milliCpu,
+				memoryMb: current.memMb,
+				warmStart: current.warmStart,
+			},
+		};
+	},
+
+	getUrl: async (sandbox, options) =>
+		(await client().sandboxes.openTunnel(sandbox.id, options.port)).url,
+};
+
+const createRuncloudProvider = defineProvider<Sandbox, undefined>({
+	name: PROVIDER,
+	methods: { sandbox: methods },
+});
+
+export function runcloudCompute() {
+	return createRuncloudProvider(undefined);
+}

--- a/packages/providers/src/lib/runcloud.ts
+++ b/packages/providers/src/lib/runcloud.ts
@@ -55,7 +55,13 @@ let cachedClient: Client | undefined;
 // A create response can arrive after every local deadline has expired. Keep that final cleanup
 // visible to the benchmark entrypoints: they intentionally use process.exit(), which otherwise
 // terminates promise continuations even while a billable sandbox is being destroyed.
-const pendingLateCreateCleanups = new Set<Promise<void>>();
+interface PendingLateCreateCleanup {
+	promise: Promise<void>;
+	/** Wall-clock ceiling covering one late response plus the complete cleanup retry sequence. */
+	deadline: number;
+}
+
+const pendingLateCreateCleanups = new Set<PendingLateCreateCleanup>();
 
 const controlPlaneFetch: typeof fetch = Object.assign(
 	(...args: Parameters<typeof fetch>) =>
@@ -304,8 +310,27 @@ function retainLateCreateCleanup(
 		},
 		() => {},
 	);
-	pendingLateCreateCleanups.add(cleanup);
-	void cleanup.finally(() => pendingLateCreateCleanups.delete(cleanup));
+	const controlPlaneTimeoutMs = Math.max(
+		1,
+		Math.floor(options.controlPlaneTimeoutMs ?? CONTROL_PLANE_REQUEST_TIMEOUT_MS),
+	);
+	const cleanupAttempts = Math.max(
+		1,
+		Math.floor(options.cleanupAttempts ?? CREATE_FAILURE_CLEANUP_ATTEMPTS),
+	);
+	const cleanupRetryMs = Math.max(0, options.cleanupRetryMs ?? CREATE_FAILURE_CLEANUP_RETRY_MS);
+	// Allow one still-pending create response, then every destroy + confirmation deadline and every
+	// inter-attempt delay. Production's default is 338s; injected tests derive a correspondingly small
+	// ceiling. The task remains registered after expiry so it can still finish and unregister itself if
+	// the caller elects to keep the process alive after the warning.
+	const deadline =
+		Date.now() +
+		controlPlaneTimeoutMs +
+		cleanupAttempts * 2 * controlPlaneTimeoutMs +
+		(cleanupAttempts - 1) * cleanupRetryMs;
+	const pending = { promise: cleanup, deadline };
+	pendingLateCreateCleanups.add(pending);
+	void cleanup.finally(() => pendingLateCreateCleanups.delete(pending));
 }
 
 /**
@@ -314,8 +339,29 @@ function retainLateCreateCleanup(
  * the deadline race is allowed to finish its fully awaited destroy/retry sequence.
  */
 export async function drainRuncloudBackgroundWork(): Promise<void> {
+	const startedAt = Date.now();
 	while (pendingLateCreateCleanups.size > 0) {
-		await Promise.all([...pendingLateCreateCleanups]);
+		const pending = [...pendingLateCreateCleanups];
+		const deadline = Math.max(...pending.map((entry) => entry.deadline));
+		const remainingMs = Math.max(0, deadline - Date.now());
+		let timer: ReturnType<typeof setTimeout> | undefined;
+		const completed = await Promise.race([
+			Promise.all(pending.map((entry) => entry.promise)).then(() => true),
+			new Promise<false>((resolve) => {
+				timer = setTimeout(() => resolve(false), remainingMs);
+			}),
+		]).finally(() => {
+			if (timer !== undefined) clearTimeout(timer);
+		});
+		if (completed) continue;
+		// A task may have been registered with a later ceiling while the previous snapshot was waiting.
+		// Recompute before giving up so concurrent provider cells retain their own full cleanup budget.
+		if ([...pendingLateCreateCleanups].some((entry) => entry.deadline > Date.now())) continue;
+		console.error(
+			`run.cloud left ${pendingLateCreateCleanups.size} late-create cleanup task(s) unfinished ` +
+				`after ${Date.now() - startedAt}ms; manual cleanup may be required`,
+		);
+		return;
 	}
 }
 

--- a/packages/providers/src/lib/runcloud.ts
+++ b/packages/providers/src/lib/runcloud.ts
@@ -52,6 +52,11 @@ interface RuncloudComputeOptions {
 
 let cachedClient: Client | undefined;
 
+// A create response can arrive after every local deadline has expired. Keep that final cleanup
+// visible to the benchmark entrypoints: they intentionally use process.exit(), which otherwise
+// terminates promise continuations even while a billable sandbox is being destroyed.
+const pendingLateCreateCleanups = new Set<Promise<void>>();
+
 const controlPlaneFetch: typeof fetch = Object.assign(
 	(...args: Parameters<typeof fetch>) =>
 		fetch(args[0], {
@@ -277,30 +282,40 @@ async function recoverAmbiguousCreate(
  * every bounded recovery window expired. Production fetches are actively aborted, so they settle
  * before this point; retaining these continuations prevents an injected/alternate client from
  * discarding a late sandbox handle. The idempotency key means every response names the same sandbox,
- * and the set prevents concurrent duplicate cleanup loops.
+ * so the first fulfilled attempt identifies the one allocation that needs cleanup.
  */
 function retainLateCreateCleanup(
 	native: RuncloudSandboxClient,
 	createAttempts: readonly Promise<Sandbox>[],
 	options: RuncloudComputeOptions,
 ): void {
-	const claimed = new Set<string>();
-	for (const attempt of createAttempts) {
-		void attempt.then(
-			async (late) => {
-				if (claimed.has(late.id)) return;
-				claimed.add(late.id);
-				try {
-					await cleanupFailedCreate(native, late.id, options);
-				} catch (error) {
-					console.error(
-						`run.cloud late create returned sandbox ${late.id}, but cleanup failed ` +
-							`(${errorMessage(error)}); manual cleanup may be required`,
-					);
-				}
-			},
-			() => {},
-		);
+	// Every replay uses one idempotency key, so the first successful response identifies the sole
+	// allocation. Promise.any also stays pending while a transport-ignoring attempt might still return.
+	const cleanup = Promise.any(createAttempts).then(
+		async (late) => {
+			try {
+				await cleanupFailedCreate(native, late.id, options);
+			} catch (error) {
+				console.error(
+					`run.cloud late create returned sandbox ${late.id}, but cleanup failed ` +
+						`(${errorMessage(error)}); manual cleanup may be required`,
+				);
+			}
+		},
+		() => {},
+	);
+	pendingLateCreateCleanups.add(cleanup);
+	void cleanup.finally(() => pendingLateCreateCleanups.delete(cleanup));
+}
+
+/**
+ * Await every late-create cleanup retained by the run.cloud adapter. Benchmark bins call this before
+ * their explicit process exit; production REST requests are abort-bounded, while a response that won
+ * the deadline race is allowed to finish its fully awaited destroy/retry sequence.
+ */
+export async function drainRuncloudBackgroundWork(): Promise<void> {
+	while (pendingLateCreateCleanups.size > 0) {
+		await Promise.all([...pendingLateCreateCleanups]);
 	}
 }
 

--- a/packages/providers/src/lib/runcloud.ts
+++ b/packages/providers/src/lib/runcloud.ts
@@ -240,7 +240,7 @@ async function cleanupFailedCreate(
 async function recoverTimedOutCreate(
 	native: RuncloudSandboxClient,
 	createInput: NonNullable<Parameters<RuncloudSandboxClient["create"]>[0]>,
-	original: Promise<Sandbox>,
+	createAttempts: Promise<Sandbox>[],
 	options: RuncloudComputeOptions,
 ): Promise<Sandbox> {
 	const attempts = Math.max(
@@ -252,9 +252,12 @@ async function recoverTimedOutCreate(
 	let lastError: unknown;
 	for (let attempt = 1; attempt <= attempts; attempt++) {
 		try {
+			// Retain every issued promise. A previous attempt may resolve during a later recovery window,
+			// and all of them need cleanup continuations if every bounded window ultimately expires.
+			createAttempts.push(Promise.resolve().then(() => native.create(createInput)));
 			return await boundedNativeCall(
 				`create recovery attempt ${attempt}`,
-				() => Promise.any([original, native.create(createInput)]),
+				() => Promise.any(createAttempts),
 				options,
 			);
 		} catch (error) {
@@ -263,6 +266,38 @@ async function recoverTimedOutCreate(
 		}
 	}
 	throw lastError;
+}
+
+/**
+ * Last-resort cleanup for a client/runtime that ignores abort and returns a create response only after
+ * every bounded recovery window expired. Production fetches are actively aborted, so they settle
+ * before this point; retaining these continuations prevents an injected/alternate client from
+ * discarding a late sandbox handle. The idempotency key means every response names the same sandbox,
+ * and the set prevents concurrent duplicate cleanup loops.
+ */
+function retainLateCreateCleanup(
+	native: RuncloudSandboxClient,
+	createAttempts: readonly Promise<Sandbox>[],
+	options: RuncloudComputeOptions,
+): void {
+	const claimed = new Set<string>();
+	for (const attempt of createAttempts) {
+		void attempt.then(
+			async (late) => {
+				if (claimed.has(late.id)) return;
+				claimed.add(late.id);
+				try {
+					await cleanupFailedCreate(native, late.id, options);
+				} catch (error) {
+					console.error(
+						`run.cloud late create returned sandbox ${late.id}, but cleanup failed ` +
+							`(${errorMessage(error)}); manual cleanup may be required`,
+					);
+				}
+			},
+			() => {},
+		);
+	}
 }
 
 function errorMessage(error: unknown): string {
@@ -352,6 +387,7 @@ export function sandboxMethods(
 				...(createOptions?.name ? { name: createOptions.name } : {}),
 			};
 			const createPromise = Promise.resolve().then(() => sdk.create(createInput));
+			const createAttempts = [createPromise];
 			let created: Sandbox;
 			try {
 				created = await boundedNativeCall("create", () => createPromise, adapterOptions);
@@ -359,8 +395,9 @@ export function sandboxMethods(
 				if (!isNativeCallTimeout(error)) throw error;
 				let recovered: Sandbox;
 				try {
-					recovered = await recoverTimedOutCreate(sdk, createInput, createPromise, adapterOptions);
+					recovered = await recoverTimedOutCreate(sdk, createInput, createAttempts, adapterOptions);
 				} catch (recoveryError) {
+					retainLateCreateCleanup(sdk, createAttempts, adapterOptions);
 					throw new AggregateError(
 						[error, recoveryError],
 						`run.cloud create timed out and its idempotent allocation could not be recovered; ` +

--- a/packages/providers/src/lib/runcloud.ts
+++ b/packages/providers/src/lib/runcloud.ts
@@ -14,6 +14,13 @@ import { Client, RunCloudError } from "@run-cloud/sdk";
 
 const PROVIDER = "runcloud";
 
+/** Create returns as soon as the control plane accepts the sandbox; the OCI pull/boot happens
+ *  asynchronously (`building_image`). The harness expects `create()` to resolve only once commands
+ *  can run, so the adapter polls until `running` (or a terminal failure). */
+const CREATE_READY_POLL_MS = 2_000;
+/** Cold pulls of the ~1.5 GiB toolchain image on a first-use host can take several minutes. */
+const CREATE_READY_TIMEOUT_MS = 20 * 60 * 1000;
+
 let cachedClient: Client | undefined;
 
 function client(): Client {
@@ -25,12 +32,44 @@ function isNotFound(error: unknown): boolean {
 	return error instanceof RunCloudError && error.status === 404;
 }
 
-function mapStatus(state: Sandbox["state"]): SandboxInfo["status"] {
+function mapStatus(state: string): SandboxInfo["status"] {
 	if (state === "running") return "running";
-	if (["paused", "stopped", "destroying", "interrupted", "destroyed"].includes(state)) {
-		return "stopped";
+	// Interrupted / failed are hard errors (not a clean stop); match the official SDK adapter.
+	if (state === "interrupted" || state === "failed") return "error";
+	// Clean stops and transitional boot states (building_image / starting) report as stopped —
+	// create() waits for running before returning, so getInfo rarely sees a transitional state.
+	return "stopped";
+}
+
+function sleep(ms: number): Promise<void> {
+	return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+/** Terminal states that mean boot failed and we should stop waiting. */
+function isTerminalBootFailure(state: string): boolean {
+	return ["failed", "interrupted", "destroyed", "destroying", "stopped"].includes(state);
+}
+
+/**
+ * Poll until the sandbox can accept execs. Returns the freshest record so callers don't keep a
+ * stale `building_image` handle from the original create response.
+ */
+async function waitUntilRunning(sandboxId: string): Promise<Sandbox> {
+	const deadline = Date.now() + CREATE_READY_TIMEOUT_MS;
+	let last: Sandbox | undefined;
+	while (Date.now() < deadline) {
+		last = await client().sandboxes.get(sandboxId);
+		if (last.state === "running") return last;
+		if (isTerminalBootFailure(last.state)) {
+			throw new Error(
+				`run.cloud sandbox ${sandboxId} entered terminal state "${last.state}" while booting`,
+			);
+		}
+		await sleep(CREATE_READY_POLL_MS);
 	}
-	return "error";
+	throw new Error(
+		`run.cloud sandbox ${sandboxId} not running after ${CREATE_READY_TIMEOUT_MS}ms (last state: ${last?.state ?? "unknown"})`,
+	);
 }
 
 function createdAt(value: string | undefined): Date {
@@ -90,7 +129,7 @@ const methods: SandboxMethods<Sandbox, undefined> = {
 		if (options?.snapshotId) {
 			throw new Error("run.cloud snapshots are not supported by this adapter");
 		}
-		const sandbox = await client().sandboxes.create({
+		const created = await client().sandboxes.create({
 			...(options?.templateId || options?.image
 				? { image: options.templateId ?? options.image }
 				: {}),
@@ -104,6 +143,9 @@ const methods: SandboxMethods<Sandbox, undefined> = {
 			...(options?.region ? { region: options.region } : {}),
 			...(options?.name ? { name: options.name } : {}),
 		});
+		// Do not return until the guest can accept commands — cold image pulls leave the sandbox in
+		// `building_image` for minutes, and exec during that window fails with API 4409.
+		const sandbox = await waitUntilRunning(created.id);
 		return { sandbox, sandboxId: sandbox.id };
 	},
 

--- a/packages/providers/src/lib/runcloud.ts
+++ b/packages/providers/src/lib/runcloud.ts
@@ -20,9 +20,6 @@ const PROVIDER = "runcloud";
 const CREATE_READY_POLL_MS = 2_000;
 /** Cold pulls of the ~1.5 GiB toolchain image on a first-use host can take several minutes. */
 export const RUNCLOUD_READY_TIMEOUT_MS = 20 * 60 * 1000;
-/** The harness's outer create race starts before the allocation request, while the readiness clock
- * starts after it. Keep five minutes of headroom for allocation latency and cleanup. */
-export const RUNCLOUD_CREATE_TIMEOUT_MS = RUNCLOUD_READY_TIMEOUT_MS + 5 * 60 * 1000;
 /** A destroy request can fail transiently after allocation succeeded. Retry inside create(), because
  * the harness has no sandbox handle (and therefore no generic cleanup path) until create resolves. */
 const CREATE_FAILURE_CLEANUP_ATTEMPTS = 5;

--- a/packages/providers/src/lib/runcloud.ts
+++ b/packages/providers/src/lib/runcloud.ts
@@ -19,11 +19,28 @@ const PROVIDER = "runcloud";
  *  can run, so the adapter polls until `running` (or a terminal failure). */
 const CREATE_READY_POLL_MS = 2_000;
 /** Cold pulls of the ~1.5 GiB toolchain image on a first-use host can take several minutes. */
-const CREATE_READY_TIMEOUT_MS = 20 * 60 * 1000;
+export const RUNCLOUD_READY_TIMEOUT_MS = 20 * 60 * 1000;
+/** The harness's outer create race starts before the allocation request, while the readiness clock
+ * starts after it. Keep five minutes of headroom for allocation latency and cleanup. */
+export const RUNCLOUD_CREATE_TIMEOUT_MS = RUNCLOUD_READY_TIMEOUT_MS + 5 * 60 * 1000;
+
+type RuncloudSandboxClient = Pick<
+	Client["sandboxes"],
+	"create" | "get" | "list" | "destroy" | "exec" | "openTunnel"
+>;
+
+interface RuncloudComputeOptions {
+	/** Test seam; production keeps constructing the native SDK client lazily from the environment. */
+	client?: RuncloudSandboxClient;
+	readyPollMs?: number;
+	readyTimeoutMs?: number;
+	sleep?: (ms: number) => Promise<void>;
+	now?: () => number;
+}
 
 let cachedClient: Client | undefined;
 
-function client(): Client {
+function defaultClient(): Client {
 	cachedClient ??= new Client();
 	return cachedClient;
 }
@@ -54,22 +71,39 @@ function isTerminalBootFailure(state: string): boolean {
  * Poll until the sandbox can accept execs. Returns the freshest record so callers don't keep a
  * stale `building_image` handle from the original create response.
  */
-async function waitUntilRunning(sandboxId: string): Promise<Sandbox> {
-	const deadline = Date.now() + CREATE_READY_TIMEOUT_MS;
+async function waitUntilRunning(
+	native: RuncloudSandboxClient,
+	sandboxId: string,
+	options: RuncloudComputeOptions,
+): Promise<Sandbox> {
+	const now = options.now ?? Date.now;
+	const wait = options.sleep ?? sleep;
+	const pollMs = options.readyPollMs ?? CREATE_READY_POLL_MS;
+	const timeoutMs = options.readyTimeoutMs ?? RUNCLOUD_READY_TIMEOUT_MS;
+	const deadline = now() + timeoutMs;
 	let last: Sandbox | undefined;
-	while (Date.now() < deadline) {
-		last = await client().sandboxes.get(sandboxId);
+	while (now() < deadline) {
+		last = await native.get(sandboxId);
 		if (last.state === "running") return last;
 		if (isTerminalBootFailure(last.state)) {
 			throw new Error(
 				`run.cloud sandbox ${sandboxId} entered terminal state "${last.state}" while booting`,
 			);
 		}
-		await sleep(CREATE_READY_POLL_MS);
+		await wait(pollMs);
 	}
 	throw new Error(
-		`run.cloud sandbox ${sandboxId} not running after ${CREATE_READY_TIMEOUT_MS}ms (last state: ${last?.state ?? "unknown"})`,
+		`run.cloud sandbox ${sandboxId} not running after ${timeoutMs}ms (last state: ${last?.state ?? "unknown"})`,
 	);
+}
+
+async function destroySandbox(native: RuncloudSandboxClient, sandboxId: string): Promise<void> {
+	try {
+		await native.destroy(sandboxId);
+	} catch (error) {
+		if (isNotFound(error)) return;
+		throw error;
+	}
 }
 
 function createdAt(value: string | undefined): Date {
@@ -94,6 +128,7 @@ function streamCallback(
 }
 
 async function runCommand(
+	native: RuncloudSandboxClient,
 	sandbox: Sandbox,
 	command: string,
 	options?: RunCommandOptions,
@@ -105,7 +140,7 @@ async function runCommand(
 	const executable = options?.background
 		? `nohup /bin/sh -lc ${shellQuote(command)} </dev/null >/dev/null 2>&1 &`
 		: command;
-	const result = await client().sandboxes.exec(sandbox.id, executable, {
+	const result = await native.exec(sandbox.id, executable, {
 		...(options?.cwd ? { cwd: options.cwd } : {}),
 		...(options?.env ? { env: options.env } : {}),
 		...(options?.timeout ? { timeoutSeconds: Math.max(1, Math.ceil(options.timeout / 1000)) } : {}),
@@ -124,83 +159,100 @@ async function runCommand(
 	};
 }
 
-const methods: SandboxMethods<Sandbox, undefined> = {
-	create: async (_config, options?: CreateSandboxOptions) => {
-		if (options?.snapshotId) {
-			throw new Error("run.cloud snapshots are not supported by this adapter");
-		}
-		const created = await client().sandboxes.create({
-			...(options?.templateId || options?.image
-				? { image: options.templateId ?? options.image }
-				: {}),
-			...(options?.cpu !== undefined ? { cpu: options.cpu } : {}),
-			...(options?.memory !== undefined ? { memory: options.memory } : {}),
-			...(options?.disk !== undefined ? { disk: options.disk } : {}),
-			...(options?.idlePauseSeconds !== undefined
-				? { idlePauseSeconds: options.idlePauseSeconds }
-				: {}),
-			...(options?.timeoutSeconds !== undefined ? { timeoutSeconds: options.timeoutSeconds } : {}),
-			...(options?.region ? { region: options.region } : {}),
-			...(options?.name ? { name: options.name } : {}),
-		});
-		// Do not return until the guest can accept commands — cold image pulls leave the sandbox in
-		// `building_image` for minutes, and exec during that window fails with API 4409.
-		const sandbox = await waitUntilRunning(created.id);
-		return { sandbox, sandboxId: sandbox.id };
-	},
+function sandboxMethods(
+	adapterOptions: RuncloudComputeOptions,
+): SandboxMethods<Sandbox, undefined> {
+	const native = () => adapterOptions.client ?? defaultClient().sandboxes;
+	return {
+		create: async (_config, createOptions?: CreateSandboxOptions) => {
+			if (createOptions?.snapshotId) {
+				throw new Error("run.cloud snapshots are not supported by this adapter");
+			}
+			const sdk = native();
+			const created = await sdk.create({
+				...(createOptions?.templateId || createOptions?.image
+					? { image: createOptions.templateId ?? createOptions.image }
+					: {}),
+				...(createOptions?.cpu !== undefined ? { cpu: createOptions.cpu } : {}),
+				...(createOptions?.memory !== undefined ? { memory: createOptions.memory } : {}),
+				...(createOptions?.disk !== undefined ? { disk: createOptions.disk } : {}),
+				...(createOptions?.idlePauseSeconds !== undefined
+					? { idlePauseSeconds: createOptions.idlePauseSeconds }
+					: {}),
+				...(createOptions?.timeoutSeconds !== undefined
+					? { timeoutSeconds: createOptions.timeoutSeconds }
+					: {}),
+				...(createOptions?.region ? { region: createOptions.region } : {}),
+				...(createOptions?.name ? { name: createOptions.name } : {}),
+			});
+			// Do not return until the guest can accept commands — cold image pulls leave the sandbox in
+			// `building_image` for minutes, and exec during that window fails with API 4409.
+			try {
+				const sandbox = await waitUntilRunning(sdk, created.id, adapterOptions);
+				return { sandbox, sandboxId: sandbox.id };
+			} catch (error) {
+				// Allocation already succeeded, but the harness has no handle until create() resolves. Clean up
+				// here so a terminal boot, transient poll failure, or readiness timeout cannot leak a sandbox.
+				try {
+					await destroySandbox(sdk, created.id);
+				} catch (destroyError) {
+					console.error(
+						`run.cloud: failed to destroy sandbox ${created.id} after readiness failure:`,
+						destroyError,
+					);
+				}
+				throw error;
+			}
+		},
 
-	getById: async (_config, sandboxId) => {
-		try {
-			const sandbox = await client().sandboxes.get(sandboxId);
-			return { sandbox, sandboxId: sandbox.id };
-		} catch (error) {
-			if (isNotFound(error)) return null;
-			throw error;
-		}
-	},
+		getById: async (_config, sandboxId) => {
+			try {
+				const sandbox = await native().get(sandboxId);
+				return { sandbox, sandboxId: sandbox.id };
+			} catch (error) {
+				if (isNotFound(error)) return null;
+				throw error;
+			}
+		},
 
-	list: async () =>
-		(await client().sandboxes.list()).map((sandbox) => ({ sandbox, sandboxId: sandbox.id })),
+		list: async () =>
+			(await native().list())
+				// The native API retains destroyed tombstones. ComputeSDK's list contract is active sandboxes;
+				// keep paused/stopped/failed records available for recovery, but omit irreversible teardown.
+				.filter((sandbox) => sandbox.state !== "destroyed" && sandbox.state !== "destroying")
+				.map((sandbox) => ({ sandbox, sandboxId: sandbox.id })),
 
-	destroy: async (_config, sandboxId) => {
-		try {
-			await client().sandboxes.destroy(sandboxId);
-		} catch (error) {
-			if (isNotFound(error)) return;
-			throw error;
-		}
-	},
+		destroy: async (_config, sandboxId) => destroySandbox(native(), sandboxId),
 
-	runCommand,
+		runCommand: (sandbox, command, runOptions) =>
+			runCommand(native(), sandbox, command, runOptions),
 
-	getInfo: async (sandbox) => {
-		const current = await client().sandboxes.get(sandbox.id);
-		return {
-			id: current.id,
-			provider: PROVIDER,
-			status: mapStatus(current.state),
-			createdAt: createdAt(current.createdAt),
-			timeout: (current.timeoutSeconds ?? 0) * 1000,
-			metadata: {
-				image: current.image,
-				region: current.region,
-				sizeClass: current.sizeClass,
-				milliCpu: current.milliCpu,
-				memoryMb: current.memMb,
-				warmStart: current.warmStart,
-			},
-		};
-	},
+		getInfo: async (sandbox) => {
+			const current = await native().get(sandbox.id);
+			return {
+				id: current.id,
+				provider: PROVIDER,
+				status: mapStatus(current.state),
+				createdAt: createdAt(current.createdAt),
+				timeout: (current.timeoutSeconds ?? 0) * 1000,
+				metadata: {
+					image: current.image,
+					region: current.region,
+					sizeClass: current.sizeClass,
+					milliCpu: current.milliCpu,
+					memoryMb: current.memMb,
+					warmStart: current.warmStart,
+				},
+			};
+		},
 
-	getUrl: async (sandbox, options) =>
-		(await client().sandboxes.openTunnel(sandbox.id, options.port)).url,
-};
+		getUrl: async (sandbox, options) => (await native().openTunnel(sandbox.id, options.port)).url,
+	};
+}
 
-const createRuncloudProvider = defineProvider<Sandbox, undefined>({
-	name: PROVIDER,
-	methods: { sandbox: methods },
-});
-
-export function runcloudCompute() {
-	return createRuncloudProvider(undefined);
+export function runcloudCompute(options: RuncloudComputeOptions = {}) {
+	return defineProvider<Sandbox, undefined>({
+		name: PROVIDER,
+		methods: { sandbox: sandboxMethods(options) },
+	})(undefined);
 }

--- a/packages/providers/src/lib/runcloud.ts
+++ b/packages/providers/src/lib/runcloud.ts
@@ -28,8 +28,8 @@ const CREATE_FAILURE_CLEANUP_RETRY_MS = 2_000;
 /** Bound each REST control-plane call independently. The adapter owns the longer readiness window,
  * but a fetch that never settles must not suspend its deadline check or failed-create cleanup. */
 const CONTROL_PLANE_REQUEST_TIMEOUT_MS = 30_000;
-/** A timed-out create response is ambiguous: the server may have allocated the sandbox. Retry the
- * same idempotent request to recover its handle so cleanup can be awaited before returning. */
+/** A timed-out, transport-failed, or 5xx create response is ambiguous: the server may have allocated
+ * the sandbox. Retry the same idempotent request to recover its handle before returning. */
 const CREATE_RECOVERY_ATTEMPTS = 3;
 
 type RuncloudSandboxClient = Pick<
@@ -78,10 +78,14 @@ class NativeCallTimeoutError extends Error {
 	}
 }
 
-function isNativeCallTimeout(error: unknown): boolean {
+/** A non-timeout 4xx is a definitive rejection: no allocation was accepted, and replaying it would
+ * only delay the real error (especially 429, which the harness recognizes for capacity retries). */
+function isDefinitiveCreateFailure(error: unknown): boolean {
 	return (
-		error instanceof NativeCallTimeoutError ||
-		(error instanceof DOMException && error.name === "TimeoutError")
+		error instanceof RunCloudError &&
+		error.status >= 400 &&
+		error.status < 500 &&
+		error.status !== 408
 	);
 }
 
@@ -233,11 +237,11 @@ async function cleanupFailedCreate(
 }
 
 /**
- * Recover the handle for an ambiguous timed-out create by replaying the SAME idempotent request. The
+ * Recover the handle for an ambiguous create failure by replaying the SAME idempotent request. The
  * original promise participates too: if its delayed response arrives during recovery, its sandbox is
  * cleaned up without waiting for another API response. Every recovery attempt has its own deadline.
  */
-async function recoverTimedOutCreate(
+async function recoverAmbiguousCreate(
 	native: RuncloudSandboxClient,
 	createInput: NonNullable<Parameters<RuncloudSandboxClient["create"]>[0]>,
 	createAttempts: Promise<Sandbox>[],
@@ -392,15 +396,21 @@ export function sandboxMethods(
 			try {
 				created = await boundedNativeCall("create", () => createPromise, adapterOptions);
 			} catch (error) {
-				if (!isNativeCallTimeout(error)) throw error;
+				if (isDefinitiveCreateFailure(error)) throw error;
 				let recovered: Sandbox;
 				try {
-					recovered = await recoverTimedOutCreate(sdk, createInput, createAttempts, adapterOptions);
+					recovered = await recoverAmbiguousCreate(
+						sdk,
+						createInput,
+						createAttempts,
+						adapterOptions,
+					);
 				} catch (recoveryError) {
 					retainLateCreateCleanup(sdk, createAttempts, adapterOptions);
 					throw new AggregateError(
 						[error, recoveryError],
-						`run.cloud create timed out and its idempotent allocation could not be recovered; ` +
+						`run.cloud create failed ambiguously (${errorMessage(error)}) and its idempotent ` +
+							`allocation could not be recovered; ` +
 							`manual cleanup may be required (idempotency key: ${createInput.idempotencyKey})`,
 					);
 				}
@@ -409,7 +419,8 @@ export function sandboxMethods(
 				} catch (cleanupError) {
 					throw new AggregateError(
 						[error, cleanupError],
-						`run.cloud create timed out, recovered sandbox ${recovered.id}, and could not destroy it ` +
+						`run.cloud create failed ambiguously (${errorMessage(error)}), recovered sandbox ` +
+							`${recovered.id}, and could not destroy it ` +
 							`after retries (${errorMessage(cleanupError)}); manual cleanup may be required`,
 					);
 				}

--- a/packages/providers/src/lib/types.ts
+++ b/packages/providers/src/lib/types.ts
@@ -33,8 +33,10 @@ export interface ProviderAdapter {
 	requiredEnvVars?: string[];
 	/** Overrides the harness's default per-attempt create timeout for providers whose `create` does not
 	 *  return until the sandbox is fully booted — the toolchain image pull then happens INSIDE the
-	 *  create call rather than behind a readiness probe. Omitted when the default is adequate. */
-	createTimeoutMs?: number;
+	 *  create call rather than behind a readiness probe. `null` disables the harness race when the
+	 *  adapter owns a bounded readiness wait and must finish its own failed-allocation cleanup before
+	 *  the caller can safely exit. Omitted when the default is adequate. */
+	createTimeoutMs?: number | null;
 }
 
 /** A provider as the harness consumes it: schema-owned identity joined with the harness adapter. */

--- a/packages/schema/src/providers.test.ts
+++ b/packages/schema/src/providers.test.ts
@@ -32,6 +32,7 @@ describe("@sandbox-benchmarks/schema providers", () => {
 			"modal-vm",
 			"namespace",
 			"novita",
+			"runcloud",
 			"vercel",
 		]);
 	});

--- a/packages/schema/src/providers.test.ts
+++ b/packages/schema/src/providers.test.ts
@@ -119,6 +119,9 @@ describe("@sandbox-benchmarks/schema providers", () => {
 			e2b: 0.0504 * TARGET_SPEC.vcpus + 0.0162 * TARGET_SPEC.memoryGb,
 			"daytona-vm": 0.0504 * TARGET_SPEC.vcpus + 0.0162 * Math.max(0, TARGET_SPEC.memoryGb - 5),
 			novita: 0.03528 * TARGET_SPEC.vcpus + 0.01152 * TARGET_SPEC.memoryGb,
+			// $0.00000492/physical-core-s ÷ 2 × 3600 = $0.008856/vCPU-hr;
+			// $0.00000083175/GiB-s × 3600 = $0.0029943/GiB-hr.
+			runcloud: 0.008856 * TARGET_SPEC.vcpus + 0.0029943 * TARGET_SPEC.memoryGb,
 		};
 		for (const [id, cost] of Object.entries(expected)) {
 			const meta = getProvider(id);

--- a/packages/schema/src/providers.ts
+++ b/packages/schema/src/providers.ts
@@ -22,13 +22,14 @@ export type ProviderId =
 	| "microsandbox-cloud"
 	| "novita"
 	| "namespace"
-	| "vercel";
+	| "vercel"
+	| "runcloud";
 
 /** Can the SDK request a pinned target spec (vCPU / memory) at create() time? */
 export type SpecPinning = "settable" | "fixed" | "unknown";
 
 /**
- * How a provider's command-exec transport behaves *through its `@computesdk/*` adapter* — the facts the
+ * How a provider's command-exec transport behaves *through its ComputeSDK adapter* — the facts the
  * harness needs to pick a per-step transport instead of hardcoding one provider's quirks (the original
  * sin this models away: the harness forced Daytona's detached+poll on every provider). Owned here
  * alongside the other declared capabilities ({@link SpecPinning}, isolation, maturity) because it is a
@@ -38,9 +39,9 @@ export type SpecPinning = "settable" | "fixed" | "unknown";
  * Three independent capabilities, each load-bearing for transport selection:
  *
  *   - `streaming` — does the adapter deliver stdout/stderr incrementally (computesdk's
- *     `onStdout`/`onStderr`)? All three shipped adapters drop those callbacks, so a long synchronous
- *     exec buffers silently. Modeled because a streaming path keeps a connection productive past an
- *     idle gateway cap; today it is uniformly `false`, so it does not yet tip the harness's choice.
+ *     `onStdout`/`onStderr`)? Most shipped adapters drop those callbacks, so a long synchronous exec
+ *     buffers silently; run.cloud's native SDK adapter passes them through. Modeled because a streaming
+ *     path keeps a connection productive past an idle gateway cap.
  *   - `syncCapMs` — the configured durability threshold for a single *synchronous* exec round-trip,
  *     or `null` when validated as uncapped. It may encode a vendor-enforced limit or a conservative
  *     repository policy where long-lived synchronous transport has not been validated. The harness
@@ -61,7 +62,7 @@ export type SpecPinning = "settable" | "fixed" | "unknown";
  *     later exec, it can detach.
  */
 export interface ProviderTransport {
-	/** Does the `@computesdk/*` adapter stream stdout/stderr chunks (`onStdout`/`onStderr`)? */
+	/** Does the ComputeSDK adapter stream stdout/stderr chunks (`onStdout`/`onStderr`)? */
 	streaming: boolean;
 	/** Conservative bound (ms) on a safe single synchronous exec round-trip; `null` when uncapped. */
 	syncCapMs: number | null;
@@ -566,6 +567,35 @@ const REGISTRY: Record<ProviderId, Omit<ProviderMeta, "id">> = {
 			// No hard vendor cap is claimed: long synchronous transport is unvalidated, so the repository's
 			// conservative 60s durability policy routes longer work to current-session detach + exec polling.
 			streaming: false,
+			syncCapMs: 60_000,
+			detachedPoll: true,
+		},
+	},
+	runcloud: {
+		displayName: "run.cloud",
+		website: "https://run.cloud",
+		sdkPackage: "@run-cloud/sdk",
+		requiredEnvVars: ["RUN_CLOUD_API_KEY"],
+		isolation: {
+			technology: "Firecracker microVM",
+			notes:
+				"Dedicated microVM sandboxes booting an arbitrary OCI image; CPU, memory, and writable disk are independently requested at create time.",
+		},
+		pricing: {
+			model: "unknown",
+			notes: "Not yet vetted against a stable published compute rate.",
+		},
+		maturity: {
+			status: "beta",
+			notes:
+				"Direct adapter over @run-cloud/sdk with create, lifecycle, streaming exec, and public tunnel support; opt-in until a committed validation run exists.",
+		},
+		specPinning: "settable",
+		transport: {
+			// The native WebSocket exec delivers stdout/stderr chunks incrementally. Keep the repository's
+			// conservative 60s policy for unvalidated long-lived streams; longer work daemonizes and polls
+			// the harness-owned done file through short execs.
+			streaming: true,
 			syncCapMs: 60_000,
 			detachedPoll: true,
 		},

--- a/packages/schema/src/providers.ts
+++ b/packages/schema/src/providers.ts
@@ -582,8 +582,19 @@ const REGISTRY: Record<ProviderId, Omit<ProviderMeta, "id">> = {
 				"Dedicated microVM sandboxes booting an arbitrary OCI image; CPU, memory, and writable disk are independently requested at create time.",
 		},
 		pricing: {
-			model: "unknown",
-			notes: "Not yet vetted against a stable published compute rate.",
+			model: "per_vcpu_hour",
+			// Published rates are per physical core-second and per GiB-second
+			// (https://run.cloud/pricing). One physical core = two vCPUs, so the
+			// vCPU-hour rate is half the physical-core-hour rate:
+			//   CPU:  $0.00000492/core-s ÷ 2 × 3600 = $0.008856/vCPU-hr
+			//   mem:  $0.00000083175/GiB-s × 3600 = $0.0029943/GiB-hr
+			// The size is a reserved billing floor; CPU above it bills at the same
+			// rate (burst). Economics here price the reserved TARGET_SPEC floor only.
+			usdPerVcpuHour: 0.008856,
+			usdPerGibHour: 0.0029943,
+			notes:
+				"Published per-second rates (exact): $0.00000492/physical-core-s (1 physical core = 2 vCPUs → $0.00000246/vCPU-s), $0.00000083175/GiB-s. No published disk overage rate.",
+			sourceUrl: "https://run.cloud/pricing",
 		},
 		maturity: {
 			status: "beta",

--- a/scripts/setup-privileged-environment.sh
+++ b/scripts/setup-privileged-environment.sh
@@ -58,6 +58,7 @@ echo "Secret checklist:"
 echo "  E2B_API_KEY, DAYTONA_API_KEY, DAYTONA_TARGET,"
 echo "  MODAL_TOKEN_ID, MODAL_TOKEN_SECRET, NOVITA_API_KEY,"
 echo "  MSB_API_KEY (and optional MSB_API_URL),"
+echo "  RUN_CLOUD_API_KEY,"
 echo "  BL_API_KEY, BL_WORKSPACE"
 echo
 echo "Also required outside this Environment (see docs/ci-secrets.md):"

--- a/tooling/repo-checks/src/workflow-hardening.test.ts
+++ b/tooling/repo-checks/src/workflow-hardening.test.ts
@@ -30,12 +30,36 @@ import {
 	TOOLCHAIN_WORKFLOW,
 	WORKFLOWS_DIR,
 } from "./lib/workflow-hardening.ts";
+import { asRecord, stepByName, stepEnv } from "./lib/workflow-yaml.ts";
 import { findRepoRoot } from "./lib/workspace.ts";
 
 /** A no-op step — the body for fixtures whose step content is irrelevant to what they assert. */
 const NOOP_STEP = { run: "true" };
 /** Build a single-job workflow doc: `{ ...root, jobs: { [id]: job } }`. */
 const oneJob = (id: string, job: object, root: object = {}) => ({ ...root, jobs: { [id]: job } });
+const SCOPED_RUNCLOUD_KEY =
+	// biome-ignore lint/suspicious/noTemplateCurlyInString: literal GitHub Actions expression under test
+	"${{ contains(fromJSON(needs.plan.outputs.matrix).include.*.provider, 'runcloud') && secrets.RUN_CLOUD_API_KEY || '' }}";
+const PLANNED_BASE_IMAGE =
+	// biome-ignore lint/suspicious/noTemplateCurlyInString: literal GitHub Actions expression under test
+	"${{ needs.build.outputs.base-digest-ref || needs.plan.outputs.image-source }}";
+// biome-ignore lint/suspicious/noTemplateCurlyInString: literal shell parameter expansion under test
+const BASE_IMAGE_ARG = '--base-image "${BASE_IMAGE_REF}"';
+
+function workflowJob(doc: unknown, jobId: string, label: string): Record<string, unknown> {
+	const root = asRecord(doc, `${label}: not a YAML mapping`);
+	const jobs = asRecord(root.jobs, `${label}: no jobs mapping`);
+	return asRecord(jobs[jobId], `${label}: job "${jobId}" not found`);
+}
+
+/** Every value assigned to a named key below one parsed YAML node, including job- and step-level env. */
+function valuesForKey(value: unknown, key: string): unknown[] {
+	if (Array.isArray(value)) return value.flatMap((item) => valuesForKey(item, key));
+	if (value === null || typeof value !== "object") return [];
+	return Object.entries(value).flatMap(([name, child]) =>
+		name === key ? [child] : valuesForKey(child, key),
+	);
+}
 
 describe("checkoutSteps against the real workflows", () => {
 	test("every workflow's checkouts are extracted with a persist-credentials reading", () => {
@@ -218,11 +242,26 @@ describe("Namespace token authentication", () => {
 
 describe("run.cloud credential scoping", () => {
 	test("the promote step exposes the key only when the resolved plan contains runcloud", () => {
-		const workflow = readFileSync(join(findRepoRoot(), WORKFLOWS_DIR, TOOLCHAIN_WORKFLOW), "utf8");
-		expect(workflow).toContain(
-			`RUN_CLOUD_API_KEY: \${{ contains(fromJSON(needs.plan.outputs.matrix).include.*.provider, 'runcloud') && secrets.RUN_CLOUD_API_KEY || '' }}`,
+		const doc = readWorkflow(`${WORKFLOWS_DIR}/${TOOLCHAIN_WORKFLOW}`);
+		const publish = workflowJob(doc, "publish", TOOLCHAIN_WORKFLOW);
+		// Exactly one assignment anywhere in the publish job, and its entire value is the plan gate. This
+		// rejects every unscoped spelling (including `secrets.RUN_CLOUD_API_KEY || ''`) rather than one
+		// fragile literal while ignoring a second assignment in another step or at job scope.
+		expect(valuesForKey(publish, "RUN_CLOUD_API_KEY")).toEqual([SCOPED_RUNCLOUD_KEY]);
+	});
+});
+
+describe("toolchain bake base-image selection", () => {
+	test("threads the release plan's source through every bake cell", () => {
+		const doc = readWorkflow(`${WORKFLOWS_DIR}/${TOOLCHAIN_WORKFLOW}`);
+		const env = stepEnv(doc, "bake", "Bake + verify candidate", TOOLCHAIN_WORKFLOW);
+		expect(env.BASE_IMAGE_REF).toBe(PLANNED_BASE_IMAGE);
+		const step = stepByName(
+			workflowJob(doc, "bake", TOOLCHAIN_WORKFLOW),
+			"Bake + verify candidate",
+			TOOLCHAIN_WORKFLOW,
 		);
-		expect(workflow).not.toContain(`RUN_CLOUD_API_KEY: \${{ secrets.RUN_CLOUD_API_KEY }}`);
+		expect(step?.run).toContain(BASE_IMAGE_ARG);
 	});
 });
 

--- a/tooling/repo-checks/src/workflow-hardening.test.ts
+++ b/tooling/repo-checks/src/workflow-hardening.test.ts
@@ -216,6 +216,16 @@ describe("Namespace token authentication", () => {
 	});
 });
 
+describe("run.cloud credential scoping", () => {
+	test("the promote step exposes the key only when the resolved plan contains runcloud", () => {
+		const workflow = readFileSync(join(findRepoRoot(), WORKFLOWS_DIR, TOOLCHAIN_WORKFLOW), "utf8");
+		expect(workflow).toContain(
+			`RUN_CLOUD_API_KEY: \${{ contains(fromJSON(needs.plan.outputs.matrix).include.*.provider, 'runcloud') && secrets.RUN_CLOUD_API_KEY || '' }}`,
+		);
+		expect(workflow).not.toContain(`RUN_CLOUD_API_KEY: \${{ secrets.RUN_CLOUD_API_KEY }}`);
+	});
+});
+
 describe("customSecretsIn", () => {
 	test("ignores GITHUB_TOKEN and extracts provider secrets in dot and bracket notation", () => {
 		expect(

--- a/tooling/repo-checks/src/workflow-hardening.test.ts
+++ b/tooling/repo-checks/src/workflow-hardening.test.ts
@@ -40,7 +40,7 @@ const oneJob = (id: string, job: object, root: object = {}) => ({ ...root, jobs:
 const SCOPED_RUNCLOUD_KEY =
 	// biome-ignore lint/suspicious/noTemplateCurlyInString: literal GitHub Actions expression under test
 	"${{ contains(fromJSON(needs.plan.outputs.matrix).include.*.provider, 'runcloud') && secrets.RUN_CLOUD_API_KEY || '' }}";
-const PLANNED_BASE_IMAGE =
+const SELECTED_BASE_IMAGE =
 	// biome-ignore lint/suspicious/noTemplateCurlyInString: literal GitHub Actions expression under test
 	"${{ needs.build.outputs.base-digest-ref || needs.plan.outputs.image-source }}";
 // biome-ignore lint/suspicious/noTemplateCurlyInString: literal shell parameter expansion under test
@@ -252,10 +252,17 @@ describe("run.cloud credential scoping", () => {
 });
 
 describe("toolchain bake base-image selection", () => {
-	test("threads the release plan's source through every bake cell", () => {
+	test("threads one immutable source through every bake cell and the Vercel mirror", () => {
 		const doc = readWorkflow(`${WORKFLOWS_DIR}/${TOOLCHAIN_WORKFLOW}`);
 		const env = stepEnv(doc, "bake", "Bake + verify candidate", TOOLCHAIN_WORKFLOW);
-		expect(env.BASE_IMAGE_REF).toBe(PLANNED_BASE_IMAGE);
+		expect(env.BASE_IMAGE_REF).toBe(SELECTED_BASE_IMAGE);
+		const mirrorEnv = stepEnv(
+			doc,
+			"bake",
+			"Mirror the toolchain base into VCR",
+			TOOLCHAIN_WORKFLOW,
+		);
+		expect(mirrorEnv.SOURCE_REF).toBe(SELECTED_BASE_IMAGE);
 		const step = stepByName(
 			workflowJob(doc, "bake", TOOLCHAIN_WORKFLOW),
 			"Bake + verify candidate",


### PR DESCRIPTION
## What changed

- register `runcloud` in the provider schema with its credential, isolation, target-spec, **vetted pricing**, maturity, and transport capabilities
- add a direct ComputeSDK adapter over `@run-cloud/sdk` for create/get/list/destroy, streaming exec, detached launch, status, and public URLs
- **wait for `running` after create** (cold image pull leaves sandboxes in `building_image`; exec during that window failed with API 4409)
- pin run.cloud sandboxes to the shared 4 vCPU / 8 GiB / 40 GiB toolchain target with a three-hour lifetime and a 20-minute create timeout for cold pulls
- wire the provider through candidate validation, bake/promote planning, release artifacts, workflow dispatch, and credential scoping
- update provider oracles and operator documentation for `RUN_CLOUD_API_KEY`

## Why

run.cloud can boot the benchmark's shared OCI toolchain image directly and independently request CPU, memory, and disk. Adding it to the registry makes it available for opt-in smoke and matrix runs while keeping it non-gating until a committed validation run exists.

## Pricing (vetted)

From https://run.cloud/pricing:

| Dimension | Published rate | Normalized |
|-----------|----------------|------------|
| CPU | $0.00000492 / physical-core-second | $0.008856 / vCPU-hour (1 physical core = 2 vCPUs) |
| Memory | $0.00000083175 / GiB-second | $0.0029943 / GiB-hour |

Economics price the reserved TARGET_SPEC floor only (CPU burst above the floor is same rate, not modeled here). No published disk overage rate.

## Validation

### Browser-free local gate
- `bun run typecheck`
- `bun run test`
- `bun run lint`
- `git diff --check`

### Live single-provider smoke (CONTRIBUTING step 5)
```
REQUIRE_PROVIDERS=runcloud bun apps/cli/src/bin/bench-smoke.ts
```
Result: **runcloud ok — 12/12 checks** (~8 min including cold pull of `ghcr.io/starslingdev/sandbox-benchmarks-toolchain:v7`).

Probes passed: node, python, mise, pnpm, hyperfine, jc, quarto, warp, pts-installed-tests (10 profiles), pgbench-payload, manifest, manifest-version.

Fork PRs do not receive provider secrets on org runners by design; this live run was done locally with a valid `RUN_CLOUD_API_KEY`. Maintainers: set `RUN_CLOUD_API_KEY` in Environment `privileged` for CI matrix/smoke cells.

## Notes

- Not in `RELEASE_REQUIRED_PROVIDERS` (opt-in / non-gating until a committed matrix run).
- No `packages/templates` builder — boots the shared OCI image directly (same class as namespace/modal).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added RunCloud as a supported compute provider with sandbox creation, execution, lookup, listing, destruction, incremental output, and tunnel URLs.
  * Added configurable CPU, memory, disk, idle-pause, and lifetime settings.
  * Added RunCloud support to release planning, toolchain validation, and benchmark workflows.
  * Added shared base-image support for provider backfills and direct image-based validation.
  * Added support for disabling harness creation timeouts when adapters manage readiness.

* **Documentation**
  * Documented optional `RUN_CLOUD_API_KEY` configuration and local credential setup.
  * Added RunCloud provider capabilities and usage guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->