### PR TITLE
Warm synthetic PTS profiles for fast host suite runs (fix fio download)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,32 +8,52 @@ benchmarks. There is no server or web UI — everything is exercised through Bun
 
 ### Toolchain (provisioned by the startup update script)
 - The startup update script is self-healing: it installs `mise` (2026.7.11) and `bun` (1.3.14) if
- they are missing, symlinks `mise`, `bun`, and **`bunx`** into `/usr/local/bin` (so they resolve on a
- bare `PATH`), then runs `mise install` (pinned non-Bun tools) + `bun install --ignore-scripts`. The
- `bunx` symlink is load-bearing: `bun run check:catalog-drift` spawns `bunx biome`, so a missing
- `bunx` on `PATH` fails that gate with `Executable not found in $PATH: "bunx"`.
+  they are missing, symlinks `mise`, `bun`, and **`bunx`** into `/usr/local/bin` (so they resolve on a
+  bare `PATH`), then runs `mise install` (pinned non-Bun tools) + `bun install --ignore-scripts`.
+  It then runs `ensure_pts` (via `lib/bench.sh`) so **Phoronix Test Suite 10.8.4** and its apt deps
+  (`stress-ng`, `nc`, `jq`, php, build toolchain, …) are present — idempotent and fast when already
+  installed. The `bunx` symlink is load-bearing: `bun run check:catalog-drift` spawns `bunx biome`,
+  so a missing `bunx` on `PATH` fails that gate with `Executable not found in $PATH: "bunx"`.
 - Non-Bun tools (`typos`, `shellcheck`, `hadolint`, `actionlint`, `zizmor`) are pinned in
- `mise.toml` and invoked via `mise exec` — never install them ad hoc.
-- **Phoronix Test Suite (PTS) is NOT installed by the update script** (it is heavy and network-bound,
- and every benchmark leaf skips gracefully without it — see below). Install it on demand.
+  `mise.toml` and invoked via `mise exec` — never install them ad hoc.
 
-### Phoronix Test Suite (PTS)
-The `.mise/tasks/benchmark/**` leaves call `phoronix-test-suite` (via `lib/bench.sh`). In provider
-sandboxes PTS is baked into the toolchain image (`packages/templates/images/base/scripts/20-pts.sh`);
-on this host VM install it on demand (the update script does not).
+### Synthetic host suites (CPU / disk / network / memory / system)
+Run these **on the cloud VM host** (no provider API keys). They write under `benchmark-results/`
+(local output; do not commit).
 
