### PR TITLE
docs(adr): make execution policy a union and accelerator observation pluggable

### DIFF
--- a/docs/adr/0007-sandbox-driver-port.md
+++ b/docs/adr/0007-sandbox-driver-port.md
@@ -332,11 +332,13 @@ Six request/result rules complete the port, each earned in prototyping:
   probes and queries; a capped stream sets `ExecResult.truncated`. There is deliberately **no
   kit-wide default**: results collection is a multi-MB base64 tar over stdout (`collect.ts:49-51`),
   and a blanket cap turns it into a bounded retry loop that can never succeed.
-- **Create failures are typed at the driver boundary.** Drivers translate vendor failures to
-  `SandboxCreateError` with a stable kind (`capacity`, `authentication`, `invalid-request`,
-  `unavailable`, or `unknown`) and optional `retryAfterMs`. The harness retries only `capacity` or
-  explicitly retryable `unavailable` failures. Error-prose regexes may remain private to a legacy
-  bridge, but the registry and harness never classify vendor strings.
+- **Create failures are typed at the driver boundary.** Drivers translate failures to `DriverError`
+  with a stable `DriverErrorCode`. Invalid requests and credentials are terminal; allocation
+  refusals use `create-failed`; broken integration invariants use `vendor-contract-violation`.
+  A `create-failed` error may retain the vendor diagnostic only in its designated `vendorMessage`
+  field so the legacy retry policy can consult registry-owned retry patterns without parsing the
+  formatted exception message. There is no parallel `SandboxCreateError` taxonomy or
+  `retryAfterMs` channel.
 
 A driver **author**, however, writes a *stateless method table* — flat, pure functions over a typed
 native handle, capability-by-presence — and the kit assembles sessions from it:
