### PR TITLE
feat(pts): expose vLLM serving metrics

### DIFF
--- a/packages/schema/src/pts-profiles/local/vllm-speed-bench-1.0.0/results-definition.xml
+++ b/packages/schema/src/pts-profiles/local/vllm-speed-bench-1.0.0/results-definition.xml
@@ -1,33 +1,153 @@
 <?xml version="1.0"?>
 <PhoronixTestSuite>
   <ResultsParser>
-    <OutputTemplate>Request throughput (req/s): #_RESULT_#</OutputTemplate>
-    <ResultScale>requests/s</ResultScale>
-    <ResultProportion>HIB</ResultProportion>
-  </ResultsParser>
-  <ResultsParser>
-    <OutputTemplate>Output token throughput (tok/s): #_RESULT_#</OutputTemplate>
+    <OutputTemplate>PTS Output token throughput (tok/s): #_RESULT_#</OutputTemplate>
     <ResultScale>output tokens/s</ResultScale>
     <ResultProportion>HIB</ResultProportion>
   </ResultsParser>
   <ResultsParser>
-    <OutputTemplate>Total token throughput (tok/s): #_RESULT_#</OutputTemplate>
+    <OutputTemplate>PTS Total token throughput (tok/s): #_RESULT_#</OutputTemplate>
     <ResultScale>total tokens/s</ResultScale>
     <ResultProportion>HIB</ResultProportion>
   </ResultsParser>
   <ResultsParser>
-    <OutputTemplate>Median TTFT (ms): #_RESULT_#</OutputTemplate>
+    <OutputTemplate>PTS Request throughput (req/s): #_RESULT_#</OutputTemplate>
+    <ResultScale>requests/s</ResultScale>
+    <ResultProportion>HIB</ResultProportion>
+  </ResultsParser>
+  <ResultsParser>
+    <OutputTemplate>PTS Peak output token throughput (tok/s): #_RESULT_#</OutputTemplate>
+    <ResultScale>peak output tokens/s</ResultScale>
+    <ResultProportion>HIB</ResultProportion>
+  </ResultsParser>
+  <ResultsParser>
+    <OutputTemplate>PTS Peak concurrent requests: #_RESULT_#</OutputTemplate>
+    <ResultScale>peak concurrent requests</ResultScale>
+    <ResultProportion>HIB</ResultProportion>
+  </ResultsParser>
+  <ResultsParser>
+    <OutputTemplate>PTS Benchmark duration (s): #_RESULT_#</OutputTemplate>
+    <ResultScale>benchmark seconds</ResultScale>
+    <ResultProportion>LIB</ResultProportion>
+  </ResultsParser>
+  <ResultsParser>
+    <OutputTemplate>PTS Successful requests: #_RESULT_#</OutputTemplate>
+    <ResultScale>successful requests</ResultScale>
+    <ResultProportion>HIB</ResultProportion>
+  </ResultsParser>
+  <ResultsParser>
+    <OutputTemplate>PTS Failed requests: #_RESULT_#</OutputTemplate>
+    <ResultScale>failed requests</ResultScale>
+    <ResultProportion>LIB</ResultProportion>
+  </ResultsParser>
+  <ResultsParser>
+    <OutputTemplate>PTS Total input tokens: #_RESULT_#</OutputTemplate>
+    <ResultScale>input tokens</ResultScale>
+    <ResultProportion>HIB</ResultProportion>
+  </ResultsParser>
+  <ResultsParser>
+    <OutputTemplate>PTS Total generated tokens: #_RESULT_#</OutputTemplate>
+    <ResultScale>generated tokens</ResultScale>
+    <ResultProportion>HIB</ResultProportion>
+  </ResultsParser>
+  <ResultsParser>
+    <OutputTemplate>PTS Mean TTFT (ms): #_RESULT_#</OutputTemplate>
+    <ResultScale>mean TTFT - ms</ResultScale>
+    <ResultProportion>LIB</ResultProportion>
+  </ResultsParser>
+  <ResultsParser>
+    <OutputTemplate>PTS Median TTFT (ms): #_RESULT_#</OutputTemplate>
     <ResultScale>median TTFT - ms</ResultScale>
     <ResultProportion>LIB</ResultProportion>
   </ResultsParser>
   <ResultsParser>