-- Install + configure on the host (idempotent, needs sudo):
- `cd /workspace && SUDO=sudo bash -c 'source lib/bench.sh && ensure_pts'`. `ensure_pts` apt-installs
- PTS (pin 10.8.4, matching `packages/templates/src/lib/pins.ts`) plus its build deps and `stress-ng`,
- then puts PTS in batch mode. It returns 1 (never aborts) if PTS can't be made available — leaves
- then skip rather than fail.
-- Verify: `phoronix-test-suite version` (expect `Phoronix Test Suite v10.8.4`).
-- Cheap end-to-end mise leaf on the host (no provider keys):  
-  `mise run benchmark:disk:pts:hardlink` — needs `stress-ng` (`apt-get install -y stress-ng`).
-  Writes under `benchmark-results/` (local output; do not commit).
-- Full OpenBenchmarking profiles (c-ray, fio, zstd, …) download/build on first use and are heavy;
-  prefer the hardlink leaf or the Docker `benchmark:realworld:selftest` when validating PTS wiring.
+| Suite | Entrypoint |
+| --- | --- |
+| CPU | `mise run benchmark:cpu:node` |
+| Disk | `mise run benchmark:disk:all` |
+| Network (iperf composition) | `mise run benchmark:network:suite` |
+| Network (legacy fast-cli + loopback) | `mise run benchmark:network:all` |
+| Memory | `mise run benchmark:memory:all` |
+| System | `mise run benchmark:system:all` |
+
+**Snapshot warm (once, when building/refreshing the cloud VM snapshot):** cold PTS profile
+installs are slow (git ~450 MB download, fio/iperf/stream source builds). After `ensure_pts` is
+green, run:
+
+```sh
+SUDO=sudo ./scripts/warm-synthetic-pts.sh
+```
+
+That pre-installs every profile the synthetic suites use (including local `hardlink` /
+`iperf-wan` and vendored `iperf` / `network-loopback` / `fast-cli` overrides) and writes
+`~/.cache/sandbox-benchmarks/synthetic-pts-warm.stamp`. Subsequent `mise run benchmark:…` calls
+then skip download/compile and go straight to measurement. Re-run the warm script only if the
+stamp is missing or a suite leaf starts writing `--skipped.json` / reinstalling profiles.
+
+- Verify PTS: `phoronix-test-suite version` (expect `Phoronix Test Suite v10.8.4`).
+- Verify warm: `phoronix-test-suite list-installed-tests` should list the synthetic profiles
+  (iperf, fio, stream, pybench, sqlite-speedtest, git, node-web-tooling, fast-cli,
+  network-loopback, local/hardlink, local/iperf-wan).
+- Cheap single-leaf smoke (no warm required beyond PTS + stress-ng):
+  `mise run benchmark:disk:pts:hardlink`.
+- Full OpenBenchmarking profiles outside the warm set still download/build on first use.
 - `benchmark:realworld:selftest` requires Docker (not installed in this Cloud VM by default).
+- Live provider benches need per-provider API keys from `.env` (see `.env.example`); without keys a
+  provider is a **skip, not a failure**.
 
 ### Running checks / the app
 The command contract lives in the root `package.json` and `docs/architecture.md`; run those scripts
@@ -49,10 +69,8 @@ directly:
   in Cursor because `core.hooksPath` is set to a custom agent-hooks directory. `--ignore-scripts`
   skips it (this is exactly what CI does) and dependencies still resolve fully. Git pre-commit hooks
   are therefore not wired here — run the gate scripts manually before committing.
-- Live provider benches (E2B/Daytona/Modal/Blaxel/Novita) need per-provider API keys from `.env`
-  (see `.env.example`). Without keys a provider is recorded as a **skip, not a failure**, so lint /
-  typecheck / test / spell and the offline CLI bins (`plan-matrix`, `leaderboard` over the committed
-  `data/dataset` runs) all work with no credentials.
 - Mise PTS leaves that lack `phoronix-test-suite` (or a leaf-specific tool like `stress-ng` /
   `nc`) call `skip_result` and exit 0 — a green task exit does **not** prove the benchmark ran.
   Check for `benchmark-results/<prefix>.xml` (success) vs `benchmark-results/<prefix>--skipped.json`.
