### PR TITLE
fix(ci): install pinned tama CLI archive

### DIFF
--- a/.github/actions/setup-tama/action.yml
+++ b/.github/actions/setup-tama/action.yml
@@ -3,7 +3,7 @@ description: Install the checksum-pinned tama CLI onto the runner, because the a
 
 inputs:
   version:
-    description: Expected `tama --version`, asserted after install so a moved release is visible.
+    description: Immutable tama release selected in the download URL and asserted after install.
     default: 0.1.17
   sha256:
     description: sha256 of tama-x86_64-unknown-linux-gnu.tar.gz, verified against our own copy.
@@ -17,4 +17,7 @@ runs:
       env:
         TAMA_VERSION: ${{ inputs.version }}
         TAMA_SHA256: ${{ inputs.sha256 }}
-      run: "${GITHUB_ACTION_PATH}/install.sh"
+        TAMA_INSTALL_DIR: ${{ runner.temp }}/tama/bin
+      run: |
+        bash "${GITHUB_ACTION_PATH}/install.sh"
+        echo "${TAMA_INSTALL_DIR}" >> "$GITHUB_PATH"

--- a/.github/actions/setup-tama/install.sh
+++ b/.github/actions/setup-tama/install.sh
@@ -8,14 +8,13 @@
 # truncated, not that the bytes are the ones anyone reviewed. So the archive is fetched directly and
 # checked against a sha256 committed to THIS repo, the same posture as the pinned mise/PTS artifacts.
 #
-# tama serves only `downloads/latest` — a versioned path returns the marketing SPA with a 200 — so the
-# pin cannot ride the URL and a new upstream release WILL fail this step. That is the intended
-# failure: refresh the pin in action.yml (the command is in the error below) rather than run an
-# unreviewed binary that creates billable machines.
+# tama retains archives under `downloads/<version>`, so select the immutable release in the URL as
+# well as checking its archive against the sha256 committed to this repo. The independent checksum
+# still protects against an upstream release being silently replaced.
 set -euo pipefail
 
 archive="tama-x86_64-unknown-linux-gnu.tar.gz"
-url="https://tama.computer/downloads/latest/${archive}"
+url="https://tama.computer/downloads/${TAMA_VERSION}/${archive}"
 workdir="$(mktemp -d "${RUNNER_TEMP:-/tmp}/tama-install.XXXXXX")"
 trap 'rm -rf "$workdir"' EXIT
 
@@ -27,20 +26,21 @@ if [[ "$observed" != "$TAMA_SHA256" ]]; then
 		tama CLI checksum mismatch for ${url}
 		  expected ${TAMA_SHA256}
 		  observed ${observed}
-		tama serves a single moving "latest" build, so this is most likely a new release rather than a
-		compromised download. Verify the release, then refresh the pin in
-		.github/actions/setup-tama/action.yml:
+		The versioned tama archive no longer matches the checksum committed to this repository.
+		Verify the release before refreshing the pin in .github/actions/setup-tama/action.yml:
 		  curl -fsSL ${url} | sha256sum
 	EOF
 	exit 1
 fi
 
 tar -xzf "${workdir}/${archive}" -C "$workdir"
-install -m 0755 "${workdir}/tama" /usr/local/bin/tama
+install_dir="${TAMA_INSTALL_DIR:-/usr/local/bin}"
+mkdir -p "$install_dir"
+install -m 0755 "${workdir}/tama" "${install_dir}/tama"
 
 # The pin is on the ARCHIVE; assert the version it unpacks to as well, so the log records exactly
 # which CLI drove the run and a silently re-cut release under the same hash cannot pass unnoticed.
-observed_version="$(tama --version | awk '{print $2}')"
+observed_version="$("${install_dir}/tama" --version | awk '{print $2}')"
 if [[ "$observed_version" != "$TAMA_VERSION" ]]; then
 	echo "tama CLI reports ${observed_version}, expected ${TAMA_VERSION}" >&2
 	exit 1

