### PR TITLE
feat(driver): the sandbox driver port and its typed error family

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -54,6 +54,19 @@
         "typescript": "catalog:",
       },
     },
+    "packages/driver": {
+      "name": "@sandbox-benchmarks/driver",
+      "version": "0.0.0",
+      "dependencies": {
+        "@sandbox-benchmarks/schema": "workspace:*",
+        "arktype": "catalog:",
+      },
+      "devDependencies": {
+        "@repo/tsconfig": "workspace:*",
+        "@types/bun": "catalog:",
+        "typescript": "catalog:",
+      },
+    },
     "packages/figures": {
       "name": "@sandbox-benchmarks/figures",
       "version": "0.0.0",
@@ -704,6 +717,8 @@
     "@runloop/api-client": ["@runloop/api-client@1.28.0", "", { "dependencies": { "@types/node": "^18.11.18", "@types/node-fetch": "^2.6.4", "abort-controller": "^3.0.0", "agentkeepalive": "^4.2.1", "form-data-encoder": "1.7.2", "formdata-node": "^4.3.2", "node-fetch": "^2.6.7", "tar": "^7.5.2", "uuidv7": "^1.0.2", "zod": "^3.24.1" } }, "sha512-ZQVSbSutqknTjgRpsfiiI5WXSkx5KgQvWkUpZQwGMsHR+dPCyM6QQegbAYqQaKuhIxEwxsLkJrSTm2fJkXmunw=="],
 
     "@sandbox-benchmarks/cli": ["@sandbox-benchmarks/cli@workspace:apps/cli"],
+
+    "@sandbox-benchmarks/driver": ["@sandbox-benchmarks/driver@workspace:packages/driver"],
 
     "@sandbox-benchmarks/figures": ["@sandbox-benchmarks/figures@workspace:packages/figures"],
 

--- a/packages/driver/package.json
+++ b/packages/driver/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "@sandbox-benchmarks/driver",
+  "version": "0.0.0",
+  "private": true,
+  "description": "The sandbox driver kit (ADR-0007): the port every provider implements (create / exec / destroy, capabilities by presence), the method-table layer the kit assembles into sessions, harness-owned shell mechanics, and the generic drivers. lib/port.ts is the single arktype source of truth for the port's data shapes, including per-provider sandbox id formats (arkregex); ./env and ./cli carry the other parsing surfaces.",
+  "type": "module",
+  "sideEffects": false,
+  "exports": {
+    ".": "./src/index.ts",
+    "./package.json": "./package.json"
+  },
+  "scripts": {
+    "test": "bun test",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@sandbox-benchmarks/schema": "workspace:*",
+    "arktype": "catalog:"
+  },
+  "devDependencies": {
+    "@repo/tsconfig": "workspace:*",
+    "typescript": "catalog:",
+    "@types/bun": "catalog:"
+  }
+}

--- a/packages/driver/src/index.ts
+++ b/packages/driver/src/index.ts
@@ -1,0 +1,42 @@
+// @sandbox-benchmarks/driver — the sandbox driver kit (ADR-0007).
+//
+// This root entry is the port and the kit: everything the harness consumes and everything a
+// driver author implements. lib/port.ts is the SINGLE SOURCE OF TRUTH for the port's data
+// shapes — arktype schemas whose static types are inferred, so the validator, the type, and
+// the error message are one declaration. Behavioral contracts stay plain TypeScript. The
+// subpaths (`./env`, `./cli`, `./computesdk`) organize the parsing surfaces; every kit
+// consumer already evaluates the schema package's arktype graph in-process, so the port's
+// schemas add no new import-cost class (ADR-0006's discipline still holds at the boundary
+// that matters: the registry identity leaf).
+
+export type { DriverErrorCode, DriverErrorFields } from "./lib/errors.ts";
+export { DriverError, isDriverError } from "./lib/errors.ts";
+export type {
+	ControlPlaneProbes,
+	CreateBudget,
+	CreateRequest,
+	ExecOptions,
+	ExecResult,
+	Exit,
+	GpuSpec,
+	ResolvedArtifact,
+	SandboxDriver,
+	SandboxFiles,
+	SandboxObservation,
+	SandboxRef,
+	SandboxSession,
+	SnapshotCapability,
+	TargetSpec,
+} from "./lib/port.ts";
+export {
+	createRequestSchema,
+	execResultSchema,
+	exitSchema,
+	gpuSpecSchema,
+	parseCreateRequest,
+	resolvedArtifactSchema,
+	sandboxObservationSchema,
+	sandboxRef,
+	sandboxRefSchema,
+	succeeded,
+} from "./lib/port.ts";

