### PR TITLE
feat(driver): kit-owned session lifecycle, shell fallbacks and readiness

### DIFF
--- a/packages/driver/src/index.ts
+++ b/packages/driver/src/index.ts
@@ -11,6 +11,8 @@
 
 export type { DriverErrorCode, DriverErrorFields } from "./lib/errors.ts";
 export { DriverError, isDriverError } from "./lib/errors.ts";
+export type { ReadinessStrategy } from "./lib/poll.ts";
+export { pollUntilReady } from "./lib/poll.ts";
 export type {
 	ControlPlaneProbes,
 	CreateBudget,
@@ -40,3 +42,5 @@ export {
 	sandboxRefSchema,
 	succeeded,
 } from "./lib/port.ts";
+export { withSessionTeardown } from "./lib/session.ts";
+export { launchDetached, readTextFile, shellQuote, writeTextFile } from "./lib/shell.ts";

--- a/packages/driver/src/lib/errors.ts
+++ b/packages/driver/src/lib/errors.ts
@@ -19,6 +19,7 @@ import type { SandboxRef } from "./port.ts";
  *     (a designated field — NOT a formatted message that embeds argv).
  *   - `readiness-timeout` — create was accepted but the sandbox never became ready in budget.
  *   - `vendor-output-unparseable` — the vendor's control-plane output drifted from its schema.
+ *   - `exec-failed` — a kit-owned shell fallback failed before it could satisfy its contract.
  *   - `destroy-failed` — teardown could not converge.
  */
 export type DriverErrorCode =
@@ -31,6 +32,7 @@ export type DriverErrorCode =
 	| "create-failed"
 	| "readiness-timeout"
 	| "vendor-output-unparseable"
+	| "exec-failed"
 	| "destroy-failed";
 
 export interface DriverErrorFields {

--- a/packages/driver/src/lib/poll.test.ts
+++ b/packages/driver/src/lib/poll.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, test } from "bun:test";
+import { DriverError } from "./errors.ts";
+import { pollUntilReady } from "./poll.ts";
+
+const delay = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
+
+describe("pollUntilReady", () => {
+	test("returns the first ready value inside the shared deadline", async () => {
+		let polls = 0;
+		await expect(
+			pollUntilReady({
+				provider: "tama",
+				deadlineMs: 100,
+				intervalMs: 1,
+				poll: async () => (++polls === 2 ? "ready" : null),
+			}),
+		).resolves.toBe("ready");
+		expect(polls).toBe(2);
+	});
+
+	test("does not accept a value whose probe resolves after the deadline", async () => {
+		const error = await pollUntilReady({
+			provider: "tama",
+			deadlineMs: 10,
+			intervalMs: 1,
+			poll: async () => {
+				await delay(30);
+				return "late";
+			},
+		}).catch((caught) => caught);
+		expect(error).toBeInstanceOf(DriverError);
+		expect((error as DriverError).code).toBe("readiness-timeout");
+	});
+
+	test("bounds a probe that never resolves", async () => {
+		const started = Date.now();
+		await expect(
+			pollUntilReady({
+				provider: "tama",
+				deadlineMs: 15,
+				intervalMs: 1,
+				poll: () => new Promise<null>(() => {}),
+			}),
+		).rejects.toMatchObject({ code: "readiness-timeout" });
+		expect(Date.now() - started).toBeLessThan(100);
+	});
+});

--- a/packages/driver/src/lib/poll.ts
+++ b/packages/driver/src/lib/poll.ts
@@ -1,0 +1,61 @@
+// Kit-owned readiness (ADR-0008 §4: readiness is a declared strategy where "the kit owns the loop
+// once" — hand-rolled deadline arithmetic "is the code easiest to get wrong"). A create-then-poll
+// driver supplies only its poll/select closures; the deadline, the interval, the sleep-clamping,
+// and the typed `readiness-timeout` error live here, so every such driver gets them identically.
+
+import type { ProviderId } from "@sandbox-benchmarks/schema/providers";
+import { DriverError } from "./errors.ts";
+
+export interface ReadinessStrategy<T> {
+	readonly provider: ProviderId;
+	/** One readiness probe; returns the ready result, or null to keep polling. */
+	poll(): Promise<T | null>;
+	readonly deadlineMs: number;
+	readonly intervalMs: number;
+}
+
+function timeoutError(strategy: ReadinessStrategy<unknown>): DriverError {
+	return new DriverError(
+		"readiness-timeout",
+		`${strategy.provider} sandbox not ready within ${strategy.deadlineMs}ms`,
+		{ provider: strategy.provider },
+	);
+}
+
+async function pollBefore<T>(strategy: ReadinessStrategy<T>, deadline: number): Promise<T | null> {
+	const remaining = deadline - Date.now();
+	if (remaining <= 0) throw timeoutError(strategy);
+
+	let timeout: ReturnType<typeof setTimeout> | undefined;
+	try {
+		const ready = await Promise.race([
+			strategy.poll(),
+			new Promise<never>((_resolve, reject) => {
+				timeout = setTimeout(() => reject(timeoutError(strategy)), remaining);
+			}),
+		]);
+		// A probe can resolve after its budget but before the timer callback gets a turn.
+		if (Date.now() >= deadline) throw timeoutError(strategy);
+		return ready;
+	} finally {
+		if (timeout !== undefined) clearTimeout(timeout);
+	}
+}
+
+/**
+ * Poll until `poll()` returns non-null or the deadline passes. Sleeps are clamped to the remaining
+ * budget, and the deadline is checked BEFORE each probe — so a timed-out create never spawns one
+ * extra wasted probe, and the failure is reported on time rather than up to `intervalMs` late.
+ */
+export async function pollUntilReady<T>(strategy: ReadinessStrategy<T>): Promise<T> {
+	const deadline = Date.now() + strategy.deadlineMs;
+	for (;;) {
+		const ready = await pollBefore(strategy, deadline);
+		if (ready !== null) {
+			return ready;
+		}
+		const remaining = deadline - Date.now();
+		if (remaining <= 0) throw timeoutError(strategy);
+		await new Promise((resolve) => setTimeout(resolve, Math.min(strategy.intervalMs, remaining)));
+	}
+}

--- a/packages/driver/src/lib/session.fixture.ts
+++ b/packages/driver/src/lib/session.fixture.ts
@@ -1,0 +1,28 @@
+// Shared test fixtures: one ExecResult stub and one minimal session, so the port's shapes have a
+// single place to update when they grow a field. `.fixture.ts` (repo convention) so the test
+// runner does not treat it as a suite.
+
+import type { ExecResult, SandboxSession } from "./port.ts";
+import { sandboxRef } from "./port.ts";
+
+export const okExec: ExecResult = {
+	exit: { kind: "exited", code: 0 },
+	stdout: "",
+	stderr: "",
+	durationMs: 0,
+	truncated: false,
+};
+
+/** A minimal session; override any member. `destroy` defaults to a no-op. */
+export function stubSession(overrides: Partial<SandboxSession> = {}): SandboxSession {
+	return {
+		sandboxRef: sandboxRef("tama", "m-1"),
+		artifact: { kind: "baked", ref: "im-1" },
+		native: null,
+		async exec() {
+			return okExec;
+		},
+		async destroy() {},
+		...overrides,
+	};
+}

--- a/packages/driver/src/lib/session.test.ts
+++ b/packages/driver/src/lib/session.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, test } from "bun:test";
+import { stubSession } from "./session.fixture.ts";
+import { withSessionTeardown } from "./session.ts";
+
+const session = (onDestroy: () => Promise<void>) => stubSession({ destroy: onDestroy });
+
+describe("withSessionTeardown", () => {
+	test("destroys exactly once on success and returns the work's result", async () => {
+		let destroys = 0;
+		const result = await withSessionTeardown(
+			session(async () => {
+				destroys += 1;
+			}),
+			async () => "measured",
+		);
+		expect(result).toBe("measured");
+		expect(destroys).toBe(1);
+	});
+
+	test("a work failure with clean teardown propagates the work failure", async () => {
+		await expect(
+			withSessionTeardown(
+				session(async () => {}),
+				async () => {
+					throw new Error("benchmark failed");
+				},
+			),
+		).rejects.toThrow("benchmark failed");
+	});
+
+	test("a teardown-only failure propagates plainly", async () => {
+		await expect(
+			withSessionTeardown(
+				session(async () => {
+					throw new Error("teardown exploded");
+				}),
+				async () => "fine",
+			),
+		).rejects.toThrow("teardown exploded");
+	});
+
+	test("a double fault preserves BOTH errors as SuppressedError", async () => {
+		try {
+			await withSessionTeardown(
+				session(async () => {
+					throw new Error("teardown exploded");
+				}),
+				async () => {
+					throw new Error("benchmark failed");
+				},
+			);
+			expect.unreachable("expected SuppressedError");
+		} catch (error) {
+			expect(error).toBeInstanceOf(SuppressedError);
+			const suppressed = error as SuppressedError;
+			expect(String(suppressed.error)).toContain("teardown exploded");
+			expect(String(suppressed.suppressed)).toContain("benchmark failed");
+		}
+	});
+});

