### PR TITLE
refactor(ci): generate provider input wiring

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -9,73 +9,81 @@
 # You do NOT need every provider: a missing credential is recorded as a skip, not a failure. CI reads
 # these from the GitHub Environment `privileged`, never from a committed file — see docs/ci-secrets.md.
 
-# --- e2b (https://e2b.dev) ---
+# >>> generated: provider-inputs-local — bun run generate-provider-wiring
+# --- E2B (https://e2b.dev) ---
 E2B_API_KEY=
+# Optional override; leave empty to use the provider default.
+E2B_TEMPLATE=
 
-# --- Daytona (https://daytona.io) ---
+# --- Daytona (VM) (https://daytona.io) ---
+# Shared by: Daytona (VM), Daytona (container)
 DAYTONA_API_KEY=
-# Runner target / region the sandbox boots in. Defaults to us-west-2 when unset (the active region);
-# the account default has no `container` runners, so leave this as us-west-2 unless you know otherwise.
+# Optional override; leave empty to use the provider default.
 DAYTONA_TARGET=us-west-2
+# Optional override; leave empty to use the provider default.
+DAYTONA_SNAPSHOT=
 
-# --- Modal (https://modal.com) ---
-MODAL_TOKEN_ID=
-MODAL_TOKEN_SECRET=
+# --- Daytona (container) (https://daytona.io) ---
+# Optional override; leave empty to use the provider default.
+DAYTONA_CONTAINER_TARGET=us-west-2
+# Optional override; leave empty to use the provider default.
+DAYTONA_CONTAINER_SNAPSHOT=
 
 # --- Blaxel (https://blaxel.ai) ---
 BL_API_KEY=
 BL_WORKSPACE=
 
-# --- Novita (https://novita.ai) — E2B-protocol-compatible control plane ---
+# --- Microsandbox (local) (https://microsandbox.dev) ---
+# CI injects 1; set locally only on a compatible runner.
+MICROSANDBOX_LOCAL_BENCH=
+
+# --- Microsandbox Cloud (https://microsandbox.dev) ---
+MSB_API_KEY=
+# Optional override; leave empty to use the provider default.
+MSB_API_URL=
+
+# --- Modal (gVisor) (https://modal.com) ---
+# Shared by: Modal (gVisor), Modal (VM)
+MODAL_TOKEN_ID=
+# Shared by: Modal (gVisor), Modal (VM)
+MODAL_TOKEN_SECRET=
+
+# --- Novita (https://novita.ai/sandbox) ---
 NOVITA_API_KEY=
+# Optional override; leave empty to use the provider default.
+NOVITA_TEMPLATE=
 
 # --- Runloop (https://runloop.ai) ---
 RUNLOOP_API_KEY=
+# Optional override; leave empty to use the provider default.
+RUNLOOP_BLUEPRINT=
 
-# --- Microsandbox (https://microsandbox.dev) ---
-# Explicit opt-in for host-local libkrun runs. The host needs KVM on Linux or
-# Hypervisor.framework on macOS; keep unset on ordinary CI runners.
-MICROSANDBOX_LOCAL_BENCH=
-# Cloud runs require only MSB_API_KEY, which stays in the control-plane client and never enters the
-# benchmark guest. Set MSB_API_URL only to override the SDK default for staging or private deployments.
-MSB_API_KEY=
-MSB_API_URL=
+# --- Namespace (https://namespace.so) ---
+NSC_TOKEN_FILE=
+
+# --- Vercel Sandbox (https://vercel.com/docs/sandbox) ---
+VERCEL_OIDC_TOKEN=
+# Optional override; leave empty to use the provider default.
+VERCEL_TEAM_SLUG=
+# Optional override; leave empty to use the provider default.
+VERCEL_PROJECT_NAME=
 
 # --- run.cloud (https://run.cloud) ---
 RUN_CLOUD_API_KEY=
 
-# --- Vercel Sandbox (https://vercel.com/docs/sandbox) ---
-# Short-lived project token consumed directly by the Vercel SDK. See the local validation flow in
-# packages/providers/README.md. Never put the long-lived VERCEL_TOKEN bootstrap credential here.
-VERCEL_OIDC_TOKEN=
-# Human-readable Vercel namespace the VCR image refs are built from. Leave unset to use the defaults
-# in packages/schema/src/toolchain.ts; set them to publish into a different team or project (a fork).
-# These are NAMES, not the team_*/prj_* API IDs the CLI reads as VERCEL_ORG_ID / VERCEL_PROJECT_ID —
-# passing an ID here is rejected, because these values become Docker registry path segments.
-# VERCEL_TEAM_SLUG=
-# VERCEL_PROJECT_NAME=
-
 # --- tama (https://tama.computer) ---
-# tama publishes no SDK, so the adapter drives the `tama` CLI as a subprocess: install it first
-# (`curl -fsSL https://tama.computer/install | sh`, or TAMA_INSTALL_DIR=~/.local/bin to skip sudo).
-# Mint the token with `tama tokens create --name <name>`; it is shown once.
-#
-# Set this EVEN IF you have already run `tama login`. The harness's credential gate reads env vars
-# only, so an authenticated CLI profile with no TAMA_TOKEN is recorded as a skip before the adapter
-# is ever constructed. The token is not spent needlessly, though: the adapter probes the existing
-# profile first and only runs `tama login --token` when that probe fails — because `login --token`
-# REPLACES the stored credential and would otherwise sign you out of your own account as a side
-# effect of running a benchmark.
 TAMA_TOKEN=
-# Path to the CLI when it is not on PATH (the adapter spawns bare `tama` otherwise).
-# TAMA_CLI=
+# Optional override; leave empty to use the provider default.
+TAMA_CLI=
+# <<< end generated: provider-inputs-local
 
-# --- Optional overrides (leave unset for the pinned public toolchain) ---
-# Point the adapters at a specific toolchain image / template instead of the canonical published one.
-# Useful only when iterating on the toolchain locally; see packages/providers/src/lib/config.ts.
+# Local authentication notes:
+# - Namespace expects NSC_TOKEN_FILE from `nsc token create --token_file <path>`.
+# - Vercel's CLI validation flow mints VERCEL_OIDC_TOKEN; never use the long-lived bootstrap token.
+# - tama needs its CLI installed and `tama tokens create`; TAMA_CLI overrides the executable path.
+# See packages/providers/README.md for the exact commands.
+
+# --- Repo-global optional override ---
+# Point every adapter at one specific toolchain image instead of the canonical published one.
+# Useful only when iterating locally; see packages/providers/src/lib/config.ts.
 # BENCH_TOOLCHAIN_IMAGE=
-# E2B_TEMPLATE=
-# DAYTONA_SNAPSHOT=
-# NOVITA_TEMPLATE=
-# Runtime-only Runloop Blueprint name override; ordinary runs use the released version name.
-# RUNLOOP_BLUEPRINT=

--- a/.github/workflows/bench-smoke.yml
+++ b/.github/workflows/bench-smoke.yml
@@ -45,30 +45,27 @@ on:
   workflow_dispatch:
     inputs:
       provider:
-        # Constrained to the PROVIDERS registry (packages/schema/src/providers.ts); the
-        # workflow-registry-sync drift gate keeps this list in lockstep, so a new provider must be
-        # added here too. The plan step re-validates it against the registry anyway, so a stale option
-        # fails the plan rather than running nothing.
+        # Generated from PROVIDER_IDS; the plan step still parses it at the external input boundary.
         description: Provider to benchmark
         type: choice
         default: daytona-vm
         options:
-          [
-            daytona-vm,
-            daytona-container,
-            e2b,
-            modal-gvisor,
-            modal-vm,
-            blaxel,
-            novita,
-            runloop,
-            vercel,
-            namespace,
-            microsandbox-local,
-            microsandbox-cloud,
-            runcloud,
-            tama,
-          ]
+          # >>> generated: provider-options — bun run generate-provider-wiring
+          - 'e2b'
+          - 'daytona-vm'
+          - 'daytona-container'
+          - 'blaxel'
+          - 'microsandbox-local'
+          - 'microsandbox-cloud'
+          - 'modal-gvisor'
+          - 'modal-vm'
+          - 'novita'
+          - 'runloop'
+          - 'namespace'
+          - 'vercel'
+          - 'runcloud'
+          - 'tama'
+          # <<< end generated: provider-options
       suite:
         # Constrained to the SUITE_NAMES registry (packages/schema/src/suites.ts); the
         # workflow-registry-sync drift gate keeps this list in lockstep, so a new suite must be added

--- a/.github/workflows/bench-suite.yml
+++ b/.github/workflows/bench-suite.yml
@@ -139,7 +139,9 @@ jobs:
     # the trade for having any local backend at all — so it also declares BENCH_RUNNER_LIFETIME_MINUTES
     # below, and bench-suite refuses a suite that cannot finish inside that window rather than letting
     # the cell be reaped mid-run with no logs and every replicate lost. Keep the three paired.
+    # >>> generated: provider-runner — bun run generate-provider-wiring
     runs-on: ${{ matrix.provider == 'microsandbox-local' && 'starsling-ubuntu-24.04-2' || 'ubuntu-24.04' }}
+    # <<< end generated: provider-runner
     timeout-minutes: 180
     strategy:
       # One provider's failure (a flaky adapter, a dead account) must not cancel the rest of the matrix.
@@ -169,7 +171,9 @@ jobs:
       - name: Set up workspace
         uses: ./.github/actions/setup-workspace
         with:
+          # >>> generated: provider-runner-cache — bun run generate-provider-wiring
           no-cache: ${{ matrix.provider == 'microsandbox-local' && 'true' || 'false' }}
+          # <<< end generated: provider-runner-cache
 
       # Namespace is the one provider with no stored secret: it federates on this job's OIDC identity
       # (id-token: write above) and mints a portable token file from the resulting CLI session — see
@@ -185,7 +189,9 @@ jobs:
       # dispatched provider by name). What it avoids in both is the raw step abort, which would kill the
       # cell with no Run document and no summary to diagnose from.
       - name: Set up Namespace credentials
+        # >>> generated: preauth-namespace-token-bench — bun run generate-provider-wiring
         if: matrix.provider == 'namespace'
+        # <<< end generated: preauth-namespace-token-bench
         continue-on-error: true
         id: namespace
         uses: ./.github/actions/namespace-token
@@ -206,7 +212,9 @@ jobs:
         uses: ./.github/actions/setup-tama
 
       - name: Authenticate with Vercel
+        # >>> generated: preauth-vercel-auth-bench — bun run generate-provider-wiring
         if: matrix.provider == 'vercel'
+        # <<< end generated: preauth-vercel-auth-bench
         continue-on-error: true
         id: vercel-auth
         uses: ./.github/actions/vercel-auth
@@ -250,49 +258,41 @@ jobs:
           # provider so a missing/misnamed secret fails the job by name instead of exiting 0 having
           # benchmarked nothing. See the require_providers input above.
           REQUIRE_PROVIDERS: ${{ inputs.require_providers }}
-          # Scope every provider credential to the cell that actually uses it: a cell receives ONLY
-          # the secret(s) for its own `matrix.provider`, so a compromised adapter or suite can't read
-          # another provider's credential out of the environment. A non-matching provider evaluates to
-          # '', which the config gatekeeper treats as unset (packages/providers/src/lib/config.ts:
-          # empty ⇒ unset), exactly like an unsynced secret — so blanking the others is inert.
-          # Both Daytona isolation variants share the account key; scope it to either cell.
-          DAYTONA_API_KEY: ${{ (matrix.provider == 'daytona-vm' || matrix.provider == 'daytona-container') && secrets.DAYTONA_API_KEY || '' }}
-          # Each Daytona variant pins its region via a variant-specific secret so operators can
-          # retarget without editing the workflow: daytona-vm reads DAYTONA_TARGET (us-west-2
-          # default), daytona-container reads DAYTONA_CONTAINER_TARGET (us-west-2 default).
-          DAYTONA_TARGET: ${{ matrix.provider == 'daytona-vm' && (secrets.DAYTONA_TARGET || 'us-west-2') || '' }}
-          DAYTONA_CONTAINER_TARGET: ${{ matrix.provider == 'daytona-container' && (secrets.DAYTONA_CONTAINER_TARGET || 'us-west-2') || '' }}
+          # Provider inputs are generated from metadata and scoped to their owning matrix cell.
+          # >>> generated: provider-inputs-bench — bun run generate-provider-wiring
           E2B_API_KEY: ${{ matrix.provider == 'e2b' && secrets.E2B_API_KEY || '' }}
-          # Both Modal variants share the account tokens; scope them to either cell.
-          MODAL_TOKEN_ID: ${{ (matrix.provider == 'modal-gvisor' || matrix.provider == 'modal-vm') && secrets.MODAL_TOKEN_ID || '' }}
-          MODAL_TOKEN_SECRET: ${{ (matrix.provider == 'modal-gvisor' || matrix.provider == 'modal-vm') && secrets.MODAL_TOKEN_SECRET || '' }}
+          E2B_TEMPLATE: ${{ matrix.provider == 'e2b' && (env.E2B_TEMPLATE || vars.E2B_TEMPLATE || secrets.E2B_TEMPLATE) || '' }}
+          DAYTONA_API_KEY: ${{ (matrix.provider == 'daytona-vm' || matrix.provider == 'daytona-container') && secrets.DAYTONA_API_KEY || '' }}
+          DAYTONA_TARGET: ${{ matrix.provider == 'daytona-vm' && (env.DAYTONA_TARGET || vars.DAYTONA_TARGET || secrets.DAYTONA_TARGET || 'us-west-2') || '' }}
+          DAYTONA_SNAPSHOT: ${{ matrix.provider == 'daytona-vm' && (env.DAYTONA_SNAPSHOT || vars.DAYTONA_SNAPSHOT || secrets.DAYTONA_SNAPSHOT) || '' }}
+          DAYTONA_CONTAINER_TARGET: ${{ matrix.provider == 'daytona-container' && (env.DAYTONA_CONTAINER_TARGET || vars.DAYTONA_CONTAINER_TARGET || secrets.DAYTONA_CONTAINER_TARGET || 'us-west-2') || '' }}
+          DAYTONA_CONTAINER_SNAPSHOT: ${{ matrix.provider == 'daytona-container' && (env.DAYTONA_CONTAINER_SNAPSHOT || vars.DAYTONA_CONTAINER_SNAPSHOT || secrets.DAYTONA_CONTAINER_SNAPSHOT) || '' }}
           BL_API_KEY: ${{ matrix.provider == 'blaxel' && secrets.BL_API_KEY || '' }}
           BL_WORKSPACE: ${{ matrix.provider == 'blaxel' && secrets.BL_WORKSPACE || '' }}
-          NOVITA_API_KEY: ${{ matrix.provider == 'novita' && secrets.NOVITA_API_KEY || '' }}
-          RUNLOOP_API_KEY: ${{ matrix.provider == 'runloop' && secrets.RUNLOOP_API_KEY || '' }}
-          RUN_CLOUD_API_KEY: ${{ matrix.provider == 'runcloud' && secrets.RUN_CLOUD_API_KEY || '' }}
-          # OIDC-federated per-cell token file (see the Namespace step above). Not a stored secret: it is
-          # empty unless THIS cell is the namespace cell AND the mint succeeded (the step only runs when
-          # matrix.provider == 'namespace', and only writes the output once `nsc token create` returned),
-          # which the harness reads as the standard missing-credentials skip on every other cell.
-          NSC_TOKEN_FILE: ${{ steps.namespace.outputs.token-file }}
-          # @computesdk/vercel reads the short-lived token exported by the auth action.
-          VERCEL_OIDC_TOKEN: ${{ matrix.provider == 'vercel' && steps.vercel-auth.outcome == 'success' && env.VERCEL_OIDC_TOKEN || '' }}
-          # Local is an explicit capability opt-in. Cloud needs only its API key; MSB_API_URL is an
-          # optional override for staging or private deployments. Neither value enters the guest.
           MICROSANDBOX_LOCAL_BENCH: ${{ matrix.provider == 'microsandbox-local' && '1' || '' }}
