### PR TITLE
fix(gpu): mark the pinned snapshot_download calls nosec for pre-1.9.4 bandit B615

### DIFF
--- a/apps/cli/src/lib/gpu/prepare-models.py
+++ b/apps/cli/src/lib/gpu/prepare-models.py
@@ -94,8 +94,19 @@ def resolve_model():
         "repo_id": model_repo_id,
         "cache_dir": cache_dir,
     }
+    # `# nosec B615` below is a false-positive suppression, not an exemption. Bandit's B615
+    # (Hugging Face download without revision pinning) in releases before 1.9.4 only accepts a
+    # revision written as a hex string literal at the call site; a variable is reported as
+    # unpinned even though every call here passes `revision=model_revision`. That variable has
+    # already been through pinned_revision(), which refuses anything but a full 40-character
+    # commit SHA before any download starts, and validate_model_snapshot() then checks the
+    # bytes on disk against that same SHA. Both controls are stricter than the linter's
+    # 7-hex-character heuristic. Bandit >= 1.9.4 trusts a non-literal revision and reports
+    # nothing here; the markers exist for scanners still on older releases.
     try:
-        path = snapshot_download(**options, revision=model_revision, local_files_only=True)
+        path = snapshot_download(  # nosec B615
+            **options, revision=model_revision, local_files_only=True
+        )
         validate_model_snapshot(path)
         disposition = "cached"
     except Exception as cache_error:
@@ -104,8 +115,10 @@ def resolve_model():
                 f"model snapshot is absent or incomplete: {model_repo_id}@{model_revision}"
             ) from cache_error
         print(f"Downloading {model_repo_id}@{model_revision}", flush=True)
-        snapshot_download(**options, revision=model_revision, max_workers=4)
-        path = snapshot_download(**options, revision=model_revision, local_files_only=True)
+        snapshot_download(**options, revision=model_revision, max_workers=4)  # nosec B615
+        path = snapshot_download(  # nosec B615
+            **options, revision=model_revision, local_files_only=True
+        )
         validate_model_snapshot(path)
         disposition = "downloaded"
     resolved = {**model, "path": path, "disposition": disposition}

--- a/apps/cli/src/lib/gpu/prepare-models.py
+++ b/apps/cli/src/lib/gpu/prepare-models.py
@@ -99,10 +99,11 @@ def resolve_model():
     # revision written as a hex string literal at the call site; a variable is reported as
     # unpinned even though every call here passes `revision=model_revision`. That variable has
     # already been through pinned_revision(), which refuses anything but a full 40-character
-    # commit SHA before any download starts, and validate_model_snapshot() then checks the
-    # bytes on disk against that same SHA. Both controls are stricter than the linter's
-    # 7-hex-character heuristic. Bandit >= 1.9.4 trusts a non-literal revision and reports
-    # nothing here; the markers exist for scanners still on older releases.
+    # commit SHA before any download starts. validate_model_snapshot() then checks that the
+    # resolved snapshot directory is named for that SHA and that the required files and every
+    # weight shard the index names are present and non-empty. Both controls are stricter than
+    # the linter's 7-hex-character heuristic. Bandit >= 1.9.4 trusts a non-literal revision
+    # and reports nothing here; the markers exist for scanners still on older releases.
     try:
         path = snapshot_download(  # nosec B615
             **options, revision=model_revision, local_files_only=True


### PR DESCRIPTION
Part of ENG-541 (OneLeet: remediate outstanding code security findings). Follow-up to #410.

## Why

OneLeet's code-security scan of `main` at f9d5dab still reports bandit B615 (CWE-494, Hugging Face download without revision pinning) on the three `snapshot_download` calls in `apps/cli/src/lib/gpu/prepare-models.py`. The calls are not unpinned. Every one passes `revision=model_revision` explicitly, and that value has already been through `pinned_revision()`, which refuses anything but a full 40-character commit SHA before any download starts.

The report is a limitation of the scanner's plugin version, not of the code. OneLeet runs Bandit 1.8.6. B615 in releases before 1.9.4 only accepts a revision written as a hex string literal at the call site; a variable resolves to nothing and is reported as unpinned. Bandit 1.9.4 added an AST check that trusts a non-literal revision. Reproduced against this file:

| Bandit | B615 findings |
|---|---|
| 1.8.6 (OneLeet) | 3 |
| 1.9.1, 1.9.2, 1.9.3 | 3 |
| 1.9.4 | 0 |

## Why our control is stricter than the scanner's

- **Length.** The B615 heuristic accepts any literal of seven or more hex characters. A truncated prefix is still ambiguous on the Hub. We require the full 40-character SHA.
- **Timing.** The heuristic only inspects the call expression. We validate the pin before the first network call, so a config that pins a branch or tag fails before anything is downloaded.
- **Snapshot identity.** The heuristic stops at the call. `validate_model_snapshot()` checks that the resolved snapshot directory is named for the pinned SHA, which is how the Hub cache keys a commit, and that the required files and every weight shard the safetensors index names are present and non-empty. It does not hash file contents; the Hub's own per-file ETag verification covers that during download.
- **Source of truth.** Hardcoding a literal at the call site would satisfy the old heuristic only by discarding the config-driven pin that `apps/cli/src/lib/gpu/config.ts` owns and that #410 introduced.

## What

`# nosec B615` on the three calls, with the rationale recorded in a comment directly above them, as ENG-541 requires for accepted false positives. The suppression is scoped to B615 alone; B310, B404 and B603 on the same file are unchanged. No behaviour change.

## Verification

- Bandit 1.8.6 and 1.9.4 both report 0 B615 findings on the file.
- `bun test src/lib/gpu/` in `apps/cli` on bun 1.4.0: 19 pass, including the `gpu.test.ts` assertion that every `snapshot_download` call carries `revision=model_revision`.
- `typos` 1.47.2 passes repo-wide. The lefthook pre-commit hook could not run natively in the authoring environment because mise's tool downloads were blocked, so its three steps were run individually: biome passed, the lockfile step had no matching files, typos passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Gspbs3VgwNZbFsEaFfkvKe

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified the security-scan suppression rationale to accurately describe model snapshot validation checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->