### PR TITLE
Add warm-pts CLI and PTS warm planning/bench helpers with tests and docs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,27 +13,70 @@ benchmarks. There is no server or web UI — everything is exercised through Bun
  `bunx` symlink is load-bearing: `bun run check:catalog-drift` spawns `bunx biome`, so a missing
  `bunx` on `PATH` fails that gate with `Executable not found in $PATH: "bunx"`.
 - Non-Bun tools (`typos`, `shellcheck`, `hadolint`, `actionlint`, `zizmor`) are pinned in
- `mise.toml` and invoked via `mise exec` — never install them ad hoc.
-- **Phoronix Test Suite (PTS) is NOT installed by the update script** (it is heavy and network-bound,
- and every benchmark leaf skips gracefully without it — see below). Install it on demand.
+  `mise.toml` and invoked via `mise exec` — never install them ad hoc.
 
-### Phoronix Test Suite (PTS)
-The `.mise/tasks/benchmark/**` leaves call `phoronix-test-suite` (via `lib/bench.sh`). In provider
-sandboxes PTS is baked into the toolchain image (`packages/templates/images/base/scripts/20-pts.sh`);
-on this host VM install it on demand (the update script does not).
+### Synthetic host suites (CPU / disk / network / memory / system)
+Run these **on the cloud VM host** (no provider API keys). They write under `benchmark-results/`
+(local output; do not commit).
 
-- Install + configure on the host (idempotent, needs sudo):
- `cd /workspace && SUDO=sudo bash -c 'source lib/bench.sh && ensure_pts'`. `ensure_pts` apt-installs
- PTS (pin 10.8.4, matching `packages/templates/src/lib/pins.ts`) plus its build deps and `stress-ng`,
- then puts PTS in batch mode. It returns 1 (never aborts) if PTS can't be made available — leaves
- then skip rather than fail.
-- Verify: `phoronix-test-suite version` (expect `Phoronix Test Suite v10.8.4`).
-- Cheap end-to-end mise leaf on the host (no provider keys):  
-  `mise run benchmark:disk:pts:hardlink` — needs `stress-ng` (`apt-get install -y stress-ng`).
-  Writes under `benchmark-results/` (local output; do not commit).
-- Full OpenBenchmarking profiles (c-ray, fio, zstd, …) download/build on first use and are heavy;
-  prefer the hardlink leaf or the Docker `benchmark:realworld:selftest` when validating PTS wiring.
+| Suite | Entrypoint |
+| --- | --- |
+| CPU | `mise run benchmark:cpu:node` |
+| Disk | `mise run benchmark:disk:all` |
+| Network (iperf composition) | `mise run benchmark:network:suite` |
+| Network (legacy fast-cli + loopback) | `mise run benchmark:network:all` |
+| Memory | `mise run benchmark:memory:all` |
+| System | `mise run benchmark:system:all` |
+
+**Snapshot / on-demand PTS warm:** cold profile installs are slow (git ~450 MB, plus the fio /
+iperf / STREAM / pgbench / realworld source builds). PTS itself is installed on demand — the
+`warm-pts` bin runs `ensure_pts` for you, and every benchmark leaf calls it too — so warming a
+selection of suites is all a fresh host needs before it can measure:
+
+```sh
+bun run warm:pts -- --list-suites
+SUDO=sudo bun run warm:pts -- --suite synthetic          # default preset (incl. pgbench)
+SUDO=sudo bun run warm:pts -- --suite all                # synthetic + realworld
+SUDO=sudo bun run warm:pts -- --suite realworld
+SUDO=sudo bun run warm:pts -- --suite network            # one suite
+SUDO=sudo bun run warm:pts -- -s disk -s memory
+bun run warm:pts -- --dry-plan --suite network           # print the plan, install nothing
+```
+
+The warmer **plans** targets from `SUITES` + leaf mining — there is no hard-coded profile list, so a
+leaf that pins a new profile is warmed with no edit to the bin. It stages local profiles and
+`seed_pts_download_cache` hints through `lib/bench.sh`, loads `host-seed.json` beside a profile when
+its leaf plants no seed (fio's Ubuntu mirrors — OpenBenchmarking's `brick.kernel.dk` is often down),
+and writes `~/.cache/sandbox-benchmarks/pts-warm-<suites>.stamp`. Subsequent `mise run benchmark:…`
+calls then skip download/compile for warmed profiles. Re-run only if the stamp is missing or a suite
+leaf starts writing `--skipped.json` / reinstalling profiles. Legacy `benchmark:network:all` leaves
+(fast-cli, network-loopback) are **not** in the `network` suite plan; they install on first manual
+run. `synthetic` includes **pgbench** (heavy); name suites explicitly when snapshot time matters.
+
+Two things `--dry-plan` makes explicit, both of which the leaves dictate:
+
+- **`restagedByLeaf`** — a profile whose leaf calls `install_vendored_pts_profile` (iperf) has its
+  installed tree `rm -rf`'d at run time so the vendored override gets rebuilt. Warming its build
+  would be thrown away, so the warmer only seeds its source tarball; the download cache is what
+  survives the re-stage. The build stays in the benchmark run, by design of the override.
+- **Per-target `cflagsOverride`** — `CFLAGS_OVERRIDE` reaches every `install.sh` in a batch, and the
+  vendored iperf/STREAM installers let a caller's value win. The warmer therefore runs one
+  `batch-install` per distinct compile env, so STREAM's `-march=native` pin never rebuilds a
+  neighbouring profile as a native binary.
+
+Verification is not registration alone: PTS marks a profile installed on the launcher its
+`install.sh` writes, which a half-install (the 2026-07 pgbench one) also produces. The warmer checks
+for `install-failed.log` and, for pgbench, the built `pg_/bin/pgbench` payload.
+
+- Verify PTS: `phoronix-test-suite version` (expect `Phoronix Test Suite v10.8.4`).
+- Verify warm: `phoronix-test-suite list-installed-tests` should list the planned profiles
+  (see `--dry-plan`).
+- Cheap single-leaf smoke (no warm required beyond PTS + stress-ng):
+  `mise run benchmark:disk:pts:hardlink`.
+- Full OpenBenchmarking profiles outside the warm set still download/build on first use.
 - `benchmark:realworld:selftest` requires Docker (not installed in this Cloud VM by default).
+- Live provider benches need per-provider API keys from `.env` (see `.env.example`); without keys a
+  provider is a **skip, not a failure**.
 
 ### Running checks / the app
 The command contract lives in the root `package.json` and `docs/architecture.md`; run those scripts
@@ -49,10 +92,8 @@ directly:
   in Cursor because `core.hooksPath` is set to a custom agent-hooks directory. `--ignore-scripts`
   skips it (this is exactly what CI does) and dependencies still resolve fully. Git pre-commit hooks
   are therefore not wired here — run the gate scripts manually before committing.
-- Live provider benches (E2B/Daytona/Modal/Blaxel/Novita) need per-provider API keys from `.env`
-  (see `.env.example`). Without keys a provider is recorded as a **skip, not a failure**, so lint /
-  typecheck / test / spell and the offline CLI bins (`plan-matrix`, `leaderboard` over the committed
-  `data/dataset` runs) all work with no credentials.
 - Mise PTS leaves that lack `phoronix-test-suite` (or a leaf-specific tool like `stress-ng` /
   `nc`) call `skip_result` and exit 0 — a green task exit does **not** prove the benchmark ran.
   Check for `benchmark-results/<prefix>.xml` (success) vs `benchmark-results/<prefix>--skipped.json`.
+- The network suite's wall time is dominated by real 10s iperf trials (localhost ×3 + WAN ×2), not
+  setup, once profiles are warmed.

--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -20,7 +20,8 @@
     "stability": "./src/bin/stability.ts",
     "leaderboard": "./src/bin/leaderboard.ts",
     "reprice-dataset": "./src/bin/reprice-dataset.ts",
