### PR TITLE
feat(providers): add tama as a benchmark provider

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -55,6 +55,21 @@ VERCEL_OIDC_TOKEN=
 # VERCEL_TEAM_SLUG=
 # VERCEL_PROJECT_NAME=
 
+# --- tama (https://tama.computer) ---
+# tama publishes no SDK, so the adapter drives the `tama` CLI as a subprocess: install it first
+# (`curl -fsSL https://tama.computer/install | sh`, or TAMA_INSTALL_DIR=~/.local/bin to skip sudo).
+# Mint the token with `tama tokens create --name <name>`; it is shown once.
+#
+# Set this EVEN IF you have already run `tama login`. The harness's credential gate reads env vars
+# only, so an authenticated CLI profile with no TAMA_TOKEN is recorded as a skip before the adapter
+# is ever constructed. The token is not spent needlessly, though: the adapter probes the existing
+# profile first and only runs `tama login --token` when that probe fails — because `login --token`
+# REPLACES the stored credential and would otherwise sign you out of your own account as a side
+# effect of running a benchmark.
+TAMA_TOKEN=
+# Path to the CLI when it is not on PATH (the adapter spawns bare `tama` otherwise).
+# TAMA_CLI=
+
 # --- Optional overrides (leave unset for the pinned public toolchain) ---
 # Point the adapters at a specific toolchain image / template instead of the canonical published one.
 # Useful only when iterating on the toolchain locally; see packages/providers/src/lib/config.ts.

--- a/.github/actions/setup-tama/action.yml
+++ b/.github/actions/setup-tama/action.yml
@@ -1,0 +1,20 @@
+name: Set up the tama CLI
+description: Install the checksum-pinned tama CLI onto the runner, because the adapter drives it as a subprocess.
+
+inputs:
+  version:
+    description: Expected `tama --version`, asserted after install so a moved release is visible.
+    default: 0.1.17
+  sha256:
+    description: sha256 of tama-x86_64-unknown-linux-gnu.tar.gz, verified against our own copy.
+    default: d38f8147d3fa2df0b768c4551b34039179a577db6809adda268e8ea6af8b3fbc
+
+runs:
+  using: composite
+  steps:
+    - name: Install tama
+      shell: bash
+      env:
+        TAMA_VERSION: ${{ inputs.version }}
+        TAMA_SHA256: ${{ inputs.sha256 }}
+      run: "${GITHUB_ACTION_PATH}/install.sh"

--- a/.github/actions/setup-tama/install.sh
+++ b/.github/actions/setup-tama/install.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+# Install the tama CLI on the runner. tama publishes no SDK, so the adapter spawns this binary for
+# every control-plane call — without it the cell dies at ENOENT on its first authentication probe,
+# before any sandbox exists.
+#
+# The vendor's own installer (`curl https://tama.computer/install | sh`) verifies the archive against
+# a .sha256 served from the SAME origin, which is self-certifying: it proves the download was not
+# truncated, not that the bytes are the ones anyone reviewed. So the archive is fetched directly and
+# checked against a sha256 committed to THIS repo, the same posture as the pinned mise/PTS artifacts.
+#
+# tama serves only `downloads/latest` — a versioned path returns the marketing SPA with a 200 — so the
+# pin cannot ride the URL and a new upstream release WILL fail this step. That is the intended
+# failure: refresh the pin in action.yml (the command is in the error below) rather than run an
+# unreviewed binary that creates billable machines.
+set -euo pipefail
+
+archive="tama-x86_64-unknown-linux-gnu.tar.gz"
+url="https://tama.computer/downloads/latest/${archive}"
+workdir="$(mktemp -d "${RUNNER_TEMP:-/tmp}/tama-install.XXXXXX")"
+trap 'rm -rf "$workdir"' EXIT
+
+curl -fsSL --retry 3 --retry-connrefused "$url" -o "${workdir}/${archive}"
+
+observed="$(sha256sum "${workdir}/${archive}" | cut -d' ' -f1)"
+if [[ "$observed" != "$TAMA_SHA256" ]]; then
+	cat >&2 <<-EOF
+		tama CLI checksum mismatch for ${url}
+		  expected ${TAMA_SHA256}
+		  observed ${observed}
+		tama serves a single moving "latest" build, so this is most likely a new release rather than a
+		compromised download. Verify the release, then refresh the pin in
+		.github/actions/setup-tama/action.yml:
+		  curl -fsSL ${url} | sha256sum
+	EOF
+	exit 1
+fi
+
+tar -xzf "${workdir}/${archive}" -C "$workdir"
+install -m 0755 "${workdir}/tama" /usr/local/bin/tama
+
+# The pin is on the ARCHIVE; assert the version it unpacks to as well, so the log records exactly
+# which CLI drove the run and a silently re-cut release under the same hash cannot pass unnoticed.
+observed_version="$(tama --version | awk '{print $2}')"
+if [[ "$observed_version" != "$TAMA_VERSION" ]]; then
+	echo "tama CLI reports ${observed_version}, expected ${TAMA_VERSION}" >&2
+	exit 1
+fi
+echo "tama ${observed_version} installed (sha256 ${observed})"

--- a/.github/workflows/bench-smoke.yml
+++ b/.github/workflows/bench-smoke.yml
@@ -67,6 +67,7 @@ on:
             microsandbox-local,
             microsandbox-cloud,
             runcloud,
+            tama,
           ]
       suite:
         # Constrained to the SUITE_NAMES registry (packages/schema/src/suites.ts); the

--- a/.github/workflows/bench-suite.yml
+++ b/.github/workflows/bench-suite.yml
@@ -192,6 +192,19 @@ jobs:
         with:
           token-name: sandbox-benchmarks-${{ inputs.suite }}-${{ github.run_id }}-${{ github.run_attempt }}
 
+      # tama publishes no SDK, so its adapter spawns the `tama` binary for every control-plane call and
+      # a runner without it fails at ENOENT on the first authentication probe — before a sandbox
+      # exists, and reported as a create failure rather than as the missing tool it is. Every other
+      # provider's client arrives with `bun install`; this one has to be put on the runner.
+      #
+      # NOT continue-on-error, unlike the two credential steps above: those degrade into the harness's
+      # missing-credentials skip, which is a real, legible outcome. A missing binary has no such
+      # outcome — the cell would run on to create sandboxes it cannot talk to. The install is
+      # checksum-pinned, so it fails loudly when tama cuts a release (see the action).
+      - name: Set up the tama CLI
+        if: matrix.provider == 'tama'
+        uses: ./.github/actions/setup-tama
+
       - name: Authenticate with Vercel
         if: matrix.provider == 'vercel'
         continue-on-error: true

--- a/.github/workflows/bench-suite.yml
+++ b/.github/workflows/bench-suite.yml
@@ -275,6 +275,11 @@ jobs:
           BENCH_RUNNER_LIFETIME_MINUTES: ${{ matrix.provider == 'microsandbox-local' && '70' || '' }}
           MSB_API_URL: ${{ matrix.provider == 'microsandbox-cloud' && secrets.MSB_API_URL || '' }}
           MSB_API_KEY: ${{ matrix.provider == 'microsandbox-cloud' && secrets.MSB_API_KEY || '' }}
+          # tama ships no SDK: the adapter drives the `tama` CLI, which keeps credentials in its own
+          # profile rather than reading an env var. A fresh runner has no profile, so the adapter adopts
+          # this minted token (`tama tokens create`) on its first control-plane call. The value stays in
+          # the CLI profile and never enters the guest.
+          TAMA_TOKEN: ${{ matrix.provider == 'tama' && secrets.TAMA_TOKEN || '' }}
         run: bun apps/cli/src/bin/bench-suite.ts "$BENCH_PROVIDER" "$BENCH_SUITE" "$GITHUB_RUN_ID" --replicates "$BENCH_REPLICATES"
 
       # Did THIS attempt actually produce shard Runs? The upload below overwrites the cell's artifact,

