### PR TITLE
fix(gpu): pin every Hugging Face download to an immutable commit

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -27,3 +27,6 @@ expose credentials, allow remote code execution in CI, or leak provider API keys
 - We do not use `pull_request_target`.
 - Third-party Actions are SHA-pinned; installs use `--ignore-scripts` / Bun's empty
   `trustedDependencies` posture.
+- Hugging Face models and datasets we download are pinned to full commit SHAs, never to a branch or
+  tag, and the GPU asset preparation refuses a mutable pin at runtime. See
+  [docs/gpu-benchmark-methodology.md](./docs/gpu-benchmark-methodology.md).

--- a/apps/cli/src/lib/gpu/config.ts
+++ b/apps/cli/src/lib/gpu/config.ts
@@ -56,6 +56,16 @@ export const GPU_BENCHMARK = {
 				/<Name>Full \([^<]+<\/Name>\s*<Value>[^<]*--num-prompts ([0-9]+)/,
 				"full run --num-prompts",
 			),
+			// The dataset repository itself, pinned to an immutable commit. `prepare` below only pins
+			// the upstream *script*, which loads the dataset from its default branch — a branch can
+			// serve different rows on every run, so prepare-models.py rewrites that call to this
+			// commit before executing it (CWE-494). Refreshing this pin re-derives the dataset: keep
+			// `codingSamples` (the profile's --num-prompts) in step with the revision's coding rows,
+			// and re-check that those rows still cite only commit-pinned external sources.
+			dataset: {
+				repoId: "nvidia/SPEED-Bench",
+				revision: "487aa718444e816458d1a0a52bfce7a454285cf4",
+			},
 			prepare: {
 				revision: "e06c9b900177be3f60d6a3f99135bb5de9af9bed",
 				url: "https://raw.githubusercontent.com/NVIDIA-NeMo/Skills/e06c9b900177be3f60d6a3f99135bb5de9af9bed/nemo_skills/dataset/speed-bench/prepare.py",

--- a/apps/cli/src/lib/gpu/gpu.test.ts
+++ b/apps/cli/src/lib/gpu/gpu.test.ts
@@ -9,6 +9,7 @@ import {
 	MODEL_CACHE_ENV,
 	MODEL_OFFLINE_ENV,
 	PYTHON_ENVIRONMENT_COMMAND,
+	readSource,
 	VLLM_IMAGE_COMMANDS,
 } from "./config.ts";
 import { cudaGraphEvidenceFromLog } from "./cuda-graphs.ts";
@@ -123,6 +124,9 @@ describe("parseGpuArgs", () => {
 });
 
 describe("fixed workload", () => {
+	const script = readSource("apps/cli/src/lib/gpu/prepare-models.py");
+	const assets = modelAssetConfig();
+
 	test("pins the profile and asset preparation from one config", () => {
 		const profileDirectory = new URL(
 			"../../../../../packages/schema/src/pts-profiles/local/vllm-speed-bench-1.0.0/",
@@ -137,14 +141,32 @@ describe("fixed workload", () => {
 		expect(profile).toContain("Qualification (1 prompt x 16 output tokens)");
 		expect(profile).toContain("Full (80 prompts x 1024 output tokens)");
 
-		const script = readFileSync(new URL("prepare-models.py", import.meta.url), "utf8");
-		const assets = modelAssetConfig();
 		expect(assets.model).toEqual(model);
-		expect(assets.speedBench.prepare.revision).toHaveLength(40);
 		expect(assets.speedBench.prepare.url).toContain(assets.speedBench.prepare.revision);
-		expect(script).toContain("filter insertion anchor changed");
-		expect(script).toContain('"prepareTransform": category_filter.strip()');
+		expect(script).toContain("insertion anchor changed");
+		expect(script).toContain('"prepareTransforms": [');
 		expect(script).toContain('"contentSha256": dataset_sha256');
+	});
+
+	test("pins every Hugging Face download to an immutable commit", () => {
+		// A branch or tag resolves at download time, so anything but a full commit SHA lets the model
+		// weights or the benchmark prompts change between runs (bandit B615 / CWE-494).
+		const commit = /^[0-9a-f]{40}$/;
+		expect(assets.model.revision).toMatch(commit);
+		expect(assets.speedBench.prepare.revision).toMatch(commit);
+		expect(assets.speedBench.dataset.repoId).toBe("nvidia/SPEED-Bench");
+		expect(assets.speedBench.dataset.revision).toMatch(commit);
+
+		// Both pins are enforced sandbox-side too: the script is staged into the model-cache sandbox
+		// and run against this config, so it must reject a config that pins anything mutable rather
+		// than trust its caller.
+		expect(script.match(/_revision = pinned_revision\(/g)).toHaveLength(2);
+		// Upstream's own load is unpinned; the staged copy is rewritten to the pinned commit.
+		expect(script).toContain('revision="{dataset_revision}")');
+		const downloads = script.match(/snapshot_download\([^)]*\)/g) ?? [];
+		expect(downloads).toHaveLength(3);
+		for (const call of downloads) expect(call).toContain("revision=model_revision");
+		expect(script).toContain("root.name != model_revision");
 	});
 
 	test("keeps GPU consumers offline and the process runner fail-safe", () => {

--- a/apps/cli/src/lib/gpu/prepare-models.py
+++ b/apps/cli/src/lib/gpu/prepare-models.py
@@ -5,12 +5,32 @@ import argparse
 import hashlib
 import importlib.metadata
 import json
+import re
 import subprocess
 import sys
+import tempfile
 import urllib.request
 from pathlib import Path
 
 from huggingface_hub import snapshot_download
+
+
+COMMIT_SHA = re.compile(r"[0-9a-f]{40}")
+
+
+def pinned_revision(revision, subject):
+    """Return the immutable commit a Hugging Face repository is pinned to.
+
+    Branch and tag names are resolved at download time, so a repository pinned to one can serve
+    different bytes on every run and every downstream check here would still pass (CWE-494). Only
+    a full commit SHA names immutable content, so refuse anything else before a download starts —
+    this script is the sandbox-side entry point and cannot assume its caller pinned correctly.
+    """
+    if not isinstance(revision, str) or not COMMIT_SHA.fullmatch(revision):
+        raise RuntimeError(
+            f"{subject} must pin a 40-character Hugging Face commit SHA, not {revision!r}"
+        )
+    return revision
 
 
 parser = argparse.ArgumentParser()
@@ -25,7 +45,42 @@ cache_dir = config["paths"]["modelCache"]
 dataset_dir = Path(config["paths"]["speedBench"])
 dataset_file = dataset_dir / "qualitative.jsonl"
 manifest_file = Path(config["paths"]["modelMount"]) / "benchmark-assets.json"
+model_repo_id = model["repoId"]
+model_revision = pinned_revision(model.get("revision"), f"model {model_repo_id}")
+dataset_pin = speed_bench["dataset"]
+dataset_repo_id = dataset_pin["repoId"]
+dataset_revision = pinned_revision(dataset_pin.get("revision"), f"dataset {dataset_repo_id}")
+
+# Two source-level edits to the checksum-pinned upstream prepare.py, each anchored on an exact line
+# so an upstream change fails loudly instead of silently preparing something else.
+#   * The load pin closes the one unpinned Hugging Face download left on this path: upstream reads
+#     the dataset from its default branch, so without it the benchmark's prompts could change
+#     between runs while every local check still passed.
+#   * The category filter keeps only the coding rows this benchmark serves, and runs before any
+#     external row data is fetched.
+dataset_load = f'        dataset = load_dataset("{dataset_repo_id}", config, split="test")\n'
+pinned_dataset_load = (
+    f'        dataset = load_dataset("{dataset_repo_id}", config, split="test", '
+    f'revision="{dataset_revision}")\n'
+)
+resolve_external = "        dataset = _resolve_external_data(dataset, config)\n"
 category_filter = '        dataset = dataset.filter(lambda example: example["category"] == "coding")\n'
+prepare_transforms = (
+    (dataset_load, pinned_dataset_load),
+    (resolve_external, category_filter + resolve_external),
+)
+
+# Everything about the prepared dataset that is pinned rather than measured. The manifest nests
+# this as one subtree — the shape the kernel snapshot pointer uses for its seed — so a cached
+# dataset prepared under different pins is detected by comparing that subtree whole.
+SPEED_BENCH_PIN = {
+    "category": "coding",
+    "config": "qualitative",
+    "dataset": dataset_pin,
+    "datasetPath": str(dataset_file),
+    "prepare": speed_bench["prepare"],
+    "prepareTransforms": [pinned_dataset_load.strip(), category_filter.strip()],
+}
 
 try:
     xet_version = importlib.metadata.version("hf-xet")
@@ -34,23 +89,23 @@ except importlib.metadata.PackageNotFoundError as error:
 
 
 def resolve_model():
+    """Resolve and validate the pinned model snapshot for the requested mode."""
     options = {
-        "repo_id": model["repoId"],
-        "revision": model["revision"],
+        "repo_id": model_repo_id,
         "cache_dir": cache_dir,
     }
     try:
-        path = snapshot_download(**options, local_files_only=True)
+        path = snapshot_download(**options, revision=model_revision, local_files_only=True)
         validate_model_snapshot(path)
         disposition = "cached"
     except Exception as cache_error:
         if args.mode == "check":
             raise RuntimeError(
-                f"model snapshot is absent or incomplete: {model['repoId']}@{model['revision']}"
+                f"model snapshot is absent or incomplete: {model_repo_id}@{model_revision}"
             ) from cache_error
-        print(f"Downloading {model['repoId']}@{model['revision']}", flush=True)
-        snapshot_download(**options, max_workers=4)
-        path = snapshot_download(**options, local_files_only=True)
+        print(f"Downloading {model_repo_id}@{model_revision}", flush=True)
+        snapshot_download(**options, revision=model_revision, max_workers=4)
+        path = snapshot_download(**options, revision=model_revision, local_files_only=True)
         validate_model_snapshot(path)
         disposition = "downloaded"
     resolved = {**model, "path": path, "disposition": disposition}
@@ -59,7 +114,13 @@ def resolve_model():
 
 
 def validate_model_snapshot(snapshot):
+    """Reject a model snapshot that is not the pinned, complete safetensors snapshot."""
     root = Path(snapshot)
+    # The hub stores each snapshot under the commit it came from, so this is the one check that
+    # ties the bytes on disk to the pinned revision rather than to whatever the cache happened to
+    # hold. Everything below only proves the snapshot is complete.
+    if root.name != model_revision:
+        raise RuntimeError(f"model snapshot is not the pinned commit {model_revision}: {snapshot}")
     for relative in ("config.json", "tokenizer.json", "model.safetensors.index.json"):
         file = root / relative
         if not file.is_file() or file.stat().st_size == 0:
@@ -84,15 +145,26 @@ def validate_model_snapshot(snapshot):
 
 
 def validate_dataset():
-    if not dataset_file.is_file() or dataset_file.stat().st_size == 0:
-        raise RuntimeError(f"prepared SPEED-Bench dataset is absent: {dataset_file}")
-    rows = []
-    with dataset_file.open() as stream:
-        for line_number, line in enumerate(stream, start=1):
-            try:
-                rows.append(json.loads(line))
-            except json.JSONDecodeError as error:
-                raise RuntimeError(f"invalid SPEED-Bench JSONL at line {line_number}") from error
+    """Validate and return the exact number of coding samples in the prepared dataset."""
+    try:
+        if not dataset_file.is_file() or dataset_file.stat().st_size == 0:
+            raise RuntimeError(f"prepared SPEED-Bench dataset is absent: {dataset_file}")
+        rows = []
+        with dataset_file.open(encoding="utf-8") as stream:
+            for line_number, line in enumerate(stream, start=1):
+                try:
+                    row = json.loads(line)
+                except json.JSONDecodeError as error:
+                    raise RuntimeError(
+                        f"invalid SPEED-Bench JSONL at line {line_number}"
+                    ) from error
+                if not isinstance(row, dict):
+                    raise RuntimeError(
+                        f"invalid SPEED-Bench JSONL object at line {line_number}"
+                    )
+                rows.append(row)
+    except (OSError, UnicodeError) as error:
+        raise RuntimeError(f"prepared SPEED-Bench dataset is unreadable: {dataset_file}") from error
     coding_samples = sum(row.get("category") == "coding" for row in rows)
     expected = speed_bench["codingSamples"]
     if coding_samples != expected or len(rows) != expected:
@@ -103,39 +175,74 @@ def validate_dataset():
     return coding_samples
 
 
-def prepare_dataset():
+def recorded_manifest():
+    """Return the object manifest on the volume, or None for every unreadable state."""
     try:
-        return validate_dataset(), "cached"
+        recorded = json.loads(manifest_file.read_text(encoding="utf-8"))
+    except (OSError, UnicodeError, json.JSONDecodeError):
+        return None
+    return recorded if isinstance(recorded, dict) else None
+
+
+def validate_cached_dataset():
+    """Validate that cached dataset bytes and their manifest match the pinned inputs."""
+    recorded = (recorded_manifest() or {}).get("speedBench")
+    if not isinstance(recorded, dict) or recorded.get("pin") != SPEED_BENCH_PIN:
+        raise RuntimeError("prepared SPEED-Bench dataset does not come from the pinned inputs")
+    coding_samples = validate_dataset()
+    try:
+        actual_sha256 = hashlib.sha256(dataset_file.read_bytes()).hexdigest()
+    except OSError as error:
+        raise RuntimeError(f"prepared SPEED-Bench dataset is unreadable: {dataset_file}") from error
+    if recorded.get("contentSha256") != actual_sha256:
+        raise RuntimeError("prepared SPEED-Bench dataset does not match its recorded checksum")
+    return coding_samples
+
+
+def prepare_dataset():
+    """Reuse a verified cache or derive the dataset from its pinned, checksum-verified source."""
+    # A dataset prepared before these pins changed is stale even when it parses and counts
+    # correctly: its rows came from a different dataset revision or a different transform. Re-derive
+    # it rather than republish those bytes under the new pins.
+    try:
+        return validate_cached_dataset(), "cached"
     except RuntimeError:
         if args.mode == "check":
             raise
+        # The cached copy is absent, stale, or unusable, so re-derive it below.
 
     dataset_dir.mkdir(parents=True, exist_ok=True)
     dataset_file.unlink(missing_ok=True)
     prepare = speed_bench["prepare"]
-    script = Path("/tmp/prepare-speed-bench.py")
     print("Preparing revision-pinned SPEED-Bench coding data", flush=True)
     with urllib.request.urlopen(prepare["url"], timeout=60) as response:
         payload = response.read()
     actual_sha256 = hashlib.sha256(payload).hexdigest()
     if actual_sha256 != prepare["sha256"]:
         raise RuntimeError(f"SPEED-Bench prepare.py checksum mismatch: {actual_sha256}")
-    source = payload.decode()
-    anchor = "        dataset = _resolve_external_data(dataset, config)\n"
-    if source.count(anchor) != 1:
-        raise RuntimeError("SPEED-Bench prepare.py filter insertion anchor changed")
-    script.write_text(source.replace(anchor, category_filter + anchor))
-    subprocess.run(
-        [
-            sys.executable,
-            str(script),
-            "--config",
-            "qualitative",
-            "--output_dir",
-            str(dataset_dir),
-        ],
-        check=True,
-    )
+    source = payload.decode("utf-8")
+    for anchor, replacement in prepare_transforms:
+        if source.count(anchor) != 1:
+            raise RuntimeError(
+                f"SPEED-Bench prepare.py insertion anchor changed: {anchor.strip()}"
+            )
+        source = source.replace(anchor, replacement)
+    # Keep the checksum-verified executable private until it has finished. A predictable shared
+    # /tmp path could otherwise be replaced between verification and execution.
+    with tempfile.TemporaryDirectory(prefix="speed-bench-") as temporary_directory:
+        script = Path(temporary_directory) / "prepare.py"
+        script.write_text(source, encoding="utf-8")
+        subprocess.run(
+            [
+                sys.executable,
+                str(script),
+                "--config",
+                "qualitative",
+                "--output_dir",
+                str(dataset_dir),
+            ],
+            check=True,
+        )
     return validate_dataset(), "prepared"
 
 
@@ -143,24 +250,17 @@ resolved_model = resolve_model()
 coding_samples, dataset_disposition = prepare_dataset()
 dataset_sha256 = hashlib.sha256(dataset_file.read_bytes()).hexdigest()
 manifest = {
-    "schemaVersion": "1.0",
+    "schemaVersion": "1.1",
     "models": [model],
-    "speedBench": {
-        "category": "coding",
-        "config": "qualitative",
-        "contentSha256": dataset_sha256,
-        "datasetPath": str(dataset_file),
-        "prepare": speed_bench["prepare"],
-        "prepareTransform": category_filter.strip(),
-    },
+    "speedBench": {"contentSha256": dataset_sha256, "pin": SPEED_BENCH_PIN},
 }
 if args.mode == "download":
     encoded = json.dumps(manifest, indent=2, sort_keys=True) + "\n"
-    if not manifest_file.exists() or manifest_file.read_text() != encoded:
+    if recorded_manifest() != manifest:
         temporary = manifest_file.with_suffix(".tmp")
-        temporary.write_text(encoded)
+        temporary.write_text(encoded, encoding="utf-8")
         temporary.replace(manifest_file)
-elif not manifest_file.exists() or json.loads(manifest_file.read_text()) != manifest:
+elif recorded_manifest() != manifest:
     raise RuntimeError("benchmark asset manifest is absent or does not match the pinned inputs")
 
 print(

--- a/apps/cli/src/lib/gpu/prepare-models.test.ts
+++ b/apps/cli/src/lib/gpu/prepare-models.test.ts
@@ -1,0 +1,186 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { createHash } from "node:crypto";
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
+import { modelAssetConfig } from "./prepare-models.ts";
+
+const PREPARE_MODELS = fileURLToPath(new URL("prepare-models.py", import.meta.url));
+const fixtureRoots: string[] = [];
+
+afterEach(() => {
+	for (const root of fixtureRoots.splice(0)) rmSync(root, { recursive: true, force: true });
+});
+
+const sha256 = (content: string | Buffer): string =>
+	createHash("sha256").update(content).digest("hex");
+
+function createPreparationFixture() {
+	const root = mkdtempSync(join(tmpdir(), "gpu-model-assets-"));
+	fixtureRoots.push(root);
+	const pythonPath = join(root, "python");
+	const modelMount = join(root, "models");
+	const modelSnapshot = join(modelMount, "hub", "snapshots", modelAssetConfig().model.revision);
+	const datasetDirectory = join(modelMount, "speed-bench");
+	const datasetPath = join(datasetDirectory, "qualitative.jsonl");
+	const manifestPath = join(modelMount, "benchmark-assets.json");
+	mkdirSync(modelSnapshot, { recursive: true });
+	mkdirSync(pythonPath, { recursive: true });
+	writeFileSync(join(modelSnapshot, "config.json"), "{}\n");
+	writeFileSync(join(modelSnapshot, "tokenizer.json"), "{}\n");
+	writeFileSync(
+		join(modelSnapshot, "model.safetensors.index.json"),
+		`${JSON.stringify({ weight_map: { model: "model-00001-of-00001.safetensors" } })}\n`,
+	);
+	writeFileSync(join(modelSnapshot, "model-00001-of-00001.safetensors"), "fixture\n");
+
+	writeFileSync(
+		join(pythonPath, "huggingface_hub.py"),
+		`import os
+
+def snapshot_download(*, repo_id, revision, **_options):
+    if repo_id != os.environ["MODEL_REPO_ID"]:
+        raise RuntimeError(f"unexpected repository: {repo_id}")
+    if revision != os.environ["MODEL_REVISION"]:
+        raise RuntimeError(f"unexpected revision: {revision}")
+    return os.environ["MODEL_SNAPSHOT"]
+`,
+	);
+	const distribution = join(pythonPath, "hf_xet-1.5.2.dist-info");
+	mkdirSync(distribution);
+	writeFileSync(join(distribution, "METADATA"), "Name: hf-xet\nVersion: 1.5.2\n");
+
+	const upstreamPath = join(root, "prepare-speed-bench.py");
+	const upstream = `import argparse
+import json
+from pathlib import Path
+
+class Dataset:
+    def filter(self, predicate):
+        if not predicate({"category": "coding"}):
+            raise RuntimeError("the coding filter rejected a coding row")
+        return self
+
+def load_dataset(repo_id, config, split, revision=None):
+    if repo_id != "nvidia/SPEED-Bench" or config != "qualitative" or split != "test":
+        raise RuntimeError("unexpected dataset identity")
+    if revision != "${modelAssetConfig().speedBench.dataset.revision}":
+        raise RuntimeError(f"dataset was not pinned: {revision}")
+    return Dataset()
+
+def _resolve_external_data(dataset, _config):
+    return dataset
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--config", required=True)
+    parser.add_argument("--output_dir", required=True)
+    args = parser.parse_args()
+    for config in [args.config]:
+        dataset = load_dataset("nvidia/SPEED-Bench", config, split="test")
+        dataset = _resolve_external_data(dataset, config)
+        output = Path(args.output_dir)
+        output.mkdir(parents=True, exist_ok=True)
+        rows = [json.dumps({"category": "coding", "id": index}) for index in range(80)]
+        (output / "qualitative.jsonl").write_text("\\n".join(rows) + "\\n", encoding="utf-8")
+
+if __name__ == "__main__":
+    main()
+`;
+	writeFileSync(upstreamPath, upstream);
+
+	const assets = modelAssetConfig();
+	const config = {
+		...assets,
+		model: { ...assets.model },
+		speedBench: {
+			...assets.speedBench,
+			dataset: { ...assets.speedBench.dataset },
+			prepare: {
+				...assets.speedBench.prepare,
+				url: pathToFileURL(upstreamPath).href,
+				sha256: sha256(upstream),
+			},
+		},
+		paths: {
+			modelMount,
+			modelCache: join(modelMount, "hub"),
+			speedBench: datasetDirectory,
+		},
+	};
+	const configPath = join(root, "assets.json");
+	const writeConfig = () => writeFileSync(configPath, `${JSON.stringify(config, null, 2)}\n`);
+	writeConfig();
+
+	const run = (mode: "download" | "check") => {
+		const result = Bun.spawnSync(["python3", PREPARE_MODELS, mode, configPath], {
+			env: {
+				...process.env,
+				PYTHONPATH: pythonPath,
+				MODEL_REPO_ID: config.model.repoId,
+				MODEL_REVISION: config.model.revision,
+				MODEL_SNAPSHOT: modelSnapshot,
+			},
+			stdout: "pipe",
+			stderr: "pipe",
+		});
+		return {
+			exitCode: result.exitCode,
+			stdout: result.stdout.toString(),
+			stderr: result.stderr.toString(),
+		};
+	};
+
+	return { config, datasetPath, manifestPath, run, writeConfig };
+}
+
+describe("GPU model asset preparation", () => {
+	test("rejects mutable model revisions before resolving a snapshot", () => {
+		const fixture = createPreparationFixture();
+		fixture.config.model.revision = "main";
+		fixture.writeConfig();
+
+		const result = fixture.run("check");
+		expect(result.exitCode).not.toBe(0);
+		expect(result.stderr).toContain("must pin a 40-character Hugging Face commit SHA");
+	});
+
+	test("rejects tampered cached bytes and re-derives them in download mode", () => {
+		const fixture = createPreparationFixture();
+		const initial = fixture.run("download");
+		expect(initial).toMatchObject({ exitCode: 0 });
+		expect(initial.stdout).toContain('"disposition": "prepared"');
+		const pristine = readFileSync(fixture.datasetPath, "utf8");
+		const rows = pristine
+			.trimEnd()
+			.split("\n")
+			.map((line) => JSON.parse(line));
+		rows[0].prompt = "tampered but structurally valid";
+		writeFileSync(fixture.datasetPath, `${rows.map((row) => JSON.stringify(row)).join("\n")}\n`);
+
+		const check = fixture.run("check");
+		expect(check.exitCode).not.toBe(0);
+		expect(check.stderr).toContain("does not match its recorded checksum");
+		const repaired = fixture.run("download");
+		expect(repaired).toMatchObject({ exitCode: 0 });
+		expect(repaired.stdout).toContain('"disposition": "prepared"');
+		expect(readFileSync(fixture.datasetPath, "utf8")).toBe(pristine);
+		const manifest = JSON.parse(readFileSync(fixture.manifestPath, "utf8"));
+		expect(manifest.speedBench.contentSha256).toBe(sha256(pristine));
+	});
+
+	test("rejects an unreadable manifest in check mode and replaces it in download mode", () => {
+		const fixture = createPreparationFixture();
+		expect(fixture.run("download")).toMatchObject({ exitCode: 0 });
+		writeFileSync(fixture.manifestPath, Uint8Array.from([0xff, 0xfe, 0xfd]));
+
+		const check = fixture.run("check");
+		expect(check.exitCode).not.toBe(0);
+		expect(check.stderr).toContain("does not come from the pinned inputs");
+		const repaired = fixture.run("download");
+		expect(repaired).toMatchObject({ exitCode: 0 });
+		expect(repaired.stdout).toContain('"disposition": "prepared"');
+		expect(() => JSON.parse(readFileSync(fixture.manifestPath, "utf8"))).not.toThrow();
+	});
+});

--- a/docs/gpu-benchmark-methodology.md
+++ b/docs/gpu-benchmark-methodology.md
@@ -7,7 +7,8 @@ separate from the CPU sandbox leaderboard because its hardware, cost, and metric
 
 - PTS profile: `local/vllm-speed-bench-1.0.0`
 - Model: `Qwen/Qwen3-Coder-30B-A3B-Instruct-FP8` at a pinned Hugging Face revision
-- Dataset: NVIDIA SPEED-Bench `qualitative` / `coding`, prepared from a pinned source revision
+- Dataset: NVIDIA SPEED-Bench `qualitative` / `coding` at a pinned dataset revision, prepared by a
+  checksum-pinned upstream script
 - Server: vLLM 0.26.0 on Python 3.13 and its resolved PyTorch CUDA 13 wheel stack
 - Image: digest-pinned `nvidia/cuda:13.3.1-devel-ubuntu24.04`
 - Sandbox: one RTX PRO 6000, 8 vCPU, 96 GiB RAM, gVisor runtime
@@ -24,6 +25,19 @@ Model weights and the prepared SPEED-Bench dataset live in a named Modal Volume.
 job populates the Volume incrementally, writes a manifest containing every immutable source revision,
 and commits it before a GPU is allocated. Benchmark sandboxes mount it read-only with Hugging Face and
 Transformers offline modes enabled.
+
+Every Hugging Face download this repository issues is pinned to a full commit SHA — the model
+weights, and the SPEED-Bench dataset itself, whose upstream preparation script otherwise reads the
+default branch. Branch and tag names resolve at download time, so they could serve different weights
+or different prompts on any run (CWE-494). The preparation script refuses to download anything pinned
+to a mutable reference, verifies the cached model snapshot is the pinned commit, and re-derives the
+dataset whenever the manifest on the Volume records different pins than the ones in force.
+
+The prepared rows also cite external sources that the upstream script fetches. At the pinned dataset
+revision the coding rows cite only commit-pinned ones, and the category filter runs before that
+resolution — so no unpinned fetch is reachable, but that is a property of the pinned revision's
+contents rather than a guarantee of the upstream script. Re-check it when refreshing the dataset pin,
+alongside the coding-row count.
 
 Blackwell kernel preparation is a separate idempotent GPU job. It starts the exact production server,
 warms its compilation caches, verifies CUDA-graph capture, writes a configuration-keyed manifest, and


### PR DESCRIPTION
bandit B615 (CWE-494) flagged all three `snapshot_download` calls in the GPU
asset preparation script: the revision arrived through `**options` from a
JSON config the script never validated, so a config pinning `main` or a tag
would have downloaded mutable content and passed every downstream check.

The unpinned download the linter could not see was worse. The SPEED-Bench
preparation script we fetch, patch, and execute loads the dataset with
`load_dataset("nvidia/SPEED-Bench", config, split="test")` — no revision — so
the benchmark's prompts came from whatever the default branch served that day.

- Validate both pins as 40-character commit SHAs before any download starts,
  and pass `revision=` explicitly at each `snapshot_download` call site.
- Verify the resolved model snapshot directory is the pinned commit, tying the
  bytes on disk to the pin rather than to whatever the cache happened to hold.
- Pin the dataset repository (`nvidia/SPEED-Bench` at 487aa718, whose
  `qualitative` config carries exactly the 80 coding rows the profile requests)
  and rewrite upstream's load call to it through the existing anchored-source
  mechanism, so an upstream change fails loudly instead of preparing something
  else.
- Record both transforms and the dataset pin in the asset manifest, bumped to
  schemaVersion 1.1, and treat a cached dataset whose manifest records
  different pins as stale: `download` re-derives it, `check` refuses it.

Co-Authored-By: Claude <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_014G38rNds6mVfYz7HXZpNy5

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Pins every Hugging Face download in the GPU asset pipeline to an immutable commit SHA, so weight and benchmark prompt content can't change between runs. A config pinning a branch or tag previously passed every downstream check, and the SPEED-Bench dataset was being fetched from its default branch.

**Bug Fixes**
- Validates the model and dataset pins as 40-character commit SHAs, and verifies the cached model snapshot directory matches the pinned commit.
- Pins `nvidia/SPEED-Bench` and rewrites upstream's unpinned `load_dataset` call to use the pinned revision.
- Records the pins in the asset manifest (schemaVersion 1.1); a cached dataset prepared under different pins or with a mismatched checksum is re-derived on download and refused on check, and the checksum-verified prepare script runs from an ephemeral path rather than a predictable `/tmp` location.
- The category filter runs before upstream fetches external row sources, so the pinned revision can't reach an unpinned fetch.
- Documents the pinning policy in `SECURITY.md` and the benchmark methodology doc.

<sup>Written for commit 039644a0e4a1a35c31540b0dd01f62e51b1efc39. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/starslingdev/hpc-sandbox-benchmarks/pull/410?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Security**
  - GPU benchmark models, datasets, and preparation scripts now require immutable commit references, preventing downloads from changing branches or tags.

- **Bug Fixes**
  - Cached model and dataset inputs are verified against recorded revisions and refreshed when invalid, stale, or unreadable.
  - SPEED-Bench preparation validates dataset sources, checks integrity, and excludes unsupported coding samples before processing.

- **Documentation**
  - Updated the security policy and GPU benchmark methodology with pinning, validation, caching, and reproducibility requirements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->