-    "driver-check": "./src/bin/driver-check.ts"
+    "driver-check": "./src/bin/driver-check.ts",
+    "warm-pts": "./src/bin/warm-pts.ts"
   },
   "scripts": {
     "test": "bun test",
@@ -43,7 +44,8 @@
     "@runloop/api-client": "catalog:computesdk",
     "modal": "catalog:computesdk",
     "novita-sandbox": "catalog:computesdk",
-    "dotenv": "catalog:"
+    "dotenv": "catalog:",
+    "arktype": "catalog:"
   },
   "devDependencies": {
     "@repo/tsconfig": "workspace:*",

--- a/apps/cli/src/bin/warm-pts.test.ts
+++ b/apps/cli/src/bin/warm-pts.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from "bun:test";
+import { homedir } from "node:os";
+import { parseArgs, stampPath } from "./warm-pts.ts";
+
+describe("parseArgs", () => {
+	it("accepts repeated --suite, -s, --suite=, and positional tokens", () => {
+		expect(parseArgs(["--suite", "disk", "-s", "memory", "--suite=network", "cpu-node"])).toEqual({
+			suites: ["disk", "memory", "network", "cpu-node"],
+			dryPlan: false,
+			listSuites: false,
+		});
+	});
+
+	it("defaults to no selection (the planner's `synthetic`) and reads the mode flags", () => {
+		expect(parseArgs(["--dry-plan", "--list-suites"])).toEqual({
+			suites: [],
+			dryPlan: true,
+			listSuites: true,
+		});
+	});
+
+	it("rejects a flag-shaped value rather than swallowing the next flag as a suite", () => {
+		expect(() => parseArgs(["--suite", "--dry-plan"])).toThrow(/needs a value/);
+		expect(() => parseArgs(["--suite="])).toThrow(/needs a value/);
+		expect(() => parseArgs(["--warm-everything"])).toThrow(/unexpected argument/);
+	});
+});
+
+describe("stampPath", () => {
+	it("keys one stamp per resolved suite set, order-independent within a run", () => {
+		expect(stampPath(["disk", "memory"])).toBe(
+			`${homedir()}/.cache/sandbox-benchmarks/pts-warm-disk+memory.stamp`,
+		);
+		// A suite name can only be [a-z0-9-], but the stamp is a path: keep the sanitizer honest.
+		expect(stampPath(["../../etc/passwd"])).toBe(
+			`${homedir()}/.cache/sandbox-benchmarks/pts-warm-.._.._etc_passwd.stamp`,
+		);
+	});
+});

--- a/apps/cli/src/bin/warm-pts.ts
+++ b/apps/cli/src/bin/warm-pts.ts
@@ -1,0 +1,240 @@
+#!/usr/bin/env bun
+// `warm-pts` — pre-install the Phoronix Test Suite profiles a selection of suites runs, so a later
+// `mise run benchmark:…` on this host spends its wall time on measurement rather than on downloading
+// and compiling (git ~450 MB, plus the fio / STREAM / pgbench / realworld source builds). Profiles
+// that leaves deliberately re-stage, currently iperf, get their downloads seeded but build at run time.
+//
+// This is the HOST lane. Provider sandboxes get the same profiles baked into the toolchain image
+// (packages/templates/images/base/scripts/25-pts-profiles.sh); a dev VM has no such image, so a
+// snapshot of one is only as useful as what has been warmed into it.
+//
+// What to install is PLANNED, never listed here: ../lib/pts-warm.ts derives targets, staging and
+// download-cache seeds from the suite registry and the leaves themselves, so a leaf that pins a new
+// profile is warmed with no edit to this bin. Staging then calls the same `lib/bench.sh` helpers the
+// leaves call. Idempotent; the first-time PTS apt install needs `SUDO=sudo`.
+//
+// Usage:
+//   bun apps/cli/src/bin/warm-pts.ts --list-suites
+//   SUDO=sudo bun apps/cli/src/bin/warm-pts.ts --suite synthetic   # default when none given
+//   SUDO=sudo bun apps/cli/src/bin/warm-pts.ts --suite all         # synthetic + realworld
+//   SUDO=sudo bun apps/cli/src/bin/warm-pts.ts -s disk -s memory
+//   bun apps/cli/src/bin/warm-pts.ts --dry-plan --suite network    # print the plan, install nothing
+import { mkdirSync, writeFileSync } from "node:fs";
+import { homedir } from "node:os";
+import { dirname, join } from "node:path";
+import { SUITES } from "@sandbox-benchmarks/schema";
+import { logInfo } from "../lib/actions-log.ts";
+import type { WarmTarget } from "../lib/pts-warm.ts";
+import { formatWarmSuiteCatalog, planPtsWarm } from "../lib/pts-warm.ts";
+import {
+	batchInstall,
+	discardInstallTree,
+	ensurePts,
+	hostIsGvisor,
+	installLocalPtsProfile,
+	installPayloadProblem,
+	listInstalledTests,
+	seedPtsDownloadCache,
+} from "../lib/pts-warm-bench.ts";
+
+// apps/cli/src/bin → repo root.
+const REPO_ROOT = join(import.meta.dir, "../../../..");
+
+/** `ensure_pts` apt-installs these alongside PTS; a leaf that lacks one skips instead of measuring. */
+const REQUIRED_BINS = ["stress-ng", "nc", "jq", "php"] as const;
+
+interface Options {
+	/** Preset and/or suite-name tokens; empty defers to the planner's `synthetic` default. */
+	readonly suites: string[];
+	readonly dryPlan: boolean;
+	readonly listSuites: boolean;
+}
+
+function usage(): string {
+	return [
+		"usage: warm-pts [--suite <preset|name>]... [--dry-plan] [--list-suites]",
+		"",
+		"  --suite, -s <token>   preset (all|synthetic|realworld) or suite name; repeatable",
+		"                        (also accepted as a positional argument; default: synthetic)",
+		"  --dry-plan            print the planned warm as JSON and exit",
+		"  --list-suites         print presets + registered suites and exit",
+		"",
+		"  SUDO=sudo             required for the first-time PTS apt install",
+	].join("\n");
+}
+
+/** Parse argv, rejecting anything ambiguous rather than guessing. Suite tokens themselves are
+ *  parsed against the registry by {@link planPtsWarm}, which owns the preset vocabulary. */
+export function parseArgs(argv: readonly string[]): Options {
+	const suites: string[] = [];
+	let dryPlan = false;
+	let listSuites = false;
+	for (let index = 0; index < argv.length; index++) {
+		const arg = argv[index] as string;
+		if (arg === "--dry-plan") {
+			dryPlan = true;
+			continue;
+		}
+		if (arg === "--list-suites") {
+			listSuites = true;
+			continue;
+		}
+		if (arg === "--suite" || arg === "-s") {
+			const next = argv[index + 1];
+			if (next === undefined || next.startsWith("-")) throw new Error(`${arg} needs a value`);
+			suites.push(next);
+			index++;
+			continue;
+		}
+		if (arg.startsWith("--suite=")) {
+			const value = arg.slice("--suite=".length);
+			if (!value) throw new Error("--suite= needs a value");
+			suites.push(value);
+			continue;
+		}
+		if (arg.startsWith("-")) throw new Error(`unexpected argument ${arg}`);
+		suites.push(arg);
+	}
+	return { suites, dryPlan, listSuites };
+}
+
+/**
+ * Where the completion stamp for this selection lives.
+ *
+ * Keyed on the RESOLVED suites, not the tokens typed: `-s disk -s memory`, `-s memory -s disk` and a
+ * future preset covering both are the same warm, and three stamps for one state would each report a
+ * warm that the other two already did.
+ */
+export function stampPath(suites: readonly string[]): string {
+	const key = suites.join("+").replaceAll(/[^a-z0-9._+-]+/gi, "_") || "synthetic";
+	return join(homedir(), ".cache/sandbox-benchmarks", `pts-warm-${key}.stamp`);
+}
+
+async function main(options: Options): Promise<void> {
+	if (options.listSuites) {
+		console.log(formatWarmSuiteCatalog());
+		return;
+	}
+
+	const plan = await planPtsWarm(REPO_ROOT, { suites: options.suites });
+
+	if (options.dryPlan) {
+		// The one stdout contract this bin has: `--dry-plan` prints the plan and nothing else, so it
+		// can be diffed or piped. Progress logging goes to stderr via logInfo.
+		console.log(JSON.stringify(plan, null, 2));
+		return;
+	}
+
+	if (plan.targets.length === 0) {
+		throw new Error(
+			`warm plan for ${plan.suites.join(",")} has no PTS targets — check suite leaves`,
+		);
+	}
+	logInfo(
+		`warm suites=${plan.suites.join(",")} targets=${plan.targets.length} ` +
+			`local=${plan.localInstalls.length} seeds=${plan.seeds.length} ` +
+			`restaged-by-leaf=${plan.restagedByLeaf.length}`,
+	);
+
+	await ensurePts(REPO_ROOT);
+	const missing = REQUIRED_BINS.filter((bin) => Bun.which(bin) === null);
+	if (missing.length > 0) {
+		throw new Error(
+			`missing tools ensure_pts installs: ${missing.join(" ")} — re-run with SUDO=sudo`,
+		);
+	}
+
+	for (const seed of plan.seeds) {
+		logInfo(`seed download-cache: ${seed.filename}`);
+		await seedPtsDownloadCache(REPO_ROOT, seed.filename, seed.sha256, seed.urls);
+	}
+	for (const name of plan.restagedByLeaf) {
+		logInfo(`seed only, install left to the leaf's re-stage: pts/${name}`);
+	}
+
+	for (const install of plan.localInstalls) {
+		logInfo(`stage local profile: ${install.name}`);
+		await installLocalPtsProfile(REPO_ROOT, install.name, install.overlays);
+	}
+
+	const installed = await listInstalledTests(REPO_ROOT);
+	const pending: WarmTarget[] = [];
+	for (const target of plan.targets) {
+		if (installed.has(target.id)) {
+			logInfo(`already installed: ${target.id}`);
+			continue;
+		}
+		await discardInstallTree(REPO_ROOT, target.id);
+		pending.push(target);
+	}
+
+	if (pending.length === 0) {
+		logInfo("all planned profiles already installed");
+	} else {
+		// One batch per distinct compile env. CFLAGS_OVERRIDE reaches every install.sh in a batch, so
+		// profiles that pin nothing must not inherit a neighbour's flags (see WarmTarget.cflagsOverride).
+		const gvisor = hostIsGvisor();
+		const batches = new Map<string, string[]>();
+		for (const target of pending) {
+			const cflags = target.cflagsOverride
+				? gvisor
+					? target.cflagsOverride.gvisor
+					: target.cflagsOverride.native
+				: "";
+			const batch = batches.get(cflags);
+			if (batch) batch.push(target.id);
+			else batches.set(cflags, [target.id]);
+		}
+		for (const [cflags, ids] of batches) {
+			if (cflags) logInfo(`CFLAGS_OVERRIDE=${cflags} for ${ids.join(" ")}`);
+			await batchInstall(REPO_ROOT, ids, cflags ? { CFLAGS_OVERRIDE: cflags } : {});
+		}
+	}
+
+	// PTS's batch-install exits 0 for a profile that failed to build, and marks a profile installed
+	// on nothing more than the launcher its install.sh wrote — so registration is checked AND the
+	// tree is probed for the failure log and the payload (see installPayloadProblem).
+	const afterInstall = await listInstalledTests(REPO_ROOT);
+	const failed: string[] = [];
+	for (const target of plan.targets) {
+		if (!afterInstall.has(target.id)) {
+			failed.push(`${target.id} (not installed)`);
+			continue;
+		}
+		const problem = await installPayloadProblem(REPO_ROOT, target.id);
+		if (problem) failed.push(`${target.id} (${problem})`);
+	}
+	if (failed.length > 0) throw new Error(`warm incomplete — ${failed.join(", ")}`);
+
+	const stamp = stampPath(plan.suites);
+	mkdirSync(dirname(stamp), { recursive: true });
+	writeFileSync(
+		stamp,
+		`${new Date().toISOString()}\nsuites=${plan.suites.join(",")}\n` +
+			`targets=${plan.targets.map((target) => target.id).join(" ")}\n`,
+	);
+	logInfo(`warm complete: ${plan.targets.map((target) => target.id).join(" ")}`);
+	logInfo(`stamp: ${stamp}`);
+	for (const suite of plan.suites) {
+		for (const command of SUITES[suite].commands) logInfo(`  ${command}`);
+	}
+}
+
+if (import.meta.main) {
+	let options: Options;
+	try {
+		options = parseArgs(process.argv.slice(2));
+	} catch (err) {
+		console.error(err instanceof Error ? err.message : String(err));
+		console.error(usage());
+		process.exit(1);
+	}
+	try {
+		await main(options);
+	} catch (err) {
+		// A warm failure is a host problem (no sudo, a dead mirror, a build that will not compile),
+		// not a usage one — printing the flag list over it buries the message that matters.
+		console.error(err instanceof Error ? err.message : String(err));
+		process.exit(1);
+	}
+}

--- a/apps/cli/src/lib/pts-warm-bench.test.ts
+++ b/apps/cli/src/lib/pts-warm-bench.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from "bun:test";
+import { mkdirSync, mkdtempSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { discardInstallTree, installPayloadProblem } from "./pts-warm-bench.ts";
+
+// Both helpers interpolate the target into a bash line that reaches `rm -rf` or a path probe under
+// `pts_install_root`, so the name guard runs BEFORE anything is spawned. These cases therefore need
+// no PTS on PATH: a reachable spawn would already be the bug.
+describe("install-target name guard", () => {
+	const traversals = ["pts/../../etc", "local/.ssh", "pts/a b", 'pts/x";rm -rf /;"'];
+
+	it("refuses to discard a target that is not two plain path segments", async () => {
+		for (const target of traversals) {
+			await expect(discardInstallTree("/repo", target)).rejects.toThrow(/refusing to discard/);
+		}
+	});
+
+	it("refuses to probe a target that is not two plain path segments", async () => {
+		for (const target of traversals) {
+			await expect(installPayloadProblem("/repo", target)).rejects.toThrow(/refusing to probe/);
+		}
+	});
+
+	it("ignores a target with no namespace rather than treating the whole string as a path", async () => {
+		// PTS only ever reports `<ns>/<name>`; a bare word is not an install tree to touch.
+		expect(await discardInstallTree("/repo", "stream-1.3.4")).toBeUndefined();
+		expect(await installPayloadProblem("/repo", "stream-1.3.4")).toBeUndefined();
+	});
+});
+
+describe("installPayloadProblem", () => {
+	it("uses the bench install root safely and reports PTS's failure marker", async () => {
+		const root = mkdtempSync("/tmp/pts-warm-$-'quote-");
+		const installRoot = join(root, "installed tests");
+		mkdirSync(join(root, "lib"), { recursive: true });
+		mkdirSync(join(installRoot, "pts", "fio-2.1.0"), { recursive: true });
+		writeFileSync(
+			join(root, "lib/bench.sh"),
+			`pts_init() { :; }\npts_install_root() { printf '%s\\n' '${installRoot.replaceAll("'", `'"'"'`)}'; }\n`,
+		);
+		writeFileSync(join(installRoot, "pts", "fio-2.1.0", "install-failed.log"), "failed\n");
+
+		expect(await installPayloadProblem(root, "pts/fio-2.1.0")).toBe(
+			"PTS recorded install-failed.log",
+		);
+	});
+
+	it("fails closed when bench.sh cannot be sourced", async () => {
+		const root = mkdtempSync("/tmp/pts-warm-missing-bench-");
+		await expect(installPayloadProblem(root, "pts/fio-2.1.0")).rejects.toThrow(
+			/failed to probe install target/,
+		);
+	});
+});

--- a/apps/cli/src/lib/pts-warm-bench.ts
+++ b/apps/cli/src/lib/pts-warm-bench.ts
@@ -1,0 +1,233 @@
+/**
+ * Thin Bun wrappers around the `lib/bench.sh` PTS helpers, so warm staging has one implementation
+ * (the bash the benchmark leaves already run) instead of a TypeScript re-code of `pts_user_dir`,
+ * the install roots, and the download-cache layout — the exact paths whose per-identity differences
+ * `lib/bench.sh` exists to absorb.
+ *
+ * Every helper is invoked the way a leaf invokes it: export `REPO_ROOT`, source `lib/bench.sh`, call
+ * the function. Callers of `lib/bench.sh` must set `REPO_ROOT` before sourcing (see its header).
+ */
+import { readFileSync } from "node:fs";
+import { logInfo, logWarning } from "./actions-log.ts";
+
+export interface SpawnResult {
+	code: number;
+	stdout: string;
+	stderr: string;
+}
+
+export async function spawnCmd(
+	cmd: string[],
+	opts: { cwd: string; env?: Record<string, string>; inherit?: boolean },
+): Promise<SpawnResult> {
+	const proc = Bun.spawn(cmd, {
+		cwd: opts.cwd,
+		env: opts.env ? { ...process.env, ...opts.env } : process.env,
+		stdout: opts.inherit ? "inherit" : "pipe",
+		stderr: opts.inherit ? "inherit" : "pipe",
+	});
+	const [stdout, stderr, code] = await Promise.all([
+		opts.inherit ? Promise.resolve("") : new Response(proc.stdout).text(),
+		opts.inherit ? Promise.resolve("") : new Response(proc.stderr).text(),
+		proc.exited,
+	]);
+	return { code, stdout, stderr };
+}
+
+/** Bash-safe rendering of one argument. Single quotes prevent command, variable, and glob expansion. */
+function shellQuote(value: string): string {
+	return `'${value.replaceAll("'", `'"'"'`)}'`;
+}
+
+/** `source lib/bench.sh`, then run one helper with string args (SUDO honored for `ensure_pts`). */
+async function runBenchHelper(
+	root: string,
+	helper: string,
+	args: readonly string[],
+): Promise<SpawnResult> {
+	const sudo = process.env.SUDO ?? "";
+	const assigns = helper === "ensure_pts" && sudo ? `SUDO=${shellQuote(sudo)} ` : "";
+	const argv = args.map(shellQuote).join(" ");
+	return runBenchScript(root, `${assigns}${helper}${argv ? ` ${argv}` : ""}`);
+}
+
+/** `source lib/bench.sh`, then run one line of bash against its helpers. */
+async function runBenchScript(
+	root: string,
+	line: string,
+	opts: { capture?: boolean } = {},
+): Promise<SpawnResult> {
+	const script = [
+		`cd ${shellQuote(root)}`,
+		`export REPO_ROOT=${shellQuote(root)}`,
+		"source lib/bench.sh",
+		line,
+	].join(" && ");
+	return spawnCmd(["bash", "-c", script], { cwd: root, inherit: !opts.capture });
+}
+
+export async function ensurePts(root: string): Promise<void> {
+	const { code } = await runBenchHelper(root, "ensure_pts", []);
+	if (code !== 0) {
+		throw new Error(
+			"ensure_pts could not make phoronix-test-suite available (re-run with SUDO=sudo)",
+		);
+	}
+}
+
+export async function seedPtsDownloadCache(
+	root: string,
+	filename: string,
+	sha256: string,
+	urls: readonly string[],
+): Promise<void> {
+	const { code } = await runBenchHelper(root, "seed_pts_download_cache", [
+		filename,
+		sha256,
+		...urls,
+	]);
+	// bench.sh never fatals on a seed miss — PTS's own downloader is the fallback — so neither do we.
+	if (code !== 0) logWarning(`seed_pts_download_cache ${filename} exited ${code}`);
+}
+
+export async function installLocalPtsProfile(
+	root: string,
+	name: string,
+	overlays: readonly string[] = [],
+): Promise<void> {
+	const { code } = await runBenchHelper(root, "install_local_pts_profile", [name, ...overlays]);
+	if (code !== 0) throw new Error(`install_local_pts_profile ${name} failed (exit ${code})`);
+}
+
+/** Profile ids PTS reports as installed (`pts/fio-2.1.0`, `local/hardlink-1.0.0`, …). */
+export async function listInstalledTests(root: string): Promise<Set<string>> {
+	const { code, stdout } = await spawnCmd(["phoronix-test-suite", "list-installed-tests"], {
+		cwd: root,
+	});
+	if (code !== 0) return new Set();
+	const ids = new Set<string>();
+	for (const line of stdout.split("\n")) {
+		const id = line.trim().split(/\s+/)[0];
+		if (id?.includes("/")) ids.add(id);
+	}
+	return ids;
+}
+
+export async function batchInstall(
+	root: string,
+	targets: readonly string[],
+	env: Record<string, string>,
+): Promise<void> {
+	if (targets.length === 0) return;
+	logInfo(`batch-install: ${targets.join(" ")}`);
+	const { code } = await spawnCmd(["phoronix-test-suite", "batch-install", ...targets], {
+		cwd: root,
+		inherit: true,
+		env,
+	});
+	if (code !== 0) throw new Error(`phoronix-test-suite batch-install failed (exit ${code})`);
+}
+
+const SAFE_PATH_SEGMENT = /^[a-z0-9][a-z0-9._-]*$/i;
+
+/**
+ * Discard an incomplete install tree before retrying batch-install.
+ *
+ * A failed install leaves an `INSTALL_FAILED` tombstone that PTS honors on the retry, so a warm that
+ * hit a flaky mirror once would report the same profile missing forever. Removing the tree is what
+ * the leaves do for the same reason (see the stream leaf's discard branch); `pts_install_root` is
+ * read from bench.sh because it differs per identity.
+ */
+export async function discardInstallTree(root: string, target: string): Promise<void> {
+	const slash = target.indexOf("/");
+	if (slash <= 0) return;
+	const ns = target.slice(0, slash);
+	const name = target.slice(slash + 1);
+	if (!SAFE_PATH_SEGMENT.test(ns) || !SAFE_PATH_SEGMENT.test(name)) {
+		throw new Error(`refusing to discard unsafe install target: ${target}`);
+	}
+	const { code } = await runBenchScript(
+		root,
+		`pts_init && rm -rf "$(pts_install_root)/${ns}/${name}"`,
+	);
+	if (code !== 0) throw new Error(`failed to discard install target ${target} (exit ${code})`);
+}
+
+/**
+ * Extra payload probes for profiles whose `install.sh` can report success without producing one.
+ *
+ * PTS marks a profile installed by the launcher its `install.sh` writes, so `list-installed-tests`
+ * is install BOOKKEEPING, not evidence of a build. pgbench's upstream `install.sh` is plain `sh`
+ * with no `set -e`, and writes that launcher even when configure/make failed — the shape of the
+ * 2026-07 ICU/pkg-config half-install, where the count probe passed and the benchmark then had no
+ * `pg_/` payload to run. `pgbenchPayloadSmokeCheck` in packages/templates/src/smoke.ts is the bake's
+ * probe for the same profile; this is the host-side one, against the install root bench.sh reports.
+ *
+ * Keyed by profile-name prefix so a version bump keeps the probe. Deliberately a short list of known
+ * lying installers rather than a heuristic: a profile whose launcher legitimately drives a system
+ * binary (hardlink → stress-ng) has no payload of its own to find.
+ */
+const PAYLOAD_PROBES: ReadonlyArray<{ prefix: string; relativePath: string }> = [
+	{ prefix: "pgbench-", relativePath: "pg_/bin/pgbench" },
+];
+
+/**
+ * Why `target` is not usably installed, or undefined when it is.
+ *
+ * Checks what PTS's own bookkeeping cannot: an `install-failed.log` beside the tree (written when
+ * an installer exits non-zero, which PTS itself survives), and the built payload for the profiles
+ * above.
+ */
+export async function installPayloadProblem(
+	root: string,
+	target: string,
+): Promise<string | undefined> {
+	const slash = target.indexOf("/");
+	if (slash <= 0) return undefined;
+	const ns = target.slice(0, slash);
+	const name = target.slice(slash + 1);
+	if (!SAFE_PATH_SEGMENT.test(ns) || !SAFE_PATH_SEGMENT.test(name)) {
+		throw new Error(`refusing to probe unsafe install target: ${target}`);
+	}
+	const dir = `"$(pts_install_root)/${ns}/${name}"`;
+	const checks = [
+		// pts_init writes core.pt2so, which is how pts_user_dir picks the data dir PTS itself uses.
+		"pts_init",
+		`if [ -e ${dir}/install-failed.log ]; then echo "PROBLEM:PTS recorded install-failed.log"; fi`,
+	];
+	const probe = PAYLOAD_PROBES.find((entry) => name.startsWith(entry.prefix));
+	if (probe) {
+		checks.push(
+			`if [ ! -x ${dir}/${probe.relativePath} ]; then echo "PROBLEM:no built payload at ${probe.relativePath}"; fi`,
+		);
+	}
+	// One brace group so the whole probe is a single command in runBenchScript's `&&` chain. Each
+	// diagnostic is an `if`, so a healthy tree returns zero without masking setup/probe failures.
+	const { code, stdout, stderr } = await runBenchScript(root, `{ ${checks.join("; ")}; }`, {
+		capture: true,
+	});
+	if (code !== 0) {
+		throw new Error(
+			`failed to probe install target ${target} (exit ${code})${stderr ? `: ${stderr.trim()}` : ""}`,
+		);
+	}
+	// Prefixed lines only: pts_init and friends write to the same stdout.
+	const problems = stdout
+		.split("\n")
+		.filter((line) => line.startsWith("PROBLEM:"))
+		.map((line) => line.slice("PROBLEM:".length));
+	return problems.length > 0 ? problems.join("; ") : undefined;
+}
+
+/**
+ * Whether this host runs under gVisor, by the same `/proc/version` probe the STREAM leaf uses to
+ * pick its ISA. Getting it wrong compiles a binary the sandbox cannot execute (SIGILL on the first
+ * AVX-512 instruction), so the probe is shared rather than approximated.
+ */
+export function hostIsGvisor(): boolean {
+	try {
+		return /gvisor/i.test(readFileSync("/proc/version", "utf8"));
+	} catch {
+		return false;
+	}
+}

--- a/apps/cli/src/lib/pts-warm.ts
+++ b/apps/cli/src/lib/pts-warm.ts
@@ -1,0 +1,273 @@
+// Plan which PTS profiles a host warm must stage and install, derived from the suite registry plus
+// leaf mining rather than a hard-coded profile list — the same sources ./suite-tasks.ts already uses
+// to describe a suite, so a leaf that starts pinning a new profile is warmed without editing a list
+// here. Callers select suites by preset (`all` / `synthetic` / `realworld`) or by concrete name.
+//
+// Planning only: nothing here touches PTS or the filesystem beyond reading in-repo files, so the
+// whole plan is inspectable with `warm-pts --dry-plan` before a minute of compile time is spent.
+// Staging and installing live in ./pts-warm-bench.ts.
+import { existsSync, readFileSync } from "node:fs";
+import { join, resolve } from "node:path";
+import type { SuiteName } from "@sandbox-benchmarks/schema";
+import { SUITE_NAMES, SUITES, suiteNameSchema } from "@sandbox-benchmarks/schema";
+import { type } from "arktype";
+import type { DownloadSeed } from "./suite-tasks.ts";
+import {
+	describeSuiteTasks,
+	downloadSeedSchema,
+	realworldOverlaysFromBenchSh,
+	warmHintsFromScript,
+} from "./suite-tasks.ts";
+
+/** Presets expand to one or more registered PTS-backed suites. */
+export const warmSuitePresetSchema = type("'all' | 'synthetic' | 'realworld'");
+export type WarmSuitePreset = typeof warmSuitePresetSchema.infer;
+
+/** One selection token: a preset or a concrete suite name. Parsed at the argv boundary. */
+export const warmSuiteTokenSchema = warmSuitePresetSchema.or(suiteNameSchema);
+export type WarmSuiteToken = typeof warmSuiteTokenSchema.infer;
+
+/** Which preset a PTS-backed suite belongs to. Non-PTS suites warm nothing and return null. */
+export type SuiteWarmKind = "synthetic" | "realworld";
+
+export function suiteWarmKind(name: string): SuiteWarmKind | null {
+	if (!(name in SUITES)) return null;
+	const suite = SUITES[name as SuiteName];
+	if (!suite.setupPts) return null;
+	return name.startsWith("realworld") ? "realworld" : "synthetic";
+}
+
+/**
+ * Expand selection tokens into a stable, de-duplicated suite list in registry order.
+ * Empty input defaults to `synthetic`. Unknown tokens fail at the arktype parse.
+ */
+export function resolveWarmSuites(tokens: readonly string[] = []): SuiteName[] {
+	const effective = tokens.length > 0 ? tokens : (["synthetic"] satisfies WarmSuiteToken[]);
+	const selected = new Set<SuiteName>();
+
+	for (const raw of effective) {
+		const token = warmSuiteTokenSchema(raw);
+		if (token instanceof type.errors) {
+			throw new Error(`invalid warm suite token: ${token.summary} (see --list-suites)`);
+		}
+		if (token === "all" || token === "synthetic" || token === "realworld") {
+			for (const name of SUITE_NAMES) {
+				const kind = suiteWarmKind(name);
+				if (kind && (token === "all" || kind === token)) selected.add(name);
+			}
+			continue;
+		}
+		// A concrete suite name — rejected here rather than planned to an empty target set, which
+		// would read as "already warm" when it means "this suite runs no PTS profile".
+		if (!suiteWarmKind(token)) {
+			throw new Error(`suite ${JSON.stringify(token)} is not PTS-backed (setupPts)`);
+		}
+		selected.add(token);
+	}
+
+	const suites = SUITE_NAMES.filter((name) => selected.has(name));
+	if (suites.length === 0) throw new Error("warm suite selection resolved to an empty set");
+	return suites;
+}
+
+/** A repo-local profile to stage before install, with the overlay files it needs alongside it. */
+export interface LocalProfileInstall {
+	name: string;
+	/** Repo-relative overlay files copied into the staged profile (realworld runner/install). */
+	overlays: string[];
+}
+
+/** One profile to install, carrying the compile env its own leaf pins — never a neighbour's. */
+export interface WarmTarget {
+	/** `pts/<name>` or `local/<name>`, as PTS names it. */
+	id: string;
+	/**
+	 * `CFLAGS_OVERRIDE` the leaf that pins this profile exports, per ISA branch.
+	 *
+	 * Per target, not per plan: `CFLAGS_OVERRIDE` is read by every profile's `install.sh`, and the
+	 * vendored iperf install.sh explicitly lets a caller's value win over its deliberately generic
+	 * `-O3`. One batch-install carrying STREAM's `-march=native` would therefore rebuild iperf as a
+	 * native binary — the exact thing that profile's repair exists to prevent, and a SIGILL waiting
+	 * for the first host with a narrower ISA than the one that warmed the snapshot.
+	 */
+	cflagsOverride?: { native: string; gvisor: string };
+}
+
+/** Everything a warm run needs, planned before it touches PTS. */
+export interface PtsWarmPlan {
+	/** Resolved suites, in registry order. */
+	suites: SuiteName[];
+	/** Profiles this warm installs and then verifies. */
+	targets: WarmTarget[];
+	localInstalls: LocalProfileInstall[];
+	/**
+	 * `pts/<name>` profiles a leaf re-stages with `install_vendored_pts_profile` at run time.
+	 *
+	 * Installing these here is wasted work: that helper unconditionally `rm -rf`s the installed tree
+	 * so `run_pts_benchmark` rebuilds the vendored override, which is the whole point of the
+	 * override. Their source tarball still gets seeded, and the download cache does survive the
+	 * discard — so the warm buys the download for them, never the build.
+	 */
+	restagedByLeaf: string[];
+	seeds: DownloadSeed[];
+}
+
+/**
+ * Load and parse a `host-seed.json` sitting beside a vendored profile.
+ *
+ * These exist for profiles whose leaf plants no seed of its own but whose upstream download host is
+ * unreliable (fio's `brick.kernel.dk`), so a warm on a host with no baked download cache has a
+ * mirror to fall back to.
+ */
+export function loadHostSeedJson(path: string): DownloadSeed {
+	let raw: unknown;
+	try {
+		raw = JSON.parse(readFileSync(path, "utf8"));
+	} catch (err) {
+		throw new Error(
+			`invalid host-seed.json at ${path}: ${err instanceof Error ? err.message : String(err)}`,
+		);
+	}
+	const parsed = downloadSeedSchema(raw);
+	if (parsed instanceof type.errors) {
+		throw new Error(`invalid host-seed.json at ${path}: ${parsed.summary}`);
+	}
+	return parsed;
+}
+
+function profileDirForTarget(root: string, target: string): string | undefined {
+	if (target.startsWith("local/")) {
+		return resolve(root, "packages/schema/src/pts-profiles/local", target.slice("local/".length));
+	}
+	if (target.startsWith("pts/")) {
+		return resolve(root, "packages/schema/src/pts-profiles", target.slice("pts/".length));
+	}
+	return undefined;
+}
+
+function readTaskScript(root: string, relFile: string): string | undefined {
+	if (!relFile) return undefined;
+	try {
+		return readFileSync(resolve(root, relFile), "utf8");
+	} catch {
+		return undefined;
+	}
+}
+
+export interface PlanPtsWarmOptions {
+	/** Preset and/or suite-name tokens; empty → `synthetic`. */
+	suites?: readonly string[];
+}
+
+/**
+ * Build a warm plan for the selected suites from {@link SUITES} plus leaf mining.
+ * Seeds prefer a leaf's own `seed_pts_download_cache` call; `host-seed.json` fills the gaps.
+ */
+export async function planPtsWarm(
+	root: string = process.cwd(),
+	options: PlanPtsWarmOptions = {},
+): Promise<PtsWarmPlan> {
+	const suites = resolveWarmSuites(options.suites ?? []);
+
+	const targets = new Map<string, WarmTarget>();
+	const localNames = new Set<string>();
+	const restagedByLeaf = new Set<string>();
+	const seedsByFile = new Map<string, DownloadSeed>();
+
+	let realworldOverlays: string[] = [];
+	try {
+		const benchSh = readFileSync(resolve(root, "lib/bench.sh"), "utf8");
+		realworldOverlays = realworldOverlaysFromBenchSh(benchSh);
+	} catch {
+		// Overlays are optional enrichment; a realworld warm without them fails batch-install loudly.
+	}
+
+	for (const suite of suites) {
+		const plan = await describeSuiteTasks(suite, root);
+		for (const task of plan.tasks) {
+			const ids = task.ptsProfile
+				.split(",")
+				.map((s) => s.trim())
+				.filter(Boolean);
+			const script = readTaskScript(root, task.file);
+			const hints = script ? warmHintsFromScript(script) : undefined;
+			for (const id of ids) {
+				// The flags belong to the leaf that pins this profile, so they reach this profile's
+				// install.sh and no other. A second leaf pinning the same profile with different flags
+				// would be a genuine ambiguity, so refuse rather than let install order decide.
+				const existing = targets.get(id);
+				const cflagsOverride = hints?.cflagsOverride;
+				if (existing?.cflagsOverride && cflagsOverride) {
+					if (
+						existing.cflagsOverride.native !== cflagsOverride.native ||
+						existing.cflagsOverride.gvisor !== cflagsOverride.gvisor
+					) {
+						throw new Error(
+							`leaves pin conflicting CFLAGS_OVERRIDE for ${id}: ` +
+								`${existing.cflagsOverride.native} vs ${cflagsOverride.native}`,
+						);
+					}
+					continue;
+				}
+				targets.set(id, { id, ...(cflagsOverride ? { cflagsOverride } : {}) });
+			}
+			if (!hints) continue;
+			for (const name of hints.localProfiles) localNames.add(name);
+			for (const name of hints.vendoredProfiles) restagedByLeaf.add(name);
+			for (const seed of hints.seeds) {
+				const existing = seedsByFile.get(seed.filename);
+				if (existing && JSON.stringify(existing) !== JSON.stringify(seed)) {
+					throw new Error(`leaves pin conflicting download seeds for ${seed.filename}`);
+				}
+				seedsByFile.set(seed.filename, seed);
+			}
+		}
+	}
+
+	// A profile the leaf re-stages is seeded but never installed here (see PtsWarmPlan.restagedByLeaf).
+	for (const name of restagedByLeaf) targets.delete(`pts/${name}`);
+
+	for (const id of targets.keys()) {
+		if (id.startsWith("local/")) localNames.add(id.slice("local/".length));
+	}
+	// Seeds attach to every profile the plan knows of, restaged ones included: the download cache is
+	// the one thing a leaf's re-stage does not discard, so seeding it is the warm those profiles get.
+	for (const id of [...targets.keys(), ...[...restagedByLeaf].map((name) => `pts/${name}`)]) {
+		const dir = profileDirForTarget(root, id);
+		if (!dir) continue;
+		const hostSeedPath = join(dir, "host-seed.json");
+		if (!existsSync(hostSeedPath)) continue;
+		const seed = loadHostSeedJson(hostSeedPath);
+		if (!seedsByFile.has(seed.filename)) seedsByFile.set(seed.filename, seed);
+	}
+
+	const localInstalls: LocalProfileInstall[] = [...localNames].sort().map((name) => ({
+		name,
+		overlays: name.startsWith("realworld-") ? [...realworldOverlays] : [],
+	}));
+
+	return {
+		suites,
+		targets: [...targets.values()].sort((a, b) => a.id.localeCompare(b.id)),
+		localInstalls,
+		restagedByLeaf: [...restagedByLeaf].sort(),
+		seeds: [...seedsByFile.values()].sort((a, b) => a.filename.localeCompare(b.filename)),
+	};
+}
+
+/** Human-readable catalog for `--list-suites`. */
+export function formatWarmSuiteCatalog(): string {
+	const lines = [
+		"Presets:",
+		"  all         every PTS-backed suite (synthetic + realworld)",
+		"  synthetic   non-realworld PTS suites (includes pgbench)",
+		"  realworld   realworld-* PTS suites",
+		"",
+		"Suites:",
+	];
+	for (const name of SUITE_NAMES) {
+		const mark = suiteWarmKind(name) ?? "skip (no setupPts)";
+		lines.push(`  ${name.padEnd(24)} ${mark.padEnd(10)} ${SUITES[name].commands.join("; ")}`);
+	}
+	return lines.join("\n");
+}

--- a/apps/cli/src/lib/suite-tasks.test.ts
+++ b/apps/cli/src/lib/suite-tasks.test.ts
@@ -2,6 +2,8 @@ import { describe, expect, it } from "bun:test";
 import { readFileSync } from "node:fs";
 import { join } from "node:path";
 import { SUITE_NAMES, SUITES } from "@sandbox-benchmarks/schema";
+import type { PtsWarmPlan } from "./pts-warm.ts";
+import { planPtsWarm, resolveWarmSuites, suiteWarmKind } from "./pts-warm.ts";
 import { suiteMetricSummaryRows, suiteTaskSummaryRows } from "./suite-summary.ts";
 import {
 	conventionalTaskFile,
@@ -12,6 +14,7 @@ import {
 	ptsPinsFromScript,
 	realworldVersionFromBenchSh,
 	runTaskChildren,
+	warmHintsFromScript,
 } from "./suite-tasks.ts";
 
 // apps/cli/src/lib → repo root
@@ -204,5 +207,164 @@ describe("summary rows", () => {
 		const metricRows = suiteMetricSummaryRows(plan);
 		expect(metricRows[0]?.[0]).toEqual({ data: "Metric", header: true });
 		expect(metricRows.length).toBe(1 + plan.metrics.length);
+	});
+});
+
+describe("warmHintsFromScript", () => {
+	it("mines multiline seed_pts_download_cache + vendored install from iperf-localhost", () => {
+		const script = readFileSync(
+			join(root, ".mise/tasks/benchmark/network/pts/iperf-localhost"),
+			"utf8",
+		);
+		const hints = warmHintsFromScript(script);
+		expect(hints.vendoredProfiles).toEqual(["iperf-1.2.0"]);
+		expect(hints.localProfiles).toEqual([]);
+		expect(hints.seeds).toEqual([
+			{
+				filename: "iperf-3.14.tar.gz",
+				sha256: "723fcc430a027bc6952628fa2a3ac77584a1d0bd328275e573fc9b206c155004",
+				urls: [
+					"https://downloads.es.net/pub/iperf/iperf-3.14.tar.gz",
+					"https://sources.buildroot.net/iperf3/iperf-3.14.tar.gz",
+				],
+			},
+		]);
+	});
+
+	it("mines both ISA branches of the STREAM leaf's own CFLAGS_OVERRIDE", () => {
+		const stream = readFileSync(join(root, ".mise/tasks/benchmark/memory/pts/stream"), "utf8");
+		// Pinned against the leaf: a warm compiled with different flags than the leaf measures is the
+		// silent cross-provider skew its preamble exists to remove.
+		expect(warmHintsFromScript(stream).cflagsOverride).toEqual({
+			native: "-O3 -march=native -DSTREAM_ARRAY_SIZE=150000000",
+			gvisor: "-O3 -march=x86-64-v3 -DSTREAM_ARRAY_SIZE=150000000",
+		});
+	});
+
+	it("mines profile=$profile vendored installs, and pins no flags for a leaf without them", () => {
+		const fastCli = readFileSync(join(root, ".mise/tasks/benchmark/network/pts/fast-cli"), "utf8");
+		expect(warmHintsFromScript(fastCli).vendoredProfiles).toEqual(["fast-cli-1.0.0"]);
+		expect(warmHintsFromScript(fastCli).cflagsOverride).toBeUndefined();
+	});
+
+	it("declines to guess a CFLAGS_OVERRIDE it cannot fully resolve", () => {
+		// `\${…}` keeps the bash expansion literal (and out of Biome's noTemplateCurlyInString).
+		const marchRef = `\${march}`;
+		const script = [
+			"march=native",
+			`export CFLAGS_OVERRIDE="-O3 -march=${marchRef} -I$(pwd)"`,
+		].join("\n");
+		expect(warmHintsFromScript(script).cflagsOverride).toBeUndefined();
+	});
+
+	it("mines local hardlink install", () => {
+		const script = readFileSync(join(root, ".mise/tasks/benchmark/disk/pts/hardlink"), "utf8");
+		expect(warmHintsFromScript(script).localProfiles).toEqual(["hardlink-1.0.0"]);
+	});
+});
+
+const targetIds = (plan: PtsWarmPlan): string[] => plan.targets.map((target) => target.id);
+
+describe("planPtsWarm / resolveWarmSuites", () => {
+	it("classifies suite warm kinds and presets", () => {
+		expect(suiteWarmKind("disk")).toBe("synthetic");
+		expect(suiteWarmKind("network")).toBe("synthetic");
+		expect(suiteWarmKind("pgbench")).toBe("synthetic");
+		expect(suiteWarmKind("realworld-mastra")).toBe("realworld");
+		expect(resolveWarmSuites([])).toEqual([
+			"cpu-node",
+			"system",
+			"pgbench",
+			"memory",
+			"disk",
+			"network",
+		]);
+		expect(resolveWarmSuites(["synthetic"])).toEqual(resolveWarmSuites([]));
+		expect(resolveWarmSuites(["network"])).toEqual(["network"]);
+		expect(resolveWarmSuites(["realworld"])).toEqual([
+			"realworld-mastra",
+			"realworld-better-auth",
+			"realworld-openclaw",
+		]);
+		expect(resolveWarmSuites(["all"])).toEqual([
+			"cpu-node",
+			"system",
+			"pgbench",
+			"memory",
+			"disk",
+			"network",
+			"realworld-mastra",
+			"realworld-better-auth",
+			"realworld-openclaw",
+		]);
+		expect(resolveWarmSuites(["disk", "network"])).toEqual(["disk", "network"]);
+		expect(() => resolveWarmSuites(["not-a-suite"])).toThrow(/invalid warm suite token/);
+	});
+
+	it("plans a single suite (network) without pulling unrelated profiles", async () => {
+		const plan = await planPtsWarm(root, { suites: ["network"] });
+		expect(plan.suites).toEqual(["network"]);
+		// iperf's leaf re-stages the vendored override (which rm -rf's the installed tree), so
+		// installing it here would be thrown away: it is seeded, not warmed.
+		expect(plan.restagedByLeaf).toEqual(["iperf-1.2.0"]);
+		expect(targetIds(plan)).toEqual(["local/iperf-wan-1.0.0"]);
+		expect(plan.seeds.map((seed) => seed.filename)).toEqual(["iperf-3.14.tar.gz"]);
+		expect(plan.localInstalls).toEqual([{ name: "iperf-wan-1.0.0", overlays: [] }]);
+	});
+
+	it("plans synthetic targets/seeds from the suite registry without hard-coded profile lists", async () => {
+		const plan = await planPtsWarm(root, { suites: ["synthetic"] });
+		expect(plan.suites).toEqual(["cpu-node", "system", "pgbench", "memory", "disk", "network"]);
+		const ids = targetIds(plan);
+		expect(ids).toContain("pts/fio-2.1.0");
+		expect(ids).toContain("pts/pgbench-1.15.0");
+		expect(ids).toContain("local/hardlink-1.0.0");
+		expect(ids).toContain("local/iperf-wan-1.0.0");
+		expect(ids).toContain("pts/stream-1.3.4");
+		expect(ids).not.toContain("pts/fast-cli-1.0.0");
+		expect(ids).not.toContain("pts/iperf-1.2.0");
+		expect(plan.restagedByLeaf).toEqual(["iperf-1.2.0"]);
+		expect(plan.localInstalls).toEqual([
+			{ name: "hardlink-1.0.0", overlays: [] },
+			{ name: "iperf-wan-1.0.0", overlays: [] },
+		]);
+		// STREAM's flags stay on STREAM. Handing them to the shared batch would rebuild the vendored
+		// iperf/fio with -march=native, which their install.sh repairs exist to prevent.
+		const withFlags = plan.targets.filter((target) => target.cflagsOverride !== undefined);
+		expect(withFlags.map((target) => target.id)).toEqual(["pts/stream-1.3.4"]);
+		expect(withFlags[0]?.cflagsOverride).toEqual({
+			native: "-O3 -march=native -DSTREAM_ARRAY_SIZE=150000000",
+			gvisor: "-O3 -march=x86-64-v3 -DSTREAM_ARRAY_SIZE=150000000",
+		});
+		const fio = plan.seeds.find((s) => s.filename === "fio-3.36.tar.gz");
+		expect(fio?.sha256).toBe("0a07354876ca4d23518f8aa88682f23866455bbd2ff2d0f055d6e4b72f156553");
+		const iperf = plan.seeds.find((s) => s.filename === "iperf-3.14.tar.gz");
+		expect(iperf?.urls.length).toBeGreaterThanOrEqual(2);
+	});
+
+	it("plans realworld local profile targets with shared overlays", async () => {
+		const plan = await planPtsWarm(root, { suites: ["realworld"] });
+		expect(plan.suites).toEqual([
+			"realworld-mastra",
+			"realworld-better-auth",
+			"realworld-openclaw",
+		]);
+		expect(targetIds(plan)).toContain("local/realworld-mastra-1.0.0");
+		expect(targetIds(plan)).toContain("local/realworld-better-auth-1.0.0");
+		expect(targetIds(plan)).toContain("local/realworld-openclaw-1.0.0");
+		expect(plan.localInstalls).toEqual([
+			{
+				name: "realworld-better-auth-1.0.0",
+				overlays: ["lib/pts/realworld/install.sh", "lib/pts/realworld/realworld-runner.sh"],
+			},
+			{
+				name: "realworld-mastra-1.0.0",
+				overlays: ["lib/pts/realworld/install.sh", "lib/pts/realworld/realworld-runner.sh"],
+			},
+			{
+				name: "realworld-openclaw-1.0.0",
+				overlays: ["lib/pts/realworld/install.sh", "lib/pts/realworld/realworld-runner.sh"],
+			},
+		]);
 	});
 });

--- a/apps/cli/src/lib/suite-tasks.ts
+++ b/apps/cli/src/lib/suite-tasks.ts
@@ -14,11 +14,46 @@ import { readFileSync, statSync } from "node:fs";
 import { relative, resolve, sep } from "node:path";
 import type { SuiteName } from "@sandbox-benchmarks/schema";
 import { getMetric, SUITES } from "@sandbox-benchmarks/schema";
+import { type } from "arktype";
 
 /** One PTS/local pin mined from a leaf task script. */
 export interface PtsPin {
 	ptsProfile: string;
 	resultsPrefix: string;
+}
+
+/**
+ * One `seed_pts_download_cache` call: a source tarball plus the mirrors it may come from.
+ *
+ * This is the one mined shape that gets an arktype schema, because it is the one that crosses a
+ * real trust boundary twice — mined out of leaf bash here, and read back from a `host-seed.json`
+ * on disk in ./pts-warm.ts. A garbled digest or a non-URL mirror must fail at the parse, not at
+ * `sha256sum -c` an hour into a warm.
+ */
+export const downloadSeedSchema = type({
+	filename: "string >= 1",
+	sha256: "/^[0-9a-f]{64}$/",
+	urls: "string.url[] >= 1",
+}).onUndeclaredKey("reject");
+export type DownloadSeed = typeof downloadSeedSchema.infer;
+
+/**
+ * Host-warm staging hints mined from one leaf script: the profiles it stages before running, the
+ * download-cache seeds it plants, and the STREAM compile flags it exports.
+ *
+ * Assembled from in-repo bash by {@link warmHintsFromScript}; every field is constrained by the
+ * regex that produced it (and seeds additionally by {@link downloadSeedSchema}), so the container
+ * itself is a plain interface rather than a second schema over already-parsed parts.
+ */
+export interface LeafWarmHints {
+	localProfiles: string[];
+	vendoredProfiles: string[];
+	seeds: DownloadSeed[];
+	/**
+	 * `CFLAGS_OVERRIDE` for a leaf that pins one (STREAM), rendered for both ISA branches the leaf
+	 * itself selects between. The warmer picks the branch matching the host it runs on.
+	 */
+	cflagsOverride?: { native: string; gvisor: string };
 }
 
 /** One mise task the suite plans to run (root command or expanded leaf). */
@@ -59,6 +94,22 @@ const RUN_TASK_RE = /^\s*run_task\s+(\S+)/gm;
 const PTS_BENCHMARK_RE = /^\s*run_(?:pts_benchmark|pinned_pts)\s+"([^"]+)"\s+"([^"]+)"/gm;
 const FIO_PTS_RE = /^\s*run_fio_pts\s+"[^"]+"\s+"[^"]+"\s+"([^"]+)"/gm;
 const REALWORLD_PTS_RE = /^\s*run_realworld_pts\s+(\S+)/gm;