--- a/apps/cli/src/bin/bake.ts
+++ b/apps/cli/src/bin/bake.ts
@@ -67,6 +67,11 @@ const bakers: Record<ProviderId, (image: string, log: Log) => Promise<void>> = {
 	runcloud: async (_image, log) => {
 		log("runcloud boots the candidate image directly — no candidate artifact to bake");
 	},
+	tama: async (_image, log) => {
+		log(
+			"tama boots the candidate image directly via `tama new --image` — no candidate artifact to bake",
+		);
+	},
 };
 
 /**

--- a/apps/cli/src/bin/release-plan.test.ts
+++ b/apps/cli/src/bin/release-plan.test.ts
@@ -77,6 +77,7 @@ describe("buildReleasePlan matrix", () => {
 			"namespace",
 			"vercel",
 			"runcloud",
+			"tama",
 		]);
 	});
 

--- a/apps/cli/src/bin/release-plan.ts
+++ b/apps/cli/src/bin/release-plan.ts
@@ -83,6 +83,8 @@ function providerArtifact(id: ProviderId): string {
 			return "boots the candidate image directly (no baked artifact)";
 		case "runcloud":
 			return "boots the candidate image directly (no baked artifact)";
+		case "tama":
+			return "boots the candidate image directly (no baked artifact)";
 		case "vercel":
 			return config.vercelImageCandidate;
 	}

--- a/apps/cli/src/lib/bake/promote.ts
+++ b/apps/cli/src/lib/bake/promote.ts
@@ -337,6 +337,9 @@ export async function promoteAll(log: Log, options: PromoteOptions = {}): Promis
 							case "runcloud":
 								log("    runcloud pulls the published version image — nothing to build");
 								break;
+							case "tama":
+								log("    tama pulls the published version image — nothing to build");
+								break;
 							case "vercel":
 								await promoteImage(log, config.vercelImageCandidate, config.vercelImageVersion);
 								break;

--- a/apps/cli/src/lib/bake/validate.test.ts
+++ b/apps/cli/src/lib/bake/validate.test.ts
@@ -114,6 +114,7 @@ describe("baseImageUse", () => {
 			"modal-vm",
 			"namespace",
 			"runcloud",
+			"tama",
 		]);
 	});
 

--- a/apps/cli/src/lib/bake/validate.ts
+++ b/apps/cli/src/lib/bake/validate.ts
@@ -50,6 +50,7 @@ export function baseImageUse(id: ProviderId): BaseImageUse {
 		case "microsandbox-cloud":
 		case "namespace":
 		case "runcloud":
+		case "tama":
 			return "boots";
 		case "blaxel":
 		case "vercel":
@@ -100,6 +101,10 @@ export function candidateCreateOptions(
 			return { image: refs.toolchainImageCandidate };
 		case "runcloud":
 			// The native SDK boots an arbitrary OCI image directly; there is no template to bake.
+			return { image: refs.toolchainImageCandidate };
+		case "tama":
+			// `tama new --image` pulls an arbitrary OCI ref at create time, so the candidate boots the same
+			// way the published version does; there is no provider-side artifact.
 			return { image: refs.toolchainImageCandidate };
 		case "vercel":
 			return { templateId: refs.vercelImageCandidate };

--- a/apps/cli/src/lib/providers-run.test.ts
+++ b/apps/cli/src/lib/providers-run.test.ts
@@ -45,6 +45,7 @@ describe("forEachProviderWithCreds `only`", () => {
 			"namespace",
 			"vercel",
 			"runcloud",
+			"tama",
 		]);
 	});
 

--- a/docs/ci-secrets.md
+++ b/docs/ci-secrets.md
@@ -220,6 +220,7 @@ Do this in the GitHub UI (Settings → Environments / Rules / Actions), then del
    | `BL_WORKSPACE` | bench matrix/smoke only |
    | `MSB_API_KEY` | Microsandbox Cloud toolchain validation and bench matrix/smoke |
    | `RUN_CLOUD_API_KEY` | optional for toolchain validation; bench matrix/smoke |
+   | `TAMA_TOKEN` | bench matrix/smoke only |
    | `VERCEL_TOKEN` | Bootstrap only: Vercel CLI pulls a short-lived project OIDC token |
    | `VERCEL_ORG_ID` | Links the Vercel CLI to the repository's organization (`team_*`) |
    | `VERCEL_PROJECT_ID` | Links the Vercel CLI to the repository's project (`prj_*`) |
@@ -321,6 +322,14 @@ the canonical version-scoped Blueprint. Runloop disk snapshots remain temporary 
 measurements; they are not release artifacts and are never selected for ordinary benchmark startup.
 
 run.cloud needs `RUN_CLOUD_API_KEY`. Its SDK reads the key directly from the benchmark process; the adapter never adds it to sandbox metadata, create-time environment variables, or guest commands.
+
+tama needs `TAMA_TOKEN`, minted with `tama tokens create`. It publishes no SDK, so the bench cell
+installs the checksum-pinned CLI (`.github/actions/setup-tama`) and the adapter drives that binary as a
+subprocess. The token is adopted into the CLI's own profile on the first control-plane call and never
+reaches sandbox metadata, create-time environment variables, or guest commands; every diagnostic that
+quotes an argument vector redacts it. A fresh runner has no profile, so the secret is what authenticates
+it — locally the adapter probes an existing `tama login` profile first and only falls back to the token,
+because `tama login --token` REPLACES the stored credential.
 
 The `tooling/repo-checks` secret-hygiene gate enforces this: it fails CI if any tracked file is a
 credential file (`.env`, `*.pem`, `id_rsa`, …) or contains a high-signal secret token.

--- a/packages/providers/README.md
+++ b/packages/providers/README.md
@@ -20,7 +20,10 @@ adapters over raw vendor SDKs only where required.
 packages adapt their vendor SDK directly; Microsandbox uses a local `defineProvider` implementation.
 Vercel's local provider starts from ComputeSDK's upstream adapter but uses pinned `@vercel/sandbox`
 v2, because the published wrapper still pins a pre-VCR SDK. run.cloud also uses a local
-`defineProvider` adapter over `@run-cloud/sdk`, for which no `@computesdk/*` wrapper is published. The package also
+`defineProvider` adapter over `@run-cloud/sdk`, for which no `@computesdk/*` wrapper is published. tama
+goes one step further: it publishes no SDK in ANY language, so its `defineProvider` adapter drives the
+`tama` CLI as a subprocess and parses `--json`, bounding every call itself (a CLI has no request
+timeout to configure) and redacting credential-bearing arguments out of every diagnostic. The package also
 owns benchmark create-time policy — the pinned `TARGET_SPEC` and toolchain image. The assembled
 `providers` registry joins the schema `PROVIDERS` metadata with the adapter
 map by id; both are keyed by `ProviderId`, so a one-sided provider is a compile error rather than a

--- a/packages/providers/src/lib/adapters.ts
+++ b/packages/providers/src/lib/adapters.ts
@@ -20,6 +20,7 @@ import { microsandboxCloudCompute, microsandboxLocalCompute } from "./microsandb
 import { novitaCompute } from "./novita.ts";
 import { RUNCLOUD_CREATE_CEILING_MS, runcloudCompute } from "./runcloud.ts";
 import { runloopCompute } from "./runloop.ts";
+import { TAMA_CREATE_CEILING_MS, tamaCompute } from "./tama.ts";
 import type { ProviderAdapter } from "./types.ts";
 import { vercelCompute } from "./vercel.ts";
 
@@ -270,5 +271,22 @@ export const adapters: Record<ProviderId, ProviderAdapter> = {
 		// them over so the create-retry loop can refuse a retry the budget cannot absorb.
 		createAttemptCeilingMs: RUNCLOUD_CREATE_CEILING_MS,
 		costEvidence: runcloudCostEvidence,
+	},
+	tama: {
+		// tama publishes no SDK, so the adapter drives the `tama` CLI as a subprocess (tama.ts). The
+		// toolchain image is booted by ref — `tama new --image` pulls an arbitrary OCI image, so there is
+		// no provider-side artifact to bake. Disk is deliberately absent: tama exposes no disk knob, and
+		// the observed root filesystem is a large shared overlay that clears the 40 GB workload gate.
+		createCompute: () => tamaCompute(),
+		createOptions: {
+			image: config.toolchainImage,
+			cpu: TARGET_SPEC.vcpus,
+			memory: TARGET_SPEC.memoryGb * 1024,
+		},
+		// `tama new` does not return until the machine is ready, so the ~1.5 GiB cold image pull happens
+		// inside create (2m10s observed). Disable the harness race: the adapter owns a bounded readiness
+		// wait plus failed-create cleanup, and abandoning it mid-teardown would strand a billable machine.
+		createTimeoutMs: null,
+		createAttemptCeilingMs: TAMA_CREATE_CEILING_MS,
 	},
 };

--- a/packages/providers/src/lib/tama.test.ts
+++ b/packages/providers/src/lib/tama.test.ts
@@ -1,0 +1,216 @@
+import { describe, expect, it } from "bun:test";
+import type { CliInvokeOptions, CliResult, TamaComputeOptions, TamaMachine } from "./tama.ts";
+import {
+	execCommandLine,
+	newArgs,
+	redactArgs,
+	sandboxMethods,
+	TAMA_CREATE_CEILING_MS,
+} from "./tama.ts";
+
+/** A `tama --json` machine record with only the fields the adapter reads. */
+function machine(overrides: Partial<TamaMachine> = {}): TamaMachine {
+	return {
+		id: "m-test",
+		name: "sandbox-benchmarks-test",
+		status: "ready",
+		cpu_millicores: 4_000,
+		memory_mb: 8_192,
+		image: "ghcr.io/starslingdev/toolchain:test",
+		...overrides,
+	};
+}
+
+function ok(stdout = ""): CliResult {
+	return { stdout, stderr: "", exitCode: 0 };
+}
+
+/**
+ * Drive the adapter with a scripted CLI: every spawn is recorded, and each subcommand answers from a
+ * handler. Nothing here touches a real binary, a real clock or a real credential — `sleep` and `now`
+ * are injected so a retry loop resolves instantly instead of holding the test for its real backoff.
+ */
+function harness(
+	handlers: Partial<Record<string, (args: string[]) => Promise<CliResult>>>,
+	options: TamaComputeOptions = {},
+) {
+	const calls: string[][] = [];
+	const cli = async (args: string[], _invoke?: CliInvokeOptions): Promise<CliResult> => {
+		calls.push(args);
+		const handler = handlers[args[0] ?? ""];
+		if (!handler) throw new Error(`unscripted tama call: ${args.join(" ")}`);
+		return handler(args);
+	};
+	const methods = sandboxMethods({
+		cli,
+		token: () => "tok-test",
+		sleep: async () => {},
+		reconcileRetryMs: 0,
+		cleanupRetryMs: 0,
+		readyPollMs: 0,
+		...options,
+	});
+	return { calls, methods, removed: () => calls.filter((c) => c[0] === "rm").length };
+}
+
+describe("tama CLI adapter", () => {
+	it("creates with the pinned spec, a recovery name, and no idle expiry", async () => {
+		const args = newArgs("sandbox-benchmarks-abc", {
+			image: "ghcr.io/starslingdev/toolchain:test",
+			cpu: 4,
+			memory: 8192,
+		});
+		expect(args).toEqual([
+			"new",
+			"sandbox-benchmarks-abc",
+			"--ttl",
+			"0",
+			"--json",
+			"--image",
+			"ghcr.io/starslingdev/toolchain:test",
+			"--cpu",
+			"4",
+			"--memory",
+			"8192",
+		]);
+	});
+
+	// The leak this adapter exists to prevent: `new` exits 0 only once a machine is READY, so a zero
+	// exit with an unusable record still means a billable machine — reconcile by the pre-chosen name and
+	// adopt it rather than throwing away the handle.
+	it("adopts the machine by name when a successful create returns no usable record", async () => {
+		const created = machine({ name: "" });
+		const { methods, calls } = harness({
+			new: async (args) => {
+				created.name = args[1] ?? "";
+				return ok("{}"); // parses, carries no id/name
+			},
+			list: async () => ok(JSON.stringify([created])),
+		});
+
+		const result = await methods.create({} as never, { name: "sandbox-benchmarks" });
+		expect(result.sandboxId).toBe("m-test");
+		expect(calls.some((c) => c[0] === "list")).toBe(true);
+		expect(created.name).toMatch(/^sandbox-benchmarks-/);
+	});
+
+	it("names the machine to look for when a no-record create cannot be reconciled", async () => {
+		const { methods } = harness({
+			new: async () => ok("[]"),
+			list: async () => {
+				throw new Error("control plane unavailable");
+			},
+			// The probe that precedes create fails too, so the adapter adopts the token first; the
+			// reconciliation lookups are what stay unanswerable.
+			login: async () => ok(),
+		});
+		await expect(methods.create({} as never, {})).rejects.toThrow(
+			/unknown whether a machine was created; if one was it carries the name sandbox-benchmarks-/,
+		);
+	});
+
+	it("reports an ANSWERED absence as nothing created", async () => {
+		const { methods, removed } = harness({
+			new: async () => ok("{}"),
+			list: async () => ok("[]"),
+		});
+		await expect(methods.create({} as never, {})).rejects.toThrow(/so none was created/);
+		expect(removed()).toBe(0);
+	});
+
+	it("removes a machine that never reaches ready, and retries an ambiguous rm", async () => {
+		let rmCalls = 0;
+		const stuck = machine({ status: "creating" });
+		// A clock that ADVANCES: the readiness loop is bounded by wall time, so a frozen `now` would
+		// spin forever against an injected sleep that returns instantly.
+		let clock = 0;
+		const { methods } = harness(
+			{
+				new: async () => ok(JSON.stringify(stuck)),
+				list: async () => ok(JSON.stringify([stuck])),
+				rm: async () => {
+					rmCalls++;
+					if (rmCalls === 1) return { stdout: "", stderr: "gateway timeout", exitCode: 1 };
+					return ok();
+				},
+			},
+			{
+				readyTimeoutMs: 30_000,
+				now: () => {
+					clock += 10_000;
+					return clock;
+				},
+			},
+		);
+		await expect(methods.create({} as never, {})).rejects.toThrow(/not ready/);
+		// The first rm was ambiguous, so teardown re-asked instead of assuming the machine was gone.
+		expect(rmCalls).toBe(2);
+	});
+
+	it("surfaces an unremovable machine rather than dropping it silently", async () => {
+		let clock = 0;
+		const stuck = machine({ status: "creating" });
+		const { methods, removed } = harness(
+			{
+				new: async () => ok(JSON.stringify(stuck)),
+				list: async () => ok(JSON.stringify([stuck])),
+				rm: async () => ({ stdout: "", stderr: "gateway timeout", exitCode: 1 }),
+			},
+			{
+				readyTimeoutMs: 30_000,
+				cleanupAttempts: 3,
+				now: () => {
+					clock += 10_000;
+					return clock;
+				},
+			},
+		);
+		await expect(methods.create({} as never, {})).rejects.toThrow(/manual cleanup may be required/);
+		expect(removed()).toBe(3);
+	});
+
+	// The credential must not reach a message: these travel into gap markers, annotations, the job
+	// summary and the retained Run document.
+	it("redacts a token from any diagnostic that quotes the argument vector", async () => {
+		expect(redactArgs(["login", "--token", "secret-value"])).toBe("login --token <redacted>");
+
+		const { methods } = harness({
+			list: async () => {
+				throw new Error("not logged in");
+			},
+			login: async () => ({ stdout: "", stderr: "invalid token", exitCode: 1 }),
+		});
+		const error = await methods.create({} as never, {}).catch((e: unknown) => e);
+		expect(String(error)).toContain("<redacted>");
+		expect(String(error)).not.toContain("tok-test");
+	});
+
+	it("exports env vars for the whole command line, builtins and chained steps included", () => {
+		expect(execCommandLine("cd /repo && make", { env: { FOO: "a b" } })).toBe(
+			"export FOO='a b'; cd /repo && make",
+		);
+		expect(execCommandLine("echo hi")).toBe("echo hi");
+		expect(() => execCommandLine("echo hi", { env: { "BAD;rm -rf /": "x" } })).toThrow(
+			/not a valid environment variable name/,
+		);
+	});
+
+	it("declares a create ceiling that covers every bounded call on the longest path", () => {
+		// 20m create + 5 reconcile lookups (+waits) + a 5m readiness window whose last lookup can start
+		// just inside it + 5 cleanup attempts of two calls each (+waits).
+		const controlPlane = 60_000;
+		expect(TAMA_CREATE_CEILING_MS).toBe(
+			20 * 60_000 +
+				5 * controlPlane +
+				4 * 2_000 +
+				5 * 60_000 +
+				3_000 +
+				controlPlane +
+				5 * 2 * controlPlane +
+				4 * 2_000,
+		);
+		// It is the retry loop's reservation against a 60-minute budget: an attempt plus a 2-minute
+		// backoff has to still fit, or the cell could never retry a transient capacity failure.
+		expect(TAMA_CREATE_CEILING_MS + 2 * 60_000).toBeLessThan(60 * 60_000);
+	});
+});