--- a/packages/driver/src/lib/session.ts
+++ b/packages/driver/src/lib/session.ts
@@ -1,0 +1,40 @@
+// Session lifecycle helpers (ADR-0007 §9): teardown must never hide the primary error.
+
+import type { SandboxSession } from "./port.ts";
+
+/**
+ * Run work against a session, then destroy it — preserving BOTH errors when both fail.
+ *
+ * A bare `finally { await session.destroy() }` replaces a benchmark failure with a teardown
+ * failure; here a double fault throws `SuppressedError` in the same shape `using` produces:
+ * `error` is the teardown failure, `suppressed` is the primary it would otherwise have hidden.
+ */
+export async function withSessionTeardown<Handle, T>(
+	session: SandboxSession<Handle>,
+	work: (session: SandboxSession<Handle>) => Promise<T>,
+): Promise<T> {
+	// Run work and teardown as two linear steps (no throw-in-finally, so a teardown failure can be
+	// compared against the primary and combined rather than silently masking it).
+	let outcome: { ok: true; value: T } | { ok: false; error: unknown };
+	try {
+		outcome = { ok: true, value: await work(session) };
+	} catch (error) {
+		outcome = { ok: false, error };
+	}
+	try {
+		await session.destroy();
+	} catch (teardown) {
+		if (!outcome.ok) {
+			throw new SuppressedError(
+				teardown,
+				outcome.error,
+				"sandbox teardown failed after a primary error",
+			);
+		}
+		throw teardown;
+	}
+	if (!outcome.ok) {
+		throw outcome.error;
+	}
+	return outcome.value;
+}