+const INSTALL_LOCAL_RE = /^\s*install_local_pts_profile\s+"([^"$]+)"/gm;
+const INSTALL_VENDORED_RE = /^\s*install_vendored_pts_profile\s+"([^"$]+)"/gm;
+const INSTALL_LOCAL_PROFILE_VAR_RE = /^\s*install_local_pts_profile\s+"\$profile"/m;
+const INSTALL_VENDORED_PROFILE_VAR_RE = /^\s*install_vendored_pts_profile\s+"\$profile"/m;
+const PROFILE_ASSIGN_RE = /^\s*profile="([^"]+)"\s*$/m;
+// seed_pts_download_cache <file> <sha256> <url> [mirror...] — quoted args only (leaf convention).
+// Callers must join bash `\` continuations first (see {@link joinBashLineContinuations}).
+const SEED_CACHE_RE =
+	/^\s*seed_pts_download_cache\s+"([^"]+)"\s+"([0-9a-f]{64})"((?:\s+"[^"]+")+)/gm;
+// `export CFLAGS_OVERRIDE="…"` plus the bare `NAME=value` assignments its `${NAME}` references
+// resolve against. Mined rather than restated in TypeScript: the STREAM leaf's flags are
+// load-bearing (a wrong -march is a SIGILL under gVisor, a wrong array size is a silently
+// incomparable working set) and its own comments are where that reasoning lives.
+const CFLAGS_OVERRIDE_RE = /^\s*export\s+CFLAGS_OVERRIDE="([^"]*)"\s*$/m;
+const SCALAR_ASSIGN_RE = /^\s*([A-Za-z_][A-Za-z0-9_]*)=([A-Za-z0-9._=+-]+)\s*$/gm;
+const GVISOR_PROBE_RE = /grep\s+-qi\s+gvisor\s+\/proc\/version/;
 
 /** Extract the mise task name from a suite command like `mise run benchmark:disk:all`. */
 export function miseTaskFromCommand(command: string): string | undefined {
@@ -116,6 +167,93 @@ export function ptsPinsFromScript(
 	return pins;
 }
 
+/** Collapse bash `\` line continuations so multiline helper calls match as one logical line. */
+export function joinBashLineContinuations(script: string): string {
+	return script.replace(/\\\r?\n/g, " ");
+}
+
+/**
+ * Mine host-warm staging hints from a leaf script: local/vendored profile installs, download-cache
+ * seeds, and the `CFLAGS_OVERRIDE` a leaf pins for its own compile.
+ *
+ * Understands both literal `"name"` args and the `profile="name"` + `install_* "$profile"` shape
+ * used by fast-cli / stream-style leaves.
+ */
+export function warmHintsFromScript(script: string): LeafWarmHints {
+	const active = joinBashLineContinuations(stripBashComments(script));
+	const localProfiles = [...active.matchAll(INSTALL_LOCAL_RE)]
+		.map((m) => m[1] ?? "")
+		.filter(Boolean);
+	const vendoredProfiles = [...active.matchAll(INSTALL_VENDORED_RE)]
+		.map((m) => m[1] ?? "")
+		.filter(Boolean);
+	const profileAssign = active.match(PROFILE_ASSIGN_RE)?.[1];
+	if (profileAssign) {
+		if (INSTALL_LOCAL_PROFILE_VAR_RE.test(active)) localProfiles.push(profileAssign);
+		if (INSTALL_VENDORED_PROFILE_VAR_RE.test(active)) vendoredProfiles.push(profileAssign);
+	}
+	const seeds: DownloadSeed[] = [];
+	for (const match of active.matchAll(SEED_CACHE_RE)) {
+		const filename = match[1] ?? "";
+		const sha256 = match[2] ?? "";
+		const urlBlob = match[3] ?? "";
+		const urls = [...urlBlob.matchAll(/"([^"]+)"/g)].map((m) => m[1] ?? "").filter(Boolean);
+		const parsed = downloadSeedSchema({ filename, sha256, urls });
+		if (parsed instanceof type.errors) {
+			throw new Error(`invalid seed_pts_download_cache in leaf script: ${parsed.summary}`);
+		}
+		seeds.push(parsed);
+	}
+	const cflagsOverride = cflagsOverrideFromScript(active);
+	return {
+		localProfiles: [...new Set(localProfiles)],
+		vendoredProfiles: [...new Set(vendoredProfiles)],
+		seeds,
+		...(cflagsOverride ? { cflagsOverride } : {}),
+	};
+}
+
+/**
+ * Render the leaf's own `CFLAGS_OVERRIDE` for both ISA branches, or `undefined` when the leaf pins
+ * none (or pins one this miner cannot resolve).
+ *
+ * A leaf assigns each variable once, except for the ISA it re-assigns inside a
+ * `grep -qi gvisor /proc/version` guard — so substituting first-assignment-wins yields the
+ * non-gVisor binary and last-assignment-wins the gVisor one, which are exactly the two the leaf can
+ * produce. Anything left unsubstituted (a command substitution, an arithmetic expansion, a shape
+ * this does not model) yields `undefined` rather than a guess: the warmer then installs the profile
+ * with upstream's flags and the leaf's own in-place recompile — which every STREAM run performs and
+ * guards with a stale-binary tripwire — still lands the pinned build before measurement.
+ */
+function cflagsOverrideFromScript(active: string): { native: string; gvisor: string } | undefined {
+	const template = active.match(CFLAGS_OVERRIDE_RE)?.[1];
+	if (!template) return undefined;
+	const first = new Map<string, string>();
+	const last = new Map<string, string>();
+	for (const match of active.matchAll(SCALAR_ASSIGN_RE)) {
+		const name = match[1] as string;
+		const value = match[2] as string;
+		if (!first.has(name)) first.set(name, value);
+		last.set(name, value);
+	}
+	const render = (vars: Map<string, string>): string | undefined => {
+		let unresolved = false;
+		const out = template.replace(/\$\{([A-Za-z_][A-Za-z0-9_]*)\}/g, (_whole, name: string) => {
+			const value = vars.get(name);
+			if (value === undefined) unresolved = true;
+			return value ?? "";
+		});
+		// A `$(…)`/`$((…))`/bare `$NAME` the substitution above does not model would silently ship a
+		// literal dollar sign into a compiler invocation.
+		return unresolved || out.includes("$") ? undefined : out;
+	};
+	const native = render(first);
+	// Without the gVisor probe the leaf has no second branch: both renders are the same binary.
+	const gvisor = GVISOR_PROBE_RE.test(active) ? render(last) : native;
+	if (native === undefined || gvisor === undefined) return undefined;
+	return { native, gvisor };
+}
+
 /**
  * The `#MISE description=` a file task declares, which is exactly what `mise task info` would report
  * for it. Read straight from the script so a summary still names its tasks when the mise binary is
@@ -170,6 +308,23 @@ export function realworldVersionFromBenchSh(benchSh: string): string | undefined
 	if (!body) return undefined;
 	const match = stripBashComments(body).match(/profile="realworld-\$\{repo\}-([^"]+)"/);
 	return match?.[1];
+}
+
+/**
+ * Repo-relative overlay paths that `run_realworld_pts` passes to `install_local_pts_profile`
+ * (shared install.sh + runner). Warm must stage the same overlays or batch-install lacks the runner.
+ */
+export function realworldOverlaysFromBenchSh(benchSh: string): string[] {
+	const body = bashFunctionBody(benchSh, "run_realworld_pts");
+	if (!body) return [];
+	const active = joinBashLineContinuations(stripBashComments(body));
+	const match = active.match(
+		/install_local_pts_profile\s+"\$profile"((?:\s+"\$\{REPO_ROOT\}\/[^"]+")+)/,
+	);
+	if (!match?.[1]) return [];
+	return [...match[1].matchAll(/"\$\{REPO_ROOT\}\/([^"]+)"/g)]
+		.map((m) => m[1] ?? "")
+		.filter(Boolean);
 }
 
 interface MiseTaskInfo {

--- a/bun.lock
+++ b/bun.lock
@@ -33,6 +33,7 @@
         "stability": "./src/bin/stability.ts",
         "leaderboard": "./src/bin/leaderboard.ts",
         "driver-check": "./src/bin/driver-check.ts",
+        "warm-pts": "./src/bin/warm-pts.ts",
       },
       "dependencies": {
         "@actions/core": "1.11.1",
@@ -47,6 +48,7 @@
         "@sandbox-benchmarks/results": "workspace:*",
         "@sandbox-benchmarks/schema": "workspace:*",
         "@sandbox-benchmarks/templates": "workspace:*",
+        "arktype": "catalog:",
         "dotenv": "catalog:",
         "modal": "catalog:computesdk",
         "novita-sandbox": "catalog:computesdk",

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -70,7 +70,7 @@ docs/       methodology, ADRs, CI & secrets
 | `@sandbox-benchmarks/harness`    | providers, schema                               | —                                   |
 | `@sandbox-benchmarks/figures`    | schema                                          | `arktype`, fonts (`@fontsource/*`)  |
 | `@sandbox-benchmarks/results`    | schema, figures                                 | `arktype`, XML tooling (`catalog:xml`) |
-| `@sandbox-benchmarks/cli` (app)  | schema, driver, drivers, providers, templates, harness, results, figures | `dotenv`, `@actions/core`, provider SDKs (`catalog:computesdk`) |
+| `@sandbox-benchmarks/cli` (app)  | schema, driver, drivers, providers, templates, harness, results, figures | `arktype`, `dotenv`, `@actions/core`, provider SDKs (`catalog:computesdk`) |
 | `@repo/tsconfig`            | —                                               | —                                   |
 | `@repo/repo-checks`         | —                                               | —                                   |
 

--- a/package.json
+++ b/package.json
@@ -66,6 +66,7 @@
     "check:provider-registry-drift": "bun --filter '@sandbox-benchmarks/schema' check:provider-registry-drift",
     "generate-provider-wiring": "bun --filter '@sandbox-benchmarks/schema' generate-provider-wiring",
     "check:provider-wiring": "bun --filter '@sandbox-benchmarks/schema' check:provider-wiring",
+    "warm:pts": "bun apps/cli/src/bin/warm-pts.ts",
     "prepare": "lefthook install"
   },
   "devDependencies": {

--- a/packages/schema/src/pts-profiles/fio-2.1.0/host-seed.json
+++ b/packages/schema/src/pts-profiles/fio-2.1.0/host-seed.json
@@ -1,0 +1,9 @@
+{
+  "filename": "fio-3.36.tar.gz",
+  "sha256": "0a07354876ca4d23518f8aa88682f23866455bbd2ff2d0f055d6e4b72f156553",
+  "urls": [
+    "http://archive.ubuntu.com/ubuntu/pool/universe/f/fio/fio_3.36.orig.tar.gz",
+    "https://launchpad.net/ubuntu/+archive/primary/+sourcefiles/fio/3.36-1/fio_3.36.orig.tar.gz",
+    "https://web.archive.org/web/2020/http://brick.kernel.dk/snaps/fio-3.36.tar.gz"
+  ]
+}


### PR DESCRIPTION
### Motivation
- Provide a host-side warmer to pre-install Phoronix Test Suite (PTS) profiles so `mise run benchmark:…` spends time measuring rather than downloading/building.
- Make warming driven by the suite registry and leaf mining (no hard-coded profile lists) so new pins are picked up automatically.
- Surface deterministic planning (`--dry-plan`) and idempotent stamping to avoid redundant warms across runs.

### Description
- Add a new CLI bin `warm-pts` (`apps/cli/src/bin/warm-pts.ts`) and wire it into `apps/cli/package.json` and the repo `package.json` scripts as `warm:pts`.
- Implement planning logic in `apps/cli/src/lib/pts-warm.ts` that resolves suite tokens, mines leaves for PTS profile pins, seeds, overlays, and `CFLAGS_OVERRIDE` hints; add `host-seed.json` consumption for vendored profiles.
- Add `apps/cli/src/lib/pts-warm-bench.ts` to wrap `lib/bench.sh` helpers and PTS invocations safely (spawn helpers, batch install, list installed tests, discard install trees, payload probes, and host/ISA detection).
- Extend `suite-tasks.ts` to mine warm hints (seeds, vendored/local installs, CFLAGS overrides) and helper utilities (`joinBashLineContinuations`, `warmHintsFromScript`, `realworldOverlaysFromBenchSh`), and add a `host-seed.json` for `fio-2.1.0` profiles.
- Add name-guarding, payload probes, and safety checks to avoid unsafe path operations and incorrect flag propagation across batch installs.
- Update documentation in `AGENTS.md` and `docs/architecture.md` to describe the synthetic suites, warm CLI usage, and expected verification commands.
- Add unit tests covering arg parsing and stamping (`warm-pts.test.ts`), bench wrapper safety and payload checks (`pts-warm-bench.test.ts`), and expanded suite-task/warm planning behaviors (`suite-tasks.test.ts` updates and `pts-warm` plan tests).

### Testing
- Ran the repository test suite via `bun test` (filtered CLI tests where appropriate) and executed the new unit tests `apps/cli/src/bin/warm-pts.test.ts`, `apps/cli/src/lib/pts-warm-bench.test.ts`, and updated `suite-tasks` tests; all new and affected tests passed locally.
- Exercised `warm-pts --dry-plan` to validate that `planPtsWarm` produces a stable, inspectable JSON plan and `--list-suites` prints the suite catalog (manual verification via the bin during development).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a97461c3ab88327819a6ac9a8b3be94)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a `warm-pts` CLI that pre-installs Phoronix Test Suite profiles on the host, so `mise run benchmark:…` measures instead of downloading and building. The warm plan is derived from the suite registry and leaf mining, so new profile pins are picked up automatically.

**New Features**
- `bun run warm:pts` installs the planned profiles and stamps completion; `--dry-plan` prints the plan without touching PTS.
- Suite presets (`all`, `synthetic`, `realworld`) and per-suite selections are supported, with `--list-suites` showing the catalog.
- Adds `host-seed.json` for fio with Ubuntu mirror fallbacks since OpenBenchmarking's host is often down.

**Safety and verification**
- Profile names are validated before any path operation, and batch installs are grouped per compile env so STREAM's `-march=native` never rebuilds neighboring profiles.
- Profiles that leaves re-stage (iperf) are seeded but not installed, since the leaf discards the installed tree at run time.
- PTS marks a profile installed when its `install.sh` writes a launcher, so the warmer also checks for `install-failed.log` and probes built payloads (pgbench).
- First-time PTS installation requires `SUDO=sudo`; the warmer runs `ensure_pts` and fails if required tools are missing.

<sup>Written for commit dae9d662239dc0bffefb6143ee1109478e47346e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/starslingdev/hpc-sandbox-benchmarks/pull/411?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a `warm:pts` workflow for planning and pre-installing benchmark suites and profiles.
  * Added suite listing, dry-run JSON plans, cache seeding, installation verification, compiler settings, and command logging.
  * Added support for host-specific benchmark metadata, download sources, overlays, and compiler flags.
  * Added a bundled host seed for fio benchmark setup.

* **Documentation**
  * Updated benchmark setup, warming workflows, cache behavior, environment handling, and runtime guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->