### PR TITLE
fix(cli,schema,results): make the local Run index writable again

### DIFF
--- a/.github/workflows/commit-dataset.yml
+++ b/.github/workflows/commit-dataset.yml
@@ -92,10 +92,11 @@ jobs:
       # The globs name the Run documents EXACTLY and must not gain a `data/` segment: the bench cell
       # uploads `path: data/`, and upload-artifact roots the artifact at the least common ancestor of the
       # matched files — so a shard unpacks as `shards/<artifact>/runs/<runId>...json`, with no `data/`
-      # prefix. Two decoys sit next to them that a `runs/*.json` wildcard would sweep in: the sibling
-      # `runs/index.json` (an index, not a Run), and `dataset/runs/<oldRunId>.json` (the committed
-      # dataset, which rides along because it lives under data/, and which the `runs/` segment excludes).
-      # Both would poison the aggregate.
+      # prefix. Two decoys ride along in the artifact that a looser wildcard would sweep in: the local
+      # run index (`index.json`, at the artifact root since it sits at the root of data/ — an index, not
+      # a Run), and `dataset/runs/<oldRunId>.json` (the committed dataset, which rides along because it
+      # lives under data/, and which the `runs/` segment excludes). Both would poison the aggregate;
+      # anchoring every glob on "$RUN_ID" is what keeps them out.
       #
       # TWO shard shapes exist, and they are selected with a PREFERENCE, never unioned:
       #   * `<runId>-r<idx>.json` — the current per-replicate shards (one runner drives all R replicates

--- a/.gitignore
+++ b/.gitignore
@@ -138,6 +138,10 @@ dist
 # dataset lives under data/dataset/ and is committed by the promote step, so it is NOT ignored.
 data/raw/
 data/runs/
+# The local run index that bench-suite maintains beside them. It sits at the root of the data/ tree
+# (a Run index always does — see packages/schema runDocumentPath), so it needs its own entry rather
+# than riding the data/runs/ line above.
+data/index.json
 # Where the in-sandbox producer writes (results_dir in lib/bench.sh): running any
 # `mise run benchmark:**` leaf on a dev machine leaves artifacts here. They belong to the sandbox
 # that produced them — the harness collects them out of the sandbox and the promote step publishes

--- a/apps/cli/src/bin/bench-suite.ts
+++ b/apps/cli/src/bin/bench-suite.ts
@@ -701,11 +701,13 @@ if (import.meta.main) {
 	}
 
 	// The local newest-first Run index, shared by every replicate of this cell — one entry per SHARD,
-	// keyed by (runId, replicateIndex), so a fan-out lists all R sandboxes instead of the last one to
-	// normalize evicting its peers. A local convenience only (`leaderboard data/runs/<id>.json`
-	// discovery). Nothing downstream reads it: the aggregate is handed explicit shard paths, and
-	// commit-dataset.yml globs the shard files by run id. Writes are synchronous (writeNormalizedRun),
-	// so concurrent replicates cannot interleave a read-modify-write and corrupt it.
+	// keyed by (runId, replicateIndex) and by the file each entry names, so a fan-out lists all R
+	// sandboxes instead of the last one to normalize evicting its peers, while the single-sandbox lane
+	// (which rewrites ONE un-suffixed file whatever index it was given) keeps exactly one. A local
+	// convenience only (`leaderboard data/runs/<id>.json` discovery). Nothing downstream reads it: the
+	// aggregate is handed explicit shard paths, and commit-dataset.yml globs the shard files by run id.
+	// Writes are synchronous (writeNormalizedRun), so concurrent replicates cannot interleave a
+	// read-modify-write and corrupt it.
 	//
 	// `data/index.json`, NOT `data/runs/index.json`: a Run index sits at the ROOT of the tree holding
 	// its Runs (the same shape `aggregate` and `promote` write, and the shape RunIndex entry paths are

--- a/apps/cli/src/bin/bench-suite.ts
+++ b/apps/cli/src/bin/bench-suite.ts
@@ -124,7 +124,7 @@ usage: bench-suite [provider] [suite] [runId]
   --help, -h              Show this help.
 
 Missing provider credentials are recorded as a skip (the provider stays "pending"), so this is
-runnable without secrets. Writes the shard Run(s) under data/runs/ and updates data/runs/index.json.
+runnable without secrets. Writes the shard Run(s) under data/runs/ and updates data/index.json.
 
 examples:
   bench-suite daytona-vm cpu-node                 # one suite locally, auto runId
@@ -700,13 +700,18 @@ if (import.meta.main) {
 		}
 	}
 
