### PR TITLE
feat(driver): the method-table assembly layer and central session invariants

### DIFF
--- a/packages/driver/src/index.ts
+++ b/packages/driver/src/index.ts
@@ -44,3 +44,5 @@ export {
 } from "./lib/port.ts";
 export { withSessionTeardown } from "./lib/session.ts";
 export { launchDetached, readTextFile, shellQuote, writeTextFile } from "./lib/shell.ts";
+export type { MethodTable } from "./lib/table.ts";
+export { DeferredTeardownError, driverFromTable } from "./lib/table.ts";

--- a/packages/driver/src/lib/errors.ts
+++ b/packages/driver/src/lib/errors.ts
@@ -20,6 +20,7 @@ import type { SandboxRef } from "./port.ts";
  *   - `readiness-timeout` — create was accepted but the sandbox never became ready in budget.
  *   - `vendor-output-unparseable` — the vendor's control-plane output drifted from its schema.
  *   - `exec-failed` — a kit-owned shell fallback failed before it could satisfy its contract.
+ *   - `invalid-exec-options` — a caller supplied an impossible output-cap value.
  *   - `destroy-failed` — teardown could not converge.
  */
 export type DriverErrorCode =
@@ -33,6 +34,7 @@ export type DriverErrorCode =
 	| "readiness-timeout"
 	| "vendor-output-unparseable"
 	| "exec-failed"
+	| "invalid-exec-options"
 	| "destroy-failed";
 
 export interface DriverErrorFields {

--- a/packages/driver/src/lib/output.test.ts
+++ b/packages/driver/src/lib/output.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, test } from "bun:test";
+import { DriverError } from "./errors.ts";
+import { capExecOutput } from "./output.ts";
+import { okExec } from "./session.fixture.ts";
+
+const withStreams = (stdout: string, stderr = "") => ({ ...okExec, stdout, stderr });
+
+describe("capExecOutput", () => {
+	test("passes the result through untouched when no cap is set", () => {
+		const result = withStreams("x".repeat(1000));
+		expect(capExecOutput(result, undefined)).toBe(result);
+	});
+
+	test("passes through untouched (same reference) when under the cap", () => {
+		const result = withStreams("small");
+		expect(capExecOutput(result, 1000)).toBe(result);
+	});
+
+	test("caps by BYTES, not UTF-16 code units, and never splits a code point", () => {
+		// "😀" is 4 UTF-8 bytes but 2 UTF-16 code units. A char-based cap of 4 would keep 4 code
+		// units (two emoji, 8 bytes); the byte cap keeps exactly one emoji and reports truncation.
+		const capped = capExecOutput(withStreams("😀😀"), 4);
+		expect(capped.stdout).toBe("😀");
+		expect(Buffer.byteLength(capped.stdout, "utf8")).toBe(4);
+		expect(capped.truncated).toBe(true);
+	});
+
+	test("stops before a code point that would overflow the byte budget", () => {
+		// "é" is 2 bytes; a 3-byte cap fits one "é" (2 bytes) but not two (4), and must not emit a
+		// half code point for the leftover byte.
+		const capped = capExecOutput(withStreams("éé"), 3);
+		expect(capped.stdout).toBe("é");
+		expect(capped.truncated).toBe(true);
+	});
+
+	test("truncation on either stream sets the flag; the other stream is still capped", () => {
+		const capped = capExecOutput({ ...okExec, stdout: "short", stderr: "x".repeat(50) }, 10);
+		expect(capped.stdout).toBe("short");
+		expect(capped.stderr).toHaveLength(10);
+		expect(capped.truncated).toBe(true);
+	});
+
+	test.each([
+		-1,
+		Number.NaN,
+		Number.POSITIVE_INFINITY,
+		1.5,
+	])("rejects an invalid byte cap (%s) with a typed error", (cap) => {
+		const error = (() => {
+			try {
+				capExecOutput(withStreams("x"), cap);
+			} catch (caught) {
+				return caught;
+			}
+		})();
+		expect(error).toBeInstanceOf(DriverError);
+		expect((error as DriverError).code).toBe("invalid-exec-options");
+	});
+
+	test("accepts zero as a valid cap", () => {
+		const capped = capExecOutput(withStreams("x"), 0);
+		expect(capped.stdout).toBe("");
+		expect(capped.truncated).toBe(true);
+	});
+});

