### PR TITLE
fix: handle non-root PTS sandboxes

### DIFF
--- a/apps/cli/src/bin/bench-suite.fleet.test.ts
+++ b/apps/cli/src/bin/bench-suite.fleet.test.ts
@@ -15,7 +15,7 @@ const runFor = (overrides: Partial<Run["providers"][number]> = {}): Run =>
 			{
 				providerId: PROVIDER,
 				validationStatus: "validated",
-				observedSpecs: { cpuModel: "AMD EPYC" },
+				observedSpecs: { cpuModel: "AMD EPYC", user: "root" },
 				specMatched: true,
 				metrics: [{ metricId: "git_seconds" }, { metricId: "pybench_milliseconds" }],
 				suitesCovered: ["system"],
@@ -44,7 +44,7 @@ describe("replicateSummaryRows at wide fan-outs", () => {
 			const rows = replicateSummaryRows(PROVIDER, fleet(count));
 			expect(rows).toHaveLength(count + 1);
 			// Every row carries the full column set, so no cell silently shifts under a wide fan-out.
-			expect(new Set(rows.map((row) => row.length))).toEqual(new Set([11]));
+			expect(new Set(rows.map((row) => row.length))).toEqual(new Set([12]));
 		}
 	});
 
@@ -53,7 +53,7 @@ describe("replicateSummaryRows at wide fan-outs", () => {
 		expect(rows[0]?.[0]).toBe("<code>r0</code>");
 		expect(rows[48]?.[0]).toBe("<code>r48</code>");
 		// Distinct shard paths are what prove R replicates did not collide on one file.
-		expect(new Set(rows.map((row) => row[10])).size).toBe(49);
+		expect(new Set(rows.map((row) => row[11])).size).toBe(49);
 	});
 
 	// The per-sandbox spec columns are the point of the fan-out: a replicate that landed on different
@@ -69,8 +69,21 @@ describe("replicateSummaryRows at wide fan-outs", () => {
 				durationMs: 1_000,
 			},
 		]).slice(1);
-		expect(rows[0]?.slice(7, 10)).toEqual(["<code>AMD EPYC</code>", "—", "true"]);
-		expect(rows[1]?.slice(7, 10)).toEqual(["<code>Intel Xeon</code>", "—", "false"]);
+		expect(rows[0]?.slice(8, 11)).toEqual(["<code>AMD EPYC</code>", "—", "true"]);
+		expect(rows[1]?.slice(8, 11)).toEqual(["<code>Intel Xeon</code>", "—", "false"]);
+	});
+
+	it("flags an unexpected runtime user in the per-sandbox summary row", () => {
+		const rows = replicateSummaryRows(PROVIDER, [
+			{
+				index: 0,
+				outFile: "a.json",
+				run: runFor({ observedSpecs: { cpuModel: "AMD EPYC", user: "user" } }),
+				failed: false,
+				durationMs: 1_000,
+			},
+		]).slice(1);
+		expect(rows[0]?.[7]).toBe("⚠ user (expected root)");
 	});
 
 	it("shows an em-dash rather than an empty cell when a spec probe returned nothing", () => {
@@ -83,7 +96,7 @@ describe("replicateSummaryRows at wide fan-outs", () => {
 				durationMs: 1_000,
 			},
 		]).slice(1);
-		expect(rows[0]?.slice(7, 10)).toEqual(["<code>—</code>", "—", "—"]);
+		expect(rows[0]?.slice(7, 11)).toEqual(["—", "<code>—</code>", "—", "—"]);
 	});
 
 	// The straggler is the whole reason this column exists: R replicates share one job duration now,