-	// The local newest-first Run index, shared by every replicate of this cell. It is keyed by runId and
-	// all R shards carry the SAME runId, so the last replicate to normalize wins the entry — a local
-	// convenience only (`leaderboard data/runs/<id>.json` discovery). Nothing downstream reads it: the
-	// aggregate is handed explicit shard paths, and commit-dataset.yml globs the shard files directly.
-	// Writes are synchronous (writeNormalizedRun), so concurrent replicates cannot interleave a
-	// read-modify-write and corrupt it.
-	const indexFile = join("data", "runs", "index.json");
+	// The local newest-first Run index, shared by every replicate of this cell — one entry per SHARD,
+	// keyed by (runId, replicateIndex), so a fan-out lists all R sandboxes instead of the last one to
+	// normalize evicting its peers. A local convenience only (`leaderboard data/runs/<id>.json`
+	// discovery). Nothing downstream reads it: the aggregate is handed explicit shard paths, and
+	// commit-dataset.yml globs the shard files by run id. Writes are synchronous (writeNormalizedRun),
+	// so concurrent replicates cannot interleave a read-modify-write and corrupt it.
+	//
+	// `data/index.json`, NOT `data/runs/index.json`: a Run index sits at the ROOT of the tree holding
+	// its Runs (the same shape `aggregate` and `promote` write, and the shape RunIndex entry paths are
+	// derived for). Nested inside `runs/` it could only ever emit entries the schema rejects, which
+	// failed every local run at the final write — after the benchmark had already succeeded.
+	const indexFile = join("data", "index.json");
 	// The single-sandbox tree/shard, hoisted so the debug payload below can name them. They are the
 	// diagnostic an artifact-path failure is read with — which tree the results were pulled into,
 	// which file they normalized to — and on this path nothing else reports rawRoot at all.

--- a/packages/results/src/lib/write-run.test.ts
+++ b/packages/results/src/lib/write-run.test.ts
@@ -35,6 +35,59 @@ describe("writeNormalizedRun", () => {
 			{ runId: "run-1", generatedAt: "2026-06-20T00:00:00.000Z", path: "runs/run-1.json" },
 		]);
 	});
