### PR TITLE
docs(adr): define the sandbox driver kit architecture (ADRs 0006–0008)

### DIFF
--- a/docs/adr/0006-declarative-provider-onboarding.md
+++ b/docs/adr/0006-declarative-provider-onboarding.md
@@ -59,7 +59,7 @@ fact is spread across six exhaustive provider-keyed structures plus four hand-wr
 
 `bake.ts` and `promote.ts` differ *only* in candidate-vs-version name. `candidateCreateOptions` is
 `adapters[id].createOptions` with the name swapped. None of this is independent information. Worse,
-**seven of the thirteen `bakers` entries are no-ops** that exist only to satisfy
+**seven of the fourteen `bakers` entries are no-ops** that exist only to satisfy
 `Record<ProviderId, …>` — the type is forcing us to write code for providers that bake nothing.
 
 **2. Provider identity is stringly-typed at every process boundary.** Ids leave TypeScript as CSV in
@@ -225,9 +225,11 @@ export type BakedProviderId = IdsWithArtifact<"baked">;
 
 - the **seven no-op bakers become unconstructable** — giving `blaxel` a baker is a compile error;
 - **omitting a real one is a compile error**, so the map stays exhaustive over exactly the right set;
-- `baseImageUse`, `providerArtifact` and `CandidateRefs` collapse into reads off `artifact`, narrowed
-  by `kind` with no casts; `candidateCreateOptions` disappears because the validation lane passes a
-  resolved artifact to the selected driver instead of manufacturing vendor options in the CLI;
+- `baseImageUse` and `providerArtifact` collapse into reads off `artifact`, narrowed by `kind`
+  with no casts; `CandidateRefs` stays release-lane composition-root data (resolved
+  candidate/version refs), not artifact metadata; `candidateCreateOptions` disappears because the
+  validation lane passes a resolved artifact to the selected driver instead of manufacturing
+  vendor options in the CLI;
 - `bake` and `promote` call **one** map, differing only in the name they pass.
 
 All three negative cases above were verified to fail `tsc --strict` as intended. This is the

