### PR TITLE
Harden CLI sandbox cleanup

### DIFF
--- a/apps/cli/src/bin/bake.ts
+++ b/apps/cli/src/bin/bake.ts
@@ -9,7 +9,11 @@
 // The provider loop + skip-vs-fail contract is shared with bench-smoke/promote (providers-run.ts);
 // the boot+smoke lifecycle (probe results captured before teardown) is shared too (smoke-run.ts).
 import { writeFileSync } from "node:fs";
-import { requiredProviders, unmetRequirements } from "@sandbox-benchmarks/harness";
+import {
+	exitAfterSandboxCleanup,
+	requiredProviders,
+	unmetRequirements,
+} from "@sandbox-benchmarks/harness";
 import type { ProviderConfig } from "@sandbox-benchmarks/providers";
 import { config } from "@sandbox-benchmarks/providers";
 import type { ProviderId } from "@sandbox-benchmarks/schema";
@@ -147,13 +151,13 @@ if (import.meta.main) {
 	// provider); on the promote path it scopes the transaction to a backfill. Parsed before any build
 	// or registry call so a typo'd id fails fast (clean message, no stack) before anything is touched.
 	let only: ProviderId[] | undefined;
-	let baseImageRef: string;
+	let baseImageRef: string = config.toolchainImageCandidate;
 	try {
 		only = requestedProviders(process.argv);
 		baseImageRef = requestedBaseImage(process.argv) ?? config.toolchainImageCandidate;
 	} catch (err) {
 		log(`error: ${err instanceof Error ? err.message : String(err)}`);
-		process.exit(2);
+		await exitAfterSandboxCleanup(2);
 	}
 
 	// Promote is the release step: publish the already-validated candidate as the public version.
@@ -170,7 +174,7 @@ if (import.meta.main) {
 					"backfills providers onto an already-published version, while --force regenerates the " +
 					"whole version in place. Pick one.",
 			);
-			process.exit(2);
+			await exitAfterSandboxCleanup(2);
 		}
 		const promoted = await promoteAll(log, { force, only });
 		writeReport({
@@ -191,7 +195,7 @@ if (import.meta.main) {
 		});
 		// The transaction outcome is separate from its diagnostics: an optional provider can fail and stay
 		// visible in the report without turning a successfully published shared version red after commit.
-		process.exit(promoted.ok ? 0 : 1);
+		await exitAfterSandboxCleanup(promoted.ok ? 0 : 1);
 	}
 
 	if (only) log(`>>> restricting bake+validate to: ${only.join(", ")}`);
@@ -202,7 +206,7 @@ if (import.meta.main) {
 			await buildAndPushCandidate(log);
 		} catch (err) {
 			log(`<<< build/push failed — ${err instanceof Error ? err.message : String(err)}`);
-			process.exit(1);
+			await exitAfterSandboxCleanup(1);
 		}
 	}
 
@@ -224,7 +228,7 @@ if (import.meta.main) {
 			log(
 				`<<< could not resolve base image digest for ${baseImageRef} — ${err instanceof Error ? err.message : String(err)}`,
 			);
-			process.exit(1);
+			await exitAfterSandboxCleanup(1);
 		}
 	} else {
 		log(`>>> no provider in scope reads ${baseImageRef} — not resolving it`);
@@ -296,7 +300,7 @@ if (import.meta.main) {
 		reports,
 	});
 
-	if (anyFailed(runs)) process.exit(1);
+	if (anyFailed(runs)) await exitAfterSandboxCleanup(1);
 
 	// D1: at the publish boundary (CI passes `--require e2b,daytona-vm,modal-gvisor`) a required provider that was
 	// skipped for a missing/misnamed secret — or failed to validate — must fail the bake loudly, so a
@@ -307,6 +311,7 @@ if (import.meta.main) {
 		log(
 			`error: required providers did not pass: ${unmet.join(", ")} (--require / REQUIRE_PROVIDERS)`,
 		);
-		process.exit(1);
+		await exitAfterSandboxCleanup(1);
 	}
+	await exitAfterSandboxCleanup(0);
 }

--- a/apps/cli/src/bin/bench-lifecycle.ts
+++ b/apps/cli/src/bin/bench-lifecycle.ts
@@ -11,6 +11,7 @@
 // stdout. bun auto-loads .env, so local creds in a .env file are picked up.
 import {
 	benchmarkLifecycle,
+	exitAfterSandboxCleanup,
 	requiredProviders,
 	unmetRequirements,
 } from "@sandbox-benchmarks/harness";