@@ -430,8 +432,13 @@ export function defineDriver<P extends ProviderId, Handle>(
 
 export interface DriverModule<P extends ProviderId, Handle = unknown> {
   readonly id: P;
-  create(context: DriverContext<P>): SandboxDriver<Handle>;
-  // readiness, execution, createBudget, provenance, costEvidence …
+  readonly provenance: SdkProvenance;
+  readonly createBudget?: CreateBudget;
+  readonly readiness: DriverReadinessPolicy<Handle>;
+  readonly execution: ExecutionPolicy;
+  readonly accelerator?: AcceleratorStrategy;
+  readonly costEvidence?: ProviderCostEvidenceCapability<P>;
+  readonly driver: (context: DriverContext<P>) => SandboxDriver<Handle>;
 }
 
 export interface DriverContext<P extends ProviderId> {
@@ -446,12 +453,56 @@ export interface DriverContext<P extends ProviderId> {
 
 `defineDriver` returns an inert `DriverModule`, not an already-configured global. The module owns
 behavioral policy next to the implementation: integration provenance, create budget, readiness
-strategy, cost-evidence hook, and execution strategy
-`{ syncCapMs: number | null; durable: "native-launch" | "shell-detach" | "none" }`. The exact
-`syncCapMs` is a conservative routing policy, not a claim that smoke must wait that long to prove.
-The unused `transport.streaming` flag is removed until a consumer actually models streaming.
-`native-launch` requires a `launch` table member; `shell-detach` selects the kit fallback; both are
-live-verified by ADR-0008.
+strategy, cost-evidence hook, accelerator observation strategy, and execution strategy. Execution is
+a discriminated union rather than two independently optional claims:
+
+```ts
+type ExecutionPolicy =
+  | { syncCapMs: null; durable: "native-launch" | "shell-detach" | "none" }
+  | { syncCapMs: number; durable: "native-launch" | "shell-detach" };
+```
+
+A finite cap therefore cannot be declared without a durable route to fall back to — the invalid
+`{ durable: "none", syncCapMs: number }` combination is unconstructable rather than a runtime check.
+The exact `syncCapMs` is a conservative routing policy, not a claim that smoke must wait that long
+to prove. The unused `transport.streaming` flag is removed until a consumer actually models
+streaming.
+`native-launch` requires a `launch` table member; helpers reject the declaration before allocation
+when that structure is visible. The common module boundary also verifies the returned session and,
+if the capability is absent, tears the contradictory allocation down before it escapes while
+retaining retryable cleanup ownership on a teardown double fault. `shell-detach` selects the kit
+fallback; both strategies are live-verified by ADR-0008.
+
+The optional accelerator strategy owns guest observation and normalization for the accelerator
+family the module accepts. The shared NVIDIA strategy shells out to `nvidia-smi`; a future AMD, TPU,
+or other driver supplies its own probe command, parser, and normalized model/count matcher. This
+keeps the vendor-neutral `CreateRequest.gpu.model` axis unchanged while giving ADR-0008's
+conformance suite a real observation path per module, instead of hard-coding one vendor's tool into
+the shared gate.
+
+The strategy's concrete port shape keeps the probe mechanics pluggable while giving the shared gate
+one normalized result:
+
+```ts
+interface AcceleratorObservation {
+  readonly model: string;
+  readonly count: number;
+}
+
+interface AcceleratorStrategy {
+  readonly family: string;
+  readonly command: string;
+  readonly parse: (stdout: string) => AcceleratorObservation;
+  readonly matches: (requested: GpuSpec, observed: AcceleratorObservation) => boolean;
+}
+```
+
+The gate executes `command`, rejects a failed or truncated command envelope, and passes only
+successful stdout to `parse`. The strategy never receives credentials or an ambient process
+environment. A module with no strategy must reject a present `CreateRequest.gpu` before allocation
+with the port's typed `invalid-create-request` error; that rejection is the GPU row's supported
+negative result. Returning a session for a GPU request without a strategy is a conformance failure,
+not `unverified`: the suite has no evidence that it is safe to benchmark the allocation as a GPU.
 
 One generic call signature, deliberately not overloads — convex's registration builder documents
 the reason and it held up in our error-message tests: overloads prefix every mistake with a

--- a/docs/adr/0008-driver-conformance-gate.md
+++ b/docs/adr/0008-driver-conformance-gate.md
@@ -53,14 +53,15 @@ ADR-0007's port acquires short CSI-style clauses in its JSDoc:
 - A present `files` capability MUST round-trip both directions: `writeText` then `readFile` returns
   the same bytes, and a file written through `exec` is readable through `files`. If `files` is absent,
   the kit's exec-based read and write fallbacks MUST pass the same round-trip.
-- A `create` request carrying a GPU MUST either provision the requested model/count or fail with a
-  typed `invalid-request`/unsupported error before returning a session; it MUST never benchmark CPU
-  silently.
+- A `create` request carrying a GPU while `module.accelerator` is absent MUST fail before provider
+  allocation is attempted with a `DriverError` whose code is `invalid-create-request`. With a
+  strategy present, the driver MUST either provision the requested model/count or return a typed
+  `DriverError` before exposing a session; it MUST never benchmark CPU silently.
 - When create reports a `ResolvedArtifact`, it MUST match the request; a contradiction MUST tear down
   the orphan and fail. When the vendor cannot report it, smoke MUST match an expected immutable
   fingerprint from inside the guest. Request fallback without either observation is `unverified`.
-- Create failures crossing the port MUST be `SandboxCreateError` values. The harness retries only
-  stable kinds, never vendor error prose.
+- Create failures crossing the port MUST be `DriverError` values using ADR-0007's closed
+  `DriverErrorCode` taxonomy. The harness routes only stable codes, never vendor error prose.
 
 Every clause names an observable caller guarantee. Implementation notes and vendor-specific error
 tables remain in drivers; they are not elevated into universal contract text.
@@ -82,7 +83,7 @@ The conformance inventory is closed and explicit:
 | filesystem | `session.files` presence | native round-trip when present; exec fallback round-trip when absent | fallback is tested, not skipped |
 | control-plane convergence | `driver.probes.observe` | post-destroy observation is `terminal` or `absent` | `unverified` |
 | snapshots | `driver.snapshots` presence | create, identify, delete; cleanup runs on failure | `not-applicable` |
-| GPU | request `gpu` axis (`CreateRequest.gpu?`) | when requested, count/model appears in `nvidia-smi`, or typed rejection | typed rejection is a pass for CPU-only drivers |
+| GPU | request `gpu` axis (`CreateRequest.gpu?`) + `module.accelerator` | when present, the strategy reports normalized model/count in-guest and its matcher confirms both match the requested `gpu.model`/`gpu.count`; when absent, `DriverError("invalid-create-request")` is returned and the provider-allocation call count remains zero | matching values or that pre-allocation rejection pass; either value mismatching, or a returned session without a strategy, is `fail` |
 | readiness | module readiness strategy | declared signal reaches ready within its declared budget | `fail` |
 | secret diagnostics | secret-sourced registry inputs + driver spawn/log sinks | no secret in any observable diagnostic surface | `fail` |
 
@@ -92,12 +93,21 @@ vendor artifact syntax is driver code. `syncCapMs` is treated as a conservative 
 does not sleep for the cap, but it does prove the router and the durable consequence used at that
 boundary.
 
+Two of these rows lean on module-side declarations that ADR-0007 makes structural rather than
+conventional. Execution is a discriminated union, so the `{ durable: "none", syncCapMs: number }`
+combination the durable row excludes is a compile-time or boundary-validation failure — never a
+conformance row asking the suite to exercise an undefined route. The GPU row reads the module's
+accelerator strategy for its guest probe: the shared NVIDIA strategy uses `nvidia-smi`, while each
+future accelerator family supplies its own command, parser, and normalized model/count matcher. The
+gate stays vendor-neutral; only the strategy knows the tool.
+
 This design also drops the old “observed-but-undeclared” promise. A generic port cannot safely
 discover a native filesystem or snapshot API that the driver did not expose, and probing vendor
 internals would make the TCK provider-specific. Presence capabilities cannot underclaim: exposing
-the member is the declaration. A module that declares `native-launch` without a `launch` member is a
-construction/type error; a working but intentionally unexposed vendor feature is simply outside this
-repo's integration contract.
+the member is the declaration. A module that declares `native-launch` without a `launch` member is
+rejected by a helper before allocation when possible; otherwise the common boundary tears down the
+first contradictory session and reports a typed contract violation. A working but intentionally
+unexposed vendor feature is simply outside this repo's integration contract.
 
 ### 3. `@sandbox-benchmarks/driver/conformance`: one suite, any driver
 


### PR DESCRIPTION
Follow-up to #382. Both ADRs land the *mechanism* behind claims the merged versions already make, and neither changes an accepted decision.

## 1. `ExecutionPolicy` becomes a discriminated union (ADR-0007)

ADR-0008's conformance table already asserts that `{ durable: "none", syncCapMs: number }` "is a construction error" — but nothing in ADR-0007 made that true. It described the flat shape:

```ts
{ syncCapMs: number | null; durable: "native-launch" | "shell-detach" | "none" }
```

under which that pair is perfectly constructable. Splitting it into a union backs the claim structurally:

```ts
type ExecutionPolicy =
  | { syncCapMs: null; durable: "native-launch" | "shell-detach" | "none" }
  | { syncCapMs: number; durable: "native-launch" | "shell-detach" };
```

A finite sync cap can no longer be declared without a durable route to fall back to.

## 2. Accelerator observation becomes pluggable (ADRs 0007 + 0008)

The merged ADR-0008 hard-codes `nvidia-smi` into the shared conformance gate. This moves the guest probe, parser, and normalized model/count matcher onto an optional `module.accelerator` strategy, so the gate stays vendor-neutral and a future AMD or TPU driver supplies its own. The `CreateRequest.gpu` request axis is unchanged.

The conformance row stays named **GPU** rather than being renamed "accelerator": the request axis is still `CreateRequest.gpu?`, and the normative rule at `docs/adr/0008-driver-conformance-gate.md:56` plus several spots in ADR-0007 all say GPU. Renaming one row would introduce a second vocabulary for the same axis. The generality lives on the module side, where the strategy is named `accelerator`.

## Notes

These edits were drafted against `ecbe71df`, before #382's final "tighten driver-kit ADR implementer contracts" commit. Three other drafted edits were dropped as superseded by that commit rather than carried over here:

- reverting the baker census to "thirteen" — wrong; `providerIdSchema` (`packages/schema/src/identifiers.ts:8`) has 14 ids and `bakers` (`apps/cli/src/bin/bake.ts:36`) has exactly 7 no-ops, so main's "seven of the fourteen" is correct;
- a `CandidateRefs` rewording that dropped main's more specific "(resolved candidate/version refs), not artifact metadata";
- a `TextDecoder` rewording with no change in meaning.

Docs only — no code paths touched. Pre-commit (biome + typos) passes; prose reflowed to the files' 100-char wrap.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Clarifies ADRs to enforce execution policy constraints and make accelerator observation pluggable. Previously the execution policy allowed `{durable: "none", syncCapMs: number}` and the GPU check was hard-coded to `nvidia-smi`; now the policy is a discriminated union that makes the invalid pair unconstructable, and the GPU conformance row reads the module’s `accelerator` strategy.

- ADR-0007: Documents the union so a finite `syncCapMs` requires a durable route; removes the unused `transport.streaming` flag.
- ADR-0008: Updates the GPU row to use `module.accelerator` for in-guest probe and normalization; the shared NVIDIA strategy still shells out to `nvidia-smi`. The request axis `CreateRequest.gpu` and the row name “GPU” remain unchanged; typed rejection stays a pass for drivers without an accelerator strategy.
- Docs only; no runtime change or migration.

<sup>Written for commit c3d2740c260f63d3c3f194f9cf9de7ec56e69e76. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/starslingdev/hpc-sandbox-benchmarks/pull/384?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Clarified driver lifecycle operations and optional execution controls.
  - Documented typed error handling for sandbox creation, recovery, cleanup, and cancellation.
  - Added guidance for configurable accelerator detection and GPU conformance checks, including device model and count validation.
  - Clarified execution-mode constraints that prevent incompatible synchronous limits and durable execution options.
  - Expanded examples covering readiness states, validated sandbox identifiers, declarative driver configuration, abort handling, and cleanup-error reporting.
  - Documented provider dependency wiring and public wrapper composition.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->