+
+	// The fan-out lane: R shards of one cell share a runId and differ only by replicate index, so the
+	// index has to hold one entry per SANDBOX. Keyed by the id alone, r1 would evict r0 and the index
+	// would describe a 1-sandbox cell that never happened.
+	it("indexes every replicate shard of one runId, newest first", () => {
+		const shardDir = mkdtempSync(join(tmpdir(), "sandbox-bench-shards-"));
+		const shardIndex = join(shardDir, "index.json");
+		for (const replicateIndex of [0, 1]) {
+			writeNormalizedRun({
+				rawRoot,
+				runId: "fan-1",
+				sha: "abc123",
+				generatedAt: `2026-06-20T00:0${replicateIndex}:00.000Z`,
+				outFile: join(shardDir, "runs", `fan-1-r${replicateIndex}.json`),
+				updateIndexFile: shardIndex,
+				replicateIndex,
+			});
+		}
+		const index = parseRunIndex(JSON.parse(readFileSync(shardIndex, "utf8")));
+		expect(index.runs).toEqual([
+			{
+				runId: "fan-1",
+				generatedAt: "2026-06-20T00:01:00.000Z",
+				path: "runs/fan-1-r1.json",
+				replicateIndex: 1,
+			},
+			{
+				runId: "fan-1",
+				generatedAt: "2026-06-20T00:00:00.000Z",
+				path: "runs/fan-1-r0.json",
+				replicateIndex: 0,
+			},
+		]);
+		rmSync(shardDir, { recursive: true, force: true });
+	});
+
+	// The bug this pairing exists to prevent: an index nested inside runs/ can only ever derive entries
+	// no RunIndex accepts, and it used to surface as an arktype summary AFTER a whole benchmark had run.
+	it("refuses an index that does not sit at the root of its Run tree", () => {
+		const nestedDir = mkdtempSync(join(tmpdir(), "sandbox-bench-nested-"));
+		expect(() =>
+			writeNormalizedRun({
+				rawRoot,
+				runId: "nested-1",
+				sha: "abc123",
+				generatedAt: "2026-06-20T00:00:00.000Z",
+				outFile: join(nestedDir, "runs", "nested-1.json"),
+				// Beside the Run rather than at the root of the tree holding it.
+				updateIndexFile: join(nestedDir, "runs", "index.json"),
+			}),
+		).toThrow(/must sit at the ROOT/);
+		rmSync(nestedDir, { recursive: true, force: true });
+	});
 });
 
 describe("writeRunDocument (publish primitive)", () => {

--- a/packages/results/src/lib/write-run.test.ts
+++ b/packages/results/src/lib/write-run.test.ts
@@ -71,7 +71,56 @@ describe("writeNormalizedRun", () => {
 		rmSync(shardDir, { recursive: true, force: true });
 	});
 
-	// The bug this pairing exists to prevent: an index nested inside runs/ can only ever derive entries
+	// The OTHER lane: `bench-suite --replicate <idx>` drives one sandbox, stamps its index onto the Run,
+	// and deliberately writes the un-suffixed name (commit-dataset.yml's legacy shard shape). Holding it
+	// to the suffixed derivation moved the very failure this PR fixes onto that lane — benchmark green,
+	// shard on disk, process exit 1 at the index write.
+	it("indexes a replicate-stamped Run written under the un-suffixed single-sandbox name", () => {
+		const singleDir = mkdtempSync(join(tmpdir(), "sandbox-bench-single-"));
+		const singleIndex = join(singleDir, "index.json");
+		const outFile = join(singleDir, "runs", "solo-1.json");
+		writeNormalizedRun({
+			rawRoot,
+			runId: "solo-1",
+			sha: "abc123",
+			generatedAt: "2026-06-20T00:00:00.000Z",
+			outFile,
+			updateIndexFile: singleIndex,
+			replicateIndex: 3,
+		});
+		expect(parseRunIndex(JSON.parse(readFileSync(singleIndex, "utf8"))).runs).toEqual([
+			{
+				runId: "solo-1",
+				generatedAt: "2026-06-20T00:00:00.000Z",
+				path: "runs/solo-1.json",
+				replicateIndex: 3,
+			},
+		]);
+
+		// Re-running that lane at a DIFFERENT index overwrites the same file, so the entry it replaces is
+		// the one naming that file — keyed on identity alone, the index would keep a second entry
+		// pointing at a document that now holds another sandbox's results.
+		writeNormalizedRun({
+			rawRoot,
+			runId: "solo-1",
+			sha: "abc123",
+			generatedAt: "2026-06-20T00:05:00.000Z",
+			outFile,
+			updateIndexFile: singleIndex,
+			replicateIndex: 4,
+		});
+		expect(parseRunIndex(JSON.parse(readFileSync(singleIndex, "utf8"))).runs).toEqual([
+			{
+				runId: "solo-1",
+				generatedAt: "2026-06-20T00:05:00.000Z",
+				path: "runs/solo-1.json",
+				replicateIndex: 4,
+			},
+		]);
+		rmSync(singleDir, { recursive: true, force: true });
+	});
+
+	// The bug this pairing exists to prevent: an index nested inside runs/ can only ever produce entries
 	// no RunIndex accepts, and it used to surface as an arktype summary AFTER a whole benchmark had run.
 	it("refuses an index that does not sit at the root of its Run tree", () => {
 		const nestedDir = mkdtempSync(join(tmpdir(), "sandbox-bench-nested-"));
@@ -87,6 +136,26 @@ describe("writeNormalizedRun", () => {
 			}),
 		).toThrow(/must sit at the ROOT/);
 		rmSync(nestedDir, { recursive: true, force: true });
+	});
+
+	// A correctly placed index handed a Run under a name its identity does not allow is a DIFFERENT
+	// mistake from a misplaced index, and saying "the index is in the wrong place" about a perfectly
+	// placed index is what sent the last reader looking in the wrong direction.
+	it("names the accepted filenames when the Run document is misnamed", () => {
+		const oddDir = mkdtempSync(join(tmpdir(), "sandbox-bench-odd-"));
+		expect(() =>
+			writeNormalizedRun({
+				rawRoot,
+				runId: "odd-1",
+				sha: "abc123",
+				generatedAt: "2026-06-20T00:00:00.000Z",
+				outFile: join(oddDir, "runs", "odd-1-r9.json"),
+				updateIndexFile: join(oddDir, "index.json"),
+				// The file claims replicate 9; the Run carries replicate 2.
+				replicateIndex: 2,
+			}),
+		).toThrow(/must be written as "runs\/odd-1-r2.json" or "runs\/odd-1.json"/);
+		rmSync(oddDir, { recursive: true, force: true });
 	});
 });
 

--- a/packages/results/src/lib/write-run.ts
+++ b/packages/results/src/lib/write-run.ts
@@ -5,7 +5,7 @@
 import { mkdirSync, readFileSync, renameSync, writeFileSync } from "node:fs";
 import { dirname, relative, resolve } from "node:path";
 import type { Run, RunIndex } from "@sandbox-benchmarks/schema";
