### PR TITLE
feat(gpu): define vLLM benchmark configuration

### DIFF
--- a/apps/cli/src/lib/gpu/args.ts
+++ b/apps/cli/src/lib/gpu/args.ts
@@ -1,0 +1,166 @@
+import { lastFlagValue, parseReplicatesFlag, resolveMaxConcurrency } from "../replicates.ts";
+import type { GpuBenchmarkMode } from "./config.ts";
+import { FLASHINFER_AUTOTUNE_MODES, GPU_BENCHMARK } from "./config.ts";
+
+const PREPARATIONS = ["models", "kernels"] as const;
+const VALUE_FLAGS = new Set([
+	"--client-timeout-minutes",
+	"--cpu",
+	"--cpu-limit",
+	"--cuda-build-jobs",
+	"--flashinfer-autotune",
+	"--gpu",
+	"--kernel-snapshot-registry-volume",
+	"--max-concurrency",
+	"--max-replicate-duration-seconds",
+	"--memory-limit-mib",
+	"--memory-mib",
+	"--mode",
+	"--model-volume",
+	"--nvcc-threads",
+	"--output-dir",
+	"--prepare",
+	"--relative-ci-half-width",
+	"--replicates",
+	"--timeout-minutes",
+]);
+const SWITCH_FLAGS = new Set(["--require-duration", "--require-precision"]);
+
+function validateArguments(argv: readonly string[]): void {
+	for (let index = 0; index < argv.length; index++) {
+		const argument = argv[index] ?? "";
+		if (SWITCH_FLAGS.has(argument)) continue;
+		const flag = argument.split("=", 1)[0] ?? "";
+		if (!VALUE_FLAGS.has(flag)) throw new Error(`unknown argument: ${argument}`);
+		if (argument === flag) index++;
+	}
+}
+
+function value(argv: readonly string[], flag: string, fallback: string): string {
+	const resolved = lastFlagValue(argv, flag, "a value");
+	if (resolved === undefined) return fallback;
+	if (resolved === "" || resolved.startsWith("-")) throw new Error(`--${flag} requires a value`);
+	return resolved;
+}
+
+function positive(
+	argv: readonly string[],
+	flag: string,
+	fallback: number,
+	integer = false,
+): number {
+	const raw = lastFlagValue(argv, flag, "a positive number") ?? String(fallback);
+	const parsed = Number(raw);
+	if (!Number.isFinite(parsed) || parsed <= 0 || (integer && !Number.isInteger(parsed))) {
+		throw new Error(`--${flag} must be a positive ${integer ? "integer" : "number"}`);
+	}
+	return parsed;
+}
+
+function oneOf<T extends string>(raw: string, allowed: readonly T[], flag: string): T {
+	if ((allowed as readonly string[]).includes(raw)) return raw as T;
+	throw new Error(`--${flag} must be ${allowed.join(" or ")}`);
+}
+
+export function parseGpuArgs(argv: readonly string[]) {
+	validateArguments(argv);
+	const preparation = lastFlagValue(argv, "prepare", "models or kernels");
+	const operation =
+		preparation !== undefined
+			? oneOf(preparation, PREPARATIONS, "prepare")
+			: ("benchmark" as const);
+	const requestedReplicates = parseReplicatesFlag(argv);
+	const mode = oneOf(
+		value(argv, "mode", GPU_BENCHMARK.defaults.mode),
+		Object.keys(GPU_BENCHMARK.modes) as GpuBenchmarkMode[],
+		"mode",
+	);
+	const flashinferAutotune = oneOf(
+		value(argv, "flashinfer-autotune", "disabled"),
+		FLASHINFER_AUTOTUNE_MODES,
+		"flashinfer-autotune",
+	);
+	const requirePrecision = argv.includes("--require-precision");
+	const defaultTimeout =
+		operation === "models"
+			? 240
+			: operation === "kernels"
+				? 90
+				: GPU_BENCHMARK.modes[mode].timeoutMinutes;
+	const args = {
+		operation,
+		modelVolume: value(argv, "model-volume", GPU_BENCHMARK.volumes.models),
+		kernelSnapshotRegistryVolume: value(
+			argv,
+			"kernel-snapshot-registry-volume",
+			GPU_BENCHMARK.volumes.kernelRegistry,
+		),
+		gpu: value(argv, "gpu", GPU_BENCHMARK.defaults.gpu),
+		cpuRequested: positive(argv, "cpu", GPU_BENCHMARK.defaults.cpu),
+		cpuLimit: positive(argv, "cpu-limit", GPU_BENCHMARK.defaults.cpu),
+		memoryRequestedMiB: positive(argv, "memory-mib", GPU_BENCHMARK.defaults.memoryMiB, true),
+		memoryLimitMiB: positive(argv, "memory-limit-mib", GPU_BENCHMARK.defaults.memoryLimitMiB, true),
+		mode,
+		timeoutMinutes: positive(argv, "timeout-minutes", defaultTimeout, true),
+		clientTimeoutMinutes: positive(
+			argv,
+			"client-timeout-minutes",
+			GPU_BENCHMARK.modes[mode].clientTimeoutMinutes,
+			true,
+		),
+		flashinferAutotune,
+		cudaBuildJobs: positive(argv, "cuda-build-jobs", operation === "kernels" ? 8 : 1, true),
+		nvccThreads: positive(argv, "nvcc-threads", operation === "kernels" ? 4 : 1, true),
+		outputDirectory: value(argv, "output-dir", GPU_BENCHMARK.defaults.outputDirectory),
+		replicateIndices:
+			operation === "benchmark"
+				? (requestedReplicates ??
+					(requirePrecision
+						? Array.from({ length: GPU_BENCHMARK.defaults.minimumReplicates }, (_, index) => index)
+						: [0]))
+				: undefined,
+		maxConcurrency: resolveMaxConcurrency(argv),
+		requirePrecision,
+		precisionTarget: positive(
+			argv,
+			"relative-ci-half-width",
+			GPU_BENCHMARK.defaults.relativeCiHalfWidth,
+		),
+		requireDuration: argv.includes("--require-duration"),
+		durationTargetSeconds: positive(
+			argv,
+			"max-replicate-duration-seconds",
+			GPU_BENCHMARK.defaults.maxReplicateDurationSeconds,
+		),
+	};
+	if (args.cpuRequested > args.cpuLimit) throw new Error("--cpu cannot exceed --cpu-limit");
+	if (args.memoryRequestedMiB > args.memoryLimitMiB) {
+		throw new Error("--memory-mib cannot exceed --memory-limit-mib");
+	}
+	if (operation !== "benchmark" && requestedReplicates !== undefined) {
+		throw new Error("--replicates is supported only for benchmark execution");
+	}
+	if (operation !== "benchmark" && (args.requirePrecision || args.requireDuration)) {
+		throw new Error("benchmark gates cannot be combined with --prepare");
+	}
+	if (
+		args.requirePrecision &&
+		(args.replicateIndices?.length ?? 0) < GPU_BENCHMARK.defaults.minimumReplicates
+	) {
+		throw new Error(
+			`--require-precision requires at least ${GPU_BENCHMARK.defaults.minimumReplicates} independent replicates`,
+		);
+	}
+	const minimumTimeout =
+		(operation === "kernels"
+			? GPU_BENCHMARK.deadlines.kernelServerReadyMinutes
+			: GPU_BENCHMARK.deadlines.serverReadyMinutes +
+				(operation === "benchmark" ? args.clientTimeoutMinutes : 0)) +
+		GPU_BENCHMARK.deadlines.artifactReserveMinutes;
+	if (operation !== "models" && args.timeoutMinutes < minimumTimeout) {
+		throw new Error(`--timeout-minutes must be at least ${minimumTimeout}`);
+	}
+	return args;
+}
+
+export type GpuArgs = ReturnType<typeof parseGpuArgs>;