--- a/packages/providers/src/lib/tama.ts
+++ b/packages/providers/src/lib/tama.ts
@@ -1,0 +1,576 @@
+// ComputeSDK provider built over tama's CLI, because tama publishes no SDK in any language: the
+// `tama` binary is the only programmatic surface. Every control-plane call is therefore a subprocess
+// whose `--json` output is parsed, and every call is bounded locally — a CLI has no request timeout
+// to configure, so an unbounded spawn is the only way this adapter could hang a matrix job.
+//
+// Credentials live in the CLI's own profile (written by `tama login`), not in an env var the binary
+// reads. The schema declares TAMA_TOKEN because that is the CI-correct contract; see
+// `ensureAuthenticated` for why an already-authenticated developer profile is preferred over it
+// rather than overwritten.
+
+import { spawn } from "node:child_process";
+import { randomUUID } from "node:crypto";
+import type {
+	CommandResult,
+	CreateSandboxOptions,
+	RunCommandOptions,
+	SandboxInfo,
+	SandboxMethods,
+} from "@computesdk/provider";
+import { defineProvider } from "@computesdk/provider";
+import { markRetryableCreate } from "./retryable-create.ts";
+
+const PROVIDER = "tama";
+
+/** Bound every short control-plane CLI call (`list`, `rm`, `login`). */
+const CONTROL_PLANE_TIMEOUT_MS = 60_000;
+/** `tama new` does not return until the machine is `ready`, so the OCI pull happens INSIDE it. A cold
+ *  pull of the ~1.5 GiB toolchain image was observed at 2m10s; leave room for a slower first-use host. */
+export const TAMA_CREATE_TIMEOUT_MS = 20 * 60 * 1000;
+/** `new` reports `ready` itself, but adopt-after-ambiguous-create returns whatever `list` shows, so a
+ *  readiness wait still has to exist for that path. */
+const READY_POLL_MS = 3_000;
+const READY_TIMEOUT_MS = 5 * 60 * 1000;
+/** A `rm` can fail transiently after the machine exists. Retry inside create()'s cleanup, because the
+ *  harness has no handle — and therefore no generic teardown path — until create resolves. */
+const CREATE_FAILURE_CLEANUP_ATTEMPTS = 5;
+const CREATE_FAILURE_CLEANUP_RETRY_MS = 2_000;
+/** An ambiguous create is reconciled by NAME (chosen before the request), so a machine whose create
+ *  response was lost is still findable instead of silently billable. */
+const CREATE_RECONCILE_ATTEMPTS = 5;
+const CREATE_RECONCILE_RETRY_MS = 2_000;
+/** Prefix for the caller-owned machine name — the recovery handle, and what makes a benchmark machine
+ *  identifiable in `tama list` and to any account-wide sweep. */
+const RECOVERY_NAME_PREFIX = "sandbox-benchmarks";
+
+/**
+ * Worst-case wall time one `create` can spend before it settles, summed over every bound this adapter
+ * enforces on its longest path: the `new` call, reconciling an ambiguous one, the readiness wait, and
+ * removing a machine that failed readiness.
+ *
+ * Exported because this adapter turns the harness's per-attempt race OFF (`createTimeoutMs: null`, so
+ * its cleanup is never abandoned mid-teardown) and the retry loop still needs to know what an attempt
+ * can cost. Derived from the constants above so tightening one tightens this in the same edit.
+ */
+export const TAMA_CREATE_CEILING_MS =
+	TAMA_CREATE_TIMEOUT_MS +
+	CREATE_RECONCILE_ATTEMPTS * CONTROL_PLANE_TIMEOUT_MS +
+	(CREATE_RECONCILE_ATTEMPTS - 1) * CREATE_RECONCILE_RETRY_MS +
+	READY_TIMEOUT_MS +
+	READY_POLL_MS +
+	CREATE_FAILURE_CLEANUP_ATTEMPTS * CONTROL_PLANE_TIMEOUT_MS +
+	(CREATE_FAILURE_CLEANUP_ATTEMPTS - 1) * CREATE_FAILURE_CLEANUP_RETRY_MS;
+
+/** One machine as `tama --json` reports it. Only the fields this adapter relies on are named; the CLI
+ *  emits more (desktop_url, labels, capabilities) and may add others, so unknown keys are ignored
+ *  rather than rejected. */
+export interface TamaMachine {
+	id: string;
+	name: string;
+	/** `ready` is the only state that accepts exec; the CLI also reports transitional and failed ones. */
+	status: string;
+	status_detail?: string;
+	cpu_millicores?: number;
+	memory_mb?: number;
+	image?: string;
+	gpu?: string;
+	gpu_count?: number;
+}
+
+export interface CliResult {
+	stdout: string;
+	stderr: string;
+	exitCode: number;
+}
+
+/** Test seam: every process spawn and clock read this adapter performs goes through these. */
+export interface TamaComputeOptions {
+	cli?: (args: string[], options?: CliInvokeOptions) => Promise<CliResult>;
+	binary?: string;
+	createTimeoutMs?: number;
+	controlPlaneTimeoutMs?: number;
+	readyPollMs?: number;
+	readyTimeoutMs?: number;
+	cleanupAttempts?: number;
+	cleanupRetryMs?: number;
+	reconcileAttempts?: number;
+	reconcileRetryMs?: number;
+	sleep?: (ms: number) => Promise<void>;
+	now?: () => number;
+	/** Read once per authentication probe; injected so tests never depend on ambient credentials. */
+	token?: () => string | undefined;
+}
+
+export interface CliInvokeOptions {
+	timeoutMs?: number;
+	onStdout?: (chunk: string) => void;
+	onStderr?: (chunk: string) => void;
+}
+
+class CliTimeoutError extends Error {
+	constructor(
+		readonly args: string[],
+		readonly timeoutMs: number,
+	) {
+		super(`tama ${args.join(" ")} did not settle within ${timeoutMs}ms`);
+		this.name = "CliTimeoutError";
+	}
+}
+
+class CliError extends Error {
+	constructor(
+		readonly args: string[],
+		readonly result: CliResult,
+	) {
+		super(
+			`tama ${args.join(" ")} exited ${result.exitCode}: ${
+				result.stderr.trim() || result.stdout.trim() || "(no output)"
+			}`,
+		);
+		this.name = "CliError";
+	}
+}
+
+function sleep(ms: number): Promise<void> {
+	return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+/**
+ * Spawn the CLI and resolve its exit code and captured output. The timeout is enforced by killing the
+ * process (SIGTERM, then SIGKILL): unlike an HTTP client there is nothing to abort, so leaving the
+ * child alive would leak a process that still holds the control-plane operation.
+ */
+function spawnCli(
+	binary: string,
+	args: string[],
+	options: CliInvokeOptions = {},
+): Promise<CliResult> {
+	const timeoutMs = Math.max(1, Math.floor(options.timeoutMs ?? CONTROL_PLANE_TIMEOUT_MS));
+	return new Promise<CliResult>((resolve, reject) => {
+		const child = spawn(binary, args, { stdio: ["ignore", "pipe", "pipe"] });
+		let stdout = "";
+		let stderr = "";
+		let settled = false;
+		const kill = setTimeout(() => {
+			if (settled) return;
+			settled = true;
+			child.kill("SIGTERM");
+			// A CLI wedged in a syscall ignores SIGTERM; escalate so the deadline is real.
+			setTimeout(() => child.kill("SIGKILL"), 5_000).unref?.();
+			reject(new CliTimeoutError(args, timeoutMs));
+		}, timeoutMs);
+		child.stdout.setEncoding("utf8");
+		child.stderr.setEncoding("utf8");
+		child.stdout.on("data", (chunk: string) => {
+			stdout += chunk;
+			options.onStdout?.(chunk);
+		});
+		child.stderr.on("data", (chunk: string) => {
+			stderr += chunk;
+			options.onStderr?.(chunk);
+		});
+		child.on("error", (error) => {
+			if (settled) return;
+			settled = true;
+			clearTimeout(kill);
+			reject(error);
+		});
+		child.on("close", (code) => {
+			if (settled) return;
+			settled = true;
+			clearTimeout(kill);
+			resolve({ stdout, stderr, exitCode: code ?? 1 });
+		});
+	});
+}
+
+/** Single-quote a string for `sh -c`, so a command containing quotes survives the extra shell hop. */
+function shellQuote(value: string): string {
+	return `'${value.replace(/'/g, `'\\''`)}'`;
+}
+
+function errorMessage(error: unknown): string {
+	return error instanceof Error ? error.message : String(error);
+}
+
+/** `tama rm` on an already-deleted machine is a success for teardown purposes, not a failure. */
+function isNotFound(result: CliResult): boolean {
+	return /not found|no such machine|unknown machine/i.test(`${result.stderr} ${result.stdout}`);
+}
+
+function parseMachines(stdout: string): TamaMachine[] {
+	const trimmed = stdout.trim();
+	if (!trimmed) return [];
+	const parsed: unknown = JSON.parse(trimmed);
+	const list = Array.isArray(parsed) ? parsed : [parsed];
+	return list.filter(
+		(entry): entry is TamaMachine =>
+			typeof entry === "object" &&
+			entry !== null &&
+			typeof (entry as TamaMachine).id === "string" &&
+			typeof (entry as TamaMachine).name === "string",
+	);
+}
+
+/** `ready` accepts exec. Terminal failures must stop a readiness wait rather than burn its window. */
+function isTerminalFailure(status: string): boolean {
+	return /^(failed|error|terminated|deleted|gone)$/i.test(status);
+}
+
+function mapStatus(status: string): SandboxInfo["status"] {
+	if (/^ready$/i.test(status)) return "running";
+	if (isTerminalFailure(status)) return "error";
+	// Transitional (creating/starting/snapshotting) and clean stops both report stopped; create() waits
+	// for ready, so getInfo rarely observes a transitional state.
+	return "stopped";
+}
+
+export function createTamaClient(options: TamaComputeOptions) {
+	const binary = options.binary ?? process.env.TAMA_CLI ?? "tama";
+	const invoke = options.cli ?? ((args, invokeOptions) => spawnCli(binary, args, invokeOptions));
+	const wait = options.sleep ?? sleep;
+	const now = options.now ?? Date.now;
+	const controlPlaneTimeoutMs = options.controlPlaneTimeoutMs ?? CONTROL_PLANE_TIMEOUT_MS;
+
+	/** Run a CLI call that is expected to succeed, turning a non-zero exit into a thrown error. */
+	async function checked(args: string[], invokeOptions: CliInvokeOptions = {}): Promise<CliResult> {
+		const result = await invoke(args, {
+			timeoutMs: controlPlaneTimeoutMs,
+			...invokeOptions,
+		});
+		if (result.exitCode !== 0) throw new CliError(args, result);
+		return result;
+	}
+
+	async function list(): Promise<TamaMachine[]> {
+		return parseMachines((await checked(["list", "--json"])).stdout);
+	}
+
+	/**
+	 * Authenticate only when the ambient profile cannot already answer a control-plane call.
+	 *
+	 * `tama login --token` REPLACES the CLI profile's stored credential, so running it unconditionally
+	 * would sign a developer out of their own account as a side effect of running one benchmark. Probing
+	 * first keeps a working local profile untouched and still authenticates a fresh CI runner, where the
+	 * probe is what fails.
+	 */
+	let authenticated: Promise<void> | undefined;
+	function ensureAuthenticated(): Promise<void> {
+		authenticated ??= (async () => {
+			try {
+				await list();
+				return;
+			} catch (probeError) {
+				const token = (options.token ?? (() => process.env.TAMA_TOKEN))();
+				if (!token) {
+					throw new Error(
+						`tama CLI is not authenticated and TAMA_TOKEN is unset (${errorMessage(probeError)}); ` +
+							`run \`tama login\` locally or mint a token with \`tama tokens create\``,
+					);
+				}
+				await checked(["login", "--token", token]);
+			}
+		})();
+		return authenticated;
+	}
+
+	async function getByName(name: string): Promise<TamaMachine | undefined> {
+		return (await list()).find((machine) => machine.name === name);
+	}
+
+	async function getById(id: string): Promise<TamaMachine | undefined> {
+		return (await list()).find((machine) => machine.id === id);
+	}
+
+	async function waitUntilReady(id: string): Promise<TamaMachine> {
+		const pollMs = options.readyPollMs ?? READY_POLL_MS;
+		const deadline = now() + (options.readyTimeoutMs ?? READY_TIMEOUT_MS);
+		let last: TamaMachine | undefined;
+		while (now() < deadline) {
+			last = await getById(id);
+			if (last && /^ready$/i.test(last.status)) return last;
+			if (last && isTerminalFailure(last.status)) {
+				throw new Error(
+					`tama machine ${id} entered terminal state "${last.status}"${
+						last.status_detail ? ` (${last.status_detail})` : ""
+					}`,
+				);
+			}
+			await wait(pollMs);
+		}
+		throw new Error(
+			`tama machine ${id} not ready within the readiness window (last status: ${last?.status ?? "unknown"})`,
+		);
+	}
+
+	async function remove(id: string): Promise<void> {
+		const result = await invoke(["rm", "-y", id], { timeoutMs: controlPlaneTimeoutMs });
+		if (result.exitCode === 0 || isNotFound(result)) return;
+		throw new CliError(["rm", "-y", id], result);
+	}
+
+	/**
+	 * Remove a machine whose readiness wait failed. A rejected `rm` is ambiguous — the request may have
+	 * been accepted before the CLI died — so confirm absence via `list` before retrying, and surface
+	 * exhaustion to create() instead of reducing teardown to one best-effort call that can strand a
+	 * billable machine.
+	 */
+	async function cleanupFailedCreate(id: string): Promise<void> {
+		const attempts = Math.max(
+			1,
+			Math.floor(options.cleanupAttempts ?? CREATE_FAILURE_CLEANUP_ATTEMPTS),
+		);
+		const retryMs = Math.max(0, options.cleanupRetryMs ?? CREATE_FAILURE_CLEANUP_RETRY_MS);
+		let lastError: unknown;
+		for (let attempt = 1; attempt <= attempts; attempt++) {
+			try {
+				await remove(id);
+				return;
+			} catch (error) {
+				lastError = error;
+				try {
+					if (!(await getById(id))) return;
+				} catch {
+					// A failed confirmation is not proof of anything; the next attempt re-asks.
+				}
+				if (attempt < attempts) await wait(retryMs);
+			}
+		}
+		throw lastError;
+	}
+
+	/**
+	 * Resolve what a failed `tama new` actually DID, by looking up the caller-owned name stamped on the
+	 * request. This is a read: unlike replaying `new` it cannot allocate a second machine, and it answers
+	 * the only question that matters — does a machine carrying this name exist?
+	 *
+	 * A lookup that itself fails is not proof of absence, so exhausting the window without a single
+	 * answer reports `unanswered` rather than `absent`: concluding "nothing was created" is what strands
+	 * a billable machine, and that conclusion has to be earned by a lookup that actually answered.
+	 */
+	async function reconcile(
+		name: string,
+	): Promise<
+		| { status: "adopted"; machine: TamaMachine }
+		| { status: "absent" }
+		| { status: "unanswered"; lastError: unknown }
+	> {
+		const attempts = Math.max(
+			1,
+			Math.floor(options.reconcileAttempts ?? CREATE_RECONCILE_ATTEMPTS),
+		);
+		const retryMs = Math.max(0, options.reconcileRetryMs ?? CREATE_RECONCILE_RETRY_MS);
+		let answered = false;
+		let lastError: unknown;
+		for (let attempt = 1; attempt <= attempts; attempt++) {
+			try {
+				const machine = await getByName(name);
+				answered = true;
+				if (machine) return { status: "adopted", machine };
+			} catch (error) {
+				lastError = error;
+			}
+			if (attempt < attempts) await wait(retryMs);
+		}
+		return answered ? { status: "absent" } : { status: "unanswered", lastError };
+	}
+
+	return {
+		binary,
+		invoke,
+		list,
+		getById,
+		getByName,
+		waitUntilReady,
+		remove,
+		cleanupFailedCreate,
+		reconcile,
+		ensureAuthenticated,
+		checked,
+	};
+}
+
+export type TamaClient = ReturnType<typeof createTamaClient>;
+
+/**
+ * Build the `tama new` argument vector from the benchmark's create options.
+ *
+ * `--ttl 0` is not optional: any other value lets the control plane reclaim the machine while a
+ * multi-minute suite is mid-step, and the harness guarantees teardown itself.
+ */
+export function newArgs(name: string, createOptions?: CreateSandboxOptions): string[] {
+	const image = createOptions?.templateId ?? createOptions?.image;
+	const args = ["new", name, "--ttl", "0", "--json"];
+	if (image) args.push("--image", String(image));
+	if (createOptions?.cpu !== undefined) args.push("--cpu", String(createOptions.cpu));
+	// computesdk expresses memory in MiB, which is exactly what --memory takes.
+	if (createOptions?.memory !== undefined) args.push("--memory", String(createOptions.memory));
+	return args;
+}
+
+/**
+ * Compose the in-guest command line. `tama exec` has no `--env` flag, so environment variables are
+ * applied with `env` inside the guest shell; there is no detach flag either, so a background step is
+ * daemonized explicitly and the harness observes the real job through its own done file, exactly as it
+ * does for providers whose SDK also lacks one.
+ */
+export function execCommandLine(command: string, options?: RunCommandOptions): string {
+	const env = options?.env ?? {};
+	const assignments = Object.entries(env).map(
+		([key, value]) => `${key}=${shellQuote(String(value))}`,
+	);
+	const prefixed = assignments.length > 0 ? `env ${assignments.join(" ")} ${command}` : command;
+	return options?.background
+		? `nohup /bin/sh -lc ${shellQuote(prefixed)} </dev/null >/dev/null 2>&1 &`
+		: prefixed;
+}
+
+export function sandboxMethods(
+	adapterOptions: TamaComputeOptions = {},
+): SandboxMethods<TamaMachine, undefined> {
+	const client = createTamaClient(adapterOptions);
+	return {
+		create: async (_config, createOptions?: CreateSandboxOptions) => {
+			if (createOptions?.snapshotId) {
+				// tama does have snapshots, but the benchmark boots the shared toolchain image by ref; a
+				// snapshot id would silently benchmark different content.
+				throw new Error("tama snapshots are not supported by this adapter; pass an image ref");
+			}
+			await client.ensureAuthenticated();
+			// Chosen HERE, before the request: that is what makes it a recovery handle when the response
+			// is lost. A caller-supplied name is kept as a readable prefix and the uuid makes the later
+			// lookup unambiguous.
+			const name = `${createOptions?.name ?? RECOVERY_NAME_PREFIX}-${randomUUID()}`;
+			const args = newArgs(name, createOptions);
+			let machine: TamaMachine | undefined;
+			try {
+				const result = await client.invoke(args, {
+					timeoutMs: adapterOptions.createTimeoutMs ?? TAMA_CREATE_TIMEOUT_MS,
+				});
+				if (result.exitCode !== 0) throw new CliError(args, result);
+				[machine] = parseMachines(result.stdout);
+			} catch (error) {
+				const reconciled = await client.reconcile(name);
+				// Nothing carries this name, so nothing was created and there is nothing to leak. A timed-out
+				// create whose absence IS established is transient and safe to retry; a definite CLI error is
+				// left unmarked so a real misconfiguration fails promptly instead of masquerading as capacity.
+				if (reconciled.status === "absent") {
+					throw error instanceof CliTimeoutError ? markRetryableCreate(error) : error;
+				}
+				if (reconciled.status === "unanswered") {
+					throw new AggregateError(
+						[error, reconciled.lastError],
+						`tama create failed ambiguously (${errorMessage(error)}) and every reconciliation lookup ` +
+							`also failed (${errorMessage(reconciled.lastError)}), so it is unknown whether a machine ` +
+							`was created; if one was it carries the name ${name} and manual cleanup may be required`,
+					);
+				}
+				// A machine exists, so `new` SUCCEEDED and only its output was lost. Adopt it rather than
+				// throwing away a completed image pull; readiness below still gates whether it is usable.
+				machine = reconciled.machine;
+			}
+			if (!machine) {
+				throw new Error(`tama ${args.join(" ")} returned no machine record`);
+			}
+			// `new` blocks until ready, so this is normally one confirming lookup — it exists for the
+			// adopted-after-ambiguous-create path, where the record came from `list` instead.
+			if (!/^ready$/i.test(machine.status)) {
+				try {
+					machine = await client.waitUntilReady(machine.id);
+				} catch (error) {
+					try {
+						await client.cleanupFailedCreate(machine.id);
+					} catch (removeError) {
+						throw new AggregateError(
+							[error, removeError],
+							`tama machine ${machine.id} failed readiness (${errorMessage(error)}) and could not be ` +
+								`removed after retries (${errorMessage(removeError)}); manual cleanup may be required`,
+						);
+					}
+					throw error;
+				}
+			}
+			return { sandbox: machine, sandboxId: machine.id };
+		},
+
+		getById: async (_config, sandboxId) => {
+			const machine = await client.getById(sandboxId);
+			return machine ? { sandbox: machine, sandboxId: machine.id } : null;
+		},
+
+		list: async () =>
+			(await client.list()).map((machine) => ({ sandbox: machine, sandboxId: machine.id })),
+
+		destroy: async (_config, sandboxId) => client.remove(sandboxId),
+
+		runCommand: async (
+			sandbox,
+			command,
+			runOptions?: RunCommandOptions,
+		): Promise<CommandResult> => {
+			const started = Date.now();
+			const args = ["exec"];
+			if (runOptions?.cwd) args.push("--cwd", runOptions.cwd);
+			// Everything after the machine name is the command; the guest shell is explicit so that
+			// pipelines, redirections and `&&` in a step behave as the suites expect.
+			args.push(sandbox.id, "--", "bash", "-lc", execCommandLine(command, runOptions));
+			const result = await client.invoke(args, {
+				timeoutMs: runOptions?.timeout ?? CONTROL_PLANE_TIMEOUT_MS,
+				// A backgrounded launch returns immediately and its output is not the job's, so streaming
+				// callbacks are attached only for a synchronous exec.
+				...(runOptions?.background
+					? {}
+					: { onStdout: runOptions?.onStdout, onStderr: runOptions?.onStderr }),
+			});
+			return {
+				stdout: runOptions?.background ? "" : result.stdout,
+				stderr: runOptions?.background ? "" : result.stderr,
+				exitCode: result.exitCode,
+				durationMs: Date.now() - started,
+			};
+		},
+
+		getUrl: async (sandbox, urlOptions) => {
+			// `tama expose <machine> <port>` publishes a public URL and prints it as prose rather than
+			// JSON, so take the first absolute URL in its output instead of assuming a fixed line shape.
+			const args = ["expose", sandbox.id, String(urlOptions.port)];
+			const result = await client.checked(args);
+			const url = /https?:\/\/\S+/.exec(`${result.stdout}\n${result.stderr}`)?.[0];
+			if (!url) {
+				throw new Error(`tama ${args.join(" ")} published no URL: ${result.stdout.trim()}`);
+			}
+			// Trailing punctuation from the surrounding sentence is not part of the URL.
+			return url.replace(/[.,;)]+$/, "");
+		},
+
+		getInfo: async (sandbox) => {
+			const current = (await client.getById(sandbox.id)) ?? sandbox;
+			return {
+				id: current.id,
+				provider: PROVIDER,
+				status: mapStatus(current.status),
+				// The CLI reports no creation timestamp, and inventing one would put a fabricated value in
+				// the retained record.
+				createdAt: new Date(0),
+				// `--ttl 0` disables idle expiry, so there is no provider-side deadline to report.
+				timeout: 0,
+				metadata: {
+					name: current.name,
+					image: current.image,
+					statusDetail: current.status_detail,
+					cpuMillicores: current.cpu_millicores,
+					memoryMb: current.memory_mb,
+					gpu: current.gpu,
+					gpuCount: current.gpu_count,
+				},
+			};
+		},
+	};
+}
+
+export function tamaCompute(options: TamaComputeOptions = {}) {
+	return defineProvider<TamaMachine, undefined>({
+		name: PROVIDER,
+		methods: { sandbox: sandboxMethods(options) },
+	})(undefined);
+}