--- a/packages/driver/src/lib/errors.ts
+++ b/packages/driver/src/lib/errors.ts
@@ -1,0 +1,63 @@
+// One typed error family for the kit (ADR-0008 §1: "create failures MUST be classifiable … error
+// semantics defined by what the caller is entitled to do next"; ADR-0007 §9: "string-matching
+// error prose is how the UnsupportedFileSystem workaround started"). Every kit throw carries a
+// literal `code` the harness switches on, plus structured context — so the retry-vs-terminal and
+// invalid-input-vs-vendor decisions read a field, never a regex over a formatted message.
+
+import type { ProviderId } from "@sandbox-benchmarks/schema/providers";
+import type { SandboxRef } from "./port.ts";
+
+/**
+ * What went wrong, in terms of what the caller may do next:
+ *
+ *   - `invalid-sandbox-ref` / `invalid-create-request` / `missing-credentials` — the input or
+ *     config is wrong. Terminal; fix the input, do not retry.
+ *   - `artifact-mismatch` / `use-after-destroy` / `vendor-contract-violation` — a kit or driver
+ *     invariant was broken. Terminal; a bug, not a transient condition.
+ *   - `create-failed` — the vendor refused create. The harness decides retry-vs-terminal by
+ *     matching the registry's `retryableCreatePatterns` against {@link DriverError.vendorMessage}
+ *     (a designated field — NOT a formatted message that embeds argv).
+ *   - `readiness-timeout` — create was accepted but the sandbox never became ready in budget.
+ *   - `vendor-output-unparseable` — the vendor's control-plane output drifted from its schema.
+ *   - `destroy-failed` — teardown could not converge.
+ */
+export type DriverErrorCode =
+	| "invalid-sandbox-ref"
+	| "invalid-create-request"
+	| "missing-credentials"
+	| "artifact-mismatch"
+	| "use-after-destroy"
+	| "vendor-contract-violation"
+	| "create-failed"
+	| "readiness-timeout"
+	| "vendor-output-unparseable"
+	| "destroy-failed";
+
+export interface DriverErrorFields {
+	readonly provider?: ProviderId;
+	readonly ref?: SandboxRef;
+	/** Raw vendor stderr/detail — the field retry heuristics match, never the formatted message. */
+	readonly vendorMessage?: string;
+	readonly vendorExitCode?: number;
+	readonly cause?: unknown;
+}
+
+export class DriverError extends Error {
+	readonly code: DriverErrorCode;
+	readonly provider: ProviderId | undefined;
+	readonly ref: SandboxRef | undefined;
+	readonly vendorMessage: string | undefined;
+	readonly vendorExitCode: number | undefined;
+
+	constructor(code: DriverErrorCode, message: string, fields: DriverErrorFields = {}) {
+		super(message, fields.cause !== undefined ? { cause: fields.cause } : undefined);
+		this.name = "DriverError";
+		this.code = code;
+		this.provider = fields.provider;
+		this.ref = fields.ref;
+		this.vendorMessage = fields.vendorMessage;
+		this.vendorExitCode = fields.vendorExitCode;
+	}
+}
+
+export const isDriverError = (value: unknown): value is DriverError => value instanceof DriverError;

