### PR TITLE
fix(pts): preserve vLLM benchmark artifacts

### DIFF
--- a/packages/schema/src/pts-profiles/local/vllm-speed-bench-1.0.0/runner.sh
+++ b/packages/schema/src/pts-profiles/local/vllm-speed-bench-1.0.0/runner.sh
@@ -1,16 +1,29 @@
 #!/usr/bin/env bash
 # Own the online server/client pair so every PTS exit path also stops the GPU-serving process.
-set -u
+set -uo pipefail
 
 vllm_bin="${BENCH_VLLM_BIN:-/opt/vllm/bin/vllm}"
 dataset_dir="${SPEED_BENCH_DATASET_DIR:-/models/speed-bench}"
+native_results_dir="${BENCH_VLLM_NATIVE_RESULTS_DIR:-}"
 kernel_cache_dir="${BENCH_VLLM_KERNEL_CACHE_DIR:-}"
 ready_timeout_seconds="${BENCH_VLLM_READY_TIMEOUT_SECONDS:-2700}"
 client_timeout_seconds="${BENCH_VLLM_CLIENT_TIMEOUT_SECONDS:-600}"
+log_file="${LOG_FILE:?LOG_FILE is required}"
 status=1
 server_pid=""
 server_log=""
 readiness_watchdog_pid=""