+- The network suite's wall time is dominated by real 10s iperf trials (localhost ×3 + WAN ×2), not
+  setup, once profiles are warmed.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -39,7 +39,8 @@ SUDO=sudo ./scripts/warm-synthetic-pts.sh
 ```
 
 That pre-installs every profile the synthetic suites use (including local `hardlink` /
-`iperf-wan` and vendored `iperf` / `network-loopback` / `fast-cli` overrides) and writes
+`iperf-wan` and vendored `iperf` / `network-loopback` / `fast-cli` overrides), seeds the fio
+tarball from Ubuntu's pool (OpenBenchmarking's `brick.kernel.dk` host is often down), and writes
 `~/.cache/sandbox-benchmarks/synthetic-pts-warm.stamp`. Subsequent `mise run benchmark:…` calls
 then skip download/compile and go straight to measurement. Re-run the warm script only if the
 stamp is missing or a suite leaf starts writing `--skipped.json` / reinstalling profiles.

--- a/scripts/warm-synthetic-pts.sh
+++ b/scripts/warm-synthetic-pts.sh
@@ -36,12 +36,22 @@ if [ "${#missing[@]}" -gt 0 ]; then
 	exit 1
 fi
 
-# Seed the shared iperf source into PTS's download cache (localhost + WAN leaves share it).
-# Never fatal: seed_pts_download_cache returns 0 even when every URL fails.
+# Seed sources PTS's own downloader is single-shot for. Never fatal: seed_pts_download_cache
+# returns 0 even when every URL fails (batch-install then gets its own chance).
+#
+# iperf: localhost + WAN leaves share the same tarball.
 seed_pts_download_cache "iperf-3.14.tar.gz" \
 	"723fcc430a027bc6952628fa2a3ac77584a1d0bd328275e573fc9b206c155004" \
 	"https://downloads.es.net/pub/iperf/iperf-3.14.tar.gz" \
 	"https://sources.buildroot.net/iperf3/iperf-3.14.tar.gz"
+# fio: OpenBenchmarking pins http://brick.kernel.dk/snaps/fio-3.36.tar.gz, which is frequently
+# unreachable (PTS issue #865). Ubuntu's fio_3.36.orig.tar.gz is the same bytes (matching SHA256);
+# seed under the filename PTS looks for so batch-install copies from cache.
+seed_pts_download_cache "fio-3.36.tar.gz" \
+	"0a07354876ca4d23518f8aa88682f23866455bbd2ff2d0f055d6e4b72f156553" \
+	"http://archive.ubuntu.com/ubuntu/pool/universe/f/fio/fio_3.36.orig.tar.gz" \
+	"https://launchpad.net/ubuntu/+archive/primary/+sourcefiles/fio/3.36-1/fio_3.36.orig.tar.gz" \
+	"https://web.archive.org/web/2020/http://brick.kernel.dk/snaps/fio-3.36.tar.gz"
 
 # Repo-local profiles (PTS will not fetch these).
 install_local_pts_profile "hardlink-1.0.0"
@@ -83,6 +93,12 @@ for t in "${pts_targets[@]}"; do
 	if _pts_is_installed "$t"; then
 		echo "already installed: ${t}"
 	else
+		# A prior INSTALL_FAILED leaves a pts-install.json tombstone that can confuse a retry;
+		# discard incomplete installs before batch-install (same idea as install_vendored_pts_profile).
+		case "$t" in
+		pts/*) rm -rf "$(pts_install_root)/pts/${t#pts/}" ;;
+		local/*) rm -rf "$(pts_install_root)/local/${t#local/}" ;;
+		esac
 		to_install+=("$t")
 	fi
 done

--- a/scripts/warm-synthetic-pts.sh
+++ b/scripts/warm-synthetic-pts.sh
@@ -58,10 +58,15 @@ install_local_pts_profile "hardlink-1.0.0"
 install_local_pts_profile "iperf-wan-1.0.0"
 
 # Vendored overrides that leaves stage before install/run (same pts/<name> identifiers).
-# Staging discards any baked/upstream install so the next batch-install uses our copy.
-install_vendored_pts_profile "iperf-1.2.0"
-install_vendored_pts_profile "network-loopback-1.0.3"
-install_vendored_pts_profile "fast-cli-1.0.0"
+# Only restage when not already installed — install_vendored_pts_profile always discards the
+# installed tree, which would force a rebuild on every warm re-run.
+for vendored in iperf-1.2.0 network-loopback-1.0.3 fast-cli-1.0.0; do
+	if _pts_is_installed "pts/${vendored}"; then
+		echo "already installed: pts/${vendored} (skip vendored restage)"
+	else
+		install_vendored_pts_profile "$vendored"
+	fi
+done
 
 # STREAM: pin the same working set the memory leaf measures (see benchmark:memory:pts:stream).
 # Export before batch-install so a cold install compiles the pinned binary.

--- a/scripts/warm-synthetic-pts.sh
+++ b/scripts/warm-synthetic-pts.sh
@@ -1,0 +1,124 @@
+#!/usr/bin/env bash
+# Pre-install Phoronix Test Suite profiles used by the synthetic host suites so
+# `mise run benchmark:{cpu:node,disk:all,network:suite,memory:all,system:all}` spend wall time on
+# measurement, not download/compile.
+#
+# Idempotent: already-installed profiles are skipped. Needs sudo for the first-time PTS apt path
+# (via ensure_pts). Safe to re-run after a snapshot restore.
+#
+# Intentionally NOT part of the Cursor Cloud startup update script — a cold warm can take many
+# minutes (git ~450 MB, fio/iperf/stream compiles). Run once when building the cloud VM snapshot:
+#   SUDO=sudo ./scripts/warm-synthetic-pts.sh
+set -euo pipefail
+
+REPO_ROOT="$(git -C "$(dirname "${BASH_SOURCE[0]}")/.." rev-parse --show-toplevel)"
+cd "$REPO_ROOT"
+# shellcheck disable=SC1091 # sourced helpers live next to the repo root; not a shellcheck input.
+source "${REPO_ROOT}/lib/bench.sh"
+
+echo "========================================"
+echo "  Warm synthetic PTS profiles (host VM)"
+echo "========================================"
+
+if ! ensure_pts; then
+	echo "ERROR: ensure_pts could not make phoronix-test-suite available" >&2
+	exit 1
+fi
+
+# Leaf-specific tools the skip guards check before measurement.
+missing=()
+for bin in stress-ng nc jq php; do
+	have "$bin" || missing+=("$bin")
+done
+if [ "${#missing[@]}" -gt 0 ]; then
+	echo "ERROR: missing required tools: ${missing[*]}" >&2
+	echo "ensure_pts should have installed these; re-run with SUDO=sudo" >&2
+	exit 1
+fi
+
+# Seed the shared iperf source into PTS's download cache (localhost + WAN leaves share it).
+# Never fatal: seed_pts_download_cache returns 0 even when every URL fails.
+seed_pts_download_cache "iperf-3.14.tar.gz" \
+	"723fcc430a027bc6952628fa2a3ac77584a1d0bd328275e573fc9b206c155004" \
+	"https://downloads.es.net/pub/iperf/iperf-3.14.tar.gz" \
+	"https://sources.buildroot.net/iperf3/iperf-3.14.tar.gz"
+
+# Repo-local profiles (PTS will not fetch these).
+install_local_pts_profile "hardlink-1.0.0"
+install_local_pts_profile "iperf-wan-1.0.0"
+
+# Vendored overrides that leaves stage before install/run (same pts/<name> identifiers).
+# Staging discards any baked/upstream install so the next batch-install uses our copy.
+install_vendored_pts_profile "iperf-1.2.0"
+install_vendored_pts_profile "network-loopback-1.0.3"
+install_vendored_pts_profile "fast-cli-1.0.0"
+
+# STREAM: pin the same working set the memory leaf measures (see benchmark:memory:pts:stream).
+# Export before batch-install so a cold install compiles the pinned binary.
+STREAM_ARRAY_SIZE=150000000
+march=native
+if grep -qi gvisor /proc/version 2>/dev/null; then
+	march=x86-64-v3
+fi
+export CFLAGS_OVERRIDE="-O3 -march=${march} -DSTREAM_ARRAY_SIZE=${STREAM_ARRAY_SIZE}"
+
+# Upstream OpenBenchmarking profiles the synthetic suites batch-run (version-pinned to leaves).
+# Skip anything already registered so re-runs stay cheap.
+pts_targets=(
+	pts/pybench-1.1.3
+	pts/sqlite-speedtest-1.0.1
+	pts/fio-2.1.0
+	pts/network-loopback-1.0.3
+	pts/iperf-1.2.0
+	pts/stream-1.3.4
+	pts/node-web-tooling-1.0.1
+	pts/fast-cli-1.0.0
+	pts/git-1.1.0
+	local/hardlink-1.0.0
+	local/iperf-wan-1.0.0
+)
+
+to_install=()
+for t in "${pts_targets[@]}"; do
+	if _pts_is_installed "$t"; then
+		echo "already installed: ${t}"
+	else
+		to_install+=("$t")
+	fi
+done
+
+if [ "${#to_install[@]}" -eq 0 ]; then
+	echo "All synthetic PTS profiles already installed."
+else
+	echo "batch-install: ${to_install[*]}"
+	# PTS can exit 0 after a partial failure; verify each target below.
+	phoronix-test-suite batch-install "${to_install[@]}" || true
+fi
+
+failed=()
+for t in "${pts_targets[@]}"; do
+	if _pts_is_installed "$t"; then
+		echo "OK  ${t}"
+	else
+		echo "MISSING  ${t}" >&2
+		failed+=("$t")
+	fi
+done
+
+if [ "${#failed[@]}" -gt 0 ]; then
+	echo "ERROR: warm incomplete — missing: ${failed[*]}" >&2
+	exit 1
+fi
+
+mkdir -p "${HOME}/.cache/sandbox-benchmarks"
+date -u +%Y-%m-%dT%H:%M:%SZ >"${HOME}/.cache/sandbox-benchmarks/synthetic-pts-warm.stamp"
+
+echo
+echo "Warm complete. Synthetic suite entrypoints:"
+echo "  mise run benchmark:cpu:node"
+echo "  mise run benchmark:disk:all"
+echo "  mise run benchmark:network:suite"
+echo "  mise run benchmark:memory:all"
+echo "  mise run benchmark:system:all"
+echo
+phoronix-test-suite list-installed-tests


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What

Makes synthetic host suites (CPU / disk / network / memory / system) runnable quickly from a warmed cloud VM snapshot.

### `scripts/warm-synthetic-pts.sh`
Pre-installs every PTS profile those suites use (including local `hardlink` / `iperf-wan` and vendored overrides). Run once when building/refreshing the snapshot:

```sh
SUDO=sudo ./scripts/warm-synthetic-pts.sh
```

**fio fix:** OpenBenchmarking’s `http://brick.kernel.dk/snaps/fio-3.36.tar.gz` is often unreachable, which produced `ERROR: warm incomplete — missing: pts/fio-2.1.0`. The warm script now seeds the byte-identical Ubuntu `fio_3.36.orig.tar.gz` (matching SHA256) into the PTS download cache, clears `INSTALL_FAILED` tombstones, and retries.