--- a/apps/cli/src/lib/gpu/config.ts
+++ b/apps/cli/src/lib/gpu/config.ts
@@ -1,0 +1,176 @@
+import { readFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { validatedPins } from "@sandbox-benchmarks/templates/pins";
+
+const pins = validatedPins();
+export const REPO_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), "../../../../..");
+export const readSource = (relative: string): string =>
+	readFileSync(resolve(REPO_ROOT, relative), "utf8");
+
+const task = ".mise/tasks/benchmark/gpu/pts/vllm";
+const taskDefinition = readSource(task);
+const taskValue = (name: string): string => {
+	const value = taskDefinition.match(new RegExp(`^${name}="([^"]+)"$`, "m"))?.[1];
+	if (!value) throw new Error(`GPU benchmark task ${task} is missing ${name}`);
+	return value;
+};
+
+const profileName = taskValue("profile");
+const profile = {
+	id: `local/${profileName}`,
+	name: profileName,
+	directory: `packages/schema/src/pts-profiles/local/${profileName}`,
+	resultPrefix: taskValue("prefix"),
+} as const;
+const definition = readSource(`${profile.directory}/test-definition.xml`);
+const profileValue = (pattern: RegExp, field: string): string => {
+	const value = definition.match(pattern)?.[1];
+	if (!value) throw new Error(`GPU PTS profile is missing ${field}`);
+	return value;
+};
+const profileInteger = (pattern: RegExp, field: string): number => {
+	const value = Number(profileValue(pattern, field));
+	if (!Number.isSafeInteger(value) || value < 1) {
+		throw new Error(`GPU PTS profile has an invalid ${field}`);
+	}
+	return value;
+};
+const workload = {
+	label: profileValue(/<Name>([^<]+)<\/Name>\s*<Value>speed-bench /, "the workload name"),
+	vllmVersion: profileValue(/<AppVersion>([^<]+)<\/AppVersion>/, "AppVersion"),
+	model: {
+		repoId: profileValue(/--model ([^ ]+)/, "--model"),
+		revision: profileValue(/--revision ([0-9a-f]{40})/, "--revision"),
+	},
+} as const;
+
+export const GPU_BENCHMARK = {
+	appName: "sandbox-benchmarks-gpu",
+	task,
+	profile,
+	workload,
+	assets: {
+		speedBench: {
+			codingSamples: profileInteger(
+				/<Name>Full \([^<]+<\/Name>\s*<Value>[^<]*--num-prompts ([0-9]+)/,
+				"full run --num-prompts",
+			),
+			prepare: {
+				revision: "e06c9b900177be3f60d6a3f99135bb5de9af9bed",
+				url: "https://raw.githubusercontent.com/NVIDIA-NeMo/Skills/e06c9b900177be3f60d6a3f99135bb5de9af9bed/nemo_skills/dataset/speed-bench/prepare.py",
+				sha256: "a551be4df541474e54e21b480022b0cbb66c2da068fda61b2a64bd3223bbbed2",
+			},
+		},
+	},
+	software: {
+		python: pins.pythonVersion,
+		pts: pins.ptsVersion,
+		ptsDebSha256: pins.ptsDebSha256,
+		vllm: workload.vllmVersion,
+		uv: "0.12.3",
+		hfXet: "1.5.2",
+		cudaImage:
+			"nvidia/cuda:13.3.1-devel-ubuntu24.04@sha256:03c372fd9c65fe7739279f8c65473b315dc61efaaffab03e1e65bc7be7aee61e",
+	},
+	paths: {
+		remoteRoot: "/root/sandbox-benchmarks",
+		modelMount: "/models",
+		modelCache: "/models/huggingface",
+		speedBench: "/models/speed-bench",
+		kernelRegistryMount: "/kernel-snapshot-registry",
+		kernelCache: "/var/cache/sandbox-benchmarks/vllm",
+		vllmEnvironment: "/opt/vllm",
+		uvEnvironment: "/opt/uv",
+		cudaHome: "/usr/local/cuda",
+	},
+	volumes: {
+		models: "sandbox-benchmarks-qwen3-coder-assets-v1",
+		kernelRegistry: "sandbox-benchmarks-qwen3-coder-kernel-snapshot-registry-v1",
+	},
+	defaults: {
+		gpu: "RTX-PRO-6000",
+		mode: "qualification",
+		outputDirectory: "benchmark-results/modal-vllm",
+		cpu: 4,
+		memoryMiB: 512,
+		memoryLimitMiB: 8192,
+		minimumReplicates: 20,
+		relativeCiHalfWidth: 0.005,
+		maxReplicateDurationSeconds: 300,
+	},
+	modelPreparation: {
+		memoryMiB: 1024,
+		memoryLimitMiB: 16_384,
+	},
+	modes: {
+		qualification: { timeoutMinutes: 45, clientTimeoutMinutes: 10 },
+		full: { timeoutMinutes: 240, clientTimeoutMinutes: 180 },
+	},
+	deadlines: {
+		serverReadyMinutes: 5,
+		kernelServerReadyMinutes: 30,
+		artifactReserveMinutes: 5,
+	},
+	kernelSnapshotTtlDays: 30,
+} as const;
+
+export type GpuBenchmarkMode = keyof typeof GPU_BENCHMARK.modes;
+export const FLASHINFER_AUTOTUNE_MODES = ["disabled", "enabled"] as const;
+export type FlashInferAutotuneMode = (typeof FLASHINFER_AUTOTUNE_MODES)[number];
+
+export const MODEL_CACHE_ENV = {
+	HF_HOME: GPU_BENCHMARK.paths.modelCache,
+	HF_HUB_CACHE: `${GPU_BENCHMARK.paths.modelCache}/hub`,
+	HF_DATASETS_CACHE: `${GPU_BENCHMARK.paths.modelCache}/datasets`,
+	HF_XET_CACHE: `${GPU_BENCHMARK.paths.modelCache}/xet`,
+	HF_HUB_DISABLE_TELEMETRY: "1",
+	HF_XET_HIGH_PERFORMANCE: "1",
+	HF_XET_NUM_CONCURRENT_RANGE_GETS: "8",
+	HF_XET_RECONSTRUCT_WRITE_SEQUENTIALLY: "1",
+} as const;
+
+export const MODEL_OFFLINE_ENV = {
+	...MODEL_CACHE_ENV,
+	SPEED_BENCH_DATASET_DIR: GPU_BENCHMARK.paths.speedBench,
+	HF_HUB_OFFLINE: "1",
+	TRANSFORMERS_OFFLINE: "1",
+	HF_MODULES_CACHE: "/tmp/huggingface/modules",
+	HF_ASSETS_CACHE: "/tmp/huggingface/assets",
+} as const;
+
+export const KERNEL_CACHE_ENV = {
+	BENCH_VLLM_KERNEL_CACHE_DIR: GPU_BENCHMARK.paths.kernelCache,
+} as const;
+
+export const MODAL_GPU_ENV = {
+	GLOO_SOCKET_IFNAME: "lo",
+	NCCL_P2P_DISABLE: "1",
+	NCCL_SHM_DISABLE: "1",
+	NCCL_SOCKET_IFNAME: "lo",
+	VLLM_HOST_IP: "127.0.0.1",
+} as const;
+
+export const PYTHON_ENVIRONMENT_COMMAND =
+	`${GPU_BENCHMARK.paths.uvEnvironment}/bin/uv pip freeze ` +
+	`--python ${GPU_BENCHMARK.paths.vllmEnvironment}/bin/python`;
+
+export const VLLM_IMAGE_COMMANDS = [
+	`ENV CUDA_HOME=${GPU_BENCHMARK.paths.cudaHome}`,
+	`ENV CUDACXX=${GPU_BENCHMARK.paths.cudaHome}/bin/nvcc`,
+	"ENV UV_PYTHON_INSTALL_DIR=/opt/uv-python",
+	"RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates curl git php-cli php-xml python3 python3-dev python3-pip python3-venv && rm -rf /var/lib/apt/lists/*",
+	`RUN curl -fsSL --retry 5 --retry-all-errors -o /tmp/pts.deb https://github.com/phoronix-test-suite/phoronix-test-suite/releases/download/v${GPU_BENCHMARK.software.pts}/phoronix-test-suite_${GPU_BENCHMARK.software.pts}_all.deb && echo '${GPU_BENCHMARK.software.ptsDebSha256}  /tmp/pts.deb' | sha256sum -c - && (dpkg -i /tmp/pts.deb || (apt-get update && apt-get install -y --no-install-recommends -f)) && rm -rf /tmp/pts.deb /var/lib/apt/lists/* && printf 'y\\nn\\nn\\nn\\nn\\nn\\ny\\n' | phoronix-test-suite batch-setup && chmod -R a+rwX /var/lib/phoronix-test-suite`,
+	`RUN python3 -m venv ${GPU_BENCHMARK.paths.uvEnvironment}`,
+	`RUN ${GPU_BENCHMARK.paths.uvEnvironment}/bin/python -m pip install --disable-pip-version-check --no-cache-dir uv==${GPU_BENCHMARK.software.uv}`,
+	`RUN ${GPU_BENCHMARK.paths.uvEnvironment}/bin/uv python install ${GPU_BENCHMARK.software.python}`,
+	`RUN ${GPU_BENCHMARK.paths.uvEnvironment}/bin/uv venv ${GPU_BENCHMARK.paths.vllmEnvironment} --python ${GPU_BENCHMARK.software.python}`,
+	`RUN ${GPU_BENCHMARK.paths.uvEnvironment}/bin/uv pip install --python ${GPU_BENCHMARK.paths.vllmEnvironment}/bin/python 'vllm[bench]==${GPU_BENCHMARK.software.vllm}'`,
+] as const;
+
+// Keep transfer/runtime glue in the final cached layer so changes do not reinstall vLLM and Torch.
+export const GPU_RUNTIME_IMAGE_COMMANDS = [
+	`RUN ${GPU_BENCHMARK.paths.uvEnvironment}/bin/uv pip install --python ${GPU_BENCHMARK.paths.vllmEnvironment}/bin/python 'hf-xet==${GPU_BENCHMARK.software.hfXet}'`,
+	"RUN config=/etc/phoronix-test-suite.xml && test -f \"$config\" && sed -i -e 's#<NoInternetCommunication>[^<]*</NoInternetCommunication>#<NoInternetCommunication>TRUE</NoInternetCommunication>#' -e 's#<NoNetworkCommunication>[^<]*</NoNetworkCommunication>#<NoNetworkCommunication>TRUE</NoNetworkCommunication>#' \"$config\" && grep -q '<NoInternetCommunication>TRUE</NoInternetCommunication>' \"$config\" && grep -q '<NoNetworkCommunication>TRUE</NoNetworkCommunication>' \"$config\"",
+	`ENV PATH="${GPU_BENCHMARK.paths.vllmEnvironment}/bin:${GPU_BENCHMARK.paths.cudaHome}/bin:$PATH"`,
+] as const;


### PR DESCRIPTION
## Summary

- define the single-source GPU benchmark, CUDA image, model, volume, timeout, and precision configuration
- parse resource, preparation, replication, and statistical-gate CLI arguments
- keep configuration and argument validation independent from Modal SDK/runtime behavior

## Why

This isolates typed policy from the reusable PTS task in #369 and from the provider adapter introduced next.

## Validation

- full workspace test suite
- `bun run lint`
- `bun run typecheck`

## Stack

Depends on #369. Next: #360.