### PR TITLE
refactor(harness): share owned sandbox lifecycle

### DIFF
--- a/apps/cli/src/lib/bake/daytona.ts
+++ b/apps/cli/src/lib/bake/daytona.ts
@@ -26,8 +26,11 @@
 import type { RegistryPushAccessDto } from "@daytona/api-client";
 import { Configuration, DockerRegistryApi } from "@daytona/api-client";
 import { Daytona, SandboxClass } from "@daytona/sdk";
+import { withCleanupPreservingPrimaryError } from "@sandbox-benchmarks/harness";
 import { config } from "@sandbox-benchmarks/providers/config";
 import type { Log } from "./types.ts";
+
+export { withCleanupPreservingPrimaryError };
 
 /** Whether a snapshot delete error is a genuine "no such snapshot" (so the idempotent path may
  *  swallow it — e.g. a snapshot deleted out from under us between the list and the delete) — as
@@ -242,30 +245,6 @@ async function dockerLogin(access: RegistryPushAccessDto, log: Log): Promise<str
 	const code = await proc.exited;
 	if (code !== 0) throw new Error(`docker login ${registry} exited ${code}`);
 	return registry;
-}
-
-/** Run cleanup after an operation without letting a cleanup failure hide the primary failure. */
-export async function withCleanupPreservingPrimaryError<T>(
-	operation: () => Promise<T>,
-	cleanup: () => Promise<void>,
-	onSuppressedCleanupError: (err: unknown) => void,
-): Promise<T> {
-	let outcome: { ok: true; value: T } | { ok: false; error: unknown };
-	try {
-		outcome = { ok: true, value: await operation() };
-	} catch (error) {
-		outcome = { ok: false, error };
-	}
-
-	try {
-		await cleanup();
-	} catch (cleanupError) {
-		if (outcome.ok) throw cleanupError;
-		onSuppressedCleanupError(cleanupError);
-	}
-
-	if (!outcome.ok) throw outcome.error;
-	return outcome.value;
 }
 
 /** Remove the short-lived registry credential and fail if Docker did not remove it. */

--- a/packages/harness/src/index.ts
+++ b/packages/harness/src/index.ts
@@ -14,9 +14,11 @@ import type { LifecycleAggregate, LifecycleCompute } from "./lib/lifecycle.ts";
 import { aggregateLifecycle, measureLifecycle } from "./lib/lifecycle.ts";
 import type { WaitUntilReadyOptions } from "./lib/readiness.ts";
 import { neverReadyReason, waitUntilReady } from "./lib/readiness.ts";
-import { createOwnedSandbox } from "./lib/sandbox-owner.ts";
+import { createOwnedSandbox, withOwnedSandbox } from "./lib/sandbox-owner.ts";
 import { DIR, OBSERVED_SPECS_SCRIPT, REPO_REF, REPO_URL, setupSteps } from "./lib/setup.ts";
 