-    <OutputTemplate>Median TPOT (ms): #_RESULT_#</OutputTemplate>
+    <OutputTemplate>PTS P90 TTFT (ms): #_RESULT_#</OutputTemplate>
+    <ResultScale>p90 TTFT - ms</ResultScale>
+    <ResultProportion>LIB</ResultProportion>
+  </ResultsParser>
+  <ResultsParser>
+    <OutputTemplate>PTS P95 TTFT (ms): #_RESULT_#</OutputTemplate>
+    <ResultScale>p95 TTFT - ms</ResultScale>
+    <ResultProportion>LIB</ResultProportion>
+  </ResultsParser>
+  <ResultsParser>
+    <OutputTemplate>PTS P99 TTFT (ms): #_RESULT_#</OutputTemplate>
+    <ResultScale>p99 TTFT - ms</ResultScale>
+    <ResultProportion>LIB</ResultProportion>
+  </ResultsParser>
+  <ResultsParser>
+    <OutputTemplate>PTS Mean TPOT (ms): #_RESULT_#</OutputTemplate>
+    <ResultScale>mean TPOT - ms</ResultScale>
+    <ResultProportion>LIB</ResultProportion>
+  </ResultsParser>
+  <ResultsParser>
+    <OutputTemplate>PTS Median TPOT (ms): #_RESULT_#</OutputTemplate>
     <ResultScale>median TPOT - ms</ResultScale>
     <ResultProportion>LIB</ResultProportion>
   </ResultsParser>
   <ResultsParser>
-    <OutputTemplate>Median ITL (ms): #_RESULT_#</OutputTemplate>
+    <OutputTemplate>PTS P90 TPOT (ms): #_RESULT_#</OutputTemplate>
+    <ResultScale>p90 TPOT - ms</ResultScale>
+    <ResultProportion>LIB</ResultProportion>
+  </ResultsParser>
+  <ResultsParser>
+    <OutputTemplate>PTS P95 TPOT (ms): #_RESULT_#</OutputTemplate>
+    <ResultScale>p95 TPOT - ms</ResultScale>
+    <ResultProportion>LIB</ResultProportion>
+  </ResultsParser>
+  <ResultsParser>
+    <OutputTemplate>PTS P99 TPOT (ms): #_RESULT_#</OutputTemplate>
+    <ResultScale>p99 TPOT - ms</ResultScale>
+    <ResultProportion>LIB</ResultProportion>
+  </ResultsParser>
+  <ResultsParser>
+    <OutputTemplate>PTS Mean ITL (ms): #_RESULT_#</OutputTemplate>
+    <ResultScale>mean ITL - ms</ResultScale>
+    <ResultProportion>LIB</ResultProportion>
+  </ResultsParser>
+  <ResultsParser>
+    <OutputTemplate>PTS Median ITL (ms): #_RESULT_#</OutputTemplate>
     <ResultScale>median ITL - ms</ResultScale>
+    <ResultProportion>LIB</ResultProportion>
+  </ResultsParser>
+  <ResultsParser>
+    <OutputTemplate>PTS P90 ITL (ms): #_RESULT_#</OutputTemplate>
+    <ResultScale>p90 ITL - ms</ResultScale>
+    <ResultProportion>LIB</ResultProportion>
+  </ResultsParser>
+  <ResultsParser>
+    <OutputTemplate>PTS P95 ITL (ms): #_RESULT_#</OutputTemplate>
+    <ResultScale>p95 ITL - ms</ResultScale>
+    <ResultProportion>LIB</ResultProportion>
+  </ResultsParser>
+  <ResultsParser>
+    <OutputTemplate>PTS P99 ITL (ms): #_RESULT_#</OutputTemplate>
+    <ResultScale>p99 ITL - ms</ResultScale>
+    <ResultProportion>LIB</ResultProportion>
+  </ResultsParser>
+  <ResultsParser>
+    <OutputTemplate>PTS Mean E2EL (ms): #_RESULT_#</OutputTemplate>
+    <ResultScale>mean E2EL - ms</ResultScale>
+    <ResultProportion>LIB</ResultProportion>
+  </ResultsParser>
+  <ResultsParser>
+    <OutputTemplate>PTS Median E2EL (ms): #_RESULT_#</OutputTemplate>
+    <ResultScale>median E2EL - ms</ResultScale>
+    <ResultProportion>LIB</ResultProportion>
+  </ResultsParser>
+  <ResultsParser>
+    <OutputTemplate>PTS P90 E2EL (ms): #_RESULT_#</OutputTemplate>
+    <ResultScale>p90 E2EL - ms</ResultScale>
+    <ResultProportion>LIB</ResultProportion>
+  </ResultsParser>
+  <ResultsParser>
+    <OutputTemplate>PTS P95 E2EL (ms): #_RESULT_#</OutputTemplate>
+    <ResultScale>p95 E2EL - ms</ResultScale>
+    <ResultProportion>LIB</ResultProportion>
+  </ResultsParser>
+  <ResultsParser>
+    <OutputTemplate>PTS P99 E2EL (ms): #_RESULT_#</OutputTemplate>
+    <ResultScale>p99 E2EL - ms</ResultScale>
     <ResultProportion>LIB</ResultProportion>
   </ResultsParser>
 </PhoronixTestSuite>