--- a/packages/driver/src/lib/port.test.ts
+++ b/packages/driver/src/lib/port.test.ts
@@ -1,0 +1,155 @@
+import { describe, expect, test } from "bun:test";
+import { DriverError } from "./errors.ts";
+import type { SandboxRef } from "./port.ts";
+import { parseCreateRequest, sandboxRef, sandboxRefSchema, succeeded } from "./port.ts";
+
+// Minimal type-level assertion helpers.
+type Equal<X, Y> =
+	(<T>() => T extends X ? 1 : 2) extends <T>() => T extends Y ? 1 : 2 ? true : false;
+type Expect<T extends true> = T;
+
+describe("sandboxRef", () => {
+	test("accepts each provider's id in its own format", () => {
+		const valid = [
+			["e2b", "i2f3k4abc"],
+			["daytona-vm", "8f14e45f-ceea-4b16-a2b8-3c1e5f2a9d01"],
+			["daytona-container", "7c9e6679-7425-40de-944b-e07fc1f90ae7"],
+			["blaxel", "sandbox-abc"],
+			["microsandbox-local", "local-sandbox"],
+			["microsandbox-cloud", "cloud-sandbox"],
+			["modal-gvisor", "sb-abc123"],
+			["modal-vm", "sb-def456"],
+			["novita", "i9z8y7x6"],
+			["runloop", "dbx_9f8e7d"],
+			["namespace", "namespace-abc"],
+			["vercel", "sandbox-benchmarks-abc123"],
+			["runcloud", "sb-abc123"],
+			["tama", "m-1"],
+		] as const;
+
+		for (const [provider, id] of valid) {
+			const ref = sandboxRef(provider, id);
+			expect(ref.provider).toBe(provider);
+			expect(ref.id).toBe(id);
+		}
+	});
+
+	test("rejects an id in the wrong format for the provider, naming the pattern", () => {
+		expect(() => sandboxRef("modal-gvisor", "vm-abc123")).toThrow(
+			/invalid sandbox ref: id must be matched by \^sb-\\w\+\$ \(was "vm-abc123"\)/,
+		);
+		expect(() => sandboxRef("e2b", "sb-abc123")).toThrow(/id must be matched by \^i\[a-z0-9\]\+\$/);
+		expect(() => sandboxRef("daytona-vm", "not-a-uuid")).toThrow(/id must be a UUID/);
+		expect(() => sandboxRef("tama", "")).toThrow(/invalid sandbox ref/);
+		expect(() => sandboxRef("tama", "has spaces")).toThrow(/invalid sandbox ref/);
+	});
+
+	test("a rejection is a typed DriverError carrying the provider", () => {
+		const error = (() => {
+			try {
+				sandboxRef("modal-gvisor", "vm-abc");
+				return null;
+			} catch (caught) {
+				return caught;
+			}
+		})();
+		expect(error).toBeInstanceOf(DriverError);
+		expect((error as DriverError).code).toBe("invalid-sandbox-ref");
+		expect((error as DriverError).provider).toBe("modal-gvisor");
+	});
+
+	test("the schema rejects an unregistered provider outright", () => {
+		const parsed = sandboxRefSchema({ provider: "not-a-provider", id: "x" });
+		expect(String(parsed)).toContain("provider must be");
+	});
+
+	test("the id types are narrowed per provider, statically", () => {
+		// arkregex parses the pattern at the type level: Modal ids ARE `sb-${string}`.
+		type _modal = Expect<Equal<SandboxRef<"modal-gvisor">["id"], `sb-${string}`>>;
+		type _runloop = Expect<Equal<SandboxRef<"runloop">["id"], `dbx_${string}`>>;
+		type _provider = Expect<Equal<SandboxRef<"tama">["provider"], "tama">>;
+		const modal = sandboxRef("modal-gvisor", "sb-abc");
+		// @ts-expect-error — a modal ref's id is `sb-${string}`, not any string
+		const wrong: SandboxRef<"modal-gvisor">["id"] = "vm-abc";
+		void wrong;
+		const ok: `sb-${string}` = modal.id;
+		void ok;
+		expect(true).toBe(true); // the assertions above are compile-time; typecheck is the oracle
+	});
+});
+
+describe("parseCreateRequest", () => {
+	const valid = {
+		spec: { vcpus: 4, memoryGb: 8 },
+		artifact: { kind: "baked", ref: "im-abc123" },
+		deadlineMs: 60_000,
+		gpu: { model: "H100", count: 1 },
+	};
+
+	test("returns the parsed request (registry-unit spec reused, not re-declared)", () => {
+		const request = parseCreateRequest(valid);
+		expect(request.spec.memoryGb).toBe(8);
+		expect(request.gpu?.model).toBe("H100");
+	});
+
+	test("rejects DEEP undeclared keys — nested misspellings included", () => {
+		expect(() => parseCreateRequest({ ...valid, spec: { vcpus: 4, memroyGb: 8 } })).toThrow(
+			/spec\.memroyGb must be removed/,
+		);
+		expect(() =>
+			parseCreateRequest({ ...valid, gpu: { model: "H100", count: 1, cout: 2 } }),
+		).toThrow(/gpu\.cout must be removed/);
+		expect(() => parseCreateRequest({ ...valid, deadlienMs: 1 })).toThrow(
+			/deadlienMs must be removed/,
+		);
+	});
+
+	test("a rejection is a typed invalid-create-request DriverError", () => {
+		const error = (() => {
+			try {
+				parseCreateRequest({ ...valid, spec: { vcpus: -1, memoryGb: 8 } });
+				return null;
+			} catch (caught) {
+				return caught;
+			}
+		})();
+		expect(error).toBeInstanceOf(DriverError);
+		expect((error as DriverError).code).toBe("invalid-create-request");
+	});
+
+	test("rejects non-positive and malformed values with path-bearing messages", () => {
+		expect(() => parseCreateRequest({ ...valid, spec: { vcpus: -1, memoryGb: 8 } })).toThrow(
+			/spec\.vcpus must be/,
+		);
+		expect(() => parseCreateRequest({ ...valid, artifact: { kind: "baked", ref: "" } })).toThrow(
+			/artifact\.ref/,
+		);
+		expect(() =>
+			parseCreateRequest({ ...valid, artifact: { kind: "none", ref: "not-allowed" } }),
+		).toThrow(/artifact\.ref must be removed/);
+		expect(() => parseCreateRequest({ ...valid, deadlineMs: 0 })).toThrow(/deadlineMs/);
+		expect(() => parseCreateRequest({ ...valid, gpu: { model: "", count: 1 } })).toThrow(
+			/gpu\.model/,
+		);
+	});
+
+	test("gpu and env are genuinely optional", () => {
+		const request = parseCreateRequest({
+			spec: { vcpus: 2, memoryGb: 4, diskGb: 40 },
+			artifact: { kind: "none" },
+			deadlineMs: 1_000,
+		});
+		expect(request.gpu).toBeUndefined();
+		expect(request.artifact).toEqual({ kind: "none" });
+		expect(request.spec.diskGb).toBe(40);
+	});
+});
+
+describe("succeeded", () => {
+	test("only a zero exited code succeeds", () => {
+		expect(succeeded({ kind: "exited", code: 0 })).toBe(true);
+		expect(succeeded({ kind: "exited", code: 7 })).toBe(false);
+		expect(succeeded({ kind: "signalled", signal: "KILL" })).toBe(false);
+		expect(succeeded({ kind: "unknown", detail: "no code" })).toBe(false);
+	});
+});

