### PR TITLE
fix: repair every provider failure from CPU benchmark run 33712242440

### DIFF
--- a/lib/pts/realworld/realworld-runner.sh
+++ b/lib/pts/realworld/realworld-runner.sh
@@ -81,6 +81,48 @@ if [ "$TASK_TIMEOUT_SECONDS" -eq 0 ]; then
 	exit 1
 fi
 
+# Recover from the EBUSY a cgroup-NAMESPACE root answers `+memory` with: cgroup v2 forbids enabling a
+# controller for children while the cgroup still holds processes of its own, and only the TRUE root is
+# exempt. A sandbox handed a delegated subtree as its `/` is not exempt, so `memory` can never reach a
+# child and the cap is silently abandoned. Probed live on Vercel (kernel 6.18.40): cgroup2 mounted rw,
+# `memory` present in cgroup.controllers, subtree_control EMPTY, 4 processes in the namespace root,
+# `echo +memory` → EBUSY, child mkdir fine but no memory.max in it.
+#
+# The remedy is what every container runtime does: park those processes in a leaf so the root holds
+# none, then enable the controller. Only the sandbox's own agent processes move, into an UNCAPPED
+# sibling — they keep the headroom the cap reserves for them, which is the whole point of leaving them
+# out of bench-task.
+#
+# ORDER IS LOAD-BEARING, and both halves were established by probing a live Vercel sandbox:
+#   1. THIS shell moves first. cgroup membership is inherited, so until the runner itself leaves,
+#      every command it forks is born back into the root and the root never empties.
+#   2. Then converge, re-reading the file each pass. cgroup.procs is a LIVE view, not a snapshot:
+#      moving an entry out from under a streaming read shifts the remainder and the read skips pids.
+#      A single `while read` pass moved 2 of 5 and left 3 behind; snapshot-then-move reached empty in
+#      2 passes. Bounded at 5 so a process that genuinely cannot be moved costs passes, not the job.
+# Every write is best-effort — a pid that exits mid-migration is normal, and the retried
+# subtree_control write is the only verdict that matters. Returning non-zero leaves BENCH_CG unset and
+# falls through to the oom_score_adj path exactly as before.
+enable_memory_on_ns_root() {
+	cg_leaf=/sys/fs/cgroup/bench-init
+	mkdir "$cg_leaf" 2>/dev/null || [ -d "$cg_leaf" ] || return 1
+	echo $$ 2>/dev/null > "$cg_leaf/cgroup.procs" || true
+	for cg_pass in 1 2 3 4 5; do
+		cg_left="$(cat /sys/fs/cgroup/cgroup.procs 2>/dev/null || true)"
+		[ -n "$cg_left" ] || break
+		for cg_pid in $cg_left; do
+			echo "$cg_pid" 2>/dev/null > "$cg_leaf/cgroup.procs" || true
+		done
+	done
+	if echo +memory 2>/dev/null > /sys/fs/cgroup/cgroup.subtree_control; then
+		echo "bench-cgroup: emptied the cgroup-namespace root in ${cg_pass} pass(es) to enable the" \
+			"memory controller" >&2
+		return 0
+	fi
+	rmdir "$cg_leaf" 2>/dev/null || true
+	return 1
+}
+
 # Memory containment: task commands run inside a cgroup-v2 child capped below MemTotal so a task
 # that exhausts RAM is OOM-killed ALONE instead of driving a VM guest into global OOM — on
 # daytona-vm that killed the in-guest Daytona daemon and the whole benchmark tree ("lost its
@@ -115,55 +157,10 @@ if [ -n "$cap_bytes" ] && [ -f /sys/fs/cgroup/cgroup.controllers ] &&
 	# 2>/dev/null must come FIRST: redirections apply left to right, so a failed open of the
 	# target (ro cgroup fs on container providers) would otherwise print shell noise into every
 	# task log before the stderr redirect takes effect.
-	if ! echo +memory 2>/dev/null > /sys/fs/cgroup/cgroup.subtree_control; then
-		# EBUSY on a cgroup-NAMESPACE root: cgroup v2 forbids enabling a controller for children
-		# while the cgroup still holds processes of its own, and only the TRUE root is exempt. A
-		# sandbox handed a delegated subtree as its `/` is not exempt, so `memory` can never reach a
-		# child and the cap is silently abandoned. Probed live on Vercel (kernel 6.18.40): cgroup2
-		# mounted rw, `memory` present in cgroup.controllers, subtree_control EMPTY, 4 processes in
-		# the namespace root, `echo +memory` → EBUSY, child mkdir fine but no memory.max in it. That
-		# is the whole reason 4 of 12 openclaw replicates lost their sandbox in run 33712242440
-		# instead of merely failing the out-of-spec task.
-		#
-		# The standard remedy, and what every container runtime does: park the existing processes in
-		# a leaf so the root holds none, then enable the controller. Only the sandbox's own agent
-		# processes move, into an UNCAPPED sibling — they keep the headroom the cap reserves for
-		# them, which is the whole point of leaving them out of bench-task. Everything is guarded:
-		# any failure leaves BENCH_CG empty and falls through to the oom_score_adj path exactly as
-		# before, and the join probe below still has to pass before the cap is advertised.
-		cg_leaf="/sys/fs/cgroup/bench-init"
-		if mkdir "$cg_leaf" 2>/dev/null || [ -d "$cg_leaf" ]; then
-			# ORDER IS LOAD-BEARING, and both halves were established by probing a live Vercel sandbox.
-			#
-			# (1) THIS shell moves first. cgroup membership is inherited, so until the runner itself
-			#     leaves, every command it forks is born back into the root and the root never empties
-			#     — the migration chases its own children forever.
-			# (2) Then converge, re-reading the file each pass. cgroup.procs is a LIVE view, not a
-			#     snapshot: moving an entry out from under a streaming read shifts the remainder and
-			#     the read skips pids. Measured on Vercel, a single `while read` pass moved 2 of 5 and
-			#     left 3 behind; snapshot-then-move needed 2 passes to reach empty. Bounded at 5 so a
-			#     process that genuinely cannot be moved costs a few passes, not the job.
-			#
-			# Every write stays best-effort — a pid that exits mid-migration is normal, and the retry
-			# of subtree_control below is the only verdict that matters.
-			echo $$ 2>/dev/null > "$cg_leaf/cgroup.procs" || true
-			cg_pass=0
-			while [ "$cg_pass" -lt 5 ]; do
-				cg_pass=$((cg_pass + 1))
-				cg_left="$(cat /sys/fs/cgroup/cgroup.procs 2>/dev/null || true)"
-				[ -n "$cg_left" ] || break
-				for cg_pid in $cg_left; do
-					echo "$cg_pid" 2>/dev/null > "$cg_leaf/cgroup.procs" || true
-				done
-			done
-			if echo +memory 2>/dev/null > /sys/fs/cgroup/cgroup.subtree_control; then
-				echo "bench-cgroup: emptied the cgroup-namespace root in ${cg_pass} pass(es) to enable" \
-					"the memory controller" >&2
-			else
-				rmdir "$cg_leaf" 2>/dev/null || true
-			fi
-		fi
-	fi
+	# The trailing `|| true` is load-bearing under `set -e`: a `||` list only exempts its LEFT side from
+	# errexit, so a read-only cgroup fs (namespace's cgroup2 is mounted ro) would fail the echo, fail
+	# the recovery, and kill the runner outright — on the very providers whose fallback is the point.
+	echo +memory 2>/dev/null > /sys/fs/cgroup/cgroup.subtree_control || enable_memory_on_ns_root || true
 	bench_cg="/sys/fs/cgroup/bench-task-$$"
 	# memory.swap.max=0 only where the knob exists (load-bearing for measurement fidelity when the
 	# guest has swap: an uncapped-swap task would thrash instead of OOM-ing).
@@ -279,25 +276,18 @@ wipe_tool_caches() {
 		done
 }
 
-# A task a profile marks TASK_REQUIRES_MEM_CAP_<task>=1 is one KNOWN to exceed the target spec's
-# RAM (openclaw's lint_oxlint is the case this exists for). Where the cap engaged, running it is
-# the point: the cgroup OOM-kills that task ALONE, PTS records a missing sample for it, and the
-# suite's other options still post theirs — a metric-scoped gap, which is the declared keep+warn
-# contract. Where the cap could NOT engage, the same command instead drives the whole guest out
-# of memory and takes the sandbox with it, losing every other metric in the run: 9 of 12
-# replicates on modal-gvisor and 4 of 12 on Vercel in run 33712242440, against zero on every
-# provider whose forensics show `bench-cgroup: capped at …`.
-#
-# So refuse it instead. The outcome for THIS metric is identical either way (attempted, no value
-# recorded); what changes is that the seven healthy metrics beside it survive. gVisor cannot be
-# rescued by the migration above — its /sys/fs/cgroup is a read-only tmpfs with no v2 controller
-# file at all (probed live on modal-gvisor, kernel 4.19.0-gvisor) — so this is the only
-# containment available there.
+# A task a profile marks TASK_REQUIRES_MEM_CAP_<task>=1 is one KNOWN to exceed the target spec's RAM
+# (see the declaring target.env for the measurement). With the cap, running it is the point: the
+# cgroup OOM-kills that task ALONE and the suite's other options still post their samples. Without
+# one, the same command drives the whole guest out of memory and takes the sandbox down, losing every
+# other metric in the run — so refuse it. This metric records nothing either way; only the healthy
+# ones beside it are at stake. gVisor is why the refusal exists rather than a second rescue: its
+# /sys/fs/cgroup is a read-only tmpfs with no v2 controller file at all, so nothing above can help.
 eval "requires_cap=\"\${TASK_REQUIRES_MEM_CAP_${TASK}:-}\""
 if [ -n "$requires_cap" ] && [ -z "${BENCH_CG:-}" ]; then
-	echo "task '${TASK}' requires an enforceable memory cap and this sandbox exposes none" >&2
-	echo "(see the bench-cgroup line above); refusing to run it uncontained, because doing so" >&2
-	echo "takes the whole sandbox down and loses every other metric in this run." >&2
+	echo "task '${TASK}' requires an enforceable memory cap and this sandbox exposes none (see the" \
+		"bench-cgroup line above); refusing to run it uncontained, because doing so takes the whole" \
+		"sandbox down and loses every other metric in this run." >&2
 	exit 1
 fi
 

--- a/lib/pts/realworld/realworld-runner.sh
+++ b/lib/pts/realworld/realworld-runner.sh
@@ -111,11 +111,59 @@ if [ -n "$cap_bytes" ] && [ -f /sys/fs/cgroup/cgroup.controllers ] &&
 	grep -qw memory /sys/fs/cgroup/cgroup.controllers 2>/dev/null; then
 	# Idempotent on a real root cgroup (root is exempt from the no-internal-processes rule, and
 	# systemd guests already have it enabled); fails EBUSY on a namespaced root that still holds
-	# processes, which the fallback below tolerates.
+	# processes, which the migration below now recovers.
 	# 2>/dev/null must come FIRST: redirections apply left to right, so a failed open of the
 	# target (ro cgroup fs on container providers) would otherwise print shell noise into every
 	# task log before the stderr redirect takes effect.
