### PR TITLE
feat(gpu): seed reusable kernel snapshots

### DIFF
--- a/apps/cli/src/lib/gpu/cuda-graphs.ts
+++ b/apps/cli/src/lib/gpu/cuda-graphs.ts
@@ -1,0 +1,14 @@
+export function cudaGraphEvidenceFromLog(log: string) {
+	return {
+		requestedMode: "FULL_AND_PIECEWISE" as const,
+		runtimeModeObserved: log.includes("CUDAGraphMode.FULL_AND_PIECEWISE"),
+		eagerDisabled: log.includes("enforce_eager=False"),
+		captureCompleted: /Graph capturing finished in \d+(?:\.\d+)? secs/.test(log),
+	};
+}
+
+export type CudaGraphEvidence = ReturnType<typeof cudaGraphEvidenceFromLog>;
+
+export function cudaGraphEvidencePassed(evidence: CudaGraphEvidence): boolean {
+	return evidence.runtimeModeObserved && evidence.eagerDisabled && evidence.captureCompleted;
+}

--- a/apps/cli/src/lib/gpu/prepare-kernels.ts
+++ b/apps/cli/src/lib/gpu/prepare-kernels.ts
@@ -1,0 +1,249 @@
+import { createHash } from "node:crypto";
+import { mkdirSync, writeFileSync } from "node:fs";
+import { join, resolve } from "node:path";
+import type { App, Image, ModalClient, Volume } from "modal";
+import type { GpuArgs } from "./args.ts";
+import { GPU_BENCHMARK, readSource } from "./config.ts";
+import { cudaGraphEvidenceFromLog, cudaGraphEvidencePassed } from "./cuda-graphs.ts";
+import type { GpuSandbox } from "./modal.ts";
+import { gpuSandboxResources, stageGpuProducer, vllmEnvironment, withGpuSandbox } from "./modal.ts";
+import { validateModelAssets } from "./prepare-models.ts";
+
+const registryPointerPath = `${GPU_BENCHMARK.paths.kernelRegistryMount}/current.json`;
+const seedManifestPath = `${GPU_BENCHMARK.paths.kernelCache}/seed-manifest.json`;
+
+export function kernelSeedManifest(
+	baseImageId: string,
+	args: Pick<GpuArgs, "gpu" | "flashinferAutotune">,
+) {
+	const profileSha256 = createHash("sha256");
+	for (const file of ["install.sh", "results-definition.xml", "runner.sh", "test-definition.xml"]) {
+		profileSha256
+			.update(file)
+			.update("\0")
+			.update(readSource(`${GPU_BENCHMARK.profile.directory}/${file}`))
+			.update("\0");
+	}
+	return {
+		schemaVersion: "3.0" as const,
+		modalImageId: baseImageId,
+		cudaImage: GPU_BENCHMARK.software.cudaImage,
+		pythonVersion: GPU_BENCHMARK.software.python,
+		vllmVersion: GPU_BENCHMARK.software.vllm,
+		gpu: args.gpu,
+		modelSnapshots: [GPU_BENCHMARK.workload.model],
+		profileSha256: profileSha256.digest("hex"),
+		parallelism: { tensor: 1, pipeline: 1 } as const,
+		cudaGraphs: "FULL_AND_PIECEWISE" as const,
+		flashinferAutotune: args.flashinferAutotune,
+	};
+}
+
+export type KernelSeedManifest = ReturnType<typeof kernelSeedManifest>;
+
+function createKernelSnapshotPointer(snapshotImageId: string, seed: KernelSeedManifest) {
+	return {
+		schemaVersion: "1.0" as const,
+		snapshotImageId,
+		createdAt: new Date().toISOString(),
+		seed,
+	};
+}
+
+export type KernelSnapshotPointer = ReturnType<typeof createKernelSnapshotPointer>;
+
+const encode = (value: unknown): string => `${JSON.stringify(value, null, 2)}\n`;
+
+export function kernelSnapshotPointerFromText(
+	raw: string,
+	expectedSeed: KernelSeedManifest,
+): KernelSnapshotPointer | undefined {
+	try {
+		const pointer = JSON.parse(raw) as Partial<KernelSnapshotPointer>;
+		if (
+			pointer.schemaVersion !== "1.0" ||
+			typeof pointer.snapshotImageId !== "string" ||
+			!pointer.snapshotImageId.startsWith("im-") ||
+			typeof pointer.createdAt !== "string" ||
+			pointer.seed === undefined ||
+			encode(pointer.seed) !== encode(expectedSeed)
+		) {
+			return undefined;
+		}
+		return pointer as KernelSnapshotPointer;
+	} catch {
+		return undefined;
+	}
+}
+
+export async function resolveKernelSnapshot(options: {
+	client: ModalClient;
+	app: App;
+	baseImage: Image;
+	registryVolume: Volume;
+	registryVolumeName: string;
+	args: GpuArgs;
+}): Promise<Image | undefined> {
+	const expectedSeed = kernelSeedManifest(options.baseImage.imageId, options.args);
+	const pointer = await withGpuSandbox(
+		options.client,
+		() =>
+			options.client.sandboxes.create(options.app, options.baseImage, {
+				cpu: 0.25,
+				cpuLimit: 1,
+				memoryMiB: 128,
+				memoryLimitMiB: 512,
+				timeoutMs: 5 * 60_000,
+				blockNetwork: true,
+				volumes: {
+					[GPU_BENCHMARK.paths.kernelRegistryMount]: options.registryVolume.withMountOptions({
+						readOnly: true,
+					}),
+				},
+			}),
+		async (registry) => {
+			try {
+				await registry.sdk.setTags({
+					"gpu-benchmark-role": "kernel-snapshot-registry-check",
+					"kernel-snapshot-registry-volume": options.registryVolumeName,
+				});
+				return kernelSnapshotPointerFromText(
+					await registry.sdk.filesystem.readText(registryPointerPath),
+					expectedSeed,
+				);
+			} catch {
+				// Missing registry state is an ordinary cache miss.
+				return undefined;
+			}
+		},
+	);
+	if (!pointer) return undefined;
+
+	let candidate: Image;
+	try {
+		candidate = await options.client.images.fromId(pointer.snapshotImageId);
+	} catch {
+		return undefined;
+	}
+	let created = false;
+	try {
+		return await withGpuSandbox(
+			options.client,
+			async () => {
+				const sandbox = await options.client.sandboxes.create(options.app, candidate, {
+					cpu: 0.25,
+					cpuLimit: 1,
+					memoryMiB: 128,
+					memoryLimitMiB: 512,
+					timeoutMs: 2 * 60_000,
+					blockNetwork: true,
+				});
+				created = true;
+				return sandbox;
+			},
+			async (probe) => {
+				try {
+					await probe.sdk.setTags({
+						"gpu-benchmark-role": "kernel-snapshot-check",
+						"kernel-snapshot-image": pointer.snapshotImageId,
+					});
+					const embeddedSeed = await probe.sdk.filesystem.readText(seedManifestPath);
+					return embeddedSeed === encode(expectedSeed) ? candidate : undefined;
+				} catch {
+					return undefined;
+				}
+			},
+		);
+	} catch (error) {
+		// An expired image or failed probe allocation is a cache miss; a teardown failure is not.
+		if (!created) return undefined;
+		throw error;
+	}
+}
+
+async function installProfile(sandbox: GpuSandbox): Promise<void> {
+	await sandbox.runner.step(
+		"install PTS profile",
+		[
+			`cd ${GPU_BENCHMARK.paths.remoteRoot}`,
+			"REPO_ROOT=$PWD",
+			"source lib/bench.sh",
+			"ensure_pts",
+			`install_local_pts_profile ${GPU_BENCHMARK.profile.name}`,
+			`phoronix-test-suite batch-install ${GPU_BENCHMARK.profile.id}`,
+		].join("\n"),
+		20 * 60_000,
+	);
+}
+
+export async function prepareKernelSnapshot(options: {
+	client: ModalClient;
+	app: App;
+	baseImage: Image;
+	modelVolume: Volume;
+	modelVolumeName: string;
+	registryVolume: Volume;
+	registryVolumeName: string;
+	args: GpuArgs;
+}): Promise<KernelSnapshotPointer> {
+	const { args } = options;
+	const expectedSeed = kernelSeedManifest(options.baseImage.imageId, args);
+	const outputDirectory = resolve(args.outputDirectory);
+	mkdirSync(outputDirectory, { recursive: true });
+	return withGpuSandbox(
+		options.client,
+		() =>
+			options.client.sandboxes.create(options.app, options.baseImage, {
+				...gpuSandboxResources(args),
+				env: vllmEnvironment(args),
+				volumes: {
+					[GPU_BENCHMARK.paths.modelMount]: options.modelVolume.withMountOptions({
+						readOnly: true,
+					}),
+					[GPU_BENCHMARK.paths.kernelRegistryMount]: options.registryVolume,
+				},
+			}),
+		async (sandbox) => {
+			await sandbox.sdk.setTags({
+				"gpu-benchmark-role": "kernel-cache-seed",
+				profile: GPU_BENCHMARK.profile.name,
+				gpu: args.gpu,
+				"model-volume": options.modelVolumeName,
+				"kernel-snapshot-registry-volume": options.registryVolumeName,
+			});
+			console.error(`Modal GPU kernel-seed sandbox: ${sandbox.sandboxId}`);
+			await validateModelAssets(sandbox);
+			await stageGpuProducer(sandbox);
+			await installProfile(sandbox);
+			const model = GPU_BENCHMARK.workload.model;
+			const seed = await sandbox.runner.step(
+				"seed vLLM kernel cache",
+				`cd ${GPU_BENCHMARK.paths.remoteRoot} && LOG_FILE=/tmp/vllm-kernel-seed.log bash ${GPU_BENCHMARK.profile.directory}/runner.sh speed-bench --model ${model.repoId} --revision ${model.revision}`,
+				Math.max(
+					60_000,
+					(args.timeoutMinutes - GPU_BENCHMARK.deadlines.artifactReserveMinutes) * 60_000,
+				),
+				{ allowFailure: true },
+			);
+			writeFileSync(join(outputDirectory, "kernel-seed.stdout.log"), seed.stdout ?? "");
+			writeFileSync(join(outputDirectory, "kernel-seed.stderr.log"), seed.stderr ?? "");
+			if (seed.exitCode !== 0) throw new Error(`kernel-cache seed exited ${seed.exitCode}`);
+			const serverLog = await sandbox.sdk.filesystem.readText(
+				`${GPU_BENCHMARK.paths.remoteRoot}/benchmark-results/vllm-native/server.log`,
+			);
+			writeFileSync(join(outputDirectory, "vllm-server.log"), serverLog);
+			const cudaGraphs = cudaGraphEvidenceFromLog(serverLog);
+			if (!cudaGraphEvidencePassed(cudaGraphs)) {
+				throw new Error("kernel-cache seed reached no verified CUDA-graph capture");
+			}
+			await sandbox.sdk.filesystem.writeText(encode(expectedSeed), seedManifestPath);
+			const snapshot = await sandbox.sdk.snapshotFilesystem({
+				timeoutMs: 5 * 60_000,
+				ttlMs: GPU_BENCHMARK.kernelSnapshotTtlDays * 24 * 60 * 60_000,
+			});
+			const pointer = createKernelSnapshotPointer(snapshot.imageId, expectedSeed);
+			await sandbox.sdk.filesystem.writeText(encode(pointer), registryPointerPath);
+			return pointer;
+		},
+	);
+}


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Seeds reusable GPU kernel snapshots for `vLLM` and adds a cache lookup to reuse them across runs. This reduces warmup time and verifies CUDA graph capture before snapshotting.

- **New Features**
  - Embed seed manifest (v3.0) in the snapshot with a TTL; includes base image ID, CUDA image, Python, `vLLM`, GPU, model snapshot, PTS profile SHA-256, parallelism, CUDA graph mode, and `flashinferAutotune`.
  - Write registry pointer (v1.0) to the registry volume; resolver reads it in a read-only, network-blocked sandbox, probes the candidate image in a network-blocked sandbox, and reuses only if the embedded seed matches exactly.
  - Validate model assets, install the PTS profile, stage the GPU producer, seed the cache, and write kernel-seed stdout/stderr plus `vLLM` server logs; verify CUDA graphs from server logs (FULL_AND_PIECEWISE observed, eager disabled, capture finished). Supports Modal GPU sandboxes, model/registry volumes, and timeouts.

<sup>Written for commit b155e13d43cb3c1f78c29950bf82aa25429f62bd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/starslingdev/hpc-sandbox-benchmarks/pull/362?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

