### PR TITLE
chore(toolchain): bump TOOLCHAIN_VERSION to v8

### DIFF
--- a/.github/workflows/toolchain-image.yml
+++ b/.github/workflows/toolchain-image.yml
@@ -35,9 +35,9 @@ name: Toolchain image
 #              build is not reproducible, so a rebuild would quietly hand it a different `:vN`).
 #   promote    off ⇒ the publish job is skipped: bake + verify, look at the report, promote later.
 #
-# The canonical use is adding a provider to a version everyone else already runs — e.g. Runloop on v7:
+# The canonical use is adding a provider to a version everyone else already runs — e.g. Runloop on v8:
 #   1. providers=runloop, build=skip, promote=false → bake + verify a candidate Blueprint, nothing public
-#   2. providers=runloop, build=skip, promote=true  → publish just the Runloop v7 Blueprint
+#   2. providers=runloop, build=skip, promote=true  → publish just the Runloop v8 Blueprint
 # Neither dispatch runs the shared build job: Runloop derives its candidate/version Blueprints from
 # the one already-published base during bake/promote.
 #

--- a/docs/ci-secrets.md
+++ b/docs/ci-secrets.md
@@ -159,14 +159,14 @@ Ungated: `ci.yml`, `ci-lint.yml`, and the toolchain `pr-gate` (Docker smoke, no 
      modal, namespace, microsandbox) are unaffected: their version artifact is a retag of the exact
      candidate that was just booted.
 
-   The Runloop-on-v7 flow, as an example — two dispatches, neither of which touches another provider,
+   The Runloop-on-v8 flow, as an example — two dispatches, neither of which touches another provider,
    and neither of which runs a build job:
 
    1. **Actions → Toolchain image → Run workflow** with `providers=runloop`, `build=skip`, `promote`
-      unchecked. Builds the candidate Blueprint from the published GHCR `:v7` digest, boots it, and
+      unchecked. Builds the candidate Blueprint from the published GHCR `:v8` digest, boots it, and
       runs the smoke spec. Nothing public moves.
    2. Same dispatch with `promote` checked. Re-validates the candidate Blueprint and builds the
-      version-named Blueprint from the pinned base. The GHCR base `:v7` is never rewritten.
+      version-named Blueprint from the pinned base. The GHCR base `:v8` is never rewritten.
 
    The release pulls exactly **one** GHCR package (`sandbox-benchmarks-toolchain`), anonymously, so the
    one-time Public bootstrap it needs has already been done. Adding a provider never adds a package —

--- a/packages/schema/src/toolchain.ts
+++ b/packages/schema/src/toolchain.ts
@@ -19,7 +19,26 @@ export const VERCEL_VCR_REPOSITORY = `${TOOLCHAIN_IMAGE_NAME}-vercel`;
 // (https://vercel.com/docs/container-registry/limits-and-pricing), so the bake now installs apt in
 // TOOLCHAIN_APT_GROUPS-sized layers and PTS one profile group at a time. The image content is
 // identical; only its layer boundaries moved. Re-bake all providers before the runs that consume v7.
-export const TOOLCHAIN_VERSION = "v7";
+// v8: no toolchain pin changed from v7 — mise 2026.7.11, node 22.23.1, pnpm 10.34.5, jc 1.25.7, PTS
+// 10.8.4 and the same 10 pre-installed profiles. The delta is entirely about the UNPRIVILEGED runtime
+// user E2B-compatible providers inject (Runloop runs its whole lane that way), and it is two things:
+//   - The image ENV no longer exports PTS_USER_PATH_OVERRIDE, only PTS_TEST_INSTALL_ROOT_PATH. Sharing
+//     root's mutable state put an injected user on a 0600 core.pt2so and — because PTS expands its
+//     non-daemon ResultsDirectory through HOME regardless of the override — on a results tree
+//     lib/bench.sh's composite finder never searched. Dropping the override leaves that user on PTS's
+//     own $HOME default while the baked profiles stay shared, which is the only path PTS 10.8.4
+//     exposes an override for. Root is unaffected: its daemonized branch pins the baked root anyway.
+//   - installed-tests/pts and its parent are now group/other-writable. batch-install created them 0755
+//     root inside the profile layers, AFTER 20-pts.sh's blanket chmod, so an unprivileged user could
+//     read every baked profile but could neither install a new one nor discard a baked install — the
+//     latter is what install_vendored_pts_profile must do to replace a broken upstream runner, and its
+//     silent no-op meant the network suite benchmarked the unrepaired iperf profile.
+// v7 published WITHOUT PTS_TEST_INSTALL_ROOT_PATH (the ENV postdates that bake), which is why an
+// unprivileged run on it reports 0 of 10 installed profiles; the runtime entry points now set it
+// themselves, so v7 images keep working, but Runloop's vendored-profile path needs THIS image.
+// Numbers stay comparable across v7↔v8: no pin, profile, or build flag changed — only an env var and
+// a directory mode. Re-bake all providers before the runs that consume v8.
+export const TOOLCHAIN_VERSION = "v8";
 
 const VCR_NAMESPACE_COMPONENT = /^[a-z0-9](?:[a-z0-9-]{0,98}[a-z0-9])?$/;
 


### PR DESCRIPTION
#340 changed the baked image: the ENV no longer exports PTS_USER_PATH_OVERRIDE,
and 25-pts-profiles.sh makes installed-tests/pts writable so an injected
unprivileged user can discard and install profiles. The version tag is
immutable, so re-baking those changes onto :v7 would rewrite a published tag —
this bump has to land before any re-bake.

No toolchain pin changed from v7: same mise, node, pnpm, jc, PTS 10.8.4 and the
same 10 pre-installed profiles. The delta is one env var and one directory mode,
so v7 and v8 measurements stay comparable.

One line cascades to every provider artifact name (GHCR tag, e2b template,
daytona snapshot, Runloop Blueprint, VCR tag) — they all derive from this
constant — and to the image manifest the smoke spec asserts.

Also repoints the Runloop dispatch EXAMPLES in docs/ci-secrets.md and
toolchain-image.yml from v7 to v8. The build=skip shortcut they describe is
unchanged, but v7 is the one published base that predates
PTS_TEST_INSTALL_ROOT_PATH, so following the literal digit would bake a Runloop
Blueprint on the image whose unprivileged path #340 exists to fix.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bump `TOOLCHAIN_VERSION` to `v8` to ship #340’s baked-image fixes (drop `PTS_USER_PATH_OVERRIDE`; make `installed-tests/pts` writable) without rewriting the published `:v7`. No pins change; docs/workflow examples now reference v8, and all provider artifact tags and the smoke-test manifest advance accordingly.

- **Migration**
  - Re-bake all providers before runs that consume v8.
  - Use the v8 Runloop dispatch examples (`providers=runloop`, `build=skip`, toggle `promote`) — flow is unchanged, only the version.

<sup>Written for commit 7da95a0f3605ad7d9e56c20e0ccc8cbf282c8377. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/starslingdev/hpc-sandbox-benchmarks/pull/342?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

