### PR TITLE
feat(gpu): add Modal GPU sandbox adapter

### DIFF
--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -36,6 +36,7 @@
     "@daytona/api-client": "catalog:computesdk",
     "@daytona/sdk": "catalog:computesdk",
     "@runloop/api-client": "catalog:computesdk",
+    "modal": "catalog:computesdk",
     "novita-sandbox": "catalog:computesdk",
     "dotenv": "catalog:"
   },

--- a/apps/cli/src/lib/gpu/modal.ts
+++ b/apps/cli/src/lib/gpu/modal.ts
@@ -1,0 +1,254 @@
+import { join } from "node:path";
+import { createOwnedSandbox, StepRunner, withOwnedSandbox } from "@sandbox-benchmarks/harness";
+import type { ModalClient, ModalReadStream, Sandbox, SandboxCreateParams } from "modal";
+import type { GpuArgs } from "./args.ts";
+import {
+	GPU_BENCHMARK,
+	KERNEL_CACHE_ENV,
+	MODAL_GPU_ENV,
+	MODEL_OFFLINE_ENV,
+	PYTHON_ENVIRONMENT_COMMAND,
+	readSource,
+} from "./config.ts";
+
+const MODAL_TRANSPORT = {
+	streaming: true,
+	syncCapMs: null,
+	detachedPoll: false,
+} as const;
+
+async function drain(stream: ModalReadStream<string>): Promise<string> {
+	const reader = stream.getReader();
+	const chunks: string[] = [];
+	try {
+		for (;;) {
+			const { done, value } = await reader.read();
+			if (done) return chunks.join("");
+			chunks.push(typeof value === "string" ? value : new TextDecoder().decode(value));
+		}
+	} finally {
+		reader.releaseLock();
+	}
+}
+
+async function exec(sandbox: Sandbox, command: string) {
+	const process = await sandbox.exec(["bash", "-lc", command], {
+		mode: "text",
+		stdout: "pipe",
+		stderr: "pipe",
+	});
+	const [stdout, stderr, exitCode] = await Promise.all([
+		drain(process.stdout),
+		drain(process.stderr),
+		process.wait(),
+	]);
+	return { stdout, stderr, exitCode };
+}
+
+async function stillListed(client: ModalClient, sandboxId: string): Promise<boolean> {
+	for await (const candidate of client.sandboxes.list()) {
+		if (candidate.sandboxId === sandboxId) return true;
+	}
+	return false;
+}
+
+async function terminateAndVerify(client: ModalClient, sandbox: Sandbox): Promise<void> {
+	let lastError: unknown;
+	for (let terminateAttempt = 0; terminateAttempt < 3; terminateAttempt++) {
+		try {
+			await sandbox.terminate({ wait: true });
+		} catch (error) {
+			lastError = error;
+		}
+		for (let listAttempt = 0; listAttempt < 5; listAttempt++) {
+			try {
+				if (!(await stillListed(client, sandbox.sandboxId))) return;
+			} catch (error) {
+				lastError = error;
+				break;
+			}
+			await Bun.sleep(1000);
+		}
+	}
+	const reason = lastError instanceof Error ? `: ${lastError.message}` : "";
+	throw new Error(`Modal sandbox ${sandbox.sandboxId} is still listed after termination${reason}`);
+}
+
+function adaptGpuSandbox(client: ModalClient, sdk: Sandbox) {
+	const adapted = {
+		sandboxId: sdk.sandboxId,
+		sdk,
+		runCommand: (command: string) => exec(sdk, command),
+		destroy: () => terminateAndVerify(client, sdk),
+	};
+	return {
+		...adapted,
+		// One PTS pass per independent sandbox; fleet replication supplies machine-level variance.
+		runner: new StepRunner(adapted, MODAL_TRANSPORT, undefined, { mode: "fixed", times: 1 }),
+	};
+}
+
+async function createAdaptedGpuSandbox(client: ModalClient, create: () => Promise<Sandbox>) {
+	return adaptGpuSandbox(client, await create());
+}
+
+export async function createGpuSandbox(client: ModalClient, create: () => Promise<Sandbox>) {
+	return createOwnedSandbox(() => createAdaptedGpuSandbox(client, create));
+}
+
+export type GpuSandbox = Awaited<ReturnType<typeof createGpuSandbox>>;
+
+/** The shared lifecycle scope for short-lived GPU preparation and validation sandboxes. */
+export function withGpuSandbox<T>(
+	client: ModalClient,
+	create: () => Promise<Sandbox>,
+	fn: (sandbox: GpuSandbox) => Promise<T>,
+): Promise<T> {
+	return withOwnedSandbox(() => createAdaptedGpuSandbox(client, create), fn, "Modal GPU sandbox");
+}
+
+/** Resource and lifetime policy shared by the kernel seed and measured benchmark allocations. */
+export function gpuSandboxResources(args: GpuArgs) {
+	return {
+		gpu: args.gpu,
+		cpu: args.cpuRequested,
+		cpuLimit: args.cpuLimit,
+		memoryMiB: args.memoryRequestedMiB,
+		memoryLimitMiB: args.memoryLimitMiB,
+		timeoutMs: args.timeoutMinutes * 60_000,
+		blockNetwork: true,
+	} satisfies SandboxCreateParams;
+}
+
+/** vLLM runtime policy shared by cache seeding and measured runs. */
+export function vllmEnvironment(args: GpuArgs) {
+	if (args.operation === "models") {
+		throw new Error("model preparation does not use the vLLM runtime environment");
+	}
+	const kernelSeed = args.operation === "kernels";
+	return {
+		...MODEL_OFFLINE_ENV,
+		...KERNEL_CACHE_ENV,
+		...MODAL_GPU_ENV,
+		...(kernelSeed ? { BENCH_VLLM_PREPARE_KERNELS_ONLY: "1" } : { BENCH_VLLM_MODE: args.mode }),
+		BENCH_VLLM_FLASHINFER_AUTOTUNE: args.flashinferAutotune,
+		BENCH_VLLM_MAX_JOBS: String(kernelSeed ? args.cudaBuildJobs : 1),
+		BENCH_VLLM_NVCC_THREADS: String(kernelSeed ? args.nvccThreads : 1),
+		BENCH_VLLM_READY_TIMEOUT_SECONDS: String(
+			GPU_BENCHMARK.deadlines[kernelSeed ? "kernelServerReadyMinutes" : "serverReadyMinutes"] * 60,
+		),
+		BENCH_VLLM_CLIENT_TIMEOUT_SECONDS: String(kernelSeed ? 60 : args.clientTimeoutMinutes * 60),
+		BENCH_VLLM_BIN: `${GPU_BENCHMARK.paths.vllmEnvironment}/bin/vllm`,
+		BENCH_VLLM_NATIVE_RESULTS_DIR: `${GPU_BENCHMARK.paths.remoteRoot}/benchmark-results/vllm-native`,
+	};
+}
+
+export async function stageGpuProducer(sandbox: GpuSandbox): Promise<void> {
+	const files = [
+		"lib/bench.sh",
+		GPU_BENCHMARK.task,
+		...[
+			".catalog-ignore",
+			"install.sh",
+			"results-definition.xml",
+			"runner.sh",
+			"test-definition.xml",
+		].map((file) => `${GPU_BENCHMARK.profile.directory}/${file}`),
+	];
+	await Promise.all(
+		files.map((relative) =>
+			sandbox.sdk.filesystem.writeText(
+				readSource(relative),
+				join(GPU_BENCHMARK.paths.remoteRoot, relative),
+			),
+		),
+	);
+	await sandbox.runner.run(
+		"initialize staged benchmark",
+		`git init -q ${GPU_BENCHMARK.paths.remoteRoot}`,
+		30_000,
+	);
+}
+
+export async function stageCollectedEvidence(sandbox: GpuSandbox): Promise<void> {
+	const results = join(GPU_BENCHMARK.paths.remoteRoot, "benchmark-results");
+	await sandbox.runner.run(
+		"stage reproducibility evidence",
+		[
+			`mkdir -p ${results}`,
+			`cp ${GPU_BENCHMARK.paths.modelMount}/benchmark-assets.json ${results}/benchmark-assets.json`,
+			`${PYTHON_ENVIRONMENT_COMMAND} > ${results}/python-environment.txt`,
+		].join("\n"),
+		60_000,
+	);
+}
+
+function numberFrom(raw: string): number | undefined {
+	const trimmed = raw.trim();
+	if (!trimmed) return undefined;
+	const parsed = Number(trimmed);
+	return Number.isFinite(parsed) ? parsed : undefined;
+}
+
+export async function observeGpuSandbox(sandbox: GpuSandbox) {
+	const gpu = await sandbox.runner.run(
+		"capture GPU metadata",
+		"nvidia-smi --query-gpu=name,driver_version,memory.total,compute_cap --format=csv,noheader,nounits",
+		30_000,
+	);
+	const gpuOutput = (gpu.stdout ?? "").trim();
+	const gpuRows = gpuOutput
+		? gpuOutput.split("\n").map((line) => line.split(",").map((value) => value.trim()))
+		: [];
+	const system = await sandbox.runner.run(
+		"capture software metadata",
+		[
+			"printf 'visible_cpus=%s\\n' \"$(nproc)\"",
+			"printf 'memory_bytes='; if [ -r /sys/fs/cgroup/memory.max ] && [ \"$(cat /sys/fs/cgroup/memory.max)\" != max ]; then cat /sys/fs/cgroup/memory.max; else awk '/MemTotal:/ { print $2 * 1024 }' /proc/meminfo; fi",
+			"printf 'pts_version=%s\\n' \"$(phoronix-test-suite version | sed -n 's/^Phoronix Test Suite v//p')\"",
+			`${GPU_BENCHMARK.paths.vllmEnvironment}/bin/python - <<'PY'`,
+			"import importlib.metadata, json, platform, subprocess, torch, transformers, vllm",
+			"def version(name):",
+			"    try: return importlib.metadata.version(name)",
+			"    except importlib.metadata.PackageNotFoundError: return None",
+			"available = torch.cuda.is_available()",
+			"if not available: raise RuntimeError('torch.cuda.is_available() is false')",
+			"smoke = float((torch.ones(256, device='cuda') * 2).sum().item())",
+			"nvcc = subprocess.run(['nvcc', '--version'], check=True, capture_output=True, text=True).stdout.strip().splitlines()[-1]",
+			"print(json.dumps({'python': platform.python_version(), 'torch': torch.__version__, 'torchaudio': version('torchaudio'), 'transformers': transformers.__version__, 'triton': version('triton'), 'flashinfer': version('flashinfer-python'), 'cutlass_dsl': version('nvidia-cutlass-dsl'), 'cuda': torch.version.cuda, 'nvcc': nvcc, 'cuda_available': available, 'cuda_smoke': smoke, 'vllm': vllm.__version__}))",
+			"PY",
+		].join("\n"),
+		60_000,
+	);
+	const lines = (system.stdout ?? "").trim().split("\n");
+	const versions = JSON.parse(lines.at(-1) ?? "{}") as Record<string, unknown>;
+	const tagged = (name: string) =>
+		lines.find((line) => line.startsWith(`${name}=`))?.slice(name.length + 1);
+	const strings = (index: number) => [
+		...new Set(gpuRows.map((row) => row[index]).filter((value): value is string => Boolean(value))),
+	];
+	const value = (name: string) => (typeof versions[name] === "string" ? versions[name] : undefined);
+	const memoryBytes = numberFrom(tagged("memory_bytes") ?? "");
+	return {
+		gpuName: strings(0).length > 1 ? strings(0).join(", ") : strings(0)[0],
+		gpuCount: gpuRows.length || undefined,
+		driverVersion: strings(1).join(", "),
+		gpuMemoryMiB: gpuRows.reduce((total, row) => total + (numberFrom(row[2] ?? "") ?? 0), 0),
+		computeCapability: strings(3).join(", "),
+		visibleCpus: numberFrom(tagged("visible_cpus") ?? ""),
+		memoryLimitMiB: memoryBytes === undefined ? undefined : Math.round(memoryBytes / 1024 / 1024),
+		ptsVersion: tagged("pts_version") || undefined,
+		pythonVersion: value("python"),
+		torchVersion: value("torch"),
+		torchaudioVersion: value("torchaudio"),
+		transformersVersion: value("transformers"),
+		tritonVersion: value("triton"),
+		flashinferVersion: value("flashinfer"),
+		cutlassDslVersion: value("cutlass_dsl"),
+		cudaVersion: value("cuda"),
+		nvccVersion: value("nvcc"),
+		cudaAvailable: versions.cuda_available === true,
+		cudaSmoke: typeof versions.cuda_smoke === "number" ? String(versions.cuda_smoke) : undefined,
+		vllmVersion: value("vllm"),
+	};
+}