--- a/packages/driver/src/lib/shell.test.ts
+++ b/packages/driver/src/lib/shell.test.ts
@@ -1,0 +1,183 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { DriverError } from "./errors.ts";
+import type { ExecOptions, ExecResult, SandboxSession } from "./port.ts";
+import { stubSession } from "./session.fixture.ts";
+import { launchDetached, readTextFile, shellQuote, writeTextFile } from "./shell.ts";
+
+/**
+ * A session whose exec IS a local /bin/sh — so the shell mechanics are tested against a real
+ * shell, not against our own idea of one. No files/launch capabilities: the fallbacks under
+ * test are exactly what a capability-less vendor session exercises.
+ */
+function localShellSession(cwd: string): SandboxSession {
+	return stubSession({
+		native: cwd,
+		async exec(command): Promise<ExecResult> {
+			const started = Date.now();
+			const child = Bun.spawnSync(["/bin/sh", "-c", command], { cwd });
+			return {
+				exit:
+					child.exitCode !== null
+						? { kind: "exited", code: child.exitCode }
+						: { kind: "unknown", detail: "no exit code" },
+				stdout: child.stdout.toString(),
+				stderr: child.stderr.toString(),
+				durationMs: Date.now() - started,
+				truncated: false,
+			};
+		},
+	});
+}
+
+function recordingSession(
+	record: string[],
+	optionRecord?: Array<ExecOptions | undefined>,
+): SandboxSession {
+	return stubSession({
+		async exec(command, options): Promise<ExecResult> {
+			record.push(command);
+			optionRecord?.push(options);
+			return {
+				exit: { kind: "exited", code: 0 },
+				stdout: "",
+				stderr: "",
+				durationMs: 0,
+				truncated: false,
+			};
+		},
+	});
+}
+
+let dir: string;
+beforeEach(() => {
+	dir = mkdtempSync(join(tmpdir(), "driver-shell-"));
+});
+afterEach(() => {
+	rmSync(dir, { recursive: true, force: true });
+});
+
+describe("shellQuote", () => {
+	test("survives quotes, spaces, dollars and newlines through a real shell", async () => {
+		const session = localShellSession(dir);
+		for (const hostile of [
+			"plain",
+			"with space",
+			`single'quote`,
+			`$HOME and "double"`,
+			"line\nbreak",
+		]) {
+			const result = await session.exec(`printf '%s' ${shellQuote(hostile)}`);
+			expect(result.stdout).toBe(hostile);
+		}
+	});
+});
+
+describe("writeTextFile / readTextFile fallbacks", () => {
+	test("round-trips arbitrary content through base64-over-exec and cat", async () => {
+		const session = localShellSession(dir);
+		const content = `#!/bin/sh\necho "hé — $VALUE" 'single' | base64\n`;
+		await writeTextFile(session, join(dir, "staged.sh"), content);
+		expect(await readTextFile(session, join(dir, "staged.sh"))).toBe(content);
+	});
+
+	test("chunks content that would be unsafe to place in one argv entry", async () => {
+		const session = localShellSession(dir);
+		const content = "héllø-$-'.".repeat(25_000);
+		await writeTextFile(session, join(dir, "large.txt"), content);
+		expect(await readTextFile(session, join(dir, "large.txt"))).toBe(content);
+	});
+
+	test("readTextFile returns null (a recorded gap) for an unreadable path", async () => {
+		expect(await readTextFile(localShellSession(dir), join(dir, "missing"))).toBeNull();
+	});
+
+	test("prefers the native files capability when the session has one", async () => {
+		const writes: Array<[string, string]> = [];
+		const session = stubSession({
+			native: null,
+			files: {
+				readFile: async (path) => `native:${path}`,
+				exists: async () => true,
+				writeText: async (path, text) => {
+					writes.push([path, text]);
+				},
+			},
+		});
+		await writeTextFile(session, "/bench/a", "1");
+		expect(writes).toEqual([["/bench/a", "1"]]);
+		expect(await readTextFile(session, "/bench/a")).toBe("native:/bench/a");
+	});
+});
+
+describe("launchDetached", () => {
+	test("falls back to the nohup double-fork over exec", async () => {
+		const record: string[] = [];
+		const options: Array<ExecOptions | undefined> = [];
+		await launchDetached(recordingSession(record, options), "bash task.sh", {
+			maxOutputBytes: 64,
+		});
+		expect(record).toEqual([
+			`nohup /bin/sh -lc 'bash task.sh' </dev/null >/dev/null 2>&1 & child=$!; finish() { wait "$child"; exit $?; }; sleep 0.05; if ! kill -0 "$child" 2>/dev/null; then finish; fi; if command -v ps >/dev/null 2>&1; then state=$(ps -o state= -p "$child" 2>/dev/null || :); case "$state" in *Z*) finish ;; "") if ! kill -0 "$child" 2>/dev/null; then finish; fi ;; esac; fi; exit 0`,
+		]);
+		expect(options).toEqual([{ maxOutputBytes: 64 }]);
+	});
+
+	test("surfaces a real target command that fails during the acceptance window", async () => {
+		const error = await launchDetached(
+			localShellSession(dir),
+			"definitely-not-a-real-sandbox-command",
+		).catch((caught) => caught);
+		expect(error).toBeInstanceOf(DriverError);
+		expect(error).toMatchObject({ code: "exec-failed", vendorExitCode: 127 });
+	});
+
+	test("uses the session's native launch when present", async () => {
+		const record: string[] = [];
+		const launches: Array<[string, ExecOptions | undefined]> = [];
+		const session = stubSession({
+			...recordingSession(record),
+			launch: async (command, options) => {
+				launches.push([command, options]);
+			},
+		});
+		await launchDetached(session, "bash task.sh", { maxOutputBytes: 64 });
+		expect(launches).toEqual([["bash task.sh", { maxOutputBytes: 64 }]]);
+		expect(record).toEqual([]);
+	});
+
+	test("surfaces a fallback launcher failure as a typed error", async () => {
+		const session = stubSession({
+			async exec() {
+				return {
+					exit: { kind: "exited", code: 127 },
+					stdout: "",
+					stderr: "nohup: not found",
+					durationMs: 1,
+					truncated: false,
+				};
+			},
+		});
+		const error = await launchDetached(session, "task").catch((caught) => caught);
+		expect(error).toBeInstanceOf(DriverError);
+		expect(error).toMatchObject({
+			code: "exec-failed",
+			vendorExitCode: 127,
+			vendorMessage: "nohup: not found",
+		});
+	});
+
+	test("a detached command actually survives the exec round-trip", async () => {
+		const session = localShellSession(dir);
+		await launchDetached(
+			session,
+			`sleep 0.2 && printf done > ${shellQuote(join(dir, "done-file"))}`,
+		);
+		// The launch returned before the command finished; the done-file appears afterwards.
+		expect(await readTextFile(session, join(dir, "done-file"))).toBeNull();
+		await new Promise((resolve) => setTimeout(resolve, 300));
+		expect(await readTextFile(session, join(dir, "done-file"))).toBe("done");
+	});
+});

