### PR TITLE
Move E2B harness execution onto native driver sessions

### DIFF
--- a/CONTEXT-MAP.md
+++ b/CONTEXT-MAP.md
@@ -1,0 +1,18 @@
+# Context map
+
+## Contexts
+
+- [Sandbox drivers](./packages/driver/CONTEXT.md): sandbox sessions and their observable behavior.
+- [Benchmark execution](./packages/harness/CONTEXT.md): benchmark steps, lifecycle measurements,
+  and result gaps.
+
+Add other package glossaries as their terminology is resolved. Package responsibilities and
+reading routes are recorded in [domain documentation](./docs/agents/domain.md).
+
+## Relationships
+
+- Benchmark execution uses sandbox sessions to perform work and observe outcomes.
+- Driver capabilities describe what an integration exposes; benchmark execution records a gap
+  when a requested measurement cannot be performed.
+- Driver readiness establishes usability; lifecycle measurement separately observes the first
+  successful command according to the benchmark's measurement definition.

--- a/apps/cli/src/bin/driver-check.ts
+++ b/apps/cli/src/bin/driver-check.ts
@@ -26,7 +26,11 @@ import { isDriverError, readTextFile, succeeded, writeTextFile } from "@sandbox-
 import { verifyDriverReadiness } from "@sandbox-benchmarks/driver/conformance";
 import type { DriverProviderId } from "@sandbox-benchmarks/drivers";
 import { DRIVERS } from "@sandbox-benchmarks/drivers";
