### PR TITLE
fix(pts): nudge zero results above PTS's zero-drop threshold

### DIFF
--- a/packages/schema/src/pts-profiles/local/vllm-speed-bench-1.0.0/runner.sh
+++ b/packages/schema/src/pts-profiles/local/vllm-speed-bench-1.0.0/runner.sh
@@ -93,6 +93,15 @@ emit_pts_results() {
 	# Failed-request counts commonly equal zero, while qualification latency statistics necessarily
 	# collide. Nudge only those PTS display values below vLLM's 0.01 reporting precision; native JSON
 	# remains exact and lossless.
+	#
+	# The two drops have DIFFERENT thresholds, so they take different epsilons:
+	#   * Duplicates are compared at full parsed precision, so 0.000001 separates them. Verified in a
+	#     live run: 24.080001/24.080002/... were each stored and kept.
+	#   * The zero check runs on the value formatted to four decimals, so 0.000001 still reads as
+	#     0.0000 and the result is discarded ("This test failed to run properly"), which cost the
+	#     first live qualification run its Failed-requests value and failed the 30-metric gate.
+	#     0.001 clears that formatting with margin and stays an order of magnitude below vLLM's 0.01
+	#     reporting precision, so it can never be mistaken for a measured count.
 	if ! awk '
 		/^(Successful requests:|Failed requests:|Benchmark duration \(s\):|Total input tokens:|Total generated tokens:|Request throughput \(req\/s\):|Output token throughput \(tok\/s\):|Peak output token throughput \(tok\/s\):|Peak concurrent requests:|Total token throughput \(tok\/s\):|(Mean|Median|P90|P95|P99) (TTFT|TPOT|ITL|E2EL) \(ms\):)/ {
 			label = $0
@@ -103,7 +112,7 @@ emit_pts_results() {
 			if (value !~ /^[-+]?([0-9]+([.][0-9]*)?|[.][0-9]+)([eE][-+]?[0-9]+)?$/) exit 2
 			value += 0
 			if (value < 0) exit 2
-			if (value == 0) value = 0.000001
+			if (value == 0) value = 0.001
 			key = sprintf("%.6f", value)
 			while (key in seen) {
 				value += 0.000001

--- a/packages/schema/src/vllm-pts-profile.test.ts
+++ b/packages/schema/src/vllm-pts-profile.test.ts
@@ -78,8 +78,19 @@ describe("vLLM PTS profile", () => {
 			expect(ptsLines).toHaveLength(30);
 			expect(new Set(ptsLines.map((line) => line.split(" ").at(-1))).size).toBe(30);
 			expect(ptsLines.find((line) => line.startsWith("PTS Failed requests:"))).toBe(
-				"PTS Failed requests: 0.000001",
+				"PTS Failed requests: 0.001000",
 			);
+			// The value alone is not the contract: PTS applies its zero check to the value formatted to
+			// four decimals, so anything that renders as 0.0000 there is discarded as "failed to run
+			// properly" no matter how the runner printed it. A live qualification run lost its
+			// Failed-requests value to exactly that. Assert what PTS actually sees.
+			for (const line of ptsLines) {
+				const value = Number(line.split(" ").at(-1));
+				expect(Number(value.toFixed(4))).toBeGreaterThan(0);
+			}
+			// Duplicates are compared at full precision, so the 1e-6 separation is still what keeps the
+			// necessarily-colliding qualification percentiles apart.
+			expect(new Set(ptsLines.map((line) => Number(line.split(" ").at(-1)))).size).toBe(30);
 			const emittedLabels = new Set(ptsLines.map((line) => line.replace(/ [-+0-9.eE]+$/, "")));
 			const parsedLabels = new Set(
 				parseProfile("local", "vllm-speed-bench-1.0.0", testXml, resultsXml).parsers.map(


### PR DESCRIPTION
PTS applies two different drops with two different precisions. Duplicates are compared at
full parsed precision, so the 1e-6 separation works — a live run stored and kept
24.080001/24.080002/... But the zero check runs on the value formatted to four decimals,
where 0.000001 still reads as 0.0000, so PTS discarded the result as "failed to run
properly". The first live qualification run therefore emitted all 30 PTS lines but landed
29 numeric values, and assert_pts_numeric_values failed the leaf.

Raise only the zero replacement to 0.001 — clear of that formatting, still an order of
magnitude below vLLM's 0.01 reporting precision. The duplicate epsilon is unchanged.

The profile test asserted the emitted text, which passed while PTS dropped the value, so it
now also asserts what PTS actually sees: every value must survive four-decimal formatting.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix PTS zero-value handling by nudging zeros to 0.001 so results aren’t dropped by the four-decimal zero check. Duplicate separation stays the same, and tests verify all 30 metrics survive.

- **Bug Fixes**
  - In `runner.sh`, replace zero values with 0.001 (was 0.000001) to clear four-decimal formatting while staying below `vLLM`’s 0.01 reporting precision.
  - Keep duplicate de-dupe epsilon at 0.000001 to maintain distinct percentile metrics.
  - Update `vllm-pts-profile.test.ts` to expect "PTS Failed requests: 0.001000", assert all values remain > 0 after toFixed(4), and confirm 30 unique numeric values.

<sup>Written for commit 7707296e3f901fc19c76a12b1bbb8c5be879538c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/starslingdev/hpc-sandbox-benchmarks/pull/370?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