--- a/packages/schema/src/pts-profiles/local/vllm-speed-bench-1.0.0/runner.sh
+++ b/packages/schema/src/pts-profiles/local/vllm-speed-bench-1.0.0/runner.sh
@@ -86,6 +86,44 @@ write_argv() {
 	printf '%q ' "$@" >"$output"
 	printf '\n' >>"$output"
 }
+
+emit_pts_results() {
+	local summary="${log_file}.pts.$$"
+	# PTS 10.8.4 drops zero-valued results and later parser results with the same numeric value.
+	# Failed-request counts commonly equal zero, while qualification latency statistics necessarily
+	# collide. Nudge only those PTS display values below vLLM's 0.01 reporting precision; native JSON
+	# remains exact and lossless.
+	if ! awk '
+		/^(Successful requests:|Failed requests:|Benchmark duration \(s\):|Total input tokens:|Total generated tokens:|Request throughput \(req\/s\):|Output token throughput \(tok\/s\):|Peak output token throughput \(tok\/s\):|Peak concurrent requests:|Total token throughput \(tok\/s\):|(Mean|Median|P90|P95|P99) (TTFT|TPOT|ITL|E2EL) \(ms\):)/ {
+			label = $0
+			value = $0
+			sub(/^.*:[[:space:]]*/, "", value)
+			sub(/[[:space:]].*$/, "", value)
+			sub(/[[:space:]]+[-+0-9.eE]+[[:space:]]*$/, "", label)
+			if (value !~ /^[-+]?([0-9]+([.][0-9]*)?|[.][0-9]+)([eE][-+]?[0-9]+)?$/) exit 2
+			value += 0
+			if (value < 0) exit 2
+			if (value == 0) value = 0.000001
+			key = sprintf("%.6f", value)
+			while (key in seen) {
+				value += 0.000001
+				key = sprintf("%.6f", value)
+			}
+			seen[key] = 1
+			printf "PTS %s %.6f\n", label, value
+			count++
+		}
+		END { if (count != 30) exit 1 }
+	' "$log_file" >"$summary"; then
+		rm -f "$summary"
+		return 1
+	fi
+	printf '\n' >>"$log_file"
+	cat "$summary" >>"$log_file"
+	local cat_status=$?
+	rm -f "$summary"
+	return "$cat_status"
+}
 trap stop_server EXIT
 trap 'on_signal 129' HUP
 trap 'on_signal 130' INT
@@ -376,6 +414,10 @@ else
 	status=$?
 fi
 snapshot_metrics after
+if [ "$status" -eq 0 ] && ! emit_pts_results; then
+	echo "ERROR: vLLM did not emit the complete 30-metric PTS summary" >>"$log_file"
+	status=1
+fi
 if [ "$status" -eq 124 ]; then
 	echo "ERROR: vLLM benchmark client exceeded ${client_timeout_seconds}s" >>"$log_file"
 fi

--- a/packages/schema/src/pts-profiles/local/vllm-speed-bench-1.0.0/test-definition.xml
+++ b/packages/schema/src/pts-profiles/local/vllm-speed-bench-1.0.0/test-definition.xml
@@ -34,7 +34,7 @@
       <Menu>
         <Entry>
           <Name>Qwen3 Coder 30B-A3B FP8 SPEED-Bench Coding</Name>