--- a/packages/driver/src/lib/shell.ts
+++ b/packages/driver/src/lib/shell.ts
@@ -1,0 +1,127 @@
+// Harness-owned shell mechanics (ADR-0007 §2), written once. These express optional session
+// capabilities over the one required primitive (`exec`), so consumers never ask capability
+// questions: a session with a native fast path uses it, and one without gets the same behavior
+// through the shell. Three byte-identical shellQuote copies and four hand-rolled nohup lines
+// across the old adapters collapse into this module.
+
+import { DriverError } from "./errors.ts";
+import type { ExecOptions, ExecResult, SandboxSession } from "./port.ts";
+import { succeeded } from "./port.ts";
+
+// 64 KiB of base64 is comfortably below ordinary argv limits and is divisible by four, so every
+// non-final chunk is independently decodable. The corresponding raw chunk is 48 KiB.
+const BASE64_CHUNK_CHARS = 64 * 1024;
+
+/** POSIX single-quote escaping: the only quoting rule any of this module ever uses. */
+export const shellQuote = (value: string): string => `'${value.replace(/'/g, `'\\''`)}'`;
+
+/**
+ * Fire-and-forget a command. Uses the session's native `launch` when the vendor has one;
+ * otherwise nohup under `sh -lc`, all stdio detached. The outer shell keeps the child for a
+ * short acceptance window: an immediate missing-shell, syntax, or command failure is returned
+ * instead of becoming a later readiness timeout. Once the process survives that window,
+ * completion is observed by the caller (done-file poll), not by this call.
+ */
+export async function launchDetached(
+	session: SandboxSession,
+	command: string,
+	options?: ExecOptions,
+): Promise<void> {
+	if (session.launch) {
+		await session.launch(command, options);
+		return;
+	}
+	await execOrThrow(
+		session,
+		"launchDetached",
+		`nohup /bin/sh -lc ${shellQuote(command)} </dev/null >/dev/null 2>&1 & child=$!; finish() { wait "$child"; exit $?; }; sleep 0.05; if ! kill -0 "$child" 2>/dev/null; then finish; fi; if command -v ps >/dev/null 2>&1; then state=$(ps -o state= -p "$child" 2>/dev/null || :); case "$state" in *Z*) finish ;; "") if ! kill -0 "$child" 2>/dev/null; then finish; fi ;; esac; fi; exit 0`,
+		options,
+	);
+}
+
+/**
+ * Read a text file, via the native filesystem capability when present, `cat` otherwise.
+ * Returns null when the file is unreadable — a recorded gap, not an exception to catch.
+ */
+export async function readTextFile(session: SandboxSession, path: string): Promise<string | null> {
+	if (session.files) {
+		try {
+			return await session.files.readFile(path);
+		} catch {
+			return null;
+		}
+	}
+	const result = await session.exec(`cat ${shellQuote(path)}`);
+	return succeeded(result.exit) ? result.stdout : null;
+}
+
+/**
+ * Write a text file, via the native filesystem capability when present, base64-over-exec
+ * otherwise. Base64 (not a heredoc) so arbitrary content — quotes, dollar signs, newlines,
+ * even NUL-free binary-ish text — survives the shell without any quoting subtleties.
+ */
+export async function writeTextFile(
+	session: SandboxSession,
+	path: string,
+	text: string,
+): Promise<void> {
+	if (session.files) {
+		await session.files.writeText(path, text);
+		return;
+	}
+	// Base64 (not a heredoc) preserves arbitrary NUL-free text. Send it in bounded pieces: placing a
+	// multi-MB payload in one shell command crosses ARG_MAX before the remote base64 process starts.
+	// A sibling temporary keeps a failed write from replacing a previously valid destination.
+	const encoded = new TextEncoder().encode(text).toBase64();
+	const temporary = `${path}.sandbox-benchmarks-${crypto.randomUUID()}.tmp`;
+	try {
+		await execOrThrow(session, `writeTextFile(${path})`, `: > ${shellQuote(temporary)}`);
+		for (let offset = 0; offset < encoded.length; offset += BASE64_CHUNK_CHARS) {
+			const chunk = encoded.slice(offset, offset + BASE64_CHUNK_CHARS);
+			await execOrThrow(
+				session,
+				`writeTextFile(${path})`,
+				`printf '%s' '${chunk}' | base64 -d >> ${shellQuote(temporary)}`,
+			);
+		}
+		await execOrThrow(
+			session,
+			`writeTextFile(${path})`,
+			`mv ${shellQuote(temporary)} ${shellQuote(path)}`,
+		);
+	} catch (error) {
+		// Best effort only: preserve the primary typed failure if cleanup also fails.
+		await session.exec(`rm -f ${shellQuote(temporary)}`).catch(() => undefined);
+		throw error;
+	}
+}
+
+async function execOrThrow(
+	session: SandboxSession,
+	operation: string,
+	command: string,
+	options?: ExecOptions,
+): Promise<ExecResult> {
+	const result = await session.exec(command, options);
+	if (!succeeded(result.exit)) {
+		throw new DriverError("exec-failed", `${operation} failed: ${describeFailure(result)}`, {
+			provider: session.sandboxRef.provider,
+			ref: session.sandboxRef,
+			vendorMessage: result.stderr,
+			vendorExitCode: result.exit.kind === "exited" ? result.exit.code : undefined,
+		});
+	}
+	return result;
+}
+
+function describeFailure(result: ExecResult): string {
+	const exit = result.exit;
+	switch (exit.kind) {
+		case "exited":
+			return `exit ${exit.code}: ${result.stderr.trim()}`;
+		case "signalled":
+			return `signal ${exit.signal}`;
+		case "unknown":
+			return `unknown exit (${exit.detail})`;
+	}
+}


### PR DESCRIPTION
**Sandbox driver kit (ADR-0007) — the port every provider implements, and the kit that assembles it.**
Shipped as a 6-PR stack (merge bottom-up; each branch is independently green — typecheck + tests pass with nothing stacked above it):

1. #385 — **port**: the arktype single source of truth for the port's data shapes + the typed error family
2. #386 — **mechanics**: kit-owned session teardown, shell fallbacks, readiness polling
3. #388 — **assembly**: the method table → session layer, where the lifecycle invariants live
4. #387 — **join**: the typed registry binding (`defineDriver`/`EnvOf`) and its runtime env dual
5. #389 — **driver A**: `cliDriver`, for vendors whose control plane is a binary
6. #390 — **driver B**: the ComputeSDK bridge, now one driver among several

↑ **This PR is #386 (2/6)**, based on #385.

---

The three mechanics the kit owns once, so no driver re-implements them. All
three are leaf helpers over the port from the PR below; nothing consumes them
yet (the assembly layer and the generic drivers land above).

lib/session.ts — withSessionTeardown runs work then destroys, preserving BOTH
errors when both fail. A bare `finally { await session.destroy() }` replaces a
benchmark failure with a teardown failure; a double fault here throws
SuppressedError in the same shape `using` produces, so the primary is never
hidden (ADR-0007 §9).

lib/shell.ts — harness-owned shell mechanics expressed over the one required
primitive (exec), so consumers never ask capability questions: a session with
a native fast path uses it, one without gets the same behavior through the
shell. Three byte-identical shellQuote copies and four hand-rolled nohup lines
across the old adapters collapse into this module. writeTextFile carries the
payload as base64 rather than a heredoc, so arbitrary content survives the
shell with no quoting subtleties.

lib/poll.ts — pollUntilReady owns the readiness loop: the deadline, the
interval, sleep-clamping to the remaining budget, and the typed
readiness-timeout error (ADR-0008 §4, where hand-rolled deadline arithmetic is
called out as the code easiest to get wrong). The deadline is checked BEFORE
each probe, so a timed-out create never spawns one extra wasted probe. Its
first consumer is the CLI driver, four PRs up.

session.fixture.ts holds the shared ExecResult stub and minimal session, so
the port's shapes have one place to update when they grow a field; the
assembly-layer tests in the next PR reuse it.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Centralizes session teardown, shell fallbacks, and readiness polling in the driver kit and re-exports them from `packages/driver`, so drivers share one implementation and primary failures aren’t masked. Adds a typed `exec-failed` error for shell fallback failures.

- Session: `withSessionTeardown` runs work then destroys; on double fault throws `SuppressedError` so the primary error isn’t hidden.
- Shell: `shellQuote`; `launchDetached` uses nohup `/bin/sh -lc` with a short acceptance window; `readTextFile` returns null when unreadable; `writeTextFile` streams base64 chunks and swaps via temp+mv. Prefers native `launch`/`files` when present; fallback failures raise `DriverError` with code `exec-failed`.
- Readiness: `pollUntilReady(ReadinessStrategy)` checks the deadline before each probe, clamps sleeps, and throws a typed `readiness-timeout`.
- Exports from `packages/driver`: `ReadinessStrategy`, `pollUntilReady`, `withSessionTeardown`, `launchDetached`, `readTextFile`, `shellQuote`, `writeTextFile`.

**Migration**
- No behavior change yet; nothing consumes these helpers.
- When adopting: wrap session work with `withSessionTeardown`; replace ad‑hoc loops with `pollUntilReady`; use `launchDetached`/`readTextFile`/`writeTextFile` and handle `readTextFile` returning null.

<sup>Written for commit ce21eb3bc3bfb63338f81a6dae0eb96b450d344b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/starslingdev/hpc-sandbox-benchmarks/pull/386?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