+          MSB_API_KEY: ${{ matrix.provider == 'microsandbox-cloud' && secrets.MSB_API_KEY || '' }}
+          MSB_API_URL: ${{ matrix.provider == 'microsandbox-cloud' && (env.MSB_API_URL || vars.MSB_API_URL || secrets.MSB_API_URL) || '' }}
+          MODAL_TOKEN_ID: ${{ (matrix.provider == 'modal-gvisor' || matrix.provider == 'modal-vm') && secrets.MODAL_TOKEN_ID || '' }}
+          MODAL_TOKEN_SECRET: ${{ (matrix.provider == 'modal-gvisor' || matrix.provider == 'modal-vm') && secrets.MODAL_TOKEN_SECRET || '' }}
+          NOVITA_API_KEY: ${{ matrix.provider == 'novita' && secrets.NOVITA_API_KEY || '' }}
+          NOVITA_TEMPLATE: ${{ matrix.provider == 'novita' && (env.NOVITA_TEMPLATE || vars.NOVITA_TEMPLATE || secrets.NOVITA_TEMPLATE) || '' }}
+          RUNLOOP_API_KEY: ${{ matrix.provider == 'runloop' && secrets.RUNLOOP_API_KEY || '' }}
+          RUNLOOP_BLUEPRINT: ${{ matrix.provider == 'runloop' && (env.RUNLOOP_BLUEPRINT || vars.RUNLOOP_BLUEPRINT || secrets.RUNLOOP_BLUEPRINT) || '' }}
+          NSC_TOKEN_FILE: ${{ steps.namespace.outputs.token-file }}
+          VERCEL_OIDC_TOKEN: ${{ matrix.provider == 'vercel' && steps.vercel-auth.outcome == 'success' && env.VERCEL_OIDC_TOKEN || '' }}
+          VERCEL_TEAM_SLUG: ${{ matrix.provider == 'vercel' && (env.VERCEL_TEAM_SLUG || vars.VERCEL_TEAM_SLUG || secrets.VERCEL_TEAM_SLUG) || '' }}
+          VERCEL_PROJECT_NAME: ${{ matrix.provider == 'vercel' && (env.VERCEL_PROJECT_NAME || vars.VERCEL_PROJECT_NAME || secrets.VERCEL_PROJECT_NAME) || '' }}
+          RUN_CLOUD_API_KEY: ${{ matrix.provider == 'runcloud' && secrets.RUN_CLOUD_API_KEY || '' }}
+          TAMA_TOKEN: ${{ matrix.provider == 'tama' && secrets.TAMA_TOKEN || '' }}
+          TAMA_CLI: ${{ matrix.provider == 'tama' && (env.TAMA_CLI || vars.TAMA_CLI || secrets.TAMA_CLI) || '' }}
+          # <<< end generated: provider-inputs-bench
           # Paired with the microsandbox-local runner route above: that self-hosted label is reaped at
           # 70 minutes regardless of timeout-minutes, which no expression can encode (the workflow gate
           # requires a literal). Declaring it here lets bench-suite reject a suite that cannot finish
           # inside it, before any sandbox is created. Empty on the hosted runner, which outlives the job.
+          # >>> generated: provider-runner-lifetime — bun run generate-provider-wiring
           BENCH_RUNNER_LIFETIME_MINUTES: ${{ matrix.provider == 'microsandbox-local' && '70' || '' }}
-          MSB_API_URL: ${{ matrix.provider == 'microsandbox-cloud' && secrets.MSB_API_URL || '' }}
-          MSB_API_KEY: ${{ matrix.provider == 'microsandbox-cloud' && secrets.MSB_API_KEY || '' }}
-          # tama ships no SDK: the adapter drives the `tama` CLI, which keeps credentials in its own
-          # profile rather than reading an env var. A fresh runner has no profile, so the adapter adopts
-          # this minted token (`tama tokens create`) on its first control-plane call. The value stays in
-          # the CLI profile and never enters the guest.
-          TAMA_TOKEN: ${{ matrix.provider == 'tama' && secrets.TAMA_TOKEN || '' }}
+          # <<< end generated: provider-runner-lifetime
         run: bun apps/cli/src/bin/bench-suite.ts "$BENCH_PROVIDER" "$BENCH_SUITE" "$GITHUB_RUN_ID" --replicates "$BENCH_REPLICATES"
 
       # Did THIS attempt actually produce shard Runs? The upload below overwrites the cell's artifact,

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,6 +88,11 @@ jobs:
       - name: Provider registry drift
         run: bun run check:provider-registry-drift
 
+      # Provider wiring drift gate — metadata owns provider inputs/runner/pre-auth declarations;
+      # committed workflow, local-env, docs, and setup regions are reviewed generated projections.
+      - name: Provider wiring drift
+        run: bun run check:provider-wiring
+
       # Spelling gate — typos (pinned in mise.toml); misspellings fail the build.
       - name: Spell (typos)
         run: bun run spell

--- a/.github/workflows/toolchain-image.yml
+++ b/.github/workflows/toolchain-image.yml
@@ -412,14 +412,18 @@ jobs:
       # id/output identical is what lets provider metadata describe this input without lane-specific
       # generator exceptions. A failed federation still degrades to the normal missing-input skip.
       - name: Set up Namespace credentials
+        # >>> generated: preauth-namespace-token-bake — bun run generate-provider-wiring
         if: matrix.provider == 'namespace'
+        # <<< end generated: preauth-namespace-token-bake
         continue-on-error: true
         id: namespace
         uses: ./.github/actions/namespace-token
         with:
           token-name: sandbox-benchmarks-toolchain-bake-${{ github.run_id }}-${{ github.run_attempt }}
       - name: Authenticate with Vercel and VCR
+        # >>> generated: preauth-vercel-auth-bake — bun run generate-provider-wiring
         if: matrix.provider == 'vercel'
+        # <<< end generated: preauth-vercel-auth-bake
         continue-on-error: true
         id: vercel-auth
         uses: ./.github/actions/vercel-auth
@@ -487,39 +491,33 @@ jobs:
           # immutable output digest; a build-skipped scoped backfill supplies the published version,
           # never the mutable candidate that may already contain the next release's bytes.
           BASE_IMAGE_REF: ${{ needs.build.outputs.base-digest-ref || needs.plan.outputs.image-source }}
+          # >>> generated: provider-inputs-bake — bun run generate-provider-wiring
           E2B_API_KEY: ${{ matrix.provider == 'e2b' && secrets.E2B_API_KEY || '' }}
-          # Both Daytona isolation variants share the account key and bake in their own region.
+          E2B_TEMPLATE: ${{ matrix.provider == 'e2b' && (env.E2B_TEMPLATE || vars.E2B_TEMPLATE || secrets.E2B_TEMPLATE) || '' }}
           DAYTONA_API_KEY: ${{ (matrix.provider == 'daytona-vm' || matrix.provider == 'daytona-container') && secrets.DAYTONA_API_KEY || '' }}
-          # Both Daytona variants bake in us-west-2, pinned by a variant-specific secret so
-          # operators can retarget without editing the workflow: daytona-vm reads DAYTONA_TARGET
-          # (LINUX_VM snapshot, us-west-2 default), daytona-container reads DAYTONA_CONTAINER_TARGET
-          # (us-west-2 default). Both default so an unsynced secret can't leave a snapshot in the account's
-          # default region and fail the bake at snapshot creation.
-          DAYTONA_TARGET: ${{ matrix.provider == 'daytona-vm' && (secrets.DAYTONA_TARGET || 'us-west-2') || '' }}
-          DAYTONA_CONTAINER_TARGET: ${{ matrix.provider == 'daytona-container' && (secrets.DAYTONA_CONTAINER_TARGET || 'us-west-2') || '' }}
-          # Both Modal variants share the account tokens; the bake is a no-op for each (the image is
-          # pushed once and booted directly), but validate still boots each to prove reachability.
+          DAYTONA_TARGET: ${{ matrix.provider == 'daytona-vm' && (env.DAYTONA_TARGET || vars.DAYTONA_TARGET || secrets.DAYTONA_TARGET || 'us-west-2') || '' }}
+          DAYTONA_SNAPSHOT: ${{ matrix.provider == 'daytona-vm' && (env.DAYTONA_SNAPSHOT || vars.DAYTONA_SNAPSHOT || secrets.DAYTONA_SNAPSHOT) || '' }}
+          DAYTONA_CONTAINER_TARGET: ${{ matrix.provider == 'daytona-container' && (env.DAYTONA_CONTAINER_TARGET || vars.DAYTONA_CONTAINER_TARGET || secrets.DAYTONA_CONTAINER_TARGET || 'us-west-2') || '' }}
+          DAYTONA_CONTAINER_SNAPSHOT: ${{ matrix.provider == 'daytona-container' && (env.DAYTONA_CONTAINER_SNAPSHOT || vars.DAYTONA_CONTAINER_SNAPSHOT || secrets.DAYTONA_CONTAINER_SNAPSHOT) || '' }}
+          BL_API_KEY: ${{ matrix.provider == 'blaxel' && secrets.BL_API_KEY || '' }}
+          BL_WORKSPACE: ${{ matrix.provider == 'blaxel' && secrets.BL_WORKSPACE || '' }}
+          MICROSANDBOX_LOCAL_BENCH: ${{ matrix.provider == 'microsandbox-local' && '1' || '' }}
+          MSB_API_KEY: ${{ matrix.provider == 'microsandbox-cloud' && secrets.MSB_API_KEY || '' }}
+          MSB_API_URL: ${{ matrix.provider == 'microsandbox-cloud' && (env.MSB_API_URL || vars.MSB_API_URL || secrets.MSB_API_URL) || '' }}
           MODAL_TOKEN_ID: ${{ (matrix.provider == 'modal-gvisor' || matrix.provider == 'modal-vm') && secrets.MODAL_TOKEN_ID || '' }}
           MODAL_TOKEN_SECRET: ${{ (matrix.provider == 'modal-gvisor' || matrix.provider == 'modal-vm') && secrets.MODAL_TOKEN_SECRET || '' }}
-          # Optional: a missing NOVITA_API_KEY skips the novita bake without failing the release.
           NOVITA_API_KEY: ${{ matrix.provider == 'novita' && secrets.NOVITA_API_KEY || '' }}
-          # Runloop builds and validates a candidate Blueprint. Best-effort in an unscoped release;
-          # required (and therefore fail-closed on a missing key/build failure) when explicitly scoped.
+          NOVITA_TEMPLATE: ${{ matrix.provider == 'novita' && (env.NOVITA_TEMPLATE || vars.NOVITA_TEMPLATE || secrets.NOVITA_TEMPLATE) || '' }}
           RUNLOOP_API_KEY: ${{ matrix.provider == 'runloop' && secrets.RUNLOOP_API_KEY || '' }}
-          # run.cloud boots the candidate OCI image directly; the key is needed only for its validate boot.
-          RUN_CLOUD_API_KEY: ${{ matrix.provider == 'runcloud' && secrets.RUN_CLOUD_API_KEY || '' }}
-          # Namespace pulls the candidate image directly (no bake artifact) — its validate boot reads
-          # this OIDC-federated token file (see the Namespace CLI steps above). Not a stored secret:
-          # empty unless THIS is the namespace cell AND the mint succeeded, which the harness reads as
-          # the standard missing-credentials skip on every other cell. Best-effort like novita: namespace
-          # is not in --require, so a skipped/failed mint skips its validate boot without failing publish.
+          RUNLOOP_BLUEPRINT: ${{ matrix.provider == 'runloop' && (env.RUNLOOP_BLUEPRINT || vars.RUNLOOP_BLUEPRINT || secrets.RUNLOOP_BLUEPRINT) || '' }}
           NSC_TOKEN_FILE: ${{ steps.namespace.outputs.token-file }}
-          # Microsandbox backends boot the candidate OCI image directly. Local is an explicit runner
-          # capability opt-in. Cloud needs only its key; the URL is an optional deployment override.
-          MICROSANDBOX_LOCAL_BENCH: ${{ matrix.provider == 'microsandbox-local' && '1' || '' }}
-          MSB_API_URL: ${{ matrix.provider == 'microsandbox-cloud' && secrets.MSB_API_URL || '' }}
-          MSB_API_KEY: ${{ matrix.provider == 'microsandbox-cloud' && secrets.MSB_API_KEY || '' }}
           VERCEL_OIDC_TOKEN: ${{ matrix.provider == 'vercel' && steps.vercel-auth.outcome == 'success' && env.VERCEL_OIDC_TOKEN || '' }}
+          VERCEL_TEAM_SLUG: ${{ matrix.provider == 'vercel' && (env.VERCEL_TEAM_SLUG || vars.VERCEL_TEAM_SLUG || secrets.VERCEL_TEAM_SLUG) || '' }}
+          VERCEL_PROJECT_NAME: ${{ matrix.provider == 'vercel' && (env.VERCEL_PROJECT_NAME || vars.VERCEL_PROJECT_NAME || secrets.VERCEL_PROJECT_NAME) || '' }}
+          RUN_CLOUD_API_KEY: ${{ matrix.provider == 'runcloud' && secrets.RUN_CLOUD_API_KEY || '' }}
+          TAMA_TOKEN: ${{ matrix.provider == 'tama' && secrets.TAMA_TOKEN || '' }}
+          TAMA_CLI: ${{ matrix.provider == 'tama' && (env.TAMA_CLI || vars.TAMA_CLI || secrets.TAMA_CLI) || '' }}
+          # <<< end generated: provider-inputs-bake
           VERCEL_CANDIDATE_IMAGE: ${{ steps.vercel-vcr.outcome == 'success' && steps.vercel-vcr.outputs.digest-ref || '' }}
         run: |
           set -euo pipefail
@@ -636,7 +634,9 @@ jobs:
       # Namespace best-effort; the scope test uses matrix element equality because string contains
       # would also match a future provider id that merely contains `namespace`.
       - name: Set up Namespace credentials
+        # >>> generated: preauth-namespace-token-promote — bun run generate-provider-wiring
         if: contains(fromJSON(needs.plan.outputs.matrix).include.*.provider, 'namespace')
+        # <<< end generated: preauth-namespace-token-promote
         continue-on-error: true
         id: namespace
         uses: ./.github/actions/namespace-token
@@ -645,7 +645,9 @@ jobs:
       # Same scope gate as the Namespace mint above: a release that isn't promoting vercel has no reason
       # to pull a project OIDC token or log docker into VCR.
       - name: Authenticate with Vercel and VCR
+        # >>> generated: preauth-vercel-auth-promote — bun run generate-provider-wiring
         if: contains(fromJSON(needs.plan.outputs.matrix).include.*.provider, 'vercel')
+        # <<< end generated: preauth-vercel-auth-promote
         continue-on-error: true
         id: vercel-auth
         uses: ./.github/actions/vercel-auth
@@ -676,37 +678,33 @@ jobs:
           # CLIs inherit stdout, so a redirect would splice their chatter into the payload. bake.ts
           # writes the file even when promote aborts (it records the structured reports before exiting).
           BAKE_REPORT_FILE: promote-payload.json
