### PR TITLE
feat(bench): add vLLM PTS task

### DIFF
--- a/.mise/tasks/benchmark/gpu/pts/vllm
+++ b/.mise/tasks/benchmark/gpu/pts/vllm
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+#MISE description="PTS: Qwen3 Coder SPEED-Bench Coding with vLLM 0.26"
+# PTS owns scheduling/headline parsing; vLLM owns the online server/client and detailed JSON.
+set -euo pipefail
+REPO_ROOT="$(git -C "$(dirname "${BASH_SOURCE[0]}")" rev-parse --show-toplevel)"
+# shellcheck source=/dev/null
+source "${REPO_ROOT}/lib/bench.sh"
+
+profile="vllm-speed-bench-1.0.0"
+prefix="pts_vllm"
+
+gpu_names=""
+if have nvidia-smi; then
+	gpu_names="$(nvidia-smi --query-gpu=name --format=csv,noheader 2>/dev/null || true)"
+fi
+if [ -z "$gpu_names" ]; then
+	skip_result "NVIDIA GPU not available" "$prefix"
+	exit 0
+fi
+if ! have phoronix-test-suite; then
+	skip_result "phoronix-test-suite not installed" "$prefix"
+	exit 0
+fi
+
+install_local_pts_profile "$profile"
+
+mode="${BENCH_VLLM_MODE:-qualification}"
+case "$mode" in
+	qualification)
+		run_mode="Qualification (1 prompt x 16 output tokens)"
+		;;
+	full)
+		run_mode="Full (80 prompts x 1024 output tokens)"
+		;;
+	*)
+		echo "ERROR: BENCH_VLLM_MODE must be qualification or full" >&2
+		fail_result "invalid BENCH_VLLM_MODE: ${mode}" "$prefix"
+		exit 1
+		;;
+esac
+
+echo "vLLM benchmark mode: ${mode} (${run_mode})"
+run_pinned_pts "local/${profile}" "$prefix" \
+	"vllm-speed-bench.workload=Qwen3 Coder 30B-A3B FP8 SPEED-Bench Coding;vllm-speed-bench.run-mode=${run_mode}"
+assert_pts_numeric_values "$prefix" 30


### PR DESCRIPTION
## Summary

- add the executable mise leaf for the vLLM SPEED-Bench PTS profile
- select qualification or full workload without rewriting profile arguments
- skip honestly when PTS or an NVIDIA GPU is unavailable
- require all 30 numeric PTS results before the task can pass

## Why

The reusable PTS execution contract belongs in its own layer, separate from TypeScript GPU resource and CLI configuration.

## Validation

- `bash -n`
- ShellCheck
- executable-mode repository gate
- full workspace test suite

## Stack

Depends on #358. Next: #359.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a `.mise` task to run vLLM 0.26 SPEED-Bench (PTS) for Qwen3 Coder 30B-A3B FP8. Supports `qualification` (default) and `full` modes with strict result checks.

- **New Features**
  - New task at `.mise/tasks/benchmark/gpu/pts/vllm` running `local/vllm-speed-bench-1.0.0`.
  - Select mode via `BENCH_VLLM_MODE=qualification|full`; invalid values fail.
  - Skips when `nvidia-smi` or `phoronix-test-suite` is missing.
  - Requires 30 numeric results to pass.

<sup>Written for commit bd540e7abf2fbe18977e8aebccfcddabfeabf128. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/starslingdev/hpc-sandbox-benchmarks/pull/369?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