--- a/packages/driver/src/lib/port.ts
+++ b/packages/driver/src/lib/port.ts
@@ -1,0 +1,259 @@
+// The sandbox driver port (ADR-0007 §2): the contract every provider implements and the only
+// provider-facing surface the harness consumes.
+//
+// This module is the kit's SINGLE SOURCE OF TRUTH for the port's data shapes: every parsed or
+// persisted shape is an arktype schema and its static type is INFERRED from it — one
+// declaration yields the runtime validator, the compile-time type, and the error message.
+// Behavioral contracts (sessions, drivers, capabilities) stay plain TypeScript below, because
+// runtime schemas cannot prove asynchronous behavior, idempotency, or handle/context
+// relationships — that is ADR-0008's job.
+//
+// The target spec is deliberately NOT declared here: it is reused from the registry's own
+// `targetSpecSchema` (one spec vocabulary, one unit system — ADR-0007 §9's "never mint a
+// parallel spec shape"). The kit's consumers (harness, CLI, drivers) all already evaluate the
+// schema package in-process, so this reuse adds no new import cost class.
+
+import { targetSpecSchema } from "@sandbox-benchmarks/schema";
+import type { ProviderId } from "@sandbox-benchmarks/schema/providers";
+import { regex, type } from "arktype";
+import { DriverError } from "./errors.ts";
+
+export type { TargetSpec } from "@sandbox-benchmarks/schema";
+
+type DeepReadonly<T> = T extends (infer U)[]
+	? readonly DeepReadonly<U>[]
+	: T extends object
+		? { readonly [K in keyof T]: DeepReadonly<T[K]> }
+		: T;
+
+/* ------------------------------ Sandbox identification ------------------------------ */
+
+// Per-provider sandbox id formats, statically parsed by arkregex so the inferred id types are
+// template literals where the pattern allows (`sb-${string}` for Modal), plain-but-validated
+// strings elsewhere. Confidence varies by vendor and is annotated; every format is a behavioral
+// claim ADR-0008's smoke conformance verifies against a live sandbox — a wrong pattern fails in
+// smoke, loudly, before any benchmark runs. Formats without vendor evidence start at the
+// conservative `slugId` and are tightened by conformance evidence, never by guesswork.
+const slugId = regex("^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$"); // conservative default
+const modalId = regex("^sb-\\w+$"); // observed Modal sandbox id shape
+const e2bLikeId = regex("^i[a-z0-9]+$"); // observed E2B id shape; novita is E2B-compatible
+const runloopId = regex("^dbx_\\w+$"); // Runloop devbox prefix (bpt_/snp_ siblings observed)
+
+/**
+ * Sandbox identification: WHICH provider's control plane owns the sandbox, and its id in that
+ * provider's own format. One discriminated schema (arktype auto-discriminates on `provider`)
+ * is the source of truth for both the runtime validation and the narrowed static types —
+ * `SandboxRef<"modal-gvisor">["id"]` is `` `sb-${string}` ``, not `string`.
+ */
+export const sandboxRefSchema = type.or(
+	{ provider: "'e2b'", id: e2bLikeId },
+	{ provider: "'daytona-vm'", id: "string.uuid" },
+	{ provider: "'daytona-container'", id: "string.uuid" },
+	{ provider: "'blaxel'", id: slugId },
+	{ provider: "'microsandbox-local'", id: slugId },
+	{ provider: "'microsandbox-cloud'", id: slugId },
+	{ provider: "'modal-gvisor'", id: modalId },
+	{ provider: "'modal-vm'", id: modalId },
+	{ provider: "'novita'", id: e2bLikeId },
+	{ provider: "'runloop'", id: runloopId },
+	{ provider: "'namespace'", id: slugId },
+	// Vercel v2 is name-keyed: its caller-selected `sandbox-benchmarks-<uuid>` name is the id.
+	{ provider: "'vercel'", id: slugId },
+	{ provider: "'runcloud'", id: slugId },
+	{ provider: "'tama'", id: slugId },
+);
+
+type SandboxRefUnion = typeof sandboxRefSchema.infer;
+
+// The schema's provider branches must cover ProviderId exactly — both directions pinned at
+// compile time (type-only; erases entirely), so a provider added to the registry without an id
+// format (or a stray branch) is a type error here, not a runtime surprise.
+type Assert<T extends true> = T;
+type _refCoversRegistry = Assert<
+	[SandboxRefUnion["provider"]] extends [ProviderId]
+		? [ProviderId] extends [SandboxRefUnion["provider"]]
+			? true
+			: false
+		: false
+>;
+
+export type SandboxRef<P extends ProviderId = ProviderId> = DeepReadonly<
+	Extract<SandboxRefUnion, { provider: P }>
+>;
+
+/** The one blessed constructor: a ref that parses is a ref in that provider's real format. */
+export function sandboxRef<P extends ProviderId>(provider: P, id: string): SandboxRef<P> {
+	const parsed = sandboxRefSchema({ provider, id });
+	if (parsed instanceof type.errors) {
+		throw new DriverError("invalid-sandbox-ref", `invalid sandbox ref: ${parsed.summary}`, {
+			provider,
+		});
+	}
+	// The schema just proved the branch for `provider`; Extract names what arktype validated.
+	return parsed as SandboxRef<P>;
+}
+
+/* --------------------------------- Command results --------------------------------- */
+
+/**
+ * How a command ended. "Didn't tell us" is representable (`unknown`), so no driver ever forges
+ * an exit code (`?? 1`, `?? 127`) — a missing code becomes evidence in the run document instead
+ * of a fake failure (ADR-0008: exec MUST report the guest's real exit status).
+ */
+export const exitSchema = type.or(
+	{ kind: "'exited'", code: "number.integer" },
+	{ kind: "'signalled'", signal: "string >= 1" },
+	{ kind: "'unknown'", detail: "string" },
+);
+export type Exit = DeepReadonly<typeof exitSchema.infer>;
+
+export const succeeded = (exit: Exit): boolean => exit.kind === "exited" && exit.code === 0;
+
+export const execResultSchema = type({
+	exit: exitSchema,
+	stdout: "string",
+	stderr: "string",
+	durationMs: "number >= 0",
+	/** True when a per-call {@link ExecOptions.maxOutputBytes} cap cut a stream. */
+	truncated: "boolean",
+});
+export type ExecResult = DeepReadonly<typeof execResultSchema.infer>;
+
+export interface ExecOptions {
+	/**
+	 * Opt-in output cap for probes and queries. Deliberately NEVER a kit-wide default: results
+	 * collection is a multi-MB base64 tar over stdout (`collect.ts`), and a blanket cap would
+	 * turn it into a bounded retry loop that can never succeed (ADR-0007 §9).
+	 */
+	readonly maxOutputBytes?: number;
+}
+
+/* --------------------------------- Create requests --------------------------------- */
+
+/** Vendor-neutral GPU request; drivers map it to vendor syntax (Modal: "H100!", "A100:2"). */
+export const gpuSpecSchema = type({
+	model: "string >= 1",
+	count: "number.integer > 0",
+});
+export type GpuSpec = DeepReadonly<typeof gpuSpecSchema.infer>;
+
+/**
+ * The effective boot artifact after the composition root resolves the registry descriptor.
+ * `none` is explicit: an empty-string sentinel cannot distinguish a stock vendor image from
+ * missing evidence. Every other kind carries the concrete ref the driver is asked to boot.
+ */
+export const resolvedArtifactSchema = type.or(
+	{ kind: "'none'" },
+	{ kind: "'image'", ref: "string >= 1" },
+	{ kind: "'baked'", ref: "string >= 1" },
+	{ kind: "'mirror'", ref: "string >= 1" },
+	{ kind: "'built'", ref: "string >= 1" },
+);
+export type ResolvedArtifact = DeepReadonly<typeof resolvedArtifactSchema.infer>;
+
+/**
+ * The request a driver boots. `spec` IS the registry's `targetSpecSchema` (vcpus / memoryGb /
+ * diskGb?, registry units — vendor conversions live in exactly one driver-local expression);
+ * a driver that cannot express a *present* `diskGb` MUST fail create loudly. A driver that
+ * cannot honor a requested `gpu` MUST fail create — never silently benchmark CPU.
+ */
+export const createRequestSchema = type({
+	spec: targetSpecSchema,
+	/** The resolved artifact to boot; `none` represents a provider-owned stock image. */
+	artifact: resolvedArtifactSchema,
+	deadlineMs: "number.integer > 0",
+	"gpu?": gpuSpecSchema,
+	"env?": "Record<string, string>",
+}).onDeepUndeclaredKey("reject"); // shallow "+": "reject" misses nested misspellings (§9)
+
+export type CreateRequest = DeepReadonly<typeof createRequestSchema.infer>;
+
+/**
+ * Parse once, where CLI/config/persisted input becomes a trusted request — the plan→request
+ * seam. Drivers never re-validate: by the time a request reaches a table, it is trusted.
+ */
+export function parseCreateRequest(input: unknown): CreateRequest {
+	const parsed = createRequestSchema(input);
+	if (parsed instanceof type.errors) {
+		throw new DriverError("invalid-create-request", `invalid CreateRequest: ${parsed.summary}`);
+	}
+	return parsed;
+}
+
+/* ------------------------- Behavioral contracts (plain TS) ------------------------- */
+
+/**
+ * A working filesystem API — reads AND writes — or the capability is absent (`undefined`),
+ * never a stub that lies (the `UnsupportedFileSystem` incident is why). All-or-nothing: every
+ * vendor with a real filesystem API supports both directions, and sessions without it get
+ * harness-owned fallbacks for both (shell.ts).
+ */
+export interface SandboxFiles {
+	readFile(path: string): Promise<string>;
+	exists(path: string): Promise<boolean>;
+	writeText(path: string, text: string): Promise<void>;
+}
+
+/**
+ * A live sandbox. The required surface is exactly what every benchmark step needs: identity,
+ * run a shell command, tear down.
+ */
+export interface SandboxSession<Handle = unknown> {
+	readonly sandboxRef: SandboxRef;
+	/** Effective artifact; request fallback remains tagged and can be labelled as unverified. */
+	readonly artifact: ResolvedArtifact;
+	/** The vendor's native handle — the JDBC `unwrap()` idea, typed by the driver. */
+	readonly native: Handle;
+	exec(command: string, options?: ExecOptions): Promise<ExecResult>;
+	/** Idempotent and convergent (ADR-0008): MUST NOT resolve while the vendor still runs it. */
+	destroy(): Promise<void>;
+	readonly files?: SandboxFiles;
+	/** Optional. `undefined` ⇒ the harness wraps `exec` in its own nohup double-fork (shell.ts). */
+	launch?(command: string, options?: ExecOptions): Promise<void>;
+}
+
+/** The normalized control-plane state used to prove that destroy converged. */
+export const sandboxObservationSchema = type.or(
+	{ state: "'running'" },
+	{ state: "'terminal'" },
+	{ state: "'absent'" },
+);
+export type SandboxObservation = DeepReadonly<typeof sandboxObservationSchema.infer>;
+
+/** Optional control-plane capabilities. Absent ⇒ the harness records a clean capability gap. */
+export interface ControlPlaneProbes {
+	/** Required when probes are present: verifies per-sandbox lifecycle convergence. */
+	observe(ref: SandboxRef): Promise<SandboxObservation>;
+	/** Optional. Absent ⇒ the provider has no per-sandbox describe probe — never a no-op stub. */
+	describe?(ref: SandboxRef): Promise<unknown>;
+	/** Optional measurement-only enumeration; the value is deliberately opaque to the kit. */
+	list?(): Promise<unknown>;
+}
+
+export interface SnapshotCapability<Handle = unknown> {
+	create(session: SandboxSession<Handle>): Promise<{ readonly snapshotId: string }>;
+	delete(snapshotId: string): Promise<void>;
+}
+
+/** Everything a provider must supply. One required member; capabilities by presence. */
+export interface SandboxDriver<Handle = unknown> {
+	create(request: CreateRequest): Promise<SandboxSession<Handle>>;
+	/**
+	 * Optional: destroy by ref, no session required — reaper/cleanup lanes. Bound by the same
+	 * clauses as destroy: idempotent, convergent, and destroy-of-missing MUST succeed.
+	 */
+	destroyById?(ref: SandboxRef): Promise<void>;
+	readonly probes?: ControlPlaneProbes;
+	readonly snapshots?: SnapshotCapability<Handle>;
+}
+
+/**
+ * Who owns the create attempt's time budget. Replaces the old `createTimeoutMs: null` sentinel
+ * with a self-describing union: either the harness races create against a timeout, or the
+ * driver owns bounds AND failed-create cleanup — in which case abandoning it mid-teardown would
+ * strand a billable sandbox, so the harness awaits it. Committed driver-module data (Tier 1),
+ * so it stays plain TypeScript by the parsing doctrine.
+ */
+export type CreateBudget =
+	| { readonly owner: "harness"; readonly timeoutMs?: number }
+	| { readonly owner: "driver"; readonly attemptCeilingMs: number };

