### PR TITLE
ci(gpu): run replicated Modal benchmark

### DIFF
--- a/.github/workflows/bench-gpu.yml
+++ b/.github/workflows/bench-gpu.yml
@@ -1,0 +1,169 @@
+name: Benchmark GPU sandbox
+
+# Standalone GPU lane. GPU workloads are intentionally not added to the ordinary provider × suite
+# matrix: only Modal is wired here today, the resource/cost envelope is different, and vLLM metrics do
+# not belong in the CPU sandbox leaderboard. PTS schedules a vLLM 0.26 online-serving workload using
+# Qwen3 Coder 30B-A3B FP8 and SPEED-Bench Coding. Native vLLM JSON, the resolved environment, raw
+# PTS results, and a technical report are retained. CPU-only model preparation and an immutable
+# GPU-generated kernel snapshot keep network transfer, compilation, and cache copies out of the run.
+# A full run launches twenty independent sandboxes concurrently from one runner, matching the ordinary
+# benchmark lane's in-process replicate pattern while keeping GPU results statistically separate.
+# Qualification is a wiring check: one sandbox, one request, and none of the confirmatory gates.
+on:
+  workflow_dispatch:
+    inputs:
+      mode:
+        description: Full runs 80 × 1,024 tokens; qualification is a one-request wiring check
+        required: true
+        type: choice
+        default: full
+        options:
+          - qualification
+          - full
+
+permissions:
+  contents: read
+
+# The model cache and kernel-snapshot registry are shared across refs, so serialize workflow runs that
+# can update them. The benchmark job still launches its declared replicate fleet concurrently.
+concurrency:
+  group: gpu-benchmark-${{ github.repository }}-shared-model-cache
+  cancel-in-progress: false
+
+jobs:
+  prepare-assets:
+    name: Prepare revision-pinned benchmark assets (CPU only)
+    environment: privileged
+    runs-on: ubuntu-24.04
+    timeout-minutes: 300
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Set up workspace
+        uses: ./.github/actions/setup-workspace
+
+      - name: Incrementally prepare the shared Modal Volume
+        env:
+          MODAL_TOKEN_ID: ${{ secrets.MODAL_TOKEN_ID }}
+          MODAL_TOKEN_SECRET: ${{ secrets.MODAL_TOKEN_SECRET }}
+        run: >-
+          bun apps/cli/src/bin/bench-gpu.ts
+          --prepare models
+          --cpu 8
+          --cpu-limit 8
+          --timeout-minutes 240
+
+  prepare-kernels:
+    name: Seed revision-pinned SM120 kernel snapshot
+    needs: prepare-assets
+    environment: privileged
+    runs-on: ubuntu-24.04
+    timeout-minutes: 120
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Set up workspace
+        uses: ./.github/actions/setup-workspace
+
+      - name: Seed immutable CUDA kernel snapshot when stale
+        env:
+          MODAL_TOKEN_ID: ${{ secrets.MODAL_TOKEN_ID }}
+          MODAL_TOKEN_SECRET: ${{ secrets.MODAL_TOKEN_SECRET }}
+        run: >-
+          bun apps/cli/src/bin/bench-gpu.ts
+          --prepare kernels
+          --gpu RTX-PRO-6000
+          --cpu 8
+          --cpu-limit 64
+          --memory-mib 98304
+          --memory-limit-mib 262144
+          --cuda-build-jobs 8
+          --nvcc-threads 4
+          --timeout-minutes 90
+          --output-dir benchmark-results/modal-vllm-kernel-seed
+
+      - name: Upload kernel seed diagnostics
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: modal-vllm-kernel-seed-${{ github.run_id }}-${{ github.run_attempt }}
+          path: benchmark-results/modal-vllm-kernel-seed/
+          if-no-files-found: ignore
+          retention-days: 7
+
+  benchmark:
+    name: >-
+      Modal RTX PRO 6000 / Qwen3 Coder SPEED-Bench / ${{ inputs.mode }} /
+      ${{ inputs.mode == 'full' && '20 replicates' || '1 replicate' }}
+    needs: prepare-kernels
+    environment: privileged
+    runs-on: ubuntu-24.04
+    # The job deadline is a final safety net; each measured warm-cache replicate must finish in five minutes.
+    timeout-minutes: 30
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Set up workspace
+        uses: ./.github/actions/setup-workspace
+
+      - name: Run vLLM GPU benchmark
+        env:
+          MODAL_TOKEN_ID: ${{ secrets.MODAL_TOKEN_ID }}
+          MODAL_TOKEN_SECRET: ${{ secrets.MODAL_TOKEN_SECRET }}
+          BENCHMARK_MODE: ${{ inputs.mode }}
+        run: |
+          # The confirmatory gates belong to the measured lane only. Qualification is a one-request
+          # wiring check: --require-precision would expand it to the full twenty-sandbox fleet and
+          # then judge a single 16-token request against a 0.5% confidence interval it cannot meet.
+          # Without the gate the CLI runs one replicate, which is the whole point of the mode.
+          gates=()
+          if [ "$BENCHMARK_MODE" = full ]; then
+            gates=(
+              --require-precision
+              --relative-ci-half-width 0.005
+              --require-duration
+              --max-replicate-duration-seconds 300
+            )
+          fi
+          bun apps/cli/src/bin/bench-gpu.ts \
+            --gpu RTX-PRO-6000 \
+            --mode "$BENCHMARK_MODE" \
+            --cpu 8 \
+            --cpu-limit 8 \
+            --memory-mib 98304 \
+            --memory-limit-mib 98304 \
+            --timeout-minutes 15 \
+            --client-timeout-minutes 5 \
+            --flashinfer-autotune disabled \
+            --output-dir benchmark-results/modal-vllm \
+            "${gates[@]}"
+
+      - name: Publish report in job summary
+        if: always()
+        run: |
+          report=benchmark-results/modal-vllm/report.md
+          if [ -f "$report" ]; then
+            # Artifact-relative SVG links do not resolve in a GitHub job summary. Keep the complete
+            # illustrated report in the artifact and publish its tables/narrative inline here.
+            sed '/^!\[/d' "$report" >> "$GITHUB_STEP_SUMMARY"
+          else
+            echo '## GPU benchmark report unavailable' >> "$GITHUB_STEP_SUMMARY"
+          fi
+
+      - name: Upload raw results and technical report
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: modal-vllm-${{ github.run_id }}-${{ github.run_attempt }}
+          path: benchmark-results/modal-vllm/
+          if-no-files-found: error
+          retention-days: 30