+result=""
+
+if [ -n "$native_results_dir" ]; then
+	# Checked explicitly because this runner does not use errexit (see the client invocation, whose
+	# exit status is inspected). Every artifact below — argv, env, native JSON, both logs — is written
+	# under this directory, so continuing without it would run the benchmark and retain nothing.
+	if ! mkdir -p "$native_results_dir"; then
+		echo "ERROR: could not create the native results directory: ${native_results_dir}" >&2
+		exit 1
+	fi
+fi
 
 # shellcheck disable=SC2329 # Invoked directly and by the EXIT trap.
 stop_readiness_watchdog() {
@@ -44,12 +57,34 @@ stop_server() {
 	if [ -n "$server_pid" ]; then
 		wait "$server_pid" 2>/dev/null || true
 	fi
+	if [ -n "$native_results_dir" ] && [ -n "$server_log" ] && [ -f "$server_log" ]; then
+		cp "$server_log" "$native_results_dir/server.log" ||
+			echo "WARNING: could not update canonical server log" >&2
+	fi
 	echo "$status" >"${HOME}/test-exit-status"
 }
 # shellcheck disable=SC2329 # Invoked by the signal traps.
 on_signal() {
 	status="$1"
 	exit "$status"
+}
+
+snapshot_metrics() {
+	local phase="$1"
+	local output="${native_results_dir}/${result}.metrics.${phase}.prom"
+
+	[ -n "$native_results_dir" ] && [ -n "$result" ] || return 0
+	if ! curl --connect-timeout 2 --max-time 5 -fsS http://127.0.0.1:8000/metrics >"$output"; then
+		echo "WARNING: could not capture ${phase} vLLM metrics" >&2
+		rm -f "$output"
+	fi
+}
+
+write_argv() {
+	local output="$1"
+	shift
+	printf '%q ' "$@" >"$output"
+	printf '\n' >>"$output"
 }
 trap stop_server EXIT
 trap 'on_signal 129' HUP
@@ -153,7 +188,6 @@ if [ "$num_gpus" -ne 1 ]; then
 	exit 1
 fi
 
-server_log="${LOG_FILE:?LOG_FILE is required}.server"
 server_args=(
 	"$vllm_bin" serve "$model"
 	--revision "$revision"
@@ -188,6 +222,90 @@ case "${BENCH_VLLM_FLASHINFER_AUTOTUNE:-disabled}" in
 		exit 1
 		;;
 esac
+
+benchmark_args=(
+	"$vllm_bin" bench serve
+	--backend openai-chat
+	--endpoint /v1/chat/completions
+	--host 127.0.0.1
+	--port 8000
+	--ready-check-timeout-sec 60
+	--tokenizer "$model_path"
+	--dataset-path "$dataset_dir"
+	"${client_args[@]}"
+)
+native_args=()
+if [ -n "$native_results_dir" ]; then
+	# Build the recorded environment snapshots BEFORE the signature and hash the same bytes that get
+	# written, so a trial can never be filed under a configuration its own recorded evidence
+	# contradicts. Hashing only the argv left the inherited serving environment (NCCL/GLOO transport,
+	# host IP, cache roots) and the client's thread count out of the identity, so two trials that
+	# differed in any of them were grouped as repeats of one configuration. Both snapshots are emitted
+	# in a fixed order, so the digest is stable across runs.
+	server_env_snapshot="$(
+		printf 'GLOO_SOCKET_IFNAME=%q\n' "${GLOO_SOCKET_IFNAME:-}"
+		printf 'NCCL_P2P_DISABLE=%q\n' "${NCCL_P2P_DISABLE:-}"
+		printf 'NCCL_SHM_DISABLE=%q\n' "${NCCL_SHM_DISABLE:-}"
+		printf 'NCCL_SOCKET_IFNAME=%q\n' "${NCCL_SOCKET_IFNAME:-}"
+		printf 'VLLM_HOST_IP=%q\n' "${VLLM_HOST_IP:-}"
+		printf 'MAX_JOBS=%q\n' "${BENCH_VLLM_MAX_JOBS:-1}"
+		printf 'FLASHINFER_NVCC_THREADS=%q\n' "${BENCH_VLLM_NVCC_THREADS:-1}"
+		printf 'VLLM_MEMORY_PROFILER_ESTIMATE_CUDAGRAPHS=0\n'
+		printf 'BENCH_VLLM_FLASHINFER_AUTOTUNE=%q\n' \
+			"${BENCH_VLLM_FLASHINFER_AUTOTUNE:-disabled}"
+		printf 'HF_HUB_CACHE=%q\n' "${HF_HUB_CACHE:-}"
+		printf 'HF_HUB_OFFLINE=%q\n' "$HF_HUB_OFFLINE"
+		printf 'BENCH_VLLM_KERNEL_CACHE_DIR=%q\n' "$kernel_cache_dir"
+		if [ -n "$kernel_cache_dir" ]; then
+			printf 'HOME=%q\n' "${kernel_cache_dir}/home"
+			printf 'TRITON_CACHE_DIR=%q\n' "${kernel_cache_dir}/triton"
+			printf 'VLLM_CACHE_ROOT=%q\n' "${kernel_cache_dir}/vllm"
+			printf 'XDG_CACHE_HOME=%q\n' "${kernel_cache_dir}/xdg"
+		fi
+	)"
+	client_env_snapshot="$(
+		printf 'OMP_NUM_THREADS=%q\n' "${NUM_CPU_PHYSICAL_CORES:-1}"
+		printf 'HF_HUB_OFFLINE=%q\n' "$HF_HUB_OFFLINE"
+	)"
+	# Group trials by the complete serving and client configuration, not just client flags.
+	signature="$(
+		printf '%s\0' "$server_env_snapshot" "$client_env_snapshot" \
+			-- "${server_env[@]}" -- "${server_args[@]}" -- "${benchmark_args[@]}" |
+			sha256sum | cut -c1-16
+	)"
+	trial=1
+	while [ -e "${native_results_dir}/${signature}-${trial}.json" ] ||
+		[ -e "${native_results_dir}/${signature}-${trial}.server.log" ] ||
+		[ -e "${native_results_dir}/${signature}-${trial}.client.log" ]; do
+		trial=$((trial + 1))
+	done
+	result="${signature}-${trial}"
+	server_log="${native_results_dir}/${result}.server.log"
+	native_args=(
+		--save-result
+		--save-detailed
+		--result-dir "$native_results_dir"
+		--result-filename "${result}.json"
+		--metadata
+		"model_revision=${revision}"
+		"gpu_count=${num_gpus}"
+		"kv_cache_dtype=fp8"
+		"block_size=32"
+		"max_model_len=32768"
+		"max_num_seqs=16"
+		"kv_cache_memory_bytes=48G"
+	)
+
+	write_argv "${native_results_dir}/${result}.server.argv" "${server_args[@]}"
+	write_argv "${native_results_dir}/${result}.client.argv" \
+		"${benchmark_args[@]}" "${native_args[@]}"
+	printf '%s\n' "$server_env_snapshot" >"${native_results_dir}/${result}.server.env"
+	printf '%s\n' "$client_env_snapshot" >"${native_results_dir}/${result}.client.env"
+	"$vllm_bin" --version >"${native_results_dir}/${result}.vllm.version.txt" 2>&1 || true
+else
+	server_log="${log_file}.server"
+fi
+
 # Isolate the complete vLLM process tree so every exit path can signal the API server, engine,
 # workers, and compiler children together instead of leaving orphaned GPU processes behind.
 setsid "${server_env[@]}" "${server_args[@]}" >"$server_log" 2>&1 &