-import { parseRunIndex, providerStatusText } from "@sandbox-benchmarks/schema";
+import { parseRunIndex, providerStatusText, runDocumentPath } from "@sandbox-benchmarks/schema";
 import { normalizeResultsTree } from "./normalize-tree.ts";
 
 /**
@@ -45,15 +45,37 @@ export function updateRunIndex(indexPath: string, run: Run, runFilePath: string)
 		existing = { schemaVersion: "1", runs: [] };
 	}
 
+	// DERIVED from the Run, never measured off the filesystem: the index entry states where a Run of
+	// this identity belongs, and `runDocumentPath` is the same derivation the schema checks it against.
+	// Computing it with relative() instead is what silently produced entries no RunIndex could accept
+	// once the index was written anywhere but the root of its tree.
+	const path = runDocumentPath(run.runId, run.replicateIndex);
 	const entry = {
 		runId: run.runId,
 		generatedAt: run.generatedAt,
-		// Forward slashes so the index stays portable (relative() yields backslashes on Windows).
-		path: relative(dirname(indexPath), runFilePath).replaceAll("\\", "/"),
+		path,
+		...(run.replicateIndex !== undefined ? { replicateIndex: run.replicateIndex } : {}),
 	};
+	// The derivation is only true of a tree whose index sits at its root, so hold the caller to that
+	// here — with the two paths named — rather than letting a misplaced index emit an entry that
+	// resolves nowhere and fails deep inside an arktype summary. Forward slashes so the comparison
+	// (and the entry) stay portable: relative() yields backslashes on Windows.
+	const actual = relative(dirname(indexPath), runFilePath).replaceAll("\\", "/");
+	if (actual !== path) {
+		throw new Error(
+			`RunIndex ${indexPath} cannot describe ${runFilePath}: a Run index must sit at the ROOT of ` +
+				`the tree holding its Runs, so this Run belongs at "${path}" relative to the index but ` +
+				`resolves to "${actual}"`,
+		);
+	}
+	// Keyed by (runId, replicateIndex): every shard of a fan-out carries the SAME runId, so keying on
+	// the id alone would let the last replicate to normalize evict its peers and leave the index
+	// claiming a one-sandbox cell.
+	const supersedes = (r: RunIndex["runs"][number]): boolean =>
+		r.runId === run.runId && r.replicateIndex === run.replicateIndex;
 	// Fixed "en" locale: ISO-8601 strings sort lexicographically === chronologically, regardless of
 	// the runtime's default collation.
-	const runs = [entry, ...existing.runs.filter((r) => r.runId !== run.runId)].sort((a, b) =>
+	const runs = [entry, ...existing.runs.filter((r) => !supersedes(r))].sort((a, b) =>
 		b.generatedAt.localeCompare(a.generatedAt, "en"),
 	);
 	const index = parseRunIndex({ schemaVersion: "1", runs });

--- a/packages/results/src/lib/write-run.ts
+++ b/packages/results/src/lib/write-run.ts
@@ -5,7 +5,7 @@
 import { mkdirSync, readFileSync, renameSync, writeFileSync } from "node:fs";
 import { dirname, relative, resolve } from "node:path";
 import type { Run, RunIndex } from "@sandbox-benchmarks/schema";
-import { parseRunIndex, providerStatusText, runDocumentPath } from "@sandbox-benchmarks/schema";
+import { parseRunIndex, providerStatusText, runDocumentPaths } from "@sandbox-benchmarks/schema";
 import { normalizeResultsTree } from "./normalize-tree.ts";
 
 /**
@@ -32,7 +32,7 @@ export interface WriteNormalizedRunInput {
 	replicateIndex?: number;
 }
 
-/** Insert a Run into the index (newest first, de-duplicated by runId) and rewrite the index file. */
+/** Insert a Run into the index (newest first, one entry per replicate sandbox) and rewrite the file. */
 export function updateRunIndex(indexPath: string, run: Run, runFilePath: string): RunIndex {
 	// Read-and-parse directly rather than existsSync-then-read: a TOCTOU gap there could throw ENOENT
 	// after the Run JSON was already written, orphaning it from the index. A missing index is the
@@ -45,34 +45,49 @@ export function updateRunIndex(indexPath: string, run: Run, runFilePath: string)
 		existing = { schemaVersion: "1", runs: [] };
 	}
 
-	// DERIVED from the Run, never measured off the filesystem: the index entry states where a Run of
-	// this identity belongs, and `runDocumentPath` is the same derivation the schema checks it against.
-	// Computing it with relative() instead is what silently produced entries no RunIndex could accept
-	// once the index was written anywhere but the root of its tree.
-	const path = runDocumentPath(run.runId, run.replicateIndex);
+	// The entry records where the Run document ACTUALLY is — an index whose path is derived rather than
+	// measured can name a file that was never written — but it is admitted only if that location is one
+	// the Run's identity allows (`runDocumentPaths`, the same rule the schema re-checks it against).
+	// Measuring without checking is how entries no RunIndex accepts reached the schema in the first
+	// place; checking against a single derived name is how the un-suffixed single-sandbox shard, whose
+	// filename is a downstream contract, stopped being writable. Forward slashes so the comparison (and
+	// the entry) stay portable: relative() yields backslashes on Windows.
+	const path = relative(dirname(indexPath), runFilePath).replaceAll("\\", "/");
+	const allowed = runDocumentPaths(run.runId, run.replicateIndex);
+	if (!allowed.includes(path)) {
+		const identity =
+			run.replicateIndex === undefined
+				? `Run ${run.runId}`
+				: `Run ${run.runId} replicate ${run.replicateIndex}`;
+		// Two different mistakes, named apart: an index parked somewhere other than the root of its tree
+		// (every Run then resolves outside `runs/`, and NOTHING it could write would validate), versus a
+		// correctly placed index handed a Run document under an unexpected name. Reported here, at the
+		// call that can still say which two paths disagree, rather than as an arktype summary surfacing
+		// from deep inside a write that has already put the Run on disk.
+		throw new Error(
+			path.startsWith("runs/")
+				? `RunIndex ${indexPath} cannot describe ${runFilePath}: ${identity} must be written as ` +
+						`${allowed.map((p) => `"${p}"`).join(" or ")} relative to its index, but this one ` +
+						`resolves to "${path}"`
+				: `RunIndex ${indexPath} cannot describe ${runFilePath}: a Run index must sit at the ROOT ` +
+						`of the tree holding its Runs (which live under "runs/"), but this Run resolves to ` +
+						`"${path}" relative to the index`,
+		);
+	}
 	const entry = {
 		runId: run.runId,
 		generatedAt: run.generatedAt,
 		path,
 		...(run.replicateIndex !== undefined ? { replicateIndex: run.replicateIndex } : {}),
 	};
