### PR TITLE
fix(runcloud): reconcile an ambiguous create by name lookup, not create replay

### DIFF
--- a/apps/cli/src/bin/bake.ts
+++ b/apps/cli/src/bin/bake.ts
@@ -11,7 +11,7 @@
 import { writeFileSync } from "node:fs";
 import { requiredProviders, unmetRequirements } from "@sandbox-benchmarks/harness";
 import type { ProviderConfig } from "@sandbox-benchmarks/providers";
-import { config, drainRuncloudBackgroundWork } from "@sandbox-benchmarks/providers";
+import { config } from "@sandbox-benchmarks/providers";
 import type { ProviderId } from "@sandbox-benchmarks/schema";
 import { PROVIDERS } from "@sandbox-benchmarks/schema";
 import { bakeDaytonaContainerSnapshot, bakeDaytonaVmSnapshot } from "../lib/bake/daytona.ts";
@@ -172,30 +172,23 @@ if (import.meta.main) {
 			);
 			process.exit(2);
 		}
-		let promoted: Awaited<ReturnType<typeof promoteAll>>;
-		try {
-			promoted = await promoteAll(log, { force, only });
-			writeReport({
-				// The scope is recorded alongside the version names because those names are the FULL set the
-				// version owns — on a partial promote most of them were not touched, and the payload has to
-				// say which run this was rather than leave a reader to infer it from `reports`.
-				scope: only ?? PROVIDERS.map((p) => p.id),
-				partial: isPartialScope(only),
-				version: {
-					image: config.toolchainImageVersion,
-					e2bTemplate: config.e2bTemplateVersion,
-					daytonaSnapshot: config.daytonaSnapshotDefault,
-					daytonaContainerSnapshot: config.daytonaContainerSnapshotDefault,
-					novitaTemplate: config.novitaTemplateVersion,
-					runloopBlueprint: config.runloopBlueprintVersion,
-				},
-				reports: promoted.reports,
-			});
-		} finally {
-			// Promotion can validate run.cloud before writing its report. Preserve teardown even if either
-			// operation throws instead of returning a structured failed report.
-			await drainRuncloudBackgroundWork();
-		}
+		const promoted = await promoteAll(log, { force, only });
+		writeReport({
+			// The scope is recorded alongside the version names because those names are the FULL set the
+			// version owns — on a partial promote most of them were not touched, and the payload has to
+			// say which run this was rather than leave a reader to infer it from `reports`.
+			scope: only ?? PROVIDERS.map((p) => p.id),
+			partial: isPartialScope(only),
+			version: {
+				image: config.toolchainImageVersion,
+				e2bTemplate: config.e2bTemplateVersion,
+				daytonaSnapshot: config.daytonaSnapshotDefault,
+				daytonaContainerSnapshot: config.daytonaContainerSnapshotDefault,
+				novitaTemplate: config.novitaTemplateVersion,
+				runloopBlueprint: config.runloopBlueprintVersion,
+			},
+			reports: promoted.reports,
+		});
 		// The transaction outcome is separate from its diagnostics: an optional provider can fail and stay
 		// visible in the report without turning a successfully published shared version red after commit.
 		process.exit(promoted.ok ? 0 : 1);
@@ -291,23 +284,17 @@ if (import.meta.main) {
 		...(run.value && run.value.checks.length > 0 ? { checks: run.value.checks } : {}),
 	}));
 
-	try {
-		writeReport({
-			candidate: {
-				image: pinnedBaseImage,
-				e2bTemplate: config.e2bTemplateCandidate,
-				daytonaSnapshot: config.daytonaSnapshotCandidate,
-				daytonaContainerSnapshot: config.daytonaContainerSnapshotCandidate,
-				novitaTemplate: config.novitaTemplateCandidate,
-				runloopBlueprint: config.runloopBlueprintCandidate,
-			},
-			reports,
-		});
-	} finally {
-		// Candidate validation can exercise run.cloud. Its retained failed-create cleanup must finish even
-		// when report output throws, and before either explicit failure exit below terminates the process.
-		await drainRuncloudBackgroundWork();
-	}
+	writeReport({
+		candidate: {
+			image: pinnedBaseImage,
+			e2bTemplate: config.e2bTemplateCandidate,
+			daytonaSnapshot: config.daytonaSnapshotCandidate,
+			daytonaContainerSnapshot: config.daytonaContainerSnapshotCandidate,
+			novitaTemplate: config.novitaTemplateCandidate,
+			runloopBlueprint: config.runloopBlueprintCandidate,
+		},
+		reports,
+	});
 
 	if (anyFailed(runs)) process.exit(1);
 

--- a/apps/cli/src/bin/bench-lifecycle.ts
+++ b/apps/cli/src/bin/bench-lifecycle.ts
@@ -14,7 +14,6 @@ import {
 	requiredProviders,
 	unmetRequirements,
 } from "@sandbox-benchmarks/harness";
-import { drainRuncloudBackgroundWork } from "@sandbox-benchmarks/providers";
 import type { LifecycleMetricSummary } from "../lib/lifecycle-summary.ts";
 import {
 	formatLifecycleLines,
@@ -86,13 +85,7 @@ if (import.meta.main) {
 				}
 			: {}),
 	}));
-	try {
-		console.log(JSON.stringify({ summary }, null, 2));
-	} finally {
-		// A timed-out run.cloud create can return a handle during teardown. Output/reporting failures and
-		// the explicit exits below must not terminate cleanup while the sandbox is still being destroyed.
-		await drainRuncloudBackgroundWork();
-	}
+	console.log(JSON.stringify({ summary }, null, 2));
 
 	// Skips (missing creds) never fail the run; only a provider that ran and broke does.
 	if (anyFailed(runs)) process.exit(1);

--- a/apps/cli/src/bin/bench-smoke.ts
+++ b/apps/cli/src/bin/bench-smoke.ts
@@ -11,7 +11,6 @@
 // captured output); the machine-readable summary is the JSON on stdout. bun auto-loads .env, so
 // local creds in a .env file are picked up.
 import { requiredProviders, unmetRequirements } from "@sandbox-benchmarks/harness";
-import { drainRuncloudBackgroundWork } from "@sandbox-benchmarks/providers";
 import { anyFailed, forEachProviderWithCreds } from "../lib/providers-run.ts";
 import { bootAndSmoke, logChecks, smokeFailureReason, smokeOk } from "../lib/smoke-run.ts";
 
@@ -45,13 +44,7 @@ if (import.meta.main) {
 		...(run.durationMs !== undefined ? { durationMs: run.durationMs } : {}),
 		...(run.value && run.value.checks.length > 0 ? { checks: run.value.checks } : {}),
 	}));
-	try {
-		console.log(JSON.stringify({ summary }, null, 2));
-	} finally {
-		// A timed-out run.cloud create can return a handle during teardown. Output/reporting failures and
-		// the explicit exits below must not terminate cleanup while the sandbox is still being destroyed.
-		await drainRuncloudBackgroundWork();
-	}
+	console.log(JSON.stringify({ summary }, null, 2));
 
 	// Skips never fail the run; only a provider that ran and broke does.
 	if (anyFailed(runs)) process.exit(1);