--- a/docs/adr/0006-declarative-provider-onboarding.md
+++ b/docs/adr/0006-declarative-provider-onboarding.md
@@ -1,0 +1,363 @@
+---
+status: accepted
+---
+
+# Declarative provider onboarding
+
+## Context
+
+Adding one benchmarked provider currently touches 25–34 files. Measured over the last four
+additions:
+
+| Commit | Files changed |
+|---|---|
+| `4ee64f2` Microsandbox local + cloud | 25 |
+| `6da0dce` Vercel Sandbox | 25 |
+| `22f36c4` run.cloud | 34 |
+| `36a802a` Runloop | 34 |
+
+**Eighteen** of those files were touched by *all four*. That set is the boilerplate spine — it is
+not where the provider-specific work lives:
+
+```
+packages/schema/src/providers.ts            packages/schema/src/providers.test.ts
+packages/providers/src/lib/adapters.ts      packages/providers/src/index.test.ts
+packages/providers/package.json             package.json + bun.lock
+apps/cli/src/lib/providers-run.test.ts      apps/cli/src/lib/bake/validate.ts(.test.ts)
+apps/cli/src/lib/bake/promote.ts            apps/cli/src/bin/release-plan.ts(.test.ts)
+apps/cli/src/bin/bake.ts                    .github/workflows/toolchain-image.yml
+.github/workflows/bench-suite.yml           .github/workflows/bench-smoke.yml
+.env.example
+```
+
+The genuinely novel work — the adapter (`runcloud.ts` is 576 lines, `microsandbox.ts` 630) and its
+bake module — is 2–4 files. Everything else re-spells the same fact in a new dialect.
+
+### What already works
+
+The **runtime** path is fully registry-driven. `PROVIDERS` already feeds matrix fan-out
+(`apps/cli/src/lib/matrix.ts:57`), normalization (`results/src/lib/normalize-tree.ts:52`), figures
+(`results/src/lib/figures.ts:96`), economics (`schema/src/economics.ts:107`), and the skip-vs-fail
+credential loop (`apps/cli/src/lib/providers-run.ts`). `packages/harness` has no provider-keyed
+logic at all. This ADR does not touch that half.
+
+### Where it hurts
+
+**1. The bake/release layer has no home for "what artifact does this provider boot?"** That one
+fact is spread across six exhaustive provider-keyed structures plus four hand-written ref bags:
+
+| Site | Projection of the same fact |
+|---|---|
+| `providers/src/config.ts:113-148` | candidate/version *names* (12 consts, 2 aliases) |
+| `cli/src/bin/bake.ts:32-66` | `bakers` — builder at the **candidate** name |
+| `cli/src/lib/bake/promote.ts:295-348` | the same list at the **version** name |
+| `cli/src/lib/bake/validate.ts:39-58` | `baseImageUse` — `bakes`/`boots`/`none` |
+| `cli/src/lib/bake/validate.ts:61-107` | `candidateCreateOptions` — which create key points at it |
+| `cli/src/bin/release-plan.ts:61-89` | `providerArtifact` — the name, for plan display |
+| `cli/src/lib/bake/validate.ts:6-23` | `CandidateRefs` — one field per artifact |
+| `bake.ts:180-191`, `:232-242`, `:288-296`, `promote.ts:250-260` | four literal bags of the same names |
+
+`bake.ts` and `promote.ts` differ *only* in candidate-vs-version name. `candidateCreateOptions` is
+`adapters[id].createOptions` with the name swapped. None of this is independent information. Worse,
+**seven of the thirteen `bakers` entries are no-ops** that exist only to satisfy
+`Record<ProviderId, …>` — the type is forcing us to write code for providers that bake nothing.
+
+**2. Provider identity is stringly-typed at every process boundary.** Ids leave TypeScript as CSV in
+`$GITHUB_OUTPUT`, pass through `fromJSON()` in YAML, and return as `--provider e2b,daytona-vm`
+argv. Each crossing re-validates ad hoc, and `plan-axis.ts:24` erases the type outright
+(`select: (raw: string | undefined) => string[]`), then round-trips through
+`JSON.stringify`/`JSON.parse` *within a single process* (`plan-axis.ts:29,53`) to hand downstream
+code back a bare `string[]`.
+
+**3. GitHub Actions can't import TypeScript, so the vocabulary is re-spelled by hand.** Three
+near-identical credential blocks — `bench-suite.yml:240-277`, `toolchain-image.yml:511-544`, and
+`toolchain-image.yml:720-751` (a third dialect using `contains(fromJSON(…))`) — plus
+`bench-smoke.yml`'s choice list and `bench-matrix.yml:64`'s CSV. All are mechanical functions of
+`requiredEnvVars`. `workflow-sync.ts:105` already computes `requiredCredentialKeys()` — **the
+generator exists inside the checker; it just compares instead of emitting.** The other ~20 CI/doc
+sites have no gate, and `setup-privileged-environment.sh:57-62` is already stale (omits
+`RUNLOOP_API_KEY` and all three `VERCEL_*`).
+
+**4. The env gatekeeper hand-syncs a schema against a key array.** `providers/src/config.ts:23-44`
+declares `envSchema`; `:46-62` repeats every key in `ENV_KEYS`; `:73-76` loops over the array to
+build the input. A key added to one and not the other is **silently dropped** — no compile error, no
+test. This is a latent bug, not a style issue.
+
+**5. Surfaces that fail silently rather than loudly.**
+
+| Site | Silent failure for a new provider |
+|---|---|
+| `figures/src/model.ts:105-111` `figureProviderName` | prefix map; a new multi-variant vendor prints its full registry name in charts |
+| `figures/src/model.ts:114-137` `isolationFromRuntime` | substring map; a novel VMM yields `undefined` and the chart chip goes **blank** |
+| `results/src/lib/leaderboard.ts:646-653` `isolationClass` | order-sensitive `gvisor`→`vm`→`container` sniffing |
+| `harness/src/index.ts:404-405` | capacity errors classified by regex; a provider whose wording differs **hard-fails instead of retrying** — `:402` records this happening to runcloud |
+
+**6. Five hardcoded id-list oracles** (`providers.test.ts:24-39`, `providers-run.test.ts:33-48`,
+`release-plan.test.ts:66-79`, `validate.test.ts:104-123`, `templates/src/index.test.ts:25`) in two
+different sort orders. CONTRIBUTING's own checklist has a step named **"Exhaustive consumers"**
+(`CONTRIBUTING.md:60`). That step is the bug.
+
+## Decision
+
+### Where parsing lives: three tiers
+
+ADR-0001 established parse-don't-validate at every external boundary. The question this ADR has to
+answer is *which* of the provider seams are boundaries, because the answer is measured, not
+aesthetic — and the answer moves, so it has to be re-measured rather than assumed.
+
+Marginal cost of each module, measured sequentially in one process (bun 1.3.11, arktype 2.2.0), on
+`main` at `0ede640`:
+
+| Module | Marginal cost |
+|---|---|
+| `arktype` (library import, cold) | 240 ms |
+| `schema/src/run.ts` (the Run schema graph) | +317 ms |
+| `schema/src/providers.ts` (its own schemas) | +63 ms |
+| `schema/src/index.ts` (barrel, on top of the above) | +50 ms |
+| `schema/src/toolchain.ts` | 1.8 ms |
+
+**These numbers document an erosion that went undetected — the cautionary tale behind Tier 1.**
+`schema/providers` was once a ~6.6 ms identity leaf, and `config.ts:5-7`'s deliberate leaf import
+saved ~457 ms over the barrel. The leaf has since gained `import { type } from "arktype"` and,
+more expensively, a *value* import of `targetSpecSchema` from `run.ts` — dragging the entire Run
+schema graph into provider identity. It now costs ~620 ms against the barrel's ~662 ms; the
+optimization is all but gone, its explanatory comment is wrong, and no gate noticed. Import cost
+is an architectural property: it erodes silently unless a check owns it.
+
+That changes the reasoning but not the conclusion, and it adds a finding worth acting on
+independently of this ADR: **restore a genuinely cheap identity leaf.** `identifiers.ts` (added with
+tama) is already that seed — `ProviderId` and its schema, nothing else — but it is not listed in
+`packages/schema/package.json` `exports`, so nothing can import it. Exporting it, and moving
+`TARGET_SPEC` off the `run.ts` value import, returns provider identity to single-digit
+milliseconds. The registry's own validation should then stay out of that leaf on purpose:
+
+- **Tier 1 — committed source (the registry literal): plain TypeScript.** It is not a trust
+  boundary; it is type-checked source. `as const satisfies` plus discriminated unions give full
+  inference at zero runtime cost.
+- **Tier 2 — process boundaries (env, argv, `$GITHUB_OUTPUT`, JSON artifacts): arktype morphs.**
+  These are genuinely untrusted, crossed repeatedly, and currently guarded ad hoc. One parser per
+  boundary, narrowed literal types out the other side.
+- **Tier 3 — generator and gates (build time): arktype for invariants types can't express.** The
+  240 ms arktype import is free in a generator that runs on demand, so the descriptor schema and its `.narrow()`
+  rules live here, not in the hot import path.
+
+Everything below is verified against arktype 2.2.0, including the type-level assertions.
+
+### 1. Model the artifact as a discriminated union, and derive the partitions (Tier 1)
+
+```ts
+export type ProviderArtifact =
+  | { kind: "none" }                                                    // blaxel: vendor stock image
+  | { kind: "image";  optionKey: "templateId" | "image" }               // modal, namespace, runcloud, microsandbox
+  | { kind: "baked";  optionKey: "snapshotId" | "blueprint_name" | "templateId";
+      nameSuffix?: string }                                             // e2b, daytona-*, novita, runloop
+  | { kind: "mirror"; optionKey: "templateId"; repository: string }     // vercel
+  | { kind: "built";  recipe: string };                                 // modal-gpu: image built at run time
+```
+
+`built` covers artifacts that cannot be a committed ref because they are constructed in-process —
+the GPU lane's dockerfileCommands image resolved through a content-keyed kernel-snapshot cache.
+The registry names only the **recipe**; the driver's context factory produces the concrete
+`artifactRef` at run time (ADR-0007 §3). This is what lets `modal-gpu` join the registry instead
+of routing around it — and therefore puts its transport claims under ADR-0008's conformance gate,
+where today they are a hand-carried const (`gpu/modal.ts:14-18`).
+
+With `REGISTRY` declared `as const satisfies Record<ProviderId, ProviderMeta>`, the *type system*
+partitions the providers:
+
+```ts
+type IdsWithArtifact<K extends ProviderArtifact["kind"]> = {
+  [P in ProviderId]: (typeof REGISTRY)[P]["artifact"]["kind"] extends K ? P : never;
+}[ProviderId];
+
+export type BakedProviderId = IdsWithArtifact<"baked">;
+```
+
+`bakers` then becomes `Record<BakedProviderId, BakeFn>`, which is the payoff:
+
+- the **seven no-op bakers become unconstructable** — giving `blaxel` a baker is a compile error;
+- **omitting a real one is a compile error**, so the map stays exhaustive over exactly the right set;
+- `baseImageUse`, `candidateCreateOptions`, `providerArtifact` and `CandidateRefs` all collapse into
+  reads off `artifact`, narrowed by `kind` with no casts;
+- `bake` and `promote` call **one** map, differing only in the name they pass.
+
+All three negative cases above were verified to fail `tsc --strict` as intended. This is the
+"behavior follows from the narrowed type" property, and it costs nothing at runtime — arktype here
+would buy strictly less than the compiler already gives.
+
+### 2. One provider-identity parser for every boundary crossing (Tier 2)
+
+This is where arktype earns the most, because it replaces five ad-hoc validators with one:
+
+```ts
+export const providerId = type.enumerated(...PROVIDER_IDS);
+
+/** CSV → typed ids. The only thing `--provider`, BENCH_PROVIDERS and plan-axis should use. */
+export const providerSelection = type("string")
+  .pipe((raw) => raw.split(",").map((s) => s.trim()).filter(Boolean))
+  .to(providerId.array().atLeastLength(1));
+```
+
+Verified: the result infers as the literal union (a `readonly ("e2b")[]` annotation is correctly
+rejected), and a typo produces
+`value at [1] must be "daytona-vm", "e2b", … (was "typo-provider")` — strictly better than today's
+hand-rolled message. `selectProviders`/`selectRegistryIds` and `plan-axis.ts`'s `string[]` erasure
+and internal `JSON.stringify`/`JSON.parse` round-trip all go away; `AxisPlanConfig.select` becomes
+typed rather than `=> string[]`.
+
+### 3. Parse the cross-process JSON artifacts (Tier 2)
+
+The release plan, the bake report and the GHA matrix are written by one process and consumed by
+another through a workflow output. Use the built-in keyword rather than a bare morph:
+
+```ts
+export const releaseMatrix = type("string.json.parse").to({
+  include: type({ provider: providerId, required: "boolean" }).array(),
+});
+```
+
+`type("string.json.parse")` reports `must be a JSON string (SyntaxError: …)`, where
+`.pipe.try(JSON.parse)` degrades to `must be valid according to an anonymous predicate` — useless in
+a CI log. A bad id reports `include[0].provider must be …`, with the path.
+
+### 4. Fix the env gatekeeper with a single morph (Tier 2)
+
+`envSchema.props.map((p) => p.key)` recovers the declared keys, so the parallel `ENV_KEYS` array and
+the imperative filter loop both disappear, and issue 4's silent-drop bug becomes unrepresentable:
+
+```ts
+const declared = envSchema.props.map((p) => p.key as string);
+
+/** process.env → validated config input. Empty ⇒ unset stays the rule (config.ts:64-71), but it is
+ *  now part of the declared parse rather than a loop that can drift from the schema. */
+export const benchEnv = type("Record<string, string | undefined>")
+  .pipe((raw) => Object.fromEntries(
+    declared.flatMap((k) => (raw[k] ? [[k, raw[k]]] : [])),
+  ))
+  .to(envSchema);
+```
+
+### 5. Declare what consumers currently sniff (Tier 1)
+
+```ts
+vendor: string;                                                   // "Daytona" — kills figureProviderName's prefix map
+isolation: { technology: string; class: "microVM" | "container" | "userspace" };
+retryableCreatePatterns?: string[];                               // the declarative half of markRetryableCreate
+```
+
+`isolationClass` and `isolationFromDeclaration` become field reads. `isolationFromRuntime` **stays a
+matcher** — it maps *observed* strings from the guest probe, which the registry cannot know in
+advance. That is the line between domain modeling and genuine parsing.
+
+### 6. Credential descriptors with a normalizing morph (Tiers 2 + 3)
+
+`requiredEnvVars: string[]` can't express what the CI blocks need. Widen it, keep the string
+shorthand, and normalize once so no consumer handles two shapes:
+
+```ts
+const credentialInput = type("string >= 1").or({
+  name: "string >= 1",
+  "source?": "'secret' | 'literal' | 'step-output'",
+  "sharedWith?": "(string >= 1)[]",     // daytona-*/modal-* share one account credential
+  "default?": "string >= 1",            // DAYTONA_TARGET → "us-west-2"
+});
+
+export const credential = credentialInput.pipe((c) =>
+  typeof c === "string"
+    ? { name: c, source: "secret" as const, sharedWith: [] }
+    : { ...c, source: c.source ?? ("secret" as const), sharedWith: c.sharedWith ?? [] },
+);
+```
+
+Verified: mixed shorthand/full input normalizes to one shape, and `""` is rejected at
+`value at [0] must be non-empty`. The YAML emitter then consumes a uniform record and re-checks
+nothing. ADR-0007 §3 adds two more derived consumers of the same declarations — each driver's
+compile-time env slice (`EnvOf`) and its runtime env parser (`envSchemaFor`) — so the credential
+descriptor becomes the single declaration behind CI wiring, type checking, and runtime validation. Two further Tier-1 fields cover the remaining per-provider CI facts that are ternaries in
+YAML today: `runner?: string` and `preAuth?: "namespace-token" | "vercel-auth"`.
+
+### 7. Generate the managed regions, gate them the way ADR-0003 gates the catalog (Tier 3)
+
+Not whole-workflow codegen — the workflows carry hand-tuned logic worth keeping. Marker-delimited
+**managed regions**, exactly the `generate-catalog` → `check-catalog-drift` pattern:
+
+```yaml
+# >>> generated: provider-credentials — bun run generate-provider-wiring
+          E2B_API_KEY: ${{ matrix.provider == 'e2b' && secrets.E2B_API_KEY || '' }}
+# <<< end generated
+```
+
+Regions: the three credential blocks, `bench-smoke.yml`'s choice options,
+`docs/ci-secrets.md:208-227`, `scripts/setup-privileged-environment.sh:57-62`, and `.env.example`.
+`bun run check:provider-wiring` re-runs the generator and `git diff --exit-code`s — byte-identical to
+`check-catalog-drift.ts:14-30`.
+
+The generator is also where the descriptor's **arktype schema** lives: the invariants currently
+asserted only in `providers.test.ts` (`requiredEnvVars` non-empty; `syncCapMs` finite ⇒
+`detachedPoll: true`; variants of one vendor share a pricing object) become `.narrow()` rules on a
+schema the generator runs, so they are enforced against the descriptor *before* it is allowed to emit
+CI wiring that grants secrets. Paying arktype's import in a build-time generator is free; paying it
+in the provider identity leaf every CLI bin and harness process imports is not.
+
+`bench-matrix.yml:64`'s default CSV stays hand-edited: joining the published matrix is a deliberate
+promotion decision, not a mechanical consequence of registering, and the 18-line rationale above it
+is real content. `workflow-sync.ts` invariants 1 and 3 are deleted as redundant — a generated region
+cannot drift from its generator. Invariants 2, 3b, 4–7 are unrelated to onboarding and stay.
+Pre-auth steps stay hand-written (Vercel's VCR mirror is ~50 bespoke lines) but gain a cheap gate: a
+provider declaring `preAuth` must have the step in both lanes.
+
+### 8. Close the loop: the generator emits `as const satisfies`
+
+Generated TypeScript is re-checked by `tsc`, so arktype validates the generator's *input* and the
+compiler validates its *output*. Neither is trusted blindly, and a generator bug that emits a
+malformed registry fails typecheck rather than shipping.
+
+### 9. Then, and only then, scaffold
+
+`bun run new-provider <id>` takes a small descriptor file, parses it with the Tier-3 schema, appends
+the `REGISTRY` entry, stubs `packages/providers/src/lib/<id>.ts` (and `apps/cli/src/lib/bake/<id>.ts`
+only when `artifact.kind === "baked"`), and runs the generators.
+
+Scaffolding is deliberately last. Generating 22 edit sites is not an improvement over typing them —
+it makes duplication cheaper to create and no cheaper to maintain. It is worth writing once §1–§7
+have cut its output to three files.
+
+### Oracles
+
+Keep the hardcoded list in `providers.test.ts:24-39` — that is the independent oracle and it earns
+its place. The rest dissolve: `validate.test.ts`'s three partition oracles become tautologies once
+§1 derives the partitions at the type level, and the remaining three assert properties over
+`PROVIDERS` instead of re-listing membership.
+
+## Consequences
+
+**Adding a provider becomes:** one `REGISTRY` entry → one adapter file → optionally one bake file →
+`bun run generate-provider-wiring` → review the generated diff. Three hand-edited files against
+25–34 today, with the `bench-matrix.yml` promotion still a separate, deliberate step.
+
+**We accept:**
+
+- **A wider `ProviderMeta`.** Identity, economics, artifact and CI wiring in one record — the schema
+  would know the string `"starsling-ubuntu-24.04-2"`. The alternative is today's status quo: the
+  same facts across nine files with no gate. It stays declarative data; no builder or workflow logic
+  moves into `schema`.
+- **Two representations of the descriptor contract** — a TypeScript type (Tier 1, for inference) and
+  an arktype schema (Tier 3, for the generator's narrows). They can drift. The mitigation is that
+  the generator asserts the committed registry against the schema, so drift fails the gate rather
+  than shipping. Collapsing them by inferring the type *from* the schema is the obvious
+  simplification and is explicitly rejected here: it would pin the registry's validation cost into
+  the identity leaf, which this ADR wants to get *back* to single-digit milliseconds.
+- **Generated YAML regions.** Reviewers read a generated diff, and a bad generator ships bad wiring
+  everywhere at once. ADR-0003 already accepted this trade; the drift gate is the same mechanism.
+- **A migration touching every provider.** §1, §5 and §6 rewrite 14 registry entries and delete six
+  switches. Large but mechanically backstopped (`Record<ProviderId, …>`, exhaustive switches,
+  `assertProviderJoin`); it should land alone, with no new provider riding along.
+- **`workflow-hardening.test.ts`'s provider-specific asserts stay hand-maintained.** The Vercel
+  `toHaveLength(3)` count and the scoped `RUNLOOP_API_KEY`/`RUN_CLOUD_API_KEY` expression pins are
+  security invariants about *specific* providers, not derivable facts. They are correctly special.
+
+**We explicitly do not:** validate the registry at import time in `schema/providers` (it would add
+cost to the identity leaf for guarantees `tsc` already provides on committed source); parse the
+registry at runtime in the harness or CLI; or replace `isolationFromRuntime`'s matcher, which
+handles genuinely open input. The adapter
+contract, harness, results and figures layers are unchanged.

--- a/docs/adr/0006-declarative-provider-onboarding.md
+++ b/docs/adr/0006-declarative-provider-onboarding.md
@@ -19,7 +19,7 @@ additions:
 **Eighteen** of those files were touched by *all four*. That set is the boilerplate spine — it is
 not where the provider-specific work lives:
 
-```
+```text
 packages/schema/src/providers.ts            packages/schema/src/providers.test.ts
 packages/providers/src/lib/adapters.ts      packages/providers/src/index.test.ts
 packages/providers/package.json             package.json + bun.lock
@@ -106,7 +106,7 @@ answer is *which* of the provider seams are boundaries, because the answer is me
 aesthetic — and the answer moves, so it has to be re-measured rather than assumed.
 
 Marginal cost of each module, measured sequentially in one process (bun 1.3.11, arktype 2.2.0), on
-`main` at `0ede640`:
+the post-Tama `main` snapshot immediately preceding this ADR series:
 
 | Module | Marginal cost |
 |---|---|
@@ -125,14 +125,24 @@ optimization is all but gone, its explanatory comment is wrong, and no gate noti
 is an architectural property: it erodes silently unless a check owns it.
 
 That changes the reasoning but not the conclusion, and it adds a finding worth acting on
-independently of this ADR: **restore a genuinely cheap identity leaf.** `identifiers.ts` (added with
-tama) is already that seed — `ProviderId` and its schema, nothing else — but it is not listed in
-`packages/schema/package.json` `exports`, so nothing can import it. Exporting it, and moving
-`TARGET_SPEC` off the `run.ts` value import, returns provider identity to single-digit
-milliseconds. The registry's own validation should then stay out of that leaf on purpose:
+independently of this ADR: **restore a genuinely cheap identity leaf.** The current
+`identifiers.ts` is not that leaf: it value-imports arktype to construct `providerIdSchema`, so
+exporting it under another subpath would retain the library's cold-start cost. Introduce a pure
+`provider-ids.ts` instead:
 
-- **Tier 1 — committed source (the registry literal): plain TypeScript.** It is not a trust
-  boundary; it is type-checked source. `as const satisfies` plus discriminated unions give full
+```ts
+export const PROVIDER_IDS = ["e2b", "daytona-vm", /* … */] as const;
+export type ProviderId = (typeof PROVIDER_IDS)[number];
+```
+
+It has no runtime dependency. A separate `provider-parsers.ts` boundary module imports
+`PROVIDER_IDS` and constructs `type.enumerated(...PROVIDER_IDS)` plus the CSV/JSON morphs. Export
+both subpaths explicitly, and move `TARGET_SPEC` off the `run.ts` value import. This returns imports
+that need only provider identity to single-digit milliseconds without pretending an arktype-backed
+schema is free. The registry's own validation then stays out of the identity leaf on purpose:
+
+- **Tier 1 — committed source (provider metadata modules): plain TypeScript.** They are not a trust
+  boundary; they are type-checked source. `as const satisfies` plus discriminated unions give full
   inference at zero runtime cost.
 - **Tier 2 — process boundaries (env, argv, `$GITHUB_OUTPUT`, JSON artifacts): arktype morphs.**
   These are genuinely untrusted, crossed repeatedly, and currently guarded ad hoc. One parser per
@@ -141,28 +151,66 @@ milliseconds. The registry's own validation should then stay out of that leaf on
   240 ms arktype import is free in a generator that runs on demand, so the descriptor schema and its `.narrow()`
   rules live here, not in the hot import path.
 
-Everything below is verified against arktype 2.2.0, including the type-level assertions.
+The original parser and partition prototypes were verified against arktype 2.2.0 and the repo's
+strict TypeScript settings. The refinements accepted here—especially the arktype-free identity leaf,
+correlated metadata modules, and raw-versus-resolved input views—MUST land with positive and
+`@ts-expect-error` compiler tests; this ADR does not present unexecuted samples as prior evidence.
+
+### Registry authoring: central identity, one inert metadata file per provider
+
+A single 1,000-line registry literal would become the next merge-conflict hotspot as the fleet
+grows. Keep the published vocabulary centralized in `PROVIDER_IDS`, but author metadata in pure,
+SDK-free files:
+
+```text
+packages/schema/src/provider-meta/
+  e2b.ts  daytona-vm.ts  tama.ts  …       filename = ProviderId
+  _daytona.ts                              shared pricing/evidence constants
+  index.ts                                 generated typed assembly
+```
+
+Each provider file default-exports
+`defineProviderMeta("tama", { displayName, pricing, artifact, inputs, … })`. The helper performs no
+validation; it returns `{ id, meta }` while preserving both literals. The generated `index.ts`
+follows `PROVIDER_IDS` outward, imports exactly those metadata modules, checks them through the
+correlated type `{ [P in ProviderId]: ProviderMetaModule<P> }`, and exports their `meta` fields as
+`REGISTRY` with
+`as const satisfies Record<ProviderId, Omit<ProviderMeta, "id">>`. A file whose declared id does not
+match its generated key is therefore a compile error, not merely a filename gate finding.
+
+This is not the rejected fleet inversion in ADR-0007 §8. Deleting a metadata file cannot shrink the
+provider vocabulary: the central tuple remains authoritative and the generated import fails to
+compile. The generator evaluates only inert schema metadata, never driver modules or vendor SDKs.
+Sharding therefore buys parallel authoring and local review without giving file discovery ownership
+of identity.
 
 ### 1. Model the artifact as a discriminated union, and derive the partitions (Tier 1)
 
 ```ts
 export type ProviderArtifact =
-  | { kind: "none" }                                                    // blaxel: vendor stock image
-  | { kind: "image";  optionKey: "templateId" | "image" }               // modal, namespace, runcloud, microsandbox
-  | { kind: "baked";  optionKey: "snapshotId" | "blueprint_name" | "templateId";
-      nameSuffix?: string }                                             // e2b, daytona-*, novita, runloop
-  | { kind: "mirror"; optionKey: "templateId"; repository: string }     // vercel
-  | { kind: "built";  recipe: string };                                 // modal-gpu: image built at run time
+  | { kind: "none" }                                  // blaxel: vendor stock image
+  | { kind: "image" }                                 // modal, namespace, runcloud, microsandbox
+  | { kind: "baked"; nameSuffix?: string }            // e2b, daytona-*, novita, runloop
+  | { kind: "mirror"; repository: string }            // vercel
+  | { kind: "built"; recipe: string };                 // modal-gpu: image built at run time
 ```
+
+The registry owns the artifact's **lifecycle**, not vendor API syntax. Fields such as
+`snapshotId`, `templateId`, `blueprint_name`, and CLI flags belong in the driver that invokes that
+API (ADR-0007). Keeping an `optionKey` in the registry would merely move the current hand-written
+switch into data, would not represent nested or transformed vendor requests, and would make a
+future non-ComputeSDK provider contort itself around an obsolete passthrough convention.
 
 `built` covers artifacts that cannot be a committed ref because they are constructed in-process —
 the GPU lane's dockerfileCommands image resolved through a content-keyed kernel-snapshot cache.
-The registry names only the **recipe**; the driver's context factory produces the concrete
-`artifactRef` at run time (ADR-0007 §3). This is what lets `modal-gpu` join the registry instead
-of routing around it — and therefore puts its transport claims under ADR-0008's conformance gate,
+The registry names only the **recipe**; the composition root produces the concrete
+`ResolvedArtifact.ref` at run time (ADR-0007 §3). This is what lets `modal-gpu` join the registry
+instead of routing around it — and therefore puts its driver-module execution policy under
+ADR-0008's conformance gate,
 where today they are a hand-carried const (`gpu/modal.ts:14-18`).
 
-With `REGISTRY` declared `as const satisfies Record<ProviderId, ProviderMeta>`, the *type system*
+With `REGISTRY` exported as
+`as const satisfies Record<ProviderId, Omit<ProviderMeta, "id">>`, the *type system*
 partitions the providers:
 
 ```ts
@@ -177,8 +225,9 @@ export type BakedProviderId = IdsWithArtifact<"baked">;
 
 - the **seven no-op bakers become unconstructable** — giving `blaxel` a baker is a compile error;
 - **omitting a real one is a compile error**, so the map stays exhaustive over exactly the right set;
-- `baseImageUse`, `candidateCreateOptions`, `providerArtifact` and `CandidateRefs` all collapse into
-  reads off `artifact`, narrowed by `kind` with no casts;
+- `baseImageUse`, `providerArtifact` and `CandidateRefs` collapse into reads off `artifact`, narrowed
+  by `kind` with no casts; `candidateCreateOptions` disappears because the validation lane passes a
+  resolved artifact to the selected driver instead of manufacturing vendor options in the CLI;
 - `bake` and `promote` call **one** map, differing only in the name they pass.
 
 All three negative cases above were verified to fail `tsc --strict` as intended. This is the
@@ -220,61 +269,88 @@ export const releaseMatrix = type("string.json.parse").to({
 `.pipe.try(JSON.parse)` degrades to `must be valid according to an anonymous predicate` — useless in
 a CI log. A bad id reports `include[0].provider must be …`, with the path.
 
-### 4. Fix the env gatekeeper with a single morph (Tier 2)
+### 4. Split global config from provider inputs (Tier 2)
 
-`envSchema.props.map((p) => p.key)` recovers the declared keys, so the parallel `ENV_KEYS` array and
-the imperative filter loop both disappear, and issue 4's silent-drop bug becomes unrepresentable:
+The current `config.ts` mixes repo-global toolchain overrides with provider credentials and then
+hand-syncs `envSchema` against `ENV_KEYS`. Split the boundary in two. Repo-global values keep a
+small schema whose keys are recovered from `envSchema.props`; provider inputs are selected from the
+registry descriptor in §6 and parsed only for the chosen provider. In both cases the parallel key
+array disappears:
 
 ```ts
 const declared = envSchema.props.map((p) => p.key as string);
 
-/** process.env → validated config input. Empty ⇒ unset stays the rule (config.ts:64-71), but it is
- *  now part of the declared parse rather than a loop that can drift from the schema. */
-export const benchEnv = type("Record<string, string | undefined>")
+/** process.env → validated repo-global input. Empty ⇒ unset stays the rule. */
+export const repoEnv = type("Record<string, string | undefined>")
   .pipe((raw) => Object.fromEntries(
     declared.flatMap((k) => (raw[k] ? [[k, raw[k]]] : [])),
   ))
   .to(envSchema);
+
+/** raw input → only this provider's normalized, defaulted DriverContext.env. */
+export const parseDriverInputs = <P extends ProviderId>(id: P, raw: EnvSource): EnvOf<P> =>
+  envSchemaFor(id)(raw);
 ```
+
+The CLI composition root calls both once. Driver modules and templates receive explicit values and
+never read ambient `process.env`; ADR-0007 owns the package migration that removes the old global
+provider config object.
 
 ### 5. Declare what consumers currently sniff (Tier 1)
 
 ```ts
 vendor: string;                                                   // "Daytona" — kills figureProviderName's prefix map
-isolation: { technology: string; class: "microVM" | "container" | "userspace" };
-retryableCreatePatterns?: string[];                               // the declarative half of markRetryableCreate
+isolation: { technology: string; class: "microVM" | "container" | "userspace" | "unknown" };
 ```
 
 `isolationClass` and `isolationFromDeclaration` become field reads. `isolationFromRuntime` **stays a
 matcher** — it maps *observed* strings from the guest probe, which the registry cannot know in
-advance. That is the line between domain modeling and genuine parsing.
+advance. That is the line between domain modeling and genuine parsing. Create-error classification
+does not join this list: vendor errors are behavior, so ADR-0007 requires drivers to translate them
+to a typed `SandboxCreateError`. Regexes may exist privately inside a legacy bridge, but they are not
+registry claims that every consumer must reinterpret.
 
-### 6. Credential descriptors with a normalizing morph (Tiers 2 + 3)
+### 6. Provider-input descriptors with a normalizing morph (Tiers 2 + 3)
 
-`requiredEnvVars: string[]` can't express what the CI blocks need. Widen it, keep the string
-shorthand, and normalize once so no consumer handles two shapes:
+`requiredEnvVars: string[]` cannot distinguish secrets, ordinary variables, generated step output,
+optional tuning, or values with defaults. Replace it with `inputs`, keep the string shorthand for a
+required secret, and normalize once so no consumer handles two shapes:
 
 ```ts
-const credentialInput = type("string >= 1").or({
+const inputSource = type({ kind: "'secret'" })
+  .or({ kind: "'variable'" })
+  .or({ kind: "'step-output'", step: "string >= 1", output: "string >= 1" });
+
+const providerInput = type("string >= 1").or({
   name: "string >= 1",
-  "source?": "'secret' | 'literal' | 'step-output'",
-  "sharedWith?": "(string >= 1)[]",     // daytona-*/modal-* share one account credential
+  "source?": inputSource,
+  "required?": "boolean",
   "default?": "string >= 1",            // DAYTONA_TARGET → "us-west-2"
 });
 
-export const credential = credentialInput.pipe((c) =>
+export const input = providerInput.pipe((c) =>
   typeof c === "string"
-    ? { name: c, source: "secret" as const, sharedWith: [] }
-    : { ...c, source: c.source ?? ("secret" as const), sharedWith: c.sharedWith ?? [] },
+    ? { name: c, source: { kind: "secret" as const }, required: true }
+    : { ...c, source: c.source ?? { kind: "secret" as const },
+        required: c.required ?? (c.default === undefined) },
 );
 ```
 
 Verified: mixed shorthand/full input normalizes to one shape, and `""` is rejected at
-`value at [0] must be non-empty`. The YAML emitter then consumes a uniform record and re-checks
-nothing. ADR-0007 §3 adds two more derived consumers of the same declarations — each driver's
-compile-time env slice (`EnvOf`) and its runtime env parser (`envSchemaFor`) — so the credential
-descriptor becomes the single declaration behind CI wiring, type checking, and runtime validation. Two further Tier-1 fields cover the remaining per-provider CI facts that are ternaries in
-YAML today: `runner?: string` and `preAuth?: "namespace-token" | "vercel-auth"`.
+`value at [0] must be non-empty`. A step output names its producer step and output explicitly, so
+the emitter never guesses an expression from an env name. Tier-3 narrows reject a default on a
+secret or step output and a required input with a default. Reusing the same `name` across provider
+variants is the declaration that they share it; a parallel `sharedWith` list would be another drift
+surface.
+
+The YAML emitter consumes the normalized record and re-checks nothing. `EnvOf` and
+`envSchemaFor` derive two deliberately different views from it: the **raw** boundary permits an
+optional or defaulted input to be absent, while the **resolved** `DriverContext.env` makes a
+defaulted input a required `string` and leaves only genuinely optional inputs as `string |
+undefined`. This avoids the common mistake where a default is modeled as optional all the way into
+driver code. The descriptor is the single declaration behind CI wiring, compile-time access, and
+runtime parsing. Two further Tier-1 fields cover the remaining per-provider CI facts that are
+ternaries in YAML today: `runner?: string` and `preAuth?: "namespace-token" | "vercel-auth"`.
 
 ### 7. Generate the managed regions, gate them the way ADR-0003 gates the catalog (Tier 3)
 
@@ -287,14 +363,14 @@ Not whole-workflow codegen — the workflows carry hand-tuned logic worth keepin
 # <<< end generated
 ```
 
-Regions: the three credential blocks, `bench-smoke.yml`'s choice options,
+Regions: the three provider-input blocks, `bench-smoke.yml`'s choice options,
 `docs/ci-secrets.md:208-227`, `scripts/setup-privileged-environment.sh:57-62`, and `.env.example`.
 `bun run check:provider-wiring` re-runs the generator and `git diff --exit-code`s — byte-identical to
 `check-catalog-drift.ts:14-30`.
 
 The generator is also where the descriptor's **arktype schema** lives: the invariants currently
-asserted only in `providers.test.ts` (`requiredEnvVars` non-empty; `syncCapMs` finite ⇒
-`detachedPoll: true`; variants of one vendor share a pricing object) become `.narrow()` rules on a
+asserted only in `providers.test.ts` (required provider inputs are non-empty; defaults are valid for
+their source; variants of one vendor share a pricing object) become `.narrow()` rules on a
 schema the generator runs, so they are enforced against the descriptor *before* it is allowed to emit
 CI wiring that grants secrets. Paying arktype's import in a build-time generator is free; paying it
 in the provider identity leaf every CLI bin and harness process imports is not.
@@ -315,7 +391,8 @@ malformed registry fails typecheck rather than shipping.
 ### 9. Then, and only then, scaffold
 
 `bun run new-provider <id>` takes a small descriptor file, parses it with the Tier-3 schema, appends
-the `REGISTRY` entry, stubs `packages/providers/src/lib/<id>.ts` (and `apps/cli/src/lib/bake/<id>.ts`
+the `PROVIDER_IDS` entry, creates `packages/schema/src/provider-meta/<id>.ts`, stubs
+`packages/drivers/src/<id>.ts` (and `apps/cli/src/lib/bake/<id>.ts`
 only when `artifact.kind === "baked"`), and runs the generators.
 
 Scaffolding is deliberately last. Generating 22 edit sites is not an improvement over typing them —
@@ -331,14 +408,16 @@ its place. The rest dissolve: `validate.test.ts`'s three partition oracles becom
 
 ## Consequences
 
-**Adding a provider becomes:** one `REGISTRY` entry → one adapter file → optionally one bake file →
+**Adding a provider becomes:** one `PROVIDER_IDS` tuple entry → one provider-metadata file → one driver
+file → optionally one bake file →
 `bun run generate-provider-wiring` → review the generated diff. Three hand-edited files against
 25–34 today, with the `bench-matrix.yml` promotion still a separate, deliberate step.
 
 **We accept:**
 
-- **A wider `ProviderMeta`.** Identity, economics, artifact and CI wiring in one record — the schema
-  would know the string `"starsling-ubuntu-24.04-2"`. The alternative is today's status quo: the
+- **A wider `ProviderMeta`.** Identity, economics, artifact lifecycle and CI wiring live in one
+  descriptor. Resolved candidate/version refs do not: the composition root derives those from the
+  release lane. The alternative is today's status quo: the
   same facts across nine files with no gate. It stays declarative data; no builder or workflow logic
   moves into `schema`.
 - **Two representations of the descriptor contract** — a TypeScript type (Tier 1, for inference) and
@@ -350,14 +429,14 @@ its place. The rest dissolve: `validate.test.ts`'s three partition oracles becom
 - **Generated YAML regions.** Reviewers read a generated diff, and a bad generator ships bad wiring
   everywhere at once. ADR-0003 already accepted this trade; the drift gate is the same mechanism.
 - **A migration touching every provider.** §1, §5 and §6 rewrite 14 registry entries and delete six
-  switches. Large but mechanically backstopped (`Record<ProviderId, …>`, exhaustive switches,
-  `assertProviderJoin`); it should land alone, with no new provider riding along.
+  switches. Large but mechanically backstopped (`Record<ProviderId, …>`, exhaustive switches, and
+  ADR-0007's correlated loader); it should land alone, with no new provider riding along.
 - **`workflow-hardening.test.ts`'s provider-specific asserts stay hand-maintained.** The Vercel
   `toHaveLength(3)` count and the scoped `RUNLOOP_API_KEY`/`RUN_CLOUD_API_KEY` expression pins are
   security invariants about *specific* providers, not derivable facts. They are correctly special.
 
-**We explicitly do not:** validate the registry at import time in `schema/providers` (it would add
+**We explicitly do not:** put vendor option names or create-error regexes in the registry; validate
+the registry at import time in `schema/providers` (it would add
 cost to the identity leaf for guarantees `tsc` already provides on committed source); parse the
 registry at runtime in the harness or CLI; or replace `isolationFromRuntime`'s matcher, which
-handles genuinely open input. The adapter
-contract, harness, results and figures layers are unchanged.
+handles genuinely open input. This ADR does not define the driver port; ADR-0007 owns that migration.

--- a/docs/adr/0007-sandbox-driver-port.md
+++ b/docs/adr/0007-sandbox-driver-port.md
@@ -1,0 +1,690 @@
+---
+status: accepted
+---
+
+# The sandbox driver kit: one port, one file per provider, ComputeSDK as one driver
+
+## Context
+
+ADR-0006 makes *registering* a provider declarative. This ADR is about the other half: what a
+provider has to **implement**, and what it feels like to implement it. That surface is currently
+defined by `@computesdk/provider`'s `defineProvider`, and the evidence says it no longer fits.
+
+### ComputeSDK is now the minority case
+
+Census of the 14 registered providers on `main` at `0ede640`:
+
+| How it attaches | Count | Providers |
+|---|---|---|
+| Published `@computesdk/*` wrapper, unmodified | **3** | `modal-gvisor`, `modal-vm`, `namespace` |
+| Published wrapper, patched through its private `.methods` table | **6** | `e2b`, `daytona-vm`, `daytona-container`, `blaxel`, `runloop`, `novita` |
+| Hand-written `defineProvider` | **5** | `microsandbox-local`, `microsandbox-cloud`, `vercel`, `runcloud`, `tama` |
+
+**Only 21% consume a wrapper as shipped, and two of those three are the same vendor.** The last
+three providers added — runcloud, microsandbox, tama — are all hand-written. tama has no SDK in any
+language: its entire control plane is `spawn()` on a CLI binary (`tama.ts:11`).
+
+### The harness never depended on ComputeSDK anyway
+
+`packages/harness` and `apps/cli` contain **zero** imports from `computesdk` or `@computesdk/*`;
+`packages/harness/package.json` does not even declare it. The harness already defines its own
+structural interfaces that computesdk merely happens to satisfy — five of them, each a subset of the
+next: `DestroyableSandbox` (`sandbox-owner.ts:11`), `ReadinessProbeSandbox` (`readiness.ts:52`),
+`SandboxFilesystem` and `SandboxHandle` (`execute.ts:117,123`), `LifecycleSandbox`
+(`lifecycle.ts:79`).
+
+**The port already exists. It is just unnamed, scattered across five files, and not the thing
+providers are asked to implement.**
+
+The GPU work proves it. When the provider abstraction didn't fit, the team routed around it:
+`apps/cli/src/lib/gpu/modal.ts:77-89` builds `{ sandboxId, runCommand, destroy }` from the **native
+Modal SDK** and feeds it straight to `createOwnedSandbox` / `StepRunner`. It works. A non-computesdk
+driver already satisfies the harness today — outside the registry, because the registry has no shape
+for it.
+
+### What the harness actually uses vs. what `defineProvider` demands
+
+`SandboxMethods` (`@computesdk/provider/dist/index.d.ts:689`) makes seven methods mandatory:
+`create`, `getById`, `list`, `destroy`, `runCommand`, `getInfo`, `getUrl`.
+
+| Member | Harness usage |
+|---|---|
+| `runCommand` | 9 call sites — the workhorse |
+| `destroy` | 4 sites |
+| `create` | 3 sites; the only required *provider* method |
+| `sandboxId` | cost attribution |
+| `getInfo` | 1 site, `lifecycle.ts:283`; return value **never inspected** — a latency probe |
+| `list` | 1 site; return value **discarded** — a latency probe |
+| `filesystem.readFile`/`exists` | optional fast path; every use has a `cat` fallback |
+| `getById` | **never called** |
+| `getUrl` | **never called** — implemented 7 times across the adapters |
+
+`writeFile`, `mkdir`, `readdir`, `remove`, `getUrl`, `getInstance`, `runCode` are all unused.
+Results don't even move over the filesystem API: they come back as a base64 tar over stdout
+(`collect.ts:49-51`), chosen deliberately so it survives a full disk.
+
+Nothing the harness does requires a capability a plain "run a shell command" port lacks. Detached
+execution is a `nohup` double-fork *the harness itself writes* (`execute.ts:544-545`) with
+completion observed via a done-file; snapshots are an optional lifecycle measurement whose absence is
+a clean `skipped` gap.
+
+### What the mismatch costs
+
+**Fabricated values.** A mandatory surface wider than any vendor forces adapters to invent data —
+20+ instances, including `createdAt: new Date(0)` and `timeout: 0` (`tama.ts:614,616`), an invented
+snapshot id `` `${sandboxId}-snap-${Date.now().toString(36)}` `` (`microsandbox.ts:550`),
+`exitCode: result.exitCode ?? 1` inventing a failure (`vercel.ts:96`), a fabricated
+`{ stdout: "", stderr: "", exitCode: 0 }` for background launches (`vercel.ts:90`), and a `getUrl`
+that only throws, kept because *"Required by SandboxMethods, so it cannot be omitted"*
+(`microsandbox.ts:508-515`).
+
+**Duplication the vendors did not cause.** Three byte-identical `shellQuote` implementations
+(`tama.ts:214`, `runcloud.ts:359`, `microsandbox.ts:125`); four independent reinventions of the same
+`nohup … &` line; five `mapStatus` functions each collapsing a richer vendor state machine into
+computesdk's three values, each with a comment defending the same lossy choice; six `{ sandbox,
+sandboxId }` rewraps; five near-identical `assertPatchable` guards that exist only because
+`defineProvider` returns a generated class with no override point, so wrappers reach into its private
+`.methods` table and clone it (`novita.ts:87`, `runloop.ts:31`, `e2b-root.ts:19`,
+`blaxel-volume.ts:36`, `daytona-target.ts:37`).
+
+**An eager import wall.** `adapters.ts:5-25` statically imports every vendor SDK, and the
+`providers` barrel re-exports the composed record, so **any** import of the barrel — including
+`harness/src/index.ts:9` — evaluates all twelve vendor module graphs before a single line of
+benchmark code runs. Measured warm (bun 1.3.11, marginal costs sequentially in one process): the
+vendor graphs add **~0.9 s** (0.8–1.1 s across runs) on top of `schema`'s ~0.6 s, led by
+`@computesdk/blaxel` (~267 ms), `@computesdk/daytona` (~166 ms), `@computesdk/e2b` (~163 ms) and
+`@computesdk/modal` (~131 ms). A bench job benchmarks **exactly one provider**; it pays for
+fourteen, on every process start, tests included.
+
+**A production incident.** `@computesdk/provider` gives an adapter with no `filesystem` table its
+`UnsupportedFileSystem` stub — *a truthy object whose every method throws*. A truthiness check
+therefore selects the filesystem poll, and every poll then throws: **12 straight failures killed a
+step on namespace**, which the loop could only read as a dead sandbox (`execute.ts:404-411`). The fix
+in place today is to string-match `/not supported by .*sandbox environment/i` (`execute.ts:139-152`)
+to tell "never going to work" from "wedged for a moment". This is the single genuinely load-bearing
+computesdk *behavior* the harness depends on, and it is a workaround for a sentinel that should have
+been `undefined`.
+
+The anatomy confirms the shape of the problem: the *long* adapters are the least shim-heavy
+(tama and runcloud are ~75% real vendor logic), while the *short* ones are almost pure tax —
+`vercel.ts` is ~68% adapter boilerplate over an SDK that already does the work.
+
+### What a steelman of ComputeSDK corrects
+
+A deliberate defense of the incumbent, run against its shipped code, corrects four things this
+Context would otherwise overclaim — and each correction sharpened the Decision:
+
+- **The duplication is partly a failure to consume, not only a surface the SDK forced.**
+  `@computesdk/cmd` — a dependency of `computesdk`, in `node_modules` the whole time — ships
+  `shellEscape` **byte-identical** to all three repo copies, and `shell(cmd, { background: true })`
+  emits the same `nohup … >/dev/null 2>&1 &` wrapper the adapters hand-wrote; zero repo files import
+  it. The boilerplate indictment stands (the *mandatory surface* still forced the fabrications), but
+  §2's "own the shell mechanics once" is a consolidation ComputeSDK also attempted — one package
+  deeper than anyone looked.
+- **"Didn't tell us" has prior art inside ComputeSDK itself.** `daemond`'s result envelope is
+  `{ exitCode: number | null; signal?: string | null; … }` — the `Exit` union's semantics, shipped
+  in their newest layer while the older `CommandResult` still forces `exitCode: number`.
+- **`getUrl` and the wide surface fund features, not nothing.** `getUrl` is the bootstrap for their
+  streaming-exec channel (an in-sandbox daemon reached over SSE), and `getById`/`list` power a
+  multi-provider facade with failover and affinity routing. Dead *for this harness* — which is the
+  actual argument — not dead by design. ComputeSDK even shipped its own narrow-contract precedent,
+  `defineInfraProvider` (create/getById/list/destroy, no fabricated members), and its dominant
+  convention is already capability-by-presence; the throwing `UnsupportedFileSystem` stub is the one
+  deviation, forced by a consumer-side non-optional field.
+- **The inspectable `.methods` table is why patching was possible at all.** Six providers could be
+  behavior-patched precisely because `defineProvider` keeps methods in a cloneable table rather than
+  sealing them in closures. Any replacement port must preserve that property — which §2's
+  method-table layer does by construction, instead of rediscovering it through `assertPatchable`.
+
+## Decision
+
+Own the port, and ship it as a **kit**: a contract package a driver author reads top to bottom in
+five minutes, and a fleet package where one file *is* one provider's behavior. Four rules govern
+every choice below; each is the repo's existing discipline (ADR-0001/0002/0003) applied to the
+provider seam:
+
+1. **One declaration per fact, joined by types.** The registry entry (ADR-0006) declares identity,
+   credentials and artifact once; the driver binds to it through a single typed id parameter, and
+   the env types, artifact narrowing, loader table, exports map and CI wiring are all *derived* —
+   by inference, by construction, or by drift-gated codegen that reads **only the registry**.
+2. **A capability is present and working, or absent.** `undefined`, never a stub that lies.
+3. **Errors are values, and they all speak one grammar.** The `Exit` union for command outcomes;
+   arktype's `<path> must be <expected> (was <actual>)` for every boundary parse; and at authoring
+   time, compiler errors that land on the field the author got wrong.
+4. **The filesystem is the authoring interface.** A driver's filename is its `ProviderId`; adding a
+   provider is adding a file, not threading a record through a barrel.
+
+Everything below typechecks under `--strict --exactOptionalPropertyTypes`, including the negative
+(`@ts-expect-error`) cases; quoted error messages are verbatim compiler or runtime output. The
+design also survived a structured adversarial review — the strongest alternative it beat is
+documented in §8, with the evidence.
+
+### 1. Two packages: the contract and the fleet
+
+```
+packages/
+  driver/          @sandbox-benchmarks/driver — the port and the kit. Deps: schema, arktype.
+    src/
+      port.ts        SandboxDriver, SandboxSession, Exit, ExecResult, CreateRequest  (types only)
+      define.ts      defineDriver, DriverContext, EnvOf, ArtifactOf
+      env.ts         envSchemaFor — the runtime dual of EnvOf
+      shell.ts       shellQuote, launchDetached, readFile — harness-owned mechanics, once
+      cli.ts         cliDriver — the generic driver for CLI-only vendors
+      computesdk.ts  computeSdkDriver — the bridge (subpath ./computesdk)
+  drivers/         @sandbox-benchmarks/drivers — the fleet. Deps: driver + the vendor SDKs.
+    src/
+      e2b.ts  daytona-vm.ts  daytona-container.ts  tama.ts  …   filename = ProviderId
+      _daytona.ts    shared variant-pair factories (underscore = not a provider, generator skips)
+      index.ts       the generated loader table (drift-gated)
+```
+
+Narrow exports, in the computesdk spirit of small surfaces over a common core:
+
+- `@sandbox-benchmarks/driver` exports `.` (port + `defineDriver` + shell mechanics), `./cli`, and
+  `./computesdk` — the *only* module in the repo allowed to import `computesdk`, so the bridge's
+  cost is opt-in per driver rather than ambient.
+- `@sandbox-benchmarks/drivers` exports one subpath per provider (`./tama`, `./e2b`, …) plus a root
+  that contains **only** the loader table. The subpath list is generated from the registry and
+  drift-gated, like every other projection of it.
+
+The dependency flip is the architectural payoff: `@sandbox-benchmarks/harness` drops its dependency
+on the providers barrel (`harness/package.json` → `@sandbox-benchmarks/providers` today) and depends
+on **`driver` alone**. The harness's five overlapping structural interfaces collapse into the one
+named port; vendor SDKs leave its transitive graph entirely, and ADR-0002's DAG check enforces that
+they stay out. `apps/cli` is the only place the fleet and the harness meet.
+
+**Generation flows registry → outward, never fleet → inward.** Every generated projection (loader,
+exports map, CI regions) needs only the id list and credential names, which the registry already
+owns — so the generator never imports a driver module and never evaluates a vendor SDK. The
+fleet-side drift check is a file-existence and default-export-shape check, not a
+thirteen-vendor-module evaluation on every PR. This directionality is load-bearing; §8 shows what
+breaks without it.
+
+### 2. The port: three members, two layers
+
+The port has a consumer face and an author face, and they are different shapes on purpose. The
+**harness** consumes sessions — the ergonomic object it already implies:
+
+```ts
+export interface SandboxDriver {
+  create(request: CreateRequest): Promise<SandboxSession>;
+  /** Optional: destroy by bare id, no session needed — reaper/cleanup lanes. Idempotent. */
+  destroyById?(id: SandboxId): Promise<void>;
+  readonly probes?: ControlPlaneProbes;    // optional: latency measurement only
+  readonly snapshots?: SnapshotCapability; // optional: lifecycle measurement only
+}
+
+export interface SandboxSession {
+  readonly sandboxId: SandboxId;
+  /** The ref the driver reports it actually booted (falls back to the request's — see below). */
+  readonly artifactRef: string;
+  exec(command: string, options?: ExecOptions): Promise<ExecResult>;
+  destroy(): Promise<void>;
+  /** The vendor's native handle — the JDBC `unwrap()` idea, typed. */
+  readonly native: unknown;
+  /** Optional. A WORKING filesystem API — reads and writes — or absent; never a throwing stub. */
+  readonly files?: SandboxFiles;
+  /** Optional. `undefined` ⇒ the harness wraps `exec` in its own nohup double-fork. */
+  launch?(command: string, options?: ExecOptions): Promise<void>;
+}
+
+export interface SandboxFiles {
+  readFile(path: string): Promise<string>;
+  exists(path: string): Promise<boolean>;
+  writeText(path: string, text: string): Promise<void>;
+}
+```
+
+`CreateRequest` carries the benchmark's **full** target axis, GPUs included:
+`spec`, `artifactRef`, `deadlineMs`, and `gpu?: { model: string; count: number }` — the
+driver maps it to vendor syntax (Modal: `"H100!"`, `"A100:2"`). A GPU provider is therefore a
+driver like any other, not a separate lane; a driver that cannot honor a requested `gpu` fails
+create loudly rather than silently benchmarking CPU. `files` is all-or-nothing — every vendor
+with a working filesystem API (modal, e2b, daytona) does both directions, and staging *writes*
+are a real harness need (`gpu/modal.ts:158-165`) — while sessions without it get harness-owned
+fallbacks for both directions in `shell.ts`: `cat` for reads, base64-over-exec for writes, so
+consumers stay infallible either way.
+
+Four request/result rules complete the port, each earned in prototyping:
+
+- **One spec, one unit system.** `CreateRequest.spec` uses the registry's `targetSpecSchema`
+  fields and units (`vcpus` / `memoryGb` / `diskGb?`) — never a parallel spec type. Vendor unit
+  conversions (Modal wants MiB) live in exactly one driver-local expression. `diskGb` is
+  optional: a spec axis a vendor cannot express, when *present*, fails create loudly
+  (`SandboxCreateParams` has no disk knob) — matching the fleet's skip-and-disclose doctrine
+  rather than silently dropping a requirement.
+- **The request is parsed once, at the plan→request seam.** An arktype schema in
+  `packages/schema` — `.onDeepUndeclaredKey("reject")`, positive-value narrows — validates the
+  assembled request where CLI/config input becomes trusted data. The kit's own interfaces stay
+  plain readonly TypeScript, pinned to the schema by a mutual-`extends` type test so drift is a
+  compile error; the port core imports no arktype (arktype enters only through subpaths that
+  genuinely parse, like `./cli`). Drivers never re-validate: by the time a request reaches a
+  table, it is trusted.
+- **Drivers report what they booted.** `MethodTable.create` may return the `artifactRef` it
+  actually booted (for `built` artifacts, the ctx factory's product — e.g. `kernelImage.imageId`);
+  the kit records it on the session and fails create on a request/reported contradiction, tearing
+  down the orphan. The run document's artifact attribution is never a guess.
+- **Output limits are per-call and visible.** `ExecOptions.maxOutputBytes` is an opt-in cap for
+  probes and queries; a capped stream sets `ExecResult.truncated`. There is deliberately **no
+  kit-wide default**: results collection is a multi-MB base64 tar over stdout (`collect.ts:49-51`),
+  and a blanket cap turns it into a bounded retry loop that can never succeed.
+
+A driver **author**, however, writes a *stateless method table* — flat, pure functions over a typed
+native handle, capability-by-presence — and the kit assembles sessions from it:
+
+```ts
+export interface MethodTable<Handle, Ctx> {
+  create(ctx: Ctx, request: CreateRequest): Promise<{ handle: Handle; sandboxId: SandboxId }>;
+  exec(ctx: Ctx, handle: Handle, command: string, options?: ExecOptions): Promise<ExecResult>;
+  destroy(ctx: Ctx, handle: Handle): Promise<void>;
+  readonly files?: { readFile(ctx: Ctx, handle: Handle, path: string): Promise<string>; … };
+  launch?(ctx: Ctx, handle: Handle, command: string): Promise<void>;
+}
+export function driverFromTable<Handle, Ctx>(table: MethodTable<Handle, Ctx>, ctx: Ctx): SandboxDriver;
+```
+
+This is ComputeSDK's genuinely good bone structure (`SandboxMethods<TSandbox, TConfig>`) with its
+two pathologies removed: only three members are required, and absence is expressed by omitting a
+key, never by a stub. Measured in the side-by-side anatomy (§Prior art), the table shape wins three
+things closure sessions cannot offer: **one-statement unit tests** (`table.destroy(ctx, missing)`
+is a pure call — the closure equivalent needed a five-statement setup *plus a full create/readiness
+round-trip* to even reach the not-found path); **extraction safety** (a table is naturally a named
+`satisfies MethodTable<…>` const, where extracting a closure spec severs contextual typing); and
+**inspectable, patchable behavior** — composing over a table member is exactly what six providers
+did to computesdk's `.methods`, now a supported shape instead of a reach into private state.
+Per-driver memoized state (tama's once-per-process auth check) lives in `Ctx`, declared rather than
+hidden in a closure.
+
+Create, exec, destroy. `getById`, `getUrl`, `writeFile`, `mkdir`, `readdir`, `remove`, `runCode`
+and the mandatory `getInfo` are gone, because nothing calls them; `getInstance` survives as the
+typed `native` handle.
+
+The rules that make consumers infallible:
+
+- **Absent capabilities are `undefined`, not stubs.** `files?: SandboxFiles` is either a working
+  filesystem or absent; the driver — the place that knows — decides, and the stub never escapes it.
+  This deletes the string-matching at `execute.ts:139-152` and the entire class of bug that took out
+  the namespace step: `StepRunner`'s `pollFs` field, its permanent-abandonment logic and its
+  `isUnsupportedFilesystemError` matcher all go away.
+- **"Didn't tell us" is representable.**
+
+  ```ts
+  export type Exit =
+    | { kind: "exited"; code: number }
+    | { kind: "signalled"; signal: string }
+    | { kind: "unknown"; detail: string };
+  ```
+
+  No adapter forges `?? 1` (`vercel.ts:96`) or `127` (`e2b-root.ts:79`); a missing exit code becomes
+  evidence in the run document instead of a fake failure — which matters for a project whose output
+  is a published measurement.
+- **Distinct operations get distinct types.** `exec` returns `ExecResult`; `launch` returns `void`.
+  Four adapters currently fabricate a `CommandResult` for background launches; with the split there
+  is nothing to fabricate, and the harness supplies the fallback.
+- **Shell mechanics live in `shell.ts`, once.** `shellQuote`, the `nohup` double-fork, the done-file
+  poll and the `cat` fallback are harness concerns expressed over `exec`. Three byte-identical
+  `shellQuote` copies and four `nohup` lines collapse to one each:
+
+  ```ts
+  export async function launchDetached(s: SandboxSession, command: string): Promise<void> {
+    if (s.launch) return s.launch(command);
+    await s.exec(`nohup /bin/sh -lc ${shellQuote(command)} </dev/null >/dev/null 2>&1 &`);
+  }
+  ```
+
+### 3. `defineDriver`: one typed id joins everything
+
+The seam between "what a provider *is*" (the registry, ADR-0006) and "what it *does*" (the driver)
+used to be a bare string convention. It becomes one typed parameter, and everything a driver author
+touches derives from it:
+
+```ts
+export function defineDriver<P extends ProviderId>(
+  id: P,                          // autocompleted; a typo or unregistered id is a compile error
+  spec: DriverSpec<NoInfer<P>>,   // NoInfer: the spec can never bend P — only the id names the join
+): DriverModule<P>;
+
+export interface DriverContext<P extends ProviderId> {
+  /** Exactly the credentials the registry entry declares — required → string, optional → string? */
+  readonly env: EnvOf<P>;
+  /** The registry's artifact descriptor, narrowed to ITS literal — not the four-way union. */
+  readonly artifact: ArtifactOf<P>;
+  /** The resolved boot reference for that artifact (candidate or version name, per lane). */
+  readonly artifactRef: string;
+}
+```
+
+One generic call signature, deliberately not overloads — convex's registration builder documents
+the reason and it held up in our error-message tests: overloads prefix every mistake with a
+signature dump, while a single signature lands the error on the field the author got wrong.
+
+The whole provider file, in the shape an author actually writes:
+
+```ts
+// packages/drivers/src/tama.ts — the provider's behavior. The filename is the id.
+import { defineDriver } from "@sandbox-benchmarks/driver";
+import { cliDriver } from "@sandbox-benchmarks/driver/cli";
+import { type } from "arktype";
+
+const Machines = type("string.json.parse").to(
+  type({ id: "string", name: "string", status: "string" }).array(),
+);
+
+export default defineDriver("tama", {
+  // `tama new` blocks until ready (~2m10s cold pull) and owns failed-create cleanup, so the
+  // driver owns the create budget — abandoning it mid-teardown would strand a billable machine.
+  createBudget: { owner: "driver", attemptCeilingMs: TAMA_CREATE_CEILING_MS },
+  driver: ({ env, artifact, artifactRef }) =>
+    cliDriver({
+      binary: env.TAMA_CLI ?? "tama",
+      secretFlags: ["--token"],
+      create: (r, name) => ["new", name, "--ttl", "0", "--json", `--${artifact.optionKey}`,
+        artifactRef, "--cpu", String(r.spec.vcpus), "--memory", String(r.spec.memoryMib)],
+      ready: { poll: ["list", "--json"], parse: Machines,
+        select: (rows, name) => rows.find((m) => m.name === name && m.status === "ready")?.id ?? null },
+      exec: (id, command) => ["exec", id, "--", "bash", "-lc", command],
+      destroy: (id) => ["rm", "-y", id],
+      notFound: /not found|no such machine|unknown machine/i,
+    }),
+});
+```
+
+What the typed join buys, each verified:
+
+**The env slice is exact, and hovers flat.** `EnvOf<P>` maps the registry entry's credential tuple —
+required credentials are `string`, optional ones `string | undefined` via absence (the
+`exactOptionalPropertyTypes` distinction), wrapped in a `Prettify` flattener so the hover reads
+`{ readonly TAMA_CLI?: string; readonly TAMA_TOKEN: string }`, not an alias soup. Reading a
+credential the registry doesn't declare:
+
+```
+error TS2339: Property 'E2B_API_KEY' does not exist on type '{ readonly TAMA_CLI?: string; readonly TAMA_TOKEN: string; }'.
+```
+
+and near-misses get the compiler's spelling help:
+`Property 'BAZ_API_KEY' does not exist … Did you mean 'BAZ_APIKEY'?`. `adapters.ts`'s "Never read
+`process.env` here" comment stops being a comment; the ambient environment is simply not in scope.
+
+**The artifact arrives narrowed, so behavior follows from the type.** For `"tama"`,
+`ctx.artifact.kind` *is* the literal `"image"` and `optionKey` is `"image"` — not the four-way
+`ProviderArtifact` union — so `{ [artifact.optionKey]: artifactRef }` types as `{ image: string }`
+with zero casts and zero runtime checks, and asserting the wrong kind is a compile error. The
+`createOptions` bags that today re-spell the registry's artifact knowledge by hand become
+projections of it.
+
+**The runtime parser is derived from the same declaration.** `envSchemaFor(id)` builds the arktype
+validator from the identical registry tuple `EnvOf` maps, so type and validator cannot drift. A
+missing credential reports `BL_WORKSPACE must be a string (was missing)` — the same grammar as every
+other boundary in the repo. The CLI parses `process.env` once (ADR-0006 §4's `benchEnv`) and hands
+each driver its typed slice.
+
+**Variant pairs — the fleet's hardest real shape — are safe by construction.** daytona, modal and
+microsandbox each register two ids over one implementation (`adapters.ts:41`). A shared factory is
+typed by the union it serves, with no `as const` anywhere:
+
+```ts
+// packages/drivers/src/_daytona.ts
+export function daytonaDriver(): DriverSpec<"daytona-vm" | "daytona-container"> { … }
+```
+
+Inside it, `env.DAYTONA_API_KEY` is typed (the union's common slice) and `artifact.optionKey` is
+still the narrowed `"snapshotId"`. Both variant files attach it; attaching it to any id outside its
+union is rejected by ordinary function-parameter contravariance — verified, along with the
+unregistered-id and wrong-kind negatives, under the repo's compiler settings.
+
+**Policy is declared next to the code it governs, without sentinels.** Today's
+`createTimeoutMs: null` means "disable the harness's create race" — a sentinel a reader must know.
+It becomes a self-describing union on the module, and `costEvidence` moves in beside it:
+
+```ts
+createBudget?:
+  | { owner: "harness"; timeoutMs?: number }              // default: harness races create
+  | { owner: "driver"; attemptCeilingMs: number };        // driver owns bounds and cleanup
+```
+
+The rich rationale comments in `adapters.ts:129-291` move into the driver files they describe —
+each provider's story finally lives in one place.
+
+One honest constraint, inherited from how contextual typing works everywhere (convex documents the
+same rule): the spec literal lives **inline** in the `defineDriver(...)` call. Extracting it to an
+untyped `const` first severs the contextual type and the callback's parameters fall back to
+`any`-shaped inference errors. Extracting *typed* pieces — a `DriverSpec<…>`-annotated factory like
+`daytonaDriver()` above — keeps every guarantee; that is the supported sharing shape.
+
+### 4. The fleet loads lazily, and existence is compile-checked in both directions
+
+The loader table is a correlated record — each id maps to a dynamic import of exactly its module:
+
+```ts
+export const DRIVERS: { readonly [P in ProviderId]: () => Promise<DriverModule<P>> } = {
+  e2b: () => import("./e2b.ts").then((m) => m.default),
+  tama: () => import("./tama.ts").then((m) => m.default),
+  // …
+};
+```
+
+Because the table is typed by `ProviderId` and each module's default export carries its literal id,
+**both drift directions are compiler errors, not gate findings**: a driver file for an id the
+registry doesn't know fails inside the file (`defineDriver("nopé", …)` rejects), and a registry id
+with no driver file fails in the generated table (`TS2307: Cannot find module './novita.ts'`). A
+mismatched id/module pairing in the table itself also fails (verified). The generator's own gate
+adds only what types cannot see: filename = id, and one module per id. The generated table uses
+plain static import specifiers, so editor go-to-definition tunnels through it — the property convex
+protects deliberately in its generated `_generated/api`.
+
+This converts the eager import wall into a per-provider cost: a bench job evaluates the one vendor
+SDK it benchmarks (median ~60 ms, worst ~270 ms) instead of all twelve (~0.9 s), and harness tests
+evaluate none.
+
+### 5. `cliDriver`: vendor stdout is a trust boundary
+
+runcloud, microsandbox and tama arrived in one quarter; two of the three drive CLIs or raw HTTP.
+For CLI vendors the *entire* control plane is untyped text crossing a process boundary — exactly
+what ADR-0001 says must be parsed, and today it is `JSON.parse` + hand-rolled checks. In the kit,
+the table's `parse` fields are arktype pipelines, so a vendor changing its output shape produces a
+path-bearing report in the CI log —
+
+```
+value at [0].status must be a string (was missing)
+```
+
+— instead of an `undefined` threading through readiness logic. The generic driver owns spawn,
+timeout-and-kill, argv secret redaction and not-found matching once; a new CLI vendor is a table of
+argv templates and parsers, ~15 declarative lines against tama's 636 hand-written ones, with no
+`getUrl` regex-scraping prose, no `createdAt: new Date(0)`, no `mapStatus` collapse. Where a
+vendor's CLI needs logic a table can't express, the escape hatch is the port itself — `cliDriver` is
+a convenience over `SandboxDriver`, not a second contract.
+
+`cliDriver` compiles its declarative spec down to a §2 method table whose handle is the **parsed
+readiness row** (`ready.select` returns the row, not a bare id string) — so every generated member
+is unit-testable as a pure function, and `session.native` is the vendor's own typed record rather
+than an opaque string. The side-by-side anatomy confirmed the spec stays ~29 author lines while the
+three per-vendor quirks each remain one field: `secretFlags`, `ready`, `notFound`.
+
+### 6. ComputeSDK becomes a driver
+
+It keeps all its real value — seven maintained vendor translations — and stops being mandatory:
+
+```ts
+import { computeSdkDriver } from "@sandbox-benchmarks/driver/computesdk";
+
+export default defineDriver("e2b", {
+  driver: ({ env, artifact, artifactRef }) =>
+    computeSdkDriver(e2bCommandsAsRoot(e2b({ apiKey: env.E2B_API_KEY })), {
+      createOptions: { [artifact.optionKey]: artifactRef },   // types as { snapshotId: string }
+      hasWorkingFilesystem: true,   // explicit, because UnsupportedFileSystem lies
+    }),
+});
+```
+
+The nine wrapper-based providers keep working through the bridge, including the
+`snapshotId`/`templateId` create-option conventions the bake path relies on. The five hand-written
+adapters stop paying the `defineProvider` tax, and `assertPatchable` disappears: patching a driver
+is ordinary function composition, not a reach into a generated class's private table.
+
+One typing rule, learned from the GPU prototype: the bridge's `session.native` is typed as **the
+wrapper's `getInstance()` type — never the repo's own vendor SDK types**. Wrappers vendor their own
+SDK copies (`@computesdk/modal/node_modules/modal`), so the wrapper's `Sandbox` and the repo's are
+*different nominal classes*; a cast across them needs `as unknown as` and is wrong the day the
+versions diverge. Code that needs the repo's SDK types is code that should be a native driver.
+
+### 7. Where this meets ADR-0006
+
+`CreateRequest.artifactRef` and `DriverContext.artifact` are resolved from ADR-0006 §1's
+`artifact` descriptor (for kind `built`, by the driver's context factory at run time), so the
+registry decides *what* to boot and the driver decides *how*. §6's credential
+declarations gain two derived consumers (`EnvOf`, `envSchemaFor`) alongside the CI regions. The
+`Record<BakedProviderId, BakeFn>` partition **stays in `apps/cli`, unchanged**: bake modules import
+the harness, templates pins, and docker orchestration (`bake/e2b.ts` writes a generated Dockerfile
+into `packages/templates/images/e2b/`) — that is release-pipeline altitude, and pulling it into the
+fleet package would invert the DAG for a compile-time property the cli-side `Record` already
+provides.
+
+### 8. The single-file inversion, tested and rejected
+
+The obvious next step — collapse the registry entry *into* the driver file
+(`defineProvider({ id, credentials, artifact, pricing, driver })`, sibling-field inference, registry
+generated from the fleet) — was built, adversarially attacked, and rejected on evidence. It is
+recorded here because its failure modes are subtle and worth not re-discovering:
+
+- **The flagship guarantee fails silently on the fleet's real shape.** Sibling-field inference
+  needs the credentials tuple to stay literal. Factor a shared `const CREDS = [{ name:
+  "DAYTONA_API_KEY" }]` — the natural move for the three variant pairs, minus the `as const` nothing
+  reminds you to write — and `env` silently degrades to an open string record: `env.E2B_API_KEY`
+  compiles for a daytona driver, with zero errors anywhere. The typed join (§3) is structurally
+  immune: literalness is established once, in the reviewed registry, and drivers bind by id.
+- **The generator would evaluate its own output.** Driver files import the schema barrel, whose
+  provider module runs a validation loop that throws on a bad registry — so a broken generated
+  registry (interrupted run, merge conflict between two provider PRs, prior emit bug) bricks the
+  generator that would repair it. ADR-0003's gate works because its inputs are inert vendored XML;
+  this one's inputs would be live modules downstream of its output.
+- **Identity would be authored by a leaf's file listing.** Run documents, legacy aliases, figures
+  and economics key on `ProviderId` — the DAG root's stability contract. Under the inversion,
+  deleting a driver file and regenerating shrinks that vocabulary with no compile error anywhere;
+  for a published benchmark, frictionless deletion is the wrong default. Relatedly, `id: string`
+  (unavoidable when the fleet defines the namespace) makes §4's correlated loader untypeable.
+- **The drift gate would evaluate thirteen vendor SDK graphs on every PR.** All currently import
+  clean under `env -i` (measured, 0.88 s) — but the repo has already once fought vendor import-time
+  flakiness (`bake/novita.ts`'s `createRequire` dance), and coupling every PR's CI to third-party
+  module-graph behavior is a standing liability the registry-→-outward direction avoids entirely.
+
+What the inversion got right is kept: colocation of narrative and behavior (the rationale comments
+move into driver files), declarative policy on the module, and the one-command scaffold. What it
+got wrong was *which* declaration moves: behavior colocates; identity does not.
+
+### 9. Guardrails: sharp edges reproduced during prototyping
+
+Every item below was a real failure reproduced (compiled or executed) while prototyping this
+design, not a hypothetical. Implementation MUST honor them; the kit tier of ADR-0008's suite
+pins the runtime ones.
+
+- **`"+": "reject"` and `.onUndeclaredKey("reject")` are SHALLOW.** A nested misspelling
+  (`spec.memroyGb`) passes them untouched. Request boundaries use `.onDeepUndeclaredKey("reject")`.
+- **Never mint a parallel spec shape.** The prototype briefly carried a third `TargetSpec` with
+  clashing units (`memoryMib` vs the registry's `memoryGb`) — a bug class no individually-valid
+  schema can catch. One spec vocabulary; conversions at the vendor edge only.
+- **The `defineDriver` spec literal stays inline** (or flows through a `DriverSpec<…>`-typed
+  factory). An untyped extracted const severs contextual typing — eight implicit-`any` errors,
+  silently degraded inference. The method table is the extraction-safe shape; use it for
+  anything you want to unit-test.
+- **Never cast across vendored SDK copies.** `@computesdk/*` wrappers vendor their own SDK
+  builds; their classes are nominally different from the repo's. The bridge exposes wrapper
+  types; needing repo SDK types means writing a native driver.
+- **A lazy context memo must clear on rejection.** `memo ??= load()` without a catch turns one
+  transient plumbing failure into a process-lifetime bricked driver (reproduced). Share the
+  in-flight promise; drop it on failure.
+- **Teardown must not swallow the primary error.** `finally { await destroy() }` replaces a
+  benchmark failure with a teardown failure. Use `SuppressedError` (native in Bun; requires
+  `lib: esnext`) so both survive; settle all staged writes before teardown and aggregate their
+  failures.
+- **Use one streaming `TextDecoder` per stream.** Per-chunk decoders corrupt UTF-8 sequences
+  split across chunk boundaries (reproduced: `h��llo`). Decode with `{ stream: true }`.
+- **Convergence catches must be narrow.** `destroyById` treats only the vendor's *typed*
+  not-found error (Modal: `NotFoundError`) as already-converged; every other failure surfaces.
+  String-matching error prose is how the `UnsupportedFileSystem` workaround started.
+- **arktype stays out of the port core.** Its cold import is ~288 ms, and the kit is imported by
+  every driver file. Schemas live in `packages/schema`; parsing subpaths (`./cli`) may import it;
+  the core exposes plain interfaces drift-pinned to the schemas. ADR-0006's eroded identity leaf
+  is the standing reminder that this rule decays without a gate.
+
+### Prior art, credited
+
+The shapes here are deliberately stolen from the ecosystem's best current practice — including from
+the incumbent this ADR demotes. From **ComputeSDK**: the package model (narrow provider modules over
+a small common core — kept as subpaths over a contract package), the stateless
+`SandboxMethods<TSandbox, TConfig>` table §2's author layer is modeled on, capability-by-presence
+feature detection, `@computesdk/cmd`'s shell mechanics, and `daemond`'s nullable-exit-code
+envelope. From the **mature driver ecosystems** that have run "N vendors, one contract" for
+decades: JDBC's `unwrap()` (the typed `native` handle), Kubernetes CSI's capability-honesty and
+idempotency spec language and Testcontainers' wait-strategy decomposition (both taken further in
+ADR-0008), and the TCK discipline that a contract ships with the suite that verifies it. From the
+modern TS wave: convex's registration builders (one generic signature instead of overloads, for
+error quality; a generated registry that preserves go-to-definition) and its
+validate-args-then-infer handler pipeline; elysia's `NoInfer` discipline and
+schema-as-single-source route contracts; better-auth's plugin object with optional capability keys
+and subpath-per-plugin exports; eve's filesystem-as-authoring-interface and `define*`
+default-export modules; arkenv's env-schema-with-injected-source; better-fetch's errors-as-values.
+The `Prettify` hover flattener is the ecosystem-standard `{ [K in keyof T]: T[K] } & {}`. Where a
+pattern didn't fit (elysia-style method chaining; arkenv's coercion; sibling-field inference per
+§8), it was left out — the kit has no builder API because nothing in it accumulates type state. The
+side-by-side anatomy that settled §2's two-layer shape — the same tama-style provider written
+against real `@computesdk/provider`, as a closure spec, and as a stateless table, all
+typechecked — found 134 author lines and 5 fabricated values for the incumbent, 29 lines and 0
+fabrications for the declarative spec, and the table layer decisive for testability. The
+compiling prototypes and runnable proofs behind every claim in this ADR — including the GPU
+three-way comparison and the `verify.ts` runtime suite — are preserved under
+`docs/adr/prototypes/gpu/` on the exploration branch
+(`claude/sdk-provider-benchmark-automation-5hjo0w`).
+
+## Consequences
+
+**Adding a provider becomes three hand-written edits, each compile-checked against the others:**
+
+1. The id line in `schema`'s identity leaf — the deliberate act that extends the published
+   vocabulary. `Record<ProviderId, …>` immediately demands the next edit.
+2. The registry entry — identity, artifact, credentials, economics (ADR-0006), with the entry's
+   evidence commentary alongside it.
+3. The driver file, `packages/drivers/src/<id>.ts` — `defineDriver("<id>", …)` autocompletes the
+   id, hands the author their typed env slice and narrowed artifact, and won't compile against an
+   unregistered id; the regenerated loader won't compile without the file.
+
+Then `bun run generate-provider-wiring` → review one diff touching the loader table, the exports
+map, and the CI regions. A bake module only when `artifact.kind === "baked"` (the cli `Record`
+demands exactly those); the `bench-matrix.yml` promotion stays a deliberate, separate step.
+`bun run new-provider <id>` (ADR-0006 §9) scaffolds all three edits from one descriptor.
+
+**We accept:**
+
+- **A migration touching every adapter.** Fourteen providers move into `packages/drivers`. It is
+  mechanical and compiler-checked, but it is not small, and it should land after ADR-0006 rather
+  than alongside it. Until the last adapter lands, `computeSdkDriver` keeps unmigrated providers
+  working, so the port and `DirectProvider` coexist during the window.
+- **We own the port.** Today computesdk absorbs upstream vendor churn behind a stable interface.
+  Nine providers keep that shelter via the bridge; the five hand-written ones already had no
+  shelter, and this ADR only stops them pretending otherwise.
+- **The inline-spec rule, narrowed by the table layer.** The `defineDriver` spec literal must stay
+  inline (or flow through a `DriverSpec<…>`-typed factory); an untyped extracted const loses the
+  contextual types — verified as eight implicit-`any` errors. This is a property of TypeScript's
+  contextual typing, shared by convex and elysia. §2's method tables are the pressure valve: a
+  table is naturally a named `satisfies MethodTable<…>` const, so the code an author most wants to
+  extract and unit-test is exactly the shape that extracts safely.
+- **`createOptions` stays an open passthrough on the bridge.** The `snapshotId`/`templateId`
+  conventions are real computesdk knowledge the bake path depends on — though the typed
+  `[artifact.optionKey]` projection now covers the common cases.
+- **Losing `getInfo`/`list` as *typed* members.** Both are pure latency probes today. They move to
+  the optional `probes` capability, where an absent probe is a recorded gap rather than a stub.
+- **Default exports in `packages/drivers`.** The one place the repo uses them, accepted so the
+  generated loader is uniform (`m => m.default`) with no id→identifier name mapping.
+- **Two more packages under ADR-0002's uniform shape.** The DAG check gains the edges that make the
+  design enforceable: `harness → driver` only; vendor SDKs confined to `drivers`.
+
+**We explicitly do not:** collapse the registry into the fleet (§8 — tested, rejected on evidence);
+create one workspace package per vendor (computesdk's per-package split earns its keep on npm,
+where external consumers install one provider; in a private workspace every SDK lands in `bun.lock`
+regardless, so fourteen `package.json`s would buy ceremony, not isolation — per-provider *subpaths*
+plus the lazy loader capture the real benefits at zero package overhead); put `bake` on the driver
+module (§7 — wrong DAG altitude, and the cli `Record` already provides the compile-time property);
+delete or fork `@computesdk/*` (it does real vendor translation for nine providers and remains a
+first-class driver); model streaming exec (declared in `transport`, never used —
+`execute.ts:108-109`); or move vendor quirk-handling into the harness. The port is a shell and a
+lifecycle, deliberately nothing more.

--- a/docs/adr/0007-sandbox-driver-port.md
+++ b/docs/adr/0007-sandbox-driver-port.md
@@ -630,11 +630,10 @@ pattern didn't fit (elysia-style method chaining; arkenv's coercion; sibling-fie
 side-by-side anatomy that settled §2's two-layer shape — the same tama-style provider written
 against real `@computesdk/provider`, as a closure spec, and as a stateless table, all
 typechecked — found 134 author lines and 5 fabricated values for the incumbent, 29 lines and 0
-fabrications for the declarative spec, and the table layer decisive for testability. The
-compiling prototypes and runnable proofs behind every claim in this ADR — including the GPU
-three-way comparison and the `verify.ts` runtime suite — are preserved under
-`docs/adr/prototypes/gpu/` on the exploration branch
-(`claude/sdk-provider-benchmark-automation-5hjo0w`).
+fabrications for the declarative spec, and the table layer decisive for testability. Every code
+sample and negative (`@ts-expect-error`) case in this ADR was verified as a compiling prototype
+under the repo's strict compiler settings before acceptance; quoted error messages are verbatim
+compiler or runtime output.
 
 ## Consequences
 

--- a/docs/adr/0007-sandbox-driver-port.md
+++ b/docs/adr/0007-sandbox-driver-port.md
@@ -12,7 +12,8 @@ defined by `@computesdk/provider`'s `defineProvider`, and the evidence says it n
 
 ### ComputeSDK is now the minority case
 
-Census of the 14 registered providers on `main` at `0ede640`:
+Census of the 14 registered providers on the post-Tama `main` snapshot immediately preceding this
+ADR series:
 
 | How it attaches | Count | Providers |
 |---|---|---|
@@ -154,14 +155,15 @@ provider seam:
 4. **The filesystem is the authoring interface.** A driver's filename is its `ProviderId`; adding a
    provider is adding a file, not threading a record through a barrel.
 
-Everything below typechecks under `--strict --exactOptionalPropertyTypes`, including the negative
-(`@ts-expect-error`) cases; quoted error messages are verbatim compiler or runtime output. The
-design also survived a structured adversarial review — the strongest alternative it beat is
-documented in §8, with the evidence.
+The original driver-kit prototype typechecked under `--strict --exactOptionalPropertyTypes`,
+including its negative (`@ts-expect-error`) cases, and its quoted error messages were captured from
+the compiler/runtime. The refinements accepted here—typed handle propagation, `ResolvedArtifact`,
+typed create failures, and the fleet-private bridge—MUST receive equivalent compiler and runtime
+tests in the implementation. The strongest rejected alternative remains documented in §8.
 
 ### 1. Two packages: the contract and the fleet
 
-```
+```text
 packages/
   driver/          @sandbox-benchmarks/driver — the port and the kit. Deps: schema, arktype.
     src/
@@ -170,26 +172,27 @@ packages/
       env.ts         envSchemaFor — the runtime dual of EnvOf
       shell.ts       shellQuote, launchDetached, readFile — harness-owned mechanics, once
       cli.ts         cliDriver — the generic driver for CLI-only vendors
-      computesdk.ts  computeSdkDriver — the bridge (subpath ./computesdk)
   drivers/         @sandbox-benchmarks/drivers — the fleet. Deps: driver + the vendor SDKs.
     src/
       e2b.ts  daytona-vm.ts  daytona-container.ts  tama.ts  …   filename = ProviderId
       _daytona.ts    shared variant-pair factories (underscore = not a provider, generator skips)
+      _computesdk.ts private computeSdkDriver bridge (underscore = not a provider)
       index.ts       the generated loader table (drift-gated)
 ```
 
 Narrow exports, in the computesdk spirit of small surfaces over a common core:
 
-- `@sandbox-benchmarks/driver` exports `.` (port + `defineDriver` + shell mechanics), `./cli`, and
-  `./computesdk` — the *only* module in the repo allowed to import `computesdk`, so the bridge's
-  cost is opt-in per driver rather than ambient.
+- `@sandbox-benchmarks/driver` exports `.` (port + `defineDriver` + shell mechanics) and `./cli`.
+  It has no ComputeSDK dependency.
 - `@sandbox-benchmarks/drivers` exports one subpath per provider (`./tama`, `./e2b`, …) plus a root
   that contains **only** the loader table. The subpath list is generated from the registry and
-  drift-gated, like every other projection of it.
+  drift-gated, like every other projection of it. `_computesdk.ts` is fleet-private, so only
+  bridge-backed driver files can import it and its cost remains lazy.
 
 The dependency flip is the architectural payoff: `@sandbox-benchmarks/harness` drops its dependency
 on the providers barrel (`harness/package.json` → `@sandbox-benchmarks/providers` today) and depends
-on **`driver` alone**. The harness's five overlapping structural interfaces collapse into the one
+on **`driver` for provider behavior** while retaining its existing `schema` dependency. The
+harness's five overlapping structural interfaces collapse into the one
 named port; vendor SDKs leave its transitive graph entirely, and ADR-0002's DAG check enforces that
 they stay out. `apps/cli` is the only place the fleet and the harness meet.
 
@@ -200,28 +203,61 @@ fleet-side drift check is a file-existence and default-export-shape check, not a
 thirteen-vendor-module evaluation on every PR. This directionality is load-bearing; §8 shows what
 breaks without it.
 
+The current `@sandbox-benchmarks/providers` package is retired when the migration finishes; it does
+not remain as a third owner of provider facts. Its contents move by responsibility:
+
+- adapter behavior and provider-specific cost-evidence capture move to `drivers`;
+- the port and cost-evidence hook types move to `driver`/`schema`, so `harness` needs no fleet dep;
+- pure toolchain/artifact defaults move down to `schema/toolchain`;
+- parsing `process.env`, choosing candidate-versus-version artifacts, and constructing a selected
+  driver happen in the CLI composition root; and
+- `templates` accepts explicit inputs instead of importing a module that reads ambient env.
+
+This disposition is part of the decision. Adding `driver` and `drivers` while leaving config,
+capabilities, or adapter policy in `providers` would create the exact three-way drift this ADR is
+meant to remove.
+
+The composition flow is explicit and side-effect-free until the selected module is loaded:
+
+```ts
+const module = await loadDriverModule(providerId); // one correlated dynamic import
+const env = parseDriverInputs(providerId, rawInputs);
+const descriptor = REGISTRY[providerId].artifact;
+const resolvedArtifact = await resolveArtifact(providerId, descriptor, lane);
+const driver = module.create({ env, artifact: descriptor, resolvedArtifact });
+```
+
+`loadDriverModule` does not read ambient env, `resolveArtifact` does not import a vendor SDK, and
+the driver never decides whether a run is using a candidate or published artifact. Those are three
+different trust/ownership boundaries and remain three small functions rather than one global
+`config` object initialized at import time.
+
 ### 2. The port: three members, two layers
 
 The port has a consumer face and an author face, and they are different shapes on purpose. The
 **harness** consumes sessions — the ergonomic object it already implies:
 
 ```ts
-export interface SandboxDriver {
-  create(request: CreateRequest): Promise<SandboxSession>;
+export type ResolvedArtifact =
+  | { readonly kind: "none" }
+  | { readonly kind: "image" | "baked" | "mirror" | "built"; readonly ref: string };
+
+export interface SandboxDriver<Handle = unknown> {
+  create(request: CreateRequest): Promise<SandboxSession<Handle>>;
   /** Optional: destroy by bare id, no session needed — reaper/cleanup lanes. Idempotent. */
   destroyById?(id: SandboxId): Promise<void>;
-  readonly probes?: ControlPlaneProbes;    // optional: latency measurement only
-  readonly snapshots?: SnapshotCapability; // optional: lifecycle measurement only
+  readonly probes?: ControlPlaneProbes;    // control-plane observation + optional latency probes
+  readonly snapshots?: SnapshotCapability<Handle>; // optional: lifecycle measurement only
 }
 
-export interface SandboxSession {
+export interface SandboxSession<Handle = unknown> {
   readonly sandboxId: SandboxId;
-  /** The ref the driver reports it actually booted (falls back to the request's — see below). */
-  readonly artifactRef: string;
+  /** Effective boot artifact; request fallback is tracked as such in evidence. */
+  readonly artifact: ResolvedArtifact;
   exec(command: string, options?: ExecOptions): Promise<ExecResult>;
   destroy(): Promise<void>;
   /** The vendor's native handle — the JDBC `unwrap()` idea, typed. */
-  readonly native: unknown;
+  readonly native: Handle;
   /** Optional. A WORKING filesystem API — reads and writes — or absent; never a throwing stub. */
   readonly files?: SandboxFiles;
   /** Optional. `undefined` ⇒ the harness wraps `exec` in its own nohup double-fork. */
@@ -233,10 +269,26 @@ export interface SandboxFiles {
   exists(path: string): Promise<boolean>;
   writeText(path: string, text: string): Promise<void>;
 }
+
+export type SandboxObservation =
+  | { readonly state: "running" | "terminal" }
+  | { readonly state: "absent" };
+
+export interface ControlPlaneProbes {
+  /** Required for a driver to enter the published matrix; see ADR-0008. */
+  observe(id: SandboxId): Promise<SandboxObservation>;
+  describe?(id: SandboxId): Promise<unknown>;
+  list?(): Promise<readonly { sandboxId: SandboxId }[]>;
+}
+
+export interface SnapshotCapability<Handle = unknown> {
+  create(session: SandboxSession<Handle>): Promise<{ readonly id: string }>;
+  delete(id: string): Promise<void>;
+}
 ```
 
 `CreateRequest` carries the benchmark's **full** target axis, GPUs included:
-`spec`, `artifactRef`, `deadlineMs`, and `gpu?: { model: string; count: number }` — the
+`spec`, `artifact`, `deadlineMs`, and `gpu?: { model: string; count: number }` — the
 driver maps it to vendor syntax (Modal: `"H100!"`, `"A100:2"`). A GPU provider is therefore a
 driver like any other, not a separate lane; a driver that cannot honor a requested `gpu` fails
 create loudly rather than silently benchmarking CPU. `files` is all-or-nothing — every vendor
@@ -245,7 +297,7 @@ are a real harness need (`gpu/modal.ts:158-165`) — while sessions without it g
 fallbacks for both directions in `shell.ts`: `cat` for reads, base64-over-exec for writes, so
 consumers stay infallible either way.
 
-Four request/result rules complete the port, each earned in prototyping:
+Six request/result rules complete the port, each earned in prototyping:
 
 - **One spec, one unit system.** `CreateRequest.spec` uses the registry's `targetSpecSchema`
   fields and units (`vcpus` / `memoryGb` / `diskGb?`) — never a parallel spec type. Vendor unit
@@ -260,28 +312,56 @@ Four request/result rules complete the port, each earned in prototyping:
   compile error; the port core imports no arktype (arktype enters only through subpaths that
   genuinely parse, like `./cli`). Drivers never re-validate: by the time a request reaches a
   table, it is trusted.
-- **Drivers report what they booted.** `MethodTable.create` may return the `artifactRef` it
-  actually booted (for `built` artifacts, the ctx factory's product — e.g. `kernelImage.imageId`);
-  the kit records it on the session and fails create on a request/reported contradiction, tearing
-  down the orphan. The run document's artifact attribution is never a guess.
+- **Drivers report what they booted when the control plane exposes it.** `MethodTable.create` may
+  return the `ResolvedArtifact` it actually booted (for `built` artifacts, the context resolver's product — e.g.
+  `kernelImage.imageId`). Omission means “same as `request.artifact`.” A different report is a
+  request/reported contradiction: the kit tears down the orphan and fails create before returning a
+  session. `kind: "none"` is explicit rather than an empty-string sentinel. Artifact resolvers must
+  canonicalize mutable tags to the immutable reference they intend to request before create; a
+  vendor-returned digest is not allowed to silently rewrite evidence after the fact. Omission keeps
+  the request as the session's effective artifact but does **not** relabel it as vendor-observed.
+- **Artifact evidence is persisted with provenance.** The provider execution evidence in the Run
+  schema gains the requested artifact, optional driver-reported artifact, and the live guest
+  fingerprint used by smoke, written before teardown. Evidence labels the source
+  (`driver-reported`, `guest-fingerprint`, or `request-fallback`); request fallback alone is
+  `unverified` for matrix admission rather than a guess presented as observation. A typed session
+  field that is never serialized would not make the ADR's “published attribution” claim true. This
+  is a Run schema-version change: historical documents remain readable without the field, while documents
+  emitted by the new driver path require it.
 - **Output limits are per-call and visible.** `ExecOptions.maxOutputBytes` is an opt-in cap for
   probes and queries; a capped stream sets `ExecResult.truncated`. There is deliberately **no
   kit-wide default**: results collection is a multi-MB base64 tar over stdout (`collect.ts:49-51`),
   and a blanket cap turns it into a bounded retry loop that can never succeed.
+- **Create failures are typed at the driver boundary.** Drivers translate vendor failures to
+  `SandboxCreateError` with a stable kind (`capacity`, `authentication`, `invalid-request`,
+  `unavailable`, or `unknown`) and optional `retryAfterMs`. The harness retries only `capacity` or
+  explicitly retryable `unavailable` failures. Error-prose regexes may remain private to a legacy
+  bridge, but the registry and harness never classify vendor strings.
 
 A driver **author**, however, writes a *stateless method table* — flat, pure functions over a typed
 native handle, capability-by-presence — and the kit assembles sessions from it:
 
 ```ts
 export interface MethodTable<Handle, Ctx> {
-  create(ctx: Ctx, request: CreateRequest): Promise<{ handle: Handle; sandboxId: SandboxId }>;
+  create(ctx: Ctx, request: CreateRequest): Promise<{
+    handle: Handle;
+    sandboxId: SandboxId;
+    artifact?: ResolvedArtifact;
+  }>;
   exec(ctx: Ctx, handle: Handle, command: string, options?: ExecOptions): Promise<ExecResult>;
   destroy(ctx: Ctx, handle: Handle): Promise<void>;
   readonly files?: { readFile(ctx: Ctx, handle: Handle, path: string): Promise<string>; … };
-  launch?(ctx: Ctx, handle: Handle, command: string): Promise<void>;
+  launch?(ctx: Ctx, handle: Handle, command: string, options?: ExecOptions): Promise<void>;
 }
-export function driverFromTable<Handle, Ctx>(table: MethodTable<Handle, Ctx>, ctx: Ctx): SandboxDriver;
+export function driverFromTable<Handle, Ctx>(
+  table: MethodTable<Handle, Ctx>,
+  ctx: Ctx,
+): SandboxDriver<Handle>;
 ```
+
+`driverFromTable` forwards `ExecOptions` unchanged to both `exec` and optional `launch`. The generic
+`Handle` reaches `SandboxSession<Handle>.native`; consumers that do not unwrap a vendor handle can
+use the default `unknown`, while native-driver code retains the exact SDK type end to end.
 
 This is ComputeSDK's genuinely good bone structure (`SandboxMethods<TSandbox, TConfig>`) with its
 two pathologies removed: only three members are required, and absence is expressed by omitting a
@@ -326,9 +406,13 @@ The rules that make consumers infallible:
   `shellQuote` copies and four `nohup` lines collapse to one each:
 
   ```ts
-  export async function launchDetached(s: SandboxSession, command: string): Promise<void> {
-    if (s.launch) return s.launch(command);
-    await s.exec(`nohup /bin/sh -lc ${shellQuote(command)} </dev/null >/dev/null 2>&1 &`);
+  export async function launchDetached(
+    s: SandboxSession<unknown>,
+    command: string,
+    options?: ExecOptions,
+  ): Promise<void> {
+    if (s.launch) return s.launch(command, options);
+    await s.exec(`nohup /bin/sh -lc ${shellQuote(command)} </dev/null >/dev/null 2>&1 &`, options);
   }
   ```
 
@@ -339,20 +423,35 @@ used to be a bare string convention. It becomes one typed parameter, and everyth
 touches derives from it:
 
 ```ts
-export function defineDriver<P extends ProviderId>(
+export function defineDriver<P extends ProviderId, Handle>(
   id: P,                          // autocompleted; a typo or unregistered id is a compile error
-  spec: DriverSpec<NoInfer<P>>,   // NoInfer: the spec can never bend P — only the id names the join
-): DriverModule<P>;
+  spec: DriverSpec<NoInfer<P>, Handle>, // spec cannot bend P; Handle is inferred from the table
+): DriverModule<P, Handle>;
+
+export interface DriverModule<P extends ProviderId, Handle = unknown> {
+  readonly id: P;
+  create(context: DriverContext<P>): SandboxDriver<Handle>;
+  // readiness, execution, createBudget, provenance, costEvidence …
+}
 
 export interface DriverContext<P extends ProviderId> {
-  /** Exactly the credentials the registry entry declares — required → string, optional → string? */
+  /** Exactly the resolved inputs the registry declares — defaults already applied. */
   readonly env: EnvOf<P>;
-  /** The registry's artifact descriptor, narrowed to ITS literal — not the four-way union. */
+  /** The registry's artifact descriptor, narrowed to ITS literal — not the full union. */
   readonly artifact: ArtifactOf<P>;
-  /** The resolved boot reference for that artifact (candidate or version name, per lane). */
-  readonly artifactRef: string;
+  /** The lane-resolved artifact. `ref` does not exist when this provider's kind is `none`. */
+  readonly resolvedArtifact: ResolvedArtifactOf<P>;
 }
 ```
+
+`defineDriver` returns an inert `DriverModule`, not an already-configured global. The module owns
+behavioral policy next to the implementation: integration provenance, create budget, readiness
+strategy, cost-evidence hook, and execution strategy
+`{ syncCapMs: number | null; durable: "native-launch" | "shell-detach" | "none" }`. The exact
+`syncCapMs` is a conservative routing policy, not a claim that smoke must wait that long to prove.
+The unused `transport.streaming` flag is removed until a consumer actually models streaming.
+`native-launch` requires a `launch` table member; `shell-detach` selects the kit fallback; both are
+live-verified by ADR-0008.
 
 One generic call signature, deliberately not overloads — convex's registration builder documents
 the reason and it held up in our error-message tests: overloads prefix every mistake with a
@@ -374,30 +473,33 @@ export default defineDriver("tama", {
   // `tama new` blocks until ready (~2m10s cold pull) and owns failed-create cleanup, so the
   // driver owns the create budget — abandoning it mid-teardown would strand a billable machine.
   createBudget: { owner: "driver", attemptCeilingMs: TAMA_CREATE_CEILING_MS },
-  driver: ({ env, artifact, artifactRef }) =>
+  execution: { syncCapMs: 60_000, durable: "shell-detach" },
+  driver: ({ env, resolvedArtifact }) =>
     cliDriver({
       binary: env.TAMA_CLI ?? "tama",
       secretFlags: ["--token"],
-      create: (r, name) => ["new", name, "--ttl", "0", "--json", `--${artifact.optionKey}`,
-        artifactRef, "--cpu", String(r.spec.vcpus), "--memory", String(r.spec.memoryMib)],
+      create: (r, name) => ["new", name, "--ttl", "0", "--json", "--image",
+        resolvedArtifact.ref, "--cpu", String(r.spec.vcpus),
+        // Tama's CLI boundary is MiB; the canonical request stays in GiB everywhere else.
+        "--memory", String(r.spec.memoryGb * 1024)],
       ready: { poll: ["list", "--json"], parse: Machines,
         select: (rows, name) => rows.find((m) => m.name === name && m.status === "ready")?.id ?? null },
       exec: (id, command) => ["exec", id, "--", "bash", "-lc", command],
       destroy: (id) => ["rm", "-y", id],
-      notFound: /not found|no such machine|unknown machine/i,
+      notFound: /not found|no such machine|unknown machine/i, // private bridge translation only
     }),
 });
 ```
 
-What the typed join buys, each verified:
+What the typed join must buy, with each property pinned by implementation tests:
 
-**The env slice is exact, and hovers flat.** `EnvOf<P>` maps the registry entry's credential tuple —
-required credentials are `string`, optional ones `string | undefined` via absence (the
+**The env slice is exact, and hovers flat.** `EnvOf<P>` maps the registry entry's input tuple —
+required and defaulted inputs are `string`; genuinely optional ones are `string | undefined` via absence (the
 `exactOptionalPropertyTypes` distinction), wrapped in a `Prettify` flattener so the hover reads
 `{ readonly TAMA_CLI?: string; readonly TAMA_TOKEN: string }`, not an alias soup. Reading a
 credential the registry doesn't declare:
 
-```
+```text
 error TS2339: Property 'E2B_API_KEY' does not exist on type '{ readonly TAMA_CLI?: string; readonly TAMA_TOKEN: string; }'.
 ```
 
@@ -405,17 +507,18 @@ and near-misses get the compiler's spelling help:
 `Property 'BAZ_API_KEY' does not exist … Did you mean 'BAZ_APIKEY'?`. `adapters.ts`'s "Never read
 `process.env` here" comment stops being a comment; the ambient environment is simply not in scope.
 
-**The artifact arrives narrowed, so behavior follows from the type.** For `"tama"`,
-`ctx.artifact.kind` *is* the literal `"image"` and `optionKey` is `"image"` — not the four-way
-`ProviderArtifact` union — so `{ [artifact.optionKey]: artifactRef }` types as `{ image: string }`
-with zero casts and zero runtime checks, and asserting the wrong kind is a compile error. The
-`createOptions` bags that today re-spell the registry's artifact knowledge by hand become
-projections of it.
+**The artifact arrives narrowed, so behavior follows from the type.** For `"tama"`, both
+`ctx.artifact.kind` and `ctx.resolvedArtifact.kind` are the literal `"image"`, so
+`resolvedArtifact.ref` exists with no cast. For `blaxel`, the narrowed kind is `"none"` and reading
+`.ref` is a compile error. Vendor syntax (`--image`, `snapshotId`, a nested SDK option) remains plain
+driver code rather than a supposedly-generic registry key. The candidate/version switches that
+today manufacture provider create-option bags disappear: the composition root resolves one
+artifact and passes it to the selected driver.
 
 **The runtime parser is derived from the same declaration.** `envSchemaFor(id)` builds the arktype
 validator from the identical registry tuple `EnvOf` maps, so type and validator cannot drift. A
 missing credential reports `BL_WORKSPACE must be a string (was missing)` — the same grammar as every
-other boundary in the repo. The CLI parses `process.env` once (ADR-0006 §4's `benchEnv`) and hands
+other boundary in the repo. The CLI parses `process.env` once at `parseDriverInputs` and hands
 each driver its typed slice.
 
 **Variant pairs — the fleet's hardest real shape — are safe by construction.** daytona, modal and
@@ -427,9 +530,10 @@ typed by the union it serves, with no `as const` anywhere:
 export function daytonaDriver(): DriverSpec<"daytona-vm" | "daytona-container"> { … }
 ```
 
-Inside it, `env.DAYTONA_API_KEY` is typed (the union's common slice) and `artifact.optionKey` is
-still the narrowed `"snapshotId"`. Both variant files attach it; attaching it to any id outside its
-union is rejected by ordinary function-parameter contravariance — verified, along with the
+Inside it, `env.DAYTONA_API_KEY` is typed (the union's common slice) and `resolvedArtifact` is
+narrowed to `kind: "baked"` with a present `ref`.
+Both variant files attach it; attaching it to any id outside its union is rejected by ordinary
+function-parameter contravariance, along with the
 unregistered-id and wrong-kind negatives, under the repo's compiler settings.
 
 **Policy is declared next to the code it governs, without sentinels.** Today's
@@ -453,21 +557,33 @@ untyped `const` first severs the contextual type and the callback's parameters f
 
 ### 4. The fleet loads lazily, and existence is compile-checked in both directions
 
-The loader table is a correlated record — each id maps to a dynamic import of exactly its module:
+The loader table is a correlated record — each id maps to a dynamic import of exactly its module.
+The generated type map retains each module's inferred native handle for literal-id callers:
 
 ```ts
-export const DRIVERS: { readonly [P in ProviderId]: () => Promise<DriverModule<P>> } = {
+export interface DriverModuleMap {
+  e2b: typeof import("./e2b.ts").default;
+  tama: typeof import("./tama.ts").default;
+  // …generated
+}
+
+export const DRIVERS: { readonly [P in ProviderId]: () => Promise<DriverModuleMap[P]> } = {
   e2b: () => import("./e2b.ts").then((m) => m.default),
   tama: () => import("./tama.ts").then((m) => m.default),
   // …
 };
+
+export const loadDriverModule = <P extends ProviderId>(id: P): Promise<DriverModuleMap[P]> =>
+  DRIVERS[id]();
 ```
 
 Because the table is typed by `ProviderId` and each module's default export carries its literal id,
 **both drift directions are compiler errors, not gate findings**: a driver file for an id the
 registry doesn't know fails inside the file (`defineDriver("nopé", …)` rejects), and a registry id
 with no driver file fails in the generated table (`TS2307: Cannot find module './novita.ts'`). A
-mismatched id/module pairing in the table itself also fails (verified). The generator's own gate
+mismatched id/module pairing in the table itself also fails. A caller with a literal id retains the
+driver's `SandboxSession<Handle>.native` type through `DriverModuleMap`; a caller with a runtime
+`ProviderId` receives the safe union and the harness ignores `native`. The generator's own gate
 adds only what types cannot see: filename = id, and one module per id. The generated table uses
 plain static import specifiers, so editor go-to-definition tunnels through it — the property convex
 protects deliberately in its generated `_generated/api`.
@@ -484,7 +600,7 @@ what ADR-0001 says must be parsed, and today it is `JSON.parse` + hand-rolled ch
 the table's `parse` fields are arktype pipelines, so a vendor changing its output shape produces a
 path-bearing report in the CI log —
 
-```
+```text
 value at [0].status must be a string (was missing)
 ```
 
@@ -506,12 +622,12 @@ three per-vendor quirks each remain one field: `secretFlags`, `ready`, `notFound
 It keeps all its real value — seven maintained vendor translations — and stops being mandatory:
 
 ```ts
-import { computeSdkDriver } from "@sandbox-benchmarks/driver/computesdk";
+import { computeSdkDriver } from "./_computesdk.ts";
 
 export default defineDriver("e2b", {
-  driver: ({ env, artifact, artifactRef }) =>
+  driver: ({ env, resolvedArtifact }) =>
     computeSdkDriver(e2bCommandsAsRoot(e2b({ apiKey: env.E2B_API_KEY })), {
-      createOptions: { [artifact.optionKey]: artifactRef },   // types as { snapshotId: string }
+      createOptions: { snapshotId: resolvedArtifact.ref },
       hasWorkingFilesystem: true,   // explicit, because UnsupportedFileSystem lies
     }),
 });
@@ -530,9 +646,9 @@ versions diverge. Code that needs the repo's SDK types is code that should be a 
 
 ### 7. Where this meets ADR-0006
 
-`CreateRequest.artifactRef` and `DriverContext.artifact` are resolved from ADR-0006 §1's
-`artifact` descriptor (for kind `built`, by the driver's context factory at run time), so the
-registry decides *what* to boot and the driver decides *how*. §6's credential
+`CreateRequest.artifact` and `DriverContext.resolvedArtifact` are resolved from ADR-0006 §1's
+`artifact` descriptor (for kind `built`, by the composition root at run time), so the
+registry decides *what* to boot and the driver decides *how*. §6's provider-input
 declarations gain two derived consumers (`EnvOf`, `envSchemaFor`) alongside the CI regions. The
 `Record<BakedProviderId, BakeFn>` partition **stays in `apps/cli`, unchanged**: bake modules import
 the harness, templates pins, and docker orchestration (`bake/e2b.ts` writes a generated Dockerfile
@@ -579,7 +695,8 @@ design, not a hypothetical. Implementation MUST honor them; the kit tier of ADR-
 pins the runtime ones.
 
 - **`"+": "reject"` and `.onUndeclaredKey("reject")` are SHALLOW.** A nested misspelling
-  (`spec.memroyGb`) passes them untouched. Request boundaries use `.onDeepUndeclaredKey("reject")`.
+  (`spec.unexpectedField`) passes them untouched. Request boundaries use
+  `.onDeepUndeclaredKey("reject")`.
 - **Never mint a parallel spec shape.** The prototype briefly carried a third `TargetSpec` with
   clashing units (`memoryMib` vs the registry's `memoryGb`) — a bug class no individually-valid
   schema can catch. One spec vocabulary; conversions at the vendor edge only.
@@ -631,17 +748,17 @@ side-by-side anatomy that settled §2's two-layer shape — the same tama-style 
 against real `@computesdk/provider`, as a closure spec, and as a stateless table, all
 typechecked — found 134 author lines and 5 fabricated values for the incumbent, 29 lines and 0
 fabrications for the declarative spec, and the table layer decisive for testability. Every code
-sample and negative (`@ts-expect-error`) case in this ADR was verified as a compiling prototype
-under the repo's strict compiler settings before acceptance; quoted error messages are verbatim
-compiler or runtime output.
+sample and negative (`@ts-expect-error`) case in the original prototype was compiled under the
+repo's strict settings; refinements made during acceptance review are normative requirements and
+must be added to that executable proof rather than being retroactively described as already run.
 
 ## Consequences
 
 **Adding a provider becomes three hand-written edits, each compile-checked against the others:**
 
-1. The id line in `schema`'s identity leaf — the deliberate act that extends the published
-   vocabulary. `Record<ProviderId, …>` immediately demands the next edit.
-2. The registry entry — identity, artifact, credentials, economics (ADR-0006), with the entry's
+1. The id in `schema`'s arktype-free `PROVIDER_IDS` identity leaf — the deliberate act that extends
+   the published vocabulary. `Record<ProviderId, …>` immediately demands the next edit.
+2. The provider-metadata file — identity, artifact lifecycle, inputs, economics (ADR-0006), with its
    evidence commentary alongside it.
 3. The driver file, `packages/drivers/src/<id>.ts` — `defineDriver("<id>", …)` autocompletes the
    id, hands the author their typed env slice and narrowed artifact, and won't compile against an
@@ -668,8 +785,8 @@ demands exactly those); the `bench-matrix.yml` promotion stays a deliberate, sep
   table is naturally a named `satisfies MethodTable<…>` const, so the code an author most wants to
   extract and unit-test is exactly the shape that extracts safely.
 - **`createOptions` stays an open passthrough on the bridge.** The `snapshotId`/`templateId`
-  conventions are real computesdk knowledge the bake path depends on — though the typed
-  `[artifact.optionKey]` projection now covers the common cases.
+  conventions are real ComputeSDK knowledge and remain local to each bridge-backed driver; the
+  registry does not pretend those vendor option names are artifact metadata.
 - **Losing `getInfo`/`list` as *typed* members.** Both are pure latency probes today. They move to
   the optional `probes` capability, where an absent probe is a recorded gap rather than a stub.
 - **Default exports in `packages/drivers`.** The one place the repo uses them, accepted so the
@@ -684,6 +801,6 @@ regardless, so fourteen `package.json`s would buy ceremony, not isolation — pe
 plus the lazy loader capture the real benefits at zero package overhead); put `bake` on the driver
 module (§7 — wrong DAG altitude, and the cli `Record` already provides the compile-time property);
 delete or fork `@computesdk/*` (it does real vendor translation for nine providers and remains a
-first-class driver); model streaming exec (declared in `transport`, never used —
-`execute.ts:108-109`); or move vendor quirk-handling into the harness. The port is a shell and a
+first-class driver); model streaming exec (the current flag has no consumer); or move vendor
+quirk-handling into the harness. The port is a shell and a
 lifecycle, deliberately nothing more.

--- a/docs/adr/0008-driver-conformance-gate.md
+++ b/docs/adr/0008-driver-conformance-gate.md
@@ -7,176 +7,216 @@ status: accepted
 ## Context
 
 This repo gates every **data** projection it depends on. ADR-0003 holds the generated catalog
-byte-stable against its XML source; ADR-0006 drift-gates the CI wiring, loader and exports against
+byte-stable against its XML source; ADR-0006 drift-gates CI wiring and generated fleet files against
 the registry; ADR-0007 makes registry↔driver existence a compile error in both directions. But the
-registry also makes **behavioral** claims, and nothing gates those:
+current registry also carries behavioral claims, and nothing gates them:
 
-| Claim | Declared at | Steers |
+| Current claim | Current owner | Failure mode |
 |---|---|---|
-| `transport.detachedPoll` | registry | whether a long step may detach (`execute.ts` transport selection) |
-| `transport.syncCapMs` | registry | which steps are forbidden from synchronous exec |
-| `transport.streaming` | registry | transport choice |
-| `hasWorkingFilesystem` | driver (ADR-0007 §6 bridge) | whether the harness polls files or falls back to `cat` |
-| `retryableCreatePatterns` | registry (ADR-0006 §5) | retry-vs-fail on create |
-| `artifact.optionKey` | registry | how the boot artifact reaches `create` |
+| `transport.detachedPoll` | registry | sends long work to a path that may not complete durably |
+| `transport.syncCapMs` | registry | permits synchronous work beyond the integration's safe policy |
+| `transport.streaming` | registry | unused by any transport decision, so no meaningful verifier exists |
+| working filesystem | adapter shape | a truthy throwing stub is mistaken for a capability |
+| retryable create prose | harness regex | vendor wording changes retry-vs-fail behavior |
+| artifact option key | CLI/registry switches | the requested artifact can differ from what booted |
 
-Every one of these is asserted by hand and verified by nothing. The repo has already paid for that
-twice, and both incidents are the same failure class — *a declared capability that did not match
-observed behavior, discovered only inside a live benchmark*:
+The repo has already paid for this twice:
 
-- **namespace, `detachedPoll: false`** — a wrong hand-written claim (misread as "needs a filesystem
-  API") forced a 55-minute benchmark onto a synchronous exec its own server cut at ~4m19s, stranding
-  the run (`providers.ts:55-58`).
-- **namespace, `UnsupportedFileSystem`** — a truthy stub advertised a filesystem that throws on
-  every call; 12 straight poll failures killed the step (ADR-0007 Context).
+- **namespace, `detachedPoll: false`** — a wrong hand-written claim forced a 55-minute benchmark onto
+  a synchronous exec its server cut at ~4m19s, stranding the run (`providers.ts:55-58`).
+- **namespace, `UnsupportedFileSystem`** — a truthy stub advertised a filesystem whose every method
+  threw; 12 straight poll failures killed the step (ADR-0007 Context).
 
-The mature "N vendors, one contract" ecosystems all converged on the same answer, decades before us:
-**the contract ships with the suite that verifies implementations against it.** Kubernetes CSI's
-`csi-sanity` runs against any driver over its socket and is *capability-gated* — it first queries
-the driver's advertised capabilities, then tests exactly what was advertised, so one suite verifies
-behavior **and** capability honesty. JDBC's `jdbcCompliant()` may only return true after passing the
-compliance tests — a claim socially backed by a suite. Terraform's `terraform-plugin-testing`
-drives providers through real plan/apply/refresh/destroy cycles and ships `CheckDestroy`, which
-verifies the remote resource is *actually gone*. CSI's spec text is the model for operation
-semantics: "This operation MUST be idempotent … If the volume does not exist, the Plugin MUST reply
-OK", with per-operation error tables that specify what the **caller may do next**.
+The mature “N vendors, one contract” ecosystems converge on the same answer: the contract ships
+with the suite that verifies implementations against it. Kubernetes CSI's `csi-sanity` is
+capability-gated; Terraform provider tests drive real create/read/destroy cycles and verify remote
+resources are gone; JDBC attaches compliance meaning to a test suite rather than a type name.
 
-The repo already owns the perfect host: the smoke lane (`bench-smoke.yml`) boots one live sandbox
-per provider and is explicitly designed so "a green smoke must never hide that the provider was
-never actually smoked."
-
-The specific invariants below were each validated by reproducing the failure they guard against
-in an executed prototype before being specified; ADR-0007 §9 lists the reproduced failure modes
-they pin.
+The repo already owns the right live host: the smoke lane boots one sandbox per provider and is
+designed so a green result cannot hide that the provider was never exercised.
 
 ## Decision
 
-### 1. The port gets spec language, not just types
+### 1. The port gets normative, testable semantics
 
-ADR-0007's port acquires per-operation normative semantics, CSI-style — short, testable clauses in
-the contract's JSDoc:
+ADR-0007's port acquires short CSI-style clauses in its JSDoc:
 
-- `destroy` MUST be idempotent; destroying a sandbox that does not exist MUST succeed. (Today this
-  is a convention each adapter re-implements as a `notFound` regex; it becomes a required property
-  the suite exercises.) The same clauses bind the optional `destroyById`.
-- `destroy` MUST be **convergent**: it MUST NOT resolve while the vendor control plane still
-  reports the sandbox as running. Where the driver declares a `probes.list`/`describe` capability,
-  the suite verifies the sandbox is absent-or-terminal *after* `destroy` resolves. This promotes
-  the strongest teardown in the repo — the GPU lane's terminate-then-verify-unlisted loop
-  (`gpu/modal.ts:55-75`) — from folklore in one adapter to a clause every driver answers.
-- `exec` MUST report the guest's real exit status: `sh -c 'exit 7'` yields
-  `{ kind: "exited", code: 7 }`; a vendor that withholds the code MUST yield `kind: "unknown"` —
-  never a forged number. stdout and stderr MUST NOT be merged.
-- `launch` (or the harness fallback over `exec`) MUST produce *observable completion*: a detached
-  command's done-file is readable afterwards. This clause is precisely the `detachedPoll` claim.
-- A declared `files` capability MUST round-trip both directions: `writeText` then `readFile`
-  returns the same bytes, and a file written via `exec` is readable via `readFile`. A driver with
-  no working filesystem MUST omit the key (never a stub — ADR-0007 rule 2, now enforced rather
-  than trusted); the suite then exercises the harness's exec-based read *and write* fallbacks.
-- A `create` request carrying `gpu` MUST either provision it (verified: `nvidia-smi` succeeds and
-  reports the requested model count) or fail create — never silently benchmark CPU.
-- `create` failures MUST be classifiable: an error matching the registry's
-  `retryableCreatePatterns` is a capacity signal the harness may retry; anything else is terminal.
-  (The CSI pattern: error semantics defined by what the caller is entitled to do next.)
+- `destroy` MUST be idempotent. Calling it twice, or destroying an already-absent sandbox by id,
+  MUST succeed.
+- `destroy` MUST be **convergent**. It MUST NOT resolve while the control plane reports the sandbox
+  as running. After it resolves, `probes.observe(sandboxId)` MUST report `terminal` or `absent`.
+- `exec` MUST preserve stdout and stderr as separate streams and report the guest's real exit status:
+  `sh -c 'exit 7'` yields `{ kind: "exited", code: 7 }`; a withheld code yields `kind: "unknown"`,
+  never an invented number.
+- A durable execution strategy MUST produce observable completion: after launch, the command's
+  done-file is readable afterward. This binds both `native-launch` and `shell-detach` strategies.
+- A present `files` capability MUST round-trip both directions: `writeText` then `readFile` returns
+  the same bytes, and a file written through `exec` is readable through `files`. If `files` is absent,
+  the kit's exec-based read and write fallbacks MUST pass the same round-trip.
+- A `create` request carrying a GPU MUST either provision the requested model/count or fail with a
+  typed `invalid-request`/unsupported error before returning a session; it MUST never benchmark CPU
+  silently.
+- When create reports a `ResolvedArtifact`, it MUST match the request; a contradiction MUST tear down
+  the orphan and fail. When the vendor cannot report it, smoke MUST match an expected immutable
+  fingerprint from inside the guest. Request fallback without either observation is `unverified`.
+- Create failures crossing the port MUST be `SandboxCreateError` values. The harness retries only
+  stable kinds, never vendor error prose.
 
-### 2. `@sandbox-benchmarks/driver/conformance`: one suite, any driver
+Every clause names an observable caller guarantee. Implementation notes and vendor-specific error
+tables remain in drivers; they are not elevated into universal contract text.
 
-A capability-gated suite in the contract package, embeddable as ordinary `bun test` and drivable
-against **any** `SandboxDriver` — the `csi-sanity` shape:
+### 2. Capabilities have one owner and one verifier
+
+There is no second boolean capability registry. Capability-by-presence is the declaration:
+`session.files`, `session.launch`, `driver.snapshots`, and `driver.probes` are present and working or
+absent. Driver-module policy owns readiness and execution strategy. The data registry owns neither.
+
+The conformance inventory is closed and explicit:
+
+| Claim | Declaration source | Observation criteria | When absent |
+|---|---|---|---|
+| core lifecycle | port (always) | create, readiness, live exec 0/7, split streams, destroy twice; kit fakes cover signalled/unknown mapping | `fail` |
+| artifact identity | request + session evidence | reported ref equals requested or guest fingerprint matches; contradiction fake proves orphan teardown | `not-applicable` for `none`; otherwise `unverified` without observation |
+| durable execution | `module.execution.durable` | done-file becomes readable through the selected strategy | `not-applicable` only when durable is `none` and sync is uncapped |
+| sync routing | `module.execution.syncCapMs` | kit router selects durable at the boundary; live durable probe passes | `not-applicable` when cap is `null` |
+| filesystem | `session.files` presence | native round-trip when present; exec fallback round-trip when absent | fallback is tested, not skipped |
+| control-plane convergence | `driver.probes.observe` | post-destroy observation is `terminal` or `absent` | `unverified` |
+| snapshots | `driver.snapshots` presence | create, identify, delete; cleanup runs on failure | `not-applicable` |
+| GPU | module accelerator declaration + request | requested count/model appears in `nvidia-smi`, or typed rejection | typed rejection is a pass for CPU-only drivers |
+| readiness | module readiness strategy | declared signal reaches ready within its declared budget | `fail` |
+| secret diagnostics | secret-sourced registry inputs + driver spawn/log sinks | no secret in any observable diagnostic surface | `fail` |
+
+`transport.streaming`, registry `retryableCreatePatterns`, and `artifact.optionKey` are deliberately
+not in this inventory. Streaming has no consumer; retry classification is a typed driver error; and
+vendor artifact syntax is driver code. `syncCapMs` is treated as a conservative routing policy: smoke
+does not sleep for the cap, but it does prove the router and the durable consequence used at that
+boundary.
+
+This design also drops the old “observed-but-undeclared” promise. A generic port cannot safely
+discover a native filesystem or snapshot API that the driver did not expose, and probing vendor
+internals would make the TCK provider-specific. Presence capabilities cannot underclaim: exposing
+the member is the declaration. A module that declares `native-launch` without a `launch` member is a
+construction/type error; a working but intentionally unexposed vendor feature is simply outside this
+repo's integration contract.
+
+### 3. `@sandbox-benchmarks/driver/conformance`: one suite, any driver
+
+The contract package exports a suite embeddable in ordinary `bun test` and usable against any
+driver module:
 
 ```ts
 import { conformance } from "@sandbox-benchmarks/driver/conformance";
 
 conformance({
-  driver: () => loadDriver("tama", { env }),
-  declared: REGISTRY["tama"],          // the claims under test
+  module: await loadDriverModule("tama"),
+  context: tamaContext,
 });
 ```
 
-The suite reads the declared capabilities and tests exactly those: lifecycle round-trip; exit-code
-fidelity (0, 7, signal, and the unknown arm); stdout/stderr separation; cwd/env option handling;
-detached launch + done-file observability (**verifies `detachedPoll`**); filesystem
-read-what-you-wrote (**verifies `hasWorkingFilesystem` / `files` presence**); destroy idempotency
-and destroy-of-missing; snapshot create/delete when declared; and **secret hygiene** — no declared
-credential value may appear in any argv, log line or thrown error the suite observed (the redaction
-promise, tested instead of assumed).
+The module itself supplies behavior policy; the registry supplies only inputs and artifact
+resolution through the already-built context. There is no `declared: REGISTRY[id]` capability bag.
 
-Two tiers, matching the repo's existing gate altitudes:
+Two tiers match the repo's gate altitudes:
 
-- **Kit tier (every PR, no credentials):** the suite runs against the kit's own machinery —
-  `cliDriver` over a fake CLI, `computeSdkDriver` over a mock compute — so the *generic* drivers
-  are conformant by construction, and a kit regression fails in-editor-fast CI. This tier also
-  owns the kit's robustness invariants, each of which was reproduced as a real failure before
-  being specified: a request whose reported boot artifact contradicts its requested one fails
-  create (and tears down the orphan); a request carrying a spec axis the driver cannot map
-  (`diskGb` on Modal) fails loudly rather than silently dropping it; a teardown failure after a
-  primary failure surfaces **both** errors; partial staged-write failures aggregate; a failed
-  lazy-context load is retried, not memoized forever; opt-in output caps truncate visibly
-  (`truncated: true`) and are never applied by default — the results tar rides uncapped stdout;
-  and host-side extraction of the sandbox-produced results archive rejects `..`/absolute members
-  (the one genuinely hostile path seam, `collect.ts`'s `tar -xzf`).
-- **Smoke tier (live, per provider):** the existing smoke lane runs the suite against the real
-  vendor before the benchmark steps. One sandbox, a few extra minutes, on a lane that already
-  boots one.
+- **Kit tier (every PR, no credentials):** the contract package runs the suite against `cliDriver`
+  over a fake executable and the pure routing/readiness helpers; the fleet package embeds the same
+  suite against its private `computeSdkDriver` over a fake compute. This tier owns
+  contradiction cleanup, deep request rejection, typed create failures, retryable lazy context,
+  `SuppressedError` preservation, staged-write aggregation, streaming `TextDecoder` correctness,
+  visible opt-in truncation, uncapped results transport, safe archive extraction, and secret
+  redaction at the spawn boundary.
+- **Smoke tier (live, per provider):** run the closed inventory against the selected real vendor
+  before benchmark steps. It uses the smallest number of sandboxes compatible with teardown and
+  snapshot cleanup and emits one parsed report.
 
-### 3. Capability honesty is the gate's verdict, not a side effect
+The existing stub `CapabilityFlags`/`ProviderDescriptor` model in `schema/index.ts` and
+`@repo/test-utils` is removed during implementation. Keeping it beside this suite would create two
+capability vocabularies with different owners and make the new gate cosmetic.
 
-The suite's output is a typed **declared-vs-observed report** (arktype-parsed at the process
-boundary, per ADR-0001):
+### 4. Secret hygiene distinguishes execution from diagnostics
 
-- **Overclaim** — declared but not observed (`detachedPoll: true` but the done-file never
-  appears) — **fails the gate**. This is the namespace incident, caught in smoke instead of
-  mid-benchmark.
-- **Underclaim** — observed but not declared (a working `files` the driver omits) — is a recorded
-  finding, not a failure: the sandbox merely runs slower paths, and the report says what's being
-  left unused.
-- **Bounded claims are bounded-verified.** `syncCapMs` cannot be cheaply proven (that would mean
-  running a cap-length exec per smoke); the suite instead verifies the *consequence machinery* —
-  that the declared durable path works — so a wrong cap degrades a measurement rather than
-  stranding one.
+CLI authentication sometimes has no channel except a flag. In that case the secret necessarily
+exists in the child process's **real execution argv**. `secretFlags` does not claim otherwise; it
+defines which following values must be replaced in the separately constructed diagnostic argv.
 
-TCK discipline follows: **a provider does not enter the published matrix until its smoke
-conformance passes**, and the committed report is part of the provider's evidence. This is the
-part that only makes sense because of what this repo *is*: the product is published measurement,
-and "what the vendor's integration actually supports, verified on date X" is itself a measured,
-publishable fact — the conformance report joins the run document as integration evidence, the way
-`isolationFromRuntime` already records observed isolation rather than trusting the brochure.
+The rule is:
 
-### 4. Readiness is a strategy, not a loop
+- prefer environment, stdin, or a protected config file when the vendor supports one;
+- never reconstruct a command string from raw argv;
+- never place a declared secret in logged, reported, serialized, error-rendered, or test-snapshot
+  argv, stdout/stderr annotations, or thrown error messages; and
+- keep the raw argv local to the spawn call while every observer receives only the redacted form.
 
-runcloud, microsandbox and tama each hand-roll a readiness poll with its own deadline handling and
-terminal-state logic — the code the anatomy study showed is easiest to get wrong. Testcontainers'
-decomposition applies directly: readiness is a **declared strategy object** with three orthogonal
-axes — startup shape (create-returns-ready vs create-then-poll), the readiness signal (a
-`cliDriver` poll+parse+select, an exec probe, a vendor state field), and a timeout. The kit owns
-the loop once; drivers declare the strategy; the conformance suite exercises the declared strategy
-and times it — which turns readiness itself into comparable evidence across providers, in a repo
-whose business is exactly that comparison.
+The kit tier injects sentinel secrets, captures the spawn call and every diagnostic sink, and proves
+that execution receives the sentinel where required while observers receive the redaction token. The
+live tier inspects only observable diagnostics; it does not make the false claim that a vendor-mandated
+flag is absent from the operating system's process table. Drivers that require such a flag record that
+transport as security evidence so the exposure is reviewable.
+
+### 5. Report statuses and matrix admission are unambiguous
+
+Each inventory row produces one of:
+
+- `pass` — the required observation succeeded;
+- `fail` — behavior contradicted the contract or declaration;
+- `not-applicable` — an optional capability is absent and the contract defines the absent path; or
+- `unverified` — the suite lacked an observation path or no verifier exists.
+
+For a **new provider**, matrix admission accepts only `pass` and `not-applicable`. Any `fail` or
+`unverified` status blocks admission. In particular, omitting `probes.observe` does not turn destroy
+convergence green; it reports `unverified`, which blocks publication.
+
+Because pull requests intentionally receive no provider secrets, admission is a two-step promotion,
+not an impossible PR-time live gate: the registration/driver PR lands with the provider absent from
+`bench-matrix.yml`; the privileged smoke lane on `main` produces a workflow artifact tied to its
+run; a follow-up promotion PR commits the parsed report and adds the provider to the matrix. The
+drift gate rejects a matrix edit without a current passing report. “Current” means the report's
+contract version and hashes of the driver module plus behavior-relevant metadata match the tree;
+changing any of them requires a new live report. Local credentials may exercise the same suite
+earlier, but local output is not publication evidence.
+
+Existing matrix providers may use a temporary, committed migration waiver with an owner, reason,
+and expiry while the fleet is moved to the port. A waiver never admits a new provider, never changes
+the report status to `pass`, and fails CI after expiry. There are no implicit exceptions.
+
+The arktype-parsed report records provider id, driver revision, test tier, requested/reported
+artifact, observation provenance and fingerprint, timestamps, clause ids, statuses, and bounded
+diagnostics. The latest passing smoke report is committed under a deterministic provider path and
+referenced from the Run as integration evidence.
+
+### 6. Readiness is a strategy, not a copied loop
+
+runcloud, microsandbox, and tama each hand-roll readiness polling with different deadline and
+terminal-state behavior. The module instead declares a strategy with three orthogonal parts:
+
+- startup shape: `create-returns-ready` or `create-then-poll`;
+- signal: CLI poll+parse+select, exec probe, or typed vendor-state probe; and
+- total budget plus per-attempt timeout.
+
+The kit owns backoff, jitter policy, deadline accounting, terminal-state handling, and cleanup. The
+suite drives every strategy against deterministic fakes and times the live strategy. This keeps the
+provider file declarative without pretending vendors share one readiness signal.
 
 ## Consequences
 
-**Adding a provider gains one step that pays for itself:** the first smoke run now tells the author
-"destroy is not idempotent: second destroy threw" or "declared detachedPoll but the done-file never
-appeared" — the two mistakes that today surface as stranded benchmarks weeks later. The failure
-names the operation and the spec clause, not a stack trace in a 55-minute run.
+Adding a provider gains one meaningful step: its first smoke run names the exact failed clause—such
+as destroy convergence, durable completion, or artifact identity—before a long benchmark can strand.
 
 **We accept:**
 
-- **Suite maintenance.** The conformance suite is code the team owns, and a gate's own bugs fail
-  open. Mitigations are structural: the kit tier runs it against the kit's fakes on every PR (a
-  broken suite breaks visibly), and the smoke tier is live, so fake-vs-vendor divergence is caught
-  by the tier that matters.
-- **Smoke minutes.** A few extra minutes and one sandbox per provider per smoke, on a lane that
-  exists precisely to spend that.
-- **Bounded verification of time-based claims.** `syncCapMs` and pricing-adjacent claims are not
-  fully provable in a smoke; the gate verifies their consequence machinery, and the benchmark
-  itself remains the deep verifier.
-- **Spec language discipline.** Normative clauses in JSDoc can drift from the suite. The rule is
-  ADR-0003's: the clause and its test are reviewed together; a clause without a test is marked
-  `unverified` in the report schema, so untested normativity is at least visible.
+- **Suite maintenance.** The kit tier tests the TCK itself against deterministic fakes; the live tier
+  catches fake/vendor divergence.
+- **Smoke minutes.** A few extra minutes and the minimum live resources necessary to prove cleanup,
+  on a lane whose purpose is to spend them.
+- **No generic feature discovery.** Capability-by-presence is honest and type-safe but cannot report
+  vendor features the integration chose not to expose.
+- **Bounded verification of time policy.** Smoke proves routing and durable consequences, not a
+  multi-hour vendor cutoff.
+- **A mandatory observation path for publication.** A driver can run locally without
+  `probes.observe`, but it cannot enter the published matrix because destroy convergence would be
+  unverified.
 
-**We explicitly do not:** publish a TCK for external consumers (the suite serves this repo's
-fourteen providers, not an ecosystem); conformance-test streaming (unmodeled, per ADR-0007);
-enforce performance thresholds in conformance (latency is the benchmark's job — conformance only
-verifies *contract* behavior); or block on underclaims (honest under-declaration costs speed, not
-correctness).
+**We explicitly do not:** conformance-test streaming until the port consumes it; enforce performance
+thresholds in conformance; classify vendor failures by shared regex; probe undeclared native APIs;
+allow `unverified` to pass new-provider admission; or publish a general-purpose external TCK. This
+suite serves this repository's fleet and its measurement-integrity contract.

--- a/docs/adr/0008-driver-conformance-gate.md
+++ b/docs/adr/0008-driver-conformance-gate.md
@@ -77,12 +77,12 @@ The conformance inventory is closed and explicit:
 |---|---|---|---|
 | core lifecycle | port (always) | create, readiness, live exec 0/7, split streams, destroy twice; kit fakes cover signalled/unknown mapping | `fail` |
 | artifact identity | request + session evidence | reported ref equals requested or guest fingerprint matches; contradiction fake proves orphan teardown | `not-applicable` for `none`; otherwise `unverified` without observation |
-| durable execution | `module.execution.durable` | done-file becomes readable through the selected strategy | `not-applicable` only when durable is `none` and sync is uncapped |
+| durable execution | `module.execution.durable` | done-file becomes readable through the selected strategy | `not-applicable` only when durable is `none` and sync is uncapped; `{ durable: "none", syncCapMs: number }` is a construction error |
 | sync routing | `module.execution.syncCapMs` | kit router selects durable at the boundary; live durable probe passes | `not-applicable` when cap is `null` |
 | filesystem | `session.files` presence | native round-trip when present; exec fallback round-trip when absent | fallback is tested, not skipped |
 | control-plane convergence | `driver.probes.observe` | post-destroy observation is `terminal` or `absent` | `unverified` |
 | snapshots | `driver.snapshots` presence | create, identify, delete; cleanup runs on failure | `not-applicable` |
-| GPU | module accelerator declaration + request | requested count/model appears in `nvidia-smi`, or typed rejection | typed rejection is a pass for CPU-only drivers |
+| GPU | request `gpu` axis (`CreateRequest.gpu?`) | when requested, count/model appears in `nvidia-smi`, or typed rejection | typed rejection is a pass for CPU-only drivers |
 | readiness | module readiness strategy | declared signal reaches ready within its declared budget | `fail` |
 | secret diagnostics | secret-sourced registry inputs + driver spawn/log sinks | no secret in any observable diagnostic surface | `fail` |
 
@@ -122,9 +122,9 @@ Two tiers match the repo's gate altitudes:
   over a fake executable and the pure routing/readiness helpers; the fleet package embeds the same
   suite against its private `computeSdkDriver` over a fake compute. This tier owns
   contradiction cleanup, deep request rejection, typed create failures, retryable lazy context,
-  `SuppressedError` preservation, staged-write aggregation, streaming `TextDecoder` correctness,
-  visible opt-in truncation, uncapped results transport, safe archive extraction, and secret
-  redaction at the spawn boundary.
+  `SuppressedError` preservation, staged-write aggregation, UTF-8 stream `TextDecoder`
+  correctness (chunk-boundary decoding — not transport streaming), visible opt-in truncation,
+  uncapped results transport, safe archive extraction, and secret redaction at the spawn boundary.
 - **Smoke tier (live, per provider):** run the closed inventory against the selected real vendor
   before benchmark steps. It uses the smallest number of sandboxes compatible with teardown and
   snapshot cleanup and emits one parsed report.

--- a/docs/adr/0008-driver-conformance-gate.md
+++ b/docs/adr/0008-driver-conformance-gate.md
@@ -1,0 +1,183 @@
+---
+status: accepted
+---
+
+# Driver conformance: the behavioral drift gate
+
+## Context
+
+This repo gates every **data** projection it depends on. ADR-0003 holds the generated catalog
+byte-stable against its XML source; ADR-0006 drift-gates the CI wiring, loader and exports against
+the registry; ADR-0007 makes registry↔driver existence a compile error in both directions. But the
+registry also makes **behavioral** claims, and nothing gates those:
+
+| Claim | Declared at | Steers |
+|---|---|---|
+| `transport.detachedPoll` | registry | whether a long step may detach (`execute.ts` transport selection) |
+| `transport.syncCapMs` | registry | which steps are forbidden from synchronous exec |
+| `transport.streaming` | registry | transport choice |
+| `hasWorkingFilesystem` | driver (ADR-0007 §6 bridge) | whether the harness polls files or falls back to `cat` |
+| `retryableCreatePatterns` | registry (ADR-0006 §5) | retry-vs-fail on create |
+| `artifact.optionKey` | registry | how the boot artifact reaches `create` |
+
+Every one of these is asserted by hand and verified by nothing. The repo has already paid for that
+twice, and both incidents are the same failure class — *a declared capability that did not match
+observed behavior, discovered only inside a live benchmark*:
+
+- **namespace, `detachedPoll: false`** — a wrong hand-written claim (misread as "needs a filesystem
+  API") forced a 55-minute benchmark onto a synchronous exec its own server cut at ~4m19s, stranding
+  the run (`providers.ts:55-58`).
+- **namespace, `UnsupportedFileSystem`** — a truthy stub advertised a filesystem that throws on
+  every call; 12 straight poll failures killed the step (ADR-0007 Context).
+
+The mature "N vendors, one contract" ecosystems all converged on the same answer, decades before us:
+**the contract ships with the suite that verifies implementations against it.** Kubernetes CSI's
+`csi-sanity` runs against any driver over its socket and is *capability-gated* — it first queries
+the driver's advertised capabilities, then tests exactly what was advertised, so one suite verifies
+behavior **and** capability honesty. JDBC's `jdbcCompliant()` may only return true after passing the
+compliance tests — a claim socially backed by a suite. Terraform's `terraform-plugin-testing`
+drives providers through real plan/apply/refresh/destroy cycles and ships `CheckDestroy`, which
+verifies the remote resource is *actually gone*. CSI's spec text is the model for operation
+semantics: "This operation MUST be idempotent … If the volume does not exist, the Plugin MUST reply
+OK", with per-operation error tables that specify what the **caller may do next**.
+
+The repo already owns the perfect host: the smoke lane (`bench-smoke.yml`) boots one live sandbox
+per provider and is explicitly designed so "a green smoke must never hide that the provider was
+never actually smoked."
+
+The specific invariants below were validated during the driver-kit prototyping rounds (compiling
+prototypes and runtime proofs preserved under `docs/adr/prototypes/gpu/` on the exploration
+branch `claude/sdk-provider-benchmark-automation-5hjo0w`); ADR-0007 §9 lists the reproduced
+failure modes they pin.
+
+## Decision
+
+### 1. The port gets spec language, not just types
+
+ADR-0007's port acquires per-operation normative semantics, CSI-style — short, testable clauses in
+the contract's JSDoc:
+
+- `destroy` MUST be idempotent; destroying a sandbox that does not exist MUST succeed. (Today this
+  is a convention each adapter re-implements as a `notFound` regex; it becomes a required property
+  the suite exercises.) The same clauses bind the optional `destroyById`.
+- `destroy` MUST be **convergent**: it MUST NOT resolve while the vendor control plane still
+  reports the sandbox as running. Where the driver declares a `probes.list`/`describe` capability,
+  the suite verifies the sandbox is absent-or-terminal *after* `destroy` resolves. This promotes
+  the strongest teardown in the repo — the GPU lane's terminate-then-verify-unlisted loop
+  (`gpu/modal.ts:55-75`) — from folklore in one adapter to a clause every driver answers.
+- `exec` MUST report the guest's real exit status: `sh -c 'exit 7'` yields
+  `{ kind: "exited", code: 7 }`; a vendor that withholds the code MUST yield `kind: "unknown"` —
+  never a forged number. stdout and stderr MUST NOT be merged.
+- `launch` (or the harness fallback over `exec`) MUST produce *observable completion*: a detached
+  command's done-file is readable afterwards. This clause is precisely the `detachedPoll` claim.
+- A declared `files` capability MUST round-trip both directions: `writeText` then `readFile`
+  returns the same bytes, and a file written via `exec` is readable via `readFile`. A driver with
+  no working filesystem MUST omit the key (never a stub — ADR-0007 rule 2, now enforced rather
+  than trusted); the suite then exercises the harness's exec-based read *and write* fallbacks.
+- A `create` request carrying `gpu` MUST either provision it (verified: `nvidia-smi` succeeds and
+  reports the requested model count) or fail create — never silently benchmark CPU.
+- `create` failures MUST be classifiable: an error matching the registry's
+  `retryableCreatePatterns` is a capacity signal the harness may retry; anything else is terminal.
+  (The CSI pattern: error semantics defined by what the caller is entitled to do next.)
+
+### 2. `@sandbox-benchmarks/driver/conformance`: one suite, any driver
+
+A capability-gated suite in the contract package, embeddable as ordinary `bun test` and drivable
+against **any** `SandboxDriver` — the `csi-sanity` shape:
+
+```ts
+import { conformance } from "@sandbox-benchmarks/driver/conformance";
+
+conformance({
+  driver: () => loadDriver("tama", { env }),
+  declared: REGISTRY["tama"],          // the claims under test
+});
+```
+
+The suite reads the declared capabilities and tests exactly those: lifecycle round-trip; exit-code
+fidelity (0, 7, signal, and the unknown arm); stdout/stderr separation; cwd/env option handling;
+detached launch + done-file observability (**verifies `detachedPoll`**); filesystem
+read-what-you-wrote (**verifies `hasWorkingFilesystem` / `files` presence**); destroy idempotency
+and destroy-of-missing; snapshot create/delete when declared; and **secret hygiene** — no declared
+credential value may appear in any argv, log line or thrown error the suite observed (the redaction
+promise, tested instead of assumed).
+
+Two tiers, matching the repo's existing gate altitudes:
+
+- **Kit tier (every PR, no credentials):** the suite runs against the kit's own machinery —
+  `cliDriver` over a fake CLI, `computeSdkDriver` over a mock compute — so the *generic* drivers
+  are conformant by construction, and a kit regression fails in-editor-fast CI. This tier also
+  owns the kit's robustness invariants, each of which was reproduced as a real failure before
+  being specified: a request whose reported boot artifact contradicts its requested one fails
+  create (and tears down the orphan); a request carrying a spec axis the driver cannot map
+  (`diskGb` on Modal) fails loudly rather than silently dropping it; a teardown failure after a
+  primary failure surfaces **both** errors; partial staged-write failures aggregate; a failed
+  lazy-context load is retried, not memoized forever; opt-in output caps truncate visibly
+  (`truncated: true`) and are never applied by default — the results tar rides uncapped stdout;
+  and host-side extraction of the sandbox-produced results archive rejects `..`/absolute members
+  (the one genuinely hostile path seam, `collect.ts`'s `tar -xzf`).
+- **Smoke tier (live, per provider):** the existing smoke lane runs the suite against the real
+  vendor before the benchmark steps. One sandbox, a few extra minutes, on a lane that already
+  boots one.
+
+### 3. Capability honesty is the gate's verdict, not a side effect
+
+The suite's output is a typed **declared-vs-observed report** (arktype-parsed at the process
+boundary, per ADR-0001):
+
+- **Overclaim** — declared but not observed (`detachedPoll: true` but the done-file never
+  appears) — **fails the gate**. This is the namespace incident, caught in smoke instead of
+  mid-benchmark.
+- **Underclaim** — observed but not declared (a working `files` the driver omits) — is a recorded
+  finding, not a failure: the sandbox merely runs slower paths, and the report says what's being
+  left unused.
+- **Bounded claims are bounded-verified.** `syncCapMs` cannot be cheaply proven (that would mean
+  running a cap-length exec per smoke); the suite instead verifies the *consequence machinery* —
+  that the declared durable path works — so a wrong cap degrades a measurement rather than
+  stranding one.
+
+TCK discipline follows: **a provider does not enter the published matrix until its smoke
+conformance passes**, and the committed report is part of the provider's evidence. This is the
+part that only makes sense because of what this repo *is*: the product is published measurement,
+and "what the vendor's integration actually supports, verified on date X" is itself a measured,
+publishable fact — the conformance report joins the run document as integration evidence, the way
+`isolationFromRuntime` already records observed isolation rather than trusting the brochure.
+
+### 4. Readiness is a strategy, not a loop
+
+runcloud, microsandbox and tama each hand-roll a readiness poll with its own deadline handling and
+terminal-state logic — the code the anatomy study showed is easiest to get wrong. Testcontainers'
+decomposition applies directly: readiness is a **declared strategy object** with three orthogonal
+axes — startup shape (create-returns-ready vs create-then-poll), the readiness signal (a
+`cliDriver` poll+parse+select, an exec probe, a vendor state field), and a timeout. The kit owns
+the loop once; drivers declare the strategy; the conformance suite exercises the declared strategy
+and times it — which turns readiness itself into comparable evidence across providers, in a repo
+whose business is exactly that comparison.
+
+## Consequences
+
+**Adding a provider gains one step that pays for itself:** the first smoke run now tells the author
+"destroy is not idempotent: second destroy threw" or "declared detachedPoll but the done-file never
+appeared" — the two mistakes that today surface as stranded benchmarks weeks later. The failure
+names the operation and the spec clause, not a stack trace in a 55-minute run.
+
+**We accept:**
+
+- **Suite maintenance.** The conformance suite is code the team owns, and a gate's own bugs fail
+  open. Mitigations are structural: the kit tier runs it against the kit's fakes on every PR (a
+  broken suite breaks visibly), and the smoke tier is live, so fake-vs-vendor divergence is caught
+  by the tier that matters.
+- **Smoke minutes.** A few extra minutes and one sandbox per provider per smoke, on a lane that
+  exists precisely to spend that.
+- **Bounded verification of time-based claims.** `syncCapMs` and pricing-adjacent claims are not
+  fully provable in a smoke; the gate verifies their consequence machinery, and the benchmark
+  itself remains the deep verifier.
+- **Spec language discipline.** Normative clauses in JSDoc can drift from the suite. The rule is
+  ADR-0003's: the clause and its test are reviewed together; a clause without a test is marked
+  `unverified` in the report schema, so untested normativity is at least visible.
+
+**We explicitly do not:** publish a TCK for external consumers (the suite serves this repo's
+fourteen providers, not an ecosystem); conformance-test streaming (unmodeled, per ADR-0007);
+enforce performance thresholds in conformance (latency is the benchmark's job — conformance only
+verifies *contract* behavior); or block on underclaims (honest under-declaration costs speed, not
+correctness).

--- a/docs/adr/0008-driver-conformance-gate.md
+++ b/docs/adr/0008-driver-conformance-gate.md
@@ -45,10 +45,9 @@ The repo already owns the perfect host: the smoke lane (`bench-smoke.yml`) boots
 per provider and is explicitly designed so "a green smoke must never hide that the provider was
 never actually smoked."
 
-The specific invariants below were validated during the driver-kit prototyping rounds (compiling
-prototypes and runtime proofs preserved under `docs/adr/prototypes/gpu/` on the exploration
-branch `claude/sdk-provider-benchmark-automation-5hjo0w`); ADR-0007 §9 lists the reproduced
-failure modes they pin.
+The specific invariants below were each validated by reproducing the failure they guard against
+in an executed prototype before being specified; ADR-0007 §9 lists the reproduced failure modes
+they pin.
 
 ## Decision
 

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -15,3 +15,6 @@ here changes, supersede the ADR (leave it in place, note what replaced it) rathe
 | [0003](./0003-generated-pts-catalog-and-drift-gate.md) | Generated PTS catalog behind a drift gate |
 | [0004](./0004-consumption-layer-aggregation.md) | Raw-first history, consumption-layer candidate→promote |
 | [0005](./0005-host-vs-effective-spec-split.md) | Host-vs-effective spec split |
+| [0006](./0006-declarative-provider-onboarding.md) | Declarative provider onboarding |
+| [0007](./0007-sandbox-driver-port.md) | Sandbox driver kit: one port, one file per provider; ComputeSDK as one driver |
+| [0008](./0008-driver-conformance-gate.md) | Driver conformance: the behavioral drift gate |


### PR DESCRIPTION
## What this is

Three accepted ADRs (docs only — no code changes) that establish the target architecture for provider onboarding, the sandbox driver contract, and behavioral conformance. They are written to prospectively guide the implementation and to encode, as explicit guardrails, the failure modes discovered while validating the design.

## Why (the problem, measured on main)

- **Adding one provider touches 25–34 files.** Over the last four additions, eighteen files were touched by all four — a boilerplate spine of re-spelled facts (registry rows, bake tables, CI credential blocks, env plumbing), while the genuinely novel work is 2–4 files.
- **ComputeSDK is now the minority case.** Census of the 14 registered providers: only 3 use a published `@computesdk/*` wrapper unmodified (two are the same vendor), 6 patch wrappers through a private `.methods` table, and 5 are hand-written — including all three of the most recent additions (runcloud, microsandbox, tama; tama has no SDK at all, its control plane is `spawn()` on a CLI).
- **The harness never depended on ComputeSDK.** `packages/harness` and `apps/cli` contain zero computesdk imports; the harness defines five overlapping structural interfaces that wrappers merely happen to satisfy. The GPU lane already routes around the abstraction entirely, driving the native Modal SDK — outside the registry, because the registry has no shape for it.
- **The mismatch has real costs**: 20+ fabricated values (`createdAt: new Date(0)`, forged exit codes), three byte-identical `shellQuote` copies, ~0.9 s of vendor SDK module evaluation on every process start for a job that benchmarks exactly one provider, and two production incidents caused by declared capabilities that didn't match observed behavior (the `UnsupportedFileSystem` truthy stub that killed a namespace step after 12 straight poll failures, and the wrong `detachedPoll: false` that stranded a 55-minute benchmark on a synchronous exec its own server cut at ~4 minutes).

## What is decided

**ADR-0006 — Declarative provider onboarding.** A three-tier parsing model (committed source stays plain TypeScript; process boundaries get arktype morphs; generators get arktype narrows), a discriminated artifact union (`none` / `image` / `baked` / `mirror` / `built`) with type-level partitions that make no-op bakers unconstructable, one provider-identity parser for every boundary crossing, credential descriptors that derive CI wiring, and drift-gated generated regions for the workflow credential blocks. Adding a provider becomes three hand-edited files plus one reviewed generated diff.

**ADR-0007 — The sandbox driver kit.** The port the harness already implies (create / exec / destroy; absent capabilities are `undefined`, never stubs; a discriminated `Exit` union so no driver forges exit codes), shipped as two packages: `driver` (the contract and kit) and `drivers` (one file per provider, lazily loaded, with compile-checked existence in both directions). Drivers bind to the registry through one typed `defineDriver(id, spec)` join that derives their env slice and narrowed artifact. Authors write stateless method tables (unit-testable as pure functions, with a typed `native` escape hatch); a generic `cliDriver` turns a CLI-only vendor into ~15 declarative lines; ComputeSDK is retained as one driver behind a bridge. §8 records the tested-and-rejected single-file alternative; §9 lists nine guardrails, each a reproduced failure (shallow undeclared-key rejection, parallel spec shapes with clashing units, vendored-SDK casts, memo bricking, teardown swallowing the primary error, split-UTF-8 decoding, blanket output caps vs. the base64-tar results transport, and more).

**ADR-0008 — Driver conformance, the behavioral drift gate.** The repo gates every data projection but none of its behavioral claims — the class both incidents came from. The port gains CSI-style spec clauses (idempotent and convergent destroy, exit fidelity, files round-trip, GPU provision-or-fail), and a capability-gated conformance suite runs in two tiers: against kit fakes on every PR, and against live vendors in the existing smoke lane. Declared-vs-observed capability reports become published evidence — overclaims fail the gate, underclaims are recorded findings.

## How the claims were verified

Every code sample and negative (`@ts-expect-error`) case in the ADRs was verified as a compiling prototype under the repo's strict compiler settings before acceptance; quoted error messages are verbatim compiler or runtime output. Import costs and per-SDK module-graph measurements were taken on this repo. The design survived a structured adversarial review, including a deliberate steelman of ComputeSDK (its corrections are recorded in ADR-0007's Context) and a comparative study of mature driver ecosystems (Kubernetes CSI, Terraform plugin framework, Testcontainers, JDBC, Vercel AI SDK).

## Sequencing

ADR-0006's registry and generated wiring land first; ADR-0007's kit and the 14-adapter migration follow (the computesdk bridge keeps unmigrated providers working during the window); ADR-0008's conformance suite lands with the kit tier first, then joins the smoke lane. Each ADR's Consequences section carries its own accepted costs and rejected alternatives.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KthP5iM9B1wtRbh9RYpsYW

---
_Generated by [Claude Code](https://claude.ai/code/session_01KthP5iM9B1wtRbh9RYpsYW)_

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Accepts ADRs 0006–0008 to define declarative provider onboarding, a sandbox driver kit, and a conformance gate; docs only, no code changes. The target state makes the harness depend on `@sandbox-benchmarks/driver` (not `@computesdk/*`), loads drivers lazily from `@sandbox-benchmarks/drivers`, and enforces capability-by-presence with a conformance suite.

- ADR-0006 — Declarative onboarding: restores an arktype-free `ProviderId` identity leaf; adds an artifact union including `built`; derives typed partitions so no-op bakers are unconstructable; introduces provider-input descriptors that generate CI wiring behind a drift gate. Clarifies that `CandidateRefs` remain release-lane composition-root data.
- ADR-0007 — Driver kit: introduces `defineDriver(id, spec)`, `EnvOf`/`ArtifactOf`, `ResolvedArtifact`, shell helpers, and `cliDriver`; drivers are stateless method tables assembled into sessions; absent capabilities are `undefined`; `Exit` encodes exited/signalled/unknown; typed create failures carry retry hints; per-call output caps are opt-in; readiness is a declared strategy; a `computeSdkDriver` bridge retains existing wrappers and vendored types. Tightens guardrails and aligns the counted no-op bakers with the 14-provider census.
- ADR-0008 — Conformance gate: CSI-style clauses (idempotent/convergent destroy, exit fidelity, durable completion, filesystem round-trip with exec fallbacks, GPU provision-or-fail, artifact identity with provenance) and a capability-gated suite (kit fakes on PRs; live smoke). Clarifies invalid `durable`/`syncCapMs` combinations, that GPU declaration lives on `CreateRequest.gpu` with typed rejection, and that TextDecoder tests cover chunk-boundary decoding (not transport streaming).

**Rollout**
- Sequence: land ADR-0006 registry and generators; add the kit and migrate adapters via the `computeSdkDriver` bridge; add the conformance suite’s kit tier; then wire into smoke.
- Required: add one `ProviderId`, one registry entry, one driver file in `@sandbox-benchmarks/drivers` (plus a bake file only for `baked`), run the wiring generator, and pass smoke conformance before adding to the published matrix.

<sup>Written for commit d9fc4915e36422a5afccf27b93141d4732807924. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/starslingdev/hpc-sandbox-benchmarks/pull/382?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added accepted architecture decisions for declarative provider onboarding, a standardized sandbox driver interface, and driver conformance testing.
  * Documented provider registry patterns, lazy driver loading, capability reporting, lifecycle requirements, cleanup, retries, filesystem access, GPU support, and secret handling.
  * Updated the architecture decision index with ADRs 0006–0008.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->