-	// The derivation is only true of a tree whose index sits at its root, so hold the caller to that
-	// here — with the two paths named — rather than letting a misplaced index emit an entry that
-	// resolves nowhere and fails deep inside an arktype summary. Forward slashes so the comparison
-	// (and the entry) stay portable: relative() yields backslashes on Windows.
-	const actual = relative(dirname(indexPath), runFilePath).replaceAll("\\", "/");
-	if (actual !== path) {
-		throw new Error(
-			`RunIndex ${indexPath} cannot describe ${runFilePath}: a Run index must sit at the ROOT of ` +
-				`the tree holding its Runs, so this Run belongs at "${path}" relative to the index but ` +
-				`resolves to "${actual}"`,
-		);
-	}
-	// Keyed by (runId, replicateIndex): every shard of a fan-out carries the SAME runId, so keying on
-	// the id alone would let the last replicate to normalize evict its peers and leave the index
-	// claiming a one-sandbox cell.
+	// Superseded by IDENTITY or by LOCATION, and it has to be both. Identity, because every shard of a
+	// fan-out carries the same runId — keying on the id alone would let the last replicate to normalize
+	// evict its peers and leave the index claiming a one-sandbox cell. Location, because the two lanes
+	// can write the same sandbox under different names (and successive `--replicate <idx>` runs write
+	// DIFFERENT indices to the same un-suffixed file): without it the index would keep a stale entry
+	// pointing at a document that has since been overwritten by another replicate's results.
 	const supersedes = (r: RunIndex["runs"][number]): boolean =>