--- a/packages/driver/src/lib/output.ts
+++ b/packages/driver/src/lib/output.ts
@@ -1,0 +1,49 @@
+// Byte-accurate output capping (ADR-0007 §9: caps are per-call opt-in and never a kit default —
+// results collection rides multi-MB base64-tar over stdout). Applied ONCE, centrally, in
+// driverFromTable's assembled exec — so a method table's exec never sees the option and cannot
+// accept-and-ignore it (the contract violation the ADRs forbid). `maxOutputBytes` means bytes,
+// not UTF-16 code units, so the cap is honest on non-ASCII output and never splits a code point.
+
+import { DriverError } from "./errors.ts";
+import type { ExecResult } from "./port.ts";
+
+const encoder = new TextEncoder();
+
+/** Clip a string to at most `maxBytes` UTF-8 bytes without splitting a code point. */
+function clipToBytes(text: string, maxBytes: number): { text: string; cut: boolean } {
+	if (encoder.encode(text).length <= maxBytes) {
+		return { text, cut: false };
+	}
+	// Walk code points, accumulating byte length, until the next one would overflow.
+	let bytes = 0;
+	let end = 0;
+	for (const codePoint of text) {
+		const size = encoder.encode(codePoint).length;
+		if (bytes + size > maxBytes) break;
+		bytes += size;
+		end += codePoint.length;
+	}
+	return { text: text.slice(0, end), cut: true };
+}
+
+/**
+ * Apply an optional byte cap to an exec result, setting `truncated` when either stream was cut.
+ * `undefined` cap ⇒ the result passes through untouched (the common, uncapped path).
+ */
+export function capExecOutput(result: ExecResult, maxOutputBytes: number | undefined): ExecResult {
+	if (maxOutputBytes === undefined) {
+		return result;
+	}
+	if (!Number.isSafeInteger(maxOutputBytes) || maxOutputBytes < 0) {
+		throw new DriverError(
+			"invalid-exec-options",
+			`maxOutputBytes must be a non-negative safe integer, received ${String(maxOutputBytes)}`,
+		);
+	}
+	const stdout = clipToBytes(result.stdout, maxOutputBytes);
+	const stderr = clipToBytes(result.stderr, maxOutputBytes);
+	if (!stdout.cut && !stderr.cut) {
+		return result;
+	}
+	return { ...result, stdout: stdout.text, stderr: stderr.text, truncated: true };
+}