--- a/.github/actions/setup-tama/install.sh
+++ b/.github/actions/setup-tama/install.sh
@@ -13,11 +13,16 @@
 # still protects against an upstream release being silently replaced.
 set -euo pipefail
 
+: "${TAMA_VERSION:?TAMA_VERSION is required}"
+: "${TAMA_SHA256:?TAMA_SHA256 is required}"
+
 archive="tama-x86_64-unknown-linux-gnu.tar.gz"
 url="https://tama.computer/downloads/${TAMA_VERSION}/${archive}"
 workdir="$(mktemp -d "${RUNNER_TEMP:-/tmp}/tama-install.XXXXXX")"
 trap 'rm -rf "$workdir"' EXIT
 
+echo "tama: downloading ${archive} (version ${TAMA_VERSION})"
+echo "tama: ${url}"
 curl -fsSL --retry 3 --retry-connrefused "$url" -o "${workdir}/${archive}"
 
 observed="$(sha256sum "${workdir}/${archive}" | cut -d' ' -f1)"
@@ -34,15 +39,29 @@ if [[ "$observed" != "$TAMA_SHA256" ]]; then
 fi
 
 tar -xzf "${workdir}/${archive}" -C "$workdir"
+if [[ ! -x "${workdir}/tama" ]]; then
+	cat >&2 <<-EOF
+		tama: archive layout unexpected — expected executable ${workdir}/tama after extracting ${archive}
+		  url: ${url}
+		  archive contents:
+		$(tar -tzf "${workdir}/${archive}" | sed 's/^/    /')
+	EOF
+	exit 1
+fi
+
 install_dir="${TAMA_INSTALL_DIR:-/usr/local/bin}"
 mkdir -p "$install_dir"
 install -m 0755 "${workdir}/tama" "${install_dir}/tama"
 
 # The pin is on the ARCHIVE; assert the version it unpacks to as well, so the log records exactly
 # which CLI drove the run and a silently re-cut release under the same hash cannot pass unnoticed.
+if [[ ! -x "${install_dir}/tama" ]]; then
+	echo "tama: installed binary is missing or not executable at ${install_dir}/tama" >&2
+	exit 1
+fi
 observed_version="$("${install_dir}/tama" --version | awk '{print $2}')"
 if [[ "$observed_version" != "$TAMA_VERSION" ]]; then
 	echo "tama CLI reports ${observed_version}, expected ${TAMA_VERSION}" >&2
 	exit 1
 fi
-echo "tama ${observed_version} installed (sha256 ${observed})"
+echo "tama ${observed_version} installed at ${install_dir}/tama (sha256 ${observed})"

--- a/.github/workflows/toolchain-actions-smoke.yml
+++ b/.github/workflows/toolchain-actions-smoke.yml
@@ -1,11 +1,12 @@
 name: Toolchain actions smoke
 
-# Runtime coverage for the three local composites the toolchain PR lane actually executes. These
+# Runtime coverage for the local setup composites the benchmark and toolchain lanes execute. These
 # actions own only host setup + reporting, not image contents, so prove their contract directly on the
 # standard self-hosted runner instead of compiling the PTS-heavy base image for 6-8 minutes.
 on:
   pull_request:
     paths:
+      - ".github/actions/setup-tama/**"
       - ".github/actions/setup-toolchain/**"
       - ".github/actions/setup-workspace/**"
       - ".github/actions/release-summary/**"
@@ -22,7 +23,7 @@ permissions:
 
 jobs:
   smoke:
-    name: Set up toolchain + summary
+    name: Set up CLIs, toolchain + summary
     # This job checks out and executes the PR's local composites on a self-hosted runner. Keep the
     # same-repository boundary used by ci.yml and the full toolchain PR gate.
     if: github.event.pull_request.head.repo.full_name == github.repository
@@ -39,10 +40,14 @@ jobs:
         with:
           buildx: "true"
 
