### PR TITLE
feat(cli): add opt-in DriverModule benchmark path

### DIFF
--- a/apps/cli/src/bin/bench-suite.ts
+++ b/apps/cli/src/bin/bench-suite.ts
@@ -45,6 +45,7 @@ import {
 	writeJobSummary,
 } from "../lib/actions-log.ts";
 import { handleDiscovery } from "../lib/discovery.ts";
+import { runDriverSuite } from "../lib/driver-run.ts";
 import { installLineTagging, withLineTag } from "../lib/log-prefix.ts";
 import {
 	fleetBudgetError,
@@ -118,6 +119,8 @@ usage: bench-suite [provider] [suite] [runId]
                           un-suffixed data/runs/<runId>.json — the single-sandbox/local form.
   --require <ids>         Comma-separated providers that MUST reach "validated"; exit 1 otherwise.
                           Also read from REQUIRE_PROVIDERS. CI sets this so a missing secret fails loudly.
+  --driver-path           Use the provider's registered DriverModule. Unmigrated providers fail as a
+                          usage error; this never falls back to packages/providers.
   --list-providers        List the registered providers.
   --list-suites           List the registered suites and their dimensions/metrics.
   --json                  Emit --list-* output as JSON instead of human-readable lines.
@@ -130,6 +133,7 @@ examples:
   bench-suite daytona-vm cpu-node                 # one suite locally, auto runId
   bench-suite modal-vm memory ci-1234             # a specific cell + runId
   bench-suite e2b memory --require e2b            # fail (don't skip) if E2B_API_KEY is absent
+  bench-suite e2b system spike-1 --driver-path    # exercise the port-native benchmark path
   bench-suite e2b memory ci-1 --replicates 0,1,2  # 3 replicate sandboxes from this one process
   bench-suite --list-suites                       # discover the suite names first
 
@@ -445,6 +449,8 @@ interface ReplicateContext {
 	outFile: string;
 	indexFile: string;
 	replicateIndex?: number;
+	/** Explicit migration lane: load packages/drivers and never fall back to the legacy adapter. */
+	driverPath?: boolean;
 	/** Providers that must reach "validated" for this replicate to count as a success. */
 	required: readonly string[];
 }
@@ -484,7 +490,8 @@ export async function runReplicate(ctx: ReplicateContext): Promise<ReplicateOutc
 	let usageError: string | undefined;
 	await withGroup(`Run suite ${suite} on ${provider}`, async () => {
 		try {
-			await runSuite({
+			const executeSuite = ctx.driverPath === true ? runDriverSuite : runSuite;
+			await executeSuite({
 				runId,
 				replicateIndex,
 				providerName: provider,
@@ -635,6 +642,7 @@ if (import.meta.main) {
 	const provider = positionals[0] ?? "daytona-vm";
 	const suite = positionals[1] ?? "cpu-node";
 	const runId = positionals[2] ?? `local-${Date.now()}`;
+	const driverPath = argv.includes("--driver-path");
 	const sha = process.env.GITHUB_SHA ?? "local";
 	const cell = cellTitle(suite, provider);
 
@@ -734,6 +742,7 @@ if (import.meta.main) {
 				sha,
 				replicates: replicateIndices ?? [singleReplicate ?? null],
 				maxConcurrency: Number.isFinite(maxConcurrency) ? maxConcurrency : "unbounded",
+				driverPath,
 				// Per-mode, because a fan-out has no single pair to report: name every shard it will
 				// write, so a missing artifact can be traced to the path that was expected.
 				...(replicateIndices
@@ -802,6 +811,7 @@ if (import.meta.main) {
 			outFile: singleOutFile,
 			indexFile,
 			...(singleReplicate !== undefined ? { replicateIndex: singleReplicate } : {}),
+			driverPath,
 			required,
 		});
 		await reportCell({
@@ -865,6 +875,7 @@ if (import.meta.main) {
 					outFile: paths.outFile,
 					indexFile,
 					replicateIndex,
+					driverPath,
 					required,
 				}),
 			);

--- a/apps/cli/src/bin/driver-check.ts
+++ b/apps/cli/src/bin/driver-check.ts
@@ -7,10 +7,10 @@
 // bin runs the real composition flow (load → parse → resolve → construct), boots a real sandbox,
 // and drives a real workload through the harness's own `StepRunner` on both transports.
 //
-// It deliberately writes NO Run document. Persisting a driver-path run requires the artifact
-// provenance fields the Run schema does not yet carry, and emitting a v5 document from this path
-// would publish a measurement whose artifact attribution is unverifiable. Validation first, schema
-// bump second.
+// It deliberately writes NO Run document. This command is a contract/TCK check rather than a
+// benchmark measurement; the port-native bench-suite lane owns raw result collection and Run v6
+// artifact evidence. Keeping the two lanes separate prevents conformance probes from being published
+// as benchmark samples.
 //
 // Usage:
 //   bun apps/cli/src/bin/driver-check.ts --provider e2b

--- a/apps/cli/src/lib/driver-run.integration.test.ts
+++ b/apps/cli/src/lib/driver-run.integration.test.ts
@@ -1,0 +1,194 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type { DriverModule, ExecResult, SandboxSession } from "@sandbox-benchmarks/driver";
+import {
+	driverReadinessBudgetMs,
+	verifyDriverReadiness,
+} from "@sandbox-benchmarks/driver/conformance";
+import e2bModule from "@sandbox-benchmarks/drivers/e2b";
+import { runSuiteOnSandbox } from "@sandbox-benchmarks/harness";
+import { writeNormalizedRun } from "@sandbox-benchmarks/results";
+import type { ProviderId, Suite } from "@sandbox-benchmarks/schema";
+import { bakedArtifactName } from "@sandbox-benchmarks/schema";
+import { TOOLCHAIN_IMAGE_NAME, TOOLCHAIN_VERSION } from "@sandbox-benchmarks/schema/toolchain";
+import { driverTransport, runDriverSuite, sessionHandle } from "./driver-run.ts";
+
+const roots: string[] = [];
+
+afterEach(() => {
+	for (const root of roots.splice(0)) rmSync(root, { recursive: true, force: true });
+});
+
+function freshRoot(): string {
+	const root = mkdtempSync(join(tmpdir(), "driver-bench-spike-"));
+	roots.push(root);
+	return root;
+}
+
+function exited(stdout = ""): ExecResult {
+	return {
+		exit: { kind: "exited", code: 0 },
+		stdout,
+		stderr: "",
+		durationMs: 1,
+		truncated: false,
+	};
+}
+
+describe("DriverModule benchmark path", () => {
+	test("records a structured credential gap without loading or falling back", async () => {
+		const resultsDir = join(freshRoot(), "e2b", "cpu-node");
+		await runDriverSuite({
+			runId: "driver-spike-missing-env",
+			providerName: "e2b",
+			suiteName: "cpu-node",
+			resultsDir,
+			env: {},
+		});
+
+		expect(
+			JSON.parse(readFileSync(join(resultsDir, "sandbox-e2b-cpu-node--skipped.json"), "utf8")),
+		).toEqual({
+			provider: "e2b",
+			suite: "cpu-node",
+			outcome: "skipped",
+			reason: "Missing credentials: E2B_API_KEY",
+			cause: { kind: "missing-credentials", variables: ["E2B_API_KEY"] },
+		});
+	});
+
+	test("preserves a construction failure when its gap marker cannot be written", async () => {
+		const resultsDir = join(freshRoot(), "occupied");
+		writeFileSync(resultsDir, "not a directory");
+		const constructionError = new Error("driver env became unreadable");
+		let reads = 0;
+		const env = Object.defineProperty({} as Record<string, string | undefined>, "E2B_API_KEY", {
+			get() {
+				reads += 1;
+				if (reads === 1) return "e2b_test";
+				throw constructionError;
+			},
+		});
+		const logged: string[] = [];
+		const originalError = console.error;
+		console.error = (...values: unknown[]) => logged.push(values.map(String).join(" "));
+		try {
+			await expect(
+				runDriverSuite({
+					runId: "driver-spike-marker-failure",
+					providerName: "e2b",
+					suiteName: "cpu-node",
+					resultsDir,
+					env,
+				}),
+			).rejects.toBe(constructionError);
+		} finally {
+			console.error = originalError;
+		}
+		expect(logged.join("\n")).toContain("driver-construction error below is unaffected");
+		expect(readFileSync(resultsDir, "utf8")).toBe("not a directory");
+	});
+
+	test("rejects an unmigrated provider instead of falling back to packages/providers", async () => {
+		await expect(
+			runDriverSuite({
+				runId: "driver-spike-no-fallback",
+				providerName: "daytona-vm",
+				suiteName: "cpu-node",
+				resultsDir: freshRoot(),
+				env: { DAYTONA_API_KEY: "must-not-be-used" },
+			}),
+		).rejects.toThrow(/daytona-vm has no DriverModule/);
+	});
+
+	test("persists verified E2B artifact evidence and normalizes a valid Run v6", async () => {
+		const root = freshRoot();
+		const rawRoot = join(root, "raw");
+		const resultsDir = join(rawRoot, "e2b", "cpu-node");
+		const artifact = { kind: "baked", ref: bakedArtifactName("e2b", "version") } as const;
+		const commands: string[] = [];
+		let destroyed = false;
+		const session: SandboxSession = {
+			sandboxRef: { provider: "e2b", id: "isandbox1" },
+			artifact,
+			native: {},
+			async exec(command) {
+				commands.push(command);
+				if (command.includes("/toolchain-manifest.json")) {
+					return exited(
+						JSON.stringify({
+							image_name: TOOLCHAIN_IMAGE_NAME,
+							image_version: TOOLCHAIN_VERSION,
+						}),
+					);
+				}
+				// Force a deliberate precondition skip after readiness and fingerprinting. That keeps the
+				// fixture cheap while still producing a complete, attributable Run v6 provider row.
+				if (command.includes("df -Pk")) return exited("1\n");
+				return exited();
+			},
+			async destroy() {
+				destroyed = true;
+			},
+		};
+		const suite: Suite = {
+			setupPts: false,
+			commandTimeoutMinutes: 1,
+			timeoutMinutes: 1,
+			minDiskGb: 1,
+			ptsTimesToRun: 1,
+			defaultReplicas: 1,
+			dimensions: ["cpu"],
+			metrics: ["node_web_tooling_runs_per_s"],
+			commands: [],
+		};
+
+		await runSuiteOnSandbox(sessionHandle(session), {
+			runId: "driver-spike-1",
+			suite,
+			suiteName: "cpu-node",
+			providerName: "e2b",
+			artifact,
+			resultsDir,
+			transport: driverTransport(e2bModule.execution),
+			driverReadiness: {
+				timeoutMs: driverReadinessBudgetMs(e2bModule as DriverModule<ProviderId>),
+				verify: async ({ signal }) => {
+					// The composition root performs this same one-time handle erasure after the generated
+					// loader has proved that the selected module and provider id agree.
+					const module = e2bModule as DriverModule<ProviderId>;
+					const result = await verifyDriverReadiness(module, session, { signal });
+					return { ready: result.status === "pass", detail: result.detail };
+				},
+			},
+		});
+
+		const run = writeNormalizedRun({
+			rawRoot,
+			runId: "driver-spike-1",
+			sha: "local",
+			outFile: join(root, "run.json"),
+		});
+		const e2b = run.providers.find((provider) => provider.providerId === "e2b");
+		expect(run.schemaVersion).toBe("6");
+		expect(e2b?.artifactEvidence).toEqual([
+			expect.objectContaining({
+				cell: { runId: "driver-spike-1", providerId: "e2b", suite: "cpu-node" },
+				sandboxId: "isandbox1",
+				provenance: expect.objectContaining({ source: "guest-fingerprint", requested: artifact }),
+			}),
+		]);
+		expect(e2b?.gaps).toEqual([
+			expect.objectContaining({
+				id: "cpu-node",
+				outcome: "skipped",
+				cause: { kind: "disk-shortfall", freeGb: expect.any(Number), requiredGb: 1 },
+			}),
+		]);
+		expect(commands).toContain("sh -c 'exit 0'");
+		expect(commands).not.toContain("echo ok");
+		expect(destroyed).toBe(true);
+	});
+});

--- a/apps/cli/src/lib/driver-run.ts
+++ b/apps/cli/src/lib/driver-run.ts
@@ -10,6 +10,7 @@
 // `packages/harness` still speaks the legacy `SandboxHandle` shape. Both are deliberately thin and
 // both disappear when the harness flips to the port.
 
+import { resolve } from "node:path";
 import type {
 	CreateRequest,
 	DriverModule,
@@ -19,11 +20,24 @@ import type {
 	SandboxSession,
 } from "@sandbox-benchmarks/driver";
 import { launchDetached, readTextFile, succeeded, writeTextFile } from "@sandbox-benchmarks/driver";
-import { parseDriverEnv } from "@sandbox-benchmarks/driver/env";
+import {
+	driverReadinessBudgetMs,
+	verifyDriverReadiness,
+} from "@sandbox-benchmarks/driver/conformance";
+import { missingDriverEnvNames, parseDriverEnv } from "@sandbox-benchmarks/driver/env";
 import type { DriverProviderId } from "@sandbox-benchmarks/drivers";
-import { loadDriverModule } from "@sandbox-benchmarks/drivers";
-import type { SandboxHandle } from "@sandbox-benchmarks/harness";
-import { createOwnedSandbox, releaseOwnedSandbox } from "@sandbox-benchmarks/harness";
+import { DRIVERS, loadDriverModule } from "@sandbox-benchmarks/drivers";
+import type { RunSuiteOptions, SandboxHandle } from "@sandbox-benchmarks/harness";
+import {
+	CREATE_FAILURE_PREFIX,
+	createOwnedSandbox,
+	createSuiteSandboxFromPlan,
+	recordSuiteGap,
+	releaseOwnedSandbox,
+	runSuiteOnSandbox,
+	SUITE_CREATE_ATTEMPT_TIMEOUT_MS,
+	SuiteUsageError,
+} from "@sandbox-benchmarks/harness";
 import type {
 	ArtifactPhase,
 	ProviderArtifact,
@@ -34,6 +48,8 @@ import {
 	bakedArtifactName,
 	isBakedProviderId,
 	REGISTRY,
+	SUITE_NAMES,
+	SUITES,
 	TARGET_SPEC,
 } from "@sandbox-benchmarks/schema";
 import { toolchainImageRef } from "@sandbox-benchmarks/schema/toolchain";
@@ -150,7 +166,7 @@ export function sessionHandle(session: SandboxSession): SandboxHandle {
 			}
 			return commandResult(await session.exec(command));
 		},
-		destroy: () => session.destroy(),
+		destroy: (options?: { readonly signal?: AbortSignal }) => session.destroy(options),
 	};
 	const files = session.files;
 	if (files === undefined) return handle;
@@ -267,6 +283,148 @@ export async function openDriver<P extends DriverProviderId>(
 		resolvedArtifact: artifact,
 	} as Parameters<DriverModule<ProviderId>["driver"]>[0]);
 	return { module, driver, artifact, transport: driverTransport(module.execution) };
+}
+
+function isDriverProviderId(value: string): value is DriverProviderId {
+	return Object.hasOwn(DRIVERS, value);
+}
+
+function createBudgetOf(module: DriverModule<ProviderId>): {
+	readonly timeoutMs: number | null;
+	readonly attemptCeilingMs: number | undefined;
+	readonly requestDeadlineMs: number;
+} {
+	const budget = module.createBudget;
+	if (budget?.owner === "driver") {
+		return {
+			timeoutMs: null,
+			attemptCeilingMs: budget.attemptCeilingMs,
+			requestDeadlineMs: budget.attemptCeilingMs,
+		};
+	}
+	const timeoutMs = budget?.timeoutMs ?? SUITE_CREATE_ATTEMPT_TIMEOUT_MS;
+	return { timeoutMs, attemptCeilingMs: undefined, requestDeadlineMs: timeoutMs };
+}
+
+/**
+ * Run one real benchmark cell through a registered DriverModule.
+ *
+ * This is deliberately an explicit migration path: an unregistered provider is rejected instead of
+ * falling back to packages/providers, while the existing bench-suite path remains unchanged until
+ * the port-native lane has live evidence. The shared harness still owns create retry budgeting,
+ * failure markers, result collection, teardown, and Run v6 artifact evidence.
+ */
+export async function runDriverSuite(options: RunSuiteOptions): Promise<void> {
+	const suiteName = SUITE_NAMES.find((name) => name === options.suiteName);
+	if (suiteName === undefined) {
+		throw new SuiteUsageError(
+			`Unknown suite "${options.suiteName}". Known suites: ${SUITE_NAMES.join(", ")}`,
+		);
+	}
+	if (!isDriverProviderId(options.providerName)) {
+		throw new SuiteUsageError(
+			`${options.providerName} has no DriverModule (migrated: ${Object.keys(DRIVERS).join(", ")})`,
+		);
+	}
+
+	const providerName = options.providerName;
+	const resultsDir = resolve(options.resultsDir);
+	const env = options.env ?? process.env;
+	const missing = missingDriverEnvNames(providerName, env);
+	if (missing.length > 0) {
+		const reason = `Missing credentials: ${missing.join(", ")}`;
+		console.log(`SKIPPED ${providerName}/${suiteName}: ${reason}`);
+		recordSuiteGap({
+			resultsDir,
+			providerName,
+			suiteName,
+			outcome: "skipped",
+			reason,
+			cause: { kind: "missing-credentials", variables: [...missing] },
+		});
+		return;
+	}
+
+	let opened: OpenedDriver;
+	try {
+		opened = await openDriver(providerName, { env });
+	} catch (error) {
+		const message = error instanceof Error ? error.message : String(error);
+		// This matches the legacy boundary: constructing the selected adapter is part of sandbox create,
+		// and a failure here must leave a raw-tree fact rather than normalize as "never scheduled". Like
+		// the shared create boundary, marker persistence is best-effort: a read-only/full results tree
+		// must not replace the driver-construction error that explains why the cell failed.
+		try {
+			recordSuiteGap({
+				resultsDir,
+				providerName,
+				suiteName,
+				outcome: "failed",
+				reason: `${CREATE_FAILURE_PREFIX}${message}`,
+				cause: { kind: "sandbox-create-failed", detail: message },
+			});
+		} catch (markerError) {
+			console.error(
+				`Could not write the driver-construction gap marker (${
+					markerError instanceof Error ? markerError.message : String(markerError)
+				}); the driver-construction error below is unaffected`,
+			);
+		}
+		throw error;
+	}
+
+	const suite = SUITES[suiteName];
+	const createBudget = createBudgetOf(opened.module);
+	let session: SandboxSession | undefined;
+	const sandbox = await createSuiteSandboxFromPlan(
+		{
+			create: async (signal) => {
+				session = await opened.driver.create(
+					benchmarkCreateRequest(opened.artifact, createBudget.requestDeadlineMs),
+					{ signal },
+				);
+				return sessionHandle(session);
+			},
+			// DriverError deliberately has no retryable bit. Until the registry-owned matcher from
+			// ADR-0007 lands, guessing from error prose here would recreate the legacy drift.
+			isRetryable: () => false,
+			destroy: (destroy, destroyOptions) => destroy(destroyOptions),
+		},
+		{
+			suite,
+			suiteName,
+			providerName,
+			resultsDir,
+			createTimeoutMs: createBudget.timeoutMs,
+			...(createBudget.attemptCeilingMs === undefined
+				? {}
+				: { createAttemptCeilingMs: createBudget.attemptCeilingMs }),
+		},
+	);
+
+	await runSuiteOnSandbox(sandbox, {
+		runId: options.runId,
+		...(options.replicateIndex === undefined ? {} : { replicateIndex: options.replicateIndex }),
+		suite,
+		suiteName,
+		providerName,
+		artifact: opened.artifact,
+		resultsDir,
+		transport: opened.transport,
+		...(opened.module.costEvidence === undefined
+			? {}
+			: { costEvidence: opened.module.costEvidence }),
+		driverReadiness: {
+			timeoutMs: driverReadinessBudgetMs(opened.module),
+			verify: async ({ signal }) => {
+				if (session === undefined) {
+					return { ready: false, detail: "driver create returned no retained session" };
+				}
+				const result = await verifyDriverReadiness(opened.module, session, { signal });
+				return { ready: result.status === "pass", detail: result.detail };
+			},
+		},
+	});
 }
 
 /** The benchmark's pinned target, as a create request. Exported so callers cannot drift from it. */

--- a/packages/driver/src/conformance.test.ts
+++ b/packages/driver/src/conformance.test.ts
@@ -6,6 +6,7 @@ import {
 	formatConformanceReport,
 	runConformance,
 	selectExecutionRoute,
+	verifyDriverReadiness,
 } from "./conformance.ts";
 import type { DriverModule } from "./lib/define.ts";
 import { DriverError } from "./lib/errors.ts";
@@ -714,6 +715,42 @@ describe("readiness", () => {
 			exitFor: (command) => (command.includes("exit 0") ? { kind: "exited", code: 1 } : undefined),
 		});
 		expect(statusOf(report.clauses, "readiness")).toBe("fail");
+	});
+
+	test("bounds and reaps the create-returns-ready verification exec", async () => {
+		let cancellationObserved = false;
+		let settled = false;
+		const session: SandboxSession = {
+			sandboxRef: { provider: "e2b", id: "isandbox" },
+			artifact: BAKED,
+			native: undefined,
+			exec: (_command, options) =>
+				new Promise<ExecResult>((_resolve, reject) => {
+					const signal = options?.signal;
+					if (signal === undefined) throw new Error("verification exec received no signal");
+					signal.addEventListener(
+						"abort",
+						() => {
+							cancellationObserved = true;
+							queueMicrotask(() => {
+								settled = true;
+								reject(signal.reason);
+							});
+						},
+						{ once: true },
+					);
+				}),
+			destroy: async () => {},
+		};
+
+		const outcome = await verifyDriverReadiness(fakeModule(), session, {
+			createReturnsReadyTimeoutMs: 10,
+		});
+
+		expect(outcome.status).toBe("fail");
+		expect(outcome.detail).toContain("exceeded its 10ms budget");
+		expect(cancellationObserved).toBe(true);
+		expect(settled).toBe(true);
 	});
 
 	test("a create-then-poll signal must reach ready inside its declared budget", async () => {

--- a/packages/driver/src/conformance.ts
+++ b/packages/driver/src/conformance.ts
@@ -17,10 +17,12 @@
 import type { ProviderId } from "@sandbox-benchmarks/schema/provider-ids";
 import type { DriverContext, DriverModule } from "./lib/define.ts";
 import { DriverError, isDriverError, isFailedCreateCleanupError } from "./lib/errors.ts";
+import type { ReadinessProbeResult } from "./lib/policy.ts";
 import { selectExecutionRoute } from "./lib/policy.ts";
 import type {
 	CreateRequest,
 	DriverOperationOptions,
+	ExecResult,
 	ResolvedArtifact,
 	SandboxDriver,
 	SandboxRef,
@@ -152,6 +154,9 @@ const PROBE_FILE = "/tmp/driver-conformance-probe";
 const DEFAULT_DURABLE_POLL_INTERVAL_MS = 500;
 const READINESS_POLL_INTERVAL_MS = 250;
 const READINESS_ABORT_GRACE_MS = 1_000;
+/** A `create-returns-ready` declaration has no polling budget of its own, but its one verification
+ *  exec still needs a hard ceiling so a broken transport cannot strand conformance or a benchmark. */
+export const CREATE_RETURNS_READY_PROBE_TIMEOUT_MS = 20_000;
 
 /** Distinguishes "the attempt ran out of time" from any value a probe could legitimately return. */
 const TIMED_OUT = Symbol("readiness-attempt-timed-out");
@@ -419,19 +424,98 @@ export interface ReadinessVerification {
 	readonly detail: string;
 }
 
+/** Caller cancellation plus a test-only override for the kit-owned one-shot verification bound. */
+export interface ReadinessVerificationOptions extends DriverOperationOptions {
+	readonly createReturnsReadyTimeoutMs?: number;
+}
+
 const readinessPass = (detail: string): ReadinessVerification => ({ status: "pass", detail });
 const readinessFail = (detail: string): ReadinessVerification => ({ status: "fail", detail });
 
+/** Wall-clock budget the composition root must reserve for the selected module's readiness policy. */
+export function driverReadinessBudgetMs<P extends ProviderId>(
+	module: DriverModule<P, unknown>,
+): number {
+	return module.readiness.startup === "create-returns-ready"
+		? CREATE_RETURNS_READY_PROBE_TIMEOUT_MS
+		: module.readiness.totalBudgetMs;
+}
+
+function abortReason(signal: AbortSignal): unknown {
+	return signal.reason ?? new Error("Driver readiness verification aborted");
+}
+
+/** Forward caller cancellation into an attempt-owned controller without leaking listeners. */
+function forwardAbort(parent: AbortSignal | undefined, child: AbortController): () => void {
+	if (parent === undefined) return () => {};
+	const abort = (): void => child.abort(abortReason(parent));
+	parent.addEventListener("abort", abort, { once: true });
+	if (parent.aborted) abort();
+	return () => parent.removeEventListener("abort", abort);
+}
+
+async function settleCancelledReadinessAttempt(
+	attempt: Promise<unknown>,
+	attemptMs: number,
+	detail: string,
+): Promise<ReadinessVerification | undefined> {
+	const settled = await withAttemptTimeout(
+		attempt.then(
+			() => true,
+			() => true,
+		),
+		READINESS_ABORT_GRACE_MS,
+	);
+	return settled === TIMED_OUT
+		? readinessFail(
+				`${detail} exceeded ${attemptMs}ms and did not settle within ${READINESS_ABORT_GRACE_MS}ms after cancellation`,
+			)
+		: undefined;
+}
+
 /** Drive one module's declared readiness strategy without running any later lifecycle command. */
-export async function verifyDriverReadiness(
-	module: DriverModule<ProviderId, unknown>,
+export async function verifyDriverReadiness<P extends ProviderId>(
+	module: DriverModule<P, unknown>,
 	session: SandboxSession,
+	options: ReadinessVerificationOptions = {},
 ): Promise<ReadinessVerification> {
 	const readiness = module.readiness;
 	if (readiness.startup === "create-returns-ready") {
 		// The declaration says a resolved create is already usable, so a command must work with no
-		// polling of any kind. A driver that needs a grace period fails here, which is the point.
-		const probe = await session.exec("sh -c 'exit 0'");
+		// polling of any kind. A driver that needs a grace period fails here, which is the point. This
+		// is still an accepted driver operation: bound it, cancel it, and confirm settlement before the
+		// caller can begin teardown.
+		const attemptMs = options.createReturnsReadyTimeoutMs ?? CREATE_RETURNS_READY_PROBE_TIMEOUT_MS;
+		if (!Number.isSafeInteger(attemptMs) || attemptMs <= 0) {
+			throw new Error(`create-returns-ready verification timeout must be a positive safe integer`);
+		}
+		const attemptControl = new AbortController();
+		const stopForwarding = forwardAbort(options.signal, attemptControl);
+		const attempt = Promise.resolve().then(() => {
+			if (attemptControl.signal.aborted) throw abortReason(attemptControl.signal);
+			return session.exec("sh -c 'exit 0'", { signal: attemptControl.signal });
+		});
+		let observed: ExecResult | typeof TIMED_OUT;
+		try {
+			observed = await withAttemptTimeout(attempt, attemptMs);
+		} finally {
+			stopForwarding();
+		}
+		if (observed === TIMED_OUT) {
+			attemptControl.abort(
+				new Error(`create-returns-ready verification exceeded its ${attemptMs}ms budget`),
+			);
+			const unsettled = await settleCancelledReadinessAttempt(
+				attempt,
+				attemptMs,
+				"create-returns-ready verification exec",
+			);
+			return (
+				unsettled ??
+				readinessFail(`create-returns-ready verification exec exceeded its ${attemptMs}ms budget`)
+			);
+		}
+		const probe = observed;
 		return probe.exit.kind === "exited" && probe.exit.code === 0
 			? readinessPass("create-returns-ready: exec succeeded with no polling")
 			: readinessFail(
@@ -444,6 +528,7 @@ export async function verifyDriverReadiness(
 	const deadline = performance.now() + readiness.totalBudgetMs;
 	let timedOutAttempts = 0;
 	while (performance.now() < deadline) {
+		if (options.signal?.aborted) throw abortReason(options.signal);
 		const remainingMs = deadline - performance.now();
 		const attemptMs = Math.max(1, Math.min(readiness.attemptTimeoutMs, remainingMs));
 		// The port gives every driver operation a cancellation channel; a suite that abandoned
@@ -451,8 +536,17 @@ export async function verifyDriverReadiness(
 		// total budget against a short per-attempt bound turns that into an unbounded pile of
 		// concurrent requests aimed at the sandbox under test.
 		const attemptControl = new AbortController();
-		const attempt = readiness.probe(session, { signal: attemptControl.signal });
-		const observed = await withAttemptTimeout(attempt, attemptMs);
+		const stopForwarding = forwardAbort(options.signal, attemptControl);
+		const attempt = Promise.resolve().then(() => {
+			if (attemptControl.signal.aborted) throw abortReason(attemptControl.signal);
+			return readiness.probe(session, { signal: attemptControl.signal });
+		});
+		let observed: ReadinessProbeResult | typeof TIMED_OUT;
+		try {
+			observed = await withAttemptTimeout(attempt, attemptMs);
+		} finally {
+			stopForwarding();
+		}
 		if (observed === TIMED_OUT) {
 			// Retry only after the accepted operation has confirmed termination. Aborting a controller
 			// is a request, not evidence that an exec/vendor request stopped; starting a new attempt before
@@ -461,17 +555,13 @@ export async function verifyDriverReadiness(
 				new Error(`readiness attempt exceeded its declared ${attemptMs}ms budget`),
 			);
 			timedOutAttempts += 1;
-			const settled = await withAttemptTimeout(
-				attempt.then(
-					() => true,
-					() => true,
-				),
-				READINESS_ABORT_GRACE_MS,
+			const unsettled = await settleCancelledReadinessAttempt(
+				attempt,
+				attemptMs,
+				`readiness ${readiness.signal} probe`,
 			);
-			if (settled === TIMED_OUT) {
-				return readinessFail(
-					`readiness ${readiness.signal} probe exceeded ${attemptMs}ms and did not settle within ${READINESS_ABORT_GRACE_MS}ms after cancellation; refusing to overlap retries`,
-				);
+			if (unsettled !== undefined) {
+				return readinessFail(`${unsettled.detail}; refusing to overlap retries`);
 			}
 			await Bun.sleep(
 				Math.min(READINESS_POLL_INTERVAL_MS, Math.max(0, deadline - performance.now())),

--- a/packages/driver/src/env.test.ts
+++ b/packages/driver/src/env.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, test } from "bun:test";
-import { envSchemaFor, parseDriverEnv, sensitiveEnvValuesFor } from "./env.ts";
+import {
+	envSchemaFor,
+	missingDriverEnvNames,
+	parseDriverEnv,
+	sensitiveEnvValuesFor,
+} from "./env.ts";
 import { DriverError } from "./lib/errors.ts";
 
 type Equal<X, Y> =
@@ -56,6 +61,18 @@ describe("parseDriverEnv", () => {
 				DAYTONA_SNAPSHOT: "",
 			}),
 		).toEqual({ DAYTONA_API_KEY: "key", DAYTONA_TARGET: "eu-west-1" });
+	});
+
+	test("reports only missing required, non-defaulted inputs in registry order", () => {
+		expect(missingDriverEnvNames("blaxel", { BL_API_KEY: "key" })).toEqual(["BL_WORKSPACE"]);
+		expect(missingDriverEnvNames("daytona-vm", {})).toEqual(["DAYTONA_API_KEY"]);
+		expect(
+			missingDriverEnvNames("daytona-vm", {
+				DAYTONA_API_KEY: "key",
+				DAYTONA_TARGET: "",
+				DAYTONA_SNAPSHOT: "",
+			}),
+		).toEqual([]);
 	});
 
 	test("the direct schema deletes foreign provider secrets and resolves defaults", () => {

--- a/packages/driver/src/env.ts
+++ b/packages/driver/src/env.ts
@@ -75,6 +75,22 @@ export function parseDriverEnv<P extends ProviderId>(
 	return parsed as EnvOf<P>;
 }
 
+/** Required, non-defaulted inputs absent from one ambient environment, in registry order. */
+export function missingDriverEnvNames<P extends ProviderId>(
+	id: P,
+	ambient: Readonly<Record<string, string | undefined>>,
+): readonly string[] {
+	const missing: string[] = [];
+	for (const raw of REGISTRY[id].inputs) {
+		const input = normalizeProviderInput(raw);
+		if (input.required && input.default === undefined) {
+			const value = ambient[input.name];
+			if (value === undefined || value === "") missing.push(input.name);
+		}
+	}
+	return missing;
+}
+
 /**
  * Values whose registry source is credential-bearing and must never survive in diagnostics.
  * Ordinary variables (binary paths, image/template overrides, endpoints) stay observable so

--- a/packages/harness/src/index.test.ts
+++ b/packages/harness/src/index.test.ts
@@ -15,6 +15,7 @@ import type { SuiteRunContext } from "./index.ts";
 import {
 	benchmarkLifecycle,
 	createSuiteSandbox,
+	createSuiteSandboxFromPlan,
 	hasRequiredCreds,
 	missingCreds,
 	requiredProviders,
@@ -567,6 +568,25 @@ describe("createSuiteSandbox (creation-failure marker)", () => {
 		expect(attempts).toBe(2);
 	});
 
+	it("does not leak the legacy message matcher into an explicit create plan", async () => {
+		const resultsDir = freshDir();
+		let attempts = 0;
+		await expect(
+			createSuiteSandboxFromPlan(
+				{
+					create: async () => {
+						attempts++;
+						throw new Error("429 Too Many Requests");
+					},
+					isRetryable: () => false,
+				},
+				createCtx(resultsDir, { retryDelayMs: 1 }),
+			),
+		).rejects.toThrow("429 Too Many Requests");
+		expect(attempts).toBe(1);
+		expect(existsSync(join(resultsDir, MARKER))).toBe(true);
+	});
+
 	it("writes a FAILED marker once the retry budget is spent", async () => {
 		const resultsDir = freshDir();
 		let attempts = 0;
@@ -1097,6 +1117,45 @@ describe("runSuiteOnSandbox (orchestration + teardown)", () => {
 			outcome: "failed",
 			reason: expect.stringMatching(/never ready/),
 		});
+	});
+
+	it("cancels and settles DriverModule readiness before tearing the sandbox down", async () => {
+		const resultsDir = freshDir();
+		const destroyed = { hit: false };
+		const events: string[] = [];
+		const base = makeSandbox({ destroyed });
+		const sandbox: SandboxHandle = {
+			...base,
+			async destroy() {
+				events.push("destroy");
+				return base.destroy();
+			},
+		};
+
+		await expect(
+			runSuiteOnSandbox(sandbox, {
+				...ctx(suite({}), resultsDir),
+				driverReadiness: {
+					timeoutMs: 10,
+					verify: ({ signal }) =>
+						new Promise((_resolve, reject) => {
+							signal.addEventListener(
+								"abort",
+								() => {
+									events.push("abort");
+									queueMicrotask(() => {
+										events.push("settled");
+										reject(signal.reason);
+									});
+								},
+								{ once: true },
+							);
+						}),
+				},
+			}),
+		).rejects.toThrow(/exceeded its 10ms policy budget/);
+		expect(events).toEqual(["abort", "settled", "destroy"]);
+		expect(destroyed.hit).toBe(true);
 	});
 
 	it("tears the sandbox down when an invalid ptsTimesToRun (k < 1) fails preamble construction", async () => {

--- a/packages/harness/src/index.ts
+++ b/packages/harness/src/index.ts
@@ -14,6 +14,7 @@ import {
 	sanitizeProviderResponse,
 } from "@sandbox-benchmarks/providers";
 import type {
+	GapCause,
 	GuestFingerprint,
 	ProviderArtifactEvidence,
 	ProviderCostCell,
@@ -51,6 +52,7 @@ import type { LifecycleAggregate, LifecycleCompute } from "./lib/lifecycle.ts";
 import { aggregateLifecycle, measureLifecycle } from "./lib/lifecycle.ts";
 import type { WaitUntilReadyOptions } from "./lib/readiness.ts";
 import { neverReadyReason, waitUntilReady } from "./lib/readiness.ts";
+import type { OwnedSandboxOptions } from "./lib/sandbox-owner.ts";
 import { createOwnedSandbox, withOwnedSandbox } from "./lib/sandbox-owner.ts";
 import { DIR, OBSERVED_SPECS_SCRIPT, REPO_REF, REPO_URL, setupSteps } from "./lib/setup.ts";
 
@@ -209,6 +211,25 @@ export async function benchmarkLifecycle(
 /** An unknown provider or suite is a usage error, distinct from an operational failure mid-run. */
 export class SuiteUsageError extends Error {}
 
+/** Persist one suite-scoped gap at the same boundary used by the legacy and driver create paths. */
+export function recordSuiteGap(options: {
+	readonly resultsDir: string;
+	readonly providerName: string;
+	readonly suiteName: string;
+	readonly outcome: "skipped" | "failed";
+	readonly reason: string;
+	readonly cause?: GapCause;
+}): void {
+	writeGapMarker(
+		resolve(options.resultsDir),
+		options.providerName,
+		options.suiteName,
+		options.outcome,
+		options.reason,
+		options.cause,
+	);
+}
+
 export interface RunSuiteOptions {
 	/** Run identity carried into sandbox-scoped provider cost evidence. */
 	runId: RunId;
@@ -325,7 +346,7 @@ const CREATE_RETRY_DELAY_MS = 2 * MIN;
  *  absorbed by a readiness probe afterwards; one that boots the image inline needs its own budget via
  *  {@link ProviderConfig.createTimeoutMs}, or `null` when its adapter owns readiness + cleanup and its
  *  create promise must never be abandoned. */
-const CREATE_ATTEMPT_TIMEOUT_MS = 5 * MIN;
+export const SUITE_CREATE_ATTEMPT_TIMEOUT_MS = 5 * MIN;
 
 /**
  * Prefix on a creation-failure gap marker's reason. The single source of truth for BOTH sides of the
@@ -344,7 +365,7 @@ export interface CreateSuiteSandboxContext {
 	resultsDir: string;
 	/** The provider's pinned create-time options; the suite's lifetime is layered on top. */
 	createOptions?: SandboxCreateOptions;
-	/** Per-attempt create timeout, ms. Defaults to {@link CREATE_ATTEMPT_TIMEOUT_MS}; set per provider
+	/** Per-attempt create timeout, ms. Defaults to {@link SUITE_CREATE_ATTEMPT_TIMEOUT_MS}; set per provider
 	 *  (see {@link ProviderConfig.createTimeoutMs}) for adapters whose `create` boots the image inline,
 	 *  or `null` when the adapter owns readiness + failed-allocation cleanup and abandoning its promise
 	 *  would terminate that cleanup. Injectable so both paths are exercisable in tests. */
@@ -380,17 +401,26 @@ export interface CreateSuiteSandboxContext {
  * only while the budget can still cover the backoff PLUS that attempt's worst case, so the failure
  * marker lands inside the budget rather than one attempt past it.
  *
- * `computeFactory` (not a pre-built compute) so adapter construction lives INSIDE the marker path — a
- * computesdk provider can throw before `sandbox.create`, and that throw must be recorded too. The
- * factory is cheap and idempotent, so re-invoking it per capacity retry is harmless.
+ * The plan owns one attempt and is invoked again for each capacity retry. Both the legacy provider
+ * wrapper and the DriverModule path use this boundary, so timeout ownership, late-handle teardown,
+ * retry budgeting, and failure-marker semantics cannot drift between the two transports.
  */
-export async function createSuiteSandbox(
-	computeFactory: () => SuiteSandboxCompute,
+export interface SuiteSandboxCreatePlan {
+	/** Create one harness-shaped sandbox. The process owner supplies cooperative cancellation. */
+	readonly create: (signal: AbortSignal) => Promise<SandboxHandle>;
+	/** Whether the rejected attempt is safe to retry after the shared backoff. */
+	readonly isRetryable: (error: unknown) => boolean;
+	/** Optional cancellation bridge for the handle's captured destroy operation. */
+	readonly destroy?: OwnedSandboxOptions["destroy"];
+}
+
+export async function createSuiteSandboxFromPlan(
+	plan: SuiteSandboxCreatePlan,
 	ctx: CreateSuiteSandboxContext,
 ): Promise<SandboxHandle> {
-	const { suite, suiteName, providerName, resultsDir, createOptions } = ctx;
+	const { suiteName, providerName, resultsDir } = ctx;
 	const createTimeoutMs =
-		ctx.createTimeoutMs === undefined ? CREATE_ATTEMPT_TIMEOUT_MS : ctx.createTimeoutMs;
+		ctx.createTimeoutMs === undefined ? SUITE_CREATE_ATTEMPT_TIMEOUT_MS : ctx.createTimeoutMs;
 	const retryDelayMs = ctx.retryDelayMs ?? CREATE_RETRY_DELAY_MS;
 	// What one more attempt can cost, so the loop only starts an attempt the budget can still absorb.
 	// When the harness races the create, its own timeout IS that ceiling; when the adapter owns the
@@ -442,13 +472,9 @@ export async function createSuiteSandbox(
 		// a pending promise whose late handle must still be destroyed (see the catch).
 		let createPromise: Promise<SandboxHandle> | undefined;
 		try {
-			const compute = computeFactory();
-			createPromise = createOwnedSandbox(() =>
-				compute.sandbox.create({
-					...createOptions,
-					// Ask for a sandbox lifetime covering setup + the suite, where supported.
-					timeout: suite.timeoutMinutes * MIN,
-				}),
+			createPromise = createOwnedSandbox(
+				plan.create,
+				plan.destroy === undefined ? {} : { destroy: plan.destroy },
 			);
 			return createTimeoutMs === null
 				? await createPromise
@@ -466,13 +492,10 @@ export async function createSuiteSandbox(
 				);
 			}
 			const message = err instanceof Error ? err.message : String(err);
-			// An adapter that KNOWS its create failure is transient and allocated nothing says so explicitly;
-			// the message match is the fallback for providers that only express capacity limits in prose. The
-			// explicit mark covers a control plane that expresses saturation by stalling, whose timeout message
-			// matches none of these words — the shape that hard-failed every runcloud cell of run
-			// 30960125032 in seconds instead of letting the cells queue.
-			const retryable =
-				isRetryableCreateError(err) || /quota|rate.?limit|too many|capacity|429/i.test(message);
+			// Classification belongs to the selected plan. The legacy wrapper below preserves its explicit
+			// marker plus narrow prose fallback; a DriverModule plan can instead require typed policy without
+			// inheriting any legacy vendor-message guesses.
+			const retryable = plan.isRetryable(err);
 			// The budget bounds the CELL, not just the sleeps: an attempt is only started when the backoff
 			// AND the attempt's own worst case still fit inside it. Checking the delay alone let a provider
 			// whose attempts run long (run.cloud's adapter-owned readiness wait) begin one final attempt at
@@ -491,6 +514,32 @@ export async function createSuiteSandbox(
 			if (!fitsInBudget(0)) giveUp(err, message);
 		}
 	}
+}
+
+/** Legacy ProviderConfig create path, expressed as one shared suite-create plan. */
+export function createSuiteSandbox(
+	computeFactory: () => SuiteSandboxCompute,
+	ctx: CreateSuiteSandboxContext,
+): Promise<SandboxHandle> {
+	return createSuiteSandboxFromPlan(
+		{
+			create: () => {
+				const compute = computeFactory();
+				return compute.sandbox.create({
+					...ctx.createOptions,
+					// Ask for a sandbox lifetime covering setup + the suite, where supported.
+					timeout: ctx.suite.timeoutMinutes * MIN,
+				});
+			},
+			isRetryable: (error) => {
+				const message = error instanceof Error ? error.message : String(error);
+				return (
+					isRetryableCreateError(error) || /quota|rate.?limit|too many|capacity|429/i.test(message)
+				);
+			},
+		},
+		ctx,
+	);
 }
 
 /**
@@ -520,9 +569,63 @@ export interface SuiteRunContext {
 	/** The provider's exec transport capability — drives the per-step sync/detached choice. */
 	transport: ProviderTransport;
 	costEvidence?: ProviderCostEvidenceCapability;
+	/** Port-native readiness plan supplied by the selected DriverModule composition root. When
+	 *  present, the harness enforces its policy budget and does not run the legacy generic exec poll. */
+	driverReadiness?: SuiteDriverReadinessPlan;
 	/** Readiness budget override. Defaults to {@link SUITE_READINESS}; tests inject a fast one so a
 	 *  never-ready case doesn't really sleep out the live budget. */
 	readiness?: WaitUntilReadyOptions;
+}
+
+/** A selected DriverModule readiness strategy plus its policy-owned wall-clock budget. */
+export interface SuiteDriverReadinessPlan {
+	readonly timeoutMs: number;
+	readonly verify: (options: {
+		readonly signal: AbortSignal;
+	}) => Promise<{ readonly ready: boolean; readonly detail: string }>;
+}
+
+const DRIVER_READINESS_ABORT_GRACE_MS = 1_000;
+
+/** Bound one module-native readiness run, propagate cancellation, and let the accepted operation
+ *  settle before the suite can enter teardown. */
+async function verifySuiteDriverReadiness(
+	plan: SuiteDriverReadinessPlan,
+): Promise<{ readonly ready: boolean; readonly detail: string }> {
+	if (!Number.isSafeInteger(plan.timeoutMs) || plan.timeoutMs <= 0) {
+		throw new Error("Driver readiness timeout must be a positive safe integer");
+	}
+	const control = new AbortController();
+	const timeoutError = new Error(
+		`Driver readiness verification exceeded its ${plan.timeoutMs}ms policy budget`,
+	);
+	const started = performance.now();
+	const verification = Promise.resolve().then(() => plan.verify({ signal: control.signal }));
+	try {
+		const result = await withTimeout(verification, plan.timeoutMs, () => timeoutError);
+		// Timer callbacks can be delayed behind a late result on a busy event loop. The elapsed clock,
+		// not Promise.race ordering, decides whether the policy budget was honored.
+		if (performance.now() - started >= plan.timeoutMs) throw timeoutError;
+		return result;
+	} catch (error) {
+		if (error !== timeoutError) throw error;
+		control.abort(timeoutError);
+		try {
+			await withTimeout(
+				verification.then(
+					() => undefined,
+					() => undefined,
+				),
+				DRIVER_READINESS_ABORT_GRACE_MS,
+				`Driver readiness verification did not settle within ${DRIVER_READINESS_ABORT_GRACE_MS}ms after cancellation`,
+			);
+		} catch {
+			throw new Error(
+				`Driver readiness verification exceeded its ${plan.timeoutMs}ms policy budget and did not settle within ${DRIVER_READINESS_ABORT_GRACE_MS}ms after cancellation`,
+			);
+		}
+		throw timeoutError;
+	}
 }
 
 function sanitizeHookResponseJson(value: unknown): string {
@@ -603,8 +706,15 @@ export async function runSuiteOnSandbox(
 		// hangs instead of erroring. Without this gate the pull is charged to whatever step happens to run
 		// first, which reports the pull as that step's timeout — a 60s "check free disk" failure that had
 		// nothing to do with disk. Pre-baked providers answer the first probe and pay one round-trip.
-		const readiness = await waitUntilReady(sandbox, ctx.readiness ?? SUITE_READINESS);
-		if (!readiness.ready) throw new Error(neverReadyReason(readiness.attempts));
+		if (ctx.driverReadiness === undefined) {
+			const readiness = await waitUntilReady(sandbox, ctx.readiness ?? SUITE_READINESS);
+			if (!readiness.ready) throw new Error(neverReadyReason(readiness.attempts));
+		} else {
+			const readiness = await verifySuiteDriverReadiness(ctx.driverReadiness);
+			if (!readiness.ready) {
+				throw new Error(`Driver readiness verification failed: ${readiness.detail}`);
+			}
+		}
 		const expectedFingerprint = expectedToolchainFingerprint(providerName, ctx.artifact);
 		if (expectedFingerprint !== undefined) {
 			const captured = await runner.run(


### PR DESCRIPTION
## Summary

- add an explicit `bench-suite --driver-path` lane backed only by generated `DriverModule` registrations
- share harness create budgets, process ownership, late-handle cleanup, failure markers, suite execution, and Run v6 artifact evidence across legacy and driver paths
- use the selected module's readiness and execution policies, with structured registry-derived credential gaps and no legacy fallback
- add offline end-to-end coverage from an E2B-shaped session through normalized Run v6 evidence

## Safety and migration behavior

- the existing benchmark path remains the default
- an unmigrated provider is a usage error under `--driver-path`; it never falls back to `packages/providers`
- driver create errors are not classified from vendor prose; until typed retry policy lands, the driver lane retries none

## Validation

- `bun run typecheck`
- `bun run lint`
- `bun run spell`
- `bun run test`
- `bun run check:catalog-drift`
- `bun run check:provider-wiring`

Live E2B proof:

- driver TCK: 12 passed, 0 failed, 0 skipped
- real STREAM memory suite completed through `runDriverSuite`
- normalized Run v6 contained 5 metric records, 0 gaps, and verified `sandbox-benchmarks-toolchain-v8` guest-fingerprint evidence
- the exact benchmark sandbox was observed absent after teardown

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an opt-in `--driver-path` flag to `bench-suite` that runs benchmarks exclusively through registered `DriverModule`s, never falling back to `packages/providers`. The legacy path remains the default, and unmigrated providers fail with a usage error.

**Migration**

- `bench-suite <provider> <suite> <runId> --driver-path` exercises the port-native lane.
- A missing credential produces a structured skipped gap; driver create errors are recorded as failed but never retried until typed retry policy lands.

**Refactors**

- Extracts a shared suite-create plan so budgets, failure markers, late-handle teardown, and Run v6 artifact evidence stay identical across both paths.
- Driver readiness runs under the module's own declared budget; a timed-out probe is cancelled and must settle before teardown starts.
- Adds an offline E2B-shaped integration test through the full flow up to normalized Run v6 evidence.

<sup>Written for commit f97982a5112a6f31416159caf8ed2999f498f0c1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/starslingdev/hpc-sandbox-benchmarks/pull/409?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a `--driver-path` option to run benchmark suites through a provider’s registered driver path.
  - Added driver-native readiness checks with cancellation and configurable time limits.
  - Added clearer reporting for missing credentials, unavailable providers, construction failures, and insufficient benchmark artifacts.
  - Improved sandbox creation and cleanup behavior during retries and readiness checks.

- **Documentation**
  - Clarified that `driver-check` performs contract checks and does not produce benchmark run documents.

- **Bug Fixes**
  - Prevented stalled readiness checks and ensured timed-out operations are cancelled and settled safely.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->