@@ -249,30 +367,27 @@ case "${BENCH_VLLM_PREPARE_KERNELS_ONLY:-0}" in
 		;;
 esac
 
-benchmark_args=(
-	"$vllm_bin" bench serve
-	--backend openai-chat
-	--endpoint /v1/chat/completions
-	--host 127.0.0.1
-	--port 8000
-	--ready-check-timeout-sec 60
-	--tokenizer "$model_path"
-	--dataset-path "$dataset_dir"
-	"${client_args[@]}"
-)
-set +e
-OMP_NUM_THREADS="${NUM_CPU_PHYSICAL_CORES:-1}" timeout --foreground --signal=TERM --kill-after=30s \
-	"${client_timeout_seconds}s" "${benchmark_args[@]}" >"$LOG_FILE" 2>&1
-status=$?
-set -e
+snapshot_metrics before
+if OMP_NUM_THREADS="${NUM_CPU_PHYSICAL_CORES:-1}" \
+	timeout --foreground --signal=TERM --kill-after=30s "${client_timeout_seconds}s" \
+	"${benchmark_args[@]}" "${native_args[@]}" >"$log_file" 2>&1; then
+	status=0
+else
+	status=$?
+fi
+snapshot_metrics after
 if [ "$status" -eq 124 ]; then
-	echo "ERROR: vLLM benchmark client exceeded ${client_timeout_seconds}s" >>"$LOG_FILE"
+	echo "ERROR: vLLM benchmark client exceeded ${client_timeout_seconds}s" >>"$log_file"
 fi
 if [ "$status" -ne 0 ]; then
 	{
 		echo
 		echo "=== vLLM server tail ==="
 		tail -n 200 "$server_log" || true
-	} >>"$LOG_FILE"
+	} >>"$log_file"
+fi
+if [ -n "$native_results_dir" ] && [ -n "$result" ] && [ -f "$log_file" ]; then
+	cp "$log_file" "${native_results_dir}/${result}.client.log" ||
+		echo "WARNING: could not preserve vLLM client log" >&2
 fi
 exit "$status"


### PR DESCRIPTION
## Summary

- capture each vLLM trial's detailed JSON, client/server logs, exact argv, serving environment, and vLLM version
- snapshot the server's Prometheus endpoint before and after the timed client
- group trials by the effective server environment, server flags, and client flags
- preserve the canonical `vllm-native/server.log` consumed by lifecycle and CUDA-graph validation

## Why

The PTS log alone discarded server-side telemetry and made trials with different serving configurations look equivalent. This layer preserves lossless native evidence without changing the benchmark workload.

## Validation

- `bash -n`
- ShellCheck
- full workspace test suite

## Stack

Depends on #357. Next: #368.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Preserves full native artifacts for `vllm` PTS runs: detailed JSON, metadata, argv/env snapshots, `vllm --version`, Prometheus metrics, and client/server logs. Trials now key off the recorded env + args to avoid conflating different configs.

- New Features
  - Save detailed JSON + metadata to a native results dir; unique trial IDs from a short SHA-256 over env + args.
  - Persist server and client logs; maintain canonical `vllm-native/server.log`.
  - Record quoted server/client argv and env snapshots; store `vllm --version`.
  - Snapshot Prometheus `/metrics` before/after with short timeouts; harden runner (`set -o pipefail`, fail if results dir can’t be created, clearer timeouts, server tail on failure).

<sup>Written for commit 107d8a0f71db9c6c8c09afd670abfd1be2b8d641. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/starslingdev/hpc-sandbox-benchmarks/pull/367?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