@@ -88,7 +89,7 @@ if (import.meta.main) {
 	console.log(JSON.stringify({ summary }, null, 2));
 
 	// Skips (missing creds) never fail the run; only a provider that ran and broke does.
-	if (anyFailed(runs)) process.exit(1);
+	if (anyFailed(runs)) await exitAfterSandboxCleanup(1);
 
 	// At the CI/publish boundary a *required* provider that didn't run-and-pass must fail the lane loudly,
 	// so a green run can't hide that a provider was never actually measured.
@@ -98,6 +99,7 @@ if (import.meta.main) {
 		log(
 			`error: required providers did not pass: ${unmet.join(", ")} (--require / REQUIRE_PROVIDERS)`,
 		);
-		process.exit(1);
+		await exitAfterSandboxCleanup(1);
 	}
+	await exitAfterSandboxCleanup(0);
 }

--- a/apps/cli/src/bin/bench-smoke.ts
+++ b/apps/cli/src/bin/bench-smoke.ts
@@ -10,7 +10,11 @@
 // Observability: a per-provider/per-check log goes to stderr (with durations and, on failure, the
 // captured output); the machine-readable summary is the JSON on stdout. bun auto-loads .env, so
 // local creds in a .env file are picked up.
-import { requiredProviders, unmetRequirements } from "@sandbox-benchmarks/harness";
+import {
+	exitAfterSandboxCleanup,
+	requiredProviders,
+	unmetRequirements,
+} from "@sandbox-benchmarks/harness";
 import { anyFailed, forEachProviderWithCreds } from "../lib/providers-run.ts";
 import { bootAndSmoke, logChecks, smokeFailureReason, smokeOk } from "../lib/smoke-run.ts";
 
@@ -47,7 +51,7 @@ if (import.meta.main) {
 	console.log(JSON.stringify({ summary }, null, 2));
 
 	// Skips never fail the run; only a provider that ran and broke does.
-	if (anyFailed(runs)) process.exit(1);
+	if (anyFailed(runs)) await exitAfterSandboxCleanup(1);
 
 	// D1: at the CI/publish boundary a *required* provider that didn't run-and-pass — skipped for a
 	// missing/misnamed secret, or failed — must fail the lane loudly, so a green run can't hide that
@@ -58,6 +62,7 @@ if (import.meta.main) {
 		log(
 			`error: required providers did not pass: ${unmet.join(", ")} (--require / REQUIRE_PROVIDERS)`,
 		);
-		process.exit(1);
+		await exitAfterSandboxCleanup(1);
 	}
+	await exitAfterSandboxCleanup(0);
 }

--- a/apps/cli/src/bin/bench-suite.ts
+++ b/apps/cli/src/bin/bench-suite.ts
@@ -16,9 +16,11 @@ import { join } from "node:path";
 import * as core from "@actions/core";
 import {
 	CREATE_FAILURE_PREFIX,
+	exitAfterSandboxCleanup,
 	requiredProviders,
 	runSuite,
 	SuiteUsageError,
+	shutdownOwnedSandboxes,
 	unmetRequirements,
 } from "@sandbox-benchmarks/harness";
 import { writeNormalizedRun } from "@sandbox-benchmarks/results";
@@ -802,9 +804,13 @@ if (import.meta.main) {
 			...(outcome.detail !== undefined ? { detail: outcome.detail } : {}),
 			...(taskPlan ? { taskPlan } : {}),
 		});
-		if (outcome.failed) fail(outcome.detail ?? `Cell ${cell} failed`, { annotate: false });
-		process.exit(0);
+		if (outcome.failed) {
+			await shutdownOwnedSandboxes();
+			fail(outcome.detail ?? `Cell ${cell} failed`, { annotate: false });
+		}
+		await exitAfterSandboxCleanup(0);
 	}
+	if (replicateIndices === undefined) throw new Error("unreachable after sandbox cleanup exit");
 
 	// Fan-out path: R replicate sandboxes, all from this process. Foldable groups are turned off and
 	// every line is tagged with its replicate instead — Actions groups are a single ordered stream, so
@@ -880,14 +886,13 @@ if (import.meta.main) {
 	const failures = outcomes.filter((o) => o.failed);
 	if (failures.length > 0) {
 		// reportFleet already annotated with every failure's detail; exit non-zero without a second one.
+		await shutdownOwnedSandboxes();
 		fail(`${failures.length}/${outcomes.length} replicate(s) of ${cell} failed`, {
 			annotate: false,
 		});
 	}
 	logInfo(`Cell ${cell}: ${outcomes.length}/${outcomes.length} replicate(s) succeeded`);
-	// Exit explicitly, matching the single-sandbox path above. `createSuiteSandbox` deliberately leaves
-	// a floating `createPromise.then(destroySandbox)` behind for a create that resolved after its
-	// timeout was lost, and a provider SDK may hold a keep-alive socket; falling off the end would make
-	// the cell wait on those instead of finishing, turning an all-green fleet into a job-timeout red.
-	process.exit(0);
+	// Exit explicitly, matching the single-sandbox path above. The bounded ownership drain waits for a
+	// late create long enough to destroy it without letting a wedged provider keep the cell alive forever.
+	await exitAfterSandboxCleanup(0);
 }