-          <Value>speed-bench --model Qwen/Qwen3-Coder-30B-A3B-Instruct-FP8 --revision dcaee4d4dfc5ee71ad501f01f530e5652438fde0 --dataset-name speed_bench --speed-bench-dataset-subset qualitative --speed-bench-category coding --temperature 0.7 --top-p 0.8 --seed 0 --percentile-metrics ttft,tpot,itl --metric-percentiles 50,90,99 --trust-remote-code</Value>
+          <Value>speed-bench --model Qwen/Qwen3-Coder-30B-A3B-Instruct-FP8 --revision dcaee4d4dfc5ee71ad501f01f530e5652438fde0 --dataset-name speed_bench --speed-bench-dataset-subset qualitative --speed-bench-category coding --temperature 0.7 --top-p 0.8 --seed 0 --percentile-metrics ttft,tpot,itl,e2el --metric-percentiles 90,95,99 --trust-remote-code</Value>
         </Entry>
       </Menu>
     </Option>

--- a/packages/schema/src/vllm-pts-profile.test.ts
+++ b/packages/schema/src/vllm-pts-profile.test.ts
@@ -1,0 +1,115 @@
+import { describe, expect, test } from "bun:test";
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { parseProfile } from "../scripts/catalog/parse.ts";
+
+const profileDir = join(import.meta.dir, "pts-profiles/local/vllm-speed-bench-1.0.0");
+const testXml = readFileSync(join(profileDir, "test-definition.xml"), "utf8");
+const resultsXml = readFileSync(join(profileDir, "results-definition.xml"), "utf8");
+const runner = readFileSync(join(profileDir, "runner.sh"), "utf8");
+const baseLabels = [
+	"Successful requests:",
+	"Failed requests:",
+	"Benchmark duration (s):",
+	"Total input tokens:",
+	"Total generated tokens:",
+	"Request throughput (req/s):",
+	"Output token throughput (tok/s):",
+	"Peak output token throughput (tok/s):",
+	"Peak concurrent requests:",
+	"Total token throughput (tok/s):",
+];
+const latencyLabels = ["TTFT", "TPOT", "ITL", "E2EL"].flatMap((metric) =>
+	["Mean", "Median", "P90", "P95", "P99"].map((statistic) => `${statistic} ${metric} (ms):`),
+);
+
+function emitPtsResults(log: string) {
+	const emitFunction = runner.match(
+		/emit_pts_results\(\) \{[\s\S]*?\n\}\n(?=trap stop_server)/,
+	)?.[0];
+	if (!emitFunction) throw new Error("emit_pts_results function not found");
+	return Bun.spawnSync(["bash", "-c", `log_file="$LOG_FILE"\n${emitFunction}\nemit_pts_results`], {
+		env: { ...Bun.env, LOG_FILE: log },
+	});
+}
+
+describe("vLLM PTS profile", () => {
+	test("requests the complete serving distribution and declares 30 scalar results", () => {
+		const profile = parseProfile("local", "vllm-speed-bench-1.0.0", testXml, resultsXml);
+		const workload = profile.settings.find((option) => option.Identifier === "workload");
+		expect(workload?.Menu?.Entry[0]?.Value).toContain(
+			"--percentile-metrics ttft,tpot,itl,e2el --metric-percentiles 90,95,99",
+		);
+		expect(profile.parsers).toHaveLength(30);
+		expect(new Set(profile.parsers.map((parser) => parser.ResultScale)).size).toBe(30);
+	});
+
+	test("leads with the predeclared primary endpoint, not a validation counter", () => {
+		// Result order is the composite's order, which is the order the fleet report tabulates and
+		// charts. Output-token throughput is the predeclared primary endpoint and the test's declared
+		// tokens/s scale, so it has to come first; the request/token counters are validation evidence
+		// and belong after the throughput and latency measurements they qualify.
+		const { parsers } = parseProfile("local", "vllm-speed-bench-1.0.0", testXml, resultsXml);
+		expect(parsers[0]?.ResultScale).toBe("output tokens/s");
+		const scaleOrder = parsers.map((parser) => parser.ResultScale);
+		for (const counter of ["successful requests", "failed requests", "input tokens"]) {
+			expect(scaleOrder.indexOf(counter)).toBeGreaterThan(scaleOrder.indexOf("output tokens/s"));
+		}
+	});
+
+	test("keeps every PTS result when vLLM reports zero or duplicate numeric values", () => {
+		const directory = mkdtempSync(join(tmpdir(), "vllm-pts-profile-"));
+		const log = join(directory, "client.log");
+		writeFileSync(
+			log,
+			[...baseLabels, ...latencyLabels]
+				.map((label) => `${label} ${label === "Failed requests:" ? "0" : "1.00"}`)
+				.join("\n"),
+		);
+
+		try {
+			const process = emitPtsResults(log);
+			expect(process.exitCode).toBe(0);
+
+			const ptsLines = readFileSync(log, "utf8")
+				.split("\n")
+				.filter((line) => line.startsWith("PTS "));
+			expect(ptsLines).toHaveLength(30);
+			expect(new Set(ptsLines.map((line) => line.split(" ").at(-1))).size).toBe(30);
+			expect(ptsLines.find((line) => line.startsWith("PTS Failed requests:"))).toBe(
+				"PTS Failed requests: 0.000001",
+			);
+			const emittedLabels = new Set(ptsLines.map((line) => line.replace(/ [-+0-9.eE]+$/, "")));
+			const parsedLabels = new Set(
+				parseProfile("local", "vllm-speed-bench-1.0.0", testXml, resultsXml).parsers.map(
+					(parser) => {
+						if (!parser.OutputTemplate) throw new Error("result parser has no output template");
+						return parser.OutputTemplate.replace(" #_RESULT_#", "");
+					},
+				),
+			);
+			expect(emittedLabels).toEqual(parsedLabels);
+		} finally {
+			rmSync(directory, { recursive: true, force: true });
+		}
+	});
+
+	test("rejects nonnumeric native metrics instead of coercing them to zero", () => {
+		const directory = mkdtempSync(join(tmpdir(), "vllm-pts-profile-"));
+		const log = join(directory, "client.log");
+		writeFileSync(
+			log,
+			[...baseLabels, ...latencyLabels]
+				.map((label) => `${label} ${label === "Mean TTFT (ms):" ? "nan" : "1.00"}`)
+				.join("\n"),
+		);
+
+		try {
+			expect(emitPtsResults(log).exitCode).not.toBe(0);
+			expect(readFileSync(log, "utf8")).not.toContain("PTS ");
+		} finally {
+			rmSync(directory, { recursive: true, force: true });
+		}
+	});
+});


