### PR TITLE
feat(driver): implement the sandbox driver kit core (@sandbox-benchmarks/driver)

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -54,6 +54,19 @@
         "typescript": "catalog:",
       },
     },
+    "packages/driver": {
+      "name": "@sandbox-benchmarks/driver",
+      "version": "0.0.0",
+      "dependencies": {
+        "@sandbox-benchmarks/schema": "workspace:*",
+        "arktype": "catalog:",
+      },
+      "devDependencies": {
+        "@repo/tsconfig": "workspace:*",
+        "@types/bun": "catalog:",
+        "typescript": "catalog:",
+      },
+    },
     "packages/figures": {
       "name": "@sandbox-benchmarks/figures",
       "version": "0.0.0",
@@ -704,6 +717,8 @@
     "@runloop/api-client": ["@runloop/api-client@1.28.0", "", { "dependencies": { "@types/node": "^18.11.18", "@types/node-fetch": "^2.6.4", "abort-controller": "^3.0.0", "agentkeepalive": "^4.2.1", "form-data-encoder": "1.7.2", "formdata-node": "^4.3.2", "node-fetch": "^2.6.7", "tar": "^7.5.2", "uuidv7": "^1.0.2", "zod": "^3.24.1" } }, "sha512-ZQVSbSutqknTjgRpsfiiI5WXSkx5KgQvWkUpZQwGMsHR+dPCyM6QQegbAYqQaKuhIxEwxsLkJrSTm2fJkXmunw=="],
 
     "@sandbox-benchmarks/cli": ["@sandbox-benchmarks/cli@workspace:apps/cli"],
+
+    "@sandbox-benchmarks/driver": ["@sandbox-benchmarks/driver@workspace:packages/driver"],
 
     "@sandbox-benchmarks/figures": ["@sandbox-benchmarks/figures@workspace:packages/figures"],
 

--- a/packages/driver/package.json
+++ b/packages/driver/package.json
@@ -2,7 +2,7 @@
 	"name": "@sandbox-benchmarks/driver",
 	"version": "0.0.0",
 	"private": true,
-	"description": "The sandbox driver kit (ADR-0007): the port every provider implements (create / exec / destroy, capabilities by presence), the method-table layer the kit assembles into sessions, harness-owned shell mechanics, and the generic drivers. The root entry is deliberately arktype-free; parsing lives in the ./env and ./cli subpaths.",
+	"description": "The sandbox driver kit (ADR-0007): the port every provider implements (create / exec / destroy, capabilities by presence), the method-table layer the kit assembles into sessions, harness-owned shell mechanics, and the generic drivers. lib/port.ts is the single arktype source of truth for the port's data shapes, including per-provider sandbox id formats (arkregex); ./env and ./cli carry the other parsing surfaces.",
 	"type": "module",
 	"sideEffects": false,
 	"exports": {

--- a/packages/driver/package.json
+++ b/packages/driver/package.json
@@ -1,0 +1,28 @@
+{
+	"name": "@sandbox-benchmarks/driver",
+	"version": "0.0.0",
+	"private": true,
+	"description": "The sandbox driver kit (ADR-0007): the port every provider implements (create / exec / destroy, capabilities by presence), the method-table layer the kit assembles into sessions, harness-owned shell mechanics, and the generic drivers. The root entry is deliberately arktype-free; parsing lives in the ./env and ./cli subpaths.",
+	"type": "module",
+	"sideEffects": false,
+	"exports": {
+		".": "./src/index.ts",
+		"./env": "./src/env.ts",
+		"./cli": "./src/cli.ts",
+		"./computesdk": "./src/computesdk.ts",
+		"./package.json": "./package.json"
+	},
+	"scripts": {
+		"test": "bun test",
+		"typecheck": "tsc --noEmit"
+	},
+	"dependencies": {
+		"@sandbox-benchmarks/schema": "workspace:*",
+		"arktype": "catalog:"
+	},
+	"devDependencies": {
+		"@repo/tsconfig": "workspace:*",
+		"typescript": "catalog:",
+		"@types/bun": "catalog:"
+	}
+}

--- a/packages/driver/package.json
+++ b/packages/driver/package.json
@@ -1,28 +1,28 @@
 {
-	"name": "@sandbox-benchmarks/driver",
-	"version": "0.0.0",
-	"private": true,
-	"description": "The sandbox driver kit (ADR-0007): the port every provider implements (create / exec / destroy, capabilities by presence), the method-table layer the kit assembles into sessions, harness-owned shell mechanics, and the generic drivers. lib/port.ts is the single arktype source of truth for the port's data shapes, including per-provider sandbox id formats (arkregex); ./env and ./cli carry the other parsing surfaces.",
-	"type": "module",
-	"sideEffects": false,
-	"exports": {
-		".": "./src/index.ts",
-		"./env": "./src/env.ts",
-		"./cli": "./src/cli.ts",
-		"./computesdk": "./src/computesdk.ts",
-		"./package.json": "./package.json"
-	},
-	"scripts": {
-		"test": "bun test",
-		"typecheck": "tsc --noEmit"
-	},
-	"dependencies": {
-		"@sandbox-benchmarks/schema": "workspace:*",
-		"arktype": "catalog:"
-	},
-	"devDependencies": {
-		"@repo/tsconfig": "workspace:*",
-		"typescript": "catalog:",
-		"@types/bun": "catalog:"
-	}
+  "name": "@sandbox-benchmarks/driver",
+  "version": "0.0.0",
+  "private": true,
+  "description": "The sandbox driver kit (ADR-0007): the port every provider implements (create / exec / destroy, capabilities by presence), the method-table layer the kit assembles into sessions, harness-owned shell mechanics, and the generic drivers. lib/port.ts is the single arktype source of truth for the port's data shapes, including per-provider sandbox id formats (arkregex); ./env and ./cli carry the other parsing surfaces.",
+  "type": "module",
+  "sideEffects": false,
+  "exports": {
+    ".": "./src/index.ts",
+    "./env": "./src/env.ts",
+    "./cli": "./src/cli.ts",
+    "./computesdk": "./src/computesdk.ts",
+    "./package.json": "./package.json"
+  },
+  "scripts": {
+    "test": "bun test",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@sandbox-benchmarks/schema": "workspace:*",
+    "arktype": "catalog:"
+  },
+  "devDependencies": {
+    "@repo/tsconfig": "workspace:*",
+    "typescript": "catalog:",
+    "@types/bun": "catalog:"
+  }
 }

--- a/packages/driver/src/cli.test.ts
+++ b/packages/driver/src/cli.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, test } from "bun:test";
 import { type } from "arktype";
 import type { CreateRequest } from "./index.ts";
-import { sandboxId } from "./index.ts";
+import { sandboxRef } from "./index.ts";
 import type { CliRunResult, CliSpec } from "./cli.ts";
 import { cliDriver, cliMethodTable, redactArgs } from "./cli.ts";
 
@@ -18,6 +18,7 @@ const request: CreateRequest = {
 
 function tamaLikeSpec(overrides: Partial<CliSpec<MachineRow>> = {}): CliSpec<MachineRow> {
 	return {
+		provider: "tama",
 		binary: "fake-cli",
 		secretFlags: ["--token"],
 		create: (r, name) => ["new", name, "--token", "s3cret", "--image", r.artifactRef],
@@ -74,7 +75,7 @@ describe("cliDriver", () => {
 		const vendor = fakeVendor({ readyAfterPolls: 2 });
 		const driver = cliDriver(tamaLikeSpec(), { run: vendor.run });
 		const session = await driver.create(request);
-		expect(String(session.sandboxId)).toBe("m-1");
+		expect(session.sandboxRef).toEqual({ provider: "tama", id: "m-1" });
 		expect(session.native.status).toBe("ready");
 		const result = await session.exec("echo hi");
 		expect(result.exit).toEqual({ kind: "exited", code: 0 });
@@ -87,13 +88,13 @@ describe("cliDriver", () => {
 		const vendor = fakeVendor();
 		const table = cliMethodTable(tamaLikeSpec(), { run: vendor.run });
 		// destroy-of-missing MUST succeed (ADR-0008):
-		await table.destroyById?.(null, sandboxId("m-gone"));
+		await table.destroyById?.(null, sandboxRef("tama", "m-gone"));
 		// a genuinely different failure is not swallowed:
 		const failing = cliMethodTable(
 			tamaLikeSpec({ destroy: () => ["boom"] }),
 			{ run: async () => ({ stdout: "", stderr: "quota exceeded", code: 9 }) },
 		);
-		await expect(failing.destroyById?.(null, sandboxId("m-1"))).rejects.toThrow(/exit 9: quota exceeded/);
+		await expect(failing.destroyById?.(null, sandboxRef("tama", "m-1"))).rejects.toThrow(/exit 9: quota exceeded/);
 	});
 
 	test("unparseable vendor output produces a path-bearing report, not an undefined", async () => {

--- a/packages/driver/src/cli.test.ts
+++ b/packages/driver/src/cli.test.ts
@@ -1,0 +1,154 @@
+import { describe, expect, test } from "bun:test";
+import { type } from "arktype";
+import type { CreateRequest } from "./index.ts";
+import { sandboxId } from "./index.ts";
+import type { CliRunResult, CliSpec } from "./cli.ts";
+import { cliDriver, cliMethodTable, redactArgs } from "./cli.ts";
+
+const machineRows = type("string.json.parse").to(
+	type({ id: "string", name: "string", status: "string" }).array(),
+);
+type MachineRow = { id: string; name: string; status: string };
+
+const request: CreateRequest = {
+	spec: { vcpus: 4, memoryGb: 8 },
+	artifactRef: "registry.example/toolchain:1",
+	deadlineMs: 2_000,
+};
+
+function tamaLikeSpec(overrides: Partial<CliSpec<MachineRow>> = {}): CliSpec<MachineRow> {
+	return {
+		binary: "fake-cli",
+		secretFlags: ["--token"],
+		create: (r, name) => ["new", name, "--token", "s3cret", "--image", r.artifactRef],
+		ready: {
+			poll: ["list", "--json"],
+			parse: machineRows,
+			select: (rows, name) => rows.find((row) => row.name === name && row.status === "ready") ?? null,
+			pollIntervalMs: 1,
+		},
+		idOf: (row) => row.id,
+		exec: (id, command) => ["exec", id, "--", "bash", "-lc", command],
+		destroy: (id) => ["rm", "-y", id],
+		notFound: /not found|no such machine/i,
+		...overrides,
+	};
+}
+
+/** A scripted fake vendor CLI: create registers the machine; readiness flips after N polls. */
+function fakeVendor(options: { readyAfterPolls?: number } = {}) {
+	const calls: string[][] = [];
+	const machines = new Map<string, MachineRow>();
+	let polls = 0;
+	const run = async (_binary: string, args: readonly string[]): Promise<CliRunResult> => {
+		calls.push([...args]);
+		const [verb] = args;
+		if (verb === "new") {
+			const name = args[1] ?? "";
+			machines.set(name, { id: `m-${machines.size + 1}`, name, status: "booting" });
+			return { stdout: "", stderr: "", code: 0 };
+		}
+		if (verb === "list") {
+			polls += 1;
+			if (polls > (options.readyAfterPolls ?? 1)) {
+				for (const row of machines.values()) row.status = "ready";
+			}
+			return { stdout: JSON.stringify([...machines.values()]), stderr: "", code: 0 };
+		}
+		if (verb === "exec") {
+			return { stdout: "ran\n", stderr: "", code: 0 };
+		}
+		if (verb === "rm") {
+			const id = args[2] ?? "";
+			const existed = [...machines.values()].some((row) => row.id === id);
+			for (const [name, row] of machines) if (row.id === id) machines.delete(name);
+			return existed ? { stdout: "", stderr: "", code: 0 } : { stdout: "", stderr: `machine ${id} not found`, code: 1 };
+		}
+		return { stdout: "", stderr: `unknown verb ${verb}`, code: 2 };
+	};
+	return { run, calls, machines };
+}
+
+describe("cliDriver", () => {
+	test("create polls until ready; the session's native handle IS the parsed row", async () => {
+		const vendor = fakeVendor({ readyAfterPolls: 2 });
+		const driver = cliDriver(tamaLikeSpec(), { run: vendor.run });
+		const session = await driver.create(request);
+		expect(String(session.sandboxId)).toBe("m-1");
+		expect(session.native.status).toBe("ready");
+		const result = await session.exec("echo hi");
+		expect(result.exit).toEqual({ kind: "exited", code: 0 });
+		expect(result.stdout).toBe("ran\n");
+		await session.destroy();
+		expect(vendor.machines.size).toBe(0);
+	});
+
+	test("destroy tolerates not-found (idempotent); other failures surface", async () => {
+		const vendor = fakeVendor();
+		const table = cliMethodTable(tamaLikeSpec(), { run: vendor.run });
+		// destroy-of-missing MUST succeed (ADR-0008):
+		await table.destroyById?.(null, sandboxId("m-gone"));
+		// a genuinely different failure is not swallowed:
+		const failing = cliMethodTable(
+			tamaLikeSpec({ destroy: () => ["boom"] }),
+			{ run: async () => ({ stdout: "", stderr: "quota exceeded", code: 9 }) },
+		);
+		await expect(failing.destroyById?.(null, sandboxId("m-1"))).rejects.toThrow(/exit 9: quota exceeded/);
+	});
+
+	test("unparseable vendor output produces a path-bearing report, not an undefined", async () => {
+		const driver = cliDriver(tamaLikeSpec(), {
+			run: async (_binary, args) =>
+				args[0] === "list"
+					? { stdout: '[{"id":"m-1","name":"bench"}]', stderr: "", code: 0 }
+					: { stdout: "", stderr: "", code: 0 },
+		});
+		await expect(driver.create(request)).rejects.toThrow(/status must be a string \(was missing\)/);
+	});
+
+	test("a create that never becomes ready fails at the request deadline", async () => {
+		const vendor = fakeVendor({ readyAfterPolls: Number.POSITIVE_INFINITY });
+		const driver = cliDriver(tamaLikeSpec(), { run: vendor.run });
+		await expect(driver.create({ ...request, deadlineMs: 25 })).rejects.toThrow(/not ready within 25ms/);
+	});
+
+	test("secret argv values are redacted from every diagnostic", async () => {
+		const driver = cliDriver(tamaLikeSpec(), {
+			run: async () => ({ stdout: "", stderr: "invalid token", code: 3 }),
+		});
+		const failure = await driver.create(request).then(
+			() => null,
+			(error: unknown) => String(error),
+		);
+		expect(failure).toContain("--token ***");
+		expect(failure).not.toContain("s3cret");
+	});
+
+	test("exec caps are per-call opt-in and reported as truncation", async () => {
+		const vendor = fakeVendor();
+		const driver = cliDriver(tamaLikeSpec(), {
+			run: async (_binary, args) =>
+				args[0] === "exec"
+					? { stdout: "x".repeat(100), stderr: "", code: 0 }
+					: vendor.run(_binary, args),
+		});
+		const session = await driver.create(request);
+		const capped = await session.exec("noisy", { maxOutputBytes: 10 });
+		expect(capped.stdout).toHaveLength(10);
+		expect(capped.truncated).toBe(true);
+		const uncapped = await session.exec("noisy");
+		expect(uncapped.stdout).toHaveLength(100);
+		expect(uncapped.truncated).toBe(false);
+	});
+});
+
+describe("redactArgs", () => {
+	test("redacts exactly the value following each secret flag", () => {
+		expect(redactArgs(["login", "--token", "s3cret", "--json"], ["--token"])).toEqual([
+			"login",
+			"--token",
+			"***",
+			"--json",
+		]);
+	});
+});

--- a/packages/driver/src/cli.test.ts
+++ b/packages/driver/src/cli.test.ts
@@ -1,9 +1,9 @@
 import { describe, expect, test } from "bun:test";
 import { type } from "arktype";
-import type { CreateRequest } from "./index.ts";
-import { sandboxRef } from "./index.ts";
 import type { CliRunResult, CliSpec } from "./cli.ts";
 import { cliDriver, cliMethodTable, redactArgs } from "./cli.ts";
+import type { CreateRequest } from "./index.ts";
+import { DriverError, sandboxRef } from "./index.ts";
 
 const machineRows = type("string.json.parse").to(
 	type({ id: "string", name: "string", status: "string" }).array(),
@@ -25,7 +25,8 @@ function tamaLikeSpec(overrides: Partial<CliSpec<MachineRow>> = {}): CliSpec<Mac
 		ready: {
 			poll: ["list", "--json"],
 			parse: machineRows,
-			select: (rows, name) => rows.find((row) => row.name === name && row.status === "ready") ?? null,
+			select: (rows, name) =>
+				rows.find((row) => row.name === name && row.status === "ready") ?? null,
 			pollIntervalMs: 1,
 		},
 		idOf: (row) => row.id,
@@ -63,7 +64,9 @@ function fakeVendor(options: { readyAfterPolls?: number } = {}) {
 			const id = args[2] ?? "";
 			const existed = [...machines.values()].some((row) => row.id === id);
 			for (const [name, row] of machines) if (row.id === id) machines.delete(name);
-			return existed ? { stdout: "", stderr: "", code: 0 } : { stdout: "", stderr: `machine ${id} not found`, code: 1 };
+			return existed
+				? { stdout: "", stderr: "", code: 0 }
+				: { stdout: "", stderr: `machine ${id} not found`, code: 1 };
 		}
 		return { stdout: "", stderr: `unknown verb ${verb}`, code: 2 };
 	};
@@ -84,17 +87,23 @@ describe("cliDriver", () => {
 		expect(vendor.machines.size).toBe(0);
 	});
 
-	test("destroy tolerates not-found (idempotent); other failures surface", async () => {
+	test("destroy tolerates not-found (idempotent); other failures surface with structured fields", async () => {
 		const vendor = fakeVendor();
 		const table = cliMethodTable(tamaLikeSpec(), { run: vendor.run });
 		// destroy-of-missing MUST succeed (ADR-0008):
 		await table.destroyById?.(null, sandboxRef("tama", "m-gone"));
-		// a genuinely different failure is not swallowed:
-		const failing = cliMethodTable(
-			tamaLikeSpec({ destroy: () => ["boom"] }),
-			{ run: async () => ({ stdout: "", stderr: "quota exceeded", code: 9 }) },
-		);
-		await expect(failing.destroyById?.(null, sandboxRef("tama", "m-1"))).rejects.toThrow(/exit 9: quota exceeded/);
+		// a genuinely different failure is not swallowed — and carries a typed code + vendor fields:
+		const failing = cliMethodTable(tamaLikeSpec({ destroy: () => ["boom"] }), {
+			run: async () => ({ stdout: "", stderr: "quota exceeded", code: 9 }),
+		});
+		const error = (await failing
+			.destroyById?.(null, sandboxRef("tama", "m-1"))
+			.catch((caught: unknown) => caught)) as DriverError;
+		expect(error).toBeInstanceOf(DriverError);
+		expect(error.code).toBe("destroy-failed");
+		expect(error.vendorExitCode).toBe(9);
+		expect(error.vendorMessage).toBe("quota exceeded");
+		expect(error.provider).toBe("tama");
 	});
 
 	test("unparseable vendor output produces a path-bearing report, not an undefined", async () => {
@@ -104,25 +113,30 @@ describe("cliDriver", () => {
 					? { stdout: '[{"id":"m-1","name":"bench"}]', stderr: "", code: 0 }
 					: { stdout: "", stderr: "", code: 0 },
 		});
-		await expect(driver.create(request)).rejects.toThrow(/status must be a string \(was missing\)/);
+		const error = (await driver.create(request).catch((caught: unknown) => caught)) as DriverError;
+		expect(error.code).toBe("vendor-output-unparseable");
+		expect(error.vendorMessage).toMatch(/status must be a string \(was missing\)/);
 	});
 
 	test("a create that never becomes ready fails at the request deadline", async () => {
 		const vendor = fakeVendor({ readyAfterPolls: Number.POSITIVE_INFINITY });
 		const driver = cliDriver(tamaLikeSpec(), { run: vendor.run });
-		await expect(driver.create({ ...request, deadlineMs: 25 })).rejects.toThrow(/not ready within 25ms/);
+		const error = (await driver
+			.create({ ...request, deadlineMs: 25 })
+			.catch((caught: unknown) => caught)) as DriverError;
+		expect(error.code).toBe("readiness-timeout");
+		expect(error.message).toMatch(/tama sandbox not ready within 25ms/);
 	});
 
 	test("secret argv values are redacted from every diagnostic", async () => {
 		const driver = cliDriver(tamaLikeSpec(), {
 			run: async () => ({ stdout: "", stderr: "invalid token", code: 3 }),
 		});
-		const failure = await driver.create(request).then(
-			() => null,
-			(error: unknown) => String(error),
-		);
-		expect(failure).toContain("--token ***");
-		expect(failure).not.toContain("s3cret");
+		const error = (await driver.create(request).catch((caught: unknown) => caught)) as DriverError;
+		expect(error.code).toBe("create-failed");
+		expect(error.message).toContain("--token ***");
+		expect(error.message).not.toContain("s3cret");
+		expect(error.vendorMessage).toBe("invalid token");
 	});
 
 	test("exec caps are per-call opt-in and reported as truncation", async () => {

--- a/packages/driver/src/cli.ts
+++ b/packages/driver/src/cli.ts
@@ -9,9 +9,10 @@
 // generated member is unit-testable as a pure function and `session.native` is the vendor's
 // own typed record, not an opaque id string.
 
+import type { ProviderId } from "@sandbox-benchmarks/schema/providers";
 import type { ArkErrors } from "arktype";
-import type { CreateRequest, ExecResult, SandboxDriver, SandboxId } from "./index.ts";
-import { driverFromTable, sandboxId } from "./index.ts";
+import type { CreateRequest, ExecResult, SandboxDriver, SandboxRef } from "./index.ts";
+import { driverFromTable, sandboxRef } from "./index.ts";
 import type { MethodTable } from "./lib/table.ts";
 
 export interface CliRunResult {
@@ -24,6 +25,8 @@ export interface CliRunResult {
 export type CliRunner = (binary: string, args: readonly string[]) => Promise<CliRunResult>;
 
 export interface CliSpec<Row> {
+	/** The provider this CLI fronts — sandbox refs are validated in its id format. */
+	readonly provider: ProviderId;
 	/** Resolved binary path or name (the caller applies any env override). */
 	readonly binary: string;
 	/** Flags whose FOLLOWING argv value is a secret: redacted from every diagnostic. */
@@ -39,10 +42,10 @@ export interface CliSpec<Row> {
 		readonly select: (rows: readonly Row[], name: string) => Row | null;
 		readonly pollIntervalMs?: number;
 	};
-	/** The row's stable sandbox id. */
+	/** The row's stable sandbox id (validated into a SandboxRef by the kit). */
 	readonly idOf: (row: Row) => string;
-	readonly exec: (id: SandboxId, command: string) => readonly string[];
-	readonly destroy: (id: SandboxId) => readonly string[];
+	readonly exec: (id: string, command: string) => readonly string[];
+	readonly destroy: (id: string) => readonly string[];
 	/** Vendor prose meaning "already gone" — destroy-of-missing MUST succeed (ADR-0008). */
 	readonly notFound: RegExp;
 }
@@ -103,7 +106,7 @@ export function cliMethodTable<Row>(
 		}
 		return rows;
 	};
-	const destroyByArgs = async (id: SandboxId): Promise<void> => {
+	const destroyByArgs = async (id: string): Promise<void> => {
 		const args = spec.destroy(id);
 		const result = await call(args);
 		if (result.code !== 0 && !spec.notFound.test(result.stderr) && !spec.notFound.test(result.stdout)) {
@@ -127,7 +130,7 @@ export function cliMethodTable<Row>(
 				}
 				const row = spec.ready.select(parseRows(polled.stdout, spec.ready.poll), name);
 				if (row !== null) {
-					return { handle: row, sandboxId: sandboxId(spec.idOf(row)) };
+					return { handle: row, sandboxRef: sandboxRef(spec.provider, spec.idOf(row)) };
 				}
 				if (Date.now() >= deadline) {
 					return fail(createArgs, `${name} not ready within ${request.deadlineMs}ms`);
@@ -137,7 +140,7 @@ export function cliMethodTable<Row>(
 		},
 		async exec(_ctx, row, command, options_): Promise<ExecResult> {
 			const started = Date.now();
-			const args = spec.exec(sandboxId(spec.idOf(row)), command);
+			const args = spec.exec(spec.idOf(row), command);
 			const result = await call(args);
 			const cap = options_?.maxOutputBytes;
 			const clip = (text: string) => (cap !== undefined && text.length > cap ? text.slice(0, cap) : text);
@@ -150,10 +153,10 @@ export function cliMethodTable<Row>(
 					cap !== undefined && (result.stdout.length > cap || result.stderr.length > cap),
 			};
 		},
-		destroy: (_ctx, row) => destroyByArgs(sandboxId(spec.idOf(row))),
-		// CLI vendors get bare-id reaping for free: the destroy argv only needs the id, and
+		destroy: (_ctx, row) => destroyByArgs(spec.idOf(row)),
+		// CLI vendors get bare-ref reaping for free: the destroy argv only needs the id, and
 		// notFound tolerance already makes it idempotent.
-		destroyById: (_ctx, id) => destroyByArgs(id),
+		destroyById: (_ctx, ref) => destroyByArgs(ref.id),
 		// No files, no launch: absent, not stubbed — the harness fallbacks (shell.ts) cover both.
 	};
 }

--- a/packages/driver/src/cli.ts
+++ b/packages/driver/src/cli.ts
@@ -7,12 +7,18 @@
 //
 // The compiled shape is a MethodTable whose handle is the PARSED READINESS ROW — so every
 // generated member is unit-testable as a pure function and `session.native` is the vendor's
-// own typed record, not an opaque id string.
+// own typed record, not an opaque id string. Readiness polling, output capping and the
+// use-after-destroy guard belong to the kit layer (poll.ts, table.ts); this file supplies only
+// the vendor-specific argv and parsers.
 
+import { randomUUID } from "node:crypto";
 import type { ProviderId } from "@sandbox-benchmarks/schema/providers";
 import type { ArkErrors } from "arktype";
+import { type } from "arktype";
 import type { CreateRequest, ExecResult, SandboxDriver, SandboxRef } from "./index.ts";
 import { driverFromTable, sandboxRef } from "./index.ts";
+import { DriverError } from "./lib/errors.ts";
+import { pollUntilReady } from "./lib/poll.ts";
 import type { MethodTable } from "./lib/table.ts";
 
 export interface CliRunResult {
@@ -55,9 +61,6 @@ export interface CliDriverOptions {
 	readonly run?: CliRunner;
 }
 
-const isArkErrors = (value: unknown): value is ArkErrors =>
-	typeof value === "object" && value !== null && "summary" in value && Symbol.iterator in (value as object);
-
 const defaultRunner: CliRunner = async (binary, args) => {
 	const child = Bun.spawn([binary, ...args], { stdout: "pipe", stderr: "pipe" });
 	const [stdout, stderr, code] = await Promise.all([
@@ -79,89 +82,100 @@ export function redactArgs(args: readonly string[], secretFlags: readonly string
 	return redacted;
 }
 
-class CliError extends Error {
-	constructor(binary: string, args: readonly string[], secretFlags: readonly string[], detail: string) {
-		super(`${binary} ${redactArgs(args, secretFlags).join(" ")}: ${detail}`);
-		this.name = "CliError";
-	}
-}
-
 /** Compile a CLI spec down to a method table (handle = the parsed readiness row). */
 export function cliMethodTable<Row>(
 	spec: CliSpec<Row>,
 	options: CliDriverOptions = {},
 ): MethodTable<Row, null> {
 	const run = options.run ?? defaultRunner;
-	const call = async (args: readonly string[]): Promise<CliRunResult> => {
-		const result = await run(spec.binary, args);
-		return result;
-	};
-	const fail = (args: readonly string[], detail: string): never => {
-		throw new CliError(spec.binary, args, spec.secretFlags, detail);
-	};
-	const parseRows = (raw: string, sourceArgs: readonly string[]): readonly Row[] => {
-		const rows = spec.ready.parse(raw);
-		if (isArkErrors(rows)) {
-			return fail(sourceArgs, `unparseable output: ${rows.summary}`);
-		}
-		return rows;
-	};
-	const destroyByArgs = async (id: string): Promise<void> => {
+	const call = (args: readonly string[]) => run(spec.binary, args);
+	// Vendor failures carry structured fields (exit code + raw stderr) so the harness classifies
+	// by them, not by regexing a formatted message; the message redacts secret argv for humans.
+	const vendorFailed = (
+		code: "create-failed" | "destroy-failed",
+		args: readonly string[],
+		result: CliRunResult,
+		ref?: SandboxRef,
+	): DriverError =>
+		new DriverError(
+			code,
+			`${spec.binary} ${redactArgs(args, spec.secretFlags).join(" ")}: exit ${result.code}`,
+			{
+				provider: spec.provider,
+				vendorExitCode: result.code,
+				vendorMessage: result.stderr.trim(),
+				...(ref ? { ref } : {}),
+			},
+		);
+
+	const destroyByArgs = async (id: string, ref?: SandboxRef): Promise<void> => {
 		const args = spec.destroy(id);
 		const result = await call(args);
-		if (result.code !== 0 && !spec.notFound.test(result.stderr) && !spec.notFound.test(result.stdout)) {
-			fail(args, `exit ${result.code}: ${result.stderr.trim()}`);
+		if (
+			result.code !== 0 &&
+			!spec.notFound.test(result.stderr) &&
+			!spec.notFound.test(result.stdout)
+		) {
+			throw vendorFailed("destroy-failed", args, result, ref);
 		}
 	};
+
 	return {
 		async create(_ctx, request) {
-			const name = `bench-${Math.random().toString(36).slice(2, 10)}`;
+			const name = `bench-${randomUUID()}`;
 			const createArgs = spec.create(request, name);
 			const created = await call(createArgs);
 			if (created.code !== 0) {
-				fail(createArgs, `exit ${created.code}: ${created.stderr.trim()}`);
+				throw vendorFailed("create-failed", createArgs, created);
 			}
-			const deadline = Date.now() + request.deadlineMs;
-			const interval = spec.ready.pollIntervalMs ?? 1_000;
-			for (;;) {
-				const polled = await call(spec.ready.poll);
-				if (polled.code !== 0) {
-					fail(spec.ready.poll, `exit ${polled.code}: ${polled.stderr.trim()}`);
-				}
-				const row = spec.ready.select(parseRows(polled.stdout, spec.ready.poll), name);
-				if (row !== null) {
-					return { handle: row, sandboxRef: sandboxRef(spec.provider, spec.idOf(row)) };
-				}
-				if (Date.now() >= deadline) {
-					return fail(createArgs, `${name} not ready within ${request.deadlineMs}ms`);
-				}
-				await new Promise((resolve) => setTimeout(resolve, interval));
-			}
+			const row = await pollUntilReady({
+				provider: spec.provider,
+				deadlineMs: request.deadlineMs,
+				intervalMs: spec.ready.pollIntervalMs ?? 1_000,
+				poll: async () => {
+					const polled = await call(spec.ready.poll);
+					if (polled.code !== 0) {
+						throw vendorFailed("create-failed", spec.ready.poll, polled);
+					}
+					const rows = spec.ready.parse(polled.stdout);
+					if (rows instanceof type.errors) {
+						throw new DriverError(
+							"vendor-output-unparseable",
+							`${spec.binary} output: ${rows.summary}`,
+							{
+								provider: spec.provider,
+								vendorMessage: rows.summary,
+							},
+						);
+					}
+					return spec.ready.select(rows, name);
+				},
+			});
+			return { handle: row, sandboxRef: sandboxRef(spec.provider, spec.idOf(row)) };
 		},
-		async exec(_ctx, row, command, options_): Promise<ExecResult> {
+		async exec(_ctx, row, command): Promise<ExecResult> {
 			const started = Date.now();
-			const args = spec.exec(spec.idOf(row), command);
-			const result = await call(args);
-			const cap = options_?.maxOutputBytes;
-			const clip = (text: string) => (cap !== undefined && text.length > cap ? text.slice(0, cap) : text);
+			const result = await call(spec.exec(spec.idOf(row), command));
 			return {
 				exit: { kind: "exited", code: result.code },
-				stdout: clip(result.stdout),
-				stderr: clip(result.stderr),
+				stdout: result.stdout,
+				stderr: result.stderr,
 				durationMs: Date.now() - started,
-				truncated:
-					cap !== undefined && (result.stdout.length > cap || result.stderr.length > cap),
+				truncated: false, // the kit applies caps centrally (table.ts / output.ts)
 			};
 		},
 		destroy: (_ctx, row) => destroyByArgs(spec.idOf(row)),
 		// CLI vendors get bare-ref reaping for free: the destroy argv only needs the id, and
 		// notFound tolerance already makes it idempotent.
-		destroyById: (_ctx, ref) => destroyByArgs(ref.id),
+		destroyById: (_ctx, ref) => destroyByArgs(ref.id, ref),
 		// No files, no launch: absent, not stubbed — the harness fallbacks (shell.ts) cover both.
 	};
 }
 
 /** One generic driver; a CLI-only provider becomes a table of argv templates and parsers. */
-export function cliDriver<Row>(spec: CliSpec<Row>, options: CliDriverOptions = {}): SandboxDriver<Row> {
+export function cliDriver<Row>(
+	spec: CliSpec<Row>,
+	options: CliDriverOptions = {},
+): SandboxDriver<Row> {
 	return driverFromTable(cliMethodTable(spec, options), async () => null);
 }

--- a/packages/driver/src/cli.ts
+++ b/packages/driver/src/cli.ts
@@ -1,0 +1,164 @@
+// cliDriver (ADR-0007 §5): the generic driver for CLI-only vendors. A provider whose control
+// plane is `spawn()` on a binary becomes a declarative table of argv templates and parsers.
+// The generic driver owns spawn, secret redaction and not-found matching ONCE; vendor stdout
+// is a trust boundary, so the table's `parse` fields are arktype pipelines and a vendor
+// changing its output shape produces a path-bearing report, not an `undefined` threading
+// through readiness logic.
+//
+// The compiled shape is a MethodTable whose handle is the PARSED READINESS ROW — so every
+// generated member is unit-testable as a pure function and `session.native` is the vendor's
+// own typed record, not an opaque id string.
+
+import type { ArkErrors } from "arktype";
+import type { CreateRequest, ExecResult, SandboxDriver, SandboxId } from "./index.ts";
+import { driverFromTable, sandboxId } from "./index.ts";
+import type { MethodTable } from "./lib/table.ts";
+
+export interface CliRunResult {
+	readonly stdout: string;
+	readonly stderr: string;
+	readonly code: number;
+}
+
+/** Runs the vendor binary. Injectable so cliDriver tables are testable without a real CLI. */
+export type CliRunner = (binary: string, args: readonly string[]) => Promise<CliRunResult>;
+
+export interface CliSpec<Row> {
+	/** Resolved binary path or name (the caller applies any env override). */
+	readonly binary: string;
+	/** Flags whose FOLLOWING argv value is a secret: redacted from every diagnostic. */
+	readonly secretFlags: readonly string[];
+	/** argv to create a sandbox named `name` for `request`. */
+	readonly create: (request: CreateRequest, name: string) => readonly string[];
+	readonly ready: {
+		/** argv that lists/inspects sandboxes; polled until `select` finds the row. */
+		readonly poll: readonly string[];
+		/** Trust boundary: raw stdout → rows, as an arktype pipeline (path-bearing errors). */
+		readonly parse: (raw: string) => readonly Row[] | ArkErrors;
+		/** The created-and-ready row for `name`, or null to keep polling. */
+		readonly select: (rows: readonly Row[], name: string) => Row | null;
+		readonly pollIntervalMs?: number;
+	};
+	/** The row's stable sandbox id. */
+	readonly idOf: (row: Row) => string;
+	readonly exec: (id: SandboxId, command: string) => readonly string[];
+	readonly destroy: (id: SandboxId) => readonly string[];
+	/** Vendor prose meaning "already gone" — destroy-of-missing MUST succeed (ADR-0008). */
+	readonly notFound: RegExp;
+}
+
+export interface CliDriverOptions {
+	/** Override the spawn runner (tests). Defaults to Bun.spawn on the spec's binary. */
+	readonly run?: CliRunner;
+}
+
+const isArkErrors = (value: unknown): value is ArkErrors =>
+	typeof value === "object" && value !== null && "summary" in value && Symbol.iterator in (value as object);
+
+const defaultRunner: CliRunner = async (binary, args) => {
+	const child = Bun.spawn([binary, ...args], { stdout: "pipe", stderr: "pipe" });
+	const [stdout, stderr, code] = await Promise.all([
+		new Response(child.stdout).text(),
+		new Response(child.stderr).text(),
+		child.exited,
+	]);
+	return { stdout, stderr, code };
+};
+
+/** Redact secret values from an argv for diagnostics: the value AFTER a secret flag becomes ***. */
+export function redactArgs(args: readonly string[], secretFlags: readonly string[]): string[] {
+	const redacted: string[] = [];
+	let hide = false;
+	for (const arg of args) {
+		redacted.push(hide ? "***" : arg);
+		hide = secretFlags.includes(arg);
+	}
+	return redacted;
+}
+
+class CliError extends Error {
+	constructor(binary: string, args: readonly string[], secretFlags: readonly string[], detail: string) {
+		super(`${binary} ${redactArgs(args, secretFlags).join(" ")}: ${detail}`);
+		this.name = "CliError";
+	}
+}
+
+/** Compile a CLI spec down to a method table (handle = the parsed readiness row). */
+export function cliMethodTable<Row>(
+	spec: CliSpec<Row>,
+	options: CliDriverOptions = {},
+): MethodTable<Row, null> {
+	const run = options.run ?? defaultRunner;
+	const call = async (args: readonly string[]): Promise<CliRunResult> => {
+		const result = await run(spec.binary, args);
+		return result;
+	};
+	const fail = (args: readonly string[], detail: string): never => {
+		throw new CliError(spec.binary, args, spec.secretFlags, detail);
+	};
+	const parseRows = (raw: string, sourceArgs: readonly string[]): readonly Row[] => {
+		const rows = spec.ready.parse(raw);
+		if (isArkErrors(rows)) {
+			return fail(sourceArgs, `unparseable output: ${rows.summary}`);
+		}
+		return rows;
+	};
+	const destroyByArgs = async (id: SandboxId): Promise<void> => {
+		const args = spec.destroy(id);
+		const result = await call(args);
+		if (result.code !== 0 && !spec.notFound.test(result.stderr) && !spec.notFound.test(result.stdout)) {
+			fail(args, `exit ${result.code}: ${result.stderr.trim()}`);
+		}
+	};
+	return {
+		async create(_ctx, request) {
+			const name = `bench-${Math.random().toString(36).slice(2, 10)}`;
+			const createArgs = spec.create(request, name);
+			const created = await call(createArgs);
+			if (created.code !== 0) {
+				fail(createArgs, `exit ${created.code}: ${created.stderr.trim()}`);
+			}
+			const deadline = Date.now() + request.deadlineMs;
+			const interval = spec.ready.pollIntervalMs ?? 1_000;
+			for (;;) {
+				const polled = await call(spec.ready.poll);
+				if (polled.code !== 0) {
+					fail(spec.ready.poll, `exit ${polled.code}: ${polled.stderr.trim()}`);
+				}
+				const row = spec.ready.select(parseRows(polled.stdout, spec.ready.poll), name);
+				if (row !== null) {
+					return { handle: row, sandboxId: sandboxId(spec.idOf(row)) };
+				}
+				if (Date.now() >= deadline) {
+					return fail(createArgs, `${name} not ready within ${request.deadlineMs}ms`);
+				}
+				await new Promise((resolve) => setTimeout(resolve, interval));
+			}
+		},
+		async exec(_ctx, row, command, options_): Promise<ExecResult> {
+			const started = Date.now();
+			const args = spec.exec(sandboxId(spec.idOf(row)), command);
+			const result = await call(args);
+			const cap = options_?.maxOutputBytes;
+			const clip = (text: string) => (cap !== undefined && text.length > cap ? text.slice(0, cap) : text);
+			return {
+				exit: { kind: "exited", code: result.code },
+				stdout: clip(result.stdout),
+				stderr: clip(result.stderr),
+				durationMs: Date.now() - started,
+				truncated:
+					cap !== undefined && (result.stdout.length > cap || result.stderr.length > cap),
+			};
+		},
+		destroy: (_ctx, row) => destroyByArgs(sandboxId(spec.idOf(row))),
+		// CLI vendors get bare-id reaping for free: the destroy argv only needs the id, and
+		// notFound tolerance already makes it idempotent.
+		destroyById: (_ctx, id) => destroyByArgs(id),
+		// No files, no launch: absent, not stubbed — the harness fallbacks (shell.ts) cover both.
+	};
+}
+
+/** One generic driver; a CLI-only provider becomes a table of argv templates and parsers. */
+export function cliDriver<Row>(spec: CliSpec<Row>, options: CliDriverOptions = {}): SandboxDriver<Row> {
+	return driverFromTable(cliMethodTable(spec, options), async () => null);
+}

--- a/packages/driver/src/computesdk.test.ts
+++ b/packages/driver/src/computesdk.test.ts
@@ -24,7 +24,7 @@ function fakeCompute(sandbox: ComputeSdkSandboxLike, withList = false) {
 }
 
 const baseSandbox: ComputeSdkSandboxLike = {
-	sandboxId: "sb-1",
+	sandboxId: "i2f3k4abc",
 	runCommand: async () => ({ exitCode: 0, stdout: "ok", stderr: "" }),
 	destroy: async () => {},
 };
@@ -33,11 +33,12 @@ describe("computeSdkDriver", () => {
 	test("passes create options through with the request deadline", async () => {
 		const { compute, createOptionsSeen } = fakeCompute(baseSandbox);
 		const driver = computeSdkDriver(compute, {
+			provider: "e2b",
 			createOptions: { snapshotId: "template-1" },
 			hasWorkingFilesystem: false,
 		});
 		const session = await driver.create(request);
-		expect(String(session.sandboxId)).toBe("sb-1");
+		expect(session.sandboxRef).toEqual({ provider: "e2b", id: "i2f3k4abc" });
 		expect(session.artifactRef).toBe("template-1");
 		expect(createOptionsSeen).toEqual([{ snapshotId: "template-1", timeout: 30_000 }]);
 	});
@@ -47,7 +48,7 @@ describe("computeSdkDriver", () => {
 			...baseSandbox,
 			runCommand: async () => ({ stdout: "partial", stderr: "" }),
 		});
-		const session = await computeSdkDriver(compute, { hasWorkingFilesystem: false }).create(request);
+		const session = await computeSdkDriver(compute, { provider: "e2b", hasWorkingFilesystem: false }).create(request);
 		const result = await session.exec("true");
 		expect(result.exit).toEqual({ kind: "unknown", detail: "computesdk adapter reported no exit code" });
 		expect(result.stdout).toBe("partial");
@@ -66,7 +67,7 @@ describe("computeSdkDriver", () => {
 			},
 		};
 		const { compute: stubbed } = fakeCompute({ ...baseSandbox, filesystem: throwingStub });
-		const withoutTrust = await computeSdkDriver(stubbed, { hasWorkingFilesystem: false }).create(request);
+		const withoutTrust = await computeSdkDriver(stubbed, { provider: "e2b", hasWorkingFilesystem: false }).create(request);
 		expect(withoutTrust.files).toBeUndefined();
 
 		const reads: string[] = [];
@@ -81,7 +82,7 @@ describe("computeSdkDriver", () => {
 				writeFile: async () => {},
 			},
 		});
-		const withTrust = await computeSdkDriver(working, { hasWorkingFilesystem: true }).create(request);
+		const withTrust = await computeSdkDriver(working, { provider: "e2b", hasWorkingFilesystem: true }).create(request);
 		expect(await withTrust.files?.readFile("/bench/a")).toBe("content");
 		expect(reads).toEqual(["/bench/a"]);
 	});
@@ -95,22 +96,29 @@ describe("computeSdkDriver", () => {
 				return { exitCode: 0, stdout: "", stderr: "" };
 			},
 		});
-		const session = await computeSdkDriver(compute, { hasWorkingFilesystem: false }).create(request);
+		const session = await computeSdkDriver(compute, { provider: "e2b", hasWorkingFilesystem: false }).create(request);
 		await session.launch?.("bash task.sh");
 		expect(commands).toEqual([["bash task.sh", true]]);
 	});
 
 	test("probes exist exactly when the wrapper exposes list", async () => {
 		const { compute: withList } = fakeCompute(baseSandbox, true);
-		expect(computeSdkDriver(withList, { hasWorkingFilesystem: false }).probes).toBeDefined();
+		expect(computeSdkDriver(withList, { provider: "e2b", hasWorkingFilesystem: false }).probes).toBeDefined();
 		const { compute: withoutList } = fakeCompute(baseSandbox, false);
-		expect(computeSdkDriver(withoutList, { hasWorkingFilesystem: false }).probes).toBeUndefined();
+		expect(computeSdkDriver(withoutList, { provider: "e2b", hasWorkingFilesystem: false }).probes).toBeUndefined();
+	});
+
+	test("a vendor id in the wrong format for the provider fails ref construction", async () => {
+		const { compute } = fakeCompute({ ...baseSandbox, sandboxId: "totally wrong id!" });
+		await expect(
+			computeSdkDriver(compute, { provider: "e2b", hasWorkingFilesystem: false }).create(request),
+		).rejects.toThrow(/invalid sandbox ref: id must be matched by/);
 	});
 
 	test("a sandbox without an id fails create loudly", async () => {
 		const { compute } = fakeCompute({ ...baseSandbox, sandboxId: undefined });
 		await expect(
-			computeSdkDriver(compute, { hasWorkingFilesystem: false }).create(request),
+			computeSdkDriver(compute, { provider: "e2b", hasWorkingFilesystem: false }).create(request),
 		).rejects.toThrow("computesdk wrapper returned a sandbox without a sandboxId");
 	});
 });

--- a/packages/driver/src/computesdk.test.ts
+++ b/packages/driver/src/computesdk.test.ts
@@ -1,0 +1,116 @@
+import { describe, expect, test } from "bun:test";
+import type { CreateRequest } from "./index.ts";
+import type { ComputeSdkLike, ComputeSdkSandboxLike } from "./computesdk.ts";
+import { computeSdkDriver } from "./computesdk.ts";
+
+const request: CreateRequest = {
+	spec: { vcpus: 4, memoryGb: 8 },
+	artifactRef: "template-1",
+	deadlineMs: 30_000,
+};
+
+function fakeCompute(sandbox: ComputeSdkSandboxLike, withList = false) {
+	const createOptionsSeen: Array<Record<string, unknown>> = [];
+	const compute: ComputeSdkLike = {
+		sandbox: {
+			create: async (options) => {
+				createOptionsSeen.push(options ?? {});
+				return sandbox;
+			},
+			...(withList ? { list: async () => ["sb-1"] } : {}),
+		},
+	};
+	return { compute, createOptionsSeen };
+}
+
+const baseSandbox: ComputeSdkSandboxLike = {
+	sandboxId: "sb-1",
+	runCommand: async () => ({ exitCode: 0, stdout: "ok", stderr: "" }),
+	destroy: async () => {},
+};
+
+describe("computeSdkDriver", () => {
+	test("passes create options through with the request deadline", async () => {
+		const { compute, createOptionsSeen } = fakeCompute(baseSandbox);
+		const driver = computeSdkDriver(compute, {
+			createOptions: { snapshotId: "template-1" },
+			hasWorkingFilesystem: false,
+		});
+		const session = await driver.create(request);
+		expect(String(session.sandboxId)).toBe("sb-1");
+		expect(session.artifactRef).toBe("template-1");
+		expect(createOptionsSeen).toEqual([{ snapshotId: "template-1", timeout: 30_000 }]);
+	});
+
+	test("a withheld exit code becomes the representable unknown arm, never a forged number", async () => {
+		const { compute } = fakeCompute({
+			...baseSandbox,
+			runCommand: async () => ({ stdout: "partial", stderr: "" }),
+		});
+		const session = await computeSdkDriver(compute, { hasWorkingFilesystem: false }).create(request);
+		const result = await session.exec("true");
+		expect(result.exit).toEqual({ kind: "unknown", detail: "computesdk adapter reported no exit code" });
+		expect(result.stdout).toBe("partial");
+	});
+
+	test("the filesystem stub never escapes: files exists only when declared working AND present", async () => {
+		const throwingStub = {
+			readFile: async () => {
+				throw new Error("filesystem not supported by this sandbox environment");
+			},
+			exists: async () => {
+				throw new Error("filesystem not supported by this sandbox environment");
+			},
+			writeFile: async () => {
+				throw new Error("filesystem not supported by this sandbox environment");
+			},
+		};
+		const { compute: stubbed } = fakeCompute({ ...baseSandbox, filesystem: throwingStub });
+		const withoutTrust = await computeSdkDriver(stubbed, { hasWorkingFilesystem: false }).create(request);
+		expect(withoutTrust.files).toBeUndefined();
+
+		const reads: string[] = [];
+		const { compute: working } = fakeCompute({
+			...baseSandbox,
+			filesystem: {
+				readFile: async (path) => {
+					reads.push(path);
+					return "content";
+				},
+				exists: async () => true,
+				writeFile: async () => {},
+			},
+		});
+		const withTrust = await computeSdkDriver(working, { hasWorkingFilesystem: true }).create(request);
+		expect(await withTrust.files?.readFile("/bench/a")).toBe("content");
+		expect(reads).toEqual(["/bench/a"]);
+	});
+
+	test("launch rides the wrapper's background convention", async () => {
+		const commands: Array<[string, boolean | undefined]> = [];
+		const { compute } = fakeCompute({
+			...baseSandbox,
+			runCommand: async (command, options) => {
+				commands.push([command, options?.background]);
+				return { exitCode: 0, stdout: "", stderr: "" };
+			},
+		});
+		const session = await computeSdkDriver(compute, { hasWorkingFilesystem: false }).create(request);
+		await session.launch?.("bash task.sh");
+		expect(commands).toEqual([["bash task.sh", true]]);
+	});
+
+	test("probes exist exactly when the wrapper exposes list", async () => {
+		const { compute: withList } = fakeCompute(baseSandbox, true);
+		expect(computeSdkDriver(withList, { hasWorkingFilesystem: false }).probes).toBeDefined();
+		const { compute: withoutList } = fakeCompute(baseSandbox, false);
+		expect(computeSdkDriver(withoutList, { hasWorkingFilesystem: false }).probes).toBeUndefined();
+	});
+
+	test("a sandbox without an id fails create loudly", async () => {
+		const { compute } = fakeCompute({ ...baseSandbox, sandboxId: undefined });
+		await expect(
+			computeSdkDriver(compute, { hasWorkingFilesystem: false }).create(request),
+		).rejects.toThrow("computesdk wrapper returned a sandbox without a sandboxId");
+	});
+});

--- a/packages/driver/src/computesdk.test.ts
+++ b/packages/driver/src/computesdk.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, test } from "bun:test";
-import type { CreateRequest } from "./index.ts";
 import type { ComputeSdkLike, ComputeSdkSandboxLike } from "./computesdk.ts";
 import { computeSdkDriver } from "./computesdk.ts";
+import type { CreateRequest, DriverError } from "./index.ts";
 
 const request: CreateRequest = {
 	spec: { vcpus: 4, memoryGb: 8 },
@@ -48,9 +48,15 @@ describe("computeSdkDriver", () => {
 			...baseSandbox,
 			runCommand: async () => ({ stdout: "partial", stderr: "" }),
 		});
-		const session = await computeSdkDriver(compute, { provider: "e2b", hasWorkingFilesystem: false }).create(request);
+		const session = await computeSdkDriver(compute, {
+			provider: "e2b",
+			hasWorkingFilesystem: false,
+		}).create(request);
 		const result = await session.exec("true");
-		expect(result.exit).toEqual({ kind: "unknown", detail: "computesdk adapter reported no exit code" });
+		expect(result.exit).toEqual({
+			kind: "unknown",
+			detail: "computesdk adapter reported no exit code",
+		});
 		expect(result.stdout).toBe("partial");
 	});
 
@@ -67,7 +73,10 @@ describe("computeSdkDriver", () => {
 			},
 		};
 		const { compute: stubbed } = fakeCompute({ ...baseSandbox, filesystem: throwingStub });
-		const withoutTrust = await computeSdkDriver(stubbed, { provider: "e2b", hasWorkingFilesystem: false }).create(request);
+		const withoutTrust = await computeSdkDriver(stubbed, {
+			provider: "e2b",
+			hasWorkingFilesystem: false,
+		}).create(request);
 		expect(withoutTrust.files).toBeUndefined();
 
 		const reads: string[] = [];
@@ -82,7 +91,10 @@ describe("computeSdkDriver", () => {
 				writeFile: async () => {},
 			},
 		});
-		const withTrust = await computeSdkDriver(working, { provider: "e2b", hasWorkingFilesystem: true }).create(request);
+		const withTrust = await computeSdkDriver(working, {
+			provider: "e2b",
+			hasWorkingFilesystem: true,
+		}).create(request);
 		expect(await withTrust.files?.readFile("/bench/a")).toBe("content");
 		expect(reads).toEqual(["/bench/a"]);
 	});
@@ -96,29 +108,54 @@ describe("computeSdkDriver", () => {
 				return { exitCode: 0, stdout: "", stderr: "" };
 			},
 		});
-		const session = await computeSdkDriver(compute, { provider: "e2b", hasWorkingFilesystem: false }).create(request);
+		const session = await computeSdkDriver(compute, {
+			provider: "e2b",
+			hasWorkingFilesystem: false,
+		}).create(request);
 		await session.launch?.("bash task.sh");
 		expect(commands).toEqual([["bash task.sh", true]]);
 	});
 
 	test("probes exist exactly when the wrapper exposes list", async () => {
 		const { compute: withList } = fakeCompute(baseSandbox, true);
-		expect(computeSdkDriver(withList, { provider: "e2b", hasWorkingFilesystem: false }).probes).toBeDefined();
+		expect(
+			computeSdkDriver(withList, { provider: "e2b", hasWorkingFilesystem: false }).probes,
+		).toBeDefined();
 		const { compute: withoutList } = fakeCompute(baseSandbox, false);
-		expect(computeSdkDriver(withoutList, { provider: "e2b", hasWorkingFilesystem: false }).probes).toBeUndefined();
+		expect(
+			computeSdkDriver(withoutList, { provider: "e2b", hasWorkingFilesystem: false }).probes,
+		).toBeUndefined();
 	});
 
 	test("a vendor id in the wrong format for the provider fails ref construction", async () => {
 		const { compute } = fakeCompute({ ...baseSandbox, sandboxId: "totally wrong id!" });
-		await expect(
-			computeSdkDriver(compute, { provider: "e2b", hasWorkingFilesystem: false }).create(request),
-		).rejects.toThrow(/invalid sandbox ref: id must be matched by/);
+		const error = (await computeSdkDriver(compute, { provider: "e2b", hasWorkingFilesystem: false })
+			.create(request)
+			.catch((caught: unknown) => caught)) as DriverError;
+		expect(error.code).toBe("invalid-sandbox-ref");
+		expect(error.message).toMatch(/id must be matched by/);
+	});
+
+	test("the kit's central byte cap reaches a computesdk session (was ignored before)", async () => {
+		const { compute } = fakeCompute({
+			...baseSandbox,
+			runCommand: async () => ({ exitCode: 0, stdout: "y".repeat(100), stderr: "" }),
+		});
+		const session = await computeSdkDriver(compute, {
+			provider: "e2b",
+			hasWorkingFilesystem: false,
+		}).create(request);
+		const capped = await session.exec("noisy", { maxOutputBytes: 10 });
+		expect(capped.stdout).toHaveLength(10);
+		expect(capped.truncated).toBe(true);
 	});
 
 	test("a sandbox without an id fails create loudly", async () => {
 		const { compute } = fakeCompute({ ...baseSandbox, sandboxId: undefined });
-		await expect(
-			computeSdkDriver(compute, { provider: "e2b", hasWorkingFilesystem: false }).create(request),
-		).rejects.toThrow("computesdk wrapper returned a sandbox without a sandboxId");
+		const error = (await computeSdkDriver(compute, { provider: "e2b", hasWorkingFilesystem: false })
+			.create(request)
+			.catch((caught: unknown) => caught)) as DriverError;
+		expect(error.code).toBe("vendor-contract-violation");
+		expect(error.message).toContain("without a sandboxId");
 	});
 });

--- a/packages/driver/src/computesdk.ts
+++ b/packages/driver/src/computesdk.ts
@@ -14,8 +14,9 @@
 //     classes are nominally different. Code that needs the repo's SDK types is code that
 //     should be a native driver.
 
+import type { ProviderId } from "@sandbox-benchmarks/schema/providers";
 import type { CreateRequest, SandboxDriver, SandboxSession } from "./index.ts";
-import { sandboxId } from "./index.ts";
+import { sandboxRef } from "./index.ts";
 
 /** The structural slice of a computesdk provider instance this bridge consumes. */
 export interface ComputeSdkLike<TSandbox extends ComputeSdkSandboxLike = ComputeSdkSandboxLike> {
@@ -40,6 +41,8 @@ export interface ComputeSdkSandboxLike {
 }
 
 export interface ComputeSdkDriverOptions {
+	/** The provider this wrapper fronts — sandbox refs are validated in its id format. */
+	readonly provider: ProviderId;
 	/**
 	 * Extra create options for the wrapper (the `snapshotId`/`templateId` conventions the bake
 	 * path relies on). An open passthrough by design: the port does not model every vendor's
@@ -71,7 +74,7 @@ export function computeSdkDriver<TSandbox extends ComputeSdkSandboxLike>(
 				throw new Error("computesdk wrapper returned a sandbox without a sandboxId");
 			}
 			return {
-				sandboxId: sandboxId(id),
+				sandboxRef: sandboxRef(options.provider, id),
 				artifactRef: request.artifactRef,
 				native: created,
 				async exec(command) {

--- a/packages/driver/src/computesdk.ts
+++ b/packages/driver/src/computesdk.ts
@@ -2,21 +2,25 @@
 // translations — as ONE driver among several, and stops being the substrate every provider
 // must impersonate.
 //
-// The bridge is deliberately STRUCTURAL: it declares the shape it consumes instead of
-// importing computesdk, so this package adds no vendor dependency and the wrapper packages
-// stay confined to the fleet. Two rules from ADR-0007 are load-bearing here:
+// The bridge is a MethodTable, not a hand-assembled driver, so it flows through the same
+// assembly layer as every other driver (table.ts) and inherits its session invariants for free:
+// central output capping, the use-after-destroy guard, and artifact reconciliation. It is also
+// deliberately STRUCTURAL: it declares the shape it consumes instead of importing computesdk,
+// so this package adds no vendor dependency. Two rules from ADR-0007 are load-bearing:
 //
 //   - `hasWorkingFilesystem` is EXPLICIT, because computesdk's UnsupportedFileSystem is a
 //     truthy stub whose every method throws — the sentinel that killed a namespace step. The
-//     stub is filtered at this boundary and never reaches a consumer.
+//     stub is filtered here and never reaches a consumer.
 //   - `native` is the WRAPPER's sandbox object, typed by the wrapper's own (vendored) SDK —
 //     never cast to this repo's copy of a vendor SDK. Wrappers vendor their own builds; the
 //     classes are nominally different. Code that needs the repo's SDK types is code that
 //     should be a native driver.
 
 import type { ProviderId } from "@sandbox-benchmarks/schema/providers";
-import type { CreateRequest, SandboxDriver, SandboxSession } from "./index.ts";
-import { sandboxRef } from "./index.ts";
+import type { CreateRequest, SandboxDriver } from "./index.ts";
+import { driverFromTable, sandboxRef } from "./index.ts";
+import { DriverError } from "./lib/errors.ts";
+import type { MethodTable } from "./lib/table.ts";
 
 /** The structural slice of a computesdk provider instance this bridge consumes. */
 export interface ComputeSdkLike<TSandbox extends ComputeSdkSandboxLike = ComputeSdkSandboxLike> {
@@ -57,68 +61,96 @@ export interface ComputeSdkDriverOptions {
 	readonly hasWorkingFilesystem: boolean;
 }
 
-/** Adapt a computesdk provider instance to the port. */
-export function computeSdkDriver<TSandbox extends ComputeSdkSandboxLike>(
-	compute: ComputeSdkLike<TSandbox>,
+type ComputeCtx<TSandbox extends ComputeSdkSandboxLike> = ComputeSdkLike<TSandbox>;
+
+/** Compile a computesdk provider instance to a method table. */
+export function computeSdkMethodTable<TSandbox extends ComputeSdkSandboxLike>(
 	options: ComputeSdkDriverOptions,
-): SandboxDriver<TSandbox> {
-	const list = compute.sandbox.list?.bind(compute.sandbox);
+): MethodTable<TSandbox, ComputeCtx<TSandbox>> {
+	const wantsFiles = options.hasWorkingFilesystem;
 	return {
-		async create(request: CreateRequest): Promise<SandboxSession<TSandbox>> {
+		async create(compute, request: CreateRequest) {
 			const created = await compute.sandbox.create({
 				...options.createOptions,
 				timeout: request.deadlineMs,
 			});
 			const id = created.sandboxId;
 			if (id === undefined || id.length === 0) {
-				throw new Error("computesdk wrapper returned a sandbox without a sandboxId");
+				throw new DriverError(
+					"vendor-contract-violation",
+					"computesdk wrapper returned a sandbox without a sandboxId",
+					{
+						provider: options.provider,
+					},
+				);
 			}
+			return { handle: created, sandboxRef: sandboxRef(options.provider, id) };
+		},
+		async exec(_compute, sandbox, command) {
+			const started = Date.now();
+			const result = await sandbox.runCommand(command);
 			return {
-				sandboxRef: sandboxRef(options.provider, id),
-				artifactRef: request.artifactRef,
-				native: created,
-				async exec(command) {
-					const started = Date.now();
-					const result = await created.runCommand(command);
-					return {
-						// No forged `?? 1`: a wrapper that withholds the exit code yields the
-						// representable `unknown` arm instead of a fake failure.
-						exit:
-							result.exitCode === undefined
-								? { kind: "unknown" as const, detail: "computesdk adapter reported no exit code" }
-								: { kind: "exited" as const, code: result.exitCode },
-						stdout: result.stdout ?? "",
-						stderr: result.stderr ?? "",
-						durationMs: Date.now() - started,
-						truncated: false,
-					};
-				},
-				async destroy() {
-					await created.destroy();
-				},
-				async launch(command) {
-					await created.runCommand(command, { background: true });
-				},
-				// The stub never escapes this boundary: files exists only when the wrapper's
-				// filesystem is declared working AND present.
-				...(options.hasWorkingFilesystem && created.filesystem
-					? {
-							files: {
-								readFile: (path: string) => created.filesystem!.readFile(path),
-								exists: (path: string) => created.filesystem!.exists(path),
-								writeText: (path: string, text: string) => created.filesystem!.writeFile(path, text),
-							},
-						}
-					: {}),
+				// No forged `?? 1`: a wrapper that withholds the exit code yields the representable
+				// `unknown` arm instead of a fake failure.
+				exit:
+					result.exitCode === undefined
+						? { kind: "unknown" as const, detail: "computesdk adapter reported no exit code" }
+						: { kind: "exited" as const, code: result.exitCode },
+				stdout: result.stdout ?? "",
+				stderr: result.stderr ?? "",
+				durationMs: Date.now() - started,
+				truncated: false, // the kit applies caps centrally (table.ts / output.ts)
 			};
 		},
-		...(list
+		async destroy(_compute, sandbox) {
+			await sandbox.destroy();
+		},
+		async launch(_compute, sandbox, command) {
+			await sandbox.runCommand(command, { background: true });
+		},
+		// The stub never escapes: files exists only when the wrapper's filesystem is declared
+		// working AND present on the created sandbox (checked per sandbox, hence the guards).
+		...(wantsFiles
 			? {
-					probes: {
-						list,
-						describe: async () => undefined,
+					files: {
+						readFile: (_compute, sandbox, path) =>
+							requireFilesystem(sandbox, options.provider).readFile(path),
+						exists: (_compute, sandbox, path) =>
+							requireFilesystem(sandbox, options.provider).exists(path),
+						writeText: (_compute, sandbox, path, text) =>
+							requireFilesystem(sandbox, options.provider).writeFile(path, text),
 					},
 				}
 			: {}),
+		// probes carried through the table layer; describe is genuinely absent (no per-sandbox
+		// describe on the wrapper) — omitted, not stubbed.
+		probes: { list: (compute) => compute.sandbox.list?.() ?? Promise.resolve(undefined) },
 	};
+}
+
+function requireFilesystem<TSandbox extends ComputeSdkSandboxLike>(
+	sandbox: TSandbox,
+	provider: ProviderId,
+): NonNullable<TSandbox["filesystem"]> {
+	if (!sandbox.filesystem) {
+		throw new DriverError(
+			"vendor-contract-violation",
+			"computesdk wrapper declared a filesystem it did not provide",
+			{
+				provider,
+			},
+		);
+	}
+	return sandbox.filesystem;
+}
+
+/** Adapt a computesdk provider instance to the port. */
+export function computeSdkDriver<TSandbox extends ComputeSdkSandboxLike>(
+	compute: ComputeSdkLike<TSandbox>,
+	options: ComputeSdkDriverOptions,
+): SandboxDriver<TSandbox> {
+	// `list` presence is a per-instance fact; drop the probes capability when the wrapper lacks it.
+	const table = computeSdkMethodTable<TSandbox>(options);
+	const withProbes = compute.sandbox.list ? table : { ...table, probes: undefined };
+	return driverFromTable(withProbes, () => Promise.resolve(compute));
 }

--- a/packages/driver/src/computesdk.ts
+++ b/packages/driver/src/computesdk.ts
@@ -1,0 +1,121 @@
+// The ComputeSDK bridge (ADR-0007 §6): computesdk keeps all its real value — maintained vendor
+// translations — as ONE driver among several, and stops being the substrate every provider
+// must impersonate.
+//
+// The bridge is deliberately STRUCTURAL: it declares the shape it consumes instead of
+// importing computesdk, so this package adds no vendor dependency and the wrapper packages
+// stay confined to the fleet. Two rules from ADR-0007 are load-bearing here:
+//
+//   - `hasWorkingFilesystem` is EXPLICIT, because computesdk's UnsupportedFileSystem is a
+//     truthy stub whose every method throws — the sentinel that killed a namespace step. The
+//     stub is filtered at this boundary and never reaches a consumer.
+//   - `native` is the WRAPPER's sandbox object, typed by the wrapper's own (vendored) SDK —
+//     never cast to this repo's copy of a vendor SDK. Wrappers vendor their own builds; the
+//     classes are nominally different. Code that needs the repo's SDK types is code that
+//     should be a native driver.
+
+import type { CreateRequest, SandboxDriver, SandboxSession } from "./index.ts";
+import { sandboxId } from "./index.ts";
+
+/** The structural slice of a computesdk provider instance this bridge consumes. */
+export interface ComputeSdkLike<TSandbox extends ComputeSdkSandboxLike = ComputeSdkSandboxLike> {
+	readonly sandbox: {
+		create(options?: Record<string, unknown>): Promise<TSandbox>;
+		list?(): Promise<unknown>;
+	};
+}
+
+export interface ComputeSdkSandboxLike {
+	readonly sandboxId?: string;
+	runCommand(
+		command: string,
+		options?: { readonly background?: boolean },
+	): Promise<{ readonly exitCode?: number; readonly stdout?: string; readonly stderr?: string }>;
+	destroy(): Promise<unknown>;
+	readonly filesystem?: {
+		readFile(path: string): Promise<string>;
+		exists(path: string): Promise<boolean>;
+		writeFile(path: string, content: string): Promise<void>;
+	};
+}
+
+export interface ComputeSdkDriverOptions {
+	/**
+	 * Extra create options for the wrapper (the `snapshotId`/`templateId` conventions the bake
+	 * path relies on). An open passthrough by design: the port does not model every vendor's
+	 * create surface, and this is real computesdk knowledge that belongs at the bridge.
+	 */
+	readonly createOptions?: Readonly<Record<string, unknown>>;
+	/**
+	 * Whether the wrapper's filesystem actually works. Explicit, because the wrapper cannot be
+	 * asked: UnsupportedFileSystem is truthy and throws. ADR-0008's smoke conformance verifies
+	 * the answer against the live vendor.
+	 */
+	readonly hasWorkingFilesystem: boolean;
+}
+
+/** Adapt a computesdk provider instance to the port. */
+export function computeSdkDriver<TSandbox extends ComputeSdkSandboxLike>(
+	compute: ComputeSdkLike<TSandbox>,
+	options: ComputeSdkDriverOptions,
+): SandboxDriver<TSandbox> {
+	const list = compute.sandbox.list?.bind(compute.sandbox);
+	return {
+		async create(request: CreateRequest): Promise<SandboxSession<TSandbox>> {
+			const created = await compute.sandbox.create({
+				...options.createOptions,
+				timeout: request.deadlineMs,
+			});
+			const id = created.sandboxId;
+			if (id === undefined || id.length === 0) {
+				throw new Error("computesdk wrapper returned a sandbox without a sandboxId");
+			}
+			return {
+				sandboxId: sandboxId(id),
+				artifactRef: request.artifactRef,
+				native: created,
+				async exec(command) {
+					const started = Date.now();
+					const result = await created.runCommand(command);
+					return {
+						// No forged `?? 1`: a wrapper that withholds the exit code yields the
+						// representable `unknown` arm instead of a fake failure.
+						exit:
+							result.exitCode === undefined
+								? { kind: "unknown" as const, detail: "computesdk adapter reported no exit code" }
+								: { kind: "exited" as const, code: result.exitCode },
+						stdout: result.stdout ?? "",
+						stderr: result.stderr ?? "",
+						durationMs: Date.now() - started,
+						truncated: false,
+					};
+				},
+				async destroy() {
+					await created.destroy();
+				},
+				async launch(command) {
+					await created.runCommand(command, { background: true });
+				},
+				// The stub never escapes this boundary: files exists only when the wrapper's
+				// filesystem is declared working AND present.
+				...(options.hasWorkingFilesystem && created.filesystem
+					? {
+							files: {
+								readFile: (path: string) => created.filesystem!.readFile(path),
+								exists: (path: string) => created.filesystem!.exists(path),
+								writeText: (path: string, text: string) => created.filesystem!.writeFile(path, text),
+							},
+						}
+					: {}),
+			};
+		},
+		...(list
+			? {
+					probes: {
+						list,
+						describe: async () => undefined,
+					},
+				}
+			: {}),
+	};
+}

--- a/packages/driver/src/env.test.ts
+++ b/packages/driver/src/env.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, test } from "bun:test";
+import { parseDriverEnv } from "./env.ts";
+
+describe("parseDriverEnv", () => {
+	test("returns the exact declared slice from an ambient environment", () => {
+		const env = parseDriverEnv("blaxel", {
+			BL_API_KEY: "key",
+			BL_WORKSPACE: "ws",
+			PATH: "/usr/bin",
+			E2B_API_KEY: "someone-else's",
+		});
+		expect(env).toEqual({ BL_API_KEY: "key", BL_WORKSPACE: "ws" });
+	});
+
+	test("a missing credential fails with the repo's one error grammar, naming the provider", () => {
+		expect(() => parseDriverEnv("blaxel", { BL_API_KEY: "key" })).toThrow(
+			/missing credentials for blaxel: BL_WORKSPACE must be a string \(was missing\)/,
+		);
+	});
+
+	test("empty string counts as unset (the config gatekeeper's rule)", () => {
+		expect(() => parseDriverEnv("tama", { TAMA_TOKEN: "" })).toThrow(/TAMA_TOKEN/);
+	});
+
+	test("undeclared ambient variables are never rejected — the pick IS the slice boundary", () => {
+		const env = parseDriverEnv("tama", { TAMA_TOKEN: "tok", HOME: "/root", TERM: "xterm" });
+		expect(Object.keys(env)).toEqual(["TAMA_TOKEN"]);
+	});
+});

--- a/packages/driver/src/env.ts
+++ b/packages/driver/src/env.ts
@@ -7,16 +7,25 @@ import { type } from "arktype";
 import type { CredentialSpec, EnvOf } from "./lib/define.ts";
 import { DRIVER_CREDENTIALS } from "./lib/define.ts";
 
+// One schema per provider, compiled on first use and reused — arktype's `type()` build is the
+// expensive step, and there are only 14 possible ids.
+const schemaCache = new Map<ProviderId, import("arktype").Type<unknown>>();
+
 /** The arktype schema for a provider's env slice: required credentials are non-empty strings. */
-export function envSchemaFor<P extends ProviderId>(id: P) {
-	const shape: Record<string, "string >= 1"> = {};
-	const declared: readonly CredentialSpec[] = DRIVER_CREDENTIALS[id];
-	for (const credential of declared) {
-		shape[credential.optional ? `${credential.name}?` : credential.name] = "string >= 1";
+export function envSchemaFor<P extends ProviderId>(id: P): import("arktype").Type<EnvOf<P>> {
+	let schema = schemaCache.get(id);
+	if (schema === undefined) {
+		const shape: Record<string, "string >= 1"> = {};
+		const declared: readonly CredentialSpec[] = DRIVER_CREDENTIALS[id];
+		for (const credential of declared) {
+			shape[credential.optional ? `${credential.name}?` : credential.name] = "string >= 1";
+		}
+		schema = type(shape);
+		schemaCache.set(id, schema);
 	}
 	// The runtime shape is built from the same literal the mapped type reads; the cast records
 	// that equivalence (arktype cannot see through the dynamic key loop).
-	return type(shape) as unknown as import("arktype").Type<EnvOf<P>>;
+	return schema as unknown as import("arktype").Type<EnvOf<P>>;
 }
 
 /**

--- a/packages/driver/src/env.ts
+++ b/packages/driver/src/env.ts
@@ -1,0 +1,49 @@
+// The runtime dual of EnvOf (ADR-0007 §3), on its own subpath because it imports arktype and
+// the root entry stays arktype-free. Both the compile-time slice (define.ts) and this parser
+// derive from the SAME declaration (DRIVER_CREDENTIALS), so type and validator cannot drift.
+
+import type { ProviderId } from "@sandbox-benchmarks/schema/providers";
+import { type } from "arktype";
+import type { CredentialSpec, EnvOf } from "./lib/define.ts";
+import { DRIVER_CREDENTIALS } from "./lib/define.ts";
+
+/** The arktype schema for a provider's env slice: required credentials are non-empty strings. */
+export function envSchemaFor<P extends ProviderId>(id: P) {
+	const shape: Record<string, "string >= 1"> = {};
+	const declared: readonly CredentialSpec[] = DRIVER_CREDENTIALS[id];
+	for (const credential of declared) {
+		shape[credential.optional ? `${credential.name}?` : credential.name] = "string >= 1";
+	}
+	// The runtime shape is built from the same literal the mapped type reads; the cast records
+	// that equivalence (arktype cannot see through the dynamic key loop).
+	return type(shape) as unknown as import("arktype").Type<EnvOf<P>>;
+}
+
+/**
+ * Parse a provider's env slice out of an ambient environment (`process.env`-shaped input).
+ *
+ * Only DECLARED keys are picked before validation — the ambient environment legitimately holds
+ * hundreds of undeclared variables, so undeclared-key rejection would be wrong here; the slice
+ * boundary is the pick itself. Empty values count as unset (the config gatekeeper's rule).
+ * Failures carry the repo's one error grammar: `TAMA_TOKEN must be a string (was missing)`.
+ */
+export function parseDriverEnv<P extends ProviderId>(
+	id: P,
+	ambient: Readonly<Record<string, string | undefined>>,
+): EnvOf<P> {
+	const declared: readonly CredentialSpec[] = DRIVER_CREDENTIALS[id];
+	const picked: Record<string, string> = {};
+	for (const credential of declared) {
+		const value = ambient[credential.name];
+		if (value !== undefined && value !== "") {
+			picked[credential.name] = value;
+		}
+	}
+	const parsed = envSchemaFor(id)(picked);
+	if (parsed instanceof type.errors) {
+		throw new Error(`missing credentials for ${id}: ${parsed.summary}`);
+	}
+	// `picked` holds exactly the declared, validated keys; the cast records what the schema
+	// just proved (arktype's distilled output type cannot be named through the dynamic loop).
+	return picked as EnvOf<P>;
+}

--- a/packages/driver/src/index.ts
+++ b/packages/driver/src/index.ts
@@ -1,10 +1,13 @@
 // @sandbox-benchmarks/driver — the sandbox driver kit (ADR-0007).
 //
 // This root entry is the port and the kit: everything the harness consumes and everything a
-// driver author implements. It is deliberately arktype-free — the kit is imported by every
-// driver file, and parse machinery lives behind the subpaths that genuinely parse
-// (`./env` for credential slices, `./cli` for CLI-vendor stdout). Import cost is an
-// architectural property; it erodes silently unless a boundary owns it (ADR-0006).
+// driver author implements. lib/port.ts is the SINGLE SOURCE OF TRUTH for the port's data
+// shapes — arktype schemas whose static types are inferred, so the validator, the type, and
+// the error message are one declaration. Behavioral contracts stay plain TypeScript. The
+// subpaths (`./env`, `./cli`, `./computesdk`) organize the parsing surfaces; every kit
+// consumer already evaluates the schema package's arktype graph in-process, so the port's
+// schemas add no new import-cost class (ADR-0006's discipline still holds at the boundary
+// that matters: the registry identity leaf).
 
 export type {
 	ControlPlaneProbes,
@@ -16,12 +19,21 @@ export type {
 	GpuSpec,
 	SandboxDriver,
 	SandboxFiles,
-	SandboxId,
+	SandboxRef,
 	SandboxSession,
 	SnapshotCapability,
 	TargetSpec,
 } from "./lib/port.ts";
-export { sandboxId, succeeded } from "./lib/port.ts";
+export {
+	createRequestSchema,
+	execResultSchema,
+	exitSchema,
+	gpuSpecSchema,
+	parseCreateRequest,
+	sandboxRef,
+	sandboxRefSchema,
+	succeeded,
+} from "./lib/port.ts";
 
 export type { MethodTable } from "./lib/table.ts";
 export { driverFromTable } from "./lib/table.ts";

--- a/packages/driver/src/index.ts
+++ b/packages/driver/src/index.ts
@@ -1,0 +1,33 @@
+// @sandbox-benchmarks/driver — the sandbox driver kit (ADR-0007).
+//
+// This root entry is the port and the kit: everything the harness consumes and everything a
+// driver author implements. It is deliberately arktype-free — the kit is imported by every
+// driver file, and parse machinery lives behind the subpaths that genuinely parse
+// (`./env` for credential slices, `./cli` for CLI-vendor stdout). Import cost is an
+// architectural property; it erodes silently unless a boundary owns it (ADR-0006).
+
+export type {
+	ControlPlaneProbes,
+	CreateBudget,
+	CreateRequest,
+	ExecOptions,
+	ExecResult,
+	Exit,
+	GpuSpec,
+	SandboxDriver,
+	SandboxFiles,
+	SandboxId,
+	SandboxSession,
+	SnapshotCapability,
+	TargetSpec,
+} from "./lib/port.ts";
+export { sandboxId, succeeded } from "./lib/port.ts";
+
+export type { MethodTable } from "./lib/table.ts";
+export { driverFromTable } from "./lib/table.ts";
+
+export type { CredentialSpec, DriverContext, DriverModule, DriverSpec, EnvFromCreds, EnvOf } from "./lib/define.ts";
+export { defineDriver, DRIVER_CREDENTIALS } from "./lib/define.ts";
+
+export { launchDetached, readTextFile, shellQuote, writeTextFile } from "./lib/shell.ts";
+export { withSessionTeardown } from "./lib/session.ts";

--- a/packages/driver/src/index.ts
+++ b/packages/driver/src/index.ts
@@ -10,6 +10,20 @@
 // that matters: the registry identity leaf).
 
 export type {
+	CredentialSpec,
+	DriverContext,
+	DriverModule,
+	DriverSpec,
+	EnvFromCreds,
+	EnvOf,
+} from "./lib/define.ts";
+export { DRIVER_CREDENTIALS, defineDriver } from "./lib/define.ts";
+
+export type { DriverErrorCode, DriverErrorFields } from "./lib/errors.ts";
+export { DriverError, isDriverError } from "./lib/errors.ts";
+export type { ReadinessStrategy } from "./lib/poll.ts";
+export { pollUntilReady } from "./lib/poll.ts";
+export type {
 	ControlPlaneProbes,
 	CreateBudget,
 	CreateRequest,
@@ -34,12 +48,7 @@ export {
 	sandboxRefSchema,
 	succeeded,
 } from "./lib/port.ts";
-
+export { withSessionTeardown } from "./lib/session.ts";
+export { launchDetached, readTextFile, shellQuote, writeTextFile } from "./lib/shell.ts";
 export type { MethodTable } from "./lib/table.ts";
 export { driverFromTable } from "./lib/table.ts";
-
-export type { CredentialSpec, DriverContext, DriverModule, DriverSpec, EnvFromCreds, EnvOf } from "./lib/define.ts";
-export { defineDriver, DRIVER_CREDENTIALS } from "./lib/define.ts";
-
-export { launchDetached, readTextFile, shellQuote, writeTextFile } from "./lib/shell.ts";
-export { withSessionTeardown } from "./lib/session.ts";

--- a/packages/driver/src/lib/define.test.ts
+++ b/packages/driver/src/lib/define.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, test } from "bun:test";
+import { PROVIDERS } from "@sandbox-benchmarks/schema/providers";
+import type { SandboxDriver } from "./port.ts";
+import type { EnvOf } from "./define.ts";
+import { defineDriver, DRIVER_CREDENTIALS } from "./define.ts";
+
+// Minimal type-level assertion helpers (kept local; this is the package's only type-test site).
+type Equal<X, Y> = (<T>() => T extends X ? 1 : 2) extends <T>() => T extends Y ? 1 : 2 ? true : false;
+type Expect<T extends true> = T;
+
+const stubDriver: SandboxDriver = {
+	create: async () => {
+		throw new Error("stub driver — never created in tests");
+	},
+};
+
+describe("DRIVER_CREDENTIALS", () => {
+	test("is pinned to the registry's requiredEnvVars, name for name", () => {
+		// The literal table lives here (the registry's annotation widens its literals away, so the
+		// mapped types cannot read it yet — ADR-0006 moves the declaration there). This pin makes
+		// drift a red test in the meantime: same providers, same names, same order.
+		const fromRegistry: Record<string, string[]> = Object.fromEntries(
+			PROVIDERS.map((meta) => [meta.id, [...meta.requiredEnvVars]]),
+		);
+		const fromKit: Record<string, string[]> = Object.fromEntries(
+			Object.entries(DRIVER_CREDENTIALS).map(([id, credentials]) => [
+				id,
+				credentials.filter((credential) => !("optional" in credential)).map((credential) => credential.name),
+			]),
+		);
+		expect(fromKit).toEqual(fromRegistry);
+	});
+});
+
+describe("EnvOf", () => {
+	test("derives the exact slice from the credential literals", () => {
+		type _tama = Expect<Equal<EnvOf<"tama">, { readonly TAMA_TOKEN: string }>>;
+		type _blaxel = Expect<
+			Equal<EnvOf<"blaxel">, { readonly BL_API_KEY: string; readonly BL_WORKSPACE: string }>
+		>;
+		expect(true).toBe(true); // the assertions above are compile-time; typecheck is the oracle
+	});
+});
+
+describe("defineDriver", () => {
+	test("carries the id and spec through unchanged", () => {
+		const module_ = defineDriver("tama", {
+			createBudget: { owner: "driver", attemptCeilingMs: 60_000 },
+			driver: ({ env }) => {
+				// env is the exact tama slice; both lines below are type-checked by `tsc --noEmit`.
+				const token: string = env.TAMA_TOKEN;
+				void token;
+				// @ts-expect-error — tama declares no E2B_API_KEY; the registry is the source of truth
+				void env.E2B_API_KEY;
+				return stubDriver;
+			},
+		});
+		expect(module_.id).toBe("tama");
+		expect(module_.createBudget).toEqual({ owner: "driver", attemptCeilingMs: 60_000 });
+		const driver = module_.driver({ env: { TAMA_TOKEN: "tok" } });
+		expect(typeof driver.create).toBe("function");
+	});
+
+	test("rejects unregistered provider ids at compile time", () => {
+		// @ts-expect-error — "not-a-provider" is not a ProviderId
+		const bad = () => defineDriver("not-a-provider", { driver: () => stubDriver });
+		void bad;
+		expect(true).toBe(true);
+	});
+});

--- a/packages/driver/src/lib/define.test.ts
+++ b/packages/driver/src/lib/define.test.ts
@@ -1,11 +1,12 @@
 import { describe, expect, test } from "bun:test";
 import { PROVIDERS } from "@sandbox-benchmarks/schema/providers";
-import type { SandboxDriver } from "./port.ts";
 import type { EnvOf } from "./define.ts";
-import { defineDriver, DRIVER_CREDENTIALS } from "./define.ts";
+import { DRIVER_CREDENTIALS, defineDriver } from "./define.ts";
+import type { SandboxDriver } from "./port.ts";
 
 // Minimal type-level assertion helpers (kept local; this is the package's only type-test site).
-type Equal<X, Y> = (<T>() => T extends X ? 1 : 2) extends <T>() => T extends Y ? 1 : 2 ? true : false;
+type Equal<X, Y> =
+	(<T>() => T extends X ? 1 : 2) extends <T>() => T extends Y ? 1 : 2 ? true : false;
 type Expect<T extends true> = T;
 
 const stubDriver: SandboxDriver = {
@@ -25,7 +26,9 @@ describe("DRIVER_CREDENTIALS", () => {
 		const fromKit: Record<string, string[]> = Object.fromEntries(
 			Object.entries(DRIVER_CREDENTIALS).map(([id, credentials]) => [
 				id,
-				credentials.filter((credential) => !("optional" in credential)).map((credential) => credential.name),
+				credentials
+					.filter((credential) => !("optional" in credential))
+					.map((credential) => credential.name),
 			]),
 		);
 		expect(fromKit).toEqual(fromRegistry);

--- a/packages/driver/src/lib/define.ts
+++ b/packages/driver/src/lib/define.ts
@@ -1,0 +1,86 @@
+// The typed join (ADR-0007 §3): a driver binds to the registry through one autocompleted id
+// parameter, and everything it may touch derives from that id — its env slice at the type
+// level here, its runtime env parser in ../env.ts (the runtime dual, built from the SAME
+// declaration so the two cannot drift).
+
+import type { ProviderId } from "@sandbox-benchmarks/schema/providers";
+import type { CreateBudget, SandboxDriver } from "./port.ts";
+
+type Prettify<T> = { [K in keyof T]: T[K] } & {};
+
+export interface CredentialSpec {
+	readonly name: string;
+	readonly optional?: true;
+}
+
+/**
+ * Per-provider credential declarations, literal-typed so {@link EnvOf} is exact.
+ *
+ * This table is a projection of the registry's `requiredEnvVars` — `define.test.ts` pins the
+ * two together, so drift is a red test. Its planned home is the registry itself (ADR-0006's
+ * credential descriptors, whose annotation-free `as const satisfies` shape preserves the
+ * literals this derivation needs); the shape and every derivation below are final, only the
+ * declaration moves.
+ */
+export const DRIVER_CREDENTIALS = {
+	e2b: [{ name: "E2B_API_KEY" }],
+	"daytona-vm": [{ name: "DAYTONA_API_KEY" }],
+	"daytona-container": [{ name: "DAYTONA_API_KEY" }],
+	blaxel: [{ name: "BL_API_KEY" }, { name: "BL_WORKSPACE" }],
+	"microsandbox-local": [{ name: "MICROSANDBOX_LOCAL_BENCH" }],
+	"microsandbox-cloud": [{ name: "MSB_API_KEY" }],
+	"modal-gvisor": [{ name: "MODAL_TOKEN_ID" }, { name: "MODAL_TOKEN_SECRET" }],
+	"modal-vm": [{ name: "MODAL_TOKEN_ID" }, { name: "MODAL_TOKEN_SECRET" }],
+	novita: [{ name: "NOVITA_API_KEY" }],
+	runloop: [{ name: "RUNLOOP_API_KEY" }],
+	namespace: [{ name: "NSC_TOKEN_FILE" }],
+	vercel: [{ name: "VERCEL_OIDC_TOKEN" }],
+	runcloud: [{ name: "RUN_CLOUD_API_KEY" }],
+	tama: [{ name: "TAMA_TOKEN" }],
+} as const satisfies Record<ProviderId, readonly CredentialSpec[]>;
+
+/** The env slice a credentials tuple declares: required → `string`, optional → absent-able. */
+export type EnvFromCreds<C extends readonly CredentialSpec[]> = Prettify<
+	{ readonly [S in Extract<C[number], { optional: true }> as S["name"]]?: string } & {
+		readonly [S in Exclude<C[number], { optional: true }> as S["name"]]: string;
+	}
+>;
+
+/**
+ * The env slice a driver may read: exactly the variables its provider declares. Reading an
+ * undeclared credential is a compile error — "never read process.env here" is unrepresentable
+ * rather than a comment.
+ */
+export type EnvOf<P extends ProviderId> = EnvFromCreds<(typeof DRIVER_CREDENTIALS)[P]>;
+
+export interface DriverContext<P extends ProviderId> {
+	readonly env: EnvOf<P>;
+}
+
+export interface DriverSpec<P extends ProviderId, Handle = unknown> {
+	/** Who owns the create attempt's budget. Omitted ⇒ the harness races create (the default). */
+	readonly createBudget?: CreateBudget;
+	readonly driver: (context: DriverContext<P>) => SandboxDriver<Handle>;
+}
+
+export interface DriverModule<P extends ProviderId, Handle = unknown> extends DriverSpec<P, Handle> {
+	readonly id: P;
+}
+
+/**
+ * Define a provider's driver. The id is the whole join: it is autocompleted against
+ * {@link ProviderId}, an unregistered id fails compile, and the spec can never bend `P`
+ * (`NoInfer`) — only the id names the binding. One generic signature, deliberately not
+ * overloads: overloads prefix every mistake with a signature dump, while a single signature
+ * lands the error on the field the author got wrong.
+ *
+ * The spec literal stays inline in this call (or flows through a `DriverSpec<…>`-typed
+ * factory); an untyped extracted const severs contextual typing (ADR-0007 §9). Anything you
+ * want to extract and unit-test belongs in a `satisfies MethodTable<…>` table instead.
+ */
+export function defineDriver<P extends ProviderId, Handle = unknown>(
+	id: P,
+	spec: DriverSpec<NoInfer<P>, Handle>,
+): DriverModule<P, Handle> {
+	return { ...spec, id } as DriverModule<P, Handle>;
+}

--- a/packages/driver/src/lib/define.ts
+++ b/packages/driver/src/lib/define.ts
@@ -63,7 +63,8 @@ export interface DriverSpec<P extends ProviderId, Handle = unknown> {
 	readonly driver: (context: DriverContext<P>) => SandboxDriver<Handle>;
 }
 
-export interface DriverModule<P extends ProviderId, Handle = unknown> extends DriverSpec<P, Handle> {
+export interface DriverModule<P extends ProviderId, Handle = unknown>
+	extends DriverSpec<P, Handle> {
 	readonly id: P;
 }
 
@@ -82,5 +83,5 @@ export function defineDriver<P extends ProviderId, Handle = unknown>(
 	id: P,
 	spec: DriverSpec<NoInfer<P>, Handle>,
 ): DriverModule<P, Handle> {
-	return { ...spec, id } as DriverModule<P, Handle>;
+	return { ...spec, id };
 }

--- a/packages/driver/src/lib/errors.ts
+++ b/packages/driver/src/lib/errors.ts
@@ -1,0 +1,63 @@
+// One typed error family for the kit (ADR-0008 §1: "create failures MUST be classifiable … error
+// semantics defined by what the caller is entitled to do next"; ADR-0007 §9: "string-matching
+// error prose is how the UnsupportedFileSystem workaround started"). Every kit throw carries a
+// literal `code` the harness switches on, plus structured context — so the retry-vs-terminal and
+// invalid-input-vs-vendor decisions read a field, never a regex over a formatted message.
+
+import type { ProviderId } from "@sandbox-benchmarks/schema/providers";
+import type { SandboxRef } from "./port.ts";
+
+/**
+ * What went wrong, in terms of what the caller may do next:
+ *
+ *   - `invalid-sandbox-ref` / `invalid-create-request` / `missing-credentials` — the input or
+ *     config is wrong. Terminal; fix the input, do not retry.
+ *   - `artifact-mismatch` / `use-after-destroy` / `vendor-contract-violation` — a kit or driver
+ *     invariant was broken. Terminal; a bug, not a transient condition.
+ *   - `create-failed` — the vendor refused create. The harness decides retry-vs-terminal by
+ *     matching the registry's `retryableCreatePatterns` against {@link DriverError.vendorMessage}
+ *     (a designated field — NOT a formatted message that embeds argv).
+ *   - `readiness-timeout` — create was accepted but the sandbox never became ready in budget.
+ *   - `vendor-output-unparseable` — the vendor's control-plane output drifted from its schema.
+ *   - `destroy-failed` — teardown could not converge.
+ */
+export type DriverErrorCode =
+	| "invalid-sandbox-ref"
+	| "invalid-create-request"
+	| "missing-credentials"
+	| "artifact-mismatch"
+	| "use-after-destroy"
+	| "vendor-contract-violation"
+	| "create-failed"
+	| "readiness-timeout"
+	| "vendor-output-unparseable"
+	| "destroy-failed";
+
+export interface DriverErrorFields {
+	readonly provider?: ProviderId;
+	readonly ref?: SandboxRef;
+	/** Raw vendor stderr/detail — the field retry heuristics match, never the formatted message. */
+	readonly vendorMessage?: string;
+	readonly vendorExitCode?: number;
+	readonly cause?: unknown;
+}
+
+export class DriverError extends Error {
+	readonly code: DriverErrorCode;
+	readonly provider: ProviderId | undefined;
+	readonly ref: SandboxRef | undefined;
+	readonly vendorMessage: string | undefined;
+	readonly vendorExitCode: number | undefined;
+
+	constructor(code: DriverErrorCode, message: string, fields: DriverErrorFields = {}) {
+		super(message, fields.cause !== undefined ? { cause: fields.cause } : undefined);
+		this.name = "DriverError";
+		this.code = code;
+		this.provider = fields.provider;
+		this.ref = fields.ref;
+		this.vendorMessage = fields.vendorMessage;
+		this.vendorExitCode = fields.vendorExitCode;
+	}
+}
+
+export const isDriverError = (value: unknown): value is DriverError => value instanceof DriverError;

--- a/packages/driver/src/lib/output.test.ts
+++ b/packages/driver/src/lib/output.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, test } from "bun:test";
+import { capExecOutput } from "./output.ts";
+import { okExec } from "./session.fixture.ts";
+
+const withStreams = (stdout: string, stderr = "") => ({ ...okExec, stdout, stderr });
+
+describe("capExecOutput", () => {
+	test("passes the result through untouched when no cap is set", () => {
+		const result = withStreams("x".repeat(1000));
+		expect(capExecOutput(result, undefined)).toBe(result);
+	});
+
+	test("passes through untouched (same reference) when under the cap", () => {
+		const result = withStreams("small");
+		expect(capExecOutput(result, 1000)).toBe(result);
+	});
+
+	test("caps by BYTES, not UTF-16 code units, and never splits a code point", () => {
+		// "😀" is 4 UTF-8 bytes but 2 UTF-16 code units. A char-based cap of 4 would keep 4 code
+		// units (two emoji, 8 bytes); the byte cap keeps exactly one emoji and reports truncation.
+		const capped = capExecOutput(withStreams("😀😀"), 4);
+		expect(capped.stdout).toBe("😀");
+		expect(Buffer.byteLength(capped.stdout, "utf8")).toBe(4);
+		expect(capped.truncated).toBe(true);
+	});
+
+	test("stops before a code point that would overflow the byte budget", () => {
+		// "é" is 2 bytes; a 3-byte cap fits one "é" (2 bytes) but not two (4), and must not emit a
+		// half code point for the leftover byte.
+		const capped = capExecOutput(withStreams("éé"), 3);
+		expect(capped.stdout).toBe("é");
+		expect(capped.truncated).toBe(true);
+	});
+
+	test("truncation on either stream sets the flag; the other stream is still capped", () => {
+		const capped = capExecOutput({ ...okExec, stdout: "short", stderr: "x".repeat(50) }, 10);
+		expect(capped.stdout).toBe("short");
+		expect(capped.stderr).toHaveLength(10);
+		expect(capped.truncated).toBe(true);
+	});
+});

--- a/packages/driver/src/lib/output.ts
+++ b/packages/driver/src/lib/output.ts
@@ -1,0 +1,42 @@
+// Byte-accurate output capping (ADR-0007 §9: caps are per-call opt-in and never a kit default —
+// results collection rides multi-MB base64-tar over stdout). Applied ONCE, centrally, in
+// driverFromTable's assembled exec — so a method table's exec never sees the option and cannot
+// accept-and-ignore it (the contract violation the ADRs forbid). `maxOutputBytes` means bytes,
+// not UTF-16 code units, so the cap is honest on non-ASCII output and never splits a code point.
+
+import type { ExecResult } from "./port.ts";
+
+const encoder = new TextEncoder();
+
+/** Clip a string to at most `maxBytes` UTF-8 bytes without splitting a code point. */
+function clipToBytes(text: string, maxBytes: number): { text: string; cut: boolean } {
+	if (encoder.encode(text).length <= maxBytes) {
+		return { text, cut: false };
+	}
+	// Walk code points, accumulating byte length, until the next one would overflow.
+	let bytes = 0;
+	let end = 0;
+	for (const codePoint of text) {
+		const size = encoder.encode(codePoint).length;
+		if (bytes + size > maxBytes) break;
+		bytes += size;
+		end += codePoint.length;
+	}
+	return { text: text.slice(0, end), cut: true };
+}
+
+/**
+ * Apply an optional byte cap to an exec result, setting `truncated` when either stream was cut.
+ * `undefined` cap ⇒ the result passes through untouched (the common, uncapped path).
+ */
+export function capExecOutput(result: ExecResult, maxOutputBytes: number | undefined): ExecResult {
+	if (maxOutputBytes === undefined) {
+		return result;
+	}
+	const stdout = clipToBytes(result.stdout, maxOutputBytes);
+	const stderr = clipToBytes(result.stderr, maxOutputBytes);
+	if (!stdout.cut && !stderr.cut) {
+		return result;
+	}
+	return { ...result, stdout: stdout.text, stderr: stderr.text, truncated: true };
+}

--- a/packages/driver/src/lib/poll.ts
+++ b/packages/driver/src/lib/poll.ts
@@ -1,0 +1,39 @@
+// Kit-owned readiness (ADR-0008 §4: readiness is a declared strategy where "the kit owns the loop
+// once" — hand-rolled deadline arithmetic "is the code easiest to get wrong"). A create-then-poll
+// driver supplies only its poll/select closures; the deadline, the interval, the sleep-clamping,
+// and the typed `readiness-timeout` error live here, so every such driver gets them identically.
+
+import type { ProviderId } from "@sandbox-benchmarks/schema/providers";
+import { DriverError } from "./errors.ts";
+
+export interface ReadinessStrategy<T> {
+	readonly provider: ProviderId;
+	/** One readiness probe; returns the ready result, or null to keep polling. */
+	poll(): Promise<T | null>;
+	readonly deadlineMs: number;
+	readonly intervalMs: number;
+}
+
+/**
+ * Poll until `poll()` returns non-null or the deadline passes. Sleeps are clamped to the remaining
+ * budget, and the deadline is checked BEFORE each probe — so a timed-out create never spawns one
+ * extra wasted probe, and the failure is reported on time rather than up to `intervalMs` late.
+ */
+export async function pollUntilReady<T>(strategy: ReadinessStrategy<T>): Promise<T> {
+	const deadline = Date.now() + strategy.deadlineMs;
+	for (;;) {
+		const ready = await strategy.poll();
+		if (ready !== null) {
+			return ready;
+		}
+		const remaining = deadline - Date.now();
+		if (remaining <= 0) {
+			throw new DriverError(
+				"readiness-timeout",
+				`${strategy.provider} sandbox not ready within ${strategy.deadlineMs}ms`,
+				{ provider: strategy.provider },
+			);
+		}
+		await new Promise((resolve) => setTimeout(resolve, Math.min(strategy.intervalMs, remaining)));
+	}
+}

--- a/packages/driver/src/lib/port.test.ts
+++ b/packages/driver/src/lib/port.test.ts
@@ -1,0 +1,102 @@
+import { describe, expect, test } from "bun:test";
+import type { SandboxRef } from "./port.ts";
+import { parseCreateRequest, sandboxRef, sandboxRefSchema, succeeded } from "./port.ts";
+
+// Minimal type-level assertion helpers.
+type Equal<X, Y> = (<T>() => T extends X ? 1 : 2) extends <T>() => T extends Y ? 1 : 2 ? true : false;
+type Expect<T extends true> = T;
+
+describe("sandboxRef", () => {
+	test("accepts each provider's id in its own format", () => {
+		expect(sandboxRef("modal-gvisor", "sb-abc123")).toEqual({ provider: "modal-gvisor", id: "sb-abc123" });
+		expect(sandboxRef("daytona-vm", "8f14e45f-ceea-4b16-a2b8-3c1e5f2a9d01").id).toBe(
+			"8f14e45f-ceea-4b16-a2b8-3c1e5f2a9d01",
+		);
+		expect(sandboxRef("e2b", "i2f3k4abc").id).toBe("i2f3k4abc");
+		expect(sandboxRef("runloop", "dbx_9f8e7d").id).toBe("dbx_9f8e7d");
+		expect(sandboxRef("vercel", "sbx_1a2b3c").id).toBe("sbx_1a2b3c");
+		expect(sandboxRef("tama", "m-1").id).toBe("m-1");
+	});
+
+	test("rejects an id in the wrong format for the provider, naming the pattern", () => {
+		expect(() => sandboxRef("modal-gvisor", "vm-abc123")).toThrow(
+			/invalid sandbox ref: id must be matched by \^sb-\\w\+\$ \(was "vm-abc123"\)/,
+		);
+		expect(() => sandboxRef("e2b", "sb-abc123")).toThrow(/id must be matched by \^i\[a-z0-9\]\+\$/);
+		expect(() => sandboxRef("daytona-vm", "not-a-uuid")).toThrow(/id must be matched by/);
+		expect(() => sandboxRef("tama", "")).toThrow(/invalid sandbox ref/);
+		expect(() => sandboxRef("tama", "has spaces")).toThrow(/invalid sandbox ref/);
+	});
+
+	test("the schema rejects an unregistered provider outright", () => {
+		const parsed = sandboxRefSchema({ provider: "not-a-provider", id: "x" });
+		expect(String(parsed)).toContain("provider must be");
+	});
+
+	test("the id types are narrowed per provider, statically", () => {
+		// arkregex parses the pattern at the type level: Modal ids ARE `sb-${string}`.
+		type _modal = Expect<Equal<SandboxRef<"modal-gvisor">["id"], `sb-${string}`>>;
+		type _runloop = Expect<Equal<SandboxRef<"runloop">["id"], `dbx_${string}`>>;
+		type _provider = Expect<Equal<SandboxRef<"tama">["provider"], "tama">>;
+		const modal = sandboxRef("modal-gvisor", "sb-abc");
+		// @ts-expect-error — a modal ref's id is `sb-${string}`, not any string
+		const wrong: SandboxRef<"modal-gvisor">["id"] = "vm-abc";
+		void wrong;
+		const ok: `sb-${string}` = modal.id;
+		void ok;
+		expect(true).toBe(true); // the assertions above are compile-time; typecheck is the oracle
+	});
+});
+
+describe("parseCreateRequest", () => {
+	const valid = {
+		spec: { vcpus: 4, memoryGb: 8 },
+		artifactRef: "im-abc123",
+		deadlineMs: 60_000,
+		gpu: { model: "H100", count: 1 },
+	};
+
+	test("returns the parsed request (registry-unit spec reused, not re-declared)", () => {
+		const request = parseCreateRequest(valid);
+		expect(request.spec.memoryGb).toBe(8);
+		expect(request.gpu?.model).toBe("H100");
+	});
+
+	test("rejects DEEP undeclared keys — nested misspellings included", () => {
+		expect(() =>
+			parseCreateRequest({ ...valid, spec: { vcpus: 4, memroyGb: 8 } }),
+		).toThrow(/spec\.memroyGb must be removed/);
+		expect(() =>
+			parseCreateRequest({ ...valid, gpu: { model: "H100", count: 1, cout: 2 } }),
+		).toThrow(/gpu\.cout must be removed/);
+		expect(() => parseCreateRequest({ ...valid, deadlienMs: 1 })).toThrow(/deadlienMs must be removed/);
+	});
+
+	test("rejects non-positive and malformed values with path-bearing messages", () => {
+		expect(() => parseCreateRequest({ ...valid, spec: { vcpus: -1, memoryGb: 8 } })).toThrow(
+			/spec\.vcpus must be/,
+		);
+		expect(() => parseCreateRequest({ ...valid, artifactRef: "" })).toThrow(/artifactRef/);
+		expect(() => parseCreateRequest({ ...valid, deadlineMs: 0 })).toThrow(/deadlineMs/);
+		expect(() => parseCreateRequest({ ...valid, gpu: { model: "", count: 1 } })).toThrow(/gpu\.model/);
+	});
+
+	test("gpu and env are genuinely optional", () => {
+		const request = parseCreateRequest({
+			spec: { vcpus: 2, memoryGb: 4, diskGb: 40 },
+			artifactRef: "registry.example/toolchain:1",
+			deadlineMs: 1_000,
+		});
+		expect(request.gpu).toBeUndefined();
+		expect(request.spec.diskGb).toBe(40);
+	});
+});
+
+describe("succeeded", () => {
+	test("only a zero exited code succeeds", () => {
+		expect(succeeded({ kind: "exited", code: 0 })).toBe(true);
+		expect(succeeded({ kind: "exited", code: 7 })).toBe(false);
+		expect(succeeded({ kind: "signalled", signal: "KILL" })).toBe(false);
+		expect(succeeded({ kind: "unknown", detail: "no code" })).toBe(false);
+	});
+});

--- a/packages/driver/src/lib/port.test.ts
+++ b/packages/driver/src/lib/port.test.ts
@@ -1,14 +1,19 @@
 import { describe, expect, test } from "bun:test";
+import { DriverError } from "./errors.ts";
 import type { SandboxRef } from "./port.ts";
 import { parseCreateRequest, sandboxRef, sandboxRefSchema, succeeded } from "./port.ts";
 
 // Minimal type-level assertion helpers.
-type Equal<X, Y> = (<T>() => T extends X ? 1 : 2) extends <T>() => T extends Y ? 1 : 2 ? true : false;
+type Equal<X, Y> =
+	(<T>() => T extends X ? 1 : 2) extends <T>() => T extends Y ? 1 : 2 ? true : false;
 type Expect<T extends true> = T;
 
 describe("sandboxRef", () => {
 	test("accepts each provider's id in its own format", () => {
-		expect(sandboxRef("modal-gvisor", "sb-abc123")).toEqual({ provider: "modal-gvisor", id: "sb-abc123" });
+		expect(sandboxRef("modal-gvisor", "sb-abc123")).toEqual({
+			provider: "modal-gvisor",
+			id: "sb-abc123",
+		});
 		expect(sandboxRef("daytona-vm", "8f14e45f-ceea-4b16-a2b8-3c1e5f2a9d01").id).toBe(
 			"8f14e45f-ceea-4b16-a2b8-3c1e5f2a9d01",
 		);
@@ -23,9 +28,23 @@ describe("sandboxRef", () => {
 			/invalid sandbox ref: id must be matched by \^sb-\\w\+\$ \(was "vm-abc123"\)/,
 		);
 		expect(() => sandboxRef("e2b", "sb-abc123")).toThrow(/id must be matched by \^i\[a-z0-9\]\+\$/);
-		expect(() => sandboxRef("daytona-vm", "not-a-uuid")).toThrow(/id must be matched by/);
+		expect(() => sandboxRef("daytona-vm", "not-a-uuid")).toThrow(/id must be a UUID/);
 		expect(() => sandboxRef("tama", "")).toThrow(/invalid sandbox ref/);
 		expect(() => sandboxRef("tama", "has spaces")).toThrow(/invalid sandbox ref/);
+	});
+
+	test("a rejection is a typed DriverError carrying the provider", () => {
+		const error = (() => {
+			try {
+				sandboxRef("modal-gvisor", "vm-abc");
+				return null;
+			} catch (caught) {
+				return caught;
+			}
+		})();
+		expect(error).toBeInstanceOf(DriverError);
+		expect((error as DriverError).code).toBe("invalid-sandbox-ref");
+		expect((error as DriverError).provider).toBe("modal-gvisor");
 	});
 
 	test("the schema rejects an unregistered provider outright", () => {
@@ -63,13 +82,28 @@ describe("parseCreateRequest", () => {
 	});
 
 	test("rejects DEEP undeclared keys — nested misspellings included", () => {
-		expect(() =>
-			parseCreateRequest({ ...valid, spec: { vcpus: 4, memroyGb: 8 } }),
-		).toThrow(/spec\.memroyGb must be removed/);
+		expect(() => parseCreateRequest({ ...valid, spec: { vcpus: 4, memroyGb: 8 } })).toThrow(
+			/spec\.memroyGb must be removed/,
+		);
 		expect(() =>
 			parseCreateRequest({ ...valid, gpu: { model: "H100", count: 1, cout: 2 } }),
 		).toThrow(/gpu\.cout must be removed/);
-		expect(() => parseCreateRequest({ ...valid, deadlienMs: 1 })).toThrow(/deadlienMs must be removed/);
+		expect(() => parseCreateRequest({ ...valid, deadlienMs: 1 })).toThrow(
+			/deadlienMs must be removed/,
+		);
+	});
+
+	test("a rejection is a typed invalid-create-request DriverError", () => {
+		const error = (() => {
+			try {
+				parseCreateRequest({ ...valid, spec: { vcpus: -1, memoryGb: 8 } });
+				return null;
+			} catch (caught) {
+				return caught;
+			}
+		})();
+		expect(error).toBeInstanceOf(DriverError);
+		expect((error as DriverError).code).toBe("invalid-create-request");
 	});
 
 	test("rejects non-positive and malformed values with path-bearing messages", () => {
@@ -78,7 +112,9 @@ describe("parseCreateRequest", () => {
 		);
 		expect(() => parseCreateRequest({ ...valid, artifactRef: "" })).toThrow(/artifactRef/);
 		expect(() => parseCreateRequest({ ...valid, deadlineMs: 0 })).toThrow(/deadlineMs/);
-		expect(() => parseCreateRequest({ ...valid, gpu: { model: "", count: 1 } })).toThrow(/gpu\.model/);
+		expect(() => parseCreateRequest({ ...valid, gpu: { model: "", count: 1 } })).toThrow(
+			/gpu\.model/,
+		);
 	});
 
 	test("gpu and env are genuinely optional", () => {

--- a/packages/driver/src/lib/port.ts
+++ b/packages/driver/src/lib/port.ts
@@ -16,6 +16,7 @@
 import { targetSpecSchema } from "@sandbox-benchmarks/schema";
 import type { ProviderId } from "@sandbox-benchmarks/schema/providers";
 import { regex, type } from "arktype";
+import { DriverError } from "./errors.ts";
 
 type DeepReadonly<T> = T extends (infer U)[]
 	? readonly DeepReadonly<U>[]
@@ -32,7 +33,6 @@ type DeepReadonly<T> = T extends (infer U)[]
 // smoke, loudly, before any benchmark runs. Formats without vendor evidence start at the
 // conservative `slugId` and are tightened by conformance evidence, never by guesswork.
 const slugId = regex("^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$"); // conservative default
-const uuidId = regex("^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$"); // daytona
 const modalId = regex("^sb-\\w+$"); // observed Modal sandbox id shape
 const e2bLikeId = regex("^i[a-z0-9]+$"); // observed E2B id shape; novita is E2B-compatible
 const runloopId = regex("^dbx_\\w+$"); // Runloop devbox prefix (bpt_/snp_ siblings observed)
@@ -46,8 +46,8 @@ const vercelId = regex("^sbx_\\w+$"); // Vercel Sandbox id prefix
  */
 export const sandboxRefSchema = type.or(
 	{ provider: "'e2b'", id: e2bLikeId },
-	{ provider: "'daytona-vm'", id: uuidId },
-	{ provider: "'daytona-container'", id: uuidId },
+	{ provider: "'daytona-vm'", id: "string.uuid" },
+	{ provider: "'daytona-container'", id: "string.uuid" },
 	{ provider: "'blaxel'", id: slugId },
 	{ provider: "'microsandbox-local'", id: slugId },
 	{ provider: "'microsandbox-cloud'", id: slugId },
@@ -64,15 +64,16 @@ export const sandboxRefSchema = type.or(
 type SandboxRefUnion = typeof sandboxRefSchema.infer;
 
 // The schema's provider branches must cover ProviderId exactly — both directions pinned at
-// compile time, so a provider added to the registry without an id format (or a stray branch)
-// is a type error here, not a runtime surprise.
-type _refCoversRegistry = [SandboxRefUnion["provider"]] extends [ProviderId]
-	? [ProviderId] extends [SandboxRefUnion["provider"]]
-		? true
-		: never
-	: never;
-const _refCoversRegistry: _refCoversRegistry = true;
-void _refCoversRegistry;
+// compile time (type-only; erases entirely), so a provider added to the registry without an id
+// format (or a stray branch) is a type error here, not a runtime surprise.
+type Assert<T extends true> = T;
+type _refCoversRegistry = Assert<
+	[SandboxRefUnion["provider"]] extends [ProviderId]
+		? [ProviderId] extends [SandboxRefUnion["provider"]]
+			? true
+			: false
+		: false
+>;
 
 export type SandboxRef<P extends ProviderId = ProviderId> = DeepReadonly<
 	Extract<SandboxRefUnion, { provider: P }>
@@ -82,7 +83,9 @@ export type SandboxRef<P extends ProviderId = ProviderId> = DeepReadonly<
 export function sandboxRef<P extends ProviderId>(provider: P, id: string): SandboxRef<P> {
 	const parsed = sandboxRefSchema({ provider, id });
 	if (parsed instanceof type.errors) {
-		throw new Error(`invalid sandbox ref: ${parsed.summary}`);
+		throw new DriverError("invalid-sandbox-ref", `invalid sandbox ref: ${parsed.summary}`, {
+			provider,
+		});
 	}
 	// The schema just proved the branch for `provider`; Extract names what arktype validated.
 	return parsed as SandboxRef<P>;
@@ -160,7 +163,7 @@ export type TargetSpec = CreateRequest["spec"];
 export function parseCreateRequest(input: unknown): CreateRequest {
 	const parsed = createRequestSchema(input);
 	if (parsed instanceof type.errors) {
-		throw new Error(`invalid CreateRequest: ${parsed.summary}`);
+		throw new DriverError("invalid-create-request", `invalid CreateRequest: ${parsed.summary}`);
 	}
 	return parsed;
 }
@@ -201,7 +204,8 @@ export interface SandboxSession<Handle = unknown> {
 export interface ControlPlaneProbes {
 	/** Timed only; the value is discarded. */
 	list(): Promise<unknown>;
-	describe(ref: SandboxRef): Promise<unknown>;
+	/** Optional. Absent ⇒ the provider has no per-sandbox describe probe — never a no-op stub. */
+	describe?(ref: SandboxRef): Promise<unknown>;
 }
 
 export interface SnapshotCapability {

--- a/packages/driver/src/lib/port.ts
+++ b/packages/driver/src/lib/port.ts
@@ -1,41 +1,118 @@
 // The sandbox driver port (ADR-0007 §2): the contract every provider implements and the only
-// provider-facing surface the harness consumes. Three required operations — create, exec,
-// destroy — plus capabilities that are either present and working or absent (`undefined`),
-// never a stub that lies (the `UnsupportedFileSystem` incident is why).
+// provider-facing surface the harness consumes.
 //
-// This module is types plus two tiny constructors. It imports nothing.
+// This module is the kit's SINGLE SOURCE OF TRUTH for the port's data shapes: every parsed or
+// persisted shape is an arktype schema and its static type is INFERRED from it — one
+// declaration yields the runtime validator, the compile-time type, and the error message.
+// Behavioral contracts (sessions, drivers, capabilities) stay plain TypeScript below, because
+// runtime schemas cannot prove asynchronous behavior, idempotency, or handle/context
+// relationships — that is ADR-0008's job.
+//
+// The target spec is deliberately NOT declared here: it is reused from the registry's own
+// `targetSpecSchema` (one spec vocabulary, one unit system — ADR-0007 §9's "never mint a
+// parallel spec shape"). The kit's consumers (harness, CLI, drivers) all already evaluate the
+// schema package in-process, so this reuse adds no new import cost class.
 
-/** Branded so a sandbox id cannot be swapped with a snapshot id or a provider id. */
-export type SandboxId = string & { readonly __sandboxId: unique symbol };
+import { targetSpecSchema } from "@sandbox-benchmarks/schema";
+import type { ProviderId } from "@sandbox-benchmarks/schema/providers";
+import { regex, type } from "arktype";
 
-/** The one blessed constructor; empty ids are wiring bugs and fail here, not at the vendor. */
-export function sandboxId(raw: string): SandboxId {
-	if (raw.length === 0) {
-		throw new Error("sandboxId must be non-empty");
+type DeepReadonly<T> = T extends (infer U)[]
+	? readonly DeepReadonly<U>[]
+	: T extends object
+		? { readonly [K in keyof T]: DeepReadonly<T[K]> }
+		: T;
+
+/* ------------------------------ Sandbox identification ------------------------------ */
+
+// Per-provider sandbox id formats, statically parsed by arkregex so the inferred id types are
+// template literals where the pattern allows (`sb-${string}` for Modal), plain-but-validated
+// strings elsewhere. Confidence varies by vendor and is annotated; every format is a behavioral
+// claim ADR-0008's smoke conformance verifies against a live sandbox — a wrong pattern fails in
+// smoke, loudly, before any benchmark runs. Formats without vendor evidence start at the
+// conservative `slugId` and are tightened by conformance evidence, never by guesswork.
+const slugId = regex("^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$"); // conservative default
+const uuidId = regex("^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$"); // daytona
+const modalId = regex("^sb-\\w+$"); // observed Modal sandbox id shape
+const e2bLikeId = regex("^i[a-z0-9]+$"); // observed E2B id shape; novita is E2B-compatible
+const runloopId = regex("^dbx_\\w+$"); // Runloop devbox prefix (bpt_/snp_ siblings observed)
+const vercelId = regex("^sbx_\\w+$"); // Vercel Sandbox id prefix
+
+/**
+ * Sandbox identification: WHICH provider's control plane owns the sandbox, and its id in that
+ * provider's own format. One discriminated schema (arktype auto-discriminates on `provider`)
+ * is the source of truth for both the runtime validation and the narrowed static types —
+ * `SandboxRef<"modal-gvisor">["id"]` is `` `sb-${string}` ``, not `string`.
+ */
+export const sandboxRefSchema = type.or(
+	{ provider: "'e2b'", id: e2bLikeId },
+	{ provider: "'daytona-vm'", id: uuidId },
+	{ provider: "'daytona-container'", id: uuidId },
+	{ provider: "'blaxel'", id: slugId },
+	{ provider: "'microsandbox-local'", id: slugId },
+	{ provider: "'microsandbox-cloud'", id: slugId },
+	{ provider: "'modal-gvisor'", id: modalId },
+	{ provider: "'modal-vm'", id: modalId },
+	{ provider: "'novita'", id: e2bLikeId },
+	{ provider: "'runloop'", id: runloopId },
+	{ provider: "'namespace'", id: slugId },
+	{ provider: "'vercel'", id: vercelId },
+	{ provider: "'runcloud'", id: slugId },
+	{ provider: "'tama'", id: slugId },
+);
+
+type SandboxRefUnion = typeof sandboxRefSchema.infer;
+
+// The schema's provider branches must cover ProviderId exactly — both directions pinned at
+// compile time, so a provider added to the registry without an id format (or a stray branch)
+// is a type error here, not a runtime surprise.
+type _refCoversRegistry = [SandboxRefUnion["provider"]] extends [ProviderId]
+	? [ProviderId] extends [SandboxRefUnion["provider"]]
+		? true
+		: never
+	: never;
+const _refCoversRegistry: _refCoversRegistry = true;
+void _refCoversRegistry;
+
+export type SandboxRef<P extends ProviderId = ProviderId> = DeepReadonly<
+	Extract<SandboxRefUnion, { provider: P }>
+>;
+
+/** The one blessed constructor: a ref that parses is a ref in that provider's real format. */
+export function sandboxRef<P extends ProviderId>(provider: P, id: string): SandboxRef<P> {
+	const parsed = sandboxRefSchema({ provider, id });
+	if (parsed instanceof type.errors) {
+		throw new Error(`invalid sandbox ref: ${parsed.summary}`);
 	}
-	return raw as SandboxId;
+	// The schema just proved the branch for `provider`; Extract names what arktype validated.
+	return parsed as SandboxRef<P>;
 }
+
+/* --------------------------------- Command results --------------------------------- */
 
 /**
  * How a command ended. "Didn't tell us" is representable (`unknown`), so no driver ever forges
  * an exit code (`?? 1`, `?? 127`) — a missing code becomes evidence in the run document instead
  * of a fake failure (ADR-0008: exec MUST report the guest's real exit status).
  */
-export type Exit =
-	| { readonly kind: "exited"; readonly code: number }
-	| { readonly kind: "signalled"; readonly signal: string }
-	| { readonly kind: "unknown"; readonly detail: string };
+export const exitSchema = type.or(
+	{ kind: "'exited'", code: "number.integer" },
+	{ kind: "'signalled'", signal: "string >= 1" },
+	{ kind: "'unknown'", detail: "string" },
+);
+export type Exit = DeepReadonly<typeof exitSchema.infer>;
 
 export const succeeded = (exit: Exit): boolean => exit.kind === "exited" && exit.code === 0;
 
-export interface ExecResult {
-	readonly exit: Exit;
-	readonly stdout: string;
-	readonly stderr: string;
-	readonly durationMs: number;
+export const execResultSchema = type({
+	exit: exitSchema,
+	stdout: "string",
+	stderr: "string",
+	durationMs: "number >= 0",
 	/** True when a per-call {@link ExecOptions.maxOutputBytes} cap cut a stream. */
-	readonly truncated: boolean;
-}
+	truncated: "boolean",
+});
+export type ExecResult = DeepReadonly<typeof execResultSchema.infer>;
 
 export interface ExecOptions {
 	/**
@@ -46,42 +123,54 @@ export interface ExecOptions {
 	readonly maxOutputBytes?: number;
 }
 
-/**
- * The benchmark's resource target, in the registry's own vocabulary and units
- * (`targetSpecSchema`: vcpus / memoryGb / diskGb). Never mint a parallel spec shape — vendor
- * unit conversions (e.g. Gb→MiB) live in exactly one driver-local expression (ADR-0007 §9).
- * `diskGb` is optional: a driver that cannot express a *present* disk requirement MUST fail
- * create loudly rather than silently dropping it.
- */
-export interface TargetSpec {
-	readonly vcpus: number;
-	readonly memoryGb: number;
-	readonly diskGb?: number;
-}
+/* --------------------------------- Create requests --------------------------------- */
 
 /** Vendor-neutral GPU request; drivers map it to vendor syntax (Modal: "H100!", "A100:2"). */
-export interface GpuSpec {
-	readonly model: string;
-	readonly count: number;
-}
+export const gpuSpecSchema = type({
+	model: "string >= 1",
+	count: "number.integer > 0",
+});
+export type GpuSpec = DeepReadonly<typeof gpuSpecSchema.infer>;
 
-export interface CreateRequest {
-	readonly spec: TargetSpec;
+/**
+ * The request a driver boots. `spec` IS the registry's `targetSpecSchema` (vcpus / memoryGb /
+ * diskGb?, registry units — vendor conversions live in exactly one driver-local expression);
+ * a driver that cannot express a *present* `diskGb` MUST fail create loudly. A driver that
+ * cannot honor a requested `gpu` MUST fail create — never silently benchmark CPU.
+ */
+export const createRequestSchema = type({
+	spec: targetSpecSchema,
 	/**
 	 * The boot artifact reference resolved from the registry's artifact descriptor — or, for
 	 * artifacts built at run time (kind "built"), the ref the driver's context factory produced.
-	 * Drivers may report the ref they actually booted; see {@link MethodTable.create} in table.ts.
 	 */
-	readonly artifactRef: string;
-	readonly deadlineMs: number;
-	/** A driver that cannot honor a requested GPU MUST fail create — never silently run on CPU. */
-	readonly gpu?: GpuSpec;
-	readonly env?: Readonly<Record<string, string>>;
-}
+	artifactRef: "string >= 1",
+	deadlineMs: "number.integer > 0",
+	"gpu?": gpuSpecSchema,
+	"env?": "Record<string, string>",
+}).onDeepUndeclaredKey("reject"); // shallow "+": "reject" misses nested misspellings (§9)
+
+export type CreateRequest = DeepReadonly<typeof createRequestSchema.infer>;
+export type TargetSpec = CreateRequest["spec"];
 
 /**
- * A working filesystem API — reads AND writes — or the capability is absent. All-or-nothing:
- * every vendor with a real filesystem API supports both directions, and sessions without it get
+ * Parse once, where CLI/config/persisted input becomes a trusted request — the plan→request
+ * seam. Drivers never re-validate: by the time a request reaches a table, it is trusted.
+ */
+export function parseCreateRequest(input: unknown): CreateRequest {
+	const parsed = createRequestSchema(input);
+	if (parsed instanceof type.errors) {
+		throw new Error(`invalid CreateRequest: ${parsed.summary}`);
+	}
+	return parsed;
+}
+
+/* ------------------------- Behavioral contracts (plain TS) ------------------------- */
+
+/**
+ * A working filesystem API — reads AND writes — or the capability is absent (`undefined`),
+ * never a stub that lies (the `UnsupportedFileSystem` incident is why). All-or-nothing: every
+ * vendor with a real filesystem API supports both directions, and sessions without it get
  * harness-owned fallbacks for both (shell.ts).
  */
 export interface SandboxFiles {
@@ -95,7 +184,7 @@ export interface SandboxFiles {
  * run a shell command, tear down.
  */
 export interface SandboxSession<Handle = unknown> {
-	readonly sandboxId: SandboxId;
+	readonly sandboxRef: SandboxRef;
 	/** The ref the driver reports it actually booted (falls back to the request's). */
 	readonly artifactRef: string;
 	/** The vendor's native handle — the JDBC `unwrap()` idea, typed by the driver. */
@@ -112,11 +201,11 @@ export interface SandboxSession<Handle = unknown> {
 export interface ControlPlaneProbes {
 	/** Timed only; the value is discarded. */
 	list(): Promise<unknown>;
-	describe(id: SandboxId): Promise<unknown>;
+	describe(ref: SandboxRef): Promise<unknown>;
 }
 
 export interface SnapshotCapability {
-	create(id: SandboxId): Promise<{ readonly snapshotId: string }>;
+	create(ref: SandboxRef): Promise<{ readonly snapshotId: string }>;
 	delete(snapshotId: string): Promise<void>;
 }
 
@@ -124,20 +213,20 @@ export interface SnapshotCapability {
 export interface SandboxDriver<Handle = unknown> {
 	create(request: CreateRequest): Promise<SandboxSession<Handle>>;
 	/**
-	 * Optional: destroy by bare id, no session required — reaper/cleanup lanes. Bound by the
-	 * same clauses as destroy: idempotent, convergent, and destroy-of-missing MUST succeed.
+	 * Optional: destroy by ref, no session required — reaper/cleanup lanes. Bound by the same
+	 * clauses as destroy: idempotent, convergent, and destroy-of-missing MUST succeed.
 	 */
-	destroyById?(id: SandboxId): Promise<void>;
+	destroyById?(ref: SandboxRef): Promise<void>;
 	readonly probes?: ControlPlaneProbes;
 	readonly snapshots?: SnapshotCapability;
 }
 
 /**
  * Who owns the create attempt's time budget. Replaces the old `createTimeoutMs: null` sentinel
- * ("null means the harness must not race create") with a self-describing union: either the
- * harness races create against a timeout, or the driver owns bounds AND failed-create cleanup —
- * in which case abandoning it mid-teardown would strand a billable sandbox, so the harness
- * awaits it.
+ * with a self-describing union: either the harness races create against a timeout, or the
+ * driver owns bounds AND failed-create cleanup — in which case abandoning it mid-teardown would
+ * strand a billable sandbox, so the harness awaits it. Committed driver-module data (Tier 1),
+ * so it stays plain TypeScript by the parsing doctrine.
  */
 export type CreateBudget =
 	| { readonly owner: "harness"; readonly timeoutMs?: number }

--- a/packages/driver/src/lib/port.ts
+++ b/packages/driver/src/lib/port.ts
@@ -1,0 +1,144 @@
+// The sandbox driver port (ADR-0007 §2): the contract every provider implements and the only
+// provider-facing surface the harness consumes. Three required operations — create, exec,
+// destroy — plus capabilities that are either present and working or absent (`undefined`),
+// never a stub that lies (the `UnsupportedFileSystem` incident is why).
+//
+// This module is types plus two tiny constructors. It imports nothing.
+
+/** Branded so a sandbox id cannot be swapped with a snapshot id or a provider id. */
+export type SandboxId = string & { readonly __sandboxId: unique symbol };
+
+/** The one blessed constructor; empty ids are wiring bugs and fail here, not at the vendor. */
+export function sandboxId(raw: string): SandboxId {
+	if (raw.length === 0) {
+		throw new Error("sandboxId must be non-empty");
+	}
+	return raw as SandboxId;
+}
+
+/**
+ * How a command ended. "Didn't tell us" is representable (`unknown`), so no driver ever forges
+ * an exit code (`?? 1`, `?? 127`) — a missing code becomes evidence in the run document instead
+ * of a fake failure (ADR-0008: exec MUST report the guest's real exit status).
+ */
+export type Exit =
+	| { readonly kind: "exited"; readonly code: number }
+	| { readonly kind: "signalled"; readonly signal: string }
+	| { readonly kind: "unknown"; readonly detail: string };
+
+export const succeeded = (exit: Exit): boolean => exit.kind === "exited" && exit.code === 0;
+
+export interface ExecResult {
+	readonly exit: Exit;
+	readonly stdout: string;
+	readonly stderr: string;
+	readonly durationMs: number;
+	/** True when a per-call {@link ExecOptions.maxOutputBytes} cap cut a stream. */
+	readonly truncated: boolean;
+}
+
+export interface ExecOptions {
+	/**
+	 * Opt-in output cap for probes and queries. Deliberately NEVER a kit-wide default: results
+	 * collection is a multi-MB base64 tar over stdout (`collect.ts`), and a blanket cap would
+	 * turn it into a bounded retry loop that can never succeed (ADR-0007 §9).
+	 */
+	readonly maxOutputBytes?: number;
+}
+
+/**
+ * The benchmark's resource target, in the registry's own vocabulary and units
+ * (`targetSpecSchema`: vcpus / memoryGb / diskGb). Never mint a parallel spec shape — vendor
+ * unit conversions (e.g. Gb→MiB) live in exactly one driver-local expression (ADR-0007 §9).
+ * `diskGb` is optional: a driver that cannot express a *present* disk requirement MUST fail
+ * create loudly rather than silently dropping it.
+ */
+export interface TargetSpec {
+	readonly vcpus: number;
+	readonly memoryGb: number;
+	readonly diskGb?: number;
+}
+
+/** Vendor-neutral GPU request; drivers map it to vendor syntax (Modal: "H100!", "A100:2"). */
+export interface GpuSpec {
+	readonly model: string;
+	readonly count: number;
+}
+
+export interface CreateRequest {
+	readonly spec: TargetSpec;
+	/**
+	 * The boot artifact reference resolved from the registry's artifact descriptor — or, for
+	 * artifacts built at run time (kind "built"), the ref the driver's context factory produced.
+	 * Drivers may report the ref they actually booted; see {@link MethodTable.create} in table.ts.
+	 */
+	readonly artifactRef: string;
+	readonly deadlineMs: number;
+	/** A driver that cannot honor a requested GPU MUST fail create — never silently run on CPU. */
+	readonly gpu?: GpuSpec;
+	readonly env?: Readonly<Record<string, string>>;
+}
+
+/**
+ * A working filesystem API — reads AND writes — or the capability is absent. All-or-nothing:
+ * every vendor with a real filesystem API supports both directions, and sessions without it get
+ * harness-owned fallbacks for both (shell.ts).
+ */
+export interface SandboxFiles {
+	readFile(path: string): Promise<string>;
+	exists(path: string): Promise<boolean>;
+	writeText(path: string, text: string): Promise<void>;
+}
+
+/**
+ * A live sandbox. The required surface is exactly what every benchmark step needs: identity,
+ * run a shell command, tear down.
+ */
+export interface SandboxSession<Handle = unknown> {
+	readonly sandboxId: SandboxId;
+	/** The ref the driver reports it actually booted (falls back to the request's). */
+	readonly artifactRef: string;
+	/** The vendor's native handle — the JDBC `unwrap()` idea, typed by the driver. */
+	readonly native: Handle;
+	exec(command: string, options?: ExecOptions): Promise<ExecResult>;
+	/** Idempotent and convergent (ADR-0008): MUST NOT resolve while the vendor still runs it. */
+	destroy(): Promise<void>;
+	readonly files?: SandboxFiles;
+	/** Optional. `undefined` ⇒ the harness wraps `exec` in its own nohup double-fork (shell.ts). */
+	launch?(command: string, options?: ExecOptions): Promise<void>;
+}
+
+/** Optional, measurement-only capabilities. Absent ⇒ the harness records a clean capability gap. */
+export interface ControlPlaneProbes {
+	/** Timed only; the value is discarded. */
+	list(): Promise<unknown>;
+	describe(id: SandboxId): Promise<unknown>;
+}
+
+export interface SnapshotCapability {
+	create(id: SandboxId): Promise<{ readonly snapshotId: string }>;
+	delete(snapshotId: string): Promise<void>;
+}
+
+/** Everything a provider must supply. One required member; capabilities by presence. */
+export interface SandboxDriver<Handle = unknown> {
+	create(request: CreateRequest): Promise<SandboxSession<Handle>>;
+	/**
+	 * Optional: destroy by bare id, no session required — reaper/cleanup lanes. Bound by the
+	 * same clauses as destroy: idempotent, convergent, and destroy-of-missing MUST succeed.
+	 */
+	destroyById?(id: SandboxId): Promise<void>;
+	readonly probes?: ControlPlaneProbes;
+	readonly snapshots?: SnapshotCapability;
+}
+
+/**
+ * Who owns the create attempt's time budget. Replaces the old `createTimeoutMs: null` sentinel
+ * ("null means the harness must not race create") with a self-describing union: either the
+ * harness races create against a timeout, or the driver owns bounds AND failed-create cleanup —
+ * in which case abandoning it mid-teardown would strand a billable sandbox, so the harness
+ * awaits it.
+ */
+export type CreateBudget =
+	| { readonly owner: "harness"; readonly timeoutMs?: number }
+	| { readonly owner: "driver"; readonly attemptCeilingMs: number };

--- a/packages/driver/src/lib/session.fixture.ts
+++ b/packages/driver/src/lib/session.fixture.ts
@@ -1,0 +1,28 @@
+// Shared test fixtures: one ExecResult stub and one minimal session, so the port's shapes have a
+// single place to update when they grow a field. `.fixture.ts` (repo convention) so the test
+// runner does not treat it as a suite.
+
+import type { ExecResult, SandboxSession } from "./port.ts";
+import { sandboxRef } from "./port.ts";
+
+export const okExec: ExecResult = {
+	exit: { kind: "exited", code: 0 },
+	stdout: "",
+	stderr: "",
+	durationMs: 0,
+	truncated: false,
+};
+
+/** A minimal session; override any member. `destroy` defaults to a no-op. */
+export function stubSession(overrides: Partial<SandboxSession> = {}): SandboxSession {
+	return {
+		sandboxRef: sandboxRef("tama", "m-1"),
+		artifactRef: "im-1",
+		native: null,
+		async exec() {
+			return okExec;
+		},
+		async destroy() {},
+		...overrides,
+	};
+}

--- a/packages/driver/src/lib/session.test.ts
+++ b/packages/driver/src/lib/session.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, test } from "bun:test";
+import type { SandboxSession } from "./port.ts";
+import { sandboxId } from "./port.ts";
+import { withSessionTeardown } from "./session.ts";
+
+function session(onDestroy: () => Promise<void>): SandboxSession {
+	return {
+		sandboxId: sandboxId("sb-1"),
+		artifactRef: "im-1",
+		native: null,
+		async exec() {
+			return { exit: { kind: "exited", code: 0 }, stdout: "", stderr: "", durationMs: 0, truncated: false };
+		},
+		destroy: onDestroy,
+	};
+}
+
+describe("withSessionTeardown", () => {
+	test("destroys exactly once on success and returns the work's result", async () => {
+		let destroys = 0;
+		const result = await withSessionTeardown(
+			session(async () => {
+				destroys += 1;
+			}),
+			async () => "measured",
+		);
+		expect(result).toBe("measured");
+		expect(destroys).toBe(1);
+	});
+
+	test("a work failure with clean teardown propagates the work failure", async () => {
+		await expect(
+			withSessionTeardown(session(async () => {}), async () => {
+				throw new Error("benchmark failed");
+			}),
+		).rejects.toThrow("benchmark failed");
+	});
+
+	test("a teardown-only failure propagates plainly", async () => {
+		await expect(
+			withSessionTeardown(
+				session(async () => {
+					throw new Error("teardown exploded");
+				}),
+				async () => "fine",
+			),
+		).rejects.toThrow("teardown exploded");
+	});
+
+	test("a double fault preserves BOTH errors as SuppressedError", async () => {
+		try {
+			await withSessionTeardown(
+				session(async () => {
+					throw new Error("teardown exploded");
+				}),
+				async () => {
+					throw new Error("benchmark failed");
+				},
+			);
+			expect.unreachable("expected SuppressedError");
+		} catch (error) {
+			expect(error).toBeInstanceOf(SuppressedError);
+			const suppressed = error as SuppressedError;
+			expect(String(suppressed.error)).toContain("teardown exploded");
+			expect(String(suppressed.suppressed)).toContain("benchmark failed");
+		}
+	});
+});

--- a/packages/driver/src/lib/session.test.ts
+++ b/packages/driver/src/lib/session.test.ts
@@ -1,11 +1,11 @@
 import { describe, expect, test } from "bun:test";
 import type { SandboxSession } from "./port.ts";
-import { sandboxId } from "./port.ts";
+import { sandboxRef } from "./port.ts";
 import { withSessionTeardown } from "./session.ts";
 
 function session(onDestroy: () => Promise<void>): SandboxSession {
 	return {
-		sandboxId: sandboxId("sb-1"),
+		sandboxRef: sandboxRef("tama", "m-1"),
 		artifactRef: "im-1",
 		native: null,
 		async exec() {

--- a/packages/driver/src/lib/session.test.ts
+++ b/packages/driver/src/lib/session.test.ts
@@ -1,19 +1,8 @@
 import { describe, expect, test } from "bun:test";
-import type { SandboxSession } from "./port.ts";
-import { sandboxRef } from "./port.ts";
+import { stubSession } from "./session.fixture.ts";
 import { withSessionTeardown } from "./session.ts";
 
-function session(onDestroy: () => Promise<void>): SandboxSession {
-	return {
-		sandboxRef: sandboxRef("tama", "m-1"),
-		artifactRef: "im-1",
-		native: null,
-		async exec() {
-			return { exit: { kind: "exited", code: 0 }, stdout: "", stderr: "", durationMs: 0, truncated: false };
-		},
-		destroy: onDestroy,
-	};
-}
+const session = (onDestroy: () => Promise<void>) => stubSession({ destroy: onDestroy });
 
 describe("withSessionTeardown", () => {
 	test("destroys exactly once on success and returns the work's result", async () => {
@@ -30,9 +19,12 @@ describe("withSessionTeardown", () => {
 
 	test("a work failure with clean teardown propagates the work failure", async () => {
 		await expect(
-			withSessionTeardown(session(async () => {}), async () => {
-				throw new Error("benchmark failed");
-			}),
+			withSessionTeardown(
+				session(async () => {}),
+				async () => {
+					throw new Error("benchmark failed");
+				},
+			),
 		).rejects.toThrow("benchmark failed");
 	});
 

--- a/packages/driver/src/lib/session.ts
+++ b/packages/driver/src/lib/session.ts
@@ -1,0 +1,34 @@
+// Session lifecycle helpers (ADR-0007 §9): teardown must never hide the primary error.
+
+import type { SandboxSession } from "./port.ts";
+
+/**
+ * Run work against a session, then destroy it — preserving BOTH errors when both fail.
+ *
+ * A bare `finally { await session.destroy() }` replaces a benchmark failure with a teardown
+ * failure; here a double fault throws `SuppressedError` in the same shape `using` produces:
+ * `error` is the teardown failure, `suppressed` is the primary it would otherwise have hidden.
+ */
+export async function withSessionTeardown<Handle, T>(
+	session: SandboxSession<Handle>,
+	work: (session: SandboxSession<Handle>) => Promise<T>,
+): Promise<T> {
+	let primary: unknown;
+	let failed = false;
+	try {
+		return await work(session);
+	} catch (error) {
+		primary = error;
+		failed = true;
+		throw error;
+	} finally {
+		try {
+			await session.destroy();
+		} catch (teardown) {
+			if (failed) {
+				throw new SuppressedError(teardown, primary, "sandbox teardown failed after a primary error");
+			}
+			throw teardown;
+		}
+	}
+}

--- a/packages/driver/src/lib/session.ts
+++ b/packages/driver/src/lib/session.ts
@@ -13,22 +13,28 @@ export async function withSessionTeardown<Handle, T>(
 	session: SandboxSession<Handle>,
 	work: (session: SandboxSession<Handle>) => Promise<T>,
 ): Promise<T> {
-	let primary: unknown;
-	let failed = false;
+	// Run work and teardown as two linear steps (no throw-in-finally, so a teardown failure can be
+	// compared against the primary and combined rather than silently masking it).
+	let outcome: { ok: true; value: T } | { ok: false; error: unknown };
 	try {
-		return await work(session);
+		outcome = { ok: true, value: await work(session) };
 	} catch (error) {
-		primary = error;
-		failed = true;
-		throw error;
-	} finally {
-		try {
-			await session.destroy();
-		} catch (teardown) {
-			if (failed) {
-				throw new SuppressedError(teardown, primary, "sandbox teardown failed after a primary error");
-			}
-			throw teardown;
-		}
+		outcome = { ok: false, error };
 	}
+	try {
+		await session.destroy();
+	} catch (teardown) {
+		if (!outcome.ok) {
+			throw new SuppressedError(
+				teardown,
+				outcome.error,
+				"sandbox teardown failed after a primary error",
+			);
+		}
+		throw teardown;
+	}
+	if (!outcome.ok) {
+		throw outcome.error;
+	}
+	return outcome.value;
 }

--- a/packages/driver/src/lib/shell.test.ts
+++ b/packages/driver/src/lib/shell.test.ts
@@ -1,9 +1,9 @@
-import { describe, expect, test } from "bun:test";
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import { mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import type { ExecResult, SandboxSession } from "./port.ts";
-import { sandboxRef } from "./port.ts";
+import { stubSession } from "./session.fixture.ts";
 import { launchDetached, readTextFile, shellQuote, writeTextFile } from "./shell.ts";
 
 /**
@@ -12,9 +12,7 @@ import { launchDetached, readTextFile, shellQuote, writeTextFile } from "./shell
  * test are exactly what a capability-less vendor session exercises.
  */
 function localShellSession(cwd: string): SandboxSession {
-	return {
-		sandboxRef: sandboxRef("tama", "local-shell"),
-		artifactRef: "local",
+	return stubSession({
 		native: cwd,
 		async exec(command): Promise<ExecResult> {
 			const started = Date.now();
@@ -30,64 +28,64 @@ function localShellSession(cwd: string): SandboxSession {
 				truncated: false,
 			};
 		},
-		async destroy() {},
-	};
+	});
 }
 
 function recordingSession(record: string[]): SandboxSession {
-	return {
-		sandboxRef: sandboxRef("tama", "recorder"),
-		artifactRef: "none",
-		native: null,
+	return stubSession({
 		async exec(command): Promise<ExecResult> {
 			record.push(command);
-			return { exit: { kind: "exited", code: 0 }, stdout: "", stderr: "", durationMs: 0, truncated: false };
+			return {
+				exit: { kind: "exited", code: 0 },
+				stdout: "",
+				stderr: "",
+				durationMs: 0,
+				truncated: false,
+			};
 		},
-		async destroy() {},
-	};
+	});
 }
+
+let dir: string;
+beforeEach(() => {
+	dir = mkdtempSync(join(tmpdir(), "driver-shell-"));
+});
+afterEach(() => {
+	rmSync(dir, { recursive: true, force: true });
+});
 
 describe("shellQuote", () => {
 	test("survives quotes, spaces, dollars and newlines through a real shell", async () => {
-		const dir = mkdtempSync(join(tmpdir(), "driver-shell-"));
-		try {
-			const session = localShellSession(dir);
-			for (const hostile of ["plain", "with space", `single'quote`, `$HOME and "double"`, "line\nbreak"]) {
-				const result = await session.exec(`printf '%s' ${shellQuote(hostile)}`);
-				expect(result.stdout).toBe(hostile);
-			}
-		} finally {
-			rmSync(dir, { recursive: true, force: true });
+		const session = localShellSession(dir);
+		for (const hostile of [
+			"plain",
+			"with space",
+			`single'quote`,
+			`$HOME and "double"`,
+			"line\nbreak",
+		]) {
+			const result = await session.exec(`printf '%s' ${shellQuote(hostile)}`);
+			expect(result.stdout).toBe(hostile);
 		}
 	});
 });
 
 describe("writeTextFile / readTextFile fallbacks", () => {
 	test("round-trips arbitrary content through base64-over-exec and cat", async () => {
-		const dir = mkdtempSync(join(tmpdir(), "driver-shell-"));
-		try {
-			const session = localShellSession(dir);
-			const content = `#!/bin/sh\necho "hé — $VALUE" 'single' | base64\n`;
-			await writeTextFile(session, join(dir, "staged.sh"), content);
-			expect(await readTextFile(session, join(dir, "staged.sh"))).toBe(content);
-		} finally {
-			rmSync(dir, { recursive: true, force: true });
-		}
+		const session = localShellSession(dir);
+		const content = `#!/bin/sh\necho "hé — $VALUE" 'single' | base64\n`;
+		await writeTextFile(session, join(dir, "staged.sh"), content);
+		expect(await readTextFile(session, join(dir, "staged.sh"))).toBe(content);
 	});
 
 	test("readTextFile returns null (a recorded gap) for an unreadable path", async () => {
-		const dir = mkdtempSync(join(tmpdir(), "driver-shell-"));
-		try {
-			expect(await readTextFile(localShellSession(dir), join(dir, "missing"))).toBeNull();
-		} finally {
-			rmSync(dir, { recursive: true, force: true });
-		}
+		expect(await readTextFile(localShellSession(dir), join(dir, "missing"))).toBeNull();
 	});
 
 	test("prefers the native files capability when the session has one", async () => {
 		const writes: Array<[string, string]> = [];
-		const session: SandboxSession = {
-			...recordingSession([]),
+		const session = stubSession({
+			native: null,
 			files: {
 				readFile: async (path) => `native:${path}`,
 				exists: async () => true,
@@ -95,7 +93,7 @@ describe("writeTextFile / readTextFile fallbacks", () => {
 					writes.push([path, text]);
 				},
 			},
-		};
+		});
 		await writeTextFile(session, "/bench/a", "1");
 		expect(writes).toEqual([["/bench/a", "1"]]);
 		expect(await readTextFile(session, "/bench/a")).toBe("native:/bench/a");
@@ -112,28 +110,26 @@ describe("launchDetached", () => {
 	test("uses the session's native launch when present", async () => {
 		const record: string[] = [];
 		const launches: string[] = [];
-		const session: SandboxSession = {
+		const session = stubSession({
 			...recordingSession(record),
 			launch: async (command) => {
 				launches.push(command);
 			},
-		};
+		});
 		await launchDetached(session, "bash task.sh");
 		expect(launches).toEqual(["bash task.sh"]);
 		expect(record).toEqual([]);
 	});
 
 	test("a detached command actually survives the exec round-trip", async () => {
-		const dir = mkdtempSync(join(tmpdir(), "driver-shell-"));
-		try {
-			const session = localShellSession(dir);
-			await launchDetached(session, `sleep 0.05 && printf done > ${shellQuote(join(dir, "done-file"))}`);
-			// The launch returned before the command finished; the done-file appears afterwards.
-			expect(await readTextFile(session, join(dir, "done-file"))).toBeNull();
-			await new Promise((resolve) => setTimeout(resolve, 300));
-			expect(await readTextFile(session, join(dir, "done-file"))).toBe("done");
-		} finally {
-			rmSync(dir, { recursive: true, force: true });
-		}
+		const session = localShellSession(dir);
+		await launchDetached(
+			session,
+			`sleep 0.05 && printf done > ${shellQuote(join(dir, "done-file"))}`,
+		);
+		// The launch returned before the command finished; the done-file appears afterwards.
+		expect(await readTextFile(session, join(dir, "done-file"))).toBeNull();
+		await new Promise((resolve) => setTimeout(resolve, 300));
+		expect(await readTextFile(session, join(dir, "done-file"))).toBe("done");
 	});
 });

--- a/packages/driver/src/lib/shell.test.ts
+++ b/packages/driver/src/lib/shell.test.ts
@@ -1,0 +1,139 @@
+import { describe, expect, test } from "bun:test";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type { ExecResult, SandboxSession } from "./port.ts";
+import { sandboxId } from "./port.ts";
+import { launchDetached, readTextFile, shellQuote, writeTextFile } from "./shell.ts";
+
+/**
+ * A session whose exec IS a local /bin/sh — so the shell mechanics are tested against a real
+ * shell, not against our own idea of one. No files/launch capabilities: the fallbacks under
+ * test are exactly what a capability-less vendor session exercises.
+ */
+function localShellSession(cwd: string): SandboxSession {
+	return {
+		sandboxId: sandboxId("local-shell"),
+		artifactRef: "local",
+		native: cwd,
+		async exec(command): Promise<ExecResult> {
+			const started = Date.now();
+			const child = Bun.spawnSync(["/bin/sh", "-c", command], { cwd });
+			return {
+				exit:
+					child.exitCode !== null
+						? { kind: "exited", code: child.exitCode }
+						: { kind: "unknown", detail: "no exit code" },
+				stdout: child.stdout.toString(),
+				stderr: child.stderr.toString(),
+				durationMs: Date.now() - started,
+				truncated: false,
+			};
+		},
+		async destroy() {},
+	};
+}
+
+function recordingSession(record: string[]): SandboxSession {
+	return {
+		sandboxId: sandboxId("recorder"),
+		artifactRef: "none",
+		native: null,
+		async exec(command): Promise<ExecResult> {
+			record.push(command);
+			return { exit: { kind: "exited", code: 0 }, stdout: "", stderr: "", durationMs: 0, truncated: false };
+		},
+		async destroy() {},
+	};
+}
+
+describe("shellQuote", () => {
+	test("survives quotes, spaces, dollars and newlines through a real shell", async () => {
+		const dir = mkdtempSync(join(tmpdir(), "driver-shell-"));
+		try {
+			const session = localShellSession(dir);
+			for (const hostile of ["plain", "with space", `single'quote`, `$HOME and "double"`, "line\nbreak"]) {
+				const result = await session.exec(`printf '%s' ${shellQuote(hostile)}`);
+				expect(result.stdout).toBe(hostile);
+			}
+		} finally {
+			rmSync(dir, { recursive: true, force: true });
+		}
+	});
+});
+
+describe("writeTextFile / readTextFile fallbacks", () => {
+	test("round-trips arbitrary content through base64-over-exec and cat", async () => {
+		const dir = mkdtempSync(join(tmpdir(), "driver-shell-"));
+		try {
+			const session = localShellSession(dir);
+			const content = `#!/bin/sh\necho "hé — $VALUE" 'single' | base64\n`;
+			await writeTextFile(session, join(dir, "staged.sh"), content);
+			expect(await readTextFile(session, join(dir, "staged.sh"))).toBe(content);
+		} finally {
+			rmSync(dir, { recursive: true, force: true });
+		}
+	});
+
+	test("readTextFile returns null (a recorded gap) for an unreadable path", async () => {
+		const dir = mkdtempSync(join(tmpdir(), "driver-shell-"));
+		try {
+			expect(await readTextFile(localShellSession(dir), join(dir, "missing"))).toBeNull();
+		} finally {
+			rmSync(dir, { recursive: true, force: true });
+		}
+	});
+
+	test("prefers the native files capability when the session has one", async () => {
+		const writes: Array<[string, string]> = [];
+		const session: SandboxSession = {
+			...recordingSession([]),
+			files: {
+				readFile: async (path) => `native:${path}`,
+				exists: async () => true,
+				writeText: async (path, text) => {
+					writes.push([path, text]);
+				},
+			},
+		};
+		await writeTextFile(session, "/bench/a", "1");
+		expect(writes).toEqual([["/bench/a", "1"]]);
+		expect(await readTextFile(session, "/bench/a")).toBe("native:/bench/a");
+	});
+});
+
+describe("launchDetached", () => {
+	test("falls back to the nohup double-fork over exec", async () => {
+		const record: string[] = [];
+		await launchDetached(recordingSession(record), "bash task.sh");
+		expect(record).toEqual([`nohup /bin/sh -lc 'bash task.sh' </dev/null >/dev/null 2>&1 &`]);
+	});
+
+	test("uses the session's native launch when present", async () => {
+		const record: string[] = [];
+		const launches: string[] = [];
+		const session: SandboxSession = {
+			...recordingSession(record),
+			launch: async (command) => {
+				launches.push(command);
+			},
+		};
+		await launchDetached(session, "bash task.sh");
+		expect(launches).toEqual(["bash task.sh"]);
+		expect(record).toEqual([]);
+	});
+
+	test("a detached command actually survives the exec round-trip", async () => {
+		const dir = mkdtempSync(join(tmpdir(), "driver-shell-"));
+		try {
+			const session = localShellSession(dir);
+			await launchDetached(session, `sleep 0.05 && printf done > ${shellQuote(join(dir, "done-file"))}`);
+			// The launch returned before the command finished; the done-file appears afterwards.
+			expect(await readTextFile(session, join(dir, "done-file"))).toBeNull();
+			await new Promise((resolve) => setTimeout(resolve, 300));
+			expect(await readTextFile(session, join(dir, "done-file"))).toBe("done");
+		} finally {
+			rmSync(dir, { recursive: true, force: true });
+		}
+	});
+});

--- a/packages/driver/src/lib/shell.test.ts
+++ b/packages/driver/src/lib/shell.test.ts
@@ -3,7 +3,7 @@ import { mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import type { ExecResult, SandboxSession } from "./port.ts";
-import { sandboxId } from "./port.ts";
+import { sandboxRef } from "./port.ts";
 import { launchDetached, readTextFile, shellQuote, writeTextFile } from "./shell.ts";
 
 /**
@@ -13,7 +13,7 @@ import { launchDetached, readTextFile, shellQuote, writeTextFile } from "./shell
  */
 function localShellSession(cwd: string): SandboxSession {
 	return {
-		sandboxId: sandboxId("local-shell"),
+		sandboxRef: sandboxRef("tama", "local-shell"),
 		artifactRef: "local",
 		native: cwd,
 		async exec(command): Promise<ExecResult> {
@@ -36,7 +36,7 @@ function localShellSession(cwd: string): SandboxSession {
 
 function recordingSession(record: string[]): SandboxSession {
 	return {
-		sandboxId: sandboxId("recorder"),
+		sandboxRef: sandboxRef("tama", "recorder"),
 		artifactRef: "none",
 		native: null,
 		async exec(command): Promise<ExecResult> {

--- a/packages/driver/src/lib/shell.ts
+++ b/packages/driver/src/lib/shell.ts
@@ -54,10 +54,11 @@ export async function writeTextFile(
 		await session.files.writeText(path, text);
 		return;
 	}
-	const encoded = Buffer.from(text, "utf8").toString("base64");
-	const result = await session.exec(
-		`printf '%s' ${shellQuote(encoded)} | base64 -d > ${shellQuote(path)}`,
-	);
+	// base64's alphabet (A-Za-z0-9+/=) can never contain a single quote, so the payload — which
+	// can be multi-MB — is wrapped in literal quotes directly instead of scanned by shellQuote.
+	// `Uint8Array.toBase64` is the repo's Bun-native spelling (see harness collect.ts) — no Buffer.
+	const encoded = new TextEncoder().encode(text).toBase64();
+	const result = await session.exec(`printf '%s' '${encoded}' | base64 -d > ${shellQuote(path)}`);
 	if (!succeeded(result.exit)) {
 		throw new Error(`writeTextFile(${path}) failed: ${describeFailure(result)}`);
 	}

--- a/packages/driver/src/lib/shell.ts
+++ b/packages/driver/src/lib/shell.ts
@@ -1,0 +1,76 @@
+// Harness-owned shell mechanics (ADR-0007 §2), written once. These express optional session
+// capabilities over the one required primitive (`exec`), so consumers never ask capability
+// questions: a session with a native fast path uses it, and one without gets the same behavior
+// through the shell. Three byte-identical shellQuote copies and four hand-rolled nohup lines
+// across the old adapters collapse into this module.
+
+import type { ExecResult, SandboxSession } from "./port.ts";
+import { succeeded } from "./port.ts";
+
+/** POSIX single-quote escaping: the only quoting rule any of this module ever uses. */
+export const shellQuote = (value: string): string => `'${value.replace(/'/g, `'\\''`)}'`;
+
+/**
+ * Fire-and-forget a command. Uses the session's native `launch` when the vendor has one;
+ * otherwise the classic double-fork: nohup under `sh -lc`, all stdio detached, so the exec
+ * round-trip returns immediately and the command survives it. Completion is observed by the
+ * caller (done-file poll), not by this call.
+ */
+export async function launchDetached(session: SandboxSession, command: string): Promise<void> {
+	if (session.launch) {
+		await session.launch(command);
+		return;
+	}
+	await session.exec(`nohup /bin/sh -lc ${shellQuote(command)} </dev/null >/dev/null 2>&1 &`);
+}
+
+/**
+ * Read a text file, via the native filesystem capability when present, `cat` otherwise.
+ * Returns null when the file is unreadable — a recorded gap, not an exception to catch.
+ */
+export async function readTextFile(session: SandboxSession, path: string): Promise<string | null> {
+	if (session.files) {
+		try {
+			return await session.files.readFile(path);
+		} catch {
+			return null;
+		}
+	}
+	const result = await session.exec(`cat ${shellQuote(path)}`);
+	return succeeded(result.exit) ? result.stdout : null;
+}
+
+/**
+ * Write a text file, via the native filesystem capability when present, base64-over-exec
+ * otherwise. Base64 (not a heredoc) so arbitrary content — quotes, dollar signs, newlines,
+ * even NUL-free binary-ish text — survives the shell without any quoting subtleties.
+ */
+export async function writeTextFile(
+	session: SandboxSession,
+	path: string,
+	text: string,
+): Promise<void> {
+	if (session.files) {
+		await session.files.writeText(path, text);
+		return;
+	}
+	const encoded = Buffer.from(text, "utf8").toString("base64");
+	const result = await session.exec(
+		`printf '%s' ${shellQuote(encoded)} | base64 -d > ${shellQuote(path)}`,
+	);
+	if (!succeeded(result.exit)) {
+		throw new Error(`writeTextFile(${path}) failed: ${describeFailure(result)}`);
+	}
+}
+
+function describeFailure(result: ExecResult): string {
+	const exit = result.exit;
+	switch (exit.kind) {
+		case "exited":
+			return `exit ${exit.code}: ${result.stderr.trim()}`;
+		case "signalled":
+			return `signal ${exit.signal}`;
+		case "unknown":
+			return `unknown exit (${exit.detail})`;
+	}
+}

--- a/packages/driver/src/lib/table.test.ts
+++ b/packages/driver/src/lib/table.test.ts
@@ -1,16 +1,10 @@
 import { describe, expect, test } from "bun:test";
-import type { CreateRequest, ExecResult } from "./port.ts";
+import { DriverError } from "./errors.ts";
+import type { CreateRequest } from "./port.ts";
 import { sandboxRef } from "./port.ts";
+import { okExec } from "./session.fixture.ts";
 import type { MethodTable } from "./table.ts";
 import { driverFromTable } from "./table.ts";
-
-const okExec: ExecResult = {
-	exit: { kind: "exited", code: 0 },
-	stdout: "",
-	stderr: "",
-	durationMs: 0,
-	truncated: false,
-};
 
 const request: CreateRequest = {
 	spec: { vcpus: 4, memoryGb: 8 },
@@ -49,29 +43,60 @@ describe("driverFromTable", () => {
 		expect(attempts).toBe(2);
 	});
 
-	test("a driver-reported artifact contradiction fails create and tears down the orphan", async () => {
+	test("a driver-reported artifact contradiction fails create (typed) and tears down the orphan", async () => {
 		let destroyed = 0;
 		const driver = driverFromTable(
 			{
 				...baseTable,
-				create: async () => ({ handle: "h", sandboxRef: sandboxRef("tama", "m-2"), artifactRef: "im-OTHER" }),
+				create: async () => ({
+					handle: "h",
+					sandboxRef: sandboxRef("tama", "m-2"),
+					artifactRef: "im-OTHER",
+				}),
 				destroy: async () => {
 					destroyed += 1;
 				},
 			},
 			async () => null,
 		);
-		await expect(driver.create(request)).rejects.toThrow(
-			"artifact mismatch: request says im-abc123, driver booted im-OTHER",
-		);
+		const error = await driver.create(request).catch((caught: unknown) => caught);
+		expect(error).toBeInstanceOf(DriverError);
+		expect((error as DriverError).code).toBe("artifact-mismatch");
 		expect(destroyed).toBe(1);
+	});
+
+	test("a mismatch whose orphan teardown ALSO fails preserves the mismatch as SuppressedError", async () => {
+		const driver = driverFromTable(
+			{
+				...baseTable,
+				create: async () => ({
+					handle: "h",
+					sandboxRef: sandboxRef("tama", "m-2"),
+					artifactRef: "im-OTHER",
+				}),
+				destroy: async () => {
+					throw new Error("teardown exploded");
+				},
+			},
+			async () => null,
+		);
+		const error = (await driver
+			.create(request)
+			.catch((caught: unknown) => caught)) as SuppressedError;
+		expect(error).toBeInstanceOf(SuppressedError);
+		expect(String(error.error)).toContain("teardown exploded");
+		expect((error.suppressed as DriverError).code).toBe("artifact-mismatch");
 	});
 
 	test("a driver-reported ref that matches is recorded on the session", async () => {
 		const driver = driverFromTable(
 			{
 				...baseTable,
-				create: async () => ({ handle: "h", sandboxRef: sandboxRef("tama", "m-3"), artifactRef: "im-abc123" }),
+				create: async () => ({
+					handle: "h",
+					sandboxRef: sandboxRef("tama", "m-3"),
+					artifactRef: "im-abc123",
+				}),
 			},
 			async () => null,
 		);
@@ -104,20 +129,84 @@ describe("driverFromTable", () => {
 		expect(writes).toEqual(["/bench/a=1", "launch:sleep 1"]);
 	});
 
-	test("destroyById exists on the driver exactly when the table declares it", async () => {
+	test("the kit applies byte caps centrally; a table cannot ignore them", async () => {
+		const driver = driverFromTable(
+			{ ...baseTable, exec: async () => ({ ...okExec, stdout: "x".repeat(100) }) },
+			async () => null,
+		);
+		const session = await driver.create(request);
+		const capped = await session.exec("noisy", { maxOutputBytes: 10 });
+		expect(capped.stdout).toBe("x".repeat(10));
+		expect(capped.truncated).toBe(true);
+		const uncapped = await session.exec("noisy");
+		expect(uncapped.stdout).toHaveLength(100);
+		expect(uncapped.truncated).toBe(false);
+	});
+
+	test("destroy is idempotent and every operation after it is a typed use-after-destroy error", async () => {
+		let destroys = 0;
+		const driver = driverFromTable(
+			{
+				...baseTable,
+				destroy: async () => {
+					destroys += 1;
+				},
+				files: {
+					readFile: async () => "x",
+					exists: async () => true,
+					writeText: async () => {},
+				},
+			},
+			async () => null,
+		);
+		const session = await driver.create(request);
+		await session.destroy();
+		await session.destroy(); // idempotent — a second destroy is a no-op, not an error
+		expect(destroys).toBe(1);
+		const execError = (await session
+			.exec("echo")
+			.catch((caught: unknown) => caught)) as DriverError;
+		expect(execError).toBeInstanceOf(DriverError);
+		expect(execError.code).toBe("use-after-destroy");
+		const readError = (await (
+			session.files?.readFile("/x") ?? Promise.reject(new Error("no files"))
+		).catch((caught: unknown) => caught)) as DriverError;
+		expect(readError.code).toBe("use-after-destroy");
+	});
+
+	test("destroyById, probes and snapshots pass through exactly when the table declares them", async () => {
 		const reaped: string[] = [];
-		const without = driverFromTable(baseTable, async () => null);
-		expect(without.destroyById).toBeUndefined();
-		const withReap = driverFromTable(
+		const bare = driverFromTable(baseTable, async () => null);
+		expect(bare.destroyById).toBeUndefined();
+		expect(bare.probes).toBeUndefined();
+		expect(bare.snapshots).toBeUndefined();
+
+		const listed: string[] = [];
+		const full = driverFromTable(
 			{
 				...baseTable,
 				destroyById: async (_ctx, ref) => {
 					reaped.push(ref.id);
 				},
+				probes: {
+					list: async (ctx) => {
+						listed.push(String(ctx));
+					},
+				},
+				snapshots: {
+					create: async () => ({ snapshotId: "snap-1" }),
+					delete: async () => {},
+				},
 			},
 			async () => null,
 		);
-		await withReap.destroyById?.(sandboxRef("tama", "m-gone"));
+		await full.destroyById?.(sandboxRef("tama", "m-gone"));
 		expect(reaped).toEqual(["m-gone"]);
+		await full.probes?.list();
+		expect(listed).toEqual(["null"]);
+		expect(full.probes?.describe).toBeUndefined(); // absent, not a no-op stub
+		expect(await full.snapshots?.create(sandboxRef("tama", "m-1"))).toEqual({
+			snapshotId: "snap-1",
+		});
 	});
 });

--- a/packages/driver/src/lib/table.test.ts
+++ b/packages/driver/src/lib/table.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from "bun:test";
 import type { CreateRequest, ExecResult } from "./port.ts";
-import { sandboxId, succeeded } from "./port.ts";
+import { sandboxRef } from "./port.ts";
 import type { MethodTable } from "./table.ts";
 import { driverFromTable } from "./table.ts";
 
@@ -19,31 +19,16 @@ const request: CreateRequest = {
 };
 
 const baseTable: MethodTable<string, null> = {
-	create: async () => ({ handle: "h", sandboxId: sandboxId("sb-1") }),
+	create: async () => ({ handle: "h", sandboxRef: sandboxRef("tama", "m-1") }),
 	exec: async () => okExec,
 	destroy: async () => {},
 };
-
-describe("sandboxId", () => {
-	test("rejects the empty string at construction", () => {
-		expect(() => sandboxId("")).toThrow("sandboxId must be non-empty");
-	});
-});
-
-describe("succeeded", () => {
-	test("only a zero exited code succeeds", () => {
-		expect(succeeded({ kind: "exited", code: 0 })).toBe(true);
-		expect(succeeded({ kind: "exited", code: 7 })).toBe(false);
-		expect(succeeded({ kind: "signalled", signal: "KILL" })).toBe(false);
-		expect(succeeded({ kind: "unknown", detail: "no code" })).toBe(false);
-	});
-});
 
 describe("driverFromTable", () => {
 	test("assembles a session over the table with the request's artifactRef", async () => {
 		const driver = driverFromTable(baseTable, async () => null);
 		const session = await driver.create(request);
-		expect(String(session.sandboxId)).toBe("sb-1");
+		expect(session.sandboxRef).toEqual({ provider: "tama", id: "m-1" });
 		expect(session.artifactRef).toBe("im-abc123");
 		expect(session.native).toBe("h");
 		expect(session.files).toBeUndefined();
@@ -60,7 +45,7 @@ describe("driverFromTable", () => {
 		await expect(driver.create(request)).rejects.toThrow("transient plumbing failure");
 		// Before the memo-clear rule this replayed the memoized rejection and bricked the driver.
 		const session = await driver.create(request);
-		expect(String(session.sandboxId)).toBe("sb-1");
+		expect(session.sandboxRef.id).toBe("m-1");
 		expect(attempts).toBe(2);
 	});
 
@@ -69,7 +54,7 @@ describe("driverFromTable", () => {
 		const driver = driverFromTable(
 			{
 				...baseTable,
-				create: async () => ({ handle: "h", sandboxId: sandboxId("sb-2"), artifactRef: "im-OTHER" }),
+				create: async () => ({ handle: "h", sandboxRef: sandboxRef("tama", "m-2"), artifactRef: "im-OTHER" }),
 				destroy: async () => {
 					destroyed += 1;
 				},
@@ -86,7 +71,7 @@ describe("driverFromTable", () => {
 		const driver = driverFromTable(
 			{
 				...baseTable,
-				create: async () => ({ handle: "h", sandboxId: sandboxId("sb-3"), artifactRef: "im-abc123" }),
+				create: async () => ({ handle: "h", sandboxRef: sandboxRef("tama", "m-3"), artifactRef: "im-abc123" }),
 			},
 			async () => null,
 		);
@@ -126,13 +111,13 @@ describe("driverFromTable", () => {
 		const withReap = driverFromTable(
 			{
 				...baseTable,
-				destroyById: async (_ctx, id) => {
-					reaped.push(id);
+				destroyById: async (_ctx, ref) => {
+					reaped.push(ref.id);
 				},
 			},
 			async () => null,
 		);
-		await withReap.destroyById?.(sandboxId("sb-gone"));
-		expect(reaped).toEqual(["sb-gone"]);
+		await withReap.destroyById?.(sandboxRef("tama", "m-gone"));
+		expect(reaped).toEqual(["m-gone"]);
 	});
 });

--- a/packages/driver/src/lib/table.test.ts
+++ b/packages/driver/src/lib/table.test.ts
@@ -1,0 +1,138 @@
+import { describe, expect, test } from "bun:test";
+import type { CreateRequest, ExecResult } from "./port.ts";
+import { sandboxId, succeeded } from "./port.ts";
+import type { MethodTable } from "./table.ts";
+import { driverFromTable } from "./table.ts";
+
+const okExec: ExecResult = {
+	exit: { kind: "exited", code: 0 },
+	stdout: "",
+	stderr: "",
+	durationMs: 0,
+	truncated: false,
+};
+
+const request: CreateRequest = {
+	spec: { vcpus: 4, memoryGb: 8 },
+	artifactRef: "im-abc123",
+	deadlineMs: 60_000,
+};
+
+const baseTable: MethodTable<string, null> = {
+	create: async () => ({ handle: "h", sandboxId: sandboxId("sb-1") }),
+	exec: async () => okExec,
+	destroy: async () => {},
+};
+
+describe("sandboxId", () => {
+	test("rejects the empty string at construction", () => {
+		expect(() => sandboxId("")).toThrow("sandboxId must be non-empty");
+	});
+});
+
+describe("succeeded", () => {
+	test("only a zero exited code succeeds", () => {
+		expect(succeeded({ kind: "exited", code: 0 })).toBe(true);
+		expect(succeeded({ kind: "exited", code: 7 })).toBe(false);
+		expect(succeeded({ kind: "signalled", signal: "KILL" })).toBe(false);
+		expect(succeeded({ kind: "unknown", detail: "no code" })).toBe(false);
+	});
+});
+
+describe("driverFromTable", () => {
+	test("assembles a session over the table with the request's artifactRef", async () => {
+		const driver = driverFromTable(baseTable, async () => null);
+		const session = await driver.create(request);
+		expect(String(session.sandboxId)).toBe("sb-1");
+		expect(session.artifactRef).toBe("im-abc123");
+		expect(session.native).toBe("h");
+		expect(session.files).toBeUndefined();
+		expect(session.launch).toBeUndefined();
+	});
+
+	test("a transient context failure is retried, not memoized forever", async () => {
+		let attempts = 0;
+		const driver = driverFromTable(baseTable, async () => {
+			attempts += 1;
+			if (attempts === 1) throw new Error("transient plumbing failure");
+			return null;
+		});
+		await expect(driver.create(request)).rejects.toThrow("transient plumbing failure");
+		// Before the memo-clear rule this replayed the memoized rejection and bricked the driver.
+		const session = await driver.create(request);
+		expect(String(session.sandboxId)).toBe("sb-1");
+		expect(attempts).toBe(2);
+	});
+
+	test("a driver-reported artifact contradiction fails create and tears down the orphan", async () => {
+		let destroyed = 0;
+		const driver = driverFromTable(
+			{
+				...baseTable,
+				create: async () => ({ handle: "h", sandboxId: sandboxId("sb-2"), artifactRef: "im-OTHER" }),
+				destroy: async () => {
+					destroyed += 1;
+				},
+			},
+			async () => null,
+		);
+		await expect(driver.create(request)).rejects.toThrow(
+			"artifact mismatch: request says im-abc123, driver booted im-OTHER",
+		);
+		expect(destroyed).toBe(1);
+	});
+
+	test("a driver-reported ref that matches is recorded on the session", async () => {
+		const driver = driverFromTable(
+			{
+				...baseTable,
+				create: async () => ({ handle: "h", sandboxId: sandboxId("sb-3"), artifactRef: "im-abc123" }),
+			},
+			async () => null,
+		);
+		const session = await driver.create(request);
+		expect(session.artifactRef).toBe("im-abc123");
+	});
+
+	test("files and launch pass through only when the table declares them", async () => {
+		const writes: string[] = [];
+		const driver = driverFromTable(
+			{
+				...baseTable,
+				launch: async (_ctx, _handle, command) => {
+					writes.push(`launch:${command}`);
+				},
+				files: {
+					readFile: async (_ctx, _handle, path) => `read:${path}`,
+					exists: async () => true,
+					writeText: async (_ctx, _handle, path, text) => {
+						writes.push(`${path}=${text}`);
+					},
+				},
+			},
+			async () => null,
+		);
+		const session = await driver.create(request);
+		expect(await session.files?.readFile("/etc/os-release")).toBe("read:/etc/os-release");
+		await session.files?.writeText("/bench/a", "1");
+		await session.launch?.("sleep 1");
+		expect(writes).toEqual(["/bench/a=1", "launch:sleep 1"]);
+	});
+
+	test("destroyById exists on the driver exactly when the table declares it", async () => {
+		const reaped: string[] = [];
+		const without = driverFromTable(baseTable, async () => null);
+		expect(without.destroyById).toBeUndefined();
+		const withReap = driverFromTable(
+			{
+				...baseTable,
+				destroyById: async (_ctx, id) => {
+					reaped.push(id);
+				},
+			},
+			async () => null,
+		);
+		await withReap.destroyById?.(sandboxId("sb-gone"));
+		expect(reaped).toEqual(["sb-gone"]);
+	});
+});

--- a/packages/driver/src/lib/table.ts
+++ b/packages/driver/src/lib/table.ts
@@ -1,15 +1,22 @@
 // The method-table layer (ADR-0007 §2): driver authors write a flat table of pure functions
 // over a typed native handle — trivially unit-testable, extraction-safe (`satisfies
 // MethodTable<…>` on a named const), and patchable by ordinary composition. The kit assembles
-// the harness-facing SandboxSession from it.
+// the harness-facing SandboxSession from it — and, because every generic driver flows through
+// here, this is the ONE place the session-lifecycle invariants live: output capping (§2 below),
+// the use-after-destroy guard, artifact reconciliation, and the lazy-context memo. A driver that
+// bypassed this layer would have to re-implement all four; none do.
 
+import { DriverError } from "./errors.ts";
+import { capExecOutput } from "./output.ts";
 import type {
+	ControlPlaneProbes,
 	CreateRequest,
 	ExecOptions,
 	ExecResult,
 	SandboxDriver,
 	SandboxRef,
 	SandboxSession,
+	SnapshotCapability,
 } from "./port.ts";
 
 export interface MethodTable<Handle, Ctx> {
@@ -21,15 +28,29 @@ export interface MethodTable<Handle, Ctx> {
 	create(
 		ctx: Ctx,
 		request: CreateRequest,
-	): Promise<{ readonly handle: Handle; readonly sandboxRef: SandboxRef; readonly artifactRef?: string }>;
-	exec(ctx: Ctx, handle: Handle, command: string, options?: ExecOptions): Promise<ExecResult>;
+	): Promise<{
+		readonly handle: Handle;
+		readonly sandboxRef: SandboxRef;
+		readonly artifactRef?: string;
+	}>;
+	/** Run a command. The kit applies output caps around this — tables return full output. */
+	exec(ctx: Ctx, handle: Handle, command: string): Promise<ExecResult>;
 	destroy(ctx: Ctx, handle: Handle): Promise<void>;
 	destroyById?(ctx: Ctx, ref: SandboxRef): Promise<void>;
-	launch?(ctx: Ctx, handle: Handle, command: string, options?: ExecOptions): Promise<void>;
+	launch?(ctx: Ctx, handle: Handle, command: string): Promise<void>;
 	readonly files?: {
 		readFile(ctx: Ctx, handle: Handle, path: string): Promise<string>;
 		exists(ctx: Ctx, handle: Handle, path: string): Promise<boolean>;
 		writeText(ctx: Ctx, handle: Handle, path: string, text: string): Promise<void>;
+	};
+	/** Optional measurement capabilities, carried so a driver never bypasses this layer for them. */
+	readonly probes?: {
+		list(ctx: Ctx): Promise<unknown>;
+		describe?(ctx: Ctx, ref: SandboxRef): Promise<unknown>;
+	};
+	readonly snapshots?: {
+		create(ctx: Ctx, ref: SandboxRef): Promise<{ readonly snapshotId: string }>;
+		delete(ctx: Ctx, snapshotId: string): Promise<void>;
 	};
 }
 
@@ -56,41 +77,100 @@ export function driverFromTable<Handle, Ctx>(
 		));
 	const files = table.files;
 	const launch = table.launch;
+	const destroyById = table.destroyById;
+	const tableProbes = table.probes;
+	const probeDescribe = tableProbes?.describe;
+	const tableSnapshots = table.snapshots;
 	return {
 		async create(request) {
 			const resolved = await ctx();
 			const created = await table.create(resolved, request);
 			if (created.artifactRef !== undefined && created.artifactRef !== request.artifactRef) {
-				// Tear the orphan down before failing: nothing may bill against a wrong-artifact boot.
-				await table.destroy(resolved, created.handle);
-				throw new Error(
+				const mismatch = new DriverError(
+					"artifact-mismatch",
 					`artifact mismatch: request says ${request.artifactRef}, driver booted ${created.artifactRef}`,
+					{ ref: created.sandboxRef },
 				);
+				// Tear the orphan down before failing — but never let a teardown failure hide the
+				// mismatch (the primary, and the one naming the wrong-artifact boot). Same double-fault
+				// shape as withSessionTeardown.
+				try {
+					await table.destroy(resolved, created.handle);
+				} catch (teardown) {
+					throw new SuppressedError(
+						teardown,
+						mismatch,
+						"orphan teardown failed after an artifact mismatch",
+					);
+				}
+				throw mismatch;
 			}
 			const handle = created.handle;
+			const ref = created.sandboxRef;
+			let destroyed = false;
+			const alive = <T>(operation: () => Promise<T>): Promise<T> => {
+				if (destroyed) {
+					// Calling a dead sandbox would surface as a confusing vendor error the harness
+					// would misclassify; make the invalid state a typed, unmistakable one instead.
+					return Promise.reject(
+						new DriverError("use-after-destroy", `sandbox ${ref.id} was used after destroy`, {
+							ref,
+						}),
+					);
+				}
+				return operation();
+			};
 			const session: SandboxSession<Handle> = {
-				sandboxRef: created.sandboxRef,
+				sandboxRef: ref,
 				artifactRef: created.artifactRef ?? request.artifactRef,
 				native: handle,
-				exec: (command, options) => table.exec(resolved, handle, command, options),
-				destroy: () => table.destroy(resolved, handle),
+				exec: (command, options?: ExecOptions) =>
+					alive(() =>
+						table
+							.exec(resolved, handle, command)
+							.then((result) => capExecOutput(result, options?.maxOutputBytes)),
+					),
+				async destroy() {
+					if (destroyed) return; // idempotent (ADR-0008): a second destroy is a no-op, not an error
+					destroyed = true;
+					await table.destroy(resolved, handle);
+				},
 				...(launch
-					? { launch: (command: string, options?: ExecOptions) => launch(resolved, handle, command, options) }
+					? { launch: (command: string) => alive(() => launch(resolved, handle, command)) }
 					: {}),
 				...(files
 					? {
 							files: {
-								readFile: (path: string) => files.readFile(resolved, handle, path),
-								exists: (path: string) => files.exists(resolved, handle, path),
-								writeText: (path: string, text: string) => files.writeText(resolved, handle, path, text),
+								readFile: (path: string) => alive(() => files.readFile(resolved, handle, path)),
+								exists: (path: string) => alive(() => files.exists(resolved, handle, path)),
+								writeText: (path: string, text: string) =>
+									alive(() => files.writeText(resolved, handle, path, text)),
 							},
 						}
 					: {}),
 			};
 			return session;
 		},
-		...(table.destroyById
-			? { destroyById: async (ref: SandboxRef) => table.destroyById!(await ctx(), ref) }
+		...(destroyById
+			? { destroyById: async (ref: SandboxRef) => destroyById(await ctx(), ref) }
+			: {}),
+		...(tableProbes
+			? {
+					probes: {
+						list: async () => tableProbes.list(await ctx()),
+						...(probeDescribe
+							? { describe: async (ref: SandboxRef) => probeDescribe(await ctx(), ref) }
+							: {}),
+					} satisfies ControlPlaneProbes,
+				}
+			: {}),
+		...(tableSnapshots
+			? {
+					snapshots: {
+						create: async (ref: SandboxRef) => tableSnapshots.create(await ctx(), ref),
+						delete: async (snapshotId: string) => tableSnapshots.delete(await ctx(), snapshotId),
+					} satisfies SnapshotCapability,
+				}
 			: {}),
 	};
 }

--- a/packages/driver/src/lib/table.ts
+++ b/packages/driver/src/lib/table.ts
@@ -1,0 +1,96 @@
+// The method-table layer (ADR-0007 §2): driver authors write a flat table of pure functions
+// over a typed native handle — trivially unit-testable, extraction-safe (`satisfies
+// MethodTable<…>` on a named const), and patchable by ordinary composition. The kit assembles
+// the harness-facing SandboxSession from it.
+
+import type {
+	CreateRequest,
+	ExecOptions,
+	ExecResult,
+	SandboxDriver,
+	SandboxId,
+	SandboxSession,
+} from "./port.ts";
+
+export interface MethodTable<Handle, Ctx> {
+	/**
+	 * Boot a sandbox. `artifactRef`, when returned, is the ref the driver ACTUALLY booted (for
+	 * "built" artifacts, the ctx factory's product); the kit fails create on a contradiction
+	 * with the request so a measurement is never attributed to the wrong artifact.
+	 */
+	create(
+		ctx: Ctx,
+		request: CreateRequest,
+	): Promise<{ readonly handle: Handle; readonly sandboxId: SandboxId; readonly artifactRef?: string }>;
+	exec(ctx: Ctx, handle: Handle, command: string, options?: ExecOptions): Promise<ExecResult>;
+	destroy(ctx: Ctx, handle: Handle): Promise<void>;
+	destroyById?(ctx: Ctx, id: SandboxId): Promise<void>;
+	launch?(ctx: Ctx, handle: Handle, command: string, options?: ExecOptions): Promise<void>;
+	readonly files?: {
+		readFile(ctx: Ctx, handle: Handle, path: string): Promise<string>;
+		exists(ctx: Ctx, handle: Handle, path: string): Promise<boolean>;
+		writeText(ctx: Ctx, handle: Handle, path: string, text: string): Promise<void>;
+	};
+}
+
+/**
+ * Assemble a SandboxDriver from a method table and a lazy context factory.
+ *
+ * The context is vendor plumbing that is async and built once on demand (clients, apps, built
+ * images, volumes). A failed load CLEARS the memo, so one transient plumbing failure does not
+ * brick the driver for the process lifetime; concurrent callers share the in-flight attempt
+ * (ADR-0007 §9).
+ */
+export function driverFromTable<Handle, Ctx>(
+	table: MethodTable<Handle, Ctx>,
+	loadCtx: () => Promise<Ctx>,
+): SandboxDriver<Handle> {
+	let memo: Promise<Ctx> | undefined;
+	const ctx = () =>
+		(memo ??= loadCtx().then(
+			(value) => value,
+			(error: unknown) => {
+				memo = undefined;
+				throw error;
+			},
+		));
+	const files = table.files;
+	const launch = table.launch;
+	return {
+		async create(request) {
+			const resolved = await ctx();
+			const created = await table.create(resolved, request);
+			if (created.artifactRef !== undefined && created.artifactRef !== request.artifactRef) {
+				// Tear the orphan down before failing: nothing may bill against a wrong-artifact boot.
+				await table.destroy(resolved, created.handle);
+				throw new Error(
+					`artifact mismatch: request says ${request.artifactRef}, driver booted ${created.artifactRef}`,
+				);
+			}
+			const handle = created.handle;
+			const session: SandboxSession<Handle> = {
+				sandboxId: created.sandboxId,
+				artifactRef: created.artifactRef ?? request.artifactRef,
+				native: handle,
+				exec: (command, options) => table.exec(resolved, handle, command, options),
+				destroy: () => table.destroy(resolved, handle),
+				...(launch
+					? { launch: (command: string, options?: ExecOptions) => launch(resolved, handle, command, options) }
+					: {}),
+				...(files
+					? {
+							files: {
+								readFile: (path: string) => files.readFile(resolved, handle, path),
+								exists: (path: string) => files.exists(resolved, handle, path),
+								writeText: (path: string, text: string) => files.writeText(resolved, handle, path, text),
+							},
+						}
+					: {}),
+			};
+			return session;
+		},
+		...(table.destroyById
+			? { destroyById: async (id: SandboxId) => table.destroyById!(await ctx(), id) }
+			: {}),
+	};
+}

--- a/packages/driver/src/lib/table.ts
+++ b/packages/driver/src/lib/table.ts
@@ -8,7 +8,7 @@ import type {
 	ExecOptions,
 	ExecResult,
 	SandboxDriver,
-	SandboxId,
+	SandboxRef,
 	SandboxSession,
 } from "./port.ts";
 
@@ -21,10 +21,10 @@ export interface MethodTable<Handle, Ctx> {
 	create(
 		ctx: Ctx,
 		request: CreateRequest,
-	): Promise<{ readonly handle: Handle; readonly sandboxId: SandboxId; readonly artifactRef?: string }>;
+	): Promise<{ readonly handle: Handle; readonly sandboxRef: SandboxRef; readonly artifactRef?: string }>;
 	exec(ctx: Ctx, handle: Handle, command: string, options?: ExecOptions): Promise<ExecResult>;
 	destroy(ctx: Ctx, handle: Handle): Promise<void>;
-	destroyById?(ctx: Ctx, id: SandboxId): Promise<void>;
+	destroyById?(ctx: Ctx, ref: SandboxRef): Promise<void>;
 	launch?(ctx: Ctx, handle: Handle, command: string, options?: ExecOptions): Promise<void>;
 	readonly files?: {
 		readFile(ctx: Ctx, handle: Handle, path: string): Promise<string>;
@@ -69,7 +69,7 @@ export function driverFromTable<Handle, Ctx>(
 			}
 			const handle = created.handle;
 			const session: SandboxSession<Handle> = {
-				sandboxId: created.sandboxId,
+				sandboxRef: created.sandboxRef,
 				artifactRef: created.artifactRef ?? request.artifactRef,
 				native: handle,
 				exec: (command, options) => table.exec(resolved, handle, command, options),
@@ -90,7 +90,7 @@ export function driverFromTable<Handle, Ctx>(
 			return session;
 		},
 		...(table.destroyById
-			? { destroyById: async (id: SandboxId) => table.destroyById!(await ctx(), id) }
+			? { destroyById: async (ref: SandboxRef) => table.destroyById!(await ctx(), ref) }
 			: {}),
 	};
 }

--- a/packages/driver/tsconfig.json
+++ b/packages/driver/tsconfig.json
@@ -1,4 +1,4 @@
 {
-	"extends": "@repo/tsconfig/library.json",
-	"include": ["src"]
+  "extends": "@repo/tsconfig/library.json",
+  "include": ["src"]
 }

--- a/packages/driver/tsconfig.json
+++ b/packages/driver/tsconfig.json
@@ -1,0 +1,4 @@
+{
+	"extends": "@repo/tsconfig/library.json",
+	"include": ["src"]
+}


### PR DESCRIPTION
## What this is

The core of `@sandbox-benchmarks/driver` — the sandbox driver kit proposed in ADRs 0006–0008 (#382): the port every provider implements, the method-table layer the kit assembles into sessions, harness-owned shell mechanics, and the two generic drivers. New package only; no existing code changes, no adapter migration yet. 48 tests, all green; the repo-check invariants (DAG, package shape) pick up the package and pass.

## File structure

Narrow subpath exports. `lib/port.ts` is the **single arktype source of truth** for the port's data shapes — every parsed or persisted shape is a schema whose static type is inferred, so the validator, the type, and the error message are one declaration. Behavioral contracts (sessions, drivers, tables) stay plain TypeScript, per the tier doctrine: runtime schemas can't prove asynchronous behavior — that's the conformance suite's job (ADR-0008).

```
packages/driver/
  src/index.ts        the port + kit barrel
  src/env.ts          envSchemaFor / parseDriverEnv — the runtime dual of EnvOf
  src/cli.ts          cliDriver: a CLI-only vendor as a declarative table of argv + parsers
  src/computesdk.ts   the ComputeSDK bridge (structural — zero computesdk dependency)
  src/lib/port.ts     schemas + inferred types: SandboxRef, Exit, ExecResult, GpuSpec,
                      CreateRequest (+ parseCreateRequest); behavioral contracts as plain TS
  src/lib/table.ts    MethodTable + driverFromTable
  src/lib/define.ts   defineDriver typed join, EnvOf<P> from literal credential declarations
  src/lib/shell.ts    shellQuote, nohup detached launch, cat / base64-over-exec file fallbacks
  src/lib/session.ts  withSessionTeardown
```

Tests are colocated. Shell mechanics are tested against a **real `/bin/sh`** (quoting of hostile strings, base64 write → cat read round-trip, and an actual detached-launch race: the done-file is absent immediately after launch and present after).

## The contract, in brief

- **Sandbox identification is `SandboxRef`** — an object pairing the narrowed provider id with the sandbox id validated in *that provider's* format. One discriminated arktype schema (auto-discriminated on `provider`) carries all fourteen formats as arkregex patterns, statically parsed into the types: `SandboxRef<"modal-gvisor">["id"]` is `` `sb-${string}` ``, not `string`. A compile-time pin holds the branches in exact correspondence with `ProviderId`; a wrong-format vendor id fails ref construction with `id must be matched by ^sb-\w+$ (was "vm-abc123")`. Formats without vendor evidence start at a conservative slug pattern, annotated as behavioral claims for ADR-0008's smoke conformance to verify against live sandboxes.
- **The target spec is reused, not re-declared**: `CreateRequest.spec` *is* the registry's `targetSpecSchema` (one spec vocabulary, one unit system); `parseCreateRequest` validates once at the plan→request seam with deep undeclared-key rejection (nested misspellings like `spec.memroyGb` are caught — shallow rejection provably misses them).
- **Three required operations** — create, exec, destroy. Every other capability (`files`, `launch`, `probes`, `snapshots`, `destroyById`) exists by presence or is `undefined` — never a stub that lies.
- **"Didn't tell us" is representable**: the `Exit` union (also a schema) has an `unknown` arm, so no driver forges `?? 1` exit codes; the bridge maps a withheld computesdk exit code to it (tested).
- **The typed join**: `defineDriver("tama", { driver: ({ env }) => … })` — the id autocompletes against `ProviderId`, an unregistered id fails compile, and `env` is the exact credential slice that provider declares (`env.E2B_API_KEY` inside a tama driver is a compile error, held by `@ts-expect-error` under `tsc --noEmit`).
- **Method tables**: authors write flat, pure functions over a typed native handle — one-statement unit tests, extraction-safe `satisfies MethodTable<…>` consts, patchable by ordinary composition. `driverFromTable` owns the lazy vendor-plumbing context (a failed load clears the memo, so a transient failure can't brick the driver — tested) and artifact reconciliation (a driver-reported boot ref that contradicts the request fails create and tears down the orphan — tested).
- **`cliDriver`**: a CLI vendor becomes a table — argv templates, an arktype readiness parser (a vendor output change produces `status must be a string (was missing)` in the log, not an `undefined` in readiness logic), secret argv redaction in every diagnostic (tested: `--token ***`, the secret never appears), not-found-tolerant destroy, and free bare-ref `destroyById`. The session's `native` handle is the parsed readiness row.
- **The bridge**: structural (no computesdk dependency in this package); declares its `provider` so refs validate at construction (a malformed vendor id fails create — tested); the throwing `UnsupportedFileSystem` stub is filtered at the boundary via an explicit `hasWorkingFilesystem`; `probes` exists exactly when the wrapper exposes `list`.
- **Output caps are per-call opt-in** (`maxOutputBytes` → visible `truncated: true`), never a kit default — results collection rides multi-MB stdout by design.

## Two deliberate seams

- `EnvOf<P>` needs literal credential types, and the registry's current annotation widens `requiredEnvVars` to `string[]`. So `define.ts` carries `DRIVER_CREDENTIALS` — the per-provider literals — and `define.test.ts` **pins it name-for-name against `PROVIDERS.requiredEnvVars`**, so any drift is a red test. When the ADR-0006 registry migration lands, the declaration moves there and this table and its pin are deleted.
- The kit's root entry imports arktype (via the port schemas and the reused `targetSpecSchema`). This is a deliberate revision of the earlier arktype-free-root stance: every kit consumer (harness, CLI, drivers at runtime) already evaluates the schema package's arktype graph in-process, so the port's schemas add no new import-cost class — and single-source-of-truth beats the residual saving. ADR-0006's import-cost discipline still holds where it matters: the registry identity leaf.

## What comes next (separate PRs)

Adapter migration (14 providers onto the port, `computeSdkDriver` bridging the unmigrated during the window), the generated loader/exports wiring, and the ADR-0008 conformance suite (`./conformance`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KthP5iM9B1wtRbh9RYpsYW