--- a/packages/driver/src/lib/table.test.ts
+++ b/packages/driver/src/lib/table.test.ts
@@ -1,0 +1,440 @@
+import { describe, expect, test } from "bun:test";
+import { DriverError } from "./errors.ts";
+import type { CreateRequest } from "./port.ts";
+import { sandboxRef } from "./port.ts";
+import { okExec } from "./session.fixture.ts";
+import type { MethodTable } from "./table.ts";
+import { DeferredTeardownError, driverFromTable } from "./table.ts";
+
+const request: CreateRequest = {
+	spec: { vcpus: 4, memoryGb: 8 },
+	artifact: { kind: "image", ref: "im-abc123" },
+	deadlineMs: 60_000,
+};
+
+const baseTable: MethodTable<string, null> = {
+	create: async () => ({ handle: "h", sandboxRef: sandboxRef("tama", "m-1") }),
+	exec: async () => okExec,
+	destroy: async () => {},
+};
+
+describe("driverFromTable", () => {
+	test("assembles a session over the table with the request's tagged artifact", async () => {
+		const driver = driverFromTable(baseTable, async () => null);
+		const session = await driver.create(request);
+		expect(session.sandboxRef).toEqual({ provider: "tama", id: "m-1" });
+		expect(session.artifact).toEqual({ kind: "image", ref: "im-abc123" });
+		expect(session.native).toBe("h");
+		expect(session.files).toBeUndefined();
+		expect(session.launch).toBeUndefined();
+	});
+
+	test("a transient context failure is retried, not memoized forever", async () => {
+		let attempts = 0;
+		const driver = driverFromTable(baseTable, async () => {
+			attempts += 1;
+			if (attempts === 1) throw new Error("transient plumbing failure");
+			return null;
+		});
+		await expect(driver.create(request)).rejects.toThrow("transient plumbing failure");
+		// Before the memo-clear rule this replayed the memoized rejection and bricked the driver.
+		const session = await driver.create(request);
+		expect(session.sandboxRef.id).toBe("m-1");
+		expect(attempts).toBe(2);
+	});
+
+	test("a driver-reported artifact contradiction fails create (typed) and tears down the orphan", async () => {
+		let destroyed = 0;
+		const driver = driverFromTable(
+			{
+				...baseTable,
+				create: async () => ({
+					handle: "h",
+					sandboxRef: sandboxRef("tama", "m-2"),
+					artifact: { kind: "image" as const, ref: "im-OTHER" },
+				}),
+				destroy: async () => {
+					destroyed += 1;
+				},
+			},
+			async () => null,
+		);
+		const error = await driver.create(request).catch((caught: unknown) => caught);
+		expect(error).toBeInstanceOf(DriverError);
+		expect((error as DriverError).code).toBe("artifact-mismatch");
+		expect(destroyed).toBe(1);
+	});
+
+	test("a mismatch whose orphan teardown ALSO fails preserves the mismatch as SuppressedError", async () => {
+		const driver = driverFromTable(
+			{
+				...baseTable,
+				create: async () => ({
+					handle: "h",
+					sandboxRef: sandboxRef("tama", "m-2"),
+					artifact: { kind: "image" as const, ref: "im-OTHER" },
+				}),
+				destroy: async () => {
+					throw new Error("teardown exploded");
+				},
+			},
+			async () => null,
+		);
+		const error = (await driver
+			.create(request)
+			.catch((caught: unknown) => caught)) as SuppressedError;
+		expect(error).toBeInstanceOf(SuppressedError);
+		expect(String(error.error)).toContain("teardown exploded");
+		expect((error.suppressed as DriverError).code).toBe("artifact-mismatch");
+	});
+
+	test("a driver-reported ref that matches is recorded on the session", async () => {
+		const driver = driverFromTable(
+			{
+				...baseTable,
+				create: async () => ({
+					handle: "h",
+					sandboxRef: sandboxRef("tama", "m-3"),
+					artifact: { kind: "image" as const, ref: "im-abc123" },
+				}),
+			},
+			async () => null,
+		);
+		const session = await driver.create(request);
+		expect(session.artifact).toEqual({ kind: "image", ref: "im-abc123" });
+	});
+
+	test("artifact kinds are part of identity, including explicit none", async () => {
+		const noneRequest: CreateRequest = { ...request, artifact: { kind: "none" } };
+		const noneSession = await driverFromTable(baseTable, async () => null).create(noneRequest);
+		expect(noneSession.artifact).toEqual({ kind: "none" });
+
+		const wrongKind = driverFromTable(
+			{
+				...baseTable,
+				create: async () => ({
+					handle: "h",
+					sandboxRef: sandboxRef("tama", "m-kind"),
+					artifact: { kind: "baked" as const, ref: "im-abc123" },
+				}),
+			},
+			async () => null,
+		);
+		const error = await wrongKind.create(request).catch((caught: unknown) => caught);
+		expect(error).toBeInstanceOf(DriverError);
+		expect((error as DriverError).code).toBe("artifact-mismatch");
+	});
+
+	test("files and launch pass through only when the table declares them", async () => {
+		const writes: string[] = [];
+		const seenOptions: unknown[] = [];
+		const driver = driverFromTable(
+			{
+				...baseTable,
+				launch: async (_ctx, _handle, command, options) => {
+					writes.push(`launch:${command}`);
+					seenOptions.push(options);
+				},
+				files: {
+					readFile: async (_ctx, _handle, path) => `read:${path}`,
+					exists: async () => true,
+					writeText: async (_ctx, _handle, path, text) => {
+						writes.push(`${path}=${text}`);
+					},
+				},
+			},
+			async () => null,
+		);
+		const session = await driver.create(request);
+		expect(await session.files?.readFile("/etc/os-release")).toBe("read:/etc/os-release");
+		await session.files?.writeText("/bench/a", "1");
+		await session.launch?.("sleep 1", { maxOutputBytes: 17 });
+		expect(writes).toEqual(["/bench/a=1", "launch:sleep 1"]);
+		expect(seenOptions).toEqual([{ maxOutputBytes: 17 }]);
+	});
+
+	test("the kit applies byte caps centrally; a table cannot ignore them", async () => {
+		const seenOptions: unknown[] = [];
+		const driver = driverFromTable(
+			{
+				...baseTable,
+				exec: async (_ctx, _handle, _command, options) => {
+					seenOptions.push(options);
+					return { ...okExec, stdout: "x".repeat(100) };
+				},
+			},
+			async () => null,
+		);
+		const session = await driver.create(request);
+		const capped = await session.exec("noisy", { maxOutputBytes: 10 });
+		expect(capped.stdout).toBe("x".repeat(10));
+		expect(capped.truncated).toBe(true);
+		const uncapped = await session.exec("noisy");
+		expect(uncapped.stdout).toHaveLength(100);
+		expect(uncapped.truncated).toBe(false);
+		expect(seenOptions).toEqual([{ maxOutputBytes: 10 }, undefined]);
+	});
+
+	test("destroy is idempotent and every operation after it is a typed use-after-destroy error", async () => {
+		let destroys = 0;
+		const driver = driverFromTable(
+			{
+				...baseTable,
+				destroy: async () => {
+					destroys += 1;
+				},
+				files: {
+					readFile: async () => "x",
+					exists: async () => true,
+					writeText: async () => {},
+				},
+			},
+			async () => null,
+		);
+		const session = await driver.create(request);
+		await session.destroy();
+		await session.destroy(); // idempotent — a second destroy is a no-op, not an error
+		expect(destroys).toBe(1);
+		const execError = (await session
+			.exec("echo")
+			.catch((caught: unknown) => caught)) as DriverError;
+		expect(execError).toBeInstanceOf(DriverError);
+		expect(execError.code).toBe("use-after-destroy");
+		const readError = (await (
+			session.files?.readFile("/x") ?? Promise.reject(new Error("no files"))
+		).catch((caught: unknown) => caught)) as DriverError;
+		expect(readError.code).toBe("use-after-destroy");
+	});
+
+	test("normalizes a synchronous table throw into the session's promise contract", async () => {
+		const driver = driverFromTable(
+			{
+				...baseTable,
+				files: {
+					readFile: () => {
+						throw new DriverError("vendor-contract-violation", "filesystem disappeared");
+					},
+					exists: async () => true,
+					writeText: async () => {},
+				},
+			},
+			async () => null,
+		);
+		const session = await driver.create(request);
+		const pending = session.files?.readFile("/bench/a");
+		expect(pending).toBeInstanceOf(Promise);
+		const error = await pending?.catch((caught: unknown) => caught);
+		expect(error).toMatchObject({ code: "vendor-contract-violation" });
+	});
+
+	test("starts an accepted operation before a following destroy can begin", async () => {
+		const events: string[] = [];
+		let finishExec!: () => void;
+		const execFinished = new Promise<void>((resolve) => {
+			finishExec = resolve;
+		});
+		const driver = driverFromTable(
+			{
+				...baseTable,
+				exec: async () => {
+					events.push("exec:start");
+					await execFinished;
+					events.push("exec:end");
+					return okExec;
+				},
+				destroy: async () => {
+					events.push("destroy:start");
+				},
+			},
+			async () => null,
+		);
+		const session = await driver.create(request);
+		const executing = session.exec("slow");
+		const destroying = session.destroy();
+		expect(events).toEqual(["exec:start"]);
+		finishExec();
+		await executing;
+		await destroying;
+		expect(events).toEqual(["exec:start", "exec:end", "destroy:start"]);
+	});
+
+	test("concurrent destroys share one attempt and a failed attempt can be retried", async () => {
+		let destroys = 0;
+		let release!: () => void;
+		const firstAttempt = new Promise<void>((resolve) => {
+			release = resolve;
+		});
+		const driver = driverFromTable(
+			{
+				...baseTable,
+				destroy: async () => {
+					destroys += 1;
+					if (destroys === 1) {
+						await firstAttempt;
+						throw new Error("transient teardown failure");
+					}
+				},
+			},
+			async () => null,
+		);
+		const session = await driver.create(request);
+		const first = session.destroy();
+		const concurrent = session.destroy();
+		expect(destroys).toBe(1);
+		const firstFailure = first.catch((caught: unknown) => caught);
+		const concurrentFailure = concurrent.catch((caught: unknown) => caught);
+		release();
+		expect(await firstFailure).toEqual(new Error("transient teardown failure"));
+		expect(await concurrentFailure).toEqual(new Error("transient teardown failure"));
+
+		await session.destroy();
+		await session.destroy();
+		expect(destroys).toBe(2);
+	});
+
+	test("a synchronous destroy throw resets lifecycle state and can be retried", async () => {
+		let destroys = 0;
+		const driver = driverFromTable(
+			{
+				...baseTable,
+				destroy: () => {
+					destroys += 1;
+					if (destroys === 1) throw new Error("synchronous teardown failure");
+					return Promise.resolve();
+				},
+			},
+			async () => null,
+		);
+		const session = await driver.create(request);
+		await expect(session.destroy()).rejects.toThrow("synchronous teardown failure");
+		await session.destroy();
+		expect(destroys).toBe(2);
+	});
+
+	test("a stalled operation returns a bounded error but keeps safe teardown scheduled", async () => {
+		const events: string[] = [];
+		let finishExec!: () => void;
+		const stalled = new Promise<void>((resolve) => {
+			finishExec = resolve;
+		});
+		let noteDestroy!: () => void;
+		const providerDestroyed = new Promise<void>((resolve) => {
+			noteDestroy = resolve;
+		});
+		const driver = driverFromTable(
+			{
+				...baseTable,
+				operationDrainTimeoutMs: 5,
+				exec: async () => {
+					events.push("exec:start");
+					await stalled;
+					return okExec;
+				},
+				destroy: async () => {
+					events.push("destroy:start");
+					noteDestroy();
+				},
+			},
+			async () => null,
+		);
+		const session = await driver.create(request);
+		const executing = session.exec("stalled");
+		const destroyError = (await session
+			.destroy()
+			.catch((caught: unknown) => caught)) as DriverError;
+		expect(destroyError).toBeInstanceOf(DriverError);
+		expect(destroyError).toMatchObject({ code: "destroy-failed", ref: session.sandboxRef });
+		expect(events).toEqual(["exec:start"]);
+		const useWhileDeferred = (await session
+			.exec("too late")
+			.catch((caught: unknown) => caught)) as DriverError;
+		expect(useWhileDeferred).toMatchObject({ code: "use-after-destroy" });
+		finishExec();
+		await executing;
+		await providerDestroyed;
+		expect(events).toEqual(["exec:start", "destroy:start"]);
+		// The first caller already received its bounded failure, and no retry was needed to start the
+		// teardown once the accepted operation settled. A later destroy is simply idempotent.
+		await session.destroy();
+		expect(events).toEqual(["exec:start", "destroy:start"]);
+	});
+
+	test("a deferred provider failure remains observable and async-disposable for retry", async () => {
+		let finishExec!: () => void;
+		const stalled = new Promise<void>((resolve) => {
+			finishExec = resolve;
+		});
+		let destroys = 0;
+		const driver = driverFromTable(
+			{
+				...baseTable,
+				operationDrainTimeoutMs: 5,
+				exec: async () => {
+					await stalled;
+					return okExec;
+				},
+				destroy: async () => {
+					destroys++;
+					if (destroys === 1) throw new Error("deferred provider teardown failed");
+				},
+			},
+			async () => null,
+		);
+		const session = await driver.create(request);
+		const executing = session.exec("stalled");
+		const error = (await session
+			.destroy()
+			.catch((caught: unknown) => caught)) as DeferredTeardownError;
+		expect(error).toBeInstanceOf(DeferredTeardownError);
+
+		finishExec();
+		await executing;
+		await expect(error.completion).rejects.toThrow("deferred provider teardown failed");
+		expect(error.deferredFailure).toEqual(new Error("deferred provider teardown failed"));
+
+		await error[Symbol.asyncDispose]();
+		expect(destroys).toBe(2);
+		await session.destroy();
+	});
+
+	test("destroyById, probes and snapshots pass through exactly when the table declares them", async () => {
+		const reaped: string[] = [];
+		const bare = driverFromTable(baseTable, async () => null);
+		expect(bare.destroyById).toBeUndefined();
+		expect(bare.probes).toBeUndefined();
+		expect(bare.snapshots).toBeUndefined();
+
+		const listed: string[] = [];
+		const full = driverFromTable(
+			{
+				...baseTable,
+				destroyById: async (_ctx, ref) => {
+					reaped.push(ref.id);
+				},
+				probes: {
+					observe: async () => ({ state: "absent" as const }),
+					list: async (ctx) => {
+						listed.push(String(ctx));
+					},
+				},
+				snapshots: {
+					create: async () => ({ snapshotId: "snap-1" }),
+					delete: async () => {},
+				},
+			},
+			async () => null,
+		);
+		await full.destroyById?.(sandboxRef("tama", "m-gone"));
+		expect(reaped).toEqual(["m-gone"]);
+		await full.probes?.list?.();
+		expect(listed).toEqual(["null"]);
+		expect(await full.probes?.observe(sandboxRef("tama", "m-gone"))).toEqual({
+			state: "absent",
+		});
+		expect(full.probes?.describe).toBeUndefined(); // absent, not a no-op stub
+		const session = await full.create(request);
+		expect(await full.snapshots?.create(session)).toEqual({
+			snapshotId: "snap-1",
+		});
+	});
+});

