### PR TITLE
docs(providers): document the three functions #413 left undocumented

### DIFF
--- a/packages/providers/src/lib/daytona-snapshot.test.ts
+++ b/packages/providers/src/lib/daytona-snapshot.test.ts
@@ -22,6 +22,14 @@ const INACTIVE = `Failed to create Daytona sandbox: Snapshot ${CFG.snapshot} is 
 
 const captured: string[] = [];
 
+/**
+ * Stand in for the SDK's transport factory: record each request's URL, then fail it.
+ *
+ * Failing is deliberate — it leaves the activation in the state these tests care about (attempted,
+ * unsuccessful), which is what proves the recovery stays best-effort and never replaces the control
+ * plane's own create error with its own. The recorded URLs are how a test asserts the snapshot API
+ * was reached at all.
+ */
 function stubAxios() {
 	return {
 		interceptors: { request: { use: () => 0 }, response: { use: () => 0 } },

--- a/packages/providers/src/lib/daytona-snapshot.ts
+++ b/packages/providers/src/lib/daytona-snapshot.ts
@@ -48,6 +48,7 @@ function activateOnce(cfg: DaytonaConfig): Promise<void> {
 	const key = `${cfg.target ?? ""}:${cfg.snapshot}`;
 	const inFlight = activating.get(key);
 	if (inFlight) return inFlight;
+	/** The activation itself: read the snapshot, and wake it unless another caller already did. */
 	const started = (async () => {
 		// Explicit target, not the DAYTONA_TARGET pin daytonaClientTarget uses: this client is ours and
 		// is constructed here, so the region can be passed the way the SDK actually documents.
@@ -79,6 +80,11 @@ export function daytonaActivateSnapshot(
 		methods: ["create"],
 	});
 	const { create } = manager.methods;
+	/**
+	 * The wrapped create: pass every outcome through untouched except the one this module exists for.
+	 * An inactive snapshot starts the reactivation and comes back marked, so the harness re-issues it;
+	 * anything else — success or another failure — is returned exactly as the wrapper produced it.
+	 */
 	const activatingCreate: DaytonaSandboxMethods["create"] = async (config, options) => {
 		try {
 			return await create(config, options);


### PR DESCRIPTION
Follow-up to #413, which merged with CodeRabbit's docstring-coverage check at **76.19%** against an 80% threshold. That check is a warning rather than a block, so it did not hold the merge — but the three functions it named are genuinely worth documenting, and they are all ones #413 introduced.

Reproduced the measurement locally (parse the diff's added lines, match function definitions on them, check for a preceding JSDoc block): **10 of 13 → 13 of 13**, which lines up with the 76.19% reported.

- `stubAxios` — why the stub *fails* every request rather than answering it. That is what leaves the activation in the attempted-but-unsuccessful state the surrounding tests assert on, and it is not obvious from the code.
- The activation IIFE inside `activateOnce` — what it actually does.
- `activatingCreate` — that every outcome passes through untouched except the one the module exists for.

Docs only. No behavior change, no test changes.

<sub>Split out because #413 had already merged by the time the check was addressed.</sub>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds the three docstrings the earlier Daytona snapshot activation change left missing, closing the docstring-coverage gap. Docs only; no behavior or test changes.

- `stubAxios` now explains why it fails every request: to leave the activation attempted-but-unsuccessful, proving recovery never masks the control plane's create error.
- The activation IIFE inside `activateOnce` now says what it actually does.
- `activatingCreate` now documents that every outcome passes through untouched except the one this module exists for.

<sup>Written for commit 592c5380ec5cb7fdd60eaf417b06b123e276c022. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/starslingdev/hpc-sandbox-benchmarks/pull/414?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

