### PR TITLE
feat(driver): cliDriver, the generic driver for CLI-only vendors

### DIFF
--- a/docs/adr/0007-sandbox-driver-port.md
+++ b/docs/adr/0007-sandbox-driver-port.md
@@ -243,9 +243,9 @@ export type ResolvedArtifact =
   | { readonly kind: "image" | "baked" | "mirror" | "built"; readonly ref: string };
 
 export interface SandboxDriver<Handle = unknown> {
-  create(request: CreateRequest): Promise<SandboxSession<Handle>>;
+  create(request: CreateRequest, options?: DriverOperationOptions): Promise<SandboxSession<Handle>>;
   /** Optional: destroy by bare id, no session needed — reaper/cleanup lanes. Idempotent. */
-  destroyById?(id: SandboxId): Promise<void>;
+  destroyById?(id: SandboxId, options?: DriverOperationOptions): Promise<void>;
   readonly probes?: ControlPlaneProbes;    // control-plane observation + optional latency probes
   readonly snapshots?: SnapshotCapability<Handle>; // optional: lifecycle measurement only
 }
@@ -255,7 +255,7 @@ export interface SandboxSession<Handle = unknown> {
   /** Effective boot artifact; request fallback is tracked as such in evidence. */
   readonly artifact: ResolvedArtifact;
   exec(command: string, options?: ExecOptions): Promise<ExecResult>;
-  destroy(): Promise<void>;
+  destroy(options?: DriverOperationOptions): Promise<void>;
   /** The vendor's native handle — the JDBC `unwrap()` idea, typed. */
   readonly native: Handle;
   /** Optional. A WORKING filesystem API — reads and writes — or absent; never a throwing stub. */
@@ -461,35 +461,67 @@ The whole provider file, in the shape an author actually writes:
 
 ```ts
 // packages/drivers/src/tama.ts — the provider's behavior. The filename is the id.
-import { defineDriver } from "@sandbox-benchmarks/driver";
-import { cliDriver } from "@sandbox-benchmarks/driver/cli";
+import { defineCliDriver, defineCliSpec } from "@sandbox-benchmarks/driver/cli";
 import { type } from "arktype";
 
 const Machines = type("string.json.parse").to(
-  type({ id: "string", name: "string", status: "string" }).array(),
+  type({ id: "string", name: "string", status: "string", "status_detail?": "string" }).array(),
 );
+// Exact shape observed in committed real Tama runs (for example machine-obusdw8bsyw2).
+const TamaSandboxId = type(/^machine-[a-z0-9]{12}$/);
+const TAMA_CREATE_CEILING_MS = 25 * 60_000;
 
-export default defineDriver("tama", {
+export default defineCliDriver("tama", {
   // `tama new` blocks until ready (~2m10s cold pull) and owns failed-create cleanup, so the
-  // driver owns the create budget — abandoning it mid-teardown would strand a billable machine.
-  createBudget: { owner: "driver", attemptCeilingMs: TAMA_CREATE_CEILING_MS },
-  execution: { syncCapMs: 60_000, durable: "shell-detach" },
-  driver: ({ env, resolvedArtifact }) =>
-    cliDriver({
-      binary: env.TAMA_CLI ?? "tama",
-      secretFlags: ["--token"],
-      create: (r, name) => ["new", name, "--ttl", "0", "--json", "--image",
-        resolvedArtifact.ref, "--cpu", String(r.spec.vcpus),
-        // Tama's CLI boundary is MiB; the canonical request stays in GiB everywhere else.
-        "--memory", String(r.spec.memoryGb * 1024)],
-      ready: { poll: ["list", "--json"], parse: Machines,
-        select: (rows, name) => rows.find((m) => m.name === name && m.status === "ready")?.id ?? null },
-      exec: (id, command) => ["exec", id, "--", "bash", "-lc", command],
-      destroy: (id) => ["rm", "-y", id],
-      notFound: /not found|no such machine|unknown machine/i, // private bridge translation only
-    }),
+  // joined helper derives a driver-owned budget — abandoning teardown could strand a machine.
+  createAttemptCeilingMs: TAMA_CREATE_CEILING_MS,
+  spec: ({ env }) => defineCliSpec(Machines, {
+    binary: env.TAMA_CLI ?? "tama",
+    secretFlags: ["--token"],
+    commandTimeoutMs: 60_000,
+    // `new` owns the cold image pull; short list/login/rm/exec calls keep the tighter bound above.
+    createCommandTimeoutMs: 20 * 60_000,
+    // Preserve a working developer profile; a fresh CI runner falls back to token login.
+    prepare: {
+      probe: ["list", "--json"],
+      fallback: ["login", "--token", env.TAMA_TOKEN],
+    },
+    create: (r, name) => ["new", name, "--ttl", "0", "--json", "--image",
+      r.artifact.kind === "none" ? "stock" : r.artifact.ref,
+      "--cpu", String(r.spec.vcpus),
+      // Tama's CLI boundary is MiB; the canonical request stays in GiB everywhere else.
+      "--memory", String(r.spec.memoryGb * 1024)],
+    // `rm` accepts only an id: reconcile the generated name through typed list output first.
+    cleanupCreated: {
+      kind: "lookup",
+      select: (rows, name) => rows.find((m) => m.name === name) ?? null,
+      // A just-accepted allocation can lag the name index. Absence is stable only after this.
+      absenceConfirmationMs: 2_000,
+    },
+    ready: {
+      poll: ["list", "--json"],
+      select: (rows, name) => rows.find((m) => m.name === name) ?? null,
+      classify: (m) => m.status === "ready" ? "ready"
+        : /^(failed|error|terminated|deleted|gone)$/i.test(m.status)
+          ? { terminal: `status=${m.status}${m.status_detail ? ` (${m.status_detail})` : ""}` }
+          : "pending",
+    },
+    sandboxId: { fromRow: (row) => row.id, parse: TamaSandboxId },
+    exec: (id, command) => ["exec", id, "--", "bash", "-lc", command],
+    destroy: (id) => ["rm", "-y", id],
+    notFound: /not found|no such machine|unknown machine/i, // private bridge translation only
+  }),
 });
 ```
+
+That sequence is pinned against Tama's real CLI contract: only `login` receives `--token`, `new`
+does not, and a fallback login is followed by another parsed `list` before allocation. `rm` receives
+the module-validated machine id because it has no name-addressed form. A failed `new` therefore
+performs a typed `list` lookup by the preallocated unique name before issuing `rm -y <id>`. The
+generic driver retains that name as a retryable recovery locator whenever the lookup, validation,
+or removal cannot prove the allocation gone. A selected `failed`/`error`/`terminated` row is a
+typed terminal readiness result, so the kit begins that same cleanup immediately instead of
+spending the remaining create window polling a machine the vendor has already declared unusable.
 
 What the typed join must buy, with each property pinned by implementation tests:
 
@@ -614,8 +646,26 @@ a convenience over `SandboxDriver`, not a second contract.
 `cliDriver` compiles its declarative spec down to a §2 method table whose handle is the **parsed
 readiness row** (`ready.select` returns the row, not a bare id string) — so every generated member
 is unit-testable as a pure function, and `session.native` is the vendor's own typed record rather
-than an opaque string. The side-by-side anatomy confirmed the spec stays ~29 author lines while the
-three per-vendor quirks each remain one field: `secretFlags`, `ready`, `notFound`.
+than an opaque string. The side-by-side anatomy confirmed the spec stays roughly 30 author lines,
+with provider-specific parsing, eventual-consistency, secret, readiness, and absence rules kept as
+small declarative fields rather than repeated control flow.
+
+Every failed create outcome is reconciled by the generated name, including a nonzero CLI exit that
+may have followed a server-side allocation. If that rollback also fails, the driver rejects with a
+`FailedCreateCleanupError`: a `SuppressedError` preserving both failures plus a structured
+provider/name locator and an idempotent `Symbol.asyncDispose` retry. A generated name is released
+only after two absence observations separated by the provider-declared convergence horizon. The
+process owner recognizes that standard protocol, retains the rejected create in its bounded cleanup
+registry, and releases it only after a retry confirms teardown. A failed rollback therefore cannot
+discard the only handle to a billable allocation.
+
+Create and destroy also accept a cooperative `AbortSignal`. On process shutdown the owner aborts a
+pending create immediately, and the CLI runner kills the detached process group, cancels inherited
+pipes, and waits for the child to be reaped before rejecting. Once that rejection installs the
+generated-name recovery record, the owner spends the remainder of its existing bounded shutdown
+window on reconciliation; cancellation of that cleanup follows the same kill-and-reap rule. The
+signal is an interruption channel, not evidence that the remote allocation is absent, so aborting a
+create never releases ownership by itself.
 
 ### 6. ComputeSDK becomes a driver
 

--- a/packages/driver/package.json
+++ b/packages/driver/package.json
@@ -7,6 +7,7 @@
   "sideEffects": false,
   "exports": {
     ".": "./src/index.ts",
+    "./cli": "./src/cli.ts",
     "./env": "./src/env.ts",
     "./schemas": "./src/schemas.ts",
     "./package.json": "./package.json"

--- a/packages/driver/src/cli.test.ts
+++ b/packages/driver/src/cli.test.ts
@@ -1,0 +1,1437 @@
+import { describe, expect, test } from "bun:test";
+import { existsSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { type } from "arktype";
+import type {
+	CliDriverOptions,
+	CliRowsSchema,
+	CliRunOptions,
+	CliRunResult,
+	CliSpec,
+} from "./cli.ts";
+import {
+	cliMethodTable as compileCliMethodTable,
+	defineCliDriver,
+	defineCliSpec,
+	redactArgs,
+	redactDiagnostic,
+} from "./cli.ts";
+import type { CreateRequest } from "./index.ts";
+import { DriverError, driverFromTable, FailedCreateCleanupError, sandboxRef } from "./index.ts";
+
+const machineRows = type("string.json.parse").to(
+	type({ id: "string", name: "string", status: "string", "status_detail?": "string" }).array(),
+);
+const machineId = type(/^m-[1-9][0-9]*$/);
+const tamaMachineId = type(/^machine-[a-z0-9]{12}$/);
+type MachineRow = { id: string; name: string; status: string; status_detail?: string };
+
+type Equal<X, Y> =
+	(<T>() => T extends X ? 1 : 2) extends <T>() => T extends Y ? 1 : 2 ? true : false;
+type Expect<T extends true> = T;
+
+const request: CreateRequest = {
+	spec: { vcpus: 4, memoryGb: 8 },
+	artifact: { kind: "image", ref: "registry.example/toolchain:1" },
+	deadlineMs: 2_000,
+};
+
+function tamaLikeSpec(overrides: Partial<CliSpec<MachineRow>> = {}): CliSpec<MachineRow> {
+	return {
+		binary: "fake-cli",
+		secretFlags: ["--token"],
+		commandTimeoutMs: 1_000,
+		create: (r, name) => [
+			"new",
+			name,
+			"--token",
+			"s3cret",
+			"--image",
+			r.artifact.kind === "none" ? "stock" : r.artifact.ref,
+		],
+		cleanupCreated: {
+			kind: "command",
+			command: (name) => ["rm-name", "-y", name],
+			absenceConfirmationMs: 5,
+		},
+		ready: {
+			poll: ["list", "--json"],
+			parse: machineRows,
+			select: (rows, name) => rows.find((row) => row.name === name) ?? null,
+			classify: (row) => (row.status === "ready" ? "ready" : "pending"),
+			pollIntervalMs: 1,
+		},
+		sandboxId: {
+			fromRow: (row) => row.id,
+			parse: machineId,
+		},
+		exec: (id, command) => ["exec", id, "--", "bash", "-lc", command],
+		destroy: (id) => ["rm", "-y", id],
+		notFound: /not found|no such machine/i,
+		...overrides,
+	};
+}
+
+function cliMethodTable(spec: CliSpec<MachineRow>, options: CliDriverOptions = {}) {
+	return compileCliMethodTable("tama", spec, options);
+}
+
+function cliDriver(spec: CliSpec<MachineRow>, options: CliDriverOptions = {}) {
+	return driverFromTable(cliMethodTable(spec, options), async () => ({}));
+}
+
+/** A scripted fake vendor CLI: create registers the machine; readiness flips after N polls. */
+function fakeVendor(options: { readyAfterPolls?: number } = {}) {
+	const calls: string[][] = [];
+	const machines = new Map<string, MachineRow>();
+	let polls = 0;
+	const run = async (
+		_binary: string,
+		args: readonly string[],
+		_options: CliRunOptions,
+	): Promise<CliRunResult> => {
+		calls.push([...args]);
+		const [verb] = args;
+		if (verb === "new") {
+			const name = args[1] ?? "";
+			machines.set(name, { id: `m-${machines.size + 1}`, name, status: "booting" });
+			return { stdout: "", stderr: "", code: 0 };
+		}
+		if (verb === "list") {
+			polls += 1;
+			if (polls > (options.readyAfterPolls ?? 1)) {
+				for (const row of machines.values()) row.status = "ready";
+			}
+			return { stdout: JSON.stringify([...machines.values()]), stderr: "", code: 0 };
+		}
+		if (verb === "exec") {
+			return { stdout: "ran\n", stderr: "", code: 0 };
+		}
+		if (verb === "rm") {
+			const id = args[2] ?? "";
+			const existed = [...machines.values()].some((row) => row.id === id);
+			for (const [name, row] of machines) if (row.id === id) machines.delete(name);
+			return existed
+				? { stdout: "", stderr: "", code: 0 }
+				: { stdout: "", stderr: `machine ${id} not found`, code: 1 };
+		}
+		if (verb === "rm-name") {
+			const name = args[2] ?? "";
+			const existed = machines.delete(name);
+			return existed
+				? { stdout: "", stderr: "", code: 0 }
+				: { stdout: "", stderr: `machine ${name} not found`, code: 1 };
+		}
+		return { stdout: "", stderr: `unknown verb ${verb}`, code: 2 };
+	};
+	return { run, calls, machines };
+}
+
+describe("cliDriver", () => {
+	test("the joined module derives driver-owned budgeting from the single provider id", () => {
+		const module_ = defineCliDriver("tama", {
+			createAttemptCeilingMs: 60_000,
+			spec: ({ env }) => {
+				expect(env.TAMA_TOKEN).toBe("tok");
+				return tamaLikeSpec();
+			},
+		});
+		expect(module_.id).toBe("tama");
+		expect(module_.createBudget).toEqual({ owner: "driver", attemptCeilingMs: 60_000 });
+		expect(typeof module_.driver({ env: { TAMA_TOKEN: "tok" } }).create).toBe("function");
+
+		const missingBudget = () =>
+			defineCliDriver(
+				"tama",
+				// @ts-expect-error — every CLI driver must declare its hard create-attempt ceiling
+				{ spec: () => tamaLikeSpec() },
+			);
+		void missingBudget;
+	});
+
+	test("contextually types a complete inline provider spec without row annotations", () => {
+		const publicRowsSchema: CliRowsSchema<MachineRow> = machineRows;
+		type _rowsInput = Expect<Equal<typeof publicRowsSchema.inferIn, string>>;
+		type _rowsOutput = Expect<Equal<typeof publicRowsSchema.infer, readonly MachineRow[]>>;
+
+		const module_ = defineCliDriver("tama", {
+			createAttemptCeilingMs: 60_000,
+			spec: ({ env }) =>
+				defineCliSpec(machineRows, {
+					binary: env.TAMA_CLI ?? "tama",
+					secretFlags: ["--token"],
+					commandTimeoutMs: 10_000,
+					create: (_request, name) => ["new", name, "--token", env.TAMA_TOKEN],
+					cleanupCreated: {
+						kind: "command",
+						command: (name) => ["rm", "--name", name],
+						absenceConfirmationMs: 100,
+					},
+					ready: {
+						poll: ["list", "--json"],
+						select: (rows, name) => rows.find((row) => row.name === name) ?? null,
+						classify: () => "ready",
+					},
+					sandboxId: { fromRow: (row) => row.id, parse: machineId },
+					exec: (id, command) => ["exec", id, command],
+					destroy: (id) => ["rm", id],
+					notFound: /not found/i,
+				}),
+		});
+		expect(module_.id).toBe("tama");
+
+		const plainRowsParser = (raw: string): readonly MachineRow[] => JSON.parse(raw);
+		// @ts-expect-error — trust boundaries must be actual arktype schemas, not unchecked functions
+		const uncheckedRows: CliRowsSchema<MachineRow> = plainRowsParser;
+		const plainIdParser = (raw: unknown): string => String(raw);
+		const uncheckedIdSpec = () =>
+			tamaLikeSpec({
+				sandboxId: {
+					fromRow: (row) => row.id,
+					// @ts-expect-error — module-owned id validation must be an actual arktype schema
+					parse: plainIdParser,
+				},
+			});
+		void uncheckedRows;
+		void uncheckedIdSpec;
+	});
+
+	test("expresses Tama's real profile auth and name-to-id failed-create reconciliation", async () => {
+		const calls: string[][] = [];
+		const timeouts: Array<{ verb: string; timeoutMs: number }> = [];
+		let authenticated = false;
+		let created: MachineRow | undefined;
+		const spec = defineCliSpec(machineRows, {
+			binary: "tama",
+			secretFlags: ["--token"],
+			commandTimeoutMs: 60_000,
+			createCommandTimeoutMs: 20 * 60_000,
+			prepare: {
+				probe: ["list", "--json"],
+				fallback: ["login", "--token", "s3cret"],
+			},
+			create: (_request, name) => ["new", name, "--ttl", "0", "--json"],
+			cleanupCreated: {
+				kind: "lookup",
+				select: (rows, name) => rows.find((row) => row.name === name) ?? null,
+				absenceConfirmationMs: 5,
+			},
+			ready: {
+				poll: ["list", "--json"],
+				select: (rows, name) => rows.find((row) => row.name === name) ?? null,
+				classify: (row) =>
+					row.status === "ready"
+						? "ready"
+						: /^(failed|error|terminated|deleted|gone)$/i.test(row.status)
+							? {
+									terminal: `status=${row.status}${row.status_detail ? ` (${row.status_detail})` : ""}`,
+								}
+							: "pending",
+			},
+			sandboxId: { fromRow: (row) => row.id, parse: tamaMachineId },
+			exec: (id, command) => ["exec", id, "--", "bash", "-lc", command],
+			destroy: (id) => ["rm", "-y", id],
+			notFound: /not found|no such machine/i,
+		});
+		const driver = cliDriver(spec, {
+			createAttemptCeilingMs: 25 * 60_000,
+			run: async (_binary, args, options) => {
+				calls.push([...args]);
+				timeouts.push({ verb: args[0] ?? "", timeoutMs: options.timeoutMs });
+				if (args[0] === "list" && !authenticated) {
+					return { stdout: "", stderr: "not logged in", code: 1 };
+				}
+				if (args[0] === "login") {
+					authenticated = true;
+					return { stdout: "logged in", stderr: "", code: 0 };
+				}
+				if (args[0] === "new") {
+					created = { id: "machine-obusdw8bsyw2", name: args[1] ?? "", status: "ready" };
+					return { stdout: "", stderr: "client lost the success response", code: 7 };
+				}
+				if (args[0] === "list") {
+					return {
+						stdout: JSON.stringify(created === undefined ? [] : [created]),
+						stderr: "",
+						code: 0,
+					};
+				}
+				if (args[0] === "rm") {
+					created = undefined;
+					return { stdout: "", stderr: "", code: 0 };
+				}
+				return { stdout: "", stderr: "unexpected command", code: 2 };
+			},
+		});
+
+		const error = (await driver
+			.create({ ...request, deadlineMs: 25 * 60_000 })
+			.catch((caught: unknown) => caught)) as DriverError;
+		expect(error).toMatchObject({ code: "create-failed", vendorExitCode: 7, provider: "tama" });
+		expect(calls.map(([verb]) => verb)).toEqual(["list", "login", "list", "new", "list", "rm"]);
+		expect(calls[1]).toEqual(["login", "--token", "s3cret"]);
+		expect(calls[3]).not.toContain("--token");
+		expect(calls[3]).not.toContain("s3cret");
+		expect(calls[5]).toEqual(["rm", "-y", "machine-obusdw8bsyw2"]);
+		expect(calls[5]).not.toContain("--name");
+		expect(timeouts.find(({ verb }) => verb === "new")?.timeoutMs).toBeGreaterThan(130_000);
+		expect(
+			timeouts.filter(({ verb }) => verb !== "new").every(({ timeoutMs }) => timeoutMs <= 60_000),
+		).toBe(true);
+		expect(String(error)).not.toContain("s3cret");
+		expect(created).toBeUndefined();
+	});
+
+	test("classifies a real Tama failed row as terminal and cleans it up immediately", async () => {
+		let createdName = "";
+		const calls: string[] = [];
+		const driver = cliDriver(
+			tamaLikeSpec({
+				create: (_request, name) => {
+					createdName = name;
+					return ["new", name];
+				},
+				cleanupCreated: {
+					kind: "lookup",
+					select: (rows, name) => rows.find((row) => row.name === name) ?? null,
+					absenceConfirmationMs: 5,
+				},
+				ready: {
+					poll: ["list", "--json"],
+					parse: machineRows,
+					select: (rows, name) => rows.find((row) => row.name === name) ?? null,
+					classify: (row) =>
+						row.status === "ready"
+							? "ready"
+							: /^(failed|error|terminated|deleted|gone)$/i.test(row.status)
+								? {
+										terminal: `status=${row.status}${row.status_detail ? ` (${row.status_detail})` : ""}`,
+									}
+								: "pending",
+					pollIntervalMs: 1,
+				},
+			}),
+			{
+				run: async (_binary, args) => {
+					calls.push(args[0] ?? "");
+					if (args[0] === "new") return { stdout: "", stderr: "", code: 0 };
+					if (args[0] === "list") {
+						return {
+							stdout: JSON.stringify([
+								{
+									id: "m-1",
+									name: createdName,
+									status: "failed",
+									status_detail: "capacity unavailable",
+								},
+							]),
+							stderr: "",
+							code: 0,
+						};
+					}
+					return { stdout: "", stderr: "", code: 0 };
+				},
+			},
+		);
+
+		const error = (await driver.create(request).catch((caught: unknown) => caught)) as DriverError;
+		expect(error).toMatchObject({
+			code: "create-failed",
+			provider: "tama",
+			vendorMessage: "status=failed (capacity unavailable)",
+		});
+		expect(calls).toEqual(["new", "list", "list", "rm"]);
+	});
+
+	test("redacts overlapping prepare and cleanup secrets from terminal readiness detail", async () => {
+		let createdName = "";
+		let authenticated = false;
+		let verified = false;
+		const driver = cliDriver(
+			tamaLikeSpec({
+				prepare: {
+					probe: ["list", "--json"],
+					fallback: ["login", "--token", "s3cret-long"],
+				},
+				create: (_request, name) => {
+					createdName = name;
+					return ["new", name];
+				},
+				cleanupCreated: {
+					kind: "command",
+					command: (name) => ["rm-name", "--token", "s3cret", name],
+					absenceConfirmationMs: 5,
+				},
+				ready: {
+					poll: ["list", "--json"],
+					parse: machineRows,
+					select: (rows, name) => rows.find((row) => row.name === name) ?? null,
+					classify: () => ({ terminal: "vendor rejected s3cret-long and s3cret" }),
+					pollIntervalMs: 1,
+				},
+			}),
+			{
+				run: async (_binary, args) => {
+					if (args[0] === "login") {
+						authenticated = true;
+						return { stdout: "", stderr: "", code: 0 };
+					}
+					if (args[0] === "list" && !authenticated) {
+						return { stdout: "", stderr: "not logged in", code: 1 };
+					}
+					if (args[0] === "list" && !verified) {
+						verified = true;
+						return { stdout: "[]", stderr: "", code: 0 };
+					}
+					if (args[0] === "list") {
+						return {
+							stdout: JSON.stringify([{ id: "m-1", name: createdName, status: "failed" }]),
+							stderr: "",
+							code: 0,
+						};
+					}
+					return { stdout: "", stderr: "", code: 0 };
+				},
+			},
+		);
+
+		const error = (await driver.create(request).catch((caught: unknown) => caught)) as DriverError;
+		expect(error).toMatchObject({
+			code: "create-failed",
+			vendorMessage: "vendor rejected *** and ***",
+		});
+		expect(error.message).not.toContain("s3cret-long");
+		expect(error.message).not.toContain("s3cret");
+	});
+
+	test("redacts a create-only secret echoed by a failing readiness poll", async () => {
+		const driver = cliDriver(
+			tamaLikeSpec({
+				create: (_request, name) => ["new", name, "--token", "create-only"],
+			}),
+			{
+				run: async (_binary, args) => {
+					if (args[0] === "new" || args[0] === "rm-name") {
+						return { stdout: "", stderr: "", code: 0 };
+					}
+					return { stdout: "", stderr: "poll echoed create-only", code: 7 };
+				},
+			},
+		);
+
+		const error = (await driver.create(request).catch((caught: unknown) => caught)) as DriverError;
+		expect(error).toMatchObject({
+			code: "create-failed",
+			vendorMessage: "poll echoed ***",
+		});
+		expect(error.message).not.toContain("create-only");
+	});
+
+	test("does not overwrite a working profile when an exit-zero probe exposes schema drift", async () => {
+		const calls: string[] = [];
+		const driver = cliDriver(
+			tamaLikeSpec({
+				prepare: {
+					probe: ["list", "--json"],
+					fallback: ["login", "--token", "s3cret"],
+				},
+			}),
+			{
+				run: async (_binary, args) => {
+					calls.push(args[0] ?? "");
+					return { stdout: "not json", stderr: "", code: 0 };
+				},
+			},
+		);
+
+		const error = (await driver.create(request).catch((caught: unknown) => caught)) as DriverError;
+		expect(error).toMatchObject({ code: "vendor-output-unparseable", provider: "tama" });
+		const retry = (await driver.create(request).catch((caught: unknown) => caught)) as DriverError;
+		expect(retry).toMatchObject({ code: "vendor-output-unparseable", provider: "tama" });
+		expect(calls).toEqual(["list", "list"]);
+	});
+
+	test("memoizes successful profile preparation once per driver instance", async () => {
+		const vendor = fakeVendor({ readyAfterPolls: 0 });
+		const driver = cliDriver(
+			tamaLikeSpec({
+				prepare: {
+					probe: ["list", "--json"],
+					fallback: ["login", "--token", "s3cret"],
+				},
+			}),
+			{ run: vendor.run },
+		);
+
+		const first = await driver.create(request);
+		await first.destroy();
+		const second = await driver.create(request);
+		await second.destroy();
+
+		expect(vendor.calls.map(([verb]) => verb)).toEqual([
+			"list",
+			"new",
+			"list",
+			"rm",
+			"new",
+			"list",
+			"rm",
+		]);
+	});
+
+	test("gives concurrent preparation waiters independent deadlines and cancellation", async () => {
+		let notePrepareStarted!: () => void;
+		const prepareStarted = new Promise<void>((resolve) => {
+			notePrepareStarted = resolve;
+		});
+		let releasePrepare!: () => void;
+		const prepareGate = new Promise<void>((resolve) => {
+			releasePrepare = resolve;
+		});
+		let probes = 0;
+		const driver = cliDriver(
+			tamaLikeSpec({
+				commandTimeoutMs: 1_000,
+				prepare: {
+					probe: ["list", "--json"],
+					fallback: ["login", "--token", "s3cret"],
+				},
+			}),
+			{
+				run: async (_binary, args) => {
+					if (args[0] === "list") {
+						probes++;
+						notePrepareStarted();
+						await prepareGate;
+						return { stdout: "[]", stderr: "", code: 0 };
+					}
+					if (args[0] === "new") {
+						return { stdout: "", stderr: "create rejected", code: 7 };
+					}
+					return { stdout: "", stderr: "", code: 0 };
+				},
+			},
+		);
+		const firstCancellation = new AbortController();
+		const first = driver
+			.create(request, { signal: firstCancellation.signal })
+			.catch((caught: unknown) => caught);
+		await prepareStarted;
+		const shortStarted = Date.now();
+		const short = driver.create({ ...request, deadlineMs: 10 }).catch((caught: unknown) => caught);
+		const survivor = driver.create(request).catch((caught: unknown) => caught);
+		const cancellationReason = new Error("cancel only the first create");
+		firstCancellation.abort(cancellationReason);
+
+		const firstError = (await first) as Error;
+		expect(firstError).toMatchObject({ name: "CliRunAbortedError", cause: cancellationReason });
+		const shortError = (await short) as DriverError;
+		expect(shortError).toMatchObject({ code: "readiness-timeout", provider: "tama" });
+		expect(Date.now() - shortStarted).toBeLessThan(100);
+		expect(probes).toBe(1);
+
+		releasePrepare();
+		const survivorError = (await survivor) as DriverError;
+		expect(survivorError).toMatchObject({ code: "create-failed", provider: "tama" });
+		expect(survivorError).not.toBe(cancellationReason);
+		expect(probes).toBe(1);
+	});
+
+	test("retires and reaps an ownerless preparation before a healthy retry", async () => {
+		let notePrepareStarted!: () => void;
+		const prepareStarted = new Promise<void>((resolve) => {
+			notePrepareStarted = resolve;
+		});
+		let noteAbortObserved!: () => void;
+		const abortObserved = new Promise<void>((resolve) => {
+			noteAbortObserved = resolve;
+		});
+		let finishTermination!: () => void;
+		const terminationGate = new Promise<void>((resolve) => {
+			finishTermination = resolve;
+		});
+		let probes = 0;
+		const driver = cliDriver(
+			tamaLikeSpec({
+				commandTimeoutMs: 1_000,
+				prepare: {
+					probe: ["list", "--json"],
+					fallback: ["login", "--token", "s3cret"],
+				},
+			}),
+			{
+				run: async (_binary, args, options) => {
+					if (args[0] === "list") {
+						probes++;
+						if (probes > 1) return { stdout: "[]", stderr: "", code: 0 };
+						notePrepareStarted();
+						await new Promise<void>((resolve) => {
+							const aborted = () => {
+								noteAbortObserved();
+								void terminationGate.then(resolve);
+							};
+							options.signal?.addEventListener("abort", aborted, { once: true });
+							if (options.signal?.aborted) aborted();
+						});
+						throw options.signal?.reason;
+					}
+					if (args[0] === "new") {
+						return { stdout: "", stderr: "create rejected", code: 7 };
+					}
+					return { stdout: "", stderr: "", code: 0 };
+				},
+			},
+		);
+		let firstSettled = false;
+		const first = driver
+			.create({ ...request, deadlineMs: 5 })
+			.catch((caught: unknown) => caught)
+			.finally(() => {
+				firstSettled = true;
+			});
+		await prepareStarted;
+		await abortObserved;
+		expect(firstSettled).toBe(false);
+
+		const retry = driver.create({ ...request, deadlineMs: 500 }).catch((caught: unknown) => caught);
+		await Bun.sleep(1);
+		expect(probes).toBe(1);
+		finishTermination();
+
+		const firstError = (await first) as DriverError;
+		expect(firstError).toMatchObject({ code: "readiness-timeout", provider: "tama" });
+		const retryError = (await retry) as DriverError;
+		expect(retryError).toMatchObject({ code: "create-failed", provider: "tama" });
+		expect(retryError.message).not.toContain("no remaining create owner");
+		expect(probes).toBe(2);
+	});
+
+	test("revalidates typed list output after login before allowing create", async () => {
+		const calls: string[] = [];
+		let listCalls = 0;
+		const driver = cliDriver(
+			tamaLikeSpec({
+				prepare: {
+					probe: ["list", "--json"],
+					fallback: ["login", "--token", "s3cret"],
+				},
+			}),
+			{
+				run: async (_binary, args) => {
+					calls.push(args[0] ?? "");
+					if (args[0] === "login") return { stdout: "", stderr: "", code: 0 };
+					if (args[0] === "list" && listCalls++ === 0) {
+						return { stdout: "", stderr: "not logged in", code: 1 };
+					}
+					return { stdout: "schema drift", stderr: "", code: 0 };
+				},
+			},
+		);
+
+		const error = (await driver.create(request).catch((caught: unknown) => caught)) as DriverError;
+		expect(error).toMatchObject({ code: "vendor-output-unparseable", provider: "tama" });
+		expect(calls).toEqual(["list", "login", "list"]);
+	});
+
+	test("retains the generated name when lookup recovery finds an invalid module-owned id", async () => {
+		let createdName = "";
+		const driver = cliDriver(
+			tamaLikeSpec({
+				create: (_request, name) => {
+					createdName = name;
+					return ["new", name, "--token", "lookup-only"];
+				},
+				cleanupCreated: {
+					kind: "lookup",
+					select: (rows, name) => rows.find((row) => row.name === name) ?? null,
+					absenceConfirmationMs: 5,
+				},
+			}),
+			{
+				run: async (_binary, args) =>
+					args[0] === "new"
+						? { stdout: "", stderr: "ambiguous failure", code: 7 }
+						: {
+								stdout: JSON.stringify([
+									{ id: "wrong-lookup-only-shape", name: createdName, status: "ready" },
+								]),
+								stderr: "",
+								code: 0,
+							},
+			},
+		);
+
+		const error = (await driver
+			.create(request)
+			.catch((caught: unknown) => caught)) as FailedCreateCleanupError;
+		expect(error).toBeInstanceOf(FailedCreateCleanupError);
+		expect(error.error).toMatchObject({ code: "invalid-sandbox-ref", provider: "tama" });
+		expect(String(error.error)).not.toContain("lookup-only");
+		expect(error.suppressed).toMatchObject({ code: "create-failed", vendorExitCode: 7 });
+		expect(error.locator).toEqual({ kind: "name", value: createdName });
+	});
+
+	test("requires horizon-separated confirmation after lookup finds a row but delete says absent", async () => {
+		let createdName = "";
+		let listCalls = 0;
+		let removeCalls = 0;
+		const observations: number[] = [];
+		const confirmationMs = 20;
+		const driver = cliDriver(
+			tamaLikeSpec({
+				create: (_request, name) => {
+					createdName = name;
+					return ["new", name];
+				},
+				cleanupCreated: {
+					kind: "lookup",
+					select: (rows, name) => rows.find((row) => row.name === name) ?? null,
+					absenceConfirmationMs: confirmationMs,
+				},
+			}),
+			{
+				run: async (_binary, args) => {
+					if (args[0] === "new") return { stdout: "", stderr: "ambiguous", code: 7 };
+					if (args[0] === "list") {
+						listCalls++;
+						observations.push(Date.now());
+						return {
+							stdout: JSON.stringify(
+								listCalls === 1 ? [{ id: "m-1", name: createdName, status: "ready" }] : [],
+							),
+							stderr: "",
+							code: 0,
+						};
+					}
+					removeCalls++;
+					return { stdout: "", stderr: "machine not found", code: 1 };
+				},
+			},
+		);
+
+		const error = (await driver
+			.create({ ...request, deadlineMs: 200 })
+			.catch((caught: unknown) => caught)) as DriverError;
+		expect(error).toMatchObject({ code: "create-failed", vendorExitCode: 7 });
+		expect(listCalls).toBe(2);
+		expect(removeCalls).toBe(1);
+		expect((observations[1] ?? 0) - (observations[0] ?? 0)).toBeGreaterThanOrEqual(confirmationMs);
+	});
+
+	test("a positive lookup resets stale absence evidence before delete-not-found", async () => {
+		let createdName = "";
+		let listCalls = 0;
+		let rowsArePresent = false;
+		const confirmationMs = 20;
+		const driver = cliDriver(
+			tamaLikeSpec({
+				create: (_request, name) => {
+					createdName = name;
+					return ["new", name];
+				},
+				cleanupCreated: {
+					kind: "lookup",
+					select: (rows, name) => rows.find((row) => row.name === name) ?? null,
+					absenceConfirmationMs: confirmationMs,
+				},
+			}),
+			{
+				run: async (_binary, args) => {
+					if (args[0] === "new") return { stdout: "", stderr: "ambiguous", code: 7 };
+					if (args[0] === "list") {
+						listCalls++;
+						return {
+							stdout: JSON.stringify(
+								rowsArePresent ? [{ id: "m-1", name: createdName, status: "ready" }] : [],
+							),
+							stderr: "",
+							code: 0,
+						};
+					}
+					return { stdout: "", stderr: "machine not found", code: 1 };
+				},
+			},
+		);
+
+		const error = (await driver
+			.create({ ...request, deadlineMs: 5 })
+			.catch((caught: unknown) => caught)) as FailedCreateCleanupError;
+		expect(error).toBeInstanceOf(FailedCreateCleanupError);
+		await Bun.sleep(confirmationMs);
+		rowsArePresent = true;
+		await expect(error[Symbol.asyncDispose]()).rejects.toMatchObject({ code: "destroy-failed" });
+		expect(listCalls).toBe(3);
+
+		rowsArePresent = false;
+		await error[Symbol.asyncDispose]();
+	});
+
+	test("rejects an invalid joined create-attempt ceiling", () => {
+		expect(() =>
+			defineCliDriver("tama", {
+				createAttemptCeilingMs: 0,
+				spec: () => tamaLikeSpec(),
+			}),
+		).toThrow(expect.objectContaining({ code: "vendor-contract-violation", provider: "tama" }));
+	});
+
+	test("rejects an invalid per-command timeout as a provider contract bug", () => {
+		expect(() => cliDriver(tamaLikeSpec({ commandTimeoutMs: 0 }))).toThrow(
+			expect.objectContaining({ code: "vendor-contract-violation", provider: "tama" }),
+		);
+	});
+
+	test("rejects an invalid create-command timeout as a provider contract bug", () => {
+		expect(() => cliDriver(tamaLikeSpec({ createCommandTimeoutMs: 0 }))).toThrow(
+			expect.objectContaining({ code: "vendor-contract-violation", provider: "tama" }),
+		);
+	});
+
+	test("rejects invalid readiness poll intervals as provider contract bugs", () => {
+		for (const pollIntervalMs of [0, -1, 1.5, Number.NaN, Number.POSITIVE_INFINITY]) {
+			expect(() =>
+				cliDriver(
+					tamaLikeSpec({
+						ready: { ...tamaLikeSpec().ready, pollIntervalMs },
+					}),
+				),
+			).toThrow(expect.objectContaining({ code: "vendor-contract-violation", provider: "tama" }));
+		}
+	});
+
+	test("rejects an invalid failed-create absence horizon as a provider contract bug", () => {
+		expect(() =>
+			cliDriver(
+				tamaLikeSpec({
+					cleanupCreated: {
+						kind: "command",
+						command: (name) => ["rm-name", "-y", name],
+						absenceConfirmationMs: 0,
+					},
+				}),
+			),
+		).toThrow(expect.objectContaining({ code: "vendor-contract-violation", provider: "tama" }));
+	});
+
+	test("preflights failed-create cleanup argv before invoking the vendor", async () => {
+		let calls = 0;
+		const driver = cliDriver(
+			tamaLikeSpec({
+				cleanupCreated: {
+					kind: "command",
+					command: () => {
+						throw new Error("bad cleanup template");
+					},
+					absenceConfirmationMs: 5,
+				},
+			}),
+			{
+				run: async () => {
+					calls++;
+					return { stdout: "", stderr: "", code: 0 };
+				},
+			},
+		);
+		const error = await driver.create(request).catch((caught: unknown) => caught);
+		expect(error).toMatchObject({ code: "vendor-contract-violation", provider: "tama" });
+		expect(calls).toBe(0);
+	});
+
+	test("create polls until ready; the session's native handle IS the parsed row", async () => {
+		const vendor = fakeVendor({ readyAfterPolls: 2 });
+		const driver = cliDriver(tamaLikeSpec(), { run: vendor.run });
+		const session = await driver.create(request);
+		expect(session.sandboxRef).toEqual({ provider: "tama", id: "m-1" });
+		expect(session.native.status).toBe("ready");
+		const result = await session.exec("echo hi");
+		expect(result.exit).toEqual({ kind: "exited", code: 0 });
+		expect(result.stdout).toBe("ran\n");
+		await session.destroy();
+		expect(vendor.machines.size).toBe(0);
+	});
+
+	test("destroy tolerates not-found (idempotent); other failures surface with structured fields", async () => {
+		const vendor = fakeVendor();
+		const table = cliMethodTable(tamaLikeSpec(), { run: vendor.run });
+		// destroy-of-missing MUST succeed (ADR-0008):
+		await table.destroyById?.({}, sandboxRef("tama", "m-999"));
+		// a genuinely different failure is not swallowed — and carries a typed code + vendor fields:
+		const failing = cliMethodTable(tamaLikeSpec({ destroy: () => ["boom"] }), {
+			run: async () => ({ stdout: "", stderr: "quota exceeded", code: 9 }),
+		});
+		const error = (await failing
+			.destroyById?.({}, sandboxRef("tama", "m-1"))
+			.catch((caught: unknown) => caught)) as DriverError;
+		expect(error).toBeInstanceOf(DriverError);
+		expect(error.code).toBe("destroy-failed");
+		expect(error.vendorExitCode).toBe(9);
+		expect(error.vendorMessage).toBe("quota exceeded");
+		expect(error.provider).toBe("tama");
+	});
+
+	test("destroy not-found matching is repeatable with a global regex", async () => {
+		const vendor = fakeVendor();
+		const table = cliMethodTable(tamaLikeSpec({ notFound: /not found/gi }), { run: vendor.run });
+		const missing = sandboxRef("tama", "m-999");
+		await table.destroyById?.({}, missing);
+		await table.destroyById?.({}, missing);
+	});
+
+	test("bare-ref cleanup passes through the provider module's sandbox-id parser", async () => {
+		let calls = 0;
+		const table = cliMethodTable(tamaLikeSpec(), {
+			run: async () => {
+				calls++;
+				return { stdout: "", stderr: "", code: 0 };
+			},
+		});
+		const ref = sandboxRef("tama", "wrong-vendor-shape");
+		const error = await table.destroyById?.({}, ref).catch((caught: unknown) => caught);
+		expect(error).toMatchObject({ code: "invalid-sandbox-ref", provider: "tama", ref });
+		expect(calls).toBe(0);
+	});
+
+	test("bare-ref cleanup rejects a ref qualified for another provider", async () => {
+		let calls = 0;
+		const table = cliMethodTable(tamaLikeSpec(), {
+			run: async () => {
+				calls++;
+				return { stdout: "", stderr: "", code: 0 };
+			},
+		});
+		const ref = sandboxRef("e2b", "m-1");
+		const error = await table.destroyById?.({}, ref).catch((caught: unknown) => caught);
+		expect(error).toMatchObject({ code: "invalid-sandbox-ref", provider: "tama", ref });
+		expect(calls).toBe(0);
+	});
+
+	test("unparseable vendor output produces a path-bearing report, not an undefined", async () => {
+		const driver = cliDriver(tamaLikeSpec(), {
+			run: async (_binary, args) =>
+				args[0] === "list"
+					? { stdout: '[{"id":"m-1","name":"bench"}]', stderr: "", code: 0 }
+					: { stdout: "", stderr: "", code: 0 },
+		});
+		const error = (await driver.create(request).catch((caught: unknown) => caught)) as DriverError;
+		expect(error.code).toBe("vendor-output-unparseable");
+		expect(error.vendorMessage).toMatch(/status must be a string \(was missing\)/);
+	});
+
+	test("the provider module validates sandbox ids before the generic kit constructs a ref", async () => {
+		let cleanupCalls = 0;
+		let createdName = "";
+		const driver = cliDriver(tamaLikeSpec(), {
+			run: async (_binary, args) => {
+				if (args[0] === "new") {
+					createdName = args[1] ?? "";
+					return { stdout: "", stderr: "", code: 0 };
+				}
+				if (args[0] === "list") {
+					return {
+						stdout: JSON.stringify([
+							{ id: "vendor-shaped-wrong", name: createdName, status: "ready" },
+						]),
+						stderr: "",
+						code: 0,
+					};
+				}
+				cleanupCalls++;
+				return { stdout: "", stderr: "", code: 0 };
+			},
+		});
+		const error = (await driver.create(request).catch((caught: unknown) => caught)) as DriverError;
+		expect(error).toMatchObject({ code: "invalid-sandbox-ref", provider: "tama" });
+		expect(error.message).toMatch(/must be matched by/);
+		expect(cleanupCalls).toBe(1);
+	});
+
+	test("a create that never becomes ready reconciles inside the reserved cleanup tail", async () => {
+		const vendor = fakeVendor({ readyAfterPolls: Number.POSITIVE_INFINITY });
+		const driver = cliDriver(tamaLikeSpec(), { run: vendor.run });
+		const started = Date.now();
+		const error = (await driver
+			.create({ ...request, deadlineMs: 25 })
+			.catch((caught: unknown) => caught)) as DriverError;
+		// Readiness stops short of the attempt ceiling, so the failed create still owns a bounded
+		// window to reconcile in-line rather than deferring a billable machine to the process owner.
+		expect(error).not.toBeInstanceOf(FailedCreateCleanupError);
+		expect(error.code).toBe("readiness-timeout");
+		expect(error.message).toMatch(/tama sandbox not ready within 25ms/);
+		// The reserve is carved out of the same deadline, never added to it.
+		expect(Date.now() - started).toBeLessThan(250);
+		expect(vendor.machines.size).toBe(0);
+	});
+
+	test("a sub-millisecond cleanup remainder is deterministically deferred", async () => {
+		let cleanupCalls = 0;
+		const driver = cliDriver(tamaLikeSpec(), {
+			run: async (_binary, args) => {
+				if (args[0] === "new") return { stdout: "", stderr: "rejected", code: 7 };
+				cleanupCalls++;
+				return { stdout: "", stderr: "", code: 0 };
+			},
+		});
+		const error = (await driver
+			.create({ ...request, deadlineMs: 0.5 })
+			.catch((caught: unknown) => caught)) as FailedCreateCleanupError;
+		expect(error).toBeInstanceOf(FailedCreateCleanupError);
+		expect((error.error as DriverError).message).toMatch(/request deadline was exhausted/);
+		expect(cleanupCalls).toBe(0);
+		await error[Symbol.asyncDispose]();
+		expect(cleanupCalls).toBe(1);
+	});
+
+	test("failed-create cleanup receives only the original request's remaining budget", async () => {
+		let cleanupTimeoutMs: number | undefined;
+		const driver = cliDriver(tamaLikeSpec({ commandTimeoutMs: 10_000 }), {
+			run: async (_binary, args, options) => {
+				if (args[0] === "new") {
+					await Bun.sleep(20);
+					return { stdout: "", stderr: "post-create check failed", code: 7 };
+				}
+				cleanupTimeoutMs = options.timeoutMs;
+				return { stdout: "", stderr: "", code: 0 };
+			},
+		});
+		const deadlineMs = 100;
+		const error = (await driver
+			.create({ ...request, deadlineMs })
+			.catch((caught: unknown) => caught)) as DriverError;
+		expect(error.code).toBe("create-failed");
+		expect(cleanupTimeoutMs).toBeLessThan(deadlineMs);
+		expect(cleanupTimeoutMs).toBeGreaterThan(0);
+	});
+
+	test("create cancellation aborts reconciliation that is already in flight", async () => {
+		let cleanupAttempts = 0;
+		let cleanupSignal: AbortSignal | undefined;
+		let noteCleanupStarted!: () => void;
+		const cleanupStarted = new Promise<void>((resolve) => {
+			noteCleanupStarted = resolve;
+		});
+		const driver = cliDriver(tamaLikeSpec({ commandTimeoutMs: 10_000 }), {
+			run: async (_binary, args, options) => {
+				if (args[0] === "new") return { stdout: "", stderr: "create rejected", code: 7 };
+				cleanupAttempts++;
+				if (cleanupAttempts > 1) return { stdout: "", stderr: "", code: 0 };
+				cleanupSignal = options.signal;
+				noteCleanupStarted();
+				return new Promise<CliRunResult>((_resolve, reject) => {
+					const aborted = () => reject(options.signal?.reason);
+					options.signal?.addEventListener("abort", aborted, { once: true });
+					if (options.signal?.aborted) aborted();
+				});
+			},
+		});
+		const cancellation = new AbortController();
+		const creating = driver.create(request, { signal: cancellation.signal });
+		await cleanupStarted;
+		const reason = new Error("process shutdown");
+		cancellation.abort(reason);
+
+		const error = (await creating.catch((caught: unknown) => caught)) as FailedCreateCleanupError;
+		expect(error).toBeInstanceOf(FailedCreateCleanupError);
+		expect(cleanupSignal?.aborted).toBe(true);
+		expect(cleanupSignal?.reason).toBe(reason);
+		await error.cleanup();
+		expect(cleanupAttempts).toBe(2);
+	});
+
+	test("readiness cancellation reaps the poll runner before returning recovery ownership", async () => {
+		let notePollStarted!: () => void;
+		const pollStarted = new Promise<void>((resolve) => {
+			notePollStarted = resolve;
+		});
+		let noteAbortObserved!: () => void;
+		const abortObserved = new Promise<void>((resolve) => {
+			noteAbortObserved = resolve;
+		});
+		let finishTermination!: () => void;
+		const terminationGate = new Promise<void>((resolve) => {
+			finishTermination = resolve;
+		});
+		let pollSettled = false;
+		let cleanupCalls = 0;
+		const driver = cliDriver(tamaLikeSpec(), {
+			run: async (_binary, args, options) => {
+				if (args[0] === "new") return { stdout: "", stderr: "", code: 0 };
+				if (args[0] === "list") {
+					notePollStarted();
+					await new Promise<void>((resolve) => {
+						const aborted = () => {
+							noteAbortObserved();
+							void terminationGate.then(resolve);
+						};
+						options.signal?.addEventListener("abort", aborted, { once: true });
+						if (options.signal?.aborted) aborted();
+					});
+					pollSettled = true;
+					throw options.signal?.reason;
+				}
+				cleanupCalls++;
+				return { stdout: "", stderr: "", code: 0 };
+			},
+		});
+		const cancellation = new AbortController();
+		let createSettled = false;
+		const creating = driver
+			.create(request, { signal: cancellation.signal })
+			.catch((caught: unknown) => caught)
+			.finally(() => {
+				createSettled = true;
+			});
+		await pollStarted;
+		cancellation.abort(new Error("process shutdown"));
+		await abortObserved;
+		await Bun.sleep(1);
+		expect(createSettled).toBe(false);
+		expect(cleanupCalls).toBe(0);
+
+		finishTermination();
+		const error = (await creating) as FailedCreateCleanupError;
+		expect(error).toBeInstanceOf(FailedCreateCleanupError);
+		expect(pollSettled).toBe(true);
+		expect(cleanupCalls).toBe(0);
+		await error.cleanup();
+		expect(cleanupCalls).toBe(1);
+	});
+
+	test("provisioning time is subtracted from the readiness budget and passed to the runner", async () => {
+		const vendor = fakeVendor({ readyAfterPolls: 0 });
+		const timeouts: Array<{ verb: string; timeoutMs: number }> = [];
+		const driver = cliDriver(tamaLikeSpec({ commandTimeoutMs: 10_000 }), {
+			run: async (binary, args, options) => {
+				timeouts.push({ verb: args[0] ?? "", timeoutMs: options.timeoutMs });
+				if (args[0] === "new") await Bun.sleep(20);
+				return vendor.run(binary, args, options);
+			},
+		});
+		const session = await driver.create({ ...request, deadlineMs: 100 });
+		const createTimeout = timeouts.find(({ verb }) => verb === "new")?.timeoutMs;
+		const pollTimeout = timeouts.find(({ verb }) => verb === "list")?.timeoutMs;
+		expect(createTimeout).toBeLessThanOrEqual(100);
+		expect(pollTimeout).toBeLessThan(createTimeout ?? 0);
+		await session.destroy();
+		expect(vendor.machines.size).toBe(0);
+	});
+
+	test("a cleanup double fault preserves both failures and a retryable recovery locator", async () => {
+		let cleanupCalls = 0;
+		const driver = cliDriver(tamaLikeSpec(), {
+			run: async (_binary, args) => {
+				if (args[0] === "new") return { stdout: "", stderr: "", code: 0 };
+				if (args[0] === "list") return { stdout: "not json", stderr: "", code: 0 };
+				cleanupCalls++;
+				return cleanupCalls === 1
+					? { stdout: "", stderr: "cleanup failed", code: 7 }
+					: { stdout: "", stderr: "", code: 0 };
+			},
+		});
+		const error = (await driver
+			.create(request)
+			.catch((caught: unknown) => caught)) as FailedCreateCleanupError;
+		expect(error).toBeInstanceOf(FailedCreateCleanupError);
+		expect(error).toBeInstanceOf(SuppressedError);
+		expect((error.error as DriverError).code).toBe("destroy-failed");
+		expect((error.suppressed as DriverError).code).toBe("vendor-output-unparseable");
+		expect(error.provider).toBe("tama");
+		expect(error.locator.kind).toBe("name");
+		expect(error.locator.value).toMatch(/^bench-/);
+
+		await error[Symbol.asyncDispose]();
+		await error[Symbol.asyncDispose]();
+		expect(cleanupCalls).toBe(2);
+	});
+
+	test("failed-create cleanup retains ownership across a transient not-found", async () => {
+		let cleanupCalls = 0;
+		const driver = cliDriver(
+			tamaLikeSpec({
+				cleanupCreated: {
+					kind: "command",
+					command: (name) => ["rm-name", "-y", name],
+					absenceConfirmationMs: 100,
+				},
+			}),
+			{
+				run: async (_binary, args) => {
+					if (args[0] === "new") return { stdout: "", stderr: "", code: 0 };
+					if (args[0] === "list") return { stdout: "not json", stderr: "", code: 0 };
+					cleanupCalls++;
+					return cleanupCalls === 1
+						? { stdout: "", stderr: "machine not found", code: 0 }
+						: { stdout: "", stderr: "", code: 0 };
+				},
+			},
+		);
+		const error = (await driver
+			.create({ ...request, deadlineMs: 50 })
+			.catch((caught: unknown) => caught)) as FailedCreateCleanupError;
+		expect(error).toBeInstanceOf(FailedCreateCleanupError);
+		expect((error.error as DriverError).vendorMessage).toBe("machine not found");
+		expect(error.locator).toMatchObject({ kind: "name" });
+
+		await error[Symbol.asyncDispose]();
+		expect(cleanupCalls).toBe(2);
+	});
+
+	test("an immediate owner retry cannot confirm absence before the declared horizon", async () => {
+		let cleanupCalls = 0;
+		const observations: number[] = [];
+		const confirmationMs = 50;
+		const driver = cliDriver(
+			tamaLikeSpec({
+				cleanupCreated: {
+					kind: "command",
+					command: (name) => ["rm-name", "-y", name],
+					absenceConfirmationMs: confirmationMs,
+				},
+			}),
+			{
+				run: async (_binary, args) => {
+					if (args[0] === "new") return { stdout: "", stderr: "", code: 0 };
+					if (args[0] === "list") return { stdout: "not json", stderr: "", code: 0 };
+					cleanupCalls++;
+					observations.push(Date.now());
+					return { stdout: "", stderr: "machine not found", code: 0 };
+				},
+			},
+		);
+		const error = (await driver
+			.create({ ...request, deadlineMs: 10 })
+			.catch((caught: unknown) => caught)) as FailedCreateCleanupError;
+		expect(error).toBeInstanceOf(FailedCreateCleanupError);
+		expect(cleanupCalls).toBe(1);
+
+		const cleanup = error[Symbol.asyncDispose]();
+		await Bun.sleep(5);
+		// The process owner has observed the same immediate name-index miss, but ownership
+		// remains live until a third observation reaches the provider's convergence horizon.
+		expect(cleanupCalls).toBe(2);
+		await cleanup;
+		expect(cleanupCalls).toBe(3);
+		expect((observations[2] ?? 0) - (observations[0] ?? 0)).toBeGreaterThanOrEqual(confirmationMs);
+	});
+
+	test("the joined attempt ceiling bounds a hung create below the caller's deadline", async () => {
+		const dir = mkdtempSync(join(tmpdir(), "cli-driver-timeout-"));
+		const aliveMarker = join(dir, "survived");
+		const pidFile = join(dir, "pid");
+		try {
+			const driver = cliDriver(
+				tamaLikeSpec({
+					binary: "/bin/sh",
+					commandTimeoutMs: 1_000,
+					create: () => [
+						"-c",
+						`echo $$ > ${JSON.stringify(pidFile)}; sleep 0.2; touch ${JSON.stringify(aliveMarker)}`,
+					],
+					cleanupCreated: {
+						kind: "command",
+						command: () => ["-c", "exit 0"],
+						absenceConfirmationMs: 5,
+					},
+				}),
+				{ createAttemptCeilingMs: 75 },
+			);
+			const started = Date.now();
+			const error = (await driver
+				.create({ ...request, deadlineMs: 1_000 })
+				.catch((caught: unknown) => caught)) as FailedCreateCleanupError;
+			expect(error).toBeInstanceOf(FailedCreateCleanupError);
+			expect((error.suppressed as DriverError).code).toBe("readiness-timeout");
+			expect((error.suppressed as Error).message).toMatch(/within 75ms/);
+			expect((error.error as DriverError).message).toMatch(/request deadline was exhausted/);
+			expect(Date.now() - started).toBeLessThan(1_000);
+			const childPid = Number.parseInt(readFileSync(pidFile, "utf8"), 10);
+			expect(() => process.kill(childPid, 0)).toThrow();
+			await Bun.sleep(200);
+			expect(existsSync(aliveMarker)).toBe(false);
+			await error[Symbol.asyncDispose]();
+		} finally {
+			rmSync(dir, { recursive: true, force: true });
+		}
+	});
+
+	test.skipIf(process.platform === "win32")(
+		"create cancellation kills and reaps the detached CLI before returning recovery ownership",
+		async () => {
+			const dir = mkdtempSync(join(tmpdir(), "cli-driver-abort-"));
+			const aliveMarker = join(dir, "survived");
+			const pidFile = join(dir, "pid");
+			try {
+				const driver = cliDriver(
+					tamaLikeSpec({
+						binary: "/bin/sh",
+						commandTimeoutMs: 1_000,
+						createCommandTimeoutMs: 20_000,
+						create: () => [
+							"-c",
+							`echo $$ > ${JSON.stringify(pidFile)}; sleep 10; touch ${JSON.stringify(aliveMarker)}`,
+						],
+						cleanupCreated: {
+							kind: "command",
+							command: () => ["-c", "exit 0"],
+							absenceConfirmationMs: 5,
+						},
+					}),
+				);
+				const cancellation = new AbortController();
+				const creating = driver.create(
+					{ ...request, deadlineMs: 20_000 },
+					{ signal: cancellation.signal },
+				);
+				const waitDeadline = Date.now() + 2_000;
+				while (!existsSync(pidFile)) {
+					if (Date.now() >= waitDeadline) throw new Error("CLI create did not start");
+					await Bun.sleep(5);
+				}
+				const childPid = Number.parseInt(readFileSync(pidFile, "utf8"), 10);
+				cancellation.abort(new Error("process shutdown"));
+				const error = (await creating.catch(
+					(caught: unknown) => caught,
+				)) as FailedCreateCleanupError;
+				expect(error).toBeInstanceOf(FailedCreateCleanupError);
+				expect(() => process.kill(childPid, 0)).toThrow();
+				await Bun.sleep(100);
+				expect(existsSync(aliveMarker)).toBe(false);
+				await error.cleanup();
+			} finally {
+				rmSync(dir, { recursive: true, force: true });
+			}
+		},
+	);
+
+	test.skipIf(process.platform === "win32")(
+		"the default runner bounds pipe drain when a background helper inherits stdio",
+		async () => {
+			const dir = mkdtempSync(join(tmpdir(), "cli-driver-helper-"));
+			const aliveMarker = join(dir, "survived");
+			try {
+				const driver = cliDriver(
+					tamaLikeSpec({
+						binary: "/bin/sh",
+						commandTimeoutMs: 50,
+						create: () => ["-c", `(sleep 0.2; touch ${JSON.stringify(aliveMarker)}) &`],
+						cleanupCreated: {
+							kind: "command",
+							command: () => ["-c", "exit 0"],
+							absenceConfirmationMs: 5,
+						},
+					}),
+				);
+				const started = Date.now();
+				const error = (await driver
+					.create({ ...request, deadlineMs: 500 })
+					.catch((caught: unknown) => caught)) as DriverError;
+				expect(error).toMatchObject({ code: "create-failed", provider: "tama" });
+				expect(Date.now() - started).toBeLessThan(300);
+				await Bun.sleep(200);
+				expect(existsSync(aliveMarker)).toBe(false);
+			} finally {
+				rmSync(dir, { recursive: true, force: true });
+			}
+		},
+	);
+
+	test("secret argv values are redacted from every diagnostic", async () => {
+		const driver = cliDriver(tamaLikeSpec(), {
+			run: async (_binary, args) =>
+				args[0] === "rm-name"
+					? { stdout: "", stderr: "", code: 0 }
+					: { stdout: "", stderr: "invalid token s3cret", code: 3 },
+		});
+		const error = (await driver.create(request).catch((caught: unknown) => caught)) as DriverError;
+		expect(error.code).toBe("create-failed");
+		expect(error.message).toContain("--token ***");
+		expect(error.message).not.toContain("s3cret");
+		expect(error.vendorMessage).toBe("invalid token ***");
+	});
+
+	test("a stdout-only nonzero create keeps its diagnostic and still reconciles by name", async () => {
+		const calls: string[][] = [];
+		const driver = cliDriver(tamaLikeSpec(), {
+			run: async (_binary, args) => {
+				calls.push([...args]);
+				return args[0] === "new"
+					? { stdout: "capacity exhausted", stderr: "", code: 7 }
+					: { stdout: "", stderr: "", code: 0 };
+			},
+		});
+		const error = await driver.create(request).catch((caught: unknown) => caught);
+		expect(error).toMatchObject({
+			code: "create-failed",
+			vendorExitCode: 7,
+			vendorMessage: "capacity exhausted",
+		});
+		expect(calls.map(([verb]) => verb)).toEqual(["new", "rm-name"]);
+	});
+
+	test("exec caps are per-call opt-in and reported as truncation", async () => {
+		const vendor = fakeVendor();
+		const driver = cliDriver(tamaLikeSpec(), {
+			run: async (_binary, args, options) =>
+				args[0] === "exec"
+					? { stdout: "x".repeat(100), stderr: "", code: 0 }
+					: vendor.run(_binary, args, options),
+		});
+		const session = await driver.create(request);
+		const capped = await session.exec("noisy", { maxOutputBytes: 10 });
+		expect(capped.stdout).toHaveLength(10);
+		expect(capped.truncated).toBe(true);
+		const uncapped = await session.exec("noisy");
+		expect(uncapped.stdout).toHaveLength(100);
+		expect(uncapped.truncated).toBe(false);
+	});
+});
+
+describe("redactArgs", () => {
+	test("redacts exactly the value following each secret flag", () => {
+		expect(redactArgs(["login", "--token", "s3cret", "--json"], ["--token"])).toEqual([
+			"login",
+			"--token",
+			"***",
+			"--json",
+		]);
+	});
+
+	test("does not reinterpret a redacted value as another secret flag", () => {
+		expect(redactArgs(["login", "--token", "--token", "visible"], ["--token"])).toEqual([
+			"login",
+			"--token",
+			"***",
+			"visible",
+		]);
+	});
+
+	test("redacts declared secret values from vendor diagnostics", () => {
+		expect(
+			redactDiagnostic(
+				"command failed: --token s3cret (s3cret rejected)",
+				["login", "--token", "s3cret"],
+				["--token"],
+			),
+		).toBe("command failed: --token *** (*** rejected)");
+	});
+
+	test("redacts overlapping values longest-first", () => {
+		expect(
+			redactDiagnostic(
+				"long=s3cret-long short=s3cret",
+				["login", "--token", "s3cret-long", "--key", "s3cret"],
+				["--token", "--key"],
+			),
+		).toBe("long=*** short=***");
+	});
+
+	test("does not reinterpret a secret value as another secret flag", () => {
+		expect(
+			redactDiagnostic(
+				"the --token value failed; visible stays visible",
+				["login", "--token", "--token", "visible"],
+				["--token"],
+			),
+		).toBe("the *** value failed; visible stays visible");
+	});
+});

--- a/packages/driver/src/cli.ts
+++ b/packages/driver/src/cli.ts
@@ -1,0 +1,1122 @@
+// cliDriver (ADR-0007 §5): the generic driver for CLI-only vendors. A provider whose control
+// plane is `spawn()` on a binary becomes a declarative table of argv templates and parsers.
+// The generic driver owns spawn, secret redaction and not-found matching ONCE; vendor stdout
+// is a trust boundary, so the table's `parse` fields are arktype pipelines and a vendor
+// changing its output shape produces a path-bearing report, not an `undefined` threading
+// through readiness logic.
+//
+// The compiled shape is a MethodTable whose handle is the PARSED READINESS ROW — so every
+// generated member is unit-testable as a pure function and `session.native` is the vendor's
+// own typed record, not an opaque id string. Readiness polling, output capping and the
+// use-after-destroy guard belong to the kit layer (poll.ts, table.ts); this file supplies only
+// the vendor-specific argv and parsers.
+
+import { randomUUID } from "node:crypto";
+import type { ProviderId } from "@sandbox-benchmarks/schema/providers";
+import type { Out, Type } from "arktype";
+import { type } from "arktype";
+import type {
+	CreateRequest,
+	DriverContext,
+	DriverModule,
+	DriverOperationOptions,
+	ExecResult,
+	SandboxDriver,
+	SandboxRef,
+} from "./index.ts";
+import { defineDriver, driverFromTable, sandboxRef } from "./index.ts";
+import { DriverError, FailedCreateCleanupError } from "./lib/errors.ts";
+import { pollUntilReady } from "./lib/poll.ts";
+import type { MethodTable } from "./lib/table.ts";
+
+export interface CliRunResult {
+	readonly stdout: string;
+	readonly stderr: string;
+	readonly code: number;
+}
+
+export interface CliRunOptions {
+	/** Hard subprocess budget. Runners MUST terminate the child before rejecting on timeout. */
+	readonly timeoutMs: number;
+	/** Cooperative process-owner cancellation; runners must terminate before rejecting. */
+	readonly signal?: AbortSignal;
+}
+
+/** Runs the vendor binary. Injectable so cliDriver tables are testable without a real CLI. */
+export type CliRunner = (
+	binary: string,
+	args: readonly string[],
+	options: CliRunOptions,
+) => Promise<CliRunResult>;
+
+/** An actual arktype schema whose callable output is the provider's parsed readiness rows. */
+export type CliRowsSchema<Row> = Type<(In: string) => Out<readonly Row[]>>;
+
+export type CliFailedCreateCleanup<Row> =
+	| {
+			/** Direct name-addressed delete for CLIs that genuinely support it. */
+			readonly kind: "command";
+			readonly command: (name: string) => readonly string[];
+			readonly absenceConfirmationMs: number;
+	  }
+	| {
+			/** Resolve the generated name through the parsed list, then delete its validated id. */
+			readonly kind: "lookup";
+			readonly select: (rows: readonly Row[], name: string) => Row | null;
+			readonly absenceConfirmationMs: number;
+	  };
+
+/** Provider classification of one selected readiness row; the kit owns the resulting control flow. */
+export type CliReadinessStatus = "ready" | "pending" | { readonly terminal: string };
+
+export interface CliSpec<Row> {
+	/** Resolved binary path or name (the caller applies any env override). */
+	readonly binary: string;
+	/** Flags whose FOLLOWING argv value is a secret: redacted from every diagnostic. */
+	readonly secretFlags: readonly string[];
+	/** Kill budget for short control-plane calls: prepare, poll, exec, and destroy. */
+	readonly commandTimeoutMs: number;
+	/** Optional longer kill budget for the create subprocess; defaults to commandTimeoutMs. */
+	readonly createCommandTimeoutMs?: number;
+	/** argv to create a sandbox named `name` for `request`. */
+	readonly create: (request: CreateRequest, name: string) => readonly string[];
+	/** Optional pre-create probe with a fallback action (for profile-based CLI authentication). */
+	readonly prepare?: {
+		/** Must exit zero and parse through the readiness-row schema to count as prepared. */
+		readonly probe: readonly string[];
+		/** Checked fallback command, commonly `login --token …`; secret flags still redact it. */
+		readonly fallback: readonly string[];
+	};
+	/** Rollback/reconciliation used when no session handle can be returned. */
+	readonly cleanupCreated: CliFailedCreateCleanup<Row>;
+	readonly ready: {
+		/** argv that lists/inspects sandboxes; polled until `select` finds the row. */
+		readonly poll: readonly string[];
+		/** Trust boundary: raw stdout → rows, as an arktype pipeline (path-bearing errors). */
+		readonly parse: CliRowsSchema<Row>;
+		/** The created row for `name`, or null while it is not visible. */
+		readonly select: (rows: readonly Row[], name: string) => Row | null;
+		/** Typed vendor-state policy. The kit handles terminal errors, deadline, and cleanup. */
+		readonly classify: (row: Row) => CliReadinessStatus;
+		readonly pollIntervalMs?: number;
+	};
+	/** Trust boundary: the selected provider module extracts and validates its sandbox-id format. */
+	readonly sandboxId: {
+		readonly fromRow: (row: Row) => unknown;
+		readonly parse: Type<string>;
+	};
+	readonly exec: (id: string, command: string) => readonly string[];
+	readonly destroy: (id: string) => readonly string[];
+	/** Vendor prose meaning "already gone" — destroy-of-missing MUST succeed (ADR-0008). */
+	readonly notFound: RegExp;
+}
+
+export type CliSpecFields<Row> = Omit<CliSpec<Row>, "ready"> & {
+	readonly ready: Omit<CliSpec<Row>["ready"], "parse">;
+};
+
+/**
+ * Bind a CLI's arktype rows parser before contextual-typing the rest of its table.
+ *
+ * Keeping the parser in the first argument lets TypeScript infer `Row` once and then type every
+ * `select`/`fromRow` callback without a handwritten row alias or annotation.
+ */
+export function defineCliSpec<Row>(
+	parse: CliRowsSchema<Row>,
+	spec: CliSpecFields<NoInfer<Row>>,
+): CliSpec<Row> {
+	return { ...spec, ready: { ...spec.ready, parse } };
+}
+
+export interface CliDriverOptions {
+	/** Override the spawn runner (tests). Defaults to Bun.spawn on the spec's binary. */
+	readonly run?: CliRunner;
+	/** Joined-module ceiling. Internal/test seam; provider authors use defineCliDriver. */
+	readonly createAttemptCeilingMs?: number;
+}
+
+interface CliPreparationInFlight {
+	readonly cancellation: AbortController;
+	readonly waiters: Set<symbol>;
+	readonly promise: Promise<void>;
+}
+
+/** Per-driver state: successful profile preparation is shared; failed attempts clear for retry. */
+export interface CliDriverContext {
+	prepare?: true | CliPreparationInFlight;
+}
+
+/** One joined CLI-provider module; the helper derives the required driver-owned create budget. */
+export interface CliDriverModuleSpec<P extends ProviderId, Row> {
+	/** Hard ceiling until success or a retryable failed-create cleanup record is returned. */
+	readonly createAttemptCeilingMs: number;
+	/** Builds the small declarative CLI table from this provider's exact environment slice. */
+	readonly spec: (context: DriverContext<P>) => CliSpec<Row>;
+}
+
+class CliRunTimeoutError extends Error {
+	constructor(readonly timeoutMs: number) {
+		super(`CLI process exceeded its ${timeoutMs}ms timeout`);
+		this.name = "CliRunTimeoutError";
+	}
+}
+
+class CliRunAbortedError extends Error {
+	constructor(readonly reason: unknown) {
+		super("CLI process was aborted", { cause: reason });
+		this.name = "CliRunAbortedError";
+	}
+}
+
+function subscribeToAbort(signal: AbortSignal | undefined, listener: () => void): () => void {
+	if (signal === undefined) return () => {};
+	signal.addEventListener("abort", listener, { once: true });
+	// Abort can win between a caller's pre-check and listener registration. Re-check only after the
+	// listener is installed so that edge cannot strand a subprocess or a reconciliation sleep.
+	if (signal.aborted) {
+		signal.removeEventListener("abort", listener);
+		listener();
+		return () => {};
+	}
+	return () => signal.removeEventListener("abort", listener);
+}
+
+function abortableDelay(ms: number, signal?: AbortSignal): Promise<void> {
+	if (signal?.aborted) return Promise.reject(new CliRunAbortedError(signal.reason));
+	return new Promise((resolve, reject) => {
+		let unsubscribe = () => {};
+		const timer = setTimeout(done, ms);
+		function done(): void {
+			unsubscribe();
+			resolve();
+		}
+		function aborted(): void {
+			clearTimeout(timer);
+			unsubscribe();
+			reject(new CliRunAbortedError(signal?.reason));
+		}
+		unsubscribe = subscribeToAbort(signal, aborted);
+	});
+}
+
+function readTextStream(stream: ReadableStream<Uint8Array>): {
+	readonly text: Promise<string>;
+	cancel(): void;
+} {
+	const reader = stream.getReader();
+	const text = (async () => {
+		const decoder = new TextDecoder();
+		let output = "";
+		while (true) {
+			const next = await reader.read();
+			if (next.done) break;
+			output += decoder.decode(next.value, { stream: true });
+		}
+		return output + decoder.decode();
+	})();
+	return {
+		text,
+		cancel() {
+			// Cancellation releases this process's side of inherited pipes even if a descendant
+			// escaped the process group. The read promise is already observed by `completed`.
+			void reader.cancel().catch(() => undefined);
+		},
+	};
+}
+
+const defaultRunner: CliRunner = async (binary, args, options) => {
+	if (!Number.isSafeInteger(options.timeoutMs) || options.timeoutMs <= 0) {
+		throw new DriverError(
+			"vendor-contract-violation",
+			`CLI timeout must be a positive safe integer, received ${String(options.timeoutMs)}`,
+		);
+	}
+	if (options.signal?.aborted) throw new CliRunAbortedError(options.signal.reason);
+	const child = Bun.spawn([binary, ...args], {
+		stdout: "pipe",
+		stderr: "pipe",
+		// A separate process group lets timeout cleanup kill helpers that inherited our pipes.
+		detached: process.platform !== "win32",
+	});
+	const stdout = readTextStream(child.stdout);
+	const stderr = readTextStream(child.stderr);
+	const completed = Promise.all([child.exited, stdout.text, stderr.text]).then(
+		([code, stdout, stderr]) => ({ kind: "completed" as const, code, stdout, stderr }),
+	);
+	let timer: ReturnType<typeof setTimeout> | undefined;
+	const timeout = new Promise<{ readonly kind: "timeout" }>((resolve) => {
+		timer = setTimeout(() => resolve({ kind: "timeout" }), options.timeoutMs);
+	});
+	let abortListener = () => {};
+	const aborted = new Promise<{ readonly kind: "aborted" }>((resolve) => {
+		abortListener = subscribeToAbort(options.signal, () => resolve({ kind: "aborted" }));
+	});
+	let outcome:
+		| {
+				readonly kind: "completed";
+				readonly code: number;
+				readonly stdout: string;
+				readonly stderr: string;
+		  }
+		| { readonly kind: "timeout" }
+		| { readonly kind: "aborted" };
+	try {
+		outcome = await Promise.race([completed, timeout, aborted]);
+	} finally {
+		if (timer !== undefined) clearTimeout(timer);
+		abortListener();
+	}
+	if (outcome.kind !== "completed") {
+		stdout.cancel();
+		stderr.cancel();
+		if (process.platform === "win32") {
+			child.kill("SIGKILL");
+		} else {
+			try {
+				// `detached` makes the child the group leader. The negative pid reaches descendants
+				// even if the CLI parent already exited while a helper kept stdout/stderr open.
+				process.kill(-child.pid, "SIGKILL");
+			} catch {
+				child.kill("SIGKILL");
+			}
+		}
+		await child.exited;
+		if (outcome.kind === "timeout") throw new CliRunTimeoutError(options.timeoutMs);
+		throw new CliRunAbortedError(options.signal?.reason);
+	}
+	return { stdout: outcome.stdout, stderr: outcome.stderr, code: outcome.code };
+};
+
+/** Redact secret values from an argv for diagnostics: the value AFTER a secret flag becomes ***. */
+export function redactArgs(args: readonly string[], secretFlags: readonly string[]): string[] {
+	const redacted: string[] = [];
+	let hide = false;
+	for (const arg of args) {
+		if (hide) {
+			redacted.push("***");
+			hide = false;
+		} else {
+			redacted.push(arg);
+			hide = secretFlags.includes(arg);
+		}
+	}
+	return redacted;
+}
+
+/** Redact secret argv values if a vendor echoes its invocation into stdout/stderr. */
+export function redactDiagnostic(
+	text: string,
+	args: readonly string[],
+	secretFlags: readonly string[],
+): string {
+	return redactDiagnostics(text, [args], secretFlags);
+}
+
+function redactDiagnostics(
+	text: string,
+	commands: readonly (readonly string[])[],
+	secretFlags: readonly string[],
+): string {
+	const secrets: string[] = [];
+	for (const args of commands) {
+		let takeSecret = false;
+		for (const arg of args) {
+			if (takeSecret) {
+				if (arg !== "") secrets.push(arg);
+				takeSecret = false;
+			} else {
+				takeSecret = secretFlags.includes(arg);
+			}
+		}
+	}
+	// Replace longer overlapping credentials first, or a short prefix can leave a secret suffix.
+	secrets.sort((left, right) => right.length - left.length);
+	return secrets.reduce((redacted, secret) => redacted.replaceAll(secret, "***"), text);
+}
+
+/** Compile a CLI spec down to a method table (handle = the parsed readiness row). */
+export function cliMethodTable<Row>(
+	provider: ProviderId,
+	spec: CliSpec<Row>,
+	options: CliDriverOptions = {},
+): MethodTable<Row, CliDriverContext> {
+	const run = options.run ?? defaultRunner;
+	if (!Number.isSafeInteger(spec.commandTimeoutMs) || spec.commandTimeoutMs <= 0) {
+		throw new DriverError(
+			"vendor-contract-violation",
+			`commandTimeoutMs must be a positive safe integer, received ${String(spec.commandTimeoutMs)}`,
+			{ provider },
+		);
+	}
+	if (
+		spec.createCommandTimeoutMs !== undefined &&
+		(!Number.isSafeInteger(spec.createCommandTimeoutMs) || spec.createCommandTimeoutMs <= 0)
+	) {
+		throw new DriverError(
+			"vendor-contract-violation",
+			`createCommandTimeoutMs must be a positive safe integer, received ${String(spec.createCommandTimeoutMs)}`,
+			{ provider },
+		);
+	}
+	if (
+		options.createAttemptCeilingMs !== undefined &&
+		(!Number.isSafeInteger(options.createAttemptCeilingMs) || options.createAttemptCeilingMs <= 0)
+	) {
+		throw new DriverError(
+			"vendor-contract-violation",
+			`createAttemptCeilingMs must be a positive safe integer, received ${String(options.createAttemptCeilingMs)}`,
+			{ provider },
+		);
+	}
+	if (
+		spec.ready.pollIntervalMs !== undefined &&
+		(!Number.isSafeInteger(spec.ready.pollIntervalMs) || spec.ready.pollIntervalMs <= 0)
+	) {
+		throw new DriverError(
+			"vendor-contract-violation",
+			`ready.pollIntervalMs must be a positive safe integer, received ${String(spec.ready.pollIntervalMs)}`,
+			{ provider },
+		);
+	}
+	if (
+		!Number.isSafeInteger(spec.cleanupCreated.absenceConfirmationMs) ||
+		spec.cleanupCreated.absenceConfirmationMs <= 0
+	) {
+		throw new DriverError(
+			"vendor-contract-violation",
+			`cleanupCreated.absenceConfirmationMs must be a positive safe integer, received ${String(spec.cleanupCreated.absenceConfirmationMs)}`,
+			{ provider },
+		);
+	}
+	const call = (
+		args: readonly string[],
+		timeoutMs = spec.commandTimeoutMs,
+		signal?: AbortSignal,
+	) => {
+		const boundedTimeoutMs = Math.floor(timeoutMs);
+		if (boundedTimeoutMs <= 0) throw new CliRunTimeoutError(timeoutMs);
+		return run(spec.binary, args, {
+			timeoutMs: boundedTimeoutMs,
+			...(signal === undefined ? {} : { signal }),
+		});
+	};
+	const redactKnownDiagnostic = (text: string, args: readonly (readonly string[])[]): string => {
+		const allArgs =
+			spec.prepare === undefined ? args : [...args, spec.prepare.probe, spec.prepare.fallback];
+		return redactDiagnostics(text, allArgs, spec.secretFlags);
+	};
+	// Vendor failures carry structured fields (exit code + vendor diagnostic) so the harness classifies
+	// by them, not by regexing a formatted message; the message redacts secret argv for humans.
+	const vendorFailed = (
+		code: "create-failed" | "destroy-failed",
+		args: readonly string[],
+		result: CliRunResult,
+		ref?: SandboxRef,
+		diagnosticArgs: readonly (readonly string[])[] = [args],
+	): DriverError => {
+		const vendorDiagnostic = result.stderr.trim() || result.stdout.trim();
+		return new DriverError(
+			code,
+			`${spec.binary} ${redactArgs(args, spec.secretFlags).join(" ")}: exit ${result.code}`,
+			{
+				provider,
+				vendorExitCode: result.code,
+				vendorMessage: redactKnownDiagnostic(vendorDiagnostic, diagnosticArgs),
+				...(ref ? { ref } : {}),
+			},
+		);
+	};
+
+	const runnerFailed = (
+		code: "create-failed" | "exec-failed" | "destroy-failed",
+		args: readonly string[],
+		caught: unknown,
+		ref?: SandboxRef,
+		diagnosticArgs: readonly (readonly string[])[] = [args],
+	): DriverError => {
+		const detail = redactKnownDiagnostic(String(caught), diagnosticArgs);
+		return new DriverError(
+			code,
+			`${spec.binary} ${redactArgs(args, spec.secretFlags).join(" ")}: ${detail}`,
+			{
+				provider,
+				vendorMessage: detail,
+				...(ref ? { ref } : {}),
+			},
+		);
+	};
+
+	const parseRows = (
+		result: CliRunResult,
+		diagnosticArgs: readonly (readonly string[])[],
+	): readonly Row[] => {
+		const rows = spec.ready.parse(result.stdout);
+		// CliRowsSchema's output side is readonly Row[]. ArkType's internal distillation cannot
+		// prove that equality for an arbitrary generic Row, even though the public schema type does.
+		if (!(rows instanceof type.errors)) return rows as readonly Row[];
+		const summary = redactKnownDiagnostic(rows.summary, diagnosticArgs);
+		throw new DriverError("vendor-output-unparseable", `${spec.binary} output: ${summary}`, {
+			provider,
+			vendorMessage: summary,
+		});
+	};
+
+	const createDeadlineError = (deadlineMs: number): DriverError =>
+		new DriverError("readiness-timeout", `${provider} sandbox not ready within ${deadlineMs}ms`, {
+			provider,
+		});
+
+	const ensurePrepared = async (
+		remaining: () => number,
+		deadlineMs: number,
+		signal?: AbortSignal,
+	): Promise<void> => {
+		const prepare = spec.prepare;
+		if (prepare === undefined) return;
+		const probeBudget = remaining();
+		if (probeBudget < 1) throw createDeadlineError(deadlineMs);
+		let probed: CliRunResult | undefined;
+		try {
+			probed = await call(prepare.probe, Math.min(probeBudget, spec.commandTimeoutMs), signal);
+		} catch (caught) {
+			if (signal?.aborted) throw caught;
+			// A failed profile probe selects the checked fallback below.
+		}
+		if (probed?.code === 0) {
+			// Exit zero already proves authentication. Schema drift is not repaired by overwriting a
+			// developer's working profile, so surface it through the normal trust-boundary error.
+			parseRows(probed, [prepare.probe]);
+			return;
+		}
+
+		const fallbackBudget = remaining();
+		if (fallbackBudget < 1) throw createDeadlineError(deadlineMs);
+		let fallback: CliRunResult;
+		try {
+			fallback = await call(
+				prepare.fallback,
+				Math.min(fallbackBudget, spec.commandTimeoutMs),
+				signal,
+			);
+		} catch (caught) {
+			if (caught instanceof CliRunTimeoutError && fallbackBudget <= spec.commandTimeoutMs) {
+				throw createDeadlineError(deadlineMs);
+			}
+			throw runnerFailed("create-failed", prepare.fallback, caught);
+		}
+		if (fallback.code !== 0) {
+			throw vendorFailed("create-failed", prepare.fallback, fallback);
+		}
+
+		// A successful login proves only that the profile write worked. Re-run the typed probe before
+		// allocation so schema drift cannot make both readiness and failed-create recovery unusable.
+		const verificationBudget = remaining();
+		if (verificationBudget < 1) throw createDeadlineError(deadlineMs);
+		let verified: CliRunResult;
+		try {
+			verified = await call(
+				prepare.probe,
+				Math.min(verificationBudget, spec.commandTimeoutMs),
+				signal,
+			);
+		} catch (caught) {
+			if (caught instanceof CliRunTimeoutError && verificationBudget <= spec.commandTimeoutMs) {
+				throw createDeadlineError(deadlineMs);
+			}
+			throw runnerFailed("create-failed", prepare.probe, caught);
+		}
+		if (verified.code !== 0) {
+			throw vendorFailed("create-failed", prepare.probe, verified);
+		}
+		parseRows(verified, [prepare.probe]);
+	};
+	const ensurePreparedOnce = (
+		context: CliDriverContext,
+		remaining: () => number,
+		deadlineMs: number,
+		signal?: AbortSignal,
+	): Promise<void> => {
+		if (spec.prepare === undefined) return Promise.resolve();
+		if (context.prepare === true) {
+			if (signal?.aborted) return Promise.reject(new CliRunAbortedError(signal.reason));
+			return remaining() < 1 ? Promise.reject(createDeadlineError(deadlineMs)) : Promise.resolve();
+		}
+		const budgetMs = remaining();
+		if (budgetMs < 1) return Promise.reject(createDeadlineError(deadlineMs));
+		let preparation = context.prepare;
+		if (preparation === undefined) {
+			// Preparation is driver-owned, not owned by whichever create happened to arrive first. Each
+			// control command retains its own hard bound; callers race the shared task below against their
+			// individual request budgets and cancellation signals.
+			const sharedBudgetMs = Math.min(Number.MAX_SAFE_INTEGER, spec.commandTimeoutMs * 3);
+			const sharedDeadline = performance.now() + sharedBudgetMs;
+			const cancellation = new AbortController();
+			const waiters = new Set<symbol>();
+			let state!: CliPreparationInFlight;
+			state = {
+				cancellation,
+				waiters,
+				promise: ensurePrepared(
+					() => Math.max(0, sharedDeadline - performance.now()),
+					sharedBudgetMs,
+					cancellation.signal,
+				).then(
+					() => {
+						if (context.prepare === state) context.prepare = true;
+					},
+					(caught: unknown) => {
+						if (context.prepare === state) context.prepare = undefined;
+						throw caught;
+					},
+				),
+			};
+			context.prepare = state;
+			preparation = state;
+		}
+		if (preparation.cancellation.signal.aborted) {
+			// The previous last owner has canceled this task and is waiting for its runner to kill/reap.
+			// A new owner waits for that bounded drain under ITS budget, then transparently starts or
+			// joins the successor instead of inheriting the retired task's cancellation error.
+			let retirementTimer: ReturnType<typeof setTimeout> | undefined;
+			let unsubscribeRetirementAbort = () => {};
+			const retirementDeadline = new Promise<never>((_resolve, reject) => {
+				retirementTimer = setTimeout(() => reject(createDeadlineError(deadlineMs)), budgetMs);
+			});
+			const retirementAbort = new Promise<never>((_resolve, reject) => {
+				unsubscribeRetirementAbort = subscribeToAbort(signal, () =>
+					reject(new CliRunAbortedError(signal?.reason)),
+				);
+			});
+			const retired = preparation.promise.then(
+				() => undefined,
+				() => undefined,
+			);
+			return Promise.race([retired, retirementDeadline, retirementAbort])
+				.finally(() => {
+					if (retirementTimer !== undefined) clearTimeout(retirementTimer);
+					unsubscribeRetirementAbort();
+				})
+				.then(() => ensurePreparedOnce(context, remaining, deadlineMs, signal));
+		}
+
+		const waiter = Symbol("cli-prepare-waiter");
+		preparation.waiters.add(waiter);
+		let timer: ReturnType<typeof setTimeout> | undefined;
+		let unsubscribeAbort = () => {};
+		const ownDeadline = new Promise<never>((_resolve, reject) => {
+			timer = setTimeout(() => reject(createDeadlineError(deadlineMs)), budgetMs);
+		});
+		const ownAbort = new Promise<never>((_resolve, reject) => {
+			unsubscribeAbort = subscribeToAbort(signal, () =>
+				reject(new CliRunAbortedError(signal?.reason)),
+			);
+		});
+		return Promise.race([preparation.promise, ownDeadline, ownAbort])
+			.then(() => {
+				// Like readiness polling, do not accept a completion that landed after its budget but
+				// before the timer callback got a turn.
+				if (signal?.aborted) throw new CliRunAbortedError(signal.reason);
+				if (remaining() < 1) throw createDeadlineError(deadlineMs);
+			})
+			.finally(() => {
+				if (timer !== undefined) clearTimeout(timer);
+				unsubscribeAbort();
+				preparation.waiters.delete(waiter);
+				if (preparation.waiters.size === 0 && context.prepare === preparation) {
+					preparation.cancellation.abort(
+						new Error(`${provider} CLI preparation has no remaining create owner`),
+					);
+					// The last owner does not return until the runner honors cancellation and has reaped
+					// its subprocess. `finally` preserves the caller's own timeout/abort error afterward.
+					return preparation.promise.then(
+						() => undefined,
+						() => undefined,
+					);
+				}
+			});
+	};
+
+	const matchesNotFound = (text: string): boolean =>
+		new RegExp(spec.notFound.source, spec.notFound.flags).test(text);
+
+	const parseSandboxId = (
+		raw: unknown,
+		ref?: SandboxRef,
+		diagnosticArgs: readonly (readonly string[])[] = [],
+	): string => {
+		const id = spec.sandboxId.parse(raw);
+		if (id instanceof type.errors) {
+			const summary = redactKnownDiagnostic(id.summary, diagnosticArgs);
+			throw new DriverError(
+				"invalid-sandbox-ref",
+				`${provider} CLI returned an invalid sandbox id: ${summary}`,
+				{ provider, ...(ref ? { ref } : {}) },
+			);
+		}
+		return id;
+	};
+	const sandboxIdOf = (row: Row, diagnosticArgs: readonly (readonly string[])[] = []): string =>
+		parseSandboxId(spec.sandboxId.fromRow(row), undefined, diagnosticArgs);
+	const sandboxIdFromRef = (ref: SandboxRef): string => {
+		if (ref.provider !== provider) {
+			throw new DriverError(
+				"invalid-sandbox-ref",
+				`${provider} driver cannot destroy a ${ref.provider} sandbox ref`,
+				{ provider, ref },
+			);
+		}
+		return parseSandboxId(ref.id, ref);
+	};
+
+	const destroyByArgs = async (
+		args: readonly string[],
+		options: {
+			readonly ref?: SandboxRef;
+			readonly timeoutMs?: number;
+			readonly diagnosticArgs?: readonly (readonly string[])[];
+			readonly signal?: AbortSignal;
+		} = {},
+	): Promise<
+		| { readonly status: "destroyed" }
+		| { readonly status: "not-found"; readonly result: CliRunResult }
+	> => {
+		const timeoutMs = options.timeoutMs ?? spec.commandTimeoutMs;
+		let result: CliRunResult;
+		try {
+			result = await call(args, timeoutMs, options.signal);
+		} catch (caught) {
+			throw runnerFailed("destroy-failed", args, caught, options.ref, options.diagnosticArgs);
+		}
+		const notFound = matchesNotFound(result.stderr) || matchesNotFound(result.stdout);
+		if (notFound) return { status: "not-found", result };
+		if (result.code !== 0) {
+			throw vendorFailed("destroy-failed", args, result, options.ref, options.diagnosticArgs);
+		}
+		return { status: "destroyed" };
+	};
+
+	return {
+		async create(context, request, operationOptions) {
+			const signal = operationOptions?.signal;
+			const name = `bench-${randomUUID()}`;
+			const deadlineMs = Math.min(
+				request.deadlineMs,
+				options.createAttemptCeilingMs ?? request.deadlineMs,
+			);
+			const boundedRequest =
+				deadlineMs === request.deadlineMs ? request : { ...request, deadlineMs };
+			const deadline = performance.now() + deadlineMs;
+			const remaining = (): number => Math.max(0, deadline - performance.now());
+			// Compile every argv that rollback may need before the first external side effect. A
+			// declarative callback bug is then allocation-safe and cannot discard the only locator.
+			let createArgs: readonly string[];
+			let cleanupArgs: readonly string[] | undefined;
+			try {
+				if (spec.cleanupCreated.kind === "command") {
+					cleanupArgs = spec.cleanupCreated.command(name);
+				}
+				createArgs = spec.create(boundedRequest, name);
+			} catch (caught) {
+				throw new DriverError(
+					"vendor-contract-violation",
+					`${provider} CLI argv builder threw before create`,
+					{ provider, cause: caught },
+				);
+			}
+			const attemptArgs: readonly (readonly string[])[] =
+				cleanupArgs === undefined
+					? [createArgs, spec.ready.poll]
+					: [createArgs, spec.ready.poll, cleanupArgs];
+			await ensurePreparedOnce(context, remaining, deadlineMs, signal);
+			try {
+				const createBudget = remaining();
+				if (createBudget < 1) throw createDeadlineError(deadlineMs);
+				const createCommandTimeoutMs = spec.createCommandTimeoutMs ?? spec.commandTimeoutMs;
+				let created: CliRunResult;
+				try {
+					created = await call(createArgs, Math.min(createBudget, createCommandTimeoutMs), signal);
+				} catch (caught) {
+					if (caught instanceof CliRunTimeoutError && createBudget <= createCommandTimeoutMs) {
+						throw createDeadlineError(deadlineMs);
+					}
+					throw runnerFailed("create-failed", createArgs, caught, undefined, attemptArgs);
+				}
+				if (created.code !== 0) {
+					throw vendorFailed("create-failed", createArgs, created, undefined, attemptArgs);
+				}
+
+				const pollBudget = remaining();
+				if (pollBudget < 1) throw createDeadlineError(deadlineMs);
+				// Reserve the tail of the attempt ceiling for failed-create reconciliation. Readiness polling
+				// would otherwise spend the entire budget, so a create that was remotely accepted but never
+				// became ready would skip its only in-line cleanup attempt and hand a possibly-billable
+				// allocation to the process-level owner. Never reserve more than half, so readiness keeps a
+				// usable window on short deadlines.
+				const reconciliationReserveMs = Math.min(spec.commandTimeoutMs, Math.floor(pollBudget / 2));
+				const readinessBudget = pollBudget - reconciliationReserveMs;
+				const readinessDeadline = performance.now() + readinessBudget;
+				const remainingReadiness = (): number => Math.max(0, readinessDeadline - performance.now());
+				let row: Row;
+				let activePoll: Promise<CliRunResult> | undefined;
+				try {
+					row = await pollUntilReady({
+						provider,
+						deadlineMs: readinessBudget,
+						intervalMs: spec.ready.pollIntervalMs ?? 1_000,
+						signal,
+						poll: async () => {
+							const probeBudget = remainingReadiness();
+							if (probeBudget < 1) throw createDeadlineError(deadlineMs);
+							let polled: CliRunResult;
+							try {
+								const running = call(
+									spec.ready.poll,
+									Math.min(probeBudget, spec.commandTimeoutMs),
+									signal,
+								);
+								activePoll = running;
+								try {
+									polled = await running;
+								} finally {
+									if (activePoll === running) activePoll = undefined;
+								}
+							} catch (caught) {
+								if (caught instanceof CliRunTimeoutError && probeBudget <= spec.commandTimeoutMs) {
+									throw createDeadlineError(deadlineMs);
+								}
+								throw runnerFailed(
+									"create-failed",
+									spec.ready.poll,
+									caught,
+									undefined,
+									attemptArgs,
+								);
+							}
+							if (polled.code !== 0) {
+								throw vendorFailed(
+									"create-failed",
+									spec.ready.poll,
+									polled,
+									undefined,
+									attemptArgs,
+								);
+							}
+							const rows = parseRows(polled, attemptArgs);
+							const row = spec.ready.select(rows, name);
+							if (row === null) return null;
+							const status = spec.ready.classify(row);
+							if (status === "ready") return row;
+							if (status === "pending") return null;
+							const detail = redactKnownDiagnostic(status.terminal.trim(), attemptArgs);
+							if (detail === "") {
+								throw new DriverError(
+									"vendor-contract-violation",
+									`${provider} CLI readiness terminal detail must not be empty`,
+									{ provider },
+								);
+							}
+							throw new DriverError(
+								"create-failed",
+								`${provider} sandbox entered a terminal state: ${detail}`,
+								{ provider, vendorMessage: detail },
+							);
+						},
+					});
+				} catch (caught) {
+					// pollUntilReady owns the request deadline, but the CLI runner owns subprocess
+					// termination. Never begin failed-create reconciliation until an active poll has
+					// honored cancellation/timeout and reaped its child.
+					const drainingPoll = activePoll;
+					if (drainingPoll !== undefined) {
+						await drainingPoll.then(
+							() => undefined,
+							() => undefined,
+						);
+					}
+					if (caught instanceof DriverError && caught.code === "readiness-timeout") {
+						throw createDeadlineError(deadlineMs);
+					}
+					throw caught;
+				}
+				return {
+					handle: row,
+					sandboxRef: sandboxRef(provider, sandboxIdOf(row, attemptArgs)),
+				};
+			} catch (primary) {
+				// A CLI can submit the allocation and still exit nonzero during a client-side
+				// post-check. Reconcile by the generated name after every failed create outcome;
+				// not-found tolerance makes this safe when nothing was allocated.
+				// An immediate not-found is ambiguous here: the create may have been remotely accepted but
+				// not reached the name index yet. Keep the generated name owned and retryable instead of
+				// treating transient absence as proof that no billable allocation exists.
+				let firstMissingAt: number | undefined;
+				type CleanupObservation =
+					| { readonly status: "destroyed" }
+					| {
+							readonly status: "absent";
+							readonly result: CliRunResult;
+							readonly args: readonly string[];
+							readonly diagnosticArgs: readonly (readonly string[])[];
+					  };
+				const observeCleanup = async (
+					timeoutMs: number,
+					signal?: AbortSignal,
+				): Promise<CleanupObservation> => {
+					const observationDeadline = performance.now() + timeoutMs;
+					const remainingObservation = (): number =>
+						Math.max(0, observationDeadline - performance.now());
+					if (spec.cleanupCreated.kind === "command") {
+						if (cleanupArgs === undefined) {
+							throw new DriverError(
+								"vendor-contract-violation",
+								`${provider} CLI cleanup command was not preflighted`,
+								{ provider },
+							);
+						}
+						const outcome = await destroyByArgs(cleanupArgs, {
+							timeoutMs: remainingObservation(),
+							diagnosticArgs: attemptArgs,
+							signal,
+						});
+						return outcome.status === "destroyed"
+							? outcome
+							: {
+									status: "absent",
+									result: outcome.result,
+									args: cleanupArgs,
+									diagnosticArgs: attemptArgs,
+								};
+					}
+
+					let listed: CliRunResult;
+					try {
+						listed = await call(spec.ready.poll, remainingObservation(), signal);
+					} catch (caught) {
+						throw runnerFailed("destroy-failed", spec.ready.poll, caught, undefined, attemptArgs);
+					}
+					if (listed.code !== 0) {
+						throw vendorFailed("destroy-failed", spec.ready.poll, listed, undefined, attemptArgs);
+					}
+					const rows = parseRows(listed, attemptArgs);
+					let row: Row | null;
+					try {
+						row = spec.cleanupCreated.select(rows, name);
+					} catch (caught) {
+						throw new DriverError(
+							"vendor-contract-violation",
+							`${provider} failed-create lookup selector threw`,
+							{ provider, cause: caught },
+						);
+					}
+					if (row === null) {
+						return {
+							status: "absent",
+							result: listed,
+							args: spec.ready.poll,
+							diagnosticArgs: attemptArgs,
+						};
+					}
+					// A positive name lookup contradicts every older absence observation. If the
+					// following id-addressed delete reports not-found, it starts a fresh horizon.
+					firstMissingAt = undefined;
+
+					const id = sandboxIdOf(row, attemptArgs);
+					let destroyArgs: readonly string[];
+					try {
+						destroyArgs = spec.destroy(id);
+					} catch (caught) {
+						throw new DriverError(
+							"vendor-contract-violation",
+							`${provider} destroy argv builder threw during failed-create recovery`,
+							{ provider, cause: caught },
+						);
+					}
+					const destroyBudget = remainingObservation();
+					if (destroyBudget < 1) {
+						throw new DriverError(
+							"destroy-failed",
+							`${provider} failed-create lookup spent its cleanup attempt budget`,
+							{ provider },
+						);
+					}
+					const destroyDiagnosticArgs = [...attemptArgs, destroyArgs];
+					const destroyed = await destroyByArgs(destroyArgs, {
+						timeoutMs: destroyBudget,
+						diagnosticArgs: destroyDiagnosticArgs,
+						signal,
+					});
+					return destroyed.status === "destroyed"
+						? destroyed
+						: {
+								status: "absent",
+								result: destroyed.result,
+								args: destroyArgs,
+								diagnosticArgs: destroyDiagnosticArgs,
+							};
+				};
+				const retryCleanup = async (
+					timeoutMs = spec.commandTimeoutMs,
+					signal?: AbortSignal,
+				): Promise<void> => {
+					if (signal?.aborted) throw new CliRunAbortedError(signal.reason);
+					const attemptDeadline = performance.now() + timeoutMs;
+					const remainingAttempt = (): number => Math.max(0, attemptDeadline - performance.now());
+					const initialBudget = remainingAttempt();
+					if (initialBudget < 1) {
+						throw new DriverError(
+							"destroy-failed",
+							`${provider} failed-create cleanup attempt budget was exhausted`,
+							{ provider },
+						);
+					}
+					let outcome = await observeCleanup(initialBudget, signal);
+					if (outcome.status === "destroyed") return;
+
+					const observedAt = performance.now();
+					if (
+						firstMissingAt !== undefined &&
+						observedAt - firstMissingAt >= spec.cleanupCreated.absenceConfirmationMs
+					) {
+						return;
+					}
+					firstMissingAt ??= observedAt;
+
+					// The first absence can be an indexing race after remote acceptance. Re-observe
+					// only after the provider-declared convergence horizon; if this attempt cannot
+					// afford that wait, retain ownership for the process-level cleanup owner.
+					const confirmationAt = firstMissingAt + spec.cleanupCreated.absenceConfirmationMs;
+					const waitMs = Math.max(0, confirmationAt - performance.now());
+					const waitDurationMs = Math.ceil(waitMs);
+					if (remainingAttempt() <= waitDurationMs) {
+						throw vendorFailed(
+							"destroy-failed",
+							outcome.args,
+							outcome.result,
+							undefined,
+							outcome.diagnosticArgs,
+						);
+					}
+					if (waitDurationMs > 0) await abortableDelay(waitDurationMs, signal);
+
+					const confirmationBudget = remainingAttempt();
+					if (confirmationBudget < 1) {
+						throw vendorFailed(
+							"destroy-failed",
+							outcome.args,
+							outcome.result,
+							undefined,
+							outcome.diagnosticArgs,
+						);
+					}
+					outcome = await observeCleanup(confirmationBudget, signal);
+					if (outcome.status === "destroyed") return;
+					if (performance.now() - firstMissingAt >= spec.cleanupCreated.absenceConfirmationMs)
+						return;
+					throw vendorFailed(
+						"destroy-failed",
+						outcome.args,
+						outcome.result,
+						undefined,
+						outcome.diagnosticArgs,
+					);
+				};
+				let cleanupError: unknown;
+				const cleanupBudget = remaining();
+				if (signal?.aborted) {
+					cleanupError = new DriverError(
+						"destroy-failed",
+						`${provider} failed-create cleanup was handed to the process owner after cancellation`,
+						{ provider },
+					);
+				} else if (cleanupBudget < 1) {
+					cleanupError = new DriverError(
+						"destroy-failed",
+						`${provider} failed-create cleanup was deferred because the request deadline was exhausted`,
+						{ provider },
+					);
+				} else {
+					try {
+						await retryCleanup(Math.min(cleanupBudget, spec.commandTimeoutMs), signal);
+					} catch (caught) {
+						cleanupError = caught;
+					}
+				}
+				if (cleanupError !== undefined) {
+					throw new FailedCreateCleanupError(cleanupError, primary, {
+						provider,
+						locator: { kind: "name", value: name },
+						cleanup: (cleanupOptions: DriverOperationOptions = {}) =>
+							retryCleanup(spec.commandTimeoutMs, cleanupOptions.signal),
+					});
+				}
+				throw primary;
+			}
+		},
+		async exec(_ctx, row, command): Promise<ExecResult> {
+			const started = Date.now();
+			const args = spec.exec(sandboxIdOf(row), command);
+			let result: CliRunResult;
+			try {
+				result = await call(args);
+			} catch (caught) {
+				throw runnerFailed("exec-failed", args, caught);
+			}
+			return {
+				exit: { kind: "exited", code: result.code },
+				stdout: result.stdout,
+				stderr: result.stderr,
+				durationMs: Date.now() - started,
+				truncated: false, // the kit applies caps centrally (table.ts / output.ts)
+			};
+		},
+		destroy: async (_ctx, row, operationOptions) => {
+			await destroyByArgs(spec.destroy(sandboxIdOf(row)), {
+				signal: operationOptions?.signal,
+			});
+		},
+		// CLI vendors get bare-ref reaping for free: the destroy argv only needs the id, and
+		// notFound tolerance already makes it idempotent.
+		destroyById: async (_ctx, ref, operationOptions) => {
+			await destroyByArgs(spec.destroy(sandboxIdFromRef(ref)), {
+				ref,
+				signal: operationOptions?.signal,
+			});
+		},
+		// No files, no launch: absent, not stubbed — the harness fallbacks (shell.ts) cover both.
+	};
+}
+
+function cliDriver<Row>(
+	provider: ProviderId,
+	spec: CliSpec<Row>,
+	options: CliDriverOptions = {},
+): SandboxDriver<Row> {
+	return driverFromTable(cliMethodTable(provider, spec, options), async () => ({}));
+}
+
+/**
+ * Define one CLI-only provider from its registry id and declarative table.
+ *
+ * Unlike assembling `defineDriver` and a generic driver by hand, this makes both load-bearing
+ * invariants structural: the provider id has one literal source, and CLI creates always retain
+ * ownership through their driver-controlled attempt ceiling.
+ */
+export function defineCliDriver<P extends ProviderId, Row>(
+	id: P,
+	module: CliDriverModuleSpec<NoInfer<P>, Row>,
+): DriverModule<P, Row> {
+	if (!Number.isSafeInteger(module.createAttemptCeilingMs) || module.createAttemptCeilingMs <= 0) {
+		throw new DriverError(
+			"vendor-contract-violation",
+			`createAttemptCeilingMs must be a positive safe integer, received ${String(module.createAttemptCeilingMs)}`,
+			{ provider: id },
+		);
+	}
+	return defineDriver(id, {
+		createBudget: { owner: "driver", attemptCeilingMs: module.createAttemptCeilingMs },
+		driver: (context) =>
+			cliDriver(id, module.spec(context), {
+				createAttemptCeilingMs: module.createAttemptCeilingMs,
+			}),
+	});
+}

--- a/packages/driver/src/index.ts
+++ b/packages/driver/src/index.ts
@@ -15,14 +15,25 @@ export type {
 } from "./lib/define.ts";
 export { defineDriver } from "./lib/define.ts";
 
-export type { DriverErrorCode, DriverErrorFields } from "./lib/errors.ts";
-export { DriverError, isDriverError } from "./lib/errors.ts";
+export type {
+	DriverErrorCode,
+	DriverErrorFields,
+	FailedCreateCleanupErrorOptions,
+	FailedCreateRecovery,
+} from "./lib/errors.ts";
+export {
+	DriverError,
+	FailedCreateCleanupError,
+	isDriverError,
+	isFailedCreateCleanupError,
+} from "./lib/errors.ts";
 export type { ReadinessStrategy } from "./lib/poll.ts";
 export { pollUntilReady } from "./lib/poll.ts";
 export type {
 	ControlPlaneProbes,
 	CreateBudget,
 	CreateRequest,
+	DriverOperationOptions,
 	ExecOptions,
 	ExecResult,
 	Exit,

--- a/packages/driver/src/lib/errors.ts
+++ b/packages/driver/src/lib/errors.ts
@@ -5,7 +5,7 @@
 // invalid-input-vs-vendor decisions read a field, never a regex over a formatted message.
 
 import type { ProviderId } from "@sandbox-benchmarks/schema/provider-ids";
-import type { SandboxRef } from "./port.ts";
+import type { DriverOperationOptions, SandboxRef } from "./port.ts";
 
 /**
  * What went wrong, in terms of what the caller may do next:
@@ -40,10 +40,97 @@ export type DriverErrorCode =
 export interface DriverErrorFields {
 	readonly provider?: ProviderId;
 	readonly ref?: SandboxRef;
-	/** Raw vendor stderr/detail — the field retry heuristics match, never the formatted message. */
+	/** Raw vendor diagnostic/detail — the field retry heuristics match, never the formatted message. */
 	readonly vendorMessage?: string;
 	readonly vendorExitCode?: number;
 	readonly cause?: unknown;
+}
+
+/** A stable locator for an allocation whose create failed before a session could be returned. */
+export interface FailedCreateRecovery {
+	readonly provider: ProviderId;
+	readonly locator: {
+		readonly kind: "name" | "id";
+		readonly value: string;
+	};
+}
+
+export interface FailedCreateCleanupErrorOptions extends FailedCreateRecovery {
+	/** Idempotent, convergent retry for the allocation named by {@link locator}. */
+	readonly cleanup: (options?: DriverOperationOptions) => Promise<void>;
+}
+
+/**
+ * A create/rollback double fault that still owns a retryable cleanup record.
+ *
+ * `SuppressedError` preserves both failures in the same order as `await using`: `error` is the
+ * cleanup failure and `suppressed` is the original create failure. Implementing the standard
+ * async-disposal protocol lets a process-level owner retain this rejected create without taking a
+ * dependency on a particular driver implementation. Cleanup is shared, retryable after failure,
+ * and becomes an idempotent no-op after the first confirmed success.
+ */
+export class FailedCreateCleanupError extends SuppressedError implements AsyncDisposable {
+	readonly code = "failed-create-cleanup" as const;
+	readonly provider: ProviderId;
+	readonly locator: FailedCreateRecovery["locator"];
+	readonly #cleanup: (options?: DriverOperationOptions) => Promise<void>;
+	#cleanupInFlight: Promise<void> | undefined;
+	#cleanupAbort: AbortController | undefined;
+	#abortUnlinks: Array<() => void> = [];
+	#cleaned = false;
+
+	constructor(
+		cleanupError: unknown,
+		createError: unknown,
+		options: FailedCreateCleanupErrorOptions,
+	) {
+		super(
+			cleanupError,
+			createError,
+			`failed to clean up ${options.provider} sandbox by ${options.locator.kind} ${options.locator.value} after create failure`,
+		);
+		this.name = "FailedCreateCleanupError";
+		this.provider = options.provider;
+		this.locator = Object.freeze({ ...options.locator });
+		this.#cleanup = options.cleanup;
+	}
+
+	cleanup(options: DriverOperationOptions = {}): Promise<void> {
+		if (this.#cleaned) return Promise.resolve();
+		if (this.#cleanupInFlight !== undefined) {
+			this.#forwardAbort(options.signal);
+			return this.#cleanupInFlight;
+		}
+
+		this.#cleanupAbort = new AbortController();
+		this.#forwardAbort(options.signal);
+		const attempt = Promise.resolve()
+			.then(() => this.#cleanup({ signal: this.#cleanupAbort?.signal }))
+			.then(() => {
+				this.#cleaned = true;
+			})
+			.finally(() => {
+				for (const unlink of this.#abortUnlinks) unlink();
+				this.#abortUnlinks = [];
+				this.#cleanupAbort = undefined;
+				this.#cleanupInFlight = undefined;
+			});
+		this.#cleanupInFlight = attempt;
+		return attempt;
+	}
+
+	#forwardAbort(signal: AbortSignal | undefined): void {
+		const controller = this.#cleanupAbort;
+		if (signal === undefined || controller === undefined) return;
+		const abort = () => controller.abort(signal.reason);
+		signal.addEventListener("abort", abort, { once: true });
+		this.#abortUnlinks.push(() => signal.removeEventListener("abort", abort));
+		if (signal.aborted) abort();
+	}
+
+	[Symbol.asyncDispose](): Promise<void> {
+		return this.cleanup();
+	}
 }
 
 export class DriverError extends Error {
@@ -65,3 +152,6 @@ export class DriverError extends Error {
 }
 
 export const isDriverError = (value: unknown): value is DriverError => value instanceof DriverError;
+
+export const isFailedCreateCleanupError = (value: unknown): value is FailedCreateCleanupError =>
+	value instanceof FailedCreateCleanupError;

--- a/packages/driver/src/lib/poll.test.ts
+++ b/packages/driver/src/lib/poll.test.ts
@@ -44,4 +44,40 @@ describe("pollUntilReady", () => {
 		).rejects.toMatchObject({ code: "readiness-timeout" });
 		expect(Date.now() - started).toBeLessThan(100);
 	});
+
+	test("cancels an interval sleep without starting another probe", async () => {
+		const cancellation = new AbortController();
+		let polls = 0;
+		const polling = pollUntilReady({
+			provider: "tama",
+			deadlineMs: 10_000,
+			intervalMs: 5_000,
+			signal: cancellation.signal,
+			poll: async () => {
+				polls++;
+				return null;
+			},
+		});
+		await delay(5);
+		const reason = new Error("shutdown");
+		cancellation.abort(reason);
+		await expect(polling).rejects.toBe(reason);
+		expect(polls).toBe(1);
+	});
+
+	test("subscribes before a poll can synchronously abort", async () => {
+		const cancellation = new AbortController();
+		const reason = new Error("synchronous shutdown");
+		const polling = pollUntilReady({
+			provider: "tama",
+			deadlineMs: 1_000,
+			intervalMs: 1,
+			signal: cancellation.signal,
+			poll: () => {
+				cancellation.abort(reason);
+				return new Promise<null>(() => {});
+			},
+		});
+		await expect(polling).rejects.toBe(reason);
+	});
 });

--- a/packages/driver/src/lib/poll.ts
+++ b/packages/driver/src/lib/poll.ts
@@ -12,6 +12,40 @@ export interface ReadinessStrategy<T> {
 	poll(): Promise<T | null>;
 	readonly deadlineMs: number;
 	readonly intervalMs: number;
+	readonly signal?: AbortSignal;
+}
+
+function abortReason(signal: AbortSignal): unknown {
+	return signal.reason ?? new Error("Readiness polling aborted");
+}
+
+function subscribeToAbort(signal: AbortSignal | undefined, listener: () => void): () => void {
+	if (signal === undefined) return () => {};
+	signal.addEventListener("abort", listener, { once: true });
+	if (signal.aborted) {
+		signal.removeEventListener("abort", listener);
+		listener();
+		return () => {};
+	}
+	return () => signal.removeEventListener("abort", listener);
+}
+
+function abortableDelay(ms: number, signal?: AbortSignal): Promise<void> {
+	if (signal?.aborted) return Promise.reject(abortReason(signal));
+	return new Promise((resolve, reject) => {
+		let unsubscribe = () => {};
+		const timer = setTimeout(done, ms);
+		function done(): void {
+			unsubscribe();
+			resolve();
+		}
+		function aborted(): void {
+			clearTimeout(timer);
+			unsubscribe();
+			if (signal !== undefined) reject(abortReason(signal));
+		}
+		unsubscribe = subscribeToAbort(signal, aborted);
+	});
 }
 
 function timeoutError(strategy: ReadinessStrategy<unknown>): DriverError {
@@ -23,22 +57,36 @@ function timeoutError(strategy: ReadinessStrategy<unknown>): DriverError {
 }
 
 async function pollBefore<T>(strategy: ReadinessStrategy<T>, deadline: number): Promise<T | null> {
+	if (strategy.signal?.aborted) throw abortReason(strategy.signal);
 	const remaining = deadline - Date.now();
 	if (remaining <= 0) throw timeoutError(strategy);
 
 	let timeout: ReturnType<typeof setTimeout> | undefined;
+	let unsubscribeAbort = () => {};
 	try {
-		const ready = await Promise.race([
-			strategy.poll(),
+		const attempts: Array<Promise<T | null>> = [];
+		if (strategy.signal !== undefined)
+			attempts.push(
+				new Promise<never>((_resolve, reject) => {
+					unsubscribeAbort = subscribeToAbort(strategy.signal, () =>
+						reject(abortReason(strategy.signal as AbortSignal)),
+					);
+				}),
+			);
+		// Subscribe before invoking provider code: a synchronous poll implementation may abort.
+		attempts.push(
+			Promise.resolve().then(() => strategy.poll()),
 			new Promise<never>((_resolve, reject) => {
 				timeout = setTimeout(() => reject(timeoutError(strategy)), remaining);
 			}),
-		]);
+		);
+		const ready = await Promise.race(attempts);
 		// A probe can resolve after its budget but before the timer callback gets a turn.
 		if (Date.now() >= deadline) throw timeoutError(strategy);
 		return ready;
 	} finally {
 		if (timeout !== undefined) clearTimeout(timeout);
+		unsubscribeAbort();
 	}
 }
 
@@ -56,6 +104,6 @@ export async function pollUntilReady<T>(strategy: ReadinessStrategy<T>): Promise
 		}
 		const remaining = deadline - Date.now();
 		if (remaining <= 0) throw timeoutError(strategy);
-		await new Promise((resolve) => setTimeout(resolve, Math.min(strategy.intervalMs, remaining)));
+		await abortableDelay(Math.min(strategy.intervalMs, remaining), strategy.signal);
 	}
 }

--- a/packages/driver/src/lib/port.ts
+++ b/packages/driver/src/lib/port.ts
@@ -52,6 +52,11 @@ export interface ExecOptions {
 	readonly maxOutputBytes?: number;
 }
 
+/** Cooperative cancellation for process-owned create/destroy operations. */
+export interface DriverOperationOptions {
+	readonly signal?: AbortSignal;
+}
+
 /* --------------------------------- Create requests --------------------------------- */
 
 export interface GpuSpec {
@@ -87,7 +92,7 @@ export interface SandboxSession<Handle = unknown> {
 	readonly artifact: ResolvedArtifact;
 	readonly native: Handle;
 	exec(command: string, options?: ExecOptions): Promise<ExecResult>;
-	destroy(): Promise<void>;
+	destroy(options?: DriverOperationOptions): Promise<void>;
 	readonly files?: SandboxFiles;
 	launch?(command: string, options?: ExecOptions): Promise<void>;
 }
@@ -109,8 +114,8 @@ export interface SnapshotCapability<Handle = unknown> {
 }
 
 export interface SandboxDriver<Handle = unknown> {
-	create(request: CreateRequest): Promise<SandboxSession<Handle>>;
-	destroyById?(ref: SandboxRef): Promise<void>;
+	create(request: CreateRequest, options?: DriverOperationOptions): Promise<SandboxSession<Handle>>;
+	destroyById?(ref: SandboxRef, options?: DriverOperationOptions): Promise<void>;
 	readonly probes?: ControlPlaneProbes;
 	readonly snapshots?: SnapshotCapability<Handle>;
 }

--- a/packages/driver/src/lib/table.test.ts
+++ b/packages/driver/src/lib/table.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { DriverError } from "./errors.ts";
+import { DriverError, FailedCreateCleanupError } from "./errors.ts";
 import type { CreateRequest } from "./port.ts";
 import { sandboxRef } from "./port.ts";
 import { okExec } from "./session.fixture.ts";
@@ -19,6 +19,36 @@ const baseTable: MethodTable<string, null> = {
 };
 
 describe("driverFromTable", () => {
+	test("a later owner signal cancels an already-running failed-create cleanup", async () => {
+		let attempts = 0;
+		const failure = new FailedCreateCleanupError(
+			new Error("initial cleanup failed"),
+			new Error("create failed"),
+			{
+				provider: "tama",
+				locator: { kind: "name", value: "bench-cancel" },
+				cleanup: async ({ signal } = {}) => {
+					attempts++;
+					if (attempts > 1) return;
+					await new Promise<never>((_resolve, reject) => {
+						const aborted = () => reject(signal?.reason);
+						if (signal?.aborted) aborted();
+						else signal?.addEventListener("abort", aborted, { once: true });
+					});
+				},
+			},
+		);
+		const first = failure.cleanup();
+		const cancellation = new AbortController();
+		const joined = failure.cleanup({ signal: cancellation.signal });
+		const reason = new Error("shutdown deadline");
+		cancellation.abort(reason);
+		await expect(first).rejects.toBe(reason);
+		await expect(joined).rejects.toBe(reason);
+		await failure.cleanup();
+		expect(attempts).toBe(2);
+	});
+
 	test("assembles a session over the table with the request's tagged artifact", async () => {
 		const driver = driverFromTable(baseTable, async () => null);
 		const session = await driver.create(request);
@@ -27,6 +57,39 @@ describe("driverFromTable", () => {
 		expect(session.native).toBe("h");
 		expect(session.files).toBeUndefined();
 		expect(session.launch).toBeUndefined();
+	});
+
+	test("forwards cooperative cancellation to create, session destroy, and bare-ref destroy", async () => {
+		const createCancellation = new AbortController();
+		const destroyCancellation = new AbortController();
+		const bareCancellation = new AbortController();
+		const observed: AbortSignal[] = [];
+		const driver = driverFromTable(
+			{
+				...baseTable,
+				create: async (_ctx, _request, options) => {
+					if (options?.signal) observed.push(options.signal);
+					return { handle: "h", sandboxRef: sandboxRef("tama", "m-cancel") };
+				},
+				destroy: async (_ctx, _handle, options) => {
+					if (options?.signal) observed.push(options.signal);
+				},
+				destroyById: async (_ctx, _ref, options) => {
+					if (options?.signal) observed.push(options.signal);
+				},
+			},
+			async () => null,
+		);
+		const session = await driver.create(request, { signal: createCancellation.signal });
+		await session.destroy({ signal: destroyCancellation.signal });
+		await driver.destroyById?.(sandboxRef("tama", "m-cancel"), {
+			signal: bareCancellation.signal,
+		});
+		expect(observed).toEqual([
+			createCancellation.signal,
+			destroyCancellation.signal,
+			bareCancellation.signal,
+		]);
 	});
 
 	test("a transient context failure is retried, not memoized forever", async () => {
@@ -65,7 +128,14 @@ describe("driverFromTable", () => {
 		expect(destroyed).toBe(1);
 	});
 
-	test("a mismatch whose orphan teardown ALSO fails preserves the mismatch as SuppressedError", async () => {
+	test("a mismatch whose orphan teardown fails retains retryable process ownership", async () => {
+		let destroys = 0;
+		let initialSignal: AbortSignal | undefined;
+		let retrySignal: AbortSignal | undefined;
+		let noteRetryStarted!: () => void;
+		const retryStarted = new Promise<void>((resolve) => {
+			noteRetryStarted = resolve;
+		});
 		const driver = driverFromTable(
 			{
 				...baseTable,
@@ -74,18 +144,40 @@ describe("driverFromTable", () => {
 					sandboxRef: sandboxRef("tama", "m-2"),
 					artifact: { kind: "image" as const, ref: "im-OTHER" },
 				}),
-				destroy: async () => {
-					throw new Error("teardown exploded");
+				destroy: async (_ctx, _handle, options) => {
+					destroys++;
+					if (destroys === 1) {
+						initialSignal = options?.signal;
+						throw new Error("teardown exploded");
+					}
+					retrySignal = options?.signal;
+					noteRetryStarted();
+					await new Promise<void>((resolve) => {
+						if (options?.signal?.aborted) resolve();
+						else options?.signal?.addEventListener("abort", () => resolve(), { once: true });
+					});
 				},
 			},
 			async () => null,
 		);
+		const createCancellation = new AbortController();
 		const error = (await driver
-			.create(request)
-			.catch((caught: unknown) => caught)) as SuppressedError;
-		expect(error).toBeInstanceOf(SuppressedError);
+			.create(request, { signal: createCancellation.signal })
+			.catch((caught: unknown) => caught)) as FailedCreateCleanupError;
+		expect(error).toBeInstanceOf(FailedCreateCleanupError);
 		expect(String(error.error)).toContain("teardown exploded");
 		expect((error.suppressed as DriverError).code).toBe("artifact-mismatch");
+		expect(error.locator).toEqual({ kind: "id", value: "m-2" });
+		expect(initialSignal).toBe(createCancellation.signal);
+		const cancellation = new AbortController();
+		const cleanup = error.cleanup({ signal: cancellation.signal });
+		await retryStarted;
+		const cancellationReason = new Error("shutdown deadline");
+		cancellation.abort(cancellationReason);
+		await cleanup;
+		expect(retrySignal?.aborted).toBe(true);
+		expect(retrySignal?.reason).toBe(cancellationReason);
+		expect(destroys).toBe(2);
 	});
 
 	test("a driver-reported ref that matches is recorded on the session", async () => {
@@ -328,6 +420,41 @@ describe("driverFromTable", () => {
 		expect(await concurrentFailure).toEqual(new Error("transient teardown failure"));
 
 		await session.destroy();
+		await session.destroy();
+		expect(destroys).toBe(2);
+	});
+
+	test("a later concurrent destroy signal cancels the shared provider teardown", async () => {
+		let destroys = 0;
+		let observedSignal: AbortSignal | undefined;
+		const driver = driverFromTable(
+			{
+				...baseTable,
+				destroy: async (_ctx, _handle, options) => {
+					destroys++;
+					observedSignal = options?.signal;
+					if (destroys > 1) return;
+					await new Promise<never>((_resolve, reject) => {
+						const aborted = () => reject(options?.signal?.reason);
+						if (options?.signal?.aborted) aborted();
+						else options?.signal?.addEventListener("abort", aborted, { once: true });
+					});
+				},
+			},
+			async () => null,
+		);
+		const session = await driver.create(request);
+		const first = session.destroy();
+		const cancellation = new AbortController();
+		const joined = session.destroy({ signal: cancellation.signal });
+		const firstFailure = first.catch((caught: unknown) => caught);
+		const joinedFailure = joined.catch((caught: unknown) => caught);
+		const reason = new Error("shutdown deadline");
+		cancellation.abort(reason);
+
+		expect(await firstFailure).toBe(reason);
+		expect(await joinedFailure).toBe(reason);
+		expect(observedSignal?.aborted).toBe(true);
 		await session.destroy();
 		expect(destroys).toBe(2);
 	});

--- a/packages/driver/src/lib/table.ts
+++ b/packages/driver/src/lib/table.ts
@@ -6,11 +6,12 @@
 // the use-after-destroy guard, artifact reconciliation, and the lazy-context memo. A driver that
 // bypassed this layer would have to re-implement all four; none do.
 
-import { DriverError } from "./errors.ts";
+import { DriverError, FailedCreateCleanupError } from "./errors.ts";
 import { capExecOutput, validateMaxOutputBytes } from "./output.ts";
 import type {
 	ControlPlaneProbes,
 	CreateRequest,
+	DriverOperationOptions,
 	ExecOptions,
 	ExecResult,
 	ResolvedArtifact,
@@ -32,6 +33,7 @@ export interface MethodTable<Handle, Ctx> {
 	create(
 		ctx: Ctx,
 		request: CreateRequest,
+		options?: DriverOperationOptions,
 	): Promise<{
 		readonly handle: Handle;
 		readonly sandboxRef: SandboxRef;
@@ -39,8 +41,8 @@ export interface MethodTable<Handle, Ctx> {
 	}>;
 	/** Run a command. Options are forwarded unchanged; the kit still enforces output caps. */
 	exec(ctx: Ctx, handle: Handle, command: string, options?: ExecOptions): Promise<ExecResult>;
-	destroy(ctx: Ctx, handle: Handle): Promise<void>;
-	destroyById?(ctx: Ctx, ref: SandboxRef): Promise<void>;
+	destroy(ctx: Ctx, handle: Handle, options?: DriverOperationOptions): Promise<void>;
+	destroyById?(ctx: Ctx, ref: SandboxRef, options?: DriverOperationOptions): Promise<void>;
 	launch?(ctx: Ctx, handle: Handle, command: string, options?: ExecOptions): Promise<void>;
 	readonly files?: {
 		readFile(ctx: Ctx, handle: Handle, path: string): Promise<string>;
@@ -171,9 +173,9 @@ export function driverFromTable<Handle, Ctx>(
 	const probeDescribe = tableProbes?.describe;
 	const tableSnapshots = table.snapshots;
 	return {
-		async create(request) {
+		async create(request, operationOptions) {
 			const resolved = await ctx();
-			const created = await table.create(resolved, request);
+			const created = await table.create(resolved, request, operationOptions);
 			const artifact = created.artifact ?? request.artifact;
 			if (!artifactsEqual(artifact, request.artifact)) {
 				const mismatch = new DriverError(
@@ -185,13 +187,13 @@ export function driverFromTable<Handle, Ctx>(
 				// mismatch (the primary, and the one naming the wrong-artifact boot). Same double-fault
 				// shape as withSessionTeardown.
 				try {
-					await table.destroy(resolved, created.handle);
+					await table.destroy(resolved, created.handle, operationOptions);
 				} catch (teardown) {
-					throw new SuppressedError(
-						teardown,
-						mismatch,
-						"orphan teardown failed after an artifact mismatch",
-					);
+					throw new FailedCreateCleanupError(teardown, mismatch, {
+						provider: created.sandboxRef.provider,
+						locator: { kind: "id", value: created.sandboxRef.id },
+						cleanup: (options = {}) => table.destroy(resolved, created.handle, options),
+					});
 				}
 				throw mismatch;
 			}
@@ -201,6 +203,8 @@ export function driverFromTable<Handle, Ctx>(
 			let destroyInFlight: Promise<void> | undefined;
 			let teardownInFlight: Promise<void> | undefined;
 			let teardownDrain: Promise<void> | undefined;
+			let teardownCancellation: AbortController | undefined;
+			let teardownAbortUnlinks: Array<() => void> = [];
 			let activeOperations = 0;
 			let operationsDrained: Promise<void> | undefined;
 			let resolveOperationsDrained: (() => void) | undefined;
@@ -239,20 +243,37 @@ export function driverFromTable<Handle, Ctx>(
 					}
 				});
 			};
-			const invokeDestroy = (): Promise<void> => {
+			const invokeDestroy = (options?: DriverOperationOptions): Promise<void> => {
 				try {
-					return Promise.resolve(table.destroy(resolved, handle));
+					return Promise.resolve(table.destroy(resolved, handle, options));
 				} catch (caught) {
 					return Promise.reject(caught);
 				}
 			};
-			const beginTeardown = (): Promise<void> => {
-				if (teardownInFlight !== undefined) return teardownInFlight;
+			const forwardTeardownCancellation = (signal: AbortSignal | undefined): void => {
+				const controller = teardownCancellation;
+				if (signal === undefined || controller === undefined) return;
+				const abort = () => controller.abort(signal.reason);
+				signal.addEventListener("abort", abort, { once: true });
+				teardownAbortUnlinks.push(() => signal.removeEventListener("abort", abort));
+				// Register before re-checking so an abort cannot win the check/listen edge.
+				if (signal.aborted) abort();
+			};
+			const beginTeardown = (options?: DriverOperationOptions): Promise<void> => {
+				if (teardownInFlight !== undefined) {
+					forwardTeardownCancellation(options?.signal);
+					return teardownInFlight;
+				}
 
 				state = "destroying";
 				teardownDrain = operationsDrained;
+				teardownCancellation = new AbortController();
+				forwardTeardownCancellation(options?.signal);
+				const providerOptions = { signal: teardownCancellation.signal };
 				const destroying =
-					teardownDrain === undefined ? invokeDestroy() : teardownDrain.then(invokeDestroy);
+					teardownDrain === undefined
+						? invokeDestroy(providerOptions)
+						: teardownDrain.then(() => invokeDestroy(providerOptions));
 				const teardown = destroying
 					.then(
 						() => {
@@ -264,6 +285,9 @@ export function driverFromTable<Handle, Ctx>(
 						},
 					)
 					.finally(() => {
+						for (const unlink of teardownAbortUnlinks) unlink();
+						teardownAbortUnlinks = [];
+						teardownCancellation = undefined;
 						teardownInFlight = undefined;
 						teardownDrain = undefined;
 					});
@@ -284,11 +308,14 @@ export function driverFromTable<Handle, Ctx>(
 							.exec(resolved, handle, command, options)
 							.then((result) => capExecOutput(result, maxOutputBytes));
 					}),
-				async destroy() {
+				async destroy(options?: DriverOperationOptions) {
 					if (state === "destroyed") return;
-					if (destroyInFlight !== undefined) return destroyInFlight;
+					if (destroyInFlight !== undefined) {
+						forwardTeardownCancellation(options?.signal);
+						return destroyInFlight;
+					}
 
-					const teardown = beginTeardown();
+					const teardown = beginTeardown(options);
 					const drain = teardownDrain;
 					const bounded =
 						drain === undefined
@@ -327,7 +354,10 @@ export function driverFromTable<Handle, Ctx>(
 			return session;
 		},
 		...(destroyById
-			? { destroyById: async (ref: SandboxRef) => destroyById(await ctx(), ref) }
+			? {
+					destroyById: async (ref: SandboxRef, options?: DriverOperationOptions) =>
+						destroyById(await ctx(), ref, options),
+				}
 			: {}),
 		...(tableProbes
 			? {

--- a/packages/harness/src/index.ts
+++ b/packages/harness/src/index.ts
@@ -58,6 +58,7 @@ export type {
 	MeasureLifecycleOptions,
 } from "./lib/lifecycle.ts";
 export { aggregateLifecycle, measureLifecycle } from "./lib/lifecycle.ts";
+export type { OwnedOperationOptions, OwnedSandboxOptions } from "./lib/sandbox-owner.ts";
 export {
 	createOwnedSandbox,
 	exitAfterSandboxCleanup,

--- a/packages/harness/src/lib/sandbox-owner.signal.fixture.ts
+++ b/packages/harness/src/lib/sandbox-owner.signal.fixture.ts
@@ -6,6 +6,55 @@ if (!logFile) throw new Error("missing signal fixture log path");
 const mode = process.argv[3] ?? "signal";
 let destroyAttempts = 0;
 
+if (mode === "pending") {
+	const pidFile = process.argv[4];
+	const aliveMarker = process.argv[5];
+	if (!pidFile || !aliveMarker) throw new Error("pending mode requires pid and marker paths");
+	const creation = createOwnedSandbox(
+		(signal) =>
+			new Promise<never>((_resolve, reject) => {
+				const child = Bun.spawn(
+					[
+						"/bin/sh",
+						"-c",
+						`echo $$ > ${JSON.stringify(pidFile)}; sleep 10; touch ${JSON.stringify(aliveMarker)}`,
+					],
+					{ stdout: "ignore", stderr: "ignore", detached: process.platform !== "win32" },
+				);
+				appendFileSync(logFile, "ready\n");
+				signal.addEventListener(
+					"abort",
+					() => {
+						void (async () => {
+							if (process.platform === "win32") {
+								child.kill("SIGKILL");
+							} else {
+								try {
+									process.kill(-child.pid, "SIGKILL");
+								} catch {
+									child.kill("SIGKILL");
+								}
+							}
+							await child.exited;
+							appendFileSync(logFile, "abort\n");
+							reject(
+								Object.assign(new Error("create aborted"), {
+									async [Symbol.asyncDispose]() {
+										appendFileSync(logFile, "cleanup\n");
+									},
+								}),
+							);
+						})();
+					},
+					{ once: true },
+				);
+			}),
+	);
+	await creation.catch(() => {});
+	setInterval(() => {}, 60_000);
+	await new Promise<never>(() => {});
+}
+
 const sandbox = await createOwnedSandbox(async () => ({
 	sandboxId: "sb-signal",
 	async destroy() {

--- a/packages/harness/src/lib/sandbox-owner.test.ts
+++ b/packages/harness/src/lib/sandbox-owner.test.ts
@@ -40,6 +40,26 @@ describe("sandbox process ownership", () => {
 		expect(await cleanupOwnedSandboxes()).toEqual([]);
 	});
 
+	it("forwards cancellation through the captured original destroy without wrapper recursion", async () => {
+		let rawDestroys = 0;
+		let observedSignal: AbortSignal | undefined;
+		const sandbox = await createOwnedSandbox(
+			async () => ({
+				sandboxId: "sb-original-destroy",
+				async destroy(options?: { signal?: AbortSignal }) {
+					rawDestroys++;
+					observedSignal = options?.signal;
+				},
+			}),
+			{ destroy: (providerDestroy, options) => providerDestroy(options) },
+		);
+
+		await sandbox.destroy();
+		expect(rawDestroys).toBe(1);
+		expect(observedSignal).toBeInstanceOf(AbortSignal);
+		expect(await cleanupOwnedSandboxes()).toEqual([]);
+	});
+
 	it("owns a create before it resolves and drains the late handle", async () => {
 		const creation = deferred<{ sandboxId: string; destroy(): Promise<void> }>();
 		let destroys = 0;
@@ -73,6 +93,24 @@ describe("sandbox process ownership", () => {
 		expect(destroys).toBe(2);
 	});
 
+	it("retains a rejected create carrying a retryable async cleanup record", async () => {
+		let cleanups = 0;
+		const createFailure = Object.assign(new Error("create and rollback failed"), {
+			async [Symbol.asyncDispose]() {
+				cleanups++;
+				if (cleanups === 1) throw new Error("transient rollback failure");
+			},
+		});
+
+		await expect(
+			createOwnedSandbox(async () => {
+				throw createFailure;
+			}),
+		).rejects.toBe(createFailure);
+		expect(await cleanupOwnedSandboxes({ attempts: 2, retryDelayMs: 1 })).toEqual([]);
+		expect(cleanups).toBe(2);
+	});
+
 	it("scopes a successful operation to one owned sandbox", async () => {
 		let destroys = 0;
 		const result = await withOwnedSandbox(
@@ -89,6 +127,27 @@ describe("sandbox process ownership", () => {
 		expect(result).toBe(42);
 		expect(destroys).toBe(1);
 		expect(await cleanupOwnedSandboxes()).toEqual([]);
+	});
+
+	it("withOwnedSandbox exposes create and destroy cancellation bridges", async () => {
+		let createSignal: AbortSignal | undefined;
+		let destroySignal: AbortSignal | undefined;
+		await withOwnedSandbox(
+			async (signal) => {
+				createSignal = signal;
+				return {
+					sandboxId: "sb-scoped-cancel",
+					async destroy(options?: { signal?: AbortSignal }) {
+						destroySignal = options?.signal;
+					},
+				};
+			},
+			async () => {},
+			"cancel-aware sandbox",
+			{ destroy: (providerDestroy, options) => providerDestroy(options) },
+		);
+		expect(createSignal).toBeInstanceOf(AbortSignal);
+		expect(destroySignal).toBeInstanceOf(AbortSignal);
 	});
 
 	it("preserves the operation error and retains a failed teardown for the exit drain", async () => {
@@ -125,6 +184,68 @@ describe("sandbox process ownership", () => {
 		await sandboxPromise;
 		expect(await cleanupOwnedSandboxes()).toEqual([]);
 	});
+
+	it("cancels an in-flight destroy before the cleanup deadline and can retry it", async () => {
+		let destroyAttempts = 0;
+		let observedAbort = false;
+		const sandbox = await createOwnedSandbox(
+			async () => ({ sandboxId: "sb-slow-destroy", async destroy() {} }),
+			{
+				destroy: async (_providerDestroy, { signal }) => {
+					destroyAttempts++;
+					if (destroyAttempts > 1) return;
+					await new Promise<never>((_resolve, reject) => {
+						const aborted = () => {
+							observedAbort = true;
+							reject(new Error("destroy aborted"));
+						};
+						if (signal?.aborted) aborted();
+						else signal?.addEventListener("abort", aborted, { once: true });
+					});
+				},
+			},
+		);
+		const inFlight = sandbox.destroy().catch(() => undefined);
+		const failures = await cleanupOwnedSandboxes({ attempts: 1, timeoutMs: 40 });
+		await inFlight;
+		expect(observedAbort).toBe(true);
+		expect(failures).toHaveLength(1);
+		expect(await cleanupOwnedSandboxes({ attempts: 1, timeoutMs: 40 })).toEqual([]);
+		expect(destroyAttempts).toBe(2);
+	});
+
+	it.skipIf(process.platform === "win32")(
+		"SIGTERM aborts a pending detached create and waits for its recovery record",
+		async () => {
+			const dir = mkdtempSync(join(tmpdir(), "sandbox-owner-pending-signal-"));
+			const logFile = join(dir, "lifecycle.log");
+			const pidFile = join(dir, "child.pid");
+			const aliveMarker = join(dir, "survived");
+			const fixture = join(import.meta.dir, "sandbox-owner.signal.fixture.ts");
+			const proc = Bun.spawn(["bun", fixture, logFile, "pending", pidFile, aliveMarker], {
+				stdout: "pipe",
+				stderr: "pipe",
+			});
+			try {
+				await waitForFile(logFile);
+				await waitForFile(pidFile);
+				const childPid = Number.parseInt(readFileSync(pidFile, "utf8"), 10);
+				proc.kill("SIGTERM");
+				expect(await proc.exited).toBe(143);
+				expect(readFileSync(logFile, "utf8").trim().split("\n")).toEqual([
+					"ready",
+					"abort",
+					"cleanup",
+				]);
+				expect(() => process.kill(childPid, 0)).toThrow();
+				await Bun.sleep(100);
+				expect(existsSync(aliveMarker)).toBe(false);
+			} finally {
+				proc.kill();
+				rmSync(dir, { recursive: true, force: true });
+			}
+		},
+	);
 
 	it("retries teardown before SIGTERM exits the process", async () => {
 		const dir = mkdtempSync(join(tmpdir(), "sandbox-owner-signal-"));

--- a/packages/harness/src/lib/sandbox-owner.ts
+++ b/packages/harness/src/lib/sandbox-owner.ts
@@ -15,9 +15,22 @@ interface DestroyableSandbox {
 	destroy(): Promise<unknown>;
 }
 
+export interface OwnedOperationOptions {
+	readonly signal?: AbortSignal;
+}
+
+export interface OwnedSandboxOptions {
+	/** Cancellation bridge over the captured original destroy method (never the owner wrapper). */
+	readonly destroy?: (
+		providerDestroy: (options?: OwnedOperationOptions) => Promise<unknown>,
+		options: OwnedOperationOptions,
+	) => Promise<unknown>;
+}
+
 interface OwnedEntry<T extends DestroyableSandbox> {
 	promise: Promise<T>;
-	destroy?: () => Promise<unknown>;
+	destroy?: (options?: OwnedOperationOptions) => Promise<unknown>;
+	abortCreate?: (reason: unknown) => void;
 	sandboxId?: string;
 }
 
@@ -59,14 +72,42 @@ function release(entry: OwnedEntry<DestroyableSandbox>): void {
 	if (owned.size === 0) uninstallProcessHandlers();
 }
 
-async function destroyEntry(entry: OwnedEntry<DestroyableSandbox>): Promise<void> {
+async function destroyEntry(
+	entry: OwnedEntry<DestroyableSandbox>,
+	options: OwnedOperationOptions,
+): Promise<void> {
 	try {
 		await entry.promise;
 	} catch {
-		// A rejected create allocated no handle and removes itself from the registry.
+		// A failed create can still own an allocation when its rollback also failed. Its rejection
+		// installs a retryable cleanup record below; an ordinary rejection has already been released.
+	}
+	await entry.destroy?.(options);
+}
+
+interface FailedCreateCleanup {
+	dispose(): Promise<void>;
+	cleanup?(options?: OwnedOperationOptions): Promise<void>;
+}
+
+function failedCreateCleanup(error: unknown): FailedCreateCleanup | undefined {
+	if ((typeof error !== "object" && typeof error !== "function") || error === null) return;
+	try {
+		const dispose = Reflect.get(error, Symbol.asyncDispose);
+		if (typeof dispose !== "function") return;
+		const cleanup = Reflect.get(error, "cleanup");
+		return {
+			dispose: () => Reflect.apply(dispose, error, []),
+			...(typeof cleanup === "function"
+				? {
+						cleanup: (options?: OwnedOperationOptions) => Reflect.apply(cleanup, error, [options]),
+					}
+				: {}),
+		};
+	} catch {
+		// Inspecting an arbitrary provider error must never replace the create failure itself.
 		return;
 	}
-	await entry.destroy?.();
 }
 
 function positiveInteger(value: number | undefined, fallback: number): number {
@@ -86,12 +127,25 @@ async function withinDeadline(
 		throw new Error(`Sandbox cleanup timed out${entry.sandboxId ? ` (${entry.sandboxId})` : ""}`);
 	}
 
-	let timer: ReturnType<typeof setTimeout> | undefined;
+	const cancellation = new AbortController();
+	const cancellationReason = new Error(
+		`Sandbox process ownership cleanup requested${entry.sandboxId ? ` (${entry.sandboxId})` : " during creation"}`,
+	);
+	entry.abortCreate?.(cancellationReason);
+	// Reserve a short tail of the existing budget for cancellation-aware runners to kill and reap
+	// their subprocess group before the hard observational deadline fires.
+	const settleGraceMs = Math.min(250, Math.max(1, Math.floor(remainingMs / 4)));
+	let abortTimer: ReturnType<typeof setTimeout> | undefined;
+	let deadlineTimer: ReturnType<typeof setTimeout> | undefined;
 	try {
+		abortTimer = setTimeout(
+			() => cancellation.abort(cancellationReason),
+			Math.max(0, remainingMs - settleGraceMs),
+		);
 		await Promise.race([
-			destroyEntry(entry),
+			destroyEntry(entry, { signal: cancellation.signal }),
 			new Promise<never>((_resolve, reject) => {
-				timer = setTimeout(
+				deadlineTimer = setTimeout(
 					() =>
 						reject(
 							new Error(
@@ -103,7 +157,8 @@ async function withinDeadline(
 			}),
 		]);
 	} finally {
-		if (timer !== undefined) clearTimeout(timer);
+		if (abortTimer !== undefined) clearTimeout(abortTimer);
+		if (deadlineTimer !== undefined) clearTimeout(deadlineTimer);
 	}
 }
 
@@ -202,33 +257,72 @@ function installProcessHandlers(): void {
  * the original SDK object (several SDKs use private fields); only `destroy` is replaced.
  */
 export function createOwnedSandbox<T extends DestroyableSandbox>(
-	create: () => Promise<T>,
+	create: (signal: AbortSignal) => Promise<T>,
+	options: OwnedSandboxOptions = {},
 ): Promise<T> {
 	if (stopping) return Promise.reject(new Error("Sandbox creation refused during shutdown"));
 
 	installProcessHandlers();
 	const entry = {} as OwnedEntry<T>;
+	const createCancellation = new AbortController();
+	entry.abortCreate = (reason) => createCancellation.abort(reason);
 	owned.add(entry as OwnedEntry<DestroyableSandbox>);
 
 	entry.promise = Promise.resolve()
-		.then(create)
+		.then(() => create(createCancellation.signal))
 		.then(
 			(sandbox) => {
 				entry.sandboxId = sandbox.sandboxId;
-				const providerDestroy = sandbox.destroy.bind(sandbox);
-				let destroying: Promise<unknown> | undefined;
-				const destroy = (): Promise<unknown> => {
-					if (destroying !== undefined) return destroying;
-					destroying = providerDestroy().then(
-						(value) => {
-							release(entry as OwnedEntry<DestroyableSandbox>);
-							return value;
-						},
-						(error) => {
-							destroying = undefined;
-							throw error;
-						},
+				const originalDestroy = sandbox.destroy;
+				const providerDestroy = (operationOptions?: OwnedOperationOptions): Promise<unknown> =>
+					Reflect.apply(
+						originalDestroy,
+						sandbox,
+						operationOptions === undefined ? [] : [operationOptions],
 					);
+				let destroying: Promise<unknown> | undefined;
+				let destroyCancellation: AbortController | undefined;
+				let unlinkDestroySignal: (() => void) | undefined;
+				const forwardDestroyCancellation = (signal: AbortSignal | undefined): void => {
+					const controller = destroyCancellation;
+					if (signal === undefined || controller === undefined) return;
+					const abort = () => controller.abort(signal.reason);
+					signal.addEventListener("abort", abort, { once: true });
+					const previous = unlinkDestroySignal;
+					unlinkDestroySignal = () => {
+						previous?.();
+						signal.removeEventListener("abort", abort);
+					};
+					if (signal.aborted) abort();
+				};
+				const destroy = (operationOptions: OwnedOperationOptions = {}): Promise<unknown> => {
+					if (destroying !== undefined) {
+						forwardDestroyCancellation(operationOptions.signal);
+						return destroying;
+					}
+					destroyCancellation = new AbortController();
+					forwardDestroyCancellation(operationOptions.signal);
+					destroying = Promise.resolve()
+						.then(() =>
+							options.destroy === undefined
+								? providerDestroy()
+								: options.destroy(providerDestroy, { signal: destroyCancellation?.signal }),
+						)
+						.then(
+							(value) => {
+								release(entry as OwnedEntry<DestroyableSandbox>);
+								return value;
+							},
+							(error) => {
+								destroying = undefined;
+								throw error;
+							},
+						)
+						.finally(() => {
+							unlinkDestroySignal?.();
+							unlinkDestroySignal = undefined;
+							destroyCancellation = undefined;
+						});
 					return destroying;
 				};
 				entry.destroy = destroy;
@@ -254,7 +348,36 @@ export function createOwnedSandbox<T extends DestroyableSandbox>(
 				}
 			},
 			(error) => {
-				release(entry as OwnedEntry<DestroyableSandbox>);
+				const recoverable = failedCreateCleanup(error);
+				if (recoverable === undefined) {
+					release(entry as OwnedEntry<DestroyableSandbox>);
+				} else {
+					let cleanupInFlight: Promise<unknown> | undefined;
+					entry.destroy = (operationOptions: OwnedOperationOptions = {}) => {
+						if (cleanupInFlight !== undefined) {
+							return recoverable.cleanup === undefined
+								? cleanupInFlight
+								: recoverable.cleanup(operationOptions);
+						}
+						cleanupInFlight = Promise.resolve()
+							.then(() =>
+								recoverable.cleanup === undefined
+									? recoverable.dispose()
+									: recoverable.cleanup(operationOptions),
+							)
+							.then(
+								(value) => {
+									release(entry as OwnedEntry<DestroyableSandbox>);
+									return value;
+								},
+								(caught) => {
+									cleanupInFlight = undefined;
+									throw caught;
+								},
+							);
+						return cleanupInFlight;
+					};
+				}
 				throw error;
 			},
 		);
@@ -292,11 +415,12 @@ export async function withCleanupPreservingPrimaryError<T>(
  * also failed for the bounded exit drain to retry.
  */
 export async function withOwnedSandbox<T extends DestroyableSandbox, R>(
-	create: () => Promise<T>,
+	create: (signal: AbortSignal) => Promise<T>,
 	fn: (sandbox: T) => Promise<R>,
 	label = "sandbox",
+	ownerOptions: OwnedSandboxOptions = {},
 ): Promise<R> {
-	const sandbox = await createOwnedSandbox(create);
+	const sandbox = await createOwnedSandbox(create, ownerOptions);
 	return withCleanupPreservingPrimaryError(
 		() => fn(sandbox),
 		() => sandbox.destroy(),


### PR DESCRIPTION
## What this adds

This PR adds `cliDriver`, the generic driver for providers whose control plane is a CLI. It is the first provider-authoring layer on top of the typed driver port and registry join delivered below it.

A CLI provider now supplies one `defineCliDriver(providerId, …)` call containing:

- an ArkType schema for vendor list output and a module-owned sandbox-ID schema;
- declarative argv builders for create, poll, exec, and destroy;
- profile probing, checked fallback authentication, and a parsed post-login probe before allocation;
- either direct name-addressed rollback or typed name→ID reconciliation for ambiguous creates;
- the provider's not-found grammar and hard create-attempt ceiling.

The helper derives the driver-owned budget from that single provider ID and compiles the table into the common `SandboxDriver`. Provider code no longer reimplements spawning, polling, structured errors, secret redaction, output caps, session lifecycle, bare-ref reaping, or failed-create ownership.

## Real CLI proof case

The ADR and executable fixture use Tama's installed CLI contract rather than invented flags:

1. probe the existing profile with `tama list --json`;
2. fall back to `tama login --token …` only when the profile is unusable;
3. run `tama new …` without a token flag;
4. after an ambiguous create, find the generated name in typed list output;
5. validate the module-owned machine ID and run `tama rm -y <id>`.

If lookup, parsing, ID validation, or removal cannot prove the allocation gone, the error retains the generated name and an async cleanup operation for the process owner to retry.

## Safety properties

- The complete subprocess exit + stdout/stderr drain is deadline-bounded.
- Unix timeout cleanup kills the detached process group, cancels inherited pipes, and awaits child reaping before rejection.
- Readiness cancellation joins the active poll runner before any failed-create reconciliation can start.
- Process shutdown cooperatively cancels pending create/destroy calls, then spends the remaining bounded window on retained failed-create reconciliation.
- Long create subprocesses have a distinct bound from short control-plane calls, both under the joined attempt ceiling.
- Create, preparation, readiness, and inline cleanup share one joined attempt deadline, and readiness stops short of it: a reconciliation tail (one command timeout, never more than half the readiness budget) is reserved out of the same ceiling so a create that never becomes ready still reclaims its allocation in-line instead of deferring a billable machine to the process owner.
- Successful profile preparation is memoized once per driver instance and stays outside measured cold starts; concurrent waiters keep independent deadlines/cancellation, and an ownerless attempt is killed/reaped before a healthy successor starts.
- Artifact-mismatch teardown double faults retain an ID-addressed async cleanup record instead of releasing a possible orphan.
- Failed-create absence requires observations separated by the provider-declared convergence horizon.
- Typed vendor readiness classification turns terminal rows into immediate structured failure + cleanup.
- Parser fields structurally require ArkType schemas; plain `JSON.parse`/identity functions fail typecheck.
- All preparation/create/poll/cleanup secret argv values are redacted transaction-wide, longest-first, from commands and vendor diagnostics.
- Provider-qualified bare refs and module-owned sandbox IDs are validated before destroy.

## Stack placement

This PR is based on #387 (`defineDriver` + exact environment slices). Its current lower stack is #394 → #395 → #396 → #397 → #387; #390 remains above it for the ComputeSDK bridge.

## Verification

- full monorepo typecheck, lint, spell, catalog-drift, and test gates;
- 10 consecutive CLI-driver test runs for timing-sensitive deadline cases;
- focused driver/table/process-owner tests;
- executable real-Tama contract, invalid-ID recovery, inherited-pipe, and child-reaping regressions.