--- a/apps/cli/src/lib/gpu/report.test.ts
+++ b/apps/cli/src/lib/gpu/report.test.ts
@@ -1,0 +1,151 @@
+import { describe, expect, test } from "bun:test";
+import { parseGpuArgs } from "./args.ts";
+import { createGpuBenchmarkMetadata, renderGpuFleetReport } from "./report.ts";
+
+const xml = `<?xml version="1.0"?>
+<PhoronixTestSuite>
+  <Generated><TestClient>phoronix-test-suite/10.8.4</TestClient></Generated>
+  <Result>
+    <Identifier>local/vllm-speed-bench-1.0.0</Identifier><Title>vLLM SPEED-Bench Coding</Title>
+    <Description>Workload: Qwen3 Coder 30B-A3B FP8 SPEED-Bench Coding</Description><Scale>requests/s</Scale><Proportion>HIB</Proportion>
+    <Data><Entry><Value>5.5</Value><RawString>5.5</RawString></Entry></Data>
+  </Result>
+  <Result>
+    <Identifier>local/vllm-speed-bench-1.0.0</Identifier><Title>vLLM SPEED-Bench Coding</Title>
+    <Description>Workload: Qwen3 Coder 30B-A3B FP8 SPEED-Bench Coding</Description><Scale>output tokens/s</Scale><Proportion>HIB</Proportion>
+    <Data><Entry><Value>865</Value><RawString>865</RawString></Entry></Data>
+  </Result>
+  <Result>
+    <Identifier>local/vllm-speed-bench-1.0.0</Identifier><Title>vLLM SPEED-Bench Coding</Title>
+    <Description>Workload: Qwen3 Coder 30B-A3B FP8 SPEED-Bench Coding</Description><Scale>failed requests</Scale><Proportion>LIB</Proportion>
+    <Data><Entry><Value>0.000001</Value><RawString>0.000001</RawString></Entry></Data>
+  </Result>
+</PhoronixTestSuite>`;
+
+function metadata(index: number, durationSeconds = 240) {
+	return createGpuBenchmarkMetadata({
+		args: parseGpuArgs([]),
+		replicateIndex: index,
+		baseImageId: "im-base",
+		kernelSnapshotImageId: "im-kernel",
+		sandboxId: `sb-${index}`,
+		startedAt: new Date("2026-08-08T00:00:00.000Z"),
+		finishedAt: new Date(Date.parse("2026-08-08T00:00:00.000Z") + durationSeconds * 1000),
+		cudaGraphs: {
+			requestedMode: "FULL_AND_PIECEWISE",
+			runtimeModeObserved: true,
+			eagerDisabled: true,
+			captureCompleted: true,
+		},
+		observed: {
+			gpuName: "NVIDIA RTX PRO 6000",
+			gpuCount: 1,
+			driverVersion: "590.1",
+			gpuMemoryMiB: 97_887,
+			computeCapability: "12.0",
+			visibleCpus: 4,
+			memoryLimitMiB: 8192,
+			ptsVersion: "10.8.4",
+			pythonVersion: "3.13.14",
+			torchVersion: "2.11.0",
+			torchaudioVersion: undefined,
+			transformersVersion: "5.0.0",
+			tritonVersion: "3.6.0",
+			flashinferVersion: "0.6.4",
+			cutlassDslVersion: "4.4.0",
+			cudaVersion: "13.0",
+			nvccVersion: "release 13.3",
+			cudaAvailable: true,
+			cudaSmoke: "512",
+			vllmVersion: "0.26.0",
+		},
+	});
+}
+
+function replicates(count = 20, duration = 240) {
+	return Array.from({ length: count }, (_, index) => ({
+		index,
+		metadata: metadata(index, duration),
+		xml: xml
+			.replace("<Value>5.5</Value>", `<Value>${(5.5 + index / 10_000).toFixed(4)}</Value>`)
+			.replace("<Value>865</Value>", `<Value>${865 + index / 100}</Value>`),
+	}));
+}
+
+describe("renderGpuFleetReport", () => {
+	test("renders one technical fleet report with confidence charts", () => {
+		const report = renderGpuFleetReport({
+			replicates: replicates(),
+			failures: [],
+			requestedReplicates: 20,
+			precisionTarget: 0.005,
+		});
+		expect(report.summary.primaryPrecisionPassed).toBe(true);
+		expect(report.summary.durationPassed).toBe(true);
+		expect(report.markdown).toContain("Precision gate passed");
+		expect(report.markdown).toContain("Duration gate passed");
+		expect(report.markdown).toContain("one independently allocated Modal gVisor GPU sandbox");
+		expect(report.markdown).toContain("FULL_AND_PIECEWISE");
+		expect(report.markdown).toContain("im-kernel");
+		expect(report.assets.has("output-tokens-s-ci.svg")).toBe(true);
+		expect(report.summary.metrics.find(({ scale }) => scale === "failed requests")).toMatchObject({
+			median: 0.000001,
+			values: Array(20).fill(0.000001),
+		});
+	});
+
+	test("fails closed for incomplete fleets", () => {
+		const report = renderGpuFleetReport({
+			replicates: replicates(),
+			failures: [{ index: 20, outputDirectory: "replicates/r20", detail: "allocation failed" }],
+			requestedReplicates: 21,
+			precisionTarget: 0.005,
+		});
+		expect(report.summary.primaryPrecisionPassed).toBe(false);
+		expect(report.markdown).toContain("Precision gate did not pass");
+		expect(report.markdown).toContain("allocation failed");
+	});
+
+	test("reports duration independently from precision", () => {
+		const fleet = replicates();
+		const last = fleet.at(-1);
+		if (!last) throw new Error("fixture produced no replicates");
+		fleet[19] = { ...last, metadata: metadata(19, 301) };
+		const report = renderGpuFleetReport({
+			replicates: fleet,
+			failures: [],
+			requestedReplicates: 20,
+			precisionTarget: 0.005,
+			durationTargetSeconds: 300,
+		});
+		expect(report.summary.primaryPrecisionPassed).toBe(true);
+		expect(report.summary.durationPassed).toBe(false);
+		expect(report.summary.slowestDurationSeconds).toBe(301);
+	});
+
+	test("rejects mixed execution cohorts and incomplete CUDA-graph evidence", () => {
+		const mixed = replicates();
+		const mixedReplicate = mixed[1];
+		if (!mixedReplicate) throw new Error("fixture produced too few replicates");
+		mixedReplicate.metadata.memoryLimitMiB++;
+		expect(() =>
+			renderGpuFleetReport({
+				replicates: mixed,
+				failures: [],
+				requestedReplicates: 20,
+				precisionTarget: 0.005,
+			}),
+		).toThrow("replicate r1 does not match the fleet configuration");
+
+		const missingGraphs = replicates();
+		for (const replicate of missingGraphs) replicate.metadata.cudaGraphs.captureCompleted = false;
+		expect(() =>
+			renderGpuFleetReport({
+				replicates: missingGraphs,
+				failures: [],
+				requestedReplicates: 20,
+				precisionTarget: 0.005,
+			}),
+		).toThrow("replicate r0 has incomplete CUDA-graph evidence");
+	});
+});

