### PR TITLE
Move Modal gVisor and typed GPU allocations onto driver sessions

### DIFF
--- a/apps/cli/src/lib/driver-run.ts
+++ b/apps/cli/src/lib/driver-run.ts
@@ -343,7 +343,7 @@ export function usesDriverSuite(providerId: string, driverPathFlag = false): boo
 
 /** Providers whose consumers have moved to declarative session operations in the migration stack. */
 export function usesSessionOperations(id: DriverProviderId): boolean {
-	return id === "e2b" || id === "tama";
+	return id === "e2b" || id === "tama" || id === "modal-gvisor";
 }
 
 /**

--- a/apps/cli/src/lib/gpu/fleet.ts
+++ b/apps/cli/src/lib/gpu/fleet.ts
@@ -1,6 +1,7 @@
 import { mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { join, resolve } from "node:path";
-import { collectResults, withCleanupPreservingPrimaryError } from "@sandbox-benchmarks/harness";
+import { succeeded } from "@sandbox-benchmarks/driver";
+import { collectResults } from "@sandbox-benchmarks/harness";
 import type { App, Image, ModalClient, Volume } from "modal";
 import { installLineTagging, withLineTag } from "../log-prefix.ts";
 import { runPooled } from "../replicates.ts";
@@ -8,12 +9,12 @@ import type { GpuArgs } from "./args.ts";
 import { GPU_BENCHMARK } from "./config.ts";
 import { cudaGraphEvidenceFromLog, cudaGraphEvidencePassed } from "./cuda-graphs.ts";
 import {
-	createGpuSandbox,
 	gpuSandboxResources,
 	observeGpuSandbox,
 	stageCollectedEvidence,
 	stageGpuProducer,
 	vllmEnvironment,
+	withGpuSandbox,
 } from "./modal.ts";
 import { validateModelAssets } from "./prepare-models.ts";
 import type { GpuFleetFailure, GpuFleetReplicate } from "./report.ts";
@@ -51,18 +52,23 @@ async function runGpuReplicate(options: {
 	const outputDirectory = join(options.outputRoot, "replicates", `r${index}`);
 	mkdirSync(outputDirectory, { recursive: true });
 	const startedAt = new Date();
-	const sandbox = await createGpuSandbox(options.client, () =>
-		options.client.sandboxes.create(options.app, options.kernelImage, {
-			...gpuSandboxResources(args),
-			env: vllmEnvironment(args),
-			volumes: {
-				[GPU_BENCHMARK.paths.modelMount]: options.modelVolume.withMountOptions({ readOnly: true }),
+	return withGpuSandbox(
+		{
+			client: options.client,
+			app: options.app,
+			image: options.kernelImage,
+			options: {
+				...gpuSandboxResources(args),
+				env: vllmEnvironment(args),
+				volumes: {
+					[GPU_BENCHMARK.paths.modelMount]: options.modelVolume.withMountOptions({
+						readOnly: true,
+					}),
+				},
 			},
-		}),
-	);
-	return withCleanupPreservingPrimaryError(
-		async () => {
-			await sandbox.sdk.setTags({
+		},
+		async (sandbox) => {
+			await sandbox.session.native.setTags({
 				"gpu-benchmark-role": "benchmark-replicate",
 				"gpu-benchmark-replicate": String(index),
 				profile: GPU_BENCHMARK.profile.name,
@@ -70,7 +76,7 @@ async function runGpuReplicate(options: {
 				"model-volume": args.modelVolume,
 				"kernel-snapshot-image": options.kernelImage.imageId,
 			});
-			console.error(`Modal GPU sandbox r${index}: ${sandbox.sandboxId}`);
+			console.error(`Modal GPU sandbox r${index}: ${sandbox.session.sandboxRef.id}`);
 			await validateModelAssets(sandbox);
 			await stageGpuProducer(sandbox);
 			sandbox.runner.phase = "benchmark";
@@ -96,14 +102,14 @@ async function runGpuReplicate(options: {
 			} catch (error) {
 				artifactErrors.push(error);
 			}
-			if (benchmark.exitCode !== 0) {
+			if (!succeeded(benchmark.exit)) {
 				if (artifactErrors.length > 0) {
 					console.error(
-						`Artifact collection also failed after the PTS workload exited ${benchmark.exitCode}: ${artifactErrors.map(errorDetail).join("; ")}`,
+						`Artifact collection also failed after the PTS workload exited ${JSON.stringify(benchmark.exit)}: ${artifactErrors.map(errorDetail).join("; ")}`,
 					);
 				}
 				throw new Error(
-					`PTS vLLM workload exited ${benchmark.exitCode}; partial artifacts were retained`,
+					`PTS vLLM workload exited ${JSON.stringify(benchmark.exit)}; partial artifacts were retained`,
 				);
 			}
 			if (artifactErrors.length > 0) {
@@ -120,7 +126,7 @@ async function runGpuReplicate(options: {
 				replicateIndex: index,
 				baseImageId: options.baseImage.imageId,
 				kernelSnapshotImageId: options.kernelImage.imageId,
-				sandboxId: sandbox.sandboxId,
+				sandboxId: sandbox.session.sandboxRef.id,
 				startedAt,
 				finishedAt,
 				cudaGraphs,
@@ -132,22 +138,7 @@ async function runGpuReplicate(options: {
 			}
 			return { index, xml: readFileSync(xmlPath, "utf8"), metadata };
 		},
-		async () => {
-			await sandbox.destroy();
-			writeJson(join(outputDirectory, "lifecycle.json"), {
-				schemaVersion: "1.0",
-				replicateIndex: index,
-				sandboxId: sandbox.sandboxId,
-				terminatedAndUnlisted: true,
-				verifiedAt: new Date().toISOString(),
-			});
-		},
-		(error) => {
-			console.error(
-				`Modal GPU sandbox r${index} cleanup also failed after the operation failed:`,
-				error,
-			);
-		},
+		{ path: join(outputDirectory, "lifecycle.json"), replicateIndex: index },
 	);
 }
 

--- a/apps/cli/src/lib/gpu/gpu.test.ts
+++ b/apps/cli/src/lib/gpu/gpu.test.ts
@@ -13,7 +13,7 @@ import {
 	VLLM_IMAGE_COMMANDS,
 } from "./config.ts";
 import { cudaGraphEvidenceFromLog } from "./cuda-graphs.ts";
-import { createGpuSandbox, gpuSandboxResources, vllmEnvironment } from "./modal.ts";
+import { gpuSandboxResources, vllmEnvironment } from "./modal.ts";
 import { kernelSeedManifest, kernelSnapshotPointerFromText } from "./prepare-kernels.ts";
 import { modelAssetConfig } from "./prepare-models.ts";
 
@@ -230,23 +230,7 @@ describe("CUDA graph evidence", () => {
 	});
 });
 
-describe("Modal lifecycle adapter", () => {
-	test("terminates with wait and verifies the sandbox is absent", async () => {
-		const terminateCalls: unknown[] = [];
-		const sdk = {
-			sandboxId: "sb-test",
-			terminate: async (options: unknown) => terminateCalls.push(options),
-		};
-		const client = {
-			sandboxes: {
-				list: async function* () {},
-			},
-		};
-		const sandbox = await createGpuSandbox(client as never, async () => sdk as never);
-		await sandbox.destroy();
-		expect(terminateCalls).toEqual([{ wait: true }]);
-	});
-
+describe("Modal allocation configuration", () => {
 	test("shares resource and vLLM environment policy across seed and benchmark sandboxes", () => {
 		const args = parseGpuArgs([]);
 		expect(gpuSandboxResources(args)).toEqual({

--- a/apps/cli/src/lib/gpu/modal.ts
+++ b/apps/cli/src/lib/gpu/modal.ts
@@ -1,6 +1,12 @@
+import { writeFileSync } from "node:fs";
 import { join } from "node:path";
-import { createOwnedSandbox, StepRunner, withOwnedSandbox } from "@sandbox-benchmarks/harness";
-import type { ModalClient, ModalReadStream, Sandbox, SandboxCreateParams } from "modal";
+import type { SandboxSession } from "@sandbox-benchmarks/driver";
+import { readTextFile, writeTextFile } from "@sandbox-benchmarks/driver";
+import type { ModalAllocationConfiguration } from "@sandbox-benchmarks/drivers/modal-gvisor";
+import { createModalAllocation } from "@sandbox-benchmarks/drivers/modal-gvisor";
+import type { SandboxWork } from "@sandbox-benchmarks/harness";
+import { withSandboxWork } from "@sandbox-benchmarks/harness";
+import type { Sandbox, SandboxCreateParams } from "modal";
 import type { GpuArgs } from "./args.ts";
 import {
 	GPU_BENCHMARK,
@@ -11,100 +17,46 @@ import {
 	readSource,
 } from "./config.ts";
 
-const MODAL_TRANSPORT = {
-	streaming: true,
-	syncCapMs: null,
-	detachedPoll: false,
-} as const;
+export type GpuSandbox = SandboxWork<Sandbox>;
 
-async function drain(stream: ModalReadStream<string>): Promise<string> {
-	const reader = stream.getReader();
-	const chunks: string[] = [];
-	try {
-		for (;;) {
-			const { done, value } = await reader.read();
-			if (done) return chunks.join("");
-			chunks.push(typeof value === "string" ? value : new TextDecoder().decode(value));
-		}
-	} finally {
-		reader.releaseLock();
-	}
-}
-
-async function exec(sandbox: Sandbox, command: string) {
-	const process = await sandbox.exec(["bash", "-lc", command], {
-		mode: "text",
-		stdout: "pipe",
-		stderr: "pipe",
-	});
-	const [stdout, stderr, exitCode] = await Promise.all([
-		drain(process.stdout),
-		drain(process.stderr),
-		process.wait(),
-	]);
-	return { stdout, stderr, exitCode };
-}
-
-async function stillListed(client: ModalClient, sandboxId: string): Promise<boolean> {
-	for await (const candidate of client.sandboxes.list()) {
-		if (candidate.sandboxId === sandboxId) return true;
-	}
-	return false;
-}
-
-async function terminateAndVerify(client: ModalClient, sandbox: Sandbox): Promise<void> {
-	let lastError: unknown;
-	for (let terminateAttempt = 0; terminateAttempt < 3; terminateAttempt++) {
-		try {
-			await sandbox.terminate({ wait: true });
-		} catch (error) {
-			lastError = error;
-		}
-		for (let listAttempt = 0; listAttempt < 5; listAttempt++) {
-			try {
-				if (!(await stillListed(client, sandbox.sandboxId))) return;
-			} catch (error) {
-				lastError = error;
-				break;
-			}
-			await Bun.sleep(1000);
-		}
-	}
-	const reason = lastError instanceof Error ? `: ${lastError.message}` : "";
-	throw new Error(`Modal sandbox ${sandbox.sandboxId} is still listed after termination${reason}`);
-}
-
-function adaptGpuSandbox(client: ModalClient, sdk: Sandbox) {
-	const adapted = {
-		sandboxId: sdk.sandboxId,
-		sdk,
-		runCommand: (command: string) => exec(sdk, command),
-		destroy: () => terminateAndVerify(client, sdk),
-	};
-	return {
-		...adapted,
-		// One PTS pass per independent sandbox; fleet replication supplies machine-level variance.
-		runner: new StepRunner(adapted, MODAL_TRANSPORT, undefined, { mode: "fixed", times: 1 }),
-	};
-}
-
-async function createAdaptedGpuSandbox(client: ModalClient, create: () => Promise<Sandbox>) {
-	return adaptGpuSandbox(client, await create());
-}
-
-export async function createGpuSandbox(client: ModalClient, create: () => Promise<Sandbox>) {
-	return createOwnedSandbox(() => createAdaptedGpuSandbox(client, create));
-}
-
-export type GpuSandbox = Awaited<ReturnType<typeof createGpuSandbox>>;
-
-/** The shared lifecycle scope for short-lived GPU preparation and validation sandboxes. */
-export function withGpuSandbox<T>(
-	client: ModalClient,
-	create: () => Promise<Sandbox>,
-	fn: (sandbox: GpuSandbox) => Promise<T>,
+/** Native allocation and shared harness lifetime, with optional GPU-specific teardown evidence. */
+export async function withGpuSandbox<T>(
+	configuration: ModalAllocationConfiguration,
+	work: (sandbox: GpuSandbox) => Promise<T>,
+	evidence?: { readonly path: string; readonly replicateIndex: number },
 ): Promise<T> {
-	return withOwnedSandbox(() => createAdaptedGpuSandbox(client, create), fn, "Modal GPU sandbox");
+	type Outcome = { kind: "value"; value: T } | { kind: "error"; error: unknown };
+	let outcome: Outcome | undefined;
+	let sandboxId: string | undefined;
+	try {
+		await withSandboxWork(
+			createModalAllocation(configuration),
+			async (sandbox) => {
+				sandboxId = sandbox.session.sandboxRef.id;
+				try {
+					outcome = { kind: "value", value: await work(sandbox) };
+				} catch (error) {
+					outcome = { kind: "error", error };
+				}
+			},
+			{ ptsPassPolicy: { mode: "fixed", times: 1 } },
+		);
+		if (evidence)
+			writeFileSync(
+				evidence.path,
+				`${JSON.stringify({ schemaVersion: "1.0", replicateIndex: evidence.replicateIndex, sandboxId, terminatedAndUnlisted: true, verifiedAt: new Date().toISOString() }, null, 2)}\n`,
+			);
+	} catch (error) {
+		if (outcome?.kind === "error") {
+			console.error("Modal GPU scope cleanup or evidence also failed:", error);
+			throw outcome.error;
+		}
+		throw error;
+	}
+	if (outcome === undefined)
+		throw new Error("Modal GPU scope returned without running its workload");
+	if (outcome.kind === "error") throw outcome.error;
+	return outcome.value;
 }
 
 /** Resource and lifetime policy shared by the kernel seed and measured benchmark allocations. */
@@ -157,9 +109,10 @@ export async function stageGpuProducer(sandbox: GpuSandbox): Promise<void> {
 	];
 	await Promise.all(
 		files.map((relative) =>
-			sandbox.sdk.filesystem.writeText(
-				readSource(relative),
+			writeTextFile(
+				sandbox.session,
 				join(GPU_BENCHMARK.paths.remoteRoot, relative),
+				readSource(relative),
 			),
 		),
 	);
@@ -251,4 +204,11 @@ export async function observeGpuSandbox(sandbox: GpuSandbox) {
 		cudaSmoke: typeof versions.cuda_smoke === "number" ? String(versions.cuda_smoke) : undefined,
 		vllmVersion: value("vllm"),
 	};
+}
+
+/** GPU artifacts are required inputs; an unreadable file is never silently treated as empty. */
+export async function readGpuFile(session: SandboxSession, path: string): Promise<string> {
+	const text = await readTextFile(session, path);
+	if (text === null) throw new Error(`GPU artifact is unreadable: ${path}`);
+	return text;
 }

--- a/apps/cli/src/lib/gpu/prepare-kernels.ts
+++ b/apps/cli/src/lib/gpu/prepare-kernels.ts
@@ -1,12 +1,19 @@
 import { createHash } from "node:crypto";
 import { mkdirSync, writeFileSync } from "node:fs";
 import { join, resolve } from "node:path";
+import { succeeded, writeTextFile } from "@sandbox-benchmarks/driver";
 import type { App, Image, ModalClient, Volume } from "modal";
 import type { GpuArgs } from "./args.ts";
 import { GPU_BENCHMARK, readSource } from "./config.ts";
 import { cudaGraphEvidenceFromLog, cudaGraphEvidencePassed } from "./cuda-graphs.ts";
 import type { GpuSandbox } from "./modal.ts";
-import { gpuSandboxResources, stageGpuProducer, vllmEnvironment, withGpuSandbox } from "./modal.ts";
+import {
+	gpuSandboxResources,
+	readGpuFile,
+	stageGpuProducer,
+	vllmEnvironment,
+	withGpuSandbox,
+} from "./modal.ts";
 import { validateModelAssets } from "./prepare-models.ts";
 
 const registryPointerPath = `${GPU_BENCHMARK.paths.kernelRegistryMount}/current.json`;
@@ -86,9 +93,11 @@ export async function resolveKernelSnapshot(options: {
 }): Promise<Image | undefined> {
 	const expectedSeed = kernelSeedManifest(options.baseImage.imageId, options.args);
 	const pointer = await withGpuSandbox(
-		options.client,
-		() =>
-			options.client.sandboxes.create(options.app, options.baseImage, {
+		{
+			client: options.client,
+			app: options.app,
+			image: options.baseImage,
+			options: {
 				cpu: 0.25,
 				cpuLimit: 1,
 				memoryMiB: 128,
@@ -100,15 +109,16 @@ export async function resolveKernelSnapshot(options: {
 						readOnly: true,
 					}),
 				},
-			}),
+			},
+		},
 		async (registry) => {
 			try {
-				await registry.sdk.setTags({
+				await registry.session.native.setTags({
 					"gpu-benchmark-role": "kernel-snapshot-registry-check",
 					"kernel-snapshot-registry-volume": options.registryVolumeName,
 				});
 				return kernelSnapshotPointerFromText(
-					await registry.sdk.filesystem.readText(registryPointerPath),
+					await readGpuFile(registry.session, registryPointerPath),
 					expectedSeed,
 				);
 			} catch {
@@ -125,40 +135,33 @@ export async function resolveKernelSnapshot(options: {
 	} catch {
 		return undefined;
 	}
-	let created = false;
-	try {
-		return await withGpuSandbox(
-			options.client,
-			async () => {
-				const sandbox = await options.client.sandboxes.create(options.app, candidate, {
-					cpu: 0.25,
-					cpuLimit: 1,
-					memoryMiB: 128,
-					memoryLimitMiB: 512,
-					timeoutMs: 2 * 60_000,
-					blockNetwork: true,
+	return await withGpuSandbox(
+		{
+			client: options.client,
+			app: options.app,
+			image: candidate,
+			options: {
+				cpu: 0.25,
+				cpuLimit: 1,
+				memoryMiB: 128,
+				memoryLimitMiB: 512,
+				timeoutMs: 2 * 60_000,
+				blockNetwork: true,
+			},
+		},
+		async (probe) => {
+			try {
+				await probe.session.native.setTags({
+					"gpu-benchmark-role": "kernel-snapshot-check",
+					"kernel-snapshot-image": pointer.snapshotImageId,
 				});
-				created = true;
-				return sandbox;
-			},
-			async (probe) => {
-				try {
-					await probe.sdk.setTags({
-						"gpu-benchmark-role": "kernel-snapshot-check",
-						"kernel-snapshot-image": pointer.snapshotImageId,
-					});
-					const embeddedSeed = await probe.sdk.filesystem.readText(seedManifestPath);
-					return embeddedSeed === encode(expectedSeed) ? candidate : undefined;
-				} catch {
-					return undefined;
-				}
-			},
-		);
-	} catch (error) {
-		// An expired image or failed probe allocation is a cache miss; a teardown failure is not.
-		if (!created) return undefined;
-		throw error;
-	}
+				const embeddedSeed = await readGpuFile(probe.session, seedManifestPath);
+				return embeddedSeed === encode(expectedSeed) ? candidate : undefined;
+			} catch {
+				return undefined;
+			}
+		},
+	);
 }
 
 async function installProfile(sandbox: GpuSandbox): Promise<void> {
@@ -191,9 +194,11 @@ export async function prepareKernelSnapshot(options: {
 	const outputDirectory = resolve(args.outputDirectory);
 	mkdirSync(outputDirectory, { recursive: true });
 	return withGpuSandbox(
-		options.client,
-		() =>
-			options.client.sandboxes.create(options.app, options.baseImage, {
+		{
+			client: options.client,
+			app: options.app,
+			image: options.baseImage,
+			options: {
 				...gpuSandboxResources(args),
 				env: vllmEnvironment(args),
 				volumes: {
@@ -202,16 +207,17 @@ export async function prepareKernelSnapshot(options: {
 					}),
 					[GPU_BENCHMARK.paths.kernelRegistryMount]: options.registryVolume,
 				},
-			}),
+			},
+		},
 		async (sandbox) => {
-			await sandbox.sdk.setTags({
+			await sandbox.session.native.setTags({
 				"gpu-benchmark-role": "kernel-cache-seed",
 				profile: GPU_BENCHMARK.profile.name,
 				gpu: args.gpu,
 				"model-volume": options.modelVolumeName,
 				"kernel-snapshot-registry-volume": options.registryVolumeName,
 			});
-			console.error(`Modal GPU kernel-seed sandbox: ${sandbox.sandboxId}`);
+			console.error(`Modal GPU kernel-seed sandbox: ${sandbox.session.sandboxRef.id}`);
 			await validateModelAssets(sandbox);
 			await stageGpuProducer(sandbox);
 			await installProfile(sandbox);
@@ -227,8 +233,10 @@ export async function prepareKernelSnapshot(options: {
 			);
 			writeFileSync(join(outputDirectory, "kernel-seed.stdout.log"), seed.stdout ?? "");
 			writeFileSync(join(outputDirectory, "kernel-seed.stderr.log"), seed.stderr ?? "");
-			if (seed.exitCode !== 0) throw new Error(`kernel-cache seed exited ${seed.exitCode}`);
-			const serverLog = await sandbox.sdk.filesystem.readText(
+			if (!succeeded(seed.exit))
+				throw new Error(`kernel-cache seed exited ${JSON.stringify(seed.exit)}`);
+			const serverLog = await readGpuFile(
+				sandbox.session,
 				`${GPU_BENCHMARK.paths.remoteRoot}/benchmark-results/vllm-native/server.log`,
 			);
 			writeFileSync(join(outputDirectory, "vllm-server.log"), serverLog);
@@ -236,13 +244,13 @@ export async function prepareKernelSnapshot(options: {
 			if (!cudaGraphEvidencePassed(cudaGraphs)) {
 				throw new Error("kernel-cache seed reached no verified CUDA-graph capture");
 			}
-			await sandbox.sdk.filesystem.writeText(encode(expectedSeed), seedManifestPath);
-			const snapshot = await sandbox.sdk.snapshotFilesystem({
+			await writeTextFile(sandbox.session, seedManifestPath, encode(expectedSeed));
+			const snapshot = await sandbox.session.native.snapshotFilesystem({
 				timeoutMs: 5 * 60_000,
 				ttlMs: GPU_BENCHMARK.kernelSnapshotTtlDays * 24 * 60 * 60_000,
 			});
 			const pointer = createKernelSnapshotPointer(snapshot.imageId, expectedSeed);
-			await sandbox.sdk.filesystem.writeText(encode(pointer), registryPointerPath);
+			await writeTextFile(sandbox.session, registryPointerPath, encode(pointer));
 			return pointer;
 		},
 	);

--- a/apps/cli/src/lib/gpu/prepare-models.ts
+++ b/apps/cli/src/lib/gpu/prepare-models.ts
@@ -1,3 +1,4 @@
+import { writeTextFile } from "@sandbox-benchmarks/driver";
 import type { App, Image, ModalClient, Volume } from "modal";
 import { GPU_BENCHMARK, MODEL_CACHE_ENV, readSource } from "./config.ts";
 import type { GpuSandbox } from "./modal.ts";
@@ -20,13 +21,15 @@ export function modelAssetConfig() {
 
 async function stageModelPreparation(sandbox: GpuSandbox): Promise<void> {
 	await Promise.all([
-		sandbox.sdk.filesystem.writeText(
-			readSource("apps/cli/src/lib/gpu/prepare-models.py"),
+		writeTextFile(
+			sandbox.session,
 			REMOTE_SCRIPT,
+			readSource("apps/cli/src/lib/gpu/prepare-models.py"),
 		),
-		sandbox.sdk.filesystem.writeText(
-			`${JSON.stringify(modelAssetConfig(), null, 2)}\n`,
+		writeTextFile(
+			sandbox.session,
 			REMOTE_CONFIG,
+			`${JSON.stringify(modelAssetConfig(), null, 2)}\n`,
 		),
 	]);
 }
@@ -59,9 +62,11 @@ export async function prepareModelAssets(options: {
 	timeoutMinutes: number;
 }): Promise<void> {
 	await withGpuSandbox(
-		options.client,
-		() =>
-			options.client.sandboxes.create(options.app, options.image, {
+		{
+			client: options.client,
+			app: options.app,
+			image: options.image,
+			options: {
 				cpu: options.cpu,
 				cpuLimit: options.cpuLimit,
 				memoryMiB: GPU_BENCHMARK.modelPreparation.memoryMiB,
@@ -69,13 +74,14 @@ export async function prepareModelAssets(options: {
 				timeoutMs: options.timeoutMinutes * 60_000,
 				env: { ...MODEL_CACHE_ENV },
 				volumes: { [GPU_BENCHMARK.paths.modelMount]: options.volume },
-			}),
+			},
+		},
 		async (sandbox) => {
-			await sandbox.sdk.setTags({
+			await sandbox.session.native.setTags({
 				"gpu-benchmark-role": "model-cache",
 				"model-volume": options.volumeName,
 			});
-			console.error(`Modal model-cache sandbox: ${sandbox.sandboxId}`);
+			console.error(`Modal model-cache sandbox: ${sandbox.session.sandboxRef.id}`);
 			await runModelPreparation(
 				sandbox,
 				"download",

--- a/docs/adr/0009-harness-operations-and-gpu-allocation.md
+++ b/docs/adr/0009-harness-operations-and-gpu-allocation.md
@@ -18,6 +18,12 @@ the common driver and harness interfaces. Future GPU runners reuse the session s
 own typed allocation configuration. This preserves provider-specific resource and artifact
 semantics without an arbitrary vendor-options bag on every request.
 
+Modal GPU allocation uses the stable V1 gVisor service. The CPU gVisor DriverModule uses V2;
+prepared GPU resources resolve through a separate typed allocation factory for the same provider.
+[Modal VM sandboxes](https://modal.com/docs/guide/vm-sandboxes) and
+[Sandbox V2](https://modal.com/docs/guide/sandbox-v2) do not support GPUs. Built or restored SDK
+image IDs remain the session artifact identity, and mounted volumes retain SDK mount options.
+
 CLI composition owns environment and artifact resolution; harness owns workload execution,
 measurement, and evidence persistence; drivers own provider behavior. Migrate all existing
 providers and callers before removing the legacy package and exports. ComputeSDK may remain

--- a/packages/driver/src/conformance.ts
+++ b/packages/driver/src/conformance.ts
@@ -433,8 +433,8 @@ const readinessPass = (detail: string): ReadinessVerification => ({ status: "pas
 const readinessFail = (detail: string): ReadinessVerification => ({ status: "fail", detail });
 
 /** Wall-clock budget the composition root must reserve for the selected module's readiness policy. */
-export function driverReadinessBudgetMs<P extends ProviderId>(
-	module: DriverModule<P, unknown>,
+export function driverReadinessBudgetMs<P extends ProviderId, Handle>(
+	module: DriverModule<P, Handle>,
 ): number {
 	return module.readiness.startup === "create-returns-ready"
 		? CREATE_RETURNS_READY_PROBE_TIMEOUT_MS
@@ -474,9 +474,9 @@ async function settleCancelledReadinessAttempt(
 }
 
 /** Drive one module's declared readiness strategy without running any later lifecycle command. */
-export async function verifyDriverReadiness<P extends ProviderId>(
-	module: DriverModule<P, unknown>,
-	session: SandboxSession,
+export async function verifyDriverReadiness<P extends ProviderId, Handle>(
+	module: DriverModule<P, Handle>,
+	session: SandboxSession<Handle>,
 	options: ReadinessVerificationOptions = {},
 ): Promise<ReadinessVerification> {
 	const readiness = module.readiness;

--- a/packages/drivers/src/_computesdk.ts
+++ b/packages/drivers/src/_computesdk.ts
@@ -2115,3 +2115,17 @@ export function defineComputeSdkDriver<P extends ProviderId, TCompute extends Co
 	});
 	return joined;
 }
+
+/** Bind an explicitly prepared artifact without inventing a registry artifact for custom work. */
+export function driverFromComputeSpec<TCompute extends ComputeSdkLike>(
+	id: ProviderId,
+	binding: ComputeSdkDriverSpec<TCompute>,
+	resolvedArtifact: ResolvedArtifact,
+	sensitiveValues: readonly string[],
+) {
+	const { compute, ...spec } = binding;
+	return driverFromTable(
+		computeSdkMethodTable<TCompute>(id, { ...spec, resolvedArtifact, sensitiveValues }),
+		() => Promise.resolve(compute),
+	);
+}

--- a/packages/drivers/src/_modal-allocation.test.ts
+++ b/packages/drivers/src/_modal-allocation.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, test } from "bun:test";
+import { isDriverError } from "@sandbox-benchmarks/driver";
+import { App, Image, ModalClient } from "modal";
+import { createModalAllocation } from "./_modal-allocation.ts";
+
+function configuration(gpu?: string) {
+	const client = new ModalClient({ tokenId: "test-token", tokenSecret: "test-secret" });
+	return {
+		client,
+		app: new App("ap-prepared", "allocation-test"),
+		image: new Image(client, "im-prepared", ""),
+		options: {
+			cpu: 0.25,
+			cpuLimit: 2,
+			memoryMiB: 128,
+			memoryLimitMiB: 512,
+			timeoutMs: 300000,
+			gpu,
+			env: { WORKLOAD: "test" },
+		},
+	};
+}
+
+describe("prepared Modal allocation", () => {
+	test("preserves fractional reservations, separate limits, GPU count and prepared image identity", () => {
+		const configured = createModalAllocation(configuration("T4:2"));
+		expect(configured.request).toEqual({
+			spec: { vcpus: 0.25, memoryGb: 0.125 },
+			artifact: { kind: "built", ref: "im-prepared" },
+			gpu: { model: "T4", count: 2 },
+			env: { WORKLOAD: "test" },
+		});
+		expect(configured.module.id).toBe("modal-gvisor");
+		expect(configured.module.execution.syncCapMs).toBeNull();
+	});
+	test("rejects conflicting canonical requests before making a vendor call", async () => {
+		const configured = createModalAllocation(configuration("T4"));
+		for (const input of [
+			{ ...configured.request, spec: { vcpus: 1, memoryGb: 0.125 } },
+			{ ...configured.request, gpu: { model: "T4", count: 2 } },
+			{ ...configured.request, env: { WORKLOAD: "other" } },
+		]) {
+			try {
+				await configured.driver.create({ ...input, deadlineMs: 1000 });
+				throw new Error("accepted conflicting input");
+			} catch (error) {
+				expect(isDriverError(error) && error.code).toBe("invalid-create-request");
+			}
+		}
+	});
+	test("requires a recovery name and a resolved image before allocation", () => {
+		const options = configuration();
+		expect(() => createModalAllocation({ ...options, app: new App("ap-unnamed") })).toThrow(
+			"named app",
+		);
+		expect(() =>
+			createModalAllocation({
+				...options,
+				image: options.client.images.fromRegistry("ubuntu:24.04"),
+			}),
+		).toThrow();
+	});
+});

--- a/packages/drivers/src/_modal-allocation.ts
+++ b/packages/drivers/src/_modal-allocation.ts
@@ -1,0 +1,176 @@
+// Prepared Modal resources for GPU work use the stable V1 gVisor backend. Neither the VM
+// runtime nor the V2 service supports GPUs. Resource handles stay typed by the pinned SDK.
+import { randomUUID } from "node:crypto";
+import type { CreateRequest } from "@sandbox-benchmarks/driver";
+import { nvidiaAccelerator } from "@sandbox-benchmarks/driver";
+import { type } from "arktype";
+import type { App, Image, SandboxCreateParams } from "modal";
+import { ModalClient, Sandbox } from "modal";
+import type { ClientMiddleware } from "nice-grpc";
+import { computeSdkSpec, driverFromComputeSpec } from "./_computesdk.ts";
+import {
+	createModalControlRunner,
+	execModalCommand,
+	launchModalCommand,
+	MODAL_V1_SANDBOX_ID,
+	modalControlPlane,
+	modalCreateRecovery,
+	modalLifecycle,
+	modalProbes,
+	modalProcessResult,
+} from "./_modal.ts";
+import { nativeSdkCompute } from "./_native.ts";
+import { MODAL_NATIVE_PROVENANCE } from "./_provenance.ts";
+
+export type ModalAllocationOptions = Required<
+	Pick<SandboxCreateParams, "cpu" | "cpuLimit" | "memoryMiB" | "memoryLimitMiB" | "timeoutMs">
+> &
+	Pick<SandboxCreateParams, "gpu" | "env" | "volumes" | "blockNetwork">;
+
+export interface ModalAllocationConfiguration {
+	readonly client: ModalClient;
+	readonly app: App;
+	/** A built or restored SDK image; its imageId is the truthful artifact identity. */
+	readonly image: Image;
+	readonly options: ModalAllocationOptions;
+}
+
+const namedCreate = type({ name: "string >= 1" });
+
+/** Resolve native configuration to one canonical request and a driver with ordinary sessions. */
+export function createModalAllocation(configuration: ModalAllocationConfiguration) {
+	const { app, image, client } = configuration;
+	if (!app.name)
+		throw new Error("Modal allocation requires a named app for failed-create recovery");
+	const appName = app.name;
+	const imageId = image.imageId;
+	if (!imageId) throw new Error("Modal allocation requires a built image");
+	const params = { ...configuration.options };
+	if (params.env) params.env = { ...params.env };
+	if (params.volumes) params.volumes = { ...params.volumes };
+	const gpu = params.gpu?.match(/^([^:]+)(?::([1-9][0-9]*))?$/);
+	if (params.gpu !== undefined && !gpu) throw new Error("Invalid Modal GPU reservation");
+	const request = {
+		spec: { vcpus: params.cpu, memoryGb: params.memoryMiB / 1024 },
+		artifact: { kind: "built", ref: imageId },
+		...(params.env === undefined ? {} : { env: params.env }),
+		...(gpu === undefined || gpu === null
+			? {}
+			: { gpu: { model: gpu[1] ?? "", count: Number(gpu[2] ?? 1) } }),
+	} satisfies Omit<CreateRequest, "deadlineMs">;
+	const createClient = (middleware: ClientMiddleware) =>
+		new ModalClient({
+			tokenId: client.profile.tokenId,
+			tokenSecret: client.profile.tokenSecret,
+			endpoint: client.profile.serverUrl,
+			environment: client.profile.environment,
+			grpcMiddleware: [middleware],
+		});
+	const control = createModalControlRunner((middleware) =>
+		modalControlPlane(createClient(middleware)),
+	);
+	const allocation = createModalControlRunner(createClient, 300_000);
+	const compute = nativeSdkCompute(
+		(options) => namedCreate.assert(options),
+		(options, operation) =>
+			allocation.run(operation, async (sdk) => {
+				// Reattach the already-built image through this transaction's client so its RPCs share
+				// cancellation. App and volume handles are resolved inputs, not guest-owned resources.
+				const prepared = await sdk.images.fromId(imageId);
+				const created = await sdk.sandboxes.create(app, prepared, {
+					...params,
+					name: options.name,
+				});
+				// Allocation middleware belongs only to the create transaction. Native SDK work
+				// uses the caller-owned client; driver operations attach their own deadlines.
+				return new Sandbox(client, created.sandboxId, { isV2: false });
+			}),
+		(native) => ({
+			sandboxId: native.sandboxId,
+			runCommand: async (command: string) =>
+				modalProcessResult(
+					await native.exec(["sh", "-c", command], { stdout: "pipe", stderr: "pipe" }),
+					() => native.detach(),
+				),
+			destroy: () => native.terminate({ wait: true }),
+		}),
+	);
+	const lifecycle = modalLifecycle<typeof compute>("v1", control, appName);
+	const listRunner = createModalControlRunner(createClient, 15_000);
+	const spec = computeSdkSpec(compute, {
+		sandboxId: { fromVendor: MODAL_V1_SANDBOX_ID, canonical: MODAL_V1_SANDBOX_ID },
+		createOptions: {
+			coverage: {
+				spec: { vcpus: "mapped", memoryGb: "mapped", diskGb: "unsupported" },
+				artifact: "context",
+				deadlineMs: "harness",
+				gpu: { model: "mapped", count: "mapped" },
+				env: "mapped",
+			},
+			map: (input, unsupported) => {
+				if (
+					input.spec.vcpus !== request.spec.vcpus ||
+					input.spec.memoryGb !== request.spec.memoryGb ||
+					input.gpu?.model !== request.gpu?.model ||
+					input.gpu?.count !== request.gpu?.count
+				)
+					unsupported("request differs from the configured Modal allocation");
+				const env = input.env ?? {};
+				const configuredEnv = request.env ?? {};
+				if (
+					Object.keys(env).length !== Object.keys(configuredEnv).length ||
+					Object.entries(env).some(([key, value]) => value !== configuredEnv[key])
+				)
+					unsupported("request environment differs from the configured Modal allocation");
+				return { name: `benchmark-${randomUUID()}` };
+			},
+		},
+		commands: {
+			launch: (sandbox, command, options, ref) =>
+				launchModalCommand(control, sandbox, command, ref, options),
+			exec: (sandbox, command, options, ref) =>
+				execModalCommand(control, sandbox, command, ref, options),
+		},
+		lifecycle: {
+			destroy: async (sandbox, ref, options, locator) => {
+				await lifecycle.destroy(sandbox, ref, options, locator);
+				if (ref === undefined) return;
+				for (let attempt = 0; attempt < 5; attempt++) {
+					const listed = await listRunner.run(options, async (sdk) => {
+						for await (const candidate of sdk.sandboxes.list()) {
+							if (candidate.sandboxId === ref.id) return true;
+						}
+						return false;
+					});
+					if (!listed) return;
+					await Bun.sleep(1000);
+				}
+				throw new Error(`Modal sandbox ${ref.id} is still listed after termination`);
+			},
+		},
+		createRecovery: modalCreateRecovery("v1", control, appName),
+		hasWorkingFilesystem: false,
+		probes: modalProbes(control),
+	});
+	const driver = driverFromComputeSpec(
+		"modal-gvisor",
+		spec,
+		request.artifact,
+		[client.profile.tokenId, client.profile.tokenSecret].filter(
+			(value): value is string => typeof value === "string" && value.length > 0,
+		),
+	);
+	return {
+		module: {
+			id: "modal-gvisor" as const,
+			provenance: MODAL_NATIVE_PROVENANCE,
+			createBudget: { owner: "harness" as const, timeoutMs: 300_000 },
+			readiness: { startup: "create-returns-ready" as const },
+			execution: { syncCapMs: null, durable: "none" as const },
+			...(request.gpu === undefined ? {} : { accelerator: nvidiaAccelerator }),
+			driver: () => driver,
+		},
+		driver,
+		request,
+	};
+}

--- a/packages/drivers/src/_modal.test.ts
+++ b/packages/drivers/src/_modal.test.ts
@@ -362,7 +362,7 @@ describe("Modal enforced control deadline", () => {
 			const state = neverSettlingRunner(phase);
 			const operation =
 				phase === "lookup"
-					? modalLifecycle("vm", state.runner).destroy(
+					? modalLifecycle("v1", state.runner).destroy(
 							{} as never,
 							undefined,
 							{},
@@ -374,7 +374,7 @@ describe("Modal enforced control deadline", () => {
 					: phase === "poll"
 						? modalProbes(state.runner).observe({} as never, modalRef)
 						: phase === "terminate"
-							? modalLifecycle("vm", state.runner).destroy({} as never, modalRef, {})
+							? modalLifecycle("v1", state.runner).destroy({} as never, modalRef, {})
 							: launchModalCommand(state.runner, {} as never, "sleep 1", modalRef);
 			await expect(operation).rejects.toThrow(/exceeded 10ms/);
 			expect(state.settled()).toBe(1);
@@ -389,7 +389,7 @@ describe("Modal enforced control deadline", () => {
 	it("forwards caller cancellation through the same settling boundary", async () => {
 		const state = neverSettlingRunner("terminate");
 		const controller = new AbortController();
-		const operation = modalLifecycle("vm", state.runner).destroy({} as never, modalRef, {
+		const operation = modalLifecycle("v1", state.runner).destroy({} as never, modalRef, {
 			signal: controller.signal,
 		});
 		controller.abort(new Error("caller cancelled Modal teardown"));
@@ -516,7 +516,7 @@ describe("Modal truthful lifecycle and recovery projections", () => {
 				},
 			},
 		};
-		const lifecycle = modalLifecycle("vm", directRunner(control));
+		const lifecycle = modalLifecycle("v1", directRunner(control));
 		await lifecycle.destroy(
 			{} as never,
 			{ provider: "modal-vm", id: "sb-rxWrDWGgOCJXeCSavkiDL6" },
@@ -555,10 +555,11 @@ describe("Modal truthful lifecycle and recovery projections", () => {
 		};
 		for (const provider of ["modal-gvisor", "modal-vm"] as const) {
 			await expect(
-				modalLifecycle(
-					provider === "modal-gvisor" ? "gvisor" : "vm",
-					directRunner(control),
-				).destroy({} as never, { provider, id: "sb-rxWrDWGgOCJXeCSavkiDL6" }, {}),
+				modalLifecycle(provider === "modal-gvisor" ? "v2" : "v1", directRunner(control)).destroy(
+					{} as never,
+					{ provider, id: "sb-rxWrDWGgOCJXeCSavkiDL6" },
+					{},
+				),
 			).resolves.toBeUndefined();
 		}
 	});
@@ -580,7 +581,7 @@ describe("Modal truthful lifecycle and recovery projections", () => {
 				},
 			};
 			await expect(
-				modalLifecycle("vm", directRunner(control)).destroy({} as never, modalRef, {}),
+				modalLifecycle("v1", directRunner(control)).destroy({} as never, modalRef, {}),
 			).rejects.toMatchObject({ path, code: Status.NOT_FOUND });
 		}
 	});
@@ -603,7 +604,7 @@ describe("Modal truthful lifecycle and recovery projections", () => {
 		expect(isModalRetryableCreate(new Error("quota|rate limit|capacity"))).toBe(false);
 		expect(isModalRetryableCreate(new Error("Modal quota exceeded somewhere else"))).toBe(false);
 		expect(
-			modalCreateRecovery("vm", directRunner({ sandboxes: {} })).isRetryableCreate?.(exhausted),
+			modalCreateRecovery("v1", directRunner({ sandboxes: {} })).isRetryableCreate?.(exhausted),
 		).toBe(true);
 	});
 
@@ -627,7 +628,7 @@ describe("Modal truthful lifecycle and recovery projections", () => {
 			},
 		} as unknown as ModalClient;
 		await expect(
-			modalCreateRecovery("vm", directRunner(modalControlPlane(client))).cleanup(
+			modalCreateRecovery("v1", directRunner(modalControlPlane(client))).cleanup(
 				{} as never,
 				{ kind: "name", value: "benchmark-12345678-1234-1234-1234-123456789abc" },
 				{},
@@ -689,7 +690,7 @@ describe("Modal truthful lifecycle and recovery projections", () => {
 			},
 		};
 		await expect(
-			modalLifecycle("vm", directRunner(control)).destroy(
+			modalLifecycle("v1", directRunner(control)).destroy(
 				hostileNative as never,
 				undefined,
 				{},
@@ -717,7 +718,7 @@ describe("Modal truthful lifecycle and recovery projections", () => {
 			},
 		};
 		await expect(
-			modalLifecycle("vm", directRunner(control)).destroy(
+			modalLifecycle("v1", directRunner(control)).destroy(
 				{} as never,
 				undefined,
 				{},
@@ -760,10 +761,10 @@ describe("Modal truthful lifecycle and recovery projections", () => {
 			value: "benchmark-12345678-1234-1234-1234-123456789abc",
 		};
 		expect(
-			await modalCreateRecovery("gvisor", directRunner(control)).cleanup({} as never, locator, {}),
+			await modalCreateRecovery("v2", directRunner(control)).cleanup({} as never, locator, {}),
 		).toEqual({ status: "destroyed" });
 		expect(
-			await modalCreateRecovery("vm", directRunner(control)).cleanup({} as never, locator, {}),
+			await modalCreateRecovery("v1", directRunner(control)).cleanup({} as never, locator, {}),
 		).toEqual({ status: "destroyed" });
 		expect(lookups).toEqual([
 			`v2:${MODAL_APP_NAME}:benchmark-12345678-1234-1234-1234-123456789abc`,
@@ -836,8 +837,8 @@ describe("Modal truthful lifecycle and recovery projections", () => {
 					},
 					map: () => ({ name }),
 				},
-				lifecycle: modalLifecycle<typeof compute>("gvisor", runner),
-				createRecovery: modalCreateRecovery<typeof compute>("gvisor", runner),
+				lifecycle: modalLifecycle<typeof compute>("v2", runner),
+				createRecovery: modalCreateRecovery<typeof compute>("v2", runner),
 				prepareAndVerifyCreatedRequest: async () => ({ status: "honored" }),
 				hasWorkingFilesystem: false,
 			}),

--- a/packages/drivers/src/_modal.ts
+++ b/packages/drivers/src/_modal.ts
@@ -248,7 +248,7 @@ interface ModalTextProcess {
 	wait(): Promise<unknown>;
 }
 
-async function modalProcessResult(
+export async function modalProcessResult(
 	process: ModalTextProcess,
 	onFailure: () => void,
 ): Promise<{
@@ -391,18 +391,20 @@ export function modalCreateOptions(
 
 function modalSandboxByName(
 	control: ModalControlPlane,
-	variant: ModalVariant,
+	backend: "v1" | "v2",
 	name: string,
+	appName: string,
 ): Promise<ModalControlSandbox> {
-	return variant === "gvisor"
-		? control.sandboxes.experimentalFromName(MODAL_APP_NAME, name)
-		: control.sandboxes.fromName(MODAL_APP_NAME, name);
+	return backend === "v2"
+		? control.sandboxes.experimentalFromName(appName, name)
+		: control.sandboxes.fromName(appName, name);
 }
 
 /** Waited, bounded teardown preserves transport failures and confirms terminal state. */
 export function modalLifecycle<TCompute extends ComputeSdkLike = ModalCompute>(
-	variant: ModalVariant,
+	backend: "v1" | "v2",
 	runner: ModalControlRunner,
+	appName = MODAL_APP_NAME,
 ): ComputeSdkLifecycle<TCompute> {
 	return {
 		destroy: async (_sandbox, ref, options, recoveryLocator) => {
@@ -417,7 +419,7 @@ export function modalLifecycle<TCompute extends ComputeSdkLike = ModalCompute>(
 							if (recoveryLocator === undefined) {
 								throw new Error("Modal failed-create cleanup has no stable recovery name");
 							}
-							attached = await modalSandboxByName(control, variant, recoveryLocator.value);
+							attached = await modalSandboxByName(control, backend, recoveryLocator.value, appName);
 						}
 						await attached.terminate({ wait: true });
 					},
@@ -436,8 +438,9 @@ export function modalLifecycle<TCompute extends ComputeSdkLike = ModalCompute>(
 
 /** Stable create names let the bridge reconcile an accepted allocation whose response was lost. */
 export function modalCreateRecovery<TCompute extends ComputeSdkLike = ModalCompute>(
-	variant: ModalVariant,
+	backend: "v1" | "v2",
 	runner: ModalControlRunner,
+	appName = MODAL_APP_NAME,
 ): ComputeSdkCreateRecovery<TCompute> {
 	return {
 		absenceConfirmationMs: MODAL_RECOVERY_CONFIRMATION_MS,
@@ -451,14 +454,14 @@ export function modalCreateRecovery<TCompute extends ComputeSdkLike = ModalCompu
 				options,
 				async (control) => {
 					const lookups =
-						variant === "gvisor"
+						backend === "v2"
 							? [
-									() => control.sandboxes.experimentalFromName(MODAL_APP_NAME, name),
-									() => control.sandboxes.fromName(MODAL_APP_NAME, name),
+									() => control.sandboxes.experimentalFromName(appName, name),
+									() => control.sandboxes.fromName(appName, name),
 								]
 							: [
-									() => control.sandboxes.fromName(MODAL_APP_NAME, name),
-									() => control.sandboxes.experimentalFromName(MODAL_APP_NAME, name),
+									() => control.sandboxes.fromName(appName, name),
+									() => control.sandboxes.experimentalFromName(appName, name),
 								];
 					let found = false;
 					let destroyed = false;
@@ -671,8 +674,8 @@ function modalSpec<P extends ModalProviderId>(
 				launch: (sandbox, command, options, ref) =>
 					launchModalCommand(runner, sandbox, command, ref, options),
 			},
-			lifecycle: modalLifecycle(variant, runner),
-			createRecovery: modalCreateRecovery(variant, runner),
+			lifecycle: modalLifecycle(variant === "gvisor" ? "v2" : "v1", runner),
+			createRecovery: modalCreateRecovery(variant === "gvisor" ? "v2" : "v1", runner),
 			prepareAndVerifyCreatedRequest: (sandbox, _native, request, options, ref) =>
 				verifyModalDiskCapacity(runner, sandbox, request, options, ref),
 			// Both variants use the kit's direct-exec filesystem fallback.

--- a/packages/drivers/src/modal-gvisor.ts
+++ b/packages/drivers/src/modal-gvisor.ts
@@ -1,3 +1,9 @@
 import { defineModalDriver } from "./_modal.ts";
 
 export default defineModalDriver("modal-gvisor");
+
+export {
+	createModalAllocation,
+	type ModalAllocationConfiguration,
+	type ModalAllocationOptions,
+} from "./_modal-allocation.ts";

--- a/packages/harness/src/index.ts
+++ b/packages/harness/src/index.ts
@@ -767,9 +767,9 @@ export async function runSuiteOnSandbox(
 }
 
 /** A resolved integration and allocation inputs. The harness owns budgets and session lifetime. */
-export interface DriverAllocation {
-	readonly module: DriverModule<ProviderId>;
-	readonly driver: SandboxDriver;
+export interface DriverAllocation<Handle = unknown> {
+	readonly module: DriverModule<ProviderId, Handle>;
+	readonly driver: SandboxDriver<Handle>;
 	readonly request: Omit<CreateRequest, "deadlineMs">;
 }
 
@@ -1190,14 +1190,15 @@ export function unmetRequirements(
 }
 
 /** A custom workload borrows a ready session; scope exit always attempts teardown. */
-export interface SandboxWork {
-	readonly session: SandboxSession;
+export interface SandboxWork<Handle = unknown> {
+	readonly session: SandboxSession<Handle>;
 	readonly runner: SessionStepRunner;
 }
 
-export async function withSandboxWork<T>(
-	allocation: DriverAllocation,
-	work: (context: SandboxWork) => Promise<T>,
+export async function withSandboxWork<Handle, T>(
+	allocation: DriverAllocation<Handle>,
+	work: (context: SandboxWork<Handle>) => Promise<T>,
+	options: { readonly ptsPassPolicy?: import("./lib/execute.ts").PtsPassPolicy } = {},
 ): Promise<T> {
 	const { module, driver, request } = allocation;
 	const budget = module.createBudget;
@@ -1209,7 +1210,7 @@ export async function withSandboxWork<T>(
 		(signal) => driver.create({ ...request, deadlineMs }, { signal }),
 		{ destroy: (destroy, options) => destroy(options) },
 	);
-	let session: SandboxSession;
+	let session: SandboxSession<Handle>;
 	try {
 		session =
 			budget?.owner === "driver"
@@ -1234,7 +1235,10 @@ export async function withSandboxWork<T>(
 			});
 			if (!readiness.ready)
 				throw new Error(`Driver readiness verification failed: ${readiness.detail}`);
-			return work({ session, runner: new SessionStepRunner(session, module.execution) });
+			return work({
+				session,
+				runner: new SessionStepRunner(session, module.execution, undefined, options.ptsPassPolicy),
+			});
 		},
 		() => session.destroy(),
 		(error) =>


### PR DESCRIPTION
Move Modal CPU and GPU consumers onto declarative harness session operations. GPU preparation supplies typed SDK allocation configuration, including resource reservations and limits, images, environment, volumes, and mount options. Built and restored image IDs remain the artifact identity.

GPU allocation uses stable V1 gVisor; CPU gVisor uses V2. Command and filesystem operations share driver-session behavior, with typed native snapshot and tag handling and verified teardown.

Validation: repository checks passed; live CPU driver/smoke/lifecycle checks and T4 execution, volume persistence, snapshot restore, read-only mounts, artifact attribution, and cleanup passed.