--- a/packages/harness/src/index.test.ts
+++ b/packages/harness/src/index.test.ts
@@ -1,4 +1,4 @@
-import { afterAll, describe, expect, it } from "bun:test";
+import { afterAll, afterEach, describe, expect, it } from "bun:test";
 import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
@@ -22,6 +22,7 @@ import {
 import type { CommandResult, SandboxHandle } from "./lib/execute.ts";
 import type { LifecycleCompute } from "./lib/lifecycle.ts";
 import { READINESS_CMD } from "./lib/readiness.ts";
+import { cleanupOwnedSandboxes } from "./lib/sandbox-owner.ts";
 
 // A transport capability for the test fixtures — capped-with-detach, matching a single-round-trip
 // provider; none of these tests exercise real exec, so the exact values are inert here.
@@ -41,6 +42,7 @@ const config: ProviderConfig = {
 // A fake provider that records its lifecycle calls, so withSandbox can be exercised offline with no
 // real SDK. Only the methods withSandbox touches are implemented; the cast recovers the full type.
 function fakeProvider(calls: string[], opts: { destroyFails?: boolean } = {}): ProviderConfig {
+	let remainingDestroyFailures = opts.destroyFails ? 1 : 0;
 	const sandbox = {
 		sandboxId: "sb-1",
 		provider: "e2b",
@@ -50,7 +52,11 @@ function fakeProvider(calls: string[], opts: { destroyFails?: boolean } = {}): P
 		},
 		destroy: () => {
 			calls.push("destroy");
-			return opts.destroyFails ? Promise.reject(new Error("destroy failed")) : Promise.resolve();
+			if (remainingDestroyFailures > 0) {
+				remainingDestroyFailures--;
+				return Promise.reject(new Error("destroy failed"));
+			}
+			return Promise.resolve();
 		},
 	};
 	const compute = {
@@ -68,6 +74,10 @@ function fakeProvider(calls: string[], opts: { destroyFails?: boolean } = {}): P
 		createCompute: () => compute,
 	};
 }
+
+afterEach(async () => {
+	expect(await cleanupOwnedSandboxes()).toEqual([]);
+});
 
 describe("@sandbox-benchmarks/harness", () => {
 	it("times an operation and emits a raw run for the provider", async () => {

--- a/packages/harness/src/index.ts
+++ b/packages/harness/src/index.ts
@@ -14,6 +14,7 @@ import type { LifecycleAggregate, LifecycleCompute } from "./lib/lifecycle.ts";
 import { aggregateLifecycle, measureLifecycle } from "./lib/lifecycle.ts";
 import type { WaitUntilReadyOptions } from "./lib/readiness.ts";
 import { neverReadyReason, waitUntilReady } from "./lib/readiness.ts";
+import { createOwnedSandbox } from "./lib/sandbox-owner.ts";
 import { DIR, OBSERVED_SPECS_SCRIPT, REPO_REF, REPO_URL, setupSteps } from "./lib/setup.ts";
 
 // Re-export the lifecycle measurement surface so consumers import it from the package root, never
@@ -27,6 +28,7 @@ export type {
 	MeasureLifecycleOptions,
 } from "./lib/lifecycle.ts";
 export { aggregateLifecycle, measureLifecycle } from "./lib/lifecycle.ts";
+export { exitAfterSandboxCleanup, shutdownOwnedSandboxes } from "./lib/sandbox-owner.ts";
 
 /**
  * The universal sandbox a provider's `sandbox.create` returns (computesdk's `Sandbox`). Derived from
@@ -373,7 +375,7 @@ export async function createSuiteSandbox(
 		let createPromise: Promise<SandboxHandle> | undefined;
 		try {
 			const compute = computeFactory();
-			createPromise = Promise.resolve(
+			createPromise = createOwnedSandbox(() =>
 				compute.sandbox.create({
 					...createOptions,
 					// Ask for a sandbox lifetime covering setup + the suite, where supported.
@@ -600,7 +602,7 @@ export async function withSandbox<T>(
 	fn: (sandbox: Sandbox) => Promise<T>,
 ): Promise<T> {
 	const compute = config.createCompute();
-	const sandbox = await compute.sandbox.create(config.createOptions);
+	const sandbox = await createOwnedSandbox(() => compute.sandbox.create(config.createOptions));
 	let result: T;
 	try {
 		result = await fn(sandbox);

--- a/packages/harness/src/lib/lifecycle.test.ts
+++ b/packages/harness/src/lib/lifecycle.test.ts
@@ -1,9 +1,10 @@
-import { describe, expect, it } from "bun:test";
+import { afterEach, describe, expect, it } from "bun:test";
 import type { GapCause, RawRun, ResultGap } from "@sandbox-benchmarks/schema";
 import { HARNESS_METRIC_IDS } from "@sandbox-benchmarks/schema";
 import { GapError } from "./gap-cause.ts";
 import type { LifecycleCompute, LifecycleSandbox } from "./lifecycle.ts";
 import { aggregateLifecycle, measureLifecycle } from "./lifecycle.ts";
+import { cleanupOwnedSandboxes } from "./sandbox-owner.ts";
 
 interface FakeCalls {
 	order: string[];
@@ -39,6 +40,7 @@ const noDelay = async (): Promise<void> => {};
 function fakeCompute(opts: FakeOptions = {}): { compute: LifecycleCompute; calls: FakeCalls } {
 	const calls: FakeCalls = { order: [], deletedSnapshots: [] };
 	let readinessProbes = 0;
+	let remainingDestroyFailures = opts.failDestroy ? 1 : 0;
 	const sandbox: LifecycleSandbox = {
 		sandboxId: "sb-1",
 		async runCommand(command) {
@@ -66,7 +68,10 @@ function fakeCompute(opts: FakeOptions = {}): { compute: LifecycleCompute; calls
 		},
 		async destroy() {
 			calls.order.push("destroy");
-			if (opts.failDestroy) throw new Error("destroy boom");
+			if (remainingDestroyFailures > 0) {
+				remainingDestroyFailures--;
+				throw new Error("destroy boom");
+			}
 			return undefined;
 		},
 	};
@@ -99,6 +104,10 @@ function fakeCompute(opts: FakeOptions = {}): { compute: LifecycleCompute; calls
 	}
 	return { compute, calls };
 }
+
+afterEach(async () => {
+	expect(await cleanupOwnedSandboxes()).toEqual([]);
+});
 
 /** Map of Metric id → number of Samples that carry it. */
 function countByOp(samples: RawRun[]): Record<string, number> {

--- a/packages/harness/src/lib/lifecycle.ts
+++ b/packages/harness/src/lib/lifecycle.ts
@@ -29,6 +29,7 @@ import { aggregate, HARNESS_METRIC_IDS } from "@sandbox-benchmarks/schema";
 import { gapCauseOf } from "./gap-cause.ts";
 import { now as defaultNow, time } from "./internal.ts";
 import { neverReadyReason, waitUntilReady } from "./readiness.ts";
+import { createOwnedSandbox } from "./sandbox-owner.ts";
 
 /**
  * Per-probe ceiling for THIS driver's readiness loop, deliberately far tighter than the suite path's.
@@ -213,7 +214,7 @@ export async function measureLifecycle(
 	// usable yet (the readiness loop below measures when it becomes so). A failure has no sandbox to tear
 	// down, so it rejects and the caller records the failed cold-start cycle.
 	const t0 = clock();
-	const sandbox = await compute.sandbox.create(options.createOptions);
+	const sandbox = await createOwnedSandbox(() => compute.sandbox.create(options.createOptions));
 	const createdAt = clock();
 	sample(HARNESS_METRIC_IDS.spawn, floor(createdAt - t0));
 

--- a/packages/harness/src/lib/sandbox-owner.signal.fixture.ts
+++ b/packages/harness/src/lib/sandbox-owner.signal.fixture.ts
@@ -1,0 +1,27 @@
+import { appendFileSync } from "node:fs";
+import { createOwnedSandbox, exitAfterSandboxCleanup } from "./sandbox-owner.ts";
+
+const logFile = process.argv[2];
+if (!logFile) throw new Error("missing signal fixture log path");
+const mode = process.argv[3] ?? "signal";
+let destroyAttempts = 0;
+
+const sandbox = await createOwnedSandbox(async () => ({
+	sandboxId: "sb-signal",
+	async destroy() {
+		appendFileSync(logFile, "destroy\n");
+		destroyAttempts++;
+		if (destroyAttempts === 1 && mode !== "exit") throw new Error("transient destroy failure");
+	},
+}));
+appendFileSync(logFile, "ready\n");
+
+if (mode === "exit") await exitAfterSandboxCleanup(7);
+if (mode === "natural") {
+	await sandbox.destroy().catch(() => {});
+	appendFileSync(logFile, "end\n");
+} else {
+	// Keep the fixture alive until the test sends SIGTERM. The ownership handler performs teardown and
+	// exits; this timer must never get a chance to decide the fixture's lifetime itself.
+	setInterval(() => {}, 60_000);
+}

--- a/packages/harness/src/lib/sandbox-owner.test.ts
+++ b/packages/harness/src/lib/sandbox-owner.test.ts
@@ -1,0 +1,145 @@
+import { describe, expect, it } from "bun:test";
+import { existsSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { cleanupOwnedSandboxes, createOwnedSandbox } from "./sandbox-owner.ts";
+
+function deferred<T>(): { promise: Promise<T>; resolve: (value: T) => void } {
+	let resolve!: (value: T) => void;
+	const promise = new Promise<T>((done) => {
+		resolve = done;
+	});
+	return { promise, resolve };
+}
+
+async function waitForFile(path: string): Promise<void> {
+	const deadline = Date.now() + 2_000;
+	while (!existsSync(path)) {
+		if (Date.now() >= deadline) throw new Error("signal fixture did not become ready");
+		await Bun.sleep(10);
+	}
+}
+
+describe("sandbox process ownership", () => {
+	it("preserves the provider surface and destroys only once", async () => {
+		let destroys = 0;
+		const sandbox = await createOwnedSandbox(async () => ({
+			sandboxId: "sb-1",
+			value: 42,
+			read(this: { value: number }): number {
+				return this.value;
+			},
+			async destroy() {
+				destroys++;
+			},
+		}));
+
+		expect(sandbox.read()).toBe(42);
+		await Promise.all([sandbox.destroy(), sandbox.destroy()]);
+		expect(destroys).toBe(1);
+		expect(await cleanupOwnedSandboxes()).toEqual([]);
+	});
+
+	it("owns a create before it resolves and drains the late handle", async () => {
+		const creation = deferred<{ sandboxId: string; destroy(): Promise<void> }>();
+		let destroys = 0;
+		const sandboxPromise = createOwnedSandbox(() => creation.promise);
+		const cleanup = cleanupOwnedSandboxes();
+
+		creation.resolve({
+			sandboxId: "sb-late",
+			async destroy() {
+				destroys++;
+			},
+		});
+
+		await cleanup;
+		expect((await sandboxPromise).sandboxId).toBe("sb-late");
+		expect(destroys).toBe(1);
+	});
+
+	it("keeps a failed destroy owned so cleanup can retry it", async () => {
+		let destroys = 0;
+		const sandbox = await createOwnedSandbox(async () => ({
+			sandboxId: "sb-retry",
+			async destroy() {
+				destroys++;
+				if (destroys === 1) throw new Error("transient teardown failure");
+			},
+		}));
+
+		await expect(sandbox.destroy()).rejects.toThrow("transient teardown failure");
+		expect(await cleanupOwnedSandboxes()).toEqual([]);
+		expect(destroys).toBe(2);
+	});
+
+	it("bounds cleanup while a create is still pending", async () => {
+		const creation = deferred<{ sandboxId: string; destroy(): Promise<void> }>();
+		const sandboxPromise = createOwnedSandbox(() => creation.promise);
+		const startedAt = Date.now();
+		const failures = await cleanupOwnedSandboxes({ attempts: 1, timeoutMs: 20 });
+		expect(Date.now() - startedAt).toBeLessThan(250);
+		expect(failures).toHaveLength(1);
+		expect(String(failures[0])).toContain("timed out");
+
+		creation.resolve({ sandboxId: "sb-eventual", async destroy() {} });
+		await sandboxPromise;
+		expect(await cleanupOwnedSandboxes()).toEqual([]);
+	});
+
+	it("retries teardown before SIGTERM exits the process", async () => {
+		const dir = mkdtempSync(join(tmpdir(), "sandbox-owner-signal-"));
+		const logFile = join(dir, "lifecycle.log");
+		const fixture = join(import.meta.dir, "sandbox-owner.signal.fixture.ts");
+		const proc = Bun.spawn(["bun", fixture, logFile], { stdout: "pipe", stderr: "pipe" });
+		try {
+			await waitForFile(logFile);
+			proc.kill("SIGTERM");
+			expect(await proc.exited).toBe(143);
+			expect(readFileSync(logFile, "utf8").trim().split("\n")).toEqual([
+				"ready",
+				"destroy",
+				"destroy",
+			]);
+		} finally {
+			proc.kill();
+			rmSync(dir, { recursive: true, force: true });
+		}
+	});
+
+	it("drains before an explicit CLI exit", async () => {
+		const dir = mkdtempSync(join(tmpdir(), "sandbox-owner-exit-"));
+		const logFile = join(dir, "lifecycle.log");
+		const fixture = join(import.meta.dir, "sandbox-owner.signal.fixture.ts");
+		const proc = Bun.spawn(["bun", fixture, logFile, "exit"], { stdout: "pipe", stderr: "pipe" });
+		try {
+			expect(await proc.exited).toBe(7);
+			expect(readFileSync(logFile, "utf8").trim().split("\n")).toEqual(["ready", "destroy"]);
+		} finally {
+			proc.kill();
+			rmSync(dir, { recursive: true, force: true });
+		}
+	});
+
+	it("retries a failed teardown before natural process exit", async () => {
+		const dir = mkdtempSync(join(tmpdir(), "sandbox-owner-natural-"));
+		const logFile = join(dir, "lifecycle.log");
+		const fixture = join(import.meta.dir, "sandbox-owner.signal.fixture.ts");
+		const proc = Bun.spawn(["bun", fixture, logFile, "natural"], {
+			stdout: "pipe",
+			stderr: "pipe",
+		});
+		try {
+			expect(await proc.exited).toBe(0);
+			expect(readFileSync(logFile, "utf8").trim().split("\n")).toEqual([
+				"ready",
+				"destroy",
+				"end",
+				"destroy",
+			]);
+		} finally {
+			proc.kill();
+			rmSync(dir, { recursive: true, force: true });
+		}
+	});
+});

--- a/packages/harness/src/lib/sandbox-owner.ts
+++ b/packages/harness/src/lib/sandbox-owner.ts
@@ -1,0 +1,259 @@
+/**
+ * Process-level ownership for provider sandboxes.
+ *
+ * Every harness create goes through {@link createOwnedSandbox}. The returned handle keeps the
+ * provider's surface, but its destroy is idempotent and removes it from the process registry only
+ * after the provider confirms teardown. While anything is pending or live, SIGINT/SIGTERM drain the
+ * registry before exiting. Ordinary CLI exits use the same bounded drain, `beforeExit` covers a
+ * natural fallthrough, and a second signal preserves the usual "force quit now" escape hatch.
+ */
+
+interface DestroyableSandbox {
+	readonly sandboxId?: string;
+	destroy(): Promise<unknown>;
+}
+
+interface OwnedEntry<T extends DestroyableSandbox> {
+	promise: Promise<T>;
+	destroy?: () => Promise<unknown>;
+	sandboxId?: string;
+}
+
+export interface SandboxCleanupOptions {
+	/** Total cleanup attempts. Defaults to 3. */
+	attempts?: number;
+	/** Total wall-clock cleanup budget. Defaults to 15 seconds. */
+	timeoutMs?: number;
+	/** Delay between attempts. Defaults to 250ms. */
+	retryDelayMs?: number;
+}
+
+const owned = new Set<OwnedEntry<DestroyableSandbox>>();
+const signals = ["SIGINT", "SIGTERM"] as const;
+const DEFAULT_CLEANUP_ATTEMPTS = 3;
+const DEFAULT_CLEANUP_TIMEOUT_MS = 15_000;
+const DEFAULT_CLEANUP_RETRY_MS = 250;
+
+let handlersInstalled = false;
+let stopping = false;
+let signalCleanup: Promise<void> | undefined;
+let beforeExitCleanup: Promise<void> | undefined;
+
+function signalExitCode(signal: (typeof signals)[number]): number {
+	return signal === "SIGINT" ? 130 : 143;
+}
+
+function uninstallProcessHandlers(): void {
+	if (!handlersInstalled) return;
+	for (const signal of signals) process.off(signal, onSignal);
+	process.off("beforeExit", onBeforeExit);
+	handlersInstalled = false;
+}
+
+function release(entry: OwnedEntry<DestroyableSandbox>): void {
+	owned.delete(entry);
+	if (owned.size === 0) uninstallProcessHandlers();
+}
+
+async function destroyEntry(entry: OwnedEntry<DestroyableSandbox>): Promise<void> {
+	try {
+		await entry.promise;
+	} catch {
+		// A rejected create allocated no handle and removes itself from the registry.
+		return;
+	}
+	await entry.destroy?.();
+}
+
+function positiveInteger(value: number | undefined, fallback: number): number {
+	return value !== undefined && Number.isFinite(value) && value > 0 ? Math.floor(value) : fallback;
+}
+
+function delay(ms: number): Promise<void> {
+	return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+async function withinDeadline(
+	entry: OwnedEntry<DestroyableSandbox>,
+	deadline: number,
+): Promise<void> {
+	const remainingMs = deadline - Date.now();
+	if (remainingMs <= 0) {
+		throw new Error(`Sandbox cleanup timed out${entry.sandboxId ? ` (${entry.sandboxId})` : ""}`);
+	}
+
+	let timer: ReturnType<typeof setTimeout> | undefined;
+	try {
+		await Promise.race([
+			destroyEntry(entry),
+			new Promise<never>((_resolve, reject) => {
+				timer = setTimeout(
+					() =>
+						reject(
+							new Error(
+								`Sandbox cleanup timed out${entry.sandboxId ? ` (${entry.sandboxId})` : " during creation"}`,
+							),
+						),
+					remainingMs,
+				);
+			}),
+		]);
+	} finally {
+		if (timer !== undefined) clearTimeout(timer);
+	}
+}
+
+/** Destroy every pending/live sandbox currently owned by this process, with bounded retries. */
+export async function cleanupOwnedSandboxes(
+	options: SandboxCleanupOptions = {},
+): Promise<unknown[]> {
+	const attempts = positiveInteger(options.attempts, DEFAULT_CLEANUP_ATTEMPTS);
+	const timeoutMs = positiveInteger(options.timeoutMs, DEFAULT_CLEANUP_TIMEOUT_MS);
+	const retryDelayMs = positiveInteger(options.retryDelayMs, DEFAULT_CLEANUP_RETRY_MS);
+	const deadline = Date.now() + timeoutMs;
+	let failures: unknown[] = [];
+
+	for (let attempt = 1; attempt <= attempts && owned.size > 0; attempt++) {
+		failures = [];
+		await Promise.all(
+			[...owned].map(async (entry) => {
+				try {
+					await withinDeadline(entry, deadline);
+				} catch (error) {
+					failures.push(error);
+				}
+			}),
+		);
+		if (owned.size === 0) return [];
+
+		const remainingMs = deadline - Date.now();
+		if (attempt < attempts && remainingMs > 0) {
+			await delay(Math.min(retryDelayMs, remainingMs));
+		}
+	}
+
+	if (owned.size > 0 && failures.length === 0) {
+		failures.push(new Error(`Could not clean up ${owned.size} owned sandbox(es)`));
+	}
+	return failures;
+}
+
+function logCleanupFailures(context: string, failures: readonly unknown[]): void {
+	for (const failure of failures) {
+		console.error(
+			`[cleanup] destroy failed during ${context}: ${
+				failure instanceof Error ? failure.message : String(failure)
+			}`,
+		);
+	}
+}
+
+/** Stop new creates and drain all owned sandboxes before an ordinary CLI exit. */
+export async function shutdownOwnedSandboxes(context = "process exit"): Promise<unknown[]> {
+	stopping = true;
+	const failures = await cleanupOwnedSandboxes();
+	logCleanupFailures(context, failures);
+	return failures;
+}
+
+/** Exit only after the process has made its bounded cleanup attempts. */
+export async function exitAfterSandboxCleanup(exitCode: number): Promise<never> {
+	const failures = await shutdownOwnedSandboxes();
+	process.exit(exitCode === 0 && failures.length > 0 ? 1 : exitCode);
+}
+
+function onSignal(signal: (typeof signals)[number]): void {
+	const exitCode = signalExitCode(signal);
+	if (signalCleanup !== undefined) {
+		process.exit(exitCode);
+	}
+
+	stopping = true;
+	console.error(`[cleanup] ${signal} received; destroying ${owned.size} sandbox(es)...`);
+	signalCleanup = shutdownOwnedSandboxes(signal).then(() => {
+		uninstallProcessHandlers();
+		process.exit(exitCode);
+	});
+}
+
+function onBeforeExit(): void {
+	if (owned.size === 0 || beforeExitCleanup !== undefined) return;
+	console.error(`[cleanup] process exiting; destroying ${owned.size} sandbox(es)...`);
+	beforeExitCleanup = shutdownOwnedSandboxes("process exit").then((failures) => {
+		if (failures.length > 0) process.exitCode = 1;
+		uninstallProcessHandlers();
+	});
+}
+
+function installProcessHandlers(): void {
+	if (handlersInstalled) return;
+	for (const signal of signals) process.on(signal, onSignal);
+	process.on("beforeExit", onBeforeExit);
+	handlersInstalled = true;
+}
+
+/**
+ * Create a sandbox owned by this process. Registration happens before `create` is invoked, so a
+ * signal during provisioning waits for the handle and tears it down. Provider methods are bound to
+ * the original SDK object (several SDKs use private fields); only `destroy` is replaced.
+ */
+export function createOwnedSandbox<T extends DestroyableSandbox>(
+	create: () => Promise<T>,
+): Promise<T> {
+	if (stopping) return Promise.reject(new Error("Sandbox creation refused during shutdown"));
+
+	installProcessHandlers();
+	const entry = {} as OwnedEntry<T>;
+	owned.add(entry as OwnedEntry<DestroyableSandbox>);
+
+	entry.promise = Promise.resolve()
+		.then(create)
+		.then(
+			(sandbox) => {
+				entry.sandboxId = sandbox.sandboxId;
+				const providerDestroy = sandbox.destroy.bind(sandbox);
+				let destroying: Promise<unknown> | undefined;
+				const destroy = (): Promise<unknown> => {
+					if (destroying !== undefined) return destroying;
+					destroying = providerDestroy().then(
+						(value) => {
+							release(entry as OwnedEntry<DestroyableSandbox>);
+							return value;
+						},
+						(error) => {
+							destroying = undefined;
+							throw error;
+						},
+					);
+					return destroying;
+				};
+				entry.destroy = destroy;
+
+				// Keep object identity intact: callers may compare the returned SDK handle, and replacing one
+				// method on the instance leaves every private-field-backed provider method on its real receiver.
+				try {
+					Object.defineProperty(sandbox, "destroy", {
+						configurable: true,
+						value: destroy,
+					});
+					return sandbox;
+				} catch {
+					// Defensive fallback for an SDK that freezes its handles. Bind methods back to the real
+					// object so JavaScript private fields remain valid through the proxy.
+					return new Proxy(sandbox, {
+						get(target, property) {
+							if (property === "destroy") return destroy;
+							const value = Reflect.get(target, property, target);
+							return typeof value === "function" ? value.bind(target) : value;
+						},
+					});
+				}
+			},
+			(error) => {
+				release(entry as OwnedEntry<DestroyableSandbox>);
+				throw error;
+			},
+		);
+
+	return entry.promise;
+}


### PR DESCRIPTION
## Summary

- centralize ownership of sandboxes created by suite, smoke/bake, and lifecycle commands
- drain owned sandboxes with bounded retries on signals, explicit exits, and natural exits
- bound pending sandbox creation during cleanup and preserve idempotent teardown

## Why

The CLI's normal `finally` blocks did not cover process cancellation, explicit exits, late creates, or transient destroy failures. Those gaps could leave provider sandboxes, including expensive GPU sandboxes, running.

## Validation

- `bun run lint`
- `bun run typecheck`
- `bun run spell`
- `bun run test` (with commit signing disabled for the temporary Git fixture)
- `bun run check:catalog-drift`
- live Modal T4 ordinary-exit probe; zero tagged sandboxes remained after exit

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Centralized sandbox ownership and cleanup in `@sandbox-benchmarks/harness`. The CLI now drains pending and live sandboxes with bounded retries on signals and on exit to prevent leaked provider sandboxes.

- **New Features**
  - Added process-level ownership: `createOwnedSandbox` wraps provider creates; `destroy` is idempotent and retried; pending creates are owned and later drained.
  - Bounded cleanup with retries and timeouts via `cleanupOwnedSandboxes`; manual `shutdownOwnedSandboxes`; explicit exit helper `exitAfterSandboxCleanup`.
  - Installed signal and beforeExit hooks to drain sandboxes on SIGINT/SIGTERM and natural exits; second signal still force-exits.
  - Replaced `process.exit` with `exitAfterSandboxCleanup` in `bake`, `bench-smoke`, `bench-lifecycle`, and `bench-suite`; single-replicate failure path calls `shutdownOwnedSandboxes` before failing.
  - Added tests and a signal fixture covering late creates, transient destroy failures, signals, explicit exit, and natural exit paths.

- **Bug Fixes**
  - Closing gaps where cancellation, explicit exits, late creates, or transient teardown failures could leak provider sandboxes (including GPU instances).

<sup>Written for commit 90c24af8211c0c3913b709b590e93695ff39ad2b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/starslingdev/hpc-sandbox-benchmarks/pull/354?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automatic sandbox cleanup before CLI commands exit.
  * Added retryable, time-bounded cleanup for sandboxes during normal shutdown and termination signals.
  * Preserved sandbox handle behavior while tracking active sandbox ownership.
  * Prevented new sandbox creation during shutdown.

* **Bug Fixes**
  * Improved cleanup reliability when sandbox destruction initially fails.

* **Tests**
  * Added coverage for cleanup retries, timeouts, signal handling, and process exit scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->