### PR TITLE
feat(pts): add vLLM SPEED-Bench profile

### DIFF
--- a/packages/schema/scripts/generate-catalog.ts
+++ b/packages/schema/scripts/generate-catalog.ts
@@ -1,5 +1,5 @@
 #!/usr/bin/env bun
-// `generate-catalog` — regenerate `src/pts-generated.ts` from every vendored profile under
+// `generate-catalog` — regenerate `src/pts-generated.ts` from catalog-eligible vendored profiles under
 // `src/pts-profiles/`. Reads the committed XML (never the network), maps each profile to draft
 // `MetricDef[]` (./catalog/generate.ts), serializes deterministically (./catalog/serialize.ts), and
 // pipes the result through Biome so the committed bytes match a fresh run — the invariant the catalog
@@ -15,6 +15,7 @@ import { serializeCatalog } from "./catalog/serialize.ts";
 
 const PROFILES_DIR = `${import.meta.dir}/../src/pts-profiles`;
 const OUT_FILE = `${import.meta.dir}/../src/pts-generated.ts`;
+const CATALOG_IGNORE_FILE = ".catalog-ignore";
 
 async function readXml(path: string): Promise<string> {
 	const file = Bun.file(path);
@@ -22,7 +23,10 @@ async function readXml(path: string): Promise<string> {
 }
 
 /**
- * Discover every vendored profile as a `{ repo, dir }` pair. A flat `pts-profiles/<name>-<ver>` (with a
+ * Discover each catalog-eligible vendored profile as a `{ repo, dir }` pair. A profile-local
+ * `.catalog-ignore` keeps specialized suites (for example GPU-only matrices) vendored and runnable
+ * without pretending their heterogeneous metrics belong in the CPU sandbox comparison catalog.
+ * A flat `pts-profiles/<name>-<ver>` (with a
  * test-definition.xml directly inside) is an upstream profile → repo `pts`. A `pts-profiles/<repo>/…`
  * directory (no test-definition.xml of its own, only child profile dirs) is a repo-local source → that
  * `<repo>` is the prefix (PTS reports e.g. `local/hardlink-1.0.0`). Sorted by repo then dir so the
@@ -34,14 +38,20 @@ async function discoverProfiles(): Promise<Array<{ repo: string; dir: string; ba
 		if (!entry.isDirectory()) continue;
 		const path = `${PROFILES_DIR}/${entry.name}`;
 		if (await Bun.file(`${path}/test-definition.xml`).exists()) {
-			out.push({ repo: "pts", dir: entry.name, base: path });
+			if (!(await Bun.file(`${path}/${CATALOG_IGNORE_FILE}`).exists())) {
+				out.push({ repo: "pts", dir: entry.name, base: path });
+			}
 			continue;
 		}
 		// Repo subdir (e.g. `local/`): one level of nested profile dirs.
 		for (const child of await readdir(path, { withFileTypes: true })) {
 			if (!child.isDirectory()) continue;
-			if (await Bun.file(`${path}/${child.name}/test-definition.xml`).exists()) {
-				out.push({ repo: entry.name, dir: child.name, base: `${path}/${child.name}` });
+			const childPath = `${path}/${child.name}`;
+			if (
+				(await Bun.file(`${childPath}/test-definition.xml`).exists()) &&
+				!(await Bun.file(`${childPath}/${CATALOG_IGNORE_FILE}`).exists())
+			) {
+				out.push({ repo: entry.name, dir: child.name, base: childPath });
 			}
 		}
 	}

--- a/packages/schema/src/pts-profiles/local/vllm-speed-bench-1.0.0/.catalog-ignore
+++ b/packages/schema/src/pts-profiles/local/vllm-speed-bench-1.0.0/.catalog-ignore
@@ -1,0 +1,1 @@
+# Specialized GPU-only profile; its online-serving metrics do not belong in the CPU catalog.

--- a/packages/schema/src/pts-profiles/local/vllm-speed-bench-1.0.0/install.sh
+++ b/packages/schema/src/pts-profiles/local/vllm-speed-bench-1.0.0/install.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+# The image owns dependencies; PTS installs only the repository-owned runner.
+set -eu
+
+# Same override the runner reads, so installation validates the executable the benchmark then runs.
+vllm_bin="${BENCH_VLLM_BIN:-/opt/vllm/bin/vllm}"
+profile_dir="$(cd -- "$(dirname -- "$0")" && pwd)"
+runner="${profile_dir}/runner.sh"
+if [ ! -x "$vllm_bin" ] || [ ! -f "$runner" ]; then
+	echo "ERROR: vLLM or runner is missing: ${vllm_bin}, ${runner}" >&2
+	echo 1 >"${HOME}/install-exit-status"
+	exit 1
+fi
+"$vllm_bin" --version
+cp "$runner" "${HOME}/vllm"
+chmod +x "${HOME}/vllm"
+echo 0 >"${HOME}/install-exit-status"

--- a/packages/schema/src/pts-profiles/local/vllm-speed-bench-1.0.0/results-definition.xml
+++ b/packages/schema/src/pts-profiles/local/vllm-speed-bench-1.0.0/results-definition.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0"?>
+<PhoronixTestSuite>
+  <ResultsParser>
+    <OutputTemplate>Request throughput (req/s): #_RESULT_#</OutputTemplate>
+    <ResultScale>requests/s</ResultScale>
+    <ResultProportion>HIB</ResultProportion>
+  </ResultsParser>
+  <ResultsParser>
+    <OutputTemplate>Output token throughput (tok/s): #_RESULT_#</OutputTemplate>
+    <ResultScale>output tokens/s</ResultScale>
+    <ResultProportion>HIB</ResultProportion>
+  </ResultsParser>
+  <ResultsParser>
+    <OutputTemplate>Total token throughput (tok/s): #_RESULT_#</OutputTemplate>
+    <ResultScale>total tokens/s</ResultScale>
+    <ResultProportion>HIB</ResultProportion>
+  </ResultsParser>
+  <ResultsParser>
+    <OutputTemplate>Median TTFT (ms): #_RESULT_#</OutputTemplate>
+    <ResultScale>median TTFT - ms</ResultScale>
+    <ResultProportion>LIB</ResultProportion>
+  </ResultsParser>
+  <ResultsParser>
+    <OutputTemplate>Median TPOT (ms): #_RESULT_#</OutputTemplate>
+    <ResultScale>median TPOT - ms</ResultScale>
+    <ResultProportion>LIB</ResultProportion>
+  </ResultsParser>
+  <ResultsParser>
+    <OutputTemplate>Median ITL (ms): #_RESULT_#</OutputTemplate>
+    <ResultScale>median ITL - ms</ResultScale>
+    <ResultProportion>LIB</ResultProportion>
+  </ResultsParser>
+</PhoronixTestSuite>

--- a/packages/schema/src/pts-profiles/local/vllm-speed-bench-1.0.0/runner.sh
+++ b/packages/schema/src/pts-profiles/local/vllm-speed-bench-1.0.0/runner.sh
@@ -1,0 +1,278 @@
+#!/usr/bin/env bash
+# Own the online server/client pair so every PTS exit path also stops the GPU-serving process.
+set -u
+
+vllm_bin="${BENCH_VLLM_BIN:-/opt/vllm/bin/vllm}"
+dataset_dir="${SPEED_BENCH_DATASET_DIR:-/models/speed-bench}"
+kernel_cache_dir="${BENCH_VLLM_KERNEL_CACHE_DIR:-}"
+ready_timeout_seconds="${BENCH_VLLM_READY_TIMEOUT_SECONDS:-2700}"
+client_timeout_seconds="${BENCH_VLLM_CLIENT_TIMEOUT_SECONDS:-600}"
+status=1
+server_pid=""
+server_log=""
+readiness_watchdog_pid=""
+
+# shellcheck disable=SC2329 # Invoked directly and by the EXIT trap.
+stop_readiness_watchdog() {
+	if [ -n "$readiness_watchdog_pid" ] && kill -0 "$readiness_watchdog_pid" 2>/dev/null; then
+		# The watchdog owns a process group so cancellation also stops its sleeping timer. Killing
+		# only the shell leaves `sleep` alive and makes this wait consume the full readiness budget.
+		kill -TERM -- "-$readiness_watchdog_pid" 2>/dev/null || true
+		wait "$readiness_watchdog_pid" 2>/dev/null || true
+	fi
+	readiness_watchdog_pid=""
+}
+
+# shellcheck disable=SC2329 # Invoked by the EXIT trap.
+stop_server() {
+	stop_readiness_watchdog
+	if [ -n "$server_pid" ] && kill -0 "$server_pid" 2>/dev/null; then
+		kill -TERM -- "-$server_pid" 2>/dev/null || true
+		for _ in $(seq 1 5); do
+			server_state="$(ps -o stat= -p "$server_pid" 2>/dev/null | tr -d '[:space:]')"
+			[ -n "$server_state" ] || break
+			case "$server_state" in
+				Z*) break ;;
+			esac
+			sleep 1
+		done
+		# Reap a stopped leader immediately and kill only any children that ignored TERM. The vLLM
+		# abort path is normally immediate; five seconds is enough to flush its log without charging
+		# every benchmark for a stuck multiprocessing resource tracker.
+		kill -KILL -- "-$server_pid" 2>/dev/null || true
+	fi
+	if [ -n "$server_pid" ]; then
+		wait "$server_pid" 2>/dev/null || true
+	fi
+	echo "$status" >"${HOME}/test-exit-status"
+}
+# shellcheck disable=SC2329 # Invoked by the signal traps.
+on_signal() {
+	status="$1"
+	exit "$status"
+}
+trap stop_server EXIT
+trap 'on_signal 129' HUP
+trap 'on_signal 130' INT
+trap 'on_signal 143' TERM
+
+if [ "${1:-}" != "speed-bench" ]; then
+	echo "ERROR: expected the speed-bench workload" >&2
+	exit 1
+fi
+shift
+
+model=""
+revision=""
+client_args=()
+while [ "$#" -gt 0 ]; do
+	case "$1" in
+		--model)
+			[ "$#" -ge 2 ] || { echo "ERROR: --model requires a value" >&2; exit 1; }
+			model="$2"
+			client_args+=("$1" "$2")
+			shift 2
+			;;
+		--revision)
+			[ "$#" -ge 2 ] || { echo "ERROR: --revision requires a value" >&2; exit 1; }
+			revision="$2"
+			shift 2
+			;;
+		*)
+			client_args+=("$1")
+			shift
+			;;
+	esac
+done
+
+if [ -z "$model" ] || [ -z "$revision" ]; then
+	echo "ERROR: the profile must pin --model and --revision" >&2
+	exit 1
+fi
+model_cache_root="${HF_HUB_CACHE:-}"
+model_slug="${model//\//--}"
+model_path="${model_cache_root}/models--${model_slug}/snapshots/${revision}"
+if [ -z "$model_cache_root" ] || [ ! -s "${model_path}/tokenizer.json" ]; then
+	echo "ERROR: pinned local tokenizer snapshot is missing: ${model_path}" >&2
+	exit 1
+fi
+# The profile declares RequiresInternet FALSE and the snapshot above is prepared and validated before
+# the run, so pin every Hugging Face client — server and benchmark client both inherit this — to the
+# local cache. An incomplete snapshot then fails immediately instead of silently re-resolving it over
+# the network and charging the measured window for the transfer.
+export HF_HUB_OFFLINE=1
+if ! [[ "$ready_timeout_seconds" =~ ^[1-9][0-9]*$ ]]; then
+	echo "ERROR: BENCH_VLLM_READY_TIMEOUT_SECONDS must be a positive integer" >&2
+	exit 1
+fi
+if ! [[ "$client_timeout_seconds" =~ ^[1-9][0-9]*$ ]]; then
+	echo "ERROR: BENCH_VLLM_CLIENT_TIMEOUT_SECONDS must be a positive integer" >&2
+	exit 1
+fi
+
+# CUDA headers make FlashInfer's SM120 translation units memory intensive. Keep compile fan-out
+# bounded for a cold seed. A successful seed snapshots this local cache directory into the immutable
+# runtime image, so measured consumers neither copy a distributed filesystem nor compile from cold.
+server_env=(
+	env
+	"MAX_JOBS=${BENCH_VLLM_MAX_JOBS:-1}"
+	"FLASHINFER_NVCC_THREADS=${BENCH_VLLM_NVCC_THREADS:-1}"
+	# The benchmark has an explicit KV-cache budget, so skip vLLM's redundant CUDA-graph memory
+	# estimate. This does not disable CUDA graphs; capture remains required and verified below.
+	"VLLM_MEMORY_PROFILER_ESTIMATE_CUDAGRAPHS=0"
+)
+if [ -n "$kernel_cache_dir" ]; then
+	# This runner deliberately does not use errexit (the client's exit status is inspected, and the
+	# cleanup path must survive partial failures), so a directory the server env then points at has to
+	# be checked explicitly. Without it the server would start with cache paths that cannot be written
+	# and silently recompile every kernel.
+	if ! mkdir -p "$kernel_cache_dir/home" "$kernel_cache_dir/xdg" \
+		"$kernel_cache_dir/triton" "$kernel_cache_dir/vllm"; then
+		echo "ERROR: could not create the kernel cache directories under ${kernel_cache_dir}" >&2
+		exit 1
+	fi
+	server_env+=(
+		"HOME=${kernel_cache_dir}/home"
+		"TRITON_CACHE_DIR=${kernel_cache_dir}/triton"
+		"VLLM_CACHE_ROOT=${kernel_cache_dir}/vllm"
+		"XDG_CACHE_HOME=${kernel_cache_dir}/xdg"
+	)
+fi
+if [ ! -s "${dataset_dir}/qualitative.jsonl" ]; then
+	echo "ERROR: prepared SPEED-Bench dataset not found: ${dataset_dir}/qualitative.jsonl" >&2
+	exit 1
+fi
+
+num_gpus="$(nvidia-smi --query-gpu=name --format=csv,noheader | wc -l | tr -d ' ')"
+if ! [[ "$num_gpus" =~ ^[1-9][0-9]*$ ]]; then
+	echo "ERROR: visible GPU count is invalid: ${num_gpus}" >&2
+	exit 1
+fi
+if [ "$num_gpus" -ne 1 ]; then
+	echo "ERROR: the gVisor benchmark requires exactly one visible GPU, found ${num_gpus}" >&2
+	exit 1
+fi
+
+server_log="${LOG_FILE:?LOG_FILE is required}.server"
+server_args=(
+	"$vllm_bin" serve "$model"
+	--revision "$revision"
+	--served-model-name "$model"
+	--trust-remote-code
+	--tokenizer "$model_path"
+	--tensor-parallel-size 1
+	--pipeline-parallel-size 1
+	--kv-cache-dtype fp8
+	--block-size 32
+	--max-model-len 32768
+	--max-num-seqs 16
+	# Modal exposes the read-only model Volume as 9P, which vLLM cannot auto-detect as a network
+	# filesystem. Explicit prefetch overlaps the four safetensors shards through the OS page cache.
+	--safetensors-load-strategy prefetch
+	--kv-cache-memory-bytes 48G
+	--async-scheduling
+	--optimization-level 2
+	--compilation-config '{"cudagraph_mode":"FULL_AND_PIECEWISE"}'
+	--disable-uvicorn-access-log
+)
+case "${BENCH_VLLM_FLASHINFER_AUTOTUNE:-disabled}" in
+	disabled)
+		# SM120 sparse-MLA autotuning took longer than 30 minutes in a live ephemeral Modal
+		# Sandbox. Keep the critical CUDA graphs while using FlashInfer's deterministic tactic
+		# heuristic; an explicit cache-warming run can enable tuning and persist its output.
+		server_args+=(--kernel-config '{"enable_flashinfer_autotune":false}')
+		;;
+	enabled) ;;
+	*)
+		echo "ERROR: BENCH_VLLM_FLASHINFER_AUTOTUNE must be disabled or enabled" >&2
+		exit 1
+		;;
+esac
+# Isolate the complete vLLM process tree so every exit path can signal the API server, engine,
+# workers, and compiler children together instead of leaving orphaned GPU processes behind.
+setsid "${server_env[@]}" "${server_args[@]}" >"$server_log" 2>&1 &
+server_pid=$!
+
+# Start the wall-clock guard before the first health probe. A curl timeout cannot protect against
+# process-creation starvation when a cold CUDA build consumes the sandbox's CPU and memory budget.
+# This independent process group can still signal the server when the polling shell is delayed, and
+# can be cancelled as one unit without leaving its timer behind.
+# shellcheck disable=SC2016 # Positional parameters expand in the child bash, not this shell.
+setsid bash -c '
+	trap - EXIT HUP INT TERM
+	sleep "$1"
+	if kill -0 "$2" 2>/dev/null; then
+		echo "ERROR: hard readiness watchdog stopping vLLM after ${1}s" >&2
+		kill -TERM -- "-$2" 2>/dev/null || true
+		sleep 5
+		kill -KILL -- "-$2" 2>/dev/null || true
+	fi
+' _ "$ready_timeout_seconds" "$server_pid" &
+readiness_watchdog_pid=$!
+
+# Detect a failed engine immediately and keep model initialization outside the timed client run.
+echo "Starting vLLM server (readiness deadline: ${ready_timeout_seconds}s)"
+ready=0
+ready_started="$SECONDS"
+while [ "$((SECONDS - ready_started))" -lt "$ready_timeout_seconds" ]; do
+	# A vLLM process can bind port 8000 before the engine is ready. Bound each probe so a
+	# connected-but-unresponsive socket cannot bypass the outer readiness deadline.
+	if curl --connect-timeout 1 --max-time 2 -fsS http://127.0.0.1:8000/health >/dev/null 2>&1; then
+		ready=1
+		break
+	fi
+	if ! kill -0 "$server_pid" 2>/dev/null; then
+		echo "ERROR: vLLM server exited during startup" >&2
+		tail -n 200 "$server_log" >&2 || true
+		exit 1
+	fi
+	sleep 2
+done
+if [ "$ready" -ne 1 ]; then
+	echo "ERROR: vLLM server did not become ready within ${ready_timeout_seconds}s" >&2
+	tail -n 200 "$server_log" >&2 || true
+	exit 1
+fi
+stop_readiness_watchdog
+echo "vLLM server ready after $((SECONDS - ready_started))s; starting bounded client (${client_timeout_seconds}s)"
+
+case "${BENCH_VLLM_PREPARE_KERNELS_ONLY:-0}" in
+	0) ;;
+	1)
+		echo "Kernel-cache seed reached a healthy server; stopping before the timed client"
+		status=0
+		exit 0
+		;;
+	*)
+		echo "ERROR: BENCH_VLLM_PREPARE_KERNELS_ONLY must be 0 or 1" >&2
+		exit 1
+		;;
+esac
+
+benchmark_args=(
+	"$vllm_bin" bench serve
+	--backend openai-chat
+	--endpoint /v1/chat/completions
+	--host 127.0.0.1
+	--port 8000
+	--ready-check-timeout-sec 60
+	--tokenizer "$model_path"
+	--dataset-path "$dataset_dir"
+	"${client_args[@]}"
+)
+set +e
+OMP_NUM_THREADS="${NUM_CPU_PHYSICAL_CORES:-1}" timeout --foreground --signal=TERM --kill-after=30s \
+	"${client_timeout_seconds}s" "${benchmark_args[@]}" >"$LOG_FILE" 2>&1
+status=$?
+set -e
+if [ "$status" -eq 124 ]; then
+	echo "ERROR: vLLM benchmark client exceeded ${client_timeout_seconds}s" >>"$LOG_FILE"
+fi
+if [ "$status" -ne 0 ]; then
+	{
+		echo
+		echo "=== vLLM server tail ==="
+		tail -n 200 "$server_log" || true
+	} >>"$LOG_FILE"
+fi
+exit "$status"

--- a/packages/schema/src/pts-profiles/local/vllm-speed-bench-1.0.0/test-definition.xml
+++ b/packages/schema/src/pts-profiles/local/vllm-speed-bench-1.0.0/test-definition.xml
@@ -1,0 +1,57 @@
+<?xml version="1.0"?>
+<!-- The model/dataset pair is fixed. A separate run-mode axis keeps qualification and full
+     measurements explicit and reproducible without runtime argument rewriting. -->
+<PhoronixTestSuite>
+  <TestInformation>
+    <Title>vLLM SPEED-Bench Coding</Title>
+    <AppVersion>0.26.0</AppVersion>
+    <Description>Online vLLM serving benchmark for the revision-pinned Qwen3-Coder-30B-A3B-Instruct-FP8 model using the qualitative coding category from NVIDIA SPEED-Bench. Model weights and the prepared dataset are supplied by a read-only Modal Volume.</Description>
+    <ResultScale>tokens/s</ResultScale>
+    <Proportion>HIB</Proportion>
+    <Executable>vllm</Executable>
+    <TimesToRun>1</TimesToRun>
+  </TestInformation>
+  <TestProfile>
+    <Version>1.0.0</Version>
+    <SupportedPlatforms>Linux</SupportedPlatforms>
+    <SoftwareType>Utility</SoftwareType>
+    <TestType>Graphics</TestType>
+    <License>Free</License>
+    <Status>Verified</Status>
+    <ExternalDependencies>python, cuda</ExternalDependencies>
+    <RequiresDisplay>FALSE</RequiresDisplay>
+    <RequiresInternet>FALSE</RequiresInternet>
+    <EnvironmentSize>1</EnvironmentSize>
+    <ProjectURL>https://www.vllm.ai/</ProjectURL>
+    <RepositoryURL>https://github.com/vllm-project/vllm</RepositoryURL>
+    <Maintainer>StarSling</Maintainer>
+  </TestProfile>
+  <TestSettings>
+    <Option>
+      <DisplayName>Workload</DisplayName>
+      <Identifier>workload</Identifier>
+      <ArgumentPrefix> </ArgumentPrefix>
+      <Menu>
+        <Entry>
+          <Name>Qwen3 Coder 30B-A3B FP8 SPEED-Bench Coding</Name>
+          <Value>speed-bench --model Qwen/Qwen3-Coder-30B-A3B-Instruct-FP8 --revision dcaee4d4dfc5ee71ad501f01f530e5652438fde0 --dataset-name speed_bench --speed-bench-dataset-subset qualitative --speed-bench-category coding --temperature 0.7 --top-p 0.8 --seed 0 --percentile-metrics ttft,tpot,itl --metric-percentiles 50,90,99 --trust-remote-code</Value>
+        </Entry>
+      </Menu>
+    </Option>
+    <Option>
+      <DisplayName>Run mode</DisplayName>
+      <Identifier>run-mode</Identifier>
+      <ArgumentPrefix> </ArgumentPrefix>
+      <Menu>
+        <Entry>
+          <Name>Qualification (1 prompt x 16 output tokens)</Name>
+          <Value>--speed-bench-output-len 16 --num-prompts 1 --no-oversample --num-warmups 0 --max-concurrency 1</Value>
+        </Entry>
+        <Entry>
+          <Name>Full (80 prompts x 1024 output tokens)</Name>
+          <Value>--speed-bench-output-len 1024 --num-prompts 80 --no-oversample --num-warmups 8 --max-concurrency 16</Value>
+        </Entry>
+      </Menu>
+    </Option>
+  </TestSettings>
+</PhoronixTestSuite>


### PR DESCRIPTION
## Summary

- vendor the hermetic `local/vllm-speed-bench-1.0.0` Phoronix Test Suite profile
- define the pinned Qwen3-Coder FP8 / SPEED-Bench Coding workload, result parsers, installer, and fail-safe runner
- share one `BENCH_VLLM_BIN` override between the installer and the runner, so the executable that gets validated is the one that gets executed
- pin Hugging Face to the local cache (`HF_HUB_OFFLINE=1`) for both the server and the client, matching the profile's `RequiresInternet FALSE`
- add profile-local `.catalog-ignore` support so specialized GPU serving metrics remain outside the CPU sandbox comparison catalog

## Why

The PTS workload is independently reviewable and reusable without introducing Modal, workflow, lifecycle, or reporting code.

## Validation

- `bun run check:catalog-drift`
- `bun run lint`
- `bun run typecheck`
- ShellCheck for `install.sh` and `runner.sh`

## Stack

This is the base of the GPU benchmark stack. Next: #358. The complete workflow lands incrementally through #366.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a vLLM SPEED-Bench profile for Qwen3-Coder with qualification and full benchmark modes.
  * Added throughput and latency reporting, including time to first token, token generation time, and inter-token latency.
  * Added automated setup and execution with model validation, readiness checks, timeout handling, and diagnostics.
* **Bug Fixes**
  * Catalog discovery now excludes profiles containing a catalog-ignore marker, including specialized GPU-only benchmarks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