-      - name: Probe toolchain setup outputs
+      - name: Set up tama
+        uses: ./.github/actions/setup-tama
+
+      - name: Probe setup outputs
         run: |
           set -euo pipefail
           test "$(bun --version)" = "1.3.14"
+          test "$(tama --version | awk '{print $2}')" = "0.1.17"
           bun packages/templates/src/pins.ts >/dev/null
           docker buildx inspect --bootstrap
 
@@ -54,4 +59,4 @@ jobs:
           status: ${{ job.status }}
           mode: pr-gate
           source-ref: ${{ github.sha }}
-          verify: bun packages/templates/src/pins.ts && docker buildx inspect --bootstrap
+          verify: test "$(tama --version | awk '{print $2}')" = "0.1.17" && bun packages/templates/src/pins.ts && docker buildx inspect --bootstrap

--- a/tooling/repo-checks/src/lib/workflow-hardening.ts
+++ b/tooling/repo-checks/src/lib/workflow-hardening.ts
@@ -36,8 +36,9 @@ export const TOOLCHAIN_IMAGE_PR_PATHS = [
 	".github/workflows/toolchain-image.yml",
 ] as const;
 
-/** Local composites executed by the toolchain PR lane, plus the lightweight smoke itself. */
+/** Local setup composites executed by the lightweight smoke, plus the smoke itself. */
 export const TOOLCHAIN_ACTION_SMOKE_PR_PATHS = [
+	".github/actions/setup-tama/**",
 	".github/actions/setup-toolchain/**",
 	".github/actions/setup-workspace/**",
 	".github/actions/release-summary/**",
@@ -535,7 +536,7 @@ function exactSetError(
 }
 
 /**
- * Invariant 5: image inputs own the expensive toolchain PR smoke; the setup/reporting composites
+ * Invariant 5: image inputs own the expensive toolchain PR smoke; the CLI/setup/reporting composites
  * own a bounded smoke on the standard runner. This prevents a broad action glob from turning every
  * later push in an action-touching PR into another PTS-heavy image build.
  */
@@ -587,6 +588,9 @@ export function checkToolchainPrScope(
 			errors.push(`${jobLabel}: setup-toolchain must pass \`buildx: "true"\``);
 		}
 	}