--- a/packages/driver/tsconfig.json
+++ b/packages/driver/tsconfig.json
@@ -1,0 +1,4 @@
+{
+  "extends": "@repo/tsconfig/library.json",
+  "include": ["src"]
+}

--- a/typos.toml
+++ b/typos.toml
@@ -21,3 +21,10 @@ PN = "PN"
 # POSIX Basic Regular Expression, the grep dialect. Named in lib/probe/isolation/20-collect.sh to
 # explain why a match is done in the shell instead of with a `grep` alternation, a GNU extension to BRE.
 BRE = "BRE"
+# The driver kit's `vendor-output-unparseable` error code (packages/driver/src/lib/errors.ts). The
+# code is a literal in a union the harness switches on and rides in persisted run documents, so the
+# spelling is a wire-format identifier, not prose to reword.
+unparseable = "unparseable"
+# Deliberately misspelled fixture key in packages/driver/src/lib/port.test.ts: the test proves that
+# `onDeepUndeclaredKey("reject")` catches NESTED misspellings, so the misspelling IS the test input.
+memroy = "memroy"


### PR DESCRIPTION
**Sandbox driver kit (ADR-0007) — the port every provider implements, and the kit that assembles it.**
Shipped as a 6-PR stack (merge bottom-up; each branch is independently green — typecheck + tests pass with nothing stacked above it):