--- a/apps/cli/src/bin/bench-suite.ts
+++ b/apps/cli/src/bin/bench-suite.ts
@@ -21,7 +21,6 @@ import {
 	SuiteUsageError,
 	unmetRequirements,
 } from "@sandbox-benchmarks/harness";
-import { drainRuncloudBackgroundWork } from "@sandbox-benchmarks/providers";
 import { writeNormalizedRun } from "@sandbox-benchmarks/results";
 import type { Run, SuiteName } from "@sandbox-benchmarks/schema";
 import {
@@ -791,24 +790,18 @@ if (import.meta.main) {
 			...(singleReplicate !== undefined ? { replicateIndex: singleReplicate } : {}),
 			required,
 		});
-		try {
-			await reportCell({
-				provider,
-				suite,
-				runId,
-				sha,
-				outFile: outcome.outFile,
-				...(outcome.run ? { run: outcome.run } : {}),
-				failed: outcome.failed,
-				durationMs: outcome.durationMs,
-				...(outcome.detail !== undefined ? { detail: outcome.detail } : {}),
-				...(taskPlan ? { taskPlan } : {}),
-			});
-		} finally {
-			// run.cloud may still be destroying an allocation whose create response lost a deadline race.
-			// A failed summary write must not bypass that work on its way out of the process.
-			await drainRuncloudBackgroundWork();
-		}
+		await reportCell({
+			provider,
+			suite,
+			runId,
+			sha,
+			outFile: outcome.outFile,
+			...(outcome.run ? { run: outcome.run } : {}),
+			failed: outcome.failed,
+			durationMs: outcome.durationMs,
+			...(outcome.detail !== undefined ? { detail: outcome.detail } : {}),
+			...(taskPlan ? { taskPlan } : {}),
+		});
 		if (outcome.failed) fail(outcome.detail ?? `Cell ${cell} failed`, { annotate: false });
 		process.exit(0);
 	}
@@ -875,19 +868,14 @@ if (import.meta.main) {
 		}),
 	);
 
