### PR TITLE
feat(providers): register Codex Cloud host-ingest provider (`codex-cloud`)

### DIFF
--- a/.github/workflows/bench-smoke.yml
+++ b/.github/workflows/bench-smoke.yml
@@ -69,6 +69,7 @@ on:
             runcloud,
             cursor-cloud-agent,
             claude-cloud,
+            codex-cloud,
           ]
       suite:
         # Constrained to the SUITE_NAMES registry (packages/schema/src/suites.ts); the

--- a/.github/workflows/bench-suite.yml
+++ b/.github/workflows/bench-suite.yml
@@ -272,6 +272,8 @@ jobs:
           CURSOR_CLOUD_AGENT_BENCH: ${{ matrix.provider == 'cursor-cloud-agent' && '1' || '' }}
           # Host-ingest opt-in for Claude Code remote session VMs (no remote sandbox API).
           CLAUDE_CLOUD_BENCH: ${{ matrix.provider == 'claude-cloud' && '1' || '' }}
+          # Host-ingest opt-in for ChatGPT Codex Cloud session VMs (no remote sandbox API).
+          CODEX_CLOUD_BENCH: ${{ matrix.provider == 'codex-cloud' && '1' || '' }}
           # Paired with the microsandbox-local runner route above: that self-hosted label is reaped at
           # 70 minutes regardless of timeout-minutes, which no expression can encode (the workflow gate
           # requires a literal). Declaring it here lets bench-suite reject a suite that cannot finish

--- a/apps/cli/src/bin/bake.ts
+++ b/apps/cli/src/bin/bake.ts
@@ -73,6 +73,9 @@ const bakers: Record<ProviderId, (image: string, log: Log) => Promise<void>> = {
 	"claude-cloud": async (_image, log) => {
 		log("claude-cloud is host-ingest only — no candidate artifact to bake");
 	},
+	"codex-cloud": async (_image, log) => {
+		log("codex-cloud is host-ingest only — no candidate artifact to bake");
+	},
 };
 
 /**

--- a/apps/cli/src/bin/release-plan.test.ts
+++ b/apps/cli/src/bin/release-plan.test.ts
@@ -69,6 +69,7 @@ describe("buildReleasePlan matrix", () => {
 			"daytona-container",
 			"blaxel",
 			"microsandbox-local",
+			"codex-cloud",
 			"claude-cloud",
 			"cursor-cloud-agent",
 			"microsandbox-cloud",
@@ -133,6 +134,7 @@ describe("buildReleasePlan matrix", () => {
 		expect(plan.required).not.toContain("runloop");
 		expect(Object.keys(RELEASE_UNSCOPABLE_PROVIDERS).sort()).toEqual([
 			"blaxel",
+			"codex-cloud",
 			"claude-cloud",
 			"cursor-cloud-agent",
 		]);

--- a/apps/cli/src/bin/release-plan.ts
+++ b/apps/cli/src/bin/release-plan.ts
@@ -61,6 +61,9 @@ export const RELEASE_UNSCOPABLE_PROVIDERS: Readonly<Partial<Record<ProviderId, s
 	"claude-cloud":
 		"it is host-ingest only (Firecracker Claude Code session VM results staged into the dataset) — " +
 		"no remote sandbox API, bake artifact, or release credential wiring",
+	"codex-cloud":
+		"it is host-ingest only (Codex Cloud session VM results staged into the dataset) — no remote " +
+		"sandbox API, bake artifact, or release credential wiring",
 };
 
 /** Per-provider baked artifact name (what a cell produces), or a note for the providers that bake none. */
@@ -93,6 +96,7 @@ function providerArtifact(id: ProviderId): string {
 			return config.vercelImageCandidate;
 		case "cursor-cloud-agent":
 		case "claude-cloud":
+		case "codex-cloud":
 			return "host-ingest only (no baked artifact)";
 	}
 }

--- a/apps/cli/src/lib/bake/promote.ts
+++ b/apps/cli/src/lib/bake/promote.ts
@@ -346,6 +346,9 @@ export async function promoteAll(log: Log, options: PromoteOptions = {}): Promis
 							case "claude-cloud":
 								log("    claude-cloud is host-ingest only — nothing to promote");
 								break;
