### PR TITLE
Move Modal VM harness execution onto native driver sessions

### DIFF
--- a/apps/cli/src/lib/driver-run.ts
+++ b/apps/cli/src/lib/driver-run.ts
@@ -343,7 +343,7 @@ export function usesDriverSuite(providerId: string, driverPathFlag = false): boo
 
 /** Providers whose consumers have moved to declarative session operations in the migration stack. */
 export function usesSessionOperations(id: DriverProviderId): boolean {
-	return id === "e2b" || id === "tama" || id === "modal-gvisor";
+	return id === "e2b" || id === "tama" || id === "modal-gvisor" || id === "modal-vm";
 }
 
 /**


### PR DESCRIPTION
Route Modal VM suites, lifecycle measurement, smoke validation, and driver checks through the declarative harness session operations. Preserve VM allocation policy and unsupported list/snapshot outcomes. GPU allocation remains in the separate gVisor implementation.

Validation: affected CLI tests and typecheck passed; live VM driver checks, smoke, lifecycle execution, and teardown passed.
