### PR TITLE
feat(drivers): migrate Modal wrapper variants

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -90,6 +90,7 @@
         "e2b": "catalog:computesdk",
         "microsandbox": "catalog:computesdk",
         "modal": "catalog:computesdk",
+        "nice-grpc": "catalog:computesdk",
         "novita-sandbox": "catalog:computesdk",
       },
       "devDependencies": {
@@ -260,6 +261,7 @@
       "e2b": "2.27.1",
       "microsandbox": "0.6.8",
       "modal": "0.9.0",
+      "nice-grpc": "2.1.16",
       "novita-sandbox": "2.0.6",
     },
     "xml": {

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
         "e2b": "2.27.1",
         "microsandbox": "0.6.8",
         "modal": "0.9.0",
+        "nice-grpc": "2.1.16",
         "novita-sandbox": "2.0.6",
         "@vercel/sandbox": "2.9.2"
       },

--- a/packages/drivers/package.json
+++ b/packages/drivers/package.json
@@ -32,6 +32,7 @@
     "e2b": "catalog:computesdk",
     "microsandbox": "catalog:computesdk",
     "modal": "catalog:computesdk",
+    "nice-grpc": "catalog:computesdk",
     "novita-sandbox": "catalog:computesdk"
   },
   "devDependencies": {

--- a/packages/drivers/src/_computesdk.test.ts
+++ b/packages/drivers/src/_computesdk.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, test } from "bun:test";
 import type { E2BSandbox } from "@computesdk/e2b";
 import { e2b } from "@computesdk/e2b";
