### PR TITLE
Add runloop, namespace, and runcloud to default benchmark providers

### DIFF
--- a/.github/workflows/bench-matrix.yml
+++ b/.github/workflows/bench-matrix.yml
@@ -43,14 +43,17 @@ on:
         description: 'Comma-separated providers to benchmark (blank = every registered provider).'
         required: false
         type: string
-        # The default set is every provider that has produced comparable committed results across
-        # isolation technologies: e2b, daytona-vm (the LINUX_VM reference), modal-gvisor (Modal's default
-        # gVisor runtime), modal-vm (Modal's gVisor-free microVM), blaxel (stock base image), novita
-        # (its own pre-baked template), microsandbox-cloud, and vercel (the shared toolchain base
-        # mirrored into VCR). modal-vm + blaxel graduated into the default once committed runs validated
-        # them; microsandbox-cloud and vercel followed. daytona-container and microsandbox-local are the
-        # registered variants still opt-in; Runloop is also opt-in until it has a committed validation
-        # run (pass any of them explicitly);
+        # The default set spans the isolation technologies compared here: e2b, daytona-vm (the LINUX_VM
+        # reference), modal-gvisor (Modal's default gVisor runtime), modal-vm (Modal's gVisor-free
+        # microVM), blaxel (stock base image), novita (its own pre-baked template), microsandbox-cloud,
+        # namespace (dedicated instance), and vercel (the shared toolchain base mirrored into VCR) have
+        # all produced comparable committed results. modal-vm + blaxel graduated into the default once
+        # committed runs validated them; microsandbox-cloud, vercel, and namespace followed. runloop and
+        # runcloud join the default WITHOUT a committed validation run — the matrix itself is how they
+        # get one, so until then they surface as pending providers / leaderboard coverage gaps rather
+        # than scores, and a cell whose credential is missing skips cleanly instead of failing the run.
+        # daytona-container and microsandbox-local are the registered variants still opt-in (pass either
+        # explicitly);
         # `plan-providers` rejects any name that is not in the registry. Listed in registry order — the
         # plan re-sorts to registry order regardless, so the spelling here is cosmetic.
         #
@@ -58,7 +61,7 @@ on:
         # affect comparability — computeSpecMatched covers vCPUs and memory, the two axes providers are
         # ranked on — but a disk-hungry suite will SKIP there and surface as a leaderboard coverage gap
         # rather than a bad score. See packages/results/src/lib/specs.ts.
-        default: e2b,daytona-vm,blaxel,microsandbox-cloud,modal-gvisor,modal-vm,novita,vercel
+        default: e2b,daytona-vm,blaxel,microsandbox-cloud,modal-gvisor,modal-vm,novita,runloop,namespace,vercel,runcloud
       suites:
         description: 'Comma-separated suites to run (blank = every registered suite). E.g. "network" for a targeted pre-merge run.'
         required: false


### PR DESCRIPTION
## Summary
Updated the benchmark matrix workflow to include three additional providers in the default benchmark set: `runloop`, `namespace`, and `runcloud`. This expands the default provider coverage while clarifying the validation status and behavior of providers in the matrix.

## Changes
- **Added providers to default set**: `runloop`, `namespace`, and `runcloud` are now included in the default benchmark providers list
- **Updated documentation**: Clarified that `runloop` and `runcloud` join the default set WITHOUT a committed validation run, using the matrix itself as their validation mechanism
- **Improved clarity**: Enhanced comments to explain that providers without credentials will skip cleanly rather than fail the run, and surface as pending providers/leaderboard coverage gaps until validation is complete
- **Reorganized provider descriptions**: Restructured the comment block to better explain the distinction between providers with committed validation runs versus those being validated through the matrix

## Notable Details
- The default provider list now spans 11 providers: `e2b`, `daytona-vm`, `blaxel`, `microsandbox-cloud`, `modal-gvisor`, `modal-vm`, `novita`, `runloop`, `namespace`, `vercel`, and `runcloud`
- `daytona-container` and `microsandbox-local` remain opt-in only
- The change maintains backward compatibility—providers can still be explicitly passed to override defaults

https://claude.ai/code/session_01NsKEwk9rJdYDapqPvsSocs

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Added `runloop`, `namespace`, and `runcloud` to the default benchmark providers to broaden coverage. Clarified validation status and ensured missing credentials skip cleanly instead of failing.

- **New Features**
  - Default providers: `e2b`, `daytona-vm`, `blaxel`, `microsandbox-cloud`, `modal-gvisor`, `modal-vm`, `novita`, `runloop`, `namespace`, `vercel`, `runcloud`; `daytona-container` and `microsandbox-local` stay opt-in.
  - Validation: `namespace` has committed results; `runloop` and `runcloud` will validate via the matrix and appear as pending until then.
  - Behavior: missing credentials skip instead of failing; explicit provider overrides still work; registry order preserved.

<sup>Written for commit 82587e9ecd3dab84f73ff5079332503b87b3a813. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/starslingdev/hpc-sandbox-benchmarks/pull/343?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

