### PR TITLE
Migrate Novita to native declarative driver sessions

### DIFF
--- a/apps/cli/src/lib/driver-run.test.ts
+++ b/apps/cli/src/lib/driver-run.test.ts
@@ -84,7 +84,7 @@ describe("bench-suite driver vs legacy selection (Phase A unit 1)", () => {
 		>;
 		const driverIds = Object.keys(DRIVERS);
 		const adapterIds: string[] = providers.map((provider) => provider.name);
-		expect(driverIds.sort()).toEqual(["e2b", "modal-gvisor", "modal-vm", "tama"]);
+		expect(driverIds.sort()).toEqual(["e2b", "modal-gvisor", "modal-vm", "novita", "tama"]);
 		expect([...driverIds, ...adapterIds].sort()).toEqual(PROVIDERS.map((meta) => meta.id).sort());
 		expect(driverIds.filter((id) => adapterIds.includes(id))).toEqual([]);
 		for (const id of driverIds) {
@@ -108,7 +108,7 @@ describe("bench-suite driver vs legacy selection (Phase A unit 1)", () => {
 	test("waived ids stay on the legacy path unless --driver-path forces the driver lane", () => {
 		expect(usesDriverSuite("daytona-vm")).toBe(false);
 		expect(usesDriverSuite("runcloud")).toBe(false);
-		expect(usesDriverSuite("novita", false)).toBe(false);
+		expect(usesDriverSuite("blaxel", false)).toBe(false);
 		expect(usesDriverSuite("daytona-vm", true)).toBe(true);
 		expect(isDriverProviderId("runcloud")).toBe(false);
 	});

--- a/apps/cli/src/lib/driver-run.ts
+++ b/apps/cli/src/lib/driver-run.ts
@@ -343,7 +343,9 @@ export function usesDriverSuite(providerId: string, driverPathFlag = false): boo
 
 /** Providers whose consumers have moved to declarative session operations in the migration stack. */
 export function usesSessionOperations(id: DriverProviderId): boolean {
-	return id === "e2b" || id === "tama" || id === "modal-gvisor" || id === "modal-vm";
+	return (
+		id === "e2b" || id === "tama" || id === "modal-gvisor" || id === "modal-vm" || id === "novita"
+	);
 }
 
 /**

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -76,7 +76,7 @@ docs/       methodology, ADRs, CI & secrets
 
 ## Native SDK driver configuration
 
-E2B and both Modal variants allocate through the catalog-pinned native SDKs. `_native.ts` projects
+E2B, Novita, and both Modal variants allocate through the catalog-pinned native SDKs. `_native.ts` projects
 those exact SDK handles into the shared driver session machinery; it does not invoke ComputeSDK
 wrappers or cast between vendored SDK copies. Provider create-option schemas validate the boundary,
 and each request mapper must satisfy its schema's inferred type. Native SDK error classes reach the

--- a/packages/drivers/migration-waivers.json
+++ b/packages/drivers/migration-waivers.json
@@ -19,11 +19,6 @@
     "reason": "The Microsandbox cloud adapter has not yet migrated from packages/providers to DriverModule.",
     "expires": "2026-12-31"
   },
-  "novita": {
-    "owner": "@dbworku",
-    "reason": "The Novita adapter has not yet migrated from packages/providers to DriverModule.",
-    "expires": "2026-12-31"
-  },
   "runloop": {
     "owner": "@dbworku",
     "reason": "The Runloop adapter has not yet migrated from packages/providers to DriverModule.",

--- a/packages/drivers/package.json
+++ b/packages/drivers/package.json
@@ -10,6 +10,7 @@
     "./e2b": "./src/e2b.ts",
     "./modal-gvisor": "./src/modal-gvisor.ts",
     "./modal-vm": "./src/modal-vm.ts",
+    "./novita": "./src/novita.ts",
     "./tama": "./src/tama.ts",
     "./package.json": "./package.json"
   },

--- a/packages/drivers/src/_provenance.ts
+++ b/packages/drivers/src/_provenance.ts
@@ -20,3 +20,8 @@ export const TAMA_PROVENANCE = Object.freeze({
 	packageName: "tama CLI",
 	version: "0.1.17",
 });
+
+export const NOVITA_PROVENANCE = Object.freeze({
+	packageName: "novita-sandbox",
+	version: "2.0.6",
+});

--- a/packages/drivers/src/index.test.ts
+++ b/packages/drivers/src/index.test.ts
@@ -12,7 +12,7 @@ type Expect<Condition extends true> = Condition;
 
 describe("generated driver loader", () => {
 	test("exposes exactly the unwaived provider modules without eager vendor evaluation", () => {
-		expect(Object.keys(DRIVERS)).toEqual(["e2b", "modal-gvisor", "modal-vm", "tama"]);
+		expect(Object.keys(DRIVERS)).toEqual(["e2b", "modal-gvisor", "modal-vm", "novita", "tama"]);
 		expect(Object.values(DRIVERS).every((load) => typeof load === "function")).toBe(true);
 		expect(Object.isFrozen(DRIVERS)).toBe(true);
 	});

--- a/packages/drivers/src/index.ts
+++ b/packages/drivers/src/index.ts
@@ -7,6 +7,7 @@ export interface DriverModuleMap {
 	e2b: typeof import("./e2b.ts").default;
 	"modal-gvisor": typeof import("./modal-gvisor.ts").default;
 	"modal-vm": typeof import("./modal-vm.ts").default;
+	novita: typeof import("./novita.ts").default;
 	tama: typeof import("./tama.ts").default;
 }
 
@@ -27,6 +28,7 @@ export const DRIVERS: {
 	e2b: () => import("./e2b.ts").then((module) => module.default),
 	"modal-gvisor": () => import("./modal-gvisor.ts").then((module) => module.default),
 	"modal-vm": () => import("./modal-vm.ts").then((module) => module.default),
+	novita: () => import("./novita.ts").then((module) => module.default),
 	tama: () => import("./tama.ts").then((module) => module.default),
 });
 

--- a/packages/drivers/src/novita.test.ts
+++ b/packages/drivers/src/novita.test.ts
@@ -1,0 +1,92 @@
+import { describe, expect, spyOn, test } from "bun:test";
+import { createRequire } from "node:module";
+import novita, { NOVITA_DOMAIN, novitaSpec } from "./novita.ts";
+
+const { Sandbox, AuthenticationError, RateLimitError } = createRequire(import.meta.url)(
+	"novita-sandbox",
+) as typeof import("novita-sandbox");
+const context = {
+	env: { NOVITA_API_KEY: "nvta_test" },
+	artifact: { kind: "baked" },
+	resolvedArtifact: { kind: "baked", ref: "toolchain-test" },
+} as const;
+const request = {
+	spec: { vcpus: 4, memoryGb: 8 },
+	artifact: context.resolvedArtifact,
+	deadlineMs: 300000,
+};
+
+describe("Novita native integration", () => {
+	test("keeps the account credential in the regional control plane channel", async () => {
+		const failure = new AuthenticationError("invalid test key");
+		const create = spyOn(Sandbox, "create").mockRejectedValueOnce(failure);
+		try {
+			const driver = novita.driver(context);
+			await expect(driver.create(request)).rejects.toThrow();
+			expect(create).toHaveBeenCalledTimes(1);
+			const options = create.mock.calls[0]?.[1];
+			expect(options).toMatchObject({ apiKey: "nvta_test", domain: NOVITA_DOMAIN });
+			expect(options).not.toHaveProperty("headers");
+			expect(options).not.toHaveProperty("envs");
+		} finally {
+			create.mockRestore();
+		}
+	});
+	test("rejects requests the baked artifact cannot honor before allocation", async () => {
+		const create = spyOn(Sandbox, "create").mockClear();
+		try {
+			const driver = novita.driver(context);
+			for (const input of [
+				{ ...request, spec: { vcpus: 8, memoryGb: 8 } },
+				{ ...request, artifact: { kind: "baked" as const, ref: "other" } },
+				{ ...request, env: { OVERRIDE: "yes" } },
+			])
+				await expect(driver.create(input)).rejects.toThrow();
+			expect(create).not.toHaveBeenCalled();
+		} finally {
+			create.mockRestore();
+		}
+	});
+	test("classifies typed refusals independently from ambiguous transport failures", () => {
+		const recovery = novitaSpec(context).createRecovery;
+		if (!recovery) throw new Error("missing create recovery");
+		expect(recovery.isDefinitive?.(new AuthenticationError("bad key"))).toBe(true);
+		expect(recovery.isRetryableCreate?.(new RateLimitError("capacity"))).toBe(true);
+		expect(recovery.isDefinitive?.(new Error("HTTP 429 response lost"))).toBe(false);
+		expect(recovery.isRetryableCreate?.(new Error("capacity"))).toBe(false);
+	});
+	test("never tears down a recovery row belonging to another create attempt", async () => {
+		const spec = novitaSpec(context);
+		if (!spec.createRecovery) throw new Error("missing create recovery");
+		const paginator = Sandbox.list({ apiKey: "nvta_test", domain: NOVITA_DOMAIN });
+		const next = spyOn(paginator, "nextItems").mockResolvedValueOnce([
+			{
+				sandboxId: "iother",
+				metadata: { "sandbox-benchmarks-attempt": "other" },
+				templateId: "toolchain-test",
+				startedAt: new Date(),
+				endAt: new Date(),
+				state: "running",
+				cpuCount: 4,
+				memoryMB: 8192,
+				envdVersion: "0.0.0",
+			},
+		]);
+		const list = spyOn(Sandbox, "list").mockReturnValueOnce(paginator);
+		const kill = spyOn(Sandbox, "kill");
+		try {
+			await expect(
+				spec.createRecovery.cleanup(
+					spec.compute,
+					{ kind: "marker", key: "sandbox-benchmarks-attempt", value: "wanted" },
+					{},
+				),
+			).rejects.toThrow("unrelated sandbox");
+			expect(kill).not.toHaveBeenCalled();
+		} finally {
+			next.mockRestore();
+			list.mockRestore();
+			kill.mockRestore();
+		}
+	});
+});

--- a/packages/drivers/src/novita.ts
+++ b/packages/drivers/src/novita.ts
@@ -1,0 +1,208 @@
+// Novita's E2B-compatible SDK owns its regional control plane and credential channel. No account
+// key is injected into custom headers, which the SDK would also forward to the guest daemon.
+import { randomUUID } from "node:crypto";
+import { createRequire } from "node:module";
+import type { DriverContext, ExecOptions } from "@sandbox-benchmarks/driver";
+import { type } from "arktype";
+import type { Sandbox as NativeSandbox } from "novita-sandbox";
+import { computeSdkSpec, defineComputeSdkDriver } from "./_computesdk.ts";
+import { matchesAnyCause } from "./_errors.ts";
+import { nativeSdkCompute } from "./_native.ts";
+import { NOVITA_PROVENANCE } from "./_provenance.ts";
+
+// Match the CJS format used by the still-unmigrated legacy adapter to avoid Bun's mixed chalk
+// module-load race. This remains the native SDK; no wrapper internals are patched.
+const { Sandbox, SandboxNotFoundError, AuthenticationError, InvalidArgumentError, RateLimitError } =
+	createRequire(import.meta.url)("novita-sandbox") as typeof import("novita-sandbox");
+export const NOVITA_DOMAIN = "us-phx-1.sandbox.novita.ai";
+export const NOVITA_SANDBOX_ID = type(/^[A-Za-z0-9_-]+$/);
+const CONTROL_TIMEOUT_MS = 5000;
+const ATTEMPT_KEY = "sandbox-benchmarks-attempt";
+const optionsSchema = type({
+	template: "string >= 1",
+	marker: "string >= 1",
+});
+const recoveryRows = type({
+	sandboxId: NOVITA_SANDBOX_ID,
+	metadata: { "[string]": "string" },
+}).array();
+const commandFailure = type({
+	name: "'CommandExitError'",
+	exitCode: "number.integer",
+	stdout: "string",
+	stderr: "string",
+});
+
+async function exec(native: NativeSandbox, command: string, options?: ExecOptions) {
+	options?.signal?.throwIfAborted();
+	try {
+		return await native.commands.run(command, {
+			user: "root",
+			background: false,
+			timeoutMs: 60000,
+			requestTimeoutMs: CONTROL_TIMEOUT_MS,
+		});
+	} catch (error) {
+		const result = commandFailure(error);
+		if (!(result instanceof type.errors) && result.exitCode !== 0) return result;
+		throw error;
+	}
+}
+
+export function novitaSpec({ env, resolvedArtifact }: DriverContext<"novita">) {
+	const connection = {
+		apiKey: env.NOVITA_API_KEY,
+		domain: NOVITA_DOMAIN,
+		requestTimeoutMs: CONTROL_TIMEOUT_MS,
+	};
+	const compute = nativeSdkCompute(
+		(value) => optionsSchema.assert(value),
+		(options) =>
+			Sandbox.create(options.template, {
+				...connection,
+				requestTimeoutMs: 300000,
+				timeoutMs: 3 * 60 * 60000,
+				metadata: { [ATTEMPT_KEY]: options.marker },
+			}),
+		(native) => ({
+			sandboxId: native.sandboxId,
+			runCommand: (command: string) => exec(native, command),
+			destroy: () => native.kill(connection),
+			filesystem: {
+				readFile: (path: string) =>
+					native.files.read(path, { user: "root", requestTimeoutMs: CONTROL_TIMEOUT_MS }),
+				exists: (path: string) =>
+					native.files.exists(path, { user: "root", requestTimeoutMs: CONTROL_TIMEOUT_MS }),
+				writeFile: async (path: string, content: string) => {
+					await native.files.write(path, content, {
+						user: "root",
+						requestTimeoutMs: CONTROL_TIMEOUT_MS,
+					});
+				},
+			},
+		}),
+	);
+	return computeSdkSpec(compute, {
+		sandboxId: NOVITA_SANDBOX_ID,
+		createOptions: {
+			coverage: {
+				spec: { vcpus: { artifact: 4 }, memoryGb: { artifact: 8 }, diskGb: "runtime-verified" },
+				artifact: "context",
+				deadlineMs: "harness",
+				gpu: { model: "unsupported", count: "unsupported" },
+				env: "unsupported",
+			},
+			map: (request, unsupported) => {
+				if (request.artifact.kind !== "baked" || request.artifact.ref !== resolvedArtifact.ref)
+					unsupported("request artifact differs from the resolved Novita template");
+				return { template: resolvedArtifact.ref, marker: `benchmark-${randomUUID()}` };
+			},
+		},
+		commands: {
+			exec: (sandbox, command, options) => exec(sandbox.getInstance(), command, options),
+			launch: async (sandbox, command, options) => {
+				options?.signal?.throwIfAborted();
+				const handle = await sandbox.getInstance().commands.run(command, {
+					user: "root",
+					background: true,
+					timeoutMs: 0,
+					requestTimeoutMs: CONTROL_TIMEOUT_MS,
+				});
+				if (!Number.isSafeInteger(handle.pid) || handle.pid <= 0)
+					throw new Error("Novita returned no positive process id");
+			},
+		},
+		lifecycle: {
+			destroy: async (sandbox, ref) => {
+				if (ref) await Sandbox.kill(ref.id, connection);
+				else await sandbox.getInstance().kill(connection);
+			},
+		},
+		createRecovery: {
+			absenceConfirmationMs: 2000,
+			maxAttempts: 4,
+			locator: (options) => ({
+				kind: "marker",
+				key: ATTEMPT_KEY,
+				value: optionsSchema.assert(options).marker,
+			}),
+			isDefinitive: (error) =>
+				matchesAnyCause(
+					error,
+					(cause) =>
+						cause instanceof AuthenticationError ||
+						cause instanceof InvalidArgumentError ||
+						cause instanceof RateLimitError,
+				),
+			isRetryableCreate: (error) =>
+				matchesAnyCause(error, (cause) => cause instanceof RateLimitError),
+			cleanup: async (_compute, locator, options) => {
+				const paginator = Sandbox.list({
+					...connection,
+					query: { metadata: { [ATTEMPT_KEY]: locator.value } },
+				});
+				const ids = new Set<string>();
+				const tokens = new Set<string>();
+				for (let page = 0; ; page++) {
+					options.signal?.throwIfAborted();
+					if (page >= 100) throw new Error("Novita recovery exceeded its page limit");
+					for (const row of recoveryRows.assert(await paginator.nextItems())) {
+						if (row.metadata[ATTEMPT_KEY] !== locator.value)
+							throw new Error("Novita recovery returned an unrelated sandbox");
+						ids.add(row.sandboxId);
+					}
+					if (!paginator.hasNext) break;
+					const token = paginator.nextToken;
+					if (!token || tokens.has(token))
+						throw new Error("Novita recovery repeated or omitted a continuation token");
+					tokens.add(token);
+				}
+				let destroyed = false;
+				for (const id of ids) {
+					options.signal?.throwIfAborted();
+					destroyed = (await Sandbox.kill(id, connection)) || destroyed;
+				}
+				return destroyed
+					? { status: "destroyed" }
+					: { status: "absent", contradictedPriorAbsence: ids.size > 0 };
+			},
+		},
+		prepareAndVerifyCreatedRequest: async (_sandbox, native, request) => {
+			if (request.spec.diskGb === undefined) return { status: "honored" };
+			const result = await exec(native, "df -Pk / | awk 'NR==2 {print $2}'");
+			if (result.exitCode !== 0 || !/^\d+$/.test(result.stdout.trim()))
+				throw new Error("Novita disk capacity probe failed");
+			const capacity = Number(result.stdout.trim()) / 1024 / 1024;
+			return capacity >= request.spec.diskGb
+				? { status: "honored" }
+				: {
+						status: "unsupported",
+						detail: `requested ${request.spec.diskGb} GiB but allocation exposes ${capacity.toFixed(2)} GiB`,
+					};
+		},
+		hasWorkingFilesystem: true,
+		probes: {
+			observe: async (_compute, ref) => {
+				try {
+					const info = await Sandbox.getInfo(ref.id, connection);
+					if (info.state !== "running" && info.state !== "paused")
+						throw new Error("Novita returned an unknown state");
+					return { state: "running" };
+				} catch (error) {
+					if (error instanceof SandboxNotFoundError) return { state: "absent" };
+					throw error;
+				}
+			},
+			describe: (_compute, ref) => Sandbox.getInfo(ref.id, connection),
+			// Preserve the existing measurement: one list page, rather than timing full enumeration.
+			list: () => Sandbox.list(connection).nextItems(),
+		},
+	});
+}
+
+export default defineComputeSdkDriver("novita", {
+	provenance: NOVITA_PROVENANCE,
+	readiness: { startup: "create-returns-ready" },
+	execution: { syncCapMs: 60000, durable: "native-launch" },
+	spec: novitaSpec,
+});

--- a/packages/providers/src/index.test.ts
+++ b/packages/providers/src/index.test.ts
@@ -191,18 +191,6 @@ describe("@sandbox-benchmarks/providers", () => {
 		expect(connection).not.toHaveProperty("headers");
 	});
 
-	it("boots novita from the configured template, erroring on use — not import — without a key", () => {
-		const novita = providers.find((p) => p.name === "novita");
-		expect(novita).toBeDefined();
-		expect(novita?.requiredEnvVars).toEqual(["NOVITA_API_KEY"]);
-		expect(novita?.createOptions?.snapshotId).toBe(config.novitaTemplate);
-		// The registry module must stay importable without credentials; the factory throws only when
-		// the harness actually selects the provider (after its requiredEnvVars gate).
-		if (!process.env.NOVITA_API_KEY) {
-			expect(() => novita?.createCompute()).toThrow(/NOVITA_API_KEY/);
-		}
-	});
-
 	it("keeps Daytona alive for long suites and pins region off createOptions", () => {
 		const daytona = providers.find((p) => p.name === "daytona-vm");
 		expect(daytona).toBeDefined();

--- a/packages/providers/src/lib/adapters.ts
+++ b/packages/providers/src/lib/adapters.ts
@@ -14,7 +14,6 @@ import { runcloudCostEvidence } from "./cost-evidence.ts";
 import { daytonaActivateSnapshot } from "./daytona-snapshot.ts";
 import { daytonaClientTarget } from "./daytona-target.ts";
 import { microsandboxCloudCompute } from "./microsandbox.ts";
-import { novitaCompute } from "./novita.ts";
 import { RUNCLOUD_CREATE_CEILING_MS, runcloudCompute } from "./runcloud.ts";
 import { runloopCompute } from "./runloop.ts";
 import type { ProviderAdapter } from "./types.ts";
@@ -35,6 +34,7 @@ export const MIGRATED_DRIVER_IDS = [
 	"modal-gvisor",
 	"modal-vm",
 	"tama",
+	"novita",
 ] as const satisfies readonly ProviderId[];
 
 /** A schema id served by a registered DriverModule. Derived from the list, so the two cannot drift. */
@@ -150,15 +150,6 @@ export const adapters: Record<LegacyAdapterId, ProviderAdapter> = {
 			}),
 		createOptions: { templateId: config.toolchainImage },
 		createTimeoutMs: MICROSANDBOX_CREATE_TIMEOUT_MS,
-	},
-	novita: {
-		artifact: { kind: "baked", ref: config.novitaTemplate },
-		// The e2b wrapper re-pointed at Novita's E2B-compatible control plane (sandbox.novita.ai) —
-		// see novita.ts for exactly what is swapped and why. Boots the pre-baked toolchain template
-		// the bake pipeline creates on Novita via the same e2b CLI (computesdk maps snapshotId → the
-		// template name); cpu/memory are pinned at template create, not per-sandbox.
-		createCompute: () => novitaCompute(config.novita.apiKey),
-		createOptions: { snapshotId: config.novitaTemplate },
 	},
 	runloop: {
 		artifact: { kind: "baked", ref: config.runloopBlueprint },

--- a/packages/schema/scripts/generate-provider-wiring.test.ts
+++ b/packages/schema/scripts/generate-provider-wiring.test.ts
@@ -218,13 +218,12 @@ describe("provider wiring projections", () => {
 
 	test("generates one correlated lazy loader from every unwaived registry id", () => {
 		const fleet = driverFleetProjection();
-		expect(fleet.moduleIds).toEqual(["e2b", "modal-gvisor", "modal-vm", "tama"]);
+		expect(fleet.moduleIds).toEqual(["e2b", "modal-gvisor", "modal-vm", "novita", "tama"]);
 		expect([...PROVIDER_IDS].filter((id) => fleet.waivers[id] !== undefined)).toEqual([
 			"daytona-vm",
 			"daytona-container",
 			"blaxel",
 			"microsandbox-cloud",
-			"novita",
 			"runloop",
 			"namespace",
 			"vercel",
@@ -288,6 +287,7 @@ describe("provider wiring projections", () => {
 			"./e2b": "./src/e2b.ts",
 			"./modal-gvisor": "./src/modal-gvisor.ts",
 			"./modal-vm": "./src/modal-vm.ts",
+			"./novita": "./src/novita.ts",
 			"./tama": "./src/tama.ts",
 			"./package.json": "./package.json",
 		});

--- a/packages/schema/scripts/generate-provider-wiring.ts
+++ b/packages/schema/scripts/generate-provider-wiring.ts
@@ -453,6 +453,7 @@ export function renderDriversProvenance(root = REPO_ROOT): string {
 		// Cost-evidence consumers retain their explicit native-SDK provenance alias.
 		["MODAL_NATIVE", "modal", catalogVersion(catalog, "modal")],
 		["TAMA", "tama CLI", tamaCliVersion(root)],
+		["NOVITA", "novita-sandbox", catalogVersion(catalog, "novita-sandbox")],
 	] as const;
 	const constants = entries
 		.map(

--- a/packages/schema/src/provider-meta/novita.ts
+++ b/packages/schema/src/provider-meta/novita.ts
@@ -4,10 +4,8 @@ export default defineProviderMeta("novita", {
 	displayName: "Novita",
 	vendor: "Novita",
 	website: "https://novita.ai/sandbox",
-	// Novita's control plane speaks the E2B protocol, so the harness drives it through the e2b
-	// wrapper with its connection methods backed by novita-sandbox (Novita's fork of the e2b SDK)
-	// — see the novita adapter's compat module.
-	sdkPackage: "@computesdk/e2b",
+	// Native SDK with the regional control plane and its dedicated API-key channel.
+	sdkPackage: "novita-sandbox",
 	artifact: { kind: "baked" },
 	inputs: [
 		"NOVITA_API_KEY",
@@ -17,7 +15,7 @@ export default defineProviderMeta("novita", {
 		class: "microVM",
 		technology: "microVM",
 		notes:
-			"Dedicated microVM per sandbox; E2B-protocol-compatible control plane (us-phx-1.sandbox.novita.ai) driven through @computesdk/e2b with novita-sandbox-backed connection methods.",
+			"Dedicated microVM per sandbox; E2B-protocol-compatible control plane (us-phx-1.sandbox.novita.ai) driven through the native novita-sandbox SDK.",
 	},
 	pricing: {
 		model: "published",


### PR DESCRIPTION
Add Novita's native DriverModule and route suite, lifecycle, smoke, and driver-check execution through harness session operations. Remove Novita from legacy routing and migration waivers.

The pinned SDK owns the regional control plane and API-key channel. Allocation validates baked artifacts and resources, records create-attempt ownership for recovery, and exposes separate command streams, native files, and background launch. Recovery rejects unrelated sandbox rows; lifecycle measurements retain single-request info/list behavior and explicit unsupported snapshots.

Validation: repository checks and credential-channel, request-validation, refusal, and recovery tests passed; live driver checks, smoke, lifecycle execution, and teardown passed.
