### PR TITLE
feat: add Runloop benchmark provider

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -59,3 +59,5 @@ VERCEL_OIDC_TOKEN=
 # E2B_TEMPLATE=
 # DAYTONA_SNAPSHOT=
 # NOVITA_TEMPLATE=
+# Runtime-only Runloop Blueprint name override; ordinary runs use the released version name.
+# RUNLOOP_BLUEPRINT=

--- a/.env.example
+++ b/.env.example
@@ -29,6 +29,9 @@ BL_WORKSPACE=
 # --- Novita (https://novita.ai) — E2B-protocol-compatible control plane ---
 NOVITA_API_KEY=
 
+# --- Runloop (https://runloop.ai) ---
+RUNLOOP_API_KEY=
+
 # --- Microsandbox (https://microsandbox.dev) ---
 # Explicit opt-in for host-local libkrun runs. The host needs KVM on Linux or
 # Hypervisor.framework on macOS; keep unset on ordinary CI runners.

--- a/.github/workflows/bench-matrix.yml
+++ b/.github/workflows/bench-matrix.yml
@@ -49,7 +49,8 @@ on:
         # (its own pre-baked template), microsandbox-cloud, and vercel (the shared toolchain base
         # mirrored into VCR). modal-vm + blaxel graduated into the default once committed runs validated
         # them; microsandbox-cloud and vercel followed. daytona-container and microsandbox-local are the
-        # registered variants still opt-in (pass them explicitly);
+        # registered variants still opt-in; Runloop is also opt-in until it has a committed validation
+        # run (pass any of them explicitly);
         # `plan-providers` rejects any name that is not in the registry. Listed in registry order — the
         # plan re-sorts to registry order regardless, so the spelling here is cosmetic.
         #

--- a/.github/workflows/bench-smoke.yml
+++ b/.github/workflows/bench-smoke.yml
@@ -61,6 +61,7 @@ on:
             modal-vm,
             blaxel,
             novita,
+            runloop,
             vercel,
             namespace,
             microsandbox-local,

--- a/.github/workflows/bench-suite.yml
+++ b/.github/workflows/bench-suite.yml
@@ -256,6 +256,7 @@ jobs:
           BL_API_KEY: ${{ matrix.provider == 'blaxel' && secrets.BL_API_KEY || '' }}
           BL_WORKSPACE: ${{ matrix.provider == 'blaxel' && secrets.BL_WORKSPACE || '' }}
           NOVITA_API_KEY: ${{ matrix.provider == 'novita' && secrets.NOVITA_API_KEY || '' }}
+          RUNLOOP_API_KEY: ${{ matrix.provider == 'runloop' && secrets.RUNLOOP_API_KEY || '' }}
           # OIDC-federated per-cell token file (see the Namespace step above). Not a stored secret: it is
           # empty unless THIS cell is the namespace cell AND the mint succeeded (the step only runs when
           # matrix.provider == 'namespace', and only writes the output once `nsc token create` returned),

--- a/.github/workflows/toolchain-image.yml
+++ b/.github/workflows/toolchain-image.yml
@@ -727,8 +727,9 @@ jobs:
           MODAL_TOKEN_SECRET: ${{ secrets.MODAL_TOKEN_SECRET }}
           NOVITA_API_KEY: ${{ secrets.NOVITA_API_KEY }}
           # The serial transaction re-validates the candidate Blueprint, then builds the version-named
-          # Blueprint from the same pinned base. The key remains in the SDK control-plane client.
-          RUNLOOP_API_KEY: ${{ secrets.RUNLOOP_API_KEY }}
+          # Blueprint from the same pinned base. Keep the SDK control-plane key out of unrelated scoped
+          # promotes, matching the run.cloud credential posture below.
+          RUNLOOP_API_KEY: ${{ contains(fromJSON(needs.plan.outputs.matrix).include.*.provider, 'runloop') && secrets.RUNLOOP_API_KEY || '' }}
           # A scoped promote imports every provider module in one process. Keep the run.cloud key out
           # of that process unless the resolved release plan will actually re-validate runcloud.
           RUN_CLOUD_API_KEY: ${{ contains(fromJSON(needs.plan.outputs.matrix).include.*.provider, 'runcloud') && secrets.RUN_CLOUD_API_KEY || '' }}

--- a/.github/workflows/toolchain-image.yml
+++ b/.github/workflows/toolchain-image.yml
@@ -35,11 +35,11 @@ name: Toolchain image
 #              quietly hand it a different `:vN`).
 #   promote    off ⇒ the publish job is skipped: bake + verify, look at the report, promote later.
 #
-# The canonical use is adding a provider to a version everyone else already runs — e.g. Vercel on v7:
-#   1. providers=vercel, build=skip, promote=false  → bake + verify against the published base, nothing public
-#   2. providers=vercel, build=skip, promote=true   → publish just the Vercel v7 artifact
-# Neither dispatch runs a build job: there is nothing per-provider to stage, because every provider
-# derives its artifact from the one shared base at bake/promote time.
+# The canonical use is adding a provider to a version everyone else already runs — e.g. Runloop on v7:
+#   1. providers=runloop, build=skip, promote=false → bake + verify a candidate Blueprint, nothing public
+#   2. providers=runloop, build=skip, promote=true  → publish just the Runloop v7 Blueprint
+# Neither dispatch runs the shared build job: Runloop derives its candidate/version Blueprints from
+# the one already-published base during bake/promote.
 #
 # Cross-cutting GitHub Actions mechanics live in .github/actions/* composites (setup, ghcr login,
 # input validation, package-visibility guard, summaries); provider bake/verify/promote logic lives in
@@ -497,9 +497,8 @@ jobs:
         # it skips, exactly as the previous monolithic lane did.
         #
         # Each cell is handed ONLY its own provider's credentials. The cell already restricts execution
-        # to one provider (`--provider`), so injecting all five providers' secrets into all five cells
-        # would hand a compromised dependency in any one cell (a provider SDK, the bun toolchain) every
-        # other provider's key for no benefit — a 5× blast radius across a parallel fan-out. Scoping
+        # to one provider (`--provider`), so injecting every provider secret into every cell would hand
+        # a compromised dependency in any one cell every other provider's key for no benefit. Scoping
         # them here is what makes the fan-out least-privilege rather than just concurrent.
         env:
           PROVIDER: ${{ matrix.provider }}
@@ -520,6 +519,9 @@ jobs:
           MODAL_TOKEN_SECRET: ${{ (matrix.provider == 'modal-gvisor' || matrix.provider == 'modal-vm') && secrets.MODAL_TOKEN_SECRET || '' }}
           # Optional: a missing NOVITA_API_KEY skips the novita bake without failing the release.
           NOVITA_API_KEY: ${{ matrix.provider == 'novita' && secrets.NOVITA_API_KEY || '' }}
+          # Runloop builds and validates a candidate Blueprint. Best-effort in an unscoped release;
+          # required (and therefore fail-closed on a missing key/build failure) when explicitly scoped.
+          RUNLOOP_API_KEY: ${{ matrix.provider == 'runloop' && secrets.RUNLOOP_API_KEY || '' }}
           # Namespace pulls the candidate image directly (no bake artifact) — its validate boot reads
           # this OIDC-federated token file (see the Namespace CLI steps above). Not a stored secret:
           # empty unless THIS is the namespace cell AND the mint succeeded, which the harness reads as
@@ -717,6 +719,9 @@ jobs:
           MODAL_TOKEN_ID: ${{ secrets.MODAL_TOKEN_ID }}
           MODAL_TOKEN_SECRET: ${{ secrets.MODAL_TOKEN_SECRET }}
           NOVITA_API_KEY: ${{ secrets.NOVITA_API_KEY }}
+          # The serial transaction re-validates the candidate Blueprint, then builds the version-named
+          # Blueprint from the same pinned base. The key remains in the SDK control-plane client.
+          RUNLOOP_API_KEY: ${{ secrets.RUNLOOP_API_KEY }}
           # Namespace's re-validation boot reads this OIDC-federated token file (see the Namespace CLI
           # steps above). Not a stored secret: empty when the exchange/mint was skipped/failed, which
           # skips namespace's re-validation without failing the promote (namespace is not in --require).

--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -35,6 +35,7 @@
     "@sandbox-benchmarks/figures": "workspace:*",
     "@daytona/api-client": "catalog:computesdk",
     "@daytona/sdk": "catalog:computesdk",
+    "@runloop/api-client": "1.28.0",
     "novita-sandbox": "catalog:computesdk",
     "dotenv": "catalog:"
   },

--- a/apps/cli/src/bin/bake.ts
+++ b/apps/cli/src/bin/bake.ts
@@ -48,6 +48,9 @@ const bakers: Record<ProviderId, (image: string, log: Log) => Promise<void>> = {
 		log("blaxel boots the stock base image — no candidate artifact to bake");
 	},
 	novita: (image, log) => bakeNovitaTemplate(config.novitaTemplateCandidate, image, log),
+	runloop: async (_image, log) => {
+		log("runloop boots the stock Devbox image — no candidate artifact to bake");
+	},
 	// Same shape as blaxel: namespace pulls the toolchain image straight into a container instance at
 	// create time (no template/snapshot system), so there's no candidate artifact to bake — the
 	// validate boot right after this proves reachability. Takes the pinned candidate image like the
@@ -182,8 +185,8 @@ if (import.meta.main) {
 	// Resolve once after the push and validate the exact candidate bytes by immutable digest. This also
 	// makes a tag change between provider bakes unable to redirect Modal's validation to different bytes.
 	//
-	// Only providers that actually reference the base need it: vercel boots its own VCR mirror and
-	// blaxel the vendor's stock image, so a cell restricted to those must not die on a base candidate it
+	// Only providers that actually reference the base need it: vercel boots its own VCR mirror while
+	// blaxel and runloop boot vendor stock images, so a cell restricted to those must not die on a base candidate it
 	// never reads — under `build: skip` that ref may legitimately be stale or absent, and failing there
 	// would break the one flow the scoped release exists for.
 	const needsBase = (only ?? PROVIDERS.map((p) => p.id)).some((id) => baseImageUse(id) !== "none");

--- a/apps/cli/src/bin/bake.ts
+++ b/apps/cli/src/bin/bake.ts
@@ -20,6 +20,7 @@ import { buildAndPushCandidate, resolveImageDigestRef } from "../lib/bake/image.
 import { bakeModalImage } from "../lib/bake/modal.ts";
 import { bakeNovitaTemplate } from "../lib/bake/novita.ts";
 import { promoteAll } from "../lib/bake/promote.ts";
+import { bakeRunloopBlueprint } from "../lib/bake/runloop.ts";
 import type { BakeReport, Log } from "../lib/bake/types.ts";
 import { baseImageUse, candidateCreateOptions } from "../lib/bake/validate.ts";
 import { isPartialScope, selectProviders } from "../lib/matrix.ts";
@@ -48,9 +49,7 @@ const bakers: Record<ProviderId, (image: string, log: Log) => Promise<void>> = {
 		log("blaxel boots the stock base image — no candidate artifact to bake");
 	},
 	novita: (image, log) => bakeNovitaTemplate(config.novitaTemplateCandidate, image, log),
-	runloop: async (_image, log) => {
-		log("runloop boots the stock Devbox image — no candidate artifact to bake");
-	},
+	runloop: (image, log) => bakeRunloopBlueprint(config.runloopBlueprintCandidate, image, log),
 	// Same shape as blaxel: namespace pulls the toolchain image straight into a container instance at
 	// create time (no template/snapshot system), so there's no candidate artifact to bake — the
 	// validate boot right after this proves reachability. Takes the pinned candidate image like the
@@ -89,8 +88,8 @@ function writeReport(report: unknown): void {
  * A PRESENT-but-valueless flag (`--provider`, `--provider=`, `--provider --force`) THROWS rather than
  * falling through to the all-providers default. `selectProviders` treats a blank list as "every
  * provider", which is the right default for an *absent* dispatch input but exactly wrong here: a matrix
- * cell whose value failed to interpolate would silently bake all five providers instead of its one, and
- * five such cells would race on the same artifact names. Asking to restrict and getting everything is a
+ * cell whose value failed to interpolate would silently bake every provider instead of its one, and
+ * those cells would race on the same artifact names. Asking to restrict and getting everything is a
  * failure, so it is reported as one.
  */
 export function requestedProviders(argv: string[]): ProviderId[] | undefined {
@@ -157,6 +156,7 @@ if (import.meta.main) {
 				daytonaSnapshot: config.daytonaSnapshotDefault,
 				daytonaContainerSnapshot: config.daytonaContainerSnapshotDefault,
 				novitaTemplate: config.novitaTemplateVersion,
+				runloopBlueprint: config.runloopBlueprintVersion,
 			},
 			reports: promoted,
 		});
@@ -186,7 +186,7 @@ if (import.meta.main) {
 	// makes a tag change between provider bakes unable to redirect Modal's validation to different bytes.
 	//
 	// Only providers that actually reference the base need it: vercel boots its own VCR mirror while
-	// blaxel and runloop boot vendor stock images, so a cell restricted to those must not die on a base candidate it
+	// blaxel boots a vendor stock image, so a cell restricted to either must not die on a base candidate it
 	// never reads — under `build: skip` that ref may legitimately be stale or absent, and failing there
 	// would break the one flow the scoped release exists for.
 	const needsBase = (only ?? PROVIDERS.map((p) => p.id)).some((id) => baseImageUse(id) !== "none");
@@ -209,6 +209,7 @@ if (import.meta.main) {
 		daytonaSnapshotCandidate: config.daytonaSnapshotCandidate,
 		daytonaContainerSnapshotCandidate: config.daytonaContainerSnapshotCandidate,
 		novitaTemplateCandidate: config.novitaTemplateCandidate,
+		runloopBlueprintCandidate: config.runloopBlueprintCandidate,
 		toolchainImageCandidate: pinnedCandidateImage,
 		vercelImageCandidate: config.vercelImageCandidate,
 		daytonaVmTarget: config.daytonaVm.target,
@@ -265,6 +266,7 @@ if (import.meta.main) {
 			daytonaSnapshot: config.daytonaSnapshotCandidate,
 			daytonaContainerSnapshot: config.daytonaContainerSnapshotCandidate,
 			novitaTemplate: config.novitaTemplateCandidate,
+			runloopBlueprint: config.runloopBlueprintCandidate,
 		},
 		reports,
 	});

--- a/apps/cli/src/bin/bake.ts
+++ b/apps/cli/src/bin/bake.ts
@@ -189,20 +189,16 @@ if (import.meta.main) {
 					novitaTemplate: config.novitaTemplateVersion,
 					runloopBlueprint: config.runloopBlueprintVersion,
 				},
-				reports: promoted,
+				reports: promoted.reports,
 			});
 		} finally {
 			// Promotion can validate run.cloud before writing its report. Preserve teardown even if either
 			// operation throws instead of returning a structured failed report.
 			await drainRuncloudBackgroundWork();
 		}