-		r.runId === run.runId && r.replicateIndex === run.replicateIndex;
+		(r.runId === run.runId && r.replicateIndex === run.replicateIndex) || r.path === path;
 	// Fixed "en" locale: ISO-8601 strings sort lexicographically === chronologically, regardless of
 	// the runtime's default collation.
 	const runs = [entry, ...existing.runs.filter((r) => !supersedes(r))].sort((a, b) =>

--- a/packages/schema/src/run.test.ts
+++ b/packages/schema/src/run.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "bun:test";
-import { parseRun, parseRunIndex, runDocumentPath } from "./index.ts";
+import { parseRun, parseRunIndex, runDocumentPath, runDocumentPaths } from "./index.ts";
 
 const validRun = {
 	schemaVersion: "2",
@@ -637,12 +637,50 @@ describe("Run schema", () => {
 		for (const entry of [
 			{ path: "runs/run-1-r2.json", replicateIndex: 3 },
 			{ path: "runs/run-1-r2.json" },
-			{ path: "runs/run-1.json", replicateIndex: 2 },
+			{ path: "runs/run-2.json" },
+			{ path: "run-1.json" },
 		]) {
 			expect(() =>
 				parseRunIndex({
 					schemaVersion: "1",
 					runs: [{ runId: "run-1", generatedAt: "2026-06-20T00:00:00.000Z", ...entry }],
+				}),
+			).toThrow(/invalid RunIndex/);
+		}
+	});
+
+	// The single-sandbox lane (`bench-suite --replicate <idx>`) stamps a replicate index onto the Run
+	// but keeps the UN-suffixed filename, which commit-dataset.yml reads as the legacy shard shape. A
+	// one-name-per-identity rule outlaws that pairing, and the lane then dies at its final write —
+	// after the whole benchmark has run. Both names are legal for a replicate-stamped Run; a Run with
+	// no replicate index still has exactly one, which is what keeps the dataset invariant intact.
+	it("accepts either the suffixed or the un-suffixed name for a replicate-stamped Run", () => {
+		expect(runDocumentPaths("run-1")).toEqual(["runs/run-1.json"]);
+		expect(runDocumentPaths("run-1", 3)).toEqual(["runs/run-1-r3.json", "runs/run-1.json"]);
+
+		const index = parseRunIndex({
+			schemaVersion: "1",
+			runs: [
+				{
+					runId: "run-1",
+					generatedAt: "2026-06-20T00:00:00.000Z",
+					path: "runs/run-1.json",
+					replicateIndex: 3,
+				},
+			],
+		});
+		expect(index.runs[0]?.path).toBe("runs/run-1.json");
+	});
+
+	// The dataset index is the published artifact update-leaderboard.yml resolves a run through, and
+	// its entries never carry a replicate index (a promoted Run spans every replicate). Nothing about
+	// the shard names above may loosen what IT accepts.
+	it("still admits exactly one path for an entry that declares no replicate index", () => {
+		for (const path of ["runs/run-1-r0.json", "runs/run-1-r.json", "runs/run-1-rx.json"]) {
+			expect(() =>
+				parseRunIndex({
+					schemaVersion: "1",
+					runs: [{ runId: "run-1", generatedAt: "2026-06-20T00:00:00.000Z", path }],
 				}),
 			).toThrow(/invalid RunIndex/);
 		}

--- a/packages/schema/src/run.test.ts
+++ b/packages/schema/src/run.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "bun:test";
-import { parseRun, parseRunIndex } from "./index.ts";
+import { parseRun, parseRunIndex, runDocumentPath } from "./index.ts";
 
 const validRun = {
 	schemaVersion: "2",
@@ -610,6 +610,39 @@ describe("Run schema", () => {
 				parseRunIndex({
 					schemaVersion: "1",
 					runs: [{ runId: "run-1", generatedAt: "2026-06-20T00:00:00.000Z", path }],
+				}),
+			).toThrow(/invalid RunIndex/);
+		}
+	});
+
+	it("derives a replicate shard's path from its runId AND its replicate index", () => {
+		expect(runDocumentPath("run-1")).toBe("runs/run-1.json");
+		expect(runDocumentPath("run-1", 0)).toBe("runs/run-1-r0.json");
+
+		const index = parseRunIndex({
+			schemaVersion: "1",
+			runs: [
+				{
+					runId: "run-1",
+					generatedAt: "2026-06-20T00:00:00.000Z",
+					path: "runs/run-1-r2.json",
+					replicateIndex: 2,
+				},
+			],
+		});
+		expect(index.runs[0]?.replicateIndex).toBe(2);
+
+		// The suffix is not free-floating: it has to be the entry's OWN replicate index, and an entry
+		// that declares none is still held to the un-suffixed name.
+		for (const entry of [
+			{ path: "runs/run-1-r2.json", replicateIndex: 3 },
+			{ path: "runs/run-1-r2.json" },
+			{ path: "runs/run-1.json", replicateIndex: 2 },
+		]) {
+			expect(() =>
+				parseRunIndex({
+					schemaVersion: "1",
+					runs: [{ runId: "run-1", generatedAt: "2026-06-20T00:00:00.000Z", ...entry }],
 				}),
 			).toThrow(/invalid RunIndex/);
 		}

--- a/packages/schema/src/run.ts
+++ b/packages/schema/src/run.ts
@@ -428,13 +428,35 @@ export const targetSpecSchema = type({
 });
 export type TargetSpec = typeof targetSpecSchema.infer;
 
-/** A RunIndex entry whose path is derived solely from, and cannot disagree with, its Run id. */
+/**
+ * Where a Run document lives relative to the ROOT of the tree that holds it — the one derivation both
+ * the RunIndex invariant below and the index writer read, so the two cannot drift into the
+ * disagreement that made a whole lane unwritable (a writer computing the path from the filesystem
+ * while the schema demanded a derivation).
+ *
+ * "Relative to the root", not to the index file: an index sits at the root of a tree whose Runs are
+ * under `runs/` (`data/index.json` + `data/runs/…`, `data/dataset/index.json` +
+ * `data/dataset/runs/…`), which is what makes one rule describe every index this repo writes.
+ *
+ * A per-replicate SHARD is named by the same identity its Run carries — shards of one cell share a
+ * runId and are told apart by `replicateIndex`, so the index can list all R of them instead of
+ * letting the last one to normalize overwrite its peers' entry.
+ */
+export function runDocumentPath(runId: string, replicateIndex?: number): string {
+	return `runs/${runId}${replicateIndex === undefined ? "" : `-r${replicateIndex}`}.json`;
+}
+
+/** A RunIndex entry whose path is derived solely from, and cannot disagree with, its Run's identity
+ *  (its id, plus the replicate index when the entry describes one shard of a fan-out). */
 export const runIndexEntrySchema = type({
 	runId: runIdSchema,
 	generatedAt: "string.date.iso",
 	path: "string >= 1",
+	// Present only for a per-replicate shard entry, mirroring `Run.replicateIndex`. A promoted dataset
+	// Run spans every replicate and carries none, so dataset index entries are unchanged by this field.
+	"replicateIndex?": "number.integer >= 0",
 }).narrow((entry, ctx) => {
-	const expected = `runs/${entry.runId}.json`;
+	const expected = runDocumentPath(entry.runId, entry.replicateIndex);
 	return entry.path === expected || ctx.mustBe(`a RunIndex entry whose path is ${expected}`);
 });
 export type RunIndexEntry = typeof runIndexEntrySchema.infer;

--- a/packages/schema/src/run.ts
+++ b/packages/schema/src/run.ts
@@ -429,10 +429,11 @@ export const targetSpecSchema = type({
 export type TargetSpec = typeof targetSpecSchema.infer;
 
 /**
- * Where a Run document lives relative to the ROOT of the tree that holds it — the one derivation both
- * the RunIndex invariant below and the index writer read, so the two cannot drift into the
- * disagreement that made a whole lane unwritable (a writer computing the path from the filesystem
- * while the schema demanded a derivation).
+ * Where a Run document of this identity is written, relative to the ROOT of the tree that holds it —
+ * the CANONICAL name. It and {@link runDocumentPaths} are the one derivation both the RunIndex
+ * invariant below and the index writer read, so the two cannot drift into the disagreement that made
+ * a whole lane unwritable (a writer computing the path from the filesystem while the schema demanded
+ * a derivation).
  *
  * "Relative to the root", not to the index file: an index sits at the root of a tree whose Runs are
  * under `runs/` (`data/index.json` + `data/runs/…`, `data/dataset/index.json` +
@@ -446,8 +447,34 @@ export function runDocumentPath(runId: string, replicateIndex?: number): string 
 	return `runs/${runId}${replicateIndex === undefined ? "" : `-r${replicateIndex}`}.json`;
 }
 
-/** A RunIndex entry whose path is derived solely from, and cannot disagree with, its Run's identity
- *  (its id, plus the replicate index when the entry describes one shard of a fan-out). */
+/**
+ * Every name a Run document of this identity may legally carry, canonical first.
+ *
+ * A replicate-stamped Run has TWO legal names, because the harness has two lanes and they disagree
+ * on the filename by design:
+ *
+ *  - `runs/<runId>-r<idx>.json` — the fan-out lane (`bench-suite --replicates`), where R shards share
+ *    one runId inside one cell and only the suffix tells the sandboxes apart.
+ *  - `runs/<runId>.json` — the single-sandbox lane (`bench-suite --replicate <idx>`), which stamps
+ *    the index onto the Run but deliberately keeps the UN-suffixed name. That name is a downstream
+ *    contract, not an oversight: commit-dataset.yml reads it as the legacy shard shape when
+ *    re-aggregating a run whose artifacts predate the fan-out.
+ *
+ * So the filename is not a function of the identity alone, and a derivation that pretends otherwise
+ * rejects one of the two lanes outright — which is exactly how the single lane started failing after
+ * its benchmark had already succeeded. Membership in this set is the check; the ENTRY still records
+ * the name the file actually has, so an index never points at a document that isn't there.
+ *
+ * An entry with no `replicateIndex` (every promoted dataset entry) keeps exactly one legal name, so
+ * the dataset invariant — and the path guard update-leaderboard.yml re-applies to it — is unchanged.
+ */
+export function runDocumentPaths(runId: string, replicateIndex?: number): readonly string[] {
+	const canonical = runDocumentPath(runId, replicateIndex);
+	return replicateIndex === undefined ? [canonical] : [canonical, runDocumentPath(runId)];
+}
+
+/** A RunIndex entry whose path is one of the names its Run's identity allows (its id, plus the
+ *  replicate index when the entry describes one shard of a fan-out) — never a free-form path. */
 export const runIndexEntrySchema = type({
 	runId: runIdSchema,
 	generatedAt: "string.date.iso",
@@ -456,8 +483,11 @@ export const runIndexEntrySchema = type({
 	// Run spans every replicate and carries none, so dataset index entries are unchanged by this field.
 	"replicateIndex?": "number.integer >= 0",
 }).narrow((entry, ctx) => {
-	const expected = runDocumentPath(entry.runId, entry.replicateIndex);
-	return entry.path === expected || ctx.mustBe(`a RunIndex entry whose path is ${expected}`);
+	// Derived, never free-form: `runIdSchema` already rejects path syntax in an id and the replicate
+	// index is a non-negative integer, so no accepted name can escape `runs/` or traverse upward.
+	const allowed = runDocumentPaths(entry.runId, entry.replicateIndex);
+	if (allowed.includes(entry.path)) return true;
+	return ctx.mustBe(`a RunIndex entry whose path is ${allowed.map((p) => `"${p}"`).join(" or ")}`);
 });
 export type RunIndexEntry = typeof runIndexEntrySchema.infer;
 


### PR DESCRIPTION
Provider-independent; found while smoke-testing #375 locally, but nothing here is tama-specific.

## The break

Every `bench-suite` run has exited 1 at its final step since the RunIndex path invariant landed in #356 — *after* the benchmark succeeded and the shard Run was already on disk:

```
Suite "memory" completed on tama
::error::invalid RunIndex: runs[0] must be a RunIndex entry whose path is
  runs/smoke-tama-memory-20260813-222658.json
  (was {... "path":"smoke-tama-memory-20260813-222658.json"})
```

`runIndexEntrySchema` narrows `path` to `runs/<runId>.json`, but `bench-suite` maintained its index *inside* that directory (`data/runs/index.json`), so `updateRunIndex`'s `relative(dirname(index), runFile)` could only ever yield `<runId>.json`. It was unsatisfiable by construction, for every provider and both lanes. A stale index written before the invariant then fails to parse and blocks the *next* run too, which is why the symptom outlives a single bad run. CI hits it as well: [run 31779195159](https://github.com/starslingdev/hpc-sandbox-benchmarks/actions/runs/31779195159) failed the cell at `Normalize Run document` with the shard already written and uploaded.

`aggregate` and `promote` were never affected — both already write the index at the root of the tree holding `runs/` (`outDir/index.json` + `outDir/runs/…`), which is the convention `write-run.test.ts` has always asserted. This restores it in the one place that diverged.

## The fix

- **One rule, shared.** `runDocumentPaths(runId, replicateIndex?)` is read by both the schema invariant and the index writer. A writer that computed the path from the filesystem while the schema demanded a derivation is exactly how the two drifted apart.
- **Two legal names, because there are two lanes.** A Run document's name is not a function of its identity alone. The fan-out (`--replicates`) writes `runs/<runId>-r<idx>.json`; the single-sandbox lane (`--replicate <idx>`) stamps the replicate index onto the Run but keeps the **un-suffixed** `runs/<runId>.json`, which `commit-dataset.yml` reads as the legacy shard shape when re-aggregating an older run's retained artifacts. So a replicate-stamped Run has two legal names and an unstamped one has exactly one — which is what leaves the dataset index, and the path guard `update-leaderboard.yml` re-applies to it, untouched.
- **Measured, then checked.** The entry records the path the document *actually* has — an index whose path is derived rather than measured can name a file that was never written — and is admitted only if the Run's identity allows that name. A misplaced index and a misnamed Run document are reported as the different mistakes they are, with both paths named, instead of an arktype summary surfacing from deep inside a write.
- **Replicate shards are representable.** Entries carry an optional `replicateIndex` mirroring `Run.replicateIndex`. Keying on `(runId, replicateIndex)` retires the "last replicate to normalize wins" quirk — the index lists every sandbox of a cell instead of one arbitrary survivor — and keying *also* on the entry's path keeps successive `--replicate` runs over one file from leaving a stale twin.
- **`bench-suite` writes `data/index.json`** (gitignored), matching `aggregate` and `promote`.

## Compatibility

Dataset entries are byte-identical: a promoted Run spans every replicate and carries no `replicateIndex`, so the new field is absent from everything under `data/dataset/`, and an entry without it still admits exactly one path. `commit-dataset.yml`'s shard globs are anchored on `$RUN_ID` and never matched `index.json` in either location; its comment is updated to describe where the decoy now sits. No migration required — if a `data/runs/index.json` is lying around from before, delete it.

## Testing

`bun run typecheck`, `bun run test` (all members), `bun run lint` — all green.

Covered: a fan-out writing two shards under one runId indexes both newest-first; the single lane's replicate-stamped un-suffixed shard indexes, and re-running it at another index replaces rather than duplicates the entry; an index nested inside `runs/` is refused with the placement error; a misnamed document is refused with the accepted names; the schema accepts either name for a replicate-stamped entry and still only one for an unstamped entry.

Verified end to end against every lane a cell can take — `--replicate 3`, plain single, `--replicates 0,1`, then `aggregate` over the two shards — all exit 0, with the resulting `data/index.json` listing all four shards newest-first and the candidate index naming the merged `runs/<runId>.json`.

<sub>Updated by [Claude Code](https://claude.ai/code) for commit 3d061a4.</sub>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Run indexes now support multiple replicates per benchmark run, preserving each replicate separately and ordering entries newest first.
  - Added validation for canonical and replicate-specific run file paths, with clearer errors for invalid filenames or locations.
  - Updated CLI guidance to reference the root-level `data/index.json` and explain per-shard indexing.

- **Bug Fixes**
  - Shard aggregation now limits artifact matching to the selected run, avoiding local indexes and files from older runs.
  - Local run indexes are ignored by version control.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->