--- a/docs/gpu-benchmark-methodology.md
+++ b/docs/gpu-benchmark-methodology.md
@@ -1,0 +1,78 @@
+# GPU inference benchmark methodology
+
+The GPU lane measures online coding-model inference in Modal gVisor sandboxes. It is intentionally
+separate from the CPU sandbox leaderboard because its hardware, cost, and metrics are different.
+
+## Fixed workload
+
+- PTS profile: `local/vllm-speed-bench-1.0.0`
+- Model: `Qwen/Qwen3-Coder-30B-A3B-Instruct-FP8` at a pinned Hugging Face revision
+- Dataset: NVIDIA SPEED-Bench `qualitative` / `coding`, prepared from a pinned source revision
+- Server: vLLM 0.26.0 on Python 3.13 and its resolved PyTorch CUDA 13 wheel stack
+- Image: digest-pinned `nvidia/cuda:13.3.1-devel-ubuntu24.04`
+- Sandbox: one RTX PRO 6000, 8 vCPU, 96 GiB RAM, gVisor runtime
+- Full client: 80 prompts, 1,024 output tokens, eight warmups, concurrency 16
+
+The server uses TP=1 and PP=1, avoiding unsupported multi-GPU P2P and shared-memory transports. It
+enables asynchronous scheduling, FP8 KV cache, safetensors prefetch, optimization level 2, and
+`FULL_AND_PIECEWISE` CUDA graphs. A run is rejected unless its server log proves that eager execution
+is disabled and graph capture completed.
+
+## Cached inputs
+
+Model weights and the prepared SPEED-Bench dataset live in a named Modal Volume. A CPU-only workflow
+job populates the Volume incrementally, writes a manifest containing every immutable source revision,
+and commits it before a GPU is allocated. Benchmark sandboxes mount it read-only with Hugging Face and
+Transformers offline modes enabled.
+
+Blackwell kernel preparation is a separate idempotent GPU job. It starts the exact production server,
+warms its compilation caches, verifies CUDA-graph capture, writes a configuration-keyed manifest, and
+snapshots the sandbox filesystem. The benchmark starts directly from that immutable Modal image, with
+an ephemeral writable overlay. A small registry Volume stores only the current snapshot ID and its
+manifest; a mismatch fails before allocating benchmark GPUs.
+
+Changing the model, dataset, local PTS profile, Python, vLLM, CUDA image, GPU selector, or serving
+configuration invalidates the snapshot. Report-only changes do not.
+
+## Replication and precision
+
+The confirmatory workflow launches 20 independent Modal sandboxes concurrently through the shared
+replicate pool. Each sandbox executes the fixed PTS workload once and writes to `replicates/rN/`.
+Requests and warmups inside a sandbox are not treated as independent machines.
+
+For each metric, the report computes the median of the 20 sandbox medians and a deterministic 95%
+cluster percentile interval using 10,000 whole-sandbox bootstrap resamples. Output-token throughput is
+the predeclared primary endpoint. Its precision gate requires all 20 allocations to complete and
+
+```text
+(upper - lower) / (2 * median) <= 0.005
+```
+
+The same interval is descriptive for request throughput, total-token throughput, TTFT, TPOT, and ITL.
+A confidence interval for one configuration is not a significance test against another configuration;
+comparisons require an independently replicated baseline and an interval or test of the difference.
+
+PTS dynamic convergence is not used as a substitute for independent sandbox replication. The workflow
+also has a separate lifecycle gate requiring every allocation to finish creation through artifact
+collection within 300 seconds.
+
+## Lifecycle and evidence
+
+The GPU command uses the harness's shared process-level sandbox owner, including its pending-create
+tracking and signal cleanup. Modal's adapter terminates with `wait: true` and verifies that the sandbox
+ID disappears from provider inventory. A replicate counts as complete only after that verification.
+
+The shared harness collector pulls the complete `benchmark-results/` tree with the same retry and
+content-validation path as other benchmark suites. Each replicate retains PTS XML and metadata, native
+vLLM JSON and argv, server/client logs, CUDA-graph evidence, pinned asset manifests, the resolved Python
+environment, observed hardware/software metadata, and its lifecycle record. The aggregate artifact
+contains the fleet summary, Markdown report, and SVG confidence-interval charts.
+
+## References
+
+- [Modal Sandbox filesystem snapshots](https://modal.com/docs/guide/sandbox-snapshots)
+- [Modal Volumes](https://modal.com/docs/guide/volumes)
+- [Modal GPU selection](https://modal.com/docs/guide/gpu)
+- [vLLM 0.26 serving benchmark CLI](https://docs.vllm.ai/en/v0.26.0/cli/bench/serve/)
+- [NVIDIA SPEED-Bench](https://huggingface.co/datasets/nvidia/SPEED-Bench)
+- [Qwen3 Coder 30B-A3B FP8](https://huggingface.co/Qwen/Qwen3-Coder-30B-A3B-Instruct-FP8)


### PR DESCRIPTION
## Summary

- add the manually dispatched Modal GPU benchmark workflow
- validate qualification and full-run inputs, resource limits, preparation state, and artifact retention
- scope the confirmatory gates to the measured lane: `full` runs the twenty-sandbox fleet under the precision and duration gates, `qualification` runs one sandbox with neither
- add report gate tests
- document the final methodology and reproducibility contract

## Why

Workflow policy and documentation land last, after the complete CLI can be tested without Actions-specific coupling.

## Validation

- full workspace test suite
- `bun run lint`
- `bun run typecheck`
- `bun run spell`
- `bun run check:catalog-drift`
- actionlint and ShellCheck
- both dispatch modes resolved through `parseGpuArgs`: `qualification` → 1 replicate, no gates; `full` → 20 replicates, both gates

The stack tip no longer matches the original monolithic tree byte-for-byte — it additionally carries the review fixes landed on #357, #367, and this PR.

## Stack

Depends on #365. This is the top of the GPU benchmark stack.
