### PR TITLE
feat(driver): the ComputeSDK bridge as one driver among several

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -67,6 +67,36 @@
         "typescript": "catalog:",
       },
     },
+    "packages/drivers": {
+      "name": "@sandbox-benchmarks/drivers",
+      "version": "0.0.0",
+      "dependencies": {
+        "@blaxel/core": "catalog:computesdk",
+        "@computesdk/blaxel": "catalog:computesdk",
+        "@computesdk/daytona": "catalog:computesdk",
+        "@computesdk/e2b": "catalog:computesdk",
+        "@computesdk/modal": "catalog:computesdk",
+        "@computesdk/namespace": "catalog:computesdk",
+        "@computesdk/provider": "catalog:computesdk",
+        "@computesdk/runloop": "catalog:computesdk",
+        "@daytona/api-client": "catalog:computesdk",
+        "@daytona/sdk": "catalog:computesdk",
+        "@run-cloud/sdk": "catalog:computesdk",
+        "@runloop/api-client": "catalog:computesdk",
+        "@sandbox-benchmarks/driver": "workspace:*",
+        "@vercel/sandbox": "catalog:computesdk",
+        "arktype": "catalog:",
+        "computesdk": "catalog:computesdk",
+        "microsandbox": "catalog:computesdk",
+        "modal": "catalog:computesdk",
+        "novita-sandbox": "catalog:computesdk",
+      },
+      "devDependencies": {
+        "@repo/tsconfig": "workspace:*",
+        "@types/bun": "catalog:",
+        "typescript": "catalog:",
+      },
+    },
     "packages/figures": {
       "name": "@sandbox-benchmarks/figures",
       "version": "0.0.0",
@@ -719,6 +749,8 @@
     "@sandbox-benchmarks/cli": ["@sandbox-benchmarks/cli@workspace:apps/cli"],
 
     "@sandbox-benchmarks/driver": ["@sandbox-benchmarks/driver@workspace:packages/driver"],
+
+    "@sandbox-benchmarks/drivers": ["@sandbox-benchmarks/drivers@workspace:packages/drivers"],
 
     "@sandbox-benchmarks/figures": ["@sandbox-benchmarks/figures@workspace:packages/figures"],
 

--- a/docs/adr/0007-sandbox-driver-port.md
+++ b/docs/adr/0007-sandbox-driver-port.md
@@ -672,13 +672,23 @@ create never releases ownership by itself.
 It keeps all its real value — seven maintained vendor translations — and stops being mandatory:
 
 ```ts
-import { computeSdkDriver } from "./_computesdk.ts";
+import { computeSdkSpec, defineComputeSdkDriver } from "./_computesdk.ts";
 
-export default defineDriver("e2b", {
-  driver: ({ env, resolvedArtifact }) =>
-    computeSdkDriver(e2bCommandsAsRoot(e2b({ apiKey: env.E2B_API_KEY })), {
-      createOptions: { snapshotId: resolvedArtifact.ref },
-      hasWorkingFilesystem: true,   // explicit, because UnsupportedFileSystem lies
+export default defineComputeSdkDriver("e2b", {
+  spec: ({ env, resolvedArtifact }) =>
+    computeSdkSpec(e2bCommandsAsRoot(e2b({ apiKey: env.E2B_API_KEY })), {
+      sandboxId: E2bSandboxId,       // provider-local arktype trust boundary
+      createOptions: {
+        coverage: {
+          spec: { vcpus: "artifact", memoryGb: "artifact", diskGb: "artifact" },
+          artifact: "context",
+          deadlineMs: "harness",
+          gpu: { model: "unsupported", count: "unsupported" },
+          env: "unsupported",
+        },
+        map: () => ({ snapshotId: resolvedArtifact.ref }),
+      },
+      hasWorkingFilesystem: true,    // explicit, because UnsupportedFileSystem lies
     }),
 });
 ```
@@ -815,9 +825,12 @@ must be added to that executable proof rather than being retroactively described
    unregistered id; the regenerated loader won't compile without the file.
 
 Then `bun run generate-provider-wiring` → review one diff touching the loader table, the exports
-map, and the CI regions. A bake module only when `artifact.kind === "baked"` (the cli `Record`
+map, fleet dependency projection, and the CI regions. A bake module only when
+`artifact.kind === "baked"` (the cli `Record`
 demands exactly those); the `bench-matrix.yml` promotion stays a deliberate, separate step.
-`bun run new-provider <id>` (ADR-0006 §9) scaffolds all three edits from one descriptor.
+The final migration slice adds `bun run new-provider <id>` (ADR-0006 §9), which scaffolds all three
+edits and any new root catalog version pin from one descriptor; until that slice lands, the command
+described here is a normative destination rather than an already-available script.
 
 **We accept:**
 
@@ -834,9 +847,10 @@ demands exactly those); the `bench-matrix.yml` promotion stays a deliberate, sep
   contextual typing, shared by convex and elysia. §2's method tables are the pressure valve: a
   table is naturally a named `satisfies MethodTable<…>` const, so the code an author most wants to
   extract and unit-test is exactly the shape that extracts safely.
-- **`createOptions` stays an open passthrough on the bridge.** The `snapshotId`/`templateId`
-  conventions are real ComputeSDK knowledge and remain local to each bridge-backed driver; the
-  registry does not pretend those vendor option names are artifact metadata.
+- **The mapped ComputeSDK options stay open; canonical coverage does not.** The
+  `snapshotId`/`templateId` conventions are real ComputeSDK knowledge and remain local to each
+  bridge-backed driver, while the type-derived `coverage` declaration makes every new target,
+  GPU, environment, artifact, or budget axis a compiler-forced provider review.
 - **Losing `getInfo`/`list` as *typed* members.** Both are pure latency probes today. They move to
   the optional `probes` capability, where an absent probe is a recorded gap rather than a stub.
 - **Default exports in `packages/drivers`.** The one place the repo uses them, accepted so the

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -54,6 +54,8 @@ docs/       methodology, ADRs, CI & secrets
 | Member                      | Internal deps (`workspace:*`)                   | External (catalog)                  |
 |-----------------------------|-------------------------------------------------|-------------------------------------|
 | `@sandbox-benchmarks/schema`     | —                                               | `arktype`                           |
+| `@sandbox-benchmarks/driver`     | schema                                          | `arktype`                           |
+| `@sandbox-benchmarks/drivers`    | driver                                          | `arktype`, provider SDKs (`catalog:computesdk`) |
 | `@sandbox-benchmarks/providers`  | schema                                          | `arktype`, computesdk packages (`catalog:computesdk`) |
 | `@sandbox-benchmarks/templates`  | providers, schema                               | `computesdk` (`catalog:computesdk`) |
 | `@sandbox-benchmarks/harness`    | providers, schema                               | —                                   |

--- a/packages/driver/src/cli.test.ts
+++ b/packages/driver/src/cli.test.ts
@@ -139,7 +139,13 @@ describe("cliDriver", () => {
 		});
 		expect(module_.id).toBe("tama");
 		expect(module_.createBudget).toEqual({ owner: "driver", attemptCeilingMs: 60_000 });
-		expect(typeof module_.driver({ env: { TAMA_TOKEN: "tok" } }).create).toBe("function");
+		expect(
+			typeof module_.driver({
+				env: { TAMA_TOKEN: "tok" },
+				artifact: { kind: "image" },
+				resolvedArtifact: { kind: "image", ref: "ghcr.io/example/toolchain:v1" },
+			}).create,
+		).toBe("function");
 
 		const missingBudget = () =>
 			defineCliDriver(
@@ -1136,8 +1142,10 @@ describe("cliDriver", () => {
 		expect((error.error as DriverError).code).toBe("destroy-failed");
 		expect((error.suppressed as DriverError).code).toBe("vendor-output-unparseable");
 		expect(error.provider).toBe("tama");
-		expect(error.locator.kind).toBe("name");
-		expect(error.locator.value).toMatch(/^bench-/);
+		expect(error.locator).toEqual({
+			kind: "name",
+			value: expect.stringMatching(/^bench-/),
+		});
 
 		await error[Symbol.asyncDispose]();
 		await error[Symbol.asyncDispose]();

--- a/packages/driver/src/env.test.ts
+++ b/packages/driver/src/env.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { envSchemaFor, parseDriverEnv } from "./env.ts";
+import { envSchemaFor, parseDriverEnv, sensitiveEnvValuesFor } from "./env.ts";
 import { DriverError } from "./lib/errors.ts";
 
 type Equal<X, Y> =
@@ -90,5 +90,20 @@ describe("parseDriverEnv", () => {
 			>
 		>;
 		expect(true).toBe(true);
+	});
+
+	test("marks credential sources sensitive without hiding ordinary overrides", () => {
+		expect(
+			sensitiveEnvValuesFor("e2b", {
+				E2B_API_KEY: "secret-key",
+				E2B_TEMPLATE: "debuggable-template",
+			}),
+		).toEqual(["secret-key"]);
+		expect(
+			sensitiveEnvValuesFor("tama", {
+				TAMA_TOKEN: "secret-token",
+				TAMA_CLI: "/opt/tama",
+			}),
+		).toEqual(["secret-token"]);
 	});
 });

--- a/packages/driver/src/env.ts
+++ b/packages/driver/src/env.ts
@@ -74,3 +74,24 @@ export function parseDriverEnv<P extends ProviderId>(
 	// retain that id-indexed relationship through a mutable shape, so this cast records the proof.
 	return parsed as EnvOf<P>;
 }
+
+/**
+ * Values whose registry source is credential-bearing and must never survive in diagnostics.
+ * Ordinary variables (binary paths, image/template overrides, endpoints) stay observable so
+ * redaction cannot corrupt status text or retry classification. Step-provided values are treated as
+ * sensitive: today those are OIDC/token material or paths to it.
+ */
+export function sensitiveEnvValuesFor<P extends ProviderId>(
+	id: P,
+	env: EnvOf<P>,
+): readonly string[] {
+	const values: string[] = [];
+	const resolved = env as Readonly<Record<string, string | undefined>>;
+	for (const raw of REGISTRY[id].inputs) {
+		const input = normalizeProviderInput(raw);
+		if (input.source.kind === "variable") continue;
+		const value = resolved[input.name];
+		if (value !== undefined && value.length > 0) values.push(value);
+	}
+	return values;
+}

--- a/packages/driver/src/index.ts
+++ b/packages/driver/src/index.ts
@@ -4,7 +4,10 @@
 // everything a driver author implements. Runtime validation is isolated at `./env` and `./schemas`;
 // importing the core must not evaluate arktype or any schema-package runtime graph.
 
+export type { ProviderId } from "@sandbox-benchmarks/schema/provider-ids";
+
 export type {
+	ArtifactOf,
 	DriverContext,
 	DriverModule,
 	DriverSpec,
@@ -12,6 +15,7 @@ export type {
 	EnvInputFromInputs,
 	EnvInputOf,
 	EnvOf,
+	ResolvedArtifactOf,
 } from "./lib/define.ts";
 export { defineDriver } from "./lib/define.ts";
 
@@ -50,5 +54,5 @@ export type {
 export { sandboxRef, succeeded } from "./lib/port.ts";
 export { withSessionTeardown } from "./lib/session.ts";
 export { launchDetached, readTextFile, shellQuote, writeTextFile } from "./lib/shell.ts";
-export type { MethodTable } from "./lib/table.ts";
+export type { MethodTable, MethodTableCreateResult } from "./lib/table.ts";
 export { DeferredTeardownError, driverFromTable } from "./lib/table.ts";

--- a/packages/driver/src/lib/define.test.ts
+++ b/packages/driver/src/lib/define.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import type { EnvOf } from "./define.ts";
+import type { ArtifactOf, EnvOf, ResolvedArtifactOf } from "./define.ts";
 import { defineDriver } from "./define.ts";
 import type { SandboxDriver } from "./port.ts";
 
@@ -41,24 +41,39 @@ describe("EnvOf", () => {
 		>;
 		expect(true).toBe(true); // the assertions above are compile-time; typecheck is the oracle
 	});
+
+	test("derives exact artifact descriptors and resolved shapes from the same provider id", () => {
+		type _e2bDescriptor = Expect<Equal<ArtifactOf<"e2b">, { readonly kind: "baked" }>>;
+		type _e2bResolved = Expect<
+			Equal<ResolvedArtifactOf<"e2b">, { readonly kind: "baked"; readonly ref: string }>
+		>;
+		type _blaxelResolved = Expect<Equal<ResolvedArtifactOf<"blaxel">, { readonly kind: "none" }>>;
+		expect(true).toBe(true);
+	});
 });
 
 describe("defineDriver", () => {
 	test("carries the id and spec through unchanged", () => {
 		const module_ = defineDriver("tama", {
 			createBudget: { owner: "driver", attemptCeilingMs: 60_000 },
-			driver: ({ env }) => {
+			driver: ({ env, artifact, resolvedArtifact }) => {
 				// env is the exact tama slice; both lines below are type-checked by `tsc --noEmit`.
 				const token: string = env.TAMA_TOKEN;
 				void token;
 				// @ts-expect-error — tama declares no E2B_API_KEY; the registry is the source of truth
 				void env.E2B_API_KEY;
+				expect(artifact).toEqual({ kind: "image" });
+				expect(resolvedArtifact.kind).toBe("image");
 				return stubDriver;
 			},
 		});
 		expect(module_.id).toBe("tama");
 		expect(module_.createBudget).toEqual({ owner: "driver", attemptCeilingMs: 60_000 });
-		const driver = module_.driver({ env: { TAMA_TOKEN: "tok" } });
+		const driver = module_.driver({
+			env: { TAMA_TOKEN: "tok" },
+			artifact: { kind: "image" },
+			resolvedArtifact: { kind: "image", ref: "ghcr.io/example/toolchain:v1" },
+		});
 		expect(typeof driver.create).toBe("function");
 	});
 

--- a/packages/driver/src/lib/define.ts
+++ b/packages/driver/src/lib/define.ts
@@ -4,7 +4,7 @@
 // arktype boundary that evaluates the same descriptor tuple.
 
 import type { ProviderId, ProviderInput, REGISTRY } from "@sandbox-benchmarks/schema/providers";
-import type { CreateBudget, SandboxDriver } from "./port.ts";
+import type { CreateBudget, ResolvedArtifact, SandboxDriver } from "./port.ts";
 
 type Prettify<T> = { [K in keyof T]: T[K] } & {};
 
@@ -67,8 +67,32 @@ export type EnvInputOf<P extends ProviderId> = P extends ProviderId
 	? EnvInputFromInputs<(typeof REGISTRY)[P]["inputs"]>
 	: never;
 
+/** The exact, literal artifact descriptor authored for one provider in the registry. */
+export type ArtifactOf<P extends ProviderId> = P extends ProviderId
+	? (typeof REGISTRY)[P]["artifact"]
+	: never;
+
+type ResolvedArtifactFor<Artifact> = Artifact extends { readonly kind: "none" }
+	? Extract<ResolvedArtifact, { readonly kind: "none" }>
+	: Artifact extends { readonly kind: "image" }
+		? Extract<ResolvedArtifact, { readonly kind: "image" }>
+		: Artifact extends { readonly kind: "baked" }
+			? Extract<ResolvedArtifact, { readonly kind: "baked" }>
+			: Artifact extends { readonly kind: "mirror" }
+				? Extract<ResolvedArtifact, { readonly kind: "mirror" }>
+				: Artifact extends { readonly kind: "built" }
+					? Extract<ResolvedArtifact, { readonly kind: "built" }>
+					: never;
+
+/** The lane-resolved artifact shape for one provider; `ref` is impossible for `kind: "none"`. */
+export type ResolvedArtifactOf<P extends ProviderId> = P extends ProviderId
+	? ResolvedArtifactFor<(typeof REGISTRY)[P]["artifact"]>
+	: never;
+
 export interface DriverContext<P extends ProviderId> {
 	readonly env: EnvOf<P>;
+	readonly artifact: ArtifactOf<P>;
+	readonly resolvedArtifact: ResolvedArtifactOf<P>;
 }
 
 export interface DriverSpec<P extends ProviderId, Handle = unknown> {

--- a/packages/driver/src/lib/errors.ts
+++ b/packages/driver/src/lib/errors.ts
@@ -20,6 +20,8 @@ import type { DriverOperationOptions, SandboxRef } from "./port.ts";
  *   - `readiness-timeout` — create was accepted but the sandbox never became ready in budget.
  *   - `vendor-output-unparseable` — the vendor's control-plane output drifted from its schema.
  *   - `exec-failed` — a kit-owned shell fallback failed before it could satisfy its contract.
+ *   - `filesystem-failed` / `probe-failed` / `snapshot-failed` — an explicitly declared optional
+ *     capability failed while talking to the selected provider.
  *   - `invalid-exec-options` — a caller supplied an impossible output-cap value.
  *   - `destroy-failed` — teardown could not converge.
  */
@@ -34,6 +36,9 @@ export type DriverErrorCode =
 	| "readiness-timeout"
 	| "vendor-output-unparseable"
 	| "exec-failed"
+	| "filesystem-failed"
+	| "probe-failed"
+	| "snapshot-failed"
 	| "invalid-exec-options"
 	| "destroy-failed";
 
@@ -46,13 +51,18 @@ export interface DriverErrorFields {
 	readonly cause?: unknown;
 }
 
-/** A stable locator for an allocation whose create failed before a session could be returned. */
+/** A retained recovery locator for an allocation whose create failed before a session returned. */
 export interface FailedCreateRecovery {
 	readonly provider: ProviderId;
-	readonly locator: {
-		readonly kind: "name" | "id";
-		readonly value: string;
-	};
+	readonly locator:
+		| {
+				readonly kind: "name" | "id";
+				readonly value: string;
+		  }
+		| {
+				/** The wrapper returned no stable id, so cleanup retains its native object in-process. */
+				readonly kind: "native-handle";
+		  };
 }
 
 export interface FailedCreateCleanupErrorOptions extends FailedCreateRecovery {
@@ -84,10 +94,14 @@ export class FailedCreateCleanupError extends SuppressedError implements AsyncDi
 		createError: unknown,
 		options: FailedCreateCleanupErrorOptions,
 	) {
+		const locatorLabel =
+			options.locator.kind === "native-handle"
+				? "through its retained native handle"
+				: `by ${options.locator.kind} ${options.locator.value}`;
 		super(
 			cleanupError,
 			createError,
-			`failed to clean up ${options.provider} sandbox by ${options.locator.kind} ${options.locator.value} after create failure`,
+			`failed to clean up ${options.provider} sandbox ${locatorLabel} after create failure`,
 		);
 		this.name = "FailedCreateCleanupError";
 		this.provider = options.provider;

--- a/packages/driver/src/lib/table.test.ts
+++ b/packages/driver/src/lib/table.test.ts
@@ -59,6 +59,20 @@ describe("driverFromTable", () => {
 		expect(session.launch).toBeUndefined();
 	});
 
+	test("preserves an explicitly projected undefined native value", async () => {
+		const table: MethodTable<string, null, undefined> = {
+			create: async () => ({
+				handle: "internal-wrapper",
+				native: undefined,
+				sandboxRef: sandboxRef("tama", "m-native-undefined"),
+			}),
+			exec: async () => okExec,
+			destroy: async () => {},
+		};
+		const session = await driverFromTable(table, async () => null).create(request);
+		expect(session.native).toBeUndefined();
+	});
+
 	test("forwards cooperative cancellation to create, session destroy, and bare-ref destroy", async () => {
 		const createCancellation = new AbortController();
 		const destroyCancellation = new AbortController();

--- a/packages/driver/src/lib/table.ts
+++ b/packages/driver/src/lib/table.ts
@@ -22,7 +22,22 @@ import type {
 	SnapshotCapability,
 } from "./port.ts";
 
-export interface MethodTable<Handle, Ctx> {
+type SameType<Left, Right> =
+	(<T>() => T extends Left ? 1 : 2) extends <T>() => T extends Right ? 1 : 2
+		? (<T>() => T extends Right ? 1 : 2) extends <T>() => T extends Left ? 1 : 2
+			? true
+			: false
+		: false;
+
+export type MethodTableCreateResult<Handle, Native = Handle> = {
+	readonly handle: Handle;
+	readonly sandboxRef: SandboxRef;
+	readonly artifact?: ResolvedArtifact;
+} & (SameType<Handle, Native> extends true
+	? { readonly native?: Native }
+	: { readonly native: Native });
+
+export interface MethodTable<Handle, Ctx, Native = Handle> {
 	/** Bounded wait for accepted operations; expiry fails destroy so teardown never races the handle. */
 	readonly operationDrainTimeoutMs?: number;
 	/**
@@ -34,11 +49,7 @@ export interface MethodTable<Handle, Ctx> {
 		ctx: Ctx,
 		request: CreateRequest,
 		options?: DriverOperationOptions,
-	): Promise<{
-		readonly handle: Handle;
-		readonly sandboxRef: SandboxRef;
-		readonly artifact?: ResolvedArtifact;
-	}>;
+	): Promise<MethodTableCreateResult<Handle, Native>>;
 	/** Run a command. Options are forwarded unchanged; the kit still enforces output caps. */
 	exec(ctx: Ctx, handle: Handle, command: string, options?: ExecOptions): Promise<ExecResult>;
 	destroy(ctx: Ctx, handle: Handle, options?: DriverOperationOptions): Promise<void>;
@@ -56,7 +67,7 @@ export interface MethodTable<Handle, Ctx> {
 		describe?(ctx: Ctx, ref: SandboxRef): Promise<unknown>;
 	};
 	readonly snapshots?: {
-		create(ctx: Ctx, session: SandboxSession<Handle>): Promise<{ readonly snapshotId: string }>;
+		create(ctx: Ctx, session: SandboxSession<Native>): Promise<{ readonly snapshotId: string }>;
 		delete(ctx: Ctx, snapshotId: string): Promise<void>;
 	};
 }
@@ -145,10 +156,10 @@ export class DeferredTeardownError extends DriverError implements AsyncDisposabl
  * brick the driver for the process lifetime; concurrent callers share the in-flight attempt
  * (ADR-0007 §9).
  */
-export function driverFromTable<Handle, Ctx>(
-	table: MethodTable<Handle, Ctx>,
+export function driverFromTable<Handle, Ctx, Native = Handle>(
+	table: MethodTable<Handle, Ctx, Native>,
 	loadCtx: () => Promise<Ctx>,
-): SandboxDriver<Handle> {
+): SandboxDriver<Native> {
 	const operationDrainTimeoutMs = table.operationDrainTimeoutMs ?? 1_000;
 	if (!Number.isSafeInteger(operationDrainTimeoutMs) || operationDrainTimeoutMs <= 0) {
 		throw new DriverError(
@@ -198,6 +209,11 @@ export function driverFromTable<Handle, Ctx>(
 				throw mismatch;
 			}
 			const handle = created.handle;
+			// Presence, not truthiness, selects the explicitly projected native value. `undefined` can be
+			// a wrapper's honest getInstance() result and must not silently turn back into the table handle.
+			const native = (
+				"native" in created ? created.native : (handle as unknown as Native)
+			) as Native;
 			const ref = created.sandboxRef;
 			let state: "alive" | "destroying" | "destroyed" = "alive";
 			let destroyInFlight: Promise<void> | undefined;
@@ -294,10 +310,10 @@ export function driverFromTable<Handle, Ctx>(
 				teardownInFlight = teardown;
 				return teardown;
 			};
-			const session: SandboxSession<Handle> = {
+			const session: SandboxSession<Native> = {
 				sandboxRef: ref,
 				artifact,
-				native: handle,
+				native,
 				exec: (command, options?: ExecOptions) =>
 					alive(() => {
 						// Read the cap before provider code sees the original options object. Readonly is a
@@ -373,10 +389,10 @@ export function driverFromTable<Handle, Ctx>(
 		...(tableSnapshots
 			? {
 					snapshots: {
-						create: async (session: SandboxSession<Handle>) =>
+						create: async (session: SandboxSession<Native>) =>
 							tableSnapshots.create(await ctx(), session),
 						delete: async (snapshotId: string) => tableSnapshots.delete(await ctx(), snapshotId),
-					} satisfies SnapshotCapability<Handle>,
+					} satisfies SnapshotCapability<Native>,
 				}
 			: {}),
 	};

--- a/packages/drivers/package.json
+++ b/packages/drivers/package.json
@@ -1,0 +1,41 @@
+{
+  "name": "@sandbox-benchmarks/drivers",
+  "version": "0.0.0",
+  "private": true,
+  "description": "Lazy provider driver modules; vendor SDKs are confined to this fleet package.",
+  "type": "module",
+  "sideEffects": false,
+  "exports": {
+    "./package.json": "./package.json"
+  },
+  "scripts": {
+    "test": "bun test",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@blaxel/core": "catalog:computesdk",
+    "@computesdk/blaxel": "catalog:computesdk",
+    "@computesdk/daytona": "catalog:computesdk",
+    "@computesdk/e2b": "catalog:computesdk",
+    "@computesdk/modal": "catalog:computesdk",
+    "@computesdk/namespace": "catalog:computesdk",
+    "@computesdk/provider": "catalog:computesdk",
+    "@computesdk/runloop": "catalog:computesdk",
+    "@daytona/api-client": "catalog:computesdk",
+    "@daytona/sdk": "catalog:computesdk",
+    "@run-cloud/sdk": "catalog:computesdk",
+    "@runloop/api-client": "catalog:computesdk",
+    "@sandbox-benchmarks/driver": "workspace:*",
+    "@vercel/sandbox": "catalog:computesdk",
+    "arktype": "catalog:",
+    "computesdk": "catalog:computesdk",
+    "microsandbox": "catalog:computesdk",
+    "modal": "catalog:computesdk",
+    "novita-sandbox": "catalog:computesdk"
+  },
+  "devDependencies": {
+    "@repo/tsconfig": "workspace:*",
+    "typescript": "catalog:",
+    "@types/bun": "catalog:"
+  }
+}

--- a/packages/drivers/src/_computesdk.test.ts
+++ b/packages/drivers/src/_computesdk.test.ts
@@ -1,0 +1,1458 @@
+import { describe, expect, test } from "bun:test";
+import type { E2BSandbox } from "@computesdk/e2b";
+import { e2b } from "@computesdk/e2b";
+import type { CreateRequest, SandboxDriver } from "@sandbox-benchmarks/driver";
+import { DriverError, FailedCreateCleanupError } from "@sandbox-benchmarks/driver";
+import { type } from "arktype";
+import type {
+	ComputeSdkCreateRequestCoverage,
+	ComputeSdkCreateRequestMapper,
+	ComputeSdkDriverSpec,
+	ComputeSdkLike,
+	ComputeSdkNativeOf,
+	ComputeSdkSandboxLike,
+} from "./_computesdk.ts";
+import { computeSdkSpec, defineComputeSdkDriver } from "./_computesdk.ts";
+
+type Equal<Left, Right> =
+	(<T>() => T extends Left ? 1 : 2) extends <T>() => T extends Right ? 1 : 2
+		? (<T>() => T extends Right ? 1 : 2) extends <T>() => T extends Left ? 1 : 2
+			? true
+			: false
+		: false;
+type Expect<T extends true> = T;
+
+const request: CreateRequest = {
+	spec: { vcpus: 4, memoryGb: 8, diskGb: 40 },
+	artifact: { kind: "baked", ref: "template-1" },
+	deadlineMs: 30_000,
+};
+
+function fakeCompute<TSandbox extends ComputeSdkSandboxLike>(sandbox: TSandbox, withList = false) {
+	const createOptionsSeen: Array<Record<string, unknown>> = [];
+	const compute: ComputeSdkLike<TSandbox> = {
+		sandbox: {
+			create: async (options) => {
+				createOptionsSeen.push(options ?? {});
+				return sandbox;
+			},
+			...(withList ? { list: async () => ["sb-1"] } : {}),
+		},
+	};
+	return { compute, createOptionsSeen };
+}
+
+const nativeSandbox = { commands: { run: async () => "native-result" } };
+
+const baseSandbox: ComputeSdkSandboxLike<typeof nativeSandbox> = {
+	sandboxId: "i2f3k4abc",
+	getInstance: () => nativeSandbox,
+	runCommand: async () => ({ exitCode: 0, stdout: "ok", stderr: "" }),
+	destroy: async () => {},
+};
+
+const e2bSandboxId = type(/^i[a-z0-9]+$/);
+
+const mappedCoverage = {
+	spec: { vcpus: "mapped", memoryGb: "mapped", diskGb: "mapped" },
+	artifact: "context",
+	deadlineMs: "harness",
+	gpu: { model: "mapped", count: "mapped" },
+	env: "mapped",
+} as const satisfies ComputeSdkCreateRequestCoverage;
+
+const artifactCoverage = {
+	spec: { vcpus: "artifact", memoryGb: "artifact", diskGb: "artifact" },
+	artifact: "context",
+	deadlineMs: "harness",
+	gpu: { model: "unsupported", count: "unsupported" },
+	env: "unsupported",
+} as const satisfies ComputeSdkCreateRequestCoverage;
+
+const createRequestMapper = (
+	map: ComputeSdkCreateRequestMapper["map"] = () => ({}),
+	coverage: ComputeSdkCreateRequestCoverage = mappedCoverage,
+): ComputeSdkCreateRequestMapper => ({ coverage, map });
+
+function expectRedacted(error: unknown, code?: DriverError["code"]): void {
+	const typed = error as DriverError;
+	if (code !== undefined) expect(typed.code).toBe(code);
+	expect(typed.message).not.toContain("test-key");
+	expect(typed.vendorMessage ?? "").not.toContain("test-key");
+	expect(String(typed.cause ?? "")).not.toContain("test-key");
+	expect(`${typed.message} ${typed.vendorMessage ?? ""}`).toContain("[REDACTED]");
+}
+
+function bridge<TSandbox extends ComputeSdkSandboxLike>(
+	compute: ComputeSdkLike<TSandbox>,
+	options: Partial<
+		Omit<ComputeSdkDriverSpec<ComputeSdkLike<TSandbox>>, "compute" | "sandboxId" | "createOptions">
+	> & {
+		readonly createOptions?: ComputeSdkCreateRequestMapper["map"];
+		readonly requestCoverage?: ComputeSdkCreateRequestCoverage;
+		readonly sandboxId?: ComputeSdkDriverSpec<ComputeSdkLike<TSandbox>>["sandboxId"];
+	} = {},
+): SandboxDriver<ComputeSdkNativeOf<TSandbox>> {
+	return defineComputeSdkDriver("e2b", {
+		spec: ({ env, artifact, resolvedArtifact }) => {
+			expect(env.E2B_API_KEY).toBe("test-key");
+			expect(artifact).toEqual({ kind: "baked" });
+			expect(resolvedArtifact).toEqual({ kind: "baked", ref: "template-1" });
+			const { createOptions, requestCoverage, sandboxId, ...rest } = options;
+			return {
+				compute,
+				sandboxId: sandboxId ?? e2bSandboxId,
+				createOptions: createRequestMapper(createOptions, requestCoverage),
+				hasWorkingFilesystem: false,
+				...rest,
+			};
+		},
+	}).driver({
+		env: { E2B_API_KEY: "test-key" },
+		artifact: { kind: "baked" },
+		resolvedArtifact: { kind: "baked", ref: "template-1" },
+	});
+}
+
+describe("computeSdkDriver", () => {
+	test("infers session.native as the installed wrapper's vendored SDK instance", () => {
+		const module_ = defineComputeSdkDriver("e2b", {
+			spec: ({ env }) => ({
+				compute: e2b({ apiKey: env.E2B_API_KEY }),
+				sandboxId: e2bSandboxId,
+				createOptions: createRequestMapper(undefined, artifactCoverage),
+				hasWorkingFilesystem: true,
+			}),
+		});
+		type Driver = ReturnType<(typeof module_)["driver"]>;
+		type Session = Awaited<ReturnType<Driver["create"]>>;
+		type _native = Expect<Equal<Session["native"], E2BSandbox>>;
+		expect(module_.id).toBe("e2b");
+	});
+
+	test("preserves the installed wrapper type inside capability callbacks", () => {
+		const module_ = defineComputeSdkDriver("e2b", {
+			spec: ({ env }) =>
+				computeSdkSpec(e2b({ apiKey: env.E2B_API_KEY }), {
+					sandboxId: e2bSandboxId,
+					createOptions: createRequestMapper(undefined, artifactCoverage),
+					hasWorkingFilesystem: true,
+					probes: {
+						observe: async (compute, ref) => {
+							const found = await compute.sandbox.getById(ref.id);
+							return found === undefined ? { state: "absent" } : { state: "running" };
+						},
+					},
+				}),
+		});
+		expect(module_.id).toBe("e2b");
+	});
+
+	test("keeps the first compute argument authoritative when an extracted spec has excess state", () => {
+		const { compute: authoritative } = fakeCompute(baseSandbox);
+		const { compute: accidental } = fakeCompute({ ...baseSandbox, sandboxId: "iaccidental" });
+		const extracted = {
+			compute: accidental,
+			sandboxId: e2bSandboxId,
+			createOptions: createRequestMapper(),
+			hasWorkingFilesystem: false,
+		};
+		const joined = computeSdkSpec(authoritative, extracted);
+		expect(joined.compute).toBe(authoritative);
+	});
+
+	test("the joined helper has one provider id and contextually types its exact env slice", () => {
+		const { compute } = fakeCompute(baseSandbox);
+		const module_ = defineComputeSdkDriver("e2b", {
+			createBudget: { owner: "harness", timeoutMs: 45_000 },
+			spec: ({ env, resolvedArtifact }) => ({
+				compute,
+				sandboxId: e2bSandboxId,
+				createOptions: createRequestMapper(() => ({
+					apiKeyWasResolved: env.E2B_API_KEY.length > 0,
+					snapshotId: resolvedArtifact.ref,
+				})),
+				hasWorkingFilesystem: false,
+			}),
+		});
+		expect(module_.id).toBe("e2b");
+		expect(module_.createBudget).toEqual({ owner: "harness", timeoutMs: 45_000 });
+
+		const driverOwnedBudget = () =>
+			defineComputeSdkDriver("e2b", {
+				// @ts-expect-error — the wrapper exposes no cancellable hard attempt ceiling
+				createBudget: { owner: "driver", attemptCeilingMs: 45_000 },
+				spec: () => ({
+					compute,
+					sandboxId: e2bSandboxId,
+					createOptions: createRequestMapper(),
+					hasWorkingFilesystem: false,
+				}),
+			});
+		void driverOwnedBudget;
+		expect(() =>
+			defineComputeSdkDriver("e2b", {
+				createBudget: { owner: "driver", attemptCeilingMs: 45_000 } as never,
+				spec: () => ({
+					compute,
+					sandboxId: e2bSandboxId,
+					createOptions: createRequestMapper(),
+					hasWorkingFilesystem: false,
+				}),
+			}),
+		).toThrow(expect.objectContaining({ code: "vendor-contract-violation", provider: "e2b" }));
+
+		const uncheckedParser = () =>
+			defineComputeSdkDriver("e2b", {
+				spec: () => ({
+					compute,
+					// @ts-expect-error — module-owned ids must cross an arktype trust boundary
+					sandboxId: (value: string) => value,
+					createOptions: createRequestMapper(),
+					hasWorkingFilesystem: false,
+				}),
+			});
+		void uncheckedParser;
+
+		const missingRequestMapper = () =>
+			defineComputeSdkDriver("e2b", {
+				// @ts-expect-error — every provider must explicitly validate/map the canonical request
+				spec: () => ({
+					compute,
+					sandboxId: e2bSandboxId,
+					hasWorkingFilesystem: false,
+				}),
+			});
+		void missingRequestMapper;
+
+		const missingTargetAxis = () =>
+			createRequestMapper(undefined, {
+				// @ts-expect-error — every TargetSpec key is an explicit review decision
+				spec: { vcpus: "mapped", memoryGb: "mapped" },
+				artifact: "context",
+				deadlineMs: "harness",
+				gpu: { model: "mapped", count: "mapped" },
+				env: "mapped",
+			});
+		void missingTargetAxis;
+
+		const missingOptionalAxis = () =>
+			createRequestMapper(undefined, {
+				spec: { vcpus: "mapped", memoryGb: "mapped", diskGb: "mapped" },
+				artifact: "context",
+				deadlineMs: "harness",
+				// @ts-expect-error — GPU model and count cannot drift independently
+				gpu: { model: "mapped" },
+				env: "mapped",
+			});
+		void missingOptionalAxis;
+
+		const missingTopLevelAxis = () =>
+			createRequestMapper(
+				undefined,
+				// @ts-expect-error — every current and future top-level CreateRequest key is required
+				{
+					spec: { vcpus: "mapped", memoryGb: "mapped", diskGb: "mapped" },
+					artifact: "context",
+					deadlineMs: "harness",
+					gpu: { model: "mapped", count: "mapped" },
+				},
+			);
+		void missingTopLevelAxis;
+	});
+
+	test("types and redacts wrapper construction failures before an SDK escapes", () => {
+		const module_ = defineComputeSdkDriver<"e2b", ComputeSdkLike>("e2b", {
+			spec: ({ env }): ComputeSdkDriverSpec<ComputeSdkLike> => {
+				throw new Error(`SDK constructor echoed ${env.E2B_API_KEY}`);
+			},
+		});
+		let error: unknown;
+		try {
+			module_.driver({
+				env: { E2B_API_KEY: "test-key" },
+				artifact: { kind: "baked" },
+				resolvedArtifact: { kind: "baked", ref: "template-1" },
+			});
+		} catch (caught) {
+			error = caught;
+		}
+		expect(error).toMatchObject({ code: "vendor-contract-violation", provider: "e2b" });
+		expectRedacted(error);
+	});
+
+	test("passes composition-resolved create options without confusing deadline with lifetime", async () => {
+		const { compute, createOptionsSeen } = fakeCompute(baseSandbox);
+		const driver = bridge(compute, {
+			createOptions: ({ spec, gpu, env }) => ({
+				snapshotId: "template-1",
+				cpu: spec.vcpus,
+				memoryMiB: spec.memoryGb * 1024,
+				diskGb: spec.diskGb,
+				gpuModel: gpu?.model,
+				gpuCount: gpu?.count,
+				guestEnv: env,
+			}),
+			hasWorkingFilesystem: false,
+		});
+		const session = await driver.create({
+			...request,
+			gpu: { model: "H100", count: 2 },
+			env: { BENCH_RUN_ID: "run-1" },
+		});
+		expect(session.sandboxRef).toEqual({ provider: "e2b", id: "i2f3k4abc" });
+		expect(session.artifact).toEqual({ kind: "baked", ref: "template-1" });
+		expect(session.native).toBe(nativeSandbox);
+		expect(await session.native.commands.run()).toBe("native-result");
+		expect(createOptionsSeen).toEqual([
+			{
+				snapshotId: "template-1",
+				cpu: 4,
+				memoryMiB: 8192,
+				diskGb: 40,
+				gpuModel: "H100",
+				gpuCount: 2,
+				guestEnv: { BENCH_RUN_ID: "run-1" },
+			},
+		]);
+	});
+
+	test("preserves an explicitly undefined wrapper native value", async () => {
+		const { compute } = fakeCompute({ ...baseSandbox, getInstance: () => undefined });
+		const session = await bridge(compute).create(request);
+		expect(session.native).toBeUndefined();
+	});
+
+	test("preflights create-option mapping before the wrapper can allocate", async () => {
+		let createCalls = 0;
+		const compute: ComputeSdkLike<typeof baseSandbox> = {
+			sandbox: {
+				create: async () => {
+					createCalls += 1;
+					return baseSandbox;
+				},
+			},
+		};
+		const error = await bridge(compute, {
+			createOptions: () => {
+				throw new Error("capacity mapping missing");
+			},
+		})
+			.create({ ...request, gpu: { model: "unsupported", count: 1 } })
+			.catch((caught: unknown) => caught);
+		expect(error).toMatchObject({ code: "vendor-contract-violation", provider: "e2b" });
+		expect(createCalls).toBe(0);
+	});
+
+	test("rejects an unsupported canonical axis as terminal input before allocation", async () => {
+		let createCalls = 0;
+		const compute: ComputeSdkLike<typeof baseSandbox> = {
+			sandbox: {
+				create: async () => {
+					createCalls += 1;
+					return baseSandbox;
+				},
+			},
+		};
+		const error = await bridge(compute, {
+			requestCoverage: artifactCoverage,
+		})
+			.create({ ...request, gpu: { model: "H100", count: 2 } })
+			.catch((caught: unknown) => caught);
+		expect(error).toMatchObject({ code: "invalid-create-request", provider: "e2b" });
+		expect((error as Error).message).toContain("GPU H100 x2 is unsupported");
+		expect(createCalls).toBe(0);
+	});
+
+	test("rejects simulated future top-level and GPU axes generically before allocation", async () => {
+		let createCalls = 0;
+		const compute: ComputeSdkLike<typeof baseSandbox> = {
+			sandbox: {
+				create: async () => {
+					createCalls += 1;
+					return baseSandbox;
+				},
+			},
+		};
+		const futureCoverage = {
+			...mappedCoverage,
+			network: "unsupported",
+			gpu: { ...mappedCoverage.gpu, partition: "unsupported" },
+		} as unknown as ComputeSdkCreateRequestCoverage;
+		const driver = bridge(compute, { requestCoverage: futureCoverage });
+		const networkError = await driver
+			.create({ ...request, network: { egress: false } } as unknown as CreateRequest)
+			.catch((caught: unknown) => caught);
+		expect(networkError).toMatchObject({ code: "invalid-create-request", provider: "e2b" });
+		expect((networkError as Error).message).toContain("request axis network is unsupported");
+
+		const gpuError = await driver
+			.create({
+				...request,
+				gpu: { model: "H100", count: 1, partition: "whole" },
+			} as unknown as CreateRequest)
+			.catch((caught: unknown) => caught);
+		expect(gpuError).toMatchObject({ code: "invalid-create-request", provider: "e2b" });
+		expect((gpuError as Error).message).toContain("axis partition");
+		expect(createCalls).toBe(0);
+	});
+
+	test("reports the configured artifact so the shared mismatch guard destroys a wrong boot", async () => {
+		let destroys = 0;
+		const { compute, createOptionsSeen } = fakeCompute({
+			...baseSandbox,
+			destroy: async () => {
+				destroys += 1;
+			},
+		});
+		const module_ = defineComputeSdkDriver("e2b", {
+			spec: ({ resolvedArtifact }) => ({
+				compute,
+				sandboxId: e2bSandboxId,
+				createOptions: createRequestMapper(
+					() => ({ snapshotId: resolvedArtifact.ref }),
+					artifactCoverage,
+				),
+				hasWorkingFilesystem: false,
+			}),
+		});
+		const driver = module_.driver({
+			env: { E2B_API_KEY: "test-key" },
+			artifact: { kind: "baked" },
+			resolvedArtifact: { kind: "baked", ref: "template-context" },
+		});
+		const error = await driver
+			.create({ ...request, artifact: { kind: "baked", ref: "template-request" } })
+			.catch((caught: unknown) => caught);
+		expect(error).toMatchObject({ code: "artifact-mismatch" });
+		expect(createOptionsSeen).toEqual([{ snapshotId: "template-context" }]);
+		expect(destroys).toBe(1);
+	});
+
+	test("an artifact-mismatch cleanup fault retains the validated wrapper allocation", async () => {
+		let destroys = 0;
+		const { compute } = fakeCompute({
+			...baseSandbox,
+			destroy: async () => {
+				destroys += 1;
+				if (destroys === 1) throw new Error("transient destroy failure");
+			},
+		});
+		const module_ = defineComputeSdkDriver("e2b", {
+			spec: ({ resolvedArtifact }) => ({
+				compute,
+				sandboxId: e2bSandboxId,
+				createOptions: createRequestMapper(
+					() => ({ snapshotId: resolvedArtifact.ref }),
+					artifactCoverage,
+				),
+				hasWorkingFilesystem: false,
+			}),
+		});
+		const driver = module_.driver({
+			env: { E2B_API_KEY: "test-key" },
+			artifact: { kind: "baked" },
+			resolvedArtifact: { kind: "baked", ref: "template-context" },
+		});
+		const error = (await driver
+			.create({ ...request, artifact: { kind: "baked", ref: "template-request" } })
+			.catch((caught: unknown) => caught)) as FailedCreateCleanupError;
+		expect(error).toBeInstanceOf(FailedCreateCleanupError);
+		expect(error.locator).toEqual({ kind: "id", value: "i2f3k4abc" });
+		expect(error.suppressed).toMatchObject({ code: "artifact-mismatch" });
+		await error[Symbol.asyncDispose]();
+		expect(destroys).toBe(2);
+	});
+
+	test("an invalid unparsed id never masquerades as a stable cleanup locator", async () => {
+		const invalidId = "wrong-id";
+		const { compute } = fakeCompute({
+			...baseSandbox,
+			sandboxId: invalidId,
+			destroy: async () => {
+				throw new Error("cleanup unavailable");
+			},
+		});
+		const error = (await bridge(compute)
+			.create(request)
+			.catch((caught: unknown) => caught)) as FailedCreateCleanupError;
+		expect(error).toBeInstanceOf(FailedCreateCleanupError);
+		expect(error.locator).toEqual({ kind: "native-handle" });
+		expect(error.message).not.toContain(invalidId);
+	});
+
+	test("redacts a credential-shaped invalid id from ArkType summaries before rollback returns", async () => {
+		let destroys = 0;
+		const { compute } = fakeCompute({
+			...baseSandbox,
+			sandboxId: "test-key",
+			destroy: async () => {
+				destroys += 1;
+			},
+		});
+		const error = (await bridge(compute)
+			.create(request)
+			.catch((caught: unknown) => caught)) as DriverError;
+		expect(error).toMatchObject({ code: "invalid-sandbox-ref", provider: "e2b" });
+		expect(error.message).not.toContain("test-key");
+		expect(String(error.cause ?? "")).not.toContain("test-key");
+		expect(error.message).toContain("[REDACTED]");
+		expect(error.ref).toBeUndefined();
+		expect(destroys).toBe(1);
+	});
+
+	test("types and redacts a throwing id parser through a failed rollback", async () => {
+		let destroys = 0;
+		const throwingSchema = type("string").narrow(() => {
+			throw new Error("validator echoed test-key");
+		});
+		const { compute } = fakeCompute({
+			...baseSandbox,
+			destroy: async () => {
+				destroys += 1;
+				if (destroys === 1) throw new Error("cleanup echoed test-key");
+			},
+		});
+		const error = (await bridge(compute, { sandboxId: throwingSchema })
+			.create(request)
+			.catch((caught: unknown) => caught)) as FailedCreateCleanupError;
+		expect(error).toBeInstanceOf(FailedCreateCleanupError);
+		expect(error.locator).toEqual({ kind: "native-handle" });
+		expect(error.suppressed).toMatchObject({
+			code: "vendor-contract-violation",
+			provider: "e2b",
+		});
+		expectRedacted(error.suppressed);
+		expectRedacted(error.error, "destroy-failed");
+		await error.cleanup();
+		expect(destroys).toBe(2);
+	});
+
+	test("types and redacts a throwing id parser after a successful rollback", async () => {
+		let destroys = 0;
+		const throwingSchema = type("string").narrow(() => {
+			throw new Error("validator echoed test-key");
+		});
+		const { compute } = fakeCompute({
+			...baseSandbox,
+			destroy: async () => {
+				destroys += 1;
+			},
+		});
+		const error = await bridge(compute, { sandboxId: throwingSchema })
+			.create(request)
+			.catch((caught: unknown) => caught);
+		expect(error).toMatchObject({ code: "vendor-contract-violation", provider: "e2b" });
+		expectRedacted(error);
+		expect(destroys).toBe(1);
+	});
+
+	test("rejects an empty transformed id before constructing a session or stable locator", async () => {
+		let destroys = 0;
+		const { compute } = fakeCompute({
+			...baseSandbox,
+			destroy: async () => {
+				destroys += 1;
+			},
+		});
+		const error = await bridge(compute, {
+			sandboxId: {
+				fromVendor: type("string").pipe(() => ""),
+				canonical: type("string >= 1"),
+			},
+		})
+			.create(request)
+			.catch((caught: unknown) => caught);
+		expect(error).toMatchObject({ code: "invalid-sandbox-ref", provider: "e2b" });
+		expect((error as Error).message).toContain("empty canonical id");
+		expect(destroys).toBe(1);
+	});
+
+	test("types null and wrong-typed runtime sandbox ids before schema evaluation", async () => {
+		for (const malformedId of [null, 42]) {
+			let destroys = 0;
+			const malformed = {
+				...baseSandbox,
+				sandboxId: malformedId,
+				destroy: async () => {
+					destroys += 1;
+				},
+			} as unknown as ComputeSdkSandboxLike;
+			const { compute } = fakeCompute(malformed);
+			const error = await bridge(compute)
+				.create(request)
+				.catch((caught: unknown) => caught);
+			expect(error).toMatchObject({ code: "vendor-contract-violation", provider: "e2b" });
+			expect((error as Error).message).toContain("nonempty string sandboxId");
+			expect(destroys).toBe(1);
+		}
+	});
+
+	test("redacts a throwing sandbox-id accessor and retains cleanup after a double fault", async () => {
+		let destroys = 0;
+		const malformed = {
+			...baseSandbox,
+			destroy: async () => {
+				destroys += 1;
+				if (destroys === 1) throw new Error("cleanup echoed test-key");
+			},
+		};
+		Object.defineProperty(malformed, "sandboxId", {
+			get: () => {
+				throw new Error("sandboxId getter echoed test-key");
+			},
+		});
+		const { compute } = fakeCompute(malformed);
+		const error = (await bridge(compute)
+			.create(request)
+			.catch((caught: unknown) => caught)) as FailedCreateCleanupError;
+		expect(error).toBeInstanceOf(FailedCreateCleanupError);
+		expectRedacted(error.suppressed);
+		expectRedacted(error.error, "destroy-failed");
+		await error.cleanup();
+		expect(destroys).toBe(2);
+	});
+
+	test("a withheld exit code becomes the representable unknown arm, never a forged number", async () => {
+		const { compute } = fakeCompute({
+			...baseSandbox,
+			runCommand: async () => ({ stdout: "partial", stderr: "" }),
+		});
+		const session = await bridge(compute, {
+			hasWorkingFilesystem: false,
+		}).create(request);
+		const result = await session.exec("true");
+		expect(result.exit).toEqual({
+			kind: "unknown",
+			detail: "computesdk adapter reported no exit code",
+		});
+		expect(result.stdout).toBe("partial");
+	});
+
+	test("rejects malformed resolved command envelopes for exec and launch", async () => {
+		for (const malformed of [null, [], { exitCode: "0", stdout: "", stderr: "" }]) {
+			const { compute } = fakeCompute({
+				...baseSandbox,
+				runCommand: async () => malformed as never,
+			});
+			const session = await bridge(compute).create(request);
+			await expect(session.exec("true")).rejects.toMatchObject({
+				code: "vendor-contract-violation",
+				provider: "e2b",
+				ref: session.sandboxRef,
+			});
+			await expect(session.launch?.("task")).rejects.toMatchObject({
+				code: "vendor-contract-violation",
+				provider: "e2b",
+				ref: session.sandboxRef,
+			});
+		}
+	});
+
+	test("types and redacts a throwing background-result diagnostic accessor", async () => {
+		const malformed = { exitCode: 9, stdout: "" };
+		Object.defineProperty(malformed, "stderr", {
+			get: () => {
+				throw new Error("stderr getter echoed test-key");
+			},
+		});
+		const { compute } = fakeCompute({
+			...baseSandbox,
+			runCommand: async () => malformed,
+		});
+		const session = await bridge(compute).create(request);
+		const error = await session.launch?.("task").catch((caught: unknown) => caught);
+		expectRedacted(error, "exec-failed");
+		expect(error).toMatchObject({ ref: session.sandboxRef });
+	});
+
+	test("the filesystem stub never escapes: files exists only when declared working AND present", async () => {
+		const throwingStub = {
+			readFile: async () => {
+				throw new Error("filesystem not supported by this sandbox environment");
+			},
+			exists: async () => {
+				throw new Error("filesystem not supported by this sandbox environment");
+			},
+			writeFile: async () => {
+				throw new Error("filesystem not supported by this sandbox environment");
+			},
+		};
+		const { compute: stubbed } = fakeCompute({ ...baseSandbox, filesystem: throwingStub });
+		const withoutTrust = await bridge(stubbed, {
+			hasWorkingFilesystem: false,
+		}).create(request);
+		expect(withoutTrust.files).toBeUndefined();
+
+		const reads: string[] = [];
+		const { compute: working } = fakeCompute({
+			...baseSandbox,
+			filesystem: {
+				readFile: async (path) => {
+					reads.push(path);
+					return "content";
+				},
+				exists: async () => true,
+				writeFile: async () => {},
+			},
+		});
+		const withTrust = await bridge(working, {
+			hasWorkingFilesystem: true,
+		}).create(request);
+		expect(await withTrust.files?.readFile("/bench/a")).toBe("content");
+		expect(reads).toEqual(["/bench/a"]);
+
+		let missingDestroyed = 0;
+		const { compute: missing } = fakeCompute({
+			...baseSandbox,
+			filesystem: undefined,
+			destroy: async () => {
+				missingDestroyed += 1;
+			},
+		});
+		const missingError = await bridge(missing, {
+			hasWorkingFilesystem: true,
+		})
+			.create(request)
+			.catch((caught: unknown) => caught);
+		expect(missingError).toBeInstanceOf(DriverError);
+		expect(missingError).toMatchObject({ code: "vendor-contract-violation" });
+		expect(missingDestroyed).toBe(1);
+
+		const transientSandbox: ComputeSdkSandboxLike = {
+			...baseSandbox,
+			filesystem: {
+				readFile: async () => "content",
+				exists: async () => true,
+				writeFile: async () => {},
+			},
+		};
+		const { compute: transient } = fakeCompute(transientSandbox);
+		const transientSession = await bridge(transient, {
+			hasWorkingFilesystem: true,
+		}).create(request);
+		Object.defineProperty(transientSandbox, "filesystem", { value: undefined });
+		const withdrawn = await transientSession.files
+			?.readFile("/bench/a")
+			.catch((caught: unknown) => caught);
+		const withdrawnExists = await transientSession.files
+			?.exists("/bench/a")
+			.catch((caught: unknown) => caught);
+		expect(withdrawn).toBeInstanceOf(DriverError);
+		expect(withdrawn).toMatchObject({ code: "vendor-contract-violation" });
+		expect(withdrawnExists).toMatchObject({ code: "vendor-contract-violation" });
+	});
+
+	test("types and redacts a filesystem accessor that starts throwing after create", async () => {
+		const workingFilesystem = {
+			readFile: async () => "content",
+			exists: async () => true,
+			writeFile: async () => {},
+		};
+		let accesses = 0;
+		const sandbox = { ...baseSandbox };
+		Object.defineProperty(sandbox, "filesystem", {
+			get: () => {
+				accesses += 1;
+				if (accesses > 1) throw new Error("filesystem getter echoed test-key");
+				return workingFilesystem;
+			},
+		});
+		const { compute } = fakeCompute(sandbox as ComputeSdkSandboxLike);
+		const session = await bridge(compute, { hasWorkingFilesystem: true }).create(request);
+		const error = await session.files?.readFile("/bench/a").catch((caught: unknown) => caught);
+		expectRedacted(error, "vendor-contract-violation");
+		expect(error).toMatchObject({ ref: session.sandboxRef });
+	});
+
+	test("rejects an incomplete filesystem capability during create and rolls back", async () => {
+		let destroys = 0;
+		const { compute } = fakeCompute({
+			...baseSandbox,
+			filesystem: {} as never,
+			destroy: async () => {
+				destroys += 1;
+			},
+		});
+		const error = await bridge(compute, { hasWorkingFilesystem: true })
+			.create(request)
+			.catch((caught: unknown) => caught);
+		expect(error).toMatchObject({
+			code: "vendor-contract-violation",
+			provider: "e2b",
+		});
+		expect((error as Error).message).toContain("every required callable method");
+		expect(destroys).toBe(1);
+	});
+
+	test("retains cleanup when the initial filesystem accessor and rollback both fail", async () => {
+		let destroys = 0;
+		const sandbox = {
+			...baseSandbox,
+			destroy: async () => {
+				destroys += 1;
+				if (destroys === 1) throw new Error("cleanup echoed test-key");
+			},
+		};
+		Object.defineProperty(sandbox, "filesystem", {
+			get: () => {
+				throw new Error("filesystem getter echoed test-key");
+			},
+		});
+		const { compute } = fakeCompute(sandbox as ComputeSdkSandboxLike);
+		const error = (await bridge(compute, { hasWorkingFilesystem: true })
+			.create(request)
+			.catch((caught: unknown) => caught)) as FailedCreateCleanupError;
+		expect(error).toBeInstanceOf(FailedCreateCleanupError);
+		expectRedacted(error.suppressed, "vendor-contract-violation");
+		expectRedacted(error.error, "destroy-failed");
+		await error.cleanup();
+		expect(destroys).toBe(2);
+	});
+
+	test("launch rides the wrapper's background convention", async () => {
+		const commands: Array<[string, boolean | undefined]> = [];
+		const { compute } = fakeCompute({
+			...baseSandbox,
+			runCommand: async (command, options) => {
+				commands.push([command, options?.background]);
+				return { exitCode: 0, stdout: "", stderr: "" };
+			},
+		});
+		const session = await bridge(compute, {
+			hasWorkingFilesystem: false,
+		}).create(request);
+		await session.launch?.("bash task.sh");
+		expect(commands).toEqual([["bash task.sh", true]]);
+	});
+
+	test("launch rejects a background command that the wrapper reports as failed", async () => {
+		const { compute } = fakeCompute({
+			...baseSandbox,
+			runCommand: async () => ({ exitCode: 9, stdout: "", stderr: "launch rejected" }),
+		});
+		const session = await bridge(compute, {
+			hasWorkingFilesystem: false,
+		}).create(request);
+		const error = await session.launch?.("bash task.sh").catch((caught: unknown) => caught);
+		expect(error).toBeInstanceOf(DriverError);
+		expect(error).toMatchObject({
+			code: "exec-failed",
+			vendorExitCode: 9,
+			vendorMessage: "launch rejected",
+		});
+	});
+
+	test("an opaque list is not misrepresented as a per-sandbox lifecycle probe", () => {
+		const { compute: withList } = fakeCompute(baseSandbox, true);
+		expect(bridge(withList, { hasWorkingFilesystem: false }).probes).toBeUndefined();
+		const { compute: withoutList } = fakeCompute(baseSandbox, false);
+		expect(bridge(withoutList, { hasWorkingFilesystem: false }).probes).toBeUndefined();
+		expect(bridge(withoutList, { hasWorkingFilesystem: false }).snapshots).toBeUndefined();
+	});
+
+	test("projects explicitly implemented probes and snapshots without inventing absent ones", async () => {
+		const { compute } = fakeCompute(baseSandbox, true);
+		const calls: string[] = [];
+		const driver = bridge(compute, {
+			probes: {
+				observe: async (_compute, ref) => {
+					calls.push(`observe:${ref.id}`);
+					return { state: "running" };
+				},
+				list: async (provider) => provider.sandbox.list?.(),
+				describe: async (_compute, ref) => ({ id: ref.id }),
+			},
+			snapshots: {
+				create: async (_compute, session) => {
+					expect(session.native).toBe(nativeSandbox);
+					calls.push(`snapshot:${session.sandboxRef.id}`);
+					return { snapshotId: "snap-1" };
+				},
+				delete: async (_compute, snapshotId) => {
+					calls.push(`delete:${snapshotId}`);
+				},
+			},
+		});
+		const session = await driver.create(request);
+		expect(await driver.probes?.observe(session.sandboxRef)).toEqual({ state: "running" });
+		expect(await driver.probes?.list?.()).toEqual(["sb-1"]);
+		expect(await driver.probes?.describe?.(session.sandboxRef)).toEqual({ id: "i2f3k4abc" });
+		await expect(
+			driver.probes?.observe({ provider: "daytona-vm", id: "i2f3k4abc" }),
+		).rejects.toMatchObject({ code: "invalid-sandbox-ref", provider: "e2b" });
+		await expect(driver.probes?.observe({ provider: "e2b", id: "wrong-id" })).rejects.toMatchObject(
+			{ code: "invalid-sandbox-ref", provider: "e2b" },
+		);
+		const snapshot = await driver.snapshots?.create(session);
+		expect(snapshot).toEqual({ snapshotId: "snap-1" });
+		await expect(
+			driver.snapshots?.create({
+				...session,
+				sandboxRef: { provider: "daytona-vm", id: "bad" },
+			}),
+		).rejects.toMatchObject({ code: "invalid-sandbox-ref", provider: "e2b" });
+		await driver.snapshots?.delete("snap-1");
+		expect(calls).toEqual(["observe:i2f3k4abc", "snapshot:i2f3k4abc", "delete:snap-1"]);
+	});
+
+	test("decodes a raw wrapper id once and validates the stable canonical id thereafter", async () => {
+		const { compute } = fakeCompute({ ...baseSandbox, sandboxId: "raw-I2F3K4ABC" });
+		let receivedId = "";
+		let observedId = "";
+		const driver = bridge(compute, {
+			sandboxId: {
+				fromVendor: type(/^raw-/).pipe((id) => id.slice(4).toLowerCase()),
+				canonical: e2bSandboxId,
+			},
+			probes: {
+				observe: async (_compute, ref) => {
+					observedId = ref.id;
+					return { state: "running" };
+				},
+			},
+			snapshots: {
+				create: async (_compute, session) => {
+					receivedId = session.sandboxRef.id;
+					return { snapshotId: "snapshot-1" };
+				},
+				delete: async () => {},
+			},
+		});
+		const session = await driver.create(request);
+		expect(session.sandboxRef).toEqual({ provider: "e2b", id: "i2f3k4abc" });
+		expect(await driver.probes?.observe(session.sandboxRef)).toEqual({ state: "running" });
+		expect(observedId).toBe("i2f3k4abc");
+		await driver.snapshots?.create(session);
+		expect(receivedId).toBe("i2f3k4abc");
+		await expect(
+			driver.snapshots?.create({
+				...session,
+				sandboxRef: { provider: "e2b", id: "raw-I2F3K4ABC" },
+			}),
+		).rejects.toMatchObject({ code: "invalid-sandbox-ref", provider: "e2b" });
+	});
+
+	test("types and redacts a canonical-id validator throw before capability callbacks", async () => {
+		const canonical = type("string").narrow((id) => {
+			if (id === "test-key") throw new Error("canonical validator echoed test-key");
+			return /^i[a-z0-9]+$/.test(id);
+		});
+		const { compute } = fakeCompute(baseSandbox);
+		let observations = 0;
+		const driver = bridge(compute, {
+			sandboxId: { fromVendor: e2bSandboxId, canonical },
+			probes: {
+				observe: async () => {
+					observations += 1;
+					return { state: "running" };
+				},
+			},
+		});
+		await driver.create(request);
+		const error = (await driver.probes
+			?.observe({ provider: "e2b", id: "test-key" })
+			.catch((caught: unknown) => caught)) as DriverError;
+		expect(error).toMatchObject({ code: "vendor-contract-violation", provider: "e2b" });
+		expect(error.message).not.toContain("test-key");
+		expect(String(error.cause ?? "")).not.toContain("test-key");
+		expect(error.message).toContain("[REDACTED]");
+		expect(error.ref).toBeUndefined();
+		expect(observations).toBe(0);
+	});
+
+	test("types native extraction failures and retains cleanup ownership on a double fault", async () => {
+		let destroys = 0;
+		const { compute } = fakeCompute({
+			...baseSandbox,
+			getInstance: () => {
+				throw new Error("native unwrap failed with test-key");
+			},
+			destroy: async () => {
+				destroys += 1;
+				if (destroys === 1) throw new Error("cleanup echoed test-key");
+			},
+		});
+		const error = (await bridge(compute)
+			.create(request)
+			.catch((caught: unknown) => caught)) as FailedCreateCleanupError;
+		expect(error).toBeInstanceOf(FailedCreateCleanupError);
+		expect(error.locator).toEqual({ kind: "id", value: "i2f3k4abc" });
+		expect(error.suppressed).toMatchObject({
+			code: "vendor-contract-violation",
+			provider: "e2b",
+		});
+		expect(error.error).toMatchObject({ code: "destroy-failed", provider: "e2b" });
+		expect(String((error.suppressed as Error).message)).not.toContain("test-key");
+		expect(String((error.error as Error).message)).not.toContain("test-key");
+		await error.cleanup();
+		expect(destroys).toBe(2);
+	});
+
+	test("types a native extraction failure before returning after successful rollback", async () => {
+		let destroys = 0;
+		const { compute } = fakeCompute({
+			...baseSandbox,
+			getInstance: () => {
+				throw new Error("native unwrap failed");
+			},
+			destroy: async () => {
+				destroys += 1;
+			},
+		});
+		const error = await bridge(compute)
+			.create(request)
+			.catch((caught: unknown) => caught);
+		expect(error).toBeInstanceOf(DriverError);
+		expect(error).toMatchObject({ code: "vendor-contract-violation", provider: "e2b" });
+		expect(destroys).toBe(1);
+	});
+
+	test("redacts registry credentials from every wrapper diagnostic path", async () => {
+		const leaked = "test-key";
+
+		const createError = await bridge({
+			sandbox: { create: async () => Promise.reject(new Error(`create echoed ${leaked}`)) },
+		})
+			.create(request)
+			.catch((caught: unknown) => caught);
+		expectRedacted(createError);
+
+		const wrapper = (overrides: Partial<ComputeSdkSandboxLike> = {}) =>
+			fakeCompute({ ...baseSandbox, ...overrides }).compute;
+		const execSession = await bridge(
+			wrapper({ runCommand: async () => Promise.reject(new Error(`exec echoed ${leaked}`)) }),
+		).create(request);
+		expectRedacted(await execSession.exec("true").catch((caught: unknown) => caught));
+
+		const launchSession = await bridge(
+			wrapper({
+				runCommand: async () => ({ exitCode: 7, stderr: `launch echoed ${leaked}` }),
+			}),
+		).create(request);
+		expectRedacted(await launchSession.launch?.("task").catch((caught: unknown) => caught));
+
+		const destroySession = await bridge(
+			wrapper({ destroy: async () => Promise.reject(new Error(`destroy echoed ${leaked}`)) }),
+		).create(request);
+		expectRedacted(await destroySession.destroy().catch((caught: unknown) => caught));
+	});
+
+	test("types and redacts every projected filesystem, probe, and snapshot failure", async () => {
+		const rejected = (operation: string) =>
+			Promise.reject(new Error(`${operation} echoed test-key`));
+		const { compute } = fakeCompute({
+			...baseSandbox,
+			filesystem: {
+				readFile: () => rejected("read"),
+				exists: () => rejected("exists"),
+				writeFile: () => rejected("write"),
+			},
+		});
+		const driver = bridge(compute, {
+			hasWorkingFilesystem: true,
+			probes: {
+				observe: () => rejected("observe"),
+				list: () => rejected("list"),
+				describe: () => rejected("describe"),
+			},
+			snapshots: {
+				create: () => rejected("snapshot create"),
+				delete: () => rejected("snapshot delete"),
+			},
+		});
+		const session = await driver.create(request);
+		const attempts = [
+			session.files?.readFile("/secret"),
+			session.files?.exists("/secret"),
+			session.files?.writeText("/secret", "text"),
+			driver.probes?.observe(session.sandboxRef),
+			driver.probes?.list?.(),
+			driver.probes?.describe?.(session.sandboxRef),
+			driver.snapshots?.create(session),
+			driver.snapshots?.delete("snapshot-1"),
+		];
+		const codes = [
+			"filesystem-failed",
+			"filesystem-failed",
+			"filesystem-failed",
+			"probe-failed",
+			"probe-failed",
+			"probe-failed",
+			"snapshot-failed",
+			"snapshot-failed",
+		] as const;
+		const errors = await Promise.all(
+			attempts.map((attempt) => attempt?.catch((caught: unknown) => caught)),
+		);
+		for (const [index, error] of errors.entries()) expectRedacted(error, codes[index]);
+	});
+
+	test("does not redact ordinary one-character guest environment values", async () => {
+		const error = await bridge({
+			sandbox: {
+				create: async () => {
+					throw new Error("HTTP 401 after 1 attempt");
+				},
+			},
+		})
+			.create({ ...request, env: { BENCH_ATTEMPT: "1" } })
+			.catch((caught: unknown) => caught);
+		expect(error).toMatchObject({
+			code: "create-failed",
+			vendorMessage: "HTTP 401 after 1 attempt",
+		});
+	});
+
+	test("uses stdout when empty stderr cannot explain a missing background status", async () => {
+		const { compute } = fakeCompute({
+			...baseSandbox,
+			runCommand: async () => ({ stderr: "", stdout: "launch failed without status" }),
+		});
+		const session = await bridge(compute).create(request);
+		await expect(session.launch?.("task")).rejects.toMatchObject({
+			code: "exec-failed",
+			provider: "e2b",
+			vendorMessage: "launch failed without status",
+		});
+	});
+
+	test("supplies a nonempty fallback when a failed background launch has no diagnostic", async () => {
+		const { compute } = fakeCompute({
+			...baseSandbox,
+			runCommand: async () => ({ exitCode: 9, stderr: "", stdout: "" }),
+		});
+		const session = await bridge(compute).create(request);
+		await expect(session.launch?.("task")).rejects.toMatchObject({
+			code: "exec-failed",
+			provider: "e2b",
+			vendorMessage: "exit 9 with no diagnostic",
+		});
+	});
+
+	test("a vendor id in the wrong format for the provider fails ref construction", async () => {
+		let destroyed = 0;
+		const { compute } = fakeCompute({
+			...baseSandbox,
+			sandboxId: "totally wrong id!",
+			destroy: async () => {
+				destroyed += 1;
+			},
+		});
+		const error = (await bridge(compute, { hasWorkingFilesystem: false })
+			.create(request)
+			.catch((caught: unknown) => caught)) as DriverError;
+		expect(error.code).toBe("invalid-sandbox-ref");
+		expect(error.message).toMatch(/id must be matched by/);
+		expect(destroyed).toBe(1);
+	});
+
+	test("the kit's central byte cap reaches a computesdk session (was ignored before)", async () => {
+		const { compute } = fakeCompute({
+			...baseSandbox,
+			runCommand: async () => ({ exitCode: 0, stdout: "y".repeat(100), stderr: "" }),
+		});
+		const session = await bridge(compute, {
+			hasWorkingFilesystem: false,
+		}).create(request);
+		const capped = await session.exec("noisy", { maxOutputBytes: 10 });
+		expect(capped.stdout).toHaveLength(10);
+		expect(capped.truncated).toBe(true);
+	});
+
+	test("a sandbox without an id fails create loudly", async () => {
+		let destroyed = 0;
+		const { compute } = fakeCompute({
+			...baseSandbox,
+			sandboxId: undefined,
+			destroy: async () => {
+				destroyed += 1;
+			},
+		});
+		const error = (await bridge(compute, { hasWorkingFilesystem: false })
+			.create(request)
+			.catch((caught: unknown) => caught)) as DriverError;
+		expect(error.code).toBe("vendor-contract-violation");
+		expect(error.message).toContain("without a nonempty string sandboxId");
+		expect(destroyed).toBe(1);
+	});
+
+	test("a malformed resolved wrapper handle fails through the typed boundary", async () => {
+		const compute = {
+			sandbox: { create: async () => null },
+		} as unknown as ComputeSdkLike;
+		const error = await bridge(compute)
+			.create(request)
+			.catch((caught: unknown) => caught);
+		expect(error).toBeInstanceOf(DriverError);
+		expect(error).toMatchObject({
+			code: "vendor-contract-violation",
+			provider: "e2b",
+		});
+		expect((error as Error).message).toContain("non-object sandbox handle");
+	});
+
+	test("an already-aborted create never invokes the wrapper", async () => {
+		let createCalls = 0;
+		const compute: ComputeSdkLike = {
+			sandbox: {
+				create: async () => {
+					createCalls += 1;
+					return baseSandbox;
+				},
+			},
+		};
+		const cancellation = new AbortController();
+		cancellation.abort(new Error("shutdown"));
+		const error = await bridge(compute)
+			.create(request, { signal: cancellation.signal })
+			.catch((caught: unknown) => caught);
+		expect(error).toMatchObject({ code: "create-failed", provider: "e2b" });
+		expect(createCalls).toBe(0);
+	});
+
+	test("an abort during an uncancellable wrapper create reconciles the accepted handle first", async () => {
+		let releaseCreate!: (sandbox: ComputeSdkSandboxLike) => void;
+		const createResult = new Promise<ComputeSdkSandboxLike>((resolve) => {
+			releaseCreate = resolve;
+		});
+		let noteCreateStarted!: () => void;
+		const createStartedResult = new Promise<void>((resolve) => {
+			noteCreateStarted = resolve;
+		});
+		let releaseDestroy!: () => void;
+		const destroyResult = new Promise<void>((resolve) => {
+			releaseDestroy = resolve;
+		});
+		let noteDestroyStarted!: () => void;
+		const destroyStartedResult = new Promise<void>((resolve) => {
+			noteDestroyStarted = resolve;
+		});
+		let destroyStarted = false;
+		const accepted: ComputeSdkSandboxLike = {
+			...baseSandbox,
+			destroy: async () => {
+				destroyStarted = true;
+				noteDestroyStarted();
+				await destroyResult;
+			},
+		};
+		const compute: ComputeSdkLike = {
+			sandbox: {
+				create: async () => {
+					noteCreateStarted();
+					return createResult;
+				},
+			},
+		};
+		const cancellation = new AbortController();
+		let settled = false;
+		const creating = bridge(compute)
+			.create(request, { signal: cancellation.signal })
+			.catch((caught: unknown) => caught)
+			.finally(() => {
+				settled = true;
+			});
+
+		await createStartedResult;
+		cancellation.abort(new Error("shutdown"));
+		releaseCreate(accepted);
+		await destroyStartedResult;
+		expect(destroyStarted).toBe(true);
+		expect(settled).toBe(false);
+		releaseDestroy();
+
+		const error = await creating;
+		expect(error).toMatchObject({ code: "create-failed", provider: "e2b" });
+		expect(settled).toBe(true);
+	});
+
+	test("a validation/cleanup double fault preserves both failures and retryable ownership", async () => {
+		let destroyCalls = 0;
+		const { compute } = fakeCompute({
+			...baseSandbox,
+			sandboxId: undefined,
+			destroy: async () => {
+				destroyCalls++;
+				if (destroyCalls === 1) throw new Error("cleanup exploded");
+			},
+		});
+		const error = (await bridge(compute, {
+			hasWorkingFilesystem: false,
+		})
+			.create(request)
+			.catch((caught: unknown) => caught)) as FailedCreateCleanupError;
+		expect(error).toBeInstanceOf(FailedCreateCleanupError);
+		expect(error).toBeInstanceOf(SuppressedError);
+		expect((error.error as DriverError).code).toBe("destroy-failed");
+		expect((error.suppressed as DriverError).code).toBe("vendor-contract-violation");
+		expect(error).toMatchObject({ provider: "e2b", locator: { kind: "native-handle" } });
+
+		await error[Symbol.asyncDispose]();
+		await error[Symbol.asyncDispose]();
+		expect(destroyCalls).toBe(2);
+	});
+
+	test("wrapper rejections use the shared typed error family", async () => {
+		const retained = new FailedCreateCleanupError(
+			new Error("wrapper cleanup failed"),
+			new Error("wrapper create failed"),
+			{
+				provider: "e2b",
+				locator: { kind: "id", value: "i-retained" },
+				cleanup: async () => {},
+			},
+		);
+		const retainedCompute: ComputeSdkLike = {
+			sandbox: {
+				create: async () => {
+					throw retained;
+				},
+			},
+		};
+		expect(
+			await bridge(retainedCompute)
+				.create(request)
+				.catch((caught: unknown) => caught),
+		).toBe(retained);
+
+		const createFailure: ComputeSdkLike = {
+			sandbox: {
+				create: async () => {
+					throw new Error("provider unavailable");
+				},
+			},
+		};
+		const createError = await bridge(createFailure, {
+			hasWorkingFilesystem: false,
+		})
+			.create(request)
+			.catch((caught: unknown) => caught);
+		expect(createError).toMatchObject({
+			code: "create-failed",
+			provider: "e2b",
+			vendorMessage: "provider unavailable",
+		});
+
+		const { compute } = fakeCompute({
+			...baseSandbox,
+			runCommand: async () => {
+				throw new Error("transport closed");
+			},
+		});
+		const session = await bridge(compute, {
+			hasWorkingFilesystem: false,
+		}).create(request);
+		const execError = await session.exec("true").catch((caught: unknown) => caught);
+		expect(execError).toMatchObject({
+			code: "exec-failed",
+			provider: "e2b",
+			vendorMessage: "transport closed",
+		});
+	});
+
+	test("never preserves a foreign provider ref from an already-typed wrapper error", async () => {
+		const foreign = new DriverError("destroy-failed", "wrong wrapper channel", {
+			provider: "daytona-vm",
+			ref: { provider: "daytona-vm", id: "wrong-id" },
+		});
+		const error = (await bridge({
+			sandbox: {
+				create: async () => {
+					throw foreign;
+				},
+			},
+		})
+			.create(request)
+			.catch((caught: unknown) => caught)) as DriverError;
+		expect(error).toMatchObject({ code: "create-failed", provider: "e2b" });
+		expect(error.ref).toBeUndefined();
+	});
+
+	test("never preserves a failed-create cleanup capability across provider or operation boundaries", async () => {
+		let foreignCleanupCalls = 0;
+		const foreign = new FailedCreateCleanupError(
+			new Error("foreign cleanup failed"),
+			new Error("foreign create failed"),
+			{
+				provider: "daytona-vm",
+				locator: { kind: "id", value: "foreign-id" },
+				cleanup: async () => {
+					foreignCleanupCalls++;
+				},
+			},
+		);
+		const createError = await bridge({
+			sandbox: {
+				create: async () => {
+					throw foreign;
+				},
+			},
+		})
+			.create(request)
+			.catch((caught: unknown) => caught);
+		expect(createError).not.toBeInstanceOf(FailedCreateCleanupError);
+		expect(createError).toMatchObject({ code: "create-failed", provider: "e2b" });
+		expect(createError).not.toHaveProperty("locator");
+		expect(foreignCleanupCalls).toBe(0);
+
+		let wrongChannelCleanupCalls = 0;
+		const wrongChannel = new FailedCreateCleanupError(
+			new Error("cleanup failed"),
+			new Error("create failed"),
+			{
+				provider: "e2b",
+				locator: { kind: "id", value: "i-retained" },
+				cleanup: async () => {
+					wrongChannelCleanupCalls++;
+				},
+			},
+		);
+		const { compute } = fakeCompute({
+			...baseSandbox,
+			runCommand: async () => {
+				throw wrongChannel;
+			},
+		});
+		const session = await bridge(compute, { hasWorkingFilesystem: false }).create(request);
+		const execError = await session.exec("true").catch((caught: unknown) => caught);
+		expect(execError).not.toBeInstanceOf(FailedCreateCleanupError);
+		expect(execError).toMatchObject({
+			code: "exec-failed",
+			provider: "e2b",
+			ref: session.sandboxRef,
+		});
+		expect(execError).not.toHaveProperty("locator");
+		expect(wrongChannelCleanupCalls).toBe(0);
+	});
+
+	test("normalizes foreign typed-error codes to the current operation boundary", async () => {
+		const wrongChannel = () =>
+			new DriverError("create-failed", "wrapper chose the create channel", {
+				provider: "daytona-vm",
+			});
+		const { compute } = fakeCompute({
+			...baseSandbox,
+			runCommand: async () => {
+				throw wrongChannel();
+			},
+			filesystem: {
+				readFile: async () => {
+					throw wrongChannel();
+				},
+				exists: async () => true,
+				writeFile: async () => {},
+			},
+		});
+		const session = await bridge(compute, { hasWorkingFilesystem: true }).create(request);
+		await expect(session.exec("true")).rejects.toMatchObject({
+			code: "exec-failed",
+			provider: "e2b",
+		});
+		await expect(session.files?.readFile("/tmp/file")).rejects.toMatchObject({
+			code: "filesystem-failed",
+			provider: "e2b",
+			ref: session.sandboxRef,
+		});
+	});
+});

--- a/packages/drivers/src/_computesdk.ts
+++ b/packages/drivers/src/_computesdk.ts
@@ -1,0 +1,987 @@
+// The ComputeSDK bridge (ADR-0007 §6): computesdk keeps all its real value — maintained vendor
+// translations — as ONE driver among several, and stops being the substrate every provider
+// must impersonate.
+//
+// The bridge is a MethodTable, not a hand-assembled driver, so it flows through the same
+// assembly layer as every other driver (table.ts) and inherits its session invariants for free:
+// central output capping, the use-after-destroy guard, and artifact reconciliation. It is also
+// deliberately STRUCTURAL: this private bridge declares the shape it consumes instead of importing
+// computesdk itself. Two rules from ADR-0007 are load-bearing:
+//
+//   - `hasWorkingFilesystem` is EXPLICIT, because computesdk's UnsupportedFileSystem is a
+//     truthy stub whose every method throws — the sentinel that killed a namespace step. The
+//     stub is filtered here and never reaches a consumer.
+//   - `native` is the WRAPPER's getInstance() value, typed by the wrapper's own vendored SDK —
+//     never cast to this repo's copy of a vendor SDK. Wrappers vendor their own builds; the
+//     classes are nominally different. Code that needs the repo's SDK types is code that
+//     should be a native driver.
+
+import type {
+	CreateBudget,
+	CreateRequest,
+	DriverContext,
+	DriverErrorCode,
+	DriverModule,
+	DriverOperationOptions,
+	MethodTable,
+	ProviderId,
+	ResolvedArtifact,
+	SandboxObservation,
+	SandboxRef,
+	SandboxSession,
+} from "@sandbox-benchmarks/driver";
+import {
+	DriverError,
+	defineDriver,
+	driverFromTable,
+	FailedCreateCleanupError,
+	isDriverError,
+	isFailedCreateCleanupError,
+	sandboxRef,
+} from "@sandbox-benchmarks/driver";
+import { sensitiveEnvValuesFor } from "@sandbox-benchmarks/driver/env";
+import type { Out, Type } from "arktype";
+import { type } from "arktype";
+
+/** The structural slice of a computesdk provider instance this bridge consumes. */
+export interface ComputeSdkLike<TSandbox extends ComputeSdkSandboxLike = ComputeSdkSandboxLike> {
+	readonly sandbox: {
+		create(options?: Record<string, unknown>): Promise<TSandbox>;
+		list?(): Promise<unknown>;
+	};
+}
+
+export interface ComputeSdkSandboxLike<TNative = unknown> {
+	readonly sandboxId?: string;
+	/** The wrapper's vendored native SDK instance; this becomes SandboxSession.native. */
+	getInstance(): TNative;
+	runCommand(
+		command: string,
+		options?: { readonly background?: boolean },
+	): Promise<{ readonly exitCode?: number; readonly stdout?: string; readonly stderr?: string }>;
+	destroy(): Promise<unknown>;
+	readonly filesystem?: {
+		readFile(path: string): Promise<string>;
+		exists(path: string): Promise<boolean>;
+		writeFile(path: string, content: string): Promise<void>;
+	};
+}
+
+export type ComputeSdkNativeOf<TSandbox extends ComputeSdkSandboxLike> = ReturnType<
+	TSandbox["getInstance"]
+>;
+
+export type ComputeSdkSandboxOf<TCompute extends ComputeSdkLike> = Awaited<
+	ReturnType<TCompute["sandbox"]["create"]>
+>;
+
+type ComputeSdkSandboxIdParser = Type<string> | Type<(In: string) => Out<string>>;
+
+/**
+ * A simple provider id schema is inherently stable because its input and output are the same
+ * string grammar. Providers that decode a vendor id into a different canonical form must declare
+ * both boundaries: the raw wrapper parser and the grammar accepted everywhere after create.
+ */
+export type ComputeSdkSandboxIdSchema =
+	| Type<string>
+	| {
+			readonly fromVendor: ComputeSdkSandboxIdParser;
+			readonly canonical: Type<string>;
+	  };
+
+interface ComputeSdkSandboxIdBoundary {
+	readonly fromVendor: ComputeSdkSandboxIdParser;
+	readonly canonical: Type<string>;
+	readonly transformed: boolean;
+}
+
+type ComputeSdkTargetAxisDisposition = "mapped" | "artifact" | "unsupported";
+type ComputeSdkOptionalAxisDisposition = "mapped" | "unsupported";
+
+/**
+ * Compile-time proof that a provider author considered every canonical request axis. TargetSpec
+ * fields are listed individually, so adding (for example) a disk or accelerator field breaks every
+ * mapper until the provider declares whether it maps, artifact-pins, or cannot control that axis.
+ * Artifact selection and attempt deadline are kit/composition concerns, but remain explicit here
+ * so adding any top-level CreateRequest field is also a compiler-forced review event.
+ */
+export type ComputeSdkCreateRequestCoverage = {
+	readonly spec: {
+		readonly [Axis in keyof CreateRequest["spec"]]-?: ComputeSdkTargetAxisDisposition;
+	};
+	/** Resolved once by the composition root; never reinterpreted as a wrapper timeout/lifetime. */
+	readonly artifact: "context";
+	/** The harness owns this attempt budget; wrappers must not confuse it with sandbox lifetime. */
+	readonly deadlineMs: "harness";
+	readonly gpu: {
+		readonly [Axis in keyof NonNullable<CreateRequest["gpu"]>]-?: ComputeSdkOptionalAxisDisposition;
+	};
+} & {
+	readonly [Axis in Exclude<
+		keyof CreateRequest,
+		"spec" | "artifact" | "deadlineMs" | "gpu"
+	>]-?: ComputeSdkOptionalAxisDisposition;
+};
+
+export interface ComputeSdkCreateRequestMapper {
+	readonly coverage: ComputeSdkCreateRequestCoverage;
+	readonly map: (
+		request: CreateRequest,
+		unsupported: (detail: string) => never,
+	) => Readonly<Record<string, unknown>>;
+}
+
+export interface ComputeSdkDriverSpec<TCompute extends ComputeSdkLike> {
+	/** Construct the wrapper lazily from this provider module's exact env/artifact context. */
+	readonly compute: TCompute;
+	/** Module-owned trust boundary for the wrapper's vendor-specific sandbox id. */
+	readonly sandboxId: ComputeSdkSandboxIdSchema;
+	/**
+	 * Declare the disposition of every canonical request axis, then validate and translate the
+	 * request into wrapper options (including the `snapshotId`/`templateId` conventions the bake
+	 * path relies on). The returned options stay open because the port does not model every vendor's
+	 * create surface, while `coverage` makes additions to CreateRequest a compile-time review event.
+	 * Call `unsupported(detail)` for cross-field combinations this provider cannot honor.
+	 *
+	 * Artifact refs are resolved in DriverContext before this spec is built; provider files never
+	 * read ambient process configuration or decide candidate-versus-version lanes.
+	 */
+	readonly createOptions: ComputeSdkCreateRequestMapper;
+	/**
+	 * Whether the wrapper's filesystem actually works. Explicit, because the wrapper cannot be
+	 * asked: UnsupportedFileSystem is truthy and throws. ADR-0008's smoke conformance verifies
+	 * the answer against the live vendor.
+	 */
+	readonly hasWorkingFilesystem: boolean;
+	/** Honest lifecycle probes supplied only when this wrapper/provider can implement them. */
+	readonly probes?: {
+		observe(compute: TCompute, ref: SandboxRef): Promise<SandboxObservation>;
+		list?(compute: TCompute): Promise<unknown>;
+		describe?(compute: TCompute, ref: SandboxRef): Promise<unknown>;
+	};
+	/** Honest snapshot projection; omission records an unsupported capability instead of a stub. */
+	readonly snapshots?: {
+		create(
+			compute: TCompute,
+			session: SandboxSession<ComputeSdkNativeOf<ComputeSdkSandboxOf<TCompute>>>,
+		): Promise<{ readonly snapshotId: string }>;
+		delete(compute: TCompute, snapshotId: string): Promise<void>;
+	};
+}
+
+/**
+ * Preserve the installed wrapper's complete type while contextually typing capability callbacks.
+ * TypeScript cannot infer one object property's type and use it to type a sibling callback in the
+ * same literal, so the compute value is deliberately the first argument to this tiny authoring
+ * helper rather than being widened to the bridge's structural minimum.
+ */
+export function computeSdkSpec<TCompute extends ComputeSdkLike>(
+	compute: TCompute,
+	spec: Omit<ComputeSdkDriverSpec<TCompute>, "compute">,
+): ComputeSdkDriverSpec<TCompute> {
+	return { ...spec, compute };
+}
+
+/** One registry-joined ComputeSDK provider module. The id exists only in defineComputeSdkDriver. */
+export interface ComputeSdkDriverModuleSpec<P extends ProviderId, TCompute extends ComputeSdkLike> {
+	/** ComputeSDK exposes no cancellable hard ceiling, so only the harness may own this budget. */
+	readonly createBudget?: Extract<CreateBudget, { readonly owner: "harness" }>;
+	/** Builds the wrapper binding from exactly this provider's resolved input slice. */
+	readonly spec: (context: DriverContext<P>) => ComputeSdkDriverSpec<TCompute>;
+}
+
+type BoundComputeSdkDriverSpec<TCompute extends ComputeSdkLike> = Omit<
+	ComputeSdkDriverSpec<TCompute>,
+	"compute"
+> & {
+	readonly resolvedArtifact: ResolvedArtifact;
+	/** Registry-resolved provider inputs are credentials until proven otherwise. */
+	readonly sensitiveValues: readonly string[];
+};
+
+/** A private brand lets bridge-authored contract errors survive without trusting vendor codes. */
+class ComputeSdkContractError extends DriverError {}
+
+function vendorContractFailure(
+	provider: ProviderId,
+	operation: string,
+	caught: unknown,
+	sensitiveValues: readonly string[],
+	ref?: SandboxRef,
+): ComputeSdkContractError {
+	const detail = redactKnownDiagnostic(
+		caught instanceof Error ? caught.message : String(caught),
+		sensitiveValues,
+	);
+	return new ComputeSdkContractError(
+		"vendor-contract-violation",
+		`computesdk ${operation} violated its wrapper contract: ${detail}`,
+		{
+			provider,
+			...(ref === undefined ? {} : { ref }),
+			cause: new Error(detail),
+		},
+	);
+}
+
+function wrapperFailure(
+	code: Extract<
+		DriverErrorCode,
+		| "create-failed"
+		| "exec-failed"
+		| "destroy-failed"
+		| "filesystem-failed"
+		| "probe-failed"
+		| "snapshot-failed"
+	>,
+	provider: ProviderId,
+	operation: string,
+	caught: unknown,
+	ref?: SandboxRef,
+	sensitiveValues: readonly string[] = [],
+): DriverError | FailedCreateCleanupError {
+	// A retained cleanup capability may cross this boundary only on the create channel that owns it.
+	// Normalizing every other case drops the foreign/destructive callback just like it drops a
+	// foreign DriverError ref below.
+	if (
+		isFailedCreateCleanupError(caught) &&
+		code === "create-failed" &&
+		caught.provider === provider
+	) {
+		return caught;
+	}
+	if (caught instanceof ComputeSdkContractError) return caught;
+	const redact = (detail: string) => redactKnownDiagnostic(detail, sensitiveValues);
+	if (isDriverError(caught)) {
+		return new DriverError(code, redact(caught.message), {
+			provider,
+			...(ref ? { ref } : {}),
+			...(caught.vendorMessage === undefined
+				? {}
+				: { vendorMessage: redact(caught.vendorMessage) }),
+			...(caught.vendorExitCode === undefined ? {} : { vendorExitCode: caught.vendorExitCode }),
+			cause: new Error(redact(caught.message)),
+		});
+	}
+	const detail = redact(caught instanceof Error ? caught.message : String(caught));
+	return new DriverError(code, `computesdk ${operation} failed: ${detail}`, {
+		provider,
+		vendorMessage: detail,
+		cause: new Error(detail),
+		...(ref ? { ref } : {}),
+	});
+}
+
+async function wrapperCapability<T>(
+	code: Extract<DriverErrorCode, "filesystem-failed" | "probe-failed" | "snapshot-failed">,
+	provider: ProviderId,
+	operation: string,
+	sensitiveValues: readonly string[],
+	run: () => Promise<T>,
+	ref?: SandboxRef,
+): Promise<T> {
+	try {
+		return await run();
+	} catch (caught) {
+		throw wrapperFailure(code, provider, operation, caught, ref, sensitiveValues);
+	}
+}
+
+/** Compile a computesdk provider instance to a method table. */
+function computeSdkMethodTable<TCompute extends ComputeSdkLike>(
+	provider: ProviderId,
+	options: BoundComputeSdkDriverSpec<TCompute>,
+): MethodTable<
+	ComputeSdkSandboxOf<TCompute>,
+	TCompute,
+	ComputeSdkNativeOf<ComputeSdkSandboxOf<TCompute>>
+> {
+	const wantsFiles = options.hasWorkingFilesystem;
+	const probes = options.probes;
+	const probeList = probes?.list;
+	const probeDescribe = probes?.describe;
+	const snapshots = options.snapshots;
+	const sandboxIds = sandboxIdBoundary(options.sandboxId);
+	const handleSensitiveValues = new WeakMap<object, readonly string[]>();
+	const handleRefIds = new WeakMap<object, string>();
+	const refSensitiveValues = new Map<string, readonly string[]>();
+	const sensitiveFor = (sandbox: ComputeSdkSandboxOf<TCompute>): readonly string[] =>
+		handleSensitiveValues.get(sandbox) ?? options.sensitiveValues;
+	const sensitiveForRef = (ref: SandboxRef): readonly string[] =>
+		refSensitiveValues.get(ref.id) ?? options.sensitiveValues;
+	const refFor = (sandbox: ComputeSdkSandboxOf<TCompute>): SandboxRef | undefined => {
+		const id = handleRefIds.get(sandbox);
+		return id === undefined ? undefined : sandboxRef(provider, id);
+	};
+	return {
+		async create(compute, request: CreateRequest, operationOptions?: DriverOperationOptions) {
+			if (operationOptions?.signal?.aborted) {
+				throw wrapperAborted(provider, operationOptions.signal.reason);
+			}
+			const sensitiveValues = options.sensitiveValues;
+			const createOptions = mapCreateRequest(
+				provider,
+				options.createOptions,
+				request,
+				sensitiveValues,
+			);
+			let created: ComputeSdkSandboxOf<TCompute>;
+			try {
+				created = (await compute.sandbox.create(createOptions)) as ComputeSdkSandboxOf<TCompute>;
+			} catch (caught) {
+				throw wrapperFailure(
+					"create-failed",
+					provider,
+					"create",
+					caught,
+					undefined,
+					sensitiveValues,
+				);
+			}
+			if ((typeof created !== "object" && typeof created !== "function") || created === null) {
+				throw new DriverError(
+					"vendor-contract-violation",
+					"computesdk wrapper returned a non-object sandbox handle",
+					{ provider },
+				);
+			}
+			handleSensitiveValues.set(created, sensitiveValues);
+
+			let parsedId: string | undefined;
+			try {
+				if (operationOptions?.signal?.aborted) {
+					throw wrapperAborted(provider, operationOptions.signal.reason);
+				}
+				const id = readSandboxId(created, provider, sensitiveValues);
+				if (typeof id !== "string" || id.length === 0) {
+					throw vendorContractFailure(
+						provider,
+						"sandbox identity",
+						new Error("wrapper returned a sandbox without a nonempty string sandboxId"),
+						sensitiveValues,
+					);
+				}
+				parsedId = parseVendorSandboxId(provider, sandboxIds, id, sensitiveValues);
+				const ref = sandboxRef(provider, parsedId);
+				handleRefIds.set(created, parsedId);
+				refSensitiveValues.set(parsedId, sensitiveValues);
+				if (wantsFiles) requireFilesystem(created, provider, sensitiveValues, ref);
+				let native: ComputeSdkNativeOf<ComputeSdkSandboxOf<TCompute>>;
+				try {
+					native = created.getInstance() as ComputeSdkNativeOf<ComputeSdkSandboxOf<TCompute>>;
+				} catch (caught) {
+					const detail = redactKnownDiagnostic(
+						caught instanceof Error ? caught.message : String(caught),
+						sensitiveValues,
+					);
+					throw new DriverError(
+						"vendor-contract-violation",
+						`computesdk getInstance failed: ${detail}`,
+						{ provider, ref, cause: new Error(detail) },
+					);
+				}
+				return {
+					handle: created,
+					native,
+					sandboxRef: ref,
+					artifact: options.resolvedArtifact,
+				};
+			} catch (primary) {
+				const retryCleanup = async (cleanupOptions?: DriverOperationOptions) => {
+					if (cleanupOptions?.signal?.aborted) {
+						throw wrapperAborted(
+							provider,
+							cleanupOptions.signal.reason,
+							"failed-create cleanup",
+							"destroy-failed",
+						);
+					}
+					try {
+						await created.destroy();
+						handleSensitiveValues.delete(created);
+						handleRefIds.delete(created);
+						if (parsedId !== undefined) refSensitiveValues.delete(parsedId);
+					} catch (caught) {
+						throw wrapperFailure(
+							"destroy-failed",
+							provider,
+							"failed-create cleanup",
+							caught,
+							undefined,
+							sensitiveValues,
+						);
+					}
+				};
+				try {
+					await retryCleanup();
+				} catch (cleanupError) {
+					throw new FailedCreateCleanupError(cleanupError, primary, {
+						provider,
+						locator:
+							parsedId === undefined ? { kind: "native-handle" } : { kind: "id", value: parsedId },
+						cleanup: retryCleanup,
+					});
+				}
+				throw primary;
+			}
+		},
+		async exec(_compute, sandbox, command) {
+			const started = Date.now();
+			let result: NormalizedComputeSdkCommandResult;
+			try {
+				result = normalizeCommandResult(
+					provider,
+					"exec",
+					await sandbox.runCommand(command),
+					sensitiveFor(sandbox),
+					refFor(sandbox),
+				);
+			} catch (caught) {
+				throw wrapperFailure(
+					"exec-failed",
+					provider,
+					"exec",
+					caught,
+					refFor(sandbox),
+					sensitiveFor(sandbox),
+				);
+			}
+			return {
+				// No forged `?? 1`: a wrapper that withholds the exit code yields the representable
+				// `unknown` arm instead of a fake failure.
+				exit:
+					result.exitCode === undefined
+						? { kind: "unknown" as const, detail: "computesdk adapter reported no exit code" }
+						: { kind: "exited" as const, code: result.exitCode },
+				stdout: result.stdout ?? "",
+				stderr: result.stderr ?? "",
+				durationMs: Date.now() - started,
+				truncated: false, // the kit applies caps centrally (table.ts / output.ts)
+			};
+		},
+		async destroy(_compute, sandbox, operationOptions) {
+			if (operationOptions?.signal?.aborted) {
+				throw wrapperAborted(provider, operationOptions.signal.reason, "destroy", "destroy-failed");
+			}
+			try {
+				await sandbox.destroy();
+			} catch (caught) {
+				throw wrapperFailure(
+					"destroy-failed",
+					provider,
+					"destroy",
+					caught,
+					undefined,
+					sensitiveFor(sandbox),
+				);
+			}
+			handleSensitiveValues.delete(sandbox);
+			const refId = handleRefIds.get(sandbox);
+			handleRefIds.delete(sandbox);
+			if (refId !== undefined) refSensitiveValues.delete(refId);
+		},
+		async launch(_compute, sandbox, command) {
+			let result: NormalizedComputeSdkCommandResult;
+			try {
+				result = normalizeCommandResult(
+					provider,
+					"background launch",
+					await sandbox.runCommand(command, { background: true }),
+					sensitiveFor(sandbox),
+					refFor(sandbox),
+				);
+			} catch (caught) {
+				throw wrapperFailure(
+					"exec-failed",
+					provider,
+					"background launch",
+					caught,
+					refFor(sandbox),
+					sensitiveFor(sandbox),
+				);
+			}
+			const diagnostic =
+				result.stderr?.trim() ||
+				result.stdout?.trim() ||
+				(result.exitCode === undefined
+					? "missing exit status"
+					: `exit ${result.exitCode} with no diagnostic`);
+			if (result.exitCode === undefined) {
+				throw new DriverError(
+					"exec-failed",
+					"computesdk background launch returned no acceptance status",
+					{
+						provider,
+						vendorMessage: redactKnownDiagnostic(diagnostic, sensitiveFor(sandbox)),
+					},
+				);
+			}
+			if (result.exitCode !== 0) {
+				throw new DriverError(
+					"exec-failed",
+					`computesdk background launch exited with code ${result.exitCode}`,
+					{
+						provider,
+						vendorExitCode: result.exitCode,
+						vendorMessage: redactKnownDiagnostic(diagnostic, sensitiveFor(sandbox)),
+					},
+				);
+			}
+		},
+		// The stub never escapes: create verifies that a declared filesystem is present, and the
+		// per-operation guards catch a wrapper that later withdraws the capability.
+		...(wantsFiles
+			? {
+					files: {
+						readFile: (_compute, sandbox, path) => {
+							const filesystem = requireFilesystem(
+								sandbox,
+								provider,
+								sensitiveFor(sandbox),
+								refFor(sandbox),
+							);
+							return wrapperCapability(
+								"filesystem-failed",
+								provider,
+								"filesystem read",
+								sensitiveFor(sandbox),
+								() => filesystem.readFile(path),
+								refFor(sandbox),
+							);
+						},
+						exists: (_compute, sandbox, path) => {
+							const filesystem = requireFilesystem(
+								sandbox,
+								provider,
+								sensitiveFor(sandbox),
+								refFor(sandbox),
+							);
+							return wrapperCapability(
+								"filesystem-failed",
+								provider,
+								"filesystem exists",
+								sensitiveFor(sandbox),
+								() => filesystem.exists(path),
+								refFor(sandbox),
+							);
+						},
+						writeText: (_compute, sandbox, path, text) => {
+							const filesystem = requireFilesystem(
+								sandbox,
+								provider,
+								sensitiveFor(sandbox),
+								refFor(sandbox),
+							);
+							return wrapperCapability(
+								"filesystem-failed",
+								provider,
+								"filesystem write",
+								sensitiveFor(sandbox),
+								() => filesystem.writeFile(path, text),
+								refFor(sandbox),
+							);
+						},
+					},
+				}
+			: {}),
+		...(probes === undefined
+			? {}
+			: {
+					probes: {
+						observe: (compute, ref) => {
+							const canonical = validateRef(
+								provider,
+								sandboxIds.canonical,
+								ref,
+								sensitiveForRef(ref),
+							);
+							return wrapperCapability(
+								"probe-failed",
+								provider,
+								"probe observe",
+								sensitiveForRef(canonical),
+								() => probes.observe(compute, canonical),
+								canonical,
+							);
+						},
+						...(probeList === undefined
+							? {}
+							: {
+									list: (compute: TCompute) =>
+										wrapperCapability(
+											"probe-failed",
+											provider,
+											"probe list",
+											options.sensitiveValues,
+											() => probeList(compute),
+										),
+								}),
+						...(probeDescribe === undefined
+							? {}
+							: {
+									describe: (compute: TCompute, ref: SandboxRef) => {
+										const canonical = validateRef(
+											provider,
+											sandboxIds.canonical,
+											ref,
+											sensitiveForRef(ref),
+										);
+										return wrapperCapability(
+											"probe-failed",
+											provider,
+											"probe describe",
+											sensitiveForRef(canonical),
+											() => probeDescribe(compute, canonical),
+											canonical,
+										);
+									},
+								}),
+					},
+				}),
+		...(snapshots === undefined
+			? {}
+			: {
+					snapshots: {
+						create: (
+							compute: TCompute,
+							session: SandboxSession<ComputeSdkNativeOf<ComputeSdkSandboxOf<TCompute>>>,
+						) => {
+							const canonical = validateRef(
+								provider,
+								sandboxIds.canonical,
+								session.sandboxRef,
+								sensitiveForRef(session.sandboxRef),
+							);
+							return wrapperCapability(
+								"snapshot-failed",
+								provider,
+								"snapshot create",
+								sensitiveForRef(canonical),
+								() => snapshots.create(compute, { ...session, sandboxRef: canonical }),
+								canonical,
+							);
+						},
+						delete: (compute: TCompute, snapshotId: string) =>
+							wrapperCapability(
+								"snapshot-failed",
+								provider,
+								"snapshot delete",
+								options.sensitiveValues,
+								() => snapshots.delete(compute, snapshotId),
+							),
+					},
+				}),
+	};
+}
+
+function mapCreateRequest(
+	provider: ProviderId,
+	mapper: ComputeSdkCreateRequestMapper,
+	request: CreateRequest,
+	sensitiveValues: readonly string[],
+): Readonly<Record<string, unknown>> {
+	const redact = (detail: string) => redactKnownDiagnostic(detail, sensitiveValues);
+	let mapped: Readonly<Record<string, unknown>>;
+	try {
+		for (const [axis, disposition] of Object.entries(mapper.coverage.spec)) {
+			const value = request.spec[axis as keyof CreateRequest["spec"]];
+			if (disposition === "unsupported" && value !== undefined) {
+				throw new UnsupportedComputeSdkRequest(`target axis ${axis} is unsupported`);
+			}
+		}
+		if (request.gpu !== undefined) {
+			const gpu = request.gpu as unknown as Readonly<Record<string, unknown>>;
+			for (const [axis, disposition] of Object.entries(mapper.coverage.gpu)) {
+				if (disposition === "unsupported" && gpu[axis] !== undefined) {
+					throw new UnsupportedComputeSdkRequest(
+						`GPU ${request.gpu.model} x${request.gpu.count} is unsupported (axis ${axis})`,
+					);
+				}
+			}
+		}
+		const requestRecord = request as unknown as Readonly<Record<string, unknown>>;
+		for (const [axis, disposition] of Object.entries(mapper.coverage)) {
+			if (axis === "spec" || axis === "artifact" || axis === "deadlineMs" || axis === "gpu") {
+				continue;
+			}
+			const value = requestRecord[axis];
+			const emptyEnvironment =
+				axis === "env" &&
+				value !== null &&
+				typeof value === "object" &&
+				Object.keys(value).length === 0;
+			if (disposition === "unsupported" && value !== undefined && !emptyEnvironment) {
+				throw new UnsupportedComputeSdkRequest(
+					axis === "env"
+						? "guest environment injection is unsupported"
+						: `request axis ${axis} is unsupported`,
+				);
+			}
+		}
+		mapped = mapper.map(request, (detail) => {
+			throw new UnsupportedComputeSdkRequest(detail);
+		});
+	} catch (caught) {
+		if (caught instanceof UnsupportedComputeSdkRequest) {
+			throw new DriverError(
+				"invalid-create-request",
+				`${provider} cannot honor the requested sandbox shape: ${redact(caught.message)}`,
+				{ provider },
+			);
+		}
+		if (isDriverError(caught) && caught.code === "invalid-create-request") {
+			const detail = redact(caught.message);
+			throw new DriverError("invalid-create-request", detail, {
+				provider,
+				cause: new Error(detail),
+			});
+		}
+		const detail = redact(caught instanceof Error ? caught.message : String(caught));
+		throw new DriverError(
+			"vendor-contract-violation",
+			`${provider} create-request mapper failed: ${detail}`,
+			{ provider, cause: new Error(detail) },
+		);
+	}
+	if (mapped === null || typeof mapped !== "object" || Array.isArray(mapped)) {
+		throw new DriverError(
+			"vendor-contract-violation",
+			`${provider} create-request mapper must return an options object`,
+			{ provider },
+		);
+	}
+	return mapped;
+}
+
+function redactKnownDiagnostic(detail: string, sensitiveValues: readonly string[]): string {
+	let redacted = detail;
+	const unique = [...new Set(sensitiveValues.filter((value) => value.length > 0))].sort(
+		(left, right) => right.length - left.length,
+	);
+	for (const value of unique) redacted = redacted.replaceAll(value, "[REDACTED]");
+	return redacted;
+}
+
+class UnsupportedComputeSdkRequest extends Error {
+	constructor(detail: string) {
+		super(detail);
+		this.name = "UnsupportedComputeSdkRequest";
+	}
+}
+
+function sandboxIdBoundary(schema: ComputeSdkSandboxIdSchema): ComputeSdkSandboxIdBoundary {
+	return typeof schema === "function"
+		? { fromVendor: schema, canonical: schema, transformed: false }
+		: { ...schema, transformed: true };
+}
+
+function parseSandboxId(
+	provider: ProviderId,
+	schema: ComputeSdkSandboxIdParser,
+	value: string,
+	sensitiveValues: readonly string[],
+	boundary: "wrapper" | "canonical",
+): string {
+	const redact = (detail: string) => redactKnownDiagnostic(detail, sensitiveValues);
+	let parsed: string | type.errors;
+	try {
+		parsed = schema(value);
+	} catch (caught) {
+		const detail = redact(caught instanceof Error ? caught.message : String(caught));
+		throw new DriverError(
+			"vendor-contract-violation",
+			`${provider} ${boundary} sandbox-id validator failed: ${detail}`,
+			{ provider, cause: new Error(detail) },
+		);
+	}
+	if (parsed instanceof type.errors) {
+		const detail = redact(parsed.summary);
+		throw new DriverError("invalid-sandbox-ref", `${provider} sandbox id ${detail}`, {
+			provider,
+			cause: new Error(detail),
+		});
+	}
+	if (parsed.length === 0) {
+		throw new DriverError(
+			"invalid-sandbox-ref",
+			`${provider} ${boundary} sandbox-id validator returned an empty canonical id`,
+			{ provider },
+		);
+	}
+	return parsed;
+}
+
+function parseVendorSandboxId(
+	provider: ProviderId,
+	boundary: ComputeSdkSandboxIdBoundary,
+	rawId: string,
+	sensitiveValues: readonly string[],
+): string {
+	const decoded = parseSandboxId(provider, boundary.fromVendor, rawId, sensitiveValues, "wrapper");
+	return boundary.transformed
+		? parseSandboxId(provider, boundary.canonical, decoded, sensitiveValues, "canonical")
+		: decoded;
+}
+
+function validateRef(
+	provider: ProviderId,
+	schema: Type<string>,
+	ref: SandboxRef,
+	sensitiveValues: readonly string[],
+): SandboxRef {
+	if (ref.provider !== provider) {
+		throw new DriverError(
+			"invalid-sandbox-ref",
+			`expected ${provider} sandbox ref, received ${ref.provider}`,
+			{ provider },
+		);
+	}
+	const parsed = parseSandboxId(provider, schema, ref.id, sensitiveValues, "canonical");
+	return sandboxRef(provider, parsed);
+}
+
+function wrapperAborted(
+	provider: ProviderId,
+	reason: unknown,
+	operation = "create",
+	code: Extract<DriverErrorCode, "create-failed" | "destroy-failed"> = "create-failed",
+): DriverError {
+	return new DriverError(code, `computesdk ${operation} for ${provider} was aborted`, {
+		provider,
+		cause: reason,
+	});
+}
+
+interface NormalizedComputeSdkCommandResult {
+	readonly exitCode?: number;
+	readonly stdout: string;
+	readonly stderr: string;
+}
+
+function normalizeCommandResult(
+	provider: ProviderId,
+	operation: string,
+	result: unknown,
+	sensitiveValues: readonly string[],
+	ref?: SandboxRef,
+): NormalizedComputeSdkCommandResult {
+	if (result === null || typeof result !== "object" || Array.isArray(result)) {
+		throw vendorContractFailure(
+			provider,
+			operation,
+			new Error("wrapper returned a non-object command result"),
+			sensitiveValues,
+			ref,
+		);
+	}
+	const candidate = result as Readonly<Record<string, unknown>>;
+	const exitCode = candidate.exitCode;
+	const stdout = candidate.stdout;
+	const stderr = candidate.stderr;
+	if (
+		(exitCode !== undefined &&
+			(typeof exitCode !== "number" ||
+				!Number.isInteger(exitCode) ||
+				!Number.isFinite(exitCode))) ||
+		(stdout !== undefined && typeof stdout !== "string") ||
+		(stderr !== undefined && typeof stderr !== "string")
+	) {
+		throw vendorContractFailure(
+			provider,
+			operation,
+			new Error("wrapper returned an invalid command-result field"),
+			sensitiveValues,
+			ref,
+		);
+	}
+	return {
+		...(exitCode === undefined ? {} : { exitCode }),
+		stdout: stdout ?? "",
+		stderr: stderr ?? "",
+	};
+}
+
+function readSandboxId(
+	sandbox: ComputeSdkSandboxLike,
+	provider: ProviderId,
+	sensitiveValues: readonly string[],
+): unknown {
+	try {
+		return (sandbox as unknown as { readonly sandboxId?: unknown }).sandboxId;
+	} catch (caught) {
+		throw vendorContractFailure(provider, "sandbox identity", caught, sensitiveValues);
+	}
+}
+
+function requireFilesystem<TSandbox extends ComputeSdkSandboxLike>(
+	sandbox: TSandbox,
+	provider: ProviderId,
+	sensitiveValues: readonly string[],
+	ref?: SandboxRef,
+): NonNullable<TSandbox["filesystem"]> {
+	let filesystem: TSandbox["filesystem"];
+	let readFile: unknown;
+	let exists: unknown;
+	let writeFile: unknown;
+	try {
+		filesystem = sandbox.filesystem;
+		readFile = filesystem?.readFile;
+		exists = filesystem?.exists;
+		writeFile = filesystem?.writeFile;
+	} catch (caught) {
+		throw vendorContractFailure(provider, "filesystem accessor", caught, sensitiveValues, ref);
+	}
+	if (
+		!filesystem ||
+		typeof readFile !== "function" ||
+		typeof exists !== "function" ||
+		typeof writeFile !== "function"
+	) {
+		throw vendorContractFailure(
+			provider,
+			"filesystem accessor",
+			new Error("wrapper declared a filesystem without every required callable method"),
+			sensitiveValues,
+			ref,
+		);
+	}
+	return filesystem;
+}
+
+/**
+ * Define a ComputeSDK-backed provider from one registry id.
+ *
+ * The raw bridge is intentionally private: exposing a separate `provider` option would let a copied
+ * module compile with two disagreeing ids. This joined helper is the only authoring surface.
+ */
+export function defineComputeSdkDriver<P extends ProviderId, TCompute extends ComputeSdkLike>(
+	id: P,
+	module: ComputeSdkDriverModuleSpec<NoInfer<P>, TCompute>,
+): DriverModule<P, ComputeSdkNativeOf<ComputeSdkSandboxOf<TCompute>>> {
+	if (module.createBudget?.owner !== undefined && module.createBudget.owner !== "harness") {
+		throw new DriverError(
+			"vendor-contract-violation",
+			"ComputeSDK create budgets must be owned by the harness",
+			{ provider: id },
+		);
+	}
+	return defineDriver(id, {
+		...(module.createBudget === undefined ? {} : { createBudget: module.createBudget }),
+		driver: (context) => {
+			const sensitiveValues = sensitiveEnvValuesFor(id, context.env);
+			try {
+				const { compute, ...spec } = module.spec(context);
+				return driverFromTable(
+					computeSdkMethodTable<TCompute>(id, {
+						...spec,
+						resolvedArtifact: context.resolvedArtifact,
+						sensitiveValues,
+					}),
+					() => Promise.resolve(compute),
+				);
+			} catch (caught) {
+				throw vendorContractFailure(id, "driver construction", caught, sensitiveValues);
+			}
+		},
+	});
+}

--- a/packages/drivers/tsconfig.json
+++ b/packages/drivers/tsconfig.json
@@ -1,0 +1,4 @@
+{
+  "extends": "@repo/tsconfig/library.json",
+  "include": ["src"]
+}

--- a/packages/schema/scripts/generate-provider-wiring.test.ts
+++ b/packages/schema/scripts/generate-provider-wiring.test.ts
@@ -19,6 +19,7 @@ import {
 	renderCiSecretTable,
 	renderCiVariableTable,
 	renderDotenvValue,
+	renderDriversPackage,
 	renderEnvExample,
 	renderPreAuthCondition,
 	renderPreAuthOwnerCondition,
@@ -210,8 +211,25 @@ describe("provider wiring projections", () => {
 	test("owns one uniquely labelled region for every generated projection", () => {
 		const regions = generatedProviderRegions();
 		expect(new Set(regions.map(({ file, label }) => `${file}:${label}`)).size).toBe(regions.length);
-		expect(new Set(regions.map(({ file }) => file))).toEqual(
-			new Set(renderProviderWiringFiles().keys()),
+		expect(new Set(renderProviderWiringFiles().keys())).toEqual(
+			new Set([...regions.map(({ file }) => file), "packages/drivers/package.json"]),
 		);
+	});
+
+	test("projects the provider SDK catalog into the fleet manifest", () => {
+		const root = record(
+			JSON.parse(readFileSync(resolve(REPO_ROOT, "package.json"), "utf8")),
+			"root",
+		);
+		const workspaces = record(root.workspaces, "workspaces");
+		const catalogs = record(workspaces.catalogs, "catalogs");
+		const providerCatalog = record(catalogs.computesdk, "computesdk catalog");
+		const drivers = record(JSON.parse(renderDriversPackage()), "drivers");
+		const dependencies = record(drivers.dependencies, "drivers dependencies");
+		for (const name of Object.keys(providerCatalog)) {
+			expect(dependencies[name], name).toBe("catalog:computesdk");
+		}
+		expect(dependencies["@sandbox-benchmarks/driver"]).toBe("workspace:*");
+		expect(dependencies.arktype).toBe("catalog:");
 	});
 });

--- a/packages/schema/scripts/generate-provider-wiring.ts
+++ b/packages/schema/scripts/generate-provider-wiring.ts
@@ -370,6 +370,48 @@ export function generatedProviderRegions(): GeneratedRegion[] {
 	];
 }
 
+interface RootWorkspaceManifest {
+	readonly workspaces?: {
+		readonly catalogs?: {
+			readonly computesdk?: Readonly<Record<string, string>>;
+		};
+	};
+}
+
+/**
+ * The fleet owns every provider SDK while the root catalog owns their exact versions. Project the
+ * whole provider catalog into the private fleet package so migrating or adding a driver never adds
+ * a fourth handwritten package-manifest edit. The forthcoming new-provider scaffold owns adding a
+ * new version pin to the root catalog; this reviewed file is its generated consumer.
+ */
+export function renderDriversPackage(root = REPO_ROOT): string {
+	const rootManifest = JSON.parse(readFileSync(resolve(root, "package.json"), "utf8")) as
+		| RootWorkspaceManifest
+		| undefined;
+	const providerCatalog = rootManifest?.workspaces?.catalogs?.computesdk;
+	if (providerCatalog === undefined || Object.keys(providerCatalog).length === 0) {
+		throw new Error("package.json: workspaces.catalogs.computesdk must be a non-empty mapping");
+	}
+	for (const [name, version] of Object.entries(providerCatalog)) {
+		if (name.length === 0 || version.length === 0) {
+			throw new Error(
+				"package.json: provider catalog package names and versions must be non-empty",
+			);
+		}
+	}
+
+	const file = "packages/drivers/package.json";
+	const manifest = JSON.parse(readFileSync(resolve(root, file), "utf8")) as Record<string, unknown>;
+	const dependencies: Array<readonly [string, string]> = [
+		...Object.keys(providerCatalog).map((name): [string, string] => [name, "catalog:computesdk"]),
+		["@sandbox-benchmarks/driver", "workspace:*"],
+		["arktype", "catalog:"],
+	];
+	dependencies.sort((left, right) => left[0].localeCompare(right[0]));
+	manifest.dependencies = Object.fromEntries(dependencies);
+	return `${JSON.stringify(manifest, null, 2)}\n`;
+}
+
 export function renderProviderWiringFiles(root = REPO_ROOT): Map<string, string> {
 	// The same Tier-3 boundary that guards registry generation runs before wiring emission.
 	validateProviderModules(
@@ -383,6 +425,7 @@ export function renderProviderWiringFiles(root = REPO_ROOT): Map<string, string>
 		const source = rendered.get(region.file) ?? readFileSync(resolve(root, region.file), "utf8");
 		rendered.set(region.file, replaceGeneratedRegion(source, region));
 	}
+	rendered.set("packages/drivers/package.json", renderDriversPackage(root));
 	return rendered;
 }
 


### PR DESCRIPTION
This is the fleet-private ComputeSDK compatibility layer from ADR-0007. It keeps maintained wrapper translations available while making them one driver implementation rather than the contract every provider must impersonate.

## What changes

- Adds the private `@sandbox-benchmarks/drivers` fleet package. `_computesdk.ts` is intentionally not exported; provider modules consume it by relative import and vendor SDKs remain confined to the fleet.
- Extends `DriverContext<P>` with the registry-derived artifact descriptor and its correctly narrowed resolved artifact.
- Lets a `MethodTable` keep an internal operation handle while exposing the wrapper's real `getInstance()` native type on `SandboxSession.native`.
- Adds `defineComputeSdkDriver(id, …)` as the single provider-identity join and `computeSdkSpec(compute, …)` to preserve the complete installed wrapper type in capability callbacks.
- Requires every wrapper-backed provider to declare the disposition of every type-derived `CreateRequest` axis before allocation. Unsupported current or future axes are terminal `invalid-create-request` errors; mapper bugs are terminal contract violations.
- Applies module-owned sandbox-ID parsing before ref construction. Providers that transform raw vendor IDs declare a separate stable canonical grammar used by refs, probes, snapshots, and recovery; cleanup ownership survives typed create/rollback double faults.
- Makes filesystem, probes, and snapshots honest optional capabilities; validates provider-qualified refs before probe/snapshot callbacks.
- Redacts registry credential sources across SDK construction, schema/accessor failures, command envelopes, capabilities, and cleanup, without hiding ordinary guest/config variables.
- Generates the fleet dependency set from the root provider SDK catalog, so package dependencies are reviewed generated output instead of a hidden fourth onboarding edit.

## Safety and behavior pins

- Artifact contradictions tear down the allocation, including a retryable `FailedCreateCleanupError` path when teardown also fails.
- Abort after an uncancellable wrapper create waits for the accepted handle and reconciles it before returning.
- Missing foreground exit status remains the port's explicit `unknown` outcome; missing background acceptance status is a typed failure.
- Explicit `native: undefined` remains undefined rather than falling back to the internal wrapper handle.
- ComputeSDK create budgets are harness-owned only; the bridge does not claim a cancellation/ceiling guarantee wrappers do not provide.

## Verification

- Full workspace typecheck, lint, spelling, catalog drift, provider-registry drift, and provider-wiring drift gates pass.
- Full monorepo test suite passes, including repository metadata/Git-fixture tests.
- The bridge suite uses the installed `@computesdk/e2b` wrapper to pin exact native and lifecycle callback types, plus adversarial request-mapping, artifact, cleanup, cancellation, redaction, capability, and output-limit cases.

This PR remains a foundation slice: the next stacked PR adds the real E2B and Tama proof modules and registry-generated lazy loading, followed by fleet migration/composition-root and scaffold slices.