-          E2B_API_KEY: ${{ secrets.E2B_API_KEY }}
-          DAYTONA_API_KEY: ${{ secrets.DAYTONA_API_KEY }}
-          # Both Daytona variants may be promoted in one payload, so thread each variant's region
-          # secret (daytona-vm ⇒ DAYTONA_TARGET, daytona-container ⇒ DAYTONA_CONTAINER_TARGET).
-          DAYTONA_TARGET: ${{ secrets.DAYTONA_TARGET || 'us-west-2' }}
-          DAYTONA_CONTAINER_TARGET: ${{ secrets.DAYTONA_CONTAINER_TARGET || 'us-west-2' }}
-          MODAL_TOKEN_ID: ${{ secrets.MODAL_TOKEN_ID }}
-          MODAL_TOKEN_SECRET: ${{ secrets.MODAL_TOKEN_SECRET }}
-          NOVITA_API_KEY: ${{ secrets.NOVITA_API_KEY }}
-          # The serial transaction re-validates the candidate Blueprint, then builds the version-named
-          # Blueprint from the same pinned base. Keep the SDK control-plane key out of unrelated scoped
-          # promotes, matching the run.cloud credential posture below.
+          # >>> generated: provider-inputs-promote — bun run generate-provider-wiring
+          E2B_API_KEY: ${{ contains(fromJSON(needs.plan.outputs.matrix).include.*.provider, 'e2b') && secrets.E2B_API_KEY || '' }}
+          E2B_TEMPLATE: ${{ contains(fromJSON(needs.plan.outputs.matrix).include.*.provider, 'e2b') && (env.E2B_TEMPLATE || vars.E2B_TEMPLATE || secrets.E2B_TEMPLATE) || '' }}
+          DAYTONA_API_KEY: ${{ (contains(fromJSON(needs.plan.outputs.matrix).include.*.provider, 'daytona-vm') || contains(fromJSON(needs.plan.outputs.matrix).include.*.provider, 'daytona-container')) && secrets.DAYTONA_API_KEY || '' }}
+          DAYTONA_TARGET: ${{ contains(fromJSON(needs.plan.outputs.matrix).include.*.provider, 'daytona-vm') && (env.DAYTONA_TARGET || vars.DAYTONA_TARGET || secrets.DAYTONA_TARGET || 'us-west-2') || '' }}
+          DAYTONA_SNAPSHOT: ${{ contains(fromJSON(needs.plan.outputs.matrix).include.*.provider, 'daytona-vm') && (env.DAYTONA_SNAPSHOT || vars.DAYTONA_SNAPSHOT || secrets.DAYTONA_SNAPSHOT) || '' }}
+          DAYTONA_CONTAINER_TARGET: ${{ contains(fromJSON(needs.plan.outputs.matrix).include.*.provider, 'daytona-container') && (env.DAYTONA_CONTAINER_TARGET || vars.DAYTONA_CONTAINER_TARGET || secrets.DAYTONA_CONTAINER_TARGET || 'us-west-2') || '' }}
+          DAYTONA_CONTAINER_SNAPSHOT: ${{ contains(fromJSON(needs.plan.outputs.matrix).include.*.provider, 'daytona-container') && (env.DAYTONA_CONTAINER_SNAPSHOT || vars.DAYTONA_CONTAINER_SNAPSHOT || secrets.DAYTONA_CONTAINER_SNAPSHOT) || '' }}
+          BL_API_KEY: ${{ contains(fromJSON(needs.plan.outputs.matrix).include.*.provider, 'blaxel') && secrets.BL_API_KEY || '' }}
+          BL_WORKSPACE: ${{ contains(fromJSON(needs.plan.outputs.matrix).include.*.provider, 'blaxel') && secrets.BL_WORKSPACE || '' }}
+          MICROSANDBOX_LOCAL_BENCH: ${{ contains(fromJSON(needs.plan.outputs.matrix).include.*.provider, 'microsandbox-local') && '1' || '' }}
+          MSB_API_KEY: ${{ contains(fromJSON(needs.plan.outputs.matrix).include.*.provider, 'microsandbox-cloud') && secrets.MSB_API_KEY || '' }}
+          MSB_API_URL: ${{ contains(fromJSON(needs.plan.outputs.matrix).include.*.provider, 'microsandbox-cloud') && (env.MSB_API_URL || vars.MSB_API_URL || secrets.MSB_API_URL) || '' }}
+          MODAL_TOKEN_ID: ${{ (contains(fromJSON(needs.plan.outputs.matrix).include.*.provider, 'modal-gvisor') || contains(fromJSON(needs.plan.outputs.matrix).include.*.provider, 'modal-vm')) && secrets.MODAL_TOKEN_ID || '' }}
+          MODAL_TOKEN_SECRET: ${{ (contains(fromJSON(needs.plan.outputs.matrix).include.*.provider, 'modal-gvisor') || contains(fromJSON(needs.plan.outputs.matrix).include.*.provider, 'modal-vm')) && secrets.MODAL_TOKEN_SECRET || '' }}
+          NOVITA_API_KEY: ${{ contains(fromJSON(needs.plan.outputs.matrix).include.*.provider, 'novita') && secrets.NOVITA_API_KEY || '' }}
+          NOVITA_TEMPLATE: ${{ contains(fromJSON(needs.plan.outputs.matrix).include.*.provider, 'novita') && (env.NOVITA_TEMPLATE || vars.NOVITA_TEMPLATE || secrets.NOVITA_TEMPLATE) || '' }}
           RUNLOOP_API_KEY: ${{ contains(fromJSON(needs.plan.outputs.matrix).include.*.provider, 'runloop') && secrets.RUNLOOP_API_KEY || '' }}
-          # A scoped promote imports every provider module in one process. Keep the run.cloud key out
-          # of that process unless the resolved release plan will actually re-validate runcloud.
-          RUN_CLOUD_API_KEY: ${{ contains(fromJSON(needs.plan.outputs.matrix).include.*.provider, 'runcloud') && secrets.RUN_CLOUD_API_KEY || '' }}
-          # Namespace's re-validation boot reads this OIDC-federated token file (see the Namespace CLI
-          # steps above). Not a stored secret: empty when the exchange/mint was skipped/failed, which
-          # skips namespace's re-validation without failing the promote (namespace is not in --require).
+          RUNLOOP_BLUEPRINT: ${{ contains(fromJSON(needs.plan.outputs.matrix).include.*.provider, 'runloop') && (env.RUNLOOP_BLUEPRINT || vars.RUNLOOP_BLUEPRINT || secrets.RUNLOOP_BLUEPRINT) || '' }}
           NSC_TOKEN_FILE: ${{ steps.namespace.outputs.token-file }}
-          # The promote transaction re-validates every in-scope provider. Unlike every credential around it, this
-          # is a literal rather than a `secrets.*` reference, so it has no missing-value skip path — it
-          # is safe only because this job is PINNED to `starsling-ubuntu-24.04-2` (see runs-on above),
-          # the same virtualization-capable label the bake matrix uses. Moving promote to a runner
-          # without KVM must clear this at the same time, or every release spends a doomed libkrun boot
-          # whose failure is invisible in promote-payload.json (microsandbox-local is not in --require,
-          # so `blocks()` is false and promote never records it). Cloud uses its key + optional endpoint.
-          MICROSANDBOX_LOCAL_BENCH: "1"
-          MSB_API_URL: ${{ secrets.MSB_API_URL }}
-          MSB_API_KEY: ${{ secrets.MSB_API_KEY }}
-          VERCEL_OIDC_TOKEN: ${{ steps.vercel-auth.outcome == 'success' && env.VERCEL_OIDC_TOKEN || '' }}
+          VERCEL_OIDC_TOKEN: ${{ contains(fromJSON(needs.plan.outputs.matrix).include.*.provider, 'vercel') && steps.vercel-auth.outcome == 'success' && env.VERCEL_OIDC_TOKEN || '' }}
+          VERCEL_TEAM_SLUG: ${{ contains(fromJSON(needs.plan.outputs.matrix).include.*.provider, 'vercel') && (env.VERCEL_TEAM_SLUG || vars.VERCEL_TEAM_SLUG || secrets.VERCEL_TEAM_SLUG) || '' }}
+          VERCEL_PROJECT_NAME: ${{ contains(fromJSON(needs.plan.outputs.matrix).include.*.provider, 'vercel') && (env.VERCEL_PROJECT_NAME || vars.VERCEL_PROJECT_NAME || secrets.VERCEL_PROJECT_NAME) || '' }}
+          RUN_CLOUD_API_KEY: ${{ contains(fromJSON(needs.plan.outputs.matrix).include.*.provider, 'runcloud') && secrets.RUN_CLOUD_API_KEY || '' }}
+          TAMA_TOKEN: ${{ contains(fromJSON(needs.plan.outputs.matrix).include.*.provider, 'tama') && secrets.TAMA_TOKEN || '' }}
+          TAMA_CLI: ${{ contains(fromJSON(needs.plan.outputs.matrix).include.*.provider, 'tama') && (env.TAMA_CLI || vars.TAMA_CLI || secrets.TAMA_CLI) || '' }}
+          # <<< end generated: provider-inputs-promote
           VERCEL_CANDIDATE_IMAGE: ${{ steps.vercel-vcr.outcome == 'success' && steps.vercel-vcr.outputs.digest-ref || '' }}
         run: |
           set -euo pipefail

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -42,6 +42,7 @@ PTS-catalog changes also have a drift gate:
 bun run --filter @sandbox-benchmarks/schema generate-catalog   # regenerate from vendored profiles
 bun run check:catalog-drift                                    # fail if the committed draft drifted
 bun run check:provider-registry-drift                           # fail if provider metadata assembly drifted
+bun run check:provider-wiring                                   # fail if generated CI/docs/env wiring drifted
 ```
 
 ## Add a provider
@@ -50,10 +51,10 @@ bun run check:provider-registry-drift                           # fail if provid
    [`packages/schema/src/provider-ids.ts`](./packages/schema/src/provider-ids.ts), then add the one
    hand-authored `packages/schema/src/provider-meta/<id>.ts` module. Declare display/vendor identity,
    inputs, artifact lifecycle, isolation, vetted pricing, maturity, spec pinning, and transport there.
-   Run `bun run --filter @sandbox-benchmarks/schema generate-provider-registry` and review the
-   generated correlated index. Filename, tuple key, and declared id disagreement is a compile error;
-   malformed descriptor semantics fail the generator's Tier-3 arktype gate. Keep the independent
-   hardcoded provider oracle in `providers.test.ts` current.
+   Run `bun run generate-provider-registry` and `bun run generate-provider-wiring`, then review the
+   generated correlated index plus managed workflow/docs/env regions. Filename, tuple key, and
+   declared id disagreement is a compile error; malformed descriptor semantics fail the generator's
+   Tier-3 arktype gate. Keep the independent hardcoded provider oracle in `providers.test.ts` current.
 2. **Adapter** — add a matching entry to the adapter map in
    [`packages/providers`](./packages/providers): how to `createCompute()` and the create-time
    `createOptions` (the pinned target spec + toolchain image). The two registries are joined by id, so a
@@ -61,10 +62,10 @@ bun run check:provider-registry-drift                           # fail if provid
 3. **Artifact implementation** — only when the descriptor's `artifact.kind` requires one, add the
    provider-specific bake/template implementation. Providers using a stock or shared image do not get
    no-op bakers.
-4. **Transitional wiring** — until the provider-wiring generator lands, update the remaining CLI bake,
-   release, workflow-input, docs, and dispatch surfaces manually. `bun run
-   check:provider-registry-drift` already gates the metadata assembly; the later wiring generator will
-   replace this temporary exhaustive-consumer step.
+4. **Generated wiring** — do not hand-edit provider choice/input regions. Provider metadata generates
+   the smoke dispatch options, three least-privilege workflow input blocks, runner routing,
+   `.env.example`, CI configuration docs, and the privileged-environment checklist. The drift gate
+   rejects stale or hand-edited output.
 5. Bring the provider up with a single-provider branch dispatch. Adding it to the default benchmark
    matrix remains a separate promotion decision after live validation.
 

--- a/apps/cli/src/bin/release-plan.test.ts
+++ b/apps/cli/src/bin/release-plan.test.ts
@@ -105,9 +105,8 @@ describe("buildReleasePlan matrix", () => {
 		expect(plan.matrix.include.every((c) => c.required)).toBe(true);
 	});
 
-	// The flip side of "everything you name is required": a provider the lane carries no credentials
-	// for would fail its cell deterministically, after a privileged approval and (on `build: full`) an
-	// hour of rebuild. The plan refuses instead, naming the reason.
+	// The flip side of "everything you name is required": validating a stock provider does not create
+	// an artifact a scoped backfill can ship. The plan refuses that impossible request before approval.
 	test("refuses a scope naming a provider the release lane cannot ship", () => {
 		expect(() => buildReleasePlan({ ...base, providers: "blaxel" })).toThrow(/blaxel/);
 		expect(() => buildReleasePlan({ ...base, providers: "e2b,blaxel" })).toThrow(

--- a/apps/cli/src/bin/release-plan.ts
+++ b/apps/cli/src/bin/release-plan.ts
@@ -58,13 +58,13 @@ export const RELEASE_REQUIRED_PROVIDERS: readonly ProviderId[] = [
  * fail-fast with an explanation.
  *
  * Keyed by provider so the reason travels with the refusal. Blaxel still boots a stock vendor image,
- * so its bake/promote publishes nothing. Adding a toolchain artifact and release credential wiring is
- * what would remove the remaining entry here.
+ * so its bake/promote publishes nothing even though generated wiring now allows an unscoped release
+ * to validate it best-effort. Giving it a toolchain artifact is what would remove this entry.
  */
 export const RELEASE_UNSCOPABLE_PROVIDERS: Readonly<Partial<Record<ProviderId, string>>> = {
 	blaxel:
-		"it boots the vendor's stock image rather than the toolchain, so the release lane carries no " +
-		"BL_API_KEY/BL_WORKSPACE and has no artifact to publish for it",
+		"it boots the vendor's stock image rather than the toolchain and has no artifact to publish; " +
+		"credentialed validation alone cannot produce a scoped backfill",
 };
 
 const MIRRORED_CANDIDATE_REFS = {

--- a/docs/adr/0006-declarative-provider-onboarding.md
+++ b/docs/adr/0006-declarative-provider-onboarding.md
@@ -314,13 +314,14 @@ registry claims that every consumer must reinterpret.
 
 ### 6. Provider-input descriptors with a normalizing morph (Tiers 2 + 3)
 
-`requiredEnvVars: string[]` cannot distinguish secrets, ordinary variables, generated step output,
+`requiredEnvVars: string[]` cannot distinguish secrets, ordinary variables, generated step values,
 optional tuning, or values with defaults. Replace it with `inputs`, keep the string shorthand for a
 required secret, and normalize once so no consumer handles two shapes:
 
 ```ts
 const inputSource = type({ kind: "'secret'" })
   .or({ kind: "'variable'" })
