### PR TITLE
Set up cloud dev environment (self-healing update script + on-demand PTS)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,22 +6,28 @@ This repo is a **Bun workspace monorepo** (source-first, no build step) whose pr
 CLI (`@sandbox-benchmarks/cli`) that plans, runs, normalizes, and renders sandbox-provider
 benchmarks. There is no server or web UI — everything is exercised through Bun and the CLI bins.
 
-### Toolchain (already provisioned in the VM snapshot)
-- `bun` 1.3.14 and `mise` are pre-installed and symlinked into `/usr/local/bin`, so they resolve
-  on a bare `PATH`. The startup update script runs `mise install` + `bun install --ignore-scripts`,
-  then installs **Phoronix Test Suite** if `phoronix-test-suite` is missing.
+### Toolchain (provisioned by the startup update script)
+- The startup update script is self-healing: it installs `mise` (2026.7.11) and `bun` (1.3.14) if
+ they are missing, symlinks `mise`, `bun`, and **`bunx`** into `/usr/local/bin` (so they resolve on a
+ bare `PATH`), then runs `mise install` (pinned non-Bun tools) + `bun install --ignore-scripts`. The
+ `bunx` symlink is load-bearing: `bun run check:catalog-drift` spawns `bunx biome`, so a missing
+ `bunx` on `PATH` fails that gate with `Executable not found in $PATH: "bunx"`.
 - Non-Bun tools (`typos`, `shellcheck`, `hadolint`, `actionlint`, `zizmor`) are pinned in
-  `mise.toml` and invoked via `mise exec` — never install them ad hoc.
+ `mise.toml` and invoked via `mise exec` — never install them ad hoc.
+- **Phoronix Test Suite (PTS) is NOT installed by the update script** (it is heavy and network-bound,
+ and every benchmark leaf skips gracefully without it — see below). Install it on demand.
 
 ### Phoronix Test Suite (PTS)
 The `.mise/tasks/benchmark/**` leaves call `phoronix-test-suite` (via `lib/bench.sh`). In provider
 sandboxes PTS is baked into the toolchain image (`packages/templates/images/base/scripts/20-pts.sh`);
-on this host VM it is installed from the same pin as `packages/templates/src/lib/pins.ts`
-(`ptsVersion` 10.8.4 + `ptsDebSha256`).
+on this host VM install it on demand (the update script does not).
 
+- Install + configure on the host (idempotent, needs sudo):
+ `cd /workspace && SUDO=sudo bash -c 'source lib/bench.sh && ensure_pts'`. `ensure_pts` apt-installs
+ PTS (pin 10.8.4, matching `packages/templates/src/lib/pins.ts`) plus its build deps and `stress-ng`,
+ then puts PTS in batch mode. It returns 1 (never aborts) if PTS can't be made available — leaves
+ then skip rather than fail.
 - Verify: `phoronix-test-suite version` (expect `Phoronix Test Suite v10.8.4`).
-- Host configure helper: `source lib/bench.sh && ensure_pts` (batch mode; returns 1 only if PTS
-  cannot be made available — leaves then skip rather than fail).
 - Cheap end-to-end mise leaf on the host (no provider keys):  
   `mise run benchmark:disk:pts:hardlink` — needs `stress-ng` (`apt-get install -y stress-ng`).
   Writes under `benchmark-results/` (local output; do not commit).


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What

Sets up the Cursor Cloud development environment for this Bun-workspace monorepo and makes the startup provisioning reliable.

This VM booted **without** `bun` or `mise` (despite AGENTS.md previously claiming they were baked into the snapshot), so the environment could not be developed or tested as-is. This PR fixes that.

### Update script (registered via the environment tool)
Self-healing and idempotent:
- Installs `mise` (`2026.7.11`) and `bun` (`1.3.14`) only if missing.
- Symlinks `mise`, `bun`, and **`bunx`** into `/usr/local/bin` so they resolve on a bare `PATH`. The `bunx` symlink is load-bearing — `bun run check:catalog-drift` spawns `bunx biome` and otherwise fails with `Executable not found in $PATH: "bunx"`.
- Runs `mise install` (pinned `typos`/`shellcheck`/`hadolint`/`actionlint`/`zizmor`) + `bun install --ignore-scripts`.

### Code changes
- `AGENTS.md`: corrected the two statements that were now inaccurate — the toolchain is provisioned by the (self-healing) startup update script rather than pre-baked, and **Phoronix Test Suite is installed on demand**, not by the update script. Added the exact on-demand PTS install command and the `bunx` gotcha.

No application/source code was modified.

## Verification (all from this VM)

Full command-contract gate (matches `.github/workflows/ci.yml`):

| Check | Command | Result |
| --- | --- | --- |
| Lint | `bun run lint` | pass (312 files) |
| Typecheck | `bun run typecheck` | pass (9 members) |
| Test | `bun run test` | pass (295 CLI tests + members) |
| Spell | `bun run spell` | pass |
| Catalog drift | `bun run check:catalog-drift` | pass (1319 metrics / 15 profiles) |
| Shell lint | `bun run lint:shell` | pass |
| Docker lint | `bun run lint:docker` | pass |

Hello-world (offline CLI, no provider keys): `plan-matrix --list-providers` lists 13 providers, and `leaderboard data/dataset/runs/29926138677.json` renders the full leaderboard markdown.

PTS benchmark leaf end-to-end: after on-demand `ensure_pts` + `stress-ng`, `mise run benchmark:disk:pts:hardlink` produced a real numeric result (`7.96 bogo ops/s`) in `benchmark-results/pts_hardlink.xml` (no skip marker).

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5c248816-f81f-4ea5-b5fd-42a0c45faf73?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5c248816-f81f-4ea5-b5fd-42a0c45faf73&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Documents the cloud dev VM’s self-healing startup update script and switches Phoronix Test Suite (PTS) to on-demand install. Previously the docs claimed `bun`/`mise` were preinstalled and PTS was auto-installed; now the script installs `mise` 2026.7.11 and `bun` 1.3.14 only if missing, symlinks `mise`/`bun`/`bunx`, and leaves PTS to an explicit host install.

- Startup update script: installs if missing, symlinks `mise`, `bun`, and `bunx` into `/usr/local/bin`, then runs `mise install` and `bun install --ignore-scripts`. The `bunx` symlink fixes catalog-drift runs that spawn `bunx biome`.
- PTS is not auto-installed. To enable PTS leaves on the host (idempotent; needs sudo): `cd /workspace && SUDO=sudo bash -c 'source lib/bench.sh && ensure_pts'`. Leaves skip gracefully if PTS can’t be made available. Verify with `phoronix-test-suite version`. Some leaves also require `stress-ng`.
- Scope: docs-only change to `AGENTS.md`; no source or CI behavior changes.

<sup>Written for commit a00569f2299dfda1d9198a627a83f5076a423f98. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/starslingdev/hpc-sandbox-benchmarks/pull/372?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