-import { exitAfterSandboxCleanup, StepRunner } from "@sandbox-benchmarks/harness";
+import {
+	exitAfterSandboxCleanup,
+	SessionStepRunner,
+	StepRunner,
+} from "@sandbox-benchmarks/harness";
 import type { ArtifactPhase } from "@sandbox-benchmarks/schema";
 import type { OwnedDriverSession } from "../lib/driver-run.ts";
 import {
@@ -172,12 +176,6 @@ function skip(checks: Check[], name: string, detail: string, log: (message: stri
 }
 
 /** The most useful failure text a CommandResult carries; stderr is optional on that shape. */
-function stepError(result: { exitCode: number; stdout?: string; stderr?: string }): string {
-	const stderr = (result.stderr ?? "").trim();
-	if (stderr.length > 0) return stderr;
-	const stdout = (result.stdout ?? "").trim();
-	return stdout.length > 0 ? stdout : `exit ${result.exitCode} with no output`;
-}
 
 /**
  * The deadline for the durable step: at least the declared cap, and always longer than the workload.
@@ -209,7 +207,7 @@ async function driveSession(
 	session: SandboxSession,
 	options: Options,
 	transportSyncCapMs: number | null,
-	runner: StepRunner,
+	runner: StepRunner | SessionStepRunner,
 	checks: Check[],
 	log: (message: string) => void,
 ): Promise<void> {
@@ -275,7 +273,7 @@ async function driveSession(
 		"step-sync",
 		async () => {
 			const result = await runner.step("driver-check-sync", workloadScript(1), 30_000);
-			if (result.exitCode !== 0) throw new Error(`step failed: ${stepError(result)}`);
+
 			return (result.stdout ?? "").trim();
 		},
 		log,
@@ -292,7 +290,7 @@ async function driveSession(
 			async () => {
 				const script = workloadScript(options.workloadSeconds);
 				const result = await runner.step("driver-check-durable", script, durableTimeoutMs);
-				if (result.exitCode !== 0) throw new Error(`step failed: ${stepError(result)}`);
+
 				return `${(result.stdout ?? "").trim()} (durable path, cap ${transportSyncCapMs}ms)`;
 			},
 			log,
@@ -370,10 +368,13 @@ async function run(options: Options, log: (message: string) => void): Promise<Ch
 			log,
 		);
 		if (!ready) return checks;
-		const runner = new StepRunner(sessionHandle(live), transport, undefined, {
-			mode: "fixed",
-			times: 1,
-		});
+		const runner =
+			module.id === "e2b"
+				? new SessionStepRunner(live, module.execution, undefined, { mode: "fixed", times: 1 })
+				: new StepRunner(sessionHandle(live), transport, undefined, {
+						mode: "fixed",
+						times: 1,
+					});
 		await driveSession(live, options, transport.syncCapMs, runner, checks, log);
 	} finally {
 		if (options.keep) {

--- a/apps/cli/src/lib/driver-run.ts
+++ b/apps/cli/src/lib/driver-run.ts
@@ -1,3 +1,4 @@
+import { executeSuite, measureLifecycleOperation } from "@sandbox-benchmarks/harness";
 // The driver composition root (ADR-0007 §1).
 //
 // The kit deliberately splits three trust boundaries that a single `config` object used to blur:
@@ -244,26 +245,17 @@ export async function createOwnedDriverSession(
 	driver: SandboxDriver,
 	request: CreateRequest,
 ): Promise<OwnedDriverSession> {
-	const owned = await createOwnedSandbox(
-		async (signal) => {
-			const session = await driver.create(request, { signal });
-			return {
-				sandboxId: session.sandboxRef.id,
-				session,
-				destroy: (options?: { readonly signal?: AbortSignal }) => session.destroy(options),
-			};
-		},
-		{ destroy: (providerDestroy, options) => providerDestroy(options) },
-	);
-	const session = owned.session;
+	const session = await createOwnedSandbox((signal) => driver.create(request, { signal }), {
+		destroy: (providerDestroy, options) => providerDestroy(options),
+	});
 	const launch = session.launch?.bind(session);
 	return {
 		sandboxRef: session.sandboxRef,
 		artifact: session.artifact,
 		native: session.native,
 		exec: (command, options) => session.exec(command, options),
-		destroy: (options) => owned.destroy(options),
-		releaseOwnership: () => releaseOwnedSandbox(owned),
+		destroy: (options) => session.destroy(options),
+		releaseOwnership: () => releaseOwnedSandbox(session),
 		...(session.files === undefined ? {} : { files: session.files }),
 		...(launch === undefined ? {} : { launch }),
 	};
@@ -463,6 +455,15 @@ export async function benchmarkDriverLifecycle(
 	options: BenchmarkLifecycleOptions = {},
 ): Promise<LifecycleBenchmark> {
 	const opened = await openDriver(id);
+	if (id === "e2b")
+		return measureLifecycleOperation(
+			{
+				module: opened.module,
+				driver: opened.driver,
+				request: { spec: TARGET_SPEC, artifact: opened.artifact },
+			},
+			options,
+		);
 	return benchmarkLifecycleCompute(id, driverLifecycleCompute(opened), options);
 }
 
@@ -531,6 +532,21 @@ export async function runDriverSuite(options: RunSuiteOptions): Promise<void> {
 			);
 		}
 		throw error;
+	}
+
+	if (providerName === "e2b") {
+		await executeSuite({
+			allocation: {
+				module: opened.module,
+				driver: opened.driver,
+				request: { spec: TARGET_SPEC, artifact: opened.artifact },
+			},
+			runId: options.runId,
+			...(options.replicateIndex === undefined ? {} : { replicateIndex: options.replicateIndex }),
+			suiteName,
+			resultsDir,
+		});
+		return;
 	}
 
 	const suite = SUITES[suiteName];

--- a/apps/cli/src/lib/smoke-run.ts
+++ b/apps/cli/src/lib/smoke-run.ts
@@ -2,11 +2,12 @@
 // body that both `bench-smoke` (boot the published image) and `bake` (boot the just-baked candidate)
 // feed to {@link forEachProviderWithCreds}. The probe results are captured INSIDE the lifecycle so a
 // teardown-only failure still reports which probes passed instead of looking like nothing ran.
-import { withSandbox } from "@sandbox-benchmarks/harness";
+import { withSandbox, withSandboxWork } from "@sandbox-benchmarks/harness";
+import { TARGET_SPEC } from "@sandbox-benchmarks/schema";
 import type { SmokeResult } from "@sandbox-benchmarks/templates/smoke";
 import { runSmoke } from "@sandbox-benchmarks/templates/smoke";
 import type { ArtifactResolution } from "./driver-run.ts";
-import { withDriverSandbox } from "./driver-run.ts";
+import { openDriver, withDriverSandbox } from "./driver-run.ts";
 import type { ProviderTarget } from "./providers-run.ts";
 
 /** A smoke run's outcome: the probe results, plus the lifecycle error if boot/teardown threw. */
@@ -41,6 +42,25 @@ export async function bootAndSmoke(
 		}
 		switch (target.kind) {
 			case "driver":
+				if (target.id === "e2b") {
+					const opened = await openDriver(target.id, options);
+					await withSandboxWork(
+						{
+							module: opened.module,
+							driver: opened.driver,
+							request: { spec: TARGET_SPEC, artifact: opened.artifact },
+						},
+						async ({ session }) => {
+							checks = await runSmoke(async (command) => {
+								const result = await session.exec(command);
+								if (result.exit.kind !== "exited")
+									throw new Error(`Smoke command returned ${JSON.stringify(result.exit)}`);
+								return { stdout: result.stdout, stderr: result.stderr, exitCode: result.exit.code };
+							});
+						},
+					);
+					return { checks };
+				}
 				await withDriverSandbox(
 					target.id,
 					async (sandbox) => {

--- a/bun.lock
+++ b/bun.lock
@@ -122,6 +122,7 @@
       "name": "@sandbox-benchmarks/harness",
       "version": "0.0.0",
       "dependencies": {
+        "@sandbox-benchmarks/driver": "workspace:*",
         "@sandbox-benchmarks/providers": "workspace:*",
         "@sandbox-benchmarks/schema": "workspace:*",
       },

--- a/docs/adr/0009-harness-operations-and-gpu-allocation.md
+++ b/docs/adr/0009-harness-operations-and-gpu-allocation.md
@@ -1,0 +1,31 @@
+---
+status: accepted
+---
+
+# Separate harness operations with provider-specific GPU allocation
+
+Complete the driver migration specified by ADR-0007 using separate suite execution, lifecycle
+measurement, and managed custom-work operations with declarative inputs. Each operation owns its
+execution and cleanup sequence; all use the driver-session seam. This concentrates lifecycle
+ownership without requiring callers to assemble it or introducing a generic workflow language.
+Lifecycle measurement retains its existing create-to-first-success semantics, distinct from
+operational readiness. The published measurement contract remains unchanged during migration.
+
+GPU allocation configuration belongs to the selected provider's fleet implementation. Prefer
+exported Modal SDK types for Modal image references, volumes, and allocation fields instead of
+copying vendor shapes. Keep canonical request values single-authored and keep Modal types out of
+the common driver and harness interfaces. Future GPU runners reuse the session seam with their
+own typed allocation configuration. This preserves provider-specific resource and artifact
+semantics without an arbitrary vendor-options bag on every request.
+
+CLI composition owns environment and artifact resolution; harness owns workload execution,
+measurement, and evidence persistence; drivers own provider behavior. Migrate all existing
+providers and callers before removing the legacy package and exports. ComputeSDK may remain
+one fleet-private adapter, as ADR-0007 permits. Migration does not by itself establish live
+conformance or publication eligibility under ADR-0008.
+
+Deliver the migration as focused, stacked provider PRs. Each provider path must be live-validated
+before its PR is opened; missing credentials or infrastructure block that submission. Intermediate
+commits preserve the existing paths for unmigrated providers, and the final migration removes
+legacy compatibility. This keeps each change reviewable without declaring the whole fleet migrated
+or validated on the strength of one provider's result.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -18,3 +18,4 @@ here changes, supersede the ADR (leave it in place, note what replaced it) rathe
 | [0006](./0006-declarative-provider-onboarding.md) | Declarative provider onboarding |
 | [0007](./0007-sandbox-driver-port.md) | Sandbox driver kit: one port, one file per provider; ComputeSDK as one driver |
 | [0008](./0008-driver-conformance-gate.md) | Driver conformance: the behavioral drift gate |
+| [0009](./0009-harness-operations-and-gpu-allocation.md) | Separate harness operations and typed provider-specific GPU allocation |

--- a/packages/driver/CONTEXT.md
+++ b/packages/driver/CONTEXT.md
@@ -1,0 +1,17 @@
+# Sandbox drivers
+
+This context describes the sandbox behavior that benchmark execution can request and observe.
+
+## Language
+
+**Sandbox session**:
+An allocated sandbox with provider-qualified identity and available execution and lifecycle
+capabilities. A session identifies a particular allocation, not a provider as a whole.
+
+**Driver**:
+An implementation of sandbox creation and behavior for a provider integration. Its exposed
+capabilities describe that integration, not every capability offered by the vendor.
+
+**Durable execution**:
+Command execution that can outlive its launch interaction and whose completion is observed
+separately. Launch acceptance is not command completion or success.

--- a/packages/driver/src/index.ts
+++ b/packages/driver/src/index.ts
@@ -50,6 +50,7 @@ export type {
 	ReadinessSignal,
 	SandboxTeardownResult,
 } from "./lib/policy.ts";
+export { selectExecutionRoute } from "./lib/policy.ts";
 export type { ReadinessStrategy } from "./lib/poll.ts";
 export { pollUntilReady } from "./lib/poll.ts";
 export type {

--- a/packages/harness/CONTEXT.md
+++ b/packages/harness/CONTEXT.md
@@ -1,0 +1,17 @@
+# Benchmark execution
+
+This context describes performing benchmark work and recording the evidence used for comparison.
+
+## Language
+
+**Benchmark step**:
+A command workload executed as part of benchmark preparation, measurement, or collection, with
+its own completion outcome. A step is not necessarily a measured sample.
+
+**Lifecycle measurement**:
+A measurement of sandbox creation, first successful command execution, teardown, or an exposed
+control-plane operation. Operational readiness alone does not define the measured first success.
+
+**Result gap**:
+A recorded absence of a benchmark result, such as a skipped or failed workload. A gap is not a
+zero-valued measurement.

--- a/packages/harness/package.json
+++ b/packages/harness/package.json
@@ -11,6 +11,7 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
+    "@sandbox-benchmarks/driver": "workspace:*",
     "@sandbox-benchmarks/providers": "workspace:*",
     "@sandbox-benchmarks/schema": "workspace:*"
   },

--- a/packages/harness/src/index.ts
+++ b/packages/harness/src/index.ts
@@ -2,6 +2,18 @@
 import { readdirSync } from "node:fs";
 import { resolve } from "node:path";
 import type {
+	CreateRequest,
+	DriverModule,
+	ProviderId,
+	SandboxDriver,
+	SandboxSession,
+} from "@sandbox-benchmarks/driver";
+import { isRetryableDriverCreate } from "@sandbox-benchmarks/driver";
+import {
+	driverReadinessBudgetMs,
+	verifyDriverReadiness,
+} from "@sandbox-benchmarks/driver/conformance";
+import type {
 	DirectProvider,
 	ProviderConfig,
 	ProviderCostEvidenceCapability,
@@ -9,10 +21,9 @@ import type {
 } from "@sandbox-benchmarks/providers";
 import {
 	isRetryableCreateError,
-	providers,
 	sanitizeEvidenceDetail,
 	sanitizeProviderResponse,
-} from "@sandbox-benchmarks/providers";
+} from "@sandbox-benchmarks/providers/support";
 import type {
 	GapCause,
 	GuestFingerprint,
@@ -45,15 +56,25 @@ import {
 	writeProviderCostEvidence,
 } from "./lib/collect.ts";
 import type { SandboxHandle } from "./lib/execute.ts";
-import { MIN, resolvePtsPassPolicy, StepRunner, withTimeout } from "./lib/execute.ts";
+import {
+	MIN,
+	resolvePtsPassPolicy,
+	SessionStepRunner,
+	StepRunner,
+	withTimeout,
+} from "./lib/execute.ts";
 import { gapCauseOf } from "./lib/gap-cause.ts";
 import { time } from "./lib/internal.ts";
 import type { LifecycleAggregate, LifecycleCompute } from "./lib/lifecycle.ts";
-import { aggregateLifecycle, measureLifecycle } from "./lib/lifecycle.ts";
+import { aggregateLifecycle, measureDriverLifecycle, measureLifecycle } from "./lib/lifecycle.ts";
 import type { WaitUntilReadyOptions } from "./lib/readiness.ts";
 import { neverReadyReason, waitUntilReady } from "./lib/readiness.ts";
 import type { OwnedSandboxOptions } from "./lib/sandbox-owner.ts";
-import { createOwnedSandbox, withOwnedSandbox } from "./lib/sandbox-owner.ts";
+import {
+	createOwnedSandbox,
+	withCleanupPreservingPrimaryError,
+	withOwnedSandbox,
+} from "./lib/sandbox-owner.ts";
 import { DIR, OBSERVED_SPECS_SCRIPT, REPO_REF, REPO_URL, setupSteps } from "./lib/setup.ts";
 
 export { collectResults } from "./lib/collect.ts";
@@ -65,7 +86,7 @@ export type {
 	SandboxFilesystem,
 	SandboxHandle,
 } from "./lib/execute.ts";
-export { StepRunner } from "./lib/execute.ts";
+export { SessionStepRunner, StepRunner } from "./lib/execute.ts";
 // Re-export the lifecycle measurement surface so consumers import it from the package root, never
 // from `src/lib` (the package-boundary rule the other modules follow).
 export type {
@@ -76,7 +97,7 @@ export type {
 	LifecycleSnapshots,
 	MeasureLifecycleOptions,
 } from "./lib/lifecycle.ts";
-export { aggregateLifecycle, measureLifecycle } from "./lib/lifecycle.ts";
+export { aggregateLifecycle, measureDriverLifecycle, measureLifecycle } from "./lib/lifecycle.ts";
 export type { OwnedOperationOptions, OwnedSandboxOptions } from "./lib/sandbox-owner.ts";
 export {
 	cleanupOwnedSandboxes,
@@ -160,6 +181,43 @@ export async function benchmarkLifecycleCompute(
 	compute: LifecycleCompute,
 	options: BenchmarkLifecycleComputeOptions = {},
 ): Promise<LifecycleBenchmark> {
+	return benchmarkCycles(provider, options, () =>
+		measureLifecycle(compute, {
+			...options,
+			provider,
+			controlPlaneSamples: options.controlPlaneSamples ?? 5,
+		}),
+	);
+}
+
+/** Measure repeated cold starts through a resolved driver integration. */
+export function measureLifecycleOperation(
+	allocation: DriverAllocation,
+	options: BenchmarkLifecycleOptions = {},
+): Promise<LifecycleBenchmark> {
+	const budget = allocation.module.createBudget;
+	const deadlineMs =
+		budget?.owner === "driver"
+			? budget.attemptCeilingMs
+			: (budget?.timeoutMs ?? SUITE_CREATE_ATTEMPT_TIMEOUT_MS);
+	return benchmarkCycles(allocation.module.id, options, () =>
+		measureDriverLifecycle(
+			allocation.driver,
+			{ ...allocation.request, deadlineMs },
+			{
+				...options,
+				provider: allocation.module.id,
+				controlPlaneSamples: options.controlPlaneSamples ?? 5,
+			},
+		),
+	);
+}
+
+async function benchmarkCycles(
+	provider: string,
+	options: BenchmarkLifecycleOptions,
+	measure: () => Promise<import("./lib/lifecycle.ts").LifecycleMeasurement>,
+): Promise<LifecycleBenchmark> {
 	// `?? 5` only catches undefined; a non-finite iterations would make `i < iterations` never run
 	// (NaN) or never stop (Infinity), so it falls back to a single cycle.
 	const rawIterations = options.iterations ?? 5;
@@ -169,16 +227,7 @@ export async function benchmarkLifecycleCompute(
 	const gaps: ResultGap[] = [];
 	for (let i = 0; i < iterations; i++) {
 		try {
-			const pass = await measureLifecycle(compute, {
-				provider,
-				createOptions: options.createOptions,
-				execCommand: options.execCommand,
-				controlPlaneSamples: options.controlPlaneSamples ?? 5,
-				snapshot: options.snapshot,
-				readinessMaxAttempts: options.readinessMaxAttempts,
-				readinessRetryDelayMs: options.readinessRetryDelayMs,
-				payload: options.payload,
-			});
+			const pass = await measure();
 			samples.push(...pass.samples);
 			gaps.push(...pass.gaps);
 		} catch (err) {
@@ -272,7 +321,9 @@ export interface RunSuiteOptions {
 	env?: Record<string, string | undefined>;
 }
 
-async function destroySandbox(sandbox: SandboxHandle | undefined): Promise<SandboxTeardownResult> {
+async function destroySandbox(
+	sandbox: Pick<SandboxHandle, "destroy"> | undefined,
+): Promise<SandboxTeardownResult> {
 	const attemptedAt = new Date().toISOString();
 	if (!sandbox) return { completed: false, attemptedAt };
 	try {
@@ -302,6 +353,7 @@ export async function runSuite(options: RunSuiteOptions): Promise<void> {
 	}
 	const suite = SUITES[knownSuiteName];
 
+	const { providers } = await import("@sandbox-benchmarks/providers");
 	const config = providers.find((p) => p.name === providerName);
 	if (!config) {
 		throw new SuiteUsageError(
@@ -430,19 +482,21 @@ export interface CreateSuiteSandboxContext {
  * wrapper and the DriverModule path use this boundary, so timeout ownership, late-handle teardown,
  * retry budgeting, and failure-marker semantics cannot drift between the two transports.
  */
-export interface SuiteSandboxCreatePlan {
+export interface SuiteSandboxCreatePlan<
+	Session extends Pick<SandboxHandle, "destroy"> = SandboxHandle,
+> {
 	/** Create one harness-shaped sandbox. The process owner supplies cooperative cancellation. */
-	readonly create: (signal: AbortSignal) => Promise<SandboxHandle>;
+	readonly create: (signal: AbortSignal) => Promise<Session>;
 	/** Whether the rejected attempt is safe to retry after the shared backoff. */
 	readonly isRetryable: (error: unknown) => boolean;
 	/** Optional cancellation bridge for the handle's captured destroy operation. */
 	readonly destroy?: OwnedSandboxOptions["destroy"];
 }
 
-export async function createSuiteSandboxFromPlan(
-	plan: SuiteSandboxCreatePlan,
+export async function createSuiteSandboxFromPlan<Session extends Pick<SandboxHandle, "destroy">>(
+	plan: SuiteSandboxCreatePlan<Session>,
 	ctx: CreateSuiteSandboxContext,
-): Promise<SandboxHandle> {
+): Promise<Session> {
 	const { suiteName, providerName, resultsDir } = ctx;
 	const createTimeoutMs =
 		ctx.createTimeoutMs === undefined ? SUITE_CREATE_ATTEMPT_TIMEOUT_MS : ctx.createTimeoutMs;
@@ -495,7 +549,7 @@ export async function createSuiteSandboxFromPlan(
 		// Undefined until `sandbox.create` is actually invoked: a factory throw leaves it unset (nothing
 		// was created, so there is nothing to clean up), while a create that outlives the timeout leaves it
 		// a pending promise whose late handle must still be destroyed (see the catch).
-		let createPromise: Promise<SandboxHandle> | undefined;
+		let createPromise: Promise<Session> | undefined;
 		try {
 			createPromise = createOwnedSandbox(
 				plan.create,
@@ -694,8 +748,105 @@ export async function runSuiteOnSandbox(
 	sandbox: SandboxHandle,
 	ctx: SuiteRunContext,
 ): Promise<void> {
-	const { suite, suiteName, providerName, resultsDir, transport } = ctx;
-	const sandboxId = sandbox.sandboxId;
+	return runSuiteWork(
+		sandbox,
+		sandbox.sandboxId,
+		ctx,
+		() => new StepRunner(sandbox, ctx.transport, undefined, resolvePtsPassPolicy(ctx.suite)),
+		async () => {
+			if (ctx.driverReadiness !== undefined) {
+				const readiness = await verifySuiteDriverReadiness(ctx.driverReadiness);
+				if (!readiness.ready)
+					throw new Error(`Driver readiness verification failed: ${readiness.detail}`);
+			} else {
+				const readiness = await waitUntilReady(sandbox, ctx.readiness ?? SUITE_READINESS);
+				if (!readiness.ready) throw new Error(neverReadyReason(readiness.attempts));
+			}
+		},
+	);
+}
+
+/** A resolved integration and allocation inputs. The harness owns budgets and session lifetime. */
+export interface DriverAllocation {
+	readonly module: DriverModule<ProviderId>;
+	readonly driver: SandboxDriver;
+	readonly request: Omit<CreateRequest, "deadlineMs">;
+}
+
+export interface ExecuteSuiteOptions {
+	readonly allocation: DriverAllocation;
+	readonly runId: RunId;
+	readonly replicateIndex?: number;
+	readonly suiteName: SuiteName;
+	readonly resultsDir: string;
+}
+
+/** Allocate, execute, collect evidence and tear down one suite through the driver session seam. */
+export async function executeSuite(options: ExecuteSuiteOptions): Promise<void> {
+	const { allocation, suiteName } = options;
+	const { module, driver, request } = allocation;
+	const suite = SUITES[suiteName];
+	const budget = module.createBudget;
+	const timeoutMs =
+		budget?.owner === "driver" ? null : (budget?.timeoutMs ?? SUITE_CREATE_ATTEMPT_TIMEOUT_MS);
+	const deadlineMs =
+		budget?.owner === "driver"
+			? budget.attemptCeilingMs
+			: (timeoutMs ?? SUITE_CREATE_ATTEMPT_TIMEOUT_MS);
+	const session = await createSuiteSandboxFromPlan(
+		{
+			create: (signal) => driver.create({ ...request, deadlineMs }, { signal }),
+			isRetryable: isRetryableDriverCreate,
+			destroy: (destroy, destroyOptions) => destroy(destroyOptions),
+		},
+		{
+			suite,
+			suiteName,
+			providerName: module.id,
+			resultsDir: options.resultsDir,
+			createTimeoutMs: timeoutMs,
+			...(budget?.owner === "driver" ? { createAttemptCeilingMs: budget.attemptCeilingMs } : {}),
+		},
+	);
+	await runSuiteWork(
+		session,
+		session.sandboxRef.id,
+		{
+			...options,
+			suite,
+			providerName: module.id,
+			artifact: request.artifact,
+			...(module.costEvidence === undefined ? {} : { costEvidence: module.costEvidence }),
+		},
+		() => new SessionStepRunner(session, module.execution, undefined, resolvePtsPassPolicy(suite)),
+		async () => {
+			const readiness = await verifySuiteDriverReadiness({
+				timeoutMs: driverReadinessBudgetMs(module),
+				verify: async ({ signal }) => {
+					const result = await verifyDriverReadiness(module, session, { signal });
+					return { ready: result.status === "pass", detail: result.detail };
+				},
+			});
+			if (!readiness.ready)
+				throw new Error(`Driver readiness verification failed: ${readiness.detail}`);
+		},
+	);
+}
+
+type SuiteWorkContext = Omit<SuiteRunContext, "transport" | "driverReadiness" | "readiness">;
+type SuiteWorkRunner = Pick<StepRunner, "phase" | "stepLog"> & {
+	run: SessionStepRunner["run"] | StepRunner["run"];
+	step: SessionStepRunner["step"] | StepRunner["step"];
+};
+
+async function runSuiteWork(
+	sandbox: Pick<SandboxSession, "destroy"> | Pick<SandboxHandle, "destroy">,
+	sandboxId: string | undefined,
+	ctx: SuiteWorkContext,
+	createRunner: () => SuiteWorkRunner,
+	verifyReadiness: () => Promise<void>,
+): Promise<void> {
+	const { suite, suiteName, providerName, resultsDir } = ctx;
 	let suiteError: unknown;
 	let evidencePersistenceError: unknown;
 	let suiteSkipped = false;
@@ -722,24 +873,9 @@ export async function runSuiteOnSandbox(
 		// count on every other suite) and the BENCH_PTS_PASSES override. Constructed inside the
 		// try so a bad policy (buildPreamble rejects a fixed k < 1) is still torn down by the finally below;
 		// a throw before the try would leak the already-created sandbox.
-		const runner = new StepRunner(sandbox, transport, undefined, resolvePtsPassPolicy(suite));
+		const runner = createRunner();
 		runner.phase = "setup";
-		// Wait for the sandbox to become usable before the first real step. `create()` resolving means
-		// ALLOCATED, not ready: a provider that cold-pulls its image at create time (Namespace takes the
-		// toolchain OCI ref straight through `options.image` — it has no template to pre-bake) is still
-		// fetching image layers when its handle resolves, and an exec against a not-yet-running container
-		// hangs instead of erroring. Without this gate the pull is charged to whatever step happens to run
-		// first, which reports the pull as that step's timeout — a 60s "check free disk" failure that had
-		// nothing to do with disk. Pre-baked providers answer the first probe and pay one round-trip.
-		if (ctx.driverReadiness === undefined) {
-			const readiness = await waitUntilReady(sandbox, ctx.readiness ?? SUITE_READINESS);
-			if (!readiness.ready) throw new Error(neverReadyReason(readiness.attempts));
-		} else {
-			const readiness = await verifySuiteDriverReadiness(ctx.driverReadiness);
-			if (!readiness.ready) {
-				throw new Error(`Driver readiness verification failed: ${readiness.detail}`);
-			}
-		}
+		await verifyReadiness();
 		const expectedFingerprint = expectedToolchainFingerprint(providerName, ctx.artifact);
 		if (expectedFingerprint !== undefined) {
 			const captured = await runner.run(
@@ -1051,4 +1187,60 @@ export function unmetRequirements(
 ): string[] {
 	const passed = new Set(reports.filter((r) => r.status === "ok").map((r) => r.provider));
 	return required.filter((id) => !passed.has(id));
+}
+
+/** A custom workload borrows a ready session; scope exit always attempts teardown. */
+export interface SandboxWork {
+	readonly session: SandboxSession;
+	readonly runner: SessionStepRunner;
+}
+
+export async function withSandboxWork<T>(
+	allocation: DriverAllocation,
+	work: (context: SandboxWork) => Promise<T>,
+): Promise<T> {
+	const { module, driver, request } = allocation;
+	const budget = module.createBudget;
+	const deadlineMs =
+		budget?.owner === "driver"
+			? budget.attemptCeilingMs
+			: (budget?.timeoutMs ?? SUITE_CREATE_ATTEMPT_TIMEOUT_MS);
+	const pending = createOwnedSandbox(
+		(signal) => driver.create({ ...request, deadlineMs }, { signal }),
+		{ destroy: (destroy, options) => destroy(options) },
+	);
+	let session: SandboxSession;
+	try {
+		session =
+			budget?.owner === "driver"
+				? await pending
+				: await withTimeout(pending, deadlineMs, "Sandbox creation timed out");
+	} catch (error) {
+		// The race cannot cancel an accepted create; keep ownership until its late arrival is reclaimed.
+		void pending.then(
+			(late) => destroySandbox(late),
+			() => {},
+		);
+		throw error;
+	}
+	return withCleanupPreservingPrimaryError(
+		async () => {
+			const readiness = await verifySuiteDriverReadiness({
+				timeoutMs: driverReadinessBudgetMs(module),
+				verify: async ({ signal }) => {
+					const result = await verifyDriverReadiness(module, session, { signal });
+					return { ready: result.status === "pass", detail: result.detail };
+				},
+			});
+			if (!readiness.ready)
+				throw new Error(`Driver readiness verification failed: ${readiness.detail}`);
+			return work({ session, runner: new SessionStepRunner(session, module.execution) });
+		},
+		() => session.destroy(),
+		(error) =>
+			console.error(
+				`withSandboxWork (${module.id}): teardown failed after workload failure`,
+				error,
+			),
+	);
 }

--- a/packages/harness/src/lib/collect.ts
+++ b/packages/harness/src/lib/collect.ts
@@ -83,7 +83,12 @@ class CollectedResultsEmptyError extends Error {}
 class ReservedCollectedFileError extends Error {}
 
 /** Pull the sandbox's benchmark-results/ into `resultsDir` on the host. */
-export async function collectResults(runner: StepRunner, resultsDir: string): Promise<void> {
+export async function collectResults(
+	runner: Pick<StepRunner, "phase"> & {
+		step: (...args: Parameters<StepRunner["step"]>) => Promise<{ stdout?: string }>;
+	},
+	resultsDir: string,
+): Promise<void> {
 	runner.phase = "collect";
 	// One retry boundary wraps the ENTIRE idempotent collect — the in-sandbox tar|base64 step, the
 	// marker scan, AND the host-side decode + tar extract. A read-back transport failure, a marker

--- a/packages/harness/src/lib/execute.ts
+++ b/packages/harness/src/lib/execute.ts
@@ -23,6 +23,8 @@
  */
 
 import { randomUUID } from "node:crypto";
+import type { ExecResult, ExecutionPolicy, SandboxSession } from "@sandbox-benchmarks/driver";
+import { launchDetached, selectExecutionRoute } from "@sandbox-benchmarks/driver";
 import type { ProviderTransport } from "@sandbox-benchmarks/schema";
 import { PTS_STATE_SELECT_SH } from "@sandbox-benchmarks/schema";
 import { GapError } from "./gap-cause.ts";
@@ -393,7 +395,7 @@ function startHeartbeat(label: string, startedAt: number, timeoutMs: number): ()
  */
 export class LogReadbackError extends Error {}
 
-export class StepRunner {
+abstract class StepExecution<Result extends { stdout?: string; stderr?: string }> {
 	/** The phase subsequent steps are charged to. */
 	phase: Phase = "setup";
 	/** Every executed step with its phase, elapsed ms, and exit code. */
@@ -412,21 +414,24 @@ export class StepRunner {
 	 */
 	private pollFs?: SandboxFilesystem;
 
-	constructor(
-		private readonly sandbox: SandboxHandle,
-		/** The provider's exec transport capability — {@link step} selects sync vs detached from it. */
-		private readonly transport: ProviderTransport = DEFAULT_TRANSPORT,
-		/** The inter-poll sleep used by {@link runDetached}; injectable so tests can assert the backoff
-		 *  schedule without real waiting. */
-		private readonly sleep: (ms: number) => Promise<void> = delay,
-		/** How many timed PTS passes each case runs, or `converge` for PTS's own convergence. Omitted →
-		 *  {@link DEFAULT_PTS_PASS_POLICY} (fixed k=2), so a StepRunner built without one keeps the old
-		 *  behaviour. Resolved from the suite + `BENCH_PTS_PASSES` by {@link resolvePtsPassPolicy}. */
-		passPolicy: PtsPassPolicy = DEFAULT_PTS_PASS_POLICY,
+	protected constructor(
+		filesystem: SandboxFilesystem | undefined,
+		private readonly sleep: (ms: number) => Promise<void>,
+		passPolicy: PtsPassPolicy,
 	) {
 		this.preamble = buildPreamble(passPolicy);
-		this.pollFs = sandbox.filesystem;
+		this.pollFs = filesystem;
 	}
+
+	protected abstract execute(command: string): Promise<Result>;
+	protected abstract launch(command: string): Promise<void>;
+	protected abstract detached(timeoutMs: number): boolean;
+	protected abstract exitCode(result: Result): number | null;
+	protected abstract describeExit(result: Result): string;
+	protected parseCompletion(raw: string): number | null {
+		return parseExitCode(raw);
+	}
+	protected abstract completed(code: number | null, stdout: string, durationMs: number): Result;
 
 	/**
 	 * Observe a detached step's completion once: the exit code, or `undefined` while it is still running.
@@ -438,7 +443,7 @@ export class StepRunner {
 	 * real Blaxel incident, 2026-07-19), where permanent absence must abandon it, and only the stub's own
 	 * error distinguishes the two. A dead sandbox is still caught, because the cat poll will fail too.
 	 */
-	private async pollDoneOnce(donePath: string, label: string): Promise<number | undefined> {
+	private async pollDoneOnce(donePath: string, label: string): Promise<number | null | undefined> {
 		if (!this.pollFs) return this.pollDoneViaCat(donePath);
 		try {
 			return await this.pollDoneViaFs(this.pollFs, donePath);
@@ -466,8 +471,8 @@ export class StepRunner {
 		script: string,
 		timeoutMs: number,
 		opts: StepOptions = {},
-	): Promise<CommandResult> {
-		return selectTransport(this.transport, timeoutMs) === "detached"
+	): Promise<Result> {
+		return this.detached(timeoutMs)
 			? this.runDetached(label, script, timeoutMs, opts)
 			: this.run(label, script, timeoutMs, opts);
 	}
@@ -483,14 +488,14 @@ export class StepRunner {
 		script: string,
 		timeoutMs: number,
 		opts: StepOptions = {},
-	): Promise<CommandResult> {
+	): Promise<Result> {
 		console.log(`\n=== [${label}] ===`);
 		const started = performance.now();
 		const stopHeartbeat = startHeartbeat(label, started, timeoutMs);
-		let result: CommandResult;
+		let result: Result;
 		try {
 			result = await withTimeout(
-				this.sandbox.runCommand(`bash -c ${shellQuote(`${this.preamble}; ${script}`)}`),
+				this.execute(`bash -c ${shellQuote(`${this.preamble}; ${script}`)}`),
 				timeoutMs,
 				() => stepTimeout(label, timeoutMs),
 			);
@@ -520,7 +525,7 @@ export class StepRunner {
 		script: string,
 		timeoutMs: number,
 		opts: StepOptions = {},
-	): Promise<CommandResult> {
+	): Promise<Result> {
 		console.log(`\n=== [${label}] (detached) ===`);
 		const started = performance.now();
 		const stopHeartbeat = startHeartbeat(label, started, timeoutMs);
@@ -537,13 +542,7 @@ export class StepRunner {
 			const wrapped =
 				`bash -c ${shellQuote(`${this.preamble}; ${script}`)} > ${logPath} 2>&1 ` +
 				`&& echo 0 > ${donePath} || echo $? > ${donePath}`;
-			// Double-fork daemonization: a single nohup/setsid still blocks e2b's envd, which holds the
-			// exec open for as long as its DIRECT child lives (probed live: even `nohup ... &` pins the
-			// exec for the child's whole life; setsid doesn't help). So the direct child backgrounds the
-			// real job via a second nohup and exits at once — Daytona/Blaxel detach fine either way.
-			const daemonized = `nohup bash -c ${shellQuote(wrapped)} </dev/null >/dev/null 2>&1 &`;
-			const launch = `nohup bash -c ${shellQuote(daemonized)} </dev/null >/dev/null 2>&1 & echo launched`;
-			await this.sandbox.runCommand(`bash -c ${shellQuote(launch)}`, { background: true });
+			await this.launch(wrapped);
 
 			// Poll for the done-file, backing off adaptively so a quick step isn't over-charged for polls.
 			const deadline = started + timeoutMs;
@@ -553,7 +552,7 @@ export class StepRunner {
 				// A poll that THROWS is different from "not done yet": one blip is transient, but a run of
 				// them means the sandbox stopped answering — fail fast instead of sitting on a dead sandbox
 				// for the rest of the command budget (see MAX_CONSECUTIVE_POLL_FAILURES).
-				let exitCode: number | undefined;
+				let exitCode: number | null | undefined;
 				try {
 					exitCode = await this.pollDoneOnce(donePath, label);
 					consecutivePollFailures = 0;
@@ -573,7 +572,12 @@ export class StepRunner {
 						// this.pollFs, not the raw capability: once the poll has degraded, the read-back must not
 						// re-try the same broken API and burn its whole retry budget rediscovering that.
 						const stdout = await this.readCompletedLog(this.pollFs, logPath, label);
-						return this.finishStep(label, started, { exitCode, stdout }, opts);
+						return this.finishStep(
+							label,
+							started,
+							this.completed(exitCode, stdout, performance.now() - started),
+							opts,
+						);
 					} finally {
 						// The read-back is done — its contents are in memory — so drop the log/done files
 						// now. collectResults re-runs the WHOLE detached step on a transient read-back
@@ -590,9 +594,7 @@ export class StepRunner {
 					// must not mask the timeout.
 					const tail = await this.readLogTail(this.pollFs, logPath);
 					// Best-effort stop the detached job; don't let a failing kill mask the timeout.
-					await this.sandbox
-						.runCommand(`pkill -f ${shellQuote(tag)} || true`)
-						.catch(() => undefined);
+					await this.execute(`pkill -f ${shellQuote(tag)} || true`).catch(() => undefined);
 					if (tail === null) {
 						console.log(
 							`--- "${label}" timed out and its log could not be read: the sandbox stopped ` +
@@ -616,7 +618,7 @@ export class StepRunner {
 	private async pollDoneViaFs(
 		fs: SandboxFilesystem,
 		donePath: string,
-	): Promise<number | undefined> {
+	): Promise<number | null | undefined> {
 		// Bound both fs calls so a hung filesystem API (some adapters go over the network) can't
 		// stall the poll loop indefinitely — the outer deadline only advances between iterations.
 		// A timeout or fs error THROWS to the poll loop, which tolerates a transient blip but fails
@@ -628,17 +630,17 @@ export class StepRunner {
 		// The background script writes the done-file non-atomically (truncate, then echo the code),
 		// so an empty read means "created but not yet written" — still running, not exit 0.
 		const raw = (await withTimeout(fs.readFile(donePath), POLL_CAP_MS, "done-file fs read")).trim();
-		return raw === "" ? undefined : parseExitCode(raw);
+		return raw === "" ? undefined : this.parseCompletion(raw);
 	}
 
 	/** Poll fallback for providers whose adapter exposes no filesystem API: read the done-file with a
 	 *  `cat` exec, treating the {@link RUNNING_SENTINEL} (or empty output) as not-done-yet. */
-	private async pollDoneViaCat(donePath: string): Promise<number | undefined> {
+	private async pollDoneViaCat(donePath: string): Promise<number | null | undefined> {
 		// Bound the exec so a hung `cat` can't outlast the step budget. An exec failure or timeout
 		// THROWS to the poll loop (which tolerates transient blips but fails fast on a dead sandbox);
 		// an absent done-file is the RUNNING_SENTINEL, not an error.
 		const probe = await withTimeout(
-			this.sandbox.runCommand(
+			this.execute(
 				`bash -c ${shellQuote(`cat ${donePath} 2>/dev/null || echo ${RUNNING_SENTINEL}`)}`,
 			),
 			POLL_CAP_MS,
@@ -649,14 +651,14 @@ export class StepRunner {
 		// missing done-file. THROW so the poll loop's consecutive-failure fast-fail engages, matching
 		// pollDoneViaFs; swallowing it as "still running" would sit on a dead sandbox for the whole
 		// step budget — the exact failure this detached path exists to catch.
-		if (probe.exitCode !== 0) {
+		if (this.exitCode(probe) !== 0) {
 			throw new Error(
-				`done-file cat poll returned exit ${probe.exitCode} — sandbox not responding`,
+				`done-file cat poll returned exit ${this.exitCode(probe)} — sandbox not responding`,
 			);
 		}
 		const out = (probe.stdout ?? "").trim();
 		if (out === "" || out === RUNNING_SENTINEL) return undefined;
-		return parseExitCode(out);
+		return this.parseCompletion(out);
 	}
 
 	/** The last {@link TIMEOUT_LOG_TAIL_LINES} lines of a detached step's log, or `null` when the log
@@ -728,11 +730,11 @@ export class StepRunner {
 		// which readCompletedLog then accepted as the step's real (empty) output. Exit 0 with empty
 		// stdout remains a legitimate read of a genuinely empty log.
 		return withTimeout(
-			this.sandbox.runCommand(`bash -c ${shellQuote(`cat ${logPath} 2>/dev/null`)}`),
+			this.execute(`bash -c ${shellQuote(`cat ${logPath} 2>/dev/null`)}`),
 			POLL_CAP_MS,
 			"log cat read",
 		)
-			.then((res) => ((res.exitCode ?? 0) === 0 ? (res.stdout ?? "") : null))
+			.then((res) => (this.exitCode(res) === 0 ? (res.stdout ?? "") : null))
 			.catch(() => null);
 	}
 
@@ -742,26 +744,21 @@ export class StepRunner {
 	 *  failed rm just leaves the same orphaned files the sandbox teardown reclaims anyway. */
 	private async removeDetachedFiles(logPath: string, donePath: string): Promise<void> {
 		await withTimeout(
-			this.sandbox.runCommand(`bash -c ${shellQuote(`rm -f ${logPath} ${donePath}`)}`),
+			this.execute(`bash -c ${shellQuote(`rm -f ${logPath} ${donePath}`)}`),
 			POLL_CAP_MS,
 			"detached file cleanup",
 		).catch(() => undefined);
 	}
 
 	/** Shared post-step bookkeeping: record the step, echo output (unless silent), enforce exit code. */
-	private finishStep(
-		label: string,
-		started: number,
-		result: CommandResult,
-		opts: StepOptions,
-	): CommandResult {
+	private finishStep(label: string, started: number, result: Result, opts: StepOptions): Result {
 		const elapsedMs = Math.round(performance.now() - started);
 		const elapsedS = (elapsedMs / 1000).toFixed(1);
 		this.stepLog.push({
 			phase: this.phase,
 			label,
 			ms: elapsedMs,
-			exitCode: result.exitCode,
+			exitCode: this.exitCode(result),
 		});
 
 		if (result.stdout && !opts.silent) {
@@ -770,21 +767,104 @@ export class StepRunner {
 		if (result.stderr && !opts.silent) {
 			process.stderr.write(result.stderr.endsWith("\n") ? result.stderr : `${result.stderr}\n`);
 		}
-		console.log(`=== [${label}] exit ${result.exitCode} in ${elapsedS}s ===`);
+		console.log(`=== [${label}] exit ${this.describeExit(result)} in ${elapsedS}s ===`);
 
-		if (result.exitCode !== 0 && !opts.allowFailure) {
+		if (this.exitCode(result) !== 0 && !opts.allowFailure) {
 			// A silent step withheld its output above; surface it now so the failure is debuggable. The
 			// detached transport merges stderr into stdout (2>&1), so fall back to stdout when no stderr.
 			if (opts.silent) {
 				const tail = result.stderr || result.stdout;
 				if (tail) process.stderr.write(tail.endsWith("\n") ? tail : `${tail}\n`);
 			}
-			throw new GapError(`Step "${label}" failed with exit code ${result.exitCode}`, {
+			const code = this.exitCode(result);
+			if (code === null) throw new Error(`Step "${label}" failed: ${this.describeExit(result)}`);
+			throw new GapError(`Step "${label}" failed with exit code ${this.describeExit(result)}`, {
 				kind: "step-failed",
 				step: label,
-				exitCode: result.exitCode,
+				exitCode: code,
 			});
 		}
 		return result;
+	}
+}
+
+/** Legacy execution facade retained until the last provider migration. */
+export class StepRunner extends StepExecution<CommandResult> {
+	constructor(
+		private readonly sandbox: SandboxHandle,
+		private readonly transport: ProviderTransport = DEFAULT_TRANSPORT,
+		sleep: (ms: number) => Promise<void> = delay,
+		passPolicy: PtsPassPolicy = DEFAULT_PTS_PASS_POLICY,
+	) {
+		super(sandbox.filesystem, sleep, passPolicy);
+	}
+	protected execute(command: string): Promise<CommandResult> {
+		return this.sandbox.runCommand(command);
+	}
+	protected async launch(command: string): Promise<void> {
+		const daemonized = `nohup bash -c ${shellQuote(command)} </dev/null >/dev/null 2>&1 &`;
+		const launch = `nohup bash -c ${shellQuote(daemonized)} </dev/null >/dev/null 2>&1 & echo launched`;
+		await this.sandbox.runCommand(`bash -c ${shellQuote(launch)}`, { background: true });
+	}
+	protected detached(timeoutMs: number): boolean {
+		return selectTransport(this.transport, timeoutMs) === "detached";
+	}
+	protected exitCode(result: CommandResult): number {
+		return result.exitCode;
+	}
+	protected describeExit(result: CommandResult): string {
+		return String(result.exitCode);
+	}
+	protected completed(exitCode: number | null, stdout: string): CommandResult {
+		return { exitCode: exitCode ?? 1, stdout };
+	}
+}
+
+/** Runs workload steps directly on a driver session, retaining its full execution result. */
+export class SessionStepRunner extends StepExecution<ExecResult> {
+	constructor(
+		private readonly session: SandboxSession,
+		private readonly execution: ExecutionPolicy,
+		sleep: (ms: number) => Promise<void> = delay,
+		passPolicy: PtsPassPolicy = DEFAULT_PTS_PASS_POLICY,
+	) {
+		super(session.files, sleep, passPolicy);
+	}
+	protected execute(command: string): Promise<ExecResult> {
+		return this.session.exec(command);
+	}
+	protected launch(command: string): Promise<void> {
+		return launchDetached(this.session, command);
+	}
+	protected detached(timeoutMs: number): boolean {
+		return selectExecutionRoute(this.execution, timeoutMs) === "durable";
+	}
+	protected exitCode(result: ExecResult): number | null {
+		return result.exit.kind === "exited" ? result.exit.code : null;
+	}
+	protected describeExit(result: ExecResult): string {
+		switch (result.exit.kind) {
+			case "exited":
+				return String(result.exit.code);
+			case "signalled":
+				return `signal ${result.exit.signal}`;
+			case "unknown":
+				return `unknown (${result.exit.detail})`;
+		}
+	}
+	protected override parseCompletion(raw: string): number | null {
+		return /^(?:0|[1-9][0-9]*)$/.test(raw) && Number(raw) <= 255 ? Number(raw) : null;
+	}
+	protected completed(code: number | null, stdout: string, durationMs: number): ExecResult {
+		return {
+			exit:
+				code === null
+					? { kind: "unknown", detail: "invalid detached completion status" }
+					: { kind: "exited", code },
+			stdout,
+			stderr: "",
+			durationMs,
+			truncated: false,
+		};
 	}
 }

--- a/packages/harness/src/lib/lifecycle.ts
+++ b/packages/harness/src/lib/lifecycle.ts
@@ -1,3 +1,5 @@
+import type { CreateRequest, SandboxDriver, SandboxSession } from "@sandbox-benchmarks/driver";
+import { succeeded } from "@sandbox-benchmarks/driver";
 /**
  * Lifecycle & control-plane measurement — the harness-measured Dimensions PTS cannot see.
  *
@@ -28,7 +30,7 @@ import type {
 import { aggregate, HARNESS_METRIC_IDS } from "@sandbox-benchmarks/schema";
 import { gapCauseOf } from "./gap-cause.ts";
 import { now as defaultNow, time } from "./internal.ts";
-import { neverReadyReason, waitUntilReady } from "./readiness.ts";
+import { neverReadyReason, waitForReadiness } from "./readiness.ts";
 import { createOwnedSandbox } from "./sandbox-owner.ts";
 
 /**
@@ -158,6 +160,78 @@ export async function measureLifecycle(
 	compute: LifecycleCompute,
 	options: MeasureLifecycleOptions,
 ): Promise<LifecycleMeasurement> {
+	const snapshots = compute.snapshot;
+	return measureCycle(
+		{
+			create: () => compute.sandbox.create(options.createOptions),
+			exec: (sandbox, command) => sandbox.runCommand(command),
+			ready: async (sandbox) => (await sandbox.runCommand("echo ok")).exitCode === 0,
+			info: (sandbox) => sandbox.getInfo?.bind(sandbox),
+			list: compute.sandbox.list?.bind(compute.sandbox),
+			snapshot:
+				snapshots === undefined
+					? undefined
+					: {
+							create: async (sandbox) => (await snapshots.create(sandbox.sandboxId)).id,
+							delete: snapshots.delete.bind(snapshots),
+						},
+		},
+		options,
+	);
+}
+
+/** Measure a session directly without changing timing boundaries or sample eligibility. */
+export function measureDriverLifecycle(
+	driver: SandboxDriver,
+	request: CreateRequest,
+	options: Omit<MeasureLifecycleOptions, "createOptions">,
+): Promise<LifecycleMeasurement> {
+	const probes = driver.probes;
+	const info = (probes?.describe ?? probes?.observe)?.bind(probes);
+	const snapshots = driver.snapshots;
+	const list = probes?.list?.bind(probes);
+	return measureCycle<SandboxSession>(
+		{
+			create: (signal) => driver.create(request, { signal }),
+			exec: (session, command) => session.exec(command),
+			ready: async (session) => succeeded((await session.exec("echo ok")).exit),
+			info: (session) => (info === undefined ? undefined : () => info(session.sandboxRef)),
+			list:
+				list === undefined
+					? undefined
+					: async () => {
+							const result = await list();
+							if (!Array.isArray(result))
+								throw new Error("driver probes.list returned a non-array result");
+							return result;
+						},
+			snapshot:
+				snapshots === undefined
+					? undefined
+					: {
+							create: async (session) => (await snapshots.create(session)).snapshotId,
+							delete: (id) => snapshots.delete(id),
+						},
+		},
+		options,
+	);
+}
+
+interface CycleOperations<Session extends { destroy(): Promise<unknown> }> {
+	create(signal: AbortSignal): Promise<Session>;
+	exec(session: Session, command: string): Promise<unknown>;
+	ready(session: Session): Promise<boolean>;
+	info(session: Session): (() => Promise<unknown>) | undefined;
+	list: (() => Promise<unknown>) | undefined;
+	snapshot:
+		| { create(session: Session): Promise<string>; delete(id: string): Promise<unknown> }
+		| undefined;
+}
+
+async function measureCycle<Session extends { destroy(): Promise<unknown> }>(
+	operations: CycleOperations<Session>,
+	options: Omit<MeasureLifecycleOptions, "createOptions">,
+): Promise<LifecycleMeasurement> {
 	const { provider } = options;
 	const execCommand = options.execCommand ?? "true";
 	// `?? 1` only catches undefined; a NaN/Infinity slipping through would make `i < samples` never
@@ -224,7 +298,9 @@ export async function measureLifecycle(
 	// usable yet (the readiness loop below measures when it becomes so). A failure has no sandbox to tear
 	// down, so it rejects and the caller records the failed cold-start cycle.
 	const t0 = clock();
-	const sandbox = await createOwnedSandbox(() => compute.sandbox.create(options.createOptions));
+	const sandbox = await createOwnedSandbox(operations.create, {
+		destroy: (destroy, options) => destroy(options),
+	});
 	const createdAt = clock();
 	sample(HARNESS_METRIC_IDS.spawn, floor(createdAt - t0));
 
@@ -232,7 +308,7 @@ export async function measureLifecycle(
 		// Readiness: retry a trivial exec until it returns exitCode 0 — the FIRST success marks a usable
 		// sandbox. cold_start (t0→ready) is the honest cold start spawn alone can't see; first_exec
 		// (create→ready) isolates the readiness wait. A probe that throws counts as not-ready and retries.
-		const readiness = await waitUntilReady(sandbox, {
+		const readiness = await waitForReadiness(() => operations.ready(sandbox), {
 			maxAttempts: readinessMaxAttempts,
 			retryDelayMs: readinessRetryDelayMs,
 			probeTimeoutMs: READINESS_PROBE_TIMEOUT_MS,
@@ -262,14 +338,14 @@ export async function measureLifecycle(
 			fail(HARNESS_METRIC_IDS.exec, reason);
 			// One gap, not `controlPlaneSamples` of them: the live path records a gap per failed probe, but
 			// no probe ran here and N copies of one fact is noise, not fidelity.
-			if (sandbox.getInfo) fail(HARNESS_METRIC_IDS.controlPlaneInfo, reason);
+			if (operations.info(sandbox)) fail(HARNESS_METRIC_IDS.controlPlaneInfo, reason);
 			else skip(HARNESS_METRIC_IDS.controlPlaneInfo, NO_INFO_OP, NO_INFO_CAUSE);
 			if (wantPayload) fail(HARNESS_METRIC_IDS.execPayload64k, reason);
 			else skip(HARNESS_METRIC_IDS.execPayload64k, PAYLOAD_DISABLED, DISABLED_CAUSE);
-			if (compute.sandbox.list) fail(HARNESS_METRIC_IDS.controlPlaneList, reason);
+			if (operations.list) fail(HARNESS_METRIC_IDS.controlPlaneList, reason);
 			else skip(HARNESS_METRIC_IDS.controlPlaneList, NO_LIST_OP, NO_LIST_CAUSE);
 			if (!wantSnapshot) skip(HARNESS_METRIC_IDS.snapshot, SNAPSHOT_DISABLED, DISABLED_CAUSE);
-			else if (!compute.snapshot)
+			else if (!operations.snapshot)
 				skip(HARNESS_METRIC_IDS.snapshot, NO_SNAPSHOT_OP, NO_SNAPSHOT_CAUSE);
 			else fail(HARNESS_METRIC_IDS.snapshot, reason);
 			return { samples, gaps };
@@ -279,11 +355,11 @@ export async function measureLifecycle(
 		}
 
 		// Exec: a trivial command round-trip — the exec-path latency floor, independent of the work done.
-		await step(HARNESS_METRIC_IDS.exec, () => sandbox.runCommand(execCommand));
+		await step(HARNESS_METRIC_IDS.exec, () => operations.exec(sandbox, execCommand));
 
 		// Payload: a 64KiB-stdout exec — exec overhead including output streaming, above the trivial floor.
 		if (wantPayload) {
-			await step(HARNESS_METRIC_IDS.execPayload64k, () => sandbox.runCommand(PAYLOAD_CMD));
+			await step(HARNESS_METRIC_IDS.execPayload64k, () => operations.exec(sandbox, PAYLOAD_CMD));
 		} else {
 			skip(HARNESS_METRIC_IDS.execPayload64k, PAYLOAD_DISABLED, DISABLED_CAUSE);
 		}
@@ -291,7 +367,7 @@ export async function measureLifecycle(
 		// Control-plane read: getInfo, sampled within this one (cheap) sandbox to build a distribution
 		// without paying a fresh spawn/teardown per Sample. Absent on a DriverModule that only exposes
 		// observe/list/snapshot through optional port members — skip rather than invent a probe.
-		const getInfo = sandbox.getInfo?.bind(sandbox);
+		const getInfo = operations.info(sandbox);
 		if (getInfo) {
 			for (let i = 0; i < controlPlaneSamples; i++) {
 				await step(HARNESS_METRIC_IDS.controlPlaneInfo, () => getInfo());
@@ -302,7 +378,7 @@ export async function measureLifecycle(
 
 		// Control-plane enumeration: list, when the SDK exposes it. Bind `this` so the captured method
 		// keeps its receiver, and narrow on a const (property narrowing wouldn't survive the closure).
-		const listSandboxes = compute.sandbox.list?.bind(compute.sandbox);
+		const listSandboxes = operations.list;
 		if (listSandboxes) {
 			// Sampled `controlPlaneSamples` times like getInfo — list is a control-plane read too, so the
 			// configured probe depth governs both reads, not just info.
@@ -315,19 +391,19 @@ export async function measureLifecycle(
 
 		// Snapshot: when requested and the SDK exposes a snapshot manager. Best-effort delete afterwards
 		// so a measured snapshot never leaks into the account.
-		const snapshots = compute.snapshot;
+		const snapshots = operations.snapshot;
 		if (!wantSnapshot) {
 			skip(HARNESS_METRIC_IDS.snapshot, SNAPSHOT_DISABLED, DISABLED_CAUSE);
 		} else if (!snapshots) {
 			skip(HARNESS_METRIC_IDS.snapshot, NO_SNAPSHOT_OP, NO_SNAPSHOT_CAUSE);
 		} else {
 			try {
-				const snap = await time(() => snapshots.create(sandbox.sandboxId));
+				const snap = await time(() => snapshots.create(sandbox));
 				sample(HARNESS_METRIC_IDS.snapshot, snap.ms);
 				// Best-effort cleanup: a failed delete shouldn't fail the cycle, but it can leak a snapshot,
 				// so surface it (mirrors the destroy-failure warning) instead of swallowing it silently.
-				await snapshots.delete(snap.value.id).catch((err) => {
-					console.warn(`[lifecycle] snapshot cleanup failed (${snap.value.id}): ${reasonOf(err)}`);
+				await snapshots.delete(snap.value).catch((err) => {
+					console.warn(`[lifecycle] snapshot cleanup failed (${snap.value}): ${reasonOf(err)}`);
 				});
 			} catch (err) {
 				fail(HARNESS_METRIC_IDS.snapshot, reasonOf(err));

--- a/packages/harness/src/lib/readiness.ts
+++ b/packages/harness/src/lib/readiness.ts
@@ -92,6 +92,17 @@ export async function waitUntilReady(
 	sandbox: ReadinessProbeSandbox,
 	options: WaitUntilReadyOptions = {},
 ): Promise<ReadinessResult> {
+	return waitForReadiness(
+		async () => (await sandbox.runCommand(READINESS_CMD)).exitCode === 0,
+		options,
+	);
+}
+
+/** Shared bounded first-success loop; operational driver readiness remains a separate policy. */
+export async function waitForReadiness(
+	probeReady: () => Promise<boolean>,
+	options: WaitUntilReadyOptions = {},
+): Promise<ReadinessResult> {
 	const maxAttempts = finiteOr(options.maxAttempts, DEFAULT_READINESS_ATTEMPTS, 1);
 	const retryDelayMs = finiteOr(options.retryDelayMs, DEFAULT_READINESS_RETRY_DELAY_MS, 0);
 	const probeTimeoutMs = finiteOr(options.probeTimeoutMs, DEFAULT_READINESS_PROBE_TIMEOUT_MS, 1);
@@ -99,7 +110,7 @@ export async function waitUntilReady(
 
 	for (let attempt = 1; attempt <= maxAttempts; attempt++) {
 		try {
-			const probe = sandbox.runCommand(READINESS_CMD);
+			const probe = probeReady();
 			// A timed-out probe leaves its exec dangling: swallow a late rejection here so an abandoned
 			// attempt can't surface as an unhandled rejection while the loop is still retrying.
 			probe.catch(() => {});
@@ -108,7 +119,7 @@ export async function waitUntilReady(
 				probeTimeoutMs,
 				`readiness probe timed out after ${Math.round(probeTimeoutMs / 1000)}s`,
 			);
-			if (result.exitCode === 0) return { ready: true, attempts: maxAttempts };
+			if (result) return { ready: true, attempts: maxAttempts };
 		} catch {
 			// Not ready — fall through to the retry.
 		}

--- a/packages/harness/src/lib/sandbox-owner.ts
+++ b/packages/harness/src/lib/sandbox-owner.ts
@@ -12,6 +12,7 @@ import type { EventEmitter } from "node:events";
 
 interface DestroyableSandbox {
 	readonly sandboxId?: string;
+	readonly sandboxRef?: { readonly id: string };
 	destroy(): Promise<unknown>;
 }
 
@@ -296,7 +297,7 @@ export function createOwnedSandbox<T extends DestroyableSandbox>(
 		.then(() => create(createCancellation.signal))
 		.then(
 			(sandbox) => {
-				entry.sandboxId = sandbox.sandboxId;
+				entry.sandboxId = sandbox.sandboxRef?.id ?? sandbox.sandboxId;
 				const originalDestroy = sandbox.destroy;
 				const providerDestroy = (operationOptions?: OwnedOperationOptions): Promise<unknown> =>
 					Reflect.apply(

--- a/packages/harness/src/lib/session-execute.test.ts
+++ b/packages/harness/src/lib/session-execute.test.ts
@@ -1,0 +1,116 @@
+import { describe, expect, test } from "bun:test";
+import type { ExecResult, SandboxSession } from "@sandbox-benchmarks/driver";
+import { MIN, SessionStepRunner } from "./execute.ts";
+
+function result(stdout = "", code = 0): ExecResult {
+	return { exit: { kind: "exited", code }, stdout, stderr: "", durationMs: 1, truncated: false };
+}
+function session(overrides: Partial<SandboxSession> = {}): SandboxSession {
+	return {
+		sandboxRef: { provider: "e2b", id: "isession" },
+		artifact: { kind: "none" },
+		native: {},
+		exec: async () => result(),
+		destroy: async () => {},
+		...overrides,
+	};
+}
+
+describe("session execution", () => {
+	test("preserves the entire direct execution result and unknown exits", async () => {
+		const unknown: ExecResult = {
+			...result("partial output"),
+			exit: { kind: "unknown", detail: "connection closed" },
+			truncated: true,
+		};
+		const runner = new SessionStepRunner(session({ exec: async () => unknown }), {
+			syncCapMs: null,
+			durable: "none",
+		});
+		expect(await runner.step("probe", "true", MIN, { allowFailure: true, silent: true })).toBe(
+			unknown,
+		);
+		expect(runner.stepLog[0]?.exitCode).toBeNull();
+		await expect(runner.step("required", "true", MIN, { silent: true })).rejects.toThrow(
+			"unknown (connection closed)",
+		);
+	});
+	test("reports a signal without inventing a numeric exit", async () => {
+		const runner = new SessionStepRunner(
+			session({
+				exec: async () => ({ ...result(), exit: { kind: "signalled", signal: "SIGTERM" } }),
+			}),
+			{ syncCapMs: null, durable: "none" },
+		);
+		await expect(runner.step("killed", "true", MIN)).rejects.toThrow("signal SIGTERM");
+		expect(runner.stepLog[0]?.exitCode).toBeNull();
+	});
+	test("launches exactly once and retains combined logs with transient readback retries", async () => {
+		const launched: string[] = [];
+		let reads = 0;
+		const delays: number[] = [];
+		const runner = new SessionStepRunner(
+			session({
+				launch: async (command) => {
+					launched.push(command);
+				},
+				files: {
+					exists: async () => true,
+					readFile: async (path) => {
+						if (path.endsWith(".done")) return "7";
+						if (++reads === 1) throw new Error("transient file read");
+						return "stdout and stderr\n";
+					},
+					writeText: async () => {},
+				},
+			}),
+			{ syncCapMs: MIN, durable: "native-launch" },
+			async (ms) => {
+				delays.push(ms);
+			},
+		);
+		const done = await runner.step("durable", "echo stdout; echo stderr >&2; exit 7", MIN, {
+			allowFailure: true,
+			silent: true,
+		});
+		expect(launched).toHaveLength(1);
+		expect(launched[0]).not.toContain("nohup");
+		expect(launched[0]).toContain("2>&1");
+		expect(done.exit).toEqual({ kind: "exited", code: 7 });
+		expect(done.stdout).toBe("stdout and stderr\n");
+		expect(delays).toEqual([2000]);
+	});
+	test("uses the driver shell launch once when no native launch exists", async () => {
+		const commands: string[] = [];
+		const runner = new SessionStepRunner(
+			session({
+				exec: async (command) => {
+					commands.push(command);
+					if (command.includes("cat /tmp") && command.includes(".done")) return result("0");
+					return result("output");
+				},
+			}),
+			{ syncCapMs: MIN, durable: "shell-detach" },
+		);
+		await runner.step("shell", "true", MIN, { silent: true });
+		expect(commands.filter((command) => command.includes("nohup"))).toHaveLength(1);
+		expect(commands.find((command) => command.includes("nohup"))?.match(/nohup/g)).toHaveLength(1);
+	});
+	test("does not fabricate a numeric failure from a malformed done file", async () => {
+		const runner = new SessionStepRunner(
+			session({
+				launch: async () => {},
+				files: {
+					exists: async () => true,
+					readFile: async (path) => (path.endsWith(".done") ? "7garbage" : "partial log"),
+					writeText: async () => {},
+				},
+			}),
+			{ syncCapMs: MIN, durable: "native-launch" },
+		);
+		const done = await runner.step("malformed", "true", MIN, { allowFailure: true, silent: true });
+		expect(done.exit).toEqual({ kind: "unknown", detail: "invalid detached completion status" });
+		expect(done.stdout).toBe("partial log");
+		expect(runner.stepLog[0]?.exitCode).toBeNull();
+	});
+});

--- a/packages/harness/src/lib/session-lifecycle.test.ts
+++ b/packages/harness/src/lib/session-lifecycle.test.ts
@@ -1,0 +1,163 @@
+import { describe, expect, test } from "bun:test";
+import type {
+	CreateRequest,
+	ExecResult,
+	SandboxDriver,
+	SandboxSession,
+} from "@sandbox-benchmarks/driver";
+import { HARNESS_METRIC_IDS, TARGET_SPEC } from "@sandbox-benchmarks/schema";
+import { measureDriverLifecycle } from "./lifecycle.ts";
+
+const request: CreateRequest = { spec: TARGET_SPEC, artifact: { kind: "none" }, deadlineMs: 1000 };
+const exited = (code: number): ExecResult => ({
+	exit: { kind: "exited", code },
+	stdout: "",
+	stderr: "",
+	durationMs: 1,
+	truncated: false,
+});
+
+describe("native lifecycle measurements", () => {
+	test("preserves measurement boundaries, resolved failures, binding and snapshot ownership", async () => {
+		const order: string[] = [];
+		let clock = 0;
+		const session: SandboxSession = {
+			sandboxRef: { provider: "e2b", id: "itest" },
+			artifact: request.artifact,
+			native: {},
+			exec: async (command) => {
+				order.push(command);
+				return exited(command === "echo ok" ? 0 : 7);
+			},
+			destroy: async () => {
+				order.push("destroy");
+			},
+		};
+		const driver: SandboxDriver = {
+			async create(input, options) {
+				expect(input).toBe(request);
+				expect(options?.signal).toBeInstanceOf(AbortSignal);
+				order.push("create");
+				return session;
+			},
+			probes: {
+				async observe() {
+					throw new Error("describe should take precedence");
+				},
+				async describe(ref) {
+					expect(driver.probes).toBe(this);
+					expect(ref).toEqual(session.sandboxRef);
+					order.push("describe");
+				},
+				async list() {
+					expect(driver.probes).toBe(this);
+					order.push("list");
+					return [];
+				},
+			},
+			snapshots: {
+				async create(owned) {
+					expect(owned.sandboxRef).toEqual(session.sandboxRef);
+					order.push("snapshot");
+					return { snapshotId: "snapshot-1" };
+				},
+				async delete(id) {
+					expect(id).toBe("snapshot-1");
+					order.push("delete snapshot");
+				},
+			},
+		};
+		const measurement = await measureDriverLifecycle(driver, request, {
+			provider: "e2b",
+			controlPlaneSamples: 2,
+			now: () => ++clock,
+		});
+		expect(measurement.gaps).toEqual([]);
+		expect(measurement.samples).toHaveLength(11);
+		expect(
+			measurement.samples.find((s) => s.operation === HARNESS_METRIC_IDS.spawn)?.durationMs,
+		).toBe(1);
+		expect(
+			measurement.samples.find((s) => s.operation === HARNESS_METRIC_IDS.coldStart)?.durationMs,
+		).toBe(2);
+		expect(order).toEqual([
+			"create",
+			"echo ok",
+			"true",
+			"head -c 65536 /dev/zero | tr '\\0' 'a'",
+			"describe",
+			"describe",
+			"list",
+			"list",
+			"snapshot",
+			"delete snapshot",
+			"destroy",
+		]);
+	});
+
+	test("unknown readiness creates failed readiness gaps and preserves disabled/absent gaps", async () => {
+		let destroyed = false;
+		const driver: SandboxDriver = {
+			create: async () => ({
+				sandboxRef: { provider: "e2b", id: "itest" },
+				artifact: request.artifact,
+				native: {},
+				exec: async () => ({ ...exited(0), exit: { kind: "unknown", detail: "lost status" } }),
+				destroy: async () => {
+					destroyed = true;
+				},
+			}),
+		};
+		const measurement = await measureDriverLifecycle(driver, request, {
+			provider: "e2b",
+			readinessMaxAttempts: 1,
+			payload: false,
+			snapshot: false,
+		});
+		expect(measurement.samples.map((s) => s.operation)).toEqual([
+			HARNESS_METRIC_IDS.spawn,
+			HARNESS_METRIC_IDS.teardown,
+		]);
+		expect(measurement.gaps.find((g) => g.id === HARNESS_METRIC_IDS.coldStart)?.outcome).toBe(
+			"failed",
+		);
+		expect(measurement.gaps.find((g) => g.id === HARNESS_METRIC_IDS.execPayload64k)?.outcome).toBe(
+			"skipped",
+		);
+		expect(destroyed).toBe(true);
+	});
+
+	test("uses truthful observe fallback and rejects malformed list responses", async () => {
+		let observed = 0;
+		const driver: SandboxDriver = {
+			create: async () => ({
+				sandboxRef: { provider: "e2b", id: "itest" },
+				artifact: request.artifact,
+				native: {},
+				exec: async () => exited(0),
+				destroy: async () => {},
+			}),
+			probes: {
+				async observe() {
+					expect(driver.probes).toBe(this);
+					observed++;
+					return { state: "running" };
+				},
+				async list() {
+					return { items: [] };
+				},
+			},
+		};
+		const measurement = await measureDriverLifecycle(driver, request, {
+			provider: "e2b",
+			controlPlaneSamples: 2,
+		});
+		expect(observed).toBe(2);
+		expect(
+			measurement.gaps.filter((g) => g.id === HARNESS_METRIC_IDS.controlPlaneList),
+		).toHaveLength(2);
+		expect(
+			measurement.samples.filter((s) => s.operation === HARNESS_METRIC_IDS.controlPlaneList),
+		).toHaveLength(0);
+	});
+});

--- a/packages/harness/src/session-operations.test.ts
+++ b/packages/harness/src/session-operations.test.ts
@@ -1,0 +1,147 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { mkdtempSync, readdirSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type {
+	DriverModule,
+	ExecResult,
+	ProviderId,
+	SandboxDriver,
+	SandboxSession,
+} from "@sandbox-benchmarks/driver";
+import { bakedArtifactName, TARGET_SPEC } from "@sandbox-benchmarks/schema";
+import { TOOLCHAIN_IMAGE_NAME, TOOLCHAIN_VERSION } from "@sandbox-benchmarks/schema/toolchain";
+import { executeSuite, withSandboxWork } from "./index.ts";
+
+const roots: string[] = [];
+afterEach(() => {
+	for (const root of roots.splice(0)) rmSync(root, { recursive: true, force: true });
+});
+const result = (stdout = ""): ExecResult => ({
+	exit: { kind: "exited", code: 0 },
+	stdout,
+	stderr: "",
+	durationMs: 1,
+	truncated: false,
+});
+const artifact = { kind: "baked", ref: bakedArtifactName("e2b", "version") } as const;
+function fixture(exec: SandboxSession["exec"]) {
+	const calls: string[] = [];
+	const session: SandboxSession = {
+		sandboxRef: { provider: "e2b", id: "itest" },
+		artifact,
+		native: {},
+		exec,
+		async destroy() {
+			calls.push("destroy");
+		},
+	};
+	const driver: SandboxDriver = {
+		async create(request, options) {
+			expect(request.artifact).toEqual(artifact);
+			expect(request.deadlineMs).toBe(1000);
+			expect(options?.signal).toBeInstanceOf(AbortSignal);
+			calls.push("create");
+			return session;
+		},
+	};
+	const module: DriverModule<ProviderId> = {
+		id: "e2b",
+		driver: () => driver,
+		provenance: { packageName: "fixture", version: "1" },
+		createBudget: { owner: "harness", timeoutMs: 1000 },
+		execution: { syncCapMs: null, durable: "none" },
+		readiness: { startup: "create-returns-ready" },
+	};
+	return { allocation: { module, driver, request: { artifact, spec: TARGET_SPEC } }, calls };
+}
+
+describe("declarative session operations", () => {
+	test("persists request evidence before readiness and observed evidence before a disk gap", async () => {
+		const root = mkdtempSync(join(tmpdir(), "session-suite-"));
+		roots.push(root);
+		const { allocation, calls } = fixture(async (command) => {
+			if (command === "sh -c 'exit 0'") {
+				const files = readdirSync(root);
+				expect(files).toHaveLength(1);
+				expect(readFileSync(join(root, files[0] ?? ""), "utf8")).toContain("request-fallback");
+			}
+			if (command.includes("/toolchain-manifest.json"))
+				return result(
+					JSON.stringify({ image_name: TOOLCHAIN_IMAGE_NAME, image_version: TOOLCHAIN_VERSION }),
+				);
+			if (command.includes("df -Pk")) return result("1");
+			return result();
+		});
+		await executeSuite({
+			allocation,
+			runId: "session-test",
+			suiteName: "system",
+			resultsDir: root,
+		});
+		expect(calls).toEqual(["create", "destroy"]);
+		const contents = readdirSync(root)
+			.map((name) => readFileSync(join(root, name), "utf8"))
+			.join("\n");
+		expect(contents).toContain("guest-fingerprint");
+		expect(contents).toContain("disk-shortfall");
+		expect(contents).toContain("itest");
+	});
+	test("readiness failure retains request attribution and always destroys", async () => {
+		const root = mkdtempSync(join(tmpdir(), "session-suite-"));
+		roots.push(root);
+		const { allocation, calls } = fixture(async () => {
+			throw new Error("not ready");
+		});
+		await expect(
+			executeSuite({ allocation, runId: "session-test", suiteName: "system", resultsDir: root }),
+		).rejects.toThrow("not ready");
+		expect(calls).toEqual(["create", "destroy"]);
+		expect(
+			readdirSync(root)
+				.map((name) => readFileSync(join(root, name), "utf8"))
+				.join("\n"),
+		).toContain("request-fallback");
+	});
+	test("managed work exposes native results and tears down after workload failure", async () => {
+		const { allocation, calls } = fixture(async () => result());
+		const failure = new Error("work failed");
+		await expect(
+			withSandboxWork(allocation, async ({ session, runner }) => {
+				expect(session.sandboxRef.id).toBe("itest");
+				expect((await runner.step("work", "true", 500)).exit).toEqual({ kind: "exited", code: 0 });
+				throw failure;
+			}),
+		).rejects.toBe(failure);
+		expect(calls).toEqual(["create", "destroy"]);
+	});
+	test("managed work reclaims a create that resolves after its budget", async () => {
+		const { allocation } = fixture(async () => result());
+		const pending = Promise.withResolvers<SandboxSession>();
+		let destroyed = false;
+		let worked = false;
+		const scope = withSandboxWork(
+			{
+				...allocation,
+				module: { ...allocation.module, createBudget: { owner: "harness", timeoutMs: 1 } },
+				driver: { create: () => pending.promise },
+			},
+			async () => {
+				worked = true;
+			},
+		);
+		await expect(scope).rejects.toThrow("Sandbox creation timed out");
+		pending.resolve({
+			sandboxRef: { provider: "e2b", id: "ilate" },
+			artifact,
+			native: {},
+			exec: async () => result(),
+			destroy: async () => {
+				destroyed = true;
+			},
+		});
+		for (let i = 0; i < 10 && !destroyed; i++) await Bun.sleep(1);
+		expect(destroyed).toBe(true);
+		expect(worked).toBe(false);
+	});
+});

--- a/packages/providers/package.json
+++ b/packages/providers/package.json
@@ -5,7 +5,8 @@
   "type": "module",
   "exports": {
     ".": "./src/index.ts",
-    "./config": "./src/config.ts"
+    "./config": "./src/config.ts",
+    "./support": "./src/support.ts"
   },
   "scripts": {
     "test": "bun test",

--- a/packages/providers/src/support.ts
+++ b/packages/providers/src/support.ts
@@ -1,0 +1,3 @@
+// Legacy execution helpers without the provider registry or vendor SDK imports.
+export { sanitizeEvidenceDetail, sanitizeProviderResponse } from "./lib/cost-evidence.ts";
+export { isRetryableCreateError } from "./lib/retryable-create.ts";


### PR DESCRIPTION
E2B suite execution, lifecycle measurement, smoke validation, and driver checks now use declarative harness operations over native driver sessions. The harness owns allocation budgets, readiness, execution, evidence collection, and teardown. Durable steps launch once; unknown and signalled exits retain their meaning.

Native imports avoid loading unrelated legacy SDKs. Remaining legacy suites load their registry on demand. The ADR records the operation boundaries and measurement contract; package contexts define the shared vocabulary.

Validation: repository tests and checks passed. Live E2B driver/smoke checks, lifecycle measurements, teardown, and a single-pass STREAM run passed. Default STREAM convergence still reaches the existing time budget; this change preserves that policy.