-		// promoteAll is self-gating: the D1 required-providers gate (CI passes `--require e2b,daytona-vm,modal-gvisor`)
-		// runs INSIDE promoteAll before the immutable base is written, and every abort path (version already
-		// published, candidate re-validation failed, artifact failed, unmet requirements) pushes a structured
-		// `{ status: "failed" }` report. So a single `some(failed)` is the whole exit contract — re-deriving
-		// `unmet` here would mislabel an early abort (e.g. "version already exists") as a provider-credentials
-		// failure, since the early `reports` carry no provider "ok" entries.
-		process.exit(promoted.some((r) => r.status === "failed") ? 1 : 0);
+		// The transaction outcome is separate from its diagnostics: an optional provider can fail and stay
+		// visible in the report without turning a successfully published shared version red after commit.
+		process.exit(promoted.ok ? 0 : 1);
 	}
 
 	if (only) log(`>>> restricting bake+validate to: ${only.join(", ")}`);

--- a/apps/cli/src/bin/release-plan.test.ts
+++ b/apps/cli/src/bin/release-plan.test.ts
@@ -67,6 +67,7 @@ describe("buildReleasePlan matrix", () => {
 			"modal-gvisor",
 			"modal-vm",
 			"novita",
+			"runloop",
 			"namespace",
 			"vercel",
 		]);
@@ -101,15 +102,18 @@ describe("buildReleasePlan matrix", () => {
 		expect(() => buildReleasePlan({ ...base, providers: "e2b,blaxel" })).toThrow(
 			/BL_API_KEY|cannot ship/,
 		);
+		expect(() => buildReleasePlan({ ...base, providers: "runloop" })).toThrow(/runloop/);
 	});
 
-	// Unscoped, the same provider is simply skipped — it is not in the required set, so a missing
+	// Unscoped, the same providers are simply skipped — they are not in the required set, so a missing
 	// credential is a skip and the release proceeds. Only a scope makes it a demand.
 	test("the same provider is fine in an unscoped release", () => {
 		const plan = buildReleasePlan(base);
 		expect(plan.matrix.include.map((c) => c.provider)).toContain("blaxel");
+		expect(plan.matrix.include.map((c) => c.provider)).toContain("runloop");
 		expect(plan.required).not.toContain("blaxel");
-		expect(Object.keys(RELEASE_UNSCOPABLE_PROVIDERS)).toEqual(["blaxel"]);
+		expect(plan.required).not.toContain("runloop");
+		expect(Object.keys(RELEASE_UNSCOPABLE_PROVIDERS)).toEqual(["blaxel", "runloop"]);
 	});
 
 	// Everything keys off `partial`, never "did the operator type a list" — otherwise spelling out the
@@ -186,7 +190,7 @@ describe("planOutputs", () => {
 		expect(matrixLine).toBeDefined();
 		// The matrix value must be valid, single-line JSON (the fromJSON contract).
 		const parsed = JSON.parse((matrixLine as string).slice("matrix=".length));
-		expect(parsed.include).toHaveLength(11);
+		expect(parsed.include).toHaveLength(12);
 		expect((matrixLine as string).includes("\n")).toBe(false);
 	});
 

--- a/apps/cli/src/bin/release-plan.test.ts
+++ b/apps/cli/src/bin/release-plan.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, test } from "bun:test";
+import { config } from "@sandbox-benchmarks/providers";
 import { PROVIDERS } from "@sandbox-benchmarks/schema";
 import {
 	buildReleasePlan,
@@ -102,7 +103,13 @@ describe("buildReleasePlan matrix", () => {
 		expect(() => buildReleasePlan({ ...base, providers: "e2b,blaxel" })).toThrow(
 			/BL_API_KEY|cannot ship/,
 		);
-		expect(() => buildReleasePlan({ ...base, providers: "runloop" })).toThrow(/runloop/);
+	});
+
+	test("accepts a scoped Runloop release and makes it required", () => {
+		const plan = buildReleasePlan({ ...base, providers: "runloop" });
+		expect(plan.matrix.include).toEqual([{ provider: "runloop", required: true }]);
+		expect(plan.required).toEqual(["runloop"]);
+		expect(plan.providers[0]?.artifact).toBe(config.runloopBlueprintCandidate);
 	});
 
 	// Unscoped, the same providers are simply skipped — they are not in the required set, so a missing
@@ -113,7 +120,7 @@ describe("buildReleasePlan matrix", () => {
 		expect(plan.matrix.include.map((c) => c.provider)).toContain("runloop");
 		expect(plan.required).not.toContain("blaxel");
 		expect(plan.required).not.toContain("runloop");
-		expect(Object.keys(RELEASE_UNSCOPABLE_PROVIDERS)).toEqual(["blaxel", "runloop"]);
+		expect(Object.keys(RELEASE_UNSCOPABLE_PROVIDERS)).toEqual(["blaxel"]);
 	});
 
 	// Everything keys off `partial`, never "did the operator type a list" — otherwise spelling out the

--- a/apps/cli/src/bin/release-plan.ts
+++ b/apps/cli/src/bin/release-plan.ts
@@ -47,18 +47,14 @@ export const RELEASE_REQUIRED_PROVIDERS: readonly ProviderId[] = [
  * and, on a `build: full` dispatch, an hour of rebuild. Refusing in the plan turns that into a
  * fail-fast with an explanation.
  *
- * Keyed by provider so the reason travels with the refusal. Blaxel and Runloop both boot stock vendor
- * images, so their bakes/promotes publish nothing and their credentials live in the bench lane only
- * (docs/ci-secrets.md). Adding a toolchain artifact and release credential wiring is what would remove
- * an entry here.
+ * Keyed by provider so the reason travels with the refusal. Blaxel still boots a stock vendor image,
+ * so its bake/promote publishes nothing. Adding a toolchain artifact and release credential wiring is
+ * what would remove the remaining entry here.
  */
 export const RELEASE_UNSCOPABLE_PROVIDERS: Readonly<Partial<Record<ProviderId, string>>> = {
 	blaxel:
 		"it boots the vendor's stock image rather than the toolchain, so the release lane carries no " +
 		"BL_API_KEY/BL_WORKSPACE and has no artifact to publish for it",
-	runloop:
-		"it boots the vendor's stock Devbox image rather than the toolchain, so the release lane has " +
-		"no artifact to publish for it",
 };
 
 /** Per-provider baked artifact name (what a cell produces), or a note for the providers that bake none. */
@@ -80,7 +76,7 @@ function providerArtifact(id: ProviderId): string {
 		case "blaxel":
 			return "boots the stock base image (no baked artifact)";
 		case "runloop":
-			return "boots the stock Devbox image (no baked artifact)";
+			return config.runloopBlueprintCandidate;
 		case "namespace":
 			// No template/snapshot system — pulls the candidate image straight into an instance at
 			// create time (same as modal), so there is no baked artifact to name.

--- a/apps/cli/src/bin/release-plan.ts
+++ b/apps/cli/src/bin/release-plan.ts
@@ -47,15 +47,18 @@ export const RELEASE_REQUIRED_PROVIDERS: readonly ProviderId[] = [
  * and, on a `build: full` dispatch, an hour of rebuild. Refusing in the plan turns that into a
  * fail-fast with an explanation.
  *
- * Keyed by provider so the reason travels with the refusal. Blaxel is the only entry: its bake is a
- * no-op (it boots the vendor's stock image, not our toolchain) and its promote publishes nothing, so
- * the release lane deliberately injects no BL_API_KEY/BL_WORKSPACE — those live in the bench lane
- * only (docs/ci-secrets.md). Adding credentials to the bake matrix is what would remove an entry here.
+ * Keyed by provider so the reason travels with the refusal. Blaxel and Runloop both boot stock vendor
+ * images, so their bakes/promotes publish nothing and their credentials live in the bench lane only
+ * (docs/ci-secrets.md). Adding a toolchain artifact and release credential wiring is what would remove
+ * an entry here.
  */
 export const RELEASE_UNSCOPABLE_PROVIDERS: Readonly<Partial<Record<ProviderId, string>>> = {
 	blaxel:
 		"it boots the vendor's stock image rather than the toolchain, so the release lane carries no " +
 		"BL_API_KEY/BL_WORKSPACE and has no artifact to publish for it",
+	runloop:
+		"it boots the vendor's stock Devbox image rather than the toolchain, so the release lane has " +
+		"no artifact to publish for it",
 };
 
 /** Per-provider baked artifact name (what a cell produces), or a note for the providers that bake none. */
@@ -76,6 +79,8 @@ function providerArtifact(id: ProviderId): string {
 			return "boots the candidate image directly (no baked artifact)";
 		case "blaxel":
 			return "boots the stock base image (no baked artifact)";
+		case "runloop":
+			return "boots the stock Devbox image (no baked artifact)";
 		case "namespace":
 			// No template/snapshot system — pulls the candidate image straight into an instance at
 			// create time (same as modal), so there is no baked artifact to name.

--- a/apps/cli/src/lib/bake/promote.test.ts
+++ b/apps/cli/src/lib/bake/promote.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { promotionScopeAfterValidation } from "./promote.ts";
+import { fullPromotionResult, promotionScopeAfterValidation } from "./promote.ts";
 
 describe("promotionScopeAfterValidation", () => {
 	test("does not publish an optional provider artifact after its candidate validation fails", () => {
@@ -38,5 +38,26 @@ describe("promotionScopeAfterValidation", () => {
 				reason: "candidate re-validation produced no result",
 			},
 		]);
+	});
+});
+
+describe("fullPromotionResult", () => {
+	test("keeps an optional validation failure visible without failing after the image commits", () => {
+		const result = fullPromotionResult([
+			{ provider: "runloop", status: "failed", reason: "candidate Blueprint did not boot" },
+			{ provider: "image", status: "ok" },
+		]);
+
+		expect(result.ok).toBe(true);
+		expect(result.reports[0]).toEqual({
+			provider: "runloop",
+			status: "failed",
+			reason: "candidate Blueprint did not boot",
+		});
+	});
+
+	test("fails when the immutable image commit fails or never happens", () => {
+		expect(fullPromotionResult([{ provider: "image", status: "failed" }]).ok).toBe(false);
+		expect(fullPromotionResult([{ provider: "runloop", status: "failed" }]).ok).toBe(false);
 	});
 });

--- a/apps/cli/src/lib/bake/promote.ts
+++ b/apps/cli/src/lib/bake/promote.ts
@@ -163,7 +163,8 @@ export async function promoteAll(log: Log, options: PromoteOptions = {}): Promis
 	//     would verify one image and publish an artifact built from another. Require that identity when
 	//     such a provider is in scope. The rest don't bake from the base at all (vercel's version artifact
 	//     is a retag of the exact candidate step 2 just booted; modal/namespace/microsandbox boot the
-	//     published base directly), so a drifted candidate tag is simply irrelevant to them.
+	//     published base directly; runloop boots its stock Devbox), so a drifted candidate tag is simply
+	//     irrelevant to them.
 	const bakesFromBase = (only ?? PROVIDERS.map((p) => p.id)).filter(
 		(id) => baseImageUse(id) === "bakes",
 	);
@@ -253,6 +254,9 @@ export async function promoteAll(log: Log, options: PromoteOptions = {}): Promis
 					await bakeNovitaTemplate(config.novitaTemplateVersion, pinnedBaseImage, (m) =>
 						log(`    ${m}`),
 					);
+					break;
+				case "runloop":
+					log("    runloop boots the stock Devbox image — nothing to promote");
 					break;
 				case "namespace":
 					log("    namespace pulls the published version image — nothing to build");

--- a/apps/cli/src/lib/bake/promote.ts
+++ b/apps/cli/src/lib/bake/promote.ts
@@ -6,7 +6,8 @@
 //   1. Refuse if the public version tag already exists — it is immutable; bump to republish (or pass
 //      `--force`, wired only to a manual force_republish dispatch, to deliberately regenerate in place).
 //   2. Re-validate the candidate (boot + smoke) right now, so the bytes we publish are verified again
-//      (the candidate tag is mutable and may have changed since `bake`). Abort on any failure.
+//      (the candidate tag is mutable and may have changed since `bake`). Abort on a required failure;
+//      a failed best-effort provider is reported and its version artifact is not built.
 //   3. Build each provider's version-named artifact FROM the candidate base (the just-revalidated
 //      bytes), so the public artifact provably derives from validated bytes — BEFORE touching the base.
 //   3b. Required-providers gate: if `--require`/`REQUIRE_PROVIDERS` names providers a skipped one
@@ -75,6 +76,24 @@ export interface PromoteOptions {
 	only?: readonly ProviderId[];
 }
 
+/** Promotion diagnostics plus the transaction outcome. Optional-provider failures remain visible in
+ * `reports`, while `ok` records whether the requested publish transaction itself committed. */
+export interface PromoteResult {
+	reports: BakeReport[];
+	ok: boolean;
+}
+
+/** Finalize a full promotion after the immutable image retag attempt. Provider diagnostics do not
+ * decide the transaction status; the image commit point does. */
+export function fullPromotionResult(reports: BakeReport[]): PromoteResult {
+	return {
+		reports,
+		ok:
+			reports.some((report) => report.provider === "image" && report.status === "ok") &&
+			!reports.some((report) => report.provider === "image" && report.status === "failed"),
+	};
+}
+
 /**
  * Select the providers whose version artifacts may be built after candidate re-validation. A
  * best-effort provider is allowed to fail without blocking the shared image publish, but that must
@@ -104,17 +123,17 @@ export function promotionScopeAfterValidation(
 	return { eligible, rejected };
 }
 
-export async function promoteAll(log: Log, options: PromoteOptions = {}): Promise<BakeReport[]> {
+export async function promoteAll(log: Log, options: PromoteOptions = {}): Promise<PromoteResult> {
 	const { force = false, only } = options;
 	const partial = isPartialScope(only);
 	const reports: BakeReport[] = [];
 	const scope = only ? only.join(", ") : "every provider";
 	/** Record a refusal/abort as a structured `image` failure and stop — the shape every early exit
 	 *  below returns, so the refusal contract is written once. */
-	const refuse = (reason: string, verb = "refused"): BakeReport[] => {
+	const refuse = (reason: string, verb = "refused"): PromoteResult => {
 		log(`<<< promote ${verb} — ${reason}`);
 		reports.push({ provider: "image", status: "failed", reason });
-		return reports;
+		return { reports, ok: false };
 	};
 	// Only a REQUIRED provider gates the release (Option 1): a best-effort variant that shares a required
 	// variant's credentials — daytona-container ↔ daytona-vm, modal-vm ↔ modal-gvisor — runs rather than
@@ -173,7 +192,8 @@ export async function promoteAll(log: Log, options: PromoteOptions = {}): Promis
 	}
 
 	// 2. Re-validate the candidate immediately before publishing, so the bytes we promote are verified
-	//    again (the candidate tag is mutable). Abort the whole promote if any provider fails to validate.
+	//    again (the candidate tag is mutable). Required failures abort the whole promote; a failed
+	//    best-effort provider is excluded from step 3 and remains visible in the final report.
 	//    A PARTIAL promote pins the PUBLISHED version instead: it is not cutting a new version, it is
 	//    attaching a provider to the one already live, so the base under test must be that one.
 	const baseTag = releaseBaseTag(partial);
@@ -241,7 +261,7 @@ export async function promoteAll(log: Log, options: PromoteOptions = {}): Promis
 				...(run.durationMs !== undefined ? { durationMs: run.durationMs } : {}),
 			});
 		}
-		return reports;
+		return { reports, ok: false };
 	}
 	const requested = only ?? PROVIDERS.map((provider) => provider.id);
 	const promotionScope = promotionScopeAfterValidation(requested, validateRuns);
@@ -367,7 +387,7 @@ export async function promoteAll(log: Log, options: PromoteOptions = {}): Promis
 					: "") +
 				rerunHint,
 		);