+	if (!steps.some((step) => step.uses === "./.github/actions/setup-tama")) {
+		errors.push(`${jobLabel}: must execute ./.github/actions/setup-tama`);
+	}
 	const summary = steps.find((step) => step.uses === "./.github/actions/release-summary");
 	if (summary === undefined) {
 		errors.push(`${jobLabel}: must execute ./.github/actions/release-summary`);
@@ -601,6 +605,8 @@ export function checkToolchainPrScope(
 	for (const probe of [
 		"bun --version",
 		"1.3.14",
+		"tama --version",
+		"0.1.17",
 		"bun packages/templates/src/pins.ts",
 		"docker buildx inspect --bootstrap",
 	] as const) {

--- a/tooling/repo-checks/src/workflow-hardening.test.ts
+++ b/tooling/repo-checks/src/workflow-hardening.test.ts
@@ -595,13 +595,16 @@ describe("checkToolchainPrScope", () => {
 		buildx = "true",
 		summaryIf = "always()",
 		run = `test "$(bun --version)" = "1.3.14"
+test "$(tama --version | awk '{print $2}')" = "0.1.17"
 bun packages/templates/src/pins.ts >/dev/null
 docker buildx inspect --bootstrap`,
+		tama = true,
 	}: {
 		paths?: readonly string[];
 		buildx?: string;
 		summaryIf?: string;
 		run?: string;
+		tama?: boolean;
 	} = {}) => ({
 		on: { pull_request: { paths: [...paths] } },
 		jobs: {
@@ -611,6 +614,7 @@ docker buildx inspect --bootstrap`,
 				"timeout-minutes": 5,
 				steps: [
 					{ uses: "./.github/actions/setup-toolchain", with: { buildx } },
+					...(tama ? [{ uses: "./.github/actions/setup-tama" }] : []),
 					{ run },
 					{ uses: "./.github/actions/release-summary", if: summaryIf },
 				],
@@ -642,11 +646,19 @@ docker buildx inspect --bootstrap`,
 		);
 		const errors = checkToolchainPrScope(
 			imageDoc(),
-			actionSmokeDoc({ paths, buildx: "false", summaryIf: "success()", run: "bun --version" }),
+			actionSmokeDoc({
+				paths,
+				buildx: "false",
+				summaryIf: "success()",
+				run: "bun --version",
+				tama: false,
+			}),
 		);
 		expect(errors.some((error) => error.includes("setup-workspace/**"))).toBe(true);
 		expect(errors.some((error) => error.includes('buildx: "true"'))).toBe(true);
 		expect(errors.some((error) => error.includes("if: always()"))).toBe(true);
+		expect(errors.some((error) => error.includes("setup-tama"))).toBe(true);
+		expect(errors.some((error) => error.includes("tama --version"))).toBe(true);
 		expect(errors.some((error) => error.includes("packages/templates/src/pins.ts"))).toBe(true);
 		expect(errors.some((error) => error.includes("docker buildx inspect --bootstrap"))).toBe(true);
 	});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Install the checksum-pinned tama CLI from the immutable `downloads/<version>` URL (not moving `latest`), into a runner-writable directory on `GITHUB_PATH`, and cover the action via the toolchain actions smoke.

### Debuggability
- Echo pinned version + full download URL before `curl`
- Fail with archive contents when the unpacked `tama` binary is missing
- Assert the installed binary is executable before the version check
- Keep post-install `tama --version` assertion against the pin

### Why
The vendor installer’s same-origin `.sha256` only proves transfer integrity. This action pins the archive hash in-repo and selects a versioned URL so a new upstream release fails closed until the pin is refreshed.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019fff00-716d-7c30-be17-7c1154f479ef?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019fff00-716d-7c30-be17-7c1154f479ef&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Pin tama CLI installation to a versioned, checksum-verified archive and install it into the runner temp PATH. Previously we fetched a moving `downloads/latest` and executed a non-executable script (exit 126); now we fetch `downloads/<version>`, run via Bash, and assert the installed binary and version, improving reproducibility and debuggability.

- Fetch `https://tama.computer/downloads/${version}/tama-x86_64-unknown-linux-gnu.tar.gz` and verify against the repo-owned SHA-256; on mismatch, verify upstream and refresh the pin in `./.github/actions/setup-tama/action.yml`.
- Run installer via Bash; install to `${RUNNER_TEMP}/tama/bin` using `TAMA_INSTALL_DIR` and export via `GITHUB_PATH` (no writes to `/usr/local/bin`); assert the binary is executable and `tama --version` matches the input; echo the pinned version and URL; fail with archive contents if the unpacked layout is unexpected.
- `toolchain-actions-smoke.yml`: execute `./.github/actions/setup-tama` and assert `tama --version` is `0.1.17`; include the same check in the release summary `verify`.
- Workflow hardening: require executing `./.github/actions/setup-tama` and probing `tama --version` and `0.1.17`; add `".github/actions/setup-tama/**"` to the smoke path set.
- Migration: if any job relied on `/usr/local/bin/tama`, use `tama` from `PATH` instead. When upgrading tama, bump the `version` input and its `sha256` together.

<sup>Written for commit 06648b9687454bd60ef48fa9f562e937e730d1ca. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/starslingdev/hpc-sandbox-benchmarks/pull/379?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Tama setup now supports selecting a specific immutable release and installation directory.
  * Installation downloads the versioned archive, verifies its checksum, and confirms the installed Tama version.
  * Tama is automatically added to the workflow command path.

* **Bug Fixes**
  * Improved installation errors and validation for missing, invalid, or incomplete archives.

* **Tests**
  * Workflow smoke checks now verify both Bun and Tama versions.
  * Repository checks enforce required Tama setup and version validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->