### PR TITLE
feat(driver): the typed registry join and its runtime env dual

### DIFF
--- a/packages/driver/package.json
+++ b/packages/driver/package.json
@@ -7,6 +7,7 @@
   "sideEffects": false,
   "exports": {
     ".": "./src/index.ts",
+    "./env": "./src/env.ts",
     "./schemas": "./src/schemas.ts",
     "./package.json": "./package.json"
   },

--- a/packages/driver/src/architecture.test.ts
+++ b/packages/driver/src/architecture.test.ts
@@ -32,6 +32,7 @@ describe("driver package boundaries", () => {
 		const graph = await rootRuntimeGraph();
 		expect([...graph].map((file) => file.slice(SRC.length + 1)).sort()).toEqual([
 			"index.ts",
+			"lib/define.ts",
 			"lib/errors.ts",
 			"lib/output.ts",
 			"lib/poll.ts",

--- a/packages/driver/src/env.test.ts
+++ b/packages/driver/src/env.test.ts
@@ -1,0 +1,94 @@
+import { describe, expect, test } from "bun:test";
+import { envSchemaFor, parseDriverEnv } from "./env.ts";
+import { DriverError } from "./lib/errors.ts";
+
+type Equal<X, Y> =
+	(<T>() => T extends X ? 1 : 2) extends <T>() => T extends Y ? 1 : 2 ? true : false;
+type Expect<T extends true> = T;
+
+describe("parseDriverEnv", () => {
+	test("returns the exact declared slice from an ambient environment", () => {
+		const env = parseDriverEnv("blaxel", {
+			BL_API_KEY: "key",
+			BL_WORKSPACE: "ws",
+			PATH: "/usr/bin",
+			E2B_API_KEY: "someone-else's",
+		});
+		expect(env).toEqual({ BL_API_KEY: "key", BL_WORKSPACE: "ws" });
+	});
+
+	test("a missing credential fails with the repo's one error grammar, naming the provider", () => {
+		const error = (() => {
+			try {
+				parseDriverEnv("blaxel", { BL_API_KEY: "key" });
+			} catch (caught) {
+				return caught;
+			}
+		})();
+		expect(error).toBeInstanceOf(DriverError);
+		expect(error).toMatchObject({ code: "missing-credentials", provider: "blaxel" });
+		expect((error as Error).message).toMatch(
+			/missing credentials for blaxel: BL_WORKSPACE must be a string \(was missing\)/,
+		);
+	});
+
+	test("empty string counts as unset (the config gatekeeper's rule)", () => {
+		expect(() => parseDriverEnv("tama", { TAMA_TOKEN: "" })).toThrow(/TAMA_TOKEN/);
+	});
+
+	test("undeclared ambient variables are never rejected — the pick IS the slice boundary", () => {
+		const env = parseDriverEnv("tama", { TAMA_TOKEN: "tok", HOME: "/root", TERM: "xterm" });
+		expect(Object.keys(env)).toEqual(["TAMA_TOKEN"]);
+	});
+
+	test("applies registry defaults while leaving genuinely optional inputs absent", () => {
+		expect(parseDriverEnv("daytona-vm", { DAYTONA_API_KEY: "key" })).toEqual({
+			DAYTONA_API_KEY: "key",
+			DAYTONA_TARGET: "us-west-2",
+		});
+	});
+
+	test("ambient values override defaults and empty optional values stay absent", () => {
+		expect(
+			parseDriverEnv("daytona-vm", {
+				DAYTONA_API_KEY: "key",
+				DAYTONA_TARGET: "eu-west-1",
+				DAYTONA_SNAPSHOT: "",
+			}),
+		).toEqual({ DAYTONA_API_KEY: "key", DAYTONA_TARGET: "eu-west-1" });
+	});
+
+	test("the direct schema deletes foreign provider secrets and resolves defaults", () => {
+		expect(
+			envSchemaFor("daytona-vm")({
+				DAYTONA_API_KEY: "key",
+				E2B_API_KEY: "must-not-escape",
+			}),
+		).toEqual({ DAYTONA_API_KEY: "key", DAYTONA_TARGET: "us-west-2" });
+	});
+
+	test("the direct schema exposes distinct raw input and resolved output types", () => {
+		const schema = envSchemaFor("daytona-vm");
+		type _input = Expect<
+			Equal<
+				typeof schema.inferIn,
+				{
+					readonly DAYTONA_API_KEY: string;
+					readonly DAYTONA_TARGET?: string;
+					readonly DAYTONA_SNAPSHOT?: string;
+				}
+			>
+		>;
+		type _output = Expect<
+			Equal<
+				typeof schema.infer,
+				{
+					readonly DAYTONA_API_KEY: string;
+					readonly DAYTONA_TARGET: string;
+					readonly DAYTONA_SNAPSHOT?: string;
+				}
+			>
+		>;
+		expect(true).toBe(true);
+	});
+});

--- a/packages/driver/src/env.ts
+++ b/packages/driver/src/env.ts
@@ -1,0 +1,76 @@
+// The runtime dual of EnvOf (ADR-0007 §3), exposed on its own subpath to keep ambient-env parsing
+// and arktype separate from the root driver-kit surface. Both the compile-time slice (define.ts)
+// and this parser derive from REGISTRY[id].inputs, so type and validator cannot drift.
+
+import { normalizeProviderInput } from "@sandbox-benchmarks/schema/provider-meta";
+import type { ProviderId } from "@sandbox-benchmarks/schema/providers";
+import { REGISTRY } from "@sandbox-benchmarks/schema/providers";
+import type { Out } from "arktype";
+import { type } from "arktype";
+import type { EnvInputOf, EnvOf } from "./lib/define.ts";
+import { DriverError } from "./lib/errors.ts";
+
+// One schema per provider, compiled on first use and reused — arktype's `type()` build is the
+// expensive step, and there are only 14 possible ids.
+const schemaCache = new Map<ProviderId, import("arktype").Type>();
+const nonEmptyString = type("string >= 1");
+type StringPropertyDefinition = typeof nonEmptyString | ReturnType<typeof nonEmptyString.default>;
+type ProviderEnvSchema<P extends ProviderId> = import("arktype").Type<
+	(In: EnvInputOf<P>) => Out<EnvOf<P>>
+>;
+
+/** The exact raw-to-resolved schema for one provider's registry-declared input slice. */
+export function envSchemaFor<P extends ProviderId>(id: P): ProviderEnvSchema<P> {
+	let schema = schemaCache.get(id);
+	if (schema === undefined) {
+		const shape: Record<string, StringPropertyDefinition> = {};
+		for (const raw of REGISTRY[id].inputs) {
+			const input = normalizeProviderInput(raw);
+			if (input.default !== undefined) {
+				shape[input.name] = nonEmptyString.default(input.default);
+			} else {
+				shape[input.required ? input.name : `${input.name}?`] = nonEmptyString;
+			}
+		}
+		schema = type(shape).onUndeclaredKey("delete");
+		schemaCache.set(id, schema);
+	}
+	// The runtime shape is built from the same literal tuple both mapped types read. Arktype cannot
+	// retain that id-indexed relationship through a mutable shape, so this cast records the proof.
+	return schema as unknown as ProviderEnvSchema<P>;
+}
+
+/**
+ * Parse a provider's env slice out of an ambient environment (`process.env`-shaped input).
+ *
+ * Only DECLARED keys are picked before validation — the ambient environment legitimately holds
+ * hundreds of undeclared variables, so undeclared-key rejection would be wrong here; the slice
+ * boundary is the pick itself. Empty values count as unset (the config gatekeeper's rule).
+ * Failures carry the repo's one error grammar: `TAMA_TOKEN must be a string (was missing)`.
+ */
+export function parseDriverEnv<P extends ProviderId>(
+	id: P,
+	ambient: Readonly<Record<string, string | undefined>>,
+): EnvOf<P> {
+	const picked: Record<string, string> = {};
+	for (const raw of REGISTRY[id].inputs) {
+		const input = normalizeProviderInput(raw);
+		const value = ambient[input.name];
+		if (value !== undefined && value !== "") {
+			picked[input.name] = value;
+		}
+	}
+	const parsed = envSchemaFor(id)(picked);
+	if (parsed instanceof type.errors) {
+		throw new DriverError(
+			"missing-credentials",
+			`missing credentials for ${id}: ${parsed.summary}`,
+			{
+				provider: id,
+			},
+		);
+	}
+	// The schema is assembled dynamically from the same tuple EnvOf maps statically. Arktype cannot
+	// retain that id-indexed relationship through a mutable shape, so this cast records the proof.
+	return parsed as EnvOf<P>;
+}

--- a/packages/driver/src/index.ts
+++ b/packages/driver/src/index.ts
@@ -1,8 +1,19 @@
 // @sandbox-benchmarks/driver — the sandbox driver kit (ADR-0007).
 //
 // This root entry is the trusted, arktype-free port and kit: everything the harness consumes and
-// everything a driver author implements. Runtime validation is deliberately isolated at `./schemas`;
-// importing the core must not evaluate arktype or the schema package's Run graph.
+// everything a driver author implements. Runtime validation is isolated at `./env` and `./schemas`;
+// importing the core must not evaluate arktype or any schema-package runtime graph.
+
+export type {
+	DriverContext,
+	DriverModule,
+	DriverSpec,
+	EnvFromInputs,
+	EnvInputFromInputs,
+	EnvInputOf,
+	EnvOf,
+} from "./lib/define.ts";
+export { defineDriver } from "./lib/define.ts";
 
 export type { DriverErrorCode, DriverErrorFields } from "./lib/errors.ts";
 export { DriverError, isDriverError } from "./lib/errors.ts";

--- a/packages/driver/src/lib/define.test.ts
+++ b/packages/driver/src/lib/define.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, test } from "bun:test";
+import type { EnvOf } from "./define.ts";
+import { defineDriver } from "./define.ts";
+import type { SandboxDriver } from "./port.ts";
+
+// Minimal type-level assertion helpers (kept local; this is the package's only type-test site).
+type Equal<X, Y> =
+	(<T>() => T extends X ? 1 : 2) extends <T>() => T extends Y ? 1 : 2 ? true : false;
+type Expect<T extends true> = T;
+
+const stubDriver: SandboxDriver = {
+	create: async () => {
+		throw new Error("stub driver — never created in tests");
+	},
+};
+
+describe("EnvOf", () => {
+	test("derives the exact resolved slice from the registry input literals", () => {
+		type _tama = Expect<
+			Equal<EnvOf<"tama">, { readonly TAMA_TOKEN: string; readonly TAMA_CLI?: string }>
+		>;
+		type _blaxel = Expect<
+			Equal<EnvOf<"blaxel">, { readonly BL_API_KEY: string; readonly BL_WORKSPACE: string }>
+		>;
+		type _daytona = Expect<
+			Equal<
+				EnvOf<"daytona-vm">,
+				{
+					readonly DAYTONA_API_KEY: string;
+					readonly DAYTONA_TARGET: string;
+					readonly DAYTONA_SNAPSHOT?: string;
+				}
+			>
+		>;
+		type _union = Expect<
+			Equal<
+				EnvOf<"tama" | "e2b">,
+				| { readonly TAMA_TOKEN: string; readonly TAMA_CLI?: string }
+				| { readonly E2B_API_KEY: string; readonly E2B_TEMPLATE?: string }
+			>
+		>;
+		expect(true).toBe(true); // the assertions above are compile-time; typecheck is the oracle
+	});
+});
+
+describe("defineDriver", () => {
+	test("carries the id and spec through unchanged", () => {
+		const module_ = defineDriver("tama", {
+			createBudget: { owner: "driver", attemptCeilingMs: 60_000 },
+			driver: ({ env }) => {
+				// env is the exact tama slice; both lines below are type-checked by `tsc --noEmit`.
+				const token: string = env.TAMA_TOKEN;
+				void token;
+				// @ts-expect-error — tama declares no E2B_API_KEY; the registry is the source of truth
+				void env.E2B_API_KEY;
+				return stubDriver;
+			},
+		});
+		expect(module_.id).toBe("tama");
+		expect(module_.createBudget).toEqual({ owner: "driver", attemptCeilingMs: 60_000 });
+		const driver = module_.driver({ env: { TAMA_TOKEN: "tok" } });
+		expect(typeof driver.create).toBe("function");
+	});
+
+	test("rejects unregistered provider ids at compile time", () => {
+		// @ts-expect-error — "not-a-provider" is not a ProviderId
+		const bad = () => defineDriver("not-a-provider", { driver: () => stubDriver });
+		void bad;
+		expect(true).toBe(true);
+	});
+});

--- a/packages/driver/src/lib/define.ts
+++ b/packages/driver/src/lib/define.ts
@@ -1,0 +1,101 @@
+// The typed join (ADR-0007 §3): a driver binds to the registry through one autocompleted id
+// parameter, and everything it may touch derives from that id. This root module imports the
+// registry TYPE only so the driver kit remains runtime dependency-free; ../env.ts is the explicit
+// arktype boundary that evaluates the same descriptor tuple.
+
+import type { ProviderId, ProviderInput, REGISTRY } from "@sandbox-benchmarks/schema/providers";
+import type { CreateBudget, SandboxDriver } from "./port.ts";
+
+type Prettify<T> = { [K in keyof T]: T[K] } & {};
+
+type InputName<I extends ProviderInput> = I extends string
+	? I
+	: I extends { readonly name: infer N extends string }
+		? N
+		: never;
+
+type IsResolvedOptional<I extends ProviderInput> = I extends string
+	? false
+	: I extends { readonly default: string }
+		? false
+		: I extends { readonly required: false }
+			? true
+			: false;
+
+type IsInputOptional<I extends ProviderInput> = I extends string
+	? false
+	: I extends { readonly default: string }
+		? true
+		: I extends { readonly required: false }
+			? true
+			: false;
+
+/** The raw input slice: defaulted and genuinely optional fields may both be absent. */
+export type EnvInputFromInputs<I extends readonly ProviderInput[]> = Prettify<
+	{
+		readonly [C in I[number] as IsInputOptional<C> extends true ? never : InputName<C>]: string;
+	} & {
+		readonly [C in I[number] as IsInputOptional<C> extends true ? InputName<C> : never]?: string;
+	}
+>;
+
+/**
+ * The resolved env slice for a literal provider-input tuple.
+ *
+ * Required inputs and inputs with defaults are always strings in driver code. Only inputs that
+ * explicitly declare `required: false` without a default remain optional after parsing.
+ */
+export type EnvFromInputs<I extends readonly ProviderInput[]> = Prettify<
+	{
+		readonly [C in I[number] as IsResolvedOptional<C> extends true ? never : InputName<C>]: string;
+	} & {
+		readonly [C in I[number] as IsResolvedOptional<C> extends true ? InputName<C> : never]?: string;
+	}
+>;
+
+/**
+ * The env slice a driver may read: exactly the variables its provider declares. Reading an
+ * undeclared credential is a compile error — "never read process.env here" is unrepresentable
+ * rather than a comment.
+ */
+export type EnvOf<P extends ProviderId> = P extends ProviderId
+	? EnvFromInputs<(typeof REGISTRY)[P]["inputs"]>
+	: never;
+
+/** The provider input accepted before defaults are applied. */
+export type EnvInputOf<P extends ProviderId> = P extends ProviderId
+	? EnvInputFromInputs<(typeof REGISTRY)[P]["inputs"]>
+	: never;
+
+export interface DriverContext<P extends ProviderId> {
+	readonly env: EnvOf<P>;
+}
+
+export interface DriverSpec<P extends ProviderId, Handle = unknown> {
+	/** Who owns the create attempt's budget. Omitted ⇒ the harness races create (the default). */
+	readonly createBudget?: CreateBudget;
+	readonly driver: (context: DriverContext<P>) => SandboxDriver<Handle>;
+}
+
+export interface DriverModule<P extends ProviderId, Handle = unknown>
+	extends DriverSpec<P, Handle> {
+	readonly id: P;
+}
+
+/**
+ * Define a provider's driver. The id is the whole join: it is autocompleted against
+ * {@link ProviderId}, an unregistered id fails compile, and the spec can never bend `P`
+ * (`NoInfer`) — only the id names the binding. One generic signature, deliberately not
+ * overloads: overloads prefix every mistake with a signature dump, while a single signature
+ * lands the error on the field the author got wrong.
+ *
+ * The spec literal stays inline in this call (or flows through a `DriverSpec<…>`-typed
+ * factory); an untyped extracted const severs contextual typing (ADR-0007 §9). Anything you
+ * want to extract and unit-test belongs in a `satisfies MethodTable<…>` table instead.
+ */
+export function defineDriver<P extends ProviderId, Handle = unknown>(
+	id: P,
+	spec: DriverSpec<NoInfer<P>, Handle>,
+): DriverModule<P, Handle> {
+	return { ...spec, id };
+}

--- a/packages/driver/src/lib/output.ts
+++ b/packages/driver/src/lib/output.ts
@@ -1,8 +1,9 @@
 // Byte-accurate output capping (ADR-0007 §9: caps are per-call opt-in and never a kit default —
 // results collection rides multi-MB base64-tar over stdout). Applied ONCE, centrally, in
-// driverFromTable's assembled exec — so a method table's exec never sees the option and cannot
-// accept-and-ignore it (the contract violation the ADRs forbid). `maxOutputBytes` means bytes,
-// not UTF-16 code units, so the cap is honest on non-ASCII output and never splits a code point.
+// driverFromTable's assembled exec. Method tables receive the original options for API consistency,
+// but cannot weaken the cap: the kit snapshots and validates it before dispatch, then applies it to
+// the result. `maxOutputBytes` means bytes, not UTF-16 code units, so the cap is honest on non-ASCII
+// output and never splits a code point.
 
 import { DriverError } from "./errors.ts";
 import type { ExecResult } from "./port.ts";
@@ -31,14 +32,9 @@ function clipToBytes(text: string, maxBytes: number): { text: string; cut: boole
  * `undefined` cap ⇒ the result passes through untouched (the common, uncapped path).
  */
 export function capExecOutput(result: ExecResult, maxOutputBytes: number | undefined): ExecResult {
+	validateMaxOutputBytes(maxOutputBytes);
 	if (maxOutputBytes === undefined) {
 		return result;
-	}
-	if (!Number.isSafeInteger(maxOutputBytes) || maxOutputBytes < 0) {
-		throw new DriverError(
-			"invalid-exec-options",
-			`maxOutputBytes must be a non-negative safe integer, received ${String(maxOutputBytes)}`,
-		);
 	}
 	const stdout = clipToBytes(result.stdout, maxOutputBytes);
 	const stderr = clipToBytes(result.stderr, maxOutputBytes);
@@ -46,4 +42,15 @@ export function capExecOutput(result: ExecResult, maxOutputBytes: number | undef
 		return result;
 	}
 	return { ...result, stdout: stdout.text, stderr: stderr.text, truncated: true };
+}
+
+/** Reject invalid caps before provider execution can produce side effects. */
+export function validateMaxOutputBytes(maxOutputBytes: number | undefined): void {
+	if (maxOutputBytes === undefined) return;
+	if (!Number.isSafeInteger(maxOutputBytes) || maxOutputBytes < 0) {
+		throw new DriverError(
+			"invalid-exec-options",
+			`maxOutputBytes must be a non-negative safe integer, received ${String(maxOutputBytes)}`,
+		);
+	}
 }

--- a/packages/driver/src/lib/table.test.ts
+++ b/packages/driver/src/lib/table.test.ts
@@ -175,6 +175,46 @@ describe("driverFromTable", () => {
 		expect(seenOptions).toEqual([{ maxOutputBytes: 10 }, undefined]);
 	});
 
+	test("snapshots the byte cap before a hostile table mutates the forwarded options", async () => {
+		const options = { maxOutputBytes: 10 };
+		let seenOptions: unknown;
+		const driver = driverFromTable(
+			{
+				...baseTable,
+				exec: async (_ctx, _handle, _command, forwarded) => {
+					seenOptions = forwarded;
+					Reflect.deleteProperty(forwarded as { maxOutputBytes?: number }, "maxOutputBytes");
+					return { ...okExec, stdout: "x".repeat(100) };
+				},
+			},
+			async () => null,
+		);
+		const result = await (await driver.create(request)).exec("noisy", options);
+		expect(seenOptions).toBe(options);
+		expect(options).not.toHaveProperty("maxOutputBytes");
+		expect(result.stdout).toBe("x".repeat(10));
+		expect(result.truncated).toBe(true);
+	});
+
+	test("rejects an invalid byte cap before invoking provider code", async () => {
+		let execCalls = 0;
+		const driver = driverFromTable(
+			{
+				...baseTable,
+				exec: async () => {
+					execCalls += 1;
+					return okExec;
+				},
+			},
+			async () => null,
+		);
+		const error = await (await driver.create(request))
+			.exec("noisy", { maxOutputBytes: -1 })
+			.catch((caught: unknown) => caught);
+		expect(error).toMatchObject({ code: "invalid-exec-options" });
+		expect(execCalls).toBe(0);
+	});
+
 	test("destroy is idempotent and every operation after it is a typed use-after-destroy error", async () => {
 		let destroys = 0;
 		const driver = driverFromTable(

--- a/packages/driver/src/lib/table.ts
+++ b/packages/driver/src/lib/table.ts
@@ -7,7 +7,7 @@
 // bypassed this layer would have to re-implement all four; none do.
 
 import { DriverError } from "./errors.ts";
-import { capExecOutput } from "./output.ts";
+import { capExecOutput, validateMaxOutputBytes } from "./output.ts";
 import type {
 	ControlPlaneProbes,
 	CreateRequest,
@@ -275,11 +275,15 @@ export function driverFromTable<Handle, Ctx>(
 				artifact,
 				native: handle,
 				exec: (command, options?: ExecOptions) =>
-					alive(() =>
-						table
+					alive(() => {
+						// Read the cap before provider code sees the original options object. Readonly is a
+						// compile-time contract; a hostile callback must not mutate away kit-owned enforcement.
+						const maxOutputBytes = options?.maxOutputBytes;
+						validateMaxOutputBytes(maxOutputBytes);
+						return table
 							.exec(resolved, handle, command, options)
-							.then((result) => capExecOutput(result, options?.maxOutputBytes)),
-					),
+							.then((result) => capExecOutput(result, maxOutputBytes));
+					}),
 				async destroy() {
 					if (state === "destroyed") return;
 					if (destroyInFlight !== undefined) return destroyInFlight;


### PR DESCRIPTION
## Summary

- derives `EnvInputOf<P>` and resolved `EnvOf<P>` directly from the literal provider metadata input tuple
- builds the arktype runtime schema from that same tuple, applies defaults, preserves true optionality, deletes foreign keys, and treats empty ambient values as unset
- adds `defineDriver(id, spec)` with a single typed join and keeps the root driver runtime graph free of arktype and schema package imports
- removes the duplicate provider credential table entirely
- enforces the exec byte cap from a pre-dispatch snapshot, so a method table handed the caller's options object cannot delete `maxOutputBytes` before the kit applies it, and an impossible cap now fails before provider code can produce side effects

## Verification

- full workspace tests
- workspace typecheck, lint, and spell
- provider registry, provider wiring, and catalog drift gates
- adversarial code-reviewer approval after resolving the raw/resolved boundary and foreign-secret leak

Stack parent: #397