-		return reports;
+		return { reports, ok: false };
 	}
 
 	// Required-providers gate (D1), enforced HERE — before step 4 writes the immutable base — not
@@ -386,7 +406,7 @@ export async function promoteAll(log: Log, options: PromoteOptions = {}): Promis
 		// Push a structured failure (like the step-1 and step-4 aborts) so the emitted JSON is
 		// self-describing — a consumer sees the failed promote without re-deriving it from `--require`.
 		reports.push({ provider: "image", status: "failed", reason });
-		return reports;
+		return { reports, ok: false };
 	}
 
 	// 4. LAST: publish the candidate base as the immutable public version — the commit point. A partial
@@ -398,7 +418,7 @@ export async function promoteAll(log: Log, options: PromoteOptions = {}): Promis
 			`>>> partial promote complete: ${scope} now published for ${config.toolchainImageVersion}; ` +
 				"the public base and every other provider's artifact are unchanged",
 		);
-		return reports;
+		return { reports, ok: true };
 	}
 	log(`>>> promoting image ${pinnedBaseImage} → ${config.toolchainImageVersion}…`);
 	const imageStart = performance.now();
@@ -416,5 +436,5 @@ export async function promoteAll(log: Log, options: PromoteOptions = {}): Promis
 		});
 	}
 
-	return reports;
+	return fullPromotionResult(reports);
 }

--- a/apps/cli/src/lib/bake/promote.ts
+++ b/apps/cli/src/lib/bake/promote.ts
@@ -43,6 +43,7 @@ import {
 	resolveImageDigestRef,
 } from "./image.ts";
 import { bakeNovitaTemplate } from "./novita.ts";
+import { bakeRunloopBlueprint } from "./runloop.ts";
 import type { BakeReport, Log } from "./types.ts";
 import type { CandidateRefs } from "./validate.ts";
 import { baseImageUse } from "./validate.ts";
@@ -163,7 +164,7 @@ export async function promoteAll(log: Log, options: PromoteOptions = {}): Promis
 	//     would verify one image and publish an artifact built from another. Require that identity when
 	//     such a provider is in scope. The rest don't bake from the base at all (vercel's version artifact
 	//     is a retag of the exact candidate step 2 just booted; modal/namespace/microsandbox boot the
-	//     published base directly; runloop boots its stock Devbox), so a drifted candidate tag is simply
+	//     published base directly), so a drifted candidate tag is simply
 	//     irrelevant to them.
 	const bakesFromBase = (only ?? PROVIDERS.map((p) => p.id)).filter(
 		(id) => baseImageUse(id) === "bakes",
@@ -190,6 +191,7 @@ export async function promoteAll(log: Log, options: PromoteOptions = {}): Promis
 		daytonaSnapshotCandidate: config.daytonaSnapshotCandidate,
 		daytonaContainerSnapshotCandidate: config.daytonaContainerSnapshotCandidate,
 		novitaTemplateCandidate: config.novitaTemplateCandidate,
+		runloopBlueprintCandidate: config.runloopBlueprintCandidate,
 		toolchainImageCandidate: pinnedBaseImage,
 		vercelImageCandidate: config.vercelImageCandidate,
 		daytonaVmTarget: config.daytonaVm.target,
@@ -256,7 +258,9 @@ export async function promoteAll(log: Log, options: PromoteOptions = {}): Promis
 					);
 					break;
 				case "runloop":
-					log("    runloop boots the stock Devbox image — nothing to promote");
+					await bakeRunloopBlueprint(config.runloopBlueprintVersion, pinnedBaseImage, (m) =>
+						log(`    ${m}`),
+					);
 					break;
 				case "namespace":
 					log("    namespace pulls the published version image — nothing to build");

--- a/apps/cli/src/lib/bake/runloop.test.ts
+++ b/apps/cli/src/lib/bake/runloop.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from "bun:test";
+import type { RunloopSDK } from "@runloop/api-client";
+import { TARGET_SPEC } from "@sandbox-benchmarks/schema";
+import { bakeRunloopBlueprint, runloopBlueprintParams } from "./runloop.ts";
+
+const DIGEST = `ghcr.io/starslingdev/sandbox-benchmarks-toolchain@sha256:${"a".repeat(64)}`;
+
+describe("Runloop Blueprint bake", () => {
+	it("pins the exact immutable FROM, canonical name, and shared target sizing", () => {
+		expect(runloopBlueprintParams("sandbox-benchmarks-toolchain-v7-candidate", DIGEST)).toEqual({
+			name: "sandbox-benchmarks-toolchain-v7-candidate",
+			dockerfile: `FROM ${DIGEST}\n`,
+			launch_parameters: {
+				resource_size_request: "CUSTOM_SIZE",
+				custom_cpu_cores: TARGET_SPEC.vcpus,
+				custom_gb_memory: TARGET_SPEC.memoryGb,
+				custom_disk_size: TARGET_SPEC.diskGb,
+			},
+		});
+	});
+
+	it("creates and awaits the Blueprint without putting credentials in build parameters", async () => {
+		let received: unknown;
+		const sdk = {
+			blueprint: {
+				create: async (params: unknown) => {
+					received = params;
+					return { id: "bpt_test" };
+				},
+			},
+		} as unknown as Pick<RunloopSDK, "blueprint">;
+		const logs: string[] = [];
+		await bakeRunloopBlueprint(
+			"sandbox-benchmarks-toolchain-v7-candidate",
+			DIGEST,
+			logs.push.bind(logs),
+			sdk,
+		);
+
+		expect(received).toEqual(
+			runloopBlueprintParams("sandbox-benchmarks-toolchain-v7-candidate", DIGEST),
+		);
+		expect(JSON.stringify(received)).not.toContain("RUNLOOP_API_KEY");
+		expect(JSON.stringify(received)).not.toContain("bearerToken");
+		expect(logs.at(-1)).toContain("bpt_test");
+	});
+});

--- a/apps/cli/src/lib/bake/runloop.ts
+++ b/apps/cli/src/lib/bake/runloop.ts
@@ -1,0 +1,40 @@
+// Bake a durable Runloop Blueprint from the shared toolchain image. Runloop selects the latest
+// successfully built Blueprint by name, so candidate builds deliberately reuse one mutable name:
+// a failed successor never displaces the last working candidate.
+import { RunloopSDK } from "@runloop/api-client";
+import { config } from "@sandbox-benchmarks/providers";
+import { resolveImageDigestRef } from "./image.ts";
+import type { Log } from "./types.ts";
+
+export type RunloopBlueprintParams = Parameters<RunloopSDK["blueprint"]["create"]>[0];
+
+/** Pure Blueprint request builder, exported so the release contract is pinned without live API calls. */
+export function runloopBlueprintParams(
+	name: string,
+	pinnedBaseImage: string,
+): RunloopBlueprintParams {
+	return {
+		name,
+		dockerfile: `FROM ${pinnedBaseImage}\n`,
+		launch_parameters: {
+			resource_size_request: "CUSTOM_SIZE",
+			custom_cpu_cores: config.targetSpec.vcpus,
+			custom_gb_memory: config.targetSpec.memoryGb,
+			custom_disk_size: config.targetSpec.diskGb,
+		},
+	};
+}
+
+/** Create `name` from an immutable base digest and await a successful remote Blueprint build. */
+export async function bakeRunloopBlueprint(
+	name: string,
+	baseImage: string,
+	log: Log,
+	sdk: Pick<RunloopSDK, "blueprint"> = new RunloopSDK(),
+): Promise<void> {
+	const pinnedBaseImage = await resolveImageDigestRef(baseImage);
+	const params = runloopBlueprintParams(name, pinnedBaseImage);
+	log(`runloop Blueprint build ${name} (base ${pinnedBaseImage})`);
+	const blueprint = await sdk.blueprint.create(params);
+	log(`runloop Blueprint built: ${blueprint.id}`);
+}

--- a/apps/cli/src/lib/bake/validate.test.ts
+++ b/apps/cli/src/lib/bake/validate.test.ts
@@ -103,10 +103,10 @@ describe("baseImageUse", () => {
 		]);
 	});
 
-	// The two that make a vercel-only release able to run without the candidate base existing at all.
+	// Providers that can validate without the candidate base existing at all.
 	it("marks the providers that never reference the toolchain base", () => {
 		const none = PROVIDERS.map((p) => p.id).filter((id) => baseImageUse(id) === "none");
-		expect(none).toEqual(["blaxel", "vercel"]);
+		expect(none).toEqual(["blaxel", "runloop", "vercel"]);
 	});
 
 	// Anything that reads the base ref in candidateCreateOptions must not be classified "none", or the

