### PR TITLE
fix(harness): retry confirmed-absent transient creates

### DIFF
--- a/packages/harness/src/index.test.ts
+++ b/packages/harness/src/index.test.ts
@@ -411,6 +411,7 @@ describe("createSuiteSandbox (creation-failure marker)", () => {
 			createAttemptCeilingMs?: number;
 			retryDelayMs?: number;
 			retryBudgetMs?: number;
+			sleep?: (ms: number) => Promise<void>;
 		} = {},
 	) => ({
 		suite: suite({}),
@@ -565,6 +566,36 @@ describe("createSuiteSandbox (creation-failure marker)", () => {
 					createAttemptCeilingMs: 5_000,
 					retryDelayMs: 10,
 					retryBudgetMs: 1_000,
+				}),
+			),
+		).rejects.toThrow("create did not settle");
+		expect(attempts).toBe(1);
+		expect(JSON.parse(readFileSync(join(resultsDir, MARKER), "utf8")).outcome).toBe("failed");
+	});
+
+	it("re-checks the budget after a backoff timer that fires late", async () => {
+		const resultsDir = freshDir();
+		let attempts = 0;
+		const compute = {
+			sandbox: {
+				create: async (): Promise<SandboxHandle> => {
+					attempts++;
+					throw markRetryableCreate(new Error("create did not settle"));
+				},
+			},
+		};
+		// setTimeout promises a floor, not a ceiling: a loaded runner can return from the backoff long
+		// after it was asked to. The pre-sleep reservation was arithmetic on a clock reading that is now
+		// stale, so without the recheck this late sleep would start an attempt the budget cannot cover.
+		await expect(
+			createSuiteSandbox(
+				() => compute,
+				createCtx(resultsDir, {
+					createTimeoutMs: null,
+					createAttemptCeilingMs: 10,
+					retryDelayMs: 1,
+					retryBudgetMs: 40,
+					sleep: () => new Promise((r) => setTimeout(r, 60)),
 				}),
 			),
 		).rejects.toThrow("create did not settle");

--- a/packages/harness/src/index.test.ts
+++ b/packages/harness/src/index.test.ts
@@ -3,6 +3,7 @@ import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import type { DirectProvider, ProviderConfig } from "@sandbox-benchmarks/providers";
+import { markRetryableCreate } from "@sandbox-benchmarks/providers";
 import type { Suite } from "@sandbox-benchmarks/schema";
 import { parseGapMarker, sandboxFailureMarkerFile } from "@sandbox-benchmarks/schema";
 import {
@@ -403,7 +404,14 @@ describe("runSuite (resolution + credential gate)", () => {
 describe("createSuiteSandbox (creation-failure marker)", () => {
 	// The daytona-container incident shape: creation itself throws, so no sandbox — and no result —
 	// ever exists for the cell. The marker is the shard's ONLY record of the failure.
-	const createCtx = (resultsDir: string, overrides: { createTimeoutMs?: number | null } = {}) => ({
+	const createCtx = (
+		resultsDir: string,
+		overrides: {
+			createTimeoutMs?: number | null;
+			retryDelayMs?: number;
+			retryBudgetMs?: number;
+		} = {},
+	) => ({
 		suite: suite({}),
 		suiteName: "cpu-node",
 		providerName: "daytona-container",
@@ -445,6 +453,93 @@ describe("createSuiteSandbox (creation-failure marker)", () => {
 				detail: "Snapshot toolchain-v3-container is not available",
 			},
 		});
+	});
+
+	it("retries a create the adapter marked retryable, then returns the sandbox", async () => {
+		const resultsDir = freshDir();
+		const handle = makeSandbox({ destroyed: { hit: false } });
+		let attempts = 0;
+		const compute = {
+			sandbox: {
+				create: async (): Promise<SandboxHandle> => {
+					attempts++;
+					// A stalled control plane: the message names no quota, rate limit or 429, so only the
+					// adapter's explicit mark can keep this cell alive.
+					if (attempts < 3) {
+						throw markRetryableCreate(new Error("run.cloud create did not settle within 30000ms"));
+					}
+					return handle;
+				},
+			},
+		};
+		await expect(
+			createSuiteSandbox(() => compute, createCtx(resultsDir, { retryDelayMs: 1 })),
+		).resolves.toBe(handle);
+		expect(attempts).toBe(3);
+		// The cell recovered, so nothing failed and no marker belongs in the shard.
+		expect(existsSync(join(resultsDir, MARKER))).toBe(false);
+	});
+
+	it("does not retry an unmarked create failure whose message names no capacity limit", async () => {
+		const resultsDir = freshDir();
+		let attempts = 0;
+		const compute = {
+			sandbox: {
+				create: async (): Promise<SandboxHandle> => {
+					attempts++;
+					// Same sentence, no mark: the adapter never established that nothing was allocated, so
+					// re-issuing could stack allocations it cannot see.
+					throw new Error("run.cloud create did not settle within 30000ms");
+				},
+			},
+		};
+		await expect(
+			createSuiteSandbox(() => compute, createCtx(resultsDir, { retryDelayMs: 1 })),
+		).rejects.toThrow("did not settle");
+		expect(attempts).toBe(1);
+		expect(existsSync(join(resultsDir, MARKER))).toBe(true);
+	});
+
+	it("still retries on the message match, for adapters that do not set the mark", async () => {
+		const resultsDir = freshDir();
+		const handle = makeSandbox({ destroyed: { hit: false } });
+		let attempts = 0;
+		const compute = {
+			sandbox: {
+				create: async (): Promise<SandboxHandle> => {
+					attempts++;
+					if (attempts < 2) throw new Error("429 Too Many Requests");
+					return handle;
+				},
+			},
+		};
+		await expect(
+			createSuiteSandbox(() => compute, createCtx(resultsDir, { retryDelayMs: 1 })),
+		).resolves.toBe(handle);
+		expect(attempts).toBe(2);
+	});
+
+	it("writes a FAILED marker once the retry budget is spent", async () => {
+		const resultsDir = freshDir();
+		let attempts = 0;
+		const compute = {
+			sandbox: {
+				create: async (): Promise<SandboxHandle> => {
+					attempts++;
+					throw markRetryableCreate(new Error("no slot right now"));
+				},
+			},
+		};
+		// A budget smaller than one delay leaves no room for another attempt, so the first failure is
+		// also the last: patience is bounded, and the cell still records why it produced nothing.
+		await expect(
+			createSuiteSandbox(
+				() => compute,
+				createCtx(resultsDir, { retryDelayMs: 50, retryBudgetMs: 0 }),
+			),
+		).rejects.toThrow("no slot right now");
+		expect(attempts).toBe(1);
+		expect(JSON.parse(readFileSync(join(resultsDir, MARKER), "utf8")).outcome).toBe("failed");
 	});
 
 	it("writes a FAILED marker when adapter construction (the factory) throws before create", async () => {

--- a/packages/harness/src/index.test.ts
+++ b/packages/harness/src/index.test.ts
@@ -408,6 +408,7 @@ describe("createSuiteSandbox (creation-failure marker)", () => {
 		resultsDir: string,
 		overrides: {
 			createTimeoutMs?: number | null;
+			createAttemptCeilingMs?: number;
 			retryDelayMs?: number;
 			retryBudgetMs?: number;
 		} = {},
@@ -540,6 +541,65 @@ describe("createSuiteSandbox (creation-failure marker)", () => {
 		).rejects.toThrow("no slot right now");
 		expect(attempts).toBe(1);
 		expect(JSON.parse(readFileSync(join(resultsDir, MARKER), "utf8")).outcome).toBe("failed");
+	});
+
+	it("stops when the budget can cover the backoff but not another adapter-bounded attempt", async () => {
+		const resultsDir = freshDir();
+		let attempts = 0;
+		const compute = {
+			sandbox: {
+				create: async (): Promise<SandboxHandle> => {
+					attempts++;
+					throw markRetryableCreate(new Error("create did not settle"));
+				},
+			},
+		};
+		// The run.cloud shape: the harness race is off, so an attempt is bounded only by the ceiling the
+		// adapter declares. Room for the 10ms backoff but not the 5s attempt behind it — starting one
+		// would put the failure marker (and the matrix cell) seconds past the budget it promised.
+		await expect(
+			createSuiteSandbox(
+				() => compute,
+				createCtx(resultsDir, {
+					createTimeoutMs: null,
+					createAttemptCeilingMs: 5_000,
+					retryDelayMs: 10,
+					retryBudgetMs: 1_000,
+				}),
+			),
+		).rejects.toThrow("create did not settle");
+		expect(attempts).toBe(1);
+		expect(JSON.parse(readFileSync(join(resultsDir, MARKER), "utf8")).outcome).toBe("failed");
+	});
+
+	it("keeps retrying while the budget still covers the backoff and one whole attempt", async () => {
+		const resultsDir = freshDir();
+		const handle = makeSandbox({ destroyed: { hit: false } });
+		let attempts = 0;
+		const compute = {
+			sandbox: {
+				create: async (): Promise<SandboxHandle> => {
+					attempts++;
+					if (attempts < 2) throw markRetryableCreate(new Error("create did not settle"));
+					return handle;
+				},
+			},
+		};
+		// Same shape, ample budget: reserving one attempt's worth must not collapse the retry loop into
+		// a single try for the adapters that need it most.
+		await expect(
+			createSuiteSandbox(
+				() => compute,
+				createCtx(resultsDir, {
+					createTimeoutMs: null,
+					createAttemptCeilingMs: 5_000,
+					retryDelayMs: 1,
+					retryBudgetMs: 60_000,
+				}),
+			),
+		).resolves.toBe(handle);
+		expect(attempts).toBe(2);
+		expect(existsSync(join(resultsDir, MARKER))).toBe(false);
 	});
 
 	it("writes a FAILED marker when adapter construction (the factory) throws before create", async () => {

--- a/packages/harness/src/index.ts
+++ b/packages/harness/src/index.ts
@@ -289,6 +289,10 @@ export interface CreateSuiteSandboxContext {
 	 *  unexercised retry path is what let a hard-failing create reach production in the first place. */
 	retryDelayMs?: number;
 	retryBudgetMs?: number;
+	/** Test seam for the backoff itself, so a timer that fires LATE (the case the post-sleep deadline
+	 *  recheck exists for) is reproducible instead of dependent on event-loop pressure. Production uses
+	 *  `setTimeout`. */
+	sleep?: (ms: number) => Promise<void>;
 }
 
 /**
@@ -324,7 +328,44 @@ export async function createSuiteSandbox(
 	// an adapter that disables the race without one. Zero only for a hand-built context that disables
 	// the race and declares nothing — nothing can be reserved for an attempt of unknown cost.
 	const attemptCeilingMs = createTimeoutMs ?? ctx.createAttemptCeilingMs ?? 0;
+	const sleep = ctx.sleep ?? ((ms: number) => new Promise<void>((r) => setTimeout(r, ms)));
 	const createDeadline = Date.now() + (ctx.retryBudgetMs ?? CREATE_RETRY_BUDGET_MS);
+	/** True while the budget can still absorb a whole attempt, starting `inMs` from now. The one place
+	 *  patience is decided, asked both before the backoff (is another round worth sleeping for?) and
+	 *  after it (did the sleep overrun what was reserved?). */
+	const fitsInBudget = (inMs: number): boolean =>
+		Date.now() + inMs + attemptCeilingMs <= createDeadline;
+	/**
+	 * Record the creation failure and rethrow the provider's own error — the single exit for every way
+	 * this function gives up, so the marker can never be skipped on one of them.
+	 *
+	 * The write is best-effort: a marker-write failure (full/read-only results dir) must not REPLACE the
+	 * provider error — the creation failure is the fact worth propagating, the marker is its paper
+	 * trail. Log the write failure and rethrow the original either way. The ORIGINAL error propagates
+	 * unwrapped: bench-suite matches on the provider's own message, and `createSuiteSandbox` is called
+	 * outside {@link runSuiteOnSandbox}, so this throw never reaches the suite-level marker writer that
+	 * reads a classification. The marker written here already carries the cause as a plain value, which
+	 * is the only place it is read.
+	 */
+	const giveUp = (err: unknown, message: string): never => {
+		try {
+			writeGapMarker(
+				resultsDir,
+				providerName,
+				suiteName,
+				"failed",
+				`${CREATE_FAILURE_PREFIX}${message}`,
+				{ kind: "sandbox-create-failed", detail: message },
+			);
+		} catch (markerErr) {
+			console.error(
+				`Could not write the creation-failure gap marker (${
+					markerErr instanceof Error ? markerErr.message : String(markerErr)
+				}); the sandbox-creation error below is unaffected`,
+			);
+		}
+		throw err;
+	};
 	for (let attempt = 1; ; attempt++) {
 		// Undefined until `sandbox.create` is actually invoked: a factory throw leaves it unset (nothing
 		// was created, so there is nothing to clean up), while a create that outlives the timeout leaves it
@@ -367,37 +408,17 @@ export async function createSuiteSandbox(
 			// whose attempts run long (run.cloud's adapter-owned readiness wait) begin one final attempt at
 			// the edge of the budget and land its failure marker — and the matrix cell — far outside the
 			// hour the budget promises.
-			if (!retryable || Date.now() + retryDelayMs + attemptCeilingMs > createDeadline) {
-				// Best-effort: a marker-write failure (full/read-only results dir) must not REPLACE the
-				// provider error — the creation failure is the fact worth propagating, the marker is its
-				// paper trail. Log the write failure and rethrow the original either way.
-				try {
-					writeGapMarker(
-						resultsDir,
-						providerName,
-						suiteName,
-						"failed",
-						`${CREATE_FAILURE_PREFIX}${message}`,
-						{ kind: "sandbox-create-failed", detail: message },
-					);
-				} catch (markerErr) {
-					console.error(
-						`Could not write the creation-failure gap marker (${
-							markerErr instanceof Error ? markerErr.message : String(markerErr)
-						}); the sandbox-creation error below is unaffected`,
-					);
-				}
-				// The ORIGINAL error propagates, unwrapped: bench-suite matches on the provider's own message
-				// and `createSuiteSandbox` is called outside `runSuiteOnSandbox`, so this throw never reaches
-				// the suite-level marker writer that reads a classification. The marker written just above
-				// already carries the cause as a plain value, which is the only place it is read.
-				throw err;
-			}
+			if (!retryable || !fitsInBudget(retryDelayMs)) giveUp(err, message);
 			console.log(
 				`Sandbox create attempt ${attempt} failed transiently (${message.slice(0, 140)}); ` +
 					`retrying in ${retryDelayMs / 1000}s...`,
 			);
-			await new Promise((r) => setTimeout(r, retryDelayMs));
+			await sleep(retryDelayMs);
+			// `setTimeout` guarantees a floor, not a ceiling: a loaded runner (or a suspended process) can
+			// return from that sleep well after `retryDelayMs`, and the reservation made before it was
+			// arithmetic on a time that has since passed. Re-ask against the clock now, so a late timer
+			// spends the budget rather than silently pushing the next attempt past it.
+			if (!fitsInBudget(0)) giveUp(err, message);
 		}
 	}
 }

--- a/packages/harness/src/index.ts
+++ b/packages/harness/src/index.ts
@@ -221,6 +221,7 @@ export async function runSuite(options: RunSuiteOptions): Promise<void> {
 		resultsDir,
 		createOptions: config.createOptions,
 		createTimeoutMs: config.createTimeoutMs,
+		createAttemptCeilingMs: config.createAttemptCeilingMs,
 	});
 
 	await runSuiteOnSandbox(sandbox, {
@@ -278,6 +279,11 @@ export interface CreateSuiteSandboxContext {
 	 *  or `null` when the adapter owns readiness + failed-allocation cleanup and abandoning its promise
 	 *  would terminate that cleanup. Injectable so both paths are exercisable in tests. */
 	createTimeoutMs?: number | null;
+	/** Worst case one attempt can cost when `createTimeoutMs` is `null` — the ceiling the ADAPTER
+	 *  enforces (see {@link ProviderConfig.createAttemptCeilingMs}), which the registry requires such an
+	 *  adapter to declare. Ignored when the harness bounds the attempt itself: `createTimeoutMs` is then
+	 *  the ceiling. */
+	createAttemptCeilingMs?: number;
 	/** Test seams for the capacity-retry loop. Production always uses the module constants; a test that
 	 *  had to spend the real 2-minute delay to reach the second attempt would not be written, and an
 	 *  unexercised retry path is what let a hard-failing create reach production in the first place. */
@@ -296,6 +302,10 @@ export interface CreateSuiteSandboxContext {
  * throw that finally spends the budget records the failure. Split from {@link runSuite} (the
  * runSuiteOnSandbox precedent) so this is testable against a fake compute.
  *
+ * The retry budget bounds the whole call, not just the sleeps between attempts: a new attempt starts
+ * only while the budget can still cover the backoff PLUS that attempt's worst case, so the failure
+ * marker lands inside the budget rather than one attempt past it.
+ *
  * `computeFactory` (not a pre-built compute) so adapter construction lives INSIDE the marker path — a
  * computesdk provider can throw before `sandbox.create`, and that throw must be recorded too. The
  * factory is cheap and idempotent, so re-invoking it per capacity retry is harmless.
@@ -308,6 +318,12 @@ export async function createSuiteSandbox(
 	const createTimeoutMs =
 		ctx.createTimeoutMs === undefined ? CREATE_ATTEMPT_TIMEOUT_MS : ctx.createTimeoutMs;
 	const retryDelayMs = ctx.retryDelayMs ?? CREATE_RETRY_DELAY_MS;
+	// What one more attempt can cost, so the loop only starts an attempt the budget can still absorb.
+	// When the harness races the create, its own timeout IS that ceiling; when the adapter owns the
+	// bound (`createTimeoutMs: null`) it declares the ceiling instead, and the provider registry refuses
+	// an adapter that disables the race without one. Zero only for a hand-built context that disables
+	// the race and declares nothing — nothing can be reserved for an attempt of unknown cost.
+	const attemptCeilingMs = createTimeoutMs ?? ctx.createAttemptCeilingMs ?? 0;
 	const createDeadline = Date.now() + (ctx.retryBudgetMs ?? CREATE_RETRY_BUDGET_MS);
 	for (let attempt = 1; ; attempt++) {
 		// Undefined until `sandbox.create` is actually invoked: a factory throw leaves it unset (nothing
@@ -346,7 +362,12 @@ export async function createSuiteSandbox(
 			// 30960125032 in seconds instead of letting the cells queue.
 			const retryable =
 				isRetryableCreateError(err) || /quota|rate.?limit|too many|capacity|429/i.test(message);
-			if (!retryable || Date.now() + retryDelayMs > createDeadline) {
+			// The budget bounds the CELL, not just the sleeps: an attempt is only started when the backoff
+			// AND the attempt's own worst case still fit inside it. Checking the delay alone let a provider
+			// whose attempts run long (run.cloud's adapter-owned readiness wait) begin one final attempt at
+			// the edge of the budget and land its failure marker — and the matrix cell — far outside the
+			// hour the budget promises.
+			if (!retryable || Date.now() + retryDelayMs + attemptCeilingMs > createDeadline) {
 				// Best-effort: a marker-write failure (full/read-only results dir) must not REPLACE the
 				// provider error — the creation failure is the fact worth propagating, the marker is its
 				// paper trail. Log the write failure and rethrow the original either way.

--- a/packages/harness/src/index.ts
+++ b/packages/harness/src/index.ts
@@ -325,8 +325,8 @@ export async function createSuiteSandbox(
 	// What one more attempt can cost, so the loop only starts an attempt the budget can still absorb.
 	// When the harness races the create, its own timeout IS that ceiling; when the adapter owns the
 	// bound (`createTimeoutMs: null`) it declares the ceiling instead, and the provider registry refuses
-	// an adapter that disables the race without one. Zero only for a hand-built context that disables
-	// the race and declares nothing — nothing can be reserved for an attempt of unknown cost.
+	// an adapter that disables the race without a POSITIVE one. Zero only for a hand-built context that
+	// disables the race and declares nothing — nothing can be reserved for an attempt of unknown cost.
 	const attemptCeilingMs = createTimeoutMs ?? ctx.createAttemptCeilingMs ?? 0;
 	const sleep = ctx.sleep ?? ((ms: number) => new Promise<void>((r) => setTimeout(r, ms)));
 	const createDeadline = Date.now() + (ctx.retryBudgetMs ?? CREATE_RETRY_BUDGET_MS);

--- a/packages/harness/src/index.ts
+++ b/packages/harness/src/index.ts
@@ -2,7 +2,7 @@
 import { readdirSync } from "node:fs";
 import { resolve } from "node:path";
 import type { DirectProvider, ProviderConfig } from "@sandbox-benchmarks/providers";
-import { providers } from "@sandbox-benchmarks/providers";
+import { isRetryableCreateError, providers } from "@sandbox-benchmarks/providers";
 import type { ProviderTransport, RawRun, ResultGap, Suite } from "@sandbox-benchmarks/schema";
 import { HARNESS_METRIC_IDS, isPtsResultFile, SUITES } from "@sandbox-benchmarks/schema";
 import { collectResults, writeGapMarker } from "./lib/collect.ts";
@@ -278,6 +278,11 @@ export interface CreateSuiteSandboxContext {
 	 *  or `null` when the adapter owns readiness + failed-allocation cleanup and abandoning its promise
 	 *  would terminate that cleanup. Injectable so both paths are exercisable in tests. */
 	createTimeoutMs?: number | null;
+	/** Test seams for the capacity-retry loop. Production always uses the module constants; a test that
+	 *  had to spend the real 2-minute delay to reach the second attempt would not be written, and an
+	 *  unexercised retry path is what let a hard-failing create reach production in the first place. */
+	retryDelayMs?: number;
+	retryBudgetMs?: number;
 }
 
 /**
@@ -302,7 +307,8 @@ export async function createSuiteSandbox(
 	const { suite, suiteName, providerName, resultsDir, createOptions } = ctx;
 	const createTimeoutMs =
 		ctx.createTimeoutMs === undefined ? CREATE_ATTEMPT_TIMEOUT_MS : ctx.createTimeoutMs;
-	const createDeadline = Date.now() + CREATE_RETRY_BUDGET_MS;
+	const retryDelayMs = ctx.retryDelayMs ?? CREATE_RETRY_DELAY_MS;
+	const createDeadline = Date.now() + (ctx.retryBudgetMs ?? CREATE_RETRY_BUDGET_MS);
 	for (let attempt = 1; ; attempt++) {
 		// Undefined until `sandbox.create` is actually invoked: a factory throw leaves it unset (nothing
 		// was created, so there is nothing to clean up), while a create that outlives the timeout leaves it
@@ -333,8 +339,14 @@ export async function createSuiteSandbox(
 				);
 			}
 			const message = err instanceof Error ? err.message : String(err);
-			const capacity = /quota|rate.?limit|too many|capacity|429/i.test(message);
-			if (!capacity || Date.now() + CREATE_RETRY_DELAY_MS > createDeadline) {
+			// An adapter that KNOWS its create failure is transient and allocated nothing says so explicitly;
+			// the message match is the fallback for providers that only express capacity limits in prose. The
+			// explicit mark covers a control plane that expresses saturation by stalling, whose timeout message
+			// matches none of these words — the shape that hard-failed every runcloud cell of run
+			// 30960125032 in seconds instead of letting the cells queue.
+			const retryable =
+				isRetryableCreateError(err) || /quota|rate.?limit|too many|capacity|429/i.test(message);
+			if (!retryable || Date.now() + retryDelayMs > createDeadline) {
 				// Best-effort: a marker-write failure (full/read-only results dir) must not REPLACE the
 				// provider error — the creation failure is the fact worth propagating, the marker is its
 				// paper trail. Log the write failure and rethrow the original either way.
@@ -361,10 +373,10 @@ export async function createSuiteSandbox(
 				throw err;
 			}
 			console.log(
-				`Sandbox create attempt ${attempt} hit a capacity limit (${message.slice(0, 140)}); ` +
-					`retrying in ${CREATE_RETRY_DELAY_MS / 1000}s...`,
+				`Sandbox create attempt ${attempt} failed transiently (${message.slice(0, 140)}); ` +
+					`retrying in ${retryDelayMs / 1000}s...`,
 			);
-			await new Promise((r) => setTimeout(r, CREATE_RETRY_DELAY_MS));
+			await new Promise((r) => setTimeout(r, retryDelayMs));
 		}
 	}
 }

--- a/packages/providers/src/index.test.ts
+++ b/packages/providers/src/index.test.ts
@@ -396,6 +396,19 @@ describe("assertCreateCeilingDeclared", () => {
 		).toThrow(/runcloud disabled the harness create timeout/);
 	});
 
+	it("throws on a ceiling that is present but cannot bound anything", () => {
+		// Zero, negative, and NaN (arithmetic over an unset constant) all reserve nothing, so they are
+		// the same overrun wearing a declared field — and a declared value reads as compliance, which
+		// makes it the more dangerous shape of the two.
+		for (const createAttemptCeilingMs of [0, -1, Number.NaN]) {
+			expect(() =>
+				assertCreateCeilingDeclared({
+					runcloud: { createTimeoutMs: null, createAttemptCeilingMs },
+				}),
+			).toThrow(/without declaring a positive createAttemptCeilingMs/);
+		}
+	});
+
 	it("holds for the real registry, so every race-disabling provider is budgetable", () => {
 		// run.cloud is the live instance of this shape; assert against the registry rather than naming
 		// it, so a future adapter that disables the race is covered by the same test.

--- a/packages/providers/src/index.test.ts
+++ b/packages/providers/src/index.test.ts
@@ -13,7 +13,7 @@ import {
 	providers,
 } from "./index.ts";
 import { runE2bCommandAsRoot } from "./lib/e2b-root.ts";
-import { assertProviderJoin } from "./lib/join.ts";
+import { assertCreateCeilingDeclared, assertProviderJoin } from "./lib/join.ts";
 
 describe("@sandbox-benchmarks/providers", () => {
 	it("wires every schema provider through to a computesdk factory", () => {
@@ -370,5 +370,40 @@ describe("assertProviderJoin", () => {
 		})();
 		expect(err?.message).toContain("missing a harness adapter: ghost");
 		expect(err?.message).toContain("no schema PROVIDERS entry: modal");
+	});
+});
+
+describe("assertCreateCeilingDeclared", () => {
+	it("passes for adapters the harness bounds itself, whether or not they set a timeout", () => {
+		expect(() =>
+			assertCreateCeilingDeclared({ e2b: {}, modal: { createTimeoutMs: 10 * 60 * 1000 } }),
+		).not.toThrow();
+	});
+
+	it("passes when an adapter that disables the race declares its own ceiling", () => {
+		expect(() =>
+			assertCreateCeilingDeclared({
+				runcloud: { createTimeoutMs: null, createAttemptCeilingMs: 20 * 60 * 1000 },
+			}),
+		).not.toThrow();
+	});
+
+	it("throws naming an adapter that disabled the race without declaring a ceiling", () => {
+		// The pairing the create-retry budget depends on: with the harness race off and no ceiling, the
+		// loop has nothing to subtract and can start an attempt that outlives the budget.
+		expect(() =>
+			assertCreateCeilingDeclared({ e2b: {}, runcloud: { createTimeoutMs: null } }),
+		).toThrow(/runcloud disabled the harness create timeout/);
+	});
+
+	it("holds for the real registry, so every race-disabling provider is budgetable", () => {
+		// run.cloud is the live instance of this shape; assert against the registry rather than naming
+		// it, so a future adapter that disables the race is covered by the same test.
+		expect(() =>
+			assertCreateCeilingDeclared(Object.fromEntries(providers.map((p) => [p.name, p]))),
+		).not.toThrow();
+		const raceDisabled = providers.filter((p) => p.createTimeoutMs === null);
+		expect(raceDisabled.length).toBeGreaterThan(0);
+		for (const p of raceDisabled) expect(p.createAttemptCeilingMs).toBeGreaterThan(0);
 	});
 });

--- a/packages/providers/src/index.ts
+++ b/packages/providers/src/index.ts
@@ -20,6 +20,8 @@ export { microsandboxCloudCompute, microsandboxLocalCompute } from "./lib/micros
 // Novita's E2B-compat surface: the pinned regional domain + connection the bake pipeline reuses,
 // and the compat factory (exported for tests and for anyone driving Novita outside the harness join).
 export { NOVITA_E2B_DOMAIN, novitaCompute, novitaConnection } from "./lib/novita.ts";
+// How an adapter reports a create failure the harness should wait out rather than fail on.
+export { isRetryableCreateError, markRetryableCreate } from "./lib/retryable-create.ts";
 export type { DirectProvider, ProviderAdapter, ProviderConfig } from "./lib/types.ts";
 
 /**

--- a/packages/providers/src/index.ts
+++ b/packages/providers/src/index.ts
@@ -4,7 +4,7 @@
 // `providers` is the schema identity joined with those adapters.
 import { PROVIDERS } from "@sandbox-benchmarks/schema";
 import { adapters } from "./lib/adapters.ts";
-import { assertProviderJoin } from "./lib/join.ts";
+import { assertCreateCeilingDeclared, assertProviderJoin } from "./lib/join.ts";
 import type { ProviderConfig } from "./lib/types.ts";
 
 // The runtime configuration gatekeeper — the single validated config object consumers import.
@@ -42,6 +42,10 @@ assertProviderJoin(
 	PROVIDERS.map((meta) => meta.id),
 	Object.keys(adapters),
 );
+
+// An adapter that owns its own create bound must say how large that bound is; the harness's retry
+// budget is only honest if it can subtract one attempt's worst case before starting another.
+assertCreateCeilingDeclared(adapters);
 
 export const providers: ProviderConfig[] = PROVIDERS.map((meta) => {
 	const adapter = adapters[meta.id];

--- a/packages/providers/src/lib/adapters.ts
+++ b/packages/providers/src/lib/adapters.ts
@@ -17,7 +17,7 @@ import { daytonaClientTarget } from "./daytona-target.ts";
 import { e2bCommandsAsRoot } from "./e2b-root.ts";
 import { microsandboxCloudCompute, microsandboxLocalCompute } from "./microsandbox.ts";
 import { novitaCompute } from "./novita.ts";
-import { runcloudCompute } from "./runcloud.ts";
+import { RUNCLOUD_CREATE_CEILING_MS, runcloudCompute } from "./runcloud.ts";
 import { runloopCompute } from "./runloop.ts";
 import type { ProviderAdapter } from "./types.ts";
 import { vercelCompute } from "./vercel.ts";
@@ -265,5 +265,8 @@ export const adapters: Record<ProviderId, ProviderAdapter> = {
 			timeoutSeconds: RUNCLOUD_MAX_DURATION_SECS,
 		},
 		createTimeoutMs: null,
+		// With the harness race off, the adapter's own bounds are the only ceiling on an attempt — hand
+		// them over so the create-retry loop can refuse a retry the budget cannot absorb.
+		createAttemptCeilingMs: RUNCLOUD_CREATE_CEILING_MS,
 	},
 };

--- a/packages/providers/src/lib/join.ts
+++ b/packages/providers/src/lib/join.ts
@@ -34,3 +34,33 @@ export function assertProviderJoin(
 	}
 	throw new Error(`Provider registry mismatch — ${parts.join("; ")}`);
 }
+
+/** The create-bounding half of an adapter's contract, as {@link assertCreateCeilingDeclared} reads it. */
+interface CreateBounds {
+	createTimeoutMs?: number | null;
+	createAttemptCeilingMs?: number;
+}
+
+/**
+ * Assert that every adapter which disables the harness's per-attempt create race (`createTimeoutMs:
+ * null`) also declares the ceiling it enforces itself. The two fields are one decision — "I own the
+ * bound" — and only the pair is usable: the harness's create-retry loop subtracts the ceiling from
+ * its remaining budget to decide whether another attempt can still finish in time, so an adapter that
+ * opts out without declaring one silently buys back the overrun the budget exists to prevent (a
+ * 20-minute readiness wait started at minute 59 of a one-hour budget). Checked at load, next to
+ * {@link assertProviderJoin}, because the alternative is discovering it in a matrix job that blew its
+ * timeout. Adapters are passed in as plain records so the guard stays a pure, unit-testable function.
+ */
+export function assertCreateCeilingDeclared(
+	adapters: Readonly<Record<string, CreateBounds>>,
+): void {
+	const undeclared = Object.entries(adapters)
+		.filter(([, a]) => a.createTimeoutMs === null && a.createAttemptCeilingMs === undefined)
+		.map(([id]) => id);
+	if (undeclared.length === 0) return;
+	throw new Error(
+		`Provider adapter misconfigured — ${undeclared.join(", ")} disabled the harness create timeout ` +
+			`(createTimeoutMs: null) without declaring createAttemptCeilingMs, so the create-retry budget ` +
+			`cannot bound an attempt`,
+	);
+}

--- a/packages/providers/src/lib/join.ts
+++ b/packages/providers/src/lib/join.ts
@@ -50,17 +50,21 @@ interface CreateBounds {
  * 20-minute readiness wait started at minute 59 of a one-hour budget). Checked at load, next to
  * {@link assertProviderJoin}, because the alternative is discovering it in a matrix job that blew its
  * timeout. Adapters are passed in as plain records so the guard stays a pure, unit-testable function.
+ *
+ * The ceiling must be POSITIVE, not merely present: zero (or a negative, or a NaN from arithmetic on
+ * an unset constant) reserves nothing, which is the same overrun wearing a declared field. A declared
+ * ceiling that cannot bound an attempt is worse than a missing one — it reads as compliance.
  */
 export function assertCreateCeilingDeclared(
 	adapters: Readonly<Record<string, CreateBounds>>,
 ): void {
 	const undeclared = Object.entries(adapters)
-		.filter(([, a]) => a.createTimeoutMs === null && a.createAttemptCeilingMs === undefined)
+		.filter(([, a]) => a.createTimeoutMs === null && !((a.createAttemptCeilingMs ?? 0) > 0))
 		.map(([id]) => id);
 	if (undeclared.length === 0) return;
 	throw new Error(
 		`Provider adapter misconfigured — ${undeclared.join(", ")} disabled the harness create timeout ` +
-			`(createTimeoutMs: null) without declaring createAttemptCeilingMs, so the create-retry budget ` +
-			`cannot bound an attempt`,
+			`(createTimeoutMs: null) without declaring a positive createAttemptCeilingMs, so the ` +
+			`create-retry budget cannot bound an attempt`,
 	);
 }

--- a/packages/providers/src/lib/retryable-create.test.ts
+++ b/packages/providers/src/lib/retryable-create.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from "bun:test";
+import { isRetryableCreateError, markRetryableCreate } from "./retryable-create.ts";
+
+describe("retryable-create mark", () => {
+	it("marks and detects an error", () => {
+		const error = new Error("no slot right now");
+		expect(isRetryableCreateError(error)).toBe(false);
+		expect(markRetryableCreate(error)).toBe(error);
+		expect(isRetryableCreateError(error)).toBe(true);
+	});
+
+	it("treats an unmarked error, and every non-error value, as not retryable", () => {
+		expect(isRetryableCreateError(new Error("invalid image"))).toBe(false);
+		expect(isRetryableCreateError("quota exceeded")).toBe(false);
+		expect(isRetryableCreateError(null)).toBe(false);
+		expect(isRetryableCreateError(undefined)).toBe(false);
+	});
+
+	it("returns a non-object untouched rather than wrapping it", () => {
+		// Wrapping would lose the identity callers match on; there is simply nothing to carry the mark.
+		expect(markRetryableCreate("plain string")).toBe("plain string");
+		expect(isRetryableCreateError(markRetryableCreate("plain string"))).toBe(false);
+	});
+
+	it("keeps the mark non-enumerable so object spread cannot copy it", () => {
+		const error = markRetryableCreate(new Error("no slot"));
+		const mark = Symbol.for("sandbox-benchmarks.retryableCreate");
+		expect(Object.getOwnPropertyDescriptor(error, mark)?.enumerable).toBe(false);
+		expect(Object.getOwnPropertySymbols({ ...error })).not.toContain(mark);
+	});
+
+	it("preserves a frozen error when it cannot carry the mark", () => {
+		const error = Object.freeze(new Error("no slot"));
+		expect(markRetryableCreate(error)).toBe(error);
+		expect(isRetryableCreateError(error)).toBe(false);
+	});
+});

--- a/packages/providers/src/lib/retryable-create.ts
+++ b/packages/providers/src/lib/retryable-create.ts
@@ -1,0 +1,45 @@
+// How an adapter tells the harness that a failed create is worth waiting out.
+//
+// The harness otherwise infers this from the error MESSAGE (`/quota|rate.?limit|too many|capacity|429/`),
+// which only works for providers that answer an over-quota create with a recognisable error. A provider
+// that expresses saturation by STALLING — accepting the request and never answering — produces a timeout
+// message that matches nothing, so the cell hard-fails in seconds instead of queueing. That is what took
+// out every runcloud cell of matrix run 30960125032.
+//
+// The mark is deliberately narrower than "the create failed". Retrying issues a NEW create, so it is only
+// safe once the adapter has ESTABLISHED that the previous attempt allocated nothing. An adapter that
+// merely failed to find out must not mark the error: retrying an attempt that may have allocated is how
+// one stranded sandbox becomes a dozen.
+
+/** `Symbol.for` so the mark survives a duplicated module instance — the harness and the adapter package
+ *  can be resolved separately, and a mark that silently stopped being visible would reintroduce the
+ *  hard-fail this exists to remove. */
+const RETRYABLE_CREATE = Symbol.for("sandbox-benchmarks.retryableCreate");
+
+/**
+ * Mark an error as "this failure is transient, AND nothing was allocated" — the two conditions that
+ * together make re-issuing the create both useful and safe. Returns the error so a throw site can wrap
+ * it inline. A non-object (a thrown string) or non-extensible object is returned untouched: there is
+ * nowhere safe to carry the mark, and inventing a wrapper would lose the identity callers match on.
+ */
+export function markRetryableCreate<E>(error: E): E {
+	if (typeof error === "object" && error !== null) {
+		try {
+			Object.defineProperty(error, RETRYABLE_CREATE, { value: true, enumerable: false });
+		} catch {
+			// Error decoration is best-effort. A frozen SDK error or hostile proxy must not replace the
+			// provider's original failure with a TypeError from this helper.
+		}
+	}
+	return error;
+}
+
+/** Whether an adapter explicitly marked this failure as safe and useful to retry. */
+export function isRetryableCreateError(error: unknown): boolean {
+	if (typeof error !== "object" || error === null) return false;
+	try {
+		return (error as Record<symbol, unknown>)[RETRYABLE_CREATE] === true;
+	} catch {
+		return false;
+	}
+}

--- a/packages/providers/src/lib/runcloud.test.ts
+++ b/packages/providers/src/lib/runcloud.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "bun:test";
 import type { ExecOptions, Sandbox, SandboxState } from "@run-cloud/sdk";
 import { RunCloudError } from "@run-cloud/sdk";
+import { isRetryableCreateError } from "./retryable-create.ts";
 import { runcloudCompute, sandboxMethods } from "./runcloud.ts";
 
 type ComputeOptions = NonNullable<Parameters<typeof runcloudCompute>[0]>;
@@ -287,6 +288,76 @@ describe("run.cloud ComputeSDK adapter", () => {
 		await expect(create).rejects.not.toThrow(/manual cleanup/);
 		expect(createCalls).toBe(1);
 		expect(listCalls).toBe(3);
+		// Established absence is what makes re-issuing the create safe, and a stall that allocated
+		// nothing is this control plane reporting saturation without saying "429". Mark it so the
+		// harness waits it out instead of failing the cell in seconds.
+		expect(isRetryableCreateError(await create.catch((e) => e))).toBe(true);
+	});
+
+	it("does not mark a generic create failure as retryable after confirming absence", async () => {
+		const clientError = new Error("client serialization failed");
+		const client = nativeClient({
+			create: async () => {
+				throw clientError;
+			},
+			list: async () => [],
+		});
+
+		const rejected = await runcloudCompute({
+			client,
+			reconcileAttempts: 1,
+			sleep: async () => {},
+		})
+			.sandbox.create()
+			.catch((error) => error);
+
+		expect(rejected).toBe(clientError);
+		expect(isRetryableCreateError(rejected)).toBe(false);
+	});
+
+	it("does not mark an unanswered reconciliation as retryable", async () => {
+		const client = nativeClient({
+			create: () => new Promise<Sandbox>(() => {}),
+			list: async () => {
+				throw new Error("control plane unavailable");
+			},
+		});
+
+		const create = runcloudCompute({
+			client,
+			controlPlaneTimeoutMs: 5,
+			reconcileAttempts: 2,
+			reconcileRetryMs: 0,
+			sleep: async () => {},
+		}).sandbox.create();
+
+		const error = await create.catch((e) => e);
+		expect(error).toBeInstanceOf(AggregateError);
+		expect((error as Error).message).toMatch(/every reconciliation lookup also failed/);
+		// Re-issuing a create that may already have allocated is how one stranded sandbox becomes a
+		// dozen. Absence was never established, so this must NOT be retried.
+		expect(isRetryableCreateError(error)).toBe(false);
+	});
+
+	it("does not mark a definitive rejection as retryable", async () => {
+		const client = nativeClient({
+			create: async () => {
+				throw new RunCloudError(422, "invalid image");
+			},
+			list: async () => [],
+		});
+
+		const create = runcloudCompute({
+			client,
+			reconcileRetryMs: 0,
+			sleep: async () => {},
+		}).sandbox.create();
+
+		// Nothing was allocated here either, but re-issuing a rejected request for an hour would only
+		// delay the real error. (429 still reaches the retry through the harness's message match.)
+		const rejected = await create.catch((e) => e);
+		expect(rejected).toBeInstanceOf(RunCloudError);
+		expect(isRetryableCreateError(rejected)).toBe(false);
 	});
 
 	it("keeps asking when a reconciliation lookup fails or the allocation is not yet visible", async () => {

--- a/packages/providers/src/lib/runcloud.ts
+++ b/packages/providers/src/lib/runcloud.ts
@@ -54,6 +54,10 @@ const CREATE_RECONCILE_RETRY_MS = 2_000;
  * It is a CEILING, not an expectation — the observed create is seconds. Reserving it costs patience
  * (the harness stops starting new attempts this much earlier), which is the deliberate trade: a cell
  * that gives up slightly sooner beats one whose failure marker lands after the budget expired.
+ *
+ * Describes the DEFAULT bounds, which is what the registry gets ({@link runcloudCompute} is wired
+ * there with no options); a caller that shrinks or widens them through the test seams owns the
+ * arithmetic itself.
  */
 export const RUNCLOUD_CREATE_CEILING_MS =
 	// The create POST itself.

--- a/packages/providers/src/lib/runcloud.ts
+++ b/packages/providers/src/lib/runcloud.ts
@@ -40,6 +40,36 @@ const RECOVERY_NAME_PREFIX = "sandbox-benchmarks";
 const CREATE_RECONCILE_ATTEMPTS = 5;
 const CREATE_RECONCILE_RETRY_MS = 2_000;
 
+/**
+ * Worst-case wall time ONE `create` call can spend before it settles, summed over every bound the
+ * adapter enforces on its longest path: the create POST, reconciling an ambiguous response, the
+ * readiness wait, and destroying an allocation that failed readiness.
+ *
+ * Exported because this adapter turns the harness's own per-attempt race OFF
+ * (`createTimeoutMs: null`, so its cleanup is never abandoned mid-teardown) and the harness must
+ * still know what an attempt can cost: without a number it can start a retry that finishes long
+ * after the retry budget it promised the matrix job. Derived from the constants above rather than
+ * written as a literal, so tightening any one of them tightens this in the same edit.
+ *
+ * It is a CEILING, not an expectation — the observed create is seconds. Reserving it costs patience
+ * (the harness stops starting new attempts this much earlier), which is the deliberate trade: a cell
+ * that gives up slightly sooner beats one whose failure marker lands after the budget expired.
+ */
+export const RUNCLOUD_CREATE_CEILING_MS =
+	// The create POST itself.
+	CONTROL_PLANE_REQUEST_TIMEOUT_MS +
+	// Reconciling an ambiguous create: one bounded lookup per attempt, with a wait between attempts.
+	CREATE_RECONCILE_ATTEMPTS * CONTROL_PLANE_REQUEST_TIMEOUT_MS +
+	(CREATE_RECONCILE_ATTEMPTS - 1) * CREATE_RECONCILE_RETRY_MS +
+	// Readiness: the deadline is checked BEFORE each poll, so the last poll can start just under it and
+	// still spend one bounded get plus one inter-poll sleep on top of the window.
+	RUNCLOUD_READY_TIMEOUT_MS +
+	CONTROL_PLANE_REQUEST_TIMEOUT_MS +
+	CREATE_READY_POLL_MS +
+	// Cleanup of a failed allocation: each attempt is a bounded destroy plus a bounded confirming get.
+	CREATE_FAILURE_CLEANUP_ATTEMPTS * 2 * CONTROL_PLANE_REQUEST_TIMEOUT_MS +
+	(CREATE_FAILURE_CLEANUP_ATTEMPTS - 1) * CREATE_FAILURE_CLEANUP_RETRY_MS;
+
 type RuncloudSandboxClient = Pick<
 	Client["sandboxes"],
 	"create" | "get" | "list" | "destroy" | "exec" | "openTunnel"

--- a/packages/providers/src/lib/runcloud.ts
+++ b/packages/providers/src/lib/runcloud.ts
@@ -12,6 +12,7 @@ import type {
 import { defineProvider } from "@computesdk/provider";
 import type { Sandbox } from "@run-cloud/sdk";
 import { Client, RunCloudError } from "@run-cloud/sdk";
+import { markRetryableCreate } from "./retryable-create.ts";
 
 const PROVIDER = "runcloud";
 
@@ -421,7 +422,15 @@ export function sandboxMethods(
 				);
 				// Nothing carries this name, so nothing was allocated and there is nothing to leak. The
 				// original error is the whole truth — report it without a spurious cleanup warning.
-				if (reconciled.status === "absent") throw error;
+				//
+				// A timed-out create whose reconciliation establishes absence is both transient and safe to
+				// retry. Do not mark every ambiguous error here: a generic client bug or durable 5xx with an
+				// empty lookup must fail promptly rather than masquerade as capacity for an hour. A definitive
+				// rejection is also left unmarked — 429 already reaches the harness through its message match,
+				// while re-issuing a 422 would only delay the real error.
+				if (reconciled.status === "absent") {
+					throw error instanceof NativeCallTimeoutError ? markRetryableCreate(error) : error;
+				}
 				// The create was ambiguous AND the control plane never answered what it did with it, so
 				// absence was never established. Say so and name the recovery handle: the name is stamped
 				// before the request precisely so a sandbox that outlived this window is still findable.

--- a/packages/providers/src/lib/types.ts
+++ b/packages/providers/src/lib/types.ts
@@ -37,6 +37,13 @@ export interface ProviderAdapter {
 	 *  adapter owns a bounded readiness wait and must finish its own failed-allocation cleanup before
 	 *  the caller can safely exit. Omitted when the default is adequate. */
 	createTimeoutMs?: number | null;
+	/** Worst-case wall time one `create` can spend before it settles, as bounded by the ADAPTER itself.
+	 *  Required whenever `createTimeoutMs` is `null` (enforced at registry load by
+	 *  {@link assertCreateCeilingDeclared}): with the harness race off, this is the only thing that
+	 *  tells the retry loop how much budget an attempt can consume, and without it the loop can start
+	 *  an attempt that outlives the retry budget it promised. Meaningless — and omitted — when the
+	 *  harness bounds the attempt itself, because there `createTimeoutMs` already IS the ceiling. */
+	createAttemptCeilingMs?: number;
 }
 
 /** A provider as the harness consumes it: schema-owned identity joined with the harness adapter. */


### PR DESCRIPTION
## Summary

- add an explicit provider-to-harness signal for transient create failures that are safe to retry
- mark run.cloud create timeouts only after reconciliation confirms that no sandbox was allocated
- keep generic client errors, durable 5xx responses, definitive rejections, and unanswered reconciliation failures on the immediate-failure path
- preserve the existing message-based capacity fallback for providers that report quota, rate-limit, or 429 errors
- bound retries with the existing one-hour budget and record a failed gap marker when that budget is exhausted
- make error decoration best-effort for frozen or non-extensible SDK errors

## Why

Matrix run 30960125032 exposed a gap between the run.cloud adapter and the harness. The adapter could safely establish that a stalled create allocated nothing, but it rethrew a timeout whose message contained none of the harness's capacity keywords. Every affected cell therefore failed immediately instead of waiting for capacity.

The explicit mark carries both facts the harness needs: the failure is transient, and reissuing the create cannot duplicate an allocation. It is intentionally limited to the native create-timeout case so durable failures are not hidden behind an hour of retries.

## Impact

run.cloud cells can now wait through confirmed-absent control-plane stalls without risking duplicate or stranded sandboxes. Non-transient failures still surface promptly, and exhausted retry budgets continue to produce a failed gap marker.

## Validation

- `bun test packages/providers/src/lib/retryable-create.test.ts packages/providers/src/lib/runcloud.test.ts packages/harness/src/index.test.ts` — 65 passing
- full `bun run test` suite
- `bun run typecheck`
- `bun run lint`
- `bun run spell`
- `git diff --check`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Retries sandbox creates only when the adapter marks the failure as transient and reconciliation confirms no sandbox was allocated, and starts retries only if the budget covers the backoff plus one attempt’s ceiling with a post‑sleep budget recheck. Also requires adapters that disable the harness create timeout to declare a positive attempt ceiling to prevent overruns.

- **Bug Fixes**
  - Retries marked transient creates after confirmed absence; avoids duplicate or stranded sandboxes.
  - Reserves backoff + one attempt’s ceiling before retrying and rechecks the budget after the backoff; single give‑up path always writes a FAILED gap marker.
  - Keeps immediate‑failure path for generic client errors, durable 5xx, definitive rejections, and unanswered reconciliation.

- **New Features**
  - Added `markRetryableCreate` and `isRetryableCreateError` in `@sandbox-benchmarks/providers` for adapters to signal safe‑to‑retry create failures.
  - Added registry guard `assertCreateCeilingDeclared` that requires a positive `createAttemptCeilingMs` when `createTimeoutMs` is `null`; run.cloud declares this via `RUNCLOUD_CREATE_CEILING_MS`. Harness supports injected `retryDelayMs`/`retryBudgetMs`/`sleep` for tests; logs indicate transient retries.

<sup>Written for commit 3153398556fbfa9e88f1bcd438493120d418245e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/starslingdev/hpc-sandbox-benchmarks/pull/349?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added safer retry handling for temporary suite-creation failures.
  * Added configurable retry budgets, attempt limits, and delays.
  * Added provider-specific safeguards to prevent creation attempts from exceeding defined time limits.
  * RunCloud creation timeouts can now be retried when reconciliation confirms no resource was created.

* **Bug Fixes**
  * Prevented retries for failures that are not confirmed as safe to retry.
  * Added checks to stop retries when budgets or attempt ceilings are exhausted.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->