--- a/bun.lock
+++ b/bun.lock
@@ -44,6 +44,7 @@
         "@sandbox-benchmarks/schema": "workspace:*",
         "@sandbox-benchmarks/templates": "workspace:*",
         "dotenv": "catalog:",
+        "modal": "catalog:computesdk",
         "novita-sandbox": "catalog:computesdk",
       },
       "devDependencies": {
@@ -212,6 +213,7 @@
       "@vercel/sandbox": "2.9.2",
       "computesdk": "4.1.3",
       "microsandbox": "0.6.8",
+      "modal": "0.9.0",
       "novita-sandbox": "2.0.6",
     },
     "xml": {
@@ -854,9 +856,9 @@
 
     "ansi-colors": ["ansi-colors@4.1.3", "", {}, "sha512-/6w/C21Pm1A7aZitlI5Ni/2J6FFQN8i1Cvz3kHABAAbw93v/NlvKdVOqz7CCWz/3iv/JplRSEEZ83XION15ovw=="],
 
-    "ansi-regex": ["ansi-regex@6.2.2", "", {}, "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg=="],
+    "ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
 
-    "ansi-styles": ["ansi-styles@6.2.3", "", {}, "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg=="],
+    "ansi-styles": ["ansi-styles@4.3.0", "", { "dependencies": { "color-convert": "^2.0.1" } }, "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg=="],
 
     "any-promise": ["any-promise@1.3.0", "", {}, "sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A=="],
 
@@ -1288,7 +1290,7 @@
 
     "mkdirp": ["mkdirp@1.0.4", "", { "bin": { "mkdirp": "bin/cmd.js" } }, "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw=="],
 
-    "modal": ["modal@0.7.6", "", { "dependencies": { "cbor-x": "^1.6.0", "long": "^5.3.1", "nice-grpc": "^2.1.12", "protobufjs": "^7.5.0", "smol-toml": "^1.3.3", "uuid": "^11.1.0" } }, "sha512-AOFRO/eGl4fcNKxHkNLx55+tL318IeAiTDJCMh/Q1ZXhoaZFnpmlirVV2J5BhO32XLA7AiH6KYGA7gRBGA09lQ=="],
+    "modal": ["modal@0.9.0", "", { "dependencies": { "cbor-x": "^1.6.0", "long": "^5.3.1", "nice-grpc": "^2.1.12", "protobufjs": "^7.5.0", "smol-toml": "^1.3.3", "uuid": "^11.1.0" } }, "sha512-kCXcdJkhbJorf/q/6T9Wdlg6in9JmRnCNQnV6rVBMyeqNV/iXI6BYk4IzY4cvZ6dbauNeDMjk/Q08cbxvoIaXg=="],
 
     "module-details-from-path": ["module-details-from-path@1.0.4", "", {}, "sha512-EGWKgxALGMgzvxYF1UyGTy0HXX/2vHLkw6+NvDKW2jypWbHpjQuj4UMcqQWXHERJhVGKikolT06G3bcKe4fi7w=="],
 
@@ -1494,7 +1496,7 @@
 
     "string_decoder": ["string_decoder@1.3.0", "", { "dependencies": { "safe-buffer": "~5.2.0" } }, "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA=="],
 
-    "strip-ansi": ["strip-ansi@7.2.0", "", { "dependencies": { "ansi-regex": "^6.2.2" } }, "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w=="],
+    "strip-ansi": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
 
     "strip-ansi-cjs": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
 
@@ -1580,7 +1582,7 @@
 
     "which": ["which@2.0.2", "", { "dependencies": { "isexe": "^2.0.0" }, "bin": { "node-which": "./bin/node-which" } }, "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA=="],
 
-    "wrap-ansi": ["wrap-ansi@8.1.0", "", { "dependencies": { "ansi-styles": "^6.1.0", "string-width": "^5.0.1", "strip-ansi": "^7.0.1" } }, "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ=="],
+    "wrap-ansi": ["wrap-ansi@7.0.0", "", { "dependencies": { "ansi-styles": "^4.0.0", "string-width": "^4.1.0", "strip-ansi": "^6.0.0" } }, "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q=="],
 
     "wrap-ansi-cjs": ["wrap-ansi@7.0.0", "", { "dependencies": { "ansi-styles": "^4.0.0", "string-width": "^4.1.0", "strip-ansi": "^6.0.0" } }, "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q=="],
 
@@ -1621,6 +1623,8 @@
     "@blaxel/core/dotenv": ["dotenv@16.6.1", "", {}, "sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow=="],
 
     "@blaxel/core/zod": ["zod@3.25.76", "", {}, "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="],
+
+    "@computesdk/modal/modal": ["modal@0.7.6", "", { "dependencies": { "cbor-x": "^1.6.0", "long": "^5.3.1", "nice-grpc": "^2.1.12", "protobufjs": "^7.5.0", "smol-toml": "^1.3.3", "uuid": "^11.1.0" } }, "sha512-AOFRO/eGl4fcNKxHkNLx55+tL318IeAiTDJCMh/Q1ZXhoaZFnpmlirVV2J5BhO32XLA7AiH6KYGA7gRBGA09lQ=="],
 
     "@hey-api/json-schema-ref-parser/js-yaml": ["js-yaml@4.2.0", "", { "dependencies": { "argparse": "^2.0.1" }, "bin": { "js-yaml": "bin/js-yaml.js" } }, "sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw=="],
 
@@ -1710,10 +1714,6 @@
 
     "c12/chokidar": ["chokidar@5.0.0", "", { "dependencies": { "readdirp": "^5.0.0" } }, "sha512-TQMmc3w+5AxjpL8iIiwebF73dRDF4fBIieAqGn9RGCWaEVwQ6Fb2cGe31Yns0RRIzii5goJ1Y7xbMwo1TxMplw=="],
 
-    "cliui/strip-ansi": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
-
-    "cliui/wrap-ansi": ["wrap-ansi@7.0.0", "", { "dependencies": { "ansi-styles": "^4.0.0", "string-width": "^4.1.0", "strip-ansi": "^6.0.0" } }, "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q=="],
-
     "debug/ms": ["ms@2.1.2", "", {}, "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="],
 
     "e2b/undici": ["undici@7.27.2", "", {}, "sha512-uZsKNuzQxDMUY6M3pIMvy5tvlGmtq8XJ2oLAkfRKGNu+1VQAIvLy2xIVG5ATZl5wDXl/tddByAWCizRbOme+TA=="],
@@ -1778,25 +1778,15 @@
 
     "stream-browserify/readable-stream": ["readable-stream@3.6.2", "", { "dependencies": { "inherits": "^2.0.3", "string_decoder": "^1.1.1", "util-deprecate": "^1.0.1" } }, "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA=="],
 
-    "string-width/strip-ansi": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
-
-    "string-width-cjs/strip-ansi": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
-
-    "strip-ansi-cjs/ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
-
     "type-is/content-type": ["content-type@2.0.0", "", {}, "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ=="],
 
     "type-is/mime-types": ["mime-types@3.0.2", "", { "dependencies": { "mime-db": "^1.54.0" } }, "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A=="],
 
-    "wrap-ansi/string-width": ["string-width@5.1.2", "", { "dependencies": { "eastasianwidth": "^0.2.0", "emoji-regex": "^9.2.2", "strip-ansi": "^7.0.1" } }, "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA=="],
-
-    "wrap-ansi-cjs/ansi-styles": ["ansi-styles@4.3.0", "", { "dependencies": { "color-convert": "^2.0.1" } }, "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg=="],
-
-    "wrap-ansi-cjs/strip-ansi": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
-
     "wsl-utils/is-wsl": ["is-wsl@3.1.1", "", { "dependencies": { "is-inside-container": "^1.0.0" } }, "sha512-e6rvdUCiQCAuumZslxRJWR/Doq4VpPR82kqclvcS0efgt430SlGIk05vdCN58+VrzgtIcfNODjozVielycD4Sw=="],
 
     "yauzl/buffer-crc32": ["buffer-crc32@0.2.13", "", {}, "sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ=="],
+
+    "@computesdk/modal/modal/smol-toml": ["smol-toml@1.6.1", "", {}, "sha512-dWUG8F5sIIARXih1DTaQAX4SsiTXhInKf1buxdY9DIg4ZYPZK5nGM1VRIYmEbDbsHt7USo99xSLFu5Q1IqTmsg=="],
 
     "@hey-api/shared/open/define-lazy-prop": ["define-lazy-prop@3.0.0", "", {}, "sha512-N+MeXYoqr3pOgn8xfyRPREN7gHakLYjhsHhWGT3fWAiL4IkAt0iDw14QiiEm2bE30c5XX5q0FtAA3CK5f9/BUg=="],
 
@@ -1826,10 +1816,6 @@
 
     "c12/chokidar/readdirp": ["readdirp@5.0.0", "", {}, "sha512-9u/XQ1pvrQtYyMpZe7DXKv2p5CNvyVwzUB6uhLAnQwHMSgKMBR62lc7AHljaeteeHXn11XTAaLLUVZYVZyuRBQ=="],
 
-    "cliui/strip-ansi/ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
-
-    "cliui/wrap-ansi/ansi-styles": ["ansi-styles@4.3.0", "", { "dependencies": { "color-convert": "^2.0.1" } }, "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg=="],
-
     "express/mime-types/mime-db": ["mime-db@1.54.0", "", {}, "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ=="],
 
     "lazystream/readable-stream/safe-buffer": ["safe-buffer@5.1.2", "", {}, "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="],
@@ -1852,15 +1838,7 @@
 
     "send/mime-types/mime-db": ["mime-db@1.54.0", "", {}, "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ=="],
 
-    "string-width-cjs/strip-ansi/ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
-
-    "string-width/strip-ansi/ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
-
     "type-is/mime-types/mime-db": ["mime-db@1.54.0", "", {}, "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ=="],
-
-    "wrap-ansi-cjs/strip-ansi/ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
-
-    "wrap-ansi/string-width/emoji-regex": ["emoji-regex@9.2.2", "", {}, "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg=="],
 
     "@opentelemetry/otlp-transformer/protobufjs/@types/node/undici-types": ["undici-types@7.24.6", "", {}, "sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg=="],
 
@@ -1884,8 +1862,16 @@
 
     "archiver-utils/glob/jackspeak/@isaacs/cliui/string-width": ["string-width@5.1.2", "", { "dependencies": { "eastasianwidth": "^0.2.0", "emoji-regex": "^9.2.2", "strip-ansi": "^7.0.1" } }, "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA=="],
 
+    "archiver-utils/glob/jackspeak/@isaacs/cliui/strip-ansi": ["strip-ansi@7.2.0", "", { "dependencies": { "ansi-regex": "^6.2.2" } }, "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w=="],
+
+    "archiver-utils/glob/jackspeak/@isaacs/cliui/wrap-ansi": ["wrap-ansi@8.1.0", "", { "dependencies": { "ansi-styles": "^6.1.0", "string-width": "^5.0.1", "strip-ansi": "^7.0.1" } }, "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ=="],
+
     "archiver-utils/glob/minimatch/brace-expansion/balanced-match": ["balanced-match@1.0.2", "", {}, "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="],
 
     "archiver-utils/glob/jackspeak/@isaacs/cliui/string-width/emoji-regex": ["emoji-regex@9.2.2", "", {}, "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg=="],
+
+    "archiver-utils/glob/jackspeak/@isaacs/cliui/strip-ansi/ansi-regex": ["ansi-regex@6.2.2", "", {}, "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg=="],
+
+    "archiver-utils/glob/jackspeak/@isaacs/cliui/wrap-ansi/ansi-styles": ["ansi-styles@6.2.3", "", {}, "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg=="],
   }
 }

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
         "@daytona/sdk": "0.192.0",
         "computesdk": "4.1.3",
         "microsandbox": "0.6.8",
+        "modal": "0.9.0",
         "novita-sandbox": "2.0.6",
         "@vercel/sandbox": "2.9.2"
       },


### PR DESCRIPTION
## Summary

- add the Modal GPU sandbox adapter and verified termination loop
- centralize GPU resource and vLLM environment policy
- stage benchmark sources and collect reproducibility metadata
- add the direct Modal SDK dependency and lockfile update

## Why

This establishes the provider boundary independently from model, kernel, fleet, and workflow orchestration.

## Validation

- full workspace test suite
- `bun run lint`
- `bun run typecheck`
- frozen Bun lockfile validation

## Stack

Depends on #359. Next: #361.