--- a/packages/driver/src/lib/table.ts
+++ b/packages/driver/src/lib/table.ts
@@ -1,0 +1,349 @@
+// The method-table layer (ADR-0007 §2): driver authors write a flat table of pure functions
+// over a typed native handle — trivially unit-testable, extraction-safe (`satisfies
+// MethodTable<…>` on a named const), and patchable by ordinary composition. The kit assembles
+// the harness-facing SandboxSession from it — and, because every generic driver flows through
+// here, this is the ONE place the session-lifecycle invariants live: output capping (§2 below),
+// the use-after-destroy guard, artifact reconciliation, and the lazy-context memo. A driver that
+// bypassed this layer would have to re-implement all four; none do.
+
+import { DriverError } from "./errors.ts";
+import { capExecOutput } from "./output.ts";
+import type {
+	ControlPlaneProbes,
+	CreateRequest,
+	ExecOptions,
+	ExecResult,
+	ResolvedArtifact,
+	SandboxDriver,
+	SandboxObservation,
+	SandboxRef,
+	SandboxSession,
+	SnapshotCapability,
+} from "./port.ts";
+
+export interface MethodTable<Handle, Ctx> {
+	/** Bounded wait for accepted operations; expiry fails destroy so teardown never races the handle. */
+	readonly operationDrainTimeoutMs?: number;
+	/**
+	 * Boot a sandbox. `artifact`, when returned, is the artifact the driver ACTUALLY booted (for
+	 * "built" artifacts, the ctx factory's product); the kit fails create on a contradiction
+	 * with the request so a measurement is never attributed to the wrong artifact.
+	 */
+	create(
+		ctx: Ctx,
+		request: CreateRequest,
+	): Promise<{
+		readonly handle: Handle;
+		readonly sandboxRef: SandboxRef;
+		readonly artifact?: ResolvedArtifact;
+	}>;
+	/** Run a command. Options are forwarded unchanged; the kit still enforces output caps. */
+	exec(ctx: Ctx, handle: Handle, command: string, options?: ExecOptions): Promise<ExecResult>;
+	destroy(ctx: Ctx, handle: Handle): Promise<void>;
+	destroyById?(ctx: Ctx, ref: SandboxRef): Promise<void>;
+	launch?(ctx: Ctx, handle: Handle, command: string, options?: ExecOptions): Promise<void>;
+	readonly files?: {
+		readFile(ctx: Ctx, handle: Handle, path: string): Promise<string>;
+		exists(ctx: Ctx, handle: Handle, path: string): Promise<boolean>;
+		writeText(ctx: Ctx, handle: Handle, path: string, text: string): Promise<void>;
+	};
+	/** Optional measurement capabilities, carried so a driver never bypasses this layer for them. */
+	readonly probes?: {
+		observe(ctx: Ctx, ref: SandboxRef): Promise<SandboxObservation>;
+		list?(ctx: Ctx): Promise<unknown>;
+		describe?(ctx: Ctx, ref: SandboxRef): Promise<unknown>;
+	};
+	readonly snapshots?: {
+		create(ctx: Ctx, session: SandboxSession<Handle>): Promise<{ readonly snapshotId: string }>;
+		delete(ctx: Ctx, snapshotId: string): Promise<void>;
+	};
+}
+
+function artifactsEqual(left: ResolvedArtifact, right: ResolvedArtifact): boolean {
+	if (left.kind !== right.kind) return false;
+	return left.kind === "none" || (right.kind !== "none" && left.ref === right.ref);
+}
+
+function artifactLabel(artifact: ResolvedArtifact): string {
+	return artifact.kind === "none" ? "none" : `${artifact.kind}:${artifact.ref}`;
+}
+
+async function drainWithin(
+	drain: Promise<void>,
+	timeoutMs: number,
+	timeoutError: () => Error,
+): Promise<void> {
+	let timer: ReturnType<typeof setTimeout> | undefined;
+	try {
+		await Promise.race([
+			drain,
+			new Promise<never>((_resolve, reject) => {
+				timer = setTimeout(() => reject(timeoutError()), timeoutMs);
+			}),
+		]);
+	} finally {
+		if (timer !== undefined) clearTimeout(timer);
+	}
+}
+
+/**
+ * A bounded destroy call timed out waiting for accepted work, while safe provider teardown remains
+ * scheduled behind that work. `completion` exposes the eventual provider result; async disposal
+ * retries the session if that deferred attempt fails. This lets one-shot callers hand ownership to
+ * a generic cleanup registry without racing the native handle or erasing a later teardown failure.
+ */
+export class DeferredTeardownError extends DriverError implements AsyncDisposable {
+	readonly completion: Promise<void>;
+	deferredFailure: unknown | undefined;
+	readonly #retry: () => Promise<void>;
+	#disposeInFlight: Promise<void> | undefined;
+	#cleaned = false;
+
+	constructor(
+		ref: SandboxRef,
+		timeoutMs: number,
+		completion: Promise<void>,
+		retry: () => Promise<void>,
+	) {
+		super(
+			"destroy-failed",
+			`sandbox ${ref.id} still has an accepted operation after ${timeoutMs}ms; safe teardown remains scheduled`,
+			{ ref },
+		);
+		this.name = "DeferredTeardownError";
+		this.completion = completion;
+		this.#retry = retry;
+		void completion.catch((error: unknown) => {
+			this.deferredFailure = error;
+		});
+	}
+
+	[Symbol.asyncDispose](): Promise<void> {
+		if (this.#cleaned) return Promise.resolve();
+		if (this.#disposeInFlight !== undefined) return this.#disposeInFlight;
+
+		const attempt = this.completion
+			.catch(() => this.#retry())
+			.then(() => {
+				this.#cleaned = true;
+			})
+			.finally(() => {
+				this.#disposeInFlight = undefined;
+			});
+		this.#disposeInFlight = attempt;
+		return attempt;
+	}
+}
+
+/**
+ * Assemble a SandboxDriver from a method table and a lazy context factory.
+ *
+ * The context is vendor plumbing that is async and built once on demand (clients, apps, built
+ * images, volumes). A failed load CLEARS the memo, so one transient plumbing failure does not
+ * brick the driver for the process lifetime; concurrent callers share the in-flight attempt
+ * (ADR-0007 §9).
+ */
+export function driverFromTable<Handle, Ctx>(
+	table: MethodTable<Handle, Ctx>,
+	loadCtx: () => Promise<Ctx>,
+): SandboxDriver<Handle> {
+	const operationDrainTimeoutMs = table.operationDrainTimeoutMs ?? 1_000;
+	if (!Number.isSafeInteger(operationDrainTimeoutMs) || operationDrainTimeoutMs <= 0) {
+		throw new DriverError(
+			"vendor-contract-violation",
+			`operationDrainTimeoutMs must be a positive safe integer, received ${String(operationDrainTimeoutMs)}`,
+		);
+	}
+	let memo: Promise<Ctx> | undefined;
+	const ctx = () =>
+		(memo ??= loadCtx().then(
+			(value) => value,
+			(error: unknown) => {
+				memo = undefined;
+				throw error;
+			},
+		));
+	const files = table.files;
+	const launch = table.launch;
+	const destroyById = table.destroyById;
+	const tableProbes = table.probes;
+	const probeList = tableProbes?.list;
+	const probeDescribe = tableProbes?.describe;
+	const tableSnapshots = table.snapshots;
+	return {
+		async create(request) {
+			const resolved = await ctx();
+			const created = await table.create(resolved, request);
+			const artifact = created.artifact ?? request.artifact;
+			if (!artifactsEqual(artifact, request.artifact)) {
+				const mismatch = new DriverError(
+					"artifact-mismatch",
+					`artifact mismatch: request says ${artifactLabel(request.artifact)}, driver booted ${artifactLabel(artifact)}`,
+					{ ref: created.sandboxRef },
+				);
+				// Tear the orphan down before failing — but never let a teardown failure hide the
+				// mismatch (the primary, and the one naming the wrong-artifact boot). Same double-fault
+				// shape as withSessionTeardown.
+				try {
+					await table.destroy(resolved, created.handle);
+				} catch (teardown) {
+					throw new SuppressedError(
+						teardown,
+						mismatch,
+						"orphan teardown failed after an artifact mismatch",
+					);
+				}
+				throw mismatch;
+			}
+			const handle = created.handle;
+			const ref = created.sandboxRef;
+			let state: "alive" | "destroying" | "destroyed" = "alive";
+			let destroyInFlight: Promise<void> | undefined;
+			let teardownInFlight: Promise<void> | undefined;
+			let teardownDrain: Promise<void> | undefined;
+			let activeOperations = 0;
+			let operationsDrained: Promise<void> | undefined;
+			let resolveOperationsDrained: (() => void) | undefined;
+			const alive = <T>(operation: () => Promise<T>): Promise<T> => {
+				if (state !== "alive") {
+					// Calling a dead sandbox would surface as a confusing vendor error the harness
+					// would misclassify; make the invalid state a typed, unmistakable one instead.
+					return Promise.reject(
+						new DriverError(
+							"use-after-destroy",
+							`sandbox ${ref.id} was used during/after destroy`,
+							{
+								ref,
+							},
+						),
+					);
+				}
+				if (activeOperations === 0) {
+					operationsDrained = new Promise<void>((resolve) => {
+						resolveOperationsDrained = resolve;
+					});
+				}
+				activeOperations += 1;
+				let result: Promise<T>;
+				try {
+					result = operation();
+				} catch (caught) {
+					result = Promise.reject(caught);
+				}
+				return Promise.resolve(result).finally(() => {
+					activeOperations -= 1;
+					if (activeOperations === 0) {
+						resolveOperationsDrained?.();
+						resolveOperationsDrained = undefined;
+						operationsDrained = undefined;
+					}
+				});
+			};
+			const invokeDestroy = (): Promise<void> => {
+				try {
+					return Promise.resolve(table.destroy(resolved, handle));
+				} catch (caught) {
+					return Promise.reject(caught);
+				}
+			};
+			const beginTeardown = (): Promise<void> => {
+				if (teardownInFlight !== undefined) return teardownInFlight;
+
+				state = "destroying";
+				teardownDrain = operationsDrained;
+				const destroying =
+					teardownDrain === undefined ? invokeDestroy() : teardownDrain.then(invokeDestroy);
+				const teardown = destroying
+					.then(
+						() => {
+							state = "destroyed";
+						},
+						(error: unknown) => {
+							state = "alive";
+							throw error;
+						},
+					)
+					.finally(() => {
+						teardownInFlight = undefined;
+						teardownDrain = undefined;
+					});
+				teardownInFlight = teardown;
+				return teardown;
+			};
+			const session: SandboxSession<Handle> = {
+				sandboxRef: ref,
+				artifact,
+				native: handle,
+				exec: (command, options?: ExecOptions) =>
+					alive(() =>
+						table
+							.exec(resolved, handle, command, options)
+							.then((result) => capExecOutput(result, options?.maxOutputBytes)),
+					),
+				async destroy() {
+					if (state === "destroyed") return;
+					if (destroyInFlight !== undefined) return destroyInFlight;
+
+					const teardown = beginTeardown();
+					const drain = teardownDrain;
+					const bounded =
+						drain === undefined
+							? teardown
+							: drainWithin(
+									drain,
+									operationDrainTimeoutMs,
+									() =>
+										new DeferredTeardownError(ref, operationDrainTimeoutMs, teardown, () =>
+											session.destroy(),
+										),
+								).then(() => teardown);
+					const attempt = bounded.finally(() => {
+						destroyInFlight = undefined;
+					});
+					destroyInFlight = attempt;
+					return attempt;
+				},
+				...(launch
+					? {
+							launch: (command: string, options?: ExecOptions) =>
+								alive(() => launch(resolved, handle, command, options)),
+						}
+					: {}),
+				...(files
+					? {
+							files: {
+								readFile: (path: string) => alive(() => files.readFile(resolved, handle, path)),
+								exists: (path: string) => alive(() => files.exists(resolved, handle, path)),
+								writeText: (path: string, text: string) =>
+									alive(() => files.writeText(resolved, handle, path, text)),
+							},
+						}
+					: {}),
+			};
+			return session;
+		},
+		...(destroyById
+			? { destroyById: async (ref: SandboxRef) => destroyById(await ctx(), ref) }
+			: {}),
+		...(tableProbes
+			? {
+					probes: {
+						observe: async (ref: SandboxRef) => tableProbes.observe(await ctx(), ref),
+						...(probeList ? { list: async () => probeList(await ctx()) } : {}),
+						...(probeDescribe
+							? { describe: async (ref: SandboxRef) => probeDescribe(await ctx(), ref) }
+							: {}),
+					} satisfies ControlPlaneProbes,
+				}
+			: {}),
+		...(tableSnapshots
+			? {
+					snapshots: {
+						create: async (session: SandboxSession<Handle>) =>
+							tableSnapshots.create(await ctx(), session),
+						delete: async (snapshotId: string) => tableSnapshots.delete(await ctx(), snapshotId),
+					} satisfies SnapshotCapability<Handle>,
+				}
+			: {}),
+	};
+}


### PR DESCRIPTION
**Sandbox driver kit (ADR-0007) — the port every provider implements, and the kit that assembles it.**
Shipped as a 6-PR stack (merge bottom-up; each branch is independently green — typecheck + tests pass with nothing stacked above it):

1. #385 — **port**: the arktype single source of truth for the port's data shapes + the typed error family
2. #386 — **mechanics**: kit-owned session teardown, shell fallbacks, readiness polling
3. #388 — **assembly**: the method table → session layer, where the lifecycle invariants live
4. #387 — **join**: the typed registry binding (`defineDriver`/`EnvOf`) and its runtime env dual
5. #389 — **driver A**: `cliDriver`, for vendors whose control plane is a binary
6. #390 — **driver B**: the ComputeSDK bridge, now one driver among several

↑ **This PR is #388 (3/6)**, based on #386.

---

The layer driver authors actually write against (ADR-0007 §2): a flat table of
pure functions over a typed native handle — trivially unit-testable,
extraction-safe via `satisfies MethodTable<…>`, and patchable by ordinary
composition. driverFromTable assembles the harness-facing SandboxSession from
it.

Because every generic driver flows through here, this is the ONE place the
session-lifecycle invariants live, and a driver would have to re-implement all
four to bypass it:

  - Output capping, applied centrally around the table's exec — so a table's
    exec never sees maxOutputBytes and cannot accept-and-ignore it (the
    contract violation the ADRs forbid). lib/output.ts caps by UTF-8 BYTES,
    not UTF-16 code units, and never splits a code point, so the cap is honest
    on non-ASCII output. Caps stay per-call opt-in and never a kit default:
    results collection rides a multi-MB base64 tar over stdout, and a blanket
    cap would turn it into a bounded retry loop that can never succeed.
  - A use-after-destroy guard, so calling a dead sandbox is a typed
    DriverError rather than a confusing vendor error the harness would
    misclassify.
  - Artifact reconciliation: the kit fails create when the driver reports it
    booted a different artifactRef than the request named, so a measurement is
    never attributed to the wrong artifact. The orphan is torn down first, and
    a teardown failure cannot hide the mismatch (SuppressedError, the same
    double-fault shape as withSessionTeardown).
  - Idempotent destroy (ADR-0008): a second destroy is a no-op, not an error.

The context factory is lazy and memoized — vendor plumbing (clients, apps,
built images, volumes) is async and built once on demand. A failed load CLEARS
the memo, so one transient plumbing failure does not brick the driver for the
process lifetime, while concurrent callers still share the in-flight attempt
(ADR-0007 §9).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Introduces the `MethodTable` assembly layer and centralizes session invariants. Previously drivers could see/ignore `maxOutputBytes` and use-after-destroy surfaced as vendor errors; now `driverFromTable` assembles a `SandboxSession`, applies byte-accurate caps, reconciles artifacts on create, and makes destroy idempotent and bounded.

- Builds sessions from a `MethodTable`; forwards optional capabilities (`files`, `launch`, `destroyById`, `probes`, `snapshots`) only when provided; normalizes sync throws into rejected Promises.
- Adds `lib/output.ts` with `capExecOutput`: caps `stdout`/`stderr` by UTF-8 bytes without splitting code points, sets `truncated` when cut, rejects invalid caps with `DriverError("invalid-exec-options")`; still forwards exec options to the table.
- Enforces create-time artifact reconciliation: fail on mismatch, tear down the orphan first, preserve the mismatch via `SuppressedError` on double fault.
- Lifecycle: post-destroy calls return `DriverError("use-after-destroy")`; `destroy()` waits for accepted ops to drain within `operationDrainTimeoutMs` (default 1s; validated positive safe integer). On timeout, return `DeferredTeardownError` exposing eventual provider completion and async-disposable retry; subsequent destroys are no-ops; concurrent destroys share one attempt; failed attempts can be retried.
- Context factory is lazy and memoized; failures clear the memo and in-flight attempts are shared.
- Exports `MethodTable`, `driverFromTable`, and `DeferredTeardownError` from `index.ts`. No migration required.

<sup>Written for commit 77c7fbc671c6185ce615037730d3f7dcd896b2fb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/starslingdev/hpc-sandbox-benchmarks/pull/388?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