--- a/packages/providers/src/lib/tama.ts
+++ b/packages/providers/src/lib/tama.ts
@@ -54,11 +54,18 @@ const RECOVERY_NAME_PREFIX = "sandbox-benchmarks";
  */
 export const TAMA_CREATE_CEILING_MS =
 	TAMA_CREATE_TIMEOUT_MS +
+	// Reconciling an ambiguous create: one bounded `list` per attempt, plus the waits between them.
 	CREATE_RECONCILE_ATTEMPTS * CONTROL_PLANE_TIMEOUT_MS +
 	(CREATE_RECONCILE_ATTEMPTS - 1) * CREATE_RECONCILE_RETRY_MS +
 	READY_TIMEOUT_MS +
 	READY_POLL_MS +
-	CREATE_FAILURE_CLEANUP_ATTEMPTS * CONTROL_PLANE_TIMEOUT_MS +
+	// The readiness DEADLINE is checked before each poll, not during one, so the final lookup can start
+	// a millisecond inside the window and still run to its own timeout. Without this term the ceiling
+	// is one control-plane call short of what the loop can actually spend.
+	CONTROL_PLANE_TIMEOUT_MS +
+	// Each cleanup attempt spends up to TWO bounded calls, not one: `rm`, then the `list` that confirms
+	// absence when `rm` failed ambiguously.
+	CREATE_FAILURE_CLEANUP_ATTEMPTS * 2 * CONTROL_PLANE_TIMEOUT_MS +
 	(CREATE_FAILURE_CLEANUP_ATTEMPTS - 1) * CREATE_FAILURE_CLEANUP_RETRY_MS;
 
 /** One machine as `tama --json` reports it. Only the fields this adapter relies on are named; the CLI
@@ -107,12 +114,31 @@ export interface CliInvokeOptions {
 	onStderr?: (chunk: string) => void;
 }
 
+/** Flags whose VALUE is a credential and must never reach a message. Only `login --token` today; a
+ *  list because the next secret-bearing flag has to be added here, not remembered at the call site. */
+const SECRET_FLAGS = new Set(["--token"]);
+const REDACTED = "<redacted>";
+
+/**
+ * Render an argument vector for a diagnostic with credential values masked.
+ *
+ * Every error this adapter raises quotes the args it ran, and those messages travel further than a
+ * console: into gap markers, run annotations, the job summary and the retained Run document. `tama
+ * login --token <TAMA_TOKEN>` therefore has to be redacted at the point the message is BUILT — a
+ * caller that remembers to sanitize is one forgotten path away from persisting the credential.
+ */
+export function redactArgs(args: string[]): string {
+	return args
+		.map((arg, i) => (i > 0 && SECRET_FLAGS.has(args[i - 1] ?? "") ? REDACTED : arg))
+		.join(" ");
+}
+
 class CliTimeoutError extends Error {
 	constructor(
 		readonly args: string[],
 		readonly timeoutMs: number,
 	) {
-		super(`tama ${args.join(" ")} did not settle within ${timeoutMs}ms`);
+		super(`tama ${redactArgs(args)} did not settle within ${timeoutMs}ms`);
 		this.name = "CliTimeoutError";
 	}
 }