+  .or({ kind: "'step-env'", step: "string >= 1" })
   .or({ kind: "'step-output'", step: "string >= 1", output: "string >= 1" });
 
 const providerInput = type("string >= 1").or({
@@ -328,6 +329,7 @@ const providerInput = type("string >= 1").or({
   "source?": inputSource,
   "required?": "boolean",
   "default?": "string >= 1",            // DAYTONA_TARGET → "us-west-2"
+  "ciValue?": "string >= 1",            // MICROSANDBOX_LOCAL_BENCH → "1" in CI
 });
 
 export const input = providerInput.pipe((c) =>
@@ -339,9 +341,10 @@ export const input = providerInput.pipe((c) =>
 ```
 
 Verified: mixed shorthand/full input normalizes to one shape, and `""` is rejected at
-`value at [0] must be non-empty`. A step output names its producer step and output explicitly, so
-the emitter never guesses an expression from an env name. Tier-3 narrows reject a default on a
-secret or step output and a required input with a default. Reusing the same `name` across provider
+`value at [0] must be non-empty`. A step-provided environment value names its producer step; a step
+output names both step and output, so the emitter never guesses provenance from an env name. Tier-3
+narrows reject a default on a secret, step env, or step output; reject `ciValue` anywhere except an
+ordinary variable; and reject a required input with a default. Reusing the same `name` across provider
 variants is the declaration that they share it; a parallel `sharedWith` list would be another drift
 surface.
 
@@ -352,7 +355,10 @@ defaulted input a required `string` and leaves only genuinely optional inputs as
 undefined`. This avoids the common mistake where a default is modeled as optional all the way into
 driver code. The descriptor is the single declaration behind CI wiring, compile-time access, and
 runtime parsing. Two further Tier-1 fields cover the remaining per-provider CI facts that are
-ternaries in YAML today: `runner?: string` and `preAuth?: "namespace-token" | "vercel-auth"`.
+ternaries in YAML today: `runner?: { label: string; noCache: boolean; lifetimeMinutes?: number }`
+and `preAuth?: "namespace-token" | "vercel-auth"`. Runner routing, setup cache policy, and the
+advertised reaping budget are one structured declaration because all three are properties of the
+same runner label; Tier-3 rejects providers that assign contradictory policies to a shared label.
 
 ### 7. Generate the managed regions, gate them the way ADR-0003 gates the catalog (Tier 3)
 
@@ -381,8 +387,9 @@ in the provider identity leaf every CLI bin and harness process imports is not.
 promotion decision, not a mechanical consequence of registering, and the 18-line rationale above it
 is real content. `workflow-sync.ts` invariants 1 and 3 are deleted as redundant — a generated region
 cannot drift from its generator. Invariants 2, 3b, 4–7 are unrelated to onboarding and stay.
-Pre-auth steps stay hand-written (Vercel's VCR mirror is ~50 bespoke lines) but gain a cheap gate: a
-provider declaring `preAuth` must have the step in both lanes.
+Pre-auth steps stay hand-written (Vercel's VCR mirror is ~50 bespoke lines), while their mechanical
+owner-aware `if` expressions are generated for benchmark, bake, and promote. A structural gate also
+requires every provider declaring `preAuth` to have that exact producer step in all three jobs.
 
 ### 8. Close the loop: the generator emits `as const satisfies`
 

--- a/docs/ci-secrets.md
+++ b/docs/ci-secrets.md
@@ -149,9 +149,10 @@ Ungated: `ci.yml`, `ci-lint.yml`, and the toolchain `pr-gate` (Docker smoke, no 
    public base moves:
 
    - **`providers: blaxel` is refused.** It still boots a vendor stock image, so the release lane has
-     no artifact to publish and carries no `BL_API_KEY`/`BL_WORKSPACE`. An *unscoped* release simply
-     skips it. Runloop is scopable: its protected `RUNLOOP_API_KEY` builds and validates a candidate
-     Blueprint, and a scoped Runloop dispatch is required/fail-closed.
+     no artifact a scoped backfill can publish. Generated credentials let an *unscoped* release
+     validate it best-effort, but validation alone cannot turn the stock image into a release output.
+     Runloop is scopable: its protected `RUNLOOP_API_KEY` builds and validates a candidate Blueprint,
+     and a scoped Runloop dispatch is required/fail-closed.
    - **A drifted candidate base is refused** when the scope contains a provider that bakes its artifact
      *from* the base (e2b, daytona, novita, runloop). Those providers' candidates are verified but their version
      artifacts are rebuilt, so the two are the same bytes only while `:vN-candidate` still is `:vN` —
@@ -207,20 +208,27 @@ Do this in the GitHub UI (Settings → Environments / Rules / Actions), then del
    without it.
 4. Add these **environment** secrets (then delete repository-level copies if present):
 
+   <!-- >>> generated: provider-secrets — bun run generate-provider-wiring -->
    | Secret | Used by |
    | --- | --- |
-   | `E2B_API_KEY` | toolchain bake, bench matrix/smoke |
-   | `DAYTONA_API_KEY` | toolchain bake, bench matrix/smoke |
-   | `DAYTONA_TARGET` | optional; workflows default to `us-west-2` |
-   | `MODAL_TOKEN_ID` | toolchain bake, bench matrix/smoke |
-   | `MODAL_TOKEN_SECRET` | toolchain bake, bench matrix/smoke |
-   | `NOVITA_API_KEY` | optional for toolchain; bench matrix/smoke |
-   | `RUNLOOP_API_KEY` | protected toolchain Blueprint bake/promote, bench matrix/smoke |
-   | `BL_API_KEY` | bench matrix/smoke only |
-   | `BL_WORKSPACE` | bench matrix/smoke only |
-   | `MSB_API_KEY` | Microsandbox Cloud toolchain validation and bench matrix/smoke |
-   | `RUN_CLOUD_API_KEY` | optional for toolchain validation; bench matrix/smoke |
-   | `TAMA_TOKEN` | bench matrix/smoke only |
+   | `E2B_API_KEY` | E2B provider runtime and validation |
+   | `DAYTONA_API_KEY` | Daytona (VM), Daytona (container) provider runtime and validation |
+   | `BL_API_KEY` | Blaxel provider runtime and validation |
+   | `BL_WORKSPACE` | Blaxel provider runtime and validation |
+   | `MSB_API_KEY` | Microsandbox Cloud provider runtime and validation |
+   | `MODAL_TOKEN_ID` | Modal (gVisor), Modal (VM) provider runtime and validation |
+   | `MODAL_TOKEN_SECRET` | Modal (gVisor), Modal (VM) provider runtime and validation |
+   | `NOVITA_API_KEY` | Novita provider runtime and validation |
+   | `RUNLOOP_API_KEY` | Runloop provider runtime and validation |
+   | `RUN_CLOUD_API_KEY` | run.cloud provider runtime and validation |
+   | `TAMA_TOKEN` | tama provider runtime and validation |
+   <!-- <<< end generated: provider-secrets -->
+
+   Vercel bootstrap credentials are workflow infrastructure, not provider runtime inputs, so they
+   remain an explicit list:
+
+   | Secret | Used by |
+   | --- | --- |
    | `VERCEL_TOKEN` | Bootstrap only: Vercel CLI pulls a short-lived project OIDC token |
    | `VERCEL_ORG_ID` | Links the Vercel CLI to the repository's organization (`team_*`) |
    | `VERCEL_PROJECT_ID` | Links the Vercel CLI to the repository's project (`prj_*`) |
@@ -234,16 +242,28 @@ Do this in the GitHub UI (Settings → Environments / Rules / Actions), then del
    file. Toolchain jobs additionally run `vercel vcr login docker`, use `vercel vcr push docker` for
    publication, and always run `docker logout vcr.vercel.com`.
 
-   GitHub Actions **variables** (Settings → Secrets and variables → Actions → Variables), *not*
-   secrets — a team slug and a project name are not credentials, and leaving them readable in job logs
-   is what makes a mirror into the wrong namespace diagnosable:
+   Put ordinary, non-credential provider configuration in GitHub Actions **variables** (Settings →
+   Secrets and variables → Actions → Variables), *not* secrets. The generated workflow accepts the
+   legacy secret location as a migration fallback, but new configuration should use variables:
 
-   | Variable | Purpose |
-   | --- | --- |
-   | `VERCEL_TEAM_SLUG` | Vercel team slug (org) the VCR namespace is rooted at |
-   | `VERCEL_PROJECT_NAME` | Vercel project name the VCR namespace is scoped to |
+   <!-- >>> generated: provider-variables — bun run generate-provider-wiring -->
+   | Variable | Used by | Default |
+   | --- | --- | --- |
+   | `E2B_TEMPLATE` | E2B | — |
+   | `DAYTONA_TARGET` | Daytona (VM) | <code>us-west-2</code> |
+   | `DAYTONA_SNAPSHOT` | Daytona (VM) | — |
+   | `DAYTONA_CONTAINER_TARGET` | Daytona (container) | <code>us-west-2</code> |
+   | `DAYTONA_CONTAINER_SNAPSHOT` | Daytona (container) | — |
+   | `MSB_API_URL` | Microsandbox Cloud | — |
+   | `NOVITA_TEMPLATE` | Novita | — |
+   | `RUNLOOP_BLUEPRINT` | Runloop | — |
+   | `VERCEL_TEAM_SLUG` | Vercel Sandbox | — |
+   | `VERCEL_PROJECT_NAME` | Vercel Sandbox | — |
+   | `TAMA_CLI` | tama | — |
+   <!-- <<< end generated: provider-variables -->
 
-   Both are optional: unset, they fall back to `VERCEL_TEAM_SLUG_DEFAULT` /
+   Optional values with a declared provider default use it when unset. The two Vercel namespace
+   values fall back to `VERCEL_TEAM_SLUG_DEFAULT` /
    `VERCEL_PROJECT_NAME_DEFAULT` in `packages/schema/src/toolchain.ts`, which is the single place the
    default namespace is defined. Set them only to publish into a different team or project.
 

--- a/package.json
+++ b/package.json
@@ -60,7 +60,10 @@
     "spell": "mise exec -- typos",
     "spell:fix": "mise exec -- typos --write-changes",
     "check:catalog-drift": "bun --filter '@sandbox-benchmarks/schema' check:catalog-drift",
+    "generate-provider-registry": "bun --filter '@sandbox-benchmarks/schema' generate-provider-registry",
     "check:provider-registry-drift": "bun --filter '@sandbox-benchmarks/schema' check:provider-registry-drift",
+    "generate-provider-wiring": "bun --filter '@sandbox-benchmarks/schema' generate-provider-wiring",
+    "check:provider-wiring": "bun --filter '@sandbox-benchmarks/schema' check:provider-wiring",
     "prepare": "lefthook install"
   },
   "devDependencies": {

--- a/packages/schema/package.json
+++ b/packages/schema/package.json
@@ -23,7 +23,9 @@
     "generate-catalog": "bun run scripts/generate-catalog.ts",
     "check:catalog-drift": "bun run scripts/check-catalog-drift.ts",
     "generate-provider-registry": "bun run scripts/generate-provider-registry.ts",
-    "check:provider-registry-drift": "bun run scripts/check-provider-registry-drift.ts"
+    "check:provider-registry-drift": "bun run scripts/check-provider-registry-drift.ts",
+    "generate-provider-wiring": "bun run scripts/generate-provider-wiring.ts",
+    "check:provider-wiring": "bun run scripts/check-provider-wiring-drift.ts"
   },
   "dependencies": {
     "arktype": "catalog:"

--- a/packages/schema/scripts/check-provider-wiring-drift.ts
+++ b/packages/schema/scripts/check-provider-wiring-drift.ts
@@ -1,0 +1,17 @@
+#!/usr/bin/env bun
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { REPO_ROOT, renderProviderWiringFiles } from "./generate-provider-wiring.ts";
+
+const drifted: string[] = [];
+for (const [file, expected] of renderProviderWiringFiles()) {
+	if (readFileSync(resolve(REPO_ROOT, file), "utf8") !== expected) drifted.push(file);
+}
+
+if (drifted.length > 0) {
+	console.error(
+		`provider wiring drifted in ${drifted.join(", ")}; run \`bun run generate-provider-wiring\` and commit the result`,
+	);
+	process.exit(1);
+}
+console.log("✓ generated provider wiring is current");

--- a/packages/schema/scripts/generate-provider-wiring.test.ts
+++ b/packages/schema/scripts/generate-provider-wiring.test.ts
@@ -1,0 +1,217 @@
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import type { ProviderId } from "../src/provider-ids.ts";
+import { PROVIDER_IDS } from "../src/provider-ids.ts";
+import { REGISTRY } from "../src/provider-meta/index.ts";
+import type { NormalizedProviderInput } from "../src/provider-meta.ts";
+import {
+	normalizeProviderInput,
+	PROVIDER_PRE_AUTH_CONTRACTS,
+	PROVIDER_PRE_AUTH_POLICIES,
+} from "../src/provider-meta.ts";
+import {
+	escapeMarkdownCell,
+	generatedProviderRegions,
+	preAuthBindings,
+	providerInputBindings,
+	REPO_ROOT,
+	renderCiSecretTable,
+	renderCiVariableTable,
+	renderDotenvValue,
+	renderEnvExample,
+	renderPreAuthCondition,
+	renderPreAuthOwnerCondition,
+	renderProviderWiringFiles,
+	renderRunnerLifetime,
+	renderRunnerNoCache,
+	renderRunnerSelection,
+	renderSmokeProviderOptions,
+	renderWorkflowInputs,
+	replaceGeneratedRegion,
+} from "./generate-provider-wiring.ts";
+
+function record(value: unknown, label: string): Record<string, unknown> {
+	if (value === null || typeof value !== "object" || Array.isArray(value)) {
+		throw new Error(`${label} is not a mapping`);
+	}
+	return value as Record<string, unknown>;
+}
+
+function workflowJobSteps(file: string, jobId: string): Record<string, unknown>[] {
+	const document = record(Bun.YAML.parse(readFileSync(resolve(REPO_ROOT, file), "utf8")), file);
+	const jobs = record(document.jobs, `${file} jobs`);
+	const job = record(jobs[jobId], `${file} job ${jobId}`);
+	if (!Array.isArray(job.steps)) throw new Error(`${file} job ${jobId} has no steps`);
+	return job.steps.map((step, index) => record(step, `${file} job ${jobId} step ${index}`));
+}
+
+function workflowDispatchOptions(file: string, inputName: string): unknown[] {
+	const document = record(Bun.YAML.parse(readFileSync(resolve(REPO_ROOT, file), "utf8")), file);
+	const on = record(document.on, `${file} on`);
+	const dispatch = record(on.workflow_dispatch, `${file} workflow_dispatch`);
+	const inputs = record(dispatch.inputs, `${file} workflow_dispatch inputs`);
+	const input = record(inputs[inputName], `${file} workflow_dispatch input ${inputName}`);
+	if (!Array.isArray(input.options)) {
+		throw new Error(`${file} workflow_dispatch input ${inputName} has no options`);
+	}
+	return input.options;
+}
+
+describe("provider wiring projections", () => {
+	test("deduplicates shared inputs without changing their normalized contract", () => {
+		const expected = new Map<string, { input: NormalizedProviderInput; owners: ProviderId[] }>();
+		for (const id of PROVIDER_IDS) {
+			for (const raw of REGISTRY[id].inputs) {
+				const input = normalizeProviderInput(raw);
+				const existing = expected.get(input.name);
+				if (existing === undefined) expected.set(input.name, { input, owners: [id] });
+				else existing.owners.push(id);
+			}
+		}
+
+		expect(providerInputBindings()).toEqual(
+			[...expected.values()].map(({ input, owners }) => ({ input, owners })),
+		);
+	});
+
+	test("emits the complete provider vocabulary and metadata-owned runner route", () => {
+		expect(workflowDispatchOptions(".github/workflows/bench-smoke.yml", "provider")).toEqual([
+			...PROVIDER_IDS,
+		]);
+		const renderedOptions = record(
+			Bun.YAML.parse(`options:\n${renderSmokeProviderOptions("  ")}`),
+			"rendered provider options",
+		);
+		expect(renderedOptions.options).toEqual([...PROVIDER_IDS]);
+		expect(renderRunnerSelection()).toContain(
+			"matrix.provider == 'microsandbox-local' && 'starsling-ubuntu-24.04-2'",
+		);
+		expect(renderRunnerSelection()).toEndWith("'ubuntu-24.04' }}");
+		expect(renderRunnerNoCache("")).toBe(
+			`no-cache: \${{ matrix.provider == 'microsandbox-local' && 'true' || 'false' }}`,
+		);
+		expect(renderRunnerLifetime("")).toBe(
+			`BENCH_RUNNER_LIFETIME_MINUTES: \${{ matrix.provider == 'microsandbox-local' && '70' || '' }}`,
+		);
+	});
+
+	test("scopes secrets, shared inputs, capability literals, and pre-auth values safely", () => {
+		const matrix = renderWorkflowInputs("matrix", "");
+		expect(matrix).toContain(
+			`E2B_API_KEY: \${{ matrix.provider == 'e2b' && secrets.E2B_API_KEY || '' }}`,
+		);
+		expect(matrix).toContain(
+			`DAYTONA_API_KEY: \${{ (matrix.provider == 'daytona-vm' || matrix.provider == 'daytona-container') && secrets.DAYTONA_API_KEY || '' }}`,
+		);
+		expect(matrix).toContain(
+			`MICROSANDBOX_LOCAL_BENCH: \${{ matrix.provider == 'microsandbox-local' && '1' || '' }}`,
+		);
+		expect(matrix).toContain(`NSC_TOKEN_FILE: \${{ steps.namespace.outputs.token-file }}`);
+		expect(matrix).toContain(
+			`VERCEL_OIDC_TOKEN: \${{ matrix.provider == 'vercel' && steps.vercel-auth.outcome == 'success' && env.VERCEL_OIDC_TOKEN || '' }}`,
+		);
+		expect(matrix).not.toContain("vars.VERCEL_OIDC_TOKEN");
+		expect(matrix).not.toContain("secrets.VERCEL_OIDC_TOKEN");
+	});
+
+	test("uses the release plan to scope every promote input", () => {
+		const promote = renderWorkflowInputs("release-scope", "");
+		expect(promote).toContain(
+			`RUN_CLOUD_API_KEY: \${{ contains(fromJSON(needs.plan.outputs.matrix).include.*.provider, 'runcloud') && secrets.RUN_CLOUD_API_KEY || '' }}`,
+		);
+		expect(promote).toContain(
+			"(contains(fromJSON(needs.plan.outputs.matrix).include.*.provider, 'modal-gvisor') || contains(fromJSON(needs.plan.outputs.matrix).include.*.provider, 'modal-vm')) && secrets.MODAL_TOKEN_ID",
+		);
+	});
+
+	test("projects all user-facing local, secret, and variable documentation", () => {
+		const local = renderEnvExample();
+		const secrets = renderCiSecretTable();
+		const variables = renderCiVariableTable();
+		for (const { input } of providerInputBindings()) {
+			expect(local).toContain(`${input.name}=`);
+			if (input.source.kind === "secret") expect(secrets).toContain(`\`${input.name}\``);
+			if (input.source.kind === "variable" && input.ciValue === undefined) {
+				expect(variables).toContain(`\`${input.name}\``);
+			}
+		}
+		expect(variables).not.toContain("MICROSANDBOX_LOCAL_BENCH");
+		expect(variables).not.toContain("VERCEL_OIDC_TOKEN");
+	});
+
+	test("escapes values for dotenv and Markdown instead of trusting a generic string check", () => {
+		expect(renderDotenvValue("https://host/v1#beta")).toBe('"https://host/v1#beta"');
+		expect(renderDotenvValue("$EXPAND_ME")).toBe('"\\$EXPAND_ME"');
+		expect(escapeMarkdownCell("Vendor | `beta`\nnext")).toBe(
+			"Vendor &#124; &#96;beta&#96;<br>next",
+		);
+	});
+
+	test("keeps every committed managed region byte-identical to the generator", () => {
+		for (const [file, expected] of renderProviderWiringFiles()) {
+			expect(readFileSync(resolve(REPO_ROOT, file), "utf8"), file).toBe(expected);
+		}
+	});
+
+	test("keeps the provider-wiring drift check in the required CI job", () => {
+		const matches = workflowJobSteps(".github/workflows/ci.yml", "check").filter(
+			(step) => step.run === "bun run check:provider-wiring",
+		);
+		expect(matches).toHaveLength(1);
+		expect(matches[0]?.name).toBe("Provider wiring drift");
+	});
+
+	test("preserves marker indentation and rejects missing or duplicate markers", () => {
+		const region = { file: "fixture.yml", label: "fixture", body: "  generated: true" };
+		const source =
+			"root:\n  # >>> generated: fixture — bun run generate-provider-wiring\n  old: true\n  # <<< end generated: fixture\n";
+		expect(replaceGeneratedRegion(source, region)).toBe(
+			"root:\n  # >>> generated: fixture — bun run generate-provider-wiring\n  generated: true\n  # <<< end generated: fixture\n",
+		);
+		expect(() => replaceGeneratedRegion("root: true\n", region)).toThrow(/missing or malformed/);
+		expect(() => replaceGeneratedRegion(`${source}${source}`, region)).toThrow(/exactly once/);
+		const prefixed = `${source}# >>> generated: fixture-extra — bun run generate-provider-wiring\n# <<< end generated: fixture-extra\n`;
+		expect(replaceGeneratedRegion(prefixed, region)).toContain("generated: true");
+	});
+
+	test("requires exact owner-aware pre-auth steps in benchmark, bake, and promote", () => {
+		const lanes = [
+			{ file: ".github/workflows/bench-suite.yml", job: "bench", lane: "matrix" as const },
+			{ file: ".github/workflows/toolchain-image.yml", job: "bake", lane: "matrix" as const },
+			{
+				file: ".github/workflows/toolchain-image.yml",
+				job: "publish",
+				lane: "release-scope" as const,
+			},
+		];
+		expect(preAuthBindings().map(({ preAuth }) => preAuth)).toEqual([
+			...PROVIDER_PRE_AUTH_POLICIES,
+		]);
+		for (const binding of preAuthBindings()) {
+			const stepId = PROVIDER_PRE_AUTH_CONTRACTS[binding.preAuth].step;
+			for (const { file, job, lane } of lanes) {
+				const matches = workflowJobSteps(file, job).filter(
+					(step) => step.uses === `./.github/actions/${binding.preAuth}`,
+				);
+				expect(matches, `${binding.preAuth} in ${file} jobs.${job}`).toHaveLength(1);
+				expect(matches[0]?.id).toBe(stepId);
+				expect(matches[0]?.if).toBe(renderPreAuthCondition(binding.preAuth, lane, "").slice(4));
+			}
+		}
+	});
+
+	test("keeps retired pre-auth actions managed and unconditionally disabled", () => {
+		const rendered = renderPreAuthOwnerCondition([], "matrix", "");
+		expect(rendered).toBe(`if: \${{ false }}`);
+		expect(record(Bun.YAML.parse(rendered), "retired pre-auth condition").if).toBe(`\${{ false }}`);
+	});
+
+	test("owns one uniquely labelled region for every generated projection", () => {
+		const regions = generatedProviderRegions();
+		expect(new Set(regions.map(({ file, label }) => `${file}:${label}`)).size).toBe(regions.length);
+		expect(new Set(regions.map(({ file }) => file))).toEqual(
+			new Set(renderProviderWiringFiles().keys()),
+		);
+	});
+});

--- a/packages/schema/scripts/generate-provider-wiring.ts
+++ b/packages/schema/scripts/generate-provider-wiring.ts
@@ -1,0 +1,404 @@
+#!/usr/bin/env bun
+// Generate marker-delimited provider wiring from the validated metadata registry (ADR-0006).
+// Workflows keep their hand-tuned control flow; only mechanical provider choices/input projections
+// live here. Adding a provider changes its descriptor and this reviewed output, not six dialects.
+
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import type { ProviderId } from "../src/provider-ids.ts";
+import { PROVIDER_IDS } from "../src/provider-ids.ts";
+import { REGISTRY } from "../src/provider-meta/index.ts";
+import type {
+	NormalizedProviderInput,
+	ProviderMetaSource,
+	ProviderPreAuth,
+	ProviderRunnerPolicy,
+} from "../src/provider-meta.ts";
+import { normalizeProviderInput, PROVIDER_PRE_AUTH_POLICIES } from "../src/provider-meta.ts";
+import { validateProviderModules } from "./provider-meta-schema.ts";
+
+export const REPO_ROOT = resolve(import.meta.dir, "../../..");
+export const GENERATOR_COMMAND = "bun run generate-provider-wiring";
+
+export interface InputBinding {
+	readonly input: NormalizedProviderInput;
+	readonly owners: readonly ProviderId[];
+}
+
+export interface PreAuthBinding {
+	readonly preAuth: ProviderPreAuth;
+	readonly owners: readonly ProviderId[];
+}
+
+export interface RunnerBinding {
+	readonly policy: ProviderRunnerPolicy;
+	readonly owners: readonly ProviderId[];
+}
+
+export type WiringLane = "matrix" | "release-scope";
+
+function providerMeta(id: ProviderId): ProviderMetaSource {
+	return REGISTRY[id];
+}
+
+export interface GeneratedRegion {
+	readonly file: string;
+	readonly label: string;
+	readonly body: string;
+}
+
+function generatedStart(region: GeneratedRegion): string {
+	const marker = `>>> generated: ${region.label} — ${GENERATOR_COMMAND}`;
+	return region.file.endsWith(".md") ? `<!-- ${marker} -->` : `# ${marker}`;
+}
+
+function generatedEnd(region: GeneratedRegion): string {
+	const marker = `<<< end generated: ${region.label}`;
+	return region.file.endsWith(".md") ? `<!-- ${marker} -->` : `# ${marker}`;
+}
+
+function exactMarkerIndices(source: string, marker: string): number[] {
+	const indices: number[] = [];
+	let offset = 0;
+	for (const line of source.split("\n")) {
+		const indent = line.length - line.trimStart().length;
+		if (line.slice(indent) === marker) indices.push(offset + indent);
+		offset += line.length + 1;
+	}
+	return indices;
+}
+
+export function replaceGeneratedRegion(source: string, region: GeneratedRegion): string {
+	const start = generatedStart(region);
+	const end = generatedEnd(region);
+	const starts = exactMarkerIndices(source, start);
+	const ends = exactMarkerIndices(source, end);
+	const startIndex = starts[0];
+	const endIndex = ends[0];
+	if (startIndex === undefined || endIndex === undefined || endIndex < startIndex) {
+		throw new Error(`${region.file}: missing or malformed generated region ${region.label}`);
+	}
+	if (starts.length !== 1 || ends.length !== 1) {
+		throw new Error(`${region.file}: generated region ${region.label} must occur exactly once`);
+	}
+	const bodyStart = startIndex + start.length;
+	const lineStart = source.lastIndexOf("\n", startIndex - 1) + 1;
+	const indent = source.slice(lineStart, startIndex);
+	return `${source.slice(0, bodyStart)}\n${region.body}\n${indent}${source.slice(endIndex)}`;
+}
+
+export function providerInputBindings(): InputBinding[] {
+	const byName = new Map<string, { input: NormalizedProviderInput; owners: ProviderId[] }>();
+	for (const id of PROVIDER_IDS) {
+		for (const raw of REGISTRY[id].inputs) {
+			const input = normalizeProviderInput(raw);
+			const existing = byName.get(input.name);
+			if (existing === undefined) byName.set(input.name, { input, owners: [id] });
+			else existing.owners.push(id);
+		}
+	}
+	return [...byName.values()];
+}
+
+export function preAuthBindings(): PreAuthBinding[] {
+	const bindings = new Map<ProviderPreAuth, ProviderId[]>(
+		PROVIDER_PRE_AUTH_POLICIES.map((preAuth): [ProviderPreAuth, ProviderId[]] => [preAuth, []]),
+	);
+	for (const id of PROVIDER_IDS) {
+		const preAuth = providerMeta(id).preAuth;
+		if (preAuth === undefined) continue;
+		const owners = bindings.get(preAuth) ?? [];
+		owners.push(id);
+		bindings.set(preAuth, owners);
+	}
+	return [...bindings].map(([preAuth, owners]) => ({ preAuth, owners }));
+}
+
+export function runnerBindings(): RunnerBinding[] {
+	const bindings = new Map<string, { policy: ProviderRunnerPolicy; owners: ProviderId[] }>();
+	for (const id of PROVIDER_IDS) {
+		const runner = providerMeta(id).runner;
+		if (runner === undefined) continue;
+		const signature = JSON.stringify(runner);
+		const existing = bindings.get(signature);
+		if (existing === undefined) bindings.set(signature, { policy: runner, owners: [id] });
+		else existing.owners.push(id);
+	}
+	return [...bindings.values()];
+}
+
+function ghaString(value: string): string {
+	return `'${value.replaceAll("'", "''")}'`;
+}
+
+function ownerCondition(owners: readonly ProviderId[], lane: WiringLane): string {
+	const clauses = owners.map((id) =>
+		lane === "matrix"
+			? `matrix.provider == ${ghaString(id)}`
+			: `contains(fromJSON(needs.plan.outputs.matrix).include.*.provider, ${ghaString(id)})`,
+	);
+	return clauses.length === 1 ? (clauses[0] ?? "false") : `(${clauses.join(" || ")})`;
+}
+
+export function renderPreAuthOwnerCondition(
+	owners: readonly ProviderId[],
+	lane: WiringLane,
+	indent = "        ",
+): string {
+	if (owners.length === 0) return `${indent}if: \${{ false }}`;
+	return `${indent}if: ${ownerCondition(owners, lane)}`;
+}
+
+export function renderPreAuthCondition(
+	preAuth: ProviderPreAuth,
+	lane: WiringLane,
+	indent = "        ",
+): string {
+	const binding = preAuthBindings().find((candidate) => candidate.preAuth === preAuth);
+	if (binding === undefined) throw new Error(`unsupported pre-auth policy ${preAuth}`);
+	return renderPreAuthOwnerCondition(binding.owners, lane, indent);
+}
+
+function inputValue(input: NormalizedProviderInput): string {
+	if (input.ciValue !== undefined) return ghaString(input.ciValue);
+	switch (input.source.kind) {
+		case "secret":
+			return `secrets.${input.name}`;
+		case "step-env":
+			return `steps.${input.source.step}.outcome == 'success' && env.${input.name}`;
+		case "step-output":
+			return `steps.${input.source.step}.outputs.${input.source.output}`;
+		case "variable": {
+			// `env` covers pre-auth composites (Vercel), `vars` is the intended ordinary-value home,
+			// and `secrets` is a compatibility fallback while existing installations migrate targets and
+			// endpoint overrides out of their Environment secret store.
+			const candidates = [`env.${input.name}`, `vars.${input.name}`, `secrets.${input.name}`];
+			if (input.default !== undefined) candidates.push(ghaString(input.default));
+			return candidates.join(" || ");
+		}
+	}
+}
+
+export function renderWorkflowInputs(lane: WiringLane, indent = "          "): string {
+	return providerInputBindings()
+		.map(({ input, owners }) => {
+			if (input.source.kind === "step-output") {
+				return `${indent}${input.name}: \${{ ${inputValue(input)} }}`;
+			}
+			const condition = ownerCondition(owners, lane);
+			const value = inputValue(input);
+			const selectedValue = value.includes(" || ") ? `(${value})` : value;
+			return `${indent}${input.name}: \${{ ${condition} && ${selectedValue} || '' }}`;
+		})
+		.join("\n");
+}
+
+export function renderSmokeProviderOptions(indent = "          "): string {
+	return PROVIDER_IDS.map((id) => `${indent}- ${ghaString(id)}`).join("\n");
+}
+
+export function renderRunnerSelection(): string {
+	const routed = PROVIDER_IDS.filter((id) => providerMeta(id).runner !== undefined);
+	const clauses = routed.map(
+		(id) =>
+			`matrix.provider == ${ghaString(id)} && ${ghaString(providerMeta(id).runner?.label ?? "")}`,
+	);
+	return `    runs-on: \${{ ${[...clauses, ghaString("ubuntu-24.04")].join(" || ")} }}`;
+}
+
+export function renderRunnerNoCache(indent = "          "): string {
+	const owners = runnerBindings()
+		.filter(({ policy }) => policy.noCache)
+		.flatMap(({ owners: policyOwners }) => policyOwners);
+	const condition = owners.length === 0 ? "false" : ownerCondition(owners, "matrix");
+	return `${indent}no-cache: \${{ ${condition} && 'true' || 'false' }}`;
+}
+
+export function renderRunnerLifetime(indent = "          "): string {
+	const clauses = runnerBindings().flatMap(({ policy, owners }) =>
+		policy.lifetimeMinutes === undefined
+			? []
+			: [`${ownerCondition(owners, "matrix")} && ${ghaString(String(policy.lifetimeMinutes))}`],
+	);
+	return `${indent}BENCH_RUNNER_LIFETIME_MINUTES: \${{ ${[...clauses, "''"].join(" || ")} }}`;
+}
+
+function oneLineComment(value: string): string {
+	return value.replace(/[\r\n]+/g, " ");
+}
+
+export function renderDotenvValue(value: string): string {
+	if (/^[A-Za-z0-9_./:@+%-]+$/.test(value) && !value.includes("#")) return value;
+	return JSON.stringify(value).replaceAll("$", "\\$");
+}
+
+export function escapeMarkdownCell(value: string): string {
+	return value
+		.replaceAll("&", "&amp;")
+		.replaceAll("<", "&lt;")
+		.replaceAll(">", "&gt;")
+		.replaceAll("|", "&#124;")
+		.replaceAll("`", "&#96;")
+		.replace(/\r?\n/g, "<br>");
+}
+
+export function renderEnvExample(): string {
+	const bindings = providerInputBindings();
+	const lines: string[] = [];
+	for (const id of PROVIDER_IDS) {
+		const owned = bindings.filter(({ owners }) => owners[0] === id);
+		if (owned.length === 0) continue;
+		lines.push(
+			`# --- ${oneLineComment(REGISTRY[id].displayName)} (${oneLineComment(REGISTRY[id].website)}) ---`,
+		);
+		for (const { input, owners } of owned) {
+			if (owners.length > 1) {
+				lines.push(
+					`# Shared by: ${owners.map((owner) => oneLineComment(REGISTRY[owner].displayName)).join(", ")}`,
+				);
+			}
+			if (!input.required)
+				lines.push("# Optional override; leave empty to use the provider default.");
+			if (input.ciValue !== undefined) {
+				lines.push(`# CI injects ${input.ciValue}; set locally only on a compatible runner.`);
+			}
+			lines.push(
+				`${input.name}=${input.default === undefined ? "" : renderDotenvValue(input.default)}`,
+			);
+		}
+		lines.push("");
+	}
+	return lines.join("\n").trimEnd();
+}
+
+export function renderCiSecretTable(): string {
+	const rows = providerInputBindings()
+		.filter(({ input }) => input.source.kind === "secret")
+		.map(({ input, owners }) => {
+			const providers = owners.map((id) => escapeMarkdownCell(REGISTRY[id].displayName)).join(", ");
+			return `   | \`${input.name}\` | ${providers} provider runtime and validation |`;
+		})
+		.join("\n");
+	return `   | Secret | Used by |\n   | --- | --- |\n${rows}`;
+}
+
+export function renderCiVariableTable(): string {
+	const rows = providerInputBindings()
+		.filter(({ input }) => input.source.kind === "variable" && input.ciValue === undefined)
+		.map(({ input, owners }) => {
+			const providers = owners.map((id) => escapeMarkdownCell(REGISTRY[id].displayName)).join(", ");
+			const defaultValue =
+				input.default === undefined ? "—" : `<code>${escapeMarkdownCell(input.default)}</code>`;
+			return `   | \`${input.name}\` | ${providers} | ${defaultValue} |`;
+		})
+		.join("\n");
+	return `   | Variable | Used by | Default |\n   | --- | --- | --- |\n${rows}`;
+}
+
+export function renderSetupSecretChecklist(): string {
+	const names = providerInputBindings()
+		.filter(({ input }) => input.source.kind === "secret")
+		.map(({ input }) => input.name);
+	const chunks: string[][] = [];
+	for (let index = 0; index < names.length; index += 4) chunks.push(names.slice(index, index + 4));
+	return chunks.map((chunk) => `echo "  ${chunk.join(", ")}"`).join("\n");
+}
+
+export function generatedProviderRegions(): GeneratedRegion[] {
+	const preAuthRegions = preAuthBindings().flatMap(({ preAuth }) => [
+		{
+			file: ".github/workflows/bench-suite.yml",
+			label: `preauth-${preAuth}-bench`,
+			body: renderPreAuthCondition(preAuth, "matrix"),
+		},
+		{
+			file: ".github/workflows/toolchain-image.yml",
+			label: `preauth-${preAuth}-bake`,
+			body: renderPreAuthCondition(preAuth, "matrix"),
+		},
+		{
+			file: ".github/workflows/toolchain-image.yml",
+			label: `preauth-${preAuth}-promote`,
+			body: renderPreAuthCondition(preAuth, "release-scope"),
+		},
+	]);
+	return [
+		{
+			file: ".github/workflows/bench-smoke.yml",
+			label: "provider-options",
+			body: renderSmokeProviderOptions(),
+		},
+		{
+			file: ".github/workflows/bench-suite.yml",
+			label: "provider-runner",
+			body: renderRunnerSelection(),
+		},
+		{
+			file: ".github/workflows/bench-suite.yml",
+			label: "provider-runner-cache",
+			body: renderRunnerNoCache(),
+		},
+		{
+			file: ".github/workflows/bench-suite.yml",
+			label: "provider-runner-lifetime",
+			body: renderRunnerLifetime(),
+		},
+		...preAuthRegions,
+		{
+			file: ".github/workflows/bench-suite.yml",
+			label: "provider-inputs-bench",
+			body: renderWorkflowInputs("matrix"),
+		},
+		{
+			file: ".github/workflows/toolchain-image.yml",
+			label: "provider-inputs-bake",
+			body: renderWorkflowInputs("matrix"),
+		},
+		{
+			file: ".github/workflows/toolchain-image.yml",
+			label: "provider-inputs-promote",
+			body: renderWorkflowInputs("release-scope"),
+		},
+		{ file: ".env.example", label: "provider-inputs-local", body: renderEnvExample() },
+		{ file: "docs/ci-secrets.md", label: "provider-secrets", body: renderCiSecretTable() },
+		{ file: "docs/ci-secrets.md", label: "provider-variables", body: renderCiVariableTable() },
+		{
+			file: "scripts/setup-privileged-environment.sh",
+			label: "provider-secret-checklist",
+			body: renderSetupSecretChecklist(),
+		},
+	];
+}
+
+export function renderProviderWiringFiles(root = REPO_ROOT): Map<string, string> {
+	// The same Tier-3 boundary that guards registry generation runs before wiring emission.
+	validateProviderModules(
+		Object.fromEntries(PROVIDER_IDS.map((id) => [id, { id, meta: REGISTRY[id] }])) as Record<
+			ProviderId,
+			unknown
+		>,
+	);
+	const rendered = new Map<string, string>();
+	for (const region of generatedProviderRegions()) {
+		const source = rendered.get(region.file) ?? readFileSync(resolve(root, region.file), "utf8");
+		rendered.set(region.file, replaceGeneratedRegion(source, region));
+	}
+	return rendered;
+}
+
+export async function generateProviderWiring(root = REPO_ROOT): Promise<void> {
+	const rendered = renderProviderWiringFiles(root);
+	for (const [file, content] of rendered) {
+		await Bun.write(resolve(root, file), content);
+	}
+	console.log(`✓ generated provider wiring in ${rendered.size} files`);
+}
+
+if (import.meta.main) {
+	try {
+		await generateProviderWiring();
+	} catch (error) {
+		console.error("generate-provider-wiring failed:", error);
+		process.exit(1);
+	}
+}

--- a/packages/schema/scripts/provider-meta-schema.test.ts
+++ b/packages/schema/scripts/provider-meta-schema.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, test } from "bun:test";
 import type { ProviderId } from "../src/provider-ids.ts";
 import { PROVIDER_IDS } from "../src/provider-ids.ts";
 import { REGISTRY } from "../src/provider-meta/index.ts";
-import { validateProviderModules } from "./provider-meta-schema.ts";
+import { assertProviderIdSyntax, validateProviderModules } from "./provider-meta-schema.ts";
 
 const VALID_MODULES = Object.fromEntries(
 	PROVIDER_IDS.map((id) => [id, { id, meta: REGISTRY[id] }]),
@@ -27,16 +27,54 @@ describe("Tier-3 provider metadata schema", () => {
 		).toThrow(/e2b: metadata module declares id tama/);
 	});
 
+	test("rejects provider ids that cannot round-trip through generated YAML and argv", () => {
+		expect(() => assertProviderIdSyntax(["valid-id", "bad # id"])).toThrow(
+			/provider ids must be lowercase kebab-case/,
+		);
+		expect(() => assertProviderIdSyntax(["Uppercase"])).toThrow(/lowercase kebab-case/);
+	});
+
 	test("rejects empty artifact evidence, runner names, and invalid pre-auth policies", () => {
 		expect(() =>
 			validateProviderModules(meta("vercel", { artifact: { kind: "mirror", repository: "" } })),
 		).toThrow(/repository/);
-		expect(() => validateProviderModules(meta("microsandbox-local", { runner: "" }))).toThrow(
-			/runner/,
-		);
+		expect(() =>
+			validateProviderModules(meta("microsandbox-local", { runner: { label: "", noCache: true } })),
+		).toThrow(/label/);
 		expect(() => validateProviderModules(meta("vercel", { preAuth: "custom-auth" }))).toThrow(
 			/preAuth/,
 		);
+	});
+
+	test("rejects a pre-auth credential that is declared optional", () => {
+		// A pre-auth step mints the credential. Declaring its input optional would let a failed
+		// pre-auth pass an empty value to the provider instead of failing the workflow.
+		expect(() =>
+			validateProviderModules(
+				meta("vercel", {
+					inputs: [
+						{
+							name: "VERCEL_OIDC_TOKEN",
+							source: { kind: "step-env", step: "vercel-auth" },
+							required: false,
+						},
+					],
+				}),
+			),
+		).toThrow(/VERCEL_OIDC_TOKEN must be required/);
+		expect(() =>
+			validateProviderModules(
+				meta("namespace", {
+					inputs: [
+						{
+							name: "NSC_TOKEN_FILE",
+							source: { kind: "step-output", step: "namespace", output: "token-file" },
+							required: false,
+						},
+					],
+				}),
+			),
+		).toThrow(/NSC_TOKEN_FILE must be required/);
 	});
 
 	test("rejects malformed, reserved, and same-vendor colliding baked suffixes", () => {
@@ -82,6 +120,125 @@ describe("Tier-3 provider metadata schema", () => {
 				}),
 			),
 		).toThrow(/not both required and defaulted/);
+		expect(() =>
+			validateProviderModules(
+				meta("e2b", {
+					inputs: [{ name: "E2B_API_KEY", source: { kind: "secret" }, ciValue: "fixed" }],
+				}),
+			),
+		).toThrow(/ciValue belongs only to variable sources/);
+	});
+
+	test("rejects input names and emitted values that could corrupt workflow expressions", () => {
+		expect(() => validateProviderModules(meta("e2b", { inputs: ["bad-name"] }))).toThrow(
+			/uppercase environment variable name/,
+		);
+		expect(() =>
+			validateProviderModules(
+				meta("e2b", {
+					inputs: [
+						{
+							name: "E2B_TEMPLATE",
+							source: { kind: "variable" },
+							default: "line one\nline two",
+						},
+					],
+				}),
+			),
+		).toThrow(/single-line string/);
+		expect(() =>
+			validateProviderModules(
+				meta("vercel", {
+					inputs: [
+						{
+							name: "VERCEL_OIDC_TOKEN",
+							source: { kind: "step-env", step: "bad }} || secrets.ESCAPE" },
+						},
+					],
+				}),
+			),
+		).toThrow(/step\/output property name/);
+	});
+
+	test("requires shared input names to use one normalized policy", () => {
+		expect(() =>
+			validateProviderModules(
+				meta("daytona-container", {
+					inputs: [
+						{ name: "DAYTONA_API_KEY", source: { kind: "variable" } },
+						...REGISTRY["daytona-container"].inputs.slice(1),
+					],
+				}),
+			),
+		).toThrow(/shared provider input DAYTONA_API_KEY must use one source/);
+	});
+
+	test("requires step-provided inputs to match the provider's declared pre-auth step", () => {
+		expect(() =>
+			validateProviderModules(
+				meta("vercel", {
+					inputs: [
+						{
+							name: "VERCEL_OIDC_TOKEN",
+							source: { kind: "step-env", step: "namespace" },
+						},
+					],
+				}),
+			),
+		).toThrow(/preAuth vercel-auth must produce VERCEL_OIDC_TOKEN/);
+		expect(() =>
+			validateProviderModules(
+				meta("e2b", {
+					inputs: [
+						{
+							name: "E2B_API_KEY",
+							source: { kind: "step-output", step: "auth", output: "token" },
+						},
+					],
+				}),
+			),
+		).toThrow(/step-provided inputs require a declared preAuth policy/);
+		expect(() =>
+			validateProviderModules(meta("vercel", { inputs: ["VERCEL_OIDC_TOKEN"] })),
+		).toThrow(/preAuth vercel-auth must produce VERCEL_OIDC_TOKEN/);
+		expect(() =>
+			validateProviderModules(
+				meta("namespace", {
+					inputs: [
+						{
+							name: "NSC_TOKEN_FILE",
+							source: { kind: "step-output", step: "namespace", output: "missing" },
+						},
+					],
+				}),
+			),
+		).toThrow(/preAuth namespace-token must produce NSC_TOKEN_FILE.*output token-file/);
+		expect(() =>
+			validateProviderModules(
+				meta("vercel", {
+					inputs: [
+						{
+							name: "ACME_TOKEN",
+							source: { kind: "step-env", step: "vercel-auth" },
+						},
+					],
+				}),
+			),
+		).toThrow(/preAuth vercel-auth must produce VERCEL_OIDC_TOKEN/);
+	});
+
+	test("requires providers sharing a runner label to share its complete policy", () => {
+		expect(() =>
+			validateProviderModules(
+				meta("e2b", {
+					runner: {
+						label: "starsling-ubuntu-24.04-2",
+						noCache: false,
+						lifetimeMinutes: 70,
+					},
+				}),
+			),
+		).toThrow(/shared runner starsling-ubuntu-24.04-2 must use one cache\/lifetime policy/);
 	});
 
 	test("rejects malformed transport and pricing before generation", () => {

--- a/packages/schema/scripts/provider-meta-schema.ts
+++ b/packages/schema/scripts/provider-meta-schema.ts
@@ -4,10 +4,28 @@
 import { type } from "arktype";
 import type { ProviderId } from "../src/provider-ids.ts";
 import { PROVIDER_IDS } from "../src/provider-ids.ts";
-import type { ProviderMetaModule } from "../src/provider-meta.ts";
+import type { NormalizedProviderInput, ProviderMetaModule } from "../src/provider-meta.ts";
+import {
+	normalizeProviderInput,
+	PROVIDER_PRE_AUTH_CONTRACTS,
+	PROVIDER_PRE_AUTH_POLICIES,
+} from "../src/provider-meta.ts";
 import { providerPricingSchema } from "../src/provider-pricing.ts";
 
 const nonemptyStringSchema = type("string >= 1");
+const singleLineStringSchema = nonemptyStringSchema.narrow((value, ctx) =>
+	/[\r\n]/.test(value) ? ctx.mustBe("a non-empty single-line string") : true,
+);
+const environmentNameSchema = nonemptyStringSchema.narrow((value, ctx) =>
+	/^[A-Z][A-Z0-9_]*$/.test(value)
+		? true
+		: ctx.mustBe("an uppercase environment variable name (for example PROVIDER_API_KEY)"),
+);
+const stepPropertySchema = nonemptyStringSchema.narrow((value, ctx) =>
+	/^[A-Za-z_][A-Za-z0-9_-]*$/.test(value)
+		? true
+		: ctx.mustBe("a GitHub Actions step/output property name"),
+);
 const finitePositiveNumberSchema = type("number > 0").narrow(Number.isFinite);
 const httpUrlSchema = type("string.url").narrow((value) => {
 	const protocol = new URL(value).protocol;
@@ -16,21 +34,27 @@ const httpUrlSchema = type("string.url").narrow((value) => {
 
 const secretInputSourceSchema = type({ kind: "'secret'" }).onUndeclaredKey("reject");
 const variableInputSourceSchema = type({ kind: "'variable'" }).onUndeclaredKey("reject");
+const stepEnvInputSourceSchema = type({
+	kind: "'step-env'",
+	step: stepPropertySchema,
+}).onUndeclaredKey("reject");
 const stepOutputInputSourceSchema = type({
 	kind: "'step-output'",
-	step: nonemptyStringSchema,
-	output: nonemptyStringSchema,
+	step: stepPropertySchema,
+	output: stepPropertySchema,
 }).onUndeclaredKey("reject");
 const inputSourceSchema = secretInputSourceSchema
 	.or(variableInputSourceSchema)
+	.or(stepEnvInputSourceSchema)
 	.or(stepOutputInputSourceSchema);
 const inputDescriptorSchema = type({
-	name: nonemptyStringSchema,
+	name: environmentNameSchema,
 	"source?": inputSourceSchema,
 	"required?": "boolean",
-	"default?": nonemptyStringSchema,
+	"default?": singleLineStringSchema,
+	"ciValue?": singleLineStringSchema,
 }).onUndeclaredKey("reject");
-const providerInputSchema = nonemptyStringSchema.or(inputDescriptorSchema);
+const providerInputSchema = environmentNameSchema.or(inputDescriptorSchema);
 
 const noArtifactSchema = type({ kind: "'none'" }).onUndeclaredKey("reject");
 const imageArtifactSchema = type({ kind: "'image'" }).onUndeclaredKey("reject");
@@ -85,8 +109,12 @@ export const providerMetaSourceSchema = type({
 		detachedPoll: "boolean",
 	}).onUndeclaredKey("reject"),
 	"runtimeIdentity?": "'root' | 'unprivileged'",
-	"runner?": nonemptyStringSchema,
-	"preAuth?": "'namespace-token' | 'vercel-auth'",
+	"runner?": type({
+		label: singleLineStringSchema,
+		noCache: "boolean",
+		"lifetimeMinutes?": "number.integer > 0",
+	}).onUndeclaredKey("reject"),
+	"preAuth?": type.enumerated(...PROVIDER_PRE_AUTH_POLICIES),
 })
 	.onUndeclaredKey("reject")
 	.narrow((meta, ctx) => {
@@ -97,14 +125,22 @@ export const providerMetaSourceSchema = type({
 				return ctx.mustBe(`provider inputs whose names are unique (duplicate: ${name})`);
 			}
 			names.add(name);
-			if (typeof raw === "string" || raw.default === undefined) continue;
-			if ((raw.source?.kind ?? "secret") !== "variable") {
-				return ctx.mustBe(
-					`provider inputs whose defaults belong only to variable sources (${name})`,
-				);
+			if (typeof raw === "string") continue;
+			const sourceKind = raw.source?.kind ?? "secret";
+			if (raw.default !== undefined) {
+				if (sourceKind !== "variable") {
+					return ctx.mustBe(
+						`provider inputs whose defaults belong only to variable sources (${name})`,
+					);
+				}
+				if (raw.required === true) {
+					return ctx.mustBe(`provider inputs that are not both required and defaulted (${name})`);
+				}
 			}
-			if (raw.required === true) {
-				return ctx.mustBe(`provider inputs that are not both required and defaulted (${name})`);
+			if (raw.ciValue !== undefined && sourceKind !== "variable") {
+				return ctx.mustBe(
+					`provider inputs whose ciValue belongs only to variable sources (${name})`,
+				);
 			}
 		}
 		return true;
@@ -119,15 +155,33 @@ export type CorrelatedProviderModules = {
 	[P in ProviderId]: ProviderMetaModule<P>;
 };
 
+type StepProvidedInput = Omit<NormalizedProviderInput, "source"> & {
+	readonly source: Extract<
+		NormalizedProviderInput["source"],
+		{ readonly kind: "step-env" | "step-output" }
+	>;
+};
+
 const SHARED_VARIANT_GROUPS = [
 	["daytona-vm", "daytona-container"],
 	["modal-gvisor", "modal-vm"],
 ] as const;
 
+export function assertProviderIdSyntax(ids: readonly string[] = PROVIDER_IDS): void {
+	for (const id of ids) {
+		if (!/^[a-z][a-z0-9]*(?:-[a-z0-9]+)*$/.test(id)) {
+			throw new Error(
+				`${id}: provider ids must be lowercase kebab-case so argv, env, and generated YAML share one spelling`,
+			);
+		}
+	}
+}
+
 /** Parse all discovered modules and enforce the few cross-module invariants identity cannot express. */
 export function validateProviderModules(
 	modules: Readonly<Record<ProviderId, unknown>>,
 ): CorrelatedProviderModules {
+	assertProviderIdSyntax();
 	const parsed = {} as Record<ProviderId, ProviderMetaModule<ProviderId>>;
 	for (const expectedId of PROVIDER_IDS) {
 		const result = providerMetaModuleSchema(modules[expectedId]);
@@ -170,6 +224,86 @@ export function validateProviderModules(
 		}
 		names.set(suffix, id);
 		bakedNamesByVendor.set(vendor, names);
+	}
+
+	// Runner behavior belongs to the runner label, not the first provider that happened to use it.
+	// Sharing a label with a different cache or reaping policy would route both jobs to the same host
+	// while giving them contradictory setup/budget behavior.
+	const runnersByLabel = new Map<string, { owner: ProviderId; signature: string }>();
+	for (const id of PROVIDER_IDS) {
+		const runner = parsed[id].meta.runner;
+		if (runner === undefined) continue;
+		const signature = JSON.stringify({
+			noCache: runner.noCache,
+			lifetimeMinutes: runner.lifetimeMinutes,
+		});
+		const existing = runnersByLabel.get(runner.label);
+		if (existing !== undefined && existing.signature !== signature) {
+			throw new Error(
+				`${existing.owner}/${id}: shared runner ${runner.label} must use one cache/lifetime policy`,
+			);
+		}
+		runnersByLabel.set(runner.label, existing ?? { owner: id, signature });
+	}
+
+	// One input name is one cross-consumer contract. Shared credentials across isolation variants
+	// must normalize identically or generated CI would have to pick one owner's source/default policy.
+	const inputsByName = new Map<string, { owner: ProviderId; signature: string }>();
+	for (const id of PROVIDER_IDS) {
+		const { preAuth } = parsed[id].meta;
+		const stepInputs: StepProvidedInput[] = [];
+		for (const raw of parsed[id].meta.inputs) {
+			const input = normalizeProviderInput(raw);
+			if (input.source.kind === "step-env" || input.source.kind === "step-output") {
+				stepInputs.push({ ...input, source: input.source });
+			}
+			const signature = JSON.stringify({
+				source: input.source,
+				required: input.required,
+				default: input.default,
+				ciValue: input.ciValue,
+			});
+			const existing = inputsByName.get(input.name);
+			if (existing !== undefined && existing.signature !== signature) {
+				throw new Error(
+					`${existing.owner}/${id}: shared provider input ${input.name} must use one source/default/required policy`,
+				);
+			}
+			inputsByName.set(input.name, existing ?? { owner: id, signature });
+		}
+		if (preAuth === undefined) {
+			if (stepInputs.length > 0) {
+				throw new Error(`${id}: step-provided inputs require a declared preAuth policy`);
+			}
+			continue;
+		}
+		const contract = PROVIDER_PRE_AUTH_CONTRACTS[preAuth];
+		const [actual] = stepInputs;
+		const sourceMatches =
+			actual !== undefined &&
+			actual.name === contract.input.name &&
+			actual.source.step === contract.step &&
+			actual.source.kind === contract.input.source.kind &&
+			(actual.source.kind !== "step-output" ||
+				(contract.input.source.kind === "step-output" &&
+					actual.source.output === contract.input.source.output));
+		if (stepInputs.length !== 1 || !sourceMatches) {
+			const output =
+				contract.input.source.kind === "step-output"
+					? ` output ${contract.input.source.output}`
+					: "";
+			throw new Error(
+				`${id}: preAuth ${preAuth} must produce ${contract.input.name} from ${contract.input.source.kind} step ${contract.step}${output}`,
+			);
+		}
+		// A pre-auth step exists to mint a credential. If the input it produces is optional, a
+		// failed pre-auth degrades into an empty value that the provider only discovers at create
+		// time, long after the workflow could have failed on it. Keep that failure at the boundary.
+		if (actual?.required !== true) {
+			throw new Error(
+				`${id}: preAuth ${preAuth} input ${contract.input.name} must be required so a failed pre-auth fails the workflow`,
+			);
+		}
 	}
 	return parsed as CorrelatedProviderModules;
 }

--- a/packages/schema/src/provider-meta.ts
+++ b/packages/schema/src/provider-meta.ts
@@ -23,6 +23,7 @@ export type ProviderArtifact =
 export type ProviderInputSource =
 	| { readonly kind: "secret" }
 	| { readonly kind: "variable" }
+	| { readonly kind: "step-env"; readonly step: string }
 	| { readonly kind: "step-output"; readonly step: string; readonly output: string };
 
 export interface ProviderInputDescriptor {
@@ -30,6 +31,8 @@ export interface ProviderInputDescriptor {
 	readonly source?: ProviderInputSource;
 	readonly required?: boolean;
 	readonly default?: string;
+	/** Fixed value injected only by generated CI wiring (for runner capability opt-ins). */
+	readonly ciValue?: string;
 }
 
 /** String shorthand means a required secret. */
@@ -40,9 +43,40 @@ export interface NormalizedProviderInput {
 	readonly source: ProviderInputSource;
 	readonly required: boolean;
 	readonly default?: string;
+	readonly ciValue?: string;
 }
 
-export type ProviderPreAuth = "namespace-token" | "vercel-auth";
+/** Supported pre-auth actions and the exact provider input each one produces. */
+export const PROVIDER_PRE_AUTH_CONTRACTS = {
+	"namespace-token": {
+		step: "namespace",
+		input: {
+			name: "NSC_TOKEN_FILE",
+			source: { kind: "step-output", output: "token-file" },
+		},
+	},
+	"vercel-auth": {
+		step: "vercel-auth",
+		input: {
+			name: "VERCEL_OIDC_TOKEN",
+			source: { kind: "step-env" },
+		},
+	},
+} as const;
+
+export type ProviderPreAuth = keyof typeof PROVIDER_PRE_AUTH_CONTRACTS;
+
+export const PROVIDER_PRE_AUTH_POLICIES = Object.freeze(
+	Object.keys(PROVIDER_PRE_AUTH_CONTRACTS) as ProviderPreAuth[],
+);
+
+export interface ProviderRunnerPolicy {
+	readonly label: string;
+	/** setup-bun cache policy for this runner label; explicit so routing cannot drift from setup. */
+	readonly noCache: boolean;
+	/** Hard runner reaping window, when shorter than the Actions job timeout. */
+	readonly lifetimeMinutes?: number;
+}
 
 /** The inert object authored in `provider-meta/<id>.ts`. */
 export interface ProviderMetaSource {
@@ -62,7 +96,7 @@ export interface ProviderMetaSource {
 	readonly specPinning: SpecPinning;
 	readonly transport: ProviderTransport;
 	readonly runtimeIdentity?: ProviderRuntimeIdentity;
-	readonly runner?: string;
+	readonly runner?: ProviderRunnerPolicy;
 	readonly preAuth?: ProviderPreAuth;
 }
 
@@ -91,5 +125,6 @@ export function normalizeProviderInput(input: ProviderInput): NormalizedProvider
 		source: input.source ?? { kind: "secret" },
 		required: input.required ?? input.default === undefined,
 		...(input.default === undefined ? {} : { default: input.default }),
+		...(input.ciValue === undefined ? {} : { ciValue: input.ciValue }),
 	};
 }

--- a/packages/schema/src/provider-meta/microsandbox-local.ts
+++ b/packages/schema/src/provider-meta/microsandbox-local.ts
@@ -8,7 +8,13 @@ export default defineProviderMeta("microsandbox-local", {
 	artifact: { kind: "image" },
 	// This is an explicit capability opt-in rather than a credential. Local runs require a host
 	// with KVM on Linux or Hypervisor.framework on macOS and should skip everywhere else.
-	inputs: [{ name: "MICROSANDBOX_LOCAL_BENCH", source: { kind: "variable" } }],
+	inputs: [
+		{
+			name: "MICROSANDBOX_LOCAL_BENCH",
+			source: { kind: "variable" },
+			ciValue: "1",
+		},
+	],
 	isolation: {
 		class: "microVM",
 		technology: "libkrun microVM (local)",
@@ -42,5 +48,9 @@ export default defineProviderMeta("microsandbox-local", {
 		syncCapMs: 60_000,
 		detachedPoll: true,
 	},
-	runner: "starsling-ubuntu-24.04-2",
+	runner: {
+		label: "starsling-ubuntu-24.04-2",
+		noCache: true,
+		lifetimeMinutes: 70,
+	},
 });

--- a/packages/schema/src/provider-meta/vercel.ts
+++ b/packages/schema/src/provider-meta/vercel.ts
@@ -8,7 +8,7 @@ export default defineProviderMeta("vercel", {
 	sdkPackage: "@vercel/sandbox",
 	artifact: { kind: "mirror", repository: VERCEL_VCR_REPOSITORY },
 	inputs: [
-		{ name: "VERCEL_OIDC_TOKEN", source: { kind: "variable" } },
+		{ name: "VERCEL_OIDC_TOKEN", source: { kind: "step-env", step: "vercel-auth" } },
 		{ name: "VERCEL_TEAM_SLUG", source: { kind: "variable" }, required: false },
 		{ name: "VERCEL_PROJECT_NAME", source: { kind: "variable" }, required: false },
 	],

--- a/packages/schema/src/providers.ts
+++ b/packages/schema/src/providers.ts
@@ -14,6 +14,7 @@ import type {
 	NormalizedProviderInput,
 	ProviderArtifact,
 	ProviderPreAuth,
+	ProviderRunnerPolicy,
 } from "./provider-meta.ts";
 import { normalizeProviderInput } from "./provider-meta.ts";
 import type { PricingComponent, PricingQuantityTerm, ProviderPricing } from "./provider-pricing.ts";
@@ -43,7 +44,9 @@ export type {
 	ProviderInputDescriptor,
 	ProviderInputSource,
 	ProviderPreAuth,
+	ProviderRunnerPolicy,
 } from "./provider-meta.ts";
+export { PROVIDER_PRE_AUTH_CONTRACTS, PROVIDER_PRE_AUTH_POLICIES } from "./provider-meta.ts";
 export * from "./provider-pricing.ts";
 
 import type { TargetSpec } from "./target-spec.ts";
@@ -150,8 +153,8 @@ export interface ProviderMeta {
 	specPinning: SpecPinning;
 	/** How the provider's exec transport behaves — the harness selects sync vs detached from this. */
 	transport: ProviderTransport;
-	/** Optional GitHub runner required by this provider. */
-	runner?: string;
+	/** Optional GitHub runner route plus its coupled setup-cache and reaping-budget policy. */
+	runner?: ProviderRunnerPolicy;
 	/** Optional CI authentication preparation owned by generated wiring. */
 	preAuth?: ProviderPreAuth;
 	/**

--- a/scripts/setup-privileged-environment.sh
+++ b/scripts/setup-privileged-environment.sh
@@ -55,11 +55,12 @@ echo "     it, a branch dispatch is refused here regardless of the workflow's ow
 echo "  3. Move provider secrets onto this environment; delete repository-level copies"
 echo
 echo "Secret checklist:"
-echo "  E2B_API_KEY, DAYTONA_API_KEY, DAYTONA_TARGET,"
-echo "  MODAL_TOKEN_ID, MODAL_TOKEN_SECRET, NOVITA_API_KEY,"
-echo "  MSB_API_KEY (and optional MSB_API_URL),"
-echo "  RUN_CLOUD_API_KEY,"
-echo "  BL_API_KEY, BL_WORKSPACE"
+# >>> generated: provider-secret-checklist — bun run generate-provider-wiring
+echo "  E2B_API_KEY, DAYTONA_API_KEY, BL_API_KEY, BL_WORKSPACE"
+echo "  MSB_API_KEY, MODAL_TOKEN_ID, MODAL_TOKEN_SECRET, NOVITA_API_KEY"
+echo "  RUNLOOP_API_KEY, RUN_CLOUD_API_KEY, TAMA_TOKEN"
+# <<< end generated: provider-secret-checklist
+echo "  VERCEL_TOKEN, VERCEL_ORG_ID, VERCEL_PROJECT_ID (Vercel bootstrap)"
 echo
 echo "Also required outside this Environment (see docs/ci-secrets.md):"
 echo "  - 'Allow GitHub Actions to create and approve pull requests' on"

--- a/tooling/repo-checks/src/lib/workflow-sync.ts
+++ b/tooling/repo-checks/src/lib/workflow-sync.ts
@@ -1,45 +1,35 @@
 // Drift gate: the GitHub workflows that dispatch live benchmarks must stay in lockstep with the
-// schema registries. GHA can't import TypeScript, so the provider/suite vocabulary and the
-// per-provider credential wiring are re-spelled by hand in the workflow files; this module re-derives
-// the truth from PROVIDERS + SUITE_NAMES (packages/schema) and compares. It mirrors
+// suite registry and retain their safe delegation/timeout shape. Provider choices and provider-input
+// wiring are generated from metadata and gated separately by check:provider-wiring. It mirrors
 // runner-benchmarking's check-workflow-{env,suite}-sync.ts, adapted to this repo's workflows.
 //
 // Two workflows dispatch live benchmarks — bench-matrix.yml (the full provider × suite matrix, ending
 // in a dataset commit) and bench-smoke.yml (the same pipeline narrowed to one dispatched provider ×
 // suite and stopped before that commit) — and they are now the SAME implementation: each is a `plan`
 // job over ./.github/actions/plan-bench-axes plus one suite-matrix job calling the reusable
-// bench-suite.yml. The credential block, the run-step env and the live-run timeout therefore exist
-// exactly once, in that reusable, which is what the credential/timeout checks read.
+// bench-suite.yml. The run-step env and live-run timeout therefore exist exactly once, in that
+// reusable.
 //
-// Invariants (each maps to a real "added X, forgot the workflow" failure mode):
-//   1. bench-smoke.yml's `provider` dispatch input options == the PROVIDERS id set, and its default
-//      is one of them — a new provider must be dispatchable, a removed one must not linger.
-//   2. bench-smoke.yml's `suite` dispatch input options == SUITE_NAMES, with a valid default.
-//   3. Every provider's requiredEnvVars (schema) is present in the "Run suite and normalize" step env
-//      of the reusable bench-suite.yml — the secret a new provider needs must be wired into the one
-//      cell implementation, or every live run silently skips that provider.
-//  3b. NEITHER dispatch lane owns a benchmark cell: no "Run suite and normalize" step, no `run:` that
+// Invariants not owned by generated provider wiring:
+//   1. bench-smoke.yml's `suite` dispatch input options == SUITE_NAMES, with a valid default.
+//   2. NEITHER dispatch lane owns a benchmark cell: no "Run suite and normalize" step, no `run:` that
 //      invokes the cell driver, and no provider credential in any job- or step-level env (see
-//      checkLaneDelegates). This is the invariant that replaces the old cross-lane credential
-//      comparison — by removing the second lane's copy rather than diffing it. All three probes are
-//      needed: a name match alone misses a cell re-grown under a fresh step name, and a step-level
-//      scan alone misses credentials hung off a job-level env that every step inherits.
-//   4. checkCredentialEnv still compares a key's value expression ACROSS whatever workflows it is
-//      handed, folding each lane's provider selector. With one lane left it degenerates to a presence
-//      check; it stays cross-workflow so a future third caller is compared, not assumed.
-//   5. The live-run job (the reusable's fan-out) outlasts the longest registered sandbox lifetime by a
+//      checkLaneDelegates). All three probes are needed: a name match alone misses a cell re-grown
+//      under a fresh step name, and a step-level scan alone misses credentials hung off a job-level
+//      env that every step inherits.
+//   3. The live-run job (the reusable's fan-out) outlasts the longest registered sandbox lifetime by a
 //      fixed margin, so a suite budget increase cannot leave an otherwise healthy job to be killed by
 //      Actions first; and the budget literal it advertises equals that timeout.
-//   6. Nesting wiring for BOTH lanes' suite-matrix callers (they are held to one shape, with the two
+//   4. Nesting wiring for BOTH lanes' suite-matrix callers (they are held to one shape, with the two
 //      deliberate per-lane differences — the matrix's publish dependency, the smoke's
 //      require_providers assertion — stated explicitly at each lane, in both directions) plus the
 //      reusable's provider job name and the replicate axis reaching the cell as BENCH_REPLICATES data.
-//   7. A smoke dispatch measures ONE sandbox unless asked otherwise — the dispatch default AND the
+//   5. A smoke dispatch measures ONE sandbox unless asked otherwise — the dispatch default AND the
 //      blank-value fallback, since `default:` alone does not survive a cleared field and blank means
 //      "each suite's Suite.defaultReplicas" (R=12 on realworld). See workflow-nesting.ts.
 //
 // YAML navigation lives in workflow-yaml.ts; nesting checks in workflow-nesting.ts. This file owns
-// credential/timeout invariants plus runCheck orchestration, and re-exports the public surface the
+// timeout/delegation invariants plus runCheck orchestration, and re-exports the public surface the
 // gate's tests import.
 import { PROVIDERS, SUITE_NAMES, SUITES } from "@sandbox-benchmarks/schema";
 import {
@@ -95,11 +85,6 @@ export {
 	stepEnv,
 	WORKFLOW_TIMEOUT_MARGIN_MINUTES,
 } from "./workflow-yaml.ts";
-
-/** The canonical provider ids from the schema registry. */
-export function providerIds(): string[] {
-	return PROVIDERS.map((p) => p.id);
-}
 
 /** Every requiredEnvVars entry across the Provider registry, with provenance (key -> owning ids). */
 export function requiredCredentialKeys(): Map<string, string[]> {
@@ -166,17 +151,6 @@ function checkChoiceOptions(
 	return errors;
 }
 
-/** Invariant 1: the provider dispatch input options == the PROVIDERS id set. */
-export function checkProviderInput(input: DispatchInput, label: string = SMOKE_WORKFLOW): string[] {
-	return checkChoiceOptions(
-		input,
-		providerIds(),
-		"provider",
-		"PROVIDERS (packages/schema/src/providers.ts)",
-		label,
-	);
-}
-
 /** Invariant 2: the suite dispatch input options == SUITE_NAMES. */
 export function checkSuiteInput(input: DispatchInput, label: string = SMOKE_WORKFLOW): string[] {
 	return checkChoiceOptions(
@@ -186,59 +160,6 @@ export function checkSuiteInput(input: DispatchInput, label: string = SMOKE_WORK
 		"SUITE_NAMES (packages/schema/src/suites.ts)",
 		label,
 	);
-}
-
-/**
- * Fold a credential value expression to its lane-independent form for cross-workflow comparison. A
- * lane scopes a secret to the selected provider so a cell receives only its own credential, and a
- * caller may name that selector either way — `inputs.provider` (a dispatch input) or `matrix.provider`
- * (a matrix cell) — so both selector tokens collapse to one placeholder. A genuine drift (a secret
- * guarded on a different provider id, or a different secret entirely) survives the fold and still
- * fails Invariant 4. Only the reusable declares the block today; the fold is kept so that if a second
- * workflow ever declares one, the two are compared rather than assumed equal.
- */
-function canonicalCredentialExpr(value: string): string {
-	return value.replace(/\b(?:inputs|matrix)\.provider\b/g, "<provider>");
-}
-
-/**
- * Invariants 3 + 4: every provider requiredEnvVar is present in the run-step env of every workflow,
- * and a key shared across them maps to the same value expression (modulo each lane's provider
- * selector — see {@link canonicalCredentialExpr}). `envByWorkflow` keys are workflow paths so error
- * messages name the offending file.
- */
-export function checkCredentialEnv(
-	envByWorkflow: Record<string, Record<string, string>>,
-): string[] {
-	const errors: string[] = [];
-	const workflows = Object.keys(envByWorkflow);
-	for (const [key, owners] of requiredCredentialKeys()) {
-		// biome-ignore lint/style/noNonNullAssertion: keys come from Object.keys(envByWorkflow).
-		const missing = workflows.filter((wf) => !(key in envByWorkflow[wf]!));
-		if (missing.length > 0) {
-			errors.push(
-				`${key}: required by provider ${owners.join(", ")} (packages/schema/src/providers.ts ` +
-					`requiredEnvVars) but missing from the "${RUN_STEP}" step env of ${missing.join(" and ")}`,
-			);
-			continue;
-		}
-		// Dedupe on the canonical (selector-folded) form, but report the raw expressions so a human
-		// sees the real drift, not the placeholder. First raw value wins per canonical form.
-		const rawByCanonical = new Map<string, string>();
-		for (const wf of workflows) {
-			// biome-ignore lint/style/noNonNullAssertion: presence checked above.
-			const raw = envByWorkflow[wf]![key]!;
-			const canonical = canonicalCredentialExpr(raw);
-			if (!rawByCanonical.has(canonical)) rawByCanonical.set(canonical, raw);
-		}
-		if (rawByCanonical.size > 1) {
-			errors.push(
-				`${key}: maps to different value expressions across workflows ` +
-					`(${[...rawByCanonical.values()].map((v) => `"${v}"`).join(" vs ")}) — every lane must hand the suite the same secret`,
-			);
-		}
-	}
-	return errors;
 }
 
 /** Invariant 5: every live-run job has margin beyond the longest registered sandbox lifetime. */
@@ -297,20 +218,17 @@ export function checkCellBudgetEnv(
 export function runCheck(root: string = findRepoRoot()): string[] {
 	const smoke = readWorkflow(SMOKE_WORKFLOW, root);
 	const matrix = readWorkflow(MATRIX_WORKFLOW, root);
-	// Both lanes' credential block + live-run timeout live in the one reusable bench-suite.yml they
-	// call, so Invariants 3–5 read that file — and Invariant 3b (checkLaneDelegates) is what keeps that
-	// true by rejecting a lane that grows a cell of its own again.
+	// Both lanes' live-run timeout and cell budget live in the one reusable bench-suite.yml they call.
+	// checkLaneDelegates keeps that true by rejecting a caller that grows a cell of its own again.
 	const suiteWf = readWorkflow(SUITE_WORKFLOW, root);
-	// Read once and share: the suite run step's env feeds both the credential gate and the cell-budget
-	// gate, and its job timeout feeds both the margin gate and that same budget gate.
+	// Read once and share: the suite run step env feeds the cell-budget gate, and its job timeout feeds
+	// both the margin gate and that same budget gate.
 	const suiteEnv = stepEnv(suiteWf, SUITE_JOB, RUN_STEP, SUITE_WORKFLOW);
 	const suiteTimeout = jobTimeoutMinutes(suiteWf, SUITE_JOB, SUITE_WORKFLOW);
 	const credentialKeys = [...requiredCredentialKeys().keys()];
 	return [
-		...checkProviderInput(dispatchInput(smoke, "provider", SMOKE_WORKFLOW)),
 		...checkSuiteInput(dispatchInput(smoke, "suite", SMOKE_WORKFLOW)),
-		...checkCredentialEnv({ [SUITE_WORKFLOW]: suiteEnv }),
-		// The credential keys are what make Invariant 3b more than a step-name match: a lane that hangs
+		// Credential keys make the delegation check more than a step-name match: a lane that hangs
 		// any of them off a job- or step-level env is building a cell, whatever it calls the step.
 		...checkLaneDelegates(smoke, SMOKE_WORKFLOW, credentialKeys),
 		...checkLaneDelegates(matrix, MATRIX_WORKFLOW, credentialKeys),

--- a/tooling/repo-checks/src/workflow-registry-sync.test.ts
+++ b/tooling/repo-checks/src/workflow-registry-sync.test.ts
@@ -1,8 +1,8 @@
-// Invariant: the GitHub workflows that dispatch live benchmarks stay in lockstep with the schema
-// registries (PROVIDERS + SUITE_NAMES). GHA can't import TypeScript, so the provider/suite choices and
-// the per-provider credential env block are hand-written YAML; this gate re-derives the truth from the
-// registries and fails if someone adds a provider/suite (or its required secret) without updating the
-// workflows. Both dispatch lanes — bench-matrix.yml (the full matrix, ending in a dataset commit) and
+// Invariant: the GitHub workflows that dispatch live benchmarks stay in lockstep with the suite
+// registry and retain their safe delegation/timeout shape. Provider choices and provider input env are
+// generated from metadata and owned by check:provider-wiring, so this gate deliberately does not
+// compare those managed regions a second time. Both dispatch lanes — bench-matrix.yml (the full
+// matrix, ending in a dataset commit) and
 // bench-smoke.yml (the same pipeline narrowed to one provider × suite and stopped before that commit) —
 // are one `plan` job plus one suite-matrix job calling the reusable bench-suite.yml (native nesting:
 // suite / provider). The credential block + run-job timeout live in that single reusable, so the
@@ -16,14 +16,12 @@
 // `bun test`, same precedent as boundary.test.ts); the rest is unit coverage of the parsers and the
 // failure messages on synthetic drift, so a future regression names the offending file + key.
 import { describe, expect, test } from "bun:test";
-import { PROVIDERS, SUITE_NAMES } from "@sandbox-benchmarks/schema";
+import { SUITE_NAMES } from "@sandbox-benchmarks/schema";
 import type { SuiteMatrixCaller } from "./lib/workflow-sync.ts";
 import {
 	CELL_BUDGET_ENV_KEY,
 	checkCellBudgetEnv,
-	checkCredentialEnv,
 	checkLaneDelegates,
-	checkProviderInput,
 	checkSmokeSingleSandboxDefault,
 	checkSuiteInput,
 	checkSuiteMatrixCaller,
@@ -57,18 +55,10 @@ import {
 const smoke = readWorkflow(SMOKE_WORKFLOW);
 const matrix = readWorkflow(MATRIX_WORKFLOW);
 const suiteWf = readWorkflow(SUITE_WORKFLOW);
-const providerInput = dispatchInput(smoke, "provider", SMOKE_WORKFLOW);
 const suiteInput = dispatchInput(smoke, "suite", SMOKE_WORKFLOW);
 const suiteEnv = stepEnv(suiteWf, SUITE_JOB, RUN_STEP, SUITE_WORKFLOW);
 
 describe("parsers against the real workflow files", () => {
-	test("dispatchInput extracts the smoke provider choice (type + options + default)", () => {
-		expect(new Set(providerInput.options)).toEqual(new Set(PROVIDERS.map((p) => p.id)));
-		expect(providerInput.default).toBeDefined();
-		// `type: choice` is what makes GitHub enforce the options — assert it's captured.
-		expect(providerInput.type).toBe("choice");
-	});
-
 	test("dispatchInput extracts the smoke suite choice", () => {
 		expect(new Set(suiteInput.options)).toEqual(new Set(SUITE_NAMES));
 		expect(suiteInput.type).toBe("choice");
@@ -151,62 +141,6 @@ describe("checkCellBudgetEnv", () => {
 	});
 });
 
-describe("checkProviderInput", () => {
-	test("the real provider choice is in sync", () => {
-		expect(checkProviderInput(providerInput)).toEqual([]);
-	});
-
-	test("flags a registry provider dropped from the options", () => {
-		const drifted = {
-			...providerInput,
-			options: providerInput.options?.filter((o) => o !== "modal-gvisor"),
-		};
-		const errors = checkProviderInput(drifted);
-		expect(errors).toHaveLength(1);
-		expect(errors[0]).toContain('missing "modal-gvisor"');
-		expect(errors[0]).toContain("PROVIDERS");
-	});
-
-	test("flags a stray option that no provider owns", () => {
-		const drifted = { ...providerInput, options: [...(providerInput.options ?? []), "fly"] };
-		const errors = checkProviderInput(drifted);
-		expect(errors).toHaveLength(1);
-		expect(errors[0]).toContain('option "fly" is not in PROVIDERS');
-	});
-
-	test("flags a default that is not a known provider", () => {
-		const errors = checkProviderInput({ ...providerInput, default: "ghost" });
-		expect(errors).toHaveLength(1);
-		expect(errors[0]).toContain('default "ghost"');
-	});
-
-	test("flags a missing options list entirely", () => {
-		const errors = checkProviderInput({ type: "choice", default: "e2b" });
-		expect(errors).toHaveLength(1);
-		expect(errors[0]).toContain("no options list");
-	});
-
-	test("flags a missing default (the invariant requires one, not a vacuous pass)", () => {
-		const errors = checkProviderInput({ type: "choice", options: providerInput.options });
-		expect(errors).toHaveLength(1);
-		expect(errors[0]).toContain("no valid string default");
-	});
-
-	test('flags a non-choice type (options are unenforced free text unless "type: choice")', () => {
-		// Registry-matching options/default, but type: string → GitHub ignores the options list.
-		const errors = checkProviderInput({ ...providerInput, type: "string" });
-		expect(errors).toHaveLength(1);
-		expect(errors[0]).toContain('not "type: choice"');
-		expect(errors[0]).toContain('"string"');
-	});
-
-	test("flags a missing type (defaults to free-text string in GHA)", () => {
-		const errors = checkProviderInput({ ...providerInput, type: undefined });
-		expect(errors).toHaveLength(1);
-		expect(errors[0]).toContain("no type");
-	});
-});
-
 describe("checkSuiteInput", () => {
 	test("the real suite choice is in sync", () => {
 		expect(checkSuiteInput(suiteInput)).toEqual([]);
@@ -235,63 +169,13 @@ describe("checkSuiteInput", () => {
 	});
 });
 
-describe("checkCredentialEnv", () => {
-	// A hypothetical second lane declaring its own block, spelled with the OTHER provider selector —
-	// the shape the fold exists for. The real repo has exactly one block (Invariant 3b keeps it that
-	// way), so the cross-workflow half of this check is exercised synthetically.
-	const laneEnv = Object.fromEntries(
-		Object.entries(suiteEnv).map(([key, value]) => [
-			key,
-			value.replaceAll("matrix.provider", "inputs.provider"),
-		]),
-	);
-
+describe("requiredCredentialKeys", () => {
 	test("requiredCredentialKeys records provenance per provider", () => {
 		const required = requiredCredentialKeys();
 		expect(required.get("E2B_API_KEY")).toEqual(["e2b"]);
 		// A credential shared by a vendor's isolation variants records every owner, in registry order.
 		expect(required.get("MODAL_TOKEN_ID")).toEqual(["modal-gvisor", "modal-vm"]);
 		expect(required.get("DAYTONA_API_KEY")).toEqual(["daytona-vm", "daytona-container"]);
-	});
-
-	test("the real reusable block covers every registered provider's credentials", () => {
-		expect(checkCredentialEnv({ [SUITE_WORKFLOW]: suiteEnv })).toEqual([]);
-	});
-
-	test("flags a required key dropped from the reusable block, naming key and file", () => {
-		const { E2B_API_KEY: _, ...drifted } = suiteEnv;
-		const errors = checkCredentialEnv({ [SUITE_WORKFLOW]: drifted });
-		expect(errors).toHaveLength(1);
-		expect(errors[0]).toContain("E2B_API_KEY");
-		expect(errors[0]).toContain("required by provider e2b");
-		expect(errors[0]).toContain(SUITE_WORKFLOW);
-	});
-
-	// The selector fold: the same secret guarded on `inputs.provider` rather than `matrix.provider` is
-	// the same wiring, not drift, so two lanes spelling it either way must still agree.
-	test("folds the two provider selectors together across workflows", () => {
-		expect(checkCredentialEnv({ [SMOKE_WORKFLOW]: laneEnv, [SUITE_WORKFLOW]: suiteEnv })).toEqual(
-			[],
-		);
-	});
-
-	test("flags a shared key whose value expression differs across two workflows", () => {
-		const drifted = { ...suiteEnv, DAYTONA_API_KEY: `\${{ secrets.DAYTONA_API_KEY_OTHER }}` };
-		const errors = checkCredentialEnv({
-			[SMOKE_WORKFLOW]: laneEnv,
-			[SUITE_WORKFLOW]: drifted,
-		});
-		expect(errors).toHaveLength(1);
-		expect(errors[0]).toContain("DAYTONA_API_KEY:");
-		expect(errors[0]).toContain(laneEnv.DAYTONA_API_KEY);
-		expect(errors[0]).toContain("DAYTONA_API_KEY_OTHER");
-	});
-
-	test("tolerates extra runtime-context vars beyond the required credentials", () => {
-		const errors = checkCredentialEnv({
-			[SUITE_WORKFLOW]: { ...suiteEnv, SOME_RUNTIME_CONTEXT: "x" },
-		});
-		expect(errors).toEqual([]);
 	});
 });
 


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Generates provider input, runner, and pre‑auth wiring from validated metadata and adds a drift gate. Previously, workflows/docs/env blocks were hand-written; now marker-delimited regions are generated, reducing sync errors and making onboarding declarative. Unscoped releases can now validate Blaxel, but scoped releases still refuse it because no artifact is publishable.

- Updates `.env.example`, workflow provider options and runner/cache conditionals, toolchain pre‑auth steps, `docs/ci-secrets.md`, and the privileged env setup script using generated regions.
- Adds `packages/schema/scripts/generate-provider-wiring.ts` with tests and a new CI drift check (`check:provider-wiring`), and wires scripts in root and `@sandbox-benchmarks/schema` `package.json`.
- Extends metadata schema: `inputs` now support `step-env` and `ciValue`; formalizes pre‑auth contracts/policies; introduces `ProviderRunnerPolicy` (label, `noCache`, `lifetimeMinutes`); validates provider id syntax (lowercase kebab-case).
- Adjusts provider metadata: `microsandbox-local` sets `ciValue` and runner policy; `vercel` consumes `VERCEL_OIDC_TOKEN` from a step env.
- Narrows workflow-registry sync to suites/shape only; provider wiring drift is enforced separately in CI.

**Rollout and migration**
- After changing provider metadata, run `bun run generate-provider-wiring` and commit the generated regions. CI enforces `bun run check:provider-wiring`.
- When adding a provider, define `inputs` (secret/variable/step-env), optional `preAuth`, and `runner` policy in `packages/schema/src/provider-meta/<id>.ts`; then run `bun run generate-provider-registry` and `bun run generate-provider-wiring`.
- Ensure new provider ids are lowercase kebab-case.
- Move provider secrets to the `privileged` environment as listed by the updated setup script; workflow regions now source them from generated bindings.

<sup>Written for commit 2d7d48182081101b685dddea71eeb5ec53bfbeec. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/starslingdev/hpc-sandbox-benchmarks/pull/397?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

