### PR TITLE
fix: run benchmarks on the baked toolchain, and let a non-root sandbox use the baked artifacts

### DIFF
--- a/.mise/tasks/benchmark/memory/pts/stream
+++ b/.mise/tasks/benchmark/memory/pts/stream
@@ -70,7 +70,7 @@ export CFLAGS_OVERRIDE="-O3 -march=${march} -DSTREAM_ARRAY_SIZE=${STREAM_ARRAY_S
 profile="stream-1.3.4"
 pts_init
 if _pts_is_installed "pts/${profile}"; then
-	installed_dir="$(pts_user_dir)/installed-tests/pts/${profile}"
+	installed_dir="$(pts_install_root)/pts/${profile}"
 	recompile_stamp="$(mktemp)"
 	(
 		cd "$installed_dir"

--- a/.mise/tasks/benchmark/memory/pts/stream
+++ b/.mise/tasks/benchmark/memory/pts/stream
@@ -69,13 +69,12 @@ export CFLAGS_OVERRIDE="-O3 -march=${march} -DSTREAM_ARRAY_SIZE=${STREAM_ARRAY_S
 # batch-installs with the same exported CFLAGS_OVERRIDE.
 profile="stream-1.3.4"
 pts_init
-# Claim before repairing in place: the vendored install.sh ends with `chmod +x stream`, which is
-# ownership-gated and so fails on the bake's root-owned launcher even though the tree is a+rwX. When
-# the claim is impossible (unprivileged AND no sudo), fall through to the stock-image branch, which
-# discards the baked install and lets PTS reinstall it under THIS identity — slower, but it reaches
-# the same repaired runner instead of dying halfway through rewriting one.
-if _pts_is_installed "pts/${profile}" && claim_baked_profile_dir "$(pts_install_root)/pts/${profile}"; then
-	installed_dir="$(pts_install_root)/pts/${profile}"
+installed_dir="$(pts_install_root)/pts/${profile}"
+# Claim before repairing in place (see claim_baked_profile_dir for why a+rwX is not enough). An
+# unclaimable tree falls through to the stock-image branch, which discards the baked install and lets
+# PTS reinstall under THIS identity — slower, but it reaches the same repaired runner instead of
+# dying halfway through rewriting one.
+if _pts_is_installed "pts/${profile}" && claim_baked_profile_dir "$installed_dir"; then
 	recompile_stamp="$(mktemp)"
 	(
 		cd "$installed_dir"

--- a/.mise/tasks/benchmark/memory/pts/stream
+++ b/.mise/tasks/benchmark/memory/pts/stream
@@ -69,7 +69,12 @@ export CFLAGS_OVERRIDE="-O3 -march=${march} -DSTREAM_ARRAY_SIZE=${STREAM_ARRAY_S
 # batch-installs with the same exported CFLAGS_OVERRIDE.
 profile="stream-1.3.4"
 pts_init
-if _pts_is_installed "pts/${profile}"; then
+# Claim before repairing in place: the vendored install.sh ends with `chmod +x stream`, which is
+# ownership-gated and so fails on the bake's root-owned launcher even though the tree is a+rwX. When
+# the claim is impossible (unprivileged AND no sudo), fall through to the stock-image branch, which
+# discards the baked install and lets PTS reinstall it under THIS identity — slower, but it reaches
+# the same repaired runner instead of dying halfway through rewriting one.
+if _pts_is_installed "pts/${profile}" && claim_baked_profile_dir "$(pts_install_root)/pts/${profile}"; then
 	installed_dir="$(pts_install_root)/pts/${profile}"
 	recompile_stamp="$(mktemp)"
 	(

--- a/.mise/tasks/benchmark/memory/pts/stream
+++ b/.mise/tasks/benchmark/memory/pts/stream
@@ -70,28 +70,59 @@ export CFLAGS_OVERRIDE="-O3 -march=${march} -DSTREAM_ARRAY_SIZE=${STREAM_ARRAY_S
 profile="stream-1.3.4"
 pts_init
 installed_dir="$(pts_install_root)/pts/${profile}"
-# Claim before repairing in place (see claim_baked_profile_dir for why a+rwX is not enough). An
-# unclaimable tree falls through to the stock-image branch, which discards the baked install and lets
-# PTS reinstall under THIS identity — slower, but it reaches the same repaired runner instead of
-# dying halfway through rewriting one.
-if _pts_is_installed "pts/${profile}" && claim_baked_profile_dir "$installed_dir"; then
-	recompile_stamp="$(mktemp)"
-	(
-		cd "$installed_dir"
-		bash "${REPO_ROOT}/packages/schema/src/pts-profiles/${profile}/install.sh"
-	)
-	# The vendored script mirrors upstream, which exits 0 even when BOTH cc attempts fail — and a
-	# stale baked binary that still RUNS (native ISA on a compatible host) would pass the count
-	# guard while measuring the WRONG working set (the bake host's array size, not the 150e6 pin).
-	# The stamp is older than any binary cc just wrote, so not-newer == not rebuilt: refuse to
-	# measure rather than publish numbers for a configuration we did not compile.
-	if [ ! "${installed_dir}/stream-bin" -nt "$recompile_stamp" ]; then
+if _pts_is_installed "pts/${profile}"; then
+	# Claim before repairing in place (see claim_baked_profile_dir for why a+rwX is not enough).
+	if claim_baked_profile_dir "$installed_dir"; then
+		recompile_stamp="$(mktemp)"
+		(
+			cd "$installed_dir"
+			bash "${REPO_ROOT}/packages/schema/src/pts-profiles/${profile}/install.sh"
+		)
+		# The vendored script mirrors upstream, which exits 0 even when BOTH cc attempts fail — and a
+		# stale baked binary that still RUNS (native ISA on a compatible host) would pass the count
+		# guard while measuring the WRONG working set (the bake host's array size, not the 150e6 pin).
+		# The stamp is older than any binary cc just wrote, so not-newer == not rebuilt: refuse to
+		# measure rather than publish numbers for a configuration we did not compile.
+		if [ ! "${installed_dir}/stream-bin" -nt "$recompile_stamp" ]; then
+			rm -f "$recompile_stamp"
+			echo "ERROR: stream in-place recompile left a stale binary (stream-bin not rebuilt)" >&2
+			fail_result "stream in-place recompile failed; the stale baked binary would measure the wrong array size/ISA" "pts_stream"
+			exit 1
+		fi
 		rm -f "$recompile_stamp"
-		echo "ERROR: stream in-place recompile left a stale binary (stream-bin not rebuilt)" >&2
-		fail_result "stream in-place recompile failed; the stale baked binary would measure the wrong array size/ISA" "pts_stream"
-		exit 1
+	else
+		# An unclaimable tree cannot be repaired in place, and simply declining to repair it is the
+		# worst of the three outcomes: the profile stays REGISTERED, so run_pts_benchmark takes its
+		# already-installed fast path and measures the bake's binary — the CI runner's -march=native
+		# (AVX-512, the modal-gvisor SIGILL) and its L3-derived array size, 134217728 rather than the
+		# 150e6 pinned above. The SIGILL at least fails loudly; the array size is the silent one, four
+		# plausible numbers for a working set no other provider measured, which is precisely the
+		# cross-provider skew this whole preamble exists to remove.
+		#
+		# Discarding the install is the lever an unprivileged identity still has: unlinking needs
+		# write+execute on the PARENT directory, which the bake's a+rwX grants, where chown needs an
+		# ownership it does not have. run_pts_benchmark then takes its not-installed branch and
+		# batch-installs upstream's profile under THIS identity with the same exported
+		# CFLAGS_OVERRIDE — the stock-image (blaxel) path, slower but compiling what we pinned. Note
+		# this is NOT install_vendored_pts_profile's shape (fast-cli's else-branch): that stages a
+		# vendored profile dir, and the vendored stream-1.3.4 carries no downloads.xml, so PTS would
+		# copy no tarball and install.sh would die at `tar -jxf`. Upstream's registered profile is the
+		# one that can still fetch its own source.
+		echo "Could not claim ${installed_dir}; discarding the baked install so PTS reinstalls it"
+		# `|| true` so the -e above does not abort on the very failure this branch exists to report:
+		# an unguarded rm exits the leaf with no marker at all, which is the unexplained dead job.
+		# The existence check below is the single arbiter either way.
+		rm -rf "$installed_dir" || true
+		# Assert the discard landed (install_vendored_pts_profile's precedent): a surviving tree keeps
+		# PTS reporting the profile installed, and the run would silently be the stale-binary case
+		# above. A reinstall that then fails is already an honest recorded gap — run_pts_benchmark
+		# skips on a failed batch-install — so this is the only outcome left that needs a marker.
+		if [ -e "$installed_dir" ]; then
+			echo "ERROR: could not claim or discard the baked stream install at ${installed_dir}" >&2
+			fail_result "could not claim or discard the baked stream install; the stale baked binary would measure the wrong array size/ISA" "pts_stream"
+			exit 1
+		fi
 	fi
-	rm -f "$recompile_stamp"
 fi
 
 # Version-pinned to the vendored catalog profile AND the toolchain bake (ptsInstallTests): a

--- a/.mise/tasks/benchmark/network/pts/fast-cli
+++ b/.mise/tasks/benchmark/network/pts/fast-cli
@@ -16,7 +16,7 @@ fi
 profile="fast-cli-1.0.0"
 pts_init
 if _pts_is_installed "pts/${profile}"; then
-	installed_dir="$(pts_user_dir)/installed-tests/pts/${profile}"
+	installed_dir="$(pts_install_root)/pts/${profile}"
 	(
 		cd "$installed_dir"
 		sh "${REPO_ROOT}/packages/schema/src/pts-profiles/${profile}/install.sh"

--- a/.mise/tasks/benchmark/network/pts/fast-cli
+++ b/.mise/tasks/benchmark/network/pts/fast-cli
@@ -15,10 +15,10 @@ fi
 # on a stock image, stage the complete vendored profile so its install uses the same repair.
 profile="fast-cli-1.0.0"
 pts_init
+installed_dir="$(pts_install_root)/pts/${profile}"
 # Claim first — this vendored install.sh also ends in `chmod +x`, which needs ownership of the bake's
 # launcher, not merely the a+rwX the image grants. Unclaimable falls through to the vendored install.
-if _pts_is_installed "pts/${profile}" && claim_baked_profile_dir "$(pts_install_root)/pts/${profile}"; then
-	installed_dir="$(pts_install_root)/pts/${profile}"
+if _pts_is_installed "pts/${profile}" && claim_baked_profile_dir "$installed_dir"; then
 	(
 		cd "$installed_dir"
 		sh "${REPO_ROOT}/packages/schema/src/pts-profiles/${profile}/install.sh"

--- a/.mise/tasks/benchmark/network/pts/fast-cli
+++ b/.mise/tasks/benchmark/network/pts/fast-cli
@@ -15,7 +15,9 @@ fi
 # on a stock image, stage the complete vendored profile so its install uses the same repair.
 profile="fast-cli-1.0.0"
 pts_init
-if _pts_is_installed "pts/${profile}"; then
+# Claim first — this vendored install.sh also ends in `chmod +x`, which needs ownership of the bake's
+# launcher, not merely the a+rwX the image grants. Unclaimable falls through to the vendored install.
+if _pts_is_installed "pts/${profile}" && claim_baked_profile_dir "$(pts_install_root)/pts/${profile}"; then
 	installed_dir="$(pts_install_root)/pts/${profile}"
 	(
 		cd "$installed_dir"

--- a/.mise/tasks/benchmark/network/pts/iperf-wan
+++ b/.mise/tasks/benchmark/network/pts/iperf-wan
@@ -50,7 +50,7 @@ seed_pts_download_cache "iperf-3.14.tar.gz" \
 # conditional on the runner having produced a file at all, so a re-run where every trial fails
 # would leave the PREVIOUS execution's provenance sitting in the results tree, describing trials
 # this run never made — the exact misattribution these two lines exist to prevent.
-profile_dir="$(pts_user_dir)/installed-tests/local/iperf-wan-1.0.0"
+profile_dir="$(pts_install_root)/local/iperf-wan-1.0.0"
 rm -f "${profile_dir}/chosen-server" "${profile_dir}/server-choices.ndjson" \
 	"$(results_dir)/pts_iperf-wan--server-choices.ndjson"
 

--- a/.mise/tasks/benchmark/pgbench/pts/pgbench
+++ b/.mise/tasks/benchmark/pgbench/pts/pgbench
@@ -16,6 +16,8 @@ set -euo pipefail
 REPO_ROOT="$(git -C "$(dirname "${BASH_SOURCE[0]}")" rev-parse --show-toplevel)"
 source "${REPO_ROOT}/lib/bench.sh"
 
+claim_baked_pg_cluster
+
 # Version-pinned to the vendored profile (and its recorded fixture) so an upstream pgbench release
 # can't silently unmap the catalogued descriptions. "100"/"50" pin by NAME (they exceed the menus'
 # entry counts, so the numeric-index trap in run_pinned_pts's contract doesn't bite).

--- a/lib/bench.sh
+++ b/lib/bench.sh
@@ -325,6 +325,23 @@ pts_install_root() {
 	echo "${root%/}"
 }
 
+# Take ownership of a baked profile's INSTALLED dir when this sandbox's identity is not the bake's.
+# Returns non-zero when it cannot, so the caller can fall back rather than die mid-repair.
+#
+# 25-pts-profiles.sh leaves the tree a+rwX, which is enough to create, truncate and delete files —
+# and NOT enough for the repair-in-place leaves, because chmod is gated on OWNERSHIP, not on the mode
+# bits. A vendored install.sh that rewrites a launcher and ends with `chmod +x` therefore succeeds at
+# every write and then dies EPERM on the file it just wrote (stream, fast-cli). Writable is not
+# ownable: the mode says who may change the file's CONTENT, the owner is who may change its METADATA.
+claim_baked_profile_dir() {
+	local dir="${1:-}"
+	{ [ -n "$dir" ] && [ -d "$dir" ]; } || return 0
+	[ "$(stat -c '%u' "$dir" 2>/dev/null || echo -1)" = "$(id -u)" ] && return 0
+	{ command -v sudo >/dev/null 2>&1 && sudo -n true 2>/dev/null; } || return 1
+	sudo -n chown -R "$(id -u):$(id -g)" "$dir" || return 1
+	echo "Claimed baked profile dir: ${dir} (now $(id -un))"
+}
+
 # Make the BAKED postgres cluster usable by whatever identity this sandbox runs as. No-op under the
 # identity that baked it (every root provider), so this is purely the non-root repair.
 #

--- a/lib/bench.sh
+++ b/lib/bench.sh
@@ -361,6 +361,18 @@ claim_baked_profile_dir() {
 # Claim the cluster rather than rebuilding it: a runtime re-initdb would be simpler but would silently
 # vary encoding/locale/page layout per provider, and pgbench numbers are only comparable across
 # providers when the cluster underneath them is the same one. Ownership is the only thing that changes.
+#
+# Every abort below funnels through here: the two pgbench modes share one cluster, so a recovery this
+# function cannot FINISH leaves neither of them runnable, and under the leaf's `set -e` a bare failure
+# would exit with no marker on either prefix. Exit 0 because the skip markers ARE the outcome — an
+# honest recorded gap on both modes, not the opaque libpq error an unrepaired cluster reaches.
+_skip_pgbench_modes() {
+	local prefix
+	for prefix in pts_pgbench-read-only pts_pgbench-read-write; do
+		skip_result "$1" "$prefix"
+	done
+	exit 0
+}
 claim_baked_pg_cluster() {
 	local pgdata marker owner
 	pgdata="$(pts_install_root)/pts/pgbench-1.15.0/pg_/data/db"
@@ -384,27 +396,36 @@ claim_baked_pg_cluster() {
 
 	# The data dir's owner IS initdb's user, hence the cluster's bootstrap superuser. Read it BEFORE
 	# the chown rewrites it, and export it so libpq stops defaulting to an OS username with no role.
+	# Losing the owner is not a survivable warning: it is the bootstrap role itself. Continuing would
+	# chown the dir (or not) and leave PGUSER unset, and the NEXT invocation then reads a pgdata this
+	# identity can suddenly read and returns at the check above — so the whole recovery is skipped for
+	# good and both modes die on libpq's OS-username default.
 	owner="$(stat -c '%U' "$pgdata" 2>/dev/null || true)"
 	if [ -z "$owner" ]; then
-		echo "WARNING: cannot stat ${pgdata}; leaving the baked cluster untouched" >&2
-		return 0
+		_skip_pgbench_modes "could not read the owner of ${pgdata} to recover the baked cluster's bootstrap role"
 	fi
 
-	# One elevation policy for both claims — see claim_baked_profile_dir. Under the leaf's `set -e` an
-	# unguarded failure would abort with NO marker written, turning a diagnosable permission problem
-	# into an unexplained dead job, so an unclaimable cluster becomes an honest recorded gap on both
-	# modes instead of the confusing libpq error it would otherwise reach.
+	# One elevation policy for both claims — see claim_baked_profile_dir. An unclaimable cluster is a
+	# diagnosable permission problem, so record it rather than letting it reach the confusing libpq
+	# error.
 	if ! claim_baked_profile_dir "$pgdata"; then
-		local prefix
-		for prefix in pts_pgbench-read-only pts_pgbench-read-write; do
-			skip_result "could not claim the ${owner}-owned baked postgres data dir (needs sudo)" "$prefix"
-		done
-		exit 0
+		_skip_pgbench_modes "could not claim the ${owner}-owned baked postgres data dir (needs sudo)"
 	fi
 	export PGUSER="$owner"
 	# Record only after the chown succeeded: a marker written ahead of it would make a failed claim
 	# look complete to the next leaf, which would then skip the repair and fail on an unreadable dir.
-	echo "$owner" >"$marker" 2>/dev/null || true
+	#
+	# And treat a failed write as a failed recovery even though THIS process is already exported and
+	# would run fine: the chown has erased the only other evidence of who initdb'd the cluster, so
+	# without the marker the next invocation in a long-lived sandbox reads an owned, readable pgdata,
+	# returns early with no PGUSER, and fails opaquely. Skip loudly here instead of banking a run whose
+	# successor is already broken.
+	# No 2>/dev/null: a redirection that fails is reported by the SHELL, before the command it belongs
+	# to runs, so suppression there would be dead weight — and bash's own message names the errno the
+	# skip reason can't.
+	if ! echo "$owner" >"$marker"; then
+		_skip_pgbench_modes "claimed ${pgdata} but could not record its bootstrap role at ${marker}"
+	fi
 	echo "Claimed baked postgres cluster: ${pgdata} (now $(id -un), connecting as role ${PGUSER})"
 }
 

--- a/lib/bench.sh
+++ b/lib/bench.sh
@@ -325,6 +325,75 @@ pts_install_root() {
 	echo "${root%/}"
 }
 
+# Make the BAKED postgres cluster usable by whatever identity this sandbox runs as. No-op under the
+# identity that baked it (every root provider), so this is purely the non-root repair.
+#
+# The bake initdb's the cluster as root and 25-pts-profiles.sh must re-tighten pg_/data/db to 0700 —
+# postgres FATALs at startup on any group/other bit — which leaves an unprivileged runtime user with
+# two independent blockers, both identity mismatches with a baked artifact rather than sandbox faults:
+#
+#   1. it cannot read the data dir, so pg_ctl never starts the server at all; and
+#   2. the cluster's only role is the bake's initdb user, while the profile's generated run script
+#      passes no -U anywhere (createdb/pgbench/psql), so libpq defaults to the OS username and the
+#      server answers `FATAL: role "<user>" does not exist` — surfacing as pgbench's opaque
+#      "could not create connection for setup" with every trial empty.
+#
+# Claim the cluster rather than rebuilding it: a runtime re-initdb would be simpler but would silently
+# vary encoding/locale/page layout per provider, and pgbench numbers are only comparable across
+# providers when the cluster underneath them is the same one. Ownership is the only thing that changes.
+claim_baked_pg_cluster() {
+	local pgdata marker owner
+	pgdata="$(pts_install_root)/pts/pgbench-1.15.0/pg_/data/db"
+	# Beside the data dir, never inside it: the 0700 mode is postgres's requirement, and a stray file
+	# in there is one more thing checkDataDir can object to.
+	marker="$(dirname "$pgdata")/.bootstrap-role"
+	[ -d "$pgdata" ] || return 0
+
+	# A claim in an EARLIER leaf of this run (or an earlier run in a long-lived sandbox) already took
+	# ownership, which erases the evidence of who initdb'd it. The recorded role is still the cluster's
+	# only superuser, so replay it — without this, every leaf after the first reverts to libpq's OS
+	# username default and fails exactly the way an unclaimed cluster does.
+	if [ -r "$marker" ]; then
+		PGUSER="$(cat "$marker")"
+		export PGUSER
+		return 0
+	fi
+
+	# Readable means this identity baked the cluster (every root provider) — nothing to repair.
+	[ ! -r "$pgdata" ] || return 0
+
+	# The data dir's owner IS initdb's user, hence the cluster's bootstrap superuser. Read it BEFORE
+	# the chown rewrites it, and export it so libpq stops defaulting to an OS username with no role.
+	owner="$(stat -c '%U' "$pgdata" 2>/dev/null || true)"
+	if [ -z "$owner" ]; then
+		echo "WARNING: cannot stat ${pgdata}; leaving the baked cluster untouched" >&2
+		return 0
+	fi
+
+	if ! { command -v sudo >/dev/null 2>&1 && sudo -n true 2>/dev/null; }; then
+		# Honest recorded gap over a confusing libpq error: without elevation the 0700 root-owned data
+		# dir cannot be claimed, and nothing later in this leaf can recover from that.
+		local reason="baked postgres data dir is ${owner}-owned 0700 and this sandbox is unprivileged without sudo"
+		skip_result "$reason" "pts_pgbench-read-only"
+		skip_result "$reason" "pts_pgbench-read-write"
+		exit 0
+	fi
+
+	# Under the leaf's `set -e` a bare chown would abort with NO marker written, turning a diagnosable
+	# permission problem into an unexplained dead job — the one outcome the skip path exists to avoid.
+	if ! sudo -n chown -R "$(id -u):$(id -g)" "$pgdata"; then
+		local failed="could not claim the ${owner}-owned baked postgres data dir (chown failed)"
+		skip_result "$failed" "pts_pgbench-read-only"
+		skip_result "$failed" "pts_pgbench-read-write"
+		exit 0
+	fi
+	export PGUSER="$owner"
+	# Record only after the chown succeeded: a marker written ahead of it would make a failed claim
+	# look complete to the next leaf, which would then skip the repair and fail on an unreadable dir.
+	echo "$owner" >"$marker" 2>/dev/null || true
+	echo "Claimed baked postgres cluster: ${pgdata} (now $(id -un), connecting as role ${PGUSER})"
+}
+
 # Resolve the config file PTS itself reads and writes, mirroring its own selection order
 # (pts_config::get_config_file_location + pts_config_nye_XmlReader::__construct, v10.8.4). PTS sets
 # PTS_IS_DAEMONIZED_SERVER_PROCESS whenever /var/lib AND /etc are both writable — normally when the

--- a/lib/bench.sh
+++ b/lib/bench.sh
@@ -335,11 +335,14 @@ pts_install_root() {
 # ownable: the mode says who may change the file's CONTENT, the owner is who may change its METADATA.
 claim_baked_profile_dir() {
 	local dir="${1:-}"
-	{ [ -n "$dir" ] && [ -d "$dir" ]; } || return 0
-	[ "$(stat -c '%u' "$dir" 2>/dev/null || echo -1)" = "$(id -u)" ] && return 0
-	{ command -v sudo >/dev/null 2>&1 && sudo -n true 2>/dev/null; } || return 1
-	sudo -n chown -R "$(id -u):$(id -g)" "$dir" || return 1
-	echo "Claimed baked profile dir: ${dir} (now $(id -un))"
+	[ -d "$dir" ] || return 0
+	# A failed stat yields the empty string, which never equals a uid — no sentinel needed.
+	[ "$(stat -c '%u' "$dir" 2>/dev/null)" = "$UID" ] && return 0
+	# `have` gates on sudo EXISTING (no exec); the chown's own status then covers the NOPASSWD case, so
+	# there is no separate `sudo -n true` probe to keep in sync with the command that actually matters.
+	have sudo || return 1
+	sudo -n chown -R "${UID}:$(id -g)" "$dir" || return 1
+	echo "Claimed baked tree: ${dir} (now $(id -un))"
 }
 
 # Make the BAKED postgres cluster usable by whatever identity this sandbox runs as. No-op under the
@@ -363,7 +366,7 @@ claim_baked_pg_cluster() {
 	pgdata="$(pts_install_root)/pts/pgbench-1.15.0/pg_/data/db"
 	# Beside the data dir, never inside it: the 0700 mode is postgres's requirement, and a stray file
 	# in there is one more thing checkDataDir can object to.
-	marker="$(dirname "$pgdata")/.bootstrap-role"
+	marker="${pgdata%/*}/.bootstrap-role"
 	[ -d "$pgdata" ] || return 0
 
 	# A claim in an EARLIER leaf of this run (or an earlier run in a long-lived sandbox) already took
@@ -387,21 +390,15 @@ claim_baked_pg_cluster() {
 		return 0
 	fi
 
-	if ! { command -v sudo >/dev/null 2>&1 && sudo -n true 2>/dev/null; }; then
-		# Honest recorded gap over a confusing libpq error: without elevation the 0700 root-owned data
-		# dir cannot be claimed, and nothing later in this leaf can recover from that.
-		local reason="baked postgres data dir is ${owner}-owned 0700 and this sandbox is unprivileged without sudo"
-		skip_result "$reason" "pts_pgbench-read-only"
-		skip_result "$reason" "pts_pgbench-read-write"
-		exit 0
-	fi
-
-	# Under the leaf's `set -e` a bare chown would abort with NO marker written, turning a diagnosable
-	# permission problem into an unexplained dead job — the one outcome the skip path exists to avoid.
-	if ! sudo -n chown -R "$(id -u):$(id -g)" "$pgdata"; then
-		local failed="could not claim the ${owner}-owned baked postgres data dir (chown failed)"
-		skip_result "$failed" "pts_pgbench-read-only"
-		skip_result "$failed" "pts_pgbench-read-write"
+	# One elevation policy for both claims — see claim_baked_profile_dir. Under the leaf's `set -e` an
+	# unguarded failure would abort with NO marker written, turning a diagnosable permission problem
+	# into an unexplained dead job, so an unclaimable cluster becomes an honest recorded gap on both
+	# modes instead of the confusing libpq error it would otherwise reach.
+	if ! claim_baked_profile_dir "$pgdata"; then
+		local prefix
+		for prefix in pts_pgbench-read-only pts_pgbench-read-write; do
+			skip_result "could not claim the ${owner}-owned baked postgres data dir (needs sudo)" "$prefix"
+		done
 		exit 0
 	fi
 	export PGUSER="$owner"

--- a/packages/harness/src/lib/setup.test.ts
+++ b/packages/harness/src/lib/setup.test.ts
@@ -59,16 +59,27 @@ describe("setupSteps", () => {
 		);
 		expect(nodeStep?.script).toContain('cd "$HOME"');
 		expect(nodeStep?.script).toContain("mise use --global");
-		expect(nodeStep?.script).toContain("node@22.22.3");
-		expect(nodeStep?.script).toContain('npm install --global --prefix "$HOME/.local" pnpm@10.34.3');
+		expect(nodeStep?.script).toContain("node@22.23.1");
+		expect(nodeStep?.script).toContain('npm install --global --prefix "$HOME/.local" pnpm@10.34.5');
 		expect(nodeStep?.script).not.toMatch(/mise use[^&]*pnpm/);
 		expect(nodeStep?.script).not.toContain(`cd "$HOME/sandbox-benchmarks" && mise use`);
+	});
+
+	// The mise fallback writes to the baked image's root-owned MISE_DATA_DIR/MISE_CONFIG_DIR, so an
+	// unprivileged sandbox (runloop) needs the preamble's $SUDO to survive it. The pnpm branch must
+	// NOT be elevated — it installs under $HOME, where root-owned files would be the new bug.
+	it("elevates only the mise fallback, which writes outside $HOME", () => {
+		const nodeStep = setupSteps(SUITES["cpu-node"]).find(
+			(step) => step.label === "setup node 22 + pnpm 10",
+		);
+		expect(nodeStep?.script).toContain("$SUDO mise use --global");
+		expect(nodeStep?.script).not.toContain("$SUDO npm install");
 	});
 
 	it("checksum-verifies the pinned mise fallback without executing a remote installer", () => {
 		const miseStep = setupSteps(SUITES["cpu-node"]).find((step) => step.label === "install mise");
 		expect(miseStep?.script).toContain("sha256sum -c -");
-		expect(miseStep?.script).toContain("mise-v2026.5.16-linux-$a");
+		expect(miseStep?.script).toContain("mise-v2026.7.11-linux-$a");
 		expect(miseStep?.script).not.toContain("mise.run");
 	});
 

--- a/packages/harness/src/lib/setup.ts
+++ b/packages/harness/src/lib/setup.ts
@@ -26,15 +26,13 @@ export const DIR = '"$HOME/sandbox-benchmarks"';
 
 // Runtime versions for the stock-image fallback path (no-ops on the baked image, which already
 // ships them). These MUST equal the pins the image was baked from (packages/templates/src/lib/pins.ts,
-// rendered into the image's mise.toml) — they stay local constants rather than a templates-package
-// import so the harness remains decoupled, which means nothing but this comment couples them.
+// rendered into the image's mise.toml); they stay local constants rather than a templates-package
+// import so the harness remains decoupled from the bake, so the equality is held by the drift gate in
+// tooling/repo-checks/src/toolchain-runtime-pins.test.ts rather than by the type system.
 //
-// The equality is load-bearing, not cosmetic. Every version check below is EXACT, so a stale constant
-// makes the baked toolchain miss and takes the install fallback on every provider, every sandbox: it
-// re-downloads node and rewrites the image's own /etc/mise/config.toml, so the suite then measures a
-// runtime-fetched toolchain instead of the baked one. That failure is silent wherever the sandbox user
-// is root; where it is not (runloop), the write is denied and the step dies. Drifting these from
-// pins.ts is how #243's pin refresh reached the matrix as a Runloop-only outage two weeks later.
+// It is load-bearing, not cosmetic: every version check below is EXACT, so one stale constant makes
+// the baked toolchain miss and takes the install fallback on every provider and every sandbox — see
+// that gate's header for what it costs. #243 drifted these and it went unnoticed for two weeks.
 const MISE_VERSION = "v2026.7.11";
 const MISE_SHA256_X64 = "d31578a16ae2708385249b439c95533068e04b9507a118e905aa6768905671fc";
 const MISE_SHA256_ARM64 = "e3cb3bf4795f494a0e9be3f69ee1464de9d12a991589f126035eebd973c17796";

--- a/packages/harness/src/lib/setup.ts
+++ b/packages/harness/src/lib/setup.ts
@@ -25,13 +25,21 @@ const CLONE_URL = REPO_TOKEN
 export const DIR = '"$HOME/sandbox-benchmarks"';
 
 // Runtime versions for the stock-image fallback path (no-ops on the baked image, which already
-// ships them). Keep node/pnpm aligned with packages/templates/images/base/mise.toml. These stay as
-// local constants rather than a templates-package import so the harness remains decoupled.
-const MISE_VERSION = "v2026.5.16";
-const MISE_SHA256_X64 = "fb2d7bf1a3751398a5c336a3565cd3c60af9b41952abe6fd62e2f2f0d5f06b60";
-const MISE_SHA256_ARM64 = "a068f29d8821ab0707f1a006721b5ab0baa80acaafc5a7b71e04371287108b92";
-const NODE_VERSION = "22.22.3";
-const PNPM_VERSION = "10.34.3";
+// ships them). These MUST equal the pins the image was baked from (packages/templates/src/lib/pins.ts,
+// rendered into the image's mise.toml) — they stay local constants rather than a templates-package
+// import so the harness remains decoupled, which means nothing but this comment couples them.
+//
+// The equality is load-bearing, not cosmetic. Every version check below is EXACT, so a stale constant
+// makes the baked toolchain miss and takes the install fallback on every provider, every sandbox: it
+// re-downloads node and rewrites the image's own /etc/mise/config.toml, so the suite then measures a
+// runtime-fetched toolchain instead of the baked one. That failure is silent wherever the sandbox user
+// is root; where it is not (runloop), the write is denied and the step dies. Drifting these from
+// pins.ts is how #243's pin refresh reached the matrix as a Runloop-only outage two weeks later.
+const MISE_VERSION = "v2026.7.11";
+const MISE_SHA256_X64 = "d31578a16ae2708385249b439c95533068e04b9507a118e905aa6768905671fc";
+const MISE_SHA256_ARM64 = "e3cb3bf4795f494a0e9be3f69ee1464de9d12a991589f126035eebd973c17796";
+const NODE_VERSION = "22.23.1";
+const PNPM_VERSION = "10.34.5";
 const PTS_VERSION = "10.8.4";
 
 export interface SetupStep {
@@ -96,9 +104,17 @@ export function setupSteps(suite: Suite): SetupStep[] {
 			// matrix cells share one unauthenticated egress IP, so even the one pnpm API lookup can hit an
 			// exhausted 60-request quota. Later `mise run` commands inherit the global Node config while
 			// task auto-install stays off. The pinned baked image takes the fast path for both checks.
+			//
+			// $SUDO on the mise fallback, because that branch writes to the BAKED image's paths, not the
+			// user's: mise installs into MISE_DATA_DIR (/usr/local/share/mise) and `--global` resolves to
+			// MISE_CONFIG_DIR (/etc/mise/config.toml), both root-owned 0755. Unprivileged and unelevated,
+			// the step dies there. Redirecting both dirs under $HOME is NOT the alternative — measured on
+			// a Runloop devbox, mise still reaches back to rebuild `latest` symlinks in the root-owned
+			// tree and fails anyway. The pnpm branch stays unelevated: its --prefix is under $HOME by
+			// design, and elevating it would plant root-owned files in the sandbox user's own home.
 			script: [
 				`cd "$HOME"`,
-				`(node -e 'process.exit(process.versions.node === "${NODE_VERSION}" ? 0 : 1)' 2>/dev/null || mise use --global --yes node@${NODE_VERSION})`,
+				`(node -e 'process.exit(process.versions.node === "${NODE_VERSION}" ? 0 : 1)' 2>/dev/null || $SUDO mise use --global --yes node@${NODE_VERSION})`,
 				`if command -v pnpm >/dev/null 2>&1 && [ "$(pnpm -v)" = "${PNPM_VERSION}" ]; then :; else npm install --global --prefix "$HOME/.local" pnpm@${PNPM_VERSION}; fi`,
 				"node -v && pnpm -v",
 			].join(" && "),

--- a/tooling/repo-checks/src/toolchain-runtime-pins.test.ts
+++ b/tooling/repo-checks/src/toolchain-runtime-pins.test.ts
@@ -81,6 +81,14 @@ describe("harness runtime pins match the baked toolchain", () => {
 		expect(harnessConstant("MISE_SHA256_ARM64")).toBe(bakePin("miseSha256Arm64"));
 	});
 
+	// PTS is the fourth constant setup.ts duplicates from pins.ts, and the original gate missed it.
+	// Its fallback is guarded by `command -v` rather than an exact version match, so drift here
+	// degrades quietly — a stock-image provider benchmarks a different PTS than the baked ones —
+	// instead of failing a step. Same duplication, same fix, only a less noisy symptom.
+	it("pins the same phoronix-test-suite release the image bakes", () => {
+		expect(harnessConstant("PTS_VERSION")).toBe(bakePin("ptsVersion"));
+	});
+
 	// The gate is only meaningful while the version check stays exact — a fuzzy check (node@22) would
 	// satisfy every assertion above while silently reintroducing "some node, whichever we find".
 	it("keeps the version check exact, which is what makes a stale pin fail loudly", () => {

--- a/tooling/repo-checks/src/toolchain-runtime-pins.test.ts
+++ b/tooling/repo-checks/src/toolchain-runtime-pins.test.ts
@@ -1,0 +1,90 @@
+// Drift gate: the runtime toolchain versions exist in TWO places — the bake pins
+// (packages/templates/src/lib/pins.ts, rendered into the image's mise.toml) and the harness's
+// stock-image fallback constants (packages/harness/src/lib/setup.ts). Comment-only alignment, and it
+// drifted for real: #243 refreshed the pins (node 22.22.3 → 22.23.1, pnpm 10.34.3 → 10.34.5, mise
+// 2026.5.16 → 2026.7.11) and left setup.ts behind for two weeks.
+//
+// Why that is worse than a cosmetic mismatch: every check in setup.ts is EXACT, so a stale constant
+// makes the baked toolchain MISS on every provider and every sandbox. The fallback then downloads the
+// stale node and rewrites the image's own /etc/mise/config.toml to point at it, and the four
+// setupNode suites measure a runtime-fetched toolchain rather than the pinned one — silently,
+// wherever the sandbox user is root. Where it is not (runloop), the write is denied and the step
+// dies, which is how a repo-wide measurement bug surfaced as one provider looking flaky.
+//
+// The harness deliberately does NOT import the templates package (it stays decoupled from the bake),
+// so the coupling cannot hold by construction the way PTS_APT_DEPS does — this gate is the
+// replacement for that. Both sides are read as TEXT and extracted line-anchored, following
+// pts-profile-pins: parsing pins.ts as a module would drag a workspace dependency into repo-checks
+// for a handful of strings.
+import { describe, expect, it } from "bun:test";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { findRepoRoot } from "./lib/workspace.ts";
+
+const root = findRepoRoot();
+const setupSource = readFileSync(join(root, "packages/harness/src/lib/setup.ts"), "utf8");
+const pinsSource = readFileSync(join(root, "packages/templates/src/lib/pins.ts"), "utf8");
+
+function extract(source: string, label: string, pattern: RegExp, name: string): string {
+	const match = source.match(pattern);
+	if (!match?.[1]) {
+		throw new Error(
+			`${label} no longer declares ${name} in the shape this gate extracts; it is read as text, ` +
+				"so update the extraction alongside the rename rather than deleting the assertion",
+		);
+	}
+	return match[1];
+}
+
+/** `const <name> = "<value>";` at the top level of setup.ts. */
+function harnessConstant(name: string): string {
+	return extract(
+		setupSource,
+		"packages/harness/src/lib/setup.ts",
+		new RegExp(`^const ${name} = "([^"]+)";$`, "m"),
+		`\`const ${name}\``,
+	);
+}
+
+/** `<name>: "<value>",` inside the rawPins object literal. */
+function bakePin(name: string): string {
+	return extract(
+		pinsSource,
+		"packages/templates/src/lib/pins.ts",
+		new RegExp(`^\\t${name}: "([^"]+)",$`, "m"),
+		`\`${name}\``,
+	);
+}
+
+describe("harness runtime pins match the baked toolchain", () => {
+	// node/pnpm are what the setupNode step version-checks and, on a miss, installs. These are the two
+	// that decide WHICH toolchain the benchmarks actually measure.
+	it("pins the same node the image bakes", () => {
+		expect(harnessConstant("NODE_VERSION")).toBe(bakePin("nodeVersion"));
+	});
+
+	it("pins the same pnpm the image bakes", () => {
+		expect(harnessConstant("PNPM_VERSION")).toBe(bakePin("pnpmVersion"));
+	});
+
+	// mise carries a `v` prefix in the harness because it interpolates straight into the GitHub release
+	// URL, while pins.ts stores the bare version for the same reason on its side.
+	it("pins the same mise release the image installs, modulo the tag prefix", () => {
+		expect(harnessConstant("MISE_VERSION")).toBe(`v${bakePin("miseVersion")}`);
+	});
+
+	// The checksums travel WITH the version: a bumped version beside a stale sha256 turns the fallback
+	// into a hard `sha256sum -c` failure on any stock-image provider, which is a different outage from
+	// the one above but the same root drift.
+	it("pins the same per-arch mise checksums", () => {
+		expect(harnessConstant("MISE_SHA256_X64")).toBe(bakePin("miseSha256X64"));
+		expect(harnessConstant("MISE_SHA256_ARM64")).toBe(bakePin("miseSha256Arm64"));
+	});
+
+	// The gate is only meaningful while the version check stays exact — a fuzzy check (node@22) would
+	// satisfy every assertion above while silently reintroducing "some node, whichever we find".
+	it("keeps the version check exact, which is what makes a stale pin fail loudly", () => {
+		expect(setupSource).toContain('process.versions.node === "');
+		expect(setupSource).toMatch(/mise use --global --yes node@\$\{NODE_VERSION\}/);
+	});
+});


### PR DESCRIPTION
Every Runloop cell in [run 31009659726](https://github.com/starslingdev/hpc-sandbox-benchmarks/actions/runs/31009659726) failed except `disk`, `network` and `system`. It reads as "Runloop is flaky." It isn't: it's one repo-wide measurement bug plus three leaves that assume the identity which *baked* the image is the identity *running* it. Runloop (uid 4444) is simply the only provider that can't paper over them.

## 1. Every provider has been benchmarking the wrong toolchain

`setup.ts` and `pins.ts` each carry node/pnpm/mise, coupled by a comment. #243 bumped the pins on 2026-07-21 (node 22.22.3 → 22.23.1, pnpm 10.34.3 → 10.34.5) and left `setup.ts` behind.

Every version check in `setup.ts` is EXACT, so since then the baked toolchain has MISSED on every provider and every sandbox: the fallback downloads node 22.22.3 and runs `mise use --global`, which — because the image sets `MISE_CONFIG_DIR=/etc/mise` — rewrites the image's own `config.toml`, header (`do not edit by hand`) and all. The four `setupNode` suites have been measuring a runtime-fetched toolchain rather than the pinned one.

That is silent wherever the sandbox user is root. On Runloop the write is denied, so the step failed 3/3 attempts and took all 12 replicates of `cpu-node` and the three `realworld` suites with it.

Measured on a live devbox: shipped constants → exit 1 in 989 ms with the CI error verbatim; aligned constants → **exit 0 in 696 ms, nothing installed**.

**Leaderboard note:** the four node suites now measure node 22.23.1 / pnpm 10.34.5 instead of 22.22.3 / 10.34.3. Provider-vs-provider rankings in existing data stay valid — every provider got the same wrong node, so it was a level shift, not a skew — but numbers before and after this PR come from different toolchains, and nothing in the committed dataset records which. Worth a fresh matrix run.

## 2. Three leaves resolved the install tree by the wrong path

`$(pts_user_dir)/installed-tests` is the install root only by coincidence: for root, PTS's daemonized branch forces `pts_user_dir` to `/var/lib`. Unprivileged it moves to `$HOME` while the baked tests stay behind — the case `pts_install_root()` exists to express.

- **`memory/stream`** — hard failure. `cd: .../stream-1.3.4: No such file or directory`, 3/3 replicates.
- **`network/iperf-wan`** — *silent*. `rm -f` and `[ -f ]` on an impossible path both no-op, so the suite stayed green while the WAN provenance the leaf calls uninterpretable-without went missing. The run artifacts have `pts_iperf-wan--server-choices.ndjson` for all three e2b replicates and none for runloop.
- **`network/fast-cli`** — same bug, dormant leaf. Fixed rather than left as a live twin.

Proven inert for root providers, from the run logs: e2b stages profiles at `/var/lib/phoronix-test-suite/…` with the install root at `/var/lib/phoronix-test-suite/installed-tests` — the same tree — while runloop stages at `/home/user/.phoronix-test-suite/…`.

## 3. Baked artifacts a non-root user can write but not own

`25-pts-profiles.sh` leaves the tree `a+rwX`, which is enough to create, truncate and delete — and not enough to `chmod`, which is gated on ownership. So the stream recompile rewrote the launcher successfully and then died `EPERM` on the file it had just written. `claim_baked_profile_dir` takes ownership first, falling back to the stock-image discard-and-reinstall branch when there is no sudo.

`pgbench` is the same theme with two layers: the bake initdb's as root and must re-tighten `pg_/data/db` to 0700 (postgres FATALs on any group/other bit), so an unprivileged user can't read the data dir — `pg_ctl` never starts — and once it can, the profile's generated script passes no `-U` anywhere, so libpq defaults to an OS username with no role. That's the opaque `pgbench: error: could not create connection for setup`. `claim_baked_pg_cluster` claims the dir and exports `PGUSER` taken from the pre-chown owner, which IS initdb's user. It claims rather than re-initdb's, because a runtime initdb would vary encoding/locale per provider and pgbench only compares across the same cluster.

## 4. A gate, so this class can't recur silently

`toolchain-runtime-pins.test.ts` ties the two pin copies together (text-extracted both sides, following `pts-profile-pins` rather than pulling a workspace dep into repo-checks). Mutation-checked: restoring `NODE_VERSION = "22.22.3"` fails it with `Expected "22.23.1" / Received "22.22.3"` and nothing else. It also pins the *exactness* of the version check, since every other assertion would pass against a fuzzy `node@22` — the same bug in disguise. It covers `PTS_VERSION` too, which was a live fourth instance.

## Verification — real sandboxes, not reasoning

| suite | before | runloop now | e2b (root control) |
|---|---|---|---|
| `cpu-node` | 12/12 failed | validated | — |
| `realworld-better-auth` | 12/12 failed | validated, 10 metrics | — |
| `memory` | 3/3 failed | validated, 4 metrics | validated |
| `pgbench` | 3/3 failed | **validated, first numbers ever** | validated |
| `network` | green, provenance missing | validated + provenance | validated |

Root-provider deltas vs the committed run: pgbench +0.2%…+4.1%. STREAM came back +9%, so I measured the spread — three replicates of the same code on e2b vary 2.9–11.1%, with the committed values within 0.4% of the observed minimum. Noise, not regression.

`memory` and `pgbench` were re-run again after the `/simplify` refactor, since it touched already-proven paths.

## Not done, deliberately

- `realworld-mastra` and `realworld-openclaw` were not run. They fail and are fixed by the identical `setupNode` path that `cpu-node` and `better-auth` both prove, but that's an inference, not a measurement.
- Three deeper restructures the review surfaced: hoisting the pins into `packages/schema` so alignment holds by construction (the `PTS_APT_DEPS` precedent — strongest of the three); `rm -f`-before-heredoc in the vendored install scripts, which would delete `claim_baked_profile_dir` entirely; and writing the bootstrap role at bake time. All are outside this diff's footprint.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Run benchmarks against the baked toolchain and let non‑root sandboxes use baked artifacts safely. Fixes Runloop failures, adds a drift gate to keep runtime pins aligned with the image, and ensures `pgbench` and STREAM skip or reinstall cleanly when recovery isn’t possible.

- **Bug Fixes**
  - Aligned `node`, `pnpm`, `mise`, and `PTS` pins in `packages/harness/src/lib/setup.ts` with the baked pins; kept exact version checks and added `$SUDO` only to the `mise` fallback.
  - Resolved PTS paths using `pts_install_root` instead of `pts_user_dir`; fixed `network/iperf-wan` provenance clearing and `network/fast-cli` launcher repair.
  - For `memory/stream`, claim the baked dir before in‑place repair and guard against stale binaries; if the dir can’t be claimed, discard the baked install to force a fresh PTS reinstall, asserting the discard lands and writing a failure marker if it doesn’t.
  - For `pgbench`, `claim_baked_pg_cluster` now exports `PGUSER` from the bootstrap owner, records it beside the data dir, and writes skip markers for both modes when sudo isn’t available or the role cannot be recovered, avoiding opaque libpq failures.

- **Refactors**
  - Added `tooling/repo-checks/src/toolchain-runtime-pins.test.ts` to prevent pin drift between bake and runtime; asserts exact checks remain and includes `PTS_VERSION`.
  - Consolidated elevation and claiming logic in `lib/bench.sh`; unified sudo detection and skip handling.

<sup>Written for commit 5109e39ad8a0d589b22dfd94f620a266f9aadba1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/starslingdev/hpc-sandbox-benchmarks/pull/350?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved benchmark reliability when using preinstalled test profiles and PostgreSQL clusters in non-root environments.
  * Added safe fallback installation when existing benchmark assets cannot be claimed.
  * Skips PostgreSQL benchmarks when required permission repair is unavailable.

* **Chores**
  * Updated fallback versions for mise, Node.js, and pnpm.
  * Improved setup permissions so only system-level tooling requires elevation.

* **Tests**
  * Added checks to keep runtime versions and checksums synchronized across project configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->