Also skips vendored restage when a profile is already installed so re-runs stay cheap.

### Docs / update script
`AGENTS.md` documents suite entrypoints and the warm step. The startup update script still runs `ensure_pts` (PTS binary + apt deps); profile warm stays one-shot for the snapshot (too heavy for every boot).

## Verification
- Warm completes with **11** tests installed, including `pts/fio-2.1.0`.
- Re-running warm reports all profiles already installed (no fio missing error).

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5c248816-f81f-4ea5-b5fd-42a0c45faf73?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5c248816-f81f-4ea5-b5fd-42a0c45faf73&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Pre-installs the Phoronix Test Suite profiles used by the host synthetic suites so runs spend time measuring, not downloading/compiling. Previously, first runs did cold installs and `pts/fio-2.1.0` often failed; now the warm step installs all required profiles, seeds a byte-identical `fio-3.36.tar.gz` into the PTS cache, clears `INSTALL_FAILED` tombstones, and skips vendored restage when already installed.

- Startup update script now ensures `phoronix-test-suite 10.8.4` and apt deps are present (idempotent); suite entrypoints are unchanged.
- Snapshot builders must run once when creating/updating the VM snapshot: `SUDO=sudo ./scripts/warm-synthetic-pts.sh` (after `ensure_pts`). This writes a stamp and is safe to re-run.
- Verify: `phoronix-test-suite version` shows 10.8.4 and `list-installed-tests` includes `pts/fio-2.1.0`.

<sup>Written for commit 59cc91048c731dd3fcb6c617114b58f7c95d8f78. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/starslingdev/hpc-sandbox-benchmarks/pull/373?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