--- a/apps/cli/src/lib/bake/validate.test.ts
+++ b/apps/cli/src/lib/bake/validate.test.ts
@@ -9,6 +9,7 @@ const refs: CandidateRefs = {
 	daytonaContainerSnapshotCandidate: "snap-v1-container-candidate",
 	// Distinct from the e2b value so the novita case fails if it ever reads the e2b field.
 	novitaTemplateCandidate: "tc-v1-novita-candidate",
+	runloopBlueprintCandidate: "tc-v1-runloop-candidate",
 	toolchainImageCandidate: "ghcr.io/o/tc:v1-candidate",
 	vercelImageCandidate: "sandbox-benchmarks-toolchain-vercel:v1-candidate",
 	daytonaVmTarget: "us-west-2",
@@ -43,6 +44,12 @@ describe("candidateCreateOptions", () => {
 	it("points novita at its candidate template via snapshotId (e2b mapping, Novita's control plane)", () => {
 		expect(candidateCreateOptions("novita", refs)).toEqual({
 			snapshotId: "tc-v1-novita-candidate",
+		});
+	});
+
+	it("points Runloop at its candidate Blueprint by name", () => {
+		expect(candidateCreateOptions("runloop", refs)).toEqual({
+			blueprint_name: "tc-v1-runloop-candidate",
 		});
 	});
 
@@ -89,7 +96,7 @@ describe("candidateCreateOptions", () => {
 describe("baseImageUse", () => {
 	it("marks the providers that bake their own artifact from the base", () => {
 		const bakes = PROVIDERS.map((p) => p.id).filter((id) => baseImageUse(id) === "bakes");
-		expect(bakes).toEqual(["e2b", "daytona-vm", "daytona-container", "novita"]);
+		expect(bakes).toEqual(["e2b", "daytona-vm", "daytona-container", "novita", "runloop"]);
 	});
 
 	it("marks the providers that boot the base image directly", () => {
@@ -106,7 +113,7 @@ describe("baseImageUse", () => {
 	// Providers that can validate without the candidate base existing at all.
 	it("marks the providers that never reference the toolchain base", () => {
 		const none = PROVIDERS.map((p) => p.id).filter((id) => baseImageUse(id) === "none");
-		expect(none).toEqual(["blaxel", "runloop", "vercel"]);
+		expect(none).toEqual(["blaxel", "vercel"]);
 	});
 
 	// Anything that reads the base ref in candidateCreateOptions must not be classified "none", or the

--- a/apps/cli/src/lib/bake/validate.ts
+++ b/apps/cli/src/lib/bake/validate.ts
@@ -11,6 +11,8 @@ export interface CandidateRefs {
 	daytonaContainerSnapshotCandidate: string;
 	/** Candidate template on Novita's E2B-compatible control plane (its own namespace). */
 	novitaTemplateCandidate: string;
+	/** Candidate Blueprint on Runloop's control plane. */
+	runloopBlueprintCandidate: string;
 	toolchainImageCandidate: string;
 	/** Candidate image mirrored into the linked project's Vercel Container Registry. */
 	vercelImageCandidate: string;
@@ -25,10 +27,10 @@ export interface CandidateRefs {
  * needs, kept beside {@link candidateCreateOptions} because it is the same per-provider knowledge and
  * must stay exhaustive over `ProviderId` in the same way.
  *
- *   • `bakes` — builds its own artifact FROM the base (an e2b/novita template, a daytona snapshot), so
+ *   • `bakes` — builds its own artifact FROM the base (a template, snapshot, or Runloop Blueprint), so
  *     the artifact's bytes are decided at bake time by whichever base it was handed.
  *   • `boots` — no artifact of its own; it boots the base image by ref at create time.
- *   • `none`  — never references the base at all: blaxel and runloop boot vendor stock images, and
+ *   • `none`  — never references the base at all: blaxel boots a vendor stock image, and
  *     vercel boots its own VCR mirror (staged from the base by the build phase, not by this ref).
  */
 export type BaseImageUse = "bakes" | "boots" | "none";
@@ -40,6 +42,7 @@ export function baseImageUse(id: ProviderId): BaseImageUse {
 		case "daytona-vm":
 		case "daytona-container":
 		case "novita":
+		case "runloop":
 			return "bakes";
 		case "modal-gvisor":
 		case "modal-vm":
@@ -48,7 +51,6 @@ export function baseImageUse(id: ProviderId): BaseImageUse {
 		case "namespace":
 			return "boots";
 		case "blaxel":
-		case "runloop":
 		case "vercel":
 			return "none";
 	}
@@ -91,8 +93,7 @@ export function candidateCreateOptions(
 			// Same mapping as e2b (snapshotId → template name), against Novita's control plane.
 			return { snapshotId: refs.novitaTemplateCandidate };
 		case "runloop":
-			// Stock Devbox image — no candidate artifact to point at.
-			return {};
+			return { blueprint_name: refs.runloopBlueprintCandidate };
 		case "namespace":
 			// No template/snapshot system — points create() at the candidate image directly, same as modal.
 			return { image: refs.toolchainImageCandidate };

--- a/apps/cli/src/lib/bake/validate.ts
+++ b/apps/cli/src/lib/bake/validate.ts
@@ -28,8 +28,8 @@ export interface CandidateRefs {
  *   • `bakes` — builds its own artifact FROM the base (an e2b/novita template, a daytona snapshot), so
  *     the artifact's bytes are decided at bake time by whichever base it was handed.
  *   • `boots` — no artifact of its own; it boots the base image by ref at create time.
- *   • `none`  — never references the base at all: blaxel boots the vendor's stock image, and vercel
- *     boots its own VCR mirror (staged from the base by the build phase, not by this ref).
+ *   • `none`  — never references the base at all: blaxel and runloop boot vendor stock images, and
+ *     vercel boots its own VCR mirror (staged from the base by the build phase, not by this ref).
  */
 export type BaseImageUse = "bakes" | "boots" | "none";
 
@@ -48,6 +48,7 @@ export function baseImageUse(id: ProviderId): BaseImageUse {
 		case "namespace":
 			return "boots";
 		case "blaxel":
+		case "runloop":
 		case "vercel":
 			return "none";
 	}
@@ -89,6 +90,9 @@ export function candidateCreateOptions(
 		case "novita":
 			// Same mapping as e2b (snapshotId → template name), against Novita's control plane.
 			return { snapshotId: refs.novitaTemplateCandidate };
+		case "runloop":
+			// Stock Devbox image — no candidate artifact to point at.
+			return {};
 		case "namespace":
 			// No template/snapshot system — points create() at the candidate image directly, same as modal.
 			return { image: refs.toolchainImageCandidate };

--- a/apps/cli/src/lib/providers-run.test.ts
+++ b/apps/cli/src/lib/providers-run.test.ts
@@ -41,6 +41,7 @@ describe("forEachProviderWithCreds `only`", () => {
 			"modal-gvisor",
 			"modal-vm",
 			"novita",
+			"runloop",
 			"namespace",
 			"vercel",
 		]);

--- a/bun.lock
+++ b/bun.lock
@@ -91,6 +91,7 @@
         "@computesdk/modal": "catalog:computesdk",
         "@computesdk/namespace": "catalog:computesdk",
         "@computesdk/provider": "catalog:computesdk",
+        "@computesdk/runloop": "catalog:computesdk",
         "@sandbox-benchmarks/schema": "workspace:*",
         "@vercel/sandbox": "catalog:computesdk",
         "arktype": "catalog:",
@@ -198,6 +199,7 @@
       "@computesdk/modal": "1.9.3",
       "@computesdk/namespace": "1.6.12",
       "@computesdk/provider": "2.1.3",
+      "@computesdk/runloop": "1.3.53",
       "@daytona/api-client": "0.192.0",
       "@daytona/sdk": "0.192.0",
       "@vercel/sandbox": "2.9.2",
@@ -328,6 +330,8 @@
     "@computesdk/namespace": ["@computesdk/namespace@1.6.12", "", { "dependencies": { "@computesdk/provider": "2.1.3", "computesdk": "4.1.3" } }, "sha512-CkPkDxrD3coI0bpePMLku1mrVH/vFKBYQ8oZ/XB1JxuVdo5VDXGKraIGKtViDSn9hI/1ViTUCr2miePfjnAbVQ=="],
 
     "@computesdk/provider": ["@computesdk/provider@2.1.3", "", { "dependencies": { "@computesdk/cmd": "0.4.1", "computesdk": "4.1.3", "daemond": "0.1.4" } }, "sha512-soT+eu9VdeLkDjMdHe2fWh0WoiQ1C6xlMIdw8UKlJz5ivipJE6HP6Emm05qUdpeXooWquL1o3LQtRQDMFsrTfA=="],
+
+    "@computesdk/runloop": ["@computesdk/runloop@1.3.53", "", { "dependencies": { "@computesdk/provider": "2.1.3", "@runloop/api-client": "^1.24.0", "computesdk": "4.1.3" } }, "sha512-cfOhuLTgeBo9qCTraNtAQMPleRTBQqqGLbKPApDqzseJPcqj4cRt2z5fDC7pJqmh7VMIC+0jfVeiGIo7w4nXZQ=="],
 
     "@connectrpc/connect": ["@connectrpc/connect@2.0.0-rc.3", "", { "peerDependencies": { "@bufbuild/protobuf": "^2.2.0" } }, "sha512-ARBt64yEyKbanyRETTjcjJuHr2YXorzQo0etyS5+P6oSeW8xEuzajA9g+zDnMcj1hlX2dQE93foIWQGfpru7gQ=="],
 
@@ -685,6 +689,8 @@
 
     "@rollup/pluginutils": ["@rollup/pluginutils@5.4.0", "", { "dependencies": { "@types/estree": "^1.0.0", "estree-walker": "^2.0.2", "picomatch": "^4.0.2" }, "peerDependencies": { "rollup": "^1.20.0||^2.0.0||^3.0.0||^4.0.0" }, "optionalPeers": ["rollup"] }, "sha512-MfPp06CjRLfXQ3wY0R8vJDYBy/MvVcc9OulEfR0B8Iv9ko+GCNaRZ+EpJYFl27LhKsZK0o420sYCRHCjfCgeUg=="],
 
+    "@runloop/api-client": ["@runloop/api-client@1.28.0", "", { "dependencies": { "@types/node": "^18.11.18", "@types/node-fetch": "^2.6.4", "abort-controller": "^3.0.0", "agentkeepalive": "^4.2.1", "form-data-encoder": "1.7.2", "formdata-node": "^4.3.2", "node-fetch": "^2.6.7", "tar": "^7.5.2", "uuidv7": "^1.0.2", "zod": "^3.24.1" } }, "sha512-ZQVSbSutqknTjgRpsfiiI5WXSkx5KgQvWkUpZQwGMsHR+dPCyM6QQegbAYqQaKuhIxEwxsLkJrSTm2fJkXmunw=="],
+
     "@sandbox-benchmarks/cli": ["@sandbox-benchmarks/cli@workspace:apps/cli"],
 
     "@sandbox-benchmarks/figures": ["@sandbox-benchmarks/figures@workspace:packages/figures"],
@@ -742,6 +748,8 @@
     "@types/json-schema": ["@types/json-schema@7.0.15", "", {}, "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA=="],
 
     "@types/node": ["@types/node@25.9.2", "", { "dependencies": { "undici-types": ">=7.24.0 <7.24.7" } }, "sha512-G05zqtJhcDLb8uslf5EjCxXg9G1KQxiV8OS0R26IC//Eoyitzqe8z37I7cqvnZlrlSfgocQRfSn/AHBZJJFyGw=="],
+
+    "@types/node-fetch": ["@types/node-fetch@2.6.13", "", { "dependencies": { "@types/node": "*", "form-data": "^4.0.4" } }, "sha512-QGpRVpzSaUs30JBSGPjOg4Uveu384erbHBoT1zeONvyCfwQxIkUshLAOqN/k9EjGviPRmWTTe6aH2qySWKTVSw=="],
 
     "@vercel/backends": ["@vercel/backends@0.8.30", "", { "dependencies": { "@vercel/build-utils": "13.36.3", "@vercel/nft": "1.10.0", "@vercel/static-config": "3.4.0", "execa": "3.2.0", "fs-extra": "11.1.0", "get-port": "5.1.1", "oxc-transform": "0.111.0", "path-to-regexp": "8.3.0", "resolve.exports": "2.0.3", "rolldown": "1.0.0-rc.1", "srvx": "0.11.16", "ts-morph": "12.0.0", "tsx": "4.21.0", "zod": "3.22.4" } }, "sha512-rCDufBDL3Y9eiKOKZLoiy350KMt/kP7YmcRgI1egfrUpaaGObDesxkK9IQdP7fnYrK+rc2+rK07qb21AdsoAHw=="],
 
@@ -828,6 +836,8 @@
     "acorn-import-attributes": ["acorn-import-attributes@1.9.5", "", { "peerDependencies": { "acorn": "^8" } }, "sha512-n02Vykv5uA3eHGM/Z2dQrcD56kL8TyDb2p1+0P83PClMnC/nc+anbQRhIOWnSq4Ke/KvDPrY3C9hDtC/A3eHnQ=="],
 
     "agent-base": ["agent-base@6.0.2", "", { "dependencies": { "debug": "4" } }, "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ=="],
+
+    "agentkeepalive": ["agentkeepalive@4.6.0", "", { "dependencies": { "humanize-ms": "^1.2.1" } }, "sha512-kja8j7PjmncONqaTsB8fQ+wE2mSU2DJ9D4XKoJ5PFWIdRMa6SLSN1ff4mOr4jCbfRSsxR4keIiySJU0N9T5hIQ=="],
 
     "ajv": ["ajv@8.20.0", "", { "dependencies": { "fast-deep-equal": "^3.1.3", "fast-uri": "^3.0.1", "json-schema-traverse": "^1.0.0", "require-from-string": "^2.0.2" } }, "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA=="],
 
@@ -1081,6 +1091,10 @@
 
     "form-data": ["form-data@4.0.5", "", { "dependencies": { "asynckit": "^0.4.0", "combined-stream": "^1.0.8", "es-set-tostringtag": "^2.1.0", "hasown": "^2.0.2", "mime-types": "^2.1.12" } }, "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w=="],
 
+    "form-data-encoder": ["form-data-encoder@1.7.2", "", {}, "sha512-qfqtYan3rxrnCk1VYaA4H+Ms9xdpPqvLZa6xmMgFvhO32x7/3J/ExcTd6qpxM0vH2GdMI+poehyBZvqfMTto8A=="],
+
+    "formdata-node": ["formdata-node@4.4.1", "", { "dependencies": { "node-domexception": "1.0.0", "web-streams-polyfill": "4.0.0-beta.3" } }, "sha512-0iirZp3uVDjVGt9p49aTaqjk84TrglENEDuqfdlZQ1roC9CWlPk6Avf8EEnZNcAqPonwkG35x4n3ww/1THYAeQ=="],
+
     "forwarded": ["forwarded@0.2.0", "", {}, "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow=="],
 
     "forwarded-parse": ["forwarded-parse@2.1.2", "", {}, "sha512-alTFZZQDKMporBH77856pXgzhEzaUVmLCDk+egLgIgHst3Tpndzz8MnKe+GzRJRfvVdn69HhpW7cmXzvtLvJAw=="],
@@ -1132,6 +1146,8 @@
     "https-proxy-agent": ["https-proxy-agent@5.0.1", "", { "dependencies": { "agent-base": "6", "debug": "4" } }, "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA=="],
 
     "human-signals": ["human-signals@1.1.1", "", {}, "sha512-SEQu7vl8KjNL2eoGBLF3+wAjpsNfA9XMlXAYj/3EdaNfAlxKthD1xjEQfGOUhllCGGJVNY34bRr6lPINhNjyZw=="],
+
+    "humanize-ms": ["humanize-ms@1.2.1", "", { "dependencies": { "ms": "^2.0.0" } }, "sha512-Fl70vYtsAFb/C06PTS9dZBo7ihau+Tu/DNCk/OyHhea07S+aeMWpFFkUaXRa8fI+ScZbEI8dfSxwY7gxZ9SAVQ=="],
 
     "iconv-lite": ["iconv-lite@0.7.2", "", { "dependencies": { "safer-buffer": ">= 2.1.2 < 3.0.0" } }, "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw=="],
 
@@ -1276,6 +1292,8 @@
     "nice-grpc": ["nice-grpc@2.1.16", "", { "dependencies": { "@grpc/grpc-js": "^1.14.0", "abort-controller-x": "^0.5.0", "nice-grpc-common": "^2.0.3" } }, "sha512-Cl3Pn00212Hl8/U6bpgMxmhZj5lyv3nWoJov4cd3FjWarktrMHP4DNvSjCnDwkMWYx4W1tyscEia4JX6Y4GVCQ=="],
 
     "nice-grpc-common": ["nice-grpc-common@2.0.3", "", { "dependencies": { "ts-error": "^1.0.6" } }, "sha512-MEhnD3JMah0mgyivpb9hpRDbOBuXBxI/TVO+OK1h6rC97WM42HsPMR+zzRNQ0C5BqYJTw1nyWiQRD0DucO+pjQ=="],
+
+    "node-domexception": ["node-domexception@1.0.0", "", {}, "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ=="],
 
     "node-fetch": ["node-fetch@2.6.7", "", { "dependencies": { "whatwg-url": "^5.0.0" }, "peerDependencies": { "encoding": "^0.1.0" }, "optionalPeers": ["encoding"] }, "sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ=="],
 
@@ -1533,6 +1551,8 @@
 
     "uuid": ["uuid@11.1.1", "", { "bin": { "uuid": "dist/esm/bin/uuid" } }, "sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ=="],
 
+    "uuidv7": ["uuidv7@1.2.1", "", { "bin": { "uuidv7": "cli.js" } }, "sha512-4kPkK3/XTQW9Hbm4CaqfICn+kY9LJtDVEOfgsRRra/+n2Ofg4NqzRFceAkxvQ/Ud/6BpHOPzj8cirqM7TzTN5Q=="],
+
     "vary": ["vary@1.1.2", "", {}, "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg=="],
 
     "vercel": ["vercel@58.4.4", "", { "dependencies": { "@vercel/backends": "0.8.30", "@vercel/blob": "2.4.0", "@vercel/build-utils": "13.36.3", "@vercel/cli-auth": "0.3.1", "@vercel/cli-config": "0.2.1", "@vercel/container": "0.1.0", "@vercel/detect-agent": "1.2.3", "@vercel/elysia": "0.1.107", "@vercel/express": "0.1.121", "@vercel/fastify": "0.1.110", "@vercel/fun": "1.3.0", "@vercel/go": "3.10.2", "@vercel/h3": "0.1.116", "@vercel/hono": "0.2.110", "@vercel/hydrogen": "1.4.0", "@vercel/koa": "0.1.90", "@vercel/nestjs": "0.2.111", "@vercel/next": "4.20.5", "@vercel/node": "5.9.3", "@vercel/prepare-flags-definitions": "0.3.0", "@vercel/python": "6.54.1", "@vercel/redwood": "2.5.0", "@vercel/remix-builder": "5.9.1", "@vercel/ruby": "2.5.1", "@vercel/rust": "1.4.0", "@vercel/static-build": "2.11.13", "chokidar": "4.0.0", "esbuild": "0.27.0", "jose": "5.9.6", "jsonc-parser": "3.3.1", "luxon": "^3.4.0", "sandbox": "3.4.0", "smol-toml": "1.5.2", "undici": "5.29.0", "zod": "4.1.11" }, "bin": { "vc": "dist/vc.js", "vercel": "dist/vc.js" } }, "sha512-Mv1807Ptxhy6cQne5xV/2dD+bUGYRtpV3sLVPXEW115RBN6K/ssuvOww8eNfdGucFH9C+p5ccQF07XSyAvBPLQ=="],
@@ -1540,6 +1560,8 @@
     "vscode-languageserver-textdocument": ["vscode-languageserver-textdocument@1.0.12", "", {}, "sha512-cxWNPesCnQCcMPeenjKKsOCKQZ/L6Tv19DTRIGuLWe32lyzWhihGVJ/rcckZXJxfdKCFvRLS3fpBIsV/ZGX4zA=="],
 
     "vscode-languageserver-types": ["vscode-languageserver-types@3.18.0", "", {}, "sha512-8TsGPNMIMiiBdkORgRSvLjuiEIiAFtO+KssmYWxQ+uSVvlf7RjK8YKCOjPzZ+YA04jXEV7+7LvkSmHkhpNS99g=="],
+
+    "web-streams-polyfill": ["web-streams-polyfill@4.0.0-beta.3", "", {}, "sha512-QW95TCTaHmsYfHDybGMwO5IJIM93I/6vTRk+daHTWFPhwh+C8Cg7j7XyKrwrj8Ib6vYXe0ocYNrmzY4xAAN6ug=="],
 
     "web-vitals": ["web-vitals@0.2.4", "", {}, "sha512-6BjspCO9VriYy12z356nL6JBS0GYeEcA457YyRzD+dD6XYCQ75NKhcOHUMHentOE7OcVCIXXDvOm0jKFfQG2Gg=="],
 
@@ -1610,6 +1632,12 @@
     "@octokit/request/content-type": ["content-type@2.0.0", "", {}, "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ=="],
 
     "@opentelemetry/otlp-transformer/protobufjs": ["protobufjs@8.0.1", "", { "dependencies": { "@protobufjs/aspromise": "^1.1.2", "@protobufjs/base64": "^1.1.2", "@protobufjs/codegen": "^2.0.4", "@protobufjs/eventemitter": "^1.1.0", "@protobufjs/fetch": "^1.1.0", "@protobufjs/float": "^1.0.2", "@protobufjs/inquire": "^1.1.0", "@protobufjs/path": "^1.1.2", "@protobufjs/pool": "^1.1.0", "@protobufjs/utf8": "^1.1.0", "@types/node": ">=13.7.0", "long": "^5.0.0" } }, "sha512-NWWCCscLjs+cOKF/s/XVNFRW7Yih0fdH+9brffR5NZCy8k42yRdl5KlWKMVXuI1vfCoy4o1z80XR/W/QUb3V3w=="],
+
+    "@runloop/api-client/@types/node": ["@types/node@18.19.130", "", { "dependencies": { "undici-types": "~5.26.4" } }, "sha512-GRaXQx6jGfL8sKfaIDD6OupbIHBr9jv7Jnaml9tB7l4v068PAOXqfcujMMo5PhbIs6ggR1XODELqahT2R8v0fg=="],
+
+    "@runloop/api-client/node-fetch": ["node-fetch@2.6.9", "", { "dependencies": { "whatwg-url": "^5.0.0" }, "peerDependencies": { "encoding": "^0.1.0" }, "optionalPeers": ["encoding"] }, "sha512-DJm/CJkZkRjKKj4Zi4BsKVZh3ValV5IR5s7LVZnW+6YMh0W1BfNA8XSs6DLMGYlId5F3KnA70uu2qepcR08Qqg=="],
+
+    "@runloop/api-client/zod": ["zod@3.25.76", "", {}, "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="],
 
     "@ts-morph/common/minimatch": ["minimatch@3.1.5", "", { "dependencies": { "brace-expansion": "^1.1.7" } }, "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w=="],
 
@@ -1768,6 +1796,8 @@
     "@mapbox/node-pre-gyp/https-proxy-agent/agent-base": ["agent-base@7.1.4", "", {}, "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ=="],
 
     "@mapbox/node-pre-gyp/https-proxy-agent/debug": ["debug@4.4.3", "", { "dependencies": { "ms": "^2.1.3" }, "peerDependencies": { "supports-color": "*" }, "optionalPeers": ["supports-color"] }, "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA=="],
+
+    "@runloop/api-client/@types/node/undici-types": ["undici-types@5.26.5", "", {}, "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA=="],
 
     "@ts-morph/common/minimatch/brace-expansion": ["brace-expansion@1.1.18", "", { "dependencies": { "balanced-match": "^1.0.0", "concat-map": "0.0.1" } }, "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw=="],
 

--- a/bun.lock
+++ b/bun.lock
@@ -36,6 +36,7 @@
         "@actions/core": "1.11.1",
         "@daytona/api-client": "catalog:computesdk",
         "@daytona/sdk": "catalog:computesdk",
+        "@runloop/api-client": "1.28.0",
         "@sandbox-benchmarks/figures": "workspace:*",
         "@sandbox-benchmarks/harness": "workspace:*",
         "@sandbox-benchmarks/providers": "workspace:*",
@@ -747,7 +748,7 @@
 
     "@types/json-schema": ["@types/json-schema@7.0.15", "", {}, "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA=="],
 
-    "@types/node": ["@types/node@25.9.2", "", { "dependencies": { "undici-types": ">=7.24.0 <7.24.7" } }, "sha512-G05zqtJhcDLb8uslf5EjCxXg9G1KQxiV8OS0R26IC//Eoyitzqe8z37I7cqvnZlrlSfgocQRfSn/AHBZJJFyGw=="],
+    "@types/node": ["@types/node@18.19.130", "", { "dependencies": { "undici-types": "~5.26.4" } }, "sha512-GRaXQx6jGfL8sKfaIDD6OupbIHBr9jv7Jnaml9tB7l4v068PAOXqfcujMMo5PhbIs6ggR1XODELqahT2R8v0fg=="],
 
     "@types/node-fetch": ["@types/node-fetch@2.6.13", "", { "dependencies": { "@types/node": "*", "form-data": "^4.0.4" } }, "sha512-QGpRVpzSaUs30JBSGPjOg4Uveu384erbHBoT1zeONvyCfwQxIkUshLAOqN/k9EjGviPRmWTTe6aH2qySWKTVSw=="],
 
@@ -1295,7 +1296,7 @@
 
     "node-domexception": ["node-domexception@1.0.0", "", {}, "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ=="],
 
-    "node-fetch": ["node-fetch@2.6.7", "", { "dependencies": { "whatwg-url": "^5.0.0" }, "peerDependencies": { "encoding": "^0.1.0" }, "optionalPeers": ["encoding"] }, "sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ=="],
+    "node-fetch": ["node-fetch@2.6.9", "", { "dependencies": { "whatwg-url": "^5.0.0" }, "peerDependencies": { "encoding": "^0.1.0" }, "optionalPeers": ["encoding"] }, "sha512-DJm/CJkZkRjKKj4Zi4BsKVZh3ValV5IR5s7LVZnW+6YMh0W1BfNA8XSs6DLMGYlId5F3KnA70uu2qepcR08Qqg=="],
 
     "node-gyp-build": ["node-gyp-build@4.8.4", "", { "bin": { "node-gyp-build": "bin.js", "node-gyp-build-optional": "optional.js", "node-gyp-build-test": "build-test.js" } }, "sha512-LA4ZjwlnUblHVgq0oBF3Jl/6h/Nvs5fzBLwdEF4nuxnFdsfajde4WfxtJr3CaiH+F6ewcIB/q4jQ4UzPyid+CQ=="],
 
@@ -1537,7 +1538,7 @@
 
     "undici": ["undici@5.29.0", "", { "dependencies": { "@fastify/busboy": "^2.0.0" } }, "sha512-raqeBD6NQK4SkWhQzeYKd1KmIG6dllBOTt55Rmkt4HtI9mwdWtJljnrXjAFUBLTSN67HWrOIZ3EPF4kjUw80Bg=="],
 
-    "undici-types": ["undici-types@7.24.6", "", {}, "sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg=="],
+    "undici-types": ["undici-types@5.26.5", "", {}, "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA=="],
 
     "universal-user-agent": ["universal-user-agent@7.0.3", "", {}, "sha512-TmnEAEAsBJVZM/AADELsK76llnwcf9vMKuPz8JflO1frO8Lchitr0fNaN9d+Ap0BjKtqWqd/J17qeDnXh8CL2A=="],
 
@@ -1621,8 +1622,6 @@
 
     "@mapbox/node-pre-gyp/https-proxy-agent": ["https-proxy-agent@7.0.6", "", { "dependencies": { "agent-base": "^7.1.2", "debug": "4" } }, "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw=="],
 
-    "@mapbox/node-pre-gyp/node-fetch": ["node-fetch@2.6.9", "", { "dependencies": { "whatwg-url": "^5.0.0" }, "peerDependencies": { "encoding": "^0.1.0" }, "optionalPeers": ["encoding"] }, "sha512-DJm/CJkZkRjKKj4Zi4BsKVZh3ValV5IR5s7LVZnW+6YMh0W1BfNA8XSs6DLMGYlId5F3KnA70uu2qepcR08Qqg=="],
-
     "@mapbox/node-pre-gyp/semver": ["semver@7.8.4", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-rUCObTnP32Q08R2uuIrt7r9PlEonuTmtuXYcW6s5kjdlj3xbnwe+21yXptAUYcMAABLkYYTtnmzb3w3EDZfueA=="],
 
     "@modelcontextprotocol/sdk/jose": ["jose@6.2.3", "", {}, "sha512-YYVDInQKFJfR/xa3ojUTl8c2KoTwiL1R5Wg9YCydwH0x0B9grbzlg5HC7mMjCtUJjbQ/YnGEZIhI5tCgfTb4Hw=="],
@@ -1633,13 +1632,11 @@
 
     "@opentelemetry/otlp-transformer/protobufjs": ["protobufjs@8.0.1", "", { "dependencies": { "@protobufjs/aspromise": "^1.1.2", "@protobufjs/base64": "^1.1.2", "@protobufjs/codegen": "^2.0.4", "@protobufjs/eventemitter": "^1.1.0", "@protobufjs/fetch": "^1.1.0", "@protobufjs/float": "^1.0.2", "@protobufjs/inquire": "^1.1.0", "@protobufjs/path": "^1.1.2", "@protobufjs/pool": "^1.1.0", "@protobufjs/utf8": "^1.1.0", "@types/node": ">=13.7.0", "long": "^5.0.0" } }, "sha512-NWWCCscLjs+cOKF/s/XVNFRW7Yih0fdH+9brffR5NZCy8k42yRdl5KlWKMVXuI1vfCoy4o1z80XR/W/QUb3V3w=="],
 
-    "@runloop/api-client/@types/node": ["@types/node@18.19.130", "", { "dependencies": { "undici-types": "~5.26.4" } }, "sha512-GRaXQx6jGfL8sKfaIDD6OupbIHBr9jv7Jnaml9tB7l4v068PAOXqfcujMMo5PhbIs6ggR1XODELqahT2R8v0fg=="],
-
-    "@runloop/api-client/node-fetch": ["node-fetch@2.6.9", "", { "dependencies": { "whatwg-url": "^5.0.0" }, "peerDependencies": { "encoding": "^0.1.0" }, "optionalPeers": ["encoding"] }, "sha512-DJm/CJkZkRjKKj4Zi4BsKVZh3ValV5IR5s7LVZnW+6YMh0W1BfNA8XSs6DLMGYlId5F3KnA70uu2qepcR08Qqg=="],
-
     "@runloop/api-client/zod": ["zod@3.25.76", "", {}, "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="],
 
     "@ts-morph/common/minimatch": ["minimatch@3.1.5", "", { "dependencies": { "brace-expansion": "^1.1.7" } }, "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w=="],
+
+    "@types/node-fetch/@types/node": ["@types/node@25.9.2", "", { "dependencies": { "undici-types": ">=7.24.0 <7.24.7" } }, "sha512-G05zqtJhcDLb8uslf5EjCxXg9G1KQxiV8OS0R26IC//Eoyitzqe8z37I7cqvnZlrlSfgocQRfSn/AHBZJJFyGw=="],
 
     "@vercel/backends/zod": ["zod@3.22.4", "", {}, "sha512-iC+8Io04lddc+mVqQ9AZ7OQ2MrUKGN+oIQyq1vemgt46jwCwLfhq7/pwnBnNXXXZb8VTVLKwp9EDkx+ryxIWmg=="],
 
@@ -1650,6 +1647,8 @@
     "@vercel/fun/async-listen": ["async-listen@1.2.0", "", {}, "sha512-CcEtRh/oc9Jc4uWeUwdpG/+Mb2YUHKmdaTf0gUr7Wa+bfp4xx70HOb3RuSTJMvqKNB1TkdTfjLdrcz2X4rkkZA=="],
 
     "@vercel/fun/ms": ["ms@2.1.1", "", {}, "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg=="],
+
+    "@vercel/fun/node-fetch": ["node-fetch@2.6.7", "", { "dependencies": { "whatwg-url": "^5.0.0" }, "peerDependencies": { "encoding": "^0.1.0" }, "optionalPeers": ["encoding"] }, "sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ=="],
 
     "@vercel/fun/path-to-regexp": ["path-to-regexp@8.2.0", "", {}, "sha512-TdrF7fW9Rphjq4RjrW0Kp2AW0Ahwu9sRGTkS6bvDi0SCwZlEZYmcfDbEsTz8RVk0EHIS/Vd1bv3JhG+1xZuAyQ=="],
 
@@ -1662,8 +1661,6 @@
     "@vercel/node/@types/node": ["@types/node@20.11.0", "", { "dependencies": { "undici-types": "~5.26.4" } }, "sha512-o9bjXmDNcF7GbM4CNQpmi+TutCgap/K3w1JyKgxAjqx41zp9qlIAVFi0IhCNsJcXolEqLWhbFbEeL0PvYm4pcQ=="],
 
     "@vercel/node/es-module-lexer": ["es-module-lexer@1.4.1", "", {}, "sha512-cXLGjP0c4T3flZJKQSuziYoq7MlT+rnvfZjfp7h+I7K9BNX54kP9nyWvdbwjQ4u1iWbOL4u96fgeZLToQlZC7w=="],
-
-    "@vercel/node/node-fetch": ["node-fetch@2.6.9", "", { "dependencies": { "whatwg-url": "^5.0.0" }, "peerDependencies": { "encoding": "^0.1.0" }, "optionalPeers": ["encoding"] }, "sha512-DJm/CJkZkRjKKj4Zi4BsKVZh3ValV5IR5s7LVZnW+6YMh0W1BfNA8XSs6DLMGYlId5F3KnA70uu2qepcR08Qqg=="],
 
     "@vercel/node/path-to-regexp": ["path-to-regexp@6.1.0", "", {}, "sha512-h9DqehX3zZZDCEm+xbfU0ZmwCGFCAAraPJWMXJ4+v32NjZJilVg3k1TcKsRgIb8IQ/izZSaydDc1OhJCZvs2Dw=="],
 
@@ -1702,6 +1699,8 @@
     "body-parser/content-type": ["content-type@2.0.0", "", {}, "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ=="],
 
     "body-parser/debug": ["debug@4.4.3", "", { "dependencies": { "ms": "^2.1.3" }, "peerDependencies": { "supports-color": "*" }, "optionalPeers": ["supports-color"] }, "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA=="],
+
+    "bun-types/@types/node": ["@types/node@25.9.2", "", { "dependencies": { "undici-types": ">=7.24.0 <7.24.7" } }, "sha512-G05zqtJhcDLb8uslf5EjCxXg9G1KQxiV8OS0R26IC//Eoyitzqe8z37I7cqvnZlrlSfgocQRfSn/AHBZJJFyGw=="],
 
     "c12/chokidar": ["chokidar@5.0.0", "", { "dependencies": { "readdirp": "^5.0.0" } }, "sha512-TQMmc3w+5AxjpL8iIiwebF73dRDF4fBIieAqGn9RGCWaEVwQ6Fb2cGe31Yns0RRIzii5goJ1Y7xbMwo1TxMplw=="],
 
@@ -1748,6 +1747,8 @@
     "modal/smol-toml": ["smol-toml@1.6.1", "", {}, "sha512-dWUG8F5sIIARXih1DTaQAX4SsiTXhInKf1buxdY9DIg4ZYPZK5nGM1VRIYmEbDbsHt7USo99xSLFu5Q1IqTmsg=="],
 
     "path-scurry/lru-cache": ["lru-cache@11.5.1", "", {}, "sha512-RPimw/7aMdv2oqRrxKwvZXcPfwBrn/JZ2xYcY9Hus/6LaS3VOAKVWKWgNLCFSiOm1ESXinjsDlidVU7JlnCN2A=="],
+
+    "protobufjs/@types/node": ["@types/node@25.9.2", "", { "dependencies": { "undici-types": ">=7.24.0 <7.24.7" } }, "sha512-G05zqtJhcDLb8uslf5EjCxXg9G1KQxiV8OS0R26IC//Eoyitzqe8z37I7cqvnZlrlSfgocQRfSn/AHBZJJFyGw=="],
 
     "readable-stream/buffer": ["buffer@6.0.3", "", { "dependencies": { "base64-js": "^1.3.1", "ieee754": "^1.2.1" } }, "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA=="],
 
@@ -1797,11 +1798,11 @@
 
     "@mapbox/node-pre-gyp/https-proxy-agent/debug": ["debug@4.4.3", "", { "dependencies": { "ms": "^2.1.3" }, "peerDependencies": { "supports-color": "*" }, "optionalPeers": ["supports-color"] }, "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA=="],
 
-    "@runloop/api-client/@types/node/undici-types": ["undici-types@5.26.5", "", {}, "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA=="],
+    "@opentelemetry/otlp-transformer/protobufjs/@types/node": ["@types/node@25.9.2", "", { "dependencies": { "undici-types": ">=7.24.0 <7.24.7" } }, "sha512-G05zqtJhcDLb8uslf5EjCxXg9G1KQxiV8OS0R26IC//Eoyitzqe8z37I7cqvnZlrlSfgocQRfSn/AHBZJJFyGw=="],
 
     "@ts-morph/common/minimatch/brace-expansion": ["brace-expansion@1.1.18", "", { "dependencies": { "balanced-match": "^1.0.0", "concat-map": "0.0.1" } }, "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw=="],
 
-    "@vercel/node/@types/node/undici-types": ["undici-types@5.26.5", "", {}, "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA=="],
+    "@types/node-fetch/@types/node/undici-types": ["undici-types@7.24.6", "", {}, "sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg=="],
 
     "@vercel/rust/execa/get-stream": ["get-stream@6.0.1", "", {}, "sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg=="],
 
@@ -1814,6 +1815,8 @@
     "archiver-utils/glob/minimatch": ["minimatch@9.0.9", "", { "dependencies": { "brace-expansion": "^2.0.2" } }, "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg=="],
 
     "archiver-utils/glob/path-scurry": ["path-scurry@1.11.1", "", { "dependencies": { "lru-cache": "^10.2.0", "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0" } }, "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA=="],
+
+    "bun-types/@types/node/undici-types": ["undici-types@7.24.6", "", {}, "sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg=="],
 
     "c12/chokidar/readdirp": ["readdirp@5.0.0", "", {}, "sha512-9u/XQ1pvrQtYyMpZe7DXKv2p5CNvyVwzUB6uhLAnQwHMSgKMBR62lc7AHljaeteeHXn11XTAaLLUVZYVZyuRBQ=="],
 
@@ -1833,6 +1836,8 @@
 
     "micro/raw-body/iconv-lite": ["iconv-lite@0.4.24", "", { "dependencies": { "safer-buffer": ">= 2.1.2 < 3" } }, "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA=="],
 
+    "protobufjs/@types/node/undici-types": ["undici-types@7.24.6", "", {}, "sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg=="],
+
     "readdir-glob/minimatch/brace-expansion": ["brace-expansion@2.1.1", "", { "dependencies": { "balanced-match": "^1.0.0" } }, "sha512-WR1cURNjuvBLMZBMbqM0UoE+WAfdUcEV1ccD8PVBVOI+Z3ND4+SZbN8RsfT2bMuG1qwz5RFvPukSZm5fF2D5eA=="],
 
     "sandbox/@vercel/sandbox/jose": ["jose@6.2.3", "", {}, "sha512-YYVDInQKFJfR/xa3ojUTl8c2KoTwiL1R5Wg9YCydwH0x0B9grbzlg5HC7mMjCtUJjbQ/YnGEZIhI5tCgfTb4Hw=="],
@@ -1850,6 +1855,8 @@
     "wrap-ansi-cjs/strip-ansi/ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
 
     "wrap-ansi/string-width/emoji-regex": ["emoji-regex@9.2.2", "", {}, "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg=="],
+
+    "@opentelemetry/otlp-transformer/protobufjs/@types/node/undici-types": ["undici-types@7.24.6", "", {}, "sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg=="],
 
     "@ts-morph/common/minimatch/brace-expansion/balanced-match": ["balanced-match@1.0.2", "", {}, "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="],
 

--- a/docs/ci-secrets.md
+++ b/docs/ci-secrets.md
@@ -149,15 +149,17 @@ Ungated: `ci.yml`, `ci-lint.yml`, and the toolchain `pr-gate` (Docker smoke, no 
    first. Two more refusals keep a scoped release honest, both fail-fast in the plan or before the
    public base moves:
 
-   - **`providers: blaxel` is refused.** Blaxel boots the vendor's stock image rather than the
-     toolchain, so the release lane carries no `BL_API_KEY`/`BL_WORKSPACE` (they are bench-lane only,
-     see the table above) and has no artifact to publish for it. An *unscoped* release just skips it.
+   - **`providers: blaxel` and `providers: runloop` are refused.** Both boot vendor stock images rather
+     than the toolchain, so the release lane has no artifact to publish for either one. Blaxel's
+     `BL_API_KEY`/`BL_WORKSPACE` and Runloop's `RUNLOOP_API_KEY` are bench-lane only (see the table
+     above). An *unscoped* release simply skips them.
    - **A drifted candidate base is refused** when the scope contains a provider that bakes its artifact
      *from* the base (e2b, daytona, novita). Those providers' candidates are verified but their version
      artifacts are rebuilt, so the two are the same bytes only while `:vN-candidate` still is `:vN` —
      bump `TOOLCHAIN_VERSION` and cut a full release. Providers that don't bake from the base (vercel,
      modal, namespace, microsandbox) are unaffected: their version artifact is a retag of the exact
-     candidate that was just booted.
+     candidate that was just booted. Runloop is also unaffected by candidate drift, but has no release
+     artifact and therefore cannot be scoped into this lane.
 
    The Vercel-on-v7 flow, as an example — two dispatches, neither of which touches another provider,
    and neither of which runs a build job:
@@ -215,6 +217,7 @@ Do this in the GitHub UI (Settings → Environments / Rules / Actions), then del
    | `MODAL_TOKEN_ID` | toolchain bake, bench matrix/smoke |
    | `MODAL_TOKEN_SECRET` | toolchain bake, bench matrix/smoke |
    | `NOVITA_API_KEY` | optional for toolchain; bench matrix/smoke |
+   | `RUNLOOP_API_KEY` | bench matrix/smoke only |
    | `BL_API_KEY` | bench matrix/smoke only |
    | `BL_WORKSPACE` | bench matrix/smoke only |
    | `MSB_API_KEY` | Microsandbox Cloud toolchain validation and bench matrix/smoke |
@@ -310,6 +313,8 @@ Copy [`.env.example`](../.env.example) to a gitignored `.env` and fill in the pr
 commit them; never paste them into issues or pull requests. See [SECURITY.md](../SECURITY.md).
 
 `microsandbox-local` uses `MICROSANDBOX_LOCAL_BENCH=1` as an explicit capability opt-in rather than a credential. The runner must provide KVM on Linux or Hypervisor.framework on macOS. `microsandbox-cloud` needs `MSB_API_KEY`; `MSB_API_URL` is an optional endpoint override. The cloud adapter keeps the key in the SDK control-plane backend and never adds it to sandbox metadata, create-time environment variables, or guest commands.
+
+Runloop needs `RUNLOOP_API_KEY`. The adapter keeps it in the SDK control-plane client and launches a custom-sized stock Devbox; the harness installs its pinned fallback toolchain inside the guest before benchmarking.
 
 The `tooling/repo-checks` secret-hygiene gate enforces this: it fails CI if any tracked file is a
 credential file (`.env`, `*.pem`, `id_rsa`, …) or contains a high-signal secret token.

--- a/docs/ci-secrets.md
+++ b/docs/ci-secrets.md
@@ -137,11 +137,10 @@ Ungated: `ci.yml`, `ci-lint.yml`, and the toolchain `pr-gate` (Docker smoke, no 
    | `build` | `full` rebuilds the base (the default). `skip` skips the build job outright and derives everything from what the registry already holds. A backfill wants `skip`: it attaches to the **published** base, so the new provider gets exactly the bytes the fleet already runs — and since the toolchain build is not reproducible, a rebuild would quietly hand it a different `:vN`. |
    | `promote` | Uncheck to bake + verify only; the publish job is skipped. |
 
-   A backfill needs no build phase at all, because **nothing is staged per provider**: every provider
-   derives its artifact from the one shared toolchain base at bake/promote time. That includes Vercel —
-   its platform can only boot images from VCR, so the bake cell mirrors the shared base across rather
-   than pulling from GHCR, but the bytes are the same base image every other provider runs (Vercel
-   injects its own session agent at boot, so there is no provider delta to bake in).
+   A backfill needs no shared build phase: every provider derives its candidate or version artifact
+   from the one already-published toolchain base during bake/promote. Runloop builds a named Blueprint
+   whose Dockerfile starts from that digest. Vercel mirrors the same base into VCR because its platform
+   cannot pull GHCR directly (and injects its own session agent at boot, so there is no provider delta).
 
    `force_republish` is rejected together with a `providers` list — they are opposite operations, and
    silently picking one would do something the operator did not ask for. A scoped promote also refuses
@@ -149,26 +148,25 @@ Ungated: `ci.yml`, `ci-lint.yml`, and the toolchain `pr-gate` (Docker smoke, no 
    first. Two more refusals keep a scoped release honest, both fail-fast in the plan or before the
    public base moves:
 
-   - **`providers: blaxel` and `providers: runloop` are refused.** Both boot vendor stock images rather
-     than the toolchain, so the release lane has no artifact to publish for either one. Blaxel's
-     `BL_API_KEY`/`BL_WORKSPACE` and Runloop's `RUNLOOP_API_KEY` are bench-lane only (see the table
-     above). An *unscoped* release simply skips them.
+   - **`providers: blaxel` is refused.** It still boots a vendor stock image, so the release lane has
+     no artifact to publish and carries no `BL_API_KEY`/`BL_WORKSPACE`. An *unscoped* release simply
+     skips it. Runloop is scopable: its protected `RUNLOOP_API_KEY` builds and validates a candidate
+     Blueprint, and a scoped Runloop dispatch is required/fail-closed.
    - **A drifted candidate base is refused** when the scope contains a provider that bakes its artifact
-     *from* the base (e2b, daytona, novita). Those providers' candidates are verified but their version
+     *from* the base (e2b, daytona, novita, runloop). Those providers' candidates are verified but their version
      artifacts are rebuilt, so the two are the same bytes only while `:vN-candidate` still is `:vN` —
      bump `TOOLCHAIN_VERSION` and cut a full release. Providers that don't bake from the base (vercel,
      modal, namespace, microsandbox) are unaffected: their version artifact is a retag of the exact
-     candidate that was just booted. Runloop is also unaffected by candidate drift, but has no release
-     artifact and therefore cannot be scoped into this lane.
+     candidate that was just booted.
 
-   The Vercel-on-v7 flow, as an example — two dispatches, neither of which touches another provider,
+   The Runloop-on-v7 flow, as an example — two dispatches, neither of which touches another provider,
    and neither of which runs a build job:
 
-   1. **Actions → Toolchain image → Run workflow** with `providers=vercel`, `build=skip`, `promote`
-      unchecked. Mirrors the published GHCR `:v7` base into VCR as the Vercel candidate, boots it and
+   1. **Actions → Toolchain image → Run workflow** with `providers=runloop`, `build=skip`, `promote`
+      unchecked. Builds the candidate Blueprint from the published GHCR `:v7` digest, boots it, and
       runs the smoke spec. Nothing public moves.
-   2. Same dispatch with `promote` checked. Re-validates the VCR candidate and publishes it as the
-      Vercel `v7` image. The GHCR base `:v7` is never rewritten.
+   2. Same dispatch with `promote` checked. Re-validates the candidate Blueprint and builds the
+      version-named Blueprint from the pinned base. The GHCR base `:v7` is never rewritten.
 
    The release pulls exactly **one** GHCR package (`sandbox-benchmarks-toolchain`), anonymously, so the
    one-time Public bootstrap it needs has already been done. Adding a provider never adds a package —
@@ -217,7 +215,7 @@ Do this in the GitHub UI (Settings → Environments / Rules / Actions), then del
    | `MODAL_TOKEN_ID` | toolchain bake, bench matrix/smoke |
    | `MODAL_TOKEN_SECRET` | toolchain bake, bench matrix/smoke |
    | `NOVITA_API_KEY` | optional for toolchain; bench matrix/smoke |
-   | `RUNLOOP_API_KEY` | bench matrix/smoke only |
+   | `RUNLOOP_API_KEY` | protected toolchain Blueprint bake/promote, bench matrix/smoke |
    | `BL_API_KEY` | bench matrix/smoke only |
    | `BL_WORKSPACE` | bench matrix/smoke only |
    | `MSB_API_KEY` | Microsandbox Cloud toolchain validation and bench matrix/smoke |
@@ -314,7 +312,12 @@ commit them; never paste them into issues or pull requests. See [SECURITY.md](..
 
 `microsandbox-local` uses `MICROSANDBOX_LOCAL_BENCH=1` as an explicit capability opt-in rather than a credential. The runner must provide KVM on Linux or Hypervisor.framework on macOS. `microsandbox-cloud` needs `MSB_API_KEY`; `MSB_API_URL` is an optional endpoint override. The cloud adapter keeps the key in the SDK control-plane backend and never adds it to sandbox metadata, create-time environment variables, or guest commands.
 
-Runloop needs `RUNLOOP_API_KEY`. The adapter keeps it in the SDK control-plane client and launches a custom-sized stock Devbox; the harness installs its pinned fallback toolchain inside the guest before benchmarking.
+Runloop needs `RUNLOOP_API_KEY`. The release lane keeps it in the SDK control-plane client while
+building versioned Blueprints from digest-pinned public toolchain images; the runtime adapter boots the
+released Blueprint by name. The credential is never copied into Blueprint parameters, Devbox create
+options, or the guest. `RUNLOOP_BLUEPRINT` is an optional local runtime override; leave it unset to use
+the canonical version-scoped Blueprint. Runloop disk snapshots remain temporary lifecycle-benchmark
+measurements; they are not release artifacts and are never selected for ordinary benchmark startup.
 
 The `tooling/repo-checks` secret-hygiene gate enforces this: it fails CI if any tracked file is a
 credential file (`.env`, `*.pem`, `id_rsa`, …) or contains a high-signal secret token.

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
         "@computesdk/modal": "1.9.3",
         "@computesdk/namespace": "1.6.12",
         "@computesdk/provider": "2.1.3",
+        "@computesdk/runloop": "1.3.53",
         "@daytona/api-client": "0.192.0",
         "@daytona/sdk": "0.192.0",
         "computesdk": "4.1.3",

--- a/packages/providers/package.json
+++ b/packages/providers/package.json
@@ -18,6 +18,7 @@
     "@computesdk/modal": "catalog:computesdk",
     "@computesdk/namespace": "catalog:computesdk",
     "@computesdk/provider": "catalog:computesdk",
+    "@computesdk/runloop": "catalog:computesdk",
     "@sandbox-benchmarks/schema": "workspace:*",
     "arktype": "catalog:",
     "computesdk": "catalog:computesdk",

--- a/packages/providers/src/index.test.ts
+++ b/packages/providers/src/index.test.ts
@@ -68,6 +68,26 @@ describe("@sandbox-benchmarks/providers", () => {
 		expect(adapter?.createCompute().name).toBe("vercel");
 	});
 
+	it("pins Runloop's custom Devbox to the shared target spec", () => {
+		const adapter = providers.find((provider) => provider.name === "runloop");
+		expect(adapter).toBeDefined();
+		expect(adapter?.requiredEnvVars).toEqual(["RUNLOOP_API_KEY"]);
+		const compute = adapter?.createCompute();
+		expect(compute?.name).toBe("runloop");
+		expect(compute?.snapshot).toBeDefined();
+		expect(adapter?.createOptions).toEqual({
+			launch_parameters: {
+				resource_size_request: "CUSTOM_SIZE",
+				custom_cpu_cores: TARGET_SPEC.vcpus,
+				custom_gb_memory: TARGET_SPEC.memoryGb,
+				custom_disk_size: TARGET_SPEC.diskGb,
+				keep_alive_time_seconds: 3 * 60 * 60,
+			},
+		});
+		// The credential belongs only to the SDK control plane, never guest-visible create options.
+		expect(JSON.stringify(adapter?.createOptions)).not.toContain("RUNLOOP_API_KEY");
+	});
+
 	it("re-points the e2b wrapper at Novita without the e2b_ key-format guard", () => {
 		// Construction must accept an nvta_-prefixed key and still expose the universal manager surface
 		// the harness drives, with the mispointed snapshot/template managers removed (their every call

--- a/packages/providers/src/index.test.ts
+++ b/packages/providers/src/index.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from "bun:test";
 // The stock wrapper factory, imported so the novita test can prove the connection methods were
 // actually REPLACED (identity inequality against an unpatched instance's methods table).
 import { e2b } from "@computesdk/e2b";
-import { PROVIDERS, TARGET_SPEC } from "@sandbox-benchmarks/schema";
+import { PROVIDERS, TARGET_SPEC, TOOLCHAIN_IMAGE_NAME } from "@sandbox-benchmarks/schema";
 import {
 	config,
 	microsandboxCloudCompute,
@@ -76,6 +76,7 @@ describe("@sandbox-benchmarks/providers", () => {
 		expect(compute?.name).toBe("runloop");
 		expect(compute?.snapshot).toBeDefined();
 		expect(adapter?.createOptions).toEqual({
+			blueprint_name: config.runloopBlueprintVersion,
 			launch_parameters: {
 				resource_size_request: "CUSTOM_SIZE",
 				custom_cpu_cores: TARGET_SPEC.vcpus,
@@ -84,6 +85,11 @@ describe("@sandbox-benchmarks/providers", () => {
 				keep_alive_time_seconds: 3 * 60 * 60,
 			},
 		});
+		expect(config.runloopBlueprint).toBe(config.runloopBlueprintVersion);
+		expect(config.runloopBlueprintVersion).toBe(
+			`${TOOLCHAIN_IMAGE_NAME}-${config.toolchainVersion}`,
+		);
+		expect(config.runloopBlueprintCandidate).toBe(`${config.runloopBlueprintVersion}-candidate`);
 		// The credential belongs only to the SDK control plane, never guest-visible create options.
 		expect(JSON.stringify(adapter?.createOptions)).not.toContain("RUNLOOP_API_KEY");
 	});

--- a/packages/providers/src/lib/adapters.ts
+++ b/packages/providers/src/lib/adapters.ts
@@ -7,6 +7,7 @@ import { daytona } from "@computesdk/daytona";
 import { e2b } from "@computesdk/e2b";
 import { modal } from "@computesdk/modal";
 import { namespace } from "@computesdk/namespace";
+import { runloop } from "@computesdk/runloop";
 import type { ProviderId } from "@sandbox-benchmarks/schema";
 import { TARGET_SPEC } from "@sandbox-benchmarks/schema";
 import type { CreateSandboxOptions } from "computesdk";
@@ -17,7 +18,7 @@ import { daytonaClientTarget } from "./daytona-target.ts";
 import { e2bCommandsAsRoot } from "./e2b-root.ts";
 import { microsandboxCloudCompute, microsandboxLocalCompute } from "./microsandbox.ts";
 import { novitaCompute } from "./novita.ts";
-import type { ProviderAdapter } from "./types.ts";
+import type { DirectProvider, ProviderAdapter } from "./types.ts";
 import { vercelCompute } from "./vercel.ts";
 
 // This project's dedicated Modal app — the namespace all sandbox-benchmarks sandboxes boot under.
@@ -94,6 +95,46 @@ const MICROSANDBOX_MAX_DURATION_SECS = 3 * 60 * 60;
  * that loss is not retried: the cell records `sandbox-create-failed` and produces zero results.
  */
 const MICROSANDBOX_CREATE_TIMEOUT_MS = 20 * 60 * 1000;
+
+/** The longest suite has a 155-minute budget; leave setup/collection margin while ensuring a leaked
+ * Runloop Devbox expires. Runloop allows keep-alive durations up to 48 hours. */
+const RUNLOOP_KEEP_ALIVE_SECS = 3 * 60 * 60;
+
+/** Normalize @computesdk/runloop's native snapshot records to ComputeSDK's public DirectProvider
+ * contract. The published wrapper exposes `{create_time_ms}` while `computesdk` 4.1 expects
+ * `{provider, createdAt}`; the lifecycle harness only needs `id`, but keeping the full contract here
+ * avoids an unsafe cast and preserves Runloop's snapshot benchmark. */
+function runloopCompute(): DirectProvider {
+	const compute = runloop({});
+	const snapshots = compute.snapshot;
+	return {
+		name: compute.name,
+		sandbox: compute.sandbox,
+		...(snapshots
+			? {
+					snapshot: {
+						create: async (sandboxId, options) => {
+							const snapshot = await snapshots.create(sandboxId, options);
+							return {
+								id: snapshot.id,
+								provider: "runloop",
+								createdAt: new Date(snapshot.create_time_ms),
+								metadata: snapshot.metadata,
+							};
+						},
+						list: async () =>
+							(await snapshots.list()).map((snapshot) => ({
+								id: snapshot.id,
+								provider: "runloop",
+								createdAt: new Date(snapshot.create_time_ms),
+								metadata: snapshot.metadata,
+							})),
+						delete: (snapshotId) => snapshots.delete(snapshotId),
+					},
+				}
+			: {}),
+	};
+}
 
 function microsandboxCloudCredentials(): { kind: "cloud"; url?: string; apiKey: string } {
 	const { apiUrl, apiKey } = config.microsandboxCloud;
@@ -195,6 +236,22 @@ export const adapters: Record<ProviderId, ProviderAdapter> = {
 		// template name); cpu/memory are pinned at template create, not per-sandbox.
 		createCompute: () => novitaCompute(config.novita.apiKey),
 		createOptions: { snapshotId: config.novitaTemplate },
+	},
+	runloop: {
+		// Runloop's custom Devbox size can express the full target, including the disk gate. It boots the
+		// stock image, so the harness's pinned fallback setup installs the same runtime and PTS versions
+		// before collecting results. The API key stays in the factory's RUNLOOP_API_KEY fallback and is
+		// never included in provider options that can reach the guest.
+		createCompute: runloopCompute,
+		createOptions: {
+			launch_parameters: {
+				resource_size_request: "CUSTOM_SIZE",
+				custom_cpu_cores: TARGET_SPEC.vcpus,
+				custom_gb_memory: TARGET_SPEC.memoryGb,
+				custom_disk_size: TARGET_SPEC.diskGb,
+				keep_alive_time_seconds: RUNLOOP_KEEP_ALIVE_SECS,
+			},
+		},
 	},
 	namespace: {
 		// The token rides the factory's own NSC_TOKEN_FILE env fallback (getAndValidateCredentials) —

--- a/packages/providers/src/lib/adapters.ts
+++ b/packages/providers/src/lib/adapters.ts
@@ -238,12 +238,13 @@ export const adapters: Record<ProviderId, ProviderAdapter> = {
 		createOptions: { snapshotId: config.novitaTemplate },
 	},
 	runloop: {
-		// Runloop's custom Devbox size can express the full target, including the disk gate. It boots the
-		// stock image, so the harness's pinned fallback setup installs the same runtime and PTS versions
-		// before collecting results. The API key stays in the factory's RUNLOOP_API_KEY fallback and is
-		// never included in provider options that can reach the guest.
+		// Boot the immutable version-scoped Blueprint by name. Runloop resolves that name to its latest
+		// successful build; the release lane owns creation from the shared toolchain image. Per-run launch
+		// parameters retain the benchmark's target sizing and keep-alive override. The API key stays in
+		// the factory's RUNLOOP_API_KEY fallback and never enters guest-visible create options.
 		createCompute: runloopCompute,
 		createOptions: {
+			blueprint_name: config.runloopBlueprint,
 			launch_parameters: {
 				resource_size_request: "CUSTOM_SIZE",
 				custom_cpu_cores: TARGET_SPEC.vcpus,

--- a/packages/providers/src/lib/config.ts
+++ b/packages/providers/src/lib/config.ts
@@ -29,6 +29,7 @@ const envSchema = type({
 	"DAYTONA_CONTAINER_SNAPSHOT?": "string >= 1",
 	"NOVITA_API_KEY?": "string >= 1",
 	"NOVITA_TEMPLATE?": "string >= 1",
+	"RUNLOOP_BLUEPRINT?": "string >= 1",
 	"MSB_API_URL?": "string >= 1",
 	"MSB_API_KEY?": "string >= 1",
 	"VERCEL_CANDIDATE_IMAGE?": "string >= 1",
@@ -49,6 +50,7 @@ const ENV_KEYS = [
 	"DAYTONA_CONTAINER_SNAPSHOT",
 	"NOVITA_API_KEY",
 	"NOVITA_TEMPLATE",
+	"RUNLOOP_BLUEPRINT",
 	"MSB_API_URL",
 	"MSB_API_KEY",
 	"VERCEL_CANDIDATE_IMAGE",
@@ -125,6 +127,11 @@ const daytonaContainerSnapshotCandidate = `${daytonaContainerSnapshotDefault}${C
 // recomputed, so a change to the e2b naming formula can't silently break the shared-name invariant.
 const novitaTemplateVersion = e2bTemplateVersion;
 const novitaTemplateCandidate = e2bTemplateCandidate;
+// Runloop Blueprints live in their own provider namespace, so they can share the canonical
+// version-scoped toolchain name while remaining independent from e2b/Novita templates. Reusing the
+// same candidate suffix means every provider artifact advances together when TOOLCHAIN_VERSION bumps.
+const runloopBlueprintVersion = e2bTemplateVersion;
+const runloopBlueprintCandidate = e2bTemplateCandidate;
 // VCR refs are rooted at a human-readable Vercel namespace resolved from the environment, defaulting
 // to this repository's own team/project (schema-owned, so the build pins and the runtime agree). The
 // workflow overrides the candidate tag with the immutable fully-qualified digest after mirroring the
@@ -194,6 +201,13 @@ export const config = {
 	novita: {
 		apiKey: env.NOVITA_API_KEY,
 	} satisfies NovitaConfig,
+	/** The Runloop Blueprint runtime boots by name. `RUNLOOP_BLUEPRINT` is a local/CI validation
+	 * override; ordinary benchmark runs use the immutable version-scoped public Blueprint. */
+	runloopBlueprint: env.RUNLOOP_BLUEPRINT ?? runloopBlueprintVersion,
+	/** Public (version-scoped) Runloop Blueprint name; the promote target. */
+	runloopBlueprintVersion,
+	/** Mutable candidate Runloop Blueprint name the bake creates while iterating. */
+	runloopBlueprintCandidate,
 	/** Microsandbox Cloud connection. The provider gate requires the key before construction, while
 	 * the URL stays optional so the SDK can use its production default. */
 	microsandboxCloud: {

--- a/packages/schema/src/providers.test.ts
+++ b/packages/schema/src/providers.test.ts
@@ -32,6 +32,7 @@ describe("@sandbox-benchmarks/schema providers", () => {
 			"modal-vm",
 			"namespace",
 			"novita",
+			"runloop",
 			"vercel",
 		]);
 	});
@@ -118,6 +119,7 @@ describe("@sandbox-benchmarks/schema providers", () => {
 			e2b: 0.0504 * TARGET_SPEC.vcpus + 0.0162 * TARGET_SPEC.memoryGb,
 			"daytona-vm": 0.0504 * TARGET_SPEC.vcpus + 0.0162 * Math.max(0, TARGET_SPEC.memoryGb - 5),
 			novita: 0.03528 * TARGET_SPEC.vcpus + 0.01152 * TARGET_SPEC.memoryGb,
+			runloop: 0.108 * TARGET_SPEC.vcpus + 0.0252 * TARGET_SPEC.memoryGb,
 		};
 		for (const [id, cost] of Object.entries(expected)) {
 			const meta = getProvider(id);
@@ -136,6 +138,7 @@ describe("@sandbox-benchmarks/schema providers", () => {
 		expect(diskRate("modal-gvisor")).toBe(0); // volumes free under the 1 TiB/mo tier
 		expect(diskRate("e2b")).toBeUndefined(); // no published overage rate
 		expect(diskRate("novita")).toBe(0); // 20 GB target spec inside the 60 GB free tier
+		expect(diskRate("runloop")).toBeCloseTo(0.00034236);
 	});
 
 	it("resolves retired provider ids through the legacy aliases", () => {

--- a/packages/schema/src/providers.ts
+++ b/packages/schema/src/providers.ts
@@ -493,7 +493,7 @@ const REGISTRY: Record<ProviderId, Omit<ProviderMeta, "id">> = {
 		isolation: {
 			technology: "microVM",
 			notes:
-				"Runloop Devboxes are isolated, ephemeral virtual machines. This adapter launches the stock Devbox image at the repository's custom target size; the harness installs its pinned fallback toolchain before benchmarking.",
+				"Runloop Devboxes are isolated, ephemeral virtual machines. This adapter boots a version-scoped Blueprint built from the shared toolchain image and retains per-run custom sizing.",
 		},
 		pricing: {
 			model: "per_vcpu_hour",
@@ -509,7 +509,7 @@ const REGISTRY: Record<ProviderId, Omit<ProviderMeta, "id">> = {
 		maturity: {
 			status: "beta",
 			notes:
-				"Official ComputeSDK adapter with custom CPU, memory, and disk sizing; opt-in until a committed benchmark run validates the integration.",
+				"Official ComputeSDK adapter with a released toolchain Blueprint plus custom CPU, memory, and disk sizing; opt-in until a committed benchmark run validates the integration.",
 		},
 		// CUSTOM_SIZE exposes independent CPU, memory, and disk fields and can express 4 / 8 / 40 exactly.
 		specPinning: "settable",

--- a/packages/schema/src/providers.ts
+++ b/packages/schema/src/providers.ts
@@ -21,6 +21,7 @@ export type ProviderId =
 	| "microsandbox-local"
 	| "microsandbox-cloud"
 	| "novita"
+	| "runloop"
 	| "namespace"
 	| "vercel";
 
@@ -479,6 +480,43 @@ const REGISTRY: Record<ProviderId, Omit<ProviderMeta, "id">> = {
 			// options applies the E2B SDK's default 60s command timeout, and onStdout/onStderr are never
 			// passed through. The compat API exposes the same filesystem + `background`, so detached+poll
 			// is the long-step path.
+			streaming: false,
+			syncCapMs: 60_000,
+			detachedPoll: true,
+		},
+	},
+	runloop: {
+		displayName: "Runloop",
+		website: "https://runloop.ai",
+		sdkPackage: "@computesdk/runloop",
+		requiredEnvVars: ["RUNLOOP_API_KEY"],
+		isolation: {
+			technology: "microVM",
+			notes:
+				"Runloop Devboxes are isolated, ephemeral virtual machines. This adapter launches the stock Devbox image at the repository's custom target size; the harness installs its pinned fallback toolchain before benchmarking.",
+		},
+		pricing: {
+			model: "per_vcpu_hour",
+			// $0.00003/CPU-s × 3600 = $0.108/CPU-hr; $0.000007/GB-s × 3600 = $0.0252/GB-hr.
+			usdPerVcpuHour: 0.108,
+			usdPerGibHour: 0.0252,
+			// $0.0000000951/GB-s × 3600 = $0.00034236/GB-hr.
+			usdPerGibDiskHour: 0.00034236,
+			notes:
+				"Published per-second rates (exact): CPU $0.00003/s, memory $0.000007/GB-s, and active Devbox storage $0.0000000951/GB-s.",
+			sourceUrl: "https://runloop.ai/pricing",
+		},
+		maturity: {
+			status: "beta",
+			notes:
+				"Official ComputeSDK adapter with custom CPU, memory, and disk sizing; opt-in until a committed benchmark run validates the integration.",
+		},
+		// CUSTOM_SIZE exposes independent CPU, memory, and disk fields and can express 4 / 8 / 40 exactly.
+		specPinning: "settable",
+		transport: {
+			// The adapter waits for completed command output and does not forward streaming callbacks.
+			// Keep long steps off one control-plane request by using its background exec plus filesystem
+			// polling path; short setup commands remain synchronous.
 			streaming: false,
 			syncCapMs: 60_000,
 			detachedPoll: true,

--- a/tooling/repo-checks/src/workflow-hardening.test.ts
+++ b/tooling/repo-checks/src/workflow-hardening.test.ts
@@ -40,6 +40,9 @@ const oneJob = (id: string, job: object, root: object = {}) => ({ ...root, jobs:
 const SCOPED_RUNCLOUD_KEY =
 	// biome-ignore lint/suspicious/noTemplateCurlyInString: literal GitHub Actions expression under test
 	"${{ contains(fromJSON(needs.plan.outputs.matrix).include.*.provider, 'runcloud') && secrets.RUN_CLOUD_API_KEY || '' }}";
+const SCOPED_RUNLOOP_KEY =
+	// biome-ignore lint/suspicious/noTemplateCurlyInString: literal GitHub Actions expression under test
+	"${{ contains(fromJSON(needs.plan.outputs.matrix).include.*.provider, 'runloop') && secrets.RUNLOOP_API_KEY || '' }}";
 const SELECTED_BASE_IMAGE =
 	// biome-ignore lint/suspicious/noTemplateCurlyInString: literal GitHub Actions expression under test
 	"${{ needs.build.outputs.base-digest-ref || needs.plan.outputs.image-source }}";
@@ -248,6 +251,14 @@ describe("run.cloud credential scoping", () => {
 		// rejects every unscoped spelling (including `secrets.RUN_CLOUD_API_KEY || ''`) rather than one
 		// fragile literal while ignoring a second assignment in another step or at job scope.
 		expect(valuesForKey(publish, "RUN_CLOUD_API_KEY")).toEqual([SCOPED_RUNCLOUD_KEY]);
+	});
+});
+
+describe("Runloop credential scoping", () => {
+	test("the promote step exposes the key only when the resolved plan contains runloop", () => {
+		const doc = readWorkflow(`${WORKFLOWS_DIR}/${TOOLCHAIN_WORKFLOW}`);
+		const publish = workflowJob(doc, "publish", TOOLCHAIN_WORKFLOW);
+		expect(valuesForKey(publish, "RUNLOOP_API_KEY")).toEqual([SCOPED_RUNLOOP_KEY]);
 	});
 });
 


### PR DESCRIPTION
## Summary

- register Runloop as an opt-in benchmark provider with published pricing, microVM metadata, snapshot normalization, and shared 4 vCPU / 8 GiB / 40 GB sizing
- boot the canonical version-scoped Runloop Blueprint by `blueprint_name`, with an optional `RUNLOOP_BLUEPRINT` runtime override and no credential material in guest-visible create options
- bake candidate and version Blueprints from an immutable digest-pinned shared toolchain image through the pinned `@runloop/api-client` SDK
- make Runloop a `bakes` provider in candidate validation and release diagnostics; scoped Runloop backfills are required, while unscoped releases remain best-effort
- keep Runloop outside the default benchmark matrix until a committed live run validates it; lifecycle snapshots remain temporary benchmark measurements, not release artifacts

## Release behavior

- `providers=runloop, build=skip, promote=false` builds and smoke-validates the mutable candidate Blueprint from the already-published toolchain base
- the corresponding promote dispatch revalidates that candidate, then creates the version-named Blueprint from the same pinned base
- a failed/skipped provider validation cannot publish that provider's version artifact; an optional Runloop failure remains visible in diagnostics without turning a successfully committed unscoped image release red
- `RUNLOOP_API_KEY` is protected by the `privileged` environment, scoped to Runloop bake/promote execution, and never copied into Blueprint parameters, Devbox options, or the guest
- only Blaxel remains unscopable by the toolchain release lane

## Verification

- `bun install --frozen-lockfile --ignore-scripts`
- `bun run check:catalog-drift`
- `bun run lint`
- `bun run typecheck`
- `bun --filter @sandbox-benchmarks/providers test` — 81 passed
- `bun --filter @sandbox-benchmarks/schema test` — passed
- `bun --filter @sandbox-benchmarks/cli test` — 265 passed
- focused workflow-hardening and Runloop release tests — passed
- `review-and-fix` full mode on `fa2c5881e633d268632c62c44998365795839f68` — validated `approve`, no remaining findings

The aggregate `bun run test` passes the feature workspaces and reaches nine existing `@repo/repo-checks` failures on this macOS host because `/bin/bash` is 3.2 and `scripts/assert-paths-allowlisted.sh` requires associative arrays (`declare -A`). `mise` is not installed on this host, so `spell`, `lint:shell`, and `lint:docker` cannot run locally. No live Runloop resources were created during verification.

## Review fixes

- prevent a failed optional candidate validation from publishing its version Blueprint
- separate promotion transaction success from optional-provider diagnostics so a committed unscoped release remains best-effort
- expose `RUNLOOP_API_KEY` to the serial promote process only when the resolved plan includes Runloop

## Operational note

Add `RUNLOOP_API_KEY` to the protected `privileged` GitHub Environment before dispatching a Runloop toolchain release or benchmark. Runloop remains opt-in until a committed live benchmark validates the integration.
