### PR TITLE
Migrate Daytona containers to native SDK session operations

### DIFF
--- a/apps/cli/src/bin/driver-check.test.ts
+++ b/apps/cli/src/bin/driver-check.test.ts
@@ -78,7 +78,7 @@ describe("driver-check argv", () => {
 	test("rejects a provider that has no driver module yet", () => {
 		// The waived providers are still on packages/providers; driving them here would silently
 		// exercise the legacy path and report it as driver-path evidence.
-		expect(() => parseArgs(["--provider", "daytona-container"])).toThrow(/has no driver module/);
+		expect(() => parseArgs(["--provider", "runloop"])).toThrow(/has no driver module/);
 		expect(() => parseArgs(["--provider", "nope"])).toThrow(/has no driver module/);
 	});
 

--- a/apps/cli/src/lib/driver-run.integration.test.ts
+++ b/apps/cli/src/lib/driver-run.integration.test.ts
@@ -95,12 +95,12 @@ describe("DriverModule benchmark path", () => {
 		await expect(
 			runDriverSuite({
 				runId: "driver-spike-no-fallback",
-				providerName: "daytona-container",
+				providerName: "runloop",
 				suiteName: "cpu-node",
 				resultsDir: freshRoot(),
 				env: { DAYTONA_API_KEY: "must-not-be-used" },
 			}),
-		).rejects.toThrow(/daytona-container has no DriverModule/);
+		).rejects.toThrow(/runloop has no DriverModule/);
 	});
 
 	test("persists verified E2B artifact evidence and normalizes a valid Run v6", async () => {

--- a/apps/cli/src/lib/driver-run.test.ts
+++ b/apps/cli/src/lib/driver-run.test.ts
@@ -20,7 +20,6 @@ import { DRIVERS } from "@sandbox-benchmarks/drivers";
 import type { SandboxHandle } from "@sandbox-benchmarks/harness";
 import { cleanupOwnedSandboxes, createSuiteSandboxFromPlan } from "@sandbox-benchmarks/harness";
 import type { LegacyAdapterId } from "@sandbox-benchmarks/providers";
-import { isLegacyAdapterId, providers } from "@sandbox-benchmarks/providers";
 import type { ProviderId } from "@sandbox-benchmarks/schema";
 import { PROVIDERS, REGISTRY, SUITES, TOOLCHAIN_VERSION } from "@sandbox-benchmarks/schema";
 import type { OpenedDriver } from "./driver-run.ts";
@@ -77,7 +76,8 @@ type Equal<Left, Right> =
 type Expect<Condition extends true> = Condition;
 
 describe("bench-suite driver vs legacy selection (Phase A unit 1)", () => {
-	test("registered DriverModule ids and leftover adapters partition ProviderId", () => {
+	test("registered DriverModule ids and leftover adapters partition ProviderId", async () => {
+		const { isLegacyAdapterId, providers } = await import("@sandbox-benchmarks/providers");
 		type _complete = Expect<Equal<ProviderId, DriverProviderId | LegacyAdapterId>>;
 		type _disjoint = Expect<
 			Extract<DriverProviderId, LegacyAdapterId> extends never ? true : false
@@ -85,6 +85,7 @@ describe("bench-suite driver vs legacy selection (Phase A unit 1)", () => {
 		const driverIds = Object.keys(DRIVERS);
 		const adapterIds: string[] = providers.map((provider) => provider.name);
 		expect(driverIds.sort()).toEqual([
+			"daytona-container",
 			"daytona-vm",
 			"e2b",
 			"modal-gvisor",
@@ -113,10 +114,10 @@ describe("bench-suite driver vs legacy selection (Phase A unit 1)", () => {
 	});
 
 	test("waived ids stay on the legacy path unless --driver-path forces the driver lane", () => {
-		expect(usesDriverSuite("daytona-container")).toBe(false);
+		expect(usesDriverSuite("runloop")).toBe(false);
 		expect(usesDriverSuite("runcloud")).toBe(false);
 		expect(usesDriverSuite("blaxel", false)).toBe(false);
-		expect(usesDriverSuite("daytona-container", true)).toBe(true);
+		expect(usesDriverSuite("runloop", true)).toBe(true);
 		expect(isDriverProviderId("runcloud")).toBe(false);
 	});
 
@@ -216,6 +217,18 @@ describe("resolveDriverArtifact", () => {
 });
 
 describe("driverArtifactResolution", () => {
+	test("honors each Daytona variant's own snapshot override", () => {
+		expect(driverArtifactResolution("daytona-vm", { DAYTONA_SNAPSHOT: "vm-debug" })).toEqual({
+			ref: "vm-debug",
+		});
+		expect(
+			driverArtifactResolution("daytona-container", {
+				DAYTONA_CONTAINER_SNAPSHOT: "container-debug",
+				DAYTONA_SNAPSHOT: "wrong-vm",
+			}),
+		).toEqual({ ref: "container-debug" });
+	});
+
 	test("honors the operator's registry-declared artifact override", () => {
 		// The leftover lane read E2B_TEMPLATE through its config gatekeeper and CI still forwards it on
 		// every e2b cell, so defaulting e2b to the driver lane must not silently boot the published

--- a/apps/cli/src/lib/driver-run.ts
+++ b/apps/cli/src/lib/driver-run.ts
@@ -273,6 +273,8 @@ export async function createOwnedDriverSession(
  */
 const ARTIFACT_REF_OVERRIDE_ENV = {
 	e2b: "E2B_TEMPLATE",
+	"daytona-vm": "DAYTONA_SNAPSHOT",
+	"daytona-container": "DAYTONA_CONTAINER_SNAPSHOT",
 } as const satisfies Partial<Record<DriverProviderId, string>>;
 
 /**
@@ -349,7 +351,8 @@ export function usesSessionOperations(id: DriverProviderId): boolean {
 		id === "modal-gvisor" ||
 		id === "modal-vm" ||
 		id === "novita" ||
-		id === "daytona-vm"
+		id === "daytona-vm" ||
+		id === "daytona-container"
 	);
 }
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -76,7 +76,7 @@ docs/       methodology, ADRs, CI & secrets
 
 ## Native SDK driver configuration
 
-E2B, Novita, Daytona VM, and both Modal variants allocate through the catalog-pinned native SDKs. `_native.ts` projects
+E2B, Novita, both Daytona variants, and both Modal variants allocate through the catalog-pinned native SDKs. `_native.ts` projects
 those exact SDK handles into the shared driver session machinery; it does not invoke ComputeSDK
 wrappers or cast between vendored SDK copies. Provider create-option schemas validate the boundary,
 and each request mapper must satisfy its schema's inferred type. Native SDK error classes reach the

--- a/packages/drivers/migration-waivers.json
+++ b/packages/drivers/migration-waivers.json
@@ -1,9 +1,4 @@
 {
-  "daytona-container": {
-    "owner": "@dbworku",
-    "reason": "The Daytona container adapter has not yet migrated from packages/providers to DriverModule.",
-    "expires": "2026-12-31"
-  },
   "blaxel": {
     "owner": "@dbworku",
     "reason": "The Blaxel adapter has not yet migrated from packages/providers to DriverModule.",

--- a/packages/drivers/package.json
+++ b/packages/drivers/package.json
@@ -9,6 +9,7 @@
     ".": "./src/index.ts",
     "./e2b": "./src/e2b.ts",
     "./daytona-vm": "./src/daytona-vm.ts",
+    "./daytona-container": "./src/daytona-container.ts",
     "./modal-gvisor": "./src/modal-gvisor.ts",
     "./modal-vm": "./src/modal-vm.ts",
     "./novita": "./src/novita.ts",

--- a/packages/drivers/src/_daytona.ts
+++ b/packages/drivers/src/_daytona.ts
@@ -187,6 +187,17 @@ export function daytonaSpec<P extends DaytonaId>(
 			},
 		},
 		prepareAndVerifyCreatedRequest: async (_sandbox, native, request) => {
+			const expectedClass = "DAYTONA_CONTAINER_TARGET" in env ? "container" : "linux-vm";
+			if (native.sandboxClass !== expectedClass)
+				return {
+					status: "unsupported",
+					detail: `requested ${expectedClass} but snapshot allocates ${native.sandboxClass ?? "unknown"}`,
+				};
+			if (native.cpu !== request.spec.vcpus || native.memory !== request.spec.memoryGb)
+				return {
+					status: "unsupported",
+					detail: "Daytona snapshot resources differ from the requested CPU or memory",
+				};
 			if (request.spec.diskGb === undefined) return { status: "honored" };
 			return native.disk >= request.spec.diskGb
 				? { status: "honored" }

--- a/packages/drivers/src/daytona-container.ts
+++ b/packages/drivers/src/daytona-container.ts
@@ -1,0 +1,2 @@
+import { defineDaytonaDriver } from "./_daytona.ts";
+export default defineDaytonaDriver("daytona-container");

--- a/packages/drivers/src/index.test.ts
+++ b/packages/drivers/src/index.test.ts
@@ -15,6 +15,7 @@ describe("generated driver loader", () => {
 		expect(Object.keys(DRIVERS)).toEqual([
 			"e2b",
 			"daytona-vm",
+			"daytona-container",
 			"modal-gvisor",
 			"modal-vm",
 			"novita",

--- a/packages/drivers/src/index.ts
+++ b/packages/drivers/src/index.ts
@@ -6,6 +6,7 @@ import type { DriverModule, ProviderId } from "@sandbox-benchmarks/driver";
 export interface DriverModuleMap {
 	e2b: typeof import("./e2b.ts").default;
 	"daytona-vm": typeof import("./daytona-vm.ts").default;
+	"daytona-container": typeof import("./daytona-container.ts").default;
 	"modal-gvisor": typeof import("./modal-gvisor.ts").default;
 	"modal-vm": typeof import("./modal-vm.ts").default;
 	novita: typeof import("./novita.ts").default;
@@ -28,6 +29,7 @@ export const DRIVERS: {
 } = Object.freeze({
 	e2b: () => import("./e2b.ts").then((module) => module.default),
 	"daytona-vm": () => import("./daytona-vm.ts").then((module) => module.default),
+	"daytona-container": () => import("./daytona-container.ts").then((module) => module.default),
 	"modal-gvisor": () => import("./modal-gvisor.ts").then((module) => module.default),
 	"modal-vm": () => import("./modal-vm.ts").then((module) => module.default),
 	novita: () => import("./novita.ts").then((module) => module.default),

--- a/packages/harness/src/index.test.ts
+++ b/packages/harness/src/index.test.ts
@@ -460,14 +460,12 @@ describe("runSuite (resolution + credential gate)", () => {
 		// Empty env → daytona's required key is absent, so the suite skips before any sandbox is created.
 		await runSuite({
 			runId: "test",
-			providerName: "daytona-container",
+			providerName: "runloop",
 			suiteName: "cpu-node",
 			resultsDir,
 			env: {},
 		});
-		expect(existsSync(join(resultsDir, "sandbox-daytona-container-cpu-node--skipped.json"))).toBe(
-			true,
-		);
+		expect(existsSync(join(resultsDir, "sandbox-runloop-cpu-node--skipped.json"))).toBe(true);
 	});
 });
 

--- a/packages/providers/src/index.test.ts
+++ b/packages/providers/src/index.test.ts
@@ -191,30 +191,6 @@ describe("@sandbox-benchmarks/providers", () => {
 		expect(connection).not.toHaveProperty("headers");
 	});
 
-	it("keeps Daytona alive for long suites and pins region off createOptions", () => {
-		const daytona = providers.find((p) => p.name === "daytona-container");
-		expect(daytona).toBeDefined();
-		expect(daytona?.createOptions?.snapshotId).toBe(config.daytonaContainer.snapshot);
-		// ComputeSDK maps its universal timeout to the Daytona SDK's create-operation timeout, not the
-		// sandbox lifetime. Pass the native option through so an 8+ minute detached suite is not stopped
-		// underneath the harness; runSuite's finally block remains the cleanup authority.
-		expect(daytona?.createOptions?.autoStopInterval).toBe(0);
-
-		// The container variant shares the account key and region but boots its own snapshot. The
-		// region pin must NOT ride createOptions — the native SDK ignores createParams.target (only the
-		// client-level target reaches the wire), so a reintroduced `target` createOption here would be
-		// dead code masquerading as a region pin; daytona-target.ts owns the real channel.
-		const container = providers.find((p) => p.name === "daytona-container");
-		expect(container?.createOptions?.snapshotId).toBe(config.daytonaContainer.snapshot);
-		expect(container?.createOptions).not.toHaveProperty("target");
-
-		// No adapter override — requiredEnvVars falls back to the schema meta's static list. Pin the
-		// concrete value rather than only comparing the two lookups against each other: if both `find`s
-		// missed (provider renamed on one side), `undefined === undefined` would pass — a false green.
-		const daytonaMeta = PROVIDERS.find((m) => m.id === "daytona-vm");
-		expect(daytonaMeta?.requiredEnvVars).toEqual(["DAYTONA_API_KEY"]);
-		expect(daytona?.requiredEnvVars).toEqual(daytonaMeta?.requiredEnvVars);
-	});
 	it("exposes Microsandbox Cloud with its supported capabilities", () => {
 		const base = {
 			image: config.toolchainImage,

--- a/packages/providers/src/lib/adapters.ts
+++ b/packages/providers/src/lib/adapters.ts
@@ -3,16 +3,12 @@
 // pins Sandbox v1; run.cloud also uses its native SDK because no @computesdk wrapper is published.
 
 import { blaxel } from "@computesdk/blaxel";
-import { daytona } from "@computesdk/daytona";
 import { namespace } from "@computesdk/namespace";
 import type { ProviderId } from "@sandbox-benchmarks/schema";
 import { PROVIDER_IDS, TARGET_SPEC } from "@sandbox-benchmarks/schema";
-import type { DaytonaConfig } from "../config.ts";
 import { config } from "../config.ts";
 import { blaxelWithVolumeAndKeepAlive } from "./blaxel-volume.ts";
 import { runcloudCostEvidence } from "./cost-evidence.ts";
-import { daytonaActivateSnapshot } from "./daytona-snapshot.ts";
-import { daytonaClientTarget } from "./daytona-target.ts";
 import { microsandboxCloudCompute } from "./microsandbox.ts";
 import { RUNCLOUD_CREATE_CEILING_MS, runcloudCompute } from "./runcloud.ts";
 import { runloopCompute } from "./runloop.ts";
@@ -36,40 +32,13 @@ export const MIGRATED_DRIVER_IDS = [
 	"tama",
 	"novita",
 	"daytona-vm",
+	"daytona-container",
 ] as const satisfies readonly ProviderId[];
 
 /** A schema id served by a registered DriverModule. Derived from the list, so the two cannot drift. */
 export type MigratedDriverId = (typeof MIGRATED_DRIVER_IDS)[number];
 /** Schema ids still served by this package's ComputeSDK adapters. */
 export type LegacyAdapterId = Exclude<ProviderId, MigratedDriverId>;
-
-/**
- * The Daytona VM and container variants share one adapter shape — the same account API key and the
- * same create-time policy — and differ only in the account config the config gatekeeper resolved:
- * region target and which pre-baked snapshot to boot. The sandbox class (LINUX_VM vs CONTAINER) is
- * fixed inside each variant's snapshot at bake time, so nothing selects it here. The region CANNOT
- * ride createOptions: the native SDK's create() honors only the CLIENT-level target (constructor
- * config or the DAYTONA_TARGET env fallback), and the wrapper builds its client from the apiKey
- * alone — so daytonaClientTarget's env-pin around create is the only channel through this wrapper
- * (race-free: each CI job runs exactly one provider). autoStopInterval does ride the wrapper's
- * provider-options passthrough into Daytona's native createParams; the universal `timeout` is only
- * the create-call deadline, so disable native auto-stop and rely on the harness's guaranteed
- * teardown. Never read process.env here.
- */
-function daytonaAdapter(cfg: DaytonaConfig): ProviderAdapter {
-	return {
-		artifact: { kind: "baked", ref: cfg.snapshot },
-		createCompute: () =>
-			daytonaActivateSnapshot(
-				daytonaClientTarget(daytona({ apiKey: cfg.apiKey }), cfg.target),
-				cfg,
-			),
-		createOptions: {
-			snapshotId: cfg.snapshot,
-			autoStopInterval: 0,
-		},
-	};
-}
 
 /** The longest suite has a 155-minute budget. Give Microsandbox enough lifetime for setup and
  * teardown as well, while keeping leaked benchmark sandboxes self-expiring. */
@@ -112,9 +81,6 @@ function microsandboxCloudCredentials(): { kind: "cloud"; url?: string; apiKey: 
  * jointly complete.
  */
 export const adapters: Record<LegacyAdapterId, ProviderAdapter> = {
-	// Both Daytona variants share the account API key (the schema meta owns DAYTONA_API_KEY); they
-	// differ only in region + the class-specific snapshot resolved by the config gatekeeper.
-	"daytona-container": daytonaAdapter(config.daytonaContainer),
 	blaxel: {
 		artifact: { kind: "none" },
 		// Credentials come from BL_API_KEY/BL_WORKSPACE (the factory's env fallback). Boot the Debian

--- a/packages/providers/src/lib/daytona-target.test.ts
+++ b/packages/providers/src/lib/daytona-target.test.ts
@@ -8,7 +8,6 @@ import { daytona } from "@computesdk/daytona";
 import type { SandboxMethods } from "@computesdk/provider";
 import { Daytona } from "@daytonaio/sdk";
 import { config } from "../config.ts";
-import { adapters } from "./adapters.ts";
 import { daytonaClientTarget } from "./daytona-target.ts";
 
 interface CapturedRequest {
@@ -45,13 +44,13 @@ const ENV_KEYS = ["DAYTONA_API_KEY", "DAYTONA_TARGET", "DAYTONA_CONTAINER_TARGET
 let savedEnv: Record<string, string | undefined> = {};
 
 async function attemptCreate(
-	providerId: "daytona-container",
+	_providerId: "daytona-container",
 	createOptions?: Record<string, unknown>,
 ) {
-	const adapter = adapters[providerId];
-	const compute = adapter.createCompute();
+	const cfg = config.daytonaContainer;
+	const compute = daytonaClientTarget(daytona({ apiKey: cfg.apiKey }), cfg.target);
 	await expect(
-		compute.sandbox.create({ ...adapter.createOptions, ...createOptions }),
+		compute.sandbox.create({ snapshotId: cfg.snapshot, autoStopInterval: 0, ...createOptions }),
 	).rejects.toThrow(/Failed to create Daytona sandbox/);
 	const request = captured.find((c) => (c.url ?? "").includes("sandbox"));
 	expect(request).toBeDefined();

--- a/packages/schema/scripts/generate-provider-wiring.test.ts
+++ b/packages/schema/scripts/generate-provider-wiring.test.ts
@@ -221,13 +221,13 @@ describe("provider wiring projections", () => {
 		expect(fleet.moduleIds).toEqual([
 			"e2b",
 			"daytona-vm",
+			"daytona-container",
 			"modal-gvisor",
 			"modal-vm",
 			"novita",
 			"tama",
 		]);
 		expect([...PROVIDER_IDS].filter((id) => fleet.waivers[id] !== undefined)).toEqual([
-			"daytona-container",
 			"blaxel",
 			"microsandbox-cloud",
 			"runloop",
@@ -291,6 +291,7 @@ describe("provider wiring projections", () => {
 		expect(exports).toEqual({
 			".": "./src/index.ts",
 			"./daytona-vm": "./src/daytona-vm.ts",
+			"./daytona-container": "./src/daytona-container.ts",
 			"./e2b": "./src/e2b.ts",
 			"./modal-gvisor": "./src/modal-gvisor.ts",
 			"./modal-vm": "./src/modal-vm.ts",

--- a/packages/schema/src/provider-meta/daytona-container.ts
+++ b/packages/schema/src/provider-meta/daytona-container.ts
@@ -5,7 +5,7 @@ export default defineProviderMeta("daytona-container", {
 	displayName: "Daytona (container)",
 	vendor: "Daytona",
 	website: "https://daytona.io",
-	sdkPackage: "@computesdk/daytona",
+	sdkPackage: "@daytona/sdk",
 	artifact: { kind: "baked", nameSuffix: "-container" },
 	inputs: [
 		"DAYTONA_API_KEY",


### PR DESCRIPTION
Migrate Daytona container execution to the shared native SDK driver and declarative harness operations. Remove the container from legacy routing and migration waivers. Resolve each Daytona variant's own snapshot override; load the legacy registry only when its compatibility test runs.

Validation: repository checks and live container driver, smoke, lifecycle, and teardown checks passed. Live validation used the existing v8 container candidate in region `us`; the published container snapshot is unavailable. This PR does not change artifact publication or default region configuration.