-	try {
-		await reportFleet({
-			provider,
-			suite,
-			runId,
-			sha,
-			outcomes,
-			...(taskPlan ? { taskPlan } : {}),
-		});
-	} finally {
-		// See the single-sandbox path above. This is a no-op unless run.cloud retained a late response.
-		await drainRuncloudBackgroundWork();
-	}
+	await reportFleet({
+		provider,
+		suite,
+		runId,
+		sha,
+		outcomes,
+		...(taskPlan ? { taskPlan } : {}),
+	});
 
 	const failures = outcomes.filter((o) => o.failed);
 	if (failures.length > 0) {

--- a/packages/providers/src/index.ts
+++ b/packages/providers/src/index.ts
@@ -20,7 +20,6 @@ export { microsandboxCloudCompute, microsandboxLocalCompute } from "./lib/micros
 // Novita's E2B-compat surface: the pinned regional domain + connection the bake pipeline reuses,
 // and the compat factory (exported for tests and for anyone driving Novita outside the harness join).
 export { NOVITA_E2B_DOMAIN, novitaCompute, novitaConnection } from "./lib/novita.ts";
-export { drainRuncloudBackgroundWork } from "./lib/runcloud.ts";
 export type { DirectProvider, ProviderAdapter, ProviderConfig } from "./lib/types.ts";
 
 /**

--- a/packages/providers/src/lib/runcloud.test.ts
+++ b/packages/providers/src/lib/runcloud.test.ts
@@ -405,6 +405,34 @@ describe("run.cloud ComputeSDK adapter", () => {
 		}
 	});
 
+	it("keeps the recovery name when a conflict's reconciliation never answers", async () => {
+		let requestedName: string | undefined;
+		let listCalls = 0;
+		const client = nativeClient({
+			create: async (input) => {
+				requestedName = input?.name;
+				throw new RunCloudError(409, "idempotency key already in use");
+			},
+			list: async () => {
+				listCalls++;
+				throw new Error("control plane unavailable");
+			},
+		});
+
+		const create = runcloudCompute({
+			client,
+			reconcileAttempts: 3,
+			reconcileRetryMs: 0,
+			sleep: async () => {},
+		}).sandbox.create();
+
+		// A conflict asserts that something already exists, so it is the last error whose unanswered
+		// lookup may be written off as "nothing was allocated" — it gets the full window, not one pass.
+		await expect(create).rejects.toThrow(/unknown whether a sandbox was allocated/);
+		await expect(create).rejects.toThrow(new RegExp(requestedName ?? "unset"));
+		expect(listCalls).toBe(3);
+	});
+
 	it("adopts an allocation that a conflict response was hiding", async () => {
 		let requestedName: string | undefined;
 		const client = nativeClient({

--- a/packages/providers/src/lib/runcloud.test.ts
+++ b/packages/providers/src/lib/runcloud.test.ts
@@ -71,7 +71,7 @@ describe("run.cloud ComputeSDK adapter", () => {
 
 		expect(sandbox.sandboxId).toBe("sb-test");
 		expect(createInput).toEqual({
-			idempotencyKey: expect.stringMatching(/^sandbox-benchmarks-[0-9a-f-]+$/),
+			idempotencyKey: expect.stringMatching(/^benchmark-[0-9a-f-]+$/),
 			image: "ghcr.io/starslingdev/toolchain:candidate",
 			cpu: 4,
 			memory: 8_192,
@@ -83,6 +83,8 @@ describe("run.cloud ComputeSDK adapter", () => {
 			// recovery handle a later lookup can resolve to exactly one allocation.
 			name: expect.stringMatching(/^benchmark-[0-9a-f-]+$/),
 		});
+		// One identifier for both, so control-plane logs correlate the request with the allocation.
+		expect(createInput?.idempotencyKey).toBe(createInput?.name);
 		expect(destroyCalls).toBe(0);
 	});
 
@@ -346,6 +348,61 @@ describe("run.cloud ComputeSDK adapter", () => {
 		// A 4xx says no allocation was accepted, so this does not spend the full polling window — but it
 		// still asks once, because a conflict response can sit on top of a real allocation.
 		expect(listCalls).toBe(1);
+	});
+
+	it("reports the recovery name when no reconciliation lookup ever answered", async () => {
+		let requestedName: string | undefined;
+		let listCalls = 0;
+		const client = nativeClient({
+			create: async (input) => {
+				requestedName = input?.name;
+				throw new RunCloudError(503, "response lost after allocation");
+			},
+			list: async () => {
+				listCalls++;
+				throw new Error("control plane unavailable");
+			},
+		});
+
+		const create = runcloudCompute({
+			client,
+			reconcileAttempts: 3,
+			reconcileRetryMs: 0,
+			sleep: async () => {},
+		}).sandbox.create();
+
+		// The overload that made the create ambiguous took `list` down with it, so absence was never
+		// established. Reporting this as "nothing was allocated" is the guess that strands a sandbox.
+		await expect(create).rejects.toThrow(/unknown whether a sandbox was allocated/);
+		await expect(create).rejects.toThrow(/manual cleanup/);
+		expect(listCalls).toBe(3);
+		// The name is the handle an operator (or an account-wide sweep) needs to find the allocation.
+		await expect(create).rejects.toThrow(new RegExp(requestedName ?? "unset"));
+	});
+
+	it("does not put a definitive 4xx back in doubt when its confirming lookup fails", async () => {
+		const clientError = new RunCloudError(422, "invalid image");
+		const client = nativeClient({
+			create: async () => {
+				throw clientError;
+			},
+			list: async () => {
+				throw new Error("control plane unavailable");
+			},
+		});
+
+		try {
+			await runcloudCompute({
+				client,
+				reconcileRetryMs: 0,
+				sleep: async () => {},
+			}).sandbox.create();
+			expect.unreachable();
+		} catch (error) {
+			// The create endpoint itself supplied the rejection, so an unanswered lookup adds no doubt —
+			// and the harness's capacity retry still sees the original error rather than an AggregateError.
+			expect(error).toBe(clientError);
+		}
 	});
 
 	it("adopts an allocation that a conflict response was hiding", async () => {

--- a/packages/providers/src/lib/runcloud.test.ts
+++ b/packages/providers/src/lib/runcloud.test.ts
@@ -1,7 +1,7 @@
-import { describe, expect, it, spyOn } from "bun:test";
+import { describe, expect, it } from "bun:test";
 import type { ExecOptions, Sandbox, SandboxState } from "@run-cloud/sdk";
 import { RunCloudError } from "@run-cloud/sdk";
-import { drainRuncloudBackgroundWork, runcloudCompute, sandboxMethods } from "./runcloud.ts";
+import { runcloudCompute, sandboxMethods } from "./runcloud.ts";
 
 type ComputeOptions = NonNullable<Parameters<typeof runcloudCompute>[0]>;
 type NativeClient = NonNullable<ComputeOptions["client"]>;
@@ -79,7 +79,9 @@ describe("run.cloud ComputeSDK adapter", () => {
 			idlePauseSeconds: 10_800,
 			timeoutSeconds: 10_800,
 			region: "us-west",
-			name: "benchmark",
+			// A caller-supplied name is kept as a readable prefix; the unique suffix is what makes it a
+			// recovery handle a later lookup can resolve to exactly one allocation.
+			name: expect.stringMatching(/^benchmark-[0-9a-f-]+$/),
 		});
 		expect(destroyCalls).toBe(0);
 	});
@@ -194,167 +196,235 @@ describe("run.cloud ComputeSDK adapter", () => {
 		expect(getCalls).toBe(3);
 	});
 
-	it("recovers and destroys an allocation whose create response timed out", async () => {
-		const idempotencyKeys: Array<string | undefined> = [];
-		const destroyed: string[] = [];
+	it("adopts the allocation when the create response is lost", async () => {
 		let createCalls = 0;
+		let requestedName: string | undefined;
+		const listedNames: Array<string | undefined> = [];
+		const destroyed: string[] = [];
 		const client = nativeClient({
 			create: (input) => {
 				createCalls++;
-				idempotencyKeys.push(input?.idempotencyKey);
-				if (createCalls === 1) return new Promise<Sandbox>(() => {});
-				return Promise.resolve(nativeSandbox("building_image"));
+				requestedName = input?.name;
+				// The control plane allocated the sandbox; only the response never came back.
+				return new Promise<Sandbox>(() => {});
+			},
+			list: async (options) => {
+				listedNames.push(options?.name);
+				return [nativeSandbox("running", { name: requestedName })];
 			},
 			destroy: async (id) => {
 				destroyed.push(id);
 			},
 		});
 
-		await expect(
-			runcloudCompute({
-				client,
-				controlPlaneTimeoutMs: 5,
-				createRecoveryAttempts: 1,
-				cleanupAttempts: 1,
-			}).sandbox.create(),
-		).rejects.toThrow("run.cloud create did not settle within 5ms");
-		expect(createCalls).toBe(2);
-		expect(idempotencyKeys[0]).toBeDefined();
-		expect(idempotencyKeys[1]).toBe(idempotencyKeys[0]);
-		expect(destroyed).toEqual(["sb-test"]);
+		const sandbox = await runcloudCompute({
+			client,
+			controlPlaneTimeoutMs: 5,
+			readyPollMs: 0,
+			sleep: async () => {},
+		}).sandbox.create();
+
+		expect(sandbox.sandboxId).toBe("sb-test");
+		// Recovery is a READ: replaying the create POST is what could allocate a second sandbox.
+		expect(createCalls).toBe(1);
+		expect(listedNames).toEqual([requestedName]);
+		// Adopted rather than torn down — the sandbox is healthy, so destroying it to honour a lost
+		// HTTP response would throw away the allocation and fail the cell for no reason.
+		expect(destroyed).toEqual([]);
 	});
 
-	it("recovers and destroys after an ambiguous create 5xx", async () => {
-		const initialError = new RunCloudError(503, "response lost after allocation");
-		const idempotencyKeys: Array<string | undefined> = [];
+	it("adopts the allocation after an ambiguous create 5xx", async () => {
+		let requestedName: string | undefined;
 		const destroyed: string[] = [];
-		let createCalls = 0;
 		const client = nativeClient({
 			create: async (input) => {
-				createCalls++;
-				idempotencyKeys.push(input?.idempotencyKey);
-				if (createCalls === 1) throw initialError;
-				return nativeSandbox("building_image");
+				requestedName = input?.name;
+				throw new RunCloudError(503, "response lost after allocation");
 			},
+			list: async () => [nativeSandbox("running", { name: requestedName })],
 			destroy: async (id) => {
 				destroyed.push(id);
+			},
+		});
+
+		const sandbox = await runcloudCompute({
+			client,
+			readyPollMs: 0,
+			sleep: async () => {},
+		}).sandbox.create();
+
+		expect(sandbox.sandboxId).toBe("sb-test");
+		expect(destroyed).toEqual([]);
+	});
+
+	it("rethrows the original error once reconciliation proves nothing was allocated", async () => {
+		let createCalls = 0;
+		let listCalls = 0;
+		const client = nativeClient({
+			create: () => {
+				createCalls++;
+				return new Promise<Sandbox>(() => {});
+			},
+			list: async () => {
+				listCalls++;
+				return [];
+			},
+		});
+
+		const create = runcloudCompute({
+			client,
+			controlPlaneTimeoutMs: 5,
+			reconcileAttempts: 3,
+			reconcileRetryMs: 0,
+			sleep: async () => {},
+		}).sandbox.create();
+
+		await expect(create).rejects.toThrow("run.cloud create did not settle within 5ms");
+		// Nothing carries the name, so nothing leaked — the caller gets the plain original error rather
+		// than a manual-cleanup warning it can do nothing about.
+		await expect(create).rejects.not.toThrow(/manual cleanup/);
+		expect(createCalls).toBe(1);
+		expect(listCalls).toBe(3);
+	});
+
+	it("keeps asking when a reconciliation lookup fails or the allocation is not yet visible", async () => {
+		let requestedName: string | undefined;
+		let listCalls = 0;
+		const client = nativeClient({
+			create: async (input) => {
+				requestedName = input?.name;
+				throw new RunCloudError(503, "response lost after allocation");
+			},
+			list: async () => {
+				listCalls++;
+				// A lookup that fails is not proof of absence, and an allocation can take a moment to
+				// become visible. Either one, taken as "nothing was allocated", strands a sandbox.
+				if (listCalls === 1) throw new Error("control plane unavailable");
+				if (listCalls === 2) return [];
+				return [nativeSandbox("running", { name: requestedName })];
+			},
+		});
+
+		const sandbox = await runcloudCompute({
+			client,
+			readyPollMs: 0,
+			reconcileAttempts: 4,
+			reconcileRetryMs: 0,
+			sleep: async () => {},
+		}).sandbox.create();
+
+		expect(sandbox.sandboxId).toBe("sb-test");
+		expect(listCalls).toBe(3);
+	});
+
+	it("confirms a definitive 4xx with one reconciliation pass, then rethrows", async () => {
+		const clientError = new RunCloudError(422, "invalid image");
+		let createCalls = 0;
+		let listCalls = 0;
+		const client = nativeClient({
+			create: async () => {
+				createCalls++;
+				throw clientError;
+			},
+			list: async () => {
+				listCalls++;
+				return [];
 			},
 		});
 
 		try {
 			await runcloudCompute({
 				client,
-				createRecoveryAttempts: 1,
-				cleanupAttempts: 1,
+				reconcileRetryMs: 0,
+				sleep: async () => {},
 			}).sandbox.create();
-			expect.unreachable();
-		} catch (error) {
-			expect(error).toBe(initialError);
-		}
-		expect(createCalls).toBe(2);
-		expect(idempotencyKeys[1]).toBe(idempotencyKeys[0]);
-		expect(destroyed).toEqual(["sb-test"]);
-	});
-
-	it("rethrows definitive create 4xx responses without replaying", async () => {
-		const clientError = new RunCloudError(422, "invalid image");
-		let createCalls = 0;
-		const client = nativeClient({
-			create: async () => {
-				createCalls++;
-				throw clientError;
-			},
-		});
-
-		try {
-			await runcloudCompute({ client }).sandbox.create();
 			expect.unreachable();
 		} catch (error) {
 			expect(error).toBe(clientError);
 		}
 		expect(createCalls).toBe(1);
+		// A 4xx says no allocation was accepted, so this does not spend the full polling window — but it
+		// still asks once, because a conflict response can sit on top of a real allocation.
+		expect(listCalls).toBe(1);
 	});
 
-	it("fails within bounded recovery attempts when a timed-out create cannot be recovered", async () => {
-		const idempotencyKeys: Array<string | undefined> = [];
-		const rejectAttempts: Array<(error: Error) => void> = [];
+	it("adopts an allocation that a conflict response was hiding", async () => {
+		let requestedName: string | undefined;
 		const client = nativeClient({
-			create: (input) => {
-				idempotencyKeys.push(input?.idempotencyKey);
-				return new Promise<Sandbox>((_resolve, reject) => {
-					rejectAttempts.push(reject);
-				});
+			create: async (input) => {
+				requestedName = input?.name;
+				throw new RunCloudError(409, "idempotency key already in use");
+			},
+			list: async () => [nativeSandbox("running", { name: requestedName })],
+		});
+
+		const sandbox = await runcloudCompute({
+			client,
+			readyPollMs: 0,
+			sleep: async () => {},
+		}).sandbox.create();
+
+		expect(sandbox.sandboxId).toBe("sb-test");
+	});
+
+	it("ignores tombstones and other callers' sandboxes when reconciling", async () => {
+		let requestedName: string | undefined;
+		let listCalls = 0;
+		const client = nativeClient({
+			create: async (input) => {
+				requestedName = input?.name;
+				throw new RunCloudError(503, "response lost after allocation");
+			},
+			list: async () => {
+				listCalls++;
+				return [
+					nativeSandbox("destroyed", { id: "sb-tombstone", name: requestedName }),
+					nativeSandbox("destroying", { id: "sb-going", name: requestedName }),
+					// Guards against a server-side prefix/fuzzy name match.
+					nativeSandbox("running", { id: "sb-other", name: `${requestedName}-different` }),
+				];
 			},
 		});
 
 		await expect(
 			runcloudCompute({
 				client,
-				controlPlaneTimeoutMs: 5,
-				createRecoveryAttempts: 2,
-				cleanupAttempts: 1,
-				cleanupRetryMs: 0,
+				reconcileAttempts: 2,
+				reconcileRetryMs: 0,
 				sleep: async () => {},
 			}).sandbox.create(),
-		).rejects.toThrow(
-			/idempotent allocation could not be recovered; manual cleanup may be required/,
-		);
-		expect(idempotencyKeys).toHaveLength(3);
-		expect(new Set(idempotencyKeys).size).toBe(1);
-		const consoleError = spyOn(console, "error").mockImplementation(() => {});
-		try {
-			await drainRuncloudBackgroundWork();
-			expect(consoleError).toHaveBeenCalledWith(
-				expect.stringContaining("late-create cleanup task(s) unfinished"),
-			);
-		} finally {
-			consoleError.mockRestore();
-		}
-		// Let the retained Promise.any settle after proving the drain is bounded, so this deliberately
-		// hung fake cannot pollute later assertions. Real SDK fetches reject through the abort signal.
-		for (const reject of rejectAttempts) reject(new Error("test request cancelled"));
-		await drainRuncloudBackgroundWork();
+		).rejects.toThrow("response lost after allocation");
+		expect(listCalls).toBe(2);
 	});
 
-	it("drains cleanup for a create response that arrives after recovery exhaustion", async () => {
-		let resolveInitial: ((sandbox: Sandbox) => void) | undefined;
-		let createCalls = 0;
-		const destroyed: string[] = [];
+	it("adopts the oldest match so a duplicate allocation cannot orphan the original", async () => {
+		let requestedName: string | undefined;
 		const client = nativeClient({
-			create: () => {
-				createCalls++;
-				if (createCalls === 1) {
-					return new Promise<Sandbox>((resolve) => {
-						resolveInitial = resolve;
-					});
-				}
-				return new Promise<Sandbox>(() => {});
+			create: async (input) => {
+				requestedName = input?.name;
+				throw new RunCloudError(503, "response lost after allocation");
 			},
-			destroy: async (id) => {
-				destroyed.push(id);
-			},
+			list: async () => [
+				nativeSandbox("running", {
+					id: "sb-newer",
+					name: requestedName,
+					createdAt: "2026-08-03T00:00:05.000Z",
+				}),
+				nativeSandbox("running", {
+					id: "sb-older",
+					name: requestedName,
+					createdAt: "2026-08-03T00:00:00.000Z",
+				}),
+			],
 		});
 
-		await expect(
-			runcloudCompute({
-				client,
-				controlPlaneTimeoutMs: 5,
-				createRecoveryAttempts: 1,
-				cleanupAttempts: 1,
-			}).sandbox.create(),
-		).rejects.toThrow(/idempotent allocation could not be recovered/);
-		expect(destroyed).toEqual([]);
-		expect(resolveInitial).toBeDefined();
-		let drained = false;
-		const drain = drainRuncloudBackgroundWork().then(() => {
-			drained = true;
-		});
-		await new Promise((resolve) => setTimeout(resolve, 1));
-		expect(drained).toBe(false);
-		resolveInitial?.(nativeSandbox("building_image"));
-		await drain;
-		expect(destroyed).toEqual(["sb-test"]);
-		expect(drained).toBe(true);
+		const sandbox = await runcloudCompute({
+			client,
+			readyPollMs: 0,
+			sleep: async () => {},
+		}).sandbox.create();
+
+		expect(sandbox.sandboxId).toBe("sb-older");
 	});
 
 	it("retries a transient failed-create cleanup before preserving the readiness error", async () => {

--- a/packages/providers/src/lib/runcloud.ts
+++ b/packages/providers/src/lib/runcloud.ts
@@ -251,22 +251,32 @@ async function cleanupFailedCreate(
  * sandbox, it needs no cooperation from an overloaded create endpoint, and it answers the only question
  * that matters — does an allocation carrying this name exist?
  *
- * Returns the allocation, or null once the window closes having found none. A lookup that itself fails
- * is not proof of absence, so it costs an attempt rather than ending the search: concluding "nothing was
- * allocated" is what strands a billable sandbox, and that conclusion has to be earned.
+ * A lookup that itself fails is not proof of absence, so it costs an attempt rather than ending the
+ * search: concluding "nothing was allocated" is what strands a billable sandbox, and that conclusion
+ * has to be earned. It is earned only by a lookup that actually answered, which is why exhausting the
+ * window without a single answer reports `unanswered` rather than `absent`. The overload that makes a
+ * create ambiguous is the same overload that can take `list` down with it, so collapsing those two
+ * outcomes would silently reinstate the guess this whole design exists to remove.
  */
+type ReconcileOutcome =
+	| { status: "adopted"; sandbox: Sandbox }
+	| { status: "absent" }
+	| { status: "unanswered"; lastError: unknown };
+
 async function reconcileAmbiguousCreate(
 	native: RuncloudSandboxClient,
 	name: string,
 	options: RuncloudComputeOptions,
 	attemptOverride?: number,
-): Promise<Sandbox | null> {
+): Promise<ReconcileOutcome> {
 	const attempts = Math.max(
 		1,
 		Math.floor(attemptOverride ?? options.reconcileAttempts ?? CREATE_RECONCILE_ATTEMPTS),
 	);
 	const retryMs = Math.max(0, options.reconcileRetryMs ?? CREATE_RECONCILE_RETRY_MS);
 	const wait = options.sleep ?? sleep;
+	let answered = false;
+	let lastError: unknown;
 	for (let attempt = 1; attempt <= attempts; attempt++) {
 		try {
 			const matches = (
@@ -277,18 +287,22 @@ async function reconcileAmbiguousCreate(
 				(sandbox) =>
 					sandbox.name === name && sandbox.state !== "destroyed" && sandbox.state !== "destroying",
 			);
+			// The control plane answered, so a later empty window is a real "nothing was allocated"
+			// rather than an unanswered question wearing the same shape.
+			answered = true;
 			// One unique name per create call, so a second match would mean the server allocated twice.
 			// Prefer the oldest: adopting the later one would orphan the original.
 			const [oldest] = matches.sort(
 				(a, b) => createdAt(a.createdAt).getTime() - createdAt(b.createdAt).getTime(),
 			);
-			if (oldest) return oldest;
-		} catch {
+			if (oldest) return { status: "adopted", sandbox: oldest };
+		} catch (error) {
 			// Swallowed deliberately — see the doc comment. The next attempt re-asks.
+			lastError = error;
 		}
 		if (attempt < attempts) await wait(retryMs);
 	}
-	return null;
+	return answered ? { status: "absent" } : { status: "unanswered", lastError };
 }
 
 function errorMessage(error: unknown): string {
@@ -366,7 +380,9 @@ export function sandboxMethods(
 			// cannot turn one logical create into two allocations.
 			const recoveryName = `${createOptions?.name ?? RECOVERY_NAME_PREFIX}-${randomUUID()}`;
 			const createInput = {
-				idempotencyKey: `${RECOVERY_NAME_PREFIX}-${randomUUID()}`,
+				// Same string as the name, so one identifier locates both the request and the allocation
+				// in control-plane logs when an ambiguous create has to be investigated after the fact.
+				idempotencyKey: recoveryName,
 				name: recoveryName,
 				...(createOptions?.templateId || createOptions?.image
 					? { image: createOptions.templateId ?? createOptions.image }
@@ -389,19 +405,35 @@ export function sandboxMethods(
 				// Ask what the request actually did rather than assuming. A definitive 4xx says no
 				// allocation was accepted, so one confirming pass is enough — but it is not skipped
 				// outright, because a conflict response can still sit on top of a real allocation.
-				const recovered = await reconcileAmbiguousCreate(
+				const definitive = isDefinitiveCreateFailure(error);
+				const reconciled = await reconcileAmbiguousCreate(
 					sdk,
 					recoveryName,
 					adapterOptions,
-					isDefinitiveCreateFailure(error) ? 1 : undefined,
+					definitive ? 1 : undefined,
 				);
 				// Nothing carries this name, so nothing was allocated and there is nothing to leak. The
 				// original error is the whole truth — report it without a spurious cleanup warning.
-				if (!recovered) throw error;
+				if (reconciled.status === "absent") throw error;
+				// The create was ambiguous AND the control plane never answered what it did with it, so
+				// absence was never established. Say so and name the recovery handle: the name is stamped
+				// before the request precisely so a sandbox that outlived this window is still findable.
+				// A definitive 4xx is exempt — there the create endpoint itself supplied the rejection, so
+				// an unanswered confirming lookup does not put a rejected request back in doubt.
+				if (reconciled.status === "unanswered" && !definitive) {
+					throw new AggregateError(
+						[error, reconciled.lastError],
+						`run.cloud create failed ambiguously (${errorMessage(error)}) and every reconciliation ` +
+							`lookup also failed (${errorMessage(reconciled.lastError)}), so it is unknown whether a ` +
+							`sandbox was allocated; if one was it carries the name ${recoveryName} and manual ` +
+							`cleanup may be required`,
+					);
+				}
+				if (reconciled.status !== "adopted") throw error;
 				// An allocation exists. The create SUCCEEDED and only its response was lost, so adopt it:
 				// destroying a healthy sandbox to honour a lost HTTP response would throw away the work and
 				// fail the cell for no reason. Readiness below still gates whether it is usable.
-				created = recovered;
+				created = reconciled.sandbox;
 			}
 			// Do not return until the guest can accept commands — cold image pulls leave the sandbox in
 			// `building_image` for minutes, and exec during that window fails with API 4409.

--- a/packages/providers/src/lib/runcloud.ts
+++ b/packages/providers/src/lib/runcloud.ts
@@ -86,15 +86,21 @@ class NativeCallTimeoutError extends Error {
 	}
 }
 
-/** A non-timeout 4xx is a definitive rejection: no allocation was accepted. Reconciliation still runs
- * (a conflict response can sit on top of a real allocation) but settles for a single confirming pass
- * rather than the full polling window, so a 429 still reaches the harness's capacity retry promptly. */
+/** A non-timeout 4xx is a definitive rejection: the create endpoint itself said no allocation was
+ * accepted. Reconciliation still runs, but settles for a single confirming pass rather than the full
+ * polling window, so a 429 still reaches the harness's capacity retry promptly.
+ *
+ * 409 is excluded, because a conflict asserts the OPPOSITE of absence: something already exists under
+ * this request's identity. Treating it as a definitive rejection would let an unanswered lookup be
+ * written off as "nothing was allocated" on the one status code that says otherwise. It gets the full
+ * window and stays subject to the unanswered report. */
 function isDefinitiveCreateFailure(error: unknown): boolean {
 	return (
 		error instanceof RunCloudError &&
 		error.status >= 400 &&
 		error.status < 500 &&
-		error.status !== 408
+		error.status !== 408 &&
+		error.status !== 409
 	);
 }
 
@@ -404,7 +410,8 @@ export function sandboxMethods(
 			} catch (error) {
 				// Ask what the request actually did rather than assuming. A definitive 4xx says no
 				// allocation was accepted, so one confirming pass is enough — but it is not skipped
-				// outright, because a conflict response can still sit on top of a real allocation.
+				// outright, because even a rejection can sit on top of a real allocation. A 409 is not
+				// definitive at all (see isDefinitiveCreateFailure) and gets the full window.
 				const definitive = isDefinitiveCreateFailure(error);
 				const reconciled = await reconcileAmbiguousCreate(
 					sdk,
@@ -419,7 +426,8 @@ export function sandboxMethods(
 				// absence was never established. Say so and name the recovery handle: the name is stamped
 				// before the request precisely so a sandbox that outlived this window is still findable.
 				// A definitive 4xx is exempt — there the create endpoint itself supplied the rejection, so
-				// an unanswered confirming lookup does not put a rejected request back in doubt.
+				// an unanswered confirming lookup does not put a rejected request back in doubt. A 409 is
+				// deliberately not in that set: it is the one status that asserts something exists.
 				if (reconciled.status === "unanswered" && !definitive) {
 					throw new AggregateError(
 						[error, reconciled.lastError],

--- a/packages/providers/src/lib/runcloud.ts
+++ b/packages/providers/src/lib/runcloud.ts
@@ -28,9 +28,16 @@ const CREATE_FAILURE_CLEANUP_RETRY_MS = 2_000;
 /** Bound each REST control-plane call independently. The adapter owns the longer readiness window,
  * but a fetch that never settles must not suspend its deadline check or failed-create cleanup. */
 const CONTROL_PLANE_REQUEST_TIMEOUT_MS = 30_000;
-/** A timed-out, transport-failed, or 5xx create response is ambiguous: the server may have allocated
- * the sandbox. Retry the same idempotent request to recover its handle before returning. */
-const CREATE_RECOVERY_ATTEMPTS = 3;
+/** Prefix for the caller-owned `name` stamped on every create. The name is the RECOVERY HANDLE: it is
+ * chosen locally before the request, so a create whose response is lost still leaves an allocation the
+ * control plane can be QUERIED for by name. It also makes a benchmark sandbox identifiable in the
+ * dashboard and to any account-wide sweep. */
+const RECOVERY_NAME_PREFIX = "sandbox-benchmarks";
+/** An allocation can take a moment to become visible to `list()`, so an ambiguous create polls before
+ * concluding that nothing was allocated. Observed visibility is well under a second; this window is
+ * deliberately generous because guessing "nothing was allocated" too early is what leaks a sandbox. */
+const CREATE_RECONCILE_ATTEMPTS = 5;
+const CREATE_RECONCILE_RETRY_MS = 2_000;
 
 type RuncloudSandboxClient = Pick<
 	Client["sandboxes"],
@@ -45,23 +52,13 @@ interface RuncloudComputeOptions {
 	cleanupAttempts?: number;
 	cleanupRetryMs?: number;
 	controlPlaneTimeoutMs?: number;
-	createRecoveryAttempts?: number;
+	reconcileAttempts?: number;
+	reconcileRetryMs?: number;
 	sleep?: (ms: number) => Promise<void>;
 	now?: () => number;
 }
 
 let cachedClient: Client | undefined;
-
-// A create response can arrive after every local deadline has expired. Keep that final cleanup
-// visible to the benchmark entrypoints: they intentionally use process.exit(), which otherwise
-// terminates promise continuations even while a billable sandbox is being destroyed.
-interface PendingLateCreateCleanup {
-	promise: Promise<void>;
-	/** Wall-clock ceiling covering one late response plus the complete cleanup retry sequence. */
-	deadline: number;
-}
-
-const pendingLateCreateCleanups = new Set<PendingLateCreateCleanup>();
 
 const controlPlaneFetch: typeof fetch = Object.assign(
 	(...args: Parameters<typeof fetch>) =>
@@ -89,8 +86,9 @@ class NativeCallTimeoutError extends Error {
 	}
 }
 
-/** A non-timeout 4xx is a definitive rejection: no allocation was accepted, and replaying it would
- * only delay the real error (especially 429, which the harness recognizes for capacity retries). */
+/** A non-timeout 4xx is a definitive rejection: no allocation was accepted. Reconciliation still runs
+ * (a conflict response can sit on top of a real allocation) but settles for a single confirming pass
+ * rather than the full polling window, so a 429 still reaches the harness's capacity retry promptly. */
 function isDefinitiveCreateFailure(error: unknown): boolean {
 	return (
 		error instanceof RunCloudError &&
@@ -248,121 +246,49 @@ async function cleanupFailedCreate(
 }
 
 /**
- * Recover the handle for an ambiguous create failure by replaying the SAME idempotent request. The
- * original promise participates too: if its delayed response arrives during recovery, its sandbox is
- * cleaned up without waiting for another API response. Every recovery attempt has its own deadline.
+ * Resolve what a failed create actually DID, by querying the control plane for the caller-owned name
+ * stamped on the request. This is a read: unlike replaying the create POST it cannot allocate a second
+ * sandbox, it needs no cooperation from an overloaded create endpoint, and it answers the only question
+ * that matters — does an allocation carrying this name exist?
+ *
+ * Returns the allocation, or null once the window closes having found none. A lookup that itself fails
+ * is not proof of absence, so it costs an attempt rather than ending the search: concluding "nothing was
+ * allocated" is what strands a billable sandbox, and that conclusion has to be earned.
  */
-async function recoverAmbiguousCreate(
+async function reconcileAmbiguousCreate(
 	native: RuncloudSandboxClient,
-	createInput: NonNullable<Parameters<RuncloudSandboxClient["create"]>[0]>,
-	createAttempts: Promise<Sandbox>[],
+	name: string,
 	options: RuncloudComputeOptions,
-): Promise<Sandbox> {
+	attemptOverride?: number,
+): Promise<Sandbox | null> {
 	const attempts = Math.max(
 		1,
-		Math.floor(options.createRecoveryAttempts ?? CREATE_RECOVERY_ATTEMPTS),
+		Math.floor(attemptOverride ?? options.reconcileAttempts ?? CREATE_RECONCILE_ATTEMPTS),
 	);
-	const retryMs = Math.max(0, options.cleanupRetryMs ?? CREATE_FAILURE_CLEANUP_RETRY_MS);
+	const retryMs = Math.max(0, options.reconcileRetryMs ?? CREATE_RECONCILE_RETRY_MS);
 	const wait = options.sleep ?? sleep;
-	let lastError: unknown;
 	for (let attempt = 1; attempt <= attempts; attempt++) {
 		try {
-			// Retain every issued promise. A previous attempt may resolve during a later recovery window,
-			// and all of them need cleanup continuations if every bounded window ultimately expires.
-			createAttempts.push(Promise.resolve().then(() => native.create(createInput)));
-			return await boundedNativeCall(
-				`create recovery attempt ${attempt}`,
-				() => Promise.any(createAttempts),
-				options,
+			const matches = (
+				await boundedNativeCall(`reconcile create ${name}`, () => native.list({ name }), options)
+			).filter(
+				// Defend against a server-side prefix/fuzzy match: only an exact name is this create's
+				// allocation. Tombstones are not something to adopt or clean up.
+				(sandbox) =>
+					sandbox.name === name && sandbox.state !== "destroyed" && sandbox.state !== "destroying",
 			);
-		} catch (error) {
-			lastError = error;
-			if (attempt < attempts) await wait(retryMs);
+			// One unique name per create call, so a second match would mean the server allocated twice.
+			// Prefer the oldest: adopting the later one would orphan the original.
+			const [oldest] = matches.sort(
+				(a, b) => createdAt(a.createdAt).getTime() - createdAt(b.createdAt).getTime(),
+			);
+			if (oldest) return oldest;
+		} catch {
+			// Swallowed deliberately — see the doc comment. The next attempt re-asks.
 		}
+		if (attempt < attempts) await wait(retryMs);
 	}
-	throw lastError;
-}
-
-/**
- * Last-resort cleanup for a client/runtime that ignores abort and returns a create response only after
- * every bounded recovery window expired. Production fetches are actively aborted, so they settle
- * before this point; retaining these continuations prevents an injected/alternate client from
- * discarding a late sandbox handle. The idempotency key means every response names the same sandbox,
- * so the first fulfilled attempt identifies the one allocation that needs cleanup.
- */
-function retainLateCreateCleanup(
-	native: RuncloudSandboxClient,
-	createAttempts: readonly Promise<Sandbox>[],
-	options: RuncloudComputeOptions,
-): void {
-	// Every replay uses one idempotency key, so the first successful response identifies the sole
-	// allocation. Promise.any also stays pending while a transport-ignoring attempt might still return.
-	const cleanup = Promise.any(createAttempts).then(
-		async (late) => {
-			try {
-				await cleanupFailedCreate(native, late.id, options);
-			} catch (error) {
-				console.error(
-					`run.cloud late create returned sandbox ${late.id}, but cleanup failed ` +
-						`(${errorMessage(error)}); manual cleanup may be required`,
-				);
-			}
-		},
-		() => {},
-	);
-	const controlPlaneTimeoutMs = Math.max(
-		1,
-		Math.floor(options.controlPlaneTimeoutMs ?? CONTROL_PLANE_REQUEST_TIMEOUT_MS),
-	);
-	const cleanupAttempts = Math.max(
-		1,
-		Math.floor(options.cleanupAttempts ?? CREATE_FAILURE_CLEANUP_ATTEMPTS),
-	);
-	const cleanupRetryMs = Math.max(0, options.cleanupRetryMs ?? CREATE_FAILURE_CLEANUP_RETRY_MS);
-	// Allow one still-pending create response, then every destroy + confirmation deadline and every
-	// inter-attempt delay. Production's default is 338s; injected tests derive a correspondingly small
-	// ceiling. The task remains registered after expiry so it can still finish and unregister itself if
-	// the caller elects to keep the process alive after the warning.
-	const deadline =
-		Date.now() +
-		controlPlaneTimeoutMs +
-		cleanupAttempts * 2 * controlPlaneTimeoutMs +
-		(cleanupAttempts - 1) * cleanupRetryMs;
-	const pending = { promise: cleanup, deadline };
-	pendingLateCreateCleanups.add(pending);
-	void cleanup.finally(() => pendingLateCreateCleanups.delete(pending));
-}
-
-/**
- * Await every late-create cleanup retained by the run.cloud adapter. Benchmark bins call this before
- * their explicit process exit; production REST requests are abort-bounded, while a response that won
- * the deadline race is allowed to finish its fully awaited destroy/retry sequence.
- */
-export async function drainRuncloudBackgroundWork(): Promise<void> {
-	const startedAt = Date.now();
-	while (pendingLateCreateCleanups.size > 0) {
-		const pending = [...pendingLateCreateCleanups];
-		const deadline = Math.max(...pending.map((entry) => entry.deadline));
-		const remainingMs = Math.max(0, deadline - Date.now());
-		let timer: ReturnType<typeof setTimeout> | undefined;
-		const completed = await Promise.race([
-			Promise.all(pending.map((entry) => entry.promise)).then(() => true),
-			new Promise<false>((resolve) => {
-				timer = setTimeout(() => resolve(false), remainingMs);
-			}),
-		]).finally(() => {
-			if (timer !== undefined) clearTimeout(timer);
-		});
-		if (completed) continue;
-		// A task may have been registered with a later ceiling while the previous snapshot was waiting.
-		// Recompute before giving up so concurrent provider cells retain their own full cleanup budget.
-		if ([...pendingLateCreateCleanups].some((entry) => entry.deadline > Date.now())) continue;
-		console.error(
-			`run.cloud left ${pendingLateCreateCleanups.size} late-create cleanup task(s) unfinished ` +
-				`after ${Date.now() - startedAt}ms; manual cleanup may be required`,
-		);
-		return;
-	}
+	return null;
 }
 
 function errorMessage(error: unknown): string {
@@ -432,10 +358,16 @@ export function sandboxMethods(
 				throw new Error("run.cloud snapshots are not supported by this adapter");
 			}
 			const sdk = native();
-			// The stable key makes a timed-out response recoverable: replaying create returns the original
-			// allocation instead of creating a second sandbox, so we can await its teardown before rejecting.
+			// The name is chosen HERE, before the request, which is what makes it a recovery handle: a
+			// create whose response never arrives still leaves an allocation carrying it, so the control
+			// plane can be asked what happened instead of the answer depending on a second create response.
+			// A caller-supplied name is kept as a readable prefix; the unique suffix is what makes the
+			// later lookup unambiguous. The idempotency key remains, so an internal server-side retry
+			// cannot turn one logical create into two allocations.
+			const recoveryName = `${createOptions?.name ?? RECOVERY_NAME_PREFIX}-${randomUUID()}`;
 			const createInput = {
-				idempotencyKey: `sandbox-benchmarks-${randomUUID()}`,
+				idempotencyKey: `${RECOVERY_NAME_PREFIX}-${randomUUID()}`,
+				name: recoveryName,
 				...(createOptions?.templateId || createOptions?.image
 					? { image: createOptions.templateId ?? createOptions.image }
 					: {}),
@@ -449,43 +381,27 @@ export function sandboxMethods(
 					? { timeoutSeconds: createOptions.timeoutSeconds }
 					: {}),
 				...(createOptions?.region ? { region: createOptions.region } : {}),
-				...(createOptions?.name ? { name: createOptions.name } : {}),
 			};
-			const createPromise = Promise.resolve().then(() => sdk.create(createInput));
-			const createAttempts = [createPromise];
 			let created: Sandbox;
 			try {
-				created = await boundedNativeCall("create", () => createPromise, adapterOptions);
+				created = await boundedNativeCall("create", () => sdk.create(createInput), adapterOptions);
 			} catch (error) {
-				if (isDefinitiveCreateFailure(error)) throw error;
-				let recovered: Sandbox;
-				try {
-					recovered = await recoverAmbiguousCreate(
-						sdk,
-						createInput,
-						createAttempts,
-						adapterOptions,
-					);
-				} catch (recoveryError) {
-					retainLateCreateCleanup(sdk, createAttempts, adapterOptions);
-					throw new AggregateError(
-						[error, recoveryError],
-						`run.cloud create failed ambiguously (${errorMessage(error)}) and its idempotent ` +
-							`allocation could not be recovered; ` +
-							`manual cleanup may be required (idempotency key: ${createInput.idempotencyKey})`,
-					);
-				}
-				try {
-					await cleanupFailedCreate(sdk, recovered.id, adapterOptions);
-				} catch (cleanupError) {
-					throw new AggregateError(
-						[error, cleanupError],
-						`run.cloud create failed ambiguously (${errorMessage(error)}), recovered sandbox ` +
-							`${recovered.id}, and could not destroy it ` +
-							`after retries (${errorMessage(cleanupError)}); manual cleanup may be required`,
-					);
-				}
-				throw error;
+				// Ask what the request actually did rather than assuming. A definitive 4xx says no
+				// allocation was accepted, so one confirming pass is enough — but it is not skipped
+				// outright, because a conflict response can still sit on top of a real allocation.
+				const recovered = await reconcileAmbiguousCreate(
+					sdk,
+					recoveryName,
+					adapterOptions,
+					isDefinitiveCreateFailure(error) ? 1 : undefined,
+				);
+				// Nothing carries this name, so nothing was allocated and there is nothing to leak. The
+				// original error is the whole truth — report it without a spurious cleanup warning.
+				if (!recovered) throw error;
+				// An allocation exists. The create SUCCEEDED and only its response was lost, so adopt it:
+				// destroying a healthy sandbox to honour a lost HTTP response would throw away the work and
+				// fail the cell for no reason. Readiness below still gates whether it is usable.
+				created = recovered;
 			}
 			// Do not return until the guest can accept commands — cold image pulls leave the sandbox in
 			// `building_image` for minutes, and exec during that window fails with API 4409.


### PR DESCRIPTION
A matrix run fired ~54 concurrent creates on one run.cloud API key. The control
plane allocated 38 sandboxes but returned no response inside the adapter's 30s
per-request bound, so every cell timed out. Recovery then replayed the create
POST — the one endpoint that was already failing — and when the replays came
back empty the adapter concluded it had no handle. All 38 sandboxes leaked, at
4 vCPU / 8 GiB each with a 3h idle-pause window, and every runcloud cell in the
run went red.

Recovery now uses a handle chosen locally BEFORE the request: a unique `name`
stamped on every create. An ambiguous failure asks `list({ name })` what
actually happened. That is a read, so it cannot allocate a second sandbox and
needs no cooperation from an overloaded create endpoint. A lookup that itself
fails costs an attempt rather than ending the search, because concluding
"nothing was allocated" is precisely what strands a billable sandbox.

When the lookup finds the allocation the adapter now ADOPTS it instead of
destroying it. The create had in fact succeeded and only its response was lost,
so a slow control plane stops failing the cell at all. When the lookup finds
nothing, nothing was allocated, and the caller gets the original error without a
manual-cleanup warning it can do nothing about.

This removes the machinery the replay design needed — retainLateCreateCleanup,
the pending-cleanup registry, and drainRuncloudBackgroundWork along with its
call sites in four bins — since a late response no longer decides anything.

Validated against the live API: a create whose response is withheld is adopted
and execs successfully; a create that allocates nothing rejects cleanly; 12
concurrent creates leave zero leaked sandboxes.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switch run.cloud create recovery to a name-based reconciliation instead of replaying the create request. Ambiguous failures now adopt the real allocation, stopping leaks and false red cells; unanswered lookups surface the recovery handle.

- **Bug Fixes**
  - Stamp a unique recovery `name` on every create and set `idempotencyKey` to the same value; on timeout/5xx/409, poll `list({ name })` and adopt the oldest exact-name, non-destroyed allocation.
  - Distinguish confirmed-absent vs unanswered reconciliation: rethrow the original error for absent; for unanswered, include a manual-cleanup note with the recovery `name`.
  - Treat 4xx as definitive only when they mean “nothing was accepted” (e.g., 422, 429). Do one confirming lookup, then rethrow. 409 conflicts are no longer treated as definitive and get the full reconciliation window, including the unanswered report.

- **Refactors**
  - Removed create replay/late-response cleanup and `drainRuncloudBackgroundWork`; deleted its export and all CLI call sites.
  - Adapter options: removed `createRecoveryAttempts`; added `reconcileAttempts` and `reconcileRetryMs`.

<sup>Written for commit e8edf7db7cc877dbd035e1a53edade8e41d05dcb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/starslingdev/hpc-sandbox-benchmarks/pull/345?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved sandbox creation recovery after timeouts or server errors.
  - Prevented duplicate sandboxes by reconciling existing allocations before retrying.
  - Improved handling of temporary lookup failures and definitive client errors.
  - Ensured the oldest matching sandbox is selected when multiple matches exist.

- **Improvements**
  - CLI reports and benchmark summaries now complete with less cleanup-related waiting.
  - Sandbox recovery retries are bounded for more predictable completion.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->