### PR DESCRIPTION
## Summary

- expose 30 vLLM serving scalars through PTS: request counts, duration, throughput/peak throughput, concurrency, and TTFT/TPOT/ITL/E2EL distributions
- request mean/median plus p90, p95, and p99 latency data from vLLM 0.26
- protect every metric from PTS 10.8.4's cross-parser duplicate-value suppression while leaving native JSON exact
- add an offline regression test that forces all 30 raw values to collide and proves all 30 PTS results survive

## Why

vLLM emitted substantially more scientifically useful data than the six values the profile exposed. Qualification runs also guarantee equal mean/median/percentile values, which PTS otherwise silently drops.

## Validation

- executable 30-metric collision regression
- XML validation
- `bash -n` and ShellCheck
- full workspace test suite
- typecheck, lint, catalog drift, spelling

## Stack

Depends on #367. Next: #358.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Expose 30 `vLLM` serving metrics through `PTS`: counts, duration, throughput/peak throughput, peak concurrency, and TTFT/TPOT/ITL/E2EL latency stats (mean/median/p90/p95/p99). Adds a strict, resilient emitter that preserves zeros/duplicates, rejects nonnumeric/negative values, switches to `vLLM` 0.26 percentiles, and orders results by output-token throughput so fleet reports show the primary endpoint first.

- **New Features**
  - Added 30 result parsers with stable “PTS …” labels; output-token throughput comes first.
  - Updated runner to emit all metrics by nudging zeros/duplicates below `vLLM` 0.01 precision and hard-failing if the 30-metric summary is incomplete; native JSON stays exact.
  - Updated profile flags to request `ttft,tpot,itl,e2el` with `90,95,99` percentiles.
  - Added tests confirming 30 metrics are declared and unique, the primary result leads, collision cases retain all results, and invalid values are rejected.

<sup>Written for commit fa0dccd1a7d1ec8e95b90c49a4b726f9f05e74c7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/starslingdev/hpc-sandbox-benchmarks/pull/368?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