@@ -118,6 +131,7 @@ describe("replicateSummaryRows at wide fan-outs", () => {
 			"<code>r0</code>",
 			"failure",
 			"1s",
+			"—",
 			"—",
 			"—",
 			"—",

--- a/apps/cli/src/bin/bench-suite.test.ts
+++ b/apps/cli/src/bin/bench-suite.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "bun:test";
 import { PROVIDERS, SUITE_NAMES } from "@sandbox-benchmarks/schema";
-import { formatDuration, HELP, parseReplicateFlag } from "./bench-suite.ts";
+import { formatDuration, HELP, parseReplicateFlag, runtimeUserSummary } from "./bench-suite.ts";
 
 /** The ids `runSuite` actually matches on: it compares against the schema-joined adapter names
  *  EXACTLY, so `LEGACY_PROVIDER_ALIASES` ("daytona", "modal") does not rescue a copied example.
@@ -93,5 +93,13 @@ describe("formatDuration", () => {
 	// 59.6s rounds to 60 seconds, which must not render as "0m60s".
 	it("carries a rounded-up 60th second into the minute", () => {
 		expect(formatDuration(59_600)).toBe("1m00s");
+	});
+});
+
+describe("runtimeUserSummary", () => {
+	it("keeps root quiet and marks any other observed identity as unexpected", () => {
+		expect(runtimeUserSummary("root")).toBe("root");
+		expect(runtimeUserSummary("user")).toBe("⚠ user (expected root)");
+		expect(runtimeUserSummary(undefined)).toBe("—");
 	});
 });

--- a/apps/cli/src/bin/bench-suite.test.ts
+++ b/apps/cli/src/bin/bench-suite.test.ts
@@ -97,9 +97,22 @@ describe("formatDuration", () => {
 });
 
 describe("runtimeUserSummary", () => {
-	it("keeps root quiet and marks any other observed identity as unexpected", () => {
-		expect(runtimeUserSummary("root")).toBe("root");
-		expect(runtimeUserSummary("user")).toBe("⚠ user (expected root)");
-		expect(runtimeUserSummary(undefined)).toBe("—");
+	it("keeps a root-by-contract provider quiet and flags any other identity", () => {
+		expect(runtimeUserSummary("e2b", "root")).toBe("root");
+		expect(runtimeUserSummary("e2b", "user")).toBe("⚠ user (expected root)");
+		expect(runtimeUserSummary("e2b", undefined)).toBe("—");
+	});
+
+	// Runloop's lane runs unprivileged by design. Flagging that would put a warning on all twelve
+	// replicates of a healthy run — the noise that teaches readers to skip the column entirely.
+	it("stays quiet for a provider that declares an unprivileged runtime identity", () => {
+		expect(runtimeUserSummary("runloop", "user")).toBe("user");
+		expect(runtimeUserSummary("runloop", "sandbox")).toBe("sandbox");
+	});
+
+	// The other direction is drift too: a provider that silently gained root changed the security
+	// posture the isolation notes describe, and setup would start writing root-owned state.
+	it("flags root where an unprivileged identity was declared", () => {
+		expect(runtimeUserSummary("runloop", "root")).toBe("⚠ root (expected unprivileged)");
 	});
 });

--- a/apps/cli/src/bin/bench-suite.ts
+++ b/apps/cli/src/bin/bench-suite.ts
@@ -24,7 +24,11 @@ import {
 import { drainRuncloudBackgroundWork } from "@sandbox-benchmarks/providers";
 import { writeNormalizedRun } from "@sandbox-benchmarks/results";
 import type { Run, SuiteName } from "@sandbox-benchmarks/schema";
-import { SUITES } from "@sandbox-benchmarks/schema";
+import {
+	expectedRuntimeIdentity,
+	isUnexpectedRuntimeUser,
+	SUITES,
+} from "@sandbox-benchmarks/schema";
 import type { CellKind, SummaryRow } from "../lib/actions-log.ts";
 import {
 	escapeHtml,
@@ -62,16 +66,16 @@ function plural(n: number, singular: string, pluralForm: string = `${singular}s`
 }
 
 /**
- * Benchmark setup, baked PTS state, and provider adapters all target root. Keep this explicit in the
- * Actions report: a provider silently injecting another identity changes HOME, permissions, and tool
- * state even when every hardware-spec probe still matches.
+ * Job-summary rendering for the observed effective user, with a visible warning on contract drift.
+ *
+ * The expectation is per-provider ({@link isUnexpectedRuntimeUser}), NOT a hardcoded "root": Runloop
+ * runs its lane as an unprivileged user by design, so a fixed expectation would mark all twelve of its
+ * replicates anomalous on a healthy run and bury the identity change this column exists to surface.
  */
-export const EXPECTED_SANDBOX_USER = "root";
-
-/** Job-summary rendering for the observed effective user, with a visible warning on contract drift. */
-export function runtimeUserSummary(user: string | undefined): string {
+export function runtimeUserSummary(providerId: string, user: string | undefined): string {
 	if (!user) return "—";
-	return user === EXPECTED_SANDBOX_USER ? user : `⚠ ${user} (expected ${EXPECTED_SANDBOX_USER})`;
+	if (!isUnexpectedRuntimeUser(providerId, user)) return user;
+	return `⚠ ${user} (expected ${expectedRuntimeIdentity(providerId)})`;
 }
 
 function miseTaskSummary(plan: SuiteTaskPlan): string {
@@ -265,7 +269,7 @@ async function reportCell(
 			["Metrics", provider ? String(provider.metrics.length) : "", "plain"],
 			["Suites covered", provider ? String(provider.suitesCovered.length) : "", "plain"],
 			["Gaps", provider ? String(provider.gaps.length) : "", "plain"],
-			["Runtime user", runtimeUserSummary(provider?.observedSpecs.user), "plain"],
+			["Runtime user", runtimeUserSummary(opts.provider, provider?.observedSpecs.user), "plain"],
 			["Observed CPU", provider?.observedSpecs.cpuModel ?? "", "code"],
 			[
 				"Spec matched",
@@ -356,7 +360,7 @@ export function replicateSummaryRows(
 			escapeHtml(run ? String(run.metrics.length) : "—"),
 			escapeHtml(run ? String(run.suitesCovered.length) : "—"),
 			escapeHtml(run ? String(run.gaps.length) : "—"),
-			escapeHtml(runtimeUserSummary(run?.observedSpecs.user)),
+			escapeHtml(runtimeUserSummary(provider, run?.observedSpecs.user)),
 			renderCell(run?.observedSpecs.cpuModel || "—", "code"),
 			escapeHtml(run?.observedSpecs.region || "—"),
 			escapeHtml(run?.specMatched === undefined ? "—" : String(run.specMatched)),
@@ -385,11 +389,13 @@ async function reportFleet(
 			o.run?.providers.find((p) => p.providerId === opts.provider)?.validationStatus ===
 			"validated",
 	).length;
-	const unexpectedRuntimeUsers = opts.outcomes.filter((outcome) => {
-		const user = outcome.run?.providers.find((provider) => provider.providerId === opts.provider)
-			?.observedSpecs.user;
-		return Boolean(user && user !== EXPECTED_SANDBOX_USER);
-	}).length;
+	const unexpectedRuntimeUsers = opts.outcomes.filter((outcome) =>
+		isUnexpectedRuntimeUser(
+			opts.provider,
+			outcome.run?.providers.find((provider) => provider.providerId === opts.provider)
+				?.observedSpecs.user,
+		),
+	).length;
 	await writeCellSummary({
 		// Identity rides through as-is; `outcomes` is spent on the counts and the table below.
 		...opts,
@@ -401,7 +407,7 @@ async function reportFleet(
 			[
 				"Unexpected runtime users",
 				unexpectedRuntimeUsers > 0
-					? `${unexpectedRuntimeUsers}/${opts.outcomes.length} sandbox(es) (expected ${EXPECTED_SANDBOX_USER})`
+					? `${unexpectedRuntimeUsers}/${opts.outcomes.length} sandbox(es) (expected ${expectedRuntimeIdentity(opts.provider)})`
 					: "",
 				"plain",
 			],

--- a/apps/cli/src/bin/bench-suite.ts
+++ b/apps/cli/src/bin/bench-suite.ts
@@ -61,6 +61,19 @@ function plural(n: number, singular: string, pluralForm: string = `${singular}s`
 	return `${n} ${n === 1 ? singular : pluralForm}`;
 }
 
+/**
+ * Benchmark setup, baked PTS state, and provider adapters all target root. Keep this explicit in the
+ * Actions report: a provider silently injecting another identity changes HOME, permissions, and tool
+ * state even when every hardware-spec probe still matches.
+ */
+export const EXPECTED_SANDBOX_USER = "root";
+
+/** Job-summary rendering for the observed effective user, with a visible warning on contract drift. */
+export function runtimeUserSummary(user: string | undefined): string {
+	if (!user) return "—";
+	return user === EXPECTED_SANDBOX_USER ? user : `⚠ ${user} (expected ${EXPECTED_SANDBOX_USER})`;
+}
+
 function miseTaskSummary(plan: SuiteTaskPlan): string {
 	const commands = plan.tasks.filter((t) => t.role === "command").length;
 	const leaves = plan.tasks.filter((t) => t.role === "leaf").length;
@@ -252,6 +265,7 @@ async function reportCell(
 			["Metrics", provider ? String(provider.metrics.length) : "", "plain"],
 			["Suites covered", provider ? String(provider.suitesCovered.length) : "", "plain"],
 			["Gaps", provider ? String(provider.gaps.length) : "", "plain"],
+			["Runtime user", runtimeUserSummary(provider?.observedSpecs.user), "plain"],
 			["Observed CPU", provider?.observedSpecs.cpuModel ?? "", "code"],
 			[
 				"Spec matched",
@@ -320,6 +334,7 @@ export function replicateSummaryRows(
 		{ data: "Metrics", header: true },
 		{ data: "Suites", header: true },
 		{ data: "Gaps", header: true },
+		{ data: "Runtime user", header: true },
 		// Per-SANDBOX, not per-cell, and that is the point: R replicates exist to measure a provider's
 		// fleet variation, and a replicate that landed on different host hardware (or off the target
 		// spec) is the single most likely explanation for an outlier. reportCell surfaces these for a
@@ -341,6 +356,7 @@ export function replicateSummaryRows(
 			escapeHtml(run ? String(run.metrics.length) : "—"),
 			escapeHtml(run ? String(run.suitesCovered.length) : "—"),
 			escapeHtml(run ? String(run.gaps.length) : "—"),
+			escapeHtml(runtimeUserSummary(run?.observedSpecs.user)),
 			renderCell(run?.observedSpecs.cpuModel || "—", "code"),
 			escapeHtml(run?.observedSpecs.region || "—"),
 			escapeHtml(run?.specMatched === undefined ? "—" : String(run.specMatched)),
@@ -369,6 +385,11 @@ async function reportFleet(
 			o.run?.providers.find((p) => p.providerId === opts.provider)?.validationStatus ===
 			"validated",
 	).length;
+	const unexpectedRuntimeUsers = opts.outcomes.filter((outcome) => {
+		const user = outcome.run?.providers.find((provider) => provider.providerId === opts.provider)
+			?.observedSpecs.user;
+		return Boolean(user && user !== EXPECTED_SANDBOX_USER);
+	}).length;
 	await writeCellSummary({
 		// Identity rides through as-is; `outcomes` is spent on the counts and the table below.
 		...opts,
@@ -377,6 +398,13 @@ async function reportFleet(
 			["Replicates", String(opts.outcomes.length), "plain"],
 			["Validated replicates", `${validated}/${opts.outcomes.length}`, "plain"],
 			["Failed replicates", String(failures.length), "plain"],
+			[
+				"Unexpected runtime users",
+				unexpectedRuntimeUsers > 0
+					? `${unexpectedRuntimeUsers}/${opts.outcomes.length} sandbox(es) (expected ${EXPECTED_SANDBOX_USER})`
+					: "",
+				"plain",
+			],
 			// The cell's wall clock IS its slowest replicate, so that number — not the mean — is what
 			// to compare against the job budget, and the spread next to it says whether one sandbox
 			// dragged the cell or the whole fleet was slow.

--- a/lib/bench.sh
+++ b/lib/bench.sh
@@ -254,25 +254,45 @@ bench_cmd() {
 
 # --- Phoronix Test Suite (PTS) helpers ---
 
-# The toolchain bakes profiles as root under /var/lib. PTS 10.8.4 has separate supported overrides for
-# mutable user state and installed-profile discovery: keep the payload registry shared, but give an
-# injected unprivileged runtime user state under its own HOME. Root's core.pt2so is mode 0600, and PTS
-# expands its non-daemon ResultsDirectory through HOME regardless of a shared-state override; pointing
-# both users at /var/lib therefore warns on every invocation while the composite finder searches the
-# wrong result tree. Set this here as a fallback in case an image importer strips the Docker ENV; the
-# harness preamble makes the same choice before setup commands run.
+# The toolchain bakes profiles as root under /var/lib, but E2B-compatible providers (Runloop) inject
+# an unprivileged runtime user. Keep the installed profiles SHARED via the one path PTS 10.8.4 gives
+# its own env override, and leave that user's mutable state on PTS's own per-user default:
+#
+#   - Without PTS_TEST_INSTALL_ROOT_PATH an unprivileged run falls back to the config's
+#     ~/.phoronix-test-suite/installed-tests/ and reports ZERO installed tests, even though it can read
+#     the baked tree perfectly well. Set here as a fallback in case an image importer strips the Docker
+#     ENV, and because the published v7 image predates that ENV entirely.
+#   - PTS_USER_PATH_OVERRIDE is UNSET rather than repointed for a non-root user: PTS's default already
+#     IS $HOME/.phoronix-test-suite and PTS creates it itself, so there is no mkdir here to fail under
+#     `set -e` when HOME is unset or unwritable. Pointing that user at the baked root is what breaks —
+#     root's core.pt2so is mode 0600, and PTS expands its non-daemon ResultsDirectory through HOME
+#     regardless of the override, so the shared setting both warns on every invocation and leaves the
+#     composite finder below searching a tree PTS never writes.
+#
+# Root keeps the explicit override: redundant when PTS reaches its daemonized branch (writable /var/lib
+# AND /etc force PTS_USER_PATH to the baked root anyway), load-bearing when it does not.
+#
+# Mirrors PTS_STATE_SELECT_SH in packages/schema/src/toolchain.ts, which the harness preamble and the
+# generated smoke probe interpolate; this file cannot import TS, so the copy is gated as text by
+# tooling/repo-checks/src/pts-state-alignment.test.ts.
 if [ -d /var/lib/phoronix-test-suite ]; then
 	export PTS_TEST_INSTALL_ROOT_PATH=/var/lib/phoronix-test-suite/installed-tests/
 	if [ "$(id -u)" -eq 0 ]; then
 		export PTS_USER_PATH_OVERRIDE=/var/lib/phoronix-test-suite/
 	else
-		mkdir -p "${HOME}/.phoronix-test-suite"
-		export PTS_USER_PATH_OVERRIDE="${HOME}/.phoronix-test-suite/"
+		unset PTS_USER_PATH_OVERRIDE
 	fi
 fi
 
-# Locate PTS's effective data directory. Prefer its supported override, then probe legacy root/user
-# locations by core.pt2so, which pts_init guarantees exists. Cached for the shell.
+# Locate PTS's effective data directory — where it keeps MUTABLE state (core.pt2so, user-config.xml,
+# test-results, and any vendored/local test-profiles we stage). Prefer its supported override, then
+# probe legacy root/user locations by core.pt2so, which pts_init guarantees exists. Cached for the
+# shell.
+#
+# The probe requires core.pt2so to be READABLE, not merely present: the baked /var/lib copy is mode
+# 0600 root, so an unprivileged run that fell through to it would resolve every caller below onto a
+# tree it cannot read or write — pts_config_file would name a config PTS never reads, and the
+# composite finder would search for results in a directory PTS never writes.
 _pts_user_dir_cached=""
 pts_init() {
 	# system-info is cheap and writes core.pt2so on first run; swallow all output.
@@ -286,13 +306,23 @@ pts_user_dir() {
 	local cand dir="${PTS_USER_PATH_OVERRIDE:-${HOME}/.phoronix-test-suite}"
 	for cand in "${PTS_USER_PATH_OVERRIDE:-}" "${HOME}/.phoronix-test-suite" "/var/lib/phoronix-test-suite" "/root/.phoronix-test-suite"; do
 		[ -n "$cand" ] || continue
-		if [ -e "${cand}/core.pt2so" ]; then
+		if [ -r "${cand}/core.pt2so" ]; then
 			dir="$cand"
 			break
 		fi
 	done
-	_pts_user_dir_cached="$dir"
-	echo "$dir"
+	_pts_user_dir_cached="${dir%/}"
+	echo "$_pts_user_dir_cached"
+}
+
+# Where PTS keeps INSTALLED tests. Distinct from pts_user_dir since the non-root split: the baked
+# installed tree stays shared under /var/lib via PTS_TEST_INSTALL_ROOT_PATH while an unprivileged
+# user's mutable state lives under its own HOME. Anything that inspects or removes an INSTALL must
+# resolve it through here — deriving it from pts_user_dir silently targets the wrong tree for every
+# non-root provider, so the removal no-ops and PTS keeps reporting the stale install as present.
+pts_install_root() {
+	local root="${PTS_TEST_INSTALL_ROOT_PATH:-$(pts_user_dir)/installed-tests}"
+	echo "${root%/}"
 }
 
 # Resolve the config file PTS itself reads and writes, mirroring its own selection order
@@ -348,6 +378,7 @@ _pts_install_diagnostics() {
 	echo "--- PTS install diagnostics: ${test_name} ---"
 	echo "user=$(id -un 2>/dev/null) HOME=${HOME}"
 	echo "resolved pts_user_dir=${pts_dir}"
+	echo "resolved pts_install_root=$(pts_install_root)"
 	echo "resolved pts_config_file=$(pts_config_file)"
 	for d in "${data_dirs[@]}"; do
 		[ -e "$d/core.pt2so" ] && echo "  core.pt2so present in: $d"
@@ -357,8 +388,8 @@ _pts_install_diagnostics() {
 	echo "  install manifests on disk:"
 	find "${data_dirs[@]}" -maxdepth 5 \( -name pts-install.json -o -name pts-install.xml \) \
 		2>/dev/null | sed 's/^/    /' || true
-	echo "  installed-tests tree (${pts_dir}/installed-tests):"
-	find "${pts_dir}/installed-tests" -maxdepth 3 2>/dev/null | sed 's/^/    /' | head -40 || true
+	echo "  installed-tests tree ($(pts_install_root)):"
+	find "$(pts_install_root)" -maxdepth 3 2>/dev/null | sed 's/^/    /' | head -40 || true
 	local log
 	log=$(find "${data_dirs[@]}" -name install-failed.log -exec ls -t {} + 2>/dev/null | head -1)
 	if [ -n "$log" ] && [ -f "$log" ]; then
@@ -598,13 +629,26 @@ install_vendored_pts_profile() {
 	local pts_dir profile_dst installed_dst
 	pts_dir="$(pts_user_dir)"
 	profile_dst="${pts_dir}/test-profiles/pts/${name}"
-	installed_dst="${pts_dir}/installed-tests/pts/${name}"
+	# The INSTALL root, not pts_user_dir: for a non-root sandbox the baked installed tree stays under
+	# /var/lib while mutable state moved to HOME. Removing "${pts_dir}/installed-tests/..." there would
+	# delete nothing, _pts_is_installed would still report the BAKED upstream copy as present, and the
+	# leaf would benchmark the very runner this override exists to replace — silently, since a skipped
+	# reinstall is the normal fast path.
+	installed_dst="$(pts_install_root)/pts/${name}"
 	mkdir -p "$(dirname "$profile_dst")"
 	rm -rf "$profile_dst"
 	cp -r "$src" "$profile_dst"
 	# The image bakes the upstream profile. Removing only this pinned install makes the ordinary
 	# run_pts_benchmark path reinstall our staged source and retain all of its exit/registry checks.
 	rm -rf "$installed_dst"
+
+	# Assert the discard actually landed: a stale install here is the difference between benchmarking
+	# the vendored repair and benchmarking the broken upstream runner, and both look identical in the
+	# leaf's output. Cheap, and it fails loudly at stage time instead of publishing wrong numbers.
+	if [ -e "$installed_dst" ]; then
+		echo "ERROR: install_vendored_pts_profile: baked install still present at ${installed_dst}" >&2
+		return 1
+	fi
 
 	echo "Staged vendored PTS override: ${profile_dst} (removed ${installed_dst})"
 }
@@ -812,7 +856,14 @@ fio_direct_choice() {
 	# /var/lib/phoronix-test-suite while run_pts_benchmark's composite finder searches the stale
 	# cached dir and records a bogus "produced no composite.xml" skip for every scenario.
 	pts_init
-	dir="$(pts_user_dir)"
+	# Probe the INSTALL root, because that is where fio's own scratch file goes (its installed-test
+	# dir), and O_DIRECT is a property of the filesystem, not of the process. Since the non-root split
+	# these can be different filesystems on the same sandbox — on Blaxel /var/lib/phoronix-test-suite is
+	# a separate mounted volume while HOME is the RAM-backed root — so probing pts_user_dir would pin
+	# Direct=Yes against an overlay that supports it while every fio scenario EINVALs on the real
+	# target, or pin Direct=No and publish buffered numbers under the same metric id as the root
+	# providers' O_DIRECT ones.
+	dir="$(pts_install_root)"
 	mkdir -p "$dir"
 	probe="${dir}/.o-direct-probe"
 	# bs=4096, not 512: O_DIRECT requires logical-sector alignment, so a 512-byte write EINVALs on a

--- a/lib/bench.sh
+++ b/lib/bench.sh
@@ -254,14 +254,21 @@ bench_cmd() {
 
 # --- Phoronix Test Suite (PTS) helpers ---
 
-# The toolchain bakes profiles as root under /var/lib, but E2B-compatible providers inject an
-# unprivileged runtime user. PTS 10.8.4 has separate supported overrides for user state and installed
-# profile discovery; without the latter an unprivileged Runloop Devbox sees the profile payloads but
-# reports zero installed tests because the root bake's /etc config is not writable. Set both here as
-# a fallback in case an image importer strips the Docker ENV; the harness preamble does the same.
+# The toolchain bakes profiles as root under /var/lib. PTS 10.8.4 has separate supported overrides for
+# mutable user state and installed-profile discovery: keep the payload registry shared, but give an
+# injected unprivileged runtime user state under its own HOME. Root's core.pt2so is mode 0600, and PTS
+# expands its non-daemon ResultsDirectory through HOME regardless of a shared-state override; pointing
+# both users at /var/lib therefore warns on every invocation while the composite finder searches the
+# wrong result tree. Set this here as a fallback in case an image importer strips the Docker ENV; the
+# harness preamble makes the same choice before setup commands run.
 if [ -d /var/lib/phoronix-test-suite ]; then
-	export PTS_USER_PATH_OVERRIDE=/var/lib/phoronix-test-suite/
 	export PTS_TEST_INSTALL_ROOT_PATH=/var/lib/phoronix-test-suite/installed-tests/
+	if [ "$(id -u)" -eq 0 ]; then
+		export PTS_USER_PATH_OVERRIDE=/var/lib/phoronix-test-suite/
+	else
+		mkdir -p "${HOME}/.phoronix-test-suite"
+		export PTS_USER_PATH_OVERRIDE="${HOME}/.phoronix-test-suite/"
+	fi
 fi
 
 # Locate PTS's effective data directory. Prefer its supported override, then probe legacy root/user
@@ -290,12 +297,12 @@ pts_user_dir() {
 
 # Resolve the config file PTS itself reads and writes, mirroring its own selection order
 # (pts_config::get_config_file_location + pts_config_nye_XmlReader::__construct, v10.8.4). PTS sets
-# PTS_IS_DAEMONIZED_SERVER_PROCESS whenever /var/lib AND /etc are both writable — i.e. whenever it
-# runs as root, which is every sandbox provider here — and in that mode it uses
+# PTS_IS_DAEMONIZED_SERVER_PROCESS whenever /var/lib AND /etc are both writable — normally when the
+# sandbox runs as root — and in that mode it uses
 # /etc/phoronix-test-suite.xml UNCONDITIONALLY, without so much as probing the user dir. So under
 # root, user-config.xml is the file PTS never touches, and /etc is the live config. An unprivileged
-# run falls through to ${PTS_USER_PATH}/user-config.xml (the baked override here) — and even then a
-# writable /etc/phoronix-test-suite.xml, if one exists, still wins.
+# run falls through to ${PTS_USER_PATH}/user-config.xml — and even then a writable
+# /etc/phoronix-test-suite.xml, if one exists, still wins.
 pts_config_file() {
 	if { [ -w /var/lib ] && [ -w /etc ]; } || [ -w /etc/phoronix-test-suite.xml ]; then
 		echo /etc/phoronix-test-suite.xml

--- a/packages/harness/src/lib/execute.test.ts
+++ b/packages/harness/src/lib/execute.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "bun:test";
 import type { ProviderTransport } from "@sandbox-benchmarks/schema";
-import { getProvider } from "@sandbox-benchmarks/schema";
+import { getProvider, PTS_STATE_SELECT_SH } from "@sandbox-benchmarks/schema";
 import type { SandboxHandle } from "./execute.ts";
 import {
 	buildPreamble,
@@ -74,13 +74,20 @@ describe("sandbox preamble", () => {
 	});
 
 	it("separates an injected user's writable PTS state from the baked profile registry", () => {
+		// One canonical snippet, interpolated — not restated here, so this test cannot drift from the
+		// generated smoke probe the way three hand-written copies did.
+		expect(PREAMBLE).toContain(PTS_STATE_SELECT_SH);
 		expect(PREAMBLE).toContain(
 			"PTS_TEST_INSTALL_ROOT_PATH=/var/lib/phoronix-test-suite/installed-tests/",
 		);
-		expect(PREAMBLE).toContain('if [ "$(id -u)" -eq 0 ]');
-		expect(PREAMBLE).toContain("PTS_USER_PATH_OVERRIDE=/var/lib/phoronix-test-suite/");
-		expect(PREAMBLE).toContain('mkdir -p "$HOME/.phoronix-test-suite"');
-		expect(PREAMBLE).toContain('PTS_USER_PATH_OVERRIDE="$HOME/.phoronix-test-suite/"');
+	});
+
+	// The preamble prefixes EVERY command and is joined under `set -eo pipefail`, so a failing write
+	// here takes down the whole step — including probes that never touch PTS. PTS creates its own state
+	// directory, so selecting state must stay read-only.
+	it("selects PTS state without writing to the filesystem", () => {
+		expect(PTS_STATE_SELECT_SH).not.toContain("mkdir");
+		expect(PTS_STATE_SELECT_SH).not.toContain("$HOME");
 	});
 
 	it("never disables the mise python — baked images have no distro python3 to fall back to", () => {

--- a/packages/harness/src/lib/execute.test.ts
+++ b/packages/harness/src/lib/execute.test.ts
@@ -73,11 +73,14 @@ describe("sandbox preamble", () => {
 		expect(PREAMBLE).toContain("MISE_TASK_RUN_AUTO_INSTALL=0");
 	});
 
-	it("reuses the baked PTS registry for an injected unprivileged runtime user", () => {
-		expect(PREAMBLE).toContain("PTS_USER_PATH_OVERRIDE=/var/lib/phoronix-test-suite/");
+	it("separates an injected user's writable PTS state from the baked profile registry", () => {
 		expect(PREAMBLE).toContain(
 			"PTS_TEST_INSTALL_ROOT_PATH=/var/lib/phoronix-test-suite/installed-tests/",
 		);
+		expect(PREAMBLE).toContain('if [ "$(id -u)" -eq 0 ]');
+		expect(PREAMBLE).toContain("PTS_USER_PATH_OVERRIDE=/var/lib/phoronix-test-suite/");
+		expect(PREAMBLE).toContain('mkdir -p "$HOME/.phoronix-test-suite"');
+		expect(PREAMBLE).toContain('PTS_USER_PATH_OVERRIDE="$HOME/.phoronix-test-suite/"');
 	});
 
 	it("never disables the mise python — baked images have no distro python3 to fall back to", () => {

--- a/packages/harness/src/lib/execute.ts
+++ b/packages/harness/src/lib/execute.ts
@@ -24,6 +24,7 @@
 
 import { randomUUID } from "node:crypto";
 import type { ProviderTransport } from "@sandbox-benchmarks/schema";
+import { PTS_STATE_SELECT_SH } from "@sandbox-benchmarks/schema";
 import { GapError } from "./gap-cause.ts";
 
 export const MIN = 60_000;
@@ -318,11 +319,9 @@ const PREAMBLE_HEAD = [
 	// fine in a throwaway sandbox; the baked image sets the same.
 	"export PIP_BREAK_SYSTEM_PACKAGES=1",
 	// Keep the root-baked installed profiles shared, but never point an injected unprivileged user at
-	// root's mutable PTS state. PTS creates core.pt2so as 0600 and expands its default ResultsDirectory
-	// through $HOME for a non-daemon client; sharing /var/lib therefore emits permission errors AND makes
-	// result discovery look in a different tree from the one PTS actually writes. This runtime fallback
-	// also corrects already-published images whose Docker ENV still carries the old shared-state override.
-	'if [ -d /var/lib/phoronix-test-suite ]; then export PTS_TEST_INSTALL_ROOT_PATH=/var/lib/phoronix-test-suite/installed-tests/; if [ "$(id -u)" -eq 0 ]; then export PTS_USER_PATH_OVERRIDE=/var/lib/phoronix-test-suite/; else mkdir -p "$HOME/.phoronix-test-suite"; export PTS_USER_PATH_OVERRIDE="$HOME/.phoronix-test-suite/"; fi; fi',
+	// root's mutable PTS state. Canonical snippet — see PTS_STATE_SELECT_SH for the full rationale and
+	// for why this must also run at runtime rather than only in the image ENV.
+	PTS_STATE_SELECT_SH,
 ];
 
 /**

--- a/packages/harness/src/lib/execute.ts
+++ b/packages/harness/src/lib/execute.ts
@@ -317,9 +317,12 @@ const PREAMBLE_HEAD = [
 	// Distro pythons are PEP 668 externally-managed, but PTS profiles pip-install their harness —
 	// fine in a throwaway sandbox; the baked image sets the same.
 	"export PIP_BREAK_SYSTEM_PACKAGES=1",
-	// Some providers inject an unprivileged runtime user. Point both PTS state and installed-profile
-	// discovery at the root-baked registry even if an image importer strips the Docker ENV/config.
-	"if [ -d /var/lib/phoronix-test-suite ]; then export PTS_USER_PATH_OVERRIDE=/var/lib/phoronix-test-suite/ PTS_TEST_INSTALL_ROOT_PATH=/var/lib/phoronix-test-suite/installed-tests/; fi",
+	// Keep the root-baked installed profiles shared, but never point an injected unprivileged user at
+	// root's mutable PTS state. PTS creates core.pt2so as 0600 and expands its default ResultsDirectory
+	// through $HOME for a non-daemon client; sharing /var/lib therefore emits permission errors AND makes
+	// result discovery look in a different tree from the one PTS actually writes. This runtime fallback
+	// also corrects already-published images whose Docker ENV still carries the old shared-state override.
+	'if [ -d /var/lib/phoronix-test-suite ]; then export PTS_TEST_INSTALL_ROOT_PATH=/var/lib/phoronix-test-suite/installed-tests/; if [ "$(id -u)" -eq 0 ]; then export PTS_USER_PATH_OVERRIDE=/var/lib/phoronix-test-suite/; else mkdir -p "$HOME/.phoronix-test-suite"; export PTS_USER_PATH_OVERRIDE="$HOME/.phoronix-test-suite/"; fi; fi',
 ];
 
 /**

--- a/packages/schema/src/providers.ts
+++ b/packages/schema/src/providers.ts
@@ -115,6 +115,15 @@ export interface ProviderMaturity {
 	notes?: string;
 }
 
+/**
+ * Which identity a provider's benchmark lane runs as INSIDE the sandbox.
+ *
+ * `"unprivileged"` deliberately does not name the user: the point is the privilege level, which is
+ * what the toolchain has to accommodate (separate PTS state, no writes to root-owned trees). The
+ * account name is the provider's business and has changed without notice.
+ */
+export type ProviderRuntimeIdentity = "root" | "unprivileged";
+
 /** The static description of a sandbox provider, owned by the schema. */
 export interface ProviderMeta {
 	/** Stable identifier joined against the harness adapter map; one of {@link ProviderId}. */
@@ -131,6 +140,17 @@ export interface ProviderMeta {
 	specPinning: SpecPinning;
 	/** How the provider's exec transport behaves — the harness selects sync vs detached from this. */
 	transport: ProviderTransport;
+	/**
+	 * Identity the benchmark lane runs as in-sandbox. Omitted means `"root"`: setup, the baked PTS
+	 * state and every adapter target root, and the providers that DO inject an unprivileged user are
+	 * the exception worth declaring — e2b and novita each pin their exec back to root explicitly
+	 * (e2b-root.ts), so only a provider with no such lever is `"unprivileged"`.
+	 *
+	 * This exists so the job summary flags DRIFT rather than a supported configuration: a hardcoded
+	 * "expected root" marks every Runloop replicate anomalous on a perfectly healthy run, which trains
+	 * readers to ignore the warning that was added to catch a real identity change.
+	 */
+	runtimeIdentity?: ProviderRuntimeIdentity;
 }
 
 /**
@@ -512,6 +532,10 @@ const REGISTRY: Record<ProviderId, Omit<ProviderMeta, "id">> = {
 			notes:
 				"Official ComputeSDK adapter with a released toolchain Blueprint plus custom CPU, memory, and disk sizing; opt-in until a committed benchmark run validates the integration.",
 		},
+		// Devboxes run commands as their own unprivileged Blueprint user, and the adapter exposes no
+		// root lever the way e2b/novita do — so the toolchain accommodates it (PTS_STATE_SELECT_SH in
+		// toolchain.ts) instead of the summary flagging every replicate.
+		runtimeIdentity: "unprivileged",
 		// CUSTOM_SIZE exposes independent CPU, memory, and disk fields and can express 4 / 8 / 40 exactly.
 		specPinning: "settable",
 		transport: {
@@ -707,6 +731,29 @@ export function getProvider(id: string): ProviderMeta | undefined {
 	// the entries are immutable, so returning the reference directly is safe.
 	const canonical = LEGACY_PROVIDER_ALIASES[id] ?? id;
 	return PROVIDERS.find((p) => p.id === canonical);
+}
+
+/**
+ * The identity a provider is EXPECTED to run its benchmark lane as. Unknown ids (a run document from
+ * a retired provider) fall back to `"root"`, the toolchain's default.
+ */
+export function expectedRuntimeIdentity(providerId: string): ProviderRuntimeIdentity {
+	return getProvider(providerId)?.runtimeIdentity ?? "root";
+}
+
+/**
+ * Does an OBSERVED in-sandbox user contradict what the provider declares?
+ *
+ * Compares privilege level, not account name: a provider declared `"unprivileged"` may run as `user`,
+ * `sandbox`, or anything else and that is not news. What IS news either way is a switch — an
+ * unprivileged identity where root was expected (setup and the baked PTS state assume root) or root
+ * where an unprivileged user was expected (a provider silently gained privileges).
+ *
+ * An absent observation is never drift: not every provider's probe reports a user.
+ */
+export function isUnexpectedRuntimeUser(providerId: string, user: string | undefined): boolean {
+	if (!user) return false;
+	return (user === "root" ? "root" : "unprivileged") !== expectedRuntimeIdentity(providerId);
 }
 
 /**

--- a/packages/schema/src/toolchain.ts
+++ b/packages/schema/src/toolchain.ts
@@ -167,3 +167,42 @@ export const TOOLCHAIN_APT_GROUPS: readonly ToolchainAptGroup[] = Object.freeze(
 export const PTS_APT_DEPS = TOOLCHAIN_APT_GROUPS.filter((group) => !group.bakeOnly)
 	.map((group) => group.packages)
 	.join(" ");
+
+/** The bake's PTS root: profiles, installed tests and root's own mutable state all live under here. */
+export const PTS_BAKED_ROOT = "/var/lib/phoronix-test-suite";
+
+/**
+ * How every runtime entry point selects PTS's state directory, as ONE shell snippet.
+ *
+ * The bake installs profiles as root under {@link PTS_BAKED_ROOT}, but E2B-compatible providers
+ * (Runloop especially) inject an unprivileged runtime user. Those two identities need DIFFERENT
+ * mutable state and the SAME installed profiles, which is exactly the split below:
+ *
+ *   - `PTS_TEST_INSTALL_ROOT_PATH` keeps the baked installed tests shared. It is the only path PTS
+ *     10.8.4 exposes its own env override for, and without it an unprivileged run falls back to the
+ *     config's `~/.phoronix-test-suite/installed-tests/` and reports ZERO installed tests — the
+ *     Runloop failure this exists to prevent. The published v7 image predates this ENV, so setting it
+ *     at runtime is what makes an already-published image work.
+ *   - `PTS_USER_PATH_OVERRIDE` is UNSET for a non-root user rather than pointed anywhere. PTS's own
+ *     per-user default is already `$HOME/.phoronix-test-suite`, and it creates that directory itself —
+ *     so there is no mkdir here to fail under `set -e` when HOME is unset or unwritable. Pointing an
+ *     unprivileged user at the baked root instead is what breaks: root's `core.pt2so` is mode 0600
+ *     (the bake's chmod runs before the profile layers rewrite it), and PTS expands its non-daemon
+ *     `ResultsDirectory` through HOME regardless of the override — so the shared setting yields
+ *     permission errors AND a results tree lib/bench.sh's composite finder never searches.
+ *
+ * Root keeps the explicit override. It is redundant when PTS reaches its daemonized branch (writable
+ * /var/lib + /etc, which forces PTS_USER_PATH to the baked root anyway), and load-bearing when it
+ * does not — without it a root sandbox with a read-only /etc silently switches to
+ * /root/.phoronix-test-suite and loses every baked profile.
+ *
+ * Interpolated verbatim by the harness preamble (packages/harness/src/lib/execute.ts) and the
+ * generated smoke probe (packages/templates/src/smoke.ts). lib/bench.sh cannot import TS and restates
+ * the same decision in multi-line shell; tooling/repo-checks/src/pts-state-alignment.test.ts gates
+ * that copy as text, matching the {@link PTS_APT_DEPS} precedent.
+ */
+export const PTS_STATE_SELECT_SH =
+	`if [ -d ${PTS_BAKED_ROOT} ]; then ` +
+	`export PTS_TEST_INSTALL_ROOT_PATH=${PTS_BAKED_ROOT}/installed-tests/; ` +
+	`if [ "$(id -u)" -eq 0 ]; then export PTS_USER_PATH_OVERRIDE=${PTS_BAKED_ROOT}/; ` +
+	`else unset PTS_USER_PATH_OVERRIDE; fi; fi`;

--- a/packages/templates/images/base/Dockerfile
+++ b/packages/templates/images/base/Dockerfile
@@ -74,9 +74,16 @@ ARG DEBIAN_FRONTEND=noninteractive
 # > mise lives system-wide: one shared toolchain for every sandbox user, on PATH via its shims dir.
 # > 10-mise.sh installs from the config at MISE_CONFIG_DIR (the generated mise.toml, COPY'd below).
 # > These MUST persist at runtime, so they stay ENV.
+# > PTS_TEST_INSTALL_ROOT_PATH — and deliberately NOT PTS_USER_PATH_OVERRIDE. It is the one PTS path
+# > every identity must agree on: it keeps the baked installed tests visible to an injected
+# > unprivileged runtime user, who otherwise falls back to the config's ~/.phoronix-test-suite and
+# > reports zero installed tests. Mutable state is left to PTS's own per-user default instead, so root
+# > keeps /var/lib (its daemonized branch forces that regardless) while an unprivileged user gets
+# > $HOME — sharing root's 0600 core.pt2so and a HOME-expanded results tree is what broke Runloop. The
+# > runtime entry points restate this (PTS_STATE_SELECT_SH in packages/schema/src/toolchain.ts) because
+# > already-published images predate this ENV.
 ENV MISE_DATA_DIR=/usr/local/share/mise \
     MISE_CONFIG_DIR=/etc/mise \
-    PTS_USER_PATH_OVERRIDE=/var/lib/phoronix-test-suite/ \
     PTS_TEST_INSTALL_ROOT_PATH=/var/lib/phoronix-test-suite/installed-tests/ \
     PATH=/usr/local/share/mise/shims:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
 
@@ -152,11 +159,13 @@ RUN IMAGE_NAME="${IMAGE_NAME}" IMAGE_VERSION="${IMAGE_VERSION}" BASE_IMAGE="${BA
     bash /tmp/build/scripts/orchestrator.sh 99-manifest.sh \
     && rm -rf /tmp/build
 
-# > Security note: the generic image defaults to root, while E2B-compatible template builders inject
-# > an unprivileged runtime user. PTS_USER_PATH_OVERRIDE keeps both identities on the same pre-baked
-# > state under /var/lib/phoronix-test-suite; 20-pts.sh grants sandbox users write access because PTS
-# > writes per-run config and results there. Isolation remains the provider's outer VM/container
-# > boundary. Any setuid binary added later should be justified here.
+# > Security note: the generic image defaults to root, while E2B-compatible template builders inject an
+# > unprivileged runtime user. The two SHARE the read-mostly baked profiles (PTS_TEST_INSTALL_ROOT_PATH
+# > above) and keep SEPARATE mutable state — root under /var/lib/phoronix-test-suite, the injected user
+# > under its own $HOME, which PTS creates itself. 20-pts.sh still grants sandbox users write access to
+# > the baked tree because PTS writes install bookkeeping beside the profiles it installs. Isolation
+# > remains the provider's outer VM/container boundary. Any setuid binary added later should be
+# > justified here.
 #
 # > Plain `docker build` yields the generic toolchain image. Provider glue lives in the variant
 # > Dockerfiles (FROM this image) — never here — so these layers stay shared across providers.

--- a/packages/templates/images/base/scripts/20-pts.sh
+++ b/packages/templates/images/base/scripts/20-pts.sh
@@ -37,11 +37,11 @@ done
 # > /var/lib/phoronix-test-suite lines up at runtime.
 printf 'y\nn\nn\nn\nn\nn\ny\n' | phoronix-test-suite batch-setup
 
-# > E2B and Novita inject an unprivileged runtime user after importing this image. PTS otherwise
-# > switches from the root bake's /var/lib state to $HOME/.phoronix-test-suite, making every baked
-# > profile invisible. The image ENV pins PTS_USER_PATH_OVERRIDE to this existing directory; make the
-# > ephemeral benchmark state writable so that user can create batch config and result XML beside the
-# > read-mostly installed profiles. Provider isolation is the outer security boundary for this image.
+# > E2B, Novita and Runloop inject an unprivileged runtime user after importing this image. That user
+# > keeps its OWN mutable PTS state under $HOME (PTS's default, which it creates itself) and shares only
+# > the baked profiles, via the image's PTS_TEST_INSTALL_ROOT_PATH — so what has to be writable here is
+# > the install bookkeeping PTS writes beside the profiles it installs, not root's private state.
+# > Provider isolation is the outer security boundary for this image.
 # >
 # > Only the STATE created above is chmod'ed here. Each profile group chmods its own installed tree
 # > inside its own layer (25-pts-profiles.sh): a blanket `chmod -R` in a later layer would copy every

--- a/packages/templates/images/base/scripts/25-pts-profiles.sh
+++ b/packages/templates/images/base/scripts/25-pts-profiles.sh
@@ -100,6 +100,15 @@ for t in "${pts_tests[@]}"; do
 		[ -d "${dir}" ] && chmod -R a+rwX "${dir}"
 	done
 done
+# > The `pts/` PARENT dirs too, and NOT recursively — batch-install creates them 0755 root inside this
+# > layer, and 20-pts.sh's blanket chmod ran before they existed. Without write on the parent, an
+# > unprivileged runtime user can read every baked profile but can neither install a new one nor
+# > discard a baked install, which is exactly what install_vendored_pts_profile must do to replace a
+# > broken upstream runner (lib/bench.sh). A bare chmod on the directory copies only that directory
+# > entry into this layer, so this cannot re-inflate the image the way a `chmod -R` would.
+for dir in "${installed_dir}/pts" "${installed_dir}" "/var/lib/phoronix-test-suite/test-profiles/pts"; do
+	[ -d "${dir}" ] && chmod a+rwX "${dir}"
+done
 chmod -R a+rwX "${cache_dir}" 2>/dev/null || true
 
 # > That blanket chmod would ship pgbench broken: its install.sh initdb'd pg_/data/db as 0700, and

--- a/packages/templates/src/smoke.test.ts
+++ b/packages/templates/src/smoke.test.ts
@@ -11,7 +11,9 @@ async function runPtsCheck(
 }> {
 	const check = ptsInstalledTestsSmokeCheck(installTests);
 	const output = installedProfiles.map((profile) => `'${profile}'`).join(" ");
-	const script = `phoronix-test-suite() { printf '%s\\n' ${output}; }; ${check.cmd}`;
+	// Keep the generated check on its root branch so this unit test never creates state under the
+	// developer's real HOME; unprivileged-path selection is pinned by the string assertions below.
+	const script = `id() { printf '0\\n'; }; phoronix-test-suite() { printf '%s\\n' ${output}; }; ${check.cmd}`;
 	const proc = Bun.spawn(["bash", "-c", script], { stdout: "pipe", stderr: "pipe" });
 	const [exitCode, stdout] = await Promise.all([proc.exited, new Response(proc.stdout).text()]);
 	return { exitCode, stdout };
@@ -38,7 +40,9 @@ describe("@sandbox-benchmarks/templates smoke", () => {
 		const pts = smokeChecks.find((check) => check.name === "pts-installed-tests");
 		expect(pts?.expect).toBe("pts-profile-count=10");
 		expect(pts?.cmd).toContain("phoronix-test-suite list-installed-tests");
-		expect(pts?.cmd).toContain("PTS_USER_PATH_OVERRIDE=/var/lib/phoronix-test-suite/");
+		expect(pts?.cmd).toContain('if [ "$(id -u)" -ne 0 ]');
+		expect(pts?.cmd).toContain('pts_state="$HOME/.phoronix-test-suite"');
+		expect(pts?.cmd).toContain('PTS_USER_PATH_OVERRIDE="$pts_state/"');
 		expect(pts?.cmd).toContain(
 			"PTS_TEST_INSTALL_ROOT_PATH=/var/lib/phoronix-test-suite/installed-tests/",
 		);

--- a/packages/templates/src/smoke.test.ts
+++ b/packages/templates/src/smoke.test.ts
@@ -1,22 +1,73 @@
 import { describe, expect, it } from "bun:test";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { PTS_STATE_SELECT_SH } from "@sandbox-benchmarks/schema";
 import type { SmokeExec } from "./smoke.ts";
 import { ptsInstalledTestsSmokeCheck, runSmoke, smokeBashScript, smokeChecks } from "./smoke.ts";
 
+/** A stand-in for an override the published image ENV already exported into the sandbox. */
+const INHERITED_OVERRIDE = "/inherited-from-image-env/";
+
+/**
+ * Execute the GENERATED check under a stubbed effective uid, and report the PTS environment the
+ * probe actually handed to `phoronix-test-suite`.
+ *
+ * Two things make the unprivileged branch genuinely executable rather than merely asserted as text:
+ *
+ *  - The baked root is relocated into a temp dir. The generated command guards its whole export block
+ *    on `[ -d /var/lib/phoronix-test-suite ]`, which is false on every dev machine and CI runner, so
+ *    without this rewrite BOTH branches would be skipped and the test would prove nothing. Only the
+ *    path is relocated; the shell logic under test is byte-for-byte the shipped one.
+ *  - `PTS_USER_PATH_OVERRIDE` is seeded in the child env. Dropping an override the image ENV already
+ *    exported is the entire job of the non-root branch, and it is invisible unless something set it.
+ */
 async function runPtsCheck(
 	installTests: string,
 	installedProfiles: string[],
+	{ uid = 0 }: { uid?: number } = {},
 ): Promise<{
 	exitCode: number;
 	stdout: string;
+	/** `undefined` when the probe left PTS on its own per-user default. */
+	userPathOverride: string | undefined;
+	installRoot: string | undefined;
 }> {
 	const check = ptsInstalledTestsSmokeCheck(installTests);
 	const output = installedProfiles.map((profile) => `'${profile}'`).join(" ");
-	// Keep the generated check on its root branch so this unit test never creates state under the
-	// developer's real HOME; unprivileged-path selection is pinned by the string assertions below.
-	const script = `id() { printf '0\\n'; }; phoronix-test-suite() { printf '%s\\n' ${output}; }; ${check.cmd}`;
-	const proc = Bun.spawn(["bash", "-c", script], { stdout: "pipe", stderr: "pipe" });
-	const [exitCode, stdout] = await Promise.all([proc.exited, new Response(proc.stdout).text()]);
-	return { exitCode, stdout };
+	const root = await mkdtemp(join(tmpdir(), "pts-smoke-"));
+	try {
+		const cmd = check.cmd.replaceAll("/var/lib/phoronix-test-suite", root);
+		// The stub records the resolved PTS env to a side file, leaving stdout exactly what the real
+		// command emits. `${VAR-}` (no colon) distinguishes unset from set-but-empty — the difference
+		// between "the override was dropped" and "it was exported as an empty string".
+		const probePath = join(root, "resolved-env");
+		const script =
+			`id() { printf '${uid}\\n'; }; ` +
+			`phoronix-test-suite() { printf 'override=%s\\ninstall_root=%s\\n' ` +
+			`"\${PTS_USER_PATH_OVERRIDE-<unset>}" "\${PTS_TEST_INSTALL_ROOT_PATH-<unset>}" ` +
+			`>${JSON.stringify(probePath)}; printf '%s\\n' ${output}; }; ${cmd}`;
+		const proc = Bun.spawn(["bash", "-c", script], {
+			stdout: "pipe",
+			stderr: "pipe",
+			env: { ...process.env, PTS_USER_PATH_OVERRIDE: INHERITED_OVERRIDE },
+		});
+		const [exitCode, stdout] = await Promise.all([proc.exited, new Response(proc.stdout).text()]);
+		const probeFile = Bun.file(probePath);
+		const probe = (await probeFile.exists()) ? await probeFile.text() : "";
+		const read = (key: string): string | undefined => {
+			const value = probe.match(new RegExp(`^${key}=(.*)$`, "m"))?.[1];
+			return value === undefined || value === "<unset>" ? undefined : value.replace(root, "<root>");
+		};
+		return {
+			exitCode,
+			stdout,
+			userPathOverride: read("override"),
+			installRoot: read("install_root"),
+		};
+	} finally {
+		await rm(root, { recursive: true, force: true });
+	}
 }
 
 describe("@sandbox-benchmarks/templates smoke", () => {
@@ -40,9 +91,9 @@ describe("@sandbox-benchmarks/templates smoke", () => {
 		const pts = smokeChecks.find((check) => check.name === "pts-installed-tests");
 		expect(pts?.expect).toBe("pts-profile-count=10");
 		expect(pts?.cmd).toContain("phoronix-test-suite list-installed-tests");
-		expect(pts?.cmd).toContain('if [ "$(id -u)" -ne 0 ]');
-		expect(pts?.cmd).toContain('pts_state="$HOME/.phoronix-test-suite"');
-		expect(pts?.cmd).toContain('PTS_USER_PATH_OVERRIDE="$pts_state/"');
+		// The probe must select PTS state exactly the way the benchmark lane does, so a green smoke
+		// check cannot mean "root can see the profiles" while the injected run user cannot.
+		expect(pts?.cmd).toContain(PTS_STATE_SELECT_SH);
 		expect(pts?.cmd).toContain(
 			"PTS_TEST_INSTALL_ROOT_PATH=/var/lib/phoronix-test-suite/installed-tests/",
 		);
@@ -54,23 +105,58 @@ describe("@sandbox-benchmarks/templates smoke", () => {
 		expect(pts?.cmd).toContain('echo "pts-profile-count=$actual"');
 	});
 
-	it("handles an empty PTS install list without emitting invalid shell", async () => {
-		const check = ptsInstalledTestsSmokeCheck("  ");
-		expect(check.cmd).not.toContain("for test in");
-		expect((await runPtsCheck("  ", [])).exitCode).toBe(0);
-		expect((await runPtsCheck("  ", ["pts/unexpected-1.0.0"])).exitCode).toBe(1);
-	});
-
-	it("accepts versionless pins but requires version-pinned entries literally", async () => {
-		const result = await runPtsCheck("c-ray fio-2.1.0", ["pts/c-ray-2.0.0", "pts/fio-2.1.0"]);
+	// Runloop injects an unprivileged runtime user, so the non-root branch is the one this probe exists
+	// for — and the branch a `id() { printf '0' }`-only harness would never execute. Both identities are
+	// run for real below, and every functional case after this repeats under both.
+	it("keeps root on the baked state directory", async () => {
+		const result = await runPtsCheck("fio-2.1.0", ["pts/fio-2.1.0"], { uid: 0 });
 		expect(result.exitCode).toBe(0);
-		expect(result.stdout).toContain("pts-profile-count=2");
+		expect(result.userPathOverride).toBe("<root>/");
+		expect(result.installRoot).toBe("<root>/installed-tests/");
 	});
 
-	it("rejects an unexpected extra installed profile instead of echoing the expected count", async () => {
-		const result = await runPtsCheck("fio-2.1.0", ["pts/fio-2.1.0", "pts/stream-1.3.4"]);
-		expect(result.exitCode).toBe(1);
+	// The regression this pins: pointing an unprivileged user at root's state (or leaving the image
+	// ENV's override in place) puts PTS on a 0600 core.pt2so and a results tree lib/bench.sh never
+	// searches. The override must be DROPPED, not repointed — PTS's own $HOME default is correct — and
+	// the shared install root must survive, which is the only reason the profiles stay visible.
+	it("drops an inherited override for an unprivileged user while keeping the shared install root", async () => {
+		const result = await runPtsCheck("fio-2.1.0", ["pts/fio-2.1.0"], { uid: 1000 });
+		expect(result.exitCode).toBe(0);
+		expect(result.userPathOverride).toBeUndefined();
+		expect(result.installRoot).toBe("<root>/installed-tests/");
 	});
+
+	// No mkdir on either branch: the probe runs under `set -euo pipefail` in smokeBashScript(), so a
+	// write that fails when HOME is unset or unwritable would abort the whole smoke run rather than
+	// report one failed check. PTS creates its own state dir, so there is nothing to pre-create.
+	it("never writes to the filesystem while selecting PTS state", () => {
+		const pts = smokeChecks.find((check) => check.name === "pts-installed-tests");
+		expect(pts?.cmd).not.toContain("mkdir");
+	});
+
+	for (const uid of [0, 1000]) {
+		const as = uid === 0 ? "as root" : "as an unprivileged user";
+
+		it(`handles an empty PTS install list without emitting invalid shell (${as})`, async () => {
+			const check = ptsInstalledTestsSmokeCheck("  ");
+			expect(check.cmd).not.toContain("for test in");
+			expect((await runPtsCheck("  ", [], { uid })).exitCode).toBe(0);
+			expect((await runPtsCheck("  ", ["pts/unexpected-1.0.0"], { uid })).exitCode).toBe(1);
+		});
+
+		it(`accepts versionless pins but requires version-pinned entries literally (${as})`, async () => {
+			const result = await runPtsCheck("c-ray fio-2.1.0", ["pts/c-ray-2.0.0", "pts/fio-2.1.0"], {
+				uid,
+			});
+			expect(result.exitCode).toBe(0);
+			expect(result.stdout).toContain("pts-profile-count=2");
+		});
+
+		it(`rejects an unexpected extra installed profile instead of echoing the count (${as})`, async () => {
+			const result = await runPtsCheck("fio-2.1.0", ["pts/fio-2.1.0", "pts/stream-1.3.4"], { uid });
+			expect(result.exitCode).toBe(1);
+		});
+	}
 
 	it("emits a bash script asserting every probe", () => {
 		const script = smokeBashScript();

--- a/packages/templates/src/smoke.ts
+++ b/packages/templates/src/smoke.ts
@@ -5,7 +5,11 @@
 // The probes mirror what 99-manifest.sh bakes into the image; expects are pinned to pins.ts versions,
 // so a check fails loudly if the exact toolchain didn't make it through e2b's envd injection,
 // daytona's snapshot, or modal's fromRegistry.
-import { TOOLCHAIN_IMAGE_NAME, TOOLCHAIN_VERSION } from "@sandbox-benchmarks/schema";
+import {
+	PTS_STATE_SELECT_SH,
+	TOOLCHAIN_IMAGE_NAME,
+	TOOLCHAIN_VERSION,
+} from "@sandbox-benchmarks/schema";
 import { pins } from "./pins.ts";
 
 /** A single smoke probe: run `cmd`, pass iff it exits 0 and its output contains `expect`. */
@@ -56,8 +60,12 @@ export function ptsInstalledTestsSmokeCheck(installTests: string): SmokeCheck {
 	return {
 		name: "pts-installed-tests",
 		cmd:
-			'pts_state=/var/lib/phoronix-test-suite; if [ "$(id -u)" -ne 0 ]; then pts_state="$HOME/.phoronix-test-suite"; mkdir -p "$pts_state"; fi; ' +
-			'installed="$(PTS_USER_PATH_OVERRIDE="$pts_state/" PTS_TEST_INSTALL_ROOT_PATH=/var/lib/phoronix-test-suite/installed-tests/ phoronix-test-suite list-installed-tests 2>/dev/null)"; ' +
+			// Probe the SAME state the benchmark lane will use, root or injected unprivileged user, so a
+			// green smoke check cannot mean "root can see the profiles" while the run user cannot.
+			// `; ` because the snippet ends in `fi` — a bare space would splice the next assignment into
+			// the `if` and bash would reject the whole probe with a syntax error.
+			`${PTS_STATE_SELECT_SH}; ` +
+			'installed="$(phoronix-test-suite list-installed-tests 2>/dev/null)"; ' +
 			`profiles="$(printf '%s\\n' "$installed" | awk '$1 ~ /^pts\\// { print $1 }')"; ` +
 			verifyExpected +
 			`actual="$(printf '%s\\n' "$profiles" | awk 'NF { count++ } END { print count + 0 }')"; ` +

--- a/packages/templates/src/smoke.ts
+++ b/packages/templates/src/smoke.ts
@@ -56,7 +56,8 @@ export function ptsInstalledTestsSmokeCheck(installTests: string): SmokeCheck {
 	return {
 		name: "pts-installed-tests",
 		cmd:
-			'installed="$(PTS_USER_PATH_OVERRIDE=/var/lib/phoronix-test-suite/ PTS_TEST_INSTALL_ROOT_PATH=/var/lib/phoronix-test-suite/installed-tests/ phoronix-test-suite list-installed-tests 2>/dev/null)"; ' +
+			'pts_state=/var/lib/phoronix-test-suite; if [ "$(id -u)" -ne 0 ]; then pts_state="$HOME/.phoronix-test-suite"; mkdir -p "$pts_state"; fi; ' +
+			'installed="$(PTS_USER_PATH_OVERRIDE="$pts_state/" PTS_TEST_INSTALL_ROOT_PATH=/var/lib/phoronix-test-suite/installed-tests/ phoronix-test-suite list-installed-tests 2>/dev/null)"; ' +
 			`profiles="$(printf '%s\\n' "$installed" | awk '$1 ~ /^pts\\// { print $1 }')"; ` +
 			verifyExpected +
 			`actual="$(printf '%s\\n' "$profiles" | awk 'NF { count++ } END { print count + 0 }')"; ` +

--- a/tooling/repo-checks/src/pts-state-alignment.test.ts
+++ b/tooling/repo-checks/src/pts-state-alignment.test.ts
@@ -1,0 +1,85 @@
+// Drift gate: which PTS state directory a sandbox uses is decided in THREE places — the harness
+// preamble that prefixes every command (packages/harness/src/lib/execute.ts), the generated smoke
+// probe that validates a published image (packages/templates/src/smoke.ts), and lib/bench.sh, which
+// every measurement leaf sources. They must agree, because the run and the check that clears the run
+// would otherwise be reading different trees.
+//
+// The two TS consumers now interpolate the canonical PTS_STATE_SELECT_SH, so their alignment holds by
+// construction and only the wiring needs a tripwire. lib/bench.sh cannot import TS and restates the
+// decision in multi-line shell, so it is gated as text — same shape as the PTS_APT_DEPS gate next
+// door, and deliberately not shell parsing.
+//
+// What the assertions below actually protect, all of which produced real failures:
+//   - dropping PTS_TEST_INSTALL_ROOT_PATH makes an unprivileged run report ZERO installed profiles,
+//     because PTS falls back to the config's ~/.phoronix-test-suite/installed-tests/;
+//   - pointing an unprivileged user at the baked root puts it on root's 0600 core.pt2so and a
+//     HOME-expanded results tree that bench.sh's composite finder never searches;
+//   - a write (mkdir) while selecting state runs under `set -e` in all three contexts, so it takes
+//     down the whole step — including leaves that never touch PTS — when HOME is unset or unwritable.
+
+import { describe, expect, it } from "bun:test";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { PTS_BAKED_ROOT, PTS_STATE_SELECT_SH } from "@sandbox-benchmarks/schema";
+import { findRepoRoot } from "./lib/workspace.ts";
+
+const root = findRepoRoot();
+const read = (path: string): string => readFileSync(join(root, path), "utf8");
+
+/** The bench.sh block, extracted line-anchored on its guard through the matching `fi`. */
+function benchShStateBlock(): string {
+	const lines = read("lib/bench.sh").split("\n");
+	const start = lines.findIndex((line) => line.trim() === `if [ -d ${PTS_BAKED_ROOT} ]; then`);
+	if (start === -1) throw new Error("lib/bench.sh: no PTS state selection block");
+	const end = lines.findIndex((line, i) => i > start && line.trim() === "fi");
+	if (end === -1) throw new Error("lib/bench.sh: unterminated PTS state selection block");
+	return lines.slice(start, end + 1).join("\n");
+}
+
+describe("PTS state selection alignment", () => {
+	// The canonical snippet itself. Asserted here rather than only at its consumers so a change to the
+	// policy has to be a deliberate edit to this list, not a silent one-character fix.
+	it("keeps the shared install root and leaves an unprivileged user on PTS's own default", () => {
+		expect(PTS_STATE_SELECT_SH).toContain(
+			`export PTS_TEST_INSTALL_ROOT_PATH=${PTS_BAKED_ROOT}/installed-tests/`,
+		);
+		expect(PTS_STATE_SELECT_SH).toContain(`export PTS_USER_PATH_OVERRIDE=${PTS_BAKED_ROOT}/`);
+		// UNSET, never repointed: an inherited image ENV must be dropped, and PTS's default already is
+		// $HOME/.phoronix-test-suite.
+		expect(PTS_STATE_SELECT_SH).toContain("unset PTS_USER_PATH_OVERRIDE");
+	});
+
+	it("selects state without writing to the filesystem", () => {
+		expect(PTS_STATE_SELECT_SH).not.toContain("mkdir");
+	});
+
+	// By-construction only holds while the consumers really interpolate the constant; a re-inlined
+	// literal would drift in the sandbox while every unit test still passed.
+	for (const path of ["packages/harness/src/lib/execute.ts", "packages/templates/src/smoke.ts"]) {
+		it(`keeps ${path} wired to the canonical PTS_STATE_SELECT_SH`, () => {
+			expect(read(path)).toContain("PTS_STATE_SELECT_SH");
+		});
+	}
+
+	// lib/bench.sh is the text-gated copy: same decision, multi-line shell.
+	it("keeps lib/bench.sh making the same decision as the canonical snippet", () => {
+		const block = benchShStateBlock();
+		expect(block).toContain(`export PTS_TEST_INSTALL_ROOT_PATH=${PTS_BAKED_ROOT}/installed-tests/`);
+		expect(block).toContain('if [ "$(id -u)" -eq 0 ]');
+		expect(block).toContain(`export PTS_USER_PATH_OVERRIDE=${PTS_BAKED_ROOT}/`);
+		expect(block).toContain("unset PTS_USER_PATH_OVERRIDE");
+		expect(block).not.toContain("mkdir");
+	});
+
+	// The image ENV is the fourth copy of this policy and the one that outlives a rebuild. It must
+	// carry the shared install root and must NOT re-introduce a shared user path, which is what every
+	// runtime snippet above exists to correct on already-published images.
+	it("keeps the baked image ENV on the install root alone", () => {
+		const dockerfile = read("packages/templates/images/base/Dockerfile");
+		expect(dockerfile).toContain(
+			`PTS_TEST_INSTALL_ROOT_PATH=${PTS_BAKED_ROOT}/installed-tests/ \\`,
+		);
+		expect(dockerfile).not.toMatch(/^\s*ENV\s+PTS_USER_PATH_OVERRIDE/m);
+		expect(dockerfile).not.toMatch(/^\s+PTS_USER_PATH_OVERRIDE=/m);
+	});
+});


### PR DESCRIPTION
## Summary

- keep baked PTS profiles shared while moving mutable PTS state to `$HOME/.phoronix-test-suite` for non-root sandboxes
- make the standalone toolchain smoke use the same root/non-root state selection
- show the observed runtime user in benchmark job summaries and visibly flag identities other than the expected `root`

## Root cause

Runloop launches the v7 blueprint as `uid=4444(user)`. The image forces `PTS_USER_PATH_OVERRIDE=/var/lib/phoronix-test-suite/`, but the final root-owned `core.pt2so` is mode `0600`. More importantly, PTS 10.8.4 expands its non-daemon `ResultsDirectory` through the runtime user's `$HOME`, so PTS wrote valid `composite.xml` files under `/home/user/.phoronix-test-suite/test-results` while the harness searched `/var/lib/phoronix-test-suite/test-results`. The benchmarks succeeded, but the harness recorded false skips and failed the suite.

The runtime fallback intentionally works with the already-published immutable v7 image, so this fix does not require a toolchain version bump or rebuild.

## Validation

- `bun run lint`
- `bun run typecheck`
- `bun run test` (with local Codex Git signing/hooks disabled for the temporary-repository fixture; CI-equivalent)
- `bun run spell`
- `bun run check:catalog-drift`
- `bun run lint:shell`
- `bun run lint:docker`
- generated smoke script passes `bash -n`
- live Runloop `system` suite with `BENCH_PASSES=1`, cloning commit `997546ad` from this branch:
  - PyBench: numeric `pts_pybench.xml`
  - SQLite Speedtest: numeric `pts_sqlite-speedtest.xml`
  - Git: numeric `pts_git.xml`
  - no PTS permission warning, skip marker, or suite failure
  - observed runtime user: `user`, which the new job summary renders as unexpected

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes PTS state and result discovery for non-root sandboxes by keeping installed tests shared and letting unprivileged users use their own `$HOME/.phoronix-test-suite`. Aligns all entry points on one `PTS_STATE_SELECT_SH` and reports per-provider runtime identity drift in summaries.

- **Bug Fixes**
  - Select PTS state via `PTS_STATE_SELECT_SH`: keep `PTS_TEST_INSTALL_ROOT_PATH=/var/lib/phoronix-test-suite/installed-tests/` shared; unset `PTS_USER_PATH_OVERRIDE` for non-root; keep it for root.
  - Apply the same logic in `lib/bench.sh`, the `packages/harness` preamble, and the generated smoke; add a repo check to keep them aligned.
  - Resolve the install tree through a new `pts_install_root`; remove stale baked installs and assert the discard so vendored repairs take effect.
  - Require a readable `core.pt2so` in `pts_user_dir` and fix result lookup to avoid searching unwritten trees.
  - Target fio’s O_DIRECT probe at the install filesystem and chmod the `installed-tests/pts` parents so unprivileged users can install/remove tests; remove `PTS_USER_PATH_OVERRIDE` from the Dockerfile ENV and update comments.

- **New Features**
  - Add per-provider runtime identity (`root` or `unprivileged`) to `@sandbox-benchmarks/schema`; flag drift with “⚠ … (expected …)” in per-sandbox rows and show a fleet count of unexpected runtime users.

<sup>Written for commit 7af709f42113e1718375228ba4106c46f263445c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/starslingdev/hpc-sandbox-benchmarks/pull/340?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