+export { collectResults } from "./lib/collect.ts";
+export { StepRunner } from "./lib/execute.ts";
 // Re-export the lifecycle measurement surface so consumers import it from the package root, never
 // from `src/lib` (the package-boundary rule the other modules follow).
 export type {
@@ -28,7 +30,13 @@ export type {
 	MeasureLifecycleOptions,
 } from "./lib/lifecycle.ts";
 export { aggregateLifecycle, measureLifecycle } from "./lib/lifecycle.ts";
-export { exitAfterSandboxCleanup, shutdownOwnedSandboxes } from "./lib/sandbox-owner.ts";
+export {
+	createOwnedSandbox,
+	exitAfterSandboxCleanup,
+	shutdownOwnedSandboxes,
+	withCleanupPreservingPrimaryError,
+	withOwnedSandbox,
+} from "./lib/sandbox-owner.ts";
 
 /**
  * The universal sandbox a provider's `sandbox.create` returns (computesdk's `Sandbox`). Derived from
@@ -602,27 +610,11 @@ export async function withSandbox<T>(
 	fn: (sandbox: Sandbox) => Promise<T>,
 ): Promise<T> {
 	const compute = config.createCompute();
-	const sandbox = await createOwnedSandbox(() => compute.sandbox.create(config.createOptions));
-	let result: T;
-	try {
-		result = await fn(sandbox);
-	} catch (err) {
-		// fn failed: tear down once, but never let a destroy error mask the root cause (a
-		// `finally { await destroy() }` would swallow it). Log the secondary failure and rethrow fn's.
-		try {
-			await sandbox.destroy();
-		} catch (destroyErr) {
-			console.error(
-				`withSandbox: destroy failed after an error in fn (${config.name}):`,
-				destroyErr,
-			);
-		}
-		throw err;
-	}
-	// fn succeeded: tear down once. A teardown failure here is the only error, so let it surface
-	// (a leaked sandbox is worth failing on) — the result is already captured by the caller's fn.
-	await sandbox.destroy();
-	return result;
+	return withOwnedSandbox(
+		() => compute.sandbox.create(config.createOptions),
+		fn,
+		`withSandbox (${config.name})`,
+	);
 }
 
 /**

--- a/packages/harness/src/lib/sandbox-owner.test.ts
+++ b/packages/harness/src/lib/sandbox-owner.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from "bun:test";
 import { existsSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { cleanupOwnedSandboxes, createOwnedSandbox } from "./sandbox-owner.ts";
+import { cleanupOwnedSandboxes, createOwnedSandbox, withOwnedSandbox } from "./sandbox-owner.ts";
 
 function deferred<T>(): { promise: Promise<T>; resolve: (value: T) => void } {
 	let resolve!: (value: T) => void;
@@ -69,6 +69,45 @@ describe("sandbox process ownership", () => {
 		}));
 
 		await expect(sandbox.destroy()).rejects.toThrow("transient teardown failure");
+		expect(await cleanupOwnedSandboxes()).toEqual([]);
+		expect(destroys).toBe(2);
+	});
+
+	it("scopes a successful operation to one owned sandbox", async () => {
+		let destroys = 0;
+		const result = await withOwnedSandbox(
+			async () => ({
+				sandboxId: "sb-scoped",
+				value: 42,
+				async destroy() {
+					destroys++;
+				},
+			}),
+			async (sandbox) => sandbox.value,
+		);
+
+		expect(result).toBe(42);
+		expect(destroys).toBe(1);
+		expect(await cleanupOwnedSandboxes()).toEqual([]);
+	});
+
+	it("preserves the operation error and retains a failed teardown for the exit drain", async () => {
+		let destroys = 0;
+		await expect(
+			withOwnedSandbox(
+				async () => ({
+					sandboxId: "sb-scoped-retry",
+					async destroy() {
+						destroys++;
+						if (destroys === 1) throw new Error("teardown failed");
+					},
+				}),
+				async () => {
+					throw new Error("operation failed");
+				},
+				"test sandbox",
+			),
+		).rejects.toThrow("operation failed");
 		expect(await cleanupOwnedSandboxes()).toEqual([]);
 		expect(destroys).toBe(2);
 	});

--- a/packages/harness/src/lib/sandbox-owner.ts
+++ b/packages/harness/src/lib/sandbox-owner.ts
@@ -257,3 +257,45 @@ export function createOwnedSandbox<T extends DestroyableSandbox>(
 
 	return entry.promise;
 }
+
+/** Run cleanup without letting its failure hide an earlier operation failure. */
+export async function withCleanupPreservingPrimaryError<T>(
+	operation: () => Promise<T>,
+	cleanup: () => Promise<unknown>,
+	onSuppressedCleanupError: (error: unknown) => void,
+): Promise<T> {
+	let outcome: { ok: true; value: T } | { ok: false; error: unknown };
+	try {
+		outcome = { ok: true, value: await operation() };
+	} catch (error) {
+		outcome = { ok: false, error };
+	}
+
+	try {
+		await cleanup();
+	} catch (error) {
+		if (outcome.ok) throw error;
+		onSuppressedCleanupError(error);
+	}
+
+	if (!outcome.ok) throw outcome.error;
+	return outcome.value;
+}
+
+/**
+ * Create one process-owned sandbox, run a callback, and always tear the sandbox down. If the callback
+ * fails, preserve that primary error while the process registry retains any sandbox whose teardown
+ * also failed for the bounded exit drain to retry.
+ */
+export async function withOwnedSandbox<T extends DestroyableSandbox, R>(
+	create: () => Promise<T>,
+	fn: (sandbox: T) => Promise<R>,
+	label = "sandbox",
+): Promise<R> {
+	const sandbox = await createOwnedSandbox(create);
+	return withCleanupPreservingPrimaryError(
+		() => fn(sandbox),
+		() => sandbox.destroy(),
+		(error) => console.error(`${label}: teardown failed after the operation failed:`, error),
+	);
+}


### PR DESCRIPTION
## Summary

- add a shared `withOwnedSandbox` lifecycle primitive
- preserve operation failures when teardown also fails
- retain failed teardowns for the bounded process-exit retry drain
- refactor the existing harness `withSandbox` path to use the shared primitive
- export only the harness surfaces needed by later GPU adapters

## Why

GPU sandboxes are expensive, so all callers need one tested ownership path that destroys once on success and retries cleanup without masking the primary failure.

## Validation

- lifecycle success, operation-failure, teardown-failure, and retry tests
- full workspace test suite
- typecheck and lint

## Stack

Depends on #368. Next: #369.