@@ -123,7 +149,7 @@ class CliError extends Error {
 		readonly result: CliResult,
 	) {
 		super(
-			`tama ${args.join(" ")} exited ${result.exitCode}: ${
+			`tama ${redactArgs(args)} exited ${result.exitCode}: ${
 				result.stderr.trim() || result.stdout.trim() || "(no output)"
 			}`,
 		);
@@ -410,16 +436,28 @@ export function newArgs(name: string, createOptions?: CreateSandboxOptions): str
 
 /**
  * Compose the in-guest command line. `tama exec` has no `--env` flag, so environment variables are
- * applied with `env` inside the guest shell; there is no detach flag either, so a background step is
- * daemonized explicitly and the harness observes the real job through its own done file, exactly as it
- * does for providers whose SDK also lacks one.
+ * exported inside the guest shell; there is no detach flag either, so a background step is daemonized
+ * explicitly and the harness observes the real job through its own done file, exactly as it does for
+ * providers whose SDK also lacks one.
+ *
+ * `export …;` rather than an `env K=V <command>` PREFIX, because the command is a shell line and not
+ * an argv: the suites send pipelines, `&&` chains and `cd`. `env K=V cd /repo && make` would hand
+ * `cd` to execve (a builtin no binary implements, so it fails) and leave `make` — a separate command
+ * to the shell — running without the variables that were the point. An export statement applies to
+ * the whole line, builtins included, which is the semantics every other adapter's `env` option has.
  */
 export function execCommandLine(command: string, options?: RunCommandOptions): string {
 	const env = options?.env ?? {};
-	const assignments = Object.entries(env).map(
-		([key, value]) => `${key}=${shellQuote(String(value))}`,
-	);
-	const prefixed = assignments.length > 0 ? `env ${assignments.join(" ")} ${command}` : command;
+	const assignments = Object.entries(env).map(([key, value]) => {
+		// Values are quoted, but a NAME is syntax: an unchecked key composes straight into the shell
+		// line. Nothing in the harness produces one, which is exactly why an odd key should fail here
+		// rather than execute.
+		if (!/^[A-Za-z_][A-Za-z0-9_]*$/.test(key)) {
+			throw new Error(`tama exec: "${key}" is not a valid environment variable name`);
+		}
+		return `${key}=${shellQuote(String(value))}`;
+	});
+	const prefixed = assignments.length > 0 ? `export ${assignments.join(" ")}; ${command}` : command;
 	return options?.background
 		? `nohup /bin/sh -lc ${shellQuote(prefixed)} </dev/null >/dev/null 2>&1 &`
 		: prefixed;
@@ -469,8 +507,30 @@ export function sandboxMethods(
 				// throwing away a completed image pull; readiness below still gates whether it is usable.
 				machine = reconciled.machine;
 			}
+			// A zero exit means `new` ran to completion, so an unusable record ({}, [], a shape without
+			// id/name, or a future output change) is a REPORTING failure, not evidence that nothing was
+			// created — and `new` only exits 0 once the machine is ready, which makes it a billable one.
+			// Take the same reconcile-then-clean path an ambiguous create takes rather than throwing with
+			// no handle: adopt the machine if the name finds it, and if it doesn't, still say what name to
+			// look for. Only an ANSWERED absence is allowed to conclude that nothing leaked.
 			if (!machine) {
-				throw new Error(`tama ${args.join(" ")} returned no machine record`);
+				const reconciled = await client.reconcile(name);
+				if (reconciled.status === "adopted") {
+					machine = reconciled.machine;
+				} else if (reconciled.status === "absent") {
+					throw new Error(
+						`tama ${redactArgs(args)} exited 0 but returned no machine record, and no machine ` +
+							`carries the name ${name}, so none was created`,
+					);
+				} else {
+					throw new AggregateError(
+						[reconciled.lastError],
+						`tama ${redactArgs(args)} exited 0 but returned no machine record, and every ` +
+							`reconciliation lookup also failed (${errorMessage(reconciled.lastError)}), so it is ` +
+							`unknown whether a machine was created; if one was it carries the name ${name} and ` +
+							`manual cleanup may be required`,
+					);
+				}
 			}
 			// `new` blocks until ready, so this is normally one confirming lookup — it exists for the
 			// adopted-after-ambiguous-create path, where the record came from `list` instead.

--- a/packages/schema/src/identifiers.ts
+++ b/packages/schema/src/identifiers.ts
@@ -6,6 +6,6 @@ export type RunId = typeof runIdSchema.infer;
 
 /** Canonical provider ids shared by registries, Runs, and cost cells. */
 export const providerIdSchema = type(
-	"'e2b' | 'daytona-vm' | 'daytona-container' | 'modal-gvisor' | 'modal-vm' | 'blaxel' | 'microsandbox-local' | 'microsandbox-cloud' | 'novita' | 'runloop' | 'namespace' | 'vercel' | 'runcloud'",
+	"'e2b' | 'daytona-vm' | 'daytona-container' | 'modal-gvisor' | 'modal-vm' | 'blaxel' | 'microsandbox-local' | 'microsandbox-cloud' | 'novita' | 'runloop' | 'namespace' | 'vercel' | 'runcloud' | 'tama'",
 );
 export type ProviderId = typeof providerIdSchema.infer;

--- a/packages/schema/src/providers.test.ts
+++ b/packages/schema/src/providers.test.ts
@@ -172,10 +172,13 @@ describe("@sandbox-benchmarks/schema providers", () => {
 		for (const value of ["2026-8-08", "2026-02-30", "not-a-date"]) {
 			expect(isoDateSchema.allows(value)).toBe(false);
 		}
+		// Every citation carries a REAL date, not one hardcoded research day: rates are re-checked per
+		// provider (a provider added later is cited on the day its rate was actually read), so pinning
+		// the data to a single literal would force a new entry to backdate its evidence.
 		for (const provider of PROVIDERS) {
 			if (provider.pricing.model !== "published") continue;
 			for (const source of provider.pricing.sources) {
-				expect(source.checkedAt).toBe("2026-08-08");
+				expect(isoDateSchema.allows(source.checkedAt)).toBe(true);
 			}
 		}
 	});

--- a/packages/schema/src/providers.test.ts
+++ b/packages/schema/src/providers.test.ts
@@ -76,6 +76,7 @@ describe("@sandbox-benchmarks/schema providers", () => {
 			"novita",
 			"runcloud",
 			"runloop",
+			"tama",
 			"vercel",
 		]);
 	});

--- a/packages/schema/src/providers.ts
+++ b/packages/schema/src/providers.ts
@@ -1154,6 +1154,14 @@ const REGISTRY: Record<ProviderId, Omit<ProviderMeta, "id">> = {
 		// No SDK is published for any language; the CLI is the only programmatic surface, so the adapter
 		// drives `tama` as a subprocess and parses its `--json` output.
 		sdkPackage: "tama CLI",
+		// Required, DESPITE the adapter being able to authenticate from an existing `tama login` profile.
+		// requiredEnvVars is the credential gate, and the gate is what turns an unwired provider into a
+		// recorded SKIP instead of a failed cell: a CLI profile is invisible to it, so treating "no token"
+		// as "maybe the profile works" would mean a matrix cell with no credential at all discovers that
+		// by failing to create a sandbox. The profile preference governs whether `tama login --token`
+		// RUNS (it replaces the stored credential, so a developer must not be signed out by a benchmark),
+		// not whether the provider is credentialed. Local devs export a token from `tama tokens create`
+		// — see .env.example.
 		requiredEnvVars: ["TAMA_TOKEN"],
 		isolation: {
 			// Declared from an in-guest probe, because the vendor publishes no isolation claim. Every
@@ -1166,15 +1174,36 @@ const REGISTRY: Record<ProviderId, Omit<ProviderMeta, "id">> = {
 				"Probed, not vendor-declared. CPU and memory are enforced through cgroup v2 (cpu.max, memory.max), but /proc/meminfo reports the HOST's memory (1.5 TiB observed on an 8 GiB request), which is the shared-kernel signature and the reason memory-sized workloads need the effective-spec split.",
 		},
 		pricing: {
-			// `tama offers` publishes a $/hr rate per GPU type and nothing for CPU-only machines, which is
-			// the shape this benchmark's target (4 vCPU / 8 GiB / 40 GB, no GPU) bills under. Deriving a
-			// CPU rate from the GPU box shares would be a guess, and an invented rate is worse than a
-			// disclosed gap, so this stays unavailable until the vendor publishes one.
-			model: "unavailable",
-			reason: "unpublished",
+			// The CPU-only rate the benchmark's target bills under is published on the site's pricing
+			// section — separately from `tama offers`, which lists $/hr per GPU type plus a default box
+			// share (e.g. RTX4090 $0.66/hr, 7cpu/42Gi) and says nothing about a GPU-less machine.
+			model: "published",
+			components: [
+				{
+					id: "cpu",
+					resource: "cpu",
+					// Billed for the seconds the machine is RUNNING, against what it was allocated — a stopped
+					// machine bills nothing, but nothing about the benchmark's own load changes the rate.
+					billingBasis: "provisioned",
+					vendorUnit: "vCPU",
+					usdPerUnitHour: 0.0095,
+					quantityRule: { kind: "linear", dimension: "vcpus", unitsPerTargetUnit: 1 },
+				},
+				{
+					id: "memory",
+					resource: "memory",
+					billingBasis: "provisioned",
+					vendorUnit: "GiB",
+					usdPerUnitHour: 0.0045,
+					quantityRule: { kind: "linear", dimension: "memoryGb", unitsPerTargetUnit: 1 },
+				},
+			],
+			// No disk component: tama exposes no disk knob and prices none, so the target's 40 GB is met
+			// by the shared overlay's capacity rather than by a billable allocation (see specPinning).
+			targetHourlyCost: { kind: "exact", componentIds: ["cpu", "memory"] },
 			notes:
-				"No CPU-only rate is published: `tama offers` lists $/hr per GPU type plus a default box share (e.g. RTX4090 $0.66/hr, 7cpu/42Gi), and the console exposes no rate for a GPU-less machine. Nothing in the CLI or the public site prices the benchmark's 4 vCPU / 8 GiB target.",
-			sources: [{ label: "tama", url: "https://tama.computer", checkedAt: "2026-08-13" }],
+				"Per-second billing for the seconds a machine is running; snapshots and stopped machines are free. The rate is charged on the ALLOCATED size, so the benchmark's 4 vCPU / 8 GiB target costs 4 x $0.0095 + 8 x $0.0045 = $0.074/hr. GPU machines bill a per-card rate instead (`tama offers`), which this CPU-only target never enters.",
+			sources: [{ label: "tama pricing", url: "https://tama.computer", checkedAt: "2026-08-13" }],
 		},
 		maturity: {
 			status: "beta",

--- a/packages/schema/src/providers.ts
+++ b/packages/schema/src/providers.ts
@@ -1148,6 +1148,53 @@ const REGISTRY: Record<ProviderId, Omit<ProviderMeta, "id">> = {
 			detachedPoll: true,
 		},
 	},
+	tama: {
+		displayName: "tama",
+		website: "https://tama.computer",
+		// No SDK is published for any language; the CLI is the only programmatic surface, so the adapter
+		// drives `tama` as a subprocess and parses its `--json` output.
+		sdkPackage: "tama CLI",
+		requiredEnvVars: ["TAMA_TOKEN"],
+		isolation: {
+			// Declared from an in-guest probe, because the vendor publishes no isolation claim. Every
+			// signal points at a shared-kernel container rather than the "machine" the CLI's vocabulary
+			// implies: systemd-detect-virt reports `container-other`, there is no `hypervisor` CPU flag,
+			// /dev/kvm is absent, `/` is an overlay, PID 1 is a vendor `goproc` supervisor, and the DMI
+			// product/vendor is the bare-metal host (COMPAL SR220-2) rather than a synthetic VM board.
+			technology: "container (shared kernel)",
+			notes:
+				"Probed, not vendor-declared. CPU and memory are enforced through cgroup v2 (cpu.max, memory.max), but /proc/meminfo reports the HOST's memory (1.5 TiB observed on an 8 GiB request), which is the shared-kernel signature and the reason memory-sized workloads need the effective-spec split.",
+		},
+		pricing: {
+			// `tama offers` publishes a $/hr rate per GPU type and nothing for CPU-only machines, which is
+			// the shape this benchmark's target (4 vCPU / 8 GiB / 40 GB, no GPU) bills under. Deriving a
+			// CPU rate from the GPU box shares would be a guess, and an invented rate is worse than a
+			// disclosed gap, so this stays unavailable until the vendor publishes one.
+			model: "unavailable",
+			reason: "unpublished",
+			notes:
+				"No CPU-only rate is published: `tama offers` lists $/hr per GPU type plus a default box share (e.g. RTX4090 $0.66/hr, 7cpu/42Gi), and the console exposes no rate for a GPU-less machine. Nothing in the CLI or the public site prices the benchmark's 4 vCPU / 8 GiB target.",
+			sources: [{ label: "tama", url: "https://tama.computer", checkedAt: "2026-08-13" }],
+		},
+		maturity: {
+			status: "beta",
+			notes:
+				"CLI-backed adapter covering create, lifecycle, streaming exec, and teardown; opt-in until a committed validation run exists.",
+		},
+		// `tama new` takes --cpu and --memory. Disk is NOT settable and is not reported per machine: the
+		// observed root filesystem is a large shared overlay (878 GB), so the 40 GB target is cleared by
+		// capacity rather than by a pinned request.
+		specPinning: "settable",
+		transport: {
+			// The adapter spawns the CLI and forwards its stdout/stderr pipes as chunks, so a long exec
+			// stays observable instead of buffering. A 10-minute synchronous exec was validated end to end
+			// (see the adapter), but keep the repository's conservative 60s policy for sustained
+			// synchronous transport: longer work daemonizes and polls the harness-owned done file.
+			streaming: true,
+			syncCapMs: 60_000,
+			detachedPoll: true,
+		},
+	},
 };
 
 // Validate the authored registry exactly once. Consumers thereafter receive trusted inferred pricing


### PR DESCRIPTION
Adds [tama](https://tama.computer) to the provider matrix, following the five steps in `CONTRIBUTING.md#add-a-provider`.

## Why this one is shaped differently

tama publishes **no SDK in any language** — the `tama` binary is the only programmatic surface. So `packages/providers/src/lib/tama.ts` is a `defineProvider` over subprocess calls that parse `--json`, taking the same native-integration path `runcloud.ts` and `vercel.ts` already take for lack of a `@computesdk/*` wrapper.

Because a CLI has no request timeout to configure, an unbounded spawn is the only way this adapter could hang a matrix job, so every call is bounded locally and escalates SIGTERM → SIGKILL. `tama new` does not return until the machine is ready (the ~1.5 GiB toolchain pull happens inside it — 2m10s observed cold), so the adapter owns a bounded readiness wait plus failed-create cleanup and sets `createTimeoutMs: null` with a declared `createAttemptCeilingMs`. An ambiguous create is reconciled by a name chosen *before* the request, so a lost response cannot strand a billable machine.

## Two declarations that are probed, not vendor-claimed

tama publishes neither, so both are recorded with their evidence:

- **Isolation is a shared-kernel container**, not the "machine" the CLI's vocabulary implies: `systemd-detect-virt` → `container-other`, no `hypervisor` CPU flag, `/dev/kvm` absent, `/` an overlay, PID 1 a vendor `goproc`, DMI naming the bare-metal host. CPU/memory are enforced through cgroup v2 — but `/proc/meminfo` reports the **host's** memory (1511.5 GiB observed against an 8 GiB request), the shared-kernel signature. Requesting 8192 MiB also yielded a 10 GiB `memory.max`, so a run will likely trip the ±10% RAM comparability check; that is disclosed rather than papered over.
- ~~**Pricing is `unavailable` / `unpublished`.**~~ **Superseded — pricing is now `published`** (maintainer update, 5714f455). `tama offers` does only list a rate per GPU type plus a default box share (e.g. `RTX4090 0.66 7cpu/42Gi`), but the site's pricing section publishes the CPU-only rate this benchmark's target bills under: **$0.0095/vCPU-hour + $0.0045/GiB-hour**, charged per second while a machine runs, with snapshots and stopped machines free. That derives the 4 vCPU / 8 GiB target to **$0.074/hr** — so it is a cited rate rather than the guess the original gap was disclosed to avoid.

`tama new --image` pulls an arbitrary OCI ref, so the toolchain image boots by ref and there is no artifact to bake (`baseImageUse: "boots"`). Disk is omitted from `createOptions` because tama exposes no disk knob; the observed root filesystem is a large shared overlay (878 GB) that clears the 40 GB workload gate by capacity rather than by a pinned request.

## Live validation

Re-run at the leaderboard's own fan-out — **12 concurrent sandboxes**, matching the methodology every published provider was measured under. Shards were folded with this repo's `aggregate`, spliced into published run [`31066359914`](https://github.com/starslingdev/hpc-sandbox-benchmarks/actions/runs/31066359914) as a composite, and rendered by `apps/cli/src/bin/leaderboard.ts`, so the medians, cluster-bootstrap intervals and Mann-Whitney tie tests below are this repository's own statistics rather than hand-computed ones.

| Task | tama median (10 sandboxes) | 95% interval | Per-box spread | Placing |
| --- | ---: | ---: | ---: | --- |
| cold install *(headline)* | 128.1 s | 80.4 – 239.7 | 40.0 – 241.9 (6.0×) | **12th of 12** |
| git clone | 3.614 s | 3.05 – 5.34 | 2.8 – 7.2 (2.5×) | tied 1st (10-way) |
| lint:format | 145.8 s | 116.2 – 156.6 | 103.2 – 162.0 (1.6×) | 7th of 12 |
| build:core | 156.4 s | 107.9 – 167.4 | 94.3 – 181.6 (1.9×) | tied 8th |

Four-task pipeline **433.9 s — 10th of 12**, ahead of Runloop (457.0) and Modal gVisor (464.4).

> **This supersedes an earlier 3-sandbox reading in this PR** (cold install 40.88 s → 4th of 11; pipeline 244.9 s → 5th of 12). Those values are real but are best-case: they are reproduced by the two fastest of ten machines. Maintainers weighing whether to admit tama to a default matrix should use the numbers above.

**The variance is the material finding, not the placing.** Cold install segregates by host, and values cluster near-identically within each host group — 239.7 / 239.9 / 241.9 across three sandboxes — which is the signature of concurrent sandboxes sharing a saturated host. The 11 sandboxes landed on **5 host fingerprints across 3 CPU models**, split between bare-metal Xeon Gold (reporting 1511 GiB) and AWS Xeon Platinum 8488C instances (61.8 / 123.8 GiB); `observedMixtures` records the split. The two fastest machines match best-in-field install times, so per-machine capability is not the issue — placement under concurrency is. This is worth knowing before tama is added to any default matrix, since the suite is inherently concurrent.

Two further results from the full run:

- The renderer emitted its own comparability warning, confirming the disclosed RAM risk rather than leaving it hypothetical: *"tama's observed compute did not match the requested CPU/RAM target; its observed allocation was 4 vCPU · 10 GiB RAM · 877 GB disk. Its measured ranks are not like-for-like with compute-matched providers."*
- Completion was 10/12 sandboxes: one replicate's PTS install failed silently (exit 0, absent from `list-installed-tests`), one never wrote a shard. Teardown was still clean — **zero leaked machines** across 16 create/destroy cycles, including when the driving process was SIGTERM'd mid-run.

## Notes for maintainers

- A 10-minute synchronous exec was validated end to end, but `transport.syncCapMs` keeps the repository's conservative 60s policy; `detachedPoll` is true.
- The adapter prefers an already-authenticated CLI profile and only adopts `TAMA_TOKEN` when a probe fails, because `tama login --token` *replaces* the stored credential and would otherwise sign a developer out as a side effect of a benchmark. CI needs a `TAMA_TOKEN` secret (mint via `tama tokens create`).
- The **pre-existing, provider-independent** local-mode index bug reported here is real and is now fixed in its own PR, #377 — it turned out to be broader than the replicate path: `bench-suite` kept its index *inside* `data/runs/`, so `relative()` could never produce the `runs/<runId>.json` the invariant demands, and the plain single-sandbox path failed the same way. Nothing in this PR depends on it; a tama cell fails only at that final index write, after the Run document is already written.
- The pre-commit `typos` step could not run locally (no `mise` on this host) and was excluded for the commit; biome passed. CI will cover it.
- Per `CONTRIBUTING.md`, this is not added to any default matrix list — it wants a single-provider branch dispatch first.

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `tama` as a benchmark provider driven by the `tama` CLI. Calls are bounded, create is reconciled by a pre-chosen name to avoid leaks, and pricing is now recorded as published.

- Adapter: subprocess integration with SIGTERM→SIGKILL; pre-chosen name reconciliation; bounded readiness wait and teardown retries; disables harness create race (`createTimeoutMs: null`) and exposes a derived `TAMA_CREATE_CEILING_MS` (~41.3 min); streaming exec with 60s sync cap and detached polling; environment passed via in-guest export (fixes builtins/`&&` chains); secret-bearing CLI args are redacted in diagnostics; prefers an existing CLI profile and only adopts `TAMA_TOKEN` if the probe fails.
- Registry/schema: adds `tama` id and metadata; isolation evidenced as shared-kernel container; pricing marked published with CPU ($0.0095/vCPU-hr) and memory ($0.0045/GiB-hr) components, deriving the 4 vCPU/8 GiB target to $0.074/hr; validates pricing-source dates as real ISO dates per provider.
- Bake/release/CLI: no artifact to bake; `tama new --image` boots the toolchain by ref; CLI exec/export reflected in `bake`, `release-plan`, and validation.
- Workflows/CI: new checksum-pinned `setup-tama` action installs the CLI and asserts version; bench workflows accept `tama` and pass `TAMA_TOKEN`; missing CLI fails fast instead of creating unreachable sandboxes.
- Required action: add a `TAMA_TOKEN` secret minted via `tama tokens create`. Locally, install `tama` and either run `tama login` or set `TAMA_TOKEN`.

<sup>Written for commit 5714f45560e529400c832d844e396ac27a67dc72. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/starslingdev/hpc-sandbox-benchmarks/pull/375?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Tama as a supported compute provider.
  * Enabled running candidate images directly on Tama without separate build artifacts.
  * Added Tama authentication, machine lifecycle management, command execution, readiness checks, and recovery handling.
  * Added configurable CPU, memory, environment variables, working directories, background execution, and URL exposure.
  * Added Tama support to smoke tests, release planning, validation, and provider configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

