### PR TITLE
feat(cli): expose Modal GPU benchmark

### DIFF
--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -4,6 +4,7 @@
   "private": true,
   "type": "module",
   "bin": {
+    "bench-gpu": "./src/bin/bench-gpu.ts",
     "bench-lifecycle": "./src/bin/bench-lifecycle.ts",
     "bench-suite": "./src/bin/bench-suite.ts",
     "bench-smoke": "./src/bin/bench-smoke.ts",

--- a/apps/cli/src/bin/bench-gpu.ts
+++ b/apps/cli/src/bin/bench-gpu.ts
@@ -1,0 +1,112 @@
+#!/usr/bin/env bun
+import {
+	shutdownOwnedSandboxes,
+	withCleanupPreservingPrimaryError,
+} from "@sandbox-benchmarks/harness";
+import type { ModalClient } from "modal";
+import { ModalClient as Client } from "modal";
+import type { GpuArgs } from "../lib/gpu/args.ts";
+import { parseGpuArgs } from "../lib/gpu/args.ts";
+import {
+	GPU_BENCHMARK,
+	GPU_RUNTIME_IMAGE_COMMANDS,
+	VLLM_IMAGE_COMMANDS,
+} from "../lib/gpu/config.ts";
+import { runGpuFleet } from "../lib/gpu/fleet.ts";
+import { prepareKernelSnapshot, resolveKernelSnapshot } from "../lib/gpu/prepare-kernels.ts";
+import { prepareModelAssets } from "../lib/gpu/prepare-models.ts";
+
+async function run(args: GpuArgs, client: ModalClient): Promise<void> {
+	const app = await client.apps.fromName(GPU_BENCHMARK.appName, { createIfMissing: true });
+	const baseImage = await client.images
+		.fromRegistry(GPU_BENCHMARK.software.cudaImage)
+		.dockerfileCommands([...VLLM_IMAGE_COMMANDS])
+		.dockerfileCommands([...GPU_RUNTIME_IMAGE_COMMANDS])
+		.build(app);
+	const modelVolume = await client.volumes.fromName(args.modelVolume, {
+		createIfMissing: args.operation === "models",
+	});
+	if (args.operation === "models") {
+		await prepareModelAssets({
+			client,
+			app,
+			image: baseImage,
+			volume: modelVolume,
+			volumeName: args.modelVolume,
+			cpu: args.cpuRequested,
+			cpuLimit: args.cpuLimit,
+			timeoutMinutes: args.timeoutMinutes,
+		});
+		console.log(JSON.stringify({ status: "prepared", modelVolume: args.modelVolume }, null, 2));
+		return;
+	}
+
+	const registryVolume = await client.volumes.fromName(args.kernelSnapshotRegistryVolume, {
+		createIfMissing: args.operation === "kernels",
+	});
+	const cachedKernelImage = await resolveKernelSnapshot({
+		client,
+		app,
+		baseImage,
+		registryVolume,
+		registryVolumeName: args.kernelSnapshotRegistryVolume,
+		args,
+	});
+	if (args.operation === "kernels") {
+		const pointer = cachedKernelImage
+			? { status: "already-prepared", kernelSnapshotImageId: cachedKernelImage.imageId }
+			: {
+					status: "prepared",
+					...(await prepareKernelSnapshot({
+						client,
+						app,
+						baseImage,
+						modelVolume,
+						modelVolumeName: args.modelVolume,
+						registryVolume,
+						registryVolumeName: args.kernelSnapshotRegistryVolume,
+						args,
+					})),
+				};
+		console.log(JSON.stringify(pointer, null, 2));
+		return;
+	}
+	if (!cachedKernelImage) {
+		throw new Error(
+			"no compatible vLLM kernel snapshot is registered; run --prepare kernels first",
+		);
+	}
+	await runGpuFleet({ client, app, baseImage, kernelImage: cachedKernelImage, modelVolume, args });
+}
+
+async function main(): Promise<void> {
+	const args = parseGpuArgs(process.argv.slice(2));
+	if (!process.env.MODAL_TOKEN_ID || !process.env.MODAL_TOKEN_SECRET) {
+		throw new Error("MODAL_TOKEN_ID and MODAL_TOKEN_SECRET are required");
+	}
+	const client = new Client();
+	await withCleanupPreservingPrimaryError(
+		() => run(args, client),
+		async () => {
+			let failures: unknown[];
+			try {
+				failures = await shutdownOwnedSandboxes("GPU benchmark exit");
+			} finally {
+				client.close();
+			}
+			if (failures.length > 0) {
+				throw new AggregateError(failures, "GPU sandbox cleanup failed");
+			}
+		},
+		(error) => console.error("GPU benchmark cleanup also failed:", error),
+	);
+}
+
+if (import.meta.main) {
+	try {
+		await main();
+	} catch (error) {
+		console.error(`error: ${error instanceof Error ? error.message : String(error)}`);
+		process.exitCode = 1;
+	}
+}

--- a/apps/cli/src/lib/gpu/gpu.test.ts
+++ b/apps/cli/src/lib/gpu/gpu.test.ts
@@ -1,0 +1,252 @@
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import { parseGpuArgs } from "./args.ts";
+import {
+	GPU_BENCHMARK,
+	GPU_RUNTIME_IMAGE_COMMANDS,
+	KERNEL_CACHE_ENV,
+	MODAL_GPU_ENV,
+	MODEL_CACHE_ENV,
+	MODEL_OFFLINE_ENV,
+	PYTHON_ENVIRONMENT_COMMAND,
+	VLLM_IMAGE_COMMANDS,
+} from "./config.ts";
+import { cudaGraphEvidenceFromLog } from "./cuda-graphs.ts";
+import { createGpuSandbox, gpuSandboxResources, vllmEnvironment } from "./modal.ts";
+import { kernelSeedManifest, kernelSnapshotPointerFromText } from "./prepare-kernels.ts";
+import { modelAssetConfig } from "./prepare-models.ts";
+
+describe("vLLM image", () => {
+	test("lets vLLM own its dependency stack on the CUDA development base", () => {
+		const commands = [...VLLM_IMAGE_COMMANDS, ...GPU_RUNTIME_IMAGE_COMMANDS].join("\n");
+		expect(commands).toContain("'vllm[bench]==0.26.0'");
+		expect(commands).toContain("uv==0.12.3");
+		expect(commands).toContain("hf-xet==1.5.2");
+		expect(commands).toContain("<NoInternetCommunication>TRUE</NoInternetCommunication>");
+		expect(commands).toContain("<NoNetworkCommunication>TRUE</NoNetworkCommunication>");
+		expect(GPU_BENCHMARK.software.cudaImage).toContain(
+			"nvidia/cuda:13.3.1-devel-ubuntu24.04@sha256:",
+		);
+		expect(commands).toContain("CUDACXX=/usr/local/cuda/bin/nvcc");
+		expect(commands).toContain("uv python install 3.13.14");
+		expect(commands).toContain("phoronix-test-suite_10.8.4_all.deb");
+		expect(commands).not.toContain("cuda:12.9");
+		expect(commands).not.toMatch(/(?:^|\s)(?:torch|transformers|torchaudio|datasets|pyarrow)==/);
+		expect(commands).not.toContain("--torch-backend");
+		expect(VLLM_IMAGE_COMMANDS.join("\n")).not.toContain("hf-xet==");
+		expect(GPU_RUNTIME_IMAGE_COMMANDS.join("\n")).toContain("hf-xet==1.5.2");
+	});
+});
+
+describe("parseGpuArgs", () => {
+	test("defaults to one qualification replicate", () => {
+		expect(parseGpuArgs([])).toMatchObject({
+			operation: "benchmark",
+			gpu: GPU_BENCHMARK.defaults.gpu,
+			modelVolume: GPU_BENCHMARK.volumes.models,
+			kernelSnapshotRegistryVolume: GPU_BENCHMARK.volumes.kernelRegistry,
+			cpuRequested: 4,
+			cpuLimit: 4,
+			memoryRequestedMiB: 512,
+			memoryLimitMiB: 8192,
+			mode: "qualification",
+			timeoutMinutes: 45,
+			clientTimeoutMinutes: 10,
+			flashinferAutotune: "disabled",
+			replicateIndices: [0],
+			maxConcurrency: Number.POSITIVE_INFINITY,
+			requirePrecision: false,
+			precisionTarget: GPU_BENCHMARK.defaults.relativeCiHalfWidth,
+		});
+	});
+
+	test("reuses the shared replicate plan and enforces confirmatory gates", () => {
+		const indices = Array.from(
+			{ length: GPU_BENCHMARK.defaults.minimumReplicates },
+			(_, index) => index,
+		);
+		expect(parseGpuArgs(["--require-precision", "--require-duration"])).toMatchObject({
+			replicateIndices: indices,
+			maxConcurrency: Number.POSITIVE_INFINITY,
+			requirePrecision: true,
+			requireDuration: true,
+		});
+		expect(() => parseGpuArgs(["--replicates", "[0,1,2]", "--require-precision"])).toThrow(
+			`at least ${GPU_BENCHMARK.defaults.minimumReplicates}`,
+		);
+	});
+
+	test("uses one explicit preparation operation", () => {
+		expect(parseGpuArgs(["--prepare", "models"])).toMatchObject({
+			operation: "models",
+			timeoutMinutes: 240,
+			replicateIndices: undefined,
+		});
+		expect(parseGpuArgs(["--prepare", "kernels"])).toMatchObject({
+			operation: "kernels",
+			timeoutMinutes: 90,
+			cudaBuildJobs: 8,
+			nvccThreads: 4,
+		});
+		expect(() => parseGpuArgs(["--prepare", "models", "--replicates", "[0]"])).toThrow(
+			"--replicates is supported only for benchmark execution",
+		);
+		expect(() => parseGpuArgs(["--prepare", "other"])).toThrow(
+			"--prepare must be models or kernels",
+		);
+		expect(() => parseGpuArgs(["--prepare="])).toThrow("--prepare must be models or kernels");
+	});
+
+	test("validates modes and resource limits", () => {
+		expect(parseGpuArgs(["--mode", "full"])).toMatchObject({
+			mode: "full",
+			timeoutMinutes: 240,
+			clientTimeoutMinutes: 180,
+		});
+		expect(() => parseGpuArgs(["--mode", "unknown"])).toThrow(
+			"--mode must be qualification or full",
+		);
+		expect(() =>
+			parseGpuArgs(["--mode", "full", "--timeout-minutes", "19", "--client-timeout-minutes", "10"]),
+		).toThrow("--timeout-minutes must be at least 20");
+		expect(() => parseGpuArgs(["--cpu", "5", "--cpu-limit", "4"])).toThrow(
+			"--cpu cannot exceed --cpu-limit",
+		);
+		expect(() => parseGpuArgs(["--memory-limit-mib", "8192.5"])).toThrow(
+			"--memory-limit-mib must be a positive integer",
+		);
+		expect(() => parseGpuArgs(["--required-precision"])).toThrow(
+			"unknown argument: --required-precision",
+		);
+		expect(() => parseGpuArgs(["positional"])).toThrow("unknown argument: positional");
+	});
+});
+
+describe("fixed workload", () => {
+	test("pins the profile and asset preparation from one config", () => {
+		const profileDirectory = new URL(
+			"../../../../../packages/schema/src/pts-profiles/local/vllm-speed-bench-1.0.0/",
+			import.meta.url,
+		);
+		const profile = readFileSync(new URL("test-definition.xml", profileDirectory), "utf8");
+		const model = GPU_BENCHMARK.workload.model;
+		expect(profile).toContain(`--model ${model.repoId} --revision ${model.revision}`);
+		expect(profile).toContain(GPU_BENCHMARK.workload.label);
+		expect(profile).toContain("--dataset-name speed_bench");
+		expect(profile).toContain("--speed-bench-category coding");
+		expect(profile).toContain("Qualification (1 prompt x 16 output tokens)");
+		expect(profile).toContain("Full (80 prompts x 1024 output tokens)");
+
+		const script = readFileSync(new URL("prepare-models.py", import.meta.url), "utf8");
+		const assets = modelAssetConfig();
+		expect(assets.model).toEqual(model);
+		expect(assets.speedBench.prepare.revision).toHaveLength(40);
+		expect(assets.speedBench.prepare.url).toContain(assets.speedBench.prepare.revision);
+		expect(script).toContain("filter insertion anchor changed");
+		expect(script).toContain('"prepareTransform": category_filter.strip()');
+		expect(script).toContain('"contentSha256": dataset_sha256');
+	});
+
+	test("keeps GPU consumers offline and the process runner fail-safe", () => {
+		expect(MODEL_CACHE_ENV.HF_XET_HIGH_PERFORMANCE).toBe("1");
+		expect(MODEL_OFFLINE_ENV.HF_HUB_OFFLINE).toBe("1");
+		expect(KERNEL_CACHE_ENV.BENCH_VLLM_KERNEL_CACHE_DIR).toBe(GPU_BENCHMARK.paths.kernelCache);
+		expect(PYTHON_ENVIRONMENT_COMMAND).toBe(
+			"/opt/uv/bin/uv pip freeze --python /opt/vllm/bin/python",
+		);
+		expect(MODAL_GPU_ENV.NCCL_P2P_DISABLE).toBe("1");
+
+		const runner = readFileSync(
+			new URL(
+				"../../../../../packages/schema/src/pts-profiles/local/vllm-speed-bench-1.0.0/runner.sh",
+				import.meta.url,
+			),
+			"utf8",
+		);
+		expect(runner).toContain("trap stop_server EXIT");
+		expect(runner).toContain('setsid "$' + '{server_env[@]}" "$' + '{server_args[@]}"');
+		expect(runner).toContain('kill -TERM -- "-$server_pid"');
+		expect(runner).toContain("hard readiness watchdog stopping vLLM");
+		expect(runner).toContain(`--compilation-config '{"cudagraph_mode":"FULL_AND_PIECEWISE"}'`);
+		expect(runner).toContain("timeout --foreground --signal=TERM --kill-after=30s");
+		expect(runner).not.toMatch(/pip install|uv pip install/);
+	});
+});
+
+describe("kernel snapshot registry", () => {
+	test("accepts only a pointer for the exact inferred seed", () => {
+		const seed = kernelSeedManifest("im-base", {
+			gpu: GPU_BENCHMARK.defaults.gpu,
+			flashinferAutotune: "disabled",
+		});
+		const raw = JSON.stringify({
+			schemaVersion: "1.0",
+			snapshotImageId: "im-kernel-snapshot",
+			createdAt: "2026-08-10T00:00:00.000Z",
+			seed,
+		});
+		expect(kernelSnapshotPointerFromText(raw, seed)?.snapshotImageId).toBe("im-kernel-snapshot");
+		expect(
+			kernelSnapshotPointerFromText(raw, { ...seed, profileSha256: "changed" }),
+		).toBeUndefined();
+		expect(kernelSnapshotPointerFromText("not-json", seed)).toBeUndefined();
+	});
+});
+
+describe("CUDA graph evidence", () => {
+	test("requires the resolved mode, eager-disabled engine, and completed capture", () => {
+		expect(
+			cudaGraphEvidenceFromLog(
+				"CUDAGraphMode.FULL_AND_PIECEWISE enforce_eager=False Graph capturing finished in 19 secs",
+			),
+		).toEqual({
+			requestedMode: "FULL_AND_PIECEWISE",
+			runtimeModeObserved: true,
+			eagerDisabled: true,
+			captureCompleted: true,
+		});
+	});
+});
+
+describe("Modal lifecycle adapter", () => {
+	test("terminates with wait and verifies the sandbox is absent", async () => {
+		const terminateCalls: unknown[] = [];
+		const sdk = {
+			sandboxId: "sb-test",
+			terminate: async (options: unknown) => terminateCalls.push(options),
+		};
+		const client = {
+			sandboxes: {
+				list: async function* () {},
+			},
+		};
+		const sandbox = await createGpuSandbox(client as never, async () => sdk as never);
+		await sandbox.destroy();
+		expect(terminateCalls).toEqual([{ wait: true }]);
+	});
+
+	test("shares resource and vLLM environment policy across seed and benchmark sandboxes", () => {
+		const args = parseGpuArgs([]);
+		expect(gpuSandboxResources(args)).toEqual({
+			gpu: args.gpu,
+			cpu: args.cpuRequested,
+			cpuLimit: args.cpuLimit,
+			memoryMiB: args.memoryRequestedMiB,
+			memoryLimitMiB: args.memoryLimitMiB,
+			timeoutMs: args.timeoutMinutes * 60_000,
+			blockNetwork: true,
+		});
+		expect(vllmEnvironment(args)).toMatchObject({
+			BENCH_VLLM_MODE: "qualification",
+			BENCH_VLLM_MAX_JOBS: "1",
+			BENCH_VLLM_NVCC_THREADS: "1",
+			BENCH_VLLM_CLIENT_TIMEOUT_SECONDS: "600",
+		});
+		expect(vllmEnvironment(parseGpuArgs(["--prepare", "kernels"]))).toMatchObject({
+			BENCH_VLLM_PREPARE_KERNELS_ONLY: "1",
+			BENCH_VLLM_MAX_JOBS: "8",
+			BENCH_VLLM_NVCC_THREADS: "4",
+			BENCH_VLLM_CLIENT_TIMEOUT_SECONDS: "60",
+		});
+	});
+});

--- a/bun.lock
+++ b/bun.lock
@@ -17,6 +17,7 @@
       "name": "@sandbox-benchmarks/cli",
       "version": "0.0.0",
       "bin": {
+        "bench-gpu": "./src/bin/bench-gpu.ts",
         "bench-lifecycle": "./src/bin/bench-lifecycle.ts",
         "bench-suite": "./src/bin/bench-suite.ts",
         "bench-smoke": "./src/bin/bench-smoke.ts",


### PR DESCRIPTION
## Summary

- expose the `bench-gpu` CLI entry point
- orchestrate model preparation, kernel preparation, and benchmark execution
- drain all owned sandboxes before closing the Modal client
- add focused configuration, cache, CUDA-graph, and lifecycle integration tests

## Why

The CLI is introduced only after every service it composes is independently available and reviewable.

## Validation

- full workspace test suite: 284 tests at this stack tip
- `bun run lint`
- `bun run typecheck`
- frozen Bun lockfile validation

## Stack

Depends on #364. Next: #366.