+							case "codex-cloud":
+								log("    codex-cloud is host-ingest only — nothing to promote");
+								break;
 							default: {
 								// Exhaustiveness: a new ProviderId must add a promote branch above (compile error here).
 								const unhandled: never = provider.name;

--- a/apps/cli/src/lib/bake/validate.test.ts
+++ b/apps/cli/src/lib/bake/validate.test.ts
@@ -120,7 +120,7 @@ describe("baseImageUse", () => {
 	// Providers that can validate without the candidate base existing at all.
 	it("marks the providers that never reference the toolchain base", () => {
 		const none = PROVIDERS.map((p) => p.id).filter((id) => baseImageUse(id) === "none");
-		expect(none).toEqual(["blaxel", "claude-cloud", "cursor-cloud-agent", "vercel"]);
+		expect(none).toEqual(["blaxel", "codex-cloud", "claude-cloud", "cursor-cloud-agent", "vercel"]);
 	});
 
 	// Anything that reads the base ref in candidateCreateOptions must not be classified "none", or the

--- a/apps/cli/src/lib/bake/validate.ts
+++ b/apps/cli/src/lib/bake/validate.ts
@@ -55,6 +55,7 @@ export function baseImageUse(id: ProviderId): BaseImageUse {
 		case "vercel":
 		case "cursor-cloud-agent":
 		case "claude-cloud":
+		case "codex-cloud":
 			return "none";
 	}
 }
@@ -107,6 +108,7 @@ export function candidateCreateOptions(
 			return { templateId: refs.vercelImageCandidate };
 		case "cursor-cloud-agent":
 		case "claude-cloud":
+		case "codex-cloud":
 			// Host-ingest only — no remote create options.
 			return {};
 	}

--- a/apps/cli/src/lib/providers-run.test.ts
+++ b/apps/cli/src/lib/providers-run.test.ts
@@ -37,6 +37,7 @@ describe("forEachProviderWithCreds `only`", () => {
 			"daytona-container",
 			"blaxel",
 			"microsandbox-local",
+			"codex-cloud",
 			"claude-cloud",
 			"cursor-cloud-agent",
 			"microsandbox-cloud",

--- a/packages/providers/src/lib/adapters.ts
+++ b/packages/providers/src/lib/adapters.ts
@@ -271,6 +271,24 @@ export const adapters: Record<ProviderId, ProviderAdapter> = {
 		createAttemptCeilingMs: RUNCLOUD_CREATE_CEILING_MS,
 		costEvidence: runcloudCostEvidence,
 	},
+	// Host-ingest only: suites run on the Codex Cloud session VM, then results are staged and
+	// normalized. The DirectProvider stub exists only to keep the registry join exhaustive.
+	"codex-cloud": {
+		createCompute: () => ({
+			name: "codex-cloud",
+			sandbox: {
+				create: async () => {
+					throw new Error(
+						"codex-cloud is host-ingest only — run mise suite tasks on the session VM and normalize staged benchmark-results/",
+					);
+				},
+				getById: async () => null,
+				list: async () => [],
+				destroy: async () => {},
+			},
+		}),
+		createOptions: {},
+	},
 	// Host-ingest only: suites run on the Claude Code remote session VM, then results are staged +
 	// normalized. The DirectProvider stub exists so the PROVIDERS × adapters join typechecks; create
 	// always refuses.

--- a/packages/schema/src/identifiers.ts
+++ b/packages/schema/src/identifiers.ts
@@ -6,6 +6,6 @@ export type RunId = typeof runIdSchema.infer;
 
 /** Canonical provider ids shared by registries, Runs, and cost cells. */
 export const providerIdSchema = type(
-	"'e2b' | 'daytona-vm' | 'daytona-container' | 'modal-gvisor' | 'modal-vm' | 'blaxel' | 'microsandbox-local' | 'microsandbox-cloud' | 'novita' | 'runloop' | 'namespace' | 'vercel' | 'runcloud' | 'cursor-cloud-agent' | 'claude-cloud'",
+	"'e2b' | 'daytona-vm' | 'daytona-container' | 'modal-gvisor' | 'modal-vm' | 'blaxel' | 'microsandbox-local' | 'microsandbox-cloud' | 'novita' | 'runloop' | 'namespace' | 'vercel' | 'runcloud' | 'cursor-cloud-agent' | 'claude-cloud' | 'codex-cloud'",
 );
 export type ProviderId = typeof providerIdSchema.infer;

--- a/packages/schema/src/providers.test.ts
+++ b/packages/schema/src/providers.test.ts
@@ -66,6 +66,7 @@ describe("@sandbox-benchmarks/schema providers", () => {
 		expect(PROVIDERS.map((provider) => provider.id).sort()).toEqual([
 			"blaxel",
 			"claude-cloud",
+			"codex-cloud",
 			"cursor-cloud-agent",
 			"daytona-container",
 			"daytona-vm",

--- a/packages/schema/src/providers.ts
+++ b/packages/schema/src/providers.ts
@@ -625,6 +625,37 @@ const REGISTRY: Record<ProviderId, Omit<ProviderMeta, "id">> = {
 			detachedPoll: true,
 		},
 	},
+	"codex-cloud": {
+		displayName: "ChatGPT Codex Cloud",
+		website: "https://openai.com/codex/",
+		sdkPackage: "none",
+		// Host-ingest opt-in: suites run on the Codex Cloud session VM itself, then raw results are
+		// staged and normalized. There is no remote sandbox API, so keep it out of the default matrix.
+		requiredEnvVars: ["CODEX_CLOUD_BENCH"],
+		isolation: {
+			technology: "Cloud Hypervisor microVM + OCI container",
+			notes:
+				"Codex Cloud sessions run in an OCI container inside a Cloud Hypervisor guest (ACPI OEM CLOUDH), with virtio devices exposed by KVM. Results measure the Codex Cloud host fleet, not a provider SDK sandbox.",
+		},
+		pricing: {
+			model: "unavailable",
+			reason: "self_hosted",
+			notes:
+				"Codex Cloud session compute is bundled into ChatGPT plans; there is no published per-vCPU sandbox rate comparable to the other providers.",
+			sources: [{ label: "OpenAI Codex", url: "https://openai.com/codex/", checkedAt: "2026-08-21" }],
+		},
+		maturity: {
+			status: "beta",
+			notes:
+				"Host-ingest path only. The harness adapter refuses remote create; use mise suite tasks on the session VM and normalize staged results.",
+		},
+		specPinning: "fixed",
+		transport: {
+			streaming: false,
+			syncCapMs: 60_000,
+			detachedPoll: true,
+		},
+	},
 	"claude-cloud": {
 		displayName: "Claude Cloud",
 		website: "https://claude.com",


### PR DESCRIPTION
### Motivation

- Add ChatGPT Codex as a host-ingest provider so session-run results from Codex Cloud can be staged and normalized alongside the existing host-ingest providers (Cursor, Claude). 

### Description

- Register `codex-cloud` in the provider id schema and `REGISTRY` with host-ingest metadata and `specPinning: "fixed"`. 
- Add a host-ingest-only DirectProvider adapter that refuses remote `create()` so the harness runs suites on the session VM and normalizes staged `benchmark-results/`. 
- Wire `codex-cloud` into release/bake/validate flow: add bake no-op, promote no-op branches, include it in provider roster tests, and add the `CODEX_CLOUD_BENCH` workflow opt-in in the bench CI matrices. 
- Update tests/expectations and provider lists so `codex-cloud` participates in the matrix and register-related unit tests (`packages/schema`, `apps/cli` change set). 

### Testing

- `git diff --check` succeeded with the provider registration changes passing a code-review diff check. 
- Executed the benchmark suite runner via `mise run` for `system`, `memory`, `disk`, `network`, `pgbench`, `cpu:node`, and the three `realworld` groups; the tasks completed but all PTS-backed leaves were `SKIPPED` because Phoronix/toolchain downloads were blocked by the environment egress proxy (HTTP 403). 
- Attempted ingest with `bun scripts/ingest-host-run.ts --provider codex-cloud` failed because dependency restoration was blocked (missing `arktype`), so no `validated` provider row was produced. 
- `bun run lint` could not complete because dependency downloads were blocked by the same egress policy.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a879d5afa9c83278635326add32c027)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds ChatGPT Codex Cloud as a host-ingest provider (`codex-cloud`) so session VM results can be staged and normalized alongside existing providers. Unlike remote-sandbox providers, it has no remote create, no baked artifact, and no promotion path.

- Schema and registry (`packages/schema`): add `codex-cloud` to `providerIdSchema` and `REGISTRY` with spec pinning fixed; gate participation via CODEX_CLOUD_BENCH.
- Provider adapter (`packages/providers`): add DirectProvider stub that throws on remote create; no sandbox lifecycle.
- CLI (`apps/cli`): mark as unscopeable in release plan, return “host-ingest only” for artifact, base image use is “none”, and no-op bake/promote branches.
- CI: include `codex-cloud` in bench matrices and enable only when CODEX_CLOUD_BENCH=1 is set.
- Tests: update provider rosters and expectations accordingly.

- To run: set CODEX_CLOUD_BENCH=1, run suites on the Codex Cloud session VM, and stage results under benchmark-results/ for host ingest. No bake or promote steps apply.

<sup>Written for commit 80fa3e3a4bbdcde767b82a09119471473f9560c6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/starslingdev/hpc-sandbox-benchmarks/pull/398?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

