### PR TITLE
Move Tama harness execution onto native driver sessions

### DIFF
--- a/apps/cli/src/bin/driver-check.ts
+++ b/apps/cli/src/bin/driver-check.ts
@@ -38,6 +38,7 @@ import {
 	createOwnedDriverSession,
 	openDriver,
 	sessionHandle,
+	usesSessionOperations,
 } from "../lib/driver-run.ts";
 
 type CheckStatus = "pass" | "fail" | "skip";
@@ -368,13 +369,12 @@ async function run(options: Options, log: (message: string) => void): Promise<Ch
 			log,
 		);
 		if (!ready) return checks;
-		const runner =
-			module.id === "e2b"
-				? new SessionStepRunner(live, module.execution, undefined, { mode: "fixed", times: 1 })
-				: new StepRunner(sessionHandle(live), transport, undefined, {
-						mode: "fixed",
-						times: 1,
-					});
+		const runner = usesSessionOperations(options.provider)
+			? new SessionStepRunner(live, module.execution, undefined, { mode: "fixed", times: 1 })
+			: new StepRunner(sessionHandle(live), transport, undefined, {
+					mode: "fixed",
+					times: 1,
+				});
 		await driveSession(live, options, transport.syncCapMs, runner, checks, log);
 	} finally {
 		if (options.keep) {

--- a/apps/cli/src/lib/driver-run.ts
+++ b/apps/cli/src/lib/driver-run.ts
@@ -341,6 +341,11 @@ export function usesDriverSuite(providerId: string, driverPathFlag = false): boo
 	return driverPathFlag || isDriverProviderId(providerId);
 }
 
+/** Providers whose consumers have moved to declarative session operations in the migration stack. */
+export function usesSessionOperations(id: DriverProviderId): boolean {
+	return id === "e2b" || id === "tama";
+}
+
 /**
  * Split a module's declared create budget into the three numbers the harness and the request need.
  *
@@ -455,7 +460,7 @@ export async function benchmarkDriverLifecycle(
 	options: BenchmarkLifecycleOptions = {},
 ): Promise<LifecycleBenchmark> {
 	const opened = await openDriver(id);
-	if (id === "e2b")
+	if (usesSessionOperations(id))
 		return measureLifecycleOperation(
 			{
 				module: opened.module,
@@ -534,7 +539,7 @@ export async function runDriverSuite(options: RunSuiteOptions): Promise<void> {
 		throw error;
 	}
 
-	if (providerName === "e2b") {
+	if (usesSessionOperations(providerName)) {
 		await executeSuite({
 			allocation: {
 				module: opened.module,

--- a/apps/cli/src/lib/smoke-run.ts
+++ b/apps/cli/src/lib/smoke-run.ts
@@ -7,7 +7,7 @@ import { TARGET_SPEC } from "@sandbox-benchmarks/schema";
 import type { SmokeResult } from "@sandbox-benchmarks/templates/smoke";
 import { runSmoke } from "@sandbox-benchmarks/templates/smoke";
 import type { ArtifactResolution } from "./driver-run.ts";
-import { openDriver, withDriverSandbox } from "./driver-run.ts";
+import { openDriver, usesSessionOperations, withDriverSandbox } from "./driver-run.ts";
 import type { ProviderTarget } from "./providers-run.ts";
 
 /** A smoke run's outcome: the probe results, plus the lifecycle error if boot/teardown threw. */
@@ -42,7 +42,7 @@ export async function bootAndSmoke(
 		}
 		switch (target.kind) {
 			case "driver":
-				if (target.id === "e2b") {
+				if (usesSessionOperations(target.id)) {
 					const opened = await openDriver(target.id, options);
 					await withSandboxWork(
 						{


### PR DESCRIPTION
Route Tama suites, lifecycle measurement, smoke validation, and driver checks through the declarative harness session operations. Preserve explicit unsupported outcomes for list and snapshot measurements.

Validation: focused CLI tests and typecheck passed; live Tama driver checks, smoke, lifecycle execution, and teardown passed.
