### PR TITLE
fix(gpu): raise the replicate duration ceiling to 600 seconds

### DIFF
--- a/.github/workflows/bench-gpu.yml
+++ b/.github/workflows/bench-gpu.yml
@@ -104,7 +104,10 @@ jobs:
     needs: prepare-kernels
     environment: privileged
     runs-on: ubuntu-24.04
-    # The job deadline is a final safety net; each measured warm-cache replicate must finish in five minutes.
+    # The job deadline is a final safety net; each replicate must complete creation through artifact
+    # collection within ten minutes. That ceiling covers the whole sandbox lifecycle, not the measured
+    # window: the first full run put the client benchmark at ~59s but the replicate at ~358s, the
+    # balance being sandbox creation, image pull, model load, and CUDA-graph capture.
     timeout-minutes: 30
     steps:
       - name: Checkout
@@ -131,7 +134,7 @@ jobs:
               --require-precision
               --relative-ci-half-width 0.005
               --require-duration
-              --max-replicate-duration-seconds 300
+              --max-replicate-duration-seconds 600
             )
           fi
           bun apps/cli/src/bin/bench-gpu.ts \

--- a/apps/cli/src/lib/gpu/config.ts
+++ b/apps/cli/src/lib/gpu/config.ts
@@ -97,7 +97,11 @@ export const GPU_BENCHMARK = {
 		memoryLimitMiB: 8192,
 		minimumReplicates: 20,
 		relativeCiHalfWidth: 0.005,
-		maxReplicateDurationSeconds: 300,
+		// Whole-lifecycle ceiling: sandbox creation, image pull, model load, CUDA-graph capture, the
+		// timed client, and artifact collection. Measured across the first full 20-replicate fleet at
+		// 352-422s (median 358s), of which the client window was only ~59s — 300 was unreachable for
+		// every replicate, not just a slow tail.
+		maxReplicateDurationSeconds: 600,
 	},
 	modelPreparation: {
 		memoryMiB: 1024,


### PR DESCRIPTION
The 300-second target was unreachable for every replicate, not just a slow tail: the first
full 20-sandbox fleet ran 352-422s (median 358s) and the fastest still missed it. The gate
covers the whole sandbox lifecycle, but the timed client window was only ~59s of that — the
balance is sandbox creation, image pull, model load, and CUDA-graph capture.

600s clears the observed spread with room for image-pull variance while still tripping on a
genuinely stuck sandbox, and sits under the 900s sandbox timeout. Raised in the CLI default
as well, so a local run without the flag is not gated on a threshold this workload cannot
meet. The stale 'five minutes' comment on the job deadline now describes what is measured.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Raise the GPU benchmark replicate ceiling from 300s to 600s to match full sandbox lifecycle timing. This removes false failures while still catching stuck sandboxes and stays under the 900s sandbox timeout.

- **Bug Fixes**
  - Set `--max-replicate-duration-seconds` to 600 in the workflow and CLI default to avoid unreachable 300s runs.
  - Clarified job comment to note the full lifecycle: sandbox creation, image pull, model load, CUDA-graph capture, client run, and artifact collection.

<sup>Written for commit 5ecab555a29b18e5ded488e9b2728b21b9415efa. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/starslingdev/hpc-sandbox-benchmarks/pull/371?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Increased the GPU benchmark’s default maximum replicate duration from five to ten minutes.
  * Updated benchmark guidance to clarify that the full replicate lifecycle must complete within ten minutes.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->