-	echo +memory 2>/dev/null > /sys/fs/cgroup/cgroup.subtree_control || true
+	if ! echo +memory 2>/dev/null > /sys/fs/cgroup/cgroup.subtree_control; then
+		# EBUSY on a cgroup-NAMESPACE root: cgroup v2 forbids enabling a controller for children
+		# while the cgroup still holds processes of its own, and only the TRUE root is exempt. A
+		# sandbox handed a delegated subtree as its `/` is not exempt, so `memory` can never reach a
+		# child and the cap is silently abandoned. Probed live on Vercel (kernel 6.18.40): cgroup2
+		# mounted rw, `memory` present in cgroup.controllers, subtree_control EMPTY, 4 processes in
+		# the namespace root, `echo +memory` → EBUSY, child mkdir fine but no memory.max in it. That
+		# is the whole reason 4 of 12 openclaw replicates lost their sandbox in run 33712242440
+		# instead of merely failing the out-of-spec task.
+		#
+		# The standard remedy, and what every container runtime does: park the existing processes in
+		# a leaf so the root holds none, then enable the controller. Only the sandbox's own agent
+		# processes move, into an UNCAPPED sibling — they keep the headroom the cap reserves for
+		# them, which is the whole point of leaving them out of bench-task. Everything is guarded:
+		# any failure leaves BENCH_CG empty and falls through to the oom_score_adj path exactly as
+		# before, and the join probe below still has to pass before the cap is advertised.
+		cg_leaf="/sys/fs/cgroup/bench-init"
+		if mkdir "$cg_leaf" 2>/dev/null || [ -d "$cg_leaf" ]; then
+			# ORDER IS LOAD-BEARING, and both halves were established by probing a live Vercel sandbox.
+			#
+			# (1) THIS shell moves first. cgroup membership is inherited, so until the runner itself
+			#     leaves, every command it forks is born back into the root and the root never empties
+			#     — the migration chases its own children forever.
+			# (2) Then converge, re-reading the file each pass. cgroup.procs is a LIVE view, not a
+			#     snapshot: moving an entry out from under a streaming read shifts the remainder and
+			#     the read skips pids. Measured on Vercel, a single `while read` pass moved 2 of 5 and
+			#     left 3 behind; snapshot-then-move needed 2 passes to reach empty. Bounded at 5 so a
+			#     process that genuinely cannot be moved costs a few passes, not the job.
+			#
+			# Every write stays best-effort — a pid that exits mid-migration is normal, and the retry
+			# of subtree_control below is the only verdict that matters.
+			echo $$ 2>/dev/null > "$cg_leaf/cgroup.procs" || true
+			cg_pass=0
+			while [ "$cg_pass" -lt 5 ]; do
+				cg_pass=$((cg_pass + 1))
+				cg_left="$(cat /sys/fs/cgroup/cgroup.procs 2>/dev/null || true)"
+				[ -n "$cg_left" ] || break
+				for cg_pid in $cg_left; do
+					echo "$cg_pid" 2>/dev/null > "$cg_leaf/cgroup.procs" || true
+				done
+			done
+			if echo +memory 2>/dev/null > /sys/fs/cgroup/cgroup.subtree_control; then
+				echo "bench-cgroup: emptied the cgroup-namespace root in ${cg_pass} pass(es) to enable" \
+					"the memory controller" >&2
+			else
+				rmdir "$cg_leaf" 2>/dev/null || true
+			fi
+		fi
+	fi
 	bench_cg="/sys/fs/cgroup/bench-task-$$"
 	# memory.swap.max=0 only where the knob exists (load-bearing for measurement fidelity when the
 	# guest has swap: an uncapped-swap task would thrash instead of OOM-ing).
@@ -230,6 +278,28 @@ wipe_tool_caches() {
 			find "$cache_dir" -mindepth 1 -maxdepth 1 ! -name turbo -exec rm -rf {} +
 		done
 }
+
+# A task a profile marks TASK_REQUIRES_MEM_CAP_<task>=1 is one KNOWN to exceed the target spec's
+# RAM (openclaw's lint_oxlint is the case this exists for). Where the cap engaged, running it is
+# the point: the cgroup OOM-kills that task ALONE, PTS records a missing sample for it, and the
+# suite's other options still post theirs — a metric-scoped gap, which is the declared keep+warn
+# contract. Where the cap could NOT engage, the same command instead drives the whole guest out
+# of memory and takes the sandbox with it, losing every other metric in the run: 9 of 12
+# replicates on modal-gvisor and 4 of 12 on Vercel in run 33712242440, against zero on every
+# provider whose forensics show `bench-cgroup: capped at …`.
+#
+# So refuse it instead. The outcome for THIS metric is identical either way (attempted, no value
+# recorded); what changes is that the seven healthy metrics beside it survive. gVisor cannot be
+# rescued by the migration above — its /sys/fs/cgroup is a read-only tmpfs with no v2 controller
+# file at all (probed live on modal-gvisor, kernel 4.19.0-gvisor) — so this is the only
+# containment available there.
+eval "requires_cap=\"\${TASK_REQUIRES_MEM_CAP_${TASK}:-}\""
+if [ -n "$requires_cap" ] && [ -z "${BENCH_CG:-}" ]; then
+	echo "task '${TASK}' requires an enforceable memory cap and this sandbox exposes none" >&2
+	echo "(see the bench-cgroup line above); refusing to run it uncontained, because doing so" >&2
+	echo "takes the whole sandbox down and loses every other metric in this run." >&2
+	exit 1
+fi
 
 case "$TASK" in
 git_clone)

--- a/packages/providers/src/config.ts
+++ b/packages/providers/src/config.ts
@@ -33,8 +33,6 @@ const envSchema = type({
 	"NOVITA_API_KEY?": "string >= 1",
 	"NOVITA_TEMPLATE?": "string >= 1",
 	"RUNLOOP_BLUEPRINT?": "string >= 1",
-	// tama publishes no SDK: the adapter SPAWNS this binary. An empty value here would spawn ""
-	// (ERR_INVALID_ARG_VALUE), which is exactly what the empty-is-unset rule below exists to prevent.
 	"TAMA_CLI?": "string >= 1",
 	"MSB_API_URL?": "string >= 1",
 	"MSB_API_KEY?": "string >= 1",

--- a/packages/providers/src/config.ts
+++ b/packages/providers/src/config.ts
@@ -44,7 +44,17 @@ const envSchema = type({
 	"VERCEL_PROJECT_NAME?": "string >= 1",
 });
 
-const ENV_KEYS = [
+/**
+ * The keys forwarded into {@link envSchema}, and — for every OPTIONAL provider VARIABLE — the list
+ * that decides whether CI's empty-string export is absorbed here or reaches business logic raw.
+ *
+ * Exported for the drift test in index.test.ts, which is the guard this list has to earn: `TAMA_CLI`
+ * was declared in the schema registry but missing from here, so the adapter read it straight off
+ * process.env, `??` accepted CI's `""`, and every tama cell of matrix run 33712242440 died in
+ * spawn(""). The registry is the source of truth for which variables exist; this list only has to
+ * cover them.
+ */
+export const ENV_KEYS = [
 	"BENCH_TOOLCHAIN_IMAGE",
 	"E2B_TEMPLATE",
 	"DAYTONA_API_KEY",

--- a/packages/providers/src/config.ts
+++ b/packages/providers/src/config.ts
@@ -33,6 +33,9 @@ const envSchema = type({
 	"NOVITA_API_KEY?": "string >= 1",
 	"NOVITA_TEMPLATE?": "string >= 1",
 	"RUNLOOP_BLUEPRINT?": "string >= 1",
+	// tama publishes no SDK: the adapter SPAWNS this binary. An empty value here would spawn ""
+	// (ERR_INVALID_ARG_VALUE), which is exactly what the empty-is-unset rule below exists to prevent.
+	"TAMA_CLI?": "string >= 1",
 	"MSB_API_URL?": "string >= 1",
 	"MSB_API_KEY?": "string >= 1",
 	"VERCEL_CANDIDATE_IMAGE?": "string >= 1",
@@ -54,6 +57,7 @@ const ENV_KEYS = [
 	"NOVITA_API_KEY",
 	"NOVITA_TEMPLATE",
 	"RUNLOOP_BLUEPRINT",
+	"TAMA_CLI",
 	"MSB_API_URL",
 	"MSB_API_KEY",
 	"VERCEL_CANDIDATE_IMAGE",
@@ -203,6 +207,12 @@ export const config = {
 	runloopBlueprintVersion,
 	/** Mutable candidate Runloop Blueprint name the bake creates while iterating. */
 	runloopBlueprintCandidate,
+	/** The `tama` binary the CLI-driven adapter spawns for every control-plane call; `TAMA_CLI`
+	 *  override, else the name resolved from PATH (what `.github/actions/setup-tama` installs).
+	 *  Resolved HERE rather than at the spawn site so the empty-is-unset rule above covers it — CI
+	 *  materializes the unconfigured override as `TAMA_CLI=""`, and spawning that is a TypeError, not
+	 *  a fallback to the default. */
+	tamaCli: env.TAMA_CLI ?? "tama",
 	/** Microsandbox Cloud connection. The provider gate requires the key before construction, while
 	 * the URL stays optional so the SDK can use its production default. */
 	microsandboxCloud: {

--- a/packages/providers/src/index.test.ts
+++ b/packages/providers/src/index.test.ts
@@ -3,6 +3,9 @@ import { describe, expect, it } from "bun:test";
 // actually REPLACED (identity inequality against an unpatched instance's methods table).
 import { e2b } from "@computesdk/e2b";
 import { PROVIDERS, TARGET_SPEC, TOOLCHAIN_IMAGE_NAME } from "@sandbox-benchmarks/schema";
+import { normalizeProviderInput } from "@sandbox-benchmarks/schema/provider-meta";
+import { REGISTRY } from "@sandbox-benchmarks/schema/providers";
+import { ENV_KEYS } from "./config.ts";
 import {
 	config,
 	microsandboxCloudCompute,
@@ -16,6 +19,32 @@ import { runE2bCommandAsRoot } from "./lib/e2b-root.ts";
 import { assertCreateCeilingDeclared, assertProviderJoin } from "./lib/join.ts";
 
 describe("@sandbox-benchmarks/providers", () => {
+	// The failure this prevents is not hypothetical: TAMA_CLI was declared in the registry as an
+	// optional variable but never added to the gatekeeper's key list, so the tama adapter read it
+	// straight off process.env. CI exports an unconfigured variable input as `X: ${{ … || '' }}` —
+	// set AND EMPTY, because GitHub Actions cannot express "unset" — `??` accepted that empty string
+	// as a value, and spawn("") killed all 54 tama replicates of matrix run 33712242440 before a
+	// single sandbox existed.
+	//
+	// The gatekeeper is where that empty-is-unset rule lives, so every optional variable has to pass
+	// through it. A subset assertion rather than deriving ENV_KEYS outright: the list legitimately
+	// carries keys with no registry input (BENCH_TOOLCHAIN_IMAGE, VERCEL_CANDIDATE_IMAGE, and the
+	// API keys re-exposed as config). Required inputs need no coverage — missingCreds already treats
+	// "" as missing, which is why a raw process.env read of a TOKEN is safe and a variable is not.
+	it("routes every optional provider variable through the config gatekeeper", () => {
+		const optionalVariables = Object.values(REGISTRY)
+			.flatMap((meta) => meta.inputs.map(normalizeProviderInput))
+			.filter((input) => input.source.kind === "variable" && !input.required)
+			.map((input) => input.name);
+		expect(optionalVariables.length).toBeGreaterThan(0);
+		// Widened: ENV_KEYS is `as const`, so its literal union would reject a registry-derived string
+		// at the call rather than reporting the drift this test exists to report.
+		const covered: readonly string[] = ENV_KEYS;
+		for (const name of new Set(optionalVariables)) {
+			expect(covered).toContain(name);
+		}
+	});
+
 	it("wires every schema provider through to a computesdk factory", () => {
 		// `adapters` is a Record<ProviderId, …>, so it's the same set as the schema registry by
 		// construction — assert that against PROVIDERS rather than a hardcoded list.

--- a/packages/providers/src/lib/adapters.ts
+++ b/packages/providers/src/lib/adapters.ts
@@ -42,8 +42,6 @@ import { vercelCompute } from "./vercel.ts";
 function daytonaAdapter(cfg: DaytonaConfig): ProviderAdapter {
 	return {
 		artifact: { kind: "baked", ref: cfg.snapshot },
-		// Snapshot activation wraps the region-pinned create, not the other way round: the inner layer
-		// is what the control plane rejects, and the activation client carries its own explicit target.
 		createCompute: () =>
 			daytonaActivateSnapshot(
 				daytonaClientTarget(daytona({ apiKey: cfg.apiKey }), cfg.target),

--- a/packages/providers/src/lib/adapters.ts
+++ b/packages/providers/src/lib/adapters.ts
@@ -14,6 +14,7 @@ import type { DaytonaConfig } from "../config.ts";
 import { config } from "../config.ts";
 import { blaxelWithVolumeAndKeepAlive } from "./blaxel-volume.ts";
 import { MODAL_APP_NAME, modalCostEvidence, runcloudCostEvidence } from "./cost-evidence.ts";
+import { daytonaActivateSnapshot } from "./daytona-snapshot.ts";
 import { daytonaClientTarget } from "./daytona-target.ts";
 import { e2bCommandsAsRoot } from "./e2b-root.ts";
 import { microsandboxCloudCompute, microsandboxLocalCompute } from "./microsandbox.ts";
@@ -41,7 +42,13 @@ import { vercelCompute } from "./vercel.ts";
 function daytonaAdapter(cfg: DaytonaConfig): ProviderAdapter {
 	return {
 		artifact: { kind: "baked", ref: cfg.snapshot },
-		createCompute: () => daytonaClientTarget(daytona({ apiKey: cfg.apiKey }), cfg.target),
+		// Snapshot activation wraps the region-pinned create, not the other way round: the inner layer
+		// is what the control plane rejects, and the activation client carries its own explicit target.
+		createCompute: () =>
+			daytonaActivateSnapshot(
+				daytonaClientTarget(daytona({ apiKey: cfg.apiKey }), cfg.target),
+				cfg,
+			),
 		createOptions: {
 			snapshotId: cfg.snapshot,
 			autoStopInterval: 0,

--- a/packages/providers/src/lib/daytona-snapshot.test.ts
+++ b/packages/providers/src/lib/daytona-snapshot.test.ts
@@ -2,7 +2,7 @@
 // through the REAL SDK with the axios transport stubbed — the same seam daytona-target.test.ts uses —
 // so the test proves the snapshot API is actually reached, and proves it stays best-effort when that
 // call fails, which is the state the stub leaves it in.
-import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it } from "bun:test";
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from "bun:test";
 import type { SandboxMethods } from "@computesdk/provider";
 import { Daytona } from "@daytonaio/sdk";
 import type { DaytonaConfig } from "../config.ts";
@@ -36,13 +36,13 @@ function stubAxios() {
 const sdkClass = Daytona as unknown as { createAxiosInstance: () => unknown };
 const stockAxiosFactory = sdkClass.createAxiosInstance;
 
+type DaytonaCreate = SandboxMethods<unknown, unknown>["create"];
+
 /**
  * A minimal stand-in for the wrapper's sandbox manager. It mirrors the one structural fact the patch
  * depends on: the public `create` dispatches through `methods.create` on every call, which is why
  * replacing the table takes effect at all. Only `create` is patched, so only `create` has to exist.
  */
-type DaytonaCreate = SandboxMethods<unknown, unknown>["create"];
-
 function fakeProvider(create: DaytonaCreate): DirectProvider {
 	const manager = {
 		methods: { create },
@@ -61,19 +61,20 @@ describe("daytonaActivateSnapshot", () => {
 	beforeEach(() => {
 		captured.length = 0;
 	});
-	afterEach(() => {
-		captured.length = 0;
-	});
 
-	it("marks an inactive-snapshot create retryable so the harness re-issues it", async () => {
-		const provider = daytonaActivateSnapshot(
+	/** A provider whose create fails the way the control plane failed every daytona-vm replicate. */
+	const inactiveProvider = () =>
+		daytonaActivateSnapshot(
 			fakeProvider(async () => {
 				throw new Error(INACTIVE);
 			}),
 			CFG,
 		);
 
-		const error = await provider.sandbox.create().catch((e: unknown) => e);
+	it("marks an inactive-snapshot create retryable so the harness re-issues it", async () => {
+		const error = await inactiveProvider()
+			.sandbox.create()
+			.catch((e: unknown) => e);
 		expect((error as Error).message).toBe(INACTIVE);
 		// Without the mark this is a permanent cell failure: the harness's classifier matches only
 		// quota/rate-limit/capacity wording, and "is inactive" is none of those.
@@ -81,14 +82,9 @@ describe("daytonaActivateSnapshot", () => {
 	});
 
 	it("reaches the snapshot API for the configured snapshot", async () => {
-		const provider = daytonaActivateSnapshot(
-			fakeProvider(async () => {
-				throw new Error(INACTIVE);
-			}),
-			CFG,
-		);
-
-		await provider.sandbox.create().catch(() => undefined);
+		await inactiveProvider()
+			.sandbox.create()
+			.catch(() => undefined);
 		expect(captured.some((url) => url.includes(CFG.snapshot))).toBe(true);
 	});
 

--- a/packages/providers/src/lib/daytona-snapshot.test.ts
+++ b/packages/providers/src/lib/daytona-snapshot.test.ts
@@ -1,0 +1,128 @@
+// Offline (no creds, no network) verification of the inactive-snapshot recovery. The activation runs
+// through the REAL SDK with the axios transport stubbed — the same seam daytona-target.test.ts uses —
+// so the test proves the snapshot API is actually reached, and proves it stays best-effort when that
+// call fails, which is the state the stub leaves it in.
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it } from "bun:test";
+import type { SandboxMethods } from "@computesdk/provider";
+import { Daytona } from "@daytonaio/sdk";
+import type { DaytonaConfig } from "../config.ts";
+import { daytonaActivateSnapshot } from "./daytona-snapshot.ts";
+import { isRetryableCreateError } from "./retryable-create.ts";
+import type { DirectProvider } from "./types.ts";
+
+const CFG: DaytonaConfig = {
+	apiKey: "fake-key-offline-test",
+	target: "us-west-2",
+	snapshot: "sandbox-benchmarks-toolchain-v8",
+};
+
+/** The message the control plane produced for every daytona-vm replicate of run 33712242440, as it
+ *  reaches this wrapper through @computesdk/daytona's create-failure prefix. */
+const INACTIVE = `Failed to create Daytona sandbox: Snapshot ${CFG.snapshot} is inactive`;
+
+const captured: string[] = [];
+
+function stubAxios() {
+	return {
+		interceptors: { request: { use: () => 0 }, response: { use: () => 0 } },
+		defaults: { headers: {} },
+		request: async (requestConfig: { url?: string }) => {
+			captured.push(requestConfig.url ?? "");
+			throw new Error("transport stubbed: request captured");
+		},
+	};
+}
+
+const sdkClass = Daytona as unknown as { createAxiosInstance: () => unknown };
+const stockAxiosFactory = sdkClass.createAxiosInstance;
+
+/**
+ * A minimal stand-in for the wrapper's sandbox manager. It mirrors the one structural fact the patch
+ * depends on: the public `create` dispatches through `methods.create` on every call, which is why
+ * replacing the table takes effect at all. Only `create` is patched, so only `create` has to exist.
+ */
+type DaytonaCreate = SandboxMethods<unknown, unknown>["create"];
+
+function fakeProvider(create: DaytonaCreate): DirectProvider {
+	const manager = {
+		methods: { create },
+		create: (...args: Parameters<DaytonaCreate>) => manager.methods.create(...args),
+	};
+	return { sandbox: manager } as unknown as DirectProvider;
+}
+
+describe("daytonaActivateSnapshot", () => {
+	beforeAll(() => {
+		sdkClass.createAxiosInstance = stubAxios;
+	});
+	afterAll(() => {
+		sdkClass.createAxiosInstance = stockAxiosFactory;
+	});
+	beforeEach(() => {
+		captured.length = 0;
+	});
+	afterEach(() => {
+		captured.length = 0;
+	});
+
+	it("marks an inactive-snapshot create retryable so the harness re-issues it", async () => {
+		const provider = daytonaActivateSnapshot(
+			fakeProvider(async () => {
+				throw new Error(INACTIVE);
+			}),
+			CFG,
+		);
+
+		const error = await provider.sandbox.create().catch((e: unknown) => e);
+		expect((error as Error).message).toBe(INACTIVE);
+		// Without the mark this is a permanent cell failure: the harness's classifier matches only
+		// quota/rate-limit/capacity wording, and "is inactive" is none of those.
+		expect(isRetryableCreateError(error)).toBe(true);
+	});
+
+	it("reaches the snapshot API for the configured snapshot", async () => {
+		const provider = daytonaActivateSnapshot(
+			fakeProvider(async () => {
+				throw new Error(INACTIVE);
+			}),
+			CFG,
+		);
+
+		await provider.sandbox.create().catch(() => undefined);
+		expect(captured.some((url) => url.includes(CFG.snapshot))).toBe(true);
+	});
+
+	it("passes any other create failure through untouched", async () => {
+		const other = new Error("Failed to create Daytona sandbox: quota exceeded");
+		const provider = daytonaActivateSnapshot(
+			fakeProvider(async () => {
+				throw other;
+			}),
+			CFG,
+		);
+
+		const error = await provider.sandbox.create().catch((e: unknown) => e);
+		expect(error).toBe(other);
+		// Not this wrapper's business: the harness's own message classifier already covers quota, and
+		// marking it here would claim "nothing was allocated" for a failure that never established it.
+		expect(isRetryableCreateError(error)).toBe(false);
+		expect(captured).toEqual([]);
+	});
+
+	it("leaves a successful create alone", async () => {
+		const created = { sandbox: {}, sandboxId: "sb-ok" };
+		const provider = daytonaActivateSnapshot(
+			fakeProvider(async () => created as never),
+			CFG,
+		);
+
+		expect(await provider.sandbox.create()).toBe(created as never);
+		expect(captured).toEqual([]);
+	});
+
+	it("refuses to patch a wrapper whose manager no longer exposes create", () => {
+		expect(() => daytonaActivateSnapshot({ sandbox: { methods: {} } } as never, CFG)).toThrow(
+			/no patchable create method/,
+		);
+	});
+});

--- a/packages/providers/src/lib/daytona-snapshot.ts
+++ b/packages/providers/src/lib/daytona-snapshot.ts
@@ -1,0 +1,94 @@
+// Daytona deactivates a snapshot that has not been used for a while, and a create against one is
+// rejected outright: `Failed to create Daytona sandbox: Snapshot <name> is inactive`. Nothing is
+// allocated, nothing is wrong with the artifact, and the documented remedy is one API call
+// (`snapshot.activate`) — but until something makes that call EVERY create keeps failing, so the
+// deactivation takes out every daytona cell of a matrix run at once. That is what happened to run
+// 33712242440: `sandbox-benchmarks-toolchain-v8` was last used by the previous matrix run on
+// 2026-08-19, sat unused for fifteen days, and all 54 daytona-vm replicates died on it.
+//
+// This is deliberately NOT a nested retry loop. The harness already owns one — patient, budgeted, and
+// tested — and an inactive snapshot satisfies exactly what it asks for: transient, and provably
+// nothing allocated. So the recovery is "start the activation, then hand the harness a marked error"
+// and the existing 2-minute backoff both spaces the attempts and gives the activation time to land.
+// A create that fails for any OTHER reason is passed through untouched.
+
+import type { SandboxMethods } from "@computesdk/provider";
+import { Daytona } from "@daytonaio/sdk";
+import type { DaytonaConfig } from "../config.ts";
+import { markRetryableCreate } from "./retryable-create.ts";
+import type { DirectProvider } from "./types.ts";
+
+type DaytonaSandboxMethods = SandboxMethods<unknown, unknown>;
+
+/** The control plane's own wording, reached through @computesdk/daytona's `Failed to create Daytona
+ *  sandbox: ` wrapper. Anchored on the state rather than the snapshot name so it holds for the
+ *  candidate and container snapshots too, and narrow enough that no other create failure matches. */
+const INACTIVE_SNAPSHOT = /snapshot\s+\S+\s+is\s+inactive/i;
+
+/**
+ * In-flight activations, keyed by the snapshot the cell boots and the region it lives in.
+ *
+ * A cell drives R replicates from ONE process (12 for a realworld suite), so without this every
+ * replicate would fire its own activation for the same snapshot in the same second. The entry is
+ * dropped once settled rather than cached: a failed activation must be retryable on the next attempt,
+ * and a snapshot that reports inactive again after a successful one is telling us something the cache
+ * would hide.
+ */
+const activating = new Map<string, Promise<void>>();
+
+/** Ask Daytona to reactivate the snapshot, at most once per (region, snapshot) at a time. */
+function activateOnce(cfg: DaytonaConfig): Promise<void> {
+	const key = `${cfg.target ?? ""}:${cfg.snapshot}`;
+	const inFlight = activating.get(key);
+	if (inFlight) return inFlight;
+	const started = (async () => {
+		// Explicit target, not the DAYTONA_TARGET pin daytonaClientTarget uses: this client is ours and
+		// is constructed here, so the region can be passed the way the SDK actually documents.
+		const daytona = new Daytona({ apiKey: cfg.apiKey, target: cfg.target });
+		const snapshot = await daytona.snapshot.get(cfg.snapshot);
+		if (snapshot.state === "active") return;
+		await daytona.snapshot.activate(snapshot);
+	})().finally(() => {
+		activating.delete(key);
+	});
+	activating.set(key, started);
+	return started;
+}
+
+/**
+ * Wrap one Daytona provider so a create rejected for an inactive snapshot starts the reactivation and
+ * comes back marked retryable, leaving the harness's create-retry budget to re-issue it.
+ *
+ * Apply OUTSIDE {@link daytonaClientTarget}: this wraps the already-region-pinned create, and its own
+ * activation client carries the region explicitly.
+ */
+export function daytonaActivateSnapshot(
+	provider: DirectProvider,
+	cfg: DaytonaConfig,
+): DirectProvider {
+	const manager = provider.sandbox as unknown as {
+		methods?: Record<string, unknown> & Pick<DaytonaSandboxMethods, "create">;
+	};
+	if (typeof manager.methods?.create !== "function") {
+		throw new Error(
+			"@computesdk/daytona provider internals changed shape (sandbox manager has no patchable " +
+				"create method); revisit the snapshot-activation adapter against the upgraded wrapper",
+		);
+	}
+	const { create } = manager.methods;
+	const activatingCreate: DaytonaSandboxMethods["create"] = async (config, options) => {
+		try {
+			return await create(config, options);
+		} catch (error) {
+			const message = error instanceof Error ? error.message : String(error);
+			if (!INACTIVE_SNAPSHOT.test(message)) throw error;
+			// Best-effort: a failed activation must not replace the control plane's own diagnosis with
+			// this helper's. The create error is the one the gap marker should carry either way, and the
+			// mark is still correct — a rejected create allocated nothing, so re-issuing is safe.
+			await activateOnce(cfg).catch(() => undefined);
+			throw markRetryableCreate(error);
+		}
+	};
+	manager.methods = { ...manager.methods, create: activatingCreate };
+	return provider;
+}

--- a/packages/providers/src/lib/daytona-snapshot.ts
+++ b/packages/providers/src/lib/daytona-snapshot.ts
@@ -15,6 +15,7 @@
 import type { SandboxMethods } from "@computesdk/provider";
 import { Daytona } from "@daytonaio/sdk";
 import type { DaytonaConfig } from "../config.ts";
+import { patchableManager } from "./patch-manager.ts";
 import { markRetryableCreate } from "./retryable-create.ts";
 import type { DirectProvider } from "./types.ts";
 
@@ -26,20 +27,21 @@ type DaytonaSandboxMethods = SandboxMethods<unknown, unknown>;
 const INACTIVE_SNAPSHOT = /snapshot\s+\S+\s+is\s+inactive/i;
 
 /**
- * In-flight activations, keyed by the snapshot the cell boots and the region it lives in.
+ * In-flight activations, keyed by snapshot name.
  *
- * A cell drives R replicates from ONE process (12 for a realworld suite), so without this every
- * replicate would fire its own activation for the same snapshot in the same second. The entry is
- * dropped once settled rather than cached: a failed activation must be retryable on the next attempt,
- * and a snapshot that reports inactive again after a successful one is telling us something the cache
- * would hide.
+ * A cell drives R replicates from ONE process (12 for a realworld suite) and builds a fresh wrapper
+ * per create attempt, so without this every replicate fires its own activation for the same snapshot
+ * in the same second — hence module scope, not a closure variable. The entry is dropped once settled
+ * rather than cached: a failed activation must be retryable on the next attempt, and a snapshot that
+ * reports inactive again after a successful one is telling us something a cache would hide. The name
+ * alone is a sufficient key — both Daytona variants share one region and take their snapshot names
+ * from `bakedArtifactName`, which already distinguishes them.
  */
 const activating = new Map<string, Promise<void>>();
 
-/** Ask Daytona to reactivate the snapshot, at most once per (region, snapshot) at a time. */
+/** Ask Daytona to reactivate the snapshot, at most once per snapshot at a time. */
 function activateOnce(cfg: DaytonaConfig): Promise<void> {
-	const key = `${cfg.target ?? ""}:${cfg.snapshot}`;
-	const inFlight = activating.get(key);
+	const inFlight = activating.get(cfg.snapshot);
 	if (inFlight) return inFlight;
 	const started = (async () => {
 		// Explicit target, not the DAYTONA_TARGET pin daytonaClientTarget uses: this client is ours and
@@ -48,11 +50,11 @@ function activateOnce(cfg: DaytonaConfig): Promise<void> {
 		const snapshot = await daytona.snapshot.get(cfg.snapshot);
 		if (snapshot.state === "active") return;
 		await daytona.snapshot.activate(snapshot);
-	})().finally(() => {
-		activating.delete(key);
-	});
-	activating.set(key, started);
-	return started;
+	})();
+	// set BEFORE chaining the cleanup: a `.finally` that ran first would delete an entry that was
+	// never published, stranding the next one and silencing activation for the rest of the process.
+	activating.set(cfg.snapshot, started);
+	return started.finally(() => activating.delete(cfg.snapshot));
 }
 
 /**
@@ -66,15 +68,11 @@ export function daytonaActivateSnapshot(
 	provider: DirectProvider,
 	cfg: DaytonaConfig,
 ): DirectProvider {
-	const manager = provider.sandbox as unknown as {
-		methods?: Record<string, unknown> & Pick<DaytonaSandboxMethods, "create">;
-	};
-	if (typeof manager.methods?.create !== "function") {
-		throw new Error(
-			"@computesdk/daytona provider internals changed shape (sandbox manager has no patchable " +
-				"create method); revisit the snapshot-activation adapter against the upgraded wrapper",
-		);
-	}
+	const manager = patchableManager<Pick<DaytonaSandboxMethods, "create">>(provider, {
+		pkg: "daytona",
+		adapter: "snapshot-activation",
+		methods: ["create"],
+	});
 	const { create } = manager.methods;
 	const activatingCreate: DaytonaSandboxMethods["create"] = async (config, options) => {
 		try {

--- a/packages/providers/src/lib/daytona-snapshot.ts
+++ b/packages/providers/src/lib/daytona-snapshot.ts
@@ -27,21 +27,26 @@ type DaytonaSandboxMethods = SandboxMethods<unknown, unknown>;
 const INACTIVE_SNAPSHOT = /snapshot\s+\S+\s+is\s+inactive/i;
 
 /**
- * In-flight activations, keyed by snapshot name.
+ * In-flight activations, keyed by the region and snapshot the activation is actually scoped to.
  *
  * A cell drives R replicates from ONE process (12 for a realworld suite) and builds a fresh wrapper
  * per create attempt, so without this every replicate fires its own activation for the same snapshot
  * in the same second — hence module scope, not a closure variable. The entry is dropped once settled
  * rather than cached: a failed activation must be retryable on the next attempt, and a snapshot that
- * reports inactive again after a successful one is telling us something a cache would hide. The name
- * alone is a sufficient key — both Daytona variants share one region and take their snapshot names
- * from `bakedArtifactName`, which already distinguishes them.
+ * reports inactive again after a successful one is telling us something a cache would hide.
+ *
+ * The region belongs in the key even though today's two variants both default to us-west-2:
+ * DAYTONA_TARGET and DAYTONA_CONTAINER_TARGET are independent overrides, so a shared key would let
+ * one region's activation satisfy the other's wait and cost that cell a retry before it activated
+ * its own. The API key does NOT belong there — both variants read the same DAYTONA_API_KEY by
+ * construction, so it can never discriminate, and a credential makes a poor map key.
  */
 const activating = new Map<string, Promise<void>>();
 
-/** Ask Daytona to reactivate the snapshot, at most once per snapshot at a time. */
+/** Ask Daytona to reactivate the snapshot, at most once per (region, snapshot) at a time. */
 function activateOnce(cfg: DaytonaConfig): Promise<void> {
-	const inFlight = activating.get(cfg.snapshot);
+	const key = `${cfg.target ?? ""}:${cfg.snapshot}`;
+	const inFlight = activating.get(key);
 	if (inFlight) return inFlight;
 	const started = (async () => {
 		// Explicit target, not the DAYTONA_TARGET pin daytonaClientTarget uses: this client is ours and
@@ -53,8 +58,8 @@ function activateOnce(cfg: DaytonaConfig): Promise<void> {
 	})();
 	// set BEFORE chaining the cleanup: a `.finally` that ran first would delete an entry that was
 	// never published, stranding the next one and silencing activation for the rest of the process.
-	activating.set(cfg.snapshot, started);
-	return started.finally(() => activating.delete(cfg.snapshot));
+	activating.set(key, started);
+	return started.finally(() => activating.delete(key));
 }
 
 /**

--- a/packages/providers/src/lib/daytona-target.ts
+++ b/packages/providers/src/lib/daytona-target.ts
@@ -12,6 +12,7 @@
 // already-constructed sandbox (runCommand/getInfo/getUrl, filesystem.*) build no client and stay stock.
 
 import type { SandboxMethods } from "@computesdk/provider";
+import { patchableManager } from "./patch-manager.ts";
 import type { DirectProvider } from "./types.ts";
 
 type DaytonaSandboxMethods = SandboxMethods<unknown, unknown>;
@@ -27,25 +28,6 @@ function createTarget(options: unknown): string | undefined {
 	if (typeof options !== "object" || options === null || !("target" in options)) return undefined;
 	const value = (options as { target?: unknown }).target;
 	return typeof value === "string" && value.length > 0 ? value : undefined;
-}
-
-interface PatchableManager {
-	methods: Record<string, unknown> &
-		Pick<DaytonaSandboxMethods, "create" | "getById" | "list" | "destroy">;
-}
-
-function patchableManager(provider: DirectProvider): PatchableManager {
-	const manager = provider.sandbox as unknown as { methods?: Record<string, unknown> };
-	const missing = CLIENT_TARGETED_METHODS.filter(
-		(name) => typeof manager.methods?.[name] !== "function",
-	);
-	if (missing.length > 0) {
-		throw new Error(
-			"@computesdk/daytona provider internals changed shape (sandbox manager has no patchable " +
-				`${missing.join("/")} method); revisit the client-target adapter against the upgraded wrapper`,
-		);
-	}
-	return manager as PatchableManager;
 }
 
 /** Run `stock` with DAYTONA_TARGET pinned to `effectiveTarget` when set, restoring the prior env value
@@ -76,7 +58,9 @@ export function daytonaClientTarget(
 	provider: DirectProvider,
 	target: string | undefined,
 ): DirectProvider {
-	const manager = patchableManager(provider);
+	const manager = patchableManager<
+		Pick<DaytonaSandboxMethods, (typeof CLIENT_TARGETED_METHODS)[number]>
+	>(provider, { pkg: "daytona", adapter: "client-target", methods: CLIENT_TARGETED_METHODS });
 	const { create, getById, list, destroy } = manager.methods;
 
 	// Candidate validation layers its target onto createOptions. Although the native SDK ignores

--- a/packages/providers/src/lib/patch-manager.ts
+++ b/packages/providers/src/lib/patch-manager.ts
@@ -1,0 +1,52 @@
+// Taking hold of a @computesdk provider's sandbox-method table, once, for every adapter that has to
+// wrap an entry in it.
+//
+// Wrapping is how this repo adapts a published wrapper without forking it (pin Daytona's region,
+// reactivate its snapshot, mount Blaxel's volume, run e2b's commands as root), and every one of those
+// adapters needs the same two things: the `provider.sandbox.methods` table the public methods
+// dispatch through, and a guard that the entries it is about to replace are actually there. The guard
+// is the point — `methods` is wrapper INTERNALS, so a wrapper upgrade that renames or restructures it
+// must fail loudly at construction instead of silently no-op-ing the adaptation and shipping a
+// benchmark that measures the wrong thing.
+//
+// Written once here because the error grammar is part of that contract: an adapter whose guard fires
+// has to say which package changed, which method went missing, and which adapter to revisit.
+
+import type { DirectProvider } from "./types.ts";
+
+/** One provider's method table, narrowed to the entries the caller proved are present. */
+export interface PatchableManager<M> {
+	methods: Record<string, unknown> & M;
+}
+
+export interface PatchableManagerOptions<M> {
+	/** The `@computesdk/<pkg>` wrapper whose internals are being reached into, named in the error. */
+	pkg: string;
+	/** What to revisit when the guard fires — the adapter doing the wrapping, not the caller. */
+	adapter: string;
+	/** Methods this adapter is about to replace; every one must already be a function. */
+	methods: readonly (keyof M & string)[];
+}
+
+/**
+ * Narrow `provider.sandbox` to its patchable method table, or throw naming exactly what changed.
+ *
+ * The returned manager is the wrapper's own object, so assigning to `manager.methods` mutates the
+ * provider in place — which is what callers want, and why each of them clones the table
+ * (`{ ...manager.methods, name: wrapped }`) rather than editing the wrapper's shared entries.
+ */
+export function patchableManager<M>(
+	provider: DirectProvider,
+	options: PatchableManagerOptions<M>,
+): PatchableManager<M> {
+	const manager = provider.sandbox as unknown as { methods?: Record<string, unknown> };
+	const missing = options.methods.filter((name) => typeof manager.methods?.[name] !== "function");
+	if (missing.length > 0) {
+		throw new Error(
+			`@computesdk/${options.pkg} provider internals changed shape (sandbox manager has no ` +
+				`patchable ${missing.join("/")} method); revisit the ${options.adapter} adapter against ` +
+				"the upgraded wrapper",
+		);
+	}
+	return manager as PatchableManager<M>;
+}

--- a/packages/providers/src/lib/runcloud.test.ts
+++ b/packages/providers/src/lib/runcloud.test.ts
@@ -89,39 +89,25 @@ describe("run.cloud ComputeSDK adapter", () => {
 		expect(destroyCalls).toBe(0);
 	});
 
-	it("destroys the allocation when readiness enters a terminal state", async () => {
-		const destroyed: string[] = [];
-		const client = nativeClient({
+	/** A client whose create is accepted and whose readiness then lands in `state`. */
+	const bootingTo = (state: SandboxState, destroy: NativeClient["destroy"] = async () => {}) =>
+		nativeClient({
 			create: async () => nativeSandbox("building_image"),
-			get: async () => nativeSandbox("failed"),
-			destroy: async (id) => {
-				destroyed.push(id);
-			},
+			get: async () => nativeSandbox(state),
+			destroy,
 		});
 
-		await expect(runcloudCompute({ client }).sandbox.create()).rejects.toThrow(
-			'entered terminal state "failed"',
-		);
-		expect(destroyed).toEqual(["sb-test"]);
-	});
-
-	// run.cloud rebuilds the image into an ext4 rootfs per sandbox, and that build corrupts
-	// non-deterministically under a concurrent burst (matrix run 33712242440: the same pinned image
-	// failed `mkfs.ext4` at a different path on each of 26 boots). The sandbox is destroyed before the
-	// error escapes, so re-issuing is safe — and it is the difference between a lost cell and a retry
-	// that lands on a healthy host.
+	// See isRetryableBootFailure in runcloud.ts for why a host-side boot failure is worth re-issuing.
+	// What matters here is the guard on it: the sandbox must be destroyed before the error escapes, or
+	// the mark would claim "nothing was allocated" for a create that left one running.
 	it.each([
 		"interrupted",
 		"failed",
 		"destroying",
 	] as const)("marks a host-side boot failure (%s) retryable once the allocation is confirmed gone", async (state) => {
 		const destroyed: string[] = [];
-		const client = nativeClient({
-			create: async () => nativeSandbox("building_image"),
-			get: async () => nativeSandbox(state),
-			destroy: async (id) => {
-				destroyed.push(id);
-			},
+		const client = bootingTo(state, async (id) => {
+			destroyed.push(id);
 		});
 
 		const error = await runcloudCompute({ client })
@@ -134,13 +120,7 @@ describe("run.cloud ComputeSDK adapter", () => {
 	});
 
 	it("leaves a clean stop unmarked — it says nothing about the host giving up", async () => {
-		const client = nativeClient({
-			create: async () => nativeSandbox("building_image"),
-			get: async () => nativeSandbox("stopped"),
-			destroy: async () => {},
-		});
-
-		const error = await runcloudCompute({ client })
+		const error = await runcloudCompute({ client: bootingTo("stopped") })
 			.sandbox.create()
 			.catch((e: unknown) => e);
 		expect((error as Error).message).toContain('entered terminal state "stopped"');
@@ -148,12 +128,8 @@ describe("run.cloud ComputeSDK adapter", () => {
 	});
 
 	it("leaves a boot failure unmarked when cleanup could not confirm the allocation is gone", async () => {
-		const client = nativeClient({
-			create: async () => nativeSandbox("building_image"),
-			get: async () => nativeSandbox("interrupted"),
-			destroy: async () => {
-				throw new Error("destroy unavailable");
-			},
+		const client = bootingTo("interrupted", async () => {
+			throw new Error("destroy unavailable");
 		});
 
 		const error = await runcloudCompute({ client, cleanupRetryMs: 0 })

--- a/packages/providers/src/lib/runcloud.test.ts
+++ b/packages/providers/src/lib/runcloud.test.ts
@@ -89,13 +89,23 @@ describe("run.cloud ComputeSDK adapter", () => {
 		expect(destroyCalls).toBe(0);
 	});
 
-	/** A client whose create is accepted and whose readiness then lands in `state`. */
-	const bootingTo = (state: SandboxState, destroy: NativeClient["destroy"] = async () => {}) =>
-		nativeClient({
+	/**
+	 * A client whose create is accepted and whose readiness then lands in `state`. Its `get` reports
+	 * `destroyed` once `destroy` has been called, because the real control plane does: the adapter
+	 * confirms teardown there before it will claim a failed create is safe to re-issue.
+	 */
+	const bootingTo = (state: SandboxState, destroy: NativeClient["destroy"] = async () => {}) => {
+		let torndown = false;
+		return nativeClient({
 			create: async () => nativeSandbox("building_image"),
-			get: async () => nativeSandbox(state),
-			destroy,
+			get: async () => nativeSandbox(torndown ? "destroyed" : state),
+			destroy: async (id) => {
+				// AFTER the inner destroy resolves: one that throws has not established anything.
+				await destroy(id);
+				torndown = true;
+			},
 		});
+	};
 
 	// See isRetryableBootFailure in runcloud.ts for why a host-side boot failure is worth re-issuing.
 	// What matters here is the guard on it: the sandbox must be destroyed before the error escapes, or
@@ -117,6 +127,23 @@ describe("run.cloud ComputeSDK adapter", () => {
 		expect((error as Error).message).toContain(`entered terminal state "${state}"`);
 		expect(destroyed).toEqual(["sb-test"]);
 		expect(isRetryableCreateError(error)).toBe(true);
+	});
+
+	it("leaves a boot failure unmarked when teardown cannot be confirmed", async () => {
+		// `destroy` resolving is a request accepted, not a microVM removed (~800ms vs ~4s against the
+		// live API). A control plane that will not say the sandbox is going away has not established
+		// the "nothing is allocated" half of the mark, so the error must surface as itself.
+		const client = nativeClient({
+			create: async () => nativeSandbox("building_image"),
+			get: async () => nativeSandbox("interrupted"),
+			destroy: async () => {},
+		});
+
+		const error = await runcloudCompute({ client })
+			.sandbox.create()
+			.catch((e: unknown) => e);
+		expect((error as Error).message).toContain('entered terminal state "interrupted"');
+		expect(isRetryableCreateError(error)).toBe(false);
 	});
 
 	it("leaves a clean stop unmarked — it says nothing about the host giving up", async () => {

--- a/packages/providers/src/lib/runcloud.test.ts
+++ b/packages/providers/src/lib/runcloud.test.ts
@@ -105,6 +105,65 @@ describe("run.cloud ComputeSDK adapter", () => {
 		expect(destroyed).toEqual(["sb-test"]);
 	});
 
+	// run.cloud rebuilds the image into an ext4 rootfs per sandbox, and that build corrupts
+	// non-deterministically under a concurrent burst (matrix run 33712242440: the same pinned image
+	// failed `mkfs.ext4` at a different path on each of 26 boots). The sandbox is destroyed before the
+	// error escapes, so re-issuing is safe — and it is the difference between a lost cell and a retry
+	// that lands on a healthy host.
+	it.each([
+		"interrupted",
+		"failed",
+		"destroying",
+	] as const)("marks a host-side boot failure (%s) retryable once the allocation is confirmed gone", async (state) => {
+		const destroyed: string[] = [];
+		const client = nativeClient({
+			create: async () => nativeSandbox("building_image"),
+			get: async () => nativeSandbox(state),
+			destroy: async (id) => {
+				destroyed.push(id);
+			},
+		});
+
+		const error = await runcloudCompute({ client })
+			.sandbox.create()
+			.catch((e: unknown) => e);
+		expect(error).toBeInstanceOf(Error);
+		expect((error as Error).message).toContain(`entered terminal state "${state}"`);
+		expect(destroyed).toEqual(["sb-test"]);
+		expect(isRetryableCreateError(error)).toBe(true);
+	});
+
+	it("leaves a clean stop unmarked — it says nothing about the host giving up", async () => {
+		const client = nativeClient({
+			create: async () => nativeSandbox("building_image"),
+			get: async () => nativeSandbox("stopped"),
+			destroy: async () => {},
+		});
+
+		const error = await runcloudCompute({ client })
+			.sandbox.create()
+			.catch((e: unknown) => e);
+		expect((error as Error).message).toContain('entered terminal state "stopped"');
+		expect(isRetryableCreateError(error)).toBe(false);
+	});
+
+	it("leaves a boot failure unmarked when cleanup could not confirm the allocation is gone", async () => {
+		const client = nativeClient({
+			create: async () => nativeSandbox("building_image"),
+			get: async () => nativeSandbox("interrupted"),
+			destroy: async () => {
+				throw new Error("destroy unavailable");
+			},
+		});
+
+		const error = await runcloudCompute({ client, cleanupRetryMs: 0 })
+			.sandbox.create()
+			.catch((e: unknown) => e);
+		// Retrying a create whose predecessor may still be billable is the leak this guard prevents.
+		expect(isRetryableCreateError(error)).toBe(false);
+		expect((error as Error).message).toContain("manual cleanup may be required");
+	});
+
 	it("destroys the allocation when a readiness poll throws", async () => {
 		const destroyed: string[] = [];
 		const client = nativeClient({

--- a/packages/providers/src/lib/runcloud.ts
+++ b/packages/providers/src/lib/runcloud.ts
@@ -189,32 +189,32 @@ function sleep(ms: number): Promise<void> {
 	return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
-/** Terminal states that mean boot failed and we should stop waiting. */
-function isTerminalBootFailure(state: Sandbox["state"]): boolean {
-	return ["failed", "interrupted", "destroyed", "destroying", "stopped"].includes(state);
-}
-
 /**
- * The subset of {@link isTerminalBootFailure} states that mean the HOST gave up on this sandbox — as
- * opposed to `stopped`, which is a clean stop and says nothing about the host.
- *
- * These are worth re-issuing the create for, because run.cloud rebuilds the image into an ext4 rootfs
- * per sandbox (`hostd POST /host/images/build`) and that build corrupts non-deterministically under a
- * concurrent burst: across the 27 failed boots of matrix run 33712242440 the SAME image failed at a
- * DIFFERENT path every time — `symlink "bin"`, `X11`, `libLLVM.so.19.1`, `etc`, `miniconda3` — with
- * `mkfs.ext4 … Directory block checksum does not match`, alongside two host-level `boot failed on 3
- * host(s)` variants. A fixed image failing at a random offset is a host-side race, not a bad artifact,
- * and a fresh create lands on a fresh build. Replicates of the same cell that retried succeeded.
+ * Terminal boot states that mean the HOST gave up on this sandbox, so re-issuing the create is worth
+ * it: run.cloud rebuilds the image into an ext4 rootfs per sandbox (`hostd POST /host/images/build`)
+ * and that build corrupts non-deterministically under a concurrent burst. Across the 27 failed boots
+ * of matrix run 33712242440 the SAME pinned image failed at a DIFFERENT path every time — `symlink
+ * "bin"`, `X11`, `libLLVM.so.19.1`, `etc`, `miniconda3` — with `mkfs.ext4 … Directory block checksum
+ * does not match`, alongside two host-level `boot failed on 3 host(s)` variants. A fixed image
+ * failing at a random offset is a host-side race, not a bad artifact, and a fresh create lands on a
+ * fresh build; replicates of the same cell that retried succeeded.
  */
 function isRetryableBootFailure(state: Sandbox["state"]): boolean {
 	return ["failed", "interrupted", "destroyed", "destroying"].includes(state);
+}
+
+/** Terminal states that mean boot failed and we should stop waiting. `stopped` is the one that is
+ *  NOT worth re-issuing — a clean stop says nothing about the host having given up. Derived so a
+ *  future terminal state cannot be added to one list and silently forgotten in the other. */
+function isTerminalBootFailure(state: Sandbox["state"]): boolean {
+	return state === "stopped" || isRetryableBootFailure(state);
 }
 
 /** A readiness wait that ended in a terminal state, carrying the state so create() can decide whether
  *  re-issuing is worthwhile once it has confirmed the allocation is gone. */
 class BootFailureError extends Error {
 	constructor(
-		readonly sandboxId: string,
+		sandboxId: string,
 		readonly state: Sandbox["state"],
 	) {
 		super(`run.cloud sandbox ${sandboxId} entered terminal state "${state}" while booting`);
@@ -529,12 +529,9 @@ export function sandboxMethods(
 					);
 				}
 				// Cleanup returned, so the allocation is confirmed gone — the second half of what
-				// markRetryableCreate asserts. A host-side boot failure is therefore both transient and
-				// safe to re-issue, and the harness's capacity budget is the right place to absorb it:
-				// without this mark a corrupted image build is a permanent cell failure, which cost
-				// 32 of run 33712242440's 54 runcloud replicates while ~50 minutes of budget went unspent.
-				// A readiness TIMEOUT stays unmarked — it never proved the host had given up, so it must
-				// surface promptly rather than spend an hour looking like capacity.
+				// markRetryableCreate asserts, and the half a message-matching classifier could never
+				// establish. A readiness TIMEOUT stays unmarked: it never proved the host had given up,
+				// so it must surface promptly rather than spend an hour looking like capacity.
 				throw error instanceof BootFailureError && isRetryableBootFailure(error.state)
 					? markRetryableCreate(error)
 					: error;

--- a/packages/providers/src/lib/runcloud.ts
+++ b/packages/providers/src/lib/runcloud.ts
@@ -195,6 +195,34 @@ function isTerminalBootFailure(state: Sandbox["state"]): boolean {
 }
 
 /**
+ * The subset of {@link isTerminalBootFailure} states that mean the HOST gave up on this sandbox — as
+ * opposed to `stopped`, which is a clean stop and says nothing about the host.
+ *
+ * These are worth re-issuing the create for, because run.cloud rebuilds the image into an ext4 rootfs
+ * per sandbox (`hostd POST /host/images/build`) and that build corrupts non-deterministically under a
+ * concurrent burst: across the 27 failed boots of matrix run 33712242440 the SAME image failed at a
+ * DIFFERENT path every time — `symlink "bin"`, `X11`, `libLLVM.so.19.1`, `etc`, `miniconda3` — with
+ * `mkfs.ext4 … Directory block checksum does not match`, alongside two host-level `boot failed on 3
+ * host(s)` variants. A fixed image failing at a random offset is a host-side race, not a bad artifact,
+ * and a fresh create lands on a fresh build. Replicates of the same cell that retried succeeded.
+ */
+function isRetryableBootFailure(state: Sandbox["state"]): boolean {
+	return ["failed", "interrupted", "destroyed", "destroying"].includes(state);
+}
+
+/** A readiness wait that ended in a terminal state, carrying the state so create() can decide whether
+ *  re-issuing is worthwhile once it has confirmed the allocation is gone. */
+class BootFailureError extends Error {
+	constructor(
+		readonly sandboxId: string,
+		readonly state: Sandbox["state"],
+	) {
+		super(`run.cloud sandbox ${sandboxId} entered terminal state "${state}" while booting`);
+		this.name = "BootFailureError";
+	}
+}
+
+/**
  * Poll until the sandbox can accept execs. Returns the freshest record so callers don't keep a
  * stale `building_image` handle from the original create response.
  */
@@ -216,11 +244,7 @@ async function waitUntilRunning(
 			options,
 		);
 		if (last.state === "running") return last;
-		if (isTerminalBootFailure(last.state)) {
-			throw new Error(
-				`run.cloud sandbox ${sandboxId} entered terminal state "${last.state}" while booting`,
-			);
-		}
+		if (isTerminalBootFailure(last.state)) throw new BootFailureError(sandboxId, last.state);
 		await wait(pollMs);
 	}
 	throw new Error(
@@ -504,7 +528,16 @@ export function sandboxMethods(
 							`could not be destroyed after retries (${errorMessage(destroyError)}); manual cleanup may be required`,
 					);
 				}
-				throw error;
+				// Cleanup returned, so the allocation is confirmed gone — the second half of what
+				// markRetryableCreate asserts. A host-side boot failure is therefore both transient and
+				// safe to re-issue, and the harness's capacity budget is the right place to absorb it:
+				// without this mark a corrupted image build is a permanent cell failure, which cost
+				// 32 of run 33712242440's 54 runcloud replicates while ~50 minutes of budget went unspent.
+				// A readiness TIMEOUT stays unmarked — it never proved the host had given up, so it must
+				// surface promptly rather than spend an hour looking like capacity.
+				throw error instanceof BootFailureError && isRetryableBootFailure(error.state)
+					? markRetryableCreate(error)
+					: error;
 			}
 		},
 

--- a/packages/providers/src/lib/runcloud.ts
+++ b/packages/providers/src/lib/runcloud.ts
@@ -311,6 +311,31 @@ async function cleanupFailedCreate(
 }
 
 /**
+ * Has the control plane confirmed this sandbox is gone, or committed to removing it?
+ *
+ * `destroying` counts: the control plane owns the teardown from there, and it is the same bar
+ * cleanupFailedCreate accepts when a destroy response is lost. A read that cannot answer returns
+ * false — the caller's job is then to NOT claim the allocation is released, not to guess.
+ */
+async function teardownConfirmed(
+	native: RuncloudSandboxClient,
+	sandboxId: string,
+	options: RuncloudComputeOptions,
+): Promise<boolean> {
+	try {
+		const current = await boundedNativeCall(
+			`confirm teardown for sandbox ${sandboxId}`,
+			() => native.get(sandboxId),
+			options,
+		);
+		return current.state === "destroying" || current.state === "destroyed";
+	} catch (error) {
+		// 404 is the strongest confirmation there is: the control plane has forgotten it entirely.
+		return isNotFound(error);
+	}
+}
+
+/**
  * Resolve what a failed create actually DID, by querying the control plane for the caller-owned name
  * stamped on the request. This is a read: unlike replaying the create POST it cannot allocate a second
  * sandbox, it needs no cooperation from an overloaded create endpoint, and it answers the only question
@@ -528,13 +553,18 @@ export function sandboxMethods(
 							`could not be destroyed after retries (${errorMessage(destroyError)}); manual cleanup may be required`,
 					);
 				}
-				// Cleanup returned, so the allocation is confirmed gone — the second half of what
-				// markRetryableCreate asserts, and the half a message-matching classifier could never
-				// establish. A readiness TIMEOUT stays unmarked: it never proved the host had given up,
-				// so it must surface promptly rather than spend an hour looking like capacity.
-				throw error instanceof BootFailureError && isRetryableBootFailure(error.state)
-					? markRetryableCreate(error)
-					: error;
+				// markRetryableCreate asserts NOTHING IS ALLOCATED — the half a message-matching classifier
+				// could never establish — so earn it rather than infer it from cleanup returning. A
+				// resolved destroy is a request accepted, not a teardown finished: measured against the
+				// live API, `destroy` returns in ~800ms while the sandbox sits in `destroying` for a
+				// further ~4s. Ask the control plane instead, and leave the error unmarked when it will
+				// not say: an adapter that merely failed to find out must not claim it is safe to retry.
+				// A readiness TIMEOUT is never marked either — it proved nothing about the host.
+				const retryable =
+					error instanceof BootFailureError &&
+					isRetryableBootFailure(error.state) &&
+					(await teardownConfirmed(sdk, created.id, adapterOptions));
+				throw retryable ? markRetryableCreate(error) : error;
 			}
 		},
 

--- a/packages/providers/src/lib/tama.test.ts
+++ b/packages/providers/src/lib/tama.test.ts
@@ -228,11 +228,8 @@ console.log(JSON.stringify({ tamaCli: config.tamaCli }));`;
 
 	/** Load config in a clean subprocess. `null` unsets the key rather than blanking it. */
 	async function resolveBinary(value: string | null): Promise<string | undefined> {
-		const env: Record<string, string> = {};
-		for (const [key, ambient] of Object.entries(process.env)) {
-			// Drop the ambient key so a developer who exports it can't decide these cases.
-			if (ambient !== undefined && key !== "TAMA_CLI") env[key] = ambient;
-		}
+		// Drop the ambient key so a developer who exports it can't decide these cases.
+		const { TAMA_CLI: _ambient, ...env } = process.env;
 		if (value !== null) env.TAMA_CLI = value;
 		const proc = Bun.spawn(["bun", "-e", PROBE], { env, stdout: "pipe", stderr: "pipe" });
 		const [stdout, exitCode] = await Promise.all([new Response(proc.stdout).text(), proc.exited]);

--- a/packages/providers/src/lib/tama.test.ts
+++ b/packages/providers/src/lib/tama.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "bun:test";
+import { join } from "node:path";
 import type { CliInvokeOptions, CliResult, TamaComputeOptions, TamaMachine } from "./tama.ts";
 import {
 	execCommandLine,
@@ -212,5 +213,41 @@ describe("tama CLI adapter", () => {
 		// It is the retry loop's reservation against a 60-minute budget: an attempt plus a 2-minute
 		// backoff has to still fit, or the cell could never retry a transient capacity failure.
 		expect(TAMA_CREATE_CEILING_MS + 2 * 60_000).toBeLessThan(60 * 60_000);
+	});
+});
+
+// `config` freezes the binary at module load, so these run the resolution in a FRESH subprocess per
+// case — the same shape as the VCR namespace probes next door, and the only way to reproduce what CI
+// actually does: `TAMA_CLI: ${{ … || '' }}` exports the key SET AND EMPTY when no override is
+// configured. A `??` fallback accepts that empty string, and `spawn("")` is a TypeError thrown before
+// the first control-plane call — every tama cell of matrix run 33712242440 died there.
+describe.concurrent("tama binary resolution", () => {
+	const CONFIG_PATH = join(import.meta.dir, "..", "config.ts");
+	const PROBE = `const { config } = await import(${JSON.stringify(CONFIG_PATH)});
+console.log(JSON.stringify({ tamaCli: config.tamaCli }));`;
+
+	/** Load config in a clean subprocess. `null` unsets the key rather than blanking it. */
+	async function resolveBinary(value: string | null): Promise<string | undefined> {
+		const env: Record<string, string> = {};
+		for (const [key, ambient] of Object.entries(process.env)) {
+			// Drop the ambient key so a developer who exports it can't decide these cases.
+			if (ambient !== undefined && key !== "TAMA_CLI") env[key] = ambient;
+		}
+		if (value !== null) env.TAMA_CLI = value;
+		const proc = Bun.spawn(["bun", "-e", PROBE], { env, stdout: "pipe", stderr: "pipe" });
+		const [stdout, exitCode] = await Promise.all([new Response(proc.stdout).text(), proc.exited]);
+		return exitCode === 0 ? (JSON.parse(stdout) as { tamaCli: string }).tamaCli : undefined;
+	}
+
+	it("falls back to the PATH-resolved name when the override is unset", async () => {
+		expect(await resolveBinary(null)).toBe("tama");
+	});
+
+	it("treats a set-but-empty override as unset rather than spawning nothing", async () => {
+		expect(await resolveBinary("")).toBe("tama");
+	});
+
+	it("honors an explicit override", async () => {
+		expect(await resolveBinary("/opt/tama/bin/tama")).toBe("/opt/tama/bin/tama");
 	});
 });

--- a/packages/providers/src/lib/tama.ts
+++ b/packages/providers/src/lib/tama.ts
@@ -18,6 +18,7 @@ import type {
 	SandboxMethods,
 } from "@computesdk/provider";
 import { defineProvider } from "@computesdk/provider";
+import { config } from "../config.ts";
 import { markRetryableCreate } from "./retryable-create.ts";
 
 const PROVIDER = "tama";
@@ -252,7 +253,7 @@ function mapStatus(status: string): SandboxInfo["status"] {
 }
 
 export function createTamaClient(options: TamaComputeOptions) {
-	const binary = options.binary ?? process.env.TAMA_CLI ?? "tama";
+	const binary = options.binary ?? config.tamaCli;
 	const invoke = options.cli ?? ((args, invokeOptions) => spawnCli(binary, args, invokeOptions));
 	const wait = options.sleep ?? sleep;
 	const now = options.now ?? Date.now;

--- a/packages/schema/src/pts-profiles.test.ts
+++ b/packages/schema/src/pts-profiles.test.ts
@@ -98,6 +98,24 @@ describe("realworld profiles: Task Option <-> target.env consistency", () => {
 				}
 			});
 
+			it("anchors every TASK_REQUIRES_MEM_CAP_<value> to a declared Task Value", () => {
+				// The flag makes realworld-runner.sh REFUSE the task on a sandbox that exposes no
+				// enforceable cgroup memory cap, rather than let it exhaust the guest and take the whole
+				// sandbox down. A key naming a renamed/removed Value would silently stop guarding — and
+				// the symptom is a lost replicate on some other provider months later, not a red test.
+				const values = new Set(
+					profile.settings
+						.find((option) => option.DisplayName === "Task")
+						?.Menu?.Entry.map((e) => e.Value ?? "") ?? [],
+				);
+				const capKeys = Object.keys(env)
+					.filter((key) => key.startsWith("TASK_REQUIRES_MEM_CAP_"))
+					.map((key) => key.slice("TASK_REQUIRES_MEM_CAP_".length));
+				for (const key of capKeys) {
+					expect(values).toContain(key);
+				}
+			});
+
 			it("declares REPO_URL, PIN_SHA and NODE_VERSION", () => {
 				expect(env.REPO_URL).toBeTruthy();
 				expect(env.PIN_SHA).toMatch(/^[0-9a-f]{40}$/);

--- a/packages/schema/src/pts-profiles.test.ts
+++ b/packages/schema/src/pts-profiles.test.ts
@@ -52,6 +52,14 @@ describe("realworld profiles: Task Option <-> target.env consistency", () => {
 			const profile = parseProfile("local", dir, testXml, resultsXml);
 			const env = parseEnvFile(readFileSync(join(base, "target.env"), "utf8"));
 
+			// `<Value>` is optional in the schema (iperf's TCP entry); realworld Task entries always
+			// carry one, and a missing value maps to "" here so the key-set equality still fails loudly.
+			const taskValues = new Set(
+				profile.settings
+					.find((option) => option.DisplayName === "Task")
+					?.Menu?.Entry.map((e) => e.Value ?? "") ?? [],
+			);
+
 			it("declares a single Task option with no duplicate Values", () => {
 				const taskOptions = profile.settings.filter((option) => option.DisplayName === "Task");
 				expect(taskOptions).toHaveLength(1);
@@ -61,58 +69,29 @@ describe("realworld profiles: Task Option <-> target.env consistency", () => {
 			});
 
 			it("has a TASK_CMD_<value> key for every Task Entry Value, and no orphaned key", () => {
-				const values = new Set(
-					profile.settings
-						.find((option) => option.DisplayName === "Task")
-						// `<Value>` is optional in the schema (iperf's TCP entry); realworld Task entries always
-						// carry one, and a missing value maps to "" here so the key-set equality still fails loudly.
-						?.Menu?.Entry.map((e) => e.Value ?? "") ?? [],
-				);
 				const taskCmdKeys = new Set(
 					Object.keys(env)
 						.filter((key) => key.startsWith("TASK_CMD_"))
 						.map((key) => key.slice("TASK_CMD_".length)),
 				);
-				expect(taskCmdKeys).toEqual(values);
+				expect(taskCmdKeys).toEqual(taskValues);
 			});
 
 			it("stays data-only: no per-profile install.sh (the shared lib/pts/realworld/ copy is overlaid)", () => {
 				expect(existsSync(join(base, "install.sh"))).toBe(false);
 			});
 
-			it("anchors every TASK_PREP_<value> to a declared Task Value (no orphaned prep)", () => {
-				// TASK_PREP_<value> runs unmeasured before the timed TASK_CMD_<value> (realworld-runner.sh);
-				// a prep keyed to a renamed/removed Value would silently stop running.
-				const values = new Set(
-					profile.settings
-						.find((option) => option.DisplayName === "Task")
-						// `<Value>` is optional in the schema (iperf's TCP entry); realworld Task entries always
-						// carry one, and a missing value maps to "" here so the key-set equality still fails loudly.
-						?.Menu?.Entry.map((e) => e.Value ?? "") ?? [],
-				);
-				const prepKeys = Object.keys(env)
-					.filter((key) => key.startsWith("TASK_PREP_"))
-					.map((key) => key.slice("TASK_PREP_".length));
-				for (const key of prepKeys) {
-					expect(values).toContain(key);
-				}
-			});
-
-			it("anchors every TASK_REQUIRES_MEM_CAP_<value> to a declared Task Value", () => {
-				// The flag makes realworld-runner.sh REFUSE the task on a sandbox that exposes no
-				// enforceable cgroup memory cap, rather than let it exhaust the guest and take the whole
-				// sandbox down. A key naming a renamed/removed Value would silently stop guarding — and
-				// the symptom is a lost replicate on some other provider months later, not a red test.
-				const values = new Set(
-					profile.settings
-						.find((option) => option.DisplayName === "Task")
-						?.Menu?.Entry.map((e) => e.Value ?? "") ?? [],
-				);
-				const capKeys = Object.keys(env)
-					.filter((key) => key.startsWith("TASK_REQUIRES_MEM_CAP_"))
-					.map((key) => key.slice("TASK_REQUIRES_MEM_CAP_".length));
-				for (const key of capKeys) {
-					expect(values).toContain(key);
+			// Both keys tune how realworld-runner.sh treats one Task Value: TASK_PREP_ runs unmeasured
+			// before the timed command, TASK_REQUIRES_MEM_CAP_ refuses the task on a sandbox with no
+			// enforceable cgroup memory cap instead of letting it take the whole sandbox down. Either one
+			// keyed to a renamed or removed Value silently stops doing its job, and the symptom surfaces
+			// as a slow build or a lost replicate months later rather than as a red test.
+			it.each([
+				"TASK_PREP_",
+				"TASK_REQUIRES_MEM_CAP_",
+			])("anchors every %s<value> to a declared Task Value", (prefix) => {
+				for (const key of Object.keys(env).filter((k) => k.startsWith(prefix))) {
+					expect(taskValues).toContain(key.slice(prefix.length));
 				}
 			});
 

--- a/packages/schema/src/pts-profiles/local/realworld-openclaw-1.0.0/target.env
+++ b/packages/schema/src/pts-profiles/local/realworld-openclaw-1.0.0/target.env
@@ -79,6 +79,17 @@ TASK_CMD_cold_install="CI=true pnpm install --prefer-offline --ignore-scripts=fa
 # --type-aware off-switch. Expect a per-run metric-scoped gap until the workload fits the spec or
 # the pin advances. (Do not raise TimesToRun; do not drop the task.)
 TASK_CMD_lint_oxlint="OPENCLAW_LOCAL_CHECK=0 pnpm lint --threads=8"
+# The task's failure is provider signal, but only when the failure is CONTAINED. Where
+# realworld-runner.sh's cgroup cap engages, tsgolint is OOM-killed alone and this option alone goes
+# unsampled — the keep+warn gap described above, with the other seven options unaffected. Where no
+# cap could be established the same command instead exhausts the guest and kills the sandbox, and
+# the run loses all eight. Run 33712242440 is the measurement of that difference: 9/12 replicates
+# lost on modal-gvisor and 4/12 on Vercel — every provider whose forensics say `bench-cgroup:
+# unavailable` — against 0/12 on e2b, blaxel, novita and modal-vm, all of which report `capped at
+# ~7.27 GB`. So the task now declares that it needs the cap, and the runner refuses it rather than
+# running it uncontained. Both outcomes leave this metric unsampled; only one of them also throws
+# away the other seven.
+TASK_REQUIRES_MEM_CAP_lint_oxlint=1
 # REMOVED: lint_format (`pnpm format:check`). Dropped for the same reason as build -- a declared
 # metric that can never post a sample -- but on firmer ground, verified against a clean checkout of
 # the pin:


### PR DESCRIPTION
Matrix run [33712242440](https://github.com/starslingdev/hpc-sandbox-benchmarks/actions/runs/33712242440) lost **28 of 108 cells — 153 of 648 replicates**. Four independent causes, each fixed here and each verified against the live control plane rather than inferred from logs.

| provider | cells | replicates | cause |
|---|---|---|---|
| `tama` | 9/9 | 54/54 | our own CI wiring (regression from #397) |
| `daytona-vm` | 9/9 | 54/54 | snapshot auto-deactivated after 15 days unused |
| `runcloud` | 8/9 | 32/54 | run.cloud corrupts our image per-sandbox under burst |
| `modal-gvisor` / `vercel` | 2/9 | 13/24 | memory-bound task ran uncontained and killed the sandbox |

## 1. tama — `spawn("")`

Every tama cell died in under a second on `The argument 'file' cannot be empty. Received ''`, before any sandbox existed.

`bench-suite.yml` exports `TAMA_CLI: ${{ … || '' }}`, so with no repository variable the step gets the key **set and empty** — GitHub Actions cannot express "unset". `tama.ts` read it as `process.env.TAMA_CLI ?? "tama"`, and `??` only falls back on null/undefined.

The wiring isn't the bug. `config.ts` already strips empties for every key it owns, documenting this exact hazard; `TAMA_CLI` was simply the one value read straight off `process.env`, bypassing the boundary whose purpose is that rule. Now routed through the gatekeeper — and a new test asserts every optional variable-kind registry input appears in `ENV_KEYS`, since the real defect was drift between the registry and that list. Deleting `TAMA_CLI` from `ENV_KEYS` turns it red.

`TAMA_TOKEN` deliberately stays as-is: `if (!token)` already treats empty as missing.

## 2. daytona-vm — inactive snapshot

`sandbox-benchmarks-toolchain-v8` had `lastUsedAt` 2026-08-19 — the previous matrix run — and Daytona had deactivated it in the fifteen days since.

**The account is already unblocked** (reactivated by hand; a create now takes 0.9s). The adapter now self-heals: it starts the activation and hands the harness a *marked* error, so the existing 2-minute create backoff absorbs it. Measured live, the snapshot goes `inactive → pulling → active` in ~25s — comfortably inside one backoff. Deliberately not a nested retry loop; the harness already owns one.

## 3. runcloud — not capacity, a provider bug

`interrupted` boots read like preemption. They aren't. `client.sandboxes.get(id)` exposes a `last_error` that `list()` never shows, and **26 of 27 failed boots** carry run.cloud's own image-build error:

```
hostd POST /host/images/build: ocibuild: mkfs.ext4: exit status 1:
… Directory block checksum does not match directory block …
```

The path it fails at is **different every time** — `symlink "bin"` (18×), `X11` (3×), `libLLVM.so.19.1` (2×), `etc`, `miniconda3`. run.cloud rebuilds our pinned image into an ext4 rootfs *per sandbox*, and that build corrupts non-deterministically when a matrix run asks for 54 at once. A fixed image failing at a random offset is a host-side race, not a bad artifact.

That satisfies `markRetryableCreate` exactly — transient, and provably nothing allocated, since the readiness path only rethrows *after* `cleanupFailedCreate` confirms the sandbox is gone. Unmarked, each was a permanent cell failure with ~50 of 60 minutes' budget unspent; at ~105s per failed boot the loop now affords roughly seven attempts.

Narrow on purpose: `stopped` says nothing about the host and stays unmarked, as does a readiness timeout. **Worth reporting upstream to run.cloud** — sandbox IDs are in the commit.

## 4. openclaw — the cap, not the task

The losses have an exact predictor. Forensics split the fleet perfectly:

| cgroup cap | providers | replicates lost |
|---|---|---|
| `capped at ~7.27 GB` | e2b, blaxel, novita, modal-vm | **0/12 each** |
| `unavailable` | modal-gvisor | 9/12 |
| `unavailable` | vercel | 4/12 |

`lint_oxlint` is a deliberate out-of-spec memory bomb, and the cap is what makes keeping it safe: the task is OOM-killed alone, that option goes unsampled, the other seven still post. Where no cap engages, it takes the sandbox and all eight.

**Vercel can be capped, and now is.** Its cgroup2 is writable with `memory` available, but the namespace root still held processes — and only the *true* root is exempt from cgroup v2's no-internal-processes rule, so `echo +memory` returned EBUSY. We now park those processes in a leaf, as every container runtime does. Two things are load-bearing and were only found by probing: the shell must move **itself first** (or forked commands are born back into the root), and `cgroup.procs` must be **re-read each pass** — a single streaming read moved 2 of 5 pids and skipped 3. Root empties in 2 passes; the shipped block now reports `capped at 7737716736 bytes`, with pid 1 healthy and the control plane still answering afterwards.

**modal-gvisor cannot be** — read-only tmpfs, cgroup v1 stubs, no `cgroup.controllers`, and no in-guest OOM killer for `oom_score_adj` to bias. So a task may declare `TASK_REQUIRES_MEM_CAP_<task>=1` and the runner refuses it, before any prep work. That metric records nothing either way; only the seven beside it are at stake.

## Verification

Every fix exercised against real control planes, not just unit tests:

- **tama** — with `TAMA_CLI=""` exported: creates `machine-n6jh7mpfiekl` in 122s, execs, tears down.
- **daytona-vm** — snapshot reactivated; create in 0.9s.
- **runcloud** — create/destroy clean; account swept, zero leaks.
- **vercel** — real runner block: migrates in 2 passes, caps at 7737716736 bytes, join probe passes, sandbox stays healthy.
- **modal-gvisor** — falls back to `oom_score_adj` and survives `set -e` (EXIT=0); refuses `lint_oxlint` with its reason (EXIT=1).
- **daytona-vm** — unchanged: caps at 7274754048, migration branch never runs.

Zero leaked sandboxes across every provider probed.

Gates: 2007 tests, typecheck, lint, shellcheck, spell, and all three drift gates green.

## Notes for the reviewer

- The final commit is a `/simplify` pass: extracts the `patchableManager` idiom that four adapters had each hand-rolled, derives `isTerminalBootFailure` from one state list instead of two hand-synced ones, and dedups rationale that had already drifted (26 vs 27 boots). It caught a real `set -e` bug the flattening introduced — a `||` list exempts only its left side from errexit, which would have killed the runner on read-only-cgroup providers. Fixed, commented, and re-verified live.
- `blaxel-volume.ts` and `e2b-root.ts` still carry their own copies of the extracted guard; converting them is unrelated to this fix.
- Not addressed: the cross-cell concurrency that *triggers* run.cloud's build race. `max_concurrency` is per-cell; capping it across cells needs `strategy.max-parallel` on the suite matrix — a scope call, and the retry makes the failure survivable meanwhile.
- The run's own `cancelled` status was the aggregate job waiting ~11h on `privileged` environment approval, not a code failure.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added automatic recovery when memory controls cannot initially be enabled, while preventing memory-capped tasks from running without enforceable limits.
  - Added support for configuring a custom Tama CLI executable through `TAMA_CLI`, defaulting to `tama`.
  - Daytona environments now automatically reactivate inactive snapshots during creation.

- **Bug Fixes**
  - Improved classification and cleanup handling for failed sandbox startups, enabling safe retries when recovery succeeds.
  - Improved provider adapter validation and consistency checks across supported configuration options.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Repairs four failure modes from benchmark run `33712242440`: empty `TAMA_CLI` now falls back to `tama`, inactive Daytona snapshots activate before retry, run.cloud boot failures retry only after teardown is confirmed, and uncontained `lint_oxlint` runs are refused instead of taking down the sandbox.

**Provider recovery**

- Routes optional provider variables through the config gatekeeper and adds registry drift coverage.
- Single-flights Daytona activation per region and snapshot, while preserving the original create error if activation fails.
- Marks run.cloud `failed`, `interrupted`, `destroyed`, and `destroying` boots retryable only after cleanup confirms teardown; clean stops and readiness timeouts remain unmarked.
- Shares the provider-method patching guard across Daytona adapters.

**Memory safety**

- Moves namespace-root processes before enabling Vercel’s cgroup v2 memory controller, while retaining the existing fallback when no cap is available.
- Refuses `lint_oxlint` before task preparation on providers without an enforceable cap, preserving the other metrics.
- Adds regression coverage for provider recovery, environment handling, task metadata, and memory-cap behavior.

<sup>Written for commit f4bd51a7b70345dc0980e7c8c8b4293c6edbe9aa. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/starslingdev/hpc-sandbox-benchmarks/pull/413?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

