### PR TITLE
feat(results): persist authoritative Run v6 artifact provenance

### DIFF
--- a/apps/cli/src/bin/bake.ts
+++ b/apps/cli/src/bin/bake.ts
@@ -26,7 +26,11 @@ import {
 	nonBakedArtifactAction,
 } from "../lib/bake/provider-artifacts.ts";
 import type { BakeReport, Log } from "../lib/bake/types.ts";
-import { baseImageUse, candidateCreateOptions } from "../lib/bake/validate.ts";
+import {
+	baseImageUse,
+	candidateCreateOptions,
+	candidateResolvedArtifact,
+} from "../lib/bake/validate.ts";
 import { isPartialScope, selectProviders } from "../lib/matrix.ts";
 import { anyFailed, forEachProviderWithCreds } from "../lib/providers-run.ts";
 import { bootAndSmoke, logChecks, smokeFailureReason, smokeOk } from "../lib/smoke-run.ts";
@@ -222,6 +226,7 @@ if (import.meta.main) {
 			// Boot the just-baked candidate (override the registry adapter's version create-options).
 			const validateConfig: ProviderConfig = {
 				...provider,
+				artifact: candidateResolvedArtifact(provider.name, candidateRefs),
 				createOptions: {
 					...provider.createOptions,
 					...candidateCreateOptions(provider.name, candidateRefs),

--- a/apps/cli/src/lib/bake/validate-run.ts
+++ b/apps/cli/src/lib/bake/validate-run.ts
@@ -11,7 +11,7 @@ import type { SmokeOutcome } from "../smoke-run.ts";
 import { bootAndSmoke, logChecks, smokeFailureReason, smokeOk } from "../smoke-run.ts";
 import type { Log } from "./types.ts";
 import type { CandidateRefs } from "./validate.ts";
-import { candidateCreateOptions } from "./validate.ts";
+import { candidateCreateOptions, candidateResolvedArtifact } from "./validate.ts";
 
 /** Validate every provider's candidate artifact (boot + smoke), sharing the skip-vs-fail contract. A
  *  provider with no creds skips; one that boots and fails its smoke is `failed`. Never throws.
@@ -28,6 +28,7 @@ export function validateCandidates(
 			// Boot the candidate artifact (override the registry adapter's version create-options).
 			const validateConfig: ProviderConfig = {
 				...provider,
+				artifact: candidateResolvedArtifact(provider.name, refs),
 				createOptions: {
 					...provider.createOptions,
 					...candidateCreateOptions(provider.name, refs),

--- a/apps/cli/src/lib/bake/validate.test.ts
+++ b/apps/cli/src/lib/bake/validate.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from "bun:test";
 import { PROVIDERS } from "@sandbox-benchmarks/schema";
 import type { CandidateRefs } from "./validate.ts";
-import { baseImageUse, candidateCreateOptions } from "./validate.ts";
+import { baseImageUse, candidateCreateOptions, candidateResolvedArtifact } from "./validate.ts";
 
 const refs: CandidateRefs = {
 	e2bTemplateCandidate: "tc-v1-candidate",
@@ -17,6 +17,16 @@ const refs: CandidateRefs = {
 };
 
 describe("candidateCreateOptions", () => {
+	it("keeps every candidate's recorded artifact adjacent to its actual boot override", () => {
+		for (const provider of PROVIDERS) {
+			const artifact = candidateResolvedArtifact(provider.id, refs);
+			expect(artifact.kind).toBe(provider.artifact.kind);
+			if (artifact.kind !== "none") {
+				expect(JSON.stringify(candidateCreateOptions(provider.id, refs))).toContain(artifact.ref);
+			}
+		}
+	});
+
 	it("points e2b at the candidate template via snapshotId", () => {
 		expect(candidateCreateOptions("e2b", refs)).toEqual({ snapshotId: "tc-v1-candidate" });
 	});

--- a/apps/cli/src/lib/bake/validate.ts
+++ b/apps/cli/src/lib/bake/validate.ts
@@ -2,6 +2,7 @@
 // bake can validate exactly what it just built (not the public version). Kept pure + injectable so
 // it's unit-testable without the env-backed config.
 import type { ProviderId } from "@sandbox-benchmarks/schema";
+import type { DriverResolvedArtifact } from "@sandbox-benchmarks/schema/driver-schemas";
 
 export { baseImageUse } from "@sandbox-benchmarks/schema/provider-artifacts";
 
@@ -24,55 +25,93 @@ export interface CandidateRefs {
 	daytonaContainerTarget?: string;
 }
 
+interface CandidateLaunch {
+	artifact: DriverResolvedArtifact;
+	createOptions: Record<string, unknown>;
+}
+
+/** One authoritative candidate projection: the boot override and the identity it selects. */
+function candidateLaunch(id: ProviderId, refs: CandidateRefs): CandidateLaunch {
+	switch (id) {
+		case "e2b":
+			// computesdk maps snapshotId → the e2b template id/name.
+			return {
+				artifact: { kind: "baked", ref: refs.e2bTemplateCandidate },
+				createOptions: { snapshotId: refs.e2bTemplateCandidate },
+			};
+		case "daytona-vm":
+			return {
+				artifact: { kind: "baked", ref: refs.daytonaSnapshotCandidate },
+				createOptions: {
+					snapshotId: refs.daytonaSnapshotCandidate,
+					...(refs.daytonaVmTarget ? { target: refs.daytonaVmTarget } : {}),
+				},
+			};
+		case "daytona-container":
+			return {
+				artifact: { kind: "baked", ref: refs.daytonaContainerSnapshotCandidate },
+				createOptions: {
+					snapshotId: refs.daytonaContainerSnapshotCandidate,
+					...(refs.daytonaContainerTarget ? { target: refs.daytonaContainerTarget } : {}),
+				},
+			};
+		case "modal-gvisor":
+		case "modal-vm":
+		// Same candidate image as modal-gvisor; the VM runtime is selected by the adapter's base
+		// createOptions (experimentalOptions:{vm_runtime:true}), which validate-run.ts preserves
+		// through the spread — so this candidate override, like modal-gvisor's, is only the templateId.
+		case "microsandbox-local":
+		case "microsandbox-cloud":
+			// Both backends consume the same OCI image reference; only their SDK backend differs.
+			return {
+				artifact: { kind: "image", ref: refs.toolchainImageCandidate },
+				createOptions: { templateId: refs.toolchainImageCandidate },
+			};
+		case "blaxel":
+			// Stock base image — no candidate artifact to point at.
+			return { artifact: { kind: "none" }, createOptions: {} };
+		case "novita":
+			// Same mapping as e2b (snapshotId → template name), against Novita's control plane.
+			return {
+				artifact: { kind: "baked", ref: refs.novitaTemplateCandidate },
+				createOptions: { snapshotId: refs.novitaTemplateCandidate },
+			};
+		case "runloop":
+			return {
+				artifact: { kind: "baked", ref: refs.runloopBlueprintCandidate },
+				createOptions: { blueprint_name: refs.runloopBlueprintCandidate },
+			};
+		case "namespace":
+		// No template/snapshot system — points create() at the candidate image directly, same as modal.
+		case "runcloud":
+		// The native SDK boots an arbitrary OCI image directly; there is no template to bake.
+		case "tama":
+			// `tama new --image` pulls an arbitrary OCI ref at create time, so the candidate boots the same
+			// way the published version does; there is no provider-side artifact.
+			return {
+				artifact: { kind: "image", ref: refs.toolchainImageCandidate },
+				createOptions: { image: refs.toolchainImageCandidate },
+			};
+		case "vercel":
+			return {
+				artifact: { kind: "mirror", ref: refs.vercelImageCandidate },
+				createOptions: { templateId: refs.vercelImageCandidate },
+			};
+	}
+}
+
 /** Create-options overrides that point a provider at its candidate artifact for the validate boot. */
 export function candidateCreateOptions(
 	id: ProviderId,
 	refs: CandidateRefs,
 ): Record<string, unknown> {
-	switch (id) {
-		case "e2b":
-			// computesdk maps snapshotId → the e2b template id/name.
-			return { snapshotId: refs.e2bTemplateCandidate };
-		case "daytona-vm":
-			return {
-				snapshotId: refs.daytonaSnapshotCandidate,
-				...(refs.daytonaVmTarget ? { target: refs.daytonaVmTarget } : {}),
-			};
-		case "daytona-container":
-			return {
-				snapshotId: refs.daytonaContainerSnapshotCandidate,
-				...(refs.daytonaContainerTarget ? { target: refs.daytonaContainerTarget } : {}),
-			};
-		case "modal-gvisor":
-			return { templateId: refs.toolchainImageCandidate };
-		case "modal-vm":
-			// Same candidate image as modal-gvisor; the VM runtime is selected by the adapter's base
-			// createOptions (experimentalOptions:{vm_runtime:true}), which validate-run.ts preserves
-			// through the spread — so this candidate override, like modal-gvisor's, is only the templateId.
-			return { templateId: refs.toolchainImageCandidate };
-		case "microsandbox-local":
-		case "microsandbox-cloud":
-			// Both backends consume the same OCI image reference; only their SDK backend differs.
-			return { templateId: refs.toolchainImageCandidate };
-		case "blaxel":
-			// Stock base image — no candidate artifact to point at.
-			return {};
-		case "novita":
-			// Same mapping as e2b (snapshotId → template name), against Novita's control plane.
-			return { snapshotId: refs.novitaTemplateCandidate };
-		case "runloop":
-			return { blueprint_name: refs.runloopBlueprintCandidate };
-		case "namespace":
-			// No template/snapshot system — points create() at the candidate image directly, same as modal.
-			return { image: refs.toolchainImageCandidate };
-		case "runcloud":
-			// The native SDK boots an arbitrary OCI image directly; there is no template to bake.
-			return { image: refs.toolchainImageCandidate };
-		case "tama":
-			// `tama new --image` pulls an arbitrary OCI ref at create time, so the candidate boots the same
-			// way the published version does; there is no provider-side artifact.
-			return { image: refs.toolchainImageCandidate };
-		case "vercel":
-			return { templateId: refs.vercelImageCandidate };
-	}
+	return candidateLaunch(id, refs).createOptions;
+}
+
+/** The exact artifact selected by {@link candidateCreateOptions}, from the same projection. */
+export function candidateResolvedArtifact(
+	id: ProviderId,
+	refs: CandidateRefs,
+): DriverResolvedArtifact {
+	return candidateLaunch(id, refs).artifact;
 }

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -4,7 +4,7 @@ How the repository itself is put together: the workspace, its enforced boundarie
 contract, and the gates that hold them. For how a *measurement* is produced, see
 [methodology](./methodology.md).
 
-## Provider cost evidence (Run v5)
+## Provider sandbox evidence (Run v5 and v6)
 
 The provider adapter owns billing API interaction. After the harness attempts and awaits sandbox
 teardown, its optional hook returns one validated sandbox-scoped observed/missing record. The harness
@@ -14,6 +14,16 @@ Historical v2-v4 documents remain unchanged and cannot carry evidence.
 The sandbox collection archive cannot supply that reserved filename: collection rejects it before
 copying any entry, and only the post-teardown host writer may create it. Schema validation establishes a
 bounded, structurally valid provider-observed record; it does not authenticate the provider response.
+
+Run v6 adds one host-owned `provider-artifact-evidence.json` per benchmark cell. The provider adapter
+records the exact artifact adjacent to the create options that boot it, and the harness writes that
+request fallback before its first sandbox operation. For a canonical release artifact, the harness
+then reads the bounded `/toolchain-manifest.json` from the ready guest and atomically upgrades the
+record to `guest-fingerprint`. The expected image name/version is never supplied by the producer: the
+schema derives it from release constants plus the provider's canonical artifact mapping and rejects a
+stale manifest. Arbitrary overrides remain honest request fallbacks. Collection reserves both evidence
+filenames, normalization binds the record to its run/provider/suite/replicate cell, and aggregation
+rejects conflicts, sandbox reuse, or a mixture of v6 and older shards that could drop attribution.
 
 ## The repository
 
@@ -80,9 +90,9 @@ bun apps/cli/src/bin/driver-check.ts --provider tama --phase candidate --workloa
 
 It runs create → readiness → exec (including the exit-7 and split-stream clauses) → a filesystem
 round-trip → a real workload on BOTH transports → destroy → idempotent destroy → control-plane
-convergence, then prints a JSON report. It writes **no Run document**: persisting a driver-path run
-needs the artifact-provenance fields the Run schema does not carry yet, and a v5 document from this
-path would publish a measurement whose artifact attribution cannot be verified.
+convergence, then prints a JSON conformance report. It writes **no Run document** because it is a
+contract check, not a benchmark measurement; the benchmark harness is the Run v6 artifact-evidence
+producer.
 
 The durable step is the point of the lane. `--workload-seconds` runs a real command past the
 module's declared `syncCapMs`, which forces `StepRunner` onto the detached transport and proves the

--- a/docs/methodology.md
+++ b/docs/methodology.md
@@ -151,6 +151,15 @@ all records must be observed, cell-unique, sandbox-unique, and use one currency.
 resource-usage RPC is private and is not called. run.cloud records `not_sandbox_scoped`: its public
 usage API is organization-wide cumulative usage and is not called or delta-attributed to one sandbox.
 
+Run v6 separately retains `artifactEvidence` for every benchmark sandbox cell. The host writes the
+requested provider artifact before probing the sandbox. Canonical release refs are upgraded to
+`guest-fingerprint` only after the running guest reports the expected toolchain manifest; the schema,
+not the producer, derives that expectation from the provider/artifact mapping and release constants.
+Thus matching producer-supplied claims cannot manufacture verification, a stale manifest fails before
+benchmarking, and a noncanonical override remains visible as `request-fallback` rather than being
+silently treated as verified. The record carries run, provider, suite, replicate, and sandbox identity
+through normalization and aggregation.
+
 Allowances remain metadata, never headline discounts: Daytona's first 5 GiB is a **per-sandbox disk
 allowance**, not free memory, and monthly pools cannot establish the intrinsic cost of one sandbox
 hour. Disk rates and allowances are retained where published but excluded from economics because disk

--- a/packages/harness/src/index.test.ts
+++ b/packages/harness/src/index.test.ts
@@ -5,7 +5,12 @@ import { join } from "node:path";
 import type { DirectProvider, ProviderConfig } from "@sandbox-benchmarks/providers";
 import { markRetryableCreate } from "@sandbox-benchmarks/providers";
 import type { ProviderCostEvidence, Suite } from "@sandbox-benchmarks/schema";
-import { parseGapMarker, sandboxFailureMarkerFile } from "@sandbox-benchmarks/schema";
+import {
+	bakedArtifactName,
+	parseGapMarker,
+	parseProviderArtifactEvidence,
+	sandboxFailureMarkerFile,
+} from "@sandbox-benchmarks/schema";
 import type { SuiteRunContext } from "./index.ts";
 import {
 	benchmarkLifecycle,
@@ -33,6 +38,7 @@ const fixtureTransport = { streaming: false, syncCapMs: 60_000, detachedPoll: tr
 // test free of any real SDK while staying fully typed.
 const config: ProviderConfig = {
 	name: "e2b",
+	artifact: { kind: "baked", ref: "test-template" },
 	requiredEnvVars: [],
 	transport: fixtureTransport,
 	createCompute: () => {
@@ -70,6 +76,7 @@ function fakeProvider(calls: string[], opts: { destroyFails?: boolean } = {}): P
 	} as unknown as DirectProvider;
 	return {
 		name: "e2b",
+		artifact: { kind: "baked", ref: "test-template" },
 		requiredEnvVars: [],
 		transport: fixtureTransport,
 		createCompute: () => compute,
@@ -135,6 +142,7 @@ describe("@sandbox-benchmarks/harness", () => {
 	// modal-named config.
 	const credsCfg: ProviderConfig = {
 		name: "modal-gvisor",
+		artifact: { kind: "image", ref: "test-image" },
 		requiredEnvVars: ["A", "B"],
 		transport: { streaming: false, syncCapMs: null, detachedPoll: true },
 		createCompute: () => {
@@ -201,6 +209,7 @@ describe("@sandbox-benchmarks/harness", () => {
 		}
 		return {
 			name: "e2b",
+			artifact: { kind: "baked", ref: "test-template" },
 			requiredEnvVars: [],
 			transport: fixtureTransport,
 			createCompute: () => compute as unknown as DirectProvider,
@@ -317,6 +326,8 @@ function makeSandbox(opts: {
 	benchmarkFails?: boolean;
 	collectFails?: boolean;
 	collectFiles?: Record<string, string>;
+	/** Contents returned for the release-owned manifest probe. */
+	manifest?: string;
 	/** Never answer the readiness probe — a sandbox whose image never finishes pulling. */
 	neverReady?: boolean;
 	destroyed: { hit: boolean };
@@ -324,6 +335,11 @@ function makeSandbox(opts: {
 	// Results of detached steps, keyed by their /tmp/<tag> so the cat-polls can read them back.
 	const detached = new Map<string, { exit: number; out: string }>();
 	const resultFor = (command: string): CommandResult => {
+		if (command.includes("/toolchain-manifest.json")) {
+			return opts.manifest === undefined
+				? { exitCode: 1, stderr: "manifest missing" }
+				: { exitCode: 0, stdout: opts.manifest };
+		}
 		if (command.includes("df -Pk")) return { exitCode: 0, stdout: opts.freeKb ?? "999999999" };
 		if (command.includes("base64")) {
 			if (opts.collectFails) return { exitCode: 1, stderr: "collect boom" };
@@ -384,6 +400,7 @@ const suite = (overrides: Partial<Suite>): Suite => ({
 
 const ctx = (s: Suite, resultsDir: string): SuiteRunContext => ({
 	runId: "run-test-1",
+	artifact: { kind: "baked", ref: "test-template" },
 	suite: s,
 	suiteName: "cpu-node",
 	providerName: "daytona-vm",
@@ -748,6 +765,85 @@ describe("createSuiteSandbox (creation-failure marker)", () => {
 });
 
 describe("runSuiteOnSandbox (orchestration + teardown)", () => {
+	it("persists the honest requested-artifact fallback before touching the sandbox", async () => {
+		const resultsDir = freshDir();
+		const destroyed = { hit: false };
+		await expect(
+			runSuiteOnSandbox(makeSandbox({ destroyed, neverReady: true }), {
+				...ctx(suite({}), resultsDir),
+				readiness: {
+					maxAttempts: 1,
+					retryDelayMs: 0,
+					probeTimeoutMs: 5,
+					delay: () => Promise.resolve(),
+				},
+			}),
+		).rejects.toThrow(/never ready/);
+		const evidence = parseProviderArtifactEvidence(
+			readFileSync(join(resultsDir, "provider-artifact-evidence.json"), "utf8"),
+		);
+		expect(evidence).toEqual({
+			cell: { runId: "run-test-1", providerId: "daytona-vm", suite: "cpu-node" },
+			sandboxId: "sb-test-1",
+			provenance: {
+				source: "request-fallback",
+				requested: { kind: "baked", ref: "test-template" },
+			},
+		});
+		expect(destroyed.hit).toBe(true);
+	});
+
+	it("upgrades a canonical release artifact only after the guest manifest matches", async () => {
+		const resultsDir = freshDir();
+		const artifact = { kind: "baked", ref: bakedArtifactName("daytona-vm", "version") } as const;
+		await runSuiteOnSandbox(
+			makeSandbox({
+				destroyed: { hit: false },
+				manifest: JSON.stringify({
+					image_name: "sandbox-benchmarks-toolchain",
+					image_version: "v8",
+				}),
+			}),
+			{ ...ctx(suite({}), resultsDir), artifact },
+		);
+		const evidence = parseProviderArtifactEvidence(
+			readFileSync(join(resultsDir, "provider-artifact-evidence.json"), "utf8"),
+		);
+		expect(evidence.provenance).toEqual({
+			source: "guest-fingerprint",
+			requested: artifact,
+			fingerprint: {
+				authority: "toolchain-manifest-v1",
+				imageName: "sandbox-benchmarks-toolchain",
+				imageVersion: "v8",
+			},
+		});
+	});
+
+	it("fails before benchmarking when a canonical artifact carries a stale guest manifest", async () => {
+		const resultsDir = freshDir();
+		const destroyed = { hit: false };
+		const artifact = { kind: "baked", ref: bakedArtifactName("daytona-vm", "version") } as const;
+		await expect(
+			runSuiteOnSandbox(
+				makeSandbox({
+					destroyed,
+					manifest: JSON.stringify({
+						image_name: "sandbox-benchmarks-toolchain",
+						image_version: "v7",
+					}),
+				}),
+				{ ...ctx(suite({}), resultsDir), artifact },
+			),
+		).rejects.toThrow(/matching sandbox-benchmarks-toolchain@v8/);
+		const evidence = parseProviderArtifactEvidence(
+			readFileSync(join(resultsDir, "provider-artifact-evidence.json"), "utf8"),
+		);
+		expect(evidence.provenance.source).toBe("request-fallback");
+		expect(destroyed.hit).toBe(true);
+		expect(existsSync(join(resultsDir, "pts_node-web-tooling.xml"))).toBe(false);
+	});
+
 	it("captures and persists provider evidence strictly after confirmed teardown", async () => {
 		const resultsDir = freshDir();
 		const destroyed = { hit: false };
@@ -761,6 +857,7 @@ describe("runSuiteOnSandbox (orchestration + teardown)", () => {
 		await runSuiteOnSandbox(sandbox, {
 			...ctx(suite({ minDiskGb: 50 }), resultsDir),
 			providerName: "modal-gvisor",
+			artifact: { kind: "image", ref: "test-image" },
 			costEvidence: {
 				sdk: { packageName: "modal", version: "0.7.6" },
 				captureAfterTeardown: async (input) => {
@@ -794,6 +891,7 @@ describe("runSuiteOnSandbox (orchestration + teardown)", () => {
 			await runSuiteOnSandbox(sandbox, {
 				...ctx(suite({ minDiskGb: 50 }), resultsDir),
 				providerName: "modal-gvisor",
+				artifact: { kind: "image", ref: "test-image" },
 				costEvidence: {
 					sdk: { packageName: "modal", version: "0.7.6" },
 					captureAfterTeardown: async (input) => ({
@@ -833,6 +931,7 @@ describe("runSuiteOnSandbox (orchestration + teardown)", () => {
 		await runSuiteOnSandbox(makeSandbox({ destroyed: { hit: false }, freeKb: "1" }), {
 			...ctx(suite({ minDiskGb: 50 }), resultsDir),
 			providerName: "modal-gvisor",
+			artifact: { kind: "image", ref: "test-image" },
 			costEvidence: {
 				sdk: { packageName: "modal", version: "0.7.6" },
 				captureAfterTeardown: async () => {
@@ -856,6 +955,7 @@ describe("runSuiteOnSandbox (orchestration + teardown)", () => {
 		await runSuiteOnSandbox(makeSandbox({ destroyed: { hit: false }, freeKb: "1" }), {
 			...ctx(suite({ minDiskGb: 50 }), resultsDir),
 			providerName: "modal-gvisor",
+			artifact: { kind: "image", ref: "test-image" },
 			costEvidence: {
 				sdk: { packageName: "modal", version: "0.7.6" },
 				captureAfterTeardown: async (input) => ({
@@ -915,6 +1015,7 @@ describe("runSuiteOnSandbox (orchestration + teardown)", () => {
 			await runSuiteOnSandbox(makeSandbox({ destroyed: { hit: false }, freeKb: "1" }), {
 				...ctx(suite({ minDiskGb: 50 }), resultsDir),
 				providerName: "modal-gvisor",
+				artifact: { kind: "image", ref: "test-image" },
 				costEvidence: {
 					sdk: { packageName: "modal", version: "0.7.6" },
 					captureAfterTeardown: async (input) => {

--- a/packages/harness/src/index.ts
+++ b/packages/harness/src/index.ts
@@ -14,6 +14,8 @@ import {
 	sanitizeProviderResponse,
 } from "@sandbox-benchmarks/providers";
 import type {
+	GuestFingerprint,
+	ProviderArtifactEvidence,
 	ProviderCostCell,
 	ProviderCostEvidence,
 	ProviderTransport,
@@ -26,6 +28,7 @@ import type {
 import {
 	canonicalJsonEqual,
 	canonicalJsonString,
+	expectedToolchainFingerprint,
 	HARNESS_METRIC_IDS,
 	isPtsResultFile,
 	PROVIDER_EVIDENCE_JSON_LIMITS,
@@ -33,7 +36,13 @@ import {
 	SUITE_NAMES,
 	SUITES,
 } from "@sandbox-benchmarks/schema";
-import { collectResults, writeGapMarker, writeProviderCostEvidence } from "./lib/collect.ts";
+import type { DriverResolvedArtifact } from "@sandbox-benchmarks/schema/driver-schemas";
+import {
+	collectResults,
+	writeGapMarker,
+	writeProviderArtifactEvidence,
+	writeProviderCostEvidence,
+} from "./lib/collect.ts";
 import type { SandboxHandle } from "./lib/execute.ts";
 import { MIN, resolvePtsPassPolicy, StepRunner, withTimeout } from "./lib/execute.ts";
 import { gapCauseOf } from "./lib/gap-cause.ts";
@@ -287,6 +296,7 @@ export async function runSuite(options: RunSuiteOptions): Promise<void> {
 		suite,
 		suiteName: knownSuiteName,
 		providerName: config.name,
+		artifact: config.artifact,
 		resultsDir,
 		transport: config.transport,
 		costEvidence: config.costEvidence,
@@ -504,6 +514,8 @@ export interface SuiteRunContext {
 	suite: Suite;
 	suiteName: SuiteName;
 	providerName: ProviderConfig["name"];
+	/** Exact create input the adjacent provider adapter booted. */
+	artifact: DriverResolvedArtifact;
 	resultsDir: string;
 	/** The provider's exec transport capability — drives the per-step sync/detached choice. */
 	transport: ProviderTransport;
@@ -516,6 +528,29 @@ export interface SuiteRunContext {
 function sanitizeHookResponseJson(value: unknown): string {
 	if (typeof value !== "string") throw new Error("provider responseJson must be a JSON string");
 	return sanitizeProviderResponse(JSON.parse(value));
+}
+
+/** Parse only the two release-owned identity fields from the bounded in-guest manifest. */
+function manifestFingerprint(data: string): GuestFingerprint {
+	let value: unknown;
+	try {
+		value = JSON.parse(data);
+	} catch {
+		throw new Error("Toolchain manifest is not valid JSON");
+	}
+	if (value === null || typeof value !== "object" || Array.isArray(value)) {
+		throw new Error("Toolchain manifest must be an object");
+	}
+	const imageName = Object.getOwnPropertyDescriptor(value, "image_name")?.value;
+	const imageVersion = Object.getOwnPropertyDescriptor(value, "image_version")?.value;
+	if (typeof imageName !== "string" || typeof imageVersion !== "string") {
+		throw new Error("Toolchain manifest is missing string image_name/image_version fields");
+	}
+	return {
+		authority: "toolchain-manifest-v1",
+		imageName,
+		imageVersion,
+	};
 }
 
 /**
@@ -537,6 +572,24 @@ export async function runSuiteOnSandbox(
 	let evidencePersistenceError: unknown;
 	let suiteSkipped = false;
 	try {
+		if (sandboxId === undefined) {
+			throw new Error("Sandbox id is unavailable; artifact attribution cannot be persisted");
+		}
+		const artifactCell: ProviderCostCell = {
+			runId: ctx.runId,
+			providerId: providerName,
+			suite: suiteName,
+			...(ctx.replicateIndex !== undefined ? { replicateIndex: ctx.replicateIndex } : {}),
+		};
+		const fallbackEvidence: ProviderArtifactEvidence = {
+			cell: artifactCell,
+			sandboxId,
+			provenance: { source: "request-fallback", requested: ctx.artifact },
+		};
+		// Persist the honest floor before the first sandbox operation. If readiness or fingerprinting
+		// fails, the raw tree still says what was requested without upgrading it to an observation.
+		writeProviderArtifactEvidence(resultsDir, fallbackEvidence);
+
 		// Resolve the PTS pass policy from the suite's own default (converge on cpu-node + memory; a fixed
 		// count on every other suite) and the BENCH_PTS_PASSES override. Constructed inside the
 		// try so a bad policy (buildPreamble rejects a fixed k < 1) is still torn down by the finally below;
@@ -552,6 +605,26 @@ export async function runSuiteOnSandbox(
 		// nothing to do with disk. Pre-baked providers answer the first probe and pay one round-trip.
 		const readiness = await waitUntilReady(sandbox, ctx.readiness ?? SUITE_READINESS);
 		if (!readiness.ready) throw new Error(neverReadyReason(readiness.attempts));
+		const expectedFingerprint = expectedToolchainFingerprint(providerName, ctx.artifact);
+		if (expectedFingerprint !== undefined) {
+			const captured = await runner.run(
+				"capture artifact fingerprint",
+				'test "$(wc -c < /toolchain-manifest.json)" -le 16384 && cat /toolchain-manifest.json',
+				MIN,
+			);
+			const fingerprint = manifestFingerprint(captured.stdout ?? "");
+			// The raw writer validates this observation against the release-owned provider/artifact mapping.
+			// A stale manifest fails before any benchmark number can be attributed to the wrong toolchain.
+			writeProviderArtifactEvidence(resultsDir, {
+				cell: artifactCell,
+				sandboxId,
+				provenance: {
+					source: "guest-fingerprint",
+					requested: ctx.artifact,
+					fingerprint,
+				},
+			});
+		}
 		if (suite.minDiskGb) {
 			// Measure free space where the disk-heavy suites actually write, not the sandbox root. The
 			// heavy PTS data (realworld clones/builds, pgbench cluster, fio test files, installed-tests)

--- a/packages/harness/src/lib/collect.test.ts
+++ b/packages/harness/src/lib/collect.test.ts
@@ -13,7 +13,12 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import type { ProviderTransport } from "@sandbox-benchmarks/schema";
 import { harnessGapMarkerJson } from "@sandbox-benchmarks/schema";
-import { collectResults, writeGapMarker, writeProviderCostEvidence } from "./collect.ts";
+import {
+	collectResults,
+	writeGapMarker,
+	writeProviderArtifactEvidence,
+	writeProviderCostEvidence,
+} from "./collect.ts";
 import type { SandboxHandle } from "./execute.ts";
 import { MIN, StepRunner } from "./execute.ts";
 
@@ -106,6 +111,19 @@ describe("collectResults", () => {
 			/reserved host-owned file provider-cost-evidence\.json/,
 		);
 		expect(existsSync(join(resultsDir, "provider-cost-evidence.json"))).toBe(false);
+		expect(existsSync(join(resultsDir, "pts_node-web-tooling.xml"))).toBe(false);
+	});
+
+	it("rejects forged sandbox artifact evidence before it can replace host attribution", async () => {
+		const resultsDir = join(work, "forged-artifact-evidence");
+		const forged = payloadSandbox({
+			"pts_node-web-tooling.xml": "<xml/>",
+			"provider-artifact-evidence.json": '{"provenance":{"source":"guest-fingerprint"}}',
+		});
+		await expect(collectResults(new StepRunner(forged, UNCAPPED), resultsDir)).rejects.toThrow(
+			/reserved host-owned file provider-artifact-evidence\.json/,
+		);
+		expect(existsSync(join(resultsDir, "provider-artifact-evidence.json"))).toBe(false);
 		expect(existsSync(join(resultsDir, "pts_node-web-tooling.xml"))).toBe(false);
 	});
 
@@ -278,6 +296,25 @@ describe("collectResults", () => {
 });
 
 describe("writeGapMarker", () => {
+	it("atomically writes validated provider artifact evidence bytes", () => {
+		const dir = join(work, "artifact-evidence");
+		writeProviderArtifactEvidence(dir, {
+			cell: { runId: "run-1", providerId: "e2b", suite: "cpu-node" },
+			sandboxId: "sb-1",
+			provenance: {
+				source: "request-fallback",
+				requested: { kind: "baked", ref: "sandbox-benchmarks-toolchain-v8" },
+			},
+		});
+		const path = join(dir, "provider-artifact-evidence.json");
+		expect(readFileSync(path, "utf8").endsWith("\n")).toBe(true);
+		expect(JSON.parse(readFileSync(path, "utf8"))).toMatchObject({
+			cell: { runId: "run-1", providerId: "e2b", suite: "cpu-node" },
+			provenance: { source: "request-fallback" },
+		});
+		expect(readdirSync(dir).filter((name) => name.endsWith(".tmp"))).toEqual([]);
+	});
+
 	it("atomically writes validated provider cost evidence bytes", () => {
 		const dir = join(work, "cost-evidence");
 		writeProviderCostEvidence(dir, {

--- a/packages/harness/src/lib/collect.ts
+++ b/packages/harness/src/lib/collect.ts
@@ -9,11 +9,18 @@ import { mkdirSync, readdirSync, renameSync, rmSync, writeFileSync } from "node:
 import { cp, mkdir, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join, resolve } from "node:path";
-import type { GapCause, GapOutcome, ProviderCostEvidence } from "@sandbox-benchmarks/schema";
+import type {
+	GapCause,
+	GapOutcome,
+	ProviderArtifactEvidence,
+	ProviderCostEvidence,
+} from "@sandbox-benchmarks/schema";
 import {
 	harnessGapMarkerJson,
 	isGapMarkerFile,
 	isPtsResultFile,
+	providerArtifactEvidenceFile,
+	providerArtifactEvidenceJson,
 	providerCostEvidenceFile,
 	providerCostEvidenceJson,
 	sandboxGapMarkerFile,
@@ -30,17 +37,33 @@ const RESULTS_END = "__BENCH_RESULTS_TGZ_END__";
  *  re-running the whole step is safe and beats throwing finished results away. */
 const COLLECT_MAX_ATTEMPTS = 3;
 
-/** Validate and atomically persist the one provider cost record owned by this suite sandbox. */
-export function writeProviderCostEvidence(resultsDir: string, record: ProviderCostEvidence): void {
+function writeHostEvidence(resultsDir: string, filename: string, contents: string): void {
 	mkdirSync(resultsDir, { recursive: true });
-	const target = join(resultsDir, providerCostEvidenceFile());
+	const target = join(resultsDir, filename);
 	const temporary = `${target}.${process.pid}.${randomUUID()}.tmp`;
 	try {
-		writeFileSync(temporary, providerCostEvidenceJson(record));
+		writeFileSync(temporary, contents);
 		renameSync(temporary, target);
 	} finally {
 		rmSync(temporary, { force: true });
 	}
+}
+
+/** Validate and atomically persist the artifact attribution owned by this suite sandbox. */
+export function writeProviderArtifactEvidence(
+	resultsDir: string,
+	record: ProviderArtifactEvidence,
+): void {
+	writeHostEvidence(
+		resultsDir,
+		providerArtifactEvidenceFile(),
+		providerArtifactEvidenceJson(record),
+	);
+}
+
+/** Validate and atomically persist the one provider cost record owned by this suite sandbox. */
+export function writeProviderCostEvidence(resultsDir: string, record: ProviderCostEvidence): void {
+	writeHostEvidence(resultsDir, providerCostEvidenceFile(), providerCostEvidenceJson(record));
 }
 
 /** The in-sandbox collect command: emit a marker-bounded, newline-stripped base64 tar of
@@ -216,9 +239,12 @@ async function decodeAndExtract(base64: string, resultsDir: string): Promise<num
 /** Evidence is host-owned provenance. A sandbox may not forge it into its collected archive. */
 function assertNoReservedEvidenceFile(directory: string): void {
 	for (const entry of readdirSync(directory, { withFileTypes: true })) {
-		if (entry.name === providerCostEvidenceFile()) {
+		if (
+			entry.name === providerCostEvidenceFile() ||
+			entry.name === providerArtifactEvidenceFile()
+		) {
 			throw new ReservedCollectedFileError(
-				`Collected sandbox results contain reserved host-owned file ${providerCostEvidenceFile()}`,
+				`Collected sandbox results contain reserved host-owned file ${entry.name}`,
 			);
 		}
 		if (entry.isSymbolicLink()) {

--- a/packages/providers/src/index.test.ts
+++ b/packages/providers/src/index.test.ts
@@ -37,6 +37,25 @@ describe("@sandbox-benchmarks/providers", () => {
 		}
 	});
 
+	it("carries the exact boot artifact beside each legacy create policy", () => {
+		expect(providers.length).toBe(PROVIDERS.length);
+		for (let i = 0; i < providers.length; i++) {
+			expect(providers[i]?.artifact.kind).toBe(PROVIDERS[i]?.artifact.kind);
+		}
+		expect(providers.find((provider) => provider.name === "e2b")?.artifact).toEqual({
+			kind: "baked",
+			ref: config.e2bTemplate,
+		});
+		expect(providers.find((provider) => provider.name === "namespace")?.artifact).toEqual({
+			kind: "image",
+			ref: config.toolchainImage,
+		});
+		expect(providers.find((provider) => provider.name === "vercel")?.artifact).toEqual({
+			kind: "mirror",
+			ref: config.vercelImage,
+		});
+	});
+
 	it("pins both Modal variants' create-time spec from the shared TARGET_SPEC", () => {
 		const gvisor = providers.find((p) => p.name === "modal-gvisor");
 		const vm = providers.find((p) => p.name === "modal-vm");

--- a/packages/providers/src/lib/adapters.ts
+++ b/packages/providers/src/lib/adapters.ts
@@ -40,6 +40,7 @@ import { vercelCompute } from "./vercel.ts";
  */
 function daytonaAdapter(cfg: DaytonaConfig): ProviderAdapter {
 	return {
+		artifact: { kind: "baked", ref: cfg.snapshot },
 		createCompute: () => daytonaClientTarget(daytona({ apiKey: cfg.apiKey }), cfg.target),
 		createOptions: {
 			snapshotId: cfg.snapshot,
@@ -127,6 +128,7 @@ export const adapters: Record<ProviderId, ProviderAdapter> = {
 	// E2B SDK's root user keeps apt fallbacks, PTS config, and the root-baked registry on one runtime
 	// identity; ComputeSDK does not expose that native command option, so patch this instance.
 	e2b: {
+		artifact: { kind: "baked", ref: config.e2bTemplate },
 		createCompute: () => e2bCommandsAsRoot(e2b({})),
 		createOptions: { snapshotId: config.e2bTemplate },
 	},
@@ -135,6 +137,7 @@ export const adapters: Record<ProviderId, ProviderAdapter> = {
 	"daytona-vm": daytonaAdapter(config.daytonaVm),
 	"daytona-container": daytonaAdapter(config.daytonaContainer),
 	blaxel: {
+		artifact: { kind: "none" },
 		// Credentials come from BL_API_KEY/BL_WORKSPACE (the factory's env fallback). Boot the Debian
 		// ts-app image as root (the stock Alpine base-image has no apt — PTS uninstallable). Blaxel
 		// couples CPU to RAM (measured: vCPU ≈ memory_MB / 2048) and exposes no cgroup cpu.max, so
@@ -152,6 +155,7 @@ export const adapters: Record<ProviderId, ProviderAdapter> = {
 		createOptions: {},
 	},
 	"microsandbox-local": {
+		artifact: { kind: "image", ref: config.toolchainImage },
 		// Explicit local selection is important: a developer can have MSB_API_* configured globally and
 		// still request a true host-local benchmark without the SDK auto-selecting cloud.
 		createCompute: () =>
@@ -170,6 +174,7 @@ export const adapters: Record<ProviderId, ProviderAdapter> = {
 		createTimeoutMs: MICROSANDBOX_CREATE_TIMEOUT_MS,
 	},
 	"microsandbox-cloud": {
+		artifact: { kind: "image", ref: config.toolchainImage },
 		// The API key remains in the CloudBackend HTTP/WebSocket client. It is never forwarded through
 		// createOptions, metadata, or the benchmark's in-guest environment.
 		createCompute: () =>
@@ -191,16 +196,19 @@ export const adapters: Record<ProviderId, ProviderAdapter> = {
 	// vm_runtime experimental flag to select Modal's gVisor-free VM runtime and drops scalableSandboxes
 	// to match the VM config validated in #221 (see modalGvisorCompute/modalVmCompute above).
 	"modal-gvisor": {
+		artifact: { kind: "image", ref: config.toolchainImage },
 		createCompute: modalGvisorCompute,
 		createOptions: modalCreateOptions(),
 		costEvidence: modalCostEvidence,
 	},
 	"modal-vm": {
+		artifact: { kind: "image", ref: config.toolchainImage },
 		createCompute: modalVmCompute,
 		createOptions: modalCreateOptions({ vm_runtime: true }),
 		costEvidence: modalCostEvidence,
 	},
 	novita: {
+		artifact: { kind: "baked", ref: config.novitaTemplate },
 		// The e2b wrapper re-pointed at Novita's E2B-compatible control plane (sandbox.novita.ai) —
 		// see novita.ts for exactly what is swapped and why. Boots the pre-baked toolchain template
 		// the bake pipeline creates on Novita via the same e2b CLI (computesdk maps snapshotId → the
@@ -209,6 +217,7 @@ export const adapters: Record<ProviderId, ProviderAdapter> = {
 		createOptions: { snapshotId: config.novitaTemplate },
 	},
 	runloop: {
+		artifact: { kind: "baked", ref: config.runloopBlueprint },
 		// Boot the immutable version-scoped Blueprint by name. Runloop resolves that name to its latest
 		// successful build; the release lane owns creation from the shared toolchain image. Per-run launch
 		// parameters retain the benchmark's target sizing and keep-alive override. The API key stays in
@@ -227,6 +236,7 @@ export const adapters: Record<ProviderId, ProviderAdapter> = {
 		},
 	},
 	namespace: {
+		artifact: { kind: "image", ref: config.toolchainImage },
 		// The token rides the factory's own NSC_TOKEN_FILE env fallback (getAndValidateCredentials) —
 		// CI's OIDC federation (nscloud-setup) lands the token there, not in NSC_TOKEN — never read
 		// here, same as blaxel's BL_API_KEY. virtualCpu/memoryMegabytes are per-instance knobs on this
@@ -243,12 +253,14 @@ export const adapters: Record<ProviderId, ProviderAdapter> = {
 		createOptions: { image: config.toolchainImage },
 	},
 	vercel: {
+		artifact: { kind: "mirror", ref: config.vercelImage },
 		// @computesdk/vercel still targets Sandbox v1. Keep its defineProvider shape, but use the latest
 		// native SDK so the shared VCR image and v2 lifecycle/filesystem APIs remain available.
 		createCompute: () => vercelCompute({ image: config.vercelImage, vcpus: TARGET_SPEC.vcpus }),
 		createOptions: {},
 	},
 	runcloud: {
+		artifact: { kind: "image", ref: config.toolchainImage },
 		// run.cloud boots the OCI image directly and exposes independent CPU, memory, and writable-disk
 		// knobs. Keep both its lifetime and idle-pause window above the longest 155-minute suite so a
 		// detached benchmark is not paused while the harness is polling its done file. create() polls
@@ -273,6 +285,7 @@ export const adapters: Record<ProviderId, ProviderAdapter> = {
 		costEvidence: runcloudCostEvidence,
 	},
 	tama: {
+		artifact: { kind: "image", ref: config.toolchainImage },
 		// tama publishes no SDK, so the adapter drives the `tama` CLI as a subprocess (tama.ts). The
 		// toolchain image is booted by ref — `tama new --image` pulls an arbitrary OCI image, so there is
 		// no provider-side artifact to bake. Disk is deliberately absent: tama exposes no disk knob, and

--- a/packages/providers/src/lib/types.ts
+++ b/packages/providers/src/lib/types.ts
@@ -8,6 +8,7 @@ import type {
 	ProviderTransport,
 	SdkProvenance,
 } from "@sandbox-benchmarks/schema";
+import type { DriverResolvedArtifact } from "@sandbox-benchmarks/schema/driver-schemas";
 import type { CreateSandboxOptions, ExplicitComputeConfig } from "computesdk";
 
 /**
@@ -45,6 +46,8 @@ export interface ProviderCostEvidenceCapability {
  * streaming, filesystem, destroy), so there is deliberately nothing here that re-implements them.
  */
 export interface ProviderAdapter {
+	/** Exact artifact the adjacent create policy boots; persisted as the request-side attribution. */
+	artifact: DriverResolvedArtifact;
 	/** Construct the computesdk provider for this vendor (a @computesdk/* factory call). Lazy so the
 	 *  registry can be imported without credentials. */
 	createCompute: () => DirectProvider;

--- a/packages/results/README.md
+++ b/packages/results/README.md
@@ -1,9 +1,10 @@
 # @sandbox-benchmarks/results
 
-Normalization reads each suite's fixed provider cost-evidence file separately from PTS extraction and
-emits Run v5. Aggregation retains one deterministic record per sandbox cell, rejects conflicts and
-sandbox reuse, and never converts provider cost into a benchmark metric. This package remains
-provider-SDK-free: provider calls and response sanitization happen upstream in the providers package.
+Normalization reads each suite's fixed cost- and artifact-evidence files separately from PTS
+extraction and emits Run v6. Aggregation retains deterministic records per sandbox cell, rejects
+conflicts and sandbox reuse, and rejects a v6/older shard mixture rather than dropping attribution.
+Historical all-pre-v6 inputs still aggregate as Run v5. This package remains provider-SDK-free:
+provider calls and response sanitization happen upstream in the providers package.
 
 **Role:** normalize a raw benchmark results tree (`data/raw/<runId>/<provider>/`) into validated `Run`
 documents for reporting/promotion.

--- a/packages/results/src/index.test.ts
+++ b/packages/results/src/index.test.ts
@@ -16,7 +16,7 @@ describe("normalizeResultsTree", () => {
 	});
 
 	it("validates as a Run and includes every known provider", () => {
-		expect(run.schemaVersion).toBe("5");
+		expect(run.schemaVersion).toBe("6");
 		expect(run.providers.map((provider) => provider.providerId).sort()).toEqual(
 			PROVIDERS.map((provider) => provider.id).sort(),
 		);

--- a/packages/results/src/lib/__fixtures__/daytona-vm/cpu-node/provider-artifact-evidence.json
+++ b/packages/results/src/lib/__fixtures__/daytona-vm/cpu-node/provider-artifact-evidence.json
@@ -1,0 +1,15 @@
+{
+  "cell": {
+    "runId": "run-test",
+    "providerId": "daytona-vm",
+    "suite": "cpu-node"
+  },
+  "sandboxId": "fixture-sandbox",
+  "provenance": {
+    "source": "request-fallback",
+    "requested": {
+      "kind": "baked",
+      "ref": "sandbox-benchmarks-toolchain-v8"
+    }
+  }
+}

--- a/packages/results/src/lib/aggregate.test.ts
+++ b/packages/results/src/lib/aggregate.test.ts
@@ -3,12 +3,14 @@ import type {
 	GapCause,
 	MetricResult,
 	MissingProviderCostEvidence,
+	ProviderArtifactEvidence,
 	ProviderRun,
 	Run,
 	SuiteName,
 } from "@sandbox-benchmarks/schema";
 import {
 	aggregate,
+	bakedArtifactName,
 	ECONOMICS_METRIC_IDS,
 	getProvider,
 	HARNESS_METRIC_IDS,
@@ -69,7 +71,73 @@ const evidence = (
 	detail: "No public sandbox usage endpoint.",
 });
 
+const artifactEvidence = (
+	replicateIndex: number,
+	sandboxId: string,
+	suite: SuiteName = "cpu-node",
+): ProviderArtifactEvidence => ({
+	cell: { runId: "run-1", providerId: "daytona-vm", suite, replicateIndex },
+	sandboxId,
+	provenance: {
+		source: "request-fallback",
+		requested: { kind: "baked", ref: bakedArtifactName("daytona-vm", "version") },
+	},
+});
+
+function attributedShard(
+	replicateIndex: number,
+	sandboxId: string,
+	overrides: Partial<ProviderRun> = {},
+): Run {
+	const entry = provider("daytona-vm", [metric("node_web_tooling_runs_per_s", [10])]);
+	entry.costEvidence = [];
+	entry.artifactEvidence = [artifactEvidence(replicateIndex, sandboxId)];
+	Object.assign(entry, overrides);
+	return {
+		...shard([entry], "2026-06-01T00:00:00.000Z", replicateIndex),
+		schemaVersion: "6",
+	};
+}
+
 describe("aggregateRuns", () => {
+	it("retains deterministic cell-bound artifact evidence when every shard is v6", () => {
+		const r1 = attributedShard(1, "sb-1");
+		const r0 = attributedShard(0, "sb-0");
+		const duplicate = attributedShard(0, "sb-0");
+		const merged = aggregateRuns([r1, r0, duplicate]);
+		expect(merged.schemaVersion).toBe("6");
+		expect(merged.providers[0]?.artifactEvidence?.map((record) => record.sandboxId)).toEqual([
+			"sb-0",
+			"sb-1",
+		]);
+	});
+
+	it("rejects conflicting artifact cells, reused sandboxes, and mixed-version attribution", () => {
+		const one = attributedShard(0, "sb-0");
+		const conflicting = attributedShard(0, "sb-0", {
+			artifactEvidence: [
+				{
+					...artifactEvidence(0, "sb-0"),
+					provenance: {
+						source: "request-fallback",
+						requested: { kind: "baked", ref: "different-template" },
+					},
+				},
+			],
+		});
+		expect(() => aggregateRuns([one, conflicting])).toThrow(
+			/conflicting provider artifact evidence/,
+		);
+		const reused = attributedShard(1, "sb-0");
+		expect(() => aggregateRuns([one, reused])).toThrow(/artifact sandbox sb-0 is reused/);
+		expect(() =>
+			aggregateRuns([
+				one,
+				shard([provider("daytona-vm", [metric("node_web_tooling_runs_per_s", [11])])]),
+			]),
+		).toThrow(/cannot mix v6 artifact-attributed shards with older shards/);
+	});
+
 	it("retains deterministic per-sandbox cost evidence and deduplicates identical copies", () => {
 		const r1Provider = provider("modal-gvisor", []);
 		r1Provider.costEvidence = [evidence("cpu-node", 1, "sb-1")];

--- a/packages/results/src/lib/aggregate.ts
+++ b/packages/results/src/lib/aggregate.ts
@@ -21,6 +21,7 @@ import type {
 	MetricReplicate,
 	MetricResult,
 	ObservedSpecs,
+	ProviderArtifactEvidence,
 	ProviderCostEvidence,
 	ProviderRun,
 	ResultGap,
@@ -146,6 +147,7 @@ function mergeProvider(
 	providerId: string,
 	entries: readonly ReplicateSlice[],
 	targetSpec: TargetSpec,
+	emitArtifactEvidence: boolean,
 ): ProviderRun {
 	// Group measured metrics by id, then by the replicate that produced them, carrying that sandbox's
 	// mixture ids in the SAME record. A metric id recurring across replicate shards is R distinct
@@ -178,6 +180,8 @@ function mergeProvider(
 	const hostMetadataInputs: HostMetadataRecordInput[] = [];
 	const evidenceByCell = new Map<string, ProviderCostEvidence>();
 	const sandboxCells = new Map<string, string>();
+	const artifactByCell = new Map<string, ProviderArtifactEvidence>();
+	const artifactSandboxCells = new Map<string, string>();
 
 	// ONE pass over the slices. The mixture ids are two sha256 hashes per slice, and a real run merges
 	// ~470 slices per provider (the normalizer's placeholder rows included), so deriving them once here
@@ -214,6 +218,27 @@ function mergeProvider(
 				}
 				sandboxCells.set(sandboxId, key);
 			}
+		}
+		for (const record of slice.artifactEvidence ?? []) {
+			const key = providerCostCellKey(record);
+			const existing = artifactByCell.get(key);
+			if (existing !== undefined) {
+				if (
+					canonicalJsonString(existing, PROVIDER_EVIDENCE_JSON_LIMITS) !==
+					canonicalJsonString(record, PROVIDER_EVIDENCE_JSON_LIMITS)
+				) {
+					throw new Error(`aggregateRuns: conflicting provider artifact evidence for cell ${key}`);
+				}
+			} else {
+				artifactByCell.set(key, record);
+			}
+			const priorCell = artifactSandboxCells.get(record.sandboxId);
+			if (priorCell !== undefined && priorCell !== key) {
+				throw new Error(
+					`aggregateRuns: provider artifact sandbox ${record.sandboxId} is reused across cells`,
+				);
+			}
+			artifactSandboxCells.set(record.sandboxId, key);
 		}
 		for (const suite of slice.suitesCovered) suitesCovered.add(suite);
 
@@ -296,6 +321,13 @@ function mergeProvider(
 		if (replicate !== 0) return replicate;
 		return (a.subject.sandboxId ?? "").localeCompare(b.subject.sandboxId ?? "", "en");
 	});
+	const artifactEvidence = [...artifactByCell.values()].sort((a, b) => {
+		const suite = a.cell.suite.localeCompare(b.cell.suite, "en");
+		if (suite !== 0) return suite;
+		const replicate = (a.cell.replicateIndex ?? -1) - (b.cell.replicateIndex ?? -1);
+		if (replicate !== 0) return replicate;
+		return a.sandboxId.localeCompare(b.sandboxId, "en");
+	});
 
 	const metrics = [...measured.values()];
 	// Re-derive economics from the FULL merged measured set so $/lifecycle sums every suite's timings,
@@ -317,6 +349,7 @@ function mergeProvider(
 	return {
 		providerId,
 		costEvidence,
+		...(emitArtifactEvidence ? { artifactEvidence } : {}),
 		validationStatus: metrics.length > 0 ? "validated" : "pending",
 		...(specMatched !== undefined ? { specMatched } : {}),
 		observedSpecs,
@@ -341,6 +374,10 @@ export function aggregateRuns(runs: readonly Run[]): Run {
 	}
 	const first = runs[0];
 	if (!first) throw new Error("aggregateRuns requires at least one shard Run");
+	const emitArtifactEvidence = runs.every((run) => Number(run.schemaVersion) >= 6);
+	if (!emitArtifactEvidence && runs.some((run) => Number(run.schemaVersion) >= 6)) {
+		throw new Error("aggregateRuns: cannot mix v6 artifact-attributed shards with older shards");
+	}
 	for (const run of runs) {
 		if (run.runId !== first.runId || run.sha !== first.sha) {
 			throw new Error(
@@ -375,6 +412,7 @@ export function aggregateRuns(runs: readonly Run[]): Run {
 					.map((slice) => ({ slice, replicateIndex: run.replicateIndex ?? 0 })),
 			),
 			first.targetSpec,
+			emitArtifactEvidence,
 		),
 	);
 
@@ -385,12 +423,13 @@ export function aggregateRuns(runs: readonly Run[]): Run {
 	const sourceRunUrl = runs.find((run) => run.sourceRunUrl !== undefined)?.sourceRunUrl;
 
 	// The merged Run spans every replicate, so it carries no single `replicateIndex` — that lived on the
-	// shards. Emit v5: this layer also retains every sandbox's provider cost evidence.
+	// shards. Emit v6 only when every shard carries artifact attribution; historical all-pre-v6
+	// inputs continue to aggregate as v5 without fabricating evidence.
 	// one that can emit `observedMixtures`, join each replicate to the mixture its sandbox reported, and
 	// fold the host records. v2/v3 shards read in above validate unchanged, and the v4 document still
 	// carries the v3 replicate fold (version floors compare numerically in runSchema).
 	return parseRun({
-		schemaVersion: "5",
+		schemaVersion: emitArtifactEvidence ? "6" : "5",
 		runId: first.runId,
 		sha: first.sha,
 		generatedAt,

--- a/packages/results/src/lib/normalize-tree.test.ts
+++ b/packages/results/src/lib/normalize-tree.test.ts
@@ -107,7 +107,7 @@ describe("normalizeProviderDir reads the suite-tagged layout", () => {
 		expect(run.observedSpecs.vcpus).toBe(4);
 	});
 
-	it("strictly ingests suite-scoped provider cost evidence into a v5 Run", () => {
+	it("strictly ingests suite-scoped cost and artifact evidence into a v6 Run", () => {
 		const suiteDir = join(providerDir, "cpu-node");
 		mkdirSync(suiteDir);
 		const evidence = {
@@ -120,17 +120,33 @@ describe("normalizeProviderDir reads the suite-tagged layout", () => {
 			detail: "Organization totals cannot be attributed to one sandbox.",
 		} as const;
 		writeFileSync(join(suiteDir, "provider-cost-evidence.json"), JSON.stringify(evidence));
+		const artifactEvidence = {
+			cell: { runId: "run-cost", providerId: "daytona-vm", suite: "cpu-node" },
+			sandboxId: "sb-1",
+			provenance: {
+				source: "request-fallback",
+				requested: { kind: "baked", ref: "sandbox-benchmarks-toolchain-v8" },
+			},
+		} as const;
+		writeFileSync(
+			join(suiteDir, "provider-artifact-evidence.json"),
+			JSON.stringify(artifactEvidence),
+		);
 		const run = normalizeResultsTree({
 			rawRoot: root,
 			runId: "run-cost",
 			sha: "abc",
 			generatedAt: "2026-08-08T00:00:00.000Z",
 		});
-		expect(run.schemaVersion).toBe("5");
+		expect(run.schemaVersion).toBe("6");
 		expect(
 			run.providers.find((provider) => provider.providerId === "daytona-vm")?.costEvidence,
 		).toEqual([evidence]);
+		expect(
+			run.providers.find((provider) => provider.providerId === "daytona-vm")?.artifactEvidence,
+		).toEqual([artifactEvidence]);
 		expect(run.providers.every((provider) => Array.isArray(provider.costEvidence))).toBe(true);
+		expect(run.providers.every((provider) => Array.isArray(provider.artifactEvidence))).toBe(true);
 	});
 
 	it("fails normalization on malformed recognized evidence", () => {
@@ -170,7 +186,7 @@ describe("normalizeProviderDir reads the suite-tagged layout", () => {
 			const created = spawnSync("mkfifo", [evidencePath]);
 			if (created.status !== 0) return;
 			expect(() => normalizeProviderDir(root, "daytona-vm")).toThrow(
-				/provider cost evidence path is not a regular file/,
+				/evidence path is not a regular file/,
 			);
 		},
 	);

--- a/packages/results/src/lib/normalize-tree.ts
+++ b/packages/results/src/lib/normalize-tree.ts
@@ -21,6 +21,7 @@ import type {
 	MetricResult,
 	ObservedSpecs,
 	OffDimensionEmission,
+	ProviderArtifactEvidence,
 	ProviderCostEvidence,
 	ProviderRun,
 	ResultGap,
@@ -29,15 +30,20 @@ import type {
 } from "@sandbox-benchmarks/schema";
 import {
 	aggregate,
+	canonicalJsonEqual,
 	deriveEconomics,
 	describeOffDimensionEmission,
 	getProvider,
+	MAX_PROVIDER_ARTIFACT_EVIDENCE_FILE_BYTES,
 	MAX_PROVIDER_COST_EVIDENCE_FILE_BYTES,
 	METRIC_CATALOG,
 	offDimensionEmissions,
 	PROVIDERS,
+	parseProviderArtifactEvidence,
 	parseProviderCostEvidence,
 	parseRun,
+	providerArtifactEvidenceFile,
+	providerCostCellKey,
 	providerCostEvidenceFile,
 	SUITE_NAMES,
 	SUITES,
@@ -49,24 +55,24 @@ import { readHostMetadata } from "./host-metadata.ts";
 import { computeSpecMatched, readObservedSpecs } from "./specs.ts";
 
 /** Read max+1 bytes from one descriptor, avoiding both unbounded allocation and stat/read races. */
-function readProviderCostEvidenceFile(path: string): string {
+function readEvidenceFile(path: string, maximumBytes: number): string {
 	const descriptor = openSync(
 		path,
 		constants.O_RDONLY | constants.O_NONBLOCK | (constants.O_NOFOLLOW ?? 0),
 	);
 	try {
 		if (!fstatSync(descriptor).isFile()) {
-			throw new Error("provider cost evidence path is not a regular file");
+			throw new Error("evidence path is not a regular file");
 		}
-		const buffer = new Uint8Array(MAX_PROVIDER_COST_EVIDENCE_FILE_BYTES + 1);
+		const buffer = new Uint8Array(maximumBytes + 1);
 		let length = 0;
 		while (length < buffer.byteLength) {
 			const count = readSync(descriptor, buffer, length, buffer.byteLength - length, null);
 			if (count === 0) break;
 			length += count;
 		}
-		if (length > MAX_PROVIDER_COST_EVIDENCE_FILE_BYTES) {
-			throw new Error("provider cost evidence file exceeds 96 KiB");
+		if (length > maximumBytes) {
+			throw new Error(`evidence file exceeds ${maximumBytes / 1024} KiB`);
 		}
 		return new TextDecoder().decode(buffer.subarray(0, length));
 	} finally {
@@ -93,12 +99,12 @@ export function normalizeResultsTree(input: NormalizeInput): Run {
 		.map((meta) => normalizeProviderDir(input.rawRoot, meta.id));
 
 	const candidate = {
-		// Run v5 carries the provider cost-evidence array on every provider row. This function also stamps
+		// Run v6 carries cost and artifact evidence on every provider row. This function also stamps
 		// structured suite-gap causes (`shortfallCause`/`twinDropCause`), which `runSchema` gates at
 		// v4-or-later — lowering this while
 		// still emitting causes fails `parseRun`. A shard may also carry a replicateIndex (v3+) the
 		// aggregate folds into MetricResult.replicates.
-		schemaVersion: "5" as const,
+		schemaVersion: "6" as const,
 		runId: input.runId,
 		sha: input.sha,
 		generatedAt: input.generatedAt,
@@ -277,6 +283,7 @@ export function normalizeProviderDir(rawRoot: string, providerId: string): Provi
 		return {
 			providerId,
 			costEvidence: [],
+			artifactEvidence: [],
 			validationStatus: "pending",
 			observedSpecs: {},
 			metrics: [],
@@ -319,6 +326,7 @@ export function normalizeProviderDir(rawRoot: string, providerId: string): Provi
 	const offDimension: OffDimensionEmission[] = [];
 	const hostMetadata: HostMetadataRecord[] = [];
 	const costEvidence: ProviderCostEvidence[] = [];
+	const artifactEvidence: ProviderArtifactEvidence[] = [];
 	// Host fingerprint from a composite's <System>, first non-empty across the read order (all suites of
 	// one provider ran on the same machine). Merged UNDER the spec probe below so the probe always wins.
 	let systemHost: ObservedSpecs | undefined;
@@ -337,9 +345,38 @@ export function normalizeProviderDir(rawRoot: string, providerId: string): Provi
 	const suiteTwinDrops = new Map<string, DroppedTwinResult[]>();
 
 	for (const suite of suiteDirs) {
+		const artifactPath = join(dir, suite, providerArtifactEvidenceFile());
+		try {
+			const evidence = parseProviderArtifactEvidence(
+				readEvidenceFile(artifactPath, MAX_PROVIDER_ARTIFACT_EVIDENCE_FILE_BYTES),
+			);
+			if (evidence.cell.providerId !== providerId || evidence.cell.suite !== suite) {
+				throw new Error(
+					`artifact evidence identity mismatch: expected ${providerId}/${suite}, got ${evidence.cell.providerId}/${evidence.cell.suite}`,
+				);
+			}
+			const duplicate = artifactEvidence.find(
+				(record) => providerCostCellKey(record) === providerCostCellKey(evidence),
+			);
+			if (duplicate !== undefined) {
+				if (!canonicalJsonEqual(duplicate, evidence)) {
+					throw new Error(`conflicting artifact evidence for ${providerId}/${suite}`);
+				}
+			} else {
+				artifactEvidence.push(evidence);
+			}
+		} catch (err) {
+			if ((err as NodeJS.ErrnoException).code !== "ENOENT") {
+				throw new Error(
+					`invalid ${providerId}/${suite}/${providerArtifactEvidenceFile()}: ${err instanceof Error ? err.message : String(err)}`,
+				);
+			}
+		}
 		const evidencePath = join(dir, suite, providerCostEvidenceFile());
 		try {
-			const evidence = parseProviderCostEvidence(readProviderCostEvidenceFile(evidencePath));
+			const evidence = parseProviderCostEvidence(
+				readEvidenceFile(evidencePath, MAX_PROVIDER_COST_EVIDENCE_FILE_BYTES),
+			);
 			if (evidence.cell.providerId !== providerId || evidence.cell.suite !== suite) {
 				throw new Error(
 					`cost evidence identity mismatch: expected ${providerId}/${suite}, got ${evidence.cell.providerId}/${evidence.cell.suite}`,
@@ -651,6 +688,7 @@ export function normalizeProviderDir(rawRoot: string, providerId: string): Provi
 	return {
 		providerId,
 		costEvidence,
+		artifactEvidence,
 		// A provider is validated exactly when it produced ≥1 catalogued Metric.
 		validationStatus: metrics.length > 0 ? "validated" : "pending",
 		...(specMatched !== undefined ? { specMatched } : {}),

--- a/packages/results/src/lib/reprice.test.ts
+++ b/packages/results/src/lib/reprice.test.ts
@@ -34,7 +34,28 @@ function fixture(
 					measured(),
 					...(Number(schemaVersion) >= 4 ? [{ ...stale(), derived: true as const }] : [stale()]),
 				],
-				...(schemaVersion === "5" ? { costEvidence: [] } : {}),
+				...(Number(schemaVersion) >= 5 ? { costEvidence: [] } : {}),
+				...(schemaVersion === "6"
+					? {
+							artifactEvidence: [
+								{
+									cell: {
+										runId: "v6",
+										providerId: "daytona-vm" as const,
+										suite: "cpu-node" as const,
+									},
+									sandboxId: "sb-1",
+									provenance: {
+										source: "request-fallback" as const,
+										requested: {
+											kind: "baked" as const,
+											ref: "sandbox-benchmarks-toolchain-v8",
+										},
+									},
+								},
+							],
+						}
+					: {}),
 				suitesCovered: ["cpu-node"],
 				gaps: [],
 				uncatalogued: [],
@@ -87,6 +108,14 @@ describe("rederiveRunEconomics", () => {
 		const output = rederiveRunEconomics(input);
 		expect(output.schemaVersion).toBe("5");
 		expect(output.providers[0]?.costEvidence).toEqual(before);
+	});
+
+	it("preserves v6 artifact attribution unchanged while repricing catalog economics", () => {
+		const input = fixture("6");
+		const before = structuredClone(input.providers[0]?.artifactEvidence);
+		const output = rederiveRunEconomics(input);
+		expect(output.schemaVersion).toBe("6");
+		expect(output.providers[0]?.artifactEvidence).toEqual(before);
 	});
 
 	it("prices a historical 2-vCPU Run from its own target spec", () => {

--- a/packages/results/src/lib/write-run.test.ts
+++ b/packages/results/src/lib/write-run.test.ts
@@ -1,21 +1,52 @@
 import { afterAll, describe, expect, it } from "bun:test";
-import { mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { cpSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import type { Run } from "@sandbox-benchmarks/schema";
 import { parseRun, parseRunIndex } from "@sandbox-benchmarks/schema";
 import { writeNormalizedRun, writeRunDocument } from "./write-run.ts";
 
-const rawRoot = join(import.meta.dir, "__fixtures__");
+const fixtureRoot = join(import.meta.dir, "__fixtures__");
 const outDir = mkdtempSync(join(tmpdir(), "sandbox-bench-write-run-"));
+const rawRoots: string[] = [];
 
-afterAll(() => rmSync(outDir, { recursive: true, force: true }));
+function rawRootFor(runId: string, replicateIndex?: number): string {
+	const root = mkdtempSync(join(tmpdir(), "sandbox-bench-write-raw-"));
+	rawRoots.push(root);
+	cpSync(join(fixtureRoot, "daytona-vm"), join(root, "daytona-vm"), { recursive: true });
+	writeFileSync(
+		join(root, "daytona-vm", "cpu-node", "provider-artifact-evidence.json"),
+		`${JSON.stringify(
+			{
+				cell: {
+					runId,
+					providerId: "daytona-vm",
+					suite: "cpu-node",
+					...(replicateIndex !== undefined ? { replicateIndex } : {}),
+				},
+				sandboxId: `fixture-${runId}-${replicateIndex ?? "single"}`,
+				provenance: {
+					source: "request-fallback",
+					requested: { kind: "baked", ref: "sandbox-benchmarks-toolchain-v8" },
+				},
+			},
+			null,
+			2,
+		)}\n`,
+	);
+	return root;
+}
+
+afterAll(() => {
+	rmSync(outDir, { recursive: true, force: true });
+	for (const root of rawRoots) rmSync(root, { recursive: true, force: true });
+});
 
 describe("writeNormalizedRun", () => {
 	const outFile = join(outDir, "runs", "run-1.json");
 	const indexFile = join(outDir, "index.json");
 	const run = writeNormalizedRun({
-		rawRoot,
+		rawRoot: rawRootFor("run-1"),
 		runId: "run-1",
 		sha: "abc123",
 		generatedAt: "2026-06-20T00:00:00.000Z",
@@ -44,7 +75,7 @@ describe("writeNormalizedRun", () => {
 		const shardIndex = join(shardDir, "index.json");
 		for (const replicateIndex of [0, 1]) {
 			writeNormalizedRun({
-				rawRoot,
+				rawRoot: rawRootFor("fan-1", replicateIndex),
 				runId: "fan-1",
 				sha: "abc123",
 				generatedAt: `2026-06-20T00:0${replicateIndex}:00.000Z`,
@@ -80,7 +111,7 @@ describe("writeNormalizedRun", () => {
 		const singleIndex = join(singleDir, "index.json");
 		const outFile = join(singleDir, "runs", "solo-1.json");
 		writeNormalizedRun({
-			rawRoot,
+			rawRoot: rawRootFor("solo-1", 3),
 			runId: "solo-1",
 			sha: "abc123",
 			generatedAt: "2026-06-20T00:00:00.000Z",
@@ -101,7 +132,7 @@ describe("writeNormalizedRun", () => {
 		// the one naming that file — keyed on identity alone, the index would keep a second entry
 		// pointing at a document that now holds another sandbox's results.
 		writeNormalizedRun({
-			rawRoot,
+			rawRoot: rawRootFor("solo-1", 4),
 			runId: "solo-1",
 			sha: "abc123",
 			generatedAt: "2026-06-20T00:05:00.000Z",
@@ -126,7 +157,7 @@ describe("writeNormalizedRun", () => {
 		const nestedDir = mkdtempSync(join(tmpdir(), "sandbox-bench-nested-"));
 		expect(() =>
 			writeNormalizedRun({
-				rawRoot,
+				rawRoot: rawRootFor("nested-1"),
 				runId: "nested-1",
 				sha: "abc123",
 				generatedAt: "2026-06-20T00:00:00.000Z",
@@ -145,7 +176,7 @@ describe("writeNormalizedRun", () => {
 		const oddDir = mkdtempSync(join(tmpdir(), "sandbox-bench-odd-"));
 		expect(() =>
 			writeNormalizedRun({
-				rawRoot,
+				rawRoot: rawRootFor("odd-1", 2),
 				runId: "odd-1",
 				sha: "abc123",
 				generatedAt: "2026-06-20T00:00:00.000Z",

--- a/packages/schema/README.md
+++ b/packages/schema/README.md
@@ -41,3 +41,13 @@ external authenticity. `providerCostTotal(records, expectedCells)` returns money
 exactly equal the caller's authoritative expected-cell set and every record is unique, observed, and
 same-currency. The result is exact only relative to those supplied cells; missing evidence never
 contributes zero.
+
+## Run v6 artifact evidence
+
+Run v6 requires `artifactEvidence: []` on every provider row. A booted sandbox records its complete
+benchmark cell, sandbox id, exact requested artifact, and how that identity was established. The raw
+transport is the bounded, deterministic `provider-artifact-evidence.json` host-owned file. Canonical
+release artifacts may carry a guest observation from `/toolchain-manifest.json`; the schema derives
+the expected image identity from release constants and rejects a stale or producer-selected expected
+value. Noncanonical overrides remain `request-fallback`. Aggregation preserves one record per cell and
+rejects conflicting records, reused sandbox ids, and mixed v6/older inputs.

--- a/packages/schema/src/artifact-evidence.test.ts
+++ b/packages/schema/src/artifact-evidence.test.ts
@@ -1,0 +1,221 @@
+import { describe, expect, it } from "bun:test";
+import { type } from "arktype";
+import {
+	artifactProvenanceSchema,
+	artifactVerified,
+	effectiveArtifact,
+	expectedToolchainFingerprint,
+	providerArtifactEvidenceSchema,
+} from "./artifact-evidence.ts";
+import { bakedArtifactName } from "./provider-artifacts.ts";
+
+const BAKED = { kind: "baked", ref: bakedArtifactName("e2b", "version") } as const;
+const CELL = { runId: "run-1", providerId: "e2b", suite: "cpu-node" } as const;
+const FINGERPRINT = {
+	authority: "toolchain-manifest-v1",
+	imageName: "sandbox-benchmarks-toolchain",
+	imageVersion: "v8",
+} as const;
+
+function parseProvenance(input: unknown) {
+	const parsed = artifactProvenanceSchema(input);
+	if (parsed instanceof type.errors) throw new Error(parsed.summary);
+	return parsed;
+}
+
+function parseEvidence(input: unknown) {
+	const parsed = providerArtifactEvidenceSchema(input);
+	if (parsed instanceof type.errors) throw new Error(parsed.summary);
+	return parsed;
+}
+
+const evidence = (provenance: unknown) => ({
+	cell: CELL,
+	sandboxId: "isandbox",
+	provenance,
+});
+
+describe("artifact provenance", () => {
+	it("accepts each structurally complete way an artifact can be established", () => {
+		expect(parseProvenance({ source: "request-fallback", requested: BAKED }).source).toBe(
+			"request-fallback",
+		);
+		expect(
+			parseProvenance({ source: "driver-reported", requested: BAKED, reported: BAKED }).source,
+		).toBe("driver-reported");
+		expect(
+			parseProvenance({
+				source: "guest-fingerprint",
+				requested: BAKED,
+				fingerprint: FINGERPRINT,
+			}).source,
+		).toBe("guest-fingerprint");
+	});
+
+	it("makes a fingerprint claim without an observation unrepresentable", () => {
+		expect(() => parseProvenance({ source: "guest-fingerprint", requested: BAKED })).toThrow();
+	});
+
+	it("rejects evidence smuggled onto the weakest arm", () => {
+		expect(() =>
+			parseProvenance({
+				source: "request-fallback",
+				requested: BAKED,
+				fingerprint: FINGERPRINT,
+			}),
+		).toThrow();
+		expect(() =>
+			parseProvenance({ source: "request-fallback", requested: BAKED, reported: BAKED }),
+		).toThrow();
+	});
+
+	it("rejects a driver report that contradicts its request on either observed arm", () => {
+		const wrong = { kind: "baked", ref: "sandbox-benchmarks-toolchain-v7" } as const;
+		expect(() =>
+			parseProvenance({ source: "driver-reported", requested: BAKED, reported: wrong }),
+		).toThrow(/ref matches the request/);
+		expect(() =>
+			parseProvenance({
+				source: "guest-fingerprint",
+				requested: BAKED,
+				reported: wrong,
+				fingerprint: FINGERPRINT,
+			}),
+		).toThrow(/ref matches the request/);
+	});
+
+	it("accepts a stock boot, where both sides carry no ref", () => {
+		const none = { kind: "none" } as const;
+		expect(
+			parseProvenance({ source: "driver-reported", requested: none, reported: none }).source,
+		).toBe("driver-reported");
+	});
+});
+
+describe("authoritative guest fingerprints", () => {
+	it("derives the expected identity from a canonical provider artifact", () => {
+		expect(expectedToolchainFingerprint("e2b", BAKED)).toEqual(FINGERPRINT);
+		expect(
+			expectedToolchainFingerprint("e2b", {
+				kind: "baked",
+				ref: bakedArtifactName("e2b", "candidate"),
+			}),
+		).toEqual(FINGERPRINT);
+		expect(
+			expectedToolchainFingerprint("modal-gvisor", {
+				kind: "image",
+				ref: `ghcr.io/starslingdev/sandbox-benchmarks-toolchain@sha256:${"a".repeat(64)}`,
+			}),
+		).toEqual(FINGERPRINT);
+		expect(
+			expectedToolchainFingerprint("modal-gvisor", {
+				kind: "image",
+				ref: `ghcr.io/untrusted/sandbox-benchmarks-toolchain@sha256:${"a".repeat(64)}`,
+			}),
+		).toBeUndefined();
+	});
+
+	it("rejects a guest observation that contradicts release-owned identity", () => {
+		expect(() =>
+			parseEvidence(
+				evidence({
+					source: "guest-fingerprint",
+					requested: BAKED,
+					fingerprint: { ...FINGERPRINT, imageVersion: "v7" },
+				}),
+			),
+		).toThrow(/matching sandbox-benchmarks-toolchain@v8/);
+	});
+
+	it("cannot verify an arbitrary ref even when its producer supplies the current fingerprint", () => {
+		const override = { kind: "baked", ref: "producer-chosen-template" } as const;
+		expect(expectedToolchainFingerprint("e2b", override)).toBeUndefined();
+		expect(() =>
+			parseEvidence(
+				evidence({
+					source: "guest-fingerprint",
+					requested: override,
+					fingerprint: FINGERPRINT,
+				}),
+			),
+		).toThrow(/canonical e2b release artifact/);
+	});
+
+	it("rejects the producer-supplied expected/observed shape from the incomplete contract", () => {
+		expect(() =>
+			parseEvidence(
+				evidence({
+					source: "guest-fingerprint",
+					requested: BAKED,
+					fingerprint: { expected: "v7", observed: "v7" },
+				}),
+			),
+		).toThrow();
+	});
+});
+
+describe("artifact helpers", () => {
+	it("admits only an observed, fully bound evidence record", () => {
+		expect(
+			artifactVerified(parseEvidence(evidence({ source: "request-fallback", requested: BAKED }))),
+		).toBe(false);
+		expect(
+			artifactVerified(
+				parseEvidence(evidence({ source: "driver-reported", requested: BAKED, reported: BAKED })),
+			),
+		).toBe(true);
+		expect(
+			artifactVerified(
+				parseEvidence(
+					evidence({
+						source: "guest-fingerprint",
+						requested: BAKED,
+						fingerprint: FINGERPRINT,
+					}),
+				),
+			),
+		).toBe(true);
+	});
+
+	it("reports the effective artifact without duplicating it", () => {
+		expect(
+			effectiveArtifact(parseProvenance({ source: "request-fallback", requested: BAKED })),
+		).toEqual(BAKED);
+		expect(
+			effectiveArtifact(
+				parseProvenance({ source: "driver-reported", requested: BAKED, reported: BAKED }),
+			),
+		).toEqual(BAKED);
+	});
+});
+
+describe("provider artifact evidence", () => {
+	it("joins attribution to a complete benchmark cell and sandbox", () => {
+		const parsed = parseEvidence(evidence({ source: "request-fallback", requested: BAKED }));
+		expect(parsed.cell).toEqual(CELL);
+		expect(parsed.sandboxId).toBe("isandbox");
+	});
+
+	it("rejects a requested artifact kind outside the provider registry contract", () => {
+		expect(() =>
+			parseEvidence(
+				evidence({
+					source: "request-fallback",
+					requested: { kind: "image", ref: "image" },
+				}),
+			),
+		).toThrow(/requested kind matches e2b/);
+	});
+
+	it("rejects missing identity and undeclared keys", () => {
+		expect(() =>
+			parseEvidence({ cell: CELL, provenance: { source: "request-fallback", requested: BAKED } }),
+		).toThrow();
+		expect(() =>
+			parseEvidence({
+				...evidence({ source: "request-fallback", requested: BAKED }),
+				note: "extra",
+			}),
+		).toThrow();
+	});
+});

--- a/packages/schema/src/artifact-evidence.ts
+++ b/packages/schema/src/artifact-evidence.ts
@@ -1,0 +1,211 @@
+// Artifact provenance for a published Run (ADR-0007 §2, ADR-0008 §2's artifact-identity row).
+//
+// The benchmark's headline claim is "this provider, running THIS toolchain, produced these numbers".
+// Until now the document recorded the numbers and the provider but never the third term: which
+// artifact actually booted. The requested ref was the only thing written down, and a requested ref is
+// not an observation — it is the instruction we gave, restated.
+//
+// So the evidence is a discriminated union over HOW the effective artifact was established, not a
+// bag of optional fields plus a label that could disagree with them. `{ source: "guest-fingerprint" }`
+// without a fingerprint is unrepresentable rather than merely invalid, which is the same discipline
+// ADR-0007 applies to `ExecutionPolicy` and `Exit`.
+
+import { type } from "arktype";
+import { providerCostCellSchema } from "./cost-evidence.ts";
+import type { DriverResolvedArtifact } from "./driver-schemas.ts";
+import { resolvedArtifactSchema } from "./driver-schemas.ts";
+import { bakedArtifactName, isBakedProviderId } from "./provider-artifacts.ts";
+import type { ProviderId } from "./provider-ids.ts";
+import { REGISTRY } from "./provider-meta/index.ts";
+import {
+	TOOLCHAIN_IMAGE_NAME,
+	TOOLCHAIN_IMAGE_REPOSITORY,
+	TOOLCHAIN_VERSION,
+	toolchainImageRef,
+	VERCEL_PROJECT_NAME_DEFAULT,
+	VERCEL_TEAM_SLUG_DEFAULT,
+	vercelVcrImageRefs,
+} from "./toolchain.ts";
+
+const boundedString = (maximum: number) =>
+	type("string >= 1").narrow(
+		(value, ctx) =>
+			value.length <= maximum || ctx.mustBe(`a non-empty string of at most ${maximum} characters`),
+	);
+
+/** One bounded field read from the in-guest toolchain manifest. */
+const fingerprintString = boundedString(256);
+
+/**
+ * What the guest actually reported from the release-owned manifest.
+ *
+ * The expected value is deliberately NOT persisted beside it: letting a producer supply both
+ * `expected` and `observed` permits any internally consistent pair. The provider/artifact mapping
+ * below derives the expectation from release constants, then the evidence schema performs the
+ * comparison. That is what makes `guest-fingerprint` an observation rather than two matching claims.
+ */
+export const guestFingerprintSchema = type({
+	authority: "'toolchain-manifest-v1'",
+	imageName: fingerprintString,
+	imageVersion: fingerprintString,
+}).onUndeclaredKey("reject");
+export type GuestFingerprint = typeof guestFingerprintSchema.infer;
+const sandboxIdString = boundedString(256);
+
+const EXPECTED_TOOLCHAIN_FINGERPRINT: GuestFingerprint = Object.freeze({
+	authority: "toolchain-manifest-v1",
+	imageName: TOOLCHAIN_IMAGE_NAME,
+	imageVersion: TOOLCHAIN_VERSION,
+});
+
+/**
+ * Release-owned fingerprint for a canonical provider artifact.
+ *
+ * Returning `undefined` is intentional for stock boots and arbitrary overrides: those can still be
+ * recorded as request fallback (or driver-reported), but a producer cannot upgrade them to guest
+ * verification without first adding an authoritative release mapping here.
+ */
+export function expectedToolchainFingerprint(
+	providerId: ProviderId,
+	requested: DriverResolvedArtifact,
+): GuestFingerprint | undefined {
+	const descriptor = REGISTRY[providerId].artifact;
+	if (descriptor.kind !== requested.kind || requested.kind === "none") return;
+	let canonical = false;
+	switch (requested.kind) {
+		case "image":
+			canonical =
+				requested.ref === toolchainImageRef("version") ||
+				requested.ref === toolchainImageRef("candidate") ||
+				isRepositoryDigest(requested.ref, TOOLCHAIN_IMAGE_REPOSITORY);
+			break;
+		case "baked":
+			if (isBakedProviderId(providerId)) {
+				canonical =
+					requested.ref === bakedArtifactName(providerId, "version") ||
+					requested.ref === bakedArtifactName(providerId, "candidate");
+			}
+			break;
+		case "mirror": {
+			const refs = vercelVcrImageRefs(VERCEL_TEAM_SLUG_DEFAULT, VERCEL_PROJECT_NAME_DEFAULT);
+			canonical =
+				requested.ref === refs.version ||
+				requested.ref === refs.candidate ||
+				isRepositoryDigest(requested.ref, refs.repository);
+			break;
+		}
+	}
+	return canonical ? EXPECTED_TOOLCHAIN_FINGERPRINT : undefined;
+}
+
+/** A content-addressed image inside a release-owned repository (the bake validation path). */
+function isRepositoryDigest(ref: string, repository: string): boolean {
+	const prefix = `${repository}@sha256:`;
+	return ref.startsWith(prefix) && /^[a-f0-9]{64}$/.test(ref.slice(prefix.length));
+}
+
+/**
+ * How the effective boot artifact was established, strongest evidence last.
+ *
+ * - `request-fallback` — nobody observed the boot. The vendor exposes no report and no fingerprint
+ *   was taken, so all we can honestly say is what we asked for. ADR-0008 §5 treats this as
+ *   `unverified` for matrix admission: it is the absence of evidence, not weak evidence.
+ * - `driver-reported` — the control plane confirmed what it booted. `reported` must equal
+ *   `requested`, because ADR-0007 makes a differing report a create-time contradiction that tears
+ *   down the orphan; a persisted disagreement would mean that teardown did not happen.
+ * - `guest-fingerprint` — the strongest form: the guest itself identified the artifact from inside
+ *   the sandbox, so the claim no longer depends on the control plane being truthful. Only the
+ *   observed manifest identity is recorded; the schema derives the expected identity from release
+ *   constants and the provider's canonical requested artifact.
+ */
+export const artifactProvenanceSchema = type
+	.or(
+		{ source: "'request-fallback'", requested: resolvedArtifactSchema },
+		{
+			source: "'driver-reported'",
+			requested: resolvedArtifactSchema,
+			reported: resolvedArtifactSchema,
+		},
+		{
+			source: "'guest-fingerprint'",
+			requested: resolvedArtifactSchema,
+			fingerprint: guestFingerprintSchema,
+			"reported?": resolvedArtifactSchema,
+		},
+	)
+	.onUndeclaredKey("reject")
+	.narrow((provenance, ctx) => {
+		if (!("reported" in provenance) || provenance.reported === undefined) return true;
+		const { requested, reported } = provenance;
+		if (reported.kind !== requested.kind) {
+			return ctx.mustBe(
+				`a driver-reported artifact whose kind matches the request (requested ${requested.kind}, reported ${reported.kind})`,
+			);
+		}
+		// `kind: "none"` carries no ref on either side, so the refs agree by construction.
+		if ("ref" in requested && "ref" in reported && requested.ref !== reported.ref) {
+			return ctx.mustBe(
+				`a driver-reported artifact whose ref matches the request (requested ${requested.ref}, reported ${reported.ref})`,
+			);
+		}
+		return true;
+	});
+export type ArtifactProvenance = typeof artifactProvenanceSchema.infer;
+
+/** One sandbox's artifact attribution, written before teardown so a destroyed sandbox still has it. */
+export const providerArtifactEvidenceSchema = type({
+	/** Complete benchmark cell identity, so aggregate evidence cannot drift across shards. */
+	cell: providerCostCellSchema,
+	/** The vendor's sandbox id, so evidence joins to the sandbox that produced the measurements. */
+	sandboxId: sandboxIdString,
+	provenance: artifactProvenanceSchema,
+})
+	.onUndeclaredKey("reject")
+	.narrow((evidence, ctx) => {
+		const { providerId } = evidence.cell;
+		const { requested } = evidence.provenance;
+		const declaredKind = REGISTRY[providerId].artifact.kind;
+		if (requested.kind !== declaredKind) {
+			return ctx.mustBe(
+				`artifact evidence whose requested kind matches ${providerId}'s registry declaration (${declaredKind})`,
+			);
+		}
+		if (evidence.provenance.source !== "guest-fingerprint") return true;
+		const expected = expectedToolchainFingerprint(providerId, requested);
+		if (expected === undefined) {
+			return ctx.mustBe(
+				`guest fingerprint evidence for a canonical ${providerId} release artifact (got ${JSON.stringify(requested)})`,
+			);
+		}
+		const observed = evidence.provenance.fingerprint;
+		if (
+			observed.authority !== expected.authority ||
+			observed.imageName !== expected.imageName ||
+			observed.imageVersion !== expected.imageVersion
+		) {
+			return ctx.mustBe(
+				`a ${expected.authority} fingerprint matching ${expected.imageName}@${expected.imageVersion}`,
+			);
+		}
+		return true;
+	});
+export type ProviderArtifactEvidence = typeof providerArtifactEvidenceSchema.infer;
+
+/**
+ * Whether this attribution rests on an observation rather than on the request alone.
+ *
+ * ADR-0008 §5 admits a provider to the published matrix only on observed evidence, so this is the
+ * predicate the admission gate reads. Kept as a function beside the union rather than as a stored
+ * boolean: a persisted flag could contradict its own `source`, and there would be no way to tell
+ * which of the two was the lie.
+ */
+export function artifactVerified(evidence: ProviderArtifactEvidence): boolean {
+	return evidence.provenance.source !== "request-fallback";
+}
+
+/** The artifact a sandbox effectively booted, whatever established it. */
+export function effectiveArtifact(provenance: ArtifactProvenance): ArtifactProvenance["requested"] {
+	return "reported" in provenance && provenance.reported !== undefined
+		? provenance.reported
+		: provenance.requested;
+}

--- a/packages/schema/src/index.ts
+++ b/packages/schema/src/index.ts
@@ -5,6 +5,8 @@ import { rawRunSchema } from "./lib/internal.ts";
 
 // Pure analysis over retained Samples: the Aggregates distribution and how it's computed.
 export * from "./analysis.ts";
+// Sandbox-attributed artifact provenance: which toolchain booted, and what established that.
+export * from "./artifact-evidence.ts";
 // Bounded canonical JSON shared by evidence producers and deterministic consumers.
 export * from "./canonical-json.ts";
 // The Metric Catalog — the registry of rankable Metrics, plus lookup helpers.

--- a/packages/schema/src/raw-files.test.ts
+++ b/packages/schema/src/raw-files.test.ts
@@ -3,12 +3,16 @@ import type { ProviderRun, ResultGap } from "./index.ts";
 import {
 	aggregate,
 	harnessGapMarkerJson,
+	isProviderArtifactEvidenceFile,
 	isPtsForensicsFile,
 	isPtsResultFile,
 	isSkipMarkerFile,
 	parseGapMarker,
+	parseProviderArtifactEvidence,
 	parseProviderCostEvidence,
 	parseResultsArtifactName,
+	providerArtifactEvidenceFile,
+	providerArtifactEvidenceJson,
 	providerCostEvidenceFile,
 	providerCostEvidenceJson,
 	providerReportedNothing,
@@ -18,6 +22,26 @@ import {
 } from "./index.ts";
 
 describe("raw-file naming", () => {
+	it("round-trips bounded host-owned artifact evidence with deterministic bytes", () => {
+		const record = {
+			cell: { runId: "run-1", providerId: "e2b", suite: "cpu-node" },
+			sandboxId: "sb-1",
+			provenance: {
+				source: "request-fallback" as const,
+				requested: { kind: "baked" as const, ref: "sandbox-benchmarks-toolchain-v8" },
+			},
+		} as const;
+		expect(providerArtifactEvidenceFile()).toBe("provider-artifact-evidence.json");
+		expect(isProviderArtifactEvidenceFile(providerArtifactEvidenceFile())).toBe(true);
+		expect(isProviderArtifactEvidenceFile("provider-cost-evidence.json")).toBe(false);
+		const bytes = providerArtifactEvidenceJson(record);
+		expect(bytes.endsWith("\n")).toBe(true);
+		expect(parseProviderArtifactEvidence(bytes)).toEqual(record);
+		expect(() => parseProviderArtifactEvidence(`{"padding":"${"x".repeat(17 * 1024)}"}`)).toThrow(
+			/exceeds 16 KiB/,
+		);
+	});
+
 	it("round-trips strict provider cost evidence with deterministic bytes", () => {
 		const record = {
 			kind: "missing" as const,
@@ -368,6 +392,45 @@ describe("providerReportedNothing", () => {
 			providerReportedNothing({
 				...empty(),
 				hostMetadata: [{ source: "mise/system-provider", sourceFile: "s.json", fields: [] }],
+			}),
+		).toBe(false);
+		// A booted sandbox leaves an artifact attribution even when it produced nothing else, so a
+		// provider that has one is not a never-dispatched row. `costEvidence` counted already but was
+		// never asserted here, which left this test's "EACH" claim untrue for both sandbox-scoped
+		// arrays.
+		expect(
+			providerReportedNothing({
+				...empty(),
+				artifactEvidence: [
+					{
+						cell: {
+							runId: "run-1",
+							providerId: "modal-vm",
+							suite: "cpu-node",
+						},
+						sandboxId: "isandbox",
+						provenance: {
+							source: "request-fallback",
+							requested: { kind: "baked", ref: "toolchain-v8" },
+						},
+					},
+				],
+			}),
+		).toBe(false);
+		expect(
+			providerReportedNothing({
+				...empty(),
+				costEvidence: [
+					{
+						kind: "missing",
+						cell: { runId: "run-1", providerId: "modal-vm", suite: "cpu-node" },
+						subject: { kind: "sandbox", sandboxId: "sb-1" },
+						capturedAt: "2026-06-20T00:00:00.000Z",
+						sdk: { packageName: "modal", version: "0.9.0" },
+						reason: "sandbox_teardown_unconfirmed",
+						detail: "teardown was not confirmed",
+					},
+				],
 			}),
 		).toBe(false);
 	});

--- a/packages/schema/src/raw-files.ts
+++ b/packages/schema/src/raw-files.ts
@@ -25,6 +25,8 @@
  * lifecycle timing files (`<name>_ms.txt`, `<name>-exit-code.txt`) land with the lifecycle path.
  */
 import { type } from "arktype";
+import type { ProviderArtifactEvidence } from "./artifact-evidence.ts";
+import { providerArtifactEvidenceSchema } from "./artifact-evidence.ts";
 import type { ProviderCostEvidence } from "./cost-evidence.ts";
 import { providerCostEvidenceSchema } from "./cost-evidence.ts";
 import type { GapCause, GapOutcome, ResultGap } from "./run.ts";
@@ -32,9 +34,52 @@ import { gapCauseSchema, gapOutcomeOfCause, gapOutcomeSchema } from "./run.ts";
 
 const SKIP_SUFFIX = "--skipped.json";
 const FAILURE_SUFFIX = "--failed.json";
+const PROVIDER_ARTIFACT_EVIDENCE_FILE = "provider-artifact-evidence.json";
 const PROVIDER_COST_EVIDENCE_FILE = "provider-cost-evidence.json";
+/** The artifact envelope is small: cell, sandbox id, requested ref, and one manifest identity. */
+export const MAX_PROVIDER_ARTIFACT_EVIDENCE_FILE_BYTES = 16 * 1024;
 /** Pretty-printed envelope ceiling; responseJson itself is capped at 64 KiB. */
 export const MAX_PROVIDER_COST_EVIDENCE_FILE_BYTES = 96 * 1024;
+
+/** Fixed raw filename for one suite sandbox's artifact attribution. */
+export function providerArtifactEvidenceFile(): string {
+	return PROVIDER_ARTIFACT_EVIDENCE_FILE;
+}
+
+export function isProviderArtifactEvidenceFile(filename: string): boolean {
+	return filename === PROVIDER_ARTIFACT_EVIDENCE_FILE;
+}
+
+/** Deterministic, schema-validated bytes written by the host harness. */
+export function providerArtifactEvidenceJson(record: ProviderArtifactEvidence): string {
+	const parsed = providerArtifactEvidenceSchema(record);
+	if (parsed instanceof type.errors)
+		throw new Error(`invalid provider artifact evidence: ${parsed.summary}`);
+	const json = `${JSON.stringify(parsed, null, 2)}\n`;
+	if (new TextEncoder().encode(json).byteLength > MAX_PROVIDER_ARTIFACT_EVIDENCE_FILE_BYTES) {
+		throw new Error("provider artifact evidence file exceeds 16 KiB");
+	}
+	return json;
+}
+
+/** Strict parser: recognized malformed attribution is a normalization error, never absence. */
+export function parseProviderArtifactEvidence(data: unknown): ProviderArtifactEvidence {
+	let value = data;
+	if (typeof data === "string") {
+		if (new TextEncoder().encode(data).byteLength > MAX_PROVIDER_ARTIFACT_EVIDENCE_FILE_BYTES) {
+			throw new Error("provider artifact evidence file exceeds 16 KiB");
+		}
+		try {
+			value = JSON.parse(data);
+		} catch {
+			throw new Error("invalid provider artifact evidence JSON");
+		}
+	}
+	const parsed = providerArtifactEvidenceSchema(value);
+	if (parsed instanceof type.errors)
+		throw new Error(`invalid provider artifact evidence: ${parsed.summary}`);
+	return parsed;
+}
 
 /** Fixed raw filename for one suite sandbox's provider cost evidence. */
 export function providerCostEvidenceFile(): string {

--- a/packages/schema/src/run.test.ts
+++ b/packages/schema/src/run.test.ts
@@ -42,7 +42,7 @@ describe("Run schema", () => {
 		expect(run.providers[0]?.validationStatus).toBe("validated");
 	});
 
-	it("accepts every published schemaVersion from v2 through v5", () => {
+	it("accepts every published schemaVersion from v2 through v6", () => {
 		for (const schemaVersion of ["2", "3", "4"] as const) {
 			expect(parseRun({ ...validRun, schemaVersion }).schemaVersion).toBe(schemaVersion);
 		}
@@ -52,6 +52,170 @@ describe("Run schema", () => {
 			(provider as Record<string, unknown>).costEvidence = [];
 		}
 		expect(parseRun(v5).schemaVersion).toBe("5");
+
+		const v6 = structuredClone(v5);
+		v6.schemaVersion = "6";
+		for (const provider of v6.providers) {
+			(provider as Record<string, unknown>).artifactEvidence = [
+				{
+					cell: { runId: "run-1", providerId: "daytona-vm", suite: "cpu-node" },
+					sandboxId: "isandbox",
+					provenance: {
+						source: "request-fallback",
+						requested: { kind: "baked", ref: "toolchain-v8" },
+					},
+				},
+			];
+		}
+		expect(parseRun(v6).schemaVersion).toBe("6");
+	});
+
+	it("gates artifact evidence at v6 in both directions", () => {
+		const evidence = {
+			cell: { runId: "run-1", providerId: "daytona-vm", suite: "cpu-node" },
+			sandboxId: "isandbox",
+			provenance: {
+				source: "request-fallback",
+				requested: { kind: "baked", ref: "toolchain-v8" },
+			},
+		};
+
+		// Writing the field without bumping the version is rejected here, rather than reaching a
+		// v6-gated consumer that would read the attribution as if the producer had declared it.
+		const early = structuredClone(validRun);
+		for (const provider of early.providers) {
+			(provider as Record<string, unknown>).artifactEvidence = [evidence];
+		}
+		expect(() => parseRun(early)).toThrow(/v6 Run when a ProviderRun carries artifactEvidence/);
+
+		// And a v6 Run cannot omit the attribution that is the whole point of the version.
+		const missing = structuredClone(validRun);
+		missing.schemaVersion = "6";
+		for (const provider of missing.providers) {
+			(provider as Record<string, unknown>).costEvidence = [];
+		}
+		expect(() => parseRun(missing)).toThrow(/v6 ProviderRun with an artifactEvidence array/);
+
+		const valid = structuredClone(missing);
+		for (const provider of valid.providers) {
+			(provider as Record<string, unknown>).artifactEvidence = [evidence];
+		}
+		const parsed = parseRun(valid);
+		expect(parsed.providers[0]?.artifactEvidence?.[0]?.provenance.source).toBe("request-fallback");
+	});
+
+	it("will not let a measured v6 provider claim it never booted", () => {
+		// An empty array asserts "this provider booted nothing". A row carrying Metrics measured that
+		// inside a sandbox, so the two cannot both be true — and an unattributed measurement is the
+		// exact gap v6 exists to close.
+		const unattributed = structuredClone(validRun);
+		unattributed.schemaVersion = "6";
+		for (const provider of unattributed.providers) {
+			(provider as Record<string, unknown>).costEvidence = [];
+			(provider as Record<string, unknown>).artifactEvidence = [];
+		}
+		expect(() => parseRun(unattributed)).toThrow(/metrics carry artifact attribution/);
+
+		// A row that measured nothing may still legitimately carry an empty array.
+		const noMetrics = structuredClone(unattributed);
+		for (const provider of noMetrics.providers) {
+			(provider as Record<string, unknown>).metrics = [];
+			(provider as Record<string, unknown>).validationStatus = "pending";
+		}
+		expect(parseRun(noMetrics).schemaVersion).toBe("6");
+	});
+
+	it("rejects a persisted driver report that contradicts its request", () => {
+		// ADR-0007 makes a differing report a create-time contradiction that tears down the orphan, so
+		// a Run carrying the disagreement would mean that teardown never happened.
+		const contradiction = structuredClone(validRun);
+		contradiction.schemaVersion = "6";
+		for (const provider of contradiction.providers) {
+			(provider as Record<string, unknown>).costEvidence = [];
+			(provider as Record<string, unknown>).artifactEvidence = [
+				{
+					cell: { runId: "run-1", providerId: "daytona-vm", suite: "cpu-node" },
+					sandboxId: "isandbox",
+					provenance: {
+						source: "driver-reported",
+						requested: { kind: "baked", ref: "toolchain-v8" },
+						reported: { kind: "baked", ref: "toolchain-v7" },
+					},
+				},
+			];
+		}
+		expect(() => parseRun(contradiction)).toThrow(/ref matches the request/);
+	});
+
+	it("keeps artifact attribution joined to one unambiguous benchmark cell", () => {
+		const attributed = structuredClone(validRun);
+		attributed.schemaVersion = "6";
+		const provider = attributed.providers[0] as Record<string, unknown>;
+		provider.costEvidence = [];
+		provider.artifactEvidence = [
+			{
+				cell: { runId: "run-1", providerId: "daytona-vm", suite: "cpu-node" },
+				sandboxId: "sb-1",
+				provenance: {
+					source: "request-fallback",
+					requested: { kind: "baked", ref: "sandbox-benchmarks-toolchain-v8" },
+				},
+			},
+		];
+		expect(parseRun(attributed).schemaVersion).toBe("6");
+
+		const wrongParent = structuredClone(attributed);
+		const wrongEvidence = (
+			(wrongParent.providers[0] as Record<string, unknown>).artifactEvidence as Array<
+				Record<string, unknown>
+			>
+		)[0];
+		if (wrongEvidence)
+			wrongEvidence.cell = { runId: "other", providerId: "daytona-vm", suite: "cpu-node" };
+		expect(() => parseRun(wrongParent)).toThrow(/match its parent Run/);
+
+		const wrongShard = structuredClone(attributed);
+		(wrongShard as Record<string, unknown>).replicateIndex = 1;
+		expect(() => parseRun(wrongShard)).toThrow(/replicateIndex matches the Run/);
+
+		const duplicateCell = structuredClone(attributed);
+		const records = (duplicateCell.providers[0] as Record<string, unknown>)
+			.artifactEvidence as Array<Record<string, unknown>>;
+		records.push({ ...structuredClone(records[0]), sandboxId: "sb-2" });
+		expect(() => parseRun(duplicateCell)).toThrow(/at most one artifact attribution/);
+
+		const reusedSandbox = structuredClone(attributed);
+		const reusedRecords = (reusedSandbox.providers[0] as Record<string, unknown>)
+			.artifactEvidence as Array<Record<string, unknown>>;
+		reusedRecords.push({
+			...structuredClone(reusedRecords[0]),
+			cell: { runId: "run-1", providerId: "daytona-vm", suite: "system" },
+		});
+		expect(() => parseRun(reusedSandbox)).toThrow(/sandbox id used by exactly one benchmark cell/);
+
+		const sameArtifact = structuredClone(attributed);
+		const sameRecords = (sameArtifact.providers[0] as Record<string, unknown>)
+			.artifactEvidence as Array<Record<string, unknown>>;
+		sameRecords.push({
+			cell: { runId: "run-1", providerId: "daytona-vm", suite: "system" },
+			sandboxId: "sb-2",
+			provenance: {
+				source: "request-fallback",
+				// Deliberately reverse the JSON key order; identity is semantic, not byte-order-sensitive.
+				requested: { ref: "sandbox-benchmarks-toolchain-v8", kind: "baked" },
+			},
+		});
+		expect(parseRun(sameArtifact).providers[0]?.artifactEvidence).toHaveLength(2);
+
+		const mixedArtifact = structuredClone(sameArtifact);
+		const mixedRecords = (mixedArtifact.providers[0] as Record<string, unknown>)
+			.artifactEvidence as Array<Record<string, unknown>>;
+		const second = mixedRecords[1] as Record<string, unknown>;
+		second.provenance = {
+			source: "request-fallback",
+			requested: { kind: "baked", ref: "different-template" },
+		};
+		expect(() => parseRun(mixedArtifact)).toThrow(/one effective artifact across every sandbox/);
 	});
 
 	it("gates cost evidence at v5 and checks its parent cell identity", () => {

--- a/packages/schema/src/run.ts
+++ b/packages/schema/src/run.ts
@@ -9,7 +9,8 @@
  */
 import { type } from "arktype";
 import { aggregatesSchema } from "./analysis.ts";
-import { providerCostEvidenceSchema } from "./cost-evidence.ts";
+import { effectiveArtifact, providerArtifactEvidenceSchema } from "./artifact-evidence.ts";
+import { providerCostCellKey, providerCostEvidenceSchema } from "./cost-evidence.ts";
 import { runIdSchema } from "./identifiers.ts";
 import { directionSchema } from "./metrics.ts";
 import type { TargetSpec } from "./target-spec.ts";
@@ -658,6 +659,16 @@ export const providerRunSchema = type({
 	providerId: "string",
 	/** Sandbox-scoped provider cost evidence (required by the Run v5 gate below). */
 	"costEvidence?": providerCostEvidenceSchema.array(),
+	/**
+	 * Sandbox-scoped artifact attribution — which toolchain each sandbox actually booted, and what
+	 * established that (required by the Run v6 gate below).
+	 *
+	 * An array, like `costEvidence`, because a ProviderRun can span replicate sandboxes and each
+	 * boots its own artifact. Empty means the provider never booted anything (a skip), which is a
+	 * different fact from a provider that booted something nobody observed — that one records a
+	 * `request-fallback` entry.
+	 */
+	"artifactEvidence?": providerArtifactEvidenceSchema.array(),
 	validationStatus: validationStatusSchema,
 	// Whether observed specs honored the pinned target spec; absent when probes saw too little to judge.
 	"specMatched?": "boolean",
@@ -773,7 +784,8 @@ export type ProviderRun = typeof providerRunSchema.infer;
  * gap, no uncatalogued straggler, no observed-spec reading, no host-metadata record. This is exactly
  * the shape the normalizer emits for an absent raw directory — a registered provider the run never
  * dispatched (or whose every cell was lost before reporting anything). It is deliberately stricter
- * than "no metrics": a straggler, a spec probe, or a host record IS participation evidence, and a
+ * than "no metrics": a straggler, a spec probe, a host record, or an artifact attribution IS
+ * participation evidence, and a
  * provider that reported any of them belongs in the coverage derivation, not in the absent list.
  * Consumers (the leaderboard's coverage derivation, the CLI status logs) use it to keep the pending
  * dataset row first-class while not accusing a never-dispatched provider of per-suite holes.
@@ -788,7 +800,10 @@ export function providerReportedNothing(p: ProviderRun): boolean {
 		p.uncatalogued.length === 0 &&
 		Object.keys(p.observedSpecs).length === 0 &&
 		(p.hostMetadata?.length ?? 0) === 0 &&
-		(p.costEvidence?.length ?? 0) === 0
+		(p.costEvidence?.length ?? 0) === 0 &&
+		// A booted sandbox leaves an attribution even when it produced nothing else; counting it here
+		// keeps a provider that booted and then failed out of the never-dispatched list.
+		(p.artifactEvidence?.length ?? 0) === 0
 	);
 }
 
@@ -805,7 +820,7 @@ export function providerStatusText(p: ProviderRun): string {
 /**
  * A full benchmark Run: every provider measured against one pinned target spec at one SHA.
  *
- * `schemaVersion` accepts `"2"` through `"5"`. v1's `skips: { suite, reason }[]` could not say
+ * `schemaVersion` accepts `"2"` through `"6"`. v1's `skips: { suite, reason }[]` could not say
  * whether a benchmark was deliberately not run or had crashed, and carried no positive record of what
  * DID run — so a suite that vanished (job died, artifact never uploaded) left no trace anywhere in the
  * document. v2 replaced it with {@link resultGapSchema} + {@link ProviderRun.suitesCovered}. v3 adds
@@ -830,11 +845,18 @@ export function providerStatusText(p: ProviderRun): string {
  * historical versions cannot carry one, so absence in an older Run remains absence rather than a
  * fabricated zero or backfill.
  *
+ * v6 adds the sandbox-scoped ARTIFACT attribution beside it. The benchmark's headline claim names a
+ * toolchain, but until v6 the document retained no cell-bound artifact evidence at all. Each entry
+ * records the exact request and how the effective artifact was established
+ * ({@link ProviderArtifactEvidence}), so a reader can tell a control-plane confirmation or an in-guest
+ * fingerprint from an unobserved request fallback. Historical Runs cannot carry it, so their silence
+ * stays silence rather than being backfilled into a claim nobody made.
+ *
  * Every version validates here — already-published Runs are read unchanged, and the parser never
  * migrates them in place.
  */
 export const runSchema = type({
-	schemaVersion: "'2' | '3' | '4' | '5'",
+	schemaVersion: "'2' | '3' | '4' | '5' | '6'",
 	runId: runIdSchema,
 	sha: "string",
 	// ISO-8601 timestamp the Run was generated at — validated so the RunIndex sort key can't be a
@@ -907,6 +929,29 @@ export const runSchema = type({
 		if (version >= 5 && provider.costEvidence === undefined) {
 			return ctx.mustBe("a v5 ProviderRun with a costEvidence array");
 		}
+		// v6 gates artifactEvidence exactly as v5 gates costEvidence: forbidden below its floor so a
+		// producer that writes the field without bumping the version is rejected here rather than read
+		// by a v6-gated consumer, and required at the floor so a v6 Run cannot omit the attribution
+		// that is the whole point of the version.
+		if (version < 6 && provider.artifactEvidence !== undefined) {
+			return ctx.mustBe("a v6 Run when a ProviderRun carries artifactEvidence");
+		}
+		if (version >= 6 && provider.artifactEvidence === undefined) {
+			return ctx.mustBe("a v6 ProviderRun with an artifactEvidence array");
+		}
+		// Presence alone was not enough: the array's own doc says empty means "never booted", and
+		// nothing held a producer to it. A Metric is a measurement taken inside a sandbox, so a v6 row
+		// carrying metrics and no attribution is exactly the unattributed measurement this version
+		// exists to make impossible — the empty array stays legal only for a row that measured nothing.
+		if (
+			version >= 6 &&
+			provider.metrics.length > 0 &&
+			(provider.artifactEvidence?.length ?? 0) === 0
+		) {
+			return ctx.mustBe(
+				"a v6 ProviderRun whose metrics carry artifact attribution (an empty artifactEvidence array claims the provider never booted)",
+			);
+		}
 		for (const evidence of provider.costEvidence ?? []) {
 			if (evidence.cell.runId !== run.runId || evidence.cell.providerId !== provider.providerId) {
 				return ctx.mustBe("cost evidence whose runId and providerId match its parent Run");
@@ -914,6 +959,36 @@ export const runSchema = type({
 			if (run.replicateIndex !== undefined && evidence.cell.replicateIndex !== run.replicateIndex) {
 				return ctx.mustBe("shard cost evidence whose replicateIndex matches the Run");
 			}
+		}
+		const artifactCells = new Set<string>();
+		const artifactSandboxes = new Set<string>();
+		let effectiveArtifactKey: string | undefined;
+		for (const evidence of provider.artifactEvidence ?? []) {
+			if (evidence.cell.runId !== run.runId || evidence.cell.providerId !== provider.providerId) {
+				return ctx.mustBe("artifact evidence whose runId and providerId match its parent Run");
+			}
+			if (run.replicateIndex !== undefined && evidence.cell.replicateIndex !== run.replicateIndex) {
+				return ctx.mustBe("shard artifact evidence whose replicateIndex matches the Run");
+			}
+			const cellKey = providerCostCellKey(evidence);
+			if (artifactCells.has(cellKey)) {
+				return ctx.mustBe("at most one artifact attribution for each benchmark cell");
+			}
+			artifactCells.add(cellKey);
+			if (artifactSandboxes.has(evidence.sandboxId)) {
+				return ctx.mustBe("an artifact sandbox id used by exactly one benchmark cell");
+			}
+			artifactSandboxes.add(evidence.sandboxId);
+			const artifact = effectiveArtifact(evidence.provenance);
+			// A tuple fixes comparison order even when an input JSON object listed `ref` before `kind`.
+			const currentArtifactKey = JSON.stringify([
+				artifact.kind,
+				"ref" in artifact ? artifact.ref : null,
+			]);
+			if (effectiveArtifactKey !== undefined && currentArtifactKey !== effectiveArtifactKey) {
+				return ctx.mustBe("one effective artifact across every sandbox of a provider Run");
+			}
+			effectiveArtifactKey = currentArtifactKey;
 		}
 	}
 	// `replicateIndex` marks a per-replicate SHARD (one sandbox, not yet folded); `MetricResult.replicates`


### PR DESCRIPTION
Completes the artifact-provenance half of the driver migration on top of #407. Run v6 is now an end-to-end producer and consumer contract, not a schema-only placeholder.

## What changed

- Adds cell-bound `ProviderArtifactEvidence` with complete run/provider/suite/replicate identity, sandbox id, the exact requested `DriverResolvedArtifact`, and a closed provenance union.
- Makes guest verification authoritative. Evidence stores only the observed `/toolchain-manifest.json` identity; schema derives the expected image name/version from release constants and the provider's canonical artifact mapping. A producer cannot choose both sides of the comparison.
- Accepts canonical version/candidate refs and content-addressed digests in release-owned repositories. Arbitrary overrides remain honest `request-fallback` evidence and cannot be upgraded to guest-verified.
- Rejects request/report contradictions, stale manifests, provider-kind mismatches, parent-cell mismatches, duplicate cells, reused sandbox ids, and mixed effective artifacts within one provider Run.
- Requires measured v6 provider rows to carry attribution while preserving an empty array for providers that never booted.

## Real producer path

- Every legacy provider adapter now carries the exact artifact beside the create policy that selects it.
- Candidate validation derives its create override and recorded artifact from one projection, so those values cannot drift.
- The harness atomically writes request fallback before its first sandbox operation. Once a canonical artifact is ready, it reads the bounded guest manifest and atomically upgrades the record to `guest-fingerprint`; a stale or missing canonical manifest fails before benchmarking.
- Artifact evidence is a reserved host-owned raw filename. Sandbox collection rejects attempts to forge either artifact or cost evidence.

## Normalization and aggregation

- `normalizeResultsTree` emits Run v6 and strictly reads bounded, no-follow artifact evidence.
- Aggregation deterministically preserves one record per cell, deduplicates identical copies, rejects conflicts and sandbox reuse, and emits v6 only when every shard is v6. Mixing v6 with older shards fails instead of silently dropping attribution; all-pre-v6 inputs retain the historical v5 aggregate behavior.
- Repricing preserves v6 attribution unchanged.

## Validation

- `bun run lint`
- `bun run typecheck` across all workspace members
- schema, providers, results, harness, and candidate-validation suites
- `bun run spell`
- `bun run check:catalog-drift`
- `bun run lint:shell`
- `bun run lint:docker`
- Modal's loopback-dependent 31-test file passes outside the filesystem/network sandbox; the full workspace suite has no other failures.

The regression tests cover the original review finding directly: a canonical requested v8 artifact with a v7 guest manifest is rejected, and an arbitrary producer-selected ref cannot become verified by supplying the current manifest fields.