-import type { CreateRequest, SandboxDriver } from "@sandbox-benchmarks/driver";
+import type { CreateRequest, ExecOptions, SandboxDriver } from "@sandbox-benchmarks/driver";
 import { DriverError, FailedCreateCleanupError } from "@sandbox-benchmarks/driver";
 import { type } from "arktype";
 import type {
@@ -789,6 +789,35 @@ describe("computeSdkDriver", () => {
 		expect(error.message).not.toContain(invalidId);
 	});
 
+	test("an invalid returned id reconciles the preallocated name across a transient first miss", async () => {
+		const { compute } = fakeCompute({ ...baseSandbox, sandboxId: "wrong-id" });
+		let recoveryCalls = 0;
+		let lifecycleCalls = 0;
+		const error = (await bridge(compute, {
+			createOptions: () => ({ name: "benchmark-stable" }),
+			createRecovery: {
+				absenceConfirmationMs: 5,
+				maxAttempts: 3,
+				locator: () => ({ kind: "name", value: "benchmark-stable" }),
+				cleanup: async (_compute, locator) => {
+					expect(locator).toEqual({ kind: "name", value: "benchmark-stable" });
+					recoveryCalls += 1;
+					return recoveryCalls === 1 ? { status: "absent" } : { status: "destroyed" };
+				},
+			},
+			lifecycle: {
+				destroy: async () => {
+					lifecycleCalls += 1;
+				},
+			},
+		})
+			.create(request)
+			.catch((caught: unknown) => caught)) as DriverError;
+		expect(error).toMatchObject({ code: "invalid-sandbox-ref", provider: "e2b" });
+		expect(recoveryCalls).toBe(2);
+		expect(lifecycleCalls).toBe(0);
+	});
+
 	test("redacts a credential-shaped invalid id from ArkType summaries before rollback returns", async () => {
 		let destroys = 0;
 		const { compute } = fakeCompute({
@@ -1164,7 +1193,9 @@ describe("computeSdkDriver", () => {
 	});
 
 	test("a command projection composes over the exact wrapper without mutating its method table", async () => {
-		const projected: Array<[ComputeSdkSandboxLike, string, "exec" | "launch"]> = [];
+		const projected: Array<
+			[ComputeSdkSandboxLike, string, "exec" | "launch", ExecOptions | undefined, string]
+		> = [];
 		const sandbox = {
 			...baseSandbox,
 			runCommand: async () => {
@@ -1174,22 +1205,27 @@ describe("computeSdkDriver", () => {
 		const { compute } = fakeCompute(sandbox);
 		const session = await bridge(compute, {
 			commands: {
-				exec: async (sandbox, command) => {
-					projected.push([sandbox, command, "exec"]);
+				exec: async (sandbox, command, options, ref) => {
+					projected.push([sandbox, command, "exec", options, ref.id]);
 					return { exitCode: 0, stdout: "root\n", stderr: "" };
 				},
-				launch: async (sandbox, command) => {
-					projected.push([sandbox, command, "launch"]);
+				launch: async (sandbox, command, options, ref) => {
+					projected.push([sandbox, command, "launch", options, ref.id]);
 				},
 			},
 		}).create(request);
 
-		expect((await session.exec("id -u")).stdout).toBe("root\n");
-		await session.launch?.("daemon --start");
-		expect(projected.map(([, command, operation]) => [command, operation])).toEqual([
-			["id -u", "exec"],
-			["daemon --start", "launch"],
+		const execOptions = { maxOutputBytes: 4 } as const;
+		expect((await session.exec("id -u", execOptions)).stdout).toBe("root");
+		await session.launch?.("daemon --start", execOptions);
+		expect(
+			projected.map(([, command, operation, options, id]) => [command, operation, options, id]),
+		).toEqual([
+			["id -u", "exec", execOptions, "i2f3k4abc"],
+			["daemon --start", "launch", execOptions, "i2f3k4abc"],
 		]);
+		expect(projected[0]?.[3]).toBe(execOptions);
+		expect(projected[1]?.[3]).toBe(execOptions);
 		expect(projected.every(([projectedSandbox]) => projectedSandbox === sandbox)).toBe(true);
 	});
 
@@ -1801,6 +1837,40 @@ describe("computeSdkDriver", () => {
 		expect(identityReads).toBe(1);
 	});
 
+	test("post-create preparation receives the stable native handle and canonical identity", async () => {
+		let identityReads = 0;
+		let nativeReads = 0;
+		const stableNative = { id: "native-handle" };
+		const sandbox: ComputeSdkSandboxLike = {
+			...baseSandbox,
+			get sandboxId() {
+				identityReads += 1;
+				return identityReads === 1 ? "iright" : "iwrong";
+			},
+			getInstance: () => {
+				nativeReads += 1;
+				if (nativeReads > 1) throw new Error("mutable native accessor was reread");
+				return stableNative;
+			},
+		};
+		const { compute } = fakeCompute(sandbox);
+		let verifiedRef: string | undefined;
+		let preparedNative: unknown;
+		const session = await bridge(compute, {
+			prepareAndVerifyCreatedRequest: async (_sandbox, native, _request, _options, ref) => {
+				preparedNative = native;
+				verifiedRef = ref.id;
+				return { status: "honored" };
+			},
+		}).create(request);
+		expect(session.sandboxRef.id).toBe("iright");
+		expect(verifiedRef).toBe("iright");
+		expect(preparedNative).toBe(stableNative);
+		expect(session.native).toBe(stableNative);
+		expect(identityReads).toBe(1);
+		expect(nativeReads).toBe(1);
+	});
+
 	test("ambiguous create cleanup retains a stable locator and retryable ownership", async () => {
 		let cleanupCalls = 0;
 		const compute: ComputeSdkLike = {
@@ -1820,8 +1890,12 @@ describe("computeSdkDriver", () => {
 					key: "attempt-id",
 					value: String(createOptions.attempt),
 				}),
-				cleanup: async (_compute, createOptions) => {
-					expect(createOptions.attempt).toBe("attempt-123");
+				cleanup: async (_compute, locator) => {
+					expect(locator).toEqual({
+						kind: "marker",
+						key: "attempt-id",
+						value: "attempt-123",
+					});
 					cleanupCalls += 1;
 					if (cleanupCalls === 1) throw new Error("control plane unavailable");
 					return { status: "destroyed" };
@@ -1907,6 +1981,56 @@ describe("computeSdkDriver", () => {
 		}
 	});
 
+	test("ambiguous create cleanup cannot mutate the bridge-owned keyed marker", async () => {
+		const originalMarker = "attempt-original";
+		const seenLocators: Array<[string, string]> = [];
+		let cleanupCalls = 0;
+		const compute: ComputeSdkLike = {
+			sandbox: {
+				create: async () => {
+					throw new Error("response lost after remote acceptance");
+				},
+			},
+		};
+		const error = (await bridge(compute, {
+			createOptions: () => ({ marker: originalMarker }),
+			createRecovery: {
+				absenceConfirmationMs: 5,
+				maxAttempts: 2,
+				locator: () => ({ kind: "marker", key: "externalId", value: originalMarker }),
+				cleanup: async (_compute, locator) => {
+					cleanupCalls += 1;
+					if (locator.kind !== "marker") throw new Error("expected a marker locator");
+					seenLocators.push([locator.key, locator.value]);
+					expect(Object.isFrozen(locator)).toBe(true);
+					try {
+						Object.defineProperty(locator, "value", { value: "attempt-mutated" });
+						Object.defineProperty(locator, "key", { value: "mutated-key" });
+					} catch {
+						// A hostile cleanup cannot rewrite the bridge-owned locator.
+					}
+					if (cleanupCalls === 1) throw new Error("control plane unavailable");
+					return { status: "destroyed" };
+				},
+			},
+		})
+			.create(request)
+			.catch((caught: unknown) => caught)) as FailedCreateCleanupError;
+		expect(error).toBeInstanceOf(FailedCreateCleanupError);
+		expect(error.locator).toEqual({
+			kind: "marker",
+			key: "externalId",
+			value: originalMarker,
+		});
+		expect(error.message).not.toContain("attempt-mutated");
+		expect(error.message).not.toContain("mutated-key");
+		await error.cleanup();
+		expect(seenLocators).toEqual([
+			["externalId", originalMarker],
+			["externalId", originalMarker],
+		]);
+	});
+
 	test("rejects a malformed keyed recovery marker before allocation", async () => {
 		let createCalls = 0;
 		const compute: ComputeSdkLike = {
@@ -1964,6 +2088,36 @@ describe("computeSdkDriver", () => {
 		}
 	});
 
+	test("ambiguous create cleanup never rereads options the wrapper mutated", async () => {
+		const originalName = "benchmark-original";
+		const replacementName = "benchmark-mutated";
+		let cleanupLocator: unknown;
+		const compute: ComputeSdkLike = {
+			sandbox: {
+				create: async (options) => {
+					(options as Record<string, unknown>).name = replacementName;
+					throw new Error("response lost after options mutation");
+				},
+			},
+		};
+		const error = await bridge(compute, {
+			createOptions: () => ({ name: originalName }),
+			createRecovery: {
+				absenceConfirmationMs: 5,
+				maxAttempts: 2,
+				locator: (options) => ({ kind: "name", value: String(options.name) }),
+				cleanup: async (_compute, locator) => {
+					cleanupLocator = locator;
+					return { status: "destroyed" };
+				},
+			},
+		})
+			.create(request)
+			.catch((caught: unknown) => caught);
+		expect(error).toMatchObject({ code: "create-failed", provider: "e2b" });
+		expect(cleanupLocator).toEqual({ kind: "name", value: originalName });
+	});
+
 	test("ambiguous create absence needs two horizon-separated observations", async () => {
 		let cleanupCalls = 0;
 		const compute: ComputeSdkLike = {
@@ -2010,7 +2164,7 @@ describe("computeSdkDriver", () => {
 				absenceConfirmationMs: 5,
 				maxAttempts: 2,
 				locator: () => ({ kind: "name", value: "attempt-signal" }),
-				cleanup: async (_compute, _createOptions, options) => {
+				cleanup: async (_compute, _locator, options) => {
 					receivedSignal = options.signal;
 					return { status: "destroyed" };
 				},

--- a/packages/drivers/src/_computesdk.ts
+++ b/packages/drivers/src/_computesdk.ts
@@ -23,6 +23,7 @@ import type {
 	DriverErrorCode,
 	DriverModule,
 	DriverOperationOptions,
+	ExecOptions,
 	MethodTable,
 	ProviderId,
 	ResolvedArtifact,
@@ -75,10 +76,6 @@ export type ComputeSdkSandboxOf<TCompute extends ComputeSdkLike> = Awaited<
 	ReturnType<TCompute["sandbox"]["create"]>
 >;
 
-export interface ComputeSdkCommandOptions {
-	readonly signal?: AbortSignal;
-}
-
 /**
  * An optional execution projection for wrappers whose universal runCommand surface omits a
  * load-bearing native option (for example E2B's root user). The callback receives the wrapper's
@@ -89,13 +86,15 @@ export interface ComputeSdkCommands<TCompute extends ComputeSdkLike> {
 	exec(
 		sandbox: ComputeSdkSandboxOf<TCompute>,
 		command: string,
-		options: ComputeSdkCommandOptions,
+		options: ExecOptions | undefined,
+		ref: SandboxRef,
 	): Promise<unknown>;
 	/** Resolves only after the provider has returned a genuine background acceptance handle. */
 	launch(
 		sandbox: ComputeSdkSandboxOf<TCompute>,
 		command: string,
-		options: ComputeSdkCommandOptions,
+		options: ExecOptions | undefined,
+		ref: SandboxRef,
 	): Promise<void>;
 }
 
@@ -107,12 +106,14 @@ export interface ComputeSdkLifecycle<TCompute extends ComputeSdkLike> {
 	/**
 	 * Idempotent teardown that must surface transport/auth failures instead of swallowing them.
 	 * `ref` is the bridge-validated canonical identity when validation reached that boundary. When
-	 * it is absent, teardown must use the retained native handle and must not reread a raw wrapper id.
+	 * it is absent, teardown may use the retained native handle or the bridge-snapshotted recovery
+	 * locator, but must never reread a raw wrapper id or wrapper-visible create options.
 	 */
 	destroy(
 		sandbox: ComputeSdkSandboxOf<TCompute>,
 		ref: SandboxRef | undefined,
 		options: DriverOperationOptions,
+		recoveryLocator?: ComputeSdkRecoveryLocator,
 	): Promise<void>;
 }
 
@@ -127,10 +128,14 @@ export interface ComputeSdkCreateRecovery<TCompute extends ComputeSdkLike> {
 	readonly maxAttempts: number;
 	/** Stable owner-visible locator derived from the already-mapped create options. */
 	locator(createOptions: Readonly<Record<string, unknown>>): ComputeSdkRecoveryLocator;
-	/** One bounded observation/removal attempt. The bridge owns the confirmed-absence horizon. */
+	/**
+	 * One bounded observation/removal attempt. The bridge owns the confirmed-absence horizon and
+	 * passes the locator it snapshotted before invoking the wrapper. Cleanup must never reread the
+	 * wrapper-visible create-options object after a create attempt.
+	 */
 	cleanup(
 		compute: TCompute,
-		createOptions: Readonly<Record<string, unknown>>,
+		locator: ComputeSdkRecoveryLocator,
 		options: DriverOperationOptions,
 	): Promise<ComputeSdkCreateRecoveryObservation>;
 	/**
@@ -255,6 +260,7 @@ export interface ComputeSdkDriverSpec<TCompute extends ComputeSdkLike> {
 		native: ComputeSdkNativeOf<ComputeSdkSandboxOf<TCompute>>,
 		request: CreateRequest,
 		options: DriverOperationOptions,
+		ref: SandboxRef,
 	) => Promise<ComputeSdkCreatedRequestVerification>;
 	/**
 	 * Ordinary function composition for a provider-specific command projection. Omit this when the
@@ -627,7 +633,7 @@ async function prepareAndVerifyComputeSdkCreatedRequest<TCompute extends Compute
 	const result: unknown = await invokeComputeSdkProviderCallbackAsync(
 		provider,
 		"created-request preparation and verification",
-		() => prepareAndVerify(sandbox, native, request, operationOptions ?? {}),
+		() => prepareAndVerify(sandbox, native, request, operationOptions ?? {}, ref),
 		{ code: "create-failed", ref },
 	);
 	if (!isNonArrayObject(result)) {
@@ -864,12 +870,13 @@ function computeSdkMethodTable<TCompute extends ComputeSdkLike>(
 		sandbox: ComputeSdkSandboxOf<TCompute>,
 		ref: SandboxRef | undefined,
 		operationOptions: DriverOperationOptions = {},
+		recoveryLocator?: ComputeSdkRecoveryLocator,
 	): Promise<unknown> => {
 		if (lifecycle === undefined) return sandbox.destroy();
 		return invokeComputeSdkProviderCallbackAsync(
 			provider,
 			"lifecycle destroy",
-			() => lifecycle.destroy(sandbox, ref, operationOptions),
+			() => lifecycle.destroy(sandbox, ref, operationOptions, recoveryLocator),
 			{ code: "destroy-failed", ...(ref === undefined ? {} : { ref }) },
 		);
 	};
@@ -901,7 +908,7 @@ function computeSdkMethodTable<TCompute extends ComputeSdkLike>(
 					reconcileAmbiguousCreate(
 						provider,
 						compute,
-						createOptions,
+						recoveryLocator,
 						createRecovery,
 						cleanupOptions,
 						sensitiveValues,
@@ -1009,11 +1016,30 @@ function computeSdkMethodTable<TCompute extends ComputeSdkLike>(
 						);
 					}
 					try {
-						await destroySandbox(
-							created,
-							parsedId === undefined ? undefined : sandboxRef(provider, parsedId),
-							cleanupOptions,
-						);
+						if (
+							parsedId === undefined &&
+							createRecovery !== undefined &&
+							recoveryLocator !== undefined
+						) {
+							// A returned handle proves that an allocation existed, but an invalid wrapper id
+							// cannot identify it safely. Reconcile by the preallocated locator so an eventually
+							// consistent first name miss cannot release ownership and leak the allocation.
+							await reconcileAmbiguousCreate(
+								provider,
+								compute,
+								recoveryLocator,
+								createRecovery,
+								cleanupOptions,
+								sensitiveValues,
+							);
+						} else {
+							await destroySandbox(
+								created,
+								parsedId === undefined ? undefined : sandboxRef(provider, parsedId),
+								cleanupOptions,
+								recoveryLocator,
+							);
+						}
 						handleSensitiveValues.delete(created);
 						handleRefIds.delete(created);
 						if (parsedId !== undefined) refSensitiveValues.delete(parsedId);
@@ -1034,31 +1060,36 @@ function computeSdkMethodTable<TCompute extends ComputeSdkLike>(
 					throw new FailedCreateCleanupError(cleanupError, primary, {
 						provider,
 						locator:
-							parsedId === undefined ? { kind: "native-handle" } : { kind: "id", value: parsedId },
+							parsedId === undefined
+								? (recoveryLocator ?? { kind: "native-handle" })
+								: { kind: "id", value: parsedId },
 						cleanup: retryCleanup,
 					});
 				}
 				throw primary;
 			}
 		},
-		async exec(_compute, sandbox, command) {
+		async exec(_compute, sandbox, command, execOptions) {
 			const started = Date.now();
+			const ref = refFor(sandbox);
 			let result: NormalizedComputeSdkCommandResult;
 			try {
+				let rawResult: unknown;
+				if (commands === undefined) {
+					rawResult = await sandbox.runCommand(command);
+				} else {
+					if (ref === undefined) throw new Error("canonical sandbox identity is unavailable");
+					rawResult = await invokeComputeSdkProviderCallbackAsync(
+						provider,
+						"command exec",
+						() => commands.exec(sandbox, command, execOptions, ref),
+						{ code: "exec-failed", ref },
+					);
+				}
 				result = normalizeCommandResult(
 					provider,
 					"exec",
-					await (commands === undefined
-						? sandbox.runCommand(command)
-						: invokeComputeSdkProviderCallbackAsync(
-								provider,
-								"command exec",
-								() => commands.exec(sandbox, command, {}),
-								{
-									code: "exec-failed",
-									...(refFor(sandbox) === undefined ? {} : { ref: refFor(sandbox) }),
-								},
-							)),
+					rawResult,
 					sensitiveFor(sandbox),
 					refFor(sandbox),
 				);
@@ -1107,13 +1138,15 @@ function computeSdkMethodTable<TCompute extends ComputeSdkLike>(
 			handleRefIds.delete(sandbox);
 			if (refId !== undefined) refSensitiveValues.delete(refId);
 		},
-		async launch(_compute, sandbox, command) {
+		async launch(_compute, sandbox, command, execOptions) {
 			if (commands !== undefined) {
+				const ref = refFor(sandbox);
 				try {
+					if (ref === undefined) throw new Error("canonical sandbox identity is unavailable");
 					await invokeComputeSdkProviderCallbackAsync(
 						provider,
 						"command launch",
-						() => commands.launch(sandbox, command, {}),
+						() => commands.launch(sandbox, command, execOptions, ref),
 						{
 							code: "exec-failed",
 							...(refFor(sandbox) === undefined ? {} : { ref: refFor(sandbox) }),
@@ -1478,7 +1511,7 @@ function locatorExposesSensitiveValue(
 async function reconcileAmbiguousCreate<TCompute extends ComputeSdkLike>(
 	provider: ProviderId,
 	compute: TCompute,
-	createOptions: Readonly<Record<string, unknown>>,
+	locator: ComputeSdkRecoveryLocator,
 	recovery: ComputeSdkCreateRecovery<TCompute>,
 	operationOptions: DriverOperationOptions = {},
 	sensitiveValues: readonly string[],
@@ -1502,7 +1535,7 @@ async function reconcileAmbiguousCreate<TCompute extends ComputeSdkLike>(
 				await invokeComputeSdkProviderCallbackAsync(
 					provider,
 					"failed-create recovery cleanup",
-					() => recovery.cleanup(compute, createOptions, operationOptions),
+					() => recovery.cleanup(compute, locator, operationOptions),
 					{ code: "destroy-failed" },
 				),
 				sensitiveValues,

--- a/packages/drivers/src/_modal.test.ts
+++ b/packages/drivers/src/_modal.test.ts
@@ -1,0 +1,1158 @@
+import { describe, expect, it } from "bun:test";
+import type { CreateRequest } from "@sandbox-benchmarks/driver";
+import { ModalClient, NotFoundError } from "modal";
+import type { ClientMiddleware, ServiceDefinition } from "nice-grpc";
+import { ClientError, createServer, Status } from "nice-grpc";
+import { defineComputeSdkDriver } from "./_computesdk.ts";
+import type { ModalControlRunner } from "./_modal.ts";
+import {
+	createModalControlRunner,
+	defineModalDriver,
+	execModalCommand,
+	launchModalCommand,
+	lazyModalCompute,
+	MODAL_APP_NAME,
+	MODAL_CONTROL_TIMEOUT_MS,
+	MODAL_SANDBOX_LIFETIME_MS,
+	MODAL_V1_SANDBOX_ID,
+	MODAL_V2_SANDBOX_ID,
+	modalControlPlane,
+	modalCreateOptions,
+	modalCreateRecovery,
+	modalDetachedCommand,
+	modalLifecycle,
+	modalProbes,
+	modalSandboxId,
+	verifyModalDiskCapacity,
+} from "./_modal.ts";
+import modalGvisor from "./modal-gvisor.ts";
+import modalVm from "./modal-vm.ts";
+
+const request = (overrides: Partial<CreateRequest> = {}): CreateRequest => ({
+	spec: { vcpus: 4, memoryGb: 8, diskGb: 40 },
+	artifact: { kind: "image", ref: "registry.example/toolchain:version" },
+	deadlineMs: 300_000,
+	env: { BENCHMARK_MODE: "true" },
+	...overrides,
+});
+
+const modalRef = { provider: "modal-vm", id: "sb-rxWrDWGgOCJXeCSavkiDL6" } as const;
+
+function directRunner(control: unknown): ModalControlRunner {
+	return {
+		run: async (options, operation) => {
+			options.signal?.throwIfAborted();
+			const result = await operation(control as never);
+			options.signal?.throwIfAborted();
+			return result;
+		},
+	};
+}
+
+function unsupported(detail: string): never {
+	throw new Error(detail);
+}
+
+describe("Modal shared driver factory", () => {
+	it("attaches the shared implementation only through the two literal modules", () => {
+		expect(modalGvisor.id).toBe("modal-gvisor");
+		expect(modalVm.id).toBe("modal-vm");
+	});
+
+	it("defers the wrapper's eager app lookup until create and reuses one instance", async () => {
+		let factoryCalls = 0;
+		let createCalls = 0;
+		const compute = lazyModalCompute({}, () => {
+			factoryCalls += 1;
+			return {
+				sandbox: {
+					create: async () => {
+						createCalls += 1;
+						return {};
+					},
+				},
+			} as never;
+		});
+		expect(factoryCalls).toBe(0);
+		await compute.sandbox.create();
+		await compute.sandbox.create();
+		expect(factoryCalls).toBe(1);
+		expect(createCalls).toBe(2);
+	});
+
+	it("clears a wrapper whose captured app lookup rejects so a later create can recover", async () => {
+		let factoryCalls = 0;
+		const compute = lazyModalCompute({}, () => {
+			factoryCalls += 1;
+			const attempt = factoryCalls;
+			return {
+				sandbox: {
+					create: async () => {
+						if (attempt === 1) throw new Error("transient Modal app lookup failure");
+						return { attempt };
+					},
+				},
+			} as never;
+		});
+		await expect(compute.sandbox.create()).rejects.toThrow(/transient Modal app lookup/);
+		const recovered = await compute.sandbox.create();
+		expect((recovered as unknown as { attempt: number }).attempt).toBe(2);
+		expect(factoryCalls).toBe(2);
+	});
+
+	it("cannot attach the shared factory outside the registered Modal id union", () => {
+		const invalidAttachmentsAreCompileOnly = () => {
+			// @ts-expect-error — identity and backend are selected by one closed provider literal
+			defineModalDriver("e2b");
+		};
+		expect(invalidAttachmentsAreCompileOnly).toBeFunction();
+	});
+
+	it("binds VM to V1 ids and gVisor to V2 ids", () => {
+		expect(MODAL_V1_SANDBOX_ID.assert("sb-rxWrDWGgOCJXeCSavkiDL6")).toBe(
+			"sb-rxWrDWGgOCJXeCSavkiDL6",
+		);
+		expect(MODAL_V2_SANDBOX_ID.assert("sb-01M0BXHCKJJHRYBN29EC21NMW4")).toBe(
+			"sb-01M0BXHCKJJHRYBN29EC21NMW4",
+		);
+		expect(() => MODAL_V1_SANDBOX_ID.assert("sb-01M0BXHCKJJHRYBN29EC21NMW4")).toThrow();
+		expect(() => MODAL_V2_SANDBOX_ID.assert("sb-rxWrDWGgOCJXeCSavkiDL6")).toThrow();
+		expect(() => MODAL_V1_SANDBOX_ID.assert("sb-too-short")).toThrow();
+		expect(() => MODAL_V1_SANDBOX_ID.assert("sb-rxWrDWGgOCJXeCSavkiDL6/escape")).toThrow();
+		for (const malformed of [
+			`sb-${"a".repeat(21)}`,
+			`sb-${"a".repeat(23)}`,
+			"sb-01m0bxhckjjhrybn29ec21nmw4",
+			"sb-01M0BXHCKJJHRYBN29EC21NMI4",
+			"sb-01M0BXHCKJJHRYBN29EC21NMO4",
+			"sb-81M0BXHCKJJHRYBN29EC21NMW4",
+			"sb-91M0BXHCKJJHRYBN29EC21NMW4",
+		]) {
+			expect(() => MODAL_V2_SANDBOX_ID.assert(malformed)).toThrow();
+		}
+	});
+
+	it("maps the canonical shape and image for gVisor", () => {
+		const options = modalCreateOptions("gvisor", "registry.example/toolchain:version").map(
+			request(),
+			unsupported,
+		);
+		expect(options).toMatchObject({
+			templateId: "registry.example/toolchain:version",
+			timeout: MODAL_SANDBOX_LIFETIME_MS,
+			cpu: 4,
+			cpuLimit: 4,
+			memoryMiB: 8192,
+			memoryLimitMiB: 8192,
+			envs: { BENCHMARK_MODE: "true" },
+		});
+		expect(options.name).toMatch(/^benchmark-[0-9a-f-]{36}$/);
+		expect(options).not.toHaveProperty("experimentalOptions");
+	});
+
+	it("adds only the VM runtime projection for modal-vm", () => {
+		const options = modalCreateOptions("vm", "registry.example/toolchain:version").map(
+			request(),
+			unsupported,
+		);
+		expect(options.experimentalOptions).toEqual({ vm_runtime: true });
+	});
+
+	it("rejects a request artifact that disagrees with the joined context", () => {
+		expect(() =>
+			modalCreateOptions("gvisor", "registry.example/toolchain:version").map(
+				request({ artifact: { kind: "image", ref: "registry.example/toolchain:candidate" } }),
+				unsupported,
+			),
+		).toThrow(/does not match the resolved Modal image/);
+	});
+});
+
+// Long enough that a loopback connection, the auth RPC, and the guarded call all reach the test
+// server on a loaded CI runner before the ceiling expires. The test gates on the handler
+// actually being entered, so this bounds the run rather than defining what is asserted.
+const MODAL_TEST_CONTROL_TIMEOUT_MS = 2_000;
+const MODAL_TEST_STAGE_TIMEOUT_MS = 10_000;
+
+/**
+ * Await a transport milestone with a named failure. A bare await surfaces a slow or absent
+ * milestone as an anonymous test timeout, which cannot distinguish "the RPC never arrived" from
+ * "cancellation never came back" — the two failures this test exists to tell apart.
+ */
+async function awaitStage(label: string, reached: Promise<void>): Promise<void> {
+	let timer: ReturnType<typeof setTimeout> | undefined;
+	try {
+		await Promise.race([
+			reached,
+			new Promise<never>((_resolve, reject) => {
+				timer = setTimeout(
+					() => reject(new Error(`${label} within ${MODAL_TEST_STAGE_TIMEOUT_MS}ms`)),
+					MODAL_TEST_STAGE_TIMEOUT_MS,
+				);
+			}),
+		]);
+	} finally {
+		if (timer !== undefined) clearTimeout(timer);
+	}
+}
+
+describe("Modal enforced control deadline", () => {
+	function neverSettlingRunner(phase: "lookup" | "poll" | "terminate" | "exec") {
+		const callOptions: Array<{
+			readonly retries?: number;
+			readonly timeoutMs?: number;
+			readonly signal?: AbortSignal;
+		}> = [];
+		let settled = 0;
+		let detached = 0;
+		const runner = createModalControlRunner((middleware: ClientMiddleware) => {
+			const hang = async (): Promise<never> => {
+				const generator = middleware(
+					{
+						method: { path: "/modal.client.ModalClient/Test" },
+						requestStream: false,
+						responseStream: false,
+						request: {},
+						next: async function* (
+							_request: unknown,
+							options: {
+								readonly retries?: number;
+								readonly timeoutMs?: number;
+								readonly signal?: AbortSignal;
+							},
+						) {
+							callOptions.push(options);
+							await new Promise<never>((_resolve, reject) => {
+								const abort = () => {
+									settled += 1;
+									reject(options.signal?.reason ?? new Error("cancelled"));
+								};
+								if (options.signal?.aborted) abort();
+								else options.signal?.addEventListener("abort", abort, { once: true });
+							});
+							return {};
+						},
+					} as never,
+					{},
+				);
+				await generator.next();
+				throw new Error("unreachable");
+			};
+			const sandbox = {
+				poll: phase === "poll" ? hang : async () => null,
+				terminate: phase === "terminate" ? hang : async () => 0,
+				exec:
+					phase === "exec"
+						? hang
+						: async () => {
+								throw new Error("unused");
+							},
+				detach: () => {
+					detached += 1;
+				},
+			};
+			return {
+				sandboxes: {
+					fromId: phase === "lookup" ? hang : async () => sandbox,
+					fromName: phase === "lookup" ? hang : async () => sandbox,
+					experimentalFromName: phase === "lookup" ? hang : async () => sandbox,
+				},
+			} as never;
+		}, 10);
+		return { runner, callOptions, settled: () => settled, detached: () => detached };
+	}
+
+	it("cancels and settles hanging name lookup, poll, terminate, and exec setup", async () => {
+		for (const phase of ["lookup", "poll", "terminate", "exec"] as const) {
+			const state = neverSettlingRunner(phase);
+			const operation =
+				phase === "lookup"
+					? modalLifecycle("vm", state.runner).destroy(
+							{} as never,
+							undefined,
+							{},
+							{
+								kind: "name",
+								value: "benchmark-12345678-1234-1234-1234-123456789abc",
+							},
+						)
+					: phase === "poll"
+						? modalProbes(state.runner).observe({} as never, modalRef)
+						: phase === "terminate"
+							? modalLifecycle("vm", state.runner).destroy({} as never, modalRef, {})
+							: launchModalCommand(state.runner, {} as never, "sleep 1", modalRef);
+			await expect(operation).rejects.toThrow(/exceeded 10ms/);
+			expect(state.settled()).toBe(1);
+			expect(state.callOptions).toHaveLength(1);
+			expect(state.callOptions[0]).toMatchObject({ retries: 1, timeoutMs: 10 });
+			expect(state.callOptions[0]?.signal?.aborted).toBeTrue();
+			if (phase === "lookup") expect(state.detached()).toBe(0);
+			else expect(state.detached()).toBeGreaterThanOrEqual(1);
+		}
+	});
+
+	it("forwards caller cancellation through the same settling boundary", async () => {
+		const state = neverSettlingRunner("terminate");
+		const controller = new AbortController();
+		const operation = modalLifecycle("vm", state.runner).destroy({} as never, modalRef, {
+			signal: controller.signal,
+		});
+		controller.abort(new Error("caller cancelled Modal teardown"));
+		await expect(operation).rejects.toThrow(/caller cancelled/);
+		expect(state.settled()).toBe(1);
+		expect(state.callOptions[0]?.signal?.aborted).toBeTrue();
+		expect(state.callOptions[0]?.signal?.reason).toBe(controller.signal.reason);
+	});
+
+	it("carries cancellation through Modal 0.9's actual timeout and retry chain", async () => {
+		const encodeStringField = (value: string): Uint8Array => {
+			const bytes = new TextEncoder().encode(value);
+			if (bytes.length >= 128) throw new Error("test protobuf string is too long");
+			return Uint8Array.of(10, bytes.length, ...bytes);
+		};
+		const service = {
+			authTokenGet: {
+				path: "/modal.client.ModalClient/AuthTokenGet",
+				requestStream: false,
+				responseStream: false,
+				requestSerialize: () => new Uint8Array(),
+				requestDeserialize: () => ({}),
+				responseSerialize: (response: { token: string }) => encodeStringField(response.token),
+				responseDeserialize: () => ({ token: "" }),
+				options: {},
+			},
+			sandboxGetFromName: {
+				path: "/modal.client.ModalClient/SandboxGetFromName",
+				requestStream: false,
+				responseStream: false,
+				requestSerialize: () => new Uint8Array(),
+				requestDeserialize: () => ({}),
+				responseSerialize: () => new Uint8Array(),
+				responseDeserialize: () => ({ sandboxId: "" }),
+				options: {},
+			},
+		} as const satisfies ServiceDefinition;
+		const server = createServer();
+		let transportSettled = 0;
+		// Both signals come from the server handler, so this test waits on real transport events
+		// rather than on wall-clock budgets a loaded runner cannot honor: `handlerEntered` proves the
+		// RPC actually reached the server, and `transportSettledOnce` proves the deadline's
+		// cancellation propagated all the way back to it.
+		let markHandlerEntered: () => void = () => {};
+		const handlerEntered = new Promise<void>((resolve) => {
+			markHandlerEntered = resolve;
+		});
+		let markTransportSettled: () => void = () => {};
+		const transportSettledOnce = new Promise<void>((resolve) => {
+			markTransportSettled = resolve;
+		});
+		server.add(service, {
+			authTokenGet: async () => ({
+				// A syntactically valid JWT with an expiry in 2100 avoids another auth RPC.
+				token: "e30.eyJleHAiOjQxMDI0NDQ4MDB9.signature",
+			}),
+			sandboxGetFromName: async (_request, context) => {
+				markHandlerEntered();
+				await new Promise<void>((resolve) => {
+					if (context.signal.aborted) resolve();
+					else context.signal.addEventListener("abort", () => resolve(), { once: true });
+				});
+				transportSettled += 1;
+				markTransportSettled();
+				return { sandboxId: "" };
+			},
+		});
+		const port = await server.listen("127.0.0.1:0");
+		const previousServer = process.env.MODAL_SERVER_URL;
+		process.env.MODAL_SERVER_URL = `http://127.0.0.1:${port}`;
+		let client: ModalClient | undefined;
+		let runner: ModalControlRunner;
+		try {
+			runner = createModalControlRunner((middleware) => {
+				client = new ModalClient({
+					tokenId: "test-token-id",
+					tokenSecret: "test-token-secret",
+					grpcMiddleware: [middleware],
+				});
+				return modalControlPlane(client);
+			}, MODAL_TEST_CONTROL_TIMEOUT_MS);
+		} finally {
+			if (previousServer === undefined) delete process.env.MODAL_SERVER_URL;
+			else process.env.MODAL_SERVER_URL = previousServer;
+		}
+		try {
+			const bounded = runner.run({}, (control) =>
+				control.sandboxes.fromName(MODAL_APP_NAME, "benchmark-timeout"),
+			);
+			// Gate on arrival first: a ceiling that expired before the RPC reached the server would
+			// prove nothing about cancellation reaching the transport.
+			await awaitStage("the guarded RPC never reached the test gRPC server", handlerEntered);
+			await expect(bounded).rejects.toThrow();
+			await awaitStage(
+				"the deadline's cancellation never reached the server handler",
+				transportSettledOnce,
+			);
+			// Exactly one server invocation: the bounded retry must not re-issue an already-cancelled RPC.
+			expect(transportSettled).toBe(1);
+		} finally {
+			client?.close();
+			server.forceShutdown();
+		}
+	}, 30_000);
+});
+
+describe("Modal truthful lifecycle and recovery projections", () => {
+	it("terminates by canonical id, waits, and surfaces teardown failures", async () => {
+		const terminated: Array<{ id: string; wait: boolean }> = [];
+		const control = {
+			sandboxes: {
+				fromId: async (id: string) => ({
+					poll: async () => null,
+					terminate: async ({ wait }: { wait: true }) => {
+						terminated.push({ id, wait });
+						return 0;
+					},
+				}),
+				fromName: async () => {
+					throw new Error("unused");
+				},
+				experimentalFromName: async () => {
+					throw new Error("unused");
+				},
+			},
+		};
+		const lifecycle = modalLifecycle("vm", directRunner(control));
+		await lifecycle.destroy(
+			{} as never,
+			{ provider: "modal-vm", id: "sb-rxWrDWGgOCJXeCSavkiDL6" },
+			{},
+		);
+		expect(terminated).toEqual([{ id: "sb-rxWrDWGgOCJXeCSavkiDL6", wait: true }]);
+
+		control.sandboxes.fromId = async () => {
+			throw new Error("control plane unavailable");
+		};
+		await expect(
+			lifecycle.destroy({} as never, { provider: "modal-vm", id: "sb-rxWrDWGgOCJXeCSavkiDL6" }, {}),
+		).rejects.toThrow(/control plane unavailable/);
+	});
+
+	it("treats only sandbox-RPC not-found as converged teardown", async () => {
+		const errors = [
+			new ClientError("/modal.client.ModalClient/SandboxTerminate", Status.NOT_FOUND, "gone"),
+			new ClientError("/modal.client.ModalClient/SandboxTerminateV2", Status.NOT_FOUND, "gone"),
+		];
+		const control = {
+			sandboxes: {
+				fromId: async () => ({
+					poll: async () => null,
+					terminate: async () => {
+						throw errors.shift();
+					},
+				}),
+				fromName: async () => {
+					throw new Error("unused");
+				},
+				experimentalFromName: async () => {
+					throw new Error("unused");
+				},
+			},
+		};
+		for (const provider of ["modal-gvisor", "modal-vm"] as const) {
+			await expect(
+				modalLifecycle(
+					provider === "modal-gvisor" ? "gvisor" : "vm",
+					directRunner(control),
+				).destroy({} as never, { provider, id: "sb-rxWrDWGgOCJXeCSavkiDL6" }, {}),
+			).resolves.toBeUndefined();
+		}
+	});
+
+	it("never classifies auth or unrelated gRPC not-found as sandbox absence", async () => {
+		for (const path of [
+			"/modal.client.ModalClient/AuthTokenGet",
+			"/modal.client.ModalClient/AppGetOrCreate",
+		]) {
+			const control = {
+				sandboxes: {
+					fromId: async () => ({
+						poll: async () => null,
+						terminate: async () => {
+							throw new ClientError(path, Status.NOT_FOUND, "not a sandbox absence");
+						},
+						detach: () => {},
+					}),
+				},
+			};
+			await expect(
+				modalLifecycle("vm", directRunner(control)).destroy({} as never, modalRef, {}),
+			).rejects.toMatchObject({ path, code: Status.NOT_FOUND });
+		}
+	});
+
+	it("preserves an auth-token NOT_FOUND through production name recovery", async () => {
+		const authMissing = new ClientError(
+			"/modal.client.ModalClient/AuthTokenGet",
+			Status.NOT_FOUND,
+			"token is missing",
+		);
+		const client = {
+			environmentName: () => "",
+			cpClient: {
+				sandboxGetFromName: async () => {
+					throw authMissing;
+				},
+			},
+			sandboxes: {
+				fromId: async () => {
+					throw new Error("unused");
+				},
+			},
+		} as unknown as ModalClient;
+		await expect(
+			modalCreateRecovery("vm", directRunner(modalControlPlane(client))).cleanup(
+				{} as never,
+				{ kind: "name", value: "benchmark-12345678-1234-1234-1234-123456789abc" },
+				{},
+			),
+		).rejects.toBe(authMissing);
+	});
+
+	it("rejects cross-generation ids returned by each name endpoint", async () => {
+		const client = {
+			environmentName: () => "",
+			cpClient: {
+				sandboxGetFromName: async () => ({ sandboxId: "sb-01M0BXHCKJJHRYBN29EC21NMW4" }),
+				sandboxGetFromNameV2: async () => ({ sandboxId: "sb-rxWrDWGgOCJXeCSavkiDL6" }),
+			},
+			sandboxes: {
+				fromId: async () => {
+					throw new Error("unused");
+				},
+			},
+		} as unknown as ModalClient;
+		const control = modalControlPlane(client);
+		await expect(control.sandboxes.fromName(MODAL_APP_NAME, "wrong-v1")).rejects.toThrow();
+		await expect(
+			control.sandboxes.experimentalFromName(MODAL_APP_NAME, "wrong-v2"),
+		).rejects.toThrow();
+	});
+
+	it("uses the recovery name without touching a hostile native handle", async () => {
+		const unavailable = new ClientError(
+			"/modal.client.ModalClient/SandboxTerminate",
+			Status.UNAVAILABLE,
+			"retry",
+		);
+		let nativeReads = 0;
+		const hostileNative = {
+			getInstance: () => {
+				nativeReads += 1;
+				throw new NotFoundError("hostile accessor");
+			},
+		};
+		const lookups: string[] = [];
+		const control = {
+			sandboxes: {
+				fromId: async () => {
+					throw new Error("unused");
+				},
+				fromName: async (app: string, name: string) => {
+					lookups.push(`${app}:${name}`);
+					return {
+						terminate: async (params: { wait: true }) => {
+							expect(params).toEqual({ wait: true });
+							throw unavailable;
+						},
+					};
+				},
+				experimentalFromName: async () => {
+					throw new Error("unused");
+				},
+			},
+		};
+		await expect(
+			modalLifecycle("vm", directRunner(control)).destroy(
+				hostileNative as never,
+				undefined,
+				{},
+				{
+					kind: "name",
+					value: "benchmark-12345678-1234-1234-1234-123456789abc",
+				},
+			),
+		).rejects.toBe(unavailable);
+		expect(nativeReads).toBe(0);
+		expect(lookups).toEqual([`${MODAL_APP_NAME}:benchmark-12345678-1234-1234-1234-123456789abc`]);
+	});
+
+	it("does not release name-owned cleanup on an eventually consistent first miss", async () => {
+		const firstMiss = new ClientError(
+			"/modal.client.ModalClient/SandboxGetFromName",
+			Status.NOT_FOUND,
+			"name index has not observed the allocation yet",
+		);
+		const control = {
+			sandboxes: {
+				fromName: async () => {
+					throw firstMiss;
+				},
+			},
+		};
+		await expect(
+			modalLifecycle("vm", directRunner(control)).destroy(
+				{} as never,
+				undefined,
+				{},
+				{
+					kind: "name",
+					value: "benchmark-12345678-1234-1234-1234-123456789abc",
+				},
+			),
+		).rejects.toBe(firstMiss);
+	});
+
+	it("checks both name backends for every recovery and waits for every allocation", async () => {
+		const lookups: string[] = [];
+		const waits: boolean[] = [];
+		const sandbox = () => ({
+			poll: async () => null,
+			terminate: async ({ wait }: { wait: true }) => {
+				waits.push(wait);
+				return 0;
+			},
+			detach: () => {},
+		});
+		const control = {
+			sandboxes: {
+				fromId: async () => {
+					throw new Error("unused");
+				},
+				fromName: async (app: string, name: string) => {
+					lookups.push(`stable:${app}:${name}`);
+					return sandbox();
+				},
+				experimentalFromName: async (app: string, name: string) => {
+					lookups.push(`v2:${app}:${name}`);
+					return sandbox();
+				},
+			},
+		};
+		const locator = {
+			kind: "name" as const,
+			value: "benchmark-12345678-1234-1234-1234-123456789abc",
+		};
+		expect(
+			await modalCreateRecovery("gvisor", directRunner(control)).cleanup({} as never, locator, {}),
+		).toEqual({ status: "destroyed" });
+		expect(
+			await modalCreateRecovery("vm", directRunner(control)).cleanup({} as never, locator, {}),
+		).toEqual({ status: "destroyed" });
+		expect(lookups).toEqual([
+			`v2:${MODAL_APP_NAME}:benchmark-12345678-1234-1234-1234-123456789abc`,
+			`stable:${MODAL_APP_NAME}:benchmark-12345678-1234-1234-1234-123456789abc`,
+			`stable:${MODAL_APP_NAME}:benchmark-12345678-1234-1234-1234-123456789abc`,
+			`v2:${MODAL_APP_NAME}:benchmark-12345678-1234-1234-1234-123456789abc`,
+		]);
+		expect(waits).toEqual([true, true, true, true]);
+	});
+
+	it("destroys a cross-generation allocation before rejecting the wrapper id", async () => {
+		const name = "benchmark-12345678-1234-1234-1234-123456789abc";
+		const expectedMiss = new ClientError(
+			"/modal.client.ModalClient/SandboxGetFromNameV2",
+			Status.NOT_FOUND,
+			"not present in V2",
+		);
+		const lookups: string[] = [];
+		let terminated = 0;
+		let wrapperDestroys = 0;
+		const control = {
+			sandboxes: {
+				fromId: async () => {
+					throw new Error("unsafe direct cleanup");
+				},
+				fromName: async (app: string, lookupName: string) => {
+					lookups.push(`stable:${app}:${lookupName}`);
+					return {
+						terminate: async ({ wait }: { wait: true }) => {
+							expect(wait).toBe(true);
+							terminated += 1;
+							return 0;
+						},
+						detach: () => {},
+					};
+				},
+				experimentalFromName: async (app: string, lookupName: string) => {
+					lookups.push(`v2:${app}:${lookupName}`);
+					throw expectedMiss;
+				},
+			},
+		};
+		const runner = directRunner(control);
+		const compute = {
+			sandbox: {
+				create: async (_options?: Record<string, unknown>) => ({
+					sandboxId: "sb-rxWrDWGgOCJXeCSavkiDL6",
+					getInstance: () => ({}),
+					runCommand: async (_command: string) => ({ exitCode: 0, stdout: "", stderr: "" }),
+					destroy: async () => {
+						wrapperDestroys += 1;
+					},
+				}),
+			},
+		};
+		const module = defineComputeSdkDriver("modal-gvisor", {
+			spec: () => ({
+				compute,
+				sandboxId: modalSandboxId("gvisor"),
+				createOptions: {
+					coverage: {
+						spec: { vcpus: "mapped", memoryGb: "mapped", diskGb: "runtime-verified" },
+						artifact: "context",
+						deadlineMs: "harness",
+						gpu: { model: "unsupported", count: "unsupported" },
+						env: "mapped",
+					},
+					map: () => ({ name }),
+				},
+				lifecycle: modalLifecycle<typeof compute>("gvisor", runner),
+				createRecovery: modalCreateRecovery<typeof compute>("gvisor", runner),
+				prepareAndVerifyCreatedRequest: async () => ({ status: "honored" }),
+				hasWorkingFilesystem: false,
+			}),
+		});
+		const driver = module.driver({
+			env: { MODAL_TOKEN_ID: "test-token", MODAL_TOKEN_SECRET: "test-secret" },
+			artifact: { kind: "image" },
+			resolvedArtifact: { kind: "image", ref: "registry.example/toolchain:version" },
+		});
+		const error = await driver.create(request()).catch((caught: unknown) => caught);
+		expect(error).toMatchObject({ code: "invalid-sandbox-ref", provider: "modal-gvisor" });
+		expect(lookups).toEqual([`v2:${MODAL_APP_NAME}:${name}`, `stable:${MODAL_APP_NAME}:${name}`]);
+		expect({ terminated, wrapperDestroys }).toEqual({ terminated: 1, wrapperDestroys: 0 });
+	});
+
+	it("reports real gRPC not-found from poll as an absence observation", async () => {
+		const control = {
+			sandboxes: {
+				fromId: async () => ({
+					poll: async () => {
+						throw new ClientError(
+							"/modal.client.ModalClient/SandboxWait",
+							Status.NOT_FOUND,
+							"gone",
+						);
+					},
+					terminate: async () => 0,
+					detach: () => {},
+				}),
+				fromName: async () => {
+					throw new Error("unused");
+				},
+				experimentalFromName: async () => {
+					throw new Error("unused");
+				},
+			},
+		};
+		expect(
+			await modalProbes(directRunner(control)).observe({} as never, {
+				provider: "modal-vm",
+				id: "sb-rxWrDWGgOCJXeCSavkiDL6",
+			}),
+		).toEqual({ state: "absent" });
+	});
+
+	it("accepts only null or safe-integer poll results", async () => {
+		for (const malformed of [undefined, "0", 1.5, Number.NaN, Number.POSITIVE_INFINITY, 2 ** 53]) {
+			const control = {
+				sandboxes: {
+					fromId: async () => ({
+						poll: async () => malformed,
+						terminate: async () => 0,
+						detach: () => {},
+					}),
+					fromName: async () => {
+						throw new Error("unused");
+					},
+					experimentalFromName: async () => {
+						throw new Error("unused");
+					},
+				},
+			};
+			await expect(
+				modalProbes(directRunner(control)).observe({} as never, {
+					provider: "modal-vm",
+					id: "sb-rxWrDWGgOCJXeCSavkiDL6",
+				}),
+			).rejects.toThrow(/malformed exit code/);
+		}
+	});
+});
+
+describe("Modal post-create verification", () => {
+	it("accepts sufficient disk, rejects insufficient disk, and bounds the probe", async () => {
+		const optionsSeen: unknown[] = [];
+		const idsSeen: string[] = [];
+		let wrapperIdReads = 0;
+		const control = (kilobytes: unknown) => ({
+			sandboxes: {
+				fromId: async (id: string) => {
+					idsSeen.push(id);
+					return {
+						poll: async () => null,
+						terminate: async () => 0,
+						exec: async (_command: unknown, options: unknown) => {
+							optionsSeen.push(options);
+							return {
+								stdout: { readText: async () => `${kilobytes}\n` },
+								stderr: { readText: async () => "" },
+								wait: async () => 0,
+							};
+						},
+						detach: () => {},
+					};
+				},
+			},
+		});
+		const sandbox = {
+			get sandboxId() {
+				wrapperIdReads += 1;
+				return "sb-01M0BXHCKJJHRYBN29EC21NMW4";
+			},
+		};
+		expect(
+			await verifyModalDiskCapacity(
+				directRunner(control(50 * 1024 * 1024)),
+				sandbox as never,
+				request(),
+				{},
+				modalRef,
+			),
+		).toEqual({ status: "honored" });
+		expect(
+			await verifyModalDiskCapacity(
+				directRunner(control(20 * 1024 * 1024)),
+				sandbox as never,
+				request(),
+				{},
+				modalRef,
+			),
+		).toMatchObject({ status: "unsupported" });
+		expect(idsSeen).toEqual(["sb-rxWrDWGgOCJXeCSavkiDL6", "sb-rxWrDWGgOCJXeCSavkiDL6"]);
+		expect(optionsSeen).toEqual([
+			{ stdout: "pipe", stderr: "pipe", timeoutMs: MODAL_CONTROL_TIMEOUT_MS },
+			{ stdout: "pipe", stderr: "pipe", timeoutMs: MODAL_CONTROL_TIMEOUT_MS },
+		]);
+		await expect(
+			verifyModalDiskCapacity(
+				directRunner(control(`${Number.MAX_SAFE_INTEGER}0`)),
+				sandbox as never,
+				request(),
+				{},
+				modalRef,
+			),
+		).rejects.toThrow(/invalid capacity/);
+		expect(wrapperIdReads).toBe(0);
+	});
+
+	it("settles a bounded disk probe before observing a mid-flight abort", async () => {
+		const controller = new AbortController();
+		let settled = false;
+		const control = {
+			sandboxes: {
+				fromId: async () => ({
+					poll: async () => null,
+					terminate: async () => 0,
+					exec: async () => ({
+						stdout: { readText: async () => `${50 * 1024 * 1024}\n` },
+						stderr: { readText: async () => "" },
+						wait: async () => {
+							controller.abort();
+							settled = true;
+							return 0;
+						},
+					}),
+					detach: () => {},
+				}),
+			},
+		};
+		await expect(
+			verifyModalDiskCapacity(
+				directRunner(control),
+				{ sandboxId: "sb-rxWrDWGgOCJXeCSavkiDL6" } as never,
+				request(),
+				{ signal: controller.signal },
+				modalRef,
+			),
+		).rejects.toThrow();
+		expect(settled).toBeTrue();
+	});
+});
+
+describe("Modal command projection", () => {
+	function commandControl(
+		stdout: unknown,
+		stderr: unknown,
+		exitCode: unknown,
+		seen: Array<{ command: unknown; options: unknown }> = [],
+	) {
+		return {
+			sandboxes: {
+				fromId: async () => ({
+					poll: async () => null,
+					terminate: async () => 0,
+					exec: async (command: unknown, options: unknown) => {
+						seen.push({ command, options });
+						return {
+							stdout: { readText: async () => stdout },
+							stderr: { readText: async () => stderr },
+							wait: async () => exitCode,
+						};
+					},
+					detach: () => {},
+				}),
+			},
+		};
+	}
+
+	it("detaches an accepted control channel when foreground exec-start rejects", async () => {
+		const primary = new Error("Modal exec-start rejected");
+		let detachCalls = 0;
+		const control = {
+			sandboxes: {
+				fromId: async () => ({
+					poll: async () => null,
+					terminate: async () => 0,
+					exec: async () => Promise.reject(primary),
+					detach: () => {
+						detachCalls += 1;
+					},
+				}),
+			},
+		};
+		await expect(
+			execModalCommand(directRunner(control), {} as never, "true", modalRef),
+		).rejects.toBe(primary);
+		expect(detachCalls).toBe(1);
+	});
+
+	it("preserves the real nonzero exit and split streams", async () => {
+		const seen: Array<{ command: unknown; options: unknown }> = [];
+		expect(
+			await execModalCommand(
+				directRunner(commandControl("out", "err", 7, seen)),
+				{} as never,
+				"exit 7",
+				modalRef,
+			),
+		).toEqual({
+			stdout: "out",
+			stderr: "err",
+			exitCode: 7,
+		});
+		expect(seen).toEqual([
+			{
+				command: ["sh", "-c", "exit 7"],
+				// Modal 0.9 rejects a defined timeoutMs <= 0. Omission means the foreground
+				// process owns its duration after the bounded attachment/start transaction.
+				options: { stdout: "pipe", stderr: "pipe" },
+			},
+		]);
+	});
+
+	it("uses the harness 50ms detached-acceptance contract and bounds the process", async () => {
+		const seen: Array<{ command: unknown; options: unknown }> = [];
+		await expect(
+			launchModalCommand(
+				directRunner(commandControl("", "", 0, seen)),
+				{} as never,
+				"sleep 1",
+				modalRef,
+			),
+		).resolves.toBeUndefined();
+		expect(seen).toEqual([
+			{
+				command: ["sh", "-c", modalDetachedCommand("sleep 1")],
+				options: { stdout: "pipe", stderr: "pipe", timeoutMs: MODAL_CONTROL_TIMEOUT_MS },
+			},
+		]);
+		expect(seen[0]?.command).toEqual([
+			"sh",
+			"-c",
+			'nohup /bin/sh -lc \'sleep 1\' </dev/null >/dev/null 2>&1 & child=$!; finish() { wait "$child"; exit $?; }; sleep 0.05; if ! kill -0 "$child" 2>/dev/null; then finish; fi; if command -v ps >/dev/null 2>&1; then state=$(ps -o state= -p "$child" 2>/dev/null || :); case "$state" in *Z*) finish ;; "") if ! kill -0 "$child" 2>/dev/null; then finish; fi ;; esac; fi; exit 0',
+		]);
+		await expect(
+			launchModalCommand(
+				directRunner(commandControl("", "command not found", 127)),
+				{} as never,
+				"missing",
+				modalRef,
+			),
+		).rejects.toThrow(/exited 127: command not found/);
+	});
+
+	it("joins every process result operation before surfacing the primary failure", async () => {
+		const primary = new Error("stdout transport failed");
+		let stderrSettled = false;
+		let waitSettled = false;
+		const control = {
+			sandboxes: {
+				fromId: async () => ({
+					poll: async () => null,
+					terminate: async () => 0,
+					exec: async () => ({
+						stdout: { readText: async () => Promise.reject(primary) },
+						stderr: {
+							readText: async () => {
+								await Bun.sleep(5);
+								stderrSettled = true;
+								return "";
+							},
+						},
+						wait: async () => {
+							await Bun.sleep(10);
+							waitSettled = true;
+							return 0;
+						},
+					}),
+					detach: () => {},
+				}),
+			},
+		};
+		await expect(
+			launchModalCommand(directRunner(control), {} as never, "true", modalRef),
+		).rejects.toBe(primary);
+		expect({ stderrSettled, waitSettled }).toEqual({ stderrSettled: true, waitSettled: true });
+	});
+
+	it("joins started siblings when a later process accessor throws synchronously", async () => {
+		const primary = new Error("stderr accessor is unreadable");
+		let stdoutSettled = false;
+		let waitSettled = false;
+		const control = {
+			sandboxes: {
+				fromId: async () => ({
+					poll: async () => null,
+					terminate: async () => 0,
+					exec: async () => ({
+						stdout: {
+							readText: async () => {
+								await Bun.sleep(10);
+								stdoutSettled = true;
+								return "";
+							},
+						},
+						get stderr(): never {
+							throw primary;
+						},
+						wait: async () => {
+							waitSettled = true;
+							return 0;
+						},
+					}),
+					detach: () => {},
+				}),
+			},
+		};
+		await expect(
+			execModalCommand(directRunner(control), {} as never, "true", modalRef),
+		).rejects.toBe(primary);
+		expect({ stdoutSettled, waitSettled }).toEqual({ stdoutSettled: true, waitSettled: true });
+	});
+
+	it("detaches on the first process failure before joining cancellation-bound siblings", async () => {
+		const primary = new Error("stdout transport failed");
+		let detached = false;
+		let stderrSettled = false;
+		let waitSettled = false;
+		let releaseStderr: (() => void) | undefined;
+		let releaseWait: (() => void) | undefined;
+		const cancellationBound = (settled: () => void, install: (release: () => void) => void) => {
+			if (detached) {
+				settled();
+				return Promise.resolve("");
+			}
+			return new Promise<string>((resolve) => {
+				install(() => {
+					settled();
+					resolve("");
+				});
+			});
+		};
+		const control = {
+			sandboxes: {
+				fromId: async () => ({
+					poll: async () => null,
+					terminate: async () => 0,
+					exec: async () => ({
+						stdout: { readText: async () => Promise.reject(primary) },
+						stderr: {
+							readText: () =>
+								cancellationBound(
+									() => {
+										stderrSettled = true;
+									},
+									(release) => {
+										releaseStderr = release;
+									},
+								),
+						},
+						wait: () =>
+							cancellationBound(
+								() => {
+									waitSettled = true;
+								},
+								(release) => {
+									releaseWait = release;
+								},
+							).then(() => 0),
+					}),
+					detach: () => {
+						detached = true;
+						releaseStderr?.();
+						releaseWait?.();
+					},
+				}),
+			},
+		};
+		const operation = execModalCommand(directRunner(control), {} as never, "true", modalRef);
+		const outcome = await Promise.race([
+			operation.then(
+				() => ({ kind: "success" as const }),
+				(error: unknown) => ({ kind: "error" as const, error }),
+			),
+			Bun.sleep(50).then(() => ({ kind: "pending" as const })),
+		]);
+		if (outcome.kind === "pending") {
+			detached = true;
+			releaseStderr?.();
+			releaseWait?.();
+			await operation.catch(() => undefined);
+		}
+		expect(outcome).toEqual({ kind: "error", error: primary });
+		expect({ detached, stderrSettled, waitSettled }).toEqual({
+			detached: true,
+			stderrSettled: true,
+			waitSettled: true,
+		});
+	});
+
+	it("rejects malformed command envelopes instead of canonicalizing them", async () => {
+		for (const [stdout, stderr, exitCode] of [
+			[{}, "", 0],
+			["", {}, 0],
+			["", "", 1.5],
+			["", "", 2 ** 53],
+		] as const) {
+			await expect(
+				execModalCommand(
+					directRunner(commandControl(stdout, stderr, exitCode)),
+					{} as never,
+					"true",
+					modalRef,
+				),
+			).rejects.toThrow(/malformed result/);
+		}
+	});
+});

--- a/packages/drivers/src/_modal.ts
+++ b/packages/drivers/src/_modal.ts
@@ -1,0 +1,637 @@
+// The two Modal variants share one wrapper-backed implementation. The wrapper keeps its maintained
+// image, command, and filesystem translations; this module owns the benchmark-specific request
+// mapping and the lifecycle semantics the wrapper currently swallows.
+
+import { AsyncLocalStorage } from "node:async_hooks";
+import { randomUUID } from "node:crypto";
+import type { ModalCreateSandboxOptions } from "@computesdk/modal";
+import { modal } from "@computesdk/modal";
+import type {
+	CreateRequest,
+	DriverContext,
+	DriverOperationOptions,
+	SandboxObservation,
+	SandboxRef,
+} from "@sandbox-benchmarks/driver";
+import { shellQuote } from "@sandbox-benchmarks/driver";
+import { type } from "arktype";
+import { ModalClient, Sandbox } from "modal";
+import type { ClientMiddleware } from "nice-grpc";
+import { ClientError, Status } from "nice-grpc";
+import type {
+	ComputeSdkCreatedRequestVerification,
+	ComputeSdkCreateRecovery,
+	ComputeSdkCreateRequestCoverage,
+	ComputeSdkDriverSpec,
+	ComputeSdkLifecycle,
+	ComputeSdkLike,
+	ComputeSdkSandboxIdSchema,
+	ComputeSdkSandboxOf,
+} from "./_computesdk.ts";
+import { computeSdkSpec, defineComputeSdkDriver } from "./_computesdk.ts";
+
+export type ModalProviderId = "modal-gvisor" | "modal-vm";
+export type ModalVariant = "gvisor" | "vm";
+
+type ModalCompute = ReturnType<typeof lazyModalCompute>;
+type ModalWrapperSandbox = ComputeSdkSandboxOf<ModalCompute>;
+
+interface ModalControlSandbox {
+	poll(): Promise<number | null>;
+	terminate(params: { readonly wait: true }): Promise<number>;
+	exec(
+		command: string[],
+		params: { readonly stdout: "pipe"; readonly stderr: "pipe"; readonly timeoutMs?: number },
+	): Promise<ModalTextProcess>;
+	detach(): void;
+}
+
+interface ModalControlPlane {
+	readonly sandboxes: {
+		fromId(id: string): Promise<ModalControlSandbox>;
+		fromName(appName: string, name: string): Promise<ModalControlSandbox>;
+		experimentalFromName(appName: string, name: string): Promise<ModalControlSandbox>;
+	};
+}
+
+export interface ModalControlRunner {
+	run<T>(
+		options: DriverOperationOptions,
+		operation: (control: ModalControlPlane) => Promise<T>,
+		onAbort?: () => void,
+	): Promise<T>;
+}
+
+export const MODAL_APP_NAME = "sandbox-benchmarks";
+export const MODAL_SANDBOX_LIFETIME_MS = 3 * 60 * 60_000;
+export const MODAL_CONTROL_TIMEOUT_MS = 5_000;
+export const MODAL_RECOVERY_CONFIRMATION_MS = 2_000;
+export const MODAL_RECOVERY_MAX_ATTEMPTS = 4;
+export const MODAL_V1_SANDBOX_ID = type(/^sb-[A-Za-z0-9]{22}$/);
+export const MODAL_V2_SANDBOX_ID = type(/^sb-[0-7][0-9A-HJKMNP-TV-Z]{25}$/);
+const MODAL_CONTROL_SANDBOX_ID = type(/^sb-(?:[A-Za-z0-9]{22}|[0-7][0-9A-HJKMNP-TV-Z]{25})$/);
+
+export function modalSandboxId(variant: ModalVariant): ComputeSdkSandboxIdSchema {
+	return {
+		// A cross-generation id is still a real allocation identity. Retain it as a safe raw
+		// boundary so recovery can destroy the allocation before canonical validation rejects it.
+		fromVendor: MODAL_CONTROL_SANDBOX_ID,
+		canonical: variant === "gvisor" ? MODAL_V2_SANDBOX_ID : MODAL_V1_SANDBOX_ID,
+	};
+}
+
+export const MODAL_REQUEST_COVERAGE = {
+	spec: { vcpus: "mapped", memoryGb: "mapped", diskGb: "runtime-verified" },
+	artifact: "context",
+	deadlineMs: "harness",
+	gpu: { model: "unsupported", count: "unsupported" },
+	env: "mapped",
+} as const satisfies ComputeSdkCreateRequestCoverage;
+
+const MODAL_SANDBOX_NOT_FOUND_PATHS = new Set([
+	"/modal.client.ModalClient/SandboxGetFromName",
+	"/modal.client.ModalClient/SandboxGetFromNameV2",
+	"/modal.client.ModalClient/SandboxTerminate",
+	"/modal.client.ModalClient/SandboxTerminateV2",
+	"/modal.client.ModalClient/SandboxWait",
+	"/modal.client.ModalClient/SandboxWaitV2",
+]);
+
+function isModalNotFound(caught: unknown): boolean {
+	try {
+		return (
+			caught instanceof ClientError &&
+			caught.code === Status.NOT_FOUND &&
+			MODAL_SANDBOX_NOT_FOUND_PATHS.has(caught.path)
+		);
+	} catch {
+		return false;
+	}
+}
+
+/**
+ * Modal's high-level fromName catches every nested NOT_FOUND (including AuthTokenGet) and rewrites
+ * it to an unqualified NotFoundError. Ownership lookup uses the public control client directly so
+ * the originating RPC path survives and only a sandbox lookup can prove absence.
+ */
+export function modalControlPlane(client: ModalClient): ModalControlPlane {
+	return {
+		sandboxes: {
+			fromId: (id) => client.sandboxes.fromId(id),
+			fromName: async (appName, name) => {
+				const response = await client.cpClient.sandboxGetFromName({
+					appName,
+					sandboxName: name,
+					environmentName: client.environmentName(),
+				});
+				return new Sandbox(client, MODAL_V1_SANDBOX_ID.assert(response.sandboxId), {
+					isV2: false,
+				});
+			},
+			experimentalFromName: async (appName, name) => {
+				const response = await client.cpClient.sandboxGetFromNameV2({
+					appName,
+					sandboxName: name,
+					environmentName: client.environmentName(),
+				});
+				return new Sandbox(client, MODAL_V2_SANDBOX_ID.assert(response.sandboxId), {
+					isV2: true,
+				});
+			},
+		},
+	};
+}
+
+/**
+ * Modal 0.9 declares client timeout/retry constructor fields but does not apply them at runtime.
+ * Inject the transaction signal where the SDK's middleware chain actually consumes it. nice-grpc
+ * invokes the last-attached custom middleware first, so these options reach Modal's timeout and
+ * retry middleware on every control-plane RPC. The outer timer spans multi-RPC loops such as
+ * terminate({wait:true}).
+ */
+export function createModalControlRunner(
+	createControl: (middleware: ClientMiddleware) => ModalControlPlane,
+	timeoutMs = MODAL_CONTROL_TIMEOUT_MS,
+): ModalControlRunner {
+	const operationSignals = new AsyncLocalStorage<AbortSignal>();
+	const deadlineMiddleware: ClientMiddleware = async function* (call, options) {
+		const signal = operationSignals.getStore();
+		if (signal === undefined) {
+			throw new Error("Modal control RPC escaped its bounded operation");
+		}
+		const nextOptions = {
+			...options,
+			signal,
+			timeoutMs,
+			// Modal 0.9's retry middleware drops `signal` entirely when retries is zero, so one
+			// bounded retry is what keeps cancellation attached to the real gRPC transport; the
+			// operation-wide controller remains the hard ceiling across both attempts.
+			//
+			// Retrying a non-idempotent SandboxExec is safe here: that middleware stamps one
+			// x-idempotency-key per call and replays it on every attempt, so a response lost after
+			// the server accepted the exec is deduplicated server-side rather than starting the
+			// benchmark command a second time. Stock Modal defaults to three attempts on every unary
+			// RPC; one is the conservative setting, not a laxer one.
+			retries: 1,
+		};
+		return yield* call.next(call.request, nextOptions);
+	};
+	const control = createControl(deadlineMiddleware);
+	return {
+		run: async (options, operation, onAbort) => {
+			options.signal?.throwIfAborted();
+			const controller = new AbortController();
+			const abort = (reason: unknown) => {
+				if (controller.signal.aborted) return;
+				controller.abort(reason);
+				try {
+					onAbort?.();
+				} catch {
+					// Closing a local transport is best effort; the operation rejection remains primary.
+				}
+			};
+			const forwardAbort = () => abort(options.signal?.reason);
+			options.signal?.addEventListener("abort", forwardAbort, { once: true });
+			const timer = setTimeout(
+				() => abort(new Error(`Modal control operation exceeded ${timeoutMs}ms`)),
+				timeoutMs,
+			);
+			try {
+				const result = await operationSignals.run(controller.signal, () => operation(control));
+				controller.signal.throwIfAborted();
+				return result;
+			} finally {
+				clearTimeout(timer);
+				options.signal?.removeEventListener("abort", forwardAbort);
+				if (controller.signal.aborted) {
+					try {
+						onAbort?.();
+					} catch {
+						// The operation's cancellation/timeout remains the primary failure.
+					}
+				}
+			}
+		},
+	};
+}
+
+interface ModalTextProcess {
+	readonly stdout: { readText(): Promise<unknown> };
+	readonly stderr: { readText(): Promise<unknown> };
+	wait(): Promise<unknown>;
+}
+
+async function modalProcessResult(
+	process: ModalTextProcess,
+	onFailure: () => void,
+): Promise<{
+	readonly stdout: string;
+	readonly stderr: string;
+	readonly exitCode: number;
+}> {
+	const settleAfterFailure = async (start: () => Promise<unknown>): Promise<unknown> => {
+		try {
+			return await Promise.resolve().then(start);
+		} catch (caught) {
+			try {
+				onFailure();
+			} catch {
+				// Local transport close is best effort; the process failure remains primary.
+			}
+			throw caught;
+		}
+	};
+	const settled = await Promise.allSettled(
+		[() => process.stdout.readText(), () => process.stderr.readText(), () => process.wait()].map(
+			settleAfterFailure,
+		),
+	);
+	// Detach can reject one stream before the others finish unwinding. Join every accepted
+	// command-router operation before surfacing the first deterministic error so runner.run never
+	// releases a transaction with sibling RPCs still active.
+	const [stdout, stderr, exitCode] = settled.map((result) => {
+		if (result.status === "rejected") throw result.reason;
+		return result.value;
+	});
+	if (
+		typeof stdout !== "string" ||
+		typeof stderr !== "string" ||
+		typeof exitCode !== "number" ||
+		!Number.isSafeInteger(exitCode)
+	) {
+		throw new Error("Modal process returned a malformed result");
+	}
+	return { stdout, stderr, exitCode };
+}
+
+function modalVariant(provider: ModalProviderId): ModalVariant {
+	return provider === "modal-gvisor" ? "gvisor" : "vm";
+}
+
+/**
+ * The wrapper resolves/creates its Modal app while `modal()` runs. Defer that construction until
+ * `sandbox.create()` so app and image control-plane work stays inside the harness-owned create
+ * transaction instead of starting during composition-root module loading.
+ */
+export function lazyModalCompute(
+	config: Parameters<typeof modal>[0],
+	factory: typeof modal = modal,
+) {
+	let compute: ReturnType<typeof modal> | undefined;
+	const instance = () => (compute ??= factory(config));
+	return {
+		sandbox: {
+			create: async (options?: Record<string, unknown>) => {
+				const current = instance();
+				try {
+					return await current.sandbox.create(options as ModalCreateSandboxOptions);
+				} catch (caught) {
+					// modal() captures its eager App lookup in the wrapper instance. A transient
+					// rejection must not poison every later create in this long-lived CLI process.
+					if (compute === current) compute = undefined;
+					throw caught;
+				}
+			},
+		},
+	};
+}
+
+function recoveryName(createOptions: Readonly<Record<string, unknown>>): string {
+	const name = createOptions.name;
+	if (typeof name !== "string" || !/^benchmark-[0-9a-f-]{36}$/.test(name)) {
+		throw new Error("Modal create options contain no stable benchmark name");
+	}
+	return name;
+}
+
+/** Translate the canonical request without letting artifact or resource policy drift by variant. */
+export function modalCreateOptions(
+	variant: ModalVariant,
+	resolvedArtifactRef: string,
+): ComputeSdkDriverSpec<ModalCompute>["createOptions"] {
+	return {
+		coverage: MODAL_REQUEST_COVERAGE,
+		map: (request, unsupported) => {
+			if (request.artifact.kind !== "image" || request.artifact.ref !== resolvedArtifactRef) {
+				unsupported("the request artifact does not match the resolved Modal image");
+			}
+			return {
+				templateId: resolvedArtifactRef,
+				name: `benchmark-${randomUUID()}`,
+				timeout: MODAL_SANDBOX_LIFETIME_MS,
+				// Modal's docs describe physical cores, but live behavior contradicts that reading:
+				// cpu=1 exposes nproc=1 and delivered 264 MB hashed/worker/8s versus 512 at cpu=2
+				// (2026-07-10). `cpu` is the guest-schedulable vCPU count, so pass it unhalved.
+				cpu: request.spec.vcpus,
+				cpuLimit: request.spec.vcpus,
+				// `memoryMiB` alone is a reservation: a live guest exposed 464 GiB of host RAM,
+				// causing PTS STREAM sizing never to converge. The limit makes /proc match spec.
+				memoryMiB: request.spec.memoryGb * 1024,
+				memoryLimitMiB: request.spec.memoryGb * 1024,
+				...(request.env === undefined ? {} : { envs: request.env }),
+				// The stable service plus vm_runtime is the VM config validated in #221.
+				...(variant === "vm" ? { experimentalOptions: { vm_runtime: true } } : {}),
+			};
+		},
+	};
+}
+
+function modalSandboxByName(
+	control: ModalControlPlane,
+	variant: ModalVariant,
+	name: string,
+): Promise<ModalControlSandbox> {
+	return variant === "gvisor"
+		? control.sandboxes.experimentalFromName(MODAL_APP_NAME, name)
+		: control.sandboxes.fromName(MODAL_APP_NAME, name);
+}
+
+/** The bounded public control plane surfaces failures that the wrapper's destroy suppresses. */
+export function modalLifecycle<TCompute extends ComputeSdkLike = ModalCompute>(
+	variant: ModalVariant,
+	runner: ModalControlRunner,
+): ComputeSdkLifecycle<TCompute> {
+	return {
+		destroy: async (_sandbox, ref, options, recoveryLocator) => {
+			let attached: ModalControlSandbox | undefined;
+			try {
+				await runner.run(
+					options,
+					async (control) => {
+						if (ref !== undefined) {
+							attached = await control.sandboxes.fromId(ref.id);
+						} else {
+							if (recoveryLocator === undefined) {
+								throw new Error("Modal failed-create cleanup has no stable recovery name");
+							}
+							attached = await modalSandboxByName(control, variant, recoveryLocator.value);
+						}
+						await attached.terminate({ wait: true });
+					},
+					() => attached?.detach(),
+				);
+			} catch (caught) {
+				// A canonical-id teardown or a miss after successful name attachment proves
+				// convergence. A first miss by recovery name does not: the name index can lag a
+				// create that already returned a handle, so ownership must remain retryable.
+				if (isModalNotFound(caught) && (ref !== undefined || attached !== undefined)) return;
+				throw caught;
+			}
+		},
+	};
+}
+
+/** Stable create names let the bridge reconcile an accepted allocation whose response was lost. */
+export function modalCreateRecovery<TCompute extends ComputeSdkLike = ModalCompute>(
+	variant: ModalVariant,
+	runner: ModalControlRunner,
+): ComputeSdkCreateRecovery<TCompute> {
+	return {
+		absenceConfirmationMs: MODAL_RECOVERY_CONFIRMATION_MS,
+		maxAttempts: MODAL_RECOVERY_MAX_ATTEMPTS,
+		locator: (createOptions) => ({ kind: "name", value: recoveryName(createOptions) }),
+		cleanup: (_compute, locator, options) => {
+			const name = locator.value;
+			let active: ModalControlSandbox | undefined;
+			return runner.run(
+				options,
+				async (control) => {
+					const lookups =
+						variant === "gvisor"
+							? [
+									() => control.sandboxes.experimentalFromName(MODAL_APP_NAME, name),
+									() => control.sandboxes.fromName(MODAL_APP_NAME, name),
+								]
+							: [
+									() => control.sandboxes.fromName(MODAL_APP_NAME, name),
+									() => control.sandboxes.experimentalFromName(MODAL_APP_NAME, name),
+								];
+					let found = false;
+					let destroyed = false;
+					for (const lookup of lookups) {
+						try {
+							active = await lookup();
+							found = true;
+						} catch (caught) {
+							if (isModalNotFound(caught)) continue;
+							throw caught;
+						}
+						try {
+							// Once found, the transaction continues through waited teardown. An abort
+							// cancels the RPC and fails cleanup; it never reports false convergence.
+							await active.terminate({ wait: true });
+							destroyed = true;
+						} catch (caught) {
+							if (!isModalNotFound(caught)) throw caught;
+						} finally {
+							active.detach();
+							active = undefined;
+						}
+					}
+					if (destroyed) return { status: "destroyed" };
+					return found
+						? { status: "absent", contradictedPriorAbsence: true }
+						: { status: "absent" };
+				},
+				() => active?.detach(),
+			);
+		},
+	};
+}
+
+export function modalProbes(
+	runner: ModalControlRunner,
+): NonNullable<ComputeSdkDriverSpec<ModalCompute>["probes"]> {
+	return {
+		observe: async (_compute, ref: SandboxRef): Promise<SandboxObservation> => {
+			let sandbox: ModalControlSandbox | undefined;
+			try {
+				const exitCode = await runner.run(
+					{},
+					async (control) => {
+						sandbox = await control.sandboxes.fromId(ref.id);
+						try {
+							return await sandbox.poll();
+						} finally {
+							sandbox.detach();
+						}
+					},
+					() => sandbox?.detach(),
+				);
+				if (exitCode === null) return { state: "running" };
+				if (typeof exitCode !== "number" || !Number.isSafeInteger(exitCode)) {
+					throw new Error("Modal poll returned a malformed exit code");
+				}
+				return { state: "terminal" };
+			} catch (caught) {
+				if (isModalNotFound(caught)) return { state: "absent" };
+				throw caught;
+			}
+		},
+	};
+}
+
+/** Bypass the wrapper's fabricated exit-127 catch path and preserve Modal's real process result. */
+export async function execModalCommand(
+	runner: ModalControlRunner,
+	_sandbox: ModalWrapperSandbox,
+	command: string,
+	ref: SandboxRef,
+): Promise<unknown> {
+	let attached: ModalControlSandbox | undefined;
+	let process: ModalTextProcess;
+	try {
+		process = await runner.run(
+			{},
+			async (control) => {
+				attached = await control.sandboxes.fromId(ref.id);
+				// Bound attachment and exec-start only; foreground benchmark commands may
+				// legitimately run for minutes and own their duration outside this control budget.
+				return attached.exec(["sh", "-c", command], {
+					stdout: "pipe",
+					stderr: "pipe",
+				});
+			},
+			() => attached?.detach(),
+		);
+	} catch (caught) {
+		// A normal exec-start rejection does not pass through the runner's abort callback.
+		try {
+			attached?.detach();
+		} catch {
+			// Local transport close is best effort; the exec-start failure remains primary.
+		}
+		throw caught;
+	}
+	try {
+		return await modalProcessResult(process, () => attached?.detach());
+	} finally {
+		attached?.detach();
+	}
+}
+
+/** The same acceptance contract as the harness fallback, projected through Modal's native exec. */
+export function modalDetachedCommand(command: string): string {
+	return `nohup /bin/sh -lc ${shellQuote(command)} </dev/null >/dev/null 2>&1 & child=$!; finish() { wait "$child"; exit $?; }; sleep 0.05; if ! kill -0 "$child" 2>/dev/null; then finish; fi; if command -v ps >/dev/null 2>&1; then state=$(ps -o state= -p "$child" 2>/dev/null || :); case "$state" in *Z*) finish ;; "") if ! kill -0 "$child" 2>/dev/null; then finish; fi ;; esac; fi; exit 0`;
+}
+
+export async function launchModalCommand(
+	runner: ModalControlRunner,
+	_sandbox: ModalWrapperSandbox,
+	command: string,
+	ref: SandboxRef,
+): Promise<void> {
+	let attached: ModalControlSandbox | undefined;
+	const { stderr, exitCode } = await runner.run(
+		{},
+		async (control) => {
+			attached = await control.sandboxes.fromId(ref.id);
+			try {
+				const process = await attached.exec(["sh", "-c", modalDetachedCommand(command)], {
+					stdout: "pipe",
+					stderr: "pipe",
+					timeoutMs: MODAL_CONTROL_TIMEOUT_MS,
+				});
+				return await modalProcessResult(process, () => attached?.detach());
+			} finally {
+				attached.detach();
+			}
+		},
+		() => attached?.detach(),
+	);
+	if (exitCode !== 0) throw new Error(`Modal background launch exited ${exitCode}: ${stderr}`);
+}
+
+export async function verifyModalDiskCapacity(
+	runner: ModalControlRunner,
+	_sandbox: ModalWrapperSandbox,
+	request: CreateRequest,
+	options: DriverOperationOptions,
+	ref: SandboxRef,
+): Promise<ComputeSdkCreatedRequestVerification> {
+	const requestedDiskGb = request.spec.diskGb;
+	if (requestedDiskGb === undefined) return { status: "honored" };
+	let attached: ModalControlSandbox | undefined;
+	const { stdout, stderr, exitCode } = await runner.run(
+		options,
+		async (control) => {
+			attached = await control.sandboxes.fromId(ref.id);
+			try {
+				const process = await attached.exec(["sh", "-c", "df -Pk / | awk 'NR==2 {print $2}'"], {
+					stdout: "pipe",
+					stderr: "pipe",
+					timeoutMs: MODAL_CONTROL_TIMEOUT_MS,
+				});
+				return await modalProcessResult(process, () => attached?.detach());
+			} finally {
+				attached.detach();
+			}
+		},
+		() => attached?.detach(),
+	);
+	if (exitCode !== 0) {
+		throw new Error(`Modal disk capacity probe exited ${exitCode}: ${stderr}`);
+	}
+	const output = stdout.trim();
+	if (!/^\d+$/.test(output)) throw new Error("Modal disk capacity probe returned malformed output");
+	const capacityKb = Number(output);
+	if (!Number.isSafeInteger(capacityKb) || capacityKb <= 0) {
+		throw new Error("Modal disk capacity probe returned an invalid capacity");
+	}
+	const capacityGb = capacityKb / 1024 / 1024;
+	return capacityGb >= requestedDiskGb
+		? { status: "honored" }
+		: {
+				status: "unsupported",
+				detail: `requested ${requestedDiskGb} GiB but the allocation exposes ${capacityGb.toFixed(2)} GiB`,
+			};
+}
+
+function modalSpec<P extends ModalProviderId>(
+	provider: P,
+	{ env, resolvedArtifact }: DriverContext<P>,
+) {
+	const variant = modalVariant(provider);
+	const runner = createModalControlRunner((middleware) =>
+		modalControlPlane(
+			new ModalClient({
+				tokenId: env.MODAL_TOKEN_ID,
+				tokenSecret: env.MODAL_TOKEN_SECRET,
+				grpcMiddleware: [middleware],
+			}),
+		),
+	);
+	return computeSdkSpec(
+		lazyModalCompute({
+			tokenId: env.MODAL_TOKEN_ID,
+			tokenSecret: env.MODAL_TOKEN_SECRET,
+			// Keep benchmark allocations attributable in their own Modal dashboard app instead
+			// of mixing them into the wrapper's generic `computesdk-modal` namespace.
+			appName: MODAL_APP_NAME,
+			// gVisor uses scalable/V2; VM deliberately omits it to preserve the #221 config.
+			...(variant === "gvisor" ? { scalableSandboxes: true } : {}),
+		}),
+		{
+			sandboxId: modalSandboxId(variant),
+			createOptions: modalCreateOptions(variant, resolvedArtifact.ref),
+			commands: {
+				exec: (sandbox, command, _options, ref) => execModalCommand(runner, sandbox, command, ref),
+				launch: (sandbox, command, _options, ref) =>
+					launchModalCommand(runner, sandbox, command, ref),
+			},
+			lifecycle: modalLifecycle(variant, runner),
+			createRecovery: modalCreateRecovery(variant, runner),
+			prepareAndVerifyCreatedRequest: (sandbox, _native, request, options, ref) =>
+				verifyModalDiskCapacity(runner, sandbox, request, options, ref),
+			// The wrapper's vendored Modal 0.7 filesystem path uses deprecated Sandbox.open,
+			// which fails for V2. Both variants use the uniform, direct-exec shell fallback.
+			hasWorkingFilesystem: false,
+			probes: modalProbes(runner),
+		},
+	);
+}
+
+/** One provider literal selects both identity and backend; invalid cross-pairs are unrepresentable. */
+export function defineModalDriver<P extends ModalProviderId>(provider: P) {
+	return defineComputeSdkDriver(provider, { spec: (context) => modalSpec(provider, context) });
+}

--- a/packages/drivers/src/e2b.test.ts
+++ b/packages/drivers/src/e2b.test.ts
@@ -557,12 +557,12 @@ describe("E2B proof driver", () => {
 			}),
 		} as unknown as ComputeSdkSandboxOf<ReturnType<typeof e2bSpec>["compute"]>;
 
-		expect(await execE2bCommandAsRoot(wrapper, "id -u", {})).toEqual({
+		expect(await execE2bCommandAsRoot(wrapper, "id -u")).toEqual({
 			exitCode: 0,
 			stdout: "0\n",
 			stderr: "",
 		});
-		expect(await launchE2bCommandAsRoot(wrapper, "daemon", {})).toBeUndefined();
+		expect(await launchE2bCommandAsRoot(wrapper, "daemon")).toBeUndefined();
 		expect(calls).toEqual([
 			["id -u", { user: "root", background: false }],
 			["daemon", { user: "root", background: true }],
@@ -574,7 +574,7 @@ describe("E2B proof driver", () => {
 		const wrapper = {
 			getInstance: () => ({ commands: { run: async () => Promise.reject(failure) } }),
 		} as unknown as Parameters<typeof execE2bCommandAsRoot>[0];
-		expect(await execE2bCommandAsRoot(wrapper, "false", {})).toEqual({
+		expect(await execE2bCommandAsRoot(wrapper, "false")).toEqual({
 			exitCode: 23,
 			stdout: "",
 			stderr: "command failed",
@@ -589,7 +589,7 @@ describe("E2B proof driver", () => {
 		const foreignWrapper = {
 			getInstance: () => ({ commands: { run: async () => Promise.reject(foreignFailure) } }),
 		} as unknown as Parameters<typeof execE2bCommandAsRoot>[0];
-		expect(await execE2bCommandAsRoot(foreignWrapper, "false", {})).toEqual({
+		expect(await execE2bCommandAsRoot(foreignWrapper, "false")).toEqual({
 			exitCode: 29,
 			stdout: "foreign stdout",
 			stderr: "foreign stderr",

--- a/packages/drivers/src/e2b.ts
+++ b/packages/drivers/src/e2b.ts
@@ -14,7 +14,6 @@ import type {
 import { type } from "arktype";
 import { AuthenticationError, InvalidArgumentError, Sandbox, SandboxNotFoundError } from "e2b";
 import type {
-	ComputeSdkCommandOptions,
 	ComputeSdkCreatedRequestVerification,
 	ComputeSdkCreateRecovery,
 	ComputeSdkCreateRequestCoverage,
@@ -84,14 +83,12 @@ function foreignCommandExit(
 export async function execE2bCommandAsRoot(
 	sandbox: E2bWrapperSandbox,
 	command: string,
-	options: ComputeSdkCommandOptions,
 ): Promise<unknown> {
 	const native = sandbox.getInstance();
 	try {
 		return await native.commands.run(command, {
 			user: "root",
 			background: false,
-			...(options.signal === undefined ? {} : { signal: options.signal }),
 		});
 	} catch (caught) {
 		const failure = foreignCommandExit(caught);
@@ -104,12 +101,10 @@ export async function execE2bCommandAsRoot(
 export async function launchE2bCommandAsRoot(
 	sandbox: E2bWrapperSandbox,
 	command: string,
-	options: ComputeSdkCommandOptions,
 ): Promise<void> {
 	const handle = await sandbox.getInstance().commands.run(command, {
 		user: "root",
 		background: true,
-		...(options.signal === undefined ? {} : { signal: options.signal }),
 	});
 	if (!Number.isSafeInteger(handle.pid) || handle.pid <= 0) {
 		throw new Error("E2B background command returned no positive process id");
@@ -226,8 +221,8 @@ export function e2bCreateRecovery(apiKey: string): ComputeSdkCreateRecovery<E2bC
 			key: E2B_ATTEMPT_METADATA_KEY,
 			value: attemptMarker(createOptions),
 		}),
-		cleanup: async (_compute, createOptions, options) => {
-			const marker = attemptMarker(createOptions);
+		cleanup: async (_compute, locator, options) => {
+			const marker = locator.value;
 			const controlOptions = {
 				apiKey,
 				requestTimeoutMs: E2B_CONTROL_PLANE_TIMEOUT_MS,

--- a/packages/drivers/src/modal-gvisor.ts
+++ b/packages/drivers/src/modal-gvisor.ts
@@ -1,0 +1,3 @@
+import { defineModalDriver } from "./_modal.ts";
+
+export default defineModalDriver("modal-gvisor");

--- a/packages/drivers/src/modal-vm.ts
+++ b/packages/drivers/src/modal-vm.ts
@@ -1,0 +1,3 @@
+import { defineModalDriver } from "./_modal.ts";
+
+export default defineModalDriver("modal-vm");


### PR DESCRIPTION
## What this adds

The Modal migration, as two variants over one shared implementation: `modal-gvisor` (V2 sandbox ids) and `modal-vm` (V1). Both bind to `_modal.ts`, so the runtime split is a driver-id concern rather than two parallel providers.

Modal is the provider that forced the bridge's remaining sharp edges into the open, so this PR also finishes two contracts on the ComputeSDK bridge below it (#390):

- `ComputeSdkCommands` receives the canonical `SandboxRef` **and** the caller's `ExecOptions`. A projection needs the ref to address the sandbox through the control plane, and the options so a per-call budget is not silently dropped on the way to the vendor.
- `prepareAndVerifyCreatedRequest` gains the same ref, so Modal's post-create disk probe runs against a bounded, canonically-addressed handle.

## Bounded control plane

Modal 0.9 declares client timeout/retry constructor fields but does not apply them at runtime, so every control-plane RPC goes through a `nice-grpc` middleware that injects the transaction signal where the SDK's chain actually consumes it. Two consequences worth reviewing deliberately:

- The middleware sets `retries: 1` rather than `0`. Modal's retry middleware drops `signal` entirely on the zero-retry path, so zero would mean uncancellable RPCs. Retrying is safe because that same middleware stamps one `x-idempotency-key` per call and replays it across attempts — and stock Modal defaults to three attempts on every unary RPC, so one is the conservative setting. This is recorded in the code comment at the call site.
- Commands run through the control plane rather than the wrapper's convenience surface, to preserve real exit status and streams. Background launch keeps the same 50ms acceptance contract as the harness fallback.

## Test note

The Modal cancellation test previously polled a fixed 200ms budget for a real gRPC handler to observe cancellation, which never settled that fast on the CI runner — it failed on this branch in CI while passing locally. It now waits on a promise the server handler resolves, so it proves the propagation property directly.

## Stack placement

Top of the stack. Lower: #394 → #395 → #396 → #397 → #387 → #389 → #390 → #402.

<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds a shared Modal driver and splits it into `modal-gvisor` and `modal-vm` variants, moving lifecycle, recovery, and post-create verification out of the wrapper and into the drivers. Tightens the compute SDK bridge with frozen recovery locators, canonical `SandboxRef` propagation to commands, bounded control-plane ops, and safer ambiguous-create teardown.

- New `modal-gvisor` (V2 ids) and `modal-vm` (V1 ids) drivers with a common implementation in `_modal.ts`.
- Control-plane calls are bounded via a `nice-grpc` middleware runner (5s), with cancellation propagated and detach-on-failure.
- Name-based recovery cleans up accepted-but-ambiguous creates; the locator is snapshotted and frozen. Invalid wrapper ids reconcile via preallocated name before rejection.
- Commands execute through the control plane to preserve real exit status/streams; background launch uses a 50ms acceptance contract. Disk capacity is verified post-create via a bounded `df` probe.
- Bridge updates: recovery locator type, frozen locators, single-read canonical id, and `verifyCreatedRequest` now receives the canonical `SandboxRef`.

**Required migrations**
- `ComputeSdkCommands` signatures now pass a `SandboxRef` and no options: exec(sandbox, command, ref), launch(sandbox, command, ref).
- `ComputeSdkLifecycle.destroy` now accepts a `recoveryLocator`; when `ref` is undefined, use this locator and do not reread wrapper ids/options.
- `ComputeSdkCreateRecovery.cleanup` now receives a frozen `locator` object; do not mutate or reread create options.
- `verifyCreatedRequest` is called as verify(sandbox, request, options, ref); avoid re-reading wrapper ids inside.
- Update E2B command helpers to drop options args. Add `nice-grpc` to dependencies if implementing external drivers.

<sup>Written for commit 51ee423a23967a37e3937113c1f8f684fafbca86. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/starslingdev/hpc-sandbox-benchmarks/pull/403?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->