1. #385 — **port**: the arktype single source of truth for the port's data shapes + the typed error family
2. #386 — **mechanics**: kit-owned session teardown, shell fallbacks, readiness polling
3. #388 — **assembly**: the method table → session layer, where the lifecycle invariants live
4. #387 — **join**: the typed registry binding (`defineDriver`/`EnvOf`) and its runtime env dual
5. #389 — **driver A**: `cliDriver`, for vendors whose control plane is a binary
6. #390 — **driver B**: the ComputeSDK bridge, now one driver among several

↑ **This PR is #385 (1/6)**, based on `main`.

---

First of a six-PR stack introducing @sandbox-benchmarks/driver, the sandbox
driver kit (ADR-0007). This branch is the contract alone — no kit machinery
and no drivers yet consume it.

lib/port.ts is the SINGLE SOURCE OF TRUTH for the port's data shapes: every
parsed or persisted shape is an arktype schema whose static type is inferred
from it, so the validator, the type and the error message are one declaration.
sandboxRefSchema discriminates per-provider id formats via arkregex (Modal's
id narrows to a `sb-${string}` template literal), and a type-only assertion
pins the schema's provider branches against the registry's ProviderId in both
directions — a provider added without an id format is a compile error, not a
runtime surprise. The target spec is reused from the registry's
targetSpecSchema rather than re-declared (ADR-0007 §9: never mint a parallel
spec shape). Behavioral contracts (SandboxSession, SandboxDriver,
capabilities-by-presence) stay plain TypeScript, since runtime schemas cannot
prove async behavior, idempotency, or handle/context relationships.

lib/errors.ts is the one typed error family: every kit throw carries a literal
`code` the harness switches on plus structured fields (provider, ref,
vendorMessage, vendorExitCode), so the retry-vs-terminal decision reads a
field and never a regex over formatted prose (ADR-0007 §9 — the
UnsupportedFileSystem workaround started as string-matching error prose).

The package manifest declares only the "." subpath here; ./env, ./cli and
./computesdk are added by the PRs that introduce those files, so no branch
ships an exports map pointing at a file that does not exist yet. index.ts
grows the same way, one export block per layer.

typos.toml gains two extend-words entries, following that file's own rule
("when typos flags an intentional identifier, add it under extend-words rather
than rewording the code"): the `vendor-output-unparseable` error code, and the
deliberately-misspelled fixture key the deep-undeclared-key test uses as its
input. The repo's spell gate runs repo-wide in CI (ci.yml), so without these
every branch in the stack would be red.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Introduces `@sandbox-benchmarks/driver`: a typed driver port (create/exec/destroy; capabilities by presence) and a single `DriverError` family validated by arktype. No drivers consume it yet, so behavior is unchanged; this establishes the contract and error semantics.

- Per‑provider sandbox refs: `sandboxRefSchema` validates ids (e.g., Modal `^sb-\\w+$`, E2B‑like `^i[a-z0-9]+$`, Runloop `^dbx_\\w+$`, others as slug ids) and narrows types; compile‑time check pins branches to `ProviderId`. `sandboxRef()` throws `invalid-sandbox-ref`.
- Create requests: reuse `@sandbox-benchmarks/schema`’s `targetSpecSchema`; deep undeclared keys are rejected; `parseCreateRequest()` throws `invalid-create-request`; `gpu` and `env` are optional; `deadlineMs` must be positive.
- Exec/lifecycle types: `Exit`/`ExecResult` (with `truncated` and `durationMs ≥ 0`), `succeeded()`, `ExecOptions.maxOutputBytes`. `SandboxSession` (idempotent `destroy`, optional `files`/`launch`). `SandboxDriver` (optional `destroyById`, `probes`, `snapshots`). Adds `CreateBudget`.
- Errors: `DriverError` codes (incl. `readiness-timeout`, `vendor-output-unparseable`, `destroy-failed`) with `provider`, `ref`, `vendorMessage`, and `vendorExitCode`; `isDriverError` exported.
- Packaging/tests: `src/index.ts` exports only the port and schema helpers; `package.json` exports only `"."`. Tests cover schema rejection, type narrowing, and error codes. `typos.toml` adds `unparseable` and a fixture misspelling exception.

<sup>Written for commit 5d3df803ea99d1a72bcd4dc76c61596af6bdb1fa. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/starslingdev/hpc-sandbox-benchmarks/pull/385?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a sandbox driver package with a typed interface for creating sandboxes, executing commands, handling files, sessions, GPUs, snapshots, and control-plane checks.
  * Added validation for sandbox references, creation requests, execution results, exit states, and GPU specifications.
  * Added structured driver errors with provider, sandbox, vendor, and cause details.
  * Added helpers for parsing requests and determining command success.

* **Tests**
  * Added comprehensive coverage for driver contracts, validation, and error handling.

* **Chores**
  * Added package configuration, TypeScript settings